### PR TITLE
feat(doris): set operators — UNION/INTERSECT/EXCEPT/MINUS (T1.7)

### DIFF
--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -74,6 +74,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *JoinClause:
 		return v.Loc
+	case *SetOpStmt:
+		return v.Loc
 	case *CreateTableStmt:
 		return v.Loc
 	case *ColumnDef:

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -118,6 +118,9 @@ const (
 	// T_JoinClause is the tag for *JoinClause (JOIN expression in FROM).
 	T_JoinClause
 
+	// T_SetOpStmt is the tag for *SetOpStmt (UNION/INTERSECT/EXCEPT/MINUS).
+	T_SetOpStmt
+
 	// DDL — CREATE TABLE nodes (T2.1).
 
 	// T_CreateTableStmt is the tag for *CreateTableStmt.
@@ -220,6 +223,8 @@ func (t NodeTag) String() string {
 		return "TableRef"
 	case T_JoinClause:
 		return "JoinClause"
+	case T_SetOpStmt:
+		return "SetOpStmt"
 	case T_CreateTableStmt:
 		return "CreateTableStmt"
 	case T_ColumnDef:

--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -112,3 +112,36 @@ func (n *JoinClause) Tag() NodeTag { return T_JoinClause }
 
 // Compile-time assertion that *JoinClause satisfies Node.
 var _ Node = (*JoinClause)(nil)
+
+// ---------------------------------------------------------------------------
+// Set operation (UNION / INTERSECT / EXCEPT / MINUS) — T1.7
+// ---------------------------------------------------------------------------
+
+// SetOperator represents the type of set operation.
+type SetOperator int
+
+const (
+	SetUnion     SetOperator = iota // UNION
+	SetIntersect                    // INTERSECT
+	SetExcept                       // EXCEPT / MINUS
+)
+
+// SetOpStmt represents a set operation between two queries.
+//
+//	left UNION [ALL|DISTINCT] right
+//	left INTERSECT [ALL|DISTINCT] right
+//	left EXCEPT [ALL|DISTINCT] right
+//	left MINUS [ALL|DISTINCT] right  -- MINUS is an alias for EXCEPT in Doris
+type SetOpStmt struct {
+	Op    SetOperator // the set operator
+	All   bool        // true for ALL quantifier; false means DISTINCT (the default)
+	Left  Node        // SelectStmt or another SetOpStmt
+	Right Node        // SelectStmt or another SetOpStmt
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *SetOpStmt) Tag() NodeTag { return T_SetOpStmt }
+
+// Compile-time assertion that *SetOpStmt satisfies Node.
+var _ Node = (*SetOpStmt)(nil)

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -151,6 +151,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.On != nil {
 			Walk(v, n.On)
 		}
+	case *SetOpStmt:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
 
 	// DDL — CREATE TABLE nodes (T2.1).
 	case *CreateTableStmt:

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -207,7 +207,11 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// DML
 	case kwSELECT:
-		return p.parseSelectStmt()
+		left, err := p.parseSelectStmt()
+		if err != nil {
+			return nil, err
+		}
+		return p.parseSetOpTail(left)
 	case kwWITH:
 		return p.unsupported("WITH")
 	case kwINSERT:

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -123,6 +123,112 @@ func (p *Parser) parseSelectStmt() (*ast.SelectStmt, error) {
 }
 
 // ---------------------------------------------------------------------------
+// Set operations (UNION / INTERSECT / EXCEPT / MINUS) — T1.7
+// ---------------------------------------------------------------------------
+
+// parseSetOpTail checks whether the token stream continues with a set
+// operator (UNION, INTERSECT, EXCEPT, MINUS). If so, it loops consuming
+// set-op tokens and building a left-associative SetOpStmt tree.
+//
+// Precedence note: The SQL standard gives INTERSECT higher precedence than
+// UNION/EXCEPT. This implementation uses a two-level loop:
+//
+//  1. An inner loop collects a chain of INTERSECT clauses (higher priority).
+//  2. An outer loop then folds UNION/EXCEPT operators at lower priority.
+//
+// This matches Doris/MySQL behaviour where INTERSECT binds more tightly.
+func (p *Parser) parseSetOpTail(left ast.Node) (ast.Node, error) {
+	// Collect the left side of any pending UNION/EXCEPT operation, starting
+	// by giving INTERSECT first crack.
+	left, err := p.parseIntersectChain(left)
+	if err != nil {
+		return nil, err
+	}
+
+	// Outer loop: UNION / EXCEPT (including MINUS alias) – left-associative.
+	for {
+		var op ast.SetOperator
+		switch p.cur.Kind {
+		case kwUNION:
+			op = ast.SetUnion
+		case kwEXCEPT, kwMINUS:
+			op = ast.SetExcept
+		default:
+			return left, nil
+		}
+
+		opTok := p.advance() // consume UNION / EXCEPT / MINUS
+		_ = opTok
+
+		// Optional ALL / DISTINCT quantifier
+		all := false
+		if p.cur.Kind == kwALL {
+			p.advance()
+			all = true
+		} else if p.cur.Kind == kwDISTINCT {
+			p.advance()
+			// DISTINCT is the default — all stays false
+		}
+
+		// Parse the right-hand side: must start with SELECT.
+		if p.cur.Kind != kwSELECT {
+			return nil, p.syntaxErrorAtCur()
+		}
+		rightSelect, err := p.parseSelectStmt()
+		if err != nil {
+			return nil, err
+		}
+		// Give INTERSECT a chance to grab more operands on the right.
+		right, err := p.parseIntersectChain(rightSelect)
+		if err != nil {
+			return nil, err
+		}
+
+		left = &ast.SetOpStmt{
+			Op:    op,
+			All:   all,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(right).End},
+		}
+	}
+}
+
+// parseIntersectChain collects a left-associative chain of INTERSECT clauses
+// starting from an already-parsed left node.
+func (p *Parser) parseIntersectChain(left ast.Node) (ast.Node, error) {
+	for p.cur.Kind == kwINTERSECT {
+		p.advance() // consume INTERSECT
+
+		// Optional ALL / DISTINCT quantifier
+		all := false
+		if p.cur.Kind == kwALL {
+			p.advance()
+			all = true
+		} else if p.cur.Kind == kwDISTINCT {
+			p.advance()
+		}
+
+		if p.cur.Kind != kwSELECT {
+			return nil, p.syntaxErrorAtCur()
+		}
+		right, err := p.parseSelectStmt()
+		if err != nil {
+			return nil, err
+		}
+
+		left = &ast.SetOpStmt{
+			Op:    ast.SetIntersect,
+			All:   all,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(right).End},
+		}
+	}
+	return left, nil
+}
+
+// ---------------------------------------------------------------------------
 // SELECT list
 // ---------------------------------------------------------------------------
 

