### PR TITLE
feat(doris): SELECT core parser — first real statement parser (T1.4)

### DIFF
--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -66,6 +66,14 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *OrderByItem:
 		return v.Loc
+	case *SelectStmt:
+		return v.Loc
+	case *SelectItem:
+		return v.Loc
+	case *TableRef:
+		return v.Loc
+	case *JoinClause:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -103,6 +103,20 @@ const (
 
 	// T_OrderByItem is the tag for *OrderByItem (expr ASC/DESC NULLS FIRST/LAST).
 	T_OrderByItem
+
+	// SELECT statement nodes (T1.4).
+
+	// T_SelectStmt is the tag for *SelectStmt.
+	T_SelectStmt
+
+	// T_SelectItem is the tag for *SelectItem (one item in the SELECT list).
+	T_SelectItem
+
+	// T_TableRef is the tag for *TableRef (table reference in FROM clause).
+	T_TableRef
+
+	// T_JoinClause is the tag for *JoinClause (JOIN expression in FROM).
+	T_JoinClause
 )
 
 // String returns a human-readable representation of the tag.
@@ -166,6 +180,14 @@ func (t NodeTag) String() string {
 		return "IntervalExpr"
 	case T_OrderByItem:
 		return "OrderByItem"
+	case T_SelectStmt:
+		return "SelectStmt"
+	case T_SelectItem:
+		return "SelectItem"
+	case T_TableRef:
+		return "TableRef"
+	case T_JoinClause:
+		return "JoinClause"
 	default:
 		return "Unknown"
 	}

--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -1,0 +1,114 @@
+package ast
+
+// This file holds AST node types for SELECT statement parsing (T1.4).
+
+// ---------------------------------------------------------------------------
+// SELECT statement
+// ---------------------------------------------------------------------------
+
+// SelectStmt represents a full SELECT statement.
+//
+//	SELECT [DISTINCT|ALL] select_list
+//	  [FROM table_references]
+//	  [WHERE condition]
+//	  [GROUP BY expr, ...]
+//	  [HAVING condition]
+//	  [QUALIFY condition]
+//	  [ORDER BY expr [ASC|DESC] [NULLS FIRST|LAST], ...]
+//	  [LIMIT count [OFFSET offset]]
+type SelectStmt struct {
+	Distinct bool          // DISTINCT keyword present
+	All      bool          // ALL keyword present (explicit, rarely used)
+	Items    []*SelectItem // SELECT list
+	From     []Node        // FROM clause table references (TableRef or JoinClause)
+	Where    Node          // WHERE expression (nil if absent)
+	GroupBy  []Node        // GROUP BY expressions
+	Having   Node          // HAVING expression (nil if absent)
+	Qualify  Node          // QUALIFY expression (nil if absent)
+	OrderBy  []*OrderByItem // ORDER BY items
+	Limit    Node          // LIMIT expression (nil if absent)
+	Offset   Node          // OFFSET expression (nil if absent)
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *SelectStmt) Tag() NodeTag { return T_SelectStmt }
+
+// Compile-time assertion that *SelectStmt satisfies Node.
+var _ Node = (*SelectStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// SELECT list item
+// ---------------------------------------------------------------------------
+
+// SelectItem represents one item in the SELECT list:
+//   - expr [AS alias]    — a computed expression with optional alias
+//   - *                  — all columns
+//   - table.*            — all columns from a specific table
+type SelectItem struct {
+	Expr  Node   // the expression; for *, this is nil
+	Alias string // optional alias name; empty if absent
+	Star  bool   // true for * or table.*
+	// For table.*, TableName holds the qualifier ObjectName.
+	TableName *ObjectName
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *SelectItem) Tag() NodeTag { return T_SelectItem }
+
+// Compile-time assertion that *SelectItem satisfies Node.
+var _ Node = (*SelectItem)(nil)
+
+// ---------------------------------------------------------------------------
+// Table reference
+// ---------------------------------------------------------------------------
+
+// TableRef represents a table reference in the FROM clause.
+//
+//	table_name [AS alias]
+//	db.table_name [AS alias]
+//	catalog.db.table_name [AS alias]
+type TableRef struct {
+	Name  *ObjectName // table name (may be qualified: db.table or catalog.db.table)
+	Alias string      // optional alias; empty if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *TableRef) Tag() NodeTag { return T_TableRef }
+
+// Compile-time assertion that *TableRef satisfies Node.
+var _ Node = (*TableRef)(nil)
+
+// ---------------------------------------------------------------------------
+// JOIN clause (basic structure for T1.4; T1.5 will flesh out)
+// ---------------------------------------------------------------------------
+
+// JoinType classifies the kind of join.
+type JoinType int
+
+const (
+	JoinInner JoinType = iota // [INNER] JOIN
+	JoinLeft                  // LEFT [OUTER] JOIN
+	JoinRight                 // RIGHT [OUTER] JOIN
+	JoinFull                  // FULL [OUTER] JOIN
+	JoinCross                 // CROSS JOIN
+)
+
+// JoinClause represents a JOIN expression in the FROM clause.
+type JoinClause struct {
+	Type    JoinType
+	Left    Node   // left side of the join
+	Right   Node   // right side of the join
+	Natural bool   // NATURAL join
+	On      Node   // ON condition (nil if absent)
+	Using   []string // USING (col1, col2, ...) column names
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *JoinClause) Tag() NodeTag { return T_JoinClause }
+
+// Compile-time assertion that *JoinClause satisfies Node.
+var _ Node = (*JoinClause)(nil)

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -108,5 +108,48 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Value)
 	case *OrderByItem:
 		Walk(v, n.Expr)
+
+	// SELECT statement nodes (T1.4).
+	case *SelectStmt:
+		for _, item := range n.Items {
+			Walk(v, item)
+		}
+		walkNodes(v, n.From)
+		if n.Where != nil {
+			Walk(v, n.Where)
+		}
+		walkNodes(v, n.GroupBy)
+		if n.Having != nil {
+			Walk(v, n.Having)
+		}
+		if n.Qualify != nil {
+			Walk(v, n.Qualify)
+		}
+		for _, item := range n.OrderBy {
+			Walk(v, item)
+		}
+		if n.Limit != nil {
+			Walk(v, n.Limit)
+		}
+		if n.Offset != nil {
+			Walk(v, n.Offset)
+		}
+	case *SelectItem:
+		if n.Expr != nil {
+			Walk(v, n.Expr)
+		}
+		if n.TableName != nil {
+			Walk(v, n.TableName)
+		}
+	case *TableRef:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *JoinClause:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+		if n.On != nil {
+			Walk(v, n.On)
+		}
 	}
 }

