### PR TITLE
feat(doris): statement classification helper (T1.8)

### DIFF
--- a/doris/analysis/classify.go
+++ b/doris/analysis/classify.go
@@ -1,0 +1,132 @@
+package analysis
+
+import (
+	"github.com/bytebase/omni/doris/parser"
+)
+
+// QueryType classifies a SQL statement.
+type QueryType int
+
+const (
+	QueryTypeUnknown         QueryType = iota
+	QueryTypeSelect                    // User SELECT query
+	QueryTypeSelectInfoSchema          // SELECT from system tables, or SHOW/DESCRIBE
+	QueryTypeDML                       // INSERT, UPDATE, DELETE, MERGE, LOAD, EXPORT, TRUNCATE, COPY
+	QueryTypeDDL                       // CREATE, ALTER, DROP, plus GRANT, REVOKE, ADMIN, transaction control, KILL, SET, etc.
+)
+
+// String returns a human-readable name for the QueryType.
+func (q QueryType) String() string {
+	switch q {
+	case QueryTypeSelect:
+		return "SELECT"
+	case QueryTypeSelectInfoSchema:
+		return "SELECT_INFO_SCHEMA"
+	case QueryTypeDML:
+		return "DML"
+	case QueryTypeDDL:
+		return "DDL"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// firstKeywordType maps a leading keyword TokenKind to its QueryType.
+// Populated in init() using parser.KeywordToken so we don't depend on the
+// numeric values of the unexported kw* constants.
+var firstKeywordType map[parser.TokenKind]QueryType
+
+func init() {
+	firstKeywordType = make(map[parser.TokenKind]QueryType)
+
+	register := func(qt QueryType, names ...string) {
+		for _, name := range names {
+			kind, ok := parser.KeywordToken(name)
+			if !ok {
+				panic("doris/analysis: unknown keyword: " + name)
+			}
+			firstKeywordType[kind] = qt
+		}
+	}
+
+	// User SELECT queries (may be refined by downstream analysis for CTEs).
+	register(QueryTypeSelect,
+		"SELECT",
+		"WITH",
+	)
+
+	// Administrative / info-schema reads.
+	register(QueryTypeSelectInfoSchema,
+		"SHOW",
+		"DESCRIBE",
+		"DESC",
+		"HELP",
+		"EXPLAIN",
+	)
+
+	// Data manipulation language.
+	register(QueryTypeDML,
+		"INSERT",
+		"UPDATE",
+		"DELETE",
+		"MERGE",
+		"LOAD",
+		"EXPORT",
+		"TRUNCATE",
+		"COPY",
+	)
+
+	// Data definition language and session / administrative control.
+	register(QueryTypeDDL,
+		"CREATE",
+		"ALTER",
+		"DROP",
+		"GRANT",
+		"REVOKE",
+		"ADMIN",
+		"BEGIN",
+		"COMMIT",
+		"ROLLBACK",
+		"KILL",
+		"SET",
+		"UNSET",
+		"REFRESH",
+		"CANCEL",
+		"RECOVER",
+		"CLEAN",
+		"ANALYZE",
+		"SYNC",
+		"INSTALL",
+		"UNINSTALL",
+		"BACKUP",
+		"RESTORE",
+		"LOCK",
+		"UNLOCK",
+		"USE",
+		"WARM",
+		"PAUSE",
+		"RESUME",
+	)
+}
+
+// tokEOF is the zero value returned by the lexer at end-of-input.
+// Matches the unexported parser.tokEOF = 0.
+const tokEOF parser.TokenKind = 0
+
+// Classify determines the QueryType for a SQL statement by lexing the first
+// meaningful token. It does NOT fully parse the statement.
+//
+// Whitespace and comments are skipped automatically by the lexer. The
+// function returns QueryTypeUnknown for empty input or unrecognised leading
+// tokens.
+func Classify(statement string) QueryType {
+	l := parser.NewLexer(statement)
+	tok := l.NextToken()
+	if tok.Kind == tokEOF {
+		return QueryTypeUnknown
+	}
+	if qt, ok := firstKeywordType[tok.Kind]; ok {
+		return qt
+	}
+	return QueryTypeUnknown
+}

--- a/doris/analysis/classify_test.go
+++ b/doris/analysis/classify_test.go
@@ -1,0 +1,121 @@
+package analysis
+
+import (
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  QueryType
+	}{
+		// SELECT / WITH
+		{"SELECT 1", QueryTypeSelect},
+		{"select * from t", QueryTypeSelect},
+		{"WITH cte AS (SELECT 1) SELECT * FROM cte", QueryTypeSelect},
+		{"with cte as (select 1) select * from cte", QueryTypeSelect},
+
+		// Info-schema / admin reads
+		{"SHOW TABLES", QueryTypeSelectInfoSchema},
+		{"show databases", QueryTypeSelectInfoSchema},
+		{"DESCRIBE t", QueryTypeSelectInfoSchema},
+		{"describe my_table", QueryTypeSelectInfoSchema},
+		{"DESC t", QueryTypeSelectInfoSchema},
+		{"desc my_table", QueryTypeSelectInfoSchema},
+		{"EXPLAIN SELECT 1", QueryTypeSelectInfoSchema},
+		{"explain select * from t", QueryTypeSelectInfoSchema},
+		{"HELP", QueryTypeSelectInfoSchema},
+		{"help topics", QueryTypeSelectInfoSchema},
+
+		// DML
+		{"INSERT INTO t VALUES (1)", QueryTypeDML},
+		{"insert into t values (1)", QueryTypeDML},
+		{"UPDATE t SET c=1", QueryTypeDML},
+		{"update t set c=1 where id=2", QueryTypeDML},
+		{"DELETE FROM t", QueryTypeDML},
+		{"delete from t where id=1", QueryTypeDML},
+		{"TRUNCATE TABLE t", QueryTypeDML},
+		{"truncate table t", QueryTypeDML},
+		{"MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE", QueryTypeDML},
+		{"LOAD DATA INFILE 'f' INTO TABLE t", QueryTypeDML},
+		{"EXPORT TABLE t TO 's3://bucket'", QueryTypeDML},
+		{"COPY INTO t FROM 's3://bucket'", QueryTypeDML},
+
+		// DDL / session control
+		{"CREATE TABLE t (id INT)", QueryTypeDDL},
+		{"create table t (id int)", QueryTypeDDL},
+		{"ALTER TABLE t ADD COLUMN c INT", QueryTypeDDL},
+		{"alter table t drop column c", QueryTypeDDL},
+		{"DROP TABLE t", QueryTypeDDL},
+		{"drop view v", QueryTypeDDL},
+		{"GRANT SELECT ON t TO u", QueryTypeDDL},
+		{"REVOKE INSERT ON t FROM u", QueryTypeDDL},
+		{"SET x = 1", QueryTypeDDL},
+		{"set names utf8", QueryTypeDDL},
+		{"UNSET x", QueryTypeDDL},
+		{"BEGIN", QueryTypeDDL},
+		{"BEGIN TRANSACTION", QueryTypeDDL},
+		{"COMMIT", QueryTypeDDL},
+		{"ROLLBACK", QueryTypeDDL},
+		{"USE db", QueryTypeDDL},
+		{"use mydb", QueryTypeDDL},
+		{"KILL 123", QueryTypeDDL},
+		{"ADMIN SET FRONTEND CONFIG ('key'='value')", QueryTypeDDL},
+		{"ANALYZE TABLE t", QueryTypeDDL},
+		{"REFRESH CATALOG my_catalog", QueryTypeDDL},
+		{"CANCEL LOAD FROM db WHERE LABEL = 'lbl'", QueryTypeDDL},
+		{"RECOVER TABLE t", QueryTypeDDL},
+		{"CLEAN LABEL 'lbl' FROM db", QueryTypeDDL},
+		{"BACKUP SNAPSHOT snap TO repo", QueryTypeDDL},
+		{"RESTORE SNAPSHOT snap FROM repo", QueryTypeDDL},
+		{"LOCK TABLES t READ", QueryTypeDDL},
+		{"UNLOCK TABLES", QueryTypeDDL},
+		{"INSTALL PLUGIN FROM '/path/plugin.so'", QueryTypeDDL},
+		{"UNINSTALL PLUGIN plugin_name", QueryTypeDDL},
+		{"SYNC", QueryTypeDDL},
+		{"PAUSE ROUTINE LOAD FOR job", QueryTypeDDL},
+		{"RESUME ROUTINE LOAD FOR job", QueryTypeDDL},
+		{"WARM UP CLUSTER c WITH TABLE t", QueryTypeDDL},
+
+		// Comment skipping
+		{"-- comment\nSELECT 1", QueryTypeSelect},
+		{"/* block comment */ SELECT 1", QueryTypeSelect},
+		{"# hash comment\nINSERT INTO t VALUES (1)", QueryTypeDML},
+		{"-- leading comment\nCREATE TABLE t (id INT)", QueryTypeDDL},
+
+		// Unknown / edge cases
+		{"", QueryTypeUnknown},
+		{"FOOBAR", QueryTypeUnknown},
+		{"42", QueryTypeUnknown},
+		{"(SELECT 1)", QueryTypeUnknown}, // leading '(' is not a keyword
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := Classify(tc.input)
+			if got != tc.want {
+				t.Errorf("Classify(%q) = %s, want %s", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQueryTypeString(t *testing.T) {
+	tests := []struct {
+		qt   QueryType
+		want string
+	}{
+		{QueryTypeUnknown, "UNKNOWN"},
+		{QueryTypeSelect, "SELECT"},
+		{QueryTypeSelectInfoSchema, "SELECT_INFO_SCHEMA"},
+		{QueryTypeDML, "DML"},
+		{QueryTypeDDL, "DDL"},
+		{QueryType(999), "UNKNOWN"},
+	}
+	for _, tc := range tests {
+		got := tc.qt.String()
+		if got != tc.want {
+			t.Errorf("QueryType(%d).String() = %q, want %q", int(tc.qt), got, tc.want)
+		}
+	}
+}

--- a/doris/analysis/doc.go
+++ b/doris/analysis/doc.go
@@ -1,0 +1,3 @@
+// Package analysis provides query analysis for Doris SQL — statement
+// classification, field extraction, and table access tracking.
+package analysis


### PR DESCRIPTION
## Summary
- Add `doris/analysis` package with `Classify()` function
- Categorizes SQL into QueryTypeSelect, QueryTypeSelectInfoSchema, QueryTypeDML, QueryTypeDDL
- Uses first token to classify (lexer-only, no parsing)
- 70 table-driven test cases

DAG node: T1.8 from `docs/migration/doris/dag.md`

## Test plan
- [x] 70 tests pass (`go test ./doris/analysis/...`)
- [x] `go build ./doris/...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)