### PR TITLE
feat(elasticsearch): F6a analysis foundation — MaskableAPI + body extraction

### DIFF
--- a/elasticsearch/analysis/analysis.go
+++ b/elasticsearch/analysis/analysis.go
@@ -1,0 +1,216 @@
+// Package analysis classifies Elasticsearch REST API requests for masking
+// and extracts field references from request bodies.
+package analysis
+
+import "strings"
+
+// MaskableAPI classifies an Elasticsearch endpoint for data-masking purposes.
+type MaskableAPI int
+
+const (
+	// APIUnsupported means the request cannot return user data (e.g. PUT, DELETE).
+	APIUnsupported MaskableAPI = iota
+	// APIMaskSearch means the request is a search that may return masked fields.
+	APIMaskSearch
+	// APIMaskGetDoc means the request fetches a single document via _doc.
+	APIMaskGetDoc
+	// APIMaskGetSource means the request fetches document source via _source.
+	APIMaskGetSource
+	// APIMaskMGet means the request uses the multi-get API (_mget).
+	APIMaskMGet
+	// APIMaskExplain means the request uses the explain API (_explain).
+	APIMaskExplain
+	// APIBlocked means the endpoint cannot be safely masked (scroll, SQL, etc.).
+	APIBlocked
+)
+
+// BlockedFeature identifies a request body feature that prevents safe masking.
+type BlockedFeature int
+
+const (
+	BlockedFeatureAggs            BlockedFeature = iota // "aggs" / "aggregations"
+	BlockedFeatureSuggest                               // "suggest"
+	BlockedFeatureScriptFields                          // "script_fields"
+	BlockedFeatureRuntimeMappings                       // "runtime_mappings"
+	BlockedFeatureStoredFields                          // "stored_fields"
+	BlockedFeatureDocvalueFields                        // "docvalue_fields"
+)
+
+// BlockedFeatureNames maps BlockedFeature values to human-readable names.
+var BlockedFeatureNames = map[BlockedFeature]string{
+	BlockedFeatureAggs:            "aggregations",
+	BlockedFeatureSuggest:         "suggest",
+	BlockedFeatureScriptFields:    "script_fields",
+	BlockedFeatureRuntimeMappings: "runtime_mappings",
+	BlockedFeatureStoredFields:    "stored_fields",
+	BlockedFeatureDocvalueFields:  "docvalue_fields",
+}
+
+// RequestAnalysis is the result of analysing a single Elasticsearch request.
+type RequestAnalysis struct {
+	// API is the classified endpoint type.
+	API MaskableAPI
+	// Index is the target index name extracted from the URL (may be empty).
+	Index string
+	// BlockedFeatures lists body features that prevent safe masking.
+	BlockedFeatures []BlockedFeature
+	// SourceDisabled is true when "_source": false was set in the body.
+	SourceDisabled bool
+	// SourceFields lists fields from the _source include list.
+	SourceFields []string
+	// RequestedFields lists fields from the top-level "fields" array.
+	RequestedFields []string
+	// HighlightFields lists field names from highlight.fields.
+	HighlightFields []string
+	// SortFields lists non-metadata field names from the sort array.
+	SortFields []string
+	// HasInnerHits is true when any nested inner_hits key was found.
+	HasInnerHits bool
+	// PredicateFields lists field names referenced in the query predicate.
+	// Populated by F6b (predicate walker) — left empty here.
+	PredicateFields []string
+}
+
+// blockedEndpoints lists URL patterns that must be rejected when masking is
+// active.  These overlap with read patterns but cannot be safely masked.
+// Includes both Elasticsearch and OpenSearch equivalents.
+var blockedEndpoints = []string{
+	// Elasticsearch endpoints.
+	"_async_search",
+	"_search/scroll",
+	"_search_template",
+	"_msearch/template",
+	"_sql",
+	"_eql/search",
+	"_esql/query",
+	"_terms_enum",
+	"_termvectors",
+	"_mtermvectors",
+	"_knn_search",
+	// OpenSearch equivalents (plugin-based paths).
+	"_plugins/_asynchronous_search",
+	"_plugins/_sql",
+	"_plugins/_ppl",
+}
+
+// ClassifyMaskableAPI determines the MaskableAPI type and target index for an
+// Elasticsearch request.
+func ClassifyMaskableAPI(method, url string) (MaskableAPI, string) {
+	method = strings.ToUpper(method)
+
+	// Strip query parameters.
+	path := url
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+
+	// Strip leading slash.
+	path = strings.TrimPrefix(path, "/")
+
+	// Only GET and POST can return user data.
+	switch method {
+	case "GET":
+		if blocked, index := isBlockedEndpoint(path); blocked {
+			return APIBlocked, index
+		}
+		return classifyGetForMasking(path)
+	case "POST":
+		if blocked, index := isBlockedEndpoint(path); blocked {
+			return APIBlocked, index
+		}
+		return classifyPostForMasking(path)
+	default:
+		// HEAD, PUT, DELETE, PATCH do not return user data.
+		return APIUnsupported, ""
+	}
+}
+
+// isBlockedEndpoint checks whether the path matches a blocked endpoint pattern.
+// Returns true and the extracted index if blocked.
+func isBlockedEndpoint(path string) (bool, string) {
+	for _, pattern := range blockedEndpoints {
+		if strings.Contains(path, pattern) {
+			return true, extractIndex(path)
+		}
+	}
+	return false, ""
+}
+
+// classifyGetForMasking classifies a GET request path for masking.
+func classifyGetForMasking(path string) (MaskableAPI, string) {
+	for part := range strings.SplitSeq(path, "/") {
+		switch part {
+		case "_search", "_msearch":
+			return APIMaskSearch, extractIndex(path)
+		case "_doc":
+			return APIMaskGetDoc, extractIndex(path)
+		case "_source":
+			return APIMaskGetSource, extractIndex(path)
+		case "_mget":
+			return APIMaskMGet, extractIndex(path)
+		}
+	}
+	return APIUnsupported, ""
+}
+
+// classifyPostForMasking classifies a POST request path for masking.
+func classifyPostForMasking(path string) (MaskableAPI, string) {
+	for part := range strings.SplitSeq(path, "/") {
+		switch part {
+		case "_search", "_msearch":
+			return APIMaskSearch, extractIndex(path)
+		case "_mget":
+			return APIMaskMGet, extractIndex(path)
+		case "_explain":
+			return APIMaskExplain, extractIndex(path)
+		}
+	}
+	return APIUnsupported, ""
+}
+
+// extractIndex returns the first path segment if it does not start with "_".
+// This extracts the index name from ES URL paths like "<index>/_search".
+func extractIndex(path string) string {
+	if path == "" {
+		return ""
+	}
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	first := parts[0]
+	if strings.HasPrefix(first, "_") {
+		return ""
+	}
+	return first
+}
+
+// AnalyzeRequest combines URL classification with body analysis for an ES
+// request.  Body analysis is only performed for search and explain APIs.
+// The PredicateFields field is intentionally left empty — it will be populated
+// by the F6b predicate-walker implementation.
+func AnalyzeRequest(method, url, body string) *RequestAnalysis {
+	api, index := ClassifyMaskableAPI(method, url)
+	result := &RequestAnalysis{
+		API:   api,
+		Index: index,
+	}
+
+	// Only analyze the body for APIs that accept a query body.
+	switch api {
+	case APIMaskSearch, APIMaskExplain:
+		bodyResult := analyzeRequestBody(body)
+		result.BlockedFeatures = bodyResult.BlockedFeatures
+		result.SourceFields = bodyResult.SourceFields
+		result.SourceDisabled = bodyResult.SourceDisabled
+		result.RequestedFields = bodyResult.RequestedFields
+		result.HighlightFields = bodyResult.HighlightFields
+		result.SortFields = bodyResult.SortFields
+		result.HasInnerHits = bodyResult.HasInnerHits
+		// TODO(F6b): populate PredicateFields via the predicate walker.
+	default:
+		// No body analysis for other API types.
+	}
+
+	return result
+}

