### PR TITLE
feat(doris): hand-written lexer with 531 keywords (F2)

### DIFF
--- a/docs/superpowers/plans/2026-04-13-doris-lexer.md
+++ b/docs/superpowers/plans/2026-04-13-doris-lexer.md
@@ -1,0 +1,1169 @@
+# Doris Lexer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a hand-written lexer for Doris SQL that tokenizes all 522 keywords, identifiers, literals, operators, comments, and hints per the DorisLexer.g4 grammar.
+
+**Architecture:** Character-by-character state machine following snowflake/parser/lexer.go patterns. Single dispatch function routes to specialized scanners (string, number, identifier, operator). Keywords recognized via case-insensitive map lookup. Errors accumulated for best-effort recovery.
+
+**Tech Stack:** Go 1.25, module `github.com/bytebase/omni`, depends on `doris/ast` (Loc type)
+
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer` (branch `feat/doris/lexer`)
+
+---
+
+## File Structure
+
+| File | Responsibility | ~LOC |
+|------|----------------|------|
+| `doris/parser/tokens.go` | Token struct, TokenKind type, sentinel/literal/operator constants, LexError type | ~120 |
+| `doris/parser/keywords.go` | 522 keyword constants (kw*), keywordMap, nonReservedKeywords, KeywordToken(), IsReserved(), TokenName() | ~2100 |
+| `doris/parser/lexer.go` | Lexer struct, NewLexer, NextToken, Tokenize, Errors, all scan* helpers | ~550 |
+| `doris/parser/lexer_test.go` | Unit tests covering all token categories | ~500 |
+
+---
+
+### Task 1: Create `doris/parser/tokens.go`
+
+**Files:**
+- Create: `doris/parser/tokens.go`
+
+- [ ] **Step 1: Create the file**
+
+```go
+package parser
+
+import "github.com/bytebase/omni/doris/ast"
+
+// Special tokens.
+const (
+	tokEOF     = 0
+	tokInvalid = 1 // error-recovery token; always accompanied by a LexError
+)
+
+// TokenKind identifies a token type. Single-character operators and
+// punctuation use their ASCII byte value directly as their TokenKind
+// (e.g., ';' = 59, '(' = 40). Named constants below cover multi-char
+// operators, literals, and keywords.
+type TokenKind = int
+
+// Multi-character operators (500-599).
+const (
+	tokLessEq      = 500 + iota // <=
+	tokGreaterEq                // >=
+	tokNotEq                    // <> or !=
+	tokNullSafeEq               // <=>
+	tokLogicalAnd               // &&
+	tokDoublePipes              // ||
+	tokShiftLeft                // <<
+	tokShiftRight               // >>
+	tokArrow                    // ->
+	tokDoubleAt                 // @@
+	tokAssign                   // :=
+	tokDotDotDot                // ...
+	tokHintStart                // /*+
+	tokHintEnd                  // */ (only emitted after a hint-start)
+)
+
+// Literal tokens (600-699).
+const (
+	tokInt         = 600 + iota // integer: 42, 0xFF, 0b101
+	tokFloat                    // decimal/exponent: 3.14, 1e10, 1.5e-10
+	tokString                   // single or double quoted string
+	tokIdent                    // unquoted identifier
+	tokQuotedIdent              // backtick-quoted identifier
+	tokHexLiteral               // X'...' or x'...'
+	tokBitLiteral               // B'...' or b'...'
+	tokPlaceholder              // ?
+)
+
+// Token represents a single lexical token.
+type Token struct {
+	Kind TokenKind // tok*/kw* constant or ASCII byte value
+	Str  string    // content for identifiers, strings, hints
+	Ival int64     // parsed integer value for tokInt
+	Loc  ast.Loc   // byte offset span in source
+}
+
+// LexError records a lexing error with its source position.
+type LexError struct {
+	Msg string
+	Loc ast.Loc
+}
+
+// Error messages.
+const (
+	errUnterminatedString  = "unterminated string literal"
+	errUnterminatedQuoted  = "unterminated backtick-quoted identifier"
+	errUnterminatedComment = "unterminated block comment"
+	errUnknownChar         = "unknown character"
+)
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go build ./doris/parser/...`
+
+Expected: May fail because package has only one file. That's fine.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add doris/parser/tokens.go
+git commit -m "feat(doris/parser): add Token, TokenKind, and LexError types"
+```
+
+---
+
+### Task 2: Create `doris/parser/keywords.go`
+
+**Files:**
+- Create: `doris/parser/keywords.go`
+
+This is the largest file (~2100 LOC). It contains:
+1. 522 keyword constants (kwACCOUNT_LOCK through kwYEAR) starting at 700
+2. A `keywordMap` mapping lowercase strings to keyword constants
+3. A `nonReservedKeywords` set (172 entries)
+4. Public lookup functions
+
+- [ ] **Step 1: Create the file with all 522 keywords**
+
+The keyword list must be extracted from `/Users/h3n4l/OpenSource/parser/doris/DorisLexer.g4`. The file structure is:
+
+```go
+package parser
+
+import "strings"
+
+// Keyword token constants. Values start at 700 and grow with iota.
+// Extracted from DorisLexer.g4 (522 keywords).
+// Numeric values are NOT stable — do not persist them.
+const (
+	kwACCOUNT_LOCK TokenKind = 700 + iota
+	kwACCOUNT_UNLOCK
+	kwACTIONS
+	kwADD
+	kwADMIN
+	kwAFTER
+	kwAGG_STATE
+	kwAGGREGATE
+	kwALIAS
+	kwALL
+	kwALTER
+	kwALWAYS
+	kwANALYZE
+	kwANALYZED
+	kwANALYZER
+	kwAND
+	kwANN
+	kwANTI
+	kwAPPEND
+	kwARRAY
+	kwAS
+	kwASC
+	kwAT
+	kwAUTHORS
+	kwAUTO
+	kwAUTO_INCREMENT
+	// ... all 522 keywords in alphabetical order through kwYEAR
+)
+```
+
+To build this file correctly, the implementer MUST:
+1. Read `/Users/h3n4l/OpenSource/parser/doris/DorisLexer.g4` to get the complete keyword list
+2. Generate all 522 `kw*` constants in alphabetical order starting at `700 + iota`
+3. Build the `keywordMap` with lowercase keys mapping to constants
+4. Build the `nonReservedKeywords` set from the `nonReserved` rule in `/Users/h3n4l/OpenSource/parser/doris/DorisParser.g4` (lines 1906-2257)
+5. Add public functions: `KeywordToken`, `IsReserved`, `TokenName`
+
+The public functions:
+
+```go
+// KeywordToken returns the keyword TokenKind for a name, or (0, false)
+// if name is not a keyword. Lookup is case-insensitive.
+func KeywordToken(name string) (TokenKind, bool) {
+	kind, ok := keywordMap[strings.ToLower(name)]
+	return kind, ok
+}
+
+// IsReserved reports whether kind is a reserved keyword that cannot be
+// used as an unquoted identifier.
+func IsReserved(kind TokenKind) bool {
+	return kind >= 700 && !nonReservedKeywords[kind]
+}
+
+// tokenNames is lazily initialized by TokenName.
+var tokenNames map[TokenKind]string
+
+// TokenName returns a human-readable name for a TokenKind.
+func TokenName(kind TokenKind) string {
+	if tokenNames == nil {
+		tokenNames = make(map[TokenKind]string, len(keywordMap)+20)
+		for name, kind := range keywordMap {
+			tokenNames[kind] = strings.ToUpper(name)
+		}
+		tokenNames[tokEOF] = "EOF"
+		tokenNames[tokInvalid] = "INVALID"
+		tokenNames[tokInt] = "INT"
+		tokenNames[tokFloat] = "FLOAT"
+		tokenNames[tokString] = "STRING"
+		tokenNames[tokIdent] = "IDENT"
+		tokenNames[tokQuotedIdent] = "QUOTED_IDENT"
+		tokenNames[tokHexLiteral] = "HEX_LITERAL"
+		tokenNames[tokBitLiteral] = "BIT_LITERAL"
+		tokenNames[tokPlaceholder] = "PLACEHOLDER"
+		tokenNames[tokLessEq] = "<="
+		tokenNames[tokGreaterEq] = ">="
+		tokenNames[tokNotEq] = "<>"
+		tokenNames[tokNullSafeEq] = "<=>"
+		tokenNames[tokLogicalAnd] = "&&"
+		tokenNames[tokDoublePipes] = "||"
+		tokenNames[tokShiftLeft] = "<<"
+		tokenNames[tokShiftRight] = ">>"
+		tokenNames[tokArrow] = "->"
+		tokenNames[tokDoubleAt] = "@@"
+		tokenNames[tokAssign] = ":="
+		tokenNames[tokDotDotDot] = "..."
+		tokenNames[tokHintStart] = "HINT_START"
+		tokenNames[tokHintEnd] = "HINT_END"
+	}
+	if name, ok := tokenNames[kind]; ok {
+		return name
+	}
+	if kind > 0 && kind < 128 {
+		return string(rune(kind))
+	}
+	return "UNKNOWN"
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go build ./doris/parser/...`
+
+Expected: Success (tokens.go + keywords.go together should compile).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add doris/parser/keywords.go
+git commit -m "feat(doris/parser): add 522 keyword constants and lookup functions"
+```
+
+---
+
+### Task 3: Create `doris/parser/lexer.go`
+
+**Files:**
+- Create: `doris/parser/lexer.go`
+
+This is the core scanning engine. Follow the snowflake/parser/lexer.go pattern exactly.
+
+- [ ] **Step 1: Create the file**
+
+```go
+package parser
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// Lexer is a Doris SQL tokenizer. Construct via NewLexer (or
+// NewLexerWithOffset when tokenizing a substring) and call NextToken
+// until it returns Token{Kind: tokEOF}. Lex errors are collected in
+// Errors; each error is accompanied by a tokInvalid token so consumers
+// can halt or proceed with best-effort parsing.
+type Lexer struct {
+	input      string
+	pos        int // current byte offset
+	start      int // start byte of current token
+	errors     []LexError
+	baseOffset int // added to Loc positions on return
+	inHint     bool // true between /*+ and */
+}
+
+// NewLexer creates a lexer for the given input.
+func NewLexer(input string) *Lexer {
+	return &Lexer{input: input}
+}
+
+// NewLexerWithOffset creates a lexer whose emitted Loc values are shifted
+// by baseOffset. Used for multi-statement parsing.
+func NewLexerWithOffset(input string, baseOffset int) *Lexer {
+	return &Lexer{input: input, baseOffset: baseOffset}
+}
+
+// Errors returns all lex errors collected so far, with positions shifted
+// by baseOffset if applicable.
+func (l *Lexer) Errors() []LexError {
+	if l.baseOffset == 0 {
+		return l.errors
+	}
+	shifted := make([]LexError, len(l.errors))
+	for i, e := range l.errors {
+		shifted[i] = LexError{
+			Loc: ast.Loc{Start: e.Loc.Start + l.baseOffset, End: e.Loc.End + l.baseOffset},
+			Msg: e.Msg,
+		}
+	}
+	return shifted
+}
+
+// Tokenize is a one-shot convenience that lexes the entire input.
+func Tokenize(input string) ([]Token, []LexError) {
+	l := NewLexer(input)
+	var tokens []Token
+	for {
+		tok := l.NextToken()
+		tokens = append(tokens, tok)
+		if tok.Kind == tokEOF {
+			break
+		}
+	}
+	return tokens, l.Errors()
+}
+
+// NextToken returns the next token with baseOffset-shifted positions.
+func (l *Lexer) NextToken() Token {
+	tok := l.nextTokenInner()
+	if l.baseOffset != 0 {
+		tok.Loc.Start += l.baseOffset
+		tok.Loc.End += l.baseOffset
+	}
+	return tok
+}
+
+func (l *Lexer) nextTokenInner() Token {
+	l.skipWhitespaceAndComments()
+	if l.pos >= len(l.input) {
+		return Token{Kind: tokEOF, Loc: ast.Loc{Start: l.pos, End: l.pos}}
+	}
+	l.start = l.pos
+	ch := l.input[l.pos]
+
+	switch {
+	case ch == '\'':
+		return l.scanString('\'')
+	case ch == '"':
+		return l.scanString('"')
+	case ch == '`':
+		return l.scanBacktickIdent()
+	case ch >= '0' && ch <= '9':
+		return l.scanNumber()
+	case ch == '.' && l.peekDigit():
+		return l.scanNumber()
+	case (ch == 'X' || ch == 'x') && l.peek(1) == '\'':
+		return l.scanHexLiteral()
+	case (ch == 'B' || ch == 'b') && l.peek(1) == '\'':
+		return l.scanBitLiteral()
+	case isIdentStart(ch):
+		return l.scanIdentOrKeyword()
+	}
+	return l.scanOperator(ch)
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+func (l *Lexer) peek(offset int) byte {
+	if l.pos+offset >= len(l.input) {
+		return 0
+	}
+	return l.input[l.pos+offset]
+}
+
+func (l *Lexer) peekDigit() bool {
+	c := l.peek(1)
+	return c >= '0' && c <= '9'
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '$' || ch > 127
+}
+
+func isIdentCont(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9')
+}
+
+// --- Whitespace & Comments -------------------------------------------------
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		switch {
+		case ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r':
+			l.pos++
+		case ch == '-' && l.peek(1) == '-' && l.isLineCommentAfterDash():
+			// MySQL-compatible: -- must be followed by space/tab/newline/EOF
+			l.pos += 2
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+				l.pos++
+			}
+		case ch == '/' && l.peek(1) == '/':
+			l.pos += 2
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+				l.pos++
+			}
+		case ch == '#':
+			l.pos++
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+				l.pos++
+			}
+		case ch == '/' && l.peek(1) == '*' && l.peek(2) != '+':
+			// Block comment (but NOT hint /*+)
+			l.scanBlockComment()
+		default:
+			return
+		}
+	}
+}
+
+// isLineCommentAfterDash checks that byte after -- is space/tab/newline/EOF.
+func (l *Lexer) isLineCommentAfterDash() bool {
+	c := l.peek(2)
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == 0
+}
+
+func (l *Lexer) scanBlockComment() {
+	start := l.pos
+	l.pos += 2 // consume /*
+	for l.pos < len(l.input)-1 {
+		if l.input[l.pos] == '*' && l.input[l.pos+1] == '/' {
+			l.pos += 2
+			return
+		}
+		l.pos++
+	}
+	l.pos = len(l.input)
+	l.errors = append(l.errors, LexError{
+		Loc: ast.Loc{Start: start, End: l.pos},
+		Msg: errUnterminatedComment,
+	})
+}
+
+// --- String Scanning -------------------------------------------------------
+
+// scanString reads a single-quoted or double-quoted string literal.
+// Supports backslash escapes and doubled-quote escapes.
+func (l *Lexer) scanString(quote byte) Token {
+	start := l.start
+	l.pos++ // consume opening quote
+	var sb strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == quote {
+			if l.peek(1) == quote {
+				sb.WriteByte(quote)
+				l.pos += 2
+				continue
+			}
+			l.pos++
+			return Token{Kind: tokString, Str: sb.String(), Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		if ch == '\\' {
+			l.pos++
+			if l.pos >= len(l.input) {
+				break
+			}
+			esc := l.input[l.pos]
+			switch esc {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case 'r':
+				sb.WriteByte('\r')
+			case '0':
+				sb.WriteByte(0)
+			case '\\':
+				sb.WriteByte('\\')
+			case '\'':
+				sb.WriteByte('\'')
+			case '"':
+				sb.WriteByte('"')
+			case 'b':
+				sb.WriteByte(0x08)
+			case 'Z':
+				sb.WriteByte(0x1A)
+			default:
+				sb.WriteByte(esc)
+			}
+			l.pos++
+			continue
+		}
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedString})
+	return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+// scanBacktickIdent reads a backtick-quoted identifier. Only doubled-backtick
+// escape is supported (`` → `). No backslash escapes.
+func (l *Lexer) scanBacktickIdent() Token {
+	start := l.start
+	l.pos++ // consume opening backtick
+	var sb strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == '`' {
+			if l.peek(1) == '`' {
+				sb.WriteByte('`')
+				l.pos += 2
+				continue
+			}
+			l.pos++
+			return Token{Kind: tokQuotedIdent, Str: sb.String(), Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedQuoted})
+	return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+// --- Hex/Bit Literal Scanning -----------------------------------------------
+
+func (l *Lexer) scanHexLiteral() Token {
+	start := l.start
+	l.pos += 2 // consume X and opening quote
+	contentStart := l.pos
+	for l.pos < len(l.input) && l.input[l.pos] != '\'' {
+		l.pos++
+	}
+	if l.pos >= len(l.input) {
+		l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedString})
+		return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+	content := l.input[contentStart:l.pos]
+	l.pos++ // consume closing quote
+	return Token{Kind: tokHexLiteral, Str: content, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+func (l *Lexer) scanBitLiteral() Token {
+	start := l.start
+	l.pos += 2 // consume B and opening quote
+	contentStart := l.pos
+	for l.pos < len(l.input) && l.input[l.pos] != '\'' {
+		l.pos++
+	}
+	if l.pos >= len(l.input) {
+		l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedString})
+		return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+	content := l.input[contentStart:l.pos]
+	l.pos++ // consume closing quote
+	return Token{Kind: tokBitLiteral, Str: content, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+// --- Number Scanning -------------------------------------------------------
+
+func (l *Lexer) scanNumber() Token {
+	start := l.start
+
+	// Hex: 0x or 0X
+	if l.input[l.pos] == '0' && (l.peek(1) == 'x' || l.peek(1) == 'X') {
+		l.pos += 2
+		for l.pos < len(l.input) && isHexDigit(l.input[l.pos]) {
+			l.pos++
+		}
+		text := l.input[start:l.pos]
+		val, err := strconv.ParseInt(text[2:], 16, 64)
+		if err != nil {
+			return Token{Kind: tokFloat, Str: text, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		return Token{Kind: tokInt, Str: text, Ival: val, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	// Binary: 0b or 0B
+	if l.input[l.pos] == '0' && (l.peek(1) == 'b' || l.peek(1) == 'B') && l.peek(2) != '\'' {
+		l.pos += 2
+		for l.pos < len(l.input) && (l.input[l.pos] == '0' || l.input[l.pos] == '1') {
+			l.pos++
+		}
+		text := l.input[start:l.pos]
+		val, err := strconv.ParseInt(text[2:], 2, 64)
+		if err != nil {
+			return Token{Kind: tokFloat, Str: text, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		return Token{Kind: tokInt, Str: text, Ival: val, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	isFloat := false
+
+	// Leading dot (.5)
+	if l.input[l.pos] == '.' {
+		isFloat = true
+		l.pos++
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+	} else {
+		// Integer part
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+		// Optional decimal
+		if l.pos < len(l.input) && l.input[l.pos] == '.' {
+			isFloat = true
+			l.pos++
+			for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+				l.pos++
+			}
+		}
+	}
+
+	// Optional exponent
+	if l.pos < len(l.input) && (l.input[l.pos] == 'e' || l.input[l.pos] == 'E') {
+		isFloat = true
+		l.pos++
+		if l.pos < len(l.input) && (l.input[l.pos] == '+' || l.input[l.pos] == '-') {
+			l.pos++
+		}
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+	}
+
+	text := l.input[start:l.pos]
+	loc := ast.Loc{Start: start, End: l.pos}
+
+	if isFloat {
+		return Token{Kind: tokFloat, Str: text, Loc: loc}
+	}
+	val, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return Token{Kind: tokFloat, Str: text, Loc: loc}
+	}
+	return Token{Kind: tokInt, Str: text, Ival: val, Loc: loc}
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}
+
+// --- Identifier / Keyword Scanning -----------------------------------------
+
+func (l *Lexer) scanIdentOrKeyword() Token {
+	start := l.start
+	for l.pos < len(l.input) && isIdentCont(l.input[l.pos]) {
+		l.pos++
+	}
+	word := l.input[start:l.pos]
+	loc := ast.Loc{Start: start, End: l.pos}
+	if kw, ok := KeywordToken(word); ok {
+		return Token{Kind: kw, Str: word, Loc: loc}
+	}
+	return Token{Kind: tokIdent, Str: word, Loc: loc}
+}
+
+// --- Operator Scanning -----------------------------------------------------
+
+func (l *Lexer) scanOperator(ch byte) Token {
+	start := l.start
+	l.pos++
+
+	switch ch {
+	case '<':
+		if l.pos < len(l.input) {
+			switch l.input[l.pos] {
+			case '=':
+				if l.peek(1) == '>' {
+					l.pos += 2
+					return Token{Kind: tokNullSafeEq, Loc: ast.Loc{Start: start, End: l.pos}}
+				}
+				l.pos++
+				return Token{Kind: tokLessEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '>':
+				l.pos++
+				return Token{Kind: tokNotEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '<':
+				l.pos++
+				return Token{Kind: tokShiftLeft, Loc: ast.Loc{Start: start, End: l.pos}}
+			}
+		}
+	case '>':
+		if l.pos < len(l.input) {
+			switch l.input[l.pos] {
+			case '=':
+				l.pos++
+				return Token{Kind: tokGreaterEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '>':
+				l.pos++
+				return Token{Kind: tokShiftRight, Loc: ast.Loc{Start: start, End: l.pos}}
+			}
+		}
+	case '!':
+		if l.pos < len(l.input) {
+			switch l.input[l.pos] {
+			case '=':
+				l.pos++
+				return Token{Kind: tokNotEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '<':
+				l.pos++
+				return Token{Kind: tokGreaterEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '>':
+				l.pos++
+				return Token{Kind: tokLessEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			}
+		}
+	case '&':
+		if l.pos < len(l.input) && l.input[l.pos] == '&' {
+			l.pos++
+			return Token{Kind: tokLogicalAnd, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '|':
+		if l.pos < len(l.input) && l.input[l.pos] == '|' {
+			l.pos++
+			return Token{Kind: tokDoublePipes, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '@':
+		if l.pos < len(l.input) && l.input[l.pos] == '@' {
+			l.pos++
+			return Token{Kind: tokDoubleAt, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case ':':
+		if l.pos < len(l.input) && l.input[l.pos] == '=' {
+			l.pos++
+			return Token{Kind: tokAssign, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '.':
+		if l.pos+1 < len(l.input) && l.input[l.pos] == '.' && l.input[l.pos+1] == '.' {
+			l.pos += 2
+			return Token{Kind: tokDotDotDot, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '-':
+		if l.pos < len(l.input) && l.input[l.pos] == '>' {
+			l.pos++
+			return Token{Kind: tokArrow, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '/':
+		if l.pos+1 < len(l.input) && l.input[l.pos] == '*' && l.input[l.pos+1] == '+' {
+			l.pos += 2
+			return Token{Kind: tokHintStart, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '*':
+		if l.pos < len(l.input) && l.input[l.pos] == '/' {
+			l.pos++
+			return Token{Kind: tokHintEnd, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '?':
+		return Token{Kind: tokPlaceholder, Loc: ast.Loc{Start: start, End: l.pos}}
+	case '=':
+		// == is equivalent to =
+		if l.pos < len(l.input) && l.input[l.pos] == '=' {
+			l.pos++
+		}
+		return Token{Kind: int('='), Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	// Valid single-char operators/punctuation
+	if ch == '(' || ch == ')' || ch == ',' || ch == ';' || ch == '+' || ch == '-' ||
+		ch == '*' || ch == '/' || ch == '%' || ch == '~' || ch == '^' || ch == '&' ||
+		ch == '|' || ch == '<' || ch == '>' || ch == '=' || ch == '.' || ch == '@' ||
+		ch == ':' || ch == '!' || ch == '[' || ch == ']' || ch == '{' || ch == '}' {
+		return Token{Kind: int(ch), Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	// Unknown character
+	l.errors = append(l.errors, LexError{
+		Loc: ast.Loc{Start: start, End: l.pos},
+		Msg: errUnknownChar,
+	})
+	return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go build ./doris/parser/... && go vet ./doris/parser/...`
+
+Expected: Success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add doris/parser/lexer.go
+git commit -m "feat(doris/parser): add hand-written lexer with full Doris SQL support"
+```
+
+---
+
+### Task 4: Write tests in `doris/parser/lexer_test.go`
+
+**Files:**
+- Create: `doris/parser/lexer_test.go`
+
+- [ ] **Step 1: Create the test file**
+
+```go
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+func TestTokenizeKeywords(t *testing.T) {
+	// Spot-check a representative set of keywords, case-insensitive.
+	tests := []struct {
+		input string
+		want  TokenKind
+	}{
+		{"SELECT", kwSELECT},
+		{"select", kwSELECT},
+		{"SeLeCt", kwSELECT},
+		{"FROM", kwFROM},
+		{"CREATE", kwCREATE},
+		{"DISTRIBUTED", kwDISTRIBUTED},
+		{"AGGREGATE", kwAGGREGATE},
+		{"MATERIALIZED", kwMATERIALIZED},
+		{"BUCKETS", kwBUCKETS},
+	}
+	for _, tt := range tests {
+		tokens, errs := Tokenize(tt.input)
+		if len(errs) > 0 {
+			t.Errorf("Tokenize(%q) errors: %v", tt.input, errs)
+			continue
+		}
+		if len(tokens) < 2 || tokens[0].Kind != tt.want {
+			t.Errorf("Tokenize(%q)[0].Kind = %d, want %d", tt.input, tokens[0].Kind, tt.want)
+		}
+	}
+}
+
+func TestTokenizeIdentifiers(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantKind TokenKind
+		wantStr  string
+	}{
+		{"myTable", tokIdent, "myTable"},
+		{"`my table`", tokQuotedIdent, "my table"},
+		{"``backtick``", tokQuotedIdent, "backtick"},  // escaped backtick: `` -> `... wait
+	}
+	for _, tt := range tests {
+		tokens, errs := Tokenize(tt.input)
+		if len(errs) > 0 {
+			t.Errorf("Tokenize(%q) errors: %v", tt.input, errs)
+			continue
+		}
+		if tokens[0].Kind != tt.wantKind {
+			t.Errorf("Tokenize(%q)[0].Kind = %d, want %d", tt.input, tokens[0].Kind, tt.wantKind)
+		}
+		if tokens[0].Str != tt.wantStr {
+			t.Errorf("Tokenize(%q)[0].Str = %q, want %q", tt.input, tokens[0].Str, tt.wantStr)
+		}
+	}
+}
+
+func TestTokenizeBacktickEscape(t *testing.T) {
+	// Doubled backtick `` inside backtick-quoted ident -> single backtick
+	tokens, errs := Tokenize("`col``name`")
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if tokens[0].Kind != tokQuotedIdent || tokens[0].Str != "col`name" {
+		t.Errorf("got Kind=%d Str=%q, want tokQuotedIdent %q", tokens[0].Kind, tokens[0].Str, "col`name")
+	}
+}
+
+func TestTokenizeStrings(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantStr string
+	}{
+		{`'hello'`, "hello"},
+		{`'it''s'`, "it's"},        // doubled-quote escape
+		{`'line\nbreak'`, "line\nbreak"}, // backslash escape
+		{`"double"`, "double"},
+		{`'tab\there'`, "tab\there"},
+		{`'null\0byte'`, "null\x00byte"},
+	}
+	for _, tt := range tests {
+		tokens, errs := Tokenize(tt.input)
+		if len(errs) > 0 {
+			t.Errorf("Tokenize(%q) errors: %v", tt.input, errs)
+			continue
+		}
+		if tokens[0].Kind != tokString {
+			t.Errorf("Tokenize(%q)[0].Kind = %d, want tokString", tt.input, tokens[0].Kind)
+			continue
+		}
+		if tokens[0].Str != tt.wantStr {
+			t.Errorf("Tokenize(%q)[0].Str = %q, want %q", tt.input, tokens[0].Str, tt.wantStr)
+		}
+	}
+}
+
+func TestTokenizeNumbers(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantKind TokenKind
+		wantIval int64
+		wantStr  string
+	}{
+		{"42", tokInt, 42, "42"},
+		{"0", tokInt, 0, "0"},
+		{"3.14", tokFloat, 0, "3.14"},
+		{".5", tokFloat, 0, ".5"},
+		{"1e10", tokFloat, 0, "1e10"},
+		{"1.5e-10", tokFloat, 0, "1.5e-10"},
+		{"0xFF", tokInt, 255, "0xFF"},
+		{"0b101", tokInt, 5, "0b101"},
+	}
+	for _, tt := range tests {
+		tokens, errs := Tokenize(tt.input)
+		if len(errs) > 0 {
+			t.Errorf("Tokenize(%q) errors: %v", tt.input, errs)
+			continue
+		}
+		tok := tokens[0]
+		if tok.Kind != tt.wantKind {
+			t.Errorf("Tokenize(%q).Kind = %d, want %d", tt.input, tok.Kind, tt.wantKind)
+		}
+		if tok.Kind == tokInt && tok.Ival != tt.wantIval {
+			t.Errorf("Tokenize(%q).Ival = %d, want %d", tt.input, tok.Ival, tt.wantIval)
+		}
+		if tok.Str != tt.wantStr {
+			t.Errorf("Tokenize(%q).Str = %q, want %q", tt.input, tok.Str, tt.wantStr)
+		}
+	}
+}
+
+func TestTokenizeOperators(t *testing.T) {
+	tests := []struct {
+		input string
+		want  TokenKind
+	}{
+		{"<=", tokLessEq},
+		{">=", tokGreaterEq},
+		{"<>", tokNotEq},
+		{"!=", tokNotEq},
+		{"<=>", tokNullSafeEq},
+		{"&&", tokLogicalAnd},
+		{"||", tokDoublePipes},
+		{"<<", tokShiftLeft},
+		{">>", tokShiftRight},
+		{"->", tokArrow},
+		{"@@", tokDoubleAt},
+		{":=", tokAssign},
+		{"...", tokDotDotDot},
+		{"+", int('+')},
+		{"-", int('-')},
+		{"*", int('*')},
+		{"/", int('/')},
+		{"%", int('%')},
+		{"~", int('~')},
+		{"^", int('^')},
+		{"(", int('(')},
+		{")", int(')')},
+		{",", int(',')},
+		{";", int(';')},
+		{".", int('.')},
+		{"==", int('=')}, // == folds to =
+	}
+	for _, tt := range tests {
+		tokens, errs := Tokenize(tt.input)
+		if len(errs) > 0 {
+			t.Errorf("Tokenize(%q) errors: %v", tt.input, errs)
+			continue
+		}
+		if tokens[0].Kind != tt.want {
+			t.Errorf("Tokenize(%q)[0].Kind = %d, want %d (%s)", tt.input, tokens[0].Kind, tt.want, TokenName(tt.want))
+		}
+	}
+}
+
+func TestTokenizeComments(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string // expected first non-EOF token Str
+	}{
+		{"-- comment\nSELECT", "SELECT"},
+		{"// comment\nSELECT", "SELECT"},
+		{"# comment\nSELECT", "SELECT"},
+		{"/* block */SELECT", "SELECT"},
+	}
+	for _, tt := range tests {
+		tokens, errs := Tokenize(tt.input)
+		if len(errs) > 0 {
+			t.Errorf("Tokenize(%q) errors: %v", tt.input, errs)
+			continue
+		}
+		if tokens[0].Str != tt.want {
+			t.Errorf("Tokenize(%q)[0].Str = %q, want %q", tt.input, tokens[0].Str, tt.want)
+		}
+	}
+}
+
+func TestTokenizeDashDashRequiresSpace(t *testing.T) {
+	// -- without space after is two minus tokens, not a comment.
+	tokens, _ := Tokenize("--5")
+	if tokens[0].Kind != int('-') {
+		t.Errorf("got Kind=%d, want '-' (%d)", tokens[0].Kind, int('-'))
+	}
+}
+
+func TestTokenizeHints(t *testing.T) {
+	tokens, errs := Tokenize("/*+ SET_VAR(k=v) */")
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if tokens[0].Kind != tokHintStart {
+		t.Errorf("tokens[0].Kind = %d, want tokHintStart", tokens[0].Kind)
+	}
+}
+
+func TestTokenizeHexBitLiterals(t *testing.T) {
+	tokens, errs := Tokenize("X'FF' B'101'")
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if tokens[0].Kind != tokHexLiteral || tokens[0].Str != "FF" {
+		t.Errorf("hex: Kind=%d Str=%q", tokens[0].Kind, tokens[0].Str)
+	}
+	if tokens[1].Kind != tokBitLiteral || tokens[1].Str != "101" {
+		t.Errorf("bit: Kind=%d Str=%q", tokens[1].Kind, tokens[1].Str)
+	}
+}
+
+func TestTokenizePositions(t *testing.T) {
+	tokens, _ := Tokenize("SELECT 1")
+	// "SELECT" is bytes 0-6, "1" is bytes 7-8
+	if tokens[0].Loc != (ast.Loc{Start: 0, End: 6}) {
+		t.Errorf("SELECT loc = %v, want {0,6}", tokens[0].Loc)
+	}
+	if tokens[1].Loc != (ast.Loc{Start: 7, End: 8}) {
+		t.Errorf("1 loc = %v, want {7,8}", tokens[1].Loc)
+	}
+}
+
+func TestTokenizeBaseOffset(t *testing.T) {
+	l := NewLexerWithOffset("SELECT", 100)
+	tok := l.NextToken()
+	if tok.Loc.Start != 100 || tok.Loc.End != 106 {
+		t.Errorf("offset loc = %v, want {100,106}", tok.Loc)
+	}
+}
+
+func TestTokenizeUnterminatedString(t *testing.T) {
+	tokens, errs := Tokenize("'unterminated")
+	if len(errs) == 0 {
+		t.Fatal("expected error for unterminated string")
+	}
+	if tokens[0].Kind != tokInvalid {
+		t.Errorf("Kind = %d, want tokInvalid", tokens[0].Kind)
+	}
+}
+
+func TestTokenizeUnterminatedComment(t *testing.T) {
+	_, errs := Tokenize("/* unterminated")
+	if len(errs) == 0 {
+		t.Fatal("expected error for unterminated comment")
+	}
+}
+
+func TestTokenizeUnknownChar(t *testing.T) {
+	tokens, errs := Tokenize("\\")
+	if len(errs) == 0 {
+		t.Fatal("expected error for unknown char")
+	}
+	if tokens[0].Kind != tokInvalid {
+		t.Errorf("Kind = %d, want tokInvalid", tokens[0].Kind)
+	}
+}
+
+func TestTokenizeEmpty(t *testing.T) {
+	tokens, errs := Tokenize("")
+	if len(errs) > 0 {
+		t.Errorf("errors: %v", errs)
+	}
+	if len(tokens) != 1 || tokens[0].Kind != tokEOF {
+		t.Errorf("expected single EOF token, got %v", tokens)
+	}
+}
+
+func TestTokenizeMultiStatement(t *testing.T) {
+	tokens, errs := Tokenize("SELECT 1; SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	// Expect: SELECT, 1, ;, SELECT, 2, EOF = 6 tokens
+	if len(tokens) != 6 {
+		t.Fatalf("got %d tokens, want 6", len(tokens))
+	}
+	if tokens[2].Kind != int(';') {
+		t.Errorf("tokens[2].Kind = %d, want ';'", tokens[2].Kind)
+	}
+}
+
+func TestIsReserved(t *testing.T) {
+	if !IsReserved(kwSELECT) {
+		t.Error("SELECT should be reserved")
+	}
+	if IsReserved(kwCOMMENT) {
+		t.Error("COMMENT should NOT be reserved (it's in nonReserved)")
+	}
+}
+
+func TestTokenName(t *testing.T) {
+	if got := TokenName(kwSELECT); got != "SELECT" {
+		t.Errorf("TokenName(kwSELECT) = %q, want %q", got, "SELECT")
+	}
+	if got := TokenName(tokEOF); got != "EOF" {
+		t.Errorf("TokenName(tokEOF) = %q, want %q", got, "EOF")
+	}
+	if got := TokenName(int(';')); got != ";" {
+		t.Errorf("TokenName(';') = %q, want %q", got, ";")
+	}
+}
+
+func TestTokenizePlaceholder(t *testing.T) {
+	tokens, errs := Tokenize("SELECT ? FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if tokens[1].Kind != tokPlaceholder {
+		t.Errorf("tokens[1].Kind = %d, want tokPlaceholder", tokens[1].Kind)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go test ./doris/parser/... -v`
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add doris/parser/lexer_test.go
+git commit -m "test(doris/parser): add lexer unit tests for all token categories"
+```
+
+---
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Run full build and vet**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go build ./doris/... && go vet ./doris/...`
+
+Expected: Success.
+
+- [ ] **Step 2: Run all doris tests**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go test ./doris/... -v -count=1`
+
+Expected: All tests PASS (both ast and parser packages).
+
+- [ ] **Step 3: Verify no regressions**
+
+Run: `cd /Users/h3n4l/OpenSource/omni/.worktrees/feat-doris-lexer && go build ./...`
+
+Expected: Success.

--- a/docs/superpowers/specs/2026-04-13-doris-lexer-design.md
+++ b/docs/superpowers/specs/2026-04-13-doris-lexer-design.md
@@ -1,0 +1,275 @@
+# Doris Lexer Design
+
+DAG node: F2 (lexer)
+
+## Goal
+
+Implement the lexer for `doris/parser` -- tokenize Doris SQL input into a stream of tokens that the parser (F4), statement splitter (F3), and all downstream consumers depend on. Must handle 522 keywords, MySQL-compatible syntax (backtick identifiers, `<=>` null-safe equal, conditional comments), and Doris-specific hint syntax.
+
+## Scope
+
+### In scope
+
+- Token struct and TokenKind constants (EOF, Invalid, literals, operators, keywords)
+- 522 keyword constants with reserved/non-reserved classification
+- Lexer with character-by-character scanning
+- String literals (single-quoted, double-quoted, backtick-quoted)
+- Numeric literals (integer, decimal, float/exponent, hex `0x`, binary `0b`, suffixed `L`/`S`/`Y`/`BD`)
+- All operators and punctuation from DorisLexer.g4
+- Line comments (`--`, `//`), block comments (`/* */`)
+- Hint tokens (`/*+ ... */`)
+- Error recovery (unterminated strings/comments)
+- Unit tests
+
+### Out of scope
+
+- Statement splitter (F3)
+- Parser entry / lookahead (F4)
+- AST node creation
+- Conditional comments (`/*!NNNNN ... */`) -- not used by bytebase for Doris
+
+## Reference
+
+- Template: `snowflake/parser/lexer.go` (17KB), `snowflake/parser/tokens.go` (16KB), `snowflake/parser/keywords.go` (59KB)
+- MySQL compat: `tidb/parser/lexer.go` (56KB) for backtick/operator patterns
+- Grammar source: `/Users/h3n4l/OpenSource/parser/doris/DorisLexer.g4` (522 keywords, 709 lines)
+
+## File Structure
+
+| File | Responsibility | ~LOC |
+|------|----------------|------|
+| `doris/parser/tokens.go` | Token struct, TokenKind constants, LexError type | ~150 |
+| `doris/parser/keywords.go` | 522 keyword constants, keyword map, reserved classification, lookup/name functions | ~2000 |
+| `doris/parser/lexer.go` | Lexer struct, NewLexer, NextToken, all scanning functions | ~600 |
+| `doris/parser/lexer_test.go` | Unit tests for all token categories | ~500 |
+
+## Package: `doris/parser/`
+
+### `tokens.go`
+
+**Token struct:**
+
+```go
+type Token struct {
+    Kind TokenKind   // token type identifier
+    Str  string      // content for identifiers, strings, hints
+    Ival int64       // parsed value for tokInt
+    Loc  ast.Loc     // byte offset span {Start, End}
+}
+```
+
+**TokenKind ranges** (following snowflake/tidb convention):
+
+```go
+type TokenKind int
+
+// Sentinel tokens
+tokEOF     = 0
+tokInvalid = 1
+
+// Literal tokens (600-699)
+tokInt         = 600  // integer: 42, 0xFF, 0b101
+tokFloat       = 601  // decimal/exponent: 3.14, 1e10
+tokString      = 602  // single or double quoted string
+tokIdent       = 603  // unquoted identifier
+tokQuotedIdent = 604  // backtick-quoted identifier
+tokHexLiteral  = 605  // X'...' or x'...'
+tokBitLiteral  = 606  // B'...' or b'...'
+tokPlaceholder = 607  // ?
+
+// Multi-character operators (500-599)
+tokLessEq      = 500  // <=
+tokGreaterEq   = 501  // >=
+tokNotEq       = 502  // <> or !=
+tokNullSafeEq  = 503  // <=>
+tokLogicalAnd  = 504  // &&
+tokDoublePipes = 505  // ||
+tokShiftLeft   = 506  // <<
+tokShiftRight  = 507  // >>
+tokArrow       = 508  // ->
+tokDoubleAt    = 509  // @@
+tokAssign      = 510  // :=
+tokDotDotDot   = 511  // ...
+tokHintStart   = 512  // /*+
+tokHintEnd     = 513  // */
+
+// Keywords start at 700 (defined in keywords.go)
+
+// Single-character operators/punctuation use their ASCII byte value:
+// '(' = 40, ')' = 41, '*' = 42, '+' = 43, ',' = 44, '-' = 45,
+// '.' = 46, '/' = 47, ':' = 58, ';' = 59, '<' = 60, '=' = 61,
+// '>' = 62, '?' = 63, '@' = 64, '[' = 91, ']' = 93, '^' = 94,
+// '{' = 123, '|' = 124, '}' = 125, '~' = 126, '%' = 37, '!' = 33,
+// '&' = 38
+```
+
+**LexError type:**
+
+```go
+type LexError struct {
+    Msg string
+    Loc ast.Loc
+}
+```
+
+### `keywords.go`
+
+**Keyword constants** (522 total, starting at 700):
+
+```go
+const (
+    kwACCOUNT_LOCK TokenKind = 700 + iota
+    kwACCOUNT_UNLOCK
+    kwACTIONS
+    kwADD
+    // ... (522 constants in alphabetical order)
+    kwYEAR
+)
+```
+
+**Keyword map** (case-insensitive lookup):
+
+```go
+var keywordMap = map[string]TokenKind{
+    "account_lock":    kwACCOUNT_LOCK,
+    "account_unlock":  kwACCOUNT_UNLOCK,
+    // ... all 522 entries, lowercase keys
+}
+```
+
+**Non-reserved set** (172 keywords that can be used as identifiers):
+
+```go
+var nonReservedKeywords = map[TokenKind]bool{
+    kwACTIONS:        true,
+    kwAFTER:          true,
+    // ... 172 entries from DorisParser.g4 nonReserved rule
+}
+```
+
+**Public functions:**
+
+```go
+// KeywordToken returns the keyword TokenKind for a name, or (0, false)
+// if it's not a keyword. Lookup is case-insensitive.
+func KeywordToken(name string) (TokenKind, bool)
+
+// IsReserved reports whether kind is a reserved keyword (cannot be
+// used as an unquoted identifier).
+func IsReserved(kind TokenKind) bool
+
+// TokenName returns a human-readable name for a TokenKind. Used for
+// error messages and debugging.
+func TokenName(kind TokenKind) string
+```
+
+### `lexer.go`
+
+**Lexer struct:**
+
+```go
+type Lexer struct {
+    input      string
+    pos        int        // current byte position
+    start      int        // start of current token
+    errors     []LexError
+    baseOffset int        // added to all Loc positions on return
+}
+```
+
+**Public API:**
+
+```go
+// NewLexer creates a lexer for the given input.
+func NewLexer(input string) *Lexer
+
+// NewLexerWithOffset creates a lexer with a base offset added to all
+// token positions. Used for multi-statement parsing where each statement
+// is lexed independently but positions are relative to the full input.
+func NewLexerWithOffset(input string, baseOffset int) *Lexer
+
+// NextToken returns the next token from the input. Returns tokEOF when
+// the input is exhausted. Errors (unterminated strings, unknown chars)
+// produce tokInvalid tokens and are accumulated in Errors().
+func (l *Lexer) NextToken() Token
+
+// Tokenize is a convenience function that tokenizes the entire input
+// and returns all tokens (including tokEOF) and any errors.
+func Tokenize(input string) ([]Token, []LexError)
+
+// Errors returns all lexing errors accumulated during scanning.
+func (l *Lexer) Errors() []LexError
+```
+
+**Character dispatch** in `nextToken()`:
+
+| First byte(s) | Action |
+|---------------|--------|
+| `' '`, `\t`, `\n`, `\r` | Skip whitespace |
+| `'` or `"` | Scan string literal (backslash escapes + doubled-quote escapes) |
+| `` ` `` | Scan backtick-quoted identifier (doubled-backtick escape) |
+| `[0-9]` | Scan numeric (int/float/hex/binary/exponent/suffixed) |
+| `.` + digit | Scan decimal literal (`.5`); otherwise return `'.'` |
+| `[A-Za-z_$]` or non-ASCII | Scan identifier, check keyword map |
+| `X/x` + `'` | Scan hex literal `X'...'` |
+| `B/b` + `'` | Scan bit literal `B'...'` |
+| `-` | `--` + space: line comment (skip); `->`: tokArrow; else `'-'` |
+| `/` | `/*+`: tokHintStart; `/*`: block comment (skip); `//`: line comment (skip); else `'/'` |
+| `*` | `*/`: tokHintEnd; else `'*'` |
+| `<` | `<=`: tokLessEq; `<=>`: tokNullSafeEq; `<>`: tokNotEq; `<<`: tokShiftLeft; else `'<'` |
+| `>` | `>=`: tokGreaterEq; `>>`: tokShiftRight; else `'>'` |
+| `!` | `!=`: tokNotEq; `!<`: tokGreaterEq; `!>`: tokLessEq; else `'!'` |
+| `&` | `&&`: tokLogicalAnd; else `'&'` |
+| `\|` | `\|\|`: tokDoublePipes; else `'\|'` |
+| `@` | `@@`: tokDoubleAt; else `'@'` |
+| `:` | `:=`: tokAssign; else `':'` |
+| `.` | `...`: tokDotDotDot; else `'.'` |
+| Other single-char | Return ASCII value as TokenKind |
+
+**Comment handling:**
+- `--` followed by space/tab/newline/EOF: skip to end of line (MySQL-compatible strict)
+- `//`: skip to end of line
+- `/* ... */`: skip block comment (non-nesting)
+- `/*+ ... */`: emit tokHintStart; the parser will handle hint content
+
+**Hint strategy:**
+- When `/*+` is encountered, emit `tokHintStart` token
+- When `*/` is encountered (outside a block comment context), emit `tokHintEnd` token
+- The parser is responsible for collecting hint body tokens between these markers
+
+**String scanning:**
+- Single-quoted: backslash escapes (`\n`, `\t`, `\r`, `\0`, `\\`, `\'`, `\"`, `\b`, `\Z`) and doubled-quote escape (`''`)
+- Double-quoted: same escaping rules
+- Backtick-quoted: doubled-backtick escape only (``` `` ``` -> `` ` ``), no backslash escapes
+- Unterminated string: emit tokInvalid + LexError, consume to EOF
+
+**Numeric scanning:**
+- Leading `0x`/`0X`: hex integer
+- Leading `0b`/`0B`: binary integer
+- Digits optionally followed by `.` digits: decimal
+- Optional exponent `E/e [+-] digits`: float
+- Optional suffix `L` (bigint), `S` (smallint), `Y` (tinyint), `BD` (bigdecimal)
+- Overflow on `strconv.ParseInt`: downgrade to tokFloat
+- Leading `.` + digit: decimal (handled in main dispatch, not here)
+
+**Error recovery:**
+- Unterminated string: emit tokInvalid, record LexError, continue from EOF
+- Unterminated block comment: emit tokInvalid, record LexError, continue from EOF
+- Unknown character: emit tokInvalid for that byte, record LexError, advance one byte
+
+### Testing
+
+Tests in `doris/parser/lexer_test.go`:
+
+- **Keywords**: Verify all 522 keywords tokenize correctly (case-insensitive)
+- **Reserved/non-reserved**: Spot-check classification
+- **Identifiers**: Unquoted, backtick-quoted with escaping
+- **String literals**: Single-quoted, double-quoted, escape sequences, unterminated
+- **Numeric literals**: Integer, decimal, float, hex, binary, suffixed, overflow
+- **Operators**: All single-char and multi-char operators
+- **Comments**: Line (`--`, `//`), block (`/* */`), hints (`/*+ ... */`)
+- **Error recovery**: Unterminated string, unterminated comment, unknown character
+- **Position tracking**: Verify Loc.Start/End byte offsets, baseOffset behavior
+- **Edge cases**: Empty input, whitespace-only, EOF
+
+Run with: `go test ./doris/parser/... -v`

--- a/doris/parser/keywords.go
+++ b/doris/parser/keywords.go
@@ -1474,6 +1474,11 @@ func TokenName(kind TokenKind) string {
 		tokenNames[tokDotDotDot] = "..."
 		tokenNames[tokHintStart] = "HINT_START"
 		tokenNames[tokHintEnd] = "HINT_END"
+		// Fix non-determinism for aliases that map multiple strings
+		// to the same TokenKind (e.g., "char"/"character" -> kwCHAR).
+		tokenNames[kwCHAR] = "CHAR"
+		tokenNames[kwTYPECAST] = "TYPECAST"
+		tokenNames[kwCONVERT_LSC] = "CONVERT_LSC"
 	}
 	if name, ok := tokenNames[kind]; ok {
 		return name

--- a/doris/parser/keywords.go
+++ b/doris/parser/keywords.go
@@ -1,0 +1,1485 @@
+package parser
+
+import "strings"
+
+// Keyword token constants. Values start at 700 and grow with iota.
+// Extracted from /Users/h3n4l/OpenSource/parser/doris/DorisLexer.g4 (531 keywords).
+// Numeric values are NOT stable across edits — do not persist them.
+const (
+	kwACCOUNT_LOCK   TokenKind = 700 + iota
+	kwACCOUNT_UNLOCK            // ACCOUNT_UNLOCK
+	kwACTIONS
+	kwADD
+	kwADMIN
+	kwAFTER
+	kwAGG_STATE
+	kwAGGREGATE
+	kwALIAS
+	kwALL
+	kwALTER
+	kwALWAYS
+	kwANALYZE
+	kwANALYZED
+	kwANALYZER
+	kwAND
+	kwANN
+	kwANTI
+	kwAPPEND
+	kwARRAY
+	kwAS
+	kwASC
+	kwAT
+	kwAUTHORS
+	kwAUTO
+	kwAUTO_INCREMENT
+	kwBACKEND
+	kwBACKENDS
+	kwBACKUP
+	kwBEGIN
+	kwBELONG
+	kwBETWEEN
+	kwBIGINT
+	kwBIN
+	kwBINARY
+	kwBINLOG
+	kwBITAND
+	kwBITMAP
+	kwBITMAP_EMPTY
+	kwBITMAP_UNION
+	kwBITOR
+	kwBITXOR
+	kwBLOB
+	kwBOOLEAN
+	kwBOTH
+	kwBRANCH
+	kwBRIEF
+	kwBROKER
+	kwBUCKETS
+	kwBUILD
+	kwBUILTIN
+	kwBULK
+	kwBY
+	kwCACHE
+	kwCACHED
+	kwCALL
+	kwCANCEL
+	kwCASE
+	kwCAST
+	kwCATALOG
+	kwCATALOGS
+	kwCHAIN
+	kwCHAR // also matches 'CHARACTER'
+	kwCHAR_FILTER
+	kwCHARSET
+	kwCHECK
+	kwCLEAN
+	kwCLUSTER
+	kwCLUSTERS
+	kwCOLLATE
+	kwCOLLATION
+	kwCOLLECT
+	kwCOLOCATE
+	kwCOLUMN
+	kwCOLUMNS
+	kwCOMMENT
+	kwCOMMIT
+	kwCOMMITTED
+	kwCOMPACT
+	kwCOMPLETE
+	kwCOMPRESS_TYPE
+	kwCOMPUTE
+	kwCONDITIONS
+	kwCONFIG
+	kwCONNECTION
+	kwCONNECTION_ID
+	kwCONSISTENT
+	kwCONSTRAINT
+	kwCONSTRAINTS
+	kwCONVERT
+	kwCONVERT_LSC // matches 'CONVERT_LIGHT_SCHEMA_CHANGE_PROCESS'
+	kwCOPY
+	kwCOUNT
+	kwCREATE
+	kwCREATION
+	kwCRON
+	kwCROSS
+	kwCUBE
+	kwCURRENT
+	kwCURRENT_CATALOG
+	kwCURRENT_DATE
+	kwCURRENT_TIME
+	kwCURRENT_TIMESTAMP
+	kwCURRENT_USER
+	kwDATA
+	kwDATABASE
+	kwDATABASES
+	kwDATE
+	kwDATETIME
+	kwDATETIMEV1
+	kwDATETIMEV2
+	kwDATEV1
+	kwDATEV2
+	kwDAY
+	kwDAY_HOUR
+	kwDAY_SECOND
+	kwDAYS
+	kwDECIMAL
+	kwDECIMALV2
+	kwDECIMALV3
+	kwDECOMMISSION
+	kwDEFAULT
+	kwDEFERRED
+	kwDELETE
+	kwDEMAND
+	kwDESC
+	kwDESCRIBE
+	kwDIAGNOSE
+	kwDIAGNOSIS
+	kwDICTIONARIES
+	kwDICTIONARY
+	kwDISK
+	kwDISTINCT
+	kwDISTINCTPC
+	kwDISTINCTPCSA
+	kwDISTRIBUTED
+	kwDISTRIBUTION
+	kwDIV
+	kwDO
+	kwDORIS_INTERNAL_TABLE_ID
+	kwDOUBLE
+	kwDROP
+	kwDROPP
+	kwDUAL
+	kwDUMP
+	kwDUPLICATE
+	kwDYNAMIC
+	kwE
+	kwELSE
+	kwENABLE
+	kwENCRYPTION
+	kwENCRYPTKEY
+	kwENCRYPTKEYS
+	kwEND
+	kwENDS
+	kwENGINE
+	kwENGINES
+	kwENTER
+	kwERRORS
+	kwESCAPE
+	kwEVENTS
+	kwEVERY
+	kwEXCEPT
+	kwEXCLUDE
+	kwEXECUTE
+	kwEXISTS
+	kwEXPIRED
+	kwEXPLAIN
+	kwEXPORT
+	kwEXTENDED
+	kwEXTERNAL
+	kwEXTRACT
+	kwFAILED_LOGIN_ATTEMPTS
+	kwFALSE
+	kwFAST
+	kwFEATURE
+	kwFIELDS
+	kwFILE
+	kwFILTER
+	kwFIRST
+	kwFLOAT
+	kwFOLLOWER
+	kwFOLLOWING
+	kwFOR
+	kwFOREIGN
+	kwFORCE
+	kwFORMAT
+	kwFREE
+	kwFROM
+	kwFRONTEND
+	kwFRONTENDS
+	kwFULL
+	kwFUNCTION
+	kwFUNCTIONS
+	kwGENERATED
+	kwGENERIC
+	kwGLOBAL
+	kwGRANT
+	kwGRANTS
+	kwGRAPH
+	kwGROUP
+	kwGROUP_CONCAT
+	kwGROUPING
+	kwGROUPS
+	kwHASH
+	kwHASH_MAP
+	kwHAVING
+	kwHDFS
+	kwHELP
+	kwHISTOGRAM
+	kwHLL
+	kwHLL_UNION
+	kwHOSTNAME
+	kwHOTSPOT
+	kwHOUR
+	kwHOURS
+	kwHUB
+	kwIDENTIFIED
+	kwIF
+	kwIGNORE
+	kwIMMEDIATE
+	kwIN
+	kwINCREMENTAL
+	kwINDEX
+	kwINDEXES
+	kwINFILE
+	kwINNER
+	kwINSERT
+	kwINSTALL
+	kwINT
+	kwINTEGER
+	kwINTERMEDIATE
+	kwINTERSECT
+	kwINTERVAL
+	kwINTO
+	kwINVERTED
+	kwIP_TRIE
+	kwIPV4
+	kwIPV6
+	kwIS
+	kwIS_NOT_NULL_PRED
+	kwIS_NULL_PRED
+	kwISNULL
+	kwISOLATION
+	kwJOB
+	kwJOBS
+	kwJOIN
+	kwJSON
+	kwJSONB
+	kwKEY
+	kwKEYS
+	kwKILL
+	kwLABEL
+	kwLARGEINT
+	kwLAST
+	kwLATERAL
+	kwLAYOUT
+	kwLDAP
+	kwLDAP_ADMIN_PASSWORD
+	kwLEADING
+	kwLEFT
+	kwLESS
+	kwLEVEL
+	kwLIKE
+	kwLIMIT
+	kwLINES
+	kwLINK
+	kwLIST
+	kwLOAD
+	kwLOCAL
+	kwLOCALTIME
+	kwLOCALTIMESTAMP
+	kwLOCATION
+	kwLOCK
+	kwLOGICAL
+	kwLOW_PRIORITY
+	kwMANUAL
+	kwMAP
+	kwMATCH
+	kwMATCH_ALL
+	kwMATCH_ANY
+	kwMATCH_NAME
+	kwMATCH_NAME_GLOB
+	kwMATCH_PHRASE
+	kwMATCH_PHRASE_EDGE
+	kwMATCH_PHRASE_PREFIX
+	kwMATCH_REGEXP
+	kwMATCHED
+	kwMATERIALIZED
+	kwMAX
+	kwMAXVALUE
+	kwMEMO
+	kwMERGE
+	kwMID
+	kwMIGRATE
+	kwMIGRATIONS
+	kwMIN
+	kwMINUS
+	kwMINUTE
+	kwMINUTE_SECOND
+	kwMINUTES
+	kwMODIFY
+	kwMONTH
+	kwMTMV
+	kwNAME
+	kwNAMES
+	kwNATURAL
+	kwNEGATIVE
+	kwNEVER
+	kwNEXT
+	kwNGRAM_BF
+	kwNO
+	kwNO_USE_MV
+	kwNON_NULLABLE
+	kwNOT
+	kwNULL
+	kwNULLS
+	kwOBSERVER
+	kwOF
+	kwOFF
+	kwOFFSET
+	kwON
+	kwONLY
+	kwOPEN
+	kwOPTIMIZE
+	kwOPTIMIZED
+	kwOR
+	kwORDER
+	kwOUTER
+	kwOUTFILE
+	kwOVER
+	kwOVERWRITE
+	kwPARAMETER
+	kwPARSED
+	kwPARTITION
+	kwPARTITIONS
+	kwPASSWORD
+	kwPASSWORD_EXPIRE
+	kwPASSWORD_HISTORY
+	kwPASSWORD_LOCK_TIME
+	kwPASSWORD_REUSE
+	kwPATH
+	kwPAUSE
+	kwPERCENT
+	kwPERIOD
+	kwPERMISSIVE
+	kwPHYSICAL
+	kwPI
+	kwPLAN
+	kwPLAY
+	kwPLUGIN
+	kwPLUGINS
+	kwPOLICY
+	kwPOSITION
+	kwPRECEDING
+	kwPREPARE
+	kwPRIMARY
+	kwPRIVILEGES
+	kwPROC
+	kwPROCEDURE
+	kwPROCESS
+	kwPROCESSLIST
+	kwPROFILE
+	kwPROPERTIES
+	kwPROPERTY
+	kwQUALIFY
+	kwQUANTILE_STATE
+	kwQUANTILE_UNION
+	kwQUARTER
+	kwQUERY
+	kwQUEUED
+	kwQUOTA
+	kwRANDOM
+	kwRANGE
+	kwREAD
+	kwREAL
+	kwREBALANCE
+	kwRECENT
+	kwRECOVER
+	kwRECYCLE
+	kwREFERENCES
+	kwREFRESH
+	kwREGEXP
+	kwRELEASE
+	kwRENAME
+	kwREPAIR
+	kwREPEATABLE
+	kwREPLACE
+	kwREPLACE_IF_NOT_NULL
+	kwREPLAYER
+	kwREPLICA
+	kwREPOSITORIES
+	kwREPOSITORY
+	kwRESOURCE
+	kwRESOURCES
+	kwRESTORE
+	kwRESTRICTIVE
+	kwRESUME
+	kwRETAIN
+	kwRETENTION
+	kwRETURNS
+	kwREVOKE
+	kwREWRITTEN
+	kwRIGHT
+	kwRLIKE
+	kwROLE
+	kwROLES
+	kwROLLBACK
+	kwROLLUP
+	kwROOT
+	kwROTATE
+	kwROUTINE
+	kwROW
+	kwROWS
+	kwS3
+	kwSAMPLE
+	kwSCHEDULE
+	kwSCHEDULER
+	kwSCHEMA
+	kwSCHEMAS
+	kwSECOND
+	kwSELECT
+	kwSEMI
+	kwSEPARATOR
+	kwSERIALIZABLE
+	kwSESSION
+	kwSESSION_USER
+	kwSET
+	kwSET_SESSION_VARIABLE
+	kwSETS
+	kwSHAPE
+	kwSHOW
+	kwSIGNED
+	kwSKEW
+	kwSMALLINT
+	kwSNAPSHOT
+	kwSNAPSHOTS
+	kwSONAME
+	kwSPLIT
+	kwSQL
+	kwSQL_BLOCK_RULE
+	kwSTAGE
+	kwSTAGES
+	kwSTART
+	kwSTARTS
+	kwSTATS
+	kwSTATUS
+	kwSTOP
+	kwSTORAGE
+	kwSTREAM
+	kwSTREAMING
+	kwSTRING
+	kwSTRUCT
+	kwSUBSTR
+	kwSUBSTRING
+	kwSUM
+	kwSUPERUSER
+	kwSWITCH
+	kwSYNC
+	kwSYSTEM
+	kwTABLE
+	kwTABLES
+	kwTABLESAMPLE
+	kwTABLET
+	kwTABLETS
+	kwTAG
+	kwTASK
+	kwTASKS
+	kwTDE
+	kwTEMPORARY
+	kwTERMINATED
+	kwTEXT
+	kwTHAN
+	kwTHEN
+	kwTIME
+	kwTIMESTAMP
+	kwTINYINT
+	kwTO
+	kwTOKEN_FILTER
+	kwTOKENIZER
+	kwTRAILING
+	kwTRANSACTION
+	kwTRASH
+	kwTREE
+	kwTRIGGERS
+	kwTRIM
+	kwTRUE
+	kwTRUNCATE
+	kwTRY_CAST
+	kwTYPE
+	kwTYPECAST // matches 'TYPE_CAST'
+	kwTYPES
+	kwUNBOUNDED
+	kwUNCOMMITTED
+	kwUNINSTALL
+	kwUNION
+	kwUNIQUE
+	kwUNLOCK
+	kwUNSET
+	kwUNSIGNED
+	kwUP
+	kwUPDATE
+	kwUSE
+	kwUSE_MV
+	kwUSER
+	kwUSING
+	kwVALUE
+	kwVALUES
+	kwVARBINARY
+	kwVARCHAR
+	kwVARIABLE
+	kwVARIABLES
+	kwVARIANT
+	kwVAULT
+	kwVAULTS
+	kwVERBOSE
+	kwVERSION
+	kwVIEW
+	kwVIEWS
+	kwWARM
+	kwWARNINGS
+	kwWEEK
+	kwWHEN
+	kwWHERE
+	kwWHITELIST
+	kwWITH
+	kwWORK
+	kwWORKLOAD
+	kwWRITE
+	kwXOR
+	kwYEAR
+)
+
+// keywordMap maps lowercase keyword strings to their token kinds.
+// Case-insensitive lookup is performed by lowercasing the input in KeywordToken.
+var keywordMap = map[string]TokenKind{
+	"account_lock":                         kwACCOUNT_LOCK,
+	"account_unlock":                       kwACCOUNT_UNLOCK,
+	"actions":                              kwACTIONS,
+	"add":                                  kwADD,
+	"admin":                                kwADMIN,
+	"after":                                kwAFTER,
+	"agg_state":                            kwAGG_STATE,
+	"aggregate":                            kwAGGREGATE,
+	"alias":                                kwALIAS,
+	"all":                                  kwALL,
+	"alter":                                kwALTER,
+	"always":                               kwALWAYS,
+	"analyze":                              kwANALYZE,
+	"analyzed":                             kwANALYZED,
+	"analyzer":                             kwANALYZER,
+	"and":                                  kwAND,
+	"ann":                                  kwANN,
+	"anti":                                 kwANTI,
+	"append":                               kwAPPEND,
+	"array":                                kwARRAY,
+	"as":                                   kwAS,
+	"asc":                                  kwASC,
+	"at":                                   kwAT,
+	"authors":                              kwAUTHORS,
+	"auto":                                 kwAUTO,
+	"auto_increment":                       kwAUTO_INCREMENT,
+	"backend":                              kwBACKEND,
+	"backends":                             kwBACKENDS,
+	"backup":                               kwBACKUP,
+	"begin":                                kwBEGIN,
+	"belong":                               kwBELONG,
+	"between":                              kwBETWEEN,
+	"bigint":                               kwBIGINT,
+	"bin":                                  kwBIN,
+	"binary":                               kwBINARY,
+	"binlog":                               kwBINLOG,
+	"bitand":                               kwBITAND,
+	"bitmap":                               kwBITMAP,
+	"bitmap_empty":                         kwBITMAP_EMPTY,
+	"bitmap_union":                         kwBITMAP_UNION,
+	"bitor":                                kwBITOR,
+	"bitxor":                               kwBITXOR,
+	"blob":                                 kwBLOB,
+	"boolean":                              kwBOOLEAN,
+	"both":                                 kwBOTH,
+	"branch":                               kwBRANCH,
+	"brief":                                kwBRIEF,
+	"broker":                               kwBROKER,
+	"buckets":                              kwBUCKETS,
+	"build":                                kwBUILD,
+	"builtin":                              kwBUILTIN,
+	"bulk":                                 kwBULK,
+	"by":                                   kwBY,
+	"cache":                                kwCACHE,
+	"cached":                               kwCACHED,
+	"call":                                 kwCALL,
+	"cancel":                               kwCANCEL,
+	"case":                                 kwCASE,
+	"cast":                                 kwCAST,
+	"catalog":                              kwCATALOG,
+	"catalogs":                             kwCATALOGS,
+	"chain":                                kwCHAIN,
+	"char":                                 kwCHAR,
+	"character":                            kwCHAR, // alias for CHAR
+	"char_filter":                          kwCHAR_FILTER,
+	"charset":                              kwCHARSET,
+	"check":                                kwCHECK,
+	"clean":                                kwCLEAN,
+	"cluster":                              kwCLUSTER,
+	"clusters":                             kwCLUSTERS,
+	"collate":                              kwCOLLATE,
+	"collation":                            kwCOLLATION,
+	"collect":                              kwCOLLECT,
+	"colocate":                             kwCOLOCATE,
+	"column":                               kwCOLUMN,
+	"columns":                              kwCOLUMNS,
+	"comment":                              kwCOMMENT,
+	"commit":                               kwCOMMIT,
+	"committed":                            kwCOMMITTED,
+	"compact":                              kwCOMPACT,
+	"complete":                             kwCOMPLETE,
+	"compress_type":                        kwCOMPRESS_TYPE,
+	"compute":                              kwCOMPUTE,
+	"conditions":                           kwCONDITIONS,
+	"config":                               kwCONFIG,
+	"connection":                           kwCONNECTION,
+	"connection_id":                        kwCONNECTION_ID,
+	"consistent":                           kwCONSISTENT,
+	"constraint":                           kwCONSTRAINT,
+	"constraints":                          kwCONSTRAINTS,
+	"convert":                              kwCONVERT,
+	"convert_light_schema_change_process":  kwCONVERT_LSC,
+	"copy":                                 kwCOPY,
+	"count":                                kwCOUNT,
+	"create":                               kwCREATE,
+	"creation":                             kwCREATION,
+	"cron":                                 kwCRON,
+	"cross":                                kwCROSS,
+	"cube":                                 kwCUBE,
+	"current":                              kwCURRENT,
+	"current_catalog":                      kwCURRENT_CATALOG,
+	"current_date":                         kwCURRENT_DATE,
+	"current_time":                         kwCURRENT_TIME,
+	"current_timestamp":                    kwCURRENT_TIMESTAMP,
+	"current_user":                         kwCURRENT_USER,
+	"data":                                 kwDATA,
+	"database":                             kwDATABASE,
+	"databases":                            kwDATABASES,
+	"date":                                 kwDATE,
+	"datetime":                             kwDATETIME,
+	"datetimev1":                           kwDATETIMEV1,
+	"datetimev2":                           kwDATETIMEV2,
+	"datev1":                               kwDATEV1,
+	"datev2":                               kwDATEV2,
+	"day":                                  kwDAY,
+	"day_hour":                             kwDAY_HOUR,
+	"day_second":                           kwDAY_SECOND,
+	"days":                                 kwDAYS,
+	"decimal":                              kwDECIMAL,
+	"decimalv2":                            kwDECIMALV2,
+	"decimalv3":                            kwDECIMALV3,
+	"decommission":                         kwDECOMMISSION,
+	"default":                              kwDEFAULT,
+	"deferred":                             kwDEFERRED,
+	"delete":                               kwDELETE,
+	"demand":                               kwDEMAND,
+	"desc":                                 kwDESC,
+	"describe":                             kwDESCRIBE,
+	"diagnose":                             kwDIAGNOSE,
+	"diagnosis":                            kwDIAGNOSIS,
+	"dictionaries":                         kwDICTIONARIES,
+	"dictionary":                           kwDICTIONARY,
+	"disk":                                 kwDISK,
+	"distinct":                             kwDISTINCT,
+	"distinctpc":                           kwDISTINCTPC,
+	"distinctpcsa":                         kwDISTINCTPCSA,
+	"distributed":                          kwDISTRIBUTED,
+	"distribution":                         kwDISTRIBUTION,
+	"div":                                  kwDIV,
+	"do":                                   kwDO,
+	"doris_internal_table_id":              kwDORIS_INTERNAL_TABLE_ID,
+	"double":                               kwDOUBLE,
+	"drop":                                 kwDROP,
+	"dropp":                                kwDROPP,
+	"dual":                                 kwDUAL,
+	"dump":                                 kwDUMP,
+	"duplicate":                            kwDUPLICATE,
+	"dynamic":                              kwDYNAMIC,
+	"e":                                    kwE,
+	"else":                                 kwELSE,
+	"enable":                               kwENABLE,
+	"encryption":                           kwENCRYPTION,
+	"encryptkey":                           kwENCRYPTKEY,
+	"encryptkeys":                          kwENCRYPTKEYS,
+	"end":                                  kwEND,
+	"ends":                                 kwENDS,
+	"engine":                               kwENGINE,
+	"engines":                              kwENGINES,
+	"enter":                                kwENTER,
+	"errors":                               kwERRORS,
+	"escape":                               kwESCAPE,
+	"events":                               kwEVENTS,
+	"every":                                kwEVERY,
+	"except":                               kwEXCEPT,
+	"exclude":                              kwEXCLUDE,
+	"execute":                              kwEXECUTE,
+	"exists":                               kwEXISTS,
+	"expired":                              kwEXPIRED,
+	"explain":                              kwEXPLAIN,
+	"export":                               kwEXPORT,
+	"extended":                             kwEXTENDED,
+	"external":                             kwEXTERNAL,
+	"extract":                              kwEXTRACT,
+	"failed_login_attempts":                kwFAILED_LOGIN_ATTEMPTS,
+	"false":                                kwFALSE,
+	"fast":                                 kwFAST,
+	"feature":                              kwFEATURE,
+	"fields":                               kwFIELDS,
+	"file":                                 kwFILE,
+	"filter":                               kwFILTER,
+	"first":                                kwFIRST,
+	"float":                                kwFLOAT,
+	"follower":                             kwFOLLOWER,
+	"following":                            kwFOLLOWING,
+	"for":                                  kwFOR,
+	"foreign":                              kwFOREIGN,
+	"force":                                kwFORCE,
+	"format":                               kwFORMAT,
+	"free":                                 kwFREE,
+	"from":                                 kwFROM,
+	"frontend":                             kwFRONTEND,
+	"frontends":                            kwFRONTENDS,
+	"full":                                 kwFULL,
+	"function":                             kwFUNCTION,
+	"functions":                            kwFUNCTIONS,
+	"generated":                            kwGENERATED,
+	"generic":                              kwGENERIC,
+	"global":                               kwGLOBAL,
+	"grant":                                kwGRANT,
+	"grants":                               kwGRANTS,
+	"graph":                                kwGRAPH,
+	"group":                                kwGROUP,
+	"group_concat":                         kwGROUP_CONCAT,
+	"grouping":                             kwGROUPING,
+	"groups":                               kwGROUPS,
+	"hash":                                 kwHASH,
+	"hash_map":                             kwHASH_MAP,
+	"having":                               kwHAVING,
+	"hdfs":                                 kwHDFS,
+	"help":                                 kwHELP,
+	"histogram":                            kwHISTOGRAM,
+	"hll":                                  kwHLL,
+	"hll_union":                            kwHLL_UNION,
+	"hostname":                             kwHOSTNAME,
+	"hotspot":                              kwHOTSPOT,
+	"hour":                                 kwHOUR,
+	"hours":                                kwHOURS,
+	"hub":                                  kwHUB,
+	"identified":                           kwIDENTIFIED,
+	"if":                                   kwIF,
+	"ignore":                               kwIGNORE,
+	"immediate":                            kwIMMEDIATE,
+	"in":                                   kwIN,
+	"incremental":                          kwINCREMENTAL,
+	"index":                                kwINDEX,
+	"indexes":                              kwINDEXES,
+	"infile":                               kwINFILE,
+	"inner":                                kwINNER,
+	"insert":                               kwINSERT,
+	"install":                              kwINSTALL,
+	"int":                                  kwINT,
+	"integer":                              kwINTEGER,
+	"intermediate":                         kwINTERMEDIATE,
+	"intersect":                            kwINTERSECT,
+	"interval":                             kwINTERVAL,
+	"into":                                 kwINTO,
+	"inverted":                             kwINVERTED,
+	"ip_trie":                              kwIP_TRIE,
+	"ipv4":                                 kwIPV4,
+	"ipv6":                                 kwIPV6,
+	"is":                                   kwIS,
+	"is_not_null_pred":                     kwIS_NOT_NULL_PRED,
+	"is_null_pred":                         kwIS_NULL_PRED,
+	"isnull":                               kwISNULL,
+	"isolation":                            kwISOLATION,
+	"job":                                  kwJOB,
+	"jobs":                                 kwJOBS,
+	"join":                                 kwJOIN,
+	"json":                                 kwJSON,
+	"jsonb":                                kwJSONB,
+	"key":                                  kwKEY,
+	"keys":                                 kwKEYS,
+	"kill":                                 kwKILL,
+	"label":                                kwLABEL,
+	"largeint":                             kwLARGEINT,
+	"last":                                 kwLAST,
+	"lateral":                              kwLATERAL,
+	"layout":                               kwLAYOUT,
+	"ldap":                                 kwLDAP,
+	"ldap_admin_password":                  kwLDAP_ADMIN_PASSWORD,
+	"leading":                              kwLEADING,
+	"left":                                 kwLEFT,
+	"less":                                 kwLESS,
+	"level":                                kwLEVEL,
+	"like":                                 kwLIKE,
+	"limit":                                kwLIMIT,
+	"lines":                                kwLINES,
+	"link":                                 kwLINK,
+	"list":                                 kwLIST,
+	"load":                                 kwLOAD,
+	"local":                                kwLOCAL,
+	"localtime":                            kwLOCALTIME,
+	"localtimestamp":                       kwLOCALTIMESTAMP,
+	"location":                             kwLOCATION,
+	"lock":                                 kwLOCK,
+	"logical":                              kwLOGICAL,
+	"low_priority":                         kwLOW_PRIORITY,
+	"manual":                               kwMANUAL,
+	"map":                                  kwMAP,
+	"match":                                kwMATCH,
+	"match_all":                            kwMATCH_ALL,
+	"match_any":                            kwMATCH_ANY,
+	"match_name":                           kwMATCH_NAME,
+	"match_name_glob":                      kwMATCH_NAME_GLOB,
+	"match_phrase":                         kwMATCH_PHRASE,
+	"match_phrase_edge":                    kwMATCH_PHRASE_EDGE,
+	"match_phrase_prefix":                  kwMATCH_PHRASE_PREFIX,
+	"match_regexp":                         kwMATCH_REGEXP,
+	"matched":                              kwMATCHED,
+	"materialized":                         kwMATERIALIZED,
+	"max":                                  kwMAX,
+	"maxvalue":                             kwMAXVALUE,
+	"memo":                                 kwMEMO,
+	"merge":                                kwMERGE,
+	"mid":                                  kwMID,
+	"migrate":                              kwMIGRATE,
+	"migrations":                           kwMIGRATIONS,
+	"min":                                  kwMIN,
+	"minus":                                kwMINUS,
+	"minute":                               kwMINUTE,
+	"minute_second":                        kwMINUTE_SECOND,
+	"minutes":                              kwMINUTES,
+	"modify":                               kwMODIFY,
+	"month":                                kwMONTH,
+	"mtmv":                                 kwMTMV,
+	"name":                                 kwNAME,
+	"names":                                kwNAMES,
+	"natural":                              kwNATURAL,
+	"negative":                             kwNEGATIVE,
+	"never":                                kwNEVER,
+	"next":                                 kwNEXT,
+	"ngram_bf":                             kwNGRAM_BF,
+	"no":                                   kwNO,
+	"no_use_mv":                            kwNO_USE_MV,
+	"non_nullable":                         kwNON_NULLABLE,
+	"not":                                  kwNOT,
+	"null":                                 kwNULL,
+	"nulls":                                kwNULLS,
+	"observer":                             kwOBSERVER,
+	"of":                                   kwOF,
+	"off":                                  kwOFF,
+	"offset":                               kwOFFSET,
+	"on":                                   kwON,
+	"only":                                 kwONLY,
+	"open":                                 kwOPEN,
+	"optimize":                             kwOPTIMIZE,
+	"optimized":                            kwOPTIMIZED,
+	"or":                                   kwOR,
+	"order":                                kwORDER,
+	"outer":                                kwOUTER,
+	"outfile":                              kwOUTFILE,
+	"over":                                 kwOVER,
+	"overwrite":                            kwOVERWRITE,
+	"parameter":                            kwPARAMETER,
+	"parsed":                               kwPARSED,
+	"partition":                            kwPARTITION,
+	"partitions":                           kwPARTITIONS,
+	"password":                             kwPASSWORD,
+	"password_expire":                      kwPASSWORD_EXPIRE,
+	"password_history":                     kwPASSWORD_HISTORY,
+	"password_lock_time":                   kwPASSWORD_LOCK_TIME,
+	"password_reuse":                       kwPASSWORD_REUSE,
+	"path":                                 kwPATH,
+	"pause":                                kwPAUSE,
+	"percent":                              kwPERCENT,
+	"period":                               kwPERIOD,
+	"permissive":                           kwPERMISSIVE,
+	"physical":                             kwPHYSICAL,
+	"pi":                                   kwPI,
+	"plan":                                 kwPLAN,
+	"play":                                 kwPLAY,
+	"plugin":                               kwPLUGIN,
+	"plugins":                              kwPLUGINS,
+	"policy":                               kwPOLICY,
+	"position":                             kwPOSITION,
+	"preceding":                            kwPRECEDING,
+	"prepare":                              kwPREPARE,
+	"primary":                              kwPRIMARY,
+	"privileges":                           kwPRIVILEGES,
+	"proc":                                 kwPROC,
+	"procedure":                            kwPROCEDURE,
+	"process":                              kwPROCESS,
+	"processlist":                          kwPROCESSLIST,
+	"profile":                              kwPROFILE,
+	"properties":                           kwPROPERTIES,
+	"property":                             kwPROPERTY,
+	"qualify":                              kwQUALIFY,
+	"quantile_state":                       kwQUANTILE_STATE,
+	"quantile_union":                       kwQUANTILE_UNION,
+	"quarter":                              kwQUARTER,
+	"query":                                kwQUERY,
+	"queued":                               kwQUEUED,
+	"quota":                                kwQUOTA,
+	"random":                               kwRANDOM,
+	"range":                                kwRANGE,
+	"read":                                 kwREAD,
+	"real":                                 kwREAL,
+	"rebalance":                            kwREBALANCE,
+	"recent":                               kwRECENT,
+	"recover":                              kwRECOVER,
+	"recycle":                              kwRECYCLE,
+	"references":                           kwREFERENCES,
+	"refresh":                              kwREFRESH,
+	"regexp":                               kwREGEXP,
+	"release":                              kwRELEASE,
+	"rename":                               kwRENAME,
+	"repair":                               kwREPAIR,
+	"repeatable":                           kwREPEATABLE,
+	"replace":                              kwREPLACE,
+	"replace_if_not_null":                  kwREPLACE_IF_NOT_NULL,
+	"replayer":                             kwREPLAYER,
+	"replica":                              kwREPLICA,
+	"repositories":                         kwREPOSITORIES,
+	"repository":                           kwREPOSITORY,
+	"resource":                             kwRESOURCE,
+	"resources":                            kwRESOURCES,
+	"restore":                              kwRESTORE,
+	"restrictive":                          kwRESTRICTIVE,
+	"resume":                               kwRESUME,
+	"retain":                               kwRETAIN,
+	"retention":                            kwRETENTION,
+	"returns":                              kwRETURNS,
+	"revoke":                               kwREVOKE,
+	"rewritten":                            kwREWRITTEN,
+	"right":                                kwRIGHT,
+	"rlike":                                kwRLIKE,
+	"role":                                 kwROLE,
+	"roles":                                kwROLES,
+	"rollback":                             kwROLLBACK,
+	"rollup":                               kwROLLUP,
+	"root":                                 kwROOT,
+	"rotate":                               kwROTATE,
+	"routine":                              kwROUTINE,
+	"row":                                  kwROW,
+	"rows":                                 kwROWS,
+	"s3":                                   kwS3,
+	"sample":                               kwSAMPLE,
+	"schedule":                             kwSCHEDULE,
+	"scheduler":                            kwSCHEDULER,
+	"schema":                               kwSCHEMA,
+	"schemas":                              kwSCHEMAS,
+	"second":                               kwSECOND,
+	"select":                               kwSELECT,
+	"semi":                                 kwSEMI,
+	"separator":                            kwSEPARATOR,
+	"serializable":                         kwSERIALIZABLE,
+	"session":                              kwSESSION,
+	"session_user":                         kwSESSION_USER,
+	"set":                                  kwSET,
+	"set_session_variable":                 kwSET_SESSION_VARIABLE,
+	"sets":                                 kwSETS,
+	"shape":                                kwSHAPE,
+	"show":                                 kwSHOW,
+	"signed":                               kwSIGNED,
+	"skew":                                 kwSKEW,
+	"smallint":                             kwSMALLINT,
+	"snapshot":                             kwSNAPSHOT,
+	"snapshots":                            kwSNAPSHOTS,
+	"soname":                               kwSONAME,
+	"split":                                kwSPLIT,
+	"sql":                                  kwSQL,
+	"sql_block_rule":                       kwSQL_BLOCK_RULE,
+	"stage":                                kwSTAGE,
+	"stages":                               kwSTAGES,
+	"start":                                kwSTART,
+	"starts":                               kwSTARTS,
+	"stats":                                kwSTATS,
+	"status":                               kwSTATUS,
+	"stop":                                 kwSTOP,
+	"storage":                              kwSTORAGE,
+	"stream":                               kwSTREAM,
+	"streaming":                            kwSTREAMING,
+	"string":                               kwSTRING,
+	"struct":                               kwSTRUCT,
+	"substr":                               kwSUBSTR,
+	"substring":                            kwSUBSTRING,
+	"sum":                                  kwSUM,
+	"superuser":                            kwSUPERUSER,
+	"switch":                               kwSWITCH,
+	"sync":                                 kwSYNC,
+	"system":                               kwSYSTEM,
+	"table":                                kwTABLE,
+	"tables":                               kwTABLES,
+	"tablesample":                          kwTABLESAMPLE,
+	"tablet":                               kwTABLET,
+	"tablets":                              kwTABLETS,
+	"tag":                                  kwTAG,
+	"task":                                 kwTASK,
+	"tasks":                                kwTASKS,
+	"tde":                                  kwTDE,
+	"temporary":                            kwTEMPORARY,
+	"terminated":                           kwTERMINATED,
+	"text":                                 kwTEXT,
+	"than":                                 kwTHAN,
+	"then":                                 kwTHEN,
+	"time":                                 kwTIME,
+	"timestamp":                            kwTIMESTAMP,
+	"tinyint":                              kwTINYINT,
+	"to":                                   kwTO,
+	"token_filter":                         kwTOKEN_FILTER,
+	"tokenizer":                            kwTOKENIZER,
+	"trailing":                             kwTRAILING,
+	"transaction":                          kwTRANSACTION,
+	"trash":                                kwTRASH,
+	"tree":                                 kwTREE,
+	"triggers":                             kwTRIGGERS,
+	"trim":                                 kwTRIM,
+	"true":                                 kwTRUE,
+	"truncate":                             kwTRUNCATE,
+	"try_cast":                             kwTRY_CAST,
+	"type":                                 kwTYPE,
+	"type_cast":                            kwTYPECAST, // alias for TYPECAST
+	"types":                                kwTYPES,
+	"unbounded":                            kwUNBOUNDED,
+	"uncommitted":                          kwUNCOMMITTED,
+	"uninstall":                            kwUNINSTALL,
+	"union":                                kwUNION,
+	"unique":                               kwUNIQUE,
+	"unlock":                               kwUNLOCK,
+	"unset":                                kwUNSET,
+	"unsigned":                             kwUNSIGNED,
+	"up":                                   kwUP,
+	"update":                               kwUPDATE,
+	"use":                                  kwUSE,
+	"use_mv":                               kwUSE_MV,
+	"user":                                 kwUSER,
+	"using":                                kwUSING,
+	"value":                                kwVALUE,
+	"values":                               kwVALUES,
+	"varbinary":                            kwVARBINARY,
+	"varchar":                              kwVARCHAR,
+	"variable":                             kwVARIABLE,
+	"variables":                            kwVARIABLES,
+	"variant":                              kwVARIANT,
+	"vault":                                kwVAULT,
+	"vaults":                               kwVAULTS,
+	"verbose":                              kwVERBOSE,
+	"version":                              kwVERSION,
+	"view":                                 kwVIEW,
+	"views":                                kwVIEWS,
+	"warm":                                 kwWARM,
+	"warnings":                             kwWARNINGS,
+	"week":                                 kwWEEK,
+	"when":                                 kwWHEN,
+	"where":                                kwWHERE,
+	"whitelist":                            kwWHITELIST,
+	"with":                                 kwWITH,
+	"work":                                 kwWORK,
+	"workload":                             kwWORKLOAD,
+	"write":                                kwWRITE,
+	"xor":                                  kwXOR,
+	"year":                                 kwYEAR,
+}
+
+// nonReservedKeywords is the set of keywords that can be used as unquoted
+// identifiers. Seeded from the nonReserved rule in DorisParser.g4 (lines 1906-2257).
+// Note: COMMENT_START (/*), LEFT_BRACE ({), RIGHT_BRACE (}) and HINT_START/HINT_END
+// appear in the nonReserved grammar rule but are operators/punctuation, not keywords
+// handled here.
+var nonReservedKeywords = map[TokenKind]bool{
+	kwACTIONS:                true,
+	kwAFTER:                  true,
+	kwAGG_STATE:              true,
+	kwAGGREGATE:              true,
+	kwALIAS:                  true,
+	kwALWAYS:                 true,
+	kwANALYZED:               true,
+	kwANN:                    true,
+	kwARRAY:                  true,
+	kwAT:                     true,
+	kwAUTHORS:                true,
+	kwAUTO_INCREMENT:         true,
+	kwBACKENDS:               true,
+	kwBACKUP:                 true,
+	kwBEGIN:                  true,
+	kwBELONG:                 true,
+	kwBIN:                    true,
+	kwBITAND:                 true,
+	kwBITMAP:                 true,
+	kwBITMAP_EMPTY:           true,
+	kwBITMAP_UNION:           true,
+	kwBITOR:                  true,
+	kwBITXOR:                 true,
+	kwBLOB:                   true,
+	kwBOOLEAN:                true,
+	kwBRANCH:                 true,
+	kwBRIEF:                  true,
+	kwBROKER:                 true,
+	kwBUCKETS:                true,
+	kwBUILD:                  true,
+	kwBUILTIN:                true,
+	kwBULK:                   true,
+	kwCACHE:                  true,
+	kwCACHED:                 true,
+	kwCALL:                   true,
+	kwCATALOG:                true,
+	kwCATALOGS:               true,
+	kwCHAIN:                  true,
+	kwCHAR:                   true,
+	kwCHARSET:                true,
+	kwCHECK:                  true,
+	kwCLUSTER:                true,
+	kwCLUSTERS:               true,
+	kwCOLLATION:              true,
+	kwCOLLECT:                true,
+	kwCOLOCATE:               true,
+	kwCOLUMNS:                true,
+	kwCOMMENT:                true,
+	kwCOMMIT:                 true,
+	kwCOMMITTED:              true,
+	kwCOMPACT:                true,
+	kwCOMPLETE:               true,
+	kwCOMPRESS_TYPE:          true,
+	kwCOMPUTE:                true,
+	kwCONDITIONS:             true,
+	kwCONFIG:                 true,
+	kwCONNECTION:             true,
+	kwCONNECTION_ID:          true,
+	kwCONSISTENT:             true,
+	kwCONSTRAINTS:            true,
+	kwCONVERT:                true,
+	kwCONVERT_LSC:            true,
+	kwCOPY:                   true,
+	kwCOUNT:                  true,
+	kwCREATION:               true,
+	kwCRON:                   true,
+	kwCURRENT_CATALOG:        true,
+	kwCURRENT_DATE:           true,
+	kwCURRENT_TIME:           true,
+	kwCURRENT_TIMESTAMP:      true,
+	kwCURRENT_USER:           true,
+	kwDATA:                   true,
+	kwDATE:                   true,
+	kwDATETIME:               true,
+	kwDATETIMEV1:             true,
+	kwDATETIMEV2:             true,
+	kwDATEV1:                 true,
+	kwDATEV2:                 true,
+	kwDAY:                    true,
+	kwDAYS:                   true,
+	kwDECIMAL:                true,
+	kwDECIMALV2:              true,
+	kwDECIMALV3:              true,
+	kwDEFERRED:               true,
+	kwDEMAND:                 true,
+	kwDIAGNOSE:               true,
+	kwDIAGNOSIS:              true,
+	kwDICTIONARIES:           true,
+	kwDICTIONARY:             true,
+	kwDISTINCTPC:             true,
+	kwDISTINCTPCSA:           true,
+	kwDO:                     true,
+	kwDORIS_INTERNAL_TABLE_ID: true,
+	kwDUAL:                   true,
+	kwDYNAMIC:                true,
+	kwE:                      true,
+	kwENABLE:                 true,
+	kwENCRYPTION:             true,
+	kwENCRYPTKEY:             true,
+	kwENCRYPTKEYS:            true,
+	kwEND:                    true,
+	kwENDS:                   true,
+	kwENGINE:                 true,
+	kwENGINES:                true,
+	kwERRORS:                 true,
+	kwESCAPE:                 true,
+	kwEVENTS:                 true,
+	kwEVERY:                  true,
+	kwEXCLUDE:                true,
+	kwEXPIRED:                true,
+	kwEXTERNAL:               true,
+	kwFAILED_LOGIN_ATTEMPTS:  true,
+	kwFAST:                   true,
+	kwFEATURE:                true,
+	kwFIELDS:                 true,
+	kwFILE:                   true,
+	kwFILTER:                 true,
+	kwFIRST:                  true,
+	kwFORMAT:                 true,
+	kwFREE:                   true,
+	kwFRONTENDS:              true,
+	kwFUNCTION:               true,
+	kwGENERATED:              true,
+	kwGENERIC:                true,
+	kwGLOBAL:                 true,
+	kwGRAPH:                  true,
+	kwGROUPING:               true,
+	kwGROUPS:                 true,
+	kwGROUP_CONCAT:           true,
+	kwHASH:                   true,
+	kwHASH_MAP:               true,
+	kwHDFS:                   true,
+	kwHELP:                   true,
+	kwHISTOGRAM:              true,
+	kwHLL_UNION:              true,
+	kwHOSTNAME:               true,
+	kwHOTSPOT:                true,
+	kwHOUR:                   true,
+	kwHOURS:                  true,
+	kwHUB:                    true,
+	kwIDENTIFIED:             true,
+	kwIGNORE:                 true,
+	kwIMMEDIATE:              true,
+	kwINCREMENTAL:            true,
+	kwINDEXES:                true,
+	kwINSERT:                 true,
+	kwINVERTED:               true,
+	kwIP_TRIE:                true,
+	kwIPV4:                   true,
+	kwIPV6:                   true,
+	kwIS_NOT_NULL_PRED:       true,
+	kwIS_NULL_PRED:           true,
+	kwISNULL:                 true,
+	kwISOLATION:              true,
+	kwJOB:                    true,
+	kwJOBS:                   true,
+	kwJSON:                   true,
+	kwJSONB:                  true,
+	kwLABEL:                  true,
+	kwLAST:                   true,
+	kwLDAP:                   true,
+	kwLDAP_ADMIN_PASSWORD:    true,
+	kwLESS:                   true,
+	kwLEVEL:                  true,
+	kwLINES:                  true,
+	kwLINK:                   true,
+	kwLOCAL:                  true,
+	kwLOCALTIME:              true,
+	kwLOCALTIMESTAMP:         true,
+	kwLOCATION:               true,
+	kwLOCK:                   true,
+	kwLOGICAL:                true,
+	kwMANUAL:                 true,
+	kwMAP:                    true,
+	kwMATCHED:                true,
+	kwMATCH_ALL:              true,
+	kwMATCH_ANY:              true,
+	kwMATCH_PHRASE:           true,
+	kwMATCH_PHRASE_EDGE:      true,
+	kwMATCH_PHRASE_PREFIX:    true,
+	kwMATCH_REGEXP:           true,
+	kwMATCH_NAME:             true,
+	kwMATCH_NAME_GLOB:        true,
+	kwMATERIALIZED:           true,
+	kwMAX:                    true,
+	kwMEMO:                   true,
+	kwMERGE:                  true,
+	kwMID:                    true,
+	kwMIGRATE:                true,
+	kwMIGRATIONS:             true,
+	kwMIN:                    true,
+	kwMINUTE:                 true,
+	kwMINUTES:                true,
+	kwMODIFY:                 true,
+	kwMONTH:                  true,
+	kwMTMV:                   true,
+	kwNAME:                   true,
+	kwNAMES:                  true,
+	kwNEGATIVE:               true,
+	kwNEVER:                  true,
+	kwNEXT:                   true,
+	kwNGRAM_BF:               true,
+	kwNO:                     true,
+	kwNON_NULLABLE:           true,
+	kwNULLS:                  true,
+	kwOF:                     true,
+	kwOFF:                    true,
+	kwOFFSET:                 true,
+	kwONLY:                   true,
+	kwOPEN:                   true,
+	kwOPTIMIZE:               true,
+	kwOPTIMIZED:              true,
+	kwPARAMETER:              true,
+	kwPARSED:                 true,
+	kwPASSWORD:               true,
+	kwPASSWORD_EXPIRE:        true,
+	kwPASSWORD_HISTORY:       true,
+	kwPASSWORD_LOCK_TIME:     true,
+	kwPASSWORD_REUSE:         true,
+	kwPARTITIONS:             true,
+	kwPATH:                   true,
+	kwPAUSE:                  true,
+	kwPERCENT:                true,
+	kwPERIOD:                 true,
+	kwPERMISSIVE:             true,
+	kwPHYSICAL:               true,
+	kwPI:                     true,
+	kwPLAN:                   true,
+	kwPLUGIN:                 true,
+	kwPLUGINS:                true,
+	kwPOLICY:                 true,
+	kwPOSITION:               true,
+	kwPRIVILEGES:             true,
+	kwPROC:                   true,
+	kwPROCESS:                true,
+	kwPROCESSLIST:            true,
+	kwPROFILE:                true,
+	kwPROPERTIES:             true,
+	kwPROPERTY:               true,
+	kwQUANTILE_STATE:         true,
+	kwQUANTILE_UNION:         true,
+	kwQUARTER:                true,
+	kwQUERY:                  true,
+	kwQUOTA:                  true,
+	kwQUALIFY:                true,
+	kwQUEUED:                 true,
+	kwRANDOM:                 true,
+	kwRECENT:                 true,
+	kwRECOVER:                true,
+	kwRECYCLE:                true,
+	kwREFRESH:                true,
+	kwREPEATABLE:             true,
+	kwREPLACE:                true,
+	kwREPLACE_IF_NOT_NULL:    true,
+	kwREPLAYER:               true,
+	kwREPOSITORIES:           true,
+	kwREPOSITORY:             true,
+	kwRESOURCE:               true,
+	kwRESOURCES:              true,
+	kwRESTORE:                true,
+	kwRESTRICTIVE:            true,
+	kwRESUME:                 true,
+	kwRETAIN:                 true,
+	kwRETENTION:              true,
+	kwRETURNS:                true,
+	kwREWRITTEN:              true,
+	kwRLIKE:                  true,
+	kwROLLBACK:               true,
+	kwROLLUP:                 true,
+	kwROOT:                   true,
+	kwROTATE:                 true,
+	kwROUTINE:                true,
+	kwS3:                     true,
+	kwSAMPLE:                 true,
+	kwSCHEDULE:               true,
+	kwSCHEDULER:              true,
+	kwSCHEMA:                 true,
+	kwSECOND:                 true,
+	kwSEPARATOR:              true,
+	kwSERIALIZABLE:           true,
+	kwSET_SESSION_VARIABLE:   true,
+	kwSESSION:                true,
+	kwSESSION_USER:           true,
+	kwSHAPE:                  true,
+	kwSKEW:                   true,
+	kwSNAPSHOT:               true,
+	kwSNAPSHOTS:              true,
+	kwSONAME:                 true,
+	kwSPLIT:                  true,
+	kwSQL:                    true,
+	kwSTAGE:                  true,
+	kwSTAGES:                 true,
+	kwSTART:                  true,
+	kwSTARTS:                 true,
+	kwSTATS:                  true,
+	kwSTATUS:                 true,
+	kwSTOP:                   true,
+	kwSTORAGE:                true,
+	kwSTREAM:                 true,
+	kwSTREAMING:              true,
+	kwSTRING:                 true,
+	kwSTRUCT:                 true,
+	kwSUBSTR:                 true,
+	kwSUBSTRING:              true,
+	kwSUM:                    true,
+	kwTABLES:                 true,
+	kwTAG:                    true,
+	kwTASK:                   true,
+	kwTASKS:                  true,
+	kwTDE:                    true,
+	kwTEMPORARY:              true,
+	kwTEXT:                   true,
+	kwTHAN:                   true,
+	kwTIME:                   true,
+	kwTIMESTAMP:              true,
+	kwTRANSACTION:            true,
+	kwTREE:                   true,
+	kwTRIGGERS:               true,
+	kwTRUNCATE:               true,
+	kwTYPE:                   true,
+	kwTYPES:                  true,
+	kwUNCOMMITTED:            true,
+	kwUNLOCK:                 true,
+	kwUNSET:                  true,
+	kwUP:                     true,
+	kwUSER:                   true,
+	kwVALUE:                  true,
+	kwVARBINARY:              true,
+	kwVARCHAR:                true,
+	kwVARIABLE:               true,
+	kwVARIABLES:              true,
+	kwVARIANT:                true,
+	kwVAULT:                  true,
+	kwVAULTS:                 true,
+	kwVERBOSE:                true,
+	kwVERSION:                true,
+	kwVIEW:                   true,
+	kwVIEWS:                  true,
+	kwWARM:                   true,
+	kwWARNINGS:               true,
+	kwWEEK:                   true,
+	kwWORK:                   true,
+	kwYEAR:                   true,
+}
+
+// KeywordToken returns the keyword TokenKind for a name, or (0, false)
+// if name is not a keyword. Lookup is case-insensitive.
+func KeywordToken(name string) (TokenKind, bool) {
+	kind, ok := keywordMap[strings.ToLower(name)]
+	return kind, ok
+}
+
+// IsReserved reports whether kind is a reserved keyword that cannot be
+// used as an unquoted identifier.
+func IsReserved(kind TokenKind) bool {
+	return kind >= 700 && !nonReservedKeywords[kind]
+}
+
+// tokenNames is lazily initialized by TokenName.
+var tokenNames map[TokenKind]string
+
+// TokenName returns a human-readable name for a TokenKind.
+func TokenName(kind TokenKind) string {
+	if tokenNames == nil {
+		tokenNames = make(map[TokenKind]string, len(keywordMap)+20)
+		for name, k := range keywordMap {
+			tokenNames[k] = strings.ToUpper(name)
+		}
+		tokenNames[tokEOF] = "EOF"
+		tokenNames[tokInvalid] = "INVALID"
+		tokenNames[tokInt] = "INT"
+		tokenNames[tokFloat] = "FLOAT"
+		tokenNames[tokString] = "STRING"
+		tokenNames[tokIdent] = "IDENT"
+		tokenNames[tokQuotedIdent] = "QUOTED_IDENT"
+		tokenNames[tokHexLiteral] = "HEX_LITERAL"
+		tokenNames[tokBitLiteral] = "BIT_LITERAL"
+		tokenNames[tokPlaceholder] = "PLACEHOLDER"
+		tokenNames[tokLessEq] = "<="
+		tokenNames[tokGreaterEq] = ">="
+		tokenNames[tokNotEq] = "<>"
+		tokenNames[tokNullSafeEq] = "<=>"
+		tokenNames[tokLogicalAnd] = "&&"
+		tokenNames[tokDoublePipes] = "||"
+		tokenNames[tokShiftLeft] = "<<"
+		tokenNames[tokShiftRight] = ">>"
+		tokenNames[tokArrow] = "->"
+		tokenNames[tokDoubleAt] = "@@"
+		tokenNames[tokAssign] = ":="
+		tokenNames[tokDotDotDot] = "..."
+		tokenNames[tokHintStart] = "HINT_START"
+		tokenNames[tokHintEnd] = "HINT_END"
+	}
+	if name, ok := tokenNames[kind]; ok {
+		return name
+	}
+	if kind > 0 && kind < 128 {
+		return string(rune(kind))
+	}
+	return "UNKNOWN"
+}

--- a/doris/parser/lexer.go
+++ b/doris/parser/lexer.go
@@ -17,8 +17,7 @@ type Lexer struct {
 	pos        int // current byte offset
 	start      int // start byte of current token
 	errors     []LexError
-	baseOffset int  // added to Loc positions on return
-	inHint     bool // true between /*+ and */
+	baseOffset int // added to Loc positions on return
 }
 
 // NewLexer creates a lexer for the given input.

--- a/doris/parser/lexer.go
+++ b/doris/parser/lexer.go
@@ -1,0 +1,518 @@
+package parser
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// Lexer is a Doris SQL tokenizer. Construct via NewLexer (or
+// NewLexerWithOffset when tokenizing a substring) and call NextToken
+// until it returns Token{Kind: tokEOF}. Lex errors are collected in
+// Errors; each error is accompanied by a tokInvalid token so consumers
+// can halt or proceed with best-effort parsing.
+type Lexer struct {
+	input      string
+	pos        int // current byte offset
+	start      int // start byte of current token
+	errors     []LexError
+	baseOffset int  // added to Loc positions on return
+	inHint     bool // true between /*+ and */
+}
+
+// NewLexer creates a lexer for the given input.
+func NewLexer(input string) *Lexer {
+	return &Lexer{input: input}
+}
+
+// NewLexerWithOffset creates a lexer whose emitted Loc values are shifted
+// by baseOffset. Used for multi-statement parsing.
+func NewLexerWithOffset(input string, baseOffset int) *Lexer {
+	return &Lexer{input: input, baseOffset: baseOffset}
+}
+
+// Errors returns all lex errors collected so far, with positions shifted
+// by baseOffset if applicable.
+func (l *Lexer) Errors() []LexError {
+	if l.baseOffset == 0 {
+		return l.errors
+	}
+	shifted := make([]LexError, len(l.errors))
+	for i, e := range l.errors {
+		shifted[i] = LexError{
+			Loc: ast.Loc{Start: e.Loc.Start + l.baseOffset, End: e.Loc.End + l.baseOffset},
+			Msg: e.Msg,
+		}
+	}
+	return shifted
+}
+
+// Tokenize is a one-shot convenience that lexes the entire input.
+func Tokenize(input string) ([]Token, []LexError) {
+	l := NewLexer(input)
+	var tokens []Token
+	for {
+		tok := l.NextToken()
+		tokens = append(tokens, tok)
+		if tok.Kind == tokEOF {
+			break
+		}
+	}
+	return tokens, l.Errors()
+}
+
+// NextToken returns the next token with baseOffset-shifted positions.
+func (l *Lexer) NextToken() Token {
+	tok := l.nextTokenInner()
+	if l.baseOffset != 0 {
+		tok.Loc.Start += l.baseOffset
+		tok.Loc.End += l.baseOffset
+	}
+	return tok
+}
+
+func (l *Lexer) nextTokenInner() Token {
+	l.skipWhitespaceAndComments()
+	if l.pos >= len(l.input) {
+		return Token{Kind: tokEOF, Loc: ast.Loc{Start: l.pos, End: l.pos}}
+	}
+	l.start = l.pos
+	ch := l.input[l.pos]
+
+	switch {
+	case ch == '\'':
+		return l.scanString('\'')
+	case ch == '"':
+		return l.scanString('"')
+	case ch == '`':
+		return l.scanBacktickIdent()
+	case ch >= '0' && ch <= '9':
+		return l.scanNumber()
+	case ch == '.' && l.peekDigit():
+		return l.scanNumber()
+	case (ch == 'X' || ch == 'x') && l.peek(1) == '\'':
+		return l.scanHexLiteral()
+	case (ch == 'B' || ch == 'b') && l.peek(1) == '\'':
+		return l.scanBitLiteral()
+	case isIdentStart(ch):
+		return l.scanIdentOrKeyword()
+	}
+	return l.scanOperator(ch)
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+func (l *Lexer) peek(offset int) byte {
+	if l.pos+offset >= len(l.input) {
+		return 0
+	}
+	return l.input[l.pos+offset]
+}
+
+func (l *Lexer) peekDigit() bool {
+	c := l.peek(1)
+	return c >= '0' && c <= '9'
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == '$' || ch > 127
+}
+
+func isIdentCont(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9')
+}
+
+// --- Whitespace & Comments -------------------------------------------------
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		switch {
+		case ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r':
+			l.pos++
+		case ch == '-' && l.peek(1) == '-' && l.isLineCommentAfterDash():
+			// MySQL-compatible: -- must be followed by space/tab/newline/EOF
+			l.pos += 2
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+				l.pos++
+			}
+		case ch == '/' && l.peek(1) == '/':
+			l.pos += 2
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+				l.pos++
+			}
+		case ch == '#':
+			l.pos++
+			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
+				l.pos++
+			}
+		case ch == '/' && l.peek(1) == '*' && l.peek(2) != '+':
+			// Block comment (but NOT hint /*+)
+			l.scanBlockComment()
+		default:
+			return
+		}
+	}
+}
+
+// isLineCommentAfterDash checks that the byte after -- is space/tab/newline/EOF.
+func (l *Lexer) isLineCommentAfterDash() bool {
+	c := l.peek(2)
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == 0
+}
+
+func (l *Lexer) scanBlockComment() {
+	start := l.pos
+	l.pos += 2 // consume /*
+	for l.pos < len(l.input)-1 {
+		if l.input[l.pos] == '*' && l.input[l.pos+1] == '/' {
+			l.pos += 2
+			return
+		}
+		l.pos++
+	}
+	l.pos = len(l.input)
+	l.errors = append(l.errors, LexError{
+		Loc: ast.Loc{Start: start, End: l.pos},
+		Msg: errUnterminatedComment,
+	})
+}
+
+// --- String Scanning -------------------------------------------------------
+
+// scanString reads a single-quoted or double-quoted string literal.
+// Supports backslash escapes and doubled-quote escapes.
+// Unlike Snowflake, Doris allows newlines inside string literals.
+func (l *Lexer) scanString(quote byte) Token {
+	start := l.start
+	l.pos++ // consume opening quote
+	var sb strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == quote {
+			if l.peek(1) == quote {
+				sb.WriteByte(quote)
+				l.pos += 2
+				continue
+			}
+			l.pos++
+			return Token{Kind: tokString, Str: sb.String(), Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		if ch == '\\' {
+			l.pos++
+			if l.pos >= len(l.input) {
+				break
+			}
+			esc := l.input[l.pos]
+			switch esc {
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			case 'r':
+				sb.WriteByte('\r')
+			case '0':
+				sb.WriteByte(0)
+			case '\\':
+				sb.WriteByte('\\')
+			case '\'':
+				sb.WriteByte('\'')
+			case '"':
+				sb.WriteByte('"')
+			case 'b':
+				sb.WriteByte(0x08)
+			case 'Z':
+				sb.WriteByte(0x1A)
+			default:
+				sb.WriteByte(esc)
+			}
+			l.pos++
+			continue
+		}
+		// Newlines are allowed inside Doris string literals.
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedString})
+	return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+// scanBacktickIdent reads a backtick-quoted identifier. Only doubled-backtick
+// escape is supported (`` → `). No backslash escapes.
+func (l *Lexer) scanBacktickIdent() Token {
+	start := l.start
+	l.pos++ // consume opening backtick
+	var sb strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch == '`' {
+			if l.peek(1) == '`' {
+				sb.WriteByte('`')
+				l.pos += 2
+				continue
+			}
+			l.pos++
+			return Token{Kind: tokQuotedIdent, Str: sb.String(), Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		sb.WriteByte(ch)
+		l.pos++
+	}
+	l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedQuoted})
+	return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+// --- Hex/Bit Literal Scanning -----------------------------------------------
+
+func (l *Lexer) scanHexLiteral() Token {
+	start := l.start
+	l.pos += 2 // consume X and opening quote
+	contentStart := l.pos
+	for l.pos < len(l.input) && l.input[l.pos] != '\'' {
+		l.pos++
+	}
+	if l.pos >= len(l.input) {
+		l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedString})
+		return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+	content := l.input[contentStart:l.pos]
+	l.pos++ // consume closing quote
+	return Token{Kind: tokHexLiteral, Str: content, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+func (l *Lexer) scanBitLiteral() Token {
+	start := l.start
+	l.pos += 2 // consume B and opening quote
+	contentStart := l.pos
+	for l.pos < len(l.input) && l.input[l.pos] != '\'' {
+		l.pos++
+	}
+	if l.pos >= len(l.input) {
+		l.errors = append(l.errors, LexError{Loc: ast.Loc{Start: start, End: l.pos}, Msg: errUnterminatedString})
+		return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+	content := l.input[contentStart:l.pos]
+	l.pos++ // consume closing quote
+	return Token{Kind: tokBitLiteral, Str: content, Loc: ast.Loc{Start: start, End: l.pos}}
+}
+
+// --- Number Scanning -------------------------------------------------------
+
+func (l *Lexer) scanNumber() Token {
+	start := l.start
+
+	// Hex: 0x or 0X
+	if l.input[l.pos] == '0' && (l.peek(1) == 'x' || l.peek(1) == 'X') {
+		l.pos += 2
+		for l.pos < len(l.input) && isHexDigit(l.input[l.pos]) {
+			l.pos++
+		}
+		text := l.input[start:l.pos]
+		val, err := strconv.ParseInt(text[2:], 16, 64)
+		if err != nil {
+			return Token{Kind: tokFloat, Str: text, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		return Token{Kind: tokInt, Str: text, Ival: val, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	// Binary: 0b or 0B (only when not followed by a quote, which would be a bit literal)
+	if l.input[l.pos] == '0' && (l.peek(1) == 'b' || l.peek(1) == 'B') && l.peek(2) != '\'' {
+		l.pos += 2
+		for l.pos < len(l.input) && (l.input[l.pos] == '0' || l.input[l.pos] == '1') {
+			l.pos++
+		}
+		text := l.input[start:l.pos]
+		val, err := strconv.ParseInt(text[2:], 2, 64)
+		if err != nil {
+			return Token{Kind: tokFloat, Str: text, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+		return Token{Kind: tokInt, Str: text, Ival: val, Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	isFloat := false
+
+	// Leading dot (.5)
+	if l.input[l.pos] == '.' {
+		isFloat = true
+		l.pos++
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+	} else {
+		// Integer part
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+		// Optional decimal
+		if l.pos < len(l.input) && l.input[l.pos] == '.' {
+			isFloat = true
+			l.pos++
+			for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+				l.pos++
+			}
+		}
+	}
+
+	// Optional exponent
+	if l.pos < len(l.input) && (l.input[l.pos] == 'e' || l.input[l.pos] == 'E') {
+		isFloat = true
+		l.pos++
+		if l.pos < len(l.input) && (l.input[l.pos] == '+' || l.input[l.pos] == '-') {
+			l.pos++
+		}
+		for l.pos < len(l.input) && l.input[l.pos] >= '0' && l.input[l.pos] <= '9' {
+			l.pos++
+		}
+	}
+
+	text := l.input[start:l.pos]
+	loc := ast.Loc{Start: start, End: l.pos}
+
+	if isFloat {
+		return Token{Kind: tokFloat, Str: text, Loc: loc}
+	}
+	val, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return Token{Kind: tokFloat, Str: text, Loc: loc}
+	}
+	return Token{Kind: tokInt, Str: text, Ival: val, Loc: loc}
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}
+
+// --- Identifier / Keyword Scanning -----------------------------------------
+
+func (l *Lexer) scanIdentOrKeyword() Token {
+	start := l.start
+	for l.pos < len(l.input) && isIdentCont(l.input[l.pos]) {
+		l.pos++
+	}
+	word := l.input[start:l.pos]
+	loc := ast.Loc{Start: start, End: l.pos}
+	if kw, ok := KeywordToken(word); ok {
+		return Token{Kind: kw, Str: word, Loc: loc}
+	}
+	return Token{Kind: tokIdent, Str: word, Loc: loc}
+}
+
+// --- Operator Scanning -----------------------------------------------------
+
+func (l *Lexer) scanOperator(ch byte) Token {
+	start := l.start
+	l.pos++
+
+	switch ch {
+	case '<':
+		if l.pos < len(l.input) {
+			switch l.input[l.pos] {
+			case '=':
+				if l.peek(1) == '>' {
+					// <=> null-safe equal
+					l.pos += 2
+					return Token{Kind: tokNullSafeEq, Loc: ast.Loc{Start: start, End: l.pos}}
+				}
+				l.pos++
+				return Token{Kind: tokLessEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '>':
+				l.pos++
+				return Token{Kind: tokNotEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '<':
+				l.pos++
+				return Token{Kind: tokShiftLeft, Loc: ast.Loc{Start: start, End: l.pos}}
+			}
+		}
+	case '>':
+		if l.pos < len(l.input) {
+			switch l.input[l.pos] {
+			case '=':
+				l.pos++
+				return Token{Kind: tokGreaterEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '>':
+				l.pos++
+				return Token{Kind: tokShiftRight, Loc: ast.Loc{Start: start, End: l.pos}}
+			}
+		}
+	case '!':
+		if l.pos < len(l.input) {
+			switch l.input[l.pos] {
+			case '=':
+				l.pos++
+				return Token{Kind: tokNotEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '<':
+				// !< maps to >= per DorisLexer.g4: GTE: '>=' | '!<'
+				l.pos++
+				return Token{Kind: tokGreaterEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			case '>':
+				// !> maps to <= per DorisLexer.g4: LTE: '<=' | '!>'
+				l.pos++
+				return Token{Kind: tokLessEq, Loc: ast.Loc{Start: start, End: l.pos}}
+			}
+		}
+	case '&':
+		if l.pos < len(l.input) && l.input[l.pos] == '&' {
+			l.pos++
+			return Token{Kind: tokLogicalAnd, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '|':
+		if l.pos < len(l.input) && l.input[l.pos] == '|' {
+			l.pos++
+			return Token{Kind: tokDoublePipes, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '@':
+		if l.pos < len(l.input) && l.input[l.pos] == '@' {
+			l.pos++
+			return Token{Kind: tokDoubleAt, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case ':':
+		if l.pos < len(l.input) && l.input[l.pos] == '=' {
+			l.pos++
+			return Token{Kind: tokAssign, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '.':
+		if l.pos+1 < len(l.input) && l.input[l.pos] == '.' && l.input[l.pos+1] == '.' {
+			l.pos += 2
+			return Token{Kind: tokDotDotDot, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '-':
+		if l.pos < len(l.input) && l.input[l.pos] == '>' {
+			l.pos++
+			return Token{Kind: tokArrow, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '/':
+		// /*+ starts a hint (check for * then + at positions pos and pos+1)
+		if l.pos+1 < len(l.input) && l.input[l.pos] == '*' && l.input[l.pos+1] == '+' {
+			l.pos += 2
+			return Token{Kind: tokHintStart, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '*':
+		if l.pos < len(l.input) && l.input[l.pos] == '/' {
+			l.pos++
+			return Token{Kind: tokHintEnd, Loc: ast.Loc{Start: start, End: l.pos}}
+		}
+	case '?':
+		return Token{Kind: tokPlaceholder, Loc: ast.Loc{Start: start, End: l.pos}}
+	case '=':
+		// == is equivalent to =
+		if l.pos < len(l.input) && l.input[l.pos] == '=' {
+			l.pos++
+		}
+		return Token{Kind: int('='), Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	// Valid single-char operators/punctuation
+	if ch == '(' || ch == ')' || ch == ',' || ch == ';' || ch == '+' || ch == '-' ||
+		ch == '*' || ch == '/' || ch == '%' || ch == '~' || ch == '^' || ch == '&' ||
+		ch == '|' || ch == '<' || ch == '>' || ch == '=' || ch == '.' || ch == '@' ||
+		ch == ':' || ch == '!' || ch == '[' || ch == ']' || ch == '{' || ch == '}' {
+		return Token{Kind: int(ch), Loc: ast.Loc{Start: start, End: l.pos}}
+	}
+
+	// Unknown character
+	l.errors = append(l.errors, LexError{
+		Loc: ast.Loc{Start: start, End: l.pos},
+		Msg: errUnknownChar,
+	})
+	return Token{Kind: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+}

--- a/doris/parser/lexer_test.go
+++ b/doris/parser/lexer_test.go
@@ -1,0 +1,968 @@
+package parser
+
+import (
+	"testing"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+// tokenize is a thin wrapper that returns only token kinds, dropping EOF.
+func tokenizeKinds(t *testing.T, input string) []TokenKind {
+	t.Helper()
+	tokens, _ := Tokenize(input)
+	out := make([]TokenKind, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok.Kind != tokEOF {
+			out = append(out, tok.Kind)
+		}
+	}
+	return out
+}
+
+// singleToken lexes input and asserts exactly one non-EOF token is returned,
+// returning it for further inspection.
+func singleToken(t *testing.T, input string) Token {
+	t.Helper()
+	tokens, errs := Tokenize(input)
+	// expect at most one non-EOF token
+	nonEOF := make([]Token, 0, 2)
+	for _, tok := range tokens {
+		if tok.Kind != tokEOF {
+			nonEOF = append(nonEOF, tok)
+		}
+	}
+	if len(nonEOF) != 1 {
+		t.Fatalf("singleToken(%q): got %d non-EOF tokens, want 1", input, len(nonEOF))
+	}
+	if len(errs) > 0 {
+		t.Fatalf("singleToken(%q): unexpected errors: %v", input, errs)
+	}
+	return nonEOF[0]
+}
+
+// assertKinds verifies token kinds ignoring EOF.
+func assertKinds(t *testing.T, input string, want []TokenKind) {
+	t.Helper()
+	got := tokenizeKinds(t, input)
+	if len(got) != len(want) {
+		t.Fatalf("assertKinds(%q): got %d tokens %v, want %d %v", input, len(got), got, len(want), want)
+	}
+	for i, k := range want {
+		if got[i] != k {
+			t.Errorf("assertKinds(%q) token[%d]: got kind %d, want %d", input, i, got[i], k)
+		}
+	}
+}
+
+// ---- 1. Keywords ------------------------------------------------------------
+
+func TestKeywords_BasicReserved(t *testing.T) {
+	cases := []struct {
+		input string
+		want  TokenKind
+	}{
+		{"SELECT", kwSELECT},
+		{"select", kwSELECT},
+		{"FROM", kwFROM},
+		{"from", kwFROM},
+		{"WHERE", kwWHERE},
+		{"AND", kwAND},
+		{"OR", kwOR},
+		{"NOT", kwNOT},
+		{"CREATE", kwCREATE},
+		{"TABLE", kwTABLE},
+	}
+	for _, tc := range cases {
+		tok := singleToken(t, tc.input)
+		if tok.Kind != tc.want {
+			t.Errorf("keyword %q: got kind %d, want %d", tc.input, tok.Kind, tc.want)
+		}
+	}
+}
+
+func TestKeywords_DorisCaseInsensitive(t *testing.T) {
+	// Mix of cases for Doris-specific keywords.
+	cases := []struct {
+		input string
+		want  TokenKind
+	}{
+		{"DISTRIBUTED", kwDISTRIBUTED},
+		{"Distributed", kwDISTRIBUTED},
+		{"distributed", kwDISTRIBUTED},
+		{"AGGREGATE", kwAGGREGATE},
+		{"aggregate", kwAGGREGATE},
+		{"BUCKETS", kwBUCKETS},
+		{"buckets", kwBUCKETS},
+		{"MATERIALIZED", kwMATERIALIZED},
+		{"materialized", kwMATERIALIZED},
+		{"COMMENT", kwCOMMENT},
+		{"comment", kwCOMMENT},
+	}
+	for _, tc := range cases {
+		tok := singleToken(t, tc.input)
+		if tok.Kind != tc.want {
+			t.Errorf("keyword %q: got kind %d (%s), want %d (%s)",
+				tc.input, tok.Kind, TokenName(tok.Kind), tc.want, TokenName(tc.want))
+		}
+	}
+}
+
+func TestKeywords_StrFieldPreservedAsInput(t *testing.T) {
+	// Keyword tokens carry the original (mixed-case) text in Str.
+	tok := singleToken(t, "Select")
+	if tok.Str != "Select" {
+		t.Errorf("Str field: got %q, want %q", tok.Str, "Select")
+	}
+}
+
+// ---- 2. Identifiers ---------------------------------------------------------
+
+func TestIdentifiers_Unquoted(t *testing.T) {
+	cases := []string{"my_table", "col1", "_priv", "$alias", "notAKeyword123"}
+	for _, input := range cases {
+		tok := singleToken(t, input)
+		if tok.Kind != tokIdent {
+			t.Errorf("ident %q: got kind %d, want tokIdent", input, tok.Kind)
+		}
+		if tok.Str != input {
+			t.Errorf("ident %q: Str = %q, want %q", input, tok.Str, input)
+		}
+	}
+}
+
+func TestIdentifiers_BacktickQuoted(t *testing.T) {
+	tok := singleToken(t, "`my column`")
+	if tok.Kind != tokQuotedIdent {
+		t.Fatalf("backtick ident: got kind %d, want tokQuotedIdent", tok.Kind)
+	}
+	if tok.Str != "my column" {
+		t.Errorf("backtick ident Str: got %q, want %q", tok.Str, "my column")
+	}
+}
+
+func TestIdentifiers_BacktickDoubledEscape(t *testing.T) {
+	// `` inside backtick literal -> single backtick in value
+	tok := singleToken(t, "`a``b`")
+	if tok.Kind != tokQuotedIdent {
+		t.Fatalf("backtick ident: got kind %d", tok.Kind)
+	}
+	if tok.Str != "a`b" {
+		t.Errorf("backtick doubled escape: got %q, want %q", tok.Str, "a`b")
+	}
+}
+
+func TestIdentifiers_BacktickKeywordName(t *testing.T) {
+	// Backtick-quoting a reserved keyword produces tokQuotedIdent, not a keyword.
+	tok := singleToken(t, "`select`")
+	if tok.Kind != tokQuotedIdent {
+		t.Errorf("`select`: got kind %d, want tokQuotedIdent", tok.Kind)
+	}
+}
+
+func TestIdentifiers_UnterminatedBacktick(t *testing.T) {
+	tokens, errs := Tokenize("`unterminated")
+	if len(errs) == 0 {
+		t.Fatal("unterminated backtick: expected error")
+	}
+	if errs[0].Msg != errUnterminatedQuoted {
+		t.Errorf("error msg: got %q, want %q", errs[0].Msg, errUnterminatedQuoted)
+	}
+	// Should emit tokInvalid
+	found := false
+	for _, tok := range tokens {
+		if tok.Kind == tokInvalid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("unterminated backtick: expected tokInvalid token")
+	}
+}
+
+// ---- 3. String literals -----------------------------------------------------
+
+func TestStrings_SingleQuoted(t *testing.T) {
+	tok := singleToken(t, `'hello world'`)
+	if tok.Kind != tokString {
+		t.Fatalf("single-quoted string: got kind %d", tok.Kind)
+	}
+	if tok.Str != "hello world" {
+		t.Errorf("Str: got %q, want %q", tok.Str, "hello world")
+	}
+}
+
+func TestStrings_DoubleQuoted(t *testing.T) {
+	tok := singleToken(t, `"hello world"`)
+	if tok.Kind != tokString {
+		t.Fatalf("double-quoted string: got kind %d", tok.Kind)
+	}
+	if tok.Str != "hello world" {
+		t.Errorf("Str: got %q, want %q", tok.Str, "hello world")
+	}
+}
+
+func TestStrings_EscapeSequences(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`'\n'`, "\n"},
+		{`'\t'`, "\t"},
+		{`'\r'`, "\r"},
+		{`'\0'`, string([]byte{0})},
+		{`'\\'`, "\\"},
+		{`'\''`, "'"},
+		{`'\"'`, `"`},
+		{`'\b'`, string([]byte{0x08})},
+		{`'\Z'`, string([]byte{0x1A})},
+	}
+	for _, tc := range cases {
+		tok := singleToken(t, tc.input)
+		if tok.Kind != tokString {
+			t.Errorf("escape %s: got kind %d, want tokString", tc.input, tok.Kind)
+			continue
+		}
+		if tok.Str != tc.want {
+			t.Errorf("escape %s: Str = %q, want %q", tc.input, tok.Str, tc.want)
+		}
+	}
+}
+
+func TestStrings_DoubledQuoteEscape(t *testing.T) {
+	// '' inside single-quoted string -> single '
+	tok := singleToken(t, `'it''s'`)
+	if tok.Kind != tokString {
+		t.Fatalf("doubled-quote: kind %d", tok.Kind)
+	}
+	if tok.Str != "it's" {
+		t.Errorf("doubled-quote: Str = %q, want %q", tok.Str, "it's")
+	}
+}
+
+func TestStrings_NewlineAllowed(t *testing.T) {
+	// Doris (unlike Snowflake) allows real newlines inside string literals.
+	tok := singleToken(t, "'line1\nline2'")
+	if tok.Kind != tokString {
+		t.Fatalf("newline in string: kind %d", tok.Kind)
+	}
+	if tok.Str != "line1\nline2" {
+		t.Errorf("newline in string: Str = %q", tok.Str)
+	}
+}
+
+func TestStrings_UnterminatedSingleQuote(t *testing.T) {
+	_, errs := Tokenize("'unterminated")
+	if len(errs) == 0 {
+		t.Fatal("unterminated single-quote: expected error")
+	}
+	if errs[0].Msg != errUnterminatedString {
+		t.Errorf("error msg: got %q, want %q", errs[0].Msg, errUnterminatedString)
+	}
+}
+
+func TestStrings_UnterminatedDoubleQuote(t *testing.T) {
+	_, errs := Tokenize(`"unterminated`)
+	if len(errs) == 0 {
+		t.Fatal("unterminated double-quote: expected error")
+	}
+	if errs[0].Msg != errUnterminatedString {
+		t.Errorf("error msg: got %q, want %q", errs[0].Msg, errUnterminatedString)
+	}
+}
+
+// ---- 4. Numeric literals ----------------------------------------------------
+
+func TestNumbers_Integer(t *testing.T) {
+	tok := singleToken(t, "42")
+	if tok.Kind != tokInt {
+		t.Fatalf("integer: got kind %d", tok.Kind)
+	}
+	if tok.Ival != 42 {
+		t.Errorf("Ival: got %d, want 42", tok.Ival)
+	}
+}
+
+func TestNumbers_Zero(t *testing.T) {
+	tok := singleToken(t, "0")
+	if tok.Kind != tokInt || tok.Ival != 0 {
+		t.Errorf("zero: kind=%d Ival=%d", tok.Kind, tok.Ival)
+	}
+}
+
+func TestNumbers_Decimal(t *testing.T) {
+	for _, input := range []string{"3.14", ".5", "0.0"} {
+		tok := singleToken(t, input)
+		if tok.Kind != tokFloat {
+			t.Errorf("decimal %q: got kind %d, want tokFloat", input, tok.Kind)
+		}
+	}
+}
+
+func TestNumbers_Exponent(t *testing.T) {
+	for _, input := range []string{"1e10", "1E10", "1.5e-10", "2.0E+3"} {
+		tok := singleToken(t, input)
+		if tok.Kind != tokFloat {
+			t.Errorf("exponent %q: got kind %d, want tokFloat", input, tok.Kind)
+		}
+		if tok.Str != input {
+			t.Errorf("exponent %q: Str = %q", input, tok.Str)
+		}
+	}
+}
+
+func TestNumbers_HexPrefix(t *testing.T) {
+	tok := singleToken(t, "0xFF")
+	if tok.Kind != tokInt {
+		t.Fatalf("0xFF: got kind %d, want tokInt", tok.Kind)
+	}
+	if tok.Ival != 255 {
+		t.Errorf("0xFF Ival: got %d, want 255", tok.Ival)
+	}
+}
+
+func TestNumbers_HexPrefixLower(t *testing.T) {
+	tok := singleToken(t, "0xdeadbeef")
+	if tok.Kind != tokInt {
+		t.Fatalf("0xdeadbeef: got kind %d, want tokInt", tok.Kind)
+	}
+	if tok.Ival != 0xdeadbeef {
+		t.Errorf("0xdeadbeef Ival: got %d, want %d", tok.Ival, int64(0xdeadbeef))
+	}
+}
+
+func TestNumbers_BinaryPrefix(t *testing.T) {
+	tok := singleToken(t, "0b101")
+	if tok.Kind != tokInt {
+		t.Fatalf("0b101: got kind %d, want tokInt", tok.Kind)
+	}
+	if tok.Ival != 5 {
+		t.Errorf("0b101 Ival: got %d, want 5", tok.Ival)
+	}
+}
+
+func TestNumbers_OverflowBecomesFloat(t *testing.T) {
+	// A number too large for int64 should become tokFloat.
+	tok := singleToken(t, "99999999999999999999999999")
+	if tok.Kind != tokFloat {
+		t.Errorf("overflow: got kind %d, want tokFloat", tok.Kind)
+	}
+}
+
+// ---- 5. Operators -----------------------------------------------------------
+
+func TestOperators_MultiChar(t *testing.T) {
+	cases := []struct {
+		input string
+		want  TokenKind
+	}{
+		{"<=", tokLessEq},
+		{">=", tokGreaterEq},
+		{"<>", tokNotEq},
+		{"!=", tokNotEq},
+		{"<=>", tokNullSafeEq},
+		{"&&", tokLogicalAnd},
+		{"||", tokDoublePipes},
+		{"<<", tokShiftLeft},
+		{">>", tokShiftRight},
+		{"->", tokArrow},
+		{"@@", tokDoubleAt},
+		{":=", tokAssign},
+		{"...", tokDotDotDot},
+		{"==", int('=')}, // == is normalized to =
+	}
+	for _, tc := range cases {
+		tok := singleToken(t, tc.input)
+		if tok.Kind != tc.want {
+			t.Errorf("operator %q: got kind %d (%s), want %d (%s)",
+				tc.input, tok.Kind, TokenName(tok.Kind), tc.want, TokenName(tc.want))
+		}
+	}
+}
+
+func TestOperators_SingleChar(t *testing.T) {
+	singles := []byte{'+', '-', '*', '/', '%', '~', '^', '(', ')', ',', ';', '&', '|', '<', '>', '=', '.', '@', ':', '!'}
+	for _, ch := range singles {
+		input := string(ch)
+		tok := singleToken(t, input)
+		if tok.Kind != int(ch) {
+			t.Errorf("single-char %q: got kind %d, want %d", input, tok.Kind, int(ch))
+		}
+	}
+}
+
+func TestOperators_DorisSpecialAlternatives(t *testing.T) {
+	// !< maps to >= and !> maps to <=
+	cases := []struct {
+		input string
+		want  TokenKind
+	}{
+		{"!<", tokGreaterEq},
+		{"!>", tokLessEq},
+	}
+	for _, tc := range cases {
+		tok := singleToken(t, tc.input)
+		if tok.Kind != tc.want {
+			t.Errorf("operator %q: got kind %d, want %d", tc.input, tok.Kind, tc.want)
+		}
+	}
+}
+
+// ---- 6. Comments ------------------------------------------------------------
+
+func TestComments_DashDashSpace(t *testing.T) {
+	// "-- comment" is stripped; remaining tokens are just the integer.
+	assertKinds(t, "42 -- this is a comment", []TokenKind{tokInt})
+}
+
+func TestComments_DashDashTab(t *testing.T) {
+	assertKinds(t, "1 --\tcomment", []TokenKind{tokInt})
+}
+
+func TestComments_DashDashNewline(t *testing.T) {
+	assertKinds(t, "1 --\nstill", []TokenKind{tokInt, tokIdent})
+}
+
+func TestComments_DashDashEOF(t *testing.T) {
+	// -- at end of input with nothing after: treated as line comment.
+	assertKinds(t, "1 --", []TokenKind{tokInt})
+}
+
+func TestComments_DoubleSlash(t *testing.T) {
+	assertKinds(t, "1 // comment\n2", []TokenKind{tokInt, tokInt})
+}
+
+func TestComments_Hash(t *testing.T) {
+	assertKinds(t, "1 # comment\n2", []TokenKind{tokInt, tokInt})
+}
+
+func TestComments_BlockComment(t *testing.T) {
+	assertKinds(t, "1 /* block */ 2", []TokenKind{tokInt, tokInt})
+}
+
+func TestComments_BlockCommentMultiline(t *testing.T) {
+	assertKinds(t, "1 /* line1\nline2 */ 2", []TokenKind{tokInt, tokInt})
+}
+
+func TestComments_UnterminatedBlock(t *testing.T) {
+	_, errs := Tokenize("/* unterminated")
+	if len(errs) == 0 {
+		t.Fatal("unterminated block comment: expected error")
+	}
+	if errs[0].Msg != errUnterminatedComment {
+		t.Errorf("error msg: got %q, want %q", errs[0].Msg, errUnterminatedComment)
+	}
+}
+
+func TestComments_HintNotConsumedAsComment(t *testing.T) {
+	// /*+ must NOT be skipped as a block comment.
+	kinds := tokenizeKinds(t, "/*+ hint */")
+	if len(kinds) == 0 {
+		t.Fatal("hint: expected tokens, got none")
+	}
+	if kinds[0] != tokHintStart {
+		t.Errorf("hint: first token kind %d, want tokHintStart (%d)", kinds[0], tokHintStart)
+	}
+}
+
+// ---- 7. Hints ---------------------------------------------------------------
+
+func TestHints_StartAndEnd(t *testing.T) {
+	assertKinds(t, "/*+ USE_HASH(t) */", []TokenKind{
+		tokHintStart,
+		tokIdent,  // USE_HASH (or keyword if recognized)
+		int('('),
+		tokIdent, // t
+		int(')'),
+		tokHintEnd,
+	})
+}
+
+func TestHints_StartToken(t *testing.T) {
+	tokens, _ := Tokenize("/*+")
+	if tokens[0].Kind != tokHintStart {
+		t.Errorf("/*+: first token kind %d, want tokHintStart", tokens[0].Kind)
+	}
+}
+
+// ---- 8. Hex/Bit literals ----------------------------------------------------
+
+func TestHexLiteral_Uppercase(t *testing.T) {
+	tok := singleToken(t, "X'FF'")
+	if tok.Kind != tokHexLiteral {
+		t.Fatalf("X'FF': kind %d, want tokHexLiteral", tok.Kind)
+	}
+	if tok.Str != "FF" {
+		t.Errorf("X'FF' Str: got %q, want %q", tok.Str, "FF")
+	}
+}
+
+func TestHexLiteral_Lowercase(t *testing.T) {
+	tok := singleToken(t, "x'ff'")
+	if tok.Kind != tokHexLiteral {
+		t.Fatalf("x'ff': kind %d, want tokHexLiteral", tok.Kind)
+	}
+	if tok.Str != "ff" {
+		t.Errorf("x'ff' Str: got %q, want %q", tok.Str, "ff")
+	}
+}
+
+func TestBitLiteral_Uppercase(t *testing.T) {
+	tok := singleToken(t, "B'101'")
+	if tok.Kind != tokBitLiteral {
+		t.Fatalf("B'101': kind %d, want tokBitLiteral", tok.Kind)
+	}
+	if tok.Str != "101" {
+		t.Errorf("B'101' Str: got %q, want %q", tok.Str, "101")
+	}
+}
+
+func TestBitLiteral_Lowercase(t *testing.T) {
+	tok := singleToken(t, "b'0'")
+	if tok.Kind != tokBitLiteral {
+		t.Fatalf("b'0': kind %d", tok.Kind)
+	}
+	if tok.Str != "0" {
+		t.Errorf("b'0' Str: got %q, want %q", tok.Str, "0")
+	}
+}
+
+func TestHexLiteral_DistinctFromHexPrefix(t *testing.T) {
+	// X'FF' -> tokHexLiteral, 0xFF -> tokInt
+	tokX := singleToken(t, "X'FF'")
+	tok0x := singleToken(t, "0xFF")
+	if tokX.Kind != tokHexLiteral {
+		t.Errorf("X'FF': want tokHexLiteral, got %d", tokX.Kind)
+	}
+	if tok0x.Kind != tokInt {
+		t.Errorf("0xFF: want tokInt, got %d", tok0x.Kind)
+	}
+}
+
+// ---- 9. Error recovery ------------------------------------------------------
+
+func TestErrors_UnterminatedString(t *testing.T) {
+	tokens, errs := Tokenize("'oops")
+	if len(errs) == 0 {
+		t.Fatal("unterminated string: expected error")
+	}
+	if errs[0].Msg != errUnterminatedString {
+		t.Errorf("error msg: got %q", errs[0].Msg)
+	}
+	// tokInvalid must be emitted
+	found := false
+	for _, tok := range tokens {
+		if tok.Kind == tokInvalid {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected tokInvalid token for unterminated string")
+	}
+}
+
+func TestErrors_UnterminatedBlockComment(t *testing.T) {
+	_, errs := Tokenize("SELECT /* no end")
+	if len(errs) == 0 {
+		t.Fatal("unterminated block comment: expected error")
+	}
+	if errs[0].Msg != errUnterminatedComment {
+		t.Errorf("error msg: got %q", errs[0].Msg)
+	}
+}
+
+func TestErrors_UnknownCharacter(t *testing.T) {
+	tokens, errs := Tokenize("\x01")
+	if len(errs) == 0 {
+		t.Fatal("unknown char: expected error")
+	}
+	if errs[0].Msg != errUnknownChar {
+		t.Errorf("error msg: got %q", errs[0].Msg)
+	}
+	found := false
+	for _, tok := range tokens {
+		if tok.Kind == tokInvalid {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected tokInvalid token for unknown char")
+	}
+}
+
+func TestErrors_RecoveryAfterError(t *testing.T) {
+	// After an unterminated string, the lexer should still emit subsequent tokens.
+	tokens, errs := Tokenize("'oops 42")
+	if len(errs) == 0 {
+		t.Fatal("expected lex error")
+	}
+	// The tokInvalid should be present.
+	foundInvalid := false
+	for _, tok := range tokens {
+		if tok.Kind == tokInvalid {
+			foundInvalid = true
+		}
+	}
+	if !foundInvalid {
+		t.Error("expected tokInvalid in error recovery")
+	}
+}
+
+// ---- 10. Position tracking --------------------------------------------------
+
+func TestPosition_BasicOffsets(t *testing.T) {
+	// "SELECT" starts at 0, ends at 6.
+	tokens, _ := Tokenize("SELECT")
+	if len(tokens) == 0 || tokens[0].Kind == tokEOF {
+		t.Fatal("no tokens")
+	}
+	tok := tokens[0]
+	if tok.Loc.Start != 0 {
+		t.Errorf("Loc.Start: got %d, want 0", tok.Loc.Start)
+	}
+	if tok.Loc.End != 6 {
+		t.Errorf("Loc.End: got %d, want 6", tok.Loc.End)
+	}
+}
+
+func TestPosition_WithLeadingWhitespace(t *testing.T) {
+	// "   42" - integer starts at byte 3.
+	tokens, _ := Tokenize("   42")
+	nonEOF := filterNonEOF(tokens)
+	if len(nonEOF) == 0 {
+		t.Fatal("no tokens")
+	}
+	tok := nonEOF[0]
+	if tok.Loc.Start != 3 {
+		t.Errorf("Loc.Start: got %d, want 3", tok.Loc.Start)
+	}
+	if tok.Loc.End != 5 {
+		t.Errorf("Loc.End: got %d, want 5", tok.Loc.End)
+	}
+}
+
+func TestPosition_MultipleTokens(t *testing.T) {
+	// "a b" — ident 'a' at [0,1), space, ident 'b' at [2,3).
+	tokens, _ := Tokenize("a b")
+	nonEOF := filterNonEOF(tokens)
+	if len(nonEOF) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(nonEOF))
+	}
+	if nonEOF[0].Loc.Start != 0 || nonEOF[0].Loc.End != 1 {
+		t.Errorf("first token loc: [%d,%d), want [0,1)", nonEOF[0].Loc.Start, nonEOF[0].Loc.End)
+	}
+	if nonEOF[1].Loc.Start != 2 || nonEOF[1].Loc.End != 3 {
+		t.Errorf("second token loc: [%d,%d), want [2,3)", nonEOF[1].Loc.Start, nonEOF[1].Loc.End)
+	}
+}
+
+func TestPosition_BaseOffset(t *testing.T) {
+	// NewLexerWithOffset shifts all emitted Locs by baseOffset.
+	const base = 100
+	l := NewLexerWithOffset("SELECT", base)
+	tok := l.NextToken()
+	if tok.Kind == tokEOF {
+		t.Fatal("expected non-EOF token")
+	}
+	if tok.Loc.Start != base {
+		t.Errorf("shifted Loc.Start: got %d, want %d", tok.Loc.Start, base)
+	}
+	if tok.Loc.End != base+6 {
+		t.Errorf("shifted Loc.End: got %d, want %d", tok.Loc.End, base+6)
+	}
+}
+
+func TestPosition_BaseOffsetError(t *testing.T) {
+	// Errors() should also shift positions by baseOffset.
+	const base = 50
+	l := NewLexerWithOffset("'unterminated", base)
+	for {
+		tok := l.NextToken()
+		if tok.Kind == tokEOF {
+			break
+		}
+	}
+	errs := l.Errors()
+	if len(errs) == 0 {
+		t.Fatal("expected error")
+	}
+	if errs[0].Loc.Start != base {
+		t.Errorf("shifted error Loc.Start: got %d, want %d", errs[0].Loc.Start, base)
+	}
+}
+
+func filterNonEOF(tokens []Token) []Token {
+	out := make([]Token, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok.Kind != tokEOF {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+// ---- 11. Edge cases ---------------------------------------------------------
+
+func TestEdge_EmptyInput(t *testing.T) {
+	tokens, errs := Tokenize("")
+	if len(errs) != 0 {
+		t.Errorf("empty input: unexpected errors %v", errs)
+	}
+	if len(tokens) != 1 || tokens[0].Kind != tokEOF {
+		t.Errorf("empty input: expected exactly EOF, got %v", tokens)
+	}
+}
+
+func TestEdge_WhitespaceOnly(t *testing.T) {
+	tokens, errs := Tokenize("   \t\n\r  ")
+	if len(errs) != 0 {
+		t.Errorf("whitespace-only: unexpected errors")
+	}
+	if len(tokens) != 1 || tokens[0].Kind != tokEOF {
+		t.Errorf("whitespace-only: expected exactly EOF, got %v", tokens)
+	}
+}
+
+func TestEdge_MultiStatement(t *testing.T) {
+	// SELECT 1; SELECT 2 — should produce two SELECT keywords, two ints, one semicolon.
+	kinds := tokenizeKinds(t, "SELECT 1; SELECT 2")
+	want := []TokenKind{kwSELECT, tokInt, int(';'), kwSELECT, tokInt}
+	if len(kinds) != len(want) {
+		t.Fatalf("multi-statement: got %v, want %v", kinds, want)
+	}
+	for i, k := range want {
+		if kinds[i] != k {
+			t.Errorf("multi-statement token[%d]: got %d, want %d", i, kinds[i], k)
+		}
+	}
+}
+
+func TestEdge_Placeholder(t *testing.T) {
+	tok := singleToken(t, "?")
+	if tok.Kind != tokPlaceholder {
+		t.Errorf("placeholder: got kind %d, want tokPlaceholder", tok.Kind)
+	}
+}
+
+func TestEdge_PlaceholderInExpression(t *testing.T) {
+	assertKinds(t, "WHERE x = ?", []TokenKind{kwWHERE, tokIdent, int('='), tokPlaceholder})
+}
+
+// ---- 12. Keyword classification ---------------------------------------------
+
+func TestKeywordClass_SelectIsReserved(t *testing.T) {
+	if !IsReserved(kwSELECT) {
+		t.Error("SELECT should be reserved")
+	}
+}
+
+func TestKeywordClass_FromIsReserved(t *testing.T) {
+	if !IsReserved(kwFROM) {
+		t.Error("FROM should be reserved")
+	}
+}
+
+func TestKeywordClass_CommentIsNonReserved(t *testing.T) {
+	if IsReserved(kwCOMMENT) {
+		t.Error("COMMENT should be non-reserved")
+	}
+}
+
+func TestKeywordClass_MaterializedIsNonReserved(t *testing.T) {
+	if IsReserved(kwMATERIALIZED) {
+		t.Error("MATERIALIZED should be non-reserved")
+	}
+}
+
+func TestKeywordClass_BucketsIsNonReserved(t *testing.T) {
+	if IsReserved(kwBUCKETS) {
+		t.Error("BUCKETS should be non-reserved")
+	}
+}
+
+func TestKeywordClass_AggregateIsNonReserved(t *testing.T) {
+	if IsReserved(kwAGGREGATE) {
+		t.Error("AGGREGATE should be non-reserved")
+	}
+}
+
+func TestKeywordClass_LiteralsAreNotReserved(t *testing.T) {
+	for _, kind := range []TokenKind{tokInt, tokFloat, tokString, tokIdent, tokPlaceholder} {
+		if IsReserved(kind) {
+			t.Errorf("literal token %d (%s) should not be reserved", kind, TokenName(kind))
+		}
+	}
+}
+
+func TestTokenName_Keywords(t *testing.T) {
+	cases := []struct {
+		kind TokenKind
+		want string
+	}{
+		{kwSELECT, "SELECT"},
+		{kwFROM, "FROM"},
+		{kwCOMMENT, "COMMENT"},
+		{kwDISTRIBUTED, "DISTRIBUTED"},
+		{kwBUCKETS, "BUCKETS"},
+	}
+	for _, tc := range cases {
+		got := TokenName(tc.kind)
+		if got != tc.want {
+			t.Errorf("TokenName(%d): got %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestTokenName_SpecialTokens(t *testing.T) {
+	cases := []struct {
+		kind TokenKind
+		want string
+	}{
+		{tokEOF, "EOF"},
+		{tokInvalid, "INVALID"},
+		{tokInt, "INT"},
+		{tokFloat, "FLOAT"},
+		{tokString, "STRING"},
+		{tokIdent, "IDENT"},
+		{tokQuotedIdent, "QUOTED_IDENT"},
+		{tokHexLiteral, "HEX_LITERAL"},
+		{tokBitLiteral, "BIT_LITERAL"},
+		{tokPlaceholder, "PLACEHOLDER"},
+	}
+	for _, tc := range cases {
+		got := TokenName(tc.kind)
+		if got != tc.want {
+			t.Errorf("TokenName(%d): got %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestTokenName_Operators(t *testing.T) {
+	cases := []struct {
+		kind TokenKind
+		want string
+	}{
+		{tokLessEq, "<="},
+		{tokGreaterEq, ">="},
+		{tokNotEq, "<>"},
+		{tokNullSafeEq, "<=>"},
+		{tokLogicalAnd, "&&"},
+		{tokDoublePipes, "||"},
+		{tokShiftLeft, "<<"},
+		{tokShiftRight, ">>"},
+		{tokArrow, "->"},
+		{tokDoubleAt, "@@"},
+		{tokAssign, ":="},
+		{tokDotDotDot, "..."},
+		{tokHintStart, "HINT_START"},
+		{tokHintEnd, "HINT_END"},
+	}
+	for _, tc := range cases {
+		got := TokenName(tc.kind)
+		if got != tc.want {
+			t.Errorf("TokenName(%d): got %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestTokenName_ASCIISingleChar(t *testing.T) {
+	// Single ASCII printable chars map to their string form.
+	for _, ch := range []byte{'+', '-', '*', '/', '(', ')', ';', ','} {
+		got := TokenName(int(ch))
+		want := string(ch)
+		if got != want {
+			t.Errorf("TokenName(%d): got %q, want %q", ch, got, want)
+		}
+	}
+}
+
+func TestKeywordToken_CaseInsensitive(t *testing.T) {
+	cases := []string{"select", "SELECT", "Select", "SeLeCt"}
+	for _, s := range cases {
+		kind, ok := KeywordToken(s)
+		if !ok {
+			t.Errorf("KeywordToken(%q): not found", s)
+			continue
+		}
+		if kind != kwSELECT {
+			t.Errorf("KeywordToken(%q): got %d, want kwSELECT", s, kind)
+		}
+	}
+}
+
+func TestKeywordToken_NonKeyword(t *testing.T) {
+	_, ok := KeywordToken("notakeyword")
+	if ok {
+		t.Error("KeywordToken(\"notakeyword\"): expected not found")
+	}
+}
+
+// ---- 13. MySQL-strict dash-dash --------------------------------------------
+
+func TestDashDash_NoSpaceShouldNotBeComment(t *testing.T) {
+	// "--5" is NOT a comment (no space/tab/newline after --), so it produces
+	// two minus tokens followed by an integer, not a skipped comment.
+	kinds := tokenizeKinds(t, "--5")
+	if len(kinds) == 0 {
+		t.Fatal("--5: expected tokens, got none (should not be treated as comment)")
+	}
+	// The integer 5 must appear somewhere in the token stream.
+	foundInt := false
+	for _, k := range kinds {
+		if k == tokInt {
+			foundInt = true
+		}
+	}
+	if !foundInt {
+		t.Errorf("--5: expected tokInt in output, got %v", kinds)
+	}
+}
+
+func TestDashDash_WithSpaceIsComment(t *testing.T) {
+	// "-- comment\n5" skips the comment; only the integer 5 should remain.
+	kinds := tokenizeKinds(t, "-- comment\n5")
+	if len(kinds) != 1 || kinds[0] != tokInt {
+		t.Errorf("-- comment: expected [tokInt], got %v", kinds)
+	}
+}
+
+func TestDashDash_AtEOFIsComment(t *testing.T) {
+	// "5 --" at EOF: the -- is a valid line comment (EOF counts).
+	kinds := tokenizeKinds(t, "5 --")
+	if len(kinds) != 1 || kinds[0] != tokInt {
+		t.Errorf("5 --: expected [tokInt], got %v", kinds)
+	}
+}
+
+// ---- 14. Tokenize convenience function --------------------------------------
+
+func TestTokenize_ReturnsErrorsAndTokens(t *testing.T) {
+	tokens, errs := Tokenize("SELECT 'unterminated")
+	if len(errs) == 0 {
+		t.Fatal("expected lex errors")
+	}
+	// SELECT keyword should still appear.
+	found := false
+	for _, tok := range tokens {
+		if tok.Kind == kwSELECT {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Tokenize: SELECT keyword missing despite error after it")
+	}
+}
+
+func TestTokenize_AlwaysEndsWithEOF(t *testing.T) {
+	for _, input := range []string{"", "SELECT 1", "   ", "'oops"} {
+		tokens, _ := Tokenize(input)
+		if len(tokens) == 0 {
+			t.Errorf("input %q: no tokens at all", input)
+			continue
+		}
+		last := tokens[len(tokens)-1]
+		if last.Kind != tokEOF {
+			t.Errorf("input %q: last token is %d, want tokEOF", input, last.Kind)
+		}
+	}
+}

--- a/doris/parser/tokens.go
+++ b/doris/parser/tokens.go
@@ -1,0 +1,67 @@
+package parser
+
+import "github.com/bytebase/omni/doris/ast"
+
+// Special tokens.
+const (
+	tokEOF     = 0
+	tokInvalid = 1 // error-recovery token; always accompanied by a LexError
+)
+
+// TokenKind identifies a token type. Single-character operators and
+// punctuation use their ASCII byte value directly as their TokenKind
+// (e.g., ';' = 59, '(' = 40). Named constants below cover multi-char
+// operators, literals, and keywords.
+type TokenKind = int
+
+// Multi-character operators (500-599).
+const (
+	tokLessEq     = 500 + iota // <=
+	tokGreaterEq               // >=
+	tokNotEq                   // <> or !=
+	tokNullSafeEq              // <=>
+	tokLogicalAnd              // &&
+	tokDoublePipes             // ||
+	tokShiftLeft               // <<
+	tokShiftRight              // >>
+	tokArrow                   // ->
+	tokDoubleAt                // @@
+	tokAssign                  // :=
+	tokDotDotDot               // ...
+	tokHintStart               // /*+
+	tokHintEnd                 // */ (only emitted after a hint-start)
+)
+
+// Literal tokens (600-699).
+const (
+	tokInt         = 600 + iota // integer: 42, 0xFF, 0b101
+	tokFloat                    // decimal/exponent: 3.14, 1e10, 1.5e-10
+	tokString                   // single or double quoted string
+	tokIdent                    // unquoted identifier
+	tokQuotedIdent              // backtick-quoted identifier
+	tokHexLiteral               // X'...' or x'...'
+	tokBitLiteral               // B'...' or b'...'
+	tokPlaceholder              // ?
+)
+
+// Token represents a single lexical token.
+type Token struct {
+	Kind TokenKind // tok*/kw* constant or ASCII byte value
+	Str  string    // content for identifiers, strings, hints
+	Ival int64     // parsed integer value for tokInt
+	Loc  ast.Loc   // byte offset span in source
+}
+
+// LexError records a lexing error with its source position.
+type LexError struct {
+	Msg string
+	Loc ast.Loc
+}
+
+// Error messages.
+const (
+	errUnterminatedString  = "unterminated string literal"
+	errUnterminatedQuoted  = "unterminated backtick-quoted identifier"
+	errUnterminatedComment = "unterminated block comment"
+	errUnknownChar         = "unknown character"
+)

--- a/doris/parser/tokens.go
+++ b/doris/parser/tokens.go
@@ -29,7 +29,7 @@ const (
 	tokAssign                  // :=
 	tokDotDotDot               // ...
 	tokHintStart               // /*+
-	tokHintEnd                 // */ (only emitted after a hint-start)
+	tokHintEnd                 // */ — emitted for ANY */ in the token stream; the parser is responsible for validating hint context
 )
 
 // Literal tokens (600-699).


### PR DESCRIPTION
## Summary
- Add `doris/parser/` package with hand-written lexer for Doris SQL
- 531 keyword constants extracted from DorisLexer.g4 with reserved/non-reserved classification
- Full scanning support: backtick-quoted identifiers, string literals (backslash + doubled-quote escapes), numeric literals (int/float/hex/binary/exponent), all Doris operators (including `<=>`, `&&`, `||`, `->`, `!<`, `!>`), hints (`/*+`/`*/`), comments (`--`, `//`, `#`, `/* */`)
- 72 unit tests covering all token categories, error recovery, and position tracking

DAG node: F2 (lexer) from `docs/migration/doris/dag.md`

## Test plan
- [x] 72 unit tests pass (`go test ./doris/parser/...`)
- [x] `go build ./...` clean (no regressions)
- [x] `go vet ./doris/parser/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)