### PR TITLE
refactor(mongo): move ANTLR examples into testdata

### DIFF
--- a/mongo/parsertest/antlr_compat_test.go
+++ b/mongo/parsertest/antlr_compat_test.go
@@ -15,7 +15,7 @@ import (
 //  2. At least one statement is produced.
 //  3. Every statement has valid position tracking.
 func TestANTLRExampleFiles(t *testing.T) {
-	dir := "/Users/h3n4l/OpenSource/parser/mongodb/examples"
+	dir := filepath.Join("testdata")
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/mongo/parsertest/testdata/aggregate-js-functions.js
+++ b/mongo/parsertest/testdata/aggregate-js-functions.js
@@ -1,0 +1,206 @@
+// $function operator - custom JavaScript functions in aggregation
+// The JavaScript code is passed as a string in the "body" field
+
+// Basic $function usage
+db.players.aggregate([
+    { $addFields: {
+        isFound: {
+            $function: {
+                body: "function(name) { return name.length > 5; }",
+                args: ["$name"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function with multiple arguments
+db.orders.aggregate([
+    { $addFields: {
+        discount: {
+            $function: {
+                body: "function(price, quantity) { return price * quantity * 0.1; }",
+                args: ["$price", "$quantity"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function with complex logic
+db.events.aggregate([
+    { $addFields: {
+        category: {
+            $function: {
+                body: "function(score) { if (score >= 90) return 'A'; else if (score >= 80) return 'B'; else if (score >= 70) return 'C'; else return 'F'; }",
+                args: ["$score"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function with no arguments
+db.items.aggregate([
+    { $addFields: {
+        timestamp: {
+            $function: {
+                body: "function() { return new Date().toISOString(); }",
+                args: [],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function with array argument
+db.data.aggregate([
+    { $addFields: {
+        processed: {
+            $function: {
+                body: "function(arr) { return arr.map(x => x * 2); }",
+                args: ["$values"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function with multiline string (escaped)
+db.documents.aggregate([
+    { $addFields: {
+        result: {
+            $function: {
+                body: "function(doc) {\n  var sum = 0;\n  for (var i = 0; i < doc.length; i++) {\n    sum += doc[i];\n  }\n  return sum;\n}",
+                args: ["$numbers"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $accumulator operator - custom accumulator with JavaScript
+db.sales.aggregate([
+    { $group: {
+        _id: "$category",
+        customSum: {
+            $accumulator: {
+                init: "function() { return { sum: 0, count: 0 }; }",
+                accumulate: "function(state, value) { return { sum: state.sum + value, count: state.count + 1 }; }",
+                accumulateArgs: ["$amount"],
+                merge: "function(state1, state2) { return { sum: state1.sum + state2.sum, count: state1.count + state2.count }; }",
+                finalize: "function(state) { return state.sum / state.count; }",
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $accumulator with initArgs
+db.transactions.aggregate([
+    { $group: {
+        _id: "$accountId",
+        balance: {
+            $accumulator: {
+                init: "function(initial) { return initial; }",
+                initArgs: [0],
+                accumulate: "function(state, amount, type) { return type === 'credit' ? state + amount : state - amount; }",
+                accumulateArgs: ["$amount", "$type"],
+                merge: "function(s1, s2) { return s1 + s2; }",
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $accumulator without finalize
+db.metrics.aggregate([
+    { $group: {
+        _id: "$source",
+        values: {
+            $accumulator: {
+                init: "function() { return []; }",
+                accumulate: "function(state, val) { state.push(val); return state; }",
+                accumulateArgs: ["$value"],
+                merge: "function(s1, s2) { return s1.concat(s2); }",
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// Combined $function and standard operators
+db.products.aggregate([
+    { $match: { inStock: true } },
+    { $addFields: {
+        priceCategory: {
+            $function: {
+                body: "function(p) { return p < 10 ? 'cheap' : p < 100 ? 'moderate' : 'expensive'; }",
+                args: ["$price"],
+                lang: "js"
+            }
+        }
+    }},
+    { $group: { _id: "$priceCategory", count: { $sum: 1 } } },
+    { $sort: { count: -1 } }
+])
+
+// $function in $project stage
+db.users.aggregate([
+    { $project: {
+        name: 1,
+        maskedEmail: {
+            $function: {
+                body: "function(email) { var parts = email.split('@'); return parts[0].substring(0, 2) + '***@' + parts[1]; }",
+                args: ["$email"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function with object argument
+db.records.aggregate([
+    { $addFields: {
+        serialized: {
+            $function: {
+                body: "function(obj) { return JSON.stringify(obj); }",
+                args: ["$metadata"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// $function returning object
+db.coordinates.aggregate([
+    { $addFields: {
+        point: {
+            $function: {
+                body: "function(lat, lng) { return { type: 'Point', coordinates: [lng, lat] }; }",
+                args: ["$latitude", "$longitude"],
+                lang: "js"
+            }
+        }
+    }}
+])
+
+// Nested $function in $facet
+db.analytics.aggregate([
+    { $facet: {
+        processed: [
+            { $addFields: {
+                normalized: {
+                    $function: {
+                        body: "function(v, min, max) { return (v - min) / (max - min); }",
+                        args: ["$value", "$minValue", "$maxValue"],
+                        lang: "js"
+                    }
+                }
+            }}
+        ],
+        summary: [
+            { $group: { _id: null, total: { $sum: "$value" } } }
+        ]
+    }}
+])

--- a/mongo/parsertest/testdata/atlas-createSearchIndex.js
+++ b/mongo/parsertest/testdata/atlas-createSearchIndex.js
@@ -1,0 +1,65 @@
+// db.collection.createSearchIndex() - Create an Atlas Search index
+
+// Basic search index
+db.movies.createSearchIndex({
+    name: "default",
+    definition: { mappings: { dynamic: true } }
+})
+
+// Search index with specific mappings
+db.products.createSearchIndex({
+    name: "product_search",
+    definition: {
+        mappings: {
+            dynamic: false,
+            fields: {
+                name: { type: "string", analyzer: "lucene.standard" },
+                description: { type: "string" },
+                category: { type: "token" }
+            }
+        }
+    }
+})
+
+// Search index with analyzers
+db.articles.createSearchIndex({
+    name: "article_search",
+    definition: {
+        analyzer: "lucene.standard",
+        searchAnalyzer: "lucene.standard",
+        mappings: {
+            dynamic: true
+        }
+    }
+})
+
+// Search index with synonyms
+db.products.createSearchIndex({
+    name: "synonym_search",
+    definition: {
+        mappings: { dynamic: true },
+        synonyms: [{
+            name: "product_synonyms",
+            source: { collection: "synonyms" },
+            analyzer: "lucene.standard"
+        }]
+    }
+})
+
+// Vector search index
+db.embeddings.createSearchIndex({
+    name: "vector_index",
+    type: "vectorSearch",
+    definition: {
+        fields: [{
+            type: "vector",
+            path: "embedding",
+            numDimensions: 1536,
+            similarity: "cosine"
+        }]
+    }
+})
+
+// Collection access patterns
+db["movies"].createSearchIndex({ name: "search" })
+db.getCollection("movies").createSearchIndex({ name: "search" })

--- a/mongo/parsertest/testdata/atlas-createSearchIndexes.js
+++ b/mongo/parsertest/testdata/atlas-createSearchIndexes.js
@@ -1,0 +1,70 @@
+// db.collection.createSearchIndexes() - Create multiple Atlas Search indexes
+
+// Create multiple search indexes at once
+db.movies.createSearchIndexes([
+    {
+        name: "default",
+        definition: { mappings: { dynamic: true } }
+    },
+    {
+        name: "title_search",
+        definition: {
+            mappings: {
+                dynamic: false,
+                fields: {
+                    title: { type: "string", analyzer: "lucene.standard" }
+                }
+            }
+        }
+    }
+])
+
+// Create text and vector search indexes together
+db.products.createSearchIndexes([
+    {
+        name: "text_search",
+        definition: {
+            mappings: {
+                dynamic: false,
+                fields: {
+                    name: { type: "string" },
+                    description: { type: "string" }
+                }
+            }
+        }
+    },
+    {
+        name: "vector_search",
+        type: "vectorSearch",
+        definition: {
+            fields: [{
+                type: "vector",
+                path: "embedding",
+                numDimensions: 768,
+                similarity: "dotProduct"
+            }]
+        }
+    }
+])
+
+// Create search indexes with different analyzers
+db.articles.createSearchIndexes([
+    {
+        name: "english_search",
+        definition: {
+            analyzer: "lucene.english",
+            mappings: { dynamic: true }
+        }
+    },
+    {
+        name: "french_search",
+        definition: {
+            analyzer: "lucene.french",
+            mappings: { dynamic: true }
+        }
+    }
+])
+
+// Collection access patterns
+db["movies"].createSearchIndexes([{ name: "idx1" }])
+db.getCollection("movies").createSearchIndexes([{ name: "idx1" }])

--- a/mongo/parsertest/testdata/atlas-dropSearchIndex.js
+++ b/mongo/parsertest/testdata/atlas-dropSearchIndex.js
@@ -1,0 +1,19 @@
+// db.collection.dropSearchIndex() - Drop an Atlas Search index
+
+// Drop search index by name
+db.movies.dropSearchIndex("default")
+
+// Drop text search index
+db.products.dropSearchIndex("product_search")
+
+// Drop vector search index
+db.embeddings.dropSearchIndex("vector_index")
+
+// Drop search index with various names
+db.articles.dropSearchIndex("english_search")
+db.articles.dropSearchIndex("french_search")
+db.users.dropSearchIndex("user_profile_search")
+
+// Collection access patterns
+db["movies"].dropSearchIndex("default")
+db.getCollection("movies").dropSearchIndex("default")

--- a/mongo/parsertest/testdata/atlas-updateSearchIndex.js
+++ b/mongo/parsertest/testdata/atlas-updateSearchIndex.js
@@ -1,0 +1,60 @@
+// db.collection.updateSearchIndex() - Update an Atlas Search index
+
+// Update search index definition
+db.movies.updateSearchIndex("default", {
+    definition: {
+        mappings: { dynamic: true }
+    }
+})
+
+// Update search index with specific field mappings
+db.products.updateSearchIndex("product_search", {
+    definition: {
+        mappings: {
+            dynamic: false,
+            fields: {
+                name: { type: "string", analyzer: "lucene.standard" },
+                description: { type: "string", analyzer: "lucene.english" },
+                category: { type: "token" },
+                price: { type: "number" }
+            }
+        }
+    }
+})
+
+// Update vector search index
+db.embeddings.updateSearchIndex("vector_index", {
+    definition: {
+        fields: [{
+            type: "vector",
+            path: "embedding",
+            numDimensions: 1536,
+            similarity: "euclidean"
+        }]
+    }
+})
+
+// Update search index with new analyzer
+db.articles.updateSearchIndex("article_search", {
+    definition: {
+        analyzer: "lucene.english",
+        searchAnalyzer: "lucene.english",
+        mappings: { dynamic: true }
+    }
+})
+
+// Update search index with synonyms
+db.products.updateSearchIndex("synonym_search", {
+    definition: {
+        mappings: { dynamic: true },
+        synonyms: [{
+            name: "updated_synonyms",
+            source: { collection: "new_synonyms" },
+            analyzer: "lucene.standard"
+        }]
+    }
+})
+
+// Collection access patterns
+db["movies"].updateSearchIndex("default", { definition: { mappings: { dynamic: true } } })
+db.getCollection("movies").updateSearchIndex("default", { definition: { mappings: { dynamic: true } } })

--- a/mongo/parsertest/testdata/bulk-arrayFilters.js
+++ b/mongo/parsertest/testdata/bulk-arrayFilters.js
@@ -1,0 +1,16 @@
+// Bulk.find().arrayFilters() - Specify array filters for bulk update operations
+
+// Basic arrayFilters with updateOne
+db.users.initializeUnorderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") }).arrayFilters([{ "elem.grade": { $gte: 85 } }]).updateOne({ $set: { "grades.$[elem].passed": true } })
+
+// ArrayFilters with update (all matching)
+db.students.initializeOrderedBulkOp().find({ semester: 1 }).arrayFilters([{ "x.grade": { $gte: 90 } }]).update({ $set: { "grades.$[x].honors": true } })
+
+// Multiple array filters
+db.orders.initializeUnorderedBulkOp().find({ status: "processing" }).arrayFilters([{ "item.qty": { $gt: 10 } }, { "item.price": { $lt: 50 } }]).updateOne({ $set: { "items.$[item].discount": 0.1 } })
+
+// ArrayFilters with nested arrays
+db.inventory.initializeOrderedBulkOp().find({ warehouse: "A" }).arrayFilters([{ "loc.qty": { $gt: 0 } }]).update({ $inc: { "locations.$[loc].qty": -1 } })
+
+// ArrayFilters and execute
+db.products.initializeUnorderedBulkOp().find({ category: "electronics" }).arrayFilters([{ "v.rating": { $gte: 4 } }]).updateOne({ $set: { "variants.$[v].featured": true } }).execute()

--- a/mongo/parsertest/testdata/bulk-arrayInsert.js
+++ b/mongo/parsertest/testdata/bulk-arrayInsert.js
@@ -1,0 +1,16 @@
+// Bulk array insert pattern - Multiple inserts using bulk operations
+
+// Multiple inserts in sequence
+db.users.initializeUnorderedBulkOp().insert({ name: "alice" }).insert({ name: "bob" }).insert({ name: "charlie" })
+
+// Insert array of documents pattern
+db.products.initializeOrderedBulkOp().insert({ sku: "A001", name: "Widget" }).insert({ sku: "A002", name: "Gadget" }).insert({ sku: "A003", name: "Gizmo" }).execute()
+
+// Insert with varying document structures
+db.logs.initializeUnorderedBulkOp().insert({ level: "info", message: "Started" }).insert({ level: "warn", message: "Slow query", duration: 500 }).insert({ level: "error", message: "Failed", stack: "..." })
+
+// Bulk insert with IDs
+db.users.initializeOrderedBulkOp().insert({ _id: ObjectId(), name: "dave" }).insert({ _id: ObjectId(), name: "eve" })
+
+// Insert documents with helper functions
+db.events.initializeUnorderedBulkOp().insert({ type: "login", timestamp: ISODate() }).insert({ type: "logout", timestamp: ISODate() }).execute()

--- a/mongo/parsertest/testdata/bulk-collation.js
+++ b/mongo/parsertest/testdata/bulk-collation.js
@@ -1,0 +1,16 @@
+// Bulk.find().collation() - Specify collation for bulk operations
+
+// Collation with update
+db.users.initializeUnorderedBulkOp().find({ name: "cafe" }).collation({ locale: "fr", strength: 1 }).update({ $set: { found: true } })
+
+// Collation with remove
+db.users.initializeOrderedBulkOp().find({ city: "munchen" }).collation({ locale: "de" }).remove()
+
+// Collation with updateOne
+db.products.initializeUnorderedBulkOp().find({ name: "WIDGET" }).collation({ locale: "en", strength: 2 }).updateOne({ $set: { normalized: true } })
+
+// Collation with case insensitive search
+db.users.initializeOrderedBulkOp().find({ lastName: "smith" }).collation({ locale: "en", strength: 1 }).update({ $set: { processed: true } })
+
+// Multiple operations with collation
+db.inventory.initializeUnorderedBulkOp().find({ item: "abc" }).collation({ locale: "en", strength: 2 }).updateOne({ $inc: { qty: 1 } }).execute()

--- a/mongo/parsertest/testdata/bulk-execute.js
+++ b/mongo/parsertest/testdata/bulk-execute.js
@@ -1,0 +1,16 @@
+// Bulk.execute() - Execute all bulk operations
+
+// Basic execute
+db.users.initializeUnorderedBulkOp().insert({ name: "alice" }).execute()
+
+// Execute with write concern
+db.users.initializeOrderedBulkOp().insert({ name: "bob" }).execute({ w: "majority" })
+
+// Chained operations then execute
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).remove().execute()
+
+// Execute ordered operations
+db.orders.initializeOrderedBulkOp().insert({ item: "apple" }).insert({ item: "banana" }).execute()
+
+// Execute with detailed write concern
+db.users.initializeOrderedBulkOp().insert({ name: "charlie" }).execute({ w: 1, j: true })

--- a/mongo/parsertest/testdata/bulk-find.js
+++ b/mongo/parsertest/testdata/bulk-find.js
@@ -1,0 +1,16 @@
+// Bulk.find() - Specify a query for bulk update/remove operations
+
+// Basic find for bulk update
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" })
+
+// Find with complex query
+db.users.initializeOrderedBulkOp().find({ age: { $gt: 18 } })
+
+// Find with multiple conditions
+db.users.initializeUnorderedBulkOp().find({ status: "active", role: "user" })
+
+// Find with ObjectId
+db.users.initializeOrderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") })
+
+// Find with nested document query
+db.orders.initializeUnorderedBulkOp().find({ "address.city": "NYC" })

--- a/mongo/parsertest/testdata/bulk-getOperations.js
+++ b/mongo/parsertest/testdata/bulk-getOperations.js
@@ -1,0 +1,16 @@
+// Bulk.getOperations() - Get the list of queued operations
+
+// Get operations after inserts
+db.users.initializeUnorderedBulkOp().insert({ name: "alice" }).getOperations()
+
+// Get operations after updates
+db.users.initializeOrderedBulkOp().find({ status: "inactive" }).update({ $set: { status: "archived" } }).getOperations()
+
+// Get operations after mixed operations
+db.users.initializeUnorderedBulkOp().insert({ name: "bob" }).find({ old: true }).remove().getOperations()
+
+// Get operations for ordered bulk
+db.products.initializeOrderedBulkOp().insert({ sku: "A001" }).insert({ sku: "A002" }).getOperations()
+
+// Get operations before execute
+db.orders.initializeUnorderedBulkOp().find({ status: "pending" }).updateOne({ $set: { status: "processing" } }).getOperations()

--- a/mongo/parsertest/testdata/bulk-hint.js
+++ b/mongo/parsertest/testdata/bulk-hint.js
@@ -1,0 +1,16 @@
+// Bulk.find().hint() - Specify index hint for bulk operations
+
+// Hint with index name
+db.users.initializeUnorderedBulkOp().find({ status: "active" }).hint("status_1").update({ $set: { checked: true } })
+
+// Hint with index document
+db.users.initializeOrderedBulkOp().find({ email: "alice@example.com" }).hint({ email: 1 }).updateOne({ $set: { verified: true } })
+
+// Hint with compound index
+db.orders.initializeUnorderedBulkOp().find({ customerId: "C001", status: "pending" }).hint({ customerId: 1, status: 1 }).update({ $set: { reviewed: true } })
+
+// Hint with remove
+db.logs.initializeOrderedBulkOp().find({ level: "debug" }).hint("level_1_timestamp_1").remove()
+
+// Hint and execute
+db.products.initializeUnorderedBulkOp().find({ category: "electronics" }).hint({ category: 1 }).updateOne({ $inc: { viewCount: 1 } }).execute()

--- a/mongo/parsertest/testdata/bulk-initializeOrderedBulkOp.js
+++ b/mongo/parsertest/testdata/bulk-initializeOrderedBulkOp.js
@@ -1,0 +1,16 @@
+// Bulk.initializeOrderedBulkOp() - Initialize ordered bulk operation
+
+// Basic initialization
+db.users.initializeOrderedBulkOp()
+
+// Initialize and assign to variable
+db.users.initializeOrderedBulkOp()
+
+// Initialize with bracket notation
+db["users"].initializeOrderedBulkOp()
+
+// Initialize with getCollection
+db.getCollection("users").initializeOrderedBulkOp()
+
+// Ordered bulk operations execute in order
+db.orders.initializeOrderedBulkOp()

--- a/mongo/parsertest/testdata/bulk-initializeUnorderedBulkOp.js
+++ b/mongo/parsertest/testdata/bulk-initializeUnorderedBulkOp.js
@@ -1,0 +1,16 @@
+// Bulk.initializeUnorderedBulkOp() - Initialize unordered bulk operation
+
+// Basic initialization
+db.users.initializeUnorderedBulkOp()
+
+// Initialize and assign to variable
+db.users.initializeUnorderedBulkOp()
+
+// Initialize with bracket notation
+db["users"].initializeUnorderedBulkOp()
+
+// Initialize with getCollection
+db.getCollection("users").initializeUnorderedBulkOp()
+
+// Unordered bulk operations may execute in any order for efficiency
+db.orders.initializeUnorderedBulkOp()

--- a/mongo/parsertest/testdata/bulk-insert.js
+++ b/mongo/parsertest/testdata/bulk-insert.js
@@ -1,0 +1,19 @@
+// Bulk.insert() - Queue an insert operation
+
+// Basic insert
+db.users.initializeUnorderedBulkOp().insert({ name: "alice", age: 25 })
+
+// Multiple inserts
+db.users.initializeOrderedBulkOp().insert({ name: "bob" }).insert({ name: "charlie" })
+
+// Insert with nested document
+db.users.initializeUnorderedBulkOp().insert({ name: "dave", address: { city: "NYC", zip: "10001" } })
+
+// Insert with array
+db.users.initializeOrderedBulkOp().insert({ name: "eve", tags: ["admin", "user"] })
+
+// Insert with helper functions
+db.users.initializeUnorderedBulkOp().insert({ name: "frank", createdAt: ISODate(), id: UUID("550e8400-e29b-41d4-a716-446655440000") })
+
+// Insert and execute
+db.users.initializeOrderedBulkOp().insert({ name: "grace" }).execute()

--- a/mongo/parsertest/testdata/bulk-mixed.js
+++ b/mongo/parsertest/testdata/bulk-mixed.js
@@ -1,0 +1,19 @@
+// Bulk mixed operations - Combining insert, update, and remove in one bulk
+
+// Mixed insert and update
+db.users.initializeOrderedBulkOp().insert({ name: "alice", status: "new" }).find({ status: "inactive" }).update({ $set: { status: "archived" } })
+
+// Mixed insert, update, and remove
+db.products.initializeUnorderedBulkOp().insert({ sku: "NEW001", name: "New Product" }).find({ discontinued: true }).remove().find({ price: { $lt: 10 } }).updateOne({ $set: { onSale: true } })
+
+// Complex mixed operations with execute
+db.orders.initializeOrderedBulkOp().insert({ orderId: "ORD100", status: "pending" }).find({ status: "shipped" }).updateOne({ $set: { status: "delivered" } }).find({ status: "cancelled" }).remove().execute()
+
+// Multiple operations of each type
+db.inventory.initializeUnorderedBulkOp().insert({ item: "apple", qty: 100 }).insert({ item: "banana", qty: 50 }).find({ qty: 0 }).remove().find({ qty: { $lt: 10 } }).update({ $set: { lowStock: true } }).execute()
+
+// Mixed with upsert
+db.users.initializeOrderedBulkOp().find({ email: "new@example.com" }).upsert().updateOne({ $set: { name: "New User", email: "new@example.com" } }).insert({ email: "another@example.com", name: "Another User" }).find({ deleted: true }).remove()
+
+// Mixed ordered operations (execute in sequence)
+db.logs.initializeOrderedBulkOp().insert({ level: "info", message: "Process started" }).find({ level: "debug" }).remove().insert({ level: "info", message: "Process completed" }).execute({ w: "majority" })

--- a/mongo/parsertest/testdata/bulk-remove.js
+++ b/mongo/parsertest/testdata/bulk-remove.js
@@ -1,0 +1,16 @@
+// Bulk.find().remove() - Queue a remove operation for matching documents
+
+// Remove all matching documents
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).remove()
+
+// Remove with complex query
+db.users.initializeOrderedBulkOp().find({ age: { $lt: 18 } }).remove()
+
+// Remove and execute
+db.users.initializeUnorderedBulkOp().find({ deleted: true }).remove().execute()
+
+// Multiple removes
+db.users.initializeOrderedBulkOp().find({ role: "guest" }).remove().find({ expired: true }).remove()
+
+// Remove with date condition
+db.logs.initializeUnorderedBulkOp().find({ createdAt: { $lt: ISODate("2023-01-01") } }).remove()

--- a/mongo/parsertest/testdata/bulk-removeOne.js
+++ b/mongo/parsertest/testdata/bulk-removeOne.js
@@ -1,0 +1,16 @@
+// Bulk.find().removeOne() - Queue a remove operation for one matching document
+
+// Remove one matching document
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).removeOne()
+
+// Remove one with complex query
+db.users.initializeOrderedBulkOp().find({ age: { $lt: 18 } }).removeOne()
+
+// Remove one and execute
+db.users.initializeUnorderedBulkOp().find({ deleted: true }).removeOne().execute()
+
+// Multiple remove ones
+db.users.initializeOrderedBulkOp().find({ role: "guest" }).removeOne().find({ expired: true }).removeOne()
+
+// Remove one with ObjectId
+db.users.initializeUnorderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") }).removeOne()

--- a/mongo/parsertest/testdata/bulk-replaceOne.js
+++ b/mongo/parsertest/testdata/bulk-replaceOne.js
@@ -1,0 +1,16 @@
+// Bulk.find().replaceOne() - Queue a replace operation for one matching document
+
+// Basic replaceOne
+db.users.initializeUnorderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") }).replaceOne({ name: "Alice Updated", email: "alice@example.com", age: 26 })
+
+// ReplaceOne with query
+db.users.initializeOrderedBulkOp().find({ email: "bob@example.com" }).replaceOne({ name: "Bob New", email: "bob@example.com", role: "admin" })
+
+// ReplaceOne and execute
+db.products.initializeUnorderedBulkOp().find({ sku: "ABC123" }).replaceOne({ sku: "ABC123", name: "Widget", price: 19.99 }).execute()
+
+// Multiple replaceOnes
+db.users.initializeOrderedBulkOp().find({ name: "alice" }).replaceOne({ name: "Alice", status: "active" }).find({ name: "bob" }).replaceOne({ name: "Bob", status: "inactive" })
+
+// ReplaceOne with nested document
+db.orders.initializeUnorderedBulkOp().find({ orderId: "ORD001" }).replaceOne({ orderId: "ORD001", items: [{ name: "apple", qty: 5 }], total: 25.00 })

--- a/mongo/parsertest/testdata/bulk-toString.js
+++ b/mongo/parsertest/testdata/bulk-toString.js
@@ -1,0 +1,16 @@
+// Bulk.toString() - Get string representation of bulk operation
+
+// Basic toString
+db.users.initializeUnorderedBulkOp().toString()
+
+// ToString after inserts
+db.users.initializeOrderedBulkOp().insert({ name: "alice" }).toString()
+
+// ToString after updates
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).update({ $set: { status: "archived" } }).toString()
+
+// ToString for ordered bulk
+db.products.initializeOrderedBulkOp().insert({ sku: "A001" }).insert({ sku: "A002" }).toString()
+
+// ToString after mixed operations
+db.orders.initializeUnorderedBulkOp().insert({ item: "apple" }).find({ qty: 0 }).remove().toString()

--- a/mongo/parsertest/testdata/bulk-tojson.js
+++ b/mongo/parsertest/testdata/bulk-tojson.js
@@ -1,0 +1,16 @@
+// Bulk.tojson() - Get JSON representation of bulk operation
+
+// Basic tojson
+db.users.initializeUnorderedBulkOp().tojson()
+
+// Tojson after inserts
+db.users.initializeOrderedBulkOp().insert({ name: "alice" }).tojson()
+
+// Tojson after updates
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).update({ $set: { status: "archived" } }).tojson()
+
+// Tojson for ordered bulk
+db.products.initializeOrderedBulkOp().insert({ sku: "A001" }).insert({ sku: "A002" }).tojson()
+
+// Tojson after mixed operations
+db.orders.initializeUnorderedBulkOp().insert({ item: "apple" }).find({ qty: 0 }).remove().tojson()

--- a/mongo/parsertest/testdata/bulk-update.js
+++ b/mongo/parsertest/testdata/bulk-update.js
@@ -1,0 +1,16 @@
+// Bulk.find().update() - Queue an update operation for matching documents
+
+// Update all matching documents
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).update({ $set: { status: "archived" } })
+
+// Update with multiple operators
+db.users.initializeOrderedBulkOp().find({ role: "user" }).update({ $set: { verified: true }, $inc: { loginCount: 1 } })
+
+// Update and execute
+db.users.initializeUnorderedBulkOp().find({ needsUpdate: true }).update({ $set: { updated: true } }).execute()
+
+// Multiple updates
+db.users.initializeOrderedBulkOp().find({ tier: "free" }).update({ $set: { tier: "basic" } }).find({ tier: "basic" }).update({ $set: { tier: "premium" } })
+
+// Update with array operators
+db.users.initializeUnorderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") }).update({ $push: { tags: "active" } })

--- a/mongo/parsertest/testdata/bulk-updateOne.js
+++ b/mongo/parsertest/testdata/bulk-updateOne.js
@@ -1,0 +1,16 @@
+// Bulk.find().updateOne() - Queue an update operation for one matching document
+
+// Update one matching document
+db.users.initializeUnorderedBulkOp().find({ status: "inactive" }).updateOne({ $set: { status: "active" } })
+
+// Update one with complex query
+db.users.initializeOrderedBulkOp().find({ email: "alice@example.com" }).updateOne({ $set: { verified: true } })
+
+// Update one and execute
+db.users.initializeUnorderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") }).updateOne({ $inc: { count: 1 } }).execute()
+
+// Multiple update ones
+db.users.initializeOrderedBulkOp().find({ name: "alice" }).updateOne({ $set: { active: true } }).find({ name: "bob" }).updateOne({ $set: { active: false } })
+
+// Update one with unset
+db.users.initializeUnorderedBulkOp().find({ tempField: { $exists: true } }).updateOne({ $unset: { tempField: "" } })

--- a/mongo/parsertest/testdata/bulk-updateOneWithArrayFilters.js
+++ b/mongo/parsertest/testdata/bulk-updateOneWithArrayFilters.js
@@ -1,0 +1,16 @@
+// Bulk.find().arrayFilters().updateOne() - UpdateOne with array filters
+
+// Basic updateOne with arrayFilters
+db.users.initializeUnorderedBulkOp().find({ _id: ObjectId("507f1f77bcf86cd799439011") }).arrayFilters([{ "elem.status": "pending" }]).updateOne({ $set: { "tasks.$[elem].status": "completed" } })
+
+// UpdateOne with multiple array filters
+db.orders.initializeOrderedBulkOp().find({ customerId: "C001" }).arrayFilters([{ "item.qty": { $gt: 5 } }, { "item.price": { $gte: 100 } }]).updateOne({ $set: { "items.$[item].priority": "high" } })
+
+// UpdateOne with nested array filter
+db.inventory.initializeUnorderedBulkOp().find({ warehouse: "main" }).arrayFilters([{ "bin.count": { $lt: 10 } }]).updateOne({ $set: { "bins.$[bin].needsRestock": true } })
+
+// Chained operations with arrayFilters
+db.students.initializeOrderedBulkOp().find({ class: "Math101" }).arrayFilters([{ "g.score": { $gte: 90 } }]).updateOne({ $set: { "grades.$[g].letter": "A" } }).find({ class: "Math101" }).arrayFilters([{ "g.score": { $lt: 60 } }]).updateOne({ $set: { "grades.$[g].letter": "F" } })
+
+// UpdateOne with arrayFilters and execute
+db.products.initializeUnorderedBulkOp().find({ category: "clothing" }).arrayFilters([{ "size.stock": 0 }]).updateOne({ $set: { "sizes.$[size].outOfStock": true } }).execute()

--- a/mongo/parsertest/testdata/bulk-updateOneWithHint.js
+++ b/mongo/parsertest/testdata/bulk-updateOneWithHint.js
@@ -1,0 +1,16 @@
+// Bulk.find().hint().updateOne() - UpdateOne with index hint
+
+// UpdateOne with string hint
+db.users.initializeUnorderedBulkOp().find({ email: "alice@example.com" }).hint("email_1").updateOne({ $set: { lastLogin: ISODate() } })
+
+// UpdateOne with document hint
+db.orders.initializeOrderedBulkOp().find({ orderId: "ORD001" }).hint({ orderId: 1 }).updateOne({ $set: { status: "shipped" } })
+
+// Chained find with hint and updateOne
+db.products.initializeUnorderedBulkOp().find({ sku: "ABC123" }).hint({ sku: 1, warehouse: 1 }).updateOne({ $inc: { stock: -1 } })
+
+// Multiple updateOnes with hints
+db.inventory.initializeOrderedBulkOp().find({ item: "apple" }).hint("item_1").updateOne({ $set: { fresh: true } }).find({ item: "banana" }).hint("item_1").updateOne({ $set: { fresh: true } })
+
+// UpdateOne with hint and execute
+db.logs.initializeUnorderedBulkOp().find({ level: "error", timestamp: { $lt: ISODate() } }).hint("level_1_timestamp_-1").updateOne({ $set: { archived: true } }).execute()

--- a/mongo/parsertest/testdata/bulk-upsert.js
+++ b/mongo/parsertest/testdata/bulk-upsert.js
@@ -1,0 +1,16 @@
+// Bulk.find().upsert() - Set upsert flag for update operations
+
+// Upsert with updateOne
+db.users.initializeUnorderedBulkOp().find({ email: "alice@example.com" }).upsert().updateOne({ $set: { name: "Alice", email: "alice@example.com" } })
+
+// Upsert with update
+db.users.initializeOrderedBulkOp().find({ sku: "ABC123" }).upsert().update({ $set: { sku: "ABC123", qty: 100 } })
+
+// Upsert with replaceOne
+db.users.initializeUnorderedBulkOp().find({ email: "bob@example.com" }).upsert().replaceOne({ name: "Bob", email: "bob@example.com", role: "user" })
+
+// Upsert and execute
+db.products.initializeOrderedBulkOp().find({ sku: "XYZ789" }).upsert().updateOne({ $set: { price: 29.99 } }).execute()
+
+// Multiple upserts
+db.inventory.initializeUnorderedBulkOp().find({ item: "apple" }).upsert().updateOne({ $set: { qty: 50 } }).find({ item: "banana" }).upsert().updateOne({ $set: { qty: 30 } })

--- a/mongo/parsertest/testdata/collection-aggregate.js
+++ b/mongo/parsertest/testdata/collection-aggregate.js
@@ -1,0 +1,107 @@
+// db.collection.aggregate() - Aggregation pipeline
+
+// Empty pipeline
+db.orders.aggregate([])
+
+// Single stage pipelines
+db.orders.aggregate([{ $match: { status: "completed" } }])
+db.orders.aggregate([{ $group: { _id: "$category", count: { $sum: 1 } } }])
+db.orders.aggregate([{ $sort: { createdAt: -1 } }])
+db.orders.aggregate([{ $limit: 10 }])
+db.orders.aggregate([{ $skip: 20 }])
+db.orders.aggregate([{ $project: { name: 1, total: 1, _id: 0 } }])
+db.orders.aggregate([{ $unwind: "$items" }])
+db.orders.aggregate([{ $count: "totalOrders" }])
+
+// $match stage variations
+db.users.aggregate([{ $match: { age: { $gt: 18 } } }])
+db.users.aggregate([{ $match: { status: { $in: ["active", "pending"] } } }])
+db.users.aggregate([{ $match: { $or: [{ role: "admin" }, { role: "moderator" }] } }])
+db.users.aggregate([{ $match: { "address.country": "USA" } }])
+
+// $group stage variations
+db.orders.aggregate([{ $group: { _id: "$customerId", total: { $sum: "$amount" } } }])
+db.orders.aggregate([{ $group: { _id: "$category", avgPrice: { $avg: "$price" } } }])
+db.orders.aggregate([{ $group: { _id: "$status", count: { $sum: 1 }, items: { $push: "$name" } } }])
+db.orders.aggregate([{ $group: { _id: null, totalRevenue: { $sum: "$amount" } } }])
+db.sales.aggregate([{ $group: { _id: { year: { $year: "$date" }, month: { $month: "$date" } }, total: { $sum: "$amount" } } }])
+
+// $project stage variations
+db.users.aggregate([{ $project: { name: 1, email: 1 } }])
+db.users.aggregate([{ $project: { password: 0, ssn: 0 } }])
+db.users.aggregate([{ $project: { fullName: { $concat: ["$firstName", " ", "$lastName"] } } }])
+db.orders.aggregate([{ $project: { total: { $multiply: ["$price", "$quantity"] } } }])
+
+// $sort stage variations
+db.users.aggregate([{ $sort: { name: 1 } }])
+db.users.aggregate([{ $sort: { createdAt: -1 } }])
+db.users.aggregate([{ $sort: { lastName: 1, firstName: 1 } }])
+
+// $lookup stage (join)
+db.orders.aggregate([{ $lookup: { from: "users", localField: "customerId", foreignField: "_id", as: "customer" } }])
+db.orders.aggregate([{ $lookup: { from: "products", localField: "productIds", foreignField: "_id", as: "products" } }])
+
+// Multi-stage pipelines
+db.orders.aggregate([
+    { $match: { status: "completed" } },
+    { $group: { _id: "$customerId", total: { $sum: "$amount" } } },
+    { $sort: { total: -1 } },
+    { $limit: 10 }
+])
+
+db.sales.aggregate([
+    { $match: { date: { $gte: ISODate("2024-01-01"), $lt: ISODate("2025-01-01") } } },
+    { $group: {
+        _id: { year: { $year: "$date" }, month: { $month: "$date" } },
+        totalRevenue: { $sum: "$amount" },
+        avgOrderValue: { $avg: "$amount" },
+        orderCount: { $sum: 1 }
+    } },
+    { $sort: { "_id.year": 1, "_id.month": 1 } }
+])
+
+db.users.aggregate([
+    { $match: { status: "active" } },
+    { $lookup: { from: "orders", localField: "_id", foreignField: "customerId", as: "orders" } },
+    { $project: { name: 1, email: 1, orderCount: { $size: "$orders" } } },
+    { $sort: { orderCount: -1 } },
+    { $limit: 100 }
+])
+
+// Pipeline with $addFields
+db.orders.aggregate([
+    { $addFields: { totalWithTax: { $multiply: ["$total", 1.1] } } }
+])
+
+// Pipeline with $set (alias for $addFields)
+db.orders.aggregate([
+    { $set: { processed: true, processedAt: ISODate() } }
+])
+
+// Pipeline with $unset
+db.users.aggregate([
+    { $unset: ["password", "ssn", "internalNotes"] }
+])
+
+// Pipeline with $replaceRoot
+db.orders.aggregate([
+    { $replaceRoot: { newRoot: "$shipping" } }
+])
+
+// Pipeline with $facet (multiple pipelines)
+db.products.aggregate([
+    { $facet: {
+        categoryCounts: [{ $group: { _id: "$category", count: { $sum: 1 } } }],
+        priceStats: [{ $group: { _id: null, avgPrice: { $avg: "$price" }, maxPrice: { $max: "$price" } } }]
+    } }
+])
+
+// Aggregate with options (options passed to driver)
+db.orders.aggregate([{ $match: { status: "completed" } }], { allowDiskUse: true })
+db.orders.aggregate([{ $group: { _id: "$category" } }], { maxTimeMS: 60000 })
+db.orders.aggregate([{ $sort: { total: -1 } }], { collation: { locale: "en" } })
+
+// Aggregate with collection access patterns
+db["orders"].aggregate([{ $match: { status: "pending" } }])
+db['audit-logs'].aggregate([{ $group: { _id: "$action", count: { $sum: 1 } } }])
+db.getCollection("sales").aggregate([{ $match: { year: 2024 } }])

--- a/mongo/parsertest/testdata/collection-analyzeShardKey.js
+++ b/mongo/parsertest/testdata/collection-analyzeShardKey.js
@@ -1,0 +1,43 @@
+// db.collection.analyzeShardKey() - Analyze a shard key for a collection
+
+// Analyze simple shard key
+db.users.analyzeShardKey({ email: 1 })
+db.orders.analyzeShardKey({ customerId: 1 })
+db.products.analyzeShardKey({ category: 1 })
+
+// Analyze compound shard key
+db.orders.analyzeShardKey({ customerId: 1, createdAt: 1 })
+db.events.analyzeShardKey({ tenantId: 1, timestamp: 1 })
+db.logs.analyzeShardKey({ source: 1, level: 1, timestamp: 1 })
+
+// Analyze hashed shard key
+db.users.analyzeShardKey({ _id: "hashed" })
+db.sessions.analyzeShardKey({ sessionId: "hashed" })
+
+// Analyze with options
+db.orders.analyzeShardKey({ customerId: 1 }, { keyCharacteristics: true })
+db.products.analyzeShardKey({ sku: 1 }, { readWriteDistribution: true })
+
+// Analyze with sampleRate
+db.largeCollection.analyzeShardKey({ userId: 1 }, { sampleRate: 0.1 })
+db.analytics.analyzeShardKey({ eventType: 1 }, { sampleRate: 0.05 })
+
+// Analyze with sampleSize
+db.orders.analyzeShardKey({ region: 1 }, { sampleSize: 10000 })
+
+// Analyze with all options
+db.transactions.analyzeShardKey(
+    { accountId: 1, transactionDate: 1 },
+    {
+        keyCharacteristics: true,
+        readWriteDistribution: true,
+        sampleRate: 0.2
+    }
+)
+
+// Collection access patterns
+db["users"].analyzeShardKey({ userId: 1 })
+db["users"].analyzeShardKey({ email: 1 }, { keyCharacteristics: true })
+db.getCollection("users").analyzeShardKey({ tenantId: 1 })
+db.getCollection("orders").analyzeShardKey({ customerId: 1, orderId: 1 })
+db["event-logs"].analyzeShardKey({ source: 1, timestamp: 1 })

--- a/mongo/parsertest/testdata/collection-bulkWrite.js
+++ b/mongo/parsertest/testdata/collection-bulkWrite.js
@@ -1,0 +1,53 @@
+// db.collection.bulkWrite() - Bulk write operations (unsupported - use individual write commands)
+
+// Basic bulk write with insert
+db.users.bulkWrite([
+    { insertOne: { document: { name: "alice", age: 25 } } }
+])
+
+// Bulk write with multiple operations
+db.users.bulkWrite([
+    { insertOne: { document: { name: "alice", age: 25 } } },
+    { insertOne: { document: { name: "bob", age: 30 } } },
+    { updateOne: { filter: { name: "charlie" }, update: { $set: { age: 35 } } } },
+    { updateMany: { filter: { status: "pending" }, update: { $set: { status: "active" } } } },
+    { deleteOne: { filter: { name: "dave" } } },
+    { deleteMany: { filter: { status: "deleted" } } },
+    { replaceOne: { filter: { name: "eve" }, replacement: { name: "eve", age: 28 } } }
+])
+
+// Bulk write with options
+db.orders.bulkWrite([
+    { insertOne: { document: { orderId: 1, status: "new" } } },
+    { updateOne: { filter: { orderId: 2 }, update: { $set: { status: "shipped" } } } }
+], { ordered: false })
+
+db.products.bulkWrite([
+    { deleteOne: { filter: { discontinued: true } } }
+], { ordered: true })
+
+// Bulk write with write concern
+db.inventory.bulkWrite([
+    { updateMany: { filter: { qty: { $lt: 10 } }, update: { $set: { reorder: true } } } }
+], { writeConcern: { w: "majority" } })
+
+// Bulk write with upsert in update operations
+db.users.bulkWrite([
+    { updateOne: { filter: { email: "test@example.com" }, update: { $set: { name: "Test User" } }, upsert: true } },
+    { replaceOne: { filter: { code: "ABC" }, replacement: { code: "ABC", value: 100 }, upsert: true } }
+])
+
+// Bulk write with array filters
+db.inventory.bulkWrite([
+    { updateOne: { filter: { item: "abc123" }, update: { $set: { "sizes.$[size].qty": 0 } }, arrayFilters: [{ "size.type": "small" }] } }
+])
+
+// Bulk write with collation
+db.products.bulkWrite([
+    { deleteMany: { filter: { category: "electronics" } } }
+], { ordered: false, collation: { locale: "en", strength: 2 } })
+
+// Collection access patterns
+db["users"].bulkWrite([{ insertOne: { document: { x: 1 } } }])
+db.getCollection("users").bulkWrite([{ insertOne: { document: { y: 1 } } }])
+db["user-data"].bulkWrite([{ deleteOne: { filter: { expired: true } } }], { ordered: false })

--- a/mongo/parsertest/testdata/collection-compactStructuredEncryptionData.js
+++ b/mongo/parsertest/testdata/collection-compactStructuredEncryptionData.js
@@ -1,0 +1,21 @@
+// db.collection.compactStructuredEncryptionData() - Compact encrypted data structures
+
+// Basic compaction
+db.users.compactStructuredEncryptionData()
+db.orders.compactStructuredEncryptionData()
+db.medicalRecords.compactStructuredEncryptionData()
+
+// Compact with options
+db.financialData.compactStructuredEncryptionData({})
+db.sensitiveData.compactStructuredEncryptionData({})
+
+// Compact encrypted collections
+db.encryptedPII.compactStructuredEncryptionData()
+db.patientRecords.compactStructuredEncryptionData()
+db.creditCards.compactStructuredEncryptionData()
+
+// Collection access patterns
+db["users"].compactStructuredEncryptionData()
+db.getCollection("users").compactStructuredEncryptionData()
+db["encrypted-data"].compactStructuredEncryptionData()
+db.getCollection("sensitive.records").compactStructuredEncryptionData()

--- a/mongo/parsertest/testdata/collection-configureQueryAnalyzer.js
+++ b/mongo/parsertest/testdata/collection-configureQueryAnalyzer.js
@@ -1,0 +1,32 @@
+// db.collection.configureQueryAnalyzer() - Configure query analyzer for a collection
+
+// Enable query analyzer with mode
+db.users.configureQueryAnalyzer({ mode: "full" })
+db.orders.configureQueryAnalyzer({ mode: "off" })
+
+// Configure with sample rate
+db.products.configureQueryAnalyzer({ mode: "full", sampleRate: 100 })
+db.events.configureQueryAnalyzer({ mode: "full", sampleRate: 50 })
+db.logs.configureQueryAnalyzer({ mode: "full", sampleRate: 10 })
+
+// Disable query analyzer
+db.users.configureQueryAnalyzer({ mode: "off" })
+db.analytics.configureQueryAnalyzer({ mode: "off" })
+
+// Configure for specific analysis
+db.orders.configureQueryAnalyzer({
+    mode: "full",
+    sampleRate: 200
+})
+
+db.transactions.configureQueryAnalyzer({
+    mode: "full",
+    sampleRate: 1000
+})
+
+// Collection access patterns
+db["users"].configureQueryAnalyzer({ mode: "full" })
+db["users"].configureQueryAnalyzer({ mode: "full", sampleRate: 100 })
+db.getCollection("users").configureQueryAnalyzer({ mode: "off" })
+db.getCollection("orders").configureQueryAnalyzer({ mode: "full", sampleRate: 50 })
+db["query-logs"].configureQueryAnalyzer({ mode: "full", sampleRate: 25 })

--- a/mongo/parsertest/testdata/collection-count.js
+++ b/mongo/parsertest/testdata/collection-count.js
@@ -1,0 +1,36 @@
+// db.collection.count() - Count documents (deprecated - use countDocuments or estimatedDocumentCount)
+
+// Basic count
+db.users.count()
+db.orders.count()
+
+// Count with filter
+db.users.count({ status: "active" })
+db.users.count({ age: { $gte: 18 } })
+db.orders.count({ status: "pending", customerId: ObjectId("507f1f77bcf86cd799439011") })
+
+// Count with complex filter
+db.users.count({ $or: [{ status: "active" }, { role: "admin" }] })
+db.products.count({ price: { $gte: 10, $lte: 100 }, inStock: true })
+
+// Count with options
+db.users.count({ status: "active" }, { limit: 1000 })
+db.orders.count({ createdAt: { $gte: ISODate("2024-01-01") } }, { skip: 10 })
+db.products.count({}, { limit: 100, skip: 50 })
+
+// Count with hint
+db.users.count({ email: { $exists: true } }, { hint: { email: 1 } })
+db.orders.count({ customerId: 123 }, { hint: "customerId_1" })
+
+// Count with maxTimeMS
+db.largeCollection.count({ type: "log" }, { maxTimeMS: 5000 })
+
+// Count with readConcern
+db.users.count({ active: true }, { readConcern: { level: "majority" } })
+
+// Collection access patterns
+db["users"].count()
+db["users"].count({ status: "active" })
+db.getCollection("users").count()
+db.getCollection("users").count({ role: "admin" })
+db["user-events"].count({ type: "login" })

--- a/mongo/parsertest/testdata/collection-countDocuments.js
+++ b/mongo/parsertest/testdata/collection-countDocuments.js
@@ -1,0 +1,45 @@
+// db.collection.countDocuments() - Count documents matching a filter
+
+// Count all documents
+db.users.countDocuments()
+db.users.countDocuments({})
+
+// Count with simple filter
+db.users.countDocuments({ status: "active" })
+db.users.countDocuments({ verified: true })
+db.users.countDocuments({ role: "admin" })
+
+// Count with comparison operators
+db.users.countDocuments({ age: { $gt: 18 } })
+db.users.countDocuments({ age: { $gte: 21, $lt: 65 } })
+db.users.countDocuments({ loginCount: { $gte: 10 } })
+
+// Count with logical operators
+db.users.countDocuments({ $or: [{ status: "active" }, { status: "pending" }] })
+db.users.countDocuments({ $and: [{ verified: true }, { active: true }] })
+
+// Count with array operators
+db.users.countDocuments({ tags: { $in: ["premium", "enterprise"] } })
+db.users.countDocuments({ roles: { $all: ["read", "write"] } })
+
+// Count with existence check
+db.users.countDocuments({ email: { $exists: true } })
+db.users.countDocuments({ deletedAt: { $exists: false } })
+
+// Count with nested documents
+db.users.countDocuments({ "address.country": "USA" })
+db.users.countDocuments({ "profile.verified": true })
+
+// Count with helper functions
+db.users.countDocuments({ createdAt: { $gt: ISODate("2024-01-01") } })
+db.users.countDocuments({ lastLogin: { $lt: ISODate("2024-06-01") } })
+
+// Count with options (options passed to driver)
+db.users.countDocuments({ status: "active" }, { skip: 10, limit: 100 })
+db.users.countDocuments({ verified: true }, { maxTimeMS: 5000 })
+db.users.countDocuments({}, { hint: { status: 1 } })
+
+// Count with collection access patterns
+db["users"].countDocuments({ active: true })
+db['audit-logs'].countDocuments({ level: "error" })
+db.getCollection("orders").countDocuments({ status: "completed" })

--- a/mongo/parsertest/testdata/collection-createIndex.js
+++ b/mongo/parsertest/testdata/collection-createIndex.js
@@ -1,0 +1,40 @@
+// db.collection.createIndex() - Create an index on a collection
+
+// Basic single field index
+db.users.createIndex({ email: 1 })
+db.users.createIndex({ age: -1 })
+
+// Compound index
+db.users.createIndex({ lastName: 1, firstName: 1 })
+db.orders.createIndex({ customerId: 1, createdAt: -1 })
+
+// Text index
+db.articles.createIndex({ content: "text" })
+db.posts.createIndex({ title: "text", body: "text" })
+
+// Unique index
+db.users.createIndex({ email: 1 }, { unique: true })
+
+// Sparse index
+db.users.createIndex({ phone: 1 }, { sparse: true })
+
+// TTL index
+db.sessions.createIndex({ createdAt: 1 }, { expireAfterSeconds: 3600 })
+
+// Partial index
+db.orders.createIndex({ status: 1 }, { partialFilterExpression: { status: "pending" } })
+
+// Index with options
+db.users.createIndex({ username: 1 }, { unique: true, background: true })
+db.products.createIndex({ name: 1, category: 1 }, { name: "name_category_idx" })
+
+// Hashed index
+db.users.createIndex({ hashedField: "hashed" })
+
+// Geospatial index
+db.places.createIndex({ location: "2dsphere" })
+db.stores.createIndex({ coordinates: "2d" })
+
+// Collection access patterns
+db["users"].createIndex({ email: 1 })
+db.getCollection("users").createIndex({ email: 1 })

--- a/mongo/parsertest/testdata/collection-createIndexes.js
+++ b/mongo/parsertest/testdata/collection-createIndexes.js
@@ -1,0 +1,31 @@
+// db.collection.createIndexes() - Create multiple indexes on a collection
+
+// Create multiple indexes at once
+db.users.createIndexes([
+    { key: { email: 1 }, unique: true },
+    { key: { username: 1 } },
+    { key: { createdAt: -1 } }
+])
+
+// Create indexes with options
+db.orders.createIndexes([
+    { key: { customerId: 1 } },
+    { key: { status: 1 }, sparse: true },
+    { key: { orderDate: -1 }, name: "order_date_idx" }
+])
+
+// Create compound indexes
+db.products.createIndexes([
+    { key: { category: 1, name: 1 } },
+    { key: { price: 1, rating: -1 } }
+])
+
+// With write concern options
+db.users.createIndexes(
+    [{ key: { email: 1 } }],
+    { commitQuorum: "majority" }
+)
+
+// Collection access patterns
+db["users"].createIndexes([{ key: { email: 1 } }])
+db.getCollection("users").createIndexes([{ key: { email: 1 } }])

--- a/mongo/parsertest/testdata/collection-dataSize.js
+++ b/mongo/parsertest/testdata/collection-dataSize.js
@@ -1,0 +1,13 @@
+// db.collection.dataSize() - Get the size of the collection's data in bytes
+
+// Basic usage
+db.users.dataSize()
+db.orders.dataSize()
+db.products.dataSize()
+db.logs.dataSize()
+
+// Collection access patterns
+db["users"].dataSize()
+db.getCollection("users").dataSize()
+db["large-collection"].dataSize()
+db.getCollection("archived.orders").dataSize()

--- a/mongo/parsertest/testdata/collection-deleteMany.js
+++ b/mongo/parsertest/testdata/collection-deleteMany.js
@@ -1,0 +1,20 @@
+// db.collection.deleteMany() - Delete multiple documents
+
+// Basic delete
+db.users.deleteMany({ status: "inactive" })
+
+// Delete all documents
+db.users.deleteMany({})
+
+// Delete with comparison operators
+db.users.deleteMany({ lastLogin: { $lt: ISODate("2023-01-01") } })
+
+// Delete with logical operators
+db.users.deleteMany({ $or: [{ deleted: true }, { banned: true }] })
+
+// Delete with options
+db.users.deleteMany({ temp: true }, { writeConcern: { w: "majority" } })
+
+// Collection access patterns
+db["logs"].deleteMany({ level: "debug" })
+db.getCollection("sessions").deleteMany({ expired: true })

--- a/mongo/parsertest/testdata/collection-deleteOne.js
+++ b/mongo/parsertest/testdata/collection-deleteOne.js
@@ -1,0 +1,17 @@
+// db.collection.deleteOne() - Delete a single document
+
+// Basic delete
+db.users.deleteOne({ name: "alice" })
+
+// Delete by _id
+db.users.deleteOne({ _id: ObjectId("507f1f77bcf86cd799439011") })
+
+// Delete with comparison operators
+db.users.deleteOne({ createdAt: { $lt: ISODate("2020-01-01") } })
+
+// Delete with options
+db.users.deleteOne({ status: "deleted" }, { writeConcern: { w: 1 } })
+
+// Collection access patterns
+db["users"].deleteOne({ temp: true })
+db.getCollection("users").deleteOne({ expired: true })

--- a/mongo/parsertest/testdata/collection-distinct.js
+++ b/mongo/parsertest/testdata/collection-distinct.js
@@ -1,0 +1,43 @@
+// db.collection.distinct() - Find distinct values for a field
+
+// Distinct with field only (required)
+db.users.distinct("status")
+db.users.distinct("country")
+db.users.distinct("role")
+db.orders.distinct("category")
+db.products.distinct("brand")
+
+// Distinct with nested field
+db.users.distinct("address.city")
+db.users.distinct("address.country")
+db.users.distinct("profile.department")
+
+// Distinct with field and empty query
+db.users.distinct("status", {})
+db.users.distinct("city", {})
+
+// Distinct with field and filter query
+db.users.distinct("city", { country: "USA" })
+db.users.distinct("status", { active: true })
+db.users.distinct("role", { department: "engineering" })
+db.orders.distinct("productId", { status: "completed" })
+
+// Distinct with comparison operators in query
+db.users.distinct("city", { age: { $gt: 18 } })
+db.users.distinct("status", { createdAt: { $gt: ISODate("2024-01-01") } })
+
+// Distinct with logical operators in query
+db.users.distinct("role", { $or: [{ active: true }, { verified: true }] })
+db.users.distinct("department", { $and: [{ status: "active" }, { role: "employee" }] })
+
+// Distinct with array operators in query
+db.users.distinct("city", { tags: { $in: ["premium", "enterprise"] } })
+
+// Distinct with field, query, and options (options passed to driver)
+db.users.distinct("email", { status: "active" }, { collation: { locale: "en" } })
+db.users.distinct("name", {}, { maxTimeMS: 5000 })
+
+// Distinct with collection access patterns
+db["users"].distinct("status")
+db['audit-logs'].distinct("action")
+db.getCollection("orders").distinct("status", { year: 2024 })

--- a/mongo/parsertest/testdata/collection-drop.js
+++ b/mongo/parsertest/testdata/collection-drop.js
@@ -1,0 +1,15 @@
+// db.collection.drop() - Drop a collection from the database
+
+// Basic drop
+db.users.drop()
+db.orders.drop()
+db.tempData.drop()
+
+// Drop with write concern
+db.logs.drop({ writeConcern: { w: "majority" } })
+
+// Collection access patterns
+db["users"].drop()
+db.getCollection("users").drop()
+db["temp-data"].drop()
+db.getCollection("archived.orders").drop()

--- a/mongo/parsertest/testdata/collection-dropIndex.js
+++ b/mongo/parsertest/testdata/collection-dropIndex.js
@@ -1,0 +1,19 @@
+// db.collection.dropIndex() - Drop an index from a collection
+
+// Drop by index name
+db.users.dropIndex("email_1")
+db.orders.dropIndex("customerId_1_createdAt_-1")
+
+// Drop by index key pattern
+db.users.dropIndex({ email: 1 })
+db.orders.dropIndex({ customerId: 1, createdAt: -1 })
+
+// Drop text index
+db.articles.dropIndex("content_text")
+
+// Drop geospatial index
+db.places.dropIndex({ location: "2dsphere" })
+
+// Collection access patterns
+db["users"].dropIndex("email_1")
+db.getCollection("users").dropIndex({ email: 1 })

--- a/mongo/parsertest/testdata/collection-dropIndexes.js
+++ b/mongo/parsertest/testdata/collection-dropIndexes.js
@@ -1,0 +1,20 @@
+// db.collection.dropIndexes() - Drop all indexes or specified indexes from a collection
+
+// Drop all indexes (except _id)
+db.users.dropIndexes()
+db.orders.dropIndexes()
+
+// Drop specific index by name
+db.users.dropIndexes("email_1")
+
+// Drop multiple indexes by name
+db.users.dropIndexes(["email_1", "username_1"])
+
+// Drop index by key pattern
+db.orders.dropIndexes({ customerId: 1 })
+
+// Collection access patterns
+db["users"].dropIndexes()
+db.getCollection("users").dropIndexes()
+db["orders"].dropIndexes("status_1")
+db.getCollection("orders").dropIndexes(["idx1", "idx2"])

--- a/mongo/parsertest/testdata/collection-estimatedDocumentCount.js
+++ b/mongo/parsertest/testdata/collection-estimatedDocumentCount.js
@@ -1,0 +1,17 @@
+// db.collection.estimatedDocumentCount() - Fast estimated count using collection metadata
+
+// Basic estimated count (no filter - uses metadata)
+db.users.estimatedDocumentCount()
+db.orders.estimatedDocumentCount()
+db.products.estimatedDocumentCount()
+
+// Estimated count with options (options passed to driver)
+db.users.estimatedDocumentCount({})
+db.users.estimatedDocumentCount({ maxTimeMS: 1000 })
+db.users.estimatedDocumentCount({ maxTimeMS: 5000 })
+
+// Estimated count with collection access patterns
+db["users"].estimatedDocumentCount()
+db['audit-logs'].estimatedDocumentCount()
+db.getCollection("orders").estimatedDocumentCount()
+db.getCollection("large-collection").estimatedDocumentCount({ maxTimeMS: 10000 })

--- a/mongo/parsertest/testdata/collection-explain.js
+++ b/mongo/parsertest/testdata/collection-explain.js
@@ -1,0 +1,49 @@
+// db.collection.explain() - Return explain plan for query operations (unsupported)
+
+// Basic explain
+db.users.explain()
+db.orders.explain()
+
+// Explain with verbosity modes
+db.users.explain("queryPlanner")
+db.users.explain("executionStats")
+db.users.explain("allPlansExecution")
+
+// Explain find operations
+db.users.explain().find({ status: "active" })
+db.users.explain("executionStats").find({ age: { $gt: 25 } })
+db.orders.explain("allPlansExecution").find({ customerId: 123, status: "pending" })
+
+// Explain find with sort and limit
+db.users.explain().find({ status: "active" }).sort({ createdAt: -1 })
+db.users.explain("executionStats").find({}).sort({ age: 1 }).limit(10)
+
+// Explain aggregate operations
+db.users.explain().aggregate([{ $match: { status: "active" } }, { $group: { _id: "$role", count: { $sum: 1 } } }])
+db.orders.explain("executionStats").aggregate([{ $match: { status: "shipped" } }, { $sort: { createdAt: -1 } }])
+
+// Explain count operations
+db.users.explain().count({ status: "active" })
+db.orders.explain("executionStats").count({ createdAt: { $gte: ISODate("2024-01-01") } })
+
+// Explain distinct operations
+db.users.explain().distinct("status")
+db.products.explain("executionStats").distinct("category", { inStock: true })
+
+// Explain update operations
+db.users.explain().update({ name: "alice" }, { $set: { age: 26 } })
+db.orders.explain("executionStats").updateMany({ status: "pending" }, { $set: { status: "cancelled" } })
+
+// Explain delete operations
+db.users.explain().remove({ status: "deleted" })
+db.logs.explain("executionStats").deleteMany({ createdAt: { $lt: ISODate("2023-01-01") } })
+
+// Explain findAndModify operations
+db.users.explain().findAndModify({ query: { name: "alice" }, update: { $inc: { loginCount: 1 } } })
+
+// Collection access patterns
+db["users"].explain()
+db["users"].explain("executionStats")
+db.getCollection("users").explain()
+db.getCollection("orders").explain("allPlansExecution").find({ status: "active" })
+db["user-logs"].explain().find({ level: "error" })

--- a/mongo/parsertest/testdata/collection-find.js
+++ b/mongo/parsertest/testdata/collection-find.js
@@ -1,0 +1,76 @@
+// db.collection.find() - Query documents in a collection
+
+// Basic find
+db.users.find()
+db.users.find({})
+
+// Find with simple filter
+db.users.find({ name: "alice" })
+db.users.find({ age: 25 })
+db.users.find({ status: "active" })
+
+// Find with comparison operators
+db.users.find({ age: { $gt: 25 } })
+db.users.find({ age: { $gte: 18 } })
+db.users.find({ age: { $lt: 65 } })
+db.users.find({ age: { $lte: 30 } })
+db.users.find({ age: { $ne: 0 } })
+db.users.find({ age: { $gte: 18, $lt: 65 } })
+
+// Find with array operators
+db.users.find({ status: { $in: ["active", "pending"] } })
+db.users.find({ status: { $nin: ["deleted", "banned"] } })
+db.users.find({ tags: { $all: ["mongodb", "database"] } })
+db.users.find({ scores: { $elemMatch: { $gt: 80, $lt: 90 } } })
+
+// Find with logical operators
+db.users.find({ $or: [{ name: "alice" }, { name: "bob" }] })
+db.users.find({ $and: [{ age: { $gt: 18 } }, { status: "active" }] })
+db.users.find({ age: { $not: { $lt: 18 } } })
+db.users.find({ $nor: [{ status: "deleted" }, { status: "banned" }] })
+
+// Find with nested documents
+db.users.find({ "address.city": "New York" })
+db.users.find({ "profile.settings.theme": "dark" })
+db.users.find({ profile: { name: "test", active: true } })
+
+// Find with array fields
+db.users.find({ tags: "mongodb" })
+db.users.find({ "tags.0": "primary" })
+
+// Find with existence check
+db.users.find({ email: { $exists: true } })
+db.users.find({ deletedAt: { $exists: false } })
+
+// Find with type check
+db.users.find({ age: { $type: "number" } })
+db.users.find({ name: { $type: "string" } })
+
+// Find with regex
+db.users.find({ name: /^alice/i })
+db.users.find({ email: { $regex: /.*@example\.com$/ } })
+
+// Find with helper functions
+db.users.find({ _id: ObjectId("507f1f77bcf86cd799439011") })
+db.users.find({ createdAt: { $gt: ISODate("2024-01-01T00:00:00Z") } })
+db.users.find({ sessionId: UUID("550e8400-e29b-41d4-a716-446655440000") })
+
+// Find with cursor modifiers
+db.users.find().sort({ age: -1 })
+db.users.find().limit(10)
+db.users.find().skip(5)
+db.users.find().count()
+db.users.find().projection({ name: 1, age: 1 })
+db.users.find().project({ name: 1, email: 1, _id: 0 })
+
+// Find with chained cursor modifiers
+db.users.find().sort({ age: -1 }).limit(10)
+db.users.find().sort({ createdAt: -1 }).skip(20).limit(10)
+db.users.find({ status: "active" }).sort({ name: 1 }).limit(100).skip(0)
+db.users.find({ status: "active" }).sort({ name: 1 }).limit(100).count()
+
+// Find with collection access patterns
+db["users"].find({ name: "alice" })
+db['user-logs'].find({ level: "error" })
+db.getCollection("users").find({ active: true })
+db.getCollection("my.collection").find()

--- a/mongo/parsertest/testdata/collection-findAndModify.js
+++ b/mongo/parsertest/testdata/collection-findAndModify.js
@@ -1,0 +1,96 @@
+// db.collection.findAndModify() - Atomically find and modify a document (unsupported - use findOneAndUpdate/Delete/Replace)
+
+// Basic findAndModify with update
+db.users.findAndModify({
+    query: { name: "alice" },
+    update: { $set: { status: "active" } }
+})
+
+// findAndModify with sort
+db.queue.findAndModify({
+    query: { status: "pending" },
+    sort: { priority: -1, createdAt: 1 },
+    update: { $set: { status: "processing" } }
+})
+
+// findAndModify returning new document
+db.users.findAndModify({
+    query: { _id: ObjectId("507f1f77bcf86cd799439011") },
+    update: { $inc: { score: 10 } },
+    new: true
+})
+
+// findAndModify with upsert
+db.users.findAndModify({
+    query: { email: "test@example.com" },
+    update: { $set: { name: "Test User", active: true } },
+    upsert: true,
+    new: true
+})
+
+// findAndModify with projection
+db.users.findAndModify({
+    query: { name: "bob" },
+    update: { $set: { lastLogin: Date() } },
+    fields: { name: 1, email: 1, lastLogin: 1 }
+})
+
+// findAndModify for removal
+db.users.findAndModify({
+    query: { status: "deleted" },
+    remove: true
+})
+
+// findAndModify with sort for removal
+db.tasks.findAndModify({
+    query: { completed: true },
+    sort: { completedAt: 1 },
+    remove: true
+})
+
+// findAndModify with bypassDocumentValidation
+db.users.findAndModify({
+    query: { _id: 1 },
+    update: { $set: { invalidField: "value" } },
+    bypassDocumentValidation: true
+})
+
+// findAndModify with writeConcern
+db.orders.findAndModify({
+    query: { orderId: 12345 },
+    update: { $set: { status: "confirmed" } },
+    writeConcern: { w: "majority", wtimeout: 5000 }
+})
+
+// findAndModify with collation
+db.products.findAndModify({
+    query: { name: "cafe" },
+    update: { $set: { available: true } },
+    collation: { locale: "fr", strength: 1 }
+})
+
+// findAndModify with arrayFilters
+db.inventory.findAndModify({
+    query: { item: "abc123" },
+    update: { $set: { "sizes.$[elem].qty": 0 } },
+    arrayFilters: [{ "elem.size": "small" }]
+})
+
+// findAndModify with maxTimeMS
+db.largeCollection.findAndModify({
+    query: { type: "temp" },
+    update: { $set: { processed: true } },
+    maxTimeMS: 5000
+})
+
+// findAndModify with let variables
+db.users.findAndModify({
+    query: { $expr: { $eq: ["$_id", "$$targetId"] } },
+    update: { $set: { found: true } },
+    let: { targetId: ObjectId("507f1f77bcf86cd799439011") }
+})
+
+// Collection access patterns
+db["users"].findAndModify({ query: { x: 1 }, update: { $set: { y: 2 } } })
+db.getCollection("users").findAndModify({ query: { a: 1 }, remove: true })
+db["task-queue"].findAndModify({ query: { status: "new" }, sort: { createdAt: 1 }, update: { $set: { status: "taken" } } })

--- a/mongo/parsertest/testdata/collection-findOne.js
+++ b/mongo/parsertest/testdata/collection-findOne.js
@@ -1,0 +1,36 @@
+// db.collection.findOne() - Find a single document in a collection
+
+// Basic findOne
+db.users.findOne()
+db.users.findOne({})
+
+// FindOne with simple filter
+db.users.findOne({ name: "alice" })
+db.users.findOne({ _id: ObjectId("507f1f77bcf86cd799439011") })
+db.users.findOne({ email: "alice@example.com" })
+
+// FindOne with comparison operators
+db.users.findOne({ age: { $gt: 18 } })
+db.users.findOne({ age: { $gte: 21, $lt: 65 } })
+
+// FindOne with logical operators
+db.users.findOne({ $or: [{ name: "alice" }, { email: "alice@example.com" }] })
+db.users.findOne({ $and: [{ status: "active" }, { verified: true }] })
+
+// FindOne with nested documents
+db.users.findOne({ "address.city": "New York" })
+db.users.findOne({ "profile.settings.notifications": true })
+
+// FindOne with array operators
+db.users.findOne({ tags: { $in: ["admin", "moderator"] } })
+db.users.findOne({ roles: { $all: ["read", "write"] } })
+
+// FindOne with helper functions
+db.users.findOne({ createdAt: { $gt: ISODate("2024-01-01") } })
+db.sessions.findOne({ sessionId: UUID("550e8400-e29b-41d4-a716-446655440000") })
+db.orders.findOne({ total: NumberDecimal("99.99") })
+
+// FindOne with collection access patterns
+db["users"].findOne({ name: "bob" })
+db['audit-logs'].findOne({ action: "login" })
+db.getCollection("users").findOne({ active: true })

--- a/mongo/parsertest/testdata/collection-findOneAndDelete.js
+++ b/mongo/parsertest/testdata/collection-findOneAndDelete.js
@@ -1,0 +1,20 @@
+// db.collection.findOneAndDelete() - Find and delete a document atomically
+
+// Basic find and delete
+db.users.findOneAndDelete({ name: "alice" })
+
+// With projection
+db.users.findOneAndDelete({ status: "deleted" }, { projection: { name: 1, email: 1 } })
+
+// With sort (delete oldest)
+db.users.findOneAndDelete({ status: "expired" }, { sort: { createdAt: 1 } })
+
+// Delete by _id
+db.users.findOneAndDelete({ _id: ObjectId("507f1f77bcf86cd799439011") })
+
+// With maxTimeMS
+db.users.findOneAndDelete({ temp: true }, { maxTimeMS: 5000 })
+
+// Collection access patterns
+db["users"].findOneAndDelete({ processed: true })
+db.getCollection("queue").findOneAndDelete({ status: "pending" }, { sort: { priority: -1 } })

--- a/mongo/parsertest/testdata/collection-findOneAndReplace.js
+++ b/mongo/parsertest/testdata/collection-findOneAndReplace.js
@@ -1,0 +1,20 @@
+// db.collection.findOneAndReplace() - Find and replace a document atomically
+
+// Basic find and replace
+db.users.findOneAndReplace({ name: "alice" }, { name: "alice", version: 2 })
+
+// Return new document
+db.users.findOneAndReplace({ name: "bob" }, { name: "bob", replaced: true }, { returnDocument: "after" })
+
+// With upsert
+db.users.findOneAndReplace({ email: "new@example.com" }, { email: "new@example.com", name: "new" }, { upsert: true })
+
+// With projection
+db.users.findOneAndReplace({ name: "charlie" }, { name: "charlie", active: true }, { projection: { name: 1 } })
+
+// With sort
+db.users.findOneAndReplace({ status: "old" }, { status: "new", migrated: true }, { sort: { createdAt: 1 } })
+
+// Collection access patterns
+db["users"].findOneAndReplace({ id: 1 }, { id: 1, data: "new" })
+db.getCollection("users").findOneAndReplace({ key: "abc" }, { key: "abc", value: "xyz" })

--- a/mongo/parsertest/testdata/collection-findOneAndUpdate.js
+++ b/mongo/parsertest/testdata/collection-findOneAndUpdate.js
@@ -1,0 +1,20 @@
+// db.collection.findOneAndUpdate() - Find and update a document atomically
+
+// Basic find and update
+db.users.findOneAndUpdate({ name: "alice" }, { $set: { age: 26 } })
+
+// Return new document
+db.users.findOneAndUpdate({ name: "bob" }, { $inc: { score: 10 } }, { returnDocument: "after" })
+
+// With upsert
+db.users.findOneAndUpdate({ email: "new@example.com" }, { $set: { name: "new" } }, { upsert: true, returnDocument: "after" })
+
+// With projection
+db.users.findOneAndUpdate({ name: "charlie" }, { $set: { active: true } }, { projection: { name: 1, active: 1 } })
+
+// With sort
+db.users.findOneAndUpdate({ status: "pending" }, { $set: { status: "processing" } }, { sort: { createdAt: 1 } })
+
+// Collection access patterns
+db["users"].findOneAndUpdate({ id: 1 }, { $set: { processed: true } })
+db.getCollection("users").findOneAndUpdate({ key: "abc" }, { $set: { value: "xyz" } })

--- a/mongo/parsertest/testdata/collection-getIndexes.js
+++ b/mongo/parsertest/testdata/collection-getIndexes.js
@@ -1,0 +1,15 @@
+// db.collection.getIndexes() - Get all indexes on a collection
+
+// Basic getIndexes
+db.users.getIndexes()
+db.orders.getIndexes()
+db.products.getIndexes()
+db.sessions.getIndexes()
+
+// GetIndexes with collection access patterns
+db["users"].getIndexes()
+db['audit-logs'].getIndexes()
+db["user-sessions"].getIndexes()
+db.getCollection("users").getIndexes()
+db.getCollection("my.collection").getIndexes()
+db.getCollection("special-collection").getIndexes()

--- a/mongo/parsertest/testdata/collection-getShardDistribution.js
+++ b/mongo/parsertest/testdata/collection-getShardDistribution.js
@@ -1,0 +1,22 @@
+// db.collection.getShardDistribution() - Print shard distribution statistics
+
+// Basic shard distribution
+db.users.getShardDistribution()
+db.orders.getShardDistribution()
+db.products.getShardDistribution()
+
+// Get distribution for large collections
+db.events.getShardDistribution()
+db.logs.getShardDistribution()
+db.analytics.getShardDistribution()
+
+// Get distribution for sharded collections
+db.transactions.getShardDistribution()
+db.sessions.getShardDistribution()
+db.inventory.getShardDistribution()
+
+// Collection access patterns
+db["users"].getShardDistribution()
+db.getCollection("users").getShardDistribution()
+db["user-data"].getShardDistribution()
+db.getCollection("order.items").getShardDistribution()

--- a/mongo/parsertest/testdata/collection-getShardVersion.js
+++ b/mongo/parsertest/testdata/collection-getShardVersion.js
@@ -1,0 +1,22 @@
+// db.collection.getShardVersion() - Get the shard version for a collection
+
+// Basic shard version
+db.users.getShardVersion()
+db.orders.getShardVersion()
+db.products.getShardVersion()
+
+// Get version for various collections
+db.events.getShardVersion()
+db.logs.getShardVersion()
+db.analytics.getShardVersion()
+
+// Get version for sharded collections
+db.transactions.getShardVersion()
+db.sessions.getShardVersion()
+db.inventory.getShardVersion()
+
+// Collection access patterns
+db["users"].getShardVersion()
+db.getCollection("users").getShardVersion()
+db["user-data"].getShardVersion()
+db.getCollection("order.items").getShardVersion()

--- a/mongo/parsertest/testdata/collection-hideIndex.js
+++ b/mongo/parsertest/testdata/collection-hideIndex.js
@@ -1,0 +1,31 @@
+// db.collection.hideIndex() - Hide an index from the query planner
+
+// Hide index by name
+db.users.hideIndex("email_1")
+db.orders.hideIndex("customerId_1_createdAt_-1")
+db.products.hideIndex("name_text")
+
+// Hide index by key specification
+db.users.hideIndex({ email: 1 })
+db.orders.hideIndex({ customerId: 1, createdAt: -1 })
+db.products.hideIndex({ category: 1, price: -1 })
+
+// Hide compound index
+db.users.hideIndex({ lastName: 1, firstName: 1 })
+db.orders.hideIndex({ status: 1, priority: -1, createdAt: -1 })
+
+// Hide text index
+db.articles.hideIndex({ content: "text" })
+
+// Hide geospatial index
+db.places.hideIndex({ location: "2dsphere" })
+
+// Hide hashed index
+db.users.hideIndex({ hashedField: "hashed" })
+
+// Collection access patterns
+db["users"].hideIndex("email_1")
+db["users"].hideIndex({ email: 1 })
+db.getCollection("users").hideIndex("status_1")
+db.getCollection("users").hideIndex({ status: 1 })
+db["user-profiles"].hideIndex("userId_1")

--- a/mongo/parsertest/testdata/collection-insert.js
+++ b/mongo/parsertest/testdata/collection-insert.js
@@ -1,0 +1,77 @@
+// db.collection.insert() - Insert documents (deprecated - use insertOne or insertMany)
+
+// Insert single document
+db.users.insert({ name: "alice", age: 25 })
+db.users.insert({ name: "bob", email: "bob@example.com", status: "active" })
+
+// Insert with _id
+db.users.insert({ _id: 1, name: "charlie" })
+db.users.insert({ _id: ObjectId("507f1f77bcf86cd799439011"), name: "dave" })
+
+// Insert with nested document
+db.users.insert({
+    name: "eve",
+    address: {
+        street: "123 Main St",
+        city: "New York",
+        zip: "10001"
+    }
+})
+
+// Insert with array
+db.users.insert({
+    name: "frank",
+    tags: ["admin", "user", "moderator"],
+    scores: [85, 90, 78]
+})
+
+// Insert multiple documents (array)
+db.users.insert([
+    { name: "grace", age: 30 },
+    { name: "henry", age: 35 },
+    { name: "ivy", age: 28 }
+])
+
+// Insert with write concern
+db.users.insert({ name: "jack" }, { writeConcern: { w: "majority" } })
+db.orders.insert({ orderId: 1 }, { writeConcern: { w: 1, j: true } })
+
+// Insert with ordered option
+db.users.insert([
+    { name: "kate" },
+    { name: "leo" },
+    { name: "mike" }
+], { ordered: false })
+
+// Insert complex document with dates
+db.events.insert({
+    type: "login",
+    userId: ObjectId("507f1f77bcf86cd799439011"),
+    timestamp: Date(),
+    metadata: { ip: "192.168.1.1", userAgent: "Mozilla/5.0" }
+})
+
+// Insert with ISODate
+db.logs.insert({
+    message: "Application started",
+    level: "info",
+    createdAt: ISODate("2024-01-15T10:30:00Z")
+})
+
+// Insert with various data types
+db.mixed.insert({
+    stringField: "text",
+    numberField: 42,
+    floatField: 3.14,
+    boolField: true,
+    nullField: null,
+    arrayField: [1, 2, 3],
+    objectField: { nested: "value" }
+})
+
+// Collection access patterns
+db["users"].insert({ name: "nina" })
+db["users"].insert([{ a: 1 }, { b: 2 }])
+db.getCollection("users").insert({ name: "oscar" })
+db.getCollection("user-data").insert({ type: "profile", data: {} })
+db["event-log"].insert({ event: "click", target: "button" })

--- a/mongo/parsertest/testdata/collection-insertMany.js
+++ b/mongo/parsertest/testdata/collection-insertMany.js
@@ -1,0 +1,19 @@
+// db.collection.insertMany() - Insert multiple documents
+
+// Basic insert
+db.users.insertMany([{ name: "alice" }, { name: "bob" }])
+
+// Insert with various documents
+db.users.insertMany([
+    { name: "charlie", age: 25 },
+    { name: "dave", age: 30 },
+    { name: "eve", age: 35 }
+])
+
+// Insert with options
+db.users.insertMany([{ name: "frank" }], { ordered: false })
+db.users.insertMany([{ name: "grace" }], { writeConcern: { w: 1 } })
+
+// Collection access patterns
+db["users"].insertMany([{ name: "heidi" }])
+db.getCollection("users").insertMany([{ name: "ivan" }])

--- a/mongo/parsertest/testdata/collection-insertOne.js
+++ b/mongo/parsertest/testdata/collection-insertOne.js
@@ -1,0 +1,21 @@
+// db.collection.insertOne() - Insert a single document
+
+// Basic insert
+db.users.insertOne({ name: "alice", age: 25 })
+db.users.insertOne({ _id: ObjectId(), name: "bob" })
+
+// Insert with nested document
+db.users.insertOne({ name: "charlie", address: { city: "NYC", zip: "10001" } })
+
+// Insert with array
+db.users.insertOne({ name: "dave", tags: ["admin", "user"] })
+
+// Insert with helper functions
+db.users.insertOne({ name: "eve", createdAt: ISODate(), id: UUID("550e8400-e29b-41d4-a716-446655440000") })
+
+// Insert with options
+db.users.insertOne({ name: "frank" }, { writeConcern: { w: "majority" } })
+
+// Collection access patterns
+db["users"].insertOne({ name: "grace" })
+db.getCollection("users").insertOne({ name: "heidi" })

--- a/mongo/parsertest/testdata/collection-isCapped.js
+++ b/mongo/parsertest/testdata/collection-isCapped.js
@@ -1,0 +1,17 @@
+// db.collection.isCapped() - Check if a collection is a capped collection
+
+// Basic usage
+db.users.isCapped()
+db.orders.isCapped()
+db.logs.isCapped()
+db.events.isCapped()
+
+// Commonly used for checking log collections
+db.systemLogs.isCapped()
+db.auditTrail.isCapped()
+
+// Collection access patterns
+db["users"].isCapped()
+db.getCollection("users").isCapped()
+db["capped-logs"].isCapped()
+db.getCollection("system.profile").isCapped()

--- a/mongo/parsertest/testdata/collection-latencyStats.js
+++ b/mongo/parsertest/testdata/collection-latencyStats.js
@@ -1,0 +1,17 @@
+// db.collection.latencyStats() - Get latency statistics for a collection
+
+// Basic latency stats
+db.users.latencyStats()
+db.orders.latencyStats()
+
+// With histogram options
+db.users.latencyStats({ histograms: true })
+
+// Without histogram details
+db.orders.latencyStats({ histograms: false })
+
+// Collection access patterns
+db["users"].latencyStats()
+db.getCollection("users").latencyStats()
+db["high-traffic"].latencyStats({ histograms: true })
+db.getCollection("production.api").latencyStats()

--- a/mongo/parsertest/testdata/collection-mapReduce.js
+++ b/mongo/parsertest/testdata/collection-mapReduce.js
@@ -1,0 +1,129 @@
+// db.collection.mapReduce() - Perform map-reduce aggregation (deprecated - use aggregation pipeline)
+// Note: JavaScript function expressions are not supported by this parser.
+// The examples below show the method structure with string placeholders.
+
+// Basic mapReduce with string function representations
+db.orders.mapReduce(
+    "function() { emit(this.customerId, this.amount); }",
+    "function(key, values) { return Array.sum(values); }",
+    { out: "order_totals" }
+)
+
+// mapReduce with query
+db.orders.mapReduce(
+    "function() { emit(this.product, 1); }",
+    "function(key, values) { return Array.sum(values); }",
+    {
+        query: { status: "completed" },
+        out: "product_counts"
+    }
+)
+
+// mapReduce with inline output
+db.products.mapReduce(
+    "function() { emit(this.category, this.price); }",
+    "function(key, values) { return Array.avg(values); }",
+    { out: { inline: 1 } }
+)
+
+// mapReduce with finalize function
+db.scores.mapReduce(
+    "function() { emit(this.playerId, { sum: this.score, count: 1 }); }",
+    "function(key, values) { return { sum: 0, count: 0 }; }",
+    {
+        finalize: "function(key, reduced) { return reduced.sum / reduced.count; }",
+        out: "player_averages"
+    }
+)
+
+// mapReduce with sort and limit
+db.logs.mapReduce(
+    "function() { emit(this.level, 1); }",
+    "function(key, values) { return Array.sum(values); }",
+    {
+        sort: { timestamp: -1 },
+        limit: 10000,
+        out: { inline: 1 }
+    }
+)
+
+// mapReduce with scope
+db.orders.mapReduce(
+    "function() { emit(this.customerId, this.amount * factor); }",
+    "function(key, values) { return Array.sum(values); }",
+    {
+        scope: { factor: 1.1 },
+        out: "adjusted_totals"
+    }
+)
+
+// mapReduce with jsMode
+db.events.mapReduce(
+    "function() { emit(this.type, 1); }",
+    "function(key, values) { return Array.sum(values); }",
+    {
+        jsMode: true,
+        out: { inline: 1 }
+    }
+)
+
+// mapReduce with output options
+db.sales.mapReduce(
+    "function() { emit(this.region, this.revenue); }",
+    "function(key, values) { return Array.sum(values); }",
+    { out: { replace: "region_revenue" } }
+)
+
+db.sales.mapReduce(
+    "function() { emit(this.region, this.revenue); }",
+    "function(key, values) { return Array.sum(values); }",
+    { out: { merge: "region_revenue" } }
+)
+
+db.sales.mapReduce(
+    "function() { emit(this.region, this.revenue); }",
+    "function(key, values) { return Array.sum(values); }",
+    { out: { reduce: "region_revenue" } }
+)
+
+// mapReduce with output to different database
+db.orders.mapReduce(
+    "function() { emit(this.product, this.qty); }",
+    "function(key, values) { return Array.sum(values); }",
+    { out: { replace: "product_totals", db: "reports" } }
+)
+
+// mapReduce with verbose output
+db.logs.mapReduce(
+    "function() { emit(this.source, 1); }",
+    "function(key, values) { return Array.sum(values); }",
+    {
+        out: { inline: 1 },
+        verbose: true
+    }
+)
+
+// mapReduce with bypassDocumentValidation
+db.data.mapReduce(
+    "function() { emit(this.key, this.value); }",
+    "function(key, values) { return values.join(','); }",
+    {
+        out: "combined_data",
+        bypassDocumentValidation: true
+    }
+)
+
+// mapReduce with collation
+db.products.mapReduce(
+    "function() { emit(this.name.toLowerCase(), 1); }",
+    "function(key, values) { return Array.sum(values); }",
+    {
+        out: { inline: 1 },
+        collation: { locale: "en", strength: 2 }
+    }
+)
+
+// Collection access patterns
+db["orders"].mapReduce("function() { emit(this.x, 1); }", "function(k, v) { return Array.sum(v); }", { out: { inline: 1 } })
+db.getCollection("orders").mapReduce("function() { emit(this.y, 1); }", "function(k, v) { return Array.sum(v); }", { out: "result" })
+db["order-items"].mapReduce("function() { emit(this.orderId, this.total); }", "function(k, v) { return Array.sum(v); }", { out: { inline: 1 } })

--- a/mongo/parsertest/testdata/collection-reIndex.js
+++ b/mongo/parsertest/testdata/collection-reIndex.js
@@ -1,0 +1,21 @@
+// db.collection.reIndex() - Rebuild all indexes on a collection (deprecated)
+
+// Basic reIndex
+db.users.reIndex()
+db.orders.reIndex()
+db.products.reIndex()
+
+// reIndex after heavy write operations
+db.logs.reIndex()
+db.events.reIndex()
+db.sessions.reIndex()
+
+// reIndex on large collections
+db.analytics.reIndex()
+db.transactions.reIndex()
+
+// Collection access patterns
+db["users"].reIndex()
+db.getCollection("users").reIndex()
+db["user-data"].reIndex()
+db.getCollection("order.items").reIndex()

--- a/mongo/parsertest/testdata/collection-remove.js
+++ b/mongo/parsertest/testdata/collection-remove.js
@@ -1,0 +1,53 @@
+// db.collection.remove() - Remove documents (deprecated - use deleteOne or deleteMany)
+
+// Remove all documents
+db.users.remove({})
+db.logs.remove({})
+
+// Remove with filter
+db.users.remove({ status: "deleted" })
+db.users.remove({ name: "alice" })
+db.orders.remove({ status: "cancelled" })
+
+// Remove with comparison operators
+db.users.remove({ age: { $lt: 18 } })
+db.logs.remove({ createdAt: { $lt: ISODate("2023-01-01") } })
+db.sessions.remove({ expiresAt: { $lte: Date() } })
+
+// Remove with complex filter
+db.users.remove({ $or: [{ status: "deleted" }, { status: "banned" }] })
+db.orders.remove({ status: "cancelled", createdAt: { $lt: ISODate("2024-01-01") } })
+
+// Remove with array operators
+db.users.remove({ tags: { $in: ["spam", "bot"] } })
+db.products.remove({ categories: { $all: ["discontinued", "clearance"] } })
+
+// Remove single document (justOne option)
+db.users.remove({ status: "inactive" }, true)
+db.users.remove({ status: "pending" }, { justOne: true })
+db.queue.remove({ processed: true }, { justOne: true })
+
+// Remove with write concern
+db.users.remove({ temp: true }, { writeConcern: { w: "majority" } })
+db.orders.remove({ status: "test" }, { writeConcern: { w: 1, j: true } })
+
+// Remove with collation
+db.products.remove({ name: "cafe" }, { collation: { locale: "fr", strength: 1 } })
+
+// Remove by _id
+db.users.remove({ _id: ObjectId("507f1f77bcf86cd799439011") })
+db.users.remove({ _id: 1 })
+
+// Remove with nested field
+db.users.remove({ "profile.deleted": true })
+db.orders.remove({ "shipping.status": "failed" })
+
+// Remove with let option
+db.users.remove({ $expr: { $eq: ["$_id", "$$targetId"] } }, { let: { targetId: ObjectId("507f1f77bcf86cd799439011") } })
+
+// Collection access patterns
+db["users"].remove({ status: "deleted" })
+db["users"].remove({}, true)
+db.getCollection("users").remove({ expired: true })
+db.getCollection("temp-data").remove({})
+db["user-sessions"].remove({ expiresAt: { $lt: Date() } })

--- a/mongo/parsertest/testdata/collection-renameCollection.js
+++ b/mongo/parsertest/testdata/collection-renameCollection.js
@@ -1,0 +1,18 @@
+// db.collection.renameCollection() - Rename a collection
+
+// Basic rename
+db.users.renameCollection("users_old")
+db.orders.renameCollection("archived_orders")
+
+// Rename with dropTarget option (drops target collection if exists)
+db.users.renameCollection("users_backup", true)
+db.orders.renameCollection("orders_v2", false)
+
+// Rename to collection in same database
+db.tempData.renameCollection("permanentData")
+db.staging.renameCollection("production")
+
+// Collection access patterns
+db["users"].renameCollection("users_backup")
+db.getCollection("users").renameCollection("users_archive")
+db["old-data"].renameCollection("archived-data")

--- a/mongo/parsertest/testdata/collection-replaceOne.js
+++ b/mongo/parsertest/testdata/collection-replaceOne.js
@@ -1,0 +1,17 @@
+// db.collection.replaceOne() - Replace a single document
+
+// Basic replace
+db.users.replaceOne({ name: "alice" }, { name: "alice", age: 30, status: "active" })
+
+// Replace with upsert
+db.users.replaceOne({ email: "new@example.com" }, { email: "new@example.com", name: "New User" }, { upsert: true })
+
+// Replace by _id
+db.users.replaceOne({ _id: ObjectId("507f1f77bcf86cd799439011") }, { _id: ObjectId("507f1f77bcf86cd799439011"), name: "replaced", version: 2 })
+
+// Replace with options
+db.users.replaceOne({ name: "bob" }, { name: "bob", migrated: true }, { writeConcern: { w: 1 } })
+
+// Collection access patterns
+db["users"].replaceOne({ id: 1 }, { id: 1, data: "new" })
+db.getCollection("users").replaceOne({ key: "abc" }, { key: "abc", value: "xyz" })

--- a/mongo/parsertest/testdata/collection-stats.js
+++ b/mongo/parsertest/testdata/collection-stats.js
@@ -1,0 +1,22 @@
+// db.collection.stats() - Get collection statistics
+
+// Basic stats
+db.users.stats()
+db.orders.stats()
+db.products.stats()
+
+// Stats with scale factor (convert bytes to KB, MB, etc.)
+db.users.stats({ scale: 1024 })
+db.largeCollection.stats({ scale: 1048576 })
+
+// Stats with index details
+db.users.stats({ indexDetails: true })
+
+// Stats with multiple options
+db.orders.stats({ scale: 1024, indexDetails: true })
+
+// Collection access patterns
+db["users"].stats()
+db.getCollection("users").stats()
+db["large-collection"].stats({ scale: 1024 })
+db.getCollection("archived.data").stats({ indexDetails: true })

--- a/mongo/parsertest/testdata/collection-storageSize.js
+++ b/mongo/parsertest/testdata/collection-storageSize.js
@@ -1,0 +1,13 @@
+// db.collection.storageSize() - Get the storage size of a collection in bytes
+
+// Basic usage
+db.users.storageSize()
+db.orders.storageSize()
+db.products.storageSize()
+db.logs.storageSize()
+
+// Collection access patterns
+db["users"].storageSize()
+db.getCollection("users").storageSize()
+db["large-collection"].storageSize()
+db.getCollection("archived.orders").storageSize()

--- a/mongo/parsertest/testdata/collection-totalIndexSize.js
+++ b/mongo/parsertest/testdata/collection-totalIndexSize.js
@@ -1,0 +1,13 @@
+// db.collection.totalIndexSize() - Get the total size of all indexes on a collection in bytes
+
+// Basic usage
+db.users.totalIndexSize()
+db.orders.totalIndexSize()
+db.products.totalIndexSize()
+db.sessions.totalIndexSize()
+
+// Collection access patterns
+db["users"].totalIndexSize()
+db.getCollection("users").totalIndexSize()
+db["indexed-collection"].totalIndexSize()
+db.getCollection("heavily.indexed").totalIndexSize()

--- a/mongo/parsertest/testdata/collection-totalSize.js
+++ b/mongo/parsertest/testdata/collection-totalSize.js
@@ -1,0 +1,13 @@
+// db.collection.totalSize() - Get the total size of collection data plus indexes in bytes
+
+// Basic usage
+db.users.totalSize()
+db.orders.totalSize()
+db.products.totalSize()
+db.logs.totalSize()
+
+// Collection access patterns
+db["users"].totalSize()
+db.getCollection("users").totalSize()
+db["large-collection"].totalSize()
+db.getCollection("archived.data").totalSize()

--- a/mongo/parsertest/testdata/collection-unhideIndex.js
+++ b/mongo/parsertest/testdata/collection-unhideIndex.js
@@ -1,0 +1,31 @@
+// db.collection.unhideIndex() - Unhide a hidden index to make it visible to the query planner
+
+// Unhide index by name
+db.users.unhideIndex("email_1")
+db.orders.unhideIndex("customerId_1_createdAt_-1")
+db.products.unhideIndex("name_text")
+
+// Unhide index by key specification
+db.users.unhideIndex({ email: 1 })
+db.orders.unhideIndex({ customerId: 1, createdAt: -1 })
+db.products.unhideIndex({ category: 1, price: -1 })
+
+// Unhide compound index
+db.users.unhideIndex({ lastName: 1, firstName: 1 })
+db.orders.unhideIndex({ status: 1, priority: -1, createdAt: -1 })
+
+// Unhide text index
+db.articles.unhideIndex({ content: "text" })
+
+// Unhide geospatial index
+db.places.unhideIndex({ location: "2dsphere" })
+
+// Unhide hashed index
+db.users.unhideIndex({ hashedField: "hashed" })
+
+// Collection access patterns
+db["users"].unhideIndex("email_1")
+db["users"].unhideIndex({ email: 1 })
+db.getCollection("users").unhideIndex("status_1")
+db.getCollection("users").unhideIndex({ status: 1 })
+db["user-profiles"].unhideIndex("userId_1")

--- a/mongo/parsertest/testdata/collection-update.js
+++ b/mongo/parsertest/testdata/collection-update.js
@@ -1,0 +1,75 @@
+// db.collection.update() - Update documents (deprecated - use updateOne or updateMany)
+
+// Basic update with $set
+db.users.update({ name: "alice" }, { $set: { age: 26 } })
+db.users.update({ _id: 1 }, { $set: { status: "active" } })
+
+// Update with multiple operators
+db.users.update({ name: "bob" }, {
+    $set: { status: "active" },
+    $inc: { loginCount: 1 },
+    $currentDate: { lastLogin: true }
+})
+
+// Update with $inc
+db.products.update({ sku: "abc123" }, { $inc: { qty: -1 } })
+db.users.update({ _id: ObjectId("507f1f77bcf86cd799439011") }, { $inc: { score: 10, attempts: 1 } })
+
+// Update with $unset
+db.users.update({ name: "charlie" }, { $unset: { tempField: "" } })
+
+// Update with $push
+db.users.update({ name: "dave" }, { $push: { tags: "premium" } })
+db.users.update({ name: "eve" }, { $push: { scores: { $each: [85, 90, 78] } } })
+
+// Update with $pull
+db.users.update({ name: "frank" }, { $pull: { tags: "inactive" } })
+db.users.update({ name: "grace" }, { $pull: { items: { qty: { $lte: 0 } } } })
+
+// Update with $addToSet
+db.users.update({ name: "henry" }, { $addToSet: { roles: "editor" } })
+db.users.update({ name: "ivy" }, { $addToSet: { tags: { $each: ["a", "b", "c"] } } })
+
+// Update multiple documents (multi option)
+db.users.update({ status: "pending" }, { $set: { status: "active" } }, { multi: true })
+db.orders.update({ shipped: false }, { $set: { shipped: true, shippedAt: Date() } }, { multi: true })
+
+// Update with upsert
+db.users.update({ email: "new@example.com" }, { $set: { name: "New User" } }, { upsert: true })
+db.settings.update({ key: "theme" }, { $set: { value: "dark" } }, { upsert: true })
+
+// Update with multi and upsert
+db.counters.update({ name: "pageViews" }, { $inc: { count: 1 } }, { upsert: true, multi: false })
+
+// Replace document (no update operators)
+db.users.update({ _id: 1 }, { name: "replaced", status: "new" })
+
+// Update with arrayFilters
+db.inventory.update(
+    { item: "abc123" },
+    { $set: { "sizes.$[elem].qty": 0 } },
+    { arrayFilters: [{ "elem.size": "small" }] }
+)
+
+// Update with write concern
+db.users.update({ name: "jack" }, { $set: { verified: true } }, { writeConcern: { w: "majority" } })
+
+// Update with collation
+db.products.update({ name: "cafe" }, { $set: { available: true } }, { collation: { locale: "fr", strength: 1 } })
+
+// Update with hint
+db.users.update({ status: "active" }, { $set: { lastChecked: Date() } }, { hint: { status: 1 } })
+
+// Update with let variables
+db.users.update(
+    { $expr: { $eq: ["$_id", "$$targetId"] } },
+    { $set: { found: true } },
+    { let: { targetId: ObjectId("507f1f77bcf86cd799439011") } }
+)
+
+// Collection access patterns
+db["users"].update({ x: 1 }, { $set: { y: 2 } })
+db["users"].update({ a: 1 }, { $inc: { b: 1 } }, { multi: true })
+db.getCollection("users").update({ status: "old" }, { $set: { status: "new" } })
+db.getCollection("config").update({ key: "value" }, { $set: { data: {} } }, { upsert: true })
+db["user-preferences"].update({ userId: 1 }, { $set: { theme: "dark" } })

--- a/mongo/parsertest/testdata/collection-updateMany.js
+++ b/mongo/parsertest/testdata/collection-updateMany.js
@@ -1,0 +1,17 @@
+// db.collection.updateMany() - Update multiple documents
+
+// Basic update
+db.users.updateMany({ status: "inactive" }, { $set: { status: "active" } })
+
+// Update with comparison operators
+db.users.updateMany({ age: { $lt: 18 } }, { $set: { category: "minor" } })
+
+// Update with multiple operators
+db.users.updateMany({ verified: false }, { $set: { verified: true }, $currentDate: { verifiedAt: true } })
+
+// Update with options
+db.users.updateMany({ country: "US" }, { $set: { region: "NA" } }, { writeConcern: { w: "majority" } })
+
+// Collection access patterns
+db["users"].updateMany({}, { $set: { migrated: true } })
+db.getCollection("users").updateMany({ role: "guest" }, { $set: { role: "user" } })

--- a/mongo/parsertest/testdata/collection-updateOne.js
+++ b/mongo/parsertest/testdata/collection-updateOne.js
@@ -1,0 +1,17 @@
+// db.collection.updateOne() - Update a single document
+
+// Basic update with $set
+db.users.updateOne({ name: "alice" }, { $set: { age: 26 } })
+
+// Update with multiple operators
+db.users.updateOne({ _id: ObjectId("507f1f77bcf86cd799439011") }, { $set: { status: "active" }, $inc: { loginCount: 1 } })
+
+// Update with upsert
+db.users.updateOne({ email: "new@example.com" }, { $set: { name: "new user" } }, { upsert: true })
+
+// Update with array filters
+db.users.updateOne({ name: "alice" }, { $set: { "grades.$[elem].score": 100 } }, { arrayFilters: [{ "elem.grade": { $gte: 85 } }] })
+
+// Collection access patterns
+db["users"].updateOne({ name: "bob" }, { $set: { active: true } })
+db.getCollection("users").updateOne({ name: "charlie" }, { $unset: { tempField: "" } })

--- a/mongo/parsertest/testdata/collection-validate.js
+++ b/mongo/parsertest/testdata/collection-validate.js
@@ -1,0 +1,26 @@
+// db.collection.validate() - Validate a collection's data and indexes
+
+// Basic validation
+db.users.validate()
+db.orders.validate()
+
+// Full validation (more thorough but slower)
+db.users.validate({ full: true })
+
+// Quick validation (faster, less thorough)
+db.products.validate({ full: false })
+
+// Validation with repair option
+db.logs.validate({ repair: true })
+
+// Validation with metadata check only
+db.sessions.validate({ metadata: true })
+
+// Combined options
+db.largeCollection.validate({ full: true, background: true })
+
+// Collection access patterns
+db["users"].validate()
+db.getCollection("users").validate()
+db["important-data"].validate({ full: true })
+db.getCollection("production.orders").validate({ repair: true })

--- a/mongo/parsertest/testdata/collection-watch.js
+++ b/mongo/parsertest/testdata/collection-watch.js
@@ -1,0 +1,60 @@
+// db.collection.watch() - Open a change stream cursor (unsupported - requires persistent connection)
+
+// Basic watch
+db.users.watch()
+db.orders.watch()
+
+// Watch with empty pipeline
+db.users.watch([])
+
+// Watch with pipeline stages
+db.users.watch([{ $match: { operationType: "insert" } }])
+db.orders.watch([{ $match: { "fullDocument.status": "shipped" } }])
+
+// Watch with multiple pipeline stages
+db.products.watch([
+    { $match: { operationType: { $in: ["insert", "update", "replace"] } } },
+    { $project: { fullDocument: 1, operationType: 1 } }
+])
+
+// Watch with options
+db.users.watch([], { fullDocument: "updateLookup" })
+db.orders.watch([], { fullDocument: "whenAvailable" })
+db.products.watch([], { fullDocumentBeforeChange: "whenAvailable" })
+
+// Watch with resumeAfter
+db.users.watch([], { resumeAfter: { _data: "826..." } })
+
+// Watch with startAfter
+db.orders.watch([], { startAfter: { _data: "826..." } })
+
+// Watch with startAtOperationTime
+db.events.watch([], { startAtOperationTime: Timestamp(1609459200, 1) })
+
+// Watch with batchSize
+db.users.watch([], { batchSize: 100 })
+
+// Watch with maxAwaitTimeMS
+db.logs.watch([], { maxAwaitTimeMS: 5000 })
+
+// Watch with collation
+db.products.watch([{ $match: { "fullDocument.category": "Electronics" } }], { collation: { locale: "en", strength: 2 } })
+
+// Watch with showExpandedEvents
+db.users.watch([], { showExpandedEvents: true })
+
+// Watch combined options
+db.orders.watch([
+    { $match: { operationType: "update" } }
+], {
+    fullDocument: "updateLookup",
+    batchSize: 50,
+    maxAwaitTimeMS: 10000
+})
+
+// Collection access patterns
+db["users"].watch()
+db["users"].watch([{ $match: { operationType: "delete" } }])
+db.getCollection("users").watch()
+db.getCollection("events").watch([], { fullDocument: "updateLookup" })
+db["change-events"].watch([])

--- a/mongo/parsertest/testdata/comments.js
+++ b/mongo/parsertest/testdata/comments.js
@@ -1,0 +1,22 @@
+// Line comment
+db.users.find({ name: "alice" }) // inline comment
+
+// Block comment
+/* This is a block comment */
+db.users.find({ age: 25 })
+
+/*
+ * Multi-line
+ * block comment
+ */
+db.users.find({
+    /* comment inside document */
+    name: "test",
+    // another comment
+    age: 30
+})
+
+// Multiple statements with comments
+show dbs // list all databases
+show collections /* list collections */
+db.users.find() // find all users

--- a/mongo/parsertest/testdata/connection-Mongo.js
+++ b/mongo/parsertest/testdata/connection-Mongo.js
@@ -1,0 +1,26 @@
+// Mongo() - Create a new connection to a MongoDB server
+
+// Basic connection
+Mongo()
+Mongo("localhost")
+Mongo("localhost:27017")
+Mongo("mongodb://localhost:27017")
+
+// Connection with options
+Mongo("mongodb://localhost:27017", { tls: true })
+Mongo("mongodb://user:pass@localhost:27017/test?authSource=admin")
+Mongo("mongodb://localhost:27017", { ssl: true, retryWrites: true })
+
+// Connection with replica set
+Mongo("mongodb://host1:27017,host2:27017,host3:27017/test?replicaSet=myRS")
+Mongo("mongodb://localhost:27017", { replicaSet: "myRS" })
+
+// Using connection to get database
+Mongo().getDB("test")
+Mongo("localhost").getDB("mydb")
+Mongo("mongodb://localhost:27017").getDB("admin")
+
+// Chaining multiple methods
+Mongo("localhost").getDB("test").getCollection("users")
+Mongo().setReadPref("secondary")
+Mongo("localhost").setReadConcern("majority")

--- a/mongo/parsertest/testdata/connection-adminCommand.js
+++ b/mongo/parsertest/testdata/connection-adminCommand.js
@@ -1,0 +1,28 @@
+// adminCommand() - Run an administrative command on the admin database
+
+// Basic admin commands
+Mongo().adminCommand({ listDatabases: 1 })
+Mongo("localhost").adminCommand({ serverStatus: 1 })
+Mongo("mongodb://localhost:27017").adminCommand({ ping: 1 })
+
+// User management commands
+Mongo().adminCommand({ createUser: "myuser", pwd: "password", roles: ["readWrite"] })
+Mongo().adminCommand({ usersInfo: 1 })
+Mongo().adminCommand({ dropUser: "olduser" })
+
+// Replica set commands
+Mongo().adminCommand({ replSetGetStatus: 1 })
+Mongo().adminCommand({ replSetGetConfig: 1 })
+
+// Sharding commands
+Mongo().adminCommand({ listShards: 1 })
+Mongo().adminCommand({ balancerStatus: 1 })
+
+// Database commands
+Mongo().adminCommand({ currentOp: 1 })
+Mongo("localhost").adminCommand({ killOp: 1, op: 12345 })
+
+// adminCommand from db.getMongo()
+db.getMongo().adminCommand({ listDatabases: 1 })
+db.getMongo().adminCommand({ serverStatus: 1 })
+db.getMongo().adminCommand({ ping: 1 })

--- a/mongo/parsertest/testdata/connection-close.js
+++ b/mongo/parsertest/testdata/connection-close.js
@@ -1,0 +1,12 @@
+// close() - Close the database connection
+
+// Close on Mongo connection
+Mongo().close()
+Mongo("localhost").close()
+Mongo("mongodb://localhost:27017").close()
+
+// Close after operations
+Mongo("localhost").getDB("test").close()
+
+// Close from db.getMongo()
+db.getMongo().close()

--- a/mongo/parsertest/testdata/connection-connect.js
+++ b/mongo/parsertest/testdata/connection-connect.js
@@ -1,0 +1,22 @@
+// connect() - Connect to a MongoDB server and return a database object
+
+// Basic connect
+connect()
+connect("localhost")
+connect("localhost:27017")
+connect("mongodb://localhost:27017")
+
+// Connect with database name
+connect("localhost/mydb")
+connect("mongodb://localhost:27017/test")
+
+// Connect with options
+connect("mongodb://localhost:27017/test", { readPreference: "secondary" })
+connect("mongodb://user:pass@localhost:27017/admin", { ssl: true })
+
+// Connect with authentication
+connect("mongodb://user:password@localhost:27017/mydb?authSource=admin")
+
+// Connect and chain methods
+connect("localhost").getDB("test")
+connect("mongodb://localhost:27017").setReadPref("primaryPreferred")

--- a/mongo/parsertest/testdata/connection-getDB.js
+++ b/mongo/parsertest/testdata/connection-getDB.js
@@ -1,0 +1,18 @@
+// getDB() - Get a database reference from a connection
+
+// Basic getDB
+Mongo().getDB("test")
+Mongo().getDB("mydb")
+Mongo().getDB("admin")
+
+// getDB with connection string
+Mongo("localhost").getDB("test")
+Mongo("mongodb://localhost:27017").getDB("mydb")
+
+// getDB from db.getMongo()
+db.getMongo().getDB("anotherdb")
+db.getMongo().getDB("test")
+
+// Chain database operations
+Mongo().getDB("test").getCollection("users")
+Mongo("localhost").getDB("mydb").getCollectionNames()

--- a/mongo/parsertest/testdata/connection-getDBNames.js
+++ b/mongo/parsertest/testdata/connection-getDBNames.js
@@ -1,0 +1,13 @@
+// getDBNames() - Get a list of all database names
+
+// Basic getDBNames
+Mongo().getDBNames()
+Mongo("localhost").getDBNames()
+Mongo("mongodb://localhost:27017").getDBNames()
+
+// getDBNames from db.getMongo()
+db.getMongo().getDBNames()
+
+// getDBNames after connecting with credentials
+Mongo("mongodb://user:pass@localhost:27017").getDBNames()
+Mongo("mongodb://admin:password@localhost:27017/?authSource=admin").getDBNames()

--- a/mongo/parsertest/testdata/connection-getReadConcern.js
+++ b/mongo/parsertest/testdata/connection-getReadConcern.js
@@ -1,0 +1,12 @@
+// getReadConcern() - Get the read concern for the connection
+
+// Basic getReadConcern
+Mongo().getReadConcern()
+Mongo("localhost").getReadConcern()
+Mongo("mongodb://localhost:27017").getReadConcern()
+
+// getReadConcern from db.getMongo()
+db.getMongo().getReadConcern()
+
+// getReadConcern after setting it
+Mongo().setReadConcern("majority").getReadConcern()

--- a/mongo/parsertest/testdata/connection-getReadPref.js
+++ b/mongo/parsertest/testdata/connection-getReadPref.js
@@ -1,0 +1,13 @@
+// getReadPref() - Get the read preference for the connection
+
+// Basic getReadPref
+Mongo().getReadPref()
+Mongo("localhost").getReadPref()
+Mongo("mongodb://localhost:27017").getReadPref()
+
+// getReadPref from db.getMongo()
+db.getMongo().getReadPref()
+
+// getReadPref after setting it
+Mongo().setReadPref("secondary").getReadPref()
+Mongo("localhost").setReadPref("nearest").getReadPref()

--- a/mongo/parsertest/testdata/connection-getReadPrefMode.js
+++ b/mongo/parsertest/testdata/connection-getReadPrefMode.js
@@ -1,0 +1,13 @@
+// getReadPrefMode() - Get the read preference mode for the connection
+
+// Basic getReadPrefMode
+Mongo().getReadPrefMode()
+Mongo("localhost").getReadPrefMode()
+Mongo("mongodb://localhost:27017").getReadPrefMode()
+
+// getReadPrefMode from db.getMongo()
+db.getMongo().getReadPrefMode()
+
+// getReadPrefMode after setting read preference
+Mongo().setReadPref("secondary").getReadPrefMode()
+Mongo("localhost").setReadPref("primaryPreferred").getReadPrefMode()

--- a/mongo/parsertest/testdata/connection-getReadPrefTagSet.js
+++ b/mongo/parsertest/testdata/connection-getReadPrefTagSet.js
@@ -1,0 +1,13 @@
+// getReadPrefTagSet() - Get the read preference tag set for the connection
+
+// Basic getReadPrefTagSet
+Mongo().getReadPrefTagSet()
+Mongo("localhost").getReadPrefTagSet()
+Mongo("mongodb://localhost:27017").getReadPrefTagSet()
+
+// getReadPrefTagSet from db.getMongo()
+db.getMongo().getReadPrefTagSet()
+
+// getReadPrefTagSet after setting read preference with tags
+Mongo().setReadPref("secondary", [{ dc: "east" }]).getReadPrefTagSet()
+Mongo("localhost").setReadPref("nearest", [{ region: "us" }]).getReadPrefTagSet()

--- a/mongo/parsertest/testdata/connection-getWriteConcern.js
+++ b/mongo/parsertest/testdata/connection-getWriteConcern.js
@@ -1,0 +1,13 @@
+// getWriteConcern() - Get the write concern for the connection
+
+// Basic getWriteConcern
+Mongo().getWriteConcern()
+Mongo("localhost").getWriteConcern()
+Mongo("mongodb://localhost:27017").getWriteConcern()
+
+// getWriteConcern from db.getMongo()
+db.getMongo().getWriteConcern()
+
+// getWriteConcern after setting it
+Mongo().setWriteConcern({ w: "majority" }).getWriteConcern()
+Mongo("localhost").setWriteConcern({ w: 1, j: true }).getWriteConcern()

--- a/mongo/parsertest/testdata/connection-setReadConcern.js
+++ b/mongo/parsertest/testdata/connection-setReadConcern.js
@@ -1,0 +1,20 @@
+// setReadConcern() - Set the read concern for the connection
+
+// Basic setReadConcern
+Mongo().setReadConcern("local")
+Mongo().setReadConcern("majority")
+Mongo().setReadConcern("linearizable")
+Mongo().setReadConcern("available")
+Mongo().setReadConcern("snapshot")
+
+// setReadConcern with connection string
+Mongo("localhost").setReadConcern("majority")
+Mongo("mongodb://localhost:27017").setReadConcern("local")
+
+// setReadConcern from db.getMongo()
+db.getMongo().setReadConcern("majority")
+db.getMongo().setReadConcern("linearizable")
+
+// Chain with other methods
+Mongo().setReadConcern("majority").getDB("test")
+Mongo("localhost").setReadConcern("local").setReadPref("secondary")

--- a/mongo/parsertest/testdata/connection-setReadPref.js
+++ b/mongo/parsertest/testdata/connection-setReadPref.js
@@ -1,0 +1,24 @@
+// setReadPref() - Set the read preference for the connection
+
+// Basic setReadPref with mode only
+Mongo().setReadPref("primary")
+Mongo().setReadPref("secondary")
+Mongo().setReadPref("primaryPreferred")
+Mongo().setReadPref("secondaryPreferred")
+Mongo().setReadPref("nearest")
+
+// setReadPref with connection string
+Mongo("localhost").setReadPref("secondary")
+Mongo("mongodb://localhost:27017").setReadPref("nearest")
+
+// setReadPref with tag set
+Mongo().setReadPref("secondary", [{ dc: "east" }])
+Mongo().setReadPref("nearest", [{ region: "us-east-1" }])
+Mongo("localhost").setReadPref("secondaryPreferred", [{ dc: "east" }, { dc: "west" }])
+
+// setReadPref with options
+Mongo().setReadPref("secondary", [{ dc: "east" }], { maxStalenessSeconds: 120 })
+
+// setReadPref from db.getMongo()
+db.getMongo().setReadPref("secondary")
+db.getMongo().setReadPref("nearest", [{ region: "us" }])

--- a/mongo/parsertest/testdata/connection-setWriteConcern.js
+++ b/mongo/parsertest/testdata/connection-setWriteConcern.js
@@ -1,0 +1,25 @@
+// setWriteConcern() - Set the write concern for the connection
+
+// Basic setWriteConcern
+Mongo().setWriteConcern({ w: 1 })
+Mongo().setWriteConcern({ w: "majority" })
+Mongo().setWriteConcern({ w: 2 })
+
+// setWriteConcern with journal
+Mongo().setWriteConcern({ w: 1, j: true })
+Mongo().setWriteConcern({ w: "majority", j: true })
+
+// setWriteConcern with timeout
+Mongo().setWriteConcern({ w: "majority", wtimeout: 5000 })
+Mongo().setWriteConcern({ w: 2, j: true, wtimeout: 10000 })
+
+// setWriteConcern with connection string
+Mongo("localhost").setWriteConcern({ w: "majority" })
+Mongo("mongodb://localhost:27017").setWriteConcern({ w: 1, j: true })
+
+// setWriteConcern from db.getMongo()
+db.getMongo().setWriteConcern({ w: "majority" })
+db.getMongo().setWriteConcern({ w: 1, j: true, wtimeout: 5000 })
+
+// Chain with other methods
+Mongo().setWriteConcern({ w: "majority" }).getDB("test")

--- a/mongo/parsertest/testdata/connection-startSession.js
+++ b/mongo/parsertest/testdata/connection-startSession.js
@@ -1,0 +1,23 @@
+// startSession() - Start a new client session
+
+// Basic startSession
+Mongo().startSession()
+Mongo("localhost").startSession()
+Mongo("mongodb://localhost:27017").startSession()
+
+// startSession with options
+Mongo().startSession({})
+Mongo().startSession({ causalConsistency: true })
+Mongo().startSession({ causalConsistency: false })
+
+// startSession with retryable writes
+Mongo().startSession({ retryWrites: true })
+Mongo("localhost").startSession({ retryWrites: true, causalConsistency: true })
+
+// startSession with snapshot reads
+Mongo().startSession({ snapshot: true })
+
+// startSession from db.getMongo()
+db.getMongo().startSession()
+db.getMongo().startSession({ causalConsistency: true })
+db.getMongo().startSession({ retryWrites: true })

--- a/mongo/parsertest/testdata/connection-watch.js
+++ b/mongo/parsertest/testdata/connection-watch.js
@@ -1,0 +1,27 @@
+// watch() - Watch for changes on the entire cluster
+
+// Basic watch
+Mongo().watch()
+Mongo("localhost").watch()
+Mongo("mongodb://localhost:27017").watch()
+
+// watch with empty pipeline
+Mongo().watch([])
+
+// watch with pipeline stages
+Mongo().watch([{ $match: { operationType: "insert" } }])
+Mongo("localhost").watch([{ $match: { "fullDocument.status": "active" } }])
+Mongo().watch([
+    { $match: { operationType: { $in: ["insert", "update", "replace"] } } },
+    { $project: { documentKey: 1, fullDocument: 1 } }
+])
+
+// watch with options
+Mongo().watch([], { fullDocument: "updateLookup" })
+Mongo("localhost").watch([], { maxAwaitTimeMS: 1000 })
+Mongo().watch([], { batchSize: 100, fullDocument: "updateLookup" })
+
+// watch from db.getMongo()
+db.getMongo().watch()
+db.getMongo().watch([{ $match: { operationType: "insert" } }])
+db.getMongo().watch([], { fullDocument: "updateLookup" })

--- a/mongo/parsertest/testdata/cursor-addOption.js
+++ b/mongo/parsertest/testdata/cursor-addOption.js
@@ -1,0 +1,34 @@
+// cursor.addOption() - Add query flags using numeric option values
+
+// Add tailable option (2)
+db.cappedCollection.find().addOption(2)
+
+// Add slaveOk option (4)
+db.users.find().addOption(4)
+
+// Add oplogReplay option (8)
+db.oplog.find().addOption(8)
+
+// Add noCursorTimeout option (16)
+db.users.find().addOption(16)
+
+// Add awaitData option (32)
+db.cappedCollection.find().addOption(32)
+
+// Add exhaust option (64)
+db.users.find().addOption(64)
+
+// Add partial option (128)
+db.users.find().addOption(128)
+
+// Combine multiple options
+db.cappedCollection.find().addOption(2).addOption(32)
+db.users.find().addOption(4).addOption(16)
+
+// Chained with other cursor methods
+db.users.find().addOption(16).sort({ name: 1 })
+db.users.find().addOption(4).limit(100)
+
+// With query filter
+db.logs.find({ level: "error" }).addOption(16)
+db.events.find({ type: "notification" }).addOption(2).addOption(32)

--- a/mongo/parsertest/testdata/cursor-allowDiskUse.js
+++ b/mongo/parsertest/testdata/cursor-allowDiskUse.js
@@ -1,0 +1,30 @@
+// cursor.allowDiskUse() - Allow query to use disk for large sorts
+
+// Basic usage (enable disk use)
+db.users.find().allowDiskUse()
+db.users.find().allowDiskUse(true)
+
+// Disable disk use
+db.users.find().allowDiskUse(false)
+
+// With query filter
+db.users.find({ status: "active" }).allowDiskUse()
+db.orders.find({ total: { $gt: 1000 } }).allowDiskUse(true)
+
+// Essential for large sorts
+db.users.find().sort({ name: 1 }).allowDiskUse()
+db.largeCollection.find().sort({ createdAt: -1, name: 1 }).allowDiskUse(true)
+
+// Chained with other cursor methods
+db.users.find().sort({ score: -1 }).allowDiskUse().limit(1000)
+db.users.find({ status: "active" }).sort({ name: 1 }).allowDiskUse(true).skip(100).limit(50)
+
+// For queries exceeding memory limits
+db.analytics.find({ date: { $gte: ISODate("2024-01-01") } }).sort({ date: -1 }).allowDiskUse()
+db.logs.find().sort({ timestamp: -1, level: 1 }).allowDiskUse(true)
+
+// With projection to reduce memory
+db.users.find().projection({ name: 1, email: 1 }).sort({ name: 1 }).allowDiskUse()
+
+// With explain
+db.users.find().sort({ name: 1 }).allowDiskUse().explain("executionStats")

--- a/mongo/parsertest/testdata/cursor-batchSize.js
+++ b/mongo/parsertest/testdata/cursor-batchSize.js
@@ -1,0 +1,24 @@
+// cursor.batchSize() - Set batch size for cursor iteration
+
+// Basic usage
+db.users.find().batchSize(100)
+db.users.find().batchSize(50)
+db.users.find().batchSize(1000)
+
+// With query filter
+db.users.find({ status: "active" }).batchSize(50)
+db.users.find({ age: { $gte: 18 } }).batchSize(200)
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).batchSize(25)
+db.users.find().sort({ name: 1 }).batchSize(25).limit(100)
+db.users.find().skip(100).limit(50).batchSize(10)
+
+// Small batch size for memory-constrained environments
+db.largeCollection.find().batchSize(10)
+
+// Large batch size for faster iteration
+db.users.find().batchSize(5000)
+
+// With projection
+db.users.find().projection({ name: 1 }).batchSize(100)

--- a/mongo/parsertest/testdata/cursor-close.js
+++ b/mongo/parsertest/testdata/cursor-close.js
@@ -1,0 +1,18 @@
+// cursor.close() - Close the cursor and free server resources
+
+// Basic usage - close cursor after getting some results
+db.users.find().close()
+
+// With query filter
+db.users.find({ status: "active" }).close()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).close()
+db.users.find().limit(10).close()
+db.users.find().batchSize(100).close()
+
+// Close after iterating
+db.users.find({ status: "pending" }).sort({ createdAt: -1 }).close()
+
+// With projection
+db.users.find().projection({ name: 1 }).close()

--- a/mongo/parsertest/testdata/cursor-collation.js
+++ b/mongo/parsertest/testdata/cursor-collation.js
@@ -1,0 +1,31 @@
+// cursor.collation() - Specify collation for string comparison
+
+// Basic collation with locale
+db.users.find().collation({ locale: "en" })
+db.users.find().collation({ locale: "fr" })
+db.users.find().collation({ locale: "de" })
+
+// Case-insensitive collation
+db.users.find({ name: "alice" }).collation({ locale: "en", strength: 2 })
+
+// Numeric ordering for strings
+db.products.find().collation({ locale: "en", numericOrdering: true })
+
+// With sort for locale-aware sorting
+db.users.find().sort({ name: 1 }).collation({ locale: "en" })
+db.users.find().sort({ name: 1 }).collation({ locale: "de", caseLevel: true })
+
+// Full collation options
+db.users.find().collation({
+    locale: "en",
+    strength: 2,
+    caseLevel: false,
+    caseFirst: "off",
+    numericOrdering: false,
+    alternate: "non-ignorable",
+    maxVariable: "punct",
+    backwards: false
+})
+
+// Chained with other cursor methods
+db.users.find({ status: "active" }).collation({ locale: "en" }).sort({ name: 1 }).limit(10)

--- a/mongo/parsertest/testdata/cursor-comment.js
+++ b/mongo/parsertest/testdata/cursor-comment.js
@@ -1,0 +1,20 @@
+// cursor.comment() - Add a comment to the query for profiling/logging
+
+// Basic usage
+db.users.find().comment("User listing query")
+db.users.find().comment("Admin dashboard query")
+
+// With query filter
+db.users.find({ status: "active" }).comment("Active users query")
+db.orders.find({ total: { $gt: 1000 } }).comment("High value orders")
+
+// Chained with other cursor methods
+db.users.find().sort({ createdAt: -1 }).comment("Recent users").limit(10)
+db.users.find({ role: "admin" }).comment("Admin lookup").projection({ name: 1, email: 1 })
+
+// Detailed comments for debugging
+db.users.find({ status: "pending" }).comment("Pending approval - ticket #12345")
+db.analytics.find({ date: { $gte: ISODate("2024-01-01") } }).comment("Q1 2024 analytics export")
+
+// Comment with special characters
+db.logs.find({ level: "error" }).comment("Error logs - check /var/log")

--- a/mongo/parsertest/testdata/cursor-count.js
+++ b/mongo/parsertest/testdata/cursor-count.js
@@ -1,0 +1,22 @@
+// cursor.count() - Count the number of documents matching the query
+
+// Basic usage
+db.users.find().count()
+db.users.find({}).count()
+
+// With query filter
+db.users.find({ status: "active" }).count()
+db.users.find({ age: { $gte: 18 } }).count()
+db.users.find({ "address.city": "New York" }).count()
+
+// After sort (sort doesn't affect count)
+db.users.find().sort({ name: 1 }).count()
+
+// After limit/skip (count ignores limit/skip by default)
+db.users.find().limit(10).count()
+db.users.find().skip(5).count()
+db.users.find().skip(5).limit(10).count()
+
+// Complex query with count
+db.users.find({ $or: [{ status: "active" }, { role: "admin" }] }).count()
+db.orders.find({ total: { $gt: 100 }, status: "completed" }).count()

--- a/mongo/parsertest/testdata/cursor-explain.js
+++ b/mongo/parsertest/testdata/cursor-explain.js
@@ -1,0 +1,28 @@
+// cursor.explain() - Return query execution information
+
+// Basic explain (default verbosity)
+db.users.find().explain()
+db.users.find({}).explain()
+
+// Explain with verbosity levels
+db.users.find().explain("queryPlanner")
+db.users.find().explain("executionStats")
+db.users.find().explain("allPlansExecution")
+
+// With query filter
+db.users.find({ status: "active" }).explain()
+db.users.find({ age: { $gt: 25 } }).explain("executionStats")
+
+// Explain sorted queries
+db.users.find().sort({ name: 1 }).explain()
+db.users.find({ status: "active" }).sort({ createdAt: -1 }).explain("executionStats")
+
+// Explain queries with indexes
+db.users.find({ email: "test@example.com" }).explain("allPlansExecution")
+db.orders.find({ customerId: ObjectId("507f1f77bcf86cd799439011") }).explain()
+
+// Explain complex queries
+db.users.find({ $or: [{ status: "active" }, { role: "admin" }] }).explain("executionStats")
+
+// Explain with limit/skip
+db.users.find().skip(100).limit(10).explain()

--- a/mongo/parsertest/testdata/cursor-forEach.js
+++ b/mongo/parsertest/testdata/cursor-forEach.js
@@ -1,0 +1,20 @@
+// cursor.forEach() - Iterate over each document with a callback function
+
+// Basic usage with document argument
+db.users.find().forEach({ handler: "print" })
+
+// With query filter
+db.users.find({ status: "active" }).forEach({ action: "log" })
+db.orders.find({ total: { $gt: 100 } }).forEach({ type: "process" })
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).forEach({ output: "console" })
+db.users.find().limit(10).forEach({ format: "json" })
+db.users.find({ status: "active" }).sort({ createdAt: -1 }).limit(5).forEach({ mode: "verbose" })
+
+// With projection
+db.users.find().projection({ name: 1, email: 1 }).forEach({ display: true })
+
+// With string argument representing callback name
+db.users.find().forEach("printjson")
+db.logs.find({ level: "error" }).forEach("processError")

--- a/mongo/parsertest/testdata/cursor-hasNext.js
+++ b/mongo/parsertest/testdata/cursor-hasNext.js
@@ -1,0 +1,21 @@
+// cursor.hasNext() - Check if there are more documents in the cursor
+
+// Basic usage
+db.users.find().hasNext()
+db.users.find({}).hasNext()
+
+// With query filter
+db.users.find({ status: "active" }).hasNext()
+db.users.find({ age: { $gt: 65 } }).hasNext()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).hasNext()
+db.users.find().limit(10).hasNext()
+db.users.find().skip(1000).hasNext()
+
+// Check for existence of matching documents
+db.users.find({ email: "admin@example.com" }).hasNext()
+db.orders.find({ status: "pending", createdAt: { $lt: ISODate("2024-01-01") } }).hasNext()
+
+// With projection
+db.users.find().projection({ _id: 1 }).hasNext()

--- a/mongo/parsertest/testdata/cursor-hint.js
+++ b/mongo/parsertest/testdata/cursor-hint.js
@@ -1,0 +1,24 @@
+// cursor.hint() - Force the query optimizer to use a specific index
+
+// Hint with index name
+db.users.find({ status: "active" }).hint("status_1")
+db.users.find({ email: "test@example.com" }).hint("email_1")
+
+// Hint with index specification document
+db.users.find({ status: "active" }).hint({ status: 1 })
+db.users.find({ name: "alice", age: 25 }).hint({ name: 1, age: 1 })
+
+// Force collection scan (no index)
+db.users.find({ status: "active" }).hint({ $natural: 1 })
+db.users.find().hint({ $natural: -1 })
+
+// Chained with other cursor methods
+db.users.find({ status: "active" }).hint("status_1").sort({ createdAt: -1 })
+db.users.find({ status: "active" }).hint({ status: 1 }).limit(10)
+db.orders.find({ customerId: ObjectId("507f1f77bcf86cd799439011") }).hint("customerId_1").explain()
+
+// Compound index hint
+db.products.find({ category: "electronics", price: { $lt: 500 } }).hint({ category: 1, price: 1 })
+
+// With projection
+db.users.find({ status: "active" }).hint("status_1").projection({ name: 1, email: 1 })

--- a/mongo/parsertest/testdata/cursor-isClosed.js
+++ b/mongo/parsertest/testdata/cursor-isClosed.js
@@ -1,0 +1,20 @@
+// cursor.isClosed() - Check if the cursor is closed
+
+// Basic usage
+db.users.find().isClosed()
+db.users.find({}).isClosed()
+
+// With query filter
+db.users.find({ status: "active" }).isClosed()
+db.orders.find({ total: { $gt: 100 } }).isClosed()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).isClosed()
+db.users.find().limit(10).isClosed()
+db.users.find().batchSize(100).isClosed()
+
+// Check status after operations
+db.users.find({ status: "pending" }).skip(50).limit(25).isClosed()
+
+// With projection
+db.users.find().projection({ name: 1 }).isClosed()

--- a/mongo/parsertest/testdata/cursor-isExhausted.js
+++ b/mongo/parsertest/testdata/cursor-isExhausted.js
@@ -1,0 +1,21 @@
+// cursor.isExhausted() - Check if the cursor has no more documents and is closed
+
+// Basic usage
+db.users.find().isExhausted()
+db.users.find({}).isExhausted()
+
+// With query filter
+db.users.find({ status: "active" }).isExhausted()
+db.users.find({ role: "superadmin" }).isExhausted()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).isExhausted()
+db.users.find().limit(10).isExhausted()
+db.users.find().skip(1000000).isExhausted()
+
+// Check exhaustion status
+db.users.find({ status: "deleted" }).batchSize(10).isExhausted()
+db.logs.find({ timestamp: { $lt: ISODate("2020-01-01") } }).isExhausted()
+
+// With projection
+db.users.find().projection({ _id: 1 }).isExhausted()

--- a/mongo/parsertest/testdata/cursor-itcount.js
+++ b/mongo/parsertest/testdata/cursor-itcount.js
@@ -1,0 +1,24 @@
+// cursor.itcount() - Count documents by iterating through the cursor
+
+// Basic usage
+db.users.find().itcount()
+db.users.find({}).itcount()
+
+// With query filter
+db.users.find({ status: "active" }).itcount()
+db.users.find({ age: { $gte: 18, $lte: 65 } }).itcount()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).itcount()
+db.users.find().limit(100).itcount()
+db.users.find().skip(50).itcount()
+
+// Unlike count(), itcount() respects limit and skip
+db.users.find().skip(10).limit(5).itcount()
+
+// Complex queries
+db.orders.find({ status: "completed", total: { $gt: 500 } }).itcount()
+db.logs.find({ level: { $in: ["error", "fatal"] } }).itcount()
+
+// With projection
+db.users.find().projection({ _id: 1 }).itcount()

--- a/mongo/parsertest/testdata/cursor-limit.js
+++ b/mongo/parsertest/testdata/cursor-limit.js
@@ -1,0 +1,21 @@
+// cursor.limit() - Limit the number of documents returned
+
+// Basic usage
+db.users.find().limit(10)
+db.users.find().limit(1)
+db.users.find().limit(100)
+
+// With query filter
+db.users.find({ status: "active" }).limit(50)
+db.users.find({ age: { $gte: 18 } }).limit(25)
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).limit(10)
+db.users.find().skip(20).limit(10)
+db.users.find({ status: "active" }).sort({ createdAt: -1 }).limit(5)
+
+// Limit with projection
+db.users.find().projection({ name: 1, email: 1 }).limit(10)
+
+// Limit 0 returns all documents (no limit)
+db.users.find().limit(0)

--- a/mongo/parsertest/testdata/cursor-map.js
+++ b/mongo/parsertest/testdata/cursor-map.js
@@ -1,0 +1,20 @@
+// cursor.map() - Apply a function to each document and return array of results
+
+// Basic usage with document argument
+db.users.find().map({ field: "name" })
+
+// With query filter
+db.users.find({ status: "active" }).map({ extract: "email" })
+db.orders.find({ total: { $gt: 100 } }).map({ compute: "tax" })
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).map({ field: "name" })
+db.users.find().limit(10).map({ transform: "user" })
+db.users.find({ status: "active" }).sort({ createdAt: -1 }).limit(5).map({ format: "output" })
+
+// With projection
+db.users.find().projection({ name: 1, email: 1 }).map({ concat: "contact" })
+
+// With string argument representing transformation name
+db.products.find({ inStock: true }).map("applyDiscount")
+db.logs.find({ level: "error" }).map("extractMessage")

--- a/mongo/parsertest/testdata/cursor-max.js
+++ b/mongo/parsertest/testdata/cursor-max.js
@@ -1,0 +1,23 @@
+// cursor.max() - Specify exclusive upper bound for index-based query
+
+// Basic usage with index key pattern
+db.users.find({ age: { $gte: 18 } }).max({ age: 65 })
+
+// With compound index
+db.users.find().max({ status: "z", name: "z" })
+db.products.find({ category: "electronics" }).max({ category: "electronics", price: 1000 })
+
+// Chained with min() for range
+db.users.find().min({ age: 18 }).max({ age: 65 })
+db.products.find().min({ price: 10 }).max({ price: 100 })
+
+// With hint (required for max to work correctly)
+db.users.find().max({ age: 30 }).hint({ age: 1 })
+db.products.find().min({ price: 50 }).max({ price: 200 }).hint({ price: 1 })
+
+// Chained with other cursor methods
+db.users.find().max({ age: 50 }).hint({ age: 1 }).sort({ name: 1 })
+db.users.find().max({ age: 30 }).hint({ age: 1 }).limit(10)
+
+// With multiple fields
+db.events.find().max({ date: ISODate("2024-12-31"), priority: 10 })

--- a/mongo/parsertest/testdata/cursor-maxAwaitTimeMS.js
+++ b/mongo/parsertest/testdata/cursor-maxAwaitTimeMS.js
@@ -1,0 +1,21 @@
+// cursor.maxAwaitTimeMS() - Set maximum time for tailable cursor getMore operations
+
+// Basic usage
+db.oplog.find().maxAwaitTimeMS(1000)
+db.oplog.find().maxAwaitTimeMS(5000)
+
+// With tailable cursor
+db.capped.find().tailable().maxAwaitTimeMS(2000)
+db.events.find().tailable(true).maxAwaitTimeMS(3000)
+
+// Different timeout values
+db.oplog.find().maxAwaitTimeMS(100)
+db.oplog.find().maxAwaitTimeMS(10000)
+db.oplog.find().maxAwaitTimeMS(30000)
+
+// Chained with other cursor methods
+db.logs.find({ level: "error" }).tailable().maxAwaitTimeMS(5000)
+db.events.find().tailable().batchSize(100).maxAwaitTimeMS(2000)
+
+// For change streams and tailable cursors
+db.changes.find().tailable(true).maxAwaitTimeMS(1000).batchSize(10)

--- a/mongo/parsertest/testdata/cursor-maxTimeMS.js
+++ b/mongo/parsertest/testdata/cursor-maxTimeMS.js
@@ -1,0 +1,27 @@
+// cursor.maxTimeMS() - Set maximum execution time for the query
+
+// Basic usage
+db.users.find().maxTimeMS(5000)
+db.users.find().maxTimeMS(1000)
+db.users.find().maxTimeMS(30000)
+
+// With query filter
+db.users.find({ status: "active" }).maxTimeMS(10000)
+db.orders.find({ total: { $gt: 1000 } }).maxTimeMS(5000)
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).maxTimeMS(3000)
+db.users.find().sort({ createdAt: -1 }).limit(100).maxTimeMS(5000)
+db.users.find({ status: "active" }).skip(1000).limit(100).maxTimeMS(10000)
+
+// For long-running queries
+db.analytics.find({ date: { $gte: ISODate("2024-01-01") } }).maxTimeMS(60000)
+
+// Short timeout for quick queries
+db.users.find({ _id: ObjectId("507f1f77bcf86cd799439011") }).maxTimeMS(100)
+
+// With aggregation-style queries
+db.logs.find({ $text: { $search: "error" } }).maxTimeMS(15000)
+
+// With explain
+db.users.find({ status: "active" }).maxTimeMS(5000).explain()

--- a/mongo/parsertest/testdata/cursor-min.js
+++ b/mongo/parsertest/testdata/cursor-min.js
@@ -1,0 +1,26 @@
+// cursor.min() - Specify inclusive lower bound for index-based query
+
+// Basic usage with index key pattern
+db.users.find({ age: { $lte: 65 } }).min({ age: 18 })
+
+// With compound index
+db.users.find().min({ status: "a", name: "a" })
+db.products.find({ category: "electronics" }).min({ category: "electronics", price: 0 })
+
+// Chained with max() for range
+db.users.find().min({ age: 18 }).max({ age: 65 })
+db.products.find().min({ price: 10 }).max({ price: 100 })
+
+// With hint (required for min to work correctly)
+db.users.find().min({ age: 21 }).hint({ age: 1 })
+db.products.find().min({ price: 50 }).hint({ price: 1 })
+
+// Chained with other cursor methods
+db.users.find().min({ age: 18 }).hint({ age: 1 }).sort({ name: 1 })
+db.users.find().min({ age: 21 }).hint({ age: 1 }).limit(10)
+
+// With multiple fields
+db.events.find().min({ date: ISODate("2024-01-01"), priority: 1 })
+
+// Range query with both bounds
+db.scores.find().min({ score: 60 }).max({ score: 100 }).hint({ score: 1 })

--- a/mongo/parsertest/testdata/cursor-next.js
+++ b/mongo/parsertest/testdata/cursor-next.js
@@ -1,0 +1,24 @@
+// cursor.next() - Return the next document in the cursor
+
+// Basic usage
+db.users.find().next()
+db.users.find({}).next()
+
+// With query filter
+db.users.find({ status: "active" }).next()
+db.users.find({ role: "admin" }).next()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).next()
+db.users.find().sort({ createdAt: -1 }).next()
+db.users.find().skip(10).next()
+
+// Get first matching document
+db.users.find({ email: "admin@example.com" }).next()
+db.orders.find({ status: "pending" }).sort({ createdAt: 1 }).next()
+
+// With projection
+db.users.find().projection({ name: 1, email: 1 }).next()
+
+// With limit (still returns just one document)
+db.users.find().limit(100).next()

--- a/mongo/parsertest/testdata/cursor-noCursorTimeout.js
+++ b/mongo/parsertest/testdata/cursor-noCursorTimeout.js
@@ -1,0 +1,24 @@
+// cursor.noCursorTimeout() - Prevent cursor from timing out on the server
+
+// Basic usage
+db.users.find().noCursorTimeout()
+db.users.find({}).noCursorTimeout()
+
+// With query filter
+db.users.find({ status: "active" }).noCursorTimeout()
+db.largeCollection.find({ processed: false }).noCursorTimeout()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).noCursorTimeout()
+db.users.find().batchSize(100).noCursorTimeout()
+db.users.find().limit(10000).noCursorTimeout()
+
+// For long-running batch operations
+db.logs.find({ level: "error" }).noCursorTimeout().batchSize(50)
+db.analytics.find({ date: { $gte: ISODate("2024-01-01") } }).noCursorTimeout()
+
+// Chained after noCursorTimeout
+db.documents.find({ needsProcessing: true }).noCursorTimeout().toArray()
+
+// With projection
+db.users.find().projection({ _id: 1, data: 1 }).noCursorTimeout()

--- a/mongo/parsertest/testdata/cursor-objsLeftInBatch.js
+++ b/mongo/parsertest/testdata/cursor-objsLeftInBatch.js
@@ -1,0 +1,24 @@
+// cursor.objsLeftInBatch() - Return number of documents remaining in current batch
+
+// Basic usage
+db.users.find().objsLeftInBatch()
+db.users.find({}).objsLeftInBatch()
+
+// With query filter
+db.users.find({ status: "active" }).objsLeftInBatch()
+db.orders.find({ total: { $gt: 100 } }).objsLeftInBatch()
+
+// Chained with batchSize
+db.users.find().batchSize(100).objsLeftInBatch()
+db.users.find().batchSize(50).objsLeftInBatch()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).objsLeftInBatch()
+db.users.find().limit(1000).objsLeftInBatch()
+db.users.find().skip(100).batchSize(25).objsLeftInBatch()
+
+// For monitoring batch consumption
+db.logs.find({ level: "error" }).batchSize(10).objsLeftInBatch()
+
+// With projection
+db.users.find().projection({ name: 1 }).objsLeftInBatch()

--- a/mongo/parsertest/testdata/cursor-optional-args.js
+++ b/mongo/parsertest/testdata/cursor-optional-args.js
@@ -1,0 +1,20 @@
+// Test cursor methods with optional arguments
+
+// find and findOne with multiple args
+db.coll.find({}, {a: 1})
+db.coll.findOne({name: "test"}, {_id: 0})
+
+// Empty cursor methods
+db.coll.find().sort()
+db.coll.find().collation()
+db.coll.find().comment()
+db.coll.find().hint()
+db.coll.find().max()
+db.coll.find().min()
+db.coll.find().readConcern()
+db.coll.find().returnKey()
+db.coll.find().showRecordId()
+db.coll.find().projection()
+
+// aggregate with empty pipeline
+db.coll.aggregate()

--- a/mongo/parsertest/testdata/cursor-pretty.js
+++ b/mongo/parsertest/testdata/cursor-pretty.js
@@ -1,0 +1,24 @@
+// cursor.pretty() - Format output for readability in the shell
+
+// Basic usage
+db.users.find().pretty()
+db.users.find({}).pretty()
+
+// With query filter
+db.users.find({ status: "active" }).pretty()
+db.users.find({ age: { $gt: 25 } }).pretty()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).pretty()
+db.users.find().limit(10).pretty()
+db.users.find().skip(5).limit(5).pretty()
+
+// Complex queries with pretty output
+db.users.find({ $or: [{ status: "active" }, { role: "admin" }] }).pretty()
+db.orders.find({ items: { $elemMatch: { price: { $gt: 100 } } } }).pretty()
+
+// With projection
+db.users.find().projection({ name: 1, email: 1, address: 1 }).pretty()
+
+// Nested document display
+db.users.find({ "address.city": "New York" }).pretty()

--- a/mongo/parsertest/testdata/cursor-projection.js
+++ b/mongo/parsertest/testdata/cursor-projection.js
@@ -1,0 +1,27 @@
+// cursor.projection() / cursor.project() - Specify fields to return
+
+// Include specific fields
+db.users.find().projection({ name: 1, email: 1 })
+db.users.find().project({ name: 1, email: 1 })
+
+// Exclude _id
+db.users.find().projection({ name: 1, email: 1, _id: 0 })
+
+// Exclude specific fields
+db.users.find().projection({ password: 0, secretKey: 0 })
+
+// With query filter
+db.users.find({ status: "active" }).projection({ name: 1, status: 1 })
+db.users.find({ age: { $gte: 18 } }).project({ name: 1, age: 1 })
+
+// Nested field projection
+db.users.find().projection({ "address.city": 1, "address.country": 1 })
+db.users.find().project({ "profile.name": 1, "profile.avatar": 1 })
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).projection({ name: 1 }).limit(10)
+db.users.find({ status: "active" }).project({ name: 1, email: 1 }).skip(10).limit(10)
+
+// Array projection operators
+db.posts.find().projection({ comments: { $slice: 5 } })
+db.posts.find().projection({ comments: { $elemMatch: { score: { $gt: 5 } } } })

--- a/mongo/parsertest/testdata/cursor-readConcern.js
+++ b/mongo/parsertest/testdata/cursor-readConcern.js
@@ -1,0 +1,29 @@
+// cursor.readConcern() - Specify read concern level for the query
+
+// Local read concern (default)
+db.users.find().readConcern({ level: "local" })
+
+// Available read concern
+db.users.find().readConcern({ level: "available" })
+
+// Majority read concern
+db.users.find().readConcern({ level: "majority" })
+
+// Linearizable read concern
+db.users.find().readConcern({ level: "linearizable" })
+
+// Snapshot read concern
+db.users.find().readConcern({ level: "snapshot" })
+
+// With query filter
+db.users.find({ status: "active" }).readConcern({ level: "majority" })
+db.orders.find({ total: { $gt: 1000 } }).readConcern({ level: "local" })
+
+// Chained with other cursor methods
+db.users.find().readConcern({ level: "majority" }).sort({ name: 1 })
+db.users.find().readConcern({ level: "majority" }).limit(10)
+db.users.find({ status: "active" }).readConcern({ level: "majority" }).maxTimeMS(5000)
+
+// For consistency-critical queries
+db.inventory.find({ sku: "abc123" }).readConcern({ level: "linearizable" })
+db.balances.find({ accountId: "12345" }).readConcern({ level: "majority" })

--- a/mongo/parsertest/testdata/cursor-readPref.js
+++ b/mongo/parsertest/testdata/cursor-readPref.js
@@ -1,0 +1,35 @@
+// cursor.readPref() - Specify read preference for replica set queries
+
+// Primary read preference (default)
+db.users.find().readPref("primary")
+
+// Primary preferred
+db.users.find().readPref("primaryPreferred")
+
+// Secondary read preference
+db.users.find().readPref("secondary")
+
+// Secondary preferred
+db.users.find().readPref("secondaryPreferred")
+
+// Nearest read preference
+db.users.find().readPref("nearest")
+
+// With tag sets
+db.users.find().readPref("secondary", [{ region: "east" }])
+db.users.find().readPref("nearest", [{ dc: "us-east-1" }, { dc: "us-west-2" }])
+
+// With maxStalenessSeconds
+db.users.find().readPref("secondaryPreferred", [], { maxStalenessSeconds: 120 })
+
+// With query filter
+db.users.find({ status: "active" }).readPref("secondary")
+db.analytics.find({ date: { $gte: ISODate("2024-01-01") } }).readPref("secondaryPreferred")
+
+// Chained with other cursor methods
+db.users.find().readPref("secondary").sort({ name: 1 })
+db.users.find().readPref("nearest").limit(10)
+db.reports.find().readPref("secondaryPreferred").maxTimeMS(30000)
+
+// Read from specific data center
+db.users.find().readPref("nearest", [{ datacenter: "NYC" }])

--- a/mongo/parsertest/testdata/cursor-returnKey.js
+++ b/mongo/parsertest/testdata/cursor-returnKey.js
@@ -1,0 +1,25 @@
+// cursor.returnKey() - Return only the index keys in the result documents
+
+// Return only index keys
+db.users.find().returnKey(true)
+db.users.find({ status: "active" }).returnKey(true)
+
+// Disable returnKey (return full documents)
+db.users.find().returnKey(false)
+
+// With index hint
+db.users.find({ status: "active" }).hint({ status: 1 }).returnKey(true)
+db.users.find({ email: "test@example.com" }).hint("email_1").returnKey(true)
+
+// With compound index
+db.users.find({ name: "alice", age: 25 }).hint({ name: 1, age: 1 }).returnKey(true)
+
+// Chained with other cursor methods
+db.users.find().hint({ age: 1 }).returnKey(true).sort({ age: 1 })
+db.users.find().returnKey(true).limit(10)
+
+// Useful for debugging index usage
+db.orders.find({ customerId: ObjectId("507f1f77bcf86cd799439011") }).hint({ customerId: 1 }).returnKey(true)
+
+// With explain to see index behavior
+db.users.find({ status: "active" }).returnKey(true).explain()

--- a/mongo/parsertest/testdata/cursor-showRecordId.js
+++ b/mongo/parsertest/testdata/cursor-showRecordId.js
@@ -1,0 +1,26 @@
+// cursor.showRecordId() - Include the $recordId field in result documents
+
+// Show record IDs
+db.users.find().showRecordId(true)
+db.users.find({ status: "active" }).showRecordId(true)
+
+// Hide record IDs (default behavior)
+db.users.find().showRecordId(false)
+
+// With query filter
+db.users.find({ age: { $gt: 25 } }).showRecordId(true)
+db.orders.find({ total: { $gt: 1000 } }).showRecordId(true)
+
+// Chained with other cursor methods
+db.users.find().showRecordId(true).sort({ name: 1 })
+db.users.find().showRecordId(true).limit(10)
+db.users.find().showRecordId(true).skip(5).limit(5)
+
+// With projection
+db.users.find().projection({ name: 1, email: 1 }).showRecordId(true)
+
+// Useful for debugging and data inspection
+db.collection.find({ corrupted: true }).showRecordId(true)
+
+// With pretty for readable output
+db.users.find().showRecordId(true).pretty()

--- a/mongo/parsertest/testdata/cursor-size.js
+++ b/mongo/parsertest/testdata/cursor-size.js
@@ -1,0 +1,28 @@
+// cursor.size() - Return count of documents considering skip and limit
+
+// Basic usage
+db.users.find().size()
+db.users.find({}).size()
+
+// With query filter
+db.users.find({ status: "active" }).size()
+db.users.find({ age: { $gte: 18 } }).size()
+
+// Size considers limit and skip (unlike count)
+db.users.find().limit(10).size()
+db.users.find().skip(5).size()
+db.users.find().skip(10).limit(5).size()
+
+// Compare with count behavior
+db.users.find().limit(100).size()
+db.users.find().skip(50).limit(25).size()
+
+// With sort (doesn't affect size)
+db.users.find().sort({ name: 1 }).size()
+
+// Complex queries
+db.orders.find({ status: "completed", total: { $gt: 100 } }).size()
+db.logs.find({ level: { $in: ["error", "fatal"] } }).skip(10).size()
+
+// With projection
+db.users.find().projection({ _id: 1 }).size()

--- a/mongo/parsertest/testdata/cursor-skip.js
+++ b/mongo/parsertest/testdata/cursor-skip.js
@@ -1,0 +1,22 @@
+// cursor.skip() - Skip a number of documents in the result set
+
+// Basic usage
+db.users.find().skip(10)
+db.users.find().skip(0)
+db.users.find().skip(100)
+
+// With query filter
+db.users.find({ status: "active" }).skip(50)
+db.users.find({ age: { $gte: 18 } }).skip(25)
+
+// Chained with other cursor methods (pagination pattern)
+db.users.find().skip(0).limit(10)
+db.users.find().skip(10).limit(10)
+db.users.find().skip(20).limit(10)
+
+// With sort for consistent pagination
+db.users.find().sort({ _id: 1 }).skip(100).limit(10)
+db.users.find({ status: "active" }).sort({ createdAt: -1 }).skip(50).limit(25)
+
+// Skip with projection
+db.users.find().projection({ name: 1 }).skip(5).limit(5)

--- a/mongo/parsertest/testdata/cursor-sort.js
+++ b/mongo/parsertest/testdata/cursor-sort.js
@@ -1,0 +1,27 @@
+// cursor.sort() - Sort documents in the result set
+
+// Basic ascending sort
+db.users.find().sort({ name: 1 })
+
+// Basic descending sort
+db.users.find().sort({ age: -1 })
+
+// Multiple field sort
+db.users.find().sort({ status: 1, name: 1 })
+db.users.find().sort({ createdAt: -1, name: 1 })
+
+// With query filter
+db.users.find({ status: "active" }).sort({ name: 1 })
+db.users.find({ age: { $gt: 18 } }).sort({ age: -1 })
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).limit(10)
+db.users.find().sort({ createdAt: -1 }).skip(20).limit(10)
+db.users.find({ status: "active" }).sort({ name: 1 }).limit(100).skip(0)
+
+// Sort on nested fields
+db.users.find().sort({ "address.city": 1 })
+db.users.find().sort({ "profile.score": -1, "profile.name": 1 })
+
+// Sort with text score (for text search)
+db.articles.find({ $text: { $search: "mongodb" } }).sort({ score: { $meta: "textScore" } })

--- a/mongo/parsertest/testdata/cursor-tailable.js
+++ b/mongo/parsertest/testdata/cursor-tailable.js
@@ -1,0 +1,30 @@
+// cursor.tailable() - Create a tailable cursor for capped collections
+
+// Basic tailable cursor
+db.cappedCollection.find().tailable()
+db.oplog.find().tailable()
+
+// With explicit true/false
+db.cappedCollection.find().tailable(true)
+db.cappedCollection.find().tailable(false)
+
+// With query filter
+db.logs.find({ level: "error" }).tailable()
+db.events.find({ type: "notification" }).tailable(true)
+
+// Tailable with awaitData (for blocking behavior)
+db.cappedCollection.find().tailable().maxAwaitTimeMS(1000)
+db.oplog.find().tailable(true).maxAwaitTimeMS(5000)
+
+// Chained with other cursor methods
+db.cappedCollection.find().tailable().batchSize(10)
+db.events.find().tailable(true).batchSize(100).maxAwaitTimeMS(2000)
+
+// For real-time log tailing
+db.logs.find({ timestamp: { $gte: ISODate("2024-01-01") } }).tailable()
+
+// With projection
+db.events.find().tailable().projection({ message: 1, timestamp: 1 })
+
+// Oplog tailing pattern
+db.oplog.find({ ts: { $gt: Timestamp(0, 0) } }).tailable(true)

--- a/mongo/parsertest/testdata/cursor-toArray.js
+++ b/mongo/parsertest/testdata/cursor-toArray.js
@@ -1,0 +1,28 @@
+// cursor.toArray() - Return all documents as an array
+
+// Basic usage
+db.users.find().toArray()
+db.users.find({}).toArray()
+
+// With query filter
+db.users.find({ status: "active" }).toArray()
+db.users.find({ age: { $gte: 18, $lte: 65 } }).toArray()
+
+// Chained with other cursor methods
+db.users.find().sort({ name: 1 }).toArray()
+db.users.find().limit(10).toArray()
+db.users.find().skip(5).limit(5).toArray()
+
+// With sort and limit
+db.users.find({ status: "active" }).sort({ createdAt: -1 }).limit(100).toArray()
+
+// With projection
+db.users.find().projection({ name: 1, email: 1 }).toArray()
+db.users.find().project({ name: 1, _id: 0 }).toArray()
+
+// Complex queries
+db.orders.find({ $or: [{ status: "pending" }, { priority: "high" }] }).toArray()
+db.logs.find({ level: { $in: ["error", "warn"] } }).sort({ timestamp: -1 }).limit(50).toArray()
+
+// With maxTimeMS for timeout
+db.largeCollection.find().limit(1000).maxTimeMS(30000).toArray()

--- a/mongo/parsertest/testdata/cursor-tryNext.js
+++ b/mongo/parsertest/testdata/cursor-tryNext.js
@@ -1,0 +1,26 @@
+// cursor.tryNext() - Return next document without blocking (for tailable cursors)
+
+// Basic usage
+db.users.find().tryNext()
+db.cappedCollection.find().tryNext()
+
+// With tailable cursor
+db.cappedCollection.find().tailable().tryNext()
+db.oplog.find().tailable(true).tryNext()
+
+// With query filter
+db.events.find({ type: "notification" }).tailable().tryNext()
+db.logs.find({ level: "error" }).tailable().tryNext()
+
+// Chained with other cursor methods
+db.cappedCollection.find().tailable().batchSize(10).tryNext()
+db.events.find().tailable().maxAwaitTimeMS(1000).tryNext()
+
+// For non-blocking iteration
+db.logs.find({ timestamp: { $gte: ISODate("2024-01-01") } }).tailable().tryNext()
+
+// With projection
+db.events.find().tailable().projection({ message: 1 }).tryNext()
+
+// Standard cursor (returns next or null)
+db.users.find({ status: "active" }).tryNext()

--- a/mongo/parsertest/testdata/db-adminCommand.js
+++ b/mongo/parsertest/testdata/db-adminCommand.js
@@ -1,0 +1,44 @@
+// db.adminCommand() - Run an administrative command against the admin database
+
+// Server status
+db.adminCommand({ serverStatus: 1 })
+
+// Current operations
+db.adminCommand({ currentOp: 1 })
+db.adminCommand({ currentOp: 1, active: true })
+
+// Kill operations
+db.adminCommand({ killOp: 1, op: 12345 })
+
+// Shutdown
+db.adminCommand({ shutdown: 1 })
+db.adminCommand({ shutdown: 1, force: true })
+
+// Log management
+db.adminCommand({ getLog: "global" })
+db.adminCommand({ getLog: "startupWarnings" })
+
+// Replica set commands
+db.adminCommand({ replSetGetStatus: 1 })
+db.adminCommand({ replSetGetConfig: 1 })
+db.adminCommand({ replSetStepDown: 60 })
+
+// Sharding commands
+db.adminCommand({ listShards: 1 })
+db.adminCommand({ enableSharding: "mydb" })
+db.adminCommand({ shardCollection: "mydb.users", key: { _id: "hashed" } })
+
+// User management
+db.adminCommand({ listDatabases: 1 })
+db.adminCommand({ listDatabases: 1, nameOnly: true })
+
+// Feature compatibility
+db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 })
+db.adminCommand({ setFeatureCompatibilityVersion: "6.0" })
+
+// Connection pool
+db.adminCommand({ connPoolStats: 1 })
+
+// fsync
+db.adminCommand({ fsync: 1 })
+db.adminCommand({ fsync: 1, lock: true })

--- a/mongo/parsertest/testdata/db-aggregate.js
+++ b/mongo/parsertest/testdata/db-aggregate.js
@@ -1,0 +1,21 @@
+// db.aggregate() - Run aggregation pipeline against the database
+
+// Basic aggregation
+db.aggregate([
+    { $currentOp: {} }
+])
+
+// List all collections via aggregation
+db.aggregate([
+    { $listLocalSessions: {} }
+])
+
+// Admin database operations
+db.aggregate([
+    { $currentOp: { allUsers: true, idleSessions: true } }
+])
+
+// With options
+db.aggregate([
+    { $listLocalSessions: { allUsers: true } }
+], { allowDiskUse: true })

--- a/mongo/parsertest/testdata/db-auth.js
+++ b/mongo/parsertest/testdata/db-auth.js
@@ -1,0 +1,24 @@
+// db.auth() - Authenticate a user to the database
+
+// Basic authentication with username and password
+db.auth("username", "password")
+
+// Authentication with document
+db.auth({
+    user: "username",
+    pwd: "password"
+})
+
+// Authentication with mechanism
+db.auth({
+    user: "username",
+    pwd: "password",
+    mechanism: "SCRAM-SHA-256"
+})
+
+// Authentication with digest password disabled
+db.auth({
+    user: "username",
+    pwd: "password",
+    digestPassword: false
+})

--- a/mongo/parsertest/testdata/db-changeUserPassword.js
+++ b/mongo/parsertest/testdata/db-changeUserPassword.js
@@ -1,0 +1,6 @@
+// db.changeUserPassword() - Change a user's password
+
+// Basic usage
+db.changeUserPassword("reportUser", "newPassword123")
+db.changeUserPassword("appUser", "SecureP@ssw0rd!")
+db.changeUserPassword("admin", "adminNewPwd")

--- a/mongo/parsertest/testdata/db-cloneDatabase.js
+++ b/mongo/parsertest/testdata/db-cloneDatabase.js
@@ -1,0 +1,6 @@
+// db.cloneDatabase() - Deprecated: Clone a database from a remote host
+
+// Basic usage (deprecated in MongoDB 4.2+)
+db.cloneDatabase("source.example.com")
+db.cloneDatabase("192.168.1.100")
+db.cloneDatabase("mongodb.local:27017")

--- a/mongo/parsertest/testdata/db-commandHelp.js
+++ b/mongo/parsertest/testdata/db-commandHelp.js
@@ -1,0 +1,11 @@
+// db.commandHelp() - Returns help text for a database command
+
+// Get help for various commands
+db.commandHelp("find")
+db.commandHelp("aggregate")
+db.commandHelp("insert")
+db.commandHelp("update")
+db.commandHelp("delete")
+db.commandHelp("createIndexes")
+db.commandHelp("serverStatus")
+db.commandHelp("replSetGetStatus")

--- a/mongo/parsertest/testdata/db-copyDatabase.js
+++ b/mongo/parsertest/testdata/db-copyDatabase.js
@@ -1,0 +1,9 @@
+// db.copyDatabase() - Deprecated: Copy a database
+
+// Basic usage (deprecated in MongoDB 4.2+)
+db.copyDatabase("source", "target")
+db.copyDatabase("production", "staging")
+db.copyDatabase("olddb", "newdb", "remote.host.com")
+
+// With authentication
+db.copyDatabase("source", "target", "remote.host.com", "username", "password")

--- a/mongo/parsertest/testdata/db-createCollection.js
+++ b/mongo/parsertest/testdata/db-createCollection.js
@@ -1,0 +1,49 @@
+// db.createCollection() - Create a new collection with options
+
+// Basic collection creation
+db.createCollection("users")
+db.createCollection("orders")
+db.createCollection("products")
+
+// Create capped collection
+db.createCollection("logs", { capped: true, size: 10000 })
+db.createCollection("events", { capped: true, size: 100000, max: 5000 })
+
+// Create collection with validation
+db.createCollection("contacts", {
+    validator: { $jsonSchema: {
+        bsonType: "object",
+        required: ["name", "email"],
+        properties: {
+            name: { bsonType: "string" },
+            email: { bsonType: "string" }
+        }
+    }}
+})
+
+// Create collection with storage engine options
+db.createCollection("archive", {
+    storageEngine: { wiredTiger: { configString: "block_compressor=zstd" } }
+})
+
+// Create time series collection
+db.createCollection("weather", {
+    timeseries: {
+        timeField: "timestamp",
+        metaField: "metadata",
+        granularity: "hours"
+    }
+})
+
+// Create collection with collation
+db.createCollection("users_intl", {
+    collation: { locale: "en_US", strength: 2 }
+})
+
+// Create clustered collection
+db.createCollection("orders_clustered", {
+    clusteredIndex: {
+        key: { _id: 1 },
+        unique: true
+    }
+})

--- a/mongo/parsertest/testdata/db-createRole.js
+++ b/mongo/parsertest/testdata/db-createRole.js
@@ -1,0 +1,42 @@
+// db.createRole() - Create a new role
+
+// Basic role with privileges
+db.createRole({
+    role: "readWriteReports",
+    privileges: [
+        { resource: { db: "reporting", collection: "" }, actions: ["find", "insert", "update"] }
+    ],
+    roles: []
+})
+
+// Role inheriting from other roles
+db.createRole({
+    role: "appAdmin",
+    privileges: [],
+    roles: [
+        { role: "readWrite", db: "app" },
+        { role: "read", db: "logs" }
+    ]
+})
+
+// Role with specific collection privileges
+db.createRole({
+    role: "orderManager",
+    privileges: [
+        { resource: { db: "sales", collection: "orders" }, actions: ["find", "insert", "update", "remove"] },
+        { resource: { db: "sales", collection: "customers" }, actions: ["find"] }
+    ],
+    roles: []
+})
+
+// Role with write concern
+db.createRole({
+    role: "criticalWriter",
+    privileges: [
+        { resource: { db: "critical", collection: "" }, actions: ["insert", "update"] }
+    ],
+    roles: []
+}, {
+    w: "majority",
+    wtimeout: 5000
+})

--- a/mongo/parsertest/testdata/db-createUser.js
+++ b/mongo/parsertest/testdata/db-createUser.js
@@ -1,0 +1,52 @@
+// db.createUser() - Create a new user
+
+// Basic user with role
+db.createUser({
+    user: "appUser",
+    pwd: "password123",
+    roles: ["readWrite"]
+})
+
+// User with multiple roles
+db.createUser({
+    user: "adminUser",
+    pwd: "securePassword",
+    roles: [
+        { role: "readWrite", db: "app" },
+        { role: "read", db: "reporting" }
+    ]
+})
+
+// User with custom data
+db.createUser({
+    user: "developer",
+    pwd: "devPassword",
+    roles: ["readWrite"],
+    customData: { department: "engineering", team: "backend" }
+})
+
+// User with authentication restrictions
+db.createUser({
+    user: "restrictedUser",
+    pwd: "password",
+    roles: ["read"],
+    authenticationRestrictions: [
+        { clientSource: ["192.168.1.0/24"], serverAddress: ["192.168.1.100"] }
+    ]
+})
+
+// User with SCRAM-SHA-256 mechanism
+db.createUser({
+    user: "secureUser",
+    pwd: "strongPassword",
+    roles: ["readWrite"],
+    mechanisms: ["SCRAM-SHA-256"]
+})
+
+// User with passwordDigestor
+db.createUser({
+    user: "clientDigestUser",
+    pwd: "password",
+    roles: ["read"],
+    passwordDigestor: "client"
+})

--- a/mongo/parsertest/testdata/db-createView.js
+++ b/mongo/parsertest/testdata/db-createView.js
@@ -1,0 +1,40 @@
+// db.createView() - Create a view
+
+// Basic view
+db.createView("activeUsers", "users", [
+    { $match: { status: "active" } }
+])
+
+// View with multiple pipeline stages
+db.createView("orderSummary", "orders", [
+    { $match: { status: "completed" } },
+    { $group: { _id: "$customerId", totalAmount: { $sum: "$amount" } } },
+    { $sort: { totalAmount: -1 } }
+])
+
+// View with lookup
+db.createView("userOrders", "users", [
+    { $lookup: {
+        from: "orders",
+        localField: "_id",
+        foreignField: "userId",
+        as: "orders"
+    }}
+])
+
+// View with collation
+db.createView("sortedProducts", "products", [
+    { $sort: { name: 1 } }
+], {
+    collation: { locale: "en", strength: 2 }
+})
+
+// View with projection
+db.createView("publicUsers", "users", [
+    { $project: {
+        name: 1,
+        email: 1,
+        createdAt: 1,
+        _id: 0
+    }}
+])

--- a/mongo/parsertest/testdata/db-currentOp.js
+++ b/mongo/parsertest/testdata/db-currentOp.js
@@ -1,0 +1,34 @@
+// db.currentOp() - Returns information on current database operations
+
+// Basic usage
+db.currentOp()
+
+// Show all operations including idle connections
+db.currentOp(true)
+
+// Filter by active operations
+db.currentOp({ active: true })
+
+// Filter by operation type
+db.currentOp({ op: "query" })
+db.currentOp({ op: "insert" })
+db.currentOp({ op: "update" })
+
+// Filter by namespace
+db.currentOp({ ns: "mydb.users" })
+
+// Filter long-running operations
+db.currentOp({ secs_running: { $gt: 5 } })
+
+// Combined filters
+db.currentOp({
+    active: true,
+    secs_running: { $gt: 3 },
+    op: { $ne: "none" }
+})
+
+// Filter by client
+db.currentOp({ client: "192.168.1.100:12345" })
+
+// Show operations waiting for lock
+db.currentOp({ waitingForLock: true })

--- a/mongo/parsertest/testdata/db-dropAllRoles.js
+++ b/mongo/parsertest/testdata/db-dropAllRoles.js
@@ -1,0 +1,8 @@
+// db.dropAllRoles() - Drop all user-defined roles from the database
+
+// Basic usage
+db.dropAllRoles()
+
+// With write concern
+db.dropAllRoles({ w: "majority" })
+db.dropAllRoles({ w: 1, j: true })

--- a/mongo/parsertest/testdata/db-dropAllUsers.js
+++ b/mongo/parsertest/testdata/db-dropAllUsers.js
@@ -1,0 +1,8 @@
+// db.dropAllUsers() - Drop all users from the database
+
+// Basic usage
+db.dropAllUsers()
+
+// With write concern
+db.dropAllUsers({ w: "majority" })
+db.dropAllUsers({ w: 1, j: true })

--- a/mongo/parsertest/testdata/db-dropDatabase.js
+++ b/mongo/parsertest/testdata/db-dropDatabase.js
@@ -1,0 +1,4 @@
+// db.dropDatabase() - Drop the current database
+
+// Basic usage
+db.dropDatabase()

--- a/mongo/parsertest/testdata/db-dropRole.js
+++ b/mongo/parsertest/testdata/db-dropRole.js
@@ -1,0 +1,10 @@
+// db.dropRole() - Drop a user-defined role
+
+// Basic usage
+db.dropRole("tempRole")
+db.dropRole("readWriteReports")
+db.dropRole("appAdmin")
+
+// With write concern
+db.dropRole("customRole", { w: "majority" })
+db.dropRole("deprecatedRole", { w: 1, j: true })

--- a/mongo/parsertest/testdata/db-dropUser.js
+++ b/mongo/parsertest/testdata/db-dropUser.js
@@ -1,0 +1,10 @@
+// db.dropUser() - Drop a user from the database
+
+// Basic usage
+db.dropUser("tempUser")
+db.dropUser("oldUser")
+db.dropUser("testAccount")
+
+// With write concern
+db.dropUser("removedUser", { w: "majority" })
+db.dropUser("deprecatedUser", { w: 1, j: true })

--- a/mongo/parsertest/testdata/db-fsyncLock.js
+++ b/mongo/parsertest/testdata/db-fsyncLock.js
@@ -1,0 +1,4 @@
+// db.fsyncLock() - Flush writes and lock the database for backup
+
+// Basic usage
+db.fsyncLock()

--- a/mongo/parsertest/testdata/db-fsyncUnlock.js
+++ b/mongo/parsertest/testdata/db-fsyncUnlock.js
@@ -1,0 +1,4 @@
+// db.fsyncUnlock() - Unlock the database after fsyncLock
+
+// Basic usage
+db.fsyncUnlock()

--- a/mongo/parsertest/testdata/db-getLogComponents.js
+++ b/mongo/parsertest/testdata/db-getLogComponents.js
@@ -1,0 +1,4 @@
+// db.getLogComponents() - Returns the current log verbosity settings
+
+// Basic usage
+db.getLogComponents()

--- a/mongo/parsertest/testdata/db-getMongo.js
+++ b/mongo/parsertest/testdata/db-getMongo.js
@@ -1,0 +1,4 @@
+// db.getMongo() - Returns the Mongo connection object for the database
+
+// Basic usage
+db.getMongo()

--- a/mongo/parsertest/testdata/db-getName.js
+++ b/mongo/parsertest/testdata/db-getName.js
@@ -1,0 +1,4 @@
+// db.getName() - Returns the name of the current database
+
+// Basic usage
+db.getName()

--- a/mongo/parsertest/testdata/db-getProfilingLevel.js
+++ b/mongo/parsertest/testdata/db-getProfilingLevel.js
@@ -1,0 +1,4 @@
+// db.getProfilingLevel() - Returns the current profiling level
+
+// Basic usage
+db.getProfilingLevel()

--- a/mongo/parsertest/testdata/db-getProfilingStatus.js
+++ b/mongo/parsertest/testdata/db-getProfilingStatus.js
@@ -1,0 +1,4 @@
+// db.getProfilingStatus() - Returns the current profiling status
+
+// Basic usage
+db.getProfilingStatus()

--- a/mongo/parsertest/testdata/db-getReplicationInfo.js
+++ b/mongo/parsertest/testdata/db-getReplicationInfo.js
@@ -1,0 +1,4 @@
+// db.getReplicationInfo() - Returns replication information from oplog
+
+// Basic usage
+db.getReplicationInfo()

--- a/mongo/parsertest/testdata/db-getRole.js
+++ b/mongo/parsertest/testdata/db-getRole.js
@@ -1,0 +1,16 @@
+// db.getRole() - Returns role information
+
+// Basic usage
+db.getRole("read")
+db.getRole("readWrite")
+db.getRole("dbAdmin")
+
+// With privilege information
+db.getRole("customRole", { showPrivileges: true })
+db.getRole("appAdmin", { showPrivileges: true })
+
+// With built-in roles
+db.getRole("read", { showBuiltinRoles: true })
+
+// With authentication restrictions
+db.getRole("restrictedRole", { showAuthenticationRestrictions: true })

--- a/mongo/parsertest/testdata/db-getRoles.js
+++ b/mongo/parsertest/testdata/db-getRoles.js
@@ -1,0 +1,16 @@
+// db.getRoles() - Returns all roles in the database
+
+// Basic usage
+db.getRoles()
+
+// Include built-in roles
+db.getRoles({ showBuiltinRoles: true })
+
+// Include privileges
+db.getRoles({ showPrivileges: true })
+
+// Include both
+db.getRoles({ showBuiltinRoles: true, showPrivileges: true })
+
+// Include authentication restrictions
+db.getRoles({ showAuthenticationRestrictions: true })

--- a/mongo/parsertest/testdata/db-getSiblingDB.js
+++ b/mongo/parsertest/testdata/db-getSiblingDB.js
@@ -1,0 +1,13 @@
+// db.getSiblingDB() - Returns another database without modifying db variable
+
+// Basic usage - switch to different databases
+db.getSiblingDB("admin")
+db.getSiblingDB("test")
+db.getSiblingDB("myapp")
+
+// Common use case: access admin database
+db.getSiblingDB("admin")
+
+// Access database with special characters in name
+db.getSiblingDB("my-app-db")
+db.getSiblingDB("app_v2")

--- a/mongo/parsertest/testdata/db-getUser.js
+++ b/mongo/parsertest/testdata/db-getUser.js
@@ -1,0 +1,18 @@
+// db.getUser() - Returns user information
+
+// Basic usage
+db.getUser("appUser")
+db.getUser("admin")
+db.getUser("reportUser")
+
+// With additional options
+db.getUser("appUser", { showCredentials: true })
+db.getUser("appUser", { showPrivileges: true })
+db.getUser("appUser", { showAuthenticationRestrictions: true })
+
+// With multiple options
+db.getUser("appUser", {
+    showCredentials: true,
+    showPrivileges: true,
+    showAuthenticationRestrictions: true
+})

--- a/mongo/parsertest/testdata/db-getUsers.js
+++ b/mongo/parsertest/testdata/db-getUsers.js
@@ -1,0 +1,18 @@
+// db.getUsers() - Returns all users in the database
+
+// Basic usage
+db.getUsers()
+
+// With options
+db.getUsers({ showCredentials: true })
+db.getUsers({ showPrivileges: true })
+
+// With filter
+db.getUsers({ filter: { roles: { $elemMatch: { role: "readWrite" } } } })
+
+// With multiple options
+db.getUsers({
+    showCredentials: false,
+    showPrivileges: true,
+    filter: { "customData.department": "engineering" }
+})

--- a/mongo/parsertest/testdata/db-grantPrivilegesToRole.js
+++ b/mongo/parsertest/testdata/db-grantPrivilegesToRole.js
@@ -1,0 +1,22 @@
+// db.grantPrivilegesToRole() - Grant privileges to a role
+
+// Grant single privilege
+db.grantPrivilegesToRole("customRole", [
+    { resource: { db: "mydb", collection: "users" }, actions: ["find"] }
+])
+
+// Grant multiple privileges
+db.grantPrivilegesToRole("appRole", [
+    { resource: { db: "app", collection: "logs" }, actions: ["find", "insert"] },
+    { resource: { db: "app", collection: "metrics" }, actions: ["find"] }
+])
+
+// Grant database-wide privilege
+db.grantPrivilegesToRole("dbRole", [
+    { resource: { db: "reporting", collection: "" }, actions: ["find", "listCollections"] }
+])
+
+// With write concern
+db.grantPrivilegesToRole("criticalRole", [
+    { resource: { db: "critical", collection: "data" }, actions: ["insert", "update"] }
+], { w: "majority" })

--- a/mongo/parsertest/testdata/db-grantRolesToRole.js
+++ b/mongo/parsertest/testdata/db-grantRolesToRole.js
@@ -1,0 +1,16 @@
+// db.grantRolesToRole() - Grant roles to a role
+
+// Grant single role
+db.grantRolesToRole("appRole", ["read"])
+
+// Grant multiple roles
+db.grantRolesToRole("superRole", ["readWrite", "dbAdmin"])
+
+// Grant roles from different databases
+db.grantRolesToRole("crossDbRole", [
+    { role: "read", db: "reporting" },
+    { role: "readWrite", db: "app" }
+])
+
+// With write concern
+db.grantRolesToRole("criticalRole", ["dbAdmin"], { w: "majority" })

--- a/mongo/parsertest/testdata/db-grantRolesToUser.js
+++ b/mongo/parsertest/testdata/db-grantRolesToUser.js
@@ -1,0 +1,16 @@
+// db.grantRolesToUser() - Grant roles to a user
+
+// Grant single role
+db.grantRolesToUser("appUser", ["readWrite"])
+
+// Grant multiple roles
+db.grantRolesToUser("adminUser", ["dbAdmin", "userAdmin"])
+
+// Grant roles from different databases
+db.grantRolesToUser("crossDbUser", [
+    { role: "read", db: "logs" },
+    { role: "readWrite", db: "app" }
+])
+
+// With write concern
+db.grantRolesToUser("criticalUser", ["dbOwner"], { w: "majority" })

--- a/mongo/parsertest/testdata/db-hello.js
+++ b/mongo/parsertest/testdata/db-hello.js
@@ -1,0 +1,4 @@
+// db.hello() - Returns information about the server
+
+// Basic usage
+db.hello()

--- a/mongo/parsertest/testdata/db-hostInfo.js
+++ b/mongo/parsertest/testdata/db-hostInfo.js
@@ -1,0 +1,4 @@
+// db.hostInfo() - Returns information about the system hosting MongoDB
+
+// Basic usage
+db.hostInfo()

--- a/mongo/parsertest/testdata/db-isMaster.js
+++ b/mongo/parsertest/testdata/db-isMaster.js
@@ -1,0 +1,4 @@
+// db.isMaster() - Deprecated: Returns information about the server (use db.hello() instead)
+
+// Basic usage
+db.isMaster()

--- a/mongo/parsertest/testdata/db-killOp.js
+++ b/mongo/parsertest/testdata/db-killOp.js
@@ -1,0 +1,8 @@
+// db.killOp() - Terminate an operation by operation ID
+
+// Basic usage
+db.killOp(12345)
+db.killOp(67890)
+
+// Kill operation with comment reference
+db.killOp(99999)

--- a/mongo/parsertest/testdata/db-listCommands.js
+++ b/mongo/parsertest/testdata/db-listCommands.js
@@ -1,0 +1,4 @@
+// db.listCommands() - Lists all database commands
+
+// Basic usage
+db.listCommands()

--- a/mongo/parsertest/testdata/db-logout.js
+++ b/mongo/parsertest/testdata/db-logout.js
@@ -1,0 +1,4 @@
+// db.logout() - End the current authentication session
+
+// Basic usage
+db.logout()

--- a/mongo/parsertest/testdata/db-printCollectionStats.js
+++ b/mongo/parsertest/testdata/db-printCollectionStats.js
@@ -1,0 +1,8 @@
+// db.printCollectionStats() - Print statistics for all collections
+
+// Basic usage
+db.printCollectionStats()
+
+// With scale factor
+db.printCollectionStats(1024)
+db.printCollectionStats(1048576)

--- a/mongo/parsertest/testdata/db-printReplicationInfo.js
+++ b/mongo/parsertest/testdata/db-printReplicationInfo.js
@@ -1,0 +1,4 @@
+// db.printReplicationInfo() - Print replication status from primary's perspective
+
+// Basic usage
+db.printReplicationInfo()

--- a/mongo/parsertest/testdata/db-printSecondaryReplicationInfo.js
+++ b/mongo/parsertest/testdata/db-printSecondaryReplicationInfo.js
@@ -1,0 +1,4 @@
+// db.printSecondaryReplicationInfo() - Print replication info from secondary's perspective
+
+// Basic usage
+db.printSecondaryReplicationInfo()

--- a/mongo/parsertest/testdata/db-printShardingStatus.js
+++ b/mongo/parsertest/testdata/db-printShardingStatus.js
@@ -1,0 +1,7 @@
+// db.printShardingStatus() - Print sharding status
+
+// Basic usage
+db.printShardingStatus()
+
+// With verbose output
+db.printShardingStatus(true)

--- a/mongo/parsertest/testdata/db-printSlaveReplicationInfo.js
+++ b/mongo/parsertest/testdata/db-printSlaveReplicationInfo.js
@@ -1,0 +1,4 @@
+// db.printSlaveReplicationInfo() - Deprecated: Use db.printSecondaryReplicationInfo()
+
+// Basic usage (deprecated)
+db.printSlaveReplicationInfo()

--- a/mongo/parsertest/testdata/db-revokePrivilegesFromRole.js
+++ b/mongo/parsertest/testdata/db-revokePrivilegesFromRole.js
@@ -1,0 +1,17 @@
+// db.revokePrivilegesFromRole() - Revoke privileges from a role
+
+// Revoke single privilege
+db.revokePrivilegesFromRole("customRole", [
+    { resource: { db: "mydb", collection: "users" }, actions: ["insert"] }
+])
+
+// Revoke multiple privileges
+db.revokePrivilegesFromRole("appRole", [
+    { resource: { db: "app", collection: "logs" }, actions: ["insert", "update"] },
+    { resource: { db: "app", collection: "metrics" }, actions: ["remove"] }
+])
+
+// With write concern
+db.revokePrivilegesFromRole("sensitiveRole", [
+    { resource: { db: "sensitive", collection: "data" }, actions: ["find"] }
+], { w: "majority" })

--- a/mongo/parsertest/testdata/db-revokeRolesFromRole.js
+++ b/mongo/parsertest/testdata/db-revokeRolesFromRole.js
@@ -1,0 +1,16 @@
+// db.revokeRolesFromRole() - Revoke roles from a role
+
+// Revoke single role
+db.revokeRolesFromRole("appRole", ["read"])
+
+// Revoke multiple roles
+db.revokeRolesFromRole("superRole", ["dbAdmin", "userAdmin"])
+
+// Revoke roles from different databases
+db.revokeRolesFromRole("crossDbRole", [
+    { role: "read", db: "reporting" },
+    { role: "readWrite", db: "logs" }
+])
+
+// With write concern
+db.revokeRolesFromRole("criticalRole", ["dbOwner"], { w: "majority" })

--- a/mongo/parsertest/testdata/db-revokeRolesFromUser.js
+++ b/mongo/parsertest/testdata/db-revokeRolesFromUser.js
@@ -1,0 +1,16 @@
+// db.revokeRolesFromUser() - Revoke roles from a user
+
+// Revoke single role
+db.revokeRolesFromUser("appUser", ["readWrite"])
+
+// Revoke multiple roles
+db.revokeRolesFromUser("adminUser", ["dbAdmin", "userAdmin"])
+
+// Revoke roles from different databases
+db.revokeRolesFromUser("crossDbUser", [
+    { role: "read", db: "logs" },
+    { role: "readWrite", db: "archive" }
+])
+
+// With write concern
+db.revokeRolesFromUser("sensitiveUser", ["dbOwner"], { w: "majority" })

--- a/mongo/parsertest/testdata/db-rotateCertificates.js
+++ b/mongo/parsertest/testdata/db-rotateCertificates.js
@@ -1,0 +1,7 @@
+// db.rotateCertificates() - Rotate TLS certificates
+
+// Basic usage
+db.rotateCertificates()
+
+// With message
+db.rotateCertificates("Certificate rotation triggered by admin")

--- a/mongo/parsertest/testdata/db-runCommand.js
+++ b/mongo/parsertest/testdata/db-runCommand.js
@@ -1,0 +1,52 @@
+// db.runCommand() - Run a database command
+
+// Basic commands
+db.runCommand({ ping: 1 })
+db.runCommand({ serverStatus: 1 })
+db.runCommand({ buildInfo: 1 })
+
+// Collection operations
+db.runCommand({ create: "testCollection" })
+db.runCommand({ drop: "testCollection" })
+db.runCommand({ listCollections: 1 })
+
+// Find command
+db.runCommand({
+    find: "users",
+    filter: { age: { $gt: 21 } },
+    limit: 10
+})
+
+// Aggregate command
+db.runCommand({
+    aggregate: "orders",
+    pipeline: [
+        { $match: { status: "active" } },
+        { $group: { _id: "$customerId", total: { $sum: "$amount" } } }
+    ],
+    cursor: {}
+})
+
+// Index commands
+db.runCommand({ createIndexes: "users", indexes: [{ key: { email: 1 }, name: "email_1" }] })
+db.runCommand({ dropIndexes: "users", index: "email_1" })
+
+// Admin commands
+db.runCommand({ collStats: "users" })
+db.runCommand({ dbStats: 1, scale: 1024 })
+db.runCommand({ validate: "users" })
+
+// User management
+db.runCommand({
+    createUser: "appUser",
+    pwd: "password123",
+    roles: [{ role: "readWrite", db: "mydb" }]
+})
+
+// Profiling
+db.runCommand({ profile: 1, slowms: 100 })
+db.runCommand({ profile: 0 })
+
+// Replication commands
+db.runCommand({ replSetGetStatus: 1 })
+db.runCommand({ isMaster: 1 })

--- a/mongo/parsertest/testdata/db-serverBuildInfo.js
+++ b/mongo/parsertest/testdata/db-serverBuildInfo.js
@@ -1,0 +1,4 @@
+// db.serverBuildInfo() - Returns information about MongoDB server build
+
+// Basic usage
+db.serverBuildInfo()

--- a/mongo/parsertest/testdata/db-serverStatus.js
+++ b/mongo/parsertest/testdata/db-serverStatus.js
@@ -1,0 +1,18 @@
+// db.serverStatus() - Returns an overview of the database server state
+
+// Basic server status
+db.serverStatus()
+
+// Server status with specific sections
+db.serverStatus({ repl: 0, metrics: 0 })
+db.serverStatus({ locks: 1 })
+db.serverStatus({ opcounters: 1, connections: 1 })
+
+// Exclude specific sections
+db.serverStatus({ asserts: 0, connections: 0 })
+
+// Server status with latchAnalysis
+db.serverStatus({ latchAnalysis: 1 })
+
+// Server status with mirroredReads
+db.serverStatus({ mirroredReads: 1 })

--- a/mongo/parsertest/testdata/db-setLogLevel.js
+++ b/mongo/parsertest/testdata/db-setLogLevel.js
@@ -1,0 +1,13 @@
+// db.setLogLevel() - Set the log verbosity level
+
+// Set global log level
+db.setLogLevel(1)
+db.setLogLevel(2)
+db.setLogLevel(0)
+
+// Set component-specific log level
+db.setLogLevel(1, "query")
+db.setLogLevel(2, "replication")
+db.setLogLevel(1, "storage")
+db.setLogLevel(3, "network")
+db.setLogLevel(2, "accessControl")

--- a/mongo/parsertest/testdata/db-setProfilingLevel.js
+++ b/mongo/parsertest/testdata/db-setProfilingLevel.js
@@ -1,0 +1,21 @@
+// db.setProfilingLevel() - Set the database profiler level
+
+// Turn off profiling
+db.setProfilingLevel(0)
+
+// Profile slow operations only (default threshold 100ms)
+db.setProfilingLevel(1)
+
+// Profile all operations
+db.setProfilingLevel(2)
+
+// Set custom slow operation threshold
+db.setProfilingLevel(1, 50)
+db.setProfilingLevel(1, 200)
+
+// With options object
+db.setProfilingLevel(1, { slowms: 100 })
+db.setProfilingLevel(1, { slowms: 50, sampleRate: 0.5 })
+
+// Profile with sample rate
+db.setProfilingLevel(2, { sampleRate: 0.1 })

--- a/mongo/parsertest/testdata/db-setSecondaryOk.js
+++ b/mongo/parsertest/testdata/db-setSecondaryOk.js
@@ -1,0 +1,6 @@
+// db.setSecondaryOk() - Deprecated: Allow reading from secondary
+
+// Basic usage (deprecated - use read preference instead)
+db.setSecondaryOk()
+db.setSecondaryOk(true)
+db.setSecondaryOk(false)

--- a/mongo/parsertest/testdata/db-setWriteConcern.js
+++ b/mongo/parsertest/testdata/db-setWriteConcern.js
@@ -1,0 +1,16 @@
+// db.setWriteConcern() - Set the default write concern
+
+// Set write concern with w value
+db.setWriteConcern({ w: 1 })
+db.setWriteConcern({ w: "majority" })
+db.setWriteConcern({ w: 2 })
+
+// Set write concern with journal
+db.setWriteConcern({ w: 1, j: true })
+db.setWriteConcern({ w: "majority", j: true })
+
+// Set write concern with timeout
+db.setWriteConcern({ w: "majority", wtimeout: 5000 })
+
+// Combined options
+db.setWriteConcern({ w: "majority", j: true, wtimeout: 10000 })

--- a/mongo/parsertest/testdata/db-shutdownServer.js
+++ b/mongo/parsertest/testdata/db-shutdownServer.js
@@ -1,0 +1,9 @@
+// db.shutdownServer() - Shut down the MongoDB server
+
+// Basic usage
+db.shutdownServer()
+
+// With options
+db.shutdownServer({ force: true })
+db.shutdownServer({ timeoutSecs: 60 })
+db.shutdownServer({ force: true, timeoutSecs: 30 })

--- a/mongo/parsertest/testdata/db-stats.js
+++ b/mongo/parsertest/testdata/db-stats.js
@@ -1,0 +1,17 @@
+// db.stats() - Get database statistics
+
+// Basic stats
+db.stats()
+
+// Stats with scale factor (convert bytes to KB)
+db.stats(1024)
+
+// Stats with options document
+db.stats({ scale: 1024 })
+db.stats({ scale: 1048576 })
+
+// Stats with freeStorage option
+db.stats({ freeStorage: 1 })
+
+// Stats with multiple options
+db.stats({ scale: 1024, freeStorage: 1 })

--- a/mongo/parsertest/testdata/db-updateRole.js
+++ b/mongo/parsertest/testdata/db-updateRole.js
@@ -1,0 +1,38 @@
+// db.updateRole() - Update a role
+
+// Update privileges
+db.updateRole("customRole", {
+    privileges: [
+        { resource: { db: "mydb", collection: "users" }, actions: ["find", "update"] }
+    ]
+})
+
+// Update inherited roles
+db.updateRole("appRole", {
+    roles: [
+        { role: "readWrite", db: "app" },
+        { role: "read", db: "logs" }
+    ]
+})
+
+// Update both privileges and roles
+db.updateRole("fullRole", {
+    privileges: [
+        { resource: { db: "admin", collection: "system.users" }, actions: ["find"] }
+    ],
+    roles: ["readWriteAnyDatabase"]
+})
+
+// Update authentication restrictions
+db.updateRole("restrictedRole", {
+    authenticationRestrictions: [
+        { clientSource: ["192.168.1.0/24"] }
+    ]
+})
+
+// With write concern
+db.updateRole("criticalRole", {
+    privileges: [
+        { resource: { db: "critical", collection: "" }, actions: ["find"] }
+    ]
+}, { w: "majority" })

--- a/mongo/parsertest/testdata/db-updateUser.js
+++ b/mongo/parsertest/testdata/db-updateUser.js
@@ -1,0 +1,43 @@
+// db.updateUser() - Update a user
+
+// Update password
+db.updateUser("appUser", {
+    pwd: "newPassword123"
+})
+
+// Update roles
+db.updateUser("appUser", {
+    roles: [
+        { role: "readWrite", db: "app" },
+        { role: "read", db: "reporting" }
+    ]
+})
+
+// Update custom data
+db.updateUser("appUser", {
+    customData: { department: "engineering", team: "backend", level: "senior" }
+})
+
+// Update authentication mechanisms
+db.updateUser("secureUser", {
+    mechanisms: ["SCRAM-SHA-256"]
+})
+
+// Update authentication restrictions
+db.updateUser("restrictedUser", {
+    authenticationRestrictions: [
+        { clientSource: ["10.0.0.0/8"], serverAddress: ["10.0.0.1"] }
+    ]
+})
+
+// Update multiple fields
+db.updateUser("fullUser", {
+    pwd: "newSecurePassword",
+    roles: ["readWrite"],
+    customData: { updated: true }
+})
+
+// With write concern
+db.updateUser("criticalUser", {
+    pwd: "verySecurePassword"
+}, { w: "majority" })

--- a/mongo/parsertest/testdata/db-version.js
+++ b/mongo/parsertest/testdata/db-version.js
@@ -1,0 +1,4 @@
+// db.version() - Returns the MongoDB server version
+
+// Basic usage
+db.version()

--- a/mongo/parsertest/testdata/db-watch.js
+++ b/mongo/parsertest/testdata/db-watch.js
@@ -1,0 +1,42 @@
+// db.watch() - Open a change stream on the database
+
+// Basic usage
+db.watch()
+
+// Watch with pipeline
+db.watch([
+    { $match: { operationType: "insert" } }
+])
+
+// Watch specific collections
+db.watch([
+    { $match: { "ns.coll": { $in: ["users", "orders"] } } }
+])
+
+// Watch for specific operation types
+db.watch([
+    { $match: { operationType: { $in: ["insert", "update", "delete"] } } }
+])
+
+// With options
+db.watch([], { fullDocument: "updateLookup" })
+db.watch([], { maxAwaitTimeMS: 5000 })
+
+// Watch with resume token
+db.watch([], {
+    resumeAfter: { _data: "826..." }
+})
+
+// Watch with start time
+db.watch([], {
+    startAtOperationTime: Timestamp(1234567890, 1)
+})
+
+// Combined pipeline and options
+db.watch([
+    { $match: { operationType: "update" } },
+    { $project: { fullDocument: 1, operationType: 1 } }
+], {
+    fullDocument: "updateLookup",
+    maxAwaitTimeMS: 10000
+})

--- a/mongo/parsertest/testdata/document_syntax.js
+++ b/mongo/parsertest/testdata/document_syntax.js
@@ -1,0 +1,47 @@
+// Unquoted keys
+db.users.find({ name: "alice", age: 25 })
+db.users.find({ firstName: "Alice", lastName: "Smith" })
+
+// Quoted keys
+db.users.find({ "name": "alice", "age": 25 })
+db.users.find({ 'name': 'alice', 'age': 25 })
+
+// Mixed quoted and unquoted keys
+db.users.find({ name: "alice", "special-field": "value" })
+
+// Keys with $ prefix (operators)
+db.users.find({ age: { $gt: 25, $lt: 65 } })
+db.users.find({ $and: [{ status: "active" }, { age: { $gte: 18 } }] })
+
+// Nested documents
+db.users.find({
+    profile: {
+        name: "test",
+        settings: {
+            theme: "dark",
+            notifications: true
+        }
+    }
+})
+
+// Arrays
+db.users.find({ tags: ["mongodb", "database", "nosql"] })
+db.users.find({ scores: [85, 90, 78, 92] })
+
+// Nested arrays
+db.users.find({
+    matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9]
+    ]
+})
+
+// Trailing commas (allowed in mongosh)
+db.users.find({ name: "alice", age: 25, })
+db.users.find({ tags: ["a", "b", "c",] })
+db.users.find({
+    name: "alice",
+    age: 25,
+    active: true,
+})

--- a/mongo/parsertest/testdata/encryption-addKeyAlternateName.js
+++ b/mongo/parsertest/testdata/encryption-addKeyAlternateName.js
@@ -1,0 +1,10 @@
+// KeyVault.addKeyAlternateName() - Add an alternate name to a data encryption key
+
+// Add alternate name to key
+db.getMongo().getKeyVault().addKeyAlternateName(UUID("12345678-1234-1234-1234-123456789012"), "myKeyAlias")
+
+// Add another alternate name
+db.getMongo().getKeyVault().addKeyAlternateName(UUID("abcd1234-5678-90ab-cdef-123456789012"), "production-key")
+
+// Add alternate name with special characters
+db.getMongo().getKeyVault().addKeyAlternateName(UUID("00000000-0000-0000-0000-000000000001"), "key_v2_backup")

--- a/mongo/parsertest/testdata/encryption-createEncryptedCollection.js
+++ b/mongo/parsertest/testdata/encryption-createEncryptedCollection.js
@@ -1,0 +1,66 @@
+// ClientEncryption.createEncryptedCollection() - Create a collection with encrypted fields
+
+// Create encrypted collection with basic configuration
+db.getMongo().getClientEncryption().createEncryptedCollection("myDatabase", "myCollection", {
+    provider: "local",
+    createCollectionOptions: {
+        encryptedFields: {
+            fields: [
+                {
+                    path: "ssn",
+                    bsonType: "string",
+                    queries: { queryType: "equality" }
+                }
+            ]
+        }
+    }
+})
+
+// Create with AWS KMS
+db.getMongo().getClientEncryption().createEncryptedCollection("hr", "employees", {
+    provider: "aws",
+    createCollectionOptions: {
+        encryptedFields: {
+            fields: [
+                {
+                    path: "ssn",
+                    bsonType: "string",
+                    queries: { queryType: "equality" }
+                },
+                {
+                    path: "salary",
+                    bsonType: "int"
+                }
+            ]
+        }
+    },
+    masterKey: {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    }
+})
+
+// Create with multiple encrypted fields
+db.getMongo().getClientEncryption().createEncryptedCollection("medical", "patients", {
+    provider: "local",
+    createCollectionOptions: {
+        encryptedFields: {
+            fields: [
+                {
+                    path: "medicalRecordNumber",
+                    bsonType: "string",
+                    queries: { queryType: "equality" }
+                },
+                {
+                    path: "diagnosis",
+                    bsonType: "string"
+                },
+                {
+                    path: "insuranceNumber",
+                    bsonType: "string",
+                    queries: { queryType: "equality" }
+                }
+            ]
+        }
+    }
+})

--- a/mongo/parsertest/testdata/encryption-createKey.js
+++ b/mongo/parsertest/testdata/encryption-createKey.js
@@ -1,0 +1,33 @@
+// KeyVault.createKey() - Create a new data encryption key
+
+// Basic key creation with local KMS
+db.getMongo().getKeyVault().createKey("local")
+
+// Key with AWS KMS
+db.getMongo().getKeyVault().createKey("aws", {
+    region: "us-east-1",
+    key: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+})
+
+// Key with alternate names
+db.getMongo().getKeyVault().createKey("local", "", ["myKey", "keyAlias"])
+
+// Key with GCP KMS
+db.getMongo().getKeyVault().createKey("gcp", {
+    projectId: "my-project",
+    location: "us-east1",
+    keyRing: "my-keyring",
+    keyName: "my-key"
+})
+
+// Key with Azure KMS
+db.getMongo().getKeyVault().createKey("azure", {
+    keyVaultEndpoint: "https://my-vault.vault.azure.net",
+    keyName: "my-key"
+})
+
+// Key with KMIP provider
+db.getMongo().getKeyVault().createKey("kmip")
+
+// Key with alternate key names array
+db.getMongo().getKeyVault().createKey("local", null, ["key1", "key2", "key3"])

--- a/mongo/parsertest/testdata/encryption-decrypt.js
+++ b/mongo/parsertest/testdata/encryption-decrypt.js
@@ -1,0 +1,10 @@
+// ClientEncryption.decrypt() - Decrypt an encrypted value
+
+// Decrypt with string representation
+db.getMongo().getClientEncryption().decrypt("encryptedBinaryData")
+
+// Decrypt placeholder encrypted data
+db.getMongo().getClientEncryption().decrypt("base64EncodedEncryptedValue")
+
+// Decrypt another encrypted value
+db.getMongo().getClientEncryption().decrypt("anotherEncryptedValue")

--- a/mongo/parsertest/testdata/encryption-deleteKey.js
+++ b/mongo/parsertest/testdata/encryption-deleteKey.js
@@ -1,0 +1,10 @@
+// KeyVault.deleteKey() - Delete a data encryption key from the key vault
+
+// Delete key by UUID
+db.getMongo().getKeyVault().deleteKey(UUID("12345678-1234-1234-1234-123456789012"))
+
+// Delete key with specific UUID
+db.getMongo().getKeyVault().deleteKey(UUID("abcd1234-5678-90ab-cdef-123456789012"))
+
+// Delete key
+db.getMongo().getKeyVault().deleteKey(UUID("00000000-0000-0000-0000-000000000001"))

--- a/mongo/parsertest/testdata/encryption-encrypt.js
+++ b/mongo/parsertest/testdata/encryption-encrypt.js
@@ -1,0 +1,36 @@
+// ClientEncryption.encrypt() - Encrypt a value using client-side field level encryption
+
+// Encrypt a string value with deterministic encryption
+db.getMongo().getClientEncryption().encrypt(
+    UUID("12345678-1234-1234-1234-123456789012"),
+    "sensitive-data",
+    "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+)
+
+// Encrypt with random encryption (default)
+db.getMongo().getClientEncryption().encrypt(
+    UUID("abcd1234-5678-90ab-cdef-123456789012"),
+    "secret-value",
+    "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+)
+
+// Encrypt a number
+db.getMongo().getClientEncryption().encrypt(
+    UUID("12345678-1234-1234-1234-123456789012"),
+    123456789,
+    "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+)
+
+// Encrypt with options document
+db.getMongo().getClientEncryption().encrypt(
+    UUID("12345678-1234-1234-1234-123456789012"),
+    { ssn: "123-45-6789" },
+    "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+)
+
+// Encrypt using key alternate name
+db.getMongo().getClientEncryption().encrypt(
+    "myDataKey",
+    "confidential",
+    "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+)

--- a/mongo/parsertest/testdata/encryption-encryptExpression.js
+++ b/mongo/parsertest/testdata/encryption-encryptExpression.js
@@ -1,0 +1,30 @@
+// ClientEncryption.encryptExpression() - Encrypt a match expression for queryable encryption
+
+// Encrypt a simple equality expression
+db.getMongo().getClientEncryption().encryptExpression(
+    UUID("12345678-1234-1234-1234-123456789012"),
+    { $and: [{ ssn: { $eq: "123-45-6789" } }] }
+)
+
+// Encrypt expression with range query
+db.getMongo().getClientEncryption().encryptExpression(
+    UUID("abcd1234-5678-90ab-cdef-123456789012"),
+    { $and: [{ salary: { $gte: 50000, $lte: 100000 } }] }
+)
+
+// Encrypt expression for encrypted field search
+db.getMongo().getClientEncryption().encryptExpression(
+    UUID("12345678-1234-1234-1234-123456789012"),
+    { $and: [{ medicalRecordNumber: "MRN-12345" }] }
+)
+
+// Encrypt complex expression
+db.getMongo().getClientEncryption().encryptExpression(
+    UUID("12345678-1234-1234-1234-123456789012"),
+    {
+        $and: [
+            { ssn: { $eq: "123-45-6789" } },
+            { status: "active" }
+        ]
+    }
+)

--- a/mongo/parsertest/testdata/encryption-getClientEncryption.js
+++ b/mongo/parsertest/testdata/encryption-getClientEncryption.js
@@ -1,0 +1,10 @@
+// ClientEncryption.getClientEncryption() - Get the ClientEncryption object for field-level encryption
+
+// Get the ClientEncryption object from the current connection
+db.getMongo().getClientEncryption()
+
+// Chain with encryption methods
+db.getMongo().getClientEncryption().encrypt(UUID("12345678-1234-1234-1234-123456789012"), "sensitiveData", "AEAD_AES_256_CBC_HMAC_SHA_512-Random")
+
+// Get ClientEncryption for various operations
+db.getMongo().getClientEncryption().decrypt("encryptedValue")

--- a/mongo/parsertest/testdata/encryption-getKey.js
+++ b/mongo/parsertest/testdata/encryption-getKey.js
@@ -1,0 +1,10 @@
+// KeyVault.getKey() - Get a specific data encryption key by its UUID
+
+// Get key by UUID
+db.getMongo().getKeyVault().getKey(UUID("12345678-1234-1234-1234-123456789012"))
+
+// Get key with string UUID
+db.getMongo().getKeyVault().getKey(UUID("abcd1234-5678-90ab-cdef-123456789012"))
+
+// Get key and convert to document
+db.getMongo().getKeyVault().getKey(UUID("00000000-0000-0000-0000-000000000001"))

--- a/mongo/parsertest/testdata/encryption-getKeyByAltName.js
+++ b/mongo/parsertest/testdata/encryption-getKeyByAltName.js
@@ -1,0 +1,13 @@
+// KeyVault.getKeyByAltName() - Get a data encryption key by its alternate name
+
+// Get key by alternate name
+db.getMongo().getKeyVault().getKeyByAltName("myKeyAlias")
+
+// Get key by production name
+db.getMongo().getKeyVault().getKeyByAltName("production-key")
+
+// Get key by backup name
+db.getMongo().getKeyVault().getKeyByAltName("backup-key")
+
+// Get key with underscore name
+db.getMongo().getKeyVault().getKeyByAltName("data_encryption_key_v1")

--- a/mongo/parsertest/testdata/encryption-getKeyVault.js
+++ b/mongo/parsertest/testdata/encryption-getKeyVault.js
@@ -1,0 +1,10 @@
+// KeyVault.getKeyVault() - Get the KeyVault object for encryption key management
+
+// Get the KeyVault object from the current connection
+db.getMongo().getKeyVault()
+
+// Chain with other KeyVault methods
+db.getMongo().getKeyVault().getKeys()
+
+// Get KeyVault and list all keys
+db.getMongo().getKeyVault().getKeys().toArray()

--- a/mongo/parsertest/testdata/encryption-getKeys.js
+++ b/mongo/parsertest/testdata/encryption-getKeys.js
@@ -1,0 +1,10 @@
+// KeyVault.getKeys() - Get all data encryption keys in the key vault
+
+// Get all keys
+db.getMongo().getKeyVault().getKeys()
+
+// Get keys and convert to array
+db.getMongo().getKeyVault().getKeys().toArray()
+
+// Count all keys
+db.getMongo().getKeyVault().getKeys().count()

--- a/mongo/parsertest/testdata/encryption-removeKeyAlternateName.js
+++ b/mongo/parsertest/testdata/encryption-removeKeyAlternateName.js
@@ -1,0 +1,10 @@
+// KeyVault.removeKeyAlternateName() - Remove an alternate name from a data encryption key
+
+// Remove alternate name from key
+db.getMongo().getKeyVault().removeKeyAlternateName(UUID("12345678-1234-1234-1234-123456789012"), "myKeyAlias")
+
+// Remove alternate name
+db.getMongo().getKeyVault().removeKeyAlternateName(UUID("abcd1234-5678-90ab-cdef-123456789012"), "old-key-name")
+
+// Remove alternate name
+db.getMongo().getKeyVault().removeKeyAlternateName(UUID("00000000-0000-0000-0000-000000000001"), "deprecated-alias")

--- a/mongo/parsertest/testdata/encryption-rewrapManyDataKey.js
+++ b/mongo/parsertest/testdata/encryption-rewrapManyDataKey.js
@@ -1,0 +1,36 @@
+// KeyVault.rewrapManyDataKey() - Rewrap (re-encrypt) multiple data encryption keys
+
+// Rewrap all keys with no filter
+db.getMongo().getKeyVault().rewrapManyDataKey({})
+
+// Rewrap keys matching a filter
+db.getMongo().getKeyVault().rewrapManyDataKey({ masterKey: { provider: "aws" } })
+
+// Rewrap with new master key
+db.getMongo().getKeyVault().rewrapManyDataKey({}, {
+    provider: "aws",
+    masterKey: {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:123456789012:key/new-key-id"
+    }
+})
+
+// Rewrap keys from one provider to another
+db.getMongo().getKeyVault().rewrapManyDataKey({ "masterKey.provider": "local" }, {
+    provider: "gcp",
+    masterKey: {
+        projectId: "my-project",
+        location: "us-east1",
+        keyRing: "my-keyring",
+        keyName: "my-key"
+    }
+})
+
+// Rewrap with Azure KMS
+db.getMongo().getKeyVault().rewrapManyDataKey({ keyAltNames: "production" }, {
+    provider: "azure",
+    masterKey: {
+        keyVaultEndpoint: "https://my-vault.vault.azure.net",
+        keyName: "new-master-key"
+    }
+})

--- a/mongo/parsertest/testdata/helper_functions.js
+++ b/mongo/parsertest/testdata/helper_functions.js
@@ -1,0 +1,46 @@
+// ObjectId
+db.users.find({ _id: ObjectId("507f1f77bcf86cd799439011") })
+db.users.find({ _id: ObjectId() })
+
+// ISODate
+db.events.find({ createdAt: ISODate("2024-01-15T00:00:00.000Z") })
+db.events.find({ createdAt: { $gt: ISODate() } })
+
+// Date
+db.events.find({ timestamp: Date() })
+db.events.find({ timestamp: Date("2024-01-15") })
+db.events.find({ timestamp: Date(1705276800000) })
+
+// UUID
+db.sessions.find({ sessionId: UUID("550e8400-e29b-41d4-a716-446655440000") })
+
+// Long / NumberLong
+db.stats.find({ count: Long(9007199254740993) })
+db.stats.find({ count: Long("9007199254740993") })
+db.stats.find({ count: NumberLong(123456789012345) })
+db.stats.find({ count: NumberLong("123456789012345") })
+
+// Int32 / NumberInt
+db.items.find({ quantity: Int32(100) })
+db.items.find({ quantity: NumberInt(100) })
+
+// Double
+db.measurements.find({ value: Double(3.14159) })
+db.measurements.find({ value: Double(-273.15) })
+
+// Decimal128 / NumberDecimal
+db.financial.find({ amount: Decimal128("1234567890.123456789") })
+db.financial.find({ amount: NumberDecimal("99.99") })
+
+// Timestamp
+db.oplog.find({ ts: Timestamp(1627811580, 1) })
+db.oplog.find({ ts: Timestamp({ t: 1627811580, i: 1 }) })
+
+// Mixed helper functions in complex queries
+db.users.find({
+    _id: ObjectId("507f1f77bcf86cd799439011"),
+    createdAt: { $gt: ISODate("2024-01-01T00:00:00Z") },
+    lastLogin: { $lt: Date() },
+    sessionId: UUID("550e8400-e29b-41d4-a716-446655440000"),
+    loginCount: NumberLong(1000)
+})

--- a/mongo/parsertest/testdata/literals.js
+++ b/mongo/parsertest/testdata/literals.js
@@ -1,0 +1,37 @@
+// String literals - double quoted
+db.users.find({ name: "alice" })
+db.users.find({ message: "Hello, World!" })
+db.users.find({ path: "C:\\Users\\test" })
+db.users.find({ unicode: "\u0048\u0065\u006C\u006C\u006F" })
+
+// String literals - single quoted
+db.users.find({ name: 'alice' })
+db.users.find({ message: 'Hello, World!' })
+db.users.find({ escaped: 'It\'s a test' })
+
+// Numbers - integers
+db.users.find({ age: 25 })
+db.users.find({ count: 0 })
+db.users.find({ score: -10 })
+db.users.find({ bigNum: 1000000 })
+
+// Numbers - floats
+db.users.find({ price: 19.99 })
+db.users.find({ temperature: -40.5 })
+db.users.find({ ratio: 0.5 })
+db.users.find({ tiny: .001 })
+
+// Numbers - scientific notation
+db.users.find({ distance: 1.5e10 })
+db.users.find({ small: 1e-6 })
+db.users.find({ precise: 6.022e23 })
+db.users.find({ negative: -1.23e-4 })
+
+// Booleans
+db.users.find({ active: true })
+db.users.find({ deleted: false })
+db.users.find({ $and: [{ active: true }, { verified: true }] })
+
+// Null
+db.users.find({ deletedAt: null })
+db.users.find({ middleName: null })

--- a/mongo/parsertest/testdata/native-cat.js
+++ b/mongo/parsertest/testdata/native-cat.js
@@ -1,0 +1,11 @@
+// cat() - Display the contents of a file
+
+// Display file contents
+cat("config.json")
+cat("/path/to/file.txt")
+cat("scripts/setup.js")
+
+// Display multiple files
+cat("file1.txt")
+cat("file2.txt")
+cat("logs/app.log")

--- a/mongo/parsertest/testdata/native-cd.js
+++ b/mongo/parsertest/testdata/native-cd.js
@@ -1,0 +1,10 @@
+// cd() - Change the current working directory
+
+// Change to a directory
+cd("/tmp")
+cd("/home/user")
+cd("scripts")
+
+// Change to home directory
+cd("~")
+cd("/var/log")

--- a/mongo/parsertest/testdata/native-getHostName.js
+++ b/mongo/parsertest/testdata/native-getHostName.js
@@ -1,0 +1,4 @@
+// getHostName() - Returns the hostname of the system
+
+// Get system hostname
+getHostName()

--- a/mongo/parsertest/testdata/native-getMemInfo.js
+++ b/mongo/parsertest/testdata/native-getMemInfo.js
@@ -1,0 +1,4 @@
+// getMemInfo() - Returns memory usage information
+
+// Get memory info
+getMemInfo()

--- a/mongo/parsertest/testdata/native-hostname.js
+++ b/mongo/parsertest/testdata/native-hostname.js
@@ -1,0 +1,4 @@
+// hostname() - Returns the hostname of the system
+
+// Get system hostname
+hostname()

--- a/mongo/parsertest/testdata/native-isInteractive.js
+++ b/mongo/parsertest/testdata/native-isInteractive.js
@@ -1,0 +1,4 @@
+// isInteractive() - Returns whether the shell is running in interactive mode
+
+// Check if interactive
+isInteractive()

--- a/mongo/parsertest/testdata/native-listFiles.js
+++ b/mongo/parsertest/testdata/native-listFiles.js
@@ -1,0 +1,9 @@
+// listFiles() - Returns an array of files in a directory
+
+// List files in current directory
+listFiles()
+
+// List files in specific directory
+listFiles("/tmp")
+listFiles("/home/user/scripts")
+listFiles(".")

--- a/mongo/parsertest/testdata/native-load.js
+++ b/mongo/parsertest/testdata/native-load.js
@@ -1,0 +1,10 @@
+// load() - Load and execute a JavaScript file
+
+// Load a script
+load("scripts/init.js")
+load("/path/to/script.js")
+
+// Load multiple scripts
+load("script1.js")
+load("script2.js")
+load("lib/helpers.js")

--- a/mongo/parsertest/testdata/native-ls.js
+++ b/mongo/parsertest/testdata/native-ls.js
@@ -1,0 +1,9 @@
+// ls() - List contents of a directory
+
+// List current directory
+ls()
+
+// List specific directory
+ls("/tmp")
+ls("/home/user")
+ls("scripts")

--- a/mongo/parsertest/testdata/native-md5sumFile.js
+++ b/mongo/parsertest/testdata/native-md5sumFile.js
@@ -1,0 +1,6 @@
+// md5sumFile() - Returns the MD5 checksum of a file
+
+// Get MD5 checksum
+md5sumFile("data.json")
+md5sumFile("/path/to/file.bin")
+md5sumFile("backup/dump.bson")

--- a/mongo/parsertest/testdata/native-mkdir.js
+++ b/mongo/parsertest/testdata/native-mkdir.js
@@ -1,0 +1,6 @@
+// mkdir() - Create a directory
+
+// Create a directory
+mkdir("backup")
+mkdir("/tmp/mongodb")
+mkdir("logs/daily")

--- a/mongo/parsertest/testdata/native-pwd.js
+++ b/mongo/parsertest/testdata/native-pwd.js
@@ -1,0 +1,4 @@
+// pwd() - Print the current working directory
+
+// Get current directory
+pwd()

--- a/mongo/parsertest/testdata/native-quit.js
+++ b/mongo/parsertest/testdata/native-quit.js
@@ -1,0 +1,8 @@
+// quit() - Exit the shell
+
+// Basic quit
+quit()
+
+// Quit with exit code
+quit(0)
+quit(1)

--- a/mongo/parsertest/testdata/native-removeFile.js
+++ b/mongo/parsertest/testdata/native-removeFile.js
@@ -1,0 +1,6 @@
+// removeFile() - Delete a file
+
+// Remove a file
+removeFile("temp.json")
+removeFile("/tmp/output.txt")
+removeFile("logs/old.log")

--- a/mongo/parsertest/testdata/native-sleep.js
+++ b/mongo/parsertest/testdata/native-sleep.js
@@ -1,0 +1,7 @@
+// sleep() - Pause execution for a specified number of milliseconds
+
+// Sleep for various durations
+sleep(1000)
+sleep(5000)
+sleep(100)
+sleep(60000)

--- a/mongo/parsertest/testdata/native-version.js
+++ b/mongo/parsertest/testdata/native-version.js
@@ -1,0 +1,4 @@
+// version() - Returns the version of the MongoDB shell
+
+// Get version
+version()

--- a/mongo/parsertest/testdata/objectConstructor-BSONRegExp.js
+++ b/mongo/parsertest/testdata/objectConstructor-BSONRegExp.js
@@ -1,0 +1,47 @@
+// BSONRegExp() - Create BSON regular expression
+
+// Basic usage with pattern only
+BSONRegExp("pattern")
+
+// With flags
+BSONRegExp("pattern", "i")
+BSONRegExp("pattern", "im")
+BSONRegExp("pattern", "imxs")
+
+// In document
+db.rules.insertOne({
+    name: "email_validation",
+    pattern: BSONRegExp("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", "i")
+})
+
+// In query - match documents with specific regex pattern
+db.rules.find({
+    pattern: BSONRegExp("pattern", "i")
+})
+
+// Complex patterns
+db.validations.insertMany([
+    { name: "phone", regex: BSONRegExp("^\\+?[1-9]\\d{1,14}$") },
+    { name: "url", regex: BSONRegExp("^https?://", "i") },
+    { name: "ipv4", regex: BSONRegExp("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$") },
+    { name: "hex_color", regex: BSONRegExp("^#[0-9A-Fa-f]{6}$", "i") }
+])
+
+// Using in aggregation pipeline
+db.logs.aggregate([
+    {
+        $match: {
+            message: { $regex: BSONRegExp("error", "i") }
+        }
+    }
+])
+
+// Various flag combinations
+db.patterns.insertMany([
+    { flags: "none", pattern: BSONRegExp("test") },
+    { flags: "case_insensitive", pattern: BSONRegExp("test", "i") },
+    { flags: "multiline", pattern: BSONRegExp("^line", "m") },
+    { flags: "dotall", pattern: BSONRegExp(".*", "s") },
+    { flags: "extended", pattern: BSONRegExp("test", "x") },
+    { flags: "combined", pattern: BSONRegExp("test", "imsx") }
+])

--- a/mongo/parsertest/testdata/objectConstructor-BinData.js
+++ b/mongo/parsertest/testdata/objectConstructor-BinData.js
@@ -1,0 +1,36 @@
+// BinData() - Create binary data with subtype
+
+// Basic usage - subtype 0 (generic binary)
+BinData(0, "SGVsbG8gV29ybGQh")
+
+// UUID subtype (4)
+BinData(4, "JDQ3MjA3M2Q0LTJhOTMtNGUxNy1hNzYyLTlkMTI0NWE5ZDRjMQ==")
+
+// MD5 digest subtype (5)
+BinData(5, "d41d8cd98f00b204e9800998ecf8427e")
+
+// User-defined binary (128)
+BinData(128, "Y3VzdG9tIGJpbmFyeQ==")
+
+// In document
+db.files.insertOne({
+    name: "attachment.pdf",
+    data: BinData(0, "JVBERi0xLjQKJcOkw7zDtsOf...")
+})
+
+// In query
+db.files.find({
+    data: BinData(0, "SGVsbG8gV29ybGQh")
+})
+
+// Various subtypes
+db.binaries.insertMany([
+    { type: "generic", data: BinData(0, "Z2VuZXJpYw==") },
+    { type: "function", data: BinData(1, "ZnVuY3Rpb24=") },
+    { type: "old_binary", data: BinData(2, "b2xk") },
+    { type: "uuid_old", data: BinData(3, "dXVpZC1vbGQ=") },
+    { type: "uuid", data: BinData(4, "dXVpZA==") },
+    { type: "md5", data: BinData(5, "bWQ1") },
+    { type: "encrypted", data: BinData(6, "ZW5jcnlwdGVk") },
+    { type: "user_defined", data: BinData(128, "dXNlcg==") }
+])

--- a/mongo/parsertest/testdata/objectConstructor-Binary.js
+++ b/mongo/parsertest/testdata/objectConstructor-Binary.js
@@ -1,0 +1,60 @@
+// Binary() - Create binary data (BSON Binary type)
+
+// In document - basic usage with base64 string
+db.files.insertOne({
+    name: "document.bin",
+    content: Binary("Y29udGVudA==")
+})
+
+// In query
+db.files.find({
+    content: Binary("Y29udGVudA==")
+})
+
+// Binary with subtype
+db.files.insertOne({
+    data: Binary("SGVsbG8gV29ybGQh", 0)
+})
+
+// With different subtypes
+db.binaries.insertMany([
+    { type: "generic", data: Binary("Z2VuZXJpYw==", 0) },
+    { type: "uuid", data: Binary("dXVpZA==", 4) },
+    { type: "md5", data: Binary("bWQ1", 5) }
+])
+
+// Using Binary.createFromBase64() static method
+db.files.insertOne({
+    fromBase64: Binary.createFromBase64("SGVsbG8=")
+})
+
+// Binary.createFromBase64() with subtype
+db.files.insertOne({
+    fromBase64: Binary.createFromBase64("SGVsbG8=", 0)
+})
+
+// Using Binary.createFromHexString() static method
+db.files.insertOne({
+    fromHex: Binary.createFromHexString("48656c6c6f")
+})
+
+// Binary.createFromHexString() with subtype
+db.files.insertOne({
+    fromHex: Binary.createFromHexString("48656c6c6f", 0)
+})
+
+// Using all static methods in a single document
+db.files.insertOne({
+    direct: Binary("Y29udGVudA=="),
+    fromBase64: Binary.createFromBase64("SGVsbG8="),
+    fromHex: Binary.createFromHexString("48656c6c6f")
+})
+
+// In aggregation pipeline
+db.files.aggregate([
+    {
+        $match: {
+            data: Binary("dGVzdA==")
+        }
+    }
+])

--- a/mongo/parsertest/testdata/objectConstructor-HexData.js
+++ b/mongo/parsertest/testdata/objectConstructor-HexData.js
@@ -1,0 +1,42 @@
+// HexData() - Create binary data from hex string with subtype
+
+// Basic usage - subtype 0 (generic binary)
+HexData(0, "48656c6c6f20576f726c6421")
+
+// UUID subtype (4)
+HexData(4, "550e8400e29b41d4a716446655440000")
+
+// MD5 digest subtype (5)
+HexData(5, "d41d8cd98f00b204e9800998ecf8427e")
+
+// User-defined binary (128)
+HexData(128, "637573746f6d2062696e617279")
+
+// In document
+db.files.insertOne({
+    name: "checksum.txt",
+    md5: HexData(5, "d41d8cd98f00b204e9800998ecf8427e")
+})
+
+// In query
+db.files.find({
+    md5: HexData(5, "d41d8cd98f00b204e9800998ecf8427e")
+})
+
+// Various subtypes with hex data
+db.hexdata.insertMany([
+    { type: "generic", data: HexData(0, "67656e65726963") },
+    { type: "function", data: HexData(1, "66756e6374696f6e") },
+    { type: "old_binary", data: HexData(2, "6f6c64") },
+    { type: "uuid_old", data: HexData(3, "757569642d6f6c64") },
+    { type: "uuid", data: HexData(4, "75756964") },
+    { type: "md5", data: HexData(5, "6d6435") },
+    { type: "encrypted", data: HexData(6, "656e63727970746564") },
+    { type: "user_defined", data: HexData(128, "75736572") }
+])
+
+// Storing binary hashes
+db.hashes.insertOne({
+    algorithm: "sha256",
+    hash: HexData(0, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+})

--- a/mongo/parsertest/testdata/plancache-clear.js
+++ b/mongo/parsertest/testdata/plancache-clear.js
@@ -1,0 +1,13 @@
+// db.collection.getPlanCache().clear() - Clear all cached query plans for a collection
+
+// Basic usage
+db.users.getPlanCache().clear()
+
+// With collection access patterns
+db["users"].getPlanCache().clear()
+db.getCollection("users").getPlanCache().clear()
+
+// Different collections
+db.orders.getPlanCache().clear()
+db.products.getPlanCache().clear()
+db.sessions.getPlanCache().clear()

--- a/mongo/parsertest/testdata/plancache-clearPlansByQuery.js
+++ b/mongo/parsertest/testdata/plancache-clearPlansByQuery.js
@@ -1,0 +1,26 @@
+// db.collection.getPlanCache().clearPlansByQuery() - Clear cached plans for a specific query shape
+
+// Clear by query shape
+db.users.getPlanCache().clearPlansByQuery({ status: "active" })
+
+// Clear with projection and sort
+db.users.getPlanCache().clearPlansByQuery({ status: "active" }, { name: 1 }, { age: -1 })
+
+// Clear with only query and projection
+db.orders.getPlanCache().clearPlansByQuery({ customer: "alice" }, { total: 1 })
+
+// Collection access patterns
+db["orders"].getPlanCache().clearPlansByQuery({ customer: "alice" })
+db.getCollection("products").getPlanCache().clearPlansByQuery({ category: "electronics" })
+
+// Complex query shapes
+db.users.getPlanCache().clearPlansByQuery({
+    status: "active",
+    age: { $gte: 18 }
+})
+
+db.orders.getPlanCache().clearPlansByQuery(
+    { status: "pending", total: { $gt: 100 } },
+    { _id: 0, orderId: 1, total: 1 },
+    { createdAt: -1 }
+)

--- a/mongo/parsertest/testdata/plancache-getPlanCache.js
+++ b/mongo/parsertest/testdata/plancache-getPlanCache.js
@@ -1,0 +1,13 @@
+// db.collection.getPlanCache() - Get the plan cache object for a collection
+
+// Basic usage - get the plan cache object
+db.users.getPlanCache()
+
+// With collection access patterns
+db["users"].getPlanCache()
+db.getCollection("users").getPlanCache()
+
+// Different collection names
+db.orders.getPlanCache()
+db.products.getPlanCache()
+db.customers.getPlanCache()

--- a/mongo/parsertest/testdata/plancache-help.js
+++ b/mongo/parsertest/testdata/plancache-help.js
@@ -1,0 +1,12 @@
+// db.collection.getPlanCache().help() - Display help information for plan cache methods
+
+// Basic usage
+db.users.getPlanCache().help()
+
+// With collection access patterns
+db["users"].getPlanCache().help()
+db.getCollection("users").getPlanCache().help()
+
+// Different collections
+db.orders.getPlanCache().help()
+db.products.getPlanCache().help()

--- a/mongo/parsertest/testdata/plancache-list.js
+++ b/mongo/parsertest/testdata/plancache-list.js
@@ -1,0 +1,24 @@
+// db.collection.getPlanCache().list() - List query plan cache entries
+
+// Basic usage
+db.users.getPlanCache().list()
+
+// With collection access patterns
+db["users"].getPlanCache().list()
+db.getCollection("users").getPlanCache().list()
+
+// Different collections
+db.orders.getPlanCache().list()
+db.products.getPlanCache().list()
+
+// With options (pipeline stages)
+db.users.getPlanCache().list([{ $match: { isActive: true } }])
+
+db.orders.getPlanCache().list([
+    { $match: { planCacheKey: "abc123" } }
+])
+
+// List with projection
+db.users.getPlanCache().list([
+    { $project: { queryHash: 1, planCacheKey: 1 } }
+])

--- a/mongo/parsertest/testdata/regex.js
+++ b/mongo/parsertest/testdata/regex.js
@@ -1,0 +1,14 @@
+// Regex literals
+db.users.find({ name: /alice/ })
+db.users.find({ name: /^alice/i })
+db.users.find({ email: /.*@example\.com$/ })
+db.users.find({ username: /user\d+/gm })
+
+// RegExp constructor
+db.users.find({ name: RegExp("alice") })
+db.users.find({ name: RegExp("^alice", "i") })
+db.users.find({ name: RegExp("test", "gi") })
+
+// Regex with query operators
+db.users.find({ name: { $regex: /^test/i } })
+db.logs.find({ message: { $regex: /error/i, $not: /warning/ } })

--- a/mongo/parsertest/testdata/rs-add.js
+++ b/mongo/parsertest/testdata/rs-add.js
@@ -1,0 +1,27 @@
+// rs.add() - Add a member to the replica set
+
+// Add member by hostname
+rs.add("mongo4:27017")
+
+// Add member with options document
+rs.add({ host: "mongo4:27017" })
+
+// Add member with priority
+rs.add({ host: "mongo4:27017", priority: 0 })
+
+// Add member as hidden
+rs.add({ host: "mongo4:27017", hidden: true, priority: 0 })
+
+// Add member with votes
+rs.add({ host: "mongo4:27017", votes: 0, priority: 0 })
+
+// Add member with build indexes disabled
+rs.add({ host: "mongo4:27017", buildIndexes: false, priority: 0 })
+
+// Add delayed member
+rs.add({
+    host: "mongo4:27017",
+    priority: 0,
+    hidden: true,
+    secondaryDelaySecs: 3600
+})

--- a/mongo/parsertest/testdata/rs-addArb.js
+++ b/mongo/parsertest/testdata/rs-addArb.js
@@ -1,0 +1,7 @@
+// rs.addArb() - Add an arbiter to the replica set
+
+// Add arbiter by hostname
+rs.addArb("arbiter:27017")
+
+// Add arbiter with full hostname and port
+rs.addArb("arbiter.example.com:27017")

--- a/mongo/parsertest/testdata/rs-conf.js
+++ b/mongo/parsertest/testdata/rs-conf.js
@@ -1,0 +1,4 @@
+// rs.conf() - Get replica set configuration (alias for rs.config())
+
+// Basic usage
+rs.conf()

--- a/mongo/parsertest/testdata/rs-config.js
+++ b/mongo/parsertest/testdata/rs-config.js
@@ -1,0 +1,4 @@
+// rs.config() - Get replica set configuration
+
+// Basic usage
+rs.config()

--- a/mongo/parsertest/testdata/rs-freeze.js
+++ b/mongo/parsertest/testdata/rs-freeze.js
@@ -1,0 +1,10 @@
+// rs.freeze() - Prevent a secondary from becoming primary for a period of time
+
+// Freeze for 120 seconds
+rs.freeze(120)
+
+// Freeze for 0 seconds (unfreeze immediately)
+rs.freeze(0)
+
+// Freeze for 1 hour
+rs.freeze(3600)

--- a/mongo/parsertest/testdata/rs-hello.js
+++ b/mongo/parsertest/testdata/rs-hello.js
@@ -1,0 +1,4 @@
+// rs.hello() - Returns replica set hello information
+
+// Basic usage
+rs.hello()

--- a/mongo/parsertest/testdata/rs-help.js
+++ b/mongo/parsertest/testdata/rs-help.js
@@ -1,0 +1,4 @@
+// rs.help() - Display replica set helper methods
+
+// Basic usage
+rs.help()

--- a/mongo/parsertest/testdata/rs-initiate.js
+++ b/mongo/parsertest/testdata/rs-initiate.js
@@ -1,0 +1,34 @@
+// rs.initiate() - Initialize replica set
+
+// No config (auto-initiate single node)
+rs.initiate()
+
+// With configuration
+rs.initiate({
+    _id: "myReplicaSet",
+    members: [
+        { _id: 0, host: "mongo1:27017" },
+        { _id: 1, host: "mongo2:27017" },
+        { _id: 2, host: "mongo3:27017" }
+    ]
+})
+
+// With configuration including priority and votes
+rs.initiate({
+    _id: "rs0",
+    members: [
+        { _id: 0, host: "primary:27017", priority: 2 },
+        { _id: 1, host: "secondary1:27017", priority: 1 },
+        { _id: 2, host: "secondary2:27017", priority: 1, votes: 1 }
+    ]
+})
+
+// With arbiter configuration
+rs.initiate({
+    _id: "rs0",
+    members: [
+        { _id: 0, host: "mongo1:27017" },
+        { _id: 1, host: "mongo2:27017" },
+        { _id: 2, host: "arbiter:27017", arbiterOnly: true }
+    ]
+})

--- a/mongo/parsertest/testdata/rs-isMaster.js
+++ b/mongo/parsertest/testdata/rs-isMaster.js
@@ -1,0 +1,4 @@
+// rs.isMaster() - Returns replica set isMaster information (deprecated, use rs.hello())
+
+// Basic usage
+rs.isMaster()

--- a/mongo/parsertest/testdata/rs-printReplicationInfo.js
+++ b/mongo/parsertest/testdata/rs-printReplicationInfo.js
@@ -1,0 +1,4 @@
+// rs.printReplicationInfo() - Print oplog information from the primary
+
+// Basic usage
+rs.printReplicationInfo()

--- a/mongo/parsertest/testdata/rs-printSecondaryReplicationInfo.js
+++ b/mongo/parsertest/testdata/rs-printSecondaryReplicationInfo.js
@@ -1,0 +1,4 @@
+// rs.printSecondaryReplicationInfo() - Print secondary members replication info
+
+// Basic usage
+rs.printSecondaryReplicationInfo()

--- a/mongo/parsertest/testdata/rs-reconfig.js
+++ b/mongo/parsertest/testdata/rs-reconfig.js
@@ -1,0 +1,44 @@
+// rs.reconfig() - Reconfigure the replica set
+
+// Basic reconfig with new configuration
+rs.reconfig({
+    _id: "rs0",
+    version: 2,
+    members: [
+        { _id: 0, host: "mongo1:27017" },
+        { _id: 1, host: "mongo2:27017" },
+        { _id: 2, host: "mongo3:27017" }
+    ]
+})
+
+// Reconfig with force option
+rs.reconfig({
+    _id: "rs0",
+    version: 3,
+    members: [
+        { _id: 0, host: "mongo1:27017" },
+        { _id: 1, host: "mongo2:27017" }
+    ]
+}, { force: true })
+
+// Reconfig changing member priority
+rs.reconfig({
+    _id: "rs0",
+    version: 4,
+    members: [
+        { _id: 0, host: "mongo1:27017", priority: 2 },
+        { _id: 1, host: "mongo2:27017", priority: 1 },
+        { _id: 2, host: "mongo3:27017", priority: 0 }
+    ]
+})
+
+// Reconfig adding hidden member
+rs.reconfig({
+    _id: "rs0",
+    version: 5,
+    members: [
+        { _id: 0, host: "mongo1:27017" },
+        { _id: 1, host: "mongo2:27017" },
+        { _id: 2, host: "mongo3:27017", hidden: true, priority: 0 }
+    ]
+})

--- a/mongo/parsertest/testdata/rs-remove.js
+++ b/mongo/parsertest/testdata/rs-remove.js
@@ -1,0 +1,7 @@
+// rs.remove() - Remove a member from the replica set
+
+// Remove member by hostname
+rs.remove("mongo4:27017")
+
+// Remove member with full hostname
+rs.remove("mongo4.example.com:27017")

--- a/mongo/parsertest/testdata/rs-status.js
+++ b/mongo/parsertest/testdata/rs-status.js
@@ -1,0 +1,7 @@
+// rs.status() - Get replica set status
+
+// Basic usage
+rs.status()
+
+// With options
+rs.status({ initialSync: 1 })

--- a/mongo/parsertest/testdata/sh-abortReshardCollection.js
+++ b/mongo/parsertest/testdata/sh-abortReshardCollection.js
@@ -1,0 +1,7 @@
+// sh.abortReshardCollection() - Abort an in-progress resharding operation
+
+// Basic usage
+sh.abortReshardCollection("mydb.users")
+
+// Abort resharding for specific namespace
+sh.abortReshardCollection("test.orders")

--- a/mongo/parsertest/testdata/sh-addShard.js
+++ b/mongo/parsertest/testdata/sh-addShard.js
@@ -1,0 +1,13 @@
+// sh.addShard() - Add a shard to a sharded cluster
+
+// Add a standalone mongod
+sh.addShard("hostname:27017")
+
+// Add a replica set shard
+sh.addShard("rs0/hostname1:27017,hostname2:27017,hostname3:27017")
+
+// Add with replica set name prefix
+sh.addShard("shard0001/mongodb0.example.net:27017")
+
+// Add multiple hosts for replica set
+sh.addShard("rs1/host1:27017,host2:27017")

--- a/mongo/parsertest/testdata/sh-addShardTag.js
+++ b/mongo/parsertest/testdata/sh-addShardTag.js
@@ -1,0 +1,11 @@
+// sh.addShardTag() - Associate a tag with a shard (deprecated, use addShardToZone)
+
+// Basic usage
+sh.addShardTag("shard0000", "NYC")
+
+// Add tag for geographic distribution
+sh.addShardTag("shard0001", "LAX")
+
+// Add multiple tags to same shard
+sh.addShardTag("shard0002", "EU")
+sh.addShardTag("shard0002", "EMEA")

--- a/mongo/parsertest/testdata/sh-addShardToZone.js
+++ b/mongo/parsertest/testdata/sh-addShardToZone.js
@@ -1,0 +1,14 @@
+// sh.addShardToZone() - Associate a shard with a zone
+
+// Basic usage
+sh.addShardToZone("shard0000", "NYC")
+
+// Add shard to geographic zone
+sh.addShardToZone("shard0001", "EU-WEST")
+
+// Add shard to data center zone
+sh.addShardToZone("shard0002", "DC1")
+
+// Multiple shards in same zone
+sh.addShardToZone("shard0003", "US-EAST")
+sh.addShardToZone("shard0004", "US-EAST")

--- a/mongo/parsertest/testdata/sh-addTagRange.js
+++ b/mongo/parsertest/testdata/sh-addTagRange.js
@@ -1,0 +1,15 @@
+// sh.addTagRange() - Associate a range of shard key values with a tag (deprecated, use updateZoneKeyRange)
+
+// Basic usage with numeric range
+sh.addTagRange("mydb.users", { zipcode: "10001" }, { zipcode: "10099" }, "NYC")
+
+// Range with MinKey/MaxKey
+sh.addTagRange("mydb.orders", { region: "A" }, { region: "M" }, "REGION_A_M")
+
+// Compound shard key range
+sh.addTagRange(
+    "mydb.events",
+    { date: ISODate("2024-01-01"), region: "US" },
+    { date: ISODate("2024-12-31"), region: "US" },
+    "US_2024"
+)

--- a/mongo/parsertest/testdata/sh-analyzeShardKey.js
+++ b/mongo/parsertest/testdata/sh-analyzeShardKey.js
@@ -1,0 +1,13 @@
+// sh.analyzeShardKey() - Analyze a potential shard key
+
+// Basic usage
+sh.analyzeShardKey("mydb.users", { email: 1 })
+
+// Analyze hashed key
+sh.analyzeShardKey("mydb.orders", { orderId: "hashed" })
+
+// Analyze compound key
+sh.analyzeShardKey("mydb.events", { region: 1, timestamp: 1 })
+
+// With options
+sh.analyzeShardKey("mydb.logs", { deviceId: 1 }, { sampleRate: 0.5 })

--- a/mongo/parsertest/testdata/sh-balancerCollectionStatus.js
+++ b/mongo/parsertest/testdata/sh-balancerCollectionStatus.js
@@ -1,0 +1,10 @@
+// sh.balancerCollectionStatus() - Get balancer status for a specific collection
+
+// Basic usage
+sh.balancerCollectionStatus("mydb.users")
+
+// Check status for sharded collection
+sh.balancerCollectionStatus("test.orders")
+
+// Namespace with dot notation
+sh.balancerCollectionStatus("analytics.events")

--- a/mongo/parsertest/testdata/sh-checkMetadataConsistency.js
+++ b/mongo/parsertest/testdata/sh-checkMetadataConsistency.js
@@ -1,0 +1,7 @@
+// sh.checkMetadataConsistency() - Check metadata consistency
+
+// Basic usage (no arguments)
+sh.checkMetadataConsistency()
+
+// With options
+sh.checkMetadataConsistency({ checkIndexes: true })

--- a/mongo/parsertest/testdata/sh-clearBalancerWindow.js
+++ b/mongo/parsertest/testdata/sh-clearBalancerWindow.js
@@ -1,0 +1,4 @@
+// sh.clearBalancerWindow() - Clear the balancer window
+
+// Basic usage (no arguments)
+sh.clearBalancerWindow()

--- a/mongo/parsertest/testdata/sh-commitReshardCollection.js
+++ b/mongo/parsertest/testdata/sh-commitReshardCollection.js
@@ -1,0 +1,7 @@
+// sh.commitReshardCollection() - Commit a resharding operation
+
+// Basic usage
+sh.commitReshardCollection("mydb.users")
+
+// Commit resharding for specific namespace
+sh.commitReshardCollection("test.orders")

--- a/mongo/parsertest/testdata/sh-configureQueryAnalyzer.js
+++ b/mongo/parsertest/testdata/sh-configureQueryAnalyzer.js
@@ -1,0 +1,10 @@
+// sh.configureQueryAnalyzer() - Configure the query analyzer for a collection
+
+// Enable query analysis
+sh.configureQueryAnalyzer("mydb.users", { mode: "full", sampleRate: 1.0 })
+
+// Disable query analysis
+sh.configureQueryAnalyzer("mydb.users", { mode: "off" })
+
+// Sample a portion of queries
+sh.configureQueryAnalyzer("mydb.orders", { mode: "full", sampleRate: 0.1 })

--- a/mongo/parsertest/testdata/sh-disableAutoMerger.js
+++ b/mongo/parsertest/testdata/sh-disableAutoMerger.js
@@ -1,0 +1,4 @@
+// sh.disableAutoMerger() - Disable the auto-merger for the sharded cluster
+
+// Basic usage (no arguments)
+sh.disableAutoMerger()

--- a/mongo/parsertest/testdata/sh-disableAutoSplit.js
+++ b/mongo/parsertest/testdata/sh-disableAutoSplit.js
@@ -1,0 +1,4 @@
+// sh.disableAutoSplit() - Disable auto-splitting of chunks
+
+// Basic usage (no arguments, deprecated in MongoDB 6.1)
+sh.disableAutoSplit()

--- a/mongo/parsertest/testdata/sh-disableBalancing.js
+++ b/mongo/parsertest/testdata/sh-disableBalancing.js
@@ -1,0 +1,10 @@
+// sh.disableBalancing() - Disable balancing for a specific collection
+
+// Basic usage
+sh.disableBalancing("mydb.users")
+
+// Disable for specific namespace
+sh.disableBalancing("test.orders")
+
+// Disable for collection in analytics database
+sh.disableBalancing("analytics.events")

--- a/mongo/parsertest/testdata/sh-enableAutoMerger.js
+++ b/mongo/parsertest/testdata/sh-enableAutoMerger.js
@@ -1,0 +1,4 @@
+// sh.enableAutoMerger() - Enable the auto-merger for the sharded cluster
+
+// Basic usage (no arguments)
+sh.enableAutoMerger()

--- a/mongo/parsertest/testdata/sh-enableAutoSplit.js
+++ b/mongo/parsertest/testdata/sh-enableAutoSplit.js
@@ -1,0 +1,4 @@
+// sh.enableAutoSplit() - Enable auto-splitting of chunks
+
+// Basic usage (no arguments, deprecated in MongoDB 6.1)
+sh.enableAutoSplit()

--- a/mongo/parsertest/testdata/sh-enableBalancing.js
+++ b/mongo/parsertest/testdata/sh-enableBalancing.js
@@ -1,0 +1,10 @@
+// sh.enableBalancing() - Enable balancing for a specific collection
+
+// Basic usage
+sh.enableBalancing("mydb.users")
+
+// Enable for specific namespace
+sh.enableBalancing("test.orders")
+
+// Enable after maintenance window
+sh.enableBalancing("analytics.events")

--- a/mongo/parsertest/testdata/sh-enableSharding.js
+++ b/mongo/parsertest/testdata/sh-enableSharding.js
@@ -1,0 +1,13 @@
+// sh.enableSharding() - Enable sharding for a database
+
+// Basic usage
+sh.enableSharding("myDatabase")
+
+// With primaryShard option
+sh.enableSharding("myDatabase", { primaryShard: "shard0001" })
+
+// Enable sharding for test database
+sh.enableSharding("test")
+
+// Enable with specific primary shard
+sh.enableSharding("analytics", { primaryShard: "shard0002" })

--- a/mongo/parsertest/testdata/sh-flushRouterConfig.js
+++ b/mongo/parsertest/testdata/sh-flushRouterConfig.js
@@ -1,0 +1,7 @@
+// sh.flushRouterConfig() - Flush the routing table cache
+
+// Basic usage (no arguments)
+sh.flushRouterConfig()
+
+// Flush for specific namespace
+sh.flushRouterConfig("mydb.users")

--- a/mongo/parsertest/testdata/sh-getBalancerHost.js
+++ b/mongo/parsertest/testdata/sh-getBalancerHost.js
@@ -1,0 +1,4 @@
+// sh.getBalancerHost() - Get the host running the balancer
+
+// Basic usage (no arguments, deprecated)
+sh.getBalancerHost()

--- a/mongo/parsertest/testdata/sh-getBalancerLockDetails.js
+++ b/mongo/parsertest/testdata/sh-getBalancerLockDetails.js
@@ -1,0 +1,4 @@
+// sh.getBalancerLockDetails() - Get details about the balancer lock
+
+// Basic usage (no arguments)
+sh.getBalancerLockDetails()

--- a/mongo/parsertest/testdata/sh-getBalancerState.js
+++ b/mongo/parsertest/testdata/sh-getBalancerState.js
@@ -1,0 +1,4 @@
+// sh.getBalancerState() - Get the current balancer state
+
+// Basic usage (no arguments)
+sh.getBalancerState()

--- a/mongo/parsertest/testdata/sh-getBalancerWindow.js
+++ b/mongo/parsertest/testdata/sh-getBalancerWindow.js
@@ -1,0 +1,4 @@
+// sh.getBalancerWindow() - Get the balancer window settings
+
+// Basic usage (no arguments)
+sh.getBalancerWindow()

--- a/mongo/parsertest/testdata/sh-getRecentFailedRounds.js
+++ b/mongo/parsertest/testdata/sh-getRecentFailedRounds.js
@@ -1,0 +1,4 @@
+// sh.getRecentFailedRounds() - Get recent failed balancer rounds
+
+// Basic usage (no arguments)
+sh.getRecentFailedRounds()

--- a/mongo/parsertest/testdata/sh-getRecentMigrations.js
+++ b/mongo/parsertest/testdata/sh-getRecentMigrations.js
@@ -1,0 +1,7 @@
+// sh.getRecentMigrations() - Get recent chunk migrations
+
+// Basic usage (no arguments)
+sh.getRecentMigrations()
+
+// With limit
+sh.getRecentMigrations(10)

--- a/mongo/parsertest/testdata/sh-getShardedDataDistribution.js
+++ b/mongo/parsertest/testdata/sh-getShardedDataDistribution.js
@@ -1,0 +1,4 @@
+// sh.getShardedDataDistribution() - Get data distribution across shards
+
+// Basic usage (no arguments)
+sh.getShardedDataDistribution()

--- a/mongo/parsertest/testdata/sh-getShouldAutoSplit.js
+++ b/mongo/parsertest/testdata/sh-getShouldAutoSplit.js
@@ -1,0 +1,4 @@
+// sh.getShouldAutoSplit() - Check if auto-split is enabled
+
+// Basic usage (no arguments, deprecated in MongoDB 6.1)
+sh.getShouldAutoSplit()

--- a/mongo/parsertest/testdata/sh-help.js
+++ b/mongo/parsertest/testdata/sh-help.js
@@ -1,0 +1,4 @@
+// sh.help() - Display sharding helper methods
+
+// Basic usage
+sh.help()

--- a/mongo/parsertest/testdata/sh-isBalancerRunning.js
+++ b/mongo/parsertest/testdata/sh-isBalancerRunning.js
@@ -1,0 +1,4 @@
+// sh.isBalancerRunning() - Check if the balancer is currently running
+
+// Basic usage (no arguments)
+sh.isBalancerRunning()

--- a/mongo/parsertest/testdata/sh-listShards.js
+++ b/mongo/parsertest/testdata/sh-listShards.js
@@ -1,0 +1,4 @@
+// sh.listShards() - List all shards in the cluster
+
+// Basic usage (no arguments)
+sh.listShards()

--- a/mongo/parsertest/testdata/sh-moveChunk.js
+++ b/mongo/parsertest/testdata/sh-moveChunk.js
@@ -1,0 +1,10 @@
+// sh.moveChunk() - Move a chunk to a different shard
+
+// Move by find query
+sh.moveChunk("mydb.users", { zipcode: "10001" }, "shard0001")
+
+// Move chunk containing specific document
+sh.moveChunk("test.orders", { _id: ObjectId("507f1f77bcf86cd799439011") }, "shard0002")
+
+// Move by shard key value
+sh.moveChunk("analytics.events", { region: "US", timestamp: ISODate("2024-01-01") }, "shard0003")

--- a/mongo/parsertest/testdata/sh-moveRange.js
+++ b/mongo/parsertest/testdata/sh-moveRange.js
@@ -1,0 +1,19 @@
+// sh.moveRange() - Move a range of shard key values to a shard
+
+// Basic usage
+sh.moveRange("mydb.users", { min: { zipcode: "10001" }, max: { zipcode: "20000" } }, "shard0001")
+
+// Move range with specific bounds
+sh.moveRange(
+    "test.orders",
+    { min: { customerId: 1000 }, max: { customerId: 2000 } },
+    "shard0002"
+)
+
+// Move with forceJumbo option
+sh.moveRange(
+    "mydb.events",
+    { min: { region: "US" }, max: { region: "UZ" } },
+    "shard0003",
+    { forceJumbo: true }
+)

--- a/mongo/parsertest/testdata/sh-refineCollectionShardKey.js
+++ b/mongo/parsertest/testdata/sh-refineCollectionShardKey.js
@@ -1,0 +1,10 @@
+// sh.refineCollectionShardKey() - Refine the shard key of a sharded collection
+
+// Basic usage - add suffix fields
+sh.refineCollectionShardKey("mydb.users", { region: 1, email: 1 })
+
+// Refine with additional timestamp
+sh.refineCollectionShardKey("mydb.orders", { customerId: 1, orderId: 1, timestamp: 1 })
+
+// Add more specificity to shard key
+sh.refineCollectionShardKey("mydb.events", { category: 1, subCategory: 1, eventId: 1 })

--- a/mongo/parsertest/testdata/sh-removeShard.js
+++ b/mongo/parsertest/testdata/sh-removeShard.js
@@ -1,0 +1,10 @@
+// sh.removeShard() - Remove a shard from the cluster
+
+// Basic usage
+sh.removeShard("shard0003")
+
+// Remove shard by name
+sh.removeShard("rs2")
+
+// Remove replica set shard
+sh.removeShard("shard0001")

--- a/mongo/parsertest/testdata/sh-removeShardFromZone.js
+++ b/mongo/parsertest/testdata/sh-removeShardFromZone.js
@@ -1,0 +1,10 @@
+// sh.removeShardFromZone() - Remove a shard from a zone
+
+// Basic usage
+sh.removeShardFromZone("shard0000", "NYC")
+
+// Remove from geographic zone
+sh.removeShardFromZone("shard0001", "EU-WEST")
+
+// Remove from data center zone
+sh.removeShardFromZone("shard0002", "DC1")

--- a/mongo/parsertest/testdata/sh-removeShardTag.js
+++ b/mongo/parsertest/testdata/sh-removeShardTag.js
@@ -1,0 +1,10 @@
+// sh.removeShardTag() - Remove a tag from a shard (deprecated, use removeShardFromZone)
+
+// Basic usage
+sh.removeShardTag("shard0000", "NYC")
+
+// Remove geographic tag
+sh.removeShardTag("shard0001", "LAX")
+
+// Remove data center tag
+sh.removeShardTag("shard0002", "DC1")

--- a/mongo/parsertest/testdata/sh-removeTagRange.js
+++ b/mongo/parsertest/testdata/sh-removeTagRange.js
@@ -1,0 +1,12 @@
+// sh.removeTagRange() - Remove a tag range (deprecated, use updateZoneKeyRange)
+
+// Basic usage
+sh.removeTagRange("mydb.users", { zipcode: "10001" }, { zipcode: "10099" }, "NYC")
+
+// Remove compound key range
+sh.removeTagRange(
+    "mydb.events",
+    { date: ISODate("2024-01-01"), region: "US" },
+    { date: ISODate("2024-12-31"), region: "US" },
+    "US_2024"
+)

--- a/mongo/parsertest/testdata/sh-reshardCollection.js
+++ b/mongo/parsertest/testdata/sh-reshardCollection.js
@@ -1,0 +1,24 @@
+// sh.reshardCollection() - Reshard a collection with a new shard key
+
+// Basic usage - change to hashed shard key
+sh.reshardCollection("mydb.users", { email: "hashed" })
+
+// Reshard with range-based key
+sh.reshardCollection("mydb.orders", { orderId: 1 })
+
+// Reshard with compound key
+sh.reshardCollection("mydb.events", { region: 1, timestamp: 1 })
+
+// With options
+sh.reshardCollection(
+    "mydb.products",
+    { category: 1, productId: 1 },
+    { unique: false, numInitialChunks: 8 }
+)
+
+// With zone specification
+sh.reshardCollection(
+    "mydb.customers",
+    { country: 1, customerId: 1 },
+    { zones: [{ zone: "EU", min: { country: "AA" }, max: { country: "MZ" } }] }
+)

--- a/mongo/parsertest/testdata/sh-setBalancerState.js
+++ b/mongo/parsertest/testdata/sh-setBalancerState.js
@@ -1,0 +1,7 @@
+// sh.setBalancerState() - Enable or disable the balancer
+
+// Enable the balancer
+sh.setBalancerState(true)
+
+// Disable the balancer
+sh.setBalancerState(false)

--- a/mongo/parsertest/testdata/sh-setBalancerWindow.js
+++ b/mongo/parsertest/testdata/sh-setBalancerWindow.js
@@ -1,0 +1,10 @@
+// sh.setBalancerWindow() - Set the balancer window
+
+// Set balancer window with start and stop times
+sh.setBalancerWindow("23:00", "06:00")
+
+// Set overnight balancing window
+sh.setBalancerWindow("02:00", "04:00")
+
+// Set with options
+sh.setBalancerWindow({ start: "00:00", stop: "05:00" })

--- a/mongo/parsertest/testdata/sh-shardCollection.js
+++ b/mongo/parsertest/testdata/sh-shardCollection.js
@@ -1,0 +1,33 @@
+// sh.shardCollection() - Shard a collection
+
+// Shard with hashed key
+sh.shardCollection("mydb.users", { _id: "hashed" })
+
+// Shard with range-based key
+sh.shardCollection("mydb.orders", { customerId: 1 })
+
+// Compound shard key
+sh.shardCollection("mydb.events", { region: 1, timestamp: 1 })
+
+// With unique constraint
+sh.shardCollection("mydb.products", { sku: 1 }, { unique: true })
+
+// With numInitialChunks
+sh.shardCollection("mydb.logs", { timestamp: 1 }, { numInitialChunks: 4 })
+
+// Hashed with presplit chunks
+sh.shardCollection("mydb.telemetry", { deviceId: "hashed" }, { numInitialChunks: 10 })
+
+// With collation
+sh.shardCollection(
+    "mydb.customers",
+    { lastName: 1 },
+    { collation: { locale: "en", strength: 2 } }
+)
+
+// With timeseries collection
+sh.shardCollection(
+    "mydb.metrics",
+    { "metadata.sensorId": 1, timestamp: 1 },
+    { timeseries: { timeField: "timestamp", metaField: "metadata" } }
+)

--- a/mongo/parsertest/testdata/sh-splitAt.js
+++ b/mongo/parsertest/testdata/sh-splitAt.js
@@ -1,0 +1,13 @@
+// sh.splitAt() - Split a chunk at a specific shard key value
+
+// Basic usage
+sh.splitAt("mydb.users", { zipcode: "50000" })
+
+// Split at specific point
+sh.splitAt("test.orders", { orderId: 1000000 })
+
+// Split with compound key
+sh.splitAt("analytics.events", { region: "US", timestamp: ISODate("2024-06-01") })
+
+// Split at ObjectId boundary
+sh.splitAt("mydb.documents", { _id: ObjectId("507f1f77bcf86cd799439011") })

--- a/mongo/parsertest/testdata/sh-splitFind.js
+++ b/mongo/parsertest/testdata/sh-splitFind.js
@@ -1,0 +1,10 @@
+// sh.splitFind() - Split the chunk that contains a document matching the query
+
+// Basic usage
+sh.splitFind("mydb.users", { zipcode: "10001" })
+
+// Split chunk containing document
+sh.splitFind("test.orders", { customerId: 12345 })
+
+// Split with compound key query
+sh.splitFind("analytics.events", { region: "EU", timestamp: ISODate("2024-03-15") })

--- a/mongo/parsertest/testdata/sh-startBalancer.js
+++ b/mongo/parsertest/testdata/sh-startBalancer.js
@@ -1,0 +1,10 @@
+// sh.startBalancer() - Start the balancer
+
+// Basic usage (no arguments)
+sh.startBalancer()
+
+// With timeout in milliseconds
+sh.startBalancer(60000)
+
+// Start with options
+sh.startBalancer({ timeout: 60000 })

--- a/mongo/parsertest/testdata/sh-status.js
+++ b/mongo/parsertest/testdata/sh-status.js
@@ -1,0 +1,13 @@
+// sh.status() - Display sharding status
+
+// Basic usage
+sh.status()
+
+// Verbose output
+sh.status(true)
+
+// With verbose option object
+sh.status({ verbose: true })
+
+// Show detailed chunk information
+sh.status({ verbose: 1 })

--- a/mongo/parsertest/testdata/sh-stopBalancer.js
+++ b/mongo/parsertest/testdata/sh-stopBalancer.js
@@ -1,0 +1,10 @@
+// sh.stopBalancer() - Stop the balancer
+
+// Basic usage (no arguments)
+sh.stopBalancer()
+
+// With timeout in milliseconds
+sh.stopBalancer(60000)
+
+// Stop with options
+sh.stopBalancer({ timeout: 60000 })

--- a/mongo/parsertest/testdata/sh-transitionFromDedicatedConfigServer.js
+++ b/mongo/parsertest/testdata/sh-transitionFromDedicatedConfigServer.js
@@ -1,0 +1,4 @@
+// sh.transitionFromDedicatedConfigServer() - Transition from dedicated config server
+
+// Basic usage (no arguments)
+sh.transitionFromDedicatedConfigServer()

--- a/mongo/parsertest/testdata/sh-transitionToDedicatedConfigServer.js
+++ b/mongo/parsertest/testdata/sh-transitionToDedicatedConfigServer.js
@@ -1,0 +1,4 @@
+// sh.transitionToDedicatedConfigServer() - Transition to dedicated config server
+
+// Basic usage (no arguments)
+sh.transitionToDedicatedConfigServer()

--- a/mongo/parsertest/testdata/sh-unshardCollection.js
+++ b/mongo/parsertest/testdata/sh-unshardCollection.js
@@ -1,0 +1,10 @@
+// sh.unshardCollection() - Unshard a collection (move all data to a single shard)
+
+// Basic usage
+sh.unshardCollection("mydb.users")
+
+// Unshard to specific shard
+sh.unshardCollection("mydb.orders", "shard0001")
+
+// With options
+sh.unshardCollection("mydb.logs", { toShard: "shard0002" })

--- a/mongo/parsertest/testdata/sh-updateZoneKeyRange.js
+++ b/mongo/parsertest/testdata/sh-updateZoneKeyRange.js
@@ -1,0 +1,23 @@
+// sh.updateZoneKeyRange() - Associate a range of shard key values with a zone
+
+// Basic usage
+sh.updateZoneKeyRange("mydb.users", { zipcode: "10001" }, { zipcode: "10099" }, "NYC")
+
+// Remove zone assignment (null zone)
+sh.updateZoneKeyRange("mydb.users", { zipcode: "10001" }, { zipcode: "10099" }, null)
+
+// Compound shard key range
+sh.updateZoneKeyRange(
+    "mydb.events",
+    { region: "US", timestamp: ISODate("2024-01-01") },
+    { region: "US", timestamp: ISODate("2025-01-01") },
+    "US_2024"
+)
+
+// Geographic zone assignment
+sh.updateZoneKeyRange(
+    "mydb.customers",
+    { country: "FR" },
+    { country: "FZ" },
+    "EU-WEST"
+)

--- a/mongo/parsertest/testdata/sh-waitForBalancer.js
+++ b/mongo/parsertest/testdata/sh-waitForBalancer.js
@@ -1,0 +1,10 @@
+// sh.waitForBalancer() - Wait for a balancing round to complete
+
+// Basic usage (no arguments)
+sh.waitForBalancer()
+
+// With timeout
+sh.waitForBalancer(true)
+
+// With timeout in milliseconds
+sh.waitForBalancer(true, 60000)

--- a/mongo/parsertest/testdata/sh-waitForBalancerOff.js
+++ b/mongo/parsertest/testdata/sh-waitForBalancerOff.js
@@ -1,0 +1,7 @@
+// sh.waitForBalancerOff() - Wait for the balancer to stop
+
+// Basic usage (no arguments)
+sh.waitForBalancerOff()
+
+// With timeout in milliseconds
+sh.waitForBalancerOff(60000)

--- a/mongo/parsertest/testdata/sh-waitForPingChange.js
+++ b/mongo/parsertest/testdata/sh-waitForPingChange.js
@@ -1,0 +1,10 @@
+// sh.waitForPingChange() - Wait for a change in ping times
+
+// Basic usage with activePings array
+sh.waitForPingChange([{ _id: "shard0000" }, { _id: "shard0001" }])
+
+// With timeout
+sh.waitForPingChange([{ _id: "shard0000" }], 60000)
+
+// With options
+sh.waitForPingChange([{ _id: "shard0000" }], { timeout: 60000 })

--- a/mongo/parsertest/testdata/shell_commands.js
+++ b/mongo/parsertest/testdata/shell_commands.js
@@ -1,0 +1,4 @@
+// Shell commands
+show dbs
+show databases
+show collections

--- a/mongo/parsertest/testdata/sp-createStreamProcessor.js
+++ b/mongo/parsertest/testdata/sp-createStreamProcessor.js
@@ -1,0 +1,59 @@
+// sp.createStreamProcessor() - Create a stream processor
+
+// Basic stream processor
+sp.createStreamProcessor("myProcessor", {
+    pipeline: [
+        { $source: { connectionName: "connection1" } },
+        { $match: { status: "active" } },
+        { $emit: { connectionName: "connection2" } }
+    ]
+})
+
+// With options
+sp.createStreamProcessor("analyticsProcessor", {
+    pipeline: [
+        { $source: { connectionName: "logs" } },
+        { $merge: { into: "processed_logs" } }
+    ],
+    options: { dlq: { connectionName: "dlq_connection" } }
+})
+
+// Stream processor with aggregation stages
+sp.createStreamProcessor("aggregateProcessor", {
+    pipeline: [
+        { $source: { connectionName: "events" } },
+        { $match: { type: "purchase" } },
+        { $group: { _id: "$userId", total: { $sum: "$amount" } } },
+        { $emit: { connectionName: "aggregated_events" } }
+    ]
+})
+
+// Stream processor with window operations
+sp.createStreamProcessor("windowProcessor", {
+    pipeline: [
+        { $source: { connectionName: "metrics" } },
+        { $tumblingWindow: {
+            interval: { size: 1, unit: "minute" },
+            pipeline: [
+                { $group: { _id: "$sensor", avg: { $avg: "$value" } } }
+            ]
+        }},
+        { $merge: { into: "metric_averages" } }
+    ]
+})
+
+// Stream processor with dead letter queue
+sp.createStreamProcessor("dlqProcessor", {
+    pipeline: [
+        { $source: { connectionName: "input_stream" } },
+        { $match: { valid: true } },
+        { $emit: { connectionName: "output_stream" } }
+    ],
+    options: {
+        dlq: {
+            connectionName: "dlq_connection",
+            db: "errors",
+            coll: "failed_records"
+        }
+    }
+})

--- a/mongo/parsertest/testdata/sp-drop.js
+++ b/mongo/parsertest/testdata/sp-drop.js
@@ -1,0 +1,24 @@
+// sp.<processor>.drop() - Drop (delete) a stream processor
+
+// Drop processor via direct access
+sp.myProcessor.drop()
+
+// Drop various processors
+sp.analyticsProcessor.drop()
+sp.dataProcessor.drop()
+sp.eventProcessor.drop()
+sp.sensorProcessor.drop()
+
+// Drop processors with different naming patterns
+sp.my_stream_processor.drop()
+sp.processor1.drop()
+sp.stream_v2.drop()
+
+// Drop old or deprecated processors
+sp.oldProcessor.drop()
+sp.legacyProcessor.drop()
+sp.testProcessor.drop()
+
+// Drop pipeline processors
+sp.deprecatedPipeline.drop()
+sp.temporaryProcessor.drop()

--- a/mongo/parsertest/testdata/sp-getProcessor.js
+++ b/mongo/parsertest/testdata/sp-getProcessor.js
@@ -1,0 +1,17 @@
+// sp.getProcessor() - Get a stream processor by name
+
+// Get processor by name
+sp.getProcessor("myProcessor")
+
+// Get processor and check its state
+sp.getProcessor("analyticsProcessor")
+
+// Get processor with different names
+sp.getProcessor("dataProcessor")
+sp.getProcessor("eventProcessor")
+sp.getProcessor("sensorProcessor")
+
+// Get processor with special naming patterns
+sp.getProcessor("my_stream_processor")
+sp.getProcessor("processor-v1")
+sp.getProcessor("stream_2024")

--- a/mongo/parsertest/testdata/sp-listStreamProcessors.js
+++ b/mongo/parsertest/testdata/sp-listStreamProcessors.js
@@ -1,0 +1,18 @@
+// sp.listStreamProcessors() - List all stream processors
+
+// List all stream processors
+sp.listStreamProcessors()
+
+// List stream processors with filter
+sp.listStreamProcessors({ name: "myProcessor" })
+
+// List stream processors by state
+sp.listStreamProcessors({ state: "RUNNING" })
+sp.listStreamProcessors({ state: "STOPPED" })
+sp.listStreamProcessors({ state: "CREATED" })
+
+// List stream processors with multiple filters
+sp.listStreamProcessors({ state: "RUNNING", name: "analyticsProcessor" })
+
+// List stream processors with regex pattern
+sp.listStreamProcessors({ name: /^analytics.*/ })

--- a/mongo/parsertest/testdata/sp-process.js
+++ b/mongo/parsertest/testdata/sp-process.js
@@ -1,0 +1,40 @@
+// sp.process() - Run an inline stream processing pipeline
+
+// Basic process with pipeline
+sp.process([
+    { $source: { connectionName: "sample_stream_solar" } },
+    { $match: { status: "active" } },
+    { $emit: { connectionName: "output_stream" } }
+])
+
+// Process with aggregation
+sp.process([
+    { $source: { connectionName: "events" } },
+    { $group: { _id: "$category", count: { $sum: 1 } } },
+    { $merge: { into: "event_counts" } }
+])
+
+// Process with window function
+sp.process([
+    { $source: { connectionName: "sensor_data" } },
+    { $tumblingWindow: {
+        interval: { size: 5, unit: "second" },
+        pipeline: [
+            { $group: { _id: null, avgTemp: { $avg: "$temperature" } } }
+        ]
+    }},
+    { $emit: { connectionName: "temp_averages" } }
+])
+
+// Process with complex transformations
+sp.process([
+    { $source: { connectionName: "raw_logs" } },
+    { $match: { level: { $in: ["ERROR", "WARN"] } } },
+    { $project: {
+        timestamp: 1,
+        level: 1,
+        message: 1,
+        processed: true
+    }},
+    { $merge: { into: "filtered_logs" } }
+])

--- a/mongo/parsertest/testdata/sp-processor.js
+++ b/mongo/parsertest/testdata/sp-processor.js
@@ -1,0 +1,28 @@
+// sp.<processor-name> - Access a specific stream processor
+
+// Access processor by name and check stats
+sp.myProcessor.stats()
+
+// Access processor and start it
+sp.analyticsProcessor.start()
+
+// Access processor and stop it
+sp.dataProcessor.stop()
+
+// Access processor and drop it
+sp.oldProcessor.drop()
+
+// Access processor and get sample data
+sp.sensorProcessor.sample()
+
+// Chain operations on processor
+sp.eventProcessor.stats()
+sp.eventProcessor.start()
+sp.eventProcessor.stop()
+
+// Access processor with underscore in name
+sp.my_stream_processor.stats()
+
+// Access processor with number in name
+sp.processor1.stats()
+sp.stream_v2.start()

--- a/mongo/parsertest/testdata/sp-sample.js
+++ b/mongo/parsertest/testdata/sp-sample.js
@@ -1,0 +1,24 @@
+// sp.<processor>.sample() - Sample documents from a stream processor
+
+// Sample from processor via direct access
+sp.myProcessor.sample()
+
+// Sample from various processors
+sp.analyticsProcessor.sample()
+sp.dataProcessor.sample()
+sp.eventProcessor.sample()
+sp.sensorProcessor.sample()
+
+// Sample from processors with different naming patterns
+sp.my_stream_processor.sample()
+sp.processor1.sample()
+sp.stream_v2.sample()
+
+// Sample from pipeline processors
+sp.ingestPipeline.sample()
+sp.transformPipeline.sample()
+sp.outputPipeline.sample()
+
+// Sample for debugging
+sp.debugProcessor.sample()
+sp.testProcessor.sample()

--- a/mongo/parsertest/testdata/sp-start.js
+++ b/mongo/parsertest/testdata/sp-start.js
@@ -1,0 +1,20 @@
+// sp.<processor>.start() - Start a stream processor
+
+// Start processor via direct access
+sp.myProcessor.start()
+
+// Start various processors
+sp.analyticsProcessor.start()
+sp.dataProcessor.start()
+sp.eventProcessor.start()
+sp.sensorProcessor.start()
+
+// Start processors with different naming patterns
+sp.my_stream_processor.start()
+sp.processor1.start()
+sp.stream_v2.start()
+
+// Start a specific processor for data pipeline
+sp.ingestPipeline.start()
+sp.transformPipeline.start()
+sp.outputPipeline.start()

--- a/mongo/parsertest/testdata/sp-stop.js
+++ b/mongo/parsertest/testdata/sp-stop.js
@@ -1,0 +1,24 @@
+// sp.<processor>.stop() - Stop a stream processor
+
+// Stop processor via direct access
+sp.myProcessor.stop()
+
+// Stop various processors
+sp.analyticsProcessor.stop()
+sp.dataProcessor.stop()
+sp.eventProcessor.stop()
+sp.sensorProcessor.stop()
+
+// Stop processors with different naming patterns
+sp.my_stream_processor.stop()
+sp.processor1.stop()
+sp.stream_v2.stop()
+
+// Stop pipeline processors
+sp.ingestPipeline.stop()
+sp.transformPipeline.stop()
+sp.outputPipeline.stop()
+
+// Stop for maintenance
+sp.productionProcessor.stop()
+sp.stagingProcessor.stop()

--- a/mongo/parsertest/testdata/unicode.js
+++ b/mongo/parsertest/testdata/unicode.js
@@ -1,0 +1,103 @@
+// Unicode support - emoji characters
+db.posts.find({ reaction: "👍" })
+db.posts.find({ emoji: "🎉🎊🎁" })
+db.posts.insertOne({ title: "Hello 🌍", content: "Testing emoji support 😀" })
+db.messages.updateOne({ _id: 1 }, { $set: { status: "✅ completed" } })
+
+// Unicode - emoji in field names (quoted)
+db.reactions.find({ "👍": { $gt: 10 } })
+db.reactions.insertOne({ "👍": 100, "👎": 5, "❤️": 50 })
+
+// Unicode - Hindi (Devanagari script)
+db.users.find({ name: "नमस्ते" })
+db.users.find({ greeting: "आपका स्वागत है" })
+db.products.insertOne({ name: "चाय", description: "भारतीय मसाला चाय" })
+db.articles.find({ title: "हिंदी में लेख" })
+
+// Unicode - Chinese (Simplified)
+db.users.find({ name: "你好世界" })
+db.products.find({ category: "电子产品" })
+db.orders.insertOne({ item: "笔记本电脑", price: 5999 })
+
+// Unicode - Chinese (Traditional)
+db.users.find({ name: "繁體中文" })
+db.products.find({ description: "傳統工藝品" })
+
+// Unicode - Japanese (Hiragana, Katakana, Kanji)
+db.users.find({ greeting: "こんにちは" })
+db.products.find({ name: "カタカナ" })
+db.articles.find({ title: "日本語の記事" })
+
+// Unicode - Korean
+db.users.find({ name: "안녕하세요" })
+db.products.find({ category: "한국 음식" })
+
+// Unicode - Arabic (right-to-left)
+db.users.find({ name: "مرحبا بالعالم" })
+db.articles.find({ title: "مقال باللغة العربية" })
+
+// Unicode - Thai
+db.users.find({ greeting: "สวัสดี" })
+db.products.find({ name: "อาหารไทย" })
+
+// Unicode - Russian (Cyrillic)
+db.users.find({ name: "Привет мир" })
+db.articles.find({ title: "Русский текст" })
+
+// Unicode - Greek
+db.users.find({ name: "Γειά σου κόσμε" })
+db.math.find({ symbol: "π", value: 3.14159 })
+
+// Unicode - Hebrew
+db.users.find({ greeting: "שלום עולם" })
+
+// Unicode - mixed scripts in single document
+db.international.insertOne({
+    english: "Hello",
+    hindi: "नमस्ते",
+    chinese: "你好",
+    japanese: "こんにちは",
+    korean: "안녕하세요",
+    arabic: "مرحبا",
+    russian: "Привет",
+    emoji: "👋🌍"
+})
+
+// Unicode - special characters and symbols
+db.math.find({ formula: "∑∏∫∂√∞" })
+db.currency.find({ symbols: "€£¥₹₽₿" })
+db.symbols.find({ arrows: "←→↑↓↔↕" })
+db.music.find({ notes: "♪♫♬♩" })
+
+// Unicode - combining characters and diacritics
+db.users.find({ name: "José García" })
+db.users.find({ name: "François Müller" })
+db.users.find({ name: "Søren Kierkegaard" })
+db.users.find({ name: "Nguyễn Văn A" })
+
+// Unicode in aggregation pipelines
+db.posts.aggregate([
+    { $match: { reaction: "👍" } },
+    { $group: { _id: "$emoji", count: { $sum: 1 } } }
+])
+
+db.international.aggregate([
+    { $project: { greeting: { $concat: ["Hello ", "$hindi", " ", "$emoji"] } } }
+])
+
+// Unicode in array values
+db.tags.find({ labels: { $in: ["重要", "紧急", "🔥"] } })
+db.posts.insertOne({ tags: ["日本語", "한국어", "中文", "हिंदी"] })
+
+// Unicode escape sequences (existing support)
+db.users.find({ escaped: "\u0048\u0065\u006C\u006C\u006F" })
+db.users.find({ mixed: "Hello \u4E16\u754C" })
+
+// Unicode in regex patterns
+db.articles.find({ title: /नमस्ते/ })
+db.products.find({ name: /^你好/ })
+
+// Unicode in index and collection names (via bracket notation)
+db["文章"].find({})
+db["статьи"].insertOne({ title: "Тест" })
+db["記事"].aggregate([{ $match: { published: true } }])


### PR DESCRIPTION
## Summary

- Copy 309 ANTLR example `.js` files from `bytebase/parser/mongodb` into `mongo/parsertest/testdata/`
- Update `antlr_compat_test.go` to use relative `testdata` path instead of hardcoded absolute path
- Tests now work without a sibling `bytebase/parser` repo checkout

## Test plan

- [x] `go test ./mongo/parsertest/ -run TestANTLR` passes (309/309 examples)
- [x] Full `go test ./mongo/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)