### PR TITLE
feat(snowflake): T2.6 advisor dispatcher framework

### DIFF
--- a/docs/superpowers/plans/2026-04-14-snowflake-advisor-dispatcher.md
+++ b/docs/superpowers/plans/2026-04-14-snowflake-advisor-dispatcher.md
@@ -1,0 +1,63 @@
+# Snowflake Advisor Dispatcher — Implementation Plan (T2.6)
+
+Date: 2026-04-14
+Status: In progress
+
+---
+
+## Steps
+
+### Step 1 — Core types (advisor.go + rule.go)
+
+Files: `snowflake/advisor/advisor.go`, `snowflake/advisor/rule.go`
+
+- Define `Severity` (int, ERROR/WARNING/INFO constants + String())
+- Define `Finding` struct (RuleID, Severity, Loc, Message)
+- Define `Context` struct (SQL string)
+- Define `Rule` interface (ID, Severity, Check)
+- Define `Advisor` struct with per-run state
+- Implement `New(rules ...Rule) *Advisor`
+- Implement `Advisor.Check(ctx *Context, root ast.Node) []*Finding`
+- Implement `Advisor` as `ast.Visitor` (Visit method)
+
+### Step 2 — Example rule (example_rule.go)
+
+File: `snowflake/advisor/example_rule.go`
+
+- Implement `NoSelectStarRule` (Rule interface)
+- ID: `"snowflake.select.no-select-star"`
+- Severity: WARNING
+- Check: match `*ast.SelectTarget` with Star==true, Qualifier==nil
+
+### Step 3 — Tests (advisor_test.go)
+
+File: `snowflake/advisor/advisor_test.go`
+
+- Test: empty rules, empty AST → no findings
+- Test: counting rule is called once per node
+- Test: NoSelectStar fires on `SELECT *`
+- Test: NoSelectStar does NOT fire on `SELECT a, b`
+- Test: NoSelectStar fires on `SELECT t.*` (qualified star — rule should NOT flag)
+- Test: location accuracy — Loc.Start/End bracket the * token
+- Test: severity on finding matches rule's Severity()
+
+### Step 4 — Run tests + fmt
+
+```
+cd /Users/h3n4l/OpenSource/omni/.worktrees/snowflake-advisor
+go test ./snowflake/advisor/... ./snowflake/... -count=1
+gofmt -w snowflake/
+```
+
+### Step 5 — Commit + push + PR
+
+Commit message: `feat(snowflake): T2.6 advisor dispatcher framework`
+
+---
+
+## Dependency tree
+
+- advisor.go depends on snowflake/ast (Loc, Node, Walk)
+- rule.go depends on advisor.go (Context, Finding, Severity)
+- example_rule.go depends on snowflake/ast (SelectTarget, StarExpr) and advisor.go
+- advisor_test.go depends on all of the above + snowflake/parser (Parse)

