### PR TITLE
feat(snowflake): T1.5 joins — JoinExpr + extended TableRef

### DIFF
--- a/docs/superpowers/plans/2026-04-10-snowflake-joins.md
+++ b/docs/superpowers/plans/2026-04-10-snowflake-joins.md
@@ -1,0 +1,217 @@
+# Snowflake Joins (T1.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend T1.4's FROM clause from simple comma-separated table refs to full JOIN syntax — JoinExpr Node, extended TableRef (subquery/func/lateral), 6 join types, ON/USING/MATCH_CONDITION conditions, left-associative join chain parsing.
+
+**Architecture:** `parseFromClause()` returns `[]ast.Node` (was `[]*ast.TableRef`). Each comma-separated item is parsed by `parseFromItem()` which calls `parsePrimarySource()` for the base table/subquery/function, then `parseJoinChain()` for any following JOINs. JoinExpr nodes form a left-associative binary tree.
+
+**Tech Stack:** Go 1.25, stdlib only (`strings` for MATCH_CONDITION ident check).
+
+**Spec:** `docs/superpowers/specs/2026-04-10-snowflake-joins-design.md` (commit `6cb51b9`)
+
+**Worktree:** `/Users/h3n4l/OpenSource/omni/.worktrees/joins` on branch `feat/snowflake/joins`
+
+**Commit policy:** No commits during implementation. User reviews the full diff at the end.
+
+---
+
+## File Structure
+
+| File | Change | Approx LOC |
+|------|--------|-----------|
+| `snowflake/ast/parsenodes.go` | MODIFY: extend TableRef + add JoinExpr + JoinType | +60 |
+| `snowflake/ast/nodetags.go` | MODIFY: +T_JoinExpr + String() | +3 |
+| `snowflake/ast/loc.go` | MODIFY: +*JoinExpr case | +2 |
+| `snowflake/ast/walk_generated.go` | REGENERATED | auto |
+| `snowflake/parser/select.go` | MODIFY: rewrite parseFromClause + add join functions | +250 |
+| `snowflake/parser/select_test.go` | MODIFY: update From assertions + add 15 join tests | +300 |
+
+Total: ~600 LOC across 6 modified files.
+
+---
+
+## Task 1: AST types + nodetag + walker regen
+
+**Files:** Modify parsenodes.go, nodetags.go, loc.go. Regenerate walk_generated.go.
+
+- [ ] **Step 1: Extend TableRef and add JoinExpr + JoinType to parsenodes.go**
+
+Extend the existing `TableRef` struct with 3 new fields and add JoinExpr + JoinType after it:
+
+```go
+// Updated TableRef — add Subquery, FuncCall, Lateral fields
+type TableRef struct {
+    Name     *ObjectName    // table name; nil for subquery/func sources
+    Alias    Ident          // AS alias; zero if absent
+    Subquery Node           // (SELECT ...) in FROM; nil for table refs
+    FuncCall *FuncCallExpr  // TABLE(func(...)); nil for table refs
+    Lateral  bool           // LATERAL prefix
+    Loc      Loc
+}
+
+// JoinExpr represents a JOIN between two FROM sources.
+type JoinExpr struct {
+    Type           JoinType
+    Left           Node    // TableRef or nested JoinExpr
+    Right          Node    // TableRef or nested JoinExpr
+    On             Node    // ON condition; nil for CROSS/NATURAL/USING-only
+    Using          []Ident // USING columns; nil if ON or NATURAL
+    Natural        bool
+    Directed       bool    // Snowflake DIRECTED hint
+    MatchCondition Node    // ASOF MATCH_CONDITION(expr); nil for non-ASOF
+    Loc            Loc
+}
+
+func (n *JoinExpr) Tag() NodeTag { return T_JoinExpr }
+var _ Node = (*JoinExpr)(nil)
+
+type JoinType int
+const (
+    JoinInner JoinType = iota
+    JoinLeft
+    JoinRight
+    JoinFull
+    JoinCross
+    JoinAsof
+)
+```
+
+- [ ] **Step 2: Change SelectStmt.From type**
+
+In the SelectStmt struct, change `From []*TableRef` to `From []Node`.
+
+- [ ] **Step 3: Add T_JoinExpr to nodetags.go + NodeLoc case to loc.go**
+
+- [ ] **Step 4: Regenerate walker**
+
+Run: `go generate ./snowflake/ast/...`
+
+- [ ] **Step 5: Verify AST builds**
+
+Run: `go build ./snowflake/ast/...`
+
+Note: `go build ./snowflake/parser/...` will FAIL because select.go still returns `[]*ast.TableRef` from parseFromClause — Task 2 fixes that.
+
+---
+
+## Task 2: Rewrite parseFromClause + add join parsing functions
+
+**Files:** Modify `snowflake/parser/select.go`
+
+- [ ] **Step 1: Rewrite parseFromClause + add all join functions**
+
+The implementer must:
+
+1. **Read the spec** for the full function list and flow
+2. **Read the existing `parseFromClause` and `parseTableRef`** in select.go to understand what to replace
+3. **Rewrite `parseFromClause()`** to return `[]ast.Node` and call `parseFromItem()` for each comma-separated item
+4. **Add `parseFromItem()`** — calls parsePrimarySource + parseJoinChain
+5. **Add `parsePrimarySource()`** — dispatches on `(` (subquery/parens), `kwLATERAL`, `kwTABLE`, otherwise existing parseTableRef
+6. **Add `parseJoinChain(left)`** — left-associative loop consuming JOIN keywords + right source + conditions
+7. **Add `parseJoinKeywords()`** — recognizes all JOIN keyword combinations and returns (JoinType, natural, directed, ok)
+8. **Keep existing `parseTableRef()`** for simple ObjectName + alias cases (it's still called by parsePrimarySource)
+
+Key patterns:
+
+**parseJoinKeywords** must handle these token sequences:
+- `kwJOIN` → JoinInner
+- `kwINNER kwJOIN` → JoinInner
+- `kwLEFT [kwOUTER] kwJOIN` → JoinLeft
+- `kwRIGHT [kwOUTER] kwJOIN` → JoinRight
+- `kwFULL [kwOUTER] kwJOIN` → JoinFull
+- `kwCROSS kwJOIN` → JoinCross
+- `kwNATURAL [kwLEFT|kwRIGHT|kwFULL] kwJOIN` → sets natural=true
+- `kwASOF kwJOIN` → JoinAsof (check if kwASOF exists; may need tokIdent check)
+
+**ASOF** — check if `kwASOF` exists in F2. If not, use `tokIdent && strings.ToUpper(p.cur.Str) == "ASOF"`.
+
+**DIRECTED** — similarly check kwDIRECTED. If not in F2, use tokIdent check.
+
+**MATCH_CONDITION** — use tokIdent check (`strings.ToUpper(p.cur.Str) == "MATCH_CONDITION"`).
+
+**Subquery in FROM** — in parsePrimarySource, when `(` is current:
+- Peek for kwSELECT/kwWITH → parse as subquery, expect `)`, parseOptionalAlias, wrap in TableRef{Subquery: ...}
+- Otherwise → parse as parenthesized from-item `(t1 JOIN t2 ON ...)`, expect `)`
+
+**TABLE() function** — when kwTABLE is current:
+- Consume kwTABLE, expect `(`, parse function call expression, expect `)`, parseOptionalAlias
+- Wrap in TableRef{FuncCall: ...}
+
+**LATERAL** — when kwLATERAL is current:
+- Consume kwLATERAL, parse the next source (subquery or table function), set Lateral=true
+- Special case: `LATERAL FLATTEN(...)` — FLATTEN is a function call, parse as FuncCallExpr
+
+- [ ] **Step 2: Update select_test.go From assertions**
+
+The existing T1.4 tests that check `From []*ast.TableRef` will break because the type is now `[]ast.Node`. Update them to type-assert `From[i].(*ast.TableRef)`.
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./snowflake/parser/...`
+Expected: clean.
+
+Run: `go test ./snowflake/...`
+Expected: all existing tests pass with the updated assertions.
+
+---
+
+## Task 3: Write join tests
+
+**Files:** Modify `snowflake/parser/select_test.go`
+
+- [ ] **Step 1: Add 15 join test categories**
+
+Add join-specific tests using the existing `testParseSelectStmt` helper. Each test parses a full SELECT statement and asserts the From structure:
+
+1. Basic INNER JOIN — From[0] is *JoinExpr{Type: JoinInner, Left: *TableRef, Right: *TableRef, On: not nil}
+2. LEFT JOIN
+3. RIGHT OUTER JOIN
+4. FULL JOIN
+5. CROSS JOIN (no ON)
+6. NATURAL JOIN (no ON/USING)
+7. USING clause
+8. Chained JOINs — From[0] is JoinExpr{Left: JoinExpr{...}, Right: TableRef}
+9. Comma + JOIN mixed — From has 2 items: TableRef and JoinExpr
+10. Subquery in FROM — From[0] is *TableRef with Subquery set
+11. LATERAL subquery
+12. TABLE(FLATTEN(...)) — TableRef with FuncCall
+13. ASOF JOIN with MATCH_CONDITION
+14. DIRECTED JOIN
+15. Error cases
+
+- [ ] **Step 2: Run all tests**
+
+Run: `go test ./snowflake/...`
+Expected: all pass.
+
+---
+
+## Task 4: Final acceptance sweep
+
+- [ ] **Step 1:** `go build ./snowflake/...` — clean
+- [ ] **Step 2:** `go vet ./snowflake/...` — clean
+- [ ] **Step 3:** `gofmt -l snowflake/` — clean
+- [ ] **Step 4:** `go test ./snowflake/...` — pass
+- [ ] **Step 5:** Walker regen byte-identical
+- [ ] **Step 6:** STOP and present for review
+
+---
+
+## Spec Coverage Checklist
+
+| Spec section | Covered by |
+|---|---|
+| JoinExpr Node + JoinType enum | Task 1 |
+| Extended TableRef (Subquery/FuncCall/Lateral) | Task 1 |
+| SelectStmt.From type change | Task 1 |
+| T_JoinExpr tag | Task 1 |
+| parseFromClause rewrite | Task 2 |
+| parseFromItem / parsePrimarySource / parseJoinChain / parseJoinKeywords | Task 2 |
+| Subquery-in-FROM | Task 2 |
+| TABLE() / LATERAL / FLATTEN | Task 2 |
+| ASOF / DIRECTED | Task 2 |
+| ON / USING / MATCH_CONDITION | Task 2 |
+| Existing test updates | Task 2 |
+| 15 join test categories | Task 3 |
+| Acceptance criteria | Task 4 |

--- a/docs/superpowers/specs/2026-04-10-snowflake-joins-design.md
+++ b/docs/superpowers/specs/2026-04-10-snowflake-joins-design.md
@@ -1,0 +1,205 @@
+# Snowflake Joins (T1.5) — Design
+
+**DAG node:** T1.5 — joins
+**Branch:** `feat/snowflake/joins`
+**Depends on:** T1.4 (SELECT core).
+**Unblocks:** T1.7 (set operators), T1.8 (statement classification), T2.x (DDL with subqueries).
+
+## Purpose
+
+T1.5 extends T1.4's FROM clause from simple comma-separated table references to full JOIN syntax. After T1.5, the parser handles every FROM-clause form in the legacy grammar.
+
+## AST Types
+
+### JoinExpr (Node)
+
+```go
+type JoinExpr struct {
+    Type           JoinType
+    Left           Node    // TableRef or nested JoinExpr
+    Right          Node    // TableRef or nested JoinExpr
+    On             Node    // ON condition; nil for CROSS/NATURAL/USING-only
+    Using          []Ident // USING columns; nil if ON or NATURAL
+    Natural        bool    // NATURAL JOIN
+    Directed       bool    // DIRECTED hint (Snowflake-specific)
+    MatchCondition Node    // ASOF MATCH_CONDITION(expr); nil for non-ASOF
+    Loc            Loc
+}
+func (n *JoinExpr) Tag() NodeTag { return T_JoinExpr }
+
+type JoinType int
+const (
+    JoinInner JoinType = iota // [INNER] JOIN
+    JoinLeft                   // LEFT [OUTER] JOIN
+    JoinRight                  // RIGHT [OUTER] JOIN
+    JoinFull                   // FULL [OUTER] JOIN
+    JoinCross                  // CROSS JOIN
+    JoinAsof                   // ASOF JOIN (Snowflake-specific)
+)
+```
+
+### Extended TableRef (3 new fields)
+
+```go
+type TableRef struct {
+    Name     *ObjectName    // table name; nil for subquery/func sources
+    Alias    Ident          // AS alias; zero if absent
+    Subquery Node           // (SELECT ...) in FROM; nil for table refs
+    FuncCall *FuncCallExpr  // TABLE(func(...)); nil for table refs
+    Lateral  bool           // LATERAL prefix
+    Loc      Loc
+}
+```
+
+A TableRef is now polymorphic:
+- **Table**: Name is set, others nil
+- **Subquery**: Subquery is set, Name is nil
+- **Table function**: FuncCall is set, Name is nil
+- Any of the above can have `Lateral = true`
+
+### SelectStmt.From type change
+
+```go
+// Was: From []*TableRef
+From []Node // mixed TableRef and JoinExpr
+```
+
+This is a breaking change to T1.4's type. Since we control all consumers (only select_test.go references `From`), the fix is to update those test assertions.
+
+### NodeTag addition
+
+One new tag: `T_JoinExpr`.
+
+## Parser Changes
+
+### Revised `parseFromClause()`
+
+Returns `[]ast.Node` instead of `[]*ast.TableRef`. Parses comma-separated "from items" where each item is a primary source optionally followed by a chain of JOINs.
+
+```go
+func (p *Parser) parseFromClause() ([]ast.Node, error) {
+    // consume FROM
+    var items []ast.Node
+    item, err := p.parseFromItem()
+    items = append(items, item)
+    for p.cur.Type == ',' {
+        p.advance()
+        item, err = p.parseFromItem()
+        items = append(items, item)
+    }
+    return items, nil
+}
+```
+
+### New: `parseFromItem()`
+
+Parses one comma-separated FROM item: a primary source + optional JOIN chain.
+
+```go
+func (p *Parser) parseFromItem() (ast.Node, error) {
+    left, err := p.parsePrimarySource()
+    return p.parseJoinChain(left)
+}
+```
+
+### New: `parsePrimarySource()`
+
+Dispatches on the current token:
+- `(` → subquery (`(SELECT ...)`) or parenthesized from-item (`(t1 JOIN t2 ON ...)`)
+- `kwLATERAL` → consume, then recurse (sets Lateral=true on result)
+- `kwTABLE` → consume `TABLE(`, parse function call, wrap in TableRef{FuncCall: ...}
+- Otherwise → `parseTableRef()` (existing: ObjectName + alias)
+
+### New: `parseJoinChain(left)`
+
+Left-associative loop that builds a JoinExpr tree:
+
+```go
+func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
+    for {
+        joinType, natural, directed, ok := p.parseJoinKeywords()
+        if !ok { break }
+        right, err := p.parsePrimarySource()
+        // parse ON / USING / MATCH_CONDITION
+        join := &ast.JoinExpr{Type: joinType, Left: left, Right: right, Natural: natural, Directed: directed, ...}
+        left = join
+    }
+    return left, nil
+}
+```
+
+### New: `parseJoinKeywords()`
+
+Recognizes all JOIN keyword combinations:
+- `[INNER] JOIN` → JoinInner
+- `LEFT [OUTER] JOIN` → JoinLeft
+- `RIGHT [OUTER] JOIN` → JoinRight
+- `FULL [OUTER] JOIN` → JoinFull
+- `CROSS JOIN` → JoinCross
+- `NATURAL [LEFT|RIGHT|FULL] JOIN` → sets natural=true + appropriate type
+- `ASOF JOIN` → JoinAsof
+- `DIRECTED [INNER|LEFT|...] JOIN` → sets directed=true + appropriate type
+- `JOIN` alone → JoinInner (implicit INNER)
+
+Returns `(joinType, natural, directed, ok)` where ok=false if current position is not a join keyword.
+
+### Join condition parsing
+
+After the right source:
+- If `kwON`: parse expression → `JoinExpr.On`
+- If `kwUSING`: expect `(`, parse ident list, expect `)` → `JoinExpr.Using`
+- If ASOF: expect `kwMATCH_CONDITION` (or tokIdent "MATCH_CONDITION"), expect `(`, parse expr, expect `)` → `JoinExpr.MatchCondition`
+- CROSS and NATURAL joins: no condition required
+- All other joins: ON or USING is expected (error if absent)
+
+## File Layout
+
+| File | Change | Approx LOC |
+|------|--------|-----------|
+| `snowflake/ast/parsenodes.go` | MODIFY: extend TableRef + add JoinExpr + JoinType | +60 |
+| `snowflake/ast/nodetags.go` | MODIFY: +T_JoinExpr | +3 |
+| `snowflake/ast/loc.go` | MODIFY: +*JoinExpr case | +2 |
+| `snowflake/ast/walk_generated.go` | REGENERATED | auto |
+| `snowflake/parser/select.go` | MODIFY: replace parseFromClause + add parseFromItem/parsePrimarySource/parseJoinChain/parseJoinKeywords | +250 |
+| `snowflake/parser/select_test.go` | MODIFY: update From assertions + add 15 join test categories | +300 |
+
+**Estimated total: ~600 LOC** across 0 new + 6 modified files.
+
+## Testing (15 categories)
+
+1. `FROM t1 JOIN t2 ON t1.id = t2.id` — basic INNER
+2. `FROM t1 LEFT JOIN t2 ON ...` — LEFT
+3. `FROM t1 RIGHT OUTER JOIN t2 ON ...` — RIGHT OUTER
+4. `FROM t1 FULL JOIN t2 ON ...` — FULL
+5. `FROM t1 CROSS JOIN t2` — CROSS (no ON)
+6. `FROM t1 NATURAL JOIN t2` — NATURAL (no ON/USING)
+7. `FROM t1 JOIN t2 USING (id)` — USING
+8. `FROM t1 JOIN t2 ON ... JOIN t3 ON ...` — chained left-assoc
+9. `FROM t1, t2 JOIN t3 ON ...` — comma + join mixed
+10. `FROM (SELECT 1 AS x) AS sub` — subquery in FROM
+11. `FROM LATERAL (SELECT ...)` — LATERAL subquery
+12. `FROM TABLE(FLATTEN(v:arr))` — table function (basic — may need tokIdent check for FLATTEN)
+13. `FROM t1 ASOF JOIN t2 MATCH_CONDITION (t1.ts >= t2.ts)` — Snowflake ASOF
+14. `FROM t1 DIRECTED INNER JOIN t2 ON ...` — DIRECTED hint
+15. Error cases: JOIN without ON, missing alias for subquery
+
+## Out of Scope
+
+| Feature | Where |
+|---|---|
+| PIVOT / UNPIVOT | T5.3 |
+| SAMPLE / TABLESAMPLE | T5.3 |
+| MATCH_RECOGNIZE | T5.3 |
+| CHANGES clause | T5.3 |
+| AT / BEFORE (time travel) | T5.3 |
+
+## Acceptance Criteria
+
+1. `go build ./snowflake/...` succeeds
+2. `go vet ./snowflake/...` clean
+3. `gofmt -l snowflake/` clean
+4. `go test ./snowflake/...` passes
+5. `Parse("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id;")` returns a SelectStmt with `From[0]` being a `*JoinExpr`
+6. Existing T1.4 SELECT tests still pass (updated for `From []Node` type change)
+7. Walker regen correct
+8. After merge, dag.md T1.5 → done

--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -62,6 +62,10 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *SetOperationStmt:
 		return v.Loc
+	case *TableRef:
+		return v.Loc
+	case *JoinExpr:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -48,6 +48,8 @@ const (
 	T_ExistsExpr
 	T_SelectStmt
 	T_SetOperationStmt
+	T_TableRef
+	T_JoinExpr
 )
 
 // String returns a human-readable representation of the tag.
@@ -107,6 +109,10 @@ func (t NodeTag) String() string {
 		return "SelectStmt"
 	case T_SetOperationStmt:
 		return "SetOperationStmt"
+	case T_TableRef:
+		return "TableRef"
+	case T_JoinExpr:
+		return "JoinExpr"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -717,7 +717,7 @@ type SelectStmt struct {
 	All      bool            // SELECT ALL
 	Top      Node            // TOP n expression; nil if absent
 	Targets  []*SelectTarget // SELECT list items
-	From     []*TableRef     // FROM table references; nil if absent
+	From     []Node          // FROM: mixed *TableRef and *JoinExpr; nil if absent
 	Where    Node            // WHERE condition; nil if absent
 	GroupBy  *GroupByClause  // GROUP BY; nil if absent
 	Having   Node            // HAVING condition; nil if absent
@@ -745,12 +745,52 @@ type SelectTarget struct {
 }
 
 // TableRef is a table reference in the FROM clause.
-// T1.5 extends this with join syntax.
+// A TableRef is polymorphic:
+//   - Table: Name is set, others nil
+//   - Subquery: Subquery is set, Name is nil
+//   - Table function: FuncCall is set, Name is nil
+//   - Any of the above can have Lateral = true
 type TableRef struct {
-	Name  *ObjectName // table name
-	Alias Ident       // AS alias; zero if absent
-	Loc   Loc
+	Name     *ObjectName   // table name; nil for subquery/func sources
+	Alias    Ident         // AS alias; zero if absent
+	Subquery Node          // (SELECT ...) in FROM; nil for table refs
+	FuncCall *FuncCallExpr // TABLE(func(...)); nil for table refs
+	Lateral  bool          // LATERAL prefix
+	Loc      Loc
 }
+
+func (n *TableRef) Tag() NodeTag { return T_TableRef }
+
+var _ Node = (*TableRef)(nil)
+
+// JoinExpr represents a JOIN between two FROM sources.
+type JoinExpr struct {
+	Type           JoinType
+	Left           Node    // TableRef or nested JoinExpr
+	Right          Node    // TableRef or nested JoinExpr
+	On             Node    // ON condition; nil for CROSS/NATURAL/USING-only
+	Using          []Ident // USING columns; nil if ON or NATURAL
+	Natural        bool
+	Directed       bool // Snowflake DIRECTED hint
+	MatchCondition Node // ASOF MATCH_CONDITION(expr); nil for non-ASOF
+	Loc            Loc
+}
+
+func (n *JoinExpr) Tag() NodeTag { return T_JoinExpr }
+
+var _ Node = (*JoinExpr)(nil)
+
+// JoinType enumerates the kinds of JOIN.
+type JoinType int
+
+const (
+	JoinInner JoinType = iota // [INNER] JOIN
+	JoinLeft                  // LEFT [OUTER] JOIN
+	JoinRight                 // RIGHT [OUTER] JOIN
+	JoinFull                  // FULL [OUTER] JOIN
+	JoinCross                 // CROSS JOIN
+	JoinAsof                  // ASOF JOIN (Snowflake-specific)
+)
 
 // CTE represents a Common Table Expression in a WITH clause.
 type CTE struct {

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -44,6 +44,11 @@ func walkChildren(v Visitor, node Node) {
 	case *IsExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.DistinctFrom)
+	case *JoinExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+		Walk(v, n.On)
+		Walk(v, n.MatchCondition)
 	case *LambdaExpr:
 		Walk(v, n.Body)
 	case *LikeExpr:
@@ -55,6 +60,7 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Expr)
 	case *SelectStmt:
 		Walk(v, n.Top)
+		walkNodes(v, n.From)
 		Walk(v, n.Where)
 		Walk(v, n.Having)
 		Walk(v, n.Qualify)
@@ -69,6 +75,14 @@ func walkChildren(v Visitor, node Node) {
 		}
 	case *SubqueryExpr:
 		Walk(v, n.Query)
+	case *TableRef:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.Subquery)
+		if n.FuncCall != nil {
+			Walk(v, n.FuncCall)
+		}
 	case *TypeName:
 		if n.ElementType != nil {
 			Walk(v, n.ElementType)

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -462,30 +462,422 @@ func (p *Parser) parseSelectTarget() (*ast.SelectTarget, error) {
 // FROM clause
 // ---------------------------------------------------------------------------
 
-// parseFromClause parses comma-separated table references.
+// parseFromClause parses comma-separated FROM items, where each item is
+// a primary source optionally followed by a chain of JOINs.
 // The FROM keyword has already been consumed by the caller.
-func (p *Parser) parseFromClause() ([]*ast.TableRef, error) {
-	var refs []*ast.TableRef
+func (p *Parser) parseFromClause() ([]ast.Node, error) {
+	var items []ast.Node
 
-	ref, err := p.parseTableRef()
+	item, err := p.parseFromItem()
 	if err != nil {
 		return nil, err
 	}
-	refs = append(refs, ref)
+	items = append(items, item)
 
 	for p.cur.Type == ',' {
 		p.advance() // consume ','
-		ref, err = p.parseTableRef()
+		item, err = p.parseFromItem()
 		if err != nil {
 			return nil, err
 		}
-		refs = append(refs, ref)
+		items = append(items, item)
 	}
 
-	return refs, nil
+	return items, nil
 }
 
-// parseTableRef parses one table reference: object_name [AS alias].
+// parseFromItem parses one comma-separated FROM item: a primary source
+// optionally followed by a join chain.
+func (p *Parser) parseFromItem() (ast.Node, error) {
+	left, err := p.parsePrimarySource()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseJoinChain(left)
+}
+
+// parsePrimarySource dispatches on the current token to parse a single
+// FROM source:
+//   - ( → subquery or parenthesized from-item
+//   - LATERAL → consume, recurse, set Lateral=true
+//   - TABLE → TABLE(func(...))
+//   - otherwise → parseTableRef (ObjectName + alias)
+func (p *Parser) parsePrimarySource() (ast.Node, error) {
+	startLoc := p.cur.Loc
+
+	// Parenthesized: subquery or parenthesized from-item.
+	if p.cur.Type == '(' {
+		next := p.peekNext()
+		if next.Type == kwSELECT || next.Type == kwWITH {
+			// Subquery in FROM: (SELECT ...) [AS] alias
+			p.advance() // consume '('
+			var query ast.Node
+			var err error
+			if p.cur.Type == kwWITH {
+				query, err = p.parseWithSelect()
+			} else {
+				query, err = p.parseSelectStmt()
+			}
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return nil, err
+			}
+			ref := &ast.TableRef{
+				Subquery: query,
+				Loc:      ast.Loc{Start: startLoc.Start},
+			}
+			alias, hasAlias := p.parseOptionalAlias()
+			if hasAlias {
+				ref.Alias = alias
+			}
+			ref.Loc.End = p.prev.Loc.End
+			return ref, nil
+		}
+		// Parenthesized from-item: (t1 JOIN t2 ON ...)
+		p.advance() // consume '('
+		inner, err := p.parseFromItem()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		return inner, nil
+	}
+
+	// LATERAL prefix
+	if p.cur.Type == kwLATERAL {
+		p.advance() // consume LATERAL
+		// LATERAL can be followed by a subquery, TABLE(func), or FLATTEN(...)
+		source, err := p.parsePrimarySource()
+		if err != nil {
+			return nil, err
+		}
+		// Set Lateral on the resulting TableRef
+		if ref, ok := source.(*ast.TableRef); ok {
+			ref.Lateral = true
+			ref.Loc.Start = startLoc.Start
+			return ref, nil
+		}
+		// If it's not a TableRef (shouldn't normally happen), wrap it
+		return source, nil
+	}
+
+	// TABLE(func(...)) — table function
+	if p.cur.Type == kwTABLE {
+		p.advance() // consume TABLE
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		// Parse the function call expression inside TABLE(...)
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		funcCall, ok := expr.(*ast.FuncCallExpr)
+		if !ok {
+			return nil, &ParseError{
+				Loc: ast.NodeLoc(expr),
+				Msg: "expected function call inside TABLE(...)",
+			}
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		ref := &ast.TableRef{
+			FuncCall: funcCall,
+			Loc:      ast.Loc{Start: startLoc.Start},
+		}
+		alias, hasAlias := p.parseOptionalAlias()
+		if hasAlias {
+			ref.Alias = alias
+		}
+		ref.Loc.End = p.prev.Loc.End
+		return ref, nil
+	}
+
+	// FLATTEN(...) as a bare function in FROM (common Snowflake pattern)
+	if p.cur.Type == kwFLATTEN {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		funcCall, ok := expr.(*ast.FuncCallExpr)
+		if !ok {
+			return nil, &ParseError{
+				Loc: ast.NodeLoc(expr),
+				Msg: "expected function call for FLATTEN",
+			}
+		}
+		ref := &ast.TableRef{
+			FuncCall: funcCall,
+			Loc:      ast.Loc{Start: startLoc.Start},
+		}
+		alias, hasAlias := p.parseOptionalAlias()
+		if hasAlias {
+			ref.Alias = alias
+		}
+		ref.Loc.End = p.prev.Loc.End
+		return ref, nil
+	}
+
+	// Default: simple table reference (ObjectName + alias)
+	return p.parseTableRef()
+}
+
+// parseJoinChain builds a left-associative JoinExpr tree from any
+// JOIN keywords following the left source.
+func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
+	for {
+		joinType, natural, directed, ok := p.parseJoinKeywords()
+		if !ok {
+			break
+		}
+
+		right, err := p.parsePrimarySource()
+		if err != nil {
+			return nil, err
+		}
+
+		join := &ast.JoinExpr{
+			Type:     joinType,
+			Left:     left,
+			Right:    right,
+			Natural:  natural,
+			Directed: directed,
+			Loc:      ast.Loc{Start: ast.NodeLoc(left).Start},
+		}
+
+		// Parse join condition
+		switch {
+		case joinType == ast.JoinAsof:
+			// ASOF JOIN: expect MATCH_CONDITION(expr)
+			if p.cur.Type == kwMATCH_CONDITION ||
+				(p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "MATCH_CONDITION") {
+				p.advance() // consume MATCH_CONDITION
+				if _, err := p.expect('('); err != nil {
+					return nil, err
+				}
+				cond, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				if _, err := p.expect(')'); err != nil {
+					return nil, err
+				}
+				join.MatchCondition = cond
+			}
+			// ASOF may also have ON
+			if p.cur.Type == kwON {
+				p.advance() // consume ON
+				onExpr, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				join.On = onExpr
+			}
+
+		case joinType == ast.JoinCross || natural:
+			// CROSS JOIN and NATURAL JOIN: no condition required
+
+		case p.cur.Type == kwON:
+			p.advance() // consume ON
+			onExpr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			join.On = onExpr
+
+		case p.cur.Type == kwUSING:
+			p.advance() // consume USING
+			if _, err := p.expect('('); err != nil {
+				return nil, err
+			}
+			var cols []ast.Ident
+			col, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			cols = append(cols, col)
+			for p.cur.Type == ',' {
+				p.advance() // consume ','
+				col, err = p.parseIdent()
+				if err != nil {
+					return nil, err
+				}
+				cols = append(cols, col)
+			}
+			if _, err := p.expect(')'); err != nil {
+				return nil, err
+			}
+			join.Using = cols
+		}
+
+		join.Loc.End = p.prev.Loc.End
+		left = join
+	}
+	return left, nil
+}
+
+// parseJoinKeywords checks whether the current token position starts a
+// JOIN keyword sequence. If so, it consumes the tokens and returns
+// (joinType, natural, directed, true). If not, returns (0, false, false, false)
+// without consuming any tokens.
+func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
+	// NATURAL [LEFT|RIGHT|FULL] [OUTER] JOIN
+	if p.cur.Type == kwNATURAL {
+		next := p.peekNext()
+		// NATURAL JOIN
+		if next.Type == kwJOIN {
+			p.advance() // consume NATURAL
+			p.advance() // consume JOIN
+			return ast.JoinInner, true, false, true
+		}
+		// NATURAL LEFT/RIGHT/FULL [OUTER] JOIN
+		if next.Type == kwLEFT || next.Type == kwRIGHT || next.Type == kwFULL {
+			p.advance() // consume NATURAL
+			jt := p.consumeDirectionAndJoin()
+			return jt, true, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// DIRECTED [INNER|LEFT|RIGHT|FULL|CROSS] JOIN
+	if p.cur.Type == kwDIRECTED {
+		next := p.peekNext()
+		switch next.Type {
+		case kwJOIN:
+			p.advance() // consume DIRECTED
+			p.advance() // consume JOIN
+			return ast.JoinInner, false, true, true
+		case kwINNER:
+			p.advance() // consume DIRECTED
+			p.advance() // consume INNER
+			if _, err := p.expect(kwJOIN); err == nil {
+				return ast.JoinInner, false, true, true
+			}
+			return 0, false, false, false
+		case kwLEFT, kwRIGHT, kwFULL:
+			p.advance() // consume DIRECTED
+			jt := p.consumeDirectionAndJoin()
+			return jt, false, true, true
+		case kwCROSS:
+			p.advance() // consume DIRECTED
+			p.advance() // consume CROSS
+			if _, err := p.expect(kwJOIN); err == nil {
+				return ast.JoinCross, false, true, true
+			}
+			return 0, false, false, false
+		}
+		return 0, false, false, false
+	}
+
+	// ASOF JOIN
+	if p.cur.Type == kwASOF {
+		next := p.peekNext()
+		if next.Type == kwJOIN {
+			p.advance() // consume ASOF
+			p.advance() // consume JOIN
+			return ast.JoinAsof, false, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// INNER JOIN
+	if p.cur.Type == kwINNER {
+		next := p.peekNext()
+		if next.Type == kwJOIN {
+			p.advance() // consume INNER
+			p.advance() // consume JOIN
+			return ast.JoinInner, false, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// LEFT [OUTER] JOIN
+	if p.cur.Type == kwLEFT {
+		jt := p.consumeDirectionAndJoin()
+		if jt == ast.JoinLeft {
+			return jt, false, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// RIGHT [OUTER] JOIN
+	if p.cur.Type == kwRIGHT {
+		jt := p.consumeDirectionAndJoin()
+		if jt == ast.JoinRight {
+			return jt, false, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// FULL [OUTER] JOIN
+	if p.cur.Type == kwFULL {
+		jt := p.consumeDirectionAndJoin()
+		if jt == ast.JoinFull {
+			return jt, false, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// CROSS JOIN
+	if p.cur.Type == kwCROSS {
+		next := p.peekNext()
+		if next.Type == kwJOIN {
+			p.advance() // consume CROSS
+			p.advance() // consume JOIN
+			return ast.JoinCross, false, false, true
+		}
+		return 0, false, false, false
+	}
+
+	// Bare JOIN (= INNER)
+	if p.cur.Type == kwJOIN {
+		p.advance() // consume JOIN
+		return ast.JoinInner, false, false, true
+	}
+
+	return 0, false, false, false
+}
+
+// consumeDirectionAndJoin consumes LEFT/RIGHT/FULL [OUTER] JOIN and returns
+// the corresponding JoinType. The caller must have already checked that
+// p.cur.Type is kwLEFT, kwRIGHT, or kwFULL.
+// If the sequence doesn't end with JOIN, this returns JoinInner as a sentinel
+// (the caller checks the return value).
+func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
+	dir := p.cur.Type
+	p.advance() // consume LEFT/RIGHT/FULL
+
+	// Optional OUTER
+	if p.cur.Type == kwOUTER {
+		p.advance() // consume OUTER
+	}
+
+	// Expect JOIN
+	if p.cur.Type != kwJOIN {
+		// Not a join sequence — but we already consumed tokens.
+		// This is an issue; for safety, return a sentinel and let caller handle.
+		return ast.JoinInner
+	}
+	p.advance() // consume JOIN
+
+	switch dir {
+	case kwLEFT:
+		return ast.JoinLeft
+	case kwRIGHT:
+		return ast.JoinRight
+	case kwFULL:
+		return ast.JoinFull
+	default:
+		return ast.JoinInner
+	}
+}
+
+// parseTableRef parses one simple table reference: object_name [AS alias].
 func (p *Parser) parseTableRef() (*ast.TableRef, error) {
 	name, err := p.parseObjectName()
 	if err != nil {
@@ -729,7 +1121,8 @@ func isClauseKeyword(t int) bool {
 		kwLIMIT, kwOFFSET, kwFETCH, kwUNION, kwEXCEPT, kwMINUS, kwINTERSECT,
 		kwINTO, kwON, kwJOIN, kwINNER, kwLEFT, kwRIGHT, kwFULL,
 		kwCROSS, kwNATURAL, kwWITH, kwSELECT, kwSET, kwWHEN,
-		kwTHEN, kwELSE, kwEND, kwCASE, kwROWS, kwGROUPS, kwOVER:
+		kwTHEN, kwELSE, kwEND, kwCASE, kwROWS, kwGROUPS, kwOVER,
+		kwUSING, kwOUTER, kwASOF, kwDIRECTED, kwLATERAL, kwMATCH_CONDITION:
 		return true
 	}
 	return false

--- a/snowflake/parser/select_test.go
+++ b/snowflake/parser/select_test.go
@@ -254,17 +254,25 @@ func TestSelect_CommaFrom(t *testing.T) {
 	if len(sel.From) != 2 {
 		t.Fatalf("from = %d, want 2", len(sel.From))
 	}
-	if sel.From[0].Name.Name.Name != "t1" {
-		t.Errorf("from[0] = %q, want %q", sel.From[0].Name.Name.Name, "t1")
+	from0, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0]: expected *ast.TableRef, got %T", sel.From[0])
 	}
-	if !sel.From[0].Alias.IsEmpty() {
-		t.Errorf("from[0] alias should be empty, got %q", sel.From[0].Alias.Name)
+	if from0.Name.Name.Name != "t1" {
+		t.Errorf("from[0] = %q, want %q", from0.Name.Name.Name, "t1")
 	}
-	if sel.From[1].Name.Name.Name != "t2" {
-		t.Errorf("from[1] = %q, want %q", sel.From[1].Name.Name.Name, "t2")
+	if !from0.Alias.IsEmpty() {
+		t.Errorf("from[0] alias should be empty, got %q", from0.Alias.Name)
 	}
-	if sel.From[1].Alias.Name != "x" {
-		t.Errorf("from[1] alias = %q, want %q", sel.From[1].Alias.Name, "x")
+	from1, ok := sel.From[1].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[1]: expected *ast.TableRef, got %T", sel.From[1])
+	}
+	if from1.Name.Name.Name != "t2" {
+		t.Errorf("from[1] = %q, want %q", from1.Name.Name.Name, "t2")
+	}
+	if from1.Alias.Name != "x" {
+		t.Errorf("from[1] alias = %q, want %q", from1.Alias.Name, "x")
 	}
 }
 
@@ -796,8 +804,12 @@ func TestSelect_TableAliasNotConsumeWHERE(t *testing.T) {
 	if len(sel.From) != 1 {
 		t.Fatalf("from = %d, want 1", len(sel.From))
 	}
-	if !sel.From[0].Alias.IsEmpty() {
-		t.Errorf("table alias should be empty, got %q", sel.From[0].Alias.Name)
+	from0, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0]: expected *ast.TableRef, got %T", sel.From[0])
+	}
+	if !from0.Alias.IsEmpty() {
+		t.Errorf("table alias should be empty, got %q", from0.Alias.Name)
 	}
 	if sel.Where == nil {
 		t.Fatal("WHERE should be set")
@@ -812,11 +824,19 @@ func TestSelect_TableImplicitAlias(t *testing.T) {
 	if len(sel.From) != 2 {
 		t.Fatalf("from = %d, want 2", len(sel.From))
 	}
-	if sel.From[0].Alias.Name != "x" {
-		t.Errorf("from[0] alias = %q, want %q", sel.From[0].Alias.Name, "x")
+	from0, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0]: expected *ast.TableRef, got %T", sel.From[0])
 	}
-	if sel.From[1].Alias.Name != "y" {
-		t.Errorf("from[1] alias = %q, want %q", sel.From[1].Alias.Name, "y")
+	if from0.Alias.Name != "x" {
+		t.Errorf("from[0] alias = %q, want %q", from0.Alias.Name, "x")
+	}
+	from1, ok := sel.From[1].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[1]: expected *ast.TableRef, got %T", sel.From[1])
+	}
+	if from1.Alias.Name != "y" {
+		t.Errorf("from[1] alias = %q, want %q", from1.Alias.Name, "y")
 	}
 }
 
@@ -873,7 +893,11 @@ func TestSelect_QualifiedTableName(t *testing.T) {
 	if len(sel.From) != 1 {
 		t.Fatalf("from = %d, want 1", len(sel.From))
 	}
-	name := sel.From[0].Name
+	from0, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0]: expected *ast.TableRef, got %T", sel.From[0])
+	}
+	name := from0.Name
 	if name.Database.Name != "mydb" {
 		t.Errorf("database = %q, want %q", name.Database.Name, "mydb")
 	}
@@ -1197,5 +1221,707 @@ func TestSetOp_WithCTE(t *testing.T) {
 	}
 	if _, ok := node.Right.(*ast.SelectStmt); !ok {
 		t.Errorf("Right: expected *SelectStmt, got %T", node.Right)
+	}
+}
+
+// ===========================================================================
+// JOIN tests (T1.5)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// J1. Basic INNER JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoin_InnerJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %v, want JoinInner", join.Type)
+	}
+	if join.Natural {
+		t.Error("expected Natural = false")
+	}
+	if join.Directed {
+		t.Error("expected Directed = false")
+	}
+
+	// Left and Right should be TableRef
+	left, ok := join.Left.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("left: expected *ast.TableRef, got %T", join.Left)
+	}
+	if left.Name.Name.Name != "t1" {
+		t.Errorf("left = %q, want %q", left.Name.Name.Name, "t1")
+	}
+	right, ok := join.Right.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("right: expected *ast.TableRef, got %T", join.Right)
+	}
+	if right.Name.Name.Name != "t2" {
+		t.Errorf("right = %q, want %q", right.Name.Name.Name, "t2")
+	}
+
+	// ON condition
+	if join.On == nil {
+		t.Fatal("expected ON condition")
+	}
+	_, ok = join.On.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("ON: expected *ast.BinaryExpr, got %T", join.On)
+	}
+}
+
+func TestJoin_ExplicitInnerJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 INNER JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %v, want JoinInner", join.Type)
+	}
+	if join.On == nil {
+		t.Fatal("expected ON condition")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J2. LEFT JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoin_LeftJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join type = %v, want JoinLeft", join.Type)
+	}
+	if join.On == nil {
+		t.Fatal("expected ON condition")
+	}
+}
+
+func TestJoin_LeftOuterJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join type = %v, want JoinLeft", join.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J3. RIGHT OUTER JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoin_RightOuterJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinRight {
+		t.Errorf("join type = %v, want JoinRight", join.Type)
+	}
+}
+
+func TestJoin_RightJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 RIGHT JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinRight {
+		t.Errorf("join type = %v, want JoinRight", join.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J4. FULL JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoin_FullJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 FULL JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinFull {
+		t.Errorf("join type = %v, want JoinFull", join.Type)
+	}
+}
+
+func TestJoin_FullOuterJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinFull {
+		t.Errorf("join type = %v, want JoinFull", join.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J5. CROSS JOIN (no ON)
+// ---------------------------------------------------------------------------
+
+func TestJoin_CrossJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 CROSS JOIN t2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinCross {
+		t.Errorf("join type = %v, want JoinCross", join.Type)
+	}
+	if join.On != nil {
+		t.Error("CROSS JOIN should not have ON condition")
+	}
+	if join.Using != nil {
+		t.Error("CROSS JOIN should not have USING")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J6. NATURAL JOIN (no ON/USING)
+// ---------------------------------------------------------------------------
+
+func TestJoin_NaturalJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 NATURAL JOIN t2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %v, want JoinInner", join.Type)
+	}
+	if !join.Natural {
+		t.Error("expected Natural = true")
+	}
+	if join.On != nil {
+		t.Error("NATURAL JOIN should not have ON")
+	}
+	if join.Using != nil {
+		t.Error("NATURAL JOIN should not have USING")
+	}
+}
+
+func TestJoin_NaturalLeftJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 NATURAL LEFT JOIN t2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join type = %v, want JoinLeft", join.Type)
+	}
+	if !join.Natural {
+		t.Error("expected Natural = true")
+	}
+}
+
+func TestJoin_NaturalRightJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 NATURAL RIGHT JOIN t2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinRight {
+		t.Errorf("join type = %v, want JoinRight", join.Type)
+	}
+	if !join.Natural {
+		t.Error("expected Natural = true")
+	}
+}
+
+func TestJoin_NaturalFullJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 NATURAL FULL JOIN t2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinFull {
+		t.Errorf("join type = %v, want JoinFull", join.Type)
+	}
+	if !join.Natural {
+		t.Error("expected Natural = true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J7. USING clause
+// ---------------------------------------------------------------------------
+
+func TestJoin_UsingClause(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 JOIN t2 USING (id)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %v, want JoinInner", join.Type)
+	}
+	if join.On != nil {
+		t.Error("USING join should not have ON")
+	}
+	if len(join.Using) != 1 {
+		t.Fatalf("Using = %d, want 1", len(join.Using))
+	}
+	if join.Using[0].Name != "id" {
+		t.Errorf("Using[0] = %q, want %q", join.Using[0].Name, "id")
+	}
+}
+
+func TestJoin_UsingMultipleColumns(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 JOIN t2 USING (id, name)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if len(join.Using) != 2 {
+		t.Fatalf("Using = %d, want 2", len(join.Using))
+	}
+	if join.Using[0].Name != "id" {
+		t.Errorf("Using[0] = %q, want %q", join.Using[0].Name, "id")
+	}
+	if join.Using[1].Name != "name" {
+		t.Errorf("Using[1] = %q, want %q", join.Using[1].Name, "name")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J8. Chained JOINs — left-associative
+// ---------------------------------------------------------------------------
+
+func TestJoin_ChainedJoins(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id JOIN t3 ON t2.id = t3.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	// Outer join: (t1 JOIN t2) JOIN t3
+	outerJoin, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected outer *ast.JoinExpr, got %T", sel.From[0])
+	}
+	// Left of outer should be inner join
+	innerJoin, ok := outerJoin.Left.(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("outer.Left: expected *ast.JoinExpr, got %T", outerJoin.Left)
+	}
+	// innerJoin.Left = t1, innerJoin.Right = t2
+	t1, ok := innerJoin.Left.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("inner.Left: expected *ast.TableRef, got %T", innerJoin.Left)
+	}
+	if t1.Name.Name.Name != "t1" {
+		t.Errorf("inner.Left = %q, want %q", t1.Name.Name.Name, "t1")
+	}
+	t2, ok := innerJoin.Right.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("inner.Right: expected *ast.TableRef, got %T", innerJoin.Right)
+	}
+	if t2.Name.Name.Name != "t2" {
+		t.Errorf("inner.Right = %q, want %q", t2.Name.Name.Name, "t2")
+	}
+	// outerJoin.Right = t3
+	t3, ok := outerJoin.Right.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("outer.Right: expected *ast.TableRef, got %T", outerJoin.Right)
+	}
+	if t3.Name.Name.Name != "t3" {
+		t.Errorf("outer.Right = %q, want %q", t3.Name.Name.Name, "t3")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J9. Comma + JOIN mixed
+// ---------------------------------------------------------------------------
+
+func TestJoin_CommaAndJoinMixed(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1, t2 JOIN t3 ON t2.id = t3.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 2 {
+		t.Fatalf("from = %d, want 2", len(sel.From))
+	}
+	// From[0] = TableRef(t1)
+	ref0, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0]: expected *ast.TableRef, got %T", sel.From[0])
+	}
+	if ref0.Name.Name.Name != "t1" {
+		t.Errorf("from[0] = %q, want %q", ref0.Name.Name.Name, "t1")
+	}
+	// From[1] = JoinExpr(t2 JOIN t3)
+	join1, ok := sel.From[1].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("from[1]: expected *ast.JoinExpr, got %T", sel.From[1])
+	}
+	left, ok := join1.Left.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[1].Left: expected *ast.TableRef, got %T", join1.Left)
+	}
+	if left.Name.Name.Name != "t2" {
+		t.Errorf("from[1].Left = %q, want %q", left.Name.Name.Name, "t2")
+	}
+	right, ok := join1.Right.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[1].Right: expected *ast.TableRef, got %T", join1.Right)
+	}
+	if right.Name.Name.Name != "t3" {
+		t.Errorf("from[1].Right = %q, want %q", right.Name.Name.Name, "t3")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J10. Subquery in FROM
+// ---------------------------------------------------------------------------
+
+func TestJoin_SubqueryInFrom(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM (SELECT 1 AS x) AS sub")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("expected *ast.TableRef, got %T", sel.From[0])
+	}
+	if ref.Subquery == nil {
+		t.Fatal("expected Subquery to be set")
+	}
+	if ref.Name != nil {
+		t.Error("Name should be nil for subquery source")
+	}
+	innerSel, ok := ref.Subquery.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Subquery: expected *ast.SelectStmt, got %T", ref.Subquery)
+	}
+	if len(innerSel.Targets) != 1 {
+		t.Errorf("inner targets = %d, want 1", len(innerSel.Targets))
+	}
+	if ref.Alias.Name != "sub" {
+		t.Errorf("alias = %q, want %q", ref.Alias.Name, "sub")
+	}
+}
+
+func TestJoin_SubqueryJoinTable(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM (SELECT 1 AS id) AS sub JOIN t2 ON sub.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	left, ok := join.Left.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("Left: expected *ast.TableRef, got %T", join.Left)
+	}
+	if left.Subquery == nil {
+		t.Fatal("Left.Subquery should be set")
+	}
+	if left.Alias.Name != "sub" {
+		t.Errorf("Left.Alias = %q, want %q", left.Alias.Name, "sub")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J11. LATERAL subquery
+// ---------------------------------------------------------------------------
+
+func TestJoin_LateralSubquery(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1, LATERAL (SELECT t1.id) AS lat")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 2 {
+		t.Fatalf("from = %d, want 2", len(sel.From))
+	}
+	ref, ok := sel.From[1].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[1]: expected *ast.TableRef, got %T", sel.From[1])
+	}
+	if !ref.Lateral {
+		t.Error("expected Lateral = true")
+	}
+	if ref.Subquery == nil {
+		t.Fatal("expected Subquery to be set")
+	}
+	if ref.Alias.Name != "lat" {
+		t.Errorf("alias = %q, want %q", ref.Alias.Name, "lat")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J12. TABLE(FLATTEN(...)) — table function
+// ---------------------------------------------------------------------------
+
+func TestJoin_TableFlatten(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM TABLE(FLATTEN(v))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("expected *ast.TableRef, got %T", sel.From[0])
+	}
+	if ref.FuncCall == nil {
+		t.Fatal("expected FuncCall to be set")
+	}
+	if ref.FuncCall.Name.Name.Name != "FLATTEN" {
+		t.Errorf("FuncCall name = %q, want %q", ref.FuncCall.Name.Name.Name, "FLATTEN")
+	}
+	if ref.Name != nil {
+		t.Error("Name should be nil for table function source")
+	}
+}
+
+func TestJoin_TableFlattenWithAlias(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT f.value FROM TABLE(FLATTEN(v)) AS f")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("expected *ast.TableRef, got %T", sel.From[0])
+	}
+	if ref.FuncCall == nil {
+		t.Fatal("expected FuncCall to be set")
+	}
+	if ref.Alias.Name != "f" {
+		t.Errorf("alias = %q, want %q", ref.Alias.Name, "f")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J13. ASOF JOIN with MATCH_CONDITION
+// ---------------------------------------------------------------------------
+
+func TestJoin_AsofJoinMatchCondition(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 ASOF JOIN t2 MATCH_CONDITION (t1.ts >= t2.ts)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinAsof {
+		t.Errorf("join type = %v, want JoinAsof", join.Type)
+	}
+	if join.MatchCondition == nil {
+		t.Fatal("expected MatchCondition to be set")
+	}
+	_, ok = join.MatchCondition.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("MatchCondition: expected *ast.BinaryExpr, got %T", join.MatchCondition)
+	}
+}
+
+func TestJoin_AsofJoinMatchConditionAndOn(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 ASOF JOIN t2 MATCH_CONDITION (t1.ts >= t2.ts) ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinAsof {
+		t.Errorf("join type = %v, want JoinAsof", join.Type)
+	}
+	if join.MatchCondition == nil {
+		t.Fatal("expected MatchCondition to be set")
+	}
+	if join.On == nil {
+		t.Fatal("expected ON condition to be set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J14. DIRECTED JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoin_DirectedInnerJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 DIRECTED INNER JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %v, want JoinInner", join.Type)
+	}
+	if !join.Directed {
+		t.Error("expected Directed = true")
+	}
+}
+
+func TestJoin_DirectedLeftJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 DIRECTED LEFT JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join type = %v, want JoinLeft", join.Type)
+	}
+	if !join.Directed {
+		t.Error("expected Directed = true")
+	}
+}
+
+func TestJoin_DirectedBareJoin(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 DIRECTED JOIN t2 ON t1.id = t2.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %v, want JoinInner", join.Type)
+	}
+	if !join.Directed {
+		t.Error("expected Directed = true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// J15. Error cases
+// ---------------------------------------------------------------------------
+
+func TestJoin_ErrorJoinWithoutTable(t *testing.T) {
+	// JOIN with no right-hand table — should produce an error
+	_, errs := testParseSelectStmt("SELECT * FROM t1 JOIN")
+	if len(errs) == 0 {
+		t.Fatal("expected error for JOIN without right table")
+	}
+}
+
+func TestJoin_ErrorSubqueryNoClosingParen(t *testing.T) {
+	// Missing closing paren for subquery
+	_, errs := testParseSelectStmt("SELECT * FROM (SELECT 1")
+	if len(errs) == 0 {
+		t.Fatal("expected error for unclosed subquery in FROM")
+	}
+}
+
+func TestJoin_JoinWithWhereClause(t *testing.T) {
+	// Full query with JOIN + WHERE to ensure they compose correctly
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id WHERE t1.active = 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+	_, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if sel.Where == nil {
+		t.Fatal("expected WHERE to be set")
+	}
+}
+
+func TestJoin_JoinWithOrderByLimit(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id ORDER BY t1.id LIMIT 10")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("expected *ast.JoinExpr, got %T", sel.From[0])
+	}
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join type = %v, want JoinLeft", join.Type)
+	}
+	if len(sel.OrderBy) != 1 {
+		t.Fatalf("OrderBy = %d, want 1", len(sel.OrderBy))
+	}
+	if sel.Limit == nil {
+		t.Fatal("expected LIMIT to be set")
 	}
 }


### PR DESCRIPTION
## Summary

Fifth Tier 1 node. Extends T1.4's FROM clause from simple comma-separated table refs to full JOIN syntax with 6 join types, subquery-in-FROM, LATERAL, TABLE(func()), and Snowflake-specific ASOF/DIRECTED joins. 1,213 insertions across 6 files.

Depends on T1.4 SELECT core (PR #48). Unblocks T1.7 (set operators) and T1.8 (statement classification).

## What's new

- **JoinExpr** Node with Left/Right/On/Using/Natural/Directed/MatchCondition
- **JoinType** enum: Inner, Left, Right, Full, Cross, Asof
- **Extended TableRef** (promoted to Node): Subquery, FuncCall, Lateral fields
- **SelectStmt.From** changed from `[]*TableRef` to `[]Node`
- **Left-associative join chain parsing**: `a JOIN b ON ... JOIN c ON ...`

31 new join tests across 15 categories. Walker: 23 cases, 47 child fields.

## Test plan

- [ ] CI green on `snowflake/`
- [ ] `Parse("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id;")` returns JoinExpr in From
- [ ] Chained joins produce nested JoinExpr tree
- [ ] ASOF JOIN with MATCH_CONDITION parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)