### PR TITLE
feat(elasticsearch): F3 statement splitter

### DIFF
--- a/elasticsearch/parsertest/splitter_test.go
+++ b/elasticsearch/parsertest/splitter_test.go
@@ -1,0 +1,56 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	es "github.com/bytebase/omni/elasticsearch"
+)
+
+func TestSplitMultiSQL(t *testing.T) {
+	type statementCase struct {
+		Text  string      `yaml:"text,omitempty"`
+		Start es.Position `yaml:"start,omitempty"`
+		End   es.Position `yaml:"end,omitempty"`
+		Range es.Range    `yaml:"range,omitempty"`
+	}
+	type testCase struct {
+		Description   string          `yaml:"description,omitempty"`
+		Statement     string          `yaml:"statement,omitempty"`
+		ExpectedCount int             `yaml:"expectedCount"`
+		Statements    []statementCase `yaml:"statements,omitempty"`
+	}
+
+	cases := loadYAML[testCase](t, "splitter.yaml")
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got, err := es.SplitMultiSQL(tc.Statement)
+			require.NoErrorf(t, err, "description: %s", tc.Description)
+			require.Lenf(t, got, tc.ExpectedCount, "description: %s", tc.Description)
+
+			for i, want := range tc.Statements {
+				if i >= len(got) {
+					break
+				}
+				stmt := got[i]
+				if want.Text != "" {
+					require.Equalf(t, want.Text, stmt.Text, "description: %s, statement[%d].text", tc.Description, i)
+				}
+				if want.Start.Line != 0 || want.Start.Column != 0 {
+					require.Equalf(t, want.Start.Line, stmt.Start.Line, "description: %s, statement[%d].start.line", tc.Description, i)
+					require.Equalf(t, want.Start.Column, stmt.Start.Column, "description: %s, statement[%d].start.column", tc.Description, i)
+				}
+				if want.End.Line != 0 || want.End.Column != 0 {
+					require.Equalf(t, want.End.Line, stmt.End.Line, "description: %s, statement[%d].end.line", tc.Description, i)
+					require.Equalf(t, want.End.Column, stmt.End.Column, "description: %s, statement[%d].end.column", tc.Description, i)
+				}
+				if want.Range.Start != 0 || want.Range.End != 0 {
+					require.Equalf(t, want.Range.Start, stmt.Range.Start, "description: %s, statement[%d].range.start", tc.Description, i)
+					require.Equalf(t, want.Range.End, stmt.Range.End, "description: %s, statement[%d].range.end", tc.Description, i)
+				}
+			}
+		})
+	}
+}

--- a/elasticsearch/splitter.go
+++ b/elasticsearch/splitter.go
@@ -1,0 +1,85 @@
+package elasticsearch
+
+import "strings"
+
+// Statement is a single parsed Elasticsearch REST API request with position and byte range info.
+type Statement struct {
+	Text  string   `yaml:"text,omitempty"`
+	Empty bool     `yaml:"empty,omitempty"`
+	Start Position `yaml:"start,omitempty"`
+	End   Position `yaml:"end,omitempty"`
+	Range Range    `yaml:"range,omitempty"`
+}
+
+// Range holds the byte start and end offsets of a statement.
+type Range struct {
+	Start int `yaml:"start"`
+	End   int `yaml:"end"`
+}
+
+// SplitMultiSQL splits the input into individual Elasticsearch REST API requests.
+func SplitMultiSQL(statement string) ([]Statement, error) {
+	parseResult, err := ParseElasticsearchREST(statement)
+	if err != nil {
+		return nil, err
+	}
+
+	if parseResult == nil || len(parseResult.Requests) == 0 {
+		if len(strings.TrimSpace(statement)) == 0 {
+			return nil, nil
+		}
+		return []Statement{{Text: statement}}, nil
+	}
+
+	var statements []Statement
+	for _, req := range parseResult.Requests {
+		if req == nil {
+			continue
+		}
+		text := statement[req.StartOffset:req.EndOffset]
+		empty := len(strings.TrimSpace(text)) == 0
+
+		startLine, startColumn := byteOffsetToPosition(statement, req.StartOffset)
+		endLine, endColumn := byteOffsetToPosition(statement, req.EndOffset)
+
+		statements = append(statements, Statement{
+			Text:  text,
+			Empty: empty,
+			Start: Position{
+				Line:   startLine,
+				Column: startColumn,
+			},
+			End: Position{
+				Line:   endLine,
+				Column: endColumn,
+			},
+			Range: Range{
+				Start: req.StartOffset,
+				End:   req.EndOffset,
+			},
+		})
+	}
+	return statements, nil
+}
+
+// byteOffsetToPosition converts a byte offset to 1-based line and column numbers.
+// Column is measured in Unicode code points (runes), not bytes.
+func byteOffsetToPosition(text string, byteOffset int) (line, column int) {
+	line = 1
+	column = 1
+	currentByte := 0
+
+	for _, r := range text {
+		if currentByte >= byteOffset {
+			break
+		}
+		if r == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+		currentByte += len(string(r))
+	}
+	return line, column
+}


### PR DESCRIPTION
## Summary

- Ports `SplitMultiSQL` from bytebase's elasticsearch parser into omni as a standalone function with no external dependencies
- Defines `Statement` and `Range` types in `elasticsearch/splitter.go` with YAML tags matching the golden file schema
- Adds `byteOffsetToPosition()` helper that converts byte offsets to 1-based line/column numbers (counting Unicode code points)
- Adds `elasticsearch/parsertest/splitter_test.go` with YAML-driven tests against `testdata/splitter.yaml` covering empty input, whitespace-only, single GET, single POST with body, and multiple requests

## Test plan

- [ ] `go test ./elasticsearch/...` passes (all 6 sub-tests in `TestSplitMultiSQL` pass)
- [ ] All pre-existing tests (`TestParseElasticsearchREST`, `TestParse`, `TestGoldenFilesLoadable`, etc.) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)