### PR TITLE
feat(elasticsearch): F7 query span integration

### DIFF
--- a/elasticsearch/parsertest/queryspan_test.go
+++ b/elasticsearch/parsertest/queryspan_test.go
@@ -1,0 +1,98 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/elasticsearch"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetQuerySpan(t *testing.T) {
+	type testCase struct {
+		Description string                `yaml:"description"`
+		Statement   string                `yaml:"statement"`
+		QueryType   elasticsearch.QueryType `yaml:"queryType"`
+	}
+
+	cases := loadYAML[testCase](t, "query_span.yaml")
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			span, err := elasticsearch.GetQuerySpan(tc.Statement)
+			require.NoError(t, err)
+			require.NotNil(t, span)
+			require.Equalf(t, tc.QueryType, span.Type,
+				"description: %s, statement: %s", tc.Description, tc.Statement)
+		})
+	}
+}
+
+func TestGetQuerySpanPredicatePaths(t *testing.T) {
+	tests := []struct {
+		description    string
+		statement      string
+		predicatePaths map[string]bool
+	}{
+		{
+			description: "search with match predicate",
+			statement:   `GET /users/_search` + "\n" + `{"query":{"match":{"email":"alice"}}}`,
+			predicatePaths: map[string]bool{
+				"email": true,
+			},
+		},
+		{
+			description: "search with nested bool query",
+			statement: `GET /users/_search` + "\n" +
+				`{"query":{"bool":{"must":[{"term":{"status":"active"}},{"range":{"age":{"gte":18}}}]}}}`,
+			predicatePaths: map[string]bool{
+				"status": true,
+				"age":    true,
+			},
+		},
+		{
+			description:    "get doc returns no predicates",
+			statement:      "GET /users/_doc/123",
+			predicatePaths: map[string]bool{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			span, err := elasticsearch.GetQuerySpan(tc.statement)
+			require.NoError(t, err, tc.description)
+			require.Equal(t, len(tc.predicatePaths), len(span.PredicatePaths), tc.description)
+			for path := range tc.predicatePaths {
+				_, ok := span.PredicatePaths[path]
+				require.Truef(t, ok, "%s: missing path %q", tc.description, path)
+			}
+		})
+	}
+}
+
+func TestGetQuerySpanDotPathAST(t *testing.T) {
+	tests := []struct {
+		dotPath  string
+		segments []string
+	}{
+		{"email", []string{"email"}},
+		{"user.name", []string{"user", "name"}},
+		{"contact.address.city", []string{"contact", "address", "city"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.dotPath, func(t *testing.T) {
+			ast := elasticsearch.DotPathToPathAST(tc.dotPath)
+			require.NotNil(t, ast)
+			require.NotNil(t, ast.Root)
+
+			// Walk the chain and collect segment names.
+			var got []string
+			cur := ast.Root
+			for cur != nil {
+				got = append(got, cur.Name)
+				cur = cur.Next
+			}
+			require.Equal(t, tc.segments, got)
+		})
+	}
+}

--- a/elasticsearch/queryspan.go
+++ b/elasticsearch/queryspan.go
@@ -1,0 +1,105 @@
+package elasticsearch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/omni/elasticsearch/analysis"
+)
+
+// QuerySpan is the result of analysing a single Elasticsearch REST statement.
+// It contains the query classification, the masking analysis, and the set of
+// predicate field paths expressed as PathAST chains.
+type QuerySpan struct {
+	// Type is the high-level classification of the request.
+	Type QueryType
+	// ElasticsearchAnalysis holds the body-level masking analysis result.
+	ElasticsearchAnalysis *analysis.RequestAnalysis
+	// PredicatePaths maps each dot-notation predicate field name to its PathAST
+	// representation.  Nil when the request has no predicate fields.
+	PredicatePaths map[string]*PathAST
+}
+
+// PathAST is a linked chain of path segments that represents a dot-delimited
+// field reference such as "user.address.city".  Each node is an ItemSelector
+// that holds a single segment name and a pointer to the next segment.
+type PathAST struct {
+	// Root is the first segment of the path.
+	Root *ItemSelector
+}
+
+// ItemSelector is a single named segment in a PathAST chain.
+type ItemSelector struct {
+	// Name is the path segment (e.g. "user", "address", "city").
+	Name string
+	// Next is the following segment, or nil for the last segment.
+	Next *ItemSelector
+}
+
+// String returns the dot-joined representation of the full PathAST chain
+// starting at this node, useful for debugging.
+func (s *ItemSelector) String() string {
+	if s.Next == nil {
+		return s.Name
+	}
+	return fmt.Sprintf("%s.%s", s.Name, s.Next.String())
+}
+
+// GetQuerySpan parses a single Elasticsearch REST statement and returns a
+// QuerySpan describing its type, masking analysis, and predicate field paths.
+func GetQuerySpan(statement string) (*QuerySpan, error) {
+	parseResult, err := ParseElasticsearchREST(statement)
+	if err != nil {
+		return nil, err
+	}
+
+	if parseResult == nil {
+		return &QuerySpan{Type: QueryTypeUnknown}, nil
+	}
+
+	if len(parseResult.Errors) > 0 {
+		firstErr := parseResult.Errors[0]
+		return nil, fmt.Errorf("syntax error at line %d, column %d: %s",
+			firstErr.Position.Line, firstErr.Position.Column, firstErr.Message)
+	}
+
+	if len(parseResult.Requests) == 0 {
+		return &QuerySpan{Type: QueryTypeUnknown}, nil
+	}
+
+	// After splitting, each statement should contain a single request.
+	// Use the first request for classification.
+	req := parseResult.Requests[0]
+	queryType := ClassifyRequest(req.Method, req.URL)
+
+	span := &QuerySpan{Type: queryType}
+
+	requestAnalysis := analysis.AnalyzeRequest(req.Method, req.URL, strings.Join(req.Data, "\n"))
+	span.ElasticsearchAnalysis = requestAnalysis
+
+	if len(requestAnalysis.PredicateFields) > 0 {
+		span.PredicatePaths = make(map[string]*PathAST, len(requestAnalysis.PredicateFields))
+		for _, field := range requestAnalysis.PredicateFields {
+			span.PredicatePaths[field] = DotPathToPathAST(field)
+		}
+	}
+
+	return span, nil
+}
+
+// DotPathToPathAST converts a dot-delimited field path (e.g. "contact.phone")
+// into a PathAST with linked ItemSelector nodes.
+func DotPathToPathAST(dotPath string) *PathAST {
+	parts := strings.Split(dotPath, ".")
+	if len(parts) == 0 {
+		return nil
+	}
+	root := &ItemSelector{Name: parts[0]}
+	current := root
+	for _, part := range parts[1:] {
+		next := &ItemSelector{Name: part}
+		current.Next = next
+		current = next
+	}
+	return &PathAST{Root: root}
+}

--- a/elasticsearch/querytype.go
+++ b/elasticsearch/querytype.go
@@ -6,12 +6,12 @@ import "strings"
 type QueryType int
 
 const (
-	QueryTypeUnknown         QueryType = iota
-	QueryTypeSelect                    // Read-only data query
-	QueryTypeSelectInfoSchema          // Read-only cluster/node metadata
-	QueryTypeDML                       // Document write (index, update, delete)
-	QueryTypeDDL                       // Index/alias/mapping management
-	QueryTypeExplain                   // Query explanation
+	QueryTypeUnknown         QueryType = iota // 0
+	QueryTypeSelect                           // 1 — Read-only data query
+	QueryTypeExplain                          // 2 — Query explanation
+	QueryTypeSelectInfoSchema                 // 3 — Read-only cluster/node metadata
+	QueryTypeDDL                              // 4 — Index/alias/mapping management
+	QueryTypeDML                              // 5 — Document write (index, update, delete)
 )
 
 // readOnlyPostEndpoints lists URL patterns that are read-only despite using POST.


### PR DESCRIPTION
## Summary

- Adds `elasticsearch/queryspan.go` with omni-native `QuerySpan`, `PathAST`, `ItemSelector` types and `GetQuerySpan(statement string)` + `DotPathToPathAST()` functions that wire together parser, classification, and body analysis
- Adds `elasticsearch/parsertest/queryspan_test.go` with three test functions: golden YAML drive (47 cases from `query_span.yaml`), inline predicate-path assertions, and dot-path chain shape checks
- Fixes `QueryType` iota ordering in `querytype.go` to align with the `query_span.yaml` golden file values (Unknown=0, Select=1, Explain=2, SelectInfoSchema=3, DDL=4, DML=5); all existing tests use named constants and are unaffected

## Test plan

- [ ] `go test ./elasticsearch/...` passes (all 47 YAML golden cases + inline predicate path tests + dot-path chain tests)
- [ ] Regression: `TestAnalyzeRequest` (F6b golden, `masking_analyze_request.yaml`) still passes
- [ ] No bytebase imports introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)