### PR TITLE
feat(snowflake/parser): F3 statement splitter for snowflake parser migration

### DIFF
--- a/docs/migration/snowflake/dag.md
+++ b/docs/migration/snowflake/dag.md
@@ -27,7 +27,7 @@ snowflake/
 | ID | Node | Package | Depends On | Parallel With | Tier | Priority | Status |
 |----|------|---------|------------|---------------|------|----------|--------|
 | **F1** | ast-core | `snowflake/ast` | — | F2, C1, C2 | 0 | P0 | **done** (PR #14) |
-| **F2** | lexer | `snowflake/parser` | F1 | C1, C2 | 0 | P0 | not started |
+| **F2** | lexer | `snowflake/parser` | F1 | C1, C2 | 0 | P0 | **done** (PR #17) |
 | **F3** | statement-splitter | `snowflake/parser` | F2 | F4 | 0 | P0 | not started |
 | **F4** | parser-entry + walker | `snowflake/parser` | F1, F2 | F3 | 0 | P0 | not started |
 | **C1** | corpus-legacy (lift 27 SQL files) | `snowflake/parser/testdata/legacy` | — | F1–F4, C2 | 0 | P0 | **done** |

--- a/docs/superpowers/plans/2026-04-09-snowflake-splitter.md
+++ b/docs/superpowers/plans/2026-04-09-snowflake-splitter.md
@@ -1,0 +1,891 @@
+# Snowflake Statement Splitter (F3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `Split(input string) []Segment` function in `snowflake/parser/split.go` — a lexer-based streaming state machine that extracts top-level SQL statement byte ranges from a source string, correctly handling Snowflake Scripting `BEGIN..END` blocks (including `DECLARE..BEGIN..END` and nested blocks).
+
+**Architecture:** F3 adds two files (`split.go` and `split_test.go`) to the existing `snowflake/parser` package. `Split` iterates tokens via F2's `Lexer.NextToken()` (no byte-walking), tracks a 3-state state machine (`stateTop`, `stateInDeclare`, `stateInBlock`), and uses a 1-token lookahead buffer to disambiguate TCL `BEGIN` (followed by `TRANSACTION`/`WORK`/`NAME`/`;`/EOF) from Snowflake Scripting `BEGIN`.
+
+**Tech Stack:** Go 1.25, stdlib only. Depends only on F2's existing `Lexer`, `Token`, and keyword constants (`kwBEGIN`, `kwEND`, `kwDECLARE`, `kwTRANSACTION`, `kwWORK`, `kwNAME`).
+
+**Spec:** `docs/superpowers/specs/2026-04-09-snowflake-splitter-design.md` (commit `f1e7d55`)
+
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/splitter` on branch `feat/snowflake/splitter`
+
+**Module path:** `github.com/bytebase/omni`. F3 lives in `github.com/bytebase/omni/snowflake/parser` (same package as F2).
+
+**Commit policy:** No commits during implementation. The user reviews the full diff at the end; only after explicit approval do we commit.
+
+---
+
+## File Structure
+
+| File | Responsibility | Approx LOC |
+|------|----------------|-----------|
+| `snowflake/parser/split.go` | `Segment` struct, `Split` function, state machine, `Empty` method, `isTCLBeginFollower` helper | 180 |
+| `snowflake/parser/split_test.go` | Table-driven tests for simple splits, edge cases, BEGIN..END blocks, and the legacy corpus smoke test | 400 |
+
+Total: ~580 LOC across 2 new files. Both live in the existing `snowflake/parser` package — no new subpackage.
+
+---
+
+## Task 1: Scaffold split.go and split_test.go
+
+**Files:**
+- Create: `snowflake/parser/split.go`
+- Create: `snowflake/parser/split_test.go`
+
+- [ ] **Step 1: Confirm worktree state**
+
+Run: `pwd && git rev-parse --abbrev-ref HEAD`
+Expected:
+```
+/Users/h3n4l/OpenSource/omni/.worktrees/splitter
+feat/snowflake/splitter
+```
+
+If either is wrong, stop. Do NOT proceed.
+
+- [ ] **Step 2: Write `snowflake/parser/split.go` stub**
+
+```go
+package parser
+```
+
+- [ ] **Step 3: Write `snowflake/parser/split_test.go` stub**
+
+```go
+package parser
+```
+
+- [ ] **Step 4: Verify the package still compiles**
+
+Run: `go build ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Verify existing tests still pass**
+
+Run: `go test ./snowflake/parser/...`
+Expected:
+```
+ok  	github.com/bytebase/omni/snowflake/parser	(some duration)
+```
+
+All existing F2 tests (lexer, position, edge cases, error recovery, legacy corpus, keyword completeness) should still pass since we haven't changed any code.
+
+---
+
+## Task 2: Implement Segment struct and Empty method
+
+**Files:**
+- Modify: `snowflake/parser/split.go`
+
+- [ ] **Step 1: Replace the stub with the Segment type and Empty method**
+
+Overwrite `snowflake/parser/split.go` with:
+
+```go
+package parser
+
+// Segment represents one top-level SQL statement extracted from a source string.
+//
+// Text is the raw substring of the input from ByteStart (inclusive) to
+// ByteEnd (exclusive). It is NOT trimmed — leading/trailing whitespace and
+// comments are preserved verbatim. The trailing `;` delimiter (if present)
+// is NOT part of Text or ByteEnd; it lives between this segment's ByteEnd
+// and the next segment's ByteStart.
+type Segment struct {
+	Text      string // the raw text of the statement (no trailing semicolon)
+	ByteStart int    // inclusive start byte offset in the original source
+	ByteEnd   int    // exclusive end byte offset; points AT the trailing ; if present, otherwise at len(input)
+}
+
+// Empty reports whether the segment contains no meaningful SQL content —
+// that is, only whitespace and comments. It works by re-lexing Text and
+// checking whether the first token is tokEOF.
+//
+// Empty segments are filtered out by Split.
+func (s Segment) Empty() bool {
+	return NewLexer(s.Text).NextToken().Type == tokEOF
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `go build ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Verify vet**
+
+Run: `go vet ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+Run: `go test ./snowflake/parser/...`
+Expected: clean pass.
+
+---
+
+## Task 3: Implement Split function and state machine
+
+**Files:**
+- Modify: `snowflake/parser/split.go`
+
+- [ ] **Step 1: Append the Split function and its helpers to split.go**
+
+Use Edit to append the following code to `snowflake/parser/split.go` (after the `Empty` method, at end of file):
+
+```go
+
+// splitState is the state machine state for Split.
+type splitState int
+
+const (
+	stateTop splitState = iota
+	stateInDeclare
+	stateInBlock
+)
+
+// Split extracts top-level SQL statements from input.
+//
+// The returned slice contains one Segment per non-empty statement. Empty
+// statements (lone semicolons, comment-only chunks) are filtered out.
+//
+// Split is infallible — it always returns a result, even for malformed
+// input. Lexing errors are suppressed internally; callers who need them
+// should use NewLexer(input).Errors() directly.
+//
+// Split correctly handles:
+//   - Single-quoted strings with '' and \ escapes
+//   - Double-quoted identifiers with "" escape
+//   - $$...$$ dollar strings
+//   - X'...' hex literals
+//   - Line comments (-- and //) and block comments (/* */ including nested)
+//   - Snowflake Scripting BEGIN..END blocks (including nested and DECLARE..BEGIN..END)
+//   - Inline procedure bodies (CREATE TASK/PROCEDURE/FUNCTION ... AS BEGIN ... END;)
+//
+// Split does NOT handle:
+//   - IF/FOR/WHILE/REPEAT/CASE at top level (these are only valid inside a BEGIN..END body)
+//   - DECLARE CURSOR at top level without a matching BEGIN (unusual; best-effort)
+//   - DELIMITER directive (MySQL-specific, not used in Snowflake)
+func Split(input string) []Segment {
+	if len(input) == 0 {
+		return nil
+	}
+
+	l := NewLexer(input)
+	var segments []Segment
+	stmtStart := 0
+	state := stateTop
+	depth := 0
+
+	// We need one-token lookahead after kwBEGIN to disambiguate TCL from
+	// scripting. Use a one-slot buffered lookahead.
+	var pending *Token
+	nextToken := func() Token {
+		if pending != nil {
+			t := *pending
+			pending = nil
+			return t
+		}
+		return l.NextToken()
+	}
+	peekToken := func() Token {
+		if pending == nil {
+			t := l.NextToken()
+			pending = &t
+		}
+		return *pending
+	}
+
+	// emit creates a Segment covering input[stmtStart:end] — where end is
+	// the byte offset BEFORE any trailing delimiter. The caller is
+	// responsible for advancing stmtStart past the delimiter.
+	emit := func(end int) {
+		seg := Segment{
+			Text:      input[stmtStart:end],
+			ByteStart: stmtStart,
+			ByteEnd:   end,
+		}
+		if !seg.Empty() {
+			segments = append(segments, seg)
+		}
+	}
+
+	for {
+		tok := nextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+
+		switch state {
+		case stateTop:
+			switch tok.Type {
+			case kwDECLARE:
+				state = stateInDeclare
+			case kwBEGIN:
+				next := peekToken()
+				if isTCLBeginFollower(next) {
+					// Stay in stateTop; the buffered peek will be returned
+					// by the next nextToken() call and handled normally
+					// (including the `;` emission path if applicable).
+				} else {
+					state = stateInBlock
+					depth = 1
+				}
+			case int(';'):
+				// tok.Loc.Start is the position of the `;`, tok.Loc.End is
+				// one past the `;`. Segment text stops BEFORE the `;`; the
+				// next segment starts AFTER the `;`.
+				emit(tok.Loc.Start)
+				stmtStart = tok.Loc.End
+			}
+
+		case stateInDeclare:
+			switch tok.Type {
+			case kwBEGIN:
+				state = stateInBlock
+				depth = 1
+			}
+			// Semicolons and all other tokens are absorbed in stateInDeclare.
+
+		case stateInBlock:
+			switch tok.Type {
+			case kwBEGIN:
+				depth++
+			case kwEND:
+				if depth > 0 {
+					depth--
+					if depth == 0 {
+						state = stateTop
+					}
+				}
+			}
+			// Semicolons and all other tokens are absorbed in stateInBlock.
+		}
+	}
+
+	// Trailing segment — whatever remains after the last `;` (or the whole
+	// input if there was no `;`). ByteEnd is len(input) in this case.
+	if stmtStart < len(input) {
+		emit(len(input))
+	}
+
+	return segments
+}
+
+// isTCLBeginFollower reports whether tok, appearing immediately after a
+// top-level BEGIN keyword, indicates a transaction-start (TCL) rather than
+// a Snowflake Scripting block opener.
+//
+// TCL forms: BEGIN;, BEGIN TRANSACTION, BEGIN WORK, BEGIN NAME <id>, BEGIN EOF
+func isTCLBeginFollower(tok Token) bool {
+	switch tok.Type {
+	case int(';'), tokEOF, kwTRANSACTION, kwWORK, kwNAME:
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `go build ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Verify vet**
+
+Run: `go vet ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+Run: `go test ./snowflake/parser/...`
+Expected: clean pass. No new tests yet, but the F2 tests should still be green.
+
+- [ ] **Step 5: Smoke-test Split by hand**
+
+Run a quick sanity check via a temporary Go file:
+
+```bash
+cat > /tmp/split-smoke.go <<'EOF'
+package main
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+func main() {
+	cases := []string{
+		"SELECT 1;",
+		"SELECT 1; SELECT 2;",
+		"BEGIN SELECT 1; END;",
+		"BEGIN; SELECT 1;",
+	}
+	for _, c := range cases {
+		segs := parser.Split(c)
+		fmt.Printf("%q → %d segments\n", c, len(segs))
+		for _, s := range segs {
+			fmt.Printf("  [%d,%d] %q\n", s.ByteStart, s.ByteEnd, s.Text)
+		}
+	}
+}
+EOF
+go run /tmp/split-smoke.go
+rm /tmp/split-smoke.go
+```
+
+Expected output (exact):
+```
+"SELECT 1;" → 1 segments
+  [0,8] "SELECT 1"
+"SELECT 1; SELECT 2;" → 2 segments
+  [0,8] "SELECT 1"
+  [9,18] " SELECT 2"
+"BEGIN SELECT 1; END;" → 1 segments
+  [0,19] "BEGIN SELECT 1; END"
+"BEGIN; SELECT 1;" → 2 segments
+  [0,5] "BEGIN"
+  [6,15] " SELECT 1"
+```
+
+If the output doesn't match exactly, stop and diagnose. The most common issue will be byte-position math (off-by-one).
+
+---
+
+## Task 4: Write basic table-driven tests
+
+**Files:**
+- Modify: `snowflake/parser/split_test.go`
+
+- [ ] **Step 1: Replace the stub with the test helper and basic cases**
+
+Overwrite `snowflake/parser/split_test.go` with:
+
+```go
+package parser
+
+import (
+	"reflect"
+	"testing"
+)
+
+// runSplitCases is a table-driven helper that asserts Split(input) returns
+// exactly the expected Segment list.
+func runSplitCases(t *testing.T, cases []struct {
+	name  string
+	input string
+	want  []Segment
+}) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Split(c.input)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Split(%q) mismatch\n got: %+v\nwant: %+v", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSplit_Empty(t *testing.T) {
+	if got := Split(""); got != nil {
+		t.Errorf("Split(\"\") = %+v, want nil", got)
+	}
+}
+
+func TestSplit_Simple(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"one with semi", "SELECT 1;", []Segment{{"SELECT 1", 0, 8}}},
+		{"one no semi", "SELECT 1", []Segment{{"SELECT 1", 0, 8}}},
+		{"two stmts", "SELECT 1;SELECT 2;", []Segment{
+			{"SELECT 1", 0, 8},
+			{"SELECT 2", 9, 17},
+		}},
+		{"three stmts", "A;B;C;", []Segment{
+			{"A", 0, 1},
+			{"B", 2, 3},
+			{"C", 4, 5},
+		}},
+		{"trailing whitespace", "SELECT 1;  ", []Segment{{"SELECT 1", 0, 8}}},
+		{"leading whitespace", "  SELECT 1;", []Segment{{"  SELECT 1", 0, 10}}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_EmptyStatements(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"lone semi", ";", nil},
+		{"triple semi", ";;;", nil},
+		{"leading semi", ";SELECT 1;", []Segment{{"SELECT 1", 1, 9}}},
+		{"trailing semi", "SELECT 1;;", []Segment{{"SELECT 1", 0, 8}}},
+		{"embedded semi", "SELECT 1;;SELECT 2;", []Segment{
+			{"SELECT 1", 0, 8},
+			{"SELECT 2", 10, 18},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_Positions(t *testing.T) {
+	// Verify byte offsets are accurate for a representative multi-statement input.
+	input := "SELECT 1; SELECT 2; SELECT 3"
+	//        0123456789...
+	//        s1=[0,8] ; s2=[9,18] ; s3=[19,28]
+	got := Split(input)
+	want := []Segment{
+		{"SELECT 1", 0, 8},
+		{" SELECT 2", 9, 18},
+		{" SELECT 3", 19, 28},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `go test ./snowflake/parser/...`
+Expected: clean pass. All F2 tests plus 4 new F3 tests (`TestSplit_Empty`, `TestSplit_Simple`, `TestSplit_EmptyStatements`, `TestSplit_Positions`).
+
+- [ ] **Step 3: Run with verbose output to verify each subtest**
+
+Run: `go test -v ./snowflake/parser/... -run TestSplit 2>&1 | tail -30`
+Expected: each subtest reported as PASS:
+```
+=== RUN   TestSplit_Empty
+--- PASS: TestSplit_Empty
+=== RUN   TestSplit_Simple
+=== RUN   TestSplit_Simple/one_with_semi
+--- PASS: TestSplit_Simple/one_with_semi
+...
+```
+
+All subtests pass. If any fail, diagnose the exact byte-offset mismatch and fix either the test or the production code.
+
+---
+
+## Task 5: Write edge case tests
+
+**Files:**
+- Modify: `snowflake/parser/split_test.go`
+
+- [ ] **Step 1: Append edge case tests to split_test.go**
+
+Use Edit to append the following code to the end of `snowflake/parser/split_test.go`:
+
+```go
+
+func TestSplit_SemisInStrings(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"single-quoted", "SELECT 'a;b';", []Segment{{"SELECT 'a;b'", 0, 12}}},
+		{"doubled-quote in string", "SELECT 'a''b;c';", []Segment{{"SELECT 'a''b;c'", 0, 15}}},
+		{"dollar-quoted", "SELECT $$a;b$$;", []Segment{{"SELECT $$a;b$$", 0, 14}}},
+		{"hex literal", "SELECT X'3B';", []Segment{{"SELECT X'3B'", 0, 12}}},
+		{"quoted ident with semi", `SELECT "a;b";`, []Segment{{`SELECT "a;b"`, 0, 12}}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_Comments(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"dash line before", "-- comment\nSELECT 1;", []Segment{
+			{"-- comment\nSELECT 1", 0, 19},
+		}},
+		{"slash line before", "// comment\nSELECT 1;", []Segment{
+			{"// comment\nSELECT 1", 0, 19},
+		}},
+		{"block before", "/* comment */ SELECT 1;", []Segment{
+			{"/* comment */ SELECT 1", 0, 22},
+		}},
+		{"inline block", "SELECT /* a; b */ 1;", []Segment{
+			{"SELECT /* a; b */ 1", 0, 19},
+		}},
+		{"nested block", "/* outer /* inner */ still */ SELECT 1;", []Segment{
+			{"/* outer /* inner */ still */ SELECT 1", 0, 38},
+		}},
+		{"comment-only filtered", "-- just a comment\n", nil},
+		{"block comment only filtered", "/* only */", nil},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_TCLBegin(t *testing.T) {
+	// BEGIN followed by ;, TRANSACTION, WORK, NAME, or EOF is a TCL
+	// statement, not a Snowflake Scripting block.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"bare begin semi", "BEGIN; SELECT 1; COMMIT;", []Segment{
+			{"BEGIN", 0, 5},
+			{" SELECT 1", 6, 15},
+			{" COMMIT", 16, 23},
+		}},
+		{"begin transaction", "BEGIN TRANSACTION; SELECT 1; COMMIT;", []Segment{
+			{"BEGIN TRANSACTION", 0, 17},
+			{" SELECT 1", 18, 27},
+			{" COMMIT", 28, 35},
+		}},
+		{"begin work", "BEGIN WORK; COMMIT;", []Segment{
+			{"BEGIN WORK", 0, 10},
+			{" COMMIT", 11, 18},
+		}},
+		{"begin name", "BEGIN NAME tx1; COMMIT;", []Segment{
+			{"BEGIN NAME tx1", 0, 14},
+			{" COMMIT", 15, 22},
+		}},
+		{"begin at eof", "BEGIN", []Segment{
+			{"BEGIN", 0, 5},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_ScriptingBegin(t *testing.T) {
+	// BEGIN followed by non-TCL tokens (INSERT, SELECT, DECLARE, etc.) is
+	// a Snowflake Scripting block — the whole BEGIN..END is one statement.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"simple block", "BEGIN SELECT 1; END;", []Segment{
+			{"BEGIN SELECT 1; END", 0, 19},
+		}},
+		{"two stmts in block", "BEGIN INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); END;", []Segment{
+			{"BEGIN INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); END", 0, 61},
+		}},
+		{"nested block", "BEGIN BEGIN SELECT 1; END; END;", []Segment{
+			{"BEGIN BEGIN SELECT 1; END; END", 0, 30},
+		}},
+		{"block then top-level", "BEGIN SELECT 1; END; SELECT 2;", []Segment{
+			{"BEGIN SELECT 1; END", 0, 19},
+			{" SELECT 2", 20, 29},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_DeclareBegin(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"standalone declare begin", "DECLARE x INTEGER; BEGIN x := 1; END;", []Segment{
+			{"DECLARE x INTEGER; BEGIN x := 1; END", 0, 36},
+		}},
+		{"multiple decls", "DECLARE x INT; y FLOAT; BEGIN x := 1; END;", []Segment{
+			{"DECLARE x INT; y FLOAT; BEGIN x := 1; END", 0, 41},
+		}},
+		{"declare then top-level", "DECLARE x INT; BEGIN SELECT 1; END; SELECT 2;", []Segment{
+			{"DECLARE x INT; BEGIN SELECT 1; END", 0, 34},
+			{" SELECT 2", 35, 44},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_InlineProcedureBody(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"create task begin end", "CREATE TASK t AS BEGIN SELECT 1; END;", []Segment{
+			{"CREATE TASK t AS BEGIN SELECT 1; END", 0, 36},
+		}},
+		{"create task declare begin end", "CREATE TASK t AS DECLARE x FLOAT; BEGIN x := 1; END;", []Segment{
+			{"CREATE TASK t AS DECLARE x FLOAT; BEGIN x := 1; END", 0, 51},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_DollarQuotedBody(t *testing.T) {
+	// Dollar-quoted strings are opaque to the splitter — the entire $$..$$
+	// block lexes as one tokString, so internal ; BEGIN END are invisible.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"proc with dollar body", "CREATE PROCEDURE p() AS $$ BEGIN SELECT 1; END; $$;", []Segment{
+			{"CREATE PROCEDURE p() AS $$ BEGIN SELECT 1; END; $$", 0, 50},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_UnclosedBlock(t *testing.T) {
+	// BEGIN without a matching END should produce a best-effort single
+	// segment covering the whole input.
+	got := Split("BEGIN SELECT 1;")
+	want := []Segment{{"BEGIN SELECT 1;", 0, 15}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split(unclosed BEGIN) = %+v, want %+v", got, want)
+	}
+}
+
+func TestSplit_TrailingWhitespaceAfterSemi(t *testing.T) {
+	// Whitespace-only content after the last `;` should NOT produce a
+	// trailing segment (filtered by Empty()).
+	got := Split("SELECT 1;   \n\t")
+	want := []Segment{{"SELECT 1", 0, 8}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `go test ./snowflake/parser/...`
+Expected: clean pass.
+
+- [ ] **Step 3: Verbose run to spot any failures**
+
+Run: `go test -v ./snowflake/parser/... -run TestSplit 2>&1 | grep -E "^(=== RUN|--- (PASS|FAIL))" | tail -60`
+Expected: every subtest PASS. No FAILs.
+
+If any tests fail:
+- If the failure is byte-offset arithmetic (e.g. expected ByteEnd=36 got 37), the test expectation is probably wrong — recompute by hand and fix the test
+- If the failure is a missing segment or extra segment, the state machine logic is wrong — re-read `split.go` Task 3 step 1 and fix
+- If the failure is in the Text field, the slicing bounds are wrong — check `input[stmtStart:end]`
+
+---
+
+## Task 6: Write legacy corpus smoke test
+
+**Files:**
+- Modify: `snowflake/parser/split_test.go`
+
+- [ ] **Step 1: Append the legacy corpus test**
+
+Use Edit to append the following code to the end of `snowflake/parser/split_test.go`:
+
+```go
+
+func TestSplit_LegacyCorpus(t *testing.T) {
+	corpusDir := "testdata/legacy"
+	entries, err := os.ReadDir(corpusDir)
+	if err != nil {
+		t.Fatalf("failed to read corpus dir %s: %v", corpusDir, err)
+	}
+
+	sqlCount := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		sqlCount++
+
+		t.Run(entry.Name(), func(t *testing.T) {
+			path := filepath.Join(corpusDir, entry.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			segments := Split(string(data))
+
+			// Every corpus file must produce at least one segment.
+			if len(segments) == 0 {
+				t.Errorf("%s: Split returned 0 segments", entry.Name())
+				return
+			}
+
+			// Every segment must have valid byte range and non-empty text.
+			for i, seg := range segments {
+				if seg.ByteStart >= seg.ByteEnd {
+					t.Errorf("%s: segment[%d] ByteStart=%d >= ByteEnd=%d",
+						entry.Name(), i, seg.ByteStart, seg.ByteEnd)
+				}
+				if seg.Empty() {
+					t.Errorf("%s: segment[%d] Text is empty or whitespace-only: %q",
+						entry.Name(), i, seg.Text)
+				}
+				// Text must equal the raw slice.
+				if seg.Text != string(data)[seg.ByteStart:seg.ByteEnd] {
+					t.Errorf("%s: segment[%d] Text != input[%d:%d]",
+						entry.Name(), i, seg.ByteStart, seg.ByteEnd)
+				}
+			}
+		})
+	}
+
+	if sqlCount == 0 {
+		t.Errorf("found 0 .sql files in %s — corpus missing?", corpusDir)
+	}
+	if sqlCount != 27 {
+		t.Logf("note: found %d .sql files (expected 27 from the legacy lift)", sqlCount)
+	}
+}
+
+func TestSplit_TaskScriptingHasTwoSegments(t *testing.T) {
+	// task_scripting.sql contains two CREATE TASK statements, each with
+	// an inline BEGIN..END body. The legacy (dumb) splitter would produce
+	// 5+ fragments. F3's state machine must produce exactly 2 segments.
+	data, err := os.ReadFile("testdata/legacy/task_scripting.sql")
+	if err != nil {
+		t.Fatalf("read task_scripting.sql: %v", err)
+	}
+	segments := Split(string(data))
+	if len(segments) != 2 {
+		t.Errorf("Split(task_scripting.sql) returned %d segments, want 2:", len(segments))
+		for i, seg := range segments {
+			t.Errorf("  [%d] [%d,%d] %q", i, seg.ByteStart, seg.ByteEnd, seg.Text)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Add the required imports**
+
+The new tests use `os`, `path/filepath`, and `strings`. Use Edit to update the import block at the top of `split_test.go`:
+
+```go
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+```
+
+(Replace the existing import block `import (\n\t"reflect"\n\t"testing"\n)` with the expanded version above.)
+
+- [ ] **Step 3: Run the tests**
+
+Run: `go test ./snowflake/parser/...`
+Expected: clean pass. The legacy corpus test adds 27 sub-tests (one per `.sql` file) plus the `task_scripting` assertion.
+
+- [ ] **Step 4: Verbose verification**
+
+Run: `go test -v ./snowflake/parser/... -run "TestSplit_LegacyCorpus|TestSplit_TaskScriptingHasTwoSegments" 2>&1 | tail -40`
+Expected: every `.sql` sub-test PASS, and `TestSplit_TaskScriptingHasTwoSegments` PASS.
+
+If `TestSplit_TaskScriptingHasTwoSegments` fails, the state machine is not handling `CREATE TASK ... AS BEGIN ... END;` correctly — likely the `kwBEGIN` lookahead isn't transitioning to `stateInBlock`, or the `kwDECLARE` case is mishandling the `DECLARE x FLOAT; BEGIN` sequence in the second task.
+
+If any corpus file fails, the splitter is producing either too many or zero segments. Read the failing file and trace through the state machine by hand to find the bug.
+
+---
+
+## Task 7: Final acceptance criteria sweep
+
+This task runs every acceptance criterion from the spec back-to-back to confirm F3 is complete.
+
+- [ ] **Step 1: Build**
+
+Run: `go build ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 2: Vet**
+
+Run: `go vet ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Gofmt**
+
+Run: `gofmt -l snowflake/parser/`
+Expected: no output (no files need reformatting).
+
+If any file is listed, run `gofmt -w snowflake/parser/` to apply and re-run the check.
+
+- [ ] **Step 4: Test**
+
+Run: `go test ./snowflake/parser/...`
+Expected:
+```
+ok  	github.com/bytebase/omni/snowflake/parser	(some duration)
+```
+
+- [ ] **Step 5: Verbose test run to confirm test counts**
+
+Run: `go test -v ./snowflake/parser/... 2>&1 | tail -60`
+Expected: all tests PASS. F2 tests (lexer, position, edge, recovery, legacy corpus, keyword completeness) still green. F3 tests (TestSplit_*) all green.
+
+- [ ] **Step 6: Package isolation**
+
+Run: `go build ./snowflake/...`
+Expected: no output, exit 0. Confirms `snowflake/parser` builds without depending on any package beyond F1's `snowflake/ast`.
+
+- [ ] **Step 7: List all files for review**
+
+Run: `git status snowflake/parser docs/superpowers`
+Expected output:
+```
+On branch feat/snowflake/splitter
+Changes not staged for commit:  (none)
+Untracked files:
+	snowflake/parser/split.go
+	snowflake/parser/split_test.go
+```
+
+Plus the already-committed spec doc and plan doc at `docs/superpowers/specs/2026-04-09-snowflake-splitter-design.md` and `docs/superpowers/plans/2026-04-09-snowflake-splitter.md` (which will be tracked).
+
+- [ ] **Step 8: STOP and present for review**
+
+Do NOT commit. Output a summary:
+
+> F3 (snowflake/parser splitter) implementation complete.
+>
+> All 7 tasks done. Acceptance criteria green:
+> - `go build ./snowflake/parser/...` ✓
+> - `go vet ./snowflake/parser/...` ✓
+> - `gofmt -l snowflake/parser/` clean ✓
+> - `go test ./snowflake/parser/...` ✓
+> - 27 legacy corpus files produce ≥1 non-empty segments ✓
+> - task_scripting.sql returns exactly 2 segments ✓
+> - `go build ./snowflake/...` (isolation) ✓
+>
+> Files created:
+> - snowflake/parser/split.go
+> - snowflake/parser/split_test.go
+> - docs/superpowers/plans/2026-04-09-snowflake-splitter.md (this plan)
+>
+> Please review the diff. After your approval I will commit and run finishing-a-development-branch.
+
+---
+
+## Spec Coverage Checklist
+
+| Spec section | Covered by |
+|--------------|-----------|
+| Purpose | Implicitly by having the Split function |
+| Architecture (lexer-based, 3-state machine) | Task 3 |
+| Public API (Segment, Split, Empty) | Tasks 2 + 3 |
+| State machine transitions (stateTop/stateInDeclare/stateInBlock) | Task 3 |
+| TCL vs scripting BEGIN disambiguation | Task 3 (isTCLBeginFollower) + Task 5 tests |
+| Final segment emission (no trailing `;`) | Task 3 (`if stmtStart < len(input)` branch) |
+| Empty segment filtering | Task 2 (Empty method) + Task 3 (`if !seg.Empty()`) |
+| Key Snowflake behaviors (strings, comments, blocks) | Task 5 tests |
+| Divergence from legacy (task_scripting.sql → 2 segments) | Task 6 explicit assertion |
+| File layout (split.go + split_test.go) | Task 1 scaffold |
+| 14 test categories | Tasks 4-6 |
+| 27-file legacy corpus smoke test | Task 6 |
+| Acceptance criteria 1-8 | Task 7 |

--- a/docs/superpowers/specs/2026-04-09-snowflake-splitter-design.md
+++ b/docs/superpowers/specs/2026-04-09-snowflake-splitter-design.md
@@ -1,0 +1,439 @@
+# Snowflake Statement Splitter (F3) — Design
+
+**DAG node:** F3 — `snowflake/parser` statement splitter
+**Migration:** `docs/migration/snowflake/dag.md`
+**Branch:** `feat/snowflake/splitter`
+**Status:** Approved, ready for plan + implementation.
+**Depends on:** F2 (lexer, merged via PR #17) — uses `Lexer.NextToken` as its input source.
+**Unblocks:** nothing parser-side (F4 depends on F1+F2, not F3). But F3 is on the critical path for bytebase's `split.go` and `statement_ranges.go` consumers, which can migrate to omni as soon as F3 lands.
+
+## Purpose
+
+F3 extracts top-level SQL statement byte ranges from a source string. Given a SQL input, it produces a list of `Segment{Text, ByteStart, ByteEnd}` values where each segment is one top-level statement. The byte range covers the statement text only — the trailing `;` (if present) is NOT part of the segment's `Text` or `ByteEnd`. This matches `mysql/parser/split.go`'s convention.
+
+Bytebase consumers today:
+- `backend/plugin/parser/snowflake/split.go` — returns `[]base.Statement` for the editor's statement-execution feature
+- `backend/plugin/parser/snowflake/statement_ranges.go` — returns UTF-16 byte ranges for the editor's statement-highlighting feature
+
+Both consumers currently rely on the legacy ANTLR4 parser's token stream via `base.SplitSQLByLexer(stream, SnowflakeLexerSEMI)`. That base helper splits on every `SEMI` token with **zero depth tracking** — meaning it produces a broken result for Snowflake Scripting `BEGIN..END` blocks. F3 fixes this bug.
+
+## Architecture
+
+F3 is a lexer-based streaming state machine. It reuses F2's `Lexer.NextToken()` rather than doing byte-level scanning (the approach `mysql/parser/split.go` uses). This is a deliberate divergence from the mysql reference — F2's lexer already handles every Snowflake string/comment form correctly (`'...'`, `"..."`, `$$...$$`, `X'...'`, nested `/* */`, `--`, `//`), so re-implementing those byte-walking details would duplicate ~400 LOC of logic. F3 is ~200 LOC instead.
+
+The state machine tracks three states to handle Snowflake Scripting blocks correctly:
+
+- **`stateTop`** — top-level. Semicolons emit statement boundaries.
+- **`stateInDeclare`** — inside a `DECLARE` region before the matching `BEGIN` arrives. Semicolons are suppressed (they terminate individual declarations, not the outer statement).
+- **`stateInBlock(depth)`** — inside a `BEGIN..END` body. Semicolons at depth > 0 are suppressed. Nested `BEGIN..END` pairs are supported via the depth counter.
+
+TCL `BEGIN` (transaction start) is disambiguated from scripting `BEGIN` by one-token lookahead: if the token after `BEGIN` is `kwTRANSACTION`, `kwWORK`, `kwNAME`, `;`, or EOF, it's a TCL transaction start and no block is entered.
+
+## Public API
+
+```go
+package parser
+
+// Segment represents one top-level SQL statement extracted from a source string.
+//
+// Text is the raw substring of the input from ByteStart (inclusive) to
+// ByteEnd (exclusive). It is NOT trimmed — leading/trailing whitespace and
+// comments are preserved verbatim. The trailing `;` delimiter (if present)
+// is NOT part of Text or ByteEnd; it lives between this segment's ByteEnd
+// and the next segment's ByteStart.
+type Segment struct {
+    Text      string // the raw text of the statement (no trailing semicolon)
+    ByteStart int    // inclusive start byte offset in the original source
+    ByteEnd   int    // exclusive end byte offset; points AT the trailing ; if present, otherwise at len(input)
+}
+
+// Empty reports whether the segment contains no meaningful SQL content —
+// that is, only whitespace and comments. It works by re-lexing Text and
+// checking whether the first token is tokEOF.
+//
+// Empty segments are filtered out by Split.
+func (s Segment) Empty() bool
+
+// Split extracts top-level SQL statements from input. The returned slice
+// contains one Segment per non-empty statement. Empty statements (lone
+// semicolons, comment-only chunks) are filtered out.
+//
+// Split is infallible — it always returns a result, even for malformed
+// input. Lexing errors are suppressed internally; callers who need them
+// should use NewLexer(input).Errors() directly.
+//
+// Split correctly handles:
+//   - Single-quoted strings with ' and \\ escapes
+//   - Double-quoted identifiers with " escape
+//   - $$...$$ dollar strings
+//   - X'...' hex literals
+//   - Line comments (-- and //) and block comments (/* */ including nested)
+//   - Snowflake Scripting BEGIN..END blocks (including nested and DECLARE..BEGIN..END)
+//   - Inline procedure bodies (CREATE TASK/PROCEDURE/FUNCTION ... AS BEGIN ... END;)
+//
+// Split does NOT handle:
+//   - IF/FOR/WHILE/REPEAT/CASE at top level (these are only valid inside a BEGIN..END body)
+//   - DECLARE CURSOR at top level without a matching BEGIN (unusual; best-effort)
+//   - DELIMITER directive (MySQL-specific, not used in Snowflake)
+func Split(input string) []Segment
+```
+
+No second `SplitRanges` function. Bytebase consumers that need only byte ranges can call `Split` and extract `{ByteStart, ByteEnd}` from each segment. The convenience wrapper is not worth the API surface.
+
+No error return. The splitter is best-effort; lex errors are available via `Lexer.Errors()` if the caller constructs a lexer explicitly, but `Split` itself is infallible.
+
+## State Machine
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│                        ┌──────────┐                             │
+│                        │          │                             │
+│                  ┌────►│ stateTop │◄─────────────────┐          │
+│                  │     │          │                  │          │
+│                  │     └──┬───┬───┘                  │          │
+│                  │        │   │                      │          │
+│                  │  kwBEGIN   kwDECLARE              │          │
+│                  │  (not TCL) │                      │          │
+│                  │        │   │                      │          │
+│                  │        ▼   ▼                      │          │
+│                  │  ┌─────────────┐   kwBEGIN   ┌────┴────────┐ │
+│               emit ;│             │─────────────►             │ │
+│             (depth  │stateInDeclare│             │stateInBlock │ │
+│                =0)  │             │             │  (depth=1)  │ │
+│                  │  └─────────────┘             │             │ │
+│                  │                              └─┬─────────┬─┘ │
+│                  │                                │         │   │
+│                  │                           kwBEGIN       kwEND│
+│                  │                           depth++       depth│
+│                  │                                │         -- │
+│                  │                                └─────────┘   │
+│                  │                                  (stays)     │
+│                  │                                              │
+│                  │                      kwEND when depth==0     │
+│                  └──────────────────────────────────────────────┘
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Transition rules
+
+**`stateTop`** → initial state. `stmtStart` points at the first byte of the current statement.
+- Token `kwDECLARE` → transition to `stateInDeclare`
+- Token `kwBEGIN` → one-token lookahead: if the next token is `kwTRANSACTION`, `kwWORK`, `kwNAME`, `int(';')`, or `tokEOF`, stay in `stateTop` (TCL BEGIN); otherwise transition to `stateInBlock` with `depth = 1`
+- Token `int(';')` → emit `Segment{Text: trim(input[stmtStart:tok.Loc.End]), ByteStart: stmtStart, ByteEnd: tok.Loc.End}`; set `stmtStart = tok.Loc.End`
+- Any other token → stay
+
+**`stateInDeclare`** → inside a DECLARE region, waiting for the matching BEGIN. The semicolons inside DECLARE terminate individual declarations and must not split the outer statement.
+- Token `kwBEGIN` → transition to `stateInBlock` with `depth = 1`
+- Token `int(';')` → suppressed (no emission)
+- Any other token → stay
+- Token `tokEOF` → emit remaining input as a best-effort final segment
+
+**`stateInBlock(depth)`** → inside a `BEGIN..END` body. Semicolons are suppressed.
+- Token `kwBEGIN` → `depth++` (nested block)
+- Token `kwEND` → `depth--`; if `depth == 0`, transition to `stateTop`
+- Token `int(';')` → suppressed
+- Any other token → stay
+- Token `tokEOF` → emit remaining input as a best-effort final segment (unclosed block)
+
+### Final segment emission
+
+After the main loop exits (on `tokEOF`), if `stmtStart < len(input)`, emit a trailing segment from `stmtStart` to `len(input)`. This covers the case where the last statement has no trailing semicolon.
+
+Apply `Segment.Empty()` filter to all emitted segments — skip any segment whose `Text` (after trimming) is whitespace-only.
+
+## Key Snowflake-specific Behaviors
+
+| Input | Expected output | Why |
+|-------|-----------------|-----|
+| `SELECT 1;` | 1 segment | Trivial split on `;` |
+| `SELECT 1; SELECT 2;` | 2 segments | Two top-level statements |
+| `SELECT 1` | 1 segment (no trailing `;`) | Trailing statement without `;` |
+| `;;;` | 0 segments | All empty, filtered out |
+| `SELECT 'a;b';` | 1 segment | `'a;b'` lexes as one `tokString`, semicolon invisible |
+| `SELECT $$a;b$$;` | 1 segment | `$$a;b$$` lexes as one `tokString` |
+| `SELECT /* ; */ 1;` | 1 segment | Comment dropped by `skipWhitespaceAndComments` |
+| `BEGIN; SELECT 1; COMMIT;` | 3 segments | TCL BEGIN (next is `;`) → stateTop → splits normally |
+| `BEGIN TRANSACTION; SELECT 1; COMMIT;` | 3 segments | TCL BEGIN (next is `kwTRANSACTION`) → stateTop → splits normally |
+| `BEGIN INSERT t VALUES (1); INSERT t VALUES (2); END;` | 1 segment | Scripting BEGIN → stateInBlock → suppresses inner `;` → emits on outer `;` after END |
+| `BEGIN BEGIN SELECT 1; END; END;` | 1 segment | Nested blocks handled via depth counter |
+| `DECLARE x INTEGER; BEGIN x := 1; END;` | 1 segment | DECLARE → stateInDeclare → suppresses `;` after `INTEGER` → BEGIN → stateInBlock → END → stateTop → emits on final `;` |
+| `CREATE PROCEDURE p() AS $$ BEGIN SELECT 1; END; $$;` | 1 segment | Body is one `tokString` (dollar-quoted); splitter never sees inner BEGIN/END/`;` |
+| `CREATE TASK t AS BEGIN SELECT 1; END;` | 1 segment | Inline BEGIN..END body; state machine enters stateInBlock on `kwBEGIN`, suppresses inner `;`, emits on outer `;` after END |
+| `CREATE TASK t AS DECLARE x FLOAT; BEGIN x := 1; END;` | 1 segment | Inline DECLARE..BEGIN..END body; stateInDeclare → stateInBlock → stateTop |
+| `BEGIN SELECT 1;` (unclosed) | 1 segment (best-effort) | stateInBlock stays open until EOF, then emits remaining input |
+
+The `task_scripting.sql` file in the legacy corpus contains the two inline-procedure forms (`CREATE TASK ... AS BEGIN ... END;` and `CREATE TASK ... AS DECLARE ... BEGIN ... END;`) and is the primary regression test for block handling. Expected: **2 segments** (one per CREATE TASK). Under the legacy broken splitter: 5+ fragments.
+
+## Divergence from Legacy Splitter
+
+The legacy bytebase splitter (`base.SplitSQLByLexer(stream, SnowflakeLexerSEMI)`) splits on every `SEMI` token with no depth tracking. This produces incorrect output for any input containing a `BEGIN..END` block — `task_scripting.sql` in particular fragments into 5+ pieces instead of 2.
+
+F3 diverges from this behavior by tracking block depth correctly. This is a **fix**, not a compatibility break:
+- The legacy output is broken by any reasonable interpretation (the fragments aren't individually valid SQL).
+- Bytebase's editor-side consumers will get better results immediately after migration.
+- No downstream behavior depends on the legacy splitter's broken fragmentation.
+
+The divergence is documented in the bytebase migration notes so consumers can validate the new output against their expectations before cutover.
+
+## File Layout
+
+```
+snowflake/parser/split.go        # Split function, Segment struct, state machine
+snowflake/parser/split_test.go   # Table-driven tests + legacy corpus smoke test
+```
+
+Both files added to the existing `snowflake/parser` package (the same package F2's lexer lives in). No new subpackage. No new dependencies beyond `github.com/bytebase/omni/snowflake/ast` (which `snowflake/parser` already imports via F2) — and in fact F3 does not use `ast` directly at all; `Segment` uses plain `int` fields for byte offsets, matching mysql's `Segment` shape.
+
+## Implementation Sketch
+
+```go
+package parser
+
+// Segment represents one top-level SQL statement.
+type Segment struct {
+    Text      string
+    ByteStart int
+    ByteEnd   int
+}
+
+// Empty reports whether the segment contains no meaningful SQL content.
+// It re-lexes Text and checks whether the first token is tokEOF.
+func (s Segment) Empty() bool {
+    return NewLexer(s.Text).NextToken().Type == tokEOF
+}
+
+// splitState is the state machine state for Split.
+type splitState int
+
+const (
+    stateTop splitState = iota
+    stateInDeclare
+    stateInBlock
+)
+
+// Split extracts top-level SQL statements from input.
+func Split(input string) []Segment {
+    if len(input) == 0 {
+        return nil
+    }
+
+    l := NewLexer(input)
+    var segments []Segment
+    stmtStart := 0
+    state := stateTop
+    depth := 0
+
+    // We need one-token lookahead after kwBEGIN to disambiguate TCL from
+    // scripting. Use a buffered "pending" slot — one-slot ring buffer.
+    var pending *Token
+    nextToken := func() Token {
+        if pending != nil {
+            t := *pending
+            pending = nil
+            return t
+        }
+        return l.NextToken()
+    }
+    peekToken := func() Token {
+        if pending == nil {
+            t := l.NextToken()
+            pending = &t
+        }
+        return *pending
+    }
+
+    // emit creates a Segment covering input[stmtStart:end] — where end is
+    // the byte offset BEFORE any trailing delimiter. The caller is
+    // responsible for advancing stmtStart past the delimiter.
+    emit := func(end int) {
+        seg := Segment{
+            Text:      input[stmtStart:end],
+            ByteStart: stmtStart,
+            ByteEnd:   end,
+        }
+        if !seg.Empty() {
+            segments = append(segments, seg)
+        }
+    }
+
+    for {
+        tok := nextToken()
+        if tok.Type == tokEOF {
+            break
+        }
+
+        switch state {
+        case stateTop:
+            switch tok.Type {
+            case kwDECLARE:
+                state = stateInDeclare
+            case kwBEGIN:
+                next := peekToken()
+                if isTCLBeginFollower(next) {
+                    // Stay in stateTop; the buffered peek will be returned
+                    // by the next nextToken() call and handled normally
+                    // (including the `;` emission path if applicable).
+                } else {
+                    state = stateInBlock
+                    depth = 1
+                }
+            case int(';'):
+                // tok.Loc.Start is the position of the `;`, tok.Loc.End is
+                // one past the `;`. Segment text stops BEFORE the `;`; the
+                // next segment starts AFTER the `;`.
+                emit(tok.Loc.Start)
+                stmtStart = tok.Loc.End
+            }
+
+        case stateInDeclare:
+            switch tok.Type {
+            case kwBEGIN:
+                state = stateInBlock
+                depth = 1
+            // Semicolons and all other tokens are absorbed — stay in state.
+            }
+
+        case stateInBlock:
+            switch tok.Type {
+            case kwBEGIN:
+                depth++
+            case kwEND:
+                if depth > 0 {
+                    depth--
+                    if depth == 0 {
+                        state = stateTop
+                    }
+                }
+            // Semicolons and all other tokens are absorbed.
+            }
+        }
+    }
+
+    // Trailing segment — whatever remains after the last `;` (or the whole
+    // input if there was no `;`). ByteEnd is len(input) in this case.
+    if stmtStart < len(input) {
+        emit(len(input))
+    }
+
+    return segments
+}
+
+// isTCLBeginFollower reports whether tok, appearing immediately after a
+// top-level BEGIN keyword, indicates a transaction-start (TCL) rather than
+// a Snowflake Scripting block opener.
+//
+// TCL forms: BEGIN;, BEGIN TRANSACTION, BEGIN WORK, BEGIN NAME <id>, BEGIN EOF
+func isTCLBeginFollower(tok Token) bool {
+    switch tok.Type {
+    case int(';'), tokEOF, kwTRANSACTION, kwWORK, kwNAME:
+        return true
+    }
+    return false
+}
+```
+
+Key positioning rules (matching `mysql/parser/split.go`):
+
+- `tok.Loc.Start` for a `;` token is the byte offset OF the `;`.
+- `tok.Loc.End` for a `;` token is the byte offset just past the `;`.
+- A statement's `ByteEnd` points AT its trailing `;` (so `Text` excludes the `;`).
+- The next statement's `ByteStart` is `tok.Loc.End` — one past the `;`, which may include leading whitespace before the next keyword (that's fine; `Text` is raw).
+
+The `pending` slot acts as a 1-token buffer so we can peek ahead after `kwBEGIN` without losing that next token. When the TCL BEGIN path stays in `stateTop`, the buffered next token is returned by the subsequent `nextToken()` call and processed normally — for example, a `;` after `BEGIN;` will emit the segment correctly.
+
+## Testing
+
+Test file: `snowflake/parser/split_test.go`. Run with `go test ./snowflake/parser/...` (scoped — never global).
+
+### Required test categories
+
+1. **Simple splits** — `SELECT 1`, `SELECT 1;`, `SELECT 1; SELECT 2;`, `SELECT 1; SELECT 2; SELECT 3;`
+2. **Empty statements** — `;`, `;;;`, `;SELECT 1;`, `SELECT 1;;`, `SELECT 1;;SELECT 2;`
+3. **Semicolons in strings** — `SELECT 'a;b';`, `SELECT "a;b";`, `SELECT $$a;b$$;`, `SELECT X'3B';` (`X'3B'` is the byte `;`)
+4. **Comments** — `-- comment\nSELECT 1;`, `// comment\nSELECT 1;`, `/* comment */ SELECT 1;`, `SELECT 1 /* a; b */;`, `/* nested /* */ */SELECT 1;`
+5. **TCL BEGIN** — `BEGIN; SELECT 1; COMMIT;` (3 segments), `BEGIN TRANSACTION; SELECT 1; COMMIT;` (3 segments), `BEGIN WORK; COMMIT;` (2 segments), `BEGIN NAME tx1; COMMIT;` (2 segments)
+6. **Scripting BEGIN..END** — `BEGIN SELECT 1; END;` (1 segment), `BEGIN INSERT t VALUES (1); INSERT t VALUES (2); END;` (1 segment)
+7. **Nested BEGIN..END** — `BEGIN BEGIN SELECT 1; END; END;` (1 segment), 3-deep nesting
+8. **DECLARE..BEGIN..END** — `DECLARE x INT; BEGIN x := 1; END;` (1 segment)
+9. **Inline procedure bodies** — `CREATE TASK t AS BEGIN SELECT 1; END;` (1 segment), `CREATE TASK t AS DECLARE x FLOAT; BEGIN x := 1; END;` (1 segment)
+10. **Dollar-quoted bodies** — `CREATE PROCEDURE p() AS $$ BEGIN SELECT 1; END; $$;` (1 segment; internal `;` invisible because the body is one `tokString`)
+11. **Unclosed block** — `BEGIN SELECT 1;` (no END) → 1 best-effort segment covering the whole input
+12. **Empty input** — `Split("")` returns `nil`
+13. **Position accuracy** — for each representative case, assert `ByteStart` and `ByteEnd` are byte-correct against a hand-computed position
+14. **Legacy corpus smoke test** — iterate every `.sql` file in `snowflake/parser/testdata/legacy/` (27 files); for each file assert:
+    - `Split` returns at least 1 segment
+    - Every segment has `ByteStart < ByteEnd`
+    - No segment's `Text` is empty
+    - The last segment's `ByteEnd` is at or beyond the file's last non-whitespace byte position
+    - Specifically assert that `task_scripting.sql` returns exactly **2 segments** (the two CREATE TASK blocks)
+
+### Test fixture style
+
+Table-driven with a helper:
+
+```go
+func TestSplit_Simple(t *testing.T) {
+    cases := []struct {
+        name  string
+        input string
+        want  []Segment  // Text + ByteStart + ByteEnd
+    }{
+        {"empty", "", nil},
+        {"one with semi", "SELECT 1;", []Segment{{"SELECT 1", 0, 8}}},      // ByteEnd=8 is the `;` position
+        {"one no semi",   "SELECT 1",  []Segment{{"SELECT 1", 0, 8}}},      // ByteEnd=8 is len(input)
+        {"two stmts",     "SELECT 1;SELECT 2;",
+            []Segment{{"SELECT 1", 0, 8}, {"SELECT 2", 9, 17}}},            // Second starts at byte 9 (after `;`)
+        // ...
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            got := Split(c.input)
+            // assert got equals c.want
+        })
+    }
+}
+```
+
+Note on `Text` semantics:
+- `Text = input[ByteStart:ByteEnd]` — the raw substring, NOT trimmed
+- `ByteEnd` is the position OF the trailing `;` (so Text excludes the `;`), or `len(input)` if there's no trailing `;`
+- The next segment's `ByteStart` is the byte AFTER the `;` — meaning leading whitespace may appear at the start of subsequent segments. That's fine; `Empty()` will filter out whitespace-only chunks via re-lexing.
+
+## Out of Scope
+
+F3 does NOT include:
+
+| Feature | Where it lives |
+|---|---|
+| `Parse(sql) (*File, error)` recursive-descent parser | F4 |
+| AST construction | F4 |
+| Syntax validation | F4 |
+| IF/FOR/WHILE/REPEAT/CASE top-level block markers | Handled implicitly because they only exist inside an outer BEGIN..END |
+| UTF-16 byte offset conversion | Bytebase consumer does this on its own |
+| `DELIMITER` directive | MySQL-specific, not in Snowflake |
+| Catalog, completion, semantic, deparse | Separate DAG branches |
+
+## Acceptance Criteria
+
+F3 is complete when:
+
+1. `go build ./snowflake/parser/...` succeeds.
+2. `go vet ./snowflake/parser/...` clean.
+3. `gofmt -l snowflake/parser/` clean.
+4. `go test ./snowflake/parser/...` passes — all F2 tests still pass, plus the new F3 tests.
+5. All 27 files in `snowflake/parser/testdata/legacy/` produce at least one non-empty segment from `Split`.
+6. `task_scripting.sql` specifically returns exactly **2 segments** (verifying BEGIN..END handling).
+7. `go build ./snowflake/...` (isolation check) — F3 builds without depending on any DAG node beyond F1+F2.
+8. After merge, `docs/migration/snowflake/dag.md` F3 status is flipped to `done`.
+
+## Files Created
+
+```
+snowflake/parser/split.go
+snowflake/parser/split_test.go
+docs/superpowers/specs/2026-04-09-snowflake-splitter-design.md  (this file)
+```
+
+Estimated total: ~550 LOC across 2 code files plus this design document.

--- a/snowflake/parser/split.go
+++ b/snowflake/parser/split.go
@@ -1,0 +1,173 @@
+package parser
+
+// Segment represents one top-level SQL statement extracted from a source string.
+//
+// Text is the raw substring of the input from ByteStart (inclusive) to
+// ByteEnd (exclusive). It is NOT trimmed — leading/trailing whitespace and
+// comments are preserved verbatim. The trailing `;` delimiter (if present)
+// is NOT part of Text or ByteEnd; it lives between this segment's ByteEnd
+// and the next segment's ByteStart.
+type Segment struct {
+	Text      string // the raw text of the statement (no trailing semicolon)
+	ByteStart int    // inclusive start byte offset in the original source
+	ByteEnd   int    // exclusive end byte offset; points AT the trailing ; if present, otherwise at len(input)
+}
+
+// Empty reports whether the segment contains no meaningful SQL content —
+// that is, only whitespace and comments. It works by re-lexing Text and
+// checking whether the first token is tokEOF.
+//
+// Empty segments are filtered out by Split.
+func (s Segment) Empty() bool {
+	return NewLexer(s.Text).NextToken().Type == tokEOF
+}
+
+// splitState is the state machine state for Split.
+type splitState int
+
+const (
+	stateTop splitState = iota
+	stateInDeclare
+	stateInBlock
+)
+
+// Split extracts top-level SQL statements from input.
+//
+// The returned slice contains one Segment per non-empty statement. Empty
+// statements (lone semicolons, comment-only chunks) are filtered out.
+//
+// Split is infallible — it always returns a result, even for malformed
+// input. Lexing errors are suppressed internally; callers who need them
+// should use NewLexer(input).Errors() directly.
+//
+// Split correctly handles:
+//   - Single-quoted strings with ” and \ escapes
+//   - Double-quoted identifiers with "" escape
+//   - $$...$$ dollar strings
+//   - X'...' hex literals
+//   - Line comments (-- and //) and block comments (/* */ including nested)
+//   - Snowflake Scripting BEGIN..END blocks (including nested and DECLARE..BEGIN..END)
+//   - Inline procedure bodies (CREATE TASK/PROCEDURE/FUNCTION ... AS BEGIN ... END;)
+//
+// Split does NOT handle:
+//   - IF/FOR/WHILE/REPEAT/CASE at top level (these are only valid inside a BEGIN..END body)
+//   - DECLARE CURSOR at top level without a matching BEGIN (unusual; best-effort)
+//   - DELIMITER directive (MySQL-specific, not used in Snowflake)
+func Split(input string) []Segment {
+	if len(input) == 0 {
+		return nil
+	}
+
+	l := NewLexer(input)
+	var segments []Segment
+	stmtStart := 0
+	state := stateTop
+	depth := 0
+
+	// We need one-token lookahead after kwBEGIN to disambiguate TCL from
+	// scripting. Use a one-slot buffered lookahead.
+	var pending *Token
+	nextToken := func() Token {
+		if pending != nil {
+			t := *pending
+			pending = nil
+			return t
+		}
+		return l.NextToken()
+	}
+	peekToken := func() Token {
+		if pending == nil {
+			t := l.NextToken()
+			pending = &t
+		}
+		return *pending
+	}
+
+	// emit creates a Segment covering input[stmtStart:end] — where end is
+	// the byte offset BEFORE any trailing delimiter. The caller is
+	// responsible for advancing stmtStart past the delimiter.
+	emit := func(end int) {
+		seg := Segment{
+			Text:      input[stmtStart:end],
+			ByteStart: stmtStart,
+			ByteEnd:   end,
+		}
+		if !seg.Empty() {
+			segments = append(segments, seg)
+		}
+	}
+
+	for {
+		tok := nextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+
+		switch state {
+		case stateTop:
+			switch tok.Type {
+			case kwDECLARE:
+				state = stateInDeclare
+			case kwBEGIN:
+				next := peekToken()
+				if isTCLBeginFollower(next) {
+					// Stay in stateTop; the buffered peek will be returned
+					// by the next nextToken() call and handled normally
+					// (including the `;` emission path if applicable).
+				} else {
+					state = stateInBlock
+					depth = 1
+				}
+			case int(';'):
+				// tok.Loc.Start is the position of the `;`, tok.Loc.End is
+				// one past the `;`. Segment text stops BEFORE the `;`; the
+				// next segment starts AFTER the `;`.
+				emit(tok.Loc.Start)
+				stmtStart = tok.Loc.End
+			}
+
+		case stateInDeclare:
+			switch tok.Type {
+			case kwBEGIN:
+				state = stateInBlock
+				depth = 1
+			}
+			// Semicolons and all other tokens are absorbed in stateInDeclare.
+
+		case stateInBlock:
+			switch tok.Type {
+			case kwBEGIN:
+				depth++
+			case kwEND:
+				if depth > 0 {
+					depth--
+					if depth == 0 {
+						state = stateTop
+					}
+				}
+			}
+			// Semicolons and all other tokens are absorbed in stateInBlock.
+		}
+	}
+
+	// Trailing segment — whatever remains after the last `;` (or the whole
+	// input if there was no `;`). ByteEnd is len(input) in this case.
+	if stmtStart < len(input) {
+		emit(len(input))
+	}
+
+	return segments
+}
+
+// isTCLBeginFollower reports whether tok, appearing immediately after a
+// top-level BEGIN keyword, indicates a transaction-start (TCL) rather than
+// a Snowflake Scripting block opener.
+//
+// TCL forms: BEGIN;, BEGIN TRANSACTION, BEGIN WORK, BEGIN NAME <id>, BEGIN EOF
+func isTCLBeginFollower(tok Token) bool {
+	switch tok.Type {
+	case int(';'), tokEOF, kwTRANSACTION, kwWORK, kwNAME:
+		return true
+	}
+	return false
+}

--- a/snowflake/parser/split_test.go
+++ b/snowflake/parser/split_test.go
@@ -1,0 +1,333 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// runSplitCases is a table-driven helper that asserts Split(input) returns
+// exactly the expected Segment list.
+func runSplitCases(t *testing.T, cases []struct {
+	name  string
+	input string
+	want  []Segment
+}) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Split(c.input)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Split(%q) mismatch\n got: %+v\nwant: %+v", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSplit_Empty(t *testing.T) {
+	if got := Split(""); got != nil {
+		t.Errorf("Split(\"\") = %+v, want nil", got)
+	}
+}
+
+func TestSplit_Simple(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"one with semi", "SELECT 1;", []Segment{{"SELECT 1", 0, 8}}},
+		{"one no semi", "SELECT 1", []Segment{{"SELECT 1", 0, 8}}},
+		{"two stmts", "SELECT 1;SELECT 2;", []Segment{
+			{"SELECT 1", 0, 8},
+			{"SELECT 2", 9, 17},
+		}},
+		{"three stmts", "A;B;C;", []Segment{
+			{"A", 0, 1},
+			{"B", 2, 3},
+			{"C", 4, 5},
+		}},
+		{"trailing whitespace", "SELECT 1;  ", []Segment{{"SELECT 1", 0, 8}}},
+		{"leading whitespace", "  SELECT 1;", []Segment{{"  SELECT 1", 0, 10}}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_EmptyStatements(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"lone semi", ";", nil},
+		{"triple semi", ";;;", nil},
+		{"leading semi", ";SELECT 1;", []Segment{{"SELECT 1", 1, 9}}},
+		{"trailing semi", "SELECT 1;;", []Segment{{"SELECT 1", 0, 8}}},
+		{"embedded semi", "SELECT 1;;SELECT 2;", []Segment{
+			{"SELECT 1", 0, 8},
+			{"SELECT 2", 10, 18},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_Positions(t *testing.T) {
+	// Verify byte offsets are accurate for a representative multi-statement input.
+	input := "SELECT 1; SELECT 2; SELECT 3"
+	//        0123456789...
+	//        s1=[0,8] ; s2=[9,18] ; s3=[19,28]
+	got := Split(input)
+	want := []Segment{
+		{"SELECT 1", 0, 8},
+		{" SELECT 2", 9, 18},
+		{" SELECT 3", 19, 28},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestSplit_SemisInStrings(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"single-quoted", "SELECT 'a;b';", []Segment{{"SELECT 'a;b'", 0, 12}}},
+		{"doubled-quote in string", "SELECT 'a''b;c';", []Segment{{"SELECT 'a''b;c'", 0, 15}}},
+		{"dollar-quoted", "SELECT $$a;b$$;", []Segment{{"SELECT $$a;b$$", 0, 14}}},
+		{"hex literal", "SELECT X'3B';", []Segment{{"SELECT X'3B'", 0, 12}}},
+		{"quoted ident with semi", `SELECT "a;b";`, []Segment{{`SELECT "a;b"`, 0, 12}}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_Comments(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"dash line before", "-- comment\nSELECT 1;", []Segment{
+			{"-- comment\nSELECT 1", 0, 19},
+		}},
+		{"slash line before", "// comment\nSELECT 1;", []Segment{
+			{"// comment\nSELECT 1", 0, 19},
+		}},
+		{"block before", "/* comment */ SELECT 1;", []Segment{
+			{"/* comment */ SELECT 1", 0, 22},
+		}},
+		{"inline block", "SELECT /* a; b */ 1;", []Segment{
+			{"SELECT /* a; b */ 1", 0, 19},
+		}},
+		{"nested block", "/* outer /* inner */ still */ SELECT 1;", []Segment{
+			{"/* outer /* inner */ still */ SELECT 1", 0, 38},
+		}},
+		{"comment-only filtered", "-- just a comment\n", nil},
+		{"block comment only filtered", "/* only */", nil},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_TCLBegin(t *testing.T) {
+	// BEGIN followed by ;, TRANSACTION, WORK, NAME, or EOF is a TCL
+	// statement, not a Snowflake Scripting block.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"bare begin semi", "BEGIN; SELECT 1; COMMIT;", []Segment{
+			{"BEGIN", 0, 5},
+			{" SELECT 1", 6, 15},
+			{" COMMIT", 16, 23},
+		}},
+		{"begin transaction", "BEGIN TRANSACTION; SELECT 1; COMMIT;", []Segment{
+			{"BEGIN TRANSACTION", 0, 17},
+			{" SELECT 1", 18, 27},
+			{" COMMIT", 28, 35},
+		}},
+		{"begin work", "BEGIN WORK; COMMIT;", []Segment{
+			{"BEGIN WORK", 0, 10},
+			{" COMMIT", 11, 18},
+		}},
+		{"begin name", "BEGIN NAME tx1; COMMIT;", []Segment{
+			{"BEGIN NAME tx1", 0, 14},
+			{" COMMIT", 15, 22},
+		}},
+		{"begin at eof", "BEGIN", []Segment{
+			{"BEGIN", 0, 5},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_ScriptingBegin(t *testing.T) {
+	// BEGIN followed by non-TCL tokens (INSERT, SELECT, DECLARE, etc.) is
+	// a Snowflake Scripting block — the whole BEGIN..END is one statement.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"simple block", "BEGIN SELECT 1; END;", []Segment{
+			{"BEGIN SELECT 1; END", 0, 19},
+		}},
+		{"two stmts in block", "BEGIN INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); END;", []Segment{
+			{"BEGIN INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); END", 0, 61},
+		}},
+		{"nested block", "BEGIN BEGIN SELECT 1; END; END;", []Segment{
+			{"BEGIN BEGIN SELECT 1; END; END", 0, 30},
+		}},
+		{"block then top-level", "BEGIN SELECT 1; END; SELECT 2;", []Segment{
+			{"BEGIN SELECT 1; END", 0, 19},
+			{" SELECT 2", 20, 29},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_DeclareBegin(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"standalone declare begin", "DECLARE x INTEGER; BEGIN x := 1; END;", []Segment{
+			{"DECLARE x INTEGER; BEGIN x := 1; END", 0, 36},
+		}},
+		{"multiple decls", "DECLARE x INT; y FLOAT; BEGIN x := 1; END;", []Segment{
+			{"DECLARE x INT; y FLOAT; BEGIN x := 1; END", 0, 41},
+		}},
+		{"declare then top-level", "DECLARE x INT; BEGIN SELECT 1; END; SELECT 2;", []Segment{
+			{"DECLARE x INT; BEGIN SELECT 1; END", 0, 34},
+			{" SELECT 2", 35, 44},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_InlineProcedureBody(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"create task begin end", "CREATE TASK t AS BEGIN SELECT 1; END;", []Segment{
+			{"CREATE TASK t AS BEGIN SELECT 1; END", 0, 36},
+		}},
+		{"create task declare begin end", "CREATE TASK t AS DECLARE x FLOAT; BEGIN x := 1; END;", []Segment{
+			{"CREATE TASK t AS DECLARE x FLOAT; BEGIN x := 1; END", 0, 51},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_DollarQuotedBody(t *testing.T) {
+	// Dollar-quoted strings are opaque to the splitter — the entire $$..$$
+	// block lexes as one tokString, so internal ; BEGIN END are invisible.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"proc with dollar body", "CREATE PROCEDURE p() AS $$ BEGIN SELECT 1; END; $$;", []Segment{
+			{"CREATE PROCEDURE p() AS $$ BEGIN SELECT 1; END; $$", 0, 50},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_UnclosedBlock(t *testing.T) {
+	// BEGIN without a matching END should produce a best-effort single
+	// segment covering the whole input.
+	got := Split("BEGIN SELECT 1;")
+	want := []Segment{{"BEGIN SELECT 1;", 0, 15}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split(unclosed BEGIN) = %+v, want %+v", got, want)
+	}
+}
+
+func TestSplit_TrailingWhitespaceAfterSemi(t *testing.T) {
+	// Whitespace-only content after the last `;` should NOT produce a
+	// trailing segment (filtered by Empty()).
+	got := Split("SELECT 1;   \n\t")
+	want := []Segment{{"SELECT 1", 0, 8}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestSplit_LegacyCorpus(t *testing.T) {
+	corpusDir := "testdata/legacy"
+	entries, err := os.ReadDir(corpusDir)
+	if err != nil {
+		t.Fatalf("failed to read corpus dir %s: %v", corpusDir, err)
+	}
+
+	sqlCount := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		sqlCount++
+
+		t.Run(entry.Name(), func(t *testing.T) {
+			path := filepath.Join(corpusDir, entry.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			segments := Split(string(data))
+
+			// Every corpus file must produce at least one segment.
+			if len(segments) == 0 {
+				t.Errorf("%s: Split returned 0 segments", entry.Name())
+				return
+			}
+
+			// Every segment must have valid byte range and non-empty text.
+			for i, seg := range segments {
+				if seg.ByteStart >= seg.ByteEnd {
+					t.Errorf("%s: segment[%d] ByteStart=%d >= ByteEnd=%d",
+						entry.Name(), i, seg.ByteStart, seg.ByteEnd)
+				}
+				if seg.Empty() {
+					t.Errorf("%s: segment[%d] Text is empty or whitespace-only: %q",
+						entry.Name(), i, seg.Text)
+				}
+				// Text must equal the raw slice.
+				if seg.Text != string(data)[seg.ByteStart:seg.ByteEnd] {
+					t.Errorf("%s: segment[%d] Text != input[%d:%d]",
+						entry.Name(), i, seg.ByteStart, seg.ByteEnd)
+				}
+			}
+		})
+	}
+
+	if sqlCount == 0 {
+		t.Errorf("found 0 .sql files in %s — corpus missing?", corpusDir)
+	}
+	if sqlCount != 27 {
+		t.Logf("note: found %d .sql files (expected 27 from the legacy lift)", sqlCount)
+	}
+}
+
+func TestSplit_TaskScriptingHasTwoSegments(t *testing.T) {
+	// task_scripting.sql contains two CREATE TASK statements, each with
+	// an inline BEGIN..END body. The legacy (dumb) splitter would produce
+	// 5+ fragments. F3's state machine must produce exactly 2 segments.
+	data, err := os.ReadFile("testdata/legacy/task_scripting.sql")
+	if err != nil {
+		t.Fatalf("read task_scripting.sql: %v", err)
+	}
+	segments := Split(string(data))
+	if len(segments) != 2 {
+		t.Errorf("Split(task_scripting.sql) returned %d segments, want 2:", len(segments))
+		for i, seg := range segments {
+			t.Errorf("  [%d] [%d,%d] %q", i, seg.ByteStart, seg.ByteEnd, seg.Text)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Third DAG node of the snowflake parser migration (BYT-9000): a lexer-based statement splitter for `snowflake/parser`. Extracts top-level SQL statements from a source string as `Segment{Text, ByteStart, ByteEnd}` values, correctly handling Snowflake Scripting `BEGIN..END` blocks via a 3-state state machine.

Depends on F1 ast-core (PR #14) and F2 lexer (PR #17), both merged. Unblocks bytebase's `backend/plugin/parser/snowflake/{split.go,statement_ranges.go}` consumers, which can migrate from the legacy ANTLR4 parser to omni as soon as this lands.

## Design highlights

- **Lexer-based (not byte-scanner).** Reuses F2's `Lexer.NextToken()` rather than doing byte-level scanning like `mysql/parser/split.go`. Justified because F2 already handles every Snowflake string/comment form correctly: single-quoted strings with `\\` and `''` escapes, double-quoted identifiers with `\"\"` escape, `\$\$...\$\$` dollar strings, `X'...'` hex literals, `--` and `//` line comments, and nested `/* */` block comments. Reimplementing all of that via byte scanning would duplicate ~400 LOC of F2 logic. F3 is ~170 LOC instead.

- **3-state state machine** handles Snowflake Scripting:

  | State | Behavior |
  |---|---|
  | `stateTop` | Semicolons emit statement boundaries |
  | `stateInDeclare` | Inside `DECLARE` before the matching `BEGIN`; semicolons suppressed |
  | `stateInBlock(depth)` | Inside `BEGIN..END`; semicolons at any depth suppressed; nested blocks tracked via depth counter |

- **TCL BEGIN disambiguation via one-token lookahead.** `BEGIN;`, `BEGIN TRANSACTION`, `BEGIN WORK`, `BEGIN NAME ...`, and `BEGIN` at EOF are TCL transaction starts (stay in `stateTop`). Otherwise, `BEGIN` is treated as a Snowflake Scripting block opener (enter `stateInBlock` with depth=1).

- **`Segment` shape matches mysql/parser's convention.** `{Text string, ByteStart int, ByteEnd int}`. `Text` is the raw substring from `ByteStart` (inclusive) to `ByteEnd` (exclusive). `ByteEnd` points AT the trailing `;` (not past it), so `Text` excludes the delimiter. Text is NOT trimmed — leading/trailing whitespace is preserved verbatim.

- **Infallible API.** `Split` never returns an error. Lex errors are collected internally but hidden from callers — the splitter is best-effort and produces segments for malformed input too.

## Fixes a real bug in the legacy splitter

The legacy bytebase splitter (\`base.SplitSQLByLexer(stream, SnowflakeLexerSEMI)\`) splits on every \`;\` token with zero depth tracking, producing **broken output for Snowflake Scripting blocks**. For example, \`snowflake/parser/testdata/legacy/task_scripting.sql\` contains two \`CREATE TASK\` statements with inline \`BEGIN..END\` bodies; the legacy splitter fragments this into 5+ incorrect pieces, while F3's state machine produces exactly **2 segments** (one per CREATE TASK).

This is a deliberate fix, not a compatibility break. The legacy output is broken by any reasonable interpretation (the fragments aren't individually valid SQL). Bytebase's editor-side consumers will get better results immediately after migration.

The regression is guarded by a dedicated test: `TestSplit_TaskScriptingHasTwoSegments` asserts exactly 2 segments for `task_scripting.sql`.

## Public API

```go
type Segment struct {
    Text      string
    ByteStart int
    ByteEnd   int
}

func (s Segment) Empty() bool

func Split(input string) []Segment
```

`Empty()` reports whether the segment is whitespace + comments only by re-lexing Text and checking if the first token is `tokEOF`. Empty segments are filtered out by `Split`.

No separate `SplitRanges` function. Bytebase consumers that need only byte ranges can call `Split()` and extract `{ByteStart, ByteEnd}`.

## Testing

- **506 LOC** across 2 files (`split.go` 173 + `split_test.go` 333)
- **15+ test functions** with 40+ table-driven cases
- **27-file legacy corpus regression smoke test** — every file produces ≥1 non-empty segments
- **`TestSplit_TaskScriptingHasTwoSegments`** — specific regression check for BEGIN..END handling

Test categories cover:
- Simple splits (1/2/3+ statements with/without trailing `;`)
- Empty statements (`;`, `;;;`, leading/trailing/embedded empty)
- Semicolons inside string literals (`'a;b'`, `\$\$a;b\$\$`, `X'3B'`, `\"a;b\"`)
- Comments (all three forms including nested blocks)
- TCL BEGIN variants (bare, TRANSACTION, WORK, NAME, EOF)
- Scripting BEGIN..END (simple, nested 2-deep)
- DECLARE..BEGIN..END blocks
- Inline procedure bodies (`CREATE TASK t AS BEGIN ... END;`)
- Dollar-quoted bodies (`CREATE PROCEDURE p() AS \$\$ BEGIN ... END; \$\$;`)
- Unclosed blocks (best-effort recovery)
- Position accuracy (byte-offset math)

```bash
go test ./snowflake/parser/...     # all tests pass
go vet ./snowflake/parser/...      # clean
gofmt -l snowflake/parser/          # clean
go build ./snowflake/...            # isolated — only depends on F1+F2 within the same package
```

## Divergence note

F3's public API is mysql-compatible (`Segment{Text, ByteStart, ByteEnd}`, infallible `Split`), but the **implementation** diverges from `mysql/parser/split.go` — F3 uses F2's Lexer via `NextToken()`, while mysql does byte-level scanning with `matchWord` helpers. This divergence is justified in the spec ("Implementation Strategy" section): Snowflake's richer lexer handles all string/comment forms, so reusing it avoids ~400 LOC of duplication.

## Spec / plan

- Design spec: `docs/superpowers/specs/2026-04-09-snowflake-splitter-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-09-snowflake-splitter.md`
- Migration DAG: `docs/migration/snowflake/dag.md` — F3 status will be flipped to \`done\` after this PR merges

Also includes `docs(snowflake): mark F2 lexer (DAG node 2) as done` (cherry-picked from local main) — a 1-line DAG status update for F2 that hadn't been pushed yet.

## Test plan

- [ ] CI green on `snowflake/parser/`
- [ ] No regressions in other engine packages (this PR adds new code only; doesn't touch anything outside `snowflake/parser`)
- [ ] Verify `go test -v ./snowflake/parser/... -run TestSplit` shows all F3 tests passing
- [ ] Specifically verify `TestSplit_TaskScriptingHasTwoSegments` passes
- [ ] Verify `TestSplit_LegacyCorpus` has 27 subtests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)