### PR TITLE
feat(snowflake): T2.7 14 bytebase lint rules

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-lint-rules.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-lint-rules.md
@@ -1,0 +1,20 @@
+# Plan: Snowflake Lint Rules (T2.7)
+
+## Steps
+
+1. Read advisor framework (done)
+2. Read AST node types (done)
+3. Read parser.IsReservedKeyword (done)
+4. Write spec (done — specs/2026-04-15-snowflake-lint-rules-design.md)
+5. Implement 14 rules in `snowflake/advisor/rules/`:
+   - Step 5a: Column rules (column_no_null, column_require, column_maximum_varchar_length)
+   - Step 5b: Table rules (table_require_pk, table_no_foreign_key)
+   - Step 5c: Naming rules (naming_table, naming_table_no_keyword, naming_identifier_case, naming_identifier_no_keyword)
+   - Step 5d: Query rules (select_no_select_all, where_require_select, where_require_update_delete)
+   - Step 5e: Migration rules (migration_compatibility, table_drop_naming_convention)
+6. Write tests for each rule (co-located *_test.go files)
+7. Write integration test (rules_integration_test.go)
+8. Run `go test ./snowflake/...`
+9. gofmt -w
+10. Commit in logical chunks
+11. Push and open PR

--- a/docs/superpowers/specs/2026-04-15-snowflake-lint-rules-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-lint-rules-design.md
@@ -1,0 +1,73 @@
+# Spec: Snowflake Lint Rules (T2.7)
+
+## Context
+
+T2.7 adds 14 production-quality lint rules to the Snowflake advisor framework (T2.6). All AST dependencies are available: CREATE TABLE (T2.2), ALTER TABLE (T2.3), DROP/UNDROP (T2.5), advisor framework (T2.6), and SELECT core (T1.4).
+
+## Rules
+
+### Column rules (3)
+
+**column_no_null** — Every column in a CREATE TABLE must have a NOT NULL constraint (either `col TYPE NOT NULL` or no explicit `NULL`). Virtual columns (WITH AS expr) are exempt because they cannot have NOT NULL. Fires on ColumnDef where `NotNull == false && Nullable == false` is NOT sufficient — we want explicit NOT NULL. Design decision: fire when `NotNull == false` (i.e., NOT NULL absent) AND `VirtualExpr == nil`.
+
+**column_require** — A configured list of column names must appear in every CREATE TABLE. Config = slice of required column names (case-insensitive match via Snowflake normalize). Default = empty (no-op).
+
+**column_maximum_varchar_length** — VARCHAR/STRING/TEXT/CHAR columns in CREATE TABLE whose declared length > configured max. TypeKind TypeVarchar and TypeChar with `Params[0] > max`. For types with no Params (unbounded), skip. Default max = 1024.
+
+### Table rules (2)
+
+**table_require_pk** — Every CREATE TABLE (non-TEMPORARY, non-TRANSIENT, non-VOLATILE, and not AS SELECT / LIKE / CLONE) must define a PRIMARY KEY. Check: any ColumnDef with inline `ConstrPrimaryKey` OR any TableConstraint with `ConstrPrimaryKey`. Except for derived tables (AsSelect/Like/Clone non-nil) and temp tables.
+
+**table_no_foreign_key** — No FOREIGN KEY constraints. Checks: ColumnDef.InlineConstraint.Type == ConstrForeignKey OR TableConstraint.Type == ConstrForeignKey.
+
+### Naming rules (4)
+
+**naming_table** — Table name (last part of ObjectName) in CREATE TABLE must match configured regex. Default: `^[a-z][a-z0-9_]{0,63}$`. Match against unquoted name as-is (preserving source case, since lint runs before resolution).
+
+**naming_table_no_keyword** — Table name (last part of ObjectName) in CREATE TABLE must not be a reserved keyword. Uses `parser.IsReservedKeyword`. Quoted names are exempt (they can always be used as identifiers).
+
+**naming_identifier_case** — All identifiers (column names, table names, aliases) must match a configured case convention. Default: LOWER. Conventions: LOWER (all lowercase), UPPER (all uppercase), CAMEL (camelCase). Applied to unquoted identifiers only. Visits: ColumnDef.Name, CreateTableStmt.Name.Name, TableRef.Alias, SelectTarget.Alias, UpdateStmt.Target.Name, DeleteStmt.Target.Name.
+
+**naming_identifier_no_keyword** — No unquoted identifier may be a reserved keyword. Applies to column names, table aliases, CTE names. Visits ColumnDef.Name (in CreateTableStmt), TableRef.Alias, SelectTarget.Alias, CTE.Name.
+
+### Query rules (3)
+
+**select_no_select_all** — SELECT * (bare star) not allowed. Identical trigger to the example NoSelectStarRule but with rule ID `snowflake.select.no-select-all` and Severity ERROR. Note: the example rule has a different ID and Severity, so these are distinct.
+
+**where_require_select** — SELECT without a WHERE clause. Only fires for SelectStmt with `From != nil` (i.e., not `SELECT 1`). CTE body SELECTs also fire.
+
+**where_require_update_delete** — UPDATE or DELETE without a WHERE clause.
+
+### Migration rules (2)
+
+**migration_compatibility** — Forbids destructive DDL: DROP TABLE, DROP COLUMN (in ALTER TABLE), ALTER TABLE DROP constraint. Also fires on DropStmt with Kind==DropTable; AlterTableAction with Kind==AlterTableDropColumn.
+
+**table_drop_naming_convention** — When DROP TABLE is used, the table name must match a configured regex (allows "archive" naming patterns). Default: `^_deleted$|^deleted_` i.e. name starts with `deleted_` OR equals `_deleted`. Match against the unquoted last-part name.
+
+## AST Field Mapping
+
+| Rule | Trigger Node | Key Fields |
+|------|-------------|------------|
+| column_no_null | *CreateTableStmt | .Columns[i].NotNull, .VirtualExpr |
+| column_require | *CreateTableStmt | .Columns[i].Name |
+| column_maximum_varchar_length | *CreateTableStmt | .Columns[i].DataType.Kind, .Params[0] |
+| table_require_pk | *CreateTableStmt | .Columns[i].InlineConstraint, .Constraints[i].Type |
+| table_no_foreign_key | *CreateTableStmt | .Columns[i].InlineConstraint.Type, .Constraints[i].Type |
+| naming_table | *CreateTableStmt | .Name.Name |
+| naming_table_no_keyword | *CreateTableStmt | .Name.Name.Quoted, IsReservedKeyword |
+| naming_identifier_case | *CreateTableStmt, *SelectStmt | .Columns[i].Name, .Name.Name, .Targets[i].Alias |
+| naming_identifier_no_keyword | *CreateTableStmt, *SelectStmt | .Columns[i].Name, .Targets[i].Alias, .With[i].Name |
+| select_no_select_all | *SelectStmt | .Targets[i].Star, StarExpr.Qualifier |
+| where_require_select | *SelectStmt | .Where, .From |
+| where_require_update_delete | *UpdateStmt, *DeleteStmt | .Where |
+| migration_compatibility | *DropStmt, *AlterTableStmt | .Kind, .Actions[i].Kind |
+| table_drop_naming_convention | *DropStmt | .Kind==DropTable, .Name.Name |
+
+## Design Decisions
+
+1. **naming_identifier_case**: Applied to unquoted identifiers only. Quoted identifiers are intentionally case-sensitive and must not be folded.
+2. **table_require_pk**: Temporary/transient/volatile tables are exempt (they're often used as scratch space).
+3. **column_no_null**: Virtual columns (computed AS expr) are always exempt — Snowflake does not allow NOT NULL on virtual columns.
+4. **select_no_select_all vs example NoSelectStarRule**: The production rule has ID `snowflake.select.no-select-all` (matching the bytebase naming convention) and Severity ERROR (stricter).
+5. **where_require_select**: `SELECT 1` (no FROM clause) is exempt — table-less selects are always safe.
+6. **migration_compatibility**: Only fires for structural drops: DROP TABLE, DROP COLUMN. Does NOT fire for DROP VIEW, DROP INDEX, etc.

--- a/snowflake/advisor/rules/column_maximum_varchar_length.go
+++ b/snowflake/advisor/rules/column_maximum_varchar_length.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+const (
+	// DefaultMaxVarcharLength is the default maximum allowed length for VARCHAR/CHAR columns.
+	DefaultMaxVarcharLength = 1024
+)
+
+// ColumnMaximumVarcharLengthConfig holds the maximum allowed VARCHAR/CHAR length.
+type ColumnMaximumVarcharLengthConfig struct {
+	// MaxLength is the maximum allowed length. Zero means use DefaultMaxVarcharLength.
+	MaxLength int
+}
+
+// columnMaximumVarcharLengthRule fires when a VARCHAR or CHAR column declares a
+// length greater than the configured maximum.
+//
+// Rule ID:  "snowflake.column.maximum-varchar-length"
+// Severity: ERROR
+//
+// Columns with no explicit length parameter (unbounded VARCHAR) are not flagged
+// because they have an implicit length determined by Snowflake (16MB for VARCHAR).
+// Callers who want to forbid unbounded types should combine this rule with a
+// separate type restriction rule.
+type columnMaximumVarcharLengthRule struct {
+	maxLength int
+}
+
+const columnMaximumVarcharLengthID = "snowflake.column.maximum-varchar-length"
+
+// NewColumnMaximumVarcharLengthRule constructs the rule.
+func NewColumnMaximumVarcharLengthRule(cfg ColumnMaximumVarcharLengthConfig) advisor.Rule {
+	max := cfg.MaxLength
+	if max <= 0 {
+		max = DefaultMaxVarcharLength
+	}
+	return &columnMaximumVarcharLengthRule{maxLength: max}
+}
+
+// ID implements Rule.
+func (*columnMaximumVarcharLengthRule) ID() string { return columnMaximumVarcharLengthID }
+
+// Severity implements Rule.
+func (*columnMaximumVarcharLengthRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (r *columnMaximumVarcharLengthRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	var findings []*advisor.Finding
+	for _, col := range stmt.Columns {
+		dt := col.DataType
+		if dt == nil {
+			continue
+		}
+		if dt.Kind != ast.TypeVarchar && dt.Kind != ast.TypeChar {
+			continue
+		}
+		if len(dt.Params) == 0 {
+			// No explicit length — skip.
+			continue
+		}
+		length := dt.Params[0]
+		if length > r.maxLength {
+			findings = append(findings, &advisor.Finding{
+				RuleID:   columnMaximumVarcharLengthID,
+				Severity: advisor.SeverityError,
+				Loc:      col.Loc,
+				Message: fmt.Sprintf(
+					"column %q declares %s(%d) which exceeds the maximum allowed length %d",
+					col.Name.Name, dt.Name, length, r.maxLength,
+				),
+			})
+		}
+	}
+	return findings
+}

--- a/snowflake/advisor/rules/column_maximum_varchar_length_test.go
+++ b/snowflake/advisor/rules/column_maximum_varchar_length_test.go
@@ -1,0 +1,95 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestColumnMaximumVarcharLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		maxLen    int // 0 means use default
+		wantCount int
+	}{
+		{
+			name:      "varchar within limit — no findings",
+			sql:       "CREATE TABLE t (name VARCHAR(100) NOT NULL)",
+			maxLen:    200,
+			wantCount: 0,
+		},
+		{
+			name:      "varchar exceeds limit — one finding",
+			sql:       "CREATE TABLE t (name VARCHAR(500) NOT NULL)",
+			maxLen:    200,
+			wantCount: 1,
+		},
+		{
+			name:      "char exceeds limit — one finding",
+			sql:       "CREATE TABLE t (code CHAR(10) NOT NULL)",
+			maxLen:    5,
+			wantCount: 1,
+		},
+		{
+			name:      "varchar no length param — no findings",
+			sql:       "CREATE TABLE t (name VARCHAR NOT NULL)",
+			maxLen:    100,
+			wantCount: 0,
+		},
+		{
+			name:      "int column — no findings",
+			sql:       "CREATE TABLE t (id INT NOT NULL)",
+			maxLen:    100,
+			wantCount: 0,
+		},
+		{
+			name:      "default max (1024) — exactly at limit — no findings",
+			sql:       "CREATE TABLE t (name VARCHAR(1024) NOT NULL)",
+			maxLen:    0,
+			wantCount: 0,
+		},
+		{
+			name:      "default max (1024) — over limit — one finding",
+			sql:       "CREATE TABLE t (name VARCHAR(1025) NOT NULL)",
+			maxLen:    0,
+			wantCount: 1,
+		},
+		{
+			name:      "multiple columns mixed — one finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL, name VARCHAR(50) NOT NULL, bio VARCHAR(5000) NOT NULL)",
+			maxLen:    200,
+			wantCount: 1,
+		},
+		{
+			name:      "SELECT statement — no findings",
+			sql:       "SELECT a FROM t",
+			maxLen:    100,
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := rules.ColumnMaximumVarcharLengthConfig{MaxLength: tt.maxLen}
+			rule := rules.NewColumnMaximumVarcharLengthRule(cfg)
+			findings := runRule(t, tt.sql, rule)
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestColumnMaximumVarcharLength_Metadata(t *testing.T) {
+	r := rules.NewColumnMaximumVarcharLengthRule(rules.ColumnMaximumVarcharLengthConfig{MaxLength: 100})
+	if r.ID() != "snowflake.column.maximum-varchar-length" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/column_no_null.go
+++ b/snowflake/advisor/rules/column_no_null.go
@@ -1,0 +1,52 @@
+// Package rules provides the production lint rules for the Snowflake advisor.
+// Each file in this package implements one Rule from the T2.7 specification.
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ColumnNoNullRule requires every non-virtual column in CREATE TABLE to have
+// an explicit NOT NULL constraint.
+//
+// Rule ID:  "snowflake.column.no-null"
+// Severity: ERROR
+//
+// Virtual columns (ColumnDef.VirtualExpr != nil) are exempt because Snowflake
+// does not permit NOT NULL on computed columns.
+type ColumnNoNullRule struct{}
+
+const columnNoNullID = "snowflake.column.no-null"
+
+// ID implements Rule.
+func (ColumnNoNullRule) ID() string { return columnNoNullID }
+
+// Severity implements Rule.
+func (ColumnNoNullRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (ColumnNoNullRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	var findings []*advisor.Finding
+	for _, col := range stmt.Columns {
+		// Virtual columns cannot have NOT NULL — skip them.
+		if col.VirtualExpr != nil {
+			continue
+		}
+		if !col.NotNull {
+			findings = append(findings, &advisor.Finding{
+				RuleID:   columnNoNullID,
+				Severity: advisor.SeverityError,
+				Loc:      col.Loc,
+				Message:  fmt.Sprintf("column %q must have a NOT NULL constraint", col.Name.Name),
+			})
+		}
+	}
+	return findings
+}

--- a/snowflake/advisor/rules/column_no_null_test.go
+++ b/snowflake/advisor/rules/column_no_null_test.go
@@ -1,0 +1,83 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestColumnNoNull(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "all NOT NULL — no findings",
+			sql:       "CREATE TABLE t (id INT NOT NULL, name VARCHAR(100) NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "one nullable column — one finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL, name VARCHAR(100))",
+			wantCount: 1,
+		},
+		{
+			name:      "two nullable columns — two findings",
+			sql:       "CREATE TABLE t (id INT, name VARCHAR(100))",
+			wantCount: 2,
+		},
+		{
+			name:      "explicit NULL — one finding",
+			sql:       "CREATE TABLE t (id INT NULL)",
+			wantCount: 1,
+		},
+		{
+			name:      "virtual column exempt",
+			sql:       "CREATE TABLE t (id INT NOT NULL, full_name VARCHAR(200) AS (id::VARCHAR))",
+			wantCount: 0,
+		},
+		{
+			name:      "mix of virtual and nullable — only real cols fire",
+			sql:       "CREATE TABLE t (id INT, full_name VARCHAR(200) AS (id::VARCHAR))",
+			wantCount: 1,
+		},
+		{
+			name:      "SELECT statement — no findings",
+			sql:       "SELECT a, b FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.ColumnNoNullRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestColumnNoNull_Metadata(t *testing.T) {
+	r := rules.ColumnNoNullRule{}
+	if r.ID() != "snowflake.column.no-null" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}
+
+func TestColumnNoNull_FindingHasCorrectRuleID(t *testing.T) {
+	findings := runRule(t, "CREATE TABLE t (id INT)", rules.ColumnNoNullRule{})
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if findings[0].RuleID != "snowflake.column.no-null" {
+		t.Errorf("RuleID = %q", findings[0].RuleID)
+	}
+}

--- a/snowflake/advisor/rules/column_require.go
+++ b/snowflake/advisor/rules/column_require.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ColumnRequireConfig holds the list of column names that every CREATE TABLE
+// must define.
+type ColumnRequireConfig struct {
+	// Required is a list of column names (case-insensitive). An empty list
+	// means the rule is a no-op.
+	Required []string
+}
+
+// columnRequireRule fires when a CREATE TABLE is missing one or more required
+// columns.
+//
+// Rule ID:  "snowflake.column.require"
+// Severity: ERROR
+type columnRequireRule struct {
+	required []string // normalized (uppercased) required column names
+}
+
+const columnRequireID = "snowflake.column.require"
+
+// NewColumnRequireRule constructs the rule with the given configuration.
+func NewColumnRequireRule(cfg ColumnRequireConfig) advisor.Rule {
+	normalized := make([]string, len(cfg.Required))
+	for i, n := range cfg.Required {
+		normalized[i] = strings.ToUpper(n)
+	}
+	return &columnRequireRule{required: normalized}
+}
+
+// ID implements Rule.
+func (*columnRequireRule) ID() string { return columnRequireID }
+
+// Severity implements Rule.
+func (*columnRequireRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (r *columnRequireRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	if len(r.required) == 0 {
+		return nil
+	}
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	// Build a set of present column names.
+	present := make(map[string]bool, len(stmt.Columns))
+	for _, col := range stmt.Columns {
+		present[strings.ToUpper(col.Name.Name)] = true
+	}
+	var findings []*advisor.Finding
+	for _, req := range r.required {
+		if !present[req] {
+			findings = append(findings, &advisor.Finding{
+				RuleID:   columnRequireID,
+				Severity: advisor.SeverityError,
+				Loc:      stmt.Loc,
+				Message:  fmt.Sprintf("table %q must have a column named %q", stmt.Name.String(), req),
+			})
+		}
+	}
+	return findings
+}

--- a/snowflake/advisor/rules/column_require_test.go
+++ b/snowflake/advisor/rules/column_require_test.go
@@ -1,0 +1,77 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestColumnRequire(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		required  []string
+		wantCount int
+	}{
+		{
+			name:      "empty config — no findings",
+			sql:       "CREATE TABLE t (id INT)",
+			required:  nil,
+			wantCount: 0,
+		},
+		{
+			name:      "required column present — no findings",
+			sql:       "CREATE TABLE t (id INT NOT NULL, created_at TIMESTAMP NOT NULL)",
+			required:  []string{"id", "created_at"},
+			wantCount: 0,
+		},
+		{
+			name:      "required column missing — one finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL)",
+			required:  []string{"id", "created_at"},
+			wantCount: 1,
+		},
+		{
+			name:      "all required missing — two findings",
+			sql:       "CREATE TABLE t (name VARCHAR(100))",
+			required:  []string{"id", "created_at"},
+			wantCount: 2,
+		},
+		{
+			name:      "case-insensitive match — no findings",
+			sql:       "CREATE TABLE t (ID INT NOT NULL)",
+			required:  []string{"id"},
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT statement — no findings",
+			sql:       "SELECT a FROM t",
+			required:  []string{"id"},
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := rules.ColumnRequireConfig{Required: tt.required}
+			rule := rules.NewColumnRequireRule(cfg)
+			findings := runRule(t, tt.sql, rule)
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestColumnRequire_Metadata(t *testing.T) {
+	r := rules.NewColumnRequireRule(rules.ColumnRequireConfig{Required: []string{"id"}})
+	if r.ID() != "snowflake.column.require" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/helpers_test.go
+++ b/snowflake/advisor/rules/helpers_test.go
@@ -1,0 +1,56 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// runRule is a test helper that parses sql, runs a single Rule via the
+// Advisor framework, and returns the findings.
+func runRule(t *testing.T, sql string, rule advisor.Rule) []*advisor.Finding {
+	t.Helper()
+	file, err := parser.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse(%q): %v", sql, err)
+	}
+	a := advisor.New(rule)
+	ctx := &advisor.Context{SQL: sql}
+	return a.Check(ctx, file)
+}
+
+// runRules is like runRule but accepts multiple rules.
+func runRules(t *testing.T, sql string, ruleList ...advisor.Rule) []*advisor.Finding {
+	t.Helper()
+	file, err := parser.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse(%q): %v", sql, err)
+	}
+	a := advisor.New(ruleList...)
+	ctx := &advisor.Context{SQL: sql}
+	return a.Check(ctx, file)
+}
+
+// findingsByRule returns the subset of findings whose RuleID equals id.
+func findingsByRule(findings []*advisor.Finding, id string) []*advisor.Finding {
+	var out []*advisor.Finding
+	for _, f := range findings {
+		if f.RuleID == id {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// mustParse parses sql and fails the test on any parse error.
+// Kept here so individual test files can use it if needed.
+func mustParse(t *testing.T, sql string) *ast.File {
+	t.Helper()
+	f, err := parser.Parse(sql)
+	if err != nil {
+		t.Fatalf("parse(%q): %v", sql, err)
+	}
+	return f
+}

--- a/snowflake/advisor/rules/migration_compatibility.go
+++ b/snowflake/advisor/rules/migration_compatibility.go
@@ -1,0 +1,78 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// MigrationCompatibilityRule forbids destructive DDL operations that can
+// cause data loss or break dependent objects:
+//
+//   - DROP TABLE
+//   - ALTER TABLE ... DROP COLUMN
+//
+// Rule ID:  "snowflake.migration.compatibility"
+// Severity: ERROR
+//
+// The intent is to protect against accidental destructive migrations in CI/CD
+// pipelines. Teams that need to drop objects should use a separate manual
+// review process.
+type MigrationCompatibilityRule struct{}
+
+const migrationCompatibilityID = "snowflake.migration.compatibility"
+
+// ID implements Rule.
+func (MigrationCompatibilityRule) ID() string { return migrationCompatibilityID }
+
+// Severity implements Rule.
+func (MigrationCompatibilityRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (MigrationCompatibilityRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	switch n := node.(type) {
+	case *ast.DropStmt:
+		return checkDropStmt(n)
+	case *ast.AlterTableStmt:
+		return checkAlterTableDrops(n)
+	}
+	return nil
+}
+
+func checkDropStmt(stmt *ast.DropStmt) []*advisor.Finding {
+	if stmt.Kind != ast.DropTable {
+		return nil
+	}
+	return []*advisor.Finding{{
+		RuleID:   migrationCompatibilityID,
+		Severity: advisor.SeverityError,
+		Loc:      stmt.Loc,
+		Message: fmt.Sprintf(
+			"DROP TABLE %q is a destructive operation and is not allowed in migration scripts",
+			stmt.Name.String(),
+		),
+	}}
+}
+
+func checkAlterTableDrops(stmt *ast.AlterTableStmt) []*advisor.Finding {
+	var findings []*advisor.Finding
+	for _, action := range stmt.Actions {
+		if action.Kind == ast.AlterTableDropColumn {
+			names := make([]string, len(action.DropColumnNames))
+			for i, n := range action.DropColumnNames {
+				names[i] = n.Name
+			}
+			findings = append(findings, &advisor.Finding{
+				RuleID:   migrationCompatibilityID,
+				Severity: advisor.SeverityError,
+				Loc:      action.Loc,
+				Message: fmt.Sprintf(
+					"ALTER TABLE %q DROP COLUMN is a destructive operation and is not allowed in migration scripts",
+					stmt.Name.String(),
+				),
+			})
+		}
+	}
+	return findings
+}

--- a/snowflake/advisor/rules/migration_compatibility_test.go
+++ b/snowflake/advisor/rules/migration_compatibility_test.go
@@ -1,0 +1,83 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestMigrationCompatibility(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "CREATE TABLE — no finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "ALTER TABLE ADD COLUMN — no finding",
+			sql:       "ALTER TABLE t ADD COLUMN new_col INT",
+			wantCount: 0,
+		},
+		{
+			name:      "DROP TABLE — one finding",
+			sql:       "DROP TABLE orders",
+			wantCount: 1,
+		},
+		{
+			name:      "DROP TABLE IF EXISTS — one finding",
+			sql:       "DROP TABLE IF EXISTS orders",
+			wantCount: 1,
+		},
+		{
+			name:      "DROP VIEW — no finding (only DROP TABLE is destructive by this rule)",
+			sql:       "DROP VIEW v",
+			wantCount: 0,
+		},
+		{
+			name:      "ALTER TABLE DROP COLUMN — one finding",
+			sql:       "ALTER TABLE t DROP COLUMN old_col",
+			wantCount: 1,
+		},
+		{
+			name:      "ALTER TABLE DROP COLUMN multiple — multiple findings",
+			sql:       "ALTER TABLE t DROP COLUMN a, DROP COLUMN b",
+			wantCount: 2,
+		},
+		{
+			name:      "ALTER TABLE RENAME — no finding",
+			sql:       "ALTER TABLE t RENAME TO t2",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT — no finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.MigrationCompatibilityRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestMigrationCompatibility_Metadata(t *testing.T) {
+	r := rules.MigrationCompatibilityRule{}
+	if r.ID() != "snowflake.migration.compatibility" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/naming_identifier_case.go
+++ b/snowflake/advisor/rules/naming_identifier_case.go
@@ -1,0 +1,183 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// IdentifierCase enumerates the supported case conventions for identifiers.
+type IdentifierCase int
+
+const (
+	// IdentifierCaseLower requires all-lowercase identifiers (snake_case friendly).
+	IdentifierCaseLower IdentifierCase = iota
+	// IdentifierCaseUpper requires all-uppercase identifiers.
+	IdentifierCaseUpper
+	// IdentifierCaseCamel requires camelCase identifiers (first char lowercase, at
+	// least one uppercase letter, no underscores).
+	IdentifierCaseCamel
+)
+
+// NamingIdentifierCaseConfig configures the required identifier case convention.
+type NamingIdentifierCaseConfig struct {
+	// Case is the required case convention. Default is IdentifierCaseLower.
+	Case IdentifierCase
+}
+
+// namingIdentifierCaseRule fires when an unquoted identifier does not match
+// the configured case convention.
+//
+// Rule ID:  "snowflake.naming.identifier-case"
+// Severity: WARNING
+//
+// Quoted identifiers are exempt — their case is intentional.
+//
+// Checked locations:
+//   - Column names in CREATE TABLE (ColumnDef.Name)
+//   - Table name in CREATE TABLE (CreateTableStmt.Name.Name)
+//   - Table alias in SelectStmt FROM clause (TableRef.Alias)
+//   - SELECT target alias (SelectTarget.Alias)
+//   - Table alias in UPDATE (UpdateStmt.Alias)
+//   - Table alias in DELETE (DeleteStmt.Alias)
+//   - CTE names (SelectStmt.With[i].Name)
+type namingIdentifierCaseRule struct {
+	caseConvention IdentifierCase
+}
+
+const namingIdentifierCaseID = "snowflake.naming.identifier-case"
+
+// NewNamingIdentifierCaseRule constructs the rule.
+func NewNamingIdentifierCaseRule(cfg NamingIdentifierCaseConfig) advisor.Rule {
+	return &namingIdentifierCaseRule{caseConvention: cfg.Case}
+}
+
+// ID implements Rule.
+func (*namingIdentifierCaseRule) ID() string { return namingIdentifierCaseID }
+
+// Severity implements Rule.
+func (*namingIdentifierCaseRule) Severity() advisor.Severity { return advisor.SeverityWarning }
+
+// Check implements Rule.
+func (r *namingIdentifierCaseRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	switch n := node.(type) {
+	case *ast.CreateTableStmt:
+		return r.checkCreateTable(n)
+	case *ast.SelectStmt:
+		return r.checkSelect(n)
+	case *ast.UpdateStmt:
+		return r.checkIdent(n.Alias, n.Loc)
+	case *ast.DeleteStmt:
+		return r.checkIdent(n.Alias, n.Loc)
+	case *ast.TableRef:
+		return r.checkIdent(n.Alias, n.Loc)
+	}
+	return nil
+}
+
+func (r *namingIdentifierCaseRule) checkCreateTable(stmt *ast.CreateTableStmt) []*advisor.Finding {
+	var findings []*advisor.Finding
+	// Table name.
+	if f := r.checkIdent(stmt.Name.Name, stmt.Name.Loc); f != nil {
+		findings = append(findings, f...)
+	}
+	// Column names.
+	for _, col := range stmt.Columns {
+		if f := r.checkIdent(col.Name, col.Loc); f != nil {
+			findings = append(findings, f...)
+		}
+	}
+	return findings
+}
+
+func (r *namingIdentifierCaseRule) checkSelect(stmt *ast.SelectStmt) []*advisor.Finding {
+	var findings []*advisor.Finding
+	// CTE names.
+	for _, cte := range stmt.With {
+		if f := r.checkIdent(cte.Name, stmt.Loc); f != nil {
+			findings = append(findings, f...)
+		}
+	}
+	// SELECT target aliases.
+	for _, target := range stmt.Targets {
+		if f := r.checkIdent(target.Alias, target.Loc); f != nil {
+			findings = append(findings, f...)
+		}
+	}
+	return findings
+}
+
+// checkIdent checks a single identifier. Returns a finding if it violates the case convention.
+func (r *namingIdentifierCaseRule) checkIdent(ident ast.Ident, loc ast.Loc) []*advisor.Finding {
+	if ident.IsEmpty() {
+		return nil
+	}
+	if ident.Quoted {
+		return nil
+	}
+	name := ident.Name
+	if r.matchesCase(name) {
+		return nil
+	}
+	return []*advisor.Finding{{
+		RuleID:   namingIdentifierCaseID,
+		Severity: advisor.SeverityWarning,
+		Loc:      loc,
+		Message: fmt.Sprintf(
+			"identifier %q does not match the required %s case convention",
+			name, r.caseLabel(),
+		),
+	}}
+}
+
+func (r *namingIdentifierCaseRule) matchesCase(name string) bool {
+	switch r.caseConvention {
+	case IdentifierCaseLower:
+		return name == strings.ToLower(name)
+	case IdentifierCaseUpper:
+		return name == strings.ToUpper(name)
+	case IdentifierCaseCamel:
+		return isCamelCase(name)
+	default:
+		return true
+	}
+}
+
+func (r *namingIdentifierCaseRule) caseLabel() string {
+	switch r.caseConvention {
+	case IdentifierCaseLower:
+		return "LOWER"
+	case IdentifierCaseUpper:
+		return "UPPER"
+	case IdentifierCaseCamel:
+		return "CAMEL"
+	default:
+		return "LOWER"
+	}
+}
+
+// isCamelCase reports whether name looks like camelCase:
+// - starts with a lowercase letter
+// - contains at least one uppercase letter
+// - contains no underscores
+func isCamelCase(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	if !unicode.IsLower(rune(name[0])) {
+		return false
+	}
+	if strings.ContainsRune(name, '_') {
+		return false
+	}
+	for _, r := range name {
+		if unicode.IsUpper(r) {
+			return true
+		}
+	}
+	// All lowercase, no underscores — acceptable as a single-word camel name.
+	return true
+}

--- a/snowflake/advisor/rules/naming_identifier_case_test.go
+++ b/snowflake/advisor/rules/naming_identifier_case_test.go
@@ -1,0 +1,111 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestNamingIdentifierCase_Lower(t *testing.T) {
+	cfg := rules.NamingIdentifierCaseConfig{Case: rules.IdentifierCaseLower}
+	rule := rules.NewNamingIdentifierCaseRule(cfg)
+
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "all lower — no findings",
+			sql:       "CREATE TABLE orders (id INT NOT NULL, user_name VARCHAR(100))",
+			wantCount: 0,
+		},
+		{
+			name:      "table name uppercase — one finding",
+			sql:       "CREATE TABLE Orders (id INT NOT NULL)",
+			wantCount: 1,
+		},
+		{
+			name:      "column name uppercase — one finding",
+			sql:       "CREATE TABLE orders (ID INT NOT NULL)",
+			wantCount: 1,
+		},
+		{
+			name:      "both uppercase — two findings",
+			sql:       "CREATE TABLE Orders (ID INT NOT NULL)",
+			wantCount: 2,
+		},
+		{
+			name:      "quoted uppercase — no finding",
+			sql:       `CREATE TABLE "Orders" ("ID" INT NOT NULL)`,
+			wantCount: 0,
+		},
+		{
+			name:      "select alias lower — no findings",
+			sql:       "SELECT a AS alias FROM t",
+			wantCount: 0,
+		},
+		{
+			name:      "select alias upper — one finding",
+			sql:       "SELECT a AS MyAlias FROM t",
+			wantCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rule)
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestNamingIdentifierCase_Upper(t *testing.T) {
+	cfg := rules.NamingIdentifierCaseConfig{Case: rules.IdentifierCaseUpper}
+	rule := rules.NewNamingIdentifierCaseRule(cfg)
+
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "all upper — no findings",
+			sql:       "CREATE TABLE ORDERS (ID INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "lowercase table — one finding",
+			sql:       "CREATE TABLE orders (ID INT NOT NULL)",
+			wantCount: 1,
+		},
+		{
+			name:      "uppercase with underscores — no findings",
+			sql:       "CREATE TABLE ORDER_ITEMS (ITEM_ID INT NOT NULL)",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rule)
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestNamingIdentifierCase_Metadata(t *testing.T) {
+	r := rules.NewNamingIdentifierCaseRule(rules.NamingIdentifierCaseConfig{})
+	if r.ID() != "snowflake.naming.identifier-case" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityWarning {
+		t.Errorf("Severity() = %v, want WARNING", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/naming_identifier_no_keyword.go
+++ b/snowflake/advisor/rules/naming_identifier_no_keyword.go
@@ -1,0 +1,84 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// NamingIdentifierNoKeywordRule fires when an unquoted identifier is a
+// reserved keyword. This complements NamingTableNoKeywordRule by covering
+// additional identifier locations: column names, aliases, and CTE names.
+//
+// Rule ID:  "snowflake.naming.identifier-no-keyword"
+// Severity: ERROR
+//
+// Quoted identifiers are exempt. Checked locations:
+//   - Column names in CREATE TABLE
+//   - Table alias in FROM / JOIN (TableRef.Alias)
+//   - SELECT target alias (SelectTarget.Alias)
+//   - CTE name (SelectStmt.With[i].Name)
+type NamingIdentifierNoKeywordRule struct{}
+
+const namingIdentifierNoKeywordID = "snowflake.naming.identifier-no-keyword"
+
+// ID implements Rule.
+func (NamingIdentifierNoKeywordRule) ID() string { return namingIdentifierNoKeywordID }
+
+// Severity implements Rule.
+func (NamingIdentifierNoKeywordRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (NamingIdentifierNoKeywordRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	switch n := node.(type) {
+	case *ast.CreateTableStmt:
+		return checkKeywordIdents(n)
+	case *ast.SelectStmt:
+		return checkKeywordSelectIdents(n)
+	case *ast.TableRef:
+		return checkKeywordIdent(n.Alias, n.Loc)
+	}
+	return nil
+}
+
+func checkKeywordIdents(stmt *ast.CreateTableStmt) []*advisor.Finding {
+	var findings []*advisor.Finding
+	for _, col := range stmt.Columns {
+		findings = append(findings, checkKeywordIdent(col.Name, col.Loc)...)
+	}
+	return findings
+}
+
+func checkKeywordSelectIdents(stmt *ast.SelectStmt) []*advisor.Finding {
+	var findings []*advisor.Finding
+	for _, cte := range stmt.With {
+		findings = append(findings, checkKeywordIdent(cte.Name, stmt.Loc)...)
+	}
+	for _, target := range stmt.Targets {
+		findings = append(findings, checkKeywordIdent(target.Alias, target.Loc)...)
+	}
+	return findings
+}
+
+func checkKeywordIdent(ident ast.Ident, loc ast.Loc) []*advisor.Finding {
+	if ident.IsEmpty() {
+		return nil
+	}
+	if ident.Quoted {
+		return nil
+	}
+	if parser.IsReservedKeyword(ident.Name) {
+		return []*advisor.Finding{{
+			RuleID:   namingIdentifierNoKeywordID,
+			Severity: advisor.SeverityError,
+			Loc:      loc,
+			Message: fmt.Sprintf(
+				"identifier %q is a reserved keyword; use a different name or quote it",
+				ident.Name,
+			),
+		}}
+	}
+	return nil
+}

--- a/snowflake/advisor/rules/naming_identifier_no_keyword_test.go
+++ b/snowflake/advisor/rules/naming_identifier_no_keyword_test.go
@@ -1,0 +1,108 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+func TestNamingIdentifierNoKeyword(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "normal identifiers — no findings",
+			sql:       "CREATE TABLE orders (id INT NOT NULL, status VARCHAR(50))",
+			wantCount: 0,
+		},
+		{
+			name:      "quoted reserved keyword column — no finding",
+			sql:       `CREATE TABLE t ("null" INT NOT NULL)`,
+			wantCount: 0,
+		},
+		{
+			name:      "non-reserved keyword column — no finding",
+			sql:       "CREATE TABLE t (access INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "normal SELECT — no findings",
+			sql:       "SELECT a AS my_alias FROM t AS tbl WHERE 1=1",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.NamingIdentifierNoKeywordRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestNamingIdentifierNoKeyword_DirectAST tests the rule with a hand-crafted AST
+// node to verify the core logic fires when a reserved keyword appears as an
+// unquoted identifier. This bypasses the parser which rejects reserved keywords
+// in most identifier positions.
+func TestNamingIdentifierNoKeyword_DirectAST(t *testing.T) {
+	rule := rules.NamingIdentifierNoKeywordRule{}
+	ctx := &advisor.Context{SQL: ""}
+
+	// Simulate a CreateTableStmt where column name is the reserved keyword "null".
+	stmt := &ast.CreateTableStmt{
+		Name: &ast.ObjectName{Name: ast.Ident{Name: "orders"}},
+		Columns: []*ast.ColumnDef{
+			{
+				Name:    ast.Ident{Name: "null", Quoted: false}, // unquoted reserved keyword
+				NotNull: true,
+			},
+		},
+	}
+	findings := rule.Check(ctx, stmt)
+	if len(findings) != 1 {
+		t.Errorf("expected 1 finding for reserved keyword column, got %d", len(findings))
+		return
+	}
+	if findings[0].RuleID != "snowflake.naming.identifier-no-keyword" {
+		t.Errorf("RuleID = %q", findings[0].RuleID)
+	}
+}
+
+// TestNamingIdentifierNoKeyword_QuotedSafe verifies that quoted reserved keyword
+// identifiers do not trigger the rule.
+func TestNamingIdentifierNoKeyword_QuotedSafe(t *testing.T) {
+	rule := rules.NamingIdentifierNoKeywordRule{}
+	ctx := &advisor.Context{SQL: ""}
+
+	stmt := &ast.CreateTableStmt{
+		Name: &ast.ObjectName{Name: ast.Ident{Name: "orders"}},
+		Columns: []*ast.ColumnDef{
+			{
+				Name:    ast.Ident{Name: "select", Quoted: true}, // quoted — safe
+				NotNull: true,
+			},
+		},
+	}
+	findings := rule.Check(ctx, stmt)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for quoted identifier, got %d", len(findings))
+	}
+}
+
+func TestNamingIdentifierNoKeyword_Metadata(t *testing.T) {
+	r := rules.NamingIdentifierNoKeywordRule{}
+	if r.ID() != "snowflake.naming.identifier-no-keyword" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/naming_table.go
+++ b/snowflake/advisor/rules/naming_table.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+const (
+	// DefaultTableNamePattern is the default regex for table names.
+	DefaultTableNamePattern = `^[a-z][a-z0-9_]{0,63}$`
+)
+
+// NamingTableConfig holds the regex pattern for table names.
+type NamingTableConfig struct {
+	// Pattern is a regular expression that table names must match.
+	// An empty string means use DefaultTableNamePattern.
+	Pattern string
+}
+
+// namingTableRule fires when a CREATE TABLE name does not match the configured pattern.
+//
+// Rule ID:  "snowflake.naming.table"
+// Severity: WARNING
+//
+// The check is applied to the last (local) part of the table name.
+// Quoted identifiers are checked as-is (their case is intentional).
+// Unquoted identifiers are checked with their source case (pre-resolution).
+type namingTableRule struct {
+	re *regexp.Regexp
+}
+
+const namingTableID = "snowflake.naming.table"
+
+// NewNamingTableRule constructs the rule.
+func NewNamingTableRule(cfg NamingTableConfig) advisor.Rule {
+	pattern := cfg.Pattern
+	if pattern == "" {
+		pattern = DefaultTableNamePattern
+	}
+	return &namingTableRule{re: regexp.MustCompile(pattern)}
+}
+
+// ID implements Rule.
+func (*namingTableRule) ID() string { return namingTableID }
+
+// Severity implements Rule.
+func (*namingTableRule) Severity() advisor.Severity { return advisor.SeverityWarning }
+
+// Check implements Rule.
+func (r *namingTableRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	tableName := stmt.Name.Name.Name
+	if !r.re.MatchString(tableName) {
+		return []*advisor.Finding{{
+			RuleID:   namingTableID,
+			Severity: advisor.SeverityWarning,
+			Loc:      stmt.Name.Loc,
+			Message: fmt.Sprintf(
+				"table name %q does not match naming convention %q",
+				tableName, r.re.String(),
+			),
+		}}
+	}
+	return nil
+}

--- a/snowflake/advisor/rules/naming_table_no_keyword.go
+++ b/snowflake/advisor/rules/naming_table_no_keyword.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// NamingTableNoKeywordRule fires when a CREATE TABLE uses a reserved keyword
+// as its table name without quoting.
+//
+// Rule ID:  "snowflake.naming.table-no-keyword"
+// Severity: ERROR
+//
+// Quoted identifiers are always permitted (Snowflake allows "SELECT" as an
+// identifier when quoted). Only unquoted identifiers that collide with
+// reserved keywords are flagged.
+type NamingTableNoKeywordRule struct{}
+
+const namingTableNoKeywordID = "snowflake.naming.table-no-keyword"
+
+// ID implements Rule.
+func (NamingTableNoKeywordRule) ID() string { return namingTableNoKeywordID }
+
+// Severity implements Rule.
+func (NamingTableNoKeywordRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (NamingTableNoKeywordRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	nameIdent := stmt.Name.Name
+	// Quoted identifiers are always safe.
+	if nameIdent.Quoted {
+		return nil
+	}
+	if parser.IsReservedKeyword(nameIdent.Name) {
+		return []*advisor.Finding{{
+			RuleID:   namingTableNoKeywordID,
+			Severity: advisor.SeverityError,
+			Loc:      stmt.Name.Loc,
+			Message: fmt.Sprintf(
+				"table name %q is a reserved keyword; use a different name or quote it",
+				nameIdent.Name,
+			),
+		}}
+	}
+	return nil
+}

--- a/snowflake/advisor/rules/naming_table_no_keyword_test.go
+++ b/snowflake/advisor/rules/naming_table_no_keyword_test.go
@@ -1,0 +1,73 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestNamingTableNoKeyword(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "normal name — no finding",
+			sql:       "CREATE TABLE orders (id INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "reserved keyword SELECT — one finding",
+			sql:       `CREATE TABLE select (id INT NOT NULL)`,
+			wantCount: 1,
+		},
+		{
+			name:      "reserved keyword TABLE — one finding",
+			sql:       `CREATE TABLE table (id INT NOT NULL)`,
+			wantCount: 1,
+		},
+		{
+			name:      "quoted reserved keyword — no finding (safe)",
+			sql:       `CREATE TABLE "select" (id INT NOT NULL)`,
+			wantCount: 0,
+		},
+		{
+			name:      "non-reserved keyword (ABORT is not reserved) — no finding",
+			sql:       "CREATE TABLE abort (id INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "reserved keyword WHERE — one finding",
+			sql:       `CREATE TABLE where (id INT NOT NULL)`,
+			wantCount: 1,
+		},
+		{
+			name:      "SELECT statement — no finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.NamingTableNoKeywordRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestNamingTableNoKeyword_Metadata(t *testing.T) {
+	r := rules.NamingTableNoKeywordRule{}
+	if r.ID() != "snowflake.naming.table-no-keyword" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/naming_table_test.go
+++ b/snowflake/advisor/rules/naming_table_test.go
@@ -1,0 +1,78 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestNamingTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		pattern   string // empty means default
+		wantCount int
+	}{
+		{
+			name:      "valid snake_case — no finding",
+			sql:       "CREATE TABLE my_table (id INT)",
+			wantCount: 0,
+		},
+		{
+			name:      "uppercase name — one finding (default pattern)",
+			sql:       "CREATE TABLE MyTable (id INT)",
+			wantCount: 1,
+		},
+		{
+			name:      "underscore start (not matching default pattern) — one finding",
+			sql:       "CREATE TABLE _bad (id INT)",
+			wantCount: 1,
+		},
+		{
+			name:      "custom pattern uppercase — valid",
+			sql:       "CREATE TABLE MY_TABLE (id INT)",
+			pattern:   `^[A-Z][A-Z0-9_]+$`,
+			wantCount: 0,
+		},
+		{
+			name:      "custom pattern uppercase — invalid",
+			sql:       "CREATE TABLE my_table (id INT)",
+			pattern:   `^[A-Z][A-Z0-9_]+$`,
+			wantCount: 1,
+		},
+		{
+			name:      "valid with numbers",
+			sql:       "CREATE TABLE order2 (id INT)",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT statement — no finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := rules.NamingTableConfig{Pattern: tt.pattern}
+			rule := rules.NewNamingTableRule(cfg)
+			findings := runRule(t, tt.sql, rule)
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestNamingTable_Metadata(t *testing.T) {
+	r := rules.NewNamingTableRule(rules.NamingTableConfig{})
+	if r.ID() != "snowflake.naming.table" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityWarning {
+		t.Errorf("Severity() = %v, want WARNING", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/rules_integration_test.go
+++ b/snowflake/advisor/rules/rules_integration_test.go
@@ -1,0 +1,238 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// allTestRules returns all 14 rules configured for integration tests.
+func allTestRules() []advisor.Rule {
+	return []advisor.Rule{
+		rules.ColumnNoNullRule{},
+		rules.NewColumnRequireRule(rules.ColumnRequireConfig{Required: []string{"created_at"}}),
+		rules.NewColumnMaximumVarcharLengthRule(rules.ColumnMaximumVarcharLengthConfig{MaxLength: 100}),
+		rules.TableRequirePKRule{},
+		rules.TableNoForeignKeyRule{},
+		rules.NewNamingTableRule(rules.NamingTableConfig{}),
+		rules.NamingTableNoKeywordRule{},
+		rules.NewNamingIdentifierCaseRule(rules.NamingIdentifierCaseConfig{Case: rules.IdentifierCaseLower}),
+		rules.NamingIdentifierNoKeywordRule{},
+		rules.SelectNoSelectAllRule{},
+		rules.WhereRequireSelectRule{},
+		rules.WhereRequireUpdateDeleteRule{},
+		rules.MigrationCompatibilityRule{},
+		rules.NewTableDropNamingConventionRule(rules.TableDropNamingConventionConfig{}),
+	}
+}
+
+// TestIntegration_EachRuleFiresOnItsOwnTrigger runs every rule individually
+// against a SQL that is known to trigger it (or a direct AST node for rules
+// that cannot be triggered via parsed SQL) and asserts at least one finding
+// with the expected rule ID.
+func TestIntegration_EachRuleFiresOnItsOwnTrigger(t *testing.T) {
+	rule := rules.NamingIdentifierNoKeywordRule{}
+	ctx := &advisor.Context{}
+	// Hand-craft an AST node for naming_identifier_no_keyword since the parser
+	// rejects reserved keywords in column-name positions.
+	reservedKwStmt := &ast.CreateTableStmt{
+		Name: &ast.ObjectName{Name: ast.Ident{Name: "orders"}},
+		Columns: []*ast.ColumnDef{
+			{Name: ast.Ident{Name: "null", Quoted: false}, NotNull: true},
+		},
+	}
+	kwFindings := rule.Check(ctx, reservedKwStmt)
+
+	triggers := []struct {
+		ruleID   string
+		rule     advisor.Rule
+		sql      string
+		findings []*advisor.Finding // if non-nil, skip SQL parsing and use these
+	}{
+		{
+			ruleID: "snowflake.column.no-null",
+			rule:   rules.ColumnNoNullRule{},
+			sql:    "CREATE TABLE t (id INT)",
+		},
+		{
+			ruleID: "snowflake.column.require",
+			rule:   rules.NewColumnRequireRule(rules.ColumnRequireConfig{Required: []string{"created_at"}}),
+			sql:    "CREATE TABLE t (id INT NOT NULL)",
+		},
+		{
+			ruleID: "snowflake.column.maximum-varchar-length",
+			rule:   rules.NewColumnMaximumVarcharLengthRule(rules.ColumnMaximumVarcharLengthConfig{MaxLength: 100}),
+			sql:    "CREATE TABLE t (id INT NOT NULL, bio VARCHAR(500) NOT NULL)",
+		},
+		{
+			ruleID: "snowflake.table.require-pk",
+			rule:   rules.TableRequirePKRule{},
+			sql:    "CREATE TABLE t (id INT NOT NULL, name VARCHAR(50) NOT NULL)",
+		},
+		{
+			ruleID: "snowflake.table.no-foreign-key",
+			rule:   rules.TableNoForeignKeyRule{},
+			sql:    "CREATE TABLE t (id INT NOT NULL, user_id INT FOREIGN KEY REFERENCES users(id))",
+		},
+		{
+			ruleID: "snowflake.naming.table",
+			rule:   rules.NewNamingTableRule(rules.NamingTableConfig{}),
+			sql:    "CREATE TABLE BadTable (id INT NOT NULL)",
+		},
+		{
+			ruleID: "snowflake.naming.table-no-keyword",
+			rule:   rules.NamingTableNoKeywordRule{},
+			sql:    "CREATE TABLE select (id INT NOT NULL)",
+		},
+		{
+			ruleID: "snowflake.naming.identifier-case",
+			rule:   rules.NewNamingIdentifierCaseRule(rules.NamingIdentifierCaseConfig{Case: rules.IdentifierCaseLower}),
+			sql:    "CREATE TABLE good_table (BadCol INT NOT NULL)",
+		},
+		{
+			// naming_identifier_no_keyword: parser rejects reserved keywords in most
+			// identifier positions, so we provide the pre-computed findings directly.
+			ruleID:   "snowflake.naming.identifier-no-keyword",
+			rule:     rules.NamingIdentifierNoKeywordRule{},
+			findings: kwFindings,
+		},
+		{
+			ruleID: "snowflake.select.no-select-all",
+			rule:   rules.SelectNoSelectAllRule{},
+			sql:    "SELECT * FROM t",
+		},
+		{
+			ruleID: "snowflake.query.where-require-select",
+			rule:   rules.WhereRequireSelectRule{},
+			sql:    "SELECT a FROM t",
+		},
+		{
+			ruleID: "snowflake.query.where-require-update-delete",
+			rule:   rules.WhereRequireUpdateDeleteRule{},
+			sql:    "UPDATE t SET a = 1",
+		},
+		{
+			ruleID: "snowflake.migration.compatibility",
+			rule:   rules.MigrationCompatibilityRule{},
+			sql:    "DROP TABLE bad_table",
+		},
+		{
+			ruleID: "snowflake.table.drop-naming-convention",
+			rule:   rules.NewTableDropNamingConventionRule(rules.TableDropNamingConventionConfig{}),
+			sql:    "DROP TABLE bad_table",
+		},
+	}
+
+	for _, tt := range triggers {
+		t.Run(tt.ruleID, func(t *testing.T) {
+			var findings []*advisor.Finding
+			if tt.findings != nil {
+				findings = tt.findings
+			} else {
+				findings = runRule(t, tt.sql, tt.rule)
+			}
+			fired := false
+			for _, f := range findings {
+				if f.RuleID == tt.ruleID {
+					fired = true
+					break
+				}
+			}
+			if !fired {
+				t.Errorf("rule %q did not fire (got %d findings)", tt.ruleID, len(findings))
+				for _, f := range findings {
+					t.Logf("  got finding: ruleID=%s msg=%s", f.RuleID, f.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestIntegration_AllRulesNoFalsePositive verifies that a well-written CREATE
+// TABLE with no violations produces no findings from any of the 14 rules.
+func TestIntegration_AllRulesNoFalsePositive(t *testing.T) {
+	// This SQL should satisfy all column/table/naming rules:
+	// - columns all have NOT NULL
+	// - required column created_at is present
+	// - no VARCHAR over 100 chars
+	// - has a PRIMARY KEY
+	// - no foreign keys
+	// - table name matches default pattern
+	// - not a reserved keyword
+	// - all identifiers are lowercase
+	// - column names are not reserved keywords
+	sql := `CREATE TABLE orders (
+		id INT NOT NULL,
+		created_at TIMESTAMP NOT NULL,
+		status VARCHAR(50) NOT NULL,
+		PRIMARY KEY (id)
+	)`
+	findings := runRules(t, sql, allTestRules()...)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for clean CREATE TABLE, got %d:", len(findings))
+		for _, f := range findings {
+			t.Logf("  ruleID=%s msg=%s", f.RuleID, f.Message)
+		}
+	}
+}
+
+// TestIntegration_AllRulesCount verifies that exactly 14 unique rule IDs are
+// registered in allTestRules().
+func TestIntegration_AllRulesCount(t *testing.T) {
+	ruleList := allTestRules()
+	seen := make(map[string]bool)
+	for _, r := range ruleList {
+		id := r.ID()
+		if seen[id] {
+			t.Errorf("duplicate rule ID: %q", id)
+		}
+		seen[id] = true
+	}
+	const want = 14
+	if len(seen) != want {
+		t.Errorf("got %d unique rule IDs, want %d", len(seen), want)
+		for id := range seen {
+			t.Logf("  %s", id)
+		}
+	}
+}
+
+// TestIntegration_MixedStatements verifies that rules correctly fire across
+// multiple statement types in the same advisor run (each statement independently).
+func TestIntegration_MixedStatements(t *testing.T) {
+	tests := []struct {
+		sql    string
+		ruleID string
+		want   int
+	}{
+		{"SELECT * FROM t", "snowflake.select.no-select-all", 1},
+		{"SELECT a FROM t WHERE id = 1", "snowflake.select.no-select-all", 0},
+		{"UPDATE t SET a = 1", "snowflake.query.where-require-update-delete", 1},
+		{"UPDATE t SET a = 1 WHERE id = 1", "snowflake.query.where-require-update-delete", 0},
+		{"DELETE FROM t", "snowflake.query.where-require-update-delete", 1},
+		{"DROP TABLE my_table", "snowflake.migration.compatibility", 1},
+		{"DROP TABLE deleted_orders", "snowflake.table.drop-naming-convention", 0},
+		{"DROP TABLE my_table", "snowflake.table.drop-naming-convention", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql+"/"+tt.ruleID, func(t *testing.T) {
+			// Find the specific rule.
+			var targetRule advisor.Rule
+			for _, r := range allTestRules() {
+				if r.ID() == tt.ruleID {
+					targetRule = r
+					break
+				}
+			}
+			if targetRule == nil {
+				t.Fatalf("rule %q not found", tt.ruleID)
+			}
+			findings := findingsByRule(runRule(t, tt.sql, targetRule), tt.ruleID)
+			if len(findings) != tt.want {
+				t.Errorf("got %d findings, want %d", len(findings), tt.want)
+			}
+		})
+	}
+}

--- a/snowflake/advisor/rules/select_no_select_all.go
+++ b/snowflake/advisor/rules/select_no_select_all.go
@@ -1,0 +1,63 @@
+package rules
+
+import (
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// SelectNoSelectAllRule prohibits SELECT * (bare star) in query lists.
+//
+// Rule ID:  "snowflake.select.no-select-all"
+// Severity: ERROR
+//
+// This is the production version of the example NoSelectStarRule shipped with
+// the T2.6 advisor framework. The differences are:
+//   - Rule ID uses the bytebase convention: "snowflake.select.no-select-all"
+//   - Severity is ERROR (not WARNING) — SELECT * is a hard requirement violation
+//
+// Qualified stars (t.*) are not flagged by this rule.
+type SelectNoSelectAllRule struct{}
+
+const selectNoSelectAllID = "snowflake.select.no-select-all"
+
+// ID implements Rule.
+func (SelectNoSelectAllRule) ID() string { return selectNoSelectAllID }
+
+// Severity implements Rule.
+func (SelectNoSelectAllRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (SelectNoSelectAllRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	sel, ok := node.(*ast.SelectStmt)
+	if !ok {
+		return nil
+	}
+	var findings []*advisor.Finding
+	for _, target := range sel.Targets {
+		if !target.Star {
+			continue
+		}
+		starExpr, ok := target.Expr.(*ast.StarExpr)
+		if !ok {
+			// bare * with nil Expr
+			findings = append(findings, &advisor.Finding{
+				RuleID:   selectNoSelectAllID,
+				Severity: advisor.SeverityError,
+				Loc:      target.Loc,
+				Message:  "avoid SELECT *: list the required columns explicitly",
+			})
+			continue
+		}
+		if starExpr.Qualifier != nil {
+			// qualified star (t.*) — skip
+			continue
+		}
+		findings = append(findings, &advisor.Finding{
+			RuleID:   selectNoSelectAllID,
+			Severity: advisor.SeverityError,
+			Loc:      target.Loc,
+			Message:  "avoid SELECT *: list the required columns explicitly",
+		})
+	}
+	return findings
+}

--- a/snowflake/advisor/rules/select_no_select_all_test.go
+++ b/snowflake/advisor/rules/select_no_select_all_test.go
@@ -1,0 +1,83 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestSelectNoSelectAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "explicit column list — no findings",
+			sql:       "SELECT a, b, c FROM t",
+			wantCount: 0,
+		},
+		{
+			name:      "bare star — one finding",
+			sql:       "SELECT * FROM t",
+			wantCount: 1,
+		},
+		{
+			name:      "qualified star — no finding",
+			sql:       "SELECT t.* FROM t",
+			wantCount: 0,
+		},
+		{
+			name:      "UNION with two bare stars — two findings",
+			sql:       "SELECT * FROM a UNION ALL SELECT * FROM b",
+			wantCount: 2,
+		},
+		{
+			name:      "mix of star and column — one finding",
+			sql:       "SELECT *, a FROM t",
+			wantCount: 1,
+		},
+		{
+			name:      "CREATE TABLE — no finding",
+			sql:       "CREATE TABLE t (id INT)",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT 1 (no table) — no finding",
+			sql:       "SELECT 1",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.SelectNoSelectAllRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestSelectNoSelectAll_Metadata(t *testing.T) {
+	r := rules.SelectNoSelectAllRule{}
+	if r.ID() != "snowflake.select.no-select-all" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}
+
+func TestSelectNoSelectAll_SeverityIsError(t *testing.T) {
+	findings := runRule(t, "SELECT * FROM t", rules.SelectNoSelectAllRule{})
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if findings[0].Severity != advisor.SeverityError {
+		t.Errorf("Severity = %v, want ERROR", findings[0].Severity)
+	}
+}

--- a/snowflake/advisor/rules/table_drop_naming_convention.go
+++ b/snowflake/advisor/rules/table_drop_naming_convention.go
@@ -1,0 +1,77 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+const (
+	// DefaultDropNamingPattern is the default regex for dropped table names.
+	// Matches tables whose name starts with "deleted_" or whose name is "_deleted".
+	DefaultDropNamingPattern = `^_deleted$|^deleted_`
+)
+
+// TableDropNamingConventionConfig holds the regex pattern for dropped table names.
+type TableDropNamingConventionConfig struct {
+	// Pattern is a regular expression that the dropped table name must match.
+	// An empty string means use DefaultDropNamingPattern.
+	Pattern string
+}
+
+// tableDropNamingConventionRule fires when a DROP TABLE target does not match
+// the configured archival naming convention.
+//
+// Rule ID:  "snowflake.table.drop-naming-convention"
+// Severity: WARNING
+//
+// The intent is to require that tables be renamed to an archival name (e.g.
+// deleted_orders or orders_deleted) before dropping, so that other teams
+// have a chance to notice the deletion.
+type tableDropNamingConventionRule struct {
+	re *regexp.Regexp
+}
+
+const tableDropNamingConventionID = "snowflake.table.drop-naming-convention"
+
+// NewTableDropNamingConventionRule constructs the rule.
+func NewTableDropNamingConventionRule(cfg TableDropNamingConventionConfig) advisor.Rule {
+	pattern := cfg.Pattern
+	if pattern == "" {
+		pattern = DefaultDropNamingPattern
+	}
+	return &tableDropNamingConventionRule{re: regexp.MustCompile(pattern)}
+}
+
+// ID implements Rule.
+func (*tableDropNamingConventionRule) ID() string { return tableDropNamingConventionID }
+
+// Severity implements Rule.
+func (*tableDropNamingConventionRule) Severity() advisor.Severity { return advisor.SeverityWarning }
+
+// Check implements Rule.
+func (r *tableDropNamingConventionRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	drop, ok := node.(*ast.DropStmt)
+	if !ok {
+		return nil
+	}
+	if drop.Kind != ast.DropTable {
+		return nil
+	}
+	tableName := drop.Name.Name.Name
+	if r.re.MatchString(tableName) {
+		return nil
+	}
+	return []*advisor.Finding{{
+		RuleID:   tableDropNamingConventionID,
+		Severity: advisor.SeverityWarning,
+		Loc:      drop.Loc,
+		Message: fmt.Sprintf(
+			"table %q being dropped does not match the archival naming convention %q; "+
+				"consider renaming to an archival name before dropping",
+			tableName, r.re.String(),
+		),
+	}}
+}

--- a/snowflake/advisor/rules/table_drop_naming_convention_test.go
+++ b/snowflake/advisor/rules/table_drop_naming_convention_test.go
@@ -1,0 +1,88 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestTableDropNamingConvention(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		pattern   string // empty means default
+		wantCount int
+	}{
+		{
+			name:      "normal table name — one finding (default pattern)",
+			sql:       "DROP TABLE orders",
+			wantCount: 1,
+		},
+		{
+			name:      "deleted_ prefix — no finding",
+			sql:       "DROP TABLE deleted_orders",
+			wantCount: 0,
+		},
+		{
+			name:      "_deleted name — no finding",
+			sql:       "DROP TABLE _deleted",
+			wantCount: 0,
+		},
+		{
+			name:      "has _deleted in middle — one finding (does not match prefix/exact)",
+			sql:       "DROP TABLE orders_deleted_2024",
+			wantCount: 1,
+		},
+		{
+			name:      "custom pattern — _archive suffix",
+			sql:       "DROP TABLE orders_archive",
+			pattern:   `_archive$`,
+			wantCount: 0,
+		},
+		{
+			name:      "custom pattern — does not match",
+			sql:       "DROP TABLE orders",
+			pattern:   `_archive$`,
+			wantCount: 1,
+		},
+		{
+			name:      "DROP VIEW — no finding (only DROP TABLE applies)",
+			sql:       "DROP VIEW v",
+			wantCount: 0,
+		},
+		{
+			name:      "CREATE TABLE — no finding",
+			sql:       "CREATE TABLE t (id INT)",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT — no finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := rules.TableDropNamingConventionConfig{Pattern: tt.pattern}
+			rule := rules.NewTableDropNamingConventionRule(cfg)
+			findings := runRule(t, tt.sql, rule)
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestTableDropNamingConvention_Metadata(t *testing.T) {
+	r := rules.NewTableDropNamingConventionRule(rules.TableDropNamingConventionConfig{})
+	if r.ID() != "snowflake.table.drop-naming-convention" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityWarning {
+		t.Errorf("Severity() = %v, want WARNING", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/table_no_foreign_key.go
+++ b/snowflake/advisor/rules/table_no_foreign_key.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// TableNoForeignKeyRule prohibits FOREIGN KEY constraints in CREATE TABLE.
+//
+// Rule ID:  "snowflake.table.no-foreign-key"
+// Severity: ERROR
+//
+// Both inline (column-level) and table-level FOREIGN KEY constraints are
+// flagged. Snowflake supports FK definitions for documentation purposes but
+// does not enforce them. Many schemas prefer to avoid FK declarations to keep
+// migrations simple.
+type TableNoForeignKeyRule struct{}
+
+const tableNoForeignKeyID = "snowflake.table.no-foreign-key"
+
+// ID implements Rule.
+func (TableNoForeignKeyRule) ID() string { return tableNoForeignKeyID }
+
+// Severity implements Rule.
+func (TableNoForeignKeyRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (TableNoForeignKeyRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	var findings []*advisor.Finding
+	// Check inline column-level FKs.
+	for _, col := range stmt.Columns {
+		if col.InlineConstraint != nil && col.InlineConstraint.Type == ast.ConstrForeignKey {
+			findings = append(findings, &advisor.Finding{
+				RuleID:   tableNoForeignKeyID,
+				Severity: advisor.SeverityError,
+				Loc:      col.Loc,
+				Message: fmt.Sprintf(
+					"column %q on table %q must not define a FOREIGN KEY constraint",
+					col.Name.Name, stmt.Name.String(),
+				),
+			})
+		}
+	}
+	// Check table-level FK constraints.
+	for _, c := range stmt.Constraints {
+		if c.Type == ast.ConstrForeignKey {
+			findings = append(findings, &advisor.Finding{
+				RuleID:   tableNoForeignKeyID,
+				Severity: advisor.SeverityError,
+				Loc:      c.Loc,
+				Message: fmt.Sprintf(
+					"table %q must not define a FOREIGN KEY constraint",
+					stmt.Name.String(),
+				),
+			})
+		}
+	}
+	return findings
+}

--- a/snowflake/advisor/rules/table_no_foreign_key_test.go
+++ b/snowflake/advisor/rules/table_no_foreign_key_test.go
@@ -1,0 +1,68 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestTableNoForeignKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "no FK — no findings",
+			sql:       "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(100))",
+			wantCount: 0,
+		},
+		{
+			name:      "inline FK — one finding",
+			sql:       "CREATE TABLE orders (id INT NOT NULL PRIMARY KEY, user_id INT FOREIGN KEY REFERENCES users(id))",
+			wantCount: 1,
+		},
+		{
+			name:      "table-level FK — one finding",
+			sql:       "CREATE TABLE orders (id INT NOT NULL, user_id INT NOT NULL, PRIMARY KEY (id), FOREIGN KEY (user_id) REFERENCES users(id))",
+			wantCount: 1,
+		},
+		{
+			name:      "multiple inline FKs — multiple findings",
+			sql:       "CREATE TABLE orders (id INT NOT NULL, user_id INT FOREIGN KEY REFERENCES users(id), product_id INT FOREIGN KEY REFERENCES products(id))",
+			wantCount: 2,
+		},
+		{
+			name:      "unique constraint — no finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL, email VARCHAR(100) UNIQUE)",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT statement — no findings",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.TableNoForeignKeyRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestTableNoForeignKey_Metadata(t *testing.T) {
+	r := rules.TableNoForeignKeyRule{}
+	if r.ID() != "snowflake.table.no-foreign-key" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/table_require_pk.go
+++ b/snowflake/advisor/rules/table_require_pk.go
@@ -1,0 +1,63 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// TableRequirePKRule requires every persistent CREATE TABLE to define a
+// PRIMARY KEY (inline or table-level).
+//
+// Rule ID:  "snowflake.table.require-pk"
+// Severity: ERROR
+//
+// Exemptions:
+//   - TEMPORARY, TRANSIENT, and VOLATILE tables (scratch tables)
+//   - CREATE TABLE ... AS SELECT (the schema is derived from the query)
+//   - CREATE TABLE ... LIKE source (clone of existing table)
+//   - CREATE TABLE ... CLONE source (time-travel clone)
+type TableRequirePKRule struct{}
+
+const tableRequirePKID = "snowflake.table.require-pk"
+
+// ID implements Rule.
+func (TableRequirePKRule) ID() string { return tableRequirePKID }
+
+// Severity implements Rule.
+func (TableRequirePKRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (TableRequirePKRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	stmt, ok := node.(*ast.CreateTableStmt)
+	if !ok {
+		return nil
+	}
+	// Exempt temporary / transient / volatile tables.
+	if stmt.Temporary || stmt.Transient || stmt.Volatile {
+		return nil
+	}
+	// Exempt derived-table forms that don't define columns explicitly.
+	if stmt.AsSelect != nil || stmt.Like != nil || stmt.Clone != nil {
+		return nil
+	}
+	// Check for an inline PK on any column.
+	for _, col := range stmt.Columns {
+		if col.InlineConstraint != nil && col.InlineConstraint.Type == ast.ConstrPrimaryKey {
+			return nil
+		}
+	}
+	// Check for a table-level PK constraint.
+	for _, c := range stmt.Constraints {
+		if c.Type == ast.ConstrPrimaryKey {
+			return nil
+		}
+	}
+	return []*advisor.Finding{{
+		RuleID:   tableRequirePKID,
+		Severity: advisor.SeverityError,
+		Loc:      stmt.Loc,
+		Message:  fmt.Sprintf("table %q must define a PRIMARY KEY constraint", stmt.Name.String()),
+	}}
+}

--- a/snowflake/advisor/rules/table_require_pk_test.go
+++ b/snowflake/advisor/rules/table_require_pk_test.go
@@ -1,0 +1,83 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestTableRequirePK(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "inline PK — no finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(100))",
+			wantCount: 0,
+		},
+		{
+			name:      "table-level PK — no finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL, name VARCHAR(100), PRIMARY KEY (id))",
+			wantCount: 0,
+		},
+		{
+			name:      "no PK — one finding",
+			sql:       "CREATE TABLE t (id INT NOT NULL, name VARCHAR(100))",
+			wantCount: 1,
+		},
+		{
+			name:      "TEMPORARY table — exempt",
+			sql:       "CREATE TEMPORARY TABLE t (id INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "TRANSIENT table — exempt",
+			sql:       "CREATE TRANSIENT TABLE t (id INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "VOLATILE table — exempt",
+			sql:       "CREATE VOLATILE TABLE t (id INT NOT NULL)",
+			wantCount: 0,
+		},
+		{
+			name:      "AS SELECT — exempt",
+			sql:       "CREATE TABLE t AS SELECT id, name FROM other",
+			wantCount: 0,
+		},
+		{
+			name:      "LIKE — exempt",
+			sql:       "CREATE TABLE t LIKE other_table",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT statement — no finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.TableRequirePKRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestTableRequirePK_Metadata(t *testing.T) {
+	r := rules.TableRequirePKRule{}
+	if r.ID() != "snowflake.table.require-pk" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/where_require_select.go
+++ b/snowflake/advisor/rules/where_require_select.go
@@ -1,0 +1,45 @@
+package rules
+
+import (
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// WhereRequireSelectRule requires every SELECT that reads from a table (has a
+// FROM clause) to also have a WHERE clause.
+//
+// Rule ID:  "snowflake.query.where-require-select"
+// Severity: WARNING
+//
+// Table-less selects (SELECT 1, SELECT CURRENT_TIMESTAMP()) are exempt because
+// they do not read from any table and therefore cannot produce runaway full scans.
+type WhereRequireSelectRule struct{}
+
+const whereRequireSelectID = "snowflake.query.where-require-select"
+
+// ID implements Rule.
+func (WhereRequireSelectRule) ID() string { return whereRequireSelectID }
+
+// Severity implements Rule.
+func (WhereRequireSelectRule) Severity() advisor.Severity { return advisor.SeverityWarning }
+
+// Check implements Rule.
+func (WhereRequireSelectRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	sel, ok := node.(*ast.SelectStmt)
+	if !ok {
+		return nil
+	}
+	// No FROM clause — exempt (table-less select like SELECT 1).
+	if len(sel.From) == 0 {
+		return nil
+	}
+	if sel.Where != nil {
+		return nil
+	}
+	return []*advisor.Finding{{
+		RuleID:   whereRequireSelectID,
+		Severity: advisor.SeverityWarning,
+		Loc:      sel.Loc,
+		Message:  "SELECT without a WHERE clause may produce a full table scan",
+	}}
+}

--- a/snowflake/advisor/rules/where_require_select_test.go
+++ b/snowflake/advisor/rules/where_require_select_test.go
@@ -1,0 +1,78 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestWhereRequireSelect(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "SELECT with WHERE — no finding",
+			sql:       "SELECT a FROM t WHERE id = 1",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT without WHERE — one finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 1,
+		},
+		{
+			name:      "SELECT without FROM (table-less) — no finding",
+			sql:       "SELECT 1",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT CURRENT_TIMESTAMP() — no finding",
+			sql:       "SELECT CURRENT_TIMESTAMP()",
+			wantCount: 0,
+		},
+		{
+			name:      "UNION — two findings (each branch lacks WHERE)",
+			sql:       "SELECT a FROM t1 UNION ALL SELECT b FROM t2",
+			wantCount: 2,
+		},
+		{
+			name:      "UNION — one branch has WHERE — one finding",
+			sql:       "SELECT a FROM t1 WHERE id = 1 UNION ALL SELECT b FROM t2",
+			wantCount: 1,
+		},
+		{
+			name:      "CREATE TABLE — no finding",
+			sql:       "CREATE TABLE t (id INT)",
+			wantCount: 0,
+		},
+		{
+			name:      "SELECT with GROUP BY but no WHERE — one finding",
+			sql:       "SELECT dept, COUNT(*) FROM employees GROUP BY dept",
+			wantCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.WhereRequireSelectRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestWhereRequireSelect_Metadata(t *testing.T) {
+	r := rules.WhereRequireSelectRule{}
+	if r.ID() != "snowflake.query.where-require-select" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityWarning {
+		t.Errorf("Severity() = %v, want WARNING", r.Severity())
+	}
+}

--- a/snowflake/advisor/rules/where_require_update_delete.go
+++ b/snowflake/advisor/rules/where_require_update_delete.go
@@ -1,0 +1,49 @@
+package rules
+
+import (
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// WhereRequireUpdateDeleteRule requires every UPDATE and DELETE statement to
+// include a WHERE clause.
+//
+// Rule ID:  "snowflake.query.where-require-update-delete"
+// Severity: ERROR
+//
+// An UPDATE or DELETE without WHERE modifies or removes all rows in the table,
+// which is almost never the intended behaviour in production migrations.
+type WhereRequireUpdateDeleteRule struct{}
+
+const whereRequireUpdateDeleteID = "snowflake.query.where-require-update-delete"
+
+// ID implements Rule.
+func (WhereRequireUpdateDeleteRule) ID() string { return whereRequireUpdateDeleteID }
+
+// Severity implements Rule.
+func (WhereRequireUpdateDeleteRule) Severity() advisor.Severity { return advisor.SeverityError }
+
+// Check implements Rule.
+func (WhereRequireUpdateDeleteRule) Check(_ *advisor.Context, node ast.Node) []*advisor.Finding {
+	switch n := node.(type) {
+	case *ast.UpdateStmt:
+		if n.Where == nil {
+			return []*advisor.Finding{{
+				RuleID:   whereRequireUpdateDeleteID,
+				Severity: advisor.SeverityError,
+				Loc:      n.Loc,
+				Message:  "UPDATE without a WHERE clause will modify all rows",
+			}}
+		}
+	case *ast.DeleteStmt:
+		if n.Where == nil {
+			return []*advisor.Finding{{
+				RuleID:   whereRequireUpdateDeleteID,
+				Severity: advisor.SeverityError,
+				Loc:      n.Loc,
+				Message:  "DELETE without a WHERE clause will remove all rows",
+			}}
+		}
+	}
+	return nil
+}

--- a/snowflake/advisor/rules/where_require_update_delete_test.go
+++ b/snowflake/advisor/rules/where_require_update_delete_test.go
@@ -1,0 +1,105 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/advisor"
+	"github.com/bytebase/omni/snowflake/advisor/rules"
+)
+
+func TestWhereRequireUpdateDelete(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantCount int
+	}{
+		{
+			name:      "UPDATE with WHERE — no finding",
+			sql:       "UPDATE t SET name = 'x' WHERE id = 1",
+			wantCount: 0,
+		},
+		{
+			name:      "UPDATE without WHERE — one finding",
+			sql:       "UPDATE t SET name = 'x'",
+			wantCount: 1,
+		},
+		{
+			name:      "DELETE with WHERE — no finding",
+			sql:       "DELETE FROM t WHERE id = 1",
+			wantCount: 0,
+		},
+		{
+			name:      "DELETE without WHERE — one finding",
+			sql:       "DELETE FROM t",
+			wantCount: 1,
+		},
+		{
+			name:      "SELECT — no finding",
+			sql:       "SELECT a FROM t",
+			wantCount: 0,
+		},
+		{
+			name:      "CREATE TABLE — no finding",
+			sql:       "CREATE TABLE t (id INT)",
+			wantCount: 0,
+		},
+		{
+			name:      "UPDATE with complex WHERE — no finding",
+			sql:       "UPDATE t SET status = 'active' WHERE created_at > '2024-01-01' AND status = 'pending'",
+			wantCount: 0,
+		},
+		{
+			name:      "DELETE with subquery WHERE — no finding",
+			sql:       "DELETE FROM t WHERE id IN (SELECT id FROM other WHERE flag = true)",
+			wantCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.WhereRequireUpdateDeleteRule{})
+			if len(findings) != tt.wantCount {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantCount)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestWhereRequireUpdateDelete_Metadata(t *testing.T) {
+	r := rules.WhereRequireUpdateDeleteRule{}
+	if r.ID() != "snowflake.query.where-require-update-delete" {
+		t.Errorf("ID() = %q", r.ID())
+	}
+	if r.Severity() != advisor.SeverityError {
+		t.Errorf("Severity() = %v, want ERROR", r.Severity())
+	}
+}
+
+func TestWhereRequireUpdateDelete_FindingMessages(t *testing.T) {
+	tests := []struct {
+		sql     string
+		wantMsg string
+	}{
+		{
+			sql:     "UPDATE t SET a = 1",
+			wantMsg: "UPDATE without a WHERE clause will modify all rows",
+		},
+		{
+			sql:     "DELETE FROM t",
+			wantMsg: "DELETE without a WHERE clause will remove all rows",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			findings := runRule(t, tt.sql, rules.WhereRequireUpdateDeleteRule{})
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(findings))
+			}
+			if findings[0].Message != tt.wantMsg {
+				t.Errorf("Message = %q, want %q", findings[0].Message, tt.wantMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implements all 14 production lint rules for the Snowflake advisor framework (T2.7), housed in `snowflake/advisor/rules/`
- Each rule implements the `advisor.Rule` interface from T2.6, type-asserts on the relevant AST node kind, and returns zero or more `*advisor.Finding` values
- Rules with configuration use constructor functions (`NewRuleXxx(cfg)`) to avoid global state; stateless rules use zero-value structs

## Rules implemented

| Rule ID | Severity | Description |
|---------|----------|-------------|
| `snowflake.column.no-null` | ERROR | Every non-virtual column must have NOT NULL |
| `snowflake.column.require` | ERROR | Configured column names must exist on every table |
| `snowflake.column.maximum-varchar-length` | ERROR | VARCHAR/CHAR length ≤ configured max (default 1024) |
| `snowflake.table.require-pk` | ERROR | Persistent CREATE TABLE must define a PRIMARY KEY |
| `snowflake.table.no-foreign-key` | ERROR | No FOREIGN KEY constraints (inline or table-level) |
| `snowflake.naming.table` | WARNING | Table name must match regex (default `^[a-z][a-z0-9_]{0,63}$`) |
| `snowflake.naming.table-no-keyword` | ERROR | Unquoted table name must not be a reserved keyword |
| `snowflake.naming.identifier-case` | WARNING | Identifiers match LOWER/UPPER/CAMEL convention |
| `snowflake.naming.identifier-no-keyword` | ERROR | Unquoted identifiers must not be reserved keywords |
| `snowflake.select.no-select-all` | ERROR | SELECT * (bare star) not allowed; qualified `t.*` exempt |
| `snowflake.query.where-require-select` | WARNING | SELECT with FROM must have WHERE (table-less selects exempt) |
| `snowflake.query.where-require-update-delete` | ERROR | UPDATE/DELETE must have WHERE clause |
| `snowflake.migration.compatibility` | ERROR | Forbids DROP TABLE and ALTER TABLE DROP COLUMN |
| `snowflake.table.drop-naming-convention` | WARNING | DROP TABLE target must match archival regex (default `^_deleted$\|^deleted_`) |

## Design decisions

- `naming_identifier_no_keyword`: The Snowflake parser itself rejects reserved keywords in most identifier positions (column names, table aliases), so this rule's primary value is defensive (programmatic AST construction, future parser relaxation). Tests cover it via direct AST node injection.
- `table_require_pk`: TEMPORARY, TRANSIENT, and VOLATILE tables are exempt; `AS SELECT / LIKE / CLONE` forms are also exempt since the schema is derived.
- `column_no_null`: Virtual columns (`WITH AS expr`) are always exempt — Snowflake does not allow NOT NULL on computed columns.
- Inline FK syntax: `col TYPE FOREIGN KEY REFERENCES table(col)` — not the shorthand `REFERENCES` form.

## Test plan

- [ ] 55 tests across 14 rule files + 1 integration file all pass
- [ ] `go test ./snowflake/... -count=1` passes clean
- [ ] Integration tests: `TestIntegration_EachRuleFiresOnItsOwnTrigger` (14 subtests), `TestIntegration_AllRulesNoFalsePositive`, `TestIntegration_AllRulesCount`, `TestIntegration_MixedStatements`

🤖 Generated with [Claude Code](https://claude.com/claude-code)