### PR TITLE
feat(snowflake): T1.3 expressions — Pratt parser + 22 AST nodes

### DIFF
--- a/docs/superpowers/plans/2026-04-10-snowflake-expressions.md
+++ b/docs/superpowers/plans/2026-04-10-snowflake-expressions.md
@@ -1,0 +1,846 @@
+# Snowflake Expressions (T1.3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Pratt expression parser for `snowflake/parser` — 22 AST node types + 5 helpers + 5 enums in `snowflake/ast`, plus a complete `parseExpr` with ~25 parse functions in `snowflake/parser/expr.go`, covering every expression form from the legacy grammar's `expr` rule (25 alternatives).
+
+**Architecture:** Pratt parsing (precedence climbing) mirroring `mysql/parser/expr.go`. The `parseExprPrec(minBP)` loop calls `parsePrefixExpr` for the left-hand side then iterates infix/postfix operators. Special forms (IS, IN, BETWEEN, LIKE, ::, OVER, access) are dispatched from the infix loop to dedicated parse helpers. Window frame specification (ROWS/RANGE/GROUPS BETWEEN ... AND ...) is included.
+
+**Tech Stack:** Go 1.25, stdlib only (`strings` for case comparisons in multi-word lookahead).
+
+**Spec:** `docs/superpowers/specs/2026-04-10-snowflake-expressions-design.md` (commit `a4ab008`)
+
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/expressions` on branch `feat/snowflake/expressions`
+
+**Commit policy:** No commits during implementation. The user reviews the full diff at the end.
+
+---
+
+## File Structure
+
+### Modified
+
+| File | Changes |
+|------|---------|
+| `snowflake/ast/parsenodes.go` | Append 5 enums + 22 node structs + 5 helper structs + all Tag/String methods (~400 LOC) |
+| `snowflake/ast/nodetags.go` | Append 17 T_* constants + String() cases |
+| `snowflake/ast/loc.go` | Append 17 NodeLoc cases |
+| `snowflake/ast/walk_generated.go` | Regenerated — many new cases with child walks |
+
+### Created
+
+| File | Purpose | Approx LOC |
+|------|---------|-----------|
+| `snowflake/parser/expr.go` | Pratt parser: parseExpr, all helpers, ParseExpr freestanding | 900 |
+| `snowflake/parser/expr_test.go` | 24 test categories | 800 |
+
+**Total: ~2,200 LOC** across 2 new + 4 modified files.
+
+---
+
+## Task 1: Add all AST enum types and expression node structs
+
+This is the largest single task — it adds all the type infrastructure to `snowflake/ast/parsenodes.go`. The node types are pure struct definitions with no complex logic.
+
+**Files:**
+- Modify: `snowflake/ast/parsenodes.go`
+
+- [ ] **Step 1: Confirm worktree state**
+
+Run: `pwd && git rev-parse --abbrev-ref HEAD`
+Expected:
+```
+/Users/h3n4l/OpenSource/omni/.worktrees/expressions
+feat/snowflake/expressions
+```
+
+- [ ] **Step 2: Append all expression enums + node types to parsenodes.go**
+
+Use Edit to append the following after the existing TypeName section at the end of `snowflake/ast/parsenodes.go`. This is a large block — the full expression AST:
+
+```go
+
+// ---------------------------------------------------------------------------
+// Expression enums
+// ---------------------------------------------------------------------------
+
+// BinaryOp enumerates binary operator types.
+type BinaryOp int
+
+const (
+	BinAdd    BinaryOp = iota // +
+	BinSub                    // -
+	BinMul                    // *
+	BinDiv                    // /
+	BinMod                    // %
+	BinConcat                 // ||
+	BinEq                     // =
+	BinNe                     // <> or !=
+	BinLt                     // <
+	BinGt                     // >
+	BinLe                     // <=
+	BinGe                     // >=
+	BinAnd                    // AND
+	BinOr                     // OR
+)
+
+// String returns the operator symbol.
+func (op BinaryOp) String() string {
+	switch op {
+	case BinAdd:
+		return "+"
+	case BinSub:
+		return "-"
+	case BinMul:
+		return "*"
+	case BinDiv:
+		return "/"
+	case BinMod:
+		return "%"
+	case BinConcat:
+		return "||"
+	case BinEq:
+		return "="
+	case BinNe:
+		return "!="
+	case BinLt:
+		return "<"
+	case BinGt:
+		return ">"
+	case BinLe:
+		return "<="
+	case BinGe:
+		return ">="
+	case BinAnd:
+		return "AND"
+	case BinOr:
+		return "OR"
+	default:
+		return "?"
+	}
+}
+
+// UnaryOp enumerates unary operator types.
+type UnaryOp int
+
+const (
+	UnaryMinus UnaryOp = iota // -
+	UnaryPlus                 // +
+	UnaryNot                  // NOT
+)
+
+// String returns the operator symbol.
+func (op UnaryOp) String() string {
+	switch op {
+	case UnaryMinus:
+		return "-"
+	case UnaryPlus:
+		return "+"
+	case UnaryNot:
+		return "NOT"
+	default:
+		return "?"
+	}
+}
+
+// LiteralKind classifies literal value types.
+type LiteralKind int
+
+const (
+	LitNull   LiteralKind = iota
+	LitBool
+	LitInt
+	LitFloat
+	LitString
+)
+
+// LikeOp enumerates LIKE operator variants.
+type LikeOp int
+
+const (
+	LikeOpLike   LikeOp = iota // LIKE
+	LikeOpILike                // ILIKE
+	LikeOpRLike                // RLIKE
+	LikeOpRegexp               // REGEXP
+)
+
+// AccessKind enumerates semi-structured access operator types.
+type AccessKind int
+
+const (
+	AccessColon   AccessKind = iota // expr:field (JSON path)
+	AccessBracket                   // expr[idx] (array subscript)
+	AccessDot                       // expr.field (dot path)
+)
+
+// WindowFrameKind enumerates window frame types.
+type WindowFrameKind int
+
+const (
+	FrameRows   WindowFrameKind = iota
+	FrameRange
+	FrameGroups
+)
+
+// WindowBoundKind enumerates window frame bound types.
+type WindowBoundKind int
+
+const (
+	BoundUnboundedPreceding WindowBoundKind = iota
+	BoundPreceding
+	BoundCurrentRow
+	BoundFollowing
+	BoundUnboundedFollowing
+)
+
+// CaseKind discriminates simple vs searched CASE expressions.
+type CaseKind int
+
+const (
+	CaseSimple  CaseKind = iota // CASE expr WHEN val THEN ...
+	CaseSearched                // CASE WHEN cond THEN ...
+)
+
+// ---------------------------------------------------------------------------
+// Expression nodes
+// ---------------------------------------------------------------------------
+
+// Literal represents an integer, float, string, boolean, or NULL literal.
+type Literal struct {
+	Kind  LiteralKind
+	Value string // raw source text for all kinds
+	Ival  int64  // for LitInt
+	Bval  bool   // for LitBool
+	Loc   Loc
+}
+
+func (n *Literal) Tag() NodeTag { return T_Literal }
+
+// ColumnRef represents a 1-4 part column reference (col, t.col, s.t.col, db.s.t.col).
+type ColumnRef struct {
+	Parts []Ident
+	Loc   Loc
+}
+
+func (n *ColumnRef) Tag() NodeTag { return T_ColumnRef }
+
+// StarExpr represents * or qualifier.* in SELECT lists and COUNT(*).
+type StarExpr struct {
+	Qualifier *ObjectName // optional table qualifier; nil for bare *
+	Loc       Loc
+}
+
+func (n *StarExpr) Tag() NodeTag { return T_StarExpr }
+
+// BinaryExpr represents a binary operation: left op right.
+type BinaryExpr struct {
+	Op    BinaryOp
+	Left  Node
+	Right Node
+	Loc   Loc
+}
+
+func (n *BinaryExpr) Tag() NodeTag { return T_BinaryExpr }
+
+// UnaryExpr represents a prefix unary operation: op expr.
+type UnaryExpr struct {
+	Op   UnaryOp
+	Expr Node
+	Loc  Loc
+}
+
+func (n *UnaryExpr) Tag() NodeTag { return T_UnaryExpr }
+
+// ParenExpr represents a parenthesized expression: ( expr ).
+type ParenExpr struct {
+	Expr Node
+	Loc  Loc
+}
+
+func (n *ParenExpr) Tag() NodeTag { return T_ParenExpr }
+
+// CastExpr represents CAST(expr AS type), TRY_CAST(expr AS type), or expr::type.
+type CastExpr struct {
+	Expr       Node
+	TypeName   *TypeName
+	TryCast    bool // true for TRY_CAST
+	ColonColon bool // true for expr::type syntax
+	Loc        Loc
+}
+
+func (n *CastExpr) Tag() NodeTag { return T_CastExpr }
+
+// CaseExpr represents a CASE expression (simple or searched).
+type CaseExpr struct {
+	Kind    CaseKind
+	Operand Node          // non-nil for CaseSimple; nil for CaseSearched
+	Whens   []*WhenClause // one or more WHEN clauses
+	Else    Node          // optional ELSE; nil if absent
+	Loc     Loc
+}
+
+func (n *CaseExpr) Tag() NodeTag { return T_CaseExpr }
+
+// WhenClause is a single WHEN...THEN branch inside a CaseExpr.
+// Not a top-level Node — embedded in CaseExpr.
+type WhenClause struct {
+	Cond   Node // the WHEN condition (or value for simple CASE)
+	Result Node // the THEN result
+	Loc    Loc
+}
+
+// FuncCallExpr represents a function call including aggregates and window functions.
+//
+// Star is true for COUNT(*). Distinct is true for COUNT(DISTINCT x).
+// OrderBy is used by aggregates with WITHIN GROUP (ORDER BY ...).
+// Over is non-nil for window functions (SUM(x) OVER (...)).
+type FuncCallExpr struct {
+	Name     ObjectName   // function name (may be qualified: schema.func)
+	Args     []Node       // argument expressions
+	Star     bool         // COUNT(*)
+	Distinct bool         // DISTINCT keyword in aggregate
+	OrderBy  []*OrderItem // for WITHIN GROUP (ORDER BY ...)
+	Over     *WindowSpec  // non-nil for window functions
+	Loc      Loc
+}
+
+func (n *FuncCallExpr) Tag() NodeTag { return T_FuncCallExpr }
+
+// IffExpr represents Snowflake's IFF(condition, then_expr, else_expr).
+type IffExpr struct {
+	Cond Node
+	Then Node
+	Else Node
+	Loc  Loc
+}
+
+func (n *IffExpr) Tag() NodeTag { return T_IffExpr }
+
+// CollateExpr represents expr COLLATE collation_name.
+type CollateExpr struct {
+	Expr      Node
+	Collation string
+	Loc       Loc
+}
+
+func (n *CollateExpr) Tag() NodeTag { return T_CollateExpr }
+
+// IsExpr represents expr IS [NOT] NULL or expr IS [NOT] DISTINCT FROM expr.
+type IsExpr struct {
+	Expr         Node
+	Not          bool // IS NOT NULL / IS NOT DISTINCT FROM
+	Null         bool // true for IS [NOT] NULL; false for IS [NOT] DISTINCT FROM
+	DistinctFrom Node // non-nil for IS [NOT] DISTINCT FROM expr
+	Loc          Loc
+}
+
+func (n *IsExpr) Tag() NodeTag { return T_IsExpr }
+
+// BetweenExpr represents expr [NOT] BETWEEN low AND high.
+type BetweenExpr struct {
+	Expr Node
+	Low  Node
+	High Node
+	Not  bool
+	Loc  Loc
+}
+
+func (n *BetweenExpr) Tag() NodeTag { return T_BetweenExpr }
+
+// InExpr represents expr [NOT] IN (value_list).
+// Subquery form (expr IN (SELECT ...)) is handled by T1.4.
+type InExpr struct {
+	Expr   Node
+	Values []Node
+	Not    bool
+	Loc    Loc
+}
+
+func (n *InExpr) Tag() NodeTag { return T_InExpr }
+
+// LikeExpr represents expr [NOT] LIKE/ILIKE/RLIKE/REGEXP pattern [ESCAPE esc].
+// Also handles LIKE ANY (...) via the Any + AnyValues fields.
+type LikeExpr struct {
+	Expr      Node
+	Pattern   Node   // the pattern expression
+	Escape    Node   // optional ESCAPE clause; nil if absent
+	Op        LikeOp // LIKE, ILIKE, RLIKE, REGEXP
+	Not       bool
+	Any       bool   // true for LIKE ANY (...)
+	AnyValues []Node // values for LIKE ANY; nil unless Any is true
+	Loc       Loc
+}
+
+func (n *LikeExpr) Tag() NodeTag { return T_LikeExpr }
+
+// AccessExpr represents semi-structured data access:
+//   - AccessColon:   expr:field (JSON path)
+//   - AccessBracket: expr[index] (array subscript)
+//   - AccessDot:     expr.field (dot path chaining)
+type AccessExpr struct {
+	Expr  Node
+	Kind  AccessKind
+	Field Ident // for Colon and Dot access
+	Index Node  // for Bracket access
+	Loc   Loc
+}
+
+func (n *AccessExpr) Tag() NodeTag { return T_AccessExpr }
+
+// ArrayLiteralExpr represents an array literal: [elem1, elem2, ...].
+type ArrayLiteralExpr struct {
+	Elements []Node
+	Loc      Loc
+}
+
+func (n *ArrayLiteralExpr) Tag() NodeTag { return T_ArrayLiteralExpr }
+
+// JsonLiteralExpr represents a JSON object literal: {key: value, ...}.
+type JsonLiteralExpr struct {
+	Pairs []KeyValuePair
+	Loc   Loc
+}
+
+func (n *JsonLiteralExpr) Tag() NodeTag { return T_JsonLiteralExpr }
+
+// KeyValuePair is a single key-value pair in a JsonLiteralExpr.
+type KeyValuePair struct {
+	Key   string
+	Value Node
+	Loc   Loc
+}
+
+// LambdaExpr represents a lambda expression: param -> body or (p1, p2) -> body.
+type LambdaExpr struct {
+	Params []Ident
+	Body   Node
+	Loc    Loc
+}
+
+func (n *LambdaExpr) Tag() NodeTag { return T_LambdaExpr }
+
+// SubqueryExpr is a placeholder for subquery expressions (SELECT ...).
+// T1.4 will fill in the real implementation.
+type SubqueryExpr struct {
+	Loc Loc
+}
+
+func (n *SubqueryExpr) Tag() NodeTag { return T_SubqueryExpr }
+
+// ExistsExpr is a placeholder for EXISTS (SELECT ...).
+// T1.4 will fill in the real implementation.
+type ExistsExpr struct {
+	Loc Loc
+}
+
+func (n *ExistsExpr) Tag() NodeTag { return T_ExistsExpr }
+
+// WindowSpec describes a window specification for OVER (...).
+// Not a top-level Node — embedded in FuncCallExpr.
+type WindowSpec struct {
+	PartitionBy []Node
+	OrderBy     []*OrderItem
+	Frame       *WindowFrame // nil if no frame clause
+	Loc         Loc
+}
+
+// OrderItem represents one element in an ORDER BY clause.
+type OrderItem struct {
+	Expr       Node
+	Desc       bool  // true for DESC
+	NullsFirst *bool // nil = unspecified, true = NULLS FIRST, false = NULLS LAST
+	Loc        Loc
+}
+
+// WindowFrame represents ROWS/RANGE/GROUPS BETWEEN start AND end.
+type WindowFrame struct {
+	Kind  WindowFrameKind
+	Start WindowBound
+	End   WindowBound // End.Kind may be zero if single-bound form (not BETWEEN)
+	Loc   Loc
+}
+
+// WindowBound represents one end of a window frame specification.
+type WindowBound struct {
+	Kind   WindowBoundKind
+	Offset Node // for BoundPreceding/BoundFollowing: the N in "N PRECEDING"; nil otherwise
+}
+
+// Compile-time assertions.
+var (
+	_ Node = (*Literal)(nil)
+	_ Node = (*ColumnRef)(nil)
+	_ Node = (*StarExpr)(nil)
+	_ Node = (*BinaryExpr)(nil)
+	_ Node = (*UnaryExpr)(nil)
+	_ Node = (*ParenExpr)(nil)
+	_ Node = (*CastExpr)(nil)
+	_ Node = (*CaseExpr)(nil)
+	_ Node = (*FuncCallExpr)(nil)
+	_ Node = (*IffExpr)(nil)
+	_ Node = (*CollateExpr)(nil)
+	_ Node = (*IsExpr)(nil)
+	_ Node = (*BetweenExpr)(nil)
+	_ Node = (*InExpr)(nil)
+	_ Node = (*LikeExpr)(nil)
+	_ Node = (*AccessExpr)(nil)
+	_ Node = (*ArrayLiteralExpr)(nil)
+	_ Node = (*JsonLiteralExpr)(nil)
+	_ Node = (*LambdaExpr)(nil)
+	_ Node = (*SubqueryExpr)(nil)
+	_ Node = (*ExistsExpr)(nil)
+)
+```
+
+- [ ] **Step 3: Verify compile**
+
+Run: `go build ./snowflake/ast/...`
+Expected: no output, exit 0. (The tag values are NOT yet defined — the file will fail because T_Literal etc. don't exist. This is expected. Move to Task 2 immediately.)
+
+Actually — the compile WILL fail because the Tag() methods reference undefined T_* constants. This is expected. Proceed to Task 2 which adds them. Do NOT halt on this expected failure.
+
+---
+
+## Task 2: Add NodeTags + NodeLoc + regenerate walker
+
+**Files:**
+- Modify: `snowflake/ast/nodetags.go`
+- Modify: `snowflake/ast/loc.go`
+- Regenerate: `snowflake/ast/walk_generated.go`
+
+- [ ] **Step 1: Add 17 new T_* constants to nodetags.go**
+
+Append after `T_TypeName`:
+
+```go
+	T_Literal
+	T_ColumnRef
+	T_StarExpr
+	T_BinaryExpr
+	T_UnaryExpr
+	T_ParenExpr
+	T_CastExpr
+	T_CaseExpr
+	T_FuncCallExpr
+	T_IffExpr
+	T_CollateExpr
+	T_IsExpr
+	T_BetweenExpr
+	T_InExpr
+	T_LikeExpr
+	T_AccessExpr
+	T_ArrayLiteralExpr
+	T_JsonLiteralExpr
+	T_LambdaExpr
+	T_SubqueryExpr
+	T_ExistsExpr
+```
+
+Add matching cases to `String()`:
+
+```go
+	case T_Literal:
+		return "Literal"
+	case T_ColumnRef:
+		return "ColumnRef"
+	case T_StarExpr:
+		return "StarExpr"
+	case T_BinaryExpr:
+		return "BinaryExpr"
+	case T_UnaryExpr:
+		return "UnaryExpr"
+	case T_ParenExpr:
+		return "ParenExpr"
+	case T_CastExpr:
+		return "CastExpr"
+	case T_CaseExpr:
+		return "CaseExpr"
+	case T_FuncCallExpr:
+		return "FuncCallExpr"
+	case T_IffExpr:
+		return "IffExpr"
+	case T_CollateExpr:
+		return "CollateExpr"
+	case T_IsExpr:
+		return "IsExpr"
+	case T_BetweenExpr:
+		return "BetweenExpr"
+	case T_InExpr:
+		return "InExpr"
+	case T_LikeExpr:
+		return "LikeExpr"
+	case T_AccessExpr:
+		return "AccessExpr"
+	case T_ArrayLiteralExpr:
+		return "ArrayLiteralExpr"
+	case T_JsonLiteralExpr:
+		return "JsonLiteralExpr"
+	case T_LambdaExpr:
+		return "LambdaExpr"
+	case T_SubqueryExpr:
+		return "SubqueryExpr"
+	case T_ExistsExpr:
+		return "ExistsExpr"
+```
+
+- [ ] **Step 2: Add 21 NodeLoc cases to loc.go**
+
+Add before the `default:` in `NodeLoc`:
+
+```go
+	case *Literal:
+		return v.Loc
+	case *ColumnRef:
+		return v.Loc
+	case *StarExpr:
+		return v.Loc
+	case *BinaryExpr:
+		return v.Loc
+	case *UnaryExpr:
+		return v.Loc
+	case *ParenExpr:
+		return v.Loc
+	case *CastExpr:
+		return v.Loc
+	case *CaseExpr:
+		return v.Loc
+	case *FuncCallExpr:
+		return v.Loc
+	case *IffExpr:
+		return v.Loc
+	case *CollateExpr:
+		return v.Loc
+	case *IsExpr:
+		return v.Loc
+	case *BetweenExpr:
+		return v.Loc
+	case *InExpr:
+		return v.Loc
+	case *LikeExpr:
+		return v.Loc
+	case *AccessExpr:
+		return v.Loc
+	case *ArrayLiteralExpr:
+		return v.Loc
+	case *JsonLiteralExpr:
+		return v.Loc
+	case *LambdaExpr:
+		return v.Loc
+	case *SubqueryExpr:
+		return v.Loc
+	case *ExistsExpr:
+		return v.Loc
+```
+
+- [ ] **Step 3: Regenerate walker**
+
+Run: `go generate ./snowflake/ast/...`
+Expected: `Generated walk_generated.go: N cases, M child fields` where N is significantly more than 2 (the previous count). The exact numbers depend on how many Node-typed fields the generator finds across all structs.
+
+- [ ] **Step 4: Verify build + tests**
+
+Run: `go build ./snowflake/... && go vet ./snowflake/... && go test ./snowflake/ast/...`
+Expected: all clean, all existing tests pass.
+
+---
+
+## Task 3: Write the Pratt parser core (expr.go)
+
+This is the central task — the Pratt parser skeleton. It creates `snowflake/parser/expr.go` with the binding power table, the core Pratt loop, prefix/primary dispatch, and the infix binary-operator handler. Special forms (IS, IN, BETWEEN, LIKE, CASE, CAST, etc.) are added in subsequent tasks as stubs initially.
+
+**Files:**
+- Create: `snowflake/parser/expr.go`
+
+- [ ] **Step 1: Write the full expr.go file**
+
+Create `snowflake/parser/expr.go` with the complete Pratt parser. This is the biggest single code file in the migration — ~900 LOC.
+
+The implementer should read the spec and the mysql reference (`mysql/parser/expr.go`), then write a Snowflake-adapted version. The file must include:
+
+1. **Binding power constants** (bpNone through bpAccess)
+2. **`parseExpr()`** — entry point, calls `parseExprPrec(bpNone + 1)`
+3. **`parseExprPrec(minBP)`** — Pratt loop: parsePrefixExpr → infix loop
+4. **`parsePrefixExpr()`** — dispatches unary -, +, NOT to `parseUnaryExpr`; delegates everything else to `parsePrimaryExpr`
+5. **`parsePrimaryExpr()`** — big switch on `p.cur.Type` dispatching to: literals (tokInt/tokFloat/tokString/kwTRUE/kwFALSE/kwNULL), identifiers → `parseIdentExpr`, `(` → `parseParenExpr`, kwCASE → `parseCaseExpr`, kwCAST → `parseCastExpr`, kwTRY_CAST → `parseTryCastExpr`, kwIFF → `parseIffExpr`, `[` → `parseArrayLiteral`, `{` → `parseJsonLiteral`, `*` → StarExpr, and lambda detection (ident + `->`)
+6. **`infixBindingPower()`** — maps current token to (bp, BinaryOp, ok) for standard binary operators; returns ok=true for special forms (IS, IN, BETWEEN, LIKE, ::, :, [, ., OVER, COLLATE) at their respective binding powers
+7. **Infix loop handlers** — inside `parseExprPrec`'s loop: regular BinaryExpr for standard ops; dedicated handlers for IS, IN, BETWEEN, LIKE/ILIKE/RLIKE, :: (cast postfix), : (JSON access), [ ] (array access), . (dot access), OVER (window), COLLATE
+8. **All helper parse functions**: `parseUnaryExpr`, `parseLiteral`, `parseIdentExpr`, `parseFuncCall`, `parseParenExpr`, `parseCaseExpr`, `parseCastExpr`, `parseTryCastExpr`, `parseIffExpr`, `parseArrayLiteral`, `parseJsonLiteral`, `parseLambdaOrIdent`, `parseIsExpr`, `parseBetweenExpr`, `parseInExpr`, `parseLikeExpr`, `parseCastPostfix`, `parseAccessExpr`, `parseOverClause`, `parseWindowFrame`, `parseWindowBound`, `parseExprList`, `parseOrderByList`, `ParseExpr` (freestanding)
+
+**Key patterns from the spec:**
+
+- The Pratt loop consumes operators greedily: `for { prec, op, ok := p.infixBindingPower(); if !ok || prec < minBP { break } ... }`
+- For standard binary ops: consume the operator, parse the right side with `parseExprPrec(prec + 1)` (left-associative), build a `BinaryExpr`
+- For postfix ops (::, COLLATE, OVER): consume the operator and its arguments, wrap left in the appropriate node, continue the loop
+- For access ops (:, [], .): highest binding power, parse the field/index, wrap left in AccessExpr
+- For IS/IN/BETWEEN/LIKE: same precedence as comparison (bpComparison), dedicated parse helpers that consume the full syntax
+
+**Import:** `"strings"` (for multi-word lookups like `strings.ToUpper(p.cur.Str) == "VARYING"` — though expressions don't need this often; the main use is for checking `DISTINCT FROM` after IS NOT).
+
+Also import `"github.com/bytebase/omni/snowflake/ast"`.
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./snowflake/parser/...`
+Expected: no output, exit 0. (No tests yet — just compile check.)
+
+Run: `go vet ./snowflake/parser/...`
+Expected: no output, exit 0.
+
+---
+
+## Task 4: Write expression tests (expr_test.go)
+
+**Files:**
+- Create: `snowflake/parser/expr_test.go`
+
+- [ ] **Step 1: Write the test file**
+
+Create `snowflake/parser/expr_test.go` with table-driven tests using a `testParseExpr` helper. The test file should cover all 24 categories from the spec:
+
+1. Literals
+2. Column refs
+3. Star
+4. Arithmetic precedence
+5. Parenthesized
+6. Comparison operators
+7. Logical operators (AND/OR/NOT precedence)
+8. Unary
+9. Concat
+10. CAST / TRY_CAST / ::
+11. CASE simple + searched
+12. IFF
+13. IS NULL / IS NOT NULL / IS DISTINCT FROM / IS NOT DISTINCT FROM
+14. BETWEEN / NOT BETWEEN
+15. IN / NOT IN
+16. LIKE / ILIKE / RLIKE / LIKE ANY
+17. Function calls (generic + COUNT(*) + COUNT(DISTINCT) + TRIM)
+18. Window functions with OVER (PARTITION BY + ORDER BY + frame)
+19. JSON access (:field), array access ([idx]), dot access (.field)
+20. Array literal / JSON literal
+21. Lambda expressions
+22. Nested expressions
+23. COLLATE
+24. Error cases
+
+Each test should assert the correct AST node type via type assertion and verify key fields (Op, Kind, Loc positions where critical).
+
+The test helper:
+
+```go
+func testParseExpr(input string) (ast.Node, error) {
+    p := &Parser{lexer: NewLexer(input), input: input}
+    p.advance()
+    return p.parseExpr()
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./snowflake/...`
+Expected: all tests pass.
+
+---
+
+## Task 5: Final acceptance criteria sweep
+
+- [ ] **Step 1: Build**
+
+Run: `go build ./snowflake/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 2: Vet**
+
+Run: `go vet ./snowflake/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Gofmt**
+
+Run: `gofmt -l snowflake/`
+Expected: no output. If any file listed, `gofmt -w snowflake/` and re-check.
+
+- [ ] **Step 4: Test**
+
+Run: `go test ./snowflake/...`
+Expected: both ast and parser pass.
+
+- [ ] **Step 5: Walker generation round-trip**
+
+Run: `cp snowflake/ast/walk_generated.go /tmp/wg.go && go generate ./snowflake/ast/... && diff /tmp/wg.go snowflake/ast/walk_generated.go && echo "BYTE_IDENTICAL" && rm /tmp/wg.go`
+Expected: `BYTE_IDENTICAL`.
+
+- [ ] **Step 6: STOP and present for review**
+
+Do NOT commit.
+
+---
+
+## Spec Coverage Checklist
+
+| Spec section | Covered by |
+|---|---|
+| 5 enum types (BinaryOp, UnaryOp, LiteralKind, LikeOp, AccessKind) | Task 1 |
+| Window enums (WindowFrameKind, WindowBoundKind, CaseKind) | Task 1 |
+| 22 expression node types + 5 helpers | Task 1 |
+| 17 NodeTag constants | Task 2 |
+| 17 NodeLoc cases | Task 2 |
+| Walker regeneration | Task 2 |
+| Pratt parser (parseExpr, parseExprPrec, infixBindingPower) | Task 3 |
+| Prefix dispatch (parsePrefixExpr, parseUnaryExpr) | Task 3 |
+| Primary dispatch (parsePrimaryExpr) | Task 3 |
+| Special form helpers (CASE, CAST, IFF, IS, IN, BETWEEN, LIKE) | Task 3 |
+| Function calls + aggregates + window | Task 3 |
+| Access operators (:, [], .) | Task 3 |
+| Lambda expressions | Task 3 |
+| Array/JSON literals | Task 3 |
+| ParseExpr freestanding | Task 3 |
+| 24 test categories | Task 4 |
+| Acceptance criteria | Task 5 |
+
+## Implementation Notes for Subagents
+
+**Task 3 is the critical task.** The implementer must:
+
+1. Read `mysql/parser/expr.go` (1932 LOC) as the reference implementation
+2. Read the spec's binding power table and node inventory
+3. Write a Snowflake-adapted Pratt parser that handles all 25 expr alternatives from the legacy grammar
+4. The parser must compile cleanly and integrate with the existing Parser struct from F4
+
+**Key differences from mysql's expr.go:**
+- Snowflake has `::` cast postfix (mysql doesn't)
+- Snowflake has JSON `:` access (mysql uses `->` / `->>`; snowflake uses `:`)
+- Snowflake has IFF() (mysql uses IF())
+- Snowflake has ILIKE (mysql doesn't)
+- Snowflake has LIKE ANY (...) (mysql doesn't)
+- Snowflake has lambda expressions (mysql doesn't)
+- Snowflake has array/JSON literals in expression position (mysql doesn't)
+- Snowflake does NOT have: `:=` assignment, `^` XOR, `&` bitwise AND, `|` bitwise OR, `<<` `>>` shifts, `<=>` null-safe equal, `SOUNDS LIKE`, `MATCH ... AGAINST`, `CONVERT`, `INTERVAL`
+
+**The Pratt parser structure:**
+```
+parseExpr → parseExprPrec(1)
+  parsePrefixExpr:
+    case '-': unary minus at bpUnary
+    case '+': skip (unary plus is a no-op)
+    case kwNOT: unary NOT at bpNot
+    default: parsePrimaryExpr
+  parsePrimaryExpr:
+    case tokInt/tokFloat/tokString: Literal
+    case kwTRUE/kwFALSE: Literal(LitBool)
+    case kwNULL: Literal(LitNull)
+    case tokIdent/tokQuotedIdent/keyword-as-ident: parseIdentExpr → ColumnRef or FuncCallExpr
+    case '(': parseParenExpr (check for SELECT → error placeholder)
+    case kwCASE: parseCaseExpr
+    case kwCAST: parseCastExpr
+    case kwTRY_CAST: parseTryCastExpr
+    case kwIFF: parseIffExpr
+    case '[': parseArrayLiteral
+    case '{': parseJsonLiteral
+    case '*': StarExpr
+    case kwEXISTS: error "subquery not yet supported"
+  infix loop:
+    binary ops: +, -, *, /, %, =, <>, <, >, <=, >=, !=, AND, OR, ||
+    special: IS (bpComparison), IN (bpComparison), BETWEEN (bpComparison),
+             LIKE/ILIKE/RLIKE (bpComparison), :: (bpPostfix),
+             COLLATE (bpPostfix), OVER (bpPostfix),
+             : (bpAccess), [ (bpAccess), . (bpAccess)
+```

--- a/docs/superpowers/specs/2026-04-10-snowflake-expressions-design.md
+++ b/docs/superpowers/specs/2026-04-10-snowflake-expressions-design.md
@@ -1,0 +1,306 @@
+# Snowflake Expressions (T1.3) — Design
+
+**DAG node:** T1.3 — expressions
+**Branch:** `feat/snowflake/expressions`
+**Depends on:** T1.2 (data types), T1.1 (identifiers).
+**Unblocks:** T1.4 (SELECT core), T1.5 (joins), T2.x (DDL), T5.x (DML).
+
+## Purpose
+
+T1.3 adds the expression parser — the core of any SQL parser. Every SQL clause that contains a value (SELECT list, WHERE, GROUP BY, HAVING, ORDER BY, CAST arguments, function arguments, DEFAULT values, CHECK constraints) calls `parseExpr()`.
+
+T1.3 ships:
+1. **22 AST node types + 5 helper types + 5 enums** in `snowflake/ast`
+2. **A Pratt parser** (`parseExpr` + ~25 helper functions) in `snowflake/parser/expr.go`
+3. **Comprehensive tests** (~800 LOC) in `snowflake/parser/expr_test.go`
+
+## Architecture — Pratt Parsing
+
+Mirrors `mysql/parser/expr.go` (1,932 LOC). The Pratt pattern:
+
+```
+parseExpr()
+  └── parseExprPrec(minBP)
+        ├── parsePrefixExpr()           // prefix: unary -, +, NOT, primary
+        │     └── parsePrimaryExpr()    // literals, idents, parens, CASE, CAST, IFF, etc.
+        └── infix loop                  // binary ops + postfix + special forms
+              ├── infixBindingPower()   // maps token → (bp, BinaryOp)
+              ├── BinaryExpr           // regular binary
+              └── special handlers      // IS, IN, BETWEEN, LIKE, ::, [], :, ., OVER, COLLATE
+```
+
+### Binding power table
+
+```go
+const (
+    bpNone       = 0
+    bpOr         = 10  // OR
+    bpAnd        = 20  // AND
+    bpNot        = 30  // NOT (prefix)
+    bpComparison = 40  // =, <>, <, >, <=, >=, != + IS, IN, BETWEEN, LIKE
+    bpAdd        = 50  // +, -, ||
+    bpMul        = 60  // *, /, %
+    bpUnary      = 70  // unary -, +
+    bpPostfix    = 80  // ::, COLLATE, OVER
+    bpAccess     = 90  // :, [], .
+)
+```
+
+## AST Types
+
+### Enums
+
+```go
+type BinaryOp int
+const (
+    BinAdd BinaryOp = iota // +
+    BinSub                  // -
+    BinMul                  // *
+    BinDiv                  // /
+    BinMod                  // %
+    BinConcat               // ||
+    BinEq                   // =
+    BinNe                   // <> or !=
+    BinLt                   // <
+    BinGt                   // >
+    BinLe                   // <=
+    BinGe                   // >=
+    BinAnd                  // AND
+    BinOr                   // OR
+)
+
+type UnaryOp int
+const ( UnaryMinus UnaryOp = iota; UnaryPlus; UnaryNot )
+
+type LiteralKind int
+const ( LitNull LiteralKind = iota; LitBool; LitInt; LitFloat; LitString )
+
+type LikeOp int
+const ( LikeOpLike LikeOp = iota; LikeOpILike; LikeOpRLike; LikeOpRegexp )
+
+type AccessKind int
+const ( AccessColon AccessKind = iota; AccessBracket; AccessDot )
+```
+
+### Expression Nodes (22 types)
+
+Each is a Node with `Tag() NodeTag` and `Loc Loc`.
+
+**Core (11):**
+
+| Node | Fields | Grammar alternative |
+|---|---|---|
+| `Literal` | Kind LiteralKind, Value string, Ival int64, Bval bool | `literal` rule |
+| `ColumnRef` | Parts []Ident | `full_column_name` (1-4 parts) |
+| `StarExpr` | Qualifier *ObjectName (optional) | `id_ '.' STAR` or bare `*` |
+| `BinaryExpr` | Op BinaryOp, Left/Right Node | arithmetic/comparison/logical/concat |
+| `UnaryExpr` | Op UnaryOp, Expr Node | prefix `-, +, NOT` |
+| `ParenExpr` | Expr Node | `bracket_expression` (non-subquery) |
+| `CastExpr` | Expr Node, TypeName *TypeName, TryCast bool, ColonColon bool | `cast_expr`, `try_cast_expr`, `expr :: data_type` |
+| `CaseExpr` | Operand Node (nil for searched), Whens []*WhenClause, Else Node | `case_expression` |
+| `FuncCallExpr` | Name ObjectName, Args []Node, Star bool, Distinct bool, OrderBy []*OrderItem, Over *WindowSpec | `function_call`, `aggregate_function`, `ranking_windowed_function`, `trim_expression` |
+| `IffExpr` | Cond/Then/Else Node | `iff_expr` |
+| `CollateExpr` | Expr Node, Collation string | `expr COLLATE string` |
+
+**Predicates (5):**
+
+| Node | Fields | Grammar alternative |
+|---|---|---|
+| `IsExpr` | Expr Node, Not bool, Null bool, DistinctFrom Node | `expr IS [NOT] NULL` / `expr IS [NOT] DISTINCT FROM expr` |
+| `BetweenExpr` | Expr/Low/High Node, Not bool | `expr [NOT] BETWEEN low AND high` |
+| `InExpr` | Expr Node, Values []Node, Not bool | `expr [NOT] IN (expr_list)` |
+| `LikeExpr` | Expr/Pattern Node, Escape Node, Op LikeOp, Not bool, Any bool, AnyValues []Node | `expr [NOT] LIKE/ILIKE/RLIKE pattern` + `LIKE ANY (...)` |
+| `ExistsExpr` | Query Node | placeholder for T1.4 |
+
+**Semi-structured + special (5):**
+
+| Node | Fields | Grammar alternative |
+|---|---|---|
+| `AccessExpr` | Expr Node, Kind AccessKind, Field Ident (colon/dot), Index Node (bracket) | `expr:field`, `expr[idx]`, `expr.field` |
+| `ArrayLiteralExpr` | Elements []Node | `arr_literal` |
+| `JsonLiteralExpr` | Pairs []KeyValuePair | `json_literal` |
+| `LambdaExpr` | Params []Ident, Body Node | `lambda_params '->' expr` |
+| `SubqueryExpr` | Query Node | placeholder for T1.4 |
+
+**Window (1):**
+
+| Node | Fields |
+|---|---|
+| `WindowSpec` | PartitionBy []Node, OrderBy []*OrderItem, Frame *WindowFrame |
+
+### Helper Types (5, NOT Nodes)
+
+```go
+type WhenClause struct { Cond, Result Node; Loc Loc }
+type KeyValuePair struct { Key string; Value Node; Loc Loc }
+type OrderItem struct { Expr Node; Desc bool; NullsFirst *bool; Loc Loc }
+type WindowFrame struct { Kind WindowFrameKind; Start, End WindowBound; Loc Loc }
+type WindowBound struct { Kind WindowBoundKind; Offset Node; Loc Loc }
+```
+
+Window frame enums:
+
+```go
+type WindowFrameKind int
+const ( FrameRows WindowFrameKind = iota; FrameRange; FrameGroups )
+
+type WindowBoundKind int
+const (
+    BoundUnboundedPreceding WindowBoundKind = iota
+    BoundPreceding      // N PRECEDING
+    BoundCurrentRow
+    BoundFollowing      // N FOLLOWING
+    BoundUnboundedFollowing
+)
+```
+
+### NodeTag additions
+
+17 new tags: `T_Literal`, `T_ColumnRef`, `T_StarExpr`, `T_BinaryExpr`, `T_UnaryExpr`, `T_ParenExpr`, `T_CastExpr`, `T_CaseExpr`, `T_FuncCallExpr`, `T_IffExpr`, `T_CollateExpr`, `T_IsExpr`, `T_BetweenExpr`, `T_InExpr`, `T_LikeExpr`, `T_AccessExpr`, `T_ArrayLiteralExpr`, `T_JsonLiteralExpr`, `T_LambdaExpr`.
+
+(`ExistsExpr`, `SubqueryExpr`, `WindowSpec` are either T1.4 stubs or helper types without their own tags.)
+
+## Parser Functions
+
+All in `snowflake/parser/expr.go`:
+
+### Core Pratt loop
+
+```go
+func (p *Parser) parseExpr() (ast.Node, error)                    // entry: calls parseExprPrec(bpNone + 1)
+func (p *Parser) parseExprPrec(minBP int) (ast.Node, error)        // Pratt loop
+func (p *Parser) parsePrefixExpr() (ast.Node, error)               // unary + primary dispatch
+func (p *Parser) parsePrimaryExpr() (ast.Node, error)              // big switch: literals, idents, parens, CASE, CAST, IFF, etc.
+func (p *Parser) infixBindingPower() (int, BinaryOp, bool)         // maps current token to (bp, op, ok)
+```
+
+### Primary expression helpers
+
+```go
+func (p *Parser) parseLiteral() (*ast.Literal, error)
+func (p *Parser) parseIdentExpr() (ast.Node, error)                // ident → ColumnRef or FuncCallExpr (if followed by '(')
+func (p *Parser) parseFuncCall(name ast.ObjectName) (*ast.FuncCallExpr, error)
+func (p *Parser) parseParenExpr() (ast.Node, error)                // (expr) or (expr_list) for IN
+func (p *Parser) parseCaseExpr() (*ast.CaseExpr, error)
+func (p *Parser) parseCastExpr() (*ast.CastExpr, error)
+func (p *Parser) parseTryCastExpr() (*ast.CastExpr, error)
+func (p *Parser) parseIffExpr() (*ast.IffExpr, error)
+func (p *Parser) parseArrayLiteral() (*ast.ArrayLiteralExpr, error)
+func (p *Parser) parseJsonLiteral() (*ast.JsonLiteralExpr, error)
+func (p *Parser) parseLambdaExpr() (*ast.LambdaExpr, error)        // heuristic: ident -> or ( ident, ident ) ->
+```
+
+### Infix/postfix special handlers
+
+```go
+func (p *Parser) parseIsExpr(left ast.Node) (ast.Node, error)
+func (p *Parser) parseBetweenExpr(left ast.Node) (ast.Node, error)
+func (p *Parser) parseInExpr(left ast.Node) (ast.Node, error)
+func (p *Parser) parseLikeExpr(left ast.Node) (ast.Node, error)
+func (p *Parser) parseCastPostfix(left ast.Node) (*ast.CastExpr, error)     // :: postfix
+func (p *Parser) parseAccessExpr(left ast.Node) (*ast.AccessExpr, error)    // :, [], .
+func (p *Parser) parseOverClause() (*ast.WindowSpec, error)
+func (p *Parser) parseWindowFrame() (*ast.WindowFrame, error)
+func (p *Parser) parseWindowBound() (ast.WindowBound, error)
+```
+
+### Utilities
+
+```go
+func (p *Parser) parseExprList() ([]ast.Node, error)               // comma-separated expression list
+func (p *Parser) parseOrderByList() ([]*ast.OrderItem, error)       // for window ORDER BY and WITHIN GROUP
+```
+
+### Public helper
+
+```go
+func ParseExpr(input string) (ast.Node, []ParseError)              // freestanding for tests + callers
+```
+
+## Subquery Handling (T1.4 placeholder)
+
+When `parsePrimaryExpr` encounters `(` followed by `kwSELECT` or `kwWITH`, it returns a `ParseError` "subquery expressions not yet supported". When `parseExpr` encounters `kwEXISTS` followed by `(`, same error.
+
+T1.4 will fill in the real implementations by:
+1. Adding a `kwSELECT` / `kwWITH` branch inside `parseParenExpr`
+2. Adding an `kwEXISTS` branch inside `parsePrimaryExpr`
+
+The Pratt framework does NOT need modification — only the primary-expression dispatch gains new cases.
+
+## Lambda Detection Heuristic
+
+Snowflake's `lambda_params '->' expr` is syntactically ambiguous: `x -> x + 1` starts with an identifier, which could also be a column reference. The parser must lookahead to distinguish.
+
+**Heuristic** (same approach as many SQL parsers):
+- If the current token is an identifier AND the next is `->`, parse as lambda
+- If the current token is `(` AND after matching identifiers and `)` the next is `->`, parse as lambda
+- Otherwise, parse as a normal expression
+
+This is handled inside `parsePrimaryExpr`'s identifier branch: peek for `->` before falling through to parseIdentExpr.
+
+## File Layout
+
+| File | Change | Approx LOC |
+|------|--------|-----------|
+| `snowflake/ast/parsenodes.go` | MODIFY: append 22 node types + 5 helpers + 5 enums | +400 |
+| `snowflake/ast/nodetags.go` | MODIFY: +17 T_* tags + String() cases | +40 |
+| `snowflake/ast/loc.go` | MODIFY: +17 NodeLoc cases | +35 |
+| `snowflake/ast/walk_generated.go` | REGENERATED: many new cases | ~auto |
+| `snowflake/parser/expr.go` | NEW: Pratt parser + all helpers | 900 |
+| `snowflake/parser/expr_test.go` | NEW: comprehensive tests | 800 |
+
+**Estimated total: ~2,200 LOC** across 2 new + 4 modified files.
+
+## Testing
+
+Table-driven with `testParseExpr(input) (ast.Node, error)`.
+
+### Test categories (22)
+
+1. Literals: `42`, `3.14`, `'hello'`, `TRUE`, `FALSE`, `NULL`
+2. Column refs: `col`, `t.col`, `s.t.col`, `db.s.t.col`
+3. Star: `*`, `t.*`
+4. Arithmetic precedence: `1 + 2 * 3` → BinaryExpr(+, 1, BinaryExpr(*, 2, 3))
+5. Parenthesized: `(1 + 2) * 3`
+6. Comparison: `a = b`, `a <> b`, `a != b`, `a >= b`
+7. Logical: `a AND b OR c` → BinaryExpr(OR, BinaryExpr(AND, a, b), c)
+8. NOT prefix: `NOT a`, `NOT NOT a`
+9. Unary: `-a`, `+a`
+10. Concat: `a || b || c`
+11. CAST: `CAST(x AS INT)`, `TRY_CAST(x AS VARCHAR(100))`, `x::INT`
+12. CASE simple: `CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END`
+13. CASE searched: `CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END`
+14. IFF: `IFF(x > 0, 'pos', 'neg')`
+15. IS NULL: `x IS NULL`, `x IS NOT NULL`, `x IS DISTINCT FROM y`, `x IS NOT DISTINCT FROM y`
+16. BETWEEN: `x BETWEEN 1 AND 10`, `x NOT BETWEEN 1 AND 10`
+17. IN: `x IN (1, 2, 3)`, `x NOT IN (1, 2, 3)`
+18. LIKE: `x LIKE 'pat%'`, `x ILIKE '%pat%'`, `x RLIKE '.*'`, `x LIKE '%' ESCAPE '\'`, `x LIKE ANY ('a%', 'b%')`
+19. Function calls: `f()`, `f(1, 2)`, `COUNT(*)`, `COUNT(DISTINCT x)`, `TRIM(x)`
+20. Window: `ROW_NUMBER() OVER (PARTITION BY a ORDER BY b)`, `SUM(x) OVER (ORDER BY y ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`
+21. JSON/Array/Access: `v:field`, `v[0]`, `v:field.subfield`, `[1, 2, 3]`, `{'key': 'val'}`
+22. Lambda: `x -> x + 1`, `(x, y) -> x + y`
+23. Nested: `CAST(IFF(a > b, a, b) AS INT)`, `f(g(x))`, `a + b * c :: INT`
+24. Error cases: unclosed paren, missing THEN in CASE, unterminated BETWEEN
+
+## Out of Scope
+
+| Feature | Where |
+|---|---|
+| Subquery expressions `(SELECT ...)` | T1.4 |
+| EXISTS (subquery) | T1.4 |
+| IN (subquery) | T1.4 |
+| FLATTEN / LATERAL | T5.3 |
+| Aggregate WITHIN GROUP (ORDER BY) | Included in FuncCallExpr via OrderBy field |
+| LISTAGG / ARRAY_AGG special forms | Handled as FuncCallExpr with OrderBy |
+
+## Acceptance Criteria
+
+1. `go build ./snowflake/...` succeeds
+2. `go vet ./snowflake/...` clean
+3. `gofmt -l snowflake/` clean
+4. `go test ./snowflake/...` passes
+5. `go generate ./snowflake/ast/...` produces correct walker with expression node child walks
+6. Every expression form from the legacy `expr` rule (25 alternatives) has a corresponding parse path
+7. Precedence is correct: `1 + 2 * 3` parses as `1 + (2 * 3)`, not `(1 + 2) * 3`
+8. Window frames parse correctly: `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
+9. After merge, `docs/migration/snowflake/dag.md` T1.3 status → `done`

--- a/snowflake/ast/cmd/genwalker/main.go
+++ b/snowflake/ast/cmd/genwalker/main.go
@@ -56,6 +56,11 @@ func main() {
 
 	var structs []structInfo
 
+	// nodeStructs tracks which structs implement the Node interface (have a Tag() method).
+	// Only these structs get their own case in the walkChildren switch, and only
+	// pointer-to-Node-struct fields generate Walk calls.
+	nodeStructs := map[string]bool{}
+
 	for _, f := range files {
 		for _, decl := range f.Decls {
 			gd, ok := decl.(*ast.GenDecl)
@@ -66,6 +71,35 @@ func main() {
 				ts := spec.(*ast.TypeSpec)
 				if _, ok := ts.Type.(*ast.StructType); ok {
 					structNames[ts.Name.Name] = true
+				}
+			}
+		}
+		// Scan function declarations for Tag() methods to identify Node types.
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv == nil || fd.Name.Name != "Tag" {
+				continue
+			}
+			// Check it returns NodeTag and has no parameters.
+			if fd.Type.Params != nil && len(fd.Type.Params.List) > 0 {
+				continue
+			}
+			if fd.Type.Results == nil || len(fd.Type.Results.List) != 1 {
+				continue
+			}
+			// Extract the receiver type name (handles both *T and T receivers).
+			for _, recv := range fd.Recv.List {
+				recvName := ""
+				switch rt := recv.Type.(type) {
+				case *ast.StarExpr:
+					if id, ok := rt.X.(*ast.Ident); ok {
+						recvName = id.Name
+					}
+				case *ast.Ident:
+					recvName = rt.Name
+				}
+				if recvName != "" {
+					nodeStructs[recvName] = true
 				}
 			}
 		}
@@ -91,7 +125,7 @@ func main() {
 						continue // embedded
 					}
 					typStr := typeString(fld.Type)
-					if isChildType(typStr, structNames) {
+					if isChildType(typStr, nodeStructs) {
 						for _, name := range fld.Names {
 							fields = append(fields, field{Name: name.Name, Type: typStr})
 						}
@@ -118,6 +152,10 @@ func main() {
 
 	for _, s := range structs {
 		if len(s.Fields) == 0 {
+			continue
+		}
+		// Only emit cases for structs that implement Node (have a Tag() method).
+		if !nodeStructs[s.Name] {
 			continue
 		}
 		fmt.Fprintf(&buf, "\tcase *%s:\n", s.Name)
@@ -157,7 +195,7 @@ func main() {
 	cases := 0
 	fields := 0
 	for _, s := range structs {
-		if len(s.Fields) > 0 {
+		if len(s.Fields) > 0 && nodeStructs[s.Name] {
 			cases++
 			fields += len(s.Fields)
 		}
@@ -188,10 +226,11 @@ func typeString(expr ast.Expr) string {
 // Recognized shapes:
 //   - "Node"             — the Node interface
 //   - "[]Node"           — slice of nodes
-//   - "*<KnownStruct>"   — pointer to a struct defined in parsenodes.go or node.go
+//   - "*<NodeStruct>"    — pointer to a struct that implements Node (has Tag() method)
 //
-// Excluded: pointer to "Loc" (Loc is not a node), and any other shape.
-func isChildType(typStr string, structNames map[string]bool) bool {
+// Excluded: pointer to "Loc" (Loc is not a node), pointer to non-Node structs
+// (helper types like WhenClause, WindowSpec, etc.), and any other shape.
+func isChildType(typStr string, nodeStructs map[string]bool) bool {
 	if typStr == "Node" {
 		return true
 	}
@@ -203,7 +242,7 @@ func isChildType(typStr string, structNames map[string]bool) bool {
 		if name == "Loc" {
 			return false
 		}
-		return structNames[name]
+		return nodeStructs[name]
 	}
 	return false
 }

--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -16,6 +16,48 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *TypeName:
 		return v.Loc
+	case *Literal:
+		return v.Loc
+	case *ColumnRef:
+		return v.Loc
+	case *StarExpr:
+		return v.Loc
+	case *BinaryExpr:
+		return v.Loc
+	case *UnaryExpr:
+		return v.Loc
+	case *ParenExpr:
+		return v.Loc
+	case *CastExpr:
+		return v.Loc
+	case *CaseExpr:
+		return v.Loc
+	case *FuncCallExpr:
+		return v.Loc
+	case *IffExpr:
+		return v.Loc
+	case *CollateExpr:
+		return v.Loc
+	case *IsExpr:
+		return v.Loc
+	case *BetweenExpr:
+		return v.Loc
+	case *InExpr:
+		return v.Loc
+	case *LikeExpr:
+		return v.Loc
+	case *AccessExpr:
+		return v.Loc
+	case *ArrayLiteralExpr:
+		return v.Loc
+	case *JsonLiteralExpr:
+		return v.Loc
+	case *LambdaExpr:
+		return v.Loc
+	case *SubqueryExpr:
+		return v.Loc
+	case *ExistsExpr:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -24,6 +24,28 @@ const (
 
 	// T_TypeName is the tag for *TypeName, a data type reference.
 	T_TypeName
+
+	T_Literal
+	T_ColumnRef
+	T_StarExpr
+	T_BinaryExpr
+	T_UnaryExpr
+	T_ParenExpr
+	T_CastExpr
+	T_CaseExpr
+	T_FuncCallExpr
+	T_IffExpr
+	T_CollateExpr
+	T_IsExpr
+	T_BetweenExpr
+	T_InExpr
+	T_LikeExpr
+	T_AccessExpr
+	T_ArrayLiteralExpr
+	T_JsonLiteralExpr
+	T_LambdaExpr
+	T_SubqueryExpr
+	T_ExistsExpr
 )
 
 // String returns a human-readable representation of the tag.
@@ -37,6 +59,48 @@ func (t NodeTag) String() string {
 		return "ObjectName"
 	case T_TypeName:
 		return "TypeName"
+	case T_Literal:
+		return "Literal"
+	case T_ColumnRef:
+		return "ColumnRef"
+	case T_StarExpr:
+		return "StarExpr"
+	case T_BinaryExpr:
+		return "BinaryExpr"
+	case T_UnaryExpr:
+		return "UnaryExpr"
+	case T_ParenExpr:
+		return "ParenExpr"
+	case T_CastExpr:
+		return "CastExpr"
+	case T_CaseExpr:
+		return "CaseExpr"
+	case T_FuncCallExpr:
+		return "FuncCallExpr"
+	case T_IffExpr:
+		return "IffExpr"
+	case T_CollateExpr:
+		return "CollateExpr"
+	case T_IsExpr:
+		return "IsExpr"
+	case T_BetweenExpr:
+		return "BetweenExpr"
+	case T_InExpr:
+		return "InExpr"
+	case T_LikeExpr:
+		return "LikeExpr"
+	case T_AccessExpr:
+		return "AccessExpr"
+	case T_ArrayLiteralExpr:
+		return "ArrayLiteralExpr"
+	case T_JsonLiteralExpr:
+		return "JsonLiteralExpr"
+	case T_LambdaExpr:
+		return "LambdaExpr"
+	case T_SubqueryExpr:
+		return "SubqueryExpr"
+	case T_ExistsExpr:
+		return "ExistsExpr"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -274,3 +274,434 @@ func (n *TypeName) Tag() NodeTag { return T_TypeName }
 
 // Compile-time assertion that *TypeName satisfies Node.
 var _ Node = (*TypeName)(nil)
+
+// ---------------------------------------------------------------------------
+// Expression enums
+// ---------------------------------------------------------------------------
+
+// BinaryOp enumerates binary operator types.
+type BinaryOp int
+
+const (
+	BinAdd    BinaryOp = iota // +
+	BinSub                    // -
+	BinMul                    // *
+	BinDiv                    // /
+	BinMod                    // %
+	BinConcat                 // ||
+	BinEq                     // =
+	BinNe                     // <> or !=
+	BinLt                     // <
+	BinGt                     // >
+	BinLe                     // <=
+	BinGe                     // >=
+	BinAnd                    // AND
+	BinOr                     // OR
+)
+
+// String returns the operator symbol.
+func (op BinaryOp) String() string {
+	switch op {
+	case BinAdd:
+		return "+"
+	case BinSub:
+		return "-"
+	case BinMul:
+		return "*"
+	case BinDiv:
+		return "/"
+	case BinMod:
+		return "%"
+	case BinConcat:
+		return "||"
+	case BinEq:
+		return "="
+	case BinNe:
+		return "!="
+	case BinLt:
+		return "<"
+	case BinGt:
+		return ">"
+	case BinLe:
+		return "<="
+	case BinGe:
+		return ">="
+	case BinAnd:
+		return "AND"
+	case BinOr:
+		return "OR"
+	default:
+		return "?"
+	}
+}
+
+// UnaryOp enumerates unary operator types.
+type UnaryOp int
+
+const (
+	UnaryMinus UnaryOp = iota // -
+	UnaryPlus                 // +
+	UnaryNot                  // NOT
+)
+
+// String returns the operator symbol.
+func (op UnaryOp) String() string {
+	switch op {
+	case UnaryMinus:
+		return "-"
+	case UnaryPlus:
+		return "+"
+	case UnaryNot:
+		return "NOT"
+	default:
+		return "?"
+	}
+}
+
+// LiteralKind classifies literal value types.
+type LiteralKind int
+
+const (
+	LitNull LiteralKind = iota
+	LitBool
+	LitInt
+	LitFloat
+	LitString
+)
+
+// LikeOp enumerates LIKE operator variants.
+type LikeOp int
+
+const (
+	LikeOpLike   LikeOp = iota // LIKE
+	LikeOpILike                // ILIKE
+	LikeOpRLike                // RLIKE
+	LikeOpRegexp               // REGEXP
+)
+
+// AccessKind enumerates semi-structured access operator types.
+type AccessKind int
+
+const (
+	AccessColon   AccessKind = iota // expr:field (JSON path)
+	AccessBracket                   // expr[idx] (array subscript)
+	AccessDot                       // expr.field (dot path)
+)
+
+// WindowFrameKind enumerates window frame types.
+type WindowFrameKind int
+
+const (
+	FrameRows WindowFrameKind = iota
+	FrameRange
+	FrameGroups
+)
+
+// WindowBoundKind enumerates window frame bound types.
+type WindowBoundKind int
+
+const (
+	BoundUnboundedPreceding WindowBoundKind = iota
+	BoundPreceding
+	BoundCurrentRow
+	BoundFollowing
+	BoundUnboundedFollowing
+)
+
+// CaseKind discriminates simple vs searched CASE expressions.
+type CaseKind int
+
+const (
+	CaseSimple   CaseKind = iota // CASE expr WHEN val THEN ...
+	CaseSearched                 // CASE WHEN cond THEN ...
+)
+
+// ---------------------------------------------------------------------------
+// Expression nodes
+// ---------------------------------------------------------------------------
+
+// Literal represents an integer, float, string, boolean, or NULL literal.
+type Literal struct {
+	Kind  LiteralKind
+	Value string // raw source text for all kinds
+	Ival  int64  // for LitInt
+	Bval  bool   // for LitBool
+	Loc   Loc
+}
+
+func (n *Literal) Tag() NodeTag { return T_Literal }
+
+// ColumnRef represents a 1-4 part column reference (col, t.col, s.t.col, db.s.t.col).
+type ColumnRef struct {
+	Parts []Ident
+	Loc   Loc
+}
+
+func (n *ColumnRef) Tag() NodeTag { return T_ColumnRef }
+
+// StarExpr represents * or qualifier.* in SELECT lists and COUNT(*).
+type StarExpr struct {
+	Qualifier *ObjectName // optional table qualifier; nil for bare *
+	Loc       Loc
+}
+
+func (n *StarExpr) Tag() NodeTag { return T_StarExpr }
+
+// BinaryExpr represents a binary operation: left op right.
+type BinaryExpr struct {
+	Op    BinaryOp
+	Left  Node
+	Right Node
+	Loc   Loc
+}
+
+func (n *BinaryExpr) Tag() NodeTag { return T_BinaryExpr }
+
+// UnaryExpr represents a prefix unary operation: op expr.
+type UnaryExpr struct {
+	Op   UnaryOp
+	Expr Node
+	Loc  Loc
+}
+
+func (n *UnaryExpr) Tag() NodeTag { return T_UnaryExpr }
+
+// ParenExpr represents a parenthesized expression: ( expr ).
+type ParenExpr struct {
+	Expr Node
+	Loc  Loc
+}
+
+func (n *ParenExpr) Tag() NodeTag { return T_ParenExpr }
+
+// CastExpr represents CAST(expr AS type), TRY_CAST(expr AS type), or expr::type.
+type CastExpr struct {
+	Expr       Node
+	TypeName   *TypeName
+	TryCast    bool // true for TRY_CAST
+	ColonColon bool // true for expr::type syntax
+	Loc        Loc
+}
+
+func (n *CastExpr) Tag() NodeTag { return T_CastExpr }
+
+// CaseExpr represents a CASE expression (simple or searched).
+type CaseExpr struct {
+	Kind    CaseKind
+	Operand Node          // non-nil for CaseSimple; nil for CaseSearched
+	Whens   []*WhenClause // one or more WHEN clauses
+	Else    Node          // optional ELSE; nil if absent
+	Loc     Loc
+}
+
+func (n *CaseExpr) Tag() NodeTag { return T_CaseExpr }
+
+// WhenClause is a single WHEN...THEN branch inside a CaseExpr.
+// Not a top-level Node — embedded in CaseExpr.
+type WhenClause struct {
+	Cond   Node // the WHEN condition (or value for simple CASE)
+	Result Node // the THEN result
+	Loc    Loc
+}
+
+// FuncCallExpr represents a function call including aggregates and window functions.
+//
+// Star is true for COUNT(*). Distinct is true for COUNT(DISTINCT x).
+// OrderBy is used by aggregates with WITHIN GROUP (ORDER BY ...).
+// Over is non-nil for window functions (SUM(x) OVER (...)).
+type FuncCallExpr struct {
+	Name     ObjectName   // function name (may be qualified: schema.func)
+	Args     []Node       // argument expressions
+	Star     bool         // COUNT(*)
+	Distinct bool         // DISTINCT keyword in aggregate
+	OrderBy  []*OrderItem // for WITHIN GROUP (ORDER BY ...)
+	Over     *WindowSpec  // non-nil for window functions
+	Loc      Loc
+}
+
+func (n *FuncCallExpr) Tag() NodeTag { return T_FuncCallExpr }
+
+// IffExpr represents Snowflake's IFF(condition, then_expr, else_expr).
+type IffExpr struct {
+	Cond Node
+	Then Node
+	Else Node
+	Loc  Loc
+}
+
+func (n *IffExpr) Tag() NodeTag { return T_IffExpr }
+
+// CollateExpr represents expr COLLATE collation_name.
+type CollateExpr struct {
+	Expr      Node
+	Collation string
+	Loc       Loc
+}
+
+func (n *CollateExpr) Tag() NodeTag { return T_CollateExpr }
+
+// IsExpr represents expr IS [NOT] NULL or expr IS [NOT] DISTINCT FROM expr.
+type IsExpr struct {
+	Expr         Node
+	Not          bool // IS NOT NULL / IS NOT DISTINCT FROM
+	Null         bool // true for IS [NOT] NULL; false for IS [NOT] DISTINCT FROM
+	DistinctFrom Node // non-nil for IS [NOT] DISTINCT FROM expr
+	Loc          Loc
+}
+
+func (n *IsExpr) Tag() NodeTag { return T_IsExpr }
+
+// BetweenExpr represents expr [NOT] BETWEEN low AND high.
+type BetweenExpr struct {
+	Expr Node
+	Low  Node
+	High Node
+	Not  bool
+	Loc  Loc
+}
+
+func (n *BetweenExpr) Tag() NodeTag { return T_BetweenExpr }
+
+// InExpr represents expr [NOT] IN (value_list).
+// Subquery form (expr IN (SELECT ...)) is handled by T1.4.
+type InExpr struct {
+	Expr   Node
+	Values []Node
+	Not    bool
+	Loc    Loc
+}
+
+func (n *InExpr) Tag() NodeTag { return T_InExpr }
+
+// LikeExpr represents expr [NOT] LIKE/ILIKE/RLIKE/REGEXP pattern [ESCAPE esc].
+// Also handles LIKE ANY (...) via the Any + AnyValues fields.
+type LikeExpr struct {
+	Expr      Node
+	Pattern   Node   // the pattern expression
+	Escape    Node   // optional ESCAPE clause; nil if absent
+	Op        LikeOp // LIKE, ILIKE, RLIKE, REGEXP
+	Not       bool
+	Any       bool   // true for LIKE ANY (...)
+	AnyValues []Node // values for LIKE ANY; nil unless Any is true
+	Loc       Loc
+}
+
+func (n *LikeExpr) Tag() NodeTag { return T_LikeExpr }
+
+// AccessExpr represents semi-structured data access:
+//   - AccessColon:   expr:field (JSON path)
+//   - AccessBracket: expr[index] (array subscript)
+//   - AccessDot:     expr.field (dot path chaining)
+type AccessExpr struct {
+	Expr  Node
+	Kind  AccessKind
+	Field Ident // for Colon and Dot access
+	Index Node  // for Bracket access
+	Loc   Loc
+}
+
+func (n *AccessExpr) Tag() NodeTag { return T_AccessExpr }
+
+// ArrayLiteralExpr represents an array literal: [elem1, elem2, ...].
+type ArrayLiteralExpr struct {
+	Elements []Node
+	Loc      Loc
+}
+
+func (n *ArrayLiteralExpr) Tag() NodeTag { return T_ArrayLiteralExpr }
+
+// JsonLiteralExpr represents a JSON object literal: {key: value, ...}.
+type JsonLiteralExpr struct {
+	Pairs []KeyValuePair
+	Loc   Loc
+}
+
+func (n *JsonLiteralExpr) Tag() NodeTag { return T_JsonLiteralExpr }
+
+// KeyValuePair is a single key-value pair in a JsonLiteralExpr.
+type KeyValuePair struct {
+	Key   string
+	Value Node
+	Loc   Loc
+}
+
+// LambdaExpr represents a lambda expression: param -> body or (p1, p2) -> body.
+type LambdaExpr struct {
+	Params []Ident
+	Body   Node
+	Loc    Loc
+}
+
+func (n *LambdaExpr) Tag() NodeTag { return T_LambdaExpr }
+
+// SubqueryExpr is a placeholder for subquery expressions (SELECT ...).
+// T1.4 will fill in the real implementation.
+type SubqueryExpr struct {
+	Loc Loc
+}
+
+func (n *SubqueryExpr) Tag() NodeTag { return T_SubqueryExpr }
+
+// ExistsExpr is a placeholder for EXISTS (SELECT ...).
+// T1.4 will fill in the real implementation.
+type ExistsExpr struct {
+	Loc Loc
+}
+
+func (n *ExistsExpr) Tag() NodeTag { return T_ExistsExpr }
+
+// WindowSpec describes a window specification for OVER (...).
+// Not a top-level Node — embedded in FuncCallExpr.
+type WindowSpec struct {
+	PartitionBy []Node
+	OrderBy     []*OrderItem
+	Frame       *WindowFrame // nil if no frame clause
+	Loc         Loc
+}
+
+// OrderItem represents one element in an ORDER BY clause.
+type OrderItem struct {
+	Expr       Node
+	Desc       bool  // true for DESC
+	NullsFirst *bool // nil = unspecified, true = NULLS FIRST, false = NULLS LAST
+	Loc        Loc
+}
+
+// WindowFrame represents ROWS/RANGE/GROUPS BETWEEN start AND end.
+type WindowFrame struct {
+	Kind  WindowFrameKind
+	Start WindowBound
+	End   WindowBound // End.Kind may be zero if single-bound form (not BETWEEN)
+	Loc   Loc
+}
+
+// WindowBound represents one end of a window frame specification.
+type WindowBound struct {
+	Kind   WindowBoundKind
+	Offset Node // for BoundPreceding/BoundFollowing: the N in "N PRECEDING"; nil otherwise
+}
+
+// Compile-time assertions.
+var (
+	_ Node = (*Literal)(nil)
+	_ Node = (*ColumnRef)(nil)
+	_ Node = (*StarExpr)(nil)
+	_ Node = (*BinaryExpr)(nil)
+	_ Node = (*UnaryExpr)(nil)
+	_ Node = (*ParenExpr)(nil)
+	_ Node = (*CastExpr)(nil)
+	_ Node = (*CaseExpr)(nil)
+	_ Node = (*FuncCallExpr)(nil)
+	_ Node = (*IffExpr)(nil)
+	_ Node = (*CollateExpr)(nil)
+	_ Node = (*IsExpr)(nil)
+	_ Node = (*BetweenExpr)(nil)
+	_ Node = (*InExpr)(nil)
+	_ Node = (*LikeExpr)(nil)
+	_ Node = (*AccessExpr)(nil)
+	_ Node = (*ArrayLiteralExpr)(nil)
+	_ Node = (*JsonLiteralExpr)(nil)
+	_ Node = (*LambdaExpr)(nil)
+	_ Node = (*SubqueryExpr)(nil)
+	_ Node = (*ExistsExpr)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -6,11 +6,60 @@ package ast
 // for each child. This function is generated from parsenodes.go and node.go.
 func walkChildren(v Visitor, node Node) {
 	switch n := node.(type) {
+	case *AccessExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Index)
+	case *ArrayLiteralExpr:
+		walkNodes(v, n.Elements)
+	case *BetweenExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Low)
+		Walk(v, n.High)
+	case *BinaryExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *CaseExpr:
+		Walk(v, n.Operand)
+		Walk(v, n.Else)
+	case *CastExpr:
+		Walk(v, n.Expr)
+		if n.TypeName != nil {
+			Walk(v, n.TypeName)
+		}
+	case *CollateExpr:
+		Walk(v, n.Expr)
 	case *File:
 		walkNodes(v, n.Stmts)
+	case *FuncCallExpr:
+		walkNodes(v, n.Args)
+	case *IffExpr:
+		Walk(v, n.Cond)
+		Walk(v, n.Then)
+		Walk(v, n.Else)
+	case *InExpr:
+		Walk(v, n.Expr)
+		walkNodes(v, n.Values)
+	case *IsExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.DistinctFrom)
+	case *LambdaExpr:
+		Walk(v, n.Body)
+	case *LikeExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Pattern)
+		Walk(v, n.Escape)
+		walkNodes(v, n.AnyValues)
+	case *ParenExpr:
+		Walk(v, n.Expr)
+	case *StarExpr:
+		if n.Qualifier != nil {
+			Walk(v, n.Qualifier)
+		}
 	case *TypeName:
 		if n.ElementType != nil {
 			Walk(v, n.ElementType)
 		}
+	case *UnaryExpr:
+		Walk(v, n.Expr)
 	}
 }

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -1,0 +1,1567 @@
+package parser
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// Binding power constants for Pratt parsing (low to high).
+const (
+	bpNone       = 0
+	bpOr         = 10 // OR
+	bpAnd        = 20 // AND
+	bpNot        = 30 // NOT (prefix)
+	bpComparison = 40 // =, <>, <, >, <=, >=, != + IS, IN, BETWEEN, LIKE
+	bpAdd        = 50 // +, -, ||
+	bpMul        = 60 // *, /, %
+	bpUnary      = 70 // unary -, +
+	bpPostfix    = 80 // ::, COLLATE, OVER
+	bpAccess     = 90 // :, [], .
+)
+
+// ---------------------------------------------------------------------------
+// Core Pratt loop
+// ---------------------------------------------------------------------------
+
+// parseExpr is the entry point for expression parsing. It parses an
+// expression using Pratt parsing / precedence climbing.
+func (p *Parser) parseExpr() (ast.Node, error) {
+	return p.parseExprPrec(bpNone + 1)
+}
+
+// parseExprPrec parses an expression with the given minimum binding power.
+func (p *Parser) parseExprPrec(minBP int) (ast.Node, error) {
+	left, err := p.parsePrefixExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		bp, op, special, ok := p.infixBindingPower()
+		if !ok || bp < minBP {
+			break
+		}
+
+		if special != "" {
+			switch special {
+			case "IS":
+				left, err = p.parseIsExpr(left)
+			case "BETWEEN":
+				left, err = p.parseBetweenExpr(left)
+			case "NOT_BETWEEN":
+				left, err = p.parseBetweenExpr(left)
+			case "IN":
+				left, err = p.parseInExpr(left)
+			case "NOT_IN":
+				left, err = p.parseInExpr(left)
+			case "LIKE":
+				left, err = p.parseLikeExpr(left, ast.LikeOpLike, false)
+			case "NOT_LIKE":
+				left, err = p.parseLikeExpr(left, ast.LikeOpLike, true)
+			case "ILIKE":
+				left, err = p.parseLikeExpr(left, ast.LikeOpILike, false)
+			case "NOT_ILIKE":
+				left, err = p.parseLikeExpr(left, ast.LikeOpILike, true)
+			case "RLIKE":
+				left, err = p.parseLikeExpr(left, ast.LikeOpRLike, false)
+			case "NOT_RLIKE":
+				left, err = p.parseLikeExpr(left, ast.LikeOpRLike, true)
+			case "REGEXP":
+				left, err = p.parseLikeExpr(left, ast.LikeOpRegexp, false)
+			case "NOT_REGEXP":
+				left, err = p.parseLikeExpr(left, ast.LikeOpRegexp, true)
+			case "DOUBLE_COLON":
+				left, err = p.parseCastPostfix(left)
+			case "COLLATE":
+				left, err = p.parseCollatePostfix(left)
+			case "OVER":
+				left, err = p.parseOverPostfix(left)
+			case "COLON_ACCESS":
+				left, err = p.parseColonAccess(left)
+			case "BRACKET_ACCESS":
+				left, err = p.parseBracketAccess(left)
+			case "DOT_ACCESS":
+				left, err = p.parseDotAccess(left)
+			}
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		// Regular binary operator: consume the operator, parse right side.
+		startLoc := p.cur.Loc
+		p.advance()
+		right, err := p.parseExprPrec(bp + 1)
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{
+			Op:    op,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: startLoc.Start, End: ast.NodeLoc(right).End},
+		}
+	}
+
+	return left, nil
+}
+
+// infixBindingPower returns (bp, op, special, ok) for the current token.
+// If special is non-empty, the caller must dispatch to the named handler
+// instead of building a BinaryExpr.
+func (p *Parser) infixBindingPower() (int, ast.BinaryOp, string, bool) {
+	switch p.cur.Type {
+	// Logical
+	case kwOR:
+		return bpOr, ast.BinOr, "", true
+	case kwAND:
+		return bpAnd, ast.BinAnd, "", true
+
+	// NOT as infix prefix for BETWEEN, IN, LIKE, ILIKE, RLIKE, REGEXP
+	case kwNOT:
+		next := p.peekNext()
+		switch next.Type {
+		case kwBETWEEN:
+			return bpComparison, 0, "NOT_BETWEEN", true
+		case kwIN:
+			return bpComparison, 0, "NOT_IN", true
+		case kwLIKE:
+			return bpComparison, 0, "NOT_LIKE", true
+		case kwILIKE:
+			return bpComparison, 0, "NOT_ILIKE", true
+		case kwRLIKE:
+			return bpComparison, 0, "NOT_RLIKE", true
+		default:
+			// Check for REGEXP via tokIdent
+			if next.Type == tokIdent && strings.ToUpper(next.Str) == "REGEXP" {
+				return bpComparison, 0, "NOT_REGEXP", true
+			}
+		}
+		return 0, 0, "", false
+
+	// Comparison operators
+	case '=':
+		return bpComparison, ast.BinEq, "", true
+	case tokNotEq:
+		return bpComparison, ast.BinNe, "", true
+	case '<':
+		return bpComparison, ast.BinLt, "", true
+	case '>':
+		return bpComparison, ast.BinGt, "", true
+	case tokLessEq:
+		return bpComparison, ast.BinLe, "", true
+	case tokGreaterEq:
+		return bpComparison, ast.BinGe, "", true
+	case kwIS:
+		return bpComparison, 0, "IS", true
+	case kwBETWEEN:
+		return bpComparison, 0, "BETWEEN", true
+	case kwIN:
+		return bpComparison, 0, "IN", true
+	case kwLIKE:
+		return bpComparison, 0, "LIKE", true
+	case kwILIKE:
+		return bpComparison, 0, "ILIKE", true
+	case kwRLIKE:
+		return bpComparison, 0, "RLIKE", true
+
+	// Arithmetic
+	case '+':
+		return bpAdd, ast.BinAdd, "", true
+	case '-':
+		return bpAdd, ast.BinSub, "", true
+	case tokConcat:
+		return bpAdd, ast.BinConcat, "", true
+	case '*':
+		return bpMul, ast.BinMul, "", true
+	case '/':
+		return bpMul, ast.BinDiv, "", true
+	case '%':
+		return bpMul, ast.BinMod, "", true
+
+	// Postfix: :: cast
+	case tokDoubleColon:
+		return bpPostfix, 0, "DOUBLE_COLON", true
+
+	// Postfix: COLLATE
+	case kwCOLLATE:
+		return bpPostfix, 0, "COLLATE", true
+
+	// Postfix: OVER
+	case kwOVER:
+		return bpPostfix, 0, "OVER", true
+
+	// Access: : (JSON path)
+	case ':':
+		return bpAccess, 0, "COLON_ACCESS", true
+
+	// Access: [ (array subscript)
+	case '[':
+		return bpAccess, 0, "BRACKET_ACCESS", true
+
+	// Access: . (dot path) — only for semi-structured chaining after :/[]
+	case '.':
+		// Dot access is tricky: we only want to treat . as an access operator
+		// when the left side is an AccessExpr (semi-structured chaining).
+		// Otherwise . is not an infix expression operator (it's handled in
+		// identifier parsing for column refs).
+		return bpAccess, 0, "DOT_ACCESS", true
+	}
+
+	// Check for REGEXP via tokIdent (not a keyword in F2)
+	if p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "REGEXP" {
+		return bpComparison, 0, "REGEXP", true
+	}
+
+	return 0, 0, "", false
+}
+
+// ---------------------------------------------------------------------------
+// Prefix dispatch
+// ---------------------------------------------------------------------------
+
+// parsePrefixExpr handles prefix unary operators (-, +, NOT) and delegates
+// everything else to parsePrimaryExpr.
+func (p *Parser) parsePrefixExpr() (ast.Node, error) {
+	switch p.cur.Type {
+	case '-':
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryMinus,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case '+':
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryPlus,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case kwNOT:
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpNot)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryNot,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case kwEXISTS:
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "EXISTS subquery expressions not yet supported",
+		}
+
+	default:
+		return p.parsePrimaryExpr()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primary expression dispatch
+// ---------------------------------------------------------------------------
+
+// parsePrimaryExpr parses atomic expressions: literals, identifiers,
+// function calls, parenthesized expressions, CASE, CAST, IFF, array/JSON
+// literals, and lambda expressions.
+func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
+	switch p.cur.Type {
+	case tokInt:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitInt,
+			Value: tok.Str,
+			Ival:  tok.Ival,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokFloat, tokReal:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitFloat,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokString:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitString,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case kwTRUE:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitBool,
+			Value: tok.Str,
+			Bval:  true,
+			Loc:   tok.Loc,
+		}, nil
+
+	case kwFALSE:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitBool,
+			Value: tok.Str,
+			Bval:  false,
+			Loc:   tok.Loc,
+		}, nil
+
+	case kwNULL:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitNull,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case '(':
+		return p.parseParenExpr()
+
+	case kwCASE:
+		return p.parseCaseExpr()
+
+	case kwCAST:
+		return p.parseCastExpr()
+
+	case kwTRY_CAST:
+		return p.parseTryCastExpr()
+
+	case kwIFF:
+		return p.parseIffExpr()
+
+	case '[':
+		return p.parseArrayLiteral()
+
+	case '{':
+		return p.parseJsonLiteral()
+
+	case '*':
+		tok := p.advance()
+		return &ast.StarExpr{Loc: tok.Loc}, nil
+
+	default:
+		// Lambda detection: single ident followed by ->
+		if p.isIdentToken() && p.peekNext().Type == tokArrow {
+			return p.parseLambdaExpr()
+		}
+
+		// Identifier-based: column ref or function call
+		if p.isIdentToken() {
+			return p.parseIdentExpr()
+		}
+
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// isIdentToken reports whether the current token is usable as an identifier
+// in expression context: tokIdent, tokQuotedIdent, or a non-reserved keyword.
+func (p *Parser) isIdentToken() bool {
+	switch p.cur.Type {
+	case tokIdent, tokQuotedIdent:
+		return true
+	}
+	return p.cur.Type >= 700 && !keywordReserved[p.cur.Type]
+}
+
+// ---------------------------------------------------------------------------
+// Primary expression helpers
+// ---------------------------------------------------------------------------
+
+// parseIdentExpr parses an identifier that could be a column ref, function
+// call, or a multi-part dotted name followed by function call/star.
+func (p *Parser) parseIdentExpr() (ast.Node, error) {
+	first, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for function call: name(
+	if p.cur.Type == '(' {
+		objName := ast.ObjectName{Name: first, Loc: first.Loc}
+		return p.parseFuncCall(objName, first.Loc)
+	}
+
+	// Check for qualified name: name.name or name.name.name
+	if p.cur.Type == '.' {
+		// Could be schema.table.column or table.column or table.*
+		// But be careful: dot access for semi-structured data is handled in
+		// the infix loop (DOT_ACCESS). Here we only handle standard SQL
+		// dotted column references.
+		return p.parseDottedIdentOrFunc(first)
+	}
+
+	// Simple column ref (1 part).
+	return &ast.ColumnRef{
+		Parts: []ast.Ident{first},
+		Loc:   first.Loc,
+	}, nil
+}
+
+// parseDottedIdentOrFunc handles dotted names after the first ident.
+// Returns a ColumnRef, StarExpr, or FuncCallExpr depending on what follows.
+func (p *Parser) parseDottedIdentOrFunc(first ast.Ident) (ast.Node, error) {
+	parts := []ast.Ident{first}
+
+	for p.cur.Type == '.' {
+		p.advance() // consume '.'
+
+		// table.*
+		if p.cur.Type == '*' {
+			starTok := p.advance()
+			var qualifier *ast.ObjectName
+			switch len(parts) {
+			case 1:
+				qualifier = &ast.ObjectName{
+					Name: parts[0],
+					Loc:  parts[0].Loc,
+				}
+			case 2:
+				qualifier = &ast.ObjectName{
+					Schema: parts[0],
+					Name:   parts[1],
+					Loc:    ast.Loc{Start: parts[0].Loc.Start, End: parts[1].Loc.End},
+				}
+			case 3:
+				qualifier = &ast.ObjectName{
+					Database: parts[0],
+					Schema:   parts[1],
+					Name:     parts[2],
+					Loc:      ast.Loc{Start: parts[0].Loc.Start, End: parts[2].Loc.End},
+				}
+			}
+			return &ast.StarExpr{
+				Qualifier: qualifier,
+				Loc:       ast.Loc{Start: first.Loc.Start, End: starTok.Loc.End},
+			}, nil
+		}
+
+		ident, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, ident)
+
+		// Check for function call: schema.func(
+		if p.cur.Type == '(' {
+			var objName ast.ObjectName
+			switch len(parts) {
+			case 2:
+				objName = ast.ObjectName{
+					Schema: parts[0],
+					Name:   parts[1],
+					Loc:    ast.Loc{Start: parts[0].Loc.Start, End: parts[1].Loc.End},
+				}
+			case 3:
+				objName = ast.ObjectName{
+					Database: parts[0],
+					Schema:   parts[1],
+					Name:     parts[2],
+					Loc:      ast.Loc{Start: parts[0].Loc.Start, End: parts[2].Loc.End},
+				}
+			default:
+				objName = ast.ObjectName{
+					Name: parts[len(parts)-1],
+					Loc:  parts[len(parts)-1].Loc,
+				}
+			}
+			return p.parseFuncCall(objName, ast.Loc{Start: first.Loc.Start})
+		}
+
+		if len(parts) >= 4 {
+			break // max 4 parts for column ref
+		}
+	}
+
+	return &ast.ColumnRef{
+		Parts: parts,
+		Loc:   ast.Loc{Start: parts[0].Loc.Start, End: parts[len(parts)-1].Loc.End},
+	}, nil
+}
+
+// parseFuncCall parses a function call starting after the opening '('.
+// The name and startLoc identify the function name and its starting position.
+func (p *Parser) parseFuncCall(name ast.ObjectName, startLoc ast.Loc) (*ast.FuncCallExpr, error) {
+	p.advance() // consume '('
+
+	funcName := strings.ToUpper(name.Name.Name)
+	fc := &ast.FuncCallExpr{
+		Name: name,
+		Loc:  ast.Loc{Start: startLoc.Start},
+	}
+
+	// COUNT(*) special handling
+	if funcName == "COUNT" && p.cur.Type == '*' {
+		p.advance()
+		fc.Star = true
+		closeTok, err := p.expect(')')
+		if err != nil {
+			return nil, err
+		}
+		fc.Loc.End = closeTok.Loc.End
+		return fc, nil
+	}
+
+	// DISTINCT handling for aggregates like COUNT(DISTINCT x)
+	if p.cur.Type == kwDISTINCT {
+		p.advance()
+		fc.Distinct = true
+	}
+
+	// TRIM special handling: TRIM( expr ) or TRIM( LEADING|TRAILING|BOTH expr FROM expr )
+	// We parse TRIM as a regular function call with arguments.
+
+	if p.cur.Type != ')' {
+		args, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		fc.Args = args
+	}
+
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	fc.Loc.End = closeTok.Loc.End
+
+	// Check for WITHIN GROUP (ORDER BY ...)
+	if p.cur.Type == kwWITHIN {
+		p.advance() // consume WITHIN
+		if _, err := p.expect(kwGROUP); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwORDER); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		orderItems, err := p.parseOrderByList()
+		if err != nil {
+			return nil, err
+		}
+		fc.OrderBy = orderItems
+		closeOrd, err := p.expect(')')
+		if err != nil {
+			return nil, err
+		}
+		fc.Loc.End = closeOrd.Loc.End
+	}
+
+	return fc, nil
+}
+
+// parseParenExpr parses a parenthesized expression. If it encounters
+// SELECT or WITH after the open paren, it returns an error placeholder
+// for subquery support.
+func (p *Parser) parseParenExpr() (ast.Node, error) {
+	openTok := p.advance() // consume '('
+
+	// Subquery placeholder
+	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "subquery expressions not yet supported",
+		}
+	}
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.ParenExpr{
+		Expr: expr,
+		Loc:  ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseCaseExpr parses a CASE expression (simple or searched).
+func (p *Parser) parseCaseExpr() (*ast.CaseExpr, error) {
+	caseTok := p.advance() // consume CASE
+
+	ce := &ast.CaseExpr{
+		Loc: ast.Loc{Start: caseTok.Loc.Start},
+	}
+
+	// Determine if this is a simple CASE (CASE expr WHEN ...) or
+	// searched CASE (CASE WHEN ...).
+	if p.cur.Type != kwWHEN {
+		// Simple CASE: parse the operand expression.
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Kind = ast.CaseSimple
+		ce.Operand = operand
+	} else {
+		ce.Kind = ast.CaseSearched
+	}
+
+	// Parse WHEN clauses.
+	for p.cur.Type == kwWHEN {
+		whenTok := p.advance() // consume WHEN
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		result, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Whens = append(ce.Whens, &ast.WhenClause{
+			Cond:   cond,
+			Result: result,
+			Loc:    ast.Loc{Start: whenTok.Loc.Start, End: ast.NodeLoc(result).End},
+		})
+	}
+
+	if len(ce.Whens) == 0 {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected WHEN in CASE expression",
+		}
+	}
+
+	// Optional ELSE.
+	if p.cur.Type == kwELSE {
+		p.advance() // consume ELSE
+		elseExpr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Else = elseExpr
+	}
+
+	endTok, err := p.expect(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	ce.Loc.End = endTok.Loc.End
+
+	return ce, nil
+}
+
+// parseCastExpr parses CAST( expr AS type ).
+func (p *Parser) parseCastExpr() (*ast.CastExpr, error) {
+	castTok := p.advance() // consume CAST
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	typeName, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CastExpr{
+		Expr:     expr,
+		TypeName: typeName,
+		Loc:      ast.Loc{Start: castTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseTryCastExpr parses TRY_CAST( expr AS type ).
+func (p *Parser) parseTryCastExpr() (*ast.CastExpr, error) {
+	castTok := p.advance() // consume TRY_CAST
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	typeName, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CastExpr{
+		Expr:     expr,
+		TypeName: typeName,
+		TryCast:  true,
+		Loc:      ast.Loc{Start: castTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseIffExpr parses IFF( cond, then, else ).
+func (p *Parser) parseIffExpr() (*ast.IffExpr, error) {
+	iffTok := p.advance() // consume IFF
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+	thenExpr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+	elseExpr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	return &ast.IffExpr{
+		Cond: cond,
+		Then: thenExpr,
+		Else: elseExpr,
+		Loc:  ast.Loc{Start: iffTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseArrayLiteral parses [ elem, elem, ... ].
+func (p *Parser) parseArrayLiteral() (*ast.ArrayLiteralExpr, error) {
+	openTok := p.advance() // consume '['
+
+	arr := &ast.ArrayLiteralExpr{
+		Loc: ast.Loc{Start: openTok.Loc.Start},
+	}
+
+	if p.cur.Type != ']' {
+		elems, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		arr.Elements = elems
+	}
+
+	closeTok, err := p.expect(']')
+	if err != nil {
+		return nil, err
+	}
+	arr.Loc.End = closeTok.Loc.End
+
+	return arr, nil
+}
+
+// parseJsonLiteral parses { key: value, key: value, ... }.
+// Keys can be quoted strings or identifiers.
+func (p *Parser) parseJsonLiteral() (*ast.JsonLiteralExpr, error) {
+	openTok := p.advance() // consume '{'
+
+	jl := &ast.JsonLiteralExpr{
+		Loc: ast.Loc{Start: openTok.Loc.Start},
+	}
+
+	if p.cur.Type != '}' {
+		for {
+			pairLoc := p.cur.Loc
+			var key string
+			if p.cur.Type == tokString {
+				tok := p.advance()
+				key = tok.Str
+			} else if p.isIdentToken() {
+				tok := p.advance()
+				key = tok.Str
+			} else {
+				return nil, &ParseError{
+					Loc: p.cur.Loc,
+					Msg: "expected string or identifier key in JSON literal",
+				}
+			}
+
+			if _, err := p.expect(':'); err != nil {
+				return nil, err
+			}
+
+			val, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+
+			jl.Pairs = append(jl.Pairs, ast.KeyValuePair{
+				Key:   key,
+				Value: val,
+				Loc:   ast.Loc{Start: pairLoc.Start, End: ast.NodeLoc(val).End},
+			})
+
+			if p.cur.Type != ',' {
+				break
+			}
+			p.advance() // consume ','
+		}
+	}
+
+	closeTok, err := p.expect('}')
+	if err != nil {
+		return nil, err
+	}
+	jl.Loc.End = closeTok.Loc.End
+
+	return jl, nil
+}
+
+// parseLambdaExpr parses a lambda expression: x -> body or (x, y) -> body.
+// Called when we know the current token is an ident followed by ->.
+func (p *Parser) parseLambdaExpr() (*ast.LambdaExpr, error) {
+	startLoc := p.cur.Loc
+
+	ident, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	params := []ast.Ident{ident}
+
+	// Consume ->
+	if _, err := p.expect(tokArrow); err != nil {
+		return nil, err
+	}
+
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.LambdaExpr{
+		Params: params,
+		Body:   body,
+		Loc:    ast.Loc{Start: startLoc.Start, End: ast.NodeLoc(body).End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Infix/postfix handlers
+// ---------------------------------------------------------------------------
+
+// parseIsExpr parses IS [NOT] NULL or IS [NOT] DISTINCT FROM expr.
+func (p *Parser) parseIsExpr(left ast.Node) (ast.Node, error) {
+	p.advance() // consume IS
+
+	notFlag := false
+	if p.cur.Type == kwNOT {
+		p.advance()
+		notFlag = true
+	}
+
+	// IS [NOT] DISTINCT FROM expr
+	if p.cur.Type == kwDISTINCT {
+		p.advance() // consume DISTINCT
+		if _, err := p.expect(kwFROM); err != nil {
+			return nil, err
+		}
+		right, err := p.parseExprPrec(bpComparison + 1)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.IsExpr{
+			Expr:         left,
+			Not:          notFlag,
+			Null:         false,
+			DistinctFrom: right,
+			Loc:          ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(right).End},
+		}, nil
+	}
+
+	// IS [NOT] NULL
+	if p.cur.Type != kwNULL {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected NULL or DISTINCT after IS [NOT]",
+		}
+	}
+	nullTok := p.advance()
+
+	return &ast.IsExpr{
+		Expr: left,
+		Not:  notFlag,
+		Null: true,
+		Loc:  ast.Loc{Start: ast.NodeLoc(left).Start, End: nullTok.Loc.End},
+	}, nil
+}
+
+// parseBetweenExpr parses [NOT] BETWEEN low AND high.
+func (p *Parser) parseBetweenExpr(left ast.Node) (ast.Node, error) {
+	notFlag := false
+	if p.cur.Type == kwNOT {
+		p.advance() // consume NOT
+		notFlag = true
+	}
+
+	p.advance() // consume BETWEEN
+
+	// Parse low bound at bpComparison+1 to avoid re-consuming AND as an
+	// infix binary operator.
+	low, err := p.parseExprPrec(bpComparison + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwAND); err != nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected AND in BETWEEN expression",
+		}
+	}
+
+	high, err := p.parseExprPrec(bpComparison + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.BetweenExpr{
+		Expr: left,
+		Low:  low,
+		High: high,
+		Not:  notFlag,
+		Loc:  ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(high).End},
+	}, nil
+}
+
+// parseInExpr parses [NOT] IN ( values ).
+func (p *Parser) parseInExpr(left ast.Node) (ast.Node, error) {
+	notFlag := false
+	if p.cur.Type == kwNOT {
+		p.advance() // consume NOT
+		notFlag = true
+	}
+
+	p.advance() // consume IN
+
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	// Subquery placeholder
+	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "subquery expressions not yet supported",
+		}
+	}
+
+	values, err := p.parseExprList()
+	if err != nil {
+		return nil, err
+	}
+
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.InExpr{
+		Expr:   left,
+		Values: values,
+		Not:    notFlag,
+		Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseLikeExpr parses [NOT] LIKE/ILIKE/RLIKE/REGEXP pattern [ESCAPE esc]
+// or LIKE ANY (...). The NOT has already been consumed if present (notFlag=true).
+// The likeOp and notFlag are determined by the caller (infixBindingPower).
+func (p *Parser) parseLikeExpr(left ast.Node, likeOp ast.LikeOp, notFlag bool) (ast.Node, error) {
+	// If we have NOT, it was recognized in infixBindingPower; need to
+	// consume it here if present.
+	if notFlag && p.cur.Type == kwNOT {
+		p.advance() // consume NOT
+	}
+
+	// Consume the LIKE/ILIKE/RLIKE keyword (or REGEXP ident).
+	if p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "REGEXP" {
+		p.advance()
+	} else {
+		p.advance() // consume kwLIKE, kwILIKE, kwRLIKE
+	}
+
+	// LIKE ANY (...)
+	if likeOp == ast.LikeOpLike && p.cur.Type == kwANY {
+		p.advance() // consume ANY
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		values, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(')')
+		if err != nil {
+			return nil, err
+		}
+		return &ast.LikeExpr{
+			Expr:      left,
+			Op:        likeOp,
+			Not:       notFlag,
+			Any:       true,
+			AnyValues: values,
+			Loc:       ast.Loc{Start: ast.NodeLoc(left).Start, End: closeTok.Loc.End},
+		}, nil
+	}
+
+	// ILIKE ANY (...)
+	if likeOp == ast.LikeOpILike && p.cur.Type == kwANY {
+		p.advance() // consume ANY
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		values, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(')')
+		if err != nil {
+			return nil, err
+		}
+		return &ast.LikeExpr{
+			Expr:      left,
+			Op:        likeOp,
+			Not:       notFlag,
+			Any:       true,
+			AnyValues: values,
+			Loc:       ast.Loc{Start: ast.NodeLoc(left).Start, End: closeTok.Loc.End},
+		}, nil
+	}
+
+	// Regular LIKE/ILIKE/RLIKE/REGEXP pattern
+	pattern, err := p.parseExprPrec(bpComparison + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	le := &ast.LikeExpr{
+		Expr:    left,
+		Pattern: pattern,
+		Op:      likeOp,
+		Not:     notFlag,
+		Loc:     ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(pattern).End},
+	}
+
+	// Optional ESCAPE clause (only for LIKE and ILIKE)
+	if p.cur.Type == kwESCAPE {
+		p.advance() // consume ESCAPE
+		escExpr, err := p.parseExprPrec(bpComparison + 1)
+		if err != nil {
+			return nil, err
+		}
+		le.Escape = escExpr
+		le.Loc.End = ast.NodeLoc(escExpr).End
+	}
+
+	return le, nil
+}
+
+// parseCastPostfix parses the :: type cast postfix operator.
+func (p *Parser) parseCastPostfix(left ast.Node) (ast.Node, error) {
+	p.advance() // consume ::
+
+	typeName, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.CastExpr{
+		Expr:       left,
+		TypeName:   typeName,
+		ColonColon: true,
+		Loc:        ast.Loc{Start: ast.NodeLoc(left).Start, End: typeName.Loc.End},
+	}, nil
+}
+
+// parseCollatePostfix parses COLLATE collation_name.
+func (p *Parser) parseCollatePostfix(left ast.Node) (ast.Node, error) {
+	p.advance() // consume COLLATE
+
+	// Collation can be a string literal or an identifier.
+	var collation string
+	switch p.cur.Type {
+	case tokString:
+		tok := p.advance()
+		collation = tok.Str
+		return &ast.CollateExpr{
+			Expr:      left,
+			Collation: collation,
+			Loc:       ast.Loc{Start: ast.NodeLoc(left).Start, End: tok.Loc.End},
+		}, nil
+	default:
+		ident, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		collation = ident.Name
+		return &ast.CollateExpr{
+			Expr:      left,
+			Collation: collation,
+			Loc:       ast.Loc{Start: ast.NodeLoc(left).Start, End: ident.Loc.End},
+		}, nil
+	}
+}
+
+// parseOverPostfix parses OVER ( window_spec ) and attaches it to the
+// preceding function call.
+func (p *Parser) parseOverPostfix(left ast.Node) (ast.Node, error) {
+	fc, ok := left.(*ast.FuncCallExpr)
+	if !ok {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "OVER can only follow a function call",
+		}
+	}
+
+	p.advance() // consume OVER
+
+	ws, err := p.parseOverClause()
+	if err != nil {
+		return nil, err
+	}
+	fc.Over = ws
+	fc.Loc.End = ws.Loc.End
+
+	return fc, nil
+}
+
+// parseOverClause parses ( PARTITION BY ... ORDER BY ... frame ).
+func (p *Parser) parseOverClause() (*ast.WindowSpec, error) {
+	openTok, err := p.expect('(')
+	if err != nil {
+		return nil, err
+	}
+
+	ws := &ast.WindowSpec{
+		Loc: ast.Loc{Start: openTok.Loc.Start},
+	}
+
+	// PARTITION BY
+	if p.cur.Type == kwPARTITION {
+		p.advance() // consume PARTITION
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		parts, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		ws.PartitionBy = parts
+	}
+
+	// ORDER BY
+	if p.cur.Type == kwORDER {
+		p.advance() // consume ORDER
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		orderItems, err := p.parseOrderByList()
+		if err != nil {
+			return nil, err
+		}
+		ws.OrderBy = orderItems
+	}
+
+	// Window frame: ROWS | RANGE | GROUPS
+	if p.cur.Type == kwROWS || p.isFrameKeyword() {
+		frame, err := p.parseWindowFrame()
+		if err != nil {
+			return nil, err
+		}
+		ws.Frame = frame
+	}
+
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	ws.Loc.End = closeTok.Loc.End
+
+	return ws, nil
+}
+
+// isFrameKeyword checks if the current token is RANGE or GROUPS. Since
+// RANGE is not a keyword in F2, we check by ident comparison. GROUPS is
+// a keyword (kwGROUPS). ROWS is also a keyword (kwROWS).
+func (p *Parser) isFrameKeyword() bool {
+	if p.cur.Type == kwGROUPS {
+		return true
+	}
+	if p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "RANGE" {
+		return true
+	}
+	return false
+}
+
+// parseWindowFrame parses ROWS|RANGE|GROUPS BETWEEN start AND end.
+func (p *Parser) parseWindowFrame() (*ast.WindowFrame, error) {
+	startLoc := p.cur.Loc
+
+	var kind ast.WindowFrameKind
+	switch {
+	case p.cur.Type == kwROWS:
+		kind = ast.FrameRows
+		p.advance()
+	case p.cur.Type == kwGROUPS:
+		kind = ast.FrameGroups
+		p.advance()
+	case p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "RANGE":
+		kind = ast.FrameRange
+		p.advance()
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	frame := &ast.WindowFrame{
+		Kind: kind,
+		Loc:  ast.Loc{Start: startLoc.Start},
+	}
+
+	// BETWEEN start AND end
+	if p.cur.Type == kwBETWEEN {
+		p.advance() // consume BETWEEN
+
+		startBound, err := p.parseWindowBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.Start = startBound
+
+		if _, err := p.expect(kwAND); err != nil {
+			return nil, err
+		}
+
+		endBound, err := p.parseWindowBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.End = endBound
+		frame.Loc.End = p.prev.Loc.End
+	} else {
+		// Single bound (no BETWEEN): just the start bound
+		startBound, err := p.parseWindowBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.Start = startBound
+		frame.Loc.End = p.prev.Loc.End
+	}
+
+	return frame, nil
+}
+
+// parseWindowBound parses one window frame bound:
+//   - UNBOUNDED PRECEDING
+//   - UNBOUNDED FOLLOWING
+//   - CURRENT ROW
+//   - N PRECEDING
+//   - N FOLLOWING
+func (p *Parser) parseWindowBound() (ast.WindowBound, error) {
+	// UNBOUNDED PRECEDING / UNBOUNDED FOLLOWING
+	if p.isUnbounded() {
+		p.advance() // consume UNBOUNDED
+
+		if p.isPreceding() {
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundUnboundedPreceding}, nil
+		}
+		if p.isFollowing() {
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundUnboundedFollowing}, nil
+		}
+		return ast.WindowBound{}, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected PRECEDING or FOLLOWING after UNBOUNDED",
+		}
+	}
+
+	// CURRENT ROW
+	if p.cur.Type == kwCURRENT {
+		p.advance() // consume CURRENT
+		if p.cur.Type == kwROW {
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundCurrentRow}, nil
+		}
+		return ast.WindowBound{}, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected ROW after CURRENT",
+		}
+	}
+
+	// N PRECEDING / N FOLLOWING
+	offset, err := p.parseExprPrec(bpComparison + 1)
+	if err != nil {
+		return ast.WindowBound{}, err
+	}
+
+	if p.isPreceding() {
+		p.advance()
+		return ast.WindowBound{Kind: ast.BoundPreceding, Offset: offset}, nil
+	}
+	if p.isFollowing() {
+		p.advance()
+		return ast.WindowBound{Kind: ast.BoundFollowing, Offset: offset}, nil
+	}
+
+	return ast.WindowBound{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "expected PRECEDING or FOLLOWING",
+	}
+}
+
+// isUnbounded checks if the current token is the UNBOUNDED keyword.
+// UNBOUNDED is not in F2's keyword table, so we check via tokIdent.
+func (p *Parser) isUnbounded() bool {
+	return p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "UNBOUNDED"
+}
+
+// isPreceding checks if the current token is the PRECEDING keyword.
+// PRECEDING is not in F2's keyword table, so we check via tokIdent.
+func (p *Parser) isPreceding() bool {
+	return p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "PRECEDING"
+}
+
+// isFollowing checks if the current token is the FOLLOWING keyword.
+// FOLLOWING is not in F2's keyword table, so we check via tokIdent.
+func (p *Parser) isFollowing() bool {
+	return p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "FOLLOWING"
+}
+
+// ---------------------------------------------------------------------------
+// Access operators
+// ---------------------------------------------------------------------------
+
+// parseColonAccess parses : field (JSON path access).
+func (p *Parser) parseColonAccess(left ast.Node) (ast.Node, error) {
+	p.advance() // consume ':'
+
+	ident, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.AccessExpr{
+		Expr:  left,
+		Kind:  ast.AccessColon,
+		Field: ident,
+		Loc:   ast.Loc{Start: ast.NodeLoc(left).Start, End: ident.Loc.End},
+	}, nil
+}
+
+// parseBracketAccess parses [ index ] (array subscript).
+func (p *Parser) parseBracketAccess(left ast.Node) (ast.Node, error) {
+	p.advance() // consume '['
+
+	idx, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	closeTok, err := p.expect(']')
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.AccessExpr{
+		Expr:  left,
+		Kind:  ast.AccessBracket,
+		Index: idx,
+		Loc:   ast.Loc{Start: ast.NodeLoc(left).Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseDotAccess parses .field (dot path chaining for semi-structured data).
+func (p *Parser) parseDotAccess(left ast.Node) (ast.Node, error) {
+	p.advance() // consume '.'
+
+	// In dot access context, allow '$' prefix identifiers and general identifiers.
+	ident, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.AccessExpr{
+		Expr:  left,
+		Kind:  ast.AccessDot,
+		Field: ident,
+		Loc:   ast.Loc{Start: ast.NodeLoc(left).Start, End: ident.Loc.End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+// parseExprList parses a comma-separated list of expressions.
+func (p *Parser) parseExprList() ([]ast.Node, error) {
+	var exprs []ast.Node
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	exprs = append(exprs, expr)
+
+	for p.cur.Type == ',' {
+		p.advance() // consume ','
+		expr, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+
+	return exprs, nil
+}
+
+// parseOrderByList parses ORDER BY items: expr [ASC|DESC] [NULLS FIRST|LAST].
+func (p *Parser) parseOrderByList() ([]*ast.OrderItem, error) {
+	var items []*ast.OrderItem
+
+	for {
+		item, err := p.parseOrderItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+	}
+
+	return items, nil
+}
+
+// parseOrderItem parses a single ORDER BY item.
+func (p *Parser) parseOrderItem() (*ast.OrderItem, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	item := &ast.OrderItem{
+		Expr: expr,
+		Loc:  ast.NodeLoc(expr),
+	}
+
+	// ASC / DESC
+	if p.cur.Type == kwASC {
+		p.advance()
+		item.Desc = false
+		item.Loc.End = p.prev.Loc.End
+	} else if p.cur.Type == kwDESC {
+		p.advance()
+		item.Desc = true
+		item.Loc.End = p.prev.Loc.End
+	}
+
+	// NULLS FIRST / NULLS LAST
+	if p.cur.Type == kwNULLS {
+		p.advance() // consume NULLS
+		if p.cur.Type == kwFIRST {
+			p.advance()
+			nf := true
+			item.NullsFirst = &nf
+			item.Loc.End = p.prev.Loc.End
+		} else if p.cur.Type == kwLAST {
+			p.advance()
+			nf := false
+			item.NullsFirst = &nf
+			item.Loc.End = p.prev.Loc.End
+		} else {
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "expected FIRST or LAST after NULLS",
+			}
+		}
+	}
+
+	return item, nil
+}
+
+// ---------------------------------------------------------------------------
+// Public helper
+// ---------------------------------------------------------------------------
+
+// ParseExpr parses an expression from a standalone string. Returns the
+// parsed AST node and any errors. Useful for tests and callers that have
+// an expression string but not a token stream.
+func ParseExpr(input string) (ast.Node, []ParseError) {
+	p := &Parser{
+		lexer: NewLexer(input),
+		input: input,
+	}
+	p.advance()
+
+	node, err := p.parseExpr()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+
+	if p.cur.Type != tokEOF {
+		return node, []ParseError{{
+			Loc: p.cur.Loc,
+			Msg: "unexpected token after expression: " + tokenDesc(p.cur),
+		}}
+	}
+
+	return node, nil
+}
+
+// tokenDesc returns a human-readable description of a token for error messages.
+func tokenDesc(tok Token) string {
+	if tok.Str != "" {
+		return strconv.Quote(tok.Str)
+	}
+	return TokenName(tok.Type)
+}

--- a/snowflake/parser/expr_test.go
+++ b/snowflake/parser/expr_test.go
@@ -1,0 +1,1510 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseExpr constructs a Parser from input and calls parseExpr.
+func testParseExpr(input string) (ast.Node, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p.parseExpr()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Literals
+// ---------------------------------------------------------------------------
+
+func TestExpr_Literals(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantKind ast.LiteralKind
+		wantIval int64
+		wantBval bool
+	}{
+		{"42", ast.LitInt, 42, false},
+		{"0", ast.LitInt, 0, false},
+		{"3.14", ast.LitFloat, 0, false},
+		{"TRUE", ast.LitBool, 0, true},
+		{"FALSE", ast.LitBool, 0, false},
+		{"NULL", ast.LitNull, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node, err := testParseExpr(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			lit, ok := node.(*ast.Literal)
+			if !ok {
+				t.Fatalf("expected *ast.Literal, got %T", node)
+			}
+			if lit.Kind != tt.wantKind {
+				t.Errorf("Kind = %v, want %v", lit.Kind, tt.wantKind)
+			}
+			if tt.wantKind == ast.LitInt && lit.Ival != tt.wantIval {
+				t.Errorf("Ival = %d, want %d", lit.Ival, tt.wantIval)
+			}
+			if tt.wantKind == ast.LitBool && lit.Bval != tt.wantBval {
+				t.Errorf("Bval = %v, want %v", lit.Bval, tt.wantBval)
+			}
+		})
+	}
+}
+
+func TestExpr_StringLiteral(t *testing.T) {
+	node, err := testParseExpr("'hello'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitString {
+		t.Errorf("Kind = %v, want LitString", lit.Kind)
+	}
+	if lit.Value != "hello" {
+		t.Errorf("Value = %q, want %q", lit.Value, "hello")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Column refs
+// ---------------------------------------------------------------------------
+
+func TestExpr_ColumnRef(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantParts int
+	}{
+		{"col", 1},
+		{"t.col", 2},
+		{"s.t.col", 3},
+		{"db.s.t.col", 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node, err := testParseExpr(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cr, ok := node.(*ast.ColumnRef)
+			if !ok {
+				t.Fatalf("expected *ast.ColumnRef, got %T", node)
+			}
+			if len(cr.Parts) != tt.wantParts {
+				t.Errorf("len(Parts) = %d, want %d", len(cr.Parts), tt.wantParts)
+			}
+		})
+	}
+}
+
+func TestExpr_QuotedColumnRef(t *testing.T) {
+	node, err := testParseExpr(`"My Column"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cr, ok := node.(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("expected *ast.ColumnRef, got %T", node)
+	}
+	if len(cr.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(cr.Parts))
+	}
+	if cr.Parts[0].Name != "My Column" {
+		t.Errorf("Name = %q, want %q", cr.Parts[0].Name, "My Column")
+	}
+	if !cr.Parts[0].Quoted {
+		t.Error("expected Quoted = true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Star
+// ---------------------------------------------------------------------------
+
+func TestExpr_Star(t *testing.T) {
+	node, err := testParseExpr("*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	star, ok := node.(*ast.StarExpr)
+	if !ok {
+		t.Fatalf("expected *ast.StarExpr, got %T", node)
+	}
+	if star.Qualifier != nil {
+		t.Error("expected nil Qualifier for bare *")
+	}
+}
+
+func TestExpr_QualifiedStar(t *testing.T) {
+	node, err := testParseExpr("t.*")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	star, ok := node.(*ast.StarExpr)
+	if !ok {
+		t.Fatalf("expected *ast.StarExpr, got %T", node)
+	}
+	if star.Qualifier == nil {
+		t.Fatal("expected non-nil Qualifier")
+	}
+	if star.Qualifier.Name.Name != "t" {
+		t.Errorf("Qualifier.Name = %q, want %q", star.Qualifier.Name.Name, "t")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Arithmetic precedence
+// ---------------------------------------------------------------------------
+
+func TestExpr_ArithmeticPrecedence(t *testing.T) {
+	// 1 + 2 * 3 should produce BinaryExpr(+, Literal(1), BinaryExpr(*, Literal(2), Literal(3)))
+	node, err := testParseExpr("1 + 2 * 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	add, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if add.Op != ast.BinAdd {
+		t.Errorf("Op = %v, want BinAdd", add.Op)
+	}
+
+	// Left should be Literal(1)
+	left, ok := add.Left.(*ast.Literal)
+	if !ok {
+		t.Fatalf("left: expected *ast.Literal, got %T", add.Left)
+	}
+	if left.Ival != 1 {
+		t.Errorf("left.Ival = %d, want 1", left.Ival)
+	}
+
+	// Right should be BinaryExpr(*, 2, 3)
+	mul, ok := add.Right.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("right: expected *ast.BinaryExpr, got %T", add.Right)
+	}
+	if mul.Op != ast.BinMul {
+		t.Errorf("right.Op = %v, want BinMul", mul.Op)
+	}
+	right2, _ := mul.Left.(*ast.Literal)
+	right3, _ := mul.Right.(*ast.Literal)
+	if right2 == nil || right2.Ival != 2 {
+		t.Errorf("right.Left = %v, want Literal(2)", mul.Left)
+	}
+	if right3 == nil || right3.Ival != 3 {
+		t.Errorf("right.Right = %v, want Literal(3)", mul.Right)
+	}
+}
+
+func TestExpr_ArithmeticLeftAssociativity(t *testing.T) {
+	// 1 - 2 - 3 should produce BinaryExpr(-, BinaryExpr(-, 1, 2), 3)
+	node, err := testParseExpr("1 - 2 - 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outer, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if outer.Op != ast.BinSub {
+		t.Errorf("Op = %v, want BinSub", outer.Op)
+	}
+	inner, ok := outer.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("left: expected *ast.BinaryExpr, got %T", outer.Left)
+	}
+	if inner.Op != ast.BinSub {
+		t.Errorf("inner.Op = %v, want BinSub", inner.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Parenthesized expressions
+// ---------------------------------------------------------------------------
+
+func TestExpr_ParenExpr(t *testing.T) {
+	// (1 + 2) * 3 should produce BinaryExpr(*, ParenExpr(BinaryExpr(+, 1, 2)), 3)
+	node, err := testParseExpr("(1 + 2) * 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mul, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if mul.Op != ast.BinMul {
+		t.Errorf("Op = %v, want BinMul", mul.Op)
+	}
+	paren, ok := mul.Left.(*ast.ParenExpr)
+	if !ok {
+		t.Fatalf("left: expected *ast.ParenExpr, got %T", mul.Left)
+	}
+	add, ok := paren.Expr.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("paren.Expr: expected *ast.BinaryExpr, got %T", paren.Expr)
+	}
+	if add.Op != ast.BinAdd {
+		t.Errorf("paren.Expr.Op = %v, want BinAdd", add.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Comparison operators
+// ---------------------------------------------------------------------------
+
+func TestExpr_Comparison(t *testing.T) {
+	tests := []struct {
+		input  string
+		wantOp ast.BinaryOp
+	}{
+		{"a = b", ast.BinEq},
+		{"a <> b", ast.BinNe},
+		{"a != b", ast.BinNe},
+		{"a < b", ast.BinLt},
+		{"a > b", ast.BinGt},
+		{"a <= b", ast.BinLe},
+		{"a >= b", ast.BinGe},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node, err := testParseExpr(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			binExpr, ok := node.(*ast.BinaryExpr)
+			if !ok {
+				t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+			}
+			if binExpr.Op != tt.wantOp {
+				t.Errorf("Op = %v, want %v", binExpr.Op, tt.wantOp)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. Logical operators
+// ---------------------------------------------------------------------------
+
+func TestExpr_LogicalPrecedence(t *testing.T) {
+	// a AND b OR c => BinaryExpr(OR, BinaryExpr(AND, a, b), c)
+	node, err := testParseExpr("a AND b OR c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	orExpr, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if orExpr.Op != ast.BinOr {
+		t.Errorf("top Op = %v, want BinOr", orExpr.Op)
+	}
+	andExpr, ok := orExpr.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("left: expected *ast.BinaryExpr, got %T", orExpr.Left)
+	}
+	if andExpr.Op != ast.BinAnd {
+		t.Errorf("left.Op = %v, want BinAnd", andExpr.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. NOT prefix
+// ---------------------------------------------------------------------------
+
+func TestExpr_NotPrefix(t *testing.T) {
+	node, err := testParseExpr("NOT a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	unary, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if unary.Op != ast.UnaryNot {
+		t.Errorf("Op = %v, want UnaryNot", unary.Op)
+	}
+}
+
+func TestExpr_NotNotPrefix(t *testing.T) {
+	node, err := testParseExpr("NOT NOT a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outer, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if outer.Op != ast.UnaryNot {
+		t.Errorf("Op = %v, want UnaryNot", outer.Op)
+	}
+	inner, ok := outer.Expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("inner: expected *ast.UnaryExpr, got %T", outer.Expr)
+	}
+	if inner.Op != ast.UnaryNot {
+		t.Errorf("inner.Op = %v, want UnaryNot", inner.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. Unary minus and plus
+// ---------------------------------------------------------------------------
+
+func TestExpr_UnaryMinus(t *testing.T) {
+	node, err := testParseExpr("-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	unary, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if unary.Op != ast.UnaryMinus {
+		t.Errorf("Op = %v, want UnaryMinus", unary.Op)
+	}
+}
+
+func TestExpr_UnaryPlus(t *testing.T) {
+	node, err := testParseExpr("+a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	unary, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if unary.Op != ast.UnaryPlus {
+		t.Errorf("Op = %v, want UnaryPlus", unary.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 10. Concat
+// ---------------------------------------------------------------------------
+
+func TestExpr_Concat(t *testing.T) {
+	// a || b || c => left-assoc: BinaryExpr(||, BinaryExpr(||, a, b), c)
+	node, err := testParseExpr("a || b || c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outer, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if outer.Op != ast.BinConcat {
+		t.Errorf("Op = %v, want BinConcat", outer.Op)
+	}
+	inner, ok := outer.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("left: expected *ast.BinaryExpr, got %T", outer.Left)
+	}
+	if inner.Op != ast.BinConcat {
+		t.Errorf("inner.Op = %v, want BinConcat", inner.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 11. CAST / TRY_CAST / ::
+// ---------------------------------------------------------------------------
+
+func TestExpr_Cast(t *testing.T) {
+	node, err := testParseExpr("CAST(x AS INT)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if cast.TryCast {
+		t.Error("TryCast should be false for CAST")
+	}
+	if cast.ColonColon {
+		t.Error("ColonColon should be false for CAST")
+	}
+	if cast.TypeName.Kind != ast.TypeInt {
+		t.Errorf("TypeName.Kind = %v, want TypeInt", cast.TypeName.Kind)
+	}
+}
+
+func TestExpr_TryCast(t *testing.T) {
+	node, err := testParseExpr("TRY_CAST(x AS VARCHAR(100))")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if !cast.TryCast {
+		t.Error("TryCast should be true for TRY_CAST")
+	}
+	if cast.TypeName.Kind != ast.TypeVarchar {
+		t.Errorf("TypeName.Kind = %v, want TypeVarchar", cast.TypeName.Kind)
+	}
+}
+
+func TestExpr_ColonColonCast(t *testing.T) {
+	node, err := testParseExpr("x::INT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if !cast.ColonColon {
+		t.Error("ColonColon should be true for ::")
+	}
+	if cast.TypeName.Kind != ast.TypeInt {
+		t.Errorf("TypeName.Kind = %v, want TypeInt", cast.TypeName.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 12. CASE simple
+// ---------------------------------------------------------------------------
+
+func TestExpr_CaseSimple(t *testing.T) {
+	node, err := testParseExpr("CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce, ok := node.(*ast.CaseExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CaseExpr, got %T", node)
+	}
+	if ce.Kind != ast.CaseSimple {
+		t.Errorf("Kind = %v, want CaseSimple", ce.Kind)
+	}
+	if ce.Operand == nil {
+		t.Error("Operand should be non-nil for simple CASE")
+	}
+	if len(ce.Whens) != 2 {
+		t.Errorf("len(Whens) = %d, want 2", len(ce.Whens))
+	}
+	if ce.Else == nil {
+		t.Error("Else should be non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 13. CASE searched
+// ---------------------------------------------------------------------------
+
+func TestExpr_CaseSearched(t *testing.T) {
+	node, err := testParseExpr("CASE WHEN x > 0 THEN 'pos' ELSE 'neg' END")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce, ok := node.(*ast.CaseExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CaseExpr, got %T", node)
+	}
+	if ce.Kind != ast.CaseSearched {
+		t.Errorf("Kind = %v, want CaseSearched", ce.Kind)
+	}
+	if ce.Operand != nil {
+		t.Error("Operand should be nil for searched CASE")
+	}
+	if len(ce.Whens) != 1 {
+		t.Errorf("len(Whens) = %d, want 1", len(ce.Whens))
+	}
+}
+
+func TestExpr_CaseNoElse(t *testing.T) {
+	node, err := testParseExpr("CASE WHEN x > 0 THEN 'pos' END")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ce, ok := node.(*ast.CaseExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CaseExpr, got %T", node)
+	}
+	if ce.Else != nil {
+		t.Error("Else should be nil when absent")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 14. IFF
+// ---------------------------------------------------------------------------
+
+func TestExpr_Iff(t *testing.T) {
+	node, err := testParseExpr("IFF(x > 0, 'pos', 'neg')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	iff, ok := node.(*ast.IffExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IffExpr, got %T", node)
+	}
+	if iff.Cond == nil || iff.Then == nil || iff.Else == nil {
+		t.Error("Cond, Then, Else must all be non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 15. IS NULL / IS NOT NULL / IS DISTINCT FROM / IS NOT DISTINCT FROM
+// ---------------------------------------------------------------------------
+
+func TestExpr_IsNull(t *testing.T) {
+	node, err := testParseExpr("x IS NULL")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if is.Not {
+		t.Error("Not should be false")
+	}
+	if !is.Null {
+		t.Error("Null should be true")
+	}
+}
+
+func TestExpr_IsNotNull(t *testing.T) {
+	node, err := testParseExpr("x IS NOT NULL")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if !is.Not {
+		t.Error("Not should be true")
+	}
+	if !is.Null {
+		t.Error("Null should be true")
+	}
+}
+
+func TestExpr_IsDistinctFrom(t *testing.T) {
+	node, err := testParseExpr("x IS DISTINCT FROM y")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if is.Not {
+		t.Error("Not should be false")
+	}
+	if is.Null {
+		t.Error("Null should be false for DISTINCT FROM")
+	}
+	if is.DistinctFrom == nil {
+		t.Error("DistinctFrom should be non-nil")
+	}
+}
+
+func TestExpr_IsNotDistinctFrom(t *testing.T) {
+	node, err := testParseExpr("x IS NOT DISTINCT FROM y")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if !is.Not {
+		t.Error("Not should be true")
+	}
+	if is.Null {
+		t.Error("Null should be false for DISTINCT FROM")
+	}
+	if is.DistinctFrom == nil {
+		t.Error("DistinctFrom should be non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 16. BETWEEN / NOT BETWEEN
+// ---------------------------------------------------------------------------
+
+func TestExpr_Between(t *testing.T) {
+	node, err := testParseExpr("x BETWEEN 1 AND 10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	be, ok := node.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T", node)
+	}
+	if be.Not {
+		t.Error("Not should be false")
+	}
+	if be.Low == nil || be.High == nil {
+		t.Error("Low and High must be non-nil")
+	}
+}
+
+func TestExpr_NotBetween(t *testing.T) {
+	node, err := testParseExpr("x NOT BETWEEN 1 AND 10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	be, ok := node.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T", node)
+	}
+	if !be.Not {
+		t.Error("Not should be true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 17. IN / NOT IN
+// ---------------------------------------------------------------------------
+
+func TestExpr_In(t *testing.T) {
+	node, err := testParseExpr("x IN (1, 2, 3)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	in, ok := node.(*ast.InExpr)
+	if !ok {
+		t.Fatalf("expected *ast.InExpr, got %T", node)
+	}
+	if in.Not {
+		t.Error("Not should be false")
+	}
+	if len(in.Values) != 3 {
+		t.Errorf("len(Values) = %d, want 3", len(in.Values))
+	}
+}
+
+func TestExpr_NotIn(t *testing.T) {
+	node, err := testParseExpr("x NOT IN (1, 2, 3)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	in, ok := node.(*ast.InExpr)
+	if !ok {
+		t.Fatalf("expected *ast.InExpr, got %T", node)
+	}
+	if !in.Not {
+		t.Error("Not should be true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 18. LIKE / ILIKE / RLIKE / REGEXP / LIKE ANY / ESCAPE
+// ---------------------------------------------------------------------------
+
+func TestExpr_Like(t *testing.T) {
+	node, err := testParseExpr("x LIKE 'pat%'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpLike {
+		t.Errorf("Op = %v, want LikeOpLike", le.Op)
+	}
+	if le.Not {
+		t.Error("Not should be false")
+	}
+	if le.Any {
+		t.Error("Any should be false")
+	}
+}
+
+func TestExpr_NotLike(t *testing.T) {
+	node, err := testParseExpr("x NOT LIKE 'pat%'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if !le.Not {
+		t.Error("Not should be true")
+	}
+}
+
+func TestExpr_ILike(t *testing.T) {
+	node, err := testParseExpr("x ILIKE '%pat%'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpILike {
+		t.Errorf("Op = %v, want LikeOpILike", le.Op)
+	}
+}
+
+func TestExpr_RLike(t *testing.T) {
+	node, err := testParseExpr("x RLIKE '.*'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpRLike {
+		t.Errorf("Op = %v, want LikeOpRLike", le.Op)
+	}
+}
+
+func TestExpr_LikeEscape(t *testing.T) {
+	node, err := testParseExpr("x LIKE '%' ESCAPE '#'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Escape == nil {
+		t.Error("Escape should be non-nil")
+	}
+}
+
+func TestExpr_LikeAny(t *testing.T) {
+	node, err := testParseExpr("x LIKE ANY ('a%', 'b%')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if !le.Any {
+		t.Error("Any should be true")
+	}
+	if len(le.AnyValues) != 2 {
+		t.Errorf("len(AnyValues) = %d, want 2", len(le.AnyValues))
+	}
+}
+
+func TestExpr_ILikeAny(t *testing.T) {
+	node, err := testParseExpr("x ILIKE ANY ('a%', 'b%')")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpILike {
+		t.Errorf("Op = %v, want LikeOpILike", le.Op)
+	}
+	if !le.Any {
+		t.Error("Any should be true")
+	}
+}
+
+func TestExpr_Regexp(t *testing.T) {
+	node, err := testParseExpr("x REGEXP '.*'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpRegexp {
+		t.Errorf("Op = %v, want LikeOpRegexp", le.Op)
+	}
+}
+
+func TestExpr_NotRegexp(t *testing.T) {
+	node, err := testParseExpr("x NOT REGEXP '.*'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpRegexp {
+		t.Errorf("Op = %v, want LikeOpRegexp", le.Op)
+	}
+	if !le.Not {
+		t.Error("Not should be true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 19. Function calls
+// ---------------------------------------------------------------------------
+
+func TestExpr_FuncCallNoArgs(t *testing.T) {
+	node, err := testParseExpr("f()")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Name.Name.Name != "f" {
+		t.Errorf("Name = %q, want %q", fc.Name.Name.Name, "f")
+	}
+	if len(fc.Args) != 0 {
+		t.Errorf("len(Args) = %d, want 0", len(fc.Args))
+	}
+}
+
+func TestExpr_FuncCallWithArgs(t *testing.T) {
+	node, err := testParseExpr("f(1, 2)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 2 {
+		t.Errorf("len(Args) = %d, want 2", len(fc.Args))
+	}
+}
+
+func TestExpr_CountStar(t *testing.T) {
+	node, err := testParseExpr("COUNT(*)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if !fc.Star {
+		t.Error("Star should be true for COUNT(*)")
+	}
+}
+
+func TestExpr_CountDistinct(t *testing.T) {
+	node, err := testParseExpr("COUNT(DISTINCT x)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if !fc.Distinct {
+		t.Error("Distinct should be true")
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("len(Args) = %d, want 1", len(fc.Args))
+	}
+}
+
+func TestExpr_TrimFunc(t *testing.T) {
+	node, err := testParseExpr("TRIM(x)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("len(Args) = %d, want 1", len(fc.Args))
+	}
+}
+
+func TestExpr_QualifiedFunc(t *testing.T) {
+	node, err := testParseExpr("my_schema.my_func(1)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Name.Schema.Name != "my_schema" {
+		t.Errorf("Schema = %q, want %q", fc.Name.Schema.Name, "my_schema")
+	}
+	if fc.Name.Name.Name != "my_func" {
+		t.Errorf("Name = %q, want %q", fc.Name.Name.Name, "my_func")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 20. Window functions
+// ---------------------------------------------------------------------------
+
+func TestExpr_WindowRowNumber(t *testing.T) {
+	node, err := testParseExpr("ROW_NUMBER() OVER (PARTITION BY a ORDER BY b)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Over == nil {
+		t.Fatal("Over should be non-nil for window function")
+	}
+	if len(fc.Over.PartitionBy) != 1 {
+		t.Errorf("len(PartitionBy) = %d, want 1", len(fc.Over.PartitionBy))
+	}
+	if len(fc.Over.OrderBy) != 1 {
+		t.Errorf("len(OrderBy) = %d, want 1", len(fc.Over.OrderBy))
+	}
+}
+
+func TestExpr_WindowWithFrame(t *testing.T) {
+	node, err := testParseExpr("SUM(x) OVER (ORDER BY y ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Over == nil {
+		t.Fatal("Over should be non-nil")
+	}
+	if fc.Over.Frame == nil {
+		t.Fatal("Frame should be non-nil")
+	}
+	if fc.Over.Frame.Kind != ast.FrameRows {
+		t.Errorf("Frame.Kind = %v, want FrameRows", fc.Over.Frame.Kind)
+	}
+	if fc.Over.Frame.Start.Kind != ast.BoundUnboundedPreceding {
+		t.Errorf("Frame.Start.Kind = %v, want BoundUnboundedPreceding", fc.Over.Frame.Start.Kind)
+	}
+	if fc.Over.Frame.End.Kind != ast.BoundCurrentRow {
+		t.Errorf("Frame.End.Kind = %v, want BoundCurrentRow", fc.Over.Frame.End.Kind)
+	}
+}
+
+func TestExpr_WindowRangeFrame(t *testing.T) {
+	node, err := testParseExpr("SUM(x) OVER (ORDER BY y RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Over.Frame.Kind != ast.FrameRange {
+		t.Errorf("Frame.Kind = %v, want FrameRange", fc.Over.Frame.Kind)
+	}
+	if fc.Over.Frame.Start.Kind != ast.BoundPreceding {
+		t.Errorf("Frame.Start.Kind = %v, want BoundPreceding", fc.Over.Frame.Start.Kind)
+	}
+	if fc.Over.Frame.End.Kind != ast.BoundFollowing {
+		t.Errorf("Frame.End.Kind = %v, want BoundFollowing", fc.Over.Frame.End.Kind)
+	}
+}
+
+func TestExpr_WindowGroupsFrame(t *testing.T) {
+	node, err := testParseExpr("SUM(x) OVER (ORDER BY y GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Over.Frame.Kind != ast.FrameGroups {
+		t.Errorf("Frame.Kind = %v, want FrameGroups", fc.Over.Frame.Kind)
+	}
+	if fc.Over.Frame.Start.Kind != ast.BoundCurrentRow {
+		t.Errorf("Frame.Start.Kind = %v, want BoundCurrentRow", fc.Over.Frame.Start.Kind)
+	}
+	if fc.Over.Frame.End.Kind != ast.BoundUnboundedFollowing {
+		t.Errorf("Frame.End.Kind = %v, want BoundUnboundedFollowing", fc.Over.Frame.End.Kind)
+	}
+}
+
+func TestExpr_WindowOrderByNulls(t *testing.T) {
+	node, err := testParseExpr("RANK() OVER (ORDER BY a DESC NULLS LAST)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Over == nil {
+		t.Fatal("Over should be non-nil")
+	}
+	if len(fc.Over.OrderBy) != 1 {
+		t.Fatalf("len(OrderBy) = %d, want 1", len(fc.Over.OrderBy))
+	}
+	item := fc.Over.OrderBy[0]
+	if !item.Desc {
+		t.Error("Desc should be true")
+	}
+	if item.NullsFirst == nil {
+		t.Fatal("NullsFirst should be non-nil")
+	}
+	if *item.NullsFirst {
+		t.Error("NullsFirst should be false (NULLS LAST)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 21. JSON access / Array access / Dot access
+// ---------------------------------------------------------------------------
+
+func TestExpr_ColonAccess(t *testing.T) {
+	node, err := testParseExpr("v:field")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acc, ok := node.(*ast.AccessExpr)
+	if !ok {
+		t.Fatalf("expected *ast.AccessExpr, got %T", node)
+	}
+	if acc.Kind != ast.AccessColon {
+		t.Errorf("Kind = %v, want AccessColon", acc.Kind)
+	}
+	if acc.Field.Name != "field" {
+		t.Errorf("Field.Name = %q, want %q", acc.Field.Name, "field")
+	}
+}
+
+func TestExpr_BracketAccess(t *testing.T) {
+	node, err := testParseExpr("v[0]")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acc, ok := node.(*ast.AccessExpr)
+	if !ok {
+		t.Fatalf("expected *ast.AccessExpr, got %T", node)
+	}
+	if acc.Kind != ast.AccessBracket {
+		t.Errorf("Kind = %v, want AccessBracket", acc.Kind)
+	}
+	if acc.Index == nil {
+		t.Error("Index should be non-nil")
+	}
+}
+
+func TestExpr_ChainedAccess(t *testing.T) {
+	// v:field.subfield should parse as AccessExpr(Dot, AccessExpr(Colon, v, field), subfield)
+	node, err := testParseExpr("v:field.subfield")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dot, ok := node.(*ast.AccessExpr)
+	if !ok {
+		t.Fatalf("expected *ast.AccessExpr, got %T", node)
+	}
+	if dot.Kind != ast.AccessDot {
+		t.Errorf("Kind = %v, want AccessDot", dot.Kind)
+	}
+	if dot.Field.Name != "subfield" {
+		t.Errorf("Field.Name = %q, want %q", dot.Field.Name, "subfield")
+	}
+	inner, ok := dot.Expr.(*ast.AccessExpr)
+	if !ok {
+		t.Fatalf("inner: expected *ast.AccessExpr, got %T", dot.Expr)
+	}
+	if inner.Kind != ast.AccessColon {
+		t.Errorf("inner.Kind = %v, want AccessColon", inner.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 22. Array literal / JSON literal
+// ---------------------------------------------------------------------------
+
+func TestExpr_ArrayLiteral(t *testing.T) {
+	node, err := testParseExpr("[1, 2, 3]")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arr, ok := node.(*ast.ArrayLiteralExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ArrayLiteralExpr, got %T", node)
+	}
+	if len(arr.Elements) != 3 {
+		t.Errorf("len(Elements) = %d, want 3", len(arr.Elements))
+	}
+}
+
+func TestExpr_EmptyArrayLiteral(t *testing.T) {
+	node, err := testParseExpr("[]")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arr, ok := node.(*ast.ArrayLiteralExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ArrayLiteralExpr, got %T", node)
+	}
+	if len(arr.Elements) != 0 {
+		t.Errorf("len(Elements) = %d, want 0", len(arr.Elements))
+	}
+}
+
+func TestExpr_JsonLiteral(t *testing.T) {
+	node, err := testParseExpr("{'key': 'val'}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	jl, ok := node.(*ast.JsonLiteralExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JsonLiteralExpr, got %T", node)
+	}
+	if len(jl.Pairs) != 1 {
+		t.Fatalf("len(Pairs) = %d, want 1", len(jl.Pairs))
+	}
+	if jl.Pairs[0].Key != "key" {
+		t.Errorf("Key = %q, want %q", jl.Pairs[0].Key, "key")
+	}
+}
+
+func TestExpr_JsonLiteralMultiPair(t *testing.T) {
+	node, err := testParseExpr("{'a': 1, 'b': 2}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	jl, ok := node.(*ast.JsonLiteralExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JsonLiteralExpr, got %T", node)
+	}
+	if len(jl.Pairs) != 2 {
+		t.Errorf("len(Pairs) = %d, want 2", len(jl.Pairs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 23. Lambda expressions
+// ---------------------------------------------------------------------------
+
+func TestExpr_Lambda(t *testing.T) {
+	node, err := testParseExpr("x -> x + 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lam, ok := node.(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LambdaExpr, got %T", node)
+	}
+	if len(lam.Params) != 1 {
+		t.Errorf("len(Params) = %d, want 1", len(lam.Params))
+	}
+	if lam.Params[0].Name != "x" {
+		t.Errorf("Params[0].Name = %q, want %q", lam.Params[0].Name, "x")
+	}
+	if lam.Body == nil {
+		t.Error("Body should be non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 24. Nested expressions
+// ---------------------------------------------------------------------------
+
+func TestExpr_NestedCastIff(t *testing.T) {
+	node, err := testParseExpr("CAST(IFF(a > b, a, b) AS INT)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	_, ok = cast.Expr.(*ast.IffExpr)
+	if !ok {
+		t.Fatalf("cast.Expr: expected *ast.IffExpr, got %T", cast.Expr)
+	}
+}
+
+func TestExpr_NestedFuncCalls(t *testing.T) {
+	node, err := testParseExpr("f(g(x))")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outer, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(outer.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(outer.Args))
+	}
+	inner, ok := outer.Args[0].(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("inner: expected *ast.FuncCallExpr, got %T", outer.Args[0])
+	}
+	if inner.Name.Name.Name != "g" {
+		t.Errorf("inner.Name = %q, want %q", inner.Name.Name.Name, "g")
+	}
+}
+
+func TestExpr_CastPostfixPrecedence(t *testing.T) {
+	// a + b * c :: INT
+	// :: binds tighter than + and *, so this is: a + (b * (c :: INT))
+	// Actually :: is bpPostfix (80) > bpMul (60) > bpAdd (50)
+	// So: a + (b * (c::INT))
+	node, err := testParseExpr("a + b * c :: INT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	add, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if add.Op != ast.BinAdd {
+		t.Errorf("Op = %v, want BinAdd", add.Op)
+	}
+	mul, ok := add.Right.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("right: expected *ast.BinaryExpr, got %T", add.Right)
+	}
+	if mul.Op != ast.BinMul {
+		t.Errorf("right.Op = %v, want BinMul", mul.Op)
+	}
+	_, ok = mul.Right.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("mul.Right: expected *ast.CastExpr, got %T", mul.Right)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 25. COLLATE
+// ---------------------------------------------------------------------------
+
+func TestExpr_Collate(t *testing.T) {
+	node, err := testParseExpr("x COLLATE utf8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	col, ok := node.(*ast.CollateExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CollateExpr, got %T", node)
+	}
+	if col.Collation != "utf8" {
+		t.Errorf("Collation = %q, want %q", col.Collation, "utf8")
+	}
+}
+
+func TestExpr_CollateString(t *testing.T) {
+	node, err := testParseExpr("x COLLATE 'en_US'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	col, ok := node.(*ast.CollateExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CollateExpr, got %T", node)
+	}
+	if col.Collation != "en_US" {
+		t.Errorf("Collation = %q, want %q", col.Collation, "en_US")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 26. Error cases
+// ---------------------------------------------------------------------------
+
+func TestExpr_Error_UnclosedParen(t *testing.T) {
+	_, err := testParseExpr("(1 + 2")
+	if err == nil {
+		t.Fatal("expected error for unclosed paren")
+	}
+}
+
+func TestExpr_Error_MissingThenInCase(t *testing.T) {
+	_, err := testParseExpr("CASE WHEN x > 0 ELSE 'neg' END")
+	if err == nil {
+		t.Fatal("expected error for missing THEN in CASE")
+	}
+}
+
+func TestExpr_Error_UnterminatedBetween(t *testing.T) {
+	_, err := testParseExpr("x BETWEEN 1")
+	if err == nil {
+		t.Fatal("expected error for unterminated BETWEEN")
+	}
+}
+
+func TestExpr_Error_SubqueryNotSupported(t *testing.T) {
+	_, err := testParseExpr("(SELECT 1)")
+	if err == nil {
+		t.Fatal("expected error for subquery")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.Msg != "subquery expressions not yet supported" {
+		t.Errorf("Msg = %q, want subquery error", pe.Msg)
+	}
+}
+
+func TestExpr_Error_ExistsNotSupported(t *testing.T) {
+	_, err := testParseExpr("EXISTS (SELECT 1)")
+	if err == nil {
+		t.Fatal("expected error for EXISTS")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.Msg != "EXISTS subquery expressions not yet supported" {
+		t.Errorf("Msg = %q, want EXISTS error", pe.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseExpr public helper
+// ---------------------------------------------------------------------------
+
+func TestParseExpr_Public(t *testing.T) {
+	node, errs := ParseExpr("1 + 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	_, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+}
+
+func TestParseExpr_TrailingToken(t *testing.T) {
+	_, errs := ParseExpr("1 + 2 extra")
+	if len(errs) == 0 {
+		t.Fatal("expected error for trailing token")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WITHIN GROUP support
+// ---------------------------------------------------------------------------
+
+func TestExpr_WithinGroup(t *testing.T) {
+	node, err := testParseExpr("LISTAGG(x, ',') WITHIN GROUP (ORDER BY y)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.OrderBy) != 1 {
+		t.Errorf("len(OrderBy) = %d, want 1 for WITHIN GROUP", len(fc.OrderBy))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional edge cases
+// ---------------------------------------------------------------------------
+
+func TestExpr_ModOperator(t *testing.T) {
+	node, err := testParseExpr("10 % 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinMod {
+		t.Errorf("Op = %v, want BinMod", bin.Op)
+	}
+}
+
+func TestExpr_DivOperator(t *testing.T) {
+	node, err := testParseExpr("10 / 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinDiv {
+		t.Errorf("Op = %v, want BinDiv", bin.Op)
+	}
+}
+
+func TestExpr_NotILike(t *testing.T) {
+	node, err := testParseExpr("x NOT ILIKE '%foo%'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpILike {
+		t.Errorf("Op = %v, want LikeOpILike", le.Op)
+	}
+	if !le.Not {
+		t.Error("Not should be true")
+	}
+}
+
+func TestExpr_NotRLike(t *testing.T) {
+	node, err := testParseExpr("x NOT RLIKE '.*'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	le, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if le.Op != ast.LikeOpRLike {
+		t.Errorf("Op = %v, want LikeOpRLike", le.Op)
+	}
+	if !le.Not {
+		t.Error("Not should be true")
+	}
+}
+
+func TestExpr_MultipleColonCast(t *testing.T) {
+	// x::INT::VARCHAR should parse as CastExpr(CastExpr(x, INT), VARCHAR)
+	node, err := testParseExpr("x::INT::VARCHAR")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outer, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if outer.TypeName.Kind != ast.TypeVarchar {
+		t.Errorf("outer TypeName.Kind = %v, want TypeVarchar", outer.TypeName.Kind)
+	}
+	inner, ok := outer.Expr.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("inner: expected *ast.CastExpr, got %T", outer.Expr)
+	}
+	if inner.TypeName.Kind != ast.TypeInt {
+		t.Errorf("inner TypeName.Kind = %v, want TypeInt", inner.TypeName.Kind)
+	}
+}
+
+func TestExpr_WindowSingleBound(t *testing.T) {
+	// Window frame with single bound (no BETWEEN)
+	node, err := testParseExpr("SUM(x) OVER (ORDER BY y ROWS UNBOUNDED PRECEDING)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Over == nil || fc.Over.Frame == nil {
+		t.Fatal("expected frame")
+	}
+	if fc.Over.Frame.Start.Kind != ast.BoundUnboundedPreceding {
+		t.Errorf("Start.Kind = %v, want BoundUnboundedPreceding", fc.Over.Frame.Start.Kind)
+	}
+}


### PR DESCRIPTION
## Summary

Third Tier 1 node and the biggest single PR in the snowflake parser migration (BYT-9000): a complete Pratt (precedence climbing) expression parser covering all 25 alternatives from the legacy grammar's `expr` rule. **3,708 insertions** across 7 files.

Depends on T1.2 data types (PR #39) and T1.1 identifiers (PR #22). Unblocks T1.4 (SELECT core) and every downstream node that needs expression parsing.

## Highlights

- **1,567 LOC** Pratt parser in `snowflake/parser/expr.go`
- **22 AST node types** + 5 helper types + 8 enums in `snowflake/ast`
- **1,510 LOC** tests with 78 individual test cases across 24+ categories
- **18 walker cases, 31 child fields** after regeneration
- **Window frame** support included (ROWS/RANGE/GROUPS BETWEEN ... AND ...)

## Expression forms covered

Literals, column refs (1-4 part), star, arithmetic (+,-,*,/,%), comparison (=,<>,<,>,<=,>=,!=), logical (AND, OR, NOT), string concat (||), unary (-, +, NOT), parenthesized, CAST/TRY_CAST/:: cast, CASE (simple + searched), IFF, IS [NOT] NULL, IS [NOT] DISTINCT FROM, BETWEEN, IN, LIKE/ILIKE/RLIKE/REGEXP + LIKE ANY, function calls (generic + COUNT(*) + DISTINCT + WITHIN GROUP), window functions with OVER (PARTITION BY + ORDER BY + frame), JSON/array/dot access (:, [], .), array/JSON literals, lambda (x -> expr), COLLATE.

Subqueries and EXISTS are placeholder errors pending T1.4 (SELECT core).

## Test plan

- [ ] CI green on `snowflake/ast/` and `snowflake/parser/`
- [ ] Walker regen: 18 cases, 31 child fields, byte-identical
- [ ] Precedence: `1 + 2 * 3` parses as `+(1, *(2, 3))`
- [ ] Window frame: `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` parses correctly
- [ ] :: cast chains: `x::INT::VARCHAR` parses as nested CastExpr

🤖 Generated with [Claude Code](https://claude.com/claude-code)