### PR TITLE
feat(doris): syntax diagnostics for SQL editor (T3.2)

### DIFF
--- a/doris/parser/diagnose.go
+++ b/doris/parser/diagnose.go
@@ -1,0 +1,26 @@
+package parser
+
+import "github.com/bytebase/omni/doris/ast"
+
+// Diagnostic represents a syntax diagnostic (error or warning) with position.
+type Diagnostic struct {
+	Msg string
+	Loc ast.Loc
+}
+
+// Diagnose parses the input and returns any syntax errors as diagnostics.
+// It calls Parse internally; all ParseErrors (including lex errors promoted
+// during parseSingle) are converted to Diagnostics and returned.
+//
+// Note: while statement-level parsing is stubbed, valid SQL input produces
+// "not yet supported" diagnostics. Those disappear as Tier 1+ nodes implement
+// real parsing. Lexer errors (unterminated strings, unknown characters) are
+// always genuine diagnostics.
+func Diagnose(input string) []Diagnostic {
+	_, errs := Parse(input)
+	diags := make([]Diagnostic, len(errs))
+	for i, e := range errs {
+		diags[i] = Diagnostic{Msg: e.Msg, Loc: e.Loc}
+	}
+	return diags
+}

--- a/doris/parser/diagnose_test.go
+++ b/doris/parser/diagnose_test.go
@@ -1,0 +1,85 @@
+package parser
+
+import "testing"
+
+func TestDiagnoseCleanInput(t *testing.T) {
+	// Empty input should produce no diagnostics (no statements to parse).
+	diags := Diagnose("")
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics for empty input, got %d", len(diags))
+	}
+}
+
+func TestDiagnoseLexErrors(t *testing.T) {
+	// Unterminated string literal is a genuine lex error.
+	diags := Diagnose("SELECT 'unterminated")
+	found := false
+	for _, d := range diags {
+		if d.Msg == "unterminated string literal" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected unterminated string diagnostic")
+	}
+}
+
+func TestDiagnoseUnterminatedComment(t *testing.T) {
+	diags := Diagnose("SELECT /* unterminated")
+	found := false
+	for _, d := range diags {
+		if d.Msg == "unterminated block comment" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected unterminated comment diagnostic")
+	}
+}
+
+func TestDiagnoseMultiStatement(t *testing.T) {
+	// Multiple statements each produce their own "unsupported" diagnostics.
+	diags := Diagnose("SELECT 1; INSERT INTO t")
+	if len(diags) < 2 {
+		t.Errorf("expected at least 2 diagnostics, got %d", len(diags))
+	}
+}
+
+func TestDiagnosticPositions(t *testing.T) {
+	// The unterminated string starts at byte 7 (after "SELECT ").
+	diags := Diagnose("SELECT 'bad")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostics")
+	}
+	for _, d := range diags {
+		if d.Msg == "unterminated string literal" {
+			if d.Loc.Start != 7 {
+				t.Errorf("Loc.Start = %d, want 7", d.Loc.Start)
+			}
+			return
+		}
+	}
+	t.Error("unterminated string literal diagnostic not found")
+}
+
+func TestDiagnoseUnterminatedBacktickIdentifier(t *testing.T) {
+	// Unterminated backtick-quoted identifier is also a genuine lex error.
+	diags := Diagnose("SELECT `col")
+	found := false
+	for _, d := range diags {
+		if d.Msg == "unterminated backtick-quoted identifier" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected unterminated backtick-quoted identifier diagnostic")
+	}
+}
+
+func TestDiagnoseReturnsDiagnosticSlice(t *testing.T) {
+	// Diagnose on a supported-but-stubbed keyword returns a non-nil slice.
+	diags := Diagnose("SELECT 1")
+	if diags == nil {
+		t.Error("expected non-nil diagnostics slice")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Diagnose()` function returning `[]Diagnostic` with position info
- Delegates to `Parse()` which promotes lex errors (unterminated strings/comments) into diagnostics
- Currently also reports "not yet supported" for valid statements (disappears as T1.1+ nodes add real parsing)
- 7 unit tests

DAG node: T3.2 from `docs/migration/doris/dag.md`

## Test plan
- [x] 7 new tests pass (`go test ./doris/parser/...`)
- [x] `go build ./doris/...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)