--- a/docs/superpowers/specs/2026-04-14-snowflake-advisor-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-04-14-snowflake-advisor-dispatcher-design.md
@@ -1,0 +1,181 @@
+# Snowflake Advisor Dispatcher — Design Spec (T2.6)
+
+Date: 2026-04-14
+Author: Claude (agent)
+Status: Accepted
+
+---
+
+## Context
+
+T2.7 will implement 14 lint rules for Snowflake SQL. Before those rules can land, we need
+the framework that runs rules against a parsed AST and collects findings. This is T2.6.
+
+The omni repo has no existing advisor framework for any engine — this is the first one. We
+design it to be reusable but keep the scope narrow (YAGNI): just enough that T2.7 can add
+14 rules by implementing one interface each.
+
+---
+
+## Goals
+
+1. A `Rule` interface that rules implement (ID, Severity, Check).
+2. A per-instance `Advisor` that holds a rule set and runs them over an AST.
+3. A `Context` struct that rules can inspect (source text, config knobs — minimal for now).
+4. A `Finding` value type (rule ID, severity, location, message).
+5. A `Severity` type with ERROR / WARNING / INFO constants matching bytebase conventions.
+6. A stub example rule (`NoSelectStar`) to prove the wiring works.
+7. Tests: registration, invocation, finding collection, location accuracy.
+
+---
+
+## Non-Goals
+
+- No global registry (per-instance is more testable; global can be added later).
+- No rule config / payload beyond what Rule.Check receives in Context.
+- No database schema / catalog in Context (T2.7 rules don't need it yet).
+- The 14 T2.7 rules themselves.
+
+---
+
+## Package layout
+
+```
+snowflake/advisor/
+  advisor.go         — Advisor, Context, Finding, Severity
+  rule.go            — Rule interface
+  example_rule.go    — NoSelectStar (trivial example rule)
+  advisor_test.go    — framework tests + example rule tests
+```
+
+---
+
+## Key types
+
+### Severity
+
+```go
+type Severity int
+
+const (
+    SeverityInfo    Severity = iota
+    SeverityWarning
+    SeverityError
+)
+```
+
+Matches bytebase's INFO / WARNING / ERROR ordering (lower = less severe).
+
+### Finding
+
+```go
+type Finding struct {
+    RuleID   string
+    Severity Severity
+    Loc      ast.Loc
+    Message  string
+}
+```
+
+`Loc` carries the byte range from the AST node that triggered the finding. Callers (e.g.
+bytebase) can map byte offsets to line/column using a line table.
+
+### Rule interface
+
+```go
+type Rule interface {
+    // ID returns the canonical rule identifier, e.g. "snowflake.select.no-select-star".
+    ID() string
+
+    // Severity is the default severity for findings emitted by this rule.
+    // Individual findings may carry the same or a different severity if the
+    // rule implementation wishes to vary it.
+    Severity() Severity
+
+    // Check is called for each AST node during a depth-first walk.
+    // It must be non-blocking and side-effect-free outside the returned slice.
+    Check(ctx *Context, node ast.Node) []*Finding
+}
+```
+
+Why a method-per-node approach was rejected: the AST has ~30 node types; storing one
+callback per node type in the registry would add complexity with no gain for 14 rules.
+
+### Context
+
+```go
+type Context struct {
+    // SQL is the original source text. Rules may use it for substring extraction.
+    SQL string
+}
+```
+
+Deliberately minimal. If T2.7 needs catalog data, Context will grow then.
+
+### Advisor
+
+```go
+type Advisor struct {
+    rules []Rule
+}
+
+func New(rules ...Rule) *Advisor
+
+func (a *Advisor) Check(ctx *Context, root ast.Node) []*Finding
+```
+
+`Check` performs a depth-first `ast.Walk` using itself as the `ast.Visitor`. On each
+`Visit(node)` call it fans out to every registered rule and collects their findings.
+
+The `Advisor` implements `ast.Visitor`:
+
+```go
+func (a *Advisor) Visit(node ast.Node) ast.Visitor {
+    if node == nil {
+        return nil  // post-order signal; nothing to do
+    }
+    for _, r := range a.rules {
+        a.findings = append(a.findings, r.Check(a.ctx, node)...)
+    }
+    return a  // continue descent
+}
+```
+
+Note: `findings` is stored on a per-run scratchpad, not on the Advisor struct itself, so
+the Advisor is safe to reuse across calls.
+
+---
+
+## Example rule: NoSelectStar
+
+Rule ID: `"snowflake.select.no-select-star"`
+Severity: WARNING
+Logic: emit a finding when `*SelectTarget` has `Star == true` and `Qualifier == nil`.
+
+This exercises the full pipeline without depending on any real bytebase rule catalog.
+
+---
+
+## Testing strategy
+
+1. Unit test: construct an Advisor with a counting Rule, walk a trivial AST, assert invocation count equals node count.
+2. Integration test: parse a real SELECT * statement, run NoSelectStar rule, assert one WARNING finding with a correct Loc.
+3. Location test: Loc.Start / Loc.End map to the expected source bytes.
+4. Severity filtering test: construct a multi-rule Advisor, verify findings carry the rule's severity.
+5. Empty input test: no stmts → no findings.
+
+---
+
+## Alternatives considered
+
+**Functional rule (CheckFunc instead of interface)**
+Simpler for trivial rules, but forces callers to store ID/severity separately.
+Rejected in favour of the interface which bundles all metadata.
+
+**Global registry (init()-based)**
+Mirrors bytebase's advisor.Register pattern. Not needed for omni's current design where the
+caller explicitly wires rules. Can be layered on top later.
+
+**Node-type callbacks (per-type OnEnter/OnExit)**
+The bytebase legacy pattern (GenericChecker.EnterEveryRule). Useful when rules need both
+enter and exit events. None of the T2.7 rules need exit events; a single Check() is cleaner.

--- a/snowflake/advisor/advisor.go
+++ b/snowflake/advisor/advisor.go
@@ -1,0 +1,115 @@
+// Package advisor implements the lint-rule framework for Snowflake SQL.
+//
+// Usage:
+//
+//	a := advisor.New(myRule1, myRule2)
+//	ctx := &advisor.Context{SQL: sql}
+//	findings := a.Check(ctx, parsedFile)
+//
+// The Advisor walks the AST depth-first and fans out each node to every
+// registered Rule. Findings from all rules are returned in traversal order.
+//
+// See rule.go for the Rule interface, and example_rule.go for a minimal
+// worked example (NoSelectStarRule).
+package advisor
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// Severity classifies how serious a finding is.
+// The numeric ordering is intentional: higher value = more severe.
+type Severity int
+
+const (
+	// SeverityInfo is an informational notice; does not block deployment.
+	SeverityInfo Severity = iota
+	// SeverityWarning flags a practice that should be reviewed.
+	SeverityWarning
+	// SeverityError flags a violation that must be corrected.
+	SeverityError
+)
+
+// String returns the human-readable severity label used in messages and logs.
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "INFO"
+	case SeverityWarning:
+		return "WARNING"
+	case SeverityError:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Finding is a single lint result emitted by a Rule.
+type Finding struct {
+	// RuleID is the canonical identifier of the rule that produced this finding.
+	RuleID string
+	// Severity is the severity of this specific finding.
+	Severity Severity
+	// Loc is the source byte range of the AST node that triggered the finding.
+	// Callers can map Loc.Start/End to line/column using a line table.
+	Loc ast.Loc
+	// Message is a human-readable description of the issue.
+	Message string
+}
+
+// Context carries per-run information that rules can inspect.
+// It is intentionally minimal for T2.6; T2.7 rules may extend it
+// when catalog or session-level data is needed.
+type Context struct {
+	// SQL is the original source text passed to the parser.
+	// Rules may extract source snippets using Loc.Start / Loc.End as
+	// indices into this string.
+	SQL string
+}
+
+// Advisor runs a fixed set of Rules against an AST.
+// Each Advisor instance is safe to reuse for multiple Check calls.
+type Advisor struct {
+	rules []Rule
+}
+
+// New constructs an Advisor with the given rules. Rules are invoked in
+// the order they are provided; order only affects the order of findings
+// in the returned slice, not correctness.
+func New(rules ...Rule) *Advisor {
+	r := make([]Rule, len(rules))
+	copy(r, rules)
+	return &Advisor{rules: r}
+}
+
+// Check walks root depth-first and fans each node out to every Rule.
+// The returned slice contains all findings from all rules, in traversal order
+// (parent before children, rules in registration order per node).
+//
+// Check is safe to call concurrently on different Context/root pairs as long
+// as no rule itself has shared mutable state.
+func (a *Advisor) Check(ctx *Context, root ast.Node) []*Finding {
+	run := &advisorRun{advisor: a, ctx: ctx}
+	ast.Walk(run, root)
+	return run.findings
+}
+
+// advisorRun holds per-Check state so that Advisor itself is stateless.
+type advisorRun struct {
+	advisor  *Advisor
+	ctx      *Context
+	findings []*Finding
+}
+
+// Visit implements ast.Visitor. It is called for each node during the walk.
+// A nil node signals the post-order (end-of-children) event; we return nil
+// to terminate that branch — no action needed.
+func (r *advisorRun) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+	for _, rule := range r.advisor.rules {
+		r.findings = append(r.findings, rule.Check(r.ctx, node)...)
+	}
+	return r // continue descending into children
+}

