### PR TITLE
feat(snowflake): T2.3 ALTER TABLE full action set

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-alter-table.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-alter-table.md
@@ -1,0 +1,36 @@
+# Snowflake ALTER TABLE Implementation Plan (T2.3)
+
+## Steps
+
+### Step 1 — AST types (parsenodes.go + nodetags.go)
+- Add `AlterTableStmt`, `AlterTableAction`, `AlterTableActionKind`, `ColumnAlter`, `ColumnAlterKind`, `TableProp` to `parsenodes.go`
+- Add `T_AlterTableStmt` to `nodetags.go`
+- Run `go build ./snowflake/ast/...` to verify
+
+### Step 2 — Regenerate walker
+- Run `cd snowflake/ast && go run ./cmd/genwalker`
+- Verify `walk_generated.go` has case for `*AlterTableStmt`
+
+### Step 3 — Parser: alter_table.go
+- Create `snowflake/parser/alter_table.go`
+- Implement `parseAlterTableStmt()`
+- Implement all action sub-parsers
+- Update `parseAlterStmt()` in `database_schema.go` to dispatch `kwTABLE`
+
+### Step 4 — Tests: alter_table_test.go
+- Lint-critical paths: ADD COLUMN, DROP COLUMN, RENAME TO, ADD CONSTRAINT, DROP PRIMARY KEY
+- Other paths: SWAP WITH, RENAME COLUMN, ALTER COLUMN variants, CLUSTER BY, SET, UNSET, TAG, ROW ACCESS POLICY, SEARCH OPTIMIZATION
+
+### Step 5 — Verify and format
+- `go test ./snowflake/... -count=1`
+- `gofmt -w snowflake/`
+
+### Step 6 — Commits (3-5 logical)
+1. `feat(snowflake): AlterTableStmt AST types + NodeTag (T2.3 step 1)`
+2. `feat(snowflake): regen walker for AlterTableStmt (T2.3 step 2)`
+3. `feat(snowflake): ALTER TABLE parser — all major actions (T2.3 step 3)`
+4. `feat(snowflake): ALTER TABLE tests — lint-critical + coverage (T2.3 step 4)`
+
+### Step 7 — Push + PR
+- `git push -u origin feat/snowflake/alter-table`
+- `gh pr create ...`

--- a/docs/superpowers/specs/2026-04-15-snowflake-alter-table-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-alter-table-design.md
@@ -1,0 +1,170 @@
+# Snowflake ALTER TABLE Design (T2.3)
+
+## Overview
+
+ALTER TABLE is one of Snowflake's largest DDL statements.  
+This spec covers the full action set, splitting actions into:
+- **Lint-critical**: ADD COLUMN, DROP COLUMN, RENAME TO, ADD CONSTRAINT, DROP CONSTRAINT, DROP PRIMARY KEY
+- **Full-fidelity parse**: all others
+
+## AST Design
+
+### Top-level node
+
+```go
+type AlterTableStmt struct {
+    IfExists bool
+    Name     *ObjectName
+    Actions  []*AlterTableAction
+    Loc      Loc
+}
+```
+
+A single ALTER TABLE statement may carry multiple comma-separated actions
+(Snowflake allows this for ADD COLUMN, DROP COLUMN, and some others).
+
+### Action discriminated union
+
+```go
+type AlterTableActionKind int
+
+const (
+    AlterTableRename               AlterTableActionKind = iota
+    AlterTableSwapWith
+    AlterTableAddColumn
+    AlterTableDropColumn
+    AlterTableRenameColumn
+    AlterTableAlterColumn
+    AlterTableAddConstraint
+    AlterTableDropConstraint
+    AlterTableRenameConstraint
+    AlterTableClusterBy
+    AlterTableDropClusterKey
+    AlterTableRecluster
+    AlterTableSuspendRecluster
+    AlterTableResumeRecluster
+    AlterTableSet
+    AlterTableUnset
+    AlterTableSetTag
+    AlterTableUnsetTag
+    AlterTableAddRowAccessPolicy
+    AlterTableDropRowAccessPolicy
+    AlterTableDropAllRowAccessPolicies
+    AlterTableAddSearchOpt
+    AlterTableDropSearchOpt
+    AlterTableSetMaskingPolicy
+    AlterTableUnsetMaskingPolicy
+    AlterTableSetColumnTag
+    AlterTableUnsetColumnTag
+)
+```
+
+### Per-action payload (union-style fields)
+
+Only the fields relevant to each Kind are populated. This avoids a large
+proliferation of struct types while keeping full fidelity for lint-critical paths.
+
+Key fields:
+- `NewName *ObjectName` — RENAME TO, SWAP WITH target
+- `Columns []*ColumnDef` — ADD COLUMN definitions (reuse T2.2)
+- `DropColumnNames []Ident` — DROP COLUMN list
+- `IfExists bool` / `IfNotExists bool` — guards on column ops
+- `OldName Ident` + `NewColName Ident` — RENAME COLUMN old TO new
+- `ColumnAlter *ColumnAlter` — ALTER/MODIFY COLUMN specification
+- `Constraint *TableConstraint` — ADD CONSTRAINT (reuse T2.2)
+- `ConstraintName Ident` — DROP CONSTRAINT by name
+- `IsPrimaryKey bool` — DROP PRIMARY KEY (not named)
+- `DropUnique bool` — DROP UNIQUE (not named)
+- `DropForeignKey bool` — DROP FOREIGN KEY
+- `Cascade bool`, `Restrict bool` — DROP CONSTRAINT options
+- `ClusterBy []Node` — CLUSTER BY expressions
+- `Linear bool` — CLUSTER BY LINEAR
+- `Props []*TableProp` — SET properties
+- `UnsetProps []string` — UNSET property names
+- `Tags []*TagAssignment` — SET TAG assignments
+- `UnsetTags []*ObjectName` — UNSET TAG names
+- `PolicyName *ObjectName` — row access / masking policy
+- `PolicyCols []Ident` — row access policy ON (cols)
+- `MaskColumn Ident` — SET/UNSET MASKING POLICY column
+- `SearchOptOn []Node` — ADD/DROP SEARCH OPTIMIZATION ON targets
+
+### ColumnAlter
+
+Captures ALTER/MODIFY COLUMN sub-actions:
+
+```go
+type ColumnAlter struct {
+    Column Ident
+    Kind   ColumnAlterKind
+    // Per-kind fields:
+    DataType      *TypeName
+    DefaultExpr   Node
+    Comment       *string
+    MaskingPolicy *ObjectName
+    Tags          []*TagAssignment
+    UnsetTags     []*ObjectName
+}
+```
+
+### TableProp
+
+```go
+type TableProp struct {
+    Name  string
+    Value string
+}
+```
+
+## Grammar coverage
+
+From legacy `alter_table` + `alter_table_alter_column`:
+
+| Form | Kind |
+|------|------|
+| RENAME TO name | AlterTableRename |
+| SWAP WITH name | AlterTableSwapWith |
+| ADD [COLUMN] [IF NOT EXISTS] col_def [, ...] | AlterTableAddColumn |
+| DROP [COLUMN] [IF EXISTS] col [, ...] | AlterTableDropColumn |
+| RENAME COLUMN old TO new | AlterTableRenameColumn |
+| ALTER/MODIFY [COLUMN] col [...] | AlterTableAlterColumn |
+| ADD [CONSTRAINT name] PK/UK/FK | AlterTableAddConstraint |
+| DROP CONSTRAINT name | AlterTableDropConstraint |
+| DROP PRIMARY KEY | AlterTableDropConstraint (IsPrimaryKey=true) |
+| RENAME CONSTRAINT old TO new | AlterTableRenameConstraint |
+| CLUSTER BY [LINEAR] (exprs) | AlterTableClusterBy |
+| DROP CLUSTERING KEY | AlterTableDropClusterKey |
+| RECLUSTER [...] | AlterTableRecluster |
+| SUSPEND RECLUSTER | AlterTableSuspendRecluster |
+| RESUME RECLUSTER | AlterTableResumeRecluster |
+| SET properties... | AlterTableSet |
+| UNSET properties... | AlterTableUnset |
+| SET TAG (...) | AlterTableSetTag |
+| UNSET TAG (...) | AlterTableUnsetTag |
+| ADD ROW ACCESS POLICY | AlterTableAddRowAccessPolicy |
+| DROP ROW ACCESS POLICY | AlterTableDropRowAccessPolicy |
+| DROP ALL ROW ACCESS POLICIES | AlterTableDropAllRowAccessPolicies |
+| ADD SEARCH OPTIMIZATION [ON ...] | AlterTableAddSearchOpt |
+| DROP SEARCH OPTIMIZATION [ON ...] | AlterTableDropSearchOpt |
+| ALTER/MODIFY COLUMN col SET MASKING POLICY | AlterTableSetMaskingPolicy |
+| ALTER/MODIFY COLUMN col UNSET MASKING POLICY | AlterTableUnsetMaskingPolicy |
+| ALTER/MODIFY col SET TAG (...) | AlterTableSetColumnTag |
+| ALTER/MODIFY col UNSET TAG (...) | AlterTableUnsetColumnTag |
+
+## Walker integration
+
+`walkChildren` must visit:
+- `n.Name` (*ObjectName)
+- For each action: `NewName`, `Columns` (each ColumnDef), `Constraint`, `PolicyName`
+- `ColumnAlter.DataType`, `ColumnAlter.DefaultExpr`, `ColumnAlter.MaskingPolicy`
+
+Since `AlterTableAction` is not a Node itself, walker traverses actions inline
+from the `AlterTableStmt` case.
+
+## Lint-critical contract
+
+Downstream advisors will type-assert `*ast.AlterTableStmt` and inspect `Actions`:
+- `AlterTableAddColumn` → `Columns[i].Name`, `Columns[i].DataType`
+- `AlterTableDropColumn` → `DropColumnNames`
+- `AlterTableRename` → `NewName`
+- `AlterTableAddConstraint` → `Constraint.Type` (PK/FK/UNIQUE), `Constraint.Columns`
+- `AlterTableDropConstraint` → `ConstraintName`, `IsPrimaryKey`

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -76,6 +76,9 @@ const (
 	T_CreateMaterializedViewStmt
 	T_AlterViewStmt
 	T_AlterMaterializedViewStmt
+
+	// ALTER TABLE tag (T2.3)
+	T_AlterTableStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -183,6 +186,8 @@ func (t NodeTag) String() string {
 		return "AlterViewStmt"
 	case T_AlterMaterializedViewStmt:
 		return "AlterMaterializedViewStmt"
+	case T_AlterTableStmt:
+		return "AlterTableStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1585,3 +1585,156 @@ type AlterMaterializedViewStmt struct {
 func (n *AlterMaterializedViewStmt) Tag() NodeTag { return T_AlterMaterializedViewStmt }
 
 var _ Node = (*AlterMaterializedViewStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// ALTER TABLE DDL — enums, helpers, and statement node
+// ---------------------------------------------------------------------------
+
+// AlterTableActionKind discriminates the action variants of ALTER TABLE.
+type AlterTableActionKind int
+
+const (
+	AlterTableRename                   AlterTableActionKind = iota // RENAME TO new_name
+	AlterTableSwapWith                                             // SWAP WITH other_table
+	AlterTableAddColumn                                            // ADD [COLUMN] [IF NOT EXISTS] col_def [, ...]
+	AlterTableDropColumn                                           // DROP [COLUMN] [IF EXISTS] col [, ...]
+	AlterTableRenameColumn                                         // RENAME COLUMN old TO new
+	AlterTableAlterColumn                                          // ALTER/MODIFY COLUMN col ...
+	AlterTableAddConstraint                                        // ADD [CONSTRAINT name] PK/UK/FK
+	AlterTableDropConstraint                                       // DROP CONSTRAINT name | DROP PRIMARY KEY | DROP UNIQUE
+	AlterTableRenameConstraint                                     // RENAME CONSTRAINT old TO new
+	AlterTableClusterBy                                            // CLUSTER BY [LINEAR] (exprs)
+	AlterTableDropClusterKey                                       // DROP CLUSTERING KEY
+	AlterTableRecluster                                            // RECLUSTER [MAX_SIZE = n] [WHERE expr]
+	AlterTableSuspendRecluster                                     // SUSPEND RECLUSTER
+	AlterTableResumeRecluster                                      // RESUME RECLUSTER
+	AlterTableSet                                                  // SET properties
+	AlterTableUnset                                                // UNSET properties
+	AlterTableSetTag                                               // SET TAG (...)
+	AlterTableUnsetTag                                             // UNSET TAG (...)
+	AlterTableAddRowAccessPolicy                                   // ADD ROW ACCESS POLICY name ON (cols)
+	AlterTableDropRowAccessPolicy                                  // DROP ROW ACCESS POLICY name
+	AlterTableDropAllRowAccessPolicies                             // DROP ALL ROW ACCESS POLICIES
+	AlterTableAddSearchOpt                                         // ADD SEARCH OPTIMIZATION [ON ...]
+	AlterTableDropSearchOpt                                        // DROP SEARCH OPTIMIZATION [ON ...]
+	AlterTableSetMaskingPolicy                                     // ALTER/MODIFY COLUMN col SET MASKING POLICY
+	AlterTableUnsetMaskingPolicy                                   // ALTER/MODIFY COLUMN col UNSET MASKING POLICY
+	AlterTableSetColumnTag                                         // ALTER/MODIFY col SET TAG (...)
+	AlterTableUnsetColumnTag                                       // ALTER/MODIFY col UNSET TAG (...)
+)
+
+// ColumnAlterKind discriminates the sub-action inside ALTER/MODIFY COLUMN.
+type ColumnAlterKind int
+
+const (
+	ColumnAlterSetDataType  ColumnAlterKind = iota // SET DATA TYPE t | TYPE t | t
+	ColumnAlterSetDefault                          // SET DEFAULT expr
+	ColumnAlterDropDefault                         // DROP DEFAULT
+	ColumnAlterSetNotNull                          // SET NOT NULL
+	ColumnAlterDropNotNull                         // DROP NOT NULL
+	ColumnAlterSetComment                          // COMMENT 'text'
+	ColumnAlterUnsetComment                        // UNSET COMMENT
+)
+
+// ColumnAlter holds the specification for a single ALTER/MODIFY COLUMN
+// sub-action (used inside AlterTableAction.ColumnAlters).
+//
+// ColumnAlter is NOT a Node. It is owned by AlterTableAction.
+type ColumnAlter struct {
+	Column      Ident // column being altered
+	Kind        ColumnAlterKind
+	DataType    *TypeName // for ColumnAlterSetDataType
+	DefaultExpr Node      // for ColumnAlterSetDefault
+	Comment     *string   // for ColumnAlterSetComment
+}
+
+// TableProp is a single SET property key=value pair used in ALTER TABLE SET.
+// It is NOT a Node.
+type TableProp struct {
+	Name  string // uppercased property name
+	Value string // raw value text
+}
+
+// AlterTableAction represents one action in an ALTER TABLE statement.
+// Only the fields relevant to the Kind are populated.
+//
+// AlterTableAction is NOT a Node. It is owned by AlterTableStmt.
+type AlterTableAction struct {
+	Kind AlterTableActionKind
+
+	// --- Rename / SwapWith ---
+	NewName *ObjectName // RENAME TO target / SWAP WITH target
+
+	// --- AddColumn ---
+	Columns     []*ColumnDef // column definitions for ADD COLUMN
+	IfNotExists bool         // ADD COLUMN IF NOT EXISTS guard
+
+	// --- DropColumn ---
+	DropColumnNames []Ident // column names for DROP COLUMN
+	IfExists        bool    // DROP COLUMN IF EXISTS guard
+
+	// --- RenameColumn ---
+	OldName    Ident // RENAME COLUMN old
+	NewColName Ident // RENAME COLUMN ... TO new
+
+	// --- AlterColumn ---
+	ColumnAlters []*ColumnAlter // one per ALTER/MODIFY COLUMN spec
+
+	// --- AddConstraint ---
+	Constraint *TableConstraint // reuse T2.2 TableConstraint
+
+	// --- DropConstraint / RenameConstraint ---
+	ConstraintName    Ident // DROP CONSTRAINT name / RENAME CONSTRAINT old
+	NewConstraintName Ident // RENAME CONSTRAINT ... TO new
+	IsPrimaryKey      bool  // DROP PRIMARY KEY (unnamed)
+	DropUnique        bool  // DROP UNIQUE
+	DropForeignKey    bool  // DROP FOREIGN KEY
+	Cascade           bool
+	Restrict          bool
+
+	// --- ClusterBy ---
+	ClusterBy []Node // CLUSTER BY expressions
+	Linear    bool   // CLUSTER BY LINEAR
+
+	// --- Recluster ---
+	ReclusterMaxSize *int64 // MAX_SIZE = n; nil if absent
+	ReclusterWhere   Node   // WHERE expr; nil if absent
+
+	// --- Set / Unset properties ---
+	Props      []*TableProp // SET property list
+	UnsetProps []string     // UNSET property names
+
+	// --- SetTag / UnsetTag ---
+	Tags      []*TagAssignment // SET TAG assignments
+	UnsetTags []*ObjectName    // UNSET TAG names
+
+	// --- Row access policy ---
+	PolicyName *ObjectName // ADD/DROP ROW ACCESS POLICY name
+	PolicyCols []Ident     // ADD ROW ACCESS POLICY ... ON (cols)
+
+	// --- Search optimization ---
+	SearchOptOn []string // ON targets (raw text); nil = no ON clause
+
+	// --- Masking policy (column-level) ---
+	MaskColumn    Ident       // column for SET/UNSET MASKING POLICY
+	MaskingPolicy *ObjectName // SET MASKING POLICY target
+
+	// --- Column tag (ALTER/MODIFY col SET/UNSET TAG) ---
+	TagColumn Ident // column for SetColumnTag / UnsetColumnTag
+
+	Loc Loc
+}
+
+// AlterTableStmt represents ALTER TABLE [IF EXISTS] name action [, action ...].
+type AlterTableStmt struct {
+	IfExists bool
+	Name     *ObjectName
+	Actions  []*AlterTableAction
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *AlterTableStmt) Tag() NodeTag { return T_AlterTableStmt }
+
+// Compile-time assertion.
+var _ Node = (*AlterTableStmt)(nil)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -31,6 +31,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterTableStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *AlterViewStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)

--- a/snowflake/parser/alter_table.go
+++ b/snowflake/parser/alter_table.go
@@ -1,0 +1,1144 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// ALTER TABLE statement parser
+// ---------------------------------------------------------------------------
+
+// parseAlterTableStmt parses ALTER TABLE [IF EXISTS] name action [, action ...].
+// The ALTER keyword has already been consumed.
+func (p *Parser) parseAlterTableStmt() (ast.Node, error) {
+	altTok := p.advance() // consume TABLE
+	stmt := &ast.AlterTableStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Table name
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Parse one or more comma-separated actions.
+	// Not all action types allow comma-separated chaining, but we handle it
+	// generically at this level (the grammar allows multiple actions for ADD
+	// COLUMN, DROP COLUMN, etc.).
+	for {
+		action, err := p.parseAlterTableAction()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Actions = append(stmt.Actions, action)
+
+		// Some action forms allow comma-chaining (ADD COLUMN col, col; DROP COLUMN a, b...)
+		// but the top-level multi-action form (action , action) is handled here.
+		// We stop if the next token is not a comma that introduces a new top-level action.
+		// For ADD COLUMN and DROP COLUMN we allow comma continuations inside the action
+		// itself; at this level we stop on anything other than another action keyword.
+		if p.cur.Type != ',' {
+			break
+		}
+		// Peek ahead: if the comma is followed by an action keyword we continue;
+		// otherwise stop (it might be a semi-colon, EOF, etc.).
+		next := p.peekNext()
+		if !p.isAlterTableActionKeyword(next.Type) {
+			break
+		}
+		p.advance() // consume ','
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// isAlterTableActionKeyword returns true if tok starts a new ALTER TABLE action.
+func (p *Parser) isAlterTableActionKeyword(tokType int) bool {
+	switch tokType {
+	case kwRENAME, kwSWAP, kwADD, kwDROP, kwALTER, kwMODIFY,
+		kwCLUSTER, kwSUSPEND, kwRESUME, kwSET, kwUNSET, kwRECLUSTER:
+		return true
+	}
+	return false
+}
+
+// parseAlterTableAction parses a single ALTER TABLE action and returns it.
+func (p *Parser) parseAlterTableAction() (*ast.AlterTableAction, error) {
+	action := &ast.AlterTableAction{Loc: p.cur.Loc}
+
+	switch p.cur.Type {
+	case kwRENAME:
+		p.advance() // consume RENAME
+		switch p.cur.Type {
+		case kwTO:
+			// RENAME TO new_name
+			p.advance() // consume TO
+			newName, err := p.parseObjectName()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableRename
+			action.NewName = newName
+
+		case kwCOLUMN:
+			// RENAME COLUMN old TO new
+			p.advance() // consume COLUMN
+			oldName, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwTO); err != nil {
+				return nil, err
+			}
+			newCol, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableRenameColumn
+			action.OldName = oldName
+			action.NewColName = newCol
+
+		case kwCONSTRAINT:
+			// RENAME CONSTRAINT old TO new
+			p.advance() // consume CONSTRAINT
+			oldName, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(kwTO); err != nil {
+				return nil, err
+			}
+			newName, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableRenameConstraint
+			action.ConstraintName = oldName
+			action.NewConstraintName = newName
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwSWAP:
+		// SWAP WITH other_table
+		p.advance() // consume SWAP
+		if _, err := p.expect(kwWITH); err != nil {
+			return nil, err
+		}
+		otherName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		action.Kind = ast.AlterTableSwapWith
+		action.NewName = otherName
+
+	case kwADD:
+		p.advance() // consume ADD
+		if err := p.parseAlterTableAddAction(action); err != nil {
+			return nil, err
+		}
+
+	case kwDROP:
+		p.advance() // consume DROP
+		if err := p.parseAlterTableDropAction(action); err != nil {
+			return nil, err
+		}
+
+	case kwALTER, kwMODIFY:
+		p.advance() // consume ALTER or MODIFY
+		if err := p.parseAlterTableModifyAction(action); err != nil {
+			return nil, err
+		}
+
+	case kwCLUSTER:
+		// CLUSTER BY [LINEAR] (exprs)
+		p.advance() // consume CLUSTER
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		if p.cur.Type == kwLINEAR {
+			p.advance() // consume LINEAR
+			action.Linear = true
+		}
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		action.Kind = ast.AlterTableClusterBy
+		action.ClusterBy = exprs
+
+	case kwRECLUSTER:
+		// RECLUSTER [MAX_SIZE = n] [WHERE expr]
+		p.advance() // consume RECLUSTER
+		action.Kind = ast.AlterTableRecluster
+		if p.cur.Type == kwMAX_SIZE {
+			p.advance() // consume MAX_SIZE
+			if p.cur.Type == '=' {
+				p.advance()
+			}
+			tok, err := p.expect(tokInt)
+			if err != nil {
+				return nil, err
+			}
+			v := tok.Ival
+			action.ReclusterMaxSize = &v
+		}
+		if p.cur.Type == kwWHERE {
+			p.advance() // consume WHERE
+			whereExpr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			action.ReclusterWhere = whereExpr
+		}
+
+	case kwSUSPEND:
+		// SUSPEND RECLUSTER
+		p.advance() // consume SUSPEND
+		if p.cur.Type == kwRECLUSTER {
+			p.advance() // consume RECLUSTER
+			action.Kind = ast.AlterTableSuspendRecluster
+		} else {
+			// plain SUSPEND (table suspend)
+			action.Kind = ast.AlterTableSuspendRecluster
+		}
+
+	case kwRESUME:
+		// RESUME RECLUSTER
+		p.advance() // consume RESUME
+		if p.cur.Type == kwRECLUSTER {
+			p.advance() // consume RECLUSTER
+			action.Kind = ast.AlterTableResumeRecluster
+		} else {
+			action.Kind = ast.AlterTableResumeRecluster
+		}
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			// SET TAG (name = 'val', ...)
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableSetTag
+			action.Tags = tags
+		} else {
+			// SET table properties
+			props, err := p.parseTableSetProps()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableSet
+			action.Props = props
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			// UNSET TAG (name, ...)
+			names, err := p.parseUnsetTagList()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableUnsetTag
+			action.UnsetTags = names
+		} else {
+			// UNSET property_name [, ...]
+			props, err := p.parseTableUnsetProps()
+			if err != nil {
+				return nil, err
+			}
+			action.Kind = ast.AlterTableUnset
+			action.UnsetProps = props
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	action.Loc.End = p.prev.Loc.End
+	return action, nil
+}
+
+// ---------------------------------------------------------------------------
+// ADD sub-actions
+// ---------------------------------------------------------------------------
+
+// parseAlterTableAddAction parses the portion after ADD in an ALTER TABLE action.
+func (p *Parser) parseAlterTableAddAction(action *ast.AlterTableAction) error {
+	switch p.cur.Type {
+	case kwCOLUMN, kwIF:
+		// ADD [COLUMN] [IF NOT EXISTS] col_def [, col_def ...]
+		// Optionally consume COLUMN keyword
+		if p.cur.Type == kwCOLUMN {
+			p.advance()
+		}
+		if p.cur.Type == kwIF {
+			if p.peekNext().Type == kwNOT {
+				p.advance() // consume IF
+				p.advance() // consume NOT
+				if _, err := p.expect(kwEXISTS); err != nil {
+					return err
+				}
+				action.IfNotExists = true
+			}
+		}
+		action.Kind = ast.AlterTableAddColumn
+		return p.parseAddColumnList(action)
+
+	case kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN:
+		// ADD [CONSTRAINT name] PK/UK/FK
+		con, err := p.parseOutOfLineConstraint()
+		if err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableAddConstraint
+		action.Constraint = con
+		return nil
+
+	case kwROW:
+		// ADD ROW ACCESS POLICY name ON (cols)
+		p.advance() // consume ROW
+		if _, err := p.expect(kwACCESS); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return err
+		}
+		policyName, err := p.parseObjectName()
+		if err != nil {
+			return err
+		}
+		if _, err := p.expect(kwON); err != nil {
+			return err
+		}
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableAddRowAccessPolicy
+		action.PolicyName = policyName
+		action.PolicyCols = cols
+		return nil
+
+	case kwSEARCH:
+		// ADD SEARCH OPTIMIZATION [ON search_method(target), ...]
+		p.advance() // consume SEARCH
+		if _, err := p.expect(kwOPTIMIZATION); err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableAddSearchOpt
+		if p.cur.Type == kwON {
+			p.advance() // consume ON
+			if err := p.parseSearchOptTargets(action); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		// ADD col_def (no COLUMN keyword, no IF NOT EXISTS)
+		// Check whether current token looks like the start of a column name
+		if p.cur.Type == tokIdent || p.isNonReservedKeyword(p.cur.Type) {
+			action.Kind = ast.AlterTableAddColumn
+			return p.parseAddColumnList(action)
+		}
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// parseAddColumnList parses one or more column definitions for ADD COLUMN.
+// Called after ADD [COLUMN] [IF NOT EXISTS] has already been consumed.
+func (p *Parser) parseAddColumnList(action *ast.AlterTableAction) error {
+	col, err := p.parseColumnDef()
+	if err != nil {
+		return err
+	}
+	action.Columns = append(action.Columns, col)
+
+	for p.cur.Type == ',' {
+		// Peek ahead: if next is another column name (ident / non-reserved kw),
+		// keep going; otherwise stop (could be next top-level action).
+		next := p.peekNext()
+		if !p.isColumnNameToken(next.Type) {
+			break
+		}
+		p.advance() // consume ','
+		col, err = p.parseColumnDef()
+		if err != nil {
+			return err
+		}
+		action.Columns = append(action.Columns, col)
+	}
+	return nil
+}
+
+// parseSearchOptTargets parses the ON method(target) list for SEARCH OPTIMIZATION.
+func (p *Parser) parseSearchOptTargets(action *ast.AlterTableAction) error {
+	for {
+		// method can be EQUALITY, SUBSTRING, GEO, or an identifier
+		var method string
+		switch p.cur.Type {
+		case kwEQUALITY:
+			p.advance()
+			method = "EQUALITY"
+		case kwSUBSTRING:
+			p.advance()
+			method = "SUBSTRING"
+		case kwGEO:
+			p.advance()
+			method = "GEO"
+		case tokIdent:
+			tok := p.advance()
+			method = tok.Str
+		default:
+			return p.syntaxErrorAtCur()
+		}
+		// (STAR | expr)
+		if _, err := p.expect('('); err != nil {
+			return err
+		}
+		var target string
+		if p.cur.Type == '*' {
+			p.advance()
+			target = "*"
+		} else {
+			// skip expression tokens until matching ')'
+			expr, err := p.parseExpr()
+			if err != nil {
+				return err
+			}
+			_ = expr
+			target = "expr"
+		}
+		if _, err := p.expect(')'); err != nil {
+			return err
+		}
+		action.SearchOptOn = append(action.SearchOptOn, method+"("+target+")")
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// DROP sub-actions
+// ---------------------------------------------------------------------------
+
+// parseAlterTableDropAction parses the portion after DROP in an ALTER TABLE action.
+func (p *Parser) parseAlterTableDropAction(action *ast.AlterTableAction) error {
+	switch p.cur.Type {
+	case kwCOLUMN, kwIF:
+		// DROP [COLUMN] [IF EXISTS] col [, col ...]
+		if p.cur.Type == kwCOLUMN {
+			p.advance()
+		}
+		if p.cur.Type == kwIF {
+			if p.peekNext().Type == kwEXISTS {
+				p.advance() // consume IF
+				p.advance() // consume EXISTS
+				action.IfExists = true
+			}
+		}
+		action.Kind = ast.AlterTableDropColumn
+		return p.parseDropColumnList(action)
+
+	case kwCONSTRAINT:
+		// DROP CONSTRAINT name [CASCADE|RESTRICT]
+		p.advance() // consume CONSTRAINT
+		cname, err := p.parseIdent()
+		if err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropConstraint
+		action.ConstraintName = cname
+		p.parseDropCascadeRestrict(action)
+		return nil
+
+	case kwPRIMARY:
+		// DROP PRIMARY KEY [CASCADE|RESTRICT]
+		p.advance() // consume PRIMARY
+		if _, err := p.expect(kwKEY); err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropConstraint
+		action.IsPrimaryKey = true
+		p.parseDropCascadeRestrict(action)
+		return nil
+
+	case kwUNIQUE:
+		// DROP UNIQUE (cols)? [CASCADE|RESTRICT]
+		p.advance() // consume UNIQUE
+		action.Kind = ast.AlterTableDropConstraint
+		action.DropUnique = true
+		// optional column list
+		if p.cur.Type == '(' {
+			if err := p.skipParenthesized(); err != nil {
+				return err
+			}
+		}
+		p.parseDropCascadeRestrict(action)
+		return nil
+
+	case kwFOREIGN:
+		// DROP FOREIGN KEY (cols)? [CASCADE|RESTRICT]
+		p.advance() // consume FOREIGN
+		if _, err := p.expect(kwKEY); err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropConstraint
+		action.DropForeignKey = true
+		if p.cur.Type == '(' {
+			if err := p.skipParenthesized(); err != nil {
+				return err
+			}
+		}
+		p.parseDropCascadeRestrict(action)
+		return nil
+
+	case kwCLUSTERING:
+		// DROP CLUSTERING KEY
+		p.advance() // consume CLUSTERING
+		if _, err := p.expect(kwKEY); err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropClusterKey
+		return nil
+
+	case kwROW:
+		// DROP ROW ACCESS POLICY name
+		p.advance() // consume ROW
+		if _, err := p.expect(kwACCESS); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return err
+		}
+		policyName, err := p.parseObjectName()
+		if err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropRowAccessPolicy
+		action.PolicyName = policyName
+
+		// Optional: , ADD ROW ACCESS POLICY name ON (cols)
+		// (combined drop+add form — treat as a separate grammar note,
+		// we just consume and discard the extra ADD for now)
+		if p.cur.Type == ',' {
+			next := p.peekNext()
+			if next.Type == kwADD {
+				p.advance() // consume ','
+				p.advance() // consume ADD
+				p.advance() // consume ROW
+				if _, err := p.expect(kwACCESS); err != nil {
+					return err
+				}
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return err
+				}
+				if _, err := p.parseObjectName(); err != nil {
+					return err
+				}
+				if _, err := p.expect(kwON); err != nil {
+					return err
+				}
+				if err := p.skipParenthesized(); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+
+	case kwALL:
+		// DROP ALL ROW ACCESS POLICIES
+		p.advance() // consume ALL
+		p.advance() // consume ROW
+		if _, err := p.expect(kwACCESS); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwPOLICIES); err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropAllRowAccessPolicies
+		return nil
+
+	case kwSEARCH:
+		// DROP SEARCH OPTIMIZATION [ON search_method(target), ...]
+		p.advance() // consume SEARCH
+		if _, err := p.expect(kwOPTIMIZATION); err != nil {
+			return err
+		}
+		action.Kind = ast.AlterTableDropSearchOpt
+		if p.cur.Type == kwON {
+			p.advance() // consume ON
+			if err := p.parseSearchOptTargets(action); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		// DROP col [, col ...] — column name directly without COLUMN keyword
+		if p.cur.Type == tokIdent || p.isNonReservedKeyword(p.cur.Type) {
+			action.Kind = ast.AlterTableDropColumn
+			return p.parseDropColumnList(action)
+		}
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// parseDropColumnList parses a comma-separated list of column names after
+// DROP [COLUMN] [IF EXISTS].
+func (p *Parser) parseDropColumnList(action *ast.AlterTableAction) error {
+	col, err := p.parseIdent()
+	if err != nil {
+		return err
+	}
+	action.DropColumnNames = append(action.DropColumnNames, col)
+
+	for p.cur.Type == ',' {
+		next := p.peekNext()
+		if !p.isColumnNameToken(next.Type) {
+			break
+		}
+		p.advance() // consume ','
+		col, err = p.parseIdent()
+		if err != nil {
+			return err
+		}
+		action.DropColumnNames = append(action.DropColumnNames, col)
+	}
+	return nil
+}
+
+// parseDropCascadeRestrict optionally consumes CASCADE or RESTRICT.
+func (p *Parser) parseDropCascadeRestrict(action *ast.AlterTableAction) {
+	switch p.cur.Type {
+	case kwCASCADE:
+		p.advance()
+		action.Cascade = true
+	case kwRESTRICT:
+		p.advance()
+		action.Restrict = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER/MODIFY sub-actions
+// ---------------------------------------------------------------------------
+
+// parseAlterTableModifyAction parses the portion after ALTER/MODIFY in an
+// ALTER TABLE action (column modifications, masking policies, tag ops).
+func (p *Parser) parseAlterTableModifyAction(action *ast.AlterTableAction) error {
+	switch p.cur.Type {
+	case kwCOLUMN:
+		// ALTER/MODIFY COLUMN col <specific-op>
+		p.advance() // consume COLUMN
+		colName, err := p.parseIdent()
+		if err != nil {
+			return err
+		}
+		return p.parseColumnSpecificOp(action, colName)
+
+	default:
+		// ALTER/MODIFY col <specific-op> or
+		// ALTER/MODIFY (col_alter, col_alter, ...) or
+		// ALTER/MODIFY col_alter [, col_alter ...]
+		if p.cur.Type == '(' {
+			// ALTER MODIFY (alter_column_clause, ...)
+			p.advance() // consume '('
+			if err := p.parseAlterColumnClauses(action); err != nil {
+				return err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return err
+			}
+			return nil
+		}
+		// check if it looks like a column name (ident or non-reserved kw)
+		if p.cur.Type == tokIdent || p.isNonReservedKeyword(p.cur.Type) {
+			colName, err := p.parseIdent()
+			if err != nil {
+				return err
+			}
+			return p.parseColumnSpecificOp(action, colName)
+		}
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// parseColumnSpecificOp handles ALTER/MODIFY COLUMN col <op>.
+// <op> is one of: SET MASKING POLICY, UNSET MASKING POLICY,
+//
+//	SET TAG, UNSET TAG, or the standard alter_column_opts.
+func (p *Parser) parseColumnSpecificOp(action *ast.AlterTableAction, colName ast.Ident) error {
+	switch p.cur.Type {
+	case kwSET:
+		next := p.peekNext()
+		switch next.Type {
+		case kwMASKING:
+			// SET MASKING POLICY name [USING (...)] [FORCE]
+			p.advance() // consume SET
+			p.advance() // consume MASKING
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return err
+			}
+			policyName, err := p.parseObjectName()
+			if err != nil {
+				return err
+			}
+			if p.cur.Type == kwUSING {
+				p.advance() // consume USING
+				if err := p.skipParenthesized(); err != nil {
+					return err
+				}
+			}
+			if p.cur.Type == kwFORCE {
+				p.advance() // consume FORCE
+			}
+			action.Kind = ast.AlterTableSetMaskingPolicy
+			action.MaskColumn = colName
+			action.MaskingPolicy = policyName
+			return nil
+
+		case kwTAG:
+			// SET TAG (name = 'val', ...)
+			p.advance() // consume SET
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return err
+			}
+			action.Kind = ast.AlterTableSetColumnTag
+			action.TagColumn = colName
+			action.Tags = tags
+			return nil
+
+		default:
+			// SET DEFAULT, SET NOT NULL, SET DATA TYPE handled below
+		}
+
+	case kwUNSET:
+		next := p.peekNext()
+		switch next.Type {
+		case kwMASKING:
+			// UNSET MASKING POLICY
+			p.advance() // consume UNSET
+			p.advance() // consume MASKING
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return err
+			}
+			action.Kind = ast.AlterTableUnsetMaskingPolicy
+			action.MaskColumn = colName
+			return nil
+
+		case kwTAG:
+			// UNSET TAG (name, ...)
+			p.advance() // consume UNSET
+			names, err := p.parseUnsetTagList()
+			if err != nil {
+				return err
+			}
+			action.Kind = ast.AlterTableUnsetColumnTag
+			action.TagColumn = colName
+			action.UnsetTags = names
+			return nil
+
+		default:
+			// UNSET COMMENT handled below
+		}
+	}
+
+	// Standard alter_column_opts (inline, non-parenthesized form)
+	ca, err := p.parseAlterColumnOpts(colName)
+	if err != nil {
+		return err
+	}
+	action.Kind = ast.AlterTableAlterColumn
+	action.ColumnAlters = append(action.ColumnAlters, ca)
+
+	// More column alters may follow, comma-separated (no parentheses)
+	for p.cur.Type == ',' {
+		next := p.peekNext()
+		if !p.isAlterColumnStart(next.Type) {
+			break
+		}
+		p.advance() // consume ','
+		// Optional COLUMN keyword
+		if p.cur.Type == kwCOLUMN {
+			p.advance()
+		}
+		nextCol, err := p.parseIdent()
+		if err != nil {
+			return err
+		}
+		ca, err = p.parseAlterColumnOpts(nextCol)
+		if err != nil {
+			return err
+		}
+		action.ColumnAlters = append(action.ColumnAlters, ca)
+	}
+	return nil
+}
+
+// parseAlterColumnClauses parses ALTER/MODIFY ( col_alter, ... ) — the
+// parenthesized multi-column form. Expects the opening '(' already consumed.
+func (p *Parser) parseAlterColumnClauses(action *ast.AlterTableAction) error {
+	action.Kind = ast.AlterTableAlterColumn
+
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		// Optional COLUMN keyword
+		if p.cur.Type == kwCOLUMN {
+			p.advance()
+		}
+		colName, err := p.parseIdent()
+		if err != nil {
+			return err
+		}
+		ca, err := p.parseAlterColumnOpts(colName)
+		if err != nil {
+			return err
+		}
+		action.ColumnAlters = append(action.ColumnAlters, ca)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+		} else {
+			break
+		}
+	}
+	return nil
+}
+
+// parseAlterColumnOpts parses the alter_column_opts production for one column:
+//
+//	DROP DEFAULT
+//	SET DEFAULT obj.NEXTVAL
+//	SET NOT NULL | DROP NOT NULL
+//	(SET DATA)? TYPE? data_type  | just data_type
+//	COMMENT 'str'
+//	UNSET COMMENT
+func (p *Parser) parseAlterColumnOpts(colName ast.Ident) (*ast.ColumnAlter, error) {
+	ca := &ast.ColumnAlter{Column: colName}
+
+	switch p.cur.Type {
+	case kwDROP:
+		p.advance() // consume DROP
+		switch p.cur.Type {
+		case kwDEFAULT:
+			p.advance()
+			ca.Kind = ast.ColumnAlterDropDefault
+
+		case kwNOT:
+			p.advance() // consume NOT
+			if _, err := p.expect(kwNULL); err != nil {
+				return nil, err
+			}
+			ca.Kind = ast.ColumnAlterDropNotNull
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwSET:
+		p.advance() // consume SET
+		switch p.cur.Type {
+		case kwDEFAULT:
+			// SET DEFAULT obj.NEXTVAL
+			p.advance() // consume DEFAULT
+			// Parse obj.NEXTVAL as an expression
+			expr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			ca.Kind = ast.ColumnAlterSetDefault
+			ca.DefaultExpr = expr
+
+		case kwNOT:
+			// SET NOT NULL
+			p.advance() // consume NOT
+			if _, err := p.expect(kwNULL); err != nil {
+				return nil, err
+			}
+			ca.Kind = ast.ColumnAlterSetNotNull
+
+		case kwDATA:
+			// SET DATA TYPE data_type
+			p.advance() // consume DATA
+			if _, err := p.expect(kwTYPE); err != nil {
+				return nil, err
+			}
+			dt, err := p.parseDataType()
+			if err != nil {
+				return nil, err
+			}
+			ca.Kind = ast.ColumnAlterSetDataType
+			ca.DataType = dt
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwNOT:
+		// NOT NULL (shorthand, without SET)
+		p.advance() // consume NOT
+		if _, err := p.expect(kwNULL); err != nil {
+			return nil, err
+		}
+		ca.Kind = ast.ColumnAlterSetNotNull
+
+	case kwTYPE:
+		// TYPE data_type
+		p.advance() // consume TYPE
+		dt, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		ca.Kind = ast.ColumnAlterSetDataType
+		ca.DataType = dt
+
+	case kwCOMMENT:
+		// COMMENT 'str'
+		p.advance() // consume COMMENT
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		s := tok.Str
+		ca.Kind = ast.ColumnAlterSetComment
+		ca.Comment = &s
+
+	case kwUNSET:
+		// UNSET COMMENT
+		p.advance() // consume UNSET
+		if _, err := p.expect(kwCOMMENT); err != nil {
+			return nil, err
+		}
+		ca.Kind = ast.ColumnAlterUnsetComment
+
+	default:
+		// data_type directly (no SET DATA TYPE prefix)
+		dt, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		ca.Kind = ast.ColumnAlterSetDataType
+		ca.DataType = dt
+	}
+
+	return ca, nil
+}
+
+// isAlterColumnStart returns true if tok can start a column alter inside
+// a multi-column ALTER MODIFY list.
+func (p *Parser) isAlterColumnStart(tokType int) bool {
+	switch tokType {
+	case tokIdent, kwCOLUMN:
+		return true
+	}
+	return p.isNonReservedKeyword(tokType)
+}
+
+// ---------------------------------------------------------------------------
+// SET / UNSET table properties
+// ---------------------------------------------------------------------------
+
+// parseTableSetProps parses the SET properties after ALTER TABLE ... SET.
+// Returns a slice of TableProp, consuming all recognized properties.
+func (p *Parser) parseTableSetProps() ([]*ast.TableProp, error) {
+	var props []*ast.TableProp
+	for {
+		prop, ok, err := p.parseOneTableProp()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+		props = append(props, prop)
+	}
+	return props, nil
+}
+
+// parseOneTableProp attempts to parse a single known SET property.
+// Returns (prop, true, nil) on success, (nil, false, nil) if no property found.
+func (p *Parser) parseOneTableProp() (*ast.TableProp, bool, error) {
+	switch p.cur.Type {
+	case kwDATA_RETENTION_TIME_IN_DAYS:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		tok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, false, err
+		}
+		return &ast.TableProp{Name: "DATA_RETENTION_TIME_IN_DAYS", Value: tok.Str}, true, nil
+
+	case kwMAX_DATA_EXTENSION_TIME_IN_DAYS:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		tok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, false, err
+		}
+		return &ast.TableProp{Name: "MAX_DATA_EXTENSION_TIME_IN_DAYS", Value: tok.Str}, true, nil
+
+	case kwCHANGE_TRACKING:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		if p.cur.Type == kwTRUE || p.cur.Type == kwFALSE {
+			tok := p.advance()
+			return &ast.TableProp{Name: "CHANGE_TRACKING", Value: tok.Str}, true, nil
+		}
+		return nil, false, p.syntaxErrorAtCur()
+
+	case kwDEFAULT_DDL_COLLATION:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, false, err
+		}
+		return &ast.TableProp{Name: "DEFAULT_DDL_COLLATION", Value: tok.Str}, true, nil
+
+	case kwCOMMENT:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, false, err
+		}
+		return &ast.TableProp{Name: "COMMENT", Value: tok.Str}, true, nil
+
+	case kwSTAGE_FILE_FORMAT:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		if err := p.skipParenthesized(); err != nil {
+			return nil, false, err
+		}
+		return &ast.TableProp{Name: "STAGE_FILE_FORMAT", Value: "(...)"}, true, nil
+
+	case kwSTAGE_COPY_OPTIONS:
+		p.advance()
+		if p.cur.Type == '=' {
+			p.advance()
+		}
+		if err := p.skipParenthesized(); err != nil {
+			return nil, false, err
+		}
+		return &ast.TableProp{Name: "STAGE_COPY_OPTIONS", Value: "(...)"}, true, nil
+
+	default:
+		return nil, false, nil
+	}
+}
+
+// parseTableUnsetProps parses the UNSET property names (one or more, comma-sep).
+func (p *Parser) parseTableUnsetProps() ([]string, error) {
+	name, err := p.parseTableUnsetPropName()
+	if err != nil {
+		return nil, err
+	}
+	names := []string{name}
+	for p.cur.Type == ',' {
+		next := p.peekNext()
+		if !p.isTableUnsetPropToken(next.Type) {
+			break
+		}
+		p.advance() // consume ','
+		name, err = p.parseTableUnsetPropName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// parseTableUnsetPropName parses a single UNSET property name keyword.
+func (p *Parser) parseTableUnsetPropName() (string, error) {
+	switch p.cur.Type {
+	case kwDATA_RETENTION_TIME_IN_DAYS:
+		p.advance()
+		return "DATA_RETENTION_TIME_IN_DAYS", nil
+	case kwMAX_DATA_EXTENSION_TIME_IN_DAYS:
+		p.advance()
+		return "MAX_DATA_EXTENSION_TIME_IN_DAYS", nil
+	case kwCHANGE_TRACKING:
+		p.advance()
+		return "CHANGE_TRACKING", nil
+	case kwDEFAULT_DDL_COLLATION:
+		p.advance()
+		return "DEFAULT_DDL_COLLATION", nil
+	case kwCOMMENT:
+		p.advance()
+		return "COMMENT", nil
+	case tokIdent:
+		tok := p.advance()
+		return tok.Str, nil
+	default:
+		return "", p.syntaxErrorAtCur()
+	}
+}
+
+// isTableUnsetPropToken returns true if tok can be a TABLE UNSET prop name.
+func (p *Parser) isTableUnsetPropToken(tokType int) bool {
+	switch tokType {
+	case kwDATA_RETENTION_TIME_IN_DAYS, kwMAX_DATA_EXTENSION_TIME_IN_DAYS,
+		kwCHANGE_TRACKING, kwDEFAULT_DDL_COLLATION, kwCOMMENT, tokIdent:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// isColumnNameToken returns true if tok could be a column name.
+func (p *Parser) isColumnNameToken(tokType int) bool {
+	if tokType == tokIdent {
+		return true
+	}
+	return p.isNonReservedKeyword(tokType)
+}
+
+// isNonReservedKeyword returns true if a keyword token is non-reserved
+// (usable as an identifier without quoting) in Snowflake. This is used to
+// disambiguate comma-separated lists where the next token could be a column
+// name that happens to be a keyword.
+func (p *Parser) isNonReservedKeyword(tokType int) bool {
+	// keyword tokens start at kwABORT (700); anything below is not a keyword
+	if tokType < kwABORT {
+		return false
+	}
+	return !keywordReserved[tokType]
+}

--- a/snowflake/parser/alter_table_test.go
+++ b/snowflake/parser/alter_table_test.go
@@ -1,0 +1,790 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func testParseAlterTable(input string) (*ast.AlterTableStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.AlterTableStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not an AlterTableStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func requireAlterTable(t *testing.T, input string) *ast.AlterTableStmt {
+	t.Helper()
+	stmt, errs := testParseAlterTable(input)
+	if len(errs) > 0 {
+		t.Fatalf("parse errors for %q: %v", input, errs)
+	}
+	if stmt == nil {
+		t.Fatalf("expected AlterTableStmt for %q, got nil", input)
+	}
+	return stmt
+}
+
+func requireAction(t *testing.T, stmt *ast.AlterTableStmt, idx int) *ast.AlterTableAction {
+	t.Helper()
+	if idx >= len(stmt.Actions) {
+		t.Fatalf("expected action[%d], only %d actions", idx, len(stmt.Actions))
+	}
+	return stmt.Actions[idx]
+}
+
+// ---------------------------------------------------------------------------
+// RENAME TO (lint-critical: migration_compatibility)
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_RenameTo(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t1 RENAME TO t2")
+	if stmt.Name.Normalize() != "T1" {
+		t.Errorf("name = %q, want T1", stmt.Name.Normalize())
+	}
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableRename {
+		t.Errorf("kind = %v, want AlterTableRename", a.Kind)
+	}
+	if a.NewName == nil || a.NewName.Normalize() != "T2" {
+		t.Errorf("NewName = %v, want T2", a.NewName)
+	}
+}
+
+func TestAlterTable_RenameToIfExists(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE IF EXISTS mydb.myschema.t1 RENAME TO t2")
+	if !stmt.IfExists {
+		t.Error("expected IfExists = true")
+	}
+	if stmt.Name.Normalize() != "MYDB.MYSCHEMA.T1" {
+		t.Errorf("name = %q", stmt.Name.Normalize())
+	}
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableRename {
+		t.Errorf("kind = %v, want AlterTableRename", a.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SWAP WITH
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_SwapWith(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE orders SWAP WITH orders_backup")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSwapWith {
+		t.Errorf("kind = %v, want AlterTableSwapWith", a.Kind)
+	}
+	if a.NewName == nil || a.NewName.Normalize() != "ORDERS_BACKUP" {
+		t.Errorf("NewName = %v", a.NewName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ADD COLUMN (lint-critical: column detection)
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_AddColumn_Simple(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD COLUMN age INT")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddColumn {
+		t.Fatalf("kind = %v, want AlterTableAddColumn", a.Kind)
+	}
+	if len(a.Columns) != 1 {
+		t.Fatalf("expected 1 column, got %d", len(a.Columns))
+	}
+	col := a.Columns[0]
+	if col.Name.Normalize() != "AGE" {
+		t.Errorf("col name = %q, want AGE", col.Name.Normalize())
+	}
+	if col.DataType == nil || col.DataType.Kind != ast.TypeInt {
+		t.Errorf("col datatype = %v, want Int", col.DataType)
+	}
+}
+
+func TestAlterTable_AddColumn_NoColumnKeyword(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD name VARCHAR(100)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddColumn {
+		t.Fatalf("kind = %v, want AlterTableAddColumn", a.Kind)
+	}
+	if len(a.Columns) != 1 || a.Columns[0].Name.Normalize() != "NAME" {
+		t.Errorf("unexpected columns: %v", a.Columns)
+	}
+}
+
+func TestAlterTable_AddColumn_IfNotExists(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD COLUMN IF NOT EXISTS email VARCHAR")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddColumn {
+		t.Fatalf("kind = %v, want AlterTableAddColumn", a.Kind)
+	}
+	if !a.IfNotExists {
+		t.Error("expected IfNotExists = true")
+	}
+	if len(a.Columns) != 1 || a.Columns[0].Name.Normalize() != "EMAIL" {
+		t.Errorf("unexpected columns: %v", a.Columns)
+	}
+}
+
+func TestAlterTable_AddColumn_Multiple(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD COLUMN col1 INT, col2 VARCHAR(50), col3 BOOLEAN")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddColumn {
+		t.Fatalf("kind = %v, want AlterTableAddColumn", a.Kind)
+	}
+	if len(a.Columns) != 3 {
+		t.Fatalf("expected 3 columns, got %d", len(a.Columns))
+	}
+	if a.Columns[0].Name.Normalize() != "COL1" {
+		t.Errorf("col[0] name = %q", a.Columns[0].Name.Normalize())
+	}
+	if a.Columns[2].Name.Normalize() != "COL3" {
+		t.Errorf("col[2] name = %q", a.Columns[2].Name.Normalize())
+	}
+}
+
+func TestAlterTable_AddColumn_WithOptions(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD COLUMN id INT NOT NULL DEFAULT 0 COMMENT 'primary key'")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddColumn {
+		t.Fatalf("kind = %v, want AlterTableAddColumn", a.Kind)
+	}
+	col := a.Columns[0]
+	if !col.NotNull {
+		t.Error("expected NotNull = true")
+	}
+	if col.Default == nil {
+		t.Error("expected Default != nil")
+	}
+	if col.Comment == nil || *col.Comment != "primary key" {
+		t.Errorf("comment = %v", col.Comment)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP COLUMN (lint-critical: naming convention check)
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_DropColumn_Simple(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP COLUMN age")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropColumn {
+		t.Fatalf("kind = %v, want AlterTableDropColumn", a.Kind)
+	}
+	if len(a.DropColumnNames) != 1 || a.DropColumnNames[0].Normalize() != "AGE" {
+		t.Errorf("DropColumnNames = %v", a.DropColumnNames)
+	}
+}
+
+func TestAlterTable_DropColumn_IfExists(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP COLUMN IF EXISTS salary")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropColumn {
+		t.Fatalf("kind = %v, want AlterTableDropColumn", a.Kind)
+	}
+	if !a.IfExists {
+		t.Error("expected IfExists = true")
+	}
+	if len(a.DropColumnNames) != 1 || a.DropColumnNames[0].Normalize() != "SALARY" {
+		t.Errorf("DropColumnNames = %v", a.DropColumnNames)
+	}
+}
+
+func TestAlterTable_DropColumn_Multiple(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP COLUMN col1, col2, col3")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropColumn {
+		t.Fatalf("kind = %v, want AlterTableDropColumn", a.Kind)
+	}
+	if len(a.DropColumnNames) != 3 {
+		t.Fatalf("expected 3 drop cols, got %d", len(a.DropColumnNames))
+	}
+}
+
+func TestAlterTable_DropColumn_NoColumnKeyword(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP salary")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropColumn {
+		t.Fatalf("kind = %v, want AlterTableDropColumn", a.Kind)
+	}
+	if len(a.DropColumnNames) != 1 || a.DropColumnNames[0].Normalize() != "SALARY" {
+		t.Errorf("DropColumnNames = %v", a.DropColumnNames)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RENAME COLUMN
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_RenameColumn(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t RENAME COLUMN old_name TO new_name")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableRenameColumn {
+		t.Fatalf("kind = %v, want AlterTableRenameColumn", a.Kind)
+	}
+	if a.OldName.Normalize() != "OLD_NAME" {
+		t.Errorf("OldName = %q", a.OldName.Normalize())
+	}
+	if a.NewColName.Normalize() != "NEW_NAME" {
+		t.Errorf("NewColName = %q", a.NewColName.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ADD CONSTRAINT (lint-critical: PK/FK/UK detection)
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_AddPrimaryKey(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD PRIMARY KEY (id)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddConstraint {
+		t.Fatalf("kind = %v, want AlterTableAddConstraint", a.Kind)
+	}
+	if a.Constraint == nil {
+		t.Fatal("Constraint is nil")
+	}
+	if a.Constraint.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint type = %v, want PRIMARY KEY", a.Constraint.Type)
+	}
+	if len(a.Constraint.Columns) != 1 || a.Constraint.Columns[0].Normalize() != "ID" {
+		t.Errorf("columns = %v", a.Constraint.Columns)
+	}
+}
+
+func TestAlterTable_AddPrimaryKeyNamed(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD CONSTRAINT pk_t PRIMARY KEY (id, code)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddConstraint {
+		t.Fatalf("kind = %v, want AlterTableAddConstraint", a.Kind)
+	}
+	if a.Constraint.Name.Normalize() != "PK_T" {
+		t.Errorf("constraint name = %q", a.Constraint.Name.Normalize())
+	}
+	if a.Constraint.Type != ast.ConstrPrimaryKey {
+		t.Errorf("constraint type = %v", a.Constraint.Type)
+	}
+	if len(a.Constraint.Columns) != 2 {
+		t.Errorf("expected 2 columns, got %d", len(a.Constraint.Columns))
+	}
+}
+
+func TestAlterTable_AddUniqueConstraint(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD UNIQUE (email)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddConstraint {
+		t.Fatalf("kind = %v, want AlterTableAddConstraint", a.Kind)
+	}
+	if a.Constraint.Type != ast.ConstrUnique {
+		t.Errorf("constraint type = %v, want UNIQUE", a.Constraint.Type)
+	}
+}
+
+func TestAlterTable_AddForeignKey(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE orders ADD FOREIGN KEY (customer_id) REFERENCES customers (id)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddConstraint {
+		t.Fatalf("kind = %v, want AlterTableAddConstraint", a.Kind)
+	}
+	if a.Constraint.Type != ast.ConstrForeignKey {
+		t.Errorf("constraint type = %v, want FOREIGN KEY", a.Constraint.Type)
+	}
+	if a.Constraint.References == nil {
+		t.Fatal("References is nil")
+	}
+	if a.Constraint.References.Table.Normalize() != "CUSTOMERS" {
+		t.Errorf("references table = %q", a.Constraint.References.Table.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP CONSTRAINT (lint-critical)
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_DropConstraintNamed(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP CONSTRAINT pk_t")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropConstraint {
+		t.Fatalf("kind = %v, want AlterTableDropConstraint", a.Kind)
+	}
+	if a.ConstraintName.Normalize() != "PK_T" {
+		t.Errorf("ConstraintName = %q", a.ConstraintName.Normalize())
+	}
+}
+
+func TestAlterTable_DropConstraintCascade(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP CONSTRAINT fk_c CASCADE")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropConstraint {
+		t.Fatalf("kind = %v, want AlterTableDropConstraint", a.Kind)
+	}
+	if !a.Cascade {
+		t.Error("expected Cascade = true")
+	}
+}
+
+func TestAlterTable_DropPrimaryKey(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP PRIMARY KEY")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropConstraint {
+		t.Fatalf("kind = %v, want AlterTableDropConstraint", a.Kind)
+	}
+	if !a.IsPrimaryKey {
+		t.Error("expected IsPrimaryKey = true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RENAME CONSTRAINT
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_RenameConstraint(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t RENAME CONSTRAINT old_pk TO new_pk")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableRenameConstraint {
+		t.Fatalf("kind = %v, want AlterTableRenameConstraint", a.Kind)
+	}
+	if a.ConstraintName.Normalize() != "OLD_PK" {
+		t.Errorf("ConstraintName = %q", a.ConstraintName.Normalize())
+	}
+	if a.NewConstraintName.Normalize() != "NEW_PK" {
+		t.Errorf("NewConstraintName = %q", a.NewConstraintName.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CLUSTER BY / DROP CLUSTERING KEY
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_ClusterBy(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t CLUSTER BY (col1, col2)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableClusterBy {
+		t.Fatalf("kind = %v, want AlterTableClusterBy", a.Kind)
+	}
+	if len(a.ClusterBy) != 2 {
+		t.Errorf("ClusterBy exprs = %d, want 2", len(a.ClusterBy))
+	}
+}
+
+func TestAlterTable_ClusterByLinear(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t CLUSTER BY LINEAR (col1)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableClusterBy {
+		t.Fatalf("kind = %v, want AlterTableClusterBy", a.Kind)
+	}
+	if !a.Linear {
+		t.Error("expected Linear = true")
+	}
+}
+
+func TestAlterTable_DropClusteringKey(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP CLUSTERING KEY")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropClusterKey {
+		t.Fatalf("kind = %v, want AlterTableDropClusterKey", a.Kind)
+	}
+}
+
+func TestAlterTable_SuspendRecluster(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t SUSPEND RECLUSTER")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSuspendRecluster {
+		t.Fatalf("kind = %v, want AlterTableSuspendRecluster", a.Kind)
+	}
+}
+
+func TestAlterTable_ResumeRecluster(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t RESUME RECLUSTER")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableResumeRecluster {
+		t.Fatalf("kind = %v, want AlterTableResumeRecluster", a.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER/MODIFY COLUMN variants
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_AlterColumn_SetDataType(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c SET DATA TYPE VARCHAR(200)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAlterColumn {
+		t.Fatalf("kind = %v, want AlterTableAlterColumn", a.Kind)
+	}
+	if len(a.ColumnAlters) != 1 {
+		t.Fatalf("expected 1 ColumnAlter, got %d", len(a.ColumnAlters))
+	}
+	ca := a.ColumnAlters[0]
+	if ca.Column.Normalize() != "C" {
+		t.Errorf("column = %q", ca.Column.Normalize())
+	}
+	if ca.Kind != ast.ColumnAlterSetDataType {
+		t.Errorf("alter kind = %v", ca.Kind)
+	}
+	if ca.DataType == nil || ca.DataType.Kind != ast.TypeVarchar {
+		t.Errorf("datatype = %v", ca.DataType)
+	}
+}
+
+func TestAlterTable_AlterColumn_TypeShorthand(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c TYPE NUMBER(10,2)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAlterColumn {
+		t.Fatalf("kind = %v, want AlterTableAlterColumn", a.Kind)
+	}
+	ca := a.ColumnAlters[0]
+	if ca.Kind != ast.ColumnAlterSetDataType {
+		t.Errorf("alter kind = %v", ca.Kind)
+	}
+}
+
+func TestAlterTable_ModifyColumn_DropDefault(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t MODIFY COLUMN c DROP DEFAULT")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAlterColumn {
+		t.Fatalf("kind = %v, want AlterTableAlterColumn", a.Kind)
+	}
+	ca := a.ColumnAlters[0]
+	if ca.Kind != ast.ColumnAlterDropDefault {
+		t.Errorf("alter kind = %v, want DropDefault", ca.Kind)
+	}
+}
+
+func TestAlterTable_AlterColumn_SetNotNull(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c SET NOT NULL")
+	a := requireAction(t, stmt, 0)
+	ca := a.ColumnAlters[0]
+	if ca.Kind != ast.ColumnAlterSetNotNull {
+		t.Errorf("alter kind = %v, want SetNotNull", ca.Kind)
+	}
+}
+
+func TestAlterTable_AlterColumn_DropNotNull(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c DROP NOT NULL")
+	a := requireAction(t, stmt, 0)
+	ca := a.ColumnAlters[0]
+	if ca.Kind != ast.ColumnAlterDropNotNull {
+		t.Errorf("alter kind = %v, want DropNotNull", ca.Kind)
+	}
+}
+
+func TestAlterTable_AlterColumn_Comment(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c COMMENT 'my column'")
+	a := requireAction(t, stmt, 0)
+	ca := a.ColumnAlters[0]
+	if ca.Kind != ast.ColumnAlterSetComment {
+		t.Errorf("alter kind = %v, want SetComment", ca.Kind)
+	}
+	if ca.Comment == nil || *ca.Comment != "my column" {
+		t.Errorf("comment = %v", ca.Comment)
+	}
+}
+
+func TestAlterTable_AlterColumn_UnsetComment(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c UNSET COMMENT")
+	a := requireAction(t, stmt, 0)
+	ca := a.ColumnAlters[0]
+	if ca.Kind != ast.ColumnAlterUnsetComment {
+		t.Errorf("alter kind = %v, want UnsetComment", ca.Kind)
+	}
+}
+
+func TestAlterTable_AlterColumn_Parenthesized(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t MODIFY (col1 SET NOT NULL, col2 DROP DEFAULT)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAlterColumn {
+		t.Fatalf("kind = %v, want AlterTableAlterColumn", a.Kind)
+	}
+	if len(a.ColumnAlters) != 2 {
+		t.Fatalf("expected 2 ColumnAlters, got %d", len(a.ColumnAlters))
+	}
+	if a.ColumnAlters[0].Column.Normalize() != "COL1" {
+		t.Errorf("col[0] = %q", a.ColumnAlters[0].Column.Normalize())
+	}
+	if a.ColumnAlters[1].Column.Normalize() != "COL2" {
+		t.Errorf("col[1] = %q", a.ColumnAlters[1].Column.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SET MASKING POLICY / UNSET MASKING POLICY
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_SetMaskingPolicy(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN ssn SET MASKING POLICY pii_mask")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSetMaskingPolicy {
+		t.Fatalf("kind = %v, want AlterTableSetMaskingPolicy", a.Kind)
+	}
+	if a.MaskColumn.Normalize() != "SSN" {
+		t.Errorf("MaskColumn = %q", a.MaskColumn.Normalize())
+	}
+	if a.MaskingPolicy == nil || a.MaskingPolicy.Normalize() != "PII_MASK" {
+		t.Errorf("MaskingPolicy = %v", a.MaskingPolicy)
+	}
+}
+
+func TestAlterTable_UnsetMaskingPolicy(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN ssn UNSET MASKING POLICY")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableUnsetMaskingPolicy {
+		t.Fatalf("kind = %v, want AlterTableUnsetMaskingPolicy", a.Kind)
+	}
+	if a.MaskColumn.Normalize() != "SSN" {
+		t.Errorf("MaskColumn = %q", a.MaskColumn.Normalize())
+	}
+}
+
+func TestAlterTable_ModifyColumn_SetMaskingPolicyWithForce(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t MODIFY COLUMN email SET MASKING POLICY email_mask USING (email, scope) FORCE")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSetMaskingPolicy {
+		t.Fatalf("kind = %v, want AlterTableSetMaskingPolicy", a.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SET / UNSET table properties
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_SetComment(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t SET COMMENT = 'my table'")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSet {
+		t.Fatalf("kind = %v, want AlterTableSet", a.Kind)
+	}
+	if len(a.Props) != 1 {
+		t.Fatalf("expected 1 prop, got %d", len(a.Props))
+	}
+	if a.Props[0].Name != "COMMENT" {
+		t.Errorf("prop name = %q", a.Props[0].Name)
+	}
+	if a.Props[0].Value != "my table" {
+		t.Errorf("prop value = %q", a.Props[0].Value)
+	}
+}
+
+func TestAlterTable_SetDataRetention(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t SET DATA_RETENTION_TIME_IN_DAYS = 7")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSet {
+		t.Fatalf("kind = %v, want AlterTableSet", a.Kind)
+	}
+	if len(a.Props) < 1 || a.Props[0].Name != "DATA_RETENTION_TIME_IN_DAYS" {
+		t.Errorf("props = %v", a.Props)
+	}
+}
+
+func TestAlterTable_SetChangeTracking(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t SET CHANGE_TRACKING = TRUE")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSet {
+		t.Fatalf("kind = %v, want AlterTableSet", a.Kind)
+	}
+}
+
+func TestAlterTable_UnsetProps(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t UNSET DATA_RETENTION_TIME_IN_DAYS, COMMENT")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableUnset {
+		t.Fatalf("kind = %v, want AlterTableUnset", a.Kind)
+	}
+	if len(a.UnsetProps) != 2 {
+		t.Fatalf("expected 2 unset props, got %d", len(a.UnsetProps))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SET TAG / UNSET TAG
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_SetTag(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t SET TAG (my_tag = 'v1', other_tag = 'v2')")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSetTag {
+		t.Fatalf("kind = %v, want AlterTableSetTag", a.Kind)
+	}
+	if len(a.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(a.Tags))
+	}
+	if a.Tags[0].Value != "v1" {
+		t.Errorf("tag[0] value = %q", a.Tags[0].Value)
+	}
+}
+
+func TestAlterTable_UnsetTag(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t UNSET TAG (my_tag, other_tag)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableUnsetTag {
+		t.Fatalf("kind = %v, want AlterTableUnsetTag", a.Kind)
+	}
+	if len(a.UnsetTags) != 2 {
+		t.Fatalf("expected 2 unset tags, got %d", len(a.UnsetTags))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ROW ACCESS POLICY
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_AddRowAccessPolicy(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD ROW ACCESS POLICY rap1 ON (col1, col2)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddRowAccessPolicy {
+		t.Fatalf("kind = %v, want AlterTableAddRowAccessPolicy", a.Kind)
+	}
+	if a.PolicyName == nil || a.PolicyName.Normalize() != "RAP1" {
+		t.Errorf("PolicyName = %v", a.PolicyName)
+	}
+	if len(a.PolicyCols) != 2 {
+		t.Errorf("PolicyCols = %v", a.PolicyCols)
+	}
+}
+
+func TestAlterTable_DropRowAccessPolicy(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP ROW ACCESS POLICY rap1")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropRowAccessPolicy {
+		t.Fatalf("kind = %v, want AlterTableDropRowAccessPolicy", a.Kind)
+	}
+	if a.PolicyName == nil || a.PolicyName.Normalize() != "RAP1" {
+		t.Errorf("PolicyName = %v", a.PolicyName)
+	}
+}
+
+func TestAlterTable_DropAllRowAccessPolicies(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP ALL ROW ACCESS POLICIES")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropAllRowAccessPolicies {
+		t.Fatalf("kind = %v, want AlterTableDropAllRowAccessPolicies", a.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SEARCH OPTIMIZATION
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_AddSearchOptimization(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddSearchOpt {
+		t.Fatalf("kind = %v, want AlterTableAddSearchOpt", a.Kind)
+	}
+	if len(a.SearchOptOn) != 0 {
+		t.Errorf("expected no ON targets, got %v", a.SearchOptOn)
+	}
+}
+
+func TestAlterTable_DropSearchOptimization(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP SEARCH OPTIMIZATION")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropSearchOpt {
+		t.Fatalf("kind = %v, want AlterTableDropSearchOpt", a.Kind)
+	}
+}
+
+func TestAlterTable_AddSearchOptimizationOnEquality(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(col1)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddSearchOpt {
+		t.Fatalf("kind = %v, want AlterTableAddSearchOpt", a.Kind)
+	}
+	if len(a.SearchOptOn) != 1 {
+		t.Errorf("expected 1 ON target, got %v", a.SearchOptOn)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Column SET/UNSET TAG
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_SetColumnTag(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c SET TAG (sensitivity = 'pii')")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableSetColumnTag {
+		t.Fatalf("kind = %v, want AlterTableSetColumnTag", a.Kind)
+	}
+	if a.TagColumn.Normalize() != "C" {
+		t.Errorf("TagColumn = %q", a.TagColumn.Normalize())
+	}
+	if len(a.Tags) != 1 || a.Tags[0].Value != "pii" {
+		t.Errorf("tags = %v", a.Tags)
+	}
+}
+
+func TestAlterTable_UnsetColumnTag(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ALTER COLUMN c UNSET TAG (sensitivity)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableUnsetColumnTag {
+		t.Fatalf("kind = %v, want AlterTableUnsetColumnTag", a.Kind)
+	}
+	if a.TagColumn.Normalize() != "C" {
+		t.Errorf("TagColumn = %q", a.TagColumn.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Recluster
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_Recluster(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t RECLUSTER MAX_SIZE = 1000 WHERE id > 0")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableRecluster {
+		t.Fatalf("kind = %v, want AlterTableRecluster", a.Kind)
+	}
+	if a.ReclusterMaxSize == nil || *a.ReclusterMaxSize != 1000 {
+		t.Errorf("ReclusterMaxSize = %v", a.ReclusterMaxSize)
+	}
+	if a.ReclusterWhere == nil {
+		t.Error("expected ReclusterWhere != nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-action comma-separated (top-level)
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_MultiAction_DropUnique(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t DROP UNIQUE (col1)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropConstraint {
+		t.Fatalf("kind = %v, want AlterTableDropConstraint", a.Kind)
+	}
+	if !a.DropUnique {
+		t.Error("expected DropUnique = true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Location tracking
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_LocTracking(t *testing.T) {
+	input := "ALTER TABLE t ADD COLUMN c INT"
+	stmt, errs := testParseAlterTable(input)
+	if len(errs) > 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	if !stmt.Loc.IsValid() {
+		t.Error("stmt.Loc is not valid")
+	}
+	// Loc.Start is at the TABLE token (ALTER is consumed by the dispatcher),
+	// consistent with how AlterDatabaseStmt and AlterSchemaStmt set their loc.
+	if stmt.Loc.Start <= 0 {
+		t.Errorf("stmt.Loc.Start = %d, expected > 0 (TABLE keyword position)", stmt.Loc.Start)
+	}
+	if stmt.Loc.End <= stmt.Loc.Start {
+		t.Errorf("stmt.Loc.End (%d) <= Start (%d)", stmt.Loc.End, stmt.Loc.Start)
+	}
+}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -161,6 +161,8 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	p.advance() // consume ALTER
 
 	switch p.cur.Type {
+	case kwTABLE:
+		return p.parseAlterTableStmt()
 	case kwDATABASE:
 		return p.parseAlterDatabaseStmt()
 	case kwSCHEMA:


### PR DESCRIPTION
## Summary

- Implement full `ALTER TABLE` parser for Snowflake (T2.3), covering all major action variants from the legacy ANTLR4 grammar
- Add `AlterTableStmt` AST node with `AlterTableAction` union-style struct (27 action kinds) plus `ColumnAlter` and `TableProp` helpers
- Regenerate walker; dispatch `kwTABLE` in the existing `parseAlterStmt()` dispatcher

## Lint-critical actions (full AST fidelity)

| Action | Fields populated |
|--------|-----------------|
| `ADD COLUMN` | `Columns[i].Name`, `Columns[i].DataType` |
| `DROP COLUMN` | `DropColumnNames`, `IfExists` |
| `RENAME TO` | `NewName` |
| `ADD CONSTRAINT` | `Constraint.Type` (PK/FK/UK), `Constraint.Columns`, `Constraint.Name` |
| `DROP CONSTRAINT` | `ConstraintName`, `IsPrimaryKey`, `DropUnique`, `Cascade/Restrict` |

## Other actions covered (parse-and-store)

SWAP WITH, RENAME COLUMN, RENAME CONSTRAINT, ALTER/MODIFY COLUMN (set data type, default, nullability, comment, masking policy, column tags), CLUSTER BY / DROP CLUSTERING KEY / RECLUSTER / SUSPEND|RESUME RECLUSTER, SET/UNSET table properties, SET/UNSET TAG, ADD/DROP ROW ACCESS POLICY, DROP ALL ROW ACCESS POLICIES, ADD/DROP SEARCH OPTIMIZATION (with ON targets)

## Test plan

- [x] `go test ./snowflake/... -count=1` — all 4 packages pass
- [x] `gofmt -w snowflake/` applied, tests re-verified
- [x] 50+ test cases: lint-critical paths with full field assertions + other action kinds
- [x] IF EXISTS / IF NOT EXISTS guards, multi-column ADD/DROP, FORCE/USING for masking policy, nested parens in SEARCH OPTIMIZATION ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)