### PR TITLE
feat(snowflake): T2.1 DATABASE+SCHEMA DDL — CREATE/ALTER/DROP/UNDROP

### DIFF
--- a/docs/superpowers/plans/2026-04-14-snowflake-db-schema.md
+++ b/docs/superpowers/plans/2026-04-14-snowflake-db-schema.md
@@ -1,0 +1,74 @@
+# Plan: T2.1 — DATABASE + SCHEMA DDL (Snowflake)
+
+**Date:** 2026-04-14
+**Spec:** `docs/superpowers/specs/2026-04-14-snowflake-db-schema-design.md`
+
+## Steps
+
+### Step 1 — AST types + NodeTags (commit 1)
+
+1. Edit `snowflake/ast/parsenodes.go`:
+   - Add `AlterDatabaseAction` enum + constants
+   - Add `AlterSchemaAction` enum + constants
+   - Add `DBSchemaProps` helper struct
+   - Add `CreateDatabaseStmt`, `CreateSchemaStmt`
+   - Add `AlterDatabaseStmt`, `AlterSchemaStmt`
+   - Add `DropDatabaseStmt`, `DropSchemaStmt`
+   - Add `UndropDatabaseStmt`, `UndropSchemaStmt`
+   - Add compile-time var _ Node assertions
+
+2. Edit `snowflake/ast/nodetags.go`:
+   - Add 8 T_* constants to the iota block
+   - Add 8 String() cases
+
+3. Run `go run ./snowflake/ast/cmd/genwalker` to regenerate walker
+
+4. Run `go test ./snowflake/...` — must pass (no parser tests yet)
+
+### Step 2 — Parser implementation (commit 2)
+
+1. Edit `snowflake/parser/create_table.go`:
+   - Add `kwDATABASE` and `kwSCHEMA` cases to `parseCreateStmt`'s switch
+
+2. Edit `snowflake/parser/parser.go`:
+   - Replace `unsupported("ALTER")` with `p.parseAlterStmt()`
+   - Replace `unsupported("DROP")` with `p.parseDropStmt()`
+   - Replace `unsupported("UNDROP")` with `p.parseUndropStmt()`
+
+3. Create `snowflake/parser/database_schema.go` with:
+   - `parseCreateDatabaseStmt`
+   - `parseCreateSchemaStmt`
+   - `parseAlterStmt` dispatcher
+   - `parseAlterDatabaseStmt`
+   - `parseAlterSchemaStmt`
+   - `parseDropStmt` dispatcher
+   - `parseDropDatabaseStmt`
+   - `parseDropSchemaStmt`
+   - `parseUndropStmt` dispatcher
+   - `parseUndropDatabaseStmt`
+   - `parseUndropSchemaStmt`
+   - `parseDBSchemaProps` helper
+   - `parsePropertyNameList` helper
+   - `parseUnsetTagList` helper
+
+4. Run `go build ./snowflake/...` — must pass
+
+### Step 3 — Tests (commit 3)
+
+1. Create `snowflake/parser/database_schema_test.go` with ~45 test cases
+2. Run `go test ./snowflake/... -count=1` — must pass
+3. Run `gofmt -w snowflake/`
+
+### Step 4 — Docs + commit (commit 4 or merge with commit 1)
+
+- Spec and plan already written before code changes
+- Combine docs commit with AST commit if clean
+
+## Commit messages
+
+```
+feat(snowflake): T2.1 step 1 — AST nodes for DATABASE/SCHEMA DDL
+feat(snowflake): T2.1 step 2 — parser for DATABASE/SCHEMA DDL
+feat(snowflake): T2.1 step 3 — tests for DATABASE/SCHEMA DDL
+feat(snowflake): T2.1 step 4 — spec+plan docs for DATABASE/SCHEMA DDL
+```

