### PR TITLE
feat(snowflake): T1.1 identifiers + qualified names for snowflake parser

### DIFF
--- a/docs/migration/snowflake/dag.md
+++ b/docs/migration/snowflake/dag.md
@@ -29,7 +29,7 @@ snowflake/
 | **F1** | ast-core | `snowflake/ast` | — | F2, C1, C2 | 0 | P0 | **done** (PR #14) |
 | **F2** | lexer | `snowflake/parser` | F1 | C1, C2 | 0 | P0 | **done** (PR #17) |
 | **F3** | statement-splitter | `snowflake/parser` | F2 | F4 | 0 | P0 | **done** (PR #18) |
-| **F4** | parser-entry + walker | `snowflake/parser` | F1, F2 | F3 | 0 | P0 | not started |
+| **F4** | parser-entry + walker | `snowflake/parser` | F1, F2 | F3 | 0 | P0 | **done** (PR #19) |
 | **C1** | corpus-legacy (lift 27 SQL files) | `snowflake/parser/testdata/legacy` | — | F1–F4, C2 | 0 | P0 | **done** |
 | **C2** | corpus-official (scrape docs.snowflake.com) | `snowflake/parser/testdata/official` | — | F1–F4, C1 | 0 | P0 | not started |
 | **T1.1** | identifiers + qualified names + normalization helpers | `snowflake/parser` | F4 | — | 1 | P0 | not started |

--- a/docs/superpowers/plans/2026-04-10-snowflake-identifiers.md
+++ b/docs/superpowers/plans/2026-04-10-snowflake-identifiers.md
@@ -1,0 +1,1085 @@
+# Snowflake Identifiers + Qualified Names (T1.1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `Ident` value struct and `ObjectName` Node struct to `snowflake/ast`, plus `parseIdent` / `parseObjectName` parser helpers to `snowflake/parser`, so every Tier 1+ node has identifier parsing available.
+
+**Architecture:** `Ident` is a value struct (not a Node) carrying `{Name, Quoted, Loc}` with Snowflake-specific normalization (unquoted → UPPERCASE, quoted → as-is). `ObjectName` is a Node with three named `Ident` fields (Database, Schema, Name) matching pg's `RangeVar` shape but with per-part quoted tracking. Parser helpers accept `tokIdent`, `tokQuotedIdent`, and non-reserved keyword tokens via the unexported `keywordReserved` map.
+
+**Tech Stack:** Go 1.25, stdlib only (`strings` for normalization).
+
+**Spec:** `docs/superpowers/specs/2026-04-10-snowflake-identifiers-design.md` (commit `e4f0f4f`)
+
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/identifiers` on branch `feat/snowflake/identifiers`
+
+**Commit policy:** No commits during implementation. The user reviews the full diff at the end.
+
+---
+
+## File Structure
+
+### Modified
+
+| File | Changes | Approx delta |
+|------|---------|-------------|
+| `snowflake/ast/parsenodes.go` | Add `import "strings"`, append `Ident` struct + methods + `ObjectName` struct + methods + compile-time assertion | +120 |
+| `snowflake/ast/nodetags.go` | Append `T_ObjectName` constant + update `String()` | +5 |
+| `snowflake/ast/loc.go` | Append `*ObjectName` case to `NodeLoc` switch | +2 |
+| `snowflake/ast/walk_generated.go` | Regenerated via `go generate` (no new cases — ObjectName has no Node children) | ~0 net |
+
+### Created
+
+| File | Purpose | Approx LOC |
+|------|---------|-----------|
+| `snowflake/ast/identifiers_test.go` | Ident + ObjectName unit tests (Normalize, String, IsEmpty, Parts, Matches, Tag) | 200 |
+| `snowflake/parser/identifiers.go` | parseIdent, parseIdentStrict, parseObjectName, ParseObjectName helpers | 120 |
+| `snowflake/parser/identifiers_test.go` | Parser helper tests (bare/quoted/keyword ident, 1/2/3-part names, errors) | 250 |
+
+**Total: ~700 LOC** across 3 new + 4 modified files.
+
+---
+
+## Task 1: Add Ident struct + methods to parsenodes.go
+
+**Files:**
+- Modify: `snowflake/ast/parsenodes.go`
+
+- [ ] **Step 1: Confirm worktree state**
+
+Run: `pwd && git rev-parse --abbrev-ref HEAD`
+Expected:
+```
+/Users/h3n4l/OpenSource/omni/.worktrees/identifiers
+feat/snowflake/identifiers
+```
+
+- [ ] **Step 2: Add import and Ident to parsenodes.go**
+
+The file currently has no imports. Use Edit to add the import and append the Ident type after the existing `File` block (after line 22 `var _ Node = (*File)(nil)`).
+
+First, add the import. Replace the first line `package ast` with:
+
+```go
+package ast
+
+import "strings"
+```
+
+Then append the Ident struct after `var _ Node = (*File)(nil)`:
+
+```go
+
+// ---------------------------------------------------------------------------
+// Identifier types
+// ---------------------------------------------------------------------------
+
+// Ident represents a single identifier — a name used to reference a database
+// object (table, column, schema, etc.).
+//
+// Name is the raw text from source: for quoted identifiers, the content
+// between the double-quotes with "" un-escaped; for unquoted identifiers,
+// the source bytes with case preserved.
+//
+// Quoted reports whether the source used "..." quoting. This matters because
+// Snowflake case-folds unquoted identifiers to uppercase at resolution time,
+// while quoted identifiers preserve case.
+//
+// Ident is a value struct, NOT a Node. It is embedded by value in parent
+// nodes (e.g. ObjectName) and is not visited by the AST walker.
+//
+// The zero value (Name == "" && Quoted == false) represents an absent
+// identifier — used by ObjectName for unused parts (e.g. a 1-part name
+// has zero Database and Schema).
+type Ident struct {
+	Name   string
+	Quoted bool
+	Loc    Loc
+}
+
+// Normalize returns the canonical form of the identifier per Snowflake
+// resolution rules:
+//   - Quoted identifiers: returned as-is (case-sensitive)
+//   - Unquoted identifiers: uppercased
+func (i Ident) Normalize() string {
+	if i.Quoted {
+		return i.Name
+	}
+	return strings.ToUpper(i.Name)
+}
+
+// String returns the source form of the identifier, re-quoting if it was
+// originally quoted. Inner " characters are escaped as "". Useful for
+// deparse and error messages.
+func (i Ident) String() string {
+	if !i.Quoted {
+		return i.Name
+	}
+	return `"` + strings.ReplaceAll(i.Name, `"`, `""`) + `"`
+}
+
+// IsEmpty reports whether the identifier is the zero value (absent).
+// Used by ObjectName to check whether a part (Database, Schema) is present.
+func (i Ident) IsEmpty() bool {
+	return i.Name == "" && !i.Quoted
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./snowflake/ast/...`
+Expected: no output, exit 0.
+
+Run: `go vet ./snowflake/ast/...`
+Expected: no output, exit 0.
+
+---
+
+## Task 2: Add ObjectName struct + nodetag + NodeLoc + regenerate walker
+
+**Files:**
+- Modify: `snowflake/ast/parsenodes.go`
+- Modify: `snowflake/ast/nodetags.go`
+- Modify: `snowflake/ast/loc.go`
+- Regenerate: `snowflake/ast/walk_generated.go`
+
+- [ ] **Step 1: Append ObjectName to parsenodes.go**
+
+Use Edit to append the following after the `Ident.IsEmpty` function at the end of `snowflake/ast/parsenodes.go`:
+
+```go
+
+// ObjectName represents a qualified object name (1/2/3-part) like
+// `table`, `schema.table`, or `database.schema.table`.
+//
+// For 1-part names, only Name is set (Database and Schema are zero Idents).
+// For 2-part names, Schema and Name are set.
+// For 3-part names, all three are set.
+//
+// ObjectName is a Node and can be used as a child in the AST tree. The
+// walker visits *ObjectName but does NOT descend into the embedded Ident
+// fields (they are value structs, not Nodes).
+type ObjectName struct {
+	Database Ident // may be zero (IsEmpty)
+	Schema   Ident // may be zero (IsEmpty)
+	Name     Ident // always present for a valid ObjectName
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *ObjectName) Tag() NodeTag { return T_ObjectName }
+
+// Compile-time assertion that *ObjectName satisfies Node.
+var _ Node = (*ObjectName)(nil)
+
+// Normalize returns the canonical dotted form with each non-empty part
+// normalized per Snowflake resolution rules.
+//
+// Examples:
+//   - 1-part: "TABLE"
+//   - 2-part: "SCHEMA.TABLE"
+//   - 3-part: "DB.SCHEMA.TABLE"
+func (n ObjectName) Normalize() string {
+	parts := n.Parts()
+	normalized := make([]string, len(parts))
+	for i, p := range parts {
+		normalized[i] = p.Normalize()
+	}
+	return strings.Join(normalized, ".")
+}
+
+// String returns the source form with dots. Each part is re-quoted if it
+// was originally quoted.
+func (n ObjectName) String() string {
+	parts := n.Parts()
+	strs := make([]string, len(parts))
+	for i, p := range parts {
+		strs[i] = p.String()
+	}
+	return strings.Join(strs, ".")
+}
+
+// Parts returns the non-empty parts in order. Length is 1, 2, or 3.
+func (n ObjectName) Parts() []Ident {
+	switch {
+	case !n.Database.IsEmpty():
+		return []Ident{n.Database, n.Schema, n.Name}
+	case !n.Schema.IsEmpty():
+		return []Ident{n.Schema, n.Name}
+	default:
+		return []Ident{n.Name}
+	}
+}
+
+// Matches reports whether this ObjectName suffix-matches other using
+// normalized (case-folded) comparison. A 1-part name matches any other
+// with the same normalized Name. A 2-part name matches any other with
+// the same normalized Schema + Name. A 3-part name requires all three
+// parts to match.
+func (n ObjectName) Matches(other ObjectName) bool {
+	if n.Name.Normalize() != other.Name.Normalize() {
+		return false
+	}
+	if n.Schema.IsEmpty() {
+		return true // 1-part match
+	}
+	if n.Schema.Normalize() != other.Schema.Normalize() {
+		return false
+	}
+	if n.Database.IsEmpty() {
+		return true // 2-part match
+	}
+	return n.Database.Normalize() == other.Database.Normalize()
+}
+```
+
+- [ ] **Step 2: Add T_ObjectName to nodetags.go**
+
+In `snowflake/ast/nodetags.go`, add the constant after `T_File`:
+
+```go
+	// T_ObjectName is the tag for *ObjectName, a qualified 1/2/3-part name.
+	T_ObjectName
+```
+
+And add a case to the `String()` method:
+
+```go
+	case T_ObjectName:
+		return "ObjectName"
+```
+
+- [ ] **Step 3: Add *ObjectName case to NodeLoc in loc.go**
+
+In `snowflake/ast/loc.go`, add a case to the `NodeLoc` switch before the `default`:
+
+```go
+	case *ObjectName:
+		return v.Loc
+```
+
+- [ ] **Step 4: Regenerate walk_generated.go**
+
+Run: `go generate ./snowflake/ast/...`
+Expected output:
+```
+Generated walk_generated.go: 1 cases, 1 child fields
+```
+
+**Important:** The output still says "1 cases, 1 child fields" — the same as before T1.1. This is CORRECT. The generator skips `ObjectName` because it has zero Node-typed child fields (all fields are `Ident` value types or `Loc`). The walker's `walkChildren` switch still has only the `*File` case. This is the expected behavior for leaf Nodes with no children.
+
+- [ ] **Step 5: Verify build and generation round-trip**
+
+Run: `go build ./snowflake/ast/...`
+Expected: no output, exit 0.
+
+Run: `go vet ./snowflake/ast/...`
+Expected: no output, exit 0.
+
+Verify the generated file is stable:
+
+Run: `cp snowflake/ast/walk_generated.go /tmp/walk_gen_before.go && go generate ./snowflake/ast/... && diff /tmp/walk_gen_before.go snowflake/ast/walk_generated.go && echo "BYTE_IDENTICAL" && rm /tmp/walk_gen_before.go`
+Expected: `BYTE_IDENTICAL` (no diff).
+
+Run: `go test ./snowflake/ast/...`
+Expected: all existing F1 tests still pass.
+
+---
+
+## Task 3: Write AST unit tests (identifiers_test.go)
+
+**Files:**
+- Create: `snowflake/ast/identifiers_test.go`
+
+- [ ] **Step 1: Write the full test file**
+
+Create `snowflake/ast/identifiers_test.go`:
+
+```go
+package ast
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Ident tests
+// ---------------------------------------------------------------------------
+
+func TestIdent_Normalize(t *testing.T) {
+	cases := []struct {
+		name   string
+		ident  Ident
+		want   string
+	}{
+		{"unquoted lowercase", Ident{Name: "foo"}, "FOO"},
+		{"unquoted uppercase", Ident{Name: "FOO"}, "FOO"},
+		{"unquoted mixed", Ident{Name: "FoO"}, "FOO"},
+		{"quoted lowercase", Ident{Name: "foo", Quoted: true}, "foo"},
+		{"quoted uppercase", Ident{Name: "FOO", Quoted: true}, "FOO"},
+		{"quoted mixed", Ident{Name: "FoO", Quoted: true}, "FoO"},
+		{"empty unquoted", Ident{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ident.Normalize(); got != c.want {
+				t.Errorf("Normalize() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIdent_String(t *testing.T) {
+	cases := []struct {
+		name  string
+		ident Ident
+		want  string
+	}{
+		{"unquoted", Ident{Name: "foo"}, "foo"},
+		{"quoted simple", Ident{Name: "foo", Quoted: true}, `"foo"`},
+		{"quoted with space", Ident{Name: "my table", Quoted: true}, `"my table"`},
+		{"quoted with inner quote", Ident{Name: `a"b`, Quoted: true}, `"a""b"`},
+		{"empty unquoted", Ident{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ident.String(); got != c.want {
+				t.Errorf("String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIdent_IsEmpty(t *testing.T) {
+	cases := []struct {
+		name  string
+		ident Ident
+		want  bool
+	}{
+		{"zero value", Ident{}, true},
+		{"has name", Ident{Name: "x"}, false},
+		{"quoted empty name", Ident{Quoted: true}, false},
+		{"has loc only", Ident{Loc: Loc{Start: 0, End: 1}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ident.IsEmpty(); got != c.want {
+				t.Errorf("IsEmpty() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ObjectName tests
+// ---------------------------------------------------------------------------
+
+func TestObjectName_Normalize(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  ObjectName
+		want string
+	}{
+		{"1-part unquoted", ObjectName{Name: Ident{Name: "table"}}, "TABLE"},
+		{"1-part quoted", ObjectName{Name: Ident{Name: "Table", Quoted: true}}, "Table"},
+		{"2-part", ObjectName{
+			Schema: Ident{Name: "schema"},
+			Name:   Ident{Name: "table"},
+		}, "SCHEMA.TABLE"},
+		{"3-part", ObjectName{
+			Database: Ident{Name: "db"},
+			Schema:   Ident{Name: "schema"},
+			Name:     Ident{Name: "table"},
+		}, "DB.SCHEMA.TABLE"},
+		{"3-part mixed quoting", ObjectName{
+			Database: Ident{Name: "My DB", Quoted: true},
+			Schema:   Ident{Name: "schema"},
+			Name:     Ident{Name: "Quoted Table", Quoted: true},
+		}, "My DB.SCHEMA.Quoted Table"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.obj.Normalize(); got != c.want {
+				t.Errorf("Normalize() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestObjectName_String(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  ObjectName
+		want string
+	}{
+		{"1-part", ObjectName{Name: Ident{Name: "table"}}, "table"},
+		{"2-part", ObjectName{
+			Schema: Ident{Name: "schema"},
+			Name:   Ident{Name: "table"},
+		}, "schema.table"},
+		{"3-part quoted", ObjectName{
+			Database: Ident{Name: "My DB", Quoted: true},
+			Schema:   Ident{Name: "schema"},
+			Name:     Ident{Name: "Quoted Table", Quoted: true},
+		}, `"My DB".schema."Quoted Table"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.obj.String(); got != c.want {
+				t.Errorf("String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestObjectName_Parts(t *testing.T) {
+	cases := []struct {
+		name     string
+		obj      ObjectName
+		wantLen  int
+	}{
+		{"1-part", ObjectName{Name: Ident{Name: "t"}}, 1},
+		{"2-part", ObjectName{Schema: Ident{Name: "s"}, Name: Ident{Name: "t"}}, 2},
+		{"3-part", ObjectName{Database: Ident{Name: "d"}, Schema: Ident{Name: "s"}, Name: Ident{Name: "t"}}, 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			parts := c.obj.Parts()
+			if len(parts) != c.wantLen {
+				t.Errorf("Parts() len = %d, want %d", len(parts), c.wantLen)
+			}
+		})
+	}
+}
+
+func TestObjectName_Matches(t *testing.T) {
+	mkObj := func(db, schema, name string, dbQ, schemaQ, nameQ bool) ObjectName {
+		o := ObjectName{Name: Ident{Name: name, Quoted: nameQ}}
+		if schema != "" {
+			o.Schema = Ident{Name: schema, Quoted: schemaQ}
+		}
+		if db != "" {
+			o.Database = Ident{Name: db, Quoted: dbQ}
+		}
+		return o
+	}
+
+	cases := []struct {
+		name string
+		a, b ObjectName
+		want bool
+	}{
+		{"1-part matches same name (case-folded)",
+			mkObj("", "", "foo", false, false, false),
+			mkObj("db", "schema", "FOO", false, false, false),
+			true},
+		{"1-part does NOT match different name",
+			mkObj("", "", "foo", false, false, false),
+			mkObj("", "", "bar", false, false, false),
+			false},
+		{"2-part matches same schema.name",
+			mkObj("", "schema", "table", false, false, false),
+			mkObj("db", "SCHEMA", "TABLE", false, false, false),
+			true},
+		{"2-part does NOT match different schema",
+			mkObj("", "schema1", "table", false, false, false),
+			mkObj("", "schema2", "table", false, false, false),
+			false},
+		{"3-part exact match",
+			mkObj("db", "schema", "table", false, false, false),
+			mkObj("DB", "SCHEMA", "TABLE", false, false, false),
+			true},
+		{"3-part does NOT match different db",
+			mkObj("db1", "schema", "table", false, false, false),
+			mkObj("db2", "schema", "table", false, false, false),
+			false},
+		{"quoted vs unquoted are DIFFERENT",
+			mkObj("", "", "foo", false, false, true),
+			mkObj("", "", "foo", false, false, false),
+			false},
+		{"quoted vs unquoted same normalized value",
+			mkObj("", "", "FOO", false, false, true),
+			mkObj("", "", "foo", false, false, false),
+			true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.a.Matches(c.b); got != c.want {
+				t.Errorf("Matches() = %v, want %v\n  a=%+v\n  b=%+v", got, c.want, c.a, c.b)
+			}
+		})
+	}
+}
+
+func TestObjectName_Tag(t *testing.T) {
+	var n ObjectName
+	if (&n).Tag() != T_ObjectName {
+		t.Errorf("Tag() = %v, want T_ObjectName", (&n).Tag())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./snowflake/ast/...`
+Expected: all existing F1 tests plus all new T1.1 AST tests pass.
+
+- [ ] **Step 3: Verbose check**
+
+Run: `go test -v ./snowflake/ast/... -run "TestIdent_|TestObjectName_" 2>&1 | grep -E "^(=== RUN|--- (PASS|FAIL))" | tail -40`
+Expected: every subtest reported as PASS.
+
+---
+
+## Task 4: Write parser helpers (identifiers.go)
+
+**Files:**
+- Create: `snowflake/parser/identifiers.go`
+
+- [ ] **Step 1: Write the full parser helpers file**
+
+Create `snowflake/parser/identifiers.go`:
+
+```go
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// parseIdent parses one identifier from the token stream. Accepts:
+//   - tokIdent (bare identifier)
+//   - tokQuotedIdent (double-quoted identifier)
+//   - Any non-reserved keyword token (type >= 700 and not in keywordReserved)
+//
+// Returns a ParseError if the current token is none of the above.
+func (p *Parser) parseIdent() (ast.Ident, error) {
+	switch {
+	case p.cur.Type == tokIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	case p.cur.Type == tokQuotedIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+	case p.cur.Type >= 700 && !keywordReserved[p.cur.Type]:
+		// Non-reserved keyword used as an identifier.
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	}
+	return ast.Ident{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "expected identifier",
+	}
+}
+
+// parseIdentStrict parses one identifier but ONLY accepts tokIdent or
+// tokQuotedIdent — NOT non-reserved keywords. Used in contexts where
+// keyword-as-identifier is not allowed (rare in Snowflake).
+func (p *Parser) parseIdentStrict() (ast.Ident, error) {
+	switch p.cur.Type {
+	case tokIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	case tokQuotedIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+	}
+	return ast.Ident{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "expected identifier",
+	}
+}
+
+// parseObjectName parses a dotted object name with 1, 2, or 3 parts:
+//
+//	table
+//	schema.table
+//	database.schema.table
+//
+// Starts by parsing one identifier, then greedily consumes up to two more
+// dot-separated identifiers if present. Returns *ast.ObjectName with the
+// correct parts populated and Loc spanning all parts.
+func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
+	first, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type != '.' {
+		// 1-part name.
+		return &ast.ObjectName{
+			Name: first,
+			Loc:  first.Loc,
+		}, nil
+	}
+	p.advance() // consume first dot
+
+	second, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type != '.' {
+		// 2-part name: schema.table.
+		return &ast.ObjectName{
+			Schema: first,
+			Name:   second,
+			Loc:    ast.Loc{Start: first.Loc.Start, End: second.Loc.End},
+		}, nil
+	}
+	p.advance() // consume second dot
+
+	third, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	// 3-part name: database.schema.table.
+	return &ast.ObjectName{
+		Database: first,
+		Schema:   second,
+		Name:     third,
+		Loc:      ast.Loc{Start: first.Loc.Start, End: third.Loc.End},
+	}, nil
+}
+
+// ParseObjectName parses an object name from a standalone string. Returns
+// the ObjectName and any ParseErrors encountered. Useful for catalog
+// lookups, tests, and callers that have a name string but not a token
+// stream.
+//
+// Examples:
+//
+//	ParseObjectName("my_table")
+//	ParseObjectName("schema.table")
+//	ParseObjectName(`"My DB".schema."Quoted Table"`)
+func ParseObjectName(input string) (*ast.ObjectName, []ParseError) {
+	p := &Parser{
+		lexer: NewLexer(input),
+		input: input,
+	}
+	p.advance()
+
+	obj, err := p.parseObjectName()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+
+	// Check for trailing tokens (should be EOF).
+	if p.cur.Type != tokEOF {
+		return obj, []ParseError{{
+			Loc: p.cur.Loc,
+			Msg: "unexpected token after object name",
+		}}
+	}
+
+	return obj, nil
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+Run: `go vet ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+Run: `go test ./snowflake/parser/...`
+Expected: all existing F2/F3/F4 tests still pass.
+
+---
+
+## Task 5: Write parser helper tests (identifiers_test.go)
+
+**Files:**
+- Create: `snowflake/parser/identifiers_test.go`
+
+- [ ] **Step 1: Write the full test file**
+
+Create `snowflake/parser/identifiers_test.go`:
+
+```go
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseIdent is a helper that constructs a Parser from input and
+// calls parseIdent. Since parseIdent is unexported, tests in the same
+// package can call it directly through this helper.
+func testParseIdent(input string) (ast.Ident, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseIdent()
+}
+
+// testParseIdentStrict wraps parseIdentStrict the same way.
+func testParseIdentStrict(input string) (ast.Ident, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseIdentStrict()
+}
+
+// testParseObjectName wraps parseObjectName the same way.
+func testParseObjectName(input string) (*ast.ObjectName, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseObjectName()
+}
+
+// ---------------------------------------------------------------------------
+// parseIdent tests
+// ---------------------------------------------------------------------------
+
+func TestParseIdent_Bare(t *testing.T) {
+	id, err := testParseIdent("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, unquoted}", id)
+	}
+}
+
+func TestParseIdent_Quoted(t *testing.T) {
+	id, err := testParseIdent(`"foo"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || !id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, quoted}", id)
+	}
+}
+
+func TestParseIdent_QuotedWithSpaces(t *testing.T) {
+	id, err := testParseIdent(`"my table"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "my table" || !id.Quoted {
+		t.Errorf("got %+v, want Ident{my table, quoted}", id)
+	}
+}
+
+func TestParseIdent_QuotedEscape(t *testing.T) {
+	// F2's lexer un-escapes "" → " in Token.Str.
+	id, err := testParseIdent(`"a""b"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != `a"b` || !id.Quoted {
+		t.Errorf("got %+v, want Ident{a\"b, quoted}", id)
+	}
+}
+
+func TestParseIdent_NonReservedKeyword(t *testing.T) {
+	// ALERT is a non-reserved keyword — should be accepted as identifier.
+	id, err := testParseIdent("ALERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "ALERT" || id.Quoted {
+		t.Errorf("got %+v, want Ident{ALERT, unquoted}", id)
+	}
+}
+
+func TestParseIdent_ReservedKeyword(t *testing.T) {
+	// SELECT is a reserved keyword — should be rejected.
+	_, err := testParseIdent("SELECT")
+	if err == nil {
+		t.Fatal("expected error for reserved keyword SELECT, got nil")
+	}
+	if pe, ok := err.(*ParseError); ok {
+		if !strings.Contains(pe.Msg, "expected identifier") {
+			t.Errorf("error Msg = %q, want 'expected identifier'", pe.Msg)
+		}
+	} else {
+		t.Errorf("expected *ParseError, got %T", err)
+	}
+}
+
+func TestParseIdent_EOF(t *testing.T) {
+	_, err := testParseIdent("")
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestParseIdent_LocCorrect(t *testing.T) {
+	// "   foo" — the identifier starts at byte 3.
+	id, err := testParseIdent("   foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Loc.Start != 3 || id.Loc.End != 6 {
+		t.Errorf("Loc = %+v, want {3, 6}", id.Loc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseIdentStrict tests
+// ---------------------------------------------------------------------------
+
+func TestParseIdentStrict_AcceptsBare(t *testing.T) {
+	id, err := testParseIdentStrict("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, unquoted}", id)
+	}
+}
+
+func TestParseIdentStrict_AcceptsQuoted(t *testing.T) {
+	id, err := testParseIdentStrict(`"foo"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || !id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, quoted}", id)
+	}
+}
+
+func TestParseIdentStrict_RejectsNonReservedKeyword(t *testing.T) {
+	// parseIdentStrict rejects ALL keywords, even non-reserved ones.
+	_, err := testParseIdentStrict("ALERT")
+	if err == nil {
+		t.Fatal("expected error for keyword ALERT in strict mode, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseObjectName tests
+// ---------------------------------------------------------------------------
+
+func TestParseObjectName_OnePart(t *testing.T) {
+	obj, err := testParseObjectName("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Name.Name != "foo" || !obj.Schema.IsEmpty() || !obj.Database.IsEmpty() {
+		t.Errorf("got %+v, want 1-part name foo", obj)
+	}
+}
+
+func TestParseObjectName_TwoParts(t *testing.T) {
+	obj, err := testParseObjectName("schema.table")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Schema.Name != "schema" || obj.Name.Name != "table" || !obj.Database.IsEmpty() {
+		t.Errorf("got Schema=%q Name=%q DB=%q, want schema.table",
+			obj.Schema.Name, obj.Name.Name, obj.Database.Name)
+	}
+	// Loc should span both parts.
+	if obj.Loc.Start != 0 || obj.Loc.End != 12 {
+		t.Errorf("Loc = %+v, want {0, 12}", obj.Loc)
+	}
+}
+
+func TestParseObjectName_ThreeParts(t *testing.T) {
+	obj, err := testParseObjectName("db.schema.table")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Database.Name != "db" || obj.Schema.Name != "schema" || obj.Name.Name != "table" {
+		t.Errorf("got DB=%q Schema=%q Name=%q, want db.schema.table",
+			obj.Database.Name, obj.Schema.Name, obj.Name.Name)
+	}
+	if obj.Loc.Start != 0 || obj.Loc.End != 15 {
+		t.Errorf("Loc = %+v, want {0, 15}", obj.Loc)
+	}
+}
+
+func TestParseObjectName_Mixed(t *testing.T) {
+	// "My DB".schema."Quoted Table"
+	obj, err := testParseObjectName(`"My DB".schema."Quoted Table"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !obj.Database.Quoted || obj.Database.Name != "My DB" {
+		t.Errorf("Database = %+v, want quoted 'My DB'", obj.Database)
+	}
+	if obj.Schema.Quoted || obj.Schema.Name != "schema" {
+		t.Errorf("Schema = %+v, want unquoted 'schema'", obj.Schema)
+	}
+	if !obj.Name.Quoted || obj.Name.Name != "Quoted Table" {
+		t.Errorf("Name = %+v, want quoted 'Quoted Table'", obj.Name)
+	}
+}
+
+func TestParseObjectName_TrailingDot(t *testing.T) {
+	// "foo." — error after the dot (no identifier follows).
+	_, err := testParseObjectName("foo.")
+	if err == nil {
+		t.Fatal("expected error for trailing dot, got nil")
+	}
+}
+
+func TestParseObjectName_LeadingDot(t *testing.T) {
+	// ".foo" — the dot is not an identifier.
+	_, err := testParseObjectName(".foo")
+	if err == nil {
+		t.Fatal("expected error for leading dot, got nil")
+	}
+}
+
+func TestParseObjectName_DoubleDot(t *testing.T) {
+	// "foo..bar" — error at the second dot.
+	_, err := testParseObjectName("foo..bar")
+	if err == nil {
+		t.Fatal("expected error for double dot, got nil")
+	}
+}
+
+func TestParseObjectName_Freestanding(t *testing.T) {
+	// ParseObjectName is the public freestanding helper.
+	obj, errs := ParseObjectName("db.schema.table")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %+v", errs)
+	}
+	if obj.Database.Name != "db" || obj.Schema.Name != "schema" || obj.Name.Name != "table" {
+		t.Errorf("ParseObjectName mismatch: %+v", obj)
+	}
+}
+
+func TestParseObjectName_FreestandingTrailingTokens(t *testing.T) {
+	// "foo bar" — parses "foo" then complains about trailing "bar".
+	obj, errs := ParseObjectName("foo bar")
+	if obj == nil {
+		t.Fatal("expected non-nil ObjectName even with trailing tokens")
+	}
+	if obj.Name.Name != "foo" {
+		t.Errorf("Name = %q, want foo", obj.Name.Name)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Msg, "unexpected token") {
+		t.Errorf("expected 1 'unexpected token' error, got %+v", errs)
+	}
+}
+
+func TestParseObjectName_FreestandingEmpty(t *testing.T) {
+	_, errs := ParseObjectName("")
+	if len(errs) == 0 {
+		t.Error("expected error for empty input, got none")
+	}
+}
+
+func TestParseObjectName_KeywordAsPart(t *testing.T) {
+	// Non-reserved keyword ALERT should be usable as any part.
+	obj, err := testParseObjectName("ALERT.ALERT.ALERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Database.Name != "ALERT" || obj.Schema.Name != "ALERT" || obj.Name.Name != "ALERT" {
+		t.Errorf("got %+v, want ALERT.ALERT.ALERT", obj)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./snowflake/...`
+Expected: clean pass. All F1 + F2 + F3 + F4 + T1.1 tests green.
+
+- [ ] **Step 3: Verbose check**
+
+Run: `go test -v ./snowflake/parser/... -run "TestParseIdent|TestParseObjectName" 2>&1 | grep -E "^(=== RUN|--- (PASS|FAIL))" | tail -40`
+Expected: every subtest reported as PASS.
+
+---
+
+## Task 6: Final acceptance criteria sweep
+
+- [ ] **Step 1: Build**
+
+Run: `go build ./snowflake/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 2: Vet**
+
+Run: `go vet ./snowflake/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Gofmt**
+
+Run: `gofmt -l snowflake/`
+Expected: no output.
+
+If any file is listed, apply `gofmt -w snowflake/` and re-run.
+
+- [ ] **Step 4: Test**
+
+Run: `go test ./snowflake/...`
+Expected:
+```
+ok  	github.com/bytebase/omni/snowflake/ast	(some duration)
+ok  	github.com/bytebase/omni/snowflake/parser	(some duration)
+```
+
+Both packages pass.
+
+- [ ] **Step 5: Walker generation round-trip**
+
+Run: `cp snowflake/ast/walk_generated.go /tmp/walk_gen_check.go && go generate ./snowflake/ast/... && diff /tmp/walk_gen_check.go snowflake/ast/walk_generated.go && echo "BYTE_IDENTICAL" && rm /tmp/walk_gen_check.go`
+Expected: `BYTE_IDENTICAL`.
+
+- [ ] **Step 6: List all changed files**
+
+Run: `git status snowflake/`
+Expected:
+```
+modified:   snowflake/ast/loc.go
+modified:   snowflake/ast/nodetags.go
+modified:   snowflake/ast/parsenodes.go
+
+Untracked files:
+	snowflake/ast/identifiers_test.go
+	snowflake/parser/identifiers.go
+	snowflake/parser/identifiers_test.go
+```
+
+(`walk_generated.go` should NOT show as modified because the regen produced byte-identical output.)
+
+- [ ] **Step 7: STOP and present for review**
+
+Do NOT commit. Output a summary:
+
+> T1.1 (snowflake identifiers + qualified names) implementation complete.
+>
+> All 6 tasks done. Acceptance criteria green:
+> - `go build ./snowflake/...` ✓
+> - `go vet ./snowflake/...` ✓
+> - `gofmt -l snowflake/` clean ✓
+> - `go test ./snowflake/...` ✓ (both ast and parser)
+> - Walker generation round-trip ✓
+>
+> Files modified/created:
+> - snowflake/ast/parsenodes.go (Ident + ObjectName types)
+> - snowflake/ast/nodetags.go (T_ObjectName)
+> - snowflake/ast/loc.go (*ObjectName case)
+> - snowflake/ast/identifiers_test.go (NEW)
+> - snowflake/parser/identifiers.go (NEW)
+> - snowflake/parser/identifiers_test.go (NEW)
+
+---
+
+## Spec Coverage Checklist
+
+| Spec section | Covered by |
+|---|---|
+| Ident struct (Name, Quoted, Loc) | Task 1 |
+| Ident.Normalize / String / IsEmpty | Task 1 |
+| ObjectName struct (Database, Schema, Name as Ident, Loc) | Task 2 |
+| ObjectName.Tag / Normalize / String / Parts / Matches | Task 2 |
+| T_ObjectName constant + String() | Task 2 |
+| NodeLoc *ObjectName case | Task 2 |
+| Walker regeneration | Task 2 |
+| Ident unit tests (8 categories) | Task 3 |
+| parseIdent / parseIdentStrict | Task 4 |
+| parseObjectName | Task 4 |
+| ParseObjectName freestanding | Task 4 |
+| Parser helper tests (16 categories) | Task 5 |
+| Acceptance criteria | Task 6 |

--- a/docs/superpowers/specs/2026-04-10-snowflake-identifiers-design.md
+++ b/docs/superpowers/specs/2026-04-10-snowflake-identifiers-design.md
@@ -1,0 +1,438 @@
+# Snowflake Identifiers + Qualified Names (T1.1) — Design
+
+**DAG node:** T1.1 — identifiers + qualified names + normalization helpers
+**Migration:** `docs/migration/snowflake/dag.md`
+**Branch:** `feat/snowflake/identifiers`
+**Status:** Approved, ready for plan + implementation.
+**Depends on:** F4 (parser-entry, merged via PR #19).
+**Unblocks:** T1.2 (data types), T1.3 (expressions), T1.4 (SELECT core), and transitively every Tier 1+ node that parses identifier-shaped tokens.
+
+## Purpose
+
+T1.1 adds the identifier and qualified-name building blocks that every subsequent Tier 1+ parser node needs. It ships:
+
+1. **`Ident` struct** in `snowflake/ast` — a single identifier with Name, Quoted flag, and Loc. NOT a Node (no Tag method) — it's a value struct embedded in parent nodes.
+2. **`ObjectName` struct** in `snowflake/ast` — a 1/2/3-part qualified name (database.schema.name) with three named Ident fields. IS a Node (`*ObjectName` satisfies Node via `Tag() NodeTag`).
+3. **Normalization helpers** on Ident and ObjectName — `Normalize()`, `String()`, `IsEmpty()`, `Parts()`, `Matches()`.
+4. **Parser helpers** in `snowflake/parser` — `parseIdent()`, `parseIdentStrict()`, `parseObjectName()`, `ParseObjectName()` (freestanding).
+
+T1.1 does NOT replace any dispatch cases in F4's `parseStmt`. It adds helper functions that Tier 1.2/1.3/1.4/etc. will call when they parse concrete statements containing identifiers.
+
+## Why Snowflake needs a dedicated Ident type (unlike pg/mysql)
+
+pg and mysql don't have a per-identifier `Quoted` flag because their case-folding happens at lex time (pg lower-cases, mysql preserves). Snowflake's case-folding is different:
+
+- **Unquoted identifiers**: source case is preserved through lexing and parsing; case-folding to UPPERCASE happens at **resolution time** (by the query planner).
+- **Quoted identifiers**: case-sensitive, preserved as-is through resolution.
+
+Bytebase's masking and query-span features need to know whether an identifier was quoted to correctly distinguish `foo` (resolves to `FOO`) from `"foo"` (resolves to `foo`). Storing just the string would lose this distinction. The `Quoted bool` flag preserves it at zero runtime cost.
+
+## AST Type Definitions
+
+### `Ident` (value struct, NOT a Node)
+
+Added to `snowflake/ast/parsenodes.go`:
+
+```go
+// Ident represents a single identifier — a name used to reference a database
+// object (table, column, schema, etc.).
+//
+// Name is the raw text from source: for quoted identifiers, the content
+// between the double-quotes with "" un-escaped; for unquoted identifiers,
+// the source bytes with case preserved.
+//
+// Quoted reports whether the source used "..." quoting. This matters because
+// Snowflake case-folds unquoted identifiers to uppercase at resolution time,
+// while quoted identifiers preserve case.
+//
+// Ident is a value struct, NOT a Node. It is embedded by value in parent
+// nodes (e.g. ObjectName) and is not visited by the AST walker.
+//
+// The zero value (Name == "" && Quoted == false) represents an absent
+// identifier — used by ObjectName for unused parts (e.g. a 1-part name
+// has zero Database and Schema).
+type Ident struct {
+    Name   string
+    Quoted bool
+    Loc    Loc
+}
+
+// Normalize returns the canonical form of the identifier per Snowflake
+// resolution rules:
+//   - Quoted identifiers: returned as-is (case-sensitive)
+//   - Unquoted identifiers: uppercased
+func (i Ident) Normalize() string {
+    if i.Quoted {
+        return i.Name
+    }
+    return strings.ToUpper(i.Name)
+}
+
+// String returns the source form of the identifier, re-quoting if it was
+// originally quoted. Inner " characters are escaped as "". Useful for
+// deparse and error messages.
+func (i Ident) String() string {
+    if !i.Quoted {
+        return i.Name
+    }
+    return `"` + strings.ReplaceAll(i.Name, `"`, `""`) + `"`
+}
+
+// IsEmpty reports whether the identifier is the zero value (absent).
+// Used by ObjectName to check whether a part (Database, Schema) is present.
+func (i Ident) IsEmpty() bool {
+    return i.Name == "" && !i.Quoted
+}
+```
+
+Note: `Ident` needs `import "strings"` in `parsenodes.go`. Since the current file doesn't have any imports, this will add an import block.
+
+### `ObjectName` (Node)
+
+Also in `snowflake/ast/parsenodes.go`:
+
+```go
+// ObjectName represents a qualified object name (1/2/3-part) like
+// `table`, `schema.table`, or `database.schema.table`.
+//
+// For 1-part names, only Name is set (Database and Schema are zero Idents).
+// For 2-part names, Schema and Name are set.
+// For 3-part names, all three are set.
+//
+// ObjectName is a Node and can be used as a child in the AST tree. The
+// walker visits *ObjectName but does NOT descend into the embedded Ident
+// fields (they are value structs, not Nodes).
+type ObjectName struct {
+    Database Ident // may be zero (IsEmpty)
+    Schema   Ident // may be zero (IsEmpty)
+    Name     Ident // always present for a valid ObjectName
+    Loc      Loc
+}
+
+// Tag implements Node.
+func (n *ObjectName) Tag() NodeTag { return T_ObjectName }
+
+// Compile-time assertion that *ObjectName satisfies Node.
+var _ Node = (*ObjectName)(nil)
+
+// Normalize returns the canonical dotted form with each non-empty part
+// normalized per Snowflake resolution rules.
+//
+// Examples:
+//   - 1-part: "TABLE"
+//   - 2-part: "SCHEMA.TABLE"
+//   - 3-part: "DB.SCHEMA.TABLE"
+func (n ObjectName) Normalize() string {
+    parts := n.Parts()
+    normalized := make([]string, len(parts))
+    for i, p := range parts {
+        normalized[i] = p.Normalize()
+    }
+    return strings.Join(normalized, ".")
+}
+
+// String returns the source form with dots. Each part is re-quoted if it
+// was originally quoted.
+func (n ObjectName) String() string {
+    parts := n.Parts()
+    strs := make([]string, len(parts))
+    for i, p := range parts {
+        strs[i] = p.String()
+    }
+    return strings.Join(strs, ".")
+}
+
+// Parts returns the non-empty parts in order. Length is 1, 2, or 3.
+func (n ObjectName) Parts() []Ident {
+    switch {
+    case !n.Database.IsEmpty():
+        return []Ident{n.Database, n.Schema, n.Name}
+    case !n.Schema.IsEmpty():
+        return []Ident{n.Schema, n.Name}
+    default:
+        return []Ident{n.Name}
+    }
+}
+
+// Matches reports whether this ObjectName suffix-matches other using
+// normalized (case-folded) comparison. A 1-part name matches any other
+// with the same normalized Name. A 2-part name matches any other with
+// the same normalized Schema + Name. A 3-part name requires all three
+// parts to match.
+func (n ObjectName) Matches(other ObjectName) bool {
+    if n.Name.Normalize() != other.Name.Normalize() {
+        return false
+    }
+    if n.Schema.IsEmpty() {
+        return true // 1-part match
+    }
+    if n.Schema.Normalize() != other.Schema.Normalize() {
+        return false
+    }
+    if n.Database.IsEmpty() {
+        return true // 2-part match
+    }
+    return n.Database.Normalize() == other.Database.Normalize()
+}
+```
+
+### NodeTag additions
+
+Add to `snowflake/ast/nodetags.go`:
+
+```go
+T_ObjectName
+```
+
+(After `T_File`. `T_Ident` is NOT added because Ident is not a Node.)
+
+Also update `NodeTag.String()` to include the new tag.
+
+### Walker regeneration
+
+After adding `ObjectName` to `parsenodes.go`, run `go generate ./snowflake/ast/...` to regenerate `walk_generated.go`. The generator will add a case for `*ObjectName` with NO child walks (all fields are non-Node value types: `Ident`, `Loc`).
+
+### `NodeLoc` update
+
+Add a case for `*ObjectName` in `snowflake/ast/loc.go`'s `NodeLoc` switch:
+
+```go
+case *ObjectName:
+    return v.Loc
+```
+
+## Parser Helpers
+
+Added in a new file `snowflake/parser/identifiers.go`:
+
+```go
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// parseIdent parses one identifier from the token stream. Accepts:
+//   - tokIdent (bare identifier)
+//   - tokQuotedIdent (double-quoted identifier)
+//   - Any non-reserved keyword token (type >= 700 and not in keywordReserved)
+//
+// Returns a ParseError if the current token is none of the above.
+func (p *Parser) parseIdent() (ast.Ident, error) {
+    switch {
+    case p.cur.Type == tokIdent:
+        tok := p.advance()
+        return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+    case p.cur.Type == tokQuotedIdent:
+        tok := p.advance()
+        return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+    case p.cur.Type >= 700 && !keywordReserved[p.cur.Type]:
+        tok := p.advance()
+        return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+    }
+    return ast.Ident{}, &ParseError{
+        Loc: p.cur.Loc,
+        Msg: "expected identifier",
+    }
+}
+
+// parseIdentStrict parses one identifier but ONLY accepts tokIdent or
+// tokQuotedIdent — NOT non-reserved keywords. Used in contexts where
+// keyword-as-identifier is not allowed (rare in Snowflake).
+func (p *Parser) parseIdentStrict() (ast.Ident, error) {
+    switch p.cur.Type {
+    case tokIdent:
+        tok := p.advance()
+        return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+    case tokQuotedIdent:
+        tok := p.advance()
+        return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+    }
+    return ast.Ident{}, &ParseError{
+        Loc: p.cur.Loc,
+        Msg: "expected identifier",
+    }
+}
+
+// parseObjectName parses a dotted object name with 1, 2, or 3 parts:
+//   table
+//   schema.table
+//   database.schema.table
+//
+// Starts by parsing one identifier, then greedily consumes up to two more
+// .-separated identifiers if present. Returns *ast.ObjectName with the
+// correct parts populated.
+func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
+    first, err := p.parseIdent()
+    if err != nil {
+        return nil, err
+    }
+
+    if p.cur.Type != '.' {
+        // 1-part name
+        return &ast.ObjectName{
+            Name: first,
+            Loc:  first.Loc,
+        }, nil
+    }
+    p.advance() // consume first dot
+
+    second, err := p.parseIdent()
+    if err != nil {
+        return nil, err
+    }
+
+    if p.cur.Type != '.' {
+        // 2-part name: schema.table
+        return &ast.ObjectName{
+            Schema: first,
+            Name:   second,
+            Loc:    ast.Loc{Start: first.Loc.Start, End: second.Loc.End},
+        }, nil
+    }
+    p.advance() // consume second dot
+
+    third, err := p.parseIdent()
+    if err != nil {
+        return nil, err
+    }
+
+    // 3-part name: database.schema.table
+    return &ast.ObjectName{
+        Database: first,
+        Schema:   second,
+        Name:     third,
+        Loc:      ast.Loc{Start: first.Loc.Start, End: third.Loc.End},
+    }, nil
+}
+
+// ParseObjectName parses an object name from a standalone string. Returns
+// the ObjectName and any ParseErrors encountered. Useful for catalog
+// lookups, tests, and callers that have a name string but not a token
+// stream.
+//
+// Examples:
+//   ParseObjectName("my_table")
+//   ParseObjectName("schema.table")
+//   ParseObjectName(`"My DB".schema."Quoted Table"`)
+func ParseObjectName(input string) (*ast.ObjectName, []ParseError) {
+    p := &Parser{
+        lexer: NewLexer(input),
+        input: input,
+    }
+    p.advance()
+
+    obj, err := p.parseObjectName()
+    if err != nil {
+        if pe, ok := err.(*ParseError); ok {
+            return nil, []ParseError{*pe}
+        }
+        return nil, []ParseError{{Msg: err.Error()}}
+    }
+
+    // Check for trailing tokens (should be EOF).
+    if p.cur.Type != tokEOF {
+        return obj, []ParseError{{
+            Loc: p.cur.Loc,
+            Msg: "unexpected token after object name",
+        }}
+    }
+
+    return obj, nil
+}
+```
+
+## File Layout
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `snowflake/ast/parsenodes.go` | Append `Ident` struct + methods, `ObjectName` struct + methods. Add `import "strings"` |
+| `snowflake/ast/nodetags.go` | Append `T_ObjectName` constant + update `String()` |
+| `snowflake/ast/loc.go` | Append `*ObjectName` case to `NodeLoc` switch |
+| `snowflake/ast/walk_generated.go` | Regenerated via `go generate` (adds empty `*ObjectName` case) |
+
+### Created files
+
+| File | Purpose | Approx LOC |
+|------|---------|-----------|
+| `snowflake/parser/identifiers.go` | `parseIdent`, `parseIdentStrict`, `parseObjectName`, `ParseObjectName` | 120 |
+| `snowflake/parser/identifiers_test.go` | Parser helper tests | 250 |
+| `snowflake/ast/identifiers_test.go` | Ident/ObjectName unit tests (Normalize, String, Matches, etc.) | 200 |
+
+**Estimated total: ~570 LOC** of new code across 3 new + 4 modified files.
+
+## Testing
+
+### `snowflake/ast/identifiers_test.go`
+
+1. **TestIdent_Normalize** — `Ident{"foo", false, _}.Normalize() == "FOO"`; `Ident{"foo", true, _}.Normalize() == "foo"`
+2. **TestIdent_String** — unquoted returns Name as-is; quoted re-wraps in `"..."` with `""` escape
+3. **TestIdent_IsEmpty** — zero value is empty; non-empty Name is not empty
+4. **TestObjectName_Normalize** — 1/2/3-part: `"TABLE"`, `"SCHEMA.TABLE"`, `"DB.SCHEMA.TABLE"`
+5. **TestObjectName_String** — round-trip: `"My DB".schema.TABLE`
+6. **TestObjectName_Parts** — correct count and order for 1/2/3-part names
+7. **TestObjectName_Matches** — suffix match: 1-part matches 3-part with same name; 2-part matches only if schema matches; 3-part exact; quoted-vs-unquoted are DIFFERENT
+8. **TestObjectName_Tag** — `(*ObjectName)(nil).Tag() == T_ObjectName` (compile-time + runtime assertion)
+
+### `snowflake/parser/identifiers_test.go`
+
+1. **TestParseIdent_Bare** — `foo` → `Ident{Name: "foo", Quoted: false}`
+2. **TestParseIdent_Quoted** — `"foo"` → `Ident{Name: "foo", Quoted: true}`
+3. **TestParseIdent_QuotedWithSpaces** — `"my table"` → `Ident{Name: "my table", Quoted: true}`
+4. **TestParseIdent_QuotedEscape** — `"a""b"` → `Ident{Name: "a\"b", Quoted: true}` (F2 lexer already un-escapes)
+5. **TestParseIdent_NonReservedKeyword** — `ALERT` → `Ident{Name: "ALERT", Quoted: false}`
+6. **TestParseIdent_ReservedKeyword** — `SELECT` → ParseError "expected identifier"
+7. **TestParseIdent_EOF** — empty → ParseError
+8. **TestParseObjectName_OnePart** — `foo` → `ObjectName{Name: {"foo", false, _}}`
+9. **TestParseObjectName_TwoParts** — `schema.table` → `ObjectName{Schema: _, Name: _}`
+10. **TestParseObjectName_ThreeParts** — `db.schema.table` → all three set
+11. **TestParseObjectName_Mixed** — `"My DB".schema."Quoted Table"` → per-part Quoted flags correct
+12. **TestParseObjectName_TrailingDot** — `foo.` → error after the dot
+13. **TestParseObjectName_LeadingDot** — `.foo` → error at the dot (not an identifier)
+14. **TestParseObjectName_DoubleDot** — `foo..bar` → error at the second dot
+15. **TestParseObjectName_FreestandingHelper** — `ParseObjectName("db.schema.table")` → correct ObjectName + no errors; `ParseObjectName("foo bar")` → ObjectName + trailing-token error
+16. **TestParseIdentStrict_RejectsKeyword** — `ALERT` → error (even though ALERT is non-reserved)
+
+Run scope: `go test ./snowflake/...`
+
+## Out of Scope
+
+| Feature | Where it lives |
+|---|---|
+| Column references (`table.column` in expressions) | T1.3 (expressions) |
+| FROM clause alias handling (`FROM t AS alias`) | T1.4 (SELECT core) |
+| Table function syntax (`FLATTEN(...)`) | T5.3 |
+| Type names (`VARCHAR(100)`, `NUMBER(38,0)`) | T1.2 (data types) |
+| Catalog/schema-resolution logic | `snowflake/catalog` (not yet in DAG) |
+| Deparse (ObjectName → SQL string round-trip) | T3.2 |
+
+## Acceptance Criteria
+
+T1.1 is complete when:
+
+1. `go build ./snowflake/...` succeeds.
+2. `go vet ./snowflake/...` clean.
+3. `gofmt -l snowflake/` clean.
+4. `go test ./snowflake/...` passes — all F1/F2/F3/F4 tests still green + all T1.1 tests.
+5. `go generate ./snowflake/ast/...` produces a byte-identical `walk_generated.go`.
+6. `Ident.Normalize()` correctly uppercases unquoted identifiers and preserves quoted identifiers.
+7. `ObjectName.Matches()` correctly handles suffix-match semantics with normalized comparison.
+8. `parseIdent()` accepts `tokIdent`, `tokQuotedIdent`, and non-reserved keyword tokens — rejects reserved keywords.
+9. `parseObjectName()` correctly parses 1/2/3-part dotted names with correct Loc spanning all parts.
+10. `ParseObjectName(input)` freestanding helper works correctly for standalone string inputs.
+11. After merge, `docs/migration/snowflake/dag.md` T1.1 status is flipped to `done`.
+
+## Files Created / Modified
+
+```
+snowflake/ast/parsenodes.go          (MODIFIED: +Ident, +ObjectName, +methods, +import "strings")
+snowflake/ast/nodetags.go            (MODIFIED: +T_ObjectName, +String case)
+snowflake/ast/loc.go                 (MODIFIED: +*ObjectName case in NodeLoc)
+snowflake/ast/walk_generated.go      (REGENERATED via go generate)
+snowflake/ast/identifiers_test.go    (NEW: Ident/ObjectName unit tests)
+snowflake/parser/identifiers.go      (NEW: parseIdent, parseIdentStrict, parseObjectName, ParseObjectName)
+snowflake/parser/identifiers_test.go (NEW: parser helper tests)
+docs/superpowers/specs/2026-04-10-snowflake-identifiers-design.md (this file)
+```
+
+Estimated total: ~570 LOC across 3 new + 4 modified files.

--- a/snowflake/ast/identifiers_test.go
+++ b/snowflake/ast/identifiers_test.go
@@ -1,0 +1,219 @@
+package ast
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Ident tests
+// ---------------------------------------------------------------------------
+
+func TestIdent_Normalize(t *testing.T) {
+	cases := []struct {
+		name  string
+		ident Ident
+		want  string
+	}{
+		{"unquoted lowercase", Ident{Name: "foo"}, "FOO"},
+		{"unquoted uppercase", Ident{Name: "FOO"}, "FOO"},
+		{"unquoted mixed", Ident{Name: "FoO"}, "FOO"},
+		{"quoted lowercase", Ident{Name: "foo", Quoted: true}, "foo"},
+		{"quoted uppercase", Ident{Name: "FOO", Quoted: true}, "FOO"},
+		{"quoted mixed", Ident{Name: "FoO", Quoted: true}, "FoO"},
+		{"empty unquoted", Ident{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ident.Normalize(); got != c.want {
+				t.Errorf("Normalize() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIdent_String(t *testing.T) {
+	cases := []struct {
+		name  string
+		ident Ident
+		want  string
+	}{
+		{"unquoted", Ident{Name: "foo"}, "foo"},
+		{"quoted simple", Ident{Name: "foo", Quoted: true}, `"foo"`},
+		{"quoted with space", Ident{Name: "my table", Quoted: true}, `"my table"`},
+		{"quoted with inner quote", Ident{Name: `a"b`, Quoted: true}, `"a""b"`},
+		{"empty unquoted", Ident{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ident.String(); got != c.want {
+				t.Errorf("String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIdent_IsEmpty(t *testing.T) {
+	cases := []struct {
+		name  string
+		ident Ident
+		want  bool
+	}{
+		{"zero value", Ident{}, true},
+		{"has name", Ident{Name: "x"}, false},
+		{"quoted empty name", Ident{Quoted: true}, false},
+		{"has loc only", Ident{Loc: Loc{Start: 0, End: 1}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ident.IsEmpty(); got != c.want {
+				t.Errorf("IsEmpty() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ObjectName tests
+// ---------------------------------------------------------------------------
+
+func TestObjectName_Normalize(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  ObjectName
+		want string
+	}{
+		{"1-part unquoted", ObjectName{Name: Ident{Name: "table"}}, "TABLE"},
+		{"1-part quoted", ObjectName{Name: Ident{Name: "Table", Quoted: true}}, "Table"},
+		{"2-part", ObjectName{
+			Schema: Ident{Name: "schema"},
+			Name:   Ident{Name: "table"},
+		}, "SCHEMA.TABLE"},
+		{"3-part", ObjectName{
+			Database: Ident{Name: "db"},
+			Schema:   Ident{Name: "schema"},
+			Name:     Ident{Name: "table"},
+		}, "DB.SCHEMA.TABLE"},
+		{"3-part mixed quoting", ObjectName{
+			Database: Ident{Name: "My DB", Quoted: true},
+			Schema:   Ident{Name: "schema"},
+			Name:     Ident{Name: "Quoted Table", Quoted: true},
+		}, "My DB.SCHEMA.Quoted Table"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.obj.Normalize(); got != c.want {
+				t.Errorf("Normalize() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestObjectName_String(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  ObjectName
+		want string
+	}{
+		{"1-part", ObjectName{Name: Ident{Name: "table"}}, "table"},
+		{"2-part", ObjectName{
+			Schema: Ident{Name: "schema"},
+			Name:   Ident{Name: "table"},
+		}, "schema.table"},
+		{"3-part quoted", ObjectName{
+			Database: Ident{Name: "My DB", Quoted: true},
+			Schema:   Ident{Name: "schema"},
+			Name:     Ident{Name: "Quoted Table", Quoted: true},
+		}, `"My DB".schema."Quoted Table"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.obj.String(); got != c.want {
+				t.Errorf("String() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestObjectName_Parts(t *testing.T) {
+	cases := []struct {
+		name    string
+		obj     ObjectName
+		wantLen int
+	}{
+		{"1-part", ObjectName{Name: Ident{Name: "t"}}, 1},
+		{"2-part", ObjectName{Schema: Ident{Name: "s"}, Name: Ident{Name: "t"}}, 2},
+		{"3-part", ObjectName{Database: Ident{Name: "d"}, Schema: Ident{Name: "s"}, Name: Ident{Name: "t"}}, 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			parts := c.obj.Parts()
+			if len(parts) != c.wantLen {
+				t.Errorf("Parts() len = %d, want %d", len(parts), c.wantLen)
+			}
+		})
+	}
+}
+
+func TestObjectName_Matches(t *testing.T) {
+	mkObj := func(db, schema, name string, dbQ, schemaQ, nameQ bool) ObjectName {
+		o := ObjectName{Name: Ident{Name: name, Quoted: nameQ}}
+		if schema != "" {
+			o.Schema = Ident{Name: schema, Quoted: schemaQ}
+		}
+		if db != "" {
+			o.Database = Ident{Name: db, Quoted: dbQ}
+		}
+		return o
+	}
+
+	cases := []struct {
+		name string
+		a, b ObjectName
+		want bool
+	}{
+		{"1-part matches same name (case-folded)",
+			mkObj("", "", "foo", false, false, false),
+			mkObj("db", "schema", "FOO", false, false, false),
+			true},
+		{"1-part does NOT match different name",
+			mkObj("", "", "foo", false, false, false),
+			mkObj("", "", "bar", false, false, false),
+			false},
+		{"2-part matches same schema.name",
+			mkObj("", "schema", "table", false, false, false),
+			mkObj("db", "SCHEMA", "TABLE", false, false, false),
+			true},
+		{"2-part does NOT match different schema",
+			mkObj("", "schema1", "table", false, false, false),
+			mkObj("", "schema2", "table", false, false, false),
+			false},
+		{"3-part exact match",
+			mkObj("db", "schema", "table", false, false, false),
+			mkObj("DB", "SCHEMA", "TABLE", false, false, false),
+			true},
+		{"3-part does NOT match different db",
+			mkObj("db1", "schema", "table", false, false, false),
+			mkObj("db2", "schema", "table", false, false, false),
+			false},
+		{"quoted vs unquoted are DIFFERENT",
+			mkObj("", "", "foo", false, false, true),
+			mkObj("", "", "foo", false, false, false),
+			false},
+		{"quoted vs unquoted same normalized value",
+			mkObj("", "", "FOO", false, false, true),
+			mkObj("", "", "foo", false, false, false),
+			true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.a.Matches(c.b); got != c.want {
+				t.Errorf("Matches() = %v, want %v\n  a=%+v\n  b=%+v", got, c.want, c.a, c.b)
+			}
+		})
+	}
+}
+
+func TestObjectName_Tag(t *testing.T) {
+	var n ObjectName
+	if (&n).Tag() != T_ObjectName {
+		t.Errorf("Tag() = %v, want T_ObjectName", (&n).Tag())
+	}
+}

--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -12,6 +12,8 @@ func NodeLoc(n Node) Loc {
 	switch v := n.(type) {
 	case *File:
 		return v.Loc
+	case *ObjectName:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -18,6 +18,9 @@ const (
 	// T_File is the tag for *File, the root statement-list container
 	// returned by F4 (parser-entry).
 	T_File
+
+	// T_ObjectName is the tag for *ObjectName, a qualified 1/2/3-part name.
+	T_ObjectName
 )
 
 // String returns a human-readable representation of the tag.
@@ -27,6 +30,8 @@ func (t NodeTag) String() string {
 		return "Invalid"
 	case T_File:
 		return "File"
+	case T_ObjectName:
+		return "ObjectName"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1,5 +1,7 @@
 package ast
 
+import "strings"
+
 // This file holds the concrete snowflake parse-tree node types. F1 ships
 // only the File root container; Tier 1+ migration nodes (identifiers,
 // types, expressions, SELECT core, DDL, etc.) populate the rest.
@@ -20,3 +22,140 @@ func (f *File) Tag() NodeTag { return T_File }
 
 // Compile-time assertion that *File satisfies Node.
 var _ Node = (*File)(nil)
+
+// ---------------------------------------------------------------------------
+// Identifier types
+// ---------------------------------------------------------------------------
+
+// Ident represents a single identifier — a name used to reference a database
+// object (table, column, schema, etc.).
+//
+// Name is the raw text from source: for quoted identifiers, the content
+// between the double-quotes with "" un-escaped; for unquoted identifiers,
+// the source bytes with case preserved.
+//
+// Quoted reports whether the source used "..." quoting. This matters because
+// Snowflake case-folds unquoted identifiers to uppercase at resolution time,
+// while quoted identifiers preserve case.
+//
+// Ident is a value struct, NOT a Node. It is embedded by value in parent
+// nodes (e.g. ObjectName) and is not visited by the AST walker.
+//
+// The zero value (Name == "" && Quoted == false) represents an absent
+// identifier — used by ObjectName for unused parts (e.g. a 1-part name
+// has zero Database and Schema).
+type Ident struct {
+	Name   string
+	Quoted bool
+	Loc    Loc
+}
+
+// Normalize returns the canonical form of the identifier per Snowflake
+// resolution rules:
+//   - Quoted identifiers: returned as-is (case-sensitive)
+//   - Unquoted identifiers: uppercased
+func (i Ident) Normalize() string {
+	if i.Quoted {
+		return i.Name
+	}
+	return strings.ToUpper(i.Name)
+}
+
+// String returns the source form of the identifier, re-quoting if it was
+// originally quoted. Inner " characters are escaped as "". Useful for
+// deparse and error messages.
+func (i Ident) String() string {
+	if !i.Quoted {
+		return i.Name
+	}
+	return `"` + strings.ReplaceAll(i.Name, `"`, `""`) + `"`
+}
+
+// IsEmpty reports whether the identifier is the zero value (absent).
+// Used by ObjectName to check whether a part (Database, Schema) is present.
+func (i Ident) IsEmpty() bool {
+	return i.Name == "" && !i.Quoted
+}
+
+// ObjectName represents a qualified object name (1/2/3-part) like
+// `table`, `schema.table`, or `database.schema.table`.
+//
+// For 1-part names, only Name is set (Database and Schema are zero Idents).
+// For 2-part names, Schema and Name are set.
+// For 3-part names, all three are set.
+//
+// ObjectName is a Node and can be used as a child in the AST tree. The
+// walker visits *ObjectName but does NOT descend into the embedded Ident
+// fields (they are value structs, not Nodes).
+type ObjectName struct {
+	Database Ident // may be zero (IsEmpty)
+	Schema   Ident // may be zero (IsEmpty)
+	Name     Ident // always present for a valid ObjectName
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *ObjectName) Tag() NodeTag { return T_ObjectName }
+
+// Compile-time assertion that *ObjectName satisfies Node.
+var _ Node = (*ObjectName)(nil)
+
+// Normalize returns the canonical dotted form with each non-empty part
+// normalized per Snowflake resolution rules.
+//
+// Examples:
+//   - 1-part: "TABLE"
+//   - 2-part: "SCHEMA.TABLE"
+//   - 3-part: "DB.SCHEMA.TABLE"
+func (n ObjectName) Normalize() string {
+	parts := n.Parts()
+	normalized := make([]string, len(parts))
+	for i, p := range parts {
+		normalized[i] = p.Normalize()
+	}
+	return strings.Join(normalized, ".")
+}
+
+// String returns the source form with dots. Each part is re-quoted if it
+// was originally quoted.
+func (n ObjectName) String() string {
+	parts := n.Parts()
+	strs := make([]string, len(parts))
+	for i, p := range parts {
+		strs[i] = p.String()
+	}
+	return strings.Join(strs, ".")
+}
+
+// Parts returns the non-empty parts in order. Length is 1, 2, or 3.
+func (n ObjectName) Parts() []Ident {
+	switch {
+	case !n.Database.IsEmpty():
+		return []Ident{n.Database, n.Schema, n.Name}
+	case !n.Schema.IsEmpty():
+		return []Ident{n.Schema, n.Name}
+	default:
+		return []Ident{n.Name}
+	}
+}
+
+// Matches reports whether this ObjectName suffix-matches other using
+// normalized (case-folded) comparison. A 1-part name matches any other
+// with the same normalized Name. A 2-part name matches any other with
+// the same normalized Schema + Name. A 3-part name requires all three
+// parts to match.
+func (n ObjectName) Matches(other ObjectName) bool {
+	if n.Name.Normalize() != other.Name.Normalize() {
+		return false
+	}
+	if n.Schema.IsEmpty() {
+		return true // 1-part match
+	}
+	if n.Schema.Normalize() != other.Schema.Normalize() {
+		return false
+	}
+	if n.Database.IsEmpty() {
+		return true // 2-part match
+	}
+	return n.Database.Normalize() == other.Database.Normalize()
+}

--- a/snowflake/parser/identifiers.go
+++ b/snowflake/parser/identifiers.go
@@ -1,0 +1,135 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// parseIdent parses one identifier from the token stream. Accepts:
+//   - tokIdent (bare identifier)
+//   - tokQuotedIdent (double-quoted identifier)
+//   - Any non-reserved keyword token (type >= 700 and not in keywordReserved)
+//
+// Returns a ParseError if the current token is none of the above.
+func (p *Parser) parseIdent() (ast.Ident, error) {
+	switch {
+	case p.cur.Type == tokIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	case p.cur.Type == tokQuotedIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+	case p.cur.Type >= 700 && !keywordReserved[p.cur.Type]:
+		// Non-reserved keyword used as an identifier.
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	}
+	return ast.Ident{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "expected identifier",
+	}
+}
+
+// parseIdentStrict parses one identifier but ONLY accepts tokIdent or
+// tokQuotedIdent — NOT non-reserved keywords. Used in contexts where
+// keyword-as-identifier is not allowed (rare in Snowflake).
+func (p *Parser) parseIdentStrict() (ast.Ident, error) {
+	switch p.cur.Type {
+	case tokIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	case tokQuotedIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+	}
+	return ast.Ident{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "expected identifier",
+	}
+}
+
+// parseObjectName parses a dotted object name with 1, 2, or 3 parts:
+//
+//	table
+//	schema.table
+//	database.schema.table
+//
+// Starts by parsing one identifier, then greedily consumes up to two more
+// dot-separated identifiers if present. Returns *ast.ObjectName with the
+// correct parts populated and Loc spanning all parts.
+func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
+	first, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type != '.' {
+		// 1-part name.
+		return &ast.ObjectName{
+			Name: first,
+			Loc:  first.Loc,
+		}, nil
+	}
+	p.advance() // consume first dot
+
+	second, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type != '.' {
+		// 2-part name: schema.table.
+		return &ast.ObjectName{
+			Schema: first,
+			Name:   second,
+			Loc:    ast.Loc{Start: first.Loc.Start, End: second.Loc.End},
+		}, nil
+	}
+	p.advance() // consume second dot
+
+	third, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	// 3-part name: database.schema.table.
+	return &ast.ObjectName{
+		Database: first,
+		Schema:   second,
+		Name:     third,
+		Loc:      ast.Loc{Start: first.Loc.Start, End: third.Loc.End},
+	}, nil
+}
+
+// ParseObjectName parses an object name from a standalone string. Returns
+// the ObjectName and any ParseErrors encountered. Useful for catalog
+// lookups, tests, and callers that have a name string but not a token
+// stream.
+//
+// Examples:
+//
+//	ParseObjectName("my_table")
+//	ParseObjectName("schema.table")
+//	ParseObjectName(`"My DB".schema."Quoted Table"`)
+func ParseObjectName(input string) (*ast.ObjectName, []ParseError) {
+	p := &Parser{
+		lexer: NewLexer(input),
+		input: input,
+	}
+	p.advance()
+
+	obj, err := p.parseObjectName()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+
+	// Check for trailing tokens (should be EOF).
+	if p.cur.Type != tokEOF {
+		return obj, []ParseError{{
+			Loc: p.cur.Loc,
+			Msg: "unexpected token after object name",
+		}}
+	}
+
+	return obj, nil
+}

--- a/snowflake/parser/identifiers_test.go
+++ b/snowflake/parser/identifiers_test.go
@@ -1,0 +1,279 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseIdent is a helper that constructs a Parser from input and
+// calls parseIdent. Since parseIdent is unexported, tests in the same
+// package can call it directly through this helper.
+func testParseIdent(input string) (ast.Ident, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseIdent()
+}
+
+// testParseIdentStrict wraps parseIdentStrict the same way.
+func testParseIdentStrict(input string) (ast.Ident, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseIdentStrict()
+}
+
+// testParseObjectName wraps parseObjectName the same way.
+func testParseObjectName(input string) (*ast.ObjectName, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseObjectName()
+}
+
+// ---------------------------------------------------------------------------
+// parseIdent tests
+// ---------------------------------------------------------------------------
+
+func TestParseIdent_Bare(t *testing.T) {
+	id, err := testParseIdent("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, unquoted}", id)
+	}
+}
+
+func TestParseIdent_Quoted(t *testing.T) {
+	id, err := testParseIdent(`"foo"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || !id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, quoted}", id)
+	}
+}
+
+func TestParseIdent_QuotedWithSpaces(t *testing.T) {
+	id, err := testParseIdent(`"my table"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "my table" || !id.Quoted {
+		t.Errorf("got %+v, want Ident{my table, quoted}", id)
+	}
+}
+
+func TestParseIdent_QuotedEscape(t *testing.T) {
+	// F2's lexer un-escapes "" → " in Token.Str.
+	id, err := testParseIdent(`"a""b"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != `a"b` || !id.Quoted {
+		t.Errorf("got %+v, want Ident{a\"b, quoted}", id)
+	}
+}
+
+func TestParseIdent_NonReservedKeyword(t *testing.T) {
+	// ALERT is a non-reserved keyword — should be accepted as identifier.
+	id, err := testParseIdent("ALERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "ALERT" || id.Quoted {
+		t.Errorf("got %+v, want Ident{ALERT, unquoted}", id)
+	}
+}
+
+func TestParseIdent_ReservedKeyword(t *testing.T) {
+	// SELECT is a reserved keyword — should be rejected.
+	_, err := testParseIdent("SELECT")
+	if err == nil {
+		t.Fatal("expected error for reserved keyword SELECT, got nil")
+	}
+	if pe, ok := err.(*ParseError); ok {
+		if !strings.Contains(pe.Msg, "expected identifier") {
+			t.Errorf("error Msg = %q, want 'expected identifier'", pe.Msg)
+		}
+	} else {
+		t.Errorf("expected *ParseError, got %T", err)
+	}
+}
+
+func TestParseIdent_EOF(t *testing.T) {
+	_, err := testParseIdent("")
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestParseIdent_LocCorrect(t *testing.T) {
+	// "   foo" — the identifier starts at byte 3.
+	id, err := testParseIdent("   foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Loc.Start != 3 || id.Loc.End != 6 {
+		t.Errorf("Loc = %+v, want {3, 6}", id.Loc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseIdentStrict tests
+// ---------------------------------------------------------------------------
+
+func TestParseIdentStrict_AcceptsBare(t *testing.T) {
+	id, err := testParseIdentStrict("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, unquoted}", id)
+	}
+}
+
+func TestParseIdentStrict_AcceptsQuoted(t *testing.T) {
+	id, err := testParseIdentStrict(`"foo"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Name != "foo" || !id.Quoted {
+		t.Errorf("got %+v, want Ident{foo, quoted}", id)
+	}
+}
+
+func TestParseIdentStrict_RejectsNonReservedKeyword(t *testing.T) {
+	// parseIdentStrict rejects ALL keywords, even non-reserved ones.
+	_, err := testParseIdentStrict("ALERT")
+	if err == nil {
+		t.Fatal("expected error for keyword ALERT in strict mode, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseObjectName tests
+// ---------------------------------------------------------------------------
+
+func TestParseObjectName_OnePart(t *testing.T) {
+	obj, err := testParseObjectName("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Name.Name != "foo" || !obj.Schema.IsEmpty() || !obj.Database.IsEmpty() {
+		t.Errorf("got %+v, want 1-part name foo", obj)
+	}
+}
+
+func TestParseObjectName_TwoParts(t *testing.T) {
+	obj, err := testParseObjectName("sch.tbl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Schema.Name != "sch" || obj.Name.Name != "tbl" || !obj.Database.IsEmpty() {
+		t.Errorf("got Schema=%q Name=%q DB=%q, want sch.tbl",
+			obj.Schema.Name, obj.Name.Name, obj.Database.Name)
+	}
+	// Loc should span both parts.
+	if obj.Loc.Start != 0 || obj.Loc.End != 7 {
+		t.Errorf("Loc = %+v, want {0, 7}", obj.Loc)
+	}
+}
+
+func TestParseObjectName_ThreeParts(t *testing.T) {
+	obj, err := testParseObjectName("db.sch.tbl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Database.Name != "db" || obj.Schema.Name != "sch" || obj.Name.Name != "tbl" {
+		t.Errorf("got DB=%q Schema=%q Name=%q, want db.sch.tbl",
+			obj.Database.Name, obj.Schema.Name, obj.Name.Name)
+	}
+	if obj.Loc.Start != 0 || obj.Loc.End != 10 {
+		t.Errorf("Loc = %+v, want {0, 10}", obj.Loc)
+	}
+}
+
+func TestParseObjectName_Mixed(t *testing.T) {
+	// "My DB".sch."Quoted Table"
+	obj, err := testParseObjectName(`"My DB".sch."Quoted Table"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !obj.Database.Quoted || obj.Database.Name != "My DB" {
+		t.Errorf("Database = %+v, want quoted 'My DB'", obj.Database)
+	}
+	if obj.Schema.Quoted || obj.Schema.Name != "sch" {
+		t.Errorf("Schema = %+v, want unquoted 'sch'", obj.Schema)
+	}
+	if !obj.Name.Quoted || obj.Name.Name != "Quoted Table" {
+		t.Errorf("Name = %+v, want quoted 'Quoted Table'", obj.Name)
+	}
+}
+
+func TestParseObjectName_TrailingDot(t *testing.T) {
+	// "foo." — error after the dot (no identifier follows).
+	_, err := testParseObjectName("foo.")
+	if err == nil {
+		t.Fatal("expected error for trailing dot, got nil")
+	}
+}
+
+func TestParseObjectName_LeadingDot(t *testing.T) {
+	// ".foo" — the dot is not an identifier.
+	_, err := testParseObjectName(".foo")
+	if err == nil {
+		t.Fatal("expected error for leading dot, got nil")
+	}
+}
+
+func TestParseObjectName_DoubleDot(t *testing.T) {
+	// "foo..bar" — error at the second dot.
+	_, err := testParseObjectName("foo..bar")
+	if err == nil {
+		t.Fatal("expected error for double dot, got nil")
+	}
+}
+
+func TestParseObjectName_Freestanding(t *testing.T) {
+	// ParseObjectName is the public freestanding helper.
+	obj, errs := ParseObjectName("db.sch.tbl")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %+v", errs)
+	}
+	if obj.Database.Name != "db" || obj.Schema.Name != "sch" || obj.Name.Name != "tbl" {
+		t.Errorf("ParseObjectName mismatch: %+v", obj)
+	}
+}
+
+func TestParseObjectName_FreestandingTrailingTokens(t *testing.T) {
+	// "foo bar" — parses "foo" then complains about trailing "bar".
+	obj, errs := ParseObjectName("foo bar")
+	if obj == nil {
+		t.Fatal("expected non-nil ObjectName even with trailing tokens")
+	}
+	if obj.Name.Name != "foo" {
+		t.Errorf("Name = %q, want foo", obj.Name.Name)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Msg, "unexpected token") {
+		t.Errorf("expected 1 'unexpected token' error, got %+v", errs)
+	}
+}
+
+func TestParseObjectName_FreestandingEmpty(t *testing.T) {
+	_, errs := ParseObjectName("")
+	if len(errs) == 0 {
+		t.Error("expected error for empty input, got none")
+	}
+}
+
+func TestParseObjectName_KeywordAsPart(t *testing.T) {
+	// Non-reserved keyword ALERT should be usable as any part.
+	obj, err := testParseObjectName("ALERT.ALERT.ALERT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if obj.Database.Name != "ALERT" || obj.Schema.Name != "ALERT" || obj.Name.Name != "ALERT" {
+		t.Errorf("got %+v, want ALERT.ALERT.ALERT", obj)
+	}
+}


### PR DESCRIPTION
## Summary

First Tier 1 node of the snowflake parser migration (BYT-9000): identifier and qualified-name building blocks that every subsequent Tier 1+ parser node depends on for parsing table names, column names, schema references, etc.

Depends on F4 parser-entry (PR #19, merged). Unblocks T1.2 (data types), T1.3 (expressions), T1.4 (SELECT core), and transitively every Tier 1+ node.

Also includes the F4 DAG done-marker commit (`docs(snowflake): mark F4 parser-entry (DAG node 4) as done`).

## What's new

### `Ident` value struct (`snowflake/ast`)

```go
type Ident struct {
    Name   string  // raw text, case-preserved
    Quoted bool    // true if source used "..." quoting
    Loc    Loc
}
```

Methods: `Normalize()` (quoted → as-is; unquoted → UPPERCASE), `String()` (re-quotes if originally quoted), `IsEmpty()` (zero-value convention for absent parts).

**Why Snowflake needs a `Quoted` flag (unlike pg/mysql):** Snowflake case-folds unquoted identifiers to UPPERCASE at **resolution** time (not lex time like pg). `"foo"` resolves to `foo` while `foo` resolves to `FOO` — they're different objects. Bytebase's masking and query-span features need this distinction for correctness.

### `ObjectName` Node struct (`snowflake/ast`)

```go
type ObjectName struct {
    Database Ident  // may be zero (1-part name)
    Schema   Ident  // may be zero (1-part or 2-part)
    Name     Ident  // always present
    Loc      Loc
}
```

Three named `Ident` fields matching pg's `RangeVar` shape. Methods: `Normalize()`, `String()`, `Parts()` (returns `[]Ident` of length 1/2/3), `Matches(other)` (suffix match using normalized comparison for catalog lookup).

`ObjectName` is a Node (`T_ObjectName` tag, satisfies `ast.Node`). `Ident` is deliberately NOT a Node — it's a value struct embedded in parent nodes, not visited by the walker.

### Parser helpers (`snowflake/parser`)

```go
func (p *Parser) parseIdent() (ast.Ident, error)
func (p *Parser) parseIdentStrict() (ast.Ident, error)
func (p *Parser) parseObjectName() (*ast.ObjectName, error)
func ParseObjectName(input string) (*ast.ObjectName, []ParseError)
```

`parseIdent` accepts `tokIdent`, `tokQuotedIdent`, and non-reserved keyword tokens (via F2's `keywordReserved` map). Reserved keywords like SELECT/TABLE are rejected with "expected identifier". `parseObjectName` greedily consumes 1/2/3 dot-separated parts. `ParseObjectName` is a freestanding exported helper for standalone string parsing.

## Testing

```bash
go test ./snowflake/...   # both ast and parser pass
go vet ./snowflake/...    # clean
gofmt -l snowflake/       # clean
```

- **44 AST subtests**: Ident normalization (quoted/unquoted/mixed case), String (re-quoting with `""` escape), IsEmpty (zero value, non-empty, quoted-empty-name edge), ObjectName normalization (1/2/3-part, mixed quoting), String round-trip, Parts count, suffix Matches (case-folding, quoted-vs-unquoted distinctness), Tag assertion
- **23 parser subtests**: bare/quoted/keyword-as-ident/reserved-rejected/EOF, 1/2/3-part object names, mixed quoting, trailing-dot/leading-dot/double-dot errors, freestanding ParseObjectName helper, position accuracy

## Spec / plan

- Design spec: `docs/superpowers/specs/2026-04-10-snowflake-identifiers-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-10-snowflake-identifiers.md`

## Test plan

- [ ] CI green on `snowflake/ast/` and `snowflake/parser/`
- [ ] No regressions in other engine packages
- [ ] Walker generation round-trip produces byte-identical `walk_generated.go` (ObjectName has no Node children — generator correctly skips it)
- [ ] `TestParseIdent_ReservedKeyword` passes (SELECT rejected as identifier)
- [ ] `TestParseIdent_NonReservedKeyword` passes (ALERT accepted as identifier)
- [ ] `TestObjectName_Matches` verifies quoted-vs-unquoted are DIFFERENT objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)