### PR TITLE
feat(doris): Pratt expression parser with 17 AST node types (T1.3)

### DIFF
--- a/doris/ast/exprnodes.go
+++ b/doris/ast/exprnodes.go
@@ -1,0 +1,353 @@
+package ast
+
+// This file holds expression AST node types for Doris SQL (T1.3).
+
+// ---------------------------------------------------------------------------
+// Operator types
+// ---------------------------------------------------------------------------
+
+// BinaryOp identifies a binary operator kind.
+type BinaryOp int
+
+const (
+	// Logical operators.
+	BinOr  BinaryOp = iota // OR, ||
+	BinAnd                  // AND, &&
+	BinXor                  // XOR
+
+	// Comparison operators.
+	BinEq        // =
+	BinNe        // <> or !=
+	BinLt        // <
+	BinGt        // >
+	BinLe        // <=
+	BinGe        // >=
+	BinNullSafeEq // <=>
+
+	// Arithmetic operators.
+	BinAdd // +
+	BinSub // -
+	BinMul // *
+	BinDiv // /
+	BinMod // % or MOD
+	BinIntDiv // DIV
+
+	// Bitwise operators.
+	BinBitOr  // |
+	BinBitAnd // &
+	BinBitXor // ^
+	BinShiftLeft  // <<
+	BinShiftRight // >>
+)
+
+// String returns the SQL text form of the operator.
+func (op BinaryOp) String() string {
+	switch op {
+	case BinOr:
+		return "OR"
+	case BinAnd:
+		return "AND"
+	case BinXor:
+		return "XOR"
+	case BinEq:
+		return "="
+	case BinNe:
+		return "<>"
+	case BinLt:
+		return "<"
+	case BinGt:
+		return ">"
+	case BinLe:
+		return "<="
+	case BinGe:
+		return ">="
+	case BinNullSafeEq:
+		return "<=>"
+	case BinAdd:
+		return "+"
+	case BinSub:
+		return "-"
+	case BinMul:
+		return "*"
+	case BinDiv:
+		return "/"
+	case BinMod:
+		return "%"
+	case BinIntDiv:
+		return "DIV"
+	case BinBitOr:
+		return "|"
+	case BinBitAnd:
+		return "&"
+	case BinBitXor:
+		return "^"
+	case BinShiftLeft:
+		return "<<"
+	case BinShiftRight:
+		return ">>"
+	default:
+		return "?"
+	}
+}
+
+// UnaryOp identifies a unary operator kind.
+type UnaryOp int
+
+const (
+	UnaryMinus  UnaryOp = iota // -
+	UnaryPlus                   // +
+	UnaryBitNot                 // ~
+	UnaryNot                    // NOT
+)
+
+// String returns the SQL text form of the unary operator.
+func (op UnaryOp) String() string {
+	switch op {
+	case UnaryMinus:
+		return "-"
+	case UnaryPlus:
+		return "+"
+	case UnaryBitNot:
+		return "~"
+	case UnaryNot:
+		return "NOT"
+	default:
+		return "?"
+	}
+}
+
+// LitKind classifies a literal value.
+type LitKind int
+
+const (
+	LitInt    LitKind = iota // integer literal
+	LitFloat                 // decimal/float literal
+	LitString                // string literal
+	LitBool                  // TRUE or FALSE
+	LitNull                  // NULL
+)
+
+// CaseKind classifies a CASE expression as simple or searched.
+type CaseKind int
+
+const (
+	CaseSearched CaseKind = iota // CASE WHEN ...
+	CaseSimple                    // CASE operand WHEN ...
+)
+
+// ---------------------------------------------------------------------------
+// Expression nodes
+// ---------------------------------------------------------------------------
+
+// BinaryExpr represents a binary operation: left op right.
+type BinaryExpr struct {
+	Op    BinaryOp
+	Left  Node
+	Right Node
+	Loc   Loc
+}
+
+func (n *BinaryExpr) Tag() NodeTag { return T_BinaryExpr }
+
+var _ Node = (*BinaryExpr)(nil)
+
+// UnaryExpr represents a unary operation: op expr.
+type UnaryExpr struct {
+	Op   UnaryOp
+	Expr Node
+	Loc  Loc
+}
+
+func (n *UnaryExpr) Tag() NodeTag { return T_UnaryExpr }
+
+var _ Node = (*UnaryExpr)(nil)
+
+// IsExpr represents expr IS [NOT] NULL / TRUE / FALSE.
+type IsExpr struct {
+	Expr    Node
+	Not     bool
+	IsWhat  string // "NULL", "TRUE", "FALSE"
+	Loc     Loc
+}
+
+func (n *IsExpr) Tag() NodeTag { return T_IsExpr }
+
+var _ Node = (*IsExpr)(nil)
+
+// BetweenExpr represents expr [NOT] BETWEEN low AND high.
+type BetweenExpr struct {
+	Expr Node
+	Low  Node
+	High Node
+	Not  bool
+	Loc  Loc
+}
+
+func (n *BetweenExpr) Tag() NodeTag { return T_BetweenExpr }
+
+var _ Node = (*BetweenExpr)(nil)
+
+// InExpr represents expr [NOT] IN (values...) or expr [NOT] IN (subquery).
+type InExpr struct {
+	Expr     Node
+	Values   []Node // list of values; for subquery, contains one SubqueryExpr
+	Not      bool
+	Loc      Loc
+}
+
+func (n *InExpr) Tag() NodeTag { return T_InExpr }
+
+var _ Node = (*InExpr)(nil)
+
+// LikeExpr represents expr [NOT] LIKE pattern [ESCAPE esc].
+type LikeExpr struct {
+	Expr    Node
+	Pattern Node
+	Escape  Node // nil if no ESCAPE clause
+	Not     bool
+	Loc     Loc
+}
+
+func (n *LikeExpr) Tag() NodeTag { return T_LikeExpr }
+
+var _ Node = (*LikeExpr)(nil)
+
+// RegexpExpr represents expr [NOT] REGEXP|RLIKE pattern.
+type RegexpExpr struct {
+	Expr    Node
+	Pattern Node
+	Not     bool
+	Loc     Loc
+}
+
+func (n *RegexpExpr) Tag() NodeTag { return T_RegexpExpr }
+
+var _ Node = (*RegexpExpr)(nil)
+
+// FuncCallExpr represents a function call: name(args...).
+type FuncCallExpr struct {
+	Name     *ObjectName
+	Args     []Node
+	Distinct bool   // COUNT(DISTINCT x)
+	Star     bool   // COUNT(*)
+	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
+	Separator string // optional SEPARATOR value for GROUP_CONCAT
+	Loc      Loc
+}
+
+func (n *FuncCallExpr) Tag() NodeTag { return T_FuncCallExpr }
+
+var _ Node = (*FuncCallExpr)(nil)
+
+// CastExpr represents CAST(expr AS type) or TRY_CAST(expr AS type).
+type CastExpr struct {
+	Expr     Node
+	TypeName *TypeName
+	TryCast  bool // true for TRY_CAST
+	Loc      Loc
+}
+
+func (n *CastExpr) Tag() NodeTag { return T_CastExpr }
+
+var _ Node = (*CastExpr)(nil)
+
+// CaseExpr represents CASE [operand] WHEN...THEN...ELSE...END.
+type CaseExpr struct {
+	Kind    CaseKind
+	Operand Node          // nil for searched CASE
+	Whens   []*WhenClause
+	Else    Node          // nil if no ELSE
+	Loc     Loc
+}
+
+func (n *CaseExpr) Tag() NodeTag { return T_CaseExpr }
+
+var _ Node = (*CaseExpr)(nil)
+
+// WhenClause represents one WHEN cond THEN result arm of a CASE expression.
+type WhenClause struct {
+	Cond   Node
+	Result Node
+	Loc    Loc
+}
+
+func (n *WhenClause) Tag() NodeTag { return T_WhenClause }
+
+var _ Node = (*WhenClause)(nil)
+
+// SubqueryExpr is a placeholder for a subquery appearing in expression
+// position. Real subquery parsing comes in T1.4; for now it stores the
+// raw text between parentheses.
+type SubqueryExpr struct {
+	RawText string // raw SQL text of the subquery (without outer parens)
+	Loc     Loc
+}
+
+func (n *SubqueryExpr) Tag() NodeTag { return T_SubqueryExpr }
+
+var _ Node = (*SubqueryExpr)(nil)
+
+// ColumnRef represents a qualified column reference used as an expression.
+// It reuses ObjectName for the multipart identifier.
+type ColumnRef struct {
+	Name *ObjectName
+	Loc  Loc
+}
+
+func (n *ColumnRef) Tag() NodeTag { return T_ColumnRef }
+
+var _ Node = (*ColumnRef)(nil)
+
+// Literal represents a literal value: numeric, string, boolean, or NULL.
+type Literal struct {
+	Kind  LitKind
+	Value string // original source text
+	Loc   Loc
+}
+
+func (n *Literal) Tag() NodeTag { return T_Literal }
+
+var _ Node = (*Literal)(nil)
+
+// ParenExpr represents a parenthesized expression: (expr).
+type ParenExpr struct {
+	Expr Node
+	Loc  Loc
+}
+
+func (n *ParenExpr) Tag() NodeTag { return T_ParenExpr }
+
+var _ Node = (*ParenExpr)(nil)
+
+// ExistsExpr represents EXISTS (subquery).
+type ExistsExpr struct {
+	Subquery *SubqueryExpr
+	Loc      Loc
+}
+
+func (n *ExistsExpr) Tag() NodeTag { return T_ExistsExpr }
+
+var _ Node = (*ExistsExpr)(nil)
+
+// IntervalExpr represents INTERVAL expr unit.
+type IntervalExpr struct {
+	Value Node
+	Unit  string // e.g., "DAY", "HOUR", "MINUTE", "SECOND", "MONTH", "YEAR"
+	Loc   Loc
+}
+
+func (n *IntervalExpr) Tag() NodeTag { return T_IntervalExpr }
+
+var _ Node = (*IntervalExpr)(nil)
+
+// OrderByItem represents an expression with optional ASC/DESC and NULLS FIRST/LAST.
+type OrderByItem struct {
+	Expr       Node
+	Desc       bool   // true for DESC, false for ASC (default)
+	NullsFirst *bool  // nil if not specified; true for NULLS FIRST, false for NULLS LAST
+	Loc        Loc
+}
+
+func (n *OrderByItem) Tag() NodeTag { return T_OrderByItem }
+
+var _ Node = (*OrderByItem)(nil)

