### PR TITLE
feat(doris): data type parsing + INDEX DDL (T1.2+T2.5)

### DIFF
--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -14,6 +14,14 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *ObjectName:
 		return v.Loc
+	case *TypeName:
+		return v.Loc
+	case *CreateIndexStmt:
+		return v.Loc
+	case *DropIndexStmt:
+		return v.Loc
+	case *BuildIndexStmt:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -22,6 +22,19 @@ const (
 	// T_ObjectName is the tag for *ObjectName, a qualified multi-part name
 	// (e.g., catalog.db.table).
 	T_ObjectName
+
+	// T_TypeName is the tag for *TypeName, a Doris data type as it appears in
+	// SQL source (e.g., INT, VARCHAR(255), ARRAY<INT>, MAP<STRING,INT>).
+	T_TypeName
+
+	// T_CreateIndexStmt is the tag for *CreateIndexStmt.
+	T_CreateIndexStmt
+
+	// T_DropIndexStmt is the tag for *DropIndexStmt.
+	T_DropIndexStmt
+
+	// T_BuildIndexStmt is the tag for *BuildIndexStmt.
+	T_BuildIndexStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -33,6 +46,14 @@ func (t NodeTag) String() string {
 		return "File"
 	case T_ObjectName:
 		return "ObjectName"
+	case T_TypeName:
+		return "TypeName"
+	case T_CreateIndexStmt:
+		return "CreateIndexStmt"
+	case T_DropIndexStmt:
+		return "DropIndexStmt"
+	case T_BuildIndexStmt:
+		return "BuildIndexStmt"
 	default:
 		return "Unknown"
 	}

--- a/doris/ast/parsenodes.go
+++ b/doris/ast/parsenodes.go
@@ -2,6 +2,13 @@ package ast
 
 import "strings"
 
+// Property represents a key=value pair used in PROPERTIES(...) clauses.
+type Property struct {
+	Key   string
+	Value string
+	Loc   Loc
+}
+
 // This file holds the concrete Doris parse-tree node types. F1 ships only
 // the File root container and ObjectName; later migration nodes (T1.1+)
 // populate the rest.
@@ -51,3 +58,100 @@ var _ Node = (*ObjectName)(nil)
 func (n *ObjectName) String() string {
 	return strings.Join(n.Parts, ".")
 }
+
+// ---------------------------------------------------------------------------
+// Data type nodes
+// ---------------------------------------------------------------------------
+
+// TypeName represents a Doris data type as it appears in SQL source.
+//
+// Examples:
+//
+//	INT                         → Name="INT", Params=nil
+//	VARCHAR(255)                → Name="VARCHAR", Params=[255]
+//	DECIMAL(10,2)               → Name="DECIMAL", Params=[10,2]
+//	ARRAY<INT>                  → Name="ARRAY", ElementType=&TypeName{Name:"INT"}
+//	MAP<STRING,INT>             → Name="MAP", ElementType=&TypeName{Name:"STRING"}, ValueType=&TypeName{Name:"INT"}
+//	STRUCT<name VARCHAR(50)>    → Name="STRUCT", Fields=[{Name:"name", Type:...}]
+type TypeName struct {
+	Name        string         // source text of type name: "INT", "VARCHAR", "ARRAY", etc.
+	Params      []int          // numeric params like (10) or (10,2); nil if absent
+	ElementType *TypeName      // for ARRAY<T>: element type; for MAP<K,V>: key type
+	ValueType   *TypeName      // for MAP<K,V>: value type
+	Fields      []*StructField // for STRUCT<name type, ...>: field list
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *TypeName) Tag() NodeTag { return T_TypeName }
+
+// Compile-time assertion that *TypeName satisfies Node.
+var _ Node = (*TypeName)(nil)
+
+// StructField represents one named field in a STRUCT type: `name dataType`.
+type StructField struct {
+	Name string
+	Type *TypeName
+	Loc  Loc
+}
+
+// ---------------------------------------------------------------------------
+// Index DDL nodes (T2.5)
+// ---------------------------------------------------------------------------
+
+// CreateIndexStmt represents:
+//
+//	CREATE INDEX [IF NOT EXISTS] name ON table (col1, col2, ...)
+//	  [USING index_type]
+//	  [COMMENT 'comment']
+//	  [PROPERTIES("key"="value", ...)]
+//
+// index_type is one of: BITMAP, NGRAM_BF, INVERTED, ANN, or empty string.
+type CreateIndexStmt struct {
+	Name        *ObjectName
+	Table       *ObjectName
+	Columns     []string    // column names (bare, stripped of backticks)
+	IfNotExists bool
+	IndexType   string      // BITMAP, NGRAM_BF, INVERTED, ANN, or ""
+	Properties  []*Property // optional PROPERTIES(...)
+	Comment     string      // optional COMMENT 'text'
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateIndexStmt) Tag() NodeTag { return T_CreateIndexStmt }
+
+// Compile-time assertion that *CreateIndexStmt satisfies Node.
+var _ Node = (*CreateIndexStmt)(nil)
+
+// DropIndexStmt represents:
+//
+//	DROP INDEX [IF EXISTS] name ON table
+type DropIndexStmt struct {
+	Name     *ObjectName
+	Table    *ObjectName
+	IfExists bool
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *DropIndexStmt) Tag() NodeTag { return T_DropIndexStmt }
+
+// Compile-time assertion that *DropIndexStmt satisfies Node.
+var _ Node = (*DropIndexStmt)(nil)
+
+// BuildIndexStmt represents:
+//
+//	BUILD INDEX name ON table [PARTITIONS(p1, p2, ...)]
+type BuildIndexStmt struct {
+	Name       *ObjectName
+	Table      *ObjectName
+	Partitions []string // optional partition names
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *BuildIndexStmt) Tag() NodeTag { return T_BuildIndexStmt }
+
+// Compile-time assertion that *BuildIndexStmt satisfies Node.
+var _ Node = (*BuildIndexStmt)(nil)

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -9,5 +9,26 @@ func walkChildren(v Visitor, node Node) {
 		walkNodes(v, n.Stmts)
 	case *ObjectName:
 		// leaf node, no children
+	case *TypeName:
+		if n.ElementType != nil {
+			Walk(v, n.ElementType)
+		}
+		if n.ValueType != nil {
+			Walk(v, n.ValueType)
+		}
+		for _, f := range n.Fields {
+			if f.Type != nil {
+				Walk(v, f.Type)
+			}
+		}
+	case *CreateIndexStmt:
+		Walk(v, n.Name)
+		Walk(v, n.Table)
+	case *DropIndexStmt:
+		Walk(v, n.Name)
+		Walk(v, n.Table)
+	case *BuildIndexStmt:
+		Walk(v, n.Name)
+		Walk(v, n.Table)
 	}
 }

--- a/doris/parser/datatypes.go
+++ b/doris/parser/datatypes.go
@@ -1,0 +1,433 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// isPrimitiveTypeKeyword reports whether kind is a keyword that names a
+// primitive Doris column type (i.e., usable as a standalone type name without
+// angle-bracket parameters).
+func isPrimitiveTypeKeyword(kind TokenKind) bool {
+	switch kind {
+	// Integer types
+	case kwTINYINT, kwSMALLINT, kwINT, kwINTEGER, kwBIGINT, kwLARGEINT:
+		return true
+	// Float/decimal types
+	case kwFLOAT, kwDOUBLE, kwDECIMAL, kwDECIMALV2, kwDECIMALV3:
+		return true
+	// Boolean
+	case kwBOOLEAN:
+		return true
+	// String types
+	case kwSTRING, kwTEXT, kwVARCHAR, kwCHAR, kwVARBINARY:
+		return true
+	// Date/time types
+	case kwDATE, kwDATETIME, kwTIME, kwDATEV1, kwDATEV2, kwDATETIMEV1, kwDATETIMEV2:
+		return true
+	// Special Doris types
+	case kwBITMAP, kwHLL, kwQUANTILE_STATE, kwJSON, kwJSONB:
+		return true
+	case kwIPV4, kwIPV6, kwVARIANT, kwAGG_STATE:
+		return true
+	// ALL keyword can appear as a type name in some grammar positions
+	case kwALL:
+		return true
+	default:
+		return false
+	}
+}
+
+// typeKeywordName returns the canonical uppercase name for a type keyword.
+// Falls back to the token's Str field (which may be lowercase from the lexer)
+// uppercased.
+func typeKeywordName(tok Token) string {
+	switch tok.Kind {
+	case kwTINYINT:
+		return "TINYINT"
+	case kwSMALLINT:
+		return "SMALLINT"
+	case kwINT:
+		return "INT"
+	case kwINTEGER:
+		return "INTEGER"
+	case kwBIGINT:
+		return "BIGINT"
+	case kwLARGEINT:
+		return "LARGEINT"
+	case kwFLOAT:
+		return "FLOAT"
+	case kwDOUBLE:
+		return "DOUBLE"
+	case kwDECIMAL:
+		return "DECIMAL"
+	case kwDECIMALV2:
+		return "DECIMALV2"
+	case kwDECIMALV3:
+		return "DECIMALV3"
+	case kwBOOLEAN:
+		return "BOOLEAN"
+	case kwSTRING:
+		return "STRING"
+	case kwTEXT:
+		return "TEXT"
+	case kwVARCHAR:
+		return "VARCHAR"
+	case kwCHAR:
+		return "CHAR"
+	case kwVARBINARY:
+		return "VARBINARY"
+	case kwDATE:
+		return "DATE"
+	case kwDATETIME:
+		return "DATETIME"
+	case kwTIME:
+		return "TIME"
+	case kwDATEV1:
+		return "DATEV1"
+	case kwDATEV2:
+		return "DATEV2"
+	case kwDATETIMEV1:
+		return "DATETIMEV1"
+	case kwDATETIMEV2:
+		return "DATETIMEV2"
+	case kwBITMAP:
+		return "BITMAP"
+	case kwHLL:
+		return "HLL"
+	case kwQUANTILE_STATE:
+		return "QUANTILE_STATE"
+	case kwJSON:
+		return "JSON"
+	case kwJSONB:
+		return "JSONB"
+	case kwIPV4:
+		return "IPV4"
+	case kwIPV6:
+		return "IPV6"
+	case kwVARIANT:
+		return "VARIANT"
+	case kwAGG_STATE:
+		return "AGG_STATE"
+	case kwALL:
+		return "ALL"
+	case kwARRAY:
+		return "ARRAY"
+	case kwMAP:
+		return "MAP"
+	case kwSTRUCT:
+		return "STRUCT"
+	default:
+		return strings.ToUpper(tok.Str)
+	}
+}
+
+// parseDataType parses a Doris data type expression and returns an *ast.TypeName.
+//
+// Supported forms:
+//
+//	primitive_type                    — e.g. INT, VARCHAR, BOOLEAN
+//	primitive_type(N)                 — e.g. VARCHAR(255), CHAR(1)
+//	primitive_type(N, M)              — e.g. DECIMAL(10,2)
+//	ARRAY<elementType>
+//	MAP<keyType, valueType>
+//	STRUCT<name1 type1, name2 type2, ...>
+func (p *Parser) parseDataType() (*ast.TypeName, error) {
+	tok := p.cur
+
+	switch tok.Kind {
+	case kwARRAY:
+		return p.parseArrayType()
+	case kwMAP:
+		return p.parseMapType()
+	case kwSTRUCT:
+		return p.parseStructType()
+	default:
+		if isPrimitiveTypeKeyword(tok.Kind) {
+			return p.parsePrimitiveType()
+		}
+		// Also accept unquoted identifiers as type names (for forward
+		// compatibility with new type names not yet in the keyword list).
+		if tok.Kind == tokIdent || tok.Kind == tokQuotedIdent {
+			return p.parsePrimitiveType()
+		}
+		return nil, &ParseError{
+			Loc: tok.Loc,
+			Msg: fmt.Sprintf("expected a data type, got %q", tok.Str),
+		}
+	}
+}
+
+// parsePrimitiveType parses a primitive type name and its optional numeric
+// parameter list: type_name [ '(' N [ ',' M ] ')' ]
+func (p *Parser) parsePrimitiveType() (*ast.TypeName, error) {
+	tok := p.advance()
+	typName := &ast.TypeName{
+		Name: typeKeywordName(tok),
+		Loc:  tok.Loc,
+	}
+
+	// Optional parameter list: (N) or (N, M)
+	if p.cur.Kind == int('(') {
+		params, endLoc, err := p.parseTypeParams()
+		if err != nil {
+			return nil, err
+		}
+		typName.Params = params
+		typName.Loc.End = endLoc
+	}
+
+	return typName, nil
+}
+
+// parseTypeParams parses the optional numeric parameter list for a type:
+//
+//	'(' integer [',' integer] ')'
+//
+// Returns the list of param values and the End byte offset of the closing ')'.
+func (p *Parser) parseTypeParams() ([]int, int, error) {
+	// consume '('
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+
+	firstTok := p.cur
+	if firstTok.Kind != tokInt {
+		return nil, 0, &ParseError{
+			Loc: firstTok.Loc,
+			Msg: fmt.Sprintf("expected integer parameter, got %q", firstTok.Str),
+		}
+	}
+	p.advance()
+	params := []int{int(firstTok.Ival)}
+
+	// Optional second param
+	if p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		secondTok := p.cur
+		if secondTok.Kind != tokInt {
+			return nil, 0, &ParseError{
+				Loc: secondTok.Loc,
+				Msg: fmt.Sprintf("expected integer parameter, got %q", secondTok.Str),
+			}
+		}
+		p.advance()
+		params = append(params, int(secondTok.Ival))
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+	return params, closeTok.Loc.End, nil
+}
+
+// expectGT consumes a '>' token in a type-argument context, handling the case
+// where the lexer emits tokShiftRight (>>) for the terminal ">>" in nested
+// types like ARRAY<ARRAY<INT>>. When tokShiftRight is seen, we "split" it:
+// return a synthetic first '>' and leave the parser positioned at a synthetic
+// second '>' so the outer type parser can also consume its closing '>'.
+func (p *Parser) expectGT() (Token, error) {
+	if p.cur.Kind == int('>') {
+		return p.advance(), nil
+	}
+	if p.cur.Kind == tokShiftRight {
+		tok := p.cur // the ">>" token
+		firstGT := Token{
+			Kind: int('>'),
+			Str:  ">",
+			Loc:  ast.Loc{Start: tok.Loc.Start, End: tok.Loc.Start + 1},
+		}
+		secondGT := Token{
+			Kind: int('>'),
+			Str:  ">",
+			Loc:  ast.Loc{Start: tok.Loc.Start + 1, End: tok.Loc.End},
+		}
+		// advance() puts the token after ">>" into p.cur and clears hasNext.
+		p.advance()
+		// Now p.cur = token-after->>, p.hasNext = false.
+		// We want cur = secondGT, and next = token-after->>.
+		realNext := p.cur
+		p.cur = secondGT
+		p.nextBuf = realNext
+		p.hasNext = true
+		return firstGT, nil
+	}
+	return Token{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: fmt.Sprintf("expected '>', got %q", p.cur.Str),
+	}
+}
+
+// parseArrayType parses: ARRAY '<' elementType '>'
+func (p *Parser) parseArrayType() (*ast.TypeName, error) {
+	startTok := p.advance() // consume ARRAY
+	typName := &ast.TypeName{
+		Name: "ARRAY",
+		Loc:  startTok.Loc,
+	}
+
+	// Expect '<'
+	if _, err := p.expect(int('<')); err != nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected '<' after ARRAY",
+		}
+	}
+
+	// Parse element type recursively
+	elemType, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	typName.ElementType = elemType
+
+	// Expect '>' — uses expectGT to handle ">>" (tokShiftRight) in nested types
+	// like ARRAY<ARRAY<INT>> where the lexer produces a single tokShiftRight.
+	closeTok, err := p.expectGT()
+	if err != nil {
+		return nil, err
+	}
+	typName.Loc.End = closeTok.Loc.End
+
+	return typName, nil
+}
+
+// parseMapType parses: MAP '<' keyType ',' valueType '>'
+func (p *Parser) parseMapType() (*ast.TypeName, error) {
+	startTok := p.advance() // consume MAP
+	typName := &ast.TypeName{
+		Name: "MAP",
+		Loc:  startTok.Loc,
+	}
+
+	// Expect '<'
+	if _, err := p.expect(int('<')); err != nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected '<' after MAP",
+		}
+	}
+
+	// Parse key type
+	keyType, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	typName.ElementType = keyType
+
+	// Expect ','
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected ',' between MAP key and value types",
+		}
+	}
+
+	// Parse value type
+	valType, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	typName.ValueType = valType
+
+	// Expect '>' — handle ">>" from nested types.
+	closeTok, err := p.expectGT()
+	if err != nil {
+		return nil, err
+	}
+	typName.Loc.End = closeTok.Loc.End
+
+	return typName, nil
+}
+
+// parseStructType parses: STRUCT '<' name1 type1 [',' name2 type2 ...] '>'
+func (p *Parser) parseStructType() (*ast.TypeName, error) {
+	startTok := p.advance() // consume STRUCT
+	typName := &ast.TypeName{
+		Name: "STRUCT",
+		Loc:  startTok.Loc,
+	}
+
+	// Expect '<'
+	if _, err := p.expect(int('<')); err != nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected '<' after STRUCT",
+		}
+	}
+
+	// Parse one or more field definitions: name type [, name type ...]
+	for {
+		field, err := p.parseStructField()
+		if err != nil {
+			return nil, err
+		}
+		typName.Fields = append(typName.Fields, field)
+
+		// Stop at '>' (or '>>' which will be split by expectGT)
+		if p.cur.Kind == int('>') || p.cur.Kind == tokShiftRight {
+			break
+		}
+		if p.cur.Kind != int(',') {
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "expected ',' or '>' in STRUCT type field list",
+			}
+		}
+		p.advance() // consume ','
+
+		// Allow trailing comma before '>'
+		if p.cur.Kind == int('>') || p.cur.Kind == tokShiftRight {
+			break
+		}
+	}
+
+	// Expect '>' — handle ">>" from nested types.
+	closeTok, err := p.expectGT()
+	if err != nil {
+		return nil, err
+	}
+	typName.Loc.End = closeTok.Loc.End
+
+	return typName, nil
+}
+
+// parseStructField parses a single STRUCT field definition: name dataType
+//
+// The field name may be an identifier or a non-reserved keyword used as a
+// field name.
+func (p *Parser) parseStructField() (*ast.StructField, error) {
+	// Field name: accept identifiers AND keywords (field names can shadow keywords)
+	nameTok := p.cur
+	var fieldName string
+	switch {
+	case nameTok.Kind == tokIdent || nameTok.Kind == tokQuotedIdent:
+		fieldName = nameTok.Str
+		p.advance()
+	case nameTok.Kind >= 700:
+		// Any keyword token is valid as a struct field name
+		fieldName = nameTok.Str
+		p.advance()
+	default:
+		return nil, &ParseError{
+			Loc: nameTok.Loc,
+			Msg: fmt.Sprintf("expected field name in STRUCT, got %q", nameTok.Str),
+		}
+	}
+
+	// Field type
+	fieldType, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+
+	field := &ast.StructField{
+		Name: fieldName,
+		Type: fieldType,
+		Loc:  ast.Loc{Start: nameTok.Loc.Start, End: fieldType.Loc.End},
+	}
+	return field, nil
+}

--- a/doris/parser/datatypes_test.go
+++ b/doris/parser/datatypes_test.go
@@ -1,0 +1,638 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// parseType is a test helper that creates a parser for the given input string
+// and calls parseDataType. It returns the parsed TypeName and any error.
+func parseType(input string) (*ast.TypeName, error) {
+	p := makeParser(input)
+	return p.parseDataType()
+}
+
+// assertTypeName checks that tn.Name equals want.
+func assertTypeName(t *testing.T, tn *ast.TypeName, want string) {
+	t.Helper()
+	if tn == nil {
+		t.Fatalf("TypeName is nil, want Name=%q", want)
+	}
+	if tn.Name != want {
+		t.Errorf("TypeName.Name = %q, want %q", tn.Name, want)
+	}
+}
+
+// assertParams checks that tn.Params matches want.
+func assertParams(t *testing.T, tn *ast.TypeName, want ...int) {
+	t.Helper()
+	if len(tn.Params) != len(want) {
+		t.Errorf("Params = %v, want %v", tn.Params, want)
+		return
+	}
+	for i, w := range want {
+		if tn.Params[i] != w {
+			t.Errorf("Params[%d] = %d, want %d", i, tn.Params[i], w)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Simple primitive types (no parameters)
+// ---------------------------------------------------------------------------
+
+func TestDataType_INT(t *testing.T) {
+	tn, err := parseType("INT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "INT")
+	if len(tn.Params) != 0 {
+		t.Errorf("expected no params, got %v", tn.Params)
+	}
+}
+
+func TestDataType_INTEGER(t *testing.T) {
+	tn, err := parseType("INTEGER")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "INTEGER")
+}
+
+func TestDataType_TINYINT(t *testing.T) {
+	tn, err := parseType("TINYINT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "TINYINT")
+}
+
+func TestDataType_SMALLINT(t *testing.T) {
+	tn, err := parseType("SMALLINT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "SMALLINT")
+}
+
+func TestDataType_BIGINT(t *testing.T) {
+	tn, err := parseType("BIGINT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "BIGINT")
+}
+
+func TestDataType_FLOAT(t *testing.T) {
+	tn, err := parseType("FLOAT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "FLOAT")
+}
+
+func TestDataType_DOUBLE(t *testing.T) {
+	tn, err := parseType("DOUBLE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DOUBLE")
+}
+
+func TestDataType_BOOLEAN(t *testing.T) {
+	tn, err := parseType("BOOLEAN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "BOOLEAN")
+}
+
+func TestDataType_DATE(t *testing.T) {
+	tn, err := parseType("DATE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATE")
+}
+
+func TestDataType_DATETIME(t *testing.T) {
+	tn, err := parseType("DATETIME")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATETIME")
+}
+
+func TestDataType_TIME(t *testing.T) {
+	tn, err := parseType("TIME")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "TIME")
+}
+
+func TestDataType_STRING(t *testing.T) {
+	tn, err := parseType("STRING")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "STRING")
+}
+
+func TestDataType_TEXT(t *testing.T) {
+	tn, err := parseType("TEXT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "TEXT")
+}
+
+// ---------------------------------------------------------------------------
+// Legacy Doris versioned type names
+// ---------------------------------------------------------------------------
+
+func TestDataType_LARGEINT(t *testing.T) {
+	tn, err := parseType("LARGEINT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "LARGEINT")
+}
+
+func TestDataType_DATEV1(t *testing.T) {
+	tn, err := parseType("DATEV1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATEV1")
+}
+
+func TestDataType_DATEV2(t *testing.T) {
+	tn, err := parseType("DATEV2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATEV2")
+}
+
+func TestDataType_DATETIMEV1(t *testing.T) {
+	tn, err := parseType("DATETIMEV1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATETIMEV1")
+}
+
+func TestDataType_DATETIMEV2(t *testing.T) {
+	tn, err := parseType("DATETIMEV2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATETIMEV2")
+}
+
+func TestDataType_DECIMALV2(t *testing.T) {
+	tn, err := parseType("DECIMALV2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DECIMALV2")
+}
+
+func TestDataType_DECIMALV3(t *testing.T) {
+	tn, err := parseType("DECIMALV3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DECIMALV3")
+}
+
+// ---------------------------------------------------------------------------
+// Special Doris types
+// ---------------------------------------------------------------------------
+
+func TestDataType_HLL(t *testing.T) {
+	tn, err := parseType("HLL")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "HLL")
+}
+
+func TestDataType_BITMAP(t *testing.T) {
+	tn, err := parseType("BITMAP")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "BITMAP")
+}
+
+func TestDataType_QUANTILE_STATE(t *testing.T) {
+	tn, err := parseType("QUANTILE_STATE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "QUANTILE_STATE")
+}
+
+func TestDataType_JSON(t *testing.T) {
+	tn, err := parseType("JSON")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "JSON")
+}
+
+func TestDataType_JSONB(t *testing.T) {
+	tn, err := parseType("JSONB")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "JSONB")
+}
+
+func TestDataType_AGG_STATE(t *testing.T) {
+	tn, err := parseType("AGG_STATE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "AGG_STATE")
+}
+
+func TestDataType_IPV4(t *testing.T) {
+	tn, err := parseType("IPV4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "IPV4")
+}
+
+func TestDataType_IPV6(t *testing.T) {
+	tn, err := parseType("IPV6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "IPV6")
+}
+
+func TestDataType_VARIANT(t *testing.T) {
+	tn, err := parseType("VARIANT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "VARIANT")
+}
+
+func TestDataType_VARBINARY(t *testing.T) {
+	tn, err := parseType("VARBINARY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "VARBINARY")
+}
+
+// ---------------------------------------------------------------------------
+// Parameterized types
+// ---------------------------------------------------------------------------
+
+func TestDataType_VARCHAR_Param(t *testing.T) {
+	tn, err := parseType("VARCHAR(255)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "VARCHAR")
+	assertParams(t, tn, 255)
+}
+
+func TestDataType_CHAR_Param(t *testing.T) {
+	tn, err := parseType("CHAR(1)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "CHAR")
+	assertParams(t, tn, 1)
+}
+
+func TestDataType_DECIMAL_TwoParams(t *testing.T) {
+	tn, err := parseType("DECIMAL(10,2)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DECIMAL")
+	assertParams(t, tn, 10, 2)
+}
+
+func TestDataType_DECIMAL_OneParam(t *testing.T) {
+	tn, err := parseType("DECIMAL(18)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DECIMAL")
+	assertParams(t, tn, 18)
+}
+
+func TestDataType_DECIMALV3_TwoParams(t *testing.T) {
+	tn, err := parseType("DECIMALV3(27,9)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DECIMALV3")
+	assertParams(t, tn, 27, 9)
+}
+
+func TestDataType_DATETIMEV2_Param(t *testing.T) {
+	tn, err := parseType("DATETIMEV2(3)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "DATETIMEV2")
+	assertParams(t, tn, 3)
+}
+
+// ---------------------------------------------------------------------------
+// ARRAY types
+// ---------------------------------------------------------------------------
+
+func TestDataType_ARRAY_INT(t *testing.T) {
+	tn, err := parseType("ARRAY<INT>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "ARRAY")
+	if tn.ElementType == nil {
+		t.Fatal("ElementType is nil")
+	}
+	assertTypeName(t, tn.ElementType, "INT")
+}
+
+func TestDataType_ARRAY_VARCHAR(t *testing.T) {
+	tn, err := parseType("ARRAY<VARCHAR(255)>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "ARRAY")
+	if tn.ElementType == nil {
+		t.Fatal("ElementType is nil")
+	}
+	assertTypeName(t, tn.ElementType, "VARCHAR")
+	assertParams(t, tn.ElementType, 255)
+}
+
+func TestDataType_ARRAY_Nested(t *testing.T) {
+	tn, err := parseType("ARRAY<ARRAY<INT>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "ARRAY")
+	if tn.ElementType == nil {
+		t.Fatal("outer ElementType is nil")
+	}
+	assertTypeName(t, tn.ElementType, "ARRAY")
+	if tn.ElementType.ElementType == nil {
+		t.Fatal("inner ElementType is nil")
+	}
+	assertTypeName(t, tn.ElementType.ElementType, "INT")
+}
+
+func TestDataType_ARRAY_BIGINT(t *testing.T) {
+	tn, err := parseType("ARRAY<BIGINT>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "ARRAY")
+	assertTypeName(t, tn.ElementType, "BIGINT")
+}
+
+// ---------------------------------------------------------------------------
+// MAP types
+// ---------------------------------------------------------------------------
+
+func TestDataType_MAP_StringInt(t *testing.T) {
+	tn, err := parseType("MAP<STRING, INT>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "MAP")
+	if tn.ElementType == nil {
+		t.Fatal("key type (ElementType) is nil")
+	}
+	assertTypeName(t, tn.ElementType, "STRING")
+	if tn.ValueType == nil {
+		t.Fatal("value type (ValueType) is nil")
+	}
+	assertTypeName(t, tn.ValueType, "INT")
+}
+
+func TestDataType_MAP_VarcharArray(t *testing.T) {
+	tn, err := parseType("MAP<VARCHAR(10), ARRAY<INT>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "MAP")
+	if tn.ElementType == nil {
+		t.Fatal("key type is nil")
+	}
+	assertTypeName(t, tn.ElementType, "VARCHAR")
+	assertParams(t, tn.ElementType, 10)
+	if tn.ValueType == nil {
+		t.Fatal("value type is nil")
+	}
+	assertTypeName(t, tn.ValueType, "ARRAY")
+	if tn.ValueType.ElementType == nil {
+		t.Fatal("value array element type is nil")
+	}
+	assertTypeName(t, tn.ValueType.ElementType, "INT")
+}
+
+func TestDataType_MAP_NoSpaces(t *testing.T) {
+	tn, err := parseType("MAP<STRING,INT>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "MAP")
+	assertTypeName(t, tn.ElementType, "STRING")
+	assertTypeName(t, tn.ValueType, "INT")
+}
+
+// ---------------------------------------------------------------------------
+// STRUCT types
+// ---------------------------------------------------------------------------
+
+func TestDataType_STRUCT_SingleField(t *testing.T) {
+	tn, err := parseType("STRUCT<name VARCHAR(50)>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "STRUCT")
+	if len(tn.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(tn.Fields))
+	}
+	if tn.Fields[0].Name != "name" {
+		t.Errorf("Fields[0].Name = %q, want %q", tn.Fields[0].Name, "name")
+	}
+	assertTypeName(t, tn.Fields[0].Type, "VARCHAR")
+	assertParams(t, tn.Fields[0].Type, 50)
+}
+
+func TestDataType_STRUCT_TwoFields(t *testing.T) {
+	tn, err := parseType("STRUCT<name VARCHAR(50), age INT>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "STRUCT")
+	if len(tn.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(tn.Fields))
+	}
+	if tn.Fields[0].Name != "name" {
+		t.Errorf("Fields[0].Name = %q, want %q", tn.Fields[0].Name, "name")
+	}
+	assertTypeName(t, tn.Fields[0].Type, "VARCHAR")
+	assertParams(t, tn.Fields[0].Type, 50)
+	if tn.Fields[1].Name != "age" {
+		t.Errorf("Fields[1].Name = %q, want %q", tn.Fields[1].Name, "age")
+	}
+	assertTypeName(t, tn.Fields[1].Type, "INT")
+}
+
+func TestDataType_STRUCT_ThreeFields(t *testing.T) {
+	tn, err := parseType("STRUCT<id BIGINT, label VARCHAR(100), score DOUBLE>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "STRUCT")
+	if len(tn.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(tn.Fields))
+	}
+	wantNames := []string{"id", "label", "score"}
+	wantTypes := []string{"BIGINT", "VARCHAR", "DOUBLE"}
+	for i := range wantNames {
+		if tn.Fields[i].Name != wantNames[i] {
+			t.Errorf("Fields[%d].Name = %q, want %q", i, tn.Fields[i].Name, wantNames[i])
+		}
+		assertTypeName(t, tn.Fields[i].Type, wantTypes[i])
+	}
+}
+
+func TestDataType_STRUCT_NestedArray(t *testing.T) {
+	tn, err := parseType("STRUCT<tags ARRAY<STRING>, metadata MAP<STRING, INT>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "STRUCT")
+	if len(tn.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(tn.Fields))
+	}
+	assertTypeName(t, tn.Fields[0].Type, "ARRAY")
+	assertTypeName(t, tn.Fields[1].Type, "MAP")
+}
+
+// ---------------------------------------------------------------------------
+// Source location tracking
+// ---------------------------------------------------------------------------
+
+func TestDataType_Loc_Simple(t *testing.T) {
+	tn, err := parseType("INT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tn.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", tn.Loc.Start)
+	}
+	if tn.Loc.End != 3 {
+		t.Errorf("Loc.End = %d, want 3", tn.Loc.End)
+	}
+}
+
+func TestDataType_Loc_Parameterized(t *testing.T) {
+	tn, err := parseType("VARCHAR(255)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tn.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", tn.Loc.Start)
+	}
+	// "VARCHAR(255)" is 12 chars → End = 12
+	if tn.Loc.End != 12 {
+		t.Errorf("Loc.End = %d, want 12", tn.Loc.End)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NodeTag
+// ---------------------------------------------------------------------------
+
+func TestDataType_NodeTag(t *testing.T) {
+	tn, err := parseType("INT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tn.Tag().String() != "TypeName" {
+		t.Errorf("Tag().String() = %q, want %q", tn.Tag().String(), "TypeName")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+func TestDataType_Error_EmptyInput(t *testing.T) {
+	_, err := parseType("")
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestDataType_Error_NotAType(t *testing.T) {
+	// SELECT is a reserved keyword but not a type name
+	_, err := parseType("SELECT")
+	if err == nil {
+		t.Fatal("expected error for SELECT as type, got nil")
+	}
+}
+
+func TestDataType_Error_ARRAY_MissingAngle(t *testing.T) {
+	_, err := parseType("ARRAY INT")
+	if err == nil {
+		t.Fatal("expected error for ARRAY without '<'")
+	}
+}
+
+func TestDataType_Error_MAP_MissingComma(t *testing.T) {
+	_, err := parseType("MAP<STRING INT>")
+	if err == nil {
+		t.Fatal("expected error for MAP without ','")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lowercase / case-insensitive keyword input
+// ---------------------------------------------------------------------------
+
+func TestDataType_Lowercase_int(t *testing.T) {
+	tn, err := parseType("int")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Canonical name should be uppercase regardless of input case
+	assertTypeName(t, tn, "INT")
+}
+
+func TestDataType_Lowercase_varchar(t *testing.T) {
+	tn, err := parseType("varchar(100)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "VARCHAR")
+	assertParams(t, tn, 100)
+}
+
+func TestDataType_Lowercase_array(t *testing.T) {
+	tn, err := parseType("array<int>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertTypeName(t, tn, "ARRAY")
+	assertTypeName(t, tn.ElementType, "INT")
+}

--- a/doris/parser/identifiers.go
+++ b/doris/parser/identifiers.go
@@ -1,0 +1,162 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// isIdentifierToken reports whether kind can form a standalone identifier in
+// the first position of a qualified name (i.e., without dot context):
+//   - tokIdent: unquoted identifier (e.g. myTable)
+//   - tokQuotedIdent: backtick-quoted identifier (e.g. `my table`)
+//   - a non-reserved keyword (e.g. COMMENT, BUCKETS) used as an identifier
+func isIdentifierToken(kind TokenKind) bool {
+	switch kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		// A keyword token that is not reserved can serve as an identifier.
+		if kind >= 700 && !IsReserved(kind) {
+			return true
+		}
+		return false
+	}
+}
+
+// isIdentifierTokenQualified reports whether kind is a valid identifier in a
+// qualified (dot-following) position. After a '.', ALL keyword tokens —
+// including reserved ones — are valid identifier parts because the context is
+// syntactically unambiguous (e.g., db.table, catalog.select.foo).
+func isIdentifierTokenQualified(kind TokenKind) bool {
+	switch kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		// Any keyword token (reserved or not) is valid after a dot.
+		return kind >= 700
+	}
+}
+
+// parseIdentifier parses a single identifier token and returns its string
+// value and source location. Accepted tokens are:
+//   - tokIdent: unquoted identifier
+//   - tokQuotedIdent: backtick-quoted identifier (lexer has already stripped backticks)
+//   - a non-reserved keyword used as an identifier
+//
+// Returns a syntax error if the current token is not a valid identifier.
+func (p *Parser) parseIdentifier() (string, ast.Loc, error) {
+	tok := p.cur
+	switch tok.Kind {
+	case tokIdent, tokQuotedIdent:
+		p.advance()
+		return tok.Str, tok.Loc, nil
+	default:
+		// Non-reserved keywords may be used as identifiers.
+		if tok.Kind >= 700 && !IsReserved(tok.Kind) {
+			p.advance()
+			return tok.Str, tok.Loc, nil
+		}
+		return "", ast.Loc{}, p.syntaxErrorAtCur()
+	}
+}
+
+// parseIdentifierQualified parses a single identifier token in a qualified
+// (post-dot) position. In this context ALL keyword tokens are accepted as
+// identifier parts because the syntax is unambiguous.
+func (p *Parser) parseIdentifierQualified() (string, ast.Loc, error) {
+	tok := p.cur
+	switch tok.Kind {
+	case tokIdent, tokQuotedIdent:
+		p.advance()
+		return tok.Str, tok.Loc, nil
+	default:
+		// After a '.', any keyword (reserved or not) is a valid identifier part.
+		if tok.Kind >= 700 {
+			p.advance()
+			return tok.Str, tok.Loc, nil
+		}
+		return "", ast.Loc{}, p.syntaxErrorAtCur()
+	}
+}
+
+// parseMultipartIdentifier parses a dot-separated qualified name:
+//
+//	identifier ('.' identifier)*
+//
+// Returns an *ast.ObjectName with Parts populated. The Loc on the returned
+// node spans from the start of the first identifier to the end of the last.
+//
+// In the first position only non-reserved keywords are accepted as identifiers.
+// In subsequent positions (after '.') all keywords are accepted because the
+// dot context makes the parse unambiguous (e.g., db.select is valid).
+func (p *Parser) parseMultipartIdentifier() (*ast.ObjectName, error) {
+	first, loc, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	name := &ast.ObjectName{
+		Parts: []string{first},
+		Loc:   loc,
+	}
+
+	// Consume additional '.identifier' segments.
+	for p.cur.Kind == int('.') {
+		// Peek past the dot to make sure we have an identifier; if not, stop
+		// here rather than consuming the dot and getting a confusing error.
+		// Note: peekNext looks at the token after cur (the '.').
+		next := p.peekNext()
+		if !isIdentifierTokenQualified(next.Kind) {
+			break
+		}
+
+		p.advance() // consume '.'
+
+		part, partLoc, err := p.parseIdentifierQualified()
+		if err != nil {
+			return nil, err
+		}
+		name.Parts = append(name.Parts, part)
+		name.Loc.End = partLoc.End
+	}
+
+	return name, nil
+}
+
+// parseIdentifierOrString parses either an identifier or a string literal.
+// Some Doris syntax allows either form in certain positions (e.g. catalog/db
+// names in certain DDL contexts). Returns the string value and its location.
+func (p *Parser) parseIdentifierOrString() (string, ast.Loc, error) {
+	if p.cur.Kind == tokString {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
+	return p.parseIdentifier()
+}
+
+// NormalizeIdentifier returns the canonical form of a Doris identifier.
+// Doris is case-insensitive for unquoted identifiers, so unquoted identifiers
+// are lowercased. Backtick-quoted identifiers preserve their original case
+// (the lexer strips backticks and stores the raw content in Str, so the
+// quoted flag drives the normalization decision).
+func NormalizeIdentifier(name string, quoted bool) string {
+	if quoted {
+		return name
+	}
+	return strings.ToLower(name)
+}
+
+// NormalizeObjectName returns a normalized dot-joined representation of an
+// ObjectName. Each part is lowercased to match Doris case-insensitive
+// identifier comparison semantics. Useful for lookups and equality checks.
+func NormalizeObjectName(name *ast.ObjectName) string {
+	if name == nil {
+		return ""
+	}
+	parts := make([]string, len(name.Parts))
+	for i, p := range name.Parts {
+		parts[i] = strings.ToLower(p)
+	}
+	return strings.Join(parts, ".")
+}

--- a/doris/parser/identifiers_test.go
+++ b/doris/parser/identifiers_test.go
@@ -1,0 +1,345 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// makeParser creates a Parser primed on the given input, ready to parse.
+func makeParser(input string) *Parser {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance() // prime cur
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// parseIdentifier
+// ---------------------------------------------------------------------------
+
+func TestParseIdentifier_Unquoted(t *testing.T) {
+	p := makeParser("myTable")
+	name, loc, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "myTable" {
+		t.Errorf("got %q, want %q", name, "myTable")
+	}
+	if loc.Start != 0 || loc.End != 7 {
+		t.Errorf("loc = %v, want {0,7}", loc)
+	}
+	// parser should now be at EOF
+	if p.cur.Kind != tokEOF {
+		t.Errorf("cur after parse = %d, want EOF", p.cur.Kind)
+	}
+}
+
+func TestParseIdentifier_BacktickQuoted(t *testing.T) {
+	p := makeParser("`my table`")
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// lexer strips backticks, so we get the raw content
+	if name != "my table" {
+		t.Errorf("got %q, want %q", name, "my table")
+	}
+}
+
+func TestParseIdentifier_BacktickPreservesCase(t *testing.T) {
+	p := makeParser("`MyMixedCase`")
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "MyMixedCase" {
+		t.Errorf("got %q, want %q", name, "MyMixedCase")
+	}
+}
+
+func TestParseIdentifier_NonReservedKeyword(t *testing.T) {
+	// COMMENT is non-reserved in Doris and should parse as identifier.
+	p := makeParser("comment")
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "comment" {
+		t.Errorf("got %q, want %q", name, "comment")
+	}
+}
+
+func TestParseIdentifier_ReservedKeywordFails(t *testing.T) {
+	// SELECT is reserved and must not parse as an identifier.
+	p := makeParser("select")
+	_, _, err := p.parseIdentifier()
+	if err == nil {
+		t.Fatal("expected error for reserved keyword SELECT, got nil")
+	}
+}
+
+func TestParseIdentifier_EOF_Fails(t *testing.T) {
+	p := makeParser("")
+	_, _, err := p.parseIdentifier()
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseMultipartIdentifier
+// ---------------------------------------------------------------------------
+
+func TestParseMultipartIdentifier_Single(t *testing.T) {
+	p := makeParser("myTable")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(name.Parts) != 1 {
+		t.Fatalf("got %d parts, want 1", len(name.Parts))
+	}
+	if name.Parts[0] != "myTable" {
+		t.Errorf("Parts[0] = %q, want %q", name.Parts[0], "myTable")
+	}
+}
+
+func TestParseMultipartIdentifier_TwoPart(t *testing.T) {
+	p := makeParser("db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"db", "table"}
+	if len(name.Parts) != len(want) {
+		t.Fatalf("got %d parts, want %d: %v", len(name.Parts), len(want), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_ThreePart(t *testing.T) {
+	p := makeParser("catalog.db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"catalog", "db", "table"}
+	if len(name.Parts) != 3 {
+		t.Fatalf("got %d parts, want 3: %v", len(name.Parts), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_QuotedSingle(t *testing.T) {
+	p := makeParser("`my table`")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(name.Parts) != 1 || name.Parts[0] != "my table" {
+		t.Errorf("got Parts=%v, want [\"my table\"]", name.Parts)
+	}
+}
+
+func TestParseMultipartIdentifier_MixedQuoted(t *testing.T) {
+	// db.`my table`
+	p := makeParser("db.`my table`")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"db", "my table"}
+	if len(name.Parts) != 2 {
+		t.Fatalf("got %d parts, want 2: %v", len(name.Parts), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_NonReservedKeyword(t *testing.T) {
+	// COMMENT is non-reserved and valid as a table name.
+	p := makeParser("db.comment")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"db", "comment"}
+	if len(name.Parts) != 2 {
+		t.Fatalf("got %d parts, want 2: %v", len(name.Parts), name.Parts)
+	}
+	for i, w := range want {
+		if name.Parts[i] != w {
+			t.Errorf("Parts[%d] = %q, want %q", i, name.Parts[i], w)
+		}
+	}
+}
+
+func TestParseMultipartIdentifier_DotNotFollowedByIdent(t *testing.T) {
+	// "mytable.(" — the '.' is followed by '(' which is not an identifier,
+	// so we stop at the first part and leave '.(' for the caller.
+	// (Note: "mytable.123" would not work because the lexer folds ".123" into
+	// a tokFloat when it immediately follows an identifier.)
+	p := makeParser("mytable.(")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(name.Parts) != 1 || name.Parts[0] != "mytable" {
+		t.Errorf("got Parts=%v, want [\"mytable\"]", name.Parts)
+	}
+	// The '.' should still be in the stream.
+	if p.cur.Kind != int('.') {
+		t.Errorf("cur after partial parse = %d, want '.'", p.cur.Kind)
+	}
+}
+
+func TestParseMultipartIdentifier_ReservedKeywordFails(t *testing.T) {
+	// SELECT is reserved — parsing it as an identifier must fail.
+	p := makeParser("select")
+	_, err := p.parseMultipartIdentifier()
+	if err == nil {
+		t.Fatal("expected error for reserved keyword SELECT, got nil")
+	}
+}
+
+func TestParseMultipartIdentifier_LocSpan(t *testing.T) {
+	// "db.table": start=0, end=8
+	p := makeParser("db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", name.Loc.Start)
+	}
+	if name.Loc.End != 8 {
+		t.Errorf("Loc.End = %d, want 8", name.Loc.End)
+	}
+}
+
+func TestParseMultipartIdentifier_String(t *testing.T) {
+	p := makeParser("catalog.db.table")
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name.String() != "catalog.db.table" {
+		t.Errorf("String() = %q, want %q", name.String(), "catalog.db.table")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseIdentifierOrString
+// ---------------------------------------------------------------------------
+
+func TestParseIdentifierOrString_Identifier(t *testing.T) {
+	p := makeParser("mydb")
+	val, _, err := p.parseIdentifierOrString()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "mydb" {
+		t.Errorf("got %q, want %q", val, "mydb")
+	}
+}
+
+func TestParseIdentifierOrString_StringLiteral(t *testing.T) {
+	p := makeParser("'mydb'")
+	val, _, err := p.parseIdentifierOrString()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "mydb" {
+		t.Errorf("got %q, want %q", val, "mydb")
+	}
+}
+
+func TestParseIdentifierOrString_DoubleQuotedString(t *testing.T) {
+	p := makeParser(`"mydb"`)
+	val, _, err := p.parseIdentifierOrString()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "mydb" {
+		t.Errorf("got %q, want %q", val, "mydb")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NormalizeIdentifier
+// ---------------------------------------------------------------------------
+
+func TestNormalizeIdentifier_UnquotedLowercases(t *testing.T) {
+	got := NormalizeIdentifier("MyTable", false)
+	if got != "mytable" {
+		t.Errorf("NormalizeIdentifier(%q, false) = %q, want %q", "MyTable", got, "mytable")
+	}
+}
+
+func TestNormalizeIdentifier_QuotedPreservesCase(t *testing.T) {
+	got := NormalizeIdentifier("MyTable", true)
+	if got != "MyTable" {
+		t.Errorf("NormalizeIdentifier(%q, true) = %q, want %q", "MyTable", got, "MyTable")
+	}
+}
+
+func TestNormalizeIdentifier_AlreadyLower(t *testing.T) {
+	got := NormalizeIdentifier("mytable", false)
+	if got != "mytable" {
+		t.Errorf("NormalizeIdentifier(%q, false) = %q, want %q", "mytable", got, "mytable")
+	}
+}
+
+func TestNormalizeIdentifier_AllUpper(t *testing.T) {
+	got := NormalizeIdentifier("MYTABLE", false)
+	if got != "mytable" {
+		t.Errorf("NormalizeIdentifier(%q, false) = %q, want %q", "MYTABLE", got, "mytable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NormalizeObjectName
+// ---------------------------------------------------------------------------
+
+func TestNormalizeObjectName_SinglePart(t *testing.T) {
+	name := &ast.ObjectName{Parts: []string{"MyTable"}}
+	got := NormalizeObjectName(name)
+	if got != "mytable" {
+		t.Errorf("NormalizeObjectName = %q, want %q", got, "mytable")
+	}
+}
+
+func TestNormalizeObjectName_MultiPart(t *testing.T) {
+	name := &ast.ObjectName{Parts: []string{"MyCatalog", "MyDB", "MyTable"}}
+	got := NormalizeObjectName(name)
+	if got != "mycatalog.mydb.mytable" {
+		t.Errorf("NormalizeObjectName = %q, want %q", got, "mycatalog.mydb.mytable")
+	}
+}
+
+func TestNormalizeObjectName_Nil(t *testing.T) {
+	got := NormalizeObjectName(nil)
+	if got != "" {
+		t.Errorf("NormalizeObjectName(nil) = %q, want %q", got, "")
+	}
+}
+
+func TestNormalizeObjectName_AlreadyLower(t *testing.T) {
+	name := &ast.ObjectName{Parts: []string{"catalog", "db", "table"}}
+	got := NormalizeObjectName(name)
+	if got != "catalog.db.table" {
+		t.Errorf("NormalizeObjectName = %q, want %q", got, "catalog.db.table")
+	}
+}

--- a/doris/parser/index.go
+++ b/doris/parser/index.go
@@ -1,0 +1,277 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// parseCreateIndex parses a CREATE INDEX statement.
+//
+//	CREATE INDEX [IF NOT EXISTS] index_name ON table_name (col1, col2, ...)
+//	  [USING index_type]
+//	  [COMMENT 'comment']
+//	  [PROPERTIES("key"="value", ...)]
+//
+// The CREATE keyword has already been consumed when this method is called.
+// cur is kwINDEX on entry. startLoc is the Loc of the CREATE token.
+func (p *Parser) parseCreateIndex(startLoc ast.Loc) (ast.Node, error) {
+	// Consume INDEX.
+	p.advance()
+
+	// Optional IF NOT EXISTS.
+	ifNotExists := false
+	if p.cur.Kind == kwIF {
+		p.advance()
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		ifNotExists = true
+	}
+
+	// Index name.
+	indexName, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// ON table_name.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	tableName, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// (col1, col2, ...).
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	columns, err := p.parseIdentifierList()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	// Optional clauses: USING, COMMENT, PROPERTIES (in any order, each at most once).
+	var indexType string
+	var comment string
+	var properties []*ast.Property
+
+	for {
+		switch p.cur.Kind {
+		case kwUSING:
+			p.advance()
+			typeTok := p.cur
+			// Index type is one of: BITMAP, NGRAM_BF, INVERTED, ANN (all non-reserved).
+			// Accept any non-reserved keyword or plain identifier as an index type name.
+			if !isIdentifierToken(typeTok.Kind) {
+				return nil, p.syntaxErrorAtCur()
+			}
+			// Normalize to lowercase for case-insensitive comparison.
+			indexType = strings.ToLower(typeTok.Str)
+			p.advance()
+			continue
+		case kwCOMMENT:
+			p.advance()
+			if p.cur.Kind != tokString {
+				return nil, p.syntaxErrorAtCur()
+			}
+			comment = p.cur.Str
+			p.advance()
+			continue
+		case kwPROPERTIES:
+			var err error
+			properties, err = p.parseProperties()
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		break
+	}
+
+	endLoc := p.prev.Loc
+	stmt := &ast.CreateIndexStmt{
+		Name:        indexName,
+		Table:       tableName,
+		Columns:     columns,
+		IfNotExists: ifNotExists,
+		IndexType:   indexType,
+		Properties:  properties,
+		Comment:     comment,
+		Loc:         ast.Loc{Start: startLoc.Start, End: endLoc.End},
+	}
+	return stmt, nil
+}
+
+// parseDropIndex parses a DROP INDEX statement.
+//
+//	DROP INDEX [IF EXISTS] index_name ON table_name
+//
+// The DROP keyword has already been consumed when this method is called.
+// cur is kwINDEX on entry. startLoc is the Loc of the DROP token.
+func (p *Parser) parseDropIndex(startLoc ast.Loc) (ast.Node, error) {
+	// Consume INDEX.
+	p.advance()
+
+	// Optional IF EXISTS.
+	ifExists := false
+	if p.cur.Kind == kwIF {
+		p.advance()
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		ifExists = true
+	}
+
+	// Index name.
+	indexName, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// ON table_name.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	tableName, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	endLoc := p.prev.Loc
+	stmt := &ast.DropIndexStmt{
+		Name:     indexName,
+		Table:    tableName,
+		IfExists: ifExists,
+		Loc:      ast.Loc{Start: startLoc.Start, End: endLoc.End},
+	}
+	return stmt, nil
+}
+
+// parseBuildIndex parses a BUILD INDEX statement.
+//
+//	BUILD INDEX index_name ON table_name [PARTITIONS(p1, p2, ...)]
+//
+// cur is kwINDEX on entry (BUILD has already been consumed).
+// startLoc is the Loc of the BUILD token.
+func (p *Parser) parseBuildIndex(startLoc ast.Loc) (ast.Node, error) {
+	// Consume INDEX.
+	p.advance()
+
+	// Index name.
+	indexName, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// ON table_name.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	tableName, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional PARTITIONS(p1, p2, ...).
+	var partitions []string
+	if p.cur.Kind == kwPARTITIONS {
+		p.advance()
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		partitions, err = p.parseIdentifierList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+	}
+
+	endLoc := p.prev.Loc
+	stmt := &ast.BuildIndexStmt{
+		Name:       indexName,
+		Table:      tableName,
+		Partitions: partitions,
+		Loc:        ast.Loc{Start: startLoc.Start, End: endLoc.End},
+	}
+	return stmt, nil
+}
+
+// parseIdentifierList parses a comma-separated list of bare identifiers.
+// Used for column lists and partition name lists.
+// The surrounding parentheses are NOT consumed here.
+func (p *Parser) parseIdentifierList() ([]string, error) {
+	first, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	names := []string{first}
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		name, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// parseProperties parses a PROPERTIES("key"="value", ...) clause.
+// cur must be kwPROPERTIES on entry; it is consumed here.
+func (p *Parser) parseProperties() ([]*ast.Property, error) {
+	p.advance() // consume PROPERTIES
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	var props []*ast.Property
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		propLoc := p.cur.Loc
+
+		// Key: string literal or identifier.
+		key, _, err := p.parseIdentifierOrString()
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := p.expect(int('=')); err != nil {
+			return nil, err
+		}
+
+		// Value: string literal or identifier.
+		value, valueLoc, err := p.parseIdentifierOrString()
+		if err != nil {
+			return nil, err
+		}
+
+		props = append(props, &ast.Property{
+			Key:   key,
+			Value: value,
+			Loc:   ast.Loc{Start: propLoc.Start, End: valueLoc.End},
+		})
+
+		if p.cur.Kind == int(',') {
+			p.advance()
+		} else {
+			break
+		}
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return props, nil
+}

--- a/doris/parser/index_test.go
+++ b/doris/parser/index_test.go
@@ -1,0 +1,335 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// helper: parse a single statement and expect no errors, returning the node.
+func parseIndexStmt(t *testing.T, sql string) ast.Node {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d stmts, want 1", sql, len(file.Stmts))
+	}
+	return file.Stmts[0]
+}
+
+func TestCreateIndexBasic(t *testing.T) {
+	sql := "CREATE INDEX idx ON t (col1)"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.Name.String() != "idx" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "idx")
+	}
+	if stmt.Table.String() != "t" {
+		t.Errorf("Table = %q, want %q", stmt.Table.String(), "t")
+	}
+	if len(stmt.Columns) != 1 || stmt.Columns[0] != "col1" {
+		t.Errorf("Columns = %v, want [col1]", stmt.Columns)
+	}
+	if stmt.IfNotExists {
+		t.Error("IfNotExists should be false")
+	}
+	if stmt.IndexType != "" {
+		t.Errorf("IndexType = %q, want empty", stmt.IndexType)
+	}
+}
+
+func TestCreateIndexIfNotExists(t *testing.T) {
+	sql := "CREATE INDEX IF NOT EXISTS idx ON t (col1, col2)"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists should be true")
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("Columns = %v, want 2 columns", stmt.Columns)
+	}
+	if stmt.Columns[0] != "col1" || stmt.Columns[1] != "col2" {
+		t.Errorf("Columns = %v, want [col1 col2]", stmt.Columns)
+	}
+}
+
+func TestCreateIndexUsingBitmap(t *testing.T) {
+	sql := "CREATE INDEX idx ON t (col1) USING BITMAP"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.IndexType != "bitmap" {
+		t.Errorf("IndexType = %q, want %q", stmt.IndexType, "bitmap")
+	}
+}
+
+func TestCreateIndexUsingInverted(t *testing.T) {
+	sql := "CREATE INDEX idx ON t (col1) USING INVERTED"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.IndexType != "inverted" {
+		t.Errorf("IndexType = %q, want %q", stmt.IndexType, "inverted")
+	}
+}
+
+func TestCreateIndexNgramBfWithProperties(t *testing.T) {
+	sql := `CREATE INDEX idx ON t (col1) USING NGRAM_BF PROPERTIES("gram_size"="3")`
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.IndexType != "ngram_bf" {
+		t.Errorf("IndexType = %q, want %q", stmt.IndexType, "ngram_bf")
+	}
+	if len(stmt.Properties) != 1 {
+		t.Fatalf("Properties = %v, want 1 property", stmt.Properties)
+	}
+	if stmt.Properties[0].Key != "gram_size" {
+		t.Errorf("Properties[0].Key = %q, want %q", stmt.Properties[0].Key, "gram_size")
+	}
+	if stmt.Properties[0].Value != "3" {
+		t.Errorf("Properties[0].Value = %q, want %q", stmt.Properties[0].Value, "3")
+	}
+}
+
+func TestCreateIndexWithComment(t *testing.T) {
+	sql := "CREATE INDEX idx ON t (col1) COMMENT 'my index'"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.Comment != "my index" {
+		t.Errorf("Comment = %q, want %q", stmt.Comment, "my index")
+	}
+}
+
+func TestCreateIndexQualifiedTable(t *testing.T) {
+	sql := "CREATE INDEX idx ON db.t (col1) USING BITMAP"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.Table.String() != "db.t" {
+		t.Errorf("Table = %q, want %q", stmt.Table.String(), "db.t")
+	}
+}
+
+func TestCreateIndexMultipleProperties(t *testing.T) {
+	sql := `CREATE INDEX idx ON t (col1) USING NGRAM_BF PROPERTIES("gram_size"="3", "bf_size"="64")`
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if len(stmt.Properties) != 2 {
+		t.Fatalf("Properties = %v, want 2 properties", stmt.Properties)
+	}
+	if stmt.Properties[1].Key != "bf_size" {
+		t.Errorf("Properties[1].Key = %q, want %q", stmt.Properties[1].Key, "bf_size")
+	}
+}
+
+func TestDropIndexBasic(t *testing.T) {
+	sql := "DROP INDEX idx ON t"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.DropIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.DropIndexStmt, got %T", node)
+	}
+	if stmt.Name.String() != "idx" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "idx")
+	}
+	if stmt.Table.String() != "t" {
+		t.Errorf("Table = %q, want %q", stmt.Table.String(), "t")
+	}
+	if stmt.IfExists {
+		t.Error("IfExists should be false")
+	}
+}
+
+func TestDropIndexIfExists(t *testing.T) {
+	sql := "DROP INDEX IF EXISTS idx ON t"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.DropIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.DropIndexStmt, got %T", node)
+	}
+	if !stmt.IfExists {
+		t.Error("IfExists should be true")
+	}
+	if stmt.Name.String() != "idx" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "idx")
+	}
+	if stmt.Table.String() != "t" {
+		t.Errorf("Table = %q, want %q", stmt.Table.String(), "t")
+	}
+}
+
+func TestBuildIndexBasic(t *testing.T) {
+	sql := "BUILD INDEX idx ON t"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.BuildIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.BuildIndexStmt, got %T", node)
+	}
+	if stmt.Name.String() != "idx" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "idx")
+	}
+	if stmt.Table.String() != "t" {
+		t.Errorf("Table = %q, want %q", stmt.Table.String(), "t")
+	}
+	if len(stmt.Partitions) != 0 {
+		t.Errorf("Partitions = %v, want empty", stmt.Partitions)
+	}
+}
+
+func TestBuildIndexWithPartitions(t *testing.T) {
+	sql := "BUILD INDEX idx ON t PARTITIONS(p1, p2)"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.BuildIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.BuildIndexStmt, got %T", node)
+	}
+	if len(stmt.Partitions) != 2 {
+		t.Fatalf("Partitions = %v, want 2 partitions", stmt.Partitions)
+	}
+	if stmt.Partitions[0] != "p1" || stmt.Partitions[1] != "p2" {
+		t.Errorf("Partitions = %v, want [p1 p2]", stmt.Partitions)
+	}
+}
+
+func TestBuildIndexQualifiedTable(t *testing.T) {
+	sql := "BUILD INDEX idx ON db.t PARTITIONS(p1)"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.BuildIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.BuildIndexStmt, got %T", node)
+	}
+	if stmt.Table.String() != "db.t" {
+		t.Errorf("Table = %q, want %q", stmt.Table.String(), "db.t")
+	}
+}
+
+func TestCreateIndexLocIsSet(t *testing.T) {
+	sql := "CREATE INDEX idx ON t (col1)"
+	node := parseIndexStmt(t, sql)
+
+	stmt := node.(*ast.CreateIndexStmt)
+	if !stmt.Loc.IsValid() {
+		t.Errorf("Loc = %v, want valid location", stmt.Loc)
+	}
+	// Loc.Start should be 0 (start of CREATE keyword).
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+}
+
+func TestDropIndexLocIsSet(t *testing.T) {
+	sql := "DROP INDEX idx ON t"
+	node := parseIndexStmt(t, sql)
+
+	stmt := node.(*ast.DropIndexStmt)
+	if !stmt.Loc.IsValid() {
+		t.Errorf("Loc = %v, want valid location", stmt.Loc)
+	}
+}
+
+func TestBuildIndexLocIsSet(t *testing.T) {
+	sql := "BUILD INDEX idx ON t"
+	node := parseIndexStmt(t, sql)
+
+	stmt := node.(*ast.BuildIndexStmt)
+	if !stmt.Loc.IsValid() {
+		t.Errorf("Loc = %v, want valid location", stmt.Loc)
+	}
+}
+
+func TestCreateIndexANN(t *testing.T) {
+	sql := "CREATE INDEX idx ON t (embedding_col) USING ANN"
+	node := parseIndexStmt(t, sql)
+
+	stmt, ok := node.(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateIndexStmt, got %T", node)
+	}
+	if stmt.IndexType != "ann" {
+		t.Errorf("IndexType = %q, want %q", stmt.IndexType, "ann")
+	}
+}
+
+// TestCreateIndexNodeTag verifies Tag() returns the correct value.
+func TestCreateIndexNodeTag(t *testing.T) {
+	stmt := &ast.CreateIndexStmt{}
+	if stmt.Tag() != ast.T_CreateIndexStmt {
+		t.Errorf("Tag() = %v, want T_CreateIndexStmt", stmt.Tag())
+	}
+}
+
+func TestDropIndexNodeTag(t *testing.T) {
+	stmt := &ast.DropIndexStmt{}
+	if stmt.Tag() != ast.T_DropIndexStmt {
+		t.Errorf("Tag() = %v, want T_DropIndexStmt", stmt.Tag())
+	}
+}
+
+func TestBuildIndexNodeTag(t *testing.T) {
+	stmt := &ast.BuildIndexStmt{}
+	if stmt.Tag() != ast.T_BuildIndexStmt {
+		t.Errorf("Tag() = %v, want T_BuildIndexStmt", stmt.Tag())
+	}
+}
+
+// TestCreateIndexStillUnsupportedForNonIndex verifies that CREATE TABLE
+// still returns the "not yet supported" error path.
+func TestCreateIndexStillUnsupportedForNonIndex(t *testing.T) {
+	_, errs := Parse("CREATE TABLE t (id INT)")
+	if len(errs) == 0 {
+		t.Fatal("expected error for CREATE TABLE")
+	}
+	want := "CREATE statement parsing is not yet supported"
+	if errs[0].Msg != want {
+		t.Errorf("got %q, want %q", errs[0].Msg, want)
+	}
+}
+
+// TestDropIndexStillUnsupportedForNonIndex verifies that DROP TABLE
+// still returns the "not yet supported" error path.
+func TestDropIndexStillUnsupportedForNonIndex(t *testing.T) {
+	_, errs := Parse("DROP TABLE t")
+	if len(errs) == 0 {
+		t.Fatal("expected error for DROP TABLE")
+	}
+	want := "DROP statement parsing is not yet supported"
+	if errs[0].Msg != want {
+		t.Errorf("got %q, want %q", errs[0].Msg, want)
+	}
+}

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -173,10 +173,18 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	switch p.cur.Kind {
 	// DDL
 	case kwCREATE:
+		createTok := p.advance() // consume CREATE
+		if p.cur.Kind == kwINDEX {
+			return p.parseCreateIndex(createTok.Loc)
+		}
 		return p.unsupported("CREATE")
 	case kwALTER:
 		return p.unsupported("ALTER")
 	case kwDROP:
+		dropTok := p.advance() // consume DROP
+		if p.cur.Kind == kwINDEX {
+			return p.parseDropIndex(dropTok.Loc)
+		}
 		return p.unsupported("DROP")
 	case kwTRUNCATE:
 		return p.unsupported("TRUNCATE")
@@ -282,6 +290,14 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	// Clean
 	case kwCLEAN:
 		return p.unsupported("CLEAN")
+
+	// Index async build
+	case kwBUILD:
+		buildTok := p.advance() // consume BUILD
+		if p.cur.Kind == kwINDEX {
+			return p.parseBuildIndex(buildTok.Loc)
+		}
+		return p.unsupported("BUILD")
 
 	default:
 		return nil, p.unknownStatementError()


### PR DESCRIPTION
## Summary
- Add `TypeName` AST node with support for primitive, parameterized, ARRAY<T>, MAP<K,V>, STRUCT<name type, ...>
- `parseDataType()` handles all Doris types: INT/BIGINT/LARGEINT, VARCHAR/CHAR, DECIMAL, BOOLEAN, DATE/DATETIME, HLL, BITMAP, QUANTILE_STATE, JSON, JSONB, IPV4, IPV6, VARIANT, AGG_STATE
- Smart `>>` splitting for nested generics like `ARRAY<ARRAY<INT>>`
- CREATE/DROP/BUILD INDEX with BITMAP, NGRAM_BF, INVERTED, ANN index types
- 57 data type tests + 22 index tests

DAG nodes: T1.2 (data types) + T2.5 (INDEX DDL) from `docs/migration/doris/dag.md`

## Test plan
- [x] 79 new tests pass (`go test ./doris/...`)
- [x] `go build ./doris/...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)