### PR TITLE
mssql: expose DROP INDEX target tables, DEFAULT VALUES flag, and fix SELECT INTO soft-fail

### DIFF
--- a/mssql/ast/outfuncs.go
+++ b/mssql/ast/outfuncs.go
@@ -602,6 +602,9 @@ func writeInsertStmt(sb *strings.Builder, n *InsertStmt) {
 		sb.WriteString(" :source ")
 		writeNode(sb, n.Source)
 	}
+	if n.DefaultValues {
+		sb.WriteString(" :defaultValues true")
+	}
 	if n.OutputClause != nil {
 		sb.WriteString(" :output ")
 		writeNode(sb, n.OutputClause)
@@ -836,6 +839,10 @@ func writeDropStmt(sb *strings.Builder, n *DropStmt) {
 	if n.Names != nil {
 		sb.WriteString(" :names ")
 		writeNode(sb, n.Names)
+	}
+	if n.OnTables != nil {
+		sb.WriteString(" :onTables ")
+		writeNode(sb, n.OnTables)
 	}
 	sb.WriteString(fmt.Sprintf(" :ifExists %t", n.IfExists))
 	if n.Options != nil {

--- a/mssql/ast/parsenodes.go
+++ b/mssql/ast/parsenodes.go
@@ -165,14 +165,15 @@ func (n *CommonTableExpr) nodeTag() {}
 // InsertStmt represents an INSERT statement.
 // Ref: https://learn.microsoft.com/en-us/sql/t-sql/statements/insert-transact-sql
 type InsertStmt struct {
-	WithClause   *WithClause
-	Top          *TopClause
-	Relation     TableExpr // *TableRef or *TableVarRef
-	Cols         *List // column name list
-	Source       Node  // SELECT, VALUES, EXEC, or DEFAULT VALUES
-	OutputClause *OutputClause
-	OptionClause *List // OPTION ( <query_hint> [,...n] )
-	Loc          Loc
+	WithClause    *WithClause
+	Top           *TopClause
+	Relation      TableExpr // *TableRef or *TableVarRef
+	Cols          *List     // column name list
+	Source        Node      // SELECT, VALUES, or EXEC; nil when DefaultValues is true
+	DefaultValues bool      // DEFAULT VALUES (mutually exclusive with Source)
+	OutputClause  *OutputClause
+	OptionClause  *List // OPTION ( <query_hint> [,...n] )
+	Loc           Loc
 }
 
 func (n *InsertStmt) nodeTag()  {}
@@ -570,8 +571,13 @@ func (n *AlterColumnOption) nodeTag() {}
 // DropStmt represents a DROP statement.
 // Ref: https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-table-transact-sql
 type DropStmt struct {
-	ObjectType   DropObjectType
-	Names        *List // list of TableRef
+	ObjectType DropObjectType
+	Names      *List // list of TableRef
+	// OnTables is a parallel list to Names for DROP INDEX:
+	// OnTables.Items[i] is the *TableRef after `ON` for the i-th clause
+	// (`idx ON tbl` form), or nil for the backward-compatible `tbl.idx` form.
+	// Only populated when ObjectType == DropIndex.
+	OnTables     *List
 	IfExists     bool
 	Options      *List // WITH options (e.g., DROP INDEX ... WITH (MAXDOP=1, ONLINE=ON))
 	OnDatabase   bool  // ON DATABASE (DROP TRIGGER for DDL triggers)

--- a/mssql/ast/walk_generated.go
+++ b/mssql/ast/walk_generated.go
@@ -408,6 +408,7 @@ func walkChildren(v Visitor, node Node) {
 		walkList(v, n.Names)
 	case *DropStmt:
 		walkList(v, n.Names)
+		walkList(v, n.OnTables)
 		walkList(v, n.Options)
 	case *EdgeConnectionDef:
 		if n.FromTable != nil {

--- a/mssql/parser/compare_test.go
+++ b/mssql/parser/compare_test.go
@@ -1367,7 +1367,14 @@ func TestParseInsert(t *testing.T) {
 
 	t.Run("insert default values", func(t *testing.T) {
 		sql := "INSERT INTO t DEFAULT VALUES"
-		ParseAndCheck(t, sql)
+		result := ParseAndCheck(t, sql)
+		stmt := result.Items[0].(*ast.InsertStmt)
+		if !stmt.DefaultValues {
+			t.Error("expected DefaultValues=true")
+		}
+		if stmt.Source != nil {
+			t.Errorf("expected Source=nil when DefaultValues, got %T", stmt.Source)
+		}
 	})
 
 	t.Run("insert with output", func(t *testing.T) {
@@ -19154,6 +19161,55 @@ func TestParseIndexBnfReview(t *testing.T) {
 		}
 		if stmt.Options == nil {
 			t.Error("expected non-nil Options for DROP INDEX WITH")
+		}
+		if stmt.OnTables == nil || len(stmt.OnTables.Items) != 1 {
+			t.Fatalf("expected OnTables with 1 item, got %+v", stmt.OnTables)
+		}
+		onTbl, ok := stmt.OnTables.Items[0].(*ast.TableRef)
+		if !ok {
+			t.Fatalf("expected *TableRef in OnTables[0], got %T", stmt.OnTables.Items[0])
+		}
+		if onTbl.Schema != "dbo" || onTbl.Object != "t" {
+			t.Errorf("expected OnTables[0]=dbo.t, got %s.%s", onTbl.Schema, onTbl.Object)
+		}
+	})
+
+	// DROP INDEX with multiple clauses, each with its own ON table.
+	t.Run("drop index multiple clauses", func(t *testing.T) {
+		sql := "DROP INDEX idx1 ON dbo.t1, idx2 ON dbo.t2"
+		result := ParseAndCheck(t, sql)
+		stmt := result.Items[0].(*ast.DropStmt)
+		if stmt.Names == nil || len(stmt.Names.Items) != 2 {
+			t.Fatalf("expected Names with 2 items, got %+v", stmt.Names)
+		}
+		if stmt.OnTables == nil || len(stmt.OnTables.Items) != 2 {
+			t.Fatalf("expected OnTables with 2 items, got %+v", stmt.OnTables)
+		}
+		checkOn := func(i int, wantObj string) {
+			t.Helper()
+			ref, ok := stmt.OnTables.Items[i].(*ast.TableRef)
+			if !ok {
+				t.Fatalf("OnTables[%d]: expected *TableRef, got %T", i, stmt.OnTables.Items[i])
+			}
+			if ref.Object != wantObj {
+				t.Errorf("OnTables[%d]: expected Object=%s, got %s", i, wantObj, ref.Object)
+			}
+		}
+		checkOn(0, "t1")
+		checkOn(1, "t2")
+	})
+
+	// DROP INDEX backward-compatible form: table.index (no ON clause).
+	// OnTables.Items[i] must be nil so indexes align with Names.
+	t.Run("drop index backward compatible form", func(t *testing.T) {
+		sql := "DROP INDEX dbo.t.idx"
+		result := ParseAndCheck(t, sql)
+		stmt := result.Items[0].(*ast.DropStmt)
+		if stmt.OnTables == nil || len(stmt.OnTables.Items) != 1 {
+			t.Fatalf("expected OnTables with 1 item, got %+v", stmt.OnTables)
+		}
+		if stmt.OnTables.Items[0] != nil {
+			t.Errorf("expected nil OnTables[0] for backward-compatible form, got %T", stmt.OnTables.Items[0])
 		}
 	})
 

--- a/mssql/parser/drop.go
+++ b/mssql/parser/drop.go
@@ -198,26 +198,36 @@ func (p *Parser) parseDropStmt() (*nodes.DropStmt, error) {
 
 	// Names (comma-separated)
 	var names []nodes.Node
+	// For DROP INDEX: OnTables parallels Names; Items[i] is the table after ON
+	// for `idx ON tbl` form, or nil for the backward-compatible `tbl.idx` form.
+	var onTables []nodes.Node
 
 	// DROP FULLTEXT INDEX ON table does not have a "name" per se - the table IS the target
 	if stmt.ObjectType == nodes.DropFulltextIndex {
 		// ON table_name
 		if _, ok := p.match(kwON); ok {
-			if ref , _ := p.parseTableRef(); ref != nil {
+			if ref, _ := p.parseTableRef(); ref != nil {
 				names = append(names, ref)
 			}
 		}
 	} else {
 		for {
-			name , _ := p.parseTableRef()
+			name, _ := p.parseTableRef()
 			if name == nil {
 				break
 			}
 			// For DROP INDEX: index_name ON table_name [ WITH ( options ) ]
+			// Backward-compatible form `tbl.idx` has no ON clause; keep nil placeholder
+			// so OnTables.Items[i] aligns with Names.Items[i].
 			if stmt.ObjectType == nodes.DropIndex {
+				var onTable nodes.Node
 				if _, ok := p.match(kwON); ok {
-					p.parseTableRef() // consume table name
+					ref, _ := p.parseTableRef()
+					if ref != nil {
+						onTable = ref
+					}
 				}
+				onTables = append(onTables, onTable)
 				// WITH ( <drop_clustered_index_option> [ ,...n ] )
 				if p.cur.Type == kwWITH {
 					p.advance()
@@ -233,6 +243,9 @@ func (p *Parser) parseDropStmt() (*nodes.DropStmt, error) {
 		}
 	}
 	stmt.Names = &nodes.List{Items: names}
+	if stmt.ObjectType == nodes.DropIndex && len(onTables) > 0 {
+		stmt.OnTables = &nodes.List{Items: onTables}
+	}
 
 	// DROP TRIGGER ... ON { DATABASE | ALL SERVER } (for DDL/logon triggers)
 	if stmt.ObjectType == nodes.DropTrigger {

--- a/mssql/parser/insert.go
+++ b/mssql/parser/insert.go
@@ -146,15 +146,11 @@ func (p *Parser) parseInsertStmt() (*nodes.InsertStmt, error) {
 		stmt.Source = execStmt
 	case p.cur.Type == kwDEFAULT:
 		// DEFAULT VALUES
-		defLoc := p.pos()
 		p.advance()
 		if p.cur.Type == kwVALUES {
 			p.advance()
 		}
-		stmt.Source = &nodes.Literal{
-			Type: nodes.LitDefault,
-			Loc:  nodes.Loc{Start: defLoc, End: -1},
-		}
+		stmt.DefaultValues = true
 	}
 
 	// Optional OPTION clause

--- a/mssql/parser/select.go
+++ b/mssql/parser/select.go
@@ -110,6 +110,9 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 		if err != nil {
 			return nil, err
 		}
+		if stmt.IntoTable == nil {
+			return nil, p.newParseError(p.cur.Loc, "expected table name after INTO")
+		}
 	}
 
 	// FROM


### PR DESCRIPTION
## Summary

Three small mssql changes motivated by bytebase's migration off ANTLR:

- **`DropStmt.OnTables *List`** — parallel list to `Names` for `DROP INDEX`. Items hold the `ON <table>` target for `idx ON tbl` form, or `nil` for the backward-compatible `tbl.idx` form (preserving index alignment with `Names`). Unblocks `extractChangedResources` parity for `DROP INDEX` in bytebase.
- **`InsertStmt.DefaultValues bool`** — replaces the `*Literal{LitDefault}` sentinel for `INSERT ... DEFAULT VALUES`, aligning with the existing `MergeInsertAction.DefaultValues` pattern. `LitDefault` kept for expression-level `DEFAULT` (e.g. `VALUES (DEFAULT, ...)`).
- **SELECT INTO hard-fail** — `SELECT 1 INTO FROM dbo.t` no longer parses cleanly. `parseTableRef` returns `(nil, nil)` for non-identifier tokens; the INTO branch now rejects when the target is absent, matching SQL Server and the existing hard-fail pattern in INSERT/UPDATE/DELETE.

## T-SQL grammar coverage (DROP INDEX)

- `idx ON tbl` → `OnTables[i] = *TableRef`
- `idx1 ON t1, idx2 ON t2` → index-aligned
- `[schema.]tbl.idx` (backward-compat) → `OnTables[i] = nil`
- `DROP FULLTEXT INDEX ON tbl` → target still in `Names` (table IS the target there)

## Bytebase consumer after this change

```go
case ast.DropIndex:
    for i, item := range n.Names.Items {
        if i < len(n.OnTables.Items) {
            if ref, ok := n.OnTables.Items[i].(*ast.TableRef); ok && ref != nil {
                addTable(ref, false)
            }
        }
    }
```

## Test plan

- [x] `go test ./mssql/...` — all green (previously-failing `TestKeywordOracleCoreAsIdentifier/alias_into_bare` now passes)
- [x] New cases in `mssql/parser/compare_test.go`:
  - `drop index with options` — `OnTables[0]` is `dbo.t`
  - `drop index multiple clauses` — 2-item OnTables aligned with Names
  - `drop index backward compatible form` — `OnTables[0] == nil`
  - `insert default values` — `DefaultValues==true`, `Source==nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)