--- a/docs/superpowers/specs/2026-04-14-snowflake-db-schema-design.md
+++ b/docs/superpowers/specs/2026-04-14-snowflake-db-schema-design.md
@@ -1,0 +1,288 @@
+# Spec: T2.1 — DATABASE + SCHEMA DDL (Snowflake)
+
+**Date:** 2026-04-14
+**Author:** Claude (T2.1 implementation)
+**Node:** T2.1 in the Snowflake migration DAG
+**Depends on:** T2.2 (CREATE TABLE patterns), T1.4 (SELECT core), F1–F4 (AST/lexer/splitter/parser-entry)
+
+---
+
+## Goal
+
+Implement full parse-tree support for DATABASE and SCHEMA DDL statements in the
+Snowflake omni parser. The eight target statements are:
+
+- `CREATE DATABASE`
+- `CREATE SCHEMA`
+- `ALTER DATABASE`
+- `ALTER SCHEMA`
+- `DROP DATABASE`
+- `DROP SCHEMA`
+- `UNDROP DATABASE`
+- `UNDROP SCHEMA`
+
+## Source of truth
+
+Legacy grammar: `/parser/snowflake/SnowflakeParser.g4`, rules
+`create_database`, `create_schema`, `alter_database`, `alter_schema`,
+`drop_database`, `drop_schema`, `undrop_database`, `undrop_schema`.
+
+---
+
+## AST design
+
+### New node types (in `parsenodes.go`)
+
+#### `CreateDatabaseStmt`
+
+```
+OrReplace       bool
+Transient       bool
+IfNotExists     bool
+Name            *ObjectName
+Clone           *CloneSource         // CLONE ... [AT|BEFORE ...]
+DataRetention   *int64               // DATA_RETENTION_TIME_IN_DAYS = n
+MaxDataExt      *int64               // MAX_DATA_EXTENSION_TIME_IN_DAYS = n
+DefaultDDLColl  *string              // DEFAULT_DDL_COLLATION = 's'
+Comment         *string
+Tags            []*TagAssignment
+Loc             Loc
+```
+
+#### `CreateSchemaStmt`
+
+```
+OrReplace       bool
+Transient       bool
+IfNotExists     bool
+Name            *ObjectName
+Clone           *CloneSource
+ManagedAccess   bool                 // WITH MANAGED ACCESS
+DataRetention   *int64
+MaxDataExt      *int64
+DefaultDDLColl  *string
+Comment         *string
+Tags            []*TagAssignment
+Loc             Loc
+```
+
+#### `AlterDatabaseStmt`
+
+Represents all ALTER DATABASE variants. Uses a discriminated `Action` field:
+
+```
+IfExists    bool
+Name        *ObjectName
+Action      AlterDatabaseAction  (enum)
+// Populated based on Action:
+NewName     *ObjectName       // RENAME TO / SWAP WITH
+SetProps    *DBSchemaProps    // SET ...
+UnsetProps  []string          // UNSET property, ...
+Tags        []*TagAssignment  // SET TAG (...)
+UnsetTags   []*ObjectName     // UNSET TAG (...)
+Loc         Loc
+```
+
+`AlterDatabaseAction` enum:
+- `AlterDBRename` — RENAME TO
+- `AlterDBSwap` — SWAP WITH
+- `AlterDBSet` — SET properties
+- `AlterDBUnset` — UNSET properties
+- `AlterDBSetTag` — SET TAG
+- `AlterDBUnsetTag` — UNSET TAG
+- `AlterDBEnableReplication` — ENABLE REPLICATION (structural only)
+- `AlterDBDisableReplication` — DISABLE REPLICATION (structural only)
+- `AlterDBEnableFailover` — ENABLE FAILOVER (structural only)
+- `AlterDBDisableFailover` — DISABLE FAILOVER (structural only)
+- `AlterDBRefresh` — REFRESH
+- `AlterDBPrimary` — PRIMARY
+
+`DBSchemaProps` helper struct (not a Node):
+```
+DataRetention  *int64
+MaxDataExt     *int64
+DefaultDDLColl *string
+Comment        *string
+```
+
+#### `AlterSchemaStmt`
+
+```
+IfExists      bool
+Name          *ObjectName
+Action        AlterSchemaAction  (enum)
+NewName       *ObjectName       // RENAME TO / SWAP WITH
+SetProps      *DBSchemaProps
+UnsetProps    []string
+Tags          []*TagAssignment
+UnsetTags     []*ObjectName
+ManagedAccess *bool             // true=ENABLE, false=DISABLE, nil=not set
+Loc           Loc
+```
+
+`AlterSchemaAction` enum:
+- `AlterSchemaRename`
+- `AlterSchemaSwap`
+- `AlterSchemaSet`
+- `AlterSchemaUnset`
+- `AlterSchemaSetTag`
+- `AlterSchemaUnsetTag`
+- `AlterSchemaEnableManagedAccess`
+- `AlterSchemaDisableManagedAccess`
+
+#### `DropDatabaseStmt`
+
+```
+IfExists  bool
+Name      *ObjectName
+Cascade   bool         // CASCADE
+Restrict  bool         // RESTRICT
+Loc       Loc
+```
+
+#### `DropSchemaStmt`
+
+```
+IfExists  bool
+Name      *ObjectName
+Cascade   bool
+Restrict  bool
+Loc       Loc
+```
+
+#### `UndropDatabaseStmt`
+
+```
+Name  *ObjectName
+Loc   Loc
+```
+
+#### `UndropSchemaStmt`
+
+```
+Name  *ObjectName
+Loc   Loc
+```
+
+---
+
+## Parser dispatch design
+
+### `parseCreateStmt` extension (`create_table.go`)
+
+Add `kwDATABASE` and `kwSCHEMA` cases to the existing switch. Both DATABASE and
+SCHEMA accept TRANSIENT; SCHEMA does NOT accept TEMPORARY/VOLATILE.
+
+The `transient` boolean already computed by `parseCreateStmt` is forwarded to
+the new sub-parsers.
+
+### New top-level dispatchers in `parser.go`
+
+Replace `unsupported("ALTER")`, `unsupported("DROP")`, `unsupported("UNDROP")`
+with sub-dispatchers that peek at the object-type keyword:
+
+```
+parseAlterStmt():
+  consume ALTER
+  switch cur.Type:
+    case kwDATABASE: return parseAlterDatabaseStmt(...)
+    case kwSCHEMA:   return parseAlterSchemaStmt(...)
+    default:         return unsupported("ALTER")
+
+parseDropStmt():
+  consume DROP
+  switch cur.Type:
+    case kwDATABASE: return parseDropDatabaseStmt(...)
+    case kwSCHEMA:   return parseDropSchemaStmt(...)
+    default:         return unsupported("DROP")
+
+parseUndropStmt():
+  consume UNDROP
+  switch cur.Type:
+    case kwDATABASE: return parseUndropDatabaseStmt()
+    case kwSCHEMA:   return parseUndropSchemaStmt()
+    default:         return unsupported("UNDROP")
+```
+
+---
+
+## Property parsing helpers
+
+### `parseDBSchemaProps()` — shared by CREATE and ALTER SET
+
+Parses zero or more optional properties from the set:
+- `DATA_RETENTION_TIME_IN_DAYS = n`
+- `MAX_DATA_EXTENSION_TIME_IN_DAYS = n`
+- `DEFAULT_DDL_COLLATION = 'str'` (also `DEFAULT_DDL_COLLATION_`)
+- `COMMENT = 'str'`
+
+Returns a `*DBSchemaProps`.
+
+### `parsePropertyNameList()` — for UNSET
+
+Returns a `[]string` of uppercased property names.
+
+### `parseUnsetTagList()` — for UNSET TAG
+
+Parses `TAG ( name, name, ... )`, returns `[]*ObjectName`.
+
+---
+
+## Walker entries
+
+The genwalker will add cases for:
+- `*CreateDatabaseStmt` — walk Name, Clone.Source (via *ObjectName)
+- `*CreateSchemaStmt` — walk Name, Clone.Source
+- `*AlterDatabaseStmt` — walk Name, NewName, Tags[].Name, UnsetTags
+- `*AlterSchemaStmt` — walk Name, NewName, Tags[].Name, UnsetTags
+- `*DropDatabaseStmt` — walk Name
+- `*DropSchemaStmt` — walk Name
+- `*UndropDatabaseStmt` — walk Name
+- `*UndropSchemaStmt` — walk Name
+
+Walker generation: `go run ./snowflake/ast/cmd/genwalker` from the worktree root.
+
+---
+
+## NodeTag additions (in `nodetags.go`)
+
+Eight new tags:
+`T_CreateDatabaseStmt`, `T_CreateSchemaStmt`,
+`T_AlterDatabaseStmt`, `T_AlterSchemaStmt`,
+`T_DropDatabaseStmt`, `T_DropSchemaStmt`,
+`T_UndropDatabaseStmt`, `T_UndropSchemaStmt`
+
+---
+
+## Test coverage targets
+
+File: `snowflake/parser/database_schema_test.go`
+
+| Group | Cases |
+|-------|-------|
+| `TestCreateDatabase_*` | Basic, OrReplace, Transient, IfNotExists, WithClone, WithProps, WithTags |
+| `TestCreateSchema_*` | Basic, OrReplace, Transient, IfNotExists, WithClone, ManagedAccess, WithProps, WithTags |
+| `TestAlterDatabase_*` | RenameToNew, SwapWith, SetProps, SetComment, UnsetProp, SetTag, UnsetTag, EnableReplication, DisableReplication, EnableFailover, Refresh, Primary |
+| `TestAlterSchema_*` | Rename, Swap, SetProps, Unset, SetTag, UnsetTag, EnableManagedAccess, DisableManagedAccess |
+| `TestDropDatabase_*` | Basic, IfExists, Cascade, Restrict |
+| `TestDropSchema_*` | Basic, IfExists, Cascade, Restrict |
+| `TestUndropDatabase_*` | Basic |
+| `TestUndropSchema_*` | Basic |
+
+Target: ~45 test cases.
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `snowflake/ast/parsenodes.go` | Add 8 stmt nodes + helpers |
+| `snowflake/ast/nodetags.go` | Add 8 NodeTag constants + String() cases |
+| `snowflake/ast/walk_generated.go` | Regenerated by genwalker |
+| `snowflake/parser/create_table.go` | Add DATABASE/SCHEMA cases to CREATE sub-dispatch |
+| `snowflake/parser/parser.go` | Replace ALTER/DROP/UNDROP stubs with dispatchers |
+| `snowflake/parser/database_schema.go` | New: all 8 statement parsers + helpers |
+| `snowflake/parser/database_schema_test.go` | New: ~45 tests |
+| `docs/superpowers/specs/2026-04-14-snowflake-db-schema-design.md` | This file |
+| `docs/superpowers/plans/2026-04-14-snowflake-db-schema.md` | Plan |

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -53,6 +53,14 @@ const (
 	T_CreateTableStmt
 	T_ColumnDef
 	T_TableConstraint
+	T_CreateDatabaseStmt
+	T_AlterDatabaseStmt
+	T_DropDatabaseStmt
+	T_UndropDatabaseStmt
+	T_CreateSchemaStmt
+	T_AlterSchemaStmt
+	T_DropSchemaStmt
+	T_UndropSchemaStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -122,6 +130,22 @@ func (t NodeTag) String() string {
 		return "ColumnDef"
 	case T_TableConstraint:
 		return "TableConstraint"
+	case T_CreateDatabaseStmt:
+		return "CreateDatabaseStmt"
+	case T_AlterDatabaseStmt:
+		return "AlterDatabaseStmt"
+	case T_DropDatabaseStmt:
+		return "DropDatabaseStmt"
+	case T_UndropDatabaseStmt:
+		return "UndropDatabaseStmt"
+	case T_CreateSchemaStmt:
+		return "CreateSchemaStmt"
+	case T_AlterSchemaStmt:
+		return "AlterSchemaStmt"
+	case T_DropSchemaStmt:
+		return "DropSchemaStmt"
+	case T_UndropSchemaStmt:
+		return "UndropSchemaStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -954,9 +954,9 @@ type CreateTableStmt struct {
 	Name        *ObjectName
 	Columns     []*ColumnDef
 	Constraints []*TableConstraint
-	ClusterBy   []Node           // CLUSTER BY expressions; nil if absent
-	Linear      bool             // CLUSTER BY LINEAR modifier
-	Comment     *string          // COMMENT = 'text'; nil if absent
+	ClusterBy   []Node  // CLUSTER BY expressions; nil if absent
+	Linear      bool    // CLUSTER BY LINEAR modifier
+	Comment     *string // COMMENT = 'text'; nil if absent
 	CopyGrants  bool
 	Tags        []*TagAssignment // WITH TAG (...); nil if absent
 	AsSelect    Node             // CREATE TABLE ... AS SELECT; nil if absent
@@ -970,8 +970,8 @@ func (n *CreateTableStmt) Tag() NodeTag { return T_CreateTableStmt }
 // ColumnDef represents a column definition in CREATE TABLE.
 type ColumnDef struct {
 	Name             Ident
-	DataType         *TypeName         // nil for virtual columns without explicit type
-	Default          Node              // DEFAULT expr; nil if absent
+	DataType         *TypeName // nil for virtual columns without explicit type
+	Default          Node      // DEFAULT expr; nil if absent
 	NotNull          bool
 	Nullable         bool              // explicit NULL
 	Identity         *IdentitySpec     // IDENTITY/AUTOINCREMENT; nil if absent
@@ -1031,14 +1031,14 @@ const (
 type AlterSchemaAction int
 
 const (
-	AlterSchemaRename                AlterSchemaAction = iota // RENAME TO
-	AlterSchemaSwap                                           // SWAP WITH
-	AlterSchemaSet                                            // SET <properties>
-	AlterSchemaUnset                                          // UNSET <properties>
-	AlterSchemaSetTag                                         // SET TAG (...)
-	AlterSchemaUnsetTag                                       // UNSET TAG (...)
-	AlterSchemaEnableManagedAccess                            // ENABLE MANAGED ACCESS
-	AlterSchemaDisableManagedAccess                           // DISABLE MANAGED ACCESS
+	AlterSchemaRename               AlterSchemaAction = iota // RENAME TO
+	AlterSchemaSwap                                          // SWAP WITH
+	AlterSchemaSet                                           // SET <properties>
+	AlterSchemaUnset                                         // UNSET <properties>
+	AlterSchemaSetTag                                        // SET TAG (...)
+	AlterSchemaUnsetTag                                      // UNSET TAG (...)
+	AlterSchemaEnableManagedAccess                           // ENABLE MANAGED ACCESS
+	AlterSchemaDisableManagedAccess                          // DISABLE MANAGED ACCESS
 )
 
 // DBSchemaProps holds the optional settable properties shared by DATABASE and

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1004,3 +1004,170 @@ var (
 	_ Node = (*ColumnDef)(nil)
 	_ Node = (*TableConstraint)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// DATABASE / SCHEMA DDL — enums and helpers
+// ---------------------------------------------------------------------------
+
+// AlterDatabaseAction discriminates the action variants of ALTER DATABASE.
+type AlterDatabaseAction int
+
+const (
+	AlterDBRename             AlterDatabaseAction = iota // RENAME TO
+	AlterDBSwap                                          // SWAP WITH
+	AlterDBSet                                           // SET <properties>
+	AlterDBUnset                                         // UNSET <properties>
+	AlterDBSetTag                                        // SET TAG (...)
+	AlterDBUnsetTag                                      // UNSET TAG (...)
+	AlterDBEnableReplication                             // ENABLE REPLICATION ...
+	AlterDBDisableReplication                            // DISABLE REPLICATION ...
+	AlterDBEnableFailover                                // ENABLE FAILOVER ...
+	AlterDBDisableFailover                               // DISABLE FAILOVER ...
+	AlterDBRefresh                                       // REFRESH
+	AlterDBPrimary                                       // PRIMARY
+)
+
+// AlterSchemaAction discriminates the action variants of ALTER SCHEMA.
+type AlterSchemaAction int
+
+const (
+	AlterSchemaRename                AlterSchemaAction = iota // RENAME TO
+	AlterSchemaSwap                                           // SWAP WITH
+	AlterSchemaSet                                            // SET <properties>
+	AlterSchemaUnset                                          // UNSET <properties>
+	AlterSchemaSetTag                                         // SET TAG (...)
+	AlterSchemaUnsetTag                                       // UNSET TAG (...)
+	AlterSchemaEnableManagedAccess                            // ENABLE MANAGED ACCESS
+	AlterSchemaDisableManagedAccess                           // DISABLE MANAGED ACCESS
+)
+
+// DBSchemaProps holds the optional settable properties shared by DATABASE and
+// SCHEMA DDL statements.  It is NOT a Node — embedded by value or pointer in
+// the statement nodes that need it.
+type DBSchemaProps struct {
+	DataRetention *int64  // DATA_RETENTION_TIME_IN_DAYS = n; nil if absent
+	MaxDataExt    *int64  // MAX_DATA_EXTENSION_TIME_IN_DAYS = n; nil if absent
+	DefaultDDLCol *string // DEFAULT_DDL_COLLATION = 'str'; nil if absent
+	Comment       *string // COMMENT = 'str'; nil if absent
+}
+
+// ---------------------------------------------------------------------------
+// DATABASE DDL statement nodes
+// ---------------------------------------------------------------------------
+
+// CreateDatabaseStmt represents CREATE [OR REPLACE] [TRANSIENT] DATABASE ...
+type CreateDatabaseStmt struct {
+	OrReplace   bool
+	Transient   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Clone       *CloneSource     // CLONE source [AT|BEFORE (...)]; nil if absent
+	Props       DBSchemaProps    // optional properties
+	Tags        []*TagAssignment // WITH TAG (...); nil if absent
+	Loc         Loc
+}
+
+func (n *CreateDatabaseStmt) Tag() NodeTag { return T_CreateDatabaseStmt }
+
+var _ Node = (*CreateDatabaseStmt)(nil)
+
+// AlterDatabaseStmt represents ALTER DATABASE ... (all action variants).
+type AlterDatabaseStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterDatabaseAction
+	NewName    *ObjectName      // RENAME TO / SWAP WITH target
+	SetProps   *DBSchemaProps   // SET properties; non-nil for AlterDBSet
+	UnsetProps []string         // UNSET property names
+	Tags       []*TagAssignment // SET TAG (...) assignments
+	UnsetTags  []*ObjectName    // UNSET TAG (...) names
+	Loc        Loc
+}
+
+func (n *AlterDatabaseStmt) Tag() NodeTag { return T_AlterDatabaseStmt }
+
+var _ Node = (*AlterDatabaseStmt)(nil)
+
+// DropDatabaseStmt represents DROP DATABASE [IF EXISTS] name [CASCADE|RESTRICT].
+type DropDatabaseStmt struct {
+	IfExists bool
+	Name     *ObjectName
+	Cascade  bool
+	Restrict bool
+	Loc      Loc
+}
+
+func (n *DropDatabaseStmt) Tag() NodeTag { return T_DropDatabaseStmt }
+
+var _ Node = (*DropDatabaseStmt)(nil)
+
+// UndropDatabaseStmt represents UNDROP DATABASE name.
+type UndropDatabaseStmt struct {
+	Name *ObjectName
+	Loc  Loc
+}
+
+func (n *UndropDatabaseStmt) Tag() NodeTag { return T_UndropDatabaseStmt }
+
+var _ Node = (*UndropDatabaseStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// SCHEMA DDL statement nodes
+// ---------------------------------------------------------------------------
+
+// CreateSchemaStmt represents CREATE [OR REPLACE] [TRANSIENT] SCHEMA ...
+type CreateSchemaStmt struct {
+	OrReplace     bool
+	Transient     bool
+	IfNotExists   bool
+	Name          *ObjectName
+	Clone         *CloneSource     // CLONE source [AT|BEFORE (...)]; nil if absent
+	ManagedAccess bool             // WITH MANAGED ACCESS
+	Props         DBSchemaProps    // optional properties
+	Tags          []*TagAssignment // WITH TAG (...); nil if absent
+	Loc           Loc
+}
+
+func (n *CreateSchemaStmt) Tag() NodeTag { return T_CreateSchemaStmt }
+
+var _ Node = (*CreateSchemaStmt)(nil)
+
+// AlterSchemaStmt represents ALTER SCHEMA ... (all action variants).
+type AlterSchemaStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterSchemaAction
+	NewName    *ObjectName      // RENAME TO / SWAP WITH target
+	SetProps   *DBSchemaProps   // SET properties; non-nil for AlterSchemaSet
+	UnsetProps []string         // UNSET property names
+	Tags       []*TagAssignment // SET TAG (...) assignments
+	UnsetTags  []*ObjectName    // UNSET TAG (...) names
+	Loc        Loc
+}
+
+func (n *AlterSchemaStmt) Tag() NodeTag { return T_AlterSchemaStmt }
+
+var _ Node = (*AlterSchemaStmt)(nil)
+
+// DropSchemaStmt represents DROP SCHEMA [IF EXISTS] name [CASCADE|RESTRICT].
+type DropSchemaStmt struct {
+	IfExists bool
+	Name     *ObjectName
+	Cascade  bool
+	Restrict bool
+	Loc      Loc
+}
+
+func (n *DropSchemaStmt) Tag() NodeTag { return T_DropSchemaStmt }
+
+var _ Node = (*DropSchemaStmt)(nil)
+
+// UndropSchemaStmt represents UNDROP SCHEMA name.
+type UndropSchemaStmt struct {
+	Name *ObjectName
+	Loc  Loc
+}
+
+func (n *UndropSchemaStmt) Tag() NodeTag { return T_UndropSchemaStmt }
+
+var _ Node = (*UndropSchemaStmt)(nil)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -9,6 +9,20 @@ func walkChildren(v Visitor, node Node) {
 	case *AccessExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.Index)
+	case *AlterDatabaseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
+	case *AlterSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *ArrayLiteralExpr:
 		walkNodes(v, n.Elements)
 	case *BetweenExpr:
@@ -37,6 +51,14 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.MaskingPolicy)
 		}
 		Walk(v, n.VirtualExpr)
+	case *CreateDatabaseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *CreateSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreateTableStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -45,6 +67,14 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.AsSelect)
 		if n.Like != nil {
 			Walk(v, n.Like)
+		}
+	case *DropDatabaseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *DropSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
 		}
 	case *ExistsExpr:
 		Walk(v, n.Query)
