### PR TITLE
feat(snowflake): T5.1 DML — INSERT/UPDATE/DELETE/MERGE

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-dml.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-dml.md
@@ -1,0 +1,39 @@
+# T5.1: Snowflake DML Implementation Plan
+
+**Goal:** Implement INSERT/UPDATE/DELETE/MERGE parsing for the Snowflake engine.
+
+**Architecture:** Four new parser files (`insert.go`, `update.go`, `delete.go`, `merge.go`) and corresponding test files. New AST node types appended to `parsenodes.go`, tags to `nodetags.go`, walker cases regenerated.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `snowflake/ast/parsenodes.go` | Modify | Add InsertStmt, InsertMultiStmt, InsertMultiBranch, UpdateStmt, UpdateSet, DeleteStmt, MergeStmt, MergeWhen, MergeAction |
+| `snowflake/ast/nodetags.go` | Modify | Add T_InsertStmt, T_InsertMultiStmt, T_UpdateStmt, T_DeleteStmt, T_MergeStmt tags |
+| `snowflake/ast/walk_generated.go` | Regenerate | Auto-generated walker cases |
+| `snowflake/parser/parser.go` | Modify | Replace 4 unsupported stubs with real calls |
+| `snowflake/parser/insert.go` | Create | parseInsertStmt, parseInsertMultiStmt |
+| `snowflake/parser/update.go` | Create | parseUpdateStmt |
+| `snowflake/parser/delete.go` | Create | parseDeleteStmt |
+| `snowflake/parser/merge.go` | Create | parseMergeStmt |
+| `snowflake/parser/insert_test.go` | Create | INSERT tests |
+| `snowflake/parser/update_test.go` | Create | UPDATE tests |
+| `snowflake/parser/delete_test.go` | Create | DELETE tests |
+| `snowflake/parser/merge_test.go` | Create | MERGE tests |
+
+---
+
+## Steps
+
+- [ ] Step 1: Add AST types to parsenodes.go
+- [ ] Step 2: Add node tags to nodetags.go
+- [ ] Step 3: Regenerate walk_generated.go
+- [ ] Step 4: Implement insert.go + insert_test.go
+- [ ] Step 5: Implement update.go + update_test.go
+- [ ] Step 6: Implement delete.go + delete_test.go
+- [ ] Step 7: Implement merge.go + merge_test.go
+- [ ] Step 8: Wire parseStmt dispatch in parser.go
+- [ ] Step 9: go test ./snowflake/... + gofmt -w
+- [ ] Step 10: Commit + PR

--- a/docs/superpowers/specs/2026-04-15-snowflake-dml-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-dml-design.md
@@ -1,0 +1,141 @@
+# Snowflake DML (T5.1) — Design
+
+**DAG node:** T5.1 — DML: INSERT/UPDATE/DELETE/MERGE
+**Branch:** `feat/snowflake/dml`
+**Depends on:** T1.4 (SELECT core), T1.6 (CTEs), expressions
+**Unblocks:** T3.2 (deparse)
+
+## Purpose
+
+T5.1 adds the four primary DML statement parsers for Snowflake SQL. These replace
+the `unsupported("INSERT")`, `unsupported("UPDATE")`, `unsupported("DELETE")`, and
+`unsupported("MERGE")` stubs in `parser.go`.
+
+## Scope
+
+Derived from the legacy `SnowflakeParser.g4` grammar:
+- `insert_statement` — single-row INSERT with VALUES or SELECT
+- `insert_multi_table_statement` — INSERT ALL / INSERT FIRST (multi-table)
+- `update_statement` — UPDATE with optional FROM (Snowflake extension)
+- `delete_statement` — DELETE with optional USING
+- `merge_statement` — MERGE INTO ... USING ... ON ... WHEN clauses
+
+## AST Types
+
+### InsertStmt (single-row INSERT)
+
+```go
+type InsertStmt struct {
+    Overwrite bool
+    Target    *ObjectName
+    Columns   []Ident    // optional; nil if not specified
+    Values    [][]Node   // VALUES rows; nil if SELECT used
+    Select    Node       // SELECT body; nil if VALUES used
+    Loc       Loc
+}
+```
+
+### InsertMultiStmt (INSERT ALL / INSERT FIRST)
+
+```go
+type InsertMultiStmt struct {
+    Overwrite bool
+    First     bool                 // true = FIRST, false = ALL
+    Branches  []*InsertMultiBranch // INTO targets
+    Select    Node                 // driving SELECT
+    Loc       Loc
+}
+
+type InsertMultiBranch struct {
+    When    Node    // nil for unconditional; non-nil for WHEN cond THEN
+    Target  *ObjectName
+    Columns []Ident
+    Values  []Node  // single-row values; nil if VALUES omitted
+    Loc     Loc
+}
+```
+
+### UpdateStmt
+
+```go
+type UpdateStmt struct {
+    Target *ObjectName
+    Alias  Ident
+    Sets   []*UpdateSet
+    From   []Node   // FROM items (Snowflake extension)
+    Where  Node
+    Loc    Loc
+}
+
+type UpdateSet struct {
+    Column Ident
+    Value  Node
+    Loc    Loc
+}
+```
+
+### DeleteStmt
+
+```go
+type DeleteStmt struct {
+    Target *ObjectName
+    Alias  Ident
+    Using  []Node   // USING items
+    Where  Node
+    Loc    Loc
+}
+```
+
+### MergeStmt
+
+```go
+type MergeStmt struct {
+    Target      *ObjectName
+    TargetAlias Ident
+    Source      Node   // table ref or subquery
+    SourceAlias Ident
+    On          Node
+    Whens       []*MergeWhen
+    Loc         Loc
+}
+
+type MergeWhen struct {
+    Matched       bool        // true = WHEN MATCHED
+    BySource      bool        // WHEN NOT MATCHED BY SOURCE
+    ByTarget      bool        // WHEN NOT MATCHED [BY TARGET]
+    AndCond       Node        // optional AND condition
+    Action        MergeAction
+    Sets          []*UpdateSet // for UPDATE SET
+    InsertCols    []Ident      // for INSERT (cols)
+    InsertVals    []Node       // for INSERT VALUES (exprs)
+    InsertDefault bool         // for INSERT VALUES DEFAULT
+    Loc           Loc
+}
+
+type MergeAction int
+const (
+    MergeActionUpdate MergeAction = iota
+    MergeActionDelete
+    MergeActionInsert
+)
+```
+
+## Parser strategy
+
+- `parseInsertStmt` dispatches on ALL/FIRST for multi-table vs single-row
+- Reuse `parseFromClause`, `parseFromItem`, `parseTableRef`, `parseQueryExpr`, `parseExprList`
+- `parseOptionalAlias` for aliases throughout
+- MERGE source uses `parsePrimarySource` (handles table refs and subqueries)
+- WHEN NOT MATCHED BY SOURCE/TARGET: `SOURCE` is `kwSOURCE`, `TARGET` is `tokIdent`
+
+## Walker
+
+All new Node types get cases in `walk_generated.go` (regenerated via `go generate ./snowflake/ast/...`).
+
+## Test plan
+
+- INSERT single: VALUES, SELECT, OVERWRITE, column list, multi-value
+- INSERT ALL/FIRST: unconditional and conditional
+- UPDATE: basic SET, FROM, WHERE, alias
+- DELETE: basic, USING, WHERE, alias
+- MERGE: WHEN MATCHED UPDATE/DELETE, WHEN NOT MATCHED INSERT, BY SOURCE/TARGET, multiple WHEN

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -63,6 +63,13 @@ const (
 	T_UndropSchemaStmt
 	T_DropStmt
 	T_UndropStmt
+
+	// DML statement tags (T5.1)
+	T_InsertStmt
+	T_InsertMultiStmt
+	T_UpdateStmt
+	T_DeleteStmt
+	T_MergeStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -152,6 +159,16 @@ func (t NodeTag) String() string {
 		return "DropStmt"
 	case T_UndropStmt:
 		return "UndropStmt"
+	case T_InsertStmt:
+		return "InsertStmt"
+	case T_InsertMultiStmt:
+		return "InsertMultiStmt"
+	case T_UpdateStmt:
+		return "UpdateStmt"
+	case T_DeleteStmt:
+		return "DeleteStmt"
+	case T_MergeStmt:
+		return "MergeStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1294,3 +1294,131 @@ var (
 	_ Node = (*DropStmt)(nil)
 	_ Node = (*UndropStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// DML statement nodes
+// ---------------------------------------------------------------------------
+
+// InsertStmt represents a single-table INSERT statement:
+//
+//	INSERT [OVERWRITE] INTO table [(cols)] {VALUES (exprs)[, ...] | SELECT ...}
+type InsertStmt struct {
+	Overwrite bool
+	Target    *ObjectName
+	Columns   []Ident  // optional column list; nil if not specified
+	Values    [][]Node // VALUES rows; nil if SELECT form used
+	Select    Node     // SELECT body; nil if VALUES form used
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *InsertStmt) Tag() NodeTag { return T_InsertStmt }
+
+// InsertMultiStmt represents INSERT ALL / INSERT FIRST (multi-table insert):
+//
+//	INSERT [OVERWRITE] {ALL | FIRST} [WHEN cond THEN] INTO target [(cols)] VALUES (exprs) ... SELECT ...
+type InsertMultiStmt struct {
+	Overwrite bool
+	First     bool                 // true = INSERT FIRST, false = INSERT ALL
+	Branches  []*InsertMultiBranch // INTO targets with optional WHEN guards
+	Select    Node                 // driving SELECT query
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *InsertMultiStmt) Tag() NodeTag { return T_InsertMultiStmt }
+
+// InsertMultiBranch is one INTO target inside an INSERT ALL/FIRST statement.
+// When is nil for unconditional branches; non-nil for WHEN cond THEN branches.
+type InsertMultiBranch struct {
+	When    Node // nil for unconditional ALL/FIRST; WHEN condition otherwise
+	Target  *ObjectName
+	Columns []Ident
+	Values  []Node // single row of VALUES expressions; nil if VALUES clause omitted
+	Loc     Loc
+}
+
+// UpdateSet represents one assignment in an UPDATE SET list.
+// Column holds the target column name, which may be qualified (e.g. t.col).
+type UpdateSet struct {
+	Column *ObjectName
+	Value  Node
+	Loc    Loc
+}
+
+// UpdateStmt represents an UPDATE statement:
+//
+//	UPDATE table [alias] SET col = expr [, ...] [FROM sources] [WHERE cond]
+type UpdateStmt struct {
+	Target *ObjectName
+	Alias  Ident // table alias; zero Ident if absent
+	Sets   []*UpdateSet
+	From   []Node // FROM clause items (Snowflake extension for joins); nil if absent
+	Where  Node   // WHERE condition; nil if absent
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *UpdateStmt) Tag() NodeTag { return T_UpdateStmt }
+
+// DeleteStmt represents a DELETE statement:
+//
+//	DELETE FROM table [alias] [USING sources] [WHERE cond]
+type DeleteStmt struct {
+	Target *ObjectName
+	Alias  Ident  // table alias; zero Ident if absent
+	Using  []Node // USING clause items; nil if absent
+	Where  Node   // WHERE condition; nil if absent
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *DeleteStmt) Tag() NodeTag { return T_DeleteStmt }
+
+// MergeAction identifies the action in a WHEN clause of a MERGE statement.
+type MergeAction int
+
+const (
+	MergeActionUpdate MergeAction = iota // WHEN ... THEN UPDATE SET ...
+	MergeActionDelete                    // WHEN ... THEN DELETE
+	MergeActionInsert                    // WHEN ... THEN INSERT ...
+)
+
+// MergeWhen represents one WHEN clause in a MERGE statement.
+type MergeWhen struct {
+	Matched       bool // true = WHEN MATCHED, false = WHEN NOT MATCHED
+	BySource      bool // WHEN NOT MATCHED BY SOURCE (Snowflake extension)
+	ByTarget      bool // WHEN NOT MATCHED BY TARGET (or plain NOT MATCHED)
+	AndCond       Node // optional AND condition; nil if absent
+	Action        MergeAction
+	Sets          []*UpdateSet // for MergeActionUpdate
+	InsertCols    []Ident      // for MergeActionInsert: optional column list
+	InsertVals    []Node       // for MergeActionInsert: VALUES expressions
+	InsertDefault bool         // for MergeActionInsert: INSERT VALUES DEFAULT
+	Loc           Loc
+}
+
+// MergeStmt represents a MERGE statement:
+//
+//	MERGE INTO target [alias] USING source [alias] ON cond [WHEN ...]...
+type MergeStmt struct {
+	Target      *ObjectName
+	TargetAlias Ident // alias for target; zero Ident if absent
+	Source      Node  // table ref or subquery
+	SourceAlias Ident // alias for source; zero Ident if absent
+	On          Node
+	Whens       []*MergeWhen
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *MergeStmt) Tag() NodeTag { return T_MergeStmt }
+
+// Compile-time assertions for DML nodes.
+var (
+	_ Node = (*InsertStmt)(nil)
+	_ Node = (*InsertMultiStmt)(nil)
+	_ Node = (*UpdateStmt)(nil)
+	_ Node = (*DeleteStmt)(nil)
+	_ Node = (*MergeStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -68,6 +68,12 @@ func walkChildren(v Visitor, node Node) {
 		if n.Like != nil {
 			Walk(v, n.Like)
 		}
+	case *DeleteStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		walkNodes(v, n.Using)
+		Walk(v, n.Where)
 	case *DropDatabaseStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -93,6 +99,13 @@ func walkChildren(v Visitor, node Node) {
 	case *InExpr:
 		Walk(v, n.Expr)
 		walkNodes(v, n.Values)
+	case *InsertMultiStmt:
+		Walk(v, n.Select)
+	case *InsertStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		Walk(v, n.Select)
 	case *IsExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.DistinctFrom)
@@ -108,6 +121,12 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Pattern)
 		Walk(v, n.Escape)
 		walkNodes(v, n.AnyValues)
+	case *MergeStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		Walk(v, n.Source)
+		Walk(v, n.On)
 	case *ParenExpr:
 		Walk(v, n.Expr)
 	case *SelectStmt:
@@ -153,5 +172,11 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *UpdateStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		walkNodes(v, n.From)
+		Walk(v, n.Where)
 	}
 }

--- a/snowflake/parser/delete.go
+++ b/snowflake/parser/delete.go
@@ -1,0 +1,87 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// DELETE statement parser
+// ---------------------------------------------------------------------------
+
+// parseDeleteStmt parses a DELETE statement:
+//
+//	DELETE FROM table [alias] [USING source [, source ...]] [WHERE cond]
+func (p *Parser) parseDeleteStmt() (*ast.DeleteStmt, error) {
+	deleteTok, err := p.expect(kwDELETE)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+
+	target, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.DeleteStmt{
+		Target: target,
+		Loc:    ast.Loc{Start: deleteTok.Loc.Start},
+	}
+
+	// Optional table alias
+	alias, hasAlias := p.parseOptionalAlias()
+	if hasAlias {
+		stmt.Alias = alias
+	}
+
+	// Optional USING clause
+	if p.cur.Type == kwUSING {
+		p.advance() // consume USING
+		using, err := p.parseTableOrQueryList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Using = using
+	}
+
+	// Optional WHERE clause
+	if p.cur.Type == kwWHERE {
+		p.advance() // consume WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseTableOrQueryList parses a comma-separated list of table references or
+// subqueries. Used by DELETE USING.
+//
+//	table_or_query := object_name [alias] | '(' subquery ')' [alias]
+func (p *Parser) parseTableOrQueryList() ([]ast.Node, error) {
+	var items []ast.Node
+
+	item, err := p.parseFromItem()
+	if err != nil {
+		return nil, err
+	}
+	items = append(items, item)
+
+	for p.cur.Type == ',' {
+		p.advance() // consume ','
+		item, err = p.parseFromItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	return items, nil
+}

--- a/snowflake/parser/delete_test.go
+++ b/snowflake/parser/delete_test.go
@@ -1,0 +1,121 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseDeleteStmt parses and returns the first statement as *ast.DeleteStmt.
+func testParseDeleteStmt(t *testing.T, input string) *ast.DeleteStmt {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected statement, got none")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.DeleteStmt)
+	if !ok {
+		t.Fatalf("expected *ast.DeleteStmt, got %T", result.File.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic DELETE FROM
+// ---------------------------------------------------------------------------
+
+func TestDelete_Basic(t *testing.T) {
+	stmt := testParseDeleteStmt(t, "DELETE FROM employees")
+	if stmt.Target.Name.Name != "employees" {
+		t.Errorf("target = %q, want %q", stmt.Target.Name.Name, "employees")
+	}
+	if stmt.Where != nil {
+		t.Error("Where should be nil")
+	}
+	if len(stmt.Using) != 0 {
+		t.Errorf("using = %d, want 0", len(stmt.Using))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. DELETE FROM ... WHERE
+// ---------------------------------------------------------------------------
+
+func TestDelete_WithWhere(t *testing.T) {
+	stmt := testParseDeleteStmt(t, "DELETE FROM t WHERE id = 42")
+	if stmt.Where == nil {
+		t.Fatal("Where should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. DELETE with alias
+// ---------------------------------------------------------------------------
+
+func TestDelete_WithAlias(t *testing.T) {
+	stmt := testParseDeleteStmt(t, "DELETE FROM employees e WHERE e.dept = 'HR'")
+	if stmt.Alias.Name != "e" {
+		t.Errorf("alias = %q, want %q", stmt.Alias.Name, "e")
+	}
+	if stmt.Where == nil {
+		t.Error("Where should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. DELETE ... USING (Snowflake extension)
+// ---------------------------------------------------------------------------
+
+func TestDelete_WithUsing(t *testing.T) {
+	stmt := testParseDeleteStmt(t, `
+		DELETE FROM orders o
+		USING customers c
+		WHERE o.customer_id = c.id AND c.active = false
+	`)
+	if len(stmt.Using) != 1 {
+		t.Fatalf("using = %d, want 1", len(stmt.Using))
+	}
+	if stmt.Where == nil {
+		t.Error("Where should not be nil")
+	}
+	// Check alias on the USING source
+	ref, ok := stmt.Using[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("using[0] is %T, want *ast.TableRef", stmt.Using[0])
+	}
+	if ref.Alias.Name != "c" {
+		t.Errorf("using[0].alias = %q, want %q", ref.Alias.Name, "c")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. DELETE USING multiple tables
+// ---------------------------------------------------------------------------
+
+func TestDelete_UsingMultiple(t *testing.T) {
+	stmt := testParseDeleteStmt(t, `
+		DELETE FROM t
+		USING a, b
+		WHERE t.x = a.x AND t.y = b.y
+	`)
+	if len(stmt.Using) != 2 {
+		t.Fatalf("using = %d, want 2", len(stmt.Using))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. DELETE qualified table
+// ---------------------------------------------------------------------------
+
+func TestDelete_QualifiedName(t *testing.T) {
+	stmt := testParseDeleteStmt(t, "DELETE FROM mydb.myschema.t WHERE id = 1")
+	if stmt.Target.Name.Name != "t" {
+		t.Errorf("name = %q, want %q", stmt.Target.Name.Name, "t")
+	}
+	if stmt.Target.Schema.Name != "myschema" {
+		t.Errorf("schema = %q, want %q", stmt.Target.Schema.Name, "myschema")
+	}
+}

--- a/snowflake/parser/insert.go
+++ b/snowflake/parser/insert.go
@@ -1,0 +1,311 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// INSERT statement parser
+// ---------------------------------------------------------------------------
+
+// parseInsertStmt is the top-level dispatcher for INSERT statements.
+// It handles both single-table INSERT and multi-table INSERT ALL/FIRST.
+//
+//	INSERT [OVERWRITE] INTO ...            → parseInsertSingleStmt
+//	INSERT [OVERWRITE] ALL ...             → parseInsertMultiStmt
+//	INSERT [OVERWRITE] FIRST ...           → parseInsertMultiStmt
+func (p *Parser) parseInsertStmt() (ast.Node, error) {
+	insertTok, err := p.expect(kwINSERT)
+	if err != nil {
+		return nil, err
+	}
+	startLoc := insertTok.Loc.Start
+
+	// Optional OVERWRITE
+	overwrite := false
+	if p.cur.Type == kwOVERWRITE {
+		p.advance()
+		overwrite = true
+	}
+
+	// Dispatch: ALL or FIRST → multi-table INSERT
+	if p.cur.Type == kwALL || p.cur.Type == kwFIRST {
+		return p.parseInsertMultiBody(startLoc, overwrite)
+	}
+
+	// Default: single-table INSERT INTO ...
+	return p.parseInsertSingleBody(startLoc, overwrite)
+}
+
+// parseInsertSingleBody parses the body of a single-table INSERT:
+//
+//	INTO table [(cols)] {VALUES (exprs)[, ...] | SELECT ...}
+func (p *Parser) parseInsertSingleBody(startLoc int, overwrite bool) (*ast.InsertStmt, error) {
+	if _, err := p.expect(kwINTO); err != nil {
+		return nil, err
+	}
+
+	target, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.InsertStmt{
+		Overwrite: overwrite,
+		Target:    target,
+		Loc:       ast.Loc{Start: startLoc},
+	}
+
+	// Optional column list: (col1, col2, ...)
+	if p.cur.Type == '(' && p.isColumnList() {
+		p.advance() // consume '('
+		cols, err := p.parseIdentList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Columns = cols
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+	}
+
+	// VALUES or SELECT
+	if p.cur.Type == kwVALUES {
+		values, err := p.parseValuesRows()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Values = values
+	} else {
+		// SELECT / WITH SELECT
+		query, err := p.parseInsertQuery()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Select = query
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseInsertMultiBody parses the body of INSERT ALL / INSERT FIRST.
+//
+// Two forms:
+//
+//  1. Unconditional:
+//     INSERT [OVERWRITE] ALL INTO t1 [(cols)] VALUES (exprs) [INTO t2 ...]
+//     select_statement
+//
+//  2. Conditional (with WHEN):
+//     INSERT [OVERWRITE] {ALL | FIRST}
+//     WHEN cond THEN INTO t [(cols)] VALUES (exprs) [INTO t ...]
+//     [WHEN ... THEN INTO ...]
+//     [ELSE INTO t [(cols)] VALUES (exprs)]
+//     select_statement
+func (p *Parser) parseInsertMultiBody(startLoc int, overwrite bool) (*ast.InsertMultiStmt, error) {
+	first := p.cur.Type == kwFIRST
+	p.advance() // consume ALL or FIRST
+
+	stmt := &ast.InsertMultiStmt{
+		Overwrite: overwrite,
+		First:     first,
+		Loc:       ast.Loc{Start: startLoc},
+	}
+
+	if p.cur.Type == kwWHEN {
+		// Conditional form: WHEN cond THEN INTO ... [ELSE INTO ...]
+		for p.cur.Type == kwWHEN {
+			p.advance() // consume WHEN
+			cond, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwTHEN); err != nil {
+				return nil, err
+			}
+			// One or more INTO clauses under this WHEN
+			for p.cur.Type == kwINTO {
+				branch, err := p.parseInsertMultiBranch(cond)
+				if err != nil {
+					return nil, err
+				}
+				stmt.Branches = append(stmt.Branches, branch)
+			}
+		}
+		// Optional ELSE INTO ...
+		if p.cur.Type == kwELSE {
+			p.advance() // consume ELSE
+			for p.cur.Type == kwINTO {
+				branch, err := p.parseInsertMultiBranch(nil)
+				if err != nil {
+					return nil, err
+				}
+				stmt.Branches = append(stmt.Branches, branch)
+			}
+		}
+	} else if p.cur.Type == kwINTO {
+		// Unconditional form: INTO t1 [(cols)] VALUES (exprs) [INTO t2 ...]
+		for p.cur.Type == kwINTO {
+			branch, err := p.parseInsertMultiBranch(nil)
+			if err != nil {
+				return nil, err
+			}
+			stmt.Branches = append(stmt.Branches, branch)
+		}
+	}
+
+	// Driving SELECT
+	query, err := p.parseInsertQuery()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Select = query
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseInsertMultiBranch parses one INTO clause inside INSERT ALL/FIRST:
+//
+//	INTO table [(cols)] [VALUES (exprs)]
+//
+// The when parameter is the WHEN condition (nil for unconditional branches).
+func (p *Parser) parseInsertMultiBranch(when ast.Node) (*ast.InsertMultiBranch, error) {
+	intoTok, err := p.expect(kwINTO)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	branch := &ast.InsertMultiBranch{
+		When:   when,
+		Target: target,
+		Loc:    ast.Loc{Start: intoTok.Loc.Start},
+	}
+
+	// Optional column list
+	if p.cur.Type == '(' && p.isColumnList() {
+		p.advance() // consume '('
+		cols, err := p.parseIdentList()
+		if err != nil {
+			return nil, err
+		}
+		branch.Columns = cols
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+	}
+
+	// Optional VALUES (exprs)
+	if p.cur.Type == kwVALUES {
+		p.advance() // consume VALUES
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		vals, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		branch.Values = vals
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+	}
+
+	branch.Loc.End = p.prev.Loc.End
+	return branch, nil
+}
+
+// parseValuesRows parses one or more VALUES rows:
+//
+//	VALUES (expr, ...) [, (expr, ...) ...]
+func (p *Parser) parseValuesRows() ([][]ast.Node, error) {
+	if _, err := p.expect(kwVALUES); err != nil {
+		return nil, err
+	}
+
+	var rows [][]ast.Node
+
+	row, err := p.parseValueRow()
+	if err != nil {
+		return nil, err
+	}
+	rows = append(rows, row)
+
+	for p.cur.Type == ',' {
+		// Peek: is the next token '(' to start another row?
+		next := p.peekNext()
+		if next.Type != '(' {
+			break
+		}
+		p.advance() // consume ','
+		row, err = p.parseValueRow()
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+
+	return rows, nil
+}
+
+// parseValueRow parses one parenthesized row: (expr, ...)
+func (p *Parser) parseValueRow() ([]ast.Node, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	vals, err := p.parseExprList()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return vals, nil
+}
+
+// parseInsertQuery parses the driving SELECT for an INSERT statement.
+// Supports both SELECT and WITH ... SELECT.
+func (p *Parser) parseInsertQuery() (ast.Node, error) {
+	if p.cur.Type == kwWITH {
+		return p.parseWithQueryExpr()
+	}
+	return p.parseQueryExpr()
+}
+
+// parseIdentList parses a comma-separated list of identifiers.
+// Used for column lists in INSERT.
+func (p *Parser) parseIdentList() ([]ast.Ident, error) {
+	var idents []ast.Ident
+
+	id, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	idents = append(idents, id)
+
+	for p.cur.Type == ',' {
+		p.advance() // consume ','
+		id, err = p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		idents = append(idents, id)
+	}
+
+	return idents, nil
+}
+
+// isColumnList looks ahead to determine whether the current '(' starts a
+// column list (identifiers separated by commas) as opposed to a subquery.
+// It peeks at the next token: if it's a SELECT or WITH keyword, it's a
+// subquery, not a column list.
+func (p *Parser) isColumnList() bool {
+	next := p.peekNext()
+	// If the first token inside '(' is SELECT or WITH, it's a subquery.
+	return next.Type != kwSELECT && next.Type != kwWITH
+}

--- a/snowflake/parser/insert_test.go
+++ b/snowflake/parser/insert_test.go
@@ -1,0 +1,258 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseInsertStmt parses the input and returns the first statement as
+// *ast.InsertStmt. Returns nil if the statement is not an InsertStmt.
+func testParseInsertStmt(t *testing.T, input string) *ast.InsertStmt {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected statement, got none")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.InsertStmt)
+	if !ok {
+		t.Fatalf("expected *ast.InsertStmt, got %T", result.File.Stmts[0])
+	}
+	return stmt
+}
+
+// testParseInsertMultiStmt parses and returns the first statement as *ast.InsertMultiStmt.
+func testParseInsertMultiStmt(t *testing.T, input string) *ast.InsertMultiStmt {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected statement, got none")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.InsertMultiStmt)
+	if !ok {
+		t.Fatalf("expected *ast.InsertMultiStmt, got %T", result.File.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// 1. Simple INSERT INTO ... VALUES
+// ---------------------------------------------------------------------------
+
+func TestInsert_BasicValues(t *testing.T) {
+	stmt := testParseInsertStmt(t, "INSERT INTO t VALUES (1, 2, 3)")
+	if stmt.Overwrite {
+		t.Error("Overwrite should be false")
+	}
+	if stmt.Target.Name.Name != "t" {
+		t.Errorf("target = %q, want %q", stmt.Target.Name.Name, "t")
+	}
+	if len(stmt.Columns) != 0 {
+		t.Errorf("columns = %d, want 0", len(stmt.Columns))
+	}
+	if len(stmt.Values) != 1 {
+		t.Fatalf("rows = %d, want 1", len(stmt.Values))
+	}
+	if len(stmt.Values[0]) != 3 {
+		t.Errorf("values[0] = %d, want 3", len(stmt.Values[0]))
+	}
+	if stmt.Select != nil {
+		t.Error("Select should be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. INSERT INTO ... (cols) VALUES (...)
+// ---------------------------------------------------------------------------
+
+func TestInsert_WithColumnList(t *testing.T) {
+	stmt := testParseInsertStmt(t, "INSERT INTO employees (id, name, dept) VALUES (1, 'Alice', 'Eng')")
+	if len(stmt.Columns) != 3 {
+		t.Fatalf("columns = %d, want 3", len(stmt.Columns))
+	}
+	if stmt.Columns[0].Name != "id" {
+		t.Errorf("columns[0] = %q, want %q", stmt.Columns[0].Name, "id")
+	}
+	if stmt.Columns[1].Name != "name" {
+		t.Errorf("columns[1] = %q, want %q", stmt.Columns[1].Name, "name")
+	}
+	if stmt.Columns[2].Name != "dept" {
+		t.Errorf("columns[2] = %q, want %q", stmt.Columns[2].Name, "dept")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. INSERT INTO ... SELECT ...
+// ---------------------------------------------------------------------------
+
+func TestInsert_Select(t *testing.T) {
+	stmt := testParseInsertStmt(t, "INSERT INTO t2 SELECT a, b FROM t1 WHERE a > 0")
+	if stmt.Select == nil {
+		t.Fatal("Select should not be nil")
+	}
+	if len(stmt.Values) != 0 {
+		t.Errorf("values should be nil, got %d rows", len(stmt.Values))
+	}
+	sel, ok := stmt.Select.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Select is %T, want *ast.SelectStmt", stmt.Select)
+	}
+	if len(sel.Targets) != 2 {
+		t.Errorf("targets = %d, want 2", len(sel.Targets))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. INSERT OVERWRITE INTO
+// ---------------------------------------------------------------------------
+
+func TestInsert_Overwrite(t *testing.T) {
+	stmt := testParseInsertStmt(t, "INSERT OVERWRITE INTO t VALUES (42)")
+	if !stmt.Overwrite {
+		t.Error("Overwrite should be true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. INSERT INTO ... multi-row VALUES
+// ---------------------------------------------------------------------------
+
+func TestInsert_MultiRowValues(t *testing.T) {
+	stmt := testParseInsertStmt(t, "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+	if len(stmt.Values) != 3 {
+		t.Fatalf("rows = %d, want 3", len(stmt.Values))
+	}
+	for i, row := range stmt.Values {
+		if len(row) != 2 {
+			t.Errorf("row[%d] = %d, want 2", i, len(row))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. INSERT qualified table name
+// ---------------------------------------------------------------------------
+
+func TestInsert_QualifiedTableName(t *testing.T) {
+	stmt := testParseInsertStmt(t, "INSERT INTO mydb.myschema.mytable VALUES (1)")
+	if stmt.Target.Name.Name != "mytable" {
+		t.Errorf("name = %q, want %q", stmt.Target.Name.Name, "mytable")
+	}
+	if stmt.Target.Schema.Name != "myschema" {
+		t.Errorf("schema = %q, want %q", stmt.Target.Schema.Name, "myschema")
+	}
+	if stmt.Target.Database.Name != "mydb" {
+		t.Errorf("database = %q, want %q", stmt.Target.Database.Name, "mydb")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. INSERT ALL (unconditional)
+// ---------------------------------------------------------------------------
+
+func TestInsertAll_Unconditional(t *testing.T) {
+	stmt := testParseInsertMultiStmt(t, `
+		INSERT ALL
+		  INTO t1 VALUES (1, 'a')
+		  INTO t2 VALUES (2, 'b')
+		SELECT * FROM src
+	`)
+	if stmt.First {
+		t.Error("First should be false for INSERT ALL")
+	}
+	if stmt.Overwrite {
+		t.Error("Overwrite should be false")
+	}
+	if len(stmt.Branches) != 2 {
+		t.Fatalf("branches = %d, want 2", len(stmt.Branches))
+	}
+	if stmt.Branches[0].Target.Name.Name != "t1" {
+		t.Errorf("branch[0].target = %q, want %q", stmt.Branches[0].Target.Name.Name, "t1")
+	}
+	if stmt.Branches[1].Target.Name.Name != "t2" {
+		t.Errorf("branch[1].target = %q, want %q", stmt.Branches[1].Target.Name.Name, "t2")
+	}
+	if stmt.Select == nil {
+		t.Error("Select should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. INSERT FIRST (conditional)
+// ---------------------------------------------------------------------------
+
+func TestInsertFirst_Conditional(t *testing.T) {
+	stmt := testParseInsertMultiStmt(t, `
+		INSERT FIRST
+		  WHEN amount > 100 THEN INTO big_sales VALUES (id, amount)
+		  WHEN amount > 10  THEN INTO mid_sales VALUES (id, amount)
+		  ELSE INTO small_sales VALUES (id, amount)
+		SELECT id, amount FROM sales
+	`)
+	if !stmt.First {
+		t.Error("First should be true for INSERT FIRST")
+	}
+	if len(stmt.Branches) != 3 {
+		t.Fatalf("branches = %d, want 3", len(stmt.Branches))
+	}
+	// First two branches should have WHEN conditions
+	if stmt.Branches[0].When == nil {
+		t.Error("branch[0].When should not be nil")
+	}
+	if stmt.Branches[1].When == nil {
+		t.Error("branch[1].When should not be nil")
+	}
+	// ELSE branch has no condition
+	if stmt.Branches[2].When != nil {
+		t.Error("branch[2].When should be nil (ELSE)")
+	}
+	if stmt.Select == nil {
+		t.Error("Select should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. INSERT ALL with column list in branch
+// ---------------------------------------------------------------------------
+
+func TestInsertAll_WithColumns(t *testing.T) {
+	stmt := testParseInsertMultiStmt(t, `
+		INSERT ALL
+		  INTO t1 (col1, col2) VALUES (a, b)
+		SELECT a, b FROM src
+	`)
+	if len(stmt.Branches) != 1 {
+		t.Fatalf("branches = %d, want 1", len(stmt.Branches))
+	}
+	if len(stmt.Branches[0].Columns) != 2 {
+		t.Errorf("columns = %d, want 2", len(stmt.Branches[0].Columns))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 10. INSERT ... SELECT (WITH CTE)
+// ---------------------------------------------------------------------------
+
+func TestInsert_WithCTESelect(t *testing.T) {
+	stmt := testParseInsertStmt(t, `
+		INSERT INTO t
+		WITH cte AS (SELECT 1 AS x)
+		SELECT x FROM cte
+	`)
+	if stmt.Select == nil {
+		t.Fatal("Select should not be nil")
+	}
+	sel, ok := stmt.Select.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Select is %T, want *ast.SelectStmt", stmt.Select)
+	}
+	if len(sel.With) == 0 {
+		t.Error("expected WITH CTEs")
+	}
+}

--- a/snowflake/parser/merge.go
+++ b/snowflake/parser/merge.go
@@ -1,0 +1,251 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// MERGE statement parser
+// ---------------------------------------------------------------------------
+
+// parseMergeStmt parses a MERGE statement:
+//
+//	MERGE INTO target [alias] USING source [alias] ON cond
+//	  [WHEN MATCHED [AND cond] THEN {UPDATE SET ... | DELETE}]...
+//	  [WHEN NOT MATCHED [BY TARGET|SOURCE] [AND cond] THEN {INSERT ...}]...
+func (p *Parser) parseMergeStmt() (*ast.MergeStmt, error) {
+	mergeTok, err := p.expect(kwMERGE)
+	if err != nil {
+		return nil, err
+	}
+
+	// INTO is required
+	if _, err := p.expect(kwINTO); err != nil {
+		return nil, err
+	}
+
+	target, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.MergeStmt{
+		Target: target,
+		Loc:    ast.Loc{Start: mergeTok.Loc.Start},
+	}
+
+	// Optional target alias
+	targetAlias, hasTargetAlias := p.parseOptionalAlias()
+	if hasTargetAlias {
+		stmt.TargetAlias = targetAlias
+	}
+
+	// USING source
+	if _, err := p.expect(kwUSING); err != nil {
+		return nil, err
+	}
+
+	source, err := p.parseMergeSource()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Source = source
+
+	// Optional source alias
+	sourceAlias, hasSourceAlias := p.parseOptionalAlias()
+	if hasSourceAlias {
+		stmt.SourceAlias = sourceAlias
+	}
+
+	// ON condition
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	on, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = on
+
+	// WHEN clauses (one or more)
+	for p.cur.Type == kwWHEN {
+		when, err := p.parseMergeWhen()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Whens = append(stmt.Whens, when)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseMergeSource parses the USING source: either a table reference or
+// a parenthesized subquery. It does NOT parse the alias; the caller parses
+// the optional alias after this function returns.
+func (p *Parser) parseMergeSource() (ast.Node, error) {
+	if p.cur.Type == '(' {
+		startLoc := p.cur.Loc
+		next := p.peekNext()
+		if next.Type == kwSELECT || next.Type == kwWITH {
+			p.advance() // consume '('
+			var query ast.Node
+			var err error
+			if p.cur.Type == kwWITH {
+				query, err = p.parseWithQueryExpr()
+			} else {
+				query, err = p.parseQueryExpr()
+			}
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return nil, err
+			}
+			ref := &ast.TableRef{
+				Subquery: query,
+				Loc:      ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+			}
+			return ref, nil
+		}
+	}
+	// Simple table reference: parse name only, NOT alias.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.TableRef{
+		Name: name,
+		Loc:  name.Loc,
+	}, nil
+}
+
+// parseMergeWhen parses one WHEN clause:
+//
+//	WHEN MATCHED [AND cond] THEN {UPDATE SET ... | DELETE}
+//	WHEN NOT MATCHED [BY TARGET|SOURCE] [AND cond] THEN INSERT ...
+func (p *Parser) parseMergeWhen() (*ast.MergeWhen, error) {
+	whenTok, err := p.expect(kwWHEN)
+	if err != nil {
+		return nil, err
+	}
+
+	when := &ast.MergeWhen{
+		Loc: ast.Loc{Start: whenTok.Loc.Start},
+	}
+
+	if p.cur.Type == kwMATCHED {
+		p.advance() // consume MATCHED
+		when.Matched = true
+	} else if p.cur.Type == kwNOT {
+		p.advance() // consume NOT
+		if _, err := p.expect(kwMATCHED); err != nil {
+			return nil, err
+		}
+		when.Matched = false
+		// Optional BY TARGET|SOURCE
+		if p.cur.Type == kwBY {
+			p.advance() // consume BY
+			switch {
+			case p.cur.Type == kwSOURCE:
+				p.advance() // consume SOURCE
+				when.BySource = true
+			case p.cur.Type == tokIdent && strings.ToUpper(p.cur.Str) == "TARGET":
+				p.advance() // consume TARGET (identifier)
+				when.ByTarget = true
+			default:
+				// Unexpected token after BY
+				return nil, p.syntaxErrorAtCur()
+			}
+		} else {
+			// Plain WHEN NOT MATCHED defaults to BY TARGET
+			when.ByTarget = true
+		}
+	} else {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	// Optional AND condition
+	if p.cur.Type == kwAND {
+		p.advance() // consume AND
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		when.AndCond = cond
+	}
+
+	// THEN action
+	if _, err := p.expect(kwTHEN); err != nil {
+		return nil, err
+	}
+
+	switch p.cur.Type {
+	case kwUPDATE:
+		p.advance() // consume UPDATE
+		if _, err := p.expect(kwSET); err != nil {
+			return nil, err
+		}
+		sets, err := p.parseUpdateSetList()
+		if err != nil {
+			return nil, err
+		}
+		when.Action = ast.MergeActionUpdate
+		when.Sets = sets
+
+	case kwDELETE:
+		p.advance() // consume DELETE
+		when.Action = ast.MergeActionDelete
+
+	case kwINSERT:
+		p.advance() // consume INSERT
+		when.Action = ast.MergeActionInsert
+
+		// Optional column list
+		if p.cur.Type == '(' {
+			// Peek to see if it's a column list or VALUES
+			next := p.peekNext()
+			if next.Type != kwVALUES && next.Type != kwDEFAULT {
+				p.advance() // consume '('
+				cols, err := p.parseIdentList()
+				if err != nil {
+					return nil, err
+				}
+				when.InsertCols = cols
+				if _, err := p.expect(')'); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		// VALUES (exprs) or VALUES DEFAULT
+		if _, err := p.expect(kwVALUES); err != nil {
+			return nil, err
+		}
+
+		if p.cur.Type == kwDEFAULT {
+			p.advance() // consume DEFAULT
+			when.InsertDefault = true
+		} else {
+			if _, err := p.expect('('); err != nil {
+				return nil, err
+			}
+			vals, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			when.InsertVals = vals
+			if _, err := p.expect(')'); err != nil {
+				return nil, err
+			}
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	when.Loc.End = p.prev.Loc.End
+	return when, nil
+}

--- a/snowflake/parser/merge_test.go
+++ b/snowflake/parser/merge_test.go
@@ -1,0 +1,295 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseMergeStmt parses and returns the first statement as *ast.MergeStmt.
+func testParseMergeStmt(t *testing.T, input string) *ast.MergeStmt {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected statement, got none")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.MergeStmt)
+	if !ok {
+		t.Fatalf("expected *ast.MergeStmt, got %T", result.File.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic MERGE with WHEN MATCHED UPDATE
+// ---------------------------------------------------------------------------
+
+func TestMerge_BasicMatchedUpdate(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING source s
+		ON t.id = s.id
+		WHEN MATCHED THEN UPDATE SET t.value = s.value
+	`)
+	if stmt.Target.Name.Name != "target" {
+		t.Errorf("target = %q, want %q", stmt.Target.Name.Name, "target")
+	}
+	if stmt.TargetAlias.Name != "t" {
+		t.Errorf("targetAlias = %q, want %q", stmt.TargetAlias.Name, "t")
+	}
+	if stmt.SourceAlias.Name != "s" {
+		t.Errorf("sourceAlias = %q, want %q", stmt.SourceAlias.Name, "s")
+	}
+	if stmt.On == nil {
+		t.Error("On should not be nil")
+	}
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if !when.Matched {
+		t.Error("Matched should be true")
+	}
+	if when.Action != ast.MergeActionUpdate {
+		t.Errorf("action = %v, want MergeActionUpdate", when.Action)
+	}
+	if len(when.Sets) != 1 {
+		t.Fatalf("sets = %d, want 1", len(when.Sets))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. MERGE with WHEN MATCHED DELETE
+// ---------------------------------------------------------------------------
+
+func TestMerge_MatchedDelete(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target
+		USING source
+		ON target.id = source.id
+		WHEN MATCHED THEN DELETE
+	`)
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if !when.Matched {
+		t.Error("Matched should be true")
+	}
+	if when.Action != ast.MergeActionDelete {
+		t.Errorf("action = %v, want MergeActionDelete", when.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. MERGE with WHEN NOT MATCHED INSERT
+// ---------------------------------------------------------------------------
+
+func TestMerge_NotMatchedInsert(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING source s
+		ON t.id = s.id
+		WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name)
+	`)
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if when.Matched {
+		t.Error("Matched should be false for NOT MATCHED")
+	}
+	if when.Action != ast.MergeActionInsert {
+		t.Errorf("action = %v, want MergeActionInsert", when.Action)
+	}
+	if len(when.InsertCols) != 2 {
+		t.Errorf("insertCols = %d, want 2", len(when.InsertCols))
+	}
+	if len(when.InsertVals) != 2 {
+		t.Errorf("insertVals = %d, want 2", len(when.InsertVals))
+	}
+	if when.InsertDefault {
+		t.Error("InsertDefault should be false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. MERGE with multiple WHEN clauses
+// ---------------------------------------------------------------------------
+
+func TestMerge_MultipleWhenClauses(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING source s
+		ON t.id = s.id
+		WHEN MATCHED AND s.active = false THEN DELETE
+		WHEN MATCHED THEN UPDATE SET t.value = s.value, t.ts = CURRENT_TIMESTAMP()
+		WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.value, s.ts)
+	`)
+	if len(stmt.Whens) != 3 {
+		t.Fatalf("whens = %d, want 3", len(stmt.Whens))
+	}
+
+	// First: WHEN MATCHED AND ... THEN DELETE
+	w0 := stmt.Whens[0]
+	if !w0.Matched {
+		t.Error("whens[0].Matched should be true")
+	}
+	if w0.AndCond == nil {
+		t.Error("whens[0].AndCond should not be nil")
+	}
+	if w0.Action != ast.MergeActionDelete {
+		t.Errorf("whens[0].action = %v, want Delete", w0.Action)
+	}
+
+	// Second: WHEN MATCHED THEN UPDATE
+	w1 := stmt.Whens[1]
+	if !w1.Matched {
+		t.Error("whens[1].Matched should be true")
+	}
+	if w1.AndCond != nil {
+		t.Error("whens[1].AndCond should be nil")
+	}
+	if w1.Action != ast.MergeActionUpdate {
+		t.Errorf("whens[1].action = %v, want Update", w1.Action)
+	}
+	if len(w1.Sets) != 2 {
+		t.Errorf("whens[1].sets = %d, want 2", len(w1.Sets))
+	}
+
+	// Third: WHEN NOT MATCHED THEN INSERT
+	w2 := stmt.Whens[2]
+	if w2.Matched {
+		t.Error("whens[2].Matched should be false")
+	}
+	if w2.Action != ast.MergeActionInsert {
+		t.Errorf("whens[2].action = %v, want Insert", w2.Action)
+	}
+	if len(w2.InsertCols) != 0 {
+		t.Errorf("whens[2].insertCols = %d, want 0 (no column list)", len(w2.InsertCols))
+	}
+	if len(w2.InsertVals) != 3 {
+		t.Errorf("whens[2].insertVals = %d, want 3", len(w2.InsertVals))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. MERGE with WHEN NOT MATCHED BY SOURCE
+// ---------------------------------------------------------------------------
+
+func TestMerge_NotMatchedBySource(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING source s
+		ON t.id = s.id
+		WHEN NOT MATCHED BY SOURCE THEN DELETE
+	`)
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if when.Matched {
+		t.Error("Matched should be false")
+	}
+	if !when.BySource {
+		t.Error("BySource should be true")
+	}
+	if when.ByTarget {
+		t.Error("ByTarget should be false")
+	}
+	if when.Action != ast.MergeActionDelete {
+		t.Errorf("action = %v, want Delete", when.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. MERGE with WHEN NOT MATCHED BY TARGET
+// ---------------------------------------------------------------------------
+
+func TestMerge_NotMatchedByTarget(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING source s
+		ON t.id = s.id
+		WHEN NOT MATCHED BY TARGET THEN INSERT VALUES (s.id, s.name)
+	`)
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if when.Matched {
+		t.Error("Matched should be false")
+	}
+	if when.BySource {
+		t.Error("BySource should be false")
+	}
+	if !when.ByTarget {
+		t.Error("ByTarget should be true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. MERGE with subquery as source
+// ---------------------------------------------------------------------------
+
+func TestMerge_SubquerySource(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING (SELECT id, value FROM staging WHERE processed = false) s
+		ON t.id = s.id
+		WHEN MATCHED THEN UPDATE SET t.value = s.value
+	`)
+	sourceRef, ok := stmt.Source.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("source is %T, want *ast.TableRef", stmt.Source)
+	}
+	if sourceRef.Subquery == nil {
+		t.Error("source.Subquery should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. MERGE with INSERT VALUES DEFAULT
+// ---------------------------------------------------------------------------
+
+func TestMerge_InsertValuesDefault(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO target t
+		USING source s
+		ON t.id = s.id
+		WHEN NOT MATCHED THEN INSERT VALUES DEFAULT
+	`)
+	when := stmt.Whens[0]
+	if !when.InsertDefault {
+		t.Error("InsertDefault should be true")
+	}
+	if len(when.InsertVals) != 0 {
+		t.Errorf("InsertVals should be empty, got %d", len(when.InsertVals))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. MERGE without aliases
+// ---------------------------------------------------------------------------
+
+func TestMerge_NoAliases(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO sales
+		USING new_sales
+		ON sales.id = new_sales.id
+		WHEN MATCHED THEN UPDATE SET sales.amount = new_sales.amount
+		WHEN NOT MATCHED THEN INSERT (id, amount) VALUES (new_sales.id, new_sales.amount)
+	`)
+	if !stmt.TargetAlias.IsEmpty() {
+		t.Errorf("TargetAlias should be empty, got %q", stmt.TargetAlias.Name)
+	}
+	if !stmt.SourceAlias.IsEmpty() {
+		t.Errorf("SourceAlias should be empty, got %q", stmt.SourceAlias.Name)
+	}
+	if len(stmt.Whens) != 2 {
+		t.Fatalf("whens = %d, want 2", len(stmt.Whens))
+	}
+}

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -205,13 +205,13 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwWITH:
 		return p.parseWithQueryExpr()
 	case kwINSERT:
-		return p.unsupported("INSERT")
+		return p.parseInsertStmt()
 	case kwUPDATE:
-		return p.unsupported("UPDATE")
+		return p.parseUpdateStmt()
 	case kwDELETE:
-		return p.unsupported("DELETE")
+		return p.parseDeleteStmt()
 	case kwMERGE:
-		return p.unsupported("MERGE")
+		return p.parseMergeStmt()
 	case kwCOPY:
 		return p.unsupported("COPY")
 	case kwPUT:

--- a/snowflake/parser/parser_test.go
+++ b/snowflake/parser/parser_test.go
@@ -91,17 +91,12 @@ func TestParse_SingleSelect(t *testing.T) {
 }
 
 func TestParse_MultiMixed(t *testing.T) {
-	// "SELECT 1; INSERT INTO t VALUES (1);" has SELECT at byte 0 and
-	// INSERT at byte 10 (after "SELECT 1; "). SELECT now succeeds.
+	// "SELECT 1; INSERT INTO t VALUES (1);" — both statements now parse.
 	runParseBestEffortCase(t, parseCase{
 		name:        "SELECT then INSERT",
 		input:       "SELECT 1; INSERT INTO t VALUES (1);",
-		wantStmtCnt: 1,
-		wantErrCnt:  1,
-		wantErrMsgs: []string{
-			"INSERT statement parsing is not yet supported",
-		},
-		wantErrLocs: []int{10},
+		wantStmtCnt: 2,
+		wantErrCnt:  0,
 	})
 }
 
@@ -151,9 +146,9 @@ func TestParse_BeginEndBlockOneError(t *testing.T) {
 }
 
 func TestParse_StrictVsBestEffort(t *testing.T) {
-	// Parse returns the first error; ParseBestEffort returns all errors.
-	// SELECT now succeeds, so the first error is INSERT.
-	input := "SELECT 1; INSERT INTO t VALUES (1);"
+	// INSERT now parses successfully — both statements in the input succeed.
+	// Use a BEGIN statement (still unsupported) to produce an error.
+	input := "SELECT 1; BEGIN TRANSACTION;"
 
 	file, err := Parse(input)
 	if err == nil {
@@ -162,8 +157,8 @@ func TestParse_StrictVsBestEffort(t *testing.T) {
 		pe, ok := err.(*ParseError)
 		if !ok {
 			t.Errorf("Parse: expected *ParseError, got %T", err)
-		} else if !strings.Contains(pe.Msg, "INSERT") {
-			t.Errorf("Parse: first error Msg = %q, want to contain INSERT", pe.Msg)
+		} else if !strings.Contains(pe.Msg, "BEGIN") {
+			t.Errorf("Parse: first error Msg = %q, want to contain BEGIN", pe.Msg)
 		}
 	}
 	if file == nil {

--- a/snowflake/parser/update.go
+++ b/snowflake/parser/update.go
@@ -1,0 +1,117 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// UPDATE statement parser
+// ---------------------------------------------------------------------------
+
+// parseUpdateStmt parses an UPDATE statement:
+//
+//	UPDATE table [alias] SET col = expr [, col = expr ...]
+//	  [FROM table_refs]
+//	  [WHERE cond]
+func (p *Parser) parseUpdateStmt() (*ast.UpdateStmt, error) {
+	updateTok, err := p.expect(kwUPDATE)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.UpdateStmt{
+		Target: target,
+		Loc:    ast.Loc{Start: updateTok.Loc.Start},
+	}
+
+	// Optional table alias (not AS — Snowflake allows bare alias)
+	alias, hasAlias := p.parseOptionalAlias()
+	if hasAlias {
+		stmt.Alias = alias
+	}
+
+	// SET col = expr [, ...]
+	if _, err := p.expect(kwSET); err != nil {
+		return nil, err
+	}
+	sets, err := p.parseUpdateSetList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Sets = sets
+
+	// Optional FROM clause (Snowflake extension)
+	if p.cur.Type == kwFROM {
+		p.advance() // consume FROM
+		from, err := p.parseFromClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+	}
+
+	// Optional WHERE clause
+	if p.cur.Type == kwWHERE {
+		p.advance() // consume WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseUpdateSetList parses comma-separated col = expr assignments.
+func (p *Parser) parseUpdateSetList() ([]*ast.UpdateSet, error) {
+	var sets []*ast.UpdateSet
+
+	set, err := p.parseUpdateSet()
+	if err != nil {
+		return nil, err
+	}
+	sets = append(sets, set)
+
+	for p.cur.Type == ',' {
+		p.advance() // consume ','
+		set, err = p.parseUpdateSet()
+		if err != nil {
+			return nil, err
+		}
+		sets = append(sets, set)
+	}
+
+	return sets, nil
+}
+
+// parseUpdateSet parses one col = expr assignment.
+// The column may be qualified (e.g. alias.column).
+func (p *Parser) parseUpdateSet() (*ast.UpdateSet, error) {
+	col, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	startLoc := col.Loc.Start
+
+	if _, err := p.expect('='); err != nil {
+		return nil, err
+	}
+
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.UpdateSet{
+		Column: col,
+		Value:  val,
+		Loc:    ast.Loc{Start: startLoc, End: p.prev.Loc.End},
+	}, nil
+}

--- a/snowflake/parser/update_test.go
+++ b/snowflake/parser/update_test.go
@@ -1,0 +1,137 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// testParseUpdateStmt parses and returns the first statement as *ast.UpdateStmt.
+func testParseUpdateStmt(t *testing.T, input string) *ast.UpdateStmt {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) == 0 {
+		t.Fatal("expected statement, got none")
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.UpdateStmt)
+	if !ok {
+		t.Fatalf("expected *ast.UpdateStmt, got %T", result.File.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic UPDATE ... SET
+// ---------------------------------------------------------------------------
+
+func TestUpdate_BasicSet(t *testing.T) {
+	stmt := testParseUpdateStmt(t, "UPDATE employees SET salary = 100000")
+	if stmt.Target.Name.Name != "employees" {
+		t.Errorf("target = %q, want %q", stmt.Target.Name.Name, "employees")
+	}
+	if len(stmt.Sets) != 1 {
+		t.Fatalf("sets = %d, want 1", len(stmt.Sets))
+	}
+	if stmt.Sets[0].Column.Name.Name != "salary" {
+		t.Errorf("column = %q, want %q", stmt.Sets[0].Column.Name.Name, "salary")
+	}
+	if stmt.Where != nil {
+		t.Error("Where should be nil")
+	}
+	if len(stmt.From) != 0 {
+		t.Errorf("from = %d, want 0", len(stmt.From))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. UPDATE with multiple SET assignments
+// ---------------------------------------------------------------------------
+
+func TestUpdate_MultipleSet(t *testing.T) {
+	stmt := testParseUpdateStmt(t, "UPDATE t SET a = 1, b = 2, c = 3")
+	if len(stmt.Sets) != 3 {
+		t.Fatalf("sets = %d, want 3", len(stmt.Sets))
+	}
+	cols := []string{"a", "b", "c"}
+	for i, want := range cols {
+		if stmt.Sets[i].Column.Name.Name != want {
+			t.Errorf("sets[%d].column = %q, want %q", i, stmt.Sets[i].Column.Name.Name, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. UPDATE with WHERE clause
+// ---------------------------------------------------------------------------
+
+func TestUpdate_WithWhere(t *testing.T) {
+	stmt := testParseUpdateStmt(t, "UPDATE t SET x = 5 WHERE id = 10")
+	if stmt.Where == nil {
+		t.Fatal("Where should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. UPDATE with table alias
+// ---------------------------------------------------------------------------
+
+func TestUpdate_WithAlias(t *testing.T) {
+	stmt := testParseUpdateStmt(t, "UPDATE employees e SET e.salary = 90000 WHERE e.id = 1")
+	if stmt.Alias.Name != "e" {
+		t.Errorf("alias = %q, want %q", stmt.Alias.Name, "e")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. UPDATE with FROM clause (Snowflake extension)
+// ---------------------------------------------------------------------------
+
+func TestUpdate_WithFrom(t *testing.T) {
+	stmt := testParseUpdateStmt(t, `
+		UPDATE target_tbl
+		SET target_tbl.value = src.value
+		FROM source_tbl src
+		WHERE target_tbl.id = src.id
+	`)
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	if stmt.Where == nil {
+		t.Error("Where should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. UPDATE with qualified table name
+// ---------------------------------------------------------------------------
+
+func TestUpdate_QualifiedName(t *testing.T) {
+	stmt := testParseUpdateStmt(t, "UPDATE db.schema.t SET a = 1")
+	if stmt.Target.Name.Name != "t" {
+		t.Errorf("name = %q, want %q", stmt.Target.Name.Name, "t")
+	}
+	if stmt.Target.Schema.Name != "schema" {
+		t.Errorf("schema = %q, want %q", stmt.Target.Schema.Name, "schema")
+	}
+	if stmt.Target.Database.Name != "db" {
+		t.Errorf("database = %q, want %q", stmt.Target.Database.Name, "db")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. UPDATE with expression in SET value
+// ---------------------------------------------------------------------------
+
+func TestUpdate_ExpressionValue(t *testing.T) {
+	stmt := testParseUpdateStmt(t, "UPDATE t SET price = price * 1.1 WHERE category = 'A'")
+	if len(stmt.Sets) != 1 {
+		t.Fatalf("sets = %d, want 1", len(stmt.Sets))
+	}
+	// The value should be a BinaryExpr (price * 1.1)
+	if _, ok := stmt.Sets[0].Value.(*ast.BinaryExpr); !ok {
+		t.Errorf("expected *ast.BinaryExpr, got %T", stmt.Sets[0].Value)
+	}
+}


### PR DESCRIPTION
## Summary

- **INSERT** (single-table): `INSERT [OVERWRITE] INTO table [(cols)] {VALUES (exprs)[, ...] | SELECT ...}` — with multi-row VALUES support and WITH CTE select
- **INSERT ALL / INSERT FIRST** (multi-table): unconditional `INTO t VALUES(...)` chains and conditional `WHEN cond THEN INTO ...` / `ELSE INTO ...` forms
- **UPDATE**: `UPDATE table [alias] SET col=expr [FROM sources] [WHERE cond]` — supports qualified column names (`alias.col`) in SET; Snowflake FROM extension for join-based updates
- **DELETE**: `DELETE FROM table [alias] [USING sources] [WHERE cond]` — USING reuses `parseFromItem` for subquery support
- **MERGE**: full `MERGE INTO target USING source ON cond WHEN ...` with MATCHED UPDATE/DELETE, NOT MATCHED INSERT (col list, VALUES, VALUES DEFAULT), BY SOURCE / BY TARGET extensions, AND conditions per WHEN clause

**New AST types:** `InsertStmt`, `InsertMultiStmt` + `InsertMultiBranch`, `UpdateStmt` + `UpdateSet` (with `*ObjectName` column), `DeleteStmt`, `MergeStmt` + `MergeWhen` + `MergeAction`. Walker regenerated (41 cases).

**Parser wiring:** Replaces `unsupported("INSERT")`, `unsupported("UPDATE")`, `unsupported("DELETE")`, `unsupported("MERGE")` stubs in `parseStmt`.

## Test plan

- [ ] `go test ./snowflake/... -count=1` passes (all 3 packages)
- [ ] 10 INSERT tests: basic VALUES, column list, SELECT, OVERWRITE, multi-row, qualified name, CTE, INSERT ALL/FIRST
- [ ] 7 UPDATE tests: basic SET, multiple assigns, WHERE, alias, FROM join, qualified name, expression value
- [ ] 6 DELETE tests: basic, WHERE, alias, USING single/multiple, qualified name
- [ ] 9 MERGE tests: MATCHED UPDATE/DELETE, NOT MATCHED INSERT, multiple WHENs, BY SOURCE/TARGET, subquery source, VALUES DEFAULT, no aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)