### PR TITLE
fix(pg/pgregress): update known_failures after prefix unary operator support

### DIFF
--- a/pg/pgregress/known_failures.json
+++ b/pg/pgregress/known_failures.json
@@ -19,13 +19,6 @@
     252,
     316
   ],
-  "bit.sql": [
-    32,
-    39
-  ],
-  "box.sql": [
-    26
-  ],
   "cluster.sql": [
     180,
     189
@@ -71,9 +64,7 @@
     294
   ],
   "create_operator.sql": [
-    3,
     10,
-    12,
     13
   ],
   "create_role.sql": [
@@ -150,16 +141,6 @@
   "fast_default.sql": [
     74
   ],
-  "float4.sql": [
-    57
-  ],
-  "float8.sql": [
-    49,
-    58,
-    59,
-    96,
-    97
-  ],
   "foreign_data.sql": [
     199,
     201,
@@ -173,37 +154,6 @@
     227,
     586
   ],
-  "geometry.sql": [
-    2,
-    4,
-    5,
-    30,
-    31,
-    41,
-    42,
-    43,
-    44,
-    79,
-    117
-  ],
-  "horology.sql": [
-    176,
-    177,
-    178,
-    179,
-    180,
-    181,
-    182,
-    183,
-    184,
-    185,
-    186,
-    187,
-    188,
-    189,
-    190,
-    191
-  ],
   "identity.sql": [
     118,
     123,
@@ -211,9 +161,6 @@
     194,
     195,
     196
-  ],
-  "inet.sql": [
-    81
   ],
   "inherit.sql": [
     416,
@@ -229,9 +176,6 @@
     22,
     23,
     363
-  ],
-  "int8.sql": [
-    117
   ],
   "join.sql": [
     133,
@@ -299,12 +243,6 @@
   "largeobject.sql": [
     16
   ],
-  "macaddr.sql": [
-    27
-  ],
-  "macaddr8.sql": [
-    63
-  ],
   "merge.sql": [
     20,
     23,
@@ -342,11 +280,6 @@
   ],
   "plpgsql.sql": [
     938
-  ],
-  "prepare.sql": [
-    17,
-    19,
-    20
   ],
   "privileges.sql": [
     25,
@@ -418,9 +351,6 @@
   ],
   "select_parallel.sql": [
     229
-  ],
-  "select_views.sql": [
-    1
   ],
   "sequence.sql": [
     153
@@ -530,14 +460,7 @@
     1041
   ],
   "tsearch.sql": [
-    209,
     282
-  ],
-  "tsrf.sql": [
-    65
-  ],
-  "tstypes.sql": [
-    80
   ],
   "tuplesort.sql": [
     50


### PR DESCRIPTION
## Summary
- Remove 49 entries from `known_failures.json` that now pass after the parser gained prefix unary operator support in ddd999e
- Affected SQL test files: bit, box, create_operator, float4, float8, geometry, horology, inet, int8, macaddr, macaddr8, prepare, select_views, tsearch, tsrf, tstypes

## Test plan
- [x] `go test -run TestPGRegress -update` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)