### PR TITLE
feat(doris): Materialized Views MTMV (T5.1)

### DIFF
--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -124,6 +124,22 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *MergeClause:
 		return v.Loc
+	case *MTMVRefreshTrigger:
+		return v.Loc
+	case *CreateMTMVStmt:
+		return v.Loc
+	case *AlterMTMVStmt:
+		return v.Loc
+	case *DropMTMVStmt:
+		return v.Loc
+	case *RefreshMTMVStmt:
+		return v.Loc
+	case *PauseMTMVJobStmt:
+		return v.Loc
+	case *ResumeMTMVJobStmt:
+		return v.Loc
+	case *CancelMTMVTaskStmt:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/doris/ast/mtmv.go
+++ b/doris/ast/mtmv.go
@@ -1,0 +1,174 @@
+package ast
+
+// This file holds AST node types for Doris Materialized View (MTMV) DDL (T5.1).
+//
+// Doris supports two kinds of materialized views:
+//   - Sync materialized views (CREATE MATERIALIZED VIEW ... AS SELECT ...)
+//     that refresh synchronously with DML and are attached to a base table.
+//   - Async (MTMV) materialized views that have explicit refresh scheduling.
+//
+// The nodes here cover both variants.
+
+// ---------------------------------------------------------------------------
+// CREATE MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// MTMVRefreshTrigger represents the ON SCHEDULE / ON COMMIT / ON MANUAL
+// trigger clause in CREATE MATERIALIZED VIEW.
+type MTMVRefreshTrigger struct {
+	OnManual   bool
+	OnCommit   bool
+	OnSchedule bool
+	Interval   string // raw interval text, e.g., "1 DAY"
+	StartsAt   string // optional STARTS timestamp string literal value
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *MTMVRefreshTrigger) Tag() NodeTag { return T_MTMVRefreshTrigger }
+
+var _ Node = (*MTMVRefreshTrigger)(nil)
+
+// CreateMTMVStmt represents:
+//
+//	CREATE MATERIALIZED VIEW [IF NOT EXISTS] mv_name
+//	    [BUILD IMMEDIATE | DEFERRED]
+//	    [REFRESH COMPLETE | AUTO | NEVER | INCREMENTAL]
+//	    [(col_def, ...)]
+//	    [COMMENT 'text']
+//	    [PARTITION BY ...]
+//	    [DISTRIBUTED BY ...]
+//	    [ON SCHEDULE EVERY interval [STARTS ts] | ON COMMIT | ON MANUAL]
+//	    [PROPERTIES (...)]
+//	    AS query
+type CreateMTMVStmt struct {
+	Name           *ObjectName
+	IfNotExists    bool
+	BuildMode      string             // "IMMEDIATE", "DEFERRED", or ""
+	RefreshMethod  string             // "COMPLETE", "AUTO", "NEVER", "INCREMENTAL", or ""
+	RefreshTrigger *MTMVRefreshTrigger // ON SCHEDULE / ON COMMIT / ON MANUAL
+	Columns        []*ViewColumn      // optional column list
+	Comment        string
+	PartitionBy    *PartitionDesc
+	DistributedBy  *DistributionDesc
+	Properties     []*Property
+	Query          Node // *SelectStmt or *SetOpStmt
+	Loc            Loc
+}
+
+// Tag implements Node.
+func (n *CreateMTMVStmt) Tag() NodeTag { return T_CreateMTMVStmt }
+
+var _ Node = (*CreateMTMVStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// ALTER MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// AlterMTMVStmt represents:
+//
+//	ALTER MATERIALIZED VIEW mv_name
+//	    { RENAME new_name
+//	    | REFRESH method
+//	    | REPLACE WITH MATERIALIZED VIEW other_mv
+//	    | SET PROPERTIES (...) }
+type AlterMTMVStmt struct {
+	Name          *ObjectName
+	NewName       *ObjectName // for RENAME
+	RefreshMethod string      // for REFRESH method change
+	Replace       bool        // REPLACE WITH MATERIALIZED VIEW
+	ReplaceTarget *ObjectName // the other MV for REPLACE WITH
+	Properties    []*Property // for SET PROPERTIES
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *AlterMTMVStmt) Tag() NodeTag { return T_AlterMTMVStmt }
+
+var _ Node = (*AlterMTMVStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// DROP MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// DropMTMVStmt represents:
+//
+//	DROP MATERIALIZED VIEW [IF EXISTS] mv_name [ON base_table]
+type DropMTMVStmt struct {
+	Name     *ObjectName
+	IfExists bool
+	OnBase   *ObjectName // for sync MV: ON base_table
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *DropMTMVStmt) Tag() NodeTag { return T_DropMTMVStmt }
+
+var _ Node = (*DropMTMVStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// REFRESH MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// RefreshMTMVStmt represents:
+//
+//	REFRESH MATERIALIZED VIEW mv_name [COMPLETE | AUTO | PARTITIONS(p1, p2, ...)]
+type RefreshMTMVStmt struct {
+	Name       *ObjectName
+	Mode       string   // "COMPLETE", "AUTO", or ""
+	Partitions []string // partition names when PARTITIONS(...) specified
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *RefreshMTMVStmt) Tag() NodeTag { return T_RefreshMTMVStmt }
+
+var _ Node = (*RefreshMTMVStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// PAUSE / RESUME MATERIALIZED VIEW JOB
+// ---------------------------------------------------------------------------
+
+// PauseMTMVJobStmt represents:
+//
+//	PAUSE MATERIALIZED VIEW JOB ON mv_name
+type PauseMTMVJobStmt struct {
+	Name *ObjectName // the MV name after ON
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *PauseMTMVJobStmt) Tag() NodeTag { return T_PauseMTMVJobStmt }
+
+var _ Node = (*PauseMTMVJobStmt)(nil)
+
+// ResumeMTMVJobStmt represents:
+//
+//	RESUME MATERIALIZED VIEW JOB ON mv_name
+type ResumeMTMVJobStmt struct {
+	Name *ObjectName // the MV name after ON
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ResumeMTMVJobStmt) Tag() NodeTag { return T_ResumeMTMVJobStmt }
+
+var _ Node = (*ResumeMTMVJobStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// CANCEL MATERIALIZED VIEW TASK
+// ---------------------------------------------------------------------------
+
+// CancelMTMVTaskStmt represents:
+//
+//	CANCEL MATERIALIZED VIEW TASK task_id ON mv_name
+type CancelMTMVTaskStmt struct {
+	TaskID int64
+	Name   *ObjectName // the MV name after ON
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *CancelMTMVTaskStmt) Tag() NodeTag { return T_CancelMTMVTaskStmt }
+
+var _ Node = (*CancelMTMVTaskStmt)(nil)

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -206,6 +206,32 @@ const (
 
 	// T_MergeClause is the tag for *MergeClause (one WHEN clause inside MERGE).
 	T_MergeClause
+
+	// DDL — Materialized View nodes (T5.1).
+
+	// T_MTMVRefreshTrigger is the tag for *MTMVRefreshTrigger.
+	T_MTMVRefreshTrigger
+
+	// T_CreateMTMVStmt is the tag for *CreateMTMVStmt.
+	T_CreateMTMVStmt
+
+	// T_AlterMTMVStmt is the tag for *AlterMTMVStmt.
+	T_AlterMTMVStmt
+
+	// T_DropMTMVStmt is the tag for *DropMTMVStmt.
+	T_DropMTMVStmt
+
+	// T_RefreshMTMVStmt is the tag for *RefreshMTMVStmt.
+	T_RefreshMTMVStmt
+
+	// T_PauseMTMVJobStmt is the tag for *PauseMTMVJobStmt.
+	T_PauseMTMVJobStmt
+
+	// T_ResumeMTMVJobStmt is the tag for *ResumeMTMVJobStmt.
+	T_ResumeMTMVJobStmt
+
+	// T_CancelMTMVTaskStmt is the tag for *CancelMTMVTaskStmt.
+	T_CancelMTMVTaskStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -327,6 +353,22 @@ func (t NodeTag) String() string {
 		return "MergeStmt"
 	case T_MergeClause:
 		return "MergeClause"
+	case T_MTMVRefreshTrigger:
+		return "MTMVRefreshTrigger"
+	case T_CreateMTMVStmt:
+		return "CreateMTMVStmt"
+	case T_AlterMTMVStmt:
+		return "AlterMTMVStmt"
+	case T_DropMTMVStmt:
+		return "DropMTMVStmt"
+	case T_RefreshMTMVStmt:
+		return "RefreshMTMVStmt"
+	case T_PauseMTMVJobStmt:
+		return "PauseMTMVJobStmt"
+	case T_ResumeMTMVJobStmt:
+		return "ResumeMTMVJobStmt"
+	case T_CancelMTMVTaskStmt:
+		return "CancelMTMVTaskStmt"
 	default:
 		return "Unknown"
 	}

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -348,5 +348,66 @@ func walkChildren(v Visitor, node Node) {
 				Walk(v, val)
 			}
 		}
+
+	// DDL — Materialized View nodes (T5.1).
+	case *MTMVRefreshTrigger:
+		// leaf-ish node, no Node children
+
+	case *CreateMTMVStmt:
+		Walk(v, n.Name)
+		for _, col := range n.Columns {
+			Walk(v, col)
+		}
+		if n.RefreshTrigger != nil {
+			Walk(v, n.RefreshTrigger)
+		}
+		if n.PartitionBy != nil {
+			Walk(v, n.PartitionBy)
+		}
+		if n.DistributedBy != nil {
+			Walk(v, n.DistributedBy)
+		}
+		for _, prop := range n.Properties {
+			Walk(v, prop)
+		}
+		if n.Query != nil {
+			Walk(v, n.Query)
+		}
+
+	case *AlterMTMVStmt:
+		Walk(v, n.Name)
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
+		if n.ReplaceTarget != nil {
+			Walk(v, n.ReplaceTarget)
+		}
+		for _, prop := range n.Properties {
+			Walk(v, prop)
+		}
+
+	case *DropMTMVStmt:
+		Walk(v, n.Name)
+		if n.OnBase != nil {
+			Walk(v, n.OnBase)
+		}
+
+	case *RefreshMTMVStmt:
+		Walk(v, n.Name)
+
+	case *PauseMTMVJobStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+
+	case *ResumeMTMVJobStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+
+	case *CancelMTMVTaskStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	}
 }

--- a/doris/parser/mtmv.go
+++ b/doris/parser/mtmv.go
@@ -1,0 +1,619 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// parseCreateMTMV parses a CREATE MATERIALIZED VIEW statement.
+// On entry, CREATE has been consumed and cur is MATERIALIZED.
+//
+// Syntax:
+//
+//	CREATE MATERIALIZED VIEW [IF NOT EXISTS] mv_name
+//	    [BUILD IMMEDIATE | DEFERRED]
+//	    [REFRESH COMPLETE | AUTO | NEVER | INCREMENTAL]
+//	    [(col_name [COMMENT 'text'], ...)]
+//	    [COMMENT 'text']
+//	    [PARTITION BY ...]
+//	    [DISTRIBUTED BY ...]
+//	    [ON SCHEDULE EVERY interval [STARTS ts] | ON COMMIT | ON MANUAL]
+//	    [PROPERTIES (...)]
+//	    AS query
+func (p *Parser) parseCreateMTMV(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateMTMVStmt{}
+
+	// Optional IF NOT EXISTS
+	if p.cur.Kind == kwIF {
+		p.advance() // consume IF
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
+	// MV name
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Parse optional clauses in a tolerant loop until we see AS or EOF.
+	// Clauses can appear in any order per Doris docs.
+	for p.cur.Kind != kwAS && p.cur.Kind != tokEOF {
+		switch p.cur.Kind {
+		case kwBUILD:
+			// BUILD IMMEDIATE | DEFERRED
+			p.advance() // consume BUILD
+			switch p.cur.Kind {
+			case kwIMMEDIATE:
+				stmt.BuildMode = "IMMEDIATE"
+				p.advance()
+			case kwDEFERRED:
+				stmt.BuildMode = "DEFERRED"
+				p.advance()
+			default:
+				// tolerate unknown token after BUILD
+				stmt.BuildMode = strings.ToUpper(p.cur.Str)
+				p.advance()
+			}
+
+		case kwREFRESH:
+			// REFRESH COMPLETE | AUTO | NEVER | INCREMENTAL
+			p.advance() // consume REFRESH
+			switch p.cur.Kind {
+			case kwCOMPLETE:
+				stmt.RefreshMethod = "COMPLETE"
+				p.advance()
+			case kwAUTO:
+				stmt.RefreshMethod = "AUTO"
+				p.advance()
+			case kwNEVER:
+				stmt.RefreshMethod = "NEVER"
+				p.advance()
+			case kwINCREMENTAL:
+				stmt.RefreshMethod = "INCREMENTAL"
+				p.advance()
+			default:
+				// tolerate unknown
+				stmt.RefreshMethod = strings.ToUpper(p.cur.Str)
+				p.advance()
+			}
+
+		case kwON:
+			// ON SCHEDULE EVERY interval [STARTS ts]
+			// ON COMMIT
+			// ON MANUAL
+			trigger, err := p.parseMTMVRefreshTrigger()
+			if err != nil {
+				return nil, err
+			}
+			stmt.RefreshTrigger = trigger
+
+		case int('('):
+			// Optional column list: (col_name [COMMENT 'text'], ...)
+			cols, err := p.parseViewColumns()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Columns = cols
+
+		case kwCOMMENT:
+			p.advance() // consume COMMENT
+			if p.cur.Kind != tokString {
+				return nil, p.syntaxErrorAtCur()
+			}
+			stmt.Comment = p.cur.Str
+			p.advance()
+
+		case kwPARTITION:
+			partDesc, err := p.parsePartitionBy()
+			if err != nil {
+				return nil, err
+			}
+			stmt.PartitionBy = partDesc
+
+		case kwAUTO:
+			// AUTO PARTITION BY ...
+			partDesc, err := p.parsePartitionBy()
+			if err != nil {
+				return nil, err
+			}
+			stmt.PartitionBy = partDesc
+
+		case kwDISTRIBUTED:
+			distDesc, err := p.parseDistributedBy()
+			if err != nil {
+				return nil, err
+			}
+			stmt.DistributedBy = distDesc
+
+		case kwPROPERTIES:
+			props, err := p.parseProperties()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Properties = props
+
+		default:
+			// Tolerate unknown tokens — advance to avoid infinite loop.
+			p.advance()
+		}
+	}
+
+	// AS keyword is required
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+
+	// Query — SELECT or WITH ... SELECT or set operation
+	var queryNode ast.Node
+	if p.cur.Kind == kwWITH {
+		wq, err := p.parseWithSelect()
+		if err != nil {
+			return nil, err
+		}
+		queryNode = wq
+	} else {
+		query, err := p.parseSelectStmt()
+		if err != nil {
+			return nil, err
+		}
+		queryNode, err = p.parseSetOpTail(query)
+		if err != nil {
+			return nil, err
+		}
+	}
+	stmt.Query = queryNode
+
+	stmt.Loc = startLoc.Merge(ast.NodeLoc(stmt.Query))
+	return stmt, nil
+}
+
+// parseMTMVRefreshTrigger parses the ON clause of CREATE MATERIALIZED VIEW:
+//
+//	ON SCHEDULE EVERY interval [STARTS timestamp]
+//	ON COMMIT
+//	ON MANUAL
+//
+// cur is ON on entry; ON is consumed here.
+func (p *Parser) parseMTMVRefreshTrigger() (*ast.MTMVRefreshTrigger, error) {
+	startLoc := p.cur.Loc
+	p.advance() // consume ON
+
+	trigger := &ast.MTMVRefreshTrigger{Loc: startLoc}
+
+	switch p.cur.Kind {
+	case kwSCHEDULE:
+		trigger.OnSchedule = true
+		p.advance() // consume SCHEDULE
+
+		// EVERY interval_expr
+		if _, err := p.expect(kwEVERY); err != nil {
+			return nil, err
+		}
+
+		// Collect interval: integer + unit keyword (e.g., "1 DAY")
+		// The interval is stored as raw text.
+		intervalStart := p.cur.Loc.Start
+		var parts []string
+		// First token should be an integer
+		if p.cur.Kind == tokInt {
+			parts = append(parts, p.cur.Str)
+			p.advance()
+		}
+		// Unit keyword (DAY, HOUR, MINUTE, SECOND, WEEK, MONTH, YEAR, etc.)
+		if p.cur.Kind >= 700 || p.cur.Kind == tokIdent {
+			parts = append(parts, strings.ToUpper(p.cur.Str))
+			p.advance()
+		}
+		if len(parts) > 0 {
+			trigger.Interval = strings.Join(parts, " ")
+		}
+		_ = intervalStart
+
+		// Optional STARTS timestamp_string
+		if p.cur.Kind == kwSTARTS {
+			p.advance() // consume STARTS
+			if p.cur.Kind != tokString {
+				return nil, p.syntaxErrorAtCur()
+			}
+			trigger.StartsAt = p.cur.Str
+			trigger.Loc.End = p.cur.Loc.End
+			p.advance()
+		}
+
+	case kwCOMMIT:
+		trigger.OnCommit = true
+		trigger.Loc.End = p.cur.Loc.End
+		p.advance()
+
+	case kwMANUAL:
+		trigger.OnManual = true
+		trigger.Loc.End = p.cur.Loc.End
+		p.advance()
+
+	default:
+		// Tolerate unknown ON clause variant.
+		trigger.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+
+	return trigger, nil
+}
+
+// parseAlterMTMV parses an ALTER MATERIALIZED VIEW statement.
+// On entry, ALTER has been consumed and cur is MATERIALIZED.
+//
+// Syntax:
+//
+//	ALTER MATERIALIZED VIEW mv_name
+//	    { RENAME new_name
+//	    | REFRESH new_method
+//	    | REPLACE WITH MATERIALIZED VIEW other_mv
+//	    | SET PROPERTIES (...) }
+func (p *Parser) parseAlterMTMV(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.AlterMTMVStmt{}
+
+	// MV name
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action
+	switch p.cur.Kind {
+	case kwRENAME:
+		p.advance() // consume RENAME
+		newName, err := p.parseMultipartIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.NewName = newName
+		stmt.Loc = startLoc.Merge(ast.NodeLoc(newName))
+
+	case kwREFRESH:
+		p.advance() // consume REFRESH
+		switch p.cur.Kind {
+		case kwCOMPLETE:
+			stmt.RefreshMethod = "COMPLETE"
+		case kwAUTO:
+			stmt.RefreshMethod = "AUTO"
+		case kwNEVER:
+			stmt.RefreshMethod = "NEVER"
+		case kwINCREMENTAL:
+			stmt.RefreshMethod = "INCREMENTAL"
+		default:
+			stmt.RefreshMethod = strings.ToUpper(p.cur.Str)
+		}
+		stmt.Loc = startLoc.Merge(p.cur.Loc)
+		p.advance()
+
+	case kwREPLACE:
+		// REPLACE WITH MATERIALIZED VIEW other_mv
+		p.advance() // consume REPLACE
+		if _, err := p.expect(kwWITH); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwMATERIALIZED); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwVIEW); err != nil {
+			return nil, err
+		}
+		target, err := p.parseMultipartIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Replace = true
+		stmt.ReplaceTarget = target
+		stmt.Loc = startLoc.Merge(ast.NodeLoc(target))
+
+	case kwSET:
+		p.advance() // consume SET
+		// SET ("key"="val", ...) — parse the parenthesised key=value list directly.
+		props, err := p.parseMTMVPropertyList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Properties = props
+		stmt.Loc = startLoc.Merge(p.prev.Loc)
+
+	default:
+		stmt.Loc = startLoc.Merge(p.cur.Loc)
+	}
+
+	return stmt, nil
+}
+
+// parseDropMTMV parses a DROP MATERIALIZED VIEW statement.
+// On entry, DROP has been consumed and cur is MATERIALIZED.
+//
+// Syntax:
+//
+//	DROP MATERIALIZED VIEW [IF EXISTS] mv_name [ON base_table]
+func (p *Parser) parseDropMTMV(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.DropMTMVStmt{}
+
+	// Optional IF EXISTS
+	if p.cur.Kind == kwIF {
+		p.advance() // consume IF
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		stmt.IfExists = true
+	}
+
+	// MV name
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc = startLoc.Merge(ast.NodeLoc(name))
+
+	// Optional ON base_table (for sync MVs)
+	if p.cur.Kind == kwON {
+		p.advance() // consume ON
+		baseName, err := p.parseMultipartIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.OnBase = baseName
+		stmt.Loc = startLoc.Merge(ast.NodeLoc(baseName))
+	}
+
+	return stmt, nil
+}
+
+// parseRefreshMTMV parses a REFRESH MATERIALIZED VIEW statement.
+// On entry, REFRESH has been consumed and cur is MATERIALIZED.
+//
+// Syntax:
+//
+//	REFRESH MATERIALIZED VIEW mv_name [COMPLETE | AUTO | PARTITIONS(p1, p2, ...)]
+func (p *Parser) parseRefreshMTMV(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.RefreshMTMVStmt{}
+
+	// MV name
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc = startLoc.Merge(ast.NodeLoc(name))
+
+	// Optional mode or PARTITIONS
+	switch p.cur.Kind {
+	case kwCOMPLETE:
+		stmt.Mode = "COMPLETE"
+		stmt.Loc.End = p.cur.Loc.End
+		p.advance()
+	case kwAUTO:
+		stmt.Mode = "AUTO"
+		stmt.Loc.End = p.cur.Loc.End
+		p.advance()
+	case kwPARTITIONS:
+		p.advance() // consume PARTITIONS
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		// Parse comma-separated partition names
+		for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+			partName, _, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Partitions = append(stmt.Partitions, partName)
+			if p.cur.Kind == int(',') {
+				p.advance()
+			}
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		stmt.Loc.End = closeTok.Loc.End
+	}
+
+	return stmt, nil
+}
+
+// parsePauseMTMVJob parses a PAUSE MATERIALIZED VIEW JOB ON mv_name statement.
+// On entry, PAUSE has been consumed and cur is MATERIALIZED.
+func (p *Parser) parsePauseMTMVJob(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	// Consume JOB
+	if _, err := p.expect(kwJOB); err != nil {
+		return nil, err
+	}
+	// Consume ON
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.PauseMTMVJobStmt{}
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc = startLoc.Merge(ast.NodeLoc(name))
+	return stmt, nil
+}
+
+// parseResumeMTMVJob parses a RESUME MATERIALIZED VIEW JOB ON mv_name statement.
+// On entry, RESUME has been consumed and cur is MATERIALIZED.
+func (p *Parser) parseResumeMTMVJob(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	// Consume JOB
+	if _, err := p.expect(kwJOB); err != nil {
+		return nil, err
+	}
+	// Consume ON
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.ResumeMTMVJobStmt{}
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc = startLoc.Merge(ast.NodeLoc(name))
+	return stmt, nil
+}
+
+// parseMTMVPropertyList parses a parenthesised key=value list:
+//
+//	( "key" = "val" [, "key" = "val"] ... )
+//
+// cur must be '(' on entry. Used for ALTER MATERIALIZED VIEW ... SET (...).
+func (p *Parser) parseMTMVPropertyList() ([]*ast.Property, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	var props []*ast.Property
+
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		startLoc := p.cur.Loc
+
+		// Key — string literal or bare identifier
+		var key string
+		if p.cur.Kind == tokString {
+			key = p.cur.Str
+			p.advance()
+		} else {
+			var err error
+			key, _, err = p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// '='
+		if _, err := p.expect(int('=')); err != nil {
+			return nil, err
+		}
+
+		// Value — string literal
+		if p.cur.Kind != tokString {
+			return nil, p.syntaxErrorAtCur()
+		}
+		val := p.cur.Str
+		endLoc := p.cur.Loc
+		p.advance()
+
+		props = append(props, &ast.Property{
+			Key:   key,
+			Value: val,
+			Loc:   ast.Loc{Start: startLoc.Start, End: endLoc.End},
+		})
+
+		if p.cur.Kind == int(',') {
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	return props, nil
+}
+
+// parseCancelMTMVTask parses a CANCEL MATERIALIZED VIEW TASK task_id ON mv_name statement.
+// On entry, CANCEL has been consumed and cur is MATERIALIZED.
+func (p *Parser) parseCancelMTMVTask(startLoc ast.Loc) (ast.Node, error) {
+	// Consume MATERIALIZED
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	// Consume VIEW
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	// Consume TASK
+	if _, err := p.expect(kwTASK); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CancelMTMVTaskStmt{}
+
+	// task_id — integer
+	if p.cur.Kind != tokInt {
+		return nil, p.syntaxErrorAtCur()
+	}
+	stmt.TaskID = p.cur.Ival
+	p.advance()
+
+	// ON mv_name
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	name, err := p.parseMultipartIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc = startLoc.Merge(ast.NodeLoc(name))
+	return stmt, nil
+}

--- a/doris/parser/mtmv_test.go
+++ b/doris/parser/mtmv_test.go
@@ -1,0 +1,592 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func parseCreateMTMVStmt(t *testing.T, sql string) *ast.CreateMTMVStmt {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d stmts, want 1", sql, len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.CreateMTMVStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateMTMVStmt, got %T", file.Stmts[0])
+	}
+	return stmt
+}
+
+func parseAlterMTMVStmt(t *testing.T, sql string) *ast.AlterMTMVStmt {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d stmts, want 1", sql, len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.AlterMTMVStmt)
+	if !ok {
+		t.Fatalf("expected *ast.AlterMTMVStmt, got %T", file.Stmts[0])
+	}
+	return stmt
+}
+
+func parseDropMTMVStmt(t *testing.T, sql string) *ast.DropMTMVStmt {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d stmts, want 1", sql, len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.DropMTMVStmt)
+	if !ok {
+		t.Fatalf("expected *ast.DropMTMVStmt, got %T", file.Stmts[0])
+	}
+	return stmt
+}
+
+func parseRefreshMTMVStmt(t *testing.T, sql string) *ast.RefreshMTMVStmt {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): got %d stmts, want 1", sql, len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.RefreshMTMVStmt)
+	if !ok {
+		t.Fatalf("expected *ast.RefreshMTMVStmt, got %T", file.Stmts[0])
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// CREATE MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+func TestCreateMTMV_Minimal(t *testing.T) {
+	stmt := parseCreateMTMVStmt(t, "CREATE MATERIALIZED VIEW mv AS SELECT * FROM t")
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "mv")
+	}
+	if stmt.IfNotExists {
+		t.Error("IfNotExists should be false")
+	}
+	if stmt.BuildMode != "" {
+		t.Errorf("BuildMode = %q, want empty", stmt.BuildMode)
+	}
+	if stmt.RefreshMethod != "" {
+		t.Errorf("RefreshMethod = %q, want empty", stmt.RefreshMethod)
+	}
+	if stmt.Query == nil {
+		t.Fatal("Query is nil")
+	}
+}
+
+func TestCreateMTMV_IfNotExists(t *testing.T) {
+	stmt := parseCreateMTMVStmt(t, "CREATE MATERIALIZED VIEW IF NOT EXISTS mv AS SELECT id FROM t")
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists should be true")
+	}
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "mv")
+	}
+}
+
+func TestCreateMTMV_BuildImmediate_RefreshAuto(t *testing.T) {
+	stmt := parseCreateMTMVStmt(t,
+		"CREATE MATERIALIZED VIEW IF NOT EXISTS mv BUILD IMMEDIATE REFRESH AUTO AS SELECT id FROM t")
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists should be true")
+	}
+	if stmt.BuildMode != "IMMEDIATE" {
+		t.Errorf("BuildMode = %q, want IMMEDIATE", stmt.BuildMode)
+	}
+	if stmt.RefreshMethod != "AUTO" {
+		t.Errorf("RefreshMethod = %q, want AUTO", stmt.RefreshMethod)
+	}
+	if stmt.Query == nil {
+		t.Fatal("Query is nil")
+	}
+}
+
+func TestCreateMTMV_RefreshComplete_OnSchedule(t *testing.T) {
+	sql := "CREATE MATERIALIZED VIEW mv REFRESH COMPLETE ON SCHEDULE EVERY 1 DAY AS SELECT * FROM t"
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want %q", stmt.Name.String(), "mv")
+	}
+	if stmt.RefreshMethod != "COMPLETE" {
+		t.Errorf("RefreshMethod = %q, want COMPLETE", stmt.RefreshMethod)
+	}
+	if stmt.RefreshTrigger == nil {
+		t.Fatal("RefreshTrigger is nil")
+	}
+	if !stmt.RefreshTrigger.OnSchedule {
+		t.Error("RefreshTrigger.OnSchedule should be true")
+	}
+	if stmt.RefreshTrigger.Interval != "1 DAY" {
+		t.Errorf("Interval = %q, want %q", stmt.RefreshTrigger.Interval, "1 DAY")
+	}
+}
+
+func TestCreateMTMV_OnSchedule_WithStarts(t *testing.T) {
+	sql := `CREATE MATERIALIZED VIEW mv BUILD IMMEDIATE REFRESH AUTO ON SCHEDULE EVERY 1 DAY STARTS '2024-12-01 20:30:00' DISTRIBUTED BY HASH(orderkey) BUCKETS 2 PROPERTIES("replication_num" = "1") AS SELECT id FROM t`
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.BuildMode != "IMMEDIATE" {
+		t.Errorf("BuildMode = %q, want IMMEDIATE", stmt.BuildMode)
+	}
+	if stmt.RefreshMethod != "AUTO" {
+		t.Errorf("RefreshMethod = %q, want AUTO", stmt.RefreshMethod)
+	}
+	if stmt.RefreshTrigger == nil {
+		t.Fatal("RefreshTrigger is nil")
+	}
+	if stmt.RefreshTrigger.StartsAt != "2024-12-01 20:30:00" {
+		t.Errorf("StartsAt = %q, want %q", stmt.RefreshTrigger.StartsAt, "2024-12-01 20:30:00")
+	}
+	if stmt.DistributedBy == nil {
+		t.Fatal("DistributedBy is nil")
+	}
+	if stmt.DistributedBy.Type != "HASH" {
+		t.Errorf("DistributedBy.Type = %q, want HASH", stmt.DistributedBy.Type)
+	}
+	if stmt.DistributedBy.Buckets != 2 {
+		t.Errorf("DistributedBy.Buckets = %d, want 2", stmt.DistributedBy.Buckets)
+	}
+	if len(stmt.Properties) != 1 {
+		t.Fatalf("Properties: got %d, want 1", len(stmt.Properties))
+	}
+	if stmt.Properties[0].Key != "replication_num" || stmt.Properties[0].Value != "1" {
+		t.Errorf("Properties[0] = {%q: %q}, want {replication_num: 1}",
+			stmt.Properties[0].Key, stmt.Properties[0].Value)
+	}
+}
+
+func TestCreateMTMV_WithColumnList(t *testing.T) {
+	sql := `CREATE MATERIALIZED VIEW complete_mv (orderdate COMMENT 'Order date', orderkey COMMENT 'Order key', partkey COMMENT 'Part key') BUILD IMMEDIATE REFRESH AUTO ON SCHEDULE EVERY 1 DAY STARTS '2024-12-01 20:30:00' DISTRIBUTED BY HASH(orderkey) BUCKETS 2 PROPERTIES("replication_num" = "1") AS SELECT o_orderdate, l_orderkey, l_partkey FROM orders`
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.Name.String() != "complete_mv" {
+		t.Errorf("Name = %q, want complete_mv", stmt.Name.String())
+	}
+	if len(stmt.Columns) != 3 {
+		t.Fatalf("Columns: got %d, want 3", len(stmt.Columns))
+	}
+	if stmt.Columns[0].Name != "orderdate" {
+		t.Errorf("Columns[0].Name = %q, want orderdate", stmt.Columns[0].Name)
+	}
+	if stmt.Columns[0].Comment != "Order date" {
+		t.Errorf("Columns[0].Comment = %q, want 'Order date'", stmt.Columns[0].Comment)
+	}
+}
+
+func TestCreateMTMV_WithPartitionBy(t *testing.T) {
+	sql := `CREATE MATERIALIZED VIEW partition_mv BUILD IMMEDIATE REFRESH AUTO ON SCHEDULE EVERY 1 DAY STARTS '2024-12-01 20:30:00' PARTITION BY (o_orderdate) DISTRIBUTED BY HASH(l_orderkey) BUCKETS 2 PROPERTIES("replication_num" = "3") AS SELECT o_orderdate, l_orderkey FROM orders`
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.Name.String() != "partition_mv" {
+		t.Errorf("Name = %q, want partition_mv", stmt.Name.String())
+	}
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+}
+
+func TestCreateMTMV_DistributedByHash_Properties(t *testing.T) {
+	sql := `CREATE MATERIALIZED VIEW mv DISTRIBUTED BY HASH(id) BUCKETS 3 PROPERTIES("replication_num"="3") AS SELECT id FROM t`
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.DistributedBy == nil {
+		t.Fatal("DistributedBy is nil")
+	}
+	if stmt.DistributedBy.Type != "HASH" {
+		t.Errorf("DistributedBy.Type = %q, want HASH", stmt.DistributedBy.Type)
+	}
+	if stmt.DistributedBy.Buckets != 3 {
+		t.Errorf("DistributedBy.Buckets = %d, want 3", stmt.DistributedBy.Buckets)
+	}
+	if len(stmt.Properties) != 1 {
+		t.Fatalf("Properties: got %d, want 1", len(stmt.Properties))
+	}
+	if stmt.Properties[0].Key != "replication_num" {
+		t.Errorf("Properties[0].Key = %q, want replication_num", stmt.Properties[0].Key)
+	}
+}
+
+func TestCreateMTMV_OnManual(t *testing.T) {
+	sql := "CREATE MATERIALIZED VIEW mv REFRESH COMPLETE ON MANUAL AS SELECT * FROM t"
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.RefreshTrigger == nil {
+		t.Fatal("RefreshTrigger is nil")
+	}
+	if !stmt.RefreshTrigger.OnManual {
+		t.Error("RefreshTrigger.OnManual should be true")
+	}
+	if stmt.RefreshTrigger.OnSchedule {
+		t.Error("RefreshTrigger.OnSchedule should be false")
+	}
+}
+
+func TestCreateMTMV_OnCommit(t *testing.T) {
+	sql := "CREATE MATERIALIZED VIEW mv REFRESH AUTO ON COMMIT AS SELECT * FROM t"
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.RefreshTrigger == nil {
+		t.Fatal("RefreshTrigger is nil")
+	}
+	if !stmt.RefreshTrigger.OnCommit {
+		t.Error("RefreshTrigger.OnCommit should be true")
+	}
+}
+
+func TestCreateMTMV_RefreshNever(t *testing.T) {
+	sql := "CREATE MATERIALIZED VIEW mv REFRESH NEVER AS SELECT * FROM t"
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.RefreshMethod != "NEVER" {
+		t.Errorf("RefreshMethod = %q, want NEVER", stmt.RefreshMethod)
+	}
+}
+
+func TestCreateMTMV_QualifiedName(t *testing.T) {
+	stmt := parseCreateMTMVStmt(t, "CREATE MATERIALIZED VIEW db1.mv1 AS SELECT * FROM t")
+	if stmt.Name.String() != "db1.mv1" {
+		t.Errorf("Name = %q, want db1.mv1", stmt.Name.String())
+	}
+}
+
+// Legacy corpus test: complete_mv (from materialized_view.sql line 1)
+func TestCreateMTMV_Legacy_CompleteMV(t *testing.T) {
+	sql := `CREATE MATERIALIZED VIEW complete_mv (orderdate COMMENT 'Order date', orderkey COMMENT 'Order key', partkey COMMENT 'Part key') BUILD IMMEDIATE REFRESH AUTO ON SCHEDULE EVERY 1 DAY STARTS '2024-12-01 20:30:00' DISTRIBUTED BY HASH(orderkey) BUCKETS 2 PROPERTIES("replication_num" = "1") AS SELECT o_orderdate, l_orderkey, l_partkey FROM orders LEFT JOIN lineitem ON l_orderkey = o_orderkey LEFT JOIN partsupp ON ps_partkey = l_partkey AND l_suppkey = ps_suppkey`
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.Name.String() != "complete_mv" {
+		t.Errorf("Name = %q, want complete_mv", stmt.Name.String())
+	}
+	if stmt.BuildMode != "IMMEDIATE" {
+		t.Errorf("BuildMode = %q, want IMMEDIATE", stmt.BuildMode)
+	}
+	if stmt.RefreshMethod != "AUTO" {
+		t.Errorf("RefreshMethod = %q, want AUTO", stmt.RefreshMethod)
+	}
+	if stmt.RefreshTrigger == nil || !stmt.RefreshTrigger.OnSchedule {
+		t.Error("RefreshTrigger.OnSchedule should be true")
+	}
+	if stmt.RefreshTrigger.Interval != "1 DAY" {
+		t.Errorf("Interval = %q, want '1 DAY'", stmt.RefreshTrigger.Interval)
+	}
+	if stmt.RefreshTrigger.StartsAt != "2024-12-01 20:30:00" {
+		t.Errorf("StartsAt = %q, want '2024-12-01 20:30:00'", stmt.RefreshTrigger.StartsAt)
+	}
+	if stmt.DistributedBy == nil || stmt.DistributedBy.Buckets != 2 {
+		t.Errorf("DistributedBy.Buckets = %d, want 2", stmt.DistributedBy.Buckets)
+	}
+	if stmt.Query == nil {
+		t.Fatal("Query is nil")
+	}
+}
+
+// Legacy corpus test: partition_mv (from async_materialized_view.sql line 16)
+func TestCreateMTMV_Legacy_PartitionMV(t *testing.T) {
+	sql := `CREATE MATERIALIZED VIEW partition_mv BUILD IMMEDIATE REFRESH AUTO ON SCHEDULE EVERY 1 DAY STARTS '2024-12-01 20:30:00' PARTITION BY (DATE_TRUNC(o_orderdate, 'MONTH')) DISTRIBUTED BY HASH(l_orderkey) BUCKETS 2 PROPERTIES("replication_num" = "3") AS SELECT o_orderdate, l_orderkey, l_partkey FROM orders LEFT JOIN lineitem ON l_orderkey = o_orderkey LEFT JOIN partsupp ON ps_partkey = l_partkey AND l_suppkey = ps_suppkey`
+	stmt := parseCreateMTMVStmt(t, sql)
+	if stmt.Name.String() != "partition_mv" {
+		t.Errorf("Name = %q, want partition_mv", stmt.Name.String())
+	}
+	if stmt.PartitionBy == nil {
+		t.Fatal("PartitionBy is nil")
+	}
+	if stmt.DistributedBy == nil || stmt.DistributedBy.Buckets != 2 {
+		t.Errorf("DistributedBy.Buckets = %d, want 2", stmt.DistributedBy.Buckets)
+	}
+	if len(stmt.Properties) != 1 || stmt.Properties[0].Key != "replication_num" {
+		t.Error("expected replication_num property")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+func TestAlterMTMV_Rename(t *testing.T) {
+	stmt := parseAlterMTMVStmt(t, "ALTER MATERIALIZED VIEW mv RENAME new_mv")
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want mv", stmt.Name.String())
+	}
+	if stmt.NewName == nil {
+		t.Fatal("NewName is nil")
+	}
+	if stmt.NewName.String() != "new_mv" {
+		t.Errorf("NewName = %q, want new_mv", stmt.NewName.String())
+	}
+}
+
+func TestAlterMTMV_RefreshComplete(t *testing.T) {
+	// Legacy corpus: ALTER MATERIALIZED VIEW partition_mv REFRESH COMPLETE;
+	stmt := parseAlterMTMVStmt(t, "ALTER MATERIALIZED VIEW partition_mv REFRESH COMPLETE")
+	if stmt.Name.String() != "partition_mv" {
+		t.Errorf("Name = %q, want partition_mv", stmt.Name.String())
+	}
+	if stmt.RefreshMethod != "COMPLETE" {
+		t.Errorf("RefreshMethod = %q, want COMPLETE", stmt.RefreshMethod)
+	}
+}
+
+func TestAlterMTMV_SetProperties(t *testing.T) {
+	// Legacy corpus: ALTER MATERIALIZED VIEW partition_mv SET ("grace_period" = "10", ...);
+	sql := `ALTER MATERIALIZED VIEW partition_mv SET ("grace_period" = "10", "excluded_trigger_tables" = "lineitem,partsupp")`
+	stmt := parseAlterMTMVStmt(t, sql)
+	if stmt.Name.String() != "partition_mv" {
+		t.Errorf("Name = %q, want partition_mv", stmt.Name.String())
+	}
+	if len(stmt.Properties) != 2 {
+		t.Fatalf("Properties: got %d, want 2", len(stmt.Properties))
+	}
+	if stmt.Properties[0].Key != "grace_period" || stmt.Properties[0].Value != "10" {
+		t.Errorf("Properties[0] = {%q: %q}, want {grace_period: 10}",
+			stmt.Properties[0].Key, stmt.Properties[0].Value)
+	}
+	if stmt.Properties[1].Key != "excluded_trigger_tables" {
+		t.Errorf("Properties[1].Key = %q, want excluded_trigger_tables", stmt.Properties[1].Key)
+	}
+}
+
+func TestAlterMTMV_ReplaceWith(t *testing.T) {
+	stmt := parseAlterMTMVStmt(t, "ALTER MATERIALIZED VIEW mv REPLACE WITH MATERIALIZED VIEW mv2")
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want mv", stmt.Name.String())
+	}
+	if !stmt.Replace {
+		t.Error("Replace should be true")
+	}
+	if stmt.ReplaceTarget == nil {
+		t.Fatal("ReplaceTarget is nil")
+	}
+	if stmt.ReplaceTarget.String() != "mv2" {
+		t.Errorf("ReplaceTarget = %q, want mv2", stmt.ReplaceTarget.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DROP MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+func TestDropMTMV_Basic(t *testing.T) {
+	stmt := parseDropMTMVStmt(t, "DROP MATERIALIZED VIEW mv1")
+	if stmt.Name.String() != "mv1" {
+		t.Errorf("Name = %q, want mv1", stmt.Name.String())
+	}
+	if stmt.IfExists {
+		t.Error("IfExists should be false")
+	}
+	if stmt.OnBase != nil {
+		t.Error("OnBase should be nil")
+	}
+}
+
+func TestDropMTMV_IfExists(t *testing.T) {
+	stmt := parseDropMTMVStmt(t, "DROP MATERIALIZED VIEW IF EXISTS mv1")
+	if !stmt.IfExists {
+		t.Error("IfExists should be true")
+	}
+	if stmt.Name.String() != "mv1" {
+		t.Errorf("Name = %q, want mv1", stmt.Name.String())
+	}
+}
+
+func TestDropMTMV_IfExistsQualified(t *testing.T) {
+	// Legacy corpus: DROP MATERIALIZED VIEW IF EXISTS db1.mv1
+	stmt := parseDropMTMVStmt(t, "DROP MATERIALIZED VIEW IF EXISTS db1.mv1")
+	if !stmt.IfExists {
+		t.Error("IfExists should be true")
+	}
+	if stmt.Name.String() != "db1.mv1" {
+		t.Errorf("Name = %q, want db1.mv1", stmt.Name.String())
+	}
+}
+
+func TestDropMTMV_OnBaseTable(t *testing.T) {
+	// Sync MV: DROP MATERIALIZED VIEW mv ON base_table
+	stmt := parseDropMTMVStmt(t, "DROP MATERIALIZED VIEW mv ON base_table")
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want mv", stmt.Name.String())
+	}
+	if stmt.OnBase == nil {
+		t.Fatal("OnBase is nil")
+	}
+	if stmt.OnBase.String() != "base_table" {
+		t.Errorf("OnBase = %q, want base_table", stmt.OnBase.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REFRESH MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+func TestRefreshMTMV_NoMode(t *testing.T) {
+	stmt := parseRefreshMTMVStmt(t, "REFRESH MATERIALIZED VIEW mv1")
+	if stmt.Name.String() != "mv1" {
+		t.Errorf("Name = %q, want mv1", stmt.Name.String())
+	}
+	if stmt.Mode != "" {
+		t.Errorf("Mode = %q, want empty", stmt.Mode)
+	}
+}
+
+func TestRefreshMTMV_Auto(t *testing.T) {
+	// Legacy corpus: REFRESH MATERIALIZED VIEW mv1 AUTO
+	stmt := parseRefreshMTMVStmt(t, "REFRESH MATERIALIZED VIEW mv1 AUTO")
+	if stmt.Name.String() != "mv1" {
+		t.Errorf("Name = %q, want mv1", stmt.Name.String())
+	}
+	if stmt.Mode != "AUTO" {
+		t.Errorf("Mode = %q, want AUTO", stmt.Mode)
+	}
+}
+
+func TestRefreshMTMV_Complete(t *testing.T) {
+	stmt := parseRefreshMTMVStmt(t, "REFRESH MATERIALIZED VIEW mv COMPLETE")
+	if stmt.Mode != "COMPLETE" {
+		t.Errorf("Mode = %q, want COMPLETE", stmt.Mode)
+	}
+}
+
+func TestRefreshMTMV_Partitions(t *testing.T) {
+	// Legacy corpus: REFRESH MATERIALIZED VIEW mv1 PARTITIONS(p_19950801_19950901, p_19950901_19951001)
+	stmt := parseRefreshMTMVStmt(t,
+		"REFRESH MATERIALIZED VIEW mv1 PARTITIONS(p_19950801_19950901, p_19950901_19951001)")
+	if stmt.Name.String() != "mv1" {
+		t.Errorf("Name = %q, want mv1", stmt.Name.String())
+	}
+	if len(stmt.Partitions) != 2 {
+		t.Fatalf("Partitions: got %d, want 2", len(stmt.Partitions))
+	}
+	if stmt.Partitions[0] != "p_19950801_19950901" {
+		t.Errorf("Partitions[0] = %q, want p_19950801_19950901", stmt.Partitions[0])
+	}
+	if stmt.Partitions[1] != "p_19950901_19951001" {
+		t.Errorf("Partitions[1] = %q, want p_19950901_19951001", stmt.Partitions[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PAUSE / RESUME MATERIALIZED VIEW JOB
+// ---------------------------------------------------------------------------
+
+func TestPauseMTMVJob(t *testing.T) {
+	file, errs := Parse("PAUSE MATERIALIZED VIEW JOB ON mv")
+	if len(errs) != 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("got %d stmts, want 1", len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.PauseMTMVJobStmt)
+	if !ok {
+		t.Fatalf("expected *ast.PauseMTMVJobStmt, got %T", file.Stmts[0])
+	}
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want mv", stmt.Name.String())
+	}
+}
+
+func TestResumeMTMVJob(t *testing.T) {
+	file, errs := Parse("RESUME MATERIALIZED VIEW JOB ON mv")
+	if len(errs) != 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("got %d stmts, want 1", len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.ResumeMTMVJobStmt)
+	if !ok {
+		t.Fatalf("expected *ast.ResumeMTMVJobStmt, got %T", file.Stmts[0])
+	}
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want mv", stmt.Name.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CANCEL MATERIALIZED VIEW TASK
+// ---------------------------------------------------------------------------
+
+func TestCancelMTMVTask(t *testing.T) {
+	file, errs := Parse("CANCEL MATERIALIZED VIEW TASK 12345 ON mv")
+	if len(errs) != 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("got %d stmts, want 1", len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*ast.CancelMTMVTaskStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CancelMTMVTaskStmt, got %T", file.Stmts[0])
+	}
+	if stmt.TaskID != 12345 {
+		t.Errorf("TaskID = %d, want 12345", stmt.TaskID)
+	}
+	if stmt.Name.String() != "mv" {
+		t.Errorf("Name = %q, want mv", stmt.Name.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node tags
+// ---------------------------------------------------------------------------
+
+func TestMTMVNodeTags(t *testing.T) {
+	tests := []struct {
+		node ast.Node
+		want ast.NodeTag
+		name string
+	}{
+		{&ast.CreateMTMVStmt{}, ast.T_CreateMTMVStmt, "CreateMTMVStmt"},
+		{&ast.AlterMTMVStmt{}, ast.T_AlterMTMVStmt, "AlterMTMVStmt"},
+		{&ast.DropMTMVStmt{}, ast.T_DropMTMVStmt, "DropMTMVStmt"},
+		{&ast.RefreshMTMVStmt{}, ast.T_RefreshMTMVStmt, "RefreshMTMVStmt"},
+		{&ast.MTMVRefreshTrigger{}, ast.T_MTMVRefreshTrigger, "MTMVRefreshTrigger"},
+		{&ast.PauseMTMVJobStmt{}, ast.T_PauseMTMVJobStmt, "PauseMTMVJobStmt"},
+		{&ast.ResumeMTMVJobStmt{}, ast.T_ResumeMTMVJobStmt, "ResumeMTMVJobStmt"},
+		{&ast.CancelMTMVTaskStmt{}, ast.T_CancelMTMVTaskStmt, "CancelMTMVTaskStmt"},
+	}
+	for _, tt := range tests {
+		if tt.node.Tag() != tt.want {
+			t.Errorf("%s.Tag() = %v, want %v", tt.name, tt.node.Tag(), tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tag string representation
+// ---------------------------------------------------------------------------
+
+func TestMTMVNodeTagStrings(t *testing.T) {
+	tests := []struct {
+		tag  ast.NodeTag
+		want string
+	}{
+		{ast.T_CreateMTMVStmt, "CreateMTMVStmt"},
+		{ast.T_AlterMTMVStmt, "AlterMTMVStmt"},
+		{ast.T_DropMTMVStmt, "DropMTMVStmt"},
+		{ast.T_RefreshMTMVStmt, "RefreshMTMVStmt"},
+		{ast.T_MTMVRefreshTrigger, "MTMVRefreshTrigger"},
+		{ast.T_PauseMTMVJobStmt, "PauseMTMVJobStmt"},
+		{ast.T_ResumeMTMVJobStmt, "ResumeMTMVJobStmt"},
+		{ast.T_CancelMTMVTaskStmt, "CancelMTMVTaskStmt"},
+	}
+	for _, tt := range tests {
+		if tt.tag.String() != tt.want {
+			t.Errorf("NodeTag(%d).String() = %q, want %q", int(tt.tag), tt.tag.String(), tt.want)
+		}
+	}
+}

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -183,6 +183,8 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			return p.parseCreateTable()
 		case kwVIEW:
 			return p.parseCreateView(createTok.Loc, false)
+		case kwMATERIALIZED:
+			return p.parseCreateMTMV(createTok.Loc)
 		case kwOR:
 			// CREATE OR REPLACE VIEW ...
 			p.advance() // consume OR
@@ -194,7 +196,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			return p.unsupported("CREATE")
 		}
 	case kwALTER:
-		p.advance() // consume ALTER; cur is now the object type keyword
+		alterTok := p.advance() // consume ALTER; cur is now the object type keyword
 		switch p.cur.Kind {
 		case kwDATABASE, kwSCHEMA:
 			return p.parseAlterDatabase()
@@ -202,6 +204,8 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			return p.parseAlterTable()
 		case kwVIEW:
 			return p.parseAlterView()
+		case kwMATERIALIZED:
+			return p.parseAlterMTMV(alterTok.Loc)
 		default:
 			return p.unsupported("ALTER")
 		}
@@ -214,6 +218,8 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			return p.parseDropDatabase()
 		case kwVIEW:
 			return p.parseDropView(dropTok.Loc)
+		case kwMATERIALIZED:
+			return p.parseDropMTMV(dropTok.Loc)
 		default:
 			return p.unsupported("DROP")
 		}
@@ -307,14 +313,30 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// Materialized View / Refresh
 	case kwREFRESH:
+		refreshTok := p.advance() // consume REFRESH
+		if p.cur.Kind == kwMATERIALIZED {
+			return p.parseRefreshMTMV(refreshTok.Loc)
+		}
 		return p.unsupported("REFRESH")
 
 	// Job control
 	case kwCANCEL:
+		cancelTok := p.advance() // consume CANCEL
+		if p.cur.Kind == kwMATERIALIZED {
+			return p.parseCancelMTMVTask(cancelTok.Loc)
+		}
 		return p.unsupported("CANCEL")
 	case kwPAUSE:
+		pauseTok := p.advance() // consume PAUSE
+		if p.cur.Kind == kwMATERIALIZED {
+			return p.parsePauseMTMVJob(pauseTok.Loc)
+		}
 		return p.unsupported("PAUSE")
 	case kwRESUME:
+		resumeTok := p.advance() // consume RESUME
+		if p.cur.Kind == kwMATERIALIZED {
+			return p.parseResumeMTMVJob(resumeTok.Loc)
+		}
 		return p.unsupported("RESUME")
 
 	// Analyze / Sync / Warm


### PR DESCRIPTION
## Summary
CREATE/ALTER/DROP/REFRESH MATERIALIZED VIEW, PAUSE/RESUME MATERIALIZED VIEW JOB, CANCEL MATERIALIZED VIEW TASK.
Supports BUILD IMMEDIATE/DEFERRED, REFRESH COMPLETE/AUTO/INCREMENTAL, ON SCHEDULE/COMMIT/MANUAL, partitions, distribution, properties.
31 tests.

DAG: T5.1 (P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)