### PR TITLE
feat(snowflake): T2.4 VIEW + MATERIALIZED VIEW DDL

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-view.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-view.md
@@ -1,0 +1,62 @@
+# T2.4 — Snowflake VIEW + MATERIALIZED VIEW — Implementation Plan
+
+## Step 1 — AST nodes (snowflake/ast/parsenodes.go + nodetags.go)
+
+1. Add ViewColumn helper struct (not a Node).
+2. Add RowAccessPolicy helper struct (not a Node).
+3. Add CreateViewStmt + Tag + compile-time assertion.
+4. Add CreateMaterializedViewStmt + Tag + compile-time assertion.
+5. Add AlterViewAction enum + AlterViewStmt + Tag.
+6. Add AlterMaterializedViewAction enum + AlterMaterializedViewStmt + Tag.
+7. Add NodeTag constants T_CreateViewStmt, T_CreateMaterializedViewStmt,
+   T_AlterViewStmt, T_AlterMaterializedViewStmt in nodetags.go.
+8. Add String() cases for the new tags.
+
+## Step 2 — Walker (snowflake/ast/walk_generated.go)
+
+Add cases for the four new statement types in walkChildren.
+
+## Step 3 — Parser: CREATE VIEW + CREATE MATERIALIZED VIEW (snowflake/parser/view.go — new file)
+
+Functions:
+- parseCreateViewStmt(start, orReplace, secure, recursive)
+- parseCreateMaterializedViewStmt(start, orReplace, secure)
+- parseViewColumnList() — parses ( col [COMMENT 'x'], ... )
+- parseViewCols() — parses view_col* entries
+- parseRowAccessPolicy() — parses [WITH] ROW ACCESS POLICY name ON (cols)
+
+## Step 4 — Parser: CREATE dispatch (snowflake/parser/create_table.go)
+
+In parseCreateStmt, after consuming OR REPLACE and temporary modifiers,
+add SECURE/RECURSIVE peek before the switch and add VIEW/MATERIALIZED cases.
+
+## Step 5 — Parser: ALTER VIEW + ALTER MATERIALIZED VIEW (snowflake/parser/view.go)
+
+Functions:
+- parseAlterViewStmt()
+- parseAlterMaterializedViewStmt()
+
+## Step 6 — Parser: ALTER dispatch (snowflake/parser/database_schema.go)
+
+In parseAlterStmt, add kwVIEW and kwMATERIALIZED cases.
+
+## Step 7 — Tests (snowflake/parser/view_test.go — new file)
+
+Cover all forms documented in the spec.
+
+## Step 8 — Run tests + gofmt
+
+```
+cd /Users/h3n4l/OpenSource/omni/.worktrees/snowflake-view
+go test ./snowflake/... -count=1
+gofmt -w snowflake/
+```
+
+## Step 9 — Commit in chunks
+
+Chunk 1: AST nodes + nodetags + walker
+Chunk 2: Parser CREATE VIEW + CREATE MATERIALIZED VIEW + dispatch
+Chunk 3: Parser ALTER VIEW + ALTER MATERIALIZED VIEW + dispatch  
+Chunk 4: Tests + docs
+
+## Step 10 — Open PR

--- a/docs/superpowers/specs/2026-04-15-snowflake-view-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-view-design.md
@@ -1,0 +1,228 @@
+# T2.4 — Snowflake VIEW + MATERIALIZED VIEW DDL Design
+
+## Scope
+
+T2.4 adds CREATE VIEW, CREATE MATERIALIZED VIEW, ALTER VIEW, and ALTER MATERIALIZED VIEW
+to the Snowflake parser. DROP VIEW and DROP MATERIALIZED VIEW are already handled by T2.5
+(DropStmt) and must not be touched here.
+
+## Source of truth
+
+Legacy grammar: `/Users/h3n4l/OpenSource/parser/snowflake/SnowflakeParser.g4`
+- `create_view` (line 2850)
+- `create_materialized_view` (line 1883)
+- `alter_view` (line 1438)
+- `alter_materialized_view` (line 906)
+
+Official Snowflake docs syntax matches the legacy grammar; the two sources agree.
+
+## AST nodes
+
+### ViewColumn
+
+Not a Node (value struct embedded in CreateViewStmt / CreateMaterializedViewStmt).
+
+```go
+type ViewColumn struct {
+    Name          Ident
+    MaskingPolicy *ObjectName // WITH MASKING POLICY p; nil if absent
+    MaskingUsing  []Ident     // USING (col, ...); nil if absent
+    Tags          []*TagAssignment
+    Comment       *string
+    Loc           Loc
+}
+```
+
+### CreateViewStmt (Node, tag T_CreateViewStmt)
+
+```go
+type CreateViewStmt struct {
+    OrReplace   bool
+    Secure      bool
+    Recursive   bool
+    IfNotExists bool
+    Name        *ObjectName
+    Columns     []*ViewColumn    // optional col list from ( column_list_with_comment )
+    ViewCols    []*ViewColumn    // view_col* — column-level policy/tag bindings
+    CopyGrants  bool
+    Comment     *string
+    Tags        []*TagAssignment // WITH TAG (...)
+    RowPolicy   *RowAccessPolicy // WITH ROW ACCESS POLICY ...; nil if absent
+    Query       Node             // the AS query
+    Loc         Loc
+}
+```
+
+### RowAccessPolicy (helper struct, not a Node)
+
+```go
+type RowAccessPolicy struct {
+    PolicyName *ObjectName
+    Columns    []Ident
+}
+```
+
+### CreateMaterializedViewStmt (Node, tag T_CreateMaterializedViewStmt)
+
+Same fields as CreateViewStmt minus Recursive, plus:
+
+```go
+    ClusterBy  []Node // CLUSTER BY (exprs); nil if absent
+    Linear     bool   // CLUSTER BY LINEAR modifier
+```
+
+### AlterViewAction enum
+
+```go
+type AlterViewAction int
+
+const (
+    AlterViewRename                    AlterViewAction = iota
+    AlterViewSetComment
+    AlterViewUnsetComment
+    AlterViewSetSecure
+    AlterViewUnsetSecure
+    AlterViewSetTag
+    AlterViewUnsetTag
+    AlterViewAddRowAccessPolicy
+    AlterViewDropRowAccessPolicy
+    AlterViewDropAllRowAccessPolicies
+    AlterViewColumnSetMaskingPolicy
+    AlterViewColumnUnsetMaskingPolicy
+    AlterViewColumnSetTag
+    AlterViewColumnUnsetTag
+)
+```
+
+### AlterViewStmt (Node, tag T_AlterViewStmt)
+
+```go
+type AlterViewStmt struct {
+    IfExists   bool
+    Name       *ObjectName
+    Action     AlterViewAction
+    NewName    *ObjectName      // RENAME TO
+    Comment    *string          // SET COMMENT
+    Secure     bool             // SET SECURE (true) or UNSET SECURE (false)
+    Tags       []*TagAssignment // SET TAG
+    UnsetTags  []*ObjectName    // UNSET TAG
+    PolicyName *ObjectName      // ADD/DROP ROW ACCESS POLICY
+    PolicyCols []Ident          // ON (col, ...)
+    Column     Ident            // ALTER COLUMN col
+    MaskingPolicy *ObjectName   // SET MASKING POLICY p
+    MaskingUsing  []Ident       // USING (col, ...)
+    Loc        Loc
+}
+```
+
+### AlterMaterializedViewAction enum
+
+```go
+type AlterMaterializedViewAction int
+
+const (
+    AlterMVRename           AlterMaterializedViewAction = iota
+    AlterMVClusterBy
+    AlterMVDropClusteringKey
+    AlterMVSuspend
+    AlterMVResume
+    AlterMVSuspendRecluster
+    AlterMVResumeRecluster
+    AlterMVSetSecure
+    AlterMVUnsetSecure
+    AlterMVSetComment
+    AlterMVUnsetComment
+)
+```
+
+### AlterMaterializedViewStmt (Node, tag T_AlterMaterializedViewStmt)
+
+```go
+type AlterMaterializedViewStmt struct {
+    Name      *ObjectName
+    Action    AlterMaterializedViewAction
+    NewName   *ObjectName      // RENAME TO
+    ClusterBy []Node           // CLUSTER BY (exprs)
+    Linear    bool
+    Comment   *string
+    Secure    bool
+    Loc       Loc
+}
+```
+
+Note: The legacy grammar for ALTER MATERIALIZED VIEW does NOT include IF EXISTS
+(the grammar uses `id_` not `if_exists? object_name`), consistent with Snowflake docs
+for this command.
+
+## Parser dispatch
+
+### parseCreateStmt (create_table.go)
+
+Add cases for `kwSECURE`, `kwRECURSIVE`, `kwVIEW`, `kwMATERIALIZED` after the existing
+temporary/transient checks. `SECURE` and `RECURSIVE` are view-only modifiers that appear
+before `VIEW`.
+
+```
+CREATE [OR REPLACE] [SECURE] [RECURSIVE] VIEW ...
+CREATE [OR REPLACE] [SECURE] MATERIALIZED VIEW ...
+```
+
+Decision tree:
+1. After consuming OR REPLACE, check for SECURE (consume it if present).
+2. Check for RECURSIVE (consume it if present) → must be VIEW.
+3. Check for MATERIALIZED (consume it if present) → must be VIEW next.
+4. Check for VIEW → parseCreateViewStmt.
+5. Existing TABLE/DATABASE/SCHEMA cases.
+
+### parseAlterStmt (database_schema.go)
+
+Add cases for `kwVIEW` and `kwMATERIALIZED` in the switch.
+
+## Column list parsing
+
+The legacy grammar supports two column-list forms:
+
+1. `( column_list_with_comment )` — column names with optional COMMENT per column.
+   Parsed as ViewColumn with Name and Comment only.
+
+2. `view_col*` — zero or more `column_name WITH MASKING POLICY p [WITH TAG (...)]`
+   entries outside the parens. Parsed as ViewColumn with MaskingPolicy and/or Tags.
+
+The parser checks for `(` to decide which form to parse. After the optional `( ... )`,
+it may encounter `view_col*` entries (column name followed by WITH MASKING POLICY or
+WITH TAG without a comma separator — each is a distinct col entry).
+
+## Row access policy
+
+`[WITH] ROW ACCESS POLICY policy_name ON (col1 [, col2 ...])` is stored in RowAccessPolicy.
+
+## Walker
+
+walkChildren must be extended (manually, since the generator runs at build time):
+- CreateViewStmt: Walk Name, walk Query, walk each ViewCol's MaskingPolicy/Tags.
+- CreateMaterializedViewStmt: same + ClusterBy exprs.
+- AlterViewStmt: Walk Name, NewName, PolicyName, MaskingPolicy.
+- AlterMaterializedViewStmt: Walk Name, NewName, ClusterBy exprs.
+
+Due to the complexity of nested non-Node structs (ViewColumn, RowAccessPolicy),
+the walker in walk_generated.go will walk the top-level *ObjectName and Node children
+only; ViewColumn and RowAccessPolicy are treated as opaque value structs.
+
+## Test coverage
+
+Tests in `snowflake/parser/view_test.go`:
+- CREATE VIEW basic, OR REPLACE, SECURE, RECURSIVE, IF NOT EXISTS
+- CREATE VIEW with column list + comments
+- CREATE VIEW with COPY GRANTS, COMMENT, WITH TAG, WITH ROW ACCESS POLICY
+- CREATE VIEW AS SELECT / WITH CTE query
+- CREATE MATERIALIZED VIEW basic + CLUSTER BY
+- ALTER VIEW RENAME TO
+- ALTER VIEW SET/UNSET COMMENT
+- ALTER VIEW SET/UNSET SECURE
+- ALTER VIEW SET/UNSET TAG
+- ALTER VIEW ADD/DROP ROW ACCESS POLICY
+- ALTER VIEW ALTER COLUMN SET/UNSET MASKING POLICY
+- ALTER VIEW ALTER COLUMN SET/UNSET TAG
+- ALTER MATERIALIZED VIEW RENAME, CLUSTER BY, DROP CLUSTERING KEY
+- ALTER MATERIALIZED VIEW SUSPEND, RESUME, SUSPEND RECLUSTER, RESUME RECLUSTER
+- ALTER MATERIALIZED VIEW SET/UNSET SECURE, SET/UNSET COMMENT

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -70,6 +70,12 @@ const (
 	T_UpdateStmt
 	T_DeleteStmt
 	T_MergeStmt
+
+	// VIEW + MATERIALIZED VIEW tags (T2.4)
+	T_CreateViewStmt
+	T_CreateMaterializedViewStmt
+	T_AlterViewStmt
+	T_AlterMaterializedViewStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -169,6 +175,14 @@ func (t NodeTag) String() string {
 		return "DeleteStmt"
 	case T_MergeStmt:
 		return "MergeStmt"
+	case T_CreateViewStmt:
+		return "CreateViewStmt"
+	case T_CreateMaterializedViewStmt:
+		return "CreateMaterializedViewStmt"
+	case T_AlterViewStmt:
+		return "AlterViewStmt"
+	case T_AlterMaterializedViewStmt:
+		return "AlterMaterializedViewStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1422,3 +1422,166 @@ var (
 	_ Node = (*DeleteStmt)(nil)
 	_ Node = (*MergeStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// VIEW / MATERIALIZED VIEW DDL — helper structs (not Nodes)
+// ---------------------------------------------------------------------------
+
+// ViewColumn represents a single column entry in a VIEW column list or a
+// view_col binding (WITH MASKING POLICY / WITH TAG).
+//
+// Used by both CreateViewStmt and CreateMaterializedViewStmt.
+type ViewColumn struct {
+	Name          Ident
+	MaskingPolicy *ObjectName      // WITH MASKING POLICY p; nil if absent
+	MaskingUsing  []Ident          // USING (col, ...); nil if absent
+	Tags          []*TagAssignment // WITH TAG (...); nil if absent
+	Comment       *string          // COMMENT 'text'; nil if absent
+	Loc           Loc
+}
+
+// RowAccessPolicy holds the policy name and column list from a
+// WITH ROW ACCESS POLICY name ON (col, ...) clause.
+type RowAccessPolicy struct {
+	PolicyName *ObjectName
+	Columns    []Ident
+}
+
+// ---------------------------------------------------------------------------
+// CREATE VIEW
+// ---------------------------------------------------------------------------
+
+// CreateViewStmt represents CREATE [OR REPLACE] [SECURE] [RECURSIVE] VIEW ...
+type CreateViewStmt struct {
+	OrReplace   bool
+	Secure      bool
+	Recursive   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Columns     []*ViewColumn // optional column list from ( col [COMMENT 'x'], ... )
+	ViewCols    []*ViewColumn // view_col* — column masking/tag bindings (outside parens)
+	CopyGrants  bool
+	Comment     *string          // COMMENT = 'str'; nil if absent
+	Tags        []*TagAssignment // WITH TAG (...); nil if absent
+	RowPolicy   *RowAccessPolicy // WITH ROW ACCESS POLICY ...; nil if absent
+	Query       Node             // the AS query body
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateViewStmt) Tag() NodeTag { return T_CreateViewStmt }
+
+var _ Node = (*CreateViewStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// CREATE MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// CreateMaterializedViewStmt represents CREATE [OR REPLACE] [SECURE] MATERIALIZED VIEW ...
+type CreateMaterializedViewStmt struct {
+	OrReplace   bool
+	Secure      bool
+	IfNotExists bool
+	Name        *ObjectName
+	Columns     []*ViewColumn // optional column list
+	ViewCols    []*ViewColumn // view_col* — column masking/tag bindings
+	CopyGrants  bool
+	Comment     *string          // COMMENT = 'str'; nil if absent
+	ClusterBy   []Node           // CLUSTER BY (exprs); nil if absent
+	Linear      bool             // CLUSTER BY LINEAR modifier
+	Tags        []*TagAssignment // WITH TAG (...); nil if absent
+	RowPolicy   *RowAccessPolicy // WITH ROW ACCESS POLICY ...; nil if absent
+	Query       Node             // the AS query body
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateMaterializedViewStmt) Tag() NodeTag { return T_CreateMaterializedViewStmt }
+
+var _ Node = (*CreateMaterializedViewStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// ALTER VIEW — action enum and statement
+// ---------------------------------------------------------------------------
+
+// AlterViewAction discriminates the action variants of ALTER VIEW.
+type AlterViewAction int
+
+const (
+	AlterViewRename                   AlterViewAction = iota // RENAME TO
+	AlterViewSetComment                                      // SET COMMENT = '...'
+	AlterViewUnsetComment                                    // UNSET COMMENT
+	AlterViewSetSecure                                       // SET SECURE
+	AlterViewUnsetSecure                                     // UNSET SECURE
+	AlterViewSetTag                                          // SET TAG (...)
+	AlterViewUnsetTag                                        // UNSET TAG (...)
+	AlterViewAddRowAccessPolicy                              // ADD ROW ACCESS POLICY
+	AlterViewDropRowAccessPolicy                             // DROP ROW ACCESS POLICY
+	AlterViewDropAllRowAccessPolicies                        // DROP ALL ROW ACCESS POLICIES
+	AlterViewColumnSetMaskingPolicy                          // ALTER COLUMN col SET MASKING POLICY
+	AlterViewColumnUnsetMaskingPolicy                        // ALTER COLUMN col UNSET MASKING POLICY
+	AlterViewColumnSetTag                                    // ALTER COLUMN col SET TAG (...)
+	AlterViewColumnUnsetTag                                  // ALTER COLUMN col UNSET TAG (...)
+)
+
+// AlterViewStmt represents ALTER VIEW ... (all action variants).
+type AlterViewStmt struct {
+	IfExists      bool
+	Name          *ObjectName
+	Action        AlterViewAction
+	NewName       *ObjectName      // RENAME TO
+	Comment       *string          // SET COMMENT = '...'
+	Secure        bool             // true = SET SECURE; false = UNSET SECURE (check Action)
+	Tags          []*TagAssignment // SET TAG (...)
+	UnsetTags     []*ObjectName    // UNSET TAG (...)
+	PolicyName    *ObjectName      // ADD/DROP ROW ACCESS POLICY name
+	PolicyCols    []Ident          // ON (col, ...) for ADD ROW ACCESS POLICY
+	Column        Ident            // ALTER COLUMN col name
+	MaskingPolicy *ObjectName      // SET MASKING POLICY p
+	MaskingUsing  []Ident          // USING (col, ...)
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *AlterViewStmt) Tag() NodeTag { return T_AlterViewStmt }
+
+var _ Node = (*AlterViewStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// ALTER MATERIALIZED VIEW — action enum and statement
+// ---------------------------------------------------------------------------
+
+// AlterMaterializedViewAction discriminates the action variants of ALTER MATERIALIZED VIEW.
+type AlterMaterializedViewAction int
+
+const (
+	AlterMVRename            AlterMaterializedViewAction = iota // RENAME TO
+	AlterMVClusterBy                                            // CLUSTER BY (exprs)
+	AlterMVDropClusteringKey                                    // DROP CLUSTERING KEY
+	AlterMVSuspend                                              // SUSPEND
+	AlterMVResume                                               // RESUME
+	AlterMVSuspendRecluster                                     // SUSPEND RECLUSTER
+	AlterMVResumeRecluster                                      // RESUME RECLUSTER
+	AlterMVSetSecure                                            // SET SECURE
+	AlterMVUnsetSecure                                          // UNSET SECURE
+	AlterMVSetComment                                           // SET COMMENT = '...'
+	AlterMVUnsetComment                                         // UNSET COMMENT
+)
+
+// AlterMaterializedViewStmt represents ALTER MATERIALIZED VIEW ... (all action variants).
+// Note: the legacy grammar does NOT support IF EXISTS for ALTER MATERIALIZED VIEW.
+type AlterMaterializedViewStmt struct {
+	Name      *ObjectName
+	Action    AlterMaterializedViewAction
+	NewName   *ObjectName // RENAME TO
+	ClusterBy []Node      // CLUSTER BY (exprs)
+	Linear    bool        // CLUSTER BY LINEAR modifier
+	Comment   *string     // SET COMMENT = '...'
+	Secure    bool        // true = SET SECURE; false = UNSET SECURE (check Action)
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *AlterMaterializedViewStmt) Tag() NodeTag { return T_AlterMaterializedViewStmt }
+
+var _ Node = (*AlterMaterializedViewStmt)(nil)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -16,12 +16,33 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterMaterializedViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
+		walkNodes(v, n.ClusterBy)
 	case *AlterSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
 		if n.NewName != nil {
 			Walk(v, n.NewName)
+		}
+	case *AlterViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
+		if n.PolicyName != nil {
+			Walk(v, n.PolicyName)
+		}
+		if n.MaskingPolicy != nil {
+			Walk(v, n.MaskingPolicy)
 		}
 	case *ArrayLiteralExpr:
 		walkNodes(v, n.Elements)
@@ -55,6 +76,12 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *CreateMaterializedViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		walkNodes(v, n.ClusterBy)
+		Walk(v, n.Query)
 	case *CreateSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -68,6 +95,11 @@ func walkChildren(v Visitor, node Node) {
 		if n.Like != nil {
 			Walk(v, n.Like)
 		}
+	case *CreateViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.Query)
 	case *DeleteStmt:
 		if n.Target != nil {
 			Walk(v, n.Target)

--- a/snowflake/diagnostics/diagnostics_test.go
+++ b/snowflake/diagnostics/diagnostics_test.go
@@ -85,9 +85,8 @@ func TestAnalyze_UnknownStatement(t *testing.T) {
 }
 
 func TestAnalyze_ErrorOnFirstLine_ColumnAccuracy(t *testing.T) {
-	// "INSERT INTO t" — INSERT is at byte 0, col 1 on line 1.
-	// The parser emits "INSERT statement parsing is not yet supported".
-	diags := Analyze("INSERT INTO t VALUES (1)")
+	// "@@bogus@@" — bad token at byte 0, col 1 on line 1.
+	diags := Analyze("@@bogus@@")
 	if len(diags) == 0 {
 		t.Fatal("expected at least one diagnostic, got none")
 	}
@@ -101,23 +100,23 @@ func TestAnalyze_ErrorOnFirstLine_ColumnAccuracy(t *testing.T) {
 }
 
 func TestAnalyze_UnsupportedStatementInMiddle(t *testing.T) {
-	// "SELECT 1; INSERT …" — INSERT starts at byte 10 (after "SELECT 1; ").
+	// "SELECT 1; @@bogus@@" — @@ starts at byte 10 (after "SELECT 1; ").
 	// Line is still 1, column 11.
-	sql := "SELECT 1; INSERT INTO t VALUES (1)"
+	sql := "SELECT 1; @@bogus@@"
 	diags := Analyze(sql)
 	if len(diags) == 0 {
 		t.Fatal("expected at least one diagnostic, got none")
 	}
-	insertDiag := diags[0]
-	if insertDiag.Range.Start.Line != 1 {
-		t.Errorf("line = %d, want 1", insertDiag.Range.Start.Line)
+	d := diags[0]
+	if d.Range.Start.Line != 1 {
+		t.Errorf("line = %d, want 1", d.Range.Start.Line)
 	}
-	// "SELECT 1; " is 10 bytes, so INSERT starts at column 11.
-	if insertDiag.Range.Start.Column != 11 {
-		t.Errorf("column = %d, want 11 (INSERT starts after 'SELECT 1; ')", insertDiag.Range.Start.Column)
+	// "SELECT 1; " is 10 bytes, so the bad token starts at column 11.
+	if d.Range.Start.Column != 11 {
+		t.Errorf("column = %d, want 11 (bad token starts after 'SELECT 1; ')", d.Range.Start.Column)
 	}
-	if insertDiag.Range.Start.Offset != 10 {
-		t.Errorf("offset = %d, want 10", insertDiag.Range.Start.Offset)
+	if d.Range.Start.Offset != 10 {
+		t.Errorf("offset = %d, want 10", d.Range.Start.Offset)
 	}
 }
 
@@ -126,8 +125,8 @@ func TestAnalyze_UnsupportedStatementInMiddle(t *testing.T) {
 // -----------------------------------------------------------------------
 
 func TestAnalyze_MultiLine_ErrorOnLine3(t *testing.T) {
-	// Error should be reported on line 3 (the INSERT statement).
-	sql := "SELECT 1;\nSELECT 2;\nINSERT INTO t VALUES (1)"
+	// Error should be reported on line 3 (the bad token).
+	sql := "SELECT 1;\nSELECT 2;\n@@bogus@@"
 	diags := Analyze(sql)
 	if len(diags) == 0 {
 		t.Fatal("expected at least one diagnostic")
@@ -161,7 +160,7 @@ func TestAnalyze_MultiLine_ErrorOnLine2(t *testing.T) {
 
 func TestAnalyze_CRLF_LineEndings(t *testing.T) {
 	// CRLF line endings — error should still report line 3.
-	sql := "SELECT 1;\r\nSELECT 2;\r\nINSERT INTO t VALUES (1)"
+	sql := "SELECT 1;\r\nSELECT 2;\r\n@@bogus@@"
 	diags := Analyze(sql)
 	if len(diags) == 0 {
 		t.Fatal("expected at least one diagnostic")
@@ -177,8 +176,8 @@ func TestAnalyze_CRLF_LineEndings(t *testing.T) {
 // -----------------------------------------------------------------------
 
 func TestAnalyze_MultipleErrors(t *testing.T) {
-	// Two unsupported statements.
-	sql := "INSERT INTO t VALUES (1);\nUPDATE t SET x=1"
+	// Two malformed statements.
+	sql := "@@bogus1@@;\n@@bogus2@@"
 	diags := Analyze(sql)
 	if len(diags) < 2 {
 		t.Fatalf("expected at least 2 diagnostics, got %d", len(diags))
@@ -336,14 +335,14 @@ func TestAnalyze_UTF8_ByteBasedColumn(t *testing.T) {
 func TestAnalyze_PositionConsistency(t *testing.T) {
 	// For a multi-line input, verify that the Offset of the error on line N
 	// is consistent with the line/column values.
-	sql := "SELECT 1;\nSELECT 2;\nINSERT INTO t VALUES (1)"
+	sql := "SELECT 1;\nSELECT 2;\n@@bogus@@"
 	diags := Analyze(sql)
 	if len(diags) == 0 {
 		t.Fatal("expected diagnostics")
 	}
 	d := diags[0]
-	// Line 3, column 1 → offset should equal the byte position of "INSERT" in sql.
-	wantOffset := strings.Index(sql, "INSERT")
+	// Line 3, column 1 → offset should equal the byte position of "@@bogus@@" in sql.
+	wantOffset := strings.Index(sql, "@@bogus@@")
 	if d.Range.Start.Offset != wantOffset {
 		t.Errorf("Start.Offset = %d, want %d", d.Range.Start.Offset, wantOffset)
 	}

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -23,6 +23,35 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		}
 	}
 
+	// Optional SECURE modifier (VIEW-only — must be checked before temporary modifiers
+	// since SECURE can appear before MATERIALIZED VIEW too).
+	secure := false
+	if p.cur.Type == kwSECURE {
+		p.advance()
+		secure = true
+	}
+
+	// Optional RECURSIVE modifier (VIEW-only).
+	recursive := false
+	if p.cur.Type == kwRECURSIVE {
+		p.advance()
+		recursive = true
+	}
+
+	// If SECURE or RECURSIVE were consumed, the next token must be VIEW or MATERIALIZED VIEW.
+	// Dispatch early before checking temporary modifiers.
+	if secure || recursive {
+		switch p.cur.Type {
+		case kwVIEW:
+			return p.parseCreateViewStmt(start, orReplace, secure, recursive)
+		case kwMATERIALIZED:
+			p.advance() // consume MATERIALIZED
+			return p.parseCreateMaterializedViewStmt(start, orReplace, secure)
+		default:
+			return p.unsupported("CREATE")
+		}
+	}
+
 	// Optional [LOCAL|GLOBAL] TRANSIENT|TEMPORARY|TEMP|VOLATILE
 	transient := false
 	temporary := false
@@ -52,6 +81,11 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		return p.parseCreateDatabaseStmt(start, orReplace, transient)
 	case kwSCHEMA:
 		return p.parseCreateSchemaStmt(start, orReplace, transient)
+	case kwVIEW:
+		return p.parseCreateViewStmt(start, orReplace, false, false)
+	case kwMATERIALIZED:
+		p.advance() // consume MATERIALIZED
+		return p.parseCreateMaterializedViewStmt(start, orReplace, false)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -155,7 +155,8 @@ func (p *Parser) parseCreateSchemaStmt(start ast.Loc, orReplace, transient bool)
 // ---------------------------------------------------------------------------
 
 // parseAlterStmt dispatches ALTER ... to the appropriate sub-parser.
-// Handles DATABASE and SCHEMA; falls back to unsupported for other objects.
+// Handles DATABASE, SCHEMA, VIEW, and MATERIALIZED VIEW; falls back to
+// unsupported for other objects.
 func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	p.advance() // consume ALTER
 
@@ -164,6 +165,11 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		return p.parseAlterDatabaseStmt()
 	case kwSCHEMA:
 		return p.parseAlterSchemaStmt()
+	case kwVIEW:
+		return p.parseAlterViewStmt()
+	case kwMATERIALIZED:
+		p.advance() // consume MATERIALIZED
+		return p.parseAlterMaterializedViewStmt()
 	default:
 		return p.unsupported("ALTER")
 	}

--- a/snowflake/parser/view.go
+++ b/snowflake/parser/view.go
@@ -1,0 +1,920 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// CREATE VIEW
+// ---------------------------------------------------------------------------
+
+// parseCreateViewStmt parses the body of a CREATE [OR REPLACE] [SECURE]
+// [RECURSIVE] VIEW statement. The CREATE keyword and OR REPLACE / SECURE /
+// RECURSIVE modifiers have already been consumed; start is the Loc of the
+// CREATE token.
+func (p *Parser) parseCreateViewStmt(start ast.Loc, orReplace, secure, recursive bool) (ast.Node, error) {
+	p.advance() // consume VIEW
+
+	stmt := &ast.CreateViewStmt{
+		OrReplace: orReplace,
+		Secure:    secure,
+		Recursive: recursive,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// View name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional ( column_list_with_comment )
+	if p.cur.Type == '(' {
+		cols, err := p.parseViewColumnList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Columns = cols
+	}
+
+	// Optional view_col* — column-level masking/tag bindings (outside parens)
+	viewCols, err := p.parseViewCols()
+	if err != nil {
+		return nil, err
+	}
+	stmt.ViewCols = viewCols
+
+	// Optional WITH ROW ACCESS POLICY / WITH TAG / COPY GRANTS / COMMENT = '...'
+	// These can appear in any order per Snowflake docs; the legacy grammar puts them
+	// before AS. We consume them in a loop until we hit AS.
+	if err := p.parseViewProperties(stmt); err != nil {
+		return nil, err
+	}
+
+	// AS query_statement
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	query, err := p.parseViewQuery()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Query = query
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseViewQuery parses the query body after AS in CREATE VIEW / CREATE MATERIALIZED VIEW.
+// Handles both plain SELECT and WITH ... SELECT (CTE) forms.
+func (p *Parser) parseViewQuery() (ast.Node, error) {
+	if p.cur.Type == kwWITH {
+		return p.parseWithQueryExpr()
+	}
+	return p.parseQueryExpr()
+}
+
+// parseViewColumnList parses ( col_name [COMMENT 'text'], ... ).
+// Used by both CREATE VIEW and CREATE MATERIALIZED VIEW.
+func (p *Parser) parseViewColumnList() ([]*ast.ViewColumn, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var cols []*ast.ViewColumn
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		col := &ast.ViewColumn{Loc: p.cur.Loc}
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		col.Name = name
+
+		// Optional COMMENT 'text'
+		if p.cur.Type == kwCOMMENT {
+			p.advance() // consume COMMENT
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return nil, err
+			}
+			s := tok.Str
+			col.Comment = &s
+		}
+
+		col.Loc.End = p.prev.Loc.End
+		cols = append(cols, col)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+		} else {
+			break
+		}
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return cols, nil
+}
+
+// parseViewCols parses zero or more view_col entries:
+//
+//	column_name WITH MASKING POLICY id [USING (col, ...)] [WITH TAG (...)]
+//
+// Each entry starts with an identifier that is NOT followed by a WITH that
+// leads to ROW or TAG at the statement level — we distinguish by checking
+// if the ident is followed by WITH MASKING POLICY.
+func (p *Parser) parseViewCols() ([]*ast.ViewColumn, error) {
+	var cols []*ast.ViewColumn
+
+	for {
+		// A view_col starts with an identifier (column name) followed by
+		// WITH MASKING POLICY or WITH TAG. We need two tokens of lookahead
+		// to detect this pattern. Use the heuristic: if cur is an identifier
+		// and next is WITH, and the token after WITH is MASKING or TAG —
+		// consume a view_col. Otherwise stop.
+		if p.cur.Type != tokIdent {
+			break
+		}
+		next := p.peekNext()
+		if next.Type != kwWITH {
+			break
+		}
+
+		// We have ident WITH — save the ident start, then check what follows WITH.
+		// We must consume to find the token after WITH; use a two-step look-ahead
+		// trick: peek ahead to see if the token after WITH is MASKING or TAG.
+		// Because we only have 1-token lookahead, consume optimistically and rollback
+		// is not possible. Instead, check: if peekNext() == kwWITH, advance past the
+		// column name and WITH, then check cur for MASKING or TAG.
+		colStartLoc := p.cur.Loc
+		colName, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		// cur is now WITH
+		p.advance() // consume WITH
+
+		// Now cur should be MASKING or TAG to be a valid view_col.
+		if p.cur.Type != kwMASKING && p.cur.Type != kwTAG {
+			// This is not a view_col — we over-consumed. This shouldn't happen in
+			// practice because well-formed SQL has WITH [ROW|TAG|COPY|MASKING] here,
+			// and ROW/COPY lead to statement-level properties, not column bindings.
+			// If cur is ROW or COPY or similar, we need to put back the column name
+			// and WITH. Since we can't un-advance, treat this as a parse issue and
+			// stop view_col parsing. The outer loop will handle WITH at statement level.
+			// Return what we have.
+			break
+		}
+
+		col := &ast.ViewColumn{
+			Name: colName,
+			Loc:  ast.Loc{Start: colStartLoc.Start},
+		}
+
+		// Parse the WITH MASKING POLICY / WITH TAG chain.
+		if err := p.parseViewColChain(col); err != nil {
+			return nil, err
+		}
+
+		col.Loc.End = p.prev.Loc.End
+		cols = append(cols, col)
+	}
+
+	return cols, nil
+}
+
+// parseViewColChain parses the WITH MASKING POLICY ... and/or WITH TAG (...)
+// clauses that follow a column name in a view_col. Called after WITH has been
+// consumed and cur is at MASKING or TAG.
+func (p *Parser) parseViewColChain(col *ast.ViewColumn) error {
+	for {
+		switch p.cur.Type {
+		case kwMASKING:
+			// MASKING POLICY name [USING (col, ...)]
+			p.advance() // consume MASKING
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return err
+			}
+			policyName, err := p.parseObjectName()
+			if err != nil {
+				return err
+			}
+			col.MaskingPolicy = policyName
+
+			// Optional USING (col [, col ...])
+			if p.cur.Type == kwUSING {
+				p.advance() // consume USING
+				if _, err := p.expect('('); err != nil {
+					return err
+				}
+				for p.cur.Type != ')' && p.cur.Type != tokEOF {
+					id, err := p.parseIdent()
+					if err != nil {
+						return err
+					}
+					col.MaskingUsing = append(col.MaskingUsing, id)
+					if p.cur.Type == ',' {
+						p.advance() // consume ','
+					} else {
+						break
+					}
+				}
+				if _, err := p.expect(')'); err != nil {
+					return err
+				}
+			}
+
+			// Check for optional WITH TAG following
+			if p.cur.Type == kwWITH && p.peekNext().Type == kwTAG {
+				p.advance() // consume WITH
+				// fall through to kwTAG case on next iteration
+				continue
+			}
+			return nil
+
+		case kwTAG:
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return err
+			}
+			col.Tags = append(col.Tags, tags...)
+
+			// Check for optional WITH MASKING following
+			if p.cur.Type == kwWITH && p.peekNext().Type == kwMASKING {
+				p.advance() // consume WITH
+				continue
+			}
+			return nil
+
+		default:
+			return nil
+		}
+	}
+}
+
+// parseViewProperties parses the optional clauses that appear before AS in
+// a CREATE VIEW / CREATE MATERIALIZED VIEW: WITH ROW ACCESS POLICY,
+// WITH TAG, COPY GRANTS, COMMENT = '...'. Stops when it hits AS or EOF.
+//
+// The stmt parameter is an interface — use type switch to set fields on either
+// CreateViewStmt or CreateMaterializedViewStmt.
+func (p *Parser) parseViewProperties(stmt interface{}) error {
+	for {
+		switch p.cur.Type {
+		case kwWITH:
+			next := p.peekNext()
+			switch next.Type {
+			case kwROW:
+				// WITH ROW ACCESS POLICY name ON (cols)
+				p.advance() // consume WITH
+				rp, err := p.parseRowAccessPolicyClause()
+				if err != nil {
+					return err
+				}
+				switch s := stmt.(type) {
+				case *ast.CreateViewStmt:
+					s.RowPolicy = rp
+				case *ast.CreateMaterializedViewStmt:
+					s.RowPolicy = rp
+				}
+			case kwTAG:
+				// WITH TAG (name = 'val', ...)
+				p.advance() // consume WITH
+				tags, err := p.parseTagAssignments()
+				if err != nil {
+					return err
+				}
+				switch s := stmt.(type) {
+				case *ast.CreateViewStmt:
+					s.Tags = append(s.Tags, tags...)
+				case *ast.CreateMaterializedViewStmt:
+					s.Tags = append(s.Tags, tags...)
+				}
+			default:
+				return nil
+			}
+
+		case kwTAG:
+			// TAG (...) without WITH prefix
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return err
+			}
+			switch s := stmt.(type) {
+			case *ast.CreateViewStmt:
+				s.Tags = append(s.Tags, tags...)
+			case *ast.CreateMaterializedViewStmt:
+				s.Tags = append(s.Tags, tags...)
+			}
+
+		case kwCOPY:
+			if p.peekNext().Type == kwGRANTS {
+				p.advance() // consume COPY
+				p.advance() // consume GRANTS
+				switch s := stmt.(type) {
+				case *ast.CreateViewStmt:
+					s.CopyGrants = true
+				case *ast.CreateMaterializedViewStmt:
+					s.CopyGrants = true
+				}
+			} else {
+				return nil
+			}
+
+		case kwCOMMENT:
+			// COMMENT = 'text'
+			p.advance() // consume COMMENT
+			if p.cur.Type == '=' {
+				p.advance() // consume '='
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return err
+			}
+			s := tok.Str
+			switch v := stmt.(type) {
+			case *ast.CreateViewStmt:
+				v.Comment = &s
+			case *ast.CreateMaterializedViewStmt:
+				v.Comment = &s
+			}
+
+		default:
+			return nil
+		}
+	}
+}
+
+// parseRowAccessPolicyClause parses:
+//
+//	ROW ACCESS POLICY policy_name ON (col [, col ...])
+//
+// Called after WITH has been consumed and cur is at ROW.
+func (p *Parser) parseRowAccessPolicyClause() (*ast.RowAccessPolicy, error) {
+	p.advance() // consume ROW
+	if _, err := p.expect(kwACCESS); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return nil, err
+	}
+
+	policyName, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	rp := &ast.RowAccessPolicy{PolicyName: policyName}
+
+	// ON (col [, col ...])
+	if p.cur.Type == kwON {
+		p.advance() // consume ON
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		for p.cur.Type != ')' && p.cur.Type != tokEOF {
+			id, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			rp.Columns = append(rp.Columns, id)
+			if p.cur.Type == ',' {
+				p.advance() // consume ','
+			} else {
+				break
+			}
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+	}
+
+	return rp, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// parseCreateMaterializedViewStmt parses the body of a CREATE [OR REPLACE]
+// [SECURE] MATERIALIZED VIEW statement. The CREATE keyword and OR REPLACE /
+// SECURE modifiers have already been consumed; MATERIALIZED has also been
+// consumed. start is the Loc of the CREATE token.
+func (p *Parser) parseCreateMaterializedViewStmt(start ast.Loc, orReplace, secure bool) (ast.Node, error) {
+	p.advance() // consume VIEW
+
+	stmt := &ast.CreateMaterializedViewStmt{
+		OrReplace: orReplace,
+		Secure:    secure,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// View name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional ( column_list_with_comment )
+	if p.cur.Type == '(' {
+		cols, err := p.parseViewColumnList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Columns = cols
+	}
+
+	// Optional view_col*
+	viewCols, err := p.parseViewCols()
+	if err != nil {
+		return nil, err
+	}
+	stmt.ViewCols = viewCols
+
+	// Optional WITH ROW ACCESS POLICY / WITH TAG / COPY GRANTS / COMMENT
+	if err := p.parseViewProperties(stmt); err != nil {
+		return nil, err
+	}
+
+	// Optional CLUSTER BY [LINEAR] (exprs)
+	if p.cur.Type == kwCLUSTER {
+		p.advance() // consume CLUSTER
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		if p.cur.Type == kwLINEAR {
+			p.advance() // consume LINEAR
+			stmt.Linear = true
+		}
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		stmt.ClusterBy = exprs
+	}
+
+	// AS select_statement
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	query, err := p.parseViewQuery()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Query = query
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER VIEW
+// ---------------------------------------------------------------------------
+
+// parseAlterViewStmt parses ALTER VIEW ... (all action variants).
+// The ALTER keyword has already been consumed; cur is at VIEW.
+func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
+	altTok := p.advance() // consume VIEW
+	stmt := &ast.AlterViewStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// View name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO new_name
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterViewRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		switch p.cur.Type {
+		case kwCOMMENT:
+			// SET COMMENT = '...'
+			p.advance() // consume COMMENT
+			if p.cur.Type == '=' {
+				p.advance() // consume '='
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return nil, err
+			}
+			s := tok.Str
+			stmt.Action = ast.AlterViewSetComment
+			stmt.Comment = &s
+
+		case kwSECURE:
+			p.advance() // consume SECURE
+			stmt.Action = ast.AlterViewSetSecure
+			stmt.Secure = true
+
+		case kwTAG:
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterViewSetTag
+			stmt.Tags = tags
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		switch p.cur.Type {
+		case kwCOMMENT:
+			p.advance() // consume COMMENT
+			stmt.Action = ast.AlterViewUnsetComment
+
+		case kwSECURE:
+			p.advance() // consume SECURE
+			stmt.Action = ast.AlterViewUnsetSecure
+
+		case kwTAG:
+			names, err := p.parseUnsetTagList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterViewUnsetTag
+			stmt.UnsetTags = names
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwADD:
+		// ADD ROW ACCESS POLICY policy_name ON (cols)
+		p.advance() // consume ADD
+		if _, err := p.expect(kwROW); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwACCESS); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return nil, err
+		}
+		policyName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwON); err != nil {
+			return nil, err
+		}
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterViewAddRowAccessPolicy
+		stmt.PolicyName = policyName
+		stmt.PolicyCols = cols
+
+	case kwDROP:
+		p.advance() // consume DROP
+		switch p.cur.Type {
+		case kwROW:
+			// DROP ROW ACCESS POLICY policy_name
+			// OR DROP ALL ROW ACCESS POLICIES
+			p.advance() // consume ROW
+			if _, err := p.expect(kwACCESS); err != nil {
+				return nil, err
+			}
+			if p.cur.Type == kwPOLICY {
+				p.advance() // consume POLICY
+				policyName, err := p.parseObjectName()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Action = ast.AlterViewDropRowAccessPolicy
+				stmt.PolicyName = policyName
+			} else if p.cur.Type == kwPOLICIES {
+				p.advance() // consume POLICIES
+				stmt.Action = ast.AlterViewDropAllRowAccessPolicies
+			} else {
+				return nil, p.syntaxErrorAtCur()
+			}
+		case kwALL:
+			// DROP ALL ROW ACCESS POLICIES
+			p.advance() // consume ALL
+			if _, err := p.expect(kwROW); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwACCESS); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwPOLICIES); err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterViewDropAllRowAccessPolicies
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwALTER, kwMODIFY:
+		// ALTER|MODIFY [COLUMN] col_name SET MASKING POLICY / UNSET MASKING POLICY
+		// ALTER|MODIFY [COLUMN] col_name SET TAG / UNSET TAG
+		p.advance() // consume ALTER or MODIFY
+		// Optional COLUMN keyword
+		if p.cur.Type == kwCOLUMN {
+			p.advance() // consume COLUMN
+		}
+		colName, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Column = colName
+
+		switch p.cur.Type {
+		case kwSET:
+			p.advance() // consume SET
+			switch p.cur.Type {
+			case kwMASKING:
+				// SET MASKING POLICY policy_name [USING (col, ...)] [FORCE]
+				p.advance() // consume MASKING
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return nil, err
+				}
+				policyName, err := p.parseObjectName()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Action = ast.AlterViewColumnSetMaskingPolicy
+				stmt.MaskingPolicy = policyName
+
+				// Optional USING (col, ...)
+				if p.cur.Type == kwUSING {
+					p.advance() // consume USING
+					if _, err := p.expect('('); err != nil {
+						return nil, err
+					}
+					for p.cur.Type != ')' && p.cur.Type != tokEOF {
+						id, err := p.parseIdent()
+						if err != nil {
+							return nil, err
+						}
+						stmt.MaskingUsing = append(stmt.MaskingUsing, id)
+						if p.cur.Type == ',' {
+							p.advance()
+						} else {
+							break
+						}
+					}
+					if _, err := p.expect(')'); err != nil {
+						return nil, err
+					}
+				}
+
+				// Optional FORCE
+				if p.cur.Type == kwFORCE {
+					p.advance() // consume FORCE
+				}
+
+			case kwTAG:
+				tags, err := p.parseTagAssignments()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Action = ast.AlterViewColumnSetTag
+				stmt.Tags = tags
+
+			default:
+				return nil, p.syntaxErrorAtCur()
+			}
+
+		case kwUNSET:
+			p.advance() // consume UNSET
+			switch p.cur.Type {
+			case kwMASKING:
+				p.advance() // consume MASKING
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return nil, err
+				}
+				stmt.Action = ast.AlterViewColumnUnsetMaskingPolicy
+
+			case kwTAG:
+				names, err := p.parseUnsetTagList()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Action = ast.AlterViewColumnUnsetTag
+				stmt.UnsetTags = names
+
+			default:
+				return nil, p.syntaxErrorAtCur()
+			}
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// parseAlterMaterializedViewStmt parses ALTER MATERIALIZED VIEW ... (all action variants).
+// The ALTER keyword has already been consumed; MATERIALIZED has also been consumed;
+// cur is at VIEW.
+func (p *Parser) parseAlterMaterializedViewStmt() (ast.Node, error) {
+	altTok := p.advance() // consume VIEW
+	stmt := &ast.AlterMaterializedViewStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	// Note: the legacy grammar does NOT have IF EXISTS for ALTER MATERIALIZED VIEW.
+	// The grammar uses plain `id_` (not `if_exists? object_name`).
+
+	// View name (1-part only per legacy grammar, but we use parseObjectName for generality)
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO new_name
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterMVRename
+		stmt.NewName = newName
+
+	case kwCLUSTER:
+		// CLUSTER BY (exprs)
+		p.advance() // consume CLUSTER
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		if p.cur.Type == kwLINEAR {
+			p.advance() // consume LINEAR
+			stmt.Linear = true
+		}
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterMVClusterBy
+		stmt.ClusterBy = exprs
+
+	case kwDROP:
+		// DROP CLUSTERING KEY
+		p.advance() // consume DROP
+		if _, err := p.expect(kwCLUSTERING); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwKEY); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterMVDropClusteringKey
+
+	case kwSUSPEND:
+		// SUSPEND [RECLUSTER]
+		p.advance() // consume SUSPEND
+		if p.cur.Type == kwRECLUSTER {
+			p.advance() // consume RECLUSTER
+			stmt.Action = ast.AlterMVSuspendRecluster
+		} else {
+			stmt.Action = ast.AlterMVSuspend
+		}
+
+	case kwRESUME:
+		// RESUME [RECLUSTER]
+		p.advance() // consume RESUME
+		if p.cur.Type == kwRECLUSTER {
+			p.advance() // consume RECLUSTER
+			stmt.Action = ast.AlterMVResumeRecluster
+		} else {
+			stmt.Action = ast.AlterMVResume
+		}
+
+	case kwSET:
+		// SET [SECURE] [COMMENT = '...']
+		// Can be SET SECURE, SET COMMENT = '...', or SET SECURE COMMENT = '...'
+		p.advance() // consume SET
+		switch p.cur.Type {
+		case kwSECURE:
+			p.advance() // consume SECURE
+			stmt.Action = ast.AlterMVSetSecure
+			stmt.Secure = true
+			// Check if COMMENT follows (SET SECURE COMMENT = '...')
+			if p.cur.Type == kwCOMMENT {
+				p.advance() // consume COMMENT
+				if p.cur.Type == '=' {
+					p.advance()
+				}
+				tok, err := p.expect(tokString)
+				if err != nil {
+					return nil, err
+				}
+				s := tok.Str
+				stmt.Comment = &s
+			}
+		case kwCOMMENT:
+			p.advance() // consume COMMENT
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return nil, err
+			}
+			s := tok.Str
+			stmt.Action = ast.AlterMVSetComment
+			stmt.Comment = &s
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwUNSET:
+		// UNSET SECURE | UNSET COMMENT
+		p.advance() // consume UNSET
+		switch p.cur.Type {
+		case kwSECURE:
+			p.advance() // consume SECURE
+			stmt.Action = ast.AlterMVUnsetSecure
+		case kwCOMMENT:
+			p.advance() // consume COMMENT
+			stmt.Action = ast.AlterMVUnsetComment
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/snowflake/parser/view_test.go
+++ b/snowflake/parser/view_test.go
@@ -1,0 +1,729 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func testParseCreateView(input string) (*ast.CreateViewStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CreateViewStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a CreateViewStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseCreateMaterializedView(input string) (*ast.CreateMaterializedViewStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CreateMaterializedViewStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a CreateMaterializedViewStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseAlterView(input string) (*ast.AlterViewStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.AlterViewStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not an AlterViewStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseAlterMaterializedView(input string) (*ast.AlterMaterializedViewStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.AlterMaterializedViewStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not an AlterMaterializedViewStmt"})
+	}
+	return stmt, result.Errors
+}
+
+// ---------------------------------------------------------------------------
+// CREATE VIEW tests
+// ---------------------------------------------------------------------------
+
+func TestCreateView_Basic(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected CreateViewStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "V" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "V")
+	}
+	if stmt.OrReplace || stmt.Secure || stmt.Recursive || stmt.IfNotExists {
+		t.Error("unexpected flags set")
+	}
+	if stmt.Query == nil {
+		t.Error("Query is nil")
+	}
+}
+
+func TestCreateView_OrReplace(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE OR REPLACE VIEW v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+}
+
+func TestCreateView_Secure(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE SECURE VIEW v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Secure {
+		t.Error("expected Secure=true")
+	}
+}
+
+func TestCreateView_Recursive(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE RECURSIVE VIEW v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Recursive {
+		t.Error("expected Recursive=true")
+	}
+}
+
+func TestCreateView_OrReplaceSecure(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE OR REPLACE SECURE VIEW v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.Secure {
+		t.Error("expected Secure=true")
+	}
+}
+
+func TestCreateView_IfNotExists(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW IF NOT EXISTS v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+}
+
+func TestCreateView_QualifiedName(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW mydb.myschema.v AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA.V" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MYDB.MYSCHEMA.V")
+	}
+}
+
+func TestCreateView_ColumnList(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v (col1, col2 COMMENT 'a column') AS SELECT 1, 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+	if stmt.Columns[0].Name.Normalize() != "COL1" {
+		t.Errorf("col[0] = %q, want COL1", stmt.Columns[0].Name.Normalize())
+	}
+	if stmt.Columns[1].Name.Normalize() != "COL2" {
+		t.Errorf("col[1] = %q, want COL2", stmt.Columns[1].Name.Normalize())
+	}
+	if stmt.Columns[1].Comment == nil || *stmt.Columns[1].Comment != "a column" {
+		t.Error("col[1] comment missing or wrong")
+	}
+}
+
+func TestCreateView_CopyGrants(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v COPY GRANTS AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.CopyGrants {
+		t.Error("expected CopyGrants=true")
+	}
+}
+
+func TestCreateView_Comment(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v COMMENT = 'my view' AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "my view" {
+		t.Errorf("comment = %v, want 'my view'", stmt.Comment)
+	}
+}
+
+func TestCreateView_WithTag(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v WITH TAG (env = 'prod') AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Tags) != 1 {
+		t.Fatalf("tags = %d, want 1", len(stmt.Tags))
+	}
+	if stmt.Tags[0].Value != "prod" {
+		t.Errorf("tag value = %q, want 'prod'", stmt.Tags[0].Value)
+	}
+}
+
+func TestCreateView_WithRowAccessPolicy(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v WITH ROW ACCESS POLICY my_policy ON (col1, col2) AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.RowPolicy == nil {
+		t.Fatal("RowPolicy is nil")
+	}
+	if stmt.RowPolicy.PolicyName.Normalize() != "MY_POLICY" {
+		t.Errorf("policy = %q, want MY_POLICY", stmt.RowPolicy.PolicyName.Normalize())
+	}
+	if len(stmt.RowPolicy.Columns) != 2 {
+		t.Fatalf("policy cols = %d, want 2", len(stmt.RowPolicy.Columns))
+	}
+}
+
+func TestCreateView_WithCTE(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v AS WITH cte AS (SELECT 1) SELECT * FROM cte")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Query == nil {
+		t.Error("Query is nil")
+	}
+}
+
+func TestCreateView_AllModifiers(t *testing.T) {
+	sql := `CREATE OR REPLACE SECURE VIEW v
+		COMMENT = 'test'
+		COPY GRANTS
+		WITH TAG (env = 'prod')
+		AS SELECT 1`
+	stmt, errs := testParseCreateView(sql)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.Secure {
+		t.Error("expected Secure=true")
+	}
+	if !stmt.CopyGrants {
+		t.Error("expected CopyGrants=true")
+	}
+	if stmt.Comment == nil || *stmt.Comment != "test" {
+		t.Error("comment missing or wrong")
+	}
+	if len(stmt.Tags) != 1 {
+		t.Errorf("tags = %d, want 1", len(stmt.Tags))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE MATERIALIZED VIEW tests
+// ---------------------------------------------------------------------------
+
+func TestCreateMaterializedView_Basic(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt == nil {
+		t.Fatal("expected CreateMaterializedViewStmt, got nil")
+	}
+	if stmt.Name.Normalize() != "MV" {
+		t.Errorf("name = %q, want MV", stmt.Name.Normalize())
+	}
+	if stmt.Query == nil {
+		t.Error("Query is nil")
+	}
+}
+
+func TestCreateMaterializedView_OrReplaceSecure(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE OR REPLACE SECURE MATERIALIZED VIEW mv AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.Secure {
+		t.Error("expected Secure=true")
+	}
+}
+
+func TestCreateMaterializedView_IfNotExists(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW IF NOT EXISTS mv AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+}
+
+func TestCreateMaterializedView_ClusterBy(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv CLUSTER BY (col1, col2) AS SELECT col1, col2 FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.ClusterBy) != 2 {
+		t.Fatalf("ClusterBy = %d, want 2", len(stmt.ClusterBy))
+	}
+}
+
+func TestCreateMaterializedView_ClusterByLinear(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv CLUSTER BY LINEAR (col1) AS SELECT col1 FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Linear {
+		t.Error("expected Linear=true")
+	}
+	if len(stmt.ClusterBy) != 1 {
+		t.Fatalf("ClusterBy = %d, want 1", len(stmt.ClusterBy))
+	}
+}
+
+func TestCreateMaterializedView_Comment(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv COMMENT = 'mv comment' AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "mv comment" {
+		t.Errorf("comment = %v, want 'mv comment'", stmt.Comment)
+	}
+}
+
+func TestCreateMaterializedView_ColumnList(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv (a, b) AS SELECT 1, 2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+}
+
+func TestCreateMaterializedView_WithTag(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv WITH TAG (k = 'v') AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Tags) != 1 {
+		t.Fatalf("tags = %d, want 1", len(stmt.Tags))
+	}
+}
+
+func TestCreateMaterializedView_RowAccessPolicy(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv WITH ROW ACCESS POLICY pol ON (id) AS SELECT id FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.RowPolicy == nil {
+		t.Fatal("RowPolicy is nil")
+	}
+	if stmt.RowPolicy.PolicyName.Normalize() != "POL" {
+		t.Errorf("policy = %q, want POL", stmt.RowPolicy.PolicyName.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER VIEW tests
+// ---------------------------------------------------------------------------
+
+func TestAlterView_RenameTo(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v RENAME TO v2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewRename {
+		t.Errorf("action = %v, want AlterViewRename", stmt.Action)
+	}
+	if stmt.NewName.Normalize() != "V2" {
+		t.Errorf("new name = %q, want V2", stmt.NewName.Normalize())
+	}
+}
+
+func TestAlterView_IfExists(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW IF EXISTS v RENAME TO v2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+func TestAlterView_SetComment(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET COMMENT = 'hello'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewSetComment {
+		t.Errorf("action = %v, want AlterViewSetComment", stmt.Action)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "hello" {
+		t.Errorf("comment = %v, want 'hello'", stmt.Comment)
+	}
+}
+
+func TestAlterView_UnsetComment(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v UNSET COMMENT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewUnsetComment {
+		t.Errorf("action = %v, want AlterViewUnsetComment", stmt.Action)
+	}
+}
+
+func TestAlterView_SetSecure(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET SECURE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewSetSecure {
+		t.Errorf("action = %v, want AlterViewSetSecure", stmt.Action)
+	}
+}
+
+func TestAlterView_UnsetSecure(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v UNSET SECURE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewUnsetSecure {
+		t.Errorf("action = %v, want AlterViewUnsetSecure", stmt.Action)
+	}
+}
+
+func TestAlterView_SetTag(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET TAG (env = 'prod')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewSetTag {
+		t.Errorf("action = %v, want AlterViewSetTag", stmt.Action)
+	}
+	if len(stmt.Tags) != 1 {
+		t.Fatalf("tags = %d, want 1", len(stmt.Tags))
+	}
+}
+
+func TestAlterView_UnsetTag(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v UNSET TAG (env)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewUnsetTag {
+		t.Errorf("action = %v, want AlterViewUnsetTag", stmt.Action)
+	}
+	if len(stmt.UnsetTags) != 1 {
+		t.Fatalf("unset tags = %d, want 1", len(stmt.UnsetTags))
+	}
+}
+
+func TestAlterView_AddRowAccessPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v ADD ROW ACCESS POLICY pol ON (col1, col2)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewAddRowAccessPolicy {
+		t.Errorf("action = %v, want AlterViewAddRowAccessPolicy", stmt.Action)
+	}
+	if stmt.PolicyName.Normalize() != "POL" {
+		t.Errorf("policy = %q, want POL", stmt.PolicyName.Normalize())
+	}
+	if len(stmt.PolicyCols) != 2 {
+		t.Fatalf("policy cols = %d, want 2", len(stmt.PolicyCols))
+	}
+}
+
+func TestAlterView_DropRowAccessPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v DROP ROW ACCESS POLICY pol")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewDropRowAccessPolicy {
+		t.Errorf("action = %v, want AlterViewDropRowAccessPolicy", stmt.Action)
+	}
+	if stmt.PolicyName.Normalize() != "POL" {
+		t.Errorf("policy = %q, want POL", stmt.PolicyName.Normalize())
+	}
+}
+
+func TestAlterView_DropAllRowAccessPolicies(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v DROP ALL ROW ACCESS POLICIES")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewDropAllRowAccessPolicies {
+		t.Errorf("action = %v, want AlterViewDropAllRowAccessPolicies", stmt.Action)
+	}
+}
+
+func TestAlterView_AlterColumnSetMaskingPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v ALTER COLUMN col1 SET MASKING POLICY pol")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewColumnSetMaskingPolicy {
+		t.Errorf("action = %v, want AlterViewColumnSetMaskingPolicy", stmt.Action)
+	}
+	if stmt.Column.Normalize() != "COL1" {
+		t.Errorf("column = %q, want COL1", stmt.Column.Normalize())
+	}
+	if stmt.MaskingPolicy.Normalize() != "POL" {
+		t.Errorf("policy = %q, want POL", stmt.MaskingPolicy.Normalize())
+	}
+}
+
+func TestAlterView_AlterColumnSetMaskingPolicyUsing(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v ALTER COLUMN col1 SET MASKING POLICY pol USING (col1, col2)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewColumnSetMaskingPolicy {
+		t.Errorf("action = %v, want AlterViewColumnSetMaskingPolicy", stmt.Action)
+	}
+	if len(stmt.MaskingUsing) != 2 {
+		t.Fatalf("masking using = %d, want 2", len(stmt.MaskingUsing))
+	}
+}
+
+func TestAlterView_AlterColumnUnsetMaskingPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v ALTER COLUMN col1 UNSET MASKING POLICY")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewColumnUnsetMaskingPolicy {
+		t.Errorf("action = %v, want AlterViewColumnUnsetMaskingPolicy", stmt.Action)
+	}
+}
+
+func TestAlterView_AlterColumnSetTag(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v ALTER COLUMN col1 SET TAG (env = 'prod')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewColumnSetTag {
+		t.Errorf("action = %v, want AlterViewColumnSetTag", stmt.Action)
+	}
+	if stmt.Column.Normalize() != "COL1" {
+		t.Errorf("column = %q, want COL1", stmt.Column.Normalize())
+	}
+}
+
+func TestAlterView_AlterColumnUnsetTag(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v ALTER COLUMN col1 UNSET TAG (env)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewColumnUnsetTag {
+		t.Errorf("action = %v, want AlterViewColumnUnsetTag", stmt.Action)
+	}
+}
+
+func TestAlterView_ModifyColumn(t *testing.T) {
+	// MODIFY is an alias for ALTER per legacy grammar
+	stmt, errs := testParseAlterView("ALTER VIEW v MODIFY COLUMN col1 SET MASKING POLICY pol")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewColumnSetMaskingPolicy {
+		t.Errorf("action = %v, want AlterViewColumnSetMaskingPolicy", stmt.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER MATERIALIZED VIEW tests
+// ---------------------------------------------------------------------------
+
+func TestAlterMaterializedView_RenameTo(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv RENAME TO mv2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVRename {
+		t.Errorf("action = %v, want AlterMVRename", stmt.Action)
+	}
+	if stmt.NewName.Normalize() != "MV2" {
+		t.Errorf("new name = %q, want MV2", stmt.NewName.Normalize())
+	}
+}
+
+func TestAlterMaterializedView_ClusterBy(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv CLUSTER BY (col1, col2)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVClusterBy {
+		t.Errorf("action = %v, want AlterMVClusterBy", stmt.Action)
+	}
+	if len(stmt.ClusterBy) != 2 {
+		t.Fatalf("ClusterBy = %d, want 2", len(stmt.ClusterBy))
+	}
+}
+
+func TestAlterMaterializedView_DropClusteringKey(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv DROP CLUSTERING KEY")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVDropClusteringKey {
+		t.Errorf("action = %v, want AlterMVDropClusteringKey", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_Suspend(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv SUSPEND")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVSuspend {
+		t.Errorf("action = %v, want AlterMVSuspend", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_Resume(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv RESUME")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVResume {
+		t.Errorf("action = %v, want AlterMVResume", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_SuspendRecluster(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv SUSPEND RECLUSTER")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVSuspendRecluster {
+		t.Errorf("action = %v, want AlterMVSuspendRecluster", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_ResumeRecluster(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv RESUME RECLUSTER")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVResumeRecluster {
+		t.Errorf("action = %v, want AlterMVResumeRecluster", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_SetSecure(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv SET SECURE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVSetSecure {
+		t.Errorf("action = %v, want AlterMVSetSecure", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_UnsetSecure(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv UNSET SECURE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVUnsetSecure {
+		t.Errorf("action = %v, want AlterMVUnsetSecure", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_SetComment(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv SET COMMENT = 'test mv'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVSetComment {
+		t.Errorf("action = %v, want AlterMVSetComment", stmt.Action)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "test mv" {
+		t.Errorf("comment = %v, want 'test mv'", stmt.Comment)
+	}
+}
+
+func TestAlterMaterializedView_UnsetComment(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv UNSET COMMENT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterMVUnsetComment {
+		t.Errorf("action = %v, want AlterMVUnsetComment", stmt.Action)
+	}
+}
+
+func TestAlterMaterializedView_SetSecureAndComment(t *testing.T) {
+	stmt, errs := testParseAlterMaterializedView("ALTER MATERIALIZED VIEW mv SET SECURE COMMENT = 'secured mv'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// SET SECURE with COMMENT is captured as AlterMVSetSecure with Comment populated
+	if stmt.Action != ast.AlterMVSetSecure {
+		t.Errorf("action = %v, want AlterMVSetSecure", stmt.Action)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "secured mv" {
+		t.Errorf("comment = %v, want 'secured mv'", stmt.Comment)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walker smoke test
+// ---------------------------------------------------------------------------
+
+func TestViewWalker_CreateView(t *testing.T) {
+	result := ParseBestEffort("CREATE VIEW v AS SELECT 1")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("no stmts")
+	}
+
+	visited := 0
+	ast.Inspect(result.File.Stmts[0], func(n ast.Node) bool {
+		if n != nil {
+			visited++
+		}
+		return true
+	})
+	if visited == 0 {
+		t.Error("walker visited 0 nodes")
+	}
+}


### PR DESCRIPTION
## Summary

- Add AST nodes: `CreateViewStmt`, `CreateMaterializedViewStmt`, `AlterViewStmt`, `AlterMaterializedViewStmt`, plus helper structs `ViewColumn` and `RowAccessPolicy`
- Implement `CREATE [OR REPLACE] [SECURE] [RECURSIVE] VIEW` and `CREATE [OR REPLACE] [SECURE] MATERIALIZED VIEW` parsers with full support for column lists, masking policy/tag column bindings, COPY GRANTS, COMMENT, WITH TAG, WITH ROW ACCESS POLICY, CLUSTER BY, and CTE query bodies
- Implement all `ALTER VIEW` action variants (RENAME, SET/UNSET COMMENT/SECURE/TAG, ADD/DROP ROW ACCESS POLICY, ALTER COLUMN masking/tag) and all `ALTER MATERIALIZED VIEW` variants (RENAME, CLUSTER BY, DROP CLUSTERING KEY, SUSPEND/RESUME [RECLUSTER], SET/UNSET SECURE/COMMENT)
- Hook into `parseCreateStmt` and `parseAlterStmt` dispatch; DROP VIEW/DROP MATERIALIZED VIEW untouched (T2.5)
- 45 tests covering every form; full suite `go test ./snowflake/... -count=1` passes

## Test plan

- [x] `go test ./snowflake/... -count=1` — all packages pass
- [x] `gofmt -w` applied to all modified files
- [x] CREATE VIEW: basic, OR REPLACE, SECURE, RECURSIVE, IF NOT EXISTS, qualified name, column list with COMMENT, COPY GRANTS, COMMENT, WITH TAG, WITH ROW ACCESS POLICY, CTE query, combined modifiers
- [x] CREATE MATERIALIZED VIEW: basic, OR REPLACE SECURE, IF NOT EXISTS, CLUSTER BY, CLUSTER BY LINEAR, COMMENT, column list, WITH TAG, WITH ROW ACCESS POLICY
- [x] ALTER VIEW: RENAME TO, IF EXISTS, SET/UNSET COMMENT, SET/UNSET SECURE, SET/UNSET TAG, ADD ROW ACCESS POLICY, DROP ROW ACCESS POLICY, DROP ALL ROW ACCESS POLICIES, ALTER COLUMN SET/UNSET MASKING POLICY (with USING), ALTER COLUMN SET/UNSET TAG, MODIFY alias
- [x] ALTER MATERIALIZED VIEW: RENAME TO, CLUSTER BY, DROP CLUSTERING KEY, SUSPEND, RESUME, SUSPEND RECLUSTER, RESUME RECLUSTER, SET/UNSET SECURE, SET/UNSET COMMENT, SET SECURE+COMMENT combined
- [x] Walker smoke test for CreateViewStmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)