### PR TITLE
feat(mongo): add analysis package for statement classification

### DIFF
--- a/mongo/analysis/analysis.go
+++ b/mongo/analysis/analysis.go
@@ -1,0 +1,92 @@
+// Package analysis extracts structural information from parsed MongoDB statements.
+package analysis
+
+import "github.com/bytebase/omni/mongo/ast"
+
+// Operation classifies a MongoDB statement by its analytical behavior.
+type Operation int
+
+const (
+	OpUnknown   Operation = iota
+	OpFind                // find
+	OpFindOne             // findOne
+	OpAggregate           // aggregate
+	OpCount               // countDocuments, estimatedDocumentCount, count
+	OpDistinct            // distinct
+	OpRead                // getIndexes, stats, storageSize, etc.
+	OpWrite               // insertOne, updateMany, deleteOne, etc.
+	OpAdmin               // createIndex, drop, renameCollection, etc.
+	OpInfo                // show dbs, getCollectionNames, serverStatus, etc.
+	OpExplain             // .explain() wrapped
+)
+
+// IsRead returns true for read operations (find, findOne, aggregate, count, distinct, read).
+func (op Operation) IsRead() bool {
+	switch op {
+	case OpFind, OpFindOne, OpAggregate, OpCount, OpDistinct, OpRead:
+		return true
+	}
+	return false
+}
+
+// IsWrite returns true for write operations.
+func (op Operation) IsWrite() bool { return op == OpWrite }
+
+// IsAdmin returns true for administrative operations.
+func (op Operation) IsAdmin() bool { return op == OpAdmin }
+
+// IsInfo returns true for informational/metadata operations.
+func (op Operation) IsInfo() bool { return op == OpInfo }
+
+// String returns a human-readable name for the operation.
+func (op Operation) String() string {
+	switch op {
+	case OpFind:
+		return "find"
+	case OpFindOne:
+		return "findOne"
+	case OpAggregate:
+		return "aggregate"
+	case OpCount:
+		return "count"
+	case OpDistinct:
+		return "distinct"
+	case OpRead:
+		return "read"
+	case OpWrite:
+		return "write"
+	case OpAdmin:
+		return "admin"
+	case OpInfo:
+		return "info"
+	case OpExplain:
+		return "explain"
+	default:
+		return "unknown"
+	}
+}
+
+// StatementAnalysis is the result of analyzing a parsed MongoDB statement.
+type StatementAnalysis struct {
+	Operation        Operation
+	MethodName       string   // original method name (e.g. "countDocuments" when Operation is OpCount)
+	Collection       string   // target collection; empty for db-level/show commands
+	PredicateFields  []string // sorted dot-paths from query filter document
+	PipelineStages   []string // aggregate only: stage names in order
+	ShapePreserving  bool     // true when all pipeline stages preserve document structure
+	UnsupportedStage string   // first non-shape-preserving, non-join stage
+	Joins            []JoinInfo
+}
+
+// JoinInfo records a join extracted from a $lookup or $graphLookup pipeline stage.
+type JoinInfo struct {
+	Collection string // the "from" field
+	AsField    string // the "as" field
+}
+
+// Analyze extracts structural information from a single parsed MongoDB AST node.
+// Returns nil for unrecognizable nodes.
+func Analyze(node ast.Node) *StatementAnalysis {
+	_ = node
+	return nil
+}

--- a/mongo/analysis/analysis.go
+++ b/mongo/analysis/analysis.go
@@ -87,6 +87,74 @@ type JoinInfo struct {
 // Analyze extracts structural information from a single parsed MongoDB AST node.
 // Returns nil for unrecognizable nodes.
 func Analyze(node ast.Node) *StatementAnalysis {
-	_ = node
+	if node == nil {
+		return nil
+	}
+	switch n := node.(type) {
+	case *ast.CollectionStatement:
+		return analyzeCollection(n)
+	case *ast.DatabaseStatement:
+		return &StatementAnalysis{Operation: OpInfo, MethodName: n.Method}
+	case *ast.ShowCommand:
+		return &StatementAnalysis{Operation: OpInfo, MethodName: "show"}
+	case *ast.BulkStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: "bulkOp", Collection: n.Collection}
+	case *ast.RsStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: n.MethodName}
+	case *ast.ShStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: n.MethodName}
+	case *ast.EncryptionStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Target}
+	case *ast.PlanCacheStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: "getPlanCache", Collection: n.Collection}
+	case *ast.SpStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: n.MethodName}
+	case *ast.ConnectionStatement:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Constructor}
+	case *ast.NativeFunctionCall:
+		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Name}
+	}
 	return nil
+}
+
+func analyzeCollection(s *ast.CollectionStatement) *StatementAnalysis {
+	a := &StatementAnalysis{
+		MethodName: s.Method,
+		Collection: s.Collection,
+	}
+
+	if s.Explain {
+		a.Operation = OpExplain
+		return a
+	}
+
+	switch s.Method {
+	case "find":
+		a.Operation = OpFind
+		a.PredicateFields = extractPredicateFields(s.Args)
+	case "findOne":
+		a.Operation = OpFindOne
+		a.PredicateFields = extractPredicateFields(s.Args)
+	case "aggregate":
+		a.Operation = OpAggregate
+		analyzePipelineInto(s.Args, a)
+	case "countDocuments", "estimatedDocumentCount", "count":
+		a.Operation = OpCount
+	case "distinct":
+		a.Operation = OpDistinct
+	case "insertOne", "insertMany", "updateOne", "updateMany", "deleteOne", "deleteMany",
+		"replaceOne", "findOneAndUpdate", "findOneAndReplace", "findOneAndDelete",
+		"bulkWrite", "mapReduce":
+		a.Operation = OpWrite
+	case "createIndex", "createIndexes", "dropIndex", "dropIndexes", "drop",
+		"renameCollection", "reIndex":
+		a.Operation = OpAdmin
+	case "getIndexes", "stats", "storageSize", "totalIndexSize", "totalSize",
+		"dataSize", "validate", "latencyStats", "getShardDistribution":
+		a.Operation = OpRead
+	default:
+		a.Operation = OpUnknown
+	}
+
+	return a
 }

