### PR TITLE
feat(snowflake): T2.5 DROP/UNDROP (table core + 15 other object types)

### DIFF
--- a/docs/superpowers/plans/2026-04-14-snowflake-drop-undrop.md
+++ b/docs/superpowers/plans/2026-04-14-snowflake-drop-undrop.md
@@ -1,0 +1,52 @@
+# Plan: T2.5 Snowflake DROP / UNDROP DDL
+
+## Steps
+
+### Step 1 — AST types + node tags
+
+Files: `snowflake/ast/parsenodes.go`, `snowflake/ast/nodetags.go`
+
+- Add `DropObjectKind` enum with 16 values
+- Add `DropStmt` struct (Kind, IfExists, Name, Cascade, Restrict, Loc)
+- Add `UndropObjectKind` enum with 3 values
+- Add `UndropStmt` struct (Kind, Name, Loc)
+- Add `T_DropStmt` and `T_UndropStmt` to nodetags.go
+- Add compile-time assertions `var _ Node = (*DropStmt)(nil)` etc.
+
+### Step 2 — Regenerate walker
+
+Run `go run ./snowflake/ast/cmd/genwalker` from the worktree root.
+This auto-generates cases for `*DropStmt` and `*UndropStmt` in
+`walk_generated.go`.
+
+### Step 3 — Parser: drop.go + undrop dispatch
+
+File: `snowflake/parser/drop.go` (new file)
+
+Implement:
+- `parseDropStmt()` — dispatch on object type keyword
+- `parseDropObject(kind, name *ast.ObjectName, ifExists, cascadeOK bool)` — shared builder
+- `parseUndropStmt()` — dispatch on object type keyword
+
+Update `snowflake/parser/parser.go`:
+- Replace `p.unsupported("DROP")` → `p.parseDropStmt()`
+- Replace `p.unsupported("UNDROP")` → `p.parseUndropStmt()`
+
+### Step 4 — Tests
+
+File: `snowflake/parser/drop_test.go` (new file)
+
+Cover all forms listed in the spec.
+
+### Step 5 — Verify, format, commit
+
+```
+cd /Users/h3n4l/OpenSource/omni/.worktrees/snowflake-drop
+go test ./snowflake/... -count=1
+gofmt -w snowflake/
+```
+
+Commit in 3 logical chunks:
+1. AST types + node tags
+2. Parser implementation + parser.go dispatch wiring
+3. Tests + docs

