### PR TITLE
feat(doris): CREATE TABLE with full Doris OLAP extensions (T2.1)

### DIFF
--- a/doris/ast/ddlnodes.go
+++ b/doris/ast/ddlnodes.go
@@ -1,0 +1,211 @@
+package ast
+
+// This file holds DDL AST node types for CREATE TABLE (T2.1).
+
+// ---------------------------------------------------------------------------
+// CREATE TABLE statement and supporting types
+// ---------------------------------------------------------------------------
+
+// ConstraintType classifies a table-level constraint.
+type ConstraintType int
+
+const (
+	ConstraintPrimaryKey ConstraintType = iota
+	ConstraintUnique
+)
+
+// CreateTableStmt represents:
+//
+//	CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] name
+//	    (column_def, ... [, index_def, ...])
+//	    [ENGINE = name]
+//	    [AGGREGATE|UNIQUE|DUPLICATE KEY (cols)]
+//	    [COMMENT 'text']
+//	    [PARTITION BY RANGE|LIST (cols) (...)]
+//	    [DISTRIBUTED BY HASH(cols)|RANDOM [BUCKETS n|AUTO]]
+//	    [ROLLUP (...)]
+//	    [PROPERTIES (...)]
+//	    [AS query]
+type CreateTableStmt struct {
+	Name          *ObjectName
+	IfNotExists   bool
+	External      bool
+	Temporary     bool
+	Columns       []*ColumnDef
+	Indexes       []*IndexDef       // inline INDEX definitions
+	Constraints   []*TableConstraint // table-level constraints
+	KeyDesc       *KeyDesc          // AGGREGATE KEY / UNIQUE KEY / DUPLICATE KEY
+	PartitionBy   *PartitionDesc    // PARTITION BY RANGE/LIST
+	DistributedBy *DistributionDesc // DISTRIBUTED BY HASH/RANDOM
+	Rollup        []*RollupDef      // ROLLUP (...)
+	Properties    []*Property       // PROPERTIES (...)
+	Engine        string            // ENGINE = xxx
+	Comment       string            // COMMENT 'xxx'
+	Like          *ObjectName       // CREATE TABLE ... LIKE other_table
+	AsSelect      *RawQuery         // CREATE TABLE ... AS SELECT ...
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *CreateTableStmt) Tag() NodeTag { return T_CreateTableStmt }
+
+var _ Node = (*CreateTableStmt)(nil)
+
+// ColumnDef represents a column definition in a CREATE TABLE statement.
+//
+//	col_name data_type [KEY] [agg_type]
+//	    [GENERATED ALWAYS AS (expr)]
+//	    [NOT NULL | NULL]
+//	    [AUTO_INCREMENT]
+//	    [DEFAULT value]
+//	    [ON UPDATE CURRENT_TIMESTAMP]
+//	    [COMMENT 'str']
+type ColumnDef struct {
+	Name       string
+	Type       *TypeName
+	Nullable   *bool  // nil = not specified, true = NULL, false = NOT NULL
+	Default    Node   // DEFAULT expression (nil if absent)
+	Comment    string // COMMENT string
+	IsKey      bool   // KEY keyword
+	AggType    string // aggregate type: SUM, MAX, MIN, REPLACE, REPLACE_IF_NOT_NULL, etc.
+	AutoInc    bool   // AUTO_INCREMENT
+	Generated  Node   // GENERATED ALWAYS AS (expr) -- the expression
+	OnUpdate   string // ON UPDATE CURRENT_TIMESTAMP
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *ColumnDef) Tag() NodeTag { return T_ColumnDef }
+
+var _ Node = (*ColumnDef)(nil)
+
+// IndexDef represents an inline index definition in CREATE TABLE.
+//
+//	INDEX [IF NOT EXISTS] name (col1, col2, ...) [USING type] [PROPERTIES(...)] [COMMENT 'str']
+type IndexDef struct {
+	Name        string
+	Columns     []string
+	IfNotExists bool
+	IndexType   string      // BITMAP, INVERTED, NGRAM_BF, ANN, or ""
+	Properties  []*Property // inline PROPERTIES(...)
+	Comment     string
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *IndexDef) Tag() NodeTag { return T_IndexDef }
+
+var _ Node = (*IndexDef)(nil)
+
+// TableConstraint represents a table-level constraint: PRIMARY KEY or UNIQUE.
+type TableConstraint struct {
+	Type    ConstraintType
+	Name    string   // constraint name (may be empty)
+	Columns []string
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *TableConstraint) Tag() NodeTag { return T_TableConstraint }
+
+var _ Node = (*TableConstraint)(nil)
+
+// KeyDesc represents the table-level key declaration:
+//
+//	AGGREGATE KEY(cols) | UNIQUE KEY(cols) | DUPLICATE KEY(cols)
+type KeyDesc struct {
+	Type    string   // "AGGREGATE", "UNIQUE", "DUPLICATE"
+	Columns []string
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *KeyDesc) Tag() NodeTag { return T_KeyDesc }
+
+var _ Node = (*KeyDesc)(nil)
+
+// PartitionDesc represents:
+//
+//	[AUTO] PARTITION BY RANGE|LIST (cols/functions) (partition_defs...)
+type PartitionDesc struct {
+	Type       string           // "RANGE" or "LIST"
+	Auto       bool             // AUTO PARTITION
+	Columns    []string         // column names or function expressions (stored as raw strings)
+	FuncExprs  []string         // if partition columns include function expressions
+	Partitions []*PartitionItem // individual partition definitions
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *PartitionDesc) Tag() NodeTag { return T_PartitionDesc }
+
+var _ Node = (*PartitionDesc)(nil)
+
+// PartitionItem represents one partition definition within PARTITION BY.
+//
+// For LESS THAN: PARTITION name VALUES LESS THAN (values) or MAXVALUE
+// For IN: PARTITION name VALUES IN ((values), (values))
+// For step: FROM (values) TO (values) INTERVAL n [unit]
+type PartitionItem struct {
+	Name       string   // partition name (empty for step partitions)
+	IsMaxValue bool     // VALUES LESS THAN MAXVALUE
+	Values     []string // raw value strings for LESS THAN / fixed
+	InValues   [][]string // for IN partitions: list of value lists
+	// Step partition fields
+	IsStep     bool
+	FromValues []string
+	ToValues   []string
+	Interval   string // interval amount
+	IntervalUnit string // interval unit (e.g., "DAY")
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *PartitionItem) Tag() NodeTag { return T_PartitionItem }
+
+var _ Node = (*PartitionItem)(nil)
+
+// DistributionDesc represents:
+//
+//	DISTRIBUTED BY HASH(cols) [BUCKETS n | BUCKETS AUTO]
+//	DISTRIBUTED BY RANDOM [BUCKETS n | BUCKETS AUTO]
+type DistributionDesc struct {
+	Type    string   // "HASH" or "RANDOM"
+	Columns []string // for HASH; empty for RANDOM
+	Buckets int      // bucket count; 0 if not specified
+	Auto    bool     // BUCKETS AUTO
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *DistributionDesc) Tag() NodeTag { return T_DistributionDesc }
+
+var _ Node = (*DistributionDesc)(nil)
+
+// RollupDef represents one rollup definition in ROLLUP (...).
+//
+//	rollup_name (col1, col2, ...) [DUPLICATE KEY (key_cols)] [PROPERTIES(...)]
+type RollupDef struct {
+	Name       string
+	Columns    []string
+	DupKeys    []string    // optional DUPLICATE KEY columns
+	Properties []*Property // optional PROPERTIES
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *RollupDef) Tag() NodeTag { return T_RollupDef }
+
+var _ Node = (*RollupDef)(nil)
+
+// RawQuery is a placeholder for a query (SELECT statement) that has not been
+// fully parsed. Used for CTAS (CREATE TABLE ... AS SELECT ...).
+type RawQuery struct {
+	RawText string
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *RawQuery) Tag() NodeTag { return T_RawQuery }
+
+var _ Node = (*RawQuery)(nil)

--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -74,6 +74,26 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *JoinClause:
 		return v.Loc
+	case *CreateTableStmt:
+		return v.Loc
+	case *ColumnDef:
+		return v.Loc
+	case *IndexDef:
+		return v.Loc
+	case *TableConstraint:
+		return v.Loc
+	case *KeyDesc:
+		return v.Loc
+	case *PartitionDesc:
+		return v.Loc
+	case *PartitionItem:
+		return v.Loc
+	case *DistributionDesc:
+		return v.Loc
+	case *RollupDef:
+		return v.Loc
+	case *RawQuery:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -117,6 +117,38 @@ const (
 
 	// T_JoinClause is the tag for *JoinClause (JOIN expression in FROM).
 	T_JoinClause
+
+	// DDL — CREATE TABLE nodes (T2.1).
+
+	// T_CreateTableStmt is the tag for *CreateTableStmt.
+	T_CreateTableStmt
+
+	// T_ColumnDef is the tag for *ColumnDef.
+	T_ColumnDef
+
+	// T_IndexDef is the tag for *IndexDef (inline index in CREATE TABLE).
+	T_IndexDef
+
+	// T_TableConstraint is the tag for *TableConstraint (PRIMARY KEY, UNIQUE).
+	T_TableConstraint
+
+	// T_KeyDesc is the tag for *KeyDesc (AGGREGATE/UNIQUE/DUPLICATE KEY).
+	T_KeyDesc
+
+	// T_PartitionDesc is the tag for *PartitionDesc (PARTITION BY RANGE/LIST).
+	T_PartitionDesc
+
+	// T_PartitionItem is the tag for *PartitionItem.
+	T_PartitionItem
+
+	// T_DistributionDesc is the tag for *DistributionDesc (DISTRIBUTED BY HASH/RANDOM).
+	T_DistributionDesc
+
+	// T_RollupDef is the tag for *RollupDef.
+	T_RollupDef
+
+	// T_RawQuery is the tag for *RawQuery (placeholder for unparsed SELECT).
+	T_RawQuery
 )
 
 // String returns a human-readable representation of the tag.
