### PR TITLE
feat(snowflake): T2.2 CREATE TABLE parser

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -50,6 +50,9 @@ const (
 	T_SetOperationStmt
 	T_TableRef
 	T_JoinExpr
+	T_CreateTableStmt
+	T_ColumnDef
+	T_TableConstraint
 )
 
 // String returns a human-readable representation of the tag.
@@ -113,6 +116,12 @@ func (t NodeTag) String() string {
 		return "TableRef"
 	case T_JoinExpr:
 		return "JoinExpr"
+	case T_CreateTableStmt:
+		return "CreateTableStmt"
+	case T_ColumnDef:
+		return "ColumnDef"
+	case T_TableConstraint:
+		return "TableConstraint"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -858,3 +858,149 @@ type SetOperationStmt struct {
 func (n *SetOperationStmt) Tag() NodeTag { return T_SetOperationStmt }
 
 var _ Node = (*SetOperationStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// Constraint enums
+// ---------------------------------------------------------------------------
+
+// ConstraintType enumerates constraint kinds for inline and table-level constraints.
+type ConstraintType int
+
+const (
+	ConstrPrimaryKey ConstraintType = iota
+	ConstrForeignKey
+	ConstrUnique
+)
+
+// String returns the constraint type name.
+func (c ConstraintType) String() string {
+	switch c {
+	case ConstrPrimaryKey:
+		return "PRIMARY KEY"
+	case ConstrForeignKey:
+		return "FOREIGN KEY"
+	case ConstrUnique:
+		return "UNIQUE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ReferenceAction enumerates FK referential actions.
+type ReferenceAction int
+
+const (
+	RefActNone       ReferenceAction = iota // not specified
+	RefActCascade                           // CASCADE
+	RefActSetNull                           // SET NULL
+	RefActSetDefault                        // SET DEFAULT
+	RefActRestrict                          // RESTRICT
+	RefActNoAction                          // NO ACTION
+)
+
+// ---------------------------------------------------------------------------
+// Helper structs (not Nodes)
+// ---------------------------------------------------------------------------
+
+// InlineConstraint represents a column-level constraint.
+type InlineConstraint struct {
+	Type       ConstraintType
+	Name       Ident          // CONSTRAINT name; zero if unnamed
+	References *ForeignKeyRef // for FK; nil otherwise
+	Loc        Loc
+}
+
+// ForeignKeyRef holds REFERENCES clause details.
+type ForeignKeyRef struct {
+	Table    *ObjectName
+	Columns  []Ident
+	OnDelete ReferenceAction
+	OnUpdate ReferenceAction
+	Match    string // "FULL"/"PARTIAL"/"SIMPLE"; empty if absent
+}
+
+// IdentitySpec holds IDENTITY/AUTOINCREMENT configuration.
+type IdentitySpec struct {
+	Start     *int64 // START WITH value; nil if default
+	Increment *int64 // INCREMENT BY value; nil if default
+	Order     *bool  // true=ORDER, false=NOORDER, nil=unspecified
+}
+
+// TagAssignment is a single TAG name = 'value' pair.
+type TagAssignment struct {
+	Name  *ObjectName
+	Value string
+}
+
+// CloneSource holds CLONE source with optional time travel.
+type CloneSource struct {
+	Source   *ObjectName
+	AtBefore string // "AT" or "BEFORE"; empty if no time travel
+	Kind     string // "TIMESTAMP"/"OFFSET"/"STATEMENT"
+	Value    string // the time travel value
+}
+
+// ---------------------------------------------------------------------------
+// DDL statement nodes
+// ---------------------------------------------------------------------------
+
+// CreateTableStmt represents CREATE [OR REPLACE] [TRANSIENT|TEMPORARY|VOLATILE] TABLE ...
+type CreateTableStmt struct {
+	OrReplace   bool
+	Transient   bool
+	Temporary   bool
+	Volatile    bool
+	IfNotExists bool
+	Name        *ObjectName
+	Columns     []*ColumnDef
+	Constraints []*TableConstraint
+	ClusterBy   []Node           // CLUSTER BY expressions; nil if absent
+	Linear      bool             // CLUSTER BY LINEAR modifier
+	Comment     *string          // COMMENT = 'text'; nil if absent
+	CopyGrants  bool
+	Tags        []*TagAssignment // WITH TAG (...); nil if absent
+	AsSelect    Node             // CREATE TABLE ... AS SELECT; nil if absent
+	Like        *ObjectName      // CREATE TABLE ... LIKE source; nil if absent
+	Clone       *CloneSource     // CREATE TABLE ... CLONE source; nil if absent
+	Loc         Loc
+}
+
+func (n *CreateTableStmt) Tag() NodeTag { return T_CreateTableStmt }
+
+// ColumnDef represents a column definition in CREATE TABLE.
+type ColumnDef struct {
+	Name             Ident
+	DataType         *TypeName         // nil for virtual columns without explicit type
+	Default          Node              // DEFAULT expr; nil if absent
+	NotNull          bool
+	Nullable         bool              // explicit NULL
+	Identity         *IdentitySpec     // IDENTITY/AUTOINCREMENT; nil if absent
+	Collate          string            // COLLATE 'name'; empty if absent
+	MaskingPolicy    *ObjectName       // WITH MASKING POLICY name; nil if absent
+	InlineConstraint *InlineConstraint // inline PK/FK/UNIQUE; nil if absent
+	Comment          *string           // COMMENT 'text'; nil if absent
+	Tags             []*TagAssignment  // WITH TAG (...); nil if absent
+	VirtualExpr      Node              // AS (expr); nil if absent
+	Loc              Loc
+}
+
+func (n *ColumnDef) Tag() NodeTag { return T_ColumnDef }
+
+// TableConstraint represents a table-level constraint (out-of-line).
+type TableConstraint struct {
+	Type       ConstraintType // ConstrPrimaryKey/ConstrForeignKey/ConstrUnique
+	Name       Ident          // CONSTRAINT name; zero if unnamed
+	Columns    []Ident        // constrained column names
+	References *ForeignKeyRef // FK only; nil otherwise
+	Comment    *string        // inline COMMENT 'text'; nil if absent
+	Loc        Loc
+}
+
+func (n *TableConstraint) Tag() NodeTag { return T_TableConstraint }
+
+// Compile-time assertions.
+var (
+	_ Node = (*CreateTableStmt)(nil)
+	_ Node = (*ColumnDef)(nil)
+	_ Node = (*TableConstraint)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -28,6 +28,24 @@ func walkChildren(v Visitor, node Node) {
 		}
 	case *CollateExpr:
 		Walk(v, n.Expr)
+	case *ColumnDef:
+		if n.DataType != nil {
+			Walk(v, n.DataType)
+		}
+		Walk(v, n.Default)
+		if n.MaskingPolicy != nil {
+			Walk(v, n.MaskingPolicy)
+		}
+		Walk(v, n.VirtualExpr)
+	case *CreateTableStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		walkNodes(v, n.ClusterBy)
+		Walk(v, n.AsSelect)
+		if n.Like != nil {
+			Walk(v, n.Like)
+		}
 	case *ExistsExpr:
 		Walk(v, n.Query)
 	case *File:

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -1,0 +1,1145 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// CREATE statement dispatch
+// ---------------------------------------------------------------------------
+
+// parseCreateStmt parses CREATE ... and dispatches to the appropriate
+// sub-parser based on the object type keyword (TABLE, etc.).
+func (p *Parser) parseCreateStmt() (ast.Node, error) {
+	createTok := p.advance() // consume CREATE
+	start := createTok.Loc
+
+	// OR REPLACE
+	orReplace := false
+	if p.cur.Type == kwOR {
+		next := p.peekNext()
+		if next.Type == kwREPLACE {
+			p.advance() // consume OR
+			p.advance() // consume REPLACE
+			orReplace = true
+		}
+	}
+
+	// Optional [LOCAL|GLOBAL] TRANSIENT|TEMPORARY|TEMP|VOLATILE
+	transient := false
+	temporary := false
+	volatile := false
+
+	// Consume optional LOCAL/GLOBAL prefix (they don't change semantics here)
+	if p.cur.Type == kwLOCAL || p.cur.Type == kwGLOBAL {
+		p.advance()
+	}
+
+	switch p.cur.Type {
+	case kwTRANSIENT:
+		p.advance()
+		transient = true
+	case kwTEMPORARY, kwTEMP:
+		p.advance()
+		temporary = true
+	case kwVOLATILE:
+		p.advance()
+		volatile = true
+	}
+
+	switch p.cur.Type {
+	case kwTABLE:
+		return p.parseCreateTableStmt(start, orReplace, transient, temporary, volatile)
+	default:
+		return p.unsupported("CREATE")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TABLE statement parser
+// ---------------------------------------------------------------------------
+
+// parseCreateTableStmt parses the body of a CREATE [OR REPLACE] [...] TABLE
+// statement. The CREATE keyword and optional modifiers have already been
+// consumed; start is the Loc of the CREATE token.
+func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, transient, temporary, volatile bool) (ast.Node, error) {
+	p.advance() // consume TABLE
+
+	stmt := &ast.CreateTableStmt{
+		OrReplace: orReplace,
+		Transient: transient,
+		Temporary: temporary,
+		Volatile:  volatile,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		next := p.peekNext()
+		if next.Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// Table name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Branch on what follows the table name
+	switch p.cur.Type {
+	case kwLIKE:
+		// CREATE TABLE ... LIKE source_table [table_properties]
+		p.advance() // consume LIKE
+		src, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Like = src
+		if err := p.parseTableProperties(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwCLONE:
+		// CREATE TABLE ... CLONE source [AT|BEFORE ...]
+		clone, err := p.parseCloneSource()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Clone = clone
+
+	case kwAS:
+		// CREATE TABLE ... AS SELECT (CTAS, no column list)
+		p.advance() // consume AS
+		query, err := p.parseQueryExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.AsSelect = query
+
+	case '(':
+		// CREATE TABLE ... ( column_defs [, constraints] ) [table_properties] [AS SELECT]
+		if err := p.parseColumnDeclItems(stmt); err != nil {
+			return nil, err
+		}
+		if err := p.parseTableProperties(stmt); err != nil {
+			return nil, err
+		}
+		// Optionally followed by AS SELECT (CTAS with column list)
+		if p.cur.Type == kwAS {
+			p.advance() // consume AS
+			query, err := p.parseQueryExpr()
+			if err != nil {
+				return nil, err
+			}
+			stmt.AsSelect = query
+		}
+
+	default:
+		// No body — possibly just table properties (e.g. CREATE TABLE t COMMENT = '...')
+		if err := p.parseTableProperties(stmt); err != nil {
+			return nil, err
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Column declaration items
+// ---------------------------------------------------------------------------
+
+// parseColumnDeclItems parses the parenthesized list of column definitions
+// and out-of-line constraints: ( item, item, ... ).
+func (p *Parser) parseColumnDeclItems(stmt *ast.CreateTableStmt) error {
+	if _, err := p.expect('('); err != nil {
+		return err
+	}
+
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		if p.isOutOfLineConstraintStart() {
+			con, err := p.parseOutOfLineConstraint()
+			if err != nil {
+				return err
+			}
+			stmt.Constraints = append(stmt.Constraints, con)
+		} else {
+			col, err := p.parseColumnDef()
+			if err != nil {
+				return err
+			}
+			stmt.Columns = append(stmt.Columns, col)
+		}
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+		} else {
+			break
+		}
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return err
+	}
+	return nil
+}
+
+// isOutOfLineConstraintStart returns true if the current token starts an
+// out-of-line (table-level) constraint definition.
+func (p *Parser) isOutOfLineConstraintStart() bool {
+	switch p.cur.Type {
+	case kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Column definition
+// ---------------------------------------------------------------------------
+
+// parseColumnDef parses a single column definition:
+//
+//	name [data_type | AS (expr)] [column_options...]
+func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	col := &ast.ColumnDef{
+		Name: name,
+		Loc:  ast.Loc{Start: name.Loc.Start},
+	}
+
+	// The data type is optional when followed by AS (virtual column
+	// defined with an expression). Peek ahead to decide.
+	if p.cur.Type != kwAS && p.cur.Type != ',' && p.cur.Type != ')' &&
+		p.cur.Type != kwNOT && p.cur.Type != kwNULL && p.cur.Type != kwDEFAULT &&
+		p.cur.Type != kwIDENTITY && p.cur.Type != kwAUTOINCREMENT &&
+		p.cur.Type != kwCOLLATE && p.cur.Type != kwCONSTRAINT &&
+		p.cur.Type != kwPRIMARY && p.cur.Type != kwUNIQUE && p.cur.Type != kwFOREIGN &&
+		p.cur.Type != kwCOMMENT && p.cur.Type != kwWITH && p.cur.Type != kwMASKING &&
+		p.cur.Type != kwTAG && p.cur.Type != tokEOF {
+		dt, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		col.DataType = dt
+	}
+
+	if err := p.parseColumnOptions(col); err != nil {
+		return nil, err
+	}
+
+	col.Loc.End = p.prev.Loc.End
+	return col, nil
+}
+
+// parseColumnOptions parses the optional constraints and properties that
+// follow a column name+type. Returns nil when no more column options are
+// found.
+func (p *Parser) parseColumnOptions(col *ast.ColumnDef) error {
+	for {
+		switch p.cur.Type {
+		case kwNOT:
+			// NOT NULL
+			next := p.peekNext()
+			if next.Type == kwNULL {
+				p.advance() // consume NOT
+				p.advance() // consume NULL
+				col.NotNull = true
+			} else {
+				return nil
+			}
+
+		case kwNULL:
+			p.advance() // consume NULL
+			col.Nullable = true
+
+		case kwDEFAULT:
+			p.advance() // consume DEFAULT
+			expr, err := p.parseExpr()
+			if err != nil {
+				return err
+			}
+			col.Default = expr
+
+		case kwIDENTITY, kwAUTOINCREMENT:
+			spec, err := p.parseIdentitySpec()
+			if err != nil {
+				return err
+			}
+			col.Identity = spec
+
+		case kwCOLLATE:
+			p.advance() // consume COLLATE
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return err
+			}
+			col.Collate = tok.Str
+
+		case kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN:
+			ic, err := p.parseInlineConstraint()
+			if err != nil {
+				return err
+			}
+			col.InlineConstraint = ic
+
+		case kwCOMMENT:
+			p.advance() // consume COMMENT
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return err
+			}
+			s := tok.Str
+			col.Comment = &s
+
+		case kwWITH:
+			// WITH MASKING POLICY name [USING (...)]
+			// WITH TAG (...)
+			// WITH ROW ACCESS POLICY ... — consumed and discarded
+			next := p.peekNext()
+			switch next.Type {
+			case kwMASKING:
+				p.advance() // consume WITH
+				p.advance() // consume MASKING
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return err
+				}
+				policyName, err := p.parseObjectName()
+				if err != nil {
+					return err
+				}
+				col.MaskingPolicy = policyName
+				// Optional USING (col_list)
+				if p.cur.Type == kwUSING {
+					p.advance() // consume USING
+					if err := p.skipParenthesized(); err != nil {
+						return err
+					}
+				}
+			case kwTAG:
+				p.advance() // consume WITH
+				tags, err := p.parseTagAssignments()
+				if err != nil {
+					return err
+				}
+				col.Tags = append(col.Tags, tags...)
+			case kwROW:
+				// WITH ROW ACCESS POLICY ... — consume and discard
+				p.advance() // consume WITH
+				p.advance() // consume ROW
+				if _, err := p.expect(kwACCESS); err != nil {
+					return err
+				}
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return err
+				}
+				// policy name
+				if _, err := p.parseObjectName(); err != nil {
+					return err
+				}
+				// Optional ON (cols)
+				if p.cur.Type == kwON {
+					p.advance() // consume ON
+					if err := p.skipParenthesized(); err != nil {
+						return err
+					}
+				}
+			default:
+				return nil
+			}
+
+		case kwMASKING:
+			// MASKING POLICY name [USING (...)] — without WITH prefix
+			p.advance() // consume MASKING
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return err
+			}
+			policyName, err := p.parseObjectName()
+			if err != nil {
+				return err
+			}
+			col.MaskingPolicy = policyName
+			if p.cur.Type == kwUSING {
+				p.advance() // consume USING
+				if err := p.skipParenthesized(); err != nil {
+					return err
+				}
+			}
+
+		case kwTAG:
+			// TAG (...) — without WITH prefix
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return err
+			}
+			col.Tags = append(col.Tags, tags...)
+
+		case kwAS:
+			// AS (expr) — virtual column expression
+			p.advance() // consume AS
+			if _, err := p.expect('('); err != nil {
+				return err
+			}
+			expr, err := p.parseExpr()
+			if err != nil {
+				return err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return err
+			}
+			col.VirtualExpr = expr
+
+		default:
+			return nil
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inline constraint
+// ---------------------------------------------------------------------------
+
+// parseInlineConstraint parses a column-level (inline) constraint:
+//
+//	[CONSTRAINT name] PRIMARY KEY | UNIQUE | FOREIGN KEY REFERENCES ...
+func (p *Parser) parseInlineConstraint() (*ast.InlineConstraint, error) {
+	ic := &ast.InlineConstraint{
+		Loc: p.cur.Loc,
+	}
+
+	// Optional CONSTRAINT name
+	if p.cur.Type == kwCONSTRAINT {
+		p.advance() // consume CONSTRAINT
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		ic.Name = name
+	}
+
+	switch p.cur.Type {
+	case kwPRIMARY:
+		p.advance() // consume PRIMARY
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		ic.Type = ast.ConstrPrimaryKey
+
+	case kwUNIQUE:
+		p.advance() // consume UNIQUE
+		ic.Type = ast.ConstrUnique
+
+	case kwFOREIGN:
+		p.advance() // consume FOREIGN
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		ref, err := p.parseForeignKeyRef()
+		if err != nil {
+			return nil, err
+		}
+		ic.Type = ast.ConstrForeignKey
+		ic.References = ref
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	if err := p.parseConstraintProperties(); err != nil {
+		return nil, err
+	}
+
+	ic.Loc.End = p.prev.Loc.End
+	return ic, nil
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-line (table-level) constraint
+// ---------------------------------------------------------------------------
+
+// parseOutOfLineConstraint parses a table-level (out-of-line) constraint:
+//
+//	[CONSTRAINT name] PRIMARY KEY (cols) | UNIQUE (cols) | FOREIGN KEY (cols) REFERENCES ...
+func (p *Parser) parseOutOfLineConstraint() (*ast.TableConstraint, error) {
+	con := &ast.TableConstraint{
+		Loc: p.cur.Loc,
+	}
+
+	// Optional CONSTRAINT name
+	if p.cur.Type == kwCONSTRAINT {
+		p.advance() // consume CONSTRAINT
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		con.Name = name
+	}
+
+	switch p.cur.Type {
+	case kwPRIMARY:
+		p.advance() // consume PRIMARY
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		con.Type = ast.ConstrPrimaryKey
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return nil, err
+		}
+		con.Columns = cols
+
+	case kwUNIQUE:
+		p.advance() // consume UNIQUE
+		con.Type = ast.ConstrUnique
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return nil, err
+		}
+		con.Columns = cols
+
+	case kwFOREIGN:
+		p.advance() // consume FOREIGN
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		con.Type = ast.ConstrForeignKey
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return nil, err
+		}
+		con.Columns = cols
+		ref, err := p.parseForeignKeyRef()
+		if err != nil {
+			return nil, err
+		}
+		con.References = ref
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	if err := p.parseConstraintProperties(); err != nil {
+		return nil, err
+	}
+
+	// Optional COMMENT 'text'
+	if p.cur.Type == kwCOMMENT {
+		p.advance() // consume COMMENT
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		s := tok.Str
+		con.Comment = &s
+	}
+
+	con.Loc.End = p.prev.Loc.End
+	return con, nil
+}
+
+// ---------------------------------------------------------------------------
+// Identifier list helpers
+// ---------------------------------------------------------------------------
+
+// parseIdentListInParens parses ( ident, ident, ... ).
+func (p *Parser) parseIdentListInParens() ([]ast.Ident, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var idents []ast.Ident
+	id, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	idents = append(idents, id)
+
+	for p.cur.Type == ',' {
+		p.advance() // consume ','
+		id, err = p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		idents = append(idents, id)
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return idents, nil
+}
+
+// ---------------------------------------------------------------------------
+// Foreign key reference
+// ---------------------------------------------------------------------------
+
+// parseForeignKeyRef expects and parses the REFERENCES clause.
+func (p *Parser) parseForeignKeyRef() (*ast.ForeignKeyRef, error) {
+	if _, err := p.expect(kwREFERENCES); err != nil {
+		return nil, err
+	}
+	return p.parseForeignKeyRefAfterReferences()
+}
+
+// parseForeignKeyRefAfterReferences parses the body of a REFERENCES clause
+// after the REFERENCES keyword has already been consumed:
+//
+//	table_name [(cols)] [MATCH FULL|PARTIAL|SIMPLE] [ON DELETE action] [ON UPDATE action]
+func (p *Parser) parseForeignKeyRefAfterReferences() (*ast.ForeignKeyRef, error) {
+	table, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	ref := &ast.ForeignKeyRef{
+		Table: table,
+	}
+
+	// Optional column list
+	if p.cur.Type == '(' {
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return nil, err
+		}
+		ref.Columns = cols
+	}
+
+	// Optional MATCH FULL | PARTIAL | SIMPLE
+	if p.cur.Type == kwMATCH {
+		p.advance() // consume MATCH
+		switch p.cur.Type {
+		case kwFULL:
+			p.advance()
+			ref.Match = "FULL"
+		case kwPARTIAL:
+			p.advance()
+			ref.Match = "PARTIAL"
+		case kwSIMPLE:
+			p.advance()
+			ref.Match = "SIMPLE"
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+
+	// Optional ON DELETE / ON UPDATE
+	for p.cur.Type == kwON {
+		next := p.peekNext()
+		switch next.Type {
+		case kwDELETE:
+			p.advance() // consume ON
+			p.advance() // consume DELETE
+			action, err := p.parseReferenceAction()
+			if err != nil {
+				return nil, err
+			}
+			ref.OnDelete = action
+		case kwUPDATE:
+			p.advance() // consume ON
+			p.advance() // consume UPDATE
+			action, err := p.parseReferenceAction()
+			if err != nil {
+				return nil, err
+			}
+			ref.OnUpdate = action
+		default:
+			// Not an ON DELETE/UPDATE — stop
+			return ref, nil
+		}
+	}
+
+	return ref, nil
+}
+
+// parseReferenceAction parses a referential action keyword:
+//
+//	CASCADE | SET NULL | SET DEFAULT | RESTRICT | NO ACTION
+func (p *Parser) parseReferenceAction() (ast.ReferenceAction, error) {
+	switch p.cur.Type {
+	case kwCASCADE:
+		p.advance()
+		return ast.RefActCascade, nil
+	case kwSET:
+		p.advance() // consume SET
+		switch p.cur.Type {
+		case kwNULL:
+			p.advance()
+			return ast.RefActSetNull, nil
+		case kwDEFAULT:
+			p.advance()
+			return ast.RefActSetDefault, nil
+		default:
+			return ast.RefActNone, p.syntaxErrorAtCur()
+		}
+	case kwRESTRICT:
+		p.advance()
+		return ast.RefActRestrict, nil
+	case kwNO:
+		p.advance() // consume NO
+		if _, err := p.expect(kwACTION); err != nil {
+			return ast.RefActNone, err
+		}
+		return ast.RefActNoAction, nil
+	default:
+		return ast.RefActNone, p.syntaxErrorAtCur()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constraint properties
+// ---------------------------------------------------------------------------
+
+// parseConstraintProperties consumes and discards Snowflake constraint
+// enforcement/deferral properties. Returns nil when none are present or
+// when all have been consumed.
+func (p *Parser) parseConstraintProperties() error {
+	for {
+		switch p.cur.Type {
+		case kwNOT:
+			next := p.peekNext()
+			if next.Type == kwENFORCED {
+				p.advance() // consume NOT
+				p.advance() // consume ENFORCED
+			} else if next.Type == kwDEFERRABLE {
+				p.advance() // consume NOT
+				p.advance() // consume DEFERRABLE
+			} else {
+				return nil
+			}
+		case kwENFORCED:
+			p.advance()
+		case kwDEFERRABLE:
+			p.advance()
+		case kwINITIALLY:
+			p.advance() // consume INITIALLY
+			// Expect DEFERRED or IMMEDIATE
+			if p.cur.Type == kwDEFERRED || p.cur.Type == kwIMMEDIATE {
+				p.advance()
+			} else {
+				return p.syntaxErrorAtCur()
+			}
+		case kwENABLE:
+			p.advance() // consume ENABLE
+			// Optional VALIDATE / NOVALIDATE
+			if p.cur.Type == kwVALIDATE || p.cur.Type == kwNOVALIDATE {
+				p.advance()
+			}
+		case kwDISABLE:
+			p.advance() // consume DISABLE
+			// Optional VALIDATE / NOVALIDATE
+			if p.cur.Type == kwVALIDATE || p.cur.Type == kwNOVALIDATE {
+				p.advance()
+			}
+		case kwVALIDATE:
+			p.advance()
+		case kwNOVALIDATE:
+			p.advance()
+		case kwRELY:
+			p.advance()
+		case kwNORELY:
+			p.advance()
+		default:
+			return nil
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IDENTITY / AUTOINCREMENT
+// ---------------------------------------------------------------------------
+
+// parseIdentitySpec parses an IDENTITY or AUTOINCREMENT specification:
+//
+//	IDENTITY | AUTOINCREMENT [(start, increment)]
+//	  [START WITH [=] n] [INCREMENT BY [=] n] [ORDER | NOORDER]
+func (p *Parser) parseIdentitySpec() (*ast.IdentitySpec, error) {
+	p.advance() // consume IDENTITY or AUTOINCREMENT
+
+	spec := &ast.IdentitySpec{}
+
+	// Optional (start, increment)
+	if p.cur.Type == '(' {
+		p.advance() // consume '('
+		startTok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		startVal := startTok.Ival
+		spec.Start = &startVal
+
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+
+		incrTok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		incrVal := incrTok.Ival
+		spec.Increment = &incrVal
+
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+	}
+
+	// Optional START WITH [=] n
+	if p.cur.Type == kwSTART {
+		next := p.peekNext()
+		if next.Type == kwWITH {
+			p.advance() // consume START
+			p.advance() // consume WITH
+			// Optional =
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokInt)
+			if err != nil {
+				return nil, err
+			}
+			v := tok.Ival
+			spec.Start = &v
+		}
+	}
+
+	// Optional INCREMENT BY [=] n
+	if p.cur.Type == kwINCREMENT {
+		next := p.peekNext()
+		if next.Type == kwBY {
+			p.advance() // consume INCREMENT
+			p.advance() // consume BY
+			// Optional =
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokInt)
+			if err != nil {
+				return nil, err
+			}
+			v := tok.Ival
+			spec.Increment = &v
+		}
+	}
+
+	// Optional ORDER / NOORDER
+	if p.cur.Type == kwORDER {
+		p.advance()
+		b := true
+		spec.Order = &b
+	} else if p.cur.Type == kwNOORDER {
+		p.advance()
+		b := false
+		spec.Order = &b
+	}
+
+	return spec, nil
+}
+
+// ---------------------------------------------------------------------------
+// Tag assignments
+// ---------------------------------------------------------------------------
+
+// parseTagAssignments parses TAG ( name = 'value', ... ).
+// The TAG keyword is consumed here.
+func (p *Parser) parseTagAssignments() ([]*ast.TagAssignment, error) {
+	if _, err := p.expect(kwTAG); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var tags []*ast.TagAssignment
+
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		tagName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('='); err != nil {
+			return nil, err
+		}
+		valueTok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		tags = append(tags, &ast.TagAssignment{
+			Name:  tagName,
+			Value: valueTok.Str,
+		})
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+		} else {
+			break
+		}
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return tags, nil
+}
+
+// ---------------------------------------------------------------------------
+// CLONE source
+// ---------------------------------------------------------------------------
+
+// parseCloneSource parses CLONE source_name [AT|BEFORE (kind => value)].
+// The CLONE keyword is consumed here.
+func (p *Parser) parseCloneSource() (*ast.CloneSource, error) {
+	if _, err := p.expect(kwCLONE); err != nil {
+		return nil, err
+	}
+
+	src, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	clone := &ast.CloneSource{
+		Source: src,
+	}
+
+	// Optional AT|BEFORE (TIMESTAMP|OFFSET|STATEMENT => value)
+	if p.cur.Type == kwAT || p.cur.Type == kwBEFORE {
+		atBefore := "AT"
+		if p.cur.Type == kwBEFORE {
+			atBefore = "BEFORE"
+		}
+		p.advance() // consume AT or BEFORE
+
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+
+		var kind string
+		switch p.cur.Type {
+		case kwTIMESTAMP:
+			p.advance()
+			kind = "TIMESTAMP"
+		case kwOFFSET:
+			p.advance()
+			kind = "OFFSET"
+		case kwSTATEMENT:
+			p.advance()
+			kind = "STATEMENT"
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+		// Expect => (tokAssoc)
+		if _, err := p.expect(tokAssoc); err != nil {
+			return nil, err
+		}
+
+		// Value: string or expression — consume as a string token or expression
+		valueTok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+
+		clone.AtBefore = atBefore
+		clone.Kind = kind
+		clone.Value = valueTok.Str
+	}
+
+	return clone, nil
+}
+
+// ---------------------------------------------------------------------------
+// Table properties
+// ---------------------------------------------------------------------------
+
+// parseTableProperties parses the optional table-level properties that follow
+// the column definition list (or the table name for LIKE/CLONE forms).
+// Stops when it encounters a token it doesn't recognize as a table property.
+func (p *Parser) parseTableProperties(stmt *ast.CreateTableStmt) error {
+	for {
+		switch p.cur.Type {
+		case kwCLUSTER:
+			// CLUSTER BY [LINEAR] (exprs)
+			p.advance() // consume CLUSTER
+			if _, err := p.expect(kwBY); err != nil {
+				return err
+			}
+			if p.cur.Type == kwLINEAR {
+				p.advance() // consume LINEAR
+				stmt.Linear = true
+			}
+			if _, err := p.expect('('); err != nil {
+				return err
+			}
+			exprs, err := p.parseExprList()
+			if err != nil {
+				return err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return err
+			}
+			stmt.ClusterBy = exprs
+
+		case kwCOPY:
+			// COPY GRANTS
+			next := p.peekNext()
+			if next.Type == kwGRANTS {
+				p.advance() // consume COPY
+				p.advance() // consume GRANTS
+				stmt.CopyGrants = true
+			} else {
+				return nil
+			}
+
+		case kwCOMMENT:
+			// COMMENT = 'text'
+			p.advance() // consume COMMENT
+			if p.cur.Type == '=' {
+				p.advance() // consume =
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return err
+			}
+			s := tok.Str
+			stmt.Comment = &s
+
+		case kwWITH:
+			next := p.peekNext()
+			switch next.Type {
+			case kwTAG:
+				p.advance() // consume WITH
+				tags, err := p.parseTagAssignments()
+				if err != nil {
+					return err
+				}
+				stmt.Tags = append(stmt.Tags, tags...)
+			case kwROW:
+				// WITH ROW ACCESS POLICY name ON (cols) — consume and discard
+				p.advance() // consume WITH
+				p.advance() // consume ROW
+				if _, err := p.expect(kwACCESS); err != nil {
+					return err
+				}
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return err
+				}
+				// policy name
+				if _, err := p.parseObjectName(); err != nil {
+					return err
+				}
+				// Optional ON (cols)
+				if p.cur.Type == kwON {
+					p.advance() // consume ON
+					if err := p.skipParenthesized(); err != nil {
+						return err
+					}
+				}
+			default:
+				return nil
+			}
+
+		case kwTAG:
+			// TAG (...) — without WITH prefix
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+
+		case kwDATA_RETENTION_TIME_IN_DAYS:
+			// DATA_RETENTION_TIME_IN_DAYS = n — consume and discard
+			p.advance() // consume DATA_RETENTION_TIME_IN_DAYS
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			if _, err := p.expect(tokInt); err != nil {
+				return err
+			}
+
+		case kwCHANGE_TRACKING:
+			// CHANGE_TRACKING = TRUE|FALSE — consume and discard
+			p.advance() // consume CHANGE_TRACKING
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			if p.cur.Type == kwTRUE || p.cur.Type == kwFALSE {
+				p.advance()
+			} else {
+				return p.syntaxErrorAtCur()
+			}
+
+		case kwDEFAULT_DDL_COLLATION:
+			// DEFAULT_DDL_COLLATION = 'string' — consume and discard
+			p.advance() // consume DEFAULT_DDL_COLLATION
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			if _, err := p.expect(tokString); err != nil {
+				return err
+			}
+
+		case kwSTAGE_FILE_FORMAT:
+			// STAGE_FILE_FORMAT = (...) — consume and discard
+			p.advance() // consume STAGE_FILE_FORMAT
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			if err := p.skipParenthesized(); err != nil {
+				return err
+			}
+
+		case kwSTAGE_COPY_OPTIONS:
+			// STAGE_COPY_OPTIONS = (...) — consume and discard
+			p.advance() // consume STAGE_COPY_OPTIONS
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			if err := p.skipParenthesized(); err != nil {
+				return err
+			}
+
+		default:
+			return nil
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+// skipParenthesized consumes tokens from '(' to the matching ')' inclusive,
+// tracking nesting depth to handle nested parentheses.
+func (p *Parser) skipParenthesized() error {
+	if _, err := p.expect('('); err != nil {
+		return err
+	}
+	depth := 1
+	for depth > 0 && p.cur.Type != tokEOF {
+		switch p.cur.Type {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		p.advance()
+	}
+	if depth != 0 {
+		return p.syntaxErrorAtCur()
+	}
+	return nil
+}

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -793,42 +793,42 @@ func (p *Parser) parseIdentitySpec() (*ast.IdentitySpec, error) {
 		}
 	}
 
-	// Optional START WITH [=] n
+	// Optional START [WITH] [=] n
 	if p.cur.Type == kwSTART {
-		next := p.peekNext()
-		if next.Type == kwWITH {
-			p.advance() // consume START
+		p.advance() // consume START
+		// Optional WITH
+		if p.cur.Type == kwWITH {
 			p.advance() // consume WITH
-			// Optional =
-			if p.cur.Type == '=' {
-				p.advance()
-			}
-			tok, err := p.expect(tokInt)
-			if err != nil {
-				return nil, err
-			}
-			v := tok.Ival
-			spec.Start = &v
 		}
+		// Optional =
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		tok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		v := tok.Ival
+		spec.Start = &v
 	}
 
-	// Optional INCREMENT BY [=] n
+	// Optional INCREMENT [BY] [=] n
 	if p.cur.Type == kwINCREMENT {
-		next := p.peekNext()
-		if next.Type == kwBY {
-			p.advance() // consume INCREMENT
+		p.advance() // consume INCREMENT
+		// Optional BY
+		if p.cur.Type == kwBY {
 			p.advance() // consume BY
-			// Optional =
-			if p.cur.Type == '=' {
-				p.advance()
-			}
-			tok, err := p.expect(tokInt)
-			if err != nil {
-				return nil, err
-			}
-			v := tok.Ival
-			spec.Increment = &v
 		}
+		// Optional =
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		tok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		v := tok.Ival
+		spec.Increment = &v
 	}
 
 	// Optional ORDER / NOORDER

--- a/snowflake/parser/create_table_test.go
+++ b/snowflake/parser/create_table_test.go
@@ -1,0 +1,791 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+func testParseCreateTable(input string) (*ast.CreateTableStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CreateTableStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a CreateTableStmt"})
+	}
+	return stmt, result.Errors
+}
+
+// ---------------------------------------------------------------------------
+// Task 3: Basic forms
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_Basic(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected CreateTableStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "T" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "T")
+	}
+	if len(stmt.Columns) != 1 {
+		t.Fatalf("columns = %d, want 1", len(stmt.Columns))
+	}
+	col := stmt.Columns[0]
+	if col.Name.Normalize() != "ID" {
+		t.Errorf("col name = %q, want %q", col.Name.Normalize(), "ID")
+	}
+	if col.DataType == nil {
+		t.Fatal("col DataType is nil")
+	}
+	if col.DataType.Kind != ast.TypeInt {
+		t.Errorf("col type = %v, want TypeInt", col.DataType.Kind)
+	}
+}
+
+func TestCreateTable_MultipleColumns(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT, name VARCHAR(100), active BOOLEAN)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 3 {
+		t.Fatalf("columns = %d, want 3", len(stmt.Columns))
+	}
+	if stmt.Columns[0].DataType.Kind != ast.TypeInt {
+		t.Errorf("col[0] type = %v, want TypeInt", stmt.Columns[0].DataType.Kind)
+	}
+	if stmt.Columns[1].DataType.Kind != ast.TypeVarchar {
+		t.Errorf("col[1] type = %v, want TypeVarchar", stmt.Columns[1].DataType.Kind)
+	}
+	if len(stmt.Columns[1].DataType.Params) != 1 || stmt.Columns[1].DataType.Params[0] != 100 {
+		t.Errorf("col[1] varchar params = %v, want [100]", stmt.Columns[1].DataType.Params)
+	}
+	if stmt.Columns[2].DataType.Kind != ast.TypeBoolean {
+		t.Errorf("col[2] type = %v, want TypeBoolean", stmt.Columns[2].DataType.Kind)
+	}
+}
+
+func TestCreateTable_OrReplace(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE OR REPLACE TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+}
+
+func TestCreateTable_Transient(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TRANSIENT TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Transient {
+		t.Error("expected Transient=true")
+	}
+}
+
+func TestCreateTable_Temporary(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TEMPORARY TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Temporary {
+		t.Error("expected Temporary=true")
+	}
+}
+
+func TestCreateTable_Volatile(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE VOLATILE TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Volatile {
+		t.Error("expected Volatile=true")
+	}
+}
+
+func TestCreateTable_LocalTemporary(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE LOCAL TEMPORARY TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Temporary {
+		t.Error("expected Temporary=true")
+	}
+}
+
+func TestCreateTable_IfNotExists(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE IF NOT EXISTS t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+}
+
+func TestCreateTable_AllModifiers(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE OR REPLACE TRANSIENT TABLE IF NOT EXISTS mydb.myschema.t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.Transient {
+		t.Error("expected Transient=true")
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+	// 3-part name
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA.T" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB.MYSCHEMA.T")
+	}
+	if stmt.Name.Database.Normalize() != "MYDB" {
+		t.Errorf("database = %q, want %q", stmt.Name.Database.Normalize(), "MYDB")
+	}
+	if stmt.Name.Schema.Normalize() != "MYSCHEMA" {
+		t.Errorf("schema = %q, want %q", stmt.Name.Schema.Normalize(), "MYSCHEMA")
+	}
+}
+
+func TestCreateTable_Like(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t2 LIKE db.schema.t1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Like == nil {
+		t.Fatal("expected Like != nil")
+	}
+	if stmt.Like.Normalize() != "DB.SCHEMA.T1" {
+		t.Errorf("like source = %q, want %q", stmt.Like.Normalize(), "DB.SCHEMA.T1")
+	}
+	if len(stmt.Columns) != 0 {
+		t.Errorf("columns = %d, want 0", len(stmt.Columns))
+	}
+}
+
+func TestCreateTable_Clone(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t2 CLONE t1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Clone == nil {
+		t.Fatal("expected Clone != nil")
+	}
+	if stmt.Clone.Source.Normalize() != "T1" {
+		t.Errorf("clone source = %q, want %q", stmt.Clone.Source.Normalize(), "T1")
+	}
+	if stmt.Clone.AtBefore != "" {
+		t.Errorf("AtBefore = %q, want empty", stmt.Clone.AtBefore)
+	}
+}
+
+func TestCreateTable_CloneAtTimestamp(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t2 CLONE t1 AT (TIMESTAMP => '2024-01-01')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Clone == nil {
+		t.Fatal("expected Clone != nil")
+	}
+	if stmt.Clone.AtBefore != "AT" {
+		t.Errorf("AtBefore = %q, want %q", stmt.Clone.AtBefore, "AT")
+	}
+	if stmt.Clone.Kind != "TIMESTAMP" {
+		t.Errorf("Kind = %q, want %q", stmt.Clone.Kind, "TIMESTAMP")
+	}
+	if stmt.Clone.Value != "2024-01-01" {
+		t.Errorf("Value = %q, want %q", stmt.Clone.Value, "2024-01-01")
+	}
+}
+
+func TestCreateTable_CloneBeforeStatement(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t2 CLONE t1 BEFORE (STATEMENT => '8e5d0ca1-e866-44fa-843b-5e6ad35e8bb7')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Clone == nil {
+		t.Fatal("expected Clone != nil")
+	}
+	if stmt.Clone.AtBefore != "BEFORE" {
+		t.Errorf("AtBefore = %q, want %q", stmt.Clone.AtBefore, "BEFORE")
+	}
+	if stmt.Clone.Kind != "STATEMENT" {
+		t.Errorf("Kind = %q, want %q", stmt.Clone.Kind, "STATEMENT")
+	}
+}
+
+func TestCreateTable_CTAS(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t AS SELECT 1 AS id, 'hello' AS name")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.AsSelect == nil {
+		t.Fatal("expected AsSelect != nil")
+	}
+	sel, ok := stmt.AsSelect.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("AsSelect is %T, want *ast.SelectStmt", stmt.AsSelect)
+	}
+	if len(sel.Targets) != 2 {
+		t.Errorf("select targets = %d, want 2", len(sel.Targets))
+	}
+}
+
+func TestCreateTable_CTASWithColumns(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT, name VARCHAR) AS SELECT 1, 'hello'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Errorf("columns = %d, want 2", len(stmt.Columns))
+	}
+	if stmt.AsSelect == nil {
+		t.Fatal("expected AsSelect != nil")
+	}
+	sel, ok := stmt.AsSelect.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("AsSelect is %T, want *ast.SelectStmt", stmt.AsSelect)
+	}
+	if len(sel.Targets) != 2 {
+		t.Errorf("select targets = %d, want 2", len(sel.Targets))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 4: Column features + constraints
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_ColumnNotNull(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT NOT NULL, name VARCHAR NULL)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+	if !stmt.Columns[0].NotNull {
+		t.Error("col[0]: expected NotNull=true")
+	}
+	if !stmt.Columns[1].Nullable {
+		t.Error("col[1]: expected Nullable=true")
+	}
+}
+
+func TestCreateTable_ColumnDefault(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT DEFAULT 0, name VARCHAR DEFAULT 'unknown')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+	lit0, ok := stmt.Columns[0].Default.(*ast.Literal)
+	if !ok {
+		t.Fatalf("col[0] default: expected *ast.Literal, got %T", stmt.Columns[0].Default)
+	}
+	if lit0.Kind != ast.LitInt {
+		t.Errorf("col[0] default kind = %v, want LitInt", lit0.Kind)
+	}
+	lit1, ok := stmt.Columns[1].Default.(*ast.Literal)
+	if !ok {
+		t.Fatalf("col[1] default: expected *ast.Literal, got %T", stmt.Columns[1].Default)
+	}
+	if lit1.Kind != ast.LitString {
+		t.Errorf("col[1] default kind = %v, want LitString", lit1.Kind)
+	}
+}
+
+func TestCreateTable_Identity(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT IDENTITY(1, 1))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.Identity == nil {
+		t.Fatal("expected Identity != nil")
+	}
+	if col.Identity.Start == nil || *col.Identity.Start != 1 {
+		t.Errorf("Identity.Start = %v, want 1", col.Identity.Start)
+	}
+	if col.Identity.Increment == nil || *col.Identity.Increment != 1 {
+		t.Errorf("Identity.Increment = %v, want 1", col.Identity.Increment)
+	}
+}
+
+func TestCreateTable_AutoincrementStartIncrement(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT AUTOINCREMENT START 100 INCREMENT 10)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.Identity == nil {
+		t.Fatal("expected Identity != nil")
+	}
+	if col.Identity.Start == nil || *col.Identity.Start != 100 {
+		t.Errorf("Identity.Start = %v, want 100", col.Identity.Start)
+	}
+	if col.Identity.Increment == nil || *col.Identity.Increment != 10 {
+		t.Errorf("Identity.Increment = %v, want 10", col.Identity.Increment)
+	}
+}
+
+func TestCreateTable_IdentityOrder(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT IDENTITY ORDER)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.Identity == nil {
+		t.Fatal("expected Identity != nil")
+	}
+	if col.Identity.Order == nil || !*col.Identity.Order {
+		t.Errorf("Identity.Order = %v, want true", col.Identity.Order)
+	}
+}
+
+func TestCreateTable_Collate(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (name VARCHAR COLLATE 'en-ci')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.Collate != "en-ci" {
+		t.Errorf("Collate = %q, want %q", col.Collate, "en-ci")
+	}
+}
+
+func TestCreateTable_ColumnComment(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT COMMENT 'primary identifier')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.Comment == nil {
+		t.Fatal("expected Comment != nil")
+	}
+	if *col.Comment != "primary identifier" {
+		t.Errorf("Comment = %q, want %q", *col.Comment, "primary identifier")
+	}
+}
+
+func TestCreateTable_InlinePrimaryKey(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT PRIMARY KEY)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.InlineConstraint == nil {
+		t.Fatal("expected InlineConstraint != nil")
+	}
+	if col.InlineConstraint.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint type = %v, want ConstrPrimaryKey", col.InlineConstraint.Type)
+	}
+}
+
+func TestCreateTable_InlineUnique(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (email VARCHAR UNIQUE)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.InlineConstraint == nil {
+		t.Fatal("expected InlineConstraint != nil")
+	}
+	if col.InlineConstraint.Type != ast.ConstrUnique {
+		t.Errorf("constraint type = %v, want ConstrUnique", col.InlineConstraint.Type)
+	}
+}
+
+func TestCreateTable_InlineForeignKey(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (customer_id INT FOREIGN KEY REFERENCES customers (id))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.InlineConstraint == nil {
+		t.Fatal("expected InlineConstraint != nil")
+	}
+	if col.InlineConstraint.Type != ast.ConstrForeignKey {
+		t.Errorf("constraint type = %v, want ConstrForeignKey", col.InlineConstraint.Type)
+	}
+	ref := col.InlineConstraint.References
+	if ref == nil {
+		t.Fatal("expected References != nil")
+	}
+	if ref.Table.Normalize() != "CUSTOMERS" {
+		t.Errorf("references table = %q, want %q", ref.Table.Normalize(), "CUSTOMERS")
+	}
+	if len(ref.Columns) != 1 || ref.Columns[0].Normalize() != "ID" {
+		t.Errorf("references columns = %v, want [ID]", ref.Columns)
+	}
+}
+
+func TestCreateTable_NamedInlineConstraint(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT CONSTRAINT pk_t PRIMARY KEY)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.InlineConstraint == nil {
+		t.Fatal("expected InlineConstraint != nil")
+	}
+	if col.InlineConstraint.Name.Normalize() != "PK_T" {
+		t.Errorf("constraint name = %q, want %q", col.InlineConstraint.Name.Normalize(), "PK_T")
+	}
+	if col.InlineConstraint.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint type = %v, want ConstrPrimaryKey", col.InlineConstraint.Type)
+	}
+}
+
+func TestCreateTable_OutOfLinePK(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT, name VARCHAR, PRIMARY KEY (id))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Errorf("columns = %d, want 2", len(stmt.Columns))
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if con.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint type = %v, want ConstrPrimaryKey", con.Type)
+	}
+	if len(con.Columns) != 1 || con.Columns[0].Normalize() != "ID" {
+		t.Errorf("constraint columns = %v, want [ID]", con.Columns)
+	}
+}
+
+func TestCreateTable_OutOfLineCompositePK(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if len(con.Columns) != 2 {
+		t.Errorf("PK columns = %d, want 2", len(con.Columns))
+	}
+	if con.Columns[0].Normalize() != "A" {
+		t.Errorf("PK col[0] = %q, want %q", con.Columns[0].Normalize(), "A")
+	}
+	if con.Columns[1].Normalize() != "B" {
+		t.Errorf("PK col[1] = %q, want %q", con.Columns[1].Normalize(), "B")
+	}
+}
+
+func TestCreateTable_OutOfLineFK(t *testing.T) {
+	stmt, errs := testParseCreateTable(`CREATE TABLE t (
+		id INT,
+		customer_id INT,
+		FOREIGN KEY (customer_id) REFERENCES customers (id) ON DELETE CASCADE ON UPDATE SET NULL
+	)`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if con.Type != ast.ConstrForeignKey {
+		t.Errorf("constraint type = %v, want ConstrForeignKey", con.Type)
+	}
+	if con.References == nil {
+		t.Fatal("expected References != nil")
+	}
+	if con.References.OnDelete != ast.RefActCascade {
+		t.Errorf("OnDelete = %v, want RefActCascade", con.References.OnDelete)
+	}
+	if con.References.OnUpdate != ast.RefActSetNull {
+		t.Errorf("OnUpdate = %v, want RefActSetNull", con.References.OnUpdate)
+	}
+}
+
+func TestCreateTable_OutOfLineUnique(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (a INT, b INT, UNIQUE (a, b))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if con.Type != ast.ConstrUnique {
+		t.Errorf("constraint type = %v, want ConstrUnique", con.Type)
+	}
+	if len(con.Columns) != 2 {
+		t.Errorf("unique columns = %d, want 2", len(con.Columns))
+	}
+}
+
+func TestCreateTable_NamedConstraint(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT, CONSTRAINT pk_t PRIMARY KEY (id))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if con.Name.Normalize() != "PK_T" {
+		t.Errorf("constraint name = %q, want %q", con.Name.Normalize(), "PK_T")
+	}
+	if con.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint type = %v, want ConstrPrimaryKey", con.Type)
+	}
+}
+
+func TestCreateTable_MixedColumnsAndConstraints(t *testing.T) {
+	stmt, errs := testParseCreateTable(`CREATE TABLE t (
+		id INT NOT NULL,
+		email VARCHAR NOT NULL,
+		customer_id INT,
+		PRIMARY KEY (id),
+		UNIQUE (email),
+		FOREIGN KEY (customer_id) REFERENCES customers (id)
+	)`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 3 {
+		t.Errorf("columns = %d, want 3", len(stmt.Columns))
+	}
+	if len(stmt.Constraints) != 3 {
+		t.Fatalf("constraints = %d, want 3", len(stmt.Constraints))
+	}
+	if stmt.Constraints[0].Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint[0] type = %v, want ConstrPrimaryKey", stmt.Constraints[0].Type)
+	}
+	if stmt.Constraints[1].Type != ast.ConstrUnique {
+		t.Errorf("constraint[1] type = %v, want ConstrUnique", stmt.Constraints[1].Type)
+	}
+	if stmt.Constraints[2].Type != ast.ConstrForeignKey {
+		t.Errorf("constraint[2] type = %v, want ConstrForeignKey", stmt.Constraints[2].Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 5: Table properties + acceptance
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_ClusterBy(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT) CLUSTER BY (id)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.ClusterBy) != 1 {
+		t.Errorf("ClusterBy length = %d, want 1", len(stmt.ClusterBy))
+	}
+}
+
+func TestCreateTable_ClusterByLinear(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (a INT, b INT) CLUSTER BY LINEAR (a, b)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Linear {
+		t.Error("expected Linear=true")
+	}
+	if len(stmt.ClusterBy) != 2 {
+		t.Errorf("ClusterBy length = %d, want 2", len(stmt.ClusterBy))
+	}
+}
+
+func TestCreateTable_TableComment(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT) COMMENT = 'my table'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Comment == nil {
+		t.Fatal("expected Comment != nil")
+	}
+	if *stmt.Comment != "my table" {
+		t.Errorf("Comment = %q, want %q", *stmt.Comment, "my table")
+	}
+}
+
+func TestCreateTable_CopyGrants(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT) COPY GRANTS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.CopyGrants {
+		t.Error("expected CopyGrants=true")
+	}
+}
+
+func TestCreateTable_WithTag(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT) WITH TAG (env = 'prod', team = 'data')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Tags) != 2 {
+		t.Fatalf("tags = %d, want 2", len(stmt.Tags))
+	}
+	if stmt.Tags[0].Name.Normalize() != "ENV" {
+		t.Errorf("tag[0] name = %q, want %q", stmt.Tags[0].Name.Normalize(), "ENV")
+	}
+	if stmt.Tags[0].Value != "prod" {
+		t.Errorf("tag[0] value = %q, want %q", stmt.Tags[0].Value, "prod")
+	}
+	if stmt.Tags[1].Name.Normalize() != "TEAM" {
+		t.Errorf("tag[1] name = %q, want %q", stmt.Tags[1].Name.Normalize(), "TEAM")
+	}
+	if stmt.Tags[1].Value != "data" {
+		t.Errorf("tag[1] value = %q, want %q", stmt.Tags[1].Value, "data")
+	}
+}
+
+func TestCreateTable_DataRetention(t *testing.T) {
+	_, errs := testParseCreateTable("CREATE TABLE t (id INT) DATA_RETENTION_TIME_IN_DAYS = 90")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+}
+
+func TestCreateTable_ChangeTracking(t *testing.T) {
+	_, errs := testParseCreateTable("CREATE TABLE t (id INT) CHANGE_TRACKING = TRUE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+}
+
+func TestCreateTable_MaskingPolicy(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (ssn VARCHAR WITH MASKING POLICY ssn_mask)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if col.MaskingPolicy == nil {
+		t.Fatal("expected MaskingPolicy != nil")
+	}
+	if col.MaskingPolicy.Normalize() != "SSN_MASK" {
+		t.Errorf("MaskingPolicy name = %q, want %q", col.MaskingPolicy.Normalize(), "SSN_MASK")
+	}
+}
+
+func TestCreateTable_VirtualColumn(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (a INT, b INT, c INT AS (a + b))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 3 {
+		t.Fatalf("columns = %d, want 3", len(stmt.Columns))
+	}
+	col := stmt.Columns[2]
+	if col.VirtualExpr == nil {
+		t.Fatal("expected VirtualExpr != nil")
+	}
+	_, ok := col.VirtualExpr.(*ast.BinaryExpr)
+	if !ok {
+		t.Errorf("VirtualExpr is %T, want *ast.BinaryExpr", col.VirtualExpr)
+	}
+}
+
+func TestCreateTable_Complex(t *testing.T) {
+	input := `CREATE OR REPLACE TABLE mydb.myschema.orders (
+    id INT IDENTITY(1, 1) NOT NULL,
+    customer_id INT NOT NULL,
+    amount NUMBER(10, 2) DEFAULT 0,
+    status VARCHAR(50) COLLATE 'en-ci',
+    created_at TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    CONSTRAINT pk_orders PRIMARY KEY (id),
+    CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers (id) ON DELETE CASCADE,
+    UNIQUE (customer_id, created_at)
+)
+CLUSTER BY (customer_id)
+COMMENT = 'Order records'
+COPY GRANTS`
+
+	stmt, errs := testParseCreateTable(input)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	// Table name
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA.ORDERS" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB.MYSCHEMA.ORDERS")
+	}
+
+	// Modifiers
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.CopyGrants {
+		t.Error("expected CopyGrants=true")
+	}
+
+	// Comment
+	if stmt.Comment == nil || *stmt.Comment != "Order records" {
+		t.Errorf("Comment = %v, want 'Order records'", stmt.Comment)
+	}
+
+	// ClusterBy
+	if len(stmt.ClusterBy) != 1 {
+		t.Errorf("ClusterBy length = %d, want 1", len(stmt.ClusterBy))
+	}
+
+	// Columns
+	if len(stmt.Columns) != 5 {
+		t.Fatalf("columns = %d, want 5", len(stmt.Columns))
+	}
+
+	// col[0]: id INT IDENTITY(1,1) NOT NULL
+	col0 := stmt.Columns[0]
+	if col0.Identity == nil {
+		t.Error("col[0]: expected Identity != nil")
+	} else {
+		if col0.Identity.Start == nil || *col0.Identity.Start != 1 {
+			t.Errorf("col[0] Identity.Start = %v, want 1", col0.Identity.Start)
+		}
+		if col0.Identity.Increment == nil || *col0.Identity.Increment != 1 {
+			t.Errorf("col[0] Identity.Increment = %v, want 1", col0.Identity.Increment)
+		}
+	}
+	if !col0.NotNull {
+		t.Error("col[0]: expected NotNull=true")
+	}
+
+	// col[1]: customer_id INT NOT NULL
+	if !stmt.Columns[1].NotNull {
+		t.Error("col[1]: expected NotNull=true")
+	}
+
+	// Constraints
+	if len(stmt.Constraints) != 3 {
+		t.Fatalf("constraints = %d, want 3", len(stmt.Constraints))
+	}
+
+	// constraint[0]: CONSTRAINT pk_orders PRIMARY KEY (id)
+	con0 := stmt.Constraints[0]
+	if con0.Name.Normalize() != "PK_ORDERS" {
+		t.Errorf("constraint[0] name = %q, want %q", con0.Name.Normalize(), "PK_ORDERS")
+	}
+	if con0.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint[0] type = %v, want ConstrPrimaryKey", con0.Type)
+	}
+
+	// constraint[1]: CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers (id) ON DELETE CASCADE
+	con1 := stmt.Constraints[1]
+	if con1.Name.Normalize() != "FK_CUSTOMER" {
+		t.Errorf("constraint[1] name = %q, want %q", con1.Name.Normalize(), "FK_CUSTOMER")
+	}
+	if con1.Type != ast.ConstrForeignKey {
+		t.Errorf("constraint[1] type = %v, want ConstrForeignKey", con1.Type)
+	}
+	if con1.References == nil || con1.References.OnDelete != ast.RefActCascade {
+		t.Errorf("constraint[1] OnDelete = %v, want RefActCascade", con1.References)
+	}
+}

