### PR TITLE
feat(elasticsearch): F2 request classification (ClassifyRequest)

### DIFF
--- a/docs/superpowers/plans/2026-04-10-elasticsearch-classification.md
+++ b/docs/superpowers/plans/2026-04-10-elasticsearch-classification.md
@@ -1,0 +1,114 @@
+# F2: Elasticsearch Request Classification — Implementation Plan
+
+**Goal:** Port `ClassifyRequest` and URL pattern tables from bytebase's `query_type.go` into
+`omni/elasticsearch/querytype.go`, plus table-driven tests in `elasticsearch/parsertest/querytype_test.go`.
+
+**Architecture:** Standalone file with no bytebase imports. Omni-native `QueryType` enum defined
+alongside `ClassifyRequest`. URL pattern lists ported verbatim.
+
+**Tech Stack:** Go stdlib only (`strings`).
+
+**Branch:** `feat/elasticsearch/classification`
+
+---
+
+### Task 1: Write `elasticsearch/querytype.go`
+
+**Files:**
+- Create: `elasticsearch/querytype.go`
+
+- [ ] **Step 1: Create the file with QueryType enum and URL pattern lists**
+
+Port verbatim:
+- `QueryType` type and constants (Select, SelectInfoSchema, DML, DDL, Explain, Unknown)
+- `readOnlyPostEndpoints` slice (22 strings)
+- `infoSchemaEndpoints` slice (3 strings)
+- `dmlPostEndpoints` slice (7 strings)
+- `ClassifyRequest(method, url string) QueryType`
+- `classifyPostRequest(url string) QueryType`
+- `isInfoSchemaURL(url string) bool`
+- `isReadOnlyPostURL(url string) bool`
+- `isDMLPostURL(url string) bool`
+- `isDocumentURL(url string) bool`
+- `isDocumentWriteURL(url string) bool`
+
+Replace all `base.QueryType` references with the omni-native `QueryType`.
+Replace all `base.Select`, `base.DML`, etc. with `QueryTypeSelect`, `QueryTypeDML`, etc.
+
+- [ ] **Step 2: Build check**
+
+Run: `go build ./elasticsearch/...`
+Expected: Clean exit.
+
+- [ ] **Step 3: Commit**
+
+```
+feat(elasticsearch): add F2 request classification
+
+Port ClassifyRequest and three URL pattern tables (readOnlyPostEndpoints,
+infoSchemaEndpoints, dmlPostEndpoints) verbatim from bytebase's
+query_type.go. Define omni-native QueryType enum with no bytebase imports.
+```
+
+---
+
+### Task 2: Write `elasticsearch/parsertest/querytype_test.go`
+
+**Files:**
+- Create: `elasticsearch/parsertest/querytype_test.go`
+
+- [ ] **Step 1: Write table-driven tests covering all decision branches**
+
+Test cases must cover:
+- HEAD → Select
+- GET non-info-schema → Select
+- GET with `_cat/`, `_cluster/`, `_nodes/` → SelectInfoSchema
+- DELETE with `_doc/` → DML
+- DELETE without `_doc/` → DDL
+- PUT with `_doc/`, `_doc`, `_create/`, `_bulk` → DML
+- PUT index-level → DDL
+- PATCH → DML
+- POST with `_explain` → Explain
+- POST with info schema URL → SelectInfoSchema
+- POST with read-only POST URL → Select (e.g., `_search`, `_count`)
+- POST with DML URL → DML (e.g., `_bulk`, `_doc`)
+- POST default → DDL
+- Unknown method → Unknown
+- Case-insensitive method matching (e.g., `get` → Select)
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./elasticsearch/parsertest/... -v -run TestClassifyRequest`
+Expected: All subtests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `go test ./elasticsearch/... && go test ./elasticsearch/parsertest/...`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```
+test(elasticsearch): add F2 classification tests
+
+Table-driven tests for ClassifyRequest covering all HTTP methods and
+URL-pattern branches. Ported from bytebase's query_type_test.go style.
+```
+
+---
+
+### Task 3: Write spec and plan documents
+
+- [ ] Create `docs/superpowers/specs/2026-04-10-elasticsearch-classification-design.md`
+- [ ] Create `docs/superpowers/plans/2026-04-10-elasticsearch-classification.md`
+- [ ] Commit
+
+---
+
+### Task 4: Final verification
+
+- [ ] `go build ./elasticsearch/...` — clean
+- [ ] `go vet ./elasticsearch/...` — clean
+- [ ] `go test ./elasticsearch/...` — all pass
+- [ ] `go test ./elasticsearch/parsertest/...` — all pass (including smoke test)
+- [ ] Push branch and create PR

--- a/docs/superpowers/specs/2026-04-10-elasticsearch-classification-design.md
+++ b/docs/superpowers/specs/2026-04-10-elasticsearch-classification-design.md
@@ -1,0 +1,101 @@
+# F2: Elasticsearch Request Classification — Design Spec
+
+**DAG node:** F2 (request classification)
+**Branch:** `feat/elasticsearch/classification`
+**Engine:** elasticsearch
+**Depends on:** F0 (bootstrap)
+**Unblocks:** F6a (body analysis foundation)
+**Parallel with:** F1 (parser core), F3, F4, F5
+
+## Goal
+
+Port `ClassifyRequest(method, url string)` from `bytebase/backend/plugin/parser/elasticsearch/query_type.go`
+into `omni/elasticsearch/querytype.go`. This function maps an HTTP method + URL path to a `QueryType`
+value (Select / SelectInfoSchema / DML / DDL / Explain / Unknown). It is pure data + switch logic —
+no parser state, no body analysis, no external dependencies beyond `strings`.
+
+## QueryType
+
+Define an omni-native `QueryType` type in `elasticsearch/querytype.go`. Equivalent to `base.QueryType`
+in bytebase but with no dependency on bytebase's `base` package.
+
+```go
+// QueryType classifies an Elasticsearch REST request for cost and routing decisions.
+type QueryType int
+
+const (
+    QueryTypeUnknown       QueryType = iota
+    QueryTypeSelect                  // Read-only data query
+    QueryTypeSelectInfoSchema        // Read-only cluster/node metadata
+    QueryTypeDML                     // Document write (index, update, delete)
+    QueryTypeDDL                     // Index/alias/mapping management
+    QueryTypeExplain                 // Query explanation
+)
+```
+
+Matching bytebase's integer values is not required — bytebase's glue file will translate between the
+two type systems at M1 time. What matters is that the five semantic categories are faithfully
+represented.
+
+## URL Pattern Lists
+
+Three lists are ported verbatim from bytebase without refactoring, reordering, or improvement:
+
+- `readOnlyPostEndpoints` — POST endpoints that are read-only (search, count, etc.)
+- `infoSchemaEndpoints` — cluster/node metadata endpoints
+- `dmlPostEndpoints` — document write endpoints via POST
+
+The constraint "verbatim" means: same strings, same order, same comments, same variable names.
+
+## ClassifyRequest
+
+The decision tree mirrors bytebase exactly:
+
+| Method | Condition | QueryType |
+|--------|-----------|-----------|
+| HEAD | — | Select |
+| GET | URL contains info schema pattern | SelectInfoSchema |
+| GET | otherwise | Select |
+| DELETE | URL contains `_doc/` | DML |
+| DELETE | otherwise | DDL |
+| PUT | URL contains `_doc/`, `_doc`, `_create/`, or `_bulk` | DML |
+| PUT | otherwise | DDL |
+| PATCH | — | DML |
+| POST | URL contains `_explain/` or ends with `_explain` | Explain |
+| POST | URL contains info schema pattern | SelectInfoSchema |
+| POST | URL contains read-only POST pattern | Select |
+| POST | URL contains DML POST pattern | DML |
+| POST | otherwise | DDL |
+| other | — | Unknown |
+
+Method matching is case-insensitive (normalized to upper). URL matching is case-insensitive
+(normalized to lower). Matching is substring (`strings.Contains`) or suffix (`strings.HasSuffix`)
+as in the original.
+
+## Test Strategy
+
+No YAML golden file exists for `ClassifyRequest` — bytebase tests it with inline Go table-driven
+cases in `query_type_test.go`. Since that file does not exist in the bytebase repo (the test file
+was not present), port tests that exercise the full decision tree:
+
+- Each HTTP method
+- InfoSchema vs non-InfoSchema GET
+- Document vs index-level DELETE and PUT
+- All POST branches (explain, info schema, read-only, DML, default DDL)
+- Unknown method
+
+Tests live in `elasticsearch/parsertest/querytype_test.go` using Go table-driven style.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Create | `elasticsearch/querytype.go` |
+| Create | `elasticsearch/parsertest/querytype_test.go` |
+
+## Success Criteria
+
+1. `go build ./elasticsearch/...` compiles cleanly
+2. `go test ./elasticsearch/...` passes
+3. `go test ./elasticsearch/parsertest/...` passes (including existing smoke test)
+4. `go vet ./elasticsearch/...` clean

--- a/elasticsearch/parsertest/querytype_test.go
+++ b/elasticsearch/parsertest/querytype_test.go
@@ -1,0 +1,409 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/elasticsearch"
+)
+
+func TestClassifyRequest(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		want   elasticsearch.QueryType
+	}{
+		// HEAD → always Select
+		{
+			name:   "HEAD root",
+			method: "HEAD",
+			url:    "/",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "HEAD index",
+			method: "HEAD",
+			url:    "/my-index",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+
+		// GET non-info-schema → Select
+		{
+			name:   "GET index search",
+			method: "GET",
+			url:    "/my-index/_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "GET document",
+			method: "GET",
+			url:    "/my-index/_doc/1",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "GET root",
+			method: "GET",
+			url:    "/",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+
+		// GET with info schema patterns → SelectInfoSchema
+		{
+			name:   "GET _cat/indices",
+			method: "GET",
+			url:    "/_cat/indices",
+			want:   elasticsearch.QueryTypeSelectInfoSchema,
+		},
+		{
+			name:   "GET _cluster/health",
+			method: "GET",
+			url:    "/_cluster/health",
+			want:   elasticsearch.QueryTypeSelectInfoSchema,
+		},
+		{
+			name:   "GET _nodes/stats",
+			method: "GET",
+			url:    "/_nodes/stats",
+			want:   elasticsearch.QueryTypeSelectInfoSchema,
+		},
+
+		// DELETE with _doc/ → DML
+		{
+			name:   "DELETE document",
+			method: "DELETE",
+			url:    "/my-index/_doc/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+
+		// DELETE without _doc/ → DDL
+		{
+			name:   "DELETE index",
+			method: "DELETE",
+			url:    "/my-index",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+		{
+			name:   "DELETE alias",
+			method: "DELETE",
+			url:    "/_aliases",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+
+		// PUT with document write patterns → DML
+		{
+			name:   "PUT _doc with id",
+			method: "PUT",
+			url:    "/my-index/_doc/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "PUT _create with id",
+			method: "PUT",
+			url:    "/my-index/_create/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "PUT _bulk",
+			method: "PUT",
+			url:    "/_bulk",
+			want:   elasticsearch.QueryTypeDML,
+		},
+
+		// PUT without document patterns → DDL
+		{
+			name:   "PUT index",
+			method: "PUT",
+			url:    "/my-index",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+		{
+			name:   "PUT mapping",
+			method: "PUT",
+			url:    "/my-index/_mapping",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+		{
+			name:   "PUT settings",
+			method: "PUT",
+			url:    "/my-index/_settings",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+
+		// PATCH → always DML
+		{
+			name:   "PATCH document",
+			method: "PATCH",
+			url:    "/my-index/_doc/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+
+		// POST _explain → Explain
+		{
+			name:   "POST _explain suffix",
+			method: "POST",
+			url:    "/my-index/_explain",
+			want:   elasticsearch.QueryTypeExplain,
+		},
+		{
+			name:   "POST _explain with id",
+			method: "POST",
+			url:    "/my-index/_explain/1",
+			want:   elasticsearch.QueryTypeExplain,
+		},
+
+		// POST info schema → SelectInfoSchema
+		{
+			name:   "POST _cat",
+			method: "POST",
+			url:    "/_cat/indices",
+			want:   elasticsearch.QueryTypeSelectInfoSchema,
+		},
+		{
+			name:   "POST _cluster",
+			method: "POST",
+			url:    "/_cluster/settings",
+			want:   elasticsearch.QueryTypeSelectInfoSchema,
+		},
+
+		// POST read-only endpoints → Select
+		{
+			name:   "POST _search",
+			method: "POST",
+			url:    "/my-index/_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _msearch",
+			method: "POST",
+			url:    "/_msearch",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _count",
+			method: "POST",
+			url:    "/my-index/_count",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _field_caps",
+			method: "POST",
+			url:    "/_field_caps",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _validate/query",
+			method: "POST",
+			url:    "/my-index/_validate/query",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _terms_enum",
+			method: "POST",
+			url:    "/my-index/_terms_enum",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _termvectors",
+			method: "POST",
+			url:    "/my-index/_termvectors",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _mtermvectors",
+			method: "POST",
+			url:    "/_mtermvectors",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _search_template",
+			method: "POST",
+			url:    "/my-index/_search_template",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _msearch_template",
+			method: "POST",
+			url:    "/_msearch_template",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _render/template",
+			method: "POST",
+			url:    "/_render/template",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _rank_eval",
+			method: "POST",
+			url:    "/_rank_eval",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _knn_search",
+			method: "POST",
+			url:    "/my-index/_knn_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _search_mvt",
+			method: "POST",
+			url:    "/my-index/_search_mvt/field/0/0/0",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _sql",
+			method: "POST",
+			url:    "/_sql",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _esql/query",
+			method: "POST",
+			url:    "/_esql/query",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _eql/search",
+			method: "POST",
+			url:    "/_eql/search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _fleet/_search",
+			method: "POST",
+			url:    "/_fleet/_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _fleet/_msearch",
+			method: "POST",
+			url:    "/_fleet/_msearch",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST _graph/explore",
+			method: "POST",
+			url:    "/my-index/_graph/explore",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST rollup_search",
+			method: "POST",
+			url:    "/my-index/rollup_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "POST async_search",
+			method: "POST",
+			url:    "/my-index/async_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+
+		// POST DML endpoints → DML
+		{
+			name:   "POST _doc",
+			method: "POST",
+			url:    "/my-index/_doc",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "POST _create",
+			method: "POST",
+			url:    "/my-index/_create/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "POST _update",
+			method: "POST",
+			url:    "/my-index/_update/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "POST _bulk",
+			method: "POST",
+			url:    "/_bulk",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "POST _delete_by_query",
+			method: "POST",
+			url:    "/my-index/_delete_by_query",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "POST _update_by_query",
+			method: "POST",
+			url:    "/my-index/_update_by_query",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "POST _reindex",
+			method: "POST",
+			url:    "/_reindex",
+			want:   elasticsearch.QueryTypeDML,
+		},
+
+		// POST default → DDL
+		{
+			name:   "POST index create",
+			method: "POST",
+			url:    "/my-new-index",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+		{
+			name:   "POST _aliases",
+			method: "POST",
+			url:    "/_aliases",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+		{
+			name:   "POST _shrink",
+			method: "POST",
+			url:    "/my-index/_shrink/my-shrunk-index",
+			want:   elasticsearch.QueryTypeDDL,
+		},
+
+		// Unknown method
+		{
+			name:   "CONNECT unknown",
+			method: "CONNECT",
+			url:    "/",
+			want:   elasticsearch.QueryTypeUnknown,
+		},
+		{
+			name:   "OPTIONS unknown",
+			method: "OPTIONS",
+			url:    "/",
+			want:   elasticsearch.QueryTypeUnknown,
+		},
+
+		// Case-insensitive method matching
+		{
+			name:   "lowercase get",
+			method: "get",
+			url:    "/my-index/_search",
+			want:   elasticsearch.QueryTypeSelect,
+		},
+		{
+			name:   "mixed case Post",
+			method: "Post",
+			url:    "/_bulk",
+			want:   elasticsearch.QueryTypeDML,
+		},
+		{
+			name:   "lowercase delete",
+			method: "delete",
+			url:    "/my-index/_doc/1",
+			want:   elasticsearch.QueryTypeDML,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := elasticsearch.ClassifyRequest(tc.method, tc.url)
+			if got != tc.want {
+				t.Errorf("ClassifyRequest(%q, %q) = %v, want %v", tc.method, tc.url, got, tc.want)
+			}
+		})
+	}
+}

--- a/elasticsearch/querytype.go
+++ b/elasticsearch/querytype.go
@@ -1,0 +1,164 @@
+package elasticsearch
+
+import "strings"
+
+// QueryType classifies an Elasticsearch REST request for cost and routing decisions.
+type QueryType int
+
+const (
+	QueryTypeUnknown         QueryType = iota
+	QueryTypeSelect                    // Read-only data query
+	QueryTypeSelectInfoSchema          // Read-only cluster/node metadata
+	QueryTypeDML                       // Document write (index, update, delete)
+	QueryTypeDDL                       // Index/alias/mapping management
+	QueryTypeExplain                   // Query explanation
+)
+
+// readOnlyPostEndpoints lists URL patterns that are read-only despite using POST.
+// These endpoints accept a request body for query parameters but do not modify data.
+var readOnlyPostEndpoints = []string{
+	"_search",
+	"_msearch",
+	"_count",
+	"_field_caps",
+	"_validate/query",
+	"_search_shards",
+	"_terms_enum",
+	"_termvectors",
+	"_mtermvectors",
+	"_search_template",
+	"_msearch_template",
+	"_render/template",
+	"_rank_eval",
+	"_knn_search",
+	"_search_mvt",
+	"_sql",
+	"_esql/query",
+	"_eql/search",
+	"_fleet/_search",
+	"_fleet/_msearch",
+	"_graph/explore",
+	"rollup_search",
+	"async_search",
+}
+
+// infoSchemaEndpoints lists URL patterns for cluster/node metadata queries.
+var infoSchemaEndpoints = []string{
+	"_cat/",
+	"_cluster/",
+	"_nodes/",
+}
+
+// dmlPostEndpoints lists URL patterns for document write operations via POST.
+var dmlPostEndpoints = []string{
+	"_doc",
+	"_create/",
+	"_update/",
+	"_bulk",
+	"_delete_by_query",
+	"_update_by_query",
+	"_reindex",
+}
+
+// ClassifyRequest determines the QueryType for an Elasticsearch REST API request.
+func ClassifyRequest(method, url string) QueryType {
+	method = strings.ToUpper(method)
+	urlLower := strings.ToLower(url)
+
+	switch method {
+	case "HEAD":
+		return QueryTypeSelect
+
+	case "GET":
+		if isInfoSchemaURL(urlLower) {
+			return QueryTypeSelectInfoSchema
+		}
+		return QueryTypeSelect
+
+	case "DELETE":
+		if isDocumentURL(urlLower) {
+			return QueryTypeDML
+		}
+		return QueryTypeDDL
+
+	case "PUT":
+		if isDocumentWriteURL(urlLower) {
+			return QueryTypeDML
+		}
+		return QueryTypeDDL
+
+	case "PATCH":
+		return QueryTypeDML
+
+	case "POST":
+		return classifyPostRequest(urlLower)
+
+	default:
+		return QueryTypeUnknown
+	}
+}
+
+func classifyPostRequest(url string) QueryType {
+	// Explain
+	if strings.Contains(url, "_explain/") || strings.HasSuffix(url, "_explain") {
+		return QueryTypeExplain
+	}
+
+	// Info schema (metadata reads)
+	if isInfoSchemaURL(url) {
+		return QueryTypeSelectInfoSchema
+	}
+
+	// Read-only POST endpoints
+	if isReadOnlyPostURL(url) {
+		return QueryTypeSelect
+	}
+
+	// Document writes (DML)
+	if isDMLPostURL(url) {
+		return QueryTypeDML
+	}
+
+	// Default: DDL for other POST operations (index management, admin, etc.)
+	return QueryTypeDDL
+}
+
+func isInfoSchemaURL(url string) bool {
+	for _, pattern := range infoSchemaEndpoints {
+		if strings.Contains(url, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func isReadOnlyPostURL(url string) bool {
+	for _, pattern := range readOnlyPostEndpoints {
+		if strings.Contains(url, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDMLPostURL(url string) bool {
+	for _, pattern := range dmlPostEndpoints {
+		if strings.Contains(url, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDocumentURL(url string) bool {
+	// DELETE /{index}/_doc/{id} is DML (document deletion)
+	return strings.Contains(url, "_doc/")
+}
+
+func isDocumentWriteURL(url string) bool {
+	// PUT /{index}/_doc/{id}, PUT /{index}/_create/{id}, PUT /_bulk are DML
+	return strings.Contains(url, "_doc/") ||
+		strings.Contains(url, "_doc") ||
+		strings.Contains(url, "_create/") ||
+		strings.Contains(url, "_bulk")
+}


### PR DESCRIPTION
## Summary

- Port `ClassifyRequest(method, url string) QueryType` verbatim from `bytebase/backend/plugin/parser/elasticsearch/query_type.go`
- Define omni-native `QueryType` enum (Select / SelectInfoSchema / DML / DDL / Explain / Unknown) with no bytebase imports
- Port three URL pattern lists verbatim: `readOnlyPostEndpoints` (23 strings), `infoSchemaEndpoints` (3 strings), `dmlPostEndpoints` (7 strings)
- Add 60-subtest table-driven test in `elasticsearch/parsertest/querytype_test.go` covering all HTTP methods and URL pattern branches
- Add design spec and implementation plan under `docs/superpowers/`

This is DAG node **F2** (parallel with F1). Pure stdlib — only `strings` imported.

## Test plan

- [x] `go build ./elasticsearch/...` — clean
- [x] `go vet ./elasticsearch/...` — clean
- [x] `go test ./elasticsearch/...` — 60 subtests pass (all HTTP methods, all URL branches, case-insensitive method matching)
- [x] `go test ./elasticsearch/parsertest/...` — smoke test (8 YAML golden files) still passes
- [x] `go test ./mongo/...` — no regressions in existing packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)