@@ -188,6 +220,26 @@ func (t NodeTag) String() string {
 		return "TableRef"
 	case T_JoinClause:
 		return "JoinClause"
+	case T_CreateTableStmt:
+		return "CreateTableStmt"
+	case T_ColumnDef:
+		return "ColumnDef"
+	case T_IndexDef:
+		return "IndexDef"
+	case T_TableConstraint:
+		return "TableConstraint"
+	case T_KeyDesc:
+		return "KeyDesc"
+	case T_PartitionDesc:
+		return "PartitionDesc"
+	case T_PartitionItem:
+		return "PartitionItem"
+	case T_DistributionDesc:
+		return "DistributionDesc"
+	case T_RollupDef:
+		return "RollupDef"
+	case T_RawQuery:
+		return "RawQuery"
 	default:
 		return "Unknown"
 	}

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -151,5 +151,71 @@ func walkChildren(v Visitor, node Node) {
 		if n.On != nil {
 			Walk(v, n.On)
 		}
+
+	// DDL — CREATE TABLE nodes (T2.1).
+	case *CreateTableStmt:
+		Walk(v, n.Name)
+		for _, col := range n.Columns {
+			Walk(v, col)
+		}
+		for _, idx := range n.Indexes {
+			Walk(v, idx)
+		}
+		for _, c := range n.Constraints {
+			Walk(v, c)
+		}
+		if n.KeyDesc != nil {
+			Walk(v, n.KeyDesc)
+		}
+		if n.PartitionBy != nil {
+			Walk(v, n.PartitionBy)
+		}
+		if n.DistributedBy != nil {
+			Walk(v, n.DistributedBy)
+		}
+		for _, r := range n.Rollup {
+			Walk(v, r)
+		}
+		for _, prop := range n.Properties {
+			Walk(v, prop)
+		}
+		if n.Like != nil {
+			Walk(v, n.Like)
+		}
+		if n.AsSelect != nil {
+			Walk(v, n.AsSelect)
+		}
+	case *ColumnDef:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		if n.Default != nil {
+			Walk(v, n.Default)
+		}
+		if n.Generated != nil {
+			Walk(v, n.Generated)
+		}
+	case *IndexDef:
+		for _, prop := range n.Properties {
+			Walk(v, prop)
+		}
+	case *TableConstraint:
+		// leaf-ish node, no Node children
+	case *KeyDesc:
+		// leaf-ish node, no Node children
+	case *PartitionDesc:
+		for _, p := range n.Partitions {
+			Walk(v, p)
+		}
+	case *PartitionItem:
+		// leaf-ish node, values stored as strings
+	case *DistributionDesc:
+		// leaf-ish node, no Node children
+	case *RollupDef:
+		for _, prop := range n.Properties {
+			Walk(v, prop)
+		}
+	case *RawQuery:
+		// leaf node, no parsed children
 	}
 }

--- a/doris/parser/create_table.go
+++ b/doris/parser/create_table.go
@@ -1,0 +1,1298 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// parseCreateTable parses a CREATE TABLE statement. The CREATE keyword has
+// already been consumed by the caller. cur may be kwEXTERNAL, kwTEMPORARY,
+// or kwTABLE on entry.
+//
+// Syntax:
+//
+//	CREATE [EXTERNAL] [TEMPORARY] TABLE [IF NOT EXISTS] name
+//	    (column_defs [, index_defs]) | LIKE other_table
+//	    [ENGINE = name]
+//	    [AGGREGATE|UNIQUE|DUPLICATE KEY (cols) [CLUSTER BY (cols)]]
+//	    [COMMENT 'text']
+//	    [PARTITION BY ...]
+//	    [DISTRIBUTED BY HASH(cols)|RANDOM [BUCKETS n|AUTO]]
+//	    [ROLLUP (...)]
+//	    [PROPERTIES (...)]
+//	    [BROKER ext_properties]
+//	    [AS query]
+func (p *Parser) parseCreateTable() (ast.Node, error) {
+	startLoc := p.prev.Loc // loc of CREATE token
+
+	stmt := &ast.CreateTableStmt{}
+
+	// Optional EXTERNAL
+	if p.cur.Kind == kwEXTERNAL {
+		stmt.External = true
+		p.advance()
+	}
+
+	// Optional TEMPORARY
+	if p.cur.Kind == kwTEMPORARY {
+		stmt.Temporary = true
+		p.advance()
+	}
+
+	// TABLE keyword
+	if _, err := p.expect(kwTABLE); err != nil {
+		return nil, err
+	}
+
+	// Optional IF NOT EXISTS
+	if p.cur.Kind == kwIF {
+		p.advance() // consume IF
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
+	// Table name
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Check for LIKE (CREATE TABLE ... LIKE other_table)
+	if p.cur.Kind == kwLIKE {
+		p.advance() // consume LIKE
+		likeName, err := p.parseMultipartIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Like = likeName
+		stmt.Loc = startLoc.Merge(ast.NodeLoc(likeName))
+		return stmt, nil
+	}
+
+	// Check for CTAS without column defs: CREATE TABLE t [PROPERTIES(...)] AS SELECT ...
+	// or CREATE TABLE t (col_list) ...
+	if p.cur.Kind == int('(') {
+		// Column definitions
+		if err := p.parseColumnDefsBlock(stmt); err != nil {
+			return nil, err
+		}
+	}
+
+	// Parse optional trailing clauses in any order.
+	if err := p.parseCreateTableClauses(stmt); err != nil {
+		return nil, err
+	}
+
+	// Compute location.
+	stmt.Loc = startLoc.Merge(p.prev.Loc)
+	return stmt, nil
+}
+
+// parseColumnDefsBlock parses the parenthesized column definitions block,
+// including inline index definitions and trailing commas.
+//
+//	'(' column_def [, column_def]* [, index_def]* ')'
+func (p *Parser) parseColumnDefsBlock(stmt *ast.CreateTableStmt) error {
+	if _, err := p.expect(int('(')); err != nil {
+		return err
+	}
+
+	// Parse column defs and index defs.
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		// Check if this is an INDEX definition
+		if p.cur.Kind == kwINDEX {
+			idx, err := p.parseInlineIndexDef()
+			if err != nil {
+				return err
+			}
+			stmt.Indexes = append(stmt.Indexes, idx)
+		} else if p.cur.Kind == kwCONSTRAINT || p.cur.Kind == kwPRIMARY || p.cur.Kind == kwUNIQUE {
+			// Table-level constraint
+			constraint, err := p.parseTableConstraint()
+			if err != nil {
+				return err
+			}
+			stmt.Constraints = append(stmt.Constraints, constraint)
+		} else {
+			col, err := p.parseColumnDef()
+			if err != nil {
+				return err
+			}
+			stmt.Columns = append(stmt.Columns, col)
+		}
+
+		// Optional comma separator
+		if p.cur.Kind == int(',') {
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseColumnDef parses a single column definition.
+//
+//	col_name data_type [KEY] [agg_type]
+//	    [GENERATED ALWAYS AS (expr)]
+//	    [NOT NULL | NULL] [AUTO_INCREMENT]
+//	    [DEFAULT value] [ON UPDATE CURRENT_TIMESTAMP]
+//	    [COMMENT 'str']
+func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
+	startLoc := p.cur.Loc
+
+	// Column name
+	colName, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// Data type
+	colType, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+
+	col := &ast.ColumnDef{
+		Name: colName,
+		Type: colType,
+		Loc:  ast.Loc{Start: startLoc.Start, End: colType.Loc.End},
+	}
+
+	// Parse optional column attributes in flexible order.
+	// Each attribute can appear at most once, and they can appear in various orders
+	// based on the grammar.
+	for {
+		switch p.cur.Kind {
+		case kwKEY:
+			col.IsKey = true
+			col.Loc.End = p.cur.Loc.End
+			p.advance()
+			continue
+
+		case kwMAX, kwMIN, kwSUM, kwREPLACE, kwREPLACE_IF_NOT_NULL,
+			kwHLL_UNION, kwBITMAP_UNION, kwQUANTILE_UNION, kwGENERIC:
+			col.AggType = strings.ToUpper(p.cur.Str)
+			col.Loc.End = p.cur.Loc.End
+			p.advance()
+			continue
+
+		case kwGENERATED:
+			p.advance() // consume GENERATED
+			// Optional ALWAYS
+			p.match(kwALWAYS)
+			if _, err := p.expect(kwAS); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(int('(')); err != nil {
+				return nil, err
+			}
+			expr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			closeTok, err := p.expect(int(')'))
+			if err != nil {
+				return nil, err
+			}
+			col.Generated = expr
+			col.Loc.End = closeTok.Loc.End
+			continue
+
+		case kwNOT:
+			// NOT NULL
+			p.advance()
+			if _, err := p.expect(kwNULL); err != nil {
+				return nil, err
+			}
+			b := false
+			col.Nullable = &b
+			col.Loc.End = p.prev.Loc.End
+			continue
+
+		case kwNULL:
+			b := true
+			col.Nullable = &b
+			col.Loc.End = p.cur.Loc.End
+			p.advance()
+			continue
+
+		case kwAUTO_INCREMENT:
+			col.AutoInc = true
+			col.Loc.End = p.cur.Loc.End
+			p.advance()
+			// Optional (initial_value)
+			if p.cur.Kind == int('(') {
+				p.advance()
+				if p.cur.Kind == tokInt {
+					p.advance()
+				}
+				if _, err := p.expect(int(')')); err != nil {
+					return nil, err
+				}
+				col.Loc.End = p.prev.Loc.End
+			}
+			continue
+
+		case kwDEFAULT:
+			p.advance() // consume DEFAULT
+			def, err := p.parseDefaultValue()
+			if err != nil {
+				return nil, err
+			}
+			col.Default = def
+			col.Loc.End = ast.NodeLoc(def).End
+			continue
+
+		case kwON:
+			// ON UPDATE CURRENT_TIMESTAMP
+			p.advance() // consume ON
+			if _, err := p.expect(kwUPDATE); err != nil {
+				return nil, err
+			}
+			if p.cur.Kind != kwCURRENT_TIMESTAMP {
+				return nil, p.syntaxErrorAtCur()
+			}
+			col.OnUpdate = "CURRENT_TIMESTAMP"
+			col.Loc.End = p.cur.Loc.End
+			p.advance()
+			// Optional precision: (n)
+			if p.cur.Kind == int('(') {
+				p.advance()
+				if p.cur.Kind == tokInt {
+					p.advance()
+				}
+				closeTok, err := p.expect(int(')'))
+				if err != nil {
+					return nil, err
+				}
+				col.Loc.End = closeTok.Loc.End
+			}
+			continue
+
+		case kwCOMMENT:
+			p.advance()
+			if p.cur.Kind != tokString {
+				return nil, p.syntaxErrorAtCur()
+			}
+			col.Comment = p.cur.Str
+			col.Loc.End = p.cur.Loc.End
+			p.advance()
+			continue
+		}
+		break
+	}
+
+	return col, nil
+}
+
+// parseDefaultValue parses the value after DEFAULT keyword.
+// Supports: NULL, integers, decimals, PI, E, BITMAP_EMPTY, string literals,
+// CURRENT_DATE, CURRENT_TIMESTAMP with optional precision.
+func (p *Parser) parseDefaultValue() (ast.Node, error) {
+	switch p.cur.Kind {
+	case kwNULL:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitNull, Value: "NULL", Loc: tok.Loc}, nil
+
+	case kwCURRENT_DATE:
+		tok := p.advance()
+		return &ast.FuncCallExpr{
+			Name: &ast.ObjectName{Parts: []string{"CURRENT_DATE"}, Loc: tok.Loc},
+			Loc:  tok.Loc,
+		}, nil
+
+	case kwCURRENT_TIMESTAMP:
+		tok := p.advance()
+		fc := &ast.FuncCallExpr{
+			Name: &ast.ObjectName{Parts: []string{"CURRENT_TIMESTAMP"}, Loc: tok.Loc},
+			Loc:  tok.Loc,
+		}
+		// Optional precision: (n)
+		if p.cur.Kind == int('(') {
+			p.advance()
+			if p.cur.Kind == tokInt {
+				fc.Args = append(fc.Args, &ast.Literal{
+					Kind: ast.LitInt, Value: p.cur.Str, Loc: p.cur.Loc,
+				})
+				p.advance()
+			}
+			closeTok, err := p.expect(int(')'))
+			if err != nil {
+				return nil, err
+			}
+			fc.Loc.End = closeTok.Loc.End
+		}
+		return fc, nil
+
+	case kwPI:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitFloat, Value: "PI", Loc: tok.Loc}, nil
+
+	case kwE:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitFloat, Value: "E", Loc: tok.Loc}, nil
+
+	case kwBITMAP_EMPTY:
+		tok := p.advance()
+		return &ast.FuncCallExpr{
+			Name: &ast.ObjectName{Parts: []string{"BITMAP_EMPTY"}, Loc: tok.Loc},
+			Loc:  tok.Loc,
+		}, nil
+
+	case int('-'):
+		// Negative number: -INTEGER_VALUE or -DECIMAL_VALUE
+		minusTok := p.advance()
+		if p.cur.Kind == tokInt {
+			valTok := p.advance()
+			return &ast.Literal{
+				Kind:  ast.LitInt,
+				Value: "-" + valTok.Str,
+				Loc:   ast.Loc{Start: minusTok.Loc.Start, End: valTok.Loc.End},
+			}, nil
+		}
+		if p.cur.Kind == tokFloat {
+			valTok := p.advance()
+			return &ast.Literal{
+				Kind:  ast.LitFloat,
+				Value: "-" + valTok.Str,
+				Loc:   ast.Loc{Start: minusTok.Loc.Start, End: valTok.Loc.End},
+			}, nil
+		}
+		return nil, p.syntaxErrorAtCur()
+
+	case tokInt:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitInt, Value: tok.Str, Loc: tok.Loc}, nil
+
+	case tokFloat:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitFloat, Value: tok.Str, Loc: tok.Loc}, nil
+
+	case tokString:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitString, Value: tok.Str, Loc: tok.Loc}, nil
+
+	default:
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected DEFAULT value, got %q", p.cur.Str),
+		}
+	}
+}
+
+// parseInlineIndexDef parses an inline INDEX definition in CREATE TABLE.
+//
+//	INDEX [IF NOT EXISTS] name (col1, col2, ...) [USING type] [PROPERTIES(...)] [COMMENT 'str']
+func (p *Parser) parseInlineIndexDef() (*ast.IndexDef, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume INDEX
+
+	idx := &ast.IndexDef{
+		Loc: startLoc,
+	}
+
+	// Optional IF NOT EXISTS
+	if p.cur.Kind == kwIF {
+		p.advance()
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		idx.IfNotExists = true
+	}
+
+	// Index name
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	idx.Name = name
+
+	// Column list: (col1, col2, ...)
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	cols, err := p.parseIdentifierList()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	idx.Columns = cols
+	idx.Loc.End = closeTok.Loc.End
+
+	// Optional USING index_type
+	if p.cur.Kind == kwUSING {
+		p.advance()
+		if !isIdentifierToken(p.cur.Kind) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		idx.IndexType = strings.ToLower(p.cur.Str)
+		idx.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+
+	// Optional PROPERTIES(...)
+	if p.cur.Kind == kwPROPERTIES {
+		props, err := p.parseProperties()
+		if err != nil {
+			return nil, err
+		}
+		idx.Properties = props
+		idx.Loc.End = p.prev.Loc.End
+	}
+
+	// Optional COMMENT
+	if p.cur.Kind == kwCOMMENT {
+		p.advance()
+		if p.cur.Kind != tokString {
+			return nil, p.syntaxErrorAtCur()
+		}
+		idx.Comment = p.cur.Str
+		idx.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+
+	return idx, nil
+}
+
+// parseTableConstraint parses a table-level constraint.
+//
+//	[CONSTRAINT name] PRIMARY KEY (col1, col2, ...)
+//	[CONSTRAINT name] UNIQUE [KEY] (col1, col2, ...)
+func (p *Parser) parseTableConstraint() (*ast.TableConstraint, error) {
+	startLoc := p.cur.Loc
+	tc := &ast.TableConstraint{Loc: startLoc}
+
+	// Optional CONSTRAINT name
+	if p.cur.Kind == kwCONSTRAINT {
+		p.advance()
+		name, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		tc.Name = name
+	}
+
+	switch p.cur.Kind {
+	case kwPRIMARY:
+		p.advance() // consume PRIMARY
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		tc.Type = ast.ConstraintPrimaryKey
+	case kwUNIQUE:
+		p.advance() // consume UNIQUE
+		p.match(kwKEY) // optional KEY
+		tc.Type = ast.ConstraintUnique
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	// Column list
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	cols, err := p.parseIdentifierList()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	tc.Columns = cols
+	tc.Loc.End = closeTok.Loc.End
+
+	return tc, nil
+}
+
+// parseCreateTableClauses parses the optional trailing clauses of CREATE TABLE
+// in flexible order.
+func (p *Parser) parseCreateTableClauses(stmt *ast.CreateTableStmt) error {
+	for {
+		switch p.cur.Kind {
+		case kwENGINE:
+			p.advance() // consume ENGINE
+			if _, err := p.expect(int('=')); err != nil {
+				return err
+			}
+			engineName, _, err := p.parseIdentifier()
+			if err != nil {
+				return err
+			}
+			stmt.Engine = engineName
+			continue
+
+		case kwAGGREGATE, kwUNIQUE, kwDUPLICATE:
+			keyDesc, err := p.parseKeyDesc()
+			if err != nil {
+				return err
+			}
+			stmt.KeyDesc = keyDesc
+			// Optional CLUSTER BY (cols) -- skip for now
+			if p.cur.Kind == kwCLUSTER {
+				p.advance()
+				if _, err := p.expect(kwBY); err != nil {
+					return err
+				}
+				if _, err := p.expect(int('(')); err != nil {
+					return err
+				}
+				if _, err := p.parseIdentifierList(); err != nil {
+					return err
+				}
+				if _, err := p.expect(int(')')); err != nil {
+					return err
+				}
+			}
+			continue
+
+		case kwCOMMENT:
+			p.advance()
+			if p.cur.Kind != tokString {
+				return p.syntaxErrorAtCur()
+			}
+			stmt.Comment = p.cur.Str
+			p.advance()
+			continue
+
+		case kwAUTO:
+			// AUTO PARTITION BY ...
+			partDesc, err := p.parsePartitionBy()
+			if err != nil {
+				return err
+			}
+			stmt.PartitionBy = partDesc
+			continue
+
+		case kwPARTITION:
+			partDesc, err := p.parsePartitionBy()
+			if err != nil {
+				return err
+			}
+			stmt.PartitionBy = partDesc
+			continue
+
+		case kwDISTRIBUTED:
+			distDesc, err := p.parseDistributedBy()
+			if err != nil {
+				return err
+			}
+			stmt.DistributedBy = distDesc
+			continue
+
+		case kwROLLUP:
+			rollups, err := p.parseRollup()
+			if err != nil {
+				return err
+			}
+			stmt.Rollup = rollups
+			continue
+
+		case kwPROPERTIES:
+			props, err := p.parseProperties()
+			if err != nil {
+				return err
+			}
+			stmt.Properties = props
+			continue
+
+		case kwBROKER:
+			// BROKER ext_properties -- skip the broker properties clause
+			p.advance() // consume BROKER
+			if p.cur.Kind == kwPROPERTIES {
+				if _, err := p.parseProperties(); err != nil {
+					return err
+				}
+			}
+			continue
+
+		case kwAS:
+			// AS query (CTAS)
+			p.advance() // consume AS
+			rawQuery, err := p.parseRawQuery()
+			if err != nil {
+				return err
+			}
+			stmt.AsSelect = rawQuery
+			continue
+		}
+
+		// Check for bare SELECT/WITH without AS (also valid CTAS per grammar: AS? query)
+		if p.cur.Kind == kwSELECT || p.cur.Kind == kwWITH {
+			rawQuery, err := p.parseRawQuery()
+			if err != nil {
+				return err
+			}
+			stmt.AsSelect = rawQuery
+			continue
+		}
+
+		break
+	}
+	return nil
+}
+
+// parseKeyDesc parses: AGGREGATE|UNIQUE|DUPLICATE KEY (col1, col2, ...)
+func (p *Parser) parseKeyDesc() (*ast.KeyDesc, error) {
+	startLoc := p.cur.Loc
+	keyType := strings.ToUpper(p.cur.Str)
+	p.advance() // consume AGGREGATE/UNIQUE/DUPLICATE
+
+	if _, err := p.expect(kwKEY); err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	cols, err := p.parseIdentifierList()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.KeyDesc{
+		Type:    keyType,
+		Columns: cols,
+		Loc:     ast.Loc{Start: startLoc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parsePartitionBy parses:
+//
+//	[AUTO] PARTITION BY [RANGE|LIST] (col_or_func, ...) (partition_defs...)
+func (p *Parser) parsePartitionBy() (*ast.PartitionDesc, error) {
+	startLoc := p.cur.Loc
+	pd := &ast.PartitionDesc{
+		Loc: startLoc,
+	}
+
+	// Optional AUTO
+	if p.cur.Kind == kwAUTO {
+		pd.Auto = true
+		p.advance()
+	}
+
+	// PARTITION BY
+	if _, err := p.expect(kwPARTITION); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+
+	// Optional RANGE or LIST
+	switch p.cur.Kind {
+	case kwRANGE:
+		pd.Type = "RANGE"
+		p.advance()
+	case kwLIST:
+		pd.Type = "LIST"
+		p.advance()
+	default:
+		// Type may be inferred from context (AUTO partition can omit it)
+		pd.Type = "RANGE" // default for AUTO
+	}
+
+	// Parse partition column/function list: (col1, func(col2), ...)
+	if p.cur.Kind == int('(') {
+		cols, funcs, err := p.parseIdentityOrFunctionList()
+		if err != nil {
+			return nil, err
+		}
+		pd.Columns = cols
+		pd.FuncExprs = funcs
+	}
+
+	// Parse partition definitions: (...)
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+			item, err := p.parsePartitionItem()
+			if err != nil {
+				return nil, err
+			}
+			pd.Partitions = append(pd.Partitions, item)
+
+			if p.cur.Kind == int(',') {
+				p.advance()
+			}
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		pd.Loc.End = closeTok.Loc.End
+	}
+
+	return pd, nil
+}
+
+// parseIdentityOrFunctionList parses a parenthesized list of identifiers or
+// function calls used in PARTITION BY clauses.
+// Returns (columns, funcExprs) where funcExprs contains raw function text.
+func (p *Parser) parseIdentityOrFunctionList() ([]string, []string, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, nil, err
+	}
+
+	var cols []string
+	var funcs []string
+
+	for {
+		// Check if it's a function call: identifier followed by '('
+		if isIdentifierToken(p.cur.Kind) {
+			next := p.peekNext()
+			if next.Kind == int('(') {
+				// Function call -- capture raw text
+				funcStart := p.cur.Loc.Start
+				p.advance() // consume function name
+				p.advance() // consume '('
+				depth := 1
+				for depth > 0 && p.cur.Kind != tokEOF {
+					if p.cur.Kind == int('(') {
+						depth++
+					} else if p.cur.Kind == int(')') {
+						depth--
+						if depth == 0 {
+							break
+						}
+					}
+					p.advance()
+				}
+				funcEnd := p.cur.Loc.End
+				p.advance() // consume closing ')'
+				funcText := p.input[funcStart:funcEnd]
+				funcs = append(funcs, strings.TrimSpace(funcText))
+			} else {
+				// Simple identifier
+				ident, _, err := p.parseIdentifier()
+				if err != nil {
+					return nil, nil, err
+				}
+				cols = append(cols, ident)
+			}
+		} else {
+			return nil, nil, p.syntaxErrorAtCur()
+		}
+
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, nil, err
+	}
+
+	return cols, funcs, nil
+}
+
+// parsePartitionItem parses a single partition definition.
+func (p *Parser) parsePartitionItem() (*ast.PartitionItem, error) {
+	startLoc := p.cur.Loc
+
+	// Step partition: FROM (...) TO (...) INTERVAL n [unit]
+	if p.cur.Kind == kwFROM {
+		return p.parseStepPartition(startLoc)
+	}
+
+	// Named partition: PARTITION [IF NOT EXISTS] name ...
+	if p.cur.Kind != kwPARTITION {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // consume PARTITION
+
+	// Optional IF NOT EXISTS
+	if p.cur.Kind == kwIF {
+		p.advance()
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+	}
+
+	// Partition name
+	partName, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	item := &ast.PartitionItem{
+		Name: partName,
+		Loc:  startLoc,
+	}
+
+	// VALUES clause
+	if p.cur.Kind == kwVALUES {
+		p.advance() // consume VALUES
+
+		switch p.cur.Kind {
+		case kwLESS:
+			// LESS THAN (values) | MAXVALUE
+			p.advance() // consume LESS
+			if _, err := p.expect(kwTHAN); err != nil {
+				return nil, err
+			}
+
+			if p.cur.Kind == kwMAXVALUE {
+				item.IsMaxValue = true
+				item.Loc.End = p.cur.Loc.End
+				p.advance()
+			} else {
+				vals, endLoc, err := p.parsePartitionValueList()
+				if err != nil {
+					return nil, err
+				}
+				item.Values = vals
+				item.Loc.End = endLoc
+			}
+
+		case kwIN:
+			// IN ((val1, val2), (val3, val4)) or IN (val1, val2)
+			p.advance() // consume IN
+			inVals, endLoc, err := p.parseInPartitionValues()
+			if err != nil {
+				return nil, err
+			}
+			item.InValues = inVals
+			item.Loc.End = endLoc
+
+		case int('['):
+			// Fixed range: [lower, upper)
+			vals, endLoc, err := p.parseFixedRangePartition()
+			if err != nil {
+				return nil, err
+			}
+			item.Values = vals
+			item.Loc.End = endLoc
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+
+	// Optional partition properties
+	if p.cur.Kind == int('(') {
+		// Skip inline partition properties
+		p.advance()
+		for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+			p.advance()
+		}
+		if p.cur.Kind == int(')') {
+			item.Loc.End = p.cur.Loc.End
+			p.advance()
+		}
+	}
+
+	return item, nil
+}
+
+// parseStepPartition parses: FROM (values) TO (values) INTERVAL n [unit]
+func (p *Parser) parseStepPartition(startLoc ast.Loc) (*ast.PartitionItem, error) {
+	p.advance() // consume FROM
+
+	fromVals, _, err := p.parsePartitionValueList()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+
+	toVals, _, err := p.parsePartitionValueList()
+	if err != nil {
+		return nil, err
+	}
+
+	item := &ast.PartitionItem{
+		IsStep:     true,
+		FromValues: fromVals,
+		ToValues:   toVals,
+		Loc:        startLoc,
+	}
+
+	if _, err := p.expect(kwINTERVAL); err != nil {
+		return nil, err
+	}
+
+	// Interval amount
+	if p.cur.Kind != tokInt {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected integer interval amount, got %q", p.cur.Str),
+		}
+	}
+	item.Interval = p.cur.Str
+	item.Loc.End = p.cur.Loc.End
+	p.advance()
+
+	// Optional interval unit
+	if p.cur.Kind == kwDAY || p.cur.Kind == kwWEEK || p.cur.Kind == kwMONTH ||
+		p.cur.Kind == kwYEAR || p.cur.Kind == kwHOUR || p.cur.Kind == kwMINUTE ||
+		p.cur.Kind == kwSECOND || p.cur.Kind == tokIdent {
+		item.IntervalUnit = strings.ToUpper(p.cur.Str)
+		item.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+
+	return item, nil
+}
+
+// parsePartitionValueList parses: '(' value [, value]* ')'
+// Returns the values as strings and the end byte offset.
+func (p *Parser) parsePartitionValueList() ([]string, int, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+
+	var vals []string
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		val, err := p.parsePartitionValueDef()
+		if err != nil {
+			return nil, 0, err
+		}
+		vals = append(vals, val)
+
+		if p.cur.Kind == int(',') {
+			p.advance()
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return vals, closeTok.Loc.End, nil
+}
+
+// parsePartitionValueDef parses a single partition value:
+// [-] INTEGER | STRING | MAXVALUE | NULL
+func (p *Parser) parsePartitionValueDef() (string, error) {
+	switch p.cur.Kind {
+	case kwMAXVALUE:
+		tok := p.advance()
+		return strings.ToUpper(tok.Str), nil
+	case kwNULL:
+		tok := p.advance()
+		return strings.ToUpper(tok.Str), nil
+	case tokString:
+		tok := p.advance()
+		return tok.Str, nil
+	case tokInt:
+		tok := p.advance()
+		return tok.Str, nil
+	case int('-'):
+		p.advance() // consume '-'
+		if p.cur.Kind == tokInt {
+			tok := p.advance()
+			return "-" + tok.Str, nil
+		}
+		if p.cur.Kind == tokFloat {
+			tok := p.advance()
+			return "-" + tok.Str, nil
+		}
+		return "", p.syntaxErrorAtCur()
+	default:
+		return "", &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected partition value, got %q", p.cur.Str),
+		}
+	}
+}
+
+// parseInPartitionValues parses IN partition values:
+// '(' (value_list) [, (value_list)]* ')' or '(' value [, value]* ')'
+func (p *Parser) parseInPartitionValues() ([][]string, int, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+
+	var result [][]string
+
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		if p.cur.Kind == int('(') {
+			// Parenthesized value list
+			vals, _, err := p.parsePartitionValueList()
+			if err != nil {
+				return nil, 0, err
+			}
+			result = append(result, vals)
+		} else {
+			// Single value
+			val, err := p.parsePartitionValueDef()
+			if err != nil {
+				return nil, 0, err
+			}
+			result = append(result, []string{val})
+		}
+
+		if p.cur.Kind == int(',') {
+			p.advance()
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return result, closeTok.Loc.End, nil
+}
+
+// parseFixedRangePartition parses: '[' lower_values ',' upper_values ')'
+// This is for fixed range partition syntax like: VALUES [("2020-01-01"), ("2020-02-01"))
+func (p *Parser) parseFixedRangePartition() ([]string, int, error) {
+	// Consume '['
+	p.advance()
+
+	// Parse lower bound
+	lowerVals, _, err := p.parsePartitionValueList()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, 0, err
+	}
+
+	// Parse upper bound
+	upperVals, _, err := p.parsePartitionValueList()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Expect ')' (half-open interval)
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Combine: store as lower1, lower2, ..., upper1, upper2, ...
+	all := append(lowerVals, upperVals...)
+	return all, closeTok.Loc.End, nil
+}
+
+// parseDistributedBy parses:
+//
+//	DISTRIBUTED BY HASH(col1, col2, ...) [BUCKETS n | BUCKETS AUTO]
+//	DISTRIBUTED BY RANDOM [BUCKETS n | BUCKETS AUTO]
+func (p *Parser) parseDistributedBy() (*ast.DistributionDesc, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume DISTRIBUTED
+
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+
+	dd := &ast.DistributionDesc{
+		Loc: startLoc,
+	}
+
+	switch p.cur.Kind {
+	case kwHASH:
+		dd.Type = "HASH"
+		p.advance() // consume HASH
+
+		// Column list: (col1, col2, ...)
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		cols, err := p.parseIdentifierList()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		dd.Columns = cols
+		dd.Loc.End = closeTok.Loc.End
+
+	case kwRANDOM:
+		dd.Type = "RANDOM"
+		dd.Loc.End = p.cur.Loc.End
+		p.advance()
+
+	default:
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected HASH or RANDOM after DISTRIBUTED BY, got %q", p.cur.Str),
+		}
+	}
+
+	// Optional BUCKETS n | BUCKETS AUTO
+	if p.cur.Kind == kwBUCKETS {
+		p.advance() // consume BUCKETS
+		if p.cur.Kind == kwAUTO {
+			dd.Auto = true
+			dd.Loc.End = p.cur.Loc.End
+			p.advance()
+		} else if p.cur.Kind == tokInt {
+			dd.Buckets = int(p.cur.Ival)
+			dd.Loc.End = p.cur.Loc.End
+			p.advance()
+		} else {
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: fmt.Sprintf("expected integer or AUTO after BUCKETS, got %q", p.cur.Str),
+			}
+		}
+	}
+
+	return dd, nil
+}
+
+// parseRollup parses:
+//
+//	ROLLUP '(' rollup_def [, rollup_def]* ')'
+//
+// where rollup_def is: name (col1, col2, ...) [DUPLICATE KEY (key_cols)] [PROPERTIES(...)]
+func (p *Parser) parseRollup() ([]*ast.RollupDef, error) {
+	p.advance() // consume ROLLUP
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	var rollups []*ast.RollupDef
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		rd, err := p.parseRollupDef()
+		if err != nil {
+			return nil, err
+		}
+		rollups = append(rollups, rd)
+
+		if p.cur.Kind == int(',') {
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	return rollups, nil
+}
+
+// parseRollupDef parses a single rollup definition:
+//
+//	name (col1, col2, ...) [DUPLICATE KEY (key_cols)] [PROPERTIES(...)]
+func (p *Parser) parseRollupDef() (*ast.RollupDef, error) {
+	startLoc := p.cur.Loc
+
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// Column list
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	cols, err := p.parseIdentifierList()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+
+	rd := &ast.RollupDef{
+		Name:    name,
+		Columns: cols,
+		Loc:     ast.Loc{Start: startLoc.Start, End: closeTok.Loc.End},
+	}
+
+	// Optional DUPLICATE KEY (key_cols)
+	if p.cur.Kind == kwDUPLICATE {
+		p.advance() // consume DUPLICATE
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		keys, err := p.parseIdentifierList()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		rd.DupKeys = keys
+		rd.Loc.End = closeTok.Loc.End
+	}
+
+	// Optional PROPERTIES
+	if p.cur.Kind == kwPROPERTIES {
+		props, err := p.parseProperties()
+		if err != nil {
+			return nil, err
+		}
+		rd.Properties = props
+		rd.Loc.End = p.prev.Loc.End
+	}
+
+	return rd, nil
+}
+
+// parseRawQuery consumes remaining tokens as a raw SQL query (for CTAS).
+// The AS keyword has already been consumed if present.
+func (p *Parser) parseRawQuery() (*ast.RawQuery, error) {
+	startLoc := p.cur.Loc
+	start := p.cur.Loc.Start
+
+	// Consume all remaining tokens until EOF or semicolon at depth 0.
+	depth := 0
+	for p.cur.Kind != tokEOF {
+		switch p.cur.Kind {
+		case int('('):
+			depth++
+		case int(')'):
+			if depth > 0 {
+				depth--
+			}
+		case int(';'):
+			if depth == 0 {
+				goto done
+			}
+		}
+		p.advance()
+	}
+done:
+	end := p.prev.Loc.End
+	rawText := strings.TrimSpace(p.input[start:end])
+
+	return &ast.RawQuery{
+		RawText: rawText,
+		Loc:     ast.Loc{Start: startLoc.Start, End: end},
+	}, nil
+}

--- a/doris/parser/create_table_test.go
+++ b/doris/parser/create_table_test.go
@@ -1,0 +1,779 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// helper: parse a single statement and expect no errors, returning the node.
+func parseCreateTableStmt(t *testing.T, sql string) *ast.CreateTableStmt {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d stmts, want 1", sql, len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.CreateTableStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateTableStmt, got %T", file.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// Basic CREATE TABLE
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_Basic(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT, name VARCHAR(50))")
+	if stmt.Name.String() != "t" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "t")
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.Columns[0].Name != "id" {
+		t.Errorf("Columns[0].Name = %q, want %q", stmt.Columns[0].Name, "id")
+	}
+	if stmt.Columns[0].Type.Name != "INT" {
+		t.Errorf("Columns[0].Type.Name = %q, want %q", stmt.Columns[0].Type.Name, "INT")
+	}
+	if stmt.Columns[1].Name != "name" {
+		t.Errorf("Columns[1].Name = %q, want %q", stmt.Columns[1].Name, "name")
+	}
+	if stmt.Columns[1].Type.Name != "VARCHAR" {
+		t.Errorf("Columns[1].Type.Name = %q, want %q", stmt.Columns[1].Type.Name, "VARCHAR")
+	}
+	if len(stmt.Columns[1].Type.Params) != 1 || stmt.Columns[1].Type.Params[0] != 50 {
+		t.Errorf("Columns[1].Type.Params = %v, want [50]", stmt.Columns[1].Type.Params)
+	}
+}
+
+func TestCreateTable_WithNotNullDefault(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(stmt.Columns))
+	}
+	// id: NOT NULL, DEFAULT 0
+	col0 := stmt.Columns[0]
+	if col0.Nullable == nil || *col0.Nullable != false {
+		t.Errorf("Columns[0].Nullable = %v, want false", col0.Nullable)
+	}
+	if col0.Default == nil {
+		t.Fatal("Columns[0].Default is nil, want literal 0")
+	}
+	lit, ok := col0.Default.(*ast.Literal)
+	if !ok {
+		t.Fatalf("Columns[0].Default is %T, want *ast.Literal", col0.Default)
+	}
+	if lit.Value != "0" {
+		t.Errorf("Columns[0].Default = %q, want %q", lit.Value, "0")
+	}
+	// name: NULL
+	col1 := stmt.Columns[1]
+	if col1.Nullable == nil || *col1.Nullable != true {
+		t.Errorf("Columns[1].Nullable = %v, want true", col1.Nullable)
+	}
+}
+
+func TestCreateTable_WithComment(t *testing.T) {
+	stmt := parseCreateTableStmt(t, `CREATE TABLE t (id INT COMMENT 'primary key') COMMENT 'my table'`)
+	if stmt.Columns[0].Comment != "primary key" {
+		t.Errorf("Columns[0].Comment = %q, want %q", stmt.Columns[0].Comment, "primary key")
+	}
+	if stmt.Comment != "my table" {
+		t.Errorf("Comment = %q, want %q", stmt.Comment, "my table")
+	}
+}
+
+func TestCreateTable_AggregateKey(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (k1 INT, v1 INT) AGGREGATE KEY(k1)")
+	if stmt.KeyDesc == nil {
+		t.Fatal("KeyDesc is nil")
+	}
+	if stmt.KeyDesc.Type != "AGGREGATE" {
+		t.Errorf("KeyDesc.Type = %q, want %q", stmt.KeyDesc.Type, "AGGREGATE")
+	}
+	if len(stmt.KeyDesc.Columns) != 1 || stmt.KeyDesc.Columns[0] != "k1" {
+		t.Errorf("KeyDesc.Columns = %v, want [k1]", stmt.KeyDesc.Columns)
+	}
+}
+
+func TestCreateTable_UniqueKey(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (k1 INT, v1 INT) UNIQUE KEY(k1)")
+	if stmt.KeyDesc == nil {
+		t.Fatal("KeyDesc is nil")
+	}
+	if stmt.KeyDesc.Type != "UNIQUE" {
+		t.Errorf("KeyDesc.Type = %q, want %q", stmt.KeyDesc.Type, "UNIQUE")
+	}
+}
+
+func TestCreateTable_DuplicateKey(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (k1 INT, v1 INT) DUPLICATE KEY(k1)")
+	if stmt.KeyDesc == nil {
+		t.Fatal("KeyDesc is nil")
+	}
+	if stmt.KeyDesc.Type != "DUPLICATE" {
+		t.Errorf("KeyDesc.Type = %q, want %q", stmt.KeyDesc.Type, "DUPLICATE")
+	}
+}
+
+func TestCreateTable_DistributedByHash(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT) DISTRIBUTED BY HASH(id) BUCKETS 10")
+	if stmt.DistributedBy == nil {
+		t.Fatal("DistributedBy is nil")
+	}
+	if stmt.DistributedBy.Type != "HASH" {
+		t.Errorf("DistributedBy.Type = %q, want %q", stmt.DistributedBy.Type, "HASH")
+	}
+	if len(stmt.DistributedBy.Columns) != 1 || stmt.DistributedBy.Columns[0] != "id" {
+		t.Errorf("DistributedBy.Columns = %v, want [id]", stmt.DistributedBy.Columns)
+	}
+	if stmt.DistributedBy.Buckets != 10 {
+		t.Errorf("DistributedBy.Buckets = %d, want 10", stmt.DistributedBy.Buckets)
+	}
+}
+
+func TestCreateTable_DistributedByRandom(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT) DISTRIBUTED BY RANDOM BUCKETS AUTO")
+	if stmt.DistributedBy == nil {
+		t.Fatal("DistributedBy is nil")
+	}
+	if stmt.DistributedBy.Type != "RANDOM" {
+		t.Errorf("DistributedBy.Type = %q, want %q", stmt.DistributedBy.Type, "RANDOM")
+	}
+	if !stmt.DistributedBy.Auto {
+		t.Error("DistributedBy.Auto should be true")
+	}
+}
+
+func TestCreateTable_PartitionByRange(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		`CREATE TABLE t (id INT, dt DATE) PARTITION BY RANGE(dt) (PARTITION p1 VALUES LESS THAN ('2024-01-01'))`)
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if stmt.PartitionBy.Type != "RANGE" {
+		t.Errorf("PartitionBy.Type = %q, want %q", stmt.PartitionBy.Type, "RANGE")
+	}
+	if len(stmt.PartitionBy.Columns) != 1 || stmt.PartitionBy.Columns[0] != "dt" {
+		t.Errorf("PartitionBy.Columns = %v, want [dt]", stmt.PartitionBy.Columns)
+	}
+	if len(stmt.PartitionBy.Partitions) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(stmt.PartitionBy.Partitions))
+	}
+	p := stmt.PartitionBy.Partitions[0]
+	if p.Name != "p1" {
+		t.Errorf("Partitions[0].Name = %q, want %q", p.Name, "p1")
+	}
+	if len(p.Values) != 1 || p.Values[0] != "2024-01-01" {
+		t.Errorf("Partitions[0].Values = %v, want [2024-01-01]", p.Values)
+	}
+}
+
+func TestCreateTable_PartitionByList(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		`CREATE TABLE t (id INT, dt DATE NOT NULL) PARTITION BY LIST(dt) (PARTITION p1 VALUES IN (('2020-01-01'), ('2020-01-02')))`)
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if stmt.PartitionBy.Type != "LIST" {
+		t.Errorf("PartitionBy.Type = %q, want %q", stmt.PartitionBy.Type, "LIST")
+	}
+	if len(stmt.PartitionBy.Partitions) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(stmt.PartitionBy.Partitions))
+	}
+	p := stmt.PartitionBy.Partitions[0]
+	if p.Name != "p1" {
+		t.Errorf("Partitions[0].Name = %q, want %q", p.Name, "p1")
+	}
+	if len(p.InValues) != 2 {
+		t.Fatalf("expected 2 IN value groups, got %d", len(p.InValues))
+	}
+}
+
+func TestCreateTable_WithEngine(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT) ENGINE = olap")
+	if stmt.Engine != "olap" {
+		t.Errorf("Engine = %q, want %q", stmt.Engine, "olap")
+	}
+}
+
+func TestCreateTable_WithProperties(t *testing.T) {
+	stmt := parseCreateTableStmt(t, `CREATE TABLE t (id INT) PROPERTIES("replication_num"="3")`)
+	if len(stmt.Properties) != 1 {
+		t.Fatalf("expected 1 property, got %d", len(stmt.Properties))
+	}
+	if stmt.Properties[0].Key != "replication_num" {
+		t.Errorf("Properties[0].Key = %q, want %q", stmt.Properties[0].Key, "replication_num")
+	}
+	if stmt.Properties[0].Value != "3" {
+		t.Errorf("Properties[0].Value = %q, want %q", stmt.Properties[0].Value, "3")
+	}
+}
+
+func TestCreateTable_IfNotExists(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE IF NOT EXISTS t (id INT)")
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists should be true")
+	}
+	if stmt.Name.String() != "t" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "t")
+	}
+}
+
+func TestCreateTable_External(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE EXTERNAL TABLE t (id INT)")
+	if !stmt.External {
+		t.Error("External should be true")
+	}
+}
+
+func TestCreateTable_Temporary(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TEMPORARY TABLE t (id INT)")
+	if !stmt.Temporary {
+		t.Error("Temporary should be true")
+	}
+}
+
+func TestCreateTable_CTAS(t *testing.T) {
+	stmt := parseCreateTableStmt(t, `CREATE TABLE t PROPERTIES ('replication_num' = '1') AS SELECT * FROM t1`)
+	if stmt.AsSelect == nil {
+		t.Fatal("AsSelect is nil")
+	}
+	if stmt.AsSelect.RawText != "SELECT * FROM t1" {
+		t.Errorf("AsSelect.RawText = %q, want %q", stmt.AsSelect.RawText, "SELECT * FROM t1")
+	}
+	if len(stmt.Properties) != 1 {
+		t.Fatalf("expected 1 property, got %d", len(stmt.Properties))
+	}
+}
+
+func TestCreateTable_Like(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t11 LIKE t10")
+	if stmt.Like == nil {
+		t.Fatal("Like is nil")
+	}
+	if stmt.Like.String() != "t10" {
+		t.Errorf("Like = %q, want %q", stmt.Like.String(), "t10")
+	}
+	if stmt.Name.String() != "t11" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "t11")
+	}
+}
+
+func TestCreateTable_QualifiedName(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE example_db.my_table (id INT)")
+	if stmt.Name.String() != "example_db.my_table" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "example_db.my_table")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Column definition details
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_ColumnAggType(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (c1 INT, c2 INT MAX) AGGREGATE KEY(c1)")
+	if stmt.Columns[1].AggType != "MAX" {
+		t.Errorf("Columns[1].AggType = %q, want %q", stmt.Columns[1].AggType, "MAX")
+	}
+}
+
+func TestCreateTable_ColumnReplaceAggType(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (k1 TINYINT, v1 CHAR(10) REPLACE) AGGREGATE KEY(k1)")
+	if stmt.Columns[1].AggType != "REPLACE" {
+		t.Errorf("Columns[1].AggType = %q, want %q", stmt.Columns[1].AggType, "REPLACE")
+	}
+}
+
+func TestCreateTable_ColumnDefaultString(t *testing.T) {
+	stmt := parseCreateTableStmt(t, `CREATE TABLE t (v1 VARCHAR(2048), v2 SMALLINT DEFAULT "10")`)
+	if stmt.Columns[1].Default == nil {
+		t.Fatal("Columns[1].Default is nil")
+	}
+	lit := stmt.Columns[1].Default.(*ast.Literal)
+	if lit.Value != "10" {
+		t.Errorf("Columns[1].Default = %q, want %q", lit.Value, "10")
+	}
+}
+
+func TestCreateTable_ColumnDefaultTimestamp(t *testing.T) {
+	stmt := parseCreateTableStmt(t, `CREATE TABLE t (v1 DATETIME DEFAULT "2014-02-04 15:36:00")`)
+	if stmt.Columns[0].Default == nil {
+		t.Fatal("Default is nil")
+	}
+	lit := stmt.Columns[0].Default.(*ast.Literal)
+	if lit.Value != "2014-02-04 15:36:00" {
+		t.Errorf("Default = %q, want %q", lit.Value, "2014-02-04 15:36:00")
+	}
+}
+
+func TestCreateTable_ColumnDefaultInt(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (c1 INT, c2 INT DEFAULT 10)")
+	if stmt.Columns[1].Default == nil {
+		t.Fatal("Columns[1].Default is nil")
+	}
+	lit := stmt.Columns[1].Default.(*ast.Literal)
+	if lit.Value != "10" {
+		t.Errorf("Columns[1].Default = %q, want %q", lit.Value, "10")
+	}
+}
+
+func TestCreateTable_ColumnGenerated(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (c1 INT, c2 INT GENERATED ALWAYS AS (c1 + 1))")
+	if stmt.Columns[1].Generated == nil {
+		t.Fatal("Columns[1].Generated is nil")
+	}
+}
+
+func TestCreateTable_EmptyColumnComment(t *testing.T) {
+	stmt := parseCreateTableStmt(t, `CREATE TABLE t (id INT COMMENT "")`)
+	if stmt.Columns[0].Comment != "" {
+		t.Errorf("Columns[0].Comment = %q, want empty string", stmt.Columns[0].Comment)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inline INDEX definitions
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_InlineIndex(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		`CREATE TABLE t (k1 TINYINT, k2 DECIMAL(10, 2) DEFAULT "10.5", v1 CHAR(10) REPLACE, v2 INT SUM, INDEX k1_idx (k1) USING INVERTED COMMENT 'my first index') AGGREGATE KEY(k1, k2)`)
+	if len(stmt.Indexes) != 1 {
+		t.Fatalf("expected 1 index, got %d", len(stmt.Indexes))
+	}
+	idx := stmt.Indexes[0]
+	if idx.Name != "k1_idx" {
+		t.Errorf("Index.Name = %q, want %q", idx.Name, "k1_idx")
+	}
+	if len(idx.Columns) != 1 || idx.Columns[0] != "k1" {
+		t.Errorf("Index.Columns = %v, want [k1]", idx.Columns)
+	}
+	if idx.IndexType != "inverted" {
+		t.Errorf("Index.IndexType = %q, want %q", idx.IndexType, "inverted")
+	}
+	if idx.Comment != "my first index" {
+		t.Errorf("Index.Comment = %q, want %q", idx.Comment, "my first index")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Distribution variations
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_DistributedByHashMultiCol(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t (k1 BIGINT, k2 LARGEINT) UNIQUE KEY(k1, k2) DISTRIBUTED BY HASH(k1, k2) BUCKETS 32")
+	if stmt.DistributedBy == nil {
+		t.Fatal("DistributedBy is nil")
+	}
+	if len(stmt.DistributedBy.Columns) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(stmt.DistributedBy.Columns))
+	}
+	if stmt.DistributedBy.Columns[0] != "k1" || stmt.DistributedBy.Columns[1] != "k2" {
+		t.Errorf("DistributedBy.Columns = %v, want [k1 k2]", stmt.DistributedBy.Columns)
+	}
+	if stmt.DistributedBy.Buckets != 32 {
+		t.Errorf("DistributedBy.Buckets = %d, want 32", stmt.DistributedBy.Buckets)
+	}
+}
+
+func TestCreateTable_DistributedByRandomNoBuckets(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t (c1 INT, c2 INT) DUPLICATE KEY(c1) DISTRIBUTED BY RANDOM")
+	if stmt.DistributedBy == nil {
+		t.Fatal("DistributedBy is nil")
+	}
+	if stmt.DistributedBy.Type != "RANDOM" {
+		t.Errorf("DistributedBy.Type = %q, want %q", stmt.DistributedBy.Type, "RANDOM")
+	}
+	if stmt.DistributedBy.Buckets != 0 {
+		t.Errorf("DistributedBy.Buckets = %d, want 0", stmt.DistributedBy.Buckets)
+	}
+	if stmt.DistributedBy.Auto {
+		t.Error("DistributedBy.Auto should be false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full combo tests from legacy corpus
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_Legacy_t1(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t1(c1 INT, c2 STRING) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')")
+	if stmt.Name.String() != "t1" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "t1")
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.KeyDesc == nil || stmt.KeyDesc.Type != "DUPLICATE" {
+		t.Error("expected DUPLICATE KEY")
+	}
+	if stmt.DistributedBy == nil || stmt.DistributedBy.Type != "HASH" {
+		t.Error("expected DISTRIBUTED BY HASH")
+	}
+	if len(stmt.Properties) != 1 {
+		t.Errorf("expected 1 property, got %d", len(stmt.Properties))
+	}
+}
+
+func TestCreateTable_Legacy_t2(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t2(c1 INT, c2 INT MAX) AGGREGATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')")
+	if stmt.Columns[1].AggType != "MAX" {
+		t.Errorf("c2 AggType = %q, want %q", stmt.Columns[1].AggType, "MAX")
+	}
+	if stmt.KeyDesc.Type != "AGGREGATE" {
+		t.Errorf("KeyDesc.Type = %q, want %q", stmt.KeyDesc.Type, "AGGREGATE")
+	}
+}
+
+func TestCreateTable_Legacy_t3(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t3(c1 INT, c2 INT) UNIQUE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')")
+	if stmt.KeyDesc.Type != "UNIQUE" {
+		t.Errorf("KeyDesc.Type = %q, want %q", stmt.KeyDesc.Type, "UNIQUE")
+	}
+}
+
+func TestCreateTable_Legacy_t4_Generated(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t4(c1 INT, c2 INT GENERATED ALWAYS AS (c1 + 1)) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')")
+	if stmt.Columns[1].Generated == nil {
+		t.Error("expected generated column")
+	}
+}
+
+func TestCreateTable_Legacy_t5_Default(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t5(c1 INT, c2 INT DEFAULT 10) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')")
+	if stmt.Columns[1].Default == nil {
+		t.Fatal("expected DEFAULT value")
+	}
+	lit := stmt.Columns[1].Default.(*ast.Literal)
+	if lit.Value != "10" {
+		t.Errorf("Default = %q, want %q", lit.Value, "10")
+	}
+}
+
+func TestCreateTable_Legacy_t6_RandomDist(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t6(c1 INT, c2 INT) DUPLICATE KEY(c1) DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')")
+	if stmt.DistributedBy.Type != "RANDOM" {
+		t.Errorf("DistributedBy.Type = %q, want %q", stmt.DistributedBy.Type, "RANDOM")
+	}
+}
+
+func TestCreateTable_Legacy_t10_CTAS(t *testing.T) {
+	stmt := parseCreateTableStmt(t,
+		"CREATE TABLE t10 PROPERTIES ('replication_num' = '1') AS SELECT * FROM t1")
+	if stmt.AsSelect == nil {
+		t.Fatal("AsSelect is nil")
+	}
+	if stmt.AsSelect.RawText != "SELECT * FROM t1" {
+		t.Errorf("AsSelect.RawText = %q, want %q", stmt.AsSelect.RawText, "SELECT * FROM t1")
+	}
+}
+
+func TestCreateTable_Legacy_t11_Like(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t11 LIKE t10")
+	if stmt.Like == nil {
+		t.Fatal("Like is nil")
+	}
+	if stmt.Like.String() != "t10" {
+		t.Errorf("Like = %q, want %q", stmt.Like.String(), "t10")
+	}
+}
+
+func TestCreateTable_Legacy_FullCombo(t *testing.T) {
+	sql := `CREATE TABLE example_db.table_hash(k1 BIGINT, k2 LARGEINT, v1 VARCHAR(2048), v2 SMALLINT DEFAULT "10") UNIQUE KEY(k1, k2) DISTRIBUTED BY HASH(k1, k2) BUCKETS 32 PROPERTIES("storage_medium" = "SSD", "storage_cooldown_time" = "2015-06-04 00:00:00")`
+	stmt := parseCreateTableStmt(t, sql)
+	if stmt.Name.String() != "example_db.table_hash" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "example_db.table_hash")
+	}
+	if len(stmt.Columns) != 4 {
+		t.Fatalf("expected 4 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.KeyDesc.Type != "UNIQUE" {
+		t.Errorf("KeyDesc.Type = %q, want %q", stmt.KeyDesc.Type, "UNIQUE")
+	}
+	if stmt.DistributedBy.Buckets != 32 {
+		t.Errorf("Buckets = %d, want 32", stmt.DistributedBy.Buckets)
+	}
+	if len(stmt.Properties) != 2 {
+		t.Fatalf("expected 2 properties, got %d", len(stmt.Properties))
+	}
+}
+
+func TestCreateTable_Legacy_IfNotExists(t *testing.T) {
+	sql := `CREATE TABLE IF NOT EXISTS create_table_use_created_policy (k1 BIGINT, k2 LARGEINT, v1 VARCHAR(2048)) UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES("storage_policy" = "test_create_table_use_policy", "replication_num" = "1")`
+	stmt := parseCreateTableStmt(t, sql)
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists should be true")
+	}
+	if len(stmt.Columns) != 3 {
+		t.Fatalf("expected 3 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.DistributedBy.Buckets != 3 {
+		t.Errorf("Buckets = %d, want 3", stmt.DistributedBy.Buckets)
+	}
+}
+
+func TestCreateTable_Legacy_ColocateGroup(t *testing.T) {
+	sql := `CREATE TABLE t1 (id INT COMMENT "", value VARCHAR(8) COMMENT "") DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES ("colocate_with" = "group1")`
+	stmt := parseCreateTableStmt(t, sql)
+	if len(stmt.Properties) != 1 {
+		t.Fatalf("expected 1 property, got %d", len(stmt.Properties))
+	}
+	if stmt.Properties[0].Key != "colocate_with" {
+		t.Errorf("Properties[0].Key = %q, want %q", stmt.Properties[0].Key, "colocate_with")
+	}
+}
+
+func TestCreateTable_Legacy_InlineIndexWithAggTypes(t *testing.T) {
+	sql := `CREATE TABLE example_db.table_hash(k1 TINYINT, k2 DECIMAL(10, 2) DEFAULT "10.5", v1 CHAR(10) REPLACE, v2 INT SUM, INDEX k1_idx (k1) USING INVERTED COMMENT 'my first index') AGGREGATE KEY(k1, k2) DISTRIBUTED BY HASH(k1) BUCKETS 32 PROPERTIES ("bloom_filter_columns" = "k2")`
+	stmt := parseCreateTableStmt(t, sql)
+	if len(stmt.Columns) != 4 {
+		t.Fatalf("expected 4 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.Columns[2].AggType != "REPLACE" {
+		t.Errorf("v1 AggType = %q, want %q", stmt.Columns[2].AggType, "REPLACE")
+	}
+	if stmt.Columns[3].AggType != "SUM" {
+		t.Errorf("v2 AggType = %q, want %q", stmt.Columns[3].AggType, "SUM")
+	}
+	if len(stmt.Indexes) != 1 {
+		t.Fatalf("expected 1 index, got %d", len(stmt.Indexes))
+	}
+}
+
+func TestCreateTable_Legacy_NoKeyClause(t *testing.T) {
+	sql := `CREATE TABLE example_db.table_hash(k1 TINYINT, k2 DECIMAL(10, 2) DEFAULT "10.5") DISTRIBUTED BY HASH(k1) BUCKETS 32 PROPERTIES ("replication_allocation" = "tag.location.group_a:1, tag.location.group_b:2")`
+	stmt := parseCreateTableStmt(t, sql)
+	if stmt.KeyDesc != nil {
+		t.Error("expected nil KeyDesc")
+	}
+	if stmt.DistributedBy.Buckets != 32 {
+		t.Errorf("Buckets = %d, want 32", stmt.DistributedBy.Buckets)
+	}
+}
+
+func TestCreateTable_Legacy_DynamicPartition(t *testing.T) {
+	sql := `CREATE TABLE example_db.dynamic_partition(k1 DATE, k2 INT, k3 SMALLINT, v1 VARCHAR(2048), v2 DATETIME DEFAULT "2014-02-04 15:36:00") DUPLICATE KEY(k1, k2, k3) PARTITION BY RANGE(k1) () DISTRIBUTED BY HASH(k2) BUCKETS 32 PROPERTIES("dynamic_partition.time_unit" = "DAY", "dynamic_partition.start" = "-3", "dynamic_partition.end" = "3", "dynamic_partition.prefix" = "p", "dynamic_partition.buckets" = "32")`
+	stmt := parseCreateTableStmt(t, sql)
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if stmt.PartitionBy.Type != "RANGE" {
+		t.Errorf("PartitionBy.Type = %q, want %q", stmt.PartitionBy.Type, "RANGE")
+	}
+	// Empty partition list is valid for dynamic partition
+	if len(stmt.PartitionBy.Partitions) != 0 {
+		t.Errorf("expected 0 partitions, got %d", len(stmt.PartitionBy.Partitions))
+	}
+	if len(stmt.Properties) != 5 {
+		t.Fatalf("expected 5 properties, got %d", len(stmt.Properties))
+	}
+}
+
+func TestCreateTable_Legacy_StepPartition(t *testing.T) {
+	sql := `CREATE TABLE t8(c1 INT, c2 DATETIME NOT NULL) DUPLICATE KEY(c1) PARTITION BY RANGE(c2) (FROM ('2020-01-01') TO ('2020-01-10') INTERVAL 1 DAY) DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')`
+	stmt := parseCreateTableStmt(t, sql)
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if len(stmt.PartitionBy.Partitions) != 1 {
+		t.Fatalf("expected 1 partition item, got %d", len(stmt.PartitionBy.Partitions))
+	}
+	p := stmt.PartitionBy.Partitions[0]
+	if !p.IsStep {
+		t.Error("expected step partition")
+	}
+	if len(p.FromValues) != 1 || p.FromValues[0] != "2020-01-01" {
+		t.Errorf("FromValues = %v, want [2020-01-01]", p.FromValues)
+	}
+	if len(p.ToValues) != 1 || p.ToValues[0] != "2020-01-10" {
+		t.Errorf("ToValues = %v, want [2020-01-10]", p.ToValues)
+	}
+	if p.Interval != "1" {
+		t.Errorf("Interval = %q, want %q", p.Interval, "1")
+	}
+	if p.IntervalUnit != "DAY" {
+		t.Errorf("IntervalUnit = %q, want %q", p.IntervalUnit, "DAY")
+	}
+}
+
+func TestCreateTable_Legacy_ListPartition(t *testing.T) {
+	sql := `CREATE TABLE t9(c1 INT, c2 DATE NOT NULL) DUPLICATE KEY(c1) PARTITION BY LIST(c2) (PARTITION p1 VALUES IN (('2020-01-01'), ('2020-01-02'))) DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')`
+	stmt := parseCreateTableStmt(t, sql)
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if stmt.PartitionBy.Type != "LIST" {
+		t.Errorf("PartitionBy.Type = %q, want %q", stmt.PartitionBy.Type, "LIST")
+	}
+	if len(stmt.PartitionBy.Partitions) != 1 {
+		t.Fatalf("expected 1 partition, got %d", len(stmt.PartitionBy.Partitions))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto partition
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_AutoPartition(t *testing.T) {
+	sql := `CREATE TABLE t7(c1 INT, c2 DATETIME NOT NULL) DUPLICATE KEY(c1) AUTO PARTITION BY RANGE(date_trunc(c2, 'day')) () DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')`
+	stmt := parseCreateTableStmt(t, sql)
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if !stmt.PartitionBy.Auto {
+		t.Error("PartitionBy.Auto should be true")
+	}
+	if stmt.PartitionBy.Type != "RANGE" {
+		t.Errorf("PartitionBy.Type = %q, want %q", stmt.PartitionBy.Type, "RANGE")
+	}
+	// Should have captured the function expression
+	if len(stmt.PartitionBy.FuncExprs) != 1 {
+		t.Fatalf("expected 1 funcExpr, got %d (cols=%v)", len(stmt.PartitionBy.FuncExprs), stmt.PartitionBy.Columns)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NodeTag
+// ---------------------------------------------------------------------------
+
+func TestCreateTableStmt_Tag(t *testing.T) {
+	stmt := &ast.CreateTableStmt{}
+	if stmt.Tag() != ast.T_CreateTableStmt {
+		t.Errorf("Tag() = %v, want T_CreateTableStmt", stmt.Tag())
+	}
+}
+
+func TestColumnDef_Tag(t *testing.T) {
+	col := &ast.ColumnDef{}
+	if col.Tag() != ast.T_ColumnDef {
+		t.Errorf("Tag() = %v, want T_ColumnDef", col.Tag())
+	}
+}
+
+func TestKeyDesc_Tag(t *testing.T) {
+	kd := &ast.KeyDesc{}
+	if kd.Tag() != ast.T_KeyDesc {
+		t.Errorf("Tag() = %v, want T_KeyDesc", kd.Tag())
+	}
+}
+
+func TestDistributionDesc_Tag(t *testing.T) {
+	dd := &ast.DistributionDesc{}
+	if dd.Tag() != ast.T_DistributionDesc {
+		t.Errorf("Tag() = %v, want T_DistributionDesc", dd.Tag())
+	}
+}
+
+func TestPartitionDesc_Tag(t *testing.T) {
+	pd := &ast.PartitionDesc{}
+	if pd.Tag() != ast.T_PartitionDesc {
+		t.Errorf("Tag() = %v, want T_PartitionDesc", pd.Tag())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc tracking
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_LocIsValid(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT)")
+	if !stmt.Loc.IsValid() {
+		t.Errorf("Loc = %v, want valid", stmt.Loc)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_Walk(t *testing.T) {
+	file, errs := Parse("CREATE TABLE t (id INT, name VARCHAR(50)) DISTRIBUTED BY HASH(id) BUCKETS 10")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	var visited []ast.NodeTag
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n != nil {
+			visited = append(visited, n.Tag())
+		}
+		return true
+	})
+
+	// Should visit: File, CreateTableStmt, ObjectName(t), ColumnDef(id), TypeName(INT),
+	// ColumnDef(name), TypeName(VARCHAR), DistributionDesc
+	if len(visited) < 5 {
+		t.Errorf("expected at least 5 visited nodes, got %d: %v", len(visited), visited)
+	}
+
+	// First should be File
+	if visited[0] != ast.T_File {
+		t.Errorf("visited[0] = %v, want File", visited[0])
+	}
+	// Second should be CreateTableStmt
+	if visited[1] != ast.T_CreateTableStmt {
+		t.Errorf("visited[1] = %v, want CreateTableStmt", visited[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full legacy corpus parse test
+// ---------------------------------------------------------------------------
+
+func TestCreateTable_LegacyCorpus(t *testing.T) {
+	// All statements from the legacy test corpus should parse without errors.
+	// Some may have features we partially handle; the test just verifies no panics or errors.
+	corpus := []string{
+		"CREATE TABLE t1(c1 INT, c2 STRING) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')",
+		"CREATE TABLE t2(c1 INT, c2 INT MAX) AGGREGATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')",
+		"CREATE TABLE t3(c1 INT, c2 INT) UNIQUE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')",
+		"CREATE TABLE t4(c1 INT, c2 INT GENERATED ALWAYS AS (c1 + 1)) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')",
+		"CREATE TABLE t5(c1 INT, c2 INT DEFAULT 10) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) PROPERTIES ('replication_num' = '1')",
+		"CREATE TABLE t6(c1 INT, c2 INT) DUPLICATE KEY(c1) DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')",
+		`CREATE TABLE t7(c1 INT, c2 DATETIME NOT NULL) DUPLICATE KEY(c1) AUTO PARTITION BY RANGE(date_trunc(c2, 'day')) () DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')`,
+		`CREATE TABLE t8(c1 INT, c2 DATETIME NOT NULL) DUPLICATE KEY(c1) PARTITION BY RANGE(c2) (FROM ('2020-01-01') TO ('2020-01-10') INTERVAL 1 DAY) DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')`,
+		`CREATE TABLE t9(c1 INT, c2 DATE NOT NULL) DUPLICATE KEY(c1) PARTITION BY LIST(c2) (PARTITION p1 VALUES IN (('2020-01-01'), ('2020-01-02'))) DISTRIBUTED BY RANDOM PROPERTIES ('replication_num' = '1')`,
+		`CREATE TABLE example_db.table_hash(k1 BIGINT, k2 LARGEINT, v1 VARCHAR(2048), v2 SMALLINT DEFAULT "10") UNIQUE KEY(k1, k2) DISTRIBUTED BY HASH(k1, k2) BUCKETS 32 PROPERTIES("storage_medium" = "SSD", "storage_cooldown_time" = "2015-06-04 00:00:00")`,
+		`CREATE TABLE IF NOT EXISTS create_table_use_created_policy (k1 BIGINT, k2 LARGEINT, v1 VARCHAR(2048)) UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES("storage_policy" = "test_create_table_use_policy", "replication_num" = "1")`,
+		`CREATE TABLE t1 (id INT COMMENT "", value VARCHAR(8) COMMENT "") DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES ("colocate_with" = "group1")`,
+		`CREATE TABLE t2 (id INT COMMENT "", value1 VARCHAR(8) COMMENT "", value2 VARCHAR(8) COMMENT "") DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES ("colocate_with" = "group1")`,
+		`CREATE TABLE example_db.table_hash(k1 TINYINT, k2 DECIMAL(10, 2) DEFAULT "10.5", v1 CHAR(10) REPLACE, v2 INT SUM, INDEX k1_idx (k1) USING INVERTED COMMENT 'my first index') AGGREGATE KEY(k1, k2) DISTRIBUTED BY HASH(k1) BUCKETS 32 PROPERTIES ("bloom_filter_columns" = "k2")`,
+		`CREATE TABLE example_db.table_hash(k1 TINYINT, k2 DECIMAL(10, 2) DEFAULT "10.5") DISTRIBUTED BY HASH(k1) BUCKETS 32 PROPERTIES ("replication_allocation" = "tag.location.group_a:1, tag.location.group_b:2")`,
+		`CREATE TABLE example_db.dynamic_partition(k1 DATE, k2 INT, k3 SMALLINT, v1 VARCHAR(2048), v2 DATETIME DEFAULT "2014-02-04 15:36:00") DUPLICATE KEY(k1, k2, k3) PARTITION BY RANGE(k1) () DISTRIBUTED BY HASH(k2) BUCKETS 32 PROPERTIES("dynamic_partition.time_unit" = "DAY", "dynamic_partition.start" = "-3", "dynamic_partition.end" = "3", "dynamic_partition.prefix" = "p", "dynamic_partition.buckets" = "32")`,
+		"CREATE TABLE t10 PROPERTIES ('replication_num' = '1') AS SELECT * FROM t1",
+		"CREATE TABLE t11 LIKE t10",
+	}
+
+	for i, sql := range corpus {
+		file, errs := Parse(sql)
+		if len(errs) != 0 {
+			t.Errorf("corpus[%d] Parse errors: %v\nSQL: %s", i, errs, sql)
+			continue
+		}
+		if len(file.Stmts) != 1 {
+			t.Errorf("corpus[%d] expected 1 stmt, got %d", i, len(file.Stmts))
+			continue
+		}
+		if _, ok := file.Stmts[0].(*ast.CreateTableStmt); !ok {
+			t.Errorf("corpus[%d] expected *ast.CreateTableStmt, got %T", i, file.Stmts[0])
+		}
+	}
+}

--- a/doris/parser/database_test.go
+++ b/doris/parser/database_test.go
@@ -378,14 +378,17 @@ func TestCreateDropDatabase_MultiStatement(t *testing.T) {
 // Other CREATE/ALTER/DROP still unsupported
 // ---------------------------------------------------------------------------
 
-func TestCreateTable_StillUnsupported(t *testing.T) {
-	_, errs := Parse("CREATE TABLE t (id INT)")
-	if len(errs) == 0 {
-		t.Fatal("expected error for unsupported CREATE TABLE")
+func TestCreateTable_NowSupported(t *testing.T) {
+	file, errs := Parse("CREATE TABLE t (id INT)")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
 	}
-	want := "CREATE statement parsing is not yet supported"
-	if errs[0].Msg != want {
-		t.Errorf("error = %q, want %q", errs[0].Msg, want)
+	if len(file.Stmts) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(file.Stmts))
+	}
+	_, ok := file.Stmts[0].(*ast.CreateTableStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateTableStmt, got %T", file.Stmts[0])
 	}
 }
 

--- a/doris/parser/index_test.go
+++ b/doris/parser/index_test.go
@@ -308,16 +308,15 @@ func TestBuildIndexNodeTag(t *testing.T) {
 	}
 }
 
-// TestCreateIndexStillUnsupportedForNonIndex verifies that CREATE TABLE
-// still returns the "not yet supported" error path.
-func TestCreateIndexStillUnsupportedForNonIndex(t *testing.T) {
-	_, errs := Parse("CREATE TABLE t (id INT)")
-	if len(errs) == 0 {
-		t.Fatal("expected error for CREATE TABLE")
+// TestCreateIndexCreateTableNowSupported verifies that CREATE TABLE
+// no longer returns an unsupported error.
+func TestCreateIndexCreateTableNowSupported(t *testing.T) {
+	file, errs := Parse("CREATE TABLE t (id INT)")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
 	}
-	want := "CREATE statement parsing is not yet supported"
-	if errs[0].Msg != want {
-		t.Errorf("got %q, want %q", errs[0].Msg, want)
+	if len(file.Stmts) != 1 {
+		t.Fatalf("expected 1 stmt, got %d", len(file.Stmts))
 	}
 }
 

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -179,6 +179,8 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			return p.parseCreateIndex(createTok.Loc)
 		case kwDATABASE, kwSCHEMA:
 			return p.parseCreateDatabase()
+		case kwTABLE, kwEXTERNAL, kwTEMPORARY:
+			return p.parseCreateTable()
 		default:
 			return p.unsupported("CREATE")
 		}

--- a/doris/parser/parser_test.go
+++ b/doris/parser/parser_test.go
@@ -38,8 +38,8 @@ func TestParseUnsupported(t *testing.T) {
 }
 
 func TestParseMultipleUnsupported(t *testing.T) {
-	// SELECT is now supported; INSERT and CREATE TABLE are still unsupported.
-	file, errs := Parse("SELECT 1; INSERT INTO t VALUES (1); CREATE TABLE t (id INT)")
+	// SELECT is supported; INSERT and TRUNCATE are still unsupported.
+	file, errs := Parse("SELECT 1; INSERT INTO t VALUES (1); TRUNCATE TABLE t")
 	if file == nil {
 		t.Fatal("expected non-nil File")
 	}
@@ -169,7 +169,6 @@ func TestParseAllDispatchCategories(t *testing.T) {
 		input   string
 		wantMsg string
 	}{
-		{"CREATE TABLE t (id INT)", "CREATE"},
 		{"ALTER TABLE t ADD COLUMN c INT", "ALTER"},
 		{"DROP TABLE t", "DROP"},
 		{"TRUNCATE TABLE t", "TRUNCATE"},


### PR DESCRIPTION
## Summary
- Add 10 DDL AST nodes: `CreateTableStmt`, `ColumnDef`, `IndexDef`, `TableConstraint`, `KeyDesc`, `PartitionDesc`, `PartitionItem`, `DistributionDesc`, `RollupDef`, `RawQuery`
- Full CREATE TABLE parsing with all Doris-specific extensions:
  - AGGREGATE/UNIQUE/DUPLICATE KEY
  - DISTRIBUTED BY HASH/RANDOM with BUCKETS n/AUTO
  - PARTITION BY RANGE/LIST with named partitions, step partitions, auto partition
  - ROLLUP definitions
  - Column defs with aggregate types (SUM, MAX, REPLACE, HLL_UNION, BITMAP_UNION, etc.)
  - Inline INDEX definitions (BITMAP, NGRAM_BF, INVERTED, ANN)
  - CREATE TABLE ... AS SELECT (CTAS)
  - CREATE TABLE ... LIKE
  - EXTERNAL, TEMPORARY, IF NOT EXISTS
- 49 unit tests

DAG node: T2.1 from `docs/migration/doris/dag.md`

## Test plan
- [x] 49 new tests pass (`go test ./doris/parser/...`)
- [x] `go build ./...` clean
- [x] `go vet ./doris/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)