### PR TITLE
feat(mongo): add hand-written mongosh parser with full grammar parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dashboard
 # OS
 .DS_Store
 Thumbs.db
+.worktrees/

--- a/docs/superpowers/plans/2026-03-30-cosmosdb-engine.md
+++ b/docs/superpowers/plans/2026-03-30-cosmosdb-engine.md
@@ -1,0 +1,3394 @@
+# CosmosDB Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `cosmosdb/` engine to Omni with a complete, pure-Go hand-written parser for Azure Cosmos DB's NoSQL SQL API.
+
+**Architecture:** Hand-written lexer + recursive descent parser with Pratt expression parsing, producing an AST that follows existing Omni conventions (same interfaces as `oracle/`, `mssql/`). Public API matches `pg/parse.go` pattern. Test corpus from `bytebase/parser/cosmosdb/examples/`.
+
+**Tech Stack:** Pure Go (zero runtime dependencies), `testing` package for tests.
+
+**Spec:** `docs/superpowers/specs/2026-03-30-cosmosdb-engine-design.md`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `cosmosdb/ast/node.go` | Core interfaces (Node, ExprNode, TableExpr, StmtNode), Loc, literal nodes (StringLit, NumberLit, BoolLit, NullLit, UndefinedLit, InfinityLit, NanLit), List |
+| `cosmosdb/ast/parsenodes.go` | All statement, clause, table-expr, and expression AST node types (~24 types) |
+| `cosmosdb/ast/outfuncs.go` | `NodeToString(Node) string` — deterministic text dump of any AST node |
+| `cosmosdb/parser/lexer.go` | Tokenizer: Token struct, token constants, Lexer struct, NextToken() |
+| `cosmosdb/parser/parser.go` | Parser struct, Parse(), advance/peek/match/expect helpers, parseIdentifier/parsePropertyName, top-level parseSelect |
+| `cosmosdb/parser/select.go` | parseSelectClause, parseTargetEntry, parseGroupBy, parseHaving, parseOrderBy, parseSortExpr, parseOffsetLimit |
+| `cosmosdb/parser/from.go` | parseFromClause, parseFromSource, parseContainerExpr, parseJoinClause |
+| `cosmosdb/parser/expr.go` | Pratt parser: parseExpr(precedence), all prefix and infix parse functions |
+| `cosmosdb/parser/function.go` | parseFuncCall, parseUDFCall |
+| `cosmosdb/parser/parser_test.go` | Golden-file tests using 37 example SQL files |
+| `cosmosdb/parser/testdata/*.sql` | 37 example SQL files from bytebase/parser/cosmosdb/examples/ |
+| `cosmosdb/parse.go` | Public API: Parse(sql) -> []Statement with position tracking |
+| `cosmosdb/parse_test.go` | Public API tests: positions, text slicing |
+
+---
+
+### Task 1: AST Core Interfaces and Literal Nodes
+
+**Files:**
+- Create: `cosmosdb/ast/node.go`
+
+- [ ] **Step 1: Create `cosmosdb/ast/node.go`**
+
+```go
+// Package ast defines parse tree node types for Azure Cosmos DB NoSQL SQL API.
+package ast
+
+// Node is the interface implemented by all parse tree nodes.
+type Node interface {
+	nodeTag()
+}
+
+// ExprNode is the interface for expression nodes.
+type ExprNode interface {
+	Node
+	exprNode()
+}
+
+// TableExpr is the interface for table reference nodes in FROM clauses.
+type TableExpr interface {
+	Node
+	tableExpr()
+}
+
+// StmtNode is the interface for statement nodes.
+type StmtNode interface {
+	Node
+	stmtNode()
+}
+
+// Loc represents a source location range (byte offsets).
+type Loc struct {
+	Start int // inclusive start byte offset, -1 = unknown
+	End   int // exclusive end byte offset, -1 = unknown
+}
+
+// List represents a generic list of nodes.
+type List struct {
+	Items []Node
+}
+
+func (l *List) nodeTag() {}
+
+// Len returns the number of items in the list.
+func (l *List) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.Items)
+}
+
+// ---------------------------------------------------------------------------
+// Literal nodes — all implement ExprNode
+// ---------------------------------------------------------------------------
+
+// StringLit represents a string constant ('hello' or "hello").
+type StringLit struct {
+	Val string
+	Loc Loc
+}
+
+func (*StringLit) nodeTag()  {}
+func (*StringLit) exprNode() {}
+
+// NumberLit represents a numeric constant (integer, float, hex, scientific).
+// Val stores the raw text to preserve the original representation.
+type NumberLit struct {
+	Val string
+	Loc Loc
+}
+
+func (*NumberLit) nodeTag()  {}
+func (*NumberLit) exprNode() {}
+
+// BoolLit represents true or false.
+type BoolLit struct {
+	Val bool
+	Loc Loc
+}
+
+func (*BoolLit) nodeTag()  {}
+func (*BoolLit) exprNode() {}
+
+// NullLit represents null.
+type NullLit struct {
+	Loc Loc
+}
+
+func (*NullLit) nodeTag()  {}
+func (*NullLit) exprNode() {}
+
+// UndefinedLit represents the CosmosDB-specific undefined constant.
+type UndefinedLit struct {
+	Loc Loc
+}
+
+func (*UndefinedLit) nodeTag()  {}
+func (*UndefinedLit) exprNode() {}
+
+// InfinityLit represents the Infinity constant (case-sensitive).
+type InfinityLit struct {
+	Loc Loc
+}
+
+func (*InfinityLit) nodeTag()  {}
+func (*InfinityLit) exprNode() {}
+
+// NanLit represents the NaN constant (case-sensitive).
+type NanLit struct {
+	Loc Loc
+}
+
+func (*NanLit) nodeTag()  {}
+func (*NanLit) exprNode() {}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./cosmosdb/ast/`
+Expected: Clean build, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/ast/node.go
+git commit -m "feat(cosmosdb): add AST core interfaces and literal nodes"
+```
+
+---
+
+### Task 2: AST Parse Nodes
+
+**Files:**
+- Create: `cosmosdb/ast/parsenodes.go`
+
+- [ ] **Step 1: Create `cosmosdb/ast/parsenodes.go`**
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// Wrapper / top-level
+// ---------------------------------------------------------------------------
+
+// RawStmt wraps a parsed statement with position info.
+type RawStmt struct {
+	Stmt         StmtNode
+	StmtLocation int // start byte offset
+	StmtLen      int // length in bytes; 0 means "rest of string"
+}
+
+func (*RawStmt) nodeTag() {}
+
+// ---------------------------------------------------------------------------
+// Statement nodes
+// ---------------------------------------------------------------------------
+
+// SelectStmt represents a complete SELECT query.
+type SelectStmt struct {
+	Top         *int               // TOP n (nil if not specified)
+	Distinct    bool               // DISTINCT modifier
+	Value       bool               // VALUE modifier
+	Star        bool               // SELECT *
+	Targets     []*TargetEntry     // select list (nil when Star is true)
+	From        TableExpr          // FROM clause (nil if omitted)
+	Joins       []*JoinExpr        // JOIN clauses
+	Where       ExprNode           // WHERE clause (nil if omitted)
+	GroupBy     []ExprNode         // GROUP BY expressions
+	Having      ExprNode           // HAVING clause (nil if omitted)
+	OrderBy     []*SortExpr        // ORDER BY expressions
+	OffsetLimit *OffsetLimitClause // OFFSET ... LIMIT ... (nil if omitted)
+	Loc         Loc
+}
+
+func (*SelectStmt) nodeTag()  {}
+func (*SelectStmt) stmtNode() {}
+
+// TargetEntry represents one item in a SELECT list: expr [AS alias].
+type TargetEntry struct {
+	Expr  ExprNode
+	Alias *string // nil if no alias
+	Loc   Loc
+}
+
+func (*TargetEntry) nodeTag() {}
+
+// SortExpr represents one item in an ORDER BY list.
+type SortExpr struct {
+	Expr ExprNode
+	Desc bool // true for DESC, false for ASC (default)
+	Rank bool // true for RANK expr
+	Loc  Loc
+}
+
+func (*SortExpr) nodeTag() {}
+
+// OffsetLimitClause represents OFFSET n LIMIT m.
+type OffsetLimitClause struct {
+	Offset ExprNode
+	Limit  ExprNode
+	Loc    Loc
+}
+
+func (*OffsetLimitClause) nodeTag() {}
+
+// JoinExpr represents a JOIN clause: JOIN from_source.
+type JoinExpr struct {
+	Source TableExpr
+	Loc    Loc
+}
+
+func (*JoinExpr) nodeTag() {}
+
+// ---------------------------------------------------------------------------
+// Table expression nodes — implement TableExpr
+// ---------------------------------------------------------------------------
+
+// ContainerRef references a container by name, or ROOT.
+type ContainerRef struct {
+	Name string // empty when Root is true
+	Root bool
+	Loc  Loc
+}
+
+func (*ContainerRef) nodeTag()    {}
+func (*ContainerRef) tableExpr()  {}
+
+// AliasedTableExpr wraps a table expression with an alias: source [AS] alias.
+type AliasedTableExpr struct {
+	Source TableExpr
+	Alias  string
+	Loc    Loc
+}
+
+func (*AliasedTableExpr) nodeTag()    {}
+func (*AliasedTableExpr) tableExpr()  {}
+
+// ArrayIterationExpr represents: alias IN container_expression.
+type ArrayIterationExpr struct {
+	Alias  string
+	Source TableExpr
+	Loc    Loc
+}
+
+func (*ArrayIterationExpr) nodeTag()    {}
+func (*ArrayIterationExpr) tableExpr()  {}
+
+// SubqueryExpr represents a parenthesized SELECT in FROM position.
+type SubqueryExpr struct {
+	Select *SelectStmt
+	Loc    Loc
+}
+
+func (*SubqueryExpr) nodeTag()    {}
+func (*SubqueryExpr) tableExpr()  {}
+
+// ---------------------------------------------------------------------------
+// Expression nodes — implement ExprNode
+//
+// DotAccessExpr and BracketAccessExpr also implement TableExpr since they
+// appear in both FROM container_expression and scalar_expression contexts.
+// ---------------------------------------------------------------------------
+
+// ColumnRef represents an identifier reference (alias, property name).
+type ColumnRef struct {
+	Name string
+	Loc  Loc
+}
+
+func (*ColumnRef) nodeTag()  {}
+func (*ColumnRef) exprNode() {}
+
+// DotAccessExpr represents property access: expr.property.
+type DotAccessExpr struct {
+	Expr     ExprNode
+	Property string
+	Loc      Loc
+}
+
+func (*DotAccessExpr) nodeTag()   {}
+func (*DotAccessExpr) exprNode()  {}
+func (*DotAccessExpr) tableExpr() {}
+
+// BracketAccessExpr represents bracket access: expr[index].
+type BracketAccessExpr struct {
+	Expr  ExprNode
+	Index ExprNode
+	Loc   Loc
+}
+
+func (*BracketAccessExpr) nodeTag()   {}
+func (*BracketAccessExpr) exprNode()  {}
+func (*BracketAccessExpr) tableExpr() {}
+
+// BinaryExpr represents a binary operation: left op right.
+type BinaryExpr struct {
+	Op    string
+	Left  ExprNode
+	Right ExprNode
+	Loc   Loc
+}
+
+func (*BinaryExpr) nodeTag()  {}
+func (*BinaryExpr) exprNode() {}
+
+// UnaryExpr represents a unary operation: op operand.
+type UnaryExpr struct {
+	Op      string
+	Operand ExprNode
+	Loc     Loc
+}
+
+func (*UnaryExpr) nodeTag()  {}
+func (*UnaryExpr) exprNode() {}
+
+// TernaryExpr represents: cond ? then : else.
+type TernaryExpr struct {
+	Cond ExprNode
+	Then ExprNode
+	Else ExprNode
+	Loc  Loc
+}
+
+func (*TernaryExpr) nodeTag()  {}
+func (*TernaryExpr) exprNode() {}
+
+// InExpr represents: expr [NOT] IN (list).
+type InExpr struct {
+	Expr ExprNode
+	List []ExprNode
+	Not  bool
+	Loc  Loc
+}
+
+func (*InExpr) nodeTag()  {}
+func (*InExpr) exprNode() {}
+
+// BetweenExpr represents: expr [NOT] BETWEEN low AND high.
+type BetweenExpr struct {
+	Expr ExprNode
+	Low  ExprNode
+	High ExprNode
+	Not  bool
+	Loc  Loc
+}
+
+func (*BetweenExpr) nodeTag()  {}
+func (*BetweenExpr) exprNode() {}
+
+// LikeExpr represents: expr [NOT] LIKE pattern [ESCAPE escape].
+type LikeExpr struct {
+	Expr    ExprNode
+	Pattern ExprNode
+	Escape  ExprNode // nil if no ESCAPE clause
+	Not     bool
+	Loc     Loc
+}
+
+func (*LikeExpr) nodeTag()  {}
+func (*LikeExpr) exprNode() {}
+
+// FuncCall represents a built-in function call: name([*|args]).
+type FuncCall struct {
+	Name string
+	Args []ExprNode
+	Star bool // true for COUNT(*)
+	Loc  Loc
+}
+
+func (*FuncCall) nodeTag()  {}
+func (*FuncCall) exprNode() {}
+
+// UDFCall represents a user-defined function call: udf.name(args).
+type UDFCall struct {
+	Name string
+	Args []ExprNode
+	Loc  Loc
+}
+
+func (*UDFCall) nodeTag()  {}
+func (*UDFCall) exprNode() {}
+
+// ExistsExpr represents EXISTS(SELECT ...).
+type ExistsExpr struct {
+	Select *SelectStmt
+	Loc    Loc
+}
+
+func (*ExistsExpr) nodeTag()  {}
+func (*ExistsExpr) exprNode() {}
+
+// ArrayExpr represents ARRAY(SELECT ...).
+type ArrayExpr struct {
+	Select *SelectStmt
+	Loc    Loc
+}
+
+func (*ArrayExpr) nodeTag()  {}
+func (*ArrayExpr) exprNode() {}
+
+// CreateArrayExpr represents an array literal: [elem, ...].
+type CreateArrayExpr struct {
+	Elements []ExprNode
+	Loc      Loc
+}
+
+func (*CreateArrayExpr) nodeTag()  {}
+func (*CreateArrayExpr) exprNode() {}
+
+// CreateObjectExpr represents an object literal: {key: val, ...}.
+type CreateObjectExpr struct {
+	Fields []*ObjectFieldPair
+	Loc    Loc
+}
+
+func (*CreateObjectExpr) nodeTag()  {}
+func (*CreateObjectExpr) exprNode() {}
+
+// ObjectFieldPair represents one field in an object literal: key: value.
+type ObjectFieldPair struct {
+	Key   string
+	Value ExprNode
+	Loc   Loc
+}
+
+func (*ObjectFieldPair) nodeTag() {}
+
+// ParamRef represents a parameter reference: @name.
+type ParamRef struct {
+	Name string
+	Loc  Loc
+}
+
+func (*ParamRef) nodeTag()  {}
+func (*ParamRef) exprNode() {}
+
+// SubLink represents a parenthesized subquery in expression position: (SELECT ...).
+type SubLink struct {
+	Select *SelectStmt
+	Loc    Loc
+}
+
+func (*SubLink) nodeTag()  {}
+func (*SubLink) exprNode() {}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./cosmosdb/ast/`
+Expected: Clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/ast/parsenodes.go
+git commit -m "feat(cosmosdb): add AST parse node types"
+```
+
+---
+
+### Task 3: AST Output Functions
+
+**Files:**
+- Create: `cosmosdb/ast/outfuncs.go`
+
+This produces deterministic text output for golden-file testing. The format follows the Oracle pattern: `{NODETYPE :field value ...}`.
+
+- [ ] **Step 1: Create `cosmosdb/ast/outfuncs.go`**
+
+```go
+package ast
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NodeToString converts a Node to its string representation.
+func NodeToString(node Node) string {
+	if node == nil {
+		return "<>"
+	}
+	var sb strings.Builder
+	writeNode(&sb, node, 0)
+	return sb.String()
+}
+
+func indent(sb *strings.Builder, level int) {
+	for i := 0; i < level; i++ {
+		sb.WriteString("  ")
+	}
+}
+
+func writeLoc(sb *strings.Builder, loc Loc) {
+	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", loc.Start, loc.End))
+}
+
+func writeNode(sb *strings.Builder, node Node, level int) {
+	if node == nil {
+		sb.WriteString("<>")
+		return
+	}
+
+	switch n := node.(type) {
+	case *List:
+		sb.WriteString("(")
+		for i, item := range n.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, item, level)
+		}
+		sb.WriteString(")")
+
+	// Literals
+	case *StringLit:
+		sb.WriteString(fmt.Sprintf("{STRLIT :val %q", n.Val))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *NumberLit:
+		sb.WriteString(fmt.Sprintf("{NUMLIT :val %q", n.Val))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *BoolLit:
+		sb.WriteString(fmt.Sprintf("{BOOLLIT :val %t", n.Val))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *NullLit:
+		sb.WriteString("{NULL")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *UndefinedLit:
+		sb.WriteString("{UNDEFINED")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *InfinityLit:
+		sb.WriteString("{INFINITY")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *NanLit:
+		sb.WriteString("{NAN")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+
+	// Wrapper
+	case *RawStmt:
+		sb.WriteString("{RAWSTMT")
+		sb.WriteString(fmt.Sprintf(" :stmt_location %d :stmt_len %d", n.StmtLocation, n.StmtLen))
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":stmt ")
+		writeNode(sb, n.Stmt, level+1)
+		sb.WriteString("}")
+
+	// Statement
+	case *SelectStmt:
+		writeSelectStmt(sb, n, level)
+
+	// Clause nodes
+	case *TargetEntry:
+		sb.WriteString("{TARGET :expr ")
+		writeNode(sb, n.Expr, level)
+		if n.Alias != nil {
+			sb.WriteString(fmt.Sprintf(" :alias %q", *n.Alias))
+		}
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *SortExpr:
+		sb.WriteString("{SORT :expr ")
+		writeNode(sb, n.Expr, level)
+		if n.Desc {
+			sb.WriteString(" :desc true")
+		}
+		if n.Rank {
+			sb.WriteString(" :rank true")
+		}
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *OffsetLimitClause:
+		sb.WriteString("{OFFSETLIMIT :offset ")
+		writeNode(sb, n.Offset, level)
+		sb.WriteString(" :limit ")
+		writeNode(sb, n.Limit, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *JoinExpr:
+		sb.WriteString("{JOIN :source ")
+		writeNode(sb, n.Source, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+
+	// Table expressions
+	case *ContainerRef:
+		if n.Root {
+			sb.WriteString("{CONTAINER :root true")
+		} else {
+			sb.WriteString(fmt.Sprintf("{CONTAINER :name %q", n.Name))
+		}
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *AliasedTableExpr:
+		sb.WriteString("{ALIASED :source ")
+		writeNode(sb, n.Source, level)
+		sb.WriteString(fmt.Sprintf(" :alias %q", n.Alias))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *ArrayIterationExpr:
+		sb.WriteString(fmt.Sprintf("{ARRAYITER :alias %q :source ", n.Alias))
+		writeNode(sb, n.Source, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *SubqueryExpr:
+		sb.WriteString("{SUBQUERY\n")
+		indent(sb, level+1)
+		sb.WriteString(":select ")
+		writeNode(sb, n.Select, level+1)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+
+	// Expression nodes
+	case *ColumnRef:
+		sb.WriteString(fmt.Sprintf("{COLREF :name %q", n.Name))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *DotAccessExpr:
+		sb.WriteString("{DOT :expr ")
+		writeNode(sb, n.Expr, level)
+		sb.WriteString(fmt.Sprintf(" :property %q", n.Property))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *BracketAccessExpr:
+		sb.WriteString("{BRACKET :expr ")
+		writeNode(sb, n.Expr, level)
+		sb.WriteString(" :index ")
+		writeNode(sb, n.Index, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *BinaryExpr:
+		sb.WriteString(fmt.Sprintf("{BINEXPR :op %q :left ", n.Op))
+		writeNode(sb, n.Left, level)
+		sb.WriteString(" :right ")
+		writeNode(sb, n.Right, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *UnaryExpr:
+		sb.WriteString(fmt.Sprintf("{UNARYEXPR :op %q :operand ", n.Op))
+		writeNode(sb, n.Operand, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *TernaryExpr:
+		sb.WriteString("{TERNARY :cond ")
+		writeNode(sb, n.Cond, level)
+		sb.WriteString(" :then ")
+		writeNode(sb, n.Then, level)
+		sb.WriteString(" :else ")
+		writeNode(sb, n.Else, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *InExpr:
+		sb.WriteString("{IN")
+		if n.Not {
+			sb.WriteString(" :not true")
+		}
+		sb.WriteString(" :expr ")
+		writeNode(sb, n.Expr, level)
+		sb.WriteString(" :list (")
+		for i, item := range n.List {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, item, level)
+		}
+		sb.WriteString(")")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *BetweenExpr:
+		sb.WriteString("{BETWEEN")
+		if n.Not {
+			sb.WriteString(" :not true")
+		}
+		sb.WriteString(" :expr ")
+		writeNode(sb, n.Expr, level)
+		sb.WriteString(" :low ")
+		writeNode(sb, n.Low, level)
+		sb.WriteString(" :high ")
+		writeNode(sb, n.High, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *LikeExpr:
+		sb.WriteString("{LIKE")
+		if n.Not {
+			sb.WriteString(" :not true")
+		}
+		sb.WriteString(" :expr ")
+		writeNode(sb, n.Expr, level)
+		sb.WriteString(" :pattern ")
+		writeNode(sb, n.Pattern, level)
+		if n.Escape != nil {
+			sb.WriteString(" :escape ")
+			writeNode(sb, n.Escape, level)
+		}
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *FuncCall:
+		sb.WriteString(fmt.Sprintf("{FUNCCALL :name %q", n.Name))
+		if n.Star {
+			sb.WriteString(" :star true")
+		}
+		if len(n.Args) > 0 {
+			sb.WriteString(" :args (")
+			for i, arg := range n.Args {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, arg, level)
+			}
+			sb.WriteString(")")
+		}
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *UDFCall:
+		sb.WriteString(fmt.Sprintf("{UDFCALL :name %q", n.Name))
+		if len(n.Args) > 0 {
+			sb.WriteString(" :args (")
+			for i, arg := range n.Args {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, arg, level)
+			}
+			sb.WriteString(")")
+		}
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *ExistsExpr:
+		sb.WriteString("{EXISTS\n")
+		indent(sb, level+1)
+		sb.WriteString(":select ")
+		writeNode(sb, n.Select, level+1)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *ArrayExpr:
+		sb.WriteString("{ARRAY\n")
+		indent(sb, level+1)
+		sb.WriteString(":select ")
+		writeNode(sb, n.Select, level+1)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *CreateArrayExpr:
+		sb.WriteString("{CREATEARRAY :elements (")
+		for i, elem := range n.Elements {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, elem, level)
+		}
+		sb.WriteString(")")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *CreateObjectExpr:
+		sb.WriteString("{CREATEOBJECT :fields (")
+		for i, f := range n.Fields {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, f, level)
+		}
+		sb.WriteString(")")
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *ObjectFieldPair:
+		sb.WriteString(fmt.Sprintf("{FIELD :key %q :value ", n.Key))
+		writeNode(sb, n.Value, level)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *ParamRef:
+		sb.WriteString(fmt.Sprintf("{PARAM :name %q", n.Name))
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+	case *SubLink:
+		sb.WriteString("{SUBLINK\n")
+		indent(sb, level+1)
+		sb.WriteString(":select ")
+		writeNode(sb, n.Select, level+1)
+		writeLoc(sb, n.Loc)
+		sb.WriteString("}")
+
+	default:
+		sb.WriteString(fmt.Sprintf("{UNKNOWN %T}", node))
+	}
+}
+
+func writeSelectStmt(sb *strings.Builder, n *SelectStmt, level int) {
+	sb.WriteString("{SELECT")
+	if n.Top != nil {
+		sb.WriteString(fmt.Sprintf(" :top %d", *n.Top))
+	}
+	if n.Distinct {
+		sb.WriteString(" :distinct true")
+	}
+	if n.Value {
+		sb.WriteString(" :value true")
+	}
+	if n.Star {
+		sb.WriteString(" :star true")
+	}
+	if len(n.Targets) > 0 {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":targets (")
+		for i, t := range n.Targets {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, t, level+1)
+		}
+		sb.WriteString(")")
+	}
+	if n.From != nil {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":from ")
+		writeNode(sb, n.From, level+1)
+	}
+	if len(n.Joins) > 0 {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":joins (")
+		for i, j := range n.Joins {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, j, level+1)
+		}
+		sb.WriteString(")")
+	}
+	if n.Where != nil {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":where ")
+		writeNode(sb, n.Where, level+1)
+	}
+	if len(n.GroupBy) > 0 {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":group_by (")
+		for i, g := range n.GroupBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, g, level+1)
+		}
+		sb.WriteString(")")
+	}
+	if n.Having != nil {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":having ")
+		writeNode(sb, n.Having, level+1)
+	}
+	if len(n.OrderBy) > 0 {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":order_by (")
+		for i, o := range n.OrderBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o, level+1)
+		}
+		sb.WriteString(")")
+	}
+	if n.OffsetLimit != nil {
+		sb.WriteString("\n")
+		indent(sb, level+1)
+		sb.WriteString(":offset_limit ")
+		writeNode(sb, n.OffsetLimit, level+1)
+	}
+	writeLoc(sb, n.Loc)
+	sb.WriteString("}")
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./cosmosdb/ast/`
+Expected: Clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/ast/outfuncs.go
+git commit -m "feat(cosmosdb): add AST output functions for golden testing"
+```
+
+---
+
+### Task 4: Lexer
+
+**Files:**
+- Create: `cosmosdb/parser/lexer.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/lexer.go`**
+
+```go
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Token type constants.
+const (
+	tokEOF = 0
+)
+
+// Literal and identifier tokens.
+const (
+	tokICONST = iota + 1000 // integer literal (DECIMAL)
+	tokFCONST               // float literal (REAL, FLOAT)
+	tokHCONST               // hexadecimal literal
+	tokSCONST               // single-quoted string
+	tokDCONST               // double-quoted string
+	tokIDENT                 // identifier
+	tokPARAM                 // @param
+)
+
+// Operator and punctuation tokens.
+const (
+	tokDOT      = iota + 2000 // .
+	tokCOMMA                  // ,
+	tokCOLON                  // :
+	tokLPAREN                 // (
+	tokRPAREN                 // )
+	tokLBRACK                 // [
+	tokRBRACK                 // ]
+	tokLBRACE                 // {
+	tokRBRACE                 // }
+	tokSTAR                   // *
+	tokPLUS                   // +
+	tokMINUS                  // -
+	tokDIV                    // /
+	tokMOD                    // %
+	tokEQ                     // =
+	tokNE                     // !=
+	tokNE2                    // <>
+	tokLT                     // <
+	tokLE                     // <=
+	tokGT                     // >
+	tokGE                     // >=
+	tokBITAND                 // &
+	tokBITOR                  // |
+	tokBITXOR                 // ^
+	tokBITNOT                 // ~
+	tokLSHIFT                 // <<
+	tokRSHIFT                 // >>
+	tokURSHIFT                // >>>
+	tokCONCAT                 // ||
+	tokCOALESCE               // ??
+	tokQUESTION               // ?
+)
+
+// Keyword tokens.
+const (
+	tokSELECT    = iota + 3000
+	tokFROM
+	tokWHERE
+	tokAND
+	tokOR
+	tokNOT
+	tokIN
+	tokBETWEEN
+	tokLIKE
+	tokESCAPE
+	tokAS
+	tokJOIN
+	tokTOP
+	tokDISTINCT
+	tokVALUE
+	tokORDER
+	tokBY
+	tokGROUP
+	tokHAVING
+	tokOFFSET
+	tokLIMIT
+	tokASC
+	tokDESC
+	tokEXISTS
+	tokTRUE
+	tokFALSE
+	tokNULL
+	tokUNDEFINED
+	tokUDF
+	tokARRAY
+	tokROOT
+	tokRANK
+	tokINFINITY // case-sensitive
+	tokNAN      // case-sensitive
+)
+
+var keywords = map[string]int{
+	"select":    tokSELECT,
+	"from":      tokFROM,
+	"where":     tokWHERE,
+	"and":       tokAND,
+	"or":        tokOR,
+	"not":       tokNOT,
+	"in":        tokIN,
+	"between":   tokBETWEEN,
+	"like":      tokLIKE,
+	"escape":    tokESCAPE,
+	"as":        tokAS,
+	"join":      tokJOIN,
+	"top":       tokTOP,
+	"distinct":  tokDISTINCT,
+	"value":     tokVALUE,
+	"order":     tokORDER,
+	"by":        tokBY,
+	"group":     tokGROUP,
+	"having":    tokHAVING,
+	"offset":    tokOFFSET,
+	"limit":     tokLIMIT,
+	"asc":       tokASC,
+	"desc":      tokDESC,
+	"exists":    tokEXISTS,
+	"true":      tokTRUE,
+	"false":     tokFALSE,
+	"null":      tokNULL,
+	"undefined": tokUNDEFINED,
+	"udf":       tokUDF,
+	"array":     tokARRAY,
+	"root":      tokROOT,
+	"rank":      tokRANK,
+}
+
+// Token represents a lexical token.
+type Token struct {
+	Type int
+	Str  string
+	Loc  int // byte offset in source
+}
+
+// Lexer tokenizes CosmosDB SQL input.
+type Lexer struct {
+	input string
+	pos   int   // current read position in input (next byte to consume)
+	start int   // start position of the token currently being scanned
+	Err   error
+}
+
+// NewLexer creates a new Lexer for the given input.
+func NewLexer(input string) *Lexer {
+	return &Lexer{input: input}
+}
+
+// NextToken returns the next token from the input.
+func (l *Lexer) NextToken() Token {
+	l.skipWhitespaceAndComments()
+	if l.pos >= len(l.input) {
+		return Token{Type: tokEOF, Loc: l.pos}
+	}
+
+	l.start = l.pos
+	ch := l.input[l.pos]
+
+	// Single-quoted string.
+	if ch == '\'' {
+		return l.lexString('\'', tokSCONST)
+	}
+	// Double-quoted string.
+	if ch == '"' {
+		return l.lexString('"', tokDCONST)
+	}
+	// Parameter reference: @ident.
+	if ch == '@' {
+		return l.lexParam()
+	}
+	// Number: starts with digit or dot-digit.
+	if isDigit(ch) || (ch == '.' && l.pos+1 < len(l.input) && isDigit(l.input[l.pos+1])) {
+		return l.lexNumber()
+	}
+	// Identifier or keyword.
+	if isIdentStart(ch) {
+		return l.lexIdentOrKeyword()
+	}
+	// Operators and punctuation.
+	return l.lexOperator()
+}
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '\f' {
+			l.pos++
+			continue
+		}
+		// Line comment: --
+		if ch == '-' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '-' {
+			l.pos += 2
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' && l.input[l.pos] != '\r' {
+				l.pos++
+			}
+			continue
+		}
+		break
+	}
+}
+
+func (l *Lexer) lexString(quote byte, tokType int) Token {
+	l.pos++ // skip opening quote
+	var sb strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == '\\' && l.pos+1 < len(l.input) {
+			l.pos++
+			next := l.input[l.pos]
+			switch next {
+			case 'b':
+				sb.WriteByte('\b')
+			case 't':
+				sb.WriteByte('\t')
+			case 'n':
+				sb.WriteByte('\n')
+			case 'r':
+				sb.WriteByte('\r')
+			case 'f':
+				sb.WriteByte('\f')
+			case '"':
+				sb.WriteByte('"')
+			case '\'':
+				sb.WriteByte('\'')
+			case '\\':
+				sb.WriteByte('\\')
+			case '/':
+				sb.WriteByte('/')
+			case 'u':
+				if l.pos+4 < len(l.input) {
+					hex := l.input[l.pos+1 : l.pos+5]
+					var r rune
+					if _, err := fmt.Sscanf(hex, "%04x", &r); err == nil {
+						sb.WriteRune(r)
+						l.pos += 4
+					} else {
+						sb.WriteByte('u')
+					}
+				} else {
+					sb.WriteByte('u')
+				}
+			default:
+				sb.WriteByte('\\')
+				sb.WriteByte(next)
+			}
+			l.pos++
+			continue
+		}
+		if ch == quote {
+			l.pos++ // skip closing quote
+			return Token{Type: tokType, Str: sb.String(), Loc: l.start}
+		}
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	l.Err = fmt.Errorf("unterminated string starting at byte %d", l.start)
+	return Token{Type: tokEOF, Loc: l.start}
+}
+
+func (l *Lexer) lexParam() Token {
+	l.pos++ // skip @
+	start := l.pos
+	for l.pos < len(l.input) && isIdentPart(l.input[l.pos]) {
+		l.pos++
+	}
+	if l.pos == start {
+		l.Err = fmt.Errorf("expected identifier after @ at byte %d", l.start)
+		return Token{Type: tokEOF, Loc: l.start}
+	}
+	return Token{Type: tokPARAM, Str: l.input[start:l.pos], Loc: l.start}
+}
+
+func (l *Lexer) lexNumber() Token {
+	// Hexadecimal: 0x or 0X
+	if l.input[l.pos] == '0' && l.pos+1 < len(l.input) &&
+		(l.input[l.pos+1] == 'x' || l.input[l.pos+1] == 'X') {
+		l.pos += 2
+		for l.pos < len(l.input) && isHexDigit(l.input[l.pos]) {
+			l.pos++
+		}
+		return Token{Type: tokHCONST, Str: l.input[l.start:l.pos], Loc: l.start}
+	}
+
+	// Integer or float part before dot.
+	for l.pos < len(l.input) && isDigit(l.input[l.pos]) {
+		l.pos++
+	}
+
+	isFloat := false
+
+	// Fractional part.
+	if l.pos < len(l.input) && l.input[l.pos] == '.' {
+		// Only treat as float if the next char is a digit or we already consumed digits.
+		if l.pos+1 < len(l.input) && isDigit(l.input[l.pos+1]) {
+			isFloat = true
+			l.pos++ // skip dot
+			for l.pos < len(l.input) && isDigit(l.input[l.pos]) {
+				l.pos++
+			}
+		} else if l.start == l.pos {
+			// dot-only: not a number, shouldn't reach here due to caller check.
+		} else {
+			// Digits followed by dot but no digit after: still a float like "123."
+			isFloat = true
+			l.pos++ // skip dot
+		}
+	}
+
+	// Exponent part: E/e [+-] digits.
+	if l.pos < len(l.input) && (l.input[l.pos] == 'e' || l.input[l.pos] == 'E') {
+		isFloat = true
+		l.pos++
+		if l.pos < len(l.input) && (l.input[l.pos] == '+' || l.input[l.pos] == '-') {
+			l.pos++
+		}
+		for l.pos < len(l.input) && isDigit(l.input[l.pos]) {
+			l.pos++
+		}
+	}
+
+	tok := tokICONST
+	if isFloat {
+		tok = tokFCONST
+	}
+	return Token{Type: tok, Str: l.input[l.start:l.pos], Loc: l.start}
+}
+
+func (l *Lexer) lexIdentOrKeyword() Token {
+	for l.pos < len(l.input) && isIdentPart(l.input[l.pos]) {
+		l.pos++
+	}
+	raw := l.input[l.start:l.pos]
+
+	// Case-sensitive special constants: Infinity, NaN.
+	if raw == "Infinity" {
+		return Token{Type: tokINFINITY, Str: raw, Loc: l.start}
+	}
+	if raw == "NaN" {
+		return Token{Type: tokNAN, Str: raw, Loc: l.start}
+	}
+
+	// Case-insensitive keyword lookup.
+	lower := strings.ToLower(raw)
+	if tok, ok := keywords[lower]; ok {
+		return Token{Type: tok, Str: lower, Loc: l.start}
+	}
+	return Token{Type: tokIDENT, Str: raw, Loc: l.start}
+}
+
+func (l *Lexer) lexOperator() Token {
+	ch := l.input[l.pos]
+	l.pos++
+	next := byte(0)
+	if l.pos < len(l.input) {
+		next = l.input[l.pos]
+	}
+
+	switch ch {
+	case '.':
+		return Token{Type: tokDOT, Str: ".", Loc: l.start}
+	case ',':
+		return Token{Type: tokCOMMA, Str: ",", Loc: l.start}
+	case ':':
+		return Token{Type: tokCOLON, Str: ":", Loc: l.start}
+	case '(':
+		return Token{Type: tokLPAREN, Str: "(", Loc: l.start}
+	case ')':
+		return Token{Type: tokRPAREN, Str: ")", Loc: l.start}
+	case '[':
+		return Token{Type: tokLBRACK, Str: "[", Loc: l.start}
+	case ']':
+		return Token{Type: tokRBRACK, Str: "]", Loc: l.start}
+	case '{':
+		return Token{Type: tokLBRACE, Str: "{", Loc: l.start}
+	case '}':
+		return Token{Type: tokRBRACE, Str: "}", Loc: l.start}
+	case '*':
+		return Token{Type: tokSTAR, Str: "*", Loc: l.start}
+	case '+':
+		return Token{Type: tokPLUS, Str: "+", Loc: l.start}
+	case '-':
+		return Token{Type: tokMINUS, Str: "-", Loc: l.start}
+	case '/':
+		return Token{Type: tokDIV, Str: "/", Loc: l.start}
+	case '%':
+		return Token{Type: tokMOD, Str: "%", Loc: l.start}
+	case '=':
+		return Token{Type: tokEQ, Str: "=", Loc: l.start}
+	case '~':
+		return Token{Type: tokBITNOT, Str: "~", Loc: l.start}
+	case '^':
+		return Token{Type: tokBITXOR, Str: "^", Loc: l.start}
+	case '&':
+		return Token{Type: tokBITAND, Str: "&", Loc: l.start}
+	case '!':
+		if next == '=' {
+			l.pos++
+			return Token{Type: tokNE, Str: "!=", Loc: l.start}
+		}
+		l.Err = fmt.Errorf("unexpected character '!' at byte %d", l.start)
+		return Token{Type: tokEOF, Loc: l.start}
+	case '<':
+		if next == '=' {
+			l.pos++
+			return Token{Type: tokLE, Str: "<=", Loc: l.start}
+		}
+		if next == '>' {
+			l.pos++
+			return Token{Type: tokNE2, Str: "<>", Loc: l.start}
+		}
+		if next == '<' {
+			l.pos++
+			return Token{Type: tokLSHIFT, Str: "<<", Loc: l.start}
+		}
+		return Token{Type: tokLT, Str: "<", Loc: l.start}
+	case '>':
+		if next == '=' {
+			l.pos++
+			return Token{Type: tokGE, Str: ">=", Loc: l.start}
+		}
+		if next == '>' {
+			l.pos++
+			// Check for >>>
+			if l.pos < len(l.input) && l.input[l.pos] == '>' {
+				l.pos++
+				return Token{Type: tokURSHIFT, Str: ">>>", Loc: l.start}
+			}
+			return Token{Type: tokRSHIFT, Str: ">>", Loc: l.start}
+		}
+		return Token{Type: tokGT, Str: ">", Loc: l.start}
+	case '|':
+		if next == '|' {
+			l.pos++
+			return Token{Type: tokCONCAT, Str: "||", Loc: l.start}
+		}
+		return Token{Type: tokBITOR, Str: "|", Loc: l.start}
+	case '?':
+		if next == '?' {
+			l.pos++
+			return Token{Type: tokCOALESCE, Str: "??", Loc: l.start}
+		}
+		return Token{Type: tokQUESTION, Str: "?", Loc: l.start}
+	default:
+		// Handle multi-byte UTF-8 characters gracefully.
+		_, size := utf8.DecodeRuneInString(l.input[l.start:])
+		if size > 1 {
+			l.pos = l.start + size
+		}
+		l.Err = fmt.Errorf("unexpected character %q at byte %d", string(ch), l.start)
+		return Token{Type: tokEOF, Loc: l.start}
+	}
+}
+
+func isDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+func isHexDigit(ch byte) bool {
+	return isDigit(ch) || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isIdentPart(ch byte) bool {
+	return isIdentStart(ch) || isDigit(ch)
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./cosmosdb/parser/`
+Expected: Will fail because `parser/` has no non-test `.go` file that imports it yet. Instead run:
+Run: `cd /Users/h3n4l/OpenSource/omni && go vet ./cosmosdb/parser/`
+Expected: May warn about unused imports; check with `go build` by creating a minimal parser.go in next task. For now, verify syntax:
+Run: `cd /Users/h3n4l/OpenSource/omni && gofmt -e cosmosdb/parser/lexer.go > /dev/null`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/lexer.go
+git commit -m "feat(cosmosdb): add hand-written lexer"
+```
+
+---
+
+### Task 5: Parser Core (Entry Point and Helpers)
+
+**Files:**
+- Create: `cosmosdb/parser/parser.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/parser.go`**
+
+```go
+package parser
+
+import (
+	"fmt"
+	"strconv"
+
+	nodes "github.com/bytebase/omni/cosmosdb/ast"
+)
+
+// Parser is a recursive descent parser for CosmosDB SQL.
+type Parser struct {
+	lexer   *Lexer
+	cur     Token // current token (already consumed)
+	prev    Token // previous token (for error context)
+	nextBuf Token // buffered lookahead token
+	hasNext bool  // whether nextBuf is valid
+}
+
+// ParseError represents a syntax error.
+type ParseError struct {
+	Message string
+	Pos     int
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("syntax error at byte %d: %s", e.Pos, e.Message)
+}
+
+// Parse parses a CosmosDB SQL query and returns a list containing one RawStmt.
+func Parse(sql string) (*nodes.List, error) {
+	p := &Parser{lexer: NewLexer(sql)}
+	p.advance()
+
+	if p.cur.Type == tokEOF {
+		return &nodes.List{}, nil
+	}
+
+	stmtStart := p.cur.Loc
+	stmt, err := p.parseSelect()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type != tokEOF {
+		return nil, &ParseError{
+			Message: fmt.Sprintf("unexpected token %q after query", p.cur.Str),
+			Pos:     p.cur.Loc,
+		}
+	}
+
+	raw := &nodes.RawStmt{
+		Stmt:         stmt,
+		StmtLocation: stmtStart,
+		StmtLen:      len(sql) - stmtStart,
+	}
+
+	return &nodes.List{Items: []nodes.Node{raw}}, nil
+}
+
+// parseSelect parses a full SELECT query.
+func (p *Parser) parseSelect() (*nodes.SelectStmt, error) {
+	startLoc := p.cur.Loc
+
+	selectClause, err := p.parseSelectClause()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := selectClause
+
+	// FROM clause (optional).
+	if p.cur.Type == tokFROM {
+		from, joins, err := p.parseFromClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+		stmt.Joins = joins
+	}
+
+	// WHERE clause (optional).
+	if p.cur.Type == tokWHERE {
+		p.advance()
+		where, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	// GROUP BY clause (optional).
+	if p.cur.Type == tokGROUP {
+		groupBy, err := p.parseGroupBy()
+		if err != nil {
+			return nil, err
+		}
+		stmt.GroupBy = groupBy
+	}
+
+	// HAVING clause (optional).
+	if p.cur.Type == tokHAVING {
+		p.advance()
+		having, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Having = having
+	}
+
+	// ORDER BY clause (optional).
+	if p.cur.Type == tokORDER {
+		orderBy, err := p.parseOrderBy()
+		if err != nil {
+			return nil, err
+		}
+		stmt.OrderBy = orderBy
+	}
+
+	// OFFSET ... LIMIT ... (optional).
+	if p.cur.Type == tokOFFSET {
+		ol, err := p.parseOffsetLimit()
+		if err != nil {
+			return nil, err
+		}
+		stmt.OffsetLimit = ol
+	}
+
+	stmt.Loc = nodes.Loc{Start: startLoc, End: p.pos()}
+
+	return stmt, nil
+}
+
+// -----------------------------------------------------------------------
+// Helper methods
+// -----------------------------------------------------------------------
+
+// advance consumes the current token and moves to the next one.
+func (p *Parser) advance() Token {
+	p.prev = p.cur
+	if p.hasNext {
+		p.cur = p.nextBuf
+		p.hasNext = false
+	} else {
+		p.cur = p.lexer.NextToken()
+	}
+	return p.prev
+}
+
+// peek returns the current token without consuming it.
+func (p *Parser) peek() Token {
+	return p.cur
+}
+
+// peekNext returns the next token without consuming the current one.
+func (p *Parser) peekNext() Token {
+	if !p.hasNext {
+		p.nextBuf = p.lexer.NextToken()
+		p.hasNext = true
+	}
+	return p.nextBuf
+}
+
+// match checks if the current token matches any of the given types.
+// If it matches, it consumes the token and returns it with true.
+func (p *Parser) match(types ...int) (Token, bool) {
+	for _, t := range types {
+		if p.cur.Type == t {
+			tok := p.advance()
+			return tok, true
+		}
+	}
+	return Token{}, false
+}
+
+// expect consumes the current token if it matches the given type.
+// Returns an error if it doesn't match.
+func (p *Parser) expect(tokenType int) (Token, error) {
+	if p.cur.Type == tokenType {
+		return p.advance(), nil
+	}
+	return Token{}, &ParseError{
+		Message: fmt.Sprintf("expected token type %d, got %q", tokenType, p.cur.Str),
+		Pos:     p.cur.Loc,
+	}
+}
+
+// pos returns the current byte position in the source.
+func (p *Parser) pos() int {
+	return p.cur.Loc
+}
+
+// identifierTokens are keyword tokens that can be used as identifiers.
+var identifierTokens = map[int]bool{
+	tokIN:      true,
+	tokBETWEEN: true,
+	tokTOP:     true,
+	tokVALUE:   true,
+	tokORDER:   true,
+	tokBY:      true,
+	tokGROUP:   true,
+	tokOFFSET:  true,
+	tokLIMIT:   true,
+	tokASC:     true,
+	tokDESC:    true,
+	tokEXISTS:  true,
+	tokLIKE:    true,
+	tokHAVING:  true,
+	tokJOIN:    true,
+	tokESCAPE:  true,
+	tokARRAY:   true,
+	tokROOT:    true,
+	tokRANK:    true,
+}
+
+// propertyNameExtraTokens are additional keywords valid as property names.
+var propertyNameExtraTokens = map[int]bool{
+	tokSELECT:    true,
+	tokFROM:      true,
+	tokWHERE:     true,
+	tokNOT:       true,
+	tokAND:       true,
+	tokOR:        true,
+	tokAS:        true,
+	tokTRUE:      true,
+	tokFALSE:     true,
+	tokNULL:      true,
+	tokUNDEFINED: true,
+	tokUDF:       true,
+	tokDISTINCT:  true,
+}
+
+// parseIdentifier parses an identifier, accepting keywords that are valid
+// in identifier position per the grammar's `identifier` rule.
+func (p *Parser) parseIdentifier() (string, int, error) {
+	if p.cur.Type == tokIDENT {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
+	if identifierTokens[p.cur.Type] {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
+	return "", 0, &ParseError{
+		Message: fmt.Sprintf("expected identifier, got %q", p.cur.Str),
+		Pos:     p.cur.Loc,
+	}
+}
+
+// parsePropertyName parses a property name, which allows even more keywords
+// than parseIdentifier per the grammar's `property_name` rule.
+func (p *Parser) parsePropertyName() (string, int, error) {
+	if p.cur.Type == tokIDENT || identifierTokens[p.cur.Type] || propertyNameExtraTokens[p.cur.Type] {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
+	return "", 0, &ParseError{
+		Message: fmt.Sprintf("expected property name, got %q", p.cur.Str),
+		Pos:     p.cur.Loc,
+	}
+}
+
+// parseIntLiteral parses a DECIMAL token as an integer.
+func (p *Parser) parseIntLiteral() (int, int, error) {
+	if p.cur.Type != tokICONST {
+		return 0, 0, &ParseError{
+			Message: fmt.Sprintf("expected integer, got %q", p.cur.Str),
+			Pos:     p.cur.Loc,
+		}
+	}
+	tok := p.advance()
+	n, err := strconv.Atoi(tok.Str)
+	if err != nil {
+		return 0, 0, &ParseError{Message: fmt.Sprintf("invalid integer %q", tok.Str), Pos: tok.Loc}
+	}
+	return n, tok.Loc, nil
+}
+```
+
+- [ ] **Step 2: Verify it compiles (will need stubs for parseSelectClause, parseFromClause, parseGroupBy, parseOrderBy, parseOffsetLimit, parseExpr)**
+
+Create temporary stubs by running the build; we'll fill them in the next tasks. For now, verify the file has no syntax errors:
+
+Run: `cd /Users/h3n4l/OpenSource/omni && gofmt -e cosmosdb/parser/parser.go > /dev/null`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/parser.go
+git commit -m "feat(cosmosdb): add parser core with entry point and helpers"
+```
+
+---
+
+### Task 6: Parser — SELECT and Clause Parsing
+
+**Files:**
+- Create: `cosmosdb/parser/select.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/select.go`**
+
+```go
+package parser
+
+import (
+	"fmt"
+
+	nodes "github.com/bytebase/omni/cosmosdb/ast"
+)
+
+// parseSelectClause parses: SELECT [TOP n] [DISTINCT] [VALUE] (target_list | *)
+func (p *Parser) parseSelectClause() (*nodes.SelectStmt, error) {
+	if _, err := p.expect(tokSELECT); err != nil {
+		return nil, err
+	}
+
+	stmt := &nodes.SelectStmt{}
+
+	// TOP n
+	if p.cur.Type == tokTOP {
+		p.advance()
+		n, _, err := p.parseIntLiteral()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Top = &n
+	}
+
+	// DISTINCT
+	if p.cur.Type == tokDISTINCT {
+		p.advance()
+		stmt.Distinct = true
+	}
+
+	// VALUE
+	if p.cur.Type == tokVALUE {
+		p.advance()
+		stmt.Value = true
+	}
+
+	// * or target list
+	if p.cur.Type == tokSTAR {
+		p.advance()
+		stmt.Star = true
+	} else {
+		targets, err := p.parseTargetList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Targets = targets
+	}
+
+	return stmt, nil
+}
+
+// parseTargetList parses: object_property (',' object_property)*
+func (p *Parser) parseTargetList() ([]*nodes.TargetEntry, error) {
+	var targets []*nodes.TargetEntry
+
+	t, err := p.parseTargetEntry()
+	if err != nil {
+		return nil, err
+	}
+	targets = append(targets, t)
+
+	for p.cur.Type == tokCOMMA {
+		p.advance()
+		t, err := p.parseTargetEntry()
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, t)
+	}
+
+	return targets, nil
+}
+
+// parseTargetEntry parses: scalar_expression [AS? property_alias]
+func (p *Parser) parseTargetEntry() (*nodes.TargetEntry, error) {
+	startLoc := p.cur.Loc
+
+	expr, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &nodes.TargetEntry{Expr: expr}
+
+	// Optional alias: AS? identifier
+	if p.cur.Type == tokAS {
+		p.advance()
+		name, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		entry.Alias = &name
+	} else if p.cur.Type == tokIDENT || identifierTokens[p.cur.Type] {
+		// Alias without AS — but only if it looks like an identifier, not a keyword
+		// that starts a new clause (FROM, WHERE, etc.). We check against the
+		// identifierTokens set which excludes clause-starting keywords.
+		name, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		entry.Alias = &name
+	}
+
+	entry.Loc = nodes.Loc{Start: startLoc, End: p.pos()}
+
+	return entry, nil
+}
+
+// parseGroupBy parses: GROUP BY expr (',' expr)*
+func (p *Parser) parseGroupBy() ([]nodes.ExprNode, error) {
+	p.advance() // consume GROUP
+	if _, err := p.expect(tokBY); err != nil {
+		return nil, err
+	}
+
+	var exprs []nodes.ExprNode
+	expr, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+	exprs = append(exprs, expr)
+
+	for p.cur.Type == tokCOMMA {
+		p.advance()
+		expr, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+
+	return exprs, nil
+}
+
+// parseOrderBy parses: ORDER BY sort_expression (',' sort_expression)*
+func (p *Parser) parseOrderBy() ([]*nodes.SortExpr, error) {
+	p.advance() // consume ORDER
+	if _, err := p.expect(tokBY); err != nil {
+		return nil, err
+	}
+
+	var sorts []*nodes.SortExpr
+	s, err := p.parseSortExpr()
+	if err != nil {
+		return nil, err
+	}
+	sorts = append(sorts, s)
+
+	for p.cur.Type == tokCOMMA {
+		p.advance()
+		s, err := p.parseSortExpr()
+		if err != nil {
+			return nil, err
+		}
+		sorts = append(sorts, s)
+	}
+
+	return sorts, nil
+}
+
+// parseSortExpr parses: expr [ASC|DESC] | RANK expr
+func (p *Parser) parseSortExpr() (*nodes.SortExpr, error) {
+	startLoc := p.cur.Loc
+	sort := &nodes.SortExpr{}
+
+	if p.cur.Type == tokRANK {
+		p.advance()
+		sort.Rank = true
+	}
+
+	expr, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+	sort.Expr = expr
+
+	if !sort.Rank {
+		if p.cur.Type == tokDESC {
+			p.advance()
+			sort.Desc = true
+		} else if p.cur.Type == tokASC {
+			p.advance()
+		}
+	}
+
+	sort.Loc = nodes.Loc{Start: startLoc, End: p.pos()}
+	return sort, nil
+}
+
+// parseOffsetLimit parses: OFFSET n LIMIT m
+func (p *Parser) parseOffsetLimit() (*nodes.OffsetLimitClause, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume OFFSET
+
+	offsetVal, offsetLoc, err := p.parseIntLiteral()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(tokLIMIT); err != nil {
+		return nil, err
+	}
+
+	limitVal, limitLoc, err := p.parseIntLiteral()
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodes.OffsetLimitClause{
+		Offset: &nodes.NumberLit{Val: intToStr(offsetVal), Loc: nodes.Loc{Start: offsetLoc, End: offsetLoc + len(intToStr(offsetVal))}},
+		Limit:  &nodes.NumberLit{Val: intToStr(limitVal), Loc: nodes.Loc{Start: limitLoc, End: limitLoc + len(intToStr(limitVal))}},
+		Loc:    nodes.Loc{Start: startLoc, End: p.pos()},
+	}, nil
+}
+
+func intToStr(n int) string {
+	return fmt.Sprintf("%d", n)
+}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && gofmt -e cosmosdb/parser/select.go > /dev/null`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/select.go
+git commit -m "feat(cosmosdb): add SELECT clause parsing"
+```
+
+---
+
+### Task 7: Parser — FROM Clause
+
+**Files:**
+- Create: `cosmosdb/parser/from.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/from.go`**
+
+```go
+package parser
+
+import (
+	"fmt"
+
+	nodes "github.com/bytebase/omni/cosmosdb/ast"
+)
+
+// parseFromClause parses: FROM from_specification
+// Returns the primary source and any JOINs.
+func (p *Parser) parseFromClause() (nodes.TableExpr, []*nodes.JoinExpr, error) {
+	p.advance() // consume FROM
+
+	source, err := p.parseFromSource()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var joins []*nodes.JoinExpr
+	for p.cur.Type == tokJOIN {
+		j, err := p.parseJoinClause()
+		if err != nil {
+			return nil, nil, err
+		}
+		joins = append(joins, j)
+	}
+
+	return source, joins, nil
+}
+
+// parseJoinClause parses: JOIN from_source
+func (p *Parser) parseJoinClause() (*nodes.JoinExpr, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume JOIN
+
+	source, err := p.parseFromSource()
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodes.JoinExpr{
+		Source: source,
+		Loc:    nodes.Loc{Start: startLoc, End: p.pos()},
+	}, nil
+}
+
+// parseFromSource parses:
+//
+//	container_expression [AS? identifier]   (aliased form)
+//	identifier IN container_expression      (iteration form)
+func (p *Parser) parseFromSource() (nodes.TableExpr, error) {
+	startLoc := p.cur.Loc
+
+	// Check for iteration form: identifier IN container_expression.
+	// We need lookahead: if current is an identifier-like token and next is IN.
+	if (p.cur.Type == tokIDENT || identifierTokens[p.cur.Type]) && p.peekNext().Type == tokIN {
+		alias := p.cur.Str
+		p.advance() // consume identifier
+		p.advance() // consume IN
+
+		source, err := p.parseContainerExpr()
+		if err != nil {
+			return nil, err
+		}
+
+		return &nodes.ArrayIterationExpr{
+			Alias:  alias,
+			Source: source,
+			Loc:    nodes.Loc{Start: startLoc, End: p.pos()},
+		}, nil
+	}
+
+	// Aliased form: container_expression [AS? identifier].
+	source, err := p.parseContainerExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional alias.
+	if p.cur.Type == tokAS {
+		p.advance()
+		alias, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.AliasedTableExpr{
+			Source: source,
+			Alias:  alias,
+			Loc:    nodes.Loc{Start: startLoc, End: p.pos()},
+		}, nil
+	}
+	// Implicit alias (identifier not followed by a clause keyword).
+	if p.cur.Type == tokIDENT || identifierTokens[p.cur.Type] {
+		// Only treat as alias if it's not a keyword that starts a clause.
+		if !isClauseStart(p.cur.Type) {
+			alias, _, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			return &nodes.AliasedTableExpr{
+				Source: source,
+				Alias:  alias,
+				Loc:    nodes.Loc{Start: startLoc, End: p.pos()},
+			}, nil
+		}
+	}
+
+	return source, nil
+}
+
+// parseContainerExpr parses:
+//
+//	ROOT
+//	container_name
+//	container_expression '.' property_name
+//	container_expression '[' (string | index | @param) ']'
+//	'(' select ')'
+func (p *Parser) parseContainerExpr() (nodes.TableExpr, error) {
+	var expr nodes.TableExpr
+
+	switch p.cur.Type {
+	case tokROOT:
+		expr = &nodes.ContainerRef{
+			Root: true,
+			Loc:  nodes.Loc{Start: p.cur.Loc, End: p.cur.Loc + len(p.cur.Str)},
+		}
+		p.advance()
+
+	case tokLPAREN:
+		startLoc := p.cur.Loc
+		p.advance() // consume (
+		sel, err := p.parseSelect()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokRPAREN); err != nil {
+			return nil, err
+		}
+		expr = &nodes.SubqueryExpr{
+			Select: sel,
+			Loc:    nodes.Loc{Start: startLoc, End: p.pos()},
+		}
+
+	default:
+		// container_name (identifier).
+		name, loc, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		expr = &nodes.ContainerRef{
+			Name: name,
+			Loc:  nodes.Loc{Start: loc, End: loc + len(name)},
+		}
+	}
+
+	// Postfix: .property and [index]
+	for {
+		if p.cur.Type == tokDOT {
+			startLoc := expr.(*nodes.ContainerRef)
+			_ = startLoc // use the expr's own start
+			dotStart := p.cur.Loc
+			_ = dotStart
+			p.advance() // consume .
+			prop, _, err := p.parsePropertyName()
+			if err != nil {
+				return nil, err
+			}
+			expr = &nodes.DotAccessExpr{
+				Expr:     exprFromTableExpr(expr),
+				Property: prop,
+				Loc:      nodes.Loc{Start: tableExprStart(expr), End: p.pos()},
+			}
+			continue
+		}
+		if p.cur.Type == tokLBRACK {
+			p.advance() // consume [
+			idx, err := p.parseBracketIndex()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(tokRBRACK); err != nil {
+				return nil, err
+			}
+			expr = &nodes.BracketAccessExpr{
+				Expr:  exprFromTableExpr(expr),
+				Index: idx,
+				Loc:   nodes.Loc{Start: tableExprStart(expr), End: p.pos()},
+			}
+			continue
+		}
+		break
+	}
+
+	return expr, nil
+}
+
+// parseBracketIndex parses the index inside [...]: string literal, integer, or @param.
+func (p *Parser) parseBracketIndex() (nodes.ExprNode, error) {
+	switch p.cur.Type {
+	case tokSCONST:
+		tok := p.advance()
+		return &nodes.StringLit{Val: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokDCONST:
+		tok := p.advance()
+		return &nodes.StringLit{Val: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokICONST:
+		tok := p.advance()
+		return &nodes.NumberLit{Val: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokPARAM:
+		tok := p.advance()
+		return &nodes.ParamRef{Name: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	default:
+		return nil, &ParseError{
+			Message: fmt.Sprintf("expected string, integer, or @param inside [], got %q", p.cur.Str),
+			Pos:     p.cur.Loc,
+		}
+	}
+}
+
+// exprFromTableExpr converts a TableExpr to an ExprNode.
+// DotAccessExpr and BracketAccessExpr implement both interfaces.
+// ContainerRef must be converted to a ColumnRef.
+func exprFromTableExpr(te nodes.TableExpr) nodes.ExprNode {
+	switch n := te.(type) {
+	case *nodes.DotAccessExpr:
+		return n
+	case *nodes.BracketAccessExpr:
+		return n
+	case *nodes.ContainerRef:
+		return &nodes.ColumnRef{Name: n.Name, Loc: n.Loc}
+	default:
+		// For SubqueryExpr and others, this shouldn't happen in valid SQL.
+		return nil
+	}
+}
+
+// tableExprStart returns the start byte offset of a TableExpr.
+func tableExprStart(te nodes.TableExpr) int {
+	switch n := te.(type) {
+	case *nodes.ContainerRef:
+		return n.Loc.Start
+	case *nodes.DotAccessExpr:
+		return n.Loc.Start
+	case *nodes.BracketAccessExpr:
+		return n.Loc.Start
+	case *nodes.SubqueryExpr:
+		return n.Loc.Start
+	case *nodes.AliasedTableExpr:
+		return n.Loc.Start
+	case *nodes.ArrayIterationExpr:
+		return n.Loc.Start
+	default:
+		return -1
+	}
+}
+
+// isClauseStart returns true for tokens that start a main clause and should
+// not be consumed as implicit aliases.
+func isClauseStart(tokType int) bool {
+	switch tokType {
+	case tokFROM, tokWHERE, tokGROUP, tokHAVING, tokORDER, tokOFFSET, tokLIMIT, tokJOIN:
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && gofmt -e cosmosdb/parser/from.go > /dev/null`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/from.go
+git commit -m "feat(cosmosdb): add FROM clause parsing"
+```
+
+---
+
+### Task 8: Parser — Expression Parsing (Pratt Parser)
+
+**Files:**
+- Create: `cosmosdb/parser/expr.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/expr.go`**
+
+```go
+package parser
+
+import (
+	"fmt"
+
+	nodes "github.com/bytebase/omni/cosmosdb/ast"
+)
+
+// Precedence levels for the Pratt parser.
+const (
+	precNone       = 0
+	precTernary    = 1  // ? :
+	precCoalesce   = 2  // ??
+	precOr         = 3  // OR
+	precAnd        = 4  // AND
+	precInBetween  = 5  // IN, BETWEEN, LIKE
+	precComparison = 6  // = != <> < <= > >=
+	precConcat     = 7  // ||
+	precBitOr      = 8  // |
+	precBitXor     = 9  // ^
+	precBitAnd     = 10 // &
+	precShift      = 11 // << >> >>>
+	precAdditive   = 12 // + -
+	precMult       = 13 // * / %
+	precUnary      = 14 // NOT ~ + -
+	precPostfix    = 15 // . []
+)
+
+// parseExpr parses a scalar expression using Pratt parsing.
+func (p *Parser) parseExpr(minPrec int) (nodes.ExprNode, error) {
+	left, err := p.parsePrefixExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		prec, ok := p.infixPrecedence()
+		if !ok || prec < minPrec {
+			break
+		}
+
+		left, err = p.parseInfixExpr(left, prec)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return left, nil
+}
+
+// parsePrefixExpr parses a prefix expression (constants, identifiers, unary ops, etc.).
+func (p *Parser) parsePrefixExpr() (nodes.ExprNode, error) {
+	switch p.cur.Type {
+	// Constants.
+	case tokTRUE:
+		tok := p.advance()
+		return &nodes.BoolLit{Val: true, Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+	case tokFALSE:
+		tok := p.advance()
+		return &nodes.BoolLit{Val: false, Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+	case tokNULL:
+		tok := p.advance()
+		return &nodes.NullLit{Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+	case tokUNDEFINED:
+		tok := p.advance()
+		return &nodes.UndefinedLit{Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+	case tokINFINITY:
+		tok := p.advance()
+		return &nodes.InfinityLit{Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+	case tokNAN:
+		tok := p.advance()
+		return &nodes.NanLit{Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+
+	// Numbers.
+	case tokICONST, tokFCONST, tokHCONST:
+		tok := p.advance()
+		return &nodes.NumberLit{Val: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: tok.Loc + len(tok.Str)}}, nil
+
+	// Strings.
+	case tokSCONST:
+		tok := p.advance()
+		return &nodes.StringLit{Val: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokDCONST:
+		tok := p.advance()
+		return &nodes.StringLit{Val: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+
+	// Parameter reference.
+	case tokPARAM:
+		tok := p.advance()
+		return &nodes.ParamRef{Name: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+
+	// Unary operators.
+	case tokNOT:
+		tok := p.advance()
+		operand, err := p.parseExpr(precUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.UnaryExpr{Op: "NOT", Operand: operand, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokBITNOT:
+		tok := p.advance()
+		operand, err := p.parseExpr(precUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.UnaryExpr{Op: "~", Operand: operand, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokPLUS:
+		tok := p.advance()
+		operand, err := p.parseExpr(precUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.UnaryExpr{Op: "+", Operand: operand, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+	case tokMINUS:
+		tok := p.advance()
+		operand, err := p.parseExpr(precUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.UnaryExpr{Op: "-", Operand: operand, Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}}, nil
+
+	// EXISTS(SELECT ...)
+	case tokEXISTS:
+		return p.parseExistsExpr()
+
+	// ARRAY(SELECT ...)
+	case tokARRAY:
+		// Could be ARRAY(SELECT ...) or ARRAY used as an identifier.
+		if p.peekNext().Type == tokLPAREN {
+			return p.parseArrayExpr()
+		}
+		// Fall through to identifier.
+		return p.parseIdentExprOrFuncCall()
+
+	// UDF.name(...)
+	case tokUDF:
+		return p.parseUDFCall()
+
+	// Parenthesized expression or subquery.
+	case tokLPAREN:
+		return p.parseParenExpr()
+
+	// Array literal: [...]
+	case tokLBRACK:
+		return p.parseCreateArrayExpr()
+
+	// Object literal: {...}
+	case tokLBRACE:
+		return p.parseCreateObjectExpr()
+
+	// Identifier or function call.
+	case tokIDENT:
+		return p.parseIdentExprOrFuncCall()
+
+	// Keywords usable as identifiers in expression position.
+	default:
+		if identifierTokens[p.cur.Type] {
+			return p.parseIdentExprOrFuncCall()
+		}
+		return nil, &ParseError{
+			Message: fmt.Sprintf("unexpected token %q in expression", p.cur.Str),
+			Pos:     p.cur.Loc,
+		}
+	}
+}
+
+// infixPrecedence returns the precedence of the current token as an infix operator.
+func (p *Parser) infixPrecedence() (int, bool) {
+	switch p.cur.Type {
+	case tokQUESTION:
+		return precTernary, true
+	case tokCOALESCE:
+		return precCoalesce, true
+	case tokOR:
+		return precOr, true
+	case tokAND:
+		return precAnd, true
+	case tokNOT:
+		// NOT IN, NOT BETWEEN, NOT LIKE — only valid as infix when preceding IN/BETWEEN/LIKE.
+		next := p.peekNext()
+		if next.Type == tokIN || next.Type == tokBETWEEN || next.Type == tokLIKE {
+			return precInBetween, true
+		}
+		return 0, false
+	case tokIN:
+		return precInBetween, true
+	case tokBETWEEN:
+		return precInBetween, true
+	case tokLIKE:
+		return precInBetween, true
+	case tokEQ, tokNE, tokNE2, tokLT, tokLE, tokGT, tokGE:
+		return precComparison, true
+	case tokCONCAT:
+		return precConcat, true
+	case tokBITOR:
+		return precBitOr, true
+	case tokBITXOR:
+		return precBitXor, true
+	case tokBITAND:
+		return precBitAnd, true
+	case tokLSHIFT, tokRSHIFT, tokURSHIFT:
+		return precShift, true
+	case tokPLUS, tokMINUS:
+		return precAdditive, true
+	case tokSTAR, tokDIV, tokMOD:
+		return precMult, true
+	case tokDOT:
+		return precPostfix, true
+	case tokLBRACK:
+		return precPostfix, true
+	default:
+		return 0, false
+	}
+}
+
+// parseInfixExpr parses an infix expression given the left operand.
+func (p *Parser) parseInfixExpr(left nodes.ExprNode, prec int) (nodes.ExprNode, error) {
+	startLoc := locStart(left)
+
+	switch p.cur.Type {
+	// Ternary: left ? then : else
+	case tokQUESTION:
+		p.advance()
+		then, err := p.parseExpr(0) // ternary is right-associative, parse fully
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokCOLON); err != nil {
+			return nil, err
+		}
+		elseExpr, err := p.parseExpr(precTernary) // right-assoc
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.TernaryExpr{Cond: left, Then: then, Else: elseExpr, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+
+	// NOT IN / NOT BETWEEN / NOT LIKE
+	case tokNOT:
+		p.advance() // consume NOT
+		switch p.cur.Type {
+		case tokIN:
+			return p.parseInExpr(left, true, startLoc)
+		case tokBETWEEN:
+			return p.parseBetweenExpr(left, true, startLoc)
+		case tokLIKE:
+			return p.parseLikeExpr(left, true, startLoc)
+		default:
+			return nil, &ParseError{
+				Message: fmt.Sprintf("expected IN, BETWEEN, or LIKE after NOT, got %q", p.cur.Str),
+				Pos:     p.cur.Loc,
+			}
+		}
+
+	case tokIN:
+		return p.parseInExpr(left, false, startLoc)
+	case tokBETWEEN:
+		return p.parseBetweenExpr(left, false, startLoc)
+	case tokLIKE:
+		return p.parseLikeExpr(left, false, startLoc)
+
+	// Property access: left.property
+	case tokDOT:
+		p.advance()
+		prop, _, err := p.parsePropertyName()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.DotAccessExpr{Expr: left, Property: prop, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+
+	// Bracket access: left[index]
+	case tokLBRACK:
+		p.advance()
+		idx, err := p.parseBracketIndex()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokRBRACK); err != nil {
+			return nil, err
+		}
+		return &nodes.BracketAccessExpr{Expr: left, Index: idx, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+
+	// Binary operators.
+	default:
+		op := p.cur.Str
+		// Normalize keyword ops.
+		switch p.cur.Type {
+		case tokAND:
+			op = "AND"
+		case tokOR:
+			op = "OR"
+		}
+		p.advance()
+		right, err := p.parseExpr(prec + 1) // left-associative
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.BinaryExpr{Op: op, Left: left, Right: right, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+	}
+}
+
+// parseInExpr parses: [NOT] IN (expr, ...)
+func (p *Parser) parseInExpr(left nodes.ExprNode, not bool, startLoc int) (nodes.ExprNode, error) {
+	p.advance() // consume IN
+	if _, err := p.expect(tokLPAREN); err != nil {
+		return nil, err
+	}
+
+	var list []nodes.ExprNode
+	if p.cur.Type != tokRPAREN {
+		expr, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, expr)
+		for p.cur.Type == tokCOMMA {
+			p.advance()
+			expr, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, expr)
+		}
+	}
+
+	if _, err := p.expect(tokRPAREN); err != nil {
+		return nil, err
+	}
+
+	return &nodes.InExpr{Expr: left, List: list, Not: not, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseBetweenExpr parses: [NOT] BETWEEN low AND high
+func (p *Parser) parseBetweenExpr(left nodes.ExprNode, not bool, startLoc int) (nodes.ExprNode, error) {
+	p.advance() // consume BETWEEN
+	low, err := p.parseExpr(precComparison) // parse up to comparison level to avoid consuming AND
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(tokAND); err != nil {
+		return nil, err
+	}
+	high, err := p.parseExpr(precComparison)
+	if err != nil {
+		return nil, err
+	}
+	return &nodes.BetweenExpr{Expr: left, Low: low, High: high, Not: not, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseLikeExpr parses: [NOT] LIKE pattern [ESCAPE escape]
+func (p *Parser) parseLikeExpr(left nodes.ExprNode, not bool, startLoc int) (nodes.ExprNode, error) {
+	p.advance() // consume LIKE
+	pattern, err := p.parseExpr(precComparison)
+	if err != nil {
+		return nil, err
+	}
+
+	var escape nodes.ExprNode
+	if p.cur.Type == tokESCAPE {
+		p.advance()
+		escape, err = p.parseExpr(precComparison)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &nodes.LikeExpr{Expr: left, Pattern: pattern, Escape: escape, Not: not, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseExistsExpr parses: EXISTS(SELECT ...)
+func (p *Parser) parseExistsExpr() (nodes.ExprNode, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume EXISTS
+	if _, err := p.expect(tokLPAREN); err != nil {
+		return nil, err
+	}
+	sel, err := p.parseSelect()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(tokRPAREN); err != nil {
+		return nil, err
+	}
+	return &nodes.ExistsExpr{Select: sel, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseArrayExpr parses: ARRAY(SELECT ...)
+func (p *Parser) parseArrayExpr() (nodes.ExprNode, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume ARRAY
+	if _, err := p.expect(tokLPAREN); err != nil {
+		return nil, err
+	}
+	sel, err := p.parseSelect()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(tokRPAREN); err != nil {
+		return nil, err
+	}
+	return &nodes.ArrayExpr{Select: sel, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseParenExpr parses: '(' expr ')' or '(' SELECT ... ')'
+func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume (
+
+	if p.cur.Type == tokSELECT {
+		sel, err := p.parseSelect()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokRPAREN); err != nil {
+			return nil, err
+		}
+		return &nodes.SubLink{Select: sel, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+	}
+
+	expr, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(tokRPAREN); err != nil {
+		return nil, err
+	}
+	return expr, nil
+}
+
+// parseCreateArrayExpr parses: '[' [expr (',' expr)*] ']'
+func (p *Parser) parseCreateArrayExpr() (nodes.ExprNode, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume [
+
+	var elements []nodes.ExprNode
+	if p.cur.Type != tokRBRACK {
+		elem, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		elements = append(elements, elem)
+		for p.cur.Type == tokCOMMA {
+			p.advance()
+			elem, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			elements = append(elements, elem)
+		}
+	}
+
+	if _, err := p.expect(tokRBRACK); err != nil {
+		return nil, err
+	}
+
+	return &nodes.CreateArrayExpr{Elements: elements, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseCreateObjectExpr parses: '{' [field_pair (',' field_pair)*] '}'
+func (p *Parser) parseCreateObjectExpr() (nodes.ExprNode, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume {
+
+	var fields []*nodes.ObjectFieldPair
+	if p.cur.Type != tokRBRACE {
+		f, err := p.parseObjectFieldPair()
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, f)
+		for p.cur.Type == tokCOMMA {
+			p.advance()
+			f, err := p.parseObjectFieldPair()
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, f)
+		}
+	}
+
+	if _, err := p.expect(tokRBRACE); err != nil {
+		return nil, err
+	}
+
+	return &nodes.CreateObjectExpr{Fields: fields, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseObjectFieldPair parses: (string_literal | property_name) ':' scalar_expression
+func (p *Parser) parseObjectFieldPair() (*nodes.ObjectFieldPair, error) {
+	startLoc := p.cur.Loc
+	var key string
+
+	if p.cur.Type == tokSCONST || p.cur.Type == tokDCONST {
+		tok := p.advance()
+		key = tok.Str
+	} else {
+		name, _, err := p.parsePropertyName()
+		if err != nil {
+			return nil, err
+		}
+		key = name
+	}
+
+	if _, err := p.expect(tokCOLON); err != nil {
+		return nil, err
+	}
+
+	value, err := p.parseExpr(0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodes.ObjectFieldPair{Key: key, Value: value, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+
+// parseIdentExprOrFuncCall parses an identifier that could be:
+//   - a simple column reference
+//   - a function call: name(args)
+func (p *Parser) parseIdentExprOrFuncCall() (nodes.ExprNode, error) {
+	name, loc, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// Function call: name(...)
+	if p.cur.Type == tokLPAREN {
+		return p.parseFuncCall(name, loc)
+	}
+
+	return &nodes.ColumnRef{Name: name, Loc: nodes.Loc{Start: loc, End: loc + len(name)}}, nil
+}
+
+// locStart returns the start byte offset of an ExprNode.
+func locStart(expr nodes.ExprNode) int {
+	switch n := expr.(type) {
+	case *nodes.ColumnRef:
+		return n.Loc.Start
+	case *nodes.DotAccessExpr:
+		return n.Loc.Start
+	case *nodes.BracketAccessExpr:
+		return n.Loc.Start
+	case *nodes.BinaryExpr:
+		return n.Loc.Start
+	case *nodes.UnaryExpr:
+		return n.Loc.Start
+	case *nodes.TernaryExpr:
+		return n.Loc.Start
+	case *nodes.InExpr:
+		return n.Loc.Start
+	case *nodes.BetweenExpr:
+		return n.Loc.Start
+	case *nodes.LikeExpr:
+		return n.Loc.Start
+	case *nodes.FuncCall:
+		return n.Loc.Start
+	case *nodes.UDFCall:
+		return n.Loc.Start
+	case *nodes.ExistsExpr:
+		return n.Loc.Start
+	case *nodes.ArrayExpr:
+		return n.Loc.Start
+	case *nodes.CreateArrayExpr:
+		return n.Loc.Start
+	case *nodes.CreateObjectExpr:
+		return n.Loc.Start
+	case *nodes.ParamRef:
+		return n.Loc.Start
+	case *nodes.SubLink:
+		return n.Loc.Start
+	case *nodes.StringLit:
+		return n.Loc.Start
+	case *nodes.NumberLit:
+		return n.Loc.Start
+	case *nodes.BoolLit:
+		return n.Loc.Start
+	case *nodes.NullLit:
+		return n.Loc.Start
+	case *nodes.UndefinedLit:
+		return n.Loc.Start
+	case *nodes.InfinityLit:
+		return n.Loc.Start
+	case *nodes.NanLit:
+		return n.Loc.Start
+	default:
+		return -1
+	}
+}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && gofmt -e cosmosdb/parser/expr.go > /dev/null`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/expr.go
+git commit -m "feat(cosmosdb): add Pratt expression parser"
+```
+
+---
+
+### Task 9: Parser — Function Calls
+
+**Files:**
+- Create: `cosmosdb/parser/function.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/function.go`**
+
+```go
+package parser
+
+import (
+	nodes "github.com/bytebase/omni/cosmosdb/ast"
+)
+
+// parseFuncCall parses a built-in function call: name([*|args]).
+// name and loc have already been consumed by the caller.
+func (p *Parser) parseFuncCall(name string, startLoc int) (nodes.ExprNode, error) {
+	p.advance() // consume (
+
+	fc := &nodes.FuncCall{Name: name}
+
+	if p.cur.Type == tokSTAR {
+		p.advance()
+		fc.Star = true
+	} else if p.cur.Type != tokRPAREN {
+		arg, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		fc.Args = append(fc.Args, arg)
+		for p.cur.Type == tokCOMMA {
+			p.advance()
+			arg, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			fc.Args = append(fc.Args, arg)
+		}
+	}
+
+	if _, err := p.expect(tokRPAREN); err != nil {
+		return nil, err
+	}
+
+	fc.Loc = nodes.Loc{Start: startLoc, End: p.pos()}
+	return fc, nil
+}
+
+// parseUDFCall parses: UDF.name(args)
+func (p *Parser) parseUDFCall() (nodes.ExprNode, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume UDF
+
+	if _, err := p.expect(tokDOT); err != nil {
+		return nil, err
+	}
+
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(tokLPAREN); err != nil {
+		return nil, err
+	}
+
+	var args []nodes.ExprNode
+	if p.cur.Type != tokRPAREN {
+		arg, err := p.parseExpr(0)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+		for p.cur.Type == tokCOMMA {
+			p.advance()
+			arg, err := p.parseExpr(0)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, arg)
+		}
+	}
+
+	if _, err := p.expect(tokRPAREN); err != nil {
+		return nil, err
+	}
+
+	return &nodes.UDFCall{Name: name, Args: args, Loc: nodes.Loc{Start: startLoc, End: p.pos()}}, nil
+}
+```
+
+- [ ] **Step 2: Verify the entire parser package compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./cosmosdb/parser/`
+Expected: Clean build. All files compile together now.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/function.go
+git commit -m "feat(cosmosdb): add function call parsing"
+```
+
+---
+
+### Task 10: Public API
+
+**Files:**
+- Create: `cosmosdb/parse.go`
+
+- [ ] **Step 1: Create `cosmosdb/parse.go`**
+
+```go
+// Package cosmosdb provides a parser for Azure Cosmos DB NoSQL SQL API queries.
+package cosmosdb
+
+import (
+	"sort"
+
+	"github.com/bytebase/omni/cosmosdb/ast"
+	"github.com/bytebase/omni/cosmosdb/parser"
+)
+
+// Statement represents a single parsed SQL statement with its source location.
+type Statement struct {
+	Text      string   // original SQL text
+	AST       ast.Node // inner statement node (*ast.SelectStmt), nil for empty
+	ByteStart int      // inclusive start byte offset
+	ByteEnd   int      // exclusive end byte offset
+	Start     Position // start position (line:column, 1-based)
+	End       Position // end position (line:column, 1-based)
+}
+
+// Position represents a line:column position in source text.
+type Position struct {
+	Line   int // 1-based line number
+	Column int // 1-based column in bytes
+}
+
+// Empty returns true if this statement has no AST (e.g., whitespace-only).
+func (s Statement) Empty() bool {
+	return s.AST == nil
+}
+
+// Parse parses a CosmosDB SQL query and returns a list of statements.
+// CosmosDB SQL typically contains a single SELECT statement.
+func Parse(sql string) ([]Statement, error) {
+	list, err := parser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	if list.Len() == 0 {
+		return nil, nil
+	}
+
+	idx := buildLineIndex(sql)
+
+	var stmts []Statement
+	for _, item := range list.Items {
+		raw, ok := item.(*ast.RawStmt)
+		if !ok {
+			continue
+		}
+
+		byteStart := raw.StmtLocation
+		byteEnd := byteStart + raw.StmtLen
+
+		// Trim trailing whitespace.
+		for byteEnd > byteStart && isSpace(sql[byteEnd-1]) {
+			byteEnd--
+		}
+
+		stmts = append(stmts, Statement{
+			Text:      sql[byteStart:byteEnd],
+			AST:       raw.Stmt,
+			ByteStart: byteStart,
+			ByteEnd:   byteEnd,
+			Start:     offsetToPosition(idx, byteStart),
+			End:       offsetToPosition(idx, byteEnd),
+		})
+	}
+
+	return stmts, nil
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f'
+}
+
+// lineIndex stores byte offsets for the start of each line.
+type lineIndex []int
+
+func buildLineIndex(s string) lineIndex {
+	idx := lineIndex{0}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			idx = append(idx, i+1)
+		}
+	}
+	return idx
+}
+
+func offsetToPosition(idx lineIndex, offset int) Position {
+	line := sort.SearchInts(idx, offset+1)
+	col := offset - idx[line-1] + 1
+	return Position{Line: line, Column: col}
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./cosmosdb/`
+Expected: Clean build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parse.go
+git commit -m "feat(cosmosdb): add public Parse API"
+```
+
+---
+
+### Task 11: Add Test Data Files
+
+**Files:**
+- Create: `cosmosdb/parser/testdata/*.sql` (37 files from bytebase/parser/cosmosdb/examples/)
+
+- [ ] **Step 1: Create testdata directory and download all 37 example SQL files**
+
+Create each file in `cosmosdb/parser/testdata/`. The files are fetched from `https://raw.githubusercontent.com/bytebase/parser/main/cosmosdb/examples/`. Create all 37 files:
+
+```bash
+mkdir -p /Users/h3n4l/OpenSource/omni/cosmosdb/parser/testdata
+cd /Users/h3n4l/OpenSource/omni/cosmosdb/parser/testdata
+# Download all 37 example files.
+for f in \
+  simple_select.sql select_top.sql select_functions.sql \
+  from_root.sql from_subroot.sql from_subquery.sql from_in_iteration.sql \
+  where_expression.sql where_operators.sql between_expression.sql \
+  in_expression.sql not_equal.sql not_equal_diamond.sql \
+  math_functions.sql string_functions.sql type_check_functions.sql \
+  aggregation.sql group_by.sql order_by.sql offset_limit.sql \
+  distinct_value.sql join_subquery.sql array_subquery.sql \
+  fulltext_search.sql geospatial.sql like_escape.sql \
+  coalesce_operator.sql bracket_parameter.sql \
+  property_field_name_project.sql property_array_number_project.sql \
+  property_field_name_ls_bracket_project.sql line_comment.sql \
+  keyword_property_names.sql underscore_fields.sql infinity_nan.sql \
+  value_count.sql value_keyword.sql; do
+  curl -sL "https://raw.githubusercontent.com/bytebase/parser/main/cosmosdb/examples/$f" -o "$f"
+done
+```
+
+- [ ] **Step 2: Verify files were downloaded**
+
+Run: `ls /Users/h3n4l/OpenSource/omni/cosmosdb/parser/testdata/*.sql | wc -l`
+Expected: `37`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parser/testdata/
+git commit -m "feat(cosmosdb): add 37 example SQL test files"
+```
+
+---
+
+### Task 12: Parser Tests
+
+**Files:**
+- Create: `cosmosdb/parser/parser_test.go`
+
+- [ ] **Step 1: Create `cosmosdb/parser/parser_test.go`**
+
+```go
+package parser_test
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/cosmosdb/ast"
+	"github.com/bytebase/omni/cosmosdb/parser"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func TestParseExamples(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("testdata", "*.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no test SQL files found in testdata/")
+	}
+
+	goldenDir := filepath.Join("testdata", "golden")
+	if *update {
+		if err := os.MkdirAll(goldenDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, file := range files {
+		name := filepath.Base(file)
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sql := string(data)
+
+			list, err := parser.Parse(sql)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			got := ast.NodeToString(list)
+
+			goldenFile := filepath.Join(goldenDir, strings.TrimSuffix(name, ".sql")+".txt")
+
+			if *update {
+				if err := os.WriteFile(goldenFile, []byte(got+"\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+
+			want, err := os.ReadFile(goldenFile)
+			if err != nil {
+				t.Fatalf("Golden file not found: %s (run with -update to create)", goldenFile)
+			}
+
+			if got+"\n" != string(want) {
+				t.Errorf("AST output mismatch for %s.\nGot:\n%s\nWant:\n%s", name, got, string(want))
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Generate golden files**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go test ./cosmosdb/parser/ -run TestParseExamples -update -v`
+Expected: All 37 tests pass. Golden files created in `testdata/golden/`.
+
+- [ ] **Step 3: Run tests without -update to verify golden file matching**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go test ./cosmosdb/parser/ -run TestParseExamples -v`
+Expected: All 37 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cosmosdb/parser/parser_test.go cosmosdb/parser/testdata/golden/
+git commit -m "test(cosmosdb): add parser golden-file tests for all 37 examples"
+```
+
+---
+
+### Task 13: Public API Tests
+
+**Files:**
+- Create: `cosmosdb/parse_test.go`
+
+- [ ] **Step 1: Create `cosmosdb/parse_test.go`**
+
+```go
+package cosmosdb_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/cosmosdb"
+	"github.com/bytebase/omni/cosmosdb/ast"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+		check     func(t *testing.T, stmts []cosmosdb.Statement)
+	}{
+		{
+			name:      "simple select star",
+			sql:       "SELECT * FROM c",
+			wantCount: 1,
+			check: func(t *testing.T, stmts []cosmosdb.Statement) {
+				s := stmts[0]
+				if s.Text != "SELECT * FROM c" {
+					t.Errorf("Text = %q, want %q", s.Text, "SELECT * FROM c")
+				}
+				if _, ok := s.AST.(*ast.SelectStmt); !ok {
+					t.Errorf("AST type = %T, want *ast.SelectStmt", s.AST)
+				}
+				if s.ByteStart != 0 {
+					t.Errorf("ByteStart = %d, want 0", s.ByteStart)
+				}
+				if s.ByteEnd != 15 {
+					t.Errorf("ByteEnd = %d, want 15", s.ByteEnd)
+				}
+				if s.Start.Line != 1 || s.Start.Column != 1 {
+					t.Errorf("Start = %v, want {1 1}", s.Start)
+				}
+			},
+		},
+		{
+			name:      "multiline",
+			sql:       "SELECT\n  *\nFROM\n  c",
+			wantCount: 1,
+			check: func(t *testing.T, stmts []cosmosdb.Statement) {
+				s := stmts[0]
+				if s.Start.Line != 1 {
+					t.Errorf("Start.Line = %d, want 1", s.Start.Line)
+				}
+				if s.End.Line != 4 {
+					t.Errorf("End.Line = %d, want 4", s.End.Line)
+				}
+			},
+		},
+		{
+			name:      "with trailing whitespace",
+			sql:       "SELECT * FROM c   ",
+			wantCount: 1,
+			check: func(t *testing.T, stmts []cosmosdb.Statement) {
+				s := stmts[0]
+				if s.Text != "SELECT * FROM c" {
+					t.Errorf("Text = %q, want %q", s.Text, "SELECT * FROM c")
+				}
+				if s.ByteEnd != 15 {
+					t.Errorf("ByteEnd = %d, want 15", s.ByteEnd)
+				}
+			},
+		},
+		{
+			name:      "empty input",
+			sql:       "",
+			wantCount: 0,
+		},
+		{
+			name:      "whitespace only",
+			sql:       "   \n\t  ",
+			wantCount: 0,
+		},
+		{
+			name:      "select with value",
+			sql:       "SELECT VALUE c.name FROM c",
+			wantCount: 1,
+			check: func(t *testing.T, stmts []cosmosdb.Statement) {
+				sel := stmts[0].AST.(*ast.SelectStmt)
+				if !sel.Value {
+					t.Error("Value should be true")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmts, err := cosmosdb.Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+			if len(stmts) != tt.wantCount {
+				t.Fatalf("got %d statements, want %d", len(stmts), tt.wantCount)
+			}
+			if tt.check != nil {
+				tt.check(t, stmts)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go test ./cosmosdb/ -run TestParse -v`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cosmosdb/parse_test.go
+git commit -m "test(cosmosdb): add public API tests"
+```
+
+---
+
+### Task 14: Integration Verification
+
+- [ ] **Step 1: Run all CosmosDB tests together**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go test ./cosmosdb/... -v`
+Expected: All tests pass (parser golden tests + public API tests).
+
+- [ ] **Step 2: Run go vet on the new package**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go vet ./cosmosdb/...`
+Expected: No issues.
+
+- [ ] **Step 3: Verify no impact on existing engines**
+
+Run: `cd /Users/h3n4l/OpenSource/omni && go build ./...`
+Expected: Clean build for all packages.
+
+- [ ] **Step 4: Fix any issues found, then commit fixes if needed**
+
+If all clean, no commit needed for this task.

--- a/docs/superpowers/specs/2026-03-30-cosmosdb-engine-design.md
+++ b/docs/superpowers/specs/2026-03-30-cosmosdb-engine-design.md
@@ -1,0 +1,362 @@
+# CosmosDB Engine for Omni
+
+## Overview
+
+Add a `cosmosdb/` engine to the Omni SQL toolchain. Phase 1 delivers a pure-Go
+hand-written parser for Azure Cosmos DB's NoSQL SQL API, ported from the existing
+ANTLR4 grammar at `github.com/bytebase/parser/cosmosdb`. Phase 2 (future) adds
+query span / semantic analysis.
+
+CosmosDB's SQL API is SELECT-only (no DDL/DML — mutations go through the SDK),
+targeting a document store with JSON documents, containers, and partition keys.
+This makes the parser scope significantly smaller than PostgreSQL or MySQL.
+
+### Prior Work
+
+- **`github.com/bytebase/parser/cosmosdb`** — ANTLR4-based parser with complete
+  grammar (`CosmosDBLexer.g4`, `CosmosDBParser.g4`) and 37 example SQL files.
+  Covers SELECT with TOP/DISTINCT/VALUE, FROM with JOIN/iteration/subqueries,
+  WHERE, GROUP BY, HAVING, ORDER BY, OFFSET/LIMIT, all expression types, UDFs,
+  array/object construction, parameter references.
+- **`github.com/bytebase/bytebase`** — CosmosDB features including query span
+  (column-level data lineage analysis).
+
+### Design Decisions
+
+1. **Pure Go, zero runtime dependencies** — matches Omni convention. No ANTLR4
+   runtime. Hand-written recursive descent parser.
+2. **AST follows Omni conventions** — same Node/ExprNode/TableExpr/StmtNode
+   interfaces, Loc struct for position tracking, RawStmt wrapping.
+3. **Full grammar in one pass** — CosmosDB SQL is small enough (~31 AST node
+   types vs PostgreSQL's 210+) to port completely in Phase 1.
+4. **Public API matches PostgreSQL** — `Parse(sql) -> []Statement` with byte
+   offsets and line:column positions.
+5. **Test corpus from ANTLR4 repo** — 37 example SQL files from
+   `bytebase/parser/cosmosdb/examples/` used directly.
+
+---
+
+## Directory Structure
+
+```
+cosmosdb/
+├── parse.go                  # Public API: Parse(sql) -> []Statement
+├── parse_test.go             # Public API tests (positions, text slicing)
+├── ast/
+│   ├── node.go               # Interfaces (Node, ExprNode, TableExpr, StmtNode),
+│   │                         # Loc struct, literal nodes
+│   ├── parsenodes.go         # All CosmosDB-specific AST node types (~31 types)
+│   └── outfuncs.go           # Deterministic AST text dump for golden tests
+├── parser/
+│   ├── lexer.go              # Hand-written tokenizer
+│   ├── parser.go             # Entry point, helpers (advance/peek/match/expect)
+│   ├── select.go             # SELECT clause, ORDER BY, GROUP BY, HAVING, OFFSET/LIMIT
+│   ├── from.go               # FROM, JOIN, container expressions
+│   ├── expr.go               # Pratt parser for scalar expressions
+│   ├── function.go           # Built-in function calls + UDF calls
+│   ├── parser_test.go        # Tests using 37 example files
+│   └── testdata/             # Example SQL files + golden AST output
+│       ├── *.sql             # Ported from bytebase/parser/cosmosdb/examples/
+│       └── golden/
+│           └── *.txt         # Expected AST text output
+```
+
+---
+
+## Public API
+
+File: `cosmosdb/parse.go`
+
+```go
+package cosmosdb
+
+type Statement struct {
+    Text      string       // original SQL text
+    AST       ast.Node     // inner statement node (*ast.SelectStmt)
+    ByteStart int          // inclusive start byte offset
+    ByteEnd   int          // exclusive end byte offset
+    Start     Position     // start line:column (1-based)
+    End       Position     // end line:column (1-based)
+}
+
+type Position struct {
+    Line   int  // 1-based line number
+    Column int  // 1-based column in bytes
+}
+
+func Parse(sql string) ([]Statement, error)
+```
+
+CosmosDB SQL is always a single SELECT statement, so `Parse` typically returns
+one `Statement`. The slice return type maintains consistency with the Omni
+pattern.
+
+---
+
+## AST Node Types
+
+### Core Interfaces
+
+File: `cosmosdb/ast/node.go`
+
+```go
+type Node interface { nodeTag() }
+type ExprNode interface { Node; exprNode() }
+type TableExpr interface { Node; tableExpr() }
+type StmtNode interface { Node; stmtNode() }
+
+type Loc struct {
+    Start int  // inclusive byte offset, -1 = unknown
+    End   int  // exclusive byte offset, -1 = unknown
+}
+```
+
+### Literal Nodes
+
+Defined in `ast/node.go`, all implement `ExprNode`:
+
+| Node | Fields | Grammar rule |
+|------|--------|-------------|
+| `StringLit` | Val string, Loc | `string_constant` |
+| `NumberLit` | Val string, Loc | `decimal_literal`, `hexadecimal_literal` |
+| `BoolLit` | Val bool, Loc | `boolean_constant` |
+| `NullLit` | Loc | `null_constant` |
+| `UndefinedLit` | Loc | `undefined_constant` |
+| `InfinityLit` | Loc | `INFINITY_SYMBOL` |
+| `NanLit` | Loc | `NAN_SYMBOL` |
+| `List` | Items []Node | Generic list container |
+
+`NumberLit.Val` stores the raw text to preserve the original representation
+(integer, float, hex, scientific notation).
+
+### Statement & Clause Nodes
+
+File: `cosmosdb/ast/parsenodes.go`
+
+| Node | Key Fields | Grammar rule |
+|------|-----------|-------------|
+| `RawStmt` | Stmt StmtNode, StmtLocation int, StmtLen int | Omni convention wrapper |
+| `SelectStmt` | Top *int, Distinct bool, Value bool, Star bool, Targets []*TargetEntry, From TableExpr, Joins []*JoinExpr, Where ExprNode, GroupBy []ExprNode, Having ExprNode, OrderBy []*SortExpr, OffsetLimit *OffsetLimitClause, Loc | `select` |
+| `TargetEntry` | Expr ExprNode, Alias *string, Loc | `object_property` |
+| `SortExpr` | Expr ExprNode, Desc bool, Rank bool, Loc | `sort_expression` |
+| `OffsetLimitClause` | Offset ExprNode, Limit ExprNode, Loc | `offset_limit_clause` |
+| `JoinExpr` | Source TableExpr, Loc | `join_clause` |
+
+### Table Expression Nodes
+
+Implement `TableExpr`. `DotAccessExpr` and `BracketAccessExpr` implement both
+`TableExpr` and `ExprNode` since they appear in both FROM and expression
+contexts.
+
+| Node | Key Fields | Grammar rule |
+|------|-----------|-------------|
+| `ContainerRef` | Name string, Root bool, Loc | `container_name`, `ROOT` |
+| `AliasedTableExpr` | Source TableExpr, Alias string, Loc | `from_source` alt1 |
+| `ArrayIterationExpr` | Alias string, Source TableExpr, Loc | `from_source` alt2 (`ident IN expr`) |
+| `SubqueryExpr` | Select *SelectStmt, Loc | `container_expression` alt5 |
+
+### Expression Nodes
+
+All implement `ExprNode`:
+
+| Node | Key Fields | Grammar rule |
+|------|-----------|-------------|
+| `ColumnRef` | Name string, Loc | `input_alias` |
+| `DotAccessExpr` | Expr ExprNode, Property string, Loc | `scalar_expression` alt11, `container_expression` alt3 |
+| `BracketAccessExpr` | Expr ExprNode, Index ExprNode, Loc | `scalar_expression` alt12, `container_expression` alt4 |
+| `BinaryExpr` | Op string, Left ExprNode, Right ExprNode, Loc | alts 15-22, 26-28 |
+| `UnaryExpr` | Op string, Operand ExprNode, Loc | alts 13-14 |
+| `TernaryExpr` | Cond ExprNode, Then ExprNode, Else ExprNode, Loc | alt29 (`? :`) |
+| `InExpr` | Expr ExprNode, List []ExprNode, Not bool, Loc | alt23 |
+| `BetweenExpr` | Expr ExprNode, Low ExprNode, High ExprNode, Not bool, Loc | alt24 |
+| `LikeExpr` | Expr ExprNode, Pattern ExprNode, Escape ExprNode, Not bool, Loc | alt25 |
+| `FuncCall` | Name string, Args []ExprNode, Star bool, Loc | `builtin_function_expression` |
+| `UDFCall` | Name string, Args []ExprNode, Loc | `udf_scalar_function_expression` |
+| `ExistsExpr` | Select *SelectStmt, Loc | alt9 |
+| `ArrayExpr` | Select *SelectStmt, Loc | alt10 (`ARRAY(SELECT ...)`) |
+| `CreateArrayExpr` | Elements []ExprNode, Loc | `create_array_expression` |
+| `CreateObjectExpr` | Fields []*ObjectFieldPair, Loc | `create_object_expression` |
+| `ObjectFieldPair` | Key string, Value ExprNode, Loc | `object_field_pair` |
+| `ParamRef` | Name string, Loc | `parameter_name` (`@param`) |
+| `SubLink` | Select *SelectStmt, Loc | alt8 (`(SELECT ...)` in expr position) |
+
+**Total: ~31 node types.**
+
+---
+
+## Lexer
+
+File: `cosmosdb/parser/lexer.go`
+
+```go
+type Token struct {
+    Type int
+    Str  string
+    Loc  int    // byte offset in source
+}
+
+type Lexer struct {
+    input string
+    pos   int    // current read position in input (next byte to consume)
+    start int    // start position of the token currently being scanned
+    Err   error
+}
+
+func NewLexer(input string) *Lexer
+func (l *Lexer) NextToken() Token
+```
+
+### Token Types
+
+**Literals and identifiers (iota + 1000):**
+`tokICONST` (integer), `tokFCONST` (float), `tokHCONST` (hex),
+`tokSCONST` (single-quoted string), `tokDCONST` (double-quoted string),
+`tokIDENT` (identifier), `tokPARAM` (`@param`).
+
+**Operators and punctuation:**
+`tokDOT`, `tokCOMMA`, `tokCOLON`, `tokLPAREN`, `tokRPAREN`, `tokLBRACK`,
+`tokRBRACK`, `tokLBRACE`, `tokRBRACE`, `tokSTAR`, `tokPLUS`, `tokMINUS`,
+`tokDIV`, `tokMOD`, `tokEQ`, `tokNE` (`!=`), `tokNE2` (`<>`), `tokLT`,
+`tokLE`, `tokGT`, `tokGE`, `tokBITAND`, `tokBITOR`, `tokBITXOR`,
+`tokBITNOT`, `tokLSHIFT`, `tokRSHIFT`, `tokURSHIFT` (`>>>`),
+`tokCONCAT` (`||`), `tokCOALESCE` (`??`), `tokQUESTION` (`?`).
+
+**Keywords (28, case-insensitive):**
+`tokSELECT`, `tokFROM`, `tokWHERE`, `tokAND`, `tokOR`, `tokNOT`, `tokIN`,
+`tokBETWEEN`, `tokLIKE`, `tokESCAPE`, `tokAS`, `tokJOIN`, `tokTOP`,
+`tokDISTINCT`, `tokVALUE`, `tokORDER`, `tokBY`, `tokGROUP`, `tokHAVING`,
+`tokOFFSET`, `tokLIMIT`, `tokASC`, `tokDESC`, `tokEXISTS`, `tokTRUE`,
+`tokFALSE`, `tokNULL`, `tokUNDEFINED`, `tokUDF`, `tokARRAY`, `tokROOT`,
+`tokRANK`.
+
+### Special Cases
+
+- **Case-insensitive keywords**: Identifiers are lowercased before keyword
+  lookup. Keywords always emit keyword tokens; the parser accepts them in
+  identifier positions.
+- **Case-sensitive `Infinity` and `NaN`**: Matched before lowercasing. Emitted
+  as distinct `tokINFINITY` and `tokNAN` token types.
+- **Line comments**: `--` skips to EOL.
+- **String escapes**: `\b`, `\t`, `\n`, `\r`, `\f`, `\"`, `\'`, `\\`, `\/`,
+  `\uXXXX`.
+- **Multi-character operators**: `??`, `||`, `!=`, `<>`, `<=`, `>=`, `<<`,
+  `>>`, `>>>` — resolved by longest-match lookahead.
+
+---
+
+## Parser
+
+### Structure
+
+```go
+type Parser struct {
+    lexer   *Lexer
+    cur     Token    // current token (already consumed)
+    prev    Token    // previous token (for error context)
+    nextBuf Token    // buffered lookahead token
+    hasNext bool     // whether nextBuf is valid
+}
+
+func Parse(sql string) (*ast.List, error)
+```
+
+### File Responsibilities
+
+| File | Functions |
+|------|-----------|
+| `parser.go` | `Parse()`, `advance()`, `peek()`, `peekNext()`, `match()`, `expect()`, `parseIdentifier()`, `parsePropertyName()`, top-level `parseSelect()` |
+| `select.go` | `parseSelectClause()`, `parseTargetEntry()`, `parseGroupBy()`, `parseHaving()`, `parseOrderBy()`, `parseSortExpr()`, `parseOffsetLimit()` |
+| `from.go` | `parseFromClause()`, `parseFromSource()`, `parseContainerExpr()`, `parseJoinClause()` |
+| `expr.go` | `parseExpr(precedence)`, prefix parsers (constants, identifiers, unary ops, parenthesized exprs, subqueries, EXISTS, ARRAY, object/array literals, params), infix parsers (binary ops, dot access, bracket access, IN, BETWEEN, LIKE, ternary) |
+| `function.go` | `parseFuncCall()`, `parseUDFCall()` |
+
+### Expression Precedence (Pratt Parser)
+
+From lowest to highest binding power:
+
+| Level | Operators | Associativity |
+|-------|-----------|---------------|
+| 1 | `? :` (ternary) | right |
+| 2 | `??` (coalesce) | left |
+| 3 | `OR` | left |
+| 4 | `AND` | left |
+| 5 | `NOT IN`, `NOT BETWEEN`, `NOT LIKE`, `IN`, `BETWEEN`, `LIKE` | non-assoc |
+| 6 | `=`, `!=`, `<>`, `<`, `<=`, `>`, `>=` | left |
+| 7 | `\|\|` (string concat) | left |
+| 8 | `\|` (bitwise OR) | left |
+| 9 | `^` (bitwise XOR) | left |
+| 10 | `&` (bitwise AND) | left |
+| 11 | `<<`, `>>`, `>>>` (shift) | left |
+| 12 | `+`, `-` (additive) | left |
+| 13 | `*`, `/`, `%` (multiplicative) | left |
+| 14 | `NOT`, `~`, unary `+`, unary `-` (prefix) | prefix |
+| 15 | `.`, `[]` (property access) | left |
+
+### Keyword-as-Identifier Handling
+
+Two helper functions handle the grammar's context-sensitive identifier rules:
+
+- `parseIdentifier()` — accepts `tokIDENT` plus 20 keywords that are valid as
+  identifiers: `IN`, `BETWEEN`, `TOP`, `VALUE`, `ORDER`, `BY`, `GROUP`,
+  `OFFSET`, `LIMIT`, `ASC`, `DESC`, `EXISTS`, `LIKE`, `HAVING`, `JOIN`,
+  `ESCAPE`, `ARRAY`, `ROOT`, `RANK`.
+- `parsePropertyName()` — accepts everything `parseIdentifier()` does, plus 18
+  additional keywords: `SELECT`, `FROM`, `WHERE`, `NOT`, `AND`, `OR`, `AS`,
+  `TRUE`, `FALSE`, `NULL`, `UNDEFINED`, `UDF`, `DISTINCT`, `ARRAY`, `ROOT`,
+  `ESCAPE`, `RANK`.
+
+---
+
+## Test Strategy
+
+### Test Corpus
+
+The 37 example SQL files from `github.com/bytebase/parser/cosmosdb/examples/`
+are fetched and placed in `cosmosdb/parser/testdata/`. These cover:
+
+- Basic SELECT, SELECT TOP, SELECT DISTINCT, SELECT VALUE
+- FROM with container reference, ROOT, subquery, IN iteration
+- JOIN on array properties
+- WHERE with all operator types (comparison, logical, BETWEEN, IN, LIKE, ESCAPE)
+- GROUP BY, HAVING, ORDER BY with ASC/DESC, OFFSET/LIMIT
+- Built-in functions (string, math, type-check, geospatial, aggregate)
+- UDF calls
+- Array and object construction
+- Special constants: Infinity, NaN, undefined, null
+- Coalesce (`??`), ternary (`? :`)
+- Parameter references (`@param`)
+- Keywords as property names and identifiers
+- Bracket access and dot access on nested documents
+- Line comments
+
+### Test Approach
+
+`parser_test.go` implements:
+
+1. Parse each `.sql` file from `testdata/`
+2. Produce deterministic text output via `ast/outfuncs.go`
+3. Compare against golden files in `testdata/golden/`
+4. Update golden files with a `-update` flag for initial generation
+
+`parse_test.go` tests the public API:
+
+1. Verify `Statement.Text`, `ByteStart`, `ByteEnd`, `Start`, `End` positions
+2. Verify round-trip: `statement.Text` can be re-parsed to produce identical AST
+
+No oracle testing against a real CosmosDB instance in Phase 1.
+
+---
+
+## Phase 2 (Future): Semantic Analysis
+
+Not in scope for Phase 1, but the intended direction:
+
+- **Query span / column lineage**: Track output properties back to source
+  container document paths through JOINs, subqueries, array iteration, UDFs.
+- **Lightweight catalog**: Model containers, partition keys, indexing policies.
+  No fixed schema (CosmosDB is schemaless), but container metadata is useful
+  for validation.
+- **Type inference**: CosmosDB expressions have runtime types (string, number,
+  boolean, null, undefined, array, object). Static inference where possible.
+- **Built-in function registry**: Validate function names and argument counts
+  for CosmosDB's ~100 built-in scalar functions.

--- a/mongo/ast/nodes.go
+++ b/mongo/ast/nodes.go
@@ -18,8 +18,8 @@ type Node interface {
 
 // ShowCommand represents show dbs, show collections, show profile, etc.
 type ShowCommand struct {
-	Command string // e.g. "dbs", "collections", "profile"
-	Loc     Loc
+	Target string // e.g. "dbs", "collections", "profile"
+	Loc    Loc
 }
 
 func (n *ShowCommand) GetLoc() Loc { return n.Loc }
@@ -27,85 +27,92 @@ func (n *ShowCommand) GetLoc() Loc { return n.Loc }
 // CollectionStatement represents db.collection.method().cursor()...
 // This is the most complex and common statement type.
 type CollectionStatement struct {
-	Database       string         // explicit db name or "" for implicit
-	Collection     string         // collection name
-	Method         *MethodCall    // primary method (find, insert, etc.)
-	CursorMethods  []CursorMethod // chained cursor modifiers (.sort, .limit, etc.)
-	Loc            Loc
+	Collection    string         // collection name
+	CollectionLoc Loc            // location of the collection name token
+	AccessMethod  string         // how the collection was accessed: "dot" or "getCollection"
+	Method        string         // primary method name (find, insert, etc.)
+	Args          []Node         // arguments to the primary method
+	CursorMethods []CursorMethod // chained cursor modifiers (.sort, .limit, etc.)
+	Explain       bool           // whether .explain() wraps the statement
+	ExplainArgs   []Node         // arguments to explain()
+	Loc           Loc
 }
 
 func (n *CollectionStatement) GetLoc() Loc { return n.Loc }
 
 // DatabaseStatement represents db.method() calls (e.g. db.getCollectionNames()).
 type DatabaseStatement struct {
-	Database string      // explicit db name or "" for implicit
-	Method   *MethodCall // method call
-	Loc      Loc
+	Method string // method name
+	Args   []Node // arguments
+	Loc    Loc
 }
 
 func (n *DatabaseStatement) GetLoc() Loc { return n.Loc }
 
 // BulkStatement represents db.collection.initializeOrderedBulkOp()/initializeUnorderedBulkOp() chains.
 type BulkStatement struct {
-	Database   string          // explicit db name or "" for implicit
-	Collection string          // collection name
-	Ordered    bool            // true for initializeOrderedBulkOp
-	Operations []BulkOperation // chained operations
-	Execute    bool            // whether .execute() was called
-	Loc        Loc
+	Collection   string          // collection name
+	AccessMethod string          // how the collection was accessed: "dot" or "getCollection"
+	Ordered      bool            // true for initializeOrderedBulkOp
+	Operations   []BulkOperation // chained operations
+	Loc          Loc
 }
 
 func (n *BulkStatement) GetLoc() Loc { return n.Loc }
 
 // ConnectionStatement represents Mongo(), connect(), db.getMongo() chains.
 type ConnectionStatement struct {
-	Method *MethodCall   // the connection method
-	Chain  []*MethodCall // chained methods
-	Loc    Loc
+	Constructor    string       // "Mongo", "connect", or "db.getMongo"
+	Args           []Node       // arguments to the constructor
+	ChainedMethods []MethodCall // chained methods
+	Loc            Loc
 }
 
 func (n *ConnectionStatement) GetLoc() Loc { return n.Loc }
 
 // RsStatement represents rs.method() calls (replica set).
 type RsStatement struct {
-	Method *MethodCall // method call
-	Loc    Loc
+	MethodName string // method name
+	Args       []Node // arguments
+	Loc        Loc
 }
 
 func (n *RsStatement) GetLoc() Loc { return n.Loc }
 
 // ShStatement represents sh.method() calls (sharding).
 type ShStatement struct {
-	Method *MethodCall // method call
-	Loc    Loc
+	MethodName string // method name
+	Args       []Node // arguments
+	Loc        Loc
 }
 
 func (n *ShStatement) GetLoc() Loc { return n.Loc }
 
 // EncryptionStatement represents db.getMongo().getKeyVault()/getClientEncryption() chains.
 type EncryptionStatement struct {
-	Database string        // explicit db name or "" for implicit
-	Chain    []*MethodCall // method chain
-	Loc      Loc
+	Target         string       // "keyVault" or "clientEncryption"
+	ChainedMethods []MethodCall // method chain after getKeyVault()/getClientEncryption()
+	Loc            Loc
 }
 
 func (n *EncryptionStatement) GetLoc() Loc { return n.Loc }
 
 // PlanCacheStatement represents db.collection.getPlanCache() chains.
 type PlanCacheStatement struct {
-	Database   string      // explicit db name or "" for implicit
-	Collection string      // collection name
-	Method     *MethodCall // plan cache method (clear, list, etc.)
-	Loc        Loc
+	Collection     string       // collection name
+	AccessMethod   string       // how the collection was accessed: "dot" or "getCollection"
+	ChainedMethods []MethodCall // plan cache method chain (clear, list, etc.)
+	Loc            Loc
 }
 
 func (n *PlanCacheStatement) GetLoc() Loc { return n.Loc }
 
 // SpStatement represents sp.method() or sp.x.method() calls (query planner).
 type SpStatement struct {
-	Namespace string      // sub-namespace (e.g. "x" in sp.x.method())
-	Method    *MethodCall // method call
-	Loc       Loc
+	MethodName string // method name
+	SubMethod  string // sub-method (e.g. "x" in sp.x.method())
+	Args       []Node // arguments
+	Loc        Loc
 }
 
 func (n *SpStatement) GetLoc() Loc { return n.Loc }
@@ -125,9 +132,9 @@ func (n *NativeFunctionCall) GetLoc() Loc { return n.Loc }
 
 // CursorMethod represents a chained cursor modifier like .sort({x:1}).
 type CursorMethod struct {
-	Name string // method name (sort, limit, skip, etc.)
-	Args []Node // arguments
-	Loc  Loc
+	Method string // method name (sort, limit, skip, etc.)
+	Args   []Node // arguments
+	Loc    Loc
 }
 
 // MethodCall represents a method call with name and arguments.
@@ -141,9 +148,9 @@ func (n *MethodCall) GetLoc() Loc { return n.Loc }
 
 // BulkOperation represents a single operation in a bulk chain.
 type BulkOperation struct {
-	Name string // operation name (insert, find, update, etc.)
-	Args []Node // arguments
-	Loc  Loc
+	Method string // operation name (insert, find, update, etc.)
+	Args   []Node // arguments
+	Loc    Loc
 }
 
 // ---------------------------------------------------------------------------
@@ -163,10 +170,7 @@ type KeyValue struct {
 	Key    string // field name
 	KeyLoc Loc    // location of the key
 	Value  Node   // value expression
-	Loc    Loc
 }
-
-func (n *KeyValue) GetLoc() Loc { return n.Loc }
 
 // Array represents a JSON/BSON array literal [ ... ].
 type Array struct {
@@ -186,8 +190,9 @@ func (n *StringLiteral) GetLoc() Loc { return n.Loc }
 
 // NumberLiteral represents a numeric value (integer or float).
 type NumberLiteral struct {
-	Value string // raw text of the number
-	Loc   Loc
+	Value   string // raw text of the number
+	IsFloat bool   // true if the number contains a decimal point or exponent
+	Loc     Loc
 }
 
 func (n *NumberLiteral) GetLoc() Loc { return n.Loc }

--- a/mongo/ast/nodes.go
+++ b/mongo/ast/nodes.go
@@ -1,0 +1,234 @@
+// Package ast defines MongoDB (mongosh) parse tree node types.
+package ast
+
+// Loc represents a source location range (byte offsets).
+type Loc struct {
+	Start int // inclusive start byte offset
+	End   int // exclusive end byte offset
+}
+
+// Node is the interface implemented by all mongosh parse tree nodes.
+type Node interface {
+	GetLoc() Loc
+}
+
+// ---------------------------------------------------------------------------
+// Statement nodes — one per mongosh command family
+// ---------------------------------------------------------------------------
+
+// ShowCommand represents show dbs, show collections, show profile, etc.
+type ShowCommand struct {
+	Command string // e.g. "dbs", "collections", "profile"
+	Loc     Loc
+}
+
+func (n *ShowCommand) GetLoc() Loc { return n.Loc }
+
+// CollectionStatement represents db.collection.method().cursor()...
+// This is the most complex and common statement type.
+type CollectionStatement struct {
+	Database       string         // explicit db name or "" for implicit
+	Collection     string         // collection name
+	Method         *MethodCall    // primary method (find, insert, etc.)
+	CursorMethods  []CursorMethod // chained cursor modifiers (.sort, .limit, etc.)
+	Loc            Loc
+}
+
+func (n *CollectionStatement) GetLoc() Loc { return n.Loc }
+
+// DatabaseStatement represents db.method() calls (e.g. db.getCollectionNames()).
+type DatabaseStatement struct {
+	Database string      // explicit db name or "" for implicit
+	Method   *MethodCall // method call
+	Loc      Loc
+}
+
+func (n *DatabaseStatement) GetLoc() Loc { return n.Loc }
+
+// BulkStatement represents db.collection.initializeOrderedBulkOp()/initializeUnorderedBulkOp() chains.
+type BulkStatement struct {
+	Database   string          // explicit db name or "" for implicit
+	Collection string          // collection name
+	Ordered    bool            // true for initializeOrderedBulkOp
+	Operations []BulkOperation // chained operations
+	Execute    bool            // whether .execute() was called
+	Loc        Loc
+}
+
+func (n *BulkStatement) GetLoc() Loc { return n.Loc }
+
+// ConnectionStatement represents Mongo(), connect(), db.getMongo() chains.
+type ConnectionStatement struct {
+	Method *MethodCall   // the connection method
+	Chain  []*MethodCall // chained methods
+	Loc    Loc
+}
+
+func (n *ConnectionStatement) GetLoc() Loc { return n.Loc }
+
+// RsStatement represents rs.method() calls (replica set).
+type RsStatement struct {
+	Method *MethodCall // method call
+	Loc    Loc
+}
+
+func (n *RsStatement) GetLoc() Loc { return n.Loc }
+
+// ShStatement represents sh.method() calls (sharding).
+type ShStatement struct {
+	Method *MethodCall // method call
+	Loc    Loc
+}
+
+func (n *ShStatement) GetLoc() Loc { return n.Loc }
+
+// EncryptionStatement represents db.getMongo().getKeyVault()/getClientEncryption() chains.
+type EncryptionStatement struct {
+	Database string        // explicit db name or "" for implicit
+	Chain    []*MethodCall // method chain
+	Loc      Loc
+}
+
+func (n *EncryptionStatement) GetLoc() Loc { return n.Loc }
+
+// PlanCacheStatement represents db.collection.getPlanCache() chains.
+type PlanCacheStatement struct {
+	Database   string      // explicit db name or "" for implicit
+	Collection string      // collection name
+	Method     *MethodCall // plan cache method (clear, list, etc.)
+	Loc        Loc
+}
+
+func (n *PlanCacheStatement) GetLoc() Loc { return n.Loc }
+
+// SpStatement represents sp.method() or sp.x.method() calls (query planner).
+type SpStatement struct {
+	Namespace string      // sub-namespace (e.g. "x" in sp.x.method())
+	Method    *MethodCall // method call
+	Loc       Loc
+}
+
+func (n *SpStatement) GetLoc() Loc { return n.Loc }
+
+// NativeFunctionCall represents top-level mongosh functions: sleep(), load(), etc.
+type NativeFunctionCall struct {
+	Name string // function name
+	Args []Node // arguments
+	Loc  Loc
+}
+
+func (n *NativeFunctionCall) GetLoc() Loc { return n.Loc }
+
+// ---------------------------------------------------------------------------
+// Supporting types
+// ---------------------------------------------------------------------------
+
+// CursorMethod represents a chained cursor modifier like .sort({x:1}).
+type CursorMethod struct {
+	Name string // method name (sort, limit, skip, etc.)
+	Args []Node // arguments
+	Loc  Loc
+}
+
+// MethodCall represents a method call with name and arguments.
+type MethodCall struct {
+	Name string // method name
+	Args []Node // arguments
+	Loc  Loc
+}
+
+func (n *MethodCall) GetLoc() Loc { return n.Loc }
+
+// BulkOperation represents a single operation in a bulk chain.
+type BulkOperation struct {
+	Name string // operation name (insert, find, update, etc.)
+	Args []Node // arguments
+	Loc  Loc
+}
+
+// ---------------------------------------------------------------------------
+// Value / Expression nodes
+// ---------------------------------------------------------------------------
+
+// Document represents a JSON/BSON document literal { key: value, ... }.
+type Document struct {
+	Pairs []KeyValue
+	Loc   Loc
+}
+
+func (n *Document) GetLoc() Loc { return n.Loc }
+
+// KeyValue represents a single key-value pair in a document.
+type KeyValue struct {
+	Key    string // field name
+	KeyLoc Loc    // location of the key
+	Value  Node   // value expression
+	Loc    Loc
+}
+
+func (n *KeyValue) GetLoc() Loc { return n.Loc }
+
+// Array represents a JSON/BSON array literal [ ... ].
+type Array struct {
+	Elements []Node
+	Loc      Loc
+}
+
+func (n *Array) GetLoc() Loc { return n.Loc }
+
+// StringLiteral represents a quoted string value.
+type StringLiteral struct {
+	Value string // the unescaped string content
+	Loc   Loc
+}
+
+func (n *StringLiteral) GetLoc() Loc { return n.Loc }
+
+// NumberLiteral represents a numeric value (integer or float).
+type NumberLiteral struct {
+	Value string // raw text of the number
+	Loc   Loc
+}
+
+func (n *NumberLiteral) GetLoc() Loc { return n.Loc }
+
+// BoolLiteral represents true or false.
+type BoolLiteral struct {
+	Value bool
+	Loc   Loc
+}
+
+func (n *BoolLiteral) GetLoc() Loc { return n.Loc }
+
+// NullLiteral represents null.
+type NullLiteral struct {
+	Loc Loc
+}
+
+func (n *NullLiteral) GetLoc() Loc { return n.Loc }
+
+// RegexLiteral represents a /pattern/flags regular expression.
+type RegexLiteral struct {
+	Pattern string
+	Flags   string
+	Loc     Loc
+}
+
+func (n *RegexLiteral) GetLoc() Loc { return n.Loc }
+
+// HelperCall represents a BSON helper like ObjectId("..."), NumberLong(1), etc.
+type HelperCall struct {
+	Name string // helper name (ObjectId, NumberLong, etc.)
+	Args []Node // arguments
+	Loc  Loc
+}
+
+func (n *HelperCall) GetLoc() Loc { return n.Loc }
+
+// Identifier represents an unquoted identifier or variable reference.
+type Identifier struct {
+	Name string
+	Loc  Loc
+}
+
+func (n *Identifier) GetLoc() Loc { return n.Loc }

--- a/mongo/parse.go
+++ b/mongo/parse.go
@@ -1,0 +1,113 @@
+// Package mongo provides a parser for MongoDB shell (mongosh) commands.
+package mongo
+
+import (
+	"github.com/bytebase/omni/mongo/ast"
+	"github.com/bytebase/omni/mongo/parser"
+)
+
+// Statement is the result of parsing a single mongosh command.
+type Statement struct {
+	// Text is the command text including trailing semicolon if present.
+	Text string
+	// AST is the parsed statement node. Nil for empty statements.
+	AST ast.Node
+
+	// ByteStart is the inclusive start byte offset in the original input.
+	ByteStart int
+	// ByteEnd is the exclusive end byte offset in the original input.
+	ByteEnd int
+
+	// Start is the start position (line:column) in the original input.
+	Start Position
+	// End is the exclusive end position (line:column) in the original input.
+	End Position
+}
+
+// Position represents a location in source text.
+type Position struct {
+	// Line is 1-based line number.
+	Line int
+	// Column is 1-based column in bytes.
+	Column int
+}
+
+// Empty returns true if this statement has no meaningful content.
+func (s *Statement) Empty() bool {
+	return s.AST == nil
+}
+
+// Parse splits and parses a mongosh input string into statements.
+// Each statement includes the text, AST, and byte/line positions.
+func Parse(input string) ([]Statement, error) {
+	nodes, err := parser.Parse(input)
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+
+	lineIndex := buildLineIndex(input)
+
+	var stmts []Statement
+	for _, node := range nodes {
+		loc := node.GetLoc()
+
+		// Determine text boundaries — expand to include trailing semicolons/whitespace
+		start := loc.Start
+		end := loc.End
+		// Scan past trailing whitespace to find semicolon
+		j := end
+		for j < len(input) && isSpace(input[j]) {
+			j++
+		}
+		if j < len(input) && input[j] == ';' {
+			end = j + 1
+		}
+
+		stmts = append(stmts, Statement{
+			Text:      input[start:end],
+			AST:       node,
+			ByteStart: start,
+			ByteEnd:   end,
+			Start:     offsetToPosition(lineIndex, start),
+			End:       offsetToPosition(lineIndex, end),
+		})
+	}
+	return stmts, nil
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// lineIndex stores the byte offset of each line start.
+type lineIndex []int
+
+func buildLineIndex(s string) lineIndex {
+	idx := lineIndex{0}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			idx = append(idx, i+1)
+		}
+	}
+	return idx
+}
+
+func offsetToPosition(idx lineIndex, offset int) Position {
+	// Binary search for the line containing offset.
+	lo, hi := 0, len(idx)-1
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if idx[mid] <= offset {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return Position{
+		Line:   lo + 1,              // 1-based
+		Column: offset - idx[lo] + 1, // 1-based
+	}
+}

--- a/mongo/parser/bulk.go
+++ b/mongo/parser/bulk.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseBulkStatement parses db.collection.initializeOrderedBulkOp()/initializeUnorderedBulkOp() chains.
+func (p *Parser) parseBulkStatement(database, collection string, ordered bool, startLoc int) (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/bulk.go
+++ b/mongo/parser/bulk.go
@@ -3,6 +3,6 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseBulkStatement parses db.collection.initializeOrderedBulkOp()/initializeUnorderedBulkOp() chains.
-func (p *Parser) parseBulkStatement(database, collection string, ordered bool, startLoc int) (ast.Node, error) {
+func (p *Parser) parseBulkStatement(collName string, collLoc ast.Loc, accessMethod string, stmtStart int) (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/bulk.go
+++ b/mongo/parser/bulk.go
@@ -3,6 +3,48 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseBulkStatement parses db.collection.initializeOrderedBulkOp()/initializeUnorderedBulkOp() chains.
+// Already called with collName, collLoc, accessMethod, stmtStart determined.
+// Current token is kwInitializeOrderedBulkOp or kwInitializeUnorderedBulkOp.
 func (p *Parser) parseBulkStatement(collName string, collLoc ast.Loc, accessMethod string, stmtStart int) (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	ordered := p.cur.Type == kwInitializeOrderedBulkOp
+	p.advance() // consume initializeOrderedBulkOp / initializeUnorderedBulkOp
+
+	// Expect ()
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	// Parse operation chain: .method(args)...
+	var ops []ast.BulkOperation
+	for p.cur.Type == '.' {
+		p.advance() // consume '.'
+
+		opName, opTok, err := p.expectIdent()
+		if err != nil {
+			return nil, err
+		}
+		opStart := opTok.Loc
+
+		args, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+
+		ops = append(ops, ast.BulkOperation{
+			Method: opName,
+			Args:   args,
+			Loc:    ast.Loc{Start: opStart, End: p.prev.End},
+		})
+	}
+
+	return &ast.BulkStatement{
+		Collection:   collName,
+		AccessMethod: accessMethod,
+		Ordered:      ordered,
+		Operations:   ops,
+		Loc:          ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/collection.go
+++ b/mongo/parser/collection.go
@@ -3,6 +3,82 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseCollectionStatement parses db.collection.method().cursor()... chains.
+// The collection name, its location, access method, and statement start have already been determined.
 func (p *Parser) parseCollectionStatement(collName string, collLoc ast.Loc, accessMethod string, stmtStart int) (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	// Check for bulk operations
+	if p.cur.Type == kwInitializeOrderedBulkOp || p.cur.Type == kwInitializeUnorderedBulkOp {
+		return p.parseBulkStatement(collName, collLoc, accessMethod, stmtStart)
+	}
+
+	// Check for plan cache
+	if p.cur.Type == kwGetPlanCache {
+		return p.parsePlanCacheStatement(collName, collLoc, accessMethod, stmtStart)
+	}
+
+	// Check for explain prefix
+	var explain bool
+	var explainArgs []ast.Node
+	if p.cur.Type == kwExplain {
+		explain = true
+		p.advance() // consume 'explain'
+		args, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+		explainArgs = args
+
+		// After explain(), expect '.' then the actual method
+		if _, err := p.expect('.'); err != nil {
+			return nil, err
+		}
+	}
+
+	// Parse primary method: consume method name
+	methodName, methodTok, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+	_ = methodTok
+
+	// Expect '(' and parse arguments
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse cursor method chain: while next is '.', parse chained methods
+	var cursorMethods []ast.CursorMethod
+	for p.cur.Type == '.' {
+		dotTok := p.advance() // consume '.'
+		_ = dotTok
+
+		chainName, chainTok, err := p.expectIdent()
+		if err != nil {
+			return nil, err
+		}
+		chainStart := chainTok.Loc
+
+		chainArgs, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+
+		cursorMethods = append(cursorMethods, ast.CursorMethod{
+			Method: chainName,
+			Args:   chainArgs,
+			Loc:    ast.Loc{Start: chainStart, End: p.prev.End},
+		})
+	}
+
+	return &ast.CollectionStatement{
+		Collection:    collName,
+		CollectionLoc: collLoc,
+		AccessMethod:  accessMethod,
+		Method:        methodName,
+		Args:          args,
+		CursorMethods: cursorMethods,
+		Explain:       explain,
+		ExplainArgs:   explainArgs,
+		Loc:           ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/collection.go
+++ b/mongo/parser/collection.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseCollectionMethod parses db.collection.method().cursor()... chains.
+func (p *Parser) parseCollectionMethod(database, collection string, startLoc int) (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/collection.go
+++ b/mongo/parser/collection.go
@@ -2,7 +2,7 @@ package parser
 
 import "github.com/bytebase/omni/mongo/ast"
 
-// parseCollectionMethod parses db.collection.method().cursor()... chains.
-func (p *Parser) parseCollectionMethod(database, collection string, startLoc int) (ast.Node, error) {
+// parseCollectionStatement parses db.collection.method().cursor()... chains.
+func (p *Parser) parseCollectionStatement(collName string, collLoc ast.Loc, accessMethod string, stmtStart int) (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/collection.go
+++ b/mongo/parser/collection.go
@@ -21,16 +21,25 @@ func (p *Parser) parseCollectionStatement(collName string, collLoc ast.Loc, acce
 	if p.cur.Type == kwExplain {
 		explain = true
 		p.advance() // consume 'explain'
-		args, err := p.parseArguments()
+		eArgs, err := p.parseArguments()
 		if err != nil {
 			return nil, err
 		}
-		explainArgs = args
+		explainArgs = eArgs
 
-		// After explain(), expect '.' then the actual method
-		if _, err := p.expect('.'); err != nil {
-			return nil, err
+		// After explain(), if no '.', this is a standalone explain call
+		if p.cur.Type != '.' {
+			return &ast.CollectionStatement{
+				Collection:    collName,
+				CollectionLoc: collLoc,
+				AccessMethod:  accessMethod,
+				Method:        "explain",
+				Args:          explainArgs,
+				Explain:       false,
+				Loc:           ast.Loc{Start: stmtStart, End: p.prev.End},
+			}, nil
 		}
+		p.advance() // consume '.'
 	}
 
 	// Parse primary method: consume method name

--- a/mongo/parser/connection.go
+++ b/mongo/parser/connection.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseConnectionStatement parses Mongo(), connect(), and db.getMongo() chains.
+func (p *Parser) parseConnectionStatement() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/connection.go
+++ b/mongo/parser/connection.go
@@ -2,7 +2,34 @@ package parser
 
 import "github.com/bytebase/omni/mongo/ast"
 
-// parseConnectionStatement parses Mongo(), connect(), and db.getMongo() chains.
+// parseConnectionStatement parses Mongo() and connect() chains.
+// Grammar: MONGO LPAREN arguments? RPAREN connectionMethodChain?
+//        | CONNECT LPAREN arguments? RPAREN connectionMethodChain?
 func (p *Parser) parseConnectionStatement() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	stmtStart := p.cur.Loc
+	constructor := p.cur.Str
+	p.advance() // consume 'Mongo' or 'connect'
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse optional method chain: .method().method()...
+	var chain []ast.MethodCall
+	for p.cur.Type == '.' {
+		p.advance() // consume '.'
+		mc, err := p.parseMethodCall()
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, *mc)
+	}
+
+	return &ast.ConnectionStatement{
+		Constructor:    constructor,
+		Args:           args,
+		ChainedMethods: chain,
+		Loc:            ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/database.go
+++ b/mongo/parser/database.go
@@ -90,7 +90,7 @@ func (p *Parser) parseDbStatement() (ast.Node, error) {
 	identTok := p.cur
 	identName := identTok.Str
 
-	// Check for getMongo — could be encryption chain or connection chain
+	// Check for getMongo — could be encryption chain, connection chain, or standalone
 	if identTok.Type == kwGetMongo {
 		p.advance() // consume getMongo
 		// Parse getMongo()
@@ -105,6 +105,25 @@ func (p *Parser) parseDbStatement() (ast.Node, error) {
 			if next.Type == kwGetKeyVault || next.Type == kwGetClientEncryption {
 				return p.parseEncryptionStatement(stmtStart)
 			}
+		}
+
+		// If followed by .method() chain, treat as connection statement
+		if p.cur.Type == '.' {
+			var chain []ast.MethodCall
+			for p.cur.Type == '.' {
+				p.advance() // consume '.'
+				mc, err := p.parseMethodCall()
+				if err != nil {
+					return nil, err
+				}
+				chain = append(chain, *mc)
+			}
+			return &ast.ConnectionStatement{
+				Constructor:    "db.getMongo",
+				Args:           args,
+				ChainedMethods: chain,
+				Loc:            ast.Loc{Start: stmtStart, End: p.prev.End},
+			}, nil
 		}
 
 		// Otherwise it's a database method call

--- a/mongo/parser/database.go
+++ b/mongo/parser/database.go
@@ -2,8 +2,179 @@ package parser
 
 import "github.com/bytebase/omni/mongo/ast"
 
+// dbMethodNames maps keyword token types to method name strings for known database methods.
+var dbMethodNames = map[int]string{
+	kwGetName:                  "getName",
+	kwGetSiblingDB:             "getSiblingDB",
+	kwGetMongo:                 "getMongo",
+	kwGetCollectionNames:       "getCollectionNames",
+	kwGetCollectionInfos:       "getCollectionInfos",
+	kwGetCollection:            "getCollection",
+	kwCreateCollection:         "createCollection",
+	kwCreateView:               "createView",
+	kwDropDatabase:             "dropDatabase",
+	kwAdminCommand:             "adminCommand",
+	kwRunCommand:               "runCommand",
+	kwGetProfilingStatus:       "getProfilingStatus",
+	kwSetProfilingLevel:        "setProfilingLevel",
+	kwGetLogComponents:         "getLogComponents",
+	kwSetLogLevel:              "setLogLevel",
+	kwFsyncLock:                "fsyncLock",
+	kwFsyncUnlock:              "fsyncUnlock",
+	kwCurrentOp:                "currentOp",
+	kwKillOp:                   "killOp",
+	kwGetUser:                  "getUser",
+	kwGetUsers:                 "getUsers",
+	kwCreateUser:               "createUser",
+	kwUpdateUser:               "updateUser",
+	kwDropUser:                 "dropUser",
+	kwDropAllUsers:             "dropAllUsers",
+	kwGrantRolesToUser:         "grantRolesToUser",
+	kwRevokeRolesFromUser:      "revokeRolesFromUser",
+	kwGetRole:                  "getRole",
+	kwGetRoles:                 "getRoles",
+	kwCreateRole:               "createRole",
+	kwUpdateRole:               "updateRole",
+	kwDropRole:                 "dropRole",
+	kwDropAllRoles:             "dropAllRoles",
+	kwGrantPrivilegesToRole:    "grantPrivilegesToRole",
+	kwRevokePrivilegesFromRole: "revokePrivilegesFromRole",
+	kwGrantRolesToRole:         "grantRolesToRole",
+	kwRevokeRolesFromRole:      "revokeRolesFromRole",
+	kwServerStatus:             "serverStatus",
+	kwIsMaster:                 "isMaster",
+	kwHello:                    "hello",
+	kwHostInfo:                 "hostInfo",
+	kwAggregate:                "aggregate",
+	kwWatch:                    "watch",
+	kwStats:                    "stats",
+	kwVersion:                  "version",
+	kwPrintReplicationInfo:     "printReplicationInfo",
+	kwPrintSecondaryReplicationInfo: "printSecondaryReplicationInfo",
+}
+
 // parseDbStatement parses db.method() and db.collection.method() statements.
 // Dispatches to collection, bulk, encryption, or plan cache parsers as needed.
 func (p *Parser) parseDbStatement() (ast.Node, error) {
+	stmtStart := p.cur.Loc
+	p.advance() // consume 'db'
+
+	// Check for bracket access: db["coll"] or db['coll']
+	if p.cur.Type == '[' {
+		p.advance() // consume '['
+		if p.cur.Type != tokString {
+			return nil, p.errorAtCur("expected string for collection name in bracket access")
+		}
+		collName := p.cur.Str
+		collTok := p.advance()
+		collLoc := ast.Loc{Start: collTok.Loc, End: collTok.End}
+		if _, err := p.expect(']'); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('.'); err != nil {
+			return nil, err
+		}
+		return p.parseCollectionStatement(collName, collLoc, "bracket", stmtStart)
+	}
+
+	// Must have a dot after db
+	if _, err := p.expect('.'); err != nil {
+		return nil, err
+	}
+
+	// After db., get the identifier/keyword
+	if !p.isIdentLike(p.cur.Type) && p.cur.Type != tokIdent {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	identTok := p.cur
+	identName := identTok.Str
+
+	// Check for getMongo — could be encryption chain or connection chain
+	if identTok.Type == kwGetMongo {
+		p.advance() // consume getMongo
+		// Parse getMongo()
+		args, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+
+		// Check what follows: .getKeyVault() or .getClientEncryption() → encryption
+		if p.cur.Type == '.' {
+			next := p.peekNext()
+			if next.Type == kwGetKeyVault || next.Type == kwGetClientEncryption {
+				return p.parseEncryptionStatement(stmtStart)
+			}
+		}
+
+		// Otherwise it's a database method call
+		return &ast.DatabaseStatement{
+			Method: "getMongo",
+			Args:   args,
+			Loc:    ast.Loc{Start: stmtStart, End: p.prev.End},
+		}, nil
+	}
+
+	// Check for getCollection("name") → collection access
+	if identTok.Type == kwGetCollection {
+		p.advance() // consume getCollection
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		if p.cur.Type != tokString {
+			return nil, p.errorAtCur("expected string argument for getCollection()")
+		}
+		collName := p.cur.Str
+		collTok := p.advance()
+		collLoc := ast.Loc{Start: collTok.Loc, End: collTok.End}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('.'); err != nil {
+			return nil, err
+		}
+		return p.parseCollectionStatement(collName, collLoc, "getCollection", stmtStart)
+	}
+
+	// Check if this is a known database method followed by '('
+	if _, isDbMethod := dbMethodNames[identTok.Type]; isDbMethod && p.peekNext().Type == '(' {
+		p.advance() // consume method name
+		args, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.DatabaseStatement{
+			Method: identName,
+			Args:   args,
+			Loc:    ast.Loc{Start: stmtStart, End: p.prev.End},
+		}, nil
+	}
+
+	// Disambiguation: after db.identifier, if next is '(' it's a db method call,
+	// if it's '.' it's a collection name.
+	nextTok := p.peekNext()
+	if nextTok.Type == '(' {
+		// Treat as database method (handles methods not in dbMethodNames too,
+		// like auth, changeUserPassword, etc. that may be identifiers)
+		p.advance() // consume method name
+		args, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.DatabaseStatement{
+			Method: identName,
+			Args:   args,
+			Loc:    ast.Loc{Start: stmtStart, End: p.prev.End},
+		}, nil
+	}
+
+	if nextTok.Type == '.' {
+		// It's a collection name — route to collection/bulk/plancache
+		collTok := p.advance() // consume collection name
+		collLoc := ast.Loc{Start: collTok.Loc, End: collTok.End}
+		p.advance() // consume '.'
+		return p.parseCollectionStatement(identName, collLoc, "dot", stmtStart)
+	}
+
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/database.go
+++ b/mongo/parser/database.go
@@ -1,0 +1,9 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseDbStatement parses db.method() and db.collection.method() statements.
+// Dispatches to collection, bulk, encryption, or plan cache parsers as needed.
+func (p *Parser) parseDbStatement() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/document.go
+++ b/mongo/parser/document.go
@@ -3,7 +3,7 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseDocument parses a { key: value, ... } document literal.
-func (p *Parser) parseDocument() (ast.Node, error) {
+func (p *Parser) parseDocument() (*ast.Document, error) {
 	return nil, p.syntaxErrorAtCur()
 }
 

--- a/mongo/parser/document.go
+++ b/mongo/parser/document.go
@@ -4,10 +4,119 @@ import "github.com/bytebase/omni/mongo/ast"
 
 // parseDocument parses a { key: value, ... } document literal.
 func (p *Parser) parseDocument() (*ast.Document, error) {
-	return nil, p.syntaxErrorAtCur()
+	openTok, err := p.expect('{')
+	if err != nil {
+		return nil, err
+	}
+	start := openTok.Loc
+
+	var pairs []ast.KeyValue
+
+	if p.cur.Type == '}' {
+		closeTok := p.advance()
+		return &ast.Document{
+			Pairs: pairs,
+			Loc:   ast.Loc{Start: start, End: closeTok.End},
+		}, nil
+	}
+
+	for {
+		kv, err := p.parsePair()
+		if err != nil {
+			return nil, err
+		}
+		pairs = append(pairs, kv)
+
+		// Trailing comma support
+		if p.cur.Type == ',' {
+			p.advance()
+		}
+
+		if p.cur.Type == '}' {
+			closeTok := p.advance()
+			return &ast.Document{
+				Pairs: pairs,
+				Loc:   ast.Loc{Start: start, End: closeTok.End},
+			}, nil
+		}
+	}
+}
+
+// parsePair parses a single key: value pair in a document.
+// Keys can be: quoted strings, identifiers, keywords-as-identifiers, or $-prefixed identifiers.
+func (p *Parser) parsePair() (ast.KeyValue, error) {
+	var key string
+	var keyLoc ast.Loc
+
+	switch {
+	case p.cur.Type == tokString:
+		tok := p.advance()
+		key = tok.Str
+		keyLoc = ast.Loc{Start: tok.Loc, End: tok.End}
+	case p.cur.Type == tokIdent:
+		tok := p.advance()
+		key = tok.Str
+		keyLoc = ast.Loc{Start: tok.Loc, End: tok.End}
+	case p.isIdentLike(p.cur.Type):
+		tok := p.advance()
+		key = tok.Str
+		keyLoc = ast.Loc{Start: tok.Loc, End: tok.End}
+	default:
+		return ast.KeyValue{}, p.syntaxErrorAtCur()
+	}
+
+	if _, err := p.expect(':'); err != nil {
+		return ast.KeyValue{}, err
+	}
+
+	value, err := p.parseExpression()
+	if err != nil {
+		return ast.KeyValue{}, err
+	}
+
+	return ast.KeyValue{
+		Key:    key,
+		KeyLoc: keyLoc,
+		Value:  value,
+	}, nil
 }
 
 // parseArray parses a [ elem, ... ] array literal.
 func (p *Parser) parseArray() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	openTok, err := p.expect('[')
+	if err != nil {
+		return nil, err
+	}
+	start := openTok.Loc
+
+	var elements []ast.Node
+
+	if p.cur.Type == ']' {
+		closeTok := p.advance()
+		return &ast.Array{
+			Elements: elements,
+			Loc:      ast.Loc{Start: start, End: closeTok.End},
+		}, nil
+	}
+
+	for {
+		elem, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		elements = append(elements, elem)
+
+		// Trailing comma support
+		if p.cur.Type == ',' {
+			p.advance()
+		}
+
+		if p.cur.Type == ']' {
+			closeTok := p.advance()
+			return &ast.Array{
+				Elements: elements,
+				Loc:      ast.Loc{Start: start, End: closeTok.End},
+			}, nil
+		}
+	}
 }

--- a/mongo/parser/document.go
+++ b/mongo/parser/document.go
@@ -1,0 +1,13 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseDocument parses a { key: value, ... } document literal.
+func (p *Parser) parseDocument() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}
+
+// parseArray parses a [ elem, ... ] array literal.
+func (p *Parser) parseArray() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/encryption.go
+++ b/mongo/parser/encryption.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseEncryptionStatement parses db.getMongo().getKeyVault()/getClientEncryption() chains.
+func (p *Parser) parseEncryptionStatement(database string, startLoc int) (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/encryption.go
+++ b/mongo/parser/encryption.go
@@ -3,6 +3,6 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseEncryptionStatement parses db.getMongo().getKeyVault()/getClientEncryption() chains.
-func (p *Parser) parseEncryptionStatement(database string, startLoc int) (ast.Node, error) {
+func (p *Parser) parseEncryptionStatement(stmtStart int) (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/encryption.go
+++ b/mongo/parser/encryption.go
@@ -3,6 +3,43 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseEncryptionStatement parses db.getMongo().getKeyVault()/getClientEncryption() chains.
+// Called after db.getMongo() and '.' have been consumed in parseDbStatement.
+// The '.' is still current; next token is kwGetKeyVault or kwGetClientEncryption.
 func (p *Parser) parseEncryptionStatement(stmtStart int) (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	// Consume the '.'
+	p.advance()
+
+	// Determine target
+	var target string
+	if p.cur.Type == kwGetKeyVault {
+		target = "keyVault"
+	} else {
+		target = "clientEncryption"
+	}
+	p.advance() // consume getKeyVault / getClientEncryption
+
+	// Expect ()
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	// Parse optional method chain
+	var chain []ast.MethodCall
+	for p.cur.Type == '.' {
+		p.advance() // consume '.'
+		mc, err := p.parseMethodCall()
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, *mc)
+	}
+
+	return &ast.EncryptionStatement{
+		Target:         target,
+		ChainedMethods: chain,
+		Loc:            ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/expression.go
+++ b/mongo/parser/expression.go
@@ -4,5 +4,10 @@ import "github.com/bytebase/omni/mongo/ast"
 
 // parseExpression parses a value expression (document, array, literal, helper, identifier).
 func (p *Parser) parseExpression() (ast.Node, error) {
+	return p.parseValue()
+}
+
+// parseValue parses a value expression (document, array, literal, helper, identifier).
+func (p *Parser) parseValue() (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/expression.go
+++ b/mongo/parser/expression.go
@@ -1,6 +1,11 @@
 package parser
 
-import "github.com/bytebase/omni/mongo/ast"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
 
 // parseExpression parses a value expression (document, array, literal, helper, identifier).
 func (p *Parser) parseExpression() (ast.Node, error) {
@@ -9,5 +14,119 @@ func (p *Parser) parseExpression() (ast.Node, error) {
 
 // parseValue parses a value expression (document, array, literal, helper, identifier).
 func (p *Parser) parseValue() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	switch p.cur.Type {
+	case '{':
+		return p.parseDocument()
+	case '[':
+		return p.parseArray()
+
+	case tokRegex:
+		tok := p.advance()
+		pattern, flags := splitRegex(tok.Str)
+		return &ast.RegexLiteral{
+			Pattern: pattern,
+			Flags:   flags,
+			Loc:     ast.Loc{Start: tok.Loc, End: tok.End},
+		}, nil
+
+	case tokString:
+		tok := p.advance()
+		return &ast.StringLiteral{
+			Value: tok.Str,
+			Loc:   ast.Loc{Start: tok.Loc, End: tok.End},
+		}, nil
+
+	case tokNumber:
+		tok := p.advance()
+		isFloat := strings.ContainsAny(tok.Str, ".eE")
+		return &ast.NumberLiteral{
+			Value:   tok.Str,
+			IsFloat: isFloat,
+			Loc:     ast.Loc{Start: tok.Loc, End: tok.End},
+		}, nil
+
+	case kwTrue:
+		tok := p.advance()
+		return &ast.BoolLiteral{Value: true, Loc: ast.Loc{Start: tok.Loc, End: tok.End}}, nil
+
+	case kwFalse:
+		tok := p.advance()
+		return &ast.BoolLiteral{Value: false, Loc: ast.Loc{Start: tok.Loc, End: tok.End}}, nil
+
+	case kwNull:
+		tok := p.advance()
+		return &ast.NullLiteral{Loc: ast.Loc{Start: tok.Loc, End: tok.End}}, nil
+
+	case kwNew:
+		line, col := p.lineCol(p.cur.Loc)
+		return nil, &ParseError{
+			Message:  `"new" keyword is not supported`,
+			Position: p.cur.Loc,
+			Line:     line,
+			Column:   col,
+		}
+
+	// BSON helper functions
+	case kwObjectId, kwISODate, kwDate, kwUUID,
+		kwNumberLong, kwNumberInt, kwNumberDecimal,
+		kwTimestamp, kwRegExp, kwBinData, kwHexData,
+		kwMinKey, kwMaxKey, kwCode, kwDBRef, kwSymbol, kwMD5:
+		return p.parseHelperCall()
+
+	default:
+		// Handle identifier-like tokens that could be helper names
+		// (e.g. Long, Int32, Double, Decimal128, Binary, BSONRegExp that aren't keywords)
+		if p.isIdentLike(p.cur.Type) && p.peekNext().Type == '(' {
+			return p.parseHelperCall()
+		}
+
+		// Plain identifier reference
+		if p.isIdentLike(p.cur.Type) {
+			tok := p.advance()
+			return &ast.Identifier{
+				Name: tok.Str,
+				Loc:  ast.Loc{Start: tok.Loc, End: tok.End},
+			}, nil
+		}
+
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseHelperCall parses a BSON helper call like ObjectId("..."), NumberLong(1), etc.
+func (p *Parser) parseHelperCall() (*ast.HelperCall, error) {
+	nameTok := p.advance()
+	start := nameTok.Loc
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.HelperCall{
+		Name: nameTok.Str,
+		Args: args,
+		Loc:  ast.Loc{Start: start, End: p.prev.End},
+	}, nil
+}
+
+// splitRegex splits a regex token string "pattern/flags" into pattern and flags.
+// The lexer stores regex tokens as "pattern/flags" (without the leading /).
+func splitRegex(s string) (string, string) {
+	idx := strings.LastIndex(s, "/")
+	if idx < 0 {
+		return s, ""
+	}
+	return s[:idx], s[idx+1:]
+}
+
+// errorAtCur creates a ParseError with a custom message at the current token position.
+func (p *Parser) errorAtCur(format string, args ...any) *ParseError {
+	line, col := p.lineCol(p.cur.Loc)
+	return &ParseError{
+		Message:  fmt.Sprintf(format, args...),
+		Position: p.cur.Loc,
+		Line:     line,
+		Column:   col,
+	}
 }

--- a/mongo/parser/expression.go
+++ b/mongo/parser/expression.go
@@ -7,9 +7,49 @@ import (
 	"github.com/bytebase/omni/mongo/ast"
 )
 
-// parseExpression parses a value expression (document, array, literal, helper, identifier).
+// parseExpression parses a value expression (document, array, literal, helper, identifier),
+// including optional postfix .method(args) chains (e.g., Binary.createFromBase64("...")).
 func (p *Parser) parseExpression() (ast.Node, error) {
-	return p.parseValue()
+	node, err := p.parseValue()
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle postfix .method(args) chains on identifiers/helpers
+	for p.cur.Type == '.' {
+		// Check that what follows is identifier + '(' (a method call)
+		next := p.peekNext()
+		if !p.isIdentLike(next.Type) {
+			break
+		}
+		p.advance() // consume '.'
+		mc, err := p.parseMethodCall()
+		if err != nil {
+			return nil, err
+		}
+		// Wrap as a HelperCall with qualified name
+		start := node.GetLoc().Start
+		name := nodeToName(node) + "." + mc.Name
+		node = &ast.HelperCall{
+			Name: name,
+			Args: mc.Args,
+			Loc:  ast.Loc{Start: start, End: mc.Loc.End},
+		}
+	}
+
+	return node, nil
+}
+
+// nodeToName extracts a name string from an AST node for building qualified names.
+func nodeToName(n ast.Node) string {
+	switch v := n.(type) {
+	case *ast.Identifier:
+		return v.Name
+	case *ast.HelperCall:
+		return v.Name
+	default:
+		return "?"
+	}
 }
 
 // parseValue parses a value expression (document, array, literal, helper, identifier).

--- a/mongo/parser/expression.go
+++ b/mongo/parser/expression.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseExpression parses a value expression (document, array, literal, helper, identifier).
+func (p *Parser) parseExpression() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/lexer.go
+++ b/mongo/parser/lexer.go
@@ -1,0 +1,463 @@
+package parser
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Lexer tokenizes mongosh input character by character.
+type Lexer struct {
+	input string
+	pos   int
+	start int
+}
+
+// NewLexer creates a new Lexer for the given input.
+func NewLexer(input string) *Lexer {
+	return &Lexer{input: input}
+}
+
+// NextToken returns the next token from the input.
+func (l *Lexer) NextToken() Token {
+	l.skipWhitespaceAndComments()
+
+	if l.pos >= len(l.input) {
+		return Token{Type: tokEOF, Loc: l.pos, End: l.pos}
+	}
+
+	l.start = l.pos
+	ch := l.input[l.pos]
+
+	// String literals
+	if ch == '"' || ch == '\'' {
+		return l.scanString(ch)
+	}
+
+	// Numbers: digits, or leading dot followed by digit
+	if ch >= '0' && ch <= '9' {
+		return l.scanNumber()
+	}
+	if ch == '.' && l.pos+1 < len(l.input) && l.input[l.pos+1] >= '0' && l.input[l.pos+1] <= '9' {
+		return l.scanNumber()
+	}
+
+	// Negative numbers: minus followed by digit or dot-digit
+	if ch == '-' {
+		if l.pos+1 < len(l.input) {
+			next := l.input[l.pos+1]
+			if next >= '0' && next <= '9' {
+				return l.scanNumber()
+			}
+			if next == '.' && l.pos+2 < len(l.input) && l.input[l.pos+2] >= '0' && l.input[l.pos+2] <= '9' {
+				return l.scanNumber()
+			}
+		}
+	}
+
+	// Regex literal /pattern/flags
+	// Disambiguate from division: regex can appear at start of input or after certain tokens.
+	if ch == '/' {
+		if l.canBeRegex() {
+			return l.scanRegex()
+		}
+	}
+
+	// Identifiers (including $-prefixed)
+	if isIdentStart(ch) || ch == '$' {
+		return l.scanIdentOrKeyword()
+	}
+	// Unicode identifiers
+	if ch >= 0x80 {
+		r, _ := utf8.DecodeRuneInString(l.input[l.pos:])
+		if r != utf8.RuneError && (unicode.IsLetter(r) || r == '_') {
+			return l.scanIdentOrKeyword()
+		}
+	}
+
+	// Multi-character operators
+	if l.pos+1 < len(l.input) {
+		next := l.input[l.pos+1]
+		switch {
+		case ch == '=' && next == '=':
+			if l.pos+2 < len(l.input) && l.input[l.pos+2] == '=' {
+				l.pos += 3
+				return Token{Type: tokEqEqEq, Str: "===", Loc: l.start, End: l.pos}
+			}
+			l.pos += 2
+			return Token{Type: tokEqEq, Str: "==", Loc: l.start, End: l.pos}
+		case ch == '!' && next == '=':
+			if l.pos+2 < len(l.input) && l.input[l.pos+2] == '=' {
+				l.pos += 3
+				return Token{Type: tokNotEqEq, Str: "!==", Loc: l.start, End: l.pos}
+			}
+			l.pos += 2
+			return Token{Type: tokNotEq, Str: "!=", Loc: l.start, End: l.pos}
+		case ch == '<' && next == '=':
+			l.pos += 2
+			return Token{Type: tokLessEq, Str: "<=", Loc: l.start, End: l.pos}
+		case ch == '>' && next == '=':
+			l.pos += 2
+			return Token{Type: tokGreaterEq, Str: ">=", Loc: l.start, End: l.pos}
+		case ch == '&' && next == '&':
+			l.pos += 2
+			return Token{Type: tokAnd, Str: "&&", Loc: l.start, End: l.pos}
+		case ch == '|' && next == '|':
+			l.pos += 2
+			return Token{Type: tokOr, Str: "||", Loc: l.start, End: l.pos}
+		case ch == '=' && next == '>':
+			l.pos += 2
+			return Token{Type: tokArrow, Str: "=>", Loc: l.start, End: l.pos}
+		case ch == '.' && next == '.' && l.pos+2 < len(l.input) && l.input[l.pos+2] == '.':
+			l.pos += 3
+			return Token{Type: tokSpread, Str: "...", Loc: l.start, End: l.pos}
+		case ch == '?' && next == '.':
+			l.pos += 2
+			return Token{Type: tokOptChain, Str: "?.", Loc: l.start, End: l.pos}
+		case ch == '?' && next == '?':
+			l.pos += 2
+			return Token{Type: tokNullCoal, Str: "??", Loc: l.start, End: l.pos}
+		case ch == '+' && next == '+':
+			l.pos += 2
+			return Token{Type: tokPlusPlus, Str: "++", Loc: l.start, End: l.pos}
+		case ch == '-' && next == '-':
+			l.pos += 2
+			return Token{Type: tokMinusMinus, Str: "--", Loc: l.start, End: l.pos}
+		case ch == '+' && next == '=':
+			l.pos += 2
+			return Token{Type: tokPlusEq, Str: "+=", Loc: l.start, End: l.pos}
+		case ch == '-' && next == '=':
+			l.pos += 2
+			return Token{Type: tokMinusEq, Str: "-=", Loc: l.start, End: l.pos}
+		case ch == '*' && next == '*':
+			l.pos += 2
+			return Token{Type: tokPower, Str: "**", Loc: l.start, End: l.pos}
+		case ch == '*' && next == '=':
+			l.pos += 2
+			return Token{Type: tokStarEq, Str: "*=", Loc: l.start, End: l.pos}
+		case ch == '/' && next == '=':
+			l.pos += 2
+			return Token{Type: tokSlashEq, Str: "/=", Loc: l.start, End: l.pos}
+		case ch == '%' && next == '=':
+			l.pos += 2
+			return Token{Type: tokPercentEq, Str: "%=", Loc: l.start, End: l.pos}
+		case ch == '<' && next == '<':
+			l.pos += 2
+			return Token{Type: tokShiftLeft, Str: "<<", Loc: l.start, End: l.pos}
+		case ch == '>' && next == '>':
+			l.pos += 2
+			return Token{Type: tokShiftRight, Str: ">>", Loc: l.start, End: l.pos}
+		}
+	}
+
+	// Single character tokens — returned as their ASCII value
+	l.pos++
+	return Token{Type: int(ch), Str: string(ch), Loc: l.start, End: l.pos}
+}
+
+// skipWhitespaceAndComments skips whitespace, // line comments, and /* */ block comments.
+func (l *Lexer) skipWhitespaceAndComments() {
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+
+		// Whitespace
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
+			l.pos++
+			continue
+		}
+
+		// Comments
+		if ch == '/' && l.pos+1 < len(l.input) {
+			next := l.input[l.pos+1]
+			// Line comment //
+			if next == '/' {
+				l.pos += 2
+				for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+					l.pos++
+				}
+				continue
+			}
+			// Block comment /* */
+			if next == '*' {
+				l.pos += 2
+				for l.pos+1 < len(l.input) {
+					if l.input[l.pos] == '*' && l.input[l.pos+1] == '/' {
+						l.pos += 2
+						break
+					}
+					l.pos++
+				}
+				// If we hit end without closing, just stop
+				if l.pos >= len(l.input) {
+					return
+				}
+				continue
+			}
+		}
+
+		break
+	}
+}
+
+// scanString scans a single or double quoted string with escape sequences.
+func (l *Lexer) scanString(quote byte) Token {
+	l.pos++ // skip opening quote
+	var buf []byte
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == quote {
+			l.pos++ // skip closing quote
+			return Token{Type: tokString, Str: string(buf), Loc: l.start, End: l.pos}
+		}
+		if ch == '\\' && l.pos+1 < len(l.input) {
+			l.pos++ // skip backslash
+			esc := l.input[l.pos]
+			l.pos++
+			switch esc {
+			case 'n':
+				buf = append(buf, '\n')
+			case 't':
+				buf = append(buf, '\t')
+			case 'r':
+				buf = append(buf, '\r')
+			case '\\':
+				buf = append(buf, '\\')
+			case '\'':
+				buf = append(buf, '\'')
+			case '"':
+				buf = append(buf, '"')
+			case '0':
+				buf = append(buf, 0)
+			case 'b':
+				buf = append(buf, '\b')
+			case 'f':
+				buf = append(buf, '\f')
+			case 'v':
+				buf = append(buf, '\v')
+			case 'u':
+				// \uXXXX
+				r := l.parseHex4()
+				if r >= 0 {
+					var ubuf [4]byte
+					n := utf8.EncodeRune(ubuf[:], rune(r))
+					buf = append(buf, ubuf[:n]...)
+				} else {
+					buf = append(buf, '\\', 'u')
+				}
+			case 'x':
+				// \xHH
+				if l.pos+1 < len(l.input) {
+					h1 := hexVal(l.input[l.pos])
+					h2 := hexVal(l.input[l.pos+1])
+					if h1 >= 0 && h2 >= 0 {
+						buf = append(buf, byte(h1<<4|h2))
+						l.pos += 2
+					} else {
+						buf = append(buf, '\\', 'x')
+					}
+				} else {
+					buf = append(buf, '\\', 'x')
+				}
+			default:
+				// Unknown escape — include as-is
+				buf = append(buf, '\\', esc)
+			}
+			continue
+		}
+		buf = append(buf, ch)
+		l.pos++
+	}
+	// Unterminated string — return what we have
+	return Token{Type: tokString, Str: string(buf), Loc: l.start, End: l.pos}
+}
+
+// parseHex4 parses 4 hex digits for \uXXXX escape. Returns -1 on failure.
+func (l *Lexer) parseHex4() int {
+	if l.pos+3 >= len(l.input) {
+		return -1
+	}
+	val := 0
+	for i := 0; i < 4; i++ {
+		h := hexVal(l.input[l.pos+i])
+		if h < 0 {
+			return -1
+		}
+		val = val<<4 | h
+	}
+	l.pos += 4
+	return val
+}
+
+// hexVal returns the hex digit value or -1.
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	}
+	return -1
+}
+
+// scanNumber scans an integer, float, hex, or scientific notation number.
+// Handles optional leading minus sign.
+func (l *Lexer) scanNumber() Token {
+	start := l.pos
+
+	// Optional leading minus
+	if l.pos < len(l.input) && l.input[l.pos] == '-' {
+		l.pos++
+	}
+
+	// Hex: 0x or 0X
+	if l.pos+1 < len(l.input) && l.input[l.pos] == '0' && (l.input[l.pos+1] == 'x' || l.input[l.pos+1] == 'X') {
+		l.pos += 2
+		for l.pos < len(l.input) && isHexDigit(l.input[l.pos]) {
+			l.pos++
+		}
+		return Token{Type: tokNumber, Str: l.input[start:l.pos], Loc: l.start, End: l.pos}
+	}
+
+	// Integer part (may be empty for .5)
+	for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+		l.pos++
+	}
+
+	// Fractional part
+	if l.pos < len(l.input) && l.input[l.pos] == '.' {
+		l.pos++
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+	}
+
+	// Exponent part
+	if l.pos < len(l.input) && (l.input[l.pos] == 'e' || l.input[l.pos] == 'E') {
+		l.pos++
+		if l.pos < len(l.input) && (l.input[l.pos] == '+' || l.input[l.pos] == '-') {
+			l.pos++
+		}
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+	}
+
+	return Token{Type: tokNumber, Str: l.input[start:l.pos], Loc: l.start, End: l.pos}
+}
+
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// scanRegex scans a regex literal /pattern/flags.
+func (l *Lexer) scanRegex() Token {
+	l.pos++ // skip opening /
+	var pattern []byte
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == '/' {
+			l.pos++ // skip closing /
+			// Scan flags
+			flagStart := l.pos
+			for l.pos < len(l.input) {
+				c := l.input[l.pos]
+				if c == 'g' || c == 'i' || c == 'm' || c == 's' || c == 'u' || c == 'y' {
+					l.pos++
+				} else {
+					break
+				}
+			}
+			flags := l.input[flagStart:l.pos]
+			return Token{Type: tokRegex, Str: string(pattern) + "/" + flags, Loc: l.start, End: l.pos}
+		}
+		if ch == '\\' && l.pos+1 < len(l.input) {
+			// Escaped character in regex
+			pattern = append(pattern, ch, l.input[l.pos+1])
+			l.pos += 2
+			continue
+		}
+		if ch == '\n' {
+			break // unterminated regex
+		}
+		pattern = append(pattern, ch)
+		l.pos++
+	}
+	// Unterminated — return as division operator
+	l.pos = l.start + 1
+	return Token{Type: int('/'), Str: "/", Loc: l.start, End: l.pos}
+}
+
+// canBeRegex returns true if a '/' at the current position could start a regex literal
+// rather than being a division operator.
+func (l *Lexer) canBeRegex() bool {
+	// Simple heuristic: regex can appear at start of input or after punctuation/operators
+	// that cannot end an expression. After identifiers, numbers, or closing brackets, it's division.
+	if l.start == 0 {
+		return true
+	}
+	// Look at what came before (skip whitespace backwards)
+	i := l.pos - 1
+	for i >= 0 && (l.input[i] == ' ' || l.input[i] == '\t' || l.input[i] == '\n' || l.input[i] == '\r') {
+		i--
+	}
+	if i < 0 {
+		return true
+	}
+	prev := l.input[i]
+	// After these, '/' is division
+	switch prev {
+	case ')', ']', '}':
+		return false
+	case '_':
+		return false
+	}
+	if (prev >= '0' && prev <= '9') || (prev >= 'a' && prev <= 'z') || (prev >= 'A' && prev <= 'Z') {
+		return false
+	}
+	return true
+}
+
+// scanIdentOrKeyword scans an identifier or keyword.
+func (l *Lexer) scanIdentOrKeyword() Token {
+	start := l.pos
+
+	// First character: letter, _, or $, or Unicode letter
+	r, size := utf8.DecodeRuneInString(l.input[l.pos:])
+	if r == utf8.RuneError && size <= 1 {
+		l.pos++
+	} else {
+		l.pos += size
+	}
+
+	// Subsequent characters: letter, digit, _, $, or Unicode
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '$' {
+			l.pos++
+			continue
+		}
+		if ch >= 0x80 {
+			r, size := utf8.DecodeRuneInString(l.input[l.pos:])
+			if r != utf8.RuneError && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
+				l.pos += size
+				continue
+			}
+		}
+		break
+	}
+
+	word := l.input[start:l.pos]
+
+	// Check keyword map (case-sensitive for mongosh)
+	if kw, ok := keywords[word]; ok {
+		return Token{Type: kw, Str: word, Loc: l.start, End: l.pos}
+	}
+
+	return Token{Type: tokIdent, Str: word, Loc: l.start, End: l.pos}
+}
+
+// isIdentStart returns true if c can start an identifier.
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}

--- a/mongo/parser/native.go
+++ b/mongo/parser/native.go
@@ -1,0 +1,25 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// isNativeFunction returns true if the current token is a native mongosh function name.
+func (p *Parser) isNativeFunction() bool {
+	switch p.cur.Type {
+	case kwSleep, kwLoad, kwPrint, kwPrintjson, kwQuit, kwExit,
+		kwVersion, kwCls, kwHelp, kwIt,
+		kwIsNaN, kwIsFinite, kwParseInt, kwParseFloat,
+		kwEncodeURI, kwEncodeURIComponent, kwDecodeURI, kwDecodeURIComponent:
+		return true
+	}
+	return false
+}
+
+// parseNativeFunctionCall parses a top-level native function call like sleep(1000).
+func (p *Parser) parseNativeFunctionCall() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}
+
+// parseIdentStatement parses statements starting with an unrecognized identifier.
+func (p *Parser) parseIdentStatement() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/native.go
+++ b/mongo/parser/native.go
@@ -3,6 +3,20 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseNativeFunctionCall parses a top-level native function call like sleep(1000).
+// Grammar: identifier LPAREN arguments? RPAREN
 func (p *Parser) parseNativeFunctionCall() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	stmtStart := p.cur.Loc
+	name := p.cur.Str
+	p.advance() // consume function name
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.NativeFunctionCall{
+		Name: name,
+		Args: args,
+		Loc:  ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/native.go
+++ b/mongo/parser/native.go
@@ -2,24 +2,7 @@ package parser
 
 import "github.com/bytebase/omni/mongo/ast"
 
-// isNativeFunction returns true if the current token is a native mongosh function name.
-func (p *Parser) isNativeFunction() bool {
-	switch p.cur.Type {
-	case kwSleep, kwLoad, kwPrint, kwPrintjson, kwQuit, kwExit,
-		kwVersion, kwCls, kwHelp, kwIt,
-		kwIsNaN, kwIsFinite, kwParseInt, kwParseFloat,
-		kwEncodeURI, kwEncodeURIComponent, kwDecodeURI, kwDecodeURIComponent:
-		return true
-	}
-	return false
-}
-
 // parseNativeFunctionCall parses a top-level native function call like sleep(1000).
 func (p *Parser) parseNativeFunctionCall() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
-}
-
-// parseIdentStatement parses statements starting with an unrecognized identifier.
-func (p *Parser) parseIdentStatement() (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/parser.go
+++ b/mongo/parser/parser.go
@@ -60,16 +60,10 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseConnectionStatement()
 	case kwConnect:
 		return p.parseConnectionStatement()
-	case kwUse:
-		return p.parseUseCommand()
 	default:
-		// Check for native functions
-		if p.isNativeFunction() {
+		// Check for native functions: identifier-like token followed by '('
+		if p.isIdentLike(p.cur.Type) && p.peekNext().Type == '(' {
 			return p.parseNativeFunctionCall()
-		}
-		// Check for identifiers that might be collection access via variable
-		if p.cur.Type == tokIdent {
-			return p.parseIdentStatement()
 		}
 		return nil, p.syntaxErrorAtCur()
 	}
@@ -116,16 +110,16 @@ func (p *Parser) match(types ...int) (Token, bool) {
 	return Token{}, false
 }
 
-// isIdentLike returns true if the current token is an identifier or a keyword
+// isIdentLike returns true if the given token type is an identifier or a keyword
 // that can be used as an identifier in certain contexts (e.g., method names).
-func (p *Parser) isIdentLike() bool {
-	return p.cur.Type == tokIdent || p.cur.Type >= 700
+func (p *Parser) isIdentLike(tokenType int) bool {
+	return tokenType == tokIdent || tokenType >= 700
 }
 
 // expectIdent consumes the current token if it's an identifier or keyword-as-identifier.
 // Returns the token string and an error if not identifier-like.
 func (p *Parser) expectIdent() (string, Token, error) {
-	if p.isIdentLike() {
+	if p.isIdentLike(p.cur.Type) {
 		tok := p.advance()
 		return tok.Str, tok, nil
 	}

--- a/mongo/parser/parser.go
+++ b/mongo/parser/parser.go
@@ -1,0 +1,257 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+// Parser is a recursive descent parser for mongosh commands.
+type Parser struct {
+	lexer   *Lexer
+	input   string
+	cur     Token // current token
+	prev    Token // previous token
+	nextBuf Token // buffered next token for 2-token lookahead
+	hasNext bool  // whether nextBuf is valid
+}
+
+// Parse parses a mongosh input string into a list of AST nodes.
+// Each semicolon-separated or newline-separated command becomes one node.
+func Parse(input string) ([]ast.Node, error) {
+	p := &Parser{
+		lexer: NewLexer(input),
+		input: input,
+	}
+	p.advance()
+
+	var nodes []ast.Node
+	for p.cur.Type != tokEOF {
+		// Skip semicolons between statements
+		if p.cur.Type == ';' {
+			p.advance()
+			continue
+		}
+		node, err := p.parseStatement()
+		if err != nil {
+			return nil, err
+		}
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes, nil
+}
+
+// parseStatement dispatches to the appropriate family parser based on the first token.
+func (p *Parser) parseStatement() (ast.Node, error) {
+	switch p.cur.Type {
+	case kwShow:
+		return p.parseShowCommand()
+	case kwDb:
+		return p.parseDbStatement()
+	case kwRs:
+		return p.parseRsStatement()
+	case kwSh:
+		return p.parseShStatement()
+	case kwSp:
+		return p.parseSpStatement()
+	case kwMongo:
+		return p.parseConnectionStatement()
+	case kwConnect:
+		return p.parseConnectionStatement()
+	case kwUse:
+		return p.parseUseCommand()
+	default:
+		// Check for native functions
+		if p.isNativeFunction() {
+			return p.parseNativeFunctionCall()
+		}
+		// Check for identifiers that might be collection access via variable
+		if p.cur.Type == tokIdent {
+			return p.parseIdentStatement()
+		}
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// advance consumes the current token and moves to the next one.
+func (p *Parser) advance() Token {
+	p.prev = p.cur
+	if p.hasNext {
+		p.cur = p.nextBuf
+		p.hasNext = false
+	} else {
+		p.cur = p.lexer.NextToken()
+	}
+	return p.prev
+}
+
+// peekNext returns the next token after cur without consuming it.
+func (p *Parser) peekNext() Token {
+	if !p.hasNext {
+		p.nextBuf = p.lexer.NextToken()
+		p.hasNext = true
+	}
+	return p.nextBuf
+}
+
+// expect consumes the current token if it matches the expected type.
+// Returns an error if the token does not match.
+func (p *Parser) expect(tokenType int) (Token, error) {
+	if p.cur.Type == tokenType {
+		return p.advance(), nil
+	}
+	return Token{}, p.unexpectedTokenError(tokenType)
+}
+
+// match checks if the current token type matches any of the given types.
+// If it matches, the token is consumed and returned with ok=true.
+func (p *Parser) match(types ...int) (Token, bool) {
+	for _, t := range types {
+		if p.cur.Type == t {
+			return p.advance(), true
+		}
+	}
+	return Token{}, false
+}
+
+// isIdentLike returns true if the current token is an identifier or a keyword
+// that can be used as an identifier in certain contexts (e.g., method names).
+func (p *Parser) isIdentLike() bool {
+	return p.cur.Type == tokIdent || p.cur.Type >= 700
+}
+
+// expectIdent consumes the current token if it's an identifier or keyword-as-identifier.
+// Returns the token string and an error if not identifier-like.
+func (p *Parser) expectIdent() (string, Token, error) {
+	if p.isIdentLike() {
+		tok := p.advance()
+		return tok.Str, tok, nil
+	}
+	return "", Token{}, p.unexpectedTokenError(tokIdent)
+}
+
+// parseArguments parses a parenthesized argument list: ( expr, expr, ... )
+// Assumes the opening '(' has NOT been consumed yet.
+func (p *Parser) parseArguments() ([]ast.Node, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var args []ast.Node
+	if p.cur.Type == ')' {
+		p.advance()
+		return args, nil
+	}
+
+	for {
+		expr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, expr)
+
+		if p.cur.Type == ')' {
+			p.advance()
+			return args, nil
+		}
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// parseMethodCall parses .methodName(args...) assuming the dot has been consumed.
+func (p *Parser) parseMethodCall() (*ast.MethodCall, error) {
+	name, tok, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+	start := tok.Loc
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.MethodCall{
+		Name: name,
+		Args: args,
+		Loc:  ast.Loc{Start: start, End: p.prev.End},
+	}, nil
+}
+
+// ParseError represents a parse error with position information.
+type ParseError struct {
+	Message  string
+	Position int
+	Line     int // 1-based line number
+	Column   int // 1-based column number
+}
+
+func (e *ParseError) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("%s (line %d, column %d)", e.Message, e.Line, e.Column)
+	}
+	return e.Message
+}
+
+// syntaxErrorAtCur returns a ParseError at the current token position.
+func (p *Parser) syntaxErrorAtCur() *ParseError {
+	line, col := p.lineCol(p.cur.Loc)
+	var msg string
+	if p.cur.Type == tokEOF {
+		msg = "syntax error at end of input"
+	} else {
+		text := p.cur.Str
+		if text == "" {
+			text = string(rune(p.cur.Type))
+		}
+		msg = fmt.Sprintf("syntax error at or near %q", text)
+	}
+	return &ParseError{
+		Message:  msg,
+		Position: p.cur.Loc,
+		Line:     line,
+		Column:   col,
+	}
+}
+
+// unexpectedTokenError returns a ParseError for an unexpected token.
+func (p *Parser) unexpectedTokenError(expected int) *ParseError {
+	line, col := p.lineCol(p.cur.Loc)
+	var msg string
+	if p.cur.Type == tokEOF {
+		msg = fmt.Sprintf("expected %s but reached end of input", tokenName(expected))
+	} else {
+		text := p.cur.Str
+		if text == "" {
+			text = string(rune(p.cur.Type))
+		}
+		msg = fmt.Sprintf("expected %s, got %q", tokenName(expected), text)
+	}
+	return &ParseError{
+		Message:  msg,
+		Position: p.cur.Loc,
+		Line:     line,
+		Column:   col,
+	}
+}
+
+// lineCol computes the 1-based line and column for a byte offset.
+func (p *Parser) lineCol(offset int) (int, int) {
+	if offset > len(p.input) {
+		offset = len(p.input)
+	}
+	line := 1
+	lastNewline := -1
+	for i := 0; i < offset; i++ {
+		if p.input[i] == '\n' {
+			line++
+			lastNewline = i
+		}
+	}
+	col := offset - lastNewline
+	return line, col
+}

--- a/mongo/parser/plancache.go
+++ b/mongo/parser/plancache.go
@@ -3,6 +3,34 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parsePlanCacheStatement parses db.collection.getPlanCache() chains.
+// Already called with collName, collLoc, accessMethod, stmtStart determined.
+// Current token is kwGetPlanCache.
 func (p *Parser) parsePlanCacheStatement(collName string, collLoc ast.Loc, accessMethod string, stmtStart int) (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	p.advance() // consume 'getPlanCache'
+
+	// Expect ()
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	// Parse optional method chain
+	var chain []ast.MethodCall
+	for p.cur.Type == '.' {
+		p.advance() // consume '.'
+		mc, err := p.parseMethodCall()
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, *mc)
+	}
+
+	return &ast.PlanCacheStatement{
+		Collection:     collName,
+		AccessMethod:   accessMethod,
+		ChainedMethods: chain,
+		Loc:            ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/plancache.go
+++ b/mongo/parser/plancache.go
@@ -3,6 +3,6 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parsePlanCacheStatement parses db.collection.getPlanCache() chains.
-func (p *Parser) parsePlanCacheStatement(database, collection string, startLoc int) (ast.Node, error) {
+func (p *Parser) parsePlanCacheStatement(collName string, collLoc ast.Loc, accessMethod string, stmtStart int) (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }

--- a/mongo/parser/plancache.go
+++ b/mongo/parser/plancache.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parsePlanCacheStatement parses db.collection.getPlanCache() chains.
+func (p *Parser) parsePlanCacheStatement(database, collection string, startLoc int) (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/replication.go
+++ b/mongo/parser/replication.go
@@ -3,6 +3,28 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseRsStatement parses rs.method() calls.
+// Grammar: rs DOT identifier LPAREN arguments? RPAREN
 func (p *Parser) parseRsStatement() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	stmtStart := p.cur.Loc
+	p.advance() // consume 'rs'
+
+	if _, err := p.expect('.'); err != nil {
+		return nil, err
+	}
+
+	methodName, _, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.RsStatement{
+		MethodName: methodName,
+		Args:       args,
+		Loc:        ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/replication.go
+++ b/mongo/parser/replication.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseRsStatement parses rs.method() calls.
+func (p *Parser) parseRsStatement() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/sharding.go
+++ b/mongo/parser/sharding.go
@@ -3,6 +3,28 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseShStatement parses sh.method() calls.
+// Grammar: sh DOT identifier LPAREN arguments? RPAREN
 func (p *Parser) parseShStatement() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	stmtStart := p.cur.Loc
+	p.advance() // consume 'sh'
+
+	if _, err := p.expect('.'); err != nil {
+		return nil, err
+	}
+
+	methodName, _, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.ShStatement{
+		MethodName: methodName,
+		Args:       args,
+		Loc:        ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/sharding.go
+++ b/mongo/parser/sharding.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseShStatement parses sh.method() calls.
+func (p *Parser) parseShStatement() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/shell.go
+++ b/mongo/parser/shell.go
@@ -1,0 +1,13 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseShowCommand parses "show dbs", "show collections", etc.
+func (p *Parser) parseShowCommand() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}
+
+// parseUseCommand parses "use <database>".
+func (p *Parser) parseUseCommand() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/shell.go
+++ b/mongo/parser/shell.go
@@ -6,8 +6,3 @@ import "github.com/bytebase/omni/mongo/ast"
 func (p *Parser) parseShowCommand() (ast.Node, error) {
 	return nil, p.syntaxErrorAtCur()
 }
-
-// parseUseCommand parses "use <database>".
-func (p *Parser) parseUseCommand() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
-}

--- a/mongo/parser/shell.go
+++ b/mongo/parser/shell.go
@@ -2,7 +2,49 @@ package parser
 
 import "github.com/bytebase/omni/mongo/ast"
 
-// parseShowCommand parses "show dbs", "show collections", etc.
+// parseShowCommand parses "show dbs", "show databases", "show collections", etc.
 func (p *Parser) parseShowCommand() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	showTok := p.advance() // consume 'show'
+	start := showTok.Loc
+
+	var target string
+	switch p.cur.Type {
+	case kwDbs:
+		target = "databases"
+		p.advance()
+	case kwDatabases:
+		target = "databases"
+		p.advance()
+	case kwCollections:
+		target = "collections"
+		p.advance()
+	case kwTables:
+		target = "tables"
+		p.advance()
+	case kwProfile:
+		target = "profile"
+		p.advance()
+	case kwUsers:
+		target = "users"
+		p.advance()
+	case kwRoles:
+		target = "roles"
+		p.advance()
+	case kwLog:
+		target = "log"
+		p.advance()
+	case kwLogs:
+		target = "logs"
+		p.advance()
+	case kwStartupWarnings:
+		target = "startupWarnings"
+		p.advance()
+	default:
+		return nil, p.errorAtCur("expected show target (dbs, databases, collections, etc.)")
+	}
+
+	return &ast.ShowCommand{
+		Target: target,
+		Loc:    ast.Loc{Start: start, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/stream.go
+++ b/mongo/parser/stream.go
@@ -3,6 +3,51 @@ package parser
 import "github.com/bytebase/omni/mongo/ast"
 
 // parseSpStatement parses sp.method() and sp.x.method() calls.
+// Grammar: SP DOT identifier LPAREN arguments? RPAREN
+//        | SP DOT identifier DOT identifier LPAREN arguments? RPAREN
 func (p *Parser) parseSpStatement() (ast.Node, error) {
-	return nil, p.syntaxErrorAtCur()
+	stmtStart := p.cur.Loc
+	p.advance() // consume 'sp'
+
+	if _, err := p.expect('.'); err != nil {
+		return nil, err
+	}
+
+	firstName, _, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if there's a sub-method: sp.processorName.method()
+	if p.cur.Type == '.' {
+		p.advance() // consume '.'
+		subMethod, _, err := p.expectIdent()
+		if err != nil {
+			return nil, err
+		}
+
+		args, err := p.parseArguments()
+		if err != nil {
+			return nil, err
+		}
+
+		return &ast.SpStatement{
+			MethodName: firstName,
+			SubMethod:  subMethod,
+			Args:       args,
+			Loc:        ast.Loc{Start: stmtStart, End: p.prev.End},
+		}, nil
+	}
+
+	// Simple form: sp.method()
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.SpStatement{
+		MethodName: firstName,
+		Args:       args,
+		Loc:        ast.Loc{Start: stmtStart, End: p.prev.End},
+	}, nil
 }

--- a/mongo/parser/stream.go
+++ b/mongo/parser/stream.go
@@ -1,0 +1,8 @@
+package parser
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// parseSpStatement parses sp.method() and sp.x.method() calls.
+func (p *Parser) parseSpStatement() (ast.Node, error) {
+	return nil, p.syntaxErrorAtCur()
+}

--- a/mongo/parser/token.go
+++ b/mongo/parser/token.go
@@ -324,7 +324,6 @@ const (
 	kwCls              // cls
 	kwHelp             // help
 	kwIt               // it
-	kwUse              // use
 	kwNumberIsNaN      // Number.isNaN
 	kwIsNaN            // isNaN
 	kwIsFinite         // isFinite
@@ -631,7 +630,6 @@ var keywords = map[string]int{
 	"cls":                  kwCls,
 	"help":                 kwHelp,
 	"it":                   kwIt,
-	"use":                  kwUse,
 	"isNaN":                kwIsNaN,
 	"isFinite":             kwIsFinite,
 	"parseInt":             kwParseInt,

--- a/mongo/parser/token.go
+++ b/mongo/parser/token.go
@@ -1,0 +1,729 @@
+package parser
+
+// Token represents a single lexical token.
+type Token struct {
+	Type int    // token type constant
+	Str  string // string content (identifier name, string value, number text, etc.)
+	Loc  int    // inclusive start byte offset
+	End  int    // exclusive end byte offset
+}
+
+// Token type constants for literals and punctuation.
+const (
+	tokEOF = 0
+
+	// Literal tokens (600+)
+	tokNumber = 600 + iota // integer or float
+	tokString              // double or single quoted string
+	tokRegex               // /pattern/flags
+	tokIdent               // identifier (including $-prefixed)
+
+	// Multi-character operators / punctuation
+	tokEqEq       // ==
+	tokNotEq      // !=
+	tokNotEqEq    // !==
+	tokEqEqEq     // ===
+	tokLessEq     // <=
+	tokGreaterEq  // >=
+	tokAnd        // &&
+	tokOr         // ||
+	tokArrow      // =>
+	tokSpread     // ...
+	tokOptChain   // ?.
+	tokNullCoal   // ??
+	tokPlusPlus   // ++
+	tokMinusMinus // --
+	tokPlusEq     // +=
+	tokMinusEq    // -=
+	tokStarEq     // *=
+	tokSlashEq    // /=
+	tokPercentEq  // %=
+	tokPower      // **
+	tokShiftLeft  // <<
+	tokShiftRight // >>
+)
+
+// Keyword token constants. Values start at 700.
+// mongosh keywords are case-sensitive (unlike SQL).
+const (
+	// --- mongosh top-level objects ---
+	kwDb  = 700 + iota // db
+	kwRs               // rs
+	kwSh               // sh
+	kwSp               // sp
+
+	// --- show command variants ---
+	kwShow         // show
+	kwDbs          // dbs
+	kwDatabases    // databases
+	kwCollections  // collections
+	kwTables       // tables
+	kwProfile      // profile
+	kwUsers        // users
+	kwRoles        // roles
+	kwLog          // log
+	kwLogs         // logs
+	kwStartupWarnings // startupWarnings
+
+	// --- JavaScript literals/keywords ---
+	kwTrue      // true
+	kwFalse     // false
+	kwNull      // null
+	kwUndefined // undefined
+	kwNew       // new
+	kwVar       // var
+	kwLet       // let
+	kwConst     // const
+	kwFunction  // function
+	kwReturn    // return
+	kwIf        // if
+	kwElse      // else
+	kwFor       // for
+	kwWhile     // while
+	kwDo        // do
+	kwBreak     // break
+	kwContinue  // continue
+	kwSwitch    // switch
+	kwCase      // case
+	kwDefault   // default
+	kwThrow     // throw
+	kwTry       // try
+	kwCatch     // catch
+	kwFinally   // finally
+	kwTypeof    // typeof
+	kwInstanceof // instanceof
+	kwVoid      // void
+	kwDelete    // delete
+	kwIn        // in
+	kwOf        // of
+	kwThis      // this
+	kwClass     // class
+	kwExtends   // extends
+	kwSuper     // super
+	kwYield     // yield
+	kwAsync     // async
+	kwAwait     // await
+	kwExport    // export
+	kwImport    // import
+	kwFrom      // from
+
+	// --- BSON helpers ---
+	kwObjectId       // ObjectId
+	kwNumberLong     // NumberLong
+	kwNumberInt      // NumberInt
+	kwNumberDecimal  // NumberDecimal
+	kwTimestamp      // Timestamp
+	kwDate           // Date
+	kwISODate        // ISODate
+	kwUUID           // UUID
+	kwMD5            // MD5
+	kwHexData        // HexData
+	kwBinData        // BinData
+	kwCode           // Code
+	kwDBRef          // DBRef
+	kwMinKey         // MinKey
+	kwMaxKey         // MaxKey
+	kwRegExp         // RegExp
+	kwSymbol         // Symbol
+
+	// --- Collection methods ---
+	kwFind             // find
+	kwFindOne          // findOne
+	kwFindOneAndDelete // findOneAndDelete
+	kwFindOneAndReplace // findOneAndReplace
+	kwFindOneAndUpdate  // findOneAndUpdate
+	kwInsertOne        // insertOne
+	kwInsertMany       // insertMany
+	kwUpdateOne        // updateOne
+	kwUpdateMany       // updateMany
+	kwDeleteOne        // deleteOne
+	kwDeleteMany       // deleteMany
+	kwReplaceOne       // replaceOne
+	kwBulkWrite        // bulkWrite
+	kwAggregate        // aggregate
+	kwCount            // count
+	kwCountDocuments   // countDocuments
+	kwEstimatedDocumentCount // estimatedDocumentCount
+	kwDistinct         // distinct
+	kwMapReduce        // mapReduce
+	kwWatch            // watch
+	kwCreateIndex      // createIndex
+	kwCreateIndexes    // createIndexes
+	kwDropIndex        // dropIndex
+	kwDropIndexes      // dropIndexes
+	kwGetIndexes       // getIndexes
+	kwReIndex          // reIndex
+	kwDrop             // drop
+	kwRenameCollection // renameCollection
+	kwStats            // stats
+	kwDataSize         // dataSize
+	kwStorageSize      // storageSize
+	kwTotalSize        // totalSize
+	kwTotalIndexSize   // totalIndexSize
+	kwValidate         // validate
+	kwExplain          // explain
+	kwGetShardDistribution // getShardDistribution
+	kwLatencyStats     // latencyStats
+
+	// --- Cursor methods ---
+	kwSort      // sort
+	kwLimit     // limit
+	kwSkip      // skip
+	kwToArray   // toArray
+	kwForEach   // forEach
+	kwMap       // map
+	kwHasNext   // hasNext
+	kwNext      // next
+	kwItcount   // itcount
+	kwSize      // size
+	kwPretty    // pretty
+	kwHint      // hint
+	kwMin       // min
+	kwMax       // max
+	kwReadPref  // readPref
+	kwComment   // comment
+	kwBatchSize // batchSize
+	kwClose     // close
+	kwCollation // collation
+	kwNoCursorTimeout // noCursorTimeout
+	kwAllowPartialResults // allowPartialResults
+	kwReturnKey // returnKey
+	kwShowRecordId // showRecordId
+	kwAllowDiskUse // allowDiskUse
+	kwMaxTimeMS // maxTimeMS
+	kwReadConcern // readConcern
+	kwWriteConcern // writeConcern
+	kwTailable  // tailable
+	kwOplogReplay // oplogReplay
+	kwProjection  // projection
+
+	// --- Database methods ---
+	kwGetName                 // getName
+	kwGetSiblingDB            // getSiblingDB
+	kwGetMongo                // getMongo
+	kwGetCollectionNames      // getCollectionNames
+	kwGetCollectionInfos      // getCollectionInfos
+	kwGetCollection           // getCollection
+	kwCreateCollection        // createCollection
+	kwCreateView              // createView
+	kwDropDatabase            // dropDatabase
+	kwAdminCommand            // adminCommand
+	kwRunCommand              // runCommand
+	kwGetProfilingStatus      // getProfilingStatus
+	kwSetProfilingLevel       // setProfilingLevel
+	kwGetLogComponents        // getLogComponents
+	kwSetLogLevel             // setLogLevel
+	kwFsyncLock               // fsyncLock
+	kwFsyncUnlock             // fsyncUnlock
+	kwCurrentOp               // currentOp
+	kwKillOp                  // killOp
+	kwGetUser                 // getUser
+	kwGetUsers                // getUsers
+	kwCreateUser              // createUser
+	kwUpdateUser              // updateUser
+	kwDropUser                // dropUser
+	kwDropAllUsers            // dropAllUsers
+	kwGrantRolesToUser        // grantRolesToUser
+	kwRevokeRolesFromUser     // revokeRolesFromUser
+	kwGetRole                 // getRole
+	kwGetRoles                // getRoles
+	kwCreateRole              // createRole
+	kwUpdateRole              // updateRole
+	kwDropRole                // dropRole
+	kwDropAllRoles            // dropAllRoles
+	kwGrantPrivilegesToRole   // grantPrivilegesToRole
+	kwRevokePrivilegesFromRole // revokePrivilegesFromRole
+	kwGrantRolesToRole        // grantRolesToRole
+	kwRevokeRolesFromRole     // revokeRolesFromRole
+	kwServerStatus            // serverStatus
+	kwIsMaster                // isMaster
+	kwHello                   // hello
+	kwHostInfo                // hostInfo
+
+	// --- Bulk operations ---
+	kwInitializeOrderedBulkOp   // initializeOrderedBulkOp
+	kwInitializeUnorderedBulkOp // initializeUnorderedBulkOp
+	kwInsert                    // insert
+	kwUpdate                    // update
+	kwRemove                    // remove
+	kwExecute                   // execute
+	kwTojson                    // tojson
+	kwToJSON                    // toJSON
+
+	// --- Replica set methods ---
+	kwStatus       // status
+	kwConf         // conf
+	kwConfig       // config
+	kwInitiate     // initiate
+	kwReconfig     // reconfig
+	kwAdd          // add
+	kwAddArb       // addArb
+	kwStepDown     // stepDown
+	kwFreeze       // freeze
+	kwSlaveOk      // slaveOk
+	kwSecondaryOk  // secondaryOk
+	kwSyncFrom     // syncFrom
+	kwPrintReplicationInfo     // printReplicationInfo
+	kwPrintSecondaryReplicationInfo // printSecondaryReplicationInfo
+
+	// --- Sharding methods ---
+	kwAddShard           // addShard
+	kwAddShardTag        // addShardTag
+	kwAddShardToZone     // addShardToZone
+	kwAddTagRange        // addTagRange
+	kwDisableAutoSplit   // disableAutoSplit
+	kwEnableAutoSplit    // enableAutoSplit
+	kwEnableSharding     // enableSharding
+	kwDisableBalancing   // disableBalancing
+	kwEnableBalancing    // enableBalancing
+	kwGetBalancerState   // getBalancerState
+	kwIsBalancerRunning  // isBalancerRunning
+	kwMoveChunk          // moveChunk
+	kwRemoveRangeFromZone // removeRangeFromZone
+	kwRemoveShard        // removeShard
+	kwRemoveShardTag     // removeShardTag
+	kwRemoveShardFromZone // removeShardFromZone
+	kwSetBalancerState   // setBalancerState
+	kwShardCollection    // shardCollection
+	kwSplitAt            // splitAt
+	kwSplitFind          // splitFind
+	kwStartBalancer      // startBalancer
+	kwStopBalancer       // stopBalancer
+	kwUpdateZoneKeyRange // updateZoneKeyRange
+
+	// --- Connection methods ---
+	kwMongo       // Mongo
+	kwConnect     // connect
+
+	// --- Encryption ---
+	kwGetKeyVault          // getKeyVault
+	kwGetClientEncryption  // getClientEncryption
+	kwCreateKey            // createKey
+	kwGetKey               // getKey
+	kwGetKeys              // getKeys
+	kwDeleteKey            // deleteKey
+	kwAddKeyAlternateName  // addKeyAlternateName
+	kwRemoveKeyAlternateName // removeKeyAlternateName
+	kwRewrapManyDataKey    // rewrapManyDataKey
+	kwEncrypt              // encrypt
+	kwDecrypt              // decrypt
+
+	// --- Plan cache ---
+	kwGetPlanCache // getPlanCache
+	kwClear        // clear
+	kwList         // list
+
+	// --- Native mongosh functions ---
+	kwSleep            // sleep
+	kwLoad             // load
+	kwPrint            // print
+	kwPrintjson        // printjson
+	kwQuit             // quit
+	kwExit             // exit
+	kwVersion          // version
+	kwCls              // cls
+	kwHelp             // help
+	kwIt               // it
+	kwUse              // use
+	kwNumberIsNaN      // Number.isNaN
+	kwIsNaN            // isNaN
+	kwIsFinite         // isFinite
+	kwParseInt         // parseInt
+	kwParseFloat       // parseFloat
+	kwEncodeURI        // encodeURI
+	kwEncodeURIComponent // encodeURIComponent
+	kwDecodeURI        // decodeURI
+	kwDecodeURIComponent // decodeURIComponent
+	kwJSON             // JSON
+
+	// --- Misc ---
+	kwConvert       // convert
+	kwTo            // to
+	kwType          // type
+	kwNumber        // Number
+	kwString        // String
+	kwBoolean       // Boolean
+	kwArray         // Array
+	kwObject        // Object
+	kwMath          // Math
+	kwInfinity      // Infinity
+	kwNaN           // NaN
+)
+
+// keywords maps keyword strings to their token types.
+// mongosh keywords are case-sensitive.
+var keywords = map[string]int{
+	// Top-level objects
+	"db": kwDb,
+	"rs": kwRs,
+	"sh": kwSh,
+	"sp": kwSp,
+
+	// show variants
+	"show":            kwShow,
+	"dbs":             kwDbs,
+	"databases":       kwDatabases,
+	"collections":     kwCollections,
+	"tables":          kwTables,
+	"profile":         kwProfile,
+	"users":           kwUsers,
+	"roles":           kwRoles,
+	"log":             kwLog,
+	"logs":            kwLogs,
+	"startupWarnings": kwStartupWarnings,
+
+	// JS literals/keywords
+	"true":       kwTrue,
+	"false":      kwFalse,
+	"null":       kwNull,
+	"undefined":  kwUndefined,
+	"new":        kwNew,
+	"var":        kwVar,
+	"let":        kwLet,
+	"const":      kwConst,
+	"function":   kwFunction,
+	"return":     kwReturn,
+	"if":         kwIf,
+	"else":       kwElse,
+	"for":        kwFor,
+	"while":      kwWhile,
+	"do":         kwDo,
+	"break":      kwBreak,
+	"continue":   kwContinue,
+	"switch":     kwSwitch,
+	"case":       kwCase,
+	"default":    kwDefault,
+	"throw":      kwThrow,
+	"try":        kwTry,
+	"catch":      kwCatch,
+	"finally":    kwFinally,
+	"typeof":     kwTypeof,
+	"instanceof": kwInstanceof,
+	"void":       kwVoid,
+	"delete":     kwDelete,
+	"in":         kwIn,
+	"of":         kwOf,
+	"this":       kwThis,
+	"class":      kwClass,
+	"extends":    kwExtends,
+	"super":      kwSuper,
+	"yield":      kwYield,
+	"async":      kwAsync,
+	"await":      kwAwait,
+	"export":     kwExport,
+	"import":     kwImport,
+	"from":       kwFrom,
+
+	// BSON helpers
+	"ObjectId":      kwObjectId,
+	"NumberLong":    kwNumberLong,
+	"NumberInt":     kwNumberInt,
+	"NumberDecimal": kwNumberDecimal,
+	"Timestamp":     kwTimestamp,
+	"Date":          kwDate,
+	"ISODate":       kwISODate,
+	"UUID":          kwUUID,
+	"MD5":           kwMD5,
+	"HexData":       kwHexData,
+	"BinData":       kwBinData,
+	"Code":          kwCode,
+	"DBRef":         kwDBRef,
+	"MinKey":        kwMinKey,
+	"MaxKey":        kwMaxKey,
+	"RegExp":        kwRegExp,
+	"Symbol":        kwSymbol,
+
+	// Collection methods
+	"find":                    kwFind,
+	"findOne":                 kwFindOne,
+	"findOneAndDelete":        kwFindOneAndDelete,
+	"findOneAndReplace":       kwFindOneAndReplace,
+	"findOneAndUpdate":        kwFindOneAndUpdate,
+	"insertOne":               kwInsertOne,
+	"insertMany":              kwInsertMany,
+	"updateOne":               kwUpdateOne,
+	"updateMany":              kwUpdateMany,
+	"deleteOne":               kwDeleteOne,
+	"deleteMany":              kwDeleteMany,
+	"replaceOne":              kwReplaceOne,
+	"bulkWrite":               kwBulkWrite,
+	"aggregate":               kwAggregate,
+	"count":                   kwCount,
+	"countDocuments":          kwCountDocuments,
+	"estimatedDocumentCount":  kwEstimatedDocumentCount,
+	"distinct":                kwDistinct,
+	"mapReduce":               kwMapReduce,
+	"watch":                   kwWatch,
+	"createIndex":             kwCreateIndex,
+	"createIndexes":           kwCreateIndexes,
+	"dropIndex":               kwDropIndex,
+	"dropIndexes":             kwDropIndexes,
+	"getIndexes":              kwGetIndexes,
+	"reIndex":                 kwReIndex,
+	"drop":                    kwDrop,
+	"renameCollection":        kwRenameCollection,
+	"stats":                   kwStats,
+	"dataSize":                kwDataSize,
+	"storageSize":             kwStorageSize,
+	"totalSize":               kwTotalSize,
+	"totalIndexSize":          kwTotalIndexSize,
+	"validate":                kwValidate,
+	"explain":                 kwExplain,
+	"getShardDistribution":    kwGetShardDistribution,
+	"latencyStats":            kwLatencyStats,
+
+	// Cursor methods
+	"sort":                kwSort,
+	"limit":               kwLimit,
+	"skip":                kwSkip,
+	"toArray":             kwToArray,
+	"forEach":             kwForEach,
+	"map":                 kwMap,
+	"hasNext":             kwHasNext,
+	"next":                kwNext,
+	"itcount":             kwItcount,
+	"size":                kwSize,
+	"pretty":              kwPretty,
+	"hint":                kwHint,
+	"min":                 kwMin,
+	"max":                 kwMax,
+	"readPref":            kwReadPref,
+	"comment":             kwComment,
+	"batchSize":           kwBatchSize,
+	"close":               kwClose,
+	"collation":           kwCollation,
+	"noCursorTimeout":     kwNoCursorTimeout,
+	"allowPartialResults": kwAllowPartialResults,
+	"returnKey":           kwReturnKey,
+	"showRecordId":        kwShowRecordId,
+	"allowDiskUse":        kwAllowDiskUse,
+	"maxTimeMS":           kwMaxTimeMS,
+	"readConcern":         kwReadConcern,
+	"writeConcern":        kwWriteConcern,
+	"tailable":            kwTailable,
+	"oplogReplay":         kwOplogReplay,
+	"projection":          kwProjection,
+
+	// Database methods
+	"getName":            kwGetName,
+	"getSiblingDB":       kwGetSiblingDB,
+	"getMongo":           kwGetMongo,
+	"getCollectionNames": kwGetCollectionNames,
+	"getCollectionInfos": kwGetCollectionInfos,
+	"getCollection":      kwGetCollection,
+	"createCollection":   kwCreateCollection,
+	"createView":         kwCreateView,
+	"dropDatabase":       kwDropDatabase,
+	"adminCommand":       kwAdminCommand,
+	"runCommand":         kwRunCommand,
+	"getProfilingStatus": kwGetProfilingStatus,
+	"setProfilingLevel":  kwSetProfilingLevel,
+	"getLogComponents":   kwGetLogComponents,
+	"setLogLevel":        kwSetLogLevel,
+	"fsyncLock":          kwFsyncLock,
+	"fsyncUnlock":        kwFsyncUnlock,
+	"currentOp":          kwCurrentOp,
+	"killOp":             kwKillOp,
+	"getUser":            kwGetUser,
+	"getUsers":           kwGetUsers,
+	"createUser":         kwCreateUser,
+	"updateUser":         kwUpdateUser,
+	"dropUser":           kwDropUser,
+	"dropAllUsers":       kwDropAllUsers,
+	"grantRolesToUser":   kwGrantRolesToUser,
+	"revokeRolesFromUser": kwRevokeRolesFromUser,
+	"getRole":            kwGetRole,
+	"getRoles":           kwGetRoles,
+	"createRole":         kwCreateRole,
+	"updateRole":         kwUpdateRole,
+	"dropRole":           kwDropRole,
+	"dropAllRoles":       kwDropAllRoles,
+	"grantPrivilegesToRole":   kwGrantPrivilegesToRole,
+	"revokePrivilegesFromRole": kwRevokePrivilegesFromRole,
+	"grantRolesToRole":        kwGrantRolesToRole,
+	"revokeRolesFromRole":     kwRevokeRolesFromRole,
+	"serverStatus":            kwServerStatus,
+	"isMaster":                kwIsMaster,
+	"hello":                   kwHello,
+	"hostInfo":                kwHostInfo,
+
+	// Bulk operations
+	"initializeOrderedBulkOp":   kwInitializeOrderedBulkOp,
+	"initializeUnorderedBulkOp": kwInitializeUnorderedBulkOp,
+	"insert":                    kwInsert,
+	"update":                    kwUpdate,
+	"remove":                    kwRemove,
+	"execute":                   kwExecute,
+	"tojson":                    kwTojson,
+	"toJSON":                    kwToJSON,
+
+	// Replica set methods
+	"status":                          kwStatus,
+	"conf":                            kwConf,
+	"config":                          kwConfig,
+	"initiate":                        kwInitiate,
+	"reconfig":                        kwReconfig,
+	"add":                             kwAdd,
+	"addArb":                          kwAddArb,
+	"stepDown":                        kwStepDown,
+	"freeze":                          kwFreeze,
+	"slaveOk":                         kwSlaveOk,
+	"secondaryOk":                     kwSecondaryOk,
+	"syncFrom":                        kwSyncFrom,
+	"printReplicationInfo":            kwPrintReplicationInfo,
+	"printSecondaryReplicationInfo":   kwPrintSecondaryReplicationInfo,
+
+	// Sharding methods
+	"addShard":            kwAddShard,
+	"addShardTag":         kwAddShardTag,
+	"addShardToZone":      kwAddShardToZone,
+	"addTagRange":         kwAddTagRange,
+	"disableAutoSplit":    kwDisableAutoSplit,
+	"enableAutoSplit":     kwEnableAutoSplit,
+	"enableSharding":      kwEnableSharding,
+	"disableBalancing":    kwDisableBalancing,
+	"enableBalancing":     kwEnableBalancing,
+	"getBalancerState":    kwGetBalancerState,
+	"isBalancerRunning":   kwIsBalancerRunning,
+	"moveChunk":           kwMoveChunk,
+	"removeRangeFromZone": kwRemoveRangeFromZone,
+	"removeShard":         kwRemoveShard,
+	"removeShardTag":      kwRemoveShardTag,
+	"removeShardFromZone": kwRemoveShardFromZone,
+	"setBalancerState":    kwSetBalancerState,
+	"shardCollection":     kwShardCollection,
+	"splitAt":             kwSplitAt,
+	"splitFind":           kwSplitFind,
+	"startBalancer":       kwStartBalancer,
+	"stopBalancer":        kwStopBalancer,
+	"updateZoneKeyRange":  kwUpdateZoneKeyRange,
+
+	// Connection methods
+	"Mongo":   kwMongo,
+	"connect": kwConnect,
+
+	// Encryption
+	"getKeyVault":            kwGetKeyVault,
+	"getClientEncryption":    kwGetClientEncryption,
+	"createKey":              kwCreateKey,
+	"getKey":                 kwGetKey,
+	"getKeys":                kwGetKeys,
+	"deleteKey":              kwDeleteKey,
+	"addKeyAlternateName":    kwAddKeyAlternateName,
+	"removeKeyAlternateName": kwRemoveKeyAlternateName,
+	"rewrapManyDataKey":      kwRewrapManyDataKey,
+	"encrypt":                kwEncrypt,
+	"decrypt":                kwDecrypt,
+
+	// Plan cache
+	"getPlanCache": kwGetPlanCache,
+	"clear":        kwClear,
+	"list":         kwList,
+
+	// Native functions
+	"sleep":                kwSleep,
+	"load":                 kwLoad,
+	"print":                kwPrint,
+	"printjson":            kwPrintjson,
+	"quit":                 kwQuit,
+	"exit":                 kwExit,
+	"version":              kwVersion,
+	"cls":                  kwCls,
+	"help":                 kwHelp,
+	"it":                   kwIt,
+	"use":                  kwUse,
+	"isNaN":                kwIsNaN,
+	"isFinite":             kwIsFinite,
+	"parseInt":             kwParseInt,
+	"parseFloat":           kwParseFloat,
+	"encodeURI":            kwEncodeURI,
+	"encodeURIComponent":   kwEncodeURIComponent,
+	"decodeURI":            kwDecodeURI,
+	"decodeURIComponent":   kwDecodeURIComponent,
+	"JSON":                 kwJSON,
+
+	// Misc
+	"convert":  kwConvert,
+	"to":       kwTo,
+	"type":     kwType,
+	"Number":   kwNumber,
+	"String":   kwString,
+	"Boolean":  kwBoolean,
+	"Array":    kwArray,
+	"Object":   kwObject,
+	"Math":     kwMath,
+	"Infinity": kwInfinity,
+	"NaN":      kwNaN,
+}
+
+// tokenName returns a human-readable name for a token type, used in error messages.
+func tokenName(t int) string {
+	switch {
+	case t == tokEOF:
+		return "end of input"
+	case t == tokNumber:
+		return "number"
+	case t == tokString:
+		return "string"
+	case t == tokRegex:
+		return "regex"
+	case t == tokIdent:
+		return "identifier"
+	case t == tokEqEq:
+		return "=="
+	case t == tokNotEq:
+		return "!="
+	case t == tokNotEqEq:
+		return "!=="
+	case t == tokEqEqEq:
+		return "==="
+	case t == tokLessEq:
+		return "<="
+	case t == tokGreaterEq:
+		return ">="
+	case t == tokAnd:
+		return "&&"
+	case t == tokOr:
+		return "||"
+	case t == tokArrow:
+		return "=>"
+	case t == tokSpread:
+		return "..."
+	case t == tokOptChain:
+		return "?."
+	case t == tokNullCoal:
+		return "??"
+	case t == tokPlusPlus:
+		return "++"
+	case t == tokMinusMinus:
+		return "--"
+	case t == tokPlusEq:
+		return "+="
+	case t == tokMinusEq:
+		return "-="
+	case t == tokStarEq:
+		return "*="
+	case t == tokSlashEq:
+		return "/="
+	case t == tokPercentEq:
+		return "%="
+	case t == tokPower:
+		return "**"
+	case t == tokShiftLeft:
+		return "<<"
+	case t == tokShiftRight:
+		return ">>"
+	case t >= 700:
+		// keyword — find by reverse lookup
+		for name, v := range keywords {
+			if v == t {
+				return name
+			}
+		}
+		return "keyword"
+	case t > 0 && t < 128:
+		return string(rune(t))
+	default:
+		return "?"
+	}
+}

--- a/mongo/parsertest/antlr_compat_test.go
+++ b/mongo/parsertest/antlr_compat_test.go
@@ -1,0 +1,77 @@
+package parsertest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mongo "github.com/bytebase/omni/mongo"
+)
+
+// TestANTLRExampleFiles reads every .js file from the ANTLR example directory,
+// parses it through mongo.Parse(), and validates that:
+//  1. No error is returned.
+//  2. At least one statement is produced.
+//  3. Every statement has valid position tracking.
+func TestANTLRExampleFiles(t *testing.T) {
+	dir := "/Users/h3n4l/OpenSource/parser/mongodb/examples"
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("cannot read examples directory: %v", err)
+	}
+
+	var jsFiles []os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".js") {
+			jsFiles = append(jsFiles, e)
+		}
+	}
+	if len(jsFiles) == 0 {
+		t.Fatal("no .js files found in examples directory")
+	}
+
+	t.Logf("Found %d .js example files", len(jsFiles))
+
+	passed := 0
+	failed := 0
+
+	for _, f := range jsFiles {
+		name := f.Name()
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, name)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("cannot read file: %v", err)
+			}
+			content := string(data)
+
+			stmts, err := mongo.Parse(content)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+
+			if len(stmts) == 0 {
+				t.Fatal("expected at least one statement, got 0")
+			}
+
+			for i, s := range stmts {
+				if s.ByteStart < 0 {
+					t.Errorf("stmt[%d] ByteStart = %d, want >= 0", i, s.ByteStart)
+				}
+				if s.ByteEnd <= s.ByteStart {
+					t.Errorf("stmt[%d] ByteEnd = %d <= ByteStart = %d", i, s.ByteEnd, s.ByteStart)
+				}
+				if s.Start.Line < 1 {
+					t.Errorf("stmt[%d] Start.Line = %d, want >= 1", i, s.Start.Line)
+				}
+				if s.Start.Column < 1 {
+					t.Errorf("stmt[%d] Start.Column = %d, want >= 1", i, s.Start.Column)
+				}
+			}
+		})
+	}
+
+	t.Logf("Results: %d passed, %d failed out of %d total", passed, failed, len(jsFiles))
+}

--- a/mongo/parsertest/bulk_test.go
+++ b/mongo/parsertest/bulk_test.go
@@ -1,0 +1,118 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestBulkOrderedInit(t *testing.T) {
+	node := mustParse(t, `db.users.initializeOrderedBulkOp()`)
+	stmt := node.(*ast.BulkStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if !stmt.Ordered {
+		t.Error("expected ordered to be true")
+	}
+	if stmt.AccessMethod != "dot" {
+		t.Errorf("expected access method 'dot', got %q", stmt.AccessMethod)
+	}
+	if len(stmt.Operations) != 0 {
+		t.Errorf("expected 0 operations, got %d", len(stmt.Operations))
+	}
+}
+
+func TestBulkUnorderedInit(t *testing.T) {
+	node := mustParse(t, `db.users.initializeUnorderedBulkOp()`)
+	stmt := node.(*ast.BulkStatement)
+	if stmt.Ordered {
+		t.Error("expected ordered to be false")
+	}
+}
+
+func TestBulkInsert(t *testing.T) {
+	node := mustParse(t, `db.users.initializeUnorderedBulkOp().insert({ name: "alice" })`)
+	stmt := node.(*ast.BulkStatement)
+	if len(stmt.Operations) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(stmt.Operations))
+	}
+	if stmt.Operations[0].Method != "insert" {
+		t.Errorf("expected operation 'insert', got %q", stmt.Operations[0].Method)
+	}
+}
+
+func TestBulkMultipleInserts(t *testing.T) {
+	node := mustParse(t, `db.users.initializeOrderedBulkOp().insert({ name: "bob" }).insert({ name: "charlie" })`)
+	stmt := node.(*ast.BulkStatement)
+	if len(stmt.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(stmt.Operations))
+	}
+	if stmt.Operations[0].Method != "insert" || stmt.Operations[1].Method != "insert" {
+		t.Error("expected both operations to be 'insert'")
+	}
+}
+
+func TestBulkInsertAndExecute(t *testing.T) {
+	node := mustParse(t, `db.users.initializeOrderedBulkOp().insert({ name: "grace" }).execute()`)
+	stmt := node.(*ast.BulkStatement)
+	if len(stmt.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(stmt.Operations))
+	}
+	if stmt.Operations[1].Method != "execute" {
+		t.Errorf("expected 'execute', got %q", stmt.Operations[1].Method)
+	}
+}
+
+func TestBulkExecuteWithWriteConcern(t *testing.T) {
+	node := mustParse(t, `db.users.initializeOrderedBulkOp().insert({ name: "bob" }).execute({ w: "majority" })`)
+	stmt := node.(*ast.BulkStatement)
+	if len(stmt.Operations) != 2 {
+		t.Fatalf("expected 2 operations, got %d", len(stmt.Operations))
+	}
+	if stmt.Operations[1].Method != "execute" {
+		t.Errorf("expected 'execute', got %q", stmt.Operations[1].Method)
+	}
+	if len(stmt.Operations[1].Args) != 1 {
+		t.Errorf("expected 1 arg for execute, got %d", len(stmt.Operations[1].Args))
+	}
+}
+
+func TestBulkFindRemove(t *testing.T) {
+	node := mustParse(t, `db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).remove().execute()`)
+	stmt := node.(*ast.BulkStatement)
+	if len(stmt.Operations) != 3 {
+		t.Fatalf("expected 3 operations, got %d", len(stmt.Operations))
+	}
+	if stmt.Operations[0].Method != "find" {
+		t.Errorf("expected 'find', got %q", stmt.Operations[0].Method)
+	}
+	if stmt.Operations[1].Method != "remove" {
+		t.Errorf("expected 'remove', got %q", stmt.Operations[1].Method)
+	}
+	if stmt.Operations[2].Method != "execute" {
+		t.Errorf("expected 'execute', got %q", stmt.Operations[2].Method)
+	}
+}
+
+func TestBulkGetCollectionAccess(t *testing.T) {
+	node := mustParse(t, `db.getCollection("users").initializeOrderedBulkOp()`)
+	stmt := node.(*ast.BulkStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "getCollection" {
+		t.Errorf("expected access method 'getCollection', got %q", stmt.AccessMethod)
+	}
+}
+
+func TestBulkBracketAccess(t *testing.T) {
+	node := mustParse(t, `db["users"].initializeOrderedBulkOp()`)
+	stmt := node.(*ast.BulkStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "bracket" {
+		t.Errorf("expected access method 'bracket', got %q", stmt.AccessMethod)
+	}
+}

--- a/mongo/parsertest/collection_test.go
+++ b/mongo/parsertest/collection_test.go
@@ -1,0 +1,309 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestBasicFind(t *testing.T) {
+	node := mustParse(t, `db.users.find({name: "alice"})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if stmt.Method != "find" {
+		t.Errorf("expected method 'find', got %q", stmt.Method)
+	}
+	if stmt.AccessMethod != "dot" {
+		t.Errorf("expected access method 'dot', got %q", stmt.AccessMethod)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestFindWithProjection(t *testing.T) {
+	node := mustParse(t, `db.users.find({}, {name: 1, _id: 0})`)
+	stmt := node.(*ast.CollectionStatement)
+	if len(stmt.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestFindWithCursorChain(t *testing.T) {
+	node := mustParse(t, `db.users.find({}).sort({name: 1}).limit(10).skip(5)`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "find" {
+		t.Errorf("expected 'find', got %q", stmt.Method)
+	}
+	if len(stmt.CursorMethods) != 3 {
+		t.Fatalf("expected 3 cursor methods, got %d", len(stmt.CursorMethods))
+	}
+	if stmt.CursorMethods[0].Method != "sort" {
+		t.Errorf("expected 'sort', got %q", stmt.CursorMethods[0].Method)
+	}
+	if stmt.CursorMethods[1].Method != "limit" {
+		t.Errorf("expected 'limit', got %q", stmt.CursorMethods[1].Method)
+	}
+	if stmt.CursorMethods[2].Method != "skip" {
+		t.Errorf("expected 'skip', got %q", stmt.CursorMethods[2].Method)
+	}
+}
+
+func TestFindOne(t *testing.T) {
+	node := mustParse(t, `db.users.findOne({_id: 1})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "findOne" {
+		t.Errorf("expected 'findOne', got %q", stmt.Method)
+	}
+}
+
+func TestInsertOne(t *testing.T) {
+	node := mustParse(t, `db.users.insertOne({name: "bob", age: 25})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "insertOne" {
+		t.Errorf("expected 'insertOne', got %q", stmt.Method)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestInsertMany(t *testing.T) {
+	node := mustParse(t, `db.users.insertMany([{name: "a"}, {name: "b"}])`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "insertMany" {
+		t.Errorf("expected 'insertMany', got %q", stmt.Method)
+	}
+}
+
+func TestUpdateOne(t *testing.T) {
+	node := mustParse(t, `db.users.updateOne({name: "alice"}, {$set: {age: 30}})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "updateOne" {
+		t.Errorf("expected 'updateOne', got %q", stmt.Method)
+	}
+	if len(stmt.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestDeleteOne(t *testing.T) {
+	node := mustParse(t, `db.users.deleteOne({name: "alice"})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "deleteOne" {
+		t.Errorf("expected 'deleteOne', got %q", stmt.Method)
+	}
+}
+
+func TestDeleteMany(t *testing.T) {
+	node := mustParse(t, `db.users.deleteMany({status: "inactive"})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "deleteMany" {
+		t.Errorf("expected 'deleteMany', got %q", stmt.Method)
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	node := mustParse(t, `db.orders.aggregate([{$match: {status: "A"}}, {$group: {_id: "$cust_id", total: {$sum: "$amount"}}}])`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "aggregate" {
+		t.Errorf("expected 'aggregate', got %q", stmt.Method)
+	}
+}
+
+func TestCreateIndex(t *testing.T) {
+	node := mustParse(t, `db.users.createIndex({name: 1})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "createIndex" {
+		t.Errorf("expected 'createIndex', got %q", stmt.Method)
+	}
+}
+
+func TestDropIndex(t *testing.T) {
+	node := mustParse(t, `db.users.dropIndex("name_1")`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "dropIndex" {
+		t.Errorf("expected 'dropIndex', got %q", stmt.Method)
+	}
+}
+
+func TestGetIndexes(t *testing.T) {
+	node := mustParse(t, `db.users.getIndexes()`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "getIndexes" {
+		t.Errorf("expected 'getIndexes', got %q", stmt.Method)
+	}
+	if len(stmt.Args) != 0 {
+		t.Errorf("expected 0 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestExplainPrefix(t *testing.T) {
+	node := mustParse(t, `db.users.explain().find({name: "alice"})`)
+	stmt := node.(*ast.CollectionStatement)
+	if !stmt.Explain {
+		t.Error("expected explain to be true")
+	}
+	if stmt.Method != "find" {
+		t.Errorf("expected 'find', got %q", stmt.Method)
+	}
+}
+
+func TestExplainWithArg(t *testing.T) {
+	node := mustParse(t, `db.users.explain("executionStats").find({})`)
+	stmt := node.(*ast.CollectionStatement)
+	if !stmt.Explain {
+		t.Error("expected explain to be true")
+	}
+	if len(stmt.ExplainArgs) != 1 {
+		t.Fatalf("expected 1 explain arg, got %d", len(stmt.ExplainArgs))
+	}
+	s := stmt.ExplainArgs[0].(*ast.StringLiteral)
+	if s.Value != "executionStats" {
+		t.Errorf("expected 'executionStats', got %q", s.Value)
+	}
+	if stmt.Method != "find" {
+		t.Errorf("expected 'find', got %q", stmt.Method)
+	}
+}
+
+func TestGetCollectionAccess(t *testing.T) {
+	node := mustParse(t, `db.getCollection("my-coll").find({})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Collection != "my-coll" {
+		t.Errorf("expected 'my-coll', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "getCollection" {
+		t.Errorf("expected 'getCollection', got %q", stmt.AccessMethod)
+	}
+	if stmt.Method != "find" {
+		t.Errorf("expected 'find', got %q", stmt.Method)
+	}
+}
+
+func TestBracketAccess(t *testing.T) {
+	node := mustParse(t, `db["my-coll"].find({})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Collection != "my-coll" {
+		t.Errorf("expected 'my-coll', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "bracket" {
+		t.Errorf("expected 'bracket', got %q", stmt.AccessMethod)
+	}
+}
+
+func TestBracketAccessSingleQuote(t *testing.T) {
+	node := mustParse(t, `db['my-coll'].find({})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Collection != "my-coll" {
+		t.Errorf("expected 'my-coll', got %q", stmt.Collection)
+	}
+}
+
+func TestCountDocuments(t *testing.T) {
+	node := mustParse(t, `db.users.countDocuments({active: true})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "countDocuments" {
+		t.Errorf("expected 'countDocuments', got %q", stmt.Method)
+	}
+}
+
+func TestDistinct(t *testing.T) {
+	node := mustParse(t, `db.users.distinct("name", {active: true})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "distinct" {
+		t.Errorf("expected 'distinct', got %q", stmt.Method)
+	}
+	if len(stmt.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestFindCursorToArray(t *testing.T) {
+	node := mustParse(t, `db.users.find({}).toArray()`)
+	stmt := node.(*ast.CollectionStatement)
+	if len(stmt.CursorMethods) != 1 {
+		t.Fatalf("expected 1 cursor method, got %d", len(stmt.CursorMethods))
+	}
+	if stmt.CursorMethods[0].Method != "toArray" {
+		t.Errorf("expected 'toArray', got %q", stmt.CursorMethods[0].Method)
+	}
+}
+
+func TestReplaceOne(t *testing.T) {
+	node := mustParse(t, `db.users.replaceOne({_id: 1}, {name: "new"})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "replaceOne" {
+		t.Errorf("expected 'replaceOne', got %q", stmt.Method)
+	}
+}
+
+func TestDrop(t *testing.T) {
+	node := mustParse(t, `db.users.drop()`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "drop" {
+		t.Errorf("expected 'drop', got %q", stmt.Method)
+	}
+}
+
+func TestDatabaseMethod(t *testing.T) {
+	node := mustParse(t, `db.getCollectionNames()`)
+	stmt := node.(*ast.DatabaseStatement)
+	if stmt.Method != "getCollectionNames" {
+		t.Errorf("expected 'getCollectionNames', got %q", stmt.Method)
+	}
+}
+
+func TestDatabaseDropDatabase(t *testing.T) {
+	node := mustParse(t, `db.dropDatabase()`)
+	stmt := node.(*ast.DatabaseStatement)
+	if stmt.Method != "dropDatabase" {
+		t.Errorf("expected 'dropDatabase', got %q", stmt.Method)
+	}
+}
+
+func TestDatabaseRunCommand(t *testing.T) {
+	node := mustParse(t, `db.runCommand({ping: 1})`)
+	stmt := node.(*ast.DatabaseStatement)
+	if stmt.Method != "runCommand" {
+		t.Errorf("expected 'runCommand', got %q", stmt.Method)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestDatabaseCreateCollection(t *testing.T) {
+	node := mustParse(t, `db.createCollection("test")`)
+	stmt := node.(*ast.DatabaseStatement)
+	if stmt.Method != "createCollection" {
+		t.Errorf("expected 'createCollection', got %q", stmt.Method)
+	}
+}
+
+func TestDatabaseGetSiblingDB(t *testing.T) {
+	node := mustParse(t, `db.getSiblingDB("admin")`)
+	stmt := node.(*ast.DatabaseStatement)
+	if stmt.Method != "getSiblingDB" {
+		t.Errorf("expected 'getSiblingDB', got %q", stmt.Method)
+	}
+}
+
+func TestCollectionStatementLoc(t *testing.T) {
+	node := mustParse(t, `db.c.find({})`)
+	assertLoc(t, node, 0, 13)
+}
+
+func TestMultipleStatements(t *testing.T) {
+	nodes := mustParseN(t, `db.a.find({}); db.b.insertOne({x: 1})`, 2)
+	s1 := nodes[0].(*ast.CollectionStatement)
+	s2 := nodes[1].(*ast.CollectionStatement)
+	if s1.Collection != "a" || s1.Method != "find" {
+		t.Errorf("statement 1: expected a.find, got %s.%s", s1.Collection, s1.Method)
+	}
+	if s2.Collection != "b" || s2.Method != "insertOne" {
+		t.Errorf("statement 2: expected b.insertOne, got %s.%s", s2.Collection, s2.Method)
+	}
+}

--- a/mongo/parsertest/comment_test.go
+++ b/mongo/parsertest/comment_test.go
@@ -1,0 +1,97 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/parser"
+)
+
+func TestComments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int // expected number of statements
+	}{
+		{
+			name:  "line comment before statement",
+			input: "// this is a comment\ndb.users.find()",
+			want:  1,
+		},
+		{
+			name:  "line comment after statement",
+			input: "db.users.find() // trailing comment",
+			want:  1,
+		},
+		{
+			name:  "block comment before statement",
+			input: "/* block */ db.users.find()",
+			want:  1,
+		},
+		{
+			name:  "block comment after statement",
+			input: "db.users.find() /* trailing */",
+			want:  1,
+		},
+		{
+			name:  "multiline block comment",
+			input: "/*\n * multi\n * line\n */\ndb.users.find()",
+			want:  1,
+		},
+		{
+			name:  "comment between statements",
+			input: "db.users.find()\n// separator\ndb.orders.find()",
+			want:  2,
+		},
+		{
+			name:  "block comment between statements",
+			input: "db.users.find()\n/* gap */\ndb.orders.find()",
+			want:  2,
+		},
+		{
+			name:  "only comments no statements",
+			input: "// just a comment\n/* another one */",
+			want:  0,
+		},
+		{
+			name: "comment inside document value (as string)",
+			input: `db.users.insertOne({ note: "// not a comment" })`,
+			want:  1,
+		},
+		{
+			name: "comment inside string single quotes",
+			input: `db.users.insertOne({ note: '/* not a comment */' })`,
+			want:  1,
+		},
+		{
+			name:  "inline comment in argument list",
+			input: "db.users.find(\n  { name: \"alice\" } /* filter */,\n  { _id: 0 } // projection\n)",
+			want:  1,
+		},
+		{
+			name:  "comment inside nested document",
+			input: "db.users.find({\n  // match active users\n  status: \"active\",\n  /* check age */\n  age: { $gt: 18 }\n})",
+			want:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tc.input)
+			if tc.want == 0 {
+				if err != nil {
+					t.Fatalf("parse error: %v", err)
+				}
+				if len(nodes) != 0 {
+					t.Errorf("expected 0 nodes, got %d", len(nodes))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if len(nodes) != tc.want {
+				t.Errorf("expected %d nodes, got %d", tc.want, len(nodes))
+			}
+		})
+	}
+}

--- a/mongo/parsertest/connection_test.go
+++ b/mongo/parsertest/connection_test.go
@@ -1,0 +1,95 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestMongoBasic(t *testing.T) {
+	node := mustParse(t, `Mongo()`)
+	stmt := node.(*ast.ConnectionStatement)
+	if stmt.Constructor != "Mongo" {
+		t.Errorf("expected constructor 'Mongo', got %q", stmt.Constructor)
+	}
+	if len(stmt.Args) != 0 {
+		t.Errorf("expected 0 args, got %d", len(stmt.Args))
+	}
+	if len(stmt.ChainedMethods) != 0 {
+		t.Errorf("expected 0 chained methods, got %d", len(stmt.ChainedMethods))
+	}
+}
+
+func TestMongoWithArg(t *testing.T) {
+	node := mustParse(t, `Mongo("localhost:27017")`)
+	stmt := node.(*ast.ConnectionStatement)
+	if stmt.Constructor != "Mongo" {
+		t.Errorf("expected constructor 'Mongo', got %q", stmt.Constructor)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestMongoGetDB(t *testing.T) {
+	node := mustParse(t, `Mongo().getDB("test")`)
+	stmt := node.(*ast.ConnectionStatement)
+	if stmt.Constructor != "Mongo" {
+		t.Errorf("expected constructor 'Mongo', got %q", stmt.Constructor)
+	}
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "getDB" {
+		t.Errorf("expected chained method 'getDB', got %q", stmt.ChainedMethods[0].Name)
+	}
+}
+
+func TestMongoChainMultiple(t *testing.T) {
+	node := mustParse(t, `Mongo("localhost").getDB("mydb").getCollectionNames()`)
+	stmt := node.(*ast.ConnectionStatement)
+	if len(stmt.ChainedMethods) != 2 {
+		t.Fatalf("expected 2 chained methods, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "getDB" {
+		t.Errorf("expected 'getDB', got %q", stmt.ChainedMethods[0].Name)
+	}
+	if stmt.ChainedMethods[1].Name != "getCollectionNames" {
+		t.Errorf("expected 'getCollectionNames', got %q", stmt.ChainedMethods[1].Name)
+	}
+}
+
+func TestConnectBasic(t *testing.T) {
+	node := mustParse(t, `connect()`)
+	stmt := node.(*ast.ConnectionStatement)
+	if stmt.Constructor != "connect" {
+		t.Errorf("expected constructor 'connect', got %q", stmt.Constructor)
+	}
+}
+
+func TestConnectWithURL(t *testing.T) {
+	node := mustParse(t, `connect("mongodb://localhost:27017/test")`)
+	stmt := node.(*ast.ConnectionStatement)
+	if stmt.Constructor != "connect" {
+		t.Errorf("expected constructor 'connect', got %q", stmt.Constructor)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestConnectWithChain(t *testing.T) {
+	node := mustParse(t, `connect("localhost").getDB("test")`)
+	stmt := node.(*ast.ConnectionStatement)
+	if stmt.Constructor != "connect" {
+		t.Errorf("expected constructor 'connect', got %q", stmt.Constructor)
+	}
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+}
+
+func TestMongoLoc(t *testing.T) {
+	node := mustParse(t, `Mongo()`)
+	assertLoc(t, node, 0, 7)
+}

--- a/mongo/parsertest/document_test.go
+++ b/mongo/parsertest/document_test.go
@@ -1,0 +1,138 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestEmptyDocument(t *testing.T) {
+	node := mustParse(t, `db.c.find({})`)
+	stmt := node.(*ast.CollectionStatement)
+	doc := stmt.Args[0].(*ast.Document)
+	if len(doc.Pairs) != 0 {
+		t.Errorf("expected 0 pairs, got %d", len(doc.Pairs))
+	}
+}
+
+func TestUnquotedKeys(t *testing.T) {
+	node := mustParse(t, `db.c.find({name: "alice", age: 30})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 2 {
+		t.Fatalf("expected 2 pairs, got %d", len(doc.Pairs))
+	}
+	if doc.Pairs[0].Key != "name" {
+		t.Errorf("expected key 'name', got %q", doc.Pairs[0].Key)
+	}
+	if doc.Pairs[1].Key != "age" {
+		t.Errorf("expected key 'age', got %q", doc.Pairs[1].Key)
+	}
+}
+
+func TestQuotedKeys(t *testing.T) {
+	node := mustParse(t, `db.c.find({"first name": "alice", 'last-name': "smith"})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 2 {
+		t.Fatalf("expected 2 pairs, got %d", len(doc.Pairs))
+	}
+	if doc.Pairs[0].Key != "first name" {
+		t.Errorf("expected key 'first name', got %q", doc.Pairs[0].Key)
+	}
+	if doc.Pairs[1].Key != "last-name" {
+		t.Errorf("expected key 'last-name', got %q", doc.Pairs[1].Key)
+	}
+}
+
+func TestDollarKeys(t *testing.T) {
+	node := mustParse(t, `db.c.find({$gt: 5, $in: [1, 2]})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 2 {
+		t.Fatalf("expected 2 pairs, got %d", len(doc.Pairs))
+	}
+	if doc.Pairs[0].Key != "$gt" {
+		t.Errorf("expected key '$gt', got %q", doc.Pairs[0].Key)
+	}
+	if doc.Pairs[1].Key != "$in" {
+		t.Errorf("expected key '$in', got %q", doc.Pairs[1].Key)
+	}
+}
+
+func TestTrailingComma(t *testing.T) {
+	node := mustParse(t, `db.c.find({a: 1, b: 2,})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 2 {
+		t.Errorf("expected 2 pairs, got %d", len(doc.Pairs))
+	}
+}
+
+func TestNestedDocument(t *testing.T) {
+	node := mustParse(t, `db.c.find({a: {b: {c: 1}}})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(doc.Pairs))
+	}
+	inner := doc.Pairs[0].Value.(*ast.Document)
+	if len(inner.Pairs) != 1 {
+		t.Fatalf("expected 1 inner pair, got %d", len(inner.Pairs))
+	}
+	deepest := inner.Pairs[0].Value.(*ast.Document)
+	if len(deepest.Pairs) != 1 {
+		t.Fatalf("expected 1 deepest pair, got %d", len(deepest.Pairs))
+	}
+	num := deepest.Pairs[0].Value.(*ast.NumberLiteral)
+	if num.Value != "1" {
+		t.Errorf("expected 1, got %s", num.Value)
+	}
+}
+
+func TestKeywordAsKey(t *testing.T) {
+	// Keywords like "find", "sort", "limit" can appear as document keys
+	node := mustParse(t, `db.c.find({sort: 1, limit: 10, find: true})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 3 {
+		t.Fatalf("expected 3 pairs, got %d", len(doc.Pairs))
+	}
+	if doc.Pairs[0].Key != "sort" {
+		t.Errorf("expected key 'sort', got %q", doc.Pairs[0].Key)
+	}
+	if doc.Pairs[1].Key != "limit" {
+		t.Errorf("expected key 'limit', got %q", doc.Pairs[1].Key)
+	}
+	if doc.Pairs[2].Key != "find" {
+		t.Errorf("expected key 'find', got %q", doc.Pairs[2].Key)
+	}
+}
+
+func TestMixedKeys(t *testing.T) {
+	node := mustParse(t, `db.c.insertOne({_id: 1, "name": "test", $set: true})`)
+	stmt := node.(*ast.CollectionStatement)
+	doc := stmt.Args[0].(*ast.Document)
+	if len(doc.Pairs) != 3 {
+		t.Fatalf("expected 3 pairs, got %d", len(doc.Pairs))
+	}
+	if doc.Pairs[0].Key != "_id" {
+		t.Errorf("expected '_id', got %q", doc.Pairs[0].Key)
+	}
+	if doc.Pairs[1].Key != "name" {
+		t.Errorf("expected 'name', got %q", doc.Pairs[1].Key)
+	}
+	if doc.Pairs[2].Key != "$set" {
+		t.Errorf("expected '$set', got %q", doc.Pairs[2].Key)
+	}
+}
+
+func TestDocumentWithArrayValue(t *testing.T) {
+	node := mustParse(t, `db.c.find({tags: ["a", "b"], score: {$gt: 5}})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	if len(doc.Pairs) != 2 {
+		t.Fatalf("expected 2 pairs, got %d", len(doc.Pairs))
+	}
+	arr := doc.Pairs[0].Value.(*ast.Array)
+	if len(arr.Elements) != 2 {
+		t.Errorf("expected 2 array elements, got %d", len(arr.Elements))
+	}
+	inner := doc.Pairs[1].Value.(*ast.Document)
+	if inner.Pairs[0].Key != "$gt" {
+		t.Errorf("expected '$gt', got %q", inner.Pairs[0].Key)
+	}
+}

--- a/mongo/parsertest/encryption_test.go
+++ b/mongo/parsertest/encryption_test.go
@@ -1,0 +1,96 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestEncryptionGetKeyVault(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getKeyVault()`)
+	stmt := node.(*ast.EncryptionStatement)
+	if stmt.Target != "keyVault" {
+		t.Errorf("expected target 'keyVault', got %q", stmt.Target)
+	}
+	if len(stmt.ChainedMethods) != 0 {
+		t.Errorf("expected 0 chained methods, got %d", len(stmt.ChainedMethods))
+	}
+}
+
+func TestEncryptionGetKeyVaultGetKeys(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getKeyVault().getKeys()`)
+	stmt := node.(*ast.EncryptionStatement)
+	if stmt.Target != "keyVault" {
+		t.Errorf("expected target 'keyVault', got %q", stmt.Target)
+	}
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "getKeys" {
+		t.Errorf("expected 'getKeys', got %q", stmt.ChainedMethods[0].Name)
+	}
+}
+
+func TestEncryptionCreateKey(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getKeyVault().createKey("local")`)
+	stmt := node.(*ast.EncryptionStatement)
+	if stmt.Target != "keyVault" {
+		t.Errorf("expected target 'keyVault', got %q", stmt.Target)
+	}
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "createKey" {
+		t.Errorf("expected 'createKey', got %q", stmt.ChainedMethods[0].Name)
+	}
+	if len(stmt.ChainedMethods[0].Args) != 1 {
+		t.Errorf("expected 1 arg, got %d", len(stmt.ChainedMethods[0].Args))
+	}
+}
+
+func TestEncryptionGetClientEncryption(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getClientEncryption()`)
+	stmt := node.(*ast.EncryptionStatement)
+	if stmt.Target != "clientEncryption" {
+		t.Errorf("expected target 'clientEncryption', got %q", stmt.Target)
+	}
+}
+
+func TestEncryptionEncrypt(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getClientEncryption().encrypt(UUID("key-id"), "secret", "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic")`)
+	stmt := node.(*ast.EncryptionStatement)
+	if stmt.Target != "clientEncryption" {
+		t.Errorf("expected target 'clientEncryption', got %q", stmt.Target)
+	}
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "encrypt" {
+		t.Errorf("expected 'encrypt', got %q", stmt.ChainedMethods[0].Name)
+	}
+}
+
+func TestEncryptionDecrypt(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getClientEncryption().decrypt(BinData(6, "base64data"))`)
+	stmt := node.(*ast.EncryptionStatement)
+	if stmt.Target != "clientEncryption" {
+		t.Errorf("expected target 'clientEncryption', got %q", stmt.Target)
+	}
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "decrypt" {
+		t.Errorf("expected 'decrypt', got %q", stmt.ChainedMethods[0].Name)
+	}
+}
+
+func TestEncryptionCreateKeyWithKMS(t *testing.T) {
+	node := mustParse(t, `db.getMongo().getKeyVault().createKey("aws", { region: "us-east-1", key: "arn:aws:kms:..." })`)
+	stmt := node.(*ast.EncryptionStatement)
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if len(stmt.ChainedMethods[0].Args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(stmt.ChainedMethods[0].Args))
+	}
+}

--- a/mongo/parsertest/error_test.go
+++ b/mongo/parsertest/error_test.go
@@ -1,0 +1,120 @@
+package parsertest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mongo/parser"
+)
+
+func TestParseErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty method", "db.users."},
+		{"missing parens", "db.users.find"},
+		{"unclosed brace", `db.users.find({name: "alice")`},
+		{"unclosed bracket", `db.users.find([1, 2, 3)`},
+		{"unknown top-level", "foobar"},
+		{"invalid show target", "show something"},
+		{"missing collection", "db..find()"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parser.Parse(tc.input)
+			if err == nil {
+				t.Fatalf("expected parse error for input: %s", tc.input)
+			}
+			var pe *parser.ParseError
+			if !errors.As(err, &pe) {
+				t.Fatalf("expected *parser.ParseError, got %T: %v", err, err)
+			}
+			if pe.Line < 1 {
+				t.Errorf("expected Line >= 1, got %d", pe.Line)
+			}
+			if pe.Column < 1 {
+				t.Errorf("expected Column >= 1, got %d", pe.Column)
+			}
+			if pe.Message == "" {
+				t.Error("expected non-empty error message")
+			}
+		})
+	}
+}
+
+func TestNewKeywordErrorMessage(t *testing.T) {
+	input := `db.users.find({_id: new ObjectId("abc")})`
+	_, err := parser.Parse(input)
+	if err == nil {
+		t.Fatal("expected parse error for 'new' keyword")
+	}
+	var pe *parser.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *parser.ParseError, got %T: %v", err, err)
+	}
+	if !strings.Contains(pe.Message, "new") {
+		t.Errorf("expected error message to mention 'new', got: %s", pe.Message)
+	}
+	// "new" is at column 21 (0-indexed: 20)
+	if pe.Line != 1 {
+		t.Errorf("expected line 1, got %d", pe.Line)
+	}
+}
+
+func TestErrorPosition(t *testing.T) {
+	// The error should point to the problematic token.
+	input := "show something"
+	_, err := parser.Parse(input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *parser.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *parser.ParseError, got %T", err)
+	}
+	// Error should be on line 1
+	if pe.Line != 1 {
+		t.Errorf("expected line 1, got %d", pe.Line)
+	}
+}
+
+func TestErrorOnSecondLine(t *testing.T) {
+	input := "show dbs\nfoobar"
+	_, err := parser.Parse(input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *parser.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *parser.ParseError, got %T", err)
+	}
+	if pe.Line != 2 {
+		t.Errorf("expected line 2, got %d", pe.Line)
+	}
+	if pe.Column != 1 {
+		t.Errorf("expected column 1, got %d", pe.Column)
+	}
+}
+
+func TestEmptyInput(t *testing.T) {
+	nodes, err := parser.Parse("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Errorf("expected 0 nodes, got %d", len(nodes))
+	}
+}
+
+func TestOnlySemicolons(t *testing.T) {
+	nodes, err := parser.Parse(";;;")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Errorf("expected 0 nodes, got %d", len(nodes))
+	}
+}

--- a/mongo/parsertest/expression_test.go
+++ b/mongo/parsertest/expression_test.go
@@ -1,0 +1,213 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestStringLiteral(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: "hello"})`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "find" {
+		t.Fatalf("expected find, got %s", stmt.Method)
+	}
+	doc := stmt.Args[0].(*ast.Document)
+	val := doc.Pairs[0].Value.(*ast.StringLiteral)
+	if val.Value != "hello" {
+		t.Errorf("expected 'hello', got %q", val.Value)
+	}
+}
+
+func TestNumberLiteralInt(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: 42})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	val := doc.Pairs[0].Value.(*ast.NumberLiteral)
+	if val.Value != "42" || val.IsFloat {
+		t.Errorf("expected int 42, got %q isFloat=%v", val.Value, val.IsFloat)
+	}
+}
+
+func TestNumberLiteralFloat(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: 3.14})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	val := doc.Pairs[0].Value.(*ast.NumberLiteral)
+	if val.Value != "3.14" || !val.IsFloat {
+		t.Errorf("expected float 3.14, got %q isFloat=%v", val.Value, val.IsFloat)
+	}
+}
+
+func TestNumberLiteralExponent(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: 1e10})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	val := doc.Pairs[0].Value.(*ast.NumberLiteral)
+	if val.Value != "1e10" || !val.IsFloat {
+		t.Errorf("expected float 1e10, got %q isFloat=%v", val.Value, val.IsFloat)
+	}
+}
+
+func TestNumberLiteralNegative(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: -7})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	val := doc.Pairs[0].Value.(*ast.NumberLiteral)
+	if val.Value != "-7" || val.IsFloat {
+		t.Errorf("expected int -7, got %q isFloat=%v", val.Value, val.IsFloat)
+	}
+}
+
+func TestBoolLiterals(t *testing.T) {
+	node := mustParse(t, `db.c.find({a: true, b: false})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	bTrue := doc.Pairs[0].Value.(*ast.BoolLiteral)
+	bFalse := doc.Pairs[1].Value.(*ast.BoolLiteral)
+	if !bTrue.Value {
+		t.Error("expected true")
+	}
+	if bFalse.Value {
+		t.Error("expected false")
+	}
+}
+
+func TestNullLiteral(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: null})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	_, ok := doc.Pairs[0].Value.(*ast.NullLiteral)
+	if !ok {
+		t.Error("expected NullLiteral")
+	}
+}
+
+func TestRegexLiteral(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: /abc/i})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	re := doc.Pairs[0].Value.(*ast.RegexLiteral)
+	if re.Pattern != "abc" || re.Flags != "i" {
+		t.Errorf("expected /abc/i, got /%s/%s", re.Pattern, re.Flags)
+	}
+}
+
+func TestRegexLiteralNoFlags(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: /^test$/})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	re := doc.Pairs[0].Value.(*ast.RegexLiteral)
+	if re.Pattern != "^test$" || re.Flags != "" {
+		t.Errorf("expected /^test$/, got /%s/%s", re.Pattern, re.Flags)
+	}
+}
+
+func TestHelperObjectId(t *testing.T) {
+	node := mustParse(t, `db.c.find({_id: ObjectId("507f1f77bcf86cd799439011")})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "ObjectId" {
+		t.Errorf("expected ObjectId, got %s", hc.Name)
+	}
+	if len(hc.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(hc.Args))
+	}
+	s := hc.Args[0].(*ast.StringLiteral)
+	if s.Value != "507f1f77bcf86cd799439011" {
+		t.Errorf("wrong ObjectId arg: %q", s.Value)
+	}
+}
+
+func TestHelperISODate(t *testing.T) {
+	node := mustParse(t, `db.c.find({d: ISODate("2024-01-01")})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "ISODate" {
+		t.Errorf("expected ISODate, got %s", hc.Name)
+	}
+}
+
+func TestHelperNumberLong(t *testing.T) {
+	node := mustParse(t, `db.c.find({n: NumberLong(123)})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "NumberLong" {
+		t.Errorf("expected NumberLong, got %s", hc.Name)
+	}
+}
+
+func TestHelperTimestamp(t *testing.T) {
+	node := mustParse(t, `db.c.find({t: Timestamp(1, 0)})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "Timestamp" || len(hc.Args) != 2 {
+		t.Errorf("expected Timestamp with 2 args, got %s with %d args", hc.Name, len(hc.Args))
+	}
+}
+
+func TestHelperUUID(t *testing.T) {
+	node := mustParse(t, `db.c.find({u: UUID("abc")})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "UUID" {
+		t.Errorf("expected UUID, got %s", hc.Name)
+	}
+}
+
+func TestHelperBinData(t *testing.T) {
+	node := mustParse(t, `db.c.find({b: BinData(0, "data")})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "BinData" || len(hc.Args) != 2 {
+		t.Errorf("expected BinData with 2 args, got %s with %d", hc.Name, len(hc.Args))
+	}
+}
+
+func TestHelperNoArgs(t *testing.T) {
+	node := mustParse(t, `db.c.find({_id: ObjectId()})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	hc := doc.Pairs[0].Value.(*ast.HelperCall)
+	if hc.Name != "ObjectId" || len(hc.Args) != 0 {
+		t.Errorf("expected ObjectId() with 0 args, got %s with %d", hc.Name, len(hc.Args))
+	}
+}
+
+func TestArrayLiteral(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: [1, "two", true]})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	arr := doc.Pairs[0].Value.(*ast.Array)
+	if len(arr.Elements) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(arr.Elements))
+	}
+	_ = arr.Elements[0].(*ast.NumberLiteral)
+	_ = arr.Elements[1].(*ast.StringLiteral)
+	_ = arr.Elements[2].(*ast.BoolLiteral)
+}
+
+func TestEmptyArray(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: []})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	arr := doc.Pairs[0].Value.(*ast.Array)
+	if len(arr.Elements) != 0 {
+		t.Errorf("expected 0 elements, got %d", len(arr.Elements))
+	}
+}
+
+func TestArrayTrailingComma(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: [1, 2,]})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	arr := doc.Pairs[0].Value.(*ast.Array)
+	if len(arr.Elements) != 2 {
+		t.Errorf("expected 2 elements, got %d", len(arr.Elements))
+	}
+}
+
+func TestNestedArray(t *testing.T) {
+	node := mustParse(t, `db.c.find({k: [[1, 2], [3]]})`)
+	doc := node.(*ast.CollectionStatement).Args[0].(*ast.Document)
+	arr := doc.Pairs[0].Value.(*ast.Array)
+	if len(arr.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(arr.Elements))
+	}
+	inner := arr.Elements[0].(*ast.Array)
+	if len(inner.Elements) != 2 {
+		t.Errorf("expected 2 inner elements, got %d", len(inner.Elements))
+	}
+}
+
+func TestNewKeywordError(t *testing.T) {
+	mustFail(t, `db.c.find({k: new Date()})`)
+}

--- a/mongo/parsertest/helpers_test.go
+++ b/mongo/parsertest/helpers_test.go
@@ -1,0 +1,52 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+	"github.com/bytebase/omni/mongo/parser"
+)
+
+// mustParse parses input expecting exactly one AST node.
+func mustParse(t *testing.T, input string) ast.Node {
+	t.Helper()
+	nodes, err := parser.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	return nodes[0]
+}
+
+// mustParseN parses input expecting exactly n AST nodes.
+func mustParseN(t *testing.T, input string, n int) []ast.Node {
+	t.Helper()
+	nodes, err := parser.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(nodes) != n {
+		t.Fatalf("expected %d nodes, got %d", n, len(nodes))
+	}
+	return nodes
+}
+
+// mustFail parses input and expects a parse error.
+func mustFail(t *testing.T, input string) {
+	t.Helper()
+	_, err := parser.Parse(input)
+	if err == nil {
+		t.Fatalf("expected parse error for input: %s", input)
+	}
+}
+
+// assertLoc checks that a node's location matches the expected start and end offsets.
+func assertLoc(t *testing.T, node ast.Node, start, end int) {
+	t.Helper()
+	loc := node.GetLoc()
+	if loc.Start != start || loc.End != end {
+		t.Errorf("expected loc [%d, %d), got [%d, %d)", start, end, loc.Start, loc.End)
+	}
+}

--- a/mongo/parsertest/native_test.go
+++ b/mongo/parsertest/native_test.go
@@ -1,0 +1,96 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestNativeSleep(t *testing.T) {
+	node := mustParse(t, `sleep(1000)`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "sleep" {
+		t.Errorf("expected name 'sleep', got %q", stmt.Name)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestNativeLoad(t *testing.T) {
+	node := mustParse(t, `load("scripts/init.js")`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "load" {
+		t.Errorf("expected name 'load', got %q", stmt.Name)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestNativeQuit(t *testing.T) {
+	node := mustParse(t, `quit()`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "quit" {
+		t.Errorf("expected name 'quit', got %q", stmt.Name)
+	}
+	if len(stmt.Args) != 0 {
+		t.Errorf("expected 0 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestNativeQuitWithCode(t *testing.T) {
+	node := mustParse(t, `quit(1)`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "quit" {
+		t.Errorf("expected name 'quit', got %q", stmt.Name)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestNativeExit(t *testing.T) {
+	node := mustParse(t, `exit()`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "exit" {
+		t.Errorf("expected name 'exit', got %q", stmt.Name)
+	}
+}
+
+func TestNativeVersion(t *testing.T) {
+	node := mustParse(t, `version()`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "version" {
+		t.Errorf("expected name 'version', got %q", stmt.Name)
+	}
+}
+
+func TestNativePrint(t *testing.T) {
+	node := mustParse(t, `print("hello")`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "print" {
+		t.Errorf("expected name 'print', got %q", stmt.Name)
+	}
+}
+
+func TestNativePrintjson(t *testing.T) {
+	node := mustParse(t, `printjson({ x: 1 })`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "printjson" {
+		t.Errorf("expected name 'printjson', got %q", stmt.Name)
+	}
+}
+
+func TestNativeCls(t *testing.T) {
+	node := mustParse(t, `cls()`)
+	stmt := node.(*ast.NativeFunctionCall)
+	if stmt.Name != "cls" {
+		t.Errorf("expected name 'cls', got %q", stmt.Name)
+	}
+}
+
+func TestNativeLoc(t *testing.T) {
+	node := mustParse(t, `sleep(100)`)
+	assertLoc(t, node, 0, 10)
+}

--- a/mongo/parsertest/plancache_test.go
+++ b/mongo/parsertest/plancache_test.go
@@ -1,0 +1,76 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestPlanCacheGetPlanCache(t *testing.T) {
+	node := mustParse(t, `db.users.getPlanCache()`)
+	stmt := node.(*ast.PlanCacheStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "dot" {
+		t.Errorf("expected access method 'dot', got %q", stmt.AccessMethod)
+	}
+	if len(stmt.ChainedMethods) != 0 {
+		t.Errorf("expected 0 chained methods, got %d", len(stmt.ChainedMethods))
+	}
+}
+
+func TestPlanCacheClear(t *testing.T) {
+	node := mustParse(t, `db.users.getPlanCache().clear()`)
+	stmt := node.(*ast.PlanCacheStatement)
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "clear" {
+		t.Errorf("expected 'clear', got %q", stmt.ChainedMethods[0].Name)
+	}
+}
+
+func TestPlanCacheList(t *testing.T) {
+	node := mustParse(t, `db.users.getPlanCache().list()`)
+	stmt := node.(*ast.PlanCacheStatement)
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if stmt.ChainedMethods[0].Name != "list" {
+		t.Errorf("expected 'list', got %q", stmt.ChainedMethods[0].Name)
+	}
+}
+
+func TestPlanCacheListWithArgs(t *testing.T) {
+	node := mustParse(t, `db.users.getPlanCache().list([{ $match: { isActive: true } }])`)
+	stmt := node.(*ast.PlanCacheStatement)
+	if len(stmt.ChainedMethods) != 1 {
+		t.Fatalf("expected 1 chained method, got %d", len(stmt.ChainedMethods))
+	}
+	if len(stmt.ChainedMethods[0].Args) != 1 {
+		t.Errorf("expected 1 arg, got %d", len(stmt.ChainedMethods[0].Args))
+	}
+}
+
+func TestPlanCacheGetCollectionAccess(t *testing.T) {
+	node := mustParse(t, `db.getCollection("users").getPlanCache().clear()`)
+	stmt := node.(*ast.PlanCacheStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "getCollection" {
+		t.Errorf("expected access method 'getCollection', got %q", stmt.AccessMethod)
+	}
+}
+
+func TestPlanCacheBracketAccess(t *testing.T) {
+	node := mustParse(t, `db["users"].getPlanCache().clear()`)
+	stmt := node.(*ast.PlanCacheStatement)
+	if stmt.Collection != "users" {
+		t.Errorf("expected collection 'users', got %q", stmt.Collection)
+	}
+	if stmt.AccessMethod != "bracket" {
+		t.Errorf("expected access method 'bracket', got %q", stmt.AccessMethod)
+	}
+}

--- a/mongo/parsertest/position_test.go
+++ b/mongo/parsertest/position_test.go
@@ -1,0 +1,177 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo"
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestPositionTracking(t *testing.T) {
+	input := `db.users.find({name: "alice"})`
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+
+	s := stmts[0]
+	if s.ByteStart != 0 {
+		t.Errorf("expected ByteStart=0, got %d", s.ByteStart)
+	}
+	if s.ByteEnd != len(input) {
+		t.Errorf("expected ByteEnd=%d, got %d", len(input), s.ByteEnd)
+	}
+	if s.Start.Line != 1 {
+		t.Errorf("expected Start.Line=1, got %d", s.Start.Line)
+	}
+	if s.Start.Column != 1 {
+		t.Errorf("expected Start.Column=1, got %d", s.Start.Column)
+	}
+	if s.End.Line != 1 {
+		t.Errorf("expected End.Line=1, got %d", s.End.Line)
+	}
+}
+
+func TestPositionMultipleStatements(t *testing.T) {
+	input := "show dbs\nshow collections"
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 statements, got %d", len(stmts))
+	}
+
+	// First statement: "show dbs" on line 1
+	s1 := stmts[0]
+	if s1.Start.Line != 1 {
+		t.Errorf("stmt1: expected Start.Line=1, got %d", s1.Start.Line)
+	}
+	if s1.Start.Column != 1 {
+		t.Errorf("stmt1: expected Start.Column=1, got %d", s1.Start.Column)
+	}
+	if s1.ByteStart != 0 {
+		t.Errorf("stmt1: expected ByteStart=0, got %d", s1.ByteStart)
+	}
+	if s1.ByteEnd != 8 { // "show dbs" = 8 bytes
+		t.Errorf("stmt1: expected ByteEnd=8, got %d", s1.ByteEnd)
+	}
+
+	// Second statement: "show collections" on line 2
+	s2 := stmts[1]
+	if s2.Start.Line != 2 {
+		t.Errorf("stmt2: expected Start.Line=2, got %d", s2.Start.Line)
+	}
+	if s2.Start.Column != 1 {
+		t.Errorf("stmt2: expected Start.Column=1, got %d", s2.Start.Column)
+	}
+	if s2.ByteStart != 9 { // after "show dbs\n"
+		t.Errorf("stmt2: expected ByteStart=9, got %d", s2.ByteStart)
+	}
+}
+
+func TestPositionWithSemicolons(t *testing.T) {
+	input := "show dbs; show collections"
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 statements, got %d", len(stmts))
+	}
+
+	// First statement should include the trailing semicolon in text
+	s1 := stmts[0]
+	if s1.Text != "show dbs;" {
+		t.Errorf("stmt1: expected text %q, got %q", "show dbs;", s1.Text)
+	}
+
+	// Second statement
+	s2 := stmts[1]
+	if s2.Text != "show collections" {
+		t.Errorf("stmt2: expected text %q, got %q", "show collections", s2.Text)
+	}
+}
+
+func TestPositionDocumentNodes(t *testing.T) {
+	input := `db.c.find({k: "v"})`
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+
+	s := stmts[0]
+	cs, ok := s.AST.(*ast.CollectionStatement)
+	if !ok {
+		t.Fatalf("expected *ast.CollectionStatement, got %T", s.AST)
+	}
+	if len(cs.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(cs.Args))
+	}
+
+	doc, ok := cs.Args[0].(*ast.Document)
+	if !ok {
+		t.Fatalf("expected *ast.Document, got %T", cs.Args[0])
+	}
+
+	// Document starts at '{' which is at index 10: db.c.find(
+	expectedStart := 10
+	if doc.Loc.Start != expectedStart {
+		t.Errorf("expected doc start=%d, got %d", expectedStart, doc.Loc.Start)
+	}
+
+	// {k: "v"} — '}' is at index 17, End is exclusive = 18
+	expectedEnd := 18
+	if doc.Loc.End != expectedEnd {
+		t.Errorf("expected doc end=%d, got %d", expectedEnd, doc.Loc.End)
+	}
+}
+
+func TestPositionArrayNodes(t *testing.T) {
+	input := `db.c.insert([1, 2, 3])`
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+
+	cs := stmts[0].AST.(*ast.CollectionStatement)
+	if len(cs.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(cs.Args))
+	}
+
+	arr, ok := cs.Args[0].(*ast.Array)
+	if !ok {
+		t.Fatalf("expected *ast.Array, got %T", cs.Args[0])
+	}
+
+	// Array starts at '[' at index 12
+	if arr.Loc.Start != 12 {
+		t.Errorf("expected array start=12, got %d", arr.Loc.Start)
+	}
+	// Array ends after ']' at index 21, so End=21
+	if arr.Loc.End != 21 {
+		t.Errorf("expected array end=21, got %d", arr.Loc.End)
+	}
+}
+
+func TestPositionStatementLoc(t *testing.T) {
+	// Verify the AST node's own Loc matches what we expect
+	input := `db.users.find()`
+	node := mustParse(t, input)
+	loc := node.GetLoc()
+	if loc.Start != 0 {
+		t.Errorf("expected loc.Start=0, got %d", loc.Start)
+	}
+	if loc.End != len(input) {
+		t.Errorf("expected loc.End=%d, got %d", len(input), loc.End)
+	}
+}

--- a/mongo/parsertest/replication_test.go
+++ b/mongo/parsertest/replication_test.go
@@ -1,0 +1,93 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestRsStatus(t *testing.T) {
+	node := mustParse(t, `rs.status()`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "status" {
+		t.Errorf("expected method 'status', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 0 {
+		t.Errorf("expected 0 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestRsStatusWithArgs(t *testing.T) {
+	node := mustParse(t, `rs.status({ initialSync: 1 })`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "status" {
+		t.Errorf("expected method 'status', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 1 {
+		t.Errorf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestRsInitiate(t *testing.T) {
+	node := mustParse(t, `rs.initiate()`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "initiate" {
+		t.Errorf("expected method 'initiate', got %q", stmt.MethodName)
+	}
+}
+
+func TestRsInitiateWithConfig(t *testing.T) {
+	node := mustParse(t, `rs.initiate({ _id: "myRS", members: [{ _id: 0, host: "mongo1:27017" }] })`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "initiate" {
+		t.Errorf("expected method 'initiate', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestRsConf(t *testing.T) {
+	node := mustParse(t, `rs.conf()`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "conf" {
+		t.Errorf("expected method 'conf', got %q", stmt.MethodName)
+	}
+}
+
+func TestRsReconfig(t *testing.T) {
+	node := mustParse(t, `rs.reconfig({ _id: "rs0", members: [] })`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "reconfig" {
+		t.Errorf("expected method 'reconfig', got %q", stmt.MethodName)
+	}
+}
+
+func TestRsAdd(t *testing.T) {
+	node := mustParse(t, `rs.add("mongo4:27017")`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "add" {
+		t.Errorf("expected method 'add', got %q", stmt.MethodName)
+	}
+}
+
+func TestRsFreeze(t *testing.T) {
+	node := mustParse(t, `rs.freeze(120)`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "freeze" {
+		t.Errorf("expected method 'freeze', got %q", stmt.MethodName)
+	}
+}
+
+func TestRsStepDown(t *testing.T) {
+	node := mustParse(t, `rs.stepDown(60)`)
+	stmt := node.(*ast.RsStatement)
+	if stmt.MethodName != "stepDown" {
+		t.Errorf("expected method 'stepDown', got %q", stmt.MethodName)
+	}
+}
+
+func TestRsLoc(t *testing.T) {
+	node := mustParse(t, `rs.status()`)
+	assertLoc(t, node, 0, 11)
+}

--- a/mongo/parsertest/sharding_test.go
+++ b/mongo/parsertest/sharding_test.go
@@ -1,0 +1,88 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestShStatus(t *testing.T) {
+	node := mustParse(t, `sh.status()`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "status" {
+		t.Errorf("expected method 'status', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 0 {
+		t.Errorf("expected 0 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestShAddShard(t *testing.T) {
+	node := mustParse(t, `sh.addShard("rs1/mongo1:27017")`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "addShard" {
+		t.Errorf("expected method 'addShard', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+}
+
+func TestShEnableSharding(t *testing.T) {
+	node := mustParse(t, `sh.enableSharding("mydb")`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "enableSharding" {
+		t.Errorf("expected method 'enableSharding', got %q", stmt.MethodName)
+	}
+}
+
+func TestShShardCollection(t *testing.T) {
+	node := mustParse(t, `sh.shardCollection("mydb.orders", { _id: 1 })`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "shardCollection" {
+		t.Errorf("expected method 'shardCollection', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestShGetBalancerState(t *testing.T) {
+	node := mustParse(t, `sh.getBalancerState()`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "getBalancerState" {
+		t.Errorf("expected method 'getBalancerState', got %q", stmt.MethodName)
+	}
+}
+
+func TestShStartBalancer(t *testing.T) {
+	node := mustParse(t, `sh.startBalancer()`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "startBalancer" {
+		t.Errorf("expected method 'startBalancer', got %q", stmt.MethodName)
+	}
+}
+
+func TestShStopBalancer(t *testing.T) {
+	node := mustParse(t, `sh.stopBalancer()`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "stopBalancer" {
+		t.Errorf("expected method 'stopBalancer', got %q", stmt.MethodName)
+	}
+}
+
+func TestShMoveChunk(t *testing.T) {
+	node := mustParse(t, `sh.moveChunk("mydb.orders", { _id: 1 }, "shard2")`)
+	stmt := node.(*ast.ShStatement)
+	if stmt.MethodName != "moveChunk" {
+		t.Errorf("expected method 'moveChunk', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 3 {
+		t.Fatalf("expected 3 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestShLoc(t *testing.T) {
+	node := mustParse(t, `sh.status()`)
+	assertLoc(t, node, 0, 11)
+}

--- a/mongo/parsertest/shell_test.go
+++ b/mongo/parsertest/shell_test.go
@@ -1,0 +1,92 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestShowDbs(t *testing.T) {
+	node := mustParse(t, "show dbs")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "databases" {
+		t.Errorf("expected 'databases', got %q", cmd.Target)
+	}
+}
+
+func TestShowDatabases(t *testing.T) {
+	node := mustParse(t, "show databases")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "databases" {
+		t.Errorf("expected 'databases', got %q", cmd.Target)
+	}
+}
+
+func TestShowCollections(t *testing.T) {
+	node := mustParse(t, "show collections")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "collections" {
+		t.Errorf("expected 'collections', got %q", cmd.Target)
+	}
+}
+
+func TestShowTables(t *testing.T) {
+	node := mustParse(t, "show tables")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "tables" {
+		t.Errorf("expected 'tables', got %q", cmd.Target)
+	}
+}
+
+func TestShowProfile(t *testing.T) {
+	node := mustParse(t, "show profile")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "profile" {
+		t.Errorf("expected 'profile', got %q", cmd.Target)
+	}
+}
+
+func TestShowUsers(t *testing.T) {
+	node := mustParse(t, "show users")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "users" {
+		t.Errorf("expected 'users', got %q", cmd.Target)
+	}
+}
+
+func TestShowRoles(t *testing.T) {
+	node := mustParse(t, "show roles")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "roles" {
+		t.Errorf("expected 'roles', got %q", cmd.Target)
+	}
+}
+
+func TestShowLog(t *testing.T) {
+	node := mustParse(t, "show log")
+	cmd := node.(*ast.ShowCommand)
+	if cmd.Target != "log" {
+		t.Errorf("expected 'log', got %q", cmd.Target)
+	}
+}
+
+func TestShowInvalidTarget(t *testing.T) {
+	mustFail(t, "show something")
+}
+
+func TestMultipleShowCommands(t *testing.T) {
+	nodes := mustParseN(t, "show dbs; show collections", 2)
+	cmd1 := nodes[0].(*ast.ShowCommand)
+	cmd2 := nodes[1].(*ast.ShowCommand)
+	if cmd1.Target != "databases" {
+		t.Errorf("expected 'databases', got %q", cmd1.Target)
+	}
+	if cmd2.Target != "collections" {
+		t.Errorf("expected 'collections', got %q", cmd2.Target)
+	}
+}
+
+func TestShowCommandLoc(t *testing.T) {
+	node := mustParse(t, "show dbs")
+	assertLoc(t, node, 0, 8)
+}

--- a/mongo/parsertest/stream_test.go
+++ b/mongo/parsertest/stream_test.go
@@ -1,0 +1,92 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestSpCreateStreamProcessor(t *testing.T) {
+	node := mustParse(t, `sp.createStreamProcessor("myProc", { pipeline: [] })`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "createStreamProcessor" {
+		t.Errorf("expected method 'createStreamProcessor', got %q", stmt.MethodName)
+	}
+	if stmt.SubMethod != "" {
+		t.Errorf("expected no sub-method, got %q", stmt.SubMethod)
+	}
+	if len(stmt.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestSpListStreamProcessors(t *testing.T) {
+	node := mustParse(t, `sp.listStreamProcessors()`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "listStreamProcessors" {
+		t.Errorf("expected method 'listStreamProcessors', got %q", stmt.MethodName)
+	}
+	if len(stmt.Args) != 0 {
+		t.Errorf("expected 0 args, got %d", len(stmt.Args))
+	}
+}
+
+func TestSpProcessorStats(t *testing.T) {
+	node := mustParse(t, `sp.myProcessor.stats()`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "myProcessor" {
+		t.Errorf("expected method 'myProcessor', got %q", stmt.MethodName)
+	}
+	if stmt.SubMethod != "stats" {
+		t.Errorf("expected sub-method 'stats', got %q", stmt.SubMethod)
+	}
+}
+
+func TestSpProcessorStart(t *testing.T) {
+	node := mustParse(t, `sp.analyticsProcessor.start()`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "analyticsProcessor" {
+		t.Errorf("expected method 'analyticsProcessor', got %q", stmt.MethodName)
+	}
+	if stmt.SubMethod != "start" {
+		t.Errorf("expected sub-method 'start', got %q", stmt.SubMethod)
+	}
+}
+
+func TestSpProcessorStop(t *testing.T) {
+	node := mustParse(t, `sp.dataProcessor.stop()`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "dataProcessor" {
+		t.Errorf("expected method 'dataProcessor', got %q", stmt.MethodName)
+	}
+	if stmt.SubMethod != "stop" {
+		t.Errorf("expected sub-method 'stop', got %q", stmt.SubMethod)
+	}
+}
+
+func TestSpProcessorDrop(t *testing.T) {
+	node := mustParse(t, `sp.oldProcessor.drop()`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "oldProcessor" {
+		t.Errorf("expected method 'oldProcessor', got %q", stmt.MethodName)
+	}
+	if stmt.SubMethod != "drop" {
+		t.Errorf("expected sub-method 'drop', got %q", stmt.SubMethod)
+	}
+}
+
+func TestSpProcessorSample(t *testing.T) {
+	node := mustParse(t, `sp.sensorProcessor.sample()`)
+	stmt := node.(*ast.SpStatement)
+	if stmt.MethodName != "sensorProcessor" {
+		t.Errorf("expected method 'sensorProcessor', got %q", stmt.MethodName)
+	}
+	if stmt.SubMethod != "sample" {
+		t.Errorf("expected sub-method 'sample', got %q", stmt.SubMethod)
+	}
+}
+
+func TestSpLoc(t *testing.T) {
+	node := mustParse(t, `sp.process()`)
+	assertLoc(t, node, 0, 12)
+}

--- a/mongo/parsertest/unicode_test.go
+++ b/mongo/parsertest/unicode_test.go
@@ -1,0 +1,113 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+func TestUnicodeStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "CJK characters in string value",
+			input: `db.users.insertOne({ name: "张三" })`,
+		},
+		{
+			name:  "emoji in string value",
+			input: `db.posts.insertOne({ content: "Hello 🌍🎉" })`,
+		},
+		{
+			name:  "Japanese in string value",
+			input: `db.docs.find({ title: "東京タワー" })`,
+		},
+		{
+			name:  "Korean in string value",
+			input: `db.docs.find({ city: "서울" })`,
+		},
+		{
+			name:  "unicode escape in string",
+			input: `db.users.insertOne({ name: "\u0041\u0042\u0043" })`,
+		},
+		{
+			name:  "mixed ASCII and CJK",
+			input: `db.users.find({ name: "Alice-张三-Bob" })`,
+		},
+		{
+			name:  "CJK in collection name via bracket access",
+			input: `db["用户"].find()`,
+		},
+		{
+			name:  "emoji in collection name via bracket access",
+			input: `db["📊data"].find()`,
+		},
+		{
+			name:  "unicode key in document",
+			input: `db.data.insertOne({ "名前": "太郎", "年齢": 25 })`,
+		},
+		{
+			name:  "unicode in array values",
+			input: `db.tags.insertOne({ tags: ["数据库", "MongoDB", "测试"] })`,
+		},
+		{
+			name:  "unicode in nested document",
+			input: `db.people.insertOne({ address: { city: "北京", country: "中国" } })`,
+		},
+		{
+			name:  "unicode identifier as collection name",
+			input: `db.données.find()`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := mustParse(t, tc.input)
+			loc := node.GetLoc()
+			if loc.Start < 0 {
+				t.Errorf("Start = %d, want >= 0", loc.Start)
+			}
+			if loc.End <= loc.Start {
+				t.Errorf("End = %d <= Start = %d", loc.End, loc.Start)
+			}
+		})
+	}
+}
+
+func TestUnicodeStringContent(t *testing.T) {
+	// Verify that unicode string content is preserved correctly.
+	node := mustParse(t, `db.users.insertOne({ name: "张三" })`)
+	cs, ok := node.(*ast.CollectionStatement)
+	if !ok {
+		t.Fatalf("expected CollectionStatement, got %T", node)
+	}
+	if len(cs.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(cs.Args))
+	}
+	doc, ok := cs.Args[0].(*ast.Document)
+	if !ok {
+		t.Fatalf("expected Document arg, got %T", cs.Args[0])
+	}
+	if len(doc.Pairs) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(doc.Pairs))
+	}
+	val, ok := doc.Pairs[0].Value.(*ast.StringLiteral)
+	if !ok {
+		t.Fatalf("expected StringLiteral, got %T", doc.Pairs[0].Value)
+	}
+	if val.Value != "张三" {
+		t.Errorf("string value = %q, want %q", val.Value, "张三")
+	}
+}
+
+func TestUnicodeEscapeContent(t *testing.T) {
+	// \u0041 = A, \u0042 = B, \u0043 = C
+	node := mustParse(t, `db.test.insertOne({ v: "\u0041\u0042\u0043" })`)
+	cs := node.(*ast.CollectionStatement)
+	doc := cs.Args[0].(*ast.Document)
+	val := doc.Pairs[0].Value.(*ast.StringLiteral)
+	if val.Value != "ABC" {
+		t.Errorf("unicode escape value = %q, want %q", val.Value, "ABC")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a new `mongo/` package with a hand-written recursive descent parser for MongoDB shell (mongosh) syntax
- Achieves 100% grammar parity with the existing ANTLR-based parser at `bytebase/parser/mongodb` (309/309 example files pass)
- Zero external dependencies, pure Go, consistent with omni's architecture (`pg/`, `mysql/`, `mssql/`, `oracle/`)

## What's included

**Parser** (`mongo/parser/`): Lexer + recursive descent parser covering all 9 mongosh statement families:
- Collection operations (`db.collection.find/insert/update/delete/aggregate...`)
- Database methods (`db.stats/createCollection/dropDatabase...` — 66+ methods)
- Shell commands (`show dbs/collections`)
- Bulk operations (`initializeOrderedBulkOp/UnorderedBulkOp` chains)
- Connection (`Mongo()`, `connect()`, `db.getMongo()` chains)
- Replication (`rs.*`), Sharding (`sh.*`), Stream processing (`sp.*`)
- Encryption (`getKeyVault/getClientEncryption` chains)
- Plan cache (`getPlanCache` chains)
- Native functions (`sleep`, `load`, `quit`, etc.)

**AST** (`mongo/ast/`): 11 statement node types + 10 value/expression node types, all with `Loc{Start, End}` byte-offset position tracking.

**Public API** (`mongo/parse.go`): `mongo.Parse(input) ([]Statement, error)` — same shape as `pg.Parse()`.

## Stats

| Metric | Value |
|--------|-------|
| Files | 36 |
| Lines | ~4,900 |
| Tests | 495 |
| ANTLR parity | 309/309 (100%) |

## Test plan

- [x] 495 unit tests covering all statement families, expressions, documents, error cases, position tracking
- [x] 309/309 ANTLR example files parse successfully (antlr_compat_test.go)
- [x] Unicode, comments, edge cases covered
- [x] `go vet` clean, `go build ./...` passes (no impact on existing packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)