### PR TITLE
feat(doris): complete JOIN support — all 9 join types + hints (T1.5)

### DIFF
--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -89,21 +89,26 @@ var _ Node = (*TableRef)(nil)
 type JoinType int
 
 const (
-	JoinInner JoinType = iota // [INNER] JOIN
-	JoinLeft                  // LEFT [OUTER] JOIN
-	JoinRight                 // RIGHT [OUTER] JOIN
-	JoinFull                  // FULL [OUTER] JOIN
-	JoinCross                 // CROSS JOIN
+	JoinInner     JoinType = iota // [INNER] JOIN
+	JoinLeft                      // LEFT [OUTER] JOIN
+	JoinRight                     // RIGHT [OUTER] JOIN
+	JoinFull                      // FULL [OUTER] JOIN
+	JoinCross                     // CROSS JOIN
+	JoinLeftSemi                  // LEFT SEMI JOIN
+	JoinRightSemi                 // RIGHT SEMI JOIN
+	JoinLeftAnti                  // LEFT ANTI JOIN
+	JoinRightAnti                 // RIGHT ANTI JOIN
 )
 
 // JoinClause represents a JOIN expression in the FROM clause.
 type JoinClause struct {
 	Type    JoinType
-	Left    Node   // left side of the join
-	Right   Node   // right side of the join
-	Natural bool   // NATURAL join
-	On      Node   // ON condition (nil if absent)
+	Left    Node     // left side of the join
+	Right   Node     // right side of the join
+	Natural bool     // NATURAL join modifier
+	On      Node     // ON condition (nil if absent)
 	Using   []string // USING (col1, col2, ...) column names
+	Hints   []string // execution hints, e.g. [shuffle], [broadcast]
 	Loc     Loc
 }
 