--- a/elasticsearch/analysis/body.go
+++ b/elasticsearch/analysis/body.go
@@ -1,0 +1,190 @@
+package analysis
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+)
+
+// analyzeRequestBody parses the JSON body and extracts fields and blocked
+// features.
+func analyzeRequestBody(body string) *RequestAnalysis {
+	result := &RequestAnalysis{}
+
+	parsed := make(map[string]any)
+	if json.Unmarshal([]byte(body), &parsed) != nil {
+		return result
+	}
+
+	result.BlockedFeatures = detectBlockedFeatures(parsed)
+	extractSource(parsed, result)
+	result.RequestedFields = extractStringArray(parsed, "fields")
+	result.HighlightFields = extractHighlightFields(parsed)
+	result.SortFields = extractSortFields(parsed)
+	result.HasInnerHits = containsKey(parsed, "inner_hits")
+	// PredicateFields left empty — F6b will populate via extractPredicateFields.
+
+	return result
+}
+
+// detectBlockedFeatures checks for top-level keys that indicate blocked
+// features.
+func detectBlockedFeatures(parsed map[string]any) []BlockedFeature {
+	var blocked []BlockedFeature
+
+	if _, ok := parsed["aggs"]; ok {
+		blocked = append(blocked, BlockedFeatureAggs)
+	} else if _, ok := parsed["aggregations"]; ok {
+		blocked = append(blocked, BlockedFeatureAggs)
+	}
+	if _, ok := parsed["suggest"]; ok {
+		blocked = append(blocked, BlockedFeatureSuggest)
+	}
+	if _, ok := parsed["script_fields"]; ok {
+		blocked = append(blocked, BlockedFeatureScriptFields)
+	}
+	if _, ok := parsed["runtime_mappings"]; ok {
+		blocked = append(blocked, BlockedFeatureRuntimeMappings)
+	}
+	if _, ok := parsed["stored_fields"]; ok {
+		blocked = append(blocked, BlockedFeatureStoredFields)
+	}
+	if _, ok := parsed["docvalue_fields"]; ok {
+		blocked = append(blocked, BlockedFeatureDocvalueFields)
+	}
+
+	return blocked
+}
+
+// extractSource handles the three forms of _source in the request body.
+func extractSource(parsed map[string]any, result *RequestAnalysis) {
+	src, ok := parsed["_source"]
+	if !ok {
+		return
+	}
+
+	switch v := src.(type) {
+	case bool:
+		if !v {
+			result.SourceDisabled = true
+		}
+	case []any:
+		result.SourceFields = toStringSlice(v)
+	case map[string]any:
+		if includes, ok := v["includes"]; ok {
+			if arr, ok := includes.([]any); ok {
+				result.SourceFields = toStringSlice(arr)
+			}
+		}
+	default:
+	}
+}
+
+// extractStringArray extracts a string array value from a top-level key.
+func extractStringArray(parsed map[string]any, key string) []string {
+	val, ok := parsed[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := val.([]any)
+	if !ok {
+		return nil
+	}
+	return toStringSlice(arr)
+}
+
+// extractHighlightFields extracts field names from highlight.fields.
+func extractHighlightFields(parsed map[string]any) []string {
+	highlight, ok := parsed["highlight"]
+	if !ok {
+		return nil
+	}
+	hlMap, ok := highlight.(map[string]any)
+	if !ok {
+		return nil
+	}
+	fields, ok := hlMap["fields"]
+	if !ok {
+		return nil
+	}
+	fieldsMap, ok := fields.(map[string]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(fieldsMap))
+	for k := range fieldsMap {
+		result = append(result, k)
+	}
+	slices.Sort(result)
+	return result
+}
+
+// extractSortFields extracts field names from the sort array.
+func extractSortFields(parsed map[string]any) []string {
+	sortVal, ok := parsed["sort"]
+	if !ok {
+		return nil
+	}
+	arr, ok := sortVal.([]any)
+	if !ok {
+		return nil
+	}
+	var fields []string
+	for _, item := range arr {
+		switch v := item.(type) {
+		case string:
+			if strings.HasPrefix(v, "_") {
+				continue
+			}
+			fields = append(fields, v)
+		case map[string]any:
+			for k := range v {
+				if !strings.HasPrefix(k, "_") {
+					fields = append(fields, k)
+				}
+			}
+		default:
+		}
+	}
+	return fields
+}
+
+// containsKey recursively searches for a key in a nested map structure.
+func containsKey(data map[string]any, key string) bool {
+	for k, v := range data {
+		if k == key {
+			return true
+		}
+		if containsKeyInValue(v, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsKeyInValue checks if any nested map within v contains the given key.
+func containsKeyInValue(v any, key string) bool {
+	switch child := v.(type) {
+	case map[string]any:
+		return containsKey(child, key)
+	case []any:
+		for _, item := range child {
+			if m, ok := item.(map[string]any); ok && containsKey(m, key) {
+				return true
+			}
+		}
+	default:
+	}
+	return false
+}
+
+// toStringSlice converts a []any to a []string, skipping non-string elements.
+func toStringSlice(arr []any) []string {
+	result := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/elasticsearch/parsertest/analysis_test.go
+++ b/elasticsearch/parsertest/analysis_test.go
@@ -1,0 +1,70 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/elasticsearch/analysis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyMaskableAPI(t *testing.T) {
+	type testCase struct {
+		Description string              `yaml:"description"`
+		Method      string              `yaml:"method"`
+		URL         string              `yaml:"url"`
+		WantAPI     analysis.MaskableAPI `yaml:"wantAPI"`
+		WantIndex   string              `yaml:"wantIndex"`
+	}
+
+	cases := loadYAML[testCase](t, "masking_classify_api.yaml")
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			api, index := analysis.ClassifyMaskableAPI(tc.Method, tc.URL)
+			require.Equal(t, tc.WantAPI, api, "API classification")
+			require.Equal(t, tc.WantIndex, index, "index extraction")
+		})
+	}
+}
+
+func TestAnalyzeRequestBody(t *testing.T) {
+	type testCase struct {
+		Description        string                   `yaml:"description"`
+		Body               string                   `yaml:"body"`
+		WantBlocked        []analysis.BlockedFeature `yaml:"wantBlocked"`
+		WantSourceDisabled bool                     `yaml:"wantSourceDisabled"`
+		WantSourceFields   []string                 `yaml:"wantSourceFields"`
+		WantFields         []string                 `yaml:"wantFields"`
+		WantHighlight      []string                 `yaml:"wantHighlight"`
+		WantSort           []string                 `yaml:"wantSort"`
+		WantInnerHits      bool                     `yaml:"wantInnerHits"`
+	}
+
+	cases := loadYAML[testCase](t, "masking_analyze_body.yaml")
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			result := analysis.AnalyzeRequest("POST", "/my-index/_search", tc.Body)
+
+			if tc.WantBlocked != nil {
+				require.Equal(t, tc.WantBlocked, result.BlockedFeatures)
+			} else {
+				require.Empty(t, result.BlockedFeatures)
+			}
+			require.Equal(t, tc.WantSourceDisabled, result.SourceDisabled)
+			if tc.WantSourceFields != nil {
+				require.Equal(t, tc.WantSourceFields, result.SourceFields)
+			}
+			if tc.WantFields != nil {
+				require.Equal(t, tc.WantFields, result.RequestedFields)
+			}
+			if tc.WantHighlight != nil {
+				require.ElementsMatch(t, tc.WantHighlight, result.HighlightFields)
+			}
+			if tc.WantSort != nil {
+				require.Equal(t, tc.WantSort, result.SortFields)
+			}
+			require.Equal(t, tc.WantInnerHits, result.HasInnerHits)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `elasticsearch/analysis` package with omni-native `MaskableAPI` and `BlockedFeature` enums, `RequestAnalysis` struct, `ClassifyMaskableAPI()`, and `AnalyzeRequest()`
- Ports body analysis functions verbatim from bytebase: blocked-feature detection, `_source` config extraction, `fields`/`highlight.fields`/`sort` extraction, recursive `inner_hits` detection
- Adds two YAML-driven test suites in `elasticsearch/parsertest/analysis_test.go` covering all 32 cases in `masking_classify_api.yaml` and `masking_analyze_body.yaml`
- Leaves `PredicateFields` as an empty TODO hook for F6b (predicate walker)

## Test plan

- [ ] `go test ./elasticsearch/... -run 'TestClassifyMaskableAPI|TestAnalyzeRequestBody'` — all 32 cases pass
- [ ] `TestDiagnose` failures are pre-existing on `main` and unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)