### PR TITLE
feat(snowflake): T1.8 statement-classification helper

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-stmt-classify.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-stmt-classify.md
@@ -1,0 +1,50 @@
+# T1.8 — Snowflake Statement-Classification Helper — Implementation Plan
+
+## Step 1 — Create snowflake/analysis/classify.go
+
+Implement:
+1. `Category` type and constants (Unknown, Select, DML, DDL, Show, Describe, Other).
+2. `(Category) String()` method.
+3. `Classify(node ast.Node) Category` — type switch over all current statement nodes.
+4. `ClassifySQL(sql string) Category` — parse first statement, delegate to Classify.
+
+Imports: `github.com/bytebase/omni/snowflake/ast`, `github.com/bytebase/omni/snowflake/parser`.
+
+## Step 2 — Create snowflake/analysis/classify_test.go
+
+Test cases:
+- `SELECT 1` → CategorySelect
+- `SELECT 1 UNION ALL SELECT 2` → CategorySelect
+- `WITH cte AS (SELECT 1) SELECT * FROM cte` → CategorySelect
+- `INSERT INTO t VALUES (1)` → CategoryDML
+- `UPDATE t SET c = 1 WHERE id = 1` → CategoryDML
+- `DELETE FROM t WHERE id = 1` → CategoryDML
+- `MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE` → CategoryDML
+- `CREATE TABLE t (id INT)` → CategoryDDL
+- `ALTER TABLE t ADD COLUMN c INT` → CategoryDDL
+- `DROP TABLE t` → CategoryDDL
+- `CREATE DATABASE d` → CategoryDDL
+- `CREATE VIEW v AS SELECT 1` → CategoryDDL
+- `nil` node → CategoryUnknown
+- empty string → CategoryUnknown
+- `Classify(nil)` → CategoryUnknown
+
+## Step 3 — Run tests
+
+```
+cd /Users/h3n4l/OpenSource/omni/.worktrees/snowflake-stmt-classify
+go test ./snowflake/... -count=1
+```
+
+## Step 4 — gofmt
+
+```
+gofmt -w /Users/h3n4l/OpenSource/omni/.worktrees/snowflake-stmt-classify/snowflake/analysis/
+```
+
+## Step 5 — Commit in 2 chunks
+
+Chunk 1 (T1.8 step 1): docs + classify.go (impl)
+Chunk 2 (T1.8 step 2): classify_test.go (tests)
+
+## Step 6 — Push + open PR