--- a/doris/parser/setops_test.go
+++ b/doris/parser/setops_test.go
@@ -1,0 +1,279 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// mustParseSetOp parses input and returns the first statement as *ast.SetOpStmt.
+func mustParseSetOp(t *testing.T, input string) *ast.SetOpStmt {
+	t.Helper()
+	file, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("Parse(%q) errors: %v", input, errs)
+	}
+	if len(file.Stmts) == 0 {
+		t.Fatalf("Parse(%q) returned no statements", input)
+	}
+	stmt, ok := file.Stmts[0].(*ast.SetOpStmt)
+	if !ok {
+		t.Fatalf("Parse(%q) got %T, want *ast.SetOpStmt", input, file.Stmts[0])
+	}
+	return stmt
+}
+
+// assertSelectItems is a helper that asserts a node is a *ast.SelectStmt with
+// the given number of items and that the first item has the expected expression
+// column name or literal value.
+func assertIsSelectStmt(t *testing.T, n ast.Node, label string) *ast.SelectStmt {
+	t.Helper()
+	sel, ok := n.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("%s: got %T, want *ast.SelectStmt", label, n)
+	}
+	return sel
+}
+
+// ---------------------------------------------------------------------------
+// UNION
+// ---------------------------------------------------------------------------
+
+func TestUnionBasic(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 UNION SELECT a FROM t2")
+
+	if stmt.Op != ast.SetUnion {
+		t.Errorf("Op = %v, want SetUnion", stmt.Op)
+	}
+	if stmt.All {
+		t.Error("All = true, want false (DISTINCT is default)")
+	}
+	assertIsSelectStmt(t, stmt.Left, "Left")
+	assertIsSelectStmt(t, stmt.Right, "Right")
+}
+
+func TestUnionAll(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 UNION ALL SELECT a FROM t2")
+
+	if stmt.Op != ast.SetUnion {
+		t.Errorf("Op = %v, want SetUnion", stmt.Op)
+	}
+	if !stmt.All {
+		t.Error("All = false, want true")
+	}
+	assertIsSelectStmt(t, stmt.Left, "Left")
+	assertIsSelectStmt(t, stmt.Right, "Right")
+}
+
+func TestUnionDistinct(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 UNION DISTINCT SELECT a FROM t2")
+
+	if stmt.Op != ast.SetUnion {
+		t.Errorf("Op = %v, want SetUnion", stmt.Op)
+	}
+	if stmt.All {
+		t.Error("All = true, want false for DISTINCT")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// INTERSECT
+// ---------------------------------------------------------------------------
+
+func TestIntersectBasic(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 INTERSECT SELECT a FROM t2")
+
+	if stmt.Op != ast.SetIntersect {
+		t.Errorf("Op = %v, want SetIntersect", stmt.Op)
+	}
+	if stmt.All {
+		t.Error("All = true, want false")
+	}
+	assertIsSelectStmt(t, stmt.Left, "Left")
+	assertIsSelectStmt(t, stmt.Right, "Right")
+}
+
+func TestIntersectAll(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 INTERSECT ALL SELECT a FROM t2")
+
+	if stmt.Op != ast.SetIntersect {
+		t.Errorf("Op = %v, want SetIntersect", stmt.Op)
+	}
+	if !stmt.All {
+		t.Error("All = false, want true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXCEPT
+// ---------------------------------------------------------------------------
+
+func TestExceptBasic(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 EXCEPT SELECT a FROM t2")
+
+	if stmt.Op != ast.SetExcept {
+		t.Errorf("Op = %v, want SetExcept", stmt.Op)
+	}
+	if stmt.All {
+		t.Error("All = true, want false")
+	}
+	assertIsSelectStmt(t, stmt.Left, "Left")
+	assertIsSelectStmt(t, stmt.Right, "Right")
+}
+
+func TestExceptAll(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 EXCEPT ALL SELECT a FROM t2")
+
+	if stmt.Op != ast.SetExcept {
+		t.Errorf("Op = %v, want SetExcept", stmt.Op)
+	}
+	if !stmt.All {
+		t.Error("All = false, want true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MINUS (alias for EXCEPT)
+// ---------------------------------------------------------------------------
+
+func TestMinusBasic(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 MINUS SELECT a FROM t2")
+
+	if stmt.Op != ast.SetExcept {
+		t.Errorf("Op = %v, want SetExcept (MINUS is alias for EXCEPT)", stmt.Op)
+	}
+	if stmt.All {
+		t.Error("All = true, want false")
+	}
+	assertIsSelectStmt(t, stmt.Left, "Left")
+	assertIsSelectStmt(t, stmt.Right, "Right")
+}
+
+func TestMinusAll(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT a FROM t1 MINUS ALL SELECT a FROM t2")
+
+	if stmt.Op != ast.SetExcept {
+		t.Errorf("Op = %v, want SetExcept", stmt.Op)
+	}
+	if !stmt.All {
+		t.Error("All = false, want true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Chained set operations (left-associativity)
+// ---------------------------------------------------------------------------
+
+// TestUnionChained verifies that three-way UNION is left-associative:
+//
+//	SELECT 1 UNION SELECT 2 UNION SELECT 3
+//	=> SetOpStmt{ Left=SetOpStmt{Left=S1, Right=S2}, Right=S3 }
+func TestUnionChained(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT 1 UNION SELECT 2 UNION SELECT 3")
+
+	if stmt.Op != ast.SetUnion {
+		t.Errorf("outer Op = %v, want SetUnion", stmt.Op)
+	}
+
+	// Right side of outermost must be a plain SELECT.
+	assertIsSelectStmt(t, stmt.Right, "Right")
+
+	// Left side of outermost must be another SetOpStmt.
+	inner, ok := stmt.Left.(*ast.SetOpStmt)
+	if !ok {
+		t.Fatalf("Left = %T, want *ast.SetOpStmt (left-associative)", stmt.Left)
+	}
+	if inner.Op != ast.SetUnion {
+		t.Errorf("inner Op = %v, want SetUnion", inner.Op)
+	}
+	assertIsSelectStmt(t, inner.Left, "inner.Left")
+	assertIsSelectStmt(t, inner.Right, "inner.Right")
+}
+
+// ---------------------------------------------------------------------------
+// Mixed precedence: INTERSECT binds tighter than UNION
+// ---------------------------------------------------------------------------
+
+// TestMixedPrecedenceUnionIntersect verifies:
+//
+//	SELECT 1 UNION SELECT 2 INTERSECT SELECT 3
+//	=> SetOpStmt{ Op=UNION, Left=S1, Right=SetOpStmt{Op=INTERSECT, Left=S2, Right=S3} }
+func TestMixedPrecedenceUnionIntersect(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT 1 UNION SELECT 2 INTERSECT SELECT 3")
+
+	if stmt.Op != ast.SetUnion {
+		t.Errorf("outer Op = %v, want SetUnion", stmt.Op)
+	}
+
+	// Left side of UNION must be a plain SELECT.
+	assertIsSelectStmt(t, stmt.Left, "Left")
+
+	// Right side of UNION must be an INTERSECT SetOpStmt.
+	inner, ok := stmt.Right.(*ast.SetOpStmt)
+	if !ok {
+		t.Fatalf("Right = %T, want *ast.SetOpStmt (INTERSECT has higher precedence)", stmt.Right)
+	}
+	if inner.Op != ast.SetIntersect {
+		t.Errorf("inner Op = %v, want SetIntersect", inner.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AST tag and NodeLoc
+// ---------------------------------------------------------------------------
+
+func TestSetOpStmtTag(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT 1 UNION SELECT 2")
+	if stmt.Tag() != ast.T_SetOpStmt {
+		t.Errorf("Tag() = %v, want T_SetOpStmt", stmt.Tag())
+	}
+}
+
+func TestSetOpStmtNodeLoc(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT 1 UNION SELECT 2")
+	loc := ast.NodeLoc(stmt)
+	if loc.Start < 0 || loc.End <= loc.Start {
+		t.Errorf("NodeLoc = %+v, expected valid non-empty range", loc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk visits both sides
+// ---------------------------------------------------------------------------
+
+func TestSetOpStmtWalk(t *testing.T) {
+	stmt := mustParseSetOp(t, "SELECT 1 UNION SELECT 2")
+
+	count := make(map[ast.NodeTag]int)
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if n != nil {
+			count[n.Tag()]++
+		}
+		return true
+	})
+
+	// We expect at minimum: SetOpStmt, SelectStmt (left), SelectStmt (right)
+	if count[ast.T_SetOpStmt] != 1 {
+		t.Errorf("T_SetOpStmt visited %d times, want 1", count[ast.T_SetOpStmt])
+	}
+	if count[ast.T_SelectStmt] != 2 {
+		t.Errorf("T_SelectStmt visited %d times, want 2", count[ast.T_SelectStmt])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// No-op: plain SELECT still returns *ast.SelectStmt (not wrapped)
+// ---------------------------------------------------------------------------
+
+func TestPlainSelectUnchanged(t *testing.T) {
+	file, errs := Parse("SELECT a FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(file.Stmts) == 0 {
+		t.Fatal("no statements")
+	}
+	if _, ok := file.Stmts[0].(*ast.SelectStmt); !ok {
+		t.Fatalf("got %T, want *ast.SelectStmt", file.Stmts[0])
+	}
+}


### PR DESCRIPTION
## Summary
- Add SetOpStmt AST node with SetOperator enum (Union/Intersect/Except)
- Parse UNION [ALL|DISTINCT], INTERSECT [ALL], EXCEPT/MINUS [ALL]
- SQL-standard precedence: INTERSECT binds tighter than UNION/EXCEPT
- Left-associative chaining within each precedence tier
- 15 unit tests

DAG: T1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)