### PR TITLE
feat(partiql): add Split() for semicolon-delimited statement splitting

### DIFF
--- a/docs/migration/snowflake/dag.md
+++ b/docs/migration/snowflake/dag.md
@@ -33,7 +33,7 @@ snowflake/
 | **C1** | corpus-legacy (lift 27 SQL files) | `snowflake/parser/testdata/legacy` | — | F1–F4, C2 | 0 | P0 | **done** |
 | **C2** | corpus-official (scrape docs.snowflake.com) | `snowflake/parser/testdata/official` | — | F1–F4, C1 | 0 | P0 | **done** (630 SQL files across 78 commands) |
 | **T1.1** | identifiers + qualified names + normalization helpers | `snowflake/parser` | F4 | — | 1 | P0 | **done** (PR #22) |
-| **T1.2** | data types (incl. VARIANT/OBJECT/ARRAY/VECTOR/GEO/TIMESTAMP_*) | `snowflake/parser` | T1.1 | — | 1 | P0 | not started |
+| **T1.2** | data types (incl. VARIANT/OBJECT/ARRAY/VECTOR/GEO/TIMESTAMP_*) | `snowflake/parser` | T1.1 | — | 1 | P0 | **done** (PR #39) |
 | **T1.3** | expressions (operators, function calls, CASE, CAST, JSON path, lambdas, subqueries, IN/BETWEEN/LIKE/RLIKE) | `snowflake/parser` | T1.2 | — | 1 | P0 | not started |
 | **T1.4** | SELECT core (list, FROM, WHERE, GROUP BY incl. CUBE/ROLLUP/GROUPING SETS/ALL, HAVING, QUALIFY, ORDER BY, LIMIT/OFFSET/FETCH/TOP, EXCLUDE) | `snowflake/parser` | T1.3 | — | 1 | P0 | not started |
 | **T1.5** | joins (INNER/LEFT/RIGHT/FULL/CROSS/NATURAL/ASOF/DIRECTED/LATERAL) | `snowflake/parser` | T1.4 | T1.6, T1.7 | 1 | P0 | not started |

--- a/partiql/split.go
+++ b/partiql/split.go
@@ -1,0 +1,163 @@
+// Package partiql provides a hand-written parser for the PartiQL query language
+// (AWS DynamoDB, Azure Cosmos DB).
+package partiql
+
+// Segment represents a portion of PartiQL text delimited by top-level
+// semicolons. Produced by Split.
+type Segment struct {
+	Text      string // the raw text of this segment (may include trailing ;)
+	ByteStart int    // byte offset of start in original input
+	ByteEnd   int    // byte offset of end (exclusive) in original input
+}
+
+// Empty returns true if the segment contains only whitespace, comments,
+// and semicolons — no meaningful PartiQL content.
+func (s Segment) Empty() bool {
+	t := s.Text
+	i := 0
+	for i < len(t) {
+		b := t[i]
+		// Skip whitespace and semicolons.
+		if b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == ';' {
+			i++
+			continue
+		}
+		// Skip line comments (-- to end of line).
+		if b == '-' && i+1 < len(t) && t[i+1] == '-' {
+			i += 2
+			for i < len(t) && t[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		// Skip block comments (/* ... */), supporting nesting.
+		if b == '/' && i+1 < len(t) && t[i+1] == '*' {
+			i += 2
+			depth := 1
+			for i+1 < len(t) && depth > 0 {
+				if t[i] == '/' && t[i+1] == '*' {
+					depth++
+					i += 2
+				} else if t[i] == '*' && t[i+1] == '/' {
+					depth--
+					i += 2
+				} else {
+					i++
+				}
+			}
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// Split splits a PartiQL input into segments at top-level semicolons.
+// It respects single-quoted strings (with ” escape), double-quoted
+// identifiers (with "" escape), backtick-delimited Ion literals, line
+// comments (--), and block comments (/* */ with nesting).
+//
+// Each segment's Text includes its trailing semicolon if present.
+// The final segment may not have a trailing semicolon.
+func Split(input string) []Segment {
+	var segs []Segment
+	n := len(input)
+	start := 0
+
+	i := 0
+	for i <= n {
+		if i == n {
+			// End of input: flush remaining text.
+			if i > start {
+				segs = append(segs, Segment{
+					Text:      input[start:],
+					ByteStart: start,
+					ByteEnd:   n,
+				})
+			}
+			break
+		}
+
+		ch := input[i]
+
+		switch {
+		case ch == ';':
+			// Include the semicolon in the current segment.
+			segs = append(segs, Segment{
+				Text:      input[start : i+1],
+				ByteStart: start,
+				ByteEnd:   i + 1,
+			})
+			start = i + 1
+			i++
+
+		case ch == '\'':
+			// Single-quoted string: skip to closing quote. '' is escape.
+			i++
+			for i < n {
+				if input[i] == '\'' {
+					i++
+					if i < n && input[i] == '\'' {
+						i++ // escaped ''
+						continue
+					}
+					break
+				}
+				i++
+			}
+
+		case ch == '"':
+			// Double-quoted identifier: skip to closing quote. "" is escape.
+			i++
+			for i < n {
+				if input[i] == '"' {
+					i++
+					if i < n && input[i] == '"' {
+						i++ // escaped ""
+						continue
+					}
+					break
+				}
+				i++
+			}
+
+		case ch == '`':
+			// Ion literal: skip to closing backtick.
+			i++
+			for i < n && input[i] != '`' {
+				i++
+			}
+			if i < n {
+				i++ // consume closing `
+			}
+
+		case ch == '-' && i+1 < n && input[i+1] == '-':
+			// Line comment: skip to end of line.
+			i += 2
+			for i < n && input[i] != '\n' {
+				i++
+			}
+
+		case ch == '/' && i+1 < n && input[i+1] == '*':
+			// Block comment: skip to */. Supports nesting.
+			i += 2
+			depth := 1
+			for i+1 < n && depth > 0 {
+				if input[i] == '/' && input[i+1] == '*' {
+					depth++
+					i += 2
+				} else if input[i] == '*' && input[i+1] == '/' {
+					depth--
+					i += 2
+				} else {
+					i++
+				}
+			}
+
+		default:
+			i++
+		}
+	}
+
+	return segs
+}

--- a/partiql/split_test.go
+++ b/partiql/split_test.go
@@ -1,0 +1,129 @@
+package partiql
+
+import (
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantN     int
+		wantText  []string
+		wantEmpty []bool
+	}{
+		{
+			name:      "single_statement",
+			input:     "SELECT * FROM t",
+			wantN:     1,
+			wantText:  []string{"SELECT * FROM t"},
+			wantEmpty: []bool{false},
+		},
+		{
+			name:      "two_statements",
+			input:     "SELECT 1; SELECT 2",
+			wantN:     2,
+			wantText:  []string{"SELECT 1;", " SELECT 2"},
+			wantEmpty: []bool{false, false},
+		},
+		{
+			name:      "trailing_semicolon",
+			input:     "SELECT 1;",
+			wantN:     1,
+			wantText:  []string{"SELECT 1;"},
+			wantEmpty: []bool{false},
+		},
+		{
+			name:      "multiple_trailing_semicolons",
+			input:     "SELECT 1;;",
+			wantN:     2,
+			wantText:  []string{"SELECT 1;", ";"},
+			wantEmpty: []bool{false, true},
+		},
+		{
+			name:      "semicolon_in_string",
+			input:     "SELECT 'a;b'",
+			wantN:     1,
+			wantText:  []string{"SELECT 'a;b'"},
+			wantEmpty: []bool{false},
+		},
+		{
+			name:      "semicolon_in_quoted_ident",
+			input:     `SELECT "a;b"`,
+			wantN:     1,
+			wantText:  []string{`SELECT "a;b"`},
+			wantEmpty: []bool{false},
+		},
+		{
+			name:      "semicolon_in_ion_literal",
+			input:     "SELECT `{a;b}`",
+			wantN:     1,
+			wantText:  []string{"SELECT `{a;b}`"},
+			wantEmpty: []bool{false},
+		},
+		{
+			name:      "semicolon_in_line_comment",
+			input:     "SELECT 1 -- comment; not a split\n; SELECT 2",
+			wantN:     2,
+			wantText:  []string{"SELECT 1 -- comment; not a split\n;", " SELECT 2"},
+			wantEmpty: []bool{false, false},
+		},
+		{
+			name:      "semicolon_in_block_comment",
+			input:     "SELECT /* ; */ 1; SELECT 2",
+			wantN:     2,
+			wantText:  []string{"SELECT /* ; */ 1;", " SELECT 2"},
+			wantEmpty: []bool{false, false},
+		},
+		{
+			name:  "empty_input",
+			input: "",
+			wantN: 0,
+		},
+		{
+			name:      "whitespace_only",
+			input:     "   \n\t  ",
+			wantN:     1,
+			wantText:  []string{"   \n\t  "},
+			wantEmpty: []bool{true},
+		},
+		{
+			name:      "comment_only",
+			input:     "-- just a comment",
+			wantN:     1,
+			wantText:  []string{"-- just a comment"},
+			wantEmpty: []bool{true},
+		},
+		{
+			name:      "doubled_quote_escape",
+			input:     "SELECT 'it''s'; SELECT 1",
+			wantN:     2,
+			wantText:  []string{"SELECT 'it''s';", " SELECT 1"},
+			wantEmpty: []bool{false, false},
+		},
+		{
+			name:      "nested_block_comment",
+			input:     "SELECT /* outer /* inner */ still comment */ 1",
+			wantN:     1,
+			wantText:  []string{"SELECT /* outer /* inner */ still comment */ 1"},
+			wantEmpty: []bool{false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			segs := Split(tc.input)
+			if len(segs) != tc.wantN {
+				t.Fatalf("Split(%q) returned %d segments, want %d", tc.input, len(segs), tc.wantN)
+			}
+			for i, seg := range segs {
+				if i < len(tc.wantText) && seg.Text != tc.wantText[i] {
+					t.Errorf("seg[%d].Text = %q, want %q", i, seg.Text, tc.wantText[i])
+				}
+				if i < len(tc.wantEmpty) && seg.Empty() != tc.wantEmpty[i] {
+					t.Errorf("seg[%d].Empty() = %v, want %v", i, seg.Empty(), tc.wantEmpty[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds `partiql.Split(input) []Segment` following the `pg.Split` and `mysql/parser.Split` precedent. Splits at top-level semicolons while respecting strings, identifiers, Ion literals, and comments.

## Test Plan
- [x] 14 test cases covering all quoting/comment contexts
- [x] `go vet` clean, `gofmt` clean

## Context
This supports the bytebase plugin migration (bytebase/bytebase#19965) — the splitter PR can then call `partiql.Split()` instead of reimplementing the scanner in bytebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)