### PR TITLE
feat(elasticsearch/parser): F1 parser core

### DIFF
--- a/docs/superpowers/plans/2026-04-10-elasticsearch-parser-core.md
+++ b/docs/superpowers/plans/2026-04-10-elasticsearch-parser-core.md
@@ -1,0 +1,79 @@
+# Elasticsearch Parser Core (F1) -- Implementation Plan
+
+## Overview
+
+Port the core Elasticsearch REST request parser from bytebase to omni. This is a faithful, mechanical port -- no refactoring, no simplification, no behavioral changes.
+
+## Steps
+
+### Step 1: Create `elasticsearch/parser/parser.go`
+
+Port the entire state machine from `bytebase/bytebase/backend/plugin/parser/elasticsearch/parser.go`. This includes:
+
+- `state` struct (renamed from `parser` to avoid package/type name collision)
+- `newState()` constructor
+- `Parse()` public entry point that creates a state and runs `parse()`
+- All state machine methods: `parse()`, `multiRequest()`, `request()`, `method()`, `url()`, `object()`, `value()`, `word()`, `number()`, `array()`, `string()`
+- Navigation methods: `next()`, `nextEmptyInput()`, `nNextEmptyInput()`, `nextOneOf()`, `reset()`, `peek()`
+- Whitespace/comment methods: `white()`, `strictWhite()`, `newLine()`, `comment()`
+- Request tracking: `addRequestStart()`, `addRequestEnd()`, `updateRequestEnd()`
+- String utilities: `nextUpTo()`, `includes()`
+- Supporting functions exported for use by `parse_impl.go`:
+  - `GetAdjustedParsedRequest()` -- byte offset to line number mapping
+  - `GetEditorRequest()` -- extract method/URL/data from text
+  - `SplitDataIntoJSONObjects()` -- multi-document body splitting
+  - `ParseLine()` -- extract method and URL from a request line
+  - `RemoveTrailingWhitespace()` -- strip trailing comments from URL
+  - `CollapseLiteralString()` -- normalize triple-quoted literals
+  - `IndentData()` -- HJSON round-trip for comment stripping
+  - `ContainsComments()` -- detect comments outside string literals
+
+Adaptations from original:
+- Replace `github.com/pkg/errors` with stdlib `fmt.Errorf`
+- Remove `storepb` and `base` imports (bytebase-specific)
+- Export types and functions that need to be accessed from `parse_impl.go` and tests
+- Rename `parser` struct to `state` to avoid name collision with package name
+
+### Step 2: Create `elasticsearch/parse_impl.go`
+
+Add the public `ParseElasticsearchREST(text string) (*ParseResult, error)` function that:
+
+1. Calls `parser.Parse(text)` to get raw parse result
+2. Iterates over `parser.ParsedRequest` results
+3. For each request, computes `AdjustedParsedRequest` via `GetAdjustedParsedRequest()`
+4. Extracts `EditorRequest` via `GetEditorRequest()`
+5. Applies comment stripping (`ContainsComments` + `IndentData`) and literal string normalization (`CollapseLiteralString`) to body data
+6. Maps to `elasticsearch.Request` with original byte offsets
+7. Converts `parser.SyntaxError` (byte offset) to `elasticsearch.SyntaxError` (line/column Position) using the incremental walk algorithm from the original
+8. Returns `*ParseResult` with requests and errors
+
+### Step 3: Create `elasticsearch/parsertest/parser_test.go`
+
+Four test functions:
+
+1. `TestParseElasticsearchREST` -- load `parse-elasticsearch-rest.yaml` via `loadYAML`, iterate cases, compare with `require.Equal`. Includes `record` flag for golden regeneration.
+2. `TestParse` -- inline test cases for internal `ParsedRequest` offsets (ported from bytebase's `TestParse`).
+3. `TestGetEditorRequest` -- inline test cases for editor request extraction (ported from bytebase's `TestGetEditorRequest`).
+4. `TestContainsComments` -- inline test cases for comment detection (ported from bytebase's `TestContainsComments`).
+
+### Step 4: Write design spec and implementation plan
+
+Create:
+- `docs/superpowers/specs/2026-04-10-elasticsearch-parser-core-design.md`
+- `docs/superpowers/plans/2026-04-10-elasticsearch-parser-core.md`
+
+### Step 5: Verify
+
+- `go build ./elasticsearch/...` compiles cleanly
+- `go test ./elasticsearch/parsertest/` -- all tests pass
+- `go build ./...` -- full repo still compiles
+
+## Verification checklist
+
+- [ ] `parser/parser.go` compiles with no bytebase dependencies
+- [ ] All 5 golden test cases in `parse-elasticsearch-rest.yaml` pass
+- [ ] All 6 `TestParse` inline cases pass (offset tracking)
+- [ ] All 7 `TestGetEditorRequest` inline cases pass
+- [ ] All 7 `TestContainsComments` inline cases pass
+- [ ] Full repo `go build ./...` succeeds
+- [ ] No behavioral differences from original parser

--- a/docs/superpowers/specs/2026-04-10-elasticsearch-parser-core-design.md
+++ b/docs/superpowers/specs/2026-04-10-elasticsearch-parser-core-design.md
@@ -1,0 +1,94 @@
+# Elasticsearch Parser Core (F1) -- Design Spec
+
+## Goal
+
+Port the core Elasticsearch REST request parser from `bytebase/bytebase/backend/plugin/parser/elasticsearch/parser.go` (~1262 LoC) to `omni/elasticsearch/parser/parser.go`. This is the foundation node (F1) of the Elasticsearch migration DAG -- every other feature node depends on the parse output.
+
+## Scope
+
+### In scope
+
+1. **State machine parser** -- the hand-written recursive-descent parser that consumes Kibana Dev Console REST request blocks and produces byte-offset-tracked request ranges + syntax errors.
+2. **Public entry point** -- `ParseElasticsearchREST(text string) (*ParseResult, error)` that maps internal parser output to the omni-level types defined in `elasticsearch/parse.go`.
+3. **Supporting functions** -- all functions from the original parser: `GetAdjustedParsedRequest`, `GetEditorRequest`, `SplitDataIntoJSONObjects`, `ParseLine`, `RemoveTrailingWhitespace`, `CollapseLiteralString`, `IndentData`, `ContainsComments`.
+4. **Test suite** -- golden file tests against `parse-elasticsearch-rest.yaml`, inline `TestParse` cases for internal offset tracking, `TestGetEditorRequest` cases, `TestContainsComments` cases.
+
+### Out of scope
+
+- Statement splitting (F3), statement ranges (F4), diagnostics (F5), query type classification (F6), masking analysis (F7), query span (F8) -- these are separate DAG nodes that wrap the parser output.
+- Typed body AST -- bodies remain `map[string]any` per the analysis decision.
+- Kibana TS upstream alignment -- we freeze on the existing Go parser behavior.
+
+## Architecture
+
+### Package layout
+
+```
+elasticsearch/
+  parse.go          -- types: ParseResult, Request, SyntaxError, Position (F0, already exists)
+  parse_impl.go     -- ParseElasticsearchREST() public entry point (F1, new)
+  parser/
+    doc.go          -- package doc (F0, already exists)
+    parser.go       -- core state machine + all supporting functions (F1, new)
+  parsertest/
+    helpers_test.go -- loadYAML/writeYAML (F0, already exists)
+    smoke_test.go   -- golden file loadability (F0, already exists)
+    parser_test.go  -- parser tests (F1, new)
+    testdata/
+      parse-elasticsearch-rest.yaml -- golden test data (F0, already exists)
+```
+
+### Why two packages?
+
+The `parser` sub-package contains the state machine and all internal types (`ParsedRequest`, `SyntaxError` with byte offset, `AdjustedParsedRequest`, `EditorRequest`). The parent `elasticsearch` package owns the public types (`Request`, `SyntaxError` with line/column `Position`) and the public API. This separation keeps the internal parser types from polluting the public namespace and allows future DAG nodes to import `elasticsearch` without pulling in parser internals.
+
+### Type mapping
+
+| Original (bytebase) | Internal (omni parser/) | Public (omni elasticsearch/) |
+|---|---|---|
+| `parsedRequest` | `parser.ParsedRequest` | -- (internal only) |
+| `syntaxError` | `parser.SyntaxError` | `elasticsearch.SyntaxError` |
+| `adjustedParsedRequest` | `parser.AdjustedParsedRequest` | -- (internal only) |
+| `editorRequest` | `parser.EditorRequest` | -- (internal only) |
+| `Request` | -- | `elasticsearch.Request` |
+| `ParseResult` | `parser.ParseResult` | `elasticsearch.ParseResult` |
+
+### Error conversion
+
+The original code converts byte-offset errors to 1-based line/column positions using an incremental walk. The omni port preserves this exact algorithm in `parse_impl.go`, mapping `parser.SyntaxError` (byte offset + message) to `elasticsearch.SyntaxError` (Position{Line, Column} + Message + RawMessage).
+
+The `RawMessage` field is always empty (matches original behavior).
+
+## Key behavioral properties preserved
+
+1. **Byte-offset accounting** -- three parallel position systems: `parser.ParsedRequest.StartOffset/EndOffset` (byte offset), `parser.AdjustedParsedRequest.StartLineNumber/EndLineNumber` (0-based line number), and `elasticsearch.SyntaxError.Position` (1-based line/column). All are preserved exactly.
+
+2. **Multi-document JSON splitting** -- `SplitDataIntoJSONObjects` uses brace-depth tracking that respects string boundaries and escape sequences.
+
+3. **Error recovery** -- regex-driven resync to next `^(POST|HEAD|GET|PUT|DELETE|PATCH)` method keyword. Yields valid requests + sorted error list even on malformed input.
+
+4. **Comment handling** -- line (`#`, `//`) and block (`/* */`) comments stripped during whitespace scanning.
+
+5. **HJSON tolerance** -- body round-tripped through `hjson-go/v4` for comment stripping and normalization via `IndentData`.
+
+6. **Triple-quoted literals** -- `"""..."""` preserved as-is, normalized via `CollapseLiteralString`.
+
+## Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| `github.com/hjson/hjson-go/v4` | HJSON tolerance + comment-strip round-trip |
+| `encoding/json` | JSON marshaling for `CollapseLiteralString` and `IndentData` |
+| `regexp` | Error recovery resync pattern |
+| `unicode/utf8` | Rune-level byte offset tracking |
+| `strconv` | Number and hex parsing |
+| `strings` | String manipulation throughout |
+| `slices` | Error sorting |
+
+No `github.com/pkg/errors` -- uses stdlib `fmt.Errorf` per omni convention.
+
+## Risks
+
+1. **Behavioral drift** -- the port is mechanical, but any subtle difference in error recovery or offset accounting could cause downstream DAG nodes (splitter, statement ranges) to produce wrong results. Mitigation: comprehensive golden tests + inline offset tests.
+
+2. **hjson library version** -- `hjson-go/v4` output formatting must match what the original parser produced. The same library version is used.

--- a/elasticsearch/parse_impl.go
+++ b/elasticsearch/parse_impl.go
@@ -1,0 +1,104 @@
+package elasticsearch
+
+import (
+	"slices"
+
+	"github.com/bytebase/omni/elasticsearch/parser"
+)
+
+// ParseElasticsearchREST parses the Elasticsearch REST API request text into
+// structured requests and syntax errors. This is the primary entry point for
+// the Elasticsearch parser.
+func ParseElasticsearchREST(text string) (*ParseResult, error) {
+	raw, err := parser.Parse(text)
+	if err != nil {
+		return nil, err
+	}
+
+	var requests []*Request
+	for i, pr := range raw.Requests {
+		// See https://sourcegraph.com/github.com/elastic/kibana/-/blob/src/platform/plugins/shared/console/public/application/containers/editor/monaco_editor_actions_provider.ts?L261.
+		var nextRequest *parser.ParsedRequest
+		if i < len(raw.Requests)-1 {
+			nextRequest = &raw.Requests[i+1]
+		}
+		adjustedOffset := parser.GetAdjustedParsedRequest(pr, text, nextRequest)
+		if adjustedOffset.StartLineNumber > adjustedOffset.EndLineNumber {
+			continue
+		}
+		editorRequest := parser.GetEditorRequest(text, adjustedOffset)
+		if editorRequest == nil {
+			continue
+		}
+		if len(editorRequest.Data) > 0 {
+			for j, v := range editorRequest.Data {
+				if parser.ContainsComments(v) {
+					// parse and stringify to remove comments.
+					editorRequest.Data[j] = parser.IndentData(v)
+				}
+				editorRequest.Data[j] = parser.CollapseLiteralString(editorRequest.Data[j])
+			}
+		}
+		requests = append(requests, &Request{
+			Method:      editorRequest.Method,
+			URL:         editorRequest.URL,
+			Data:        editorRequest.Data,
+			StartOffset: pr.StartOffset,
+			EndOffset:   pr.EndOffset,
+		})
+	}
+
+	// Convert errors
+	var syntaxErrors []*SyntaxError
+
+	slices.SortFunc(raw.Errors, func(a, b parser.SyntaxError) int {
+		if a.ByteOffset < b.ByteOffset {
+			return -1
+		}
+		if a.ByteOffset > b.ByteOffset {
+			return 1
+		}
+		return 0
+	})
+
+	for i, rawErr := range raw.Errors {
+		line := 0
+		column := 0
+		pos := 0
+		if i > 0 {
+			line = syntaxErrors[i-1].Position.Line
+			column = syntaxErrors[i-1].Position.Column
+			pos = raw.Errors[i-1].ByteOffset
+		}
+		boundary := rawErr.ByteOffset
+		if boundary >= len(text) {
+			boundary = len(text) - 1
+		}
+
+		for j := pos; j <= boundary; j++ {
+			if text[j] == '\n' {
+				if j == boundary {
+					// Decorate the \n position instead of the next line.
+					column++
+					continue
+				}
+				line++
+				column = 0
+			} else {
+				column++
+			}
+		}
+		syntaxErrors = append(syntaxErrors, &SyntaxError{
+			Position: Position{
+				Line:   line,
+				Column: column,
+			},
+			Message: rawErr.Message,
+		})
+	}
+
+	return &ParseResult{
+		Requests: requests,
+		Errors:   syntaxErrors,
+	}, nil
+}

--- a/elasticsearch/parser/parser.go
+++ b/elasticsearch/parser/parser.go
@@ -1,0 +1,1188 @@
+// Package parser implements a hand-written recursive-descent parser for
+// Kibana Dev Console-style Elasticsearch REST request blocks.
+//
+// This is a faithful port of the parser from
+// bytebase/bytebase/backend/plugin/parser/elasticsearch/parser.go.
+// The state machine logic, byte-offset accounting, comment handling, HJSON
+// normalization, error recovery, and multi-document body splitting are
+// preserved exactly as in the original.
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"strconv"
+	"unicode/utf8"
+
+	hjson "github.com/hjson/hjson-go/v4"
+)
+
+// ParseResult holds the raw parse output: offset-tracked request ranges and
+// syntax errors with byte offsets. The public API in the parent package
+// converts these into the omni-level types.
+type ParseResult struct {
+	Requests []ParsedRequest
+	Errors   []SyntaxError
+}
+
+// ParsedRequest is the byte range of a single request (left inclusive, right exclusive).
+type ParsedRequest struct {
+	// StartOffset is the byte offset of the first character of the request.
+	StartOffset int
+	// EndOffset is the byte offset of the end position.
+	EndOffset int
+}
+
+// SyntaxError records a parse error at a byte offset.
+type SyntaxError struct {
+	// ByteOffset is the byte offset of the first character where the error occurred, starting at 0.
+	ByteOffset int
+	Message    string
+}
+
+// EditorRequest is a single parsed request with method, URL, and body data.
+type EditorRequest struct {
+	Method string
+	URL    string
+	Data   []string
+}
+
+// AdjustedParsedRequest maps byte offsets to 0-based line numbers.
+type AdjustedParsedRequest struct {
+	// StartLineNumber is the line number of the first character of the request, starting from 0.
+	StartLineNumber int
+	// EndLineNumber is the line number of the end position, starting from 0.
+	EndLineNumber int
+}
+
+// See https://sourcegraph.com/github.com/elastic/kibana/-/blob/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts?L76.
+// Combine getRequestStartLineNumber and getRequestEndLineNumber.
+func GetAdjustedParsedRequest(r ParsedRequest, text string, nextRequest *ParsedRequest) AdjustedParsedRequest {
+	bs := []byte(text)
+	startLineNumber := 0
+	endLineNumber := 0
+	startOffset := r.StartOffset
+	// The startOffset is out of range, returning the end of document like
+	// what the model.getPositionAt does.
+	if r.StartOffset >= len(bs) {
+		startOffset = len(bs) - 1
+	}
+	for i := 0; i < r.StartOffset; i++ {
+		if bs[i] == '\n' {
+			startLineNumber++
+		}
+	}
+
+	if r.EndOffset >= 0 {
+		// if the parser set an end offset for this request, then find the line number for it.
+		endLineNumber = startLineNumber
+		endOffset := r.EndOffset
+		if endOffset >= len(bs) {
+			endOffset = len(bs) - 1
+		}
+		for i := startOffset; i < endOffset; i++ {
+			if bs[i] == '\n' {
+				endLineNumber++
+			}
+		}
+	} else {
+		// if no end offset, try to find the line before the next request starts.
+		if nextRequest != nil {
+			nextRequestStartLine := 0
+			nextRequestOffset := nextRequest.StartOffset
+			if nextRequestOffset >= len(bs) {
+				nextRequestOffset = len(bs) - 1
+			}
+			for i := 0; i < nextRequestOffset; i++ {
+				if bs[i] == '\n' {
+					nextRequestStartLine++
+				}
+			}
+			if nextRequestStartLine > startLineNumber {
+				endLineNumber = nextRequestStartLine - 1
+			} else {
+				endLineNumber = startLineNumber
+			}
+		} else {
+			// If there is no next request, find the end of the text or the line that starts with a method.
+			lines := strings.Split(text, "\n")
+			nextLineNumber := 0
+			for i := 0; i < r.StartOffset; i++ {
+				if bs[i] == '\n' {
+					nextLineNumber++
+				}
+			}
+			nextLineNumber++
+			for nextLineNumber < len(lines) {
+				content := strings.TrimSpace(lines[nextLineNumber])
+				startsWithMethodRegex := regexp.MustCompile(`(?i)^\s*(GET|POST|PUT|PATCH|DELETE)`)
+				if startsWithMethodRegex.MatchString(content) {
+					break
+				}
+				nextLineNumber++
+			}
+			// nextLineNumber is now either the line with a method or 1 line after the end of the text
+			// set the end line for this request to the line before nextLineNumber
+			if nextLineNumber > startLineNumber {
+				endLineNumber = nextLineNumber - 1
+			} else {
+				endLineNumber = startLineNumber
+			}
+		}
+	}
+	// if the end is empty, go up to find the first non-empty line.
+	lines := strings.Split(text, "\n")
+	for endLineNumber >= 0 && strings.TrimSpace(lines[endLineNumber]) == "" {
+		endLineNumber--
+	}
+	return AdjustedParsedRequest{
+		StartLineNumber: startLineNumber,
+		EndLineNumber:   endLineNumber,
+	}
+}
+
+type state struct {
+	// at is the current rune's byte offset in the input string.
+	at       int
+	ch       rune
+	escapee  map[rune]string
+	text     string
+	errors   []SyntaxError
+	requests []ParsedRequest
+	// requestStartOffset is the byte offset of the first character of the request.
+	requestStartOffset int
+	// requestEndOffset is the byte offset of the first character of the next request.
+	requestEndOffset int
+}
+
+func newState(text string) *state {
+	return &state{
+		at: 0,
+		ch: 0,
+		escapee: map[rune]string{
+			'"':  `"`,
+			'\\': `\`,
+			'/':  `/`,
+			'b':  "\b",
+			'f':  "\f",
+			'n':  "\n",
+			'r':  "\r",
+			't':  "\t",
+		},
+		text: text,
+	}
+}
+
+// Parse parses the input text and returns the raw parse result.
+func Parse(text string) (*ParseResult, error) {
+	s := newState(text)
+	requests, err := s.parse()
+	if err != nil {
+		return nil, err
+	}
+	return &ParseResult{
+		Requests: requests,
+		Errors:   s.errors,
+	}, nil
+}
+
+// See https://sourcegraph.com/github.com/elastic/kibana/-/blob/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.js.
+func (s *state) parse() ([]ParsedRequest, error) {
+	if _, err := s.nextEmptyInput(); err != nil {
+		return nil, err
+	}
+	if err := s.multiRequest(); err != nil {
+		return nil, err
+	}
+
+	if err := s.white(); err != nil {
+		return nil, err
+	}
+	if s.ch != 0 {
+		return nil, fmt.Errorf("Syntax error")
+	}
+	return s.requests, nil
+}
+
+func (s *state) multiRequest() error {
+	catch := func(e error) int {
+		s.errors = append(s.errors, SyntaxError{
+			ByteOffset: s.at,
+			Message:    e.Error(),
+		})
+		if s.at >= len(s.text) {
+			return -1
+		}
+		remain := s.text[s.at:]
+		re := regexp.MustCompile(`(?m)^(POST|HEAD|GET|PUT|DELETE|PATCH)`)
+		match := re.FindStringIndex(remain)
+		if match != nil {
+			return match[0] + s.at
+		}
+		return -1
+	}
+	for s.ch != 0 {
+		if err := s.white(); err != nil {
+			if next := catch(err); next >= 0 {
+				if err := s.reset(next); err != nil {
+					return err
+				}
+			} else {
+				return nil
+			}
+		}
+		if s.ch == 0 {
+			continue
+		}
+		if err := s.comment(); err != nil {
+			if next := catch(err); next >= 0 {
+				if err := s.reset(next); err != nil {
+					return err
+				}
+			} else {
+				return nil
+			}
+		}
+		if err := s.white(); err != nil {
+			if next := catch(err); next >= 0 {
+				if err := s.reset(next); err != nil {
+					return err
+				}
+			} else {
+				return nil
+			}
+		}
+		if s.ch == 0 {
+			continue
+		}
+		if err := s.request(); err != nil {
+			if next := catch(err); next >= 0 {
+				if err := s.reset(next); err != nil {
+					return err
+				}
+			} else {
+				return nil
+			}
+		}
+		if err := s.white(); err != nil {
+			if next := catch(err); next >= 0 {
+				if err := s.reset(next); err != nil {
+					return err
+				}
+			} else {
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *state) request() error {
+	if err := s.white(); err != nil {
+		return err
+	}
+	if err := s.addRequestStart(); err != nil {
+		return err
+	}
+	if _, err := s.method(); err != nil {
+		return err
+	}
+	if err := s.updateRequestEnd(); err != nil {
+		return err
+	}
+	if err := s.strictWhite(); err != nil {
+		return err
+	}
+	if _, err := s.url(); err != nil {
+		return err
+	}
+	if err := s.updateRequestEnd(); err != nil {
+		return err
+	}
+	// advance to one new line
+	if err := s.strictWhite(); err != nil {
+		return err
+	}
+	if err := s.newLine(); err != nil {
+		return err
+	}
+	if err := s.strictWhite(); err != nil {
+		return err
+	}
+	if s.ch == '{' {
+		if _, err := s.object(); err != nil {
+			return err
+		}
+		if err := s.updateRequestEnd(); err != nil {
+			return err
+		}
+	}
+	// multi doc request
+	// advance to one new line
+	if err := s.strictWhite(); err != nil {
+		return err
+	}
+	if err := s.newLine(); err != nil {
+		return err
+	}
+	if err := s.strictWhite(); err != nil {
+		return err
+	}
+	for s.ch == '{' {
+		// another object
+		if _, err := s.object(); err != nil {
+			return err
+		}
+		if err := s.updateRequestEnd(); err != nil {
+			return err
+		}
+		if err := s.strictWhite(); err != nil {
+			return err
+		}
+		if err := s.newLine(); err != nil {
+			return err
+		}
+		if err := s.strictWhite(); err != nil {
+			return err
+		}
+	}
+	return s.addRequestEnd()
+}
+
+func (s *state) url() (string, error) {
+	url := ""
+	for s.ch != 0 && s.ch != '\n' {
+		url += string(s.ch)
+		if _, err := s.nextEmptyInput(); err != nil {
+			return "", err
+		}
+	}
+	if url == "" {
+		return "", fmt.Errorf("Missing url")
+	}
+	return url, nil
+}
+
+func (s *state) object() (map[string]any, error) {
+	key := ""
+	object := make(map[string]any)
+
+	if s.ch == '{' {
+		if err := s.next('{'); err != nil {
+			return nil, err
+		}
+		if err := s.white(); err != nil {
+			return nil, err
+		}
+		if s.ch == '}' {
+			if err := s.next('}'); err != nil {
+				return nil, err
+			}
+			// empty object
+			return object, nil
+		}
+		for s.ch != 0 {
+			var err error
+			key, err = s.string()
+			if err != nil {
+				return nil, err
+			}
+			if err := s.white(); err != nil {
+				return nil, err
+			}
+			if err := s.next(':'); err != nil {
+				return nil, err
+			}
+			if _, ok := object[key]; ok {
+				return nil, fmt.Errorf("duplicate key '%s'", key)
+			}
+			v, err := s.value()
+			if err != nil {
+				return nil, err
+			}
+			object[key] = v
+			if err := s.white(); err != nil {
+				return nil, err
+			}
+			if s.ch == '}' {
+				if err := s.next('}'); err != nil {
+					return nil, err
+				}
+				return object, nil
+			}
+			if err := s.next(','); err != nil {
+				return nil, err
+			}
+			if err := s.white(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return nil, fmt.Errorf("bad object")
+}
+
+func (s *state) value() (any, error) {
+	if err := s.white(); err != nil {
+		return nil, err
+	}
+	switch s.ch {
+	case '{':
+		return s.object()
+	case '[':
+		return s.array()
+	case '"':
+		return s.string()
+	case '-':
+		return s.number()
+	default:
+		if s.ch >= '0' && s.ch <= '9' {
+			return s.number()
+		}
+		return s.word()
+	}
+}
+
+func (s *state) word() (any, error) {
+	switch s.ch {
+	case 't':
+		if err := s.next('t'); err != nil {
+			return nil, err
+		}
+		if err := s.next('r'); err != nil {
+			return nil, err
+		}
+		if err := s.next('u'); err != nil {
+			return nil, err
+		}
+		if err := s.next('e'); err != nil {
+			return nil, err
+		}
+		return true, nil
+	case 'f':
+		if err := s.next('f'); err != nil {
+			return nil, err
+		}
+		if err := s.next('a'); err != nil {
+			return nil, err
+		}
+		if err := s.next('l'); err != nil {
+			return nil, err
+		}
+		if err := s.next('s'); err != nil {
+			return nil, err
+		}
+		if err := s.next('e'); err != nil {
+			return nil, err
+		}
+		return false, nil
+	case 'n':
+		if err := s.next('n'); err != nil {
+			return nil, err
+		}
+		if err := s.next('u'); err != nil {
+			return nil, err
+		}
+		if err := s.next('l'); err != nil {
+			return nil, err
+		}
+		if err := s.next('l'); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unexpected '%c'", s.ch)
+	}
+}
+
+func (s *state) number() (float64, error) {
+	str := ""
+	if s.ch == '-' {
+		str = "-"
+		if err := s.next('-'); err != nil {
+			return 0, err
+		}
+	}
+	for s.ch >= '0' && s.ch <= '9' {
+		str += string(s.ch)
+		if _, err := s.nextEmptyInput(); err != nil {
+			return 0, err
+		}
+	}
+	if s.ch == '.' {
+		str += "."
+		for {
+			if _, err := s.nextEmptyInput(); err != nil {
+				return 0, err
+			}
+			if s.ch >= '0' && s.ch <= '9' {
+				str += string(s.ch)
+			} else {
+				break
+			}
+		}
+	}
+	if s.ch == 'e' || s.ch == 'E' {
+		str += string(s.ch)
+		if _, err := s.nextEmptyInput(); err != nil {
+			return 0, err
+		}
+		if s.ch == '+' || s.ch == '-' {
+			str += string(s.ch)
+			if _, err := s.nextEmptyInput(); err != nil {
+				return 0, err
+			}
+		}
+		for s.ch >= '0' && s.ch <= '9' {
+			str += string(s.ch)
+			if _, err := s.nextEmptyInput(); err != nil {
+				return 0, err
+			}
+		}
+	}
+	num, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad number")
+	}
+	return num, nil
+}
+
+func (s *state) array() ([]any, error) {
+	var array []any
+	if s.ch == '[' {
+		if err := s.next('['); err != nil {
+			return nil, err
+		}
+		if err := s.white(); err != nil {
+			return nil, err
+		}
+		if s.ch == ']' {
+			if err := s.next(']'); err != nil {
+				return nil, err
+			}
+			// empty array
+			return array, nil
+		}
+		for s.ch != 0 {
+			v, err := s.value()
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, v)
+			if err := s.white(); err != nil {
+				return nil, err
+			}
+			if s.ch == ']' {
+				if err := s.next(']'); err != nil {
+					return nil, err
+				}
+				return array, nil
+			}
+			if err := s.next(','); err != nil {
+				return nil, err
+			}
+			if err := s.white(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return nil, fmt.Errorf("bad array")
+}
+
+func (s *state) string() (string, error) {
+	str := ""
+	var uffff int32
+	if s.ch == '"' {
+		if s.peek(0) == '"' && s.peek(1) == '"' {
+			// literal
+			if err := s.next('"'); err != nil {
+				return "", err
+			}
+			if err := s.next('"'); err != nil {
+				return "", err
+			}
+			return s.nextUpTo(`"""`, `failed to find closing '"""'`)
+		}
+		for {
+			r, err := s.nextEmptyInput()
+			if err != nil {
+				return "", err
+			}
+			if r == 0 {
+				break
+			}
+			if s.ch == '"' {
+				if _, err := s.nextEmptyInput(); err != nil {
+					return "", err
+				}
+				return str, nil
+			} else if s.ch == '\\' {
+				if _, err := s.nextEmptyInput(); err != nil {
+					return "", err
+				}
+				if s.ch == 'u' {
+					uffff = 0
+					for i := 0; i < 4; i++ {
+						nextRune, err := s.nextEmptyInput()
+						if err != nil {
+							return "", err
+						}
+						// Parse next rune into hex.
+						hex, err := strconv.ParseUint(string(nextRune), 16, 32)
+						if err != nil {
+							break
+						}
+						uffff = (uffff << 4) | int32(hex&0xF)
+					}
+					// Treat uffff as UTF-16 encoded rune.
+					str += string(rune(uffff))
+				} else if v, ok := s.escapee[s.ch]; ok {
+					str += v
+				} else {
+					break
+				}
+			} else {
+				str += string(s.ch)
+			}
+		}
+	}
+
+	return "", fmt.Errorf("bad string")
+}
+
+func (s *state) nextUpTo(upTo string, errorMessage string) (string, error) {
+	currentAt := s.at
+	i := strings.Index(s.text[s.at:], upTo)
+	if i < 0 {
+		if errorMessage != "" {
+			return "", fmt.Errorf("%s", errorMessage)
+		}
+		return "", fmt.Errorf("expected '%s'", upTo)
+	}
+	i += currentAt
+	if err := s.reset(i + len(upTo)); err != nil {
+		return "", err
+	}
+	return s.text[currentAt:i], nil
+}
+
+func (s *state) reset(newAt int) error {
+	ch, sz := utf8.DecodeRuneInString(s.text[newAt:])
+	if ch == utf8.RuneError {
+		if sz == 0 {
+			return fmt.Errorf("unexpected empty input")
+		}
+		if sz == 1 {
+			return fmt.Errorf("invalid UTF-8 character")
+		}
+		return fmt.Errorf("unknown decoding rune error")
+	}
+	s.ch = ch
+	s.at = newAt + sz
+	return nil
+}
+
+func (s *state) newLine() error {
+	if s.ch == '\n' {
+		if _, err := s.nextEmptyInput(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *state) strictWhite() error {
+	for s.ch != 0 && (s.ch == ' ' || s.ch == '\t') {
+		if _, err := s.nextEmptyInput(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *state) nextOneOf(rs []rune) error {
+	if !includes(rs, s.ch) {
+		return fmt.Errorf("expected one of %+v instead of '%c'", rs, s.ch)
+	}
+	if s.at >= len(s.text) {
+		// EOF, just increase the at by 1 and set the ch to 0.
+		s.at++
+		s.ch = 0
+		return nil
+	}
+	ch, sz := utf8.DecodeRuneInString(s.text[s.at:])
+	if ch == utf8.RuneError {
+		if sz == 0 {
+			return fmt.Errorf("unexpected empty input")
+		}
+		if sz == 1 {
+			return fmt.Errorf("invalid UTF-8 character")
+		}
+		return fmt.Errorf("unknown decoding rune error")
+	}
+	s.ch = ch
+	s.at += sz
+	return nil
+}
+
+func (s *state) method() (string, error) {
+	uppercase := strings.ToUpper(string(s.ch))
+	switch uppercase {
+	case "G":
+		if err := s.nextOneOf([]rune{'G', 'g'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'E', 'e'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'T', 't'}); err != nil {
+			return "", err
+		}
+		return "GET", nil
+	case "H":
+		if err := s.nextOneOf([]rune{'H', 'h'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'E', 'e'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'A', 'a'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'D', 'd'}); err != nil {
+			return "", err
+		}
+		return "HEAD", nil
+	case "D":
+		if err := s.nextOneOf([]rune{'D', 'd'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'E', 'e'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'L', 'l'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'E', 'e'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'T', 't'}); err != nil {
+			return "", err
+		}
+		if err := s.nextOneOf([]rune{'E', 'e'}); err != nil {
+			return "", err
+		}
+		return "DELETE", nil
+	case "P":
+		if err := s.nextOneOf([]rune{'P', 'p'}); err != nil {
+			return "", err
+		}
+		nextUppercase := strings.ToUpper(string(s.ch))
+		switch nextUppercase {
+		case "A":
+			if err := s.nextOneOf([]rune{'A', 'a'}); err != nil {
+				return "", err
+			}
+			if err := s.nextOneOf([]rune{'T', 't'}); err != nil {
+				return "", err
+			}
+			if err := s.nextOneOf([]rune{'C', 'c'}); err != nil {
+				return "", err
+			}
+			if err := s.nextOneOf([]rune{'H', 'h'}); err != nil {
+				return "", err
+			}
+			return "PATCH", nil
+		case "U":
+			if err := s.nextOneOf([]rune{'U', 'u'}); err != nil {
+				return "", err
+			}
+			if err := s.nextOneOf([]rune{'T', 't'}); err != nil {
+				return "", err
+			}
+			return "PUT", nil
+		case "O":
+			if err := s.nextOneOf([]rune{'O', 'o'}); err != nil {
+				return "", err
+			}
+			if err := s.nextOneOf([]rune{'S', 's'}); err != nil {
+				return "", err
+			}
+			if err := s.nextOneOf([]rune{'T', 't'}); err != nil {
+				return "", err
+			}
+			return "POST", nil
+		default:
+			return "", fmt.Errorf("unexpected '%c'", s.ch)
+		}
+	default:
+		return "", fmt.Errorf("expected one of GET/POST/PUT/DELETE/HEAD/PATCH")
+	}
+}
+
+func (s *state) addRequestStart() error {
+	previousRune, sz := utf8.DecodeLastRuneInString(s.text[:s.at])
+	if previousRune == utf8.RuneError {
+		if sz == 0 {
+			return fmt.Errorf("unexpected empty input")
+		}
+		if sz == 1 {
+			return fmt.Errorf("invalid UTF-8 character")
+		}
+		return fmt.Errorf("unknown decoding rune error")
+	}
+	s.requestStartOffset = s.at - sz
+	s.requests = append(s.requests, ParsedRequest{
+		StartOffset: s.requestStartOffset,
+		EndOffset:   -1,
+	})
+	return nil
+}
+
+func (s *state) addRequestEnd() error {
+	if len(s.requests) == 0 {
+		return fmt.Errorf("unexpected empty requests")
+	}
+	s.requests[len(s.requests)-1].EndOffset = s.requestEndOffset
+	return nil
+}
+
+func (s *state) updateRequestEnd() error {
+	if s.at >= len(s.text) {
+		s.requestEndOffset = s.at - 1
+		return nil
+	}
+	previousRune, sz := utf8.DecodeLastRuneInString(s.text[:s.at])
+	if previousRune == utf8.RuneError {
+		if sz == 0 {
+			return fmt.Errorf("unexpected empty input")
+		}
+		if sz == 1 {
+			return fmt.Errorf("invalid UTF-8 character")
+		}
+		return fmt.Errorf("unknown decoding rune error")
+	}
+	s.requestEndOffset = s.at - sz
+	return nil
+}
+
+func (s *state) comment() error {
+	for s.ch == '#' {
+		for s.ch != 0 && s.ch != '\n' {
+			if _, err := s.nextEmptyInput(); err != nil {
+				return err
+			}
+		}
+		if err := s.white(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *state) peek(offset uint) rune {
+	if s.at >= len(s.text) {
+		return 0
+	}
+	tempAt := s.at
+	var peekCh rune
+	var sz int
+	for i := uint(0); i <= offset; i++ {
+		if tempAt >= len(s.text) {
+			return 0
+		}
+		peekCh, sz = utf8.DecodeRuneInString(s.text[tempAt:])
+		if peekCh == utf8.RuneError {
+			return 0
+		}
+		tempAt += sz
+	}
+	return peekCh
+}
+
+func (s *state) white() error {
+	for s.ch != 0 {
+		// Skip whitespace.
+		for s.ch != 0 && s.ch <= ' ' {
+			if _, err := s.nextEmptyInput(); err != nil {
+				return err
+			}
+		}
+
+		// if the current rune in iteration is '#' or the rune and the next rune is equal to '//'
+		// we are on the single line comment.
+		if s.ch == '#' || (s.ch == '/' && s.peek(0) == '/') {
+			// Until we are on the new line, skip to the next char.
+			for s.ch != 0 && s.ch != '\n' {
+				if _, err := s.nextEmptyInput(); err != nil {
+					return err
+				}
+			}
+		} else if s.ch == '/' && s.peek(0) == '*' {
+			// If the chars starts with '/*', we are on the multiline comment.
+			if err := s.nNextEmptyInput(2); err != nil {
+				return err
+			}
+			for s.ch != 0 && (s.ch != '*' || s.peek(0) != '/') {
+				// Until we have closing tags '*', skip to the next char.
+				if _, err := s.nextEmptyInput(); err != nil {
+					return err
+				}
+			}
+			if s.ch != 0 {
+				if err := s.nNextEmptyInput(2); err != nil {
+					return err
+				}
+			}
+		} else {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *state) next(c rune) error {
+	if c != s.ch {
+		return fmt.Errorf("expected '%c' instead of '%c'", c, s.ch)
+	}
+
+	_, err := s.nextEmptyInput()
+	return err
+}
+
+func (s *state) nextEmptyInput() (rune, error) {
+	if s.at >= len(s.text) {
+		// EOF
+		s.at++
+		s.ch = 0
+		return 0, nil
+	}
+	nextCh, sz := utf8.DecodeRuneInString(s.text[s.at:])
+	if nextCh == utf8.RuneError {
+		if sz == 0 {
+			return 0, fmt.Errorf("unexpected empty input")
+		}
+		if sz == 1 {
+			return 0, fmt.Errorf("invalid UTF-8 character")
+		}
+		return 0, fmt.Errorf("unknown decoding rune error")
+	}
+	s.ch = nextCh
+
+	s.at += sz
+	return nextCh, nil
+}
+
+// call s.nextEmptyInput n times.
+func (s *state) nNextEmptyInput(n int) error {
+	var err error
+	for i := 0; i < n; i++ {
+		if _, err = s.nextEmptyInput(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func includes[T rune](sl []T, e T) bool {
+	for _, v := range sl {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}
+
+// GetEditorRequest extracts a single editor request from the text using adjusted line numbers.
+// See https://sourcegraph.com/github.com/elastic/kibana/-/blob/src/platform/plugins/shared/console/public/application/containers/editor/utils/requests_utils.ts?L204.
+func GetEditorRequest(text string, a AdjustedParsedRequest) *EditorRequest {
+	e := &EditorRequest{}
+	lines := strings.Split(text, "\n")
+	methodURLLine := strings.TrimSpace(lines[a.StartLineNumber])
+	if methodURLLine == "" {
+		return nil
+	}
+	method, url := ParseLine(methodURLLine)
+	if method == "" || url == "" {
+		return nil
+	}
+	e.Method = method
+	e.URL = url
+
+	if a.EndLineNumber <= a.StartLineNumber {
+		return e
+	}
+
+	dataString := ""
+	if a.StartLineNumber < len(lines)-1 {
+		var validLines []string
+		for i := a.StartLineNumber + 1; i <= a.EndLineNumber; i++ {
+			validLines = append(validLines, lines[i])
+		}
+		dataString = strings.TrimSpace(strings.Join(validLines, "\n"))
+	}
+
+	data := SplitDataIntoJSONObjects(dataString)
+	return &EditorRequest{
+		Method: method,
+		URL:    url,
+		Data:   data,
+	}
+}
+
+// SplitDataIntoJSONObjects splits a concatenated string of JSON objects into individual JSON objects.
+// This function takes a string containing one or more JSON objects concatenated together,
+// separated by optional whitespace, and splits them into an array of individual JSON strings.
+// It ensures that nested objects and strings containing braces do not interfere with the splitting logic.
+//
+// Example inputs:
+// - '{ "query": "test"} { "query": "test" }' -> ['{ "query": "test"}', '{ "query": "test" }']
+// - '{ "query": "test"}' -> ['{ "query": "test"}']
+// - '{ "query": "{a} {b}"}' -> ['{ "query": "{a} {b}"}'].
+func SplitDataIntoJSONObjects(s string) []string {
+	var jsonObjects []string
+	// Track the depth of nested braces
+	depth := 0
+	// Holds the current JSON object as we iterate
+	currentObject := ""
+	// Tracks whether the current position is inside a string
+	insideString := false
+	// Iterate through each character in the input string
+	rs := []rune(s)
+	for i, r := range rs {
+		// Append the character to the current JSON object string
+		currentObject += string(r)
+
+		// If the character is a double quote and it is not escaped, toggle the `insideString` state
+		if r == '"' && (i == 0 || rs[i-1] != '\\') {
+			insideString = !insideString
+		} else if !insideString {
+			// Only modify depth if not inside a string
+			switch r {
+			case '{':
+				depth++
+			case '}':
+				depth--
+			default:
+				// Other characters don't affect depth
+			}
+
+			if depth == 0 {
+				jsonObjects = append(jsonObjects, strings.TrimSpace(currentObject))
+				currentObject = ""
+			}
+		}
+	}
+
+	// If there's remaining data in currentObject, add it as the last JSON object.
+	if strings.TrimSpace(currentObject) != "" {
+		jsonObjects = append(jsonObjects, strings.TrimSpace(currentObject))
+	}
+
+	// Filter out any empty strings from the result
+	var result []string
+	for i := 0; i < len(jsonObjects); i++ {
+		if jsonObjects[i] != "" {
+			result = append(result, jsonObjects[i])
+		}
+	}
+	return result
+}
+
+// ParseLine extracts the method and URL from a request line.
+func ParseLine(line string) (method string, url string) {
+	line = strings.TrimSpace(line)
+	firstWhitespaceIndex := strings.Index(line, " ")
+	if firstWhitespaceIndex < 0 {
+		// There is no url, only method
+		return line, ""
+	}
+
+	// 1st part is the method
+	method = strings.ToUpper(strings.TrimSpace(line[0:firstWhitespaceIndex]))
+	// 2nd part is the url
+	url = RemoveTrailingWhitespace(strings.TrimSpace(line[firstWhitespaceIndex:]))
+	return method, url
+}
+
+// RemoveTrailingWhitespace removes any trailing comments from a URL string.
+// For example: "_search // comment" -> "_search"
+// Ideally the parser would do that, but currently they are included in the url.
+func RemoveTrailingWhitespace(s string) string {
+	index := 0
+	whitespaceIndex := -1
+	isQueryParam := false
+	for {
+		r, sz := utf8.DecodeRuneInString(s[index:])
+		if r == utf8.RuneError {
+			break
+		}
+		if r == '"' {
+			isQueryParam = !isQueryParam
+		} else if r == ' ' && !isQueryParam {
+			whitespaceIndex = index
+			break
+		}
+		index += sz
+	}
+	if whitespaceIndex > 0 {
+		return s[:whitespaceIndex]
+	}
+	return s
+}
+
+// CollapseLiteralString collapses triple-quoted literal strings in the given string.
+func CollapseLiteralString(s string) string {
+	splitData := strings.Split(s, `"""`)
+	for idx := 1; idx < len(splitData)-1; idx += 2 {
+		v, err := json.Marshal(splitData[idx])
+		if err != nil {
+			continue
+		}
+		splitData[idx] = string(v)
+	}
+	return strings.Join(splitData, "")
+}
+
+// IndentData round-trips a string through HJSON to strip comments, then
+// re-marshals as indented JSON.
+func IndentData(s string) string {
+	v := make(map[string]any)
+	if err := hjson.Unmarshal([]byte(s), &v); err != nil {
+		return s
+	}
+	m, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return s
+	}
+	return string(m)
+}
+
+// ContainsComments checks whether a string contains JSON/JS-style comments
+// outside of string literals.
+func ContainsComments(s string) bool {
+	insideString := false
+	var prevR rune
+	rs := []rune(s)
+	for i, r := range rs {
+		nextR := rune(0)
+		if i+1 < len(rs) {
+			nextR = rs[i+1]
+		}
+
+		if !insideString && r == '"' {
+			insideString = true
+		} else if insideString && r == '"' && prevR != '\\' {
+			insideString = false
+		} else if !insideString {
+			if r == '/' && (nextR == '/' || nextR == '*') {
+				return true
+			}
+		}
+		prevR = r
+	}
+	return false
+}

--- a/elasticsearch/parsertest/parser_test.go
+++ b/elasticsearch/parsertest/parser_test.go
@@ -1,0 +1,378 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	es "github.com/bytebase/omni/elasticsearch"
+	"github.com/bytebase/omni/elasticsearch/parser"
+)
+
+func TestParseElasticsearchREST(t *testing.T) {
+	type testCase struct {
+		Description string          `yaml:"description,omitempty"`
+		Statement   string          `yaml:"statement,omitempty"`
+		Result      *es.ParseResult `yaml:"result,omitempty"`
+	}
+
+	var (
+		filename = "parse-elasticsearch-rest.yaml"
+		record   = false
+	)
+
+	cases := loadYAML[testCase](t, filename)
+
+	for i, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got, err := es.ParseElasticsearchREST(tc.Statement)
+			require.NoErrorf(t, err, "description: %s", tc.Description)
+			if record {
+				cases[i].Result = got
+			} else {
+				require.Equalf(t, tc.Result, got, "description: %s", tc.Description)
+			}
+		})
+	}
+
+	if record {
+		writeYAML(t, filename, cases)
+	}
+}
+
+func TestParse(t *testing.T) {
+	// See https://sourcegraph.com/github.com/elastic/kibana/-/blob/src/platform/packages/shared/kbn-monaco/src/languages/console/parser.test.ts.
+	testCases := []struct {
+		description string
+		input       string
+		got         []parser.ParsedRequest
+	}{
+		{
+			description: "returns parsedRequests if the input is correct",
+			input:       "GET _search",
+			got: []parser.ParsedRequest{
+				{
+					StartOffset: 0,
+					EndOffset:   11,
+				},
+			},
+		},
+		{
+			description: "parses several requests",
+			input:       "GET _search\nPOST _test_index",
+			got: []parser.ParsedRequest{
+				{
+					StartOffset: 0,
+					EndOffset:   11,
+				},
+				{
+					StartOffset: 12,
+					EndOffset:   28,
+				},
+			},
+		},
+		{
+			description: "parses a request with a request body",
+			input: "GET _search\n{\n  \"query\": {\n    \"match_all\": {}\n  }\n}",
+			got: []parser.ParsedRequest{
+				{
+					StartOffset: 0,
+					EndOffset:   52,
+				},
+			},
+		},
+		{
+			description: "allows upper case methods",
+			input:       "GET _search\nPOST _search\nPATCH _search\nPUT _search\nHEAD _search",
+			got: []parser.ParsedRequest{
+				{
+					StartOffset: 0,
+					EndOffset:   11,
+				},
+				{
+					StartOffset: 12,
+					EndOffset:   24,
+				},
+				{
+					StartOffset: 25,
+					EndOffset:   38,
+				},
+				{
+					StartOffset: 39,
+					EndOffset:   50,
+				},
+				{
+					StartOffset: 51,
+					EndOffset:   63,
+				},
+			},
+		},
+		{
+			description: "allows lower case methods",
+			input:       "get _search\npost _search\npatch _search\nput _search\nhead _search",
+			got: []parser.ParsedRequest{
+				{
+					StartOffset: 0,
+					EndOffset:   11,
+				},
+				{
+					StartOffset: 12,
+					EndOffset:   24,
+				},
+				{
+					StartOffset: 25,
+					EndOffset:   38,
+				},
+				{
+					StartOffset: 39,
+					EndOffset:   50,
+				},
+				{
+					StartOffset: 51,
+					EndOffset:   63,
+				},
+			},
+		},
+		{
+			description: "allows mixed case methods",
+			input:       "GeT _search\npOSt _search\nPaTch _search\nPut _search\nheAD _search",
+			got: []parser.ParsedRequest{
+				{
+					StartOffset: 0,
+					EndOffset:   11,
+				},
+				{
+					StartOffset: 12,
+					EndOffset:   24,
+				},
+				{
+					StartOffset: 25,
+					EndOffset:   38,
+				},
+				{
+					StartOffset: 39,
+					EndOffset:   50,
+				},
+				{
+					StartOffset: 51,
+					EndOffset:   63,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := parser.Parse(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.got, result.Requests, "description: %s", tc.description)
+		})
+	}
+}
+
+func TestGetEditorRequest(t *testing.T) {
+	testCases := []struct {
+		description string
+		content     string
+		adjusted    parser.AdjustedParsedRequest
+		want        *parser.EditorRequest
+	}{
+		{
+			description: "cleans up any text following the url",
+			content:     "GET _search // inline comment",
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   0,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    "_search",
+			},
+		},
+		{
+			description: "doesn't incorrectly removes parts of url params that include whitespaces",
+			content:     `GET _search?query="test test"`,
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   0,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    `_search?query="test test"`,
+			},
+		},
+		{
+			description: "correctly includes the request body",
+			content:     "GET _search\n{\n  \"query\": {}\n}",
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   3,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    "_search",
+				Data: []string{
+					"{\n  \"query\": {}\n}",
+				},
+			},
+		},
+		{
+			description: "correctly handles nested braces",
+			content:     "GET _search\n{\n  \"query\": \"{a} {b}\"\n}\n{\n  \"query\": {}\n}",
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   6,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    "_search",
+				Data: []string{
+					"{\n  \"query\": \"{a} {b}\"\n}",
+					"{\n  \"query\": {}\n}",
+				},
+			},
+		},
+		{
+			description: "works for several request bodies",
+			content:     "GET _search\n{\n  \"query\": {}\n}\n{\n  \"query\": {}\n}",
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   6,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    "_search",
+				Data: []string{
+					"{\n  \"query\": {}\n}",
+					"{\n  \"query\": {}\n}",
+				},
+			},
+		},
+		{
+			description: "splits several json objects",
+			content:     "GET _search\n{\"query\":\"test\"}\n{\n  \"query\": \"test\"\n}\n{\"query\":\"test\"}",
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   5,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    "_search",
+				Data: []string{
+					`{"query":"test"}`,
+					"{\n  \"query\": \"test\"\n}",
+					`{"query":"test"}`,
+				},
+			},
+		},
+		{
+			description: "works for invalid json objects",
+			content:     "GET _search\n{\"query\":\"test\"}\n{\n  \"query\":\n{",
+			adjusted: parser.AdjustedParsedRequest{
+				StartLineNumber: 0,
+				EndLineNumber:   4,
+			},
+			want: &parser.EditorRequest{
+				Method: "GET",
+				URL:    "_search",
+				Data: []string{
+					`{"query":"test"}`,
+					"{\n  \"query\":\n{",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			got := parser.GetEditorRequest(tc.content, tc.adjusted)
+			require.Equal(t, tc.want, got, "description: %s", tc.description)
+		})
+	}
+}
+
+func TestContainsComments(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       string
+		want        bool
+	}{
+		{
+			description: "should return false for JSON with // and /* inside strings",
+			input: `{
+      "docs": [
+        {
+          "_source": {
+            "trace": {
+              "name": "GET /actuator/health/**"
+            },
+            "transaction": {
+              "outcome": "success"
+            }
+          }
+        },
+        {
+          "_source": {
+            "vulnerability": {
+              "reference": [
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15778"
+              ]
+            }
+          }
+        }
+      ]
+    }`,
+			want: false,
+		},
+		{
+			description: "should return true for text with actual line comment",
+			input: `{
+      // This is a comment
+      "query": { "match_all": {} }
+    }`,
+			want: true,
+		},
+		{
+			description: "should return true for text with actual block comment",
+			input: `{
+      /* Bulk insert */
+      "index": { "_index": "test" },
+      "field1": "value1"
+    }`,
+			want: true,
+		},
+		{
+			description: "should return false for text without any comments",
+			input: `{
+      "field": "value"
+    }`,
+			want: false,
+		},
+		{
+			description: "should return false for empty string",
+			input:       ``,
+			want:        false,
+		},
+		{
+			description: "should correctly handle escaped quotes within strings",
+			input: `{
+      "field": "value with \"escaped quotes\""
+    }`,
+			want: false,
+		},
+		{
+			description: "should return true if comment is outside of strings",
+			input: `{
+      "field": "value" // comment here
+    }`,
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			got := parser.ContainsComments(tc.input)
+			require.Equal(t, tc.want, got, "description: %s", tc.description)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Port the core Elasticsearch REST request parser (~1262 LoC state machine) from bytebase to omni
- Implement public `ParseElasticsearchREST()` entry point mapping internal parser output to omni types
- Port all 4 test suites (25 test cases total) including golden file tests against `parse-elasticsearch-rest.yaml`

Key components ported:
- Recursive-descent state machine (method/URL/body scanning, comment handling, HJSON normalization, error recovery)
- Byte-offset tracking and line/column position conversion for syntax errors
- Multi-document body splitting, triple-quoted literal strings, trailing comment stripping

## Test plan

- [x] All 5 golden test cases in `parse-elasticsearch-rest.yaml` pass
- [x] All 6 `TestParse` inline cases pass (internal offset tracking)
- [x] All 7 `TestGetEditorRequest` inline cases pass
- [x] All 7 `TestContainsComments` inline cases pass
- [x] `go build ./...` succeeds (full repo)
- [ ] Review: no behavioral differences from original bytebase parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)