--- a/doris/parser/diagnose_test.go
+++ b/doris/parser/diagnose_test.go
@@ -38,8 +38,9 @@ func TestDiagnoseUnterminatedComment(t *testing.T) {
 }
 
 func TestDiagnoseMultiStatement(t *testing.T) {
-	// Multiple statements each produce their own "unsupported" diagnostics.
-	diags := Diagnose("SELECT 1; INSERT INTO t")
+	// SELECT is now supported; INSERT is still unsupported.
+	// The INSERT statement produces a diagnostic.
+	diags := Diagnose("INSERT INTO t; UPDATE t SET c = 1")
 	if len(diags) < 2 {
 		t.Errorf("expected at least 2 diagnostics, got %d", len(diags))
 	}

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -205,7 +205,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// DML
 	case kwSELECT:
-		return p.unsupported("SELECT")
+		return p.parseSelectStmt()
 	case kwWITH:
 		return p.unsupported("WITH")
 	case kwINSERT:

--- a/doris/parser/parser_test.go
+++ b/doris/parser/parser_test.go
@@ -20,8 +20,8 @@ func TestParseEmpty(t *testing.T) {
 }
 
 func TestParseUnsupported(t *testing.T) {
-	// All statement types are stubbed as unsupported in F4.
-	file, errs := Parse("SELECT 1")
+	// INSERT is still unsupported.
+	file, errs := Parse("INSERT INTO t VALUES (1)")
 	if file == nil {
 		t.Fatal("expected non-nil File")
 	}
@@ -32,21 +32,23 @@ func TestParseUnsupported(t *testing.T) {
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(errs))
 	}
-	if errs[0].Msg != "SELECT statement parsing is not yet supported" {
+	if errs[0].Msg != "INSERT statement parsing is not yet supported" {
 		t.Errorf("unexpected error: %q", errs[0].Msg)
 	}
 }
 
 func TestParseMultipleUnsupported(t *testing.T) {
+	// SELECT is now supported; INSERT and CREATE TABLE are still unsupported.
 	file, errs := Parse("SELECT 1; INSERT INTO t VALUES (1); CREATE TABLE t (id INT)")
 	if file == nil {
 		t.Fatal("expected non-nil File")
 	}
-	if len(file.Stmts) != 0 {
-		t.Errorf("expected 0 stmts, got %d", len(file.Stmts))
+	// SELECT 1 should parse successfully, producing 1 stmt.
+	if len(file.Stmts) != 1 {
+		t.Errorf("expected 1 stmt, got %d", len(file.Stmts))
 	}
-	if len(errs) != 3 {
-		t.Fatalf("expected 3 errors, got %d: %v", len(errs), errs)
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
 	}
 }
 

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -1,0 +1,660 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// ---------------------------------------------------------------------------
+// SELECT statement parser (T1.4)
+// ---------------------------------------------------------------------------
+
+// parseSelectStmt parses a full SELECT statement:
+//
+//	SELECT [DISTINCT|ALL] select_list
+//	  [FROM table_references]
+//	  [WHERE condition]
+//	  [GROUP BY expr, ...]
+//	  [HAVING condition]
+//	  [QUALIFY condition]
+//	  [ORDER BY expr [ASC|DESC] [NULLS FIRST|LAST], ...]
+//	  [LIMIT count [OFFSET offset]]
+func (p *Parser) parseSelectStmt() (*ast.SelectStmt, error) {
+	selectTok, err := p.expect(kwSELECT)
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.SelectStmt{
+		Loc: ast.Loc{Start: selectTok.Loc.Start},
+	}
+
+	// DISTINCT / ALL
+	if p.cur.Kind == kwDISTINCT {
+		p.advance()
+		stmt.Distinct = true
+	} else if p.cur.Kind == kwALL {
+		p.advance()
+		stmt.All = true
+	}
+
+	// SELECT list
+	items, err := p.parseSelectList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Items = items
+
+	// FROM clause
+	if p.cur.Kind == kwFROM {
+		p.advance() // consume FROM
+		from, err := p.parseFromClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+	}
+
+	// WHERE clause
+	if p.cur.Kind == kwWHERE {
+		p.advance() // consume WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	// GROUP BY clause
+	if p.cur.Kind == kwGROUP {
+		groupBy, err := p.parseGroupByClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.GroupBy = groupBy
+	}
+
+	// HAVING clause
+	if p.cur.Kind == kwHAVING {
+		p.advance() // consume HAVING
+		having, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Having = having
+	}
+
+	// QUALIFY clause (Doris extension)
+	if p.cur.Kind == kwQUALIFY {
+		p.advance() // consume QUALIFY
+		qualify, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Qualify = qualify
+	}
+
+	// ORDER BY clause
+	if p.cur.Kind == kwORDER {
+		p.advance() // consume ORDER
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		orderBy, err := p.parseOrderByList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.OrderBy = orderBy
+	}
+
+	// LIMIT / OFFSET
+	if p.cur.Kind == kwLIMIT {
+		limit, offset, err := p.parseLimitClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Limit = limit
+		stmt.Offset = offset
+	}
+
+	// Set End location to the last consumed token.
+	stmt.Loc.End = p.prev.Loc.End
+
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// SELECT list
+// ---------------------------------------------------------------------------
+
+// parseSelectList parses comma-separated SELECT items.
+func (p *Parser) parseSelectList() ([]*ast.SelectItem, error) {
+	var items []*ast.SelectItem
+
+	item, err := p.parseSelectItem()
+	if err != nil {
+		return nil, err
+	}
+	items = append(items, item)
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		item, err = p.parseSelectItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+// parseSelectItem parses one item in the SELECT list:
+//   - *                  — all columns
+//   - table.*            — all columns from a specific table
+//   - expr [AS alias]    — a computed expression with optional alias
+func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
+	startLoc := p.cur.Loc
+
+	// Bare star: SELECT *
+	if p.cur.Kind == int('*') {
+		p.advance() // consume '*'
+		return &ast.SelectItem{
+			Star: true,
+			Loc:  ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+		}, nil
+	}
+
+	// Try to detect table.* pattern:
+	// If we see an identifier followed by '.', it might be table.* or table.col.
+	// We need to check for qualified star: ident.* or ident.ident.*
+	if p.isSelectIdentToken() && p.peekNext().Kind == int('.') {
+		// Save state to potentially backtrack.
+		// Parse the multipart identifier first, then check for .*
+		name, err := p.parseMultipartIdentifier()
+		if err != nil {
+			return nil, err
+		}
+
+		// Check for .* after the multipart identifier
+		if p.cur.Kind == int('.') && p.peekNext().Kind == int('*') {
+			p.advance() // consume '.'
+			p.advance() // consume '*'
+			return &ast.SelectItem{
+				Star:      true,
+				TableName: name,
+				Loc:       ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+			}, nil
+		}
+
+		// Not a qualified star — the multipart identifier is a column ref or
+		// function call. Check if it's a function call.
+		if p.cur.Kind == int('(') {
+			fc, err := p.parseFuncCall(name)
+			if err != nil {
+				return nil, err
+			}
+			item := &ast.SelectItem{
+				Expr: fc,
+				Loc:  ast.Loc{Start: startLoc.Start},
+			}
+			alias := p.parseOptionalAlias()
+			if alias != "" {
+				item.Alias = alias
+			}
+			item.Loc.End = p.prev.Loc.End
+			return item, nil
+		}
+
+		// Plain column reference — check for alias.
+		colRef := &ast.ColumnRef{
+			Name: name,
+			Loc:  name.Loc,
+		}
+		item := &ast.SelectItem{
+			Expr: colRef,
+			Loc:  ast.Loc{Start: startLoc.Start},
+		}
+		alias := p.parseOptionalAlias()
+		if alias != "" {
+			item.Alias = alias
+		}
+		item.Loc.End = p.prev.Loc.End
+		return item, nil
+	}
+
+	// General expression
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	item := &ast.SelectItem{
+		Expr: expr,
+		Loc:  ast.Loc{Start: startLoc.Start},
+	}
+
+	alias := p.parseOptionalAlias()
+	if alias != "" {
+		item.Alias = alias
+	}
+
+	item.Loc.End = p.prev.Loc.End
+	return item, nil
+}
+
+// isSelectIdentToken reports whether the current token can start an identifier
+// in the SELECT list context (same as isExprIdentToken).
+func (p *Parser) isSelectIdentToken() bool {
+	return p.isExprIdentToken()
+}
+
+// parseOptionalAlias parses an optional alias after an expression in SELECT
+// or FROM context. Returns the alias string, or empty if no alias.
+//
+// Alias forms:
+//   - AS identifier
+//   - identifier (implicit, if not a clause keyword)
+func (p *Parser) parseOptionalAlias() string {
+	// Explicit: AS alias
+	if p.cur.Kind == kwAS {
+		p.advance() // consume AS
+		name, _, err := p.parseAliasIdentifier()
+		if err != nil {
+			return ""
+		}
+		return name
+	}
+
+	// Implicit alias: current token is an identifier or non-reserved keyword
+	// that does NOT start a clause.
+	if p.isAliasIdentToken() {
+		name, _, err := p.parseAliasIdentifier()
+		if err != nil {
+			return ""
+		}
+		return name
+	}
+
+	return ""
+}
+
+// isAliasIdentToken reports whether the current token can be used as an
+// implicit alias. Must be an identifier-like token that is NOT a clause keyword.
+func (p *Parser) isAliasIdentToken() bool {
+	switch p.cur.Kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		if p.cur.Kind >= 700 && !IsReserved(p.cur.Kind) && !isSelectClauseKeyword(p.cur.Kind) {
+			return true
+		}
+		return false
+	}
+}
+
+// parseAliasIdentifier parses a single identifier that serves as an alias.
+// This accepts identifiers and non-reserved keywords.
+func (p *Parser) parseAliasIdentifier() (string, ast.Loc, error) {
+	tok := p.cur
+	switch tok.Kind {
+	case tokIdent, tokQuotedIdent:
+		p.advance()
+		return tok.Str, tok.Loc, nil
+	default:
+		// Non-reserved keywords may be used as aliases.
+		if tok.Kind >= 700 && !IsReserved(tok.Kind) {
+			p.advance()
+			return tok.Str, tok.Loc, nil
+		}
+		return "", ast.Loc{}, p.syntaxErrorAtCur()
+	}
+}
+
+// isSelectClauseKeyword returns true for keywords that start SQL clauses
+// and should NOT be consumed as implicit aliases in SELECT context.
+func isSelectClauseKeyword(t int) bool {
+	switch t {
+	case kwFROM, kwWHERE, kwGROUP, kwHAVING, kwQUALIFY, kwORDER,
+		kwLIMIT, kwOFFSET, kwUNION, kwEXCEPT, kwINTERSECT,
+		kwINTO, kwON, kwJOIN, kwINNER, kwLEFT, kwRIGHT, kwFULL,
+		kwCROSS, kwNATURAL, kwWITH, kwSELECT, kwSET,
+		kwFOR, kwLOCK, kwUSING, kwOUTER:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// FROM clause
+// ---------------------------------------------------------------------------
+
+// parseFromClause parses comma-separated FROM items.
+// The FROM keyword has already been consumed by the caller.
+func (p *Parser) parseFromClause() ([]ast.Node, error) {
+	var items []ast.Node
+
+	item, err := p.parseFromItem()
+	if err != nil {
+		return nil, err
+	}
+	items = append(items, item)
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		item, err = p.parseFromItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+// parseFromItem parses one comma-separated FROM item: a primary source
+// optionally followed by a join chain.
+func (p *Parser) parseFromItem() (ast.Node, error) {
+	left, err := p.parsePrimarySource()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseJoinChain(left)
+}
+
+// parsePrimarySource dispatches on the current token to parse a single
+// FROM source:
+//   - ( → subquery or parenthesized from-item
+//   - otherwise → parseTableRef (ObjectName + alias)
+func (p *Parser) parsePrimarySource() (ast.Node, error) {
+	startLoc := p.cur.Loc
+
+	// Parenthesized: subquery
+	if p.cur.Kind == int('(') {
+		next := p.peekNext()
+		if next.Kind == kwSELECT || next.Kind == kwWITH {
+			// Subquery in FROM: (SELECT ...) [AS] alias
+			openTok := p.advance() // consume '('
+			subq, err := p.parseSubqueryPlaceholder(openTok.Loc.Start)
+			if err != nil {
+				return nil, err
+			}
+			ref := &ast.TableRef{
+				Loc: ast.Loc{Start: startLoc.Start},
+			}
+			alias := p.parseOptionalAlias()
+			if alias != "" {
+				ref.Alias = alias
+			}
+			// Store the subquery raw text in the table name for now
+			ref.Name = &ast.ObjectName{
+				Parts: []string{subq.RawText},
+				Loc:   subq.Loc,
+			}
+			ref.Loc.End = p.prev.Loc.End
+			return ref, nil
+		}
+		// Parenthesized from-item: (t1 JOIN t2 ON ...)
+		p.advance() // consume '('
+		inner, err := p.parseFromItem()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		return inner, nil
+	}
+
+	// Default: simple table reference (ObjectName + alias)
+	return p.parseTableRef()
+}
+
+// parseTableRef parses one simple table reference: object_name [AS alias].
+func (p *Parser) parseTableRef() (*ast.TableRef, error) {
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	ref := &ast.TableRef{
+		Name: name,
+		Loc:  ast.Loc{Start: name.Loc.Start},
+	}
+
+	alias := p.parseOptionalAlias()
+	if alias != "" {
+		ref.Alias = alias
+	}
+
+	ref.Loc.End = p.prev.Loc.End
+	return ref, nil
+}
+
+// ---------------------------------------------------------------------------
+// JOIN chain (basic for T1.4)
+// ---------------------------------------------------------------------------
+
+// parseJoinChain builds a left-associative JoinClause tree from any
+// JOIN keywords following the left source.
+func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
+	for {
+		joinType, natural, ok := p.parseJoinKeywords()
+		if !ok {
+			break
+		}
+
+		right, err := p.parsePrimarySource()
+		if err != nil {
+			return nil, err
+		}
+
+		join := &ast.JoinClause{
+			Type:    joinType,
+			Left:    left,
+			Right:   right,
+			Natural: natural,
+			Loc:     ast.Loc{Start: ast.NodeLoc(left).Start},
+		}
+
+		// Parse join condition
+		switch {
+		case joinType == ast.JoinCross || natural:
+			// CROSS JOIN and NATURAL JOIN: no condition required
+
+		case p.cur.Kind == kwON:
+			p.advance() // consume ON
+			onExpr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			join.On = onExpr
+
+		case p.cur.Kind == kwUSING:
+			p.advance() // consume USING
+			if _, err := p.expect(int('(')); err != nil {
+				return nil, err
+			}
+			var cols []string
+			colName, _, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			cols = append(cols, colName)
+			for p.cur.Kind == int(',') {
+				p.advance() // consume ','
+				colName, _, err = p.parseIdentifier()
+				if err != nil {
+					return nil, err
+				}
+				cols = append(cols, colName)
+			}
+			if _, err := p.expect(int(')')); err != nil {
+				return nil, err
+			}
+			join.Using = cols
+		}
+
+		join.Loc.End = p.prev.Loc.End
+		left = join
+	}
+	return left, nil
+}
+
+// parseJoinKeywords checks whether the current token position starts a
+// JOIN keyword sequence. If so, it consumes the tokens and returns
+// (joinType, natural, true). If not, returns (0, false, false)
+// without consuming any tokens.
+func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool) {
+	// NATURAL [LEFT|RIGHT|FULL] [OUTER] JOIN
+	if p.cur.Kind == kwNATURAL {
+		next := p.peekNext()
+		if next.Kind == kwJOIN {
+			p.advance() // consume NATURAL
+			p.advance() // consume JOIN
+			return ast.JoinInner, true, true
+		}
+		if next.Kind == kwLEFT || next.Kind == kwRIGHT || next.Kind == kwFULL {
+			p.advance() // consume NATURAL
+			jt := p.consumeDirectionAndJoin()
+			return jt, true, true
+		}
+		return 0, false, false
+	}
+
+	// INNER JOIN
+	if p.cur.Kind == kwINNER {
+		next := p.peekNext()
+		if next.Kind == kwJOIN {
+			p.advance() // consume INNER
+			p.advance() // consume JOIN
+			return ast.JoinInner, false, true
+		}
+		return 0, false, false
+	}
+
+	// LEFT [OUTER] JOIN
+	if p.cur.Kind == kwLEFT {
+		next := p.peekNext()
+		if next.Kind == kwJOIN || next.Kind == kwOUTER {
+			jt := p.consumeDirectionAndJoin()
+			if jt == ast.JoinLeft {
+				return jt, false, true
+			}
+		}
+		return 0, false, false
+	}
+
+	// RIGHT [OUTER] JOIN
+	if p.cur.Kind == kwRIGHT {
+		next := p.peekNext()
+		if next.Kind == kwJOIN || next.Kind == kwOUTER {
+			jt := p.consumeDirectionAndJoin()
+			if jt == ast.JoinRight {
+				return jt, false, true
+			}
+		}
+		return 0, false, false
+	}
+
+	// FULL [OUTER] JOIN
+	if p.cur.Kind == kwFULL {
+		next := p.peekNext()
+		if next.Kind == kwJOIN || next.Kind == kwOUTER {
+			jt := p.consumeDirectionAndJoin()
+			if jt == ast.JoinFull {
+				return jt, false, true
+			}
+		}
+		return 0, false, false
+	}
+
+	// CROSS JOIN
+	if p.cur.Kind == kwCROSS {
+		next := p.peekNext()
+		if next.Kind == kwJOIN {
+			p.advance() // consume CROSS
+			p.advance() // consume JOIN
+			return ast.JoinCross, false, true
+		}
+		return 0, false, false
+	}
+
+	// Bare JOIN (= INNER)
+	if p.cur.Kind == kwJOIN {
+		p.advance() // consume JOIN
+		return ast.JoinInner, false, true
+	}
+
+	return 0, false, false
+}
+
+// consumeDirectionAndJoin consumes LEFT/RIGHT/FULL [OUTER] JOIN and returns
+// the corresponding JoinType. The caller must have already checked that
+// p.cur.Kind is kwLEFT, kwRIGHT, or kwFULL.
+func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
+	dir := p.cur.Kind
+	p.advance() // consume LEFT/RIGHT/FULL
+
+	// Optional OUTER
+	if p.cur.Kind == kwOUTER {
+		p.advance() // consume OUTER
+	}
+
+	// Expect JOIN
+	if p.cur.Kind != kwJOIN {
+		return ast.JoinInner // sentinel for "not a join"
+	}
+	p.advance() // consume JOIN
+
+	switch dir {
+	case kwLEFT:
+		return ast.JoinLeft
+	case kwRIGHT:
+		return ast.JoinRight
+	case kwFULL:
+		return ast.JoinFull
+	default:
+		return ast.JoinInner
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GROUP BY clause
+// ---------------------------------------------------------------------------
+
+// parseGroupByClause parses GROUP BY expr, expr, ...
+// Returns the list of GROUP BY expressions.
+func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
+	p.advance() // consume GROUP
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+
+	return p.parseExprList()
+}
+
+// ---------------------------------------------------------------------------
+// LIMIT / OFFSET clause
+// ---------------------------------------------------------------------------
+
+// parseLimitClause parses LIMIT count [OFFSET offset].
+// Returns (limit, offset, error) where offset may be nil.
+func (p *Parser) parseLimitClause() (ast.Node, ast.Node, error) {
+	p.advance() // consume LIMIT
+
+	limitExpr, err := p.parseExpr()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var offsetExpr ast.Node
+	if p.cur.Kind == kwOFFSET {
+		p.advance() // consume OFFSET
+		offsetExpr, err = p.parseExpr()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return limitExpr, offsetExpr, nil
+}

--- a/doris/parser/select_test.go
+++ b/doris/parser/select_test.go
@@ -1,0 +1,482 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// mustParseSelect parses input and returns the first statement as *ast.SelectStmt.
+func mustParseSelect(t *testing.T, input string) *ast.SelectStmt {
+	t.Helper()
+	file, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("Parse(%q) errors: %v", input, errs)
+	}
+	if len(file.Stmts) == 0 {
+		t.Fatalf("Parse(%q) returned no statements", input)
+	}
+	stmt, ok := file.Stmts[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Parse(%q) got %T, want *ast.SelectStmt", input, file.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// Basic SELECT
+// ---------------------------------------------------------------------------
+
+func TestSelectLiteral(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT 1")
+	if len(stmt.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(stmt.Items))
+	}
+	item := stmt.Items[0]
+	if item.Star {
+		t.Error("item.Star = true, want false")
+	}
+	lit, ok := item.Expr.(*ast.Literal)
+	if !ok {
+		t.Fatalf("item.Expr = %T, want *ast.Literal", item.Expr)
+	}
+	if lit.Kind != ast.LitInt || lit.Value != "1" {
+		t.Errorf("literal = %v %q, want LitInt 1", lit.Kind, lit.Value)
+	}
+}
+
+func TestSelectColumnList(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, b, c FROM t")
+	if len(stmt.Items) != 3 {
+		t.Fatalf("items = %d, want 3", len(stmt.Items))
+	}
+	for i, name := range []string{"a", "b", "c"} {
+		item := stmt.Items[i]
+		ref, ok := item.Expr.(*ast.ColumnRef)
+		if !ok {
+			t.Fatalf("item[%d].Expr = %T, want *ast.ColumnRef", i, item.Expr)
+		}
+		if ref.Name.Parts[0] != name {
+			t.Errorf("item[%d] name = %q, want %q", i, ref.Name.Parts[0], name)
+		}
+	}
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	tbl, ok := stmt.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.TableRef", stmt.From[0])
+	}
+	if tbl.Name.Parts[0] != "t" {
+		t.Errorf("table name = %q, want %q", tbl.Name.Parts[0], "t")
+	}
+}
+
+func TestSelectStar(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM t")
+	if len(stmt.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(stmt.Items))
+	}
+	if !stmt.Items[0].Star {
+		t.Error("item.Star = false, want true")
+	}
+	if stmt.Items[0].TableName != nil {
+		t.Error("item.TableName should be nil for bare *")
+	}
+}
+
+func TestSelectQualifiedStar(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT t.* FROM t")
+	if len(stmt.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(stmt.Items))
+	}
+	item := stmt.Items[0]
+	if !item.Star {
+		t.Error("item.Star = false, want true")
+	}
+	if item.TableName == nil {
+		t.Fatal("item.TableName = nil, want non-nil")
+	}
+	if item.TableName.Parts[0] != "t" {
+		t.Errorf("table name = %q, want %q", item.TableName.Parts[0], "t")
+	}
+}
+
+func TestSelectAliases(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a AS col1, b col2 FROM t")
+	if len(stmt.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(stmt.Items))
+	}
+	if stmt.Items[0].Alias != "col1" {
+		t.Errorf("item[0].Alias = %q, want %q", stmt.Items[0].Alias, "col1")
+	}
+	if stmt.Items[1].Alias != "col2" {
+		t.Errorf("item[1].Alias = %q, want %q", stmt.Items[1].Alias, "col2")
+	}
+}
+
+func TestSelectDistinct(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT DISTINCT a FROM t")
+	if !stmt.Distinct {
+		t.Error("Distinct = false, want true")
+	}
+	if len(stmt.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(stmt.Items))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WHERE clause
+// ---------------------------------------------------------------------------
+
+func TestSelectWhere(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t WHERE a > 1")
+	if stmt.Where == nil {
+		t.Fatal("Where = nil, want non-nil")
+	}
+	binExpr, ok := stmt.Where.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("Where = %T, want *ast.BinaryExpr", stmt.Where)
+	}
+	if binExpr.Op != ast.BinGt {
+		t.Errorf("Where.Op = %v, want BinGt", binExpr.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GROUP BY clause
+// ---------------------------------------------------------------------------
+
+func TestSelectGroupBy(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, COUNT(*) FROM t GROUP BY a")
+	if len(stmt.GroupBy) != 1 {
+		t.Fatalf("GroupBy = %d, want 1", len(stmt.GroupBy))
+	}
+	ref, ok := stmt.GroupBy[0].(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("GroupBy[0] = %T, want *ast.ColumnRef", stmt.GroupBy[0])
+	}
+	if ref.Name.Parts[0] != "a" {
+		t.Errorf("GroupBy[0] name = %q, want %q", ref.Name.Parts[0], "a")
+	}
+	// Check that COUNT(*) is in the select list
+	if len(stmt.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(stmt.Items))
+	}
+	fc, ok := stmt.Items[1].Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("item[1].Expr = %T, want *ast.FuncCallExpr", stmt.Items[1].Expr)
+	}
+	if !fc.Star {
+		t.Error("COUNT(*) Star = false, want true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HAVING clause
+// ---------------------------------------------------------------------------
+
+func TestSelectHaving(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, COUNT(*) FROM t GROUP BY a HAVING COUNT(*) > 1")
+	if stmt.Having == nil {
+		t.Fatal("Having = nil, want non-nil")
+	}
+	binExpr, ok := stmt.Having.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("Having = %T, want *ast.BinaryExpr", stmt.Having)
+	}
+	if binExpr.Op != ast.BinGt {
+		t.Errorf("Having.Op = %v, want BinGt", binExpr.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ORDER BY clause
+// ---------------------------------------------------------------------------
+
+func TestSelectOrderByDesc(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t ORDER BY a DESC")
+	if len(stmt.OrderBy) != 1 {
+		t.Fatalf("OrderBy = %d, want 1", len(stmt.OrderBy))
+	}
+	if !stmt.OrderBy[0].Desc {
+		t.Error("OrderBy[0].Desc = false, want true")
+	}
+}
+
+func TestSelectOrderByNullsFirst(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t ORDER BY a ASC NULLS FIRST")
+	if len(stmt.OrderBy) != 1 {
+		t.Fatalf("OrderBy = %d, want 1", len(stmt.OrderBy))
+	}
+	item := stmt.OrderBy[0]
+	if item.Desc {
+		t.Error("OrderBy[0].Desc = true, want false")
+	}
+	if item.NullsFirst == nil {
+		t.Fatal("OrderBy[0].NullsFirst = nil, want non-nil")
+	}
+	if !*item.NullsFirst {
+		t.Error("OrderBy[0].NullsFirst = false, want true")
+	}
+}
+
+func TestSelectOrderByNullsLast(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t ORDER BY a DESC NULLS LAST")
+	if len(stmt.OrderBy) != 1 {
+		t.Fatalf("OrderBy = %d, want 1", len(stmt.OrderBy))
+	}
+	item := stmt.OrderBy[0]
+	if !item.Desc {
+		t.Error("OrderBy[0].Desc = false, want true")
+	}
+	if item.NullsFirst == nil {
+		t.Fatal("OrderBy[0].NullsFirst = nil, want non-nil")
+	}
+	if *item.NullsFirst {
+		t.Error("OrderBy[0].NullsFirst = true, want false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LIMIT / OFFSET
+// ---------------------------------------------------------------------------
+
+func TestSelectLimit(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t LIMIT 10")
+	if stmt.Limit == nil {
+		t.Fatal("Limit = nil, want non-nil")
+	}
+	lit, ok := stmt.Limit.(*ast.Literal)
+	if !ok {
+		t.Fatalf("Limit = %T, want *ast.Literal", stmt.Limit)
+	}
+	if lit.Value != "10" {
+		t.Errorf("Limit.Value = %q, want %q", lit.Value, "10")
+	}
+	if stmt.Offset != nil {
+		t.Error("Offset should be nil")
+	}
+}
+
+func TestSelectLimitOffset(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t LIMIT 10 OFFSET 5")
+	if stmt.Limit == nil {
+		t.Fatal("Limit = nil, want non-nil")
+	}
+	lit, ok := stmt.Limit.(*ast.Literal)
+	if !ok {
+		t.Fatalf("Limit = %T, want *ast.Literal", stmt.Limit)
+	}
+	if lit.Value != "10" {
+		t.Errorf("Limit.Value = %q, want %q", lit.Value, "10")
+	}
+	if stmt.Offset == nil {
+		t.Fatal("Offset = nil, want non-nil")
+	}
+	offLit, ok := stmt.Offset.(*ast.Literal)
+	if !ok {
+		t.Fatalf("Offset = %T, want *ast.Literal", stmt.Offset)
+	}
+	if offLit.Value != "5" {
+		t.Errorf("Offset.Value = %q, want %q", offLit.Value, "5")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FROM clause variations
+// ---------------------------------------------------------------------------
+
+func TestSelectCommaJoin(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t1, t2 WHERE t1.id = t2.id")
+	if len(stmt.From) != 2 {
+		t.Fatalf("from = %d, want 2", len(stmt.From))
+	}
+	tbl1, ok := stmt.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.TableRef", stmt.From[0])
+	}
+	if tbl1.Name.Parts[0] != "t1" {
+		t.Errorf("from[0] name = %q, want %q", tbl1.Name.Parts[0], "t1")
+	}
+	tbl2, ok := stmt.From[1].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[1] = %T, want *ast.TableRef", stmt.From[1])
+	}
+	if tbl2.Name.Parts[0] != "t2" {
+		t.Errorf("from[1] name = %q, want %q", tbl2.Name.Parts[0], "t2")
+	}
+}
+
+func TestSelectTableAlias(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t AS alias")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	tbl, ok := stmt.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.TableRef", stmt.From[0])
+	}
+	if tbl.Name.Parts[0] != "t" {
+		t.Errorf("table name = %q, want %q", tbl.Name.Parts[0], "t")
+	}
+	if tbl.Alias != "alias" {
+		t.Errorf("table alias = %q, want %q", tbl.Alias, "alias")
+	}
+}
+
+func TestSelectTableAliasImplicit(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t myalias")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	tbl, ok := stmt.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.TableRef", stmt.From[0])
+	}
+	if tbl.Alias != "myalias" {
+		t.Errorf("table alias = %q, want %q", tbl.Alias, "myalias")
+	}
+}
+
+func TestSelectQualifiedTableName(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM db.t")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	tbl, ok := stmt.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.TableRef", stmt.From[0])
+	}
+	if len(tbl.Name.Parts) != 2 {
+		t.Fatalf("table name parts = %d, want 2", len(tbl.Name.Parts))
+	}
+	if tbl.Name.Parts[0] != "db" {
+		t.Errorf("table name[0] = %q, want %q", tbl.Name.Parts[0], "db")
+	}
+	if tbl.Name.Parts[1] != "t" {
+		t.Errorf("table name[1] = %q, want %q", tbl.Name.Parts[1], "t")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full combination
+// ---------------------------------------------------------------------------
+
+func TestSelectFullCombo(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t WHERE a > 1 ORDER BY a LIMIT 10")
+	if stmt.Where == nil {
+		t.Error("Where = nil")
+	}
+	if len(stmt.OrderBy) != 1 {
+		t.Errorf("OrderBy = %d, want 1", len(stmt.OrderBy))
+	}
+	if stmt.Limit == nil {
+		t.Error("Limit = nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JOIN (basic)
+// ---------------------------------------------------------------------------
+
+func TestSelectInnerJoin(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t1 JOIN t2 ON t1.id = t2.id")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	join, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	if join.Type != ast.JoinInner {
+		t.Errorf("join type = %d, want JoinInner", join.Type)
+	}
+	if join.On == nil {
+		t.Error("join.On = nil, want non-nil")
+	}
+}
+
+func TestSelectLeftJoin(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t1 LEFT JOIN t2 ON t1.id = t2.id")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	join, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join type = %d, want JoinLeft", join.Type)
+	}
+}
+
+func TestSelectCrossJoin(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t1 CROSS JOIN t2")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	join, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	if join.Type != ast.JoinCross {
+		t.Errorf("join type = %d, want JoinCross", join.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// QUALIFY clause
+// ---------------------------------------------------------------------------
+
+func TestSelectQualify(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a FROM t QUALIFY ROW_NUMBER() OVER() = 1")
+	if stmt.Qualify == nil {
+		t.Fatal("Qualify = nil, want non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple statements
+// ---------------------------------------------------------------------------
+
+func TestSelectMultipleStatements(t *testing.T) {
+	file, errs := Parse("SELECT 1; SELECT 2")
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if len(file.Stmts) != 2 {
+		t.Fatalf("stmts = %d, want 2", len(file.Stmts))
+	}
+	for i, s := range file.Stmts {
+		if _, ok := s.(*ast.SelectStmt); !ok {
+			t.Errorf("stmt[%d] = %T, want *ast.SelectStmt", i, s)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node tag verification
+// ---------------------------------------------------------------------------
+
+func TestSelectStmtTag(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT 1")
+	if stmt.Tag() != ast.T_SelectStmt {
+		t.Errorf("Tag() = %v, want T_SelectStmt", stmt.Tag())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc verification
+// ---------------------------------------------------------------------------
+
+func TestSelectLoc(t *testing.T) {
+	input := "SELECT a FROM t"
+	stmt := mustParseSelect(t, input)
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SelectStmt`, `SelectItem`, `TableRef`, `JoinClause` AST nodes
- Full SELECT parsing: select list (expr/alias/star), FROM (table refs, comma joins, basic JOINs), WHERE, GROUP BY, HAVING, QUALIFY, ORDER BY (ASC/DESC/NULLS FIRST/LAST), LIMIT/OFFSET
- Wire SELECT dispatch into parser — first statement that produces real AST instead of "unsupported"
- 26 unit tests

DAG node: T1.4 from `docs/migration/doris/dag.md`

## Test plan
- [x] 26 new tests pass (`go test ./doris/parser/...`)
- [x] `go build ./...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)