--- a/snowflake/parser/create_table_test.go
+++ b/snowflake/parser/create_table_test.go
@@ -676,6 +676,23 @@ func TestCreateTable_MaskingPolicy(t *testing.T) {
 	}
 }
 
+func TestCreateTable_ColumnWithTag(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT WITH TAG (sensitivity = 'PII', team = 'security'))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	col := stmt.Columns[0]
+	if len(col.Tags) != 2 {
+		t.Fatalf("col tags = %d, want 2", len(col.Tags))
+	}
+	if col.Tags[0].Name.Normalize() != "SENSITIVITY" || col.Tags[0].Value != "PII" {
+		t.Errorf("tag[0] = %v/%v, want SENSITIVITY/PII", col.Tags[0].Name.Normalize(), col.Tags[0].Value)
+	}
+	if col.Tags[1].Name.Normalize() != "TEAM" || col.Tags[1].Value != "security" {
+		t.Errorf("tag[1] = %v/%v, want TEAM/security", col.Tags[1].Name.Normalize(), col.Tags[1].Value)
+	}
+}
+
 func TestCreateTable_VirtualColumn(t *testing.T) {
 	stmt, errs := testParseCreateTable("CREATE TABLE t (a INT, b INT, c INT AS (a + b))")
 	if len(errs) > 0 {

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -377,6 +377,21 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		tok := p.advance()
 		return &ast.StarExpr{Loc: tok.Loc}, nil
 
+	// Reserved keywords that are also common zero-argument functions:
+	// CURRENT_TIMESTAMP([prec]), CURRENT_DATE, CURRENT_TIME([prec]).
+	// Snowflake allows them both with and without parentheses.
+	case kwCURRENT_TIMESTAMP, kwCURRENT_DATE, kwCURRENT_TIME:
+		tok := p.advance()
+		name := ast.ObjectName{
+			Name: ast.Ident{Name: tok.Str, Loc: tok.Loc},
+			Loc:  tok.Loc,
+		}
+		if p.cur.Type == '(' {
+			return p.parseFuncCall(name, tok.Loc)
+		}
+		// Without parens — treat as a no-arg function call.
+		return &ast.FuncCallExpr{Name: name, Loc: tok.Loc}, nil
+
 	default:
 		// Lambda detection: single ident followed by ->
 		if p.isIdentToken() && p.peekNext().Type == tokArrow {

--- a/snowflake/parser/identifiers.go
+++ b/snowflake/parser/identifiers.go
@@ -45,6 +45,30 @@ func (p *Parser) parseIdentStrict() (ast.Ident, error) {
 	}
 }
 
+// parseNamePart parses one component of a dotted object name. It is more
+// permissive than parseIdent: it accepts any keyword token (including reserved
+// keywords) in addition to bare and quoted identifiers. This matches Snowflake
+// behaviour where reserved words such as SCHEMA or DATABASE are valid when
+// used as object-name components in a dotted path (e.g. mydb.schema.t1).
+func (p *Parser) parseNamePart() (ast.Ident, error) {
+	switch {
+	case p.cur.Type == tokIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	case p.cur.Type == tokQuotedIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: true, Loc: tok.Loc}, nil
+	case p.cur.Type >= 700:
+		// Any keyword — reserved or not — is accepted as a name part.
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: false, Loc: tok.Loc}, nil
+	}
+	return ast.Ident{}, &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "expected identifier",
+	}
+}
+
 // parseObjectName parses a dotted object name with 1, 2, or 3 parts:
 //
 //	table