--- a/snowflake/advisor/advisor_test.go
+++ b/snowflake/advisor/advisor_test.go
@@ -1,0 +1,313 @@
+package advisor_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// mustParse parses sql and fails the test on any parse error.
+func mustParse(t *testing.T, sql string) *ast.File {
+	t.Helper()
+	f, err := parser.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse(%q): %v", sql, err)
+	}
+	return f
+}
+
+// newCtx returns a Context for the given SQL string.
+func newCtx(sql string) *advisor.Context {
+	return &advisor.Context{SQL: sql}
+}
+
+// ---------------------------------------------------------------------------
+// countingRule — records every node it sees (for framework smoke tests).
+// ---------------------------------------------------------------------------
+
+type countingRule struct {
+	count int
+}
+
+func (r *countingRule) ID() string                 { return "test.counting" }
+func (r *countingRule) Severity() advisor.Severity { return advisor.SeverityInfo }
+func (r *countingRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	r.count++
+	return nil
+}
+
+// alwaysRule emits one finding for every node it sees.
+type alwaysRule struct{}
+
+func (alwaysRule) ID() string                 { return "test.always" }
+func (alwaysRule) Severity() advisor.Severity { return advisor.SeverityError }
+func (alwaysRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	return []*advisor.Finding{{
+		RuleID:   "test.always",
+		Severity: advisor.SeverityError,
+		Loc:      ast.NodeLoc(node),
+		Message:  "always fires",
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// Framework tests
+// ---------------------------------------------------------------------------
+
+// TestAdvisor_EmptyRules verifies that an Advisor with no rules produces no
+// findings even on a real AST.
+func TestAdvisor_EmptyRules(t *testing.T) {
+	file := mustParse(t, "SELECT 1")
+	a := advisor.New()
+	findings := a.Check(newCtx("SELECT 1"), file)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+// TestAdvisor_EmptyAST verifies that no findings are produced for a nil root.
+func TestAdvisor_EmptyAST(t *testing.T) {
+	a := advisor.New(alwaysRule{})
+	findings := a.Check(newCtx(""), nil)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for nil root, got %d", len(findings))
+	}
+}
+
+// TestAdvisor_RuleInvoked verifies that a rule's Check method is called at
+// least once for each node in the AST.
+func TestAdvisor_RuleInvoked(t *testing.T) {
+	sql := "SELECT 1"
+	file := mustParse(t, sql)
+	rule := &countingRule{}
+	a := advisor.New(rule)
+	a.Check(newCtx(sql), file)
+	if rule.count == 0 {
+		t.Error("expected rule.Check to be called at least once")
+	}
+}
+
+// TestAdvisor_MultipleRulesAllInvoked verifies that every registered rule
+// receives every node.
+func TestAdvisor_MultipleRulesAllInvoked(t *testing.T) {
+	sql := "SELECT 1"
+	file := mustParse(t, sql)
+	r1, r2, r3 := &countingRule{}, &countingRule{}, &countingRule{}
+	a := advisor.New(r1, r2, r3)
+	a.Check(newCtx(sql), file)
+	if r1.count == 0 || r2.count == 0 || r3.count == 0 {
+		t.Errorf("all rules should be invoked; got counts %d/%d/%d", r1.count, r2.count, r3.count)
+	}
+	if r1.count != r2.count || r2.count != r3.count {
+		t.Errorf("all rules should see the same node count; got %d/%d/%d", r1.count, r2.count, r3.count)
+	}
+}
+
+// TestAdvisor_FindingsCollected verifies that findings from all rules are
+// returned and that their RuleID / Severity fields are set correctly.
+func TestAdvisor_FindingsCollected(t *testing.T) {
+	sql := "SELECT 1"
+	file := mustParse(t, sql)
+	a := advisor.New(alwaysRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding")
+	}
+	for _, f := range findings {
+		if f.RuleID != "test.always" {
+			t.Errorf("RuleID = %q, want %q", f.RuleID, "test.always")
+		}
+		if f.Severity != advisor.SeverityError {
+			t.Errorf("Severity = %v, want ERROR", f.Severity)
+		}
+	}
+}
+
+// TestAdvisor_Reuse verifies that the same Advisor can be used for multiple
+// Check calls without cross-contamination.
+func TestAdvisor_Reuse(t *testing.T) {
+	sql := "SELECT 1"
+	file := mustParse(t, sql)
+	a := advisor.New(alwaysRule{})
+	ctx := newCtx(sql)
+	f1 := a.Check(ctx, file)
+	f2 := a.Check(ctx, file)
+	if len(f1) != len(f2) {
+		t.Errorf("reuse: run1=%d findings, run2=%d findings; want equal", len(f1), len(f2))
+	}
+}
+
+// TestAdvisor_FindingOrderIsRegistrationOrder verifies that findings from
+// multiple rules are returned in rule-registration order per node.
+func TestAdvisor_FindingOrderIsRegistrationOrder(t *testing.T) {
+	var calls []string
+	sql := "SELECT 1"
+	file := mustParse(t, sql)
+	a := advisor.New(
+		trackingRule{tag: "A", calls: &calls},
+		trackingRule{tag: "B", calls: &calls},
+		trackingRule{tag: "C", calls: &calls},
+	)
+	a.Check(newCtx(sql), file)
+
+	// For each node, A should be called before B before C.
+	// calls is: [A, B, C, A, B, C, ...] — one group per node.
+	if len(calls) == 0 {
+		t.Fatal("no calls recorded")
+	}
+	for i := 0; i+2 < len(calls); i += 3 {
+		if calls[i] != "A" || calls[i+1] != "B" || calls[i+2] != "C" {
+			t.Errorf("calls[%d:%d] = %v, want [A B C]", i, i+3, calls[i:i+3])
+		}
+	}
+}
+
+type trackingRule struct {
+	tag   string
+	calls *[]string
+}
+
+func (r trackingRule) ID() string                 { return "test.tracking." + r.tag }
+func (r trackingRule) Severity() advisor.Severity { return advisor.SeverityInfo }
+func (r trackingRule) Check(_ *advisor.Context, _ ast.Node) []*advisor.Finding {
+	*r.calls = append(*r.calls, r.tag)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Severity constant tests
+// ---------------------------------------------------------------------------
+
+func TestSeverity_String(t *testing.T) {
+	tests := []struct {
+		sev  advisor.Severity
+		want string
+	}{
+		{advisor.SeverityInfo, "INFO"},
+		{advisor.SeverityWarning, "WARNING"},
+		{advisor.SeverityError, "ERROR"},
+	}
+	for _, tt := range tests {
+		if got := tt.sev.String(); got != tt.want {
+			t.Errorf("Severity(%d).String() = %q, want %q", tt.sev, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NoSelectStarRule tests
+// ---------------------------------------------------------------------------
+
+// TestNoSelectStar_BareStarFires verifies that SELECT * triggers a WARNING.
+func TestNoSelectStar_BareStarFires(t *testing.T) {
+	sql := "SELECT * FROM t"
+	file := mustParse(t, sql)
+	a := advisor.New(advisor.NoSelectStarRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.RuleID != "snowflake.select.no-select-star" {
+		t.Errorf("RuleID = %q, want %q", f.RuleID, "snowflake.select.no-select-star")
+	}
+	if f.Severity != advisor.SeverityWarning {
+		t.Errorf("Severity = %v, want WARNING", f.Severity)
+	}
+	if !strings.Contains(f.Message, "SELECT *") {
+		t.Errorf("Message = %q, should mention SELECT *", f.Message)
+	}
+}
+
+// TestNoSelectStar_ColumnListNoFire verifies that SELECT a, b produces no
+// findings.
+func TestNoSelectStar_ColumnListNoFire(t *testing.T) {
+	sql := "SELECT a, b, c FROM t"
+	file := mustParse(t, sql)
+	a := advisor.New(advisor.NoSelectStarRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for column list, got %d", len(findings))
+	}
+}
+
+// TestNoSelectStar_QualifiedStarNoFire verifies that SELECT t.* does NOT
+// trigger the rule (qualified star is a separate concern).
+func TestNoSelectStar_QualifiedStarNoFire(t *testing.T) {
+	sql := "SELECT t.* FROM t"
+	file := mustParse(t, sql)
+	a := advisor.New(advisor.NoSelectStarRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for qualified star, got %d", len(findings))
+	}
+}
+
+// TestNoSelectStar_MultipleStarFires verifies that two bare stars in a UNION
+// produce two findings.
+func TestNoSelectStar_MultipleStarFires(t *testing.T) {
+	sql := "SELECT * FROM a UNION ALL SELECT * FROM b"
+	file := mustParse(t, sql)
+	a := advisor.New(advisor.NoSelectStarRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings for two bare stars, got %d", len(findings))
+	}
+}
+
+// TestNoSelectStar_LocationIsValid verifies that the Loc on a finding covers
+// the source bytes of the * token.
+func TestNoSelectStar_LocationIsValid(t *testing.T) {
+	sql := "SELECT * FROM t"
+	// The * is at byte offset 7 (0-indexed: "SELECT " is 7 bytes, * is at 7).
+	file := mustParse(t, sql)
+	a := advisor.New(advisor.NoSelectStarRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	loc := findings[0].Loc
+	if !loc.IsValid() {
+		t.Fatalf("Loc is not valid: %+v", loc)
+	}
+	// The SelectTarget covering * should start at/before the * character and
+	// end after it.  "SELECT * FROM t" — * is at index 7.
+	if loc.Start > 7 || loc.End <= 7 {
+		t.Errorf("Loc = {%d, %d}, want Start<=7 and End>7 to cover '*' at offset 7",
+			loc.Start, loc.End)
+	}
+	// The source substring covered by Loc should contain *.
+	sub := sql[loc.Start:loc.End]
+	if !strings.Contains(sub, "*") {
+		t.Errorf("source[%d:%d] = %q, should contain '*'", loc.Start, loc.End, sub)
+	}
+}
+
+// TestNoSelectStar_IDAndSeverity verifies the rule's static metadata.
+func TestNoSelectStar_IDAndSeverity(t *testing.T) {
+	rule := advisor.NoSelectStarRule{}
+	if rule.ID() != "snowflake.select.no-select-star" {
+		t.Errorf("ID() = %q, want %q", rule.ID(), "snowflake.select.no-select-star")
+	}
+	if rule.Severity() != advisor.SeverityWarning {
+		t.Errorf("Severity() = %v, want WARNING", rule.Severity())
+	}
+}
+
+// TestNoSelectStar_NoSelectNoFire verifies a CREATE TABLE produces no finding.
+func TestNoSelectStar_NoSelectNoFire(t *testing.T) {
+	sql := "CREATE TABLE t (id INT)"
+	file := mustParse(t, sql)
+	a := advisor.New(advisor.NoSelectStarRule{})
+	findings := a.Check(newCtx(sql), file)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for DDL, got %d", len(findings))
+	}
+}

--- a/snowflake/advisor/example_rule.go
+++ b/snowflake/advisor/example_rule.go
@@ -1,0 +1,68 @@
+package advisor
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// NoSelectStarRule warns when a SELECT list contains a bare * (SELECT *).
+//
+// This is a minimal example rule included with the framework to prove the
+// wiring works end-to-end. It is NOT one of the T2.7 production rules, but
+// it exercises the full pipeline: parse -> advisor.Check -> findings with Loc.
+//
+// Trigger:  a *ast.SelectStmt whose Targets slice contains an entry with
+//
+//	Star == true AND whose Expr is a *ast.StarExpr with Qualifier == nil
+//	(bare * — no table qualifier).
+//
+// Not flagged: qualified star such as t.* (SelectTarget.Star true with Expr set
+//
+//	to a *ast.StarExpr carrying a non-nil Qualifier). Qualified star is
+//	a different smell and is not flagged by this rule.
+//
+// Rule ID:  "snowflake.select.no-select-star"
+// Severity: WARNING
+//
+// Implementation note: ast.SelectTarget is not an ast.Node and is therefore
+// not visited directly by ast.Walk. The rule matches the parent SelectStmt
+// and inspects its Targets slice in-line.
+type NoSelectStarRule struct{}
+
+const noSelectStarID = "snowflake.select.no-select-star"
+
+// ID implements Rule.
+func (NoSelectStarRule) ID() string { return noSelectStarID }
+
+// Severity implements Rule.
+func (NoSelectStarRule) Severity() Severity { return SeverityWarning }
+
+// Check implements Rule.
+func (NoSelectStarRule) Check(_ *Context, node ast.Node) []*Finding {
+	sel, ok := node.(*ast.SelectStmt)
+	if !ok {
+		return nil
+	}
+	var findings []*Finding
+	for _, target := range sel.Targets {
+		if !target.Star {
+			continue
+		}
+		// target.Expr is always a *ast.StarExpr when Star is true.
+		// A bare * has StarExpr.Qualifier == nil.
+		// A qualified star (t.*) has StarExpr.Qualifier != nil.
+		starExpr, ok := target.Expr.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		if starExpr.Qualifier != nil {
+			continue
+		}
+		findings = append(findings, &Finding{
+			RuleID:   noSelectStarID,
+			Severity: SeverityWarning,
+			Loc:      target.Loc,
+			Message:  "avoid SELECT *: list the required columns explicitly",
+		})
+	}
+	return findings
+}

--- a/snowflake/advisor/rule.go
+++ b/snowflake/advisor/rule.go
@@ -1,0 +1,28 @@
+package advisor
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// Rule is the interface implemented by every lint rule.
+//
+// Rules are stateless with respect to a single Check call: all per-run
+// context arrives via the ctx argument, and all output is returned as
+// a slice (never stored on the Rule). This makes rules safe to reuse
+// across multiple Advisor.Check calls without re-registration.
+type Rule interface {
+	// ID returns the canonical identifier for this rule.
+	// Convention: "snowflake.<category>.<short-name>", e.g.
+	// "snowflake.select.no-select-star".
+	ID() string
+
+	// Severity returns the default severity for findings produced by this rule.
+	// Implementations may vary severity per finding if needed; the value
+	// returned here is used for documentation, filtering, and tests.
+	Severity() Severity
+
+	// Check inspects node and returns zero or more Findings.
+	// It is called once per AST node during a depth-first walk.
+	// Check must be non-blocking and must not mutate ctx or node.
+	Check(ctx *Context, node ast.Node) []*Finding
+}


### PR DESCRIPTION
## Summary

- Adds `snowflake/advisor/` package: the lint-rule framework that T2.7 will use to implement 14 Snowflake SQL rules
- `Advisor` walks the AST depth-first via `ast.Visitor` and fans each node out to all registered `Rule` implementations; findings are collected in traversal order
- Provides `Severity` (INFO/WARNING/ERROR), `Finding` (RuleID, Severity, Loc, Message), `Context` (SQL string), and the `Rule` interface (ID, Severity, Check)
- Includes `NoSelectStarRule` — a minimal example rule that warns on bare `SELECT *` — to prove the full pipeline end-to-end
- 15 tests cover: empty rules, nil root, rule invocation counts, finding collection, Advisor reuse, registration-order guarantee, severity `String()`, and all NoSelectStar variants (fires/no-fires/location accuracy/UNION/DDL)

## Design decisions

- **Per-instance registry** (not global init-based): `advisor.New(rules...)` makes the Advisor fully testable without import side-effects; a global registry can layer on top later
- **Single `Check(ctx, node)` per rule** (not enter/exit callbacks): none of the T2.7 rules need post-order events; the simpler interface is cleaner
- **Rule matches `SelectStmt` not `SelectTarget`**: `ast.SelectTarget` is not an `ast.Node` and is not visited by the walker; rules that need the select list inspect the parent `SelectStmt.Targets` directly
- **`advisorRun` scratchpad**: per-call state lives on a `advisorRun` struct, keeping `Advisor` itself stateless and safe to reuse

## Test plan

- [x] `go test ./snowflake/advisor/... -count=1` — 15/15 pass
- [x] `go test ./snowflake/... -count=1` — full suite green
- [x] `gofmt -w snowflake/` — no diff after formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)