### PR TITLE
feat(snowflake): T1.7 set operators — UNION/EXCEPT/MINUS/INTERSECT

### DIFF
--- a/docs/superpowers/specs/2026-04-13-snowflake-set-ops-design.md
+++ b/docs/superpowers/specs/2026-04-13-snowflake-set-ops-design.md
@@ -1,0 +1,110 @@
+# Snowflake Set Operators (T1.7) — Design
+
+**DAG node:** T1.7 — set operators
+**Branch:** `feat/snowflake/set-ops`
+**Depends on:** T1.4 (SELECT core).
+**Unblocks:** T1.8 (statement classification), Tier 2+ nodes.
+
+## Purpose
+
+T1.7 adds UNION/UNION ALL/EXCEPT/MINUS/INTERSECT operators that chain multiple SELECT statements. Currently `parseSelectStmt()` returns one SelectStmt. T1.7 wraps chained SELECTs in a `SetOperationStmt` node.
+
+## Scope
+
+From the legacy grammar's `set_operators` rule:
+- `UNION [ALL] [BY NAME]` — combines results, optional dedup, optional column-name matching
+- `EXCEPT` — set difference
+- `MINUS` — alias for EXCEPT (Snowflake treats them identically)
+- `INTERSECT` — set intersection
+
+Each is followed by another SELECT statement (which may itself be wrapped in parens or have its own set operators).
+
+## AST Types
+
+```go
+type SetOperationStmt struct {
+    Op    SetOp
+    All   bool    // UNION ALL
+    ByName bool   // UNION [ALL] BY NAME (Snowflake-specific)
+    Left  Node    // *SelectStmt or nested *SetOperationStmt
+    Right Node    // *SelectStmt or nested *SetOperationStmt
+    Loc   Loc
+}
+func (n *SetOperationStmt) Tag() NodeTag { return T_SetOperationStmt }
+
+type SetOp int
+const (
+    SetOpUnion     SetOp = iota
+    SetOpExcept
+    SetOpIntersect
+)
+```
+
+MINUS maps to `SetOpExcept` (they're semantically identical in Snowflake).
+
+## Parser Changes
+
+The key insight: set operators are parsed OUTSIDE `parseSelectStmt()`. The dispatch flow:
+
+```
+parseStmt dispatch:
+  case kwSELECT: return p.parseQueryExpr()   // NEW: wraps SELECT + set ops
+  case kwWITH:   return p.parseWithQueryExpr() // NEW: wraps WITH + SELECT + set ops
+
+parseQueryExpr:
+  left = parseSelectStmt()
+  while current is UNION/EXCEPT/MINUS/INTERSECT:
+    op, all, byName = parseSetOp()
+    right = parseSelectStmt()  // or (SELECT ...) in parens
+    left = &SetOperationStmt{Op: op, Left: left, Right: right, All: all, ByName: byName}
+  return left  // either bare SelectStmt or SetOperationStmt
+```
+
+This means:
+- `parseStmt` dispatch calls `parseQueryExpr()` (not `parseSelectStmt()` directly)
+- `parseQueryExpr()` is a thin wrapper that parses one SELECT then loops on set operators
+- If no set operators follow, returns the bare `*SelectStmt`
+- If set operators follow, returns a `*SetOperationStmt` wrapping left + right
+
+### Precedence
+
+Standard SQL: INTERSECT binds tighter than UNION/EXCEPT. So `SELECT 1 UNION SELECT 2 INTERSECT SELECT 3` = `SELECT 1 UNION (SELECT 2 INTERSECT SELECT 3)`.
+
+For simplicity in T1.7, treat all set operators as left-associative at the same precedence. This is what the legacy grammar does (no precedence distinction). Can refine later if needed.
+
+### Parenthesized SELECT in set operators
+
+`(SELECT ...) UNION (SELECT ...)` — the parens are optional around each SELECT. The legacy grammar's `select_statement_in_parentheses` allows recursive parens. T1.7 handles this: if `(` is current before a set operator's right side, check for SELECT inside and parse accordingly.
+
+## File Layout
+
+| File | Change |
+|------|--------|
+| `snowflake/ast/parsenodes.go` | +SetOperationStmt, SetOp enum |
+| `snowflake/ast/nodetags.go` | +T_SetOperationStmt |
+| `snowflake/ast/loc.go` | +*SetOperationStmt case |
+| `snowflake/ast/walk_generated.go` | Regenerated |
+| `snowflake/parser/select.go` | Add parseQueryExpr, parseSetOp; update dispatch |
+| `snowflake/parser/parser.go` | Update SELECT/WITH dispatch to call parseQueryExpr/parseWithQueryExpr |
+| `snowflake/parser/select_test.go` | Add set operator tests |
+
+**Estimated: ~300 LOC** across 7 modified files.
+
+## Testing (8 categories)
+
+1. `SELECT 1 UNION SELECT 2`
+2. `SELECT 1 UNION ALL SELECT 2`
+3. `SELECT 1 UNION ALL BY NAME SELECT 2`
+4. `SELECT 1 EXCEPT SELECT 2`
+5. `SELECT 1 MINUS SELECT 2` (same as EXCEPT)
+6. `SELECT 1 INTERSECT SELECT 2`
+7. Chained: `SELECT 1 UNION SELECT 2 UNION SELECT 3` — left-associative
+8. `(SELECT 1) UNION (SELECT 2)` — parenthesized
+9. With CTE: `WITH cte AS (SELECT 1) SELECT * FROM cte UNION SELECT 2`
+
+## Acceptance Criteria
+
+1. Build/vet/gofmt/test all clean
+2. `Parse("SELECT 1 UNION ALL SELECT 2;")` returns *SetOperationStmt
+3. MINUS maps to SetOpExcept
+4. Walker regen correct

--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -60,6 +60,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *SelectStmt:
 		return v.Loc
+	case *SetOperationStmt:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -47,6 +47,7 @@ const (
 	T_SubqueryExpr
 	T_ExistsExpr
 	T_SelectStmt
+	T_SetOperationStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -104,6 +105,8 @@ func (t NodeTag) String() string {
 		return "ExistsExpr"
 	case T_SelectStmt:
 		return "SelectStmt"
+	case T_SetOperationStmt:
+		return "SetOperationStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -784,3 +784,37 @@ type FetchClause struct {
 	Count Node // the count expression
 	Loc   Loc
 }
+
+// ---------------------------------------------------------------------------
+// Set operator node
+// ---------------------------------------------------------------------------
+
+// SetOp enumerates the set operator kinds.
+type SetOp int
+
+const (
+	SetOpUnion     SetOp = iota // UNION
+	SetOpExcept                 // EXCEPT (also MINUS)
+	SetOpIntersect              // INTERSECT
+)
+
+// SetOperationStmt represents a set-operation query:
+// UNION [ALL] [BY NAME] / EXCEPT / INTERSECT between two query expressions.
+//
+// Left and Right are either *SelectStmt (leaf) or nested *SetOperationStmt
+// (chained). The chain is left-associative:
+//
+//	SELECT 1 UNION SELECT 2 UNION SELECT 3
+//	→ SetOperationStmt{Left: SetOperationStmt{Left: S1, Right: S2}, Right: S3}
+type SetOperationStmt struct {
+	Op     SetOp // the operator kind
+	All    bool  // true for UNION ALL
+	ByName bool  // true for UNION [ALL] BY NAME (Snowflake-specific)
+	Left   Node  // *SelectStmt or nested *SetOperationStmt
+	Right  Node  // *SelectStmt or nested *SetOperationStmt
+	Loc    Loc
+}
+
+func (n *SetOperationStmt) Tag() NodeTag { return T_SetOperationStmt }
+
+var _ Node = (*SetOperationStmt)(nil)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -60,6 +60,9 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Qualify)
 		Walk(v, n.Limit)
 		Walk(v, n.Offset)
+	case *SetOperationStmt:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
 	case *StarExpr:
 		if n.Qualifier != nil {
 			Walk(v, n.Qualifier)

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -274,9 +274,9 @@ func (p *Parser) parsePrefixExpr() (ast.Node, error) {
 		var query ast.Node
 		var err error
 		if p.cur.Type == kwWITH {
-			query, err = p.parseWithSelect()
+			query, err = p.parseWithQueryExpr()
 		} else {
-			query, err = p.parseSelectStmt()
+			query, err = p.parseQueryExpr()
 		}
 		if err != nil {
 			return nil, err
@@ -600,14 +600,14 @@ func (p *Parser) parseParenExpr() (ast.Node, error) {
 	openTok := p.advance() // consume '('
 	startLoc := openTok.Loc.Start
 
-	// Subquery: (SELECT ...) or (WITH ... SELECT ...)
+	// Subquery: (SELECT ...) or (WITH ... SELECT ...), optionally with set ops
 	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
 		var query ast.Node
 		var err error
 		if p.cur.Type == kwWITH {
-			query, err = p.parseWithSelect()
+			query, err = p.parseWithQueryExpr()
 		} else {
-			query, err = p.parseSelectStmt()
+			query, err = p.parseQueryExpr()
 		}
 		if err != nil {
 			return nil, err
@@ -1009,14 +1009,14 @@ func (p *Parser) parseInExpr(left ast.Node) (ast.Node, error) {
 		return nil, err
 	}
 
-	// Subquery: IN (SELECT ...) or IN (WITH ... SELECT ...)
+	// Subquery: IN (SELECT ...) or IN (WITH ... SELECT ...), optionally with set ops
 	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
 		var query ast.Node
 		var err error
 		if p.cur.Type == kwWITH {
-			query, err = p.parseWithSelect()
+			query, err = p.parseWithQueryExpr()
 		} else {
-			query, err = p.parseSelectStmt()
+			query, err = p.parseQueryExpr()
 		}
 		if err != nil {
 			return nil, err

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -197,9 +197,13 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// DML (12 cases)
 	case kwSELECT:
-		return p.parseSelectStmt()
+		return p.parseQueryExpr()
+	case '(':
+		// Parenthesized query expression at top level, e.g. (SELECT 1) UNION (SELECT 2).
+		// Delegate to parseQueryExpr which handles the leading '('.
+		return p.parseQueryExpr()
 	case kwWITH:
-		return p.parseWithSelect()
+		return p.parseWithQueryExpr()
 	case kwINSERT:
 		return p.unsupported("INSERT")
 	case kwUPDATE:

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -10,6 +10,124 @@ import (
 // SELECT statement parser
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Query-expression wrappers (SELECT + optional set operators)
+// ---------------------------------------------------------------------------
+
+// parseQueryExpr parses a SELECT statement optionally followed by set
+// operators (UNION/EXCEPT/MINUS/INTERSECT). Returns either a bare
+// *SelectStmt or a *SetOperationStmt wrapping chained SELECTs.
+//
+// Also handles the case where the query starts with ( SELECT ... ), i.e.
+// a parenthesized SELECT as the leftmost operand in a set-op chain.
+func (p *Parser) parseQueryExpr() (ast.Node, error) {
+	var left ast.Node
+	var err error
+	if p.cur.Type == '(' {
+		// Parenthesized SELECT: consume '(', parse inner query, then ')'
+		p.advance() // consume '('
+		left, err = p.parseQueryExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err = p.expect(')'); err != nil {
+			return nil, err
+		}
+	} else {
+		left, err = p.parseSelectStmt()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return p.parseSetOpChain(left)
+}
+
+// parseWithQueryExpr parses WITH ... SELECT ... [set operators].
+func (p *Parser) parseWithQueryExpr() (ast.Node, error) {
+	node, err := p.parseWithSelect()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseSetOpChain(node)
+}
+
+// parseSetOpChain checks for UNION/EXCEPT/MINUS/INTERSECT after a SELECT
+// and builds a left-associative SetOperationStmt chain.
+func (p *Parser) parseSetOpChain(left ast.Node) (ast.Node, error) {
+	for {
+		op, all, byName, ok := p.tryParseSetOp()
+		if !ok {
+			break
+		}
+		// The right side may be parenthesized: (SELECT ...)
+		var right ast.Node
+		var err error
+		if p.cur.Type == '(' {
+			p.advance() // consume '('
+			right, err = p.parseQueryExpr()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return nil, err
+			}
+		} else {
+			right, err = p.parseSelectStmt()
+			if err != nil {
+				return nil, err
+			}
+		}
+		left = &ast.SetOperationStmt{
+			Op:     op,
+			All:    all,
+			ByName: byName,
+			Left:   left,
+			Right:  right,
+			Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(right).End},
+		}
+	}
+	return left, nil
+}
+
+// tryParseSetOp checks if the current token starts a set operator.
+// Returns (op, all, byName, ok). Consumes the operator tokens on match.
+func (p *Parser) tryParseSetOp() (ast.SetOp, bool, bool, bool) {
+	switch p.cur.Type {
+	case kwUNION:
+		p.advance() // consume UNION
+		all := false
+		byName := false
+		if p.cur.Type == kwALL {
+			all = true
+			p.advance() // consume ALL
+		}
+		// UNION [ALL] BY NAME — Snowflake-specific
+		if p.cur.Type == kwBY {
+			next := p.peekNext()
+			if next.Type == kwNAME {
+				p.advance() // consume BY
+				p.advance() // consume NAME
+				byName = true
+			}
+		}
+		return ast.SetOpUnion, all, byName, true
+	case kwEXCEPT:
+		p.advance() // consume EXCEPT
+		return ast.SetOpExcept, false, false, true
+	case kwMINUS:
+		p.advance() // consume MINUS (alias for EXCEPT in Snowflake)
+		return ast.SetOpExcept, false, false, true
+	case kwINTERSECT:
+		p.advance() // consume INTERSECT
+		return ast.SetOpIntersect, false, false, true
+	}
+	return 0, false, false, false
+}
+
+// ---------------------------------------------------------------------------
+// SELECT statement parser
+// ---------------------------------------------------------------------------
+
 // parseSelectStmt parses a SELECT statement:
 //
 //	SELECT [DISTINCT|ALL] [TOP n] target_list
@@ -232,12 +350,12 @@ func (p *Parser) parseCTE(recursive bool) (*ast.CTE, error) {
 		return nil, err
 	}
 
-	// The CTE body can be WITH ... SELECT or just SELECT
+	// The CTE body can be WITH ... SELECT [set ops] or just SELECT [set ops]
 	var query ast.Node
 	if p.cur.Type == kwWITH {
-		query, err = p.parseWithSelect()
+		query, err = p.parseWithQueryExpr()
 	} else {
-		query, err = p.parseSelectStmt()
+		query, err = p.parseQueryExpr()
 	}
 	if err != nil {
 		return nil, err

--- a/snowflake/parser/select_test.go
+++ b/snowflake/parser/select_test.go
@@ -1021,3 +1021,181 @@ func TestSelect_WithSubqueryInCTE(t *testing.T) {
 		t.Fatalf("expected SubqueryExpr, got %T", sel.Targets[0].Expr)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// T1.7 Set operator tests
+// ---------------------------------------------------------------------------
+
+// testParseSetOp is a helper that parses input and returns the first statement
+// as *ast.SetOperationStmt plus any errors.
+func testParseSetOp(input string) (*ast.SetOperationStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	node, ok := result.File.Stmts[0].(*ast.SetOperationStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a SetOperationStmt"})
+	}
+	return node, result.Errors
+}
+
+// TestSetOp_Union verifies UNION parsing.
+func TestSetOp_Union(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 UNION SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpUnion {
+		t.Errorf("Op = %v, want SetOpUnion", node.Op)
+	}
+	if node.All {
+		t.Error("All should be false")
+	}
+	if node.ByName {
+		t.Error("ByName should be false")
+	}
+	if _, ok := node.Left.(*ast.SelectStmt); !ok {
+		t.Errorf("Left: expected *SelectStmt, got %T", node.Left)
+	}
+	if _, ok := node.Right.(*ast.SelectStmt); !ok {
+		t.Errorf("Right: expected *SelectStmt, got %T", node.Right)
+	}
+}
+
+// TestSetOp_UnionAll verifies UNION ALL parsing.
+func TestSetOp_UnionAll(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 UNION ALL SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpUnion {
+		t.Errorf("Op = %v, want SetOpUnion", node.Op)
+	}
+	if !node.All {
+		t.Error("All should be true")
+	}
+	if node.ByName {
+		t.Error("ByName should be false")
+	}
+}
+
+// TestSetOp_UnionAllByName verifies UNION ALL BY NAME parsing.
+func TestSetOp_UnionAllByName(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 UNION ALL BY NAME SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpUnion {
+		t.Errorf("Op = %v, want SetOpUnion", node.Op)
+	}
+	if !node.All {
+		t.Error("All should be true")
+	}
+	if !node.ByName {
+		t.Error("ByName should be true")
+	}
+}
+
+// TestSetOp_Except verifies EXCEPT parsing.
+func TestSetOp_Except(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 EXCEPT SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpExcept {
+		t.Errorf("Op = %v, want SetOpExcept", node.Op)
+	}
+}
+
+// TestSetOp_Minus verifies MINUS is treated as EXCEPT.
+func TestSetOp_Minus(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 MINUS SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpExcept {
+		t.Errorf("Op = %v, want SetOpExcept (MINUS maps to EXCEPT)", node.Op)
+	}
+}
+
+// TestSetOp_Intersect verifies INTERSECT parsing.
+func TestSetOp_Intersect(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 INTERSECT SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpIntersect {
+		t.Errorf("Op = %v, want SetOpIntersect", node.Op)
+	}
+}
+
+// TestSetOp_Chained verifies left-associative chaining:
+// SELECT 1 UNION SELECT 2 UNION SELECT 3
+// → SetOperationStmt{Left: SetOperationStmt{...}, Right: SelectStmt}
+func TestSetOp_Chained(t *testing.T) {
+	node, errs := testParseSetOp("SELECT 1 UNION SELECT 2 UNION SELECT 3")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpUnion {
+		t.Errorf("outer Op = %v, want SetOpUnion", node.Op)
+	}
+	inner, ok := node.Left.(*ast.SetOperationStmt)
+	if !ok {
+		t.Fatalf("Left: expected *SetOperationStmt (left-assoc), got %T", node.Left)
+	}
+	if inner.Op != ast.SetOpUnion {
+		t.Errorf("inner Op = %v, want SetOpUnion", inner.Op)
+	}
+	if _, ok := inner.Left.(*ast.SelectStmt); !ok {
+		t.Errorf("inner.Left: expected *SelectStmt, got %T", inner.Left)
+	}
+	if _, ok := inner.Right.(*ast.SelectStmt); !ok {
+		t.Errorf("inner.Right: expected *SelectStmt, got %T", inner.Right)
+	}
+	if _, ok := node.Right.(*ast.SelectStmt); !ok {
+		t.Errorf("outer Right: expected *SelectStmt, got %T", node.Right)
+	}
+}
+
+// TestSetOp_Parenthesized verifies (SELECT 1) UNION (SELECT 2).
+func TestSetOp_Parenthesized(t *testing.T) {
+	node, errs := testParseSetOp("(SELECT 1) UNION (SELECT 2)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if node.Op != ast.SetOpUnion {
+		t.Errorf("Op = %v, want SetOpUnion", node.Op)
+	}
+}
+
+// TestSetOp_WithCTE verifies WITH cte AS (SELECT 1) SELECT * FROM cte UNION SELECT 2.
+func TestSetOp_WithCTE(t *testing.T) {
+	input := "WITH cte AS (SELECT 1) SELECT * FROM cte UNION SELECT 2"
+	result := ParseBestEffort(input)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected at least one statement")
+	}
+	node, ok := result.File.Stmts[0].(*ast.SetOperationStmt)
+	if !ok {
+		t.Fatalf("expected *SetOperationStmt, got %T", result.File.Stmts[0])
+	}
+	if node.Op != ast.SetOpUnion {
+		t.Errorf("Op = %v, want SetOpUnion", node.Op)
+	}
+	// Left side should be a SelectStmt (with With CTE attached).
+	leftSel, ok := node.Left.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Left: expected *SelectStmt, got %T", node.Left)
+	}
+	if len(leftSel.With) != 1 {
+		t.Errorf("With = %d, want 1 CTE", len(leftSel.With))
+	}
+	if _, ok := node.Right.(*ast.SelectStmt); !ok {
+		t.Errorf("Right: expected *SelectStmt, got %T", node.Right)
+	}
+}


### PR DESCRIPTION
## Summary

Seventh Tier 1 node. Adds set operator chaining for SELECT statements: UNION [ALL] [BY NAME], EXCEPT, MINUS, INTERSECT. 355 insertions across 8 files.

Depends on T1.4 SELECT core (PR #48). Unblocks T1.8 (statement classification) and Tier 2+ nodes.

- **SetOperationStmt** Node wraps chained SelectStmts (Left/Right tree)
- **SetOp** enum: Union, Except, Intersect (MINUS maps to Except)
- **UNION ALL BY NAME** — Snowflake-specific column-name matching
- **parseQueryExpr** wrapper around parseSelectStmt + left-associative chain
- Subquery expressions also updated to support set ops inside parens
- 9 new tests: UNION/UNION ALL/UNION ALL BY NAME/EXCEPT/MINUS/INTERSECT/chained/parenthesized/WITH CTE

🤖 Generated with [Claude Code](https://claude.com/claude-code)