@@ -54,8 +78,11 @@ func (p *Parser) parseIdentStrict() (ast.Ident, error) {
 // Starts by parsing one identifier, then greedily consumes up to two more
 // dot-separated identifiers if present. Returns *ast.ObjectName with the
 // correct parts populated and Loc spanning all parts.
+//
+// Each name part is parsed with parseNamePart, which accepts any keyword
+// (including reserved keywords such as SCHEMA or DATABASE) as an identifier.
 func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
-	first, err := p.parseIdent()
+	first, err := p.parseNamePart()
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +96,7 @@ func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
 	}
 	p.advance() // consume first dot
 
-	second, err := p.parseIdent()
+	second, err := p.parseNamePart()
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +111,7 @@ func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
 	}
 	p.advance() // consume second dot
 
-	third, err := p.parseIdent()
+	third, err := p.parseNamePart()
 	if err != nil {
 		return nil, err
 	}

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -183,7 +183,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	switch p.cur.Type {
 	// DDL (6 cases)
 	case kwCREATE:
-		return p.unsupported("CREATE")
+		return p.parseCreateStmt()
 	case kwALTER:
 		return p.unsupported("ALTER")
 	case kwDROP:


### PR DESCRIPTION
## Summary

- Add CREATE TABLE parsing for the Snowflake engine — the most complex DDL statement and gateway to bytebase's 14 lint rules
- Implements full `CREATE [OR REPLACE] [TRANSIENT|TEMPORARY|VOLATILE] TABLE [IF NOT EXISTS] name` with all forms: standard column/constraint definitions, CTAS, LIKE, CLONE (with time travel)
- Replaces F4's `unsupported("CREATE")` stub with a sub-dispatch pattern that future nodes (CREATE VIEW, CREATE DATABASE, etc.) can plug into

## What's included

**AST types (3 new Node types):** `CreateTableStmt`, `ColumnDef`, `TableConstraint` + helper structs (`InlineConstraint`, `ForeignKeyRef`, `IdentitySpec`, `TagAssignment`, `CloneSource`) + enums (`ConstraintType`, `ReferenceAction`)

**Parser (~1150 LOC, 18 functions):** Full column definitions (name + type + NOT NULL/NULL + DEFAULT + IDENTITY/AUTOINCREMENT + COLLATE + MASKING POLICY + inline constraints + COMMENT + WITH TAG + virtual columns), table-level constraints (PRIMARY KEY, FOREIGN KEY with ON DELETE/UPDATE, UNIQUE, named constraints with CONSTRAINT keyword), table properties (CLUSTER BY [LINEAR], COPY GRANTS, COMMENT, WITH TAG, DATA_RETENTION, CHANGE_TRACKING consumed without error)

**Bonus fixes discovered during testing:**
- `parseObjectName` now accepts reserved keywords in dotted paths (e.g. `mydb.schema.t1`) via new `parseNamePart` helper
- `parseIdentitySpec` accepts `START n` / `INCREMENT n` without optional WITH/BY
- `CURRENT_TIMESTAMP`, `CURRENT_DATE`, `CURRENT_TIME` handled as zero-arg functions in expressions (needed for `DEFAULT CURRENT_TIMESTAMP()`)

## Test plan

- [x] 43 unit tests covering all creation forms, modifiers, column features, constraints, table properties, and a complex real-world scenario
- [x] Full `go test ./snowflake/...` passes with no regressions
- [x] `gofmt` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)