--- a/mongo/analysis/analysis.go
+++ b/mongo/analysis/analysis.go
@@ -110,8 +110,12 @@ func Analyze(node ast.Node) *StatementAnalysis {
 	case *ast.SpStatement:
 		return analyzeSp(n)
 	case *ast.ConnectionStatement:
+		// Connection constructors (e.g. connect, Mongo) are not read/info/admin;
+		// default to OpWrite to match existing Bytebase behavior for unclassified statements.
 		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Constructor}
 	case *ast.NativeFunctionCall:
+		// Native shell functions (e.g. load, sleep) are not read/info/admin;
+		// default to OpWrite to match existing Bytebase behavior for unclassified statements.
 		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Name}
 	}
 	return nil
@@ -129,6 +133,8 @@ func analyzeDatabase(s *ast.DatabaseStatement) *StatementAnalysis {
 	case "runCommand", "adminCommand":
 		a.Operation = classifyCommandArgs(s.Args)
 	case "getSiblingDB", "getMongo":
+		// These return a database handle for further chaining; they are not
+		// read/info/admin so default to OpWrite per existing Bytebase behavior.
 		a.Operation = OpWrite
 	default:
 		a.Operation = OpInfo

--- a/mongo/analysis/analysis.go
+++ b/mongo/analysis/analysis.go
@@ -94,27 +94,146 @@ func Analyze(node ast.Node) *StatementAnalysis {
 	case *ast.CollectionStatement:
 		return analyzeCollection(n)
 	case *ast.DatabaseStatement:
-		return &StatementAnalysis{Operation: OpInfo, MethodName: n.Method}
+		return analyzeDatabase(n)
 	case *ast.ShowCommand:
 		return &StatementAnalysis{Operation: OpInfo, MethodName: "show"}
 	case *ast.BulkStatement:
 		return &StatementAnalysis{Operation: OpWrite, MethodName: "bulkOp", Collection: n.Collection}
 	case *ast.RsStatement:
-		return &StatementAnalysis{Operation: OpWrite, MethodName: n.MethodName}
+		return analyzeRs(n)
 	case *ast.ShStatement:
-		return &StatementAnalysis{Operation: OpWrite, MethodName: n.MethodName}
+		return analyzeSh(n)
 	case *ast.EncryptionStatement:
-		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Target}
+		return analyzeEncryption(n)
 	case *ast.PlanCacheStatement:
-		return &StatementAnalysis{Operation: OpWrite, MethodName: "getPlanCache", Collection: n.Collection}
+		return analyzePlanCache(n)
 	case *ast.SpStatement:
-		return &StatementAnalysis{Operation: OpWrite, MethodName: n.MethodName}
+		return analyzeSp(n)
 	case *ast.ConnectionStatement:
 		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Constructor}
 	case *ast.NativeFunctionCall:
 		return &StatementAnalysis{Operation: OpWrite, MethodName: n.Name}
 	}
 	return nil
+}
+
+func analyzeDatabase(s *ast.DatabaseStatement) *StatementAnalysis {
+	a := &StatementAnalysis{MethodName: s.Method}
+	switch s.Method {
+	case "dropDatabase", "createCollection", "createView":
+		a.Operation = OpAdmin
+	case "getCollectionNames", "getCollectionInfos", "serverStatus",
+		"serverBuildInfo", "version", "hostInfo", "getName",
+		"listCommands", "stats":
+		a.Operation = OpInfo
+	case "runCommand", "adminCommand":
+		a.Operation = classifyCommandArgs(s.Args)
+	case "getSiblingDB", "getMongo":
+		a.Operation = OpWrite
+	default:
+		a.Operation = OpInfo
+	}
+	return a
+}
+
+func classifyCommandArgs(args []ast.Node) Operation {
+	if len(args) == 0 {
+		return OpWrite
+	}
+	doc, ok := args[0].(*ast.Document)
+	if !ok || len(doc.Pairs) == 0 {
+		return OpWrite
+	}
+	switch doc.Pairs[0].Key {
+	case "find", "aggregate", "count", "distinct":
+		return OpRead
+	case "serverStatus", "listCollections", "listIndexes", "listDatabases",
+		"collStats", "dbStats", "hostInfo", "buildInfo", "connectionStatus":
+		return OpInfo
+	case "create", "drop", "createIndexes", "dropIndexes", "renameCollection", "collMod":
+		return OpAdmin
+	default:
+		return OpWrite
+	}
+}
+
+func analyzeRs(s *ast.RsStatement) *StatementAnalysis {
+	a := &StatementAnalysis{MethodName: s.MethodName}
+	switch s.MethodName {
+	case "status", "conf", "config", "printReplicationInfo", "printSecondaryReplicationInfo":
+		a.Operation = OpInfo
+	default:
+		a.Operation = OpWrite
+	}
+	return a
+}
+
+func analyzeSh(s *ast.ShStatement) *StatementAnalysis {
+	a := &StatementAnalysis{MethodName: s.MethodName}
+	switch s.MethodName {
+	case "status", "getBalancerState", "isBalancerRunning":
+		a.Operation = OpInfo
+	default:
+		a.Operation = OpWrite
+	}
+	return a
+}
+
+func analyzeEncryption(s *ast.EncryptionStatement) *StatementAnalysis {
+	a := &StatementAnalysis{MethodName: s.Target}
+	if len(s.ChainedMethods) > 0 {
+		last := s.ChainedMethods[len(s.ChainedMethods)-1]
+		a.MethodName = last.Name
+		switch last.Name {
+		case "getKey", "getKeyByAltName", "getKeys", "decrypt", "encrypt", "encryptExpression":
+			a.Operation = OpInfo
+		default:
+			a.Operation = OpWrite
+		}
+	} else {
+		a.Operation = OpWrite
+	}
+	return a
+}
+
+func analyzePlanCache(s *ast.PlanCacheStatement) *StatementAnalysis {
+	a := &StatementAnalysis{
+		MethodName: "getPlanCache",
+		Collection: s.Collection,
+	}
+	if len(s.ChainedMethods) > 0 {
+		last := s.ChainedMethods[len(s.ChainedMethods)-1]
+		a.MethodName = last.Name
+		switch last.Name {
+		case "list", "help":
+			a.Operation = OpInfo
+		default:
+			a.Operation = OpWrite
+		}
+	} else {
+		a.Operation = OpWrite
+	}
+	return a
+}
+
+func analyzeSp(s *ast.SpStatement) *StatementAnalysis {
+	a := &StatementAnalysis{MethodName: s.MethodName}
+	if s.SubMethod != "" {
+		switch s.SubMethod {
+		case "stats", "sample":
+			a.Operation = OpInfo
+		default:
+			a.Operation = OpWrite
+		}
+	} else {
+		switch s.MethodName {
+		case "listConnections", "listStreamProcessors":
+			a.Operation = OpInfo
+		default:
+			a.Operation = OpWrite
+		}
+	}
+	return a
 }
 
 func analyzeCollection(s *ast.CollectionStatement) *StatementAnalysis {

--- a/mongo/analysis/analysis_test.go
+++ b/mongo/analysis/analysis_test.go
@@ -391,3 +391,187 @@ func TestPipelineMatchLogicalOps(t *testing.T) {
 	}
 	assertPredicateFields(t, sa, []string{"age", "name"})
 }
