### PR TITLE
feat(snowflake): T3.3 LIMIT injection rewrite

### DIFF
--- a/docs/superpowers/plans/2026-04-15-snowflake-limit-rewrite.md
+++ b/docs/superpowers/plans/2026-04-15-snowflake-limit-rewrite.md
@@ -1,0 +1,56 @@
+# T3.3 — Snowflake LIMIT Injection Rewrite — Implementation Plan
+
+## Steps
+
+### Step 1 — Write rewrite.go
+
+File: `snowflake/deparse/rewrite.go`
+
+Functions:
+1. `InjectLimit(sql string, maxRows int) (string, error)` — public entry point
+2. `rewriteStmt(node ast.Node, maxRows int) ast.Node` — dispatch on node type
+3. `rewriteSelect(s *ast.SelectStmt, maxRows int) ast.Node` — handle SelectStmt
+4. `wrapInLimit(inner ast.Node, maxRows int) *ast.SelectStmt` — build wrapper SELECT
+
+### Step 2 — Write rewrite_test.go
+
+File: `snowflake/deparse/rewrite_test.go`
+
+Test cases (12):
+1. No LIMIT → add LIMIT
+2. Existing LIMIT n <= maxRows → unchanged
+3. Existing LIMIT n > maxRows → lowered
+4. LIMIT with bind variable → wrap
+5. FETCH FIRST n > maxRows → lowered in-place
+6. UNION → wrap
+7. WITH CTE + SELECT → add LIMIT at outer SELECT
+8. INSERT → unchanged
+9. CREATE TABLE → unchanged
+10. Multi-statement (SELECT;INSERT;SELECT) → apply only to SELECTs
+11. Invalid SQL → error returned
+12. maxRows <= 0 → error returned
+
+### Step 3 — Run tests
+
+```
+go test ./snowflake/... -count=1
+```
+
+### Step 4 — gofmt
+
+```
+gofmt -w snowflake/deparse/rewrite.go snowflake/deparse/rewrite_test.go
+```
+
+### Step 5 — Commit
+
+Commit 1: spec + plan docs
+Commit 2: rewrite.go implementation
+Commit 3: rewrite_test.go tests
+
+### Step 6 — Push + PR
+
+```
+git push -u origin feat/snowflake/limit-rewrite
+gh pr create ...
+```

--- a/docs/superpowers/specs/2026-04-15-snowflake-limit-rewrite-design.md
+++ b/docs/superpowers/specs/2026-04-15-snowflake-limit-rewrite-design.md
@@ -1,0 +1,76 @@
+# T3.3 — Snowflake LIMIT Injection Rewrite Design
+
+## Scope
+
+T3.3 adds `InjectLimit(sql string, maxRows int) (string, error)` to the
+`snowflake/deparse` package. It is called by the Bytebase read-only SQL editor
+to cap result-set size before a query is sent to Snowflake.
+
+## Public API
+
+```go
+// InjectLimit rewrites the given SQL to cap the result-set size to maxRows.
+func InjectLimit(sql string, maxRows int) (string, error)
+```
+
+## File placement
+
+New file `snowflake/deparse/rewrite.go` in the existing `deparse` package.
+No new packages are created.
+
+## Rewrite rules
+
+| Input state | Action |
+|---|---|
+| No LIMIT, no FETCH | Add `LIMIT maxRows` |
+| `LIMIT n` with n <= maxRows | Leave unchanged |
+| `LIMIT n` with n > maxRows | Replace with `LIMIT maxRows` |
+| `LIMIT expr` (non-literal) | Wrap: `SELECT * FROM (...) LIMIT maxRows` |
+| `FETCH FIRST n ROWS ONLY` with n <= maxRows | Leave unchanged |
+| `FETCH FIRST n ROWS ONLY` with n > maxRows | Replace with `FETCH FIRST maxRows ROWS ONLY` |
+| `FETCH FIRST expr ROWS ONLY` (non-literal) | Wrap: `SELECT * FROM (...) LIMIT maxRows` |
+| `SetOperationStmt` (UNION/INTERSECT/EXCEPT) | Always wrap |
+| Non-SELECT (INSERT/UPDATE/DELETE/MERGE/DDL) | Return unchanged |
+| Multi-statement | Apply per-statement independently |
+
+### FETCH vs LIMIT normalisation
+
+When a FETCH clause must be lowered, it is lowered in-place (the FETCH clause
+is kept as FETCH). If the FETCH clause uses a non-literal expression the
+statement is wrapped so semantics are preserved.
+
+When a statement has no LIMIT and no FETCH, we add a LIMIT clause (not FETCH),
+keeping the output uniform.
+
+### SetOperationStmt wrapping
+
+Set operations may legally carry a trailing LIMIT only at the outermost level
+in Snowflake (applied to the entire result). Because the AST node for a set
+operation is a `SetOperationStmt` rather than a `SelectStmt`, we always wrap:
+
+```sql
+SELECT * FROM (<original>) LIMIT maxRows
+```
+
+A subquery alias (`_q`) is applied so the generated SQL is valid.
+
+### Wrap semantics
+
+```sql
+SELECT * FROM (<inner query>) AS _q LIMIT maxRows
+```
+
+The outer SELECT uses a bare `*` target (represented in the AST as a
+`SelectTarget{Star: true, Expr: &ast.StarExpr{}}`).
+
+## Error handling
+
+- `maxRows <= 0` → return `"", fmt.Errorf("maxRows must be positive")`
+- Parse error → forward the error from `parser.Parse` immediately; do not
+  attempt partial rewrites.
+
+## Dependencies
+
+- `github.com/bytebase/omni/snowflake/ast` — AST node types
+- `github.com/bytebase/omni/snowflake/parser` — `Parse`
+- `github.com/bytebase/omni/snowflake/deparse` — `DeparseFile` (same package)

