### PR TITLE
feat(elasticsearch): F5 diagnose wrapper

### DIFF
--- a/elasticsearch/diagnose.go
+++ b/elasticsearch/diagnose.go
@@ -1,0 +1,50 @@
+package elasticsearch
+
+// DiagnosticSeverity represents the severity level of a diagnostic.
+type DiagnosticSeverity int
+
+const (
+	// SeverityError indicates a hard syntax error.
+	SeverityError DiagnosticSeverity = 1
+)
+
+// DiagnosticRange represents a character range in source text.
+type DiagnosticRange struct {
+	Start Position
+	End   Position
+}
+
+// Diagnostic holds a single parse diagnostic (error, warning, …) produced by
+// Diagnose. Positions are 0-based line and column values matching LSP
+// conventions so callers can forward them without conversion.
+type Diagnostic struct {
+	Range    DiagnosticRange
+	Severity DiagnosticSeverity
+	Message  string
+}
+
+// Diagnose parses statement and returns a Diagnostic for every SyntaxError
+// found. It returns nil, nil when there are no errors.
+func Diagnose(statement string) ([]Diagnostic, error) {
+	parseResult, _ := ParseElasticsearchREST(statement)
+	if parseResult == nil {
+		return nil, nil
+	}
+
+	var diagnostics []Diagnostic
+	for _, err := range parseResult.Errors {
+		if err == nil {
+			continue
+		}
+		// SyntaxError positions are 0-based (line and column). The end of the
+		// range is set one column past the start so callers get a non-empty span.
+		start := err.Position
+		end := Position{Line: start.Line, Column: start.Column + 1}
+		diagnostics = append(diagnostics, Diagnostic{
+			Range:    DiagnosticRange{Start: start, End: end},
+			Severity: SeverityError,
+			Message:  err.Message,
+		})
+	}
+	return diagnostics, nil
+}

--- a/elasticsearch/parsertest/diagnose_test.go
+++ b/elasticsearch/parsertest/diagnose_test.go
@@ -1,0 +1,93 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/elasticsearch"
+)
+
+func TestDiagnose(t *testing.T) {
+	tests := []struct {
+		name            string
+		statement       string
+		wantCount       int
+		wantFirstLine   int
+		wantFirstColumn int
+	}{
+		{
+			name:      "no errors — valid single request",
+			statement: "GET _search",
+			wantCount: 0,
+		},
+		{
+			name:      "no errors — valid request with body",
+			statement: "POST /my-index/_search\n{\"query\":{\"match_all\":{}}}",
+			wantCount: 0,
+		},
+		{
+			name:      "no errors — multiple valid requests",
+			statement: "GET _cluster/health\n\nPOST /my-index/_doc\n{\"field\":\"value\"}",
+			wantCount: 0,
+		},
+		{
+			// A bare non-HTTP-verb token before a valid request triggers one
+			// recoverable syntax error; the parser skips ahead to the next verb.
+			name:            "single error — bad token followed by valid request",
+			statement:       "3333\nGET _search",
+			wantCount:       1,
+			wantFirstLine:   0,
+			wantFirstColumn: 2,
+		},
+		{
+			// Bad token sandwiched between two valid requests.
+			name:            "single error — bad token between valid requests",
+			statement:       "GET _a\n3333\nPUT /index/_doc",
+			wantCount:       1,
+			wantFirstLine:   1,
+			wantFirstColumn: 2,
+		},
+		{
+			// Two separate bad tokens, each followed by a valid request, produce
+			// two distinct diagnostics.
+			name:            "multiple errors — two bad tokens interleaved with valid requests",
+			statement:       "3333\nGET _a\n4444\nGET _b",
+			wantCount:       2,
+			wantFirstLine:   0,
+			wantFirstColumn: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diags, err := elasticsearch.Diagnose(tc.statement)
+			if err != nil {
+				t.Fatalf("Diagnose returned unexpected error: %v", err)
+			}
+			if len(diags) != tc.wantCount {
+				t.Fatalf("diagnostic count: got %d, want %d\ndiags: %+v", len(diags), tc.wantCount, diags)
+			}
+			if tc.wantCount == 0 {
+				return
+			}
+			first := diags[0]
+			if first.Range.Start.Line != tc.wantFirstLine || first.Range.Start.Column != tc.wantFirstColumn {
+				t.Errorf("first diagnostic position: got line=%d col=%d, want line=%d col=%d",
+					first.Range.Start.Line, first.Range.Start.Column,
+					tc.wantFirstLine, tc.wantFirstColumn)
+			}
+			if first.Severity != elasticsearch.SeverityError {
+				t.Errorf("severity: got %d, want SeverityError", first.Severity)
+			}
+			if first.Message == "" {
+				t.Error("first diagnostic message is empty")
+			}
+			// End column must be exactly one past start (non-empty range).
+			if first.Range.End.Column != first.Range.Start.Column+1 {
+				t.Errorf("end column: got %d, want start+1=%d", first.Range.End.Column, first.Range.Start.Column+1)
+			}
+			if first.Range.End.Line != first.Range.Start.Line {
+				t.Errorf("end line: got %d, want same as start=%d", first.Range.End.Line, first.Range.Start.Line)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `elasticsearch/diagnose.go` with a minimal `Diagnostic` type (`DiagnosticSeverity`, `DiagnosticRange`, `Diagnostic`) and a `Diagnose(statement string) ([]Diagnostic, error)` function
- `Diagnose` calls `ParseElasticsearchREST`, iterates `SyntaxError` entries, and converts each to a `Diagnostic` with a 0-based position range (end = start + 1 column)
- Adds `elasticsearch/parsertest/diagnose_test.go` with 6 inline table-driven test cases covering no-error inputs, single-error inputs (with exact line/column assertions), and a multiple-error input

## Test plan

- [ ] `go test ./elasticsearch/...` passes (all 6 `TestDiagnose` subtests + existing tests)
- [ ] No bytebase imports introduced
- [ ] `Diagnose` returns `nil, nil` for inputs the underlying parser cannot recover (hard `Syntax error` from `parser.Parse`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)