### PR TITLE
feat(snowflake): T3.4 syntax diagnostics for editor integration

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-diagnostics.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-diagnostics.md
@@ -1,0 +1,57 @@
+# Snowflake Syntax Diagnostics — Implementation Plan (T3.4)
+
+Date: 2026-04-15
+Status: In progress
+
+---
+
+## Steps
+
+### Step 1 — Core types + Analyze (diagnostics.go)
+
+File: `snowflake/diagnostics/diagnostics.go`
+
+- Define `Severity` (int, Error/Warning/Info constants + String())
+- Define `Position` struct (Line, Column, Offset)
+- Define `Range` struct (Start, End Position)
+- Define `Diagnostic` struct (Severity, Range, Source, Message)
+- Implement `Analyze(sql string) []Diagnostic`:
+  - Call `parser.ParseBestEffort(sql)`
+  - Build `parser.NewLineTable(sql)`
+  - Convert each `ParseError` → `Diagnostic`
+  - Return nil for zero-error inputs
+
+### Step 2 — Tests (diagnostics_test.go)
+
+File: `snowflake/diagnostics/diagnostics_test.go`
+
+- Test: empty input → nil
+- Test: whitespace-only input → nil
+- Test: valid SELECT → nil
+- Test: single-line syntax error → line=1, correct column, SeverityError
+- Test: multi-line SQL, error on line 3 → line=3
+- Test: multiple errors → correct count
+- Test: Source == "snowflake-parser"
+- Test: Message non-empty
+- Test: UTF-8 input (multibyte chars before error) → byte-based column
+
+### Step 3 — Run tests + fmt
+
+```bash
+cd /Users/h3n4l/OpenSource/omni/.worktrees/snowflake-diagnostics
+go test ./snowflake/... -count=1
+gofmt -w snowflake/diagnostics/
+```
+
+### Step 4 — Commit + push + PR
+
+Commit 1: docs — spec + plan
+Commit 2: feat — types + Analyze implementation
+Commit 3: test — diagnostics_test.go
+
+---
+
+## Dependency tree
+
+- diagnostics.go depends on `snowflake/parser` (ParseBestEffort, NewLineTable, ParseError)
+- diagnostics_test.go depends on diagnostics.go only

