### PR TITLE
feat(partiql/ast): hand-written AST package for PartiQL parser migration (DAG node 1)

### DIFF
--- a/docs/migration/partiql/analysis.md
+++ b/docs/migration/partiql/analysis.md
@@ -1,0 +1,423 @@
+# PartiQL Migration Analysis
+
+PartiQL is the SQL++-flavored query language used by AWS DynamoDB and Azure Cosmos DB.
+In bytebase it is wired to `storepb.Engine_DYNAMODB`. The legacy parser is ANTLR4-based
+and lives at `bytebase/parser/partiql`; the bytebase wrapper lives at
+`bytebase/backend/plugin/parser/partiql`. The omni migration target is **full coverage
+of the legacy ANTLR grammar's scope**, with bytebase consumption used only for
+prioritization.
+
+## Source Locations
+
+| Path | Role |
+|------|------|
+| `bytebase/parser/partiql/PartiQLParser.g4` | Parser grammar (~685 lines) |
+| `bytebase/parser/partiql/PartiQLLexer.g4`  | Lexer grammar (~543 lines) |
+| `bytebase/parser/partiql/partiqlparser_parser.go` | ANTLR-generated parser (~212 context types) |
+| `bytebase/parser/partiql/partiqlparser_listener.go` | Generated listener interface (~1107 lines) |
+| `bytebase/parser/partiql/simple.sql` | Tiny smoke fixture (DELETE / INSERT) |
+| `bytebase/backend/plugin/parser/partiql/partiql.go` | `ParsePartiQL()` entry point |
+| `bytebase/backend/plugin/parser/partiql/split.go`   | Statement splitter |
+| `bytebase/backend/plugin/parser/partiql/query.go`   | DQL-only query validator |
+| `bytebase/backend/plugin/parser/partiql/completion.go` | Auto-completion |
+| `bytebase/backend/plugin/db/dynamodb/dynamodb.go` | Driver — only consumer of the wrapper outside `init` registration |
+
+## Grammar Coverage
+
+### Top-level structure
+
+`script` → `statement (; statement)*`. `statement` is one of: `dql`, `dml`, `ddl`, `execCommand`.
+`root` allows an optional `EXPLAIN` prefix.
+
+### DDL
+
+- `CREATE TABLE <name>` — name only, no column definitions, no constraints
+- `CREATE INDEX ON <table> ( <path>, <path>, ... )`
+- `DROP TABLE <name>`
+- `DROP INDEX <index_name> ON <table>`
+
+No `ALTER`, no `VIEW`, no constraints (PK/FK/CHECK/NOT NULL/DEFAULT). This is
+intentional — PartiQL is schemaless and document-collection oriented.
+
+### DML
+
+PartiQL has two coexisting DML syntaxes:
+
+- **Legacy path-based** (g4 lines 94–100): `UPDATE … SET …`, `FROM … DELETE …`,
+  `INSERT INTO <path> VALUE … AT … ON CONFLICT …`, `REMOVE <path>`
+- **RFC 0011 modern**: `INSERT INTO <collection> AS <alias> VALUE … ON CONFLICT …`,
+  `REPLACE INTO <collection> AS <alias> VALUE …`,
+  `UPSERT INTO <collection> AS <alias> VALUE …`
+- `DELETE FROM <path> WHERE …`
+
+`ON CONFLICT` (g4 lines 139–180):
+
+- `ON CONFLICT WHERE <expr> DO NOTHING` (legacy form)
+- `ON CONFLICT [( cols ) | ON CONSTRAINT <name>] [DO NOTHING | DO REPLACE … | DO UPDATE …]`
+- **TODO in legacy grammar (g4 lines 170, 180):** `doReplace` and `doUpdate` are stubs —
+  only the `EXCLUDED` keyword is parsed; full `SET …` / `VALUE …` clauses are missing.
+
+`RETURNING` (g4 lines 194–200): `RETURNING [MODIFIED|ALL] [OLD|NEW] (* | expr) , …`.
+
+### DQL — SELECT
+
+SELECT variants (g4 lines 216–221):
+
+- `SELECT [DISTINCT|ALL] *`
+- `SELECT [DISTINCT|ALL] expr [AS alias], …`
+- `SELECT [DISTINCT|ALL] VALUE <expr>` — single-value projection (PartiQL-unique)
+- `PIVOT <expr> AT <expr>` — used as a SELECT replacement (PartiQL-unique)
+
+Clauses:
+
+- `LET <expr> AS <alias>, …` (g4 238–242) — intermediate variable bindings, PartiQL-unique
+- `FROM <path> [AS <itemAlias>] [AT <posAlias>] [BY <keyAlias>]` — `AT` for array index,
+  `BY` for object key (PartiQL-unique)
+- `UNPIVOT <expr> [AS …] [AT …] [BY …]` (g4 408)
+- `WHERE <expr>`
+- `GROUP [PARTIAL] BY <expr> [AS alias], … [GROUP AS alias]` — `PARTIAL` is PartiQL-unique
+- `HAVING <expr>`
+- `ORDER BY <expr> [ASC|DESC] [NULLS FIRST|LAST], …`
+- `LIMIT <expr>`, `OFFSET <expr>`
+
+Set operations (g4 449–454): `UNION`, `INTERSECT`, `EXCEPT`, each with optional
+`OUTER` and `[DISTINCT|ALL]`.
+
+### Joins
+
+`CROSS`, `INNER`, `LEFT [OUTER]`, `RIGHT [OUTER]`, `FULL [OUTER]`, bare `OUTER` (natural
+outer). `ON <expr>` condition. No `LATERAL`, no `USING`.
+
+### Window Functions
+
+Only `LAG(expr [, offset [, default]]) OVER (…)` and `LEAD(…)` are explicitly in the
+grammar (g4 589–591). No `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `NTILE`. Aggregate
+functions inside `OVER(…)` are not explicit in the grammar.
+
+### Aggregates
+
+`COUNT(*)`, `COUNT([DISTINCT|ALL] expr)`, `MAX`, `MIN`, `SUM`, `AVG`. Nothing else
+(no `STDDEV`, no `ARRAY_AGG`, no custom aggregates).
+
+### Expressions
+
+Operator hierarchy: `OR` → `AND` → `NOT` → predicate (`=`/`<>`/`<`/`>`/`<=`/`>=`/`IN`/
+`BETWEEN`/`LIKE`/`IS [NOT] (NULL|MISSING|TRUE|FALSE)`) → `||` (concat) → `+/-` → `*///%`
+→ unary → primary. Multiple `mathOp` rules give the precedence layers.
+
+`expr` includes: literals, paths, function calls, `CASE [expr] WHEN … THEN … ELSE … END`,
+`CAST(expr AS type)`, `CAN_CAST`, `CAN_LOSSLESS_CAST`, parameter `?`, named variables
+`@ident` or `ident`, subqueries, graph match expressions.
+
+### Path Navigation (PartiQL-critical)
+
+Path steps (g4 618–623):
+
+- `[<expr>]` — index/key by expression
+- `[*]` — all-elements wildcard
+- `.<symbol>` — dot field access
+- `.*` — all-fields wildcard
+- Chains: `expr.a[0].b.c[key]`
+
+### Collection / Tuple Literals
+
+- **List** `[ expr, expr, … ]` — ordered, indexed (SQL array)
+- **Bag**  `<< expr, expr, … >>` — unordered, duplicate-preserving (PartiQL-unique)
+- **Tuple/Struct** `{ key: value, key: value, … }` (PartiQL-unique)
+- `LIST(…)`, `SEXP(…)` constructor function syntax
+
+### Type System (g4 674–686)
+
+Standard SQL types: `NULL`, `BOOL/BOOLEAN`, `SMALLINT`, `INTEGER`/`INT`, `BIGINT`,
+`REAL`, `DOUBLE PRECISION`, `DECIMAL(p,s)`, `NUMERIC(p,s)`, `FLOAT(n)`, `VARCHAR(n)`,
+`CHAR(n)`/`CHARACTER(n)`, `DATE`, `TIME`, `TIMESTAMP`.
+
+PartiQL-specific types: `MISSING` (distinct from `NULL`), `STRING`, `SYMBOL` (Ion),
+`STRUCT`, `TUPLE`, `LIST`, `BAG`, `SEXP`, `BLOB`, `CLOB`, `ANY`.
+
+### Built-in Functions
+
+String: `CHAR_LENGTH`, `CHARACTER_LENGTH`, `OCTET_LENGTH`, `BIT_LENGTH`, `UPPER`,
+`LOWER`, `SIZE` (collection size), `EXISTS`, `TRIM([LEADING|TRAILING|BOTH] [sub] FROM target)`,
+`SUBSTRING(expr FROM x [FOR y])`.
+
+Type: `CAST(expr AS type)`, `CAN_CAST`, `CAN_LOSSLESS_CAST`, `COALESCE`, `NULLIF`.
+
+Date/time: `EXTRACT(field FROM expr)`, `DATE_ADD(unit, expr, expr)`, `DATE_DIFF(unit, expr, expr)`,
+`DATE 'yyyy-mm-dd'`, `TIME [(p)] [WITH TIME ZONE] 'HH:MM:SS'`, `TIMESTAMP '…'` literals.
+
+Generic: any `<ident>(args)` function call (extensibility hook).
+
+### Graph Pattern Matching (GPML)
+
+Significant feature (g4 314–382, 625–630). Examples of constructs:
+
+- Nodes `(label? pattern? where?)`, edges `-[label?]->`, `<-[]-`, `~[…]~`
+- Quantifiers `+`, `*`, `{m,n}`
+- Selectors `ANY`, `ALL SHORTEST`, `SHORTEST k`
+- Restrictors `TRAIL`, `ACYCLIC`, `SIMPLE` (parsed but not semantically enforced)
+- Path variables: `p = node-[edge]-node`
+- `exprGraphMatchOne` and `exprGraphMatchMany`
+
+### Ion Embedded Literals
+
+Backtick-delimited inline Ion values (g4 669, lexer modes lines 327–403). The lexer
+has a dedicated ION mode that recognises Ion's symbols, structs, and binary forms.
+
+### EXEC
+
+`EXEC <name> [arg, arg, …]` — call stored procedures. No `CREATE PROCEDURE`.
+
+## Parse API Surface
+
+### `bytebase/backend/plugin/parser/partiql/partiql.go`
+
+```go
+func ParsePartiQL(statement string) ([]*base.ANTLRAST, error)
+```
+
+- Splits the input via `SplitSQL`, then parses each statement with the ANTLR4 lexer/parser
+- Returns one `*base.ANTLRAST` per statement; each contains:
+  - `StartPosition *storepb.Position`
+  - `Tree antlr.ParseTree`
+  - `Tokens *antlr.CommonTokenStream`
+- Custom error listeners: `base.ParseErrorListener` on both lexer and parser
+- Registered: `base.RegisterParseStatementsFunc(storepb.Engine_DYNAMODB, parsePartiQLStatements)` (partiql.go:16)
+
+### `split.go`
+
+```go
+func SplitSQL(statement string) ([]base.Statement, error)
+```
+
+- Splits by `PartiQLLexerCOLON_SEMI` (`;`) tokens via the ANTLR lexer
+- Tracks line/column/byte positions per statement
+- Registered: `base.RegisterSplitterFunc(storepb.Engine_DYNAMODB, SplitSQL)` (split.go:12)
+
+### `query.go`
+
+```go
+func validateQuery(statement string) (bool, bool, error)
+```
+
+- Walks the parse tree with a `BasePartiQLParserListener` to assert that every top-level
+  statement is DQL (or `EXPLAIN` of DQL)
+- Rejects DDL, DML, and `EXEC`
+- Registered: `base.RegisterQueryValidator(storepb.Engine_DYNAMODB, validateQuery)` (query.go:12)
+
+### `completion.go`
+
+```go
+func Completion(ctx context.Context, cCtx base.CompletionContext, statement string, …) ([]base.Candidate, error)
+```
+
+- Uses `base.CodeCompletionCore` (a Go port of the ANTLR4 c3 completion library)
+- Preferred parser rules: `varRefExpr`, `selectClause`, `fromClause`, `exprSelect`
+- Two completer strategies: standard and "tricky" (for trailing-state corner cases)
+- Surfaces table names from FROM scope and column names from current SELECT scope
+- Registered: `base.RegisterCompleteFunc(storepb.Engine_DYNAMODB, Completion)` (completion.go:177)
+
+### Error Handling Pattern
+
+All entry points share the bytebase parser convention: install
+`base.ParseErrorListener` on the lexer and parser, run the parse, then return
+the listener's accumulated error.
+
+## AST Types
+
+The legacy AST is the ANTLR-generated parse-tree context graph (~212 context types).
+Significant categories:
+
+- Top-level: `ScriptContext`, `RootContext`, `StatementContext`,
+  `QueryDqlContext`, `QueryDmlContext`, `QueryDdlContext`, `QueryExecContext`
+- Clauses: `SelectClauseContext`, `FromClauseContext`, `WhereClauseContext`,
+  `GroupClauseContext`, `OrderByClauseContext`, `LimitClauseContext`,
+  `OffsetClauseContext`, `LetClauseContext`, `HavingClauseContext`
+- DDL/DML: `CreateTableContext`, `CreateIndexContext`, `DropTableContext`,
+  `DropIndexContext`, `InsertCommandContext`, `UpdateClauseContext`,
+  `DeleteCommandContext`, `ReplaceCommandContext`, `UpsertCommandContext`,
+  `RemoveCommandContext`
+- Expressions: `ExprContext`, `ExprSelectContext`, `ExprOrContext`, `ExprAndContext`,
+  `ExprNotContext`, `ExprPredicateContext`, `MathOp00/01/02Context`,
+  `ValueExprContext`, `ExprPrimaryContext`
+- Path: `PathStepContext`, `PathStepIndexExprContext`, `PathStepDotExprContext`,
+  `PathSimpleContext`, `PathSimpleStepsContext`
+- Collections: `ArrayContext`, `BagContext`, `TupleContext`, `PairContext`,
+  `ValueListContext`, `ValuesContext`
+- Graph: `GpmlPatternContext`, `MatchPatternContext`, `NodeContext`, `EdgeContext`,
+  `PatternQuantifierContext`, `EdgeSpecContext`, `PatternPartLabelContext`
+- Functions: `AggregatContext`, `WindowFunctionContext`, `FunctionCallContext`,
+  `FunctionCallIdentContext`, `FunctionCallReservedContext`, `CastContext`,
+  `ExtractContext`, `TrimFunctionContext`, `SubstringContext`
+
+The omni AST will be hand-written and need not preserve every ANTLR context — only
+the semantic distinctions consumers care about.
+
+## Bytebase Import Sites
+
+Bytebase has only **one direct user** of the wrapper package outside of `init()`-time
+registration:
+
+| File | Function | Line | API used |
+|------|----------|------|----------|
+| `backend/plugin/db/dynamodb/dynamodb.go` | `Execute` | 99 | `base.SplitMultiSQL(storepb.Engine_DYNAMODB, statement)` |
+| `backend/plugin/db/dynamodb/dynamodb.go` | `QueryConn` | 131 | `base.SplitMultiSQL(storepb.Engine_DYNAMODB, statement)` |
+
+The DynamoDB driver splits multi-statement input because the AWS PartiQL transaction
+API cannot mix read and write in one call — splitting is operationally critical.
+
+The wrapper package is auto-imported (for its `init()` registrations) from:
+
+- `backend/server/ultimate.go:37`
+- `backend/component/sheet/sheet.go:17`
+
+`storepb.Engine_DYNAMODB` participates in many capability checks in
+`backend/common/engine.go` (lines 38, 77, 115, 142, 174, 228, 266, 302, 328, 366, 420),
+but those are flag checks, not parser calls.
+
+## Feature Dependency Map
+
+| Bytebase Feature | Parser API | Data Extracted | Status |
+|------------------|------------|----------------|--------|
+| DynamoDB driver multi-statement execution | `SplitMultiSQL` (Splitter) | Statement boundaries with positions | **Required** |
+| SQL Editor read-only validation | `ValidateSQLForEditor` (QueryValidator) | DQL vs not-DQL boolean | **Required** |
+| SQL Editor auto-complete | `Completion` (CompleteFunc) | Table/column/keyword candidates by cursor scope | **Required** |
+| Generic statement parsing | `ParseStatements` (ParseStatementsFunc) | Parse tree + tokens | **Required (pipeline plumbing)** |
+| Schema sync | — | — | Not implemented |
+| Query span / lineage | — | — | Not implemented |
+| Masking | — | — | Not implemented |
+| Diagnostics / lint advisors | — | — | Not implemented |
+| DML → SELECT transformation | — | — | Not implemented |
+| Restore SQL generation | — | — | Not implemented |
+| Statement ranges (LSP) | — | — | Not implemented |
+
+Compared with mongo/cosmosdb wrappers, partiql is **strictly the smaller subset** —
+no analysis, masking, span, or diagnostics layer exists.
+
+## Gaps and Limitations in the Legacy Parser
+
+These are constraints inherited from the ANTLR grammar that omni does not need to
+preserve as bugs:
+
+1. **`ON CONFLICT DO REPLACE/UPDATE` are stubs** — only `EXCLUDED` is parsed
+   (g4 lines 170, 180). Full SET/VALUE clauses are missing.
+2. **No `ALTER TABLE`** — by design (NoSQL).
+3. **No views, no triggers, no `CREATE PROCEDURE`** — only `EXEC` invocation.
+4. **No constraints in `CREATE TABLE`** — name only, no columns.
+5. **No CTEs / `WITH` clause.**
+6. **No recursive queries.**
+7. **Limited window functions** — only `LAG`/`LEAD`, no `ROW_NUMBER`/`RANK`/`DENSE_RANK`/`NTILE`.
+8. **Aggregate window functions ambiguous** — grammar doesn't explicitly allow
+   `SUM(...) OVER (...)`, though expression nesting may permit it.
+9. **Graph pattern restrictors not enforced** — `TRAIL`/`ACYCLIC`/`SIMPLE` parsed
+   but no semantics.
+10. **No `LATERAL` join.**
+11. **Comments stripped** — lexer routes them to the hidden channel; not preserved
+    on the AST.
+12. **Tiny smoke fixture** — `simple.sql` is 5 lines covering only DELETE/INSERT.
+    Coverage is grammar-driven, not example-driven.
+
+## Priority Ranking
+
+Migration order, derived from bytebase consumption first then legacy parser parity:
+
+### Tier 0 — Foundations (must come first)
+
+1. Lexer: keywords, identifiers, strings, numbers, `;` delimiter, Ion backtick mode
+2. Token-stream / position tracking infrastructure
+3. Statement splitter (drives `base.SplitMultiSQL`, the one feature the DynamoDB driver
+   directly needs)
+
+### Tier P0 — Required by bytebase
+
+4. Recursive-descent parser scaffolding (precedence climbing for expressions)
+5. SELECT path: `SELECT … FROM … WHERE … GROUP BY … HAVING … ORDER BY … LIMIT/OFFSET`,
+   including `SELECT VALUE`, set operations
+6. FROM path with `AS`/`AT`/`BY` aliases, joins
+7. Path navigation expressions (`a.b[0].c`, `[*]`, `.*`)
+8. Collection/tuple literals (`[…]`, `<<…>>`, `{k:v,…}`)
+9. Variable refs (`@ident`, `?` parameter)
+10. DML: `INSERT … VALUE …`, `UPDATE … SET …`, `DELETE FROM …`, `UPSERT`, `REPLACE`,
+    `REMOVE`, `ON CONFLICT`, `RETURNING`
+11. DDL: `CREATE TABLE`, `CREATE INDEX`, `DROP TABLE`, `DROP INDEX`
+12. `EXEC` command
+13. `EXPLAIN` prefix
+14. Query validator (DQL-only enforcement matching `validateQuery`)
+15. Completion engine (table-name and column-name candidates with FROM-scope tracking)
+
+### Tier P1 — Legacy parity (not consumed by bytebase, still in scope)
+
+16. `LET` clause
+17. `PIVOT` / `UNPIVOT`
+18. Window functions (`LAG`/`LEAD`)
+19. Aggregates (`COUNT(*)`, `COUNT(DISTINCT …)`, `SUM`, `AVG`, `MIN`, `MAX`)
+20. Built-in functions (`CAST`, `EXTRACT`, `TRIM`, `SUBSTRING`, `DATE_ADD`, `DATE_DIFF`,
+    `COALESCE`, `NULLIF`, `CASE`)
+21. Graph pattern matching (`MATCH` clauses, nodes/edges/quantifiers/selectors)
+22. Ion-embedded literals (backtick mode)
+23. `CAN_CAST` / `CAN_LOSSLESS_CAST`
+
+### Tier P2 — Nice-to-have / future
+
+24. Schema sync, query span, masking, diagnostics — register stubs only when bytebase
+    decides to add them; not required for the import switch
+
+## Full Coverage Target
+
+| Area | Feature | Tier |
+|------|---------|------|
+| Lexer | All keywords, identifiers, numbers, strings, `;`, Ion backtick mode | **P0** |
+| Splitter | Statement splitting by `;` | **P0** |
+| Parser | `EXPLAIN` prefix | **P0** |
+| Parser DDL | `CREATE TABLE`, `CREATE INDEX (path,…)`, `DROP TABLE`, `DROP INDEX … ON …` | **P0** |
+| Parser DML | `INSERT INTO … VALUE …` (legacy + RFC 0011) | **P0** |
+| Parser DML | `UPDATE … SET …`, `FROM … SET …` | **P0** |
+| Parser DML | `DELETE FROM … WHERE …`, `FROM … DELETE …` | **P0** |
+| Parser DML | `UPSERT INTO …`, `REPLACE INTO …` | **P0** |
+| Parser DML | `REMOVE <path>` | **P0** |
+| Parser DML | `ON CONFLICT … DO NOTHING / DO REPLACE EXCLUDED / DO UPDATE EXCLUDED` | **P0** |
+| Parser DML | `RETURNING [MODIFIED\|ALL] [OLD\|NEW] *\|expr` | **P0** |
+| Parser DQL | `SELECT [DISTINCT\|ALL] *\|items\|VALUE expr` | **P0** |
+| Parser DQL | `PIVOT expr AT expr` projection | **P1** |
+| Parser DQL | `FROM path [AS] [AT] [BY]`, `UNPIVOT` | **P0** (FROM) / **P1** (UNPIVOT) |
+| Parser DQL | Joins: `CROSS`, `INNER`, `LEFT/RIGHT/FULL [OUTER]`, bare `OUTER` | **P0** |
+| Parser DQL | `WHERE`, `GROUP [PARTIAL] BY … [GROUP AS]`, `HAVING` | **P0** |
+| Parser DQL | `ORDER BY … [ASC\|DESC] [NULLS FIRST\|LAST]`, `LIMIT`, `OFFSET` | **P0** |
+| Parser DQL | `LET expr AS alias, …` | **P1** |
+| Parser DQL | Set ops `UNION/INTERSECT/EXCEPT [OUTER] [DISTINCT\|ALL]` | **P0** |
+| Parser Expr | Operator precedence: `OR/AND/NOT/predicate/||/+−/*//%/unary/primary` | **P0** |
+| Parser Expr | Predicates: `=,<>,<,>,<=,>=,IN,BETWEEN,LIKE [ESCAPE],IS [NOT] (NULL\|MISSING\|TRUE\|FALSE)` | **P0** |
+| Parser Expr | `CASE [expr] WHEN … THEN … ELSE … END` | **P1** |
+| Parser Expr | `CAST/CAN_CAST/CAN_LOSSLESS_CAST` | **P1** |
+| Parser Expr | Path expressions: `.field`, `.*`, `[expr]`, `[*]`, chained | **P0** |
+| Parser Expr | Variables: `@ident`, bare `ident`, `?` parameter | **P0** |
+| Parser Expr | Literals: tuple `{}`, list `[]`, bag `<<>>`, ion backtick | **P0** (tuple/list) / **P1** (bag/ion) |
+| Parser Expr | Subqueries | **P0** |
+| Parser Expr | Aggregates: `COUNT(*)`, `COUNT/SUM/AVG/MIN/MAX([DISTINCT\|ALL] expr)` | **P1** |
+| Parser Expr | Window: `LAG/LEAD(... ) OVER (PARTITION BY … ORDER BY …)` | **P1** |
+| Parser Expr | Built-ins: `CHAR_LENGTH`, `OCTET_LENGTH`, `BIT_LENGTH`, `UPPER`, `LOWER`, `SIZE`, `EXISTS`, `TRIM`, `SUBSTRING`, `EXTRACT`, `DATE_ADD`, `DATE_DIFF`, `COALESCE`, `NULLIF` | **P1** |
+| Parser Expr | Generic `ident(args,…)` function call | **P0** |
+| Parser Expr | Graph patterns: `MATCH (n)-[e]->(m)`, quantifiers, selectors, restrictors | **P1** |
+| Parser Cmd | `EXEC name args…` | **P1** |
+| Type system | All standard SQL + PartiQL types (`MISSING`, `STRUCT`, `TUPLE`, `LIST`, `BAG`, `SEXP`, `BLOB`, `CLOB`, `SYMBOL`, `ANY`) | **P0** |
+| Date/time literals | `DATE 'Y-M-D'`, `TIME [(p)] [WITH TIME ZONE] '…'`, `TIMESTAMP '…'` | **P1** |
+| Analysis | Query validator (DQL-only) | **P0** |
+| Completion | Table/column/keyword candidates with FROM-scope and SELECT-scope rules | **P0** |
+| Catalog | DynamoDB-style metadata (tables = collections, columns = inferred fields) | **P2** (only when bytebase wires schema sync) |
+| Semantic / quality / deparse | — | **P2** (no consumer today) |
+
+## Notes for Planning
+
+- **Bytebase coupling is shallow.** Only four `init()` registrations and one direct
+  caller in the DynamoDB driver. Switching the import is mechanically small once
+  splitter, validator, completer, and parser are in place.
+- **Graph pattern matching is the largest single feature** in the legacy grammar that
+  has no analogue in other omni engines — budget it as its own DAG node and don't
+  underestimate it.
+- **Two DML syntaxes coexist**, so the DML parser must accept both legacy path-based
+  and RFC 0011 forms; tests should cover both spellings of `INSERT`/`UPDATE`/`DELETE`.
+- **Ion mode in the lexer** is mode-switched on backticks — needs an explicit lexer
+  state, not just a token rule.
+- **The legacy `simple.sql` fixture is too small to be a useful regression suite.**
+  Build the omni test corpus from the official PartiQL spec / AWS DynamoDB PartiQL
+  reference instead, and cross-reference each clause back to the `.g4` rules above.

--- a/docs/migration/partiql/dag.md
+++ b/docs/migration/partiql/dag.md
@@ -1,0 +1,253 @@
+# PartiQL Migration DAG
+
+Feature dependency graph for migrating the PartiQL (DynamoDB / Cosmos DB)
+parser from `bytebase/parser/partiql` (ANTLR4) to `bytebase/omni/partiql`
+(hand-written). Source: [analysis.md](./analysis.md).
+
+Linear umbrella issue: BYT-9000.
+
+**Engine constant in bytebase:** `storepb.Engine_DYNAMODB`.
+**Reference engines:** `cosmosdb/` (most similar — also NoSQL, hand-written, recent),
+`mongo/` (NoSQL conventions).
+
+Conventions follow `cosmosdb/` and `mongo/`:
+
+- `partiql/ast/`         — AST node types
+- `partiql/parser/`      — Lexer + recursive-descent parser
+- `partiql/analysis/`    — Statement classification (DQL validator)
+- `partiql/catalog/`     — Schema metadata for DynamoDB-style collections
+- `partiql/completion/`  — Auto-complete candidates
+- `partiql/parse.go`     — Public `Parse()` entry point with statement framing
+- `partiql/parsertest/`  — Test corpus support (if useful)
+
+## Nodes
+
+| # | Node | Package | Depends On | Can Parallelize With | Priority | Status |
+|---|------|---------|------------|----------------------|----------|--------|
+| 1 | ast-core | `partiql/ast` | (none) | lexer, catalog | **P0** | done |
+| 2 | lexer | `partiql/parser` (lexer.go, token.go) | ast-core | catalog | **P0** | not started |
+| 3 | catalog | `partiql/catalog` | (none) | ast-core, lexer | **P0** | not started |
+| 4 | parser-foundation | `partiql/parser` (parser.go, expr.go, path.go, literals.go) | ast-core, lexer | — | **P0** | not started |
+| 5 | parser-select | `partiql/parser` (select.go, from.go) | parser-foundation | parser-dml, parser-ddl (logically — same files conflict) | **P0** | not started |
+| 6 | parser-dml | `partiql/parser` (dml.go) | parser-foundation | parser-select, parser-ddl (logically — same files conflict) | **P0** | not started |
+| 7 | parser-ddl | `partiql/parser` (ddl.go) | parser-foundation | parser-select, parser-dml (logically — same files conflict) | **P0** | not started |
+| 8 | parse-entry | `partiql/parse.go` + `partiql/parse_test.go` | parser-foundation | parser-select/dml/ddl (entry can land before they all complete) | **P0** | not started |
+| 9 | analysis | `partiql/analysis` | ast-core, parse-entry | catalog, completion-foundation | **P0** | not started |
+| 10 | completion | `partiql/completion` | parse-entry, catalog | analysis | **P0** | not started |
+| 11 | bytebase-switch | bytebase wrapper rewrite | parse-entry, analysis, completion | — | **P0** | not started |
+| 12 | parser-let-pivot | `partiql/parser` (select.go) | parser-select | parser-window, parser-aggregates, parser-builtins, parser-graph, parser-ion-literals, parser-datetime-literals | **P1** | not started |
+| 13 | parser-window | `partiql/parser` (expr.go, function.go) | parser-foundation | parser-let-pivot, parser-aggregates, parser-builtins, parser-graph, parser-ion-literals, parser-datetime-literals | **P1** | not started |
+| 14 | parser-aggregates | `partiql/parser` (function.go) | parser-foundation | parser-let-pivot, parser-window, parser-builtins, parser-graph, parser-ion-literals, parser-datetime-literals | **P1** | not started |
+| 15 | parser-builtins | `partiql/parser` (function.go, expr.go) | parser-foundation | parser-let-pivot, parser-window, parser-aggregates, parser-graph, parser-ion-literals, parser-datetime-literals | **P1** | not started |
+| 16 | parser-graph | `partiql/parser` (graph.go) | parser-foundation | parser-let-pivot, parser-window, parser-aggregates, parser-builtins, parser-ion-literals, parser-datetime-literals | **P1** | not started |
+| 17 | parser-ion-literals | `partiql/parser` (lexer.go) | lexer | parser-let-pivot, parser-window, parser-aggregates, parser-builtins, parser-graph, parser-datetime-literals | **P1** | not started |
+| 18 | parser-datetime-literals | `partiql/parser` (literals.go, expr.go) | parser-foundation | parser-let-pivot, parser-window, parser-aggregates, parser-builtins, parser-graph, parser-ion-literals | **P1** | not started |
+
+Priority key: **P0** = on the critical path to bytebase migration (the four
+features bytebase actually consumes — splitter / parse / DQL validator / completion);
+**P1** = legacy parser parity that omni must implement to fully replace the ANTLR
+grammar, but bytebase doesn't actively consume today.
+
+## Visual Dependency Graph
+
+```dot
+digraph partiql_dag {
+  rankdir=LR;
+  node [shape=box, style=rounded];
+
+  // P0
+  subgraph cluster_p0 {
+    label="P0 — bytebase critical path";
+    color="#1f6feb";
+    style=rounded;
+    ast_core   [label="1. ast-core"];
+    lexer      [label="2. lexer"];
+    catalog    [label="3. catalog"];
+    p_found    [label="4. parser-foundation"];
+    p_select   [label="5. parser-select"];
+    p_dml      [label="6. parser-dml"];
+    p_ddl      [label="7. parser-ddl"];
+    parse_entry[label="8. parse-entry\n(parse.go)"];
+    analysis   [label="9. analysis\n(DQL validator)"];
+    completion [label="10. completion"];
+    bb_switch  [label="11. bytebase-switch", color="#cf222e", fontcolor="#cf222e"];
+  }
+
+  // P1
+  subgraph cluster_p1 {
+    label="P1 — legacy parity";
+    color="#9a6700";
+    style=rounded;
+    p_letpivot [label="12. parser-let-pivot"];
+    p_window   [label="13. parser-window"];
+    p_aggs     [label="14. parser-aggregates"];
+    p_builtins [label="15. parser-builtins"];
+    p_graph    [label="16. parser-graph (GPML)"];
+    p_ion      [label="17. parser-ion-literals"];
+    p_dt       [label="18. parser-datetime-literals"];
+  }
+
+  ast_core    -> lexer;
+  ast_core    -> p_found;
+  lexer       -> p_found;
+  p_found     -> p_select;
+  p_found     -> p_dml;
+  p_found     -> p_ddl;
+  p_found     -> parse_entry;
+  ast_core    -> analysis;
+  parse_entry -> analysis;
+  parse_entry -> completion;
+  catalog     -> completion;
+  parse_entry -> bb_switch;
+  analysis    -> bb_switch;
+  completion  -> bb_switch;
+
+  p_select    -> p_letpivot;
+  p_found     -> p_window;
+  p_found     -> p_aggs;
+  p_found     -> p_builtins;
+  p_found     -> p_graph;
+  lexer       -> p_ion;
+  p_found     -> p_dt;
+}
+```
+
+## Execution Order
+
+### Phase 1 — Foundations (parallelizable)
+
+Three independent nodes can run in parallel:
+
+1. **ast-core** — node interfaces, `Loc`, literal nodes, statement/expression/path/collection/type node taxonomy
+2. **lexer** — tokens, keywords, identifiers, numbers, strings, `;` delimiter, position tracking. (Ion backtick mode is split out as P1 node #17.)
+3. **catalog** — DynamoDB-style schema metadata (tables = collections, columns = attribute paths). Independent of parser entirely.
+
+### Phase 2 — Parser foundation (blocking)
+
+4. **parser-foundation** — Parser scaffolding (advance/peek/match/expect, error recovery), expression precedence (Pratt or precedence-climbing), path expressions (`.field`, `.*`, `[expr]`, `[*]`, chained), variables (`@id`, bare `id`, `?`), collection literals (`[...]`, `{k:v}`), basic SELECT smoke path, splitter.
+
+This must land before any other parser feature work.
+
+### Phase 3 — Statement coverage (logically parallel, file-conflict serial)
+
+Nodes 5–7 can be designed in parallel but their commits will likely serialize because
+they touch overlapping files. The **brainstorms can happen concurrently**; merging
+should be sequential.
+
+5. **parser-select** — full SELECT clause set: `FROM` with `AS`/`AT`/`BY`, joins
+   (`CROSS`/`INNER`/`LEFT`/`RIGHT`/`FULL`/bare `OUTER`), `WHERE`, `GROUP BY`/`HAVING`,
+   `ORDER BY`, `LIMIT`/`OFFSET`, set operations (`UNION`/`INTERSECT`/`EXCEPT`),
+   subqueries, `EXPLAIN` prefix
+6. **parser-dml** — `INSERT INTO … VALUE …` (legacy + RFC 0011), `UPDATE … SET …`,
+   `DELETE FROM … WHERE …`, `UPSERT`, `REPLACE`, `REMOVE`, `ON CONFLICT … DO NOTHING /
+   DO REPLACE EXCLUDED / DO UPDATE EXCLUDED`, `RETURNING`
+7. **parser-ddl** — `CREATE TABLE`, `CREATE INDEX (path,…)`, `DROP TABLE`,
+   `DROP INDEX … ON …`, `EXEC name args…`
+
+### Phase 4 — Public entry point (can land alongside Phase 3)
+
+8. **parse-entry** — `partiql/parse.go` with `Parse()` returning `[]Statement` and
+   `ParseBestEffort()` returning a `*ParseResult` (mirroring `mongo/parse.go`).
+   Statement framing, position tracking, best-effort error recovery.
+
+### Phase 5 — Analysis & completion (parallelizable)
+
+9. **analysis** — DQL-only query validator (mirror of legacy `validateQuery`). Walks
+   the AST and rejects DDL/DML/EXEC. Uses node-tag dispatch, no listener machinery.
+10. **completion** — Auto-complete using cursor scope. Surfaces table names from FROM
+    scope and column names from current SELECT scope. Mirror the candidate types from
+    the legacy `completion.go`. Test cases mirror `test_completion.yaml`.
+
+These two are independent and can run concurrently.
+
+### Phase 6 — Bytebase switch (final P0)
+
+11. **bytebase-switch** — Rewrite `bytebase/backend/plugin/parser/partiql/`
+    (`partiql.go`, `split.go`, `query.go`, `completion.go`) to call into the new
+    omni parser. Replace `github.com/bytebase/parser/partiql` imports with
+    `github.com/bytebase/omni/partiql`. The four `init()` registrations
+    (`RegisterParseStatementsFunc`, `RegisterSplitterFunc`, `RegisterQueryValidator`,
+    `RegisterCompleteFunc`) stay the same — only the implementation changes. The
+    one external caller (`backend/plugin/db/dynamodb/dynamodb.go`) does not need
+    updating because it goes through `base.SplitMultiSQL`. Run the existing
+    `test_split.yaml` and `test_completion.yaml` corpora as the regression suite.
+
+### Phase 7 — Legacy parity (post-bytebase, fully parallelizable)
+
+Once bytebase has switched, the remaining P1 nodes can land in any order. None of
+them block bytebase. They are parallelizable with each other (different files /
+different concerns), with the caveat that some touch shared parser files (note in
+the table).
+
+12. **parser-let-pivot** — `LET expr AS alias, …`, `PIVOT … AT …`, `UNPIVOT … [AS] [AT] [BY]`
+13. **parser-window** — `LAG`/`LEAD` window functions with `OVER (PARTITION BY … ORDER BY …)`
+14. **parser-aggregates** — `COUNT(*)`, `COUNT/SUM/AVG/MIN/MAX([DISTINCT|ALL] expr)`
+15. **parser-builtins** — `CAST/CAN_CAST/CAN_LOSSLESS_CAST`, `EXTRACT`, `TRIM`,
+    `SUBSTRING`, `DATE_ADD`, `DATE_DIFF`, `COALESCE`, `NULLIF`, `CASE [expr] WHEN …
+    THEN … ELSE … END`, `CHAR_LENGTH`/`OCTET_LENGTH`/`BIT_LENGTH`/`UPPER`/`LOWER`/
+    `SIZE`/`EXISTS`
+16. **parser-graph** — Graph Pattern Matching (MATCH clauses with nodes, edges,
+    quantifiers `+ * {m,n}`, selectors `ANY`/`ALL SHORTEST`/`SHORTEST k`,
+    restrictors `TRAIL`/`ACYCLIC`/`SIMPLE`, path variables). **Largest single
+    feature** — budget accordingly.
+17. **parser-ion-literals** — Backtick-delimited inline Ion values via dedicated
+    lexer mode (the existing PartiQLLexer.g4 has a full ION mode at lines 327–403)
+18. **parser-datetime-literals** — `DATE 'Y-M-D'`, `TIME [(p)] [WITH TIME ZONE] '…'`,
+    `TIMESTAMP '…'` literal forms
+
+## Out of Scope
+
+The following packages exist for some omni engines but have **no bytebase consumer**
+for PartiQL today and are explicitly out of scope until that changes:
+
+- `partiql/semantic/` — type checking, semantic validation
+- `partiql/quality/`  — lint / quality checks
+- `partiql/deparse/`  — AST → SQL string
+
+If bytebase later wires up schema sync, query span, masking, or DML transformation
+for DynamoDB, add new DAG nodes at that time.
+
+## Notes
+
+- **Bytebase coupling is shallow.** Only one direct caller exists outside
+  init-time registration (`backend/plugin/db/dynamodb/dynamodb.go`), and it goes
+  through the generic `base.SplitMultiSQL`. Switching the import is mechanically
+  small once nodes 1–10 are done.
+- **Graph Pattern Matching is the largest single feature** with no analogue in
+  other omni engines. Treat node 16 as a major sub-project — its brainstorm should
+  reference the GPML spec, not just the legacy `.g4` file. It is intentionally
+  P1 because no bytebase consumer requires it today; deferring it does not block
+  the import switch.
+- **Two DML syntaxes coexist** in PartiQL (legacy path-based `FROM … DELETE …`
+  and RFC 0011 modern `DELETE FROM …`). The DML node must accept both spellings;
+  test fixtures should cover each.
+- **Ion lexer mode** is mode-switched on backticks. Splitting it out as P1
+  (node 17) because the bytebase test corpus does not exercise it; the foundational
+  lexer (node 2) only needs the standard SQL lexical structure plus `;` and
+  identifiers. Wire the mode in later without changing the rest of the lexer.
+- **Test corpus.** The legacy `simple.sql` is 5 lines and useless as a regression
+  suite. Build the omni test corpus by:
+  1. Cross-referencing each `.g4` rule from `analysis.md` to a positive/negative
+     case
+  2. Re-running the existing `bytebase/backend/plugin/parser/partiql/test-data/`
+     YAML fixtures (`test_split.yaml`, `test_completion.yaml`) against the new
+     parser as a regression check before the bytebase switch
+  3. Pulling examples from the official PartiQL spec / AWS DynamoDB PartiQL
+     reference for clauses not exercised by the existing fixtures
+- **`ON CONFLICT DO REPLACE/UPDATE` are stubs in legacy** (only `EXCLUDED`
+  parses). The omni parser should match this behavior in node 6 (parser-dml) — not
+  silently extend it. Document the gap so a follow-up can complete it consistently
+  with future PartiQL spec updates.
+- **Best-effort recovery.** Match `mongo/parse.go`'s pattern: skip to the next
+  statement boundary on syntax error and keep going. The completion engine relies
+  on this — half-typed statements must still produce a usable AST stub.
+
+## Status Tracking Legend
+
+- `not started` — not yet begun
+- `in progress` — currently being implemented (one node at a time per worker)
+- `done` — implemented, tests passing, merged
+
+When starting work on a node, change its status to `in progress`. When the node's
+implementation is merged, change it to `done`. The implementing skill
+(`omni-engine-implementing`) reads this table to pick the next actionable node.

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -1929,14 +1929,24 @@ func (n *ExplainStmt) GetLoc() Loc { return n.Loc }
 func (*ExplainStmt) stmtNode()     {}
 
 // InsertStmt represents `INSERT INTO target [AS alias] VALUE expr
-// [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
-// (INSERT INTO p VALUE …) and RFC 0011 (INSERT INTO c AS a VALUE …) forms.
+// [AT pos] [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
+// (INSERT INTO p VALUE … [AT pos]) and RFC 0011 (INSERT INTO c AS a VALUE …)
+// forms.
+//
+// Mutual exclusion between the two forms:
+//   - Legacy form (insertCommand#InsertLegacy, insertCommandReturning):
+//     AsAlias is nil; Pos may be set.
+//   - RFC 0011 form (insertCommand#Insert): AsAlias may be set; Pos is nil.
+//   - The grammar's `insertCommandReturning` (line 130–131) is the only
+//     alternative that allows `RETURNING`; on `insertCommand#InsertLegacy`
+//     (line 134) and `insertCommand#Insert` (line 136), Returning is nil.
 //
 // Grammar: insertCommand#InsertLegacy, insertCommand#Insert, insertCommandReturning
 type InsertStmt struct {
 	Target     TableExpr
 	AsAlias    *string
 	Value      ExprNode
+	Pos        ExprNode // legacy `AT pos` clause; nil for RFC 0011 form
 	OnConflict *OnConflict
 	Returning  *ReturningClause
 	Loc        Loc
@@ -2075,11 +2085,14 @@ func (*DropIndexStmt) nodeTag()      {}
 func (n *DropIndexStmt) GetLoc() Loc { return n.Loc }
 func (*DropIndexStmt) stmtNode()     {}
 
-// ExecStmt represents `EXEC name [arg, arg, ...]`.
+// ExecStmt represents `EXEC name [arg, arg, ...]`. Per the grammar
+// (PartiQLParser.g4 line 65: `EXEC name=expr ...`), the procedure name
+// is itself an expression — typically a VarRef but may be any ExprNode
+// (e.g., a parameter `?`) so the AST keeps the full breadth.
 //
 // Grammar: execCommand
 type ExecStmt struct {
-	Name string
+	Name ExprNode
 	Args []ExprNode
 	Loc  Loc
 }
@@ -3254,7 +3267,7 @@ func writeNode(sb *strings.Builder, n Node) {
 		writeNode(sb, v.Inner)
 		sb.WriteString("}")
 	case *InsertStmt:
-		writeDmlStmt(sb, "InsertStmt", v.Target, v.AsAlias, v.Value, v.OnConflict, v.Returning)
+		writeDmlStmt(sb, "InsertStmt", v.Target, v.AsAlias, v.Value, v.Pos, v.OnConflict, v.Returning)
 	case *UpdateStmt:
 		sb.WriteString("UpdateStmt{Source:")
 		writeNode(sb, v.Source)
@@ -3288,9 +3301,9 @@ func writeNode(sb *strings.Builder, n Node) {
 		}
 		sb.WriteString("}")
 	case *UpsertStmt:
-		writeDmlStmt(sb, "UpsertStmt", v.Target, v.AsAlias, v.Value, v.OnConflict, v.Returning)
+		writeDmlStmt(sb, "UpsertStmt", v.Target, v.AsAlias, v.Value, nil, v.OnConflict, v.Returning)
 	case *ReplaceStmt:
-		writeDmlStmt(sb, "ReplaceStmt", v.Target, v.AsAlias, v.Value, v.OnConflict, v.Returning)
+		writeDmlStmt(sb, "ReplaceStmt", v.Target, v.AsAlias, v.Value, nil, v.OnConflict, v.Returning)
 	case *RemoveStmt:
 		sb.WriteString("RemoveStmt{Path:")
 		writeNode(sb, v.Path)
@@ -3321,7 +3334,9 @@ func writeNode(sb *strings.Builder, n Node) {
 		writeNode(sb, v.Table)
 		sb.WriteString("}")
 	case *ExecStmt:
-		fmt.Fprintf(sb, "ExecStmt{Name:%s Args:[", v.Name)
+		sb.WriteString("ExecStmt{Name:")
+		writeNode(sb, v.Name)
+		sb.WriteString(" Args:[")
 		for i, a := range v.Args {
 			if i > 0 {
 				sb.WriteString(" ")
@@ -3598,13 +3613,20 @@ func writeSelectStmt(sb *strings.Builder, s *SelectStmt) {
 }
 
 // writeDmlStmt is shared by InsertStmt, UpsertStmt, and ReplaceStmt — they
-// have the same shape (target, alias, value, on-conflict, returning).
-func writeDmlStmt(sb *strings.Builder, name string, target TableExpr, alias *string, value ExprNode, oc *OnConflict, ret *ReturningClause) {
+// have nearly the same shape (target, alias, value, pos, on-conflict,
+// returning). For UpsertStmt and ReplaceStmt, callers pass nil for pos
+// because the grammar's `replaceCommand` (line 121) and `upsertCommand`
+// (line 125) do not have an `AT pos` clause.
+func writeDmlStmt(sb *strings.Builder, name string, target TableExpr, alias *string, value ExprNode, pos ExprNode, oc *OnConflict, ret *ReturningClause) {
 	fmt.Fprintf(sb, "%s{Target:", name)
 	writeNode(sb, target)
 	writeOptString(sb, " AsAlias:", alias)
 	sb.WriteString(" Value:")
 	writeNode(sb, value)
+	if pos != nil {
+		sb.WriteString(" Pos:")
+		writeNode(sb, pos)
+	}
 	if oc != nil {
 		sb.WriteString(" OnConflict:")
 		writeNode(sb, oc)

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -773,7 +773,7 @@ Append rows to the `cases` slice in `TestGetLoc`:
 go test ./partiql/ast/...
 ```
 
-Expected: `ok` with 16 `TestGetLoc` sub-tests passing (10 prior + 6 new).
+Expected: `ok` with 15 `TestGetLoc` sub-tests passing (9 prior + 6 new).
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -1114,7 +1114,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, all 26 `TestGetLoc` sub-tests passing (16 prior + 10 new). Note that we are intentionally NOT adding `OrderByItem` to the test table in this task — that happens in Task 9 when the real type lands.
+Expected: ok, all 25 `TestGetLoc` sub-tests passing (15 prior + 10 new). Note that we are intentionally NOT adding `OrderByItem` to the test table in this task — that happens in Task 9 when the real type lands.
 
 - [ ] **Step 6: Run vet and gofmt**
 
@@ -1379,7 +1379,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, 38 `TestGetLoc` sub-tests passing.
+Expected: ok, 37 `TestGetLoc` sub-tests passing.
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -1572,7 +1572,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, 42 sub-tests passing.
+Expected: ok, 41 sub-tests passing.
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -1683,7 +1683,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, 43 sub-tests passing.
+Expected: ok, 42 sub-tests passing.
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -2249,7 +2249,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, 57 sub-tests passing (43 prior + 14 new statements).
+Expected: ok, 56 sub-tests passing (42 prior + 14 new statements).
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -2517,7 +2517,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, 68 sub-tests passing (57 prior + 11 new).
+Expected: ok, 67 sub-tests passing (56 prior + 11 new).
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -2797,7 +2797,7 @@ go build ./partiql/ast/...
 go test ./partiql/ast/...
 ```
 
-Expected: ok, 74 sub-tests passing.
+Expected: ok, 73 sub-tests passing.
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -3992,7 +3992,7 @@ import (
 go test -run TestNodeToString_AllNodesCovered ./partiql/ast/...
 ```
 
-Expected: ok, 74 sub-tests passing. If any sub-test fails with `outfuncs.go is missing a switch arm for X`, add the missing case to `writeNode` in `outfuncs.go` and re-run.
+Expected: ok, 73 sub-tests passing. If any sub-test fails with `outfuncs.go is missing a switch arm for X`, add the missing case to `writeNode` in `outfuncs.go` and re-run.
 
 - [ ] **Step 6: Run the full test suite**
 
@@ -4000,7 +4000,7 @@ Expected: ok, 74 sub-tests passing. If any sub-test fails with `outfuncs.go is m
 go test ./partiql/ast/...
 ```
 
-Expected: ok, all tests pass (`TestGetLoc` 74 sub-tests + `TestNodeToString` 23 sub-tests + `TestNodeToString_AllNodesCovered` 74 sub-tests = 171 sub-tests across 3 test functions).
+Expected: ok, all tests pass (`TestGetLoc` 73 sub-tests + `TestNodeToString` 23 sub-tests + `TestNodeToString_AllNodesCovered` 73 sub-tests = 169 sub-tests across 3 test functions).
 
 - [ ] **Step 7: Run vet and gofmt**
 
@@ -4019,7 +4019,7 @@ git commit -m "$(cat <<'EOF'
 feat(partiql/ast): add NodeToString and reflection safety net
 
 outfuncs.go: NodeToString writes a deterministic Go-struct-like dump
-of any AST node. Switch covers all 74 node types. Loc fields are
+of any AST node. Switch covers all 73 node types. Loc fields are
 omitted (positions are tested separately). Helpers writeSelectStmt
 and writeDmlStmt extract the bigger arms.
 
@@ -4088,14 +4088,14 @@ grep -c '^func (\*\w\+) nodeTag()' partiql/ast/*.go
 # partiql/ast/tableexprs.go:4
 # partiql/ast/types.go:1
 #
-# Total ~74. If your count differs, investigate before proceeding.
+# Total ~73. If your count differs, investigate before proceeding.
 
 # Sanity: every node has GetLoc
 grep -c 'GetLoc() Loc { return n.Loc }' partiql/ast/*.go
 
 # Sanity: outfuncs.go switch has a case for every type
 grep -c '^	case \*' partiql/ast/outfuncs.go
-# Should be ~74 (one per node type).
+# Should be ~73 (one per node type).
 ```
 
 If any number is off, look for the missing types using diff between the file lists and the switch arms.
@@ -4205,8 +4205,8 @@ After `finishing-a-development-branch` completes successfully:
 2. Confirm `dag.md` on `main` shows ast-core as `done`
 3. Report to the user:
    - Which DAG node was completed
-   - How many node types were added (~74)
-   - Test pass count (~171 sub-tests)
+   - How many node types were added (~73)
+   - Test pass count (~169 sub-tests)
    - The next actionable nodes per the DAG (node 2 `lexer` should now be unblocked, node 3 `catalog` was already unblocked)
 
 ---

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -40,7 +40,7 @@ Every node struct in this package follows the same shape:
 ```go
 // <NodeName> represents <grammar feature>.
 //
-// Grammar: <PartiQLParser.g4 rule reference>
+// Grammar: <rule or rule#Label reference from PartiQLParser.g4>
 type <NodeName> struct {
     <fields...>
     Loc Loc
@@ -52,7 +52,7 @@ func (n *<NodeName>) GetLoc() Loc   { return n.Loc }
 func (*<NodeName>) exprNode()       {}
 ```
 
-**Doc comments are required** for every node and must mention which grammar rule(s) the node represents (acceptance criterion 2 in the spec). Copy the rule name from `analysis.md`'s grammar coverage tables.
+**Doc comments are required** for every node and must mention which grammar rule(s) the node represents (acceptance criterion 2 in the spec).
 
 **Pointer receivers** for `nodeTag` / `GetLoc` / sub-interface tag methods (matches `cosmosdb/ast`).
 
@@ -61,6 +61,8 @@ func (*<NodeName>) exprNode()       {}
 **No constructor functions.** Tests and parsers build nodes with struct literals (acceptance criterion: no smart constructors).
 
 **Enum types** are declared as `type Foo int` with `const ( FooA Foo = iota; FooB; ... )` blocks. Enums get a `String() string` method that returns the canonical name (used by `NodeToString`).
+
+**Grammar reference convention.** Every `// Grammar:` comment in this package uses `rule#Label` for labeled ANTLR alternatives in `bytebase/parser/partiql/PartiQLParser.g4`, and bare `rule` for unlabeled rules. **Verify each name against the grammar file before committing — invented rule names are a regression risk that already cost one fix-up commit on `literals.go`.** When a file sources types from multiple grammar rules, its file-level header should list each rule with its line range; individual node doc comments should cite their specific `rule#Label`.
 
 ---
 
@@ -89,8 +91,8 @@ Tasks 1–10 build the AST in dependency order (foundation → leaves → branch
 //
 // PartiQL is the SQL++-flavored query language used by AWS DynamoDB and
 // Azure Cosmos DB. This package mirrors the legacy bytebase/parser/partiql
-// ANTLR grammar's full coverage scope (see docs/migration/partiql/analysis.md
-// and docs/migration/partiql/dag.md).
+// ANTLR grammar's full coverage scope as defined in
+// bytebase/parser/partiql/PartiQLParser.g4.
 //
 // AST style: sealed sub-interfaces. Every node implements Node; most also
 // implement one or more of StmtNode, ExprNode, TableExpr, PathStep, TypeName,
@@ -506,9 +508,31 @@ package ast
 //   3. Paths, variables, parameters, subqueries, collection literals,
 //      window spec, path steps
 //
-// Grammar reference: PartiQLParser.g4 expression rules (`expr`, `exprOr`,
-// `exprAnd`, `exprNot`, `exprPredicate`, `mathOp00/01/02`, `valueExpr`,
-// `exprPrimary`, etc.). See docs/migration/partiql/analysis.md.
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   exprOr            (lines 469–472)
+//   exprAnd           (lines 474–477)
+//   exprNot           (lines 479–482)
+//   exprPredicate     (lines 484–492)
+//   mathOp00/01/02    (lines 494–507)
+//   valueExpr         (lines 509–512)
+//   exprPrimary       (lines 514–534)
+//   exprTerm          (lines 542–549)
+//   functionCall      (lines 611–616)
+//   caseExpr          (lines 557–558)
+//   cast/canCast/canLosslessCast (lines 593–600)
+//   extract           (lines 602–603)
+//   trimFunction      (lines 605–606)
+//   substring         (lines 572–575)
+//   coalesce          (lines 554–555)
+//   nullIf            (lines 551–552)
+//   aggregate         (lines 577–580)
+//   windowFunction    (lines 589–591)
+//   over              (lines 276–278)
+//   array/bag/tuple/pair (lines 649–659)
+//   pathStep          (lines 618–623)
+//   varRefExpr        (lines 635–636)
+//   parameter         (lines 632–633)
+// Each type below cites its specific rule#Label.
 // ---------------------------------------------------------------------------
 
 // ===========================================================================
@@ -627,8 +651,8 @@ func (t IsType) String() string {
 
 // BinaryExpr represents a binary operator application.
 //
-// Grammar: exprOr, exprAnd, mathOp00/01/02, exprPredicate (comparison forms),
-// valueExpr (concat).
+// Grammar: exprOr#Or, exprAnd#And, exprPredicate#PredicateComparison,
+//          mathOp00 (CONCAT), mathOp01 (PLUS/MINUS), mathOp02 (PERCENT/ASTERISK/SLASH_FORWARD)
 type BinaryExpr struct {
 	Op    BinOp
 	Left  ExprNode
@@ -642,7 +666,7 @@ func (*BinaryExpr) exprNode()     {}
 
 // UnaryExpr represents a unary operator application.
 //
-// Grammar: exprNot (NOT), valueExpr (unary +/-)
+// Grammar: exprNot#Not, valueExpr (unary PLUS/MINUS)
 type UnaryExpr struct {
 	Op      UnOp
 	Operand ExprNode
@@ -660,7 +684,7 @@ func (*UnaryExpr) exprNode()     {}
 // InExpr represents `expr [NOT] IN (…)` — either a parenthesized expression
 // list or a subquery.
 //
-// Grammar: exprPredicate predicateIn
+// Grammar: exprPredicate#PredicateIn
 type InExpr struct {
 	Expr     ExprNode
 	List     []ExprNode // populated when the RHS is an expression list
@@ -675,7 +699,7 @@ func (*InExpr) exprNode()     {}
 
 // BetweenExpr represents `expr [NOT] BETWEEN low AND high`.
 //
-// Grammar: exprPredicate predicateBetween
+// Grammar: exprPredicate#PredicateBetween
 type BetweenExpr struct {
 	Expr ExprNode
 	Low  ExprNode
@@ -690,7 +714,7 @@ func (*BetweenExpr) exprNode()     {}
 
 // LikeExpr represents `expr [NOT] LIKE pattern [ESCAPE escape]`.
 //
-// Grammar: exprPredicate predicateLike
+// Grammar: exprPredicate#PredicateLike
 type LikeExpr struct {
 	Expr    ExprNode
 	Pattern ExprNode
@@ -705,7 +729,7 @@ func (*LikeExpr) exprNode()     {}
 
 // IsExpr represents `expr IS [NOT] (NULL|MISSING|TRUE|FALSE)`.
 //
-// Grammar: exprPredicate predicateIs
+// Grammar: exprPredicate#PredicateIs
 type IsExpr struct {
 	Expr ExprNode
 	Type IsType
@@ -876,8 +900,9 @@ func (s TrimSpec) String() string {
 // (LAG/LEAD with an OVER clause). The Quantifier, Star, and Over fields
 // determine which flavor a particular instance is.
 //
-// Grammar: functionCall, functionCallIdent, functionCallReserved,
-//          aggregat, windowFunction
+// Grammar: functionCall#FunctionCallReserved, functionCall#FunctionCallIdent,
+//          aggregate#CountAll, aggregate#AggregateBase,
+//          windowFunction#LagLeadFunction
 type FuncCall struct {
 	Name       string
 	Args       []ExprNode
@@ -920,7 +945,7 @@ func (n *CaseWhen) GetLoc() Loc { return n.Loc }
 
 // CastExpr covers CAST, CAN_CAST, and CAN_LOSSLESS_CAST.
 //
-// Grammar: cast | canCast | canLosslessCast
+// Grammar: cast, canCast, canLosslessCast
 type CastExpr struct {
 	Kind   CastKind
 	Expr   ExprNode
@@ -1004,7 +1029,7 @@ func (*NullIfExpr) exprNode()     {}
 // WindowSpec represents the body of an OVER (...) clause attached to
 // a window function call. Bare Node — appears only inside FuncCall.Over.
 //
-// Grammar: over (PARTITION BY ... ORDER BY ...)
+// Grammar: over
 type WindowSpec struct {
 	PartitionBy []ExprNode
 	OrderBy     []*OrderByItem // OrderByItem defined in stmts.go
@@ -1144,7 +1169,7 @@ Add after the `WindowSpec` block:
 // Root is the base expression (typically a VarRef); Steps are the chained
 // path operations from PathStep.
 //
-// Grammar: pathExpr (root path step+)
+// Grammar: exprPrimary#ExprPrimaryPath (exprPrimary pathStep+)
 type PathExpr struct {
 	Root  ExprNode
 	Steps []PathStep
@@ -1188,7 +1213,7 @@ func (*ParamRef) exprNode()     {}
 // or as a FROM source. Stmt is the inner statement (a SelectStmt or
 // SetOpStmt).
 //
-// Grammar: exprPrimary parenthesized SELECT
+// Grammar: exprTerm#ExprTermWrappedQuery (PAREN_LEFT expr PAREN_RIGHT)
 type SubLink struct {
 	Stmt StmtNode
 	Loc  Loc
@@ -1259,7 +1284,7 @@ func (n *TuplePair) GetLoc() Loc { return n.Loc }
 // DotStep represents `.field`. CaseSensitive is true for `."Field"`
 // (the field name was quoted) and false for unquoted `.field`.
 //
-// Grammar: pathStepDotExpr
+// Grammar: pathStep#PathStepDotExpr
 type DotStep struct {
 	Field         string
 	CaseSensitive bool
@@ -1272,7 +1297,7 @@ func (*DotStep) pathStep()     {}
 
 // AllFieldsStep represents `.*` — the all-fields wildcard.
 //
-// Grammar: pathStepDotAll (or equivalent)
+// Grammar: pathStep#PathStepDotAll
 type AllFieldsStep struct {
 	Loc Loc
 }
@@ -1283,7 +1308,7 @@ func (*AllFieldsStep) pathStep()     {}
 
 // IndexStep represents `[expr]` — index/key by an expression.
 //
-// Grammar: pathStepIndexExpr
+// Grammar: pathStep#PathStepIndexExpr
 type IndexStep struct {
 	Index ExprNode
 	Loc   Loc
@@ -1295,7 +1320,7 @@ func (*IndexStep) pathStep()     {}
 
 // WildcardStep represents `[*]` — all-elements wildcard.
 //
-// Grammar: pathStepIndexAll (or equivalent)
+// Grammar: pathStep#PathStepIndexAll
 type WildcardStep struct {
 	Loc Loc
 }
@@ -1400,9 +1425,17 @@ package ast
 // ---------------------------------------------------------------------------
 // Table expression nodes — implement TableExpr.
 //
-// Grammar: PartiQLParser.g4 fromClause / tableReference / joinClause /
-// unpivotClause. See docs/migration/partiql/analysis.md "Joins" and
-// "FROM Clause Extensions".
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   fromClause         (lines 297–298)
+//   tableReference     (lines 389–395)
+//   tableNonJoin       (lines 397–400)
+//   tableBaseReference (lines 402–406)
+//   tableUnpivot       (lines 408–409)
+//   joinRhs            (lines 411–414)
+//   joinSpec           (lines 416–417)
+//   joinType           (lines 419–425)
+//   fromClauseSimple   (lines 202–205)
+// Each type below cites its specific rule#Label.
 //
 // IMPORTANT: PathExpr, VarRef, and SubLink (defined in exprs.go) also
 // implement TableExpr. They are not re-listed here as their primary home
@@ -1446,7 +1479,7 @@ func (k JoinKind) String() string {
 // populated only when the reference uses dotted form `schema.table`.
 // CaseSensitive is true for double-quoted identifiers.
 //
-// Grammar: tableBaseReference
+// Grammar: tableBaseReference#TableBaseRefSymbol, tableBaseReference#TableBaseRefClauses
 type TableRef struct {
 	Name          string
 	Schema        string
@@ -1462,7 +1495,8 @@ func (*TableRef) tableExpr()    {}
 // BY key` aliasing form. PartiQL-unique because of the AT/BY positional
 // and key aliases.
 //
-// Grammar: tableUnpivot, fromClauseSimpleExplicit
+// Grammar: tableBaseReference#TableBaseRefClauses, tableBaseReference#TableBaseRefMatch,
+//          tableUnpivot, fromClauseSimple#FromClauseSimpleExplicit
 type AliasedSource struct {
 	Source TableExpr
 	As     *string // optional row alias
@@ -1478,7 +1512,8 @@ func (*AliasedSource) tableExpr()    {}
 // JoinExpr represents a JOIN clause: left JOIN right ON condition.
 // Kind selects the JOIN flavor; On is nil for CROSS JOIN.
 //
-// Grammar: joinRhs / fromClause join chain
+// Grammar: tableReference#TableCrossJoin, tableReference#TableQualifiedJoin
+//          (join-type modifier from joinType; joinRhs for right-hand side)
 type JoinExpr struct {
 	Kind  JoinKind
 	Left  TableExpr
@@ -1495,7 +1530,7 @@ func (*JoinExpr) tableExpr()    {}
 // PartiQL-unique. The Source is an expression (not a TableExpr) because
 // the grammar nests an arbitrary expression here.
 //
-// Grammar: unpivotClause
+// Grammar: tableUnpivot
 type UnpivotExpr struct {
 	Source ExprNode
 	As     *string
@@ -1587,8 +1622,13 @@ package ast
 // modifiers (Args for parameterized types, WithTimeZone for TIME/TIMESTAMP),
 // so the AST mirrors that shape.
 //
-// Grammar: PartiQLParser.g4 type / typeAtomic / typeArgSingle / typeArgDouble /
-// typeTimeZone. See docs/migration/partiql/analysis.md "Type System".
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   type#TypeAtomic    (lines 675–680)
+//   type#TypeArgSingle (line 681)
+//   type#TypeVarChar   (line 682)
+//   type#TypeArgDouble (line 683)
+//   type#TypeTimeZone  (line 684)
+//   type#TypeCustom    (line 685)
 // ---------------------------------------------------------------------------
 
 // TypeRef represents any PartiQL type reference, used by CAST and DDL.
@@ -1695,8 +1735,28 @@ package ast
 //   2. Clause helpers: TargetEntry, GroupBy, OrderBy, OnConflict, Returning,
 //      etc. (Task 9 — appended below).
 //
-// Grammar reference: PartiQLParser.g4 dql/dml/ddl/execCommand rules. See
-// docs/migration/partiql/analysis.md.
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   root                   (lines 17–18)
+//   statement              (lines 20–25)
+//   dql                    (lines 55–56)
+//   dml                    (lines 94–100)
+//   dmlBaseCommand         (lines 102–108)
+//   ddl                    (lines 73–76)
+//   createCommand          (lines 78–81)
+//   dropCommand            (lines 83–86)
+//   execCommand            (lines 64–65)
+//   selectClause           (lines 216–221)
+//   exprBagOp              (lines 449–454)
+//   exprSelect             (lines 456–467)
+//   insertCommand          (lines 133–137)
+//   insertCommandReturning (lines 130–131)
+//   updateClause           (lines 182–183)
+//   deleteCommand          (lines 191–192)
+//   upsertCommand          (lines 124–125)
+//   replaceCommand         (lines 120–121)
+//   removeCommand          (lines 127–128)
+//   setCommand             (lines 185–186)
+// Each type below cites its specific rule#Label.
 // ---------------------------------------------------------------------------
 
 // ===========================================================================
@@ -1728,8 +1788,8 @@ func (k SetOpKind) String() string {
 
 // OnConflictAction discriminates the body of an ON CONFLICT clause.
 // PartiQL's legacy ANTLR grammar leaves DO REPLACE/UPDATE as stubs that
-// only accept the EXCLUDED keyword (analysis.md gap notes); the omni AST
-// matches that scope.
+// only accept the EXCLUDED keyword (see doReplace/doUpdate rules in
+// PartiQLParser.g4 lines 168–180); the omni AST matches that scope.
 type OnConflictAction int
 
 const (
@@ -1814,7 +1874,8 @@ func (m ReturningMapping) String() string {
 // `SELECT VALUE expr`. Pivot holds the PIVOT projection. At most one of
 // (Star, Value != nil, Pivot != nil, len(Targets) > 0) is set per instance.
 //
-// Grammar: dql, selectClause, projectionItems, projectionPivot, projectionValue
+// Grammar: exprSelect#SfwQuery (with selectClause#SelectAll / selectClause#SelectItems /
+//          selectClause#SelectValue / selectClause#SelectPivot)
 type SelectStmt struct {
 	Quantifier QuantifierKind   // NONE / DISTINCT / ALL
 	Star       bool             // SELECT *
@@ -1841,7 +1902,7 @@ func (*SelectStmt) stmtNode()     {}
 // PartiQL-specific OUTER variant. Both Left and Right may themselves
 // be SetOpStmt nodes for nested set operations.
 //
-// Grammar: bagOpExpr
+// Grammar: exprBagOp#Union, exprBagOp#Intersect, exprBagOp#Except
 type SetOpStmt struct {
 	Op         SetOpKind
 	Quantifier QuantifierKind
@@ -1857,7 +1918,7 @@ func (*SetOpStmt) stmtNode()     {}
 
 // ExplainStmt wraps any other StmtNode with an EXPLAIN prefix.
 //
-// Grammar: root EXPLAIN
+// Grammar: root (EXPLAIN prefix on the root rule)
 type ExplainStmt struct {
 	Inner StmtNode
 	Loc   Loc
@@ -1871,7 +1932,7 @@ func (*ExplainStmt) stmtNode()     {}
 // [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
 // (INSERT INTO p VALUE …) and RFC 0011 (INSERT INTO c AS a VALUE …) forms.
 //
-// Grammar: insertCommandReturning, insertStatement
+// Grammar: insertCommand#InsertLegacy, insertCommand#Insert, insertCommandReturning
 type InsertStmt struct {
 	Target     TableExpr
 	AsAlias    *string
@@ -1888,7 +1949,7 @@ func (*InsertStmt) stmtNode()     {}
 // UpdateStmt represents `UPDATE source SET ... [WHERE ...] [RETURNING ...]`
 // and the equivalent `FROM source SET ...` form.
 //
-// Grammar: updateClause, dmlBaseWrapper update head
+// Grammar: updateClause, dml#DmlBaseWrapper (with dmlBaseCommand containing setCommand)
 type UpdateStmt struct {
 	Source    TableExpr
 	Sets      []*SetAssignment
@@ -1966,7 +2027,7 @@ func (*RemoveStmt) stmtNode()     {}
 // CreateTableStmt represents `CREATE TABLE name`. PartiQL DDL has no
 // column definitions or constraints — just the table name.
 //
-// Grammar: createTable
+// Grammar: createCommand#CreateTable
 type CreateTableStmt struct {
 	Name *VarRef
 	Loc  Loc
@@ -1978,7 +2039,7 @@ func (*CreateTableStmt) stmtNode()     {}
 
 // CreateIndexStmt represents `CREATE INDEX ON table (path, path, ...)`.
 //
-// Grammar: createIndex
+// Grammar: createCommand#CreateIndex
 type CreateIndexStmt struct {
 	Table *VarRef
 	Paths []*PathExpr
@@ -1991,7 +2052,7 @@ func (*CreateIndexStmt) stmtNode()     {}
 
 // DropTableStmt represents `DROP TABLE name`.
 //
-// Grammar: dropTable
+// Grammar: dropCommand#DropTable
 type DropTableStmt struct {
 	Name *VarRef
 	Loc  Loc
@@ -2003,7 +2064,7 @@ func (*DropTableStmt) stmtNode()     {}
 
 // DropIndexStmt represents `DROP INDEX index ON table`.
 //
-// Grammar: dropIndex
+// Grammar: dropCommand#DropIndex
 type DropIndexStmt struct {
 	Index *VarRef
 	Table *VarRef
@@ -2268,7 +2329,7 @@ func (n *TargetEntry) GetLoc() Loc { return n.Loc }
 // PivotProjection represents the body of a `PIVOT v AT k` projection.
 // Used as SelectStmt.Pivot. PartiQL-unique.
 //
-// Grammar: projectionPivot
+// Grammar: selectClause#SelectPivot
 type PivotProjection struct {
 	Value ExprNode
 	At    ExprNode
@@ -2352,7 +2413,7 @@ func (n *SetAssignment) GetLoc() Loc { return n.Loc }
 // OnConflict represents the body of an ON CONFLICT clause:
 // `ON CONFLICT [target] [WHERE expr] action`.
 //
-// Grammar: onConflict, onConflictLegacy
+// Grammar: onConflictClause#OnConflict, onConflictClause#OnConflictLegacy
 type OnConflict struct {
 	Target *OnConflictTarget
 	Action OnConflictAction
@@ -2392,7 +2453,7 @@ func (n *ReturningClause) GetLoc() Loc { return n.Loc }
 // in a RETURNING clause. Star is true for the `*` form; otherwise Expr
 // holds the projection expression.
 //
-// Grammar: returningElem, returningColumn
+// Grammar: returningColumn
 type ReturningItem struct {
 	Status  ReturningStatus
 	Mapping ReturningMapping
@@ -2506,13 +2567,29 @@ package ast
 //
 // PartiQL has a graph pattern matching extension based on GPML. The full
 // shape of the field set inside NodePattern/EdgePattern may be refined when
-// the parser-graph DAG node (node 16) is implemented and we read
-// PartiQLParser.g4 lines 314–382 carefully. The marker interface, the node
-// names, and the multi-interface relationship to ExprNode are stable in
-// this initial pass.
+// the parser-graph DAG node (node 16) is implemented and we read the grammar
+// more carefully. The marker interface, the node names, and the multi-interface
+// relationship to ExprNode are stable in this initial pass.
 //
-// Grammar: PartiQLParser.g4 graphMatchPattern, gpmlPattern, matchPattern,
-// nodePattern, edgePattern, etc.
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   gpmlPattern          (lines 315–316)
+//   gpmlPatternList      (lines 318–319)
+//   matchPattern         (lines 321–322)
+//   graphPart            (lines 324–328)
+//   matchSelector        (lines 330–334)
+//   patternPathVariable  (lines 336–337)
+//   patternRestrictor    (lines 339–340)
+//   node                 (lines 342–343)
+//   edge                 (lines 345–348)
+//   pattern              (lines 350–353)
+//   patternQuantifier    (lines 355–358)
+//   edgeWSpec            (lines 360–368)
+//   edgeSpec             (lines 370–371)
+//   patternPartLabel     (lines 373–374)
+//   edgeAbbrev           (lines 376–381)
+//   exprGraphMatchOne    (lines 628–629)
+//   exprGraphMatchMany   (lines 625–626)
+// Each type below cites its specific rule#Label.
 // ---------------------------------------------------------------------------
 
 // EdgeDirection identifies the direction of an edge pattern.
@@ -2630,7 +2707,7 @@ func (*GraphPattern) patternNode()  {}
 // NodePattern represents `(var:Label WHERE …)`. Variable, Labels, and
 // Where are all optional.
 //
-// Grammar: nodePattern
+// Grammar: node
 type NodePattern struct {
 	Variable *VarRef
 	Labels   []string
@@ -2645,7 +2722,8 @@ func (*NodePattern) patternNode()  {}
 // EdgePattern represents `-[var:Label]->`, `<-[]-`, `~[]~`, etc.
 // Direction is required; Variable, Labels, Where, and Quantifier are optional.
 //
-// Grammar: edgePattern, edgeWSpec
+// Grammar: edge#EdgeWithSpec, edge#EdgeAbbreviated
+//          (direction comes from edgeWSpec labels / edgeAbbrev; body from edgeSpec)
 type EdgePattern struct {
 	Direction  EdgeDirection
 	Variable   *VarRef
@@ -2676,7 +2754,7 @@ func (n *PatternQuantifier) GetLoc() Loc { return n.Loc }
 // pattern: `ANY`, `ALL SHORTEST`, or `SHORTEST k`. K is non-zero only for
 // SHORTEST K.
 //
-// Grammar: patternPathVariable selector
+// Grammar: matchSelector#SelectorBasic, matchSelector#SelectorAny, matchSelector#SelectorShortest
 type PatternSelector struct {
 	Kind SelectorKind
 	K    int

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -2606,17 +2606,21 @@ package ast
 // ---------------------------------------------------------------------------
 
 // EdgeDirection identifies the direction of an edge pattern.
+//
+// Enumerates the seven edge alternatives from PartiQLParser.g4 `edgeWSpec`
+// (lines 360–368) and `edgeAbbrev` (lines 376–381). Each value maps to the
+// bare grammar symbol via String().
 type EdgeDirection int
 
 const (
-	EdgeDirInvalid EdgeDirection = iota
-	EdgeDirRight              // ->
-	EdgeDirLeft               // <-
-	EdgeDirUndirected         // ~
-	EdgeDirLeftOrRight        // <-> (left or right)
-	EdgeDirLeftOrUndirected   // <~
-	EdgeDirRightOrUndirected  // ~>
-	EdgeDirAny                // any direction
+	EdgeDirInvalid                 EdgeDirection = iota
+	EdgeDirRight                                 // ->          edgeWSpec#EdgeSpecRight
+	EdgeDirLeft                                  // <-          edgeWSpec#EdgeSpecLeft
+	EdgeDirUndirected                            // ~           edgeWSpec#EdgeSpecUndirected
+	EdgeDirLeftOrRight                           // <->         edgeWSpec#EdgeSpecBidirectional
+	EdgeDirLeftOrUndirected                      // <~          edgeWSpec#EdgeSpecUndirectedLeft
+	EdgeDirRightOrUndirected                     // ~>          edgeWSpec#EdgeSpecUndirectedRight
+	EdgeDirUndirectedBidirectional               // -           edgeWSpec#EdgeSpecUndirectedBidirectional (any of right/left/undirected)
 )
 
 func (d EdgeDirection) String() string {
@@ -2633,8 +2637,8 @@ func (d EdgeDirection) String() string {
 		return "<~"
 	case EdgeDirRightOrUndirected:
 		return "~>"
-	case EdgeDirAny:
-		return "any"
+	case EdgeDirUndirectedBidirectional:
+		return "-"
 	default:
 		return "INVALID"
 	}

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -2865,6 +2865,7 @@ package ast
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -2892,6 +2893,15 @@ func NodeToString(n Node) string {
 // textual representation to sb.
 func writeNode(sb *strings.Builder, n Node) {
 	if n == nil {
+		sb.WriteString("<nil>")
+		return
+	}
+	// Detect typed-nil pointers (e.g. (*VarRef)(nil) wrapped in a Node
+	// interface). The plain `n == nil` check above only catches an
+	// untyped nil interface; the reflection check is needed by the
+	// TestNodeToString_AllNodesCovered safety net which constructs
+	// zero-value parent nodes whose pointer fields are typed nil.
+	if rv := reflect.ValueOf(n); rv.Kind() == reflect.Pointer && rv.IsNil() {
 		sb.WriteString("<nil>")
 		return
 	}
@@ -3488,15 +3498,24 @@ func writeNode(sb *strings.Builder, n Node) {
 		sb.WriteString("]}")
 	case *NodePattern:
 		sb.WriteString("NodePattern{")
+		first := true
+		sep := func() {
+			if !first {
+				sb.WriteString(" ")
+			}
+			first = false
+		}
 		if v.Variable != nil {
+			sep()
 			sb.WriteString("Variable:")
 			writeNode(sb, v.Variable)
-			sb.WriteString(" ")
 		}
 		if len(v.Labels) > 0 {
-			fmt.Fprintf(sb, "Labels:[%s] ", strings.Join(v.Labels, " "))
+			sep()
+			fmt.Fprintf(sb, "Labels:[%s]", strings.Join(v.Labels, " "))
 		}
 		if v.Where != nil {
+			sep()
 			sb.WriteString("Where:")
 			writeNode(sb, v.Where)
 		}

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -1,0 +1,4205 @@
+# PartiQL ast-core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `partiql/ast` Go package — ~74 hand-written AST node types covering the full legacy ANTLR PartiQL grammar, organized via 6 sealed sub-interfaces, with a `NodeToString` debug helper and table-driven unit tests for tag dispatch and `Loc` handling.
+
+**Architecture:** Sealed sub-interface style (`Node` + `StmtNode`/`ExprNode`/`TableExpr`/`PathStep`/`TypeName`/`PatternNode`) modeled on `cosmosdb/ast/`. Each node embeds a `Loc` field with byte offsets only (no line/column). 8 source files split by category, plus `ast_test.go` and `outfuncs.go`. Pure Go, standard library only, no external dependencies.
+
+**Tech Stack:** Go (matching the omni `go.mod` toolchain), `testing` package, `reflect` for the safety-net coverage test.
+
+**Spec:** `docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md`
+
+**DAG entry:** `docs/migration/partiql/dag.md` node 1 (P0).
+
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core`
+**Branch:** `feat/partiql/ast-core`
+
+---
+
+## File Map
+
+| File | Lines (approx) | Responsibility |
+|------|---------------|---------------|
+| `partiql/ast/node.go` | ~120 | Six interfaces (`Node`/`StmtNode`/`ExprNode`/`TableExpr`/`PathStep`/`TypeName`/`PatternNode`), `Loc` struct, `List` helper |
+| `partiql/ast/literals.go` | ~270 | 9 literal nodes — all `ExprNode` |
+| `partiql/ast/exprs.go` | ~750 | 28 expression nodes (operators, predicates, special-forms, paths, vars, params, subqueries, collection literals, window spec, path steps) + 6 enums |
+| `partiql/ast/tableexprs.go` | ~120 | 4 table-position nodes (`TableRef`, `AliasedSource`, `JoinExpr`, `UnpivotExpr`) + `JoinKind` enum. Also documents the multi-interface re-exports from `exprs.go`. |
+| `partiql/ast/types.go` | ~30 | Single `TypeRef` node implementing `TypeName` |
+| `partiql/ast/stmts.go` | ~700 | 14 top-level statement nodes + 11 clause/DML helpers + 5 enums |
+| `partiql/ast/patterns.go` | ~180 | 6 graph-pattern nodes + 3 enums |
+| `partiql/ast/outfuncs.go` | ~600 | `NodeToString` — giant type switch over every node type |
+| `partiql/ast/ast_test.go` | ~600 | Compile-time interface assertions, `TestGetLoc`, `TestNodeToString` golden cases, `TestNodeToString_AllNodesCovered` reflection safety net |
+
+**Total:** ~3370 lines across 9 files for ~74 node types and ~14 enum types.
+
+## Conventions Applied To Every Type
+
+Every node struct in this package follows the same shape:
+
+```go
+// <NodeName> represents <grammar feature>.
+//
+// Grammar: <PartiQLParser.g4 rule reference>
+type <NodeName> struct {
+    <fields...>
+    Loc Loc
+}
+
+func (*<NodeName>) nodeTag()        {}
+func (n *<NodeName>) GetLoc() Loc   { return n.Loc }
+// ... and one or more sub-interface tag methods, e.g.:
+func (*<NodeName>) exprNode()       {}
+```
+
+**Doc comments are required** for every node and must mention which grammar rule(s) the node represents (acceptance criterion 2 in the spec). Copy the rule name from `analysis.md`'s grammar coverage tables.
+
+**Pointer receivers** for `nodeTag` / `GetLoc` / sub-interface tag methods (matches `cosmosdb/ast`).
+
+**Loc field is always last** in the struct.
+
+**No constructor functions.** Tests and parsers build nodes with struct literals (acceptance criterion: no smart constructors).
+
+**Enum types** are declared as `type Foo int` with `const ( FooA Foo = iota; FooB; ... )` blocks. Enums get a `String() string` method that returns the canonical name (used by `NodeToString`).
+
+---
+
+## Task Order Rationale
+
+Tasks 1–10 build the AST in dependency order (foundation → leaves → branches → compound types). Task 11 wires `NodeToString` over the complete type set. Task 12 is final verification + DAG bookkeeping + branch finishing.
+
+**Why exprs.go is split into 3 tasks** (3, 4, 5): exprs.go has 28 types and would otherwise be a single ~800-line task with too many sub-types in one commit. Splitting along grammar boundaries (operators, special-forms, paths/vars/collections) keeps each commit reviewable.
+
+**Why stmts.go is split into 2 tasks** (8, 9): same reason — 25 types in two coherent groups (top-level statements vs. clause helpers).
+
+**Note on enum location:** The spec listed `QuantifierKind` under "Enums declared in stmts.go" but it is first used by `FuncCall` in `exprs.go`. To avoid forward references during incremental builds, **`QuantifierKind` is declared in `exprs.go`**, not stmts.go. This is the only deviation from the spec's enum-location list.
+
+---
+
+### Task 1: Foundation — `node.go` and test bootstrap
+
+**Files:**
+- Create: `partiql/ast/node.go`
+- Create: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Create `partiql/ast/node.go`**
+
+```go
+// Package ast defines parse-tree node types for the omni PartiQL parser.
+//
+// PartiQL is the SQL++-flavored query language used by AWS DynamoDB and
+// Azure Cosmos DB. This package mirrors the legacy bytebase/parser/partiql
+// ANTLR grammar's full coverage scope (see docs/migration/partiql/analysis.md
+// and docs/migration/partiql/dag.md).
+//
+// AST style: sealed sub-interfaces. Every node implements Node; most also
+// implement one or more of StmtNode, ExprNode, TableExpr, PathStep, TypeName,
+// or PatternNode for compile-time position discipline. A handful of small
+// clause helpers (e.g. TargetEntry, CaseWhen) are bare Node.
+//
+// See docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md for the
+// design rationale.
+package ast
+
+// Loc is a half-open byte range describing where a node appears in the
+// original source text. Loc{-1, -1} means the position is unknown
+// (synthetic nodes constructed post-parse).
+type Loc struct {
+	Start int // inclusive byte offset
+	End   int // exclusive byte offset
+}
+
+// Node is the root interface for all PartiQL parse-tree nodes.
+//
+// Implementations carry a Loc field and expose it via GetLoc. The
+// unexported nodeTag method seals the interface so only types in this
+// package can implement it.
+type Node interface {
+	nodeTag()
+	GetLoc() Loc
+}
+
+// StmtNode marks top-level statement nodes — SELECT, INSERT, CREATE TABLE,
+// EXEC, EXPLAIN, etc. Anything that can appear at script-statement position.
+type StmtNode interface {
+	Node
+	stmtNode()
+}
+
+// ExprNode marks scalar-position expression nodes — operators, predicates,
+// function calls, literals, paths, variables, subqueries, etc.
+type ExprNode interface {
+	Node
+	exprNode()
+}
+
+// TableExpr marks nodes that appear in FROM position — table references,
+// aliased sources, joins, unpivot.
+//
+// PathExpr, VarRef, and SubLink (defined in exprs.go) deliberately also
+// implement TableExpr because PartiQL's grammar lets the same productions
+// (path navigation, identifiers, parenthesized SELECTs) appear in both
+// scalar and FROM position. See tableexprs.go for details.
+type TableExpr interface {
+	Node
+	tableExpr()
+}
+
+// PathStep marks a single step in a PartiQL path expression:
+// .field, .*, [expr], [*]. Path steps are chained inside a PathExpr.
+type PathStep interface {
+	Node
+	pathStep()
+}
+
+// TypeName marks a PartiQL type reference, used by CAST and DDL.
+// PartiQL's type system is small enough that a single concrete TypeRef
+// implementation in types.go covers everything.
+type TypeName interface {
+	Node
+	typeName()
+}
+
+// PatternNode marks GPML graph-match pattern nodes — node patterns,
+// edge patterns, quantifiers, selectors.
+type PatternNode interface {
+	Node
+	patternNode()
+}
+
+// List is a generic ordered collection of nodes used as a building block
+// for cases where the elements are heterogeneous. Most parser-side lists
+// use a typed slice (e.g. []ExprNode, []*TargetEntry) instead; List exists
+// primarily so NodeToString has a uniform way to dump heterogenous groups.
+type List struct {
+	Items []Node
+	Loc   Loc
+}
+
+func (*List) nodeTag()      {}
+func (l *List) GetLoc() Loc { return l.Loc }
+
+// Len returns the number of items in the list, treating a nil receiver as 0.
+func (l *List) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.Items)
+}
+```
+
+- [ ] **Step 2: Create `partiql/ast/ast_test.go` with the package boilerplate and the `List` test**
+
+```go
+package ast
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Compile-time interface assertions.
+//
+// Every node type added to this package gets a `var _ <Interface> = (*Type)(nil)`
+// line below. The file fails to compile if a node's interface set drifts.
+// Tasks add their assertions to the appropriate section as they grow the AST.
+// ---------------------------------------------------------------------------
+
+var _ Node = (*List)(nil)
+
+// ---------------------------------------------------------------------------
+// TestGetLoc — table-driven Loc round-trip.
+//
+// One row per node type. Each row constructs the node with Loc{10, 20},
+// calls GetLoc(), and asserts the result.
+// ---------------------------------------------------------------------------
+
+func TestGetLoc(t *testing.T) {
+	cases := []struct {
+		name string
+		node Node
+	}{
+		{"List", &List{Loc: Loc{Start: 10, End: 20}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.node.GetLoc()
+			if got.Start != 10 || got.End != 20 {
+				t.Errorf("GetLoc() = %+v, want {10, 20}", got)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run `go build` and `go test` to verify it compiles and passes**
+
+Run from the worktree root:
+
+```bash
+cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected output ends with:
+
+```
+ok  	github.com/bytebase/omni/partiql/ast	0.XXXs
+```
+
+If you see `cannot find package "github.com/bytebase/omni/partiql/ast"`, the package didn't get created — re-check Step 1. If you see compile errors, fix them before proceeding.
+
+- [ ] **Step 4: Run `go vet` and `gofmt -l`**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both should produce no output. If `gofmt -l` lists a file, run `gofmt -w partiql/ast/<file>` to fix it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/node.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): scaffold ast package with interfaces and Loc
+
+First commit toward partiql/ast (DAG node 1, P0). Defines:
+- 6 sealed sub-interfaces: Node, StmtNode, ExprNode, TableExpr,
+  PathStep, TypeName, PatternNode
+- Loc struct (byte offsets, -1 = unknown)
+- List helper for heterogeneous node collections
+- ast_test.go bootstrap with TestGetLoc table
+
+Per spec docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `literals.go` — 9 literal nodes
+
+**Files:**
+- Create: `partiql/ast/literals.go`
+- Modify: `partiql/ast/ast_test.go` (append interface assertions and TestGetLoc rows)
+
+- [ ] **Step 1: Create `partiql/ast/literals.go`**
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// Literal nodes — all implement ExprNode.
+//
+// Grammar: PartiQLParser.g4 — `literal`, `dateLit`, `timeLit`, `timestampLit`,
+// `ionLit`. See docs/migration/partiql/analysis.md "Literals" sub-sections.
+// ---------------------------------------------------------------------------
+
+// StringLit represents a single-quoted string literal: 'hello'.
+//
+// Grammar: literal LITERAL_STRING
+type StringLit struct {
+	Val string // unescaped string content
+	Loc Loc
+}
+
+func (*StringLit) nodeTag()      {}
+func (n *StringLit) GetLoc() Loc { return n.Loc }
+func (*StringLit) exprNode()     {}
+
+// NumberLit represents a numeric literal. Val stores the raw text to
+// preserve the original representation (integer vs decimal vs scientific).
+//
+// Grammar: literal LITERAL_INTEGER | LITERAL_DECIMAL
+type NumberLit struct {
+	Val string // raw text as it appears in source
+	Loc Loc
+}
+
+func (*NumberLit) nodeTag()      {}
+func (n *NumberLit) GetLoc() Loc { return n.Loc }
+func (*NumberLit) exprNode()     {}
+
+// BoolLit represents TRUE or FALSE.
+//
+// Grammar: literal TRUE | FALSE
+type BoolLit struct {
+	Val bool
+	Loc Loc
+}
+
+func (*BoolLit) nodeTag()      {}
+func (n *BoolLit) GetLoc() Loc { return n.Loc }
+func (*BoolLit) exprNode()     {}
+
+// NullLit represents NULL.
+//
+// Grammar: literal NULL
+type NullLit struct {
+	Loc Loc
+}
+
+func (*NullLit) nodeTag()      {}
+func (n *NullLit) GetLoc() Loc { return n.Loc }
+func (*NullLit) exprNode()     {}
+
+// MissingLit represents the PartiQL-distinct MISSING value.
+//
+// Grammar: literal MISSING
+type MissingLit struct {
+	Loc Loc
+}
+
+func (*MissingLit) nodeTag()      {}
+func (n *MissingLit) GetLoc() Loc { return n.Loc }
+func (*MissingLit) exprNode()     {}
+
+// DateLit represents `DATE 'YYYY-MM-DD'`.
+//
+// Grammar: dateLit DATE LITERAL_STRING
+type DateLit struct {
+	Val string // YYYY-MM-DD body
+	Loc Loc
+}
+
+func (*DateLit) nodeTag()      {}
+func (n *DateLit) GetLoc() Loc { return n.Loc }
+func (*DateLit) exprNode()     {}
+
+// TimeLit represents `TIME [(p)] [WITH TIME ZONE] 'HH:MM:SS[.frac]'`.
+//
+// Grammar: timeLit TIME (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
+//          (WITH TIME ZONE)? LITERAL_STRING
+type TimeLit struct {
+	Val          string // HH:MM:SS[.frac] body
+	Precision    *int   // optional fractional-seconds precision
+	WithTimeZone bool   // WITH TIME ZONE clause present
+	Loc          Loc
+}
+
+func (*TimeLit) nodeTag()      {}
+func (n *TimeLit) GetLoc() Loc { return n.Loc }
+func (*TimeLit) exprNode()     {}
+
+// TimestampLit represents `TIMESTAMP [(p)] [WITH TIME ZONE] '…'`.
+//
+// Grammar: timestampLit TIMESTAMP (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
+//          (WITH TIME ZONE)? LITERAL_STRING
+type TimestampLit struct {
+	Val          string
+	Precision    *int
+	WithTimeZone bool
+	Loc          Loc
+}
+
+func (*TimestampLit) nodeTag()      {}
+func (n *TimestampLit) GetLoc() Loc { return n.Loc }
+func (*TimestampLit) exprNode()     {}
+
+// IonLit represents a backtick-delimited inline Ion value: `…`.
+// Text holds the verbatim contents between the backticks (no parsing,
+// no normalization). PartiQL-unique.
+//
+// Grammar: ionLit ION_LITERAL
+type IonLit struct {
+	Text string
+	Loc  Loc
+}
+
+func (*IonLit) nodeTag()      {}
+func (n *IonLit) GetLoc() Loc { return n.Loc }
+func (*IonLit) exprNode()     {}
+```
+
+- [ ] **Step 2: Append interface assertions and TestGetLoc rows to `ast_test.go`**
+
+Modify `partiql/ast/ast_test.go` — add the literal assertions just below the `var _ Node = (*List)(nil)` line:
+
+```go
+// Literals — all implement ExprNode.
+var _ ExprNode = (*StringLit)(nil)
+var _ ExprNode = (*NumberLit)(nil)
+var _ ExprNode = (*BoolLit)(nil)
+var _ ExprNode = (*NullLit)(nil)
+var _ ExprNode = (*MissingLit)(nil)
+var _ ExprNode = (*DateLit)(nil)
+var _ ExprNode = (*TimeLit)(nil)
+var _ ExprNode = (*TimestampLit)(nil)
+var _ ExprNode = (*IonLit)(nil)
+```
+
+Then expand the `cases` slice in `TestGetLoc` to include all 9 literal types (one row each):
+
+```go
+cases := []struct {
+    name string
+    node Node
+}{
+    {"List", &List{Loc: Loc{Start: 10, End: 20}}},
+    {"StringLit", &StringLit{Loc: Loc{Start: 10, End: 20}}},
+    {"NumberLit", &NumberLit{Loc: Loc{Start: 10, End: 20}}},
+    {"BoolLit", &BoolLit{Loc: Loc{Start: 10, End: 20}}},
+    {"NullLit", &NullLit{Loc: Loc{Start: 10, End: 20}}},
+    {"MissingLit", &MissingLit{Loc: Loc{Start: 10, End: 20}}},
+    {"DateLit", &DateLit{Loc: Loc{Start: 10, End: 20}}},
+    {"TimeLit", &TimeLit{Loc: Loc{Start: 10, End: 20}}},
+    {"TimestampLit", &TimestampLit{Loc: Loc{Start: 10, End: 20}}},
+    {"IonLit", &IonLit{Loc: Loc{Start: 10, End: 20}}},
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core
+go test -run TestGetLoc ./partiql/ast/...
+```
+
+Expected: `ok` with all 10 sub-tests passing (`List` + 9 literals).
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both should produce no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/literals.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add literal node types
+
+9 literal nodes — StringLit, NumberLit, BoolLit, NullLit, MissingLit,
+DateLit, TimeLit, TimestampLit, IonLit. All implement ExprNode.
+
+MissingLit and IonLit are PartiQL-unique. TimeLit/TimestampLit carry
+Precision and WithTimeZone fields for the full TIME/TIMESTAMP literal
+syntax (PartiQLParser.g4 timeLit/timestampLit rules).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `exprs.go` — operators, predicates (6 types + 3 enums)
+
+**Files:**
+- Create: `partiql/ast/exprs.go`
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Create `partiql/ast/exprs.go` with operators and predicates**
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// Expression nodes — all implement ExprNode.
+//
+// This file is built in three task groups (matching the implementation plan):
+//   1. Operators & predicates (this section)
+//   2. Special-form expressions: FuncCall, CaseExpr, CastExpr, etc.
+//   3. Paths, variables, parameters, subqueries, collection literals,
+//      window spec, path steps
+//
+// Grammar reference: PartiQLParser.g4 expression rules (`expr`, `exprOr`,
+// `exprAnd`, `exprNot`, `exprPredicate`, `mathOp00/01/02`, `valueExpr`,
+// `exprPrimary`, etc.). See docs/migration/partiql/analysis.md.
+// ---------------------------------------------------------------------------
+
+// ===========================================================================
+// Operator enums
+// ===========================================================================
+
+// BinOp identifies a binary operator.
+type BinOp int
+
+const (
+	BinOpInvalid BinOp = iota
+	BinOpOr
+	BinOpAnd
+	BinOpConcat // ||
+	BinOpAdd
+	BinOpSub
+	BinOpMul
+	BinOpDiv
+	BinOpMod
+	BinOpEq
+	BinOpNotEq
+	BinOpLt
+	BinOpGt
+	BinOpLtEq
+	BinOpGtEq
+)
+
+// String returns the canonical operator spelling.
+func (op BinOp) String() string {
+	switch op {
+	case BinOpOr:
+		return "OR"
+	case BinOpAnd:
+		return "AND"
+	case BinOpConcat:
+		return "||"
+	case BinOpAdd:
+		return "+"
+	case BinOpSub:
+		return "-"
+	case BinOpMul:
+		return "*"
+	case BinOpDiv:
+		return "/"
+	case BinOpMod:
+		return "%"
+	case BinOpEq:
+		return "="
+	case BinOpNotEq:
+		return "<>"
+	case BinOpLt:
+		return "<"
+	case BinOpGt:
+		return ">"
+	case BinOpLtEq:
+		return "<="
+	case BinOpGtEq:
+		return ">="
+	default:
+		return "INVALID"
+	}
+}
+
+// UnOp identifies a unary operator.
+type UnOp int
+
+const (
+	UnOpInvalid UnOp = iota
+	UnOpNot
+	UnOpNeg // unary -
+	UnOpPos // unary +
+)
+
+func (op UnOp) String() string {
+	switch op {
+	case UnOpNot:
+		return "NOT"
+	case UnOpNeg:
+		return "-"
+	case UnOpPos:
+		return "+"
+	default:
+		return "INVALID"
+	}
+}
+
+// IsType identifies the right-hand side of an `IS [NOT] X` predicate.
+type IsType int
+
+const (
+	IsTypeInvalid IsType = iota
+	IsTypeNull
+	IsTypeMissing
+	IsTypeTrue
+	IsTypeFalse
+)
+
+func (t IsType) String() string {
+	switch t {
+	case IsTypeNull:
+		return "NULL"
+	case IsTypeMissing:
+		return "MISSING"
+	case IsTypeTrue:
+		return "TRUE"
+	case IsTypeFalse:
+		return "FALSE"
+	default:
+		return "INVALID"
+	}
+}
+
+// ===========================================================================
+// Operator nodes
+// ===========================================================================
+
+// BinaryExpr represents a binary operator application.
+//
+// Grammar: exprOr, exprAnd, mathOp00/01/02, exprPredicate (comparison forms),
+// valueExpr (concat).
+type BinaryExpr struct {
+	Op    BinOp
+	Left  ExprNode
+	Right ExprNode
+	Loc   Loc
+}
+
+func (*BinaryExpr) nodeTag()      {}
+func (n *BinaryExpr) GetLoc() Loc { return n.Loc }
+func (*BinaryExpr) exprNode()     {}
+
+// UnaryExpr represents a unary operator application.
+//
+// Grammar: exprNot (NOT), valueExpr (unary +/-)
+type UnaryExpr struct {
+	Op      UnOp
+	Operand ExprNode
+	Loc     Loc
+}
+
+func (*UnaryExpr) nodeTag()      {}
+func (n *UnaryExpr) GetLoc() Loc { return n.Loc }
+func (*UnaryExpr) exprNode()     {}
+
+// ===========================================================================
+// Predicate nodes
+// ===========================================================================
+
+// InExpr represents `expr [NOT] IN (…)` — either a parenthesized expression
+// list or a subquery.
+//
+// Grammar: exprPredicate predicateIn
+type InExpr struct {
+	Expr     ExprNode
+	List     []ExprNode // populated when the RHS is an expression list
+	Subquery StmtNode   // populated when the RHS is a parenthesized SELECT
+	Not      bool
+	Loc      Loc
+}
+
+func (*InExpr) nodeTag()      {}
+func (n *InExpr) GetLoc() Loc { return n.Loc }
+func (*InExpr) exprNode()     {}
+
+// BetweenExpr represents `expr [NOT] BETWEEN low AND high`.
+//
+// Grammar: exprPredicate predicateBetween
+type BetweenExpr struct {
+	Expr ExprNode
+	Low  ExprNode
+	High ExprNode
+	Not  bool
+	Loc  Loc
+}
+
+func (*BetweenExpr) nodeTag()      {}
+func (n *BetweenExpr) GetLoc() Loc { return n.Loc }
+func (*BetweenExpr) exprNode()     {}
+
+// LikeExpr represents `expr [NOT] LIKE pattern [ESCAPE escape]`.
+//
+// Grammar: exprPredicate predicateLike
+type LikeExpr struct {
+	Expr    ExprNode
+	Pattern ExprNode
+	Escape  ExprNode // nil if no ESCAPE clause
+	Not     bool
+	Loc     Loc
+}
+
+func (*LikeExpr) nodeTag()      {}
+func (n *LikeExpr) GetLoc() Loc { return n.Loc }
+func (*LikeExpr) exprNode()     {}
+
+// IsExpr represents `expr IS [NOT] (NULL|MISSING|TRUE|FALSE)`.
+//
+// Grammar: exprPredicate predicateIs
+type IsExpr struct {
+	Expr ExprNode
+	Type IsType
+	Not  bool
+	Loc  Loc
+}
+
+func (*IsExpr) nodeTag()      {}
+func (n *IsExpr) GetLoc() Loc { return n.Loc }
+func (*IsExpr) exprNode()     {}
+```
+
+- [ ] **Step 2: Append interface assertions and TestGetLoc rows for the new types**
+
+In `partiql/ast/ast_test.go`, add a section below the literals assertions:
+
+```go
+// Operators & predicates (exprs.go).
+var _ ExprNode = (*BinaryExpr)(nil)
+var _ ExprNode = (*UnaryExpr)(nil)
+var _ ExprNode = (*InExpr)(nil)
+var _ ExprNode = (*BetweenExpr)(nil)
+var _ ExprNode = (*LikeExpr)(nil)
+var _ ExprNode = (*IsExpr)(nil)
+```
+
+Append rows to the `cases` slice in `TestGetLoc`:
+
+```go
+{"BinaryExpr",  &BinaryExpr{Loc: Loc{Start: 10, End: 20}}},
+{"UnaryExpr",   &UnaryExpr{Loc: Loc{Start: 10, End: 20}}},
+{"InExpr",      &InExpr{Loc: Loc{Start: 10, End: 20}}},
+{"BetweenExpr", &BetweenExpr{Loc: Loc{Start: 10, End: 20}}},
+{"LikeExpr",    &LikeExpr{Loc: Loc{Start: 10, End: 20}}},
+{"IsExpr",      &IsExpr{Loc: Loc{Start: 10, End: 20}}},
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./partiql/ast/...
+```
+
+Expected: `ok` with 16 `TestGetLoc` sub-tests passing (10 prior + 6 new).
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/exprs.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add operator and predicate expression nodes
+
+First slice of exprs.go: BinaryExpr, UnaryExpr, InExpr, BetweenExpr,
+LikeExpr, IsExpr, plus the BinOp/UnOp/IsType enums with String()
+methods. Covers PartiQLParser.g4 exprOr, exprAnd, exprNot,
+exprPredicate, mathOp00/01/02, and valueExpr concat/unary forms.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: `exprs.go` — special-form expressions (9 types + 3 enums + WindowSpec)
+
+**Files:**
+- Modify: `partiql/ast/exprs.go` (append)
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Append the special-form section to `partiql/ast/exprs.go`**
+
+Add **after** the existing IsExpr block:
+
+```go
+// ===========================================================================
+// Special-form expressions
+//
+// Function calls, CASE, CAST, and the keyword-bearing built-ins (EXTRACT,
+// TRIM, SUBSTRING) get dedicated nodes because their grammar uses keywords
+// inside parens or non-comma argument syntax. COALESCE and NULLIF also get
+// dedicated nodes because they appear as ANTLR rules. Built-ins with
+// ordinary `name(arg, arg, …)` syntax (DATE_ADD, DATE_DIFF, SIZE, EXISTS, …)
+// use plain FuncCall.
+// ===========================================================================
+
+// QuantifierKind covers the [DISTINCT|ALL] modifier on aggregates and
+// set operations. Although the spec listed it under stmts.go, it is
+// declared here because FuncCall (defined first in implementation order)
+// is its first user. SetOpStmt in stmts.go references it as ast.QuantifierKind.
+type QuantifierKind int
+
+const (
+	QuantifierNone QuantifierKind = iota
+	QuantifierAll
+	QuantifierDistinct
+)
+
+func (q QuantifierKind) String() string {
+	switch q {
+	case QuantifierAll:
+		return "ALL"
+	case QuantifierDistinct:
+		return "DISTINCT"
+	default:
+		return ""
+	}
+}
+
+// CastKind discriminates the three CAST-family operators.
+type CastKind int
+
+const (
+	CastKindInvalid CastKind = iota
+	CastKindCast
+	CastKindCanCast
+	CastKindCanLosslessCast
+)
+
+func (k CastKind) String() string {
+	switch k {
+	case CastKindCast:
+		return "CAST"
+	case CastKindCanCast:
+		return "CAN_CAST"
+	case CastKindCanLosslessCast:
+		return "CAN_LOSSLESS_CAST"
+	default:
+		return "INVALID"
+	}
+}
+
+// TrimSpec covers the optional LEADING/TRAILING/BOTH keyword inside TRIM.
+type TrimSpec int
+
+const (
+	TrimSpecNone TrimSpec = iota
+	TrimSpecLeading
+	TrimSpecTrailing
+	TrimSpecBoth
+)
+
+func (s TrimSpec) String() string {
+	switch s {
+	case TrimSpecLeading:
+		return "LEADING"
+	case TrimSpecTrailing:
+		return "TRAILING"
+	case TrimSpecBoth:
+		return "BOTH"
+	default:
+		return ""
+	}
+}
+
+// FuncCall is the generic function-call node — used for ordinary function
+// calls (DATE_ADD, SIZE, ...), aggregates (COUNT/SUM/AVG/MIN/MAX with the
+// optional DISTINCT/ALL modifier and COUNT(*) form), and window calls
+// (LAG/LEAD with an OVER clause). The Quantifier, Star, and Over fields
+// determine which flavor a particular instance is.
+//
+// Grammar: functionCall, functionCallIdent, functionCallReserved,
+//          aggregat, windowFunction
+type FuncCall struct {
+	Name       string
+	Args       []ExprNode
+	Quantifier QuantifierKind // NONE/DISTINCT/ALL — populated for aggregates
+	Star       bool           // true for COUNT(*)
+	Over       *WindowSpec    // non-nil for window calls
+	Loc        Loc
+}
+
+func (*FuncCall) nodeTag()      {}
+func (n *FuncCall) GetLoc() Loc { return n.Loc }
+func (*FuncCall) exprNode()     {}
+
+// CaseExpr covers both `CASE WHEN … THEN …` (searched) and
+// `CASE expr WHEN … THEN …` (simple) forms. Operand is nil for the
+// searched form.
+//
+// Grammar: caseExpr
+type CaseExpr struct {
+	Operand ExprNode    // nil for searched CASE
+	Whens   []*CaseWhen
+	Else    ExprNode    // nil if no ELSE clause
+	Loc     Loc
+}
+
+func (*CaseExpr) nodeTag()      {}
+func (n *CaseExpr) GetLoc() Loc { return n.Loc }
+func (*CaseExpr) exprNode()     {}
+
+// CaseWhen represents one `WHEN expr THEN expr` arm. Bare Node — does not
+// implement ExprNode because it cannot stand alone in scalar position.
+type CaseWhen struct {
+	When ExprNode
+	Then ExprNode
+	Loc  Loc
+}
+
+func (*CaseWhen) nodeTag()      {}
+func (n *CaseWhen) GetLoc() Loc { return n.Loc }
+
+// CastExpr covers CAST, CAN_CAST, and CAN_LOSSLESS_CAST.
+//
+// Grammar: cast | canCast | canLosslessCast
+type CastExpr struct {
+	Kind   CastKind
+	Expr   ExprNode
+	AsType TypeName
+	Loc    Loc
+}
+
+func (*CastExpr) nodeTag()      {}
+func (n *CastExpr) GetLoc() Loc { return n.Loc }
+func (*CastExpr) exprNode()     {}
+
+// ExtractExpr represents `EXTRACT(<field> FROM <expr>)`. Field is the
+// keyword (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, ...) — stored as the
+// raw uppercase keyword string.
+//
+// Grammar: extract
+type ExtractExpr struct {
+	Field string
+	From  ExprNode
+	Loc   Loc
+}
+
+func (*ExtractExpr) nodeTag()      {}
+func (n *ExtractExpr) GetLoc() Loc { return n.Loc }
+func (*ExtractExpr) exprNode()     {}
+
+// TrimExpr represents `TRIM([LEADING|TRAILING|BOTH] [sub] FROM target)`.
+//
+// Grammar: trimFunction
+type TrimExpr struct {
+	Spec TrimSpec
+	Sub  ExprNode // optional substring to trim; nil for default whitespace
+	From ExprNode
+	Loc  Loc
+}
+
+func (*TrimExpr) nodeTag()      {}
+func (n *TrimExpr) GetLoc() Loc { return n.Loc }
+func (*TrimExpr) exprNode()     {}
+
+// SubstringExpr represents `SUBSTRING(expr FROM start [FOR length])` and
+// the equivalent comma form `SUBSTRING(expr, start[, length])`.
+//
+// Grammar: substring
+type SubstringExpr struct {
+	Expr ExprNode
+	From ExprNode
+	For  ExprNode // optional length
+	Loc  Loc
+}
+
+func (*SubstringExpr) nodeTag()      {}
+func (n *SubstringExpr) GetLoc() Loc { return n.Loc }
+func (*SubstringExpr) exprNode()     {}
+
+// CoalesceExpr represents `COALESCE(expr, expr, …)`.
+//
+// Grammar: coalesce
+type CoalesceExpr struct {
+	Args []ExprNode
+	Loc  Loc
+}
+
+func (*CoalesceExpr) nodeTag()      {}
+func (n *CoalesceExpr) GetLoc() Loc { return n.Loc }
+func (*CoalesceExpr) exprNode()     {}
+
+// NullIfExpr represents `NULLIF(expr, expr)`.
+//
+// Grammar: nullIf
+type NullIfExpr struct {
+	Left  ExprNode
+	Right ExprNode
+	Loc   Loc
+}
+
+func (*NullIfExpr) nodeTag()      {}
+func (n *NullIfExpr) GetLoc() Loc { return n.Loc }
+func (*NullIfExpr) exprNode()     {}
+
+// WindowSpec represents the body of an OVER (...) clause attached to
+// a window function call. Bare Node — appears only inside FuncCall.Over.
+//
+// Grammar: over (PARTITION BY ... ORDER BY ...)
+type WindowSpec struct {
+	PartitionBy []ExprNode
+	OrderBy     []*OrderByItem // OrderByItem defined in stmts.go
+	Loc         Loc
+}
+
+func (*WindowSpec) nodeTag()      {}
+func (n *WindowSpec) GetLoc() Loc { return n.Loc }
+```
+
+**Note:** `WindowSpec` references `*OrderByItem` from `stmts.go`. This is fine within the same package — the field is just declared, not constructed yet, so the build only needs the type to exist by the time `stmts.go` is compiled. Since both files compile together, the order they were written in this plan doesn't matter for compilation.
+
+- [ ] **Step 2: Append assertions and TestGetLoc rows**
+
+In `ast_test.go`, add to the assertions section:
+
+```go
+// Special-form expressions (exprs.go).
+var _ ExprNode = (*FuncCall)(nil)
+var _ ExprNode = (*CaseExpr)(nil)
+var _ Node     = (*CaseWhen)(nil)
+var _ ExprNode = (*CastExpr)(nil)
+var _ ExprNode = (*ExtractExpr)(nil)
+var _ ExprNode = (*TrimExpr)(nil)
+var _ ExprNode = (*SubstringExpr)(nil)
+var _ ExprNode = (*CoalesceExpr)(nil)
+var _ ExprNode = (*NullIfExpr)(nil)
+var _ Node     = (*WindowSpec)(nil)
+```
+
+Append to `cases` in `TestGetLoc`:
+
+```go
+{"FuncCall",      &FuncCall{Loc: Loc{Start: 10, End: 20}}},
+{"CaseExpr",      &CaseExpr{Loc: Loc{Start: 10, End: 20}}},
+{"CaseWhen",      &CaseWhen{Loc: Loc{Start: 10, End: 20}}},
+{"CastExpr",      &CastExpr{Loc: Loc{Start: 10, End: 20}}},
+{"ExtractExpr",   &ExtractExpr{Loc: Loc{Start: 10, End: 20}}},
+{"TrimExpr",      &TrimExpr{Loc: Loc{Start: 10, End: 20}}},
+{"SubstringExpr", &SubstringExpr{Loc: Loc{Start: 10, End: 20}}},
+{"CoalesceExpr",  &CoalesceExpr{Loc: Loc{Start: 10, End: 20}}},
+{"NullIfExpr",    &NullIfExpr{Loc: Loc{Start: 10, End: 20}}},
+{"WindowSpec",    &WindowSpec{Loc: Loc{Start: 10, End: 20}}},
+```
+
+- [ ] **Step 3: Try to build** — expect a compile failure because `OrderByItem` doesn't exist yet
+
+```bash
+go build ./partiql/ast/...
+```
+
+Expected: `undefined: OrderByItem` (or similar) referencing `partiql/ast/exprs.go`.
+
+This is the expected gap. We're going to fix it temporarily by adding a forward-declared placeholder in `stmts.go` so the package builds. The real `OrderByItem` lands in Task 9.
+
+- [ ] **Step 4: Create a temporary `partiql/ast/stmts.go` placeholder for `OrderByItem`**
+
+Create the file with just enough to satisfy the forward reference. **This file will be replaced wholesale in Task 8 — do not invest in it now.**
+
+```go
+package ast
+
+// PLACEHOLDER — replaced in Task 8/9. The OrderByItem type is referenced
+// by WindowSpec in exprs.go (Task 4). Defining it here lets the package
+// build before its real home in stmts.go is written.
+type OrderByItem struct {
+	Expr          ExprNode
+	Desc          bool
+	NullsFirst    bool
+	NullsExplicit bool
+	Loc           Loc
+}
+
+func (*OrderByItem) nodeTag()      {}
+func (n *OrderByItem) GetLoc() Loc { return n.Loc }
+```
+
+- [ ] **Step 5: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, all 26 `TestGetLoc` sub-tests passing (16 prior + 10 new). Note that we are intentionally NOT adding `OrderByItem` to the test table in this task — that happens in Task 9 when the real type lands.
+
+- [ ] **Step 6: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add partiql/ast/exprs.go partiql/ast/stmts.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add special-form expression nodes
+
+FuncCall (covers regular calls, aggregates, window calls), CaseExpr,
+CaseWhen, CastExpr, ExtractExpr, TrimExpr, SubstringExpr, CoalesceExpr,
+NullIfExpr, WindowSpec. Plus QuantifierKind, CastKind, TrimSpec enums.
+
+Adds a placeholder OrderByItem in stmts.go to satisfy WindowSpec's
+forward reference; the real OrderByItem lands in Task 9 when stmts.go
+is written in full.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: `exprs.go` — paths, vars, params, subqueries, collection literals, path steps (13 types)
+
+**Files:**
+- Modify: `partiql/ast/exprs.go` (append)
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Append the path/var/collection/path-step section to `partiql/ast/exprs.go`**
+
+Add after the `WindowSpec` block:
+
+```go
+// ===========================================================================
+// Paths, variables, parameters, subqueries
+//
+// PathExpr, VarRef, and SubLink also implement TableExpr because PartiQL's
+// FROM grammar accepts the same productions as scalar expressions.
+// ===========================================================================
+
+// PathExpr represents a chained path navigation: root.field[idx].field[*].
+// Root is the base expression (typically a VarRef); Steps are the chained
+// path operations from PathStep.
+//
+// Grammar: pathExpr (root path step+)
+type PathExpr struct {
+	Root  ExprNode
+	Steps []PathStep
+	Loc   Loc
+}
+
+func (*PathExpr) nodeTag()      {}
+func (n *PathExpr) GetLoc() Loc { return n.Loc }
+func (*PathExpr) exprNode()     {}
+func (*PathExpr) tableExpr()    {} // PartiQL FROM accepts path expressions
+
+// VarRef represents an identifier reference. AtPrefixed distinguishes
+// `@id` (true) from bare `id` (false). CaseSensitive distinguishes
+// `"X"` (true, double-quoted) from `X` (false, unquoted).
+//
+// Grammar: varRefExpr
+type VarRef struct {
+	Name          string
+	AtPrefixed    bool
+	CaseSensitive bool
+	Loc           Loc
+}
+
+func (*VarRef) nodeTag()      {}
+func (n *VarRef) GetLoc() Loc { return n.Loc }
+func (*VarRef) exprNode()     {}
+func (*VarRef) tableExpr()    {} // a bare identifier in FROM is a VarRef
+
+// ParamRef represents a positional `?` parameter.
+//
+// Grammar: parameter
+type ParamRef struct {
+	Loc Loc
+}
+
+func (*ParamRef) nodeTag()      {}
+func (n *ParamRef) GetLoc() Loc { return n.Loc }
+func (*ParamRef) exprNode()     {}
+
+// SubLink represents a parenthesized SELECT used as a value expression
+// or as a FROM source. Stmt is the inner statement (a SelectStmt or
+// SetOpStmt).
+//
+// Grammar: exprPrimary parenthesized SELECT
+type SubLink struct {
+	Stmt StmtNode
+	Loc  Loc
+}
+
+func (*SubLink) nodeTag()      {}
+func (n *SubLink) GetLoc() Loc { return n.Loc }
+func (*SubLink) exprNode()     {}
+func (*SubLink) tableExpr()    {}
+
+// ===========================================================================
+// Collection literals
+// ===========================================================================
+
+// ListLit represents an ordered list literal: [expr, expr, …].
+//
+// Grammar: array
+type ListLit struct {
+	Items []ExprNode
+	Loc   Loc
+}
+
+func (*ListLit) nodeTag()      {}
+func (n *ListLit) GetLoc() Loc { return n.Loc }
+func (*ListLit) exprNode()     {}
+
+// BagLit represents an unordered bag literal: <<expr, expr, …>>. PartiQL-unique.
+//
+// Grammar: bag
+type BagLit struct {
+	Items []ExprNode
+	Loc   Loc
+}
+
+func (*BagLit) nodeTag()      {}
+func (n *BagLit) GetLoc() Loc { return n.Loc }
+func (*BagLit) exprNode()     {}
+
+// TupleLit represents a tuple/struct literal: {key: value, …}. PartiQL-unique.
+//
+// Grammar: tuple
+type TupleLit struct {
+	Pairs []*TuplePair
+	Loc   Loc
+}
+
+func (*TupleLit) nodeTag()      {}
+func (n *TupleLit) GetLoc() Loc { return n.Loc }
+func (*TupleLit) exprNode()     {}
+
+// TuplePair represents one `key: value` entry in a tuple literal.
+// Bare Node — appears only inside TupleLit.Pairs.
+//
+// Grammar: pair
+type TuplePair struct {
+	Key   ExprNode
+	Value ExprNode
+	Loc   Loc
+}
+
+func (*TuplePair) nodeTag()      {}
+func (n *TuplePair) GetLoc() Loc { return n.Loc }
+
+// ===========================================================================
+// Path steps — implement PathStep
+// ===========================================================================
+
+// DotStep represents `.field`. CaseSensitive is true for `."Field"`
+// (the field name was quoted) and false for unquoted `.field`.
+//
+// Grammar: pathStepDotExpr
+type DotStep struct {
+	Field         string
+	CaseSensitive bool
+	Loc           Loc
+}
+
+func (*DotStep) nodeTag()      {}
+func (n *DotStep) GetLoc() Loc { return n.Loc }
+func (*DotStep) pathStep()     {}
+
+// AllFieldsStep represents `.*` — the all-fields wildcard.
+//
+// Grammar: pathStepDotAll (or equivalent)
+type AllFieldsStep struct {
+	Loc Loc
+}
+
+func (*AllFieldsStep) nodeTag()      {}
+func (n *AllFieldsStep) GetLoc() Loc { return n.Loc }
+func (*AllFieldsStep) pathStep()     {}
+
+// IndexStep represents `[expr]` — index/key by an expression.
+//
+// Grammar: pathStepIndexExpr
+type IndexStep struct {
+	Index ExprNode
+	Loc   Loc
+}
+
+func (*IndexStep) nodeTag()      {}
+func (n *IndexStep) GetLoc() Loc { return n.Loc }
+func (*IndexStep) pathStep()     {}
+
+// WildcardStep represents `[*]` — all-elements wildcard.
+//
+// Grammar: pathStepIndexAll (or equivalent)
+type WildcardStep struct {
+	Loc Loc
+}
+
+func (*WildcardStep) nodeTag()      {}
+func (n *WildcardStep) GetLoc() Loc { return n.Loc }
+func (*WildcardStep) pathStep()     {}
+```
+
+- [ ] **Step 2: Append assertions and TestGetLoc rows**
+
+In `ast_test.go`:
+
+```go
+// Paths, vars, params, subqueries, collection literals, path steps (exprs.go).
+var _ ExprNode  = (*PathExpr)(nil)
+var _ TableExpr = (*PathExpr)(nil)
+var _ ExprNode  = (*VarRef)(nil)
+var _ TableExpr = (*VarRef)(nil)
+var _ ExprNode  = (*ParamRef)(nil)
+var _ ExprNode  = (*SubLink)(nil)
+var _ TableExpr = (*SubLink)(nil)
+var _ ExprNode  = (*ListLit)(nil)
+var _ ExprNode  = (*BagLit)(nil)
+var _ ExprNode  = (*TupleLit)(nil)
+var _ Node      = (*TuplePair)(nil)
+var _ PathStep  = (*DotStep)(nil)
+var _ PathStep  = (*AllFieldsStep)(nil)
+var _ PathStep  = (*IndexStep)(nil)
+var _ PathStep  = (*WildcardStep)(nil)
+```
+
+Append to `cases` in `TestGetLoc`:
+
+```go
+{"PathExpr",      &PathExpr{Loc: Loc{Start: 10, End: 20}}},
+{"VarRef",        &VarRef{Loc: Loc{Start: 10, End: 20}}},
+{"ParamRef",      &ParamRef{Loc: Loc{Start: 10, End: 20}}},
+{"SubLink",       &SubLink{Loc: Loc{Start: 10, End: 20}}},
+{"ListLit",       &ListLit{Loc: Loc{Start: 10, End: 20}}},
+{"BagLit",        &BagLit{Loc: Loc{Start: 10, End: 20}}},
+{"TupleLit",      &TupleLit{Loc: Loc{Start: 10, End: 20}}},
+{"TuplePair",     &TuplePair{Loc: Loc{Start: 10, End: 20}}},
+{"DotStep",       &DotStep{Loc: Loc{Start: 10, End: 20}}},
+{"AllFieldsStep", &AllFieldsStep{Loc: Loc{Start: 10, End: 20}}},
+{"IndexStep",     &IndexStep{Loc: Loc{Start: 10, End: 20}}},
+{"WildcardStep",  &WildcardStep{Loc: Loc{Start: 10, End: 20}}},
+```
+
+(`OrderByItem` from the placeholder in stmts.go is NOT added to the test table here — it lands in Task 9 when its real form is written.)
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, 38 `TestGetLoc` sub-tests passing.
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/exprs.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add path, variable, collection, and path-step nodes
+
+Final slice of exprs.go: PathExpr, VarRef, ParamRef, SubLink (all
+multi-interface where appropriate — PathExpr/VarRef/SubLink also
+implement TableExpr because PartiQL's FROM grammar accepts the same
+productions as scalar expressions); ListLit, BagLit, TupleLit,
+TuplePair collection literals; DotStep, AllFieldsStep, IndexStep,
+WildcardStep path steps.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: `tableexprs.go` — 4 table-position nodes + JoinKind enum
+
+**Files:**
+- Create: `partiql/ast/tableexprs.go`
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Create `partiql/ast/tableexprs.go`**
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// Table expression nodes — implement TableExpr.
+//
+// Grammar: PartiQLParser.g4 fromClause / tableReference / joinClause /
+// unpivotClause. See docs/migration/partiql/analysis.md "Joins" and
+// "FROM Clause Extensions".
+//
+// IMPORTANT: PathExpr, VarRef, and SubLink (defined in exprs.go) also
+// implement TableExpr. They are not re-listed here as their primary home
+// is exprs.go, but they are first-class FROM-position nodes. The compile-time
+// `var _ TableExpr = ...` lines in ast_test.go cover them.
+// ---------------------------------------------------------------------------
+
+// JoinKind identifies the JOIN flavor.
+type JoinKind int
+
+const (
+	JoinKindInvalid JoinKind = iota
+	JoinKindCross
+	JoinKindInner
+	JoinKindLeft
+	JoinKindRight
+	JoinKindFull
+	JoinKindOuter // bare OUTER JOIN (PartiQL natural-outer form)
+)
+
+func (k JoinKind) String() string {
+	switch k {
+	case JoinKindCross:
+		return "CROSS"
+	case JoinKindInner:
+		return "INNER"
+	case JoinKindLeft:
+		return "LEFT"
+	case JoinKindRight:
+		return "RIGHT"
+	case JoinKindFull:
+		return "FULL"
+	case JoinKindOuter:
+		return "OUTER"
+	default:
+		return "INVALID"
+	}
+}
+
+// TableRef represents a bare identifier in FROM position. Schema is
+// populated only when the reference uses dotted form `schema.table`.
+// CaseSensitive is true for double-quoted identifiers.
+//
+// Grammar: tableBaseReference
+type TableRef struct {
+	Name          string
+	Schema        string
+	CaseSensitive bool
+	Loc           Loc
+}
+
+func (*TableRef) nodeTag()      {}
+func (n *TableRef) GetLoc() Loc { return n.Loc }
+func (*TableRef) tableExpr()    {}
+
+// AliasedSource wraps a TableExpr with PartiQL's `AS alias AT positional
+// BY key` aliasing form. PartiQL-unique because of the AT/BY positional
+// and key aliases.
+//
+// Grammar: tableUnpivot, fromClauseSimpleExplicit
+type AliasedSource struct {
+	Source TableExpr
+	As     *string // optional row alias
+	At     *string // optional positional alias
+	By     *string // optional key alias
+	Loc    Loc
+}
+
+func (*AliasedSource) nodeTag()      {}
+func (n *AliasedSource) GetLoc() Loc { return n.Loc }
+func (*AliasedSource) tableExpr()    {}
+
+// JoinExpr represents a JOIN clause: left JOIN right ON condition.
+// Kind selects the JOIN flavor; On is nil for CROSS JOIN.
+//
+// Grammar: joinRhs / fromClause join chain
+type JoinExpr struct {
+	Kind  JoinKind
+	Left  TableExpr
+	Right TableExpr
+	On    ExprNode // nil for CROSS JOIN
+	Loc   Loc
+}
+
+func (*JoinExpr) nodeTag()      {}
+func (n *JoinExpr) GetLoc() Loc { return n.Loc }
+func (*JoinExpr) tableExpr()    {}
+
+// UnpivotExpr represents `UNPIVOT expr [AS alias] [AT pos] [BY key]`.
+// PartiQL-unique. The Source is an expression (not a TableExpr) because
+// the grammar nests an arbitrary expression here.
+//
+// Grammar: unpivotClause
+type UnpivotExpr struct {
+	Source ExprNode
+	As     *string
+	At     *string
+	By     *string
+	Loc    Loc
+}
+
+func (*UnpivotExpr) nodeTag()      {}
+func (n *UnpivotExpr) GetLoc() Loc { return n.Loc }
+func (*UnpivotExpr) tableExpr()    {}
+```
+
+- [ ] **Step 2: Append assertions and TestGetLoc rows**
+
+In `ast_test.go`:
+
+```go
+// Table expression nodes (tableexprs.go).
+var _ TableExpr = (*TableRef)(nil)
+var _ TableExpr = (*AliasedSource)(nil)
+var _ TableExpr = (*JoinExpr)(nil)
+var _ TableExpr = (*UnpivotExpr)(nil)
+```
+
+Append to `cases`:
+
+```go
+{"TableRef",      &TableRef{Loc: Loc{Start: 10, End: 20}}},
+{"AliasedSource", &AliasedSource{Loc: Loc{Start: 10, End: 20}}},
+{"JoinExpr",      &JoinExpr{Loc: Loc{Start: 10, End: 20}}},
+{"UnpivotExpr",   &UnpivotExpr{Loc: Loc{Start: 10, End: 20}}},
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, 42 sub-tests passing.
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/tableexprs.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add FROM-position table expression nodes
+
+TableRef, AliasedSource (PartiQL AS/AT/BY aliasing), JoinExpr (with
+JoinKind enum covering CROSS/INNER/LEFT/RIGHT/FULL/OUTER), UnpivotExpr.
+File doc-block notes that PathExpr/VarRef/SubLink in exprs.go also
+implement TableExpr.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: `types.go` — TypeRef
+
+**Files:**
+- Create: `partiql/ast/types.go`
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Create `partiql/ast/types.go`**
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// PartiQL type references — implement TypeName.
+//
+// One flat TypeRef covers all PartiQL types. Discrimination is by Name
+// (uppercase canonical: INT, DECIMAL, TIME, BAG, ANY, ...) rather than a
+// 25-arm Go enum. The grammar treats types as a name token with optional
+// modifiers (Args for parameterized types, WithTimeZone for TIME/TIMESTAMP),
+// so the AST mirrors that shape.
+//
+// Grammar: PartiQLParser.g4 type / typeAtomic / typeArgSingle / typeArgDouble /
+// typeTimeZone. See docs/migration/partiql/analysis.md "Type System".
+// ---------------------------------------------------------------------------
+
+// TypeRef represents any PartiQL type reference, used by CAST and DDL.
+//
+// Args carries optional precision/scale/length:
+//   - DECIMAL(10,2) -> Args=[10, 2]
+//   - VARCHAR(255)  -> Args=[255]
+//   - FLOAT(53)     -> Args=[53]
+//   - INT           -> Args=nil
+//
+// WithTimeZone is set for `TIME WITH TIME ZONE` and `TIMESTAMP WITH TIME ZONE`.
+//
+// Names covered (canonical uppercase):
+//   - Numeric: INT, INTEGER, BIGINT, SMALLINT, REAL, DOUBLE PRECISION,
+//     DECIMAL, NUMERIC, FLOAT
+//   - Boolean: BOOL, BOOLEAN
+//   - Null/missing: NULL, MISSING
+//   - String: STRING, SYMBOL, VARCHAR, CHAR, CHARACTER
+//   - Binary: BLOB, CLOB
+//   - Temporal: DATE, TIME, TIMESTAMP
+//   - Collection: STRUCT, TUPLE, LIST, BAG, SEXP
+//   - Wildcard: ANY
+type TypeRef struct {
+	Name         string
+	Args         []int
+	WithTimeZone bool
+	Loc          Loc
+}
+
+func (*TypeRef) nodeTag()      {}
+func (n *TypeRef) GetLoc() Loc { return n.Loc }
+func (*TypeRef) typeName()     {}
+```
+
+- [ ] **Step 2: Append assertion and TestGetLoc row**
+
+In `ast_test.go`:
+
+```go
+// Type names (types.go).
+var _ TypeName = (*TypeRef)(nil)
+```
+
+```go
+{"TypeRef", &TypeRef{Loc: Loc{Start: 10, End: 20}}},
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, 43 sub-tests passing.
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/types.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add TypeRef for PartiQL type references
+
+Single flat TypeRef node covers all PartiQL types (CAST and DDL).
+Discriminated by Name field; Args carries precision/scale/length;
+WithTimeZone for TIME/TIMESTAMP variants. Doc comment enumerates
+the full canonical name set.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: `stmts.go` — top-level statement nodes (14 types + enums)
+
+**Files:**
+- Modify: `partiql/ast/stmts.go` (replace the placeholder created in Task 4)
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Replace `partiql/ast/stmts.go` wholesale**
+
+Open `partiql/ast/stmts.go` and **replace the entire file contents** with:
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// Statement nodes and supporting types.
+//
+// This file is built in two task groups:
+//   1. Top-level statements (this section): SELECT, set ops, EXPLAIN,
+//      DML, DDL, EXEC.
+//   2. Clause helpers: TargetEntry, GroupBy, OrderBy, OnConflict, Returning,
+//      etc. (Task 9 — appended below).
+//
+// Grammar reference: PartiQLParser.g4 dql/dml/ddl/execCommand rules. See
+// docs/migration/partiql/analysis.md.
+// ---------------------------------------------------------------------------
+
+// ===========================================================================
+// Statement enums
+// ===========================================================================
+
+// SetOpKind identifies the set operation in SetOpStmt.
+type SetOpKind int
+
+const (
+	SetOpInvalid SetOpKind = iota
+	SetOpUnion
+	SetOpIntersect
+	SetOpExcept
+)
+
+func (k SetOpKind) String() string {
+	switch k {
+	case SetOpUnion:
+		return "UNION"
+	case SetOpIntersect:
+		return "INTERSECT"
+	case SetOpExcept:
+		return "EXCEPT"
+	default:
+		return "INVALID"
+	}
+}
+
+// OnConflictAction discriminates the body of an ON CONFLICT clause.
+// PartiQL's legacy ANTLR grammar leaves DO REPLACE/UPDATE as stubs that
+// only accept the EXCLUDED keyword (analysis.md gap notes); the omni AST
+// matches that scope.
+type OnConflictAction int
+
+const (
+	OnConflictInvalid OnConflictAction = iota
+	OnConflictDoNothing
+	OnConflictDoReplaceExcluded
+	OnConflictDoUpdateExcluded
+)
+
+func (a OnConflictAction) String() string {
+	switch a {
+	case OnConflictDoNothing:
+		return "DO_NOTHING"
+	case OnConflictDoReplaceExcluded:
+		return "DO_REPLACE_EXCLUDED"
+	case OnConflictDoUpdateExcluded:
+		return "DO_UPDATE_EXCLUDED"
+	default:
+		return "INVALID"
+	}
+}
+
+// ReturningStatus is the (MODIFIED|ALL) modifier on each RETURNING item.
+type ReturningStatus int
+
+const (
+	ReturningStatusInvalid ReturningStatus = iota
+	ReturningStatusModified
+	ReturningStatusAll
+)
+
+func (s ReturningStatus) String() string {
+	switch s {
+	case ReturningStatusModified:
+		return "MODIFIED"
+	case ReturningStatusAll:
+		return "ALL"
+	default:
+		return "INVALID"
+	}
+}
+
+// ReturningMapping is the (OLD|NEW) modifier on each RETURNING item.
+type ReturningMapping int
+
+const (
+	ReturningMappingInvalid ReturningMapping = iota
+	ReturningMappingOld
+	ReturningMappingNew
+)
+
+func (m ReturningMapping) String() string {
+	switch m {
+	case ReturningMappingOld:
+		return "OLD"
+	case ReturningMappingNew:
+		return "NEW"
+	default:
+		return "INVALID"
+	}
+}
+
+// ===========================================================================
+// Top-level statements — all implement StmtNode
+// ===========================================================================
+
+// SelectStmt is a single SELECT query (not a set-op combination — see
+// SetOpStmt for that). Carries the full clause set:
+//
+//   SELECT [DISTINCT|ALL] (* | items | VALUE expr | PIVOT v AT k)
+//   FROM ...
+//   [LET ...]
+//   [WHERE ...]
+//   [GROUP [PARTIAL] BY ... [GROUP AS alias]]
+//   [HAVING ...]
+//   [ORDER BY ...]
+//   [LIMIT ...]
+//   [OFFSET ...]
+//
+// Quantifier holds the optional DISTINCT/ALL modifier (NONE if absent).
+// Star is true for `SELECT *`. Value holds the expression for
+// `SELECT VALUE expr`. Pivot holds the PIVOT projection. At most one of
+// (Star, Value != nil, Pivot != nil, len(Targets) > 0) is set per instance.
+//
+// Grammar: dql, selectClause, projectionItems, projectionPivot, projectionValue
+type SelectStmt struct {
+	Quantifier QuantifierKind   // NONE / DISTINCT / ALL
+	Star       bool             // SELECT *
+	Value      ExprNode         // SELECT VALUE expr (PartiQL-unique)
+	Pivot      *PivotProjection // PIVOT v AT k (PartiQL-unique)
+	Targets    []*TargetEntry   // SELECT items
+	From       TableExpr        // FROM clause
+	Let        []*LetBinding    // LET bindings (PartiQL-unique)
+	Where      ExprNode
+	GroupBy    *GroupByClause
+	Having     ExprNode
+	OrderBy    []*OrderByItem
+	Limit      ExprNode
+	Offset     ExprNode
+	Loc        Loc
+}
+
+func (*SelectStmt) nodeTag()      {}
+func (n *SelectStmt) GetLoc() Loc { return n.Loc }
+func (*SelectStmt) stmtNode()     {}
+
+// SetOpStmt combines two queries with UNION/INTERSECT/EXCEPT.
+// Quantifier is the DISTINCT/ALL modifier; Outer is true for the
+// PartiQL-specific OUTER variant. Both Left and Right may themselves
+// be SetOpStmt nodes for nested set operations.
+//
+// Grammar: bagOpExpr
+type SetOpStmt struct {
+	Op         SetOpKind
+	Quantifier QuantifierKind
+	Outer      bool
+	Left       StmtNode
+	Right      StmtNode
+	Loc        Loc
+}
+
+func (*SetOpStmt) nodeTag()      {}
+func (n *SetOpStmt) GetLoc() Loc { return n.Loc }
+func (*SetOpStmt) stmtNode()     {}
+
+// ExplainStmt wraps any other StmtNode with an EXPLAIN prefix.
+//
+// Grammar: root EXPLAIN
+type ExplainStmt struct {
+	Inner StmtNode
+	Loc   Loc
+}
+
+func (*ExplainStmt) nodeTag()      {}
+func (n *ExplainStmt) GetLoc() Loc { return n.Loc }
+func (*ExplainStmt) stmtNode()     {}
+
+// InsertStmt represents `INSERT INTO target [AS alias] VALUE expr
+// [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
+// (INSERT INTO p VALUE …) and RFC 0011 (INSERT INTO c AS a VALUE …) forms.
+//
+// Grammar: insertCommandReturning, insertStatement
+type InsertStmt struct {
+	Target     TableExpr
+	AsAlias    *string
+	Value      ExprNode
+	OnConflict *OnConflict
+	Returning  *ReturningClause
+	Loc        Loc
+}
+
+func (*InsertStmt) nodeTag()      {}
+func (n *InsertStmt) GetLoc() Loc { return n.Loc }
+func (*InsertStmt) stmtNode()     {}
+
+// UpdateStmt represents `UPDATE source SET ... [WHERE ...] [RETURNING ...]`
+// and the equivalent `FROM source SET ...` form.
+//
+// Grammar: updateClause, dmlBaseWrapper update head
+type UpdateStmt struct {
+	Source    TableExpr
+	Sets      []*SetAssignment
+	Where     ExprNode
+	Returning *ReturningClause
+	Loc       Loc
+}
+
+func (*UpdateStmt) nodeTag()      {}
+func (n *UpdateStmt) GetLoc() Loc { return n.Loc }
+func (*UpdateStmt) stmtNode()     {}
+
+// DeleteStmt represents `DELETE FROM source [WHERE ...] [RETURNING ...]`
+// and the equivalent `FROM source DELETE ...` form.
+//
+// Grammar: deleteCommand
+type DeleteStmt struct {
+	Source    TableExpr
+	Where     ExprNode
+	Returning *ReturningClause
+	Loc       Loc
+}
+
+func (*DeleteStmt) nodeTag()      {}
+func (n *DeleteStmt) GetLoc() Loc { return n.Loc }
+func (*DeleteStmt) stmtNode()     {}
+
+// UpsertStmt represents `UPSERT INTO target [AS alias] VALUE expr ...`.
+// Same shape as InsertStmt; semantically the conflict-merge is implicit.
+//
+// Grammar: upsertCommand
+type UpsertStmt struct {
+	Target     TableExpr
+	AsAlias    *string
+	Value      ExprNode
+	OnConflict *OnConflict
+	Returning  *ReturningClause
+	Loc        Loc
+}
+
+func (*UpsertStmt) nodeTag()      {}
+func (n *UpsertStmt) GetLoc() Loc { return n.Loc }
+func (*UpsertStmt) stmtNode()     {}
+
+// ReplaceStmt represents `REPLACE INTO target [AS alias] VALUE expr ...`.
+// Same shape as InsertStmt.
+//
+// Grammar: replaceCommand
+type ReplaceStmt struct {
+	Target     TableExpr
+	AsAlias    *string
+	Value      ExprNode
+	OnConflict *OnConflict
+	Returning  *ReturningClause
+	Loc        Loc
+}
+
+func (*ReplaceStmt) nodeTag()      {}
+func (n *ReplaceStmt) GetLoc() Loc { return n.Loc }
+func (*ReplaceStmt) stmtNode()     {}
+
+// RemoveStmt represents `REMOVE path` — removes an element from a
+// collection. PartiQL-unique.
+//
+// Grammar: removeCommand
+type RemoveStmt struct {
+	Path *PathExpr
+	Loc  Loc
+}
+
+func (*RemoveStmt) nodeTag()      {}
+func (n *RemoveStmt) GetLoc() Loc { return n.Loc }
+func (*RemoveStmt) stmtNode()     {}
+
+// CreateTableStmt represents `CREATE TABLE name`. PartiQL DDL has no
+// column definitions or constraints — just the table name.
+//
+// Grammar: createTable
+type CreateTableStmt struct {
+	Name *VarRef
+	Loc  Loc
+}
+
+func (*CreateTableStmt) nodeTag()      {}
+func (n *CreateTableStmt) GetLoc() Loc { return n.Loc }
+func (*CreateTableStmt) stmtNode()     {}
+
+// CreateIndexStmt represents `CREATE INDEX ON table (path, path, ...)`.
+//
+// Grammar: createIndex
+type CreateIndexStmt struct {
+	Table *VarRef
+	Paths []*PathExpr
+	Loc   Loc
+}
+
+func (*CreateIndexStmt) nodeTag()      {}
+func (n *CreateIndexStmt) GetLoc() Loc { return n.Loc }
+func (*CreateIndexStmt) stmtNode()     {}
+
+// DropTableStmt represents `DROP TABLE name`.
+//
+// Grammar: dropTable
+type DropTableStmt struct {
+	Name *VarRef
+	Loc  Loc
+}
+
+func (*DropTableStmt) nodeTag()      {}
+func (n *DropTableStmt) GetLoc() Loc { return n.Loc }
+func (*DropTableStmt) stmtNode()     {}
+
+// DropIndexStmt represents `DROP INDEX index ON table`.
+//
+// Grammar: dropIndex
+type DropIndexStmt struct {
+	Index *VarRef
+	Table *VarRef
+	Loc   Loc
+}
+
+func (*DropIndexStmt) nodeTag()      {}
+func (n *DropIndexStmt) GetLoc() Loc { return n.Loc }
+func (*DropIndexStmt) stmtNode()     {}
+
+// ExecStmt represents `EXEC name [arg, arg, ...]`.
+//
+// Grammar: execCommand
+type ExecStmt struct {
+	Name string
+	Args []ExprNode
+	Loc  Loc
+}
+
+func (*ExecStmt) nodeTag()      {}
+func (n *ExecStmt) GetLoc() Loc { return n.Loc }
+func (*ExecStmt) stmtNode()     {}
+```
+
+This file currently references `OrderByItem`, `LetBinding`, `GroupByClause`, `TargetEntry`, `PivotProjection`, `OnConflict`, `ReturningClause`, `SetAssignment` — all defined in Task 9. The build will fail until Task 9 lands these helpers. To keep tasks independently testable, **add temporary forward-declared placeholder types at the bottom of this file** so the build succeeds:
+
+```go
+// ---------------------------------------------------------------------------
+// PLACEHOLDERS — replaced in Task 9.
+//
+// These are forward-declared minimal stubs so the package builds at the
+// end of Task 8 even though the real types live in the next task. Each
+// stub is a bare struct with the Loc field plus the methods Node requires.
+// Task 9 deletes this block and replaces it with the full type definitions.
+// ---------------------------------------------------------------------------
+
+type TargetEntry struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*TargetEntry) nodeTag()      {}
+func (n *TargetEntry) GetLoc() Loc { return n.Loc }
+
+type PivotProjection struct {
+	Value ExprNode
+	At    ExprNode
+	Loc   Loc
+}
+
+func (*PivotProjection) nodeTag()      {}
+func (n *PivotProjection) GetLoc() Loc { return n.Loc }
+
+type LetBinding struct {
+	Expr  ExprNode
+	Alias string
+	Loc   Loc
+}
+
+func (*LetBinding) nodeTag()      {}
+func (n *LetBinding) GetLoc() Loc { return n.Loc }
+
+type GroupByClause struct {
+	Partial bool
+	Items   []*GroupByItem
+	GroupAs *string
+	Loc     Loc
+}
+
+func (*GroupByClause) nodeTag()      {}
+func (n *GroupByClause) GetLoc() Loc { return n.Loc }
+
+type GroupByItem struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*GroupByItem) nodeTag()      {}
+func (n *GroupByItem) GetLoc() Loc { return n.Loc }
+
+type SetAssignment struct {
+	Target *PathExpr
+	Value  ExprNode
+	Loc    Loc
+}
+
+func (*SetAssignment) nodeTag()      {}
+func (n *SetAssignment) GetLoc() Loc { return n.Loc }
+
+type OnConflict struct {
+	Target *OnConflictTarget
+	Action OnConflictAction
+	Where  ExprNode
+	Loc    Loc
+}
+
+func (*OnConflict) nodeTag()      {}
+func (n *OnConflict) GetLoc() Loc { return n.Loc }
+
+type OnConflictTarget struct {
+	Cols           []*VarRef
+	ConstraintName string
+	Loc            Loc
+}
+
+func (*OnConflictTarget) nodeTag()      {}
+func (n *OnConflictTarget) GetLoc() Loc { return n.Loc }
+
+type ReturningClause struct {
+	Items []*ReturningItem
+	Loc   Loc
+}
+
+func (*ReturningClause) nodeTag()      {}
+func (n *ReturningClause) GetLoc() Loc { return n.Loc }
+
+type ReturningItem struct {
+	Status  ReturningStatus
+	Mapping ReturningMapping
+	Star    bool
+	Expr    ExprNode
+	Loc     Loc
+}
+
+func (*ReturningItem) nodeTag()      {}
+func (n *ReturningItem) GetLoc() Loc { return n.Loc }
+```
+
+**Note:** This block also keeps the existing `OrderByItem` placeholder (originally added in Task 4 Step 4). Make sure that type definition is still present in the file — it should appear above or alongside the new placeholders. If you accidentally delete it, the build will fail with `undefined: OrderByItem` from `exprs.go`.
+
+The full content of `partiql/ast/stmts.go` after Step 1 should be: header comment + enums + 14 statement types + the placeholder block (including `OrderByItem` from Task 4 + the 10 new placeholders above).
+
+- [ ] **Step 2: Append assertions and TestGetLoc rows for the 14 statements**
+
+In `ast_test.go`:
+
+```go
+// Top-level statements (stmts.go).
+var _ StmtNode = (*SelectStmt)(nil)
+var _ StmtNode = (*SetOpStmt)(nil)
+var _ StmtNode = (*ExplainStmt)(nil)
+var _ StmtNode = (*InsertStmt)(nil)
+var _ StmtNode = (*UpdateStmt)(nil)
+var _ StmtNode = (*DeleteStmt)(nil)
+var _ StmtNode = (*UpsertStmt)(nil)
+var _ StmtNode = (*ReplaceStmt)(nil)
+var _ StmtNode = (*RemoveStmt)(nil)
+var _ StmtNode = (*CreateTableStmt)(nil)
+var _ StmtNode = (*CreateIndexStmt)(nil)
+var _ StmtNode = (*DropTableStmt)(nil)
+var _ StmtNode = (*DropIndexStmt)(nil)
+var _ StmtNode = (*ExecStmt)(nil)
+```
+
+Append to `cases`:
+
+```go
+{"SelectStmt",      &SelectStmt{Loc: Loc{Start: 10, End: 20}}},
+{"SetOpStmt",       &SetOpStmt{Loc: Loc{Start: 10, End: 20}}},
+{"ExplainStmt",     &ExplainStmt{Loc: Loc{Start: 10, End: 20}}},
+{"InsertStmt",      &InsertStmt{Loc: Loc{Start: 10, End: 20}}},
+{"UpdateStmt",      &UpdateStmt{Loc: Loc{Start: 10, End: 20}}},
+{"DeleteStmt",      &DeleteStmt{Loc: Loc{Start: 10, End: 20}}},
+{"UpsertStmt",      &UpsertStmt{Loc: Loc{Start: 10, End: 20}}},
+{"ReplaceStmt",     &ReplaceStmt{Loc: Loc{Start: 10, End: 20}}},
+{"RemoveStmt",      &RemoveStmt{Loc: Loc{Start: 10, End: 20}}},
+{"CreateTableStmt", &CreateTableStmt{Loc: Loc{Start: 10, End: 20}}},
+{"CreateIndexStmt", &CreateIndexStmt{Loc: Loc{Start: 10, End: 20}}},
+{"DropTableStmt",   &DropTableStmt{Loc: Loc{Start: 10, End: 20}}},
+{"DropIndexStmt",   &DropIndexStmt{Loc: Loc{Start: 10, End: 20}}},
+{"ExecStmt",        &ExecStmt{Loc: Loc{Start: 10, End: 20}}},
+```
+
+(The clause helpers and DML helpers — TargetEntry, OnConflict, etc. — are NOT added to the test table here. They land in Task 9 when their real form is written.)
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, 57 sub-tests passing (43 prior + 14 new statements).
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/stmts.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add top-level statement nodes
+
+14 statement types covering DDL (CreateTable/Index, DropTable/Index),
+DML (Insert/Update/Delete/Upsert/Replace/Remove with both legacy and
+RFC 0011 forms), DQL (SelectStmt with full clause set, SetOpStmt for
+UNION/INTERSECT/EXCEPT, ExplainStmt), and EXEC.
+
+Plus the SetOpKind, OnConflictAction, ReturningStatus, ReturningMapping
+enums.
+
+Includes forward-declared placeholders for the clause helpers
+(TargetEntry, GroupByClause, OnConflict, ReturningClause, etc.) so
+the package builds; Task 9 replaces those with the real definitions.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: `stmts.go` — clause and DML helpers (11 types)
+
+**Files:**
+- Modify: `partiql/ast/stmts.go` (replace the placeholder block with real definitions)
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Replace the placeholder block in `partiql/ast/stmts.go`**
+
+Open `partiql/ast/stmts.go`. Find the section that begins:
+
+```go
+// PLACEHOLDERS — replaced in Task 9.
+```
+
+**Delete that entire comment block and the placeholder type definitions below it (TargetEntry, PivotProjection, LetBinding, GroupByClause, GroupByItem, OrderByItem, SetAssignment, OnConflict, OnConflictTarget, ReturningClause, ReturningItem).**
+
+Replace with the real definitions:
+
+```go
+// ===========================================================================
+// SELECT clause helpers — bare Node (no sub-interface marker).
+//
+// These types appear only as fields/elements inside SelectStmt and never
+// stand alone in scalar/statement/table-expr position, so they don't need
+// a sub-interface marker.
+// ===========================================================================
+
+// TargetEntry represents one item in a SELECT projection list:
+// `expr [AS alias]`.
+//
+// Grammar: projectionItem
+type TargetEntry struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*TargetEntry) nodeTag()      {}
+func (n *TargetEntry) GetLoc() Loc { return n.Loc }
+
+// PivotProjection represents the body of a `PIVOT v AT k` projection.
+// Used as SelectStmt.Pivot. PartiQL-unique.
+//
+// Grammar: projectionPivot
+type PivotProjection struct {
+	Value ExprNode
+	At    ExprNode
+	Loc   Loc
+}
+
+func (*PivotProjection) nodeTag()      {}
+func (n *PivotProjection) GetLoc() Loc { return n.Loc }
+
+// LetBinding represents one `expr AS alias` binding inside a LET clause.
+// PartiQL-unique.
+//
+// Grammar: letBinding
+type LetBinding struct {
+	Expr  ExprNode
+	Alias string
+	Loc   Loc
+}
+
+func (*LetBinding) nodeTag()      {}
+func (n *LetBinding) GetLoc() Loc { return n.Loc }
+
+// GroupByClause represents `GROUP [PARTIAL] BY items [GROUP AS alias]`.
+//
+// Grammar: groupClause
+type GroupByClause struct {
+	Partial bool
+	Items   []*GroupByItem
+	GroupAs *string
+	Loc     Loc
+}
+
+func (*GroupByClause) nodeTag()      {}
+func (n *GroupByClause) GetLoc() Loc { return n.Loc }
+
+// GroupByItem represents one `expr [AS alias]` item in a GROUP BY list.
+//
+// Grammar: groupKey
+type GroupByItem struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*GroupByItem) nodeTag()      {}
+func (n *GroupByItem) GetLoc() Loc { return n.Loc }
+
+// OrderByItem represents one `expr [ASC|DESC] [NULLS FIRST|LAST]` item
+// in an ORDER BY list. NullsExplicit is true when the source text included
+// a NULLS clause; NullsFirst is the resulting setting when it did.
+//
+// Grammar: orderSortSpec
+type OrderByItem struct {
+	Expr          ExprNode
+	Desc          bool
+	NullsFirst    bool
+	NullsExplicit bool
+	Loc           Loc
+}
+
+func (*OrderByItem) nodeTag()      {}
+func (n *OrderByItem) GetLoc() Loc { return n.Loc }
+
+// ===========================================================================
+// DML helpers — bare Node.
+// ===========================================================================
+
+// SetAssignment represents one `target = value` assignment in an UPDATE
+// SET clause (or in a chained-DML SET op).
+//
+// Grammar: setAssignment
+type SetAssignment struct {
+	Target *PathExpr
+	Value  ExprNode
+	Loc    Loc
+}
+
+func (*SetAssignment) nodeTag()      {}
+func (n *SetAssignment) GetLoc() Loc { return n.Loc }
+
+// OnConflict represents the body of an ON CONFLICT clause:
+// `ON CONFLICT [target] [WHERE expr] action`.
+//
+// Grammar: onConflict, onConflictLegacy
+type OnConflict struct {
+	Target *OnConflictTarget
+	Action OnConflictAction
+	Where  ExprNode
+	Loc    Loc
+}
+
+func (*OnConflict) nodeTag()      {}
+func (n *OnConflict) GetLoc() Loc { return n.Loc }
+
+// OnConflictTarget represents the target of an ON CONFLICT clause —
+// either a list of column references `(col, col, ...)` or
+// `ON CONSTRAINT name`. Exactly one of Cols/ConstraintName is set.
+//
+// Grammar: conflictTarget
+type OnConflictTarget struct {
+	Cols           []*VarRef
+	ConstraintName string
+	Loc            Loc
+}
+
+func (*OnConflictTarget) nodeTag()      {}
+func (n *OnConflictTarget) GetLoc() Loc { return n.Loc }
+
+// ReturningClause represents `RETURNING item, item, …`.
+//
+// Grammar: returningClause
+type ReturningClause struct {
+	Items []*ReturningItem
+	Loc   Loc
+}
+
+func (*ReturningClause) nodeTag()      {}
+func (n *ReturningClause) GetLoc() Loc { return n.Loc }
+
+// ReturningItem represents one `(MODIFIED|ALL) (OLD|NEW) (* | expr)` entry
+// in a RETURNING clause. Star is true for the `*` form; otherwise Expr
+// holds the projection expression.
+//
+// Grammar: returningElem, returningColumn
+type ReturningItem struct {
+	Status  ReturningStatus
+	Mapping ReturningMapping
+	Star    bool
+	Expr    ExprNode
+	Loc     Loc
+}
+
+func (*ReturningItem) nodeTag()      {}
+func (n *ReturningItem) GetLoc() Loc { return n.Loc }
+```
+
+After this step, `partiql/ast/stmts.go` should contain (in order):
+
+1. Package declaration + file header comment
+2. Enum types (`SetOpKind`, `OnConflictAction`, `ReturningStatus`, `ReturningMapping`)
+3. The 14 top-level statement types from Task 8
+4. The 11 clause/DML helper types above
+
+No placeholder block remains.
+
+- [ ] **Step 2: Append assertions and TestGetLoc rows for the 11 helpers**
+
+In `ast_test.go`:
+
+```go
+// Clause and DML helpers (stmts.go).
+var _ Node = (*TargetEntry)(nil)
+var _ Node = (*PivotProjection)(nil)
+var _ Node = (*LetBinding)(nil)
+var _ Node = (*GroupByClause)(nil)
+var _ Node = (*GroupByItem)(nil)
+var _ Node = (*OrderByItem)(nil)
+var _ Node = (*SetAssignment)(nil)
+var _ Node = (*OnConflict)(nil)
+var _ Node = (*OnConflictTarget)(nil)
+var _ Node = (*ReturningClause)(nil)
+var _ Node = (*ReturningItem)(nil)
+```
+
+Append to `cases`:
+
+```go
+{"TargetEntry",      &TargetEntry{Loc: Loc{Start: 10, End: 20}}},
+{"PivotProjection",  &PivotProjection{Loc: Loc{Start: 10, End: 20}}},
+{"LetBinding",       &LetBinding{Loc: Loc{Start: 10, End: 20}}},
+{"GroupByClause",    &GroupByClause{Loc: Loc{Start: 10, End: 20}}},
+{"GroupByItem",      &GroupByItem{Loc: Loc{Start: 10, End: 20}}},
+{"OrderByItem",      &OrderByItem{Loc: Loc{Start: 10, End: 20}}},
+{"SetAssignment",    &SetAssignment{Loc: Loc{Start: 10, End: 20}}},
+{"OnConflict",       &OnConflict{Loc: Loc{Start: 10, End: 20}}},
+{"OnConflictTarget", &OnConflictTarget{Loc: Loc{Start: 10, End: 20}}},
+{"ReturningClause",  &ReturningClause{Loc: Loc{Start: 10, End: 20}}},
+{"ReturningItem",    &ReturningItem{Loc: Loc{Start: 10, End: 20}}},
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, 68 sub-tests passing (57 prior + 11 new).
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/stmts.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add SELECT clause and DML helper nodes
+
+11 helper types — TargetEntry, PivotProjection, LetBinding,
+GroupByClause, GroupByItem, OrderByItem, SetAssignment, OnConflict,
+OnConflictTarget, ReturningClause, ReturningItem. All are bare Node
+(no sub-interface marker) because they only appear as fields inside
+the statement nodes from Task 8.
+
+Replaces the forward-declared placeholders introduced in Tasks 4 and 8.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: `patterns.go` — graph pattern nodes
+
+**Files:**
+- Create: `partiql/ast/patterns.go`
+- Modify: `partiql/ast/ast_test.go`
+
+- [ ] **Step 1: Create `partiql/ast/patterns.go`**
+
+```go
+package ast
+
+// ---------------------------------------------------------------------------
+// Graph Pattern Matching (GPML) nodes — implement PatternNode (or ExprNode
+// for the top-level MatchExpr container).
+//
+// PartiQL has a graph pattern matching extension based on GPML. The full
+// shape of the field set inside NodePattern/EdgePattern may be refined when
+// the parser-graph DAG node (node 16) is implemented and we read
+// PartiQLParser.g4 lines 314–382 carefully. The marker interface, the node
+// names, and the multi-interface relationship to ExprNode are stable in
+// this initial pass.
+//
+// Grammar: PartiQLParser.g4 graphMatchPattern, gpmlPattern, matchPattern,
+// nodePattern, edgePattern, etc.
+// ---------------------------------------------------------------------------
+
+// EdgeDirection identifies the direction of an edge pattern.
+type EdgeDirection int
+
+const (
+	EdgeDirInvalid EdgeDirection = iota
+	EdgeDirRight              // ->
+	EdgeDirLeft               // <-
+	EdgeDirUndirected         // ~
+	EdgeDirLeftOrRight        // <-> (left or right)
+	EdgeDirLeftOrUndirected   // <~
+	EdgeDirRightOrUndirected  // ~>
+	EdgeDirAny                // any direction
+)
+
+func (d EdgeDirection) String() string {
+	switch d {
+	case EdgeDirRight:
+		return "->"
+	case EdgeDirLeft:
+		return "<-"
+	case EdgeDirUndirected:
+		return "~"
+	case EdgeDirLeftOrRight:
+		return "<->"
+	case EdgeDirLeftOrUndirected:
+		return "<~"
+	case EdgeDirRightOrUndirected:
+		return "~>"
+	case EdgeDirAny:
+		return "any"
+	default:
+		return "INVALID"
+	}
+}
+
+// PatternRestrictor identifies the optional restrictor keyword on a graph pattern.
+type PatternRestrictor int
+
+const (
+	PatternRestrictorNone PatternRestrictor = iota
+	PatternRestrictorTrail
+	PatternRestrictorAcyclic
+	PatternRestrictorSimple
+)
+
+func (r PatternRestrictor) String() string {
+	switch r {
+	case PatternRestrictorTrail:
+		return "TRAIL"
+	case PatternRestrictorAcyclic:
+		return "ACYCLIC"
+	case PatternRestrictorSimple:
+		return "SIMPLE"
+	default:
+		return ""
+	}
+}
+
+// SelectorKind identifies the optional selector keyword on a graph pattern.
+type SelectorKind int
+
+const (
+	SelectorKindNone SelectorKind = iota
+	SelectorKindAny
+	SelectorKindAllShortest
+	SelectorKindShortestK
+)
+
+func (s SelectorKind) String() string {
+	switch s {
+	case SelectorKindAny:
+		return "ANY"
+	case SelectorKindAllShortest:
+		return "ALL_SHORTEST"
+	case SelectorKindShortestK:
+		return "SHORTEST_K"
+	default:
+		return ""
+	}
+}
+
+// MatchExpr is the top-level graph-match expression: MATCH(graph_expr, pattern, …).
+// Implements ExprNode because PartiQL embeds graph matching in expression
+// position (exprGraphMatchOne / exprGraphMatchMany rules).
+//
+// Grammar: exprGraphMatchOne, exprGraphMatchMany
+type MatchExpr struct {
+	Expr     ExprNode        // the graph-valued expression being matched
+	Patterns []*GraphPattern // one or more pattern alternatives
+	Loc      Loc
+}
+
+func (*MatchExpr) nodeTag()      {}
+func (n *MatchExpr) GetLoc() Loc { return n.Loc }
+func (*MatchExpr) exprNode()     {}
+
+// GraphPattern is one complete pattern: optional selector + restrictor +
+// path variable + a sequence of node/edge pattern parts.
+//
+// Grammar: gpmlPattern
+type GraphPattern struct {
+	Selector   *PatternSelector
+	Restrictor PatternRestrictor
+	Variable   *VarRef // optional `p = ...` path variable binding
+	Parts      []PatternNode
+	Loc        Loc
+}
+
+func (*GraphPattern) nodeTag()      {}
+func (n *GraphPattern) GetLoc() Loc { return n.Loc }
+func (*GraphPattern) patternNode()  {}
+
+// NodePattern represents `(var:Label WHERE …)`. Variable, Labels, and
+// Where are all optional.
+//
+// Grammar: nodePattern
+type NodePattern struct {
+	Variable *VarRef
+	Labels   []string
+	Where    ExprNode
+	Loc      Loc
+}
+
+func (*NodePattern) nodeTag()      {}
+func (n *NodePattern) GetLoc() Loc { return n.Loc }
+func (*NodePattern) patternNode()  {}
+
+// EdgePattern represents `-[var:Label]->`, `<-[]-`, `~[]~`, etc.
+// Direction is required; Variable, Labels, Where, and Quantifier are optional.
+//
+// Grammar: edgePattern, edgeWSpec
+type EdgePattern struct {
+	Direction  EdgeDirection
+	Variable   *VarRef
+	Labels     []string
+	Where      ExprNode
+	Quantifier *PatternQuantifier
+	Loc        Loc
+}
+
+func (*EdgePattern) nodeTag()      {}
+func (n *EdgePattern) GetLoc() Loc { return n.Loc }
+func (*EdgePattern) patternNode()  {}
+
+// PatternQuantifier represents the `+`, `*`, or `{m,n}` decorator on a
+// pattern part. Min and Max use -1 to indicate "unbounded".
+//
+// Grammar: patternQuantifier
+type PatternQuantifier struct {
+	Min int
+	Max int // -1 = unbounded
+	Loc Loc
+}
+
+func (*PatternQuantifier) nodeTag()      {}
+func (n *PatternQuantifier) GetLoc() Loc { return n.Loc }
+
+// PatternSelector represents the optional selector keyword on a graph
+// pattern: `ANY`, `ALL SHORTEST`, or `SHORTEST k`. K is non-zero only for
+// SHORTEST K.
+//
+// Grammar: patternPathVariable selector
+type PatternSelector struct {
+	Kind SelectorKind
+	K    int
+	Loc  Loc
+}
+
+func (*PatternSelector) nodeTag()      {}
+func (n *PatternSelector) GetLoc() Loc { return n.Loc }
+```
+
+- [ ] **Step 2: Append assertions and TestGetLoc rows**
+
+In `ast_test.go`:
+
+```go
+// Graph patterns (patterns.go).
+var _ ExprNode    = (*MatchExpr)(nil)
+var _ PatternNode = (*GraphPattern)(nil)
+var _ PatternNode = (*NodePattern)(nil)
+var _ PatternNode = (*EdgePattern)(nil)
+var _ Node        = (*PatternQuantifier)(nil)
+var _ Node        = (*PatternSelector)(nil)
+```
+
+Append to `cases`:
+
+```go
+{"MatchExpr",         &MatchExpr{Loc: Loc{Start: 10, End: 20}}},
+{"GraphPattern",      &GraphPattern{Loc: Loc{Start: 10, End: 20}}},
+{"NodePattern",       &NodePattern{Loc: Loc{Start: 10, End: 20}}},
+{"EdgePattern",       &EdgePattern{Loc: Loc{Start: 10, End: 20}}},
+{"PatternQuantifier", &PatternQuantifier{Loc: Loc{Start: 10, End: 20}}},
+{"PatternSelector",   &PatternSelector{Loc: Loc{Start: 10, End: 20}}},
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./partiql/ast/...
+go test ./partiql/ast/...
+```
+
+Expected: ok, 74 sub-tests passing.
+
+- [ ] **Step 4: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add partiql/ast/patterns.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add graph pattern matching nodes
+
+GPML scaffolding: MatchExpr (also implements ExprNode because PartiQL
+embeds MATCH in expression position), GraphPattern container,
+NodePattern/EdgePattern atomic units, PatternQuantifier (+/*/{m,n}),
+PatternSelector (ANY/ALL SHORTEST/SHORTEST k). Plus EdgeDirection,
+PatternRestrictor, SelectorKind enums.
+
+Spec notes that the field shape inside NodePattern/EdgePattern may
+be refined when parser-graph (DAG node 16) is implemented; the
+marker interface, node names, and multi-interface relationship are
+stable from this point.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: `outfuncs.go` — `NodeToString` + golden tests + reflection safety net
+
+**Files:**
+- Create: `partiql/ast/outfuncs.go`
+- Modify: `partiql/ast/ast_test.go`
+
+This is the biggest task by line count. The `NodeToString` switch has one arm per node type.
+
+- [ ] **Step 1: Create `partiql/ast/outfuncs.go`**
+
+```go
+package ast
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// NodeToString returns a deterministic textual dump of any AST node.
+// The format is Go-struct-like for readability:
+//
+//	BinaryExpr{Op:+ Left:VarRef{Name:a} Right:NumberLit{Val:1}}
+//
+// Loc fields are not dumped (positions are tested separately by
+// TestGetLoc). For nil input, returns "<nil>".
+//
+// Used by ast_test.go for snapshot-style assertions and by future
+// parser golden tests.
+func NodeToString(n Node) string {
+	if n == nil {
+		return "<nil>"
+	}
+	var sb strings.Builder
+	writeNode(&sb, n)
+	return sb.String()
+}
+
+// writeNode dispatches on the concrete node type and appends a
+// textual representation to sb.
+func writeNode(sb *strings.Builder, n Node) {
+	if n == nil {
+		sb.WriteString("<nil>")
+		return
+	}
+	switch v := n.(type) {
+
+	// -----------------------------------------------------------------------
+	// node.go
+	// -----------------------------------------------------------------------
+	case *List:
+		sb.WriteString("List{Items:[")
+		for i, item := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, item)
+		}
+		sb.WriteString("]}")
+
+	// -----------------------------------------------------------------------
+	// literals.go
+	// -----------------------------------------------------------------------
+	case *StringLit:
+		fmt.Fprintf(sb, "StringLit{Val:%q}", v.Val)
+	case *NumberLit:
+		fmt.Fprintf(sb, "NumberLit{Val:%s}", v.Val)
+	case *BoolLit:
+		fmt.Fprintf(sb, "BoolLit{Val:%t}", v.Val)
+	case *NullLit:
+		sb.WriteString("NullLit{}")
+	case *MissingLit:
+		sb.WriteString("MissingLit{}")
+	case *DateLit:
+		fmt.Fprintf(sb, "DateLit{Val:%s}", v.Val)
+	case *TimeLit:
+		sb.WriteString("TimeLit{Val:")
+		sb.WriteString(v.Val)
+		if v.Precision != nil {
+			fmt.Fprintf(sb, " Precision:%d", *v.Precision)
+		}
+		if v.WithTimeZone {
+			sb.WriteString(" WithTimeZone:true")
+		}
+		sb.WriteString("}")
+	case *TimestampLit:
+		sb.WriteString("TimestampLit{Val:")
+		sb.WriteString(v.Val)
+		if v.Precision != nil {
+			fmt.Fprintf(sb, " Precision:%d", *v.Precision)
+		}
+		if v.WithTimeZone {
+			sb.WriteString(" WithTimeZone:true")
+		}
+		sb.WriteString("}")
+	case *IonLit:
+		fmt.Fprintf(sb, "IonLit{Text:%q}", v.Text)
+
+	// -----------------------------------------------------------------------
+	// exprs.go — operators and predicates
+	// -----------------------------------------------------------------------
+	case *BinaryExpr:
+		fmt.Fprintf(sb, "BinaryExpr{Op:%s Left:", v.Op)
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		sb.WriteString("}")
+	case *UnaryExpr:
+		fmt.Fprintf(sb, "UnaryExpr{Op:%s Operand:", v.Op)
+		writeNode(sb, v.Operand)
+		sb.WriteString("}")
+	case *InExpr:
+		sb.WriteString("InExpr{Expr:")
+		writeNode(sb, v.Expr)
+		if v.Subquery != nil {
+			sb.WriteString(" Subquery:")
+			writeNode(sb, v.Subquery)
+		} else {
+			sb.WriteString(" List:[")
+			for i, e := range v.List {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, e)
+			}
+			sb.WriteString("]")
+		}
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
+	case *BetweenExpr:
+		sb.WriteString("BetweenExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" Low:")
+		writeNode(sb, v.Low)
+		sb.WriteString(" High:")
+		writeNode(sb, v.High)
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
+	case *LikeExpr:
+		sb.WriteString("LikeExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" Pattern:")
+		writeNode(sb, v.Pattern)
+		if v.Escape != nil {
+			sb.WriteString(" Escape:")
+			writeNode(sb, v.Escape)
+		}
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
+	case *IsExpr:
+		sb.WriteString("IsExpr{Expr:")
+		writeNode(sb, v.Expr)
+		fmt.Fprintf(sb, " Type:%s Not:%t}", v.Type, v.Not)
+
+	// -----------------------------------------------------------------------
+	// exprs.go — special-form expressions
+	// -----------------------------------------------------------------------
+	case *FuncCall:
+		fmt.Fprintf(sb, "FuncCall{Name:%s", v.Name)
+		if v.Quantifier != QuantifierNone {
+			fmt.Fprintf(sb, " Quantifier:%s", v.Quantifier)
+		}
+		if v.Star {
+			sb.WriteString(" Star:true")
+		}
+		sb.WriteString(" Args:[")
+		for i, a := range v.Args {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, a)
+		}
+		sb.WriteString("]")
+		if v.Over != nil {
+			sb.WriteString(" Over:")
+			writeNode(sb, v.Over)
+		}
+		sb.WriteString("}")
+	case *CaseExpr:
+		sb.WriteString("CaseExpr{")
+		if v.Operand != nil {
+			sb.WriteString("Operand:")
+			writeNode(sb, v.Operand)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("Whens:[")
+		for i, w := range v.Whens {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, w)
+		}
+		sb.WriteString("]")
+		if v.Else != nil {
+			sb.WriteString(" Else:")
+			writeNode(sb, v.Else)
+		}
+		sb.WriteString("}")
+	case *CaseWhen:
+		sb.WriteString("CaseWhen{When:")
+		writeNode(sb, v.When)
+		sb.WriteString(" Then:")
+		writeNode(sb, v.Then)
+		sb.WriteString("}")
+	case *CastExpr:
+		fmt.Fprintf(sb, "CastExpr{Kind:%s Expr:", v.Kind)
+		writeNode(sb, v.Expr)
+		sb.WriteString(" AsType:")
+		writeNode(sb, v.AsType)
+		sb.WriteString("}")
+	case *ExtractExpr:
+		fmt.Fprintf(sb, "ExtractExpr{Field:%s From:", v.Field)
+		writeNode(sb, v.From)
+		sb.WriteString("}")
+	case *TrimExpr:
+		sb.WriteString("TrimExpr{")
+		if v.Spec != TrimSpecNone {
+			fmt.Fprintf(sb, "Spec:%s ", v.Spec)
+		}
+		if v.Sub != nil {
+			sb.WriteString("Sub:")
+			writeNode(sb, v.Sub)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("From:")
+		writeNode(sb, v.From)
+		sb.WriteString("}")
+	case *SubstringExpr:
+		sb.WriteString("SubstringExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" From:")
+		writeNode(sb, v.From)
+		if v.For != nil {
+			sb.WriteString(" For:")
+			writeNode(sb, v.For)
+		}
+		sb.WriteString("}")
+	case *CoalesceExpr:
+		sb.WriteString("CoalesceExpr{Args:[")
+		for i, a := range v.Args {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, a)
+		}
+		sb.WriteString("]}")
+	case *NullIfExpr:
+		sb.WriteString("NullIfExpr{Left:")
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		sb.WriteString("}")
+	case *WindowSpec:
+		sb.WriteString("WindowSpec{PartitionBy:[")
+		for i, e := range v.PartitionBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, e)
+		}
+		sb.WriteString("] OrderBy:[")
+		for i, o := range v.OrderBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o)
+		}
+		sb.WriteString("]}")
+
+	// -----------------------------------------------------------------------
+	// exprs.go — paths, vars, params, subqueries
+	// -----------------------------------------------------------------------
+	case *PathExpr:
+		sb.WriteString("PathExpr{Root:")
+		writeNode(sb, v.Root)
+		sb.WriteString(" Steps:[")
+		for i, s := range v.Steps {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, s)
+		}
+		sb.WriteString("]}")
+	case *VarRef:
+		fmt.Fprintf(sb, "VarRef{Name:%s", v.Name)
+		if v.AtPrefixed {
+			sb.WriteString(" AtPrefixed:true")
+		}
+		if v.CaseSensitive {
+			sb.WriteString(" CaseSensitive:true")
+		}
+		sb.WriteString("}")
+	case *ParamRef:
+		sb.WriteString("ParamRef{}")
+	case *SubLink:
+		sb.WriteString("SubLink{Stmt:")
+		writeNode(sb, v.Stmt)
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// exprs.go — collection literals
+	// -----------------------------------------------------------------------
+	case *ListLit:
+		sb.WriteString("ListLit{Items:[")
+		for i, e := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, e)
+		}
+		sb.WriteString("]}")
+	case *BagLit:
+		sb.WriteString("BagLit{Items:[")
+		for i, e := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, e)
+		}
+		sb.WriteString("]}")
+	case *TupleLit:
+		sb.WriteString("TupleLit{Pairs:[")
+		for i, p := range v.Pairs {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *TuplePair:
+		sb.WriteString("TuplePair{Key:")
+		writeNode(sb, v.Key)
+		sb.WriteString(" Value:")
+		writeNode(sb, v.Value)
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// exprs.go — path steps
+	// -----------------------------------------------------------------------
+	case *DotStep:
+		fmt.Fprintf(sb, "DotStep{Field:%s", v.Field)
+		if v.CaseSensitive {
+			sb.WriteString(" CaseSensitive:true")
+		}
+		sb.WriteString("}")
+	case *AllFieldsStep:
+		sb.WriteString("AllFieldsStep{}")
+	case *IndexStep:
+		sb.WriteString("IndexStep{Index:")
+		writeNode(sb, v.Index)
+		sb.WriteString("}")
+	case *WildcardStep:
+		sb.WriteString("WildcardStep{}")
+
+	// -----------------------------------------------------------------------
+	// tableexprs.go
+	// -----------------------------------------------------------------------
+	case *TableRef:
+		fmt.Fprintf(sb, "TableRef{Name:%s", v.Name)
+		if v.Schema != "" {
+			fmt.Fprintf(sb, " Schema:%s", v.Schema)
+		}
+		if v.CaseSensitive {
+			sb.WriteString(" CaseSensitive:true")
+		}
+		sb.WriteString("}")
+	case *AliasedSource:
+		sb.WriteString("AliasedSource{Source:")
+		writeNode(sb, v.Source)
+		writeOptString(sb, " As:", v.As)
+		writeOptString(sb, " At:", v.At)
+		writeOptString(sb, " By:", v.By)
+		sb.WriteString("}")
+	case *JoinExpr:
+		fmt.Fprintf(sb, "JoinExpr{Kind:%s Left:", v.Kind)
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		if v.On != nil {
+			sb.WriteString(" On:")
+			writeNode(sb, v.On)
+		}
+		sb.WriteString("}")
+	case *UnpivotExpr:
+		sb.WriteString("UnpivotExpr{Source:")
+		writeNode(sb, v.Source)
+		writeOptString(sb, " As:", v.As)
+		writeOptString(sb, " At:", v.At)
+		writeOptString(sb, " By:", v.By)
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// types.go
+	// -----------------------------------------------------------------------
+	case *TypeRef:
+		fmt.Fprintf(sb, "TypeRef{Name:%s", v.Name)
+		if len(v.Args) > 0 {
+			sb.WriteString(" Args:[")
+			for i, a := range v.Args {
+				if i > 0 {
+					sb.WriteString(",")
+				}
+				sb.WriteString(strconv.Itoa(a))
+			}
+			sb.WriteString("]")
+		}
+		if v.WithTimeZone {
+			sb.WriteString(" WithTimeZone:true")
+		}
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// stmts.go — top-level statements
+	// -----------------------------------------------------------------------
+	case *SelectStmt:
+		writeSelectStmt(sb, v)
+	case *SetOpStmt:
+		fmt.Fprintf(sb, "SetOpStmt{Op:%s", v.Op)
+		if v.Quantifier != QuantifierNone {
+			fmt.Fprintf(sb, " Quantifier:%s", v.Quantifier)
+		}
+		if v.Outer {
+			sb.WriteString(" Outer:true")
+		}
+		sb.WriteString(" Left:")
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		sb.WriteString("}")
+	case *ExplainStmt:
+		sb.WriteString("ExplainStmt{Inner:")
+		writeNode(sb, v.Inner)
+		sb.WriteString("}")
+	case *InsertStmt:
+		writeDmlStmt(sb, "InsertStmt", v.Target, v.AsAlias, v.Value, v.OnConflict, v.Returning)
+	case *UpdateStmt:
+		sb.WriteString("UpdateStmt{Source:")
+		writeNode(sb, v.Source)
+		sb.WriteString(" Sets:[")
+		for i, s := range v.Sets {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, s)
+		}
+		sb.WriteString("]")
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		if v.Returning != nil {
+			sb.WriteString(" Returning:")
+			writeNode(sb, v.Returning)
+		}
+		sb.WriteString("}")
+	case *DeleteStmt:
+		sb.WriteString("DeleteStmt{Source:")
+		writeNode(sb, v.Source)
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		if v.Returning != nil {
+			sb.WriteString(" Returning:")
+			writeNode(sb, v.Returning)
+		}
+		sb.WriteString("}")
+	case *UpsertStmt:
+		writeDmlStmt(sb, "UpsertStmt", v.Target, v.AsAlias, v.Value, v.OnConflict, v.Returning)
+	case *ReplaceStmt:
+		writeDmlStmt(sb, "ReplaceStmt", v.Target, v.AsAlias, v.Value, v.OnConflict, v.Returning)
+	case *RemoveStmt:
+		sb.WriteString("RemoveStmt{Path:")
+		writeNode(sb, v.Path)
+		sb.WriteString("}")
+	case *CreateTableStmt:
+		sb.WriteString("CreateTableStmt{Name:")
+		writeNode(sb, v.Name)
+		sb.WriteString("}")
+	case *CreateIndexStmt:
+		sb.WriteString("CreateIndexStmt{Table:")
+		writeNode(sb, v.Table)
+		sb.WriteString(" Paths:[")
+		for i, p := range v.Paths {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *DropTableStmt:
+		sb.WriteString("DropTableStmt{Name:")
+		writeNode(sb, v.Name)
+		sb.WriteString("}")
+	case *DropIndexStmt:
+		sb.WriteString("DropIndexStmt{Index:")
+		writeNode(sb, v.Index)
+		sb.WriteString(" Table:")
+		writeNode(sb, v.Table)
+		sb.WriteString("}")
+	case *ExecStmt:
+		fmt.Fprintf(sb, "ExecStmt{Name:%s Args:[", v.Name)
+		for i, a := range v.Args {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, a)
+		}
+		sb.WriteString("]}")
+
+	// -----------------------------------------------------------------------
+	// stmts.go — clause and DML helpers
+	// -----------------------------------------------------------------------
+	case *TargetEntry:
+		sb.WriteString("TargetEntry{Expr:")
+		writeNode(sb, v.Expr)
+		writeOptString(sb, " Alias:", v.Alias)
+		sb.WriteString("}")
+	case *PivotProjection:
+		sb.WriteString("PivotProjection{Value:")
+		writeNode(sb, v.Value)
+		sb.WriteString(" At:")
+		writeNode(sb, v.At)
+		sb.WriteString("}")
+	case *LetBinding:
+		sb.WriteString("LetBinding{Expr:")
+		writeNode(sb, v.Expr)
+		fmt.Fprintf(sb, " Alias:%s}", v.Alias)
+	case *GroupByClause:
+		sb.WriteString("GroupByClause{")
+		if v.Partial {
+			sb.WriteString("Partial:true ")
+		}
+		sb.WriteString("Items:[")
+		for i, it := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, it)
+		}
+		sb.WriteString("]")
+		writeOptString(sb, " GroupAs:", v.GroupAs)
+		sb.WriteString("}")
+	case *GroupByItem:
+		sb.WriteString("GroupByItem{Expr:")
+		writeNode(sb, v.Expr)
+		writeOptString(sb, " Alias:", v.Alias)
+		sb.WriteString("}")
+	case *OrderByItem:
+		sb.WriteString("OrderByItem{Expr:")
+		writeNode(sb, v.Expr)
+		fmt.Fprintf(sb, " Desc:%t", v.Desc)
+		if v.NullsExplicit {
+			fmt.Fprintf(sb, " NullsFirst:%t", v.NullsFirst)
+		}
+		sb.WriteString("}")
+	case *SetAssignment:
+		sb.WriteString("SetAssignment{Target:")
+		writeNode(sb, v.Target)
+		sb.WriteString(" Value:")
+		writeNode(sb, v.Value)
+		sb.WriteString("}")
+	case *OnConflict:
+		sb.WriteString("OnConflict{")
+		if v.Target != nil {
+			sb.WriteString("Target:")
+			writeNode(sb, v.Target)
+			sb.WriteString(" ")
+		}
+		fmt.Fprintf(sb, "Action:%s", v.Action)
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		sb.WriteString("}")
+	case *OnConflictTarget:
+		sb.WriteString("OnConflictTarget{")
+		if v.ConstraintName != "" {
+			fmt.Fprintf(sb, "ConstraintName:%s", v.ConstraintName)
+		} else {
+			sb.WriteString("Cols:[")
+			for i, c := range v.Cols {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, c)
+			}
+			sb.WriteString("]")
+		}
+		sb.WriteString("}")
+	case *ReturningClause:
+		sb.WriteString("ReturningClause{Items:[")
+		for i, it := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, it)
+		}
+		sb.WriteString("]}")
+	case *ReturningItem:
+		fmt.Fprintf(sb, "ReturningItem{Status:%s Mapping:%s", v.Status, v.Mapping)
+		if v.Star {
+			sb.WriteString(" Star:true")
+		}
+		if v.Expr != nil {
+			sb.WriteString(" Expr:")
+			writeNode(sb, v.Expr)
+		}
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// patterns.go
+	// -----------------------------------------------------------------------
+	case *MatchExpr:
+		sb.WriteString("MatchExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" Patterns:[")
+		for i, p := range v.Patterns {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *GraphPattern:
+		sb.WriteString("GraphPattern{")
+		if v.Selector != nil {
+			sb.WriteString("Selector:")
+			writeNode(sb, v.Selector)
+			sb.WriteString(" ")
+		}
+		if v.Restrictor != PatternRestrictorNone {
+			fmt.Fprintf(sb, "Restrictor:%s ", v.Restrictor)
+		}
+		if v.Variable != nil {
+			sb.WriteString("Variable:")
+			writeNode(sb, v.Variable)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("Parts:[")
+		for i, p := range v.Parts {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *NodePattern:
+		sb.WriteString("NodePattern{")
+		if v.Variable != nil {
+			sb.WriteString("Variable:")
+			writeNode(sb, v.Variable)
+			sb.WriteString(" ")
+		}
+		if len(v.Labels) > 0 {
+			fmt.Fprintf(sb, "Labels:[%s] ", strings.Join(v.Labels, " "))
+		}
+		if v.Where != nil {
+			sb.WriteString("Where:")
+			writeNode(sb, v.Where)
+		}
+		sb.WriteString("}")
+	case *EdgePattern:
+		fmt.Fprintf(sb, "EdgePattern{Direction:%s", v.Direction)
+		if v.Variable != nil {
+			sb.WriteString(" Variable:")
+			writeNode(sb, v.Variable)
+		}
+		if len(v.Labels) > 0 {
+			fmt.Fprintf(sb, " Labels:[%s]", strings.Join(v.Labels, " "))
+		}
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		if v.Quantifier != nil {
+			sb.WriteString(" Quantifier:")
+			writeNode(sb, v.Quantifier)
+		}
+		sb.WriteString("}")
+	case *PatternQuantifier:
+		fmt.Fprintf(sb, "PatternQuantifier{Min:%d Max:%d}", v.Min, v.Max)
+	case *PatternSelector:
+		fmt.Fprintf(sb, "PatternSelector{Kind:%s", v.Kind)
+		if v.Kind == SelectorKindShortestK {
+			fmt.Fprintf(sb, " K:%d", v.K)
+		}
+		sb.WriteString("}")
+
+	default:
+		fmt.Fprintf(sb, "<unknown:%T>", v)
+	}
+}
+
+// writeSelectStmt is split out because SelectStmt has 13 fields and would
+// dominate the main switch arm.
+func writeSelectStmt(sb *strings.Builder, s *SelectStmt) {
+	sb.WriteString("SelectStmt{")
+	first := true
+	add := func(label string) {
+		if !first {
+			sb.WriteString(" ")
+		}
+		first = false
+		sb.WriteString(label)
+	}
+	if s.Quantifier != QuantifierNone {
+		add(fmt.Sprintf("Quantifier:%s", s.Quantifier))
+	}
+	if s.Star {
+		add("Star:true")
+	}
+	if s.Value != nil {
+		add("Value:")
+		writeNode(sb, s.Value)
+	}
+	if s.Pivot != nil {
+		add("Pivot:")
+		writeNode(sb, s.Pivot)
+	}
+	if len(s.Targets) > 0 {
+		add("Targets:[")
+		for i, t := range s.Targets {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, t)
+		}
+		sb.WriteString("]")
+	}
+	if s.From != nil {
+		add("From:")
+		writeNode(sb, s.From)
+	}
+	if len(s.Let) > 0 {
+		add("Let:[")
+		for i, l := range s.Let {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, l)
+		}
+		sb.WriteString("]")
+	}
+	if s.Where != nil {
+		add("Where:")
+		writeNode(sb, s.Where)
+	}
+	if s.GroupBy != nil {
+		add("GroupBy:")
+		writeNode(sb, s.GroupBy)
+	}
+	if s.Having != nil {
+		add("Having:")
+		writeNode(sb, s.Having)
+	}
+	if len(s.OrderBy) > 0 {
+		add("OrderBy:[")
+		for i, o := range s.OrderBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o)
+		}
+		sb.WriteString("]")
+	}
+	if s.Limit != nil {
+		add("Limit:")
+		writeNode(sb, s.Limit)
+	}
+	if s.Offset != nil {
+		add("Offset:")
+		writeNode(sb, s.Offset)
+	}
+	sb.WriteString("}")
+}
+
+// writeDmlStmt is shared by InsertStmt, UpsertStmt, and ReplaceStmt — they
+// have the same shape (target, alias, value, on-conflict, returning).
+func writeDmlStmt(sb *strings.Builder, name string, target TableExpr, alias *string, value ExprNode, oc *OnConflict, ret *ReturningClause) {
+	fmt.Fprintf(sb, "%s{Target:", name)
+	writeNode(sb, target)
+	writeOptString(sb, " AsAlias:", alias)
+	sb.WriteString(" Value:")
+	writeNode(sb, value)
+	if oc != nil {
+		sb.WriteString(" OnConflict:")
+		writeNode(sb, oc)
+	}
+	if ret != nil {
+		sb.WriteString(" Returning:")
+		writeNode(sb, ret)
+	}
+	sb.WriteString("}")
+}
+
+// writeOptString appends a label + value if the optional string is non-nil.
+func writeOptString(sb *strings.Builder, label string, s *string) {
+	if s == nil {
+		return
+	}
+	sb.WriteString(label)
+	sb.WriteString(*s)
+}
+```
+
+- [ ] **Step 2: Add `TestNodeToString` golden cases to `ast_test.go`**
+
+Append a new test function at the bottom of `ast_test.go`:
+
+```go
+// ---------------------------------------------------------------------------
+// TestNodeToString — golden assertions on outfuncs.go output.
+//
+// One representative case per node category, plus the multi-interface nodes
+// and at least one deeply nested case.
+// ---------------------------------------------------------------------------
+
+func TestNodeToString(t *testing.T) {
+	cases := []struct {
+		name string
+		node Node
+		want string
+	}{
+		{
+			name: "string_literal",
+			node: &StringLit{Val: "hello"},
+			want: `StringLit{Val:"hello"}`,
+		},
+		{
+			name: "number_literal",
+			node: &NumberLit{Val: "42"},
+			want: `NumberLit{Val:42}`,
+		},
+		{
+			name: "binary_expr_add",
+			node: &BinaryExpr{
+				Op:    BinOpAdd,
+				Left:  &VarRef{Name: "a"},
+				Right: &NumberLit{Val: "1"},
+			},
+			want: `BinaryExpr{Op:+ Left:VarRef{Name:a} Right:NumberLit{Val:1}}`,
+		},
+		{
+			name: "in_expr_with_list",
+			node: &InExpr{
+				Expr: &VarRef{Name: "x"},
+				List: []ExprNode{&NumberLit{Val: "1"}, &NumberLit{Val: "2"}},
+				Not:  false,
+			},
+			want: `InExpr{Expr:VarRef{Name:x} List:[NumberLit{Val:1} NumberLit{Val:2}] Not:false}`,
+		},
+		{
+			name: "is_missing_predicate",
+			node: &IsExpr{
+				Expr: &VarRef{Name: "y"},
+				Type: IsTypeMissing,
+				Not:  false,
+			},
+			want: `IsExpr{Expr:VarRef{Name:y} Type:MISSING Not:false}`,
+		},
+		{
+			name: "func_call_count_distinct",
+			node: &FuncCall{
+				Name:       "COUNT",
+				Quantifier: QuantifierDistinct,
+				Args:       []ExprNode{&VarRef{Name: "id"}},
+			},
+			want: `FuncCall{Name:COUNT Quantifier:DISTINCT Args:[VarRef{Name:id}]}`,
+		},
+		{
+			name: "func_call_count_star",
+			node: &FuncCall{Name: "COUNT", Star: true},
+			want: `FuncCall{Name:COUNT Star:true Args:[]}`,
+		},
+		{
+			name: "case_expr_searched",
+			node: &CaseExpr{
+				Whens: []*CaseWhen{
+					{When: &BoolLit{Val: true}, Then: &NumberLit{Val: "1"}},
+				},
+				Else: &NumberLit{Val: "0"},
+			},
+			want: `CaseExpr{Whens:[CaseWhen{When:BoolLit{Val:true} Then:NumberLit{Val:1}}] Else:NumberLit{Val:0}}`,
+		},
+		{
+			name: "cast_expr",
+			node: &CastExpr{
+				Kind:   CastKindCast,
+				Expr:   &VarRef{Name: "x"},
+				AsType: &TypeRef{Name: "INTEGER"},
+			},
+			want: `CastExpr{Kind:CAST Expr:VarRef{Name:x} AsType:TypeRef{Name:INTEGER}}`,
+		},
+		{
+			name: "path_expr_with_steps",
+			node: &PathExpr{
+				Root:  &VarRef{Name: "Music"},
+				Steps: []PathStep{&DotStep{Field: "albums"}, &WildcardStep{}},
+			},
+			want: `PathExpr{Root:VarRef{Name:Music} Steps:[DotStep{Field:albums} WildcardStep{}]}`,
+		},
+		{
+			name: "var_ref_at_prefixed",
+			node: &VarRef{Name: "doc", AtPrefixed: true},
+			want: `VarRef{Name:doc AtPrefixed:true}`,
+		},
+		{
+			name: "param_ref",
+			node: &ParamRef{},
+			want: `ParamRef{}`,
+		},
+		{
+			name: "sub_link",
+			node: &SubLink{Stmt: &SelectStmt{Star: true}},
+			want: `SubLink{Stmt:SelectStmt{Star:true}}`,
+		},
+		{
+			name: "list_literal",
+			node: &ListLit{Items: []ExprNode{&NumberLit{Val: "1"}, &NumberLit{Val: "2"}}},
+			want: `ListLit{Items:[NumberLit{Val:1} NumberLit{Val:2}]}`,
+		},
+		{
+			name: "bag_literal",
+			node: &BagLit{Items: []ExprNode{&NumberLit{Val: "1"}}},
+			want: `BagLit{Items:[NumberLit{Val:1}]}`,
+		},
+		{
+			name: "tuple_literal",
+			node: &TupleLit{
+				Pairs: []*TuplePair{
+					{Key: &StringLit{Val: "k"}, Value: &NumberLit{Val: "1"}},
+				},
+			},
+			want: `TupleLit{Pairs:[TuplePair{Key:StringLit{Val:"k"} Value:NumberLit{Val:1}}]}`,
+		},
+		{
+			name: "join_expr",
+			node: &JoinExpr{
+				Kind:  JoinKindInner,
+				Left:  &TableRef{Name: "a"},
+				Right: &TableRef{Name: "b"},
+				On:    &BoolLit{Val: true},
+			},
+			want: `JoinExpr{Kind:INNER Left:TableRef{Name:a} Right:TableRef{Name:b} On:BoolLit{Val:true}}`,
+		},
+		{
+			name: "select_with_path_in_from",
+			node: &SelectStmt{
+				Star: true,
+				From: &PathExpr{
+					Root:  &VarRef{Name: "Music"},
+					Steps: []PathStep{&DotStep{Field: "albums"}, &WildcardStep{}},
+				},
+			},
+			want: `SelectStmt{Star:true From:PathExpr{Root:VarRef{Name:Music} Steps:[DotStep{Field:albums} WildcardStep{}]}}`,
+		},
+		{
+			name: "insert_stmt_with_returning",
+			node: &InsertStmt{
+				Target: &TableRef{Name: "Music"},
+				Value:  &TupleLit{Pairs: []*TuplePair{{Key: &StringLit{Val: "k"}, Value: &NumberLit{Val: "1"}}}},
+				Returning: &ReturningClause{
+					Items: []*ReturningItem{
+						{Status: ReturningStatusModified, Mapping: ReturningMappingNew, Star: true},
+					},
+				},
+			},
+			want: `InsertStmt{Target:TableRef{Name:Music} Value:TupleLit{Pairs:[TuplePair{Key:StringLit{Val:"k"} Value:NumberLit{Val:1}}]} Returning:ReturningClause{Items:[ReturningItem{Status:MODIFIED Mapping:NEW Star:true}]}}`,
+		},
+		{
+			name: "match_expr",
+			node: &MatchExpr{
+				Expr: &VarRef{Name: "g"},
+				Patterns: []*GraphPattern{
+					{Parts: []PatternNode{&NodePattern{Variable: &VarRef{Name: "n"}}}},
+				},
+			},
+			want: `MatchExpr{Expr:VarRef{Name:g} Patterns:[GraphPattern{Parts:[NodePattern{Variable:VarRef{Name:n}}]}]}`,
+		},
+		{
+			name: "type_ref_decimal",
+			node: &TypeRef{Name: "DECIMAL", Args: []int{10, 2}},
+			want: `TypeRef{Name:DECIMAL Args:[10,2]}`,
+		},
+		{
+			name: "type_ref_time_with_tz",
+			node: &TypeRef{Name: "TIME", WithTimeZone: true},
+			want: `TypeRef{Name:TIME WithTimeZone:true}`,
+		},
+		{
+			name: "nil_node",
+			node: nil,
+			want: `<nil>`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NodeToString(tc.node)
+			if got != tc.want {
+				t.Errorf("NodeToString() mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run the new test**
+
+```bash
+go test -run TestNodeToString$ ./partiql/ast/...
+```
+
+Expected: ok with all 23 sub-tests passing. If any fail, fix the corresponding arm in `outfuncs.go` until the golden matches. **Do not adjust the golden to match a buggy `NodeToString` output** — the goldens encode the spec's "stable, deterministic" invariant.
+
+- [ ] **Step 4: Add the reflection safety net `TestNodeToString_AllNodesCovered`**
+
+Append at the bottom of `ast_test.go`:
+
+```go
+// ---------------------------------------------------------------------------
+// TestNodeToString_AllNodesCovered — reflection safety net.
+//
+// Walks every node in the package's TestGetLoc table and asserts that
+// NodeToString returns a non-empty result without panicking. This catches
+// the case where a new node type is added to TestGetLoc but never wired
+// into outfuncs.go's switch.
+// ---------------------------------------------------------------------------
+
+func TestNodeToString_AllNodesCovered(t *testing.T) {
+	// Build a fresh table identical in shape to TestGetLoc but constructed
+	// here so the two tests cannot drift apart silently. We could share via
+	// a top-level helper but inlining keeps the test self-contained.
+	cases := allNodesForCoverageTest()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("NodeToString panicked: %v", r)
+				}
+			}()
+			got := NodeToString(tc.node)
+			if got == "" {
+				t.Errorf("NodeToString returned empty string for %s", tc.name)
+			}
+			if strings.HasPrefix(got, "<unknown:") {
+				t.Errorf("outfuncs.go is missing a switch arm for %s: got %q", tc.name, got)
+			}
+		})
+	}
+}
+
+// allNodesForCoverageTest returns one zero-value instance of every node
+// type defined in this package. Adding a new node type means adding it
+// here too — the test will fail until you do.
+func allNodesForCoverageTest() []struct {
+	name string
+	node Node
+} {
+	return []struct {
+		name string
+		node Node
+	}{
+		// node.go
+		{"List", &List{}},
+
+		// literals.go
+		{"StringLit", &StringLit{}},
+		{"NumberLit", &NumberLit{}},
+		{"BoolLit", &BoolLit{}},
+		{"NullLit", &NullLit{}},
+		{"MissingLit", &MissingLit{}},
+		{"DateLit", &DateLit{}},
+		{"TimeLit", &TimeLit{}},
+		{"TimestampLit", &TimestampLit{}},
+		{"IonLit", &IonLit{}},
+
+		// exprs.go
+		{"BinaryExpr", &BinaryExpr{}},
+		{"UnaryExpr", &UnaryExpr{}},
+		{"InExpr", &InExpr{}},
+		{"BetweenExpr", &BetweenExpr{}},
+		{"LikeExpr", &LikeExpr{}},
+		{"IsExpr", &IsExpr{}},
+		{"FuncCall", &FuncCall{}},
+		{"CaseExpr", &CaseExpr{}},
+		{"CaseWhen", &CaseWhen{}},
+		{"CastExpr", &CastExpr{}},
+		{"ExtractExpr", &ExtractExpr{}},
+		{"TrimExpr", &TrimExpr{}},
+		{"SubstringExpr", &SubstringExpr{}},
+		{"CoalesceExpr", &CoalesceExpr{}},
+		{"NullIfExpr", &NullIfExpr{}},
+		{"WindowSpec", &WindowSpec{}},
+		{"PathExpr", &PathExpr{}},
+		{"VarRef", &VarRef{}},
+		{"ParamRef", &ParamRef{}},
+		{"SubLink", &SubLink{}},
+		{"ListLit", &ListLit{}},
+		{"BagLit", &BagLit{}},
+		{"TupleLit", &TupleLit{}},
+		{"TuplePair", &TuplePair{}},
+		{"DotStep", &DotStep{}},
+		{"AllFieldsStep", &AllFieldsStep{}},
+		{"IndexStep", &IndexStep{}},
+		{"WildcardStep", &WildcardStep{}},
+
+		// tableexprs.go
+		{"TableRef", &TableRef{}},
+		{"AliasedSource", &AliasedSource{}},
+		{"JoinExpr", &JoinExpr{}},
+		{"UnpivotExpr", &UnpivotExpr{}},
+
+		// types.go
+		{"TypeRef", &TypeRef{}},
+
+		// stmts.go — top-level
+		{"SelectStmt", &SelectStmt{}},
+		{"SetOpStmt", &SetOpStmt{}},
+		{"ExplainStmt", &ExplainStmt{}},
+		{"InsertStmt", &InsertStmt{}},
+		{"UpdateStmt", &UpdateStmt{}},
+		{"DeleteStmt", &DeleteStmt{}},
+		{"UpsertStmt", &UpsertStmt{}},
+		{"ReplaceStmt", &ReplaceStmt{}},
+		{"RemoveStmt", &RemoveStmt{}},
+		{"CreateTableStmt", &CreateTableStmt{}},
+		{"CreateIndexStmt", &CreateIndexStmt{}},
+		{"DropTableStmt", &DropTableStmt{}},
+		{"DropIndexStmt", &DropIndexStmt{}},
+		{"ExecStmt", &ExecStmt{}},
+
+		// stmts.go — clause and DML helpers
+		{"TargetEntry", &TargetEntry{}},
+		{"PivotProjection", &PivotProjection{}},
+		{"LetBinding", &LetBinding{}},
+		{"GroupByClause", &GroupByClause{}},
+		{"GroupByItem", &GroupByItem{}},
+		{"OrderByItem", &OrderByItem{}},
+		{"SetAssignment", &SetAssignment{}},
+		{"OnConflict", &OnConflict{}},
+		{"OnConflictTarget", &OnConflictTarget{}},
+		{"ReturningClause", &ReturningClause{}},
+		{"ReturningItem", &ReturningItem{}},
+
+		// patterns.go
+		{"MatchExpr", &MatchExpr{}},
+		{"GraphPattern", &GraphPattern{}},
+		{"NodePattern", &NodePattern{}},
+		{"EdgePattern", &EdgePattern{}},
+		{"PatternQuantifier", &PatternQuantifier{}},
+		{"PatternSelector", &PatternSelector{}},
+	}
+}
+```
+
+Add the import at the top of `ast_test.go` (just after the existing `"testing"` import) — `strings` is needed by the new test:
+
+```go
+import (
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 5: Run the safety net test**
+
+```bash
+go test -run TestNodeToString_AllNodesCovered ./partiql/ast/...
+```
+
+Expected: ok, 74 sub-tests passing. If any sub-test fails with `outfuncs.go is missing a switch arm for X`, add the missing case to `writeNode` in `outfuncs.go` and re-run.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+go test ./partiql/ast/...
+```
+
+Expected: ok, all tests pass (`TestGetLoc` 74 sub-tests + `TestNodeToString` 23 sub-tests + `TestNodeToString_AllNodesCovered` 74 sub-tests = 171 sub-tests across 3 test functions).
+
+- [ ] **Step 7: Run vet and gofmt**
+
+```bash
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Both clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add partiql/ast/outfuncs.go partiql/ast/ast_test.go
+git commit -m "$(cat <<'EOF'
+feat(partiql/ast): add NodeToString and reflection safety net
+
+outfuncs.go: NodeToString writes a deterministic Go-struct-like dump
+of any AST node. Switch covers all 74 node types. Loc fields are
+omitted (positions are tested separately). Helpers writeSelectStmt
+and writeDmlStmt extract the bigger arms.
+
+ast_test.go: TestNodeToString golden cases (23 representative shapes
+including the multi-interface nodes and a deeply nested case);
+TestNodeToString_AllNodesCovered reflection safety net that calls
+NodeToString on a zero value of every node type and asserts no panic
+or "<unknown:>" fallback. Adding a new node type without wiring it
+into outfuncs.go now fails the build.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: Final verification, grammar cross-check, DAG bookkeeping, finishing branch
+
+**Files:**
+- Read: `/Users/h3n4l/OpenSource/parser/partiql/PartiQLParser.g4` (legacy grammar — for cross-check)
+- Modify: `/Users/h3n4l/OpenSource/omni/docs/migration/partiql/dag.md` (mark node 1 as done — on `main`, not the worktree)
+
+This task does not write more code unless the grammar cross-check finds a missing rule. It is the acceptance gate.
+
+- [ ] **Step 1: Run the full test suite, vet, and gofmt one more time**
+
+```bash
+cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core
+go test ./partiql/ast/...
+go vet ./partiql/ast/...
+gofmt -l partiql/ast/
+```
+
+Expected: ok, no output from vet or gofmt.
+
+- [ ] **Step 2: Cross-check the AST against `PartiQLParser.g4`**
+
+Open `/Users/h3n4l/OpenSource/parser/partiql/PartiQLParser.g4` and walk it from top to bottom. For each grammar rule, find a node type in `partiql/ast/` that represents it, using the spec's "Coverage cross-check" table as the working list. Take notes:
+
+- Rules covered: ✓
+- Rules missing or wrong-shaped: list with rule name + grammar line number
+
+Expected outcome: zero gaps. The analysis spent considerable effort on this already and the spec's cross-check covers the categories. If you find a missing rule:
+
+  1. Add the corresponding node type to the appropriate file
+  2. Add it to all four test groups in `ast_test.go` (compile-time assertion, `TestGetLoc` row, `TestNodeToString` golden if representative, and `allNodesForCoverageTest`)
+  3. Add a switch arm to `outfuncs.go`
+  4. Re-run `go test ./partiql/ast/...`
+  5. Make a separate commit per missed-rule fix with message `feat(partiql/ast): add <Node> for grammar rule <name>`
+
+If you find no gaps, write a brief note in the verification commit message confirming the cross-check was run.
+
+- [ ] **Step 3: Run the cross-check spot-check commands**
+
+```bash
+# Sanity: count node types via grep
+grep -c '^func (\*\w\+) nodeTag()' partiql/ast/*.go
+
+# Should print something like:
+# partiql/ast/exprs.go:28
+# partiql/ast/literals.go:9
+# partiql/ast/node.go:1
+# partiql/ast/patterns.go:6
+# partiql/ast/stmts.go:25
+# partiql/ast/tableexprs.go:4
+# partiql/ast/types.go:1
+#
+# Total ~74. If your count differs, investigate before proceeding.
+
+# Sanity: every node has GetLoc
+grep -c 'GetLoc() Loc { return n.Loc }' partiql/ast/*.go
+
+# Sanity: outfuncs.go switch has a case for every type
+grep -c '^	case \*' partiql/ast/outfuncs.go
+# Should be ~74 (one per node type).
+```
+
+If any number is off, look for the missing types using diff between the file lists and the switch arms.
+
+- [ ] **Step 4: Run a coverage report on `outfuncs.go`**
+
+```bash
+go test -coverprofile=/tmp/partiql-ast-cover.out ./partiql/ast/...
+go tool cover -func=/tmp/partiql-ast-cover.out | grep outfuncs.go
+```
+
+Expected: `outfuncs.go:NodeToString` and `writeNode` very close to 100%. Some optional-field branches may not be exercised by goldens — that's fine.
+
+- [ ] **Step 5: Confirm the spec's acceptance criteria**
+
+Re-read `docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md` "Acceptance criteria" section and verify each item:
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | All ~73 node types defined across the 8 files | check `grep -c` output |
+| 2 | Every node has a doc comment naming the grammar rule | spot-check 5 random nodes |
+| 3 | Every node implements `nodeTag()` and `GetLoc() Loc` | covered by `var _ Node` assertions |
+| 4 | Every node implements at least one sub-interface OR is a documented bare-Node helper | covered by `var _ <Iface>` assertions |
+| 5 | `outfuncs.NodeToString` covers every type | covered by `TestNodeToString_AllNodesCovered` |
+| 6 | `go test ./partiql/ast/...` passes | Step 1 |
+| 7 | `go vet ./partiql/ast/...` clean | Step 1 |
+| 8 | `gofmt` clean | Step 1 |
+| 9 | Coverage cross-check vs `PartiQLParser.g4` | Step 2 |
+
+If any criterion fails, fix it before proceeding. Do not move to Step 6 until all are green.
+
+- [ ] **Step 6: Final commit (verification note, even if there were no code changes)**
+
+```bash
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(partiql/ast): final verification pass
+
+- go test ./partiql/ast/... — pass
+- go vet ./partiql/ast/... — clean
+- gofmt -l partiql/ast/ — clean
+- Cross-checked against bytebase/parser/partiql/PartiQLParser.g4
+  line by line; every rule maps to a node type
+- All 9 acceptance criteria from the spec satisfied
+
+Closes ast-core (DAG node 1) for the partiql migration.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(`--allow-empty` is acceptable here because this commit is purely a verification gate marker — useful for reviewers and for the DAG status update in the next steps. If the cross-check found issues and you committed them as separate `feat` commits, this final empty commit is still a useful "done" marker.)
+
+- [ ] **Step 7: Update `dag.md` on `main` to mark node 1 as `done`**
+
+The DAG file lives on `main`, not on the feature branch. Switch to the main worktree directory:
+
+```bash
+cd /Users/h3n4l/OpenSource/omni
+```
+
+The migration docs were untracked when this work started. They may still be untracked or may have been committed in the meantime. Check:
+
+```bash
+git status docs/migration/partiql/
+```
+
+If `docs/migration/partiql/dag.md` is **untracked**, you need to commit it first as a baseline before updating the status (so the diff is sensible). If it's already tracked, just edit it.
+
+Open `docs/migration/partiql/dag.md` in your editor and find the table row:
+
+```
+| 1 | ast-core | `partiql/ast` | (none) | lexer, catalog | **P0** | not started |
+```
+
+Change `not started` to `done`:
+
+```
+| 1 | ast-core | `partiql/ast` | (none) | lexer, catalog | **P0** | done |
+```
+
+If `dag.md` was untracked at the start of this session, also stage and commit it now along with the status update. Coordinate with the user about whether to commit the migration docs to main as part of this task or as a separate housekeeping commit.
+
+- [ ] **Step 8: Hand off to `superpowers:finishing-a-development-branch`**
+
+This is the integration step. From the worktree:
+
+```bash
+cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core
+git log --oneline feat/partiql/ast-core ^main
+```
+
+Verify the commit list looks right (you should see commits from Tasks 1–12 plus the spec/plan commits from brainstorming/writing-plans).
+
+Then invoke the `superpowers:finishing-a-development-branch` skill to:
+- Pick a merge strategy (squash vs merge vs PR)
+- Push the branch if needed
+- Clean up the worktree once integrated
+
+The skill will guide the branch finish — do not improvise the merge strategy.
+
+- [ ] **Step 9 (after branch finish): Clean up the worktree and report**
+
+After `finishing-a-development-branch` completes successfully:
+
+1. Confirm `git worktree list` no longer shows `feat-partiql-ast-core`
+2. Confirm `dag.md` on `main` shows ast-core as `done`
+3. Report to the user:
+   - Which DAG node was completed
+   - How many node types were added (~74)
+   - Test pass count (~171 sub-tests)
+   - The next actionable nodes per the DAG (node 2 `lexer` should now be unblocked, node 3 `catalog` was already unblocked)
+
+---
+
+## Self-Review
+
+Walking the spec section by section against this plan:
+
+**Goal & inputs (spec lines 9–18):** Task 1 establishes the package and references the spec. ✓
+
+**D1. Sealed sub-interface style (lines 22–78):** Task 1 declares all six interfaces with the correct tag-method names. ✓
+
+**D2. Multi-interface satisfaction (lines 80–90):** Task 5 implements `PathExpr`, `VarRef`, `SubLink` with both `exprNode()` and `tableExpr()` tag methods. The compile-time assertions in `ast_test.go` cover them. ✓
+
+**D3. Byte-offset Loc only (lines 92–94):** Task 1 declares `Loc{Start, End int}`. No line/column. ✓
+
+**D4. Files split by category (lines 96–112):** Task 1 creates `node.go`. Tasks 2–10 create the other 7 files. ✓
+
+**D5. Single TypeRef (lines 114–127):** Task 7 implements a flat `TypeRef`. ✓
+
+**D6. FuncCall covers regular/aggregate/window (lines 129–146):** Task 4 implements `FuncCall` with `Quantifier`, `Star`, and `Over` fields. The note about which built-ins get dedicated nodes vs plain `FuncCall` is preserved (Tasks 4 dedicate `ExtractExpr`, `TrimExpr`, `SubstringExpr`; `DATE_ADD`/`DATE_DIFF` use plain `FuncCall`). ✓
+
+**D7. No Walker, no smart constructors (lines 148–150):** Plan never adds them. ✓
+
+**Type taxonomy (lines 152–306):** Each node type from the spec's tables is created in the corresponding task. Cross-check against the file map at the top of this plan and against the `allNodesForCoverageTest` listing in Task 11 — both enumerate the full set. ✓
+
+**Coverage cross-check (lines 318–355):** Task 12 Step 2 explicitly walks the spec's cross-check table against `PartiQLParser.g4`. ✓
+
+**Test plan (lines 359–394):** Task 1 creates the `TestGetLoc` skeleton. Tasks 2–10 append rows. Task 11 adds `TestNodeToString` (golden) and `TestNodeToString_AllNodesCovered` (reflection safety net). Compile-time `var _ <Iface>` assertions are added incrementally in every task. ✓
+
+**Test corpus (forward reference, lines 396–432):** Spec marks this as out of scope for `ast-core`; plan does not include corpus tests. ✓
+
+**Acceptance criteria (lines 396–408 in updated spec):** Task 12 Step 5 walks all 9 criteria. ✓
+
+**Non-goals (lines 410–420):** Plan never implements parser logic, deparse, semantic, walker, smart constructors, corpus tests, or line/column. ✓
+
+**Risks & mitigations (lines 422–429):** The spec's mitigations are implemented in the plan:
+- Risk "missing grammar rule": Task 12 Step 2 line-by-line cross-check
+- Risk "graph pattern shape may shift": Task 10 includes the docstring noting this
+- Risk "multi-interface confuses callers": Task 5 inline doc-comments + `var _` assertions
+- Risk "outfuncs.go goes stale": Task 11 reflection safety net
+- Risk "field bloat on large nodes": acknowledged in `SelectStmt` (13 fields), no action
+
+**Placeholder scan:** Searched for "TBD", "TODO", "fill in details", "appropriate error handling", etc. None present. The forward-declared placeholder block in Task 8 is explicitly labeled as such and is removed in Task 9 — that's intentional sequencing, not a placeholder failure.
+
+**Type consistency:** Method names, field names, and enum names are consistent across tasks. `QuantifierKind` is declared in `exprs.go` (Task 4) and used in `stmts.go` (Tasks 8–9) — same package, no import. The deviation from the spec's enum-location list is documented in the "Task Order Rationale" section above.
+
+No issues found.
+
+---
+
+## Plan complete and saved
+
+Plan saved to `docs/superpowers/plans/2026-04-08-partiql-ast-core.md` (this file).
+
+Next step: pick an execution mode.

--- a/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
+++ b/docs/superpowers/plans/2026-04-08-partiql-ast-core.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement the `partiql/ast` Go package — ~74 hand-written AST node types covering the full legacy ANTLR PartiQL grammar, organized via 6 sealed sub-interfaces, with a `NodeToString` debug helper and table-driven unit tests for tag dispatch and `Loc` handling.
+**Goal:** Implement the `partiql/ast` Go package — ~73 hand-written AST node types covering the full legacy ANTLR PartiQL grammar, organized via 6 sealed sub-interfaces, with a `NodeToString` debug helper and table-driven unit tests for tag dispatch and `Loc` handling.
 
 **Architecture:** Sealed sub-interface style (`Node` + `StmtNode`/`ExprNode`/`TableExpr`/`PathStep`/`TypeName`/`PatternNode`) modeled on `cosmosdb/ast/`. Each node embeds a `Loc` field with byte offsets only (no line/column). 8 source files split by category, plus `ast_test.go` and `outfuncs.go`. Pure Go, standard library only, no external dependencies.
 
@@ -22,7 +22,7 @@
 | File | Lines (approx) | Responsibility |
 |------|---------------|---------------|
 | `partiql/ast/node.go` | ~120 | Six interfaces (`Node`/`StmtNode`/`ExprNode`/`TableExpr`/`PathStep`/`TypeName`/`PatternNode`), `Loc` struct, `List` helper |
-| `partiql/ast/literals.go` | ~270 | 9 literal nodes — all `ExprNode` |
+| `partiql/ast/literals.go` | ~240 | 8 literal nodes — all `ExprNode` |
 | `partiql/ast/exprs.go` | ~750 | 28 expression nodes (operators, predicates, special-forms, paths, vars, params, subqueries, collection literals, window spec, path steps) + 6 enums |
 | `partiql/ast/tableexprs.go` | ~120 | 4 table-position nodes (`TableRef`, `AliasedSource`, `JoinExpr`, `UnpivotExpr`) + `JoinKind` enum. Also documents the multi-interface re-exports from `exprs.go`. |
 | `partiql/ast/types.go` | ~30 | Single `TypeRef` node implementing `TypeName` |
@@ -31,7 +31,7 @@
 | `partiql/ast/outfuncs.go` | ~600 | `NodeToString` — giant type switch over every node type |
 | `partiql/ast/ast_test.go` | ~600 | Compile-time interface assertions, `TestGetLoc`, `TestNodeToString` golden cases, `TestNodeToString_AllNodesCovered` reflection safety net |
 
-**Total:** ~3370 lines across 9 files for ~74 node types and ~14 enum types.
+**Total:** ~3340 lines across 9 files for ~73 node types and ~14 enum types.
 
 ## Conventions Applied To Every Type
 
@@ -283,11 +283,13 @@ EOF
 
 ---
 
-### Task 2: `literals.go` — 9 literal nodes
+### Task 2: `literals.go` — 8 literal nodes
 
 **Files:**
 - Create: `partiql/ast/literals.go`
 - Modify: `partiql/ast/ast_test.go` (append interface assertions and TestGetLoc rows)
+
+**Grammar reference:** every literal here is one alternative of the `literal` rule in `bytebase/parser/partiql/PartiQLParser.g4` lines 661–672. The doc comments use the ANTLR alternative-label form `literal#LiteralFoo` so the cross-reference is unambiguous. **There is no `TimestampLit`** — `TIMESTAMP` is a type-name keyword in the `type` rule (line 677), not a literal alternative.
 
 - [ ] **Step 1: Create `partiql/ast/literals.go`**
 
@@ -297,15 +299,17 @@ package ast
 // ---------------------------------------------------------------------------
 // Literal nodes — all implement ExprNode.
 //
-// Grammar: PartiQLParser.g4 — `literal`, `dateLit`, `timeLit`, `timestampLit`,
-// `ionLit`. See docs/migration/partiql/analysis.md "Literals" sub-sections.
+// Grammar: PartiQLParser.g4 lines 661–672 (the `literal` rule). Each type
+// here corresponds to one labeled alternative of that rule. There is no
+// TIMESTAMP literal — TIMESTAMP appears only as a type-name keyword in the
+// `type` rule (line 677), used by CAST and DDL.
 // ---------------------------------------------------------------------------
 
 // StringLit represents a single-quoted string literal: 'hello'.
 //
-// Grammar: literal LITERAL_STRING
+// Grammar: literal#LiteralString (LITERAL_STRING)
 type StringLit struct {
-	Val string // unescaped string content
+	Val string // SQL escapes already decoded ('' → ')
 	Loc Loc
 }
 
@@ -315,8 +319,10 @@ func (*StringLit) exprNode()     {}
 
 // NumberLit represents a numeric literal. Val stores the raw text to
 // preserve the original representation (integer vs decimal vs scientific).
+// Consumers needing a typed value should call strconv.ParseFloat or
+// shopspring/decimal at the call site — this AST does not normalize.
 //
-// Grammar: literal LITERAL_INTEGER | LITERAL_DECIMAL
+// Grammar: literal#LiteralInteger / literal#LiteralDecimal
 type NumberLit struct {
 	Val string // raw text as it appears in source
 	Loc Loc
@@ -328,7 +334,7 @@ func (*NumberLit) exprNode()     {}
 
 // BoolLit represents TRUE or FALSE.
 //
-// Grammar: literal TRUE | FALSE
+// Grammar: literal#LiteralTrue / literal#LiteralFalse
 type BoolLit struct {
 	Val bool
 	Loc Loc
@@ -340,7 +346,7 @@ func (*BoolLit) exprNode()     {}
 
 // NullLit represents NULL.
 //
-// Grammar: literal NULL
+// Grammar: literal#LiteralNull
 type NullLit struct {
 	Loc Loc
 }
@@ -351,7 +357,7 @@ func (*NullLit) exprNode()     {}
 
 // MissingLit represents the PartiQL-distinct MISSING value.
 //
-// Grammar: literal MISSING
+// Grammar: literal#LiteralMissing
 type MissingLit struct {
 	Loc Loc
 }
@@ -362,7 +368,7 @@ func (*MissingLit) exprNode()     {}
 
 // DateLit represents `DATE 'YYYY-MM-DD'`.
 //
-// Grammar: dateLit DATE LITERAL_STRING
+// Grammar: literal#LiteralDate (DATE LITERAL_STRING)
 type DateLit struct {
 	Val string // YYYY-MM-DD body
 	Loc Loc
@@ -374,8 +380,8 @@ func (*DateLit) exprNode()     {}
 
 // TimeLit represents `TIME [(p)] [WITH TIME ZONE] 'HH:MM:SS[.frac]'`.
 //
-// Grammar: timeLit TIME (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
-//          (WITH TIME ZONE)? LITERAL_STRING
+// Grammar: literal#LiteralTime
+//   TIME (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)? (WITH TIME ZONE)? LITERAL_STRING
 type TimeLit struct {
 	Val          string // HH:MM:SS[.frac] body
 	Precision    *int   // optional fractional-seconds precision
@@ -387,26 +393,11 @@ func (*TimeLit) nodeTag()      {}
 func (n *TimeLit) GetLoc() Loc { return n.Loc }
 func (*TimeLit) exprNode()     {}
 
-// TimestampLit represents `TIMESTAMP [(p)] [WITH TIME ZONE] '…'`.
-//
-// Grammar: timestampLit TIMESTAMP (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
-//          (WITH TIME ZONE)? LITERAL_STRING
-type TimestampLit struct {
-	Val          string
-	Precision    *int
-	WithTimeZone bool
-	Loc          Loc
-}
-
-func (*TimestampLit) nodeTag()      {}
-func (n *TimestampLit) GetLoc() Loc { return n.Loc }
-func (*TimestampLit) exprNode()     {}
-
 // IonLit represents a backtick-delimited inline Ion value: `…`.
 // Text holds the verbatim contents between the backticks (no parsing,
 // no normalization). PartiQL-unique.
 //
-// Grammar: ionLit ION_LITERAL
+// Grammar: literal#LiteralIon (ION_CLOSURE)
 type IonLit struct {
 	Text string
 	Loc  Loc
@@ -430,11 +421,10 @@ var _ ExprNode = (*NullLit)(nil)
 var _ ExprNode = (*MissingLit)(nil)
 var _ ExprNode = (*DateLit)(nil)
 var _ ExprNode = (*TimeLit)(nil)
-var _ ExprNode = (*TimestampLit)(nil)
 var _ ExprNode = (*IonLit)(nil)
 ```
 
-Then expand the `cases` slice in `TestGetLoc` to include all 9 literal types (one row each):
+Then expand the `cases` slice in `TestGetLoc` to include all 8 literal types (one row each):
 
 ```go
 cases := []struct {
@@ -449,7 +439,6 @@ cases := []struct {
     {"MissingLit", &MissingLit{Loc: Loc{Start: 10, End: 20}}},
     {"DateLit", &DateLit{Loc: Loc{Start: 10, End: 20}}},
     {"TimeLit", &TimeLit{Loc: Loc{Start: 10, End: 20}}},
-    {"TimestampLit", &TimestampLit{Loc: Loc{Start: 10, End: 20}}},
     {"IonLit", &IonLit{Loc: Loc{Start: 10, End: 20}}},
 }
 ```
@@ -461,7 +450,7 @@ cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core
 go test -run TestGetLoc ./partiql/ast/...
 ```
 
-Expected: `ok` with all 10 sub-tests passing (`List` + 9 literals).
+Expected: `ok` with all 9 sub-tests passing (`List` + 8 literals).
 
 - [ ] **Step 4: Run vet and gofmt**
 
@@ -479,12 +468,16 @@ git add partiql/ast/literals.go partiql/ast/ast_test.go
 git commit -m "$(cat <<'EOF'
 feat(partiql/ast): add literal node types
 
-9 literal nodes — StringLit, NumberLit, BoolLit, NullLit, MissingLit,
-DateLit, TimeLit, TimestampLit, IonLit. All implement ExprNode.
+8 literal nodes — StringLit, NumberLit, BoolLit, NullLit, MissingLit,
+DateLit, TimeLit, IonLit. All implement ExprNode. Each type maps to
+one labeled alternative of the PartiQLParser.g4 `literal` rule
+(lines 661-672); doc comments use the literal#LiteralXxx form for
+unambiguous cross-reference.
 
-MissingLit and IonLit are PartiQL-unique. TimeLit/TimestampLit carry
-Precision and WithTimeZone fields for the full TIME/TIMESTAMP literal
-syntax (PartiQLParser.g4 timeLit/timestampLit rules).
+MissingLit and IonLit are PartiQL-unique. TimeLit carries Precision
+and WithTimeZone for the full TIME literal syntax. There is no
+TimestampLit because TIMESTAMP is only a type-name keyword in the
+grammar (line 677), not a literal alternative.
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 EOF
@@ -2847,16 +2840,6 @@ func writeNode(sb *strings.Builder, n Node) {
 			sb.WriteString(" WithTimeZone:true")
 		}
 		sb.WriteString("}")
-	case *TimestampLit:
-		sb.WriteString("TimestampLit{Val:")
-		sb.WriteString(v.Val)
-		if v.Precision != nil {
-			fmt.Fprintf(sb, " Precision:%d", *v.Precision)
-		}
-		if v.WithTimeZone {
-			sb.WriteString(" WithTimeZone:true")
-		}
-		sb.WriteString("}")
 	case *IonLit:
 		fmt.Fprintf(sb, "IonLit{Text:%q}", v.Text)
 
@@ -3835,7 +3818,6 @@ func allNodesForCoverageTest() []struct {
 		{"MissingLit", &MissingLit{}},
 		{"DateLit", &DateLit{}},
 		{"TimeLit", &TimeLit{}},
-		{"TimestampLit", &TimestampLit{}},
 		{"IonLit", &IonLit{}},
 
 		// exprs.go

--- a/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
+++ b/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
@@ -393,6 +393,44 @@ Walks every exported type in the package, checks it implements `Node`, and calls
 - Zero external dependencies — standard library only
 - Target ~100% line coverage on `outfuncs.go`
 
+## Test corpus (project-wide forward reference)
+
+**This section describes the test strategy for the PartiQL migration as a whole, not just `ast-core`.** `ast-core` itself only tests its type system (the four test groups above) — there is nothing parser-related to validate yet because no parser exists. The project-wide corpus policy is recorded here so it is visible from this spec and need not be re-derived for every later parser DAG node.
+
+Per the test strategy decision (made during brainstorming for `ast-core` and applicable to all subsequent parser DAG nodes), parser nodes build their regression test corpora from **two authoritative sources**:
+
+### 1. Legacy ANTLR test fixtures (parity check)
+
+Every input from the legacy `bytebase/parser` and bytebase wrapper test corpora is re-run against the new omni parser to verify behavioral parity. This catches any case where the new parser accepts/rejects a statement differently from the ANTLR baseline:
+
+- `bytebase/parser/partiql/parser_test.go` — basic ANTLR parse-tree assertions and the `simple.sql` smoke fixture
+- `bytebase/backend/plugin/parser/partiql/test-data/test_split.yaml` — statement-splitting fixtures (drives `parser-foundation`'s splitter)
+- `bytebase/backend/plugin/parser/partiql/test-data/test_completion.yaml` — auto-complete fixtures (drives the `completion` DAG node)
+- `bytebase/backend/plugin/parser/partiql/split_test.go` and `completion_test.go` — additional Go-level test cases beyond the YAML fixtures
+
+### 2. AWS DynamoDB PartiQL reference examples (coverage corpus)
+
+Every PartiQL example published under `docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html` and its sub-pages, recursively. **Already crawled and assembled** during this brainstorming session by an explicit sub-agent task: 63 examples across 19 pages, covering SELECT (with key/non-key/IN/BETWEEN/OR/ORDER BY/document paths/indexes), INSERT (legacy + RFC 0011 with tuple value literals), UPDATE (multi-SET, `list_append`, REMOVE, `set_add`, RETURNING ALL OLD/NEW), DELETE (with RETURNING), and all six built-in functions (`size`, `exists`, `attribute_type`, `begins_with`, `contains`, `missing`). Bag literals (`<<…>>`), nested document paths (`a.b.c[0]`), parameterized statements (`?`), and the `IS MISSING` predicate are all represented.
+
+Output paths (currently in the main worktree, to be brought into the parser worktrees as needed):
+- `partiql/parser/testdata/aws-corpus/index.json` — manifest with id, label, source URL, sql for each example
+- `partiql/parser/testdata/aws-corpus/<id>.partiql` — one file per example (63 files)
+
+Two entries (`select-001`, `insert-002`) are syntax skeletons with backticks/brackets and are not valid PartiQL — they are flagged in the index for filtering when running through a parser.
+
+### Wiring rule for parser DAG nodes
+
+Each parser DAG node (`parser-foundation` and onwards) is responsible for adding golden tests that load both corpora as inputs. A grammar feature is considered "covered by omni" only when:
+
+- the legacy fixture inputs that exercise it parse without error and the AST matches the expected snapshot, **and**
+- the AWS reference examples that exercise it parse without error and the AST matches the expected snapshot.
+
+Missed grammar features are caught the first time an example fails — there is no need to maintain a parallel hand-written checklist.
+
+### Why this lives in the `ast-core` spec
+
+`ast-core` has nothing to validate against these corpora because no parser exists yet. But the AST shape decided here directly determines what golden snapshots are possible — so the corpus policy is recorded alongside the type design rather than buried in a parser-foundation spec written weeks later. Subsequent parser node specs reference back to this section instead of re-deriving the policy.
+
 ## Acceptance criteria
 
 The `ast-core` DAG node is **done** when:
@@ -414,7 +452,7 @@ The `ast-core` DAG node is **done** when:
 - **No semantic analysis or type checking**
 - **No `Walker` / `Visitor` interface** — Go type switches are sufficient; cosmosdb doesn't ship one and we have no consumer that needs one. Add later only if/when a real consumer requires it.
 - **No smart constructors / builder helpers** — parsers and tests construct nodes directly with struct literals. Less indirection, less to maintain.
-- **No round-trip tests against the AWS DynamoDB PartiQL corpus** — that's gated by `parser-foundation`. The corpus already exists at `partiql/parser/testdata/aws-corpus/` (63 examples) for use by parser DAG nodes.
+- **No round-trip tests against either test corpus** (legacy ANTLR fixtures or the AWS PartiQL reference examples) — that is gated by `parser-foundation`. See "Test corpus (project-wide forward reference)" above for the full strategy.
 - **Graph-pattern AST shape may be refined** when `parser-graph` (DAG node 16) is implemented. The marker interface (`PatternNode`), node names, and multi-interface relationship to `ExprNode` are stable; only field shapes inside `NodePattern`/`EdgePattern` are at risk.
 - **No `Loc` line/column** — only byte offsets. Conversion happens at the public `partiql/parse.go` boundary.
 

--- a/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
+++ b/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
@@ -177,7 +177,7 @@ Each type maps to one alternative of the `literal` rule in `PartiQLParser.g4` li
 | `SelectStmt` | `Quantifier`, `Star`, `Value`, `Pivot *PivotProjection`, `Targets []*TargetEntry`, `From TableExpr`, `Let []*LetBinding`, `Where`, `GroupBy *GroupByClause`, `Having`, `OrderBy []*OrderByItem`, `Limit`, `Offset` |
 | `SetOpStmt` | `Op SetOpKind` (UNION/INTERSECT/EXCEPT), `Quantifier QuantifierKind`, `Outer bool`, `Left StmtNode`, `Right StmtNode` |
 | `ExplainStmt` | `Inner StmtNode` |
-| `InsertStmt` | `Target TableExpr`, `AsAlias *string`, `Value ExprNode`, `OnConflict *OnConflict`, `Returning *ReturningClause` |
+| `InsertStmt` | `Target TableExpr`, `AsAlias *string`, `Value ExprNode`, `Pos ExprNode` (legacy `AT pos` clause), `OnConflict *OnConflict`, `Returning *ReturningClause` |
 | `UpdateStmt` | `Source TableExpr`, `Sets []*SetAssignment`, `Where`, `Returning` |
 | `DeleteStmt` | `Source TableExpr`, `Where`, `Returning` |
 | `UpsertStmt` | (same shape as `InsertStmt`) |
@@ -187,7 +187,7 @@ Each type maps to one alternative of the `literal` rule in `PartiQLParser.g4` li
 | `CreateIndexStmt` | `Table *VarRef`, `Paths []*PathExpr` |
 | `DropTableStmt` | `Name *VarRef` |
 | `DropIndexStmt` | `Index *VarRef`, `Table *VarRef` |
-| `ExecStmt` | `Name string`, `Args []ExprNode` |
+| `ExecStmt` | `Name ExprNode`, `Args []ExprNode` (the procedure name is itself an expression per the grammar `EXEC name=expr ...`) |
 
 ### `stmts.go` — SELECT clause helpers (regular `Node`)
 

--- a/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
+++ b/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
@@ -434,11 +434,52 @@ Missed grammar features are caught the first time an example fails — there is 
 
 `ast-core` has nothing to validate against these corpora because no parser exists yet. But the AST shape decided here directly determines what golden snapshots are possible — so the corpus policy is recorded alongside the type design rather than buried in a parser-foundation spec written weeks later. Subsequent parser node specs reference back to this section instead of re-deriving the policy.
 
+## Known follow-up items for parser DAG nodes
+
+The Task 12 grammar cross-check (against `bytebase/parser/partiql/PartiQLParser.g4`) found four
+expression-position rules and two graph-pattern shape items that are not yet
+explicitly mapped to AST nodes. None block the `ast-core` migration — they all
+land in later parser DAG nodes — but they are recorded here so the next implementer
+does not have to re-discover them.
+
+### Expression-position constructs (decision deferred to `parser-foundation`)
+
+| Grammar rule | Lines | Suggested AST representation |
+|---|---|---|
+| `sequenceConstructor` (`LIST(...)` / `SEXP(...)`) | 569–570 | Use `FuncCall{Name:"LIST"}` / `FuncCall{Name:"SEXP"}`. Consistent with D6: `FuncCall` is the catch-all for special syntactic forms with ordinary call shape. |
+| `values` (SQL `VALUES (1,2),(3,4)` row-list constructor) | 560–561 | Open question. Option A: reuse `BagLit{Items: [ListLit, ListLit, ...]}`. Option B: introduce a `ValuesExpr` with `Rows [][]ExprNode`. Option B preserves the syntactic distinction `VALUES(...)` vs `<<...>>` which may matter for round-trip fidelity. |
+| `valueRow` (parenthesized `(expr, expr, ...)` row body inside `VALUES`) | 563–564 | Pairs with `values`. If `ValuesExpr` is added, this is just an entry in `Rows`. If `BagLit`/`ListLit` reuse is chosen, this is one inner `ListLit`. |
+| `valueList` (row constructor `(a, b)` with ≥2 elements, used in row-IN tests like `(a,b) IN ((1,2),(3,4))`) | 566–567 | Open question. Option A: reuse `ListLit`. Option B: introduce a `RowExpr{Items []ExprNode}` (matches PostgreSQL's `RowExpr`). Option B is the only way to preserve the distinction `(a,b)` (row) vs `[a,b]` (PartiQL list literal). |
+
+**Decision rule:** when `parser-foundation` reaches these productions, pick the
+option that preserves the source-text distinction needed by golden tests. If a
+new node type is added (`ValuesExpr` and/or `RowExpr`), update this spec, the
+plan, and all four test groups in `ast_test.go` (interface assertion, `TestGetLoc`
+row, `TestNodeToString` golden if representative, and `allNodesForCoverageTest`).
+
+### Graph-pattern shape items (decision deferred to `parser-graph`, DAG node 16)
+
+1. **`pattern` rule grouped sub-pattern form** (lines 350–353): the grammar's
+   `( restrictor? var? graphPart+ where? ) quantifier?` form attaches a
+   `where=whereClause?` and a `quantifier=patternQuantifier?` to a grouped
+   pattern. `GraphPattern` currently has neither `Where` nor `Quantifier`
+   fields. Add them when `parser-graph` lands, or document that grouped
+   patterns are unwrapped into the parent.
+2. **`tableBaseReference#TableBaseRefMatch`** (line 405): `source=exprGraphMatchOne asIdent? atIdent? byIdent?`
+   parses a `MATCH` expression in `FROM` position. `MatchExpr` only implements
+   `ExprNode`, not `TableExpr`. To support this faithfully, `MatchExpr` should
+   become multi-interface (like `PathExpr`, `VarRef`, `SubLink`) — add
+   `func (*MatchExpr) tableExpr() {}` when `parser-graph` lands.
+
+The `patterns.go` file header already notes that GPML field shapes may be
+refined when `parser-graph` is implemented; this section spells out the two
+specific items.
+
 ## Acceptance criteria
 
 The `ast-core` DAG node is **done** when:
 
-1. All ~72 node types defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
+1. All ~73 node types (8 thematic + 1 List in `node.go`) defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
 2. Every node has a doc comment naming the grammar rule(s) from `analysis.md` that it represents
 3. Every node implements `nodeTag()` and `GetLoc() Loc`
 4. Every node implements at least one sub-interface (`StmtNode`, `ExprNode`, `TableExpr`, `PathStep`, `TypeName`, `PatternNode`) — except small clause helpers (`TargetEntry`, `CaseWhen`, `LetBinding`, `GroupByClause`, `GroupByItem`, `OrderByItem`, `SetAssignment`, `OnConflict`, `OnConflictTarget`, `ReturningClause`, `ReturningItem`, `WindowSpec`, `TuplePair`, `PivotProjection`, `PatternQuantifier`, `PatternSelector`) which are bare `Node`

--- a/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
+++ b/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
@@ -109,7 +109,7 @@ partiql/ast/
 └── ast_test.go    # unit tests for tag dispatch + Loc handling
 ```
 
-Splitting `parsenodes.go` into 7 thematic files (vs cosmosdb's single file) because PartiQL has ~3× the node count and the grammar categories are very distinct. Each file targets ≤ ~400 lines.
+Splitting `parsenodes.go` into 6 thematic files (`literals.go`, `exprs.go`, `stmts.go`, `tableexprs.go`, `types.go`, `patterns.go`) plus the foundation `node.go` and the utility `outfuncs.go` — vs cosmosdb's single `parsenodes.go`. The split is justified because PartiQL has ~3× the node count and the grammar categories are very distinct. Each file targets ≤ ~400 lines.
 
 ### D5. Single `TypeRef` for all type names
 
@@ -151,7 +151,7 @@ Out of scope. Go type switches are sufficient for the parser, the future analyze
 
 ## Type taxonomy
 
-Around **70 node types** across the 7 thematic files, plus `node.go` and `outfuncs.go`. Tagged ★ marks PartiQL-unique features.
+Around **73 node types** across the 6 thematic files, plus `node.go` and `outfuncs.go`. Tagged ★ marks PartiQL-unique features.
 
 ### `literals.go` (9 types, all `ExprNode`)
 
@@ -377,7 +377,7 @@ This costs nothing at runtime and catches the multi-interface contracts.
 
 ### 2. `TestGetLoc` — `Loc` round-trip
 
-Table-driven, one row per node type (~70 rows). Construct an instance with `Loc{Start: 10, End: 20}`, call `GetLoc()`, assert `{10, 20}`.
+Table-driven, one row per node type (~73 rows). Construct an instance with `Loc{Start: 10, End: 20}`, call `GetLoc()`, assert `{10, 20}`.
 
 ### 3. `TestNodeToString` — `outfuncs.go` smoke (golden assertions)
 
@@ -397,7 +397,7 @@ Walks every exported type in the package, checks it implements `Node`, and calls
 
 The `ast-core` DAG node is **done** when:
 
-1. All ~70 node types defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
+1. All ~73 node types defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
 2. Every node has a doc comment naming the grammar rule(s) from `analysis.md` that it represents
 3. Every node implements `nodeTag()` and `GetLoc() Loc`
 4. Every node implements at least one sub-interface (`StmtNode`, `ExprNode`, `TableExpr`, `PathStep`, `TypeName`, `PatternNode`) — except small clause helpers (`TargetEntry`, `CaseWhen`, `LetBinding`, `GroupByClause`, `GroupByItem`, `OrderByItem`, `SetAssignment`, `OnConflict`, `OnConflictTarget`, `ReturningClause`, `ReturningItem`, `WindowSpec`, `TuplePair`, `PivotProjection`, `PatternQuantifier`, `PatternSelector`) which are bare `Node`

--- a/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
+++ b/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
@@ -1,0 +1,437 @@
+# PartiQL `ast-core` Design Spec
+
+**DAG node:** `ast-core` (node 1 in `docs/migration/partiql/dag.md`)
+**Priority:** P0 (foundational — every parser DAG node depends on this)
+**Branch:** `feat/partiql/ast-core`
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/feat-partiql-ast-core`
+**Linear umbrella:** BYT-9000
+
+## Goal
+
+Create the `partiql/ast` package — the AST type taxonomy for the omni PartiQL parser. This is the **first node** in the PartiQL migration DAG. It defines the type system every subsequent parser node will populate. Per the user decision, scope is **full taxonomy up front** (DAG choice C): the AST covers the entire legacy `bytebase/parser/partiql` ANTLR grammar in one landing, including P1 features like graph patterns, LET/PIVOT/UNPIVOT, window functions, and Ion literals. Subsequent parser DAG nodes (`parser-foundation`, `parser-select`, `parser-dml`, `parser-ddl`, …, `parser-graph`) only fill in parser logic; they should not need to amend `partiql/ast/`.
+
+## Inputs
+
+- `docs/migration/partiql/analysis.md` — full grammar coverage of the legacy parser
+- `docs/migration/partiql/dag.md` — migration DAG and node ordering
+- `bytebase/parser/partiql/PartiQLParser.g4` — authoritative grammar source (line refs in this spec)
+- Reference engines: `cosmosdb/ast/` (most recent NoSQL, sealed sub-interface style), `mongo/ast/` (looser flat style)
+
+## Architecture decisions
+
+### D1. Sealed sub-interface style (rich variant)
+
+Approach 1 from brainstorming. Six sealed sub-interfaces enforce position discipline at every grammar boundary:
+
+```go
+// node.go
+
+// Loc is a half-open byte range. -1 in both fields means unknown.
+type Loc struct {
+    Start int // inclusive
+    End   int // exclusive
+}
+
+// Node is the root interface for all PartiQL parse-tree nodes.
+type Node interface {
+    nodeTag()
+    GetLoc() Loc
+}
+
+// StmtNode marks top-level statement nodes.
+type StmtNode interface {
+    Node
+    stmtNode()
+}
+
+// ExprNode marks scalar-position expression nodes.
+type ExprNode interface {
+    Node
+    exprNode()
+}
+
+// TableExpr marks FROM-position nodes.
+type TableExpr interface {
+    Node
+    tableExpr()
+}
+
+// PathStep marks a single step in a PartiQL path expression.
+type PathStep interface {
+    Node
+    pathStep()
+}
+
+// TypeName marks PartiQL type references (used by CAST and DDL).
+type TypeName interface {
+    Node
+    typeName()
+}
+
+// PatternNode marks GPML graph-match pattern nodes.
+type PatternNode interface {
+    Node
+    patternNode()
+}
+```
+
+**Rationale:** PartiQL's grammar has more distinct categories than cosmosdb's. Path navigation (PartiQL-unique), graph patterns (GPML), and type names are first-class enough to deserve their own marker interfaces. Compile-time discrimination prevents an entire class of parser bugs (e.g., handing a `MatchExpr` to a slot that expects `BinaryExpr`).
+
+### D2. Multi-interface satisfaction for unified grammar productions
+
+Three node types satisfy more than one interface, mirroring grammar productions that legitimately appear in multiple positions:
+
+| Node | Interfaces | Why |
+|------|-----------|-----|
+| `PathExpr` | `ExprNode` + `TableExpr` | `FROM a.b[0]` is a legal table source; same path also valid in scalar position |
+| `VarRef` | `ExprNode` + `TableExpr` | `FROM tbl` resolves through the same identifier rule as scalar `tbl` |
+| `SubLink` | `ExprNode` + `TableExpr` | `(SELECT …)` is valid in both positions |
+
+These are documented inline in `tableexprs.go` with comment links back to `exprs.go`.
+
+### D3. Byte-offset `Loc` only
+
+Each node embeds a `Loc` field. `Loc` carries `Start` and `End` byte offsets only — no line/column. Line/column conversion happens at the public `partiql/parse.go` boundary (mongo-style), not in the AST. Synthetic nodes (created post-parse) use `Loc{-1, -1}`.
+
+### D4. Files split by category
+
+```
+partiql/ast/
+├── node.go        # interfaces, Loc, List
+├── literals.go    # all literal nodes (string, number, bool, null, missing, date/time/timestamp, ion)
+├── exprs.go       # expression nodes (operators, predicates, function calls, CASE, CAST,
+│                  #   subqueries, paths, variables, collection literals)
+├── stmts.go       # statement nodes + DML/SELECT clause helpers
+├── tableexprs.go  # FROM-position nodes (table refs, joins, unpivot)
+├── types.go       # type name nodes
+├── patterns.go    # graph pattern nodes (GPML / MATCH clauses)
+├── outfuncs.go    # NodeToString(Node) — deterministic debug dump
+└── ast_test.go    # unit tests for tag dispatch + Loc handling
+```
+
+Splitting `parsenodes.go` into 7 thematic files (vs cosmosdb's single file) because PartiQL has ~3× the node count and the grammar categories are very distinct. Each file targets ≤ ~400 lines.
+
+### D5. Single `TypeRef` for all type names
+
+Type names use one flat node:
+
+```go
+type TypeRef struct {
+    Name         string  // canonical uppercase: "INT", "DECIMAL", "TIME", "BAG", ...
+    Args         []int   // optional precision/scale/length: DECIMAL(10,2) -> [10,2]
+    WithTimeZone bool    // for TIME / TIMESTAMP
+    Loc          Loc
+}
+```
+
+Discrimination by `Name` rather than a Go enum. This matches the PartiQL grammar's treatment (a name token with optional modifiers) and avoids a 25-arm enum that would mostly be one-to-one with the name string.
+
+### D6. `FuncCall` covers regular calls, aggregates, and windowed calls
+
+Window functions, aggregates, and ordinary function calls use one node:
+
+```go
+type FuncCall struct {
+    Name       string
+    Args       []ExprNode
+    Quantifier QuantifierKind  // NONE/DISTINCT/ALL — for aggregates
+    Star       bool            // true for COUNT(*)
+    Over       *WindowSpec     // non-nil for window calls (LAG/LEAD)
+    Loc        Loc
+}
+```
+
+This avoids three separate node types for what's structurally the same shape. Whether a particular `FuncCall` is "really" an aggregate or a window function is determined by parser context, not by node identity.
+
+`EXTRACT`, `TRIM`, `SUBSTRING`, `CAST`, `CASE`, `COALESCE`, and `NULLIF` get their own dedicated nodes because the PartiQL grammar gives them special syntactic forms (keywords inside parens or non-comma argument syntax). `DATE_ADD` and `DATE_DIFF` use plain `FuncCall` because their syntax is just a comma-separated arg list.
+
+### D7. No `Walker` / `Visitor`, no smart constructors
+
+Out of scope. Go type switches are sufficient for the parser, the future analyzer, and the future completion engine. Adding a walker now would be speculative. Smart constructors (`NewBinaryExpr(...)`) add maintenance burden without benefit when struct literals are clear.
+
+## Type taxonomy
+
+Around **70 node types** across the 7 thematic files, plus `node.go` and `outfuncs.go`. Tagged ★ marks PartiQL-unique features.
+
+### `literals.go` (9 types, all `ExprNode`)
+
+| Node | Fields | Grammar |
+|------|--------|---------|
+| `StringLit` | `Val string` | `'…'` and `"…"` strings |
+| `NumberLit` | `Val string` (raw text preserved) | integer / decimal / scientific |
+| `BoolLit` | `Val bool` | `TRUE` / `FALSE` |
+| `NullLit` | — | `NULL` |
+| `MissingLit` ★ | — | `MISSING` |
+| `DateLit` | `Val string` | `DATE 'YYYY-MM-DD'` |
+| `TimeLit` | `Val string`, `Precision *int`, `WithTimeZone bool` | `TIME [(p)] [WITH TIME ZONE] '…'` |
+| `TimestampLit` | `Val string`, `Precision *int`, `WithTimeZone bool` | `TIMESTAMP [(p)] [WITH TIME ZONE] '…'` |
+| `IonLit` ★ | `Text string` (verbatim backtick contents) | `` ` … ` `` |
+
+### `stmts.go` — top-level statements (`StmtNode`)
+
+| Node | Key fields |
+|------|-----------|
+| `SelectStmt` | `Quantifier`, `Star`, `Value`, `Pivot *PivotProjection`, `Targets []*TargetEntry`, `From TableExpr`, `Let []*LetBinding`, `Where`, `GroupBy *GroupByClause`, `Having`, `OrderBy []*OrderByItem`, `Limit`, `Offset` |
+| `SetOpStmt` | `Op SetOpKind` (UNION/INTERSECT/EXCEPT), `Quantifier QuantifierKind`, `Outer bool`, `Left StmtNode`, `Right StmtNode` |
+| `ExplainStmt` | `Inner StmtNode` |
+| `InsertStmt` | `Target TableExpr`, `AsAlias *string`, `Value ExprNode`, `OnConflict *OnConflict`, `Returning *ReturningClause` |
+| `UpdateStmt` | `Source TableExpr`, `Sets []*SetAssignment`, `Where`, `Returning` |
+| `DeleteStmt` | `Source TableExpr`, `Where`, `Returning` |
+| `UpsertStmt` | (same shape as `InsertStmt`) |
+| `ReplaceStmt` | (same shape as `InsertStmt`) |
+| `RemoveStmt` ★ | `Path *PathExpr` |
+| `CreateTableStmt` | `Name *VarRef` |
+| `CreateIndexStmt` | `Table *VarRef`, `Paths []*PathExpr` |
+| `DropTableStmt` | `Name *VarRef` |
+| `DropIndexStmt` | `Index *VarRef`, `Table *VarRef` |
+| `ExecStmt` | `Name string`, `Args []ExprNode` |
+
+### `stmts.go` — SELECT clause helpers (regular `Node`)
+
+| Node | Fields |
+|------|--------|
+| `TargetEntry` | `Expr`, `Alias *string` |
+| `PivotProjection` ★ | `Value`, `At` |
+| `LetBinding` ★ | `Expr`, `Alias string` |
+| `GroupByClause` | `Partial bool`, `Items []*GroupByItem`, `GroupAs *string` |
+| `GroupByItem` | `Expr`, `Alias *string` |
+| `OrderByItem` | `Expr`, `Desc bool`, `NullsFirst bool`, `NullsExplicit bool` |
+
+### `stmts.go` — DML helpers (regular `Node` / enums)
+
+| Node | Fields |
+|------|--------|
+| `SetAssignment` | `Target *PathExpr`, `Value ExprNode` |
+| `OnConflict` | `Target *OnConflictTarget`, `Action OnConflictAction`, `Where ExprNode` |
+| `OnConflictTarget` | `Cols []*VarRef` _or_ `ConstraintName string` |
+| `OnConflictAction` (enum) | `DoNothing`, `DoReplaceExcluded`, `DoUpdateExcluded` (matches the legacy ANTLR stub scope; spec gap noted) |
+| `ReturningClause` | `Items []*ReturningItem` |
+| `ReturningItem` | `Status` (`MODIFIED`/`ALL`), `Mapping` (`OLD`/`NEW`), `Star bool`, `Expr ExprNode` |
+
+**Enums declared in `stmts.go`:** `SetOpKind`, `QuantifierKind`, `OnConflictAction`, `ReturningStatus`, `ReturningMapping`.
+
+### `exprs.go` — operators & predicates (`ExprNode`)
+
+| Node | Fields | Covers |
+|------|--------|--------|
+| `BinaryExpr` | `Op BinOp`, `Left`, `Right` | `OR`, `AND`, `\|\|`, `+`, `-`, `*`, `/`, `%`, `=`, `<>`, `<`, `>`, `<=`, `>=` |
+| `UnaryExpr` | `Op UnOp`, `Operand` | `NOT`, unary `+`/`-` |
+| `InExpr` | `Expr`, `List []ExprNode` _or_ `Subquery StmtNode`, `Not bool` | `expr [NOT] IN …` |
+| `BetweenExpr` | `Expr`, `Low`, `High`, `Not bool` | `expr [NOT] BETWEEN low AND high` |
+| `LikeExpr` | `Expr`, `Pattern`, `Escape ExprNode`, `Not bool` | `expr [NOT] LIKE pat [ESCAPE c]` |
+| `IsExpr` | `Expr`, `Type IsType` (`NULL`/`MISSING`/`TRUE`/`FALSE`), `Not bool` | `IS [NOT] (NULL\|MISSING\|TRUE\|FALSE)` |
+
+### `exprs.go` — special-form expressions (`ExprNode`)
+
+| Node | Fields | Notes |
+|------|--------|-------|
+| `FuncCall` | `Name string`, `Args []ExprNode`, `Quantifier QuantifierKind`, `Star bool`, `Over *WindowSpec` | Generic function call; covers aggregates and window functions |
+| `CaseExpr` | `Operand ExprNode` (nil for searched), `Whens []*CaseWhen`, `Else ExprNode` | Both `CASE WHEN` and `CASE expr WHEN` |
+| `CaseWhen` | `When`, `Then` | Regular `Node` helper |
+| `CastExpr` | `Kind CastKind` (`CAST`/`CAN_CAST`/`CAN_LOSSLESS_CAST`), `Expr`, `AsType TypeName` | |
+| `ExtractExpr` | `Field string`, `From ExprNode` | `EXTRACT(field FROM expr)` |
+| `TrimExpr` | `Spec` (`LEADING`/`TRAILING`/`BOTH`/none), `Sub ExprNode`, `From ExprNode` | `TRIM([spec] [sub] FROM target)` |
+| `SubstringExpr` | `Expr`, `From`, `For ExprNode` | `SUBSTRING(expr FROM start [FOR len])` and the comma form |
+| `CoalesceExpr` | `Args []ExprNode` | |
+| `NullIfExpr` | `Left`, `Right` | |
+
+### `exprs.go` — paths, variables, parameters, subqueries
+
+| Node | Interfaces | Fields |
+|------|-----------|--------|
+| `PathExpr` ★ | `ExprNode` + `TableExpr` | `Root ExprNode`, `Steps []PathStep` |
+| `VarRef` | `ExprNode` + `TableExpr` | `Name string`, `AtPrefixed bool`, `CaseSensitive bool` |
+| `ParamRef` | `ExprNode` | — (`?`) |
+| `SubLink` | `ExprNode` + `TableExpr` | `Stmt StmtNode` |
+
+### `exprs.go` — collection literals (`ExprNode`)
+
+| Node | Fields | Grammar |
+|------|--------|---------|
+| `ListLit` | `Items []ExprNode` | `[…]` |
+| `BagLit` ★ | `Items []ExprNode` | `<<…>>` |
+| `TupleLit` ★ | `Pairs []*TuplePair` | `{k:v, …}` |
+| `TuplePair` | `Key ExprNode`, `Value ExprNode` | Regular `Node` helper |
+
+### `exprs.go` — window spec (regular `Node`)
+
+| Node | Fields |
+|------|--------|
+| `WindowSpec` | `PartitionBy []ExprNode`, `OrderBy []*OrderByItem` |
+
+### `exprs.go` — path steps (`PathStep`)
+
+| Node | Fields | Grammar |
+|------|--------|---------|
+| `DotStep` | `Field string`, `CaseSensitive bool` | `.field` / `."Field"` |
+| `AllFieldsStep` | — | `.*` |
+| `IndexStep` | `Index ExprNode` | `[expr]` |
+| `WildcardStep` | — | `[*]` |
+
+**Enums declared in `exprs.go`:** `BinOp`, `UnOp`, `IsType`, `CastKind`, `TrimSpec`.
+
+### `tableexprs.go` (`TableExpr`)
+
+| Node | Fields |
+|------|--------|
+| `TableRef` | `Name string`, `Schema string`, `CaseSensitive bool` |
+| `AliasedSource` ★ | `Source TableExpr`, `As *string`, `At *string`, `By *string` |
+| `JoinExpr` | `Kind JoinKind`, `Left TableExpr`, `Right TableExpr`, `On ExprNode` |
+| `UnpivotExpr` ★ | `Source ExprNode`, `As *string`, `At *string`, `By *string` |
+
+`PathExpr`, `VarRef`, and `SubLink` from `exprs.go` also implement `TableExpr`. Documented inline in `tableexprs.go`.
+
+**Enum declared in `tableexprs.go`:** `JoinKind` (`CROSS`, `INNER`, `LEFT`, `RIGHT`, `FULL`, `OUTER`).
+
+### `types.go` (`TypeName`)
+
+| Node | Fields | Covers |
+|------|--------|--------|
+| `TypeRef` | `Name string`, `Args []int`, `WithTimeZone bool` | All PartiQL types: `INT`, `INTEGER`, `BIGINT`, `SMALLINT`, `BOOL`, `BOOLEAN`, `NULL`, `MISSING`, `STRING`, `SYMBOL`, `BLOB`, `CLOB`, `ANY`, `DATE`, `TIME`, `TIMESTAMP`, `REAL`, `DOUBLE PRECISION`, `DECIMAL(p,s)`, `NUMERIC(p,s)`, `FLOAT(n)`, `VARCHAR(n)`, `CHAR(n)`, `CHARACTER(n)`, `STRUCT`, `TUPLE`, `LIST`, `BAG`, `SEXP` |
+
+### `patterns.go` ★ (graph patterns)
+
+Graph Pattern Matching scaffolding. The marker interface (`PatternNode`), the node names, and the multi-interface relationship to `ExprNode` are stable in this spec. Precise field shapes inside `NodePattern`/`EdgePattern` may be refined when `parser-graph` (DAG node 16) is implemented by reading `PartiQLParser.g4` lines 314–382.
+
+| Node | Implements | Notes |
+|------|-----------|-------|
+| `MatchExpr` | `ExprNode` | Top-level `MATCH (graph_expr, pattern, …)` |
+| `GraphPattern` | `PatternNode` | Container for one pattern: optional selector + restrictor + variable + parts |
+| `NodePattern` | `PatternNode` | `(var:Label WHERE …)` |
+| `EdgePattern` | `PatternNode` | `-[var:Label]->`, `<-[]-`, `~[]~`, etc. |
+| `PatternQuantifier` | regular `Node` | `+`, `*`, `{m,n}` |
+| `PatternSelector` | regular `Node` | `ANY`, `ALL SHORTEST`, `SHORTEST k` |
+
+**Enums declared in `patterns.go`:** `EdgeDirection` (LEFT, RIGHT, UNDIRECTED, ...), `PatternRestrictor` (TRAIL, ACYCLIC, SIMPLE), `SelectorKind` (ANY, ALL_SHORTEST, SHORTEST_K).
+
+### `outfuncs.go`
+
+`NodeToString(Node) string` — deterministic textual dump of any AST node, written as a giant type switch over every node type. Pattern follows `cosmosdb/ast/outfuncs.go`. Invariants:
+
+- Stable field ordering (matches struct declaration order)
+- Parens around nested expressions for unambiguous reading
+- `Loc` is **not** dumped (positions are tested separately by `TestGetLoc`)
+- Returns non-empty for every node, including zero values
+
+Used by `ast_test.go` for snapshot-style assertions, by future parser golden tests, and for REPL debugging.
+
+## Coverage cross-check
+
+Every grammar area in `analysis.md`'s "Full Coverage Target" maps to ≥1 node type:
+
+| analysis.md grammar area | Node type(s) |
+|--------------------------|--------------|
+| DDL (CREATE/DROP TABLE/INDEX) | `CreateTableStmt`, `CreateIndexStmt`, `DropTableStmt`, `DropIndexStmt` |
+| DML — INSERT (legacy + RFC 0011) | `InsertStmt` |
+| DML — UPDATE (incl. `FROM … SET …`) | `UpdateStmt` |
+| DML — DELETE (incl. `FROM … DELETE …`) | `DeleteStmt` |
+| DML — UPSERT / REPLACE / REMOVE | `UpsertStmt`, `ReplaceStmt`, `RemoveStmt` |
+| ON CONFLICT (incl. legacy `EXCLUDED` stub) | `OnConflict`, `OnConflictTarget`, `OnConflictAction` enum |
+| RETURNING | `ReturningClause`, `ReturningItem` |
+| SELECT variants (`*`, items, `VALUE`, `PIVOT`) | `SelectStmt` (Star/Value/Pivot/Targets fields) |
+| LET clause | `LetBinding` (`SelectStmt.Let` field) |
+| FROM with `AS`/`AT`/`BY` | `AliasedSource` |
+| UNPIVOT | `UnpivotExpr` |
+| WHERE / GROUP BY / GROUP PARTIAL / GROUP AS / HAVING | `SelectStmt.Where`, `GroupByClause`, `SelectStmt.Having` |
+| ORDER BY (ASC/DESC, NULLS FIRST/LAST) | `OrderByItem` |
+| LIMIT / OFFSET | `SelectStmt.Limit`, `SelectStmt.Offset` |
+| Joins (CROSS/INNER/LEFT/RIGHT/FULL/OUTER) | `JoinExpr`, `JoinKind` enum |
+| Set ops (UNION/INTERSECT/EXCEPT, OUTER, DISTINCT/ALL) | `SetOpStmt` |
+| Window functions (LAG/LEAD with OVER) | `FuncCall.Over`, `WindowSpec` |
+| Aggregates (COUNT/SUM/AVG/MIN/MAX, DISTINCT/ALL, COUNT(*)) | `FuncCall.Quantifier`, `FuncCall.Star` |
+| Built-ins (CAST/EXTRACT/TRIM/SUBSTRING/COALESCE/NULLIF/CASE) | `CastExpr`, `ExtractExpr`, `TrimExpr`, `SubstringExpr`, `CoalesceExpr`, `NullIfExpr`, `CaseExpr` |
+| `CAST`/`CAN_CAST`/`CAN_LOSSLESS_CAST` | `CastExpr.Kind` |
+| Predicates (IN/BETWEEN/LIKE/IS NULL/MISSING/TRUE/FALSE) | `InExpr`, `BetweenExpr`, `LikeExpr`, `IsExpr` |
+| Operator hierarchy (OR/AND/NOT/+/-/*/etc.) | `BinaryExpr`, `UnaryExpr` |
+| Path navigation (`.field`, `[expr]`, `[*]`, `.*`, chained) | `PathExpr`, `DotStep`, `AllFieldsStep`, `IndexStep`, `WildcardStep` |
+| Variables (`@id`, `id`, `?`) | `VarRef`, `ParamRef` |
+| Collection literals (list/bag/tuple) | `ListLit`, `BagLit`, `TupleLit`, `TuplePair` |
+| Subqueries | `SubLink` |
+| Type system (full PartiQL type list) | `TypeRef` |
+| Date/time literals (DATE/TIME/TIMESTAMP) | `DateLit`, `TimeLit`, `TimestampLit` |
+| Ion backtick literals | `IonLit` |
+| Graph pattern matching (MATCH, nodes/edges/quantifiers/selectors/restrictors) | `MatchExpr`, `GraphPattern`, `NodePattern`, `EdgePattern`, `PatternQuantifier`, `PatternSelector` |
+| EXEC | `ExecStmt` |
+| EXPLAIN | `ExplainStmt` |
+
+During implementation, do a second-pass verification by reading `bytebase/parser/partiql/PartiQLParser.g4` line by line and checking each production maps to a node type. Any missed productions update this spec and the file.
+
+## Test plan
+
+All tests live in a single `partiql/ast/ast_test.go` and use only the standard `testing` package.
+
+### 1. Compile-time interface assertions
+
+For every node type, declare `var _ <Interface> = (*Type)(nil)` so the file fails to compile if any node's interface set drifts:
+
+```go
+var _ ExprNode  = (*BinaryExpr)(nil)
+var _ ExprNode  = (*PathExpr)(nil)
+var _ TableExpr = (*PathExpr)(nil)  // dual-purpose
+var _ ExprNode  = (*VarRef)(nil)
+var _ TableExpr = (*VarRef)(nil)
+// ... one block per category
+```
+
+This costs nothing at runtime and catches the multi-interface contracts.
+
+### 2. `TestGetLoc` — `Loc` round-trip
+
+Table-driven, one row per node type (~70 rows). Construct an instance with `Loc{Start: 10, End: 20}`, call `GetLoc()`, assert `{10, 20}`.
+
+### 3. `TestNodeToString` — `outfuncs.go` smoke (golden assertions)
+
+~30 representative cases, each pairing a hand-built node with an expected string literal. Covers one node per category, all multi-interface nodes, and at least one deeply nested case (e.g., a `SelectStmt` whose `From` is a `PathExpr` with multiple steps).
+
+### 4. `TestNodeToString_AllNodesCovered` — reflection safety net
+
+Walks every exported type in the package, checks it implements `Node`, and calls `NodeToString` on a zero value. Asserts no panic and a non-empty result. Catches the case where a new node type is added but never wired into `outfuncs.go`.
+
+### Test scope
+
+- Run with `go test ./partiql/ast/...` (no global runs, per the implementing skill's scoping rule)
+- Zero external dependencies — standard library only
+- Target ~100% line coverage on `outfuncs.go`
+
+## Acceptance criteria
+
+The `ast-core` DAG node is **done** when:
+
+1. All ~70 node types defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
+2. Every node has a doc comment naming the grammar rule(s) from `analysis.md` that it represents
+3. Every node implements `nodeTag()` and `GetLoc() Loc`
+4. Every node implements at least one sub-interface (`StmtNode`, `ExprNode`, `TableExpr`, `PathStep`, `TypeName`, `PatternNode`) — except small clause helpers (`TargetEntry`, `CaseWhen`, `LetBinding`, `GroupByClause`, `GroupByItem`, `OrderByItem`, `SetAssignment`, `OnConflict`, `OnConflictTarget`, `ReturningClause`, `ReturningItem`, `WindowSpec`, `TuplePair`, `PivotProjection`, `PatternQuantifier`, `PatternSelector`) which are bare `Node`
+5. `outfuncs.NodeToString` covers every type — verified by `TestNodeToString_AllNodesCovered`
+6. `go test ./partiql/ast/...` passes
+7. `go vet ./partiql/ast/...` clean
+8. `gofmt` clean
+9. Coverage cross-check: every grammar area in `analysis.md`'s "Full Coverage Target" maps to ≥1 node type, with the cross-check section above re-verified during implementation against `PartiQLParser.g4`
+
+## Non-goals
+
+- **No parser logic** — that's `parser-foundation` through `parser-graph` (DAG nodes 4–7, 12–18). `ast-core` only defines types; no recursive-descent code, no tokens, no error recovery
+- **No deparse / SQL printing** — separate (out-of-scope) package per `dag.md` "Out of Scope"
+- **No semantic analysis or type checking**
+- **No `Walker` / `Visitor` interface** — Go type switches are sufficient; cosmosdb doesn't ship one and we have no consumer that needs one. Add later only if/when a real consumer requires it.
+- **No smart constructors / builder helpers** — parsers and tests construct nodes directly with struct literals. Less indirection, less to maintain.
+- **No round-trip tests against the AWS DynamoDB PartiQL corpus** — that's gated by `parser-foundation`. The corpus already exists at `partiql/parser/testdata/aws-corpus/` (63 examples) for use by parser DAG nodes.
+- **Graph-pattern AST shape may be refined** when `parser-graph` (DAG node 16) is implemented. The marker interface (`PatternNode`), node names, and multi-interface relationship to `ExprNode` are stable; only field shapes inside `NodePattern`/`EdgePattern` are at risk.
+- **No `Loc` line/column** — only byte offsets. Conversion happens at the public `partiql/parse.go` boundary.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Missing a grammar rule from `analysis.md` | Acceptance criterion 9 forces a manual line-by-line re-read of `PartiQLParser.g4` during implementation; the cross-check table in this spec is the working list |
+| Graph pattern AST shape needs adjustment when `parser-graph` lands | Marker interface is stable; node names are stable; only the field shapes inside `NodePattern`/`EdgePattern` are at risk. Documented as a known refinement point. |
+| Multi-interface nodes (`PathExpr`, `VarRef`, `SubLink`) confuse parser callers | Compile-time `var _` assertions in `ast_test.go` make the dual-interface explicit; doc comments on each multi-interface node spell out the grammar reason |
+| `outfuncs.go` becomes stale when node types are added later | `TestNodeToString_AllNodesCovered` reflection test catches missing arms |
+| Field bloat on large nodes (`SelectStmt` has 13 fields) | Acceptable — mirrors PostgreSQL `SelectStmt` and cosmosdb `SelectStmt`. Subdividing would create artificial structure. |
+
+## References
+
+- `docs/migration/partiql/analysis.md` — full legacy grammar coverage
+- `docs/migration/partiql/dag.md` — migration node ordering
+- `bytebase/parser/partiql/PartiQLParser.g4` — authoritative grammar source
+- `cosmosdb/ast/node.go`, `cosmosdb/ast/parsenodes.go` — sealed-interface reference
+- `mongo/ast/nodes.go` — looser flat reference (not adopted, but compared)

--- a/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
+++ b/docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md
@@ -151,21 +151,24 @@ Out of scope. Go type switches are sufficient for the parser, the future analyze
 
 ## Type taxonomy
 
-Around **73 node types** across the 6 thematic files, plus `node.go` and `outfuncs.go`. Tagged ★ marks PartiQL-unique features.
+Around **72 node types** across the 6 thematic files, plus `node.go` and `outfuncs.go`. Tagged ★ marks PartiQL-unique features.
 
-### `literals.go` (9 types, all `ExprNode`)
+### `literals.go` (8 types, all `ExprNode`)
 
-| Node | Fields | Grammar |
-|------|--------|---------|
-| `StringLit` | `Val string` | `'…'` and `"…"` strings |
-| `NumberLit` | `Val string` (raw text preserved) | integer / decimal / scientific |
-| `BoolLit` | `Val bool` | `TRUE` / `FALSE` |
-| `NullLit` | — | `NULL` |
-| `MissingLit` ★ | — | `MISSING` |
-| `DateLit` | `Val string` | `DATE 'YYYY-MM-DD'` |
-| `TimeLit` | `Val string`, `Precision *int`, `WithTimeZone bool` | `TIME [(p)] [WITH TIME ZONE] '…'` |
-| `TimestampLit` | `Val string`, `Precision *int`, `WithTimeZone bool` | `TIMESTAMP [(p)] [WITH TIME ZONE] '…'` |
-| `IonLit` ★ | `Text string` (verbatim backtick contents) | `` ` … ` `` |
+Each type maps to one alternative of the `literal` rule in `PartiQLParser.g4` lines 661–672.
+
+| Node | Fields | Grammar (`literal#…`) |
+|------|--------|----------------------|
+| `StringLit` | `Val string` | `LiteralString` (`LITERAL_STRING`) |
+| `NumberLit` | `Val string` (raw text preserved) | `LiteralInteger` / `LiteralDecimal` |
+| `BoolLit` | `Val bool` | `LiteralTrue` / `LiteralFalse` |
+| `NullLit` | — | `LiteralNull` |
+| `MissingLit` ★ | — | `LiteralMissing` |
+| `DateLit` | `Val string` | `LiteralDate` (`DATE LITERAL_STRING`) |
+| `TimeLit` | `Val string`, `Precision *int`, `WithTimeZone bool` | `LiteralTime` (`TIME [(p)] [WITH TIME ZONE] LITERAL_STRING`) |
+| `IonLit` ★ | `Text string` (verbatim backtick contents) | `LiteralIon` (`ION_CLOSURE`) |
+
+**Note:** PartiQL does **not** have a `TIMESTAMP '…'` literal in the grammar (the `literal` rule has no `TIMESTAMP` alternative). `TIMESTAMP` only appears as a type-name keyword in the `type` rule (line 677), where it is used by `CAST` and DDL. An earlier draft of this spec listed a `TimestampLit` node type by mistake; it has been removed because no parser production would ever produce it.
 
 ### `stmts.go` — top-level statements (`StmtNode`)
 
@@ -348,7 +351,7 @@ Every grammar area in `analysis.md`'s "Full Coverage Target" maps to ≥1 node t
 | Collection literals (list/bag/tuple) | `ListLit`, `BagLit`, `TupleLit`, `TuplePair` |
 | Subqueries | `SubLink` |
 | Type system (full PartiQL type list) | `TypeRef` |
-| Date/time literals (DATE/TIME/TIMESTAMP) | `DateLit`, `TimeLit`, `TimestampLit` |
+| Date/time literals (DATE/TIME) | `DateLit`, `TimeLit` (TIMESTAMP is a type-name only — see literals.go note) |
 | Ion backtick literals | `IonLit` |
 | Graph pattern matching (MATCH, nodes/edges/quantifiers/selectors/restrictors) | `MatchExpr`, `GraphPattern`, `NodePattern`, `EdgePattern`, `PatternQuantifier`, `PatternSelector` |
 | EXEC | `ExecStmt` |
@@ -377,7 +380,7 @@ This costs nothing at runtime and catches the multi-interface contracts.
 
 ### 2. `TestGetLoc` — `Loc` round-trip
 
-Table-driven, one row per node type (~73 rows). Construct an instance with `Loc{Start: 10, End: 20}`, call `GetLoc()`, assert `{10, 20}`.
+Table-driven, one row per node type (~72 rows). Construct an instance with `Loc{Start: 10, End: 20}`, call `GetLoc()`, assert `{10, 20}`.
 
 ### 3. `TestNodeToString` — `outfuncs.go` smoke (golden assertions)
 
@@ -435,7 +438,7 @@ Missed grammar features are caught the first time an example fails — there is 
 
 The `ast-core` DAG node is **done** when:
 
-1. All ~73 node types defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
+1. All ~72 node types defined across `node.go`, `literals.go`, `stmts.go`, `exprs.go`, `tableexprs.go`, `types.go`, `patterns.go`, and `outfuncs.go`
 2. Every node has a doc comment naming the grammar rule(s) from `analysis.md` that it represents
 3. Every node implements `nodeTag()` and `GetLoc() Loc`
 4. Every node implements at least one sub-interface (`StmtNode`, `ExprNode`, `TableExpr`, `PathStep`, `TypeName`, `PatternNode`) — except small clause helpers (`TargetEntry`, `CaseWhen`, `LetBinding`, `GroupByClause`, `GroupByItem`, `OrderByItem`, `SetAssignment`, `OnConflict`, `OnConflictTarget`, `ReturningClause`, `ReturningItem`, `WindowSpec`, `TuplePair`, `PivotProjection`, `PatternQuantifier`, `PatternSelector`) which are bare `Node`

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -201,5 +202,336 @@ func TestGetLoc(t *testing.T) {
 				t.Errorf("GetLoc() = %+v, want {10, 20}", got)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNodeToString — golden assertions on outfuncs.go output.
+//
+// One representative case per node category, plus the multi-interface nodes
+// and at least one deeply nested case.
+// ---------------------------------------------------------------------------
+
+func TestNodeToString(t *testing.T) {
+	cases := []struct {
+		name string
+		node Node
+		want string
+	}{
+		{
+			name: "string_literal",
+			node: &StringLit{Val: "hello"},
+			want: `StringLit{Val:"hello"}`,
+		},
+		{
+			name: "number_literal",
+			node: &NumberLit{Val: "42"},
+			want: `NumberLit{Val:42}`,
+		},
+		{
+			name: "binary_expr_add",
+			node: &BinaryExpr{
+				Op:    BinOpAdd,
+				Left:  &VarRef{Name: "a"},
+				Right: &NumberLit{Val: "1"},
+			},
+			want: `BinaryExpr{Op:+ Left:VarRef{Name:a} Right:NumberLit{Val:1}}`,
+		},
+		{
+			name: "in_expr_with_list",
+			node: &InExpr{
+				Expr: &VarRef{Name: "x"},
+				List: []ExprNode{&NumberLit{Val: "1"}, &NumberLit{Val: "2"}},
+				Not:  false,
+			},
+			want: `InExpr{Expr:VarRef{Name:x} List:[NumberLit{Val:1} NumberLit{Val:2}] Not:false}`,
+		},
+		{
+			name: "is_missing_predicate",
+			node: &IsExpr{
+				Expr: &VarRef{Name: "y"},
+				Type: IsTypeMissing,
+				Not:  false,
+			},
+			want: `IsExpr{Expr:VarRef{Name:y} Type:MISSING Not:false}`,
+		},
+		{
+			name: "func_call_count_distinct",
+			node: &FuncCall{
+				Name:       "COUNT",
+				Quantifier: QuantifierDistinct,
+				Args:       []ExprNode{&VarRef{Name: "id"}},
+			},
+			want: `FuncCall{Name:COUNT Quantifier:DISTINCT Args:[VarRef{Name:id}]}`,
+		},
+		{
+			name: "func_call_count_star",
+			node: &FuncCall{Name: "COUNT", Star: true},
+			want: `FuncCall{Name:COUNT Star:true Args:[]}`,
+		},
+		{
+			name: "case_expr_searched",
+			node: &CaseExpr{
+				Whens: []*CaseWhen{
+					{When: &BoolLit{Val: true}, Then: &NumberLit{Val: "1"}},
+				},
+				Else: &NumberLit{Val: "0"},
+			},
+			want: `CaseExpr{Whens:[CaseWhen{When:BoolLit{Val:true} Then:NumberLit{Val:1}}] Else:NumberLit{Val:0}}`,
+		},
+		{
+			name: "cast_expr",
+			node: &CastExpr{
+				Kind:   CastKindCast,
+				Expr:   &VarRef{Name: "x"},
+				AsType: &TypeRef{Name: "INTEGER"},
+			},
+			want: `CastExpr{Kind:CAST Expr:VarRef{Name:x} AsType:TypeRef{Name:INTEGER}}`,
+		},
+		{
+			name: "path_expr_with_steps",
+			node: &PathExpr{
+				Root:  &VarRef{Name: "Music"},
+				Steps: []PathStep{&DotStep{Field: "albums"}, &WildcardStep{}},
+			},
+			want: `PathExpr{Root:VarRef{Name:Music} Steps:[DotStep{Field:albums} WildcardStep{}]}`,
+		},
+		{
+			name: "var_ref_at_prefixed",
+			node: &VarRef{Name: "doc", AtPrefixed: true},
+			want: `VarRef{Name:doc AtPrefixed:true}`,
+		},
+		{
+			name: "param_ref",
+			node: &ParamRef{},
+			want: `ParamRef{}`,
+		},
+		{
+			name: "sub_link",
+			node: &SubLink{Stmt: &SelectStmt{Star: true}},
+			want: `SubLink{Stmt:SelectStmt{Star:true}}`,
+		},
+		{
+			name: "list_literal",
+			node: &ListLit{Items: []ExprNode{&NumberLit{Val: "1"}, &NumberLit{Val: "2"}}},
+			want: `ListLit{Items:[NumberLit{Val:1} NumberLit{Val:2}]}`,
+		},
+		{
+			name: "bag_literal",
+			node: &BagLit{Items: []ExprNode{&NumberLit{Val: "1"}}},
+			want: `BagLit{Items:[NumberLit{Val:1}]}`,
+		},
+		{
+			name: "tuple_literal",
+			node: &TupleLit{
+				Pairs: []*TuplePair{
+					{Key: &StringLit{Val: "k"}, Value: &NumberLit{Val: "1"}},
+				},
+			},
+			want: `TupleLit{Pairs:[TuplePair{Key:StringLit{Val:"k"} Value:NumberLit{Val:1}}]}`,
+		},
+		{
+			name: "join_expr",
+			node: &JoinExpr{
+				Kind:  JoinKindInner,
+				Left:  &TableRef{Name: "a"},
+				Right: &TableRef{Name: "b"},
+				On:    &BoolLit{Val: true},
+			},
+			want: `JoinExpr{Kind:INNER Left:TableRef{Name:a} Right:TableRef{Name:b} On:BoolLit{Val:true}}`,
+		},
+		{
+			name: "select_with_path_in_from",
+			node: &SelectStmt{
+				Star: true,
+				From: &PathExpr{
+					Root:  &VarRef{Name: "Music"},
+					Steps: []PathStep{&DotStep{Field: "albums"}, &WildcardStep{}},
+				},
+			},
+			want: `SelectStmt{Star:true From:PathExpr{Root:VarRef{Name:Music} Steps:[DotStep{Field:albums} WildcardStep{}]}}`,
+		},
+		{
+			name: "insert_stmt_with_returning",
+			node: &InsertStmt{
+				Target: &TableRef{Name: "Music"},
+				Value:  &TupleLit{Pairs: []*TuplePair{{Key: &StringLit{Val: "k"}, Value: &NumberLit{Val: "1"}}}},
+				Returning: &ReturningClause{
+					Items: []*ReturningItem{
+						{Status: ReturningStatusModified, Mapping: ReturningMappingNew, Star: true},
+					},
+				},
+			},
+			want: `InsertStmt{Target:TableRef{Name:Music} Value:TupleLit{Pairs:[TuplePair{Key:StringLit{Val:"k"} Value:NumberLit{Val:1}}]} Returning:ReturningClause{Items:[ReturningItem{Status:MODIFIED Mapping:NEW Star:true}]}}`,
+		},
+		{
+			name: "match_expr",
+			node: &MatchExpr{
+				Expr: &VarRef{Name: "g"},
+				Patterns: []*GraphPattern{
+					{Parts: []PatternNode{&NodePattern{Variable: &VarRef{Name: "n"}}}},
+				},
+			},
+			want: `MatchExpr{Expr:VarRef{Name:g} Patterns:[GraphPattern{Parts:[NodePattern{Variable:VarRef{Name:n}}]}]}`,
+		},
+		{
+			name: "type_ref_decimal",
+			node: &TypeRef{Name: "DECIMAL", Args: []int{10, 2}},
+			want: `TypeRef{Name:DECIMAL Args:[10,2]}`,
+		},
+		{
+			name: "type_ref_time_with_tz",
+			node: &TypeRef{Name: "TIME", WithTimeZone: true},
+			want: `TypeRef{Name:TIME WithTimeZone:true}`,
+		},
+		{
+			name: "nil_node",
+			node: nil,
+			want: `<nil>`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NodeToString(tc.node)
+			if got != tc.want {
+				t.Errorf("NodeToString() mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestNodeToString_AllNodesCovered — reflection safety net.
+//
+// Walks every node in the package's TestGetLoc table and asserts that
+// NodeToString returns a non-empty result without panicking. This catches
+// the case where a new node type is added to TestGetLoc but never wired
+// into outfuncs.go's switch.
+// ---------------------------------------------------------------------------
+
+func TestNodeToString_AllNodesCovered(t *testing.T) {
+	// Build a fresh table identical in shape to TestGetLoc but constructed
+	// here so the two tests cannot drift apart silently. We could share via
+	// a top-level helper but inlining keeps the test self-contained.
+	cases := allNodesForCoverageTest()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("NodeToString panicked: %v", r)
+				}
+			}()
+			got := NodeToString(tc.node)
+			if got == "" {
+				t.Errorf("NodeToString returned empty string for %s", tc.name)
+			}
+			if strings.HasPrefix(got, "<unknown:") {
+				t.Errorf("outfuncs.go is missing a switch arm for %s: got %q", tc.name, got)
+			}
+		})
+	}
+}
+
+// allNodesForCoverageTest returns one zero-value instance of every node
+// type defined in this package. Adding a new node type means adding it
+// here too — the test will fail until you do.
+func allNodesForCoverageTest() []struct {
+	name string
+	node Node
+} {
+	return []struct {
+		name string
+		node Node
+	}{
+		// node.go
+		{"List", &List{}},
+
+		// literals.go
+		{"StringLit", &StringLit{}},
+		{"NumberLit", &NumberLit{}},
+		{"BoolLit", &BoolLit{}},
+		{"NullLit", &NullLit{}},
+		{"MissingLit", &MissingLit{}},
+		{"DateLit", &DateLit{}},
+		{"TimeLit", &TimeLit{}},
+		{"IonLit", &IonLit{}},
+
+		// exprs.go
+		{"BinaryExpr", &BinaryExpr{}},
+		{"UnaryExpr", &UnaryExpr{}},
+		{"InExpr", &InExpr{}},
+		{"BetweenExpr", &BetweenExpr{}},
+		{"LikeExpr", &LikeExpr{}},
+		{"IsExpr", &IsExpr{}},
+		{"FuncCall", &FuncCall{}},
+		{"CaseExpr", &CaseExpr{}},
+		{"CaseWhen", &CaseWhen{}},
+		{"CastExpr", &CastExpr{}},
+		{"ExtractExpr", &ExtractExpr{}},
+		{"TrimExpr", &TrimExpr{}},
+		{"SubstringExpr", &SubstringExpr{}},
+		{"CoalesceExpr", &CoalesceExpr{}},
+		{"NullIfExpr", &NullIfExpr{}},
+		{"WindowSpec", &WindowSpec{}},
+		{"PathExpr", &PathExpr{}},
+		{"VarRef", &VarRef{}},
+		{"ParamRef", &ParamRef{}},
+		{"SubLink", &SubLink{}},
+		{"ListLit", &ListLit{}},
+		{"BagLit", &BagLit{}},
+		{"TupleLit", &TupleLit{}},
+		{"TuplePair", &TuplePair{}},
+		{"DotStep", &DotStep{}},
+		{"AllFieldsStep", &AllFieldsStep{}},
+		{"IndexStep", &IndexStep{}},
+		{"WildcardStep", &WildcardStep{}},
+
+		// tableexprs.go
+		{"TableRef", &TableRef{}},
+		{"AliasedSource", &AliasedSource{}},
+		{"JoinExpr", &JoinExpr{}},
+		{"UnpivotExpr", &UnpivotExpr{}},
+
+		// types.go
+		{"TypeRef", &TypeRef{}},
+
+		// stmts.go — top-level
+		{"SelectStmt", &SelectStmt{}},
+		{"SetOpStmt", &SetOpStmt{}},
+		{"ExplainStmt", &ExplainStmt{}},
+		{"InsertStmt", &InsertStmt{}},
+		{"UpdateStmt", &UpdateStmt{}},
+		{"DeleteStmt", &DeleteStmt{}},
+		{"UpsertStmt", &UpsertStmt{}},
+		{"ReplaceStmt", &ReplaceStmt{}},
+		{"RemoveStmt", &RemoveStmt{}},
+		{"CreateTableStmt", &CreateTableStmt{}},
+		{"CreateIndexStmt", &CreateIndexStmt{}},
+		{"DropTableStmt", &DropTableStmt{}},
+		{"DropIndexStmt", &DropIndexStmt{}},
+		{"ExecStmt", &ExecStmt{}},
+
+		// stmts.go — clause and DML helpers
+		{"TargetEntry", &TargetEntry{}},
+		{"PivotProjection", &PivotProjection{}},
+		{"LetBinding", &LetBinding{}},
+		{"GroupByClause", &GroupByClause{}},
+		{"GroupByItem", &GroupByItem{}},
+		{"OrderByItem", &OrderByItem{}},
+		{"SetAssignment", &SetAssignment{}},
+		{"OnConflict", &OnConflict{}},
+		{"OnConflictTarget", &OnConflictTarget{}},
+		{"ReturningClause", &ReturningClause{}},
+		{"ReturningItem", &ReturningItem{}},
+
+		// patterns.go
+		{"MatchExpr", &MatchExpr{}},
+		{"GraphPattern", &GraphPattern{}},
+		{"NodePattern", &NodePattern{}},
+		{"EdgePattern", &EdgePattern{}},
+		{"PatternQuantifier", &PatternQuantifier{}},
+		{"PatternSelector", &PatternSelector{}},
 	}
 }

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -61,6 +61,12 @@ var _ PathStep = (*AllFieldsStep)(nil)
 var _ PathStep = (*IndexStep)(nil)
 var _ PathStep = (*WildcardStep)(nil)
 
+// Table expression nodes (tableexprs.go).
+var _ TableExpr = (*TableRef)(nil)
+var _ TableExpr = (*AliasedSource)(nil)
+var _ TableExpr = (*JoinExpr)(nil)
+var _ TableExpr = (*UnpivotExpr)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -110,6 +116,10 @@ func TestGetLoc(t *testing.T) {
 		{"AllFieldsStep", &AllFieldsStep{Loc: Loc{Start: 10, End: 20}}},
 		{"IndexStep", &IndexStep{Loc: Loc{Start: 10, End: 20}}},
 		{"WildcardStep", &WildcardStep{Loc: Loc{Start: 10, End: 20}}},
+		{"TableRef", &TableRef{Loc: Loc{Start: 10, End: 20}}},
+		{"AliasedSource", &AliasedSource{Loc: Loc{Start: 10, End: 20}}},
+		{"JoinExpr", &JoinExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"UnpivotExpr", &UnpivotExpr{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -22,7 +22,6 @@ var _ ExprNode = (*NullLit)(nil)
 var _ ExprNode = (*MissingLit)(nil)
 var _ ExprNode = (*DateLit)(nil)
 var _ ExprNode = (*TimeLit)(nil)
-var _ ExprNode = (*TimestampLit)(nil)
 var _ ExprNode = (*IonLit)(nil)
 
 // ---------------------------------------------------------------------------
@@ -45,7 +44,6 @@ func TestGetLoc(t *testing.T) {
 		{"MissingLit", &MissingLit{Loc: Loc{Start: 10, End: 20}}},
 		{"DateLit", &DateLit{Loc: Loc{Start: 10, End: 20}}},
 		{"TimeLit", &TimeLit{Loc: Loc{Start: 10, End: 20}}},
-		{"TimestampLit", &TimestampLit{Loc: Loc{Start: 10, End: 20}}},
 		{"IonLit", &IonLit{Loc: Loc{Start: 10, End: 20}}},
 	}
 

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -86,6 +86,19 @@ var _ StmtNode = (*DropTableStmt)(nil)
 var _ StmtNode = (*DropIndexStmt)(nil)
 var _ StmtNode = (*ExecStmt)(nil)
 
+// Clause and DML helpers (stmts.go).
+var _ Node = (*TargetEntry)(nil)
+var _ Node = (*PivotProjection)(nil)
+var _ Node = (*LetBinding)(nil)
+var _ Node = (*GroupByClause)(nil)
+var _ Node = (*GroupByItem)(nil)
+var _ Node = (*OrderByItem)(nil)
+var _ Node = (*SetAssignment)(nil)
+var _ Node = (*OnConflict)(nil)
+var _ Node = (*OnConflictTarget)(nil)
+var _ Node = (*ReturningClause)(nil)
+var _ Node = (*ReturningItem)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -154,6 +167,17 @@ func TestGetLoc(t *testing.T) {
 		{"DropTableStmt", &DropTableStmt{Loc: Loc{Start: 10, End: 20}}},
 		{"DropIndexStmt", &DropIndexStmt{Loc: Loc{Start: 10, End: 20}}},
 		{"ExecStmt", &ExecStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"TargetEntry", &TargetEntry{Loc: Loc{Start: 10, End: 20}}},
+		{"PivotProjection", &PivotProjection{Loc: Loc{Start: 10, End: 20}}},
+		{"LetBinding", &LetBinding{Loc: Loc{Start: 10, End: 20}}},
+		{"GroupByClause", &GroupByClause{Loc: Loc{Start: 10, End: 20}}},
+		{"GroupByItem", &GroupByItem{Loc: Loc{Start: 10, End: 20}}},
+		{"OrderByItem", &OrderByItem{Loc: Loc{Start: 10, End: 20}}},
+		{"SetAssignment", &SetAssignment{Loc: Loc{Start: 10, End: 20}}},
+		{"OnConflict", &OnConflict{Loc: Loc{Start: 10, End: 20}}},
+		{"OnConflictTarget", &OnConflictTarget{Loc: Loc{Start: 10, End: 20}}},
+		{"ReturningClause", &ReturningClause{Loc: Loc{Start: 10, End: 20}}},
+		{"ReturningItem", &ReturningItem{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -32,6 +32,18 @@ var _ ExprNode = (*BetweenExpr)(nil)
 var _ ExprNode = (*LikeExpr)(nil)
 var _ ExprNode = (*IsExpr)(nil)
 
+// Special-form expressions (exprs.go).
+var _ ExprNode = (*FuncCall)(nil)
+var _ ExprNode = (*CaseExpr)(nil)
+var _ Node = (*CaseWhen)(nil)
+var _ ExprNode = (*CastExpr)(nil)
+var _ ExprNode = (*ExtractExpr)(nil)
+var _ ExprNode = (*TrimExpr)(nil)
+var _ ExprNode = (*SubstringExpr)(nil)
+var _ ExprNode = (*CoalesceExpr)(nil)
+var _ ExprNode = (*NullIfExpr)(nil)
+var _ Node = (*WindowSpec)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -59,6 +71,16 @@ func TestGetLoc(t *testing.T) {
 		{"BetweenExpr", &BetweenExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"LikeExpr", &LikeExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"IsExpr", &IsExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"FuncCall", &FuncCall{Loc: Loc{Start: 10, End: 20}}},
+		{"CaseExpr", &CaseExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"CaseWhen", &CaseWhen{Loc: Loc{Start: 10, End: 20}}},
+		{"CastExpr", &CastExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"ExtractExpr", &ExtractExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"TrimExpr", &TrimExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"SubstringExpr", &SubstringExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"CoalesceExpr", &CoalesceExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"NullIfExpr", &NullIfExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"WindowSpec", &WindowSpec{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -70,6 +70,22 @@ var _ TableExpr = (*UnpivotExpr)(nil)
 // Type names (types.go).
 var _ TypeName = (*TypeRef)(nil)
 
+// Top-level statements (stmts.go).
+var _ StmtNode = (*SelectStmt)(nil)
+var _ StmtNode = (*SetOpStmt)(nil)
+var _ StmtNode = (*ExplainStmt)(nil)
+var _ StmtNode = (*InsertStmt)(nil)
+var _ StmtNode = (*UpdateStmt)(nil)
+var _ StmtNode = (*DeleteStmt)(nil)
+var _ StmtNode = (*UpsertStmt)(nil)
+var _ StmtNode = (*ReplaceStmt)(nil)
+var _ StmtNode = (*RemoveStmt)(nil)
+var _ StmtNode = (*CreateTableStmt)(nil)
+var _ StmtNode = (*CreateIndexStmt)(nil)
+var _ StmtNode = (*DropTableStmt)(nil)
+var _ StmtNode = (*DropIndexStmt)(nil)
+var _ StmtNode = (*ExecStmt)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -124,6 +140,20 @@ func TestGetLoc(t *testing.T) {
 		{"JoinExpr", &JoinExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"UnpivotExpr", &UnpivotExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"TypeRef", &TypeRef{Loc: Loc{Start: 10, End: 20}}},
+		{"SelectStmt", &SelectStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"SetOpStmt", &SetOpStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"ExplainStmt", &ExplainStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"InsertStmt", &InsertStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"UpdateStmt", &UpdateStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"DeleteStmt", &DeleteStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"UpsertStmt", &UpsertStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"ReplaceStmt", &ReplaceStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"RemoveStmt", &RemoveStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"CreateTableStmt", &CreateTableStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"CreateIndexStmt", &CreateIndexStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"DropTableStmt", &DropTableStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"DropIndexStmt", &DropIndexStmt{Loc: Loc{Start: 10, End: 20}}},
+		{"ExecStmt", &ExecStmt{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -67,6 +67,9 @@ var _ TableExpr = (*AliasedSource)(nil)
 var _ TableExpr = (*JoinExpr)(nil)
 var _ TableExpr = (*UnpivotExpr)(nil)
 
+// Type names (types.go).
+var _ TypeName = (*TypeRef)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -120,6 +123,7 @@ func TestGetLoc(t *testing.T) {
 		{"AliasedSource", &AliasedSource{Loc: Loc{Start: 10, End: 20}}},
 		{"JoinExpr", &JoinExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"UnpivotExpr", &UnpivotExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"TypeRef", &TypeRef{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -14,6 +14,17 @@ import (
 
 var _ Node = (*List)(nil)
 
+// Literals — all implement ExprNode.
+var _ ExprNode = (*StringLit)(nil)
+var _ ExprNode = (*NumberLit)(nil)
+var _ ExprNode = (*BoolLit)(nil)
+var _ ExprNode = (*NullLit)(nil)
+var _ ExprNode = (*MissingLit)(nil)
+var _ ExprNode = (*DateLit)(nil)
+var _ ExprNode = (*TimeLit)(nil)
+var _ ExprNode = (*TimestampLit)(nil)
+var _ ExprNode = (*IonLit)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -27,6 +38,15 @@ func TestGetLoc(t *testing.T) {
 		node Node
 	}{
 		{"List", &List{Loc: Loc{Start: 10, End: 20}}},
+		{"StringLit", &StringLit{Loc: Loc{Start: 10, End: 20}}},
+		{"NumberLit", &NumberLit{Loc: Loc{Start: 10, End: 20}}},
+		{"BoolLit", &BoolLit{Loc: Loc{Start: 10, End: 20}}},
+		{"NullLit", &NullLit{Loc: Loc{Start: 10, End: 20}}},
+		{"MissingLit", &MissingLit{Loc: Loc{Start: 10, End: 20}}},
+		{"DateLit", &DateLit{Loc: Loc{Start: 10, End: 20}}},
+		{"TimeLit", &TimeLit{Loc: Loc{Start: 10, End: 20}}},
+		{"TimestampLit", &TimestampLit{Loc: Loc{Start: 10, End: 20}}},
+		{"IonLit", &IonLit{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -1,0 +1,40 @@
+package ast
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Compile-time interface assertions.
+//
+// Every node type added to this package gets a `var _ <Interface> = (*Type)(nil)`
+// line below. The file fails to compile if a node's interface set drifts.
+// Tasks add their assertions to the appropriate section as they grow the AST.
+// ---------------------------------------------------------------------------
+
+var _ Node = (*List)(nil)
+
+// ---------------------------------------------------------------------------
+// TestGetLoc — table-driven Loc round-trip.
+//
+// One row per node type. Each row constructs the node with Loc{10, 20},
+// calls GetLoc(), and asserts the result.
+// ---------------------------------------------------------------------------
+
+func TestGetLoc(t *testing.T) {
+	cases := []struct {
+		name string
+		node Node
+	}{
+		{"List", &List{Loc: Loc{Start: 10, End: 20}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.node.GetLoc()
+			if got.Start != 10 || got.End != 20 {
+				t.Errorf("GetLoc() = %+v, want {10, 20}", got)
+			}
+		})
+	}
+}

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -99,6 +99,14 @@ var _ Node = (*OnConflictTarget)(nil)
 var _ Node = (*ReturningClause)(nil)
 var _ Node = (*ReturningItem)(nil)
 
+// Graph patterns (patterns.go).
+var _ ExprNode = (*MatchExpr)(nil)
+var _ PatternNode = (*GraphPattern)(nil)
+var _ PatternNode = (*NodePattern)(nil)
+var _ PatternNode = (*EdgePattern)(nil)
+var _ Node = (*PatternQuantifier)(nil)
+var _ Node = (*PatternSelector)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -178,6 +186,12 @@ func TestGetLoc(t *testing.T) {
 		{"OnConflictTarget", &OnConflictTarget{Loc: Loc{Start: 10, End: 20}}},
 		{"ReturningClause", &ReturningClause{Loc: Loc{Start: 10, End: 20}}},
 		{"ReturningItem", &ReturningItem{Loc: Loc{Start: 10, End: 20}}},
+		{"MatchExpr", &MatchExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"GraphPattern", &GraphPattern{Loc: Loc{Start: 10, End: 20}}},
+		{"NodePattern", &NodePattern{Loc: Loc{Start: 10, End: 20}}},
+		{"EdgePattern", &EdgePattern{Loc: Loc{Start: 10, End: 20}}},
+		{"PatternQuantifier", &PatternQuantifier{Loc: Loc{Start: 10, End: 20}}},
+		{"PatternSelector", &PatternSelector{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -24,6 +24,14 @@ var _ ExprNode = (*DateLit)(nil)
 var _ ExprNode = (*TimeLit)(nil)
 var _ ExprNode = (*IonLit)(nil)
 
+// Operators & predicates (exprs.go).
+var _ ExprNode = (*BinaryExpr)(nil)
+var _ ExprNode = (*UnaryExpr)(nil)
+var _ ExprNode = (*InExpr)(nil)
+var _ ExprNode = (*BetweenExpr)(nil)
+var _ ExprNode = (*LikeExpr)(nil)
+var _ ExprNode = (*IsExpr)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -45,6 +53,12 @@ func TestGetLoc(t *testing.T) {
 		{"DateLit", &DateLit{Loc: Loc{Start: 10, End: 20}}},
 		{"TimeLit", &TimeLit{Loc: Loc{Start: 10, End: 20}}},
 		{"IonLit", &IonLit{Loc: Loc{Start: 10, End: 20}}},
+		{"BinaryExpr", &BinaryExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"UnaryExpr", &UnaryExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"InExpr", &InExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"BetweenExpr", &BetweenExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"LikeExpr", &LikeExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"IsExpr", &IsExpr{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -44,6 +44,23 @@ var _ ExprNode = (*CoalesceExpr)(nil)
 var _ ExprNode = (*NullIfExpr)(nil)
 var _ Node = (*WindowSpec)(nil)
 
+// Paths, vars, params, subqueries, collection literals, path steps (exprs.go).
+var _ ExprNode = (*PathExpr)(nil)
+var _ TableExpr = (*PathExpr)(nil)
+var _ ExprNode = (*VarRef)(nil)
+var _ TableExpr = (*VarRef)(nil)
+var _ ExprNode = (*ParamRef)(nil)
+var _ ExprNode = (*SubLink)(nil)
+var _ TableExpr = (*SubLink)(nil)
+var _ ExprNode = (*ListLit)(nil)
+var _ ExprNode = (*BagLit)(nil)
+var _ ExprNode = (*TupleLit)(nil)
+var _ Node = (*TuplePair)(nil)
+var _ PathStep = (*DotStep)(nil)
+var _ PathStep = (*AllFieldsStep)(nil)
+var _ PathStep = (*IndexStep)(nil)
+var _ PathStep = (*WildcardStep)(nil)
+
 // ---------------------------------------------------------------------------
 // TestGetLoc — table-driven Loc round-trip.
 //
@@ -81,6 +98,18 @@ func TestGetLoc(t *testing.T) {
 		{"CoalesceExpr", &CoalesceExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"NullIfExpr", &NullIfExpr{Loc: Loc{Start: 10, End: 20}}},
 		{"WindowSpec", &WindowSpec{Loc: Loc{Start: 10, End: 20}}},
+		{"PathExpr", &PathExpr{Loc: Loc{Start: 10, End: 20}}},
+		{"VarRef", &VarRef{Loc: Loc{Start: 10, End: 20}}},
+		{"ParamRef", &ParamRef{Loc: Loc{Start: 10, End: 20}}},
+		{"SubLink", &SubLink{Loc: Loc{Start: 10, End: 20}}},
+		{"ListLit", &ListLit{Loc: Loc{Start: 10, End: 20}}},
+		{"BagLit", &BagLit{Loc: Loc{Start: 10, End: 20}}},
+		{"TupleLit", &TupleLit{Loc: Loc{Start: 10, End: 20}}},
+		{"TuplePair", &TuplePair{Loc: Loc{Start: 10, End: 20}}},
+		{"DotStep", &DotStep{Loc: Loc{Start: 10, End: 20}}},
+		{"AllFieldsStep", &AllFieldsStep{Loc: Loc{Start: 10, End: 20}}},
+		{"IndexStep", &IndexStep{Loc: Loc{Start: 10, End: 20}}},
+		{"WildcardStep", &WildcardStep{Loc: Loc{Start: 10, End: 20}}},
 	}
 
 	for _, tc := range cases {

--- a/partiql/ast/exprs.go
+++ b/partiql/ast/exprs.go
@@ -242,3 +242,229 @@ type IsExpr struct {
 func (*IsExpr) nodeTag()      {}
 func (n *IsExpr) GetLoc() Loc { return n.Loc }
 func (*IsExpr) exprNode()     {}
+
+// ===========================================================================
+// Special-form expressions
+//
+// Function calls, CASE, CAST, and the keyword-bearing built-ins (EXTRACT,
+// TRIM, SUBSTRING) get dedicated nodes because their grammar uses keywords
+// inside parens or non-comma argument syntax. COALESCE and NULLIF also get
+// dedicated nodes because they appear as ANTLR rules. Built-ins with
+// ordinary `name(arg, arg, …)` syntax (DATE_ADD, DATE_DIFF, SIZE, EXISTS, …)
+// use plain FuncCall.
+// ===========================================================================
+
+// QuantifierKind covers the [DISTINCT|ALL] modifier on aggregates and
+// set operations. Although the spec listed it under stmts.go, it is
+// declared here because FuncCall (defined first in implementation order)
+// is its first user. SetOpStmt in stmts.go references it as ast.QuantifierKind.
+type QuantifierKind int
+
+const (
+	QuantifierNone QuantifierKind = iota
+	QuantifierAll
+	QuantifierDistinct
+)
+
+func (q QuantifierKind) String() string {
+	switch q {
+	case QuantifierAll:
+		return "ALL"
+	case QuantifierDistinct:
+		return "DISTINCT"
+	default:
+		return ""
+	}
+}
+
+// CastKind discriminates the three CAST-family operators.
+type CastKind int
+
+const (
+	CastKindInvalid CastKind = iota
+	CastKindCast
+	CastKindCanCast
+	CastKindCanLosslessCast
+)
+
+func (k CastKind) String() string {
+	switch k {
+	case CastKindCast:
+		return "CAST"
+	case CastKindCanCast:
+		return "CAN_CAST"
+	case CastKindCanLosslessCast:
+		return "CAN_LOSSLESS_CAST"
+	default:
+		return "INVALID"
+	}
+}
+
+// TrimSpec covers the optional LEADING/TRAILING/BOTH keyword inside TRIM.
+type TrimSpec int
+
+const (
+	TrimSpecNone TrimSpec = iota
+	TrimSpecLeading
+	TrimSpecTrailing
+	TrimSpecBoth
+)
+
+func (s TrimSpec) String() string {
+	switch s {
+	case TrimSpecLeading:
+		return "LEADING"
+	case TrimSpecTrailing:
+		return "TRAILING"
+	case TrimSpecBoth:
+		return "BOTH"
+	default:
+		return ""
+	}
+}
+
+// FuncCall is the generic function-call node — used for ordinary function
+// calls (DATE_ADD, SIZE, ...), aggregates (COUNT/SUM/AVG/MIN/MAX with the
+// optional DISTINCT/ALL modifier and COUNT(*) form), and window calls
+// (LAG/LEAD with an OVER clause). The Quantifier, Star, and Over fields
+// determine which flavor a particular instance is.
+//
+// Grammar: functionCall#FunctionCallReserved, functionCall#FunctionCallIdent,
+//
+//	aggregate#CountAll, aggregate#AggregateBase,
+//	windowFunction#LagLeadFunction
+type FuncCall struct {
+	Name       string
+	Args       []ExprNode
+	Quantifier QuantifierKind // NONE/DISTINCT/ALL — populated for aggregates
+	Star       bool           // true for COUNT(*)
+	Over       *WindowSpec    // non-nil for window calls
+	Loc        Loc
+}
+
+func (*FuncCall) nodeTag()      {}
+func (n *FuncCall) GetLoc() Loc { return n.Loc }
+func (*FuncCall) exprNode()     {}
+
+// CaseExpr covers both `CASE WHEN … THEN …` (searched) and
+// `CASE expr WHEN … THEN …` (simple) forms. Operand is nil for the
+// searched form.
+//
+// Grammar: caseExpr
+type CaseExpr struct {
+	Operand ExprNode // nil for searched CASE
+	Whens   []*CaseWhen
+	Else    ExprNode // nil if no ELSE clause
+	Loc     Loc
+}
+
+func (*CaseExpr) nodeTag()      {}
+func (n *CaseExpr) GetLoc() Loc { return n.Loc }
+func (*CaseExpr) exprNode()     {}
+
+// CaseWhen represents one `WHEN expr THEN expr` arm. Bare Node — does not
+// implement ExprNode because it cannot stand alone in scalar position.
+type CaseWhen struct {
+	When ExprNode
+	Then ExprNode
+	Loc  Loc
+}
+
+func (*CaseWhen) nodeTag()      {}
+func (n *CaseWhen) GetLoc() Loc { return n.Loc }
+
+// CastExpr covers CAST, CAN_CAST, and CAN_LOSSLESS_CAST.
+//
+// Grammar: cast, canCast, canLosslessCast
+type CastExpr struct {
+	Kind   CastKind
+	Expr   ExprNode
+	AsType TypeName
+	Loc    Loc
+}
+
+func (*CastExpr) nodeTag()      {}
+func (n *CastExpr) GetLoc() Loc { return n.Loc }
+func (*CastExpr) exprNode()     {}
+
+// ExtractExpr represents `EXTRACT(<field> FROM <expr>)`. Field is the
+// keyword (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, ...) — stored as the
+// raw uppercase keyword string.
+//
+// Grammar: extract
+type ExtractExpr struct {
+	Field string
+	From  ExprNode
+	Loc   Loc
+}
+
+func (*ExtractExpr) nodeTag()      {}
+func (n *ExtractExpr) GetLoc() Loc { return n.Loc }
+func (*ExtractExpr) exprNode()     {}
+
+// TrimExpr represents `TRIM([LEADING|TRAILING|BOTH] [sub] FROM target)`.
+//
+// Grammar: trimFunction
+type TrimExpr struct {
+	Spec TrimSpec
+	Sub  ExprNode // optional substring to trim; nil for default whitespace
+	From ExprNode
+	Loc  Loc
+}
+
+func (*TrimExpr) nodeTag()      {}
+func (n *TrimExpr) GetLoc() Loc { return n.Loc }
+func (*TrimExpr) exprNode()     {}
+
+// SubstringExpr represents `SUBSTRING(expr FROM start [FOR length])` and
+// the equivalent comma form `SUBSTRING(expr, start[, length])`.
+//
+// Grammar: substring
+type SubstringExpr struct {
+	Expr ExprNode
+	From ExprNode
+	For  ExprNode // optional length
+	Loc  Loc
+}
+
+func (*SubstringExpr) nodeTag()      {}
+func (n *SubstringExpr) GetLoc() Loc { return n.Loc }
+func (*SubstringExpr) exprNode()     {}
+
+// CoalesceExpr represents `COALESCE(expr, expr, …)`.
+//
+// Grammar: coalesce
+type CoalesceExpr struct {
+	Args []ExprNode
+	Loc  Loc
+}
+
+func (*CoalesceExpr) nodeTag()      {}
+func (n *CoalesceExpr) GetLoc() Loc { return n.Loc }
+func (*CoalesceExpr) exprNode()     {}
+
+// NullIfExpr represents `NULLIF(expr, expr)`.
+//
+// Grammar: nullIf
+type NullIfExpr struct {
+	Left  ExprNode
+	Right ExprNode
+	Loc   Loc
+}
+
+func (*NullIfExpr) nodeTag()      {}
+func (n *NullIfExpr) GetLoc() Loc { return n.Loc }
+func (*NullIfExpr) exprNode()     {}
+
+// WindowSpec represents the body of an OVER (...) clause attached to
+// a window function call. Bare Node — appears only inside FuncCall.Over.
+//
+// Grammar: over
+type WindowSpec struct {
+	PartitionBy []ExprNode
+	OrderBy     []*OrderByItem // OrderByItem defined in stmts.go
+	Loc         Loc
+}
+
+func (*WindowSpec) nodeTag()      {}
+func (n *WindowSpec) GetLoc() Loc { return n.Loc }

--- a/partiql/ast/exprs.go
+++ b/partiql/ast/exprs.go
@@ -1,0 +1,244 @@
+package ast
+
+// ---------------------------------------------------------------------------
+// Expression nodes — all implement ExprNode.
+//
+// This file is built in three task groups (matching the implementation plan):
+//   1. Operators & predicates (this section)
+//   2. Special-form expressions: FuncCall, CaseExpr, CastExpr, etc.
+//   3. Paths, variables, parameters, subqueries, collection literals,
+//      window spec, path steps
+//
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   exprOr            (lines 469–472)
+//   exprAnd           (lines 474–477)
+//   exprNot           (lines 479–482)
+//   exprPredicate     (lines 484–492)
+//   mathOp00/01/02    (lines 494–507)
+//   valueExpr         (lines 509–512)
+//   exprPrimary       (lines 514–534)
+//   exprTerm          (lines 542–549)
+//   functionCall      (lines 611–616)
+//   caseExpr          (lines 557–558)
+//   cast/canCast/canLosslessCast (lines 593–600)
+//   extract           (lines 602–603)
+//   trimFunction      (lines 605–606)
+//   substring         (lines 572–575)
+//   coalesce          (lines 554–555)
+//   nullIf            (lines 551–552)
+//   aggregate         (lines 577–580)
+//   windowFunction    (lines 589–591)
+//   over              (lines 276–278)
+//   array/bag/tuple/pair (lines 649–659)
+//   pathStep          (lines 618–623)
+//   varRefExpr        (lines 635–636)
+//   parameter         (lines 632–633)
+// Each type below cites its specific rule#Label.
+// ---------------------------------------------------------------------------
+
+// ===========================================================================
+// Operator enums
+// ===========================================================================
+
+// BinOp identifies a binary operator.
+type BinOp int
+
+const (
+	BinOpInvalid BinOp = iota
+	BinOpOr
+	BinOpAnd
+	BinOpConcat // ||
+	BinOpAdd
+	BinOpSub
+	BinOpMul
+	BinOpDiv
+	BinOpMod
+	BinOpEq
+	BinOpNotEq
+	BinOpLt
+	BinOpGt
+	BinOpLtEq
+	BinOpGtEq
+)
+
+// String returns the canonical operator spelling.
+func (op BinOp) String() string {
+	switch op {
+	case BinOpOr:
+		return "OR"
+	case BinOpAnd:
+		return "AND"
+	case BinOpConcat:
+		return "||"
+	case BinOpAdd:
+		return "+"
+	case BinOpSub:
+		return "-"
+	case BinOpMul:
+		return "*"
+	case BinOpDiv:
+		return "/"
+	case BinOpMod:
+		return "%"
+	case BinOpEq:
+		return "="
+	case BinOpNotEq:
+		return "<>"
+	case BinOpLt:
+		return "<"
+	case BinOpGt:
+		return ">"
+	case BinOpLtEq:
+		return "<="
+	case BinOpGtEq:
+		return ">="
+	default:
+		return "INVALID"
+	}
+}
+
+// UnOp identifies a unary operator.
+type UnOp int
+
+const (
+	UnOpInvalid UnOp = iota
+	UnOpNot
+	UnOpNeg // unary -
+	UnOpPos // unary +
+)
+
+func (op UnOp) String() string {
+	switch op {
+	case UnOpNot:
+		return "NOT"
+	case UnOpNeg:
+		return "-"
+	case UnOpPos:
+		return "+"
+	default:
+		return "INVALID"
+	}
+}
+
+// IsType identifies the right-hand side of an `IS [NOT] X` predicate.
+type IsType int
+
+const (
+	IsTypeInvalid IsType = iota
+	IsTypeNull
+	IsTypeMissing
+	IsTypeTrue
+	IsTypeFalse
+)
+
+func (t IsType) String() string {
+	switch t {
+	case IsTypeNull:
+		return "NULL"
+	case IsTypeMissing:
+		return "MISSING"
+	case IsTypeTrue:
+		return "TRUE"
+	case IsTypeFalse:
+		return "FALSE"
+	default:
+		return "INVALID"
+	}
+}
+
+// ===========================================================================
+// Operator nodes
+// ===========================================================================
+
+// BinaryExpr represents a binary operator application.
+//
+// Grammar: exprOr#Or, exprAnd#And, exprPredicate#PredicateComparison,
+//
+//	mathOp00 (CONCAT), mathOp01 (PLUS/MINUS), mathOp02 (PERCENT/ASTERISK/SLASH_FORWARD)
+type BinaryExpr struct {
+	Op    BinOp
+	Left  ExprNode
+	Right ExprNode
+	Loc   Loc
+}
+
+func (*BinaryExpr) nodeTag()      {}
+func (n *BinaryExpr) GetLoc() Loc { return n.Loc }
+func (*BinaryExpr) exprNode()     {}
+
+// UnaryExpr represents a unary operator application.
+//
+// Grammar: exprNot#Not, valueExpr (unary PLUS/MINUS)
+type UnaryExpr struct {
+	Op      UnOp
+	Operand ExprNode
+	Loc     Loc
+}
+
+func (*UnaryExpr) nodeTag()      {}
+func (n *UnaryExpr) GetLoc() Loc { return n.Loc }
+func (*UnaryExpr) exprNode()     {}
+
+// ===========================================================================
+// Predicate nodes
+// ===========================================================================
+
+// InExpr represents `expr [NOT] IN (…)` — either a parenthesized expression
+// list or a subquery.
+//
+// Grammar: exprPredicate#PredicateIn
+type InExpr struct {
+	Expr     ExprNode
+	List     []ExprNode // populated when the RHS is an expression list
+	Subquery StmtNode   // populated when the RHS is a parenthesized SELECT
+	Not      bool
+	Loc      Loc
+}
+
+func (*InExpr) nodeTag()      {}
+func (n *InExpr) GetLoc() Loc { return n.Loc }
+func (*InExpr) exprNode()     {}
+
+// BetweenExpr represents `expr [NOT] BETWEEN low AND high`.
+//
+// Grammar: exprPredicate#PredicateBetween
+type BetweenExpr struct {
+	Expr ExprNode
+	Low  ExprNode
+	High ExprNode
+	Not  bool
+	Loc  Loc
+}
+
+func (*BetweenExpr) nodeTag()      {}
+func (n *BetweenExpr) GetLoc() Loc { return n.Loc }
+func (*BetweenExpr) exprNode()     {}
+
+// LikeExpr represents `expr [NOT] LIKE pattern [ESCAPE escape]`.
+//
+// Grammar: exprPredicate#PredicateLike
+type LikeExpr struct {
+	Expr    ExprNode
+	Pattern ExprNode
+	Escape  ExprNode // nil if no ESCAPE clause
+	Not     bool
+	Loc     Loc
+}
+
+func (*LikeExpr) nodeTag()      {}
+func (n *LikeExpr) GetLoc() Loc { return n.Loc }
+func (*LikeExpr) exprNode()     {}
+
+// IsExpr represents `expr IS [NOT] (NULL|MISSING|TRUE|FALSE)`.
+//
+// Grammar: exprPredicate#PredicateIs
+type IsExpr struct {
+	Expr ExprNode
+	Type IsType
+	Not  bool
+	Loc  Loc
+}
+
+func (*IsExpr) nodeTag()      {}
+func (n *IsExpr) GetLoc() Loc { return n.Loc }
+func (*IsExpr) exprNode()     {}

--- a/partiql/ast/exprs.go
+++ b/partiql/ast/exprs.go
@@ -468,3 +468,174 @@ type WindowSpec struct {
 
 func (*WindowSpec) nodeTag()      {}
 func (n *WindowSpec) GetLoc() Loc { return n.Loc }
+
+// ===========================================================================
+// Paths, variables, parameters, subqueries
+//
+// PathExpr, VarRef, and SubLink also implement TableExpr because PartiQL's
+// FROM grammar accepts the same productions as scalar expressions.
+// ===========================================================================
+
+// PathExpr represents a chained path navigation: root.field[idx].field[*].
+// Root is the base expression (typically a VarRef); Steps are the chained
+// path operations from PathStep.
+//
+// Grammar: exprPrimary#ExprPrimaryPath (exprPrimary pathStep+)
+type PathExpr struct {
+	Root  ExprNode
+	Steps []PathStep
+	Loc   Loc
+}
+
+func (*PathExpr) nodeTag()      {}
+func (n *PathExpr) GetLoc() Loc { return n.Loc }
+func (*PathExpr) exprNode()     {}
+func (*PathExpr) tableExpr()    {} // PartiQL FROM accepts path expressions
+
+// VarRef represents an identifier reference. AtPrefixed distinguishes
+// `@id` (true) from bare `id` (false). CaseSensitive distinguishes
+// `"X"` (true, double-quoted) from `X` (false, unquoted).
+//
+// Grammar: varRefExpr
+type VarRef struct {
+	Name          string
+	AtPrefixed    bool
+	CaseSensitive bool
+	Loc           Loc
+}
+
+func (*VarRef) nodeTag()      {}
+func (n *VarRef) GetLoc() Loc { return n.Loc }
+func (*VarRef) exprNode()     {}
+func (*VarRef) tableExpr()    {} // a bare identifier in FROM is a VarRef
+
+// ParamRef represents a positional `?` parameter.
+//
+// Grammar: parameter
+type ParamRef struct {
+	Loc Loc
+}
+
+func (*ParamRef) nodeTag()      {}
+func (n *ParamRef) GetLoc() Loc { return n.Loc }
+func (*ParamRef) exprNode()     {}
+
+// SubLink represents a parenthesized SELECT used as a value expression
+// or as a FROM source. Stmt is the inner statement (a SelectStmt or
+// SetOpStmt).
+//
+// Grammar: exprTerm#ExprTermWrappedQuery (PAREN_LEFT expr PAREN_RIGHT)
+type SubLink struct {
+	Stmt StmtNode
+	Loc  Loc
+}
+
+func (*SubLink) nodeTag()      {}
+func (n *SubLink) GetLoc() Loc { return n.Loc }
+func (*SubLink) exprNode()     {}
+func (*SubLink) tableExpr()    {}
+
+// ===========================================================================
+// Collection literals
+// ===========================================================================
+
+// ListLit represents an ordered list literal: [expr, expr, …].
+//
+// Grammar: array
+type ListLit struct {
+	Items []ExprNode
+	Loc   Loc
+}
+
+func (*ListLit) nodeTag()      {}
+func (n *ListLit) GetLoc() Loc { return n.Loc }
+func (*ListLit) exprNode()     {}
+
+// BagLit represents an unordered bag literal: <<expr, expr, …>>. PartiQL-unique.
+//
+// Grammar: bag
+type BagLit struct {
+	Items []ExprNode
+	Loc   Loc
+}
+
+func (*BagLit) nodeTag()      {}
+func (n *BagLit) GetLoc() Loc { return n.Loc }
+func (*BagLit) exprNode()     {}
+
+// TupleLit represents a tuple/struct literal: {key: value, …}. PartiQL-unique.
+//
+// Grammar: tuple
+type TupleLit struct {
+	Pairs []*TuplePair
+	Loc   Loc
+}
+
+func (*TupleLit) nodeTag()      {}
+func (n *TupleLit) GetLoc() Loc { return n.Loc }
+func (*TupleLit) exprNode()     {}
+
+// TuplePair represents one `key: value` entry in a tuple literal.
+// Bare Node — appears only inside TupleLit.Pairs.
+//
+// Grammar: pair
+type TuplePair struct {
+	Key   ExprNode
+	Value ExprNode
+	Loc   Loc
+}
+
+func (*TuplePair) nodeTag()      {}
+func (n *TuplePair) GetLoc() Loc { return n.Loc }
+
+// ===========================================================================
+// Path steps — implement PathStep
+// ===========================================================================
+
+// DotStep represents `.field`. CaseSensitive is true for `."Field"`
+// (the field name was quoted) and false for unquoted `.field`.
+//
+// Grammar: pathStep#PathStepDotExpr
+type DotStep struct {
+	Field         string
+	CaseSensitive bool
+	Loc           Loc
+}
+
+func (*DotStep) nodeTag()      {}
+func (n *DotStep) GetLoc() Loc { return n.Loc }
+func (*DotStep) pathStep()     {}
+
+// AllFieldsStep represents `.*` — the all-fields wildcard.
+//
+// Grammar: pathStep#PathStepDotAll
+type AllFieldsStep struct {
+	Loc Loc
+}
+
+func (*AllFieldsStep) nodeTag()      {}
+func (n *AllFieldsStep) GetLoc() Loc { return n.Loc }
+func (*AllFieldsStep) pathStep()     {}
+
+// IndexStep represents `[expr]` — index/key by an expression.
+//
+// Grammar: pathStep#PathStepIndexExpr
+type IndexStep struct {
+	Index ExprNode
+	Loc   Loc
+}
+
+func (*IndexStep) nodeTag()      {}
+func (n *IndexStep) GetLoc() Loc { return n.Loc }
+func (*IndexStep) pathStep()     {}
+
+// WildcardStep represents `[*]` — all-elements wildcard.
+//
+// Grammar: pathStep#PathStepIndexAll
+type WildcardStep struct {
+	Loc Loc
+}
+
+func (*WildcardStep) nodeTag()      {}
+func (n *WildcardStep) GetLoc() Loc { return n.Loc }
+func (*WildcardStep) pathStep()     {}

--- a/partiql/ast/literals.go
+++ b/partiql/ast/literals.go
@@ -3,15 +3,17 @@ package ast
 // ---------------------------------------------------------------------------
 // Literal nodes — all implement ExprNode.
 //
-// Grammar: PartiQLParser.g4 — `literal`, `dateLit`, `timeLit`, `timestampLit`,
-// `ionLit`. See docs/migration/partiql/analysis.md "Literals" sub-sections.
+// Grammar: PartiQLParser.g4 lines 661–672 (the `literal` rule). Each type
+// here corresponds to one labeled alternative of that rule. There is no
+// TIMESTAMP literal — TIMESTAMP appears only as a type-name keyword in the
+// `type` rule (line 677), used by CAST and DDL.
 // ---------------------------------------------------------------------------
 
 // StringLit represents a single-quoted string literal: 'hello'.
 //
-// Grammar: literal LITERAL_STRING
+// Grammar: literal#LiteralString (LITERAL_STRING)
 type StringLit struct {
-	Val string // unescaped string content
+	Val string // SQL escapes already decoded ('' → ')
 	Loc Loc
 }
 
@@ -21,8 +23,10 @@ func (*StringLit) exprNode()     {}
 
 // NumberLit represents a numeric literal. Val stores the raw text to
 // preserve the original representation (integer vs decimal vs scientific).
+// Consumers needing a typed value should call strconv.ParseFloat or
+// shopspring/decimal at the call site — this AST does not normalize.
 //
-// Grammar: literal LITERAL_INTEGER | LITERAL_DECIMAL
+// Grammar: literal#LiteralInteger / literal#LiteralDecimal
 type NumberLit struct {
 	Val string // raw text as it appears in source
 	Loc Loc
@@ -34,7 +38,7 @@ func (*NumberLit) exprNode()     {}
 
 // BoolLit represents TRUE or FALSE.
 //
-// Grammar: literal TRUE | FALSE
+// Grammar: literal#LiteralTrue / literal#LiteralFalse
 type BoolLit struct {
 	Val bool
 	Loc Loc
@@ -46,7 +50,7 @@ func (*BoolLit) exprNode()     {}
 
 // NullLit represents NULL.
 //
-// Grammar: literal NULL
+// Grammar: literal#LiteralNull
 type NullLit struct {
 	Loc Loc
 }
@@ -57,7 +61,7 @@ func (*NullLit) exprNode()     {}
 
 // MissingLit represents the PartiQL-distinct MISSING value.
 //
-// Grammar: literal MISSING
+// Grammar: literal#LiteralMissing
 type MissingLit struct {
 	Loc Loc
 }
@@ -68,7 +72,7 @@ func (*MissingLit) exprNode()     {}
 
 // DateLit represents `DATE 'YYYY-MM-DD'`.
 //
-// Grammar: dateLit DATE LITERAL_STRING
+// Grammar: literal#LiteralDate (DATE LITERAL_STRING)
 type DateLit struct {
 	Val string // YYYY-MM-DD body
 	Loc Loc
@@ -80,9 +84,9 @@ func (*DateLit) exprNode()     {}
 
 // TimeLit represents `TIME [(p)] [WITH TIME ZONE] 'HH:MM:SS[.frac]'`.
 //
-// Grammar: timeLit TIME (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
+// Grammar: literal#LiteralTime
 //
-//	(WITH TIME ZONE)? LITERAL_STRING
+//	TIME (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)? (WITH TIME ZONE)? LITERAL_STRING
 type TimeLit struct {
 	Val          string // HH:MM:SS[.frac] body
 	Precision    *int   // optional fractional-seconds precision
@@ -94,27 +98,11 @@ func (*TimeLit) nodeTag()      {}
 func (n *TimeLit) GetLoc() Loc { return n.Loc }
 func (*TimeLit) exprNode()     {}
 
-// TimestampLit represents `TIMESTAMP [(p)] [WITH TIME ZONE] '…'`.
-//
-// Grammar: timestampLit TIMESTAMP (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
-//
-//	(WITH TIME ZONE)? LITERAL_STRING
-type TimestampLit struct {
-	Val          string
-	Precision    *int
-	WithTimeZone bool
-	Loc          Loc
-}
-
-func (*TimestampLit) nodeTag()      {}
-func (n *TimestampLit) GetLoc() Loc { return n.Loc }
-func (*TimestampLit) exprNode()     {}
-
 // IonLit represents a backtick-delimited inline Ion value: `…`.
 // Text holds the verbatim contents between the backticks (no parsing,
 // no normalization). PartiQL-unique.
 //
-// Grammar: ionLit ION_LITERAL
+// Grammar: literal#LiteralIon (ION_CLOSURE)
 type IonLit struct {
 	Text string
 	Loc  Loc

--- a/partiql/ast/literals.go
+++ b/partiql/ast/literals.go
@@ -1,0 +1,125 @@
+package ast
+
+// ---------------------------------------------------------------------------
+// Literal nodes — all implement ExprNode.
+//
+// Grammar: PartiQLParser.g4 — `literal`, `dateLit`, `timeLit`, `timestampLit`,
+// `ionLit`. See docs/migration/partiql/analysis.md "Literals" sub-sections.
+// ---------------------------------------------------------------------------
+
+// StringLit represents a single-quoted string literal: 'hello'.
+//
+// Grammar: literal LITERAL_STRING
+type StringLit struct {
+	Val string // unescaped string content
+	Loc Loc
+}
+
+func (*StringLit) nodeTag()      {}
+func (n *StringLit) GetLoc() Loc { return n.Loc }
+func (*StringLit) exprNode()     {}
+
+// NumberLit represents a numeric literal. Val stores the raw text to
+// preserve the original representation (integer vs decimal vs scientific).
+//
+// Grammar: literal LITERAL_INTEGER | LITERAL_DECIMAL
+type NumberLit struct {
+	Val string // raw text as it appears in source
+	Loc Loc
+}
+
+func (*NumberLit) nodeTag()      {}
+func (n *NumberLit) GetLoc() Loc { return n.Loc }
+func (*NumberLit) exprNode()     {}
+
+// BoolLit represents TRUE or FALSE.
+//
+// Grammar: literal TRUE | FALSE
+type BoolLit struct {
+	Val bool
+	Loc Loc
+}
+
+func (*BoolLit) nodeTag()      {}
+func (n *BoolLit) GetLoc() Loc { return n.Loc }
+func (*BoolLit) exprNode()     {}
+
+// NullLit represents NULL.
+//
+// Grammar: literal NULL
+type NullLit struct {
+	Loc Loc
+}
+
+func (*NullLit) nodeTag()      {}
+func (n *NullLit) GetLoc() Loc { return n.Loc }
+func (*NullLit) exprNode()     {}
+
+// MissingLit represents the PartiQL-distinct MISSING value.
+//
+// Grammar: literal MISSING
+type MissingLit struct {
+	Loc Loc
+}
+
+func (*MissingLit) nodeTag()      {}
+func (n *MissingLit) GetLoc() Loc { return n.Loc }
+func (*MissingLit) exprNode()     {}
+
+// DateLit represents `DATE 'YYYY-MM-DD'`.
+//
+// Grammar: dateLit DATE LITERAL_STRING
+type DateLit struct {
+	Val string // YYYY-MM-DD body
+	Loc Loc
+}
+
+func (*DateLit) nodeTag()      {}
+func (n *DateLit) GetLoc() Loc { return n.Loc }
+func (*DateLit) exprNode()     {}
+
+// TimeLit represents `TIME [(p)] [WITH TIME ZONE] 'HH:MM:SS[.frac]'`.
+//
+// Grammar: timeLit TIME (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
+//
+//	(WITH TIME ZONE)? LITERAL_STRING
+type TimeLit struct {
+	Val          string // HH:MM:SS[.frac] body
+	Precision    *int   // optional fractional-seconds precision
+	WithTimeZone bool   // WITH TIME ZONE clause present
+	Loc          Loc
+}
+
+func (*TimeLit) nodeTag()      {}
+func (n *TimeLit) GetLoc() Loc { return n.Loc }
+func (*TimeLit) exprNode()     {}
+
+// TimestampLit represents `TIMESTAMP [(p)] [WITH TIME ZONE] '…'`.
+//
+// Grammar: timestampLit TIMESTAMP (PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT)?
+//
+//	(WITH TIME ZONE)? LITERAL_STRING
+type TimestampLit struct {
+	Val          string
+	Precision    *int
+	WithTimeZone bool
+	Loc          Loc
+}
+
+func (*TimestampLit) nodeTag()      {}
+func (n *TimestampLit) GetLoc() Loc { return n.Loc }
+func (*TimestampLit) exprNode()     {}
+
+// IonLit represents a backtick-delimited inline Ion value: `…`.
+// Text holds the verbatim contents between the backticks (no parsing,
+// no normalization). PartiQL-unique.
+//
+// Grammar: ionLit ION_LITERAL
+type IonLit struct {
+	Text string
+	Loc  Loc
+}
+
+func (*IonLit) nodeTag()      {}
+func (n *IonLit) GetLoc() Loc { return n.Loc }
+func (*IonLit) exprNode()     {}

--- a/partiql/ast/node.go
+++ b/partiql/ast/node.go
@@ -1,0 +1,101 @@
+// Package ast defines parse-tree node types for the omni PartiQL parser.
+//
+// PartiQL is the SQL++-flavored query language used by AWS DynamoDB and
+// Azure Cosmos DB. This package mirrors the legacy bytebase/parser/partiql
+// ANTLR grammar's full coverage scope (see docs/migration/partiql/analysis.md
+// and docs/migration/partiql/dag.md).
+//
+// AST style: sealed sub-interfaces. Every node implements Node; most also
+// implement one or more of StmtNode, ExprNode, TableExpr, PathStep, TypeName,
+// or PatternNode for compile-time position discipline. A handful of small
+// clause helpers (e.g. TargetEntry, CaseWhen) are bare Node.
+//
+// See docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md for the
+// design rationale.
+package ast
+
+// Loc is a half-open byte range describing where a node appears in the
+// original source text. Loc{-1, -1} means the position is unknown
+// (synthetic nodes constructed post-parse).
+type Loc struct {
+	Start int // inclusive byte offset
+	End   int // exclusive byte offset
+}
+
+// Node is the root interface for all PartiQL parse-tree nodes.
+//
+// Implementations carry a Loc field and expose it via GetLoc. The
+// unexported nodeTag method seals the interface so only types in this
+// package can implement it.
+type Node interface {
+	nodeTag()
+	GetLoc() Loc
+}
+
+// StmtNode marks top-level statement nodes — SELECT, INSERT, CREATE TABLE,
+// EXEC, EXPLAIN, etc. Anything that can appear at script-statement position.
+type StmtNode interface {
+	Node
+	stmtNode()
+}
+
+// ExprNode marks scalar-position expression nodes — operators, predicates,
+// function calls, literals, paths, variables, subqueries, etc.
+type ExprNode interface {
+	Node
+	exprNode()
+}
+
+// TableExpr marks nodes that appear in FROM position — table references,
+// aliased sources, joins, unpivot.
+//
+// PathExpr, VarRef, and SubLink (defined in exprs.go) deliberately also
+// implement TableExpr because PartiQL's grammar lets the same productions
+// (path navigation, identifiers, parenthesized SELECTs) appear in both
+// scalar and FROM position. See tableexprs.go for details.
+type TableExpr interface {
+	Node
+	tableExpr()
+}
+
+// PathStep marks a single step in a PartiQL path expression:
+// .field, .*, [expr], [*]. Path steps are chained inside a PathExpr.
+type PathStep interface {
+	Node
+	pathStep()
+}
+
+// TypeName marks a PartiQL type reference, used by CAST and DDL.
+// PartiQL's type system is small enough that a single concrete TypeRef
+// implementation in types.go covers everything.
+type TypeName interface {
+	Node
+	typeName()
+}
+
+// PatternNode marks GPML graph-match pattern nodes — node patterns,
+// edge patterns, quantifiers, selectors.
+type PatternNode interface {
+	Node
+	patternNode()
+}
+
+// List is a generic ordered collection of nodes used as a building block
+// for cases where the elements are heterogeneous. Most parser-side lists
+// use a typed slice (e.g. []ExprNode, []*TargetEntry) instead; List exists
+// primarily so NodeToString has a uniform way to dump heterogenous groups.
+type List struct {
+	Items []Node
+	Loc   Loc
+}
+
+func (*List) nodeTag()      {}
+func (l *List) GetLoc() Loc { return l.Loc }
+
+// Len returns the number of items in the list, treating a nil receiver as 0.
+func (l *List) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.Items)
+}

--- a/partiql/ast/outfuncs.go
+++ b/partiql/ast/outfuncs.go
@@ -1,0 +1,806 @@
+package ast
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// NodeToString returns a deterministic textual dump of any AST node.
+// The format is Go-struct-like for readability:
+//
+//	BinaryExpr{Op:+ Left:VarRef{Name:a} Right:NumberLit{Val:1}}
+//
+// Loc fields are not dumped (positions are tested separately by
+// TestGetLoc). For nil input, returns "<nil>".
+//
+// Used by ast_test.go for snapshot-style assertions and by future
+// parser golden tests.
+func NodeToString(n Node) string {
+	if n == nil {
+		return "<nil>"
+	}
+	var sb strings.Builder
+	writeNode(&sb, n)
+	return sb.String()
+}
+
+// writeNode dispatches on the concrete node type and appends a
+// textual representation to sb.
+func writeNode(sb *strings.Builder, n Node) {
+	if n == nil {
+		sb.WriteString("<nil>")
+		return
+	}
+	// Detect typed-nil pointers (e.g. (*VarRef)(nil) wrapped in a Node
+	// interface). The plain `n == nil` check above only catches an
+	// untyped nil interface.
+	if rv := reflect.ValueOf(n); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		sb.WriteString("<nil>")
+		return
+	}
+	switch v := n.(type) {
+
+	// -----------------------------------------------------------------------
+	// node.go
+	// -----------------------------------------------------------------------
+	case *List:
+		sb.WriteString("List{Items:[")
+		for i, item := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, item)
+		}
+		sb.WriteString("]}")
+
+	// -----------------------------------------------------------------------
+	// literals.go
+	// -----------------------------------------------------------------------
+	case *StringLit:
+		fmt.Fprintf(sb, "StringLit{Val:%q}", v.Val)
+	case *NumberLit:
+		fmt.Fprintf(sb, "NumberLit{Val:%s}", v.Val)
+	case *BoolLit:
+		fmt.Fprintf(sb, "BoolLit{Val:%t}", v.Val)
+	case *NullLit:
+		sb.WriteString("NullLit{}")
+	case *MissingLit:
+		sb.WriteString("MissingLit{}")
+	case *DateLit:
+		fmt.Fprintf(sb, "DateLit{Val:%s}", v.Val)
+	case *TimeLit:
+		sb.WriteString("TimeLit{Val:")
+		sb.WriteString(v.Val)
+		if v.Precision != nil {
+			fmt.Fprintf(sb, " Precision:%d", *v.Precision)
+		}
+		if v.WithTimeZone {
+			sb.WriteString(" WithTimeZone:true")
+		}
+		sb.WriteString("}")
+	case *IonLit:
+		fmt.Fprintf(sb, "IonLit{Text:%q}", v.Text)
+
+	// -----------------------------------------------------------------------
+	// exprs.go — operators and predicates
+	// -----------------------------------------------------------------------
+	case *BinaryExpr:
+		fmt.Fprintf(sb, "BinaryExpr{Op:%s Left:", v.Op)
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		sb.WriteString("}")
+	case *UnaryExpr:
+		fmt.Fprintf(sb, "UnaryExpr{Op:%s Operand:", v.Op)
+		writeNode(sb, v.Operand)
+		sb.WriteString("}")
+	case *InExpr:
+		sb.WriteString("InExpr{Expr:")
+		writeNode(sb, v.Expr)
+		if v.Subquery != nil {
+			sb.WriteString(" Subquery:")
+			writeNode(sb, v.Subquery)
+		} else {
+			sb.WriteString(" List:[")
+			for i, e := range v.List {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, e)
+			}
+			sb.WriteString("]")
+		}
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
+	case *BetweenExpr:
+		sb.WriteString("BetweenExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" Low:")
+		writeNode(sb, v.Low)
+		sb.WriteString(" High:")
+		writeNode(sb, v.High)
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
+	case *LikeExpr:
+		sb.WriteString("LikeExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" Pattern:")
+		writeNode(sb, v.Pattern)
+		if v.Escape != nil {
+			sb.WriteString(" Escape:")
+			writeNode(sb, v.Escape)
+		}
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
+	case *IsExpr:
+		sb.WriteString("IsExpr{Expr:")
+		writeNode(sb, v.Expr)
+		fmt.Fprintf(sb, " Type:%s Not:%t}", v.Type, v.Not)
+
+	// -----------------------------------------------------------------------
+	// exprs.go — special-form expressions
+	// -----------------------------------------------------------------------
+	case *FuncCall:
+		fmt.Fprintf(sb, "FuncCall{Name:%s", v.Name)
+		if v.Quantifier != QuantifierNone {
+			fmt.Fprintf(sb, " Quantifier:%s", v.Quantifier)
+		}
+		if v.Star {
+			sb.WriteString(" Star:true")
+		}
+		sb.WriteString(" Args:[")
+		for i, a := range v.Args {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, a)
+		}
+		sb.WriteString("]")
+		if v.Over != nil {
+			sb.WriteString(" Over:")
+			writeNode(sb, v.Over)
+		}
+		sb.WriteString("}")
+	case *CaseExpr:
+		sb.WriteString("CaseExpr{")
+		if v.Operand != nil {
+			sb.WriteString("Operand:")
+			writeNode(sb, v.Operand)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("Whens:[")
+		for i, w := range v.Whens {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, w)
+		}
+		sb.WriteString("]")
+		if v.Else != nil {
+			sb.WriteString(" Else:")
+			writeNode(sb, v.Else)
+		}
+		sb.WriteString("}")
+	case *CaseWhen:
+		sb.WriteString("CaseWhen{When:")
+		writeNode(sb, v.When)
+		sb.WriteString(" Then:")
+		writeNode(sb, v.Then)
+		sb.WriteString("}")
+	case *CastExpr:
+		fmt.Fprintf(sb, "CastExpr{Kind:%s Expr:", v.Kind)
+		writeNode(sb, v.Expr)
+		sb.WriteString(" AsType:")
+		writeNode(sb, v.AsType)
+		sb.WriteString("}")
+	case *ExtractExpr:
+		fmt.Fprintf(sb, "ExtractExpr{Field:%s From:", v.Field)
+		writeNode(sb, v.From)
+		sb.WriteString("}")
+	case *TrimExpr:
+		sb.WriteString("TrimExpr{")
+		if v.Spec != TrimSpecNone {
+			fmt.Fprintf(sb, "Spec:%s ", v.Spec)
+		}
+		if v.Sub != nil {
+			sb.WriteString("Sub:")
+			writeNode(sb, v.Sub)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("From:")
+		writeNode(sb, v.From)
+		sb.WriteString("}")
+	case *SubstringExpr:
+		sb.WriteString("SubstringExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" From:")
+		writeNode(sb, v.From)
+		if v.For != nil {
+			sb.WriteString(" For:")
+			writeNode(sb, v.For)
+		}
+		sb.WriteString("}")
+	case *CoalesceExpr:
+		sb.WriteString("CoalesceExpr{Args:[")
+		for i, a := range v.Args {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, a)
+		}
+		sb.WriteString("]}")
+	case *NullIfExpr:
+		sb.WriteString("NullIfExpr{Left:")
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		sb.WriteString("}")
+	case *WindowSpec:
+		sb.WriteString("WindowSpec{PartitionBy:[")
+		for i, e := range v.PartitionBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, e)
+		}
+		sb.WriteString("] OrderBy:[")
+		for i, o := range v.OrderBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o)
+		}
+		sb.WriteString("]}")
+
+	// -----------------------------------------------------------------------
+	// exprs.go — paths, vars, params, subqueries
+	// -----------------------------------------------------------------------
+	case *PathExpr:
+		sb.WriteString("PathExpr{Root:")
+		writeNode(sb, v.Root)
+		sb.WriteString(" Steps:[")
+		for i, s := range v.Steps {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, s)
+		}
+		sb.WriteString("]}")
+	case *VarRef:
+		fmt.Fprintf(sb, "VarRef{Name:%s", v.Name)
+		if v.AtPrefixed {
+			sb.WriteString(" AtPrefixed:true")
+		}
+		if v.CaseSensitive {
+			sb.WriteString(" CaseSensitive:true")
+		}
+		sb.WriteString("}")
+	case *ParamRef:
+		sb.WriteString("ParamRef{}")
+	case *SubLink:
+		sb.WriteString("SubLink{Stmt:")
+		writeNode(sb, v.Stmt)
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// exprs.go — collection literals
+	// -----------------------------------------------------------------------
+	case *ListLit:
+		sb.WriteString("ListLit{Items:[")
+		for i, e := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, e)
+		}
+		sb.WriteString("]}")
+	case *BagLit:
+		sb.WriteString("BagLit{Items:[")
+		for i, e := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, e)
+		}
+		sb.WriteString("]}")
+	case *TupleLit:
+		sb.WriteString("TupleLit{Pairs:[")
+		for i, p := range v.Pairs {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *TuplePair:
+		sb.WriteString("TuplePair{Key:")
+		writeNode(sb, v.Key)
+		sb.WriteString(" Value:")
+		writeNode(sb, v.Value)
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// exprs.go — path steps
+	// -----------------------------------------------------------------------
+	case *DotStep:
+		fmt.Fprintf(sb, "DotStep{Field:%s", v.Field)
+		if v.CaseSensitive {
+			sb.WriteString(" CaseSensitive:true")
+		}
+		sb.WriteString("}")
+	case *AllFieldsStep:
+		sb.WriteString("AllFieldsStep{}")
+	case *IndexStep:
+		sb.WriteString("IndexStep{Index:")
+		writeNode(sb, v.Index)
+		sb.WriteString("}")
+	case *WildcardStep:
+		sb.WriteString("WildcardStep{}")
+
+	// -----------------------------------------------------------------------
+	// tableexprs.go
+	// -----------------------------------------------------------------------
+	case *TableRef:
+		fmt.Fprintf(sb, "TableRef{Name:%s", v.Name)
+		if v.Schema != "" {
+			fmt.Fprintf(sb, " Schema:%s", v.Schema)
+		}
+		if v.CaseSensitive {
+			sb.WriteString(" CaseSensitive:true")
+		}
+		sb.WriteString("}")
+	case *AliasedSource:
+		sb.WriteString("AliasedSource{Source:")
+		writeNode(sb, v.Source)
+		writeOptString(sb, " As:", v.As)
+		writeOptString(sb, " At:", v.At)
+		writeOptString(sb, " By:", v.By)
+		sb.WriteString("}")
+	case *JoinExpr:
+		fmt.Fprintf(sb, "JoinExpr{Kind:%s Left:", v.Kind)
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		if v.On != nil {
+			sb.WriteString(" On:")
+			writeNode(sb, v.On)
+		}
+		sb.WriteString("}")
+	case *UnpivotExpr:
+		sb.WriteString("UnpivotExpr{Source:")
+		writeNode(sb, v.Source)
+		writeOptString(sb, " As:", v.As)
+		writeOptString(sb, " At:", v.At)
+		writeOptString(sb, " By:", v.By)
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// types.go
+	// -----------------------------------------------------------------------
+	case *TypeRef:
+		fmt.Fprintf(sb, "TypeRef{Name:%s", v.Name)
+		if len(v.Args) > 0 {
+			sb.WriteString(" Args:[")
+			for i, a := range v.Args {
+				if i > 0 {
+					sb.WriteString(",")
+				}
+				sb.WriteString(strconv.Itoa(a))
+			}
+			sb.WriteString("]")
+		}
+		if v.WithTimeZone {
+			sb.WriteString(" WithTimeZone:true")
+		}
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// stmts.go — top-level statements
+	// -----------------------------------------------------------------------
+	case *SelectStmt:
+		writeSelectStmt(sb, v)
+	case *SetOpStmt:
+		fmt.Fprintf(sb, "SetOpStmt{Op:%s", v.Op)
+		if v.Quantifier != QuantifierNone {
+			fmt.Fprintf(sb, " Quantifier:%s", v.Quantifier)
+		}
+		if v.Outer {
+			sb.WriteString(" Outer:true")
+		}
+		sb.WriteString(" Left:")
+		writeNode(sb, v.Left)
+		sb.WriteString(" Right:")
+		writeNode(sb, v.Right)
+		sb.WriteString("}")
+	case *ExplainStmt:
+		sb.WriteString("ExplainStmt{Inner:")
+		writeNode(sb, v.Inner)
+		sb.WriteString("}")
+	case *InsertStmt:
+		writeDmlStmt(sb, "InsertStmt", v.Target, v.AsAlias, v.Value, v.Pos, v.OnConflict, v.Returning)
+	case *UpdateStmt:
+		sb.WriteString("UpdateStmt{Source:")
+		writeNode(sb, v.Source)
+		sb.WriteString(" Sets:[")
+		for i, s := range v.Sets {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, s)
+		}
+		sb.WriteString("]")
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		if v.Returning != nil {
+			sb.WriteString(" Returning:")
+			writeNode(sb, v.Returning)
+		}
+		sb.WriteString("}")
+	case *DeleteStmt:
+		sb.WriteString("DeleteStmt{Source:")
+		writeNode(sb, v.Source)
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		if v.Returning != nil {
+			sb.WriteString(" Returning:")
+			writeNode(sb, v.Returning)
+		}
+		sb.WriteString("}")
+	case *UpsertStmt:
+		writeDmlStmt(sb, "UpsertStmt", v.Target, v.AsAlias, v.Value, nil, v.OnConflict, v.Returning)
+	case *ReplaceStmt:
+		writeDmlStmt(sb, "ReplaceStmt", v.Target, v.AsAlias, v.Value, nil, v.OnConflict, v.Returning)
+	case *RemoveStmt:
+		sb.WriteString("RemoveStmt{Path:")
+		writeNode(sb, v.Path)
+		sb.WriteString("}")
+	case *CreateTableStmt:
+		sb.WriteString("CreateTableStmt{Name:")
+		writeNode(sb, v.Name)
+		sb.WriteString("}")
+	case *CreateIndexStmt:
+		sb.WriteString("CreateIndexStmt{Table:")
+		writeNode(sb, v.Table)
+		sb.WriteString(" Paths:[")
+		for i, p := range v.Paths {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *DropTableStmt:
+		sb.WriteString("DropTableStmt{Name:")
+		writeNode(sb, v.Name)
+		sb.WriteString("}")
+	case *DropIndexStmt:
+		sb.WriteString("DropIndexStmt{Index:")
+		writeNode(sb, v.Index)
+		sb.WriteString(" Table:")
+		writeNode(sb, v.Table)
+		sb.WriteString("}")
+	case *ExecStmt:
+		sb.WriteString("ExecStmt{Name:")
+		writeNode(sb, v.Name)
+		sb.WriteString(" Args:[")
+		for i, a := range v.Args {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, a)
+		}
+		sb.WriteString("]}")
+
+	// -----------------------------------------------------------------------
+	// stmts.go — clause and DML helpers
+	// -----------------------------------------------------------------------
+	case *TargetEntry:
+		sb.WriteString("TargetEntry{Expr:")
+		writeNode(sb, v.Expr)
+		writeOptString(sb, " Alias:", v.Alias)
+		sb.WriteString("}")
+	case *PivotProjection:
+		sb.WriteString("PivotProjection{Value:")
+		writeNode(sb, v.Value)
+		sb.WriteString(" At:")
+		writeNode(sb, v.At)
+		sb.WriteString("}")
+	case *LetBinding:
+		sb.WriteString("LetBinding{Expr:")
+		writeNode(sb, v.Expr)
+		fmt.Fprintf(sb, " Alias:%s}", v.Alias)
+	case *GroupByClause:
+		sb.WriteString("GroupByClause{")
+		if v.Partial {
+			sb.WriteString("Partial:true ")
+		}
+		sb.WriteString("Items:[")
+		for i, it := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, it)
+		}
+		sb.WriteString("]")
+		writeOptString(sb, " GroupAs:", v.GroupAs)
+		sb.WriteString("}")
+	case *GroupByItem:
+		sb.WriteString("GroupByItem{Expr:")
+		writeNode(sb, v.Expr)
+		writeOptString(sb, " Alias:", v.Alias)
+		sb.WriteString("}")
+	case *OrderByItem:
+		sb.WriteString("OrderByItem{Expr:")
+		writeNode(sb, v.Expr)
+		fmt.Fprintf(sb, " Desc:%t", v.Desc)
+		if v.NullsExplicit {
+			fmt.Fprintf(sb, " NullsFirst:%t", v.NullsFirst)
+		}
+		sb.WriteString("}")
+	case *SetAssignment:
+		sb.WriteString("SetAssignment{Target:")
+		writeNode(sb, v.Target)
+		sb.WriteString(" Value:")
+		writeNode(sb, v.Value)
+		sb.WriteString("}")
+	case *OnConflict:
+		sb.WriteString("OnConflict{")
+		if v.Target != nil {
+			sb.WriteString("Target:")
+			writeNode(sb, v.Target)
+			sb.WriteString(" ")
+		}
+		fmt.Fprintf(sb, "Action:%s", v.Action)
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		sb.WriteString("}")
+	case *OnConflictTarget:
+		sb.WriteString("OnConflictTarget{")
+		if v.ConstraintName != "" {
+			fmt.Fprintf(sb, "ConstraintName:%s", v.ConstraintName)
+		} else {
+			sb.WriteString("Cols:[")
+			for i, c := range v.Cols {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, c)
+			}
+			sb.WriteString("]")
+		}
+		sb.WriteString("}")
+	case *ReturningClause:
+		sb.WriteString("ReturningClause{Items:[")
+		for i, it := range v.Items {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, it)
+		}
+		sb.WriteString("]}")
+	case *ReturningItem:
+		fmt.Fprintf(sb, "ReturningItem{Status:%s Mapping:%s", v.Status, v.Mapping)
+		if v.Star {
+			sb.WriteString(" Star:true")
+		}
+		if v.Expr != nil {
+			sb.WriteString(" Expr:")
+			writeNode(sb, v.Expr)
+		}
+		sb.WriteString("}")
+
+	// -----------------------------------------------------------------------
+	// patterns.go
+	// -----------------------------------------------------------------------
+	case *MatchExpr:
+		sb.WriteString("MatchExpr{Expr:")
+		writeNode(sb, v.Expr)
+		sb.WriteString(" Patterns:[")
+		for i, p := range v.Patterns {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *GraphPattern:
+		sb.WriteString("GraphPattern{")
+		if v.Selector != nil {
+			sb.WriteString("Selector:")
+			writeNode(sb, v.Selector)
+			sb.WriteString(" ")
+		}
+		if v.Restrictor != PatternRestrictorNone {
+			fmt.Fprintf(sb, "Restrictor:%s ", v.Restrictor)
+		}
+		if v.Variable != nil {
+			sb.WriteString("Variable:")
+			writeNode(sb, v.Variable)
+			sb.WriteString(" ")
+		}
+		sb.WriteString("Parts:[")
+		for i, p := range v.Parts {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, p)
+		}
+		sb.WriteString("]}")
+	case *NodePattern:
+		sb.WriteString("NodePattern{")
+		first := true
+		sep := func() {
+			if !first {
+				sb.WriteString(" ")
+			}
+			first = false
+		}
+		if v.Variable != nil {
+			sep()
+			sb.WriteString("Variable:")
+			writeNode(sb, v.Variable)
+		}
+		if len(v.Labels) > 0 {
+			sep()
+			fmt.Fprintf(sb, "Labels:[%s]", strings.Join(v.Labels, " "))
+		}
+		if v.Where != nil {
+			sep()
+			sb.WriteString("Where:")
+			writeNode(sb, v.Where)
+		}
+		sb.WriteString("}")
+	case *EdgePattern:
+		fmt.Fprintf(sb, "EdgePattern{Direction:%s", v.Direction)
+		if v.Variable != nil {
+			sb.WriteString(" Variable:")
+			writeNode(sb, v.Variable)
+		}
+		if len(v.Labels) > 0 {
+			fmt.Fprintf(sb, " Labels:[%s]", strings.Join(v.Labels, " "))
+		}
+		if v.Where != nil {
+			sb.WriteString(" Where:")
+			writeNode(sb, v.Where)
+		}
+		if v.Quantifier != nil {
+			sb.WriteString(" Quantifier:")
+			writeNode(sb, v.Quantifier)
+		}
+		sb.WriteString("}")
+	case *PatternQuantifier:
+		fmt.Fprintf(sb, "PatternQuantifier{Min:%d Max:%d}", v.Min, v.Max)
+	case *PatternSelector:
+		fmt.Fprintf(sb, "PatternSelector{Kind:%s", v.Kind)
+		if v.Kind == SelectorKindShortestK {
+			fmt.Fprintf(sb, " K:%d", v.K)
+		}
+		sb.WriteString("}")
+
+	default:
+		fmt.Fprintf(sb, "<unknown:%T>", v)
+	}
+}
+
+// writeSelectStmt is split out because SelectStmt has 13 fields and would
+// dominate the main switch arm.
+func writeSelectStmt(sb *strings.Builder, s *SelectStmt) {
+	sb.WriteString("SelectStmt{")
+	first := true
+	add := func(label string) {
+		if !first {
+			sb.WriteString(" ")
+		}
+		first = false
+		sb.WriteString(label)
+	}
+	if s.Quantifier != QuantifierNone {
+		add(fmt.Sprintf("Quantifier:%s", s.Quantifier))
+	}
+	if s.Star {
+		add("Star:true")
+	}
+	if s.Value != nil {
+		add("Value:")
+		writeNode(sb, s.Value)
+	}
+	if s.Pivot != nil {
+		add("Pivot:")
+		writeNode(sb, s.Pivot)
+	}
+	if len(s.Targets) > 0 {
+		add("Targets:[")
+		for i, t := range s.Targets {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, t)
+		}
+		sb.WriteString("]")
+	}
+	if s.From != nil {
+		add("From:")
+		writeNode(sb, s.From)
+	}
+	if len(s.Let) > 0 {
+		add("Let:[")
+		for i, l := range s.Let {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, l)
+		}
+		sb.WriteString("]")
+	}
+	if s.Where != nil {
+		add("Where:")
+		writeNode(sb, s.Where)
+	}
+	if s.GroupBy != nil {
+		add("GroupBy:")
+		writeNode(sb, s.GroupBy)
+	}
+	if s.Having != nil {
+		add("Having:")
+		writeNode(sb, s.Having)
+	}
+	if len(s.OrderBy) > 0 {
+		add("OrderBy:[")
+		for i, o := range s.OrderBy {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o)
+		}
+		sb.WriteString("]")
+	}
+	if s.Limit != nil {
+		add("Limit:")
+		writeNode(sb, s.Limit)
+	}
+	if s.Offset != nil {
+		add("Offset:")
+		writeNode(sb, s.Offset)
+	}
+	sb.WriteString("}")
+}
+
+// writeDmlStmt is shared by InsertStmt, UpsertStmt, and ReplaceStmt — they
+// have nearly the same shape (target, alias, value, pos, on-conflict,
+// returning). For UpsertStmt and ReplaceStmt, callers pass nil for pos
+// because the grammar's `replaceCommand` (line 121) and `upsertCommand`
+// (line 125) do not have an `AT pos` clause.
+func writeDmlStmt(sb *strings.Builder, name string, target TableExpr, alias *string, value ExprNode, pos ExprNode, oc *OnConflict, ret *ReturningClause) {
+	fmt.Fprintf(sb, "%s{Target:", name)
+	writeNode(sb, target)
+	writeOptString(sb, " AsAlias:", alias)
+	sb.WriteString(" Value:")
+	writeNode(sb, value)
+	if pos != nil {
+		sb.WriteString(" Pos:")
+		writeNode(sb, pos)
+	}
+	if oc != nil {
+		sb.WriteString(" OnConflict:")
+		writeNode(sb, oc)
+	}
+	if ret != nil {
+		sb.WriteString(" Returning:")
+		writeNode(sb, ret)
+	}
+	sb.WriteString("}")
+}
+
+// writeOptString appends a label + value if the optional string is non-nil.
+func writeOptString(sb *strings.Builder, label string, s *string) {
+	if s == nil {
+		return
+	}
+	sb.WriteString(label)
+	sb.WriteString(*s)
+}

--- a/partiql/ast/outfuncs.go
+++ b/partiql/ast/outfuncs.go
@@ -36,7 +36,7 @@ func writeNode(sb *strings.Builder, n Node) {
 	// Detect typed-nil pointers (e.g. (*VarRef)(nil) wrapped in a Node
 	// interface). The plain `n == nil` check above only catches an
 	// untyped nil interface.
-	if rv := reflect.ValueOf(n); rv.Kind() == reflect.Ptr && rv.IsNil() {
+	if rv := reflect.ValueOf(n); rv.Kind() == reflect.Pointer && rv.IsNil() {
 		sb.WriteString("<nil>")
 		return
 	}

--- a/partiql/ast/patterns.go
+++ b/partiql/ast/patterns.go
@@ -34,15 +34,18 @@ package ast
 // EdgeDirection identifies the direction of an edge pattern.
 type EdgeDirection int
 
+// EdgeDirection enumerates the seven edge alternatives from PartiQLParser.g4
+// `edgeWSpec` (lines 360–368) and `edgeAbbrev` (lines 376–381). Each value
+// maps to the bare grammar symbol via String().
 const (
-	EdgeDirInvalid           EdgeDirection = iota
-	EdgeDirRight                           // ->
-	EdgeDirLeft                            // <-
-	EdgeDirUndirected                      // ~
-	EdgeDirLeftOrRight                     // <-> (left or right)
-	EdgeDirLeftOrUndirected                // <~
-	EdgeDirRightOrUndirected               // ~>
-	EdgeDirAny                             // any direction
+	EdgeDirInvalid              EdgeDirection = iota
+	EdgeDirRight                              // ->          edgeWSpec#EdgeSpecRight
+	EdgeDirLeft                               // <-          edgeWSpec#EdgeSpecLeft
+	EdgeDirUndirected                         // ~           edgeWSpec#EdgeSpecUndirected
+	EdgeDirLeftOrRight                        // <->         edgeWSpec#EdgeSpecBidirectional
+	EdgeDirLeftOrUndirected                   // <~          edgeWSpec#EdgeSpecUndirectedLeft
+	EdgeDirRightOrUndirected                  // ~>          edgeWSpec#EdgeSpecUndirectedRight
+	EdgeDirUndirectedBidirectional            // -           edgeWSpec#EdgeSpecUndirectedBidirectional (any of right/left/undirected)
 )
 
 func (d EdgeDirection) String() string {
@@ -59,8 +62,8 @@ func (d EdgeDirection) String() string {
 		return "<~"
 	case EdgeDirRightOrUndirected:
 		return "~>"
-	case EdgeDirAny:
-		return "any"
+	case EdgeDirUndirectedBidirectional:
+		return "-"
 	default:
 		return "INVALID"
 	}

--- a/partiql/ast/patterns.go
+++ b/partiql/ast/patterns.go
@@ -1,0 +1,205 @@
+package ast
+
+// ---------------------------------------------------------------------------
+// Graph Pattern Matching (GPML) nodes — implement PatternNode (or ExprNode
+// for the top-level MatchExpr container).
+//
+// PartiQL has a graph pattern matching extension based on GPML. The full
+// shape of the field set inside NodePattern/EdgePattern may be refined when
+// the parser-graph DAG node (node 16) is implemented and we read the grammar
+// more carefully. The marker interface, the node names, and the multi-interface
+// relationship to ExprNode are stable in this initial pass.
+//
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   gpmlPattern          (lines 315–316)
+//   gpmlPatternList      (lines 318–319)
+//   matchPattern         (lines 321–322)
+//   graphPart            (lines 324–328)
+//   matchSelector        (lines 330–334)
+//   patternPathVariable  (lines 336–337)
+//   patternRestrictor    (lines 339–340)
+//   node                 (lines 342–343)
+//   edge                 (lines 345–348)
+//   pattern              (lines 350–353)
+//   patternQuantifier    (lines 355–358)
+//   edgeWSpec            (lines 360–368)
+//   edgeSpec             (lines 370–371)
+//   patternPartLabel     (lines 373–374)
+//   edgeAbbrev           (lines 376–381)
+//   exprGraphMatchOne    (lines 628–629)
+//   exprGraphMatchMany   (lines 625–626)
+// Each type below cites its specific rule#Label.
+// ---------------------------------------------------------------------------
+
+// EdgeDirection identifies the direction of an edge pattern.
+type EdgeDirection int
+
+const (
+	EdgeDirInvalid           EdgeDirection = iota
+	EdgeDirRight                           // ->
+	EdgeDirLeft                            // <-
+	EdgeDirUndirected                      // ~
+	EdgeDirLeftOrRight                     // <-> (left or right)
+	EdgeDirLeftOrUndirected                // <~
+	EdgeDirRightOrUndirected               // ~>
+	EdgeDirAny                             // any direction
+)
+
+func (d EdgeDirection) String() string {
+	switch d {
+	case EdgeDirRight:
+		return "->"
+	case EdgeDirLeft:
+		return "<-"
+	case EdgeDirUndirected:
+		return "~"
+	case EdgeDirLeftOrRight:
+		return "<->"
+	case EdgeDirLeftOrUndirected:
+		return "<~"
+	case EdgeDirRightOrUndirected:
+		return "~>"
+	case EdgeDirAny:
+		return "any"
+	default:
+		return "INVALID"
+	}
+}
+
+// PatternRestrictor identifies the optional restrictor keyword on a graph pattern.
+type PatternRestrictor int
+
+const (
+	PatternRestrictorNone PatternRestrictor = iota
+	PatternRestrictorTrail
+	PatternRestrictorAcyclic
+	PatternRestrictorSimple
+)
+
+func (r PatternRestrictor) String() string {
+	switch r {
+	case PatternRestrictorTrail:
+		return "TRAIL"
+	case PatternRestrictorAcyclic:
+		return "ACYCLIC"
+	case PatternRestrictorSimple:
+		return "SIMPLE"
+	default:
+		return ""
+	}
+}
+
+// SelectorKind identifies the optional selector keyword on a graph pattern.
+type SelectorKind int
+
+const (
+	SelectorKindNone SelectorKind = iota
+	SelectorKindAny
+	SelectorKindAllShortest
+	SelectorKindShortestK
+)
+
+func (s SelectorKind) String() string {
+	switch s {
+	case SelectorKindAny:
+		return "ANY"
+	case SelectorKindAllShortest:
+		return "ALL_SHORTEST"
+	case SelectorKindShortestK:
+		return "SHORTEST_K"
+	default:
+		return ""
+	}
+}
+
+// MatchExpr is the top-level graph-match expression: MATCH(graph_expr, pattern, …).
+// Implements ExprNode because PartiQL embeds graph matching in expression
+// position (exprGraphMatchOne / exprGraphMatchMany rules).
+//
+// Grammar: exprGraphMatchOne, exprGraphMatchMany
+type MatchExpr struct {
+	Expr     ExprNode        // the graph-valued expression being matched
+	Patterns []*GraphPattern // one or more pattern alternatives
+	Loc      Loc
+}
+
+func (*MatchExpr) nodeTag()      {}
+func (n *MatchExpr) GetLoc() Loc { return n.Loc }
+func (*MatchExpr) exprNode()     {}
+
+// GraphPattern is one complete pattern: optional selector + restrictor +
+// path variable + a sequence of node/edge pattern parts.
+//
+// Grammar: gpmlPattern
+type GraphPattern struct {
+	Selector   *PatternSelector
+	Restrictor PatternRestrictor
+	Variable   *VarRef // optional `p = ...` path variable binding
+	Parts      []PatternNode
+	Loc        Loc
+}
+
+func (*GraphPattern) nodeTag()      {}
+func (n *GraphPattern) GetLoc() Loc { return n.Loc }
+func (*GraphPattern) patternNode()  {}
+
+// NodePattern represents `(var:Label WHERE …)`. Variable, Labels, and
+// Where are all optional.
+//
+// Grammar: node
+type NodePattern struct {
+	Variable *VarRef
+	Labels   []string
+	Where    ExprNode
+	Loc      Loc
+}
+
+func (*NodePattern) nodeTag()      {}
+func (n *NodePattern) GetLoc() Loc { return n.Loc }
+func (*NodePattern) patternNode()  {}
+
+// EdgePattern represents `-[var:Label]->`, `<-[]-`, `~[]~`, etc.
+// Direction is required; Variable, Labels, Where, and Quantifier are optional.
+//
+// Grammar: edge#EdgeWithSpec, edge#EdgeAbbreviated
+//
+//	(direction comes from edgeWSpec labels / edgeAbbrev; body from edgeSpec)
+type EdgePattern struct {
+	Direction  EdgeDirection
+	Variable   *VarRef
+	Labels     []string
+	Where      ExprNode
+	Quantifier *PatternQuantifier
+	Loc        Loc
+}
+
+func (*EdgePattern) nodeTag()      {}
+func (n *EdgePattern) GetLoc() Loc { return n.Loc }
+func (*EdgePattern) patternNode()  {}
+
+// PatternQuantifier represents the `+`, `*`, or `{m,n}` decorator on a
+// pattern part. Min and Max use -1 to indicate "unbounded".
+//
+// Grammar: patternQuantifier
+type PatternQuantifier struct {
+	Min int
+	Max int // -1 = unbounded
+	Loc Loc
+}
+
+func (*PatternQuantifier) nodeTag()      {}
+func (n *PatternQuantifier) GetLoc() Loc { return n.Loc }
+
+// PatternSelector represents the optional selector keyword on a graph
+// pattern: `ANY`, `ALL SHORTEST`, or `SHORTEST k`. K is non-zero only for
+// SHORTEST K.
+//
+// Grammar: matchSelector#SelectorBasic, matchSelector#SelectorAny, matchSelector#SelectorShortest
+type PatternSelector struct {
+	Kind SelectorKind
+	K    int
+	Loc  Loc
+}
+
+func (*PatternSelector) nodeTag()      {}
+func (n *PatternSelector) GetLoc() Loc { return n.Loc }

--- a/partiql/ast/patterns.go
+++ b/partiql/ast/patterns.go
@@ -38,14 +38,14 @@ type EdgeDirection int
 // `edgeWSpec` (lines 360–368) and `edgeAbbrev` (lines 376–381). Each value
 // maps to the bare grammar symbol via String().
 const (
-	EdgeDirInvalid              EdgeDirection = iota
-	EdgeDirRight                              // ->          edgeWSpec#EdgeSpecRight
-	EdgeDirLeft                               // <-          edgeWSpec#EdgeSpecLeft
-	EdgeDirUndirected                         // ~           edgeWSpec#EdgeSpecUndirected
-	EdgeDirLeftOrRight                        // <->         edgeWSpec#EdgeSpecBidirectional
-	EdgeDirLeftOrUndirected                   // <~          edgeWSpec#EdgeSpecUndirectedLeft
-	EdgeDirRightOrUndirected                  // ~>          edgeWSpec#EdgeSpecUndirectedRight
-	EdgeDirUndirectedBidirectional            // -           edgeWSpec#EdgeSpecUndirectedBidirectional (any of right/left/undirected)
+	EdgeDirInvalid                 EdgeDirection = iota
+	EdgeDirRight                                 // ->          edgeWSpec#EdgeSpecRight
+	EdgeDirLeft                                  // <-          edgeWSpec#EdgeSpecLeft
+	EdgeDirUndirected                            // ~           edgeWSpec#EdgeSpecUndirected
+	EdgeDirLeftOrRight                           // <->         edgeWSpec#EdgeSpecBidirectional
+	EdgeDirLeftOrUndirected                      // <~          edgeWSpec#EdgeSpecUndirectedLeft
+	EdgeDirRightOrUndirected                     // ~>          edgeWSpec#EdgeSpecUndirectedRight
+	EdgeDirUndirectedBidirectional               // -           edgeWSpec#EdgeSpecUndirectedBidirectional (any of right/left/undirected)
 )
 
 func (d EdgeDirection) String() string {

--- a/partiql/ast/stmts.go
+++ b/partiql/ast/stmts.go
@@ -1,0 +1,15 @@
+package ast
+
+// PLACEHOLDER — replaced in Task 8/9. The OrderByItem type is referenced
+// by WindowSpec in exprs.go (Task 4). Defining it here lets the package
+// build before its real home in stmts.go is written.
+type OrderByItem struct {
+	Expr          ExprNode
+	Desc          bool
+	NullsFirst    bool
+	NullsExplicit bool
+	Loc           Loc
+}
+
+func (*OrderByItem) nodeTag()      {}
+func (n *OrderByItem) GetLoc() Loc { return n.Loc }

--- a/partiql/ast/stmts.go
+++ b/partiql/ast/stmts.go
@@ -1,8 +1,10 @@
 package ast
 
-// PLACEHOLDER — replaced in Task 8/9. The OrderByItem type is referenced
-// by WindowSpec in exprs.go (Task 4). Defining it here lets the package
-// build before its real home in stmts.go is written.
+// PLACEHOLDER FILE — will be REPLACED WHOLESALE in Task 8/9. Do NOT
+// append new types here; instead, delete this file in Task 8 and author
+// the real stmts.go from scratch. This file exists only because
+// WindowSpec (in exprs.go, Task 4) has a forward reference to
+// OrderByItem, and the package must build between Task 4 and Task 8.
 type OrderByItem struct {
 	Expr          ExprNode
 	Desc          bool

--- a/partiql/ast/stmts.go
+++ b/partiql/ast/stmts.go
@@ -204,14 +204,24 @@ func (n *ExplainStmt) GetLoc() Loc { return n.Loc }
 func (*ExplainStmt) stmtNode()     {}
 
 // InsertStmt represents `INSERT INTO target [AS alias] VALUE expr
-// [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
-// (INSERT INTO p VALUE …) and RFC 0011 (INSERT INTO c AS a VALUE …) forms.
+// [AT pos] [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
+// (INSERT INTO p VALUE … [AT pos]) and RFC 0011 (INSERT INTO c AS a VALUE …)
+// forms.
+//
+// Mutual exclusion between the two forms:
+//   - Legacy form (insertCommand#InsertLegacy, insertCommandReturning):
+//     AsAlias is nil; Pos may be set.
+//   - RFC 0011 form (insertCommand#Insert): AsAlias may be set; Pos is nil.
+//   - The grammar's `insertCommandReturning` (line 130–131) is the only
+//     alternative that allows `RETURNING`; on `insertCommand#InsertLegacy`
+//     (line 134) and `insertCommand#Insert` (line 136), Returning is nil.
 //
 // Grammar: insertCommand#InsertLegacy, insertCommand#Insert, insertCommandReturning
 type InsertStmt struct {
 	Target     TableExpr
 	AsAlias    *string
 	Value      ExprNode
+	Pos        ExprNode // legacy `AT pos` clause; nil for RFC 0011 form
 	OnConflict *OnConflict
 	Returning  *ReturningClause
 	Loc        Loc
@@ -350,11 +360,14 @@ func (*DropIndexStmt) nodeTag()      {}
 func (n *DropIndexStmt) GetLoc() Loc { return n.Loc }
 func (*DropIndexStmt) stmtNode()     {}
 
-// ExecStmt represents `EXEC name [arg, arg, ...]`.
+// ExecStmt represents `EXEC name [arg, arg, ...]`. Per the grammar
+// (PartiQLParser.g4 line 65: `EXEC name=expr ...`), the procedure name
+// is itself an expression — typically a VarRef but may be any ExprNode
+// (e.g., a parameter `?`) so the AST keeps the full breadth.
 //
 // Grammar: execCommand
 type ExecStmt struct {
-	Name string
+	Name ExprNode
 	Args []ExprNode
 	Loc  Loc
 }

--- a/partiql/ast/stmts.go
+++ b/partiql/ast/stmts.go
@@ -1,10 +1,382 @@
 package ast
 
-// PLACEHOLDER FILE — will be REPLACED WHOLESALE in Task 8/9. Do NOT
-// append new types here; instead, delete this file in Task 8 and author
-// the real stmts.go from scratch. This file exists only because
-// WindowSpec (in exprs.go, Task 4) has a forward reference to
-// OrderByItem, and the package must build between Task 4 and Task 8.
+// ---------------------------------------------------------------------------
+// Statement nodes and supporting types.
+//
+// This file is built in two task groups:
+//   1. Top-level statements (this section): SELECT, set ops, EXPLAIN,
+//      DML, DDL, EXEC.
+//   2. Clause helpers: TargetEntry, GroupBy, OrderBy, OnConflict, Returning,
+//      etc. (Task 9 — appended below).
+//
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   root                   (lines 17–18)
+//   statement              (lines 20–25)
+//   dql                    (lines 55–56)
+//   dml                    (lines 94–100)
+//   dmlBaseCommand         (lines 102–108)
+//   ddl                    (lines 73–76)
+//   createCommand          (lines 78–81)
+//   dropCommand            (lines 83–86)
+//   execCommand            (lines 64–65)
+//   selectClause           (lines 216–221)
+//   exprBagOp              (lines 449–454)
+//   exprSelect             (lines 456–467)
+//   insertCommand          (lines 133–137)
+//   insertCommandReturning (lines 130–131)
+//   updateClause           (lines 182–183)
+//   deleteCommand          (lines 191–192)
+//   upsertCommand          (lines 124–125)
+//   replaceCommand         (lines 120–121)
+//   removeCommand          (lines 127–128)
+//   setCommand             (lines 185–186)
+// Each type below cites its specific rule#Label.
+// ---------------------------------------------------------------------------
+
+// ===========================================================================
+// Statement enums
+// ===========================================================================
+
+// SetOpKind identifies the set operation in SetOpStmt.
+type SetOpKind int
+
+const (
+	SetOpInvalid SetOpKind = iota
+	SetOpUnion
+	SetOpIntersect
+	SetOpExcept
+)
+
+func (k SetOpKind) String() string {
+	switch k {
+	case SetOpUnion:
+		return "UNION"
+	case SetOpIntersect:
+		return "INTERSECT"
+	case SetOpExcept:
+		return "EXCEPT"
+	default:
+		return "INVALID"
+	}
+}
+
+// OnConflictAction discriminates the body of an ON CONFLICT clause.
+// PartiQL's legacy ANTLR grammar leaves DO REPLACE/UPDATE as stubs that
+// only accept the EXCLUDED keyword (see doReplace/doUpdate rules in
+// PartiQLParser.g4 lines 168–180); the omni AST matches that scope.
+type OnConflictAction int
+
+const (
+	OnConflictInvalid OnConflictAction = iota
+	OnConflictDoNothing
+	OnConflictDoReplaceExcluded
+	OnConflictDoUpdateExcluded
+)
+
+func (a OnConflictAction) String() string {
+	switch a {
+	case OnConflictDoNothing:
+		return "DO_NOTHING"
+	case OnConflictDoReplaceExcluded:
+		return "DO_REPLACE_EXCLUDED"
+	case OnConflictDoUpdateExcluded:
+		return "DO_UPDATE_EXCLUDED"
+	default:
+		return "INVALID"
+	}
+}
+
+// ReturningStatus is the (MODIFIED|ALL) modifier on each RETURNING item.
+type ReturningStatus int
+
+const (
+	ReturningStatusInvalid ReturningStatus = iota
+	ReturningStatusModified
+	ReturningStatusAll
+)
+
+func (s ReturningStatus) String() string {
+	switch s {
+	case ReturningStatusModified:
+		return "MODIFIED"
+	case ReturningStatusAll:
+		return "ALL"
+	default:
+		return "INVALID"
+	}
+}
+
+// ReturningMapping is the (OLD|NEW) modifier on each RETURNING item.
+type ReturningMapping int
+
+const (
+	ReturningMappingInvalid ReturningMapping = iota
+	ReturningMappingOld
+	ReturningMappingNew
+)
+
+func (m ReturningMapping) String() string {
+	switch m {
+	case ReturningMappingOld:
+		return "OLD"
+	case ReturningMappingNew:
+		return "NEW"
+	default:
+		return "INVALID"
+	}
+}
+
+// ===========================================================================
+// Top-level statements — all implement StmtNode
+// ===========================================================================
+
+// SelectStmt is a single SELECT query (not a set-op combination — see
+// SetOpStmt for that). Carries the full clause set:
+//
+//	SELECT [DISTINCT|ALL] (* | items | VALUE expr | PIVOT v AT k)
+//	FROM ...
+//	[LET ...]
+//	[WHERE ...]
+//	[GROUP [PARTIAL] BY ... [GROUP AS alias]]
+//	[HAVING ...]
+//	[ORDER BY ...]
+//	[LIMIT ...]
+//	[OFFSET ...]
+//
+// Quantifier holds the optional DISTINCT/ALL modifier (NONE if absent).
+// Star is true for `SELECT *`. Value holds the expression for
+// `SELECT VALUE expr`. Pivot holds the PIVOT projection. At most one of
+// (Star, Value != nil, Pivot != nil, len(Targets) > 0) is set per instance.
+//
+// Grammar: exprSelect#SfwQuery (with selectClause#SelectAll / selectClause#SelectItems /
+//
+//	selectClause#SelectValue / selectClause#SelectPivot)
+type SelectStmt struct {
+	Quantifier QuantifierKind   // NONE / DISTINCT / ALL
+	Star       bool             // SELECT *
+	Value      ExprNode         // SELECT VALUE expr (PartiQL-unique)
+	Pivot      *PivotProjection // PIVOT v AT k (PartiQL-unique)
+	Targets    []*TargetEntry   // SELECT items
+	From       TableExpr        // FROM clause
+	Let        []*LetBinding    // LET bindings (PartiQL-unique)
+	Where      ExprNode
+	GroupBy    *GroupByClause
+	Having     ExprNode
+	OrderBy    []*OrderByItem
+	Limit      ExprNode
+	Offset     ExprNode
+	Loc        Loc
+}
+
+func (*SelectStmt) nodeTag()      {}
+func (n *SelectStmt) GetLoc() Loc { return n.Loc }
+func (*SelectStmt) stmtNode()     {}
+
+// SetOpStmt combines two queries with UNION/INTERSECT/EXCEPT.
+// Quantifier is the DISTINCT/ALL modifier; Outer is true for the
+// PartiQL-specific OUTER variant. Both Left and Right may themselves
+// be SetOpStmt nodes for nested set operations.
+//
+// Grammar: exprBagOp#Union, exprBagOp#Intersect, exprBagOp#Except
+type SetOpStmt struct {
+	Op         SetOpKind
+	Quantifier QuantifierKind
+	Outer      bool
+	Left       StmtNode
+	Right      StmtNode
+	Loc        Loc
+}
+
+func (*SetOpStmt) nodeTag()      {}
+func (n *SetOpStmt) GetLoc() Loc { return n.Loc }
+func (*SetOpStmt) stmtNode()     {}
+
+// ExplainStmt wraps any other StmtNode with an EXPLAIN prefix.
+//
+// Grammar: root (EXPLAIN prefix on the root rule)
+type ExplainStmt struct {
+	Inner StmtNode
+	Loc   Loc
+}
+
+func (*ExplainStmt) nodeTag()      {}
+func (n *ExplainStmt) GetLoc() Loc { return n.Loc }
+func (*ExplainStmt) stmtNode()     {}
+
+// InsertStmt represents `INSERT INTO target [AS alias] VALUE expr
+// [ON CONFLICT ...] [RETURNING ...]`. Covers both legacy
+// (INSERT INTO p VALUE …) and RFC 0011 (INSERT INTO c AS a VALUE …) forms.
+//
+// Grammar: insertCommand#InsertLegacy, insertCommand#Insert, insertCommandReturning
+type InsertStmt struct {
+	Target     TableExpr
+	AsAlias    *string
+	Value      ExprNode
+	OnConflict *OnConflict
+	Returning  *ReturningClause
+	Loc        Loc
+}
+
+func (*InsertStmt) nodeTag()      {}
+func (n *InsertStmt) GetLoc() Loc { return n.Loc }
+func (*InsertStmt) stmtNode()     {}
+
+// UpdateStmt represents `UPDATE source SET ... [WHERE ...] [RETURNING ...]`
+// and the equivalent `FROM source SET ...` form.
+//
+// Grammar: updateClause, dml#DmlBaseWrapper (with dmlBaseCommand containing setCommand)
+type UpdateStmt struct {
+	Source    TableExpr
+	Sets      []*SetAssignment
+	Where     ExprNode
+	Returning *ReturningClause
+	Loc       Loc
+}
+
+func (*UpdateStmt) nodeTag()      {}
+func (n *UpdateStmt) GetLoc() Loc { return n.Loc }
+func (*UpdateStmt) stmtNode()     {}
+
+// DeleteStmt represents `DELETE FROM source [WHERE ...] [RETURNING ...]`
+// and the equivalent `FROM source DELETE ...` form.
+//
+// Grammar: deleteCommand
+type DeleteStmt struct {
+	Source    TableExpr
+	Where     ExprNode
+	Returning *ReturningClause
+	Loc       Loc
+}
+
+func (*DeleteStmt) nodeTag()      {}
+func (n *DeleteStmt) GetLoc() Loc { return n.Loc }
+func (*DeleteStmt) stmtNode()     {}
+
+// UpsertStmt represents `UPSERT INTO target [AS alias] VALUE expr ...`.
+// Same shape as InsertStmt; semantically the conflict-merge is implicit.
+//
+// Grammar: upsertCommand
+type UpsertStmt struct {
+	Target     TableExpr
+	AsAlias    *string
+	Value      ExprNode
+	OnConflict *OnConflict
+	Returning  *ReturningClause
+	Loc        Loc
+}
+
+func (*UpsertStmt) nodeTag()      {}
+func (n *UpsertStmt) GetLoc() Loc { return n.Loc }
+func (*UpsertStmt) stmtNode()     {}
+
+// ReplaceStmt represents `REPLACE INTO target [AS alias] VALUE expr ...`.
+// Same shape as InsertStmt.
+//
+// Grammar: replaceCommand
+type ReplaceStmt struct {
+	Target     TableExpr
+	AsAlias    *string
+	Value      ExprNode
+	OnConflict *OnConflict
+	Returning  *ReturningClause
+	Loc        Loc
+}
+
+func (*ReplaceStmt) nodeTag()      {}
+func (n *ReplaceStmt) GetLoc() Loc { return n.Loc }
+func (*ReplaceStmt) stmtNode()     {}
+
+// RemoveStmt represents `REMOVE path` — removes an element from a
+// collection. PartiQL-unique.
+//
+// Grammar: removeCommand
+type RemoveStmt struct {
+	Path *PathExpr
+	Loc  Loc
+}
+
+func (*RemoveStmt) nodeTag()      {}
+func (n *RemoveStmt) GetLoc() Loc { return n.Loc }
+func (*RemoveStmt) stmtNode()     {}
+
+// CreateTableStmt represents `CREATE TABLE name`. PartiQL DDL has no
+// column definitions or constraints — just the table name.
+//
+// Grammar: createCommand#CreateTable
+type CreateTableStmt struct {
+	Name *VarRef
+	Loc  Loc
+}
+
+func (*CreateTableStmt) nodeTag()      {}
+func (n *CreateTableStmt) GetLoc() Loc { return n.Loc }
+func (*CreateTableStmt) stmtNode()     {}
+
+// CreateIndexStmt represents `CREATE INDEX ON table (path, path, ...)`.
+//
+// Grammar: createCommand#CreateIndex
+type CreateIndexStmt struct {
+	Table *VarRef
+	Paths []*PathExpr
+	Loc   Loc
+}
+
+func (*CreateIndexStmt) nodeTag()      {}
+func (n *CreateIndexStmt) GetLoc() Loc { return n.Loc }
+func (*CreateIndexStmt) stmtNode()     {}
+
+// DropTableStmt represents `DROP TABLE name`.
+//
+// Grammar: dropCommand#DropTable
+type DropTableStmt struct {
+	Name *VarRef
+	Loc  Loc
+}
+
+func (*DropTableStmt) nodeTag()      {}
+func (n *DropTableStmt) GetLoc() Loc { return n.Loc }
+func (*DropTableStmt) stmtNode()     {}
+
+// DropIndexStmt represents `DROP INDEX index ON table`.
+//
+// Grammar: dropCommand#DropIndex
+type DropIndexStmt struct {
+	Index *VarRef
+	Table *VarRef
+	Loc   Loc
+}
+
+func (*DropIndexStmt) nodeTag()      {}
+func (n *DropIndexStmt) GetLoc() Loc { return n.Loc }
+func (*DropIndexStmt) stmtNode()     {}
+
+// ExecStmt represents `EXEC name [arg, arg, ...]`.
+//
+// Grammar: execCommand
+type ExecStmt struct {
+	Name string
+	Args []ExprNode
+	Loc  Loc
+}
+
+func (*ExecStmt) nodeTag()      {}
+func (n *ExecStmt) GetLoc() Loc { return n.Loc }
+func (*ExecStmt) stmtNode()     {}
+
+// ---------------------------------------------------------------------------
+// PLACEHOLDERS — replaced in Task 9.
+//
+// These are forward-declared minimal stubs so the package builds at the
+// end of Task 8 even though the real types live in the next task. Each
+// stub is a bare struct with the Loc field plus the methods Node requires.
+// Task 9 deletes this entire block and replaces it with the full type
+// definitions of the clause helpers and DML helpers.
+//
+// IMPORTANT: This block also INCLUDES the OrderByItem placeholder
+// originally added in Task 4 — DO NOT remove it during the wholesale
+// stmts.go rewrite, or exprs.go (WindowSpec.OrderBy) will fail to build.
+// ---------------------------------------------------------------------------
+
 type OrderByItem struct {
 	Expr          ExprNode
 	Desc          bool
@@ -15,3 +387,96 @@ type OrderByItem struct {
 
 func (*OrderByItem) nodeTag()      {}
 func (n *OrderByItem) GetLoc() Loc { return n.Loc }
+
+type TargetEntry struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*TargetEntry) nodeTag()      {}
+func (n *TargetEntry) GetLoc() Loc { return n.Loc }
+
+type PivotProjection struct {
+	Value ExprNode
+	At    ExprNode
+	Loc   Loc
+}
+
+func (*PivotProjection) nodeTag()      {}
+func (n *PivotProjection) GetLoc() Loc { return n.Loc }
+
+type LetBinding struct {
+	Expr  ExprNode
+	Alias string
+	Loc   Loc
+}
+
+func (*LetBinding) nodeTag()      {}
+func (n *LetBinding) GetLoc() Loc { return n.Loc }
+
+type GroupByClause struct {
+	Partial bool
+	Items   []*GroupByItem
+	GroupAs *string
+	Loc     Loc
+}
+
+func (*GroupByClause) nodeTag()      {}
+func (n *GroupByClause) GetLoc() Loc { return n.Loc }
+
+type GroupByItem struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*GroupByItem) nodeTag()      {}
+func (n *GroupByItem) GetLoc() Loc { return n.Loc }
+
+type SetAssignment struct {
+	Target *PathExpr
+	Value  ExprNode
+	Loc    Loc
+}
+
+func (*SetAssignment) nodeTag()      {}
+func (n *SetAssignment) GetLoc() Loc { return n.Loc }
+
+type OnConflict struct {
+	Target *OnConflictTarget
+	Action OnConflictAction
+	Where  ExprNode
+	Loc    Loc
+}
+
+func (*OnConflict) nodeTag()      {}
+func (n *OnConflict) GetLoc() Loc { return n.Loc }
+
+type OnConflictTarget struct {
+	Cols           []*VarRef
+	ConstraintName string
+	Loc            Loc
+}
+
+func (*OnConflictTarget) nodeTag()      {}
+func (n *OnConflictTarget) GetLoc() Loc { return n.Loc }
+
+type ReturningClause struct {
+	Items []*ReturningItem
+	Loc   Loc
+}
+
+func (*ReturningClause) nodeTag()      {}
+func (n *ReturningClause) GetLoc() Loc { return n.Loc }
+
+type ReturningItem struct {
+	Status  ReturningStatus
+	Mapping ReturningMapping
+	Star    bool
+	Expr    ExprNode
+	Loc     Loc
+}
+
+func (*ReturningItem) nodeTag()      {}
+func (n *ReturningItem) GetLoc() Loc { return n.Loc }

--- a/partiql/ast/stmts.go
+++ b/partiql/ast/stmts.go
@@ -376,20 +376,83 @@ func (*ExecStmt) nodeTag()      {}
 func (n *ExecStmt) GetLoc() Loc { return n.Loc }
 func (*ExecStmt) stmtNode()     {}
 
-// ---------------------------------------------------------------------------
-// PLACEHOLDERS — replaced in Task 9.
+// ===========================================================================
+// SELECT clause helpers — bare Node (no sub-interface marker).
 //
-// These are forward-declared minimal stubs so the package builds at the
-// end of Task 8 even though the real types live in the next task. Each
-// stub is a bare struct with the Loc field plus the methods Node requires.
-// Task 9 deletes this entire block and replaces it with the full type
-// definitions of the clause helpers and DML helpers.
-//
-// IMPORTANT: This block also INCLUDES the OrderByItem placeholder
-// originally added in Task 4 — DO NOT remove it during the wholesale
-// stmts.go rewrite, or exprs.go (WindowSpec.OrderBy) will fail to build.
-// ---------------------------------------------------------------------------
+// These types appear only as fields/elements inside SelectStmt and never
+// stand alone in scalar/statement/table-expr position, so they don't need
+// a sub-interface marker.
+// ===========================================================================
 
+// TargetEntry represents one item in a SELECT projection list:
+// `expr [AS alias]`.
+//
+// Grammar: projectionItem
+type TargetEntry struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*TargetEntry) nodeTag()      {}
+func (n *TargetEntry) GetLoc() Loc { return n.Loc }
+
+// PivotProjection represents the body of a `PIVOT v AT k` projection.
+// Used as SelectStmt.Pivot. PartiQL-unique.
+//
+// Grammar: selectClause#SelectPivot
+type PivotProjection struct {
+	Value ExprNode
+	At    ExprNode
+	Loc   Loc
+}
+
+func (*PivotProjection) nodeTag()      {}
+func (n *PivotProjection) GetLoc() Loc { return n.Loc }
+
+// LetBinding represents one `expr AS alias` binding inside a LET clause.
+// PartiQL-unique.
+//
+// Grammar: letBinding
+type LetBinding struct {
+	Expr  ExprNode
+	Alias string
+	Loc   Loc
+}
+
+func (*LetBinding) nodeTag()      {}
+func (n *LetBinding) GetLoc() Loc { return n.Loc }
+
+// GroupByClause represents `GROUP [PARTIAL] BY items [GROUP AS alias]`.
+//
+// Grammar: groupClause
+type GroupByClause struct {
+	Partial bool
+	Items   []*GroupByItem
+	GroupAs *string
+	Loc     Loc
+}
+
+func (*GroupByClause) nodeTag()      {}
+func (n *GroupByClause) GetLoc() Loc { return n.Loc }
+
+// GroupByItem represents one `expr [AS alias]` item in a GROUP BY list.
+//
+// Grammar: groupKey
+type GroupByItem struct {
+	Expr  ExprNode
+	Alias *string
+	Loc   Loc
+}
+
+func (*GroupByItem) nodeTag()      {}
+func (n *GroupByItem) GetLoc() Loc { return n.Loc }
+
+// OrderByItem represents one `expr [ASC|DESC] [NULLS FIRST|LAST]` item
+// in an ORDER BY list. NullsExplicit is true when the source text included
+// a NULLS clause; NullsFirst is the resulting setting when it did.
+//
+// Grammar: orderSortSpec
 type OrderByItem struct {
 	Expr          ExprNode
 	Desc          bool
@@ -401,52 +464,14 @@ type OrderByItem struct {
 func (*OrderByItem) nodeTag()      {}
 func (n *OrderByItem) GetLoc() Loc { return n.Loc }
 
-type TargetEntry struct {
-	Expr  ExprNode
-	Alias *string
-	Loc   Loc
-}
+// ===========================================================================
+// DML helpers — bare Node.
+// ===========================================================================
 
-func (*TargetEntry) nodeTag()      {}
-func (n *TargetEntry) GetLoc() Loc { return n.Loc }
-
-type PivotProjection struct {
-	Value ExprNode
-	At    ExprNode
-	Loc   Loc
-}
-
-func (*PivotProjection) nodeTag()      {}
-func (n *PivotProjection) GetLoc() Loc { return n.Loc }
-
-type LetBinding struct {
-	Expr  ExprNode
-	Alias string
-	Loc   Loc
-}
-
-func (*LetBinding) nodeTag()      {}
-func (n *LetBinding) GetLoc() Loc { return n.Loc }
-
-type GroupByClause struct {
-	Partial bool
-	Items   []*GroupByItem
-	GroupAs *string
-	Loc     Loc
-}
-
-func (*GroupByClause) nodeTag()      {}
-func (n *GroupByClause) GetLoc() Loc { return n.Loc }
-
-type GroupByItem struct {
-	Expr  ExprNode
-	Alias *string
-	Loc   Loc
-}
-
-func (*GroupByItem) nodeTag()      {}
-func (n *GroupByItem) GetLoc() Loc { return n.Loc }
-
+// SetAssignment represents one `target = value` assignment in an UPDATE
+// SET clause (or in a chained-DML SET op).
+//
+// Grammar: setAssignment
 type SetAssignment struct {
 	Target *PathExpr
 	Value  ExprNode
@@ -456,6 +481,10 @@ type SetAssignment struct {
 func (*SetAssignment) nodeTag()      {}
 func (n *SetAssignment) GetLoc() Loc { return n.Loc }
 
+// OnConflict represents the body of an ON CONFLICT clause:
+// `ON CONFLICT [target] [WHERE expr] action`.
+//
+// Grammar: onConflictClause#OnConflict, onConflictClause#OnConflictLegacy
 type OnConflict struct {
 	Target *OnConflictTarget
 	Action OnConflictAction
@@ -466,6 +495,11 @@ type OnConflict struct {
 func (*OnConflict) nodeTag()      {}
 func (n *OnConflict) GetLoc() Loc { return n.Loc }
 
+// OnConflictTarget represents the target of an ON CONFLICT clause —
+// either a list of column references `(col, col, ...)` or
+// `ON CONSTRAINT name`. Exactly one of Cols/ConstraintName is set.
+//
+// Grammar: conflictTarget
 type OnConflictTarget struct {
 	Cols           []*VarRef
 	ConstraintName string
@@ -475,6 +509,9 @@ type OnConflictTarget struct {
 func (*OnConflictTarget) nodeTag()      {}
 func (n *OnConflictTarget) GetLoc() Loc { return n.Loc }
 
+// ReturningClause represents `RETURNING item, item, …`.
+//
+// Grammar: returningClause
 type ReturningClause struct {
 	Items []*ReturningItem
 	Loc   Loc
@@ -483,6 +520,11 @@ type ReturningClause struct {
 func (*ReturningClause) nodeTag()      {}
 func (n *ReturningClause) GetLoc() Loc { return n.Loc }
 
+// ReturningItem represents one `(MODIFIED|ALL) (OLD|NEW) (* | expr)` entry
+// in a RETURNING clause. Star is true for the `*` form; otherwise Expr
+// holds the projection expression.
+//
+// Grammar: returningColumn
 type ReturningItem struct {
 	Status  ReturningStatus
 	Mapping ReturningMapping

--- a/partiql/ast/tableexprs.go
+++ b/partiql/ast/tableexprs.go
@@ -1,0 +1,124 @@
+package ast
+
+// ---------------------------------------------------------------------------
+// Table expression nodes — implement TableExpr.
+//
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   fromClause         (lines 297–298)
+//   tableReference     (lines 389–395)
+//   tableNonJoin       (lines 397–400)
+//   tableBaseReference (lines 402–406)
+//   tableUnpivot       (lines 408–409)
+//   joinRhs            (lines 411–414)
+//   joinSpec           (lines 416–417)
+//   joinType           (lines 419–425)
+//   fromClauseSimple   (lines 202–205)
+// Each type below cites its specific rule#Label.
+//
+// IMPORTANT: PathExpr, VarRef, and SubLink (defined in exprs.go) also
+// implement TableExpr. They are not re-listed here as their primary home
+// is exprs.go, but they are first-class FROM-position nodes. The compile-time
+// `var _ TableExpr = ...` lines in ast_test.go cover them.
+// ---------------------------------------------------------------------------
+
+// JoinKind identifies the JOIN flavor.
+type JoinKind int
+
+const (
+	JoinKindInvalid JoinKind = iota
+	JoinKindCross
+	JoinKindInner
+	JoinKindLeft
+	JoinKindRight
+	JoinKindFull
+	JoinKindOuter // bare OUTER JOIN (PartiQL natural-outer form)
+)
+
+func (k JoinKind) String() string {
+	switch k {
+	case JoinKindCross:
+		return "CROSS"
+	case JoinKindInner:
+		return "INNER"
+	case JoinKindLeft:
+		return "LEFT"
+	case JoinKindRight:
+		return "RIGHT"
+	case JoinKindFull:
+		return "FULL"
+	case JoinKindOuter:
+		return "OUTER"
+	default:
+		return "INVALID"
+	}
+}
+
+// TableRef represents a bare identifier in FROM position. Schema is
+// populated only when the reference uses dotted form `schema.table`.
+// CaseSensitive is true for double-quoted identifiers.
+//
+// Grammar: tableBaseReference#TableBaseRefSymbol, tableBaseReference#TableBaseRefClauses
+type TableRef struct {
+	Name          string
+	Schema        string
+	CaseSensitive bool
+	Loc           Loc
+}
+
+func (*TableRef) nodeTag()      {}
+func (n *TableRef) GetLoc() Loc { return n.Loc }
+func (*TableRef) tableExpr()    {}
+
+// AliasedSource wraps a TableExpr with PartiQL's `AS alias AT positional
+// BY key` aliasing form. PartiQL-unique because of the AT/BY positional
+// and key aliases.
+//
+// Grammar: tableBaseReference#TableBaseRefClauses, tableBaseReference#TableBaseRefMatch,
+//
+//	tableUnpivot, fromClauseSimple#FromClauseSimpleExplicit
+type AliasedSource struct {
+	Source TableExpr
+	As     *string // optional row alias
+	At     *string // optional positional alias
+	By     *string // optional key alias
+	Loc    Loc
+}
+
+func (*AliasedSource) nodeTag()      {}
+func (n *AliasedSource) GetLoc() Loc { return n.Loc }
+func (*AliasedSource) tableExpr()    {}
+
+// JoinExpr represents a JOIN clause: left JOIN right ON condition.
+// Kind selects the JOIN flavor; On is nil for CROSS JOIN.
+//
+// Grammar: tableReference#TableCrossJoin, tableReference#TableQualifiedJoin
+//
+//	(join-type modifier from joinType; joinRhs for right-hand side)
+type JoinExpr struct {
+	Kind  JoinKind
+	Left  TableExpr
+	Right TableExpr
+	On    ExprNode // nil for CROSS JOIN
+	Loc   Loc
+}
+
+func (*JoinExpr) nodeTag()      {}
+func (n *JoinExpr) GetLoc() Loc { return n.Loc }
+func (*JoinExpr) tableExpr()    {}
+
+// UnpivotExpr represents `UNPIVOT expr [AS alias] [AT pos] [BY key]`.
+// PartiQL-unique. The Source is an expression (not a TableExpr) because
+// the grammar nests an arbitrary expression here.
+//
+// Grammar: tableUnpivot
+type UnpivotExpr struct {
+	Source ExprNode
+	As     *string
+	At     *string
+	By     *string
+	Loc    Loc
+}
+
+func (*UnpivotExpr) nodeTag()      {}
+func (n *UnpivotExpr) GetLoc() Loc { return n.Loc }
+func (*UnpivotExpr) tableExpr()    {}

--- a/partiql/ast/types.go
+++ b/partiql/ast/types.go
@@ -20,24 +20,34 @@ package ast
 
 // TypeRef represents any PartiQL type reference, used by CAST and DDL.
 //
-// Args carries optional precision/scale/length:
-//   - DECIMAL(10,2) -> Args=[10, 2]
-//   - VARCHAR(255)  -> Args=[255]
-//   - FLOAT(53)     -> Args=[53]
-//   - INT           -> Args=nil
+// Args carries optional precision/scale/length, with positional indexing:
+//   - Args[0] = precision / length
+//   - Args[1] = scale (DECIMAL/NUMERIC only)
 //
-// WithTimeZone is set for `TIME WITH TIME ZONE` and `TIMESTAMP WITH TIME ZONE`.
+// Examples:
+//   - DECIMAL(10,2)         -> Args=[10, 2]
+//   - VARCHAR(255)          -> Args=[255]
+//   - FLOAT(53)             -> Args=[53]
+//   - TIME(6) WITH TIME ZONE -> Args=[6], WithTimeZone=true
+//   - INT                   -> Args=nil
 //
-// Names covered (canonical uppercase):
-//   - Numeric: INT, INTEGER, BIGINT, SMALLINT, REAL, DOUBLE PRECISION,
-//     DECIMAL, NUMERIC, FLOAT
+// WithTimeZone is set for `TIME WITH TIME ZONE`. (Note: the legacy
+// PartiQLParser.g4 grammar only carries the WITH TIME ZONE form on the
+// `TypeTimeZone` alternative for TIME, not TIMESTAMP — see line 684.)
+//
+// Names covered (canonical uppercase, drawn from PartiQLParser.g4 lines
+// 676–685):
+//   - Numeric: INT, INT2, INT4, INT8, INTEGER, INTEGER2, INTEGER4, INTEGER8,
+//     SMALLINT, BIGINT, REAL, DOUBLE PRECISION, FLOAT, DECIMAL, DEC, NUMERIC
 //   - Boolean: BOOL, BOOLEAN
-//   - Null/missing: NULL, MISSING
-//   - String: STRING, SYMBOL, VARCHAR, CHAR, CHARACTER
-//   - Binary: BLOB, CLOB
+//   - Null / missing: NULL, MISSING
+//   - String: STRING, SYMBOL, VARCHAR, CHAR, CHARACTER, "CHARACTER VARYING"
+//   - Large objects: BLOB, CLOB
 //   - Temporal: DATE, TIME, TIMESTAMP
 //   - Collection: STRUCT, TUPLE, LIST, BAG, SEXP
-//   - Wildcard: ANY
+//   - Any: ANY
+//   - User-defined: any symbolPrimitive identifier (the `TypeCustom`
+//     alternative on line 685)
 type TypeRef struct {
 	Name         string
 	Args         []int

--- a/partiql/ast/types.go
+++ b/partiql/ast/types.go
@@ -1,0 +1,50 @@
+package ast
+
+// ---------------------------------------------------------------------------
+// PartiQL type references — implement TypeName.
+//
+// One flat TypeRef covers all PartiQL types. Discrimination is by Name
+// (uppercase canonical: INT, DECIMAL, TIME, BAG, ANY, ...) rather than a
+// 25-arm Go enum. The grammar treats types as a name token with optional
+// modifiers (Args for parameterized types, WithTimeZone for TIME/TIMESTAMP),
+// so the AST mirrors that shape.
+//
+// Grammar: PartiQLParser.g4 — sourced from rules:
+//   type#TypeAtomic    (lines 675–680)
+//   type#TypeArgSingle (line 681)
+//   type#TypeVarChar   (line 682)
+//   type#TypeArgDouble (line 683)
+//   type#TypeTimeZone  (line 684)
+//   type#TypeCustom    (line 685)
+// ---------------------------------------------------------------------------
+
+// TypeRef represents any PartiQL type reference, used by CAST and DDL.
+//
+// Args carries optional precision/scale/length:
+//   - DECIMAL(10,2) -> Args=[10, 2]
+//   - VARCHAR(255)  -> Args=[255]
+//   - FLOAT(53)     -> Args=[53]
+//   - INT           -> Args=nil
+//
+// WithTimeZone is set for `TIME WITH TIME ZONE` and `TIMESTAMP WITH TIME ZONE`.
+//
+// Names covered (canonical uppercase):
+//   - Numeric: INT, INTEGER, BIGINT, SMALLINT, REAL, DOUBLE PRECISION,
+//     DECIMAL, NUMERIC, FLOAT
+//   - Boolean: BOOL, BOOLEAN
+//   - Null/missing: NULL, MISSING
+//   - String: STRING, SYMBOL, VARCHAR, CHAR, CHARACTER
+//   - Binary: BLOB, CLOB
+//   - Temporal: DATE, TIME, TIMESTAMP
+//   - Collection: STRUCT, TUPLE, LIST, BAG, SEXP
+//   - Wildcard: ANY
+type TypeRef struct {
+	Name         string
+	Args         []int
+	WithTimeZone bool
+	Loc          Loc
+}
+
+func (*TypeRef) nodeTag()      {}
+func (n *TypeRef) GetLoc() Loc { return n.Loc }
+func (*TypeRef) typeName()     {}

--- a/partiql/parser/testdata/aws-corpus/batching-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/batching-001.partiql
@@ -1,0 +1,1 @@
+SELECT pk FROM ProblemSet WHERE pk = 'p#9StkWHYTxm7x2AqSXcrfu7' AND sk = 'info'

--- a/partiql/parser/testdata/aws-corpus/batching-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/batching-002.partiql
@@ -1,0 +1,1 @@
+SELECT pk FROM ProblemSet WHERE pk = 'p#isC2ChceGbxHgESc4szoTE' AND sk = 'info'

--- a/partiql/parser/testdata/aws-corpus/batching-003.partiql
+++ b/partiql/parser/testdata/aws-corpus/batching-003.partiql
@@ -1,0 +1,1 @@
+INSERT INTO Music VALUE {'Artist':?,'SongTitle':?}

--- a/partiql/parser/testdata/aws-corpus/batching-004.partiql
+++ b/partiql/parser/testdata/aws-corpus/batching-004.partiql
@@ -1,0 +1,1 @@
+UPDATE Music SET AwardsWon=1, AwardDetail={'Grammys':[2020, 2018]} WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/batching-005.partiql
+++ b/partiql/parser/testdata/aws-corpus/batching-005.partiql
@@ -1,0 +1,1 @@
+INSERT INTO Music value {'Artist':'Acme Band','SongTitle':'PartiQL Rocks'}

--- a/partiql/parser/testdata/aws-corpus/batching-006.partiql
+++ b/partiql/parser/testdata/aws-corpus/batching-006.partiql
@@ -1,0 +1,1 @@
+UPDATE Music set AwardDetail.BillBoard=[2020] where Artist='Acme Band' and SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/datatypes-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/datatypes-001.partiql
@@ -1,0 +1,1 @@
+INSERT INTO TypesTable value {'primarykey':'1',  'NumberType':1, 'MapType' : {'entryname1': 'value', 'entryname2': 4},  'ListType': [1,'stringval'],  'NumberSetType':<<1,34,32,4.5>>,  'StringSetType':<<'stringval','stringval2'>> }

--- a/partiql/parser/testdata/aws-corpus/datatypes-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/datatypes-002.partiql
@@ -1,0 +1,1 @@
+UPDATE TypesTable  SET NumberType=NumberType + 100  SET MapType.NewMapEntry=[2020, 'stringvalue', 2.4] SET ListType = LIST_APPEND(ListType, [4, <<'string1', 'string2'>>]) SET NumberSetType= SET_ADD(NumberSetType, <<345, 48.4>>) SET StringSetType = SET_ADD(StringSetType, <<'stringsetvalue1', 'stringsetvalue2'>>) WHERE primarykey='1'

--- a/partiql/parser/testdata/aws-corpus/datatypes-003.partiql
+++ b/partiql/parser/testdata/aws-corpus/datatypes-003.partiql
@@ -1,0 +1,1 @@
+UPDATE TypesTable  SET NumberType=NumberType - 1 REMOVE ListType[1] REMOVE MapType.NewMapEntry SET NumberSetType = SET_DELETE( NumberSetType, <<345>>) SET StringSetType = SET_DELETE( StringSetType, <<'stringsetvalue1'>>) WHERE primarykey='1'

--- a/partiql/parser/testdata/aws-corpus/delete-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/delete-001.partiql
@@ -1,0 +1,1 @@
+DELETE FROM "Music" WHERE "Artist" = 'Acme Band' AND "SongTitle" = 'PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/delete-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/delete-002.partiql
@@ -1,0 +1,1 @@
+DELETE FROM "Music" WHERE "Artist" = 'Acme Band' AND "SongTitle" = 'PartiQL Rocks' RETURNING ALL OLD *

--- a/partiql/parser/testdata/aws-corpus/function-attribute-type-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/function-attribute-type-001.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Music" WHERE attribute_type("Artist", 'S')

--- a/partiql/parser/testdata/aws-corpus/function-begins-with-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/function-begins-with-001.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Orders" WHERE "OrderID"=1 AND begins_with("Address", '7834 24th')

--- a/partiql/parser/testdata/aws-corpus/function-contains-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/function-contains-001.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Orders" WHERE "OrderID"=1 AND contains("Address", 'Kirkland')

--- a/partiql/parser/testdata/aws-corpus/function-exists-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/function-exists-001.partiql
@@ -1,0 +1,1 @@
+EXISTS(     SELECT * FROM "Music"      WHERE "Artist" = 'Acme Band' AND "SongTitle" = 'PartiQL Rocks')

--- a/partiql/parser/testdata/aws-corpus/function-missing-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/function-missing-001.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM Music WHERE "Awards" is MISSING

--- a/partiql/parser/testdata/aws-corpus/function-size-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/function-size-001.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Orders" WHERE "OrderID"=1 AND size("Image") >300

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-001.partiql
@@ -1,0 +1,3 @@
+SELECT *
+FROM Music
+WHERE Artist='Acme Band' AND SongTitle='Happy Day'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-002.partiql
@@ -1,0 +1,3 @@
+SELECT *
+FROM Music
+WHERE Artist=? and SongTitle=?

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-003.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-003.partiql
@@ -1,0 +1,3 @@
+INSERT INTO Music
+VALUE
+{'Artist':'Acme Band','SongTitle':'PartiQL Rocks'}

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-004.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-004.partiql
@@ -1,0 +1,2 @@
+SELECT * FROM Music
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-005.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-005.partiql
@@ -1,0 +1,4 @@
+UPDATE Music
+SET AwardsWon=1
+SET AwardDetail={'Grammys':[2020, 2018]}
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-006.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-006.partiql
@@ -1,0 +1,3 @@
+UPDATE Music
+SET AwardDetail.Grammys =list_append(AwardDetail.Grammys,[2016])
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-007.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-007.partiql
@@ -1,0 +1,3 @@
+UPDATE Music
+REMOVE AwardDetail.Grammys[2]
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-008.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-008.partiql
@@ -1,0 +1,3 @@
+UPDATE Music
+SET AwardDetail.BillBoard=[2020]
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-009.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-009.partiql
@@ -1,0 +1,3 @@
+UPDATE Music
+SET BandMembers =<<'member1', 'member2'>>
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-010.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-010.partiql
@@ -1,0 +1,3 @@
+UPDATE Music
+SET BandMembers =set_add(BandMembers, <<'newmember'>>)
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-011.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-011.partiql
@@ -1,0 +1,3 @@
+DELETE
+FROM Music
+WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-012.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-012.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Music" WHERE Artist=? AND SongTitle=?

--- a/partiql/parser/testdata/aws-corpus/gettingstarted-013.partiql
+++ b/partiql/parser/testdata/aws-corpus/gettingstarted-013.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM Music WHERE Artist=? AND SongTitle=?

--- a/partiql/parser/testdata/aws-corpus/index.json
+++ b/partiql/parser/testdata/aws-corpus/index.json
@@ -1,0 +1,405 @@
+{
+  "source": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html",
+  "fetched_at": "2026-04-07T10:02:43Z",
+  "examples": [
+    {
+      "id": "gettingstarted-001",
+      "label": "Console Query Example - SELECT with WHERE AND",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "SELECT *\nFROM Music\nWHERE Artist='Acme Band' AND SongTitle='Happy Day'"
+    },
+    {
+      "id": "gettingstarted-002",
+      "label": "NoSQL Workbench parameterized SELECT",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "SELECT *\nFROM Music\nWHERE Artist=? and SongTitle=?"
+    },
+    {
+      "id": "gettingstarted-003",
+      "label": "INSERT statement with tuple value",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "INSERT INTO Music\nVALUE\n{'Artist':'Acme Band','SongTitle':'PartiQL Rocks'}"
+    },
+    {
+      "id": "gettingstarted-004",
+      "label": "Basic SELECT statement",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "SELECT * FROM Music\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-005",
+      "label": "UPDATE with two SET clauses",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "UPDATE Music\nSET AwardsWon=1\nSET AwardDetail={'Grammys':[2020, 2018]}\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-006",
+      "label": "UPDATE with list_append function",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "UPDATE Music\nSET AwardDetail.Grammys =list_append(AwardDetail.Grammys,[2016])\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-007",
+      "label": "UPDATE with REMOVE list element",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "UPDATE Music\nREMOVE AwardDetail.Grammys[2]\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-008",
+      "label": "UPDATE adding new map member",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "UPDATE Music\nSET AwardDetail.BillBoard=[2020]\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-009",
+      "label": "UPDATE with bag/string set literal",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "UPDATE Music\nSET BandMembers =<<'member1', 'member2'>>\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-010",
+      "label": "UPDATE with set_add function",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "UPDATE Music\nSET BandMembers =set_add(BandMembers, <<'newmember'>>)\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-011",
+      "label": "DELETE statement",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "DELETE\nFROM Music\nWHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "gettingstarted-012",
+      "label": "Parameterized SELECT with quoted table name",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "SELECT * FROM \"Music\" WHERE Artist=? AND SongTitle=?"
+    },
+    {
+      "id": "gettingstarted-013",
+      "label": "Parameterized SELECT (unquoted table name)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+      "sql": "SELECT * FROM Music WHERE Artist=? AND SongTitle=?"
+    },
+    {
+      "id": "datatypes-001",
+      "label": "INSERT exercising all data types (map, list, number set, string set)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.data-types.html",
+      "sql": "INSERT INTO TypesTable value {'primarykey':'1',  'NumberType':1, 'MapType' : {'entryname1': 'value', 'entryname2': 4},  'ListType': [1,'stringval'],  'NumberSetType':<<1,34,32,4.5>>,  'StringSetType':<<'stringval','stringval2'>> }"
+    },
+    {
+      "id": "datatypes-002",
+      "label": "UPDATE adding elements across all data types",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.data-types.html",
+      "sql": "UPDATE TypesTable  SET NumberType=NumberType + 100  SET MapType.NewMapEntry=[2020, 'stringvalue', 2.4] SET ListType = LIST_APPEND(ListType, [4, <<'string1', 'string2'>>]) SET NumberSetType= SET_ADD(NumberSetType, <<345, 48.4>>) SET StringSetType = SET_ADD(StringSetType, <<'stringsetvalue1', 'stringsetvalue2'>>) WHERE primarykey='1'"
+    },
+    {
+      "id": "datatypes-003",
+      "label": "UPDATE removing elements across all data types",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.data-types.html",
+      "sql": "UPDATE TypesTable  SET NumberType=NumberType - 1 REMOVE ListType[1] REMOVE MapType.NewMapEntry SET NumberSetType = SET_DELETE( NumberSetType, <<345>>) SET StringSetType = SET_DELETE( StringSetType, <<'stringsetvalue1'>>) WHERE primarykey='1'"
+    },
+    {
+      "id": "select-001",
+      "label": "SELECT syntax skeleton",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT `expression`  [, ...]  FROM `table`[.`index`] [ WHERE `condition` ] [ [ORDER BY `key` [DESC|ASC] , ...]"
+    },
+    {
+      "id": "select-002",
+      "label": "SELECT * with partition key equality",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE OrderID = 100"
+    },
+    {
+      "id": "select-003",
+      "label": "SELECT * partition key + non-key AND",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE OrderID = 100 and Address='some address'"
+    },
+    {
+      "id": "select-004",
+      "label": "SELECT * partition key OR partition key",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE OrderID = 100 or OrderID = 200"
+    },
+    {
+      "id": "select-005",
+      "label": "SELECT * with IN list",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE OrderID IN [100, 300, 234]"
+    },
+    {
+      "id": "select-006",
+      "label": "SELECT * with greater-than condition",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE OrderID > 1"
+    },
+    {
+      "id": "select-007",
+      "label": "SELECT * with non-key WHERE",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE Address='some address'"
+    },
+    {
+      "id": "select-008",
+      "label": "SELECT * with OR across key and non-key",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"Orders\"  WHERE OrderID = 100 OR Address='some address'"
+    },
+    {
+      "id": "select-009",
+      "label": "SELECT projected columns with key equality",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT OrderID, Total FROM \"Orders\" WHERE OrderID = 1"
+    },
+    {
+      "id": "select-010",
+      "label": "SELECT projected columns with OR",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT OrderID, Total FROM \"Orders\" WHERE OrderID = 1 OR OrderID = 2"
+    },
+    {
+      "id": "select-011",
+      "label": "SELECT projected columns with IN and ORDER BY DESC",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT OrderID, Total FROM \"Orders\" WHERE OrderID IN [1, 2, 3] ORDER BY OrderID DESC"
+    },
+    {
+      "id": "select-012",
+      "label": "SELECT projected columns with greater-than non-key",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT OrderID, Total  FROM \"Orders\" WHERE Total > 500"
+    },
+    {
+      "id": "select-013",
+      "label": "SELECT projected columns with IN literal list",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT OrderID, Total  FROM \"Orders\" WHERE Total IN [500, 600]"
+    },
+    {
+      "id": "select-014",
+      "label": "SELECT projected columns with BETWEEN",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT OrderID, Total  FROM \"Orders\"  WHERE Total BETWEEN 500 AND 600"
+    },
+    {
+      "id": "select-015",
+      "label": "SELECT using nested document path",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT Devices.FireStick.DateWatched[0]  FROM WatchList  WHERE CustomerID= 'C1' AND MovieID= 'M1'"
+    },
+    {
+      "id": "select-016",
+      "label": "SELECT with WHERE on nested document path",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT Devices  FROM WatchList  WHERE Devices.FireStick.DateWatched[0] >= '12/24/19'"
+    },
+    {
+      "id": "select-017",
+      "label": "SELECT querying a secondary index",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+      "sql": "SELECT *  FROM \"TableName\".\"IndexName\""
+    },
+    {
+      "id": "insert-001",
+      "label": "INSERT with quoted table name",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.insert.html",
+      "sql": "INSERT INTO \"Music\" value {'Artist' : 'Acme Band','SongTitle' : 'PartiQL Rocks'}"
+    },
+    {
+      "id": "insert-002",
+      "label": "INSERT syntax skeleton",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.insert.html",
+      "sql": "INSERT INTO `table` VALUE `item`"
+    },
+    {
+      "id": "update-001",
+      "label": "UPDATE with two SET clauses (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET AwardsWon=1  SET AwardDetail={'Grammys':[2020, 2018]}   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "update-002",
+      "label": "UPDATE with RETURNING ALL OLD *",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET AwardsWon=1  SET AwardDetail={'Grammys':[2020, 2018]}   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks' RETURNING ALL OLD *"
+    },
+    {
+      "id": "update-003",
+      "label": "UPDATE with RETURNING ALL NEW *",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET AwardsWon=1  SET AwardDetail={'Grammys':[2020, 2018]}   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks' RETURNING ALL NEW *"
+    },
+    {
+      "id": "update-004",
+      "label": "UPDATE with list_append function (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET AwardDetail.Grammys =list_append(AwardDetail.Grammys,[2016])   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "update-005",
+      "label": "UPDATE REMOVE list element (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  REMOVE AwardDetail.Grammys[2]    WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "update-006",
+      "label": "UPDATE adding map member (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET AwardDetail.BillBoard=[2020]  WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "update-007",
+      "label": "UPDATE with bag/string set literal (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET BandMembers =<<'member1', 'member2'>>  WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "update-008",
+      "label": "UPDATE with set_add function (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+      "sql": "UPDATE \"Music\"  SET BandMembers =set_add(BandMembers, <<'newbandmember'>>)  WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "delete-001",
+      "label": "Basic DELETE with quoted identifiers",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.delete.html",
+      "sql": "DELETE FROM \"Music\" WHERE \"Artist\" = 'Acme Band' AND \"SongTitle\" = 'PartiQL Rocks'"
+    },
+    {
+      "id": "delete-002",
+      "label": "DELETE with RETURNING ALL OLD *",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.delete.html",
+      "sql": "DELETE FROM \"Music\" WHERE \"Artist\" = 'Acme Band' AND \"SongTitle\" = 'PartiQL Rocks' RETURNING ALL OLD *"
+    },
+    {
+      "id": "function-size-001",
+      "label": "SELECT using SIZE function",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.size.html",
+      "sql": "SELECT * FROM \"Orders\" WHERE \"OrderID\"=1 AND size(\"Image\") >300"
+    },
+    {
+      "id": "function-exists-001",
+      "label": "EXISTS function wrapping a SELECT",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.exists.html",
+      "sql": "EXISTS(     SELECT * FROM \"Music\"      WHERE \"Artist\" = 'Acme Band' AND \"SongTitle\" = 'PartiQL Rocks')"
+    },
+    {
+      "id": "function-attribute-type-001",
+      "label": "SELECT using attribute_type function",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.attribute_type.html",
+      "sql": "SELECT * FROM \"Music\" WHERE attribute_type(\"Artist\", 'S')"
+    },
+    {
+      "id": "function-begins-with-001",
+      "label": "SELECT using begins_with function",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.beginswith.html",
+      "sql": "SELECT * FROM \"Orders\" WHERE \"OrderID\"=1 AND begins_with(\"Address\", '7834 24th')"
+    },
+    {
+      "id": "function-contains-001",
+      "label": "SELECT using contains function",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.contains.html",
+      "sql": "SELECT * FROM \"Orders\" WHERE \"OrderID\"=1 AND contains(\"Address\", 'Kirkland')"
+    },
+    {
+      "id": "function-missing-001",
+      "label": "SELECT using IS MISSING",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.missing.html",
+      "sql": "SELECT * FROM Music WHERE \"Awards\" is MISSING"
+    },
+    {
+      "id": "transactions-001",
+      "label": "EXISTS condition check with IS MISSING",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+      "sql": "EXISTS(SELECT * FROM \"Music\" where Artist='No One You Know' and SongTitle='Call Me Today' and Awards is  MISSING)"
+    },
+    {
+      "id": "transactions-002",
+      "label": "Parameterized INSERT (single param)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+      "sql": "INSERT INTO Music value {'Artist':?,'SongTitle':'?'}"
+    },
+    {
+      "id": "transactions-003",
+      "label": "UPDATE inside transaction (quoted table)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+      "sql": "UPDATE \"Music\" SET AwardsWon=1 SET AwardDetail={'Grammys':[2020, 2018]}  where Artist='Acme Band' and SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "transactions-004",
+      "label": "SELECT (item exists, all attributes)",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+      "sql": "SELECT * FROM \"Music\" WHERE Artist='No One You Know' and SongTitle='Call Me Today'"
+    },
+    {
+      "id": "transactions-005",
+      "label": "SELECT non-existent projected attribute",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+      "sql": "SELECT non_existent_projected_attribute FROM \"Music\" WHERE Artist='No One You Know' and SongTitle='Call Me Today'"
+    },
+    {
+      "id": "transactions-006",
+      "label": "SELECT non-existent item",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+      "sql": "SELECT * FROM \"Music\" WHERE Artist='No One I Know' and SongTitle='Call You Today'"
+    },
+    {
+      "id": "batching-001",
+      "label": "Batch SELECT first item",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+      "sql": "SELECT pk FROM ProblemSet WHERE pk = 'p#9StkWHYTxm7x2AqSXcrfu7' AND sk = 'info'"
+    },
+    {
+      "id": "batching-002",
+      "label": "Batch SELECT second item",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+      "sql": "SELECT pk FROM ProblemSet WHERE pk = 'p#isC2ChceGbxHgESc4szoTE' AND sk = 'info'"
+    },
+    {
+      "id": "batching-003",
+      "label": "Batch parameterized INSERT",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+      "sql": "INSERT INTO Music VALUE {'Artist':?,'SongTitle':?}"
+    },
+    {
+      "id": "batching-004",
+      "label": "Batch UPDATE with comma-separated SET",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+      "sql": "UPDATE Music SET AwardsWon=1, AwardDetail={'Grammys':[2020, 2018]} WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
+    },
+    {
+      "id": "batching-005",
+      "label": "Batch INSERT (Java SDK example) with literal tuple",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+      "sql": "INSERT INTO Music value {'Artist':'Acme Band','SongTitle':'PartiQL Rocks'}"
+    },
+    {
+      "id": "batching-006",
+      "label": "Batch UPDATE (Java SDK example) lowercase keywords",
+      "source_url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+      "sql": "UPDATE Music set AwardDetail.BillBoard=[2020] where Artist='Acme Band' and SongTitle='PartiQL Rocks'"
+    }
+  ],
+  "pages_crawled": [
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.data-types.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.statements.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.insert.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.delete.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.size.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.exists.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.attribute_type.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.beginswith.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.contains.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-functions.missing.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-operators.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-iam.html"
+  ]
+}

--- a/partiql/parser/testdata/aws-corpus/insert-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/insert-001.partiql
@@ -1,0 +1,1 @@
+INSERT INTO "Music" value {'Artist' : 'Acme Band','SongTitle' : 'PartiQL Rocks'}

--- a/partiql/parser/testdata/aws-corpus/insert-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/insert-002.partiql
@@ -1,0 +1,1 @@
+INSERT INTO `table` VALUE `item`

--- a/partiql/parser/testdata/aws-corpus/select-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-001.partiql
@@ -1,0 +1,1 @@
+SELECT `expression`  [, ...]  FROM `table`[.`index`] [ WHERE `condition` ] [ [ORDER BY `key` [DESC|ASC] , ...]

--- a/partiql/parser/testdata/aws-corpus/select-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-002.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE OrderID = 100

--- a/partiql/parser/testdata/aws-corpus/select-003.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-003.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE OrderID = 100 and Address='some address'

--- a/partiql/parser/testdata/aws-corpus/select-004.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-004.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE OrderID = 100 or OrderID = 200

--- a/partiql/parser/testdata/aws-corpus/select-005.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-005.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE OrderID IN [100, 300, 234]

--- a/partiql/parser/testdata/aws-corpus/select-006.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-006.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE OrderID > 1

--- a/partiql/parser/testdata/aws-corpus/select-007.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-007.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE Address='some address'

--- a/partiql/parser/testdata/aws-corpus/select-008.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-008.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "Orders"  WHERE OrderID = 100 OR Address='some address'

--- a/partiql/parser/testdata/aws-corpus/select-009.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-009.partiql
@@ -1,0 +1,1 @@
+SELECT OrderID, Total FROM "Orders" WHERE OrderID = 1

--- a/partiql/parser/testdata/aws-corpus/select-010.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-010.partiql
@@ -1,0 +1,1 @@
+SELECT OrderID, Total FROM "Orders" WHERE OrderID = 1 OR OrderID = 2

--- a/partiql/parser/testdata/aws-corpus/select-011.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-011.partiql
@@ -1,0 +1,1 @@
+SELECT OrderID, Total FROM "Orders" WHERE OrderID IN [1, 2, 3] ORDER BY OrderID DESC

--- a/partiql/parser/testdata/aws-corpus/select-012.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-012.partiql
@@ -1,0 +1,1 @@
+SELECT OrderID, Total  FROM "Orders" WHERE Total > 500

--- a/partiql/parser/testdata/aws-corpus/select-013.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-013.partiql
@@ -1,0 +1,1 @@
+SELECT OrderID, Total  FROM "Orders" WHERE Total IN [500, 600]

--- a/partiql/parser/testdata/aws-corpus/select-014.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-014.partiql
@@ -1,0 +1,1 @@
+SELECT OrderID, Total  FROM "Orders"  WHERE Total BETWEEN 500 AND 600

--- a/partiql/parser/testdata/aws-corpus/select-015.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-015.partiql
@@ -1,0 +1,1 @@
+SELECT Devices.FireStick.DateWatched[0]  FROM WatchList  WHERE CustomerID= 'C1' AND MovieID= 'M1'

--- a/partiql/parser/testdata/aws-corpus/select-016.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-016.partiql
@@ -1,0 +1,1 @@
+SELECT Devices  FROM WatchList  WHERE Devices.FireStick.DateWatched[0] >= '12/24/19'

--- a/partiql/parser/testdata/aws-corpus/select-017.partiql
+++ b/partiql/parser/testdata/aws-corpus/select-017.partiql
@@ -1,0 +1,1 @@
+SELECT *  FROM "TableName"."IndexName"

--- a/partiql/parser/testdata/aws-corpus/transactions-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/transactions-001.partiql
@@ -1,0 +1,1 @@
+EXISTS(SELECT * FROM "Music" where Artist='No One You Know' and SongTitle='Call Me Today' and Awards is  MISSING)

--- a/partiql/parser/testdata/aws-corpus/transactions-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/transactions-002.partiql
@@ -1,0 +1,1 @@
+INSERT INTO Music value {'Artist':?,'SongTitle':'?'}

--- a/partiql/parser/testdata/aws-corpus/transactions-003.partiql
+++ b/partiql/parser/testdata/aws-corpus/transactions-003.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music" SET AwardsWon=1 SET AwardDetail={'Grammys':[2020, 2018]}  where Artist='Acme Band' and SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/transactions-004.partiql
+++ b/partiql/parser/testdata/aws-corpus/transactions-004.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Music" WHERE Artist='No One You Know' and SongTitle='Call Me Today'

--- a/partiql/parser/testdata/aws-corpus/transactions-005.partiql
+++ b/partiql/parser/testdata/aws-corpus/transactions-005.partiql
@@ -1,0 +1,1 @@
+SELECT non_existent_projected_attribute FROM "Music" WHERE Artist='No One You Know' and SongTitle='Call Me Today'

--- a/partiql/parser/testdata/aws-corpus/transactions-006.partiql
+++ b/partiql/parser/testdata/aws-corpus/transactions-006.partiql
@@ -1,0 +1,1 @@
+SELECT * FROM "Music" WHERE Artist='No One I Know' and SongTitle='Call You Today'

--- a/partiql/parser/testdata/aws-corpus/update-001.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-001.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET AwardsWon=1  SET AwardDetail={'Grammys':[2020, 2018]}   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/update-002.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-002.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET AwardsWon=1  SET AwardDetail={'Grammys':[2020, 2018]}   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks' RETURNING ALL OLD *

--- a/partiql/parser/testdata/aws-corpus/update-003.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-003.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET AwardsWon=1  SET AwardDetail={'Grammys':[2020, 2018]}   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks' RETURNING ALL NEW *

--- a/partiql/parser/testdata/aws-corpus/update-004.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-004.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET AwardDetail.Grammys =list_append(AwardDetail.Grammys,[2016])   WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/update-005.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-005.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  REMOVE AwardDetail.Grammys[2]    WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/update-006.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-006.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET AwardDetail.BillBoard=[2020]  WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/update-007.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-007.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET BandMembers =<<'member1', 'member2'>>  WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'

--- a/partiql/parser/testdata/aws-corpus/update-008.partiql
+++ b/partiql/parser/testdata/aws-corpus/update-008.partiql
@@ -1,0 +1,1 @@
+UPDATE "Music"  SET BandMembers =set_add(BandMembers, <<'newbandmember'>>)  WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'


### PR DESCRIPTION
## Summary

First node in the PartiQL migration DAG (BYT-9000): a hand-written `partiql/ast` Go package that defines the full AST type taxonomy for the upcoming omni PartiQL parser. PartiQL is the SQL++-flavored query language used by AWS DynamoDB (`storepb.Engine_DYNAMODB`) and Azure Cosmos DB.

- **73 hand-written AST node types** across 7 thematic files plus `node.go` and `outfuncs.go`, organized via 6 sealed sub-interfaces (`StmtNode` / `ExprNode` / `TableExpr` / `PathStep` / `TypeName` / `PatternNode`)
- **Full coverage** of the legacy `bytebase/parser/partiql` ANTLR grammar, verified line-by-line against `PartiQLParser.g4`
- **`NodeToString` debug helper** with a giant type switch covering all 73 nodes, plus a reflection safety net (`TestNodeToString_AllNodesCovered`) that fails the build if any future node type is added without wiring it in
- **169 unit sub-tests** across `TestGetLoc` (73), `TestNodeToString` (23 golden cases), and `TestNodeToString_AllNodesCovered` (73), all passing
- **Migration scaffolding**: `docs/migration/partiql/{analysis.md,dag.md}` (the planning artifacts) and `partiql/parser/testdata/aws-corpus/` (63 example queries crawled from the AWS DynamoDB PartiQL reference for use by `parser-foundation` and onwards)

## What this is NOT

- **Not a parser.** No recursive-descent code, no token consumption, no error recovery. That's `parser-foundation` (DAG node 4).
- **No deparse, no semantic, no quality, no walker.** Only type definitions + a debug-dump helper.
- **No `Walker` / `Visitor` interface or smart constructors** — Go type switches are sufficient and parsers/tests construct nodes directly with struct literals.

## Design highlights

- **Sealed sub-interface style** (spec D1): 6 marker interfaces enforce position discipline at every grammar boundary, so the parser cannot accidentally hand a `MatchExpr` to a slot expecting `BinaryExpr`
- **Multi-interface nodes** (spec D2): `PathExpr`, `VarRef`, and `SubLink` implement both `ExprNode` and `TableExpr` because PartiQL's grammar lets the same productions appear in scalar and FROM position
- **Single flat `TypeRef`** (spec D5) for all PartiQL types, discriminated by `Name string` instead of a 25-arm enum — matches the grammar's "name token + modifiers" shape
- **`FuncCall` covers regular calls, aggregates, and window functions** (spec D6) via `Quantifier`/`Star`/`Over` fields rather than three separate node types
- **Byte-offset `Loc` only** (spec D3): no line/column. Conversion to line/column happens at the public `partiql/parse.go` boundary in a future task.
- **PartiQL-unique features explicitly modeled**: `MissingLit`, `IonLit`, `BagLit`, `TupleLit`, `LetBinding`, `PivotProjection`, `UnpivotExpr`, `AliasedSource` (the `AS / AT / BY` form), `RemoveStmt`, GPML graph patterns

## Testing

```bash
go test ./partiql/ast/...      # 169 sub-tests, all passing
go vet ./partiql/ast/...       # clean
gofmt -l partiql/ast/          # clean
```

The reflection safety net (`TestNodeToString_AllNodesCovered`) catches any future contributor adding a node type without wiring it into `outfuncs.go`. The compile-time `var _ <Iface> = (*Type)(nil)` assertions catch any drift in the sub-interface implementations.

## Known follow-ups (documented in spec, not blockers)

- 4 expression-position rules need representation decisions when `parser-foundation` reaches them: `sequenceConstructor` (LIST/SEXP), `values`, `valueRow`, `valueList`. The spec's "Known follow-up items" section records the open decisions (FuncCall reuse vs dedicated `ValuesExpr`/`RowExpr`).
- 2 graph-pattern shape items deferred to `parser-graph` (DAG node 16): `pattern` rule's grouped form (needs `Where` + `Quantifier` on `GraphPattern`), and `tableBaseReference#TableBaseRefMatch` (needs `MatchExpr` to also implement `TableExpr`).

## Spec / plan / DAG

- Design spec: `docs/superpowers/specs/2026-04-08-partiql-ast-core-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-08-partiql-ast-core.md`
- Migration analysis: `docs/migration/partiql/analysis.md`
- Migration DAG: `docs/migration/partiql/dag.md` (ast-core marked done; lexer / catalog now unblocked)

## Test plan

- [ ] CI green on `partiql/ast/`
- [ ] No regressions in other engine packages (this PR adds new package only; doesn't touch any existing code)
- [ ] Spot-check `outfuncs.go` golden output renders correctly via `go test -run TestNodeToString -v ./partiql/ast/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)