@@ -107,5 +137,13 @@ func walkChildren(v Visitor, node Node) {
 		}
 	case *UnaryExpr:
 		Walk(v, n.Expr)
+	case *UndropDatabaseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *UndropSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	}
 }

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -48,6 +48,10 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	switch p.cur.Type {
 	case kwTABLE:
 		return p.parseCreateTableStmt(start, orReplace, transient, temporary, volatile)
+	case kwDATABASE:
+		return p.parseCreateDatabaseStmt(start, orReplace, transient)
+	case kwSCHEMA:
+		return p.parseCreateSchemaStmt(start, orReplace, transient)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -1,0 +1,779 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// CREATE DATABASE
+// ---------------------------------------------------------------------------
+
+// parseCreateDatabaseStmt parses CREATE [OR REPLACE] [TRANSIENT] DATABASE ...
+// The CREATE keyword and optional OR REPLACE / TRANSIENT modifiers have already
+// been consumed by parseCreateStmt; start is the Loc of the CREATE token.
+func (p *Parser) parseCreateDatabaseStmt(start ast.Loc, orReplace, transient bool) (ast.Node, error) {
+	p.advance() // consume DATABASE
+
+	stmt := &ast.CreateDatabaseStmt{
+		OrReplace: orReplace,
+		Transient: transient,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		next := p.peekNext()
+		if next.Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// Database name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional CLONE source [AT|BEFORE (...)]
+	if p.cur.Type == kwCLONE {
+		clone, err := p.parseCloneSource()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Clone = clone
+	}
+
+	// Optional properties
+	if err := p.parseDBSchemaPropsInto(&stmt.Props); err != nil {
+		return nil, err
+	}
+
+	// Optional WITH TAG (...)
+	for p.cur.Type == kwWITH || p.cur.Type == kwTAG {
+		if p.cur.Type == kwWITH {
+			if p.peekNext().Type != kwTAG {
+				break
+			}
+			p.advance() // consume WITH
+		}
+		tags, err := p.parseTagAssignments()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Tags = append(stmt.Tags, tags...)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SCHEMA
+// ---------------------------------------------------------------------------
+
+// parseCreateSchemaStmt parses CREATE [OR REPLACE] [TRANSIENT] SCHEMA ...
+func (p *Parser) parseCreateSchemaStmt(start ast.Loc, orReplace, transient bool) (ast.Node, error) {
+	p.advance() // consume SCHEMA
+
+	stmt := &ast.CreateSchemaStmt{
+		OrReplace: orReplace,
+		Transient: transient,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		next := p.peekNext()
+		if next.Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// Schema name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional CLONE source [AT|BEFORE (...)]
+	if p.cur.Type == kwCLONE {
+		clone, err := p.parseCloneSource()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Clone = clone
+	}
+
+	// Optional WITH MANAGED ACCESS
+	if p.cur.Type == kwWITH {
+		if p.peekNext().Type == kwMANAGED {
+			p.advance() // consume WITH
+			p.advance() // consume MANAGED
+			if _, err := p.expect(kwACCESS); err != nil {
+				return nil, err
+			}
+			stmt.ManagedAccess = true
+		}
+	}
+
+	// Optional properties
+	if err := p.parseDBSchemaPropsInto(&stmt.Props); err != nil {
+		return nil, err
+	}
+
+	// Optional WITH TAG (...)
+	for p.cur.Type == kwWITH || p.cur.Type == kwTAG {
+		if p.cur.Type == kwWITH {
+			if p.peekNext().Type != kwTAG {
+				break
+			}
+			p.advance() // consume WITH
+		}
+		tags, err := p.parseTagAssignments()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Tags = append(stmt.Tags, tags...)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER dispatch
+// ---------------------------------------------------------------------------
+
+// parseAlterStmt dispatches ALTER ... to the appropriate sub-parser.
+// Handles DATABASE and SCHEMA; falls back to unsupported for other objects.
+func (p *Parser) parseAlterStmt() (ast.Node, error) {
+	p.advance() // consume ALTER
+
+	switch p.cur.Type {
+	case kwDATABASE:
+		return p.parseAlterDatabaseStmt()
+	case kwSCHEMA:
+		return p.parseAlterSchemaStmt()
+	default:
+		return p.unsupported("ALTER")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER DATABASE
+// ---------------------------------------------------------------------------
+
+// parseAlterDatabaseStmt parses ALTER DATABASE ... (all action variants).
+// The ALTER keyword has already been consumed.
+func (p *Parser) parseAlterDatabaseStmt() (ast.Node, error) {
+	altTok := p.advance() // consume DATABASE
+	stmt := &ast.AlterDatabaseStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Database name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO new_name
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterDBRename
+		stmt.NewName = newName
+
+	case kwSWAP:
+		// SWAP WITH other_name
+		p.advance() // consume SWAP
+		if _, err := p.expect(kwWITH); err != nil {
+			return nil, err
+		}
+		otherName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterDBSwap
+		stmt.NewName = otherName
+
+	case kwSET:
+		p.advance() // consume SET
+		// Could be SET TAG (...) or SET <properties>
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterDBSetTag
+			stmt.Tags = tags
+		} else {
+			props, err := p.parseDBSchemaProps()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterDBSet
+			stmt.SetProps = props
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			// UNSET TAG ( name, name, ... )
+			names, err := p.parseUnsetTagList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterDBUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET property [, property ...]
+			props, err := p.parsePropertyNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterDBUnset
+			stmt.UnsetProps = props
+		}
+
+	case kwENABLE:
+		p.advance() // consume ENABLE
+		switch p.cur.Type {
+		case kwREPLICATION:
+			// ENABLE REPLICATION TO ACCOUNTS account_list [IGNORE EDITION CHECK]
+			p.advance() // consume REPLICATION
+			if _, err := p.expect(kwTO); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwACCOUNTS); err != nil {
+				return nil, err
+			}
+			// Skip account identifiers until end / IGNORE
+			for p.cur.Type != tokEOF && p.cur.Type != kwIGNORE && p.cur.Type != ';' {
+				p.advance()
+			}
+			// Optional IGNORE EDITION CHECK
+			if p.cur.Type == kwIGNORE {
+				p.advance() // consume IGNORE
+				p.advance() // consume EDITION
+				p.advance() // consume CHECK
+			}
+			stmt.Action = ast.AlterDBEnableReplication
+		case kwFAILOVER:
+			// ENABLE FAILOVER TO ACCOUNTS account_list
+			p.advance() // consume FAILOVER
+			if _, err := p.expect(kwTO); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwACCOUNTS); err != nil {
+				return nil, err
+			}
+			// Skip account identifiers
+			for p.cur.Type != tokEOF && p.cur.Type != ';' {
+				p.advance()
+			}
+			stmt.Action = ast.AlterDBEnableFailover
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwDISABLE:
+		p.advance() // consume DISABLE
+		switch p.cur.Type {
+		case kwREPLICATION:
+			// DISABLE REPLICATION [TO ACCOUNTS account_list]
+			p.advance() // consume REPLICATION
+			if p.cur.Type == kwTO {
+				p.advance() // consume TO
+				if _, err := p.expect(kwACCOUNTS); err != nil {
+					return nil, err
+				}
+				for p.cur.Type != tokEOF && p.cur.Type != ';' {
+					p.advance()
+				}
+			}
+			stmt.Action = ast.AlterDBDisableReplication
+		case kwFAILOVER:
+			// DISABLE FAILOVER [TO ACCOUNTS account_list]
+			p.advance() // consume FAILOVER
+			if p.cur.Type == kwTO {
+				p.advance() // consume TO
+				if _, err := p.expect(kwACCOUNTS); err != nil {
+					return nil, err
+				}
+				for p.cur.Type != tokEOF && p.cur.Type != ';' {
+					p.advance()
+				}
+			}
+			stmt.Action = ast.AlterDBDisableFailover
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwREFRESH:
+		p.advance() // consume REFRESH
+		stmt.Action = ast.AlterDBRefresh
+
+	case kwPRIMARY:
+		p.advance() // consume PRIMARY
+		stmt.Action = ast.AlterDBPrimary
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SCHEMA
+// ---------------------------------------------------------------------------
+
+// parseAlterSchemaStmt parses ALTER SCHEMA ... (all action variants).
+// The ALTER keyword has already been consumed.
+func (p *Parser) parseAlterSchemaStmt() (ast.Node, error) {
+	altTok := p.advance() // consume SCHEMA
+	stmt := &ast.AlterSchemaStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Schema name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO new_name
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterSchemaRename
+		stmt.NewName = newName
+
+	case kwSWAP:
+		// SWAP WITH other_name
+		p.advance() // consume SWAP
+		if _, err := p.expect(kwWITH); err != nil {
+			return nil, err
+		}
+		otherName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterSchemaSwap
+		stmt.NewName = otherName
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSchemaSetTag
+			stmt.Tags = tags
+		} else {
+			props, err := p.parseDBSchemaProps()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSchemaSet
+			stmt.SetProps = props
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSchemaUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			props, err := p.parsePropertyNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSchemaUnset
+			stmt.UnsetProps = props
+		}
+
+	case kwENABLE:
+		// ENABLE MANAGED ACCESS
+		p.advance() // consume ENABLE
+		if _, err := p.expect(kwMANAGED); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwACCESS); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterSchemaEnableManagedAccess
+
+	case kwDISABLE:
+		// DISABLE MANAGED ACCESS
+		p.advance() // consume DISABLE
+		if _, err := p.expect(kwMANAGED); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwACCESS); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterSchemaDisableManagedAccess
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// DROP dispatch
+// ---------------------------------------------------------------------------
+
+// parseDropStmt dispatches DROP ... to the appropriate sub-parser.
+func (p *Parser) parseDropStmt() (ast.Node, error) {
+	p.advance() // consume DROP
+
+	switch p.cur.Type {
+	case kwDATABASE:
+		return p.parseDropDatabaseStmt()
+	case kwSCHEMA:
+		return p.parseDropSchemaStmt()
+	default:
+		return p.unsupported("DROP")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP DATABASE
+// ---------------------------------------------------------------------------
+
+// parseDropDatabaseStmt parses DROP DATABASE [IF EXISTS] name [CASCADE|RESTRICT].
+// The DROP keyword has already been consumed.
+func (p *Parser) parseDropDatabaseStmt() (ast.Node, error) {
+	dropTok := p.advance() // consume DATABASE
+	stmt := &ast.DropDatabaseStmt{Loc: ast.Loc{Start: dropTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Database name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional CASCADE | RESTRICT
+	switch p.cur.Type {
+	case kwCASCADE:
+		p.advance()
+		stmt.Cascade = true
+	case kwRESTRICT:
+		p.advance()
+		stmt.Restrict = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// DROP SCHEMA
+// ---------------------------------------------------------------------------
+
+// parseDropSchemaStmt parses DROP SCHEMA [IF EXISTS] name [CASCADE|RESTRICT].
+// The DROP keyword has already been consumed.
+func (p *Parser) parseDropSchemaStmt() (ast.Node, error) {
+	dropTok := p.advance() // consume SCHEMA
+	stmt := &ast.DropSchemaStmt{Loc: ast.Loc{Start: dropTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Schema name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional CASCADE | RESTRICT
+	switch p.cur.Type {
+	case kwCASCADE:
+		p.advance()
+		stmt.Cascade = true
+	case kwRESTRICT:
+		p.advance()
+		stmt.Restrict = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP dispatch
+// ---------------------------------------------------------------------------
+
+// parseUndropStmt dispatches UNDROP ... to the appropriate sub-parser.
+func (p *Parser) parseUndropStmt() (ast.Node, error) {
+	p.advance() // consume UNDROP
+
+	switch p.cur.Type {
+	case kwDATABASE:
+		return p.parseUndropDatabaseStmt()
+	case kwSCHEMA:
+		return p.parseUndropSchemaStmt()
+	default:
+		return p.unsupported("UNDROP")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP DATABASE
+// ---------------------------------------------------------------------------
+
+// parseUndropDatabaseStmt parses UNDROP DATABASE name.
+// The UNDROP keyword has already been consumed.
+func (p *Parser) parseUndropDatabaseStmt() (ast.Node, error) {
+	undropTok := p.advance() // consume DATABASE
+	stmt := &ast.UndropDatabaseStmt{Loc: ast.Loc{Start: undropTok.Loc.Start}}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP SCHEMA
+// ---------------------------------------------------------------------------
+
+// parseUndropSchemaStmt parses UNDROP SCHEMA name.
+// The UNDROP keyword has already been consumed.
+func (p *Parser) parseUndropSchemaStmt() (ast.Node, error) {
+	undropTok := p.advance() // consume SCHEMA
+	stmt := &ast.UndropSchemaStmt{Loc: ast.Loc{Start: undropTok.Loc.Start}}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Property parsing helpers
+// ---------------------------------------------------------------------------
+
+// parseDBSchemaProps parses zero or more optional DATABASE/SCHEMA properties
+// (DATA_RETENTION_TIME_IN_DAYS, MAX_DATA_EXTENSION_TIME_IN_DAYS,
+// DEFAULT_DDL_COLLATION, COMMENT). Returns a new *DBSchemaProps; the pointer
+// fields inside are nil unless the corresponding property was present.
+func (p *Parser) parseDBSchemaProps() (*ast.DBSchemaProps, error) {
+	props := &ast.DBSchemaProps{}
+	if err := p.parseDBSchemaPropsInto(props); err != nil {
+		return nil, err
+	}
+	return props, nil
+}
+
+// parseDBSchemaPropsInto populates *props in-place. Used by CREATE statements
+// that hold DBSchemaProps by value.
+func (p *Parser) parseDBSchemaPropsInto(props *ast.DBSchemaProps) error {
+	for {
+		switch p.cur.Type {
+		case kwDATA_RETENTION_TIME_IN_DAYS:
+			p.advance() // consume DATA_RETENTION_TIME_IN_DAYS
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokInt)
+			if err != nil {
+				return err
+			}
+			v := tok.Ival
+			props.DataRetention = &v
+
+		case kwMAX_DATA_EXTENSION_TIME_IN_DAYS:
+			p.advance() // consume MAX_DATA_EXTENSION_TIME_IN_DAYS
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokInt)
+			if err != nil {
+				return err
+			}
+			v := tok.Ival
+			props.MaxDataExt = &v
+
+		case kwDEFAULT_DDL_COLLATION:
+			p.advance() // consume DEFAULT_DDL_COLLATION / DEFAULT_DDL_COLLATION_
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return err
+			}
+			s := tok.Str
+			props.DefaultDDLCol = &s
+
+		case kwCOMMENT:
+			p.advance() // consume COMMENT
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return err
+			}
+			s := tok.Str
+			props.Comment = &s
+
+		default:
+			return nil
+		}
+	}
+}
+
+// parsePropertyNameList parses a comma-separated list of property names
+// (identifiers or reserved keywords) for UNSET clauses. Returns the uppercased
+// names. Consumes at least one name.
+func (p *Parser) parsePropertyNameList() ([]string, error) {
+	name, err := p.parsePropertyName()
+	if err != nil {
+		return nil, err
+	}
+	names := []string{name}
+
+	for p.cur.Type == ',' {
+		p.advance() // consume ','
+		name, err = p.parsePropertyName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// parsePropertyName parses a single property name. Property names can be
+// keywords (DATA_RETENTION_TIME_IN_DAYS, COMMENT, etc.) or identifiers.
+func (p *Parser) parsePropertyName() (string, error) {
+	switch p.cur.Type {
+	case kwDATA_RETENTION_TIME_IN_DAYS:
+		p.advance()
+		return "DATA_RETENTION_TIME_IN_DAYS", nil
+	case kwMAX_DATA_EXTENSION_TIME_IN_DAYS:
+		p.advance()
+		return "MAX_DATA_EXTENSION_TIME_IN_DAYS", nil
+	case kwDEFAULT_DDL_COLLATION:
+		p.advance()
+		return "DEFAULT_DDL_COLLATION", nil
+	case kwCOMMENT:
+		p.advance()
+		return "COMMENT", nil
+	case tokIdent:
+		tok := p.advance()
+		return tok.Str, nil
+	default:
+		return "", p.syntaxErrorAtCur()
+	}
+}
+
+// parseUnsetTagList parses TAG ( name [, name ...] ) for UNSET TAG clauses.
+// Consumes the TAG keyword and the parenthesized name list.
+func (p *Parser) parseUnsetTagList() ([]*ast.ObjectName, error) {
+	if _, err := p.expect(kwTAG); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var names []*ast.ObjectName
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+		} else {
+			break
+		}
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return names, nil
+}

--- a/snowflake/parser/database_schema_test.go
+++ b/snowflake/parser/database_schema_test.go
@@ -1,0 +1,893 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func testParseCreateDatabase(input string) (*ast.CreateDatabaseStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CreateDatabaseStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a CreateDatabaseStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseCreateSchema(input string) (*ast.CreateSchemaStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CreateSchemaStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a CreateSchemaStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseAlterDatabase(input string) (*ast.AlterDatabaseStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.AlterDatabaseStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not an AlterDatabaseStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseAlterSchema(input string) (*ast.AlterSchemaStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.AlterSchemaStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not an AlterSchemaStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseDropDatabase(input string) (*ast.DropDatabaseStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.DropDatabaseStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a DropDatabaseStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseDropSchema(input string) (*ast.DropSchemaStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.DropSchemaStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a DropSchemaStmt"})
+	}
+	return stmt, result.Errors
+}
+
+// ---------------------------------------------------------------------------
+// CREATE DATABASE tests
+// ---------------------------------------------------------------------------
+
+func TestCreateDatabase_Basic(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE DATABASE mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected CreateDatabaseStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "MYDB" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+	if stmt.Transient {
+		t.Error("expected Transient=false")
+	}
+	if stmt.IfNotExists {
+		t.Error("expected IfNotExists=false")
+	}
+}
+
+func TestCreateDatabase_OrReplace(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE OR REPLACE DATABASE mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+}
+
+func TestCreateDatabase_Transient(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE TRANSIENT DATABASE mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Transient {
+		t.Error("expected Transient=true")
+	}
+}
+
+func TestCreateDatabase_OrReplaceTransient(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE OR REPLACE TRANSIENT DATABASE mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.Transient {
+		t.Error("expected Transient=true")
+	}
+}
+
+func TestCreateDatabase_IfNotExists(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE DATABASE IF NOT EXISTS mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+	if stmt.Name.Normalize() != "MYDB" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB")
+	}
+}
+
+func TestCreateDatabase_WithClone(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE DATABASE mydb CLONE sourcedb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Clone == nil {
+		t.Fatal("expected Clone to be set")
+	}
+	if stmt.Clone.Source.Normalize() != "SOURCEDB" {
+		t.Errorf("clone source = %q, want %q", stmt.Clone.Source.Normalize(), "SOURCEDB")
+	}
+}
+
+func TestCreateDatabase_WithCloneAtTimestamp(t *testing.T) {
+	stmt, errs := testParseCreateDatabase(
+		`CREATE DATABASE mydb CLONE sourcedb AT (TIMESTAMP => '2024-01-01 00:00:00')`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Clone == nil {
+		t.Fatal("expected Clone to be set")
+	}
+	if stmt.Clone.AtBefore != "AT" {
+		t.Errorf("AtBefore = %q, want %q", stmt.Clone.AtBefore, "AT")
+	}
+	if stmt.Clone.Kind != "TIMESTAMP" {
+		t.Errorf("Kind = %q, want %q", stmt.Clone.Kind, "TIMESTAMP")
+	}
+}
+
+func TestCreateDatabase_WithDataRetention(t *testing.T) {
+	stmt, errs := testParseCreateDatabase(
+		"CREATE DATABASE mydb DATA_RETENTION_TIME_IN_DAYS = 7")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Props.DataRetention == nil {
+		t.Fatal("expected DataRetention to be set")
+	}
+	if *stmt.Props.DataRetention != 7 {
+		t.Errorf("DataRetention = %d, want 7", *stmt.Props.DataRetention)
+	}
+}
+
+func TestCreateDatabase_WithComment(t *testing.T) {
+	stmt, errs := testParseCreateDatabase(
+		"CREATE DATABASE mydb COMMENT = 'my database'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Props.Comment == nil {
+		t.Fatal("expected Comment to be set")
+	}
+	if *stmt.Props.Comment != "my database" {
+		t.Errorf("Comment = %q, want %q", *stmt.Props.Comment, "my database")
+	}
+}
+
+func TestCreateDatabase_WithTags(t *testing.T) {
+	stmt, errs := testParseCreateDatabase(
+		"CREATE DATABASE mydb WITH TAG (env = 'prod')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Tags) != 1 {
+		t.Fatalf("tags = %d, want 1", len(stmt.Tags))
+	}
+	if stmt.Tags[0].Name.Normalize() != "ENV" {
+		t.Errorf("tag name = %q, want %q", stmt.Tags[0].Name.Normalize(), "ENV")
+	}
+	if stmt.Tags[0].Value != "prod" {
+		t.Errorf("tag value = %q, want %q", stmt.Tags[0].Value, "prod")
+	}
+}
+
+func TestCreateDatabase_FullProps(t *testing.T) {
+	stmt, errs := testParseCreateDatabase(
+		`CREATE OR REPLACE DATABASE mydb
+		 DATA_RETENTION_TIME_IN_DAYS = 30
+		 MAX_DATA_EXTENSION_TIME_IN_DAYS = 90
+		 DEFAULT_DDL_COLLATION = 'en_US'
+		 COMMENT = 'full test'`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Props.DataRetention == nil || *stmt.Props.DataRetention != 30 {
+		t.Errorf("DataRetention = %v, want 30", stmt.Props.DataRetention)
+	}
+	if stmt.Props.MaxDataExt == nil || *stmt.Props.MaxDataExt != 90 {
+		t.Errorf("MaxDataExt = %v, want 90", stmt.Props.MaxDataExt)
+	}
+	if stmt.Props.DefaultDDLCol == nil || *stmt.Props.DefaultDDLCol != "en_US" {
+		t.Errorf("DefaultDDLCol = %v, want en_US", stmt.Props.DefaultDDLCol)
+	}
+	if stmt.Props.Comment == nil || *stmt.Props.Comment != "full test" {
+		t.Errorf("Comment = %v, want 'full test'", stmt.Props.Comment)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SCHEMA tests
+// ---------------------------------------------------------------------------
+
+func TestCreateSchema_Basic(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE SCHEMA myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected CreateSchemaStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "MYSCHEMA" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYSCHEMA")
+	}
+}
+
+func TestCreateSchema_OrReplace(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE OR REPLACE SCHEMA myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+}
+
+func TestCreateSchema_Transient(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE TRANSIENT SCHEMA myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Transient {
+		t.Error("expected Transient=true")
+	}
+}
+
+func TestCreateSchema_IfNotExists(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE SCHEMA IF NOT EXISTS myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+}
+
+func TestCreateSchema_WithClone(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE SCHEMA s2 CLONE s1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Clone == nil {
+		t.Fatal("expected Clone to be set")
+	}
+	if stmt.Clone.Source.Normalize() != "S1" {
+		t.Errorf("clone source = %q, want %q", stmt.Clone.Source.Normalize(), "S1")
+	}
+}
+
+func TestCreateSchema_ManagedAccess(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE SCHEMA myschema WITH MANAGED ACCESS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.ManagedAccess {
+		t.Error("expected ManagedAccess=true")
+	}
+}
+
+func TestCreateSchema_ManagedAccessWithProps(t *testing.T) {
+	stmt, errs := testParseCreateSchema(
+		"CREATE SCHEMA myschema WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.ManagedAccess {
+		t.Error("expected ManagedAccess=true")
+	}
+	if stmt.Props.DataRetention == nil || *stmt.Props.DataRetention != 7 {
+		t.Errorf("DataRetention = %v, want 7", stmt.Props.DataRetention)
+	}
+}
+
+func TestCreateSchema_WithTags(t *testing.T) {
+	stmt, errs := testParseCreateSchema(
+		"CREATE SCHEMA myschema WITH TAG (team = 'analytics')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Tags) != 1 {
+		t.Fatalf("tags = %d, want 1", len(stmt.Tags))
+	}
+	if stmt.Tags[0].Value != "analytics" {
+		t.Errorf("tag value = %q, want %q", stmt.Tags[0].Value, "analytics")
+	}
+}
+
+func TestCreateSchema_QualifiedName(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE SCHEMA mydb.myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB.MYSCHEMA")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER DATABASE tests
+// ---------------------------------------------------------------------------
+
+func TestAlterDatabase_RenameTo(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb RENAME TO newdb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected AlterDatabaseStmt, got nil")
+	}
+	if stmt.Action != ast.AlterDBRename {
+		t.Errorf("action = %v, want AlterDBRename", stmt.Action)
+	}
+	if stmt.Name.Normalize() != "MYDB" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB")
+	}
+	if stmt.NewName == nil || stmt.NewName.Normalize() != "NEWDB" {
+		t.Errorf("newName = %v, want NEWDB", stmt.NewName)
+	}
+}
+
+func TestAlterDatabase_SwapWith(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE db1 SWAP WITH db2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBSwap {
+		t.Errorf("action = %v, want AlterDBSwap", stmt.Action)
+	}
+	if stmt.NewName == nil || stmt.NewName.Normalize() != "DB2" {
+		t.Errorf("newName = %v, want DB2", stmt.NewName)
+	}
+}
+
+func TestAlterDatabase_SetComment(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb SET COMMENT = 'new comment'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBSet {
+		t.Errorf("action = %v, want AlterDBSet", stmt.Action)
+	}
+	if stmt.SetProps == nil {
+		t.Fatal("SetProps is nil")
+	}
+	if stmt.SetProps.Comment == nil || *stmt.SetProps.Comment != "new comment" {
+		t.Errorf("comment = %v, want 'new comment'", stmt.SetProps.Comment)
+	}
+}
+
+func TestAlterDatabase_SetDataRetention(t *testing.T) {
+	stmt, errs := testParseAlterDatabase(
+		"ALTER DATABASE mydb SET DATA_RETENTION_TIME_IN_DAYS = 14")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBSet {
+		t.Errorf("action = %v, want AlterDBSet", stmt.Action)
+	}
+	if stmt.SetProps.DataRetention == nil || *stmt.SetProps.DataRetention != 14 {
+		t.Errorf("DataRetention = %v, want 14", stmt.SetProps.DataRetention)
+	}
+}
+
+func TestAlterDatabase_SetTag(t *testing.T) {
+	stmt, errs := testParseAlterDatabase(
+		"ALTER DATABASE mydb SET TAG (env = 'production')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBSetTag {
+		t.Errorf("action = %v, want AlterDBSetTag", stmt.Action)
+	}
+	if len(stmt.Tags) != 1 {
+		t.Fatalf("tags = %d, want 1", len(stmt.Tags))
+	}
+	if stmt.Tags[0].Value != "production" {
+		t.Errorf("tag value = %q, want production", stmt.Tags[0].Value)
+	}
+}
+
+func TestAlterDatabase_UnsetComment(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb UNSET COMMENT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBUnset {
+		t.Errorf("action = %v, want AlterDBUnset", stmt.Action)
+	}
+	if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+		t.Errorf("UnsetProps = %v, want [COMMENT]", stmt.UnsetProps)
+	}
+}
+
+func TestAlterDatabase_UnsetMultiple(t *testing.T) {
+	stmt, errs := testParseAlterDatabase(
+		"ALTER DATABASE mydb UNSET DATA_RETENTION_TIME_IN_DAYS, COMMENT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBUnset {
+		t.Errorf("action = %v, want AlterDBUnset", stmt.Action)
+	}
+	if len(stmt.UnsetProps) != 2 {
+		t.Fatalf("UnsetProps = %d, want 2", len(stmt.UnsetProps))
+	}
+}
+
+func TestAlterDatabase_UnsetTag(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb UNSET TAG (env)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBUnsetTag {
+		t.Errorf("action = %v, want AlterDBUnsetTag", stmt.Action)
+	}
+	if len(stmt.UnsetTags) != 1 {
+		t.Fatalf("UnsetTags = %d, want 1", len(stmt.UnsetTags))
+	}
+}
+
+func TestAlterDatabase_IfExists(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE IF EXISTS mydb RENAME TO newdb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+func TestAlterDatabase_EnableReplication(t *testing.T) {
+	stmt, errs := testParseAlterDatabase(
+		"ALTER DATABASE mydb ENABLE REPLICATION TO ACCOUNTS org1.account1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBEnableReplication {
+		t.Errorf("action = %v, want AlterDBEnableReplication", stmt.Action)
+	}
+}
+
+func TestAlterDatabase_DisableReplication(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb DISABLE REPLICATION")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBDisableReplication {
+		t.Errorf("action = %v, want AlterDBDisableReplication", stmt.Action)
+	}
+}
+
+func TestAlterDatabase_Refresh(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb REFRESH")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBRefresh {
+		t.Errorf("action = %v, want AlterDBRefresh", stmt.Action)
+	}
+}
+
+func TestAlterDatabase_Primary(t *testing.T) {
+	stmt, errs := testParseAlterDatabase("ALTER DATABASE mydb PRIMARY")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterDBPrimary {
+		t.Errorf("action = %v, want AlterDBPrimary", stmt.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SCHEMA tests
+// ---------------------------------------------------------------------------
+
+func TestAlterSchema_RenameTo(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA s1 RENAME TO s2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected AlterSchemaStmt, got nil")
+	}
+	if stmt.Action != ast.AlterSchemaRename {
+		t.Errorf("action = %v, want AlterSchemaRename", stmt.Action)
+	}
+	if stmt.NewName == nil || stmt.NewName.Normalize() != "S2" {
+		t.Errorf("newName = %v, want S2", stmt.NewName)
+	}
+}
+
+func TestAlterSchema_SwapWith(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA s1 SWAP WITH s2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaSwap {
+		t.Errorf("action = %v, want AlterSchemaSwap", stmt.Action)
+	}
+}
+
+func TestAlterSchema_SetComment(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA myschema SET COMMENT = 'test schema'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaSet {
+		t.Errorf("action = %v, want AlterSchemaSet", stmt.Action)
+	}
+	if stmt.SetProps.Comment == nil || *stmt.SetProps.Comment != "test schema" {
+		t.Errorf("comment = %v", stmt.SetProps.Comment)
+	}
+}
+
+func TestAlterSchema_SetDataRetention(t *testing.T) {
+	stmt, errs := testParseAlterSchema(
+		"ALTER SCHEMA myschema SET DATA_RETENTION_TIME_IN_DAYS = 5")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaSet {
+		t.Errorf("action = %v, want AlterSchemaSet", stmt.Action)
+	}
+	if stmt.SetProps.DataRetention == nil || *stmt.SetProps.DataRetention != 5 {
+		t.Errorf("DataRetention = %v, want 5", stmt.SetProps.DataRetention)
+	}
+}
+
+func TestAlterSchema_UnsetComment(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA myschema UNSET COMMENT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaUnset {
+		t.Errorf("action = %v, want AlterSchemaUnset", stmt.Action)
+	}
+	if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+		t.Errorf("UnsetProps = %v, want [COMMENT]", stmt.UnsetProps)
+	}
+}
+
+func TestAlterSchema_SetTag(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA myschema SET TAG (env = 'dev')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaSetTag {
+		t.Errorf("action = %v, want AlterSchemaSetTag", stmt.Action)
+	}
+	if len(stmt.Tags) != 1 || stmt.Tags[0].Value != "dev" {
+		t.Errorf("Tags = %v", stmt.Tags)
+	}
+}
+
+func TestAlterSchema_UnsetTag(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA myschema UNSET TAG (env)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaUnsetTag {
+		t.Errorf("action = %v, want AlterSchemaUnsetTag", stmt.Action)
+	}
+	if len(stmt.UnsetTags) != 1 {
+		t.Fatalf("UnsetTags = %d, want 1", len(stmt.UnsetTags))
+	}
+}
+
+func TestAlterSchema_EnableManagedAccess(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA myschema ENABLE MANAGED ACCESS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaEnableManagedAccess {
+		t.Errorf("action = %v, want AlterSchemaEnableManagedAccess", stmt.Action)
+	}
+}
+
+func TestAlterSchema_DisableManagedAccess(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA myschema DISABLE MANAGED ACCESS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterSchemaDisableManagedAccess {
+		t.Errorf("action = %v, want AlterSchemaDisableManagedAccess", stmt.Action)
+	}
+}
+
+func TestAlterSchema_IfExists(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA IF EXISTS myschema RENAME TO newschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+func TestAlterSchema_QualifiedName(t *testing.T) {
+	stmt, errs := testParseAlterSchema("ALTER SCHEMA mydb.s1 RENAME TO mydb.s2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Name.Normalize() != "MYDB.S1" {
+		t.Errorf("name = %q, want MYDB.S1", stmt.Name.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP DATABASE tests
+// ---------------------------------------------------------------------------
+
+func TestDropDatabase_Basic(t *testing.T) {
+	stmt, errs := testParseDropDatabase("DROP DATABASE mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected DropDatabaseStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "MYDB" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB")
+	}
+	if stmt.IfExists {
+		t.Error("expected IfExists=false")
+	}
+	if stmt.Cascade {
+		t.Error("expected Cascade=false")
+	}
+	if stmt.Restrict {
+		t.Error("expected Restrict=false")
+	}
+}
+
+func TestDropDatabase_IfExists(t *testing.T) {
+	stmt, errs := testParseDropDatabase("DROP DATABASE IF EXISTS mydb")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+func TestDropDatabase_Cascade(t *testing.T) {
+	stmt, errs := testParseDropDatabase("DROP DATABASE mydb CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+}
+
+func TestDropDatabase_Restrict(t *testing.T) {
+	stmt, errs := testParseDropDatabase("DROP DATABASE mydb RESTRICT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Restrict {
+		t.Error("expected Restrict=true")
+	}
+}
+
+func TestDropDatabase_IfExistsCascade(t *testing.T) {
+	stmt, errs := testParseDropDatabase("DROP DATABASE IF EXISTS mydb CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP SCHEMA tests
+// ---------------------------------------------------------------------------
+
+func TestDropSchema_Basic(t *testing.T) {
+	stmt, errs := testParseDropSchema("DROP SCHEMA myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected DropSchemaStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "MYSCHEMA" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYSCHEMA")
+	}
+}
+
+func TestDropSchema_IfExists(t *testing.T) {
+	stmt, errs := testParseDropSchema("DROP SCHEMA IF EXISTS myschema")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+func TestDropSchema_Cascade(t *testing.T) {
+	stmt, errs := testParseDropSchema("DROP SCHEMA mydb.myschema CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA" {
+		t.Errorf("name = %q, want MYDB.MYSCHEMA", stmt.Name.Normalize())
+	}
+}
+
+func TestDropSchema_Restrict(t *testing.T) {
+	stmt, errs := testParseDropSchema("DROP SCHEMA myschema RESTRICT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Restrict {
+		t.Error("expected Restrict=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP DATABASE tests
+// ---------------------------------------------------------------------------
+
+func TestUndropDatabase_Basic(t *testing.T) {
+	result := ParseBestEffort("UNDROP DATABASE mydb")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected a statement")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.UndropDatabaseStmt)
+	if !ok {
+		t.Fatalf("expected *UndropDatabaseStmt, got %T", result.File.Stmts[0])
+	}
+	if stmt.Name.Normalize() != "MYDB" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB")
+	}
+}
+
+func TestUndropDatabase_Tag(t *testing.T) {
+	stmt, ok := ParseBestEffort("UNDROP DATABASE mydb").File.Stmts[0].(*ast.UndropDatabaseStmt)
+	if !ok {
+		t.Fatal("wrong node type")
+	}
+	if stmt.Tag() != ast.T_UndropDatabaseStmt {
+		t.Errorf("tag = %v, want T_UndropDatabaseStmt", stmt.Tag())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UNDROP SCHEMA tests
+// ---------------------------------------------------------------------------
+
+func TestUndropSchema_Basic(t *testing.T) {
+	result := ParseBestEffort("UNDROP SCHEMA myschema")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected a statement")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.UndropSchemaStmt)
+	if !ok {
+		t.Fatalf("expected *UndropSchemaStmt, got %T", result.File.Stmts[0])
+	}
+	if stmt.Name.Normalize() != "MYSCHEMA" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYSCHEMA")
+	}
+}
+
+func TestUndropSchema_QualifiedName(t *testing.T) {
+	result := ParseBestEffort("UNDROP SCHEMA mydb.myschema")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.UndropSchemaStmt)
+	if !ok {
+		t.Fatal("wrong node type")
+	}
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA" {
+		t.Errorf("name = %q, want MYDB.MYSCHEMA", stmt.Name.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NodeTag tests
+// ---------------------------------------------------------------------------
+
+func TestNodeTags_DatabaseSchema(t *testing.T) {
+	checks := []struct {
+		sql  string
+		want ast.NodeTag
+	}{
+		{"CREATE DATABASE d", ast.T_CreateDatabaseStmt},
+		{"CREATE SCHEMA s", ast.T_CreateSchemaStmt},
+		{"ALTER DATABASE d RENAME TO d2", ast.T_AlterDatabaseStmt},
+		{"ALTER SCHEMA s RENAME TO s2", ast.T_AlterSchemaStmt},
+		{"DROP DATABASE d", ast.T_DropDatabaseStmt},
+		{"DROP SCHEMA s", ast.T_DropSchemaStmt},
+		{"UNDROP DATABASE d", ast.T_UndropDatabaseStmt},
+		{"UNDROP SCHEMA s", ast.T_UndropSchemaStmt},
+	}
+
+	for _, c := range checks {
+		result := ParseBestEffort(c.sql)
+		if len(result.Errors) > 0 {
+			t.Errorf("sql=%q errors=%v", c.sql, result.Errors)
+			continue
+		}
+		if len(result.File.Stmts) == 0 {
+			t.Errorf("sql=%q: no statements", c.sql)
+			continue
+		}
+		got := result.File.Stmts[0].Tag()
+		if got != c.want {
+			t.Errorf("sql=%q: tag=%v, want %v", c.sql, got, c.want)
+		}
+	}
+}

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -185,11 +185,11 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwCREATE:
 		return p.parseCreateStmt()
 	case kwALTER:
-		return p.unsupported("ALTER")
+		return p.parseAlterStmt()
 	case kwDROP:
-		return p.unsupported("DROP")
+		return p.parseDropStmt()
 	case kwUNDROP:
-		return p.unsupported("UNDROP")
+		return p.parseUndropStmt()
 	case kwTRUNCATE:
 		return p.unsupported("TRUNCATE")
 	case kwCOMMENT:


### PR DESCRIPTION
## Summary

- Add 8 AST node types for DATABASE and SCHEMA DDL statements (`CreateDatabaseStmt`, `CreateSchemaStmt`, `AlterDatabaseStmt`, `AlterSchemaStmt`, `DropDatabaseStmt`, `DropSchemaStmt`, `UndropDatabaseStmt`, `UndropSchemaStmt`) with supporting enums (`AlterDatabaseAction`, `AlterSchemaAction`) and `DBSchemaProps` helper struct
- Implement parsers for all 8 statements in `snowflake/parser/database_schema.go`; extend the CREATE sub-dispatch with `kwDATABASE`/`kwSCHEMA` cases; replace the `ALTER`/`DROP`/`UNDROP` stubs in `parseStmt` with proper dispatchers that fall through to `unsupported()` for non-DATABASE/SCHEMA objects
- Add `database_schema_test.go` with 49 tests covering all statement variants

## What is covered

**CREATE DATABASE/SCHEMA:** `OR REPLACE`, `TRANSIENT`, `IF NOT EXISTS`, `CLONE [AT|BEFORE (...)]`, `WITH MANAGED ACCESS` (schema only), `DATA_RETENTION_TIME_IN_DAYS`, `MAX_DATA_EXTENSION_TIME_IN_DAYS`, `DEFAULT_DDL_COLLATION`, `COMMENT`, `WITH TAG`

**ALTER DATABASE/SCHEMA:** `RENAME TO`, `SWAP WITH`, `SET <props>`, `SET TAG`, `UNSET <props>`, `UNSET TAG`, `ENABLE/DISABLE MANAGED ACCESS` (schema), `ENABLE/DISABLE REPLICATION` (database), `ENABLE/DISABLE FAILOVER` (database), `REFRESH`, `PRIMARY`, with optional `IF EXISTS`

**DROP DATABASE/SCHEMA:** `IF EXISTS`, `CASCADE`, `RESTRICT`

**UNDROP DATABASE/SCHEMA:** simple name form with support for qualified names

## Test plan

- [x] `go test ./snowflake/... -count=1` passes (49 new tests, all green)
- [x] `gofmt -w snowflake/` applied
- [x] Walker regenerated via `go run ./snowflake/ast/cmd/genwalker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)