--- a/docs/superpowers/specs/2026-04-15-snowflake-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-diagnostics-design.md
@@ -1,0 +1,156 @@
+# Snowflake Syntax Diagnostics — Design Spec (T3.4)
+
+Date: 2026-04-15
+Author: Claude (agent)
+Status: Accepted
+
+---
+
+## Context
+
+T3.4 adds a thin reporting layer on top of the Snowflake parser. Its purpose is to shape
+raw parse errors into structured diagnostics suitable for editor integration (LSP/language
+server), CI linting, and problem-panel display. The parser already collects all errors via
+`ParseBestEffort`; this node just wraps that output in a well-typed, editor-friendly form.
+
+---
+
+## Goals
+
+1. A `Diagnostic` value type with severity, source, message, and a text range.
+2. A `Range` / `Position` type pair matching the LSP `Range` concept (line+column+offset).
+3. An `Analyze(sql string) []Diagnostic` function as the single public entry point.
+4. Tests covering: syntax errors, multi-line input, UTF-8, empty/whitespace input, valid SQL.
+
+---
+
+## Non-Goals
+
+- No ASP walker to detect semantic warnings — that is the advisor's responsibility (T2.6+).
+- No configuration, suppression, or rule IDs — this is pure syntax diagnostics only.
+- No changes to the parser itself.
+
+---
+
+## Package layout
+
+New package `snowflake/diagnostics/`:
+
+```
+snowflake/diagnostics/
+  diagnostics.go       — all types + Analyze function
+  diagnostics_test.go  — tests
+```
+
+A separate package gives a clean API surface (`diagnostics.Analyze`, `diagnostics.Diagnostic`)
+that is easier for consumers (e.g. bytebase's language server) to import without pulling in
+all parser internals.
+
+---
+
+## Key types
+
+### Severity
+
+```go
+type Severity int
+
+const (
+    SeverityError   Severity = iota // syntax error — the SQL will not execute
+    SeverityWarning                  // reserved for future use
+    SeverityInfo                     // reserved for future use
+)
+```
+
+Lower index = higher severity (matches typical lint tool conventions).
+
+### Position
+
+```go
+type Position struct {
+    Line   int // 1-based line number
+    Column int // 1-based column (byte offset within line)
+    Offset int // 0-based byte offset within the source
+}
+```
+
+`Offset` allows callers to reconstruct the raw position without a line table; `Line`/`Column`
+are pre-computed for convenience.
+
+### Range
+
+```go
+type Range struct {
+    Start Position
+    End   Position
+}
+```
+
+Matches the LSP `Range` shape. `End` is exclusive (same convention as `ast.Loc.End`).
+
+### Diagnostic
+
+```go
+type Diagnostic struct {
+    Severity Severity
+    Range    Range
+    Source   string // always "snowflake-parser"
+    Message  string
+}
+```
+
+---
+
+## Analyze algorithm
+
+1. Call `parser.ParseBestEffort(sql)` to obtain `*parser.ParseResult`.
+2. Build `parser.NewLineTable(sql)`.
+3. For each `parser.ParseError` in `result.Errors`:
+   a. Look up `(line, col) = lt.Position(err.Loc.Start)` for the start.
+   b. Look up `(line, col) = lt.Position(err.Loc.End)` for the end.
+   c. If `Loc.End < 0` (unknown), use `Start` for both start and end.
+   d. Emit `Diagnostic{SeverityError, Range{start, end}, "snowflake-parser", err.Msg}`.
+4. Return the slice (nil if empty).
+
+No AST walk is needed: the parser already collects all lex and parse errors via `ParseBestEffort`.
+
+---
+
+## Edge cases
+
+- **Empty input**: `ParseBestEffort("")` returns an empty error slice → `Analyze` returns nil.
+- **Whitespace-only input**: same as empty — no errors.
+- **Valid SQL**: no parse errors → nil result.
+- **Unknown `Loc.End`**: use `Start` for end (zero-width underline at the error position).
+- **Multibyte UTF-8**: `LineTable.Position` uses byte offsets — column is a byte count, not
+  a rune count. This matches the parser's byte-based tokenization.
+
+---
+
+## Testing strategy
+
+1. Single-line syntax error — verify line=1, correct column range, SeverityError.
+2. Multi-line SQL, error on line 3 — verify line=3 and correct column.
+3. Multiple errors in one input — verify count and individual positions.
+4. Valid SQL — zero diagnostics.
+5. Empty string — zero diagnostics.
+6. Whitespace-only string — zero diagnostics.
+7. UTF-8 identifier in error context — verify byte-based column.
+8. Source field — always "snowflake-parser".
+9. Message is non-empty for all diagnostics.
+
+---
+
+## Alternatives considered
+
+**Place in `snowflake/parser/diagnostics.go`**
+Simpler (no new package), but mixes parsing internals with the reporting API.
+Separate package is cleaner for consumers and follows the advisor pattern (`snowflake/advisor`).
+
+**Return `([]Diagnostic, error)`**
+Unnecessary — all errors are already captured in the diagnostics slice.
+A plain slice return keeps the API minimal.
+
+**Walk AST for `Invalid*` nodes**
+The Snowflake AST has no `Invalid*` node types at this stage. All error recovery markers
+are surfaced as `ParseError` entries. The walk can be added later if needed.

--- a/snowflake/diagnostics/diagnostics.go
+++ b/snowflake/diagnostics/diagnostics.go
@@ -1,0 +1,136 @@
+// Package diagnostics provides a thin reporting layer over the Snowflake SQL
+// parser, shaping raw parse errors into structured diagnostics suitable for
+// editor integration (LSP-style), CI linting, and problem-panel display.
+//
+// The primary entry point is Analyze, which accepts a SQL string and returns
+// a slice of Diagnostic values — one per parse or lex error. Each Diagnostic
+// carries a source range (line, column, byte offset) and a human-readable
+// message, ready for use in language servers, linters, or test assertions.
+//
+// See docs/superpowers/specs/2026-04-15-snowflake-diagnostics-design.md
+// for the design rationale.
+package diagnostics
+
+import (
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// Severity classifies the importance of a diagnostic.
+//
+// Only SeverityError is emitted today (all parse errors are fatal for
+// SQL execution). SeverityWarning and SeverityInfo are reserved for future
+// semantic / advisory diagnostics.
+type Severity int
+
+const (
+	// SeverityError indicates a syntax error that prevents SQL execution.
+	SeverityError Severity = iota
+	// SeverityWarning indicates a non-fatal issue (reserved for future use).
+	SeverityWarning
+	// SeverityInfo indicates an informational note (reserved for future use).
+	SeverityInfo
+)
+
+// String returns a human-readable label for a Severity value.
+func (s Severity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInfo:
+		return "info"
+	default:
+		return "unknown"
+	}
+}
+
+// Position is a point in the source text identified by line, column, and
+// byte offset. All three fields are provided so callers can choose their
+// preferred coordinate system.
+//
+// Line and Column are 1-based (the first character of a file is line 1,
+// column 1). Column is measured in bytes, not Unicode code points, matching
+// the byte-based tokenization used by the Snowflake lexer.
+//
+// Offset is 0-based and refers to the byte position within the full input
+// string passed to Analyze.
+type Position struct {
+	Line   int // 1-based line number
+	Column int // 1-based column (bytes from line start)
+	Offset int // 0-based byte offset within the source
+}
+
+// Range is a contiguous region of source text. Start is inclusive;
+// End is exclusive — mirroring the ast.Loc convention.
+//
+// A zero-width range (Start == End) indicates a point diagnostic where
+// the error boundary could not be determined (e.g. end-of-input errors).
+type Range struct {
+	Start Position
+	End   Position
+}
+
+// Diagnostic is a single structured error or warning produced by the parser.
+// It is intentionally shaped after the LSP Diagnostic type so consumers can
+// map it to editor underlines, problem-panel entries, or CI annotations with
+// minimal transformation.
+type Diagnostic struct {
+	// Severity is always SeverityError for syntax errors reported by the parser.
+	Severity Severity
+	// Range identifies the source region to underline.
+	Range Range
+	// Source identifies the tool that produced this diagnostic.
+	// Always "snowflake-parser" for diagnostics from this package.
+	Source string
+	// Message is the human-readable error description from the parser.
+	Message string
+}
+
+const source = "snowflake-parser"
+
+// Analyze parses sql using the Snowflake best-effort parser and converts
+// every parse or lex error into a Diagnostic with a populated source range.
+//
+// Returns nil when sql is syntactically valid or empty. The returned slice
+// is ordered by the byte offset at which each error was detected.
+//
+// Line and column numbers are 1-based and measured in bytes. Callers that
+// need Unicode-aware column numbers should post-process the Offset field.
+func Analyze(sql string) []Diagnostic {
+	result := parser.ParseBestEffort(sql)
+	if len(result.Errors) == 0 {
+		return nil
+	}
+
+	lt := parser.NewLineTable(sql)
+	diags := make([]Diagnostic, 0, len(result.Errors))
+
+	for _, pe := range result.Errors {
+		startOff := pe.Loc.Start
+		if startOff < 0 {
+			startOff = 0
+		}
+		startLine, startCol := lt.Position(startOff)
+
+		// End offset may be unknown (-1). Fall back to the start offset so
+		// we produce a zero-width (point) diagnostic rather than a garbage range.
+		endOff := pe.Loc.End
+		if endOff < 0 {
+			endOff = startOff
+		}
+		endLine, endCol := lt.Position(endOff)
+
+		diags = append(diags, Diagnostic{
+			Severity: SeverityError,
+			Range: Range{
+				Start: Position{Line: startLine, Column: startCol, Offset: startOff},
+				End:   Position{Line: endLine, Column: endCol, Offset: endOff},
+			},
+			Source:  source,
+			Message: pe.Msg,
+		})
+	}
+
+	return diags
+}

--- a/snowflake/diagnostics/diagnostics_test.go
+++ b/snowflake/diagnostics/diagnostics_test.go
@@ -1,0 +1,356 @@
+package diagnostics
+
+import (
+	"strings"
+	"testing"
+)
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+// assertNoDiags fails the test if diags is non-nil or non-empty.
+func assertNoDiags(t *testing.T, label string, diags []Diagnostic) {
+	t.Helper()
+	if len(diags) != 0 {
+		t.Errorf("%s: expected zero diagnostics, got %d:", label, len(diags))
+		for i, d := range diags {
+			t.Errorf("  [%d] %s", i, d.Message)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// Zero-diagnostic cases
+// -----------------------------------------------------------------------
+
+func TestAnalyze_EmptyInput(t *testing.T) {
+	assertNoDiags(t, "empty", Analyze(""))
+}
+
+func TestAnalyze_WhitespaceOnly(t *testing.T) {
+	assertNoDiags(t, "spaces", Analyze("   "))
+	assertNoDiags(t, "newlines", Analyze("\n\n\n"))
+	assertNoDiags(t, "mixed whitespace", Analyze("  \t\n  "))
+}
+
+func TestAnalyze_CommentOnly(t *testing.T) {
+	assertNoDiags(t, "line comment", Analyze("-- just a comment"))
+	assertNoDiags(t, "block comment", Analyze("/* just a comment */"))
+}
+
+func TestAnalyze_ValidSelect(t *testing.T) {
+	assertNoDiags(t, "SELECT 1", Analyze("SELECT 1"))
+	assertNoDiags(t, "SELECT with alias", Analyze("SELECT 1 AS n"))
+	assertNoDiags(t, "SELECT columns", Analyze("SELECT a, b FROM t"))
+	assertNoDiags(t, "SELECT with WHERE", Analyze("SELECT id FROM users WHERE active = TRUE"))
+}
+
+func TestAnalyze_ValidCTE(t *testing.T) {
+	sql := `WITH cte AS (SELECT 1 AS x)
+SELECT x FROM cte`
+	assertNoDiags(t, "CTE", Analyze(sql))
+}
+
+// -----------------------------------------------------------------------
+// Single-error cases — line/column accuracy
+// -----------------------------------------------------------------------
+
+func TestAnalyze_UnknownStatement(t *testing.T) {
+	// "FOOBAR" is not a recognised statement keyword. Error at byte 0.
+	diags := Analyze("FOOBAR BAZ")
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+
+	if d.Severity != SeverityError {
+		t.Errorf("severity = %v, want SeverityError", d.Severity)
+	}
+	if d.Source != "snowflake-parser" {
+		t.Errorf("source = %q, want %q", d.Source, "snowflake-parser")
+	}
+	if d.Message == "" {
+		t.Errorf("message must not be empty")
+	}
+	if d.Range.Start.Line != 1 {
+		t.Errorf("start line = %d, want 1", d.Range.Start.Line)
+	}
+	if d.Range.Start.Column != 1 {
+		t.Errorf("start column = %d, want 1", d.Range.Start.Column)
+	}
+	if d.Range.Start.Offset != 0 {
+		t.Errorf("start offset = %d, want 0", d.Range.Start.Offset)
+	}
+}
+
+func TestAnalyze_ErrorOnFirstLine_ColumnAccuracy(t *testing.T) {
+	// "INSERT INTO t" — INSERT is at byte 0, col 1 on line 1.
+	// The parser emits "INSERT statement parsing is not yet supported".
+	diags := Analyze("INSERT INTO t VALUES (1)")
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic, got none")
+	}
+	d := diags[0]
+	if d.Range.Start.Line != 1 {
+		t.Errorf("line = %d, want 1", d.Range.Start.Line)
+	}
+	if d.Range.Start.Column != 1 {
+		t.Errorf("column = %d, want 1", d.Range.Start.Column)
+	}
+}
+
+func TestAnalyze_UnsupportedStatementInMiddle(t *testing.T) {
+	// "SELECT 1; INSERT …" — INSERT starts at byte 10 (after "SELECT 1; ").
+	// Line is still 1, column 11.
+	sql := "SELECT 1; INSERT INTO t VALUES (1)"
+	diags := Analyze(sql)
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic, got none")
+	}
+	insertDiag := diags[0]
+	if insertDiag.Range.Start.Line != 1 {
+		t.Errorf("line = %d, want 1", insertDiag.Range.Start.Line)
+	}
+	// "SELECT 1; " is 10 bytes, so INSERT starts at column 11.
+	if insertDiag.Range.Start.Column != 11 {
+		t.Errorf("column = %d, want 11 (INSERT starts after 'SELECT 1; ')", insertDiag.Range.Start.Column)
+	}
+	if insertDiag.Range.Start.Offset != 10 {
+		t.Errorf("offset = %d, want 10", insertDiag.Range.Start.Offset)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Multi-line inputs
+// -----------------------------------------------------------------------
+
+func TestAnalyze_MultiLine_ErrorOnLine3(t *testing.T) {
+	// Error should be reported on line 3 (the INSERT statement).
+	sql := "SELECT 1;\nSELECT 2;\nINSERT INTO t VALUES (1)"
+	diags := Analyze(sql)
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+	d := diags[0]
+	if d.Range.Start.Line != 3 {
+		t.Errorf("line = %d, want 3", d.Range.Start.Line)
+	}
+}
+
+func TestAnalyze_MultiLine_ErrorOnLine2(t *testing.T) {
+	// "SELECT 1\n@@bad" — @@ introduces an error on line 2.
+	// We use an unterminated string on line 2.
+	sql := "SELECT 1;\n'unterminated"
+	diags := Analyze(sql)
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+	// The lex error for the unterminated string should be on line 2.
+	found := false
+	for _, d := range diags {
+		if d.Range.Start.Line == 2 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a diagnostic on line 2; got: %+v", diags)
+	}
+}
+
+func TestAnalyze_CRLF_LineEndings(t *testing.T) {
+	// CRLF line endings — error should still report line 3.
+	sql := "SELECT 1;\r\nSELECT 2;\r\nINSERT INTO t VALUES (1)"
+	diags := Analyze(sql)
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+	d := diags[0]
+	if d.Range.Start.Line != 3 {
+		t.Errorf("line = %d, want 3 (CRLF endings)", d.Range.Start.Line)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Multiple errors
+// -----------------------------------------------------------------------
+
+func TestAnalyze_MultipleErrors(t *testing.T) {
+	// Two unsupported statements.
+	sql := "INSERT INTO t VALUES (1);\nUPDATE t SET x=1"
+	diags := Analyze(sql)
+	if len(diags) < 2 {
+		t.Fatalf("expected at least 2 diagnostics, got %d", len(diags))
+	}
+}
+
+func TestAnalyze_LexError_UnterminatedString(t *testing.T) {
+	// The lexer emits a lex error for the unterminated string; the parser also
+	// records a parse error because the resulting tokInvalid looks like an
+	// unknown statement start. We just need at least one diagnostic, and at
+	// least one should mention "unterminated".
+	diags := Analyze("'unterminated string")
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+	for _, d := range diags {
+		if d.Severity != SeverityError {
+			t.Errorf("severity = %v, want SeverityError", d.Severity)
+		}
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "unterminated") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a diagnostic containing 'unterminated'; got: %+v", diags)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Source field and message invariants
+// -----------------------------------------------------------------------
+
+func TestAnalyze_SourceField(t *testing.T) {
+	diags := Analyze("INVALID_STATEMENT")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostics")
+	}
+	for i, d := range diags {
+		if d.Source != "snowflake-parser" {
+			t.Errorf("diags[%d].Source = %q, want \"snowflake-parser\"", i, d.Source)
+		}
+	}
+}
+
+func TestAnalyze_MessageNonEmpty(t *testing.T) {
+	diags := Analyze("INVALID_STATEMENT")
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostics")
+	}
+	for i, d := range diags {
+		if d.Message == "" {
+			t.Errorf("diags[%d].Message is empty", i)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// Severity type
+// -----------------------------------------------------------------------
+
+func TestSeverity_String(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want string
+	}{
+		{SeverityError, "error"},
+		{SeverityWarning, "warning"},
+		{SeverityInfo, "info"},
+		{Severity(99), "unknown"},
+	}
+	for _, c := range cases {
+		if got := c.s.String(); got != c.want {
+			t.Errorf("Severity(%d).String() = %q, want %q", c.s, got, c.want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// Range sanity: Start.Offset <= End.Offset
+// -----------------------------------------------------------------------
+
+func TestAnalyze_RangeSanity(t *testing.T) {
+	inputs := []string{
+		"FOOBAR",
+		"INSERT INTO t VALUES (1)",
+		"'unterminated",
+	}
+	for _, sql := range inputs {
+		diags := Analyze(sql)
+		for i, d := range diags {
+			if d.Range.Start.Offset > d.Range.End.Offset {
+				t.Errorf("sql=%q diag[%d]: Start.Offset(%d) > End.Offset(%d)",
+					sql, i, d.Range.Start.Offset, d.Range.End.Offset)
+			}
+			if d.Range.Start.Line > d.Range.End.Line {
+				t.Errorf("sql=%q diag[%d]: Start.Line(%d) > End.Line(%d)",
+					sql, i, d.Range.Start.Line, d.Range.End.Line)
+			}
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// UTF-8 / multibyte characters
+// -----------------------------------------------------------------------
+
+func TestAnalyze_UTF8_ByteBasedColumn(t *testing.T) {
+	// Place an unsupported statement on a line that starts with multi-byte
+	// UTF-8 characters so we can verify the column is byte-based.
+	//
+	// Line 2 is: "αβ INSERT INTO t VALUES (1)"
+	//   α = 2 bytes (0xCE 0xB1)
+	//   β = 2 bytes (0xCE 0xB2)
+	//   space = 1 byte
+	//   INSERT starts at byte offset 5 within that line → column 6
+	//
+	// The Snowflake lexer does not support non-ASCII identifiers; α and β will
+	// each cause an "invalid byte" lex error. We are primarily testing that the
+	// LineTable produces the correct byte-based column for the error on line 2.
+	sql := "SELECT 1;\nαβ INSERT INTO t VALUES (1)"
+
+	diags := Analyze(sql)
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostics")
+	}
+
+	// All diagnostics are on line 2 (the second line).
+	for _, d := range diags {
+		if d.Range.Start.Line != 2 {
+			t.Errorf("expected all diagnostics on line 2; got line %d (msg=%q)",
+				d.Range.Start.Line, d.Message)
+		}
+	}
+
+	// The first diagnostic is the "invalid byte" for α at column 1 (offset 10
+	// in the full input, which is the first byte of line 2).
+	d0 := diags[0]
+	if d0.Range.Start.Column != 1 {
+		t.Errorf("diags[0] column = %d, want 1 (first byte of line 2)", d0.Range.Start.Column)
+	}
+	// Offset 10 = length of "SELECT 1;\n" (10 bytes).
+	if d0.Range.Start.Offset != 10 {
+		t.Errorf("diags[0] offset = %d, want 10", d0.Range.Start.Offset)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Position consistency: Offset matches Line+Column
+// -----------------------------------------------------------------------
+
+func TestAnalyze_PositionConsistency(t *testing.T) {
+	// For a multi-line input, verify that the Offset of the error on line N
+	// is consistent with the line/column values.
+	sql := "SELECT 1;\nSELECT 2;\nINSERT INTO t VALUES (1)"
+	diags := Analyze(sql)
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostics")
+	}
+	d := diags[0]
+	// Line 3, column 1 → offset should equal the byte position of "INSERT" in sql.
+	wantOffset := strings.Index(sql, "INSERT")
+	if d.Range.Start.Offset != wantOffset {
+		t.Errorf("Start.Offset = %d, want %d", d.Range.Start.Offset, wantOffset)
+	}
+	if d.Range.Start.Line != 3 {
+		t.Errorf("Start.Line = %d, want 3", d.Range.Start.Line)
+	}
+	if d.Range.Start.Column != 1 {
+		t.Errorf("Start.Column = %d, want 1", d.Range.Start.Column)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `snowflake/diagnostics` package with `Analyze(sql string) []Diagnostic` as the single public entry point — a thin LSP-style reporting layer over `parser.ParseBestEffort`
- `Diagnostic` carries `Severity`, `Range{Start, End Position}`, `Source` (`"snowflake-parser"`), and `Message` — ready for editor underlining, problem-panel display, or CI linting
- `Position` has `Line` (1-based), `Column` (1-based, byte-measured), and `Offset` (0-based byte offset) — all three fields let callers pick their preferred coordinate system without re-parsing

## Design decisions

- **New package** (`snowflake/diagnostics/`) rather than a file in `snowflake/parser/` — cleaner API surface for consumers; mirrors the `snowflake/advisor` precedent
- **Pure consumer** — does not modify the parser; calls `ParseBestEffort` + `NewLineTable` only
- **nil on clean input** — `Analyze` returns `nil` (not an empty slice) when there are no errors, matching Go idioms for "nothing to report"
- **Point diagnostics for unknown end** — when `Loc.End < 0` (unknown), `End == Start` so the range is zero-width rather than garbage

## Test plan

- [x] Empty input → nil
- [x] Whitespace-only and comment-only → nil
- [x] Valid SELECT / CTE → nil
- [x] Single-line syntax error — line=1, column=1, offset=0
- [x] Unsupported statement in the middle of input — correct column offset
- [x] Multi-line input: error on line 2 (unterminated string), error on line 3 (INSERT)
- [x] CRLF line endings — line numbers still correct
- [x] Multiple errors in one input — count verified
- [x] Lex error (unterminated string) — at least one diagnostic contains "unterminated"
- [x] `Source` field always `"snowflake-parser"`
- [x] `Message` field always non-empty
- [x] `Severity.String()` for all four values
- [x] Range sanity: `Start.Offset <= End.Offset` and `Start.Line <= End.Line`
- [x] UTF-8 multibyte: byte-based column; first invalid byte reported at correct offset
- [x] Position consistency: `Offset` matches `Line+Column` via LineTable

All 19 test cases pass. Full suite: `go test ./snowflake/... -count=1` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)