--- a/snowflake/deparse/rewrite.go
+++ b/snowflake/deparse/rewrite.go
@@ -1,0 +1,149 @@
+// Package deparse — rewrite.go implements AST-level rewrites applied before
+// deparsing. InjectLimit caps result-set size, used by the Bytebase read-only
+// SQL editor before sending a query to Snowflake.
+package deparse
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/snowflake/ast"
+	"github.com/bytebase/omni/snowflake/parser"
+)
+
+// InjectLimit rewrites the given SQL to cap the result-set size to maxRows.
+//
+// The semantics depend on what the SQL already has:
+//   - No LIMIT, no OFFSET, no FETCH → add LIMIT maxRows
+//   - Existing LIMIT n with n <= maxRows → leave unchanged
+//   - Existing LIMIT n with n > maxRows → replace with LIMIT maxRows
+//   - Existing LIMIT n with non-literal n (expr/variable) → wrap: SELECT * FROM (...) LIMIT maxRows
+//   - Existing FETCH FIRST n ROWS ONLY → same literal vs. expr handling as LIMIT
+//   - SetOperationStmt (UNION/INTERSECT/EXCEPT) → wrap the whole thing: SELECT * FROM (...) LIMIT maxRows
+//   - Non-SELECT statements (INSERT/UPDATE/DELETE/MERGE/DDL) → return the input unchanged
+//   - Multi-statement input → apply to each statement independently
+//
+// Returns the rewritten SQL and any error encountered during parsing/deparsing.
+func InjectLimit(sql string, maxRows int) (string, error) {
+	if maxRows <= 0 {
+		return "", fmt.Errorf("maxRows must be positive")
+	}
+	file, err := parser.Parse(sql)
+	if err != nil {
+		return "", err
+	}
+	for i, stmt := range file.Stmts {
+		file.Stmts[i] = rewriteStmt(stmt, maxRows)
+	}
+	return DeparseFile(file)
+}
+
+// rewriteStmt dispatches on the concrete node type. Non-query statements are
+// returned unchanged.
+func rewriteStmt(node ast.Node, maxRows int) ast.Node {
+	switch s := node.(type) {
+	case *ast.SelectStmt:
+		return rewriteSelect(s, maxRows)
+	case *ast.SetOperationStmt:
+		// Set operations are always wrapped because the LIMIT belongs to the
+		// outermost query, not to either branch.
+		return wrapInLimit(s, maxRows)
+	default:
+		return node
+	}
+}
+
+// rewriteSelect inspects an existing SelectStmt and either adds, lowers, or
+// wraps the LIMIT/FETCH clause so that at most maxRows rows are returned.
+func rewriteSelect(s *ast.SelectStmt, maxRows int) ast.Node {
+	limitLit := asIntLiteral(s.Limit)
+	fetchLit := asFetchIntLiteral(s.Fetch)
+
+	switch {
+	// -----------------------------------------------------------------------
+	// FETCH FIRST n ROWS ONLY is present
+	// -----------------------------------------------------------------------
+	case s.Fetch != nil:
+		if fetchLit == nil {
+			// Non-literal FETCH expression — wrap to be safe.
+			return wrapInLimit(s, maxRows)
+		}
+		if fetchLit.Ival > int64(maxRows) {
+			// Lower the FETCH count in place.
+			s.Fetch = &ast.FetchClause{
+				Count: intLiteral(maxRows),
+			}
+		}
+		// fetchLit.Ival <= maxRows: leave unchanged.
+		return s
+
+	// -----------------------------------------------------------------------
+	// LIMIT is present
+	// -----------------------------------------------------------------------
+	case s.Limit != nil:
+		if limitLit == nil {
+			// Non-literal LIMIT expression (bind variable, subquery, etc.) — wrap.
+			return wrapInLimit(s, maxRows)
+		}
+		if limitLit.Ival > int64(maxRows) {
+			s.Limit = intLiteral(maxRows)
+		}
+		// limitLit.Ival <= maxRows: leave unchanged.
+		return s
+
+	// -----------------------------------------------------------------------
+	// No LIMIT and no FETCH — add LIMIT maxRows
+	// -----------------------------------------------------------------------
+	default:
+		s.Limit = intLiteral(maxRows)
+		return s
+	}
+}
+
+// wrapInLimit builds:
+//
+//	SELECT * FROM (<inner>) AS _q LIMIT maxRows
+func wrapInLimit(inner ast.Node, maxRows int) *ast.SelectStmt {
+	alias := ast.Ident{Name: "_q"}
+	return &ast.SelectStmt{
+		Targets: []*ast.SelectTarget{
+			{Star: true, Expr: &ast.StarExpr{}},
+		},
+		From: []ast.Node{
+			&ast.TableRef{
+				Subquery: inner,
+				Alias:    alias,
+			},
+		},
+		Limit: intLiteral(maxRows),
+	}
+}
+
+// intLiteral creates an integer Literal node with the given value.
+func intLiteral(v int) *ast.Literal {
+	return &ast.Literal{
+		Kind:  ast.LitInt,
+		Value: fmt.Sprintf("%d", v),
+		Ival:  int64(v),
+	}
+}
+
+// asIntLiteral returns the *ast.Literal if node is an integer literal,
+// otherwise nil.
+func asIntLiteral(node ast.Node) *ast.Literal {
+	if node == nil {
+		return nil
+	}
+	lit, ok := node.(*ast.Literal)
+	if !ok || lit.Kind != ast.LitInt {
+		return nil
+	}
+	return lit
+}
+
+// asFetchIntLiteral is like asIntLiteral but extracts from a *FetchClause.
+func asFetchIntLiteral(f *ast.FetchClause) *ast.Literal {
+	if f == nil {
+		return nil
+	}
+	return asIntLiteral(f.Count)
+}

--- a/snowflake/deparse/rewrite_test.go
+++ b/snowflake/deparse/rewrite_test.go
@@ -1,0 +1,196 @@
+package deparse_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/deparse"
+	"github.com/stretchr/testify/require"
+)
+
+// injectLimitCase is one test case for InjectLimit.
+type injectLimitCase struct {
+	name    string
+	sql     string
+	maxRows int
+	want    string // expected output SQL; empty means check wantContains / wantPrefix
+	// wantContains are substrings that must all appear in the output.
+	wantContains []string
+	wantErr      bool
+}
+
+func TestInjectLimit(t *testing.T) {
+	cases := []injectLimitCase{
+		// 1. No LIMIT — add LIMIT.
+		{
+			name:    "no limit adds limit",
+			sql:     "SELECT * FROM t",
+			maxRows: 100,
+			want:    "SELECT * FROM t LIMIT 100",
+		},
+		// 2. Existing LIMIT n <= maxRows — leave unchanged.
+		{
+			name:    "existing limit smaller unchanged",
+			sql:     "SELECT * FROM t LIMIT 50",
+			maxRows: 100,
+			want:    "SELECT * FROM t LIMIT 50",
+		},
+		// 3. Existing LIMIT n > maxRows — lower it.
+		{
+			name:    "existing limit larger lowered",
+			sql:     "SELECT * FROM t LIMIT 200",
+			maxRows: 100,
+			want:    "SELECT * FROM t LIMIT 100",
+		},
+		// 4. Existing LIMIT with non-integer expression — wrap.
+		{
+			name:    "non-literal limit wraps",
+			sql:     "SELECT * FROM t LIMIT 1+1",
+			maxRows: 100,
+			wantContains: []string{
+				"SELECT * FROM (SELECT * FROM t LIMIT 1 + 1)",
+				"LIMIT 100",
+			},
+		},
+		// 5. FETCH FIRST n > maxRows — lower in-place.
+		{
+			name:    "fetch first lowered",
+			sql:     "SELECT * FROM t FETCH FIRST 200 ROWS ONLY",
+			maxRows: 100,
+			want:    "SELECT * FROM t FETCH FIRST 100 ROWS ONLY",
+		},
+		// 5b. FETCH FIRST n <= maxRows — unchanged.
+		{
+			name:    "fetch first smaller unchanged",
+			sql:     "SELECT * FROM t FETCH FIRST 50 ROWS ONLY",
+			maxRows: 100,
+			want:    "SELECT * FROM t FETCH FIRST 50 ROWS ONLY",
+		},
+		// 6. UNION — wrap entire set operation.
+		{
+			name:    "union wrapped",
+			sql:     "SELECT a FROM t UNION SELECT b FROM u",
+			maxRows: 100,
+			wantContains: []string{
+				"SELECT * FROM (SELECT a FROM t UNION SELECT b FROM u)",
+				"LIMIT 100",
+			},
+		},
+		// 7. WITH CTE + SELECT — add LIMIT at outer SELECT level.
+		{
+			name:    "cte select adds limit",
+			sql:     "WITH cte AS (SELECT id FROM src) SELECT * FROM cte",
+			maxRows: 100,
+			wantContains: []string{
+				"WITH cte AS (SELECT id FROM src)",
+				"SELECT * FROM cte",
+				"LIMIT 100",
+			},
+		},
+		// 8. INSERT — unchanged.
+		{
+			name:    "insert unchanged",
+			sql:     "INSERT INTO t VALUES (1)",
+			maxRows: 100,
+			want:    "INSERT INTO t VALUES (1)",
+		},
+		// 9. CREATE TABLE — unchanged.
+		{
+			name:    "create table unchanged",
+			sql:     "CREATE TABLE t (id INT)",
+			maxRows: 100,
+			want:    "CREATE TABLE t (id INT)",
+		},
+		// 10. Multi-statement — apply to SELECTs only.
+		{
+			name:    "multi-statement select and non-select",
+			sql:     "SELECT 1; INSERT INTO t VALUES (1); SELECT 2",
+			maxRows: 100,
+			wantContains: []string{
+				"SELECT 1 LIMIT 100",
+				"INSERT INTO t VALUES (1)",
+				"SELECT 2 LIMIT 100",
+			},
+		},
+		// 11. Invalid SQL → error.
+		{
+			name:    "invalid sql returns error",
+			sql:     "SELECT FROM WHERE",
+			maxRows: 100,
+			wantErr: true,
+		},
+		// 12. maxRows <= 0 → error.
+		{
+			name:    "zero maxRows error",
+			sql:     "SELECT * FROM t",
+			maxRows: 0,
+			wantErr: true,
+		},
+		{
+			name:    "negative maxRows error",
+			sql:     "SELECT * FROM t",
+			maxRows: -1,
+			wantErr: true,
+		},
+		// Edge: LIMIT exactly equal to maxRows — unchanged.
+		{
+			name:    "limit equal to maxRows unchanged",
+			sql:     "SELECT * FROM t LIMIT 100",
+			maxRows: 100,
+			want:    "SELECT * FROM t LIMIT 100",
+		},
+		// Edge: FETCH FIRST via non-literal expression → wrap.
+		{
+			name:    "non-literal fetch wraps",
+			sql:     "SELECT * FROM t FETCH FIRST (SELECT 10) ROWS ONLY",
+			maxRows: 100,
+			wantContains: []string{
+				"SELECT * FROM (SELECT * FROM t FETCH FIRST (SELECT 10) ROWS ONLY)",
+				"LIMIT 100",
+			},
+		},
+		// Edge: INTERSECT — wrap.
+		{
+			name:    "intersect wrapped",
+			sql:     "SELECT a FROM t INTERSECT SELECT b FROM u",
+			maxRows: 50,
+			wantContains: []string{
+				"SELECT * FROM (SELECT a FROM t INTERSECT SELECT b FROM u)",
+				"LIMIT 50",
+			},
+		},
+		// Edge: SELECT with ORDER BY, no LIMIT — add LIMIT after ORDER BY.
+		{
+			name:    "select with order by adds limit",
+			sql:     "SELECT id FROM t ORDER BY id DESC",
+			maxRows: 10,
+			want:    "SELECT id FROM t ORDER BY id DESC LIMIT 10",
+		},
+		// Edge: SELECT with WHERE, no LIMIT.
+		{
+			name:    "select with where adds limit",
+			sql:     "SELECT id, name FROM employees WHERE active = TRUE",
+			maxRows: 25,
+			want:    "SELECT id, name FROM employees WHERE active = TRUE LIMIT 25",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deparse.InjectLimit(tc.sql, tc.maxRows)
+			if tc.wantErr {
+				require.Error(t, err, "expected an error for input %q", tc.sql)
+				return
+			}
+			require.NoError(t, err)
+			if tc.want != "" {
+				require.Equal(t, tc.want, got)
+			}
+			for _, sub := range tc.wantContains {
+				require.True(t,
+					strings.Contains(got, sub),
+					"output %q does not contain %q", got, sub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `InjectLimit(sql string, maxRows int) (string, error)` to `snowflake/deparse` — AST-level rewrite that caps result-set size before query execution
- Handles all cases: add LIMIT when absent, lower LIMIT when too large, wrap when LIMIT is a non-literal expression, wrap UNION/INTERSECT/EXCEPT, lower or wrap FETCH FIRST, leave non-SELECT statements (INSERT/DDL) unchanged, process multi-statement inputs per-statement
- 19 tests in `rewrite_test.go` covering every semantic branch

## Design decisions

**FETCH vs LIMIT normalisation**: When a FETCH clause must be lowered it is modified in-place (kept as FETCH). When there is no limit clause at all, we add LIMIT (not FETCH) for uniform output.

**Wrap heuristic**: Any non-`*ast.Literal{Kind: LitInt}` expression in LIMIT/FETCH position is wrapped rather than examined further (e.g., `BinaryExpr`, `SubqueryExpr`, `Literal{Kind: LitFloat}`). This is safe and conservative — wrapping always preserves semantics.

**SetOperationStmt always wrapped**: Set operations do not carry their own LIMIT clause in the AST; the LIMIT lives on the outermost query. Since we cannot inject directly, we always wrap: `SELECT * FROM (<set-op>) AS _q LIMIT maxRows`.

**Multi-statement**: `parser.Parse` returns an `*ast.File` whose `Stmts` is the full statement list. We iterate and apply `rewriteStmt` to each statement independently.

## Test plan

- [x] `go test ./snowflake/... -count=1` — all packages pass (deparse, parser, ast, analysis, advisor, diagnostics)
- [x] `gofmt -l` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)