--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -30,6 +30,42 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *Property:
 		return v.Loc
+	case *BinaryExpr:
+		return v.Loc
+	case *UnaryExpr:
+		return v.Loc
+	case *IsExpr:
+		return v.Loc
+	case *BetweenExpr:
+		return v.Loc
+	case *InExpr:
+		return v.Loc
+	case *LikeExpr:
+		return v.Loc
+	case *RegexpExpr:
+		return v.Loc
+	case *FuncCallExpr:
+		return v.Loc
+	case *CastExpr:
+		return v.Loc
+	case *CaseExpr:
+		return v.Loc
+	case *WhenClause:
+		return v.Loc
+	case *SubqueryExpr:
+		return v.Loc
+	case *ColumnRef:
+		return v.Loc
+	case *Literal:
+		return v.Loc
+	case *ParenExpr:
+		return v.Loc
+	case *ExistsExpr:
+		return v.Loc
+	case *IntervalExpr:
+		return v.Loc
+	case *OrderByItem:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -47,6 +47,62 @@ const (
 
 	// T_Property is the tag for *Property, a key=value pair in PROPERTIES clauses.
 	T_Property
+
+	// Expression nodes (T1.3).
+
+	// T_BinaryExpr is the tag for *BinaryExpr (left op right).
+	T_BinaryExpr
+
+	// T_UnaryExpr is the tag for *UnaryExpr (op expr).
+	T_UnaryExpr
+
+	// T_IsExpr is the tag for *IsExpr (expr IS [NOT] NULL/TRUE/FALSE).
+	T_IsExpr
+
+	// T_BetweenExpr is the tag for *BetweenExpr (expr [NOT] BETWEEN low AND high).
+	T_BetweenExpr
+
+	// T_InExpr is the tag for *InExpr (expr [NOT] IN (...)).
+	T_InExpr
+
+	// T_LikeExpr is the tag for *LikeExpr (expr [NOT] LIKE pattern [ESCAPE esc]).
+	T_LikeExpr
+
+	// T_RegexpExpr is the tag for *RegexpExpr (expr [NOT] REGEXP/RLIKE pattern).
+	T_RegexpExpr
+
+	// T_FuncCallExpr is the tag for *FuncCallExpr (name(args...)).
+	T_FuncCallExpr
+
+	// T_CastExpr is the tag for *CastExpr (CAST/TRY_CAST).
+	T_CastExpr
+
+	// T_CaseExpr is the tag for *CaseExpr (CASE...END).
+	T_CaseExpr
+
+	// T_WhenClause is the tag for *WhenClause (WHEN cond THEN result).
+	T_WhenClause
+
+	// T_SubqueryExpr is the tag for *SubqueryExpr (placeholder for subqueries).
+	T_SubqueryExpr
+
+	// T_ColumnRef is the tag for *ColumnRef (qualified column reference).
+	T_ColumnRef
+
+	// T_Literal is the tag for *Literal (numeric, string, boolean, NULL).
+	T_Literal
+
+	// T_ParenExpr is the tag for *ParenExpr ((expr)).
+	T_ParenExpr
+
+	// T_ExistsExpr is the tag for *ExistsExpr (EXISTS (subquery)).
+	T_ExistsExpr
+
+	// T_IntervalExpr is the tag for *IntervalExpr (INTERVAL expr unit).
+	T_IntervalExpr
+
+	// T_OrderByItem is the tag for *OrderByItem (expr ASC/DESC NULLS FIRST/LAST).
+	T_OrderByItem
 )
 
 // String returns a human-readable representation of the tag.
@@ -74,6 +130,42 @@ func (t NodeTag) String() string {
 		return "DropDatabaseStmt"
 	case T_Property:
 		return "Property"
+	case T_BinaryExpr:
+		return "BinaryExpr"
+	case T_UnaryExpr:
+		return "UnaryExpr"
+	case T_IsExpr:
+		return "IsExpr"
+	case T_BetweenExpr:
+		return "BetweenExpr"
+	case T_InExpr:
+		return "InExpr"
+	case T_LikeExpr:
+		return "LikeExpr"
+	case T_RegexpExpr:
+		return "RegexpExpr"
+	case T_FuncCallExpr:
+		return "FuncCallExpr"
+	case T_CastExpr:
+		return "CastExpr"
+	case T_CaseExpr:
+		return "CaseExpr"
+	case T_WhenClause:
+		return "WhenClause"
+	case T_SubqueryExpr:
+		return "SubqueryExpr"
+	case T_ColumnRef:
+		return "ColumnRef"
+	case T_Literal:
+		return "Literal"
+	case T_ParenExpr:
+		return "ParenExpr"
+	case T_ExistsExpr:
+		return "ExistsExpr"
+	case T_IntervalExpr:
+		return "IntervalExpr"
+	case T_OrderByItem:
+		return "OrderByItem"
 	default:
 		return "Unknown"
 	}

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -47,5 +47,66 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Name)
 	case *Property:
 		// leaf node, no children
+
+	// Expression nodes (T1.3).
+	case *BinaryExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *UnaryExpr:
+		Walk(v, n.Expr)
+	case *IsExpr:
+		Walk(v, n.Expr)
+	case *BetweenExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Low)
+		Walk(v, n.High)
+	case *InExpr:
+		Walk(v, n.Expr)
+		walkNodes(v, n.Values)
+	case *LikeExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Pattern)
+		if n.Escape != nil {
+			Walk(v, n.Escape)
+		}
+	case *RegexpExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Pattern)
+	case *FuncCallExpr:
+		Walk(v, n.Name)
+		walkNodes(v, n.Args)
+		for _, item := range n.OrderBy {
+			Walk(v, item)
+		}
+	case *CastExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.TypeName)
+	case *CaseExpr:
+		if n.Operand != nil {
+			Walk(v, n.Operand)
+		}
+		for _, w := range n.Whens {
+			Walk(v, w)
+		}
+		if n.Else != nil {
+			Walk(v, n.Else)
+		}
+	case *WhenClause:
+		Walk(v, n.Cond)
+		Walk(v, n.Result)
+	case *SubqueryExpr:
+		// placeholder leaf — no parsed children yet
+	case *ColumnRef:
+		Walk(v, n.Name)
+	case *Literal:
+		// leaf node, no children
+	case *ParenExpr:
+		Walk(v, n.Expr)
+	case *ExistsExpr:
+		Walk(v, n.Subquery)
+	case *IntervalExpr:
+		Walk(v, n.Value)
+	case *OrderByItem:
+		Walk(v, n.Expr)
 	}
 }