--- a/docs/superpowers/specs/2026-04-15-snowflake-stmt-classify-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-stmt-classify-design.md
@@ -1,0 +1,111 @@
+# T1.8 — Snowflake Statement-Classification Helper Design
+
+## Scope
+
+T1.8 adds a small utility package `snowflake/analysis` that classifies any parsed
+Snowflake AST node into one of six statement categories: SELECT, DML, DDL, SHOW,
+DESCRIBE, or Other. An additional convenience function classifies raw SQL strings
+directly.
+
+This is a P0 utility used by bytebase to route statements to the right handler
+(e.g. query-span extraction vs. schema migration vs. read-only check).
+
+## Package
+
+New package: `snowflake/analysis`
+
+Files:
+- `classify.go` — Category enum, Classify(node), ClassifySQL(sql)
+- `classify_test.go` — test coverage
+
+## Category enum
+
+```go
+type Category int
+
+const (
+    CategoryUnknown  Category = iota
+    CategorySelect            // SELECT, WITH+SELECT, UNION/INTERSECT/EXCEPT
+    CategoryDML               // INSERT, UPDATE, DELETE, MERGE
+    CategoryDDL               // CREATE/ALTER/DROP/UNDROP/TRUNCATE/COMMENT ON
+    CategoryShow              // SHOW (forward-compatible placeholder)
+    CategoryDescribe          // DESCRIBE/DESC (forward-compatible placeholder)
+    CategoryOther             // USE, SET, EXPLAIN, CALL, etc.
+)
+```
+
+## Classify(node ast.Node) Category
+
+Uses a type switch on the concrete `ast.Node` type.
+
+### CategorySelect
+- `*ast.SelectStmt`
+- `*ast.SetOperationStmt`
+
+### CategoryDML
+- `*ast.InsertStmt`
+- `*ast.InsertMultiStmt`
+- `*ast.UpdateStmt`
+- `*ast.DeleteStmt`
+- `*ast.MergeStmt`
+
+### CategoryDDL
+- `*ast.CreateTableStmt`
+- `*ast.AlterTableStmt`
+- `*ast.CreateDatabaseStmt`
+- `*ast.AlterDatabaseStmt`
+- `*ast.DropDatabaseStmt`
+- `*ast.UndropDatabaseStmt`
+- `*ast.CreateSchemaStmt`
+- `*ast.AlterSchemaStmt`
+- `*ast.DropSchemaStmt`
+- `*ast.UndropSchemaStmt`
+- `*ast.CreateViewStmt`
+- `*ast.CreateMaterializedViewStmt`
+- `*ast.AlterViewStmt`
+- `*ast.AlterMaterializedViewStmt`
+- `*ast.DropStmt`
+- `*ast.UndropStmt`
+
+### CategoryShow / CategoryDescribe
+Not yet implemented in the parser; placeholders ensure forward-compatible routing
+when those nodes are added later. The type switch default handles them as
+CategoryUnknown until dedicated node types exist.
+
+### Default (CategoryUnknown)
+- `nil` input
+- unrecognized node types (e.g. expression nodes passed by mistake)
+- future node types not yet classified
+
+## ClassifySQL(sql string) Category
+
+Parses the first statement from `sql` using `parser.ParseBestEffort`, then calls
+`Classify` on the first node. Returns `CategoryUnknown` if:
+- the SQL is empty
+- parsing yields no nodes (e.g. only whitespace or comments)
+- the first node is nil
+
+## String() method
+
+```
+CategoryUnknown  → "Unknown"
+CategorySelect   → "SELECT"
+CategoryDML      → "DML"
+CategoryDDL      → "DDL"
+CategoryShow     → "SHOW"
+CategoryDescribe → "DESCRIBE"
+CategoryOther    → "Other"
+```
+
+## Design notes
+
+- No new AST nodes are added; this is purely a read-only classification.
+- The package imports only `snowflake/ast` and `snowflake/parser` — no circular deps.
+- ClassifySQL intentionally ignores parse errors to be lenient; callers that need
+  strict validation should use the diagnostics package.
+- CategoryOther is intentionally NOT the same as CategoryUnknown: Unknown means
+  "we don't know how to classify this node", while Other means "we recognize this
+  as a statement but it is not SELECT/DML/DDL/SHOW/DESCRIBE" (e.g. USE, SET, CALL).
+  Since the parser does not yet emit nodes for those statements, both currently
+  fall through to CategoryUnknown in practice; the distinction becomes meaningful
+  once those nodes are added.