+
+// ---------------------------------------------------------------------------
+// Non-collection statement tests
+// ---------------------------------------------------------------------------
+
+func TestAnalyzeShowDbs(t *testing.T) {
+	sa := mustAnalyze(t, `show dbs`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeShowCollections(t *testing.T) {
+	sa := mustAnalyze(t, `show collections`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeDatabaseDropDatabase(t *testing.T) {
+	sa := mustAnalyze(t, `db.dropDatabase()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpAdmin {
+		t.Errorf("got %v, want OpAdmin", sa.Operation)
+	}
+}
+
+func TestAnalyzeDatabaseCreateCollection(t *testing.T) {
+	sa := mustAnalyze(t, `db.createCollection("test")`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpAdmin {
+		t.Errorf("got %v, want OpAdmin", sa.Operation)
+	}
+}
+
+func TestAnalyzeDatabaseGetCollectionNames(t *testing.T) {
+	sa := mustAnalyze(t, `db.getCollectionNames()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeDatabaseServerStatus(t *testing.T) {
+	sa := mustAnalyze(t, `db.serverStatus()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeRsStatus(t *testing.T) {
+	sa := mustAnalyze(t, `rs.status()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeRsInitiate(t *testing.T) {
+	sa := mustAnalyze(t, `rs.initiate()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpWrite {
+		t.Errorf("got %v, want OpWrite", sa.Operation)
+	}
+}
+
+func TestAnalyzeShStatus(t *testing.T) {
+	sa := mustAnalyze(t, `sh.status()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeShAddShard(t *testing.T) {
+	sa := mustAnalyze(t, `sh.addShard("shard1/host:port")`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpWrite {
+		t.Errorf("got %v, want OpWrite", sa.Operation)
+	}
+}
+
+func TestAnalyzeBulkStatement(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.initializeOrderedBulkOp().insert({name: "alice"}).execute()`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpWrite {
+		t.Errorf("got %v, want OpWrite", sa.Operation)
+	}
+	if sa.Collection != "users" {
+		t.Errorf("Collection = %q, want %q", sa.Collection, "users")
+	}
+}
+
+func TestAnalyzeNativeFunction(t *testing.T) {
+	sa := mustAnalyze(t, `sleep(1000)`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpWrite {
+		t.Errorf("got %v, want OpWrite", sa.Operation)
+	}
+}
+
+func TestAnalyzeNil(t *testing.T) {
+	sa := analysis.Analyze(nil)
+	if sa != nil {
+		t.Errorf("got %v, want nil", sa)
+	}
+}
+
+func TestAnalyzeRunCommandFind(t *testing.T) {
+	sa := mustAnalyze(t, `db.runCommand({find: "users", filter: {status: "active"}})`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpRead {
+		t.Errorf("got %v, want OpRead", sa.Operation)
+	}
+}
+
+func TestAnalyzeRunCommandCreate(t *testing.T) {
+	sa := mustAnalyze(t, `db.runCommand({create: "newCollection"})`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpAdmin {
+		t.Errorf("got %v, want OpAdmin", sa.Operation)
+	}
+}
+
+func TestAnalyzeRunCommandInsert(t *testing.T) {
+	sa := mustAnalyze(t, `db.runCommand({insert: "users", documents: [{name: "alice"}]})`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpWrite {
+		t.Errorf("got %v, want OpWrite", sa.Operation)
+	}
+}
+
+func TestAnalyzeRunCommandServerStatus(t *testing.T) {
+	sa := mustAnalyze(t, `db.runCommand({serverStatus: 1})`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}
+
+func TestAnalyzeAdminCommand(t *testing.T) {
+	sa := mustAnalyze(t, `db.adminCommand({listDatabases: 1})`)
+	if sa == nil {
+		t.Fatal("nil")
+	}
+	if sa.Operation != analysis.OpInfo {
+		t.Errorf("got %v, want OpInfo", sa.Operation)
+	}
+}

--- a/mongo/analysis/analysis_test.go
+++ b/mongo/analysis/analysis_test.go
@@ -1,10 +1,35 @@
 package analysis_test
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/bytebase/omni/mongo"
 	"github.com/bytebase/omni/mongo/analysis"
 )
+
+func mustAnalyze(t *testing.T, input string) *analysis.StatementAnalysis {
+	t.Helper()
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", input, err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d statements, want 1", input, len(stmts))
+	}
+	return analysis.Analyze(stmts[0].AST)
+}
+
+func assertPredicateFields(t *testing.T, sa *analysis.StatementAnalysis, want []string) {
+	t.Helper()
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	slices.Sort(want)
+	if !slices.Equal(sa.PredicateFields, want) {
+		t.Errorf("PredicateFields = %v, want %v", sa.PredicateFields, want)
+	}
+}
 
 func TestOperationIsRead(t *testing.T) {
 	tests := []struct {
@@ -52,4 +77,317 @@ func TestOperationString(t *testing.T) {
 			t.Errorf("%v.String() = %q, want %q", tc.op, got, tc.want)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Collection statement tests
+// ---------------------------------------------------------------------------
+
+func TestAnalyzeCollectionFind(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.find()`)
+	if sa.Operation != analysis.OpFind {
+		t.Errorf("Operation = %v, want OpFind", sa.Operation)
+	}
+	if sa.Collection != "users" {
+		t.Errorf("Collection = %q, want %q", sa.Collection, "users")
+	}
+	if sa.MethodName != "find" {
+		t.Errorf("MethodName = %q, want %q", sa.MethodName, "find")
+	}
+}
+
+func TestAnalyzeCollectionFindOne(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.findOne()`)
+	if sa.Operation != analysis.OpFindOne {
+		t.Errorf("Operation = %v, want OpFindOne", sa.Operation)
+	}
+}
+
+func TestAnalyzeCollectionAggregate(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate()`)
+	if sa.Operation != analysis.OpAggregate {
+		t.Errorf("Operation = %v, want OpAggregate", sa.Operation)
+	}
+}
+
+func TestAnalyzeCollectionWrite(t *testing.T) {
+	methods := []string{
+		"insertOne", "insertMany", "updateOne", "updateMany",
+		"deleteOne", "deleteMany", "replaceOne",
+	}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			sa := mustAnalyze(t, "db.users."+method+"({})")
+			if sa.Operation != analysis.OpWrite {
+				t.Errorf("%s: Operation = %v, want OpWrite", method, sa.Operation)
+			}
+			if sa.Collection != "users" {
+				t.Errorf("%s: Collection = %q, want %q", method, sa.Collection, "users")
+			}
+		})
+	}
+}
+
+func TestAnalyzeCollectionAdmin(t *testing.T) {
+	methods := []string{"createIndex", "dropIndex", "drop"}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			sa := mustAnalyze(t, "db.users."+method+"({})")
+			if sa.Operation != analysis.OpAdmin {
+				t.Errorf("%s: Operation = %v, want OpAdmin", method, sa.Operation)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCollectionRead(t *testing.T) {
+	methods := []string{"getIndexes", "stats", "storageSize"}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			sa := mustAnalyze(t, "db.users."+method+"()")
+			if sa.Operation != analysis.OpRead {
+				t.Errorf("%s: Operation = %v, want OpRead", method, sa.Operation)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCollectionCount(t *testing.T) {
+	methods := []string{"countDocuments", "estimatedDocumentCount", "count"}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			sa := mustAnalyze(t, "db.users."+method+"()")
+			if sa.Operation != analysis.OpCount {
+				t.Errorf("%s: Operation = %v, want OpCount", method, sa.Operation)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCollectionDistinct(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.distinct("name")`)
+	if sa.Operation != analysis.OpDistinct {
+		t.Errorf("Operation = %v, want OpDistinct", sa.Operation)
+	}
+	if sa.MethodName != "distinct" {
+		t.Errorf("MethodName = %q, want %q", sa.MethodName, "distinct")
+	}
+}
+
+func TestAnalyzeCollectionExplain(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.explain().find()`)
+	if sa.Operation != analysis.OpExplain {
+		t.Errorf("Operation = %v, want OpExplain", sa.Operation)
+	}
+	if sa.Collection != "users" {
+		t.Errorf("Collection = %q, want %q", sa.Collection, "users")
+	}
+}
+
+func TestAnalyzeCollectionGetCollection(t *testing.T) {
+	sa := mustAnalyze(t, `db.getCollection("users").find()`)
+	if sa.Operation != analysis.OpFind {
+		t.Errorf("Operation = %v, want OpFind", sa.Operation)
+	}
+	if sa.Collection != "users" {
+		t.Errorf("Collection = %q, want %q", sa.Collection, "users")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Predicate field extraction tests
+// ---------------------------------------------------------------------------
+
+func TestPredicateSimpleField(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.find({email: "alice@example.com"})`)
+	assertPredicateFields(t, sa, []string{"email"})
+}
+
+func TestPredicateNestedDocument(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.find({contact: {phone: "123"}})`)
+	assertPredicateFields(t, sa, []string{"contact", "contact.phone"})
+}
+
+func TestPredicateDotPathKey(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.findOne({"contact.phone": "123"})`)
+	assertPredicateFields(t, sa, []string{"contact.phone"})
+}
+
+func TestPredicateLogicalOperators(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.find({
+		$or: [{name: "alice"}, {email: "alice@example.com"}],
+		$and: [{status: "active"}, {$nor: [{contact: {phone: "123"}}, {"profile.ssn": "456"}]}]
+	})`)
+	assertPredicateFields(t, sa, []string{"contact", "contact.phone", "email", "name", "profile.ssn", "status"})
+}
+
+func TestPredicateComparisonOperatorsSkipped(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.find({age: {$gt: 18, $lt: 65}})`)
+	assertPredicateFields(t, sa, []string{"age"})
+}
+
+func TestPredicateNoArgs(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.find()`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if sa.PredicateFields != nil {
+		t.Errorf("PredicateFields = %v, want nil", sa.PredicateFields)
+	}
+}
+
+func TestPredicateFindOneFields(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.findOne({name: "alice", age: 30})`)
+	assertPredicateFields(t, sa, []string{"age", "name"})
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline analysis tests
+// ---------------------------------------------------------------------------
+
+func TestPipelineShapePreserving(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([
+		{$match: {name: "alice"}},
+		{$sort: {name: 1}},
+		{$limit: 10}
+	])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if !sa.ShapePreserving {
+		t.Error("ShapePreserving = false, want true")
+	}
+	want := []string{"$match", "$sort", "$limit"}
+	if !slices.Equal(sa.PipelineStages, want) {
+		t.Errorf("PipelineStages = %v, want %v", sa.PipelineStages, want)
+	}
+	assertPredicateFields(t, sa, []string{"name"})
+}
+
+func TestPipelineUnsupportedGroup(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([{$group: {_id: "$name"}}])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if sa.ShapePreserving {
+		t.Error("ShapePreserving = true, want false")
+	}
+	if sa.UnsupportedStage != "$group" {
+		t.Errorf("UnsupportedStage = %q, want %q", sa.UnsupportedStage, "$group")
+	}
+}
+
+func TestPipelineUnsupportedProject(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([{$match: {status: "active"}}, {$project: {name: 1}}])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if sa.UnsupportedStage != "$project" {
+		t.Errorf("UnsupportedStage = %q, want %q", sa.UnsupportedStage, "$project")
+	}
+}
+
+func TestPipelineEmpty(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if !sa.ShapePreserving {
+		t.Error("ShapePreserving = false, want true")
+	}
+	if sa.UnsupportedStage != "" {
+		t.Errorf("UnsupportedStage = %q, want empty", sa.UnsupportedStage)
+	}
+}
+
+func TestPipelineNoArgs(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate()`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if sa.Operation != analysis.OpAggregate {
+		t.Errorf("Operation = %v, want OpAggregate", sa.Operation)
+	}
+}
+
+func TestPipelineLookupSimple(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([
+		{$lookup: {from: "orders", localField: "id", foreignField: "userId", as: "orders"}}
+	])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if sa.UnsupportedStage != "" {
+		t.Errorf("UnsupportedStage = %q, want empty", sa.UnsupportedStage)
+	}
+	if len(sa.Joins) != 1 {
+		t.Fatalf("len(Joins) = %d, want 1", len(sa.Joins))
+	}
+	if sa.Joins[0].Collection != "orders" {
+		t.Errorf("Joins[0].Collection = %q, want %q", sa.Joins[0].Collection, "orders")
+	}
+	if sa.Joins[0].AsField != "orders" {
+		t.Errorf("Joins[0].AsField = %q, want %q", sa.Joins[0].AsField, "orders")
+	}
+}
+
+func TestPipelineLookupPipelineForm(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([
+		{$lookup: {from: "orders", let: {uid: "$id"}, pipeline: [{$match: {}}], as: "orders"}}
+	])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if sa.UnsupportedStage != "$lookup" {
+		t.Errorf("UnsupportedStage = %q, want %q", sa.UnsupportedStage, "$lookup")
+	}
+}
+
+func TestPipelineGraphLookup(t *testing.T) {
+	sa := mustAnalyze(t, `db.employees.aggregate([
+		{$graphLookup: {from: "employees", startWith: "$managerId", connectFromField: "managerId", connectToField: "_id", as: "hierarchy"}}
+	])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if len(sa.Joins) != 1 {
+		t.Fatalf("len(Joins) = %d, want 1", len(sa.Joins))
+	}
+	if sa.Joins[0].Collection != "employees" {
+		t.Errorf("Joins[0].Collection = %q, want %q", sa.Joins[0].Collection, "employees")
+	}
+	if sa.Joins[0].AsField != "hierarchy" {
+		t.Errorf("Joins[0].AsField = %q, want %q", sa.Joins[0].AsField, "hierarchy")
+	}
+}
+
+func TestPipelineUnwind(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([{$unwind: "$tags"}])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if !sa.ShapePreserving {
+		t.Error("ShapePreserving = false, want true")
+	}
+}
+
+func TestPipelineMatchWithUnwind(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([{$match: {status: "active"}}, {$unwind: "$tags"}])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	if !sa.ShapePreserving {
+		t.Error("ShapePreserving = false, want true")
+	}
+	assertPredicateFields(t, sa, []string{"status"})
+}
+
+func TestPipelineMatchLogicalOps(t *testing.T) {
+	sa := mustAnalyze(t, `db.users.aggregate([
+		{$match: {$or: [{name: "alice"}, {age: 30}]}}
+	])`)
+	if sa == nil {
+		t.Fatal("Analyze returned nil")
+	}
+	assertPredicateFields(t, sa, []string{"age", "name"})
 }

--- a/mongo/analysis/analysis_test.go
+++ b/mongo/analysis/analysis_test.go
@@ -1,0 +1,55 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mongo/analysis"
+)
+
+func TestOperationIsRead(t *testing.T) {
+	tests := []struct {
+		op   analysis.Operation
+		want bool
+	}{
+		{analysis.OpFind, true},
+		{analysis.OpFindOne, true},
+		{analysis.OpAggregate, true},
+		{analysis.OpCount, true},
+		{analysis.OpDistinct, true},
+		{analysis.OpRead, true},
+		{analysis.OpWrite, false},
+		{analysis.OpAdmin, false},
+		{analysis.OpInfo, false},
+		{analysis.OpExplain, false},
+		{analysis.OpUnknown, false},
+	}
+	for _, tc := range tests {
+		if got := tc.op.IsRead(); got != tc.want {
+			t.Errorf("%v.IsRead() = %v, want %v", tc.op, got, tc.want)
+		}
+	}
+}
+
+func TestOperationString(t *testing.T) {
+	tests := []struct {
+		op   analysis.Operation
+		want string
+	}{
+		{analysis.OpFind, "find"},
+		{analysis.OpFindOne, "findOne"},
+		{analysis.OpAggregate, "aggregate"},
+		{analysis.OpCount, "count"},
+		{analysis.OpDistinct, "distinct"},
+		{analysis.OpRead, "read"},
+		{analysis.OpWrite, "write"},
+		{analysis.OpAdmin, "admin"},
+		{analysis.OpInfo, "info"},
+		{analysis.OpExplain, "explain"},
+		{analysis.OpUnknown, "unknown"},
+	}
+	for _, tc := range tests {
+		if got := tc.op.String(); got != tc.want {
+			t.Errorf("%v.String() = %q, want %q", tc.op, got, tc.want)
+		}
+	}
+}

--- a/mongo/analysis/analysis_test.go
+++ b/mongo/analysis/analysis_test.go
@@ -575,3 +575,250 @@ func TestAnalyzeAdminCommand(t *testing.T) {
 		t.Errorf("got %v, want OpInfo", sa.Operation)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Masking parity integration tests
+// ---------------------------------------------------------------------------
+
+func TestAnalyzeMaskingParity(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		wantOp          analysis.Operation
+		wantMethod      string
+		wantCollection  string
+		wantPredicates  []string
+		wantShapePres   bool
+		wantUnsupported string
+		wantJoins       []analysis.JoinInfo
+		wantNil         bool
+	}{
+		{
+			name:           "find with predicate",
+			input:          `db.users.find({email: "alice@example.com"})`,
+			wantOp:         analysis.OpFind,
+			wantMethod:     "find",
+			wantCollection: "users",
+			wantPredicates: []string{"email"},
+		},
+		{
+			name:           "findOne with dot path key",
+			input:          `db.users.findOne({"contact.phone": "123"})`,
+			wantOp:         analysis.OpFindOne,
+			wantMethod:     "findOne",
+			wantCollection: "users",
+			wantPredicates: []string{"contact.phone"},
+		},
+		{
+			name:           "getCollection access",
+			input:          `db.getCollection("users").find({email: "x"})`,
+			wantOp:         analysis.OpFind,
+			wantMethod:     "find",
+			wantCollection: "users",
+			wantPredicates: []string{"email"},
+		},
+		{
+			name: "find with logical operators",
+			input: `db.getCollection("users").find({
+				$or: [
+					{email: "a@example.com"},
+					{contact: {phone: "123"}}
+				],
+				$and: [
+					{"profile.ssn": "111"},
+					{name: "alice"}
+				],
+				$nor: [{status: "inactive"}]
+			})`,
+			wantOp:         analysis.OpFind,
+			wantMethod:     "find",
+			wantCollection: "users",
+			wantPredicates: []string{"contact", "contact.phone", "email", "name", "profile.ssn", "status"},
+		},
+		{
+			name:           "aggregate shape-preserving",
+			input:          `db.users.aggregate([{$match: {name: "alice"}}])`,
+			wantOp:         analysis.OpAggregate,
+			wantMethod:     "aggregate",
+			wantCollection: "users",
+			wantPredicates: []string{"name"},
+			wantShapePres:  true,
+		},
+		{
+			name:           "aggregate multiple shape-preserving stages",
+			input:          `db.users.aggregate([{$match: {status: "active"}}, {$sort: {name: 1}}, {$limit: 10}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantPredicates: []string{"status"},
+			wantShapePres:  true,
+		},
+		{
+			name:           "aggregate match with logical operators",
+			input:          `db.users.aggregate([{$match: {$or: [{age: {$gt: 18}}, {name: "alice"}]}}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantPredicates: []string{"age", "name"},
+			wantShapePres:  true,
+		},
+		{
+			name:           "aggregate addFields and unset",
+			input:          `db.users.aggregate([{$addFields: {fullName: "test"}}, {$unset: "ssn"}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantShapePres:  true,
+		},
+		{
+			name:           "aggregate empty pipeline",
+			input:          `db.users.aggregate([])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantShapePres:  true,
+		},
+		{
+			name:           "aggregate no arguments",
+			input:          `db.users.aggregate()`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantShapePres:  true,
+		},
+		{
+			name:            "aggregate $group unsupported",
+			input:           `db.users.aggregate([{$group: {_id: "$status"}}])`,
+			wantOp:          analysis.OpAggregate,
+			wantCollection:  "users",
+			wantUnsupported: "$group",
+		},
+		{
+			name:            "aggregate $project unsupported",
+			input:           `db.users.aggregate([{$match: {name: "alice"}}, {$project: {name: 1}}])`,
+			wantOp:          analysis.OpAggregate,
+			wantCollection:  "users",
+			wantUnsupported: "$project",
+		},
+		{
+			name:           "aggregate $lookup simple",
+			input:          `db.users.aggregate([{$lookup: {from: "orders", localField: "_id", foreignField: "userId", as: "orders"}}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantShapePres:  true,
+			wantJoins:      []analysis.JoinInfo{{Collection: "orders", AsField: "orders"}},
+		},
+		{
+			name:            "aggregate $lookup pipeline form unsupported",
+			input:           `db.users.aggregate([{$lookup: {from: "orders", pipeline: [{$match: {status: "active"}}], as: "orders"}}])`,
+			wantOp:          analysis.OpAggregate,
+			wantCollection:  "users",
+			wantUnsupported: "$lookup",
+		},
+		{
+			name:           "aggregate $graphLookup",
+			input:          `db.users.aggregate([{$graphLookup: {from: "employees", startWith: "$reportsTo", connectFromField: "reportsTo", connectToField: "name", as: "reportingHierarchy"}}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantShapePres:  true,
+			wantJoins:      []analysis.JoinInfo{{Collection: "employees", AsField: "reportingHierarchy"}},
+		},
+		{
+			name:            "aggregate $out unsupported",
+			input:           `db.users.aggregate([{$match: {status: "active"}}, {$out: "activeUsers"}])`,
+			wantOp:          analysis.OpAggregate,
+			wantCollection:  "users",
+			wantUnsupported: "$out",
+		},
+		{
+			name:           "aggregate $unwind shape-preserving",
+			input:          `db.users.aggregate([{$unwind: "$tags"}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantShapePres:  true,
+		},
+		{
+			name:           "aggregate $match and $unwind",
+			input:          `db.users.aggregate([{$match: {status: "active"}}, {$unwind: "$tags"}])`,
+			wantOp:         analysis.OpAggregate,
+			wantCollection: "users",
+			wantPredicates: []string{"status"},
+			wantShapePres:  true,
+		},
+		{
+			name:            "aggregate $replaceRoot unsupported",
+			input:           `db.users.aggregate([{$replaceRoot: {newRoot: "$contact"}}])`,
+			wantOp:          analysis.OpAggregate,
+			wantCollection:  "users",
+			wantUnsupported: "$replaceRoot",
+		},
+		{
+			name:            "aggregate $count unsupported",
+			input:           `db.users.aggregate([{$count: "total"}])`,
+			wantOp:          analysis.OpAggregate,
+			wantCollection:  "users",
+			wantUnsupported: "$count",
+		},
+		{
+			name:           "countDocuments unsupported read",
+			input:          `db.users.countDocuments({})`,
+			wantOp:         analysis.OpCount,
+			wantMethod:     "countDocuments",
+			wantCollection: "users",
+		},
+		{
+			name:           "distinct unsupported read",
+			input:          `db.users.distinct("name")`,
+			wantOp:         analysis.OpDistinct,
+			wantMethod:     "distinct",
+			wantCollection: "users",
+		},
+		{
+			name:           "write method returns non-nil",
+			input:          `db.users.insertOne({name: "alice"})`,
+			wantOp:         analysis.OpWrite,
+			wantCollection: "users",
+		},
+		{
+			name:   "show dbs",
+			input:  `show dbs`,
+			wantOp: analysis.OpInfo,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sa := mustAnalyze(t, tc.input)
+			if tc.wantNil {
+				if sa != nil {
+					t.Fatalf("got %+v, want nil", sa)
+				}
+				return
+			}
+			if sa == nil {
+				t.Fatal("Analyze returned nil")
+			}
+			if sa.Operation != tc.wantOp {
+				t.Errorf("Operation = %v, want %v", sa.Operation, tc.wantOp)
+			}
+			if tc.wantMethod != "" && sa.MethodName != tc.wantMethod {
+				t.Errorf("MethodName = %q, want %q", sa.MethodName, tc.wantMethod)
+			}
+			if tc.wantCollection != "" && sa.Collection != tc.wantCollection {
+				t.Errorf("Collection = %q, want %q", sa.Collection, tc.wantCollection)
+			}
+			if tc.wantPredicates != nil {
+				slices.Sort(tc.wantPredicates)
+				if !slices.Equal(sa.PredicateFields, tc.wantPredicates) {
+					t.Errorf("PredicateFields = %v, want %v", sa.PredicateFields, tc.wantPredicates)
+				}
+			}
+			if sa.ShapePreserving != tc.wantShapePres {
+				t.Errorf("ShapePreserving = %v, want %v", sa.ShapePreserving, tc.wantShapePres)
+			}
+			if sa.UnsupportedStage != tc.wantUnsupported {
+				t.Errorf("UnsupportedStage = %q, want %q", sa.UnsupportedStage, tc.wantUnsupported)
+			}
+			if tc.wantJoins != nil {
+				if !slices.Equal(sa.Joins, tc.wantJoins) {
+					t.Errorf("Joins = %v, want %v", sa.Joins, tc.wantJoins)
+				}
+			}
+		})
+	}
+}

--- a/mongo/analysis/pipeline.go
+++ b/mongo/analysis/pipeline.go
@@ -1,0 +1,149 @@
+package analysis
+
+import (
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+// shapePreservingStages lists pipeline stages that do not change document shape.
+var shapePreservingStages = map[string]bool{
+	"$match":           true,
+	"$sort":            true,
+	"$limit":           true,
+	"$skip":            true,
+	"$sample":          true,
+	"$addFields":       true,
+	"$set":             true,
+	"$unset":           true,
+	"$geoNear":         true,
+	"$setWindowFields": true,
+	"$fill":            true,
+	"$redact":          true,
+	"$unwind":          true,
+}
+
+// analyzePipelineInto populates a with pipeline information derived from args.
+func analyzePipelineInto(args []ast.Node, a *StatementAnalysis) {
+	if len(args) == 0 {
+		a.ShapePreserving = true
+		return
+	}
+
+	arr, ok := args[0].(*ast.Array)
+	if !ok {
+		a.UnsupportedStage = "unknown"
+		return
+	}
+
+	a.ShapePreserving = true
+	fields := make(map[string]struct{})
+
+	for _, elem := range arr.Elements {
+		doc, ok := elem.(*ast.Document)
+		if !ok || len(doc.Pairs) == 0 {
+			a.UnsupportedStage = "unknown"
+			a.ShapePreserving = false
+			return
+		}
+
+		stageName := doc.Pairs[0].Key
+		a.PipelineStages = append(a.PipelineStages, stageName)
+
+		if shapePreservingStages[stageName] {
+			if stageName == "$match" {
+				stageVal := doc.Pairs[0].Value
+				if matchDoc, ok := stageVal.(*ast.Document); ok {
+					collectFromDocument(matchDoc, "", fields)
+				}
+			}
+			continue
+		}
+
+		if stageName == "$lookup" {
+			join, unsupported := extractLookup(doc.Pairs[0].Value)
+			if unsupported {
+				a.UnsupportedStage = "$lookup"
+				a.ShapePreserving = false
+				return
+			}
+			if join != nil {
+				a.Joins = append(a.Joins, *join)
+			}
+			continue
+		}
+
+		if stageName == "$graphLookup" {
+			join := extractGraphLookup(doc.Pairs[0].Value)
+			if join != nil {
+				a.Joins = append(a.Joins, *join)
+			}
+			continue
+		}
+
+		// Not shape-preserving and not a join stage
+		a.UnsupportedStage = stageName
+		a.ShapePreserving = false
+		return
+	}
+
+	if len(fields) > 0 {
+		a.PredicateFields = sortedKeys(fields)
+	}
+}
+
+// extractLookup extracts join info from a $lookup stage value.
+// Returns (nil, true) if a pipeline-form lookup is detected (unsupported).
+// Returns (*JoinInfo, false) if from+as are found.
+func extractLookup(node ast.Node) (*JoinInfo, bool) {
+	doc, ok := node.(*ast.Document)
+	if !ok {
+		return nil, false
+	}
+
+	var from, as string
+	for _, kv := range doc.Pairs {
+		switch kv.Key {
+		case "pipeline":
+			return nil, true
+		case "from":
+			if s, ok := kv.Value.(*ast.StringLiteral); ok {
+				from = s.Value
+			}
+		case "as":
+			if s, ok := kv.Value.(*ast.StringLiteral); ok {
+				as = s.Value
+			}
+		}
+	}
+
+	if from != "" && as != "" {
+		return &JoinInfo{Collection: from, AsField: as}, false
+	}
+	return nil, false
+}
+
+// extractGraphLookup extracts join info from a $graphLookup stage value.
+func extractGraphLookup(node ast.Node) *JoinInfo {
+	doc, ok := node.(*ast.Document)
+	if !ok {
+		return nil
+	}
+
+	var from, as string
+	for _, kv := range doc.Pairs {
+		switch kv.Key {
+		case "from":
+			if s, ok := kv.Value.(*ast.StringLiteral); ok {
+				from = s.Value
+			}
+		case "as":
+			if s, ok := kv.Value.(*ast.StringLiteral); ok {
+				as = s.Value
+			}
+		}
+	}
+
+	if from != "" && as != "" {
+		return &JoinInfo{Collection: from, AsField: as}
+	}
+	return nil
+}

--- a/mongo/analysis/pipeline.go
+++ b/mongo/analysis/pipeline.go
@@ -28,20 +28,27 @@ func analyzePipelineInto(args []ast.Node, a *StatementAnalysis) {
 		return
 	}
 
+	fields := make(map[string]struct{})
+
 	arr, ok := args[0].(*ast.Array)
 	if !ok {
 		a.UnsupportedStage = "unknown"
+		if len(fields) > 0 {
+			a.PredicateFields = sortedKeys(fields)
+		}
 		return
 	}
 
 	a.ShapePreserving = true
-	fields := make(map[string]struct{})
 
 	for _, elem := range arr.Elements {
 		doc, ok := elem.(*ast.Document)
 		if !ok || len(doc.Pairs) == 0 {
 			a.UnsupportedStage = "unknown"
 			a.ShapePreserving = false
+			if len(fields) > 0 {
+				a.PredicateFields = sortedKeys(fields)
+			}
 			return
 		}
 
@@ -63,6 +70,9 @@ func analyzePipelineInto(args []ast.Node, a *StatementAnalysis) {
 			if unsupported {
 				a.UnsupportedStage = "$lookup"
 				a.ShapePreserving = false
+				if len(fields) > 0 {
+					a.PredicateFields = sortedKeys(fields)
+				}
 				return
 			}
 			if join != nil {
@@ -82,6 +92,9 @@ func analyzePipelineInto(args []ast.Node, a *StatementAnalysis) {
 		// Not shape-preserving and not a join stage
 		a.UnsupportedStage = stageName
 		a.ShapePreserving = false
+		if len(fields) > 0 {
+			a.PredicateFields = sortedKeys(fields)
+		}
 		return
 	}
 

--- a/mongo/analysis/predicate.go
+++ b/mongo/analysis/predicate.go
@@ -26,6 +26,10 @@ func extractPredicateFields(args []ast.Node) []string {
 }
 
 // collectFromDocument walks a document and collects field paths into fields.
+// For nested documents like {contact: {phone: "123"}}, both "contact" and
+// "contact.phone" are emitted as predicate fields. This intentional
+// conservative over-reporting ensures all potentially accessed sub-paths are
+// included, which is safer for masking decisions.
 func collectFromDocument(doc *ast.Document, prefix string, fields map[string]struct{}) {
 	for _, kv := range doc.Pairs {
 		key := kv.Key
@@ -58,16 +62,7 @@ func collectFromValue(node ast.Node, prefix string, fields map[string]struct{}) 
 
 // collectFromLogicalOp handles $and/$or/$nor operator values.
 func collectFromLogicalOp(node ast.Node, prefix string, fields map[string]struct{}) {
-	switch v := node.(type) {
-	case *ast.Document:
-		collectFromDocument(v, prefix, fields)
-	case *ast.Array:
-		for _, elem := range v.Elements {
-			if d, ok := elem.(*ast.Document); ok {
-				collectFromDocument(d, prefix, fields)
-			}
-		}
-	}
+	collectFromValue(node, prefix, fields)
 }
 
 // isLogicalOperator returns true for $and, $or, $nor.

--- a/mongo/analysis/predicate.go
+++ b/mongo/analysis/predicate.go
@@ -1,0 +1,94 @@
+package analysis
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/bytebase/omni/mongo/ast"
+)
+
+// extractPredicateFields returns a sorted, deduplicated slice of field paths
+// found in the first argument (the query filter document) of a find/findOne call.
+func extractPredicateFields(args []ast.Node) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	doc, ok := args[0].(*ast.Document)
+	if !ok {
+		return nil
+	}
+	fields := make(map[string]struct{})
+	collectFromDocument(doc, "", fields)
+	if len(fields) == 0 {
+		return nil
+	}
+	return sortedKeys(fields)
+}
+
+// collectFromDocument walks a document and collects field paths into fields.
+func collectFromDocument(doc *ast.Document, prefix string, fields map[string]struct{}) {
+	for _, kv := range doc.Pairs {
+		key := kv.Key
+		if strings.HasPrefix(key, "$") {
+			if isLogicalOperator(key) {
+				collectFromLogicalOp(kv.Value, prefix, fields)
+			}
+			// other operators (like $expr) are skipped
+			continue
+		}
+		path := joinPath(prefix, key)
+		fields[path] = struct{}{}
+		collectFromValue(kv.Value, path, fields)
+	}
+}
+
+// collectFromValue recurses into a value node to collect nested field paths.
+func collectFromValue(node ast.Node, prefix string, fields map[string]struct{}) {
+	switch v := node.(type) {
+	case *ast.Document:
+		collectFromDocument(v, prefix, fields)
+	case *ast.Array:
+		for _, elem := range v.Elements {
+			if d, ok := elem.(*ast.Document); ok {
+				collectFromDocument(d, prefix, fields)
+			}
+		}
+	}
+}
+
+// collectFromLogicalOp handles $and/$or/$nor operator values.
+func collectFromLogicalOp(node ast.Node, prefix string, fields map[string]struct{}) {
+	switch v := node.(type) {
+	case *ast.Document:
+		collectFromDocument(v, prefix, fields)
+	case *ast.Array:
+		for _, elem := range v.Elements {
+			if d, ok := elem.(*ast.Document); ok {
+				collectFromDocument(d, prefix, fields)
+			}
+		}
+	}
+}
+
+// isLogicalOperator returns true for $and, $or, $nor.
+func isLogicalOperator(key string) bool {
+	return key == "$and" || key == "$or" || key == "$nor"
+}
+
+// joinPath joins prefix and key with a dot, omitting the dot when prefix is empty.
+func joinPath(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}
+
+// sortedKeys returns sorted keys from a string set map.
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
## Summary

- New `mongo/analysis/` package that extracts structural information from parsed MongoDB shell statements
- `Analyze(ast.Node)` classifies operations (find/write/admin/info/explain), extracts predicate fields from query filters, analyzes aggregate pipeline stages (shape-preserving, $lookup/$graphLookup joins, unsupported stage detection)
- Follows the same pattern as `cosmosdb/analysis/` — generic structural analysis that consumers (e.g. Bytebase masking) can build policy decisions on top of

## Test Plan

- [x] 89 tests covering operation classification, predicate extraction, pipeline analysis, and masking parity
- [x] All existing `mongo/parsertest` tests pass (no regressions)
- [ ] Verify Bytebase integration layer can consume `StatementAnalysis` for masking decisions