### PR TITLE
feat(elasticsearch): F6b predicate walker

### DIFF
--- a/elasticsearch/analysis/analysis.go
+++ b/elasticsearch/analysis/analysis.go
@@ -67,7 +67,6 @@ type RequestAnalysis struct {
 	// HasInnerHits is true when any nested inner_hits key was found.
 	HasInnerHits bool
 	// PredicateFields lists field names referenced in the query predicate.
-	// Populated by F6b (predicate walker) — left empty here.
 	PredicateFields []string
 }
 
@@ -187,8 +186,6 @@ func extractIndex(path string) string {
 
 // AnalyzeRequest combines URL classification with body analysis for an ES
 // request.  Body analysis is only performed for search and explain APIs.
-// The PredicateFields field is intentionally left empty — it will be populated
-// by the F6b predicate-walker implementation.
 func AnalyzeRequest(method, url, body string) *RequestAnalysis {
 	api, index := ClassifyMaskableAPI(method, url)
 	result := &RequestAnalysis{
@@ -207,7 +204,7 @@ func AnalyzeRequest(method, url, body string) *RequestAnalysis {
 		result.HighlightFields = bodyResult.HighlightFields
 		result.SortFields = bodyResult.SortFields
 		result.HasInnerHits = bodyResult.HasInnerHits
-		// TODO(F6b): populate PredicateFields via the predicate walker.
+		result.PredicateFields = bodyResult.PredicateFields
 	default:
 		// No body analysis for other API types.
 	}

--- a/elasticsearch/analysis/body.go
+++ b/elasticsearch/analysis/body.go
@@ -22,7 +22,7 @@ func analyzeRequestBody(body string) *RequestAnalysis {
 	result.HighlightFields = extractHighlightFields(parsed)
 	result.SortFields = extractSortFields(parsed)
 	result.HasInnerHits = containsKey(parsed, "inner_hits")
-	// PredicateFields left empty — F6b will populate via extractPredicateFields.
+	result.PredicateFields = extractPredicateFields(parsed)
 
 	return result
 }

--- a/elasticsearch/analysis/predicates.go
+++ b/elasticsearch/analysis/predicates.go
@@ -1,0 +1,109 @@
+package analysis
+
+import "strings"
+
+// directFieldClauses are clause types where the keys inside the clause object
+// are field names. For example, {"match": {"email": "alice"}} -> field "email".
+var directFieldClauses = map[string]bool{
+	"match": true, "match_phrase": true, "match_phrase_prefix": true, "match_bool_prefix": true,
+	"term": true, "terms": true, "terms_set": true,
+	"range":    true,
+	"wildcard": true, "prefix": true, "fuzzy": true, "regexp": true,
+	"geo_distance": true, "geo_bounding_box": true, "geo_shape": true, "geo_polygon": true,
+	"span_term": true,
+}
+
+// compoundClauses maps clause types to the keys that contain sub-queries.
+var compoundClauses = map[string][]string{
+	"bool":           {"must", "must_not", "should", "filter"},
+	"nested":         {"query"},
+	"has_child":      {"query"},
+	"has_parent":     {"query"},
+	"dis_max":        {"queries"},
+	"constant_score": {"filter"},
+	"boosting":       {"positive", "negative"},
+	"function_score": {"query"},
+}
+
+// extractPredicateFields extracts field names from ES query clauses.
+// It looks for the top-level "query" key, then recursively walks all recognized
+// clause types to collect the dot-notation field paths used in predicates.
+func extractPredicateFields(parsed map[string]any) []string {
+	queryVal, ok := parsed["query"]
+	if !ok {
+		return nil
+	}
+	queryMap, ok := queryVal.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var fields []string
+	extractFieldsFromQuery(queryMap, &fields)
+	return fields
+}
+
+// extractFieldsFromQuery recursively walks ES query clauses to collect field names.
+func extractFieldsFromQuery(queryMap map[string]any, fields *[]string) {
+	for clauseType, clauseVal := range queryMap {
+		clauseObj, ok := clauseVal.(map[string]any)
+		if !ok {
+			// Value might be an array (e.g. bare array at top level).
+			extractFieldsFromQueryArray(clauseVal, fields)
+			continue
+		}
+		switch {
+		case directFieldClauses[clauseType]:
+			extractDirectFieldNames(clauseObj, fields)
+		case clauseType == "exists":
+			if fieldVal, ok := clauseObj["field"].(string); ok {
+				*fields = append(*fields, fieldVal)
+			}
+		case compoundClauses[clauseType] != nil:
+			extractCompoundClauseFields(clauseObj, compoundClauses[clauseType], fields)
+		default:
+			// Unknown clause type — recurse in case it wraps sub-queries.
+			extractFieldsFromQuery(clauseObj, fields)
+		}
+	}
+}
+
+// extractFieldsFromQueryArray handles the case where a clause value is an array
+// of query maps (e.g. the value of "must" in a bool query).
+func extractFieldsFromQueryArray(val any, fields *[]string) {
+	arr, ok := val.([]any)
+	if !ok {
+		return
+	}
+	for _, item := range arr {
+		if m, ok := item.(map[string]any); ok {
+			extractFieldsFromQuery(m, fields)
+		}
+	}
+}
+
+// extractDirectFieldNames extracts field names from a direct field clause object.
+// Keys starting with "_" and the "boost" parameter are excluded.
+func extractDirectFieldNames(clauseObj map[string]any, fields *[]string) {
+	for fieldName := range clauseObj {
+		if !strings.HasPrefix(fieldName, "_") && fieldName != "boost" {
+			*fields = append(*fields, fieldName)
+		}
+	}
+}
+
+// extractCompoundClauseFields recurses into sub-query keys of a compound clause.
+func extractCompoundClauseFields(clauseObj map[string]any, subQueryKeys []string, fields *[]string) {
+	for _, sqKey := range subQueryKeys {
+		sqVal, ok := clauseObj[sqKey]
+		if !ok {
+			continue
+		}
+		switch sq := sqVal.(type) {
+		case map[string]any:
+			extractFieldsFromQuery(sq, fields)
+		case []any:
+			extractFieldsFromQueryArray(sq, fields)
+		default:
+		}
+	}
+}

--- a/elasticsearch/parsertest/predicate_test.go
+++ b/elasticsearch/parsertest/predicate_test.go
@@ -1,0 +1,64 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/elasticsearch/analysis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPredicateFields(t *testing.T) {
+	type testCase struct {
+		Description string   `yaml:"description"`
+		Body        string   `yaml:"body"`
+		WantFields  []string `yaml:"wantFields"`
+	}
+
+	cases := loadYAML[testCase](t, "masking_predicate_fields.yaml")
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			// Drive through AnalyzeRequest so the predicate walker is exercised
+			// end-to-end via the body analysis path.
+			result := analysis.AnalyzeRequest("POST", "/my-index/_search", tc.Body)
+			if len(tc.WantFields) > 0 {
+				require.ElementsMatch(t, tc.WantFields, result.PredicateFields)
+			} else {
+				require.Empty(t, result.PredicateFields)
+			}
+		})
+	}
+}
+
+func TestAnalyzeRequest(t *testing.T) {
+	type testCase struct {
+		Description         string                    `yaml:"description"`
+		Method              string                    `yaml:"method"`
+		URL                 string                    `yaml:"url"`
+		Body                string                    `yaml:"body"`
+		WantAPI             analysis.MaskableAPI      `yaml:"wantAPI"`
+		WantIndex           string                    `yaml:"wantIndex"`
+		WantBlocked         []analysis.BlockedFeature `yaml:"wantBlocked"`
+		WantPredicateFields []string                  `yaml:"wantPredicateFields"`
+	}
+
+	cases := loadYAML[testCase](t, "masking_analyze_request.yaml")
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			result := analysis.AnalyzeRequest(tc.Method, tc.URL, tc.Body)
+			require.Equal(t, tc.WantAPI, result.API)
+			if tc.WantIndex != "" {
+				require.Equal(t, tc.WantIndex, result.Index)
+			}
+			if tc.WantBlocked != nil {
+				require.Equal(t, tc.WantBlocked, result.BlockedFeatures)
+			} else {
+				require.Empty(t, result.BlockedFeatures)
+			}
+			if tc.WantPredicateFields != nil {
+				require.ElementsMatch(t, tc.WantPredicateFields, result.PredicateFields)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Port the recursive predicate field extractor from bytebase's `masking.go` to omni's `elasticsearch/analysis/` package as `predicates.go`
- Wire `extractPredicateFields` into both `analyzeRequestBody` (body.go) and `AnalyzeRequest` (analysis.go), replacing the F6b TODO stubs
- Add `predicate_test.go` with unit tests (via `masking_predicate_fields.yaml`) and integration tests (via `masking_analyze_request.yaml`)

### Clause types handled

**Direct field clauses** (17): `match`, `match_phrase`, `match_phrase_prefix`, `match_bool_prefix`, `term`, `terms`, `terms_set`, `range`, `wildcard`, `prefix`, `fuzzy`, `regexp`, `geo_distance`, `geo_bounding_box`, `geo_shape`, `geo_polygon`, `span_term`

**Compound clauses** (6): `bool` (must/should/must_not/filter), `dis_max`, `constant_score`, `boosting`, `function_score`

**Nested/join clauses** (3): `nested`, `has_child`, `has_parent`

**Special** (1): `exists` (extracts from the `field` key)

## Test plan

- [x] `go test ./elasticsearch/...` passes (all 9 predicate field cases + 4 integration cases)
- [x] Existing tests unaffected (all pre-existing elasticsearch tests still pass)
- [ ] Verify clause type coverage against bytebase source


🤖 Generated with [Claude Code](https://claude.com/claude-code)