--- a/snowflake/analysis/classify.go
+++ b/snowflake/analysis/classify.go
@@ -1,0 +1,148 @@
+// Package analysis provides utilities for classifying and analyzing parsed
+// Snowflake SQL AST nodes.
+//
+// The primary entry points are Classify, which maps any ast.Node to a
+// Category, and ClassifySQL, which parses a raw SQL string and classifies
+// its first statement.
+//
+// See docs/superpowers/specs/2026-04-15-snowflake-stmt-classify-design.md
+// for the design rationale.
+package analysis
+
+import (
+	"github.com/bytebase/omni/snowflake/ast"
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// Category is the broad statement category assigned by Classify.
+type Category int
+
+const (
+	// CategoryUnknown is returned for nil nodes or node types that are not
+	// recognized as a known statement kind. It is also returned when parsing
+	// fails completely.
+	CategoryUnknown Category = iota
+
+	// CategorySelect covers SELECT statements, WITH+SELECT (CTEs), and set
+	// operations (UNION / INTERSECT / EXCEPT).
+	CategorySelect
+
+	// CategoryDML covers data-manipulation statements: INSERT (single-table and
+	// multi-table), UPDATE, DELETE, and MERGE.
+	CategoryDML
+
+	// CategoryDDL covers data-definition statements: CREATE / ALTER / DROP /
+	// UNDROP for tables, views, materialized views, databases, and schemas.
+	CategoryDDL
+
+	// CategoryShow covers SHOW <objects> statements. This is a forward-compatible
+	// placeholder; the parser does not yet emit a dedicated SHOW node.
+	CategoryShow
+
+	// CategoryDescribe covers DESCRIBE / DESC statements. This is a
+	// forward-compatible placeholder; the parser does not yet emit a dedicated
+	// DESCRIBE node.
+	CategoryDescribe
+
+	// CategoryOther covers recognized SQL statements that are none of the above:
+	// USE, SET, CALL, EXPLAIN, GRANT, REVOKE, etc. This is a forward-compatible
+	// placeholder; the parser does not yet emit dedicated nodes for these.
+	CategoryOther
+)
+
+// String returns a human-readable label for the category.
+func (c Category) String() string {
+	switch c {
+	case CategorySelect:
+		return "SELECT"
+	case CategoryDML:
+		return "DML"
+	case CategoryDDL:
+		return "DDL"
+	case CategoryShow:
+		return "SHOW"
+	case CategoryDescribe:
+		return "DESCRIBE"
+	case CategoryOther:
+		return "Other"
+	default:
+		return "Unknown"
+	}
+}
+
+// Classify returns the Category for a single statement node.
+//
+// It uses a type switch over the concrete ast.Node types defined in
+// snowflake/ast/parsenodes.go. The mapping is:
+//
+//   - *ast.SelectStmt, *ast.SetOperationStmt          → CategorySelect
+//   - *ast.InsertStmt, *ast.InsertMultiStmt,
+//     *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt → CategoryDML
+//   - *ast.CreateTableStmt, *ast.AlterTableStmt,
+//     *ast.CreateDatabaseStmt, *ast.AlterDatabaseStmt,
+//     *ast.DropDatabaseStmt, *ast.UndropDatabaseStmt,
+//     *ast.CreateSchemaStmt, *ast.AlterSchemaStmt,
+//     *ast.DropSchemaStmt, *ast.UndropSchemaStmt,
+//     *ast.CreateViewStmt, *ast.CreateMaterializedViewStmt,
+//     *ast.AlterViewStmt, *ast.AlterMaterializedViewStmt,
+//     *ast.DropStmt, *ast.UndropStmt                  → CategoryDDL
+//   - nil or unrecognized node                         → CategoryUnknown
+func Classify(node ast.Node) Category {
+	if node == nil {
+		return CategoryUnknown
+	}
+	switch node.(type) {
+	// SELECT / set operations
+	case *ast.SelectStmt, *ast.SetOperationStmt:
+		return CategorySelect
+
+	// DML
+	case *ast.InsertStmt, *ast.InsertMultiStmt,
+		*ast.UpdateStmt, *ast.DeleteStmt,
+		*ast.MergeStmt:
+		return CategoryDML
+
+	// DDL — tables
+	case *ast.CreateTableStmt, *ast.AlterTableStmt:
+		return CategoryDDL
+
+	// DDL — databases
+	case *ast.CreateDatabaseStmt, *ast.AlterDatabaseStmt,
+		*ast.DropDatabaseStmt, *ast.UndropDatabaseStmt:
+		return CategoryDDL
+
+	// DDL — schemas
+	case *ast.CreateSchemaStmt, *ast.AlterSchemaStmt,
+		*ast.DropSchemaStmt, *ast.UndropSchemaStmt:
+		return CategoryDDL
+
+	// DDL — views
+	case *ast.CreateViewStmt, *ast.CreateMaterializedViewStmt,
+		*ast.AlterViewStmt, *ast.AlterMaterializedViewStmt:
+		return CategoryDDL
+
+	// DDL — generic DROP / UNDROP (TABLE, TAG, DYNAMIC TABLE, etc.)
+	case *ast.DropStmt, *ast.UndropStmt:
+		return CategoryDDL
+
+	default:
+		return CategoryUnknown
+	}
+}
+
+// ClassifySQL parses the first statement in sql and returns its Category.
+//
+// Parse errors are silently ignored; only the first successfully-parsed
+// statement node is classified. Returns CategoryUnknown if the input is
+// empty, consists only of whitespace or comments, or if parsing yields no
+// nodes.
+//
+// Callers that need strict parse-error reporting should use the
+// snowflake/diagnostics package instead.
+func ClassifySQL(sql string) Category {
+	result := parser.ParseBestEffort(sql)
+	if result.File == nil || len(result.File.Stmts) == 0 {
+		return CategoryUnknown
+	}
+	return Classify(result.File.Stmts[0])
+}

--- a/snowflake/analysis/classify_test.go
+++ b/snowflake/analysis/classify_test.go
@@ -1,0 +1,234 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/analysis"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Classify — nil / zero cases
+// ---------------------------------------------------------------------------
+
+func TestClassify_Nil(t *testing.T) {
+	if got := analysis.Classify(nil); got != analysis.CategoryUnknown {
+		t.Errorf("Classify(nil) = %v, want CategoryUnknown", got)
+	}
+}
+
+func TestClassify_NonStmtNode(t *testing.T) {
+	// ObjectName is a valid Node but not a statement — should return Unknown.
+	node := &ast.ObjectName{}
+	if got := analysis.Classify(node); got != analysis.CategoryUnknown {
+		t.Errorf("Classify(*ObjectName) = %v, want CategoryUnknown", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ClassifySQL — empty / no-parse cases
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_Empty(t *testing.T) {
+	if got := analysis.ClassifySQL(""); got != analysis.CategoryUnknown {
+		t.Errorf("ClassifySQL(\"\") = %v, want CategoryUnknown", got)
+	}
+}
+
+func TestClassifySQL_Whitespace(t *testing.T) {
+	if got := analysis.ClassifySQL("   \t\n  "); got != analysis.CategoryUnknown {
+		t.Errorf("ClassifySQL(whitespace) = %v, want CategoryUnknown", got)
+	}
+}
+
+func TestClassifySQL_CommentOnly(t *testing.T) {
+	if got := analysis.ClassifySQL("-- just a comment"); got != analysis.CategoryUnknown {
+		t.Errorf("ClassifySQL(comment) = %v, want CategoryUnknown", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CategorySelect
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_Select_Simple(t *testing.T) {
+	assertCategory(t, "SELECT 1", analysis.CategorySelect)
+}
+
+func TestClassifySQL_Select_FromTable(t *testing.T) {
+	assertCategory(t, "SELECT id, name FROM users WHERE id = 42", analysis.CategorySelect)
+}
+
+func TestClassifySQL_Select_UnionAll(t *testing.T) {
+	assertCategory(t, "SELECT 1 UNION ALL SELECT 2", analysis.CategorySelect)
+}
+
+func TestClassifySQL_Select_Intersect(t *testing.T) {
+	assertCategory(t, "SELECT id FROM a INTERSECT SELECT id FROM b", analysis.CategorySelect)
+}
+
+func TestClassifySQL_Select_Except(t *testing.T) {
+	assertCategory(t, "SELECT id FROM a EXCEPT SELECT id FROM b", analysis.CategorySelect)
+}
+
+func TestClassifySQL_Select_WithCTE(t *testing.T) {
+	assertCategory(t,
+		`WITH cte AS (SELECT 1 AS n) SELECT n FROM cte`,
+		analysis.CategorySelect)
+}
+
+func TestClassifySQL_Select_Subquery(t *testing.T) {
+	assertCategory(t,
+		`SELECT * FROM (SELECT 1 AS x) AS sub`,
+		analysis.CategorySelect)
+}
+
+// ---------------------------------------------------------------------------
+// CategoryDML
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_Insert_Values(t *testing.T) {
+	assertCategory(t, "INSERT INTO t VALUES (1)", analysis.CategoryDML)
+}
+
+func TestClassifySQL_Insert_Select(t *testing.T) {
+	assertCategory(t, "INSERT INTO t SELECT * FROM src", analysis.CategoryDML)
+}
+
+func TestClassifySQL_Insert_Multi(t *testing.T) {
+	assertCategory(t,
+		`INSERT ALL INTO t1 VALUES (1) INTO t2 VALUES (2) SELECT 1`,
+		analysis.CategoryDML)
+}
+
+func TestClassifySQL_Update(t *testing.T) {
+	assertCategory(t, "UPDATE t SET c = 1 WHERE id = 1", analysis.CategoryDML)
+}
+
+func TestClassifySQL_Delete(t *testing.T) {
+	assertCategory(t, "DELETE FROM t WHERE id = 1", analysis.CategoryDML)
+}
+
+func TestClassifySQL_Merge(t *testing.T) {
+	assertCategory(t,
+		`MERGE INTO tgt USING src ON tgt.id = src.id
+		 WHEN MATCHED THEN UPDATE SET tgt.v = src.v
+		 WHEN NOT MATCHED THEN INSERT (id, v) VALUES (src.id, src.v)`,
+		analysis.CategoryDML)
+}
+
+// ---------------------------------------------------------------------------
+// CategoryDDL — tables
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_CreateTable(t *testing.T) {
+	assertCategory(t, "CREATE TABLE t (id INT)", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_CreateTableOrReplace(t *testing.T) {
+	assertCategory(t, "CREATE OR REPLACE TABLE t (id INT, name VARCHAR)", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_AlterTable_AddColumn(t *testing.T) {
+	assertCategory(t, "ALTER TABLE t ADD COLUMN c INT", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_DropTable(t *testing.T) {
+	assertCategory(t, "DROP TABLE IF EXISTS t", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_UndropTable(t *testing.T) {
+	assertCategory(t, "UNDROP TABLE t", analysis.CategoryDDL)
+}
+
+// ---------------------------------------------------------------------------
+// CategoryDDL — databases
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_CreateDatabase(t *testing.T) {
+	assertCategory(t, "CREATE DATABASE mydb", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_AlterDatabase(t *testing.T) {
+	assertCategory(t, "ALTER DATABASE mydb RENAME TO newdb", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_DropDatabase(t *testing.T) {
+	assertCategory(t, "DROP DATABASE mydb", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_UndropDatabase(t *testing.T) {
+	assertCategory(t, "UNDROP DATABASE mydb", analysis.CategoryDDL)
+}
+
+// ---------------------------------------------------------------------------
+// CategoryDDL — schemas
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_CreateSchema(t *testing.T) {
+	assertCategory(t, "CREATE SCHEMA myschema", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_DropSchema(t *testing.T) {
+	assertCategory(t, "DROP SCHEMA myschema", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_UndropSchema(t *testing.T) {
+	assertCategory(t, "UNDROP SCHEMA myschema", analysis.CategoryDDL)
+}
+
+// ---------------------------------------------------------------------------
+// CategoryDDL — views
+// ---------------------------------------------------------------------------
+
+func TestClassifySQL_CreateView(t *testing.T) {
+	assertCategory(t, "CREATE VIEW v AS SELECT 1", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_CreateMaterializedView(t *testing.T) {
+	assertCategory(t, "CREATE MATERIALIZED VIEW mv AS SELECT id FROM t", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_AlterView(t *testing.T) {
+	assertCategory(t, "ALTER VIEW v RENAME TO v2", analysis.CategoryDDL)
+}
+
+func TestClassifySQL_DropView(t *testing.T) {
+	assertCategory(t, "DROP VIEW v", analysis.CategoryDDL)
+}
+
+// ---------------------------------------------------------------------------
+// Category.String()
+// ---------------------------------------------------------------------------
+
+func TestCategory_String(t *testing.T) {
+	cases := []struct {
+		cat  analysis.Category
+		want string
+	}{
+		{analysis.CategoryUnknown, "Unknown"},
+		{analysis.CategorySelect, "SELECT"},
+		{analysis.CategoryDML, "DML"},
+		{analysis.CategoryDDL, "DDL"},
+		{analysis.CategoryShow, "SHOW"},
+		{analysis.CategoryDescribe, "DESCRIBE"},
+		{analysis.CategoryOther, "Other"},
+	}
+	for _, tc := range cases {
+		if got := tc.cat.String(); got != tc.want {
+			t.Errorf("Category(%d).String() = %q, want %q", tc.cat, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func assertCategory(t *testing.T, sql string, want analysis.Category) {
+	t.Helper()
+	got := analysis.ClassifySQL(sql)
+	if got != want {
+		t.Errorf("ClassifySQL(%q) = %v, want %v", sql, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add new package `snowflake/analysis` with `Classify(ast.Node) Category` and `ClassifySQL(sql string) Category` helper functions
- `Category` enum covers 7 values: Unknown, SELECT, DML, DDL, SHOW, DESCRIBE, Other
- Type-switches over all 23 current statement node types (SelectStmt, SetOperationStmt, InsertStmt, InsertMultiStmt, UpdateStmt, DeleteStmt, MergeStmt, CreateTableStmt, AlterTableStmt, plus all database/schema/view DDL nodes)
- SHOW, DESCRIBE, and Other are forward-compatible placeholders for nodes not yet emitted by the parser
- 34 tests covering every category, nil node, empty SQL, whitespace, comment-only input, and `Category.String()`

## Test plan

- [x] `go test ./snowflake/... -count=1` — all packages pass (analysis, ast, parser, advisor, diagnostics)
- [x] `gofmt -w` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)