--- a/doris/parser/joins_test.go
+++ b/doris/parser/joins_test.go
@@ -1,0 +1,439 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+// mustParseJoin parses input, expects exactly one FROM item which must be a
+// *ast.JoinClause, and returns it.
+func mustParseJoin(t *testing.T, input string) *ast.JoinClause {
+	t.Helper()
+	stmt := mustParseSelect(t, input)
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	join, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	return join
+}
+
+// joinTableName extracts the table name string from the left or right node of
+// a JoinClause (assuming it is a *ast.TableRef with a single-part name).
+func joinTableName(t *testing.T, n ast.Node) string {
+	t.Helper()
+	switch v := n.(type) {
+	case *ast.TableRef:
+		if len(v.Name.Parts) == 0 {
+			t.Fatal("TableRef.Name.Parts is empty")
+		}
+		return v.Name.Parts[len(v.Name.Parts)-1]
+	case *ast.JoinClause:
+		// For chained joins, return the tag description
+		return "(JoinClause)"
+	default:
+		t.Fatalf("unexpected node type %T", n)
+		return ""
+	}
+}
+
+// ---------------------------------------------------------------------------
+// INNER JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoinInnerExplicit(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a INNER JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinInner {
+		t.Errorf("join.Type = %v, want JoinInner", join.Type)
+	}
+	if joinTableName(t, join.Left) != "a" {
+		t.Errorf("left = %q, want %q", joinTableName(t, join.Left), "a")
+	}
+	if joinTableName(t, join.Right) != "b" {
+		t.Errorf("right = %q, want %q", joinTableName(t, join.Right), "b")
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+	if join.Natural {
+		t.Error("Natural = true, want false")
+	}
+}
+
+func TestJoinInnerImplicit(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinInner {
+		t.Errorf("join.Type = %v, want JoinInner", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LEFT JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoinLeft(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a LEFT JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join.Type = %v, want JoinLeft", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinLeftOuter(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join.Type = %v, want JoinLeft", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RIGHT JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoinRight(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a RIGHT JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinRight {
+		t.Errorf("join.Type = %v, want JoinRight", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinRightOuter(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a RIGHT OUTER JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinRight {
+		t.Errorf("join.Type = %v, want JoinRight", join.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FULL JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoinFullOuter(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a FULL OUTER JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinFull {
+		t.Errorf("join.Type = %v, want JoinFull", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinFull(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a FULL JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinFull {
+		t.Errorf("join.Type = %v, want JoinFull", join.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CROSS JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoinCross(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a CROSS JOIN b")
+	if join.Type != ast.JoinCross {
+		t.Errorf("join.Type = %v, want JoinCross", join.Type)
+	}
+	if join.On != nil {
+		t.Error("On should be nil for CROSS JOIN")
+	}
+	if len(join.Using) != 0 {
+		t.Error("Using should be empty for CROSS JOIN")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SEMI / ANTI joins
+// ---------------------------------------------------------------------------
+
+func TestJoinLeftSemi(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a LEFT SEMI JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinLeftSemi {
+		t.Errorf("join.Type = %v, want JoinLeftSemi", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinRightSemi(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a RIGHT SEMI JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinRightSemi {
+		t.Errorf("join.Type = %v, want JoinRightSemi", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinLeftAnti(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a LEFT ANTI JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinLeftAnti {
+		t.Errorf("join.Type = %v, want JoinLeftAnti", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinRightAnti(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a RIGHT ANTI JOIN b ON a.id = b.id")
+	if join.Type != ast.JoinRightAnti {
+		t.Errorf("join.Type = %v, want JoinRightAnti", join.Type)
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NATURAL JOIN
+// ---------------------------------------------------------------------------
+
+func TestJoinNatural(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a NATURAL JOIN b")
+	if join.Type != ast.JoinInner {
+		t.Errorf("join.Type = %v, want JoinInner (natural)", join.Type)
+	}
+	if !join.Natural {
+		t.Error("Natural = false, want true")
+	}
+	if join.On != nil {
+		t.Error("On should be nil for NATURAL JOIN")
+	}
+}
+
+func TestJoinNaturalLeft(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a NATURAL LEFT JOIN b")
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join.Type = %v, want JoinLeft", join.Type)
+	}
+	if !join.Natural {
+		t.Error("Natural = false, want true")
+	}
+}
+
+func TestJoinNaturalRight(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a NATURAL RIGHT JOIN b")
+	if join.Type != ast.JoinRight {
+		t.Errorf("join.Type = %v, want JoinRight", join.Type)
+	}
+	if !join.Natural {
+		t.Error("Natural = false, want true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// USING clause
+// ---------------------------------------------------------------------------
+
+func TestJoinUsingSingle(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a JOIN b USING (id)")
+	if join.Type != ast.JoinInner {
+		t.Errorf("join.Type = %v, want JoinInner", join.Type)
+	}
+	if len(join.Using) != 1 {
+		t.Fatalf("Using = %v, want 1 column", join.Using)
+	}
+	if join.Using[0] != "id" {
+		t.Errorf("Using[0] = %q, want %q", join.Using[0], "id")
+	}
+	if join.On != nil {
+		t.Error("On should be nil when USING is present")
+	}
+}
+
+func TestJoinUsingMultiple(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a JOIN b USING (id, name)")
+	if len(join.Using) != 2 {
+		t.Fatalf("Using = %v, want 2 columns", join.Using)
+	}
+	if join.Using[0] != "id" {
+		t.Errorf("Using[0] = %q, want %q", join.Using[0], "id")
+	}
+	if join.Using[1] != "name" {
+		t.Errorf("Using[1] = %q, want %q", join.Using[1], "name")
+	}
+}
+
+func TestJoinLeftUsing(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a LEFT JOIN b USING (id)")
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join.Type = %v, want JoinLeft", join.Type)
+	}
+	if len(join.Using) != 1 || join.Using[0] != "id" {
+		t.Errorf("Using = %v, want [id]", join.Using)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Chained joins
+// ---------------------------------------------------------------------------
+
+func TestJoinChainedTwoInner(t *testing.T) {
+	// SELECT * FROM a JOIN b ON a.id = b.id JOIN c ON b.id = c.id
+	// Expected: JoinClause( JoinClause(a, b, ON...), c, ON... )
+	stmt := mustParseSelect(t, "SELECT * FROM a JOIN b ON a.id = b.id JOIN c ON b.id = c.id")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	outerJoin, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	if outerJoin.Type != ast.JoinInner {
+		t.Errorf("outer join type = %v, want JoinInner", outerJoin.Type)
+	}
+	if joinTableName(t, outerJoin.Right) != "c" {
+		t.Errorf("outer right = %q, want %q", joinTableName(t, outerJoin.Right), "c")
+	}
+	if outerJoin.On == nil {
+		t.Error("outer join On = nil, want non-nil")
+	}
+
+	innerJoin, ok := outerJoin.Left.(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("outer.Left = %T, want *ast.JoinClause", outerJoin.Left)
+	}
+	if innerJoin.Type != ast.JoinInner {
+		t.Errorf("inner join type = %v, want JoinInner", innerJoin.Type)
+	}
+	if joinTableName(t, innerJoin.Left) != "a" {
+		t.Errorf("inner left = %q, want %q", joinTableName(t, innerJoin.Left), "a")
+	}
+	if joinTableName(t, innerJoin.Right) != "b" {
+		t.Errorf("inner right = %q, want %q", joinTableName(t, innerJoin.Right), "b")
+	}
+}
+
+func TestJoinChainedMixed(t *testing.T) {
+	// SELECT * FROM a LEFT JOIN b ON a.id = b.id JOIN c ON b.id = c.id
+	stmt := mustParseSelect(t, "SELECT * FROM a LEFT JOIN b ON a.id = b.id JOIN c ON b.id = c.id")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	outerJoin, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	if outerJoin.Type != ast.JoinInner {
+		t.Errorf("outer join type = %v, want JoinInner", outerJoin.Type)
+	}
+	if joinTableName(t, outerJoin.Right) != "c" {
+		t.Errorf("outer right = %q, want %q", joinTableName(t, outerJoin.Right), "c")
+	}
+
+	innerJoin, ok := outerJoin.Left.(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("outer.Left = %T, want *ast.JoinClause", outerJoin.Left)
+	}
+	if innerJoin.Type != ast.JoinLeft {
+		t.Errorf("inner join type = %v, want JoinLeft", innerJoin.Type)
+	}
+}
+
+func TestJoinChainedThree(t *testing.T) {
+	// Verify 3-way chain parses without error
+	stmt := mustParseSelect(t, "SELECT * FROM a JOIN b ON a.id = b.id LEFT JOIN c ON b.id = c.id CROSS JOIN d")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	outerJoin, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	if outerJoin.Type != ast.JoinCross {
+		t.Errorf("outermost join type = %v, want JoinCross", outerJoin.Type)
+	}
+	if joinTableName(t, outerJoin.Right) != "d" {
+		t.Errorf("outermost right = %q, want %q", joinTableName(t, outerJoin.Right), "d")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Execution hints
+// ---------------------------------------------------------------------------
+
+func TestJoinBroadcastHint(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a JOIN [broadcast] b ON a.id = b.id")
+	if join.Type != ast.JoinInner {
+		t.Errorf("join.Type = %v, want JoinInner", join.Type)
+	}
+	if len(join.Hints) == 0 {
+		t.Error("Hints should be non-empty for [broadcast]")
+	}
+	if join.Hints[0] != "broadcast" {
+		t.Errorf("Hints[0] = %q, want %q", join.Hints[0], "broadcast")
+	}
+	if join.On == nil {
+		t.Error("On = nil, want non-nil")
+	}
+}
+
+func TestJoinShuffleHint(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a LEFT JOIN [shuffle] b ON a.id = b.id")
+	if join.Type != ast.JoinLeft {
+		t.Errorf("join.Type = %v, want JoinLeft", join.Type)
+	}
+	if len(join.Hints) == 0 {
+		t.Error("Hints should be non-empty for [shuffle]")
+	}
+	if join.Hints[0] != "shuffle" {
+		t.Errorf("Hints[0] = %q, want %q", join.Hints[0], "shuffle")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ON condition detail
+// ---------------------------------------------------------------------------
+
+func TestJoinOnConditionBinary(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a JOIN b ON a.id = b.id")
+	binExpr, ok := join.On.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("On = %T, want *ast.BinaryExpr", join.On)
+	}
+	if binExpr.Op != ast.BinEq {
+		t.Errorf("On.Op = %v, want BinEq", binExpr.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node tag and loc
+// ---------------------------------------------------------------------------
+
+func TestJoinClauseTag(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM a JOIN b ON a.id = b.id")
+	if join.Tag() != ast.T_JoinClause {
+		t.Errorf("Tag() = %v, want T_JoinClause", join.Tag())
+	}
+}
+
+func TestJoinClauseLoc(t *testing.T) {
+	input := "SELECT * FROM a JOIN b ON a.id = b.id"
+	join := mustParseJoin(t, input)
+	if join.Loc.Start < 0 {
+		t.Errorf("Loc.Start = %d, want >= 0", join.Loc.Start)
+	}
+	if join.Loc.End <= join.Loc.Start {
+		t.Errorf("Loc.End = %d, want > Start (%d)", join.Loc.End, join.Loc.Start)
+	}
+}

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -443,6 +443,9 @@ func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
 			break
 		}
 
+		// Skip optional Doris execution hints: [shuffle], [broadcast], etc.
+		hints := p.parseJoinHints()
+
 		right, err := p.parsePrimarySource()
 		if err != nil {
 			return nil, err
@@ -453,6 +456,7 @@ func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
 			Left:    left,
 			Right:   right,
 			Natural: natural,
+			Hints:   hints,
 			Loc:     ast.Loc{Start: ast.NodeLoc(left).Start},
 		}
 
@@ -500,6 +504,29 @@ func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
 	return left, nil
 }
 
+// parseJoinHints skips any Doris execution hint between join keywords and
+// the right-side table reference. Hints have the form [identifier] or
+// /*+ identifier */ (comment-style). Only bracket-style is handled here.
+// Returns the consumed hint identifiers (may be empty).
+func (p *Parser) parseJoinHints() []string {
+	var hints []string
+	for p.cur.Kind == int('[') {
+		p.advance() // consume '['
+		// Collect tokens until ']'
+		for p.cur.Kind != int(']') && p.cur.Kind != tokEOF {
+			if p.cur.Kind == tokIdent || p.cur.Kind == tokQuotedIdent ||
+				(p.cur.Kind >= 700) {
+				hints = append(hints, p.cur.Str)
+			}
+			p.advance()
+		}
+		if p.cur.Kind == int(']') {
+			p.advance() // consume ']'
+		}
+	}
+	return hints
+}
+
 // parseJoinKeywords checks whether the current token position starts a
 // JOIN keyword sequence. If so, it consumes the tokens and returns
 // (joinType, natural, true). If not, returns (0, false, false)
@@ -532,10 +559,27 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool) {
 		return 0, false, false
 	}
 
-	// LEFT [OUTER] JOIN
+	// LEFT variants: LEFT [OUTER] JOIN | LEFT SEMI JOIN | LEFT ANTI JOIN
 	if p.cur.Kind == kwLEFT {
 		next := p.peekNext()
-		if next.Kind == kwJOIN || next.Kind == kwOUTER {
+		switch next.Kind {
+		case kwSEMI:
+			p.advance() // consume LEFT
+			p.advance() // consume SEMI
+			if p.cur.Kind != kwJOIN {
+				return 0, false, false
+			}
+			p.advance() // consume JOIN
+			return ast.JoinLeftSemi, false, true
+		case kwANTI:
+			p.advance() // consume LEFT
+			p.advance() // consume ANTI
+			if p.cur.Kind != kwJOIN {
+				return 0, false, false
+			}
+			p.advance() // consume JOIN
+			return ast.JoinLeftAnti, false, true
+		case kwJOIN, kwOUTER:
 			jt := p.consumeDirectionAndJoin()
 			if jt == ast.JoinLeft {
 				return jt, false, true
@@ -544,10 +588,27 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool) {
 		return 0, false, false
 	}
 
-	// RIGHT [OUTER] JOIN
+	// RIGHT variants: RIGHT [OUTER] JOIN | RIGHT SEMI JOIN | RIGHT ANTI JOIN
 	if p.cur.Kind == kwRIGHT {
 		next := p.peekNext()
-		if next.Kind == kwJOIN || next.Kind == kwOUTER {
+		switch next.Kind {
+		case kwSEMI:
+			p.advance() // consume RIGHT
+			p.advance() // consume SEMI
+			if p.cur.Kind != kwJOIN {
+				return 0, false, false
+			}
+			p.advance() // consume JOIN
+			return ast.JoinRightSemi, false, true
+		case kwANTI:
+			p.advance() // consume RIGHT
+			p.advance() // consume ANTI
+			if p.cur.Kind != kwJOIN {
+				return 0, false, false
+			}
+			p.advance() // consume JOIN
+			return ast.JoinRightAnti, false, true
+		case kwJOIN, kwOUTER:
 			jt := p.consumeDirectionAndJoin()
 			if jt == ast.JoinRight {
 				return jt, false, true


### PR DESCRIPTION
## Summary
- Enhance JoinClause with all 9 join types: INNER, LEFT/RIGHT/FULL [OUTER], CROSS, LEFT/RIGHT SEMI, LEFT/RIGHT ANTI
- NATURAL join modifier
- ON/USING conditions
- Doris execution hints (bracket-style: `[shuffle]`, `[broadcast]`)
- Chained (left-associative) joins
- 27 unit tests

DAG: T1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)