### PR TITLE
fix(pg/catalog): accept standalone unique index as FK referential target

### DIFF
--- a/pg/catalog/constraint.go
+++ b/pg/catalog/constraint.go
@@ -217,8 +217,12 @@ func (c *Catalog) addFKConstraint(schema *Schema, rel *Relation, def ConstraintD
 		}
 	}
 
-	// Verify PK/UNIQUE constraint on referenced columns.
-	if c.lookupUniqueConstraint(refRel.OID, refAttnums) == nil {
+	// Verify PK/UNIQUE constraint or non-partial unique index on referenced columns.
+	// pg: src/backend/commands/tablecmds.c — transformFkeyCheckAttrs
+	// PostgreSQL accepts a unique index as a FK referential target even when
+	// no explicit UNIQUE constraint exists. pg_dump relies on this and emits
+	// CREATE UNIQUE INDEX as a separate statement after CREATE TABLE.
+	if c.lookupFKSupportingIndex(refRel.OID, refAttnums) == 0 {
 		return errInvalidFK(fmt.Sprintf("there is no unique constraint matching given keys for referenced table %q", def.RefTable))
 	}
 
@@ -312,9 +316,8 @@ func (c *Catalog) addFKConstraint(schema *Schema, rel *Relation, def ConstraintD
 
 	// FK depends on the supporting unique/PK index of the referenced table.
 	// pg: src/backend/commands/tablecmds.c — ATAddForeignKeyConstraint
-	refCon := c.lookupUniqueConstraint(refRel.OID, refAttnums)
-	if refCon != nil && refCon.IndexOID != 0 {
-		c.recordDependency('c', con.OID, 0, 'r', refCon.IndexOID, 0, DepNormal)
+	if refIdxOID := c.lookupFKSupportingIndex(refRel.OID, refAttnums); refIdxOID != 0 {
+		c.recordDependency('c', con.OID, 0, 'r', refIdxOID, 0, DepNormal)
 	}
 
 	return nil
@@ -595,6 +598,70 @@ func (c *Catalog) lookupUniqueConstraint(relOID uint32, cols []int16) *Constrain
 		}
 	}
 	return nil
+}
+
+// lookupFKSupportingIndex finds an index suitable to back a foreign-key
+// reference to (relOID, cols). It returns the index OID, or 0 if none qualifies.
+//
+// Resolution order:
+//  1. A PK or explicit UNIQUE constraint over exactly the referenced columns —
+//     the constraint's backing index OID is returned.
+//  2. A standalone unique index over exactly the referenced columns. PostgreSQL
+//     accepts a unique index as a FK target if it is unique, non-partial,
+//     contains no expression key columns, and has no INCLUDE columns. pg_dump
+//     relies on this when it emits CREATE UNIQUE INDEX as a separate statement
+//     after the owning CREATE TABLE.
+//
+// pg: src/backend/commands/tablecmds.c — transformFkeyCheckAttrs
+func (c *Catalog) lookupFKSupportingIndex(relOID uint32, cols []int16) uint32 {
+	if con := c.lookupUniqueConstraint(relOID, cols); con != nil {
+		return con.IndexOID
+	}
+
+	for _, idx := range c.indexesByRel[relOID] {
+		if !idx.IsUnique {
+			continue
+		}
+		// Skip partial indexes — a partial unique index does not enforce
+		// uniqueness over the whole relation.
+		if idx.WhereClause != "" {
+			continue
+		}
+		// Skip indexes with deparsed expression columns.
+		if len(idx.Exprs) > 0 {
+			continue
+		}
+		// Compare key columns only (excluding INCLUDE columns).
+		nKey := idx.NKeyColumns
+		if nKey == 0 {
+			nKey = len(idx.Columns)
+		}
+		if nKey != len(cols) {
+			continue
+		}
+		// Reject indexes that have any expression key columns (attnum=0).
+		hasExprKey := false
+		for i := 0; i < nKey; i++ {
+			if idx.Columns[i] == 0 {
+				hasExprKey = true
+				break
+			}
+		}
+		if hasExprKey {
+			continue
+		}
+		match := true
+		for i := 0; i < nKey; i++ {
+			if idx.Columns[i] != cols[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return idx.OID
+		}
+	}
+	return 0
 }
 
 // dropDependents drops all objects that have a DepNormal dependency on the given referent.

--- a/pg/catalog/constraint_test.go
+++ b/pg/catalog/constraint_test.go
@@ -203,6 +203,68 @@ func TestFKEmptyRefColumnsUsesPK(t *testing.T) {
 	}
 }
 