--- a/docs/superpowers/specs/2026-04-14-snowflake-drop-undrop-design.md
+++ b/docs/superpowers/specs/2026-04-14-snowflake-drop-undrop-design.md
@@ -1,0 +1,151 @@
+# Spec: T2.5 Snowflake DROP / UNDROP DDL
+
+## Scope
+
+Implement DROP and UNDROP statement parsing for Snowflake SQL.
+Does NOT include DATABASE or SCHEMA (those belong to T2.1).
+
+## Object types covered
+
+### DROP (with IF EXISTS and CASCADE/RESTRICT where applicable)
+
+| Object type         | IF EXISTS | CASCADE/RESTRICT | Notes                         |
+|---------------------|-----------|------------------|-------------------------------|
+| TABLE               | yes       | yes              | Core target                   |
+| VIEW                | yes       | no               |                               |
+| MATERIALIZED VIEW   | yes       | no               |                               |
+| DYNAMIC TABLE       | no        | no               | No IF EXISTS in legacy grammar|
+| EXTERNAL TABLE      | yes       | yes              |                               |
+| STREAM              | yes       | no               |                               |
+| TASK                | yes       | no               |                               |
+| SEQUENCE            | yes       | yes              |                               |
+| STAGE               | yes       | no               |                               |
+| FILE FORMAT         | yes       | no               | Two-keyword object type       |
+| FUNCTION            | yes       | no               | No arg_types parsing (stub)   |
+| PROCEDURE           | yes       | no               | No arg_types parsing (stub)   |
+| PIPE                | yes       | no               |                               |
+| TAG                 | yes       | no               |                               |
+| ROLE                | yes       | no               |                               |
+| WAREHOUSE           | yes       | no               |                               |
+
+For object types not in this list, the parser emits a targeted error:
+"DROP <X> statement parsing is not yet supported" and skips to the next
+statement boundary rather than a generic "DROP not supported" error.
+
+### UNDROP
+
+| Object type   | Notes                     |
+|---------------|---------------------------|
+| TABLE         | Core target               |
+| DYNAMIC TABLE | UNDROP DYNAMIC TABLE name |
+| TAG           | UNDROP TAG name           |
+
+DATABASE and SCHEMA UNDROP are excluded (T2.1 territory).
+
+## AST design
+
+### Unified DropStmt
+
+Use a single `DropStmt` type with an `ObjectKind` enum. This is cleaner
+than per-object-type structs because DROP forms are structurally near-identical.
+
+```go
+type DropObjectKind int
+
+const (
+    DropTable DropObjectKind = iota
+    DropView
+    DropMaterializedView
+    DropDynamicTable
+    DropExternalTable
+    DropStream
+    DropTask
+    DropSequence
+    DropStage
+    DropFileFormat
+    DropFunction
+    DropProcedure
+    DropPipe
+    DropTag
+    DropRole
+    DropWarehouse
+)
+
+type DropStmt struct {
+    Kind     DropObjectKind
+    IfExists bool
+    Name     *ObjectName
+    Cascade  bool // CASCADE (mutually exclusive with Restrict)
+    Restrict bool // RESTRICT (mutually exclusive with Cascade)
+    Loc      Loc
+}
+```
+
+### UndropStmt
+
+```go
+type UndropObjectKind int
+
+const (
+    UndropTable UndropObjectKind = iota
+    UndropDynamicTable
+    UndropTag
+)
+
+type UndropStmt struct {
+    Kind UndropObjectKind
+    Name *ObjectName
+    Loc  Loc
+}
+```
+
+### Node tags
+
+Add `T_DropStmt` and `T_UndropStmt` to `nodetags.go`.
+
+## Parser dispatch design
+
+```
+parseDropStmt()
+  advance() // consume DROP
+  switch cur:
+    TABLE          → parseDropObject(DropTable, ifExistsOK=true, cascadeOK=true)
+    VIEW           → parseDropObject(DropView, ifExistsOK=true, cascadeOK=false)
+    MATERIALIZED VIEW → parseDropObject(DropMaterializedView, ...)
+    DYNAMIC TABLE  → parseDropObject(DropDynamicTable, ifExistsOK=false, ...)
+    EXTERNAL TABLE → parseDropObject(DropExternalTable, ifExistsOK=true, cascadeOK=true)
+    STREAM         → parseDropObject(DropStream, ifExistsOK=true, ...)
+    TASK           → parseDropObject(DropTask, ifExistsOK=true, ...)
+    SEQUENCE       → parseDropObject(DropSequence, ifExistsOK=true, cascadeOK=true)
+    STAGE          → parseDropObject(DropStage, ifExistsOK=true, ...)
+    FILE FORMAT    → parseDropObject(DropFileFormat, ifExistsOK=true, ...)
+    FUNCTION       → parseDropObject(DropFunction, ifExistsOK=true, ...)
+    PROCEDURE      → parseDropObject(DropProcedure, ifExistsOK=true, ...)
+    PIPE           → parseDropObject(DropPipe, ifExistsOK=true, ...)
+    TAG            → parseDropObject(DropTag, ifExistsOK=true, ...)
+    ROLE           → parseDropObject(DropRole, ifExistsOK=true, ...)
+    WAREHOUSE      → parseDropObject(DropWarehouse, ifExistsOK=true, ...)
+    default        → targeted unsupported error
+```
+
+`parseDropObject(kind, ifExistsOK, cascadeOK)` is a shared helper that:
+1. Optionally consumes IF EXISTS (if ifExistsOK and next token matches)
+2. Parses the object name
+3. Optionally consumes CASCADE or RESTRICT (if cascadeOK)
+4. Returns *DropStmt
+
+`parseUndropStmt()` mirrors the same pattern.
+
+## Test coverage
+
+- DROP TABLE [IF EXISTS] name [CASCADE|RESTRICT]
+- DROP VIEW, DROP STREAM, DROP TASK, DROP SEQUENCE, DROP STAGE
+- DROP FILE FORMAT (two-word object type)
+- DROP MATERIALIZED VIEW (two-word object type)
+- DROP DYNAMIC TABLE (two-word object type)
+- DROP EXTERNAL TABLE (two-word, with CASCADE)
+- DROP FUNCTION, DROP PROCEDURE, DROP PIPE, DROP TAG, DROP ROLE, DROP WAREHOUSE
+- UNDROP TABLE, UNDROP DYNAMIC TABLE, UNDROP TAG
+- Unknown object types produce targeted error (DROP SCHEMA → unsupported)
+- Qualified names (schema.table, db.schema.table)
+- Loc tracking

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -61,6 +61,8 @@ const (
 	T_AlterSchemaStmt
 	T_DropSchemaStmt
 	T_UndropSchemaStmt
+	T_DropStmt
+	T_UndropStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -146,6 +148,10 @@ func (t NodeTag) String() string {
 		return "DropSchemaStmt"
 	case T_UndropSchemaStmt:
 		return "UndropSchemaStmt"
+	case T_DropStmt:
+		return "DropStmt"
+	case T_UndropStmt:
+		return "UndropStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1171,3 +1171,126 @@ type UndropSchemaStmt struct {
 func (n *UndropSchemaStmt) Tag() NodeTag { return T_UndropSchemaStmt }
 
 var _ Node = (*UndropSchemaStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// DROP / UNDROP statement nodes (non-DATABASE/SCHEMA object types)
+// ---------------------------------------------------------------------------
+
+// DropObjectKind enumerates the object types that can appear in a DROP
+// statement handled by this parser. DATABASE and SCHEMA are handled by T2.1.
+type DropObjectKind int
+
+const (
+	DropTable            DropObjectKind = iota
+	DropView                            // DROP VIEW
+	DropMaterializedView                // DROP MATERIALIZED VIEW
+	DropDynamicTable                    // DROP DYNAMIC TABLE
+	DropExternalTable                   // DROP EXTERNAL TABLE
+	DropStream                          // DROP STREAM
+	DropTask                            // DROP TASK
+	DropSequence                        // DROP SEQUENCE
+	DropStage                           // DROP STAGE
+	DropFileFormat                      // DROP FILE FORMAT
+	DropFunction                        // DROP FUNCTION
+	DropProcedure                       // DROP PROCEDURE
+	DropPipe                            // DROP PIPE
+	DropTag                             // DROP TAG
+	DropRole                            // DROP ROLE
+	DropWarehouse                       // DROP WAREHOUSE
+)
+
+// String returns the SQL object-type keyword for the kind.
+func (k DropObjectKind) String() string {
+	switch k {
+	case DropTable:
+		return "TABLE"
+	case DropView:
+		return "VIEW"
+	case DropMaterializedView:
+		return "MATERIALIZED VIEW"
+	case DropDynamicTable:
+		return "DYNAMIC TABLE"
+	case DropExternalTable:
+		return "EXTERNAL TABLE"
+	case DropStream:
+		return "STREAM"
+	case DropTask:
+		return "TASK"
+	case DropSequence:
+		return "SEQUENCE"
+	case DropStage:
+		return "STAGE"
+	case DropFileFormat:
+		return "FILE FORMAT"
+	case DropFunction:
+		return "FUNCTION"
+	case DropProcedure:
+		return "PROCEDURE"
+	case DropPipe:
+		return "PIPE"
+	case DropTag:
+		return "TAG"
+	case DropRole:
+		return "ROLE"
+	case DropWarehouse:
+		return "WAREHOUSE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// DropStmt represents a DROP <object_type> [IF EXISTS] name [CASCADE|RESTRICT]
+// statement. DATABASE and SCHEMA are handled by T2.1's DropDatabaseStmt /
+// DropSchemaStmt and are NOT covered by this type.
+type DropStmt struct {
+	Kind     DropObjectKind
+	IfExists bool
+	Name     *ObjectName
+	Cascade  bool // CASCADE option (mutually exclusive with Restrict)
+	Restrict bool // RESTRICT option (mutually exclusive with Cascade)
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *DropStmt) Tag() NodeTag { return T_DropStmt }
+
+// UndropObjectKind enumerates the object types that can appear in an UNDROP
+// statement. DATABASE and SCHEMA are handled by T2.1.
+type UndropObjectKind int
+
+const (
+	UndropTable        UndropObjectKind = iota
+	UndropDynamicTable                  // UNDROP DYNAMIC TABLE
+	UndropTag                           // UNDROP TAG
+)
+
+// String returns the SQL object-type keyword for the kind.
+func (k UndropObjectKind) String() string {
+	switch k {
+	case UndropTable:
+		return "TABLE"
+	case UndropDynamicTable:
+		return "DYNAMIC TABLE"
+	case UndropTag:
+		return "TAG"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// UndropStmt represents an UNDROP <object_type> name statement.
+// DATABASE and SCHEMA are handled by T2.1.
+type UndropStmt struct {
+	Kind UndropObjectKind
+	Name *ObjectName
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *UndropStmt) Tag() NodeTag { return T_UndropStmt }
+
+// Compile-time assertions.
+var (
+	_ Node = (*DropStmt)(nil)
+	_ Node = (*UndropStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -76,6 +76,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *DropStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *ExistsExpr:
 		Walk(v, n.Query)
 	case *File:
@@ -142,6 +146,10 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Name)
 		}
 	case *UndropSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *UndropStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -477,18 +477,7 @@ func (p *Parser) parseAlterSchemaStmt() (ast.Node, error) {
 // ---------------------------------------------------------------------------
 
 // parseDropStmt dispatches DROP ... to the appropriate sub-parser.
-func (p *Parser) parseDropStmt() (ast.Node, error) {
-	p.advance() // consume DROP
-
-	switch p.cur.Type {
-	case kwDATABASE:
-		return p.parseDropDatabaseStmt()
-	case kwSCHEMA:
-		return p.parseDropSchemaStmt()
-	default:
-		return p.unsupported("DROP")
-	}
-}
+// (parseDropStmt lives in drop.go; it dispatches DATABASE/SCHEMA here.)
 
 // ---------------------------------------------------------------------------
 // DROP DATABASE
@@ -574,19 +563,7 @@ func (p *Parser) parseDropSchemaStmt() (ast.Node, error) {
 // UNDROP dispatch
 // ---------------------------------------------------------------------------
 
-// parseUndropStmt dispatches UNDROP ... to the appropriate sub-parser.
-func (p *Parser) parseUndropStmt() (ast.Node, error) {
-	p.advance() // consume UNDROP
-
-	switch p.cur.Type {
-	case kwDATABASE:
-		return p.parseUndropDatabaseStmt()
-	case kwSCHEMA:
-		return p.parseUndropSchemaStmt()
-	default:
-		return p.unsupported("UNDROP")
-	}
-}
+// (parseUndropStmt lives in drop.go; it dispatches DATABASE/SCHEMA here.)
 
 // ---------------------------------------------------------------------------
 // UNDROP DATABASE

--- a/snowflake/parser/drop.go
+++ b/snowflake/parser/drop.go
@@ -13,6 +13,14 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 	start := dropTok.Loc
 
 	switch p.cur.Type {
+	case kwDATABASE:
+		// DATABASE handled by T2.1; parseDropDatabaseStmt consumes DATABASE.
+		return p.parseDropDatabaseStmt()
+
+	case kwSCHEMA:
+		// SCHEMA handled by T2.1; parseDropSchemaStmt consumes SCHEMA.
+		return p.parseDropSchemaStmt()
+
 	case kwTABLE:
 		p.advance() // consume TABLE
 		return p.parseDropObject(ast.DropTable, start, true, true)
@@ -170,6 +178,14 @@ func (p *Parser) parseUndropStmt() (ast.Node, error) {
 	start := undropTok.Loc
 
 	switch p.cur.Type {
+	case kwDATABASE:
+		// DATABASE handled by T2.1; parseUndropDatabaseStmt consumes DATABASE.
+		return p.parseUndropDatabaseStmt()
+
+	case kwSCHEMA:
+		// SCHEMA handled by T2.1; parseUndropSchemaStmt consumes SCHEMA.
+		return p.parseUndropSchemaStmt()
+
 	case kwTABLE:
 		p.advance() // consume TABLE
 		return p.parseUndropObject(ast.UndropTable, start)

--- a/snowflake/parser/drop.go
+++ b/snowflake/parser/drop.go
@@ -1,0 +1,218 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// DROP statement dispatch
+// ---------------------------------------------------------------------------
+
+// parseDropStmt parses DROP <object_type> [IF EXISTS] name [CASCADE|RESTRICT].
+// The DROP keyword has NOT yet been consumed when this function is called.
+func (p *Parser) parseDropStmt() (ast.Node, error) {
+	dropTok := p.advance() // consume DROP
+	start := dropTok.Loc
+
+	switch p.cur.Type {
+	case kwTABLE:
+		p.advance() // consume TABLE
+		return p.parseDropObject(ast.DropTable, start, true, true)
+
+	case kwVIEW:
+		p.advance() // consume VIEW
+		return p.parseDropObject(ast.DropView, start, true, false)
+
+	case kwMATERIALIZED:
+		// MATERIALIZED VIEW
+		p.advance() // consume MATERIALIZED
+		if _, err := p.expect(kwVIEW); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropMaterializedView, start, true, false)
+
+	case kwDYNAMIC:
+		// DYNAMIC TABLE — no IF EXISTS in legacy grammar
+		p.advance() // consume DYNAMIC
+		if _, err := p.expect(kwTABLE); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropDynamicTable, start, false, false)
+
+	case kwEXTERNAL:
+		// EXTERNAL TABLE
+		p.advance() // consume EXTERNAL
+		if _, err := p.expect(kwTABLE); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropExternalTable, start, true, true)
+
+	case kwSTREAM:
+		p.advance() // consume STREAM
+		return p.parseDropObject(ast.DropStream, start, true, false)
+
+	case kwTASK:
+		p.advance() // consume TASK
+		return p.parseDropObject(ast.DropTask, start, true, false)
+
+	case kwSEQUENCE:
+		p.advance() // consume SEQUENCE
+		return p.parseDropObject(ast.DropSequence, start, true, true)
+
+	case kwSTAGE:
+		p.advance() // consume STAGE
+		return p.parseDropObject(ast.DropStage, start, true, false)
+
+	case kwFILE_FORMAT:
+		p.advance() // consume FILE_FORMAT (single keyword token)
+		return p.parseDropObject(ast.DropFileFormat, start, true, false)
+
+	case kwFILE:
+		// FILE FORMAT — two-word form using separate FILE and FORMAT tokens
+		p.advance() // consume FILE
+		if _, err := p.expect(kwFORMAT); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropFileFormat, start, true, false)
+
+	case kwFUNCTION:
+		p.advance() // consume FUNCTION
+		return p.parseDropObject(ast.DropFunction, start, true, false)
+
+	case kwPROCEDURE:
+		p.advance() // consume PROCEDURE
+		return p.parseDropObject(ast.DropProcedure, start, true, false)
+
+	case kwPIPE:
+		p.advance() // consume PIPE
+		return p.parseDropObject(ast.DropPipe, start, true, false)
+
+	case kwTAG:
+		p.advance() // consume TAG
+		return p.parseDropObject(ast.DropTag, start, true, false)
+
+	case kwROLE:
+		p.advance() // consume ROLE
+		return p.parseDropObject(ast.DropRole, start, true, false)
+
+	case kwWAREHOUSE:
+		p.advance() // consume WAREHOUSE
+		return p.parseDropObject(ast.DropWarehouse, start, true, false)
+
+	default:
+		// Emit a targeted error for recognized-but-unimplemented DROP forms,
+		// or a generic error for completely unknown object types.
+		objText := p.cur.Str
+		if objText == "" {
+			objText = TokenName(p.cur.Type)
+		}
+		err := &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "DROP " + objText + " statement parsing is not yet supported",
+		}
+		p.skipToNextStatement()
+		return nil, err
+	}
+}
+
+// parseDropObject is the shared helper that parses the [IF EXISTS] name
+// [CASCADE|RESTRICT] tail common to most DROP forms.
+//
+// kind is the already-determined DropObjectKind.
+// start is the Loc of the DROP token.
+// ifExistsOK controls whether IF EXISTS is accepted.
+// cascadeOK controls whether CASCADE/RESTRICT are accepted.
+func (p *Parser) parseDropObject(kind ast.DropObjectKind, start ast.Loc, ifExistsOK, cascadeOK bool) (ast.Node, error) {
+	stmt := &ast.DropStmt{
+		Kind: kind,
+		Loc:  ast.Loc{Start: start.Start},
+	}
+
+	// Optional IF EXISTS
+	if ifExistsOK && p.cur.Type == kwIF {
+		next := p.peekNext()
+		if next.Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Object name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional CASCADE | RESTRICT
+	if cascadeOK {
+		switch p.cur.Type {
+		case kwCASCADE:
+			p.advance()
+			stmt.Cascade = true
+		case kwRESTRICT:
+			p.advance()
+			stmt.Restrict = true
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP statement dispatch
+// ---------------------------------------------------------------------------
+
+// parseUndropStmt parses UNDROP <object_type> name.
+// The UNDROP keyword has NOT yet been consumed when this function is called.
+func (p *Parser) parseUndropStmt() (ast.Node, error) {
+	undropTok := p.advance() // consume UNDROP
+	start := undropTok.Loc
+
+	switch p.cur.Type {
+	case kwTABLE:
+		p.advance() // consume TABLE
+		return p.parseUndropObject(ast.UndropTable, start)
+
+	case kwDYNAMIC:
+		// UNDROP DYNAMIC TABLE
+		p.advance() // consume DYNAMIC
+		if _, err := p.expect(kwTABLE); err != nil {
+			return nil, err
+		}
+		return p.parseUndropObject(ast.UndropDynamicTable, start)
+
+	case kwTAG:
+		p.advance() // consume TAG
+		return p.parseUndropObject(ast.UndropTag, start)
+
+	default:
+		objText := p.cur.Str
+		if objText == "" {
+			objText = TokenName(p.cur.Type)
+		}
+		err := &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "UNDROP " + objText + " statement parsing is not yet supported",
+		}
+		p.skipToNextStatement()
+		return nil, err
+	}
+}
+
+// parseUndropObject parses the name following the UNDROP <type> keywords.
+func (p *Parser) parseUndropObject(kind ast.UndropObjectKind, start ast.Loc) (ast.Node, error) {
+	stmt := &ast.UndropStmt{
+		Kind: kind,
+		Loc:  ast.Loc{Start: start.Start},
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/snowflake/parser/drop_test.go
+++ b/snowflake/parser/drop_test.go
@@ -494,12 +494,11 @@ func TestDropWarehouse_IfExists(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDropUnsupported_TargetedError(t *testing.T) {
-	// DROP DATABASE is handled by T2.1 and is NOT in our dispatch — it should
-	// produce a targeted "DROP DATABASE ... not yet supported" error rather than
+	// DROP <unrecognized object> should produce a targeted error rather than
 	// a generic "DROP not supported" error.
-	result := ParseBestEffort("DROP DATABASE db1")
+	result := ParseBestEffort("DROP NETWORK POLICY foo")
 	if len(result.Errors) == 0 {
-		t.Fatal("expected an error for DROP DATABASE, got none")
+		t.Fatal("expected an error for DROP NETWORK POLICY, got none")
 	}
 	msg := result.Errors[0].Msg
 	if msg == "DROP statement parsing is not yet supported" {
@@ -573,9 +572,9 @@ func TestUndropTag_Basic(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUndropUnsupported_TargetedError(t *testing.T) {
-	result := ParseBestEffort("UNDROP SCHEMA myschema")
+	result := ParseBestEffort("UNDROP STREAM mystream")
 	if len(result.Errors) == 0 {
-		t.Fatal("expected an error for UNDROP SCHEMA, got none")
+		t.Fatal("expected an error for UNDROP STREAM, got none")
 	}
 	msg := result.Errors[0].Msg
 	if msg == "UNDROP statement parsing is not yet supported" {

--- a/snowflake/parser/drop_test.go
+++ b/snowflake/parser/drop_test.go
@@ -1,0 +1,640 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func testParseDropStmt(input string) (*ast.DropStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.DropStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a DropStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseUndropStmt(input string) (*ast.UndropStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.UndropStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not an UndropStmt"})
+	}
+	return stmt, result.Errors
+}
+
+// ---------------------------------------------------------------------------
+// DROP TABLE tests
+// ---------------------------------------------------------------------------
+
+func TestDropTable_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropTable {
+		t.Errorf("kind = %v, want DropTable", stmt.Kind)
+	}
+	if stmt.IfExists {
+		t.Error("expected IfExists=false")
+	}
+	if stmt.Name.Normalize() != "T" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "T")
+	}
+	if stmt.Cascade || stmt.Restrict {
+		t.Error("expected Cascade=false Restrict=false")
+	}
+}
+
+func TestDropTable_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE IF EXISTS my_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+	if stmt.Name.Normalize() != "MY_TABLE" {
+		t.Errorf("name = %q, want MY_TABLE", stmt.Name.Normalize())
+	}
+}
+
+func TestDropTable_Cascade(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE t CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+	if stmt.Restrict {
+		t.Error("expected Restrict=false")
+	}
+}
+
+func TestDropTable_Restrict(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE t RESTRICT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Restrict {
+		t.Error("expected Restrict=true")
+	}
+	if stmt.Cascade {
+		t.Error("expected Cascade=false")
+	}
+}
+
+func TestDropTable_IfExistsCascade(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE IF EXISTS s.t CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+	if stmt.Name.Normalize() != "S.T" {
+		t.Errorf("name = %q, want S.T", stmt.Name.Normalize())
+	}
+}
+
+func TestDropTable_QualifiedThreePart(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE mydb.myschema.mytable")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA.MYTABLE" {
+		t.Errorf("name = %q, want MYDB.MYSCHEMA.MYTABLE", stmt.Name.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP VIEW
+// ---------------------------------------------------------------------------
+
+func TestDropView_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP VIEW v1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropView {
+		t.Errorf("kind = %v, want DropView", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "V1" {
+		t.Errorf("name = %q, want V1", stmt.Name.Normalize())
+	}
+}
+
+func TestDropView_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP VIEW IF EXISTS v1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// CASCADE/RESTRICT not accepted for VIEW — should parse fine and be ignored
+func TestDropView_NoCascade(t *testing.T) {
+	// Only the name should be consumed; CASCADE is not part of DROP VIEW
+	stmt, errs := testParseDropStmt("DROP VIEW v1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Cascade {
+		t.Error("Cascade should be false for DROP VIEW")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+func TestDropMaterializedView_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP MATERIALIZED VIEW mv1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropMaterializedView {
+		t.Errorf("kind = %v, want DropMaterializedView", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "MV1" {
+		t.Errorf("name = %q, want MV1", stmt.Name.Normalize())
+	}
+}
+
+func TestDropMaterializedView_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP MATERIALIZED VIEW IF EXISTS mv1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP DYNAMIC TABLE
+// ---------------------------------------------------------------------------
+
+func TestDropDynamicTable_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP DYNAMIC TABLE dt1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropDynamicTable {
+		t.Errorf("kind = %v, want DropDynamicTable", stmt.Kind)
+	}
+	if stmt.IfExists {
+		t.Error("IfExists should be false for DYNAMIC TABLE (not supported in grammar)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP EXTERNAL TABLE
+// ---------------------------------------------------------------------------
+
+func TestDropExternalTable_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP EXTERNAL TABLE et1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropExternalTable {
+		t.Errorf("kind = %v, want DropExternalTable", stmt.Kind)
+	}
+}
+
+func TestDropExternalTable_IfExistsCascade(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP EXTERNAL TABLE IF EXISTS et1 CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP STREAM
+// ---------------------------------------------------------------------------
+
+func TestDropStream_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP STREAM s1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropStream {
+		t.Errorf("kind = %v, want DropStream", stmt.Kind)
+	}
+}
+
+func TestDropStream_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP STREAM IF EXISTS s1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP TASK
+// ---------------------------------------------------------------------------
+
+func TestDropTask_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TASK t1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropTask {
+		t.Errorf("kind = %v, want DropTask", stmt.Kind)
+	}
+}
+
+func TestDropTask_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TASK IF EXISTS my_task")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP SEQUENCE
+// ---------------------------------------------------------------------------
+
+func TestDropSequence_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP SEQUENCE seq1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropSequence {
+		t.Errorf("kind = %v, want DropSequence", stmt.Kind)
+	}
+}
+
+func TestDropSequence_IfExistsCascade(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP SEQUENCE IF EXISTS seq1 CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP STAGE
+// ---------------------------------------------------------------------------
+
+func TestDropStage_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP STAGE my_stage")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropStage {
+		t.Errorf("kind = %v, want DropStage", stmt.Kind)
+	}
+}
+
+func TestDropStage_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP STAGE IF EXISTS my_stage")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP FILE FORMAT
+// ---------------------------------------------------------------------------
+
+func TestDropFileFormat_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP FILE FORMAT ff1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropFileFormat {
+		t.Errorf("kind = %v, want DropFileFormat", stmt.Kind)
+	}
+}
+
+func TestDropFileFormat_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP FILE FORMAT IF EXISTS ff1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP FUNCTION
+// ---------------------------------------------------------------------------
+
+func TestDropFunction_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP FUNCTION f1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropFunction {
+		t.Errorf("kind = %v, want DropFunction", stmt.Kind)
+	}
+}
+
+func TestDropFunction_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP FUNCTION IF EXISTS f1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP PROCEDURE
+// ---------------------------------------------------------------------------
+
+func TestDropProcedure_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP PROCEDURE p1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropProcedure {
+		t.Errorf("kind = %v, want DropProcedure", stmt.Kind)
+	}
+}
+
+func TestDropProcedure_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP PROCEDURE IF EXISTS p1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP PIPE
+// ---------------------------------------------------------------------------
+
+func TestDropPipe_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP PIPE pipe1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropPipe {
+		t.Errorf("kind = %v, want DropPipe", stmt.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP TAG
+// ---------------------------------------------------------------------------
+
+func TestDropTag_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TAG tag1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropTag {
+		t.Errorf("kind = %v, want DropTag", stmt.Kind)
+	}
+}
+
+func TestDropTag_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TAG IF EXISTS tag1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP ROLE
+// ---------------------------------------------------------------------------
+
+func TestDropRole_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP ROLE r1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropRole {
+		t.Errorf("kind = %v, want DropRole", stmt.Kind)
+	}
+}
+
+func TestDropRole_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP ROLE IF EXISTS r1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP WAREHOUSE
+// ---------------------------------------------------------------------------
+
+func TestDropWarehouse_Basic(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP WAREHOUSE wh1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropWarehouse {
+		t.Errorf("kind = %v, want DropWarehouse", stmt.Kind)
+	}
+}
+
+func TestDropWarehouse_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP WAREHOUSE IF EXISTS wh1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported DROP object types — targeted error, not generic
+// ---------------------------------------------------------------------------
+
+func TestDropUnsupported_TargetedError(t *testing.T) {
+	// DROP DATABASE is handled by T2.1 and is NOT in our dispatch — it should
+	// produce a targeted "DROP DATABASE ... not yet supported" error rather than
+	// a generic "DROP not supported" error.
+	result := ParseBestEffort("DROP DATABASE db1")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected an error for DROP DATABASE, got none")
+	}
+	msg := result.Errors[0].Msg
+	if msg == "DROP statement parsing is not yet supported" {
+		t.Errorf("got generic DROP error; want targeted error, got: %q", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP TABLE tests
+// ---------------------------------------------------------------------------
+
+func TestUndropTable_Basic(t *testing.T) {
+	stmt, errs := testParseUndropStmt("UNDROP TABLE t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.UndropTable {
+		t.Errorf("kind = %v, want UndropTable", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "T" {
+		t.Errorf("name = %q, want T", stmt.Name.Normalize())
+	}
+}
+
+func TestUndropTable_QualifiedName(t *testing.T) {
+	stmt, errs := testParseUndropStmt("UNDROP TABLE myschema.mytable")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Name.Normalize() != "MYSCHEMA.MYTABLE" {
+		t.Errorf("name = %q, want MYSCHEMA.MYTABLE", stmt.Name.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP DYNAMIC TABLE
+// ---------------------------------------------------------------------------
+
+func TestUndropDynamicTable_Basic(t *testing.T) {
+	stmt, errs := testParseUndropStmt("UNDROP DYNAMIC TABLE dt1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.UndropDynamicTable {
+		t.Errorf("kind = %v, want UndropDynamicTable", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "DT1" {
+		t.Errorf("name = %q, want DT1", stmt.Name.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP TAG
+// ---------------------------------------------------------------------------
+
+func TestUndropTag_Basic(t *testing.T) {
+	stmt, errs := testParseUndropStmt("UNDROP TAG tag1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.UndropTag {
+		t.Errorf("kind = %v, want UndropTag", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "TAG1" {
+		t.Errorf("name = %q, want TAG1", stmt.Name.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP unsupported — targeted error
+// ---------------------------------------------------------------------------
+
+func TestUndropUnsupported_TargetedError(t *testing.T) {
+	result := ParseBestEffort("UNDROP SCHEMA myschema")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected an error for UNDROP SCHEMA, got none")
+	}
+	msg := result.Errors[0].Msg
+	if msg == "UNDROP statement parsing is not yet supported" {
+		t.Errorf("got generic UNDROP error; want targeted error, got: %q", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc tracking
+// ---------------------------------------------------------------------------
+
+func TestDropTable_LocTracking(t *testing.T) {
+	input := "DROP TABLE t"
+	stmt, errs := testParseDropStmt(input)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}
+
+func TestUndropTable_LocTracking(t *testing.T) {
+	input := "UNDROP TABLE t"
+	stmt, errs := testParseUndropStmt(input)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NodeTag
+// ---------------------------------------------------------------------------
+
+func TestDropStmt_Tag(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP TABLE t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Tag().String() != "DropStmt" {
+		t.Errorf("Tag = %q, want DropStmt", stmt.Tag().String())
+	}
+}
+
+func TestUndropStmt_Tag(t *testing.T) {
+	stmt, errs := testParseUndropStmt("UNDROP TABLE t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Tag().String() != "UndropStmt" {
+		t.Errorf("Tag = %q, want UndropStmt", stmt.Tag().String())
+	}
+}


### PR DESCRIPTION
## Summary

- Implements T2.5: DROP and UNDROP statement parsing for the Snowflake SQL parser migration
- Adds unified `DropStmt` AST node (16 object kinds) and `UndropStmt` AST node (3 object kinds)
- Replaces generic `unsupported("DROP")` / `unsupported("UNDROP")` stubs with targeted dispatch
- Unknown object types now emit targeted errors ("DROP X not yet supported") instead of a generic stub

## Object types covered

**DROP** (all support IF EXISTS where applicable; TABLE/EXTERNAL TABLE/SEQUENCE accept CASCADE/RESTRICT):
TABLE, VIEW, MATERIALIZED VIEW, DYNAMIC TABLE, EXTERNAL TABLE, STREAM, TASK, SEQUENCE, STAGE, FILE FORMAT, FUNCTION, PROCEDURE, PIPE, TAG, ROLE, WAREHOUSE

**UNDROP**: TABLE, DYNAMIC TABLE, TAG

DATABASE and SCHEMA are excluded — handled by T2.1 in the parallel worktree.

## Design decisions

- Unified `DropStmt` with `DropObjectKind` enum rather than per-type structs — DROP forms are structurally near-identical so a single type avoids ~16 boilerplate structs.
- `FILE FORMAT` handles both the single-token `kwFILE_FORMAT` and the two-token `kwFILE` / `kwFORMAT` sequence, matching how the lexer may emit either form.
- FUNCTION and PROCEDURE skip `arg_types` parsing (not implemented, follows legacy grammar's `object_name arg_types` but we only parse the name for now).

## Test plan

- [x] `go test ./snowflake/... -count=1` — all tests pass (both `snowflake/ast` and `snowflake/parser`)
- [x] `gofmt -w snowflake/` — no formatting changes needed
- [x] 40+ test cases: basic forms, IF EXISTS, CASCADE/RESTRICT, qualified names (2-part, 3-part), Loc tracking, NodeTag verification, targeted error for unsupported types

🤖 Generated with [Claude Code](https://claude.com/claude-code)