--- a/doris/parser/expr.go
+++ b/doris/parser/expr.go
@@ -1,0 +1,965 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// Binding power constants for Pratt parsing (low to high).
+// Doris operator precedence from DorisParser.g4:
+//
+//	OR / || < XOR < AND / && < NOT (prefix) < predicates/comparison <
+//	bitwise | < bitwise & < shifts << >> < add +- < mul */% DIV MOD <
+//	bitwise ^ < unary (-, +, ~) < primary
+const (
+	bpNone    = 0
+	bpOr      = 10 // OR, ||
+	bpXor     = 15 // XOR
+	bpAnd     = 20 // AND, &&
+	bpNot     = 25 // NOT (prefix)
+	bpPred    = 30 // IS, BETWEEN, IN, LIKE, REGEXP/RLIKE
+	bpCmp     = 35 // =, <, >, <=, >=, <>, !=, <=>
+	bpBitOr   = 40 // |
+	bpBitAnd  = 45 // &
+	bpShift   = 50 // <<, >>
+	bpAdd     = 55 // +, -
+	bpMul     = 60 // *, /, %, DIV
+	bpBitXor  = 65 // ^
+	bpUnary   = 70 // unary -, +, ~
+	bpPrimary = 80 // atoms
+)
+
+// ---------------------------------------------------------------------------
+// Core Pratt loop
+// ---------------------------------------------------------------------------
+
+// parseExpr is the entry point for expression parsing.
+func (p *Parser) parseExpr() (ast.Node, error) {
+	return p.parseExprPrec(bpNone + 1)
+}
+
+// parseExprPrec parses an expression with the given minimum binding power.
+func (p *Parser) parseExprPrec(minBP int) (ast.Node, error) {
+	left, err := p.parsePrefixExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		bp, op, special, ok := p.infixBindingPower()
+		if !ok || bp < minBP {
+			break
+		}
+
+		if special != "" {
+			switch special {
+			case "IS":
+				left, err = p.parseIsExpr(left)
+			case "BETWEEN":
+				left, err = p.parseBetweenExpr(left, false)
+			case "NOT_BETWEEN":
+				left, err = p.parseBetweenExpr(left, true)
+			case "IN":
+				left, err = p.parseInExpr(left, false)
+			case "NOT_IN":
+				left, err = p.parseInExpr(left, true)
+			case "LIKE":
+				left, err = p.parseLikeExpr(left, false)
+			case "NOT_LIKE":
+				left, err = p.parseLikeExpr(left, true)
+			case "REGEXP":
+				left, err = p.parseRegexpExpr(left, false)
+			case "NOT_REGEXP":
+				left, err = p.parseRegexpExpr(left, true)
+			}
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		// Regular binary operator: consume the operator, parse right side.
+		p.advance()
+		right, err := p.parseExprPrec(bp + 1)
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{
+			Op:    op,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(right).End},
+		}
+	}
+
+	return left, nil
+}
+
+// infixBindingPower returns (bp, op, special, ok) for the current token.
+// If special is non-empty, the caller must dispatch to the named handler
+// instead of building a BinaryExpr.
+func (p *Parser) infixBindingPower() (int, ast.BinaryOp, string, bool) {
+	switch p.cur.Kind {
+	// Logical
+	case kwOR, tokDoublePipes:
+		return bpOr, ast.BinOr, "", true
+	case kwXOR:
+		return bpXor, ast.BinXor, "", true
+	case kwAND, tokLogicalAnd:
+		return bpAnd, ast.BinAnd, "", true
+
+	// NOT as infix prefix for BETWEEN, IN, LIKE, REGEXP/RLIKE
+	case kwNOT:
+		next := p.peekNext()
+		switch next.Kind {
+		case kwBETWEEN:
+			return bpPred, 0, "NOT_BETWEEN", true
+		case kwIN:
+			return bpPred, 0, "NOT_IN", true
+		case kwLIKE:
+			return bpPred, 0, "NOT_LIKE", true
+		case kwREGEXP, kwRLIKE:
+			return bpPred, 0, "NOT_REGEXP", true
+		}
+		return 0, 0, "", false
+
+	// Predicates
+	case kwIS:
+		return bpPred, 0, "IS", true
+	case kwBETWEEN:
+		return bpPred, 0, "BETWEEN", true
+	case kwIN:
+		return bpPred, 0, "IN", true
+	case kwLIKE:
+		return bpPred, 0, "LIKE", true
+	case kwREGEXP, kwRLIKE:
+		return bpPred, 0, "REGEXP", true
+
+	// Comparison operators
+	case int('='):
+		return bpCmp, ast.BinEq, "", true
+	case tokNotEq:
+		return bpCmp, ast.BinNe, "", true
+	case int('<'):
+		return bpCmp, ast.BinLt, "", true
+	case int('>'):
+		return bpCmp, ast.BinGt, "", true
+	case tokLessEq:
+		return bpCmp, ast.BinLe, "", true
+	case tokGreaterEq:
+		return bpCmp, ast.BinGe, "", true
+	case tokNullSafeEq:
+		return bpCmp, ast.BinNullSafeEq, "", true
+
+	// Bitwise OR
+	case int('|'):
+		return bpBitOr, ast.BinBitOr, "", true
+
+	// Bitwise AND
+	case int('&'):
+		return bpBitAnd, ast.BinBitAnd, "", true
+
+	// Shifts
+	case tokShiftLeft:
+		return bpShift, ast.BinShiftLeft, "", true
+	case tokShiftRight:
+		return bpShift, ast.BinShiftRight, "", true
+
+	// Addition / subtraction
+	case int('+'):
+		return bpAdd, ast.BinAdd, "", true
+	case int('-'):
+		return bpAdd, ast.BinSub, "", true
+
+	// Multiplication / division / modulo
+	case int('*'):
+		return bpMul, ast.BinMul, "", true
+	case int('/'):
+		return bpMul, ast.BinDiv, "", true
+	case int('%'):
+		return bpMul, ast.BinMod, "", true
+	case kwDIV:
+		return bpMul, ast.BinIntDiv, "", true
+
+	// Bitwise XOR
+	case int('^'):
+		return bpBitXor, ast.BinBitXor, "", true
+	}
+
+	return 0, 0, "", false
+}
+
+// ---------------------------------------------------------------------------
+// Prefix dispatch
+// ---------------------------------------------------------------------------
+
+// parsePrefixExpr handles prefix unary operators (-, +, ~, NOT) and delegates
+// everything else to parsePrimaryExpr.
+func (p *Parser) parsePrefixExpr() (ast.Node, error) {
+	switch p.cur.Kind {
+	case int('-'):
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryMinus,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case int('+'):
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryPlus,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case int('~'):
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpUnary)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryBitNot,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case kwNOT:
+		// NOT as a prefix unary operator. Only if the next token does NOT form
+		// an infix predicate (NOT BETWEEN, NOT IN, NOT LIKE, NOT REGEXP/RLIKE).
+		// In the prefix case we are at the start of an expression, so NOT always
+		// acts as prefix.
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpNot)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryNot,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
+	case kwEXISTS:
+		return p.parseExistsExpr()
+
+	case kwINTERVAL:
+		return p.parseIntervalExpr()
+
+	default:
+		return p.parsePrimaryExpr()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primary expression dispatch
+// ---------------------------------------------------------------------------
+
+// parsePrimaryExpr parses atomic expressions: literals, identifiers,
+// function calls, parenthesized expressions, CASE, CAST, etc.
+func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
+	switch p.cur.Kind {
+	case tokInt:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitInt,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokFloat:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitFloat,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokString:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitString,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case kwTRUE:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitBool,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case kwFALSE:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitBool,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case kwNULL:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitNull,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case int('('):
+		return p.parseParenExprOrSubquery()
+
+	case kwCASE:
+		return p.parseCaseExpr()
+
+	case kwCAST:
+		return p.parseCastExpr(false)
+
+	case kwTRY_CAST:
+		return p.parseCastExpr(true)
+
+	// Nilary functions: CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP,
+	// CURRENT_USER, SESSION_USER, LOCALTIME, LOCALTIMESTAMP.
+	case kwCURRENT_DATE, kwCURRENT_TIME, kwCURRENT_TIMESTAMP,
+		kwCURRENT_USER, kwSESSION_USER, kwLOCALTIME, kwLOCALTIMESTAMP:
+		return p.parseNilaryFunction()
+
+	case tokPlaceholder:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitNull, // placeholder treated as a null-ish literal
+			Value: "?",
+			Loc:   tok.Loc,
+		}, nil
+
+	default:
+		// Identifier-based: column ref or function call.
+		if p.isExprIdentToken() {
+			return p.parseIdentExpr()
+		}
+
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// isExprIdentToken reports whether the current token is usable as an identifier
+// in expression context: tokIdent, tokQuotedIdent, or a non-reserved keyword.
+func (p *Parser) isExprIdentToken() bool {
+	switch p.cur.Kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		return p.cur.Kind >= 700 && !IsReserved(p.cur.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primary expression helpers
+// ---------------------------------------------------------------------------
+
+// parseIdentExpr parses an identifier that could be a column ref or function
+// call (name followed by '(').
+func (p *Parser) parseIdentExpr() (ast.Node, error) {
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for function call: name(
+	if p.cur.Kind == int('(') {
+		return p.parseFuncCall(name)
+	}
+
+	// Simple or qualified column reference.
+	return &ast.ColumnRef{
+		Name: name,
+		Loc:  name.Loc,
+	}, nil
+}
+
+// parseFuncCall parses a function call starting at the opening '('.
+// The function name has already been parsed as an ObjectName.
+func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) {
+	p.advance() // consume '('
+
+	funcName := strings.ToUpper(name.Parts[len(name.Parts)-1])
+	fc := &ast.FuncCallExpr{
+		Name: name,
+		Loc:  ast.Loc{Start: name.Loc.Start},
+	}
+
+	// COUNT(*) special handling
+	if funcName == "COUNT" && p.cur.Kind == int('*') {
+		p.advance()
+		fc.Star = true
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		fc.Loc.End = closeTok.Loc.End
+		return fc, nil
+	}
+
+	// DISTINCT handling for aggregates like COUNT(DISTINCT x)
+	if p.cur.Kind == kwDISTINCT {
+		p.advance()
+		fc.Distinct = true
+	}
+
+	if p.cur.Kind != int(')') {
+		args, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		fc.Args = args
+
+		// Optional ORDER BY within aggregate functions (e.g., GROUP_CONCAT)
+		if p.cur.Kind == kwORDER {
+			p.advance() // consume ORDER
+			if _, err := p.expect(kwBY); err != nil {
+				return nil, err
+			}
+			orderItems, err := p.parseOrderByList()
+			if err != nil {
+				return nil, err
+			}
+			fc.OrderBy = orderItems
+		}
+
+		// Optional SEPARATOR for GROUP_CONCAT
+		if p.cur.Kind == kwSEPARATOR {
+			p.advance() // consume SEPARATOR
+			if p.cur.Kind != tokString {
+				return nil, &ParseError{
+					Loc: p.cur.Loc,
+					Msg: "expected string after SEPARATOR",
+				}
+			}
+			fc.Separator = p.advance().Str
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	fc.Loc.End = closeTok.Loc.End
+
+	return fc, nil
+}
+
+// parseExprList parses a comma-separated list of expressions.
+func (p *Parser) parseExprList() ([]ast.Node, error) {
+	var list []ast.Node
+	for {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, expr)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return list, nil
+}
+
+// parseOrderByList parses a comma-separated list of ORDER BY items.
+func (p *Parser) parseOrderByList() ([]*ast.OrderByItem, error) {
+	var items []*ast.OrderByItem
+	for {
+		item, err := p.parseOrderByItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return items, nil
+}
+
+// parseOrderByItem parses one ORDER BY item: expr [ASC|DESC] [NULLS FIRST|LAST].
+func (p *Parser) parseOrderByItem() (*ast.OrderByItem, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	item := &ast.OrderByItem{
+		Expr: expr,
+		Loc:  ast.NodeLoc(expr),
+	}
+
+	// Optional ASC/DESC
+	if p.cur.Kind == kwASC {
+		p.advance()
+		item.Desc = false
+		item.Loc.End = p.prev.Loc.End
+	} else if p.cur.Kind == kwDESC {
+		p.advance()
+		item.Desc = true
+		item.Loc.End = p.prev.Loc.End
+	}
+
+	// Optional NULLS FIRST/LAST
+	if p.cur.Kind == kwNULLS {
+		p.advance() // consume NULLS
+		switch p.cur.Kind {
+		case kwFIRST:
+			p.advance()
+			b := true
+			item.NullsFirst = &b
+			item.Loc.End = p.prev.Loc.End
+		case kwLAST:
+			p.advance()
+			b := false
+			item.NullsFirst = &b
+			item.Loc.End = p.prev.Loc.End
+		default:
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "expected FIRST or LAST after NULLS",
+			}
+		}
+	}
+
+	return item, nil
+}
+
+// parseParenExprOrSubquery parses a parenthesized expression or subquery.
+// For subqueries (SELECT/WITH after open paren), we create a placeholder
+// SubqueryExpr that stores the raw text.
+func (p *Parser) parseParenExprOrSubquery() (ast.Node, error) {
+	openTok := p.advance() // consume '('
+
+	// Subquery: (SELECT ...) or (WITH ... SELECT ...)
+	if p.cur.Kind == kwSELECT || p.cur.Kind == kwWITH {
+		return p.parseSubqueryPlaceholder(openTok.Loc.Start)
+	}
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.ParenExpr{
+		Expr: expr,
+		Loc:  ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseSubqueryPlaceholder consumes tokens until the matching closing ')' for
+// a subquery expression and returns a SubqueryExpr with the raw text.
+// startOffset is the byte offset of the opening '(' token.
+func (p *Parser) parseSubqueryPlaceholder(startOffset int) (*ast.SubqueryExpr, error) {
+	depth := 1
+	subStart := p.cur.Loc.Start
+	var subEnd int
+	for depth > 0 && p.cur.Kind != tokEOF {
+		switch p.cur.Kind {
+		case int('('):
+			depth++
+		case int(')'):
+			depth--
+			if depth == 0 {
+				subEnd = p.cur.Loc.Start
+				break
+			}
+		}
+		if depth > 0 {
+			p.advance()
+		}
+	}
+
+	if depth != 0 {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "unterminated subquery",
+		}
+	}
+
+	rawText := p.input[subStart:subEnd]
+	closeTok := p.advance() // consume ')'
+
+	return &ast.SubqueryExpr{
+		RawText: strings.TrimSpace(rawText),
+		Loc:     ast.Loc{Start: startOffset, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseCaseExpr parses a CASE expression (simple or searched).
+func (p *Parser) parseCaseExpr() (*ast.CaseExpr, error) {
+	caseTok := p.advance() // consume CASE
+
+	ce := &ast.CaseExpr{
+		Loc: ast.Loc{Start: caseTok.Loc.Start},
+	}
+
+	// Determine if this is a simple CASE (CASE expr WHEN ...) or
+	// searched CASE (CASE WHEN ...).
+	if p.cur.Kind != kwWHEN {
+		// Simple CASE: parse the operand expression.
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Kind = ast.CaseSimple
+		ce.Operand = operand
+	} else {
+		ce.Kind = ast.CaseSearched
+	}
+
+	// Parse WHEN clauses.
+	for p.cur.Kind == kwWHEN {
+		whenTok := p.advance() // consume WHEN
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		result, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Whens = append(ce.Whens, &ast.WhenClause{
+			Cond:   cond,
+			Result: result,
+			Loc:    ast.Loc{Start: whenTok.Loc.Start, End: ast.NodeLoc(result).End},
+		})
+	}
+
+	if len(ce.Whens) == 0 {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected WHEN in CASE expression",
+		}
+	}
+
+	// Optional ELSE.
+	if p.cur.Kind == kwELSE {
+		p.advance() // consume ELSE
+		elseExpr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Else = elseExpr
+	}
+
+	endTok, err := p.expect(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	ce.Loc.End = endTok.Loc.End
+
+	return ce, nil
+}
+
+// parseCastExpr parses CAST(expr AS type) or TRY_CAST(expr AS type).
+func (p *Parser) parseCastExpr(tryCast bool) (*ast.CastExpr, error) {
+	castTok := p.advance() // consume CAST or TRY_CAST
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	typeName, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CastExpr{
+		Expr:     expr,
+		TypeName: typeName,
+		TryCast:  tryCast,
+		Loc:      ast.Loc{Start: castTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseNilaryFunction parses zero-argument keyword functions like
+// CURRENT_DATE, CURRENT_TIMESTAMP, etc.
+func (p *Parser) parseNilaryFunction() (ast.Node, error) {
+	tok := p.advance()
+	name := strings.ToUpper(tok.Str)
+	objName := &ast.ObjectName{
+		Parts: []string{name},
+		Loc:   tok.Loc,
+	}
+
+	// Some of these may optionally have empty parens: CURRENT_TIMESTAMP()
+	fc := &ast.FuncCallExpr{
+		Name: objName,
+		Loc:  tok.Loc,
+	}
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		fc.Loc.End = closeTok.Loc.End
+	}
+	return fc, nil
+}
+
+// parseExistsExpr parses EXISTS (subquery).
+func (p *Parser) parseExistsExpr() (ast.Node, error) {
+	existsTok := p.advance() // consume EXISTS
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	subq, err := p.parseSubqueryPlaceholder(existsTok.Loc.Start)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.ExistsExpr{
+		Subquery: subq,
+		Loc:      ast.Loc{Start: existsTok.Loc.Start, End: subq.Loc.End},
+	}, nil
+}
+
+// parseIntervalExpr parses INTERVAL expr unit.
+func (p *Parser) parseIntervalExpr() (ast.Node, error) {
+	intervalTok := p.advance() // consume INTERVAL
+
+	value, err := p.parseExprPrec(bpPrimary)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse interval unit keyword
+	unit, err := p.parseIntervalUnit()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.IntervalExpr{
+		Value: value,
+		Unit:  unit,
+		Loc:   ast.Loc{Start: intervalTok.Loc.Start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// parseIntervalUnit parses and returns the interval unit keyword as a string.
+func (p *Parser) parseIntervalUnit() (string, error) {
+	switch p.cur.Kind {
+	case kwYEAR, kwMONTH, kwWEEK, kwDAY, kwHOUR, kwMINUTE, kwSECOND:
+		tok := p.advance()
+		return strings.ToUpper(tok.Str), nil
+	default:
+		// Allow any identifier-like token as a unit for forward compatibility
+		if p.cur.Kind == tokIdent {
+			tok := p.advance()
+			return strings.ToUpper(tok.Str), nil
+		}
+		return "", &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected interval unit, got %q", p.cur.Str),
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Infix/postfix handlers
+// ---------------------------------------------------------------------------
+
+// parseIsExpr parses IS [NOT] NULL/TRUE/FALSE.
+func (p *Parser) parseIsExpr(left ast.Node) (ast.Node, error) {
+	p.advance() // consume IS
+
+	notFlag := false
+	if p.cur.Kind == kwNOT {
+		p.advance()
+		notFlag = true
+	}
+
+	var isWhat string
+	switch p.cur.Kind {
+	case kwNULL:
+		isWhat = "NULL"
+	case kwTRUE:
+		isWhat = "TRUE"
+	case kwFALSE:
+		isWhat = "FALSE"
+	default:
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected NULL, TRUE, or FALSE after IS [NOT]",
+		}
+	}
+	endTok := p.advance()
+
+	return &ast.IsExpr{
+		Expr:   left,
+		Not:    notFlag,
+		IsWhat: isWhat,
+		Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: endTok.Loc.End},
+	}, nil
+}
+
+// parseBetweenExpr parses [NOT] BETWEEN low AND high.
+func (p *Parser) parseBetweenExpr(left ast.Node, notFlag bool) (ast.Node, error) {
+	if notFlag {
+		p.advance() // consume NOT
+	}
+	p.advance() // consume BETWEEN
+
+	// Parse low bound at bpPred+1 to avoid re-consuming AND as an
+	// infix binary operator.
+	low, err := p.parseExprPrec(bpPred + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwAND); err != nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "expected AND in BETWEEN expression",
+		}
+	}
+
+	high, err := p.parseExprPrec(bpPred + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.BetweenExpr{
+		Expr: left,
+		Low:  low,
+		High: high,
+		Not:  notFlag,
+		Loc:  ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(high).End},
+	}, nil
+}
+
+// parseInExpr parses [NOT] IN (values...) or [NOT] IN (subquery).
+func (p *Parser) parseInExpr(left ast.Node, notFlag bool) (ast.Node, error) {
+	if notFlag {
+		p.advance() // consume NOT
+	}
+	p.advance() // consume IN
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// Subquery: IN (SELECT ...) or IN (WITH ... SELECT ...)
+	if p.cur.Kind == kwSELECT || p.cur.Kind == kwWITH {
+		subq, err := p.parseSubqueryPlaceholder(ast.NodeLoc(left).Start)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.InExpr{
+			Expr:   left,
+			Values: []ast.Node{subq},
+			Not:    notFlag,
+			Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: subq.Loc.End},
+		}, nil
+	}
+
+	values, err := p.parseExprList()
+	if err != nil {
+		return nil, err
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.InExpr{
+		Expr:   left,
+		Values: values,
+		Not:    notFlag,
+		Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseLikeExpr parses [NOT] LIKE pattern [ESCAPE esc].
+func (p *Parser) parseLikeExpr(left ast.Node, notFlag bool) (ast.Node, error) {
+	if notFlag {
+		p.advance() // consume NOT
+	}
+	p.advance() // consume LIKE
+
+	pattern, err := p.parseExprPrec(bpPred + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	le := &ast.LikeExpr{
+		Expr:    left,
+		Pattern: pattern,
+		Not:     notFlag,
+		Loc:     ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(pattern).End},
+	}
+
+	// Optional ESCAPE clause
+	if p.cur.Kind == kwESCAPE {
+		p.advance() // consume ESCAPE
+		esc, err := p.parseExprPrec(bpPred + 1)
+		if err != nil {
+			return nil, err
+		}
+		le.Escape = esc
+		le.Loc.End = ast.NodeLoc(esc).End
+	}
+
+	return le, nil
+}
+
+// parseRegexpExpr parses [NOT] REGEXP|RLIKE pattern.
+func (p *Parser) parseRegexpExpr(left ast.Node, notFlag bool) (ast.Node, error) {
+	if notFlag {
+		p.advance() // consume NOT
+	}
+	p.advance() // consume REGEXP or RLIKE
+
+	pattern, err := p.parseExprPrec(bpPred + 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.RegexpExpr{
+		Expr:    left,
+		Pattern: pattern,
+		Not:     notFlag,
+		Loc:     ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(pattern).End},
+	}, nil
+}

--- a/doris/parser/expr_test.go
+++ b/doris/parser/expr_test.go
@@ -1,0 +1,1267 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// parseExprFrom creates a Parser from input and calls parseExpr.
+func parseExprFrom(input string) (ast.Node, error) {
+	p := makeParser(input)
+	return p.parseExpr()
+}
+
+// mustParseExpr is a test helper that calls parseExprFrom and fatals on error.
+func mustParseExpr(t *testing.T, input string) ast.Node {
+	t.Helper()
+	node, err := parseExprFrom(input)
+	if err != nil {
+		t.Fatalf("parseExpr(%q) error: %v", input, err)
+	}
+	if node == nil {
+		t.Fatalf("parseExpr(%q) returned nil", input)
+	}
+	return node
+}
+
+// ---------------------------------------------------------------------------
+// Literals
+// ---------------------------------------------------------------------------
+
+func TestExprLiteralInt(t *testing.T) {
+	node := mustParseExpr(t, "42")
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitInt {
+		t.Errorf("kind = %d, want LitInt", lit.Kind)
+	}
+	if lit.Value != "42" {
+		t.Errorf("value = %q, want %q", lit.Value, "42")
+	}
+}
+
+func TestExprLiteralFloat(t *testing.T) {
+	node := mustParseExpr(t, "3.14")
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitFloat {
+		t.Errorf("kind = %d, want LitFloat", lit.Kind)
+	}
+	if lit.Value != "3.14" {
+		t.Errorf("value = %q, want %q", lit.Value, "3.14")
+	}
+}
+
+func TestExprLiteralString(t *testing.T) {
+	node := mustParseExpr(t, "'hello'")
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitString {
+		t.Errorf("kind = %d, want LitString", lit.Kind)
+	}
+	if lit.Value != "hello" {
+		t.Errorf("value = %q, want %q", lit.Value, "hello")
+	}
+}
+
+func TestExprLiteralTrue(t *testing.T) {
+	node := mustParseExpr(t, "TRUE")
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitBool {
+		t.Errorf("kind = %d, want LitBool", lit.Kind)
+	}
+}
+
+func TestExprLiteralFalse(t *testing.T) {
+	node := mustParseExpr(t, "FALSE")
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitBool {
+		t.Errorf("kind = %d, want LitBool", lit.Kind)
+	}
+}
+
+func TestExprLiteralNull(t *testing.T) {
+	node := mustParseExpr(t, "NULL")
+	lit, ok := node.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected *ast.Literal, got %T", node)
+	}
+	if lit.Kind != ast.LitNull {
+		t.Errorf("kind = %d, want LitNull", lit.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Column references
+// ---------------------------------------------------------------------------
+
+func TestExprColumnRefSimple(t *testing.T) {
+	node := mustParseExpr(t, "col")
+	ref, ok := node.(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("expected *ast.ColumnRef, got %T", node)
+	}
+	if len(ref.Name.Parts) != 1 || ref.Name.Parts[0] != "col" {
+		t.Errorf("parts = %v, want [col]", ref.Name.Parts)
+	}
+}
+
+func TestExprColumnRefQualified(t *testing.T) {
+	node := mustParseExpr(t, "t.col")
+	ref, ok := node.(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("expected *ast.ColumnRef, got %T", node)
+	}
+	if len(ref.Name.Parts) != 2 || ref.Name.Parts[0] != "t" || ref.Name.Parts[1] != "col" {
+		t.Errorf("parts = %v, want [t, col]", ref.Name.Parts)
+	}
+}
+
+func TestExprColumnRefThreePart(t *testing.T) {
+	node := mustParseExpr(t, "db.t.col")
+	ref, ok := node.(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("expected *ast.ColumnRef, got %T", node)
+	}
+	if len(ref.Name.Parts) != 3 {
+		t.Errorf("parts = %v, want [db, t, col]", ref.Name.Parts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Arithmetic
+// ---------------------------------------------------------------------------
+
+func TestExprArithmeticSimple(t *testing.T) {
+	node := mustParseExpr(t, "1 + 2")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAdd {
+		t.Errorf("op = %v, want BinAdd", bin.Op)
+	}
+}
+
+func TestExprArithmeticPrecedence(t *testing.T) {
+	// a * b + c should parse as (a * b) + c
+	node := mustParseExpr(t, "a * b + c")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAdd {
+		t.Errorf("top op = %v, want BinAdd", bin.Op)
+	}
+	leftBin, ok := bin.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected left to be *ast.BinaryExpr, got %T", bin.Left)
+	}
+	if leftBin.Op != ast.BinMul {
+		t.Errorf("left op = %v, want BinMul", leftBin.Op)
+	}
+}
+
+func TestExprArithmeticParens(t *testing.T) {
+	// (a + b) * c
+	node := mustParseExpr(t, "(a + b) * c")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinMul {
+		t.Errorf("top op = %v, want BinMul", bin.Op)
+	}
+	paren, ok := bin.Left.(*ast.ParenExpr)
+	if !ok {
+		t.Fatalf("expected left to be *ast.ParenExpr, got %T", bin.Left)
+	}
+	innerBin, ok := paren.Expr.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected paren inner to be *ast.BinaryExpr, got %T", paren.Expr)
+	}
+	if innerBin.Op != ast.BinAdd {
+		t.Errorf("inner op = %v, want BinAdd", innerBin.Op)
+	}
+}
+
+func TestExprDivMod(t *testing.T) {
+	node := mustParseExpr(t, "10 / 3")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinDiv {
+		t.Errorf("op = %v, want BinDiv", bin.Op)
+	}
+
+	node2 := mustParseExpr(t, "10 % 3")
+	bin2, ok := node2.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node2)
+	}
+	if bin2.Op != ast.BinMod {
+		t.Errorf("op = %v, want BinMod", bin2.Op)
+	}
+}
+
+func TestExprDIVKeyword(t *testing.T) {
+	node := mustParseExpr(t, "10 DIV 3")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinIntDiv {
+		t.Errorf("op = %v, want BinIntDiv", bin.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+func TestExprComparisonEq(t *testing.T) {
+	node := mustParseExpr(t, "a = 1")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinEq {
+		t.Errorf("op = %v, want BinEq", bin.Op)
+	}
+}
+
+func TestExprComparisonNe(t *testing.T) {
+	node := mustParseExpr(t, "a <> b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinNe {
+		t.Errorf("op = %v, want BinNe", bin.Op)
+	}
+}
+
+func TestExprComparisonNeBang(t *testing.T) {
+	node := mustParseExpr(t, "a != b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinNe {
+		t.Errorf("op = %v, want BinNe", bin.Op)
+	}
+}
+
+func TestExprComparisonNullSafe(t *testing.T) {
+	node := mustParseExpr(t, "a <=> b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinNullSafeEq {
+		t.Errorf("op = %v, want BinNullSafeEq", bin.Op)
+	}
+}
+
+func TestExprComparisonGe(t *testing.T) {
+	node := mustParseExpr(t, "a >= 1")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinGe {
+		t.Errorf("op = %v, want BinGe", bin.Op)
+	}
+}
+
+func TestExprComparisonLt(t *testing.T) {
+	node := mustParseExpr(t, "a < 1")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinLt {
+		t.Errorf("op = %v, want BinLt", bin.Op)
+	}
+}
+
+func TestExprComparisonGt(t *testing.T) {
+	node := mustParseExpr(t, "a > 1")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinGt {
+		t.Errorf("op = %v, want BinGt", bin.Op)
+	}
+}
+
+func TestExprComparisonLe(t *testing.T) {
+	node := mustParseExpr(t, "a <= 1")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinLe {
+		t.Errorf("op = %v, want BinLe", bin.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Logical operators
+// ---------------------------------------------------------------------------
+
+func TestExprLogicalAnd(t *testing.T) {
+	node := mustParseExpr(t, "a AND b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAnd {
+		t.Errorf("op = %v, want BinAnd", bin.Op)
+	}
+}
+
+func TestExprLogicalOr(t *testing.T) {
+	node := mustParseExpr(t, "a OR b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinOr {
+		t.Errorf("op = %v, want BinOr", bin.Op)
+	}
+}
+
+func TestExprLogicalXor(t *testing.T) {
+	node := mustParseExpr(t, "a XOR b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinXor {
+		t.Errorf("op = %v, want BinXor", bin.Op)
+	}
+}
+
+func TestExprLogicalNot(t *testing.T) {
+	node := mustParseExpr(t, "NOT a")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if un.Op != ast.UnaryNot {
+		t.Errorf("op = %v, want UnaryNot", un.Op)
+	}
+}
+
+func TestExprLogicalPrecedence(t *testing.T) {
+	// a AND b OR c should parse as (a AND b) OR c
+	node := mustParseExpr(t, "a AND b OR c")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinOr {
+		t.Errorf("top op = %v, want BinOr", bin.Op)
+	}
+	leftBin, ok := bin.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected left to be *ast.BinaryExpr, got %T", bin.Left)
+	}
+	if leftBin.Op != ast.BinAnd {
+		t.Errorf("left op = %v, want BinAnd", leftBin.Op)
+	}
+}
+
+func TestExprLogicalAndSymbol(t *testing.T) {
+	node := mustParseExpr(t, "a && b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAnd {
+		t.Errorf("op = %v, want BinAnd", bin.Op)
+	}
+}
+
+func TestExprLogicalOrSymbol(t *testing.T) {
+	node := mustParseExpr(t, "a || b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinOr {
+		t.Errorf("op = %v, want BinOr", bin.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IS expressions
+// ---------------------------------------------------------------------------
+
+func TestExprIsNull(t *testing.T) {
+	node := mustParseExpr(t, "a IS NULL")
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if is.Not {
+		t.Error("expected Not=false")
+	}
+	if is.IsWhat != "NULL" {
+		t.Errorf("IsWhat = %q, want %q", is.IsWhat, "NULL")
+	}
+}
+
+func TestExprIsNotNull(t *testing.T) {
+	node := mustParseExpr(t, "a IS NOT NULL")
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if !is.Not {
+		t.Error("expected Not=true")
+	}
+	if is.IsWhat != "NULL" {
+		t.Errorf("IsWhat = %q, want %q", is.IsWhat, "NULL")
+	}
+}
+
+func TestExprIsTrue(t *testing.T) {
+	node := mustParseExpr(t, "a IS TRUE")
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if is.IsWhat != "TRUE" {
+		t.Errorf("IsWhat = %q, want %q", is.IsWhat, "TRUE")
+	}
+}
+
+func TestExprIsNotFalse(t *testing.T) {
+	node := mustParseExpr(t, "a IS NOT FALSE")
+	is, ok := node.(*ast.IsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IsExpr, got %T", node)
+	}
+	if !is.Not {
+		t.Error("expected Not=true")
+	}
+	if is.IsWhat != "FALSE" {
+		t.Errorf("IsWhat = %q, want %q", is.IsWhat, "FALSE")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BETWEEN
+// ---------------------------------------------------------------------------
+
+func TestExprBetween(t *testing.T) {
+	node := mustParseExpr(t, "a BETWEEN 1 AND 10")
+	btw, ok := node.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T", node)
+	}
+	if btw.Not {
+		t.Error("expected Not=false")
+	}
+
+	// Verify low and high are literals
+	lowLit, ok := btw.Low.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected Low to be *ast.Literal, got %T", btw.Low)
+	}
+	if lowLit.Value != "1" {
+		t.Errorf("low = %q, want %q", lowLit.Value, "1")
+	}
+
+	highLit, ok := btw.High.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected High to be *ast.Literal, got %T", btw.High)
+	}
+	if highLit.Value != "10" {
+		t.Errorf("high = %q, want %q", highLit.Value, "10")
+	}
+}
+
+func TestExprNotBetween(t *testing.T) {
+	node := mustParseExpr(t, "a NOT BETWEEN 1 AND 10")
+	btw, ok := node.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T", node)
+	}
+	if !btw.Not {
+		t.Error("expected Not=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IN
+// ---------------------------------------------------------------------------
+
+func TestExprIn(t *testing.T) {
+	node := mustParseExpr(t, "a IN (1, 2, 3)")
+	in, ok := node.(*ast.InExpr)
+	if !ok {
+		t.Fatalf("expected *ast.InExpr, got %T", node)
+	}
+	if in.Not {
+		t.Error("expected Not=false")
+	}
+	if len(in.Values) != 3 {
+		t.Errorf("len(Values) = %d, want 3", len(in.Values))
+	}
+}
+
+func TestExprNotIn(t *testing.T) {
+	node := mustParseExpr(t, "a NOT IN (1, 2)")
+	in, ok := node.(*ast.InExpr)
+	if !ok {
+		t.Fatalf("expected *ast.InExpr, got %T", node)
+	}
+	if !in.Not {
+		t.Error("expected Not=true")
+	}
+	if len(in.Values) != 2 {
+		t.Errorf("len(Values) = %d, want 2", len(in.Values))
+	}
+}
+
+func TestExprInSubquery(t *testing.T) {
+	node := mustParseExpr(t, "a IN (SELECT id FROM t)")
+	in, ok := node.(*ast.InExpr)
+	if !ok {
+		t.Fatalf("expected *ast.InExpr, got %T", node)
+	}
+	if len(in.Values) != 1 {
+		t.Fatalf("len(Values) = %d, want 1", len(in.Values))
+	}
+	subq, ok := in.Values[0].(*ast.SubqueryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.SubqueryExpr, got %T", in.Values[0])
+	}
+	if subq.RawText != "SELECT id FROM t" {
+		t.Errorf("RawText = %q, want %q", subq.RawText, "SELECT id FROM t")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LIKE
+// ---------------------------------------------------------------------------
+
+func TestExprLike(t *testing.T) {
+	node := mustParseExpr(t, "a LIKE '%foo%'")
+	like, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if like.Not {
+		t.Error("expected Not=false")
+	}
+	pat, ok := like.Pattern.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected Pattern to be *ast.Literal, got %T", like.Pattern)
+	}
+	if pat.Value != "%foo%" {
+		t.Errorf("pattern = %q, want %q", pat.Value, "%foo%")
+	}
+}
+
+func TestExprNotLike(t *testing.T) {
+	node := mustParseExpr(t, "a NOT LIKE 'bar'")
+	like, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if !like.Not {
+		t.Error("expected Not=true")
+	}
+}
+
+func TestExprLikeEscape(t *testing.T) {
+	node := mustParseExpr(t, "a NOT LIKE 'bar' ESCAPE '\\\\'")
+	like, ok := node.(*ast.LikeExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LikeExpr, got %T", node)
+	}
+	if like.Escape == nil {
+		t.Fatal("expected non-nil Escape")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REGEXP / RLIKE
+// ---------------------------------------------------------------------------
+
+func TestExprRegexp(t *testing.T) {
+	node := mustParseExpr(t, "a REGEXP '^[0-9]+'")
+	re, ok := node.(*ast.RegexpExpr)
+	if !ok {
+		t.Fatalf("expected *ast.RegexpExpr, got %T", node)
+	}
+	if re.Not {
+		t.Error("expected Not=false")
+	}
+}
+
+func TestExprRLike(t *testing.T) {
+	node := mustParseExpr(t, "a RLIKE '^abc'")
+	re, ok := node.(*ast.RegexpExpr)
+	if !ok {
+		t.Fatalf("expected *ast.RegexpExpr, got %T", node)
+	}
+	if re.Not {
+		t.Error("expected Not=false")
+	}
+}
+
+func TestExprNotRegexp(t *testing.T) {
+	node := mustParseExpr(t, "a NOT REGEXP '^[0-9]+'")
+	re, ok := node.(*ast.RegexpExpr)
+	if !ok {
+		t.Fatalf("expected *ast.RegexpExpr, got %T", node)
+	}
+	if !re.Not {
+		t.Error("expected Not=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CAST / TRY_CAST
+// ---------------------------------------------------------------------------
+
+func TestExprCast(t *testing.T) {
+	node := mustParseExpr(t, "CAST(a AS INT)")
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if cast.TryCast {
+		t.Error("expected TryCast=false")
+	}
+	if cast.TypeName.Name != "INT" {
+		t.Errorf("type = %q, want %q", cast.TypeName.Name, "INT")
+	}
+}
+
+func TestExprTryCast(t *testing.T) {
+	node := mustParseExpr(t, "TRY_CAST(a AS VARCHAR(255))")
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if !cast.TryCast {
+		t.Error("expected TryCast=true")
+	}
+	if cast.TypeName.Name != "VARCHAR" {
+		t.Errorf("type = %q, want %q", cast.TypeName.Name, "VARCHAR")
+	}
+	if len(cast.TypeName.Params) != 1 || cast.TypeName.Params[0] != 255 {
+		t.Errorf("params = %v, want [255]", cast.TypeName.Params)
+	}
+}
+
+func TestExprCastComplex(t *testing.T) {
+	node := mustParseExpr(t, "CAST(a + b AS DECIMAL(10,2))")
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	// Inner expression should be a + b
+	bin, ok := cast.Expr.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected inner to be *ast.BinaryExpr, got %T", cast.Expr)
+	}
+	if bin.Op != ast.BinAdd {
+		t.Errorf("inner op = %v, want BinAdd", bin.Op)
+	}
+	if cast.TypeName.Name != "DECIMAL" {
+		t.Errorf("type = %q, want %q", cast.TypeName.Name, "DECIMAL")
+	}
+	if len(cast.TypeName.Params) != 2 || cast.TypeName.Params[0] != 10 || cast.TypeName.Params[1] != 2 {
+		t.Errorf("params = %v, want [10,2]", cast.TypeName.Params)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CASE expressions
+// ---------------------------------------------------------------------------
+
+func TestExprCaseSearched(t *testing.T) {
+	node := mustParseExpr(t, "CASE WHEN a > 1 THEN 'yes' ELSE 'no' END")
+	ce, ok := node.(*ast.CaseExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CaseExpr, got %T", node)
+	}
+	if ce.Kind != ast.CaseSearched {
+		t.Errorf("kind = %d, want CaseSearched", ce.Kind)
+	}
+	if ce.Operand != nil {
+		t.Error("expected nil Operand for searched CASE")
+	}
+	if len(ce.Whens) != 1 {
+		t.Errorf("len(Whens) = %d, want 1", len(ce.Whens))
+	}
+	if ce.Else == nil {
+		t.Error("expected non-nil Else")
+	}
+}
+
+func TestExprCaseSimple(t *testing.T) {
+	node := mustParseExpr(t, "CASE a WHEN 1 THEN 'one' WHEN 2 THEN 'two' END")
+	ce, ok := node.(*ast.CaseExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CaseExpr, got %T", node)
+	}
+	if ce.Kind != ast.CaseSimple {
+		t.Errorf("kind = %d, want CaseSimple", ce.Kind)
+	}
+	if ce.Operand == nil {
+		t.Fatal("expected non-nil Operand for simple CASE")
+	}
+	if len(ce.Whens) != 2 {
+		t.Errorf("len(Whens) = %d, want 2", len(ce.Whens))
+	}
+	if ce.Else != nil {
+		t.Error("expected nil Else")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Function calls
+// ---------------------------------------------------------------------------
+
+func TestExprFuncCountStar(t *testing.T) {
+	node := mustParseExpr(t, "COUNT(*)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if !fc.Star {
+		t.Error("expected Star=true")
+	}
+}
+
+func TestExprFuncSum(t *testing.T) {
+	node := mustParseExpr(t, "SUM(a)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("len(Args) = %d, want 1", len(fc.Args))
+	}
+}
+
+func TestExprFuncCoalesce(t *testing.T) {
+	node := mustParseExpr(t, "COALESCE(a, b, c)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 3 {
+		t.Errorf("len(Args) = %d, want 3", len(fc.Args))
+	}
+}
+
+func TestExprFuncCountDistinct(t *testing.T) {
+	node := mustParseExpr(t, "COUNT(DISTINCT a)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if !fc.Distinct {
+		t.Error("expected Distinct=true")
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("len(Args) = %d, want 1", len(fc.Args))
+	}
+}
+
+func TestExprFuncNoArgs(t *testing.T) {
+	node := mustParseExpr(t, "NOW()")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 0 {
+		t.Errorf("len(Args) = %d, want 0", len(fc.Args))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nilary functions
+// ---------------------------------------------------------------------------
+
+func TestExprCurrentDate(t *testing.T) {
+	node := mustParseExpr(t, "CURRENT_DATE")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Name.Parts[0] != "CURRENT_DATE" {
+		t.Errorf("name = %q, want %q", fc.Name.Parts[0], "CURRENT_DATE")
+	}
+}
+
+func TestExprCurrentTimestamp(t *testing.T) {
+	node := mustParseExpr(t, "CURRENT_TIMESTAMP")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Name.Parts[0] != "CURRENT_TIMESTAMP" {
+		t.Errorf("name = %q, want %q", fc.Name.Parts[0], "CURRENT_TIMESTAMP")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unary operators
+// ---------------------------------------------------------------------------
+
+func TestExprUnaryMinus(t *testing.T) {
+	node := mustParseExpr(t, "-a")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if un.Op != ast.UnaryMinus {
+		t.Errorf("op = %v, want UnaryMinus", un.Op)
+	}
+}
+
+func TestExprUnaryPlus(t *testing.T) {
+	node := mustParseExpr(t, "+a")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if un.Op != ast.UnaryPlus {
+		t.Errorf("op = %v, want UnaryPlus", un.Op)
+	}
+}
+
+func TestExprUnaryBitNot(t *testing.T) {
+	node := mustParseExpr(t, "~a")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if un.Op != ast.UnaryBitNot {
+		t.Errorf("op = %v, want UnaryBitNot", un.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bitwise operators
+// ---------------------------------------------------------------------------
+
+func TestExprBitwiseOr(t *testing.T) {
+	node := mustParseExpr(t, "a | b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinBitOr {
+		t.Errorf("op = %v, want BinBitOr", bin.Op)
+	}
+}
+
+func TestExprBitwiseAnd(t *testing.T) {
+	node := mustParseExpr(t, "a & b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinBitAnd {
+		t.Errorf("op = %v, want BinBitAnd", bin.Op)
+	}
+}
+
+func TestExprBitwiseXor(t *testing.T) {
+	node := mustParseExpr(t, "a ^ b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinBitXor {
+		t.Errorf("op = %v, want BinBitXor", bin.Op)
+	}
+}
+
+func TestExprShiftLeft(t *testing.T) {
+	node := mustParseExpr(t, "a << 2")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinShiftLeft {
+		t.Errorf("op = %v, want BinShiftLeft", bin.Op)
+	}
+}
+
+func TestExprShiftRight(t *testing.T) {
+	node := mustParseExpr(t, "a >> 2")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinShiftRight {
+		t.Errorf("op = %v, want BinShiftRight", bin.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nested / complex expressions
+// ---------------------------------------------------------------------------
+
+func TestExprNestedComplex(t *testing.T) {
+	// a > 0 AND (b IN (1,2) OR c IS NOT NULL)
+	node := mustParseExpr(t, "a > 0 AND (b IN (1,2) OR c IS NOT NULL)")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAnd {
+		t.Errorf("top op = %v, want BinAnd", bin.Op)
+	}
+
+	// Left should be a > 0
+	leftBin, ok := bin.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected left to be *ast.BinaryExpr, got %T", bin.Left)
+	}
+	if leftBin.Op != ast.BinGt {
+		t.Errorf("left op = %v, want BinGt", leftBin.Op)
+	}
+
+	// Right should be a ParenExpr containing an OR
+	paren, ok := bin.Right.(*ast.ParenExpr)
+	if !ok {
+		t.Fatalf("expected right to be *ast.ParenExpr, got %T", bin.Right)
+	}
+	orBin, ok := paren.Expr.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected paren inner to be *ast.BinaryExpr, got %T", paren.Expr)
+	}
+	if orBin.Op != ast.BinOr {
+		t.Errorf("paren inner op = %v, want BinOr", orBin.Op)
+	}
+}
+
+func TestExprNotWithPrecedence(t *testing.T) {
+	// NOT a OR b should parse as (NOT a) OR b
+	node := mustParseExpr(t, "NOT a OR b")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinOr {
+		t.Errorf("top op = %v, want BinOr", bin.Op)
+	}
+	un, ok := bin.Left.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected left to be *ast.UnaryExpr, got %T", bin.Left)
+	}
+	if un.Op != ast.UnaryNot {
+		t.Errorf("left op = %v, want UnaryNot", un.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// INTERVAL
+// ---------------------------------------------------------------------------
+
+func TestExprInterval(t *testing.T) {
+	node := mustParseExpr(t, "INTERVAL 1 DAY")
+	iv, ok := node.(*ast.IntervalExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IntervalExpr, got %T", node)
+	}
+	if iv.Unit != "DAY" {
+		t.Errorf("unit = %q, want %q", iv.Unit, "DAY")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXISTS
+// ---------------------------------------------------------------------------
+
+func TestExprExists(t *testing.T) {
+	node := mustParseExpr(t, "EXISTS (SELECT 1 FROM t)")
+	ex, ok := node.(*ast.ExistsExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ExistsExpr, got %T", node)
+	}
+	if ex.Subquery == nil {
+		t.Fatal("expected non-nil Subquery")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parenthesized expressions
+// ---------------------------------------------------------------------------
+
+func TestExprParen(t *testing.T) {
+	node := mustParseExpr(t, "(42)")
+	paren, ok := node.(*ast.ParenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ParenExpr, got %T", node)
+	}
+	lit, ok := paren.Expr.(*ast.Literal)
+	if !ok {
+		t.Fatalf("expected inner to be *ast.Literal, got %T", paren.Expr)
+	}
+	if lit.Value != "42" {
+		t.Errorf("value = %q, want %q", lit.Value, "42")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subquery in expression position
+// ---------------------------------------------------------------------------
+
+func TestExprSubquery(t *testing.T) {
+	node := mustParseExpr(t, "(SELECT 1)")
+	subq, ok := node.(*ast.SubqueryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.SubqueryExpr, got %T", node)
+	}
+	if subq.RawText != "SELECT 1" {
+		t.Errorf("RawText = %q, want %q", subq.RawText, "SELECT 1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Location tracking
+// ---------------------------------------------------------------------------
+
+func TestExprLoc(t *testing.T) {
+	// Verify that the Loc spans the full expression
+	node := mustParseExpr(t, "1 + 2")
+	loc := ast.NodeLoc(node)
+	if loc.Start != 0 || loc.End != 5 {
+		t.Errorf("loc = %v, want {0, 5}", loc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk integration
+// ---------------------------------------------------------------------------
+
+func TestExprWalk(t *testing.T) {
+	node := mustParseExpr(t, "a + b")
+	var tags []ast.NodeTag
+	ast.Inspect(node, func(n ast.Node) bool {
+		if n != nil {
+			tags = append(tags, n.Tag())
+		}
+		return true
+	})
+	// Expected: BinaryExpr, ColumnRef, ObjectName, ColumnRef, ObjectName
+	if len(tags) < 3 {
+		t.Errorf("expected at least 3 visited nodes, got %d: %v", len(tags), tags)
+	}
+	if tags[0] != ast.T_BinaryExpr {
+		t.Errorf("first tag = %v, want BinaryExpr", tags[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases and error handling
+// ---------------------------------------------------------------------------
+
+func TestExprError_Empty(t *testing.T) {
+	_, err := parseExprFrom("")
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestExprError_UnterminatedParen(t *testing.T) {
+	_, err := parseExprFrom("(1 + 2")
+	if err == nil {
+		t.Error("expected error for unterminated paren")
+	}
+}
+
+func TestExprError_MissingOperand(t *testing.T) {
+	_, err := parseExprFrom("1 +")
+	if err == nil {
+		t.Error("expected error for missing operand")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Comprehensive precedence tests
+// ---------------------------------------------------------------------------
+
+func TestExprPrecedence_BitwiseVsComparison(t *testing.T) {
+	// a | b = c should parse as (a | b) = c since bitwise | > comparison
+	node := mustParseExpr(t, "a | b = c")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinEq {
+		t.Errorf("top op = %v, want BinEq", bin.Op)
+	}
+	leftBin, ok := bin.Left.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected left to be *ast.BinaryExpr, got %T", bin.Left)
+	}
+	if leftBin.Op != ast.BinBitOr {
+		t.Errorf("left op = %v, want BinBitOr", leftBin.Op)
+	}
+}
+
+func TestExprPrecedence_AddVsMul(t *testing.T) {
+	// 1 + 2 * 3 should parse as 1 + (2 * 3)
+	node := mustParseExpr(t, "1 + 2 * 3")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAdd {
+		t.Errorf("top op = %v, want BinAdd", bin.Op)
+	}
+	rightBin, ok := bin.Right.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected right to be *ast.BinaryExpr, got %T", bin.Right)
+	}
+	if rightBin.Op != ast.BinMul {
+		t.Errorf("right op = %v, want BinMul", rightBin.Op)
+	}
+}
+
+func TestExprPrecedence_XorVsAnd(t *testing.T) {
+	// a XOR b AND c should parse as a XOR (b AND c) since AND > XOR
+	node := mustParseExpr(t, "a XOR b AND c")
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinXor {
+		t.Errorf("top op = %v, want BinXor", bin.Op)
+	}
+	rightBin, ok := bin.Right.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected right to be *ast.BinaryExpr, got %T", bin.Right)
+	}
+	if rightBin.Op != ast.BinAnd {
+		t.Errorf("right op = %v, want BinAnd", rightBin.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple expression types in one test (table-driven)
+// ---------------------------------------------------------------------------
+
+func TestExprParseSuccess(t *testing.T) {
+	// These should all parse successfully without errors.
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"int literal", "42"},
+		{"float literal", "3.14"},
+		{"string literal", "'hello world'"},
+		{"true", "TRUE"},
+		{"false", "FALSE"},
+		{"null", "NULL"},
+		{"column ref", "col"},
+		{"qualified column", "t.col"},
+		{"three-part column", "db.t.col"},
+		{"addition", "1 + 2"},
+		{"subtraction", "3 - 1"},
+		{"multiplication", "2 * 3"},
+		{"division", "10 / 2"},
+		{"modulo", "10 % 3"},
+		{"integer division", "10 DIV 3"},
+		{"comparison eq", "a = 1"},
+		{"comparison ne", "a <> b"},
+		{"comparison ne bang", "a != b"},
+		{"comparison lt", "a < 1"},
+		{"comparison gt", "a > 1"},
+		{"comparison le", "a <= 1"},
+		{"comparison ge", "a >= 1"},
+		{"null-safe eq", "a <=> b"},
+		{"logical and", "a AND b"},
+		{"logical or", "a OR b"},
+		{"logical xor", "a XOR b"},
+		{"logical not", "NOT a"},
+		{"is null", "a IS NULL"},
+		{"is not null", "a IS NOT NULL"},
+		{"is true", "a IS TRUE"},
+		{"is not false", "a IS NOT FALSE"},
+		{"between", "a BETWEEN 1 AND 10"},
+		{"not between", "a NOT BETWEEN 1 AND 10"},
+		{"in list", "a IN (1, 2, 3)"},
+		{"not in list", "a NOT IN (1, 2)"},
+		{"in subquery", "a IN (SELECT 1)"},
+		{"like", "a LIKE '%foo%'"},
+		{"not like", "a NOT LIKE 'bar'"},
+		{"like escape", "a LIKE '%x' ESCAPE '\\\\'"},
+		{"regexp", "a REGEXP '^[0-9]+'"},
+		{"rlike", "a RLIKE '^abc'"},
+		{"not regexp", "a NOT REGEXP '^x'"},
+		{"cast int", "CAST(a AS INT)"},
+		{"cast varchar", "CAST(a AS VARCHAR(255))"},
+		{"try_cast", "TRY_CAST(a AS VARCHAR(255))"},
+		{"cast decimal", "CAST(a + b AS DECIMAL(10,2))"},
+		{"case searched", "CASE WHEN a > 1 THEN 'yes' ELSE 'no' END"},
+		{"case simple", "CASE a WHEN 1 THEN 'one' WHEN 2 THEN 'two' END"},
+		{"case with else", "CASE a WHEN 1 THEN 'one' ELSE 'other' END"},
+		{"count star", "COUNT(*)"},
+		{"sum", "SUM(a)"},
+		{"coalesce", "COALESCE(a, b, c)"},
+		{"count distinct", "COUNT(DISTINCT a)"},
+		{"func no args", "NOW()"},
+		{"current_date", "CURRENT_DATE"},
+		{"current_timestamp", "CURRENT_TIMESTAMP"},
+		{"unary minus", "-a"},
+		{"unary plus", "+a"},
+		{"unary bitnot", "~a"},
+		{"bitwise or", "a | b"},
+		{"bitwise and", "a & b"},
+		{"bitwise xor", "a ^ b"},
+		{"shift left", "a << 2"},
+		{"shift right", "a >> 2"},
+		{"paren", "(1 + 2)"},
+		{"exists", "EXISTS (SELECT 1 FROM t)"},
+		{"interval", "INTERVAL 1 DAY"},
+		{"nested", "a > 0 AND (b IN (1,2) OR c IS NOT NULL)"},
+		{"double paren", "((a + b))"},
+		{"complex arith", "a * b + c / d - e"},
+		{"and symbol", "a && b"},
+		{"or symbol", "a || b"},
+		{"multi comparison", "a = 1 AND b > 2 AND c < 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := parseExprFrom(tt.input)
+			if err != nil {
+				t.Errorf("parseExpr(%q) error: %v", tt.input, err)
+			}
+			if node == nil {
+				t.Errorf("parseExpr(%q) returned nil", tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add Pratt parser (precedence climbing) for Doris SQL expressions with 14 precedence levels
- 17 expression AST node types: BinaryExpr, UnaryExpr, ComparisonExpr, IsExpr, BetweenExpr, InExpr, LikeExpr, RegexpExpr, FuncCallExpr, CastExpr, CaseExpr, SubqueryExpr, ColumnRef, Literal, ParenExpr, IntervalExpr, ExistsExpr
- Full operator support: arithmetic (+,-,*,/,%,DIV), comparison (=,<>,!=,<,>,<=,>=,<=>), logical (AND,OR,XOR,NOT), bitwise (|,&,^,<<,>>)
- Predicates: IS [NOT] NULL/TRUE/FALSE, [NOT] BETWEEN, [NOT] IN, [NOT] LIKE with ESCAPE, [NOT] REGEXP/RLIKE
- Functions: regular, COUNT(*), COUNT(DISTINCT), aggregates with ORDER BY/SEPARATOR
- CAST/TRY_CAST, CASE (searched + simple), EXISTS, INTERVAL, nilary functions (CURRENT_DATE etc.)
- 78 unit tests

DAG node: T1.3 from `docs/migration/doris/dag.md`

## Test plan
- [x] 78 new tests pass (`go test ./doris/parser/...`)
- [x] `go build ./...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)