+// TestFKReferencesStandaloneUniqueIndex covers the pg_dump pattern: a unique
+// index defined as a separate CREATE UNIQUE INDEX statement (not as an inline
+// UNIQUE constraint) must be accepted as a FK referential target.
+//
+// pg: src/backend/commands/tablecmds.c — transformFkeyCheckAttrs
+// PostgreSQL accepts a non-partial unique index over the referenced columns
+// regardless of whether an explicit UNIQUE constraint exists. pg_dump relies
+// on this when emitting CREATE UNIQUE INDEX as a separate statement.
+func TestFKReferencesStandaloneUniqueIndex(t *testing.T) {
+	c := New()
+
+	// Referenced table has only a PK on a different column.
+	c.DefineRelation(makeCreateTableStmt("", "principal", []ColumnDef{
+		{Name: "id", Type: TypeName{Name: "integer", TypeMod: -1}},
+		{Name: "email", Type: TypeName{Name: "text", TypeMod: -1}},
+	}, []ConstraintDef{
+		{Type: ConstraintPK, Columns: []string{"id"}},
+	}, false), 'r')
+
+	// Standalone CREATE UNIQUE INDEX on email — no UNIQUE constraint object.
+	if err := c.DefineIndex(makeIndexStmt("", "principal", "idx_principal_email", []string{"email"}, true, false)); err != nil {
+		t.Fatal(err)
+	}
+
+	// FK references principal(email) — should be accepted because the unique
+	// index satisfies the referential target requirement.
+	err := c.DefineRelation(makeCreateTableStmt("", "session", []ColumnDef{
+		{Name: "user_email", Type: TypeName{Name: "text", TypeMod: -1}},
+	}, []ConstraintDef{
+		{Type: ConstraintFK, Columns: []string{"user_email"}, RefTable: "principal", RefColumns: []string{"email"}},
+	}, false), 'r')
+	if err != nil {
+		t.Fatalf("FK against standalone unique index should be accepted, got: %v", err)
+	}
+}
+
+// TestFKRejectsNonUniqueIndex confirms that a plain (non-unique) index over
+// the referenced columns does NOT satisfy the FK target requirement, matching
+// PostgreSQL's behavior.
+func TestFKRejectsNonUniqueIndex(t *testing.T) {
+	c := New()
+
+	c.DefineRelation(makeCreateTableStmt("", "parents", []ColumnDef{
+		{Name: "id", Type: TypeName{Name: "integer", TypeMod: -1}},
+		{Name: "label", Type: TypeName{Name: "text", TypeMod: -1}},
+	}, []ConstraintDef{
+		{Type: ConstraintPK, Columns: []string{"id"}},
+	}, false), 'r')
+
+	// Non-unique index on label.
+	if err := c.DefineIndex(makeIndexStmt("", "parents", "idx_parents_label", []string{"label"}, false, false)); err != nil {
+		t.Fatal(err)
+	}
+
+	err := c.DefineRelation(makeCreateTableStmt("", "children", []ColumnDef{
+		{Name: "parent_label", Type: TypeName{Name: "text", TypeMod: -1}},
+	}, []ConstraintDef{
+		{Type: ConstraintFK, Columns: []string{"parent_label"}, RefTable: "parents", RefColumns: []string{"label"}},
+	}, false), 'r')
+	assertErrorCode(t, err, CodeInvalidFK)
+}
+
 func TestCheckConstraint(t *testing.T) {
 	c := New()
 


### PR DESCRIPTION
## Summary

PostgreSQL accepts a unique index over the referenced columns as a valid foreign-key target even when no explicit `UNIQUE` constraint exists. This is documented behavior (`transformFkeyCheckAttrs` in `src/backend/commands/tablecmds.c`) that `pg_dump` relies on: it emits `CREATE UNIQUE INDEX` as a separate statement after the owning `CREATE TABLE`, not as an inline `UNIQUE` constraint.

omni's `addFKConstraint` previously only consulted `lookupUniqueConstraint`, which scans `c.consByRel` and ignores standalone indexes. As a result, any schema produced by `pg_dump` (or by tools mirroring its layout) where a FK references a column backed only by a separate `CREATE UNIQUE INDEX` would fail `LoadSDL` with:

```
ERROR: there is no unique constraint matching given keys for referenced table "..." (SQLSTATE 42830)
```

## Fix

New `lookupFKSupportingIndex` helper that:

1. First tries `lookupUniqueConstraint` (covers PK and explicit `UNIQUE` constraint).
2. Falls back to scanning `indexesByRel` for a unique index satisfying `transformFkeyCheckAttrs`'s requirements:
   - Unique
   - Non-partial (`WhereClause` empty)
   - No deparsed expressions
   - No expression key columns (attnum=0)
   - Key column count matches
   - Key columns match positionally

`addFKConstraint` now uses it for both validation and the supporting-index dependency record.

## How surfaced

Bytebase sync-schema against the bytebase metadata DB, which has a `principal` table with `CONSTRAINT principal_pkey PRIMARY KEY (id)` plus a separate `CREATE UNIQUE INDEX idx_principal_unique_email ON principal (email)`, and several other tables that FK reference `principal(email)`. After landing #11, this was the next bug down the stack — see linear bytebase/BYT-9155.

## Test plan

- [x] New `TestFKReferencesStandaloneUniqueIndex` (positive — pg_dump pattern)
- [x] New `TestFKRejectsNonUniqueIndex` (negative — confirms non-unique indexes are still rejected, no false acceptance)
- [x] Verified the positive test fails without the fix (`stash` + re-run) — proves the regression test catches the bug
- [x] Full `go test ./pg/catalog/...` passes
- [x] `golangci-lint ./pg/catalog/...` clean for modified files
- [x] End-to-end against bytebase: `:diffSchema` against the bytebase metadata DB returns `HTTP 200` with a real diff (previously failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)