### PR TITLE
feat(doris): WITH common table expressions (T1.6)

### DIFF
--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -66,6 +66,10 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *OrderByItem:
 		return v.Loc
+	case *WithClause:
+		return v.Loc
+	case *CTE:
+		return v.Loc
 	case *SelectStmt:
 		return v.Loc
 	case *SelectItem:

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -104,6 +104,14 @@ const (
 	// T_OrderByItem is the tag for *OrderByItem (expr ASC/DESC NULLS FIRST/LAST).
 	T_OrderByItem
 
+	// CTE / WITH clause nodes (T1.6).
+
+	// T_WithClause is the tag for *WithClause.
+	T_WithClause
+
+	// T_CTE is the tag for *CTE (one named CTE entry inside a WITH clause).
+	T_CTE
+
 	// SELECT statement nodes (T1.4).
 
 	// T_SelectStmt is the tag for *SelectStmt.
@@ -212,6 +220,10 @@ func (t NodeTag) String() string {
 		return "IntervalExpr"
 	case T_OrderByItem:
 		return "OrderByItem"
+	case T_WithClause:
+		return "WithClause"
+	case T_CTE:
+		return "CTE"
 	case T_SelectStmt:
 		return "SelectStmt"
 	case T_SelectItem:

--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -6,8 +6,41 @@ package ast
 // SELECT statement
 // ---------------------------------------------------------------------------
 
+// WithClause represents a WITH clause preceding a SELECT statement.
+//
+//	WITH [RECURSIVE] cte_name [(col1, col2, ...)] AS (query)
+//	  [, cte_name2 AS (query2)]
+type WithClause struct {
+	Recursive bool   // RECURSIVE keyword present
+	CTEs      []*CTE // one or more CTE definitions
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *WithClause) Tag() NodeTag { return T_WithClause }
+
+// Compile-time assertion that *WithClause satisfies Node.
+var _ Node = (*WithClause)(nil)
+
+// CTE is one named entry in a WITH clause:
+//
+//	cte_name [(col1, col2, ...)] AS (query)
+type CTE struct {
+	Name    string   // the CTE alias name
+	Columns []string // optional column aliases; nil/empty if not specified
+	Query   Node     // the inner SELECT statement (*SelectStmt)
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *CTE) Tag() NodeTag { return T_CTE }
+
+// Compile-time assertion that *CTE satisfies Node.
+var _ Node = (*CTE)(nil)
+
 // SelectStmt represents a full SELECT statement.
 //
+//	[WITH [RECURSIVE] cte ...]
 //	SELECT [DISTINCT|ALL] select_list
 //	  [FROM table_references]
 //	  [WHERE condition]
@@ -17,6 +50,7 @@ package ast
 //	  [ORDER BY expr [ASC|DESC] [NULLS FIRST|LAST], ...]
 //	  [LIMIT count [OFFSET offset]]
 type SelectStmt struct {
+	With     *WithClause   // optional WITH clause (nil if absent)
 	Distinct bool          // DISTINCT keyword present
 	All      bool          // ALL keyword present (explicit, rarely used)
 	Items    []*SelectItem // SELECT list

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -109,8 +109,21 @@ func walkChildren(v Visitor, node Node) {
 	case *OrderByItem:
 		Walk(v, n.Expr)
 
+	// CTE / WITH clause nodes (T1.6).
+	case *WithClause:
+		for _, cte := range n.CTEs {
+			Walk(v, cte)
+		}
+	case *CTE:
+		if n.Query != nil {
+			Walk(v, n.Query)
+		}
+
 	// SELECT statement nodes (T1.4).
 	case *SelectStmt:
+		if n.With != nil {
+			Walk(v, n.With)
+		}
 		for _, item := range n.Items {
 			Walk(v, item)
 		}

--- a/doris/parser/ctes.go
+++ b/doris/parser/ctes.go
@@ -1,0 +1,136 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// ---------------------------------------------------------------------------
+// WITH / CTE parsing (T1.6)
+// ---------------------------------------------------------------------------
+
+// parseWithSelect parses a WITH clause followed by a SELECT statement:
+//
+//	WITH [RECURSIVE] cte_name [(col, ...)] AS (query)
+//	  [, cte_name2 [(col, ...)] AS (query2)]
+//	SELECT ...
+//
+// The WITH keyword has NOT yet been consumed when this is called.
+func (p *Parser) parseWithSelect() (*ast.SelectStmt, error) {
+	withTok, err := p.expect(kwWITH)
+	if err != nil {
+		return nil, err
+	}
+
+	with := &ast.WithClause{
+		Loc: ast.Loc{Start: withTok.Loc.Start},
+	}
+
+	// Optional RECURSIVE keyword.
+	if p.cur.Kind == kwRECURSIVE {
+		p.advance()
+		with.Recursive = true
+	}
+
+	// Parse comma-separated CTE definitions.
+	cte, err := p.parseCTE()
+	if err != nil {
+		return nil, err
+	}
+	with.CTEs = append(with.CTEs, cte)
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		cte, err = p.parseCTE()
+		if err != nil {
+			return nil, err
+		}
+		with.CTEs = append(with.CTEs, cte)
+	}
+
+	with.Loc.End = p.prev.Loc.End
+
+	// The trailing SELECT statement (WITH must be followed by SELECT).
+	stmt, err := p.parseSelectStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	// Attach the WITH clause and extend the overall Loc to cover WITH.
+	stmt.With = with
+	stmt.Loc.Start = withTok.Loc.Start
+
+	return stmt, nil
+}
+
+// parseCTE parses one CTE definition:
+//
+//	cte_name [(col1, col2, ...)] AS ( query )
+func (p *Parser) parseCTE() (*ast.CTE, error) {
+	startLoc := p.cur.Loc
+
+	// CTE name — must be a plain or quoted identifier.
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	cte := &ast.CTE{
+		Name: name,
+		Loc:  ast.Loc{Start: startLoc.Start},
+	}
+
+	// Optional column list: (col1, col2, ...)
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+
+		colName, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		cte.Columns = append(cte.Columns, colName)
+
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			colName, _, err = p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			cte.Columns = append(cte.Columns, colName)
+		}
+
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+	}
+
+	// AS keyword.
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+
+	// Opening paren of the inner query.
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// Inner SELECT statement. If it starts with WITH, recurse; otherwise parse
+	// a plain SELECT.
+	var innerStmt ast.Node
+	if p.cur.Kind == kwWITH {
+		innerStmt, err = p.parseWithSelect()
+	} else {
+		innerStmt, err = p.parseSelectStmt()
+	}
+	if err != nil {
+		return nil, err
+	}
+	cte.Query = innerStmt
+
+	// Closing paren.
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	cte.Loc.End = p.prev.Loc.End
+	return cte, nil
+}

--- a/doris/parser/ctes_test.go
+++ b/doris/parser/ctes_test.go
@@ -1,0 +1,265 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// mustParseWithSelect parses input and returns the first statement as
+// *ast.SelectStmt, asserting that it has a non-nil With field.
+func mustParseWithSelect(t *testing.T, input string) *ast.SelectStmt {
+	t.Helper()
+	file, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("Parse(%q) errors: %v", input, errs)
+	}
+	if len(file.Stmts) == 0 {
+		t.Fatalf("Parse(%q) returned no statements", input)
+	}
+	stmt, ok := file.Stmts[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Parse(%q) got %T, want *ast.SelectStmt", input, file.Stmts[0])
+	}
+	if stmt.With == nil {
+		t.Fatalf("Parse(%q) stmt.With = nil, want non-nil", input)
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// Basic single CTE
+// ---------------------------------------------------------------------------
+
+func TestCTEBasic(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH c AS (SELECT 1) SELECT * FROM c")
+	with := stmt.With
+
+	if with.Recursive {
+		t.Error("Recursive = true, want false")
+	}
+	if len(with.CTEs) != 1 {
+		t.Fatalf("CTEs = %d, want 1", len(with.CTEs))
+	}
+
+	cte := with.CTEs[0]
+	if cte.Name != "c" {
+		t.Errorf("CTE[0].Name = %q, want %q", cte.Name, "c")
+	}
+	if len(cte.Columns) != 0 {
+		t.Errorf("CTE[0].Columns = %v, want empty", cte.Columns)
+	}
+	if cte.Query == nil {
+		t.Fatal("CTE[0].Query = nil, want non-nil")
+	}
+	innerStmt, ok := cte.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("CTE[0].Query = %T, want *ast.SelectStmt", cte.Query)
+	}
+	if len(innerStmt.Items) != 1 {
+		t.Fatalf("inner SELECT items = %d, want 1", len(innerStmt.Items))
+	}
+
+	// Outer SELECT should reference FROM c
+	if len(stmt.From) != 1 {
+		t.Fatalf("outer FROM = %d, want 1", len(stmt.From))
+	}
+	tbl, ok := stmt.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("outer FROM[0] = %T, want *ast.TableRef", stmt.From[0])
+	}
+	if tbl.Name.Parts[0] != "c" {
+		t.Errorf("outer FROM[0].Name = %q, want %q", tbl.Name.Parts[0], "c")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CTE with single column alias
+// ---------------------------------------------------------------------------
+
+func TestCTEWithSingleColumnAlias(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH c(x) AS (SELECT 1) SELECT * FROM c")
+	cte := stmt.With.CTEs[0]
+
+	if cte.Name != "c" {
+		t.Errorf("CTE.Name = %q, want %q", cte.Name, "c")
+	}
+	if len(cte.Columns) != 1 {
+		t.Fatalf("CTE.Columns = %v, want [x]", cte.Columns)
+	}
+	if cte.Columns[0] != "x" {
+		t.Errorf("CTE.Columns[0] = %q, want %q", cte.Columns[0], "x")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CTE with multiple column aliases
+// ---------------------------------------------------------------------------
+
+func TestCTEWithMultipleColumnAliases(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH c(x, y) AS (SELECT 1, 2) SELECT * FROM c")
+	cte := stmt.With.CTEs[0]
+
+	if len(cte.Columns) != 2 {
+		t.Fatalf("CTE.Columns = %v, want [x y]", cte.Columns)
+	}
+	if cte.Columns[0] != "x" {
+		t.Errorf("CTE.Columns[0] = %q, want %q", cte.Columns[0], "x")
+	}
+	if cte.Columns[1] != "y" {
+		t.Errorf("CTE.Columns[1] = %q, want %q", cte.Columns[1], "y")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple CTEs
+// ---------------------------------------------------------------------------
+
+func TestCTEMultiple(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH c1 AS (SELECT 1), c2 AS (SELECT 2) SELECT * FROM c1, c2")
+	with := stmt.With
+
+	if len(with.CTEs) != 2 {
+		t.Fatalf("CTEs = %d, want 2", len(with.CTEs))
+	}
+	if with.CTEs[0].Name != "c1" {
+		t.Errorf("CTE[0].Name = %q, want %q", with.CTEs[0].Name, "c1")
+	}
+	if with.CTEs[1].Name != "c2" {
+		t.Errorf("CTE[1].Name = %q, want %q", with.CTEs[1].Name, "c2")
+	}
+
+	// Outer SELECT should have two FROM items
+	if len(stmt.From) != 2 {
+		t.Fatalf("outer FROM = %d, want 2", len(stmt.From))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RECURSIVE keyword
+// ---------------------------------------------------------------------------
+
+func TestCTERecursive(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH RECURSIVE c AS (SELECT 1) SELECT * FROM c")
+	if !stmt.With.Recursive {
+		t.Error("Recursive = false, want true")
+	}
+	if len(stmt.With.CTEs) != 1 {
+		t.Fatalf("CTEs = %d, want 1", len(stmt.With.CTEs))
+	}
+	if stmt.With.CTEs[0].Name != "c" {
+		t.Errorf("CTE.Name = %q, want %q", stmt.With.CTEs[0].Name, "c")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Complex CTE
+// ---------------------------------------------------------------------------
+
+func TestCTEComplex(t *testing.T) {
+	sql := `WITH sales AS (SELECT product, SUM(qty) FROM orders GROUP BY product) SELECT * FROM sales WHERE product > 10`
+	stmt := mustParseWithSelect(t, sql)
+
+	with := stmt.With
+	if len(with.CTEs) != 1 {
+		t.Fatalf("CTEs = %d, want 1", len(with.CTEs))
+	}
+
+	cte := with.CTEs[0]
+	if cte.Name != "sales" {
+		t.Errorf("CTE.Name = %q, want %q", cte.Name, "sales")
+	}
+
+	innerStmt, ok := cte.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("CTE.Query = %T, want *ast.SelectStmt", cte.Query)
+	}
+	// Inner SELECT should have 2 items: product, SUM(qty)
+	if len(innerStmt.Items) != 2 {
+		t.Fatalf("inner SELECT items = %d, want 2", len(innerStmt.Items))
+	}
+	// Inner SELECT should have GROUP BY
+	if len(innerStmt.GroupBy) != 1 {
+		t.Fatalf("inner GROUP BY = %d, want 1", len(innerStmt.GroupBy))
+	}
+
+	// Outer SELECT: FROM sales WHERE product > 10
+	if len(stmt.From) != 1 {
+		t.Fatalf("outer FROM = %d, want 1", len(stmt.From))
+	}
+	if stmt.Where == nil {
+		t.Fatal("outer WHERE = nil, want non-nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node tag verification
+// ---------------------------------------------------------------------------
+
+func TestCTENodeTags(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH c AS (SELECT 1) SELECT * FROM c")
+
+	if stmt.With.Tag() != ast.T_WithClause {
+		t.Errorf("WithClause.Tag() = %v, want T_WithClause", stmt.With.Tag())
+	}
+	if stmt.With.CTEs[0].Tag() != ast.T_CTE {
+		t.Errorf("CTE.Tag() = %v, want T_CTE", stmt.With.CTEs[0].Tag())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc verification
+// ---------------------------------------------------------------------------
+
+func TestCTELoc(t *testing.T) {
+	input := "WITH c AS (SELECT 1) SELECT * FROM c"
+	stmt := mustParseWithSelect(t, input)
+
+	// The SelectStmt Loc should start at the WITH token (offset 0).
+	if stmt.Loc.Start != 0 {
+		t.Errorf("SelectStmt.Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("SelectStmt.Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+
+	// The WithClause Loc should also start at 0.
+	if stmt.With.Loc.Start != 0 {
+		t.Errorf("WithClause.Loc.Start = %d, want 0", stmt.With.Loc.Start)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk visits CTE children
+// ---------------------------------------------------------------------------
+
+func TestCTEWalk(t *testing.T) {
+	stmt := mustParseWithSelect(t, "WITH c AS (SELECT 1) SELECT * FROM c")
+
+	var visited []ast.NodeTag
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if n != nil {
+			visited = append(visited, n.Tag())
+		}
+		return true
+	})
+
+	found := func(tag ast.NodeTag) bool {
+		for _, v := range visited {
+			if v == tag {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !found(ast.T_WithClause) {
+		t.Error("Walk did not visit T_WithClause")
+	}
+	if !found(ast.T_CTE) {
+		t.Error("Walk did not visit T_CTE")
+	}
+	if !found(ast.T_SelectStmt) {
+		t.Error("Walk did not visit T_SelectStmt")
+	}
+}

--- a/doris/parser/keywords.go
+++ b/doris/parser/keywords.go
@@ -385,6 +385,7 @@ const (
 	kwREBALANCE
 	kwRECENT
 	kwRECOVER
+	kwRECURSIVE
 	kwRECYCLE
 	kwREFERENCES
 	kwREFRESH
@@ -922,6 +923,7 @@ var keywordMap = map[string]TokenKind{
 	"rebalance":                            kwREBALANCE,
 	"recent":                               kwRECENT,
 	"recover":                              kwRECOVER,
+	"recursive":                            kwRECURSIVE,
 	"recycle":                              kwRECYCLE,
 	"references":                           kwREFERENCES,
 	"refresh":                              kwREFRESH,
@@ -1331,6 +1333,7 @@ var nonReservedKeywords = map[TokenKind]bool{
 	kwRANDOM:                 true,
 	kwRECENT:                 true,
 	kwRECOVER:                true,
+	kwRECURSIVE:              true,
 	kwRECYCLE:                true,
 	kwREFRESH:                true,
 	kwREPEATABLE:             true,

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -209,7 +209,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwSELECT:
 		return p.parseSelectStmt()
 	case kwWITH:
-		return p.unsupported("WITH")
+		return p.parseWithSelect()
 	case kwINSERT:
 		return p.unsupported("INSERT")
 	case kwUPDATE:


### PR DESCRIPTION
## Summary
- Add WithClause and CTE AST nodes
- SelectStmt gets optional With field
- Parse WITH [RECURSIVE] name [(cols)] AS (query), ... SELECT ...
- Inner CTE queries are fully parsed as SelectStmt (not raw text)
- 9 unit tests

DAG: T1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)