### PR TITLE
feat(doris): identifier parsing + normalization helpers (T1.1)

### DIFF
--- a/doris/parser/identifiers.go
+++ b/doris/parser/identifiers.go
@@ -1,0 +1,162 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// isIdentifierToken reports whether kind can form a standalone identifier in
+// the first position of a qualified name (i.e., without dot context):
+//   - tokIdent: unquoted identifier (e.g. myTable)
+//   - tokQuotedIdent: backtick-quoted identifier (e.g. `my table`)
+//   - a non-reserved keyword (e.g. COMMENT, BUCKETS) used as an identifier
+func isIdentifierToken(kind TokenKind) bool {
+	switch kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		// A keyword token that is not reserved can serve as an identifier.
+		if kind >= 700 && !IsReserved(kind) {
+			return true
+		}
+		return false
+	}
+}
+
+// isIdentifierTokenQualified reports whether kind is a valid identifier in a
+// qualified (dot-following) position. After a '.', ALL keyword tokens —
+// including reserved ones — are valid identifier parts because the context is
+// syntactically unambiguous (e.g., db.table, catalog.select.foo).
+func isIdentifierTokenQualified(kind TokenKind) bool {
+	switch kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		// Any keyword token (reserved or not) is valid after a dot.
+		return kind >= 700
+	}
+}
+
+// parseIdentifier parses a single identifier token and returns its string
+// value and source location. Accepted tokens are:
+//   - tokIdent: unquoted identifier
+//   - tokQuotedIdent: backtick-quoted identifier (lexer has already stripped backticks)
+//   - a non-reserved keyword used as an identifier
+//
+// Returns a syntax error if the current token is not a valid identifier.
+func (p *Parser) parseIdentifier() (string, ast.Loc, error) {
+	tok := p.cur
+	switch tok.Kind {
+	case tokIdent, tokQuotedIdent:
+		p.advance()
+		return tok.Str, tok.Loc, nil
+	default:
+		// Non-reserved keywords may be used as identifiers.
+		if tok.Kind >= 700 && !IsReserved(tok.Kind) {
+			p.advance()
+			return tok.Str, tok.Loc, nil
+		}
+		return "", ast.Loc{}, p.syntaxErrorAtCur()
+	}
+}
+
+// parseIdentifierQualified parses a single identifier token in a qualified
+// (post-dot) position. In this context ALL keyword tokens are accepted as
+// identifier parts because the syntax is unambiguous.
+func (p *Parser) parseIdentifierQualified() (string, ast.Loc, error) {
+	tok := p.cur
+	switch tok.Kind {
+	case tokIdent, tokQuotedIdent:
+		p.advance()
+		return tok.Str, tok.Loc, nil
+	default:
+		// After a '.', any keyword (reserved or not) is a valid identifier part.
+		if tok.Kind >= 700 {
+			p.advance()
+			return tok.Str, tok.Loc, nil
+		}
+		return "", ast.Loc{}, p.syntaxErrorAtCur()
+	}
+}
+
+// parseMultipartIdentifier parses a dot-separated qualified name:
+//
+//	identifier ('.' identifier)*
+//
+// Returns an *ast.ObjectName with Parts populated. The Loc on the returned
+// node spans from the start of the first identifier to the end of the last.
+//
+// In the first position only non-reserved keywords are accepted as identifiers.
+// In subsequent positions (after '.') all keywords are accepted because the
+// dot context makes the parse unambiguous (e.g., db.select is valid).
+func (p *Parser) parseMultipartIdentifier() (*ast.ObjectName, error) {
+	first, loc, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	name := &ast.ObjectName{
+		Parts: []string{first},
+		Loc:   loc,
+	}
+
+	// Consume additional '.identifier' segments.
+	for p.cur.Kind == int('.') {
+		// Peek past the dot to make sure we have an identifier; if not, stop
+		// here rather than consuming the dot and getting a confusing error.
+		// Note: peekNext looks at the token after cur (the '.').
+		next := p.peekNext()
+		if !isIdentifierTokenQualified(next.Kind) {
+			break
+		}
+
+		p.advance() // consume '.'
+
+		part, partLoc, err := p.parseIdentifierQualified()
+		if err != nil {
+			return nil, err
+		}
+		name.Parts = append(name.Parts, part)
+		name.Loc.End = partLoc.End
+	}
+
+	return name, nil
+}
+
+// parseIdentifierOrString parses either an identifier or a string literal.
+// Some Doris syntax allows either form in certain positions (e.g. catalog/db
+// names in certain DDL contexts). Returns the string value and its location.
+func (p *Parser) parseIdentifierOrString() (string, ast.Loc, error) {
+	if p.cur.Kind == tokString {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
+	return p.parseIdentifier()
+}
+
+// NormalizeIdentifier returns the canonical form of a Doris identifier.
+// Doris is case-insensitive for unquoted identifiers, so unquoted identifiers
+// are lowercased. Backtick-quoted identifiers preserve their original case
+// (the lexer strips backticks and stores the raw content in Str, so the
+// quoted flag drives the normalization decision).
+func NormalizeIdentifier(name string, quoted bool) string {
+	if quoted {
+		return name
+	}
+	return strings.ToLower(name)
+}
+
+// NormalizeObjectName returns a normalized dot-joined representation of an
+// ObjectName. Each part is lowercased to match Doris case-insensitive
+// identifier comparison semantics. Useful for lookups and equality checks.
+func NormalizeObjectName(name *ast.ObjectName) string {
+	if name == nil {
+		return ""
+	}
+	parts := make([]string, len(name.Parts))
+	for i, p := range name.Parts {
+		parts[i] = strings.ToLower(p)
+	}
+	return strings.Join(parts, ".")
+}

--- a/doris/parser/identifiers_test.go
+++ b/doris/parser/identifiers_test.go
@@ -1,0 +1,345 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// makeParser creates a Parser primed on the given input, ready to parse.
+func makeParser(input string) *Parser {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance() // prime cur
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// parseIdentifier
+// ---------------------------------------------------------------------------
+
+func TestParseIdentifier_Unquoted(t *testing.T) {
+	p := makeParser("myTable")
+	name, loc, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "myTable" {
+		t.Errorf("got %q, want %q", name, "myTable")
+	}
+	if loc.Start != 0 || loc.End != 7 {
+		t.Errorf("loc = %v, want {0,7}", loc)
+	}
+	// parser should now be at EOF
+	if p.cur.Kind != tokEOF {
+		t.Errorf("cur after parse = %d, want EOF", p.cur.Kind)
+	}
+}
+
+func TestParseIdentifier_BacktickQuoted(t *testing.T) {
+	p := makeParser("`my table`")
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// lexer strips backticks, so we get the raw content
+	if name != "my table" {
+		t.Errorf("got %q, want %q", name, "my table")
+	}
+}
+
+func TestParseIdentifier_BacktickPreservesCase(t *testing.T) {
+	p := makeParser("`MyMixedCase`")
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "MyMixedCase" {
+		t.Errorf("got %q, want %q", name, "MyMixedCase")
+	}
+}
+
+func TestParseIdentifier_NonReservedKeyword(t *testing.T) {
+	// COMMENT is non-reserved in Doris and should parse as identifier.
+	p := makeParser("comment")
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "comment" {
+		t.Errorf("got %q, want %q", name, "comment")
+	}
+}
+
+func TestParseIdentifier_ReservedKeywordFails(t *testing.T) {
+	// SELECT is reserved and must not parse as an identifier.
+	p := makeParser("select")
+	_, _, err := p.parseIdentifier()
+	if err == nil {
+		t.Fatal("expected error for reserved keyword SELECT, got nil")
+	}
+}
+
+func TestParseIdentifier_EOF_Fails(t *testing.T) {
+	p := makeParser("")
+	_, _, err := p.parseIdentifier()
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseMultipartIdentifier
+// ---------------------------------------------------------------------------
+
+func TestParseMultipartIdentifier_Single(t *testing.T) {
+	p := makeParser("myTable")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(name.Parts) != 1 {
+		t.Fatalf("got %d parts, want 1", len(name.Parts))
+	}
+	if name.Parts[0] != "myTable" {
+		t.Errorf("Parts[0] = %q, want %q", name.Parts[0], "myTable")
+	}
+}
+
+func TestParseMultipartIdentifier_TwoPart(t *testing.T) {
+	p := makeParser("db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"db", "table"}
+	if len(name.Parts) != len(want) {
+		t.Fatalf("got %d parts, want %d: %v", len(name.Parts), len(want), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_ThreePart(t *testing.T) {
+	p := makeParser("catalog.db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"catalog", "db", "table"}
+	if len(name.Parts) != 3 {
+		t.Fatalf("got %d parts, want 3: %v", len(name.Parts), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_QuotedSingle(t *testing.T) {
+	p := makeParser("`my table`")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(name.Parts) != 1 || name.Parts[0] != "my table" {
+		t.Errorf("got Parts=%v, want [\"my table\"]", name.Parts)
+	}
+}
+
+func TestParseMultipartIdentifier_MixedQuoted(t *testing.T) {
+	// db.`my table`
+	p := makeParser("db.`my table`")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"db", "my table"}
+	if len(name.Parts) != 2 {
+		t.Fatalf("got %d parts, want 2: %v", len(name.Parts), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_NonReservedKeyword(t *testing.T) {
+	// COMMENT is non-reserved and valid as a table name.
+	p := makeParser("db.comment")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"db", "comment"}
+	if len(name.Parts) != 2 {
+		t.Fatalf("got %d parts, want 2: %v", len(name.Parts), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_DotNotFollowedByIdent(t *testing.T) {
+	// "mytable.(" — the '.' is followed by '(' which is not an identifier,
+	// so we stop at the first part and leave '.(' for the caller.
+	// (Note: "mytable.123" would not work because the lexer folds ".123" into
+	// a tokFloat when it immediately follows an identifier.)
+	p := makeParser("mytable.(")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(name.Parts) != 1 || name.Parts[0] != "mytable" {
+		t.Errorf("got Parts=%v, want [\"mytable\"]", name.Parts)
+	}
+	// The '.' should still be in the stream.
+	if p.cur.Kind != int('.') {
+		t.Errorf("cur after partial parse = %d, want '.'", p.cur.Kind)
+	}
+}
+
+func TestParseMultipartIdentifier_ReservedKeywordFails(t *testing.T) {
+	// SELECT is reserved — parsing it as an identifier must fail.
+	p := makeParser("select")
+	_, err := p.parseMultipartIdentifier()
+	if err == nil {
+		t.Fatal("expected error for reserved keyword SELECT, got nil")
+	}
+}
+
+func TestParseMultipartIdentifier_LocSpan(t *testing.T) {
+	// "db.table": start=0, end=8
+	p := makeParser("db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", name.Loc.Start)
+	}
+	if name.Loc.End != 8 {
+		t.Errorf("Loc.End = %d, want 8", name.Loc.End)
+	}
+}
+
+func TestParseMultipartIdentifier_String(t *testing.T) {
+	p := makeParser("catalog.db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name.String() != "catalog.db.table" {
+		t.Errorf("String() = %q, want %q", name.String(), "catalog.db.table")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseIdentifierOrString
+// ---------------------------------------------------------------------------
+
+func TestParseIdentifierOrString_Identifier(t *testing.T) {
+	p := makeParser("mydb")
+	val, _, err := p.parseIdentifierOrString()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "mydb" {
+		t.Errorf("got %q, want %q", val, "mydb")
+	}
+}
+
+func TestParseIdentifierOrString_StringLiteral(t *testing.T) {
+	p := makeParser("'mydb'")
+	val, _, err := p.parseIdentifierOrString()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "mydb" {
+		t.Errorf("got %q, want %q", val, "mydb")
+	}
+}
+
+func TestParseIdentifierOrString_DoubleQuotedString(t *testing.T) {
+	p := makeParser(`"mydb"`)
+	val, _, err := p.parseIdentifierOrString()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "mydb" {
+		t.Errorf("got %q, want %q", val, "mydb")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NormalizeIdentifier
+// ---------------------------------------------------------------------------
+
+func TestNormalizeIdentifier_UnquotedLowercases(t *testing.T) {
+	got := NormalizeIdentifier("MyTable", false)
+	if got != "mytable" {
+		t.Errorf("NormalizeIdentifier(%q, false) = %q, want %q", "MyTable", got, "mytable")
+	}
+}
+
+func TestNormalizeIdentifier_QuotedPreservesCase(t *testing.T) {
+	got := NormalizeIdentifier("MyTable", true)
+	if got != "MyTable" {
+		t.Errorf("NormalizeIdentifier(%q, true) = %q, want %q", "MyTable", got, "MyTable")
+	}
+}
+
+func TestNormalizeIdentifier_AlreadyLower(t *testing.T) {
+	got := NormalizeIdentifier("mytable", false)
+	if got != "mytable" {
+		t.Errorf("NormalizeIdentifier(%q, false) = %q, want %q", "mytable", got, "mytable")
+	}
+}
+
+func TestNormalizeIdentifier_AllUpper(t *testing.T) {
+	got := NormalizeIdentifier("MYTABLE", false)
+	if got != "mytable" {
+		t.Errorf("NormalizeIdentifier(%q, false) = %q, want %q", "MYTABLE", got, "mytable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NormalizeObjectName
+// ---------------------------------------------------------------------------
+
+func TestNormalizeObjectName_SinglePart(t *testing.T) {
+	name := &ast.ObjectName{Parts: []string{"MyTable"}}
+	got := NormalizeObjectName(name)
+	if got != "mytable" {
+		t.Errorf("NormalizeObjectName = %q, want %q", got, "mytable")
+	}
+}
+
+func TestNormalizeObjectName_MultiPart(t *testing.T) {
+	name := &ast.ObjectName{Parts: []string{"MyCatalog", "MyDB", "MyTable"}}
+	got := NormalizeObjectName(name)
+	if got != "mycatalog.mydb.mytable" {
+		t.Errorf("NormalizeObjectName = %q, want %q", got, "mycatalog.mydb.mytable")
+	}
+}
+
+func TestNormalizeObjectName_Nil(t *testing.T) {
+	got := NormalizeObjectName(nil)
+	if got != "" {
+		t.Errorf("NormalizeObjectName(nil) = %q, want %q", got, "")
+	}
+}
+
+func TestNormalizeObjectName_AlreadyLower(t *testing.T) {
+	name := &ast.ObjectName{Parts: []string{"catalog", "db", "table"}}
+	got := NormalizeObjectName(name)
+	if got != "catalog.db.table" {
+		t.Errorf("NormalizeObjectName = %q, want %q", got, "catalog.db.table")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `parseMultipartIdentifier`, `parseIdentifier`, `parseIdentifierOrString` to Parser
- Non-reserved keywords accepted as identifiers; after `.` all keywords accepted (dot context)
- `NormalizeIdentifier` and `NormalizeObjectName` helpers for case-insensitive comparison
- 26 unit tests

DAG node: T1.1 from `docs/migration/doris/dag.md`

## Test plan
- [x] 26 new tests pass (`go test ./doris/parser/...`)
- [x] `go build ./doris/...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)