### PR TITLE
feat(elasticsearch): F4 statement ranges wrapper

### DIFF
--- a/elasticsearch/parsertest/statement_ranges_test.go
+++ b/elasticsearch/parsertest/statement_ranges_test.go
@@ -1,0 +1,40 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	es "github.com/bytebase/omni/elasticsearch"
+)
+
+func TestGetStatementRanges(t *testing.T) {
+	type testCase struct {
+		Description string      `yaml:"description,omitempty"`
+		Statement   string      `yaml:"statement,omitempty"`
+		Result      []es.LSPRange `yaml:"result,omitempty"`
+	}
+
+	var (
+		filename = "statement-ranges.yaml"
+		record   = false
+	)
+
+	cases := loadYAML[testCase](t, filename)
+
+	for i, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got, err := es.GetStatementRanges(tc.Statement)
+			require.NoErrorf(t, err, "description: %s", tc.Description)
+			if record {
+				cases[i].Result = got
+			} else {
+				require.Equalf(t, tc.Result, got, "description: %s", tc.Description)
+			}
+		})
+	}
+
+	if record {
+		writeYAML(t, filename, cases)
+	}
+}

--- a/elasticsearch/statement_ranges.go
+++ b/elasticsearch/statement_ranges.go
@@ -1,0 +1,78 @@
+package elasticsearch
+
+import "unicode/utf8"
+
+// LSPPosition is a 0-based line/character position using UTF-16 code units,
+// following the Language Server Protocol convention.
+type LSPPosition struct {
+	Line      uint32 `yaml:"line"`
+	Character uint32 `yaml:"character"`
+}
+
+// LSPRange is a half-open [Start, End) range of LSP positions.
+type LSPRange struct {
+	Start LSPPosition `yaml:"start"`
+	End   LSPPosition `yaml:"end"`
+}
+
+// GetStatementRanges returns one LSPRange per parsed request in statement.
+// Positions use 0-based lines and UTF-16 code-unit columns, matching the LSP
+// specification (BMP characters count as 1, non-BMP characters count as 2).
+func GetStatementRanges(statement string) ([]LSPRange, error) {
+	parseResult, _ := ParseElasticsearchREST(statement)
+	if parseResult == nil {
+		return []LSPRange{}, nil
+	}
+	bs := []byte(statement)
+	var ranges []LSPRange
+	for _, r := range parseResult.Requests {
+		if r == nil {
+			continue
+		}
+		if r.EndOffset <= r.StartOffset {
+			continue
+		}
+
+		startPosition := getPositionByByteOffset(r.StartOffset, bs)
+		endPosition := getPositionByByteOffset(r.EndOffset, bs)
+		if startPosition == nil || endPosition == nil {
+			continue
+		}
+		ranges = append(ranges, LSPRange{
+			Start: *startPosition,
+			End:   *endPosition,
+		})
+	}
+	return ranges, nil
+}
+
+// getPositionByByteOffset converts a byte offset into an LSPPosition.
+// It counts newlines to determine the line number and accumulates UTF-16
+// code units for the character column. Characters outside the BMP (code points
+// above U+FFFF, encoded as 4-byte UTF-8 sequences) consume two UTF-16 code
+// units and therefore advance the character counter by 2.
+func getPositionByByteOffset(byteOffset int, bs []byte) *LSPPosition {
+	var position LSPPosition
+	for i := 0; ; {
+		if i >= byteOffset || i > len(bs) {
+			break
+		}
+		if bs[i] == '\n' {
+			position.Line++
+			position.Character = 0
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRune(bs[i:])
+		if r == utf8.RuneError {
+			return nil
+		}
+		position.Character++
+		if r > 0xFFFF {
+			// Outside the BMP — requires a surrogate pair in UTF-16.
+			position.Character++
+		}
+		i += size
+	}
+	return &position
+}


### PR DESCRIPTION
## Summary

- Ports `GetStatementRanges` from bytebase to omni as DAG node F4
- Defines `LSPPosition` (0-based line, UTF-16 character column) and `LSPRange` types local to the `elasticsearch` package — no external LSP protocol dependency
- `getPositionByByteOffset` walks the byte slice counting newlines for line and accumulating UTF-16 code units for character, correctly counting non-BMP characters (UTF-8 4-byte sequences, code points > U+FFFF) as 2 code units
- Adds `parsertest/statement_ranges_test.go` driven by the existing `testdata/statement-ranges.yaml` golden file via the shared `loadYAML[T]` helper

## Test plan

- [ ] `go test ./elasticsearch/...` — all pass (confirmed locally)
- [ ] `TestGetStatementRanges/multiple_request_with_empty_line` exercises multi-request splitting and position arithmetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)