### PR TITLE
feat(doris): query span extractor (T3.1)

### DIFF
--- a/doris/analysis/query_span.go
+++ b/doris/analysis/query_span.go
@@ -1,0 +1,474 @@
+package analysis
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+	"github.com/bytebase/omni/doris/parser"
+)
+
+// QuerySpan captures the tables and columns a query references. It is the
+// data structure consumed by Bytebase for field-level lineage and for SQL
+// editor access-tracking (read/write permission checks).
+type QuerySpan struct {
+	// Type is the classification of the query (SELECT, DML, DDL, etc.).
+	Type QueryType
+
+	// AccessTables is the set of tables the query reads from: every physical
+	// table reference in the FROM clause, JOINs, and subqueries. Entries are
+	// deduplicated; CTE references (and subquery-derived aliases) are excluded.
+	AccessTables []TableAccess
+
+	// Results is the list of output columns produced by the outermost SELECT.
+	// For set operations (UNION/INTERSECT/EXCEPT), the left side wins.
+	Results []ColumnInfo
+
+	// CTEs tracks the names defined by WITH clauses at any scope — useful for
+	// debugging and for consumers that want to show the CTE structure.
+	CTEs []string
+}
+
+// TableAccess represents a single physical table referenced in a query.
+type TableAccess struct {
+	Database string  // optional database qualifier (empty when none)
+	Table    string  // table name
+	Alias    string  // optional alias at the reference site (empty when none)
+	Loc      ast.Loc // source location of the table reference
+}
+
+// ColumnInfo represents one output column from a SELECT list.
+type ColumnInfo struct {
+	// Name is the output column name: the alias if one is present, otherwise a
+	// best-effort rendering of the expression (column name for a simple
+	// ColumnRef, "*" for star items, or empty when we cannot produce one).
+	Name string
+
+	// SourceColumns is a best-effort list of underlying column references that
+	// feed this output column. For the current scope we record every ColumnRef
+	// we encounter while walking the expression tree; full field-level lineage
+	// is out of scope for T3.1.
+	SourceColumns []ColumnRef
+}
+
+// ColumnRef identifies a column by its (optional) database/table qualifier
+// and column name.
+type ColumnRef struct {
+	Database string
+	Table    string
+	Column   string
+}
+
+// GetQuerySpan analyzes a SQL statement and returns its query span: the set
+// of tables it reads from, the CTE names it defines, and its output columns.
+//
+// GetQuerySpan is tolerant of parse errors — if the parser produces a partial
+// AST, whatever was parsed is still analyzed. On empty input it returns a
+// zero-valued span with Type=QueryTypeUnknown.
+func GetQuerySpan(statement string) (*QuerySpan, error) {
+	file, _ := parser.Parse(statement)
+	span := &QuerySpan{
+		Type: Classify(statement),
+	}
+	if file == nil || len(file.Stmts) == 0 {
+		return span, nil
+	}
+
+	w := newSpanWalker(span)
+	for _, stmt := range file.Stmts {
+		w.analyzeStmt(stmt)
+	}
+	w.finalize()
+	return span, nil
+}
+
+// ---------------------------------------------------------------------------
+// Walker
+// ---------------------------------------------------------------------------
+
+// cteScope is a linked stack of CTE name sets. When resolving a bare table
+// reference we walk outwards — an inner CTE shadows an outer one of the same
+// name.
+type cteScope struct {
+	names  map[string]bool
+	parent *cteScope
+}
+
+func (s *cteScope) isCTE(name string) bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.names[strings.ToLower(name)] {
+			return true
+		}
+	}
+	return false
+}
+
+// spanWalker performs the SELECT-tree walk that populates a QuerySpan.
+//
+// The walker maintains:
+//   - a scope stack of CTE names so bare table references can be filtered out
+//   - a deduplication map of (database, table) pairs for AccessTables
+//   - a flag indicating whether the outermost SELECT has populated Results yet
+type spanWalker struct {
+	span     *QuerySpan
+	scope    *cteScope
+	accessed map[tableKey]int // maps key -> index in span.AccessTables
+	resolved bool             // Results have been captured for the outermost SELECT
+}
+
+type tableKey struct {
+	Database string
+	Table    string
+	Alias    string
+}
+
+func newSpanWalker(span *QuerySpan) *spanWalker {
+	return &spanWalker{
+		span:     span,
+		accessed: make(map[tableKey]int),
+	}
+}
+
+// analyzeStmt dispatches on the top-level statement kind. Only SELECT /
+// set-op trees produce meaningful query-span data; other statement kinds are
+// recorded via their QueryType classification only.
+func (w *spanWalker) analyzeStmt(node ast.Node) {
+	switch n := node.(type) {
+	case *ast.SelectStmt:
+		w.visitSelect(n, true /* outermost */)
+	case *ast.SetOpStmt:
+		w.visitSetOp(n, true /* outermost */)
+	}
+}
+
+// visitSetOp walks a UNION/INTERSECT/EXCEPT tree. The left arm is the one
+// whose Results we surface when this is the outermost statement — matching
+// SQL's "take column names from the first SELECT" rule.
+func (w *spanWalker) visitSetOp(n *ast.SetOpStmt, outermost bool) {
+	if n == nil {
+		return
+	}
+	switch l := n.Left.(type) {
+	case *ast.SelectStmt:
+		w.visitSelect(l, outermost)
+	case *ast.SetOpStmt:
+		w.visitSetOp(l, outermost)
+	}
+	switch r := n.Right.(type) {
+	case *ast.SelectStmt:
+		w.visitSelect(r, false)
+	case *ast.SetOpStmt:
+		w.visitSetOp(r, false)
+	}
+}
+
+// visitSelect processes one SelectStmt. It pushes a new CTE scope so the
+// names defined by this WITH clause shadow any outer ones, then walks the
+// FROM / WHERE / HAVING / QUALIFY / SELECT list, collecting tables and
+// column references as it goes.
+func (w *spanWalker) visitSelect(stmt *ast.SelectStmt, outermost bool) {
+	if stmt == nil {
+		return
+	}
+
+	// Push a scope. CTE bodies themselves run in the *parent* scope — a CTE
+	// may not reference itself except via RECURSIVE, and sibling CTEs are
+	// allowed to reference earlier siblings. To keep things simple we treat
+	// all CTEs as visible to each other's bodies; that matches the legacy
+	// extractor's behavior.
+	scope := &cteScope{names: make(map[string]bool), parent: w.scope}
+	if stmt.With != nil {
+		for _, cte := range stmt.With.CTEs {
+			if cte == nil || cte.Name == "" {
+				continue
+			}
+			scope.names[strings.ToLower(cte.Name)] = true
+			w.span.CTEs = append(w.span.CTEs, cte.Name)
+		}
+	}
+	w.scope = scope
+
+	// Walk CTE bodies first so their FROM tables land in AccessTables.
+	if stmt.With != nil {
+		for _, cte := range stmt.With.CTEs {
+			if cte == nil || cte.Query == nil {
+				continue
+			}
+			switch q := cte.Query.(type) {
+			case *ast.SelectStmt:
+				w.visitSelect(q, false)
+			case *ast.SetOpStmt:
+				w.visitSetOp(q, false)
+			}
+		}
+	}
+
+	// FROM clause.
+	for _, src := range stmt.From {
+		w.visitFromItem(src)
+	}
+
+	// Predicate clauses — we walk them to pick up ColumnRef/subquery tables.
+	if stmt.Where != nil {
+		w.walkExpr(stmt.Where)
+	}
+	for _, g := range stmt.GroupBy {
+		w.walkExpr(g)
+	}
+	if stmt.Having != nil {
+		w.walkExpr(stmt.Having)
+	}
+	if stmt.Qualify != nil {
+		w.walkExpr(stmt.Qualify)
+	}
+	for _, o := range stmt.OrderBy {
+		if o != nil && o.Expr != nil {
+			w.walkExpr(o.Expr)
+		}
+	}
+	if stmt.Limit != nil {
+		w.walkExpr(stmt.Limit)
+	}
+	if stmt.Offset != nil {
+		w.walkExpr(stmt.Offset)
+	}
+
+	// SELECT list — walked last so Results reflect the final column order.
+	for _, item := range stmt.Items {
+		if item == nil {
+			continue
+		}
+		if outermost && !w.resolved {
+			w.span.Results = append(w.span.Results, w.makeColumnInfo(item))
+		}
+		if item.Expr != nil {
+			w.walkExpr(item.Expr)
+		}
+	}
+	if outermost {
+		w.resolved = true
+	}
+
+	// Pop the scope.
+	w.scope = scope.parent
+}
+
+// visitFromItem walks one entry in the FROM list. It may be a TableRef (bare
+// table or subquery) or a JoinClause tree.
+func (w *spanWalker) visitFromItem(node ast.Node) {
+	switch n := node.(type) {
+	case *ast.TableRef:
+		w.visitTableRef(n)
+	case *ast.JoinClause:
+		w.visitFromItem(n.Left)
+		w.visitFromItem(n.Right)
+		if n.On != nil {
+			w.walkExpr(n.On)
+		}
+	}
+}
+
+// visitTableRef handles a single TableRef from the FROM clause. The parser
+// packs a FROM-subquery's raw text into Name.Parts[0]; we detect that case by
+// trying to re-parse the text and, if it's a SELECT/set-op, recurse into it
+// instead of treating it as a physical table.
+func (w *spanWalker) visitTableRef(ref *ast.TableRef) {
+	if ref == nil || ref.Name == nil || len(ref.Name.Parts) == 0 {
+		return
+	}
+
+	// Detect FROM-subquery: parser stores the subquery's raw body in Parts[0].
+	// A legitimate table name cannot contain whitespace, and every subquery
+	// body starts with SELECT or WITH.
+	if len(ref.Name.Parts) == 1 && looksLikeSubquery(ref.Name.Parts[0]) {
+		w.analyzeSubqueryText(ref.Name.Parts[0])
+		return
+	}
+
+	var database, table string
+	switch len(ref.Name.Parts) {
+	case 1:
+		table = ref.Name.Parts[0]
+		// Bare name: skip if it matches an in-scope CTE.
+		if w.scope.isCTE(table) {
+			return
+		}
+	case 2:
+		database = ref.Name.Parts[0]
+		table = ref.Name.Parts[1]
+	default:
+		// catalog.db.table or longer — keep the last two parts.
+		database = ref.Name.Parts[len(ref.Name.Parts)-2]
+		table = ref.Name.Parts[len(ref.Name.Parts)-1]
+	}
+
+	key := tableKey{Database: database, Table: table, Alias: ref.Alias}
+	if _, ok := w.accessed[key]; ok {
+		return
+	}
+	w.accessed[key] = len(w.span.AccessTables)
+	w.span.AccessTables = append(w.span.AccessTables, TableAccess{
+		Database: database,
+		Table:    table,
+		Alias:    ref.Alias,
+		Loc:      ref.Loc,
+	})
+}
+
+// looksLikeSubquery heuristically detects text the parser stuffed into
+// ObjectName.Parts when it encountered a FROM-subquery. Bare identifiers
+// (even quoted ones) don't contain these leading keywords.
+func looksLikeSubquery(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return false
+	}
+	upper := strings.ToUpper(trimmed)
+	return strings.HasPrefix(upper, "SELECT") ||
+		strings.HasPrefix(upper, "WITH") ||
+		strings.HasPrefix(upper, "(")
+}
+
+// analyzeSubqueryText re-parses subquery text (from SubqueryExpr.RawText or
+// a FROM-subquery's packed Parts[0]) and recurses into any resulting SELECT.
+// Errors are swallowed — if the subquery is unparseable, the consumer of
+// QuerySpan still gets whatever tables were already discovered.
+func (w *spanWalker) analyzeSubqueryText(text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	file, _ := parser.Parse(text)
+	if file == nil {
+		return
+	}
+	for _, stmt := range file.Stmts {
+		switch n := stmt.(type) {
+		case *ast.SelectStmt:
+			w.visitSelect(n, false)
+		case *ast.SetOpStmt:
+			w.visitSetOp(n, false)
+		}
+	}
+}
+
+// walkExpr descends into an expression tree collecting ColumnRefs and
+// recursing into any subquery nodes (SubqueryExpr, ExistsExpr, InExpr with
+// a subquery value).
+func (w *spanWalker) walkExpr(node ast.Node) {
+	if node == nil {
+		return
+	}
+	ast.Walk(&exprVisitor{w: w}, node)
+}
+
+type exprVisitor struct {
+	w *spanWalker
+}
+
+func (v *exprVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return v
+	}
+	switch n := node.(type) {
+	case *ast.SubqueryExpr:
+		v.w.analyzeSubqueryText(n.RawText)
+		return nil // raw-text body, no parsed children
+	case *ast.ExistsExpr:
+		if n.Subquery != nil {
+			v.w.analyzeSubqueryText(n.Subquery.RawText)
+		}
+		return nil
+	case *ast.ColumnRef:
+		// ColumnRef is recorded via the outer SELECT's SourceColumns; at this
+		// point we don't know which output column it feeds, so we let
+		// makeColumnInfo capture the direct references and stop here to avoid
+		// double-visiting the ObjectName child.
+		return nil
+	}
+	return v
+}
+
+// makeColumnInfo derives a ColumnInfo from a SELECT-list item. The Name is
+// the alias if present; otherwise a simple rendering of the expression
+// (column name for a bare ColumnRef, "*" for star). SourceColumns is the set
+// of ColumnRefs the item directly references.
+func (w *spanWalker) makeColumnInfo(item *ast.SelectItem) ColumnInfo {
+	info := ColumnInfo{}
+	if item.Star {
+		if item.TableName != nil {
+			info.Name = item.TableName.String() + ".*"
+		} else {
+			info.Name = "*"
+		}
+		return info
+	}
+	if item.Alias != "" {
+		info.Name = item.Alias
+	} else if item.Expr != nil {
+		info.Name = renderColumnName(item.Expr)
+	}
+	if item.Expr != nil {
+		info.SourceColumns = collectColumnRefs(item.Expr)
+	}
+	return info
+}
+
+// renderColumnName returns a short human-readable name for an expression.
+// Only simple cases get a useful rendering; otherwise the empty string is
+// returned and the caller can fall back to the raw source text if desired.
+func renderColumnName(expr ast.Node) string {
+	switch e := expr.(type) {
+	case *ast.ColumnRef:
+		if e.Name == nil || len(e.Name.Parts) == 0 {
+			return ""
+		}
+		return e.Name.Parts[len(e.Name.Parts)-1]
+	case *ast.ParenExpr:
+		return renderColumnName(e.Expr)
+	}
+	return ""
+}
+
+// collectColumnRefs returns every ColumnRef directly mentioned in expr.
+func collectColumnRefs(expr ast.Node) []ColumnRef {
+	var refs []ColumnRef
+	ast.Inspect(expr, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.ColumnRef:
+			if node.Name == nil || len(node.Name.Parts) == 0 {
+				return false
+			}
+			refs = append(refs, columnRefFromObjectName(node.Name))
+			return false
+		case *ast.SubqueryExpr, *ast.ExistsExpr:
+			// Don't follow subqueries when collecting the *direct* column
+			// references of the current SELECT item.
+			return false
+		}
+		return true
+	})
+	return refs
+}
+
+func columnRefFromObjectName(name *ast.ObjectName) ColumnRef {
+	parts := name.Parts
+	switch len(parts) {
+	case 1:
+		return ColumnRef{Column: parts[0]}
+	case 2:
+		return ColumnRef{Table: parts[0], Column: parts[1]}
+	case 3:
+		return ColumnRef{Database: parts[0], Table: parts[1], Column: parts[2]}
+	default:
+		// Longer than 3 parts — keep the rightmost three.
+		return ColumnRef{
+			Database: parts[len(parts)-3],
+			Table:    parts[len(parts)-2],
+			Column:   parts[len(parts)-1],
+		}
+	}
+}
+
+// finalize performs any post-processing after the walk. AccessTables are
+// already deduplicated during visitation; CTE names are left as-added so
+// ordering matches declaration order.
+func (w *spanWalker) finalize() {}

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -1,0 +1,341 @@
+package analysis
+
+import (
+	"testing"
+)
+
+// tableSig is a compact form of TableAccess used for order-insensitive
+// comparison in tests.
+type tableSig struct {
+	Database string
+	Table    string
+	Alias    string
+}
+
+func toSigs(tables []TableAccess) []tableSig {
+	out := make([]tableSig, len(tables))
+	for i, t := range tables {
+		out[i] = tableSig{Database: t.Database, Table: t.Table, Alias: t.Alias}
+	}
+	return out
+}
+
+func containsSig(haystack []tableSig, needle tableSig) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetQuerySpan_Basics(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		wantType    QueryType
+		wantTables  []tableSig
+		wantResults []string // output column names, in order
+		wantCTEs    []string
+	}{
+		{
+			name:        "simple select",
+			sql:         "SELECT a FROM t",
+			wantType:    QueryTypeSelect,
+			wantTables:  []tableSig{{Table: "t"}},
+			wantResults: []string{"a"},
+		},
+		{
+			name:       "qualified table",
+			sql:        "SELECT * FROM db.t",
+			wantType:   QueryTypeSelect,
+			wantTables: []tableSig{{Database: "db", Table: "t"}},
+			wantResults: []string{"*"},
+		},
+		{
+			name:       "three-part table name",
+			sql:        "SELECT * FROM catalog1.db1.t1",
+			wantType:   QueryTypeSelect,
+			wantTables: []tableSig{{Database: "db1", Table: "t1"}},
+			wantResults: []string{"*"},
+		},
+		{
+			name:        "alias",
+			sql:         "SELECT a FROM t AS x",
+			wantType:    QueryTypeSelect,
+			wantTables:  []tableSig{{Table: "t", Alias: "x"}},
+			wantResults: []string{"a"},
+		},
+		{
+			name:        "select item alias",
+			sql:         "SELECT a AS col_a, b FROM t",
+			wantType:    QueryTypeSelect,
+			wantTables:  []tableSig{{Table: "t"}},
+			wantResults: []string{"col_a", "b"},
+		},
+		{
+			name:     "join of two tables",
+			sql:      "SELECT a, b FROM t1 JOIN t2 ON t1.id = t2.id",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"a", "b"},
+		},
+		{
+			name:     "inner and left join",
+			sql:      "SELECT a FROM t1 INNER JOIN t2 ON t1.id = t2.id LEFT JOIN db.t3 ON t1.x = t3.x",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+				{Database: "db", Table: "t3"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "cte exclusion",
+			sql:      "WITH c AS (SELECT * FROM real_t) SELECT * FROM c",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "real_t"},
+			},
+			wantResults: []string{"*"},
+			wantCTEs:    []string{"c"},
+		},
+		{
+			name: "multiple ctes chained",
+			sql: `WITH a AS (SELECT id FROM t1),
+			      b AS (SELECT id FROM a JOIN t2 ON a.id = t2.id)
+			      SELECT id FROM b`,
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"id"},
+			wantCTEs:    []string{"a", "b"},
+		},
+		{
+			name:     "subquery in where IN",
+			sql:      "SELECT a FROM t WHERE b IN (SELECT b FROM other)",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "other"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "scalar subquery in select",
+			sql:      "SELECT a, (SELECT MAX(x) FROM agg) FROM t",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "agg"},
+			},
+		},
+		{
+			name:     "exists subquery",
+			sql:      "SELECT a FROM t WHERE EXISTS (SELECT 1 FROM other WHERE other.id = t.id)",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "other"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "from subquery",
+			sql:      "SELECT x.a FROM (SELECT a FROM inner_t) AS x",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "inner_t"},
+			},
+		},
+		{
+			name:     "union two tables",
+			sql:      "SELECT a FROM t1 UNION SELECT a FROM t2",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "union all three tables",
+			sql:      "SELECT a FROM t1 UNION ALL SELECT a FROM t2 UNION ALL SELECT a FROM db.t3",
+			wantType: QueryTypeSelect,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+				{Database: "db", Table: "t3"},
+			},
+			wantResults: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tt.sql)
+			if err != nil {
+				t.Fatalf("GetQuerySpan returned error: %v", err)
+			}
+			if span.Type != tt.wantType {
+				t.Errorf("Type = %v, want %v", span.Type, tt.wantType)
+			}
+
+			gotSigs := toSigs(span.AccessTables)
+			if len(gotSigs) != len(tt.wantTables) {
+				t.Errorf("AccessTables len = %d (%v), want %d (%v)",
+					len(gotSigs), gotSigs, len(tt.wantTables), tt.wantTables)
+			}
+			for _, want := range tt.wantTables {
+				if !containsSig(gotSigs, want) {
+					t.Errorf("AccessTables missing %+v (got %+v)", want, gotSigs)
+				}
+			}
+
+			if tt.wantResults != nil {
+				if len(span.Results) != len(tt.wantResults) {
+					t.Fatalf("Results len = %d, want %d (got %+v)",
+						len(span.Results), len(tt.wantResults), span.Results)
+				}
+				for i, want := range tt.wantResults {
+					if span.Results[i].Name != want {
+						t.Errorf("Results[%d].Name = %q, want %q", i, span.Results[i].Name, want)
+					}
+				}
+			}
+
+			if tt.wantCTEs != nil {
+				if len(span.CTEs) != len(tt.wantCTEs) {
+					t.Fatalf("CTEs = %v, want %v", span.CTEs, tt.wantCTEs)
+				}
+				for i, want := range tt.wantCTEs {
+					if span.CTEs[i] != want {
+						t.Errorf("CTEs[%d] = %q, want %q", i, span.CTEs[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetQuerySpan_NonSelect(t *testing.T) {
+	tests := []struct {
+		sql      string
+		wantType QueryType
+	}{
+		{"CREATE TABLE t (id INT)", QueryTypeDDL},
+		{"SHOW TABLES", QueryTypeSelectInfoSchema},
+		{"INSERT INTO t VALUES (1)", QueryTypeDML},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			span, err := GetQuerySpan(tt.sql)
+			if err != nil {
+				t.Fatalf("GetQuerySpan returned error: %v", err)
+			}
+			if span.Type != tt.wantType {
+				t.Errorf("Type = %v, want %v", span.Type, tt.wantType)
+			}
+			// Non-SELECT statements should not populate AccessTables via our
+			// SELECT walker. (They may still land here in future when DML
+			// parsing is wired through — for now we only assert Type.)
+		})
+	}
+}
+
+func TestGetQuerySpan_Empty(t *testing.T) {
+	span, err := GetQuerySpan("")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if span.Type != QueryTypeUnknown {
+		t.Errorf("Type = %v, want QueryTypeUnknown", span.Type)
+	}
+	if len(span.AccessTables) != 0 {
+		t.Errorf("AccessTables = %v, want empty", span.AccessTables)
+	}
+	if len(span.Results) != 0 {
+		t.Errorf("Results = %v, want empty", span.Results)
+	}
+}
+
+func TestGetQuerySpan_DedupTables(t *testing.T) {
+	// Same unaliased table referenced twice — should only appear once.
+	span, err := GetQuerySpan("SELECT a FROM t WHERE b IN (SELECT b FROM t)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 1 {
+		t.Errorf("AccessTables = %v, want one entry for t", span.AccessTables)
+	}
+}
+
+func TestGetQuerySpan_SameTableDifferentAliases(t *testing.T) {
+	// Self-join — two aliases of the same physical table should each appear.
+	span, err := GetQuerySpan("SELECT * FROM t AS a JOIN t AS b ON a.id = b.id")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 2 {
+		t.Errorf("AccessTables = %+v, want two (a, b)", span.AccessTables)
+	}
+	sigs := toSigs(span.AccessTables)
+	if !containsSig(sigs, tableSig{Table: "t", Alias: "a"}) {
+		t.Errorf("missing alias a: %+v", sigs)
+	}
+	if !containsSig(sigs, tableSig{Table: "t", Alias: "b"}) {
+		t.Errorf("missing alias b: %+v", sigs)
+	}
+}
+
+func TestGetQuerySpan_SelectItemSourceColumns(t *testing.T) {
+	// Parser quirk: a SELECT item that starts with a qualified identifier
+	// (t.a) takes a fast path and only produces a ColumnRef, so we use bare
+	// identifiers here to exercise the full expression parser.
+	span, err := GetQuerySpan("SELECT a + b AS total FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	r := span.Results[0]
+	if r.Name != "total" {
+		t.Errorf("Results[0].Name = %q, want total", r.Name)
+	}
+	if len(r.SourceColumns) != 2 {
+		t.Fatalf("SourceColumns len = %d, want 2 (%+v)", len(r.SourceColumns), r.SourceColumns)
+	}
+	want := []ColumnRef{
+		{Column: "a"},
+		{Column: "b"},
+	}
+	for i, w := range want {
+		if r.SourceColumns[i] != w {
+			t.Errorf("SourceColumns[%d] = %+v, want %+v", i, r.SourceColumns[i], w)
+		}
+	}
+}
+
+func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
+	// Even if a physical table exists elsewhere named "real_t", a CTE with
+	// the same name inside the WITH clause means the outer reference resolves
+	// to the CTE — AccessTables should only contain the CTE's body tables.
+	span, err := GetQuerySpan(`
+		WITH real_t AS (SELECT id FROM underlying)
+		SELECT id FROM real_t
+	`)
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "underlying" {
+		t.Errorf("AccessTables = %+v, want [underlying]", sigs)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GetQuerySpan()` in `doris/analysis` that walks parsed SELECT AST and extracts tables/columns
- Handles CTEs (scoped, shadow semantics), joins, subqueries (SubqueryExpr/ExistsExpr/InExpr), UNION/INTERSECT/EXCEPT, aliases
- QueryType classification integrated via existing `Classify()`
- 23 unit tests

DAG: T3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)