### PR TITLE
feat(partiql/catalog): add catalog package for table metadata (DAG node 3)

### DIFF
--- a/partiql/catalog/catalog.go
+++ b/partiql/catalog/catalog.go
@@ -1,0 +1,40 @@
+// Package catalog provides metadata context for PartiQL auto-completion
+// and semantic analysis.
+//
+// PartiQL targets AWS DynamoDB (schema-on-read), so the catalog is
+// minimal: table names are the primary metadata. Future extensions may
+// add known attribute paths, type constraints, or index metadata.
+package catalog
+
+import "sort"
+
+// Catalog stores table names for a PartiQL database context.
+type Catalog struct {
+	tables map[string]struct{}
+}
+
+// New creates an empty Catalog.
+func New() *Catalog {
+	return &Catalog{tables: make(map[string]struct{})}
+}
+
+// AddTable registers a table name. Duplicates are ignored.
+func (c *Catalog) AddTable(name string) {
+	c.tables[name] = struct{}{}
+}
+
+// Tables returns all registered table names in sorted order.
+func (c *Catalog) Tables() []string {
+	result := make([]string, 0, len(c.tables))
+	for name := range c.tables {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// HasTable reports whether the named table is registered.
+func (c *Catalog) HasTable(name string) bool {
+	_, ok := c.tables[name]
+	return ok
+}

--- a/partiql/catalog/catalog_test.go
+++ b/partiql/catalog/catalog_test.go
@@ -1,0 +1,37 @@
+package catalog
+
+import "testing"
+
+func TestCatalog(t *testing.T) {
+	c := New()
+
+	// Empty catalog.
+	if len(c.Tables()) != 0 {
+		t.Errorf("expected 0 tables, got %d", len(c.Tables()))
+	}
+	if c.HasTable("Music") {
+		t.Error("HasTable returned true for non-existent table")
+	}
+
+	// Add tables.
+	c.AddTable("Music")
+	c.AddTable("Albums")
+	c.AddTable("Music") // duplicate
+
+	// Tables returns sorted, deduplicated.
+	tables := c.Tables()
+	if len(tables) != 2 {
+		t.Fatalf("expected 2 tables, got %d", len(tables))
+	}
+	if tables[0] != "Albums" || tables[1] != "Music" {
+		t.Errorf("Tables() = %v, want [Albums Music]", tables)
+	}
+
+	// HasTable.
+	if !c.HasTable("Music") {
+		t.Error("HasTable returned false for existing table")
+	}
+	if c.HasTable("NonExistent") {
+		t.Error("HasTable returned true for non-existent table")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `partiql/catalog` package following the `mongo/catalog` precedent.
- Minimal metadata store for PartiQL (AWS DynamoDB is schema-on-read): table name registration and lookup.
- API: `New()`, `AddTable(name)`, `Tables() []string` (sorted), `HasTable(name) bool`.

## Test Plan
- [x] `TestCatalog` — empty catalog, add/dedup, sorted retrieval, HasTable lookup
- [x] `go vet` clean, `gofmt` clean

## Unblocks
- analysis (node 9), completion (node 10) — both depend on catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)