### PR TITLE
feat(tidb): CREATE/ALTER/DROP PLACEMENT POLICY DDL

### DIFF
--- a/tidb/ast/outfuncs.go
+++ b/tidb/ast/outfuncs.go
@@ -137,6 +137,14 @@ func writeNode(sb *strings.Builder, node Node) {
 		writeAlterDatabaseStmt(sb, n)
 	case *DropDatabaseStmt:
 		writeDropDatabaseStmt(sb, n)
+	case *CreatePlacementPolicyStmt:
+		writeCreatePlacementPolicyStmt(sb, n)
+	case *AlterPlacementPolicyStmt:
+		writeAlterPlacementPolicyStmt(sb, n)
+	case *DropPlacementPolicyStmt:
+		writeDropPlacementPolicyStmt(sb, n)
+	case *PlacementPolicyOption:
+		writePlacementPolicyOption(sb, n)
 	case *DropIndexStmt:
 		writeDropIndexStmt(sb, n)
 	case *DropViewStmt:
@@ -1970,6 +1978,68 @@ func writeDropDatabaseStmt(sb *strings.Builder, n *DropDatabaseStmt) {
 		sb.WriteString(" :if_exists true")
 	}
 	fmt.Fprintf(sb, " :name %s", n.Name)
+	sb.WriteString("}")
+}
+
+func writeCreatePlacementPolicyStmt(sb *strings.Builder, n *CreatePlacementPolicyStmt) {
+	sb.WriteString("{CREATE_PLACEMENT_POLICY")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.OrReplace {
+		sb.WriteString(" :or_replace true")
+	}
+	if n.IfNotExists {
+		sb.WriteString(" :if_not_exists true")
+	}
+	fmt.Fprintf(sb, " :name %s", n.Name)
+	if len(n.Options) > 0 {
+		sb.WriteString(" :options ")
+		for i, o := range n.Options {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o)
+		}
+	}
+	sb.WriteString("}")
+}
+
+func writeAlterPlacementPolicyStmt(sb *strings.Builder, n *AlterPlacementPolicyStmt) {
+	sb.WriteString("{ALTER_PLACEMENT_POLICY")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.IfExists {
+		sb.WriteString(" :if_exists true")
+	}
+	fmt.Fprintf(sb, " :name %s", n.Name)
+	if len(n.Options) > 0 {
+		sb.WriteString(" :options ")
+		for i, o := range n.Options {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, o)
+		}
+	}
+	sb.WriteString("}")
+}
+
+func writeDropPlacementPolicyStmt(sb *strings.Builder, n *DropPlacementPolicyStmt) {
+	sb.WriteString("{DROP_PLACEMENT_POLICY")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.IfExists {
+		sb.WriteString(" :if_exists true")
+	}
+	fmt.Fprintf(sb, " :name %s", n.Name)
+	sb.WriteString("}")
+}
+
+func writePlacementPolicyOption(sb *strings.Builder, n *PlacementPolicyOption) {
+	sb.WriteString("{PLACEMENT_POLICY_OPTION")
+	fmt.Fprintf(sb, " :name %s", n.Name)
+	if n.IsInt {
+		fmt.Fprintf(sb, " :int_value %d", n.IntValue)
+	} else {
+		fmt.Fprintf(sb, " :value %q", n.Value)
+	}
 	sb.WriteString("}")
 }
 

--- a/tidb/ast/parsenodes.go
+++ b/tidb/ast/parsenodes.go
@@ -1749,6 +1749,68 @@ type DropDatabaseStmt struct {
 func (s *DropDatabaseStmt) nodeTag()  {}
 func (s *DropDatabaseStmt) stmtNode() {}
 
+// CreatePlacementPolicyStmt represents a TiDB CREATE [OR REPLACE]
+// PLACEMENT POLICY [IF NOT EXISTS] name option_list statement.
+// Ref: TiDB v8.5.5 parser.y:15427-15436.
+type CreatePlacementPolicyStmt struct {
+	Loc         Loc
+	OrReplace   bool
+	IfNotExists bool
+	Name        string
+	Options     []*PlacementPolicyOption
+}
+
+func (s *CreatePlacementPolicyStmt) nodeTag()  {}
+func (s *CreatePlacementPolicyStmt) stmtNode() {}
+
+// AlterPlacementPolicyStmt represents a TiDB ALTER PLACEMENT POLICY
+// [IF EXISTS] name option_list statement.
+// Ref: TiDB v8.5.5 parser.y:15438-15446.
+type AlterPlacementPolicyStmt struct {
+	Loc      Loc
+	IfExists bool
+	Name     string
+	Options  []*PlacementPolicyOption
+}
+
+func (s *AlterPlacementPolicyStmt) nodeTag()  {}
+func (s *AlterPlacementPolicyStmt) stmtNode() {}
+
+// DropPlacementPolicyStmt represents a TiDB DROP PLACEMENT POLICY
+// [IF EXISTS] name statement. Policies cannot be comma-listed.
+// Ref: TiDB v8.5.5 parser.y:15389-15396.
+type DropPlacementPolicyStmt struct {
+	Loc      Loc
+	IfExists bool
+	Name     string
+}
+
+func (s *DropPlacementPolicyStmt) nodeTag()  {}
+func (s *DropPlacementPolicyStmt) stmtNode() {}
+
+// PlacementPolicyOption is one entry in a CREATE/ALTER PLACEMENT POLICY
+// option list (DirectPlacementOption in TiDB v8.5.5 parser.y:2013-2066).
+// The grammar accepts these as comma-separated OR whitespace-separated,
+// duplicates are accepted at parse time (last-wins is a semantic concern).
+//
+// Value representation:
+//   - String-shaped options (PRIMARY_REGION, REGIONS, SCHEDULE,
+//     CONSTRAINTS and its leader/follower/voter/learner variants,
+//     SURVIVAL_PREFERENCES) carry their raw quoted-content in Value.
+//   - Integer-shaped options (FOLLOWERS, VOTERS, LEARNERS) use IntValue,
+//     and Value holds the literal numeric text for round-trip fidelity.
+//
+// Name is the uppercased option keyword (e.g. "PRIMARY_REGION").
+type PlacementPolicyOption struct {
+	Loc      Loc
+	Name     string
+	Value    string // string-shaped options OR raw numeric text
+	IntValue uint64 // numeric-shaped options (FOLLOWERS/VOTERS/LEARNERS)
+	IsInt    bool   // true when option was a numeric literal
+}
+
+func (o *PlacementPolicyOption) nodeTag() {}
+
 // DropIndexStmt represents a DROP INDEX statement.
 type DropIndexStmt struct {
 	Loc       Loc

--- a/tidb/ast/walk_generated.go
+++ b/tidb/ast/walk_generated.go
@@ -16,6 +16,12 @@ func walkChildren(v Visitor, node Node) {
 		if n.Schedule != nil {
 			Walk(v, n.Schedule)
 		}
+	case *AlterPlacementPolicyStmt:
+		for _, item := range n.Options {
+			if item != nil {
+				Walk(v, item)
+			}
+		}
 	case *AlterRoutineStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -264,6 +270,12 @@ func walkChildren(v Visitor, node Node) {
 				Walk(v, item)
 			}
 		}
+		for _, item := range n.Options {
+			if item != nil {
+				Walk(v, item)
+			}
+		}
+	case *CreatePlacementPolicyStmt:
 		for _, item := range n.Options {
 			if item != nil {
 				Walk(v, item)

--- a/tidb/catalog/altercmds.go
+++ b/tidb/catalog/altercmds.go
@@ -723,7 +723,7 @@ func (c *Catalog) alterTableOption(tbl *Table, cmd *nodes.AlterTableCmd) error {
 		if err := c.validatePolicyRef(opt.Value); err != nil {
 			return err
 		}
-		tbl.PlacementPolicy = opt.Value
+		tbl.PlacementPolicy = resolvePolicyRef(opt.Value)
 	case "ttl":
 		col, interval, err := extractTTLParts(opt.Value)
 		if err != nil {

--- a/tidb/catalog/altercmds.go
+++ b/tidb/catalog/altercmds.go
@@ -720,6 +720,9 @@ func (c *Catalog) alterTableOption(tbl *Table, cmd *nodes.AlterTableCmd) error {
 	case "auto_random_base":
 		fmt.Sscanf(opt.Value, "%d", &tbl.AutoRandomBase)
 	case "placement policy":
+		if err := c.validatePolicyRef(opt.Value); err != nil {
+			return err
+		}
 		tbl.PlacementPolicy = opt.Value
 	case "ttl":
 		col, interval, err := extractTTLParts(opt.Value)

--- a/tidb/catalog/catalog.go
+++ b/tidb/catalog/catalog.go
@@ -2,19 +2,21 @@ package catalog
 
 // Catalog is the in-memory TiDB catalog.
 type Catalog struct {
-	databases        map[string]*Database // lowered name -> Database
-	currentDB        string
-	defaultCharset   string
-	defaultCollation string
-	foreignKeyChecks bool // SET foreign_key_checks (default true)
+	databases         map[string]*Database         // lowered name -> Database
+	placementPolicies map[string]*PlacementPolicy  // lowered name -> PlacementPolicy (TiDB)
+	currentDB         string
+	defaultCharset    string
+	defaultCollation  string
+	foreignKeyChecks  bool // SET foreign_key_checks (default true)
 }
 
 func New() *Catalog {
 	return &Catalog{
-		databases:        make(map[string]*Database),
-		defaultCharset:   "utf8mb4",
-		defaultCollation: "utf8mb4_bin", // TiDB v8.5 default (MySQL 8.0 uses utf8mb4_0900_ai_ci)
-		foreignKeyChecks: true,
+		databases:         make(map[string]*Database),
+		placementPolicies: make(map[string]*PlacementPolicy),
+		defaultCharset:    "utf8mb4",
+		defaultCollation:  "utf8mb4_bin", // TiDB v8.5 default (MySQL 8.0 uses utf8mb4_0900_ai_ci)
+		foreignKeyChecks:  true,
 	}
 }
 

--- a/tidb/catalog/dbcmds.go
+++ b/tidb/catalog/dbcmds.go
@@ -38,7 +38,7 @@ func (c *Catalog) createDatabase(stmt *nodes.CreateDatabaseStmt) error {
 		}
 	}
 	db := newDatabase(name, charset, collation)
-	db.PlacementPolicy = placementPolicy
+	db.PlacementPolicy = resolvePolicyRef(placementPolicy)
 	c.databases[key] = db
 	return nil
 }
@@ -92,7 +92,7 @@ func (c *Catalog) alterDatabase(stmt *nodes.AlterDatabaseStmt) error {
 			if err := c.validatePolicyRef(opt.Value); err != nil {
 				return err
 			}
-			db.PlacementPolicy = opt.Value
+			db.PlacementPolicy = resolvePolicyRef(opt.Value)
 		}
 	}
 	// When charset is changed without explicit collation, derive the default collation.

--- a/tidb/catalog/dbcmds.go
+++ b/tidb/catalog/dbcmds.go
@@ -28,6 +28,9 @@ func (c *Catalog) createDatabase(stmt *nodes.CreateDatabaseStmt) error {
 			placementPolicy = opt.Value
 		}
 	}
+	if err := c.validatePolicyRef(placementPolicy); err != nil {
+		return err
+	}
 	// When charset is specified without explicit collation, derive the default collation.
 	if charsetExplicit && !collationExplicit {
 		if dc, ok := defaultCollationForCharset[toLower(charset)]; ok {
@@ -86,6 +89,9 @@ func (c *Catalog) alterDatabase(stmt *nodes.AlterDatabaseStmt) error {
 			db.Collation = opt.Value
 			collationExplicit = true
 		case "placement policy":
+			if err := c.validatePolicyRef(opt.Value); err != nil {
+				return err
+			}
 			db.PlacementPolicy = opt.Value
 		}
 	}

--- a/tidb/catalog/errors.go
+++ b/tidb/catalog/errors.go
@@ -45,7 +45,10 @@ const (
 	// TiDB error codes. 8239 is the closest match in TiDB's error
 	// catalog for "Placement policy <name> already exists" (err.go:261
 	// upstream). 8241 covers "unknown placement policy" (err.go:266).
+	// 8240 covers "policy still in use" — surfaced on DROP PLACEMENT
+	// POLICY when a database/table still references the policy.
 	ErrPlacementPolicyExists  = 8239
+	ErrPlacementPolicyInUse   = 8240
 	ErrPlacementPolicyMissing = 8241
 )
 
@@ -75,6 +78,9 @@ var sqlStateMap = map[int]string{
 	ErrUnsupportedGeneratedStorageChange: "HY000",
 	ErrDependentByGenCol:                 "HY000",
 	ErrWrongArguments:                    "HY000",
+	ErrPlacementPolicyExists:             "HY000",
+	ErrPlacementPolicyInUse:              "HY000",
+	ErrPlacementPolicyMissing:            "HY000",
 }
 
 func sqlState(code int) string {
@@ -102,6 +108,11 @@ func errDupPlacementPolicy(name string) error {
 func errUnknownPlacementPolicy(name string) error {
 	return &Error{Code: ErrPlacementPolicyMissing, SQLState: sqlState(ErrPlacementPolicyMissing),
 		Message: fmt.Sprintf("Unknown placement policy '%s'", name)}
+}
+
+func errPlacementPolicyInUse(name, ref string) error {
+	return &Error{Code: ErrPlacementPolicyInUse, SQLState: sqlState(ErrPlacementPolicyInUse),
+		Message: fmt.Sprintf("Placement policy '%s' is still in use by %s", name, ref)}
 }
 
 func errNoDatabaseSelected() error {

--- a/tidb/catalog/errors.go
+++ b/tidb/catalog/errors.go
@@ -42,6 +42,11 @@ const (
 	ErrUnsupportedGeneratedStorageChange = 3106
 	ErrDependentByGenCol                 = 3108
 	ErrWrongArguments                    = 1210
+	// TiDB error codes. 8239 is the closest match in TiDB's error
+	// catalog for "Placement policy <name> already exists" (err.go:261
+	// upstream). 8241 covers "unknown placement policy" (err.go:266).
+	ErrPlacementPolicyExists  = 8239
+	ErrPlacementPolicyMissing = 8241
 )
 
 var sqlStateMap = map[int]string{
@@ -87,6 +92,16 @@ func errDupDatabase(name string) error {
 func errUnknownDatabase(name string) error {
 	return &Error{Code: ErrUnknownDatabase, SQLState: sqlState(ErrUnknownDatabase),
 		Message: fmt.Sprintf("Unknown database '%s'", name)}
+}
+
+func errDupPlacementPolicy(name string) error {
+	return &Error{Code: ErrPlacementPolicyExists, SQLState: sqlState(ErrPlacementPolicyExists),
+		Message: fmt.Sprintf("Placement policy '%s' already exists", name)}
+}
+
+func errUnknownPlacementPolicy(name string) error {
+	return &Error{Code: ErrPlacementPolicyMissing, SQLState: sqlState(ErrPlacementPolicyMissing),
+		Message: fmt.Sprintf("Unknown placement policy '%s'", name)}
 }
 
 func errNoDatabaseSelected() error {

--- a/tidb/catalog/exec.go
+++ b/tidb/catalog/exec.go
@@ -147,6 +147,12 @@ func (c *Catalog) processUtility(stmt nodes.Node) error {
 		return c.alterTable(s)
 	case *nodes.AlterDatabaseStmt:
 		return c.alterDatabase(s)
+	case *nodes.CreatePlacementPolicyStmt:
+		return c.createPlacementPolicy(s)
+	case *nodes.AlterPlacementPolicyStmt:
+		return c.alterPlacementPolicy(s)
+	case *nodes.DropPlacementPolicyStmt:
+		return c.dropPlacementPolicy(s)
 	case *nodes.DropTableStmt:
 		return c.dropTable(s)
 	case *nodes.DropDatabaseStmt:
@@ -227,6 +233,12 @@ func stmtLocStart(node nodes.Node) int {
 	case *nodes.AlterTableStmt:
 		return s.Loc.Start
 	case *nodes.AlterDatabaseStmt:
+		return s.Loc.Start
+	case *nodes.CreatePlacementPolicyStmt:
+		return s.Loc.Start
+	case *nodes.AlterPlacementPolicyStmt:
+		return s.Loc.Start
+	case *nodes.DropPlacementPolicyStmt:
 		return s.Loc.Start
 	case *nodes.DropTableStmt:
 		return s.Loc.Start

--- a/tidb/catalog/placement_policy.go
+++ b/tidb/catalog/placement_policy.go
@@ -1,0 +1,105 @@
+package catalog
+
+import (
+	nodes "github.com/bytebase/omni/tidb/ast"
+)
+
+// PlacementPolicy is a first-class catalog object representing a
+// TiDB placement policy definition (CREATE PLACEMENT POLICY ...).
+// Options are stored in source order; duplicate keywords are
+// preserved (matches TiDB's own parser behavior — duplicate detection
+// is a semantic concern, not a parse concern).
+type PlacementPolicy struct {
+	Name    string
+	Options []*PlacementPolicyOption
+}
+
+// PlacementPolicyOption mirrors the parser AST node but lives in the
+// catalog layer so downstream consumers (diff, deparse) don't need
+// to import the parser's ast package just to inspect a policy.
+type PlacementPolicyOption struct {
+	Name     string // uppercased keyword (e.g. "PRIMARY_REGION")
+	Value    string // string literal content OR numeric text
+	IntValue uint64
+	IsInt    bool
+}
+
+// GetPlacementPolicy returns the named policy, or nil if not found.
+// Policy names are case-insensitive per TiDB's CIStr convention.
+func (c *Catalog) GetPlacementPolicy(name string) *PlacementPolicy {
+	if c.placementPolicies == nil {
+		return nil
+	}
+	return c.placementPolicies[toLower(name)]
+}
+
+// PlacementPolicies returns all defined placement policies, in
+// non-deterministic order (map iteration).
+func (c *Catalog) PlacementPolicies() []*PlacementPolicy {
+	out := make([]*PlacementPolicy, 0, len(c.placementPolicies))
+	for _, p := range c.placementPolicies {
+		out = append(out, p)
+	}
+	return out
+}
+
+func (c *Catalog) createPlacementPolicy(stmt *nodes.CreatePlacementPolicyStmt) error {
+	if c.placementPolicies == nil {
+		c.placementPolicies = make(map[string]*PlacementPolicy)
+	}
+	key := toLower(stmt.Name)
+	if _, exists := c.placementPolicies[key]; exists {
+		if stmt.OrReplace {
+			// OR REPLACE overwrites; no error.
+		} else if stmt.IfNotExists {
+			return nil
+		} else {
+			return errDupPlacementPolicy(stmt.Name)
+		}
+	}
+	c.placementPolicies[key] = &PlacementPolicy{
+		Name:    stmt.Name,
+		Options: convertPolicyOptions(stmt.Options),
+	}
+	return nil
+}
+
+func (c *Catalog) alterPlacementPolicy(stmt *nodes.AlterPlacementPolicyStmt) error {
+	key := toLower(stmt.Name)
+	existing, ok := c.placementPolicies[key]
+	if !ok {
+		if stmt.IfExists {
+			return nil
+		}
+		return errUnknownPlacementPolicy(stmt.Name)
+	}
+	// ALTER replaces the option list wholesale in TiDB — it's not a
+	// merge. Mirror that here so the catalog agrees with TiDB state.
+	existing.Options = convertPolicyOptions(stmt.Options)
+	return nil
+}
+
+func (c *Catalog) dropPlacementPolicy(stmt *nodes.DropPlacementPolicyStmt) error {
+	key := toLower(stmt.Name)
+	if _, ok := c.placementPolicies[key]; !ok {
+		if stmt.IfExists {
+			return nil
+		}
+		return errUnknownPlacementPolicy(stmt.Name)
+	}
+	delete(c.placementPolicies, key)
+	return nil
+}
+
+func convertPolicyOptions(src []*nodes.PlacementPolicyOption) []*PlacementPolicyOption {
+	out := make([]*PlacementPolicyOption, len(src))
+	for i, s := range src {
+		out[i] = &PlacementPolicyOption{
+			Name:     s.Name,
+			Value:    s.Value,
+			IntValue: s.IntValue,
+			IsInt:    s.IsInt,
+		}
+	}
+	return out
+}

--- a/tidb/catalog/placement_policy.go
+++ b/tidb/catalog/placement_policy.go
@@ -1,6 +1,8 @@
 package catalog
 
 import (
+	"fmt"
+
 	nodes "github.com/bytebase/omni/tidb/ast"
 )
 
@@ -87,7 +89,48 @@ func (c *Catalog) dropPlacementPolicy(stmt *nodes.DropPlacementPolicyStmt) error
 		}
 		return errUnknownPlacementPolicy(stmt.Name)
 	}
+	// TiDB rejects DROP when any database or table still references
+	// the policy (error 8240 "Placement policy 'X' is still in use").
+	// The catalog mirrors TiDB's execution-time validation since it
+	// has both the database and table reference info indexed.
+	if ref := c.findPolicyReference(stmt.Name); ref != "" {
+		return errPlacementPolicyInUse(stmt.Name, ref)
+	}
 	delete(c.placementPolicies, key)
+	return nil
+}
+
+// findPolicyReference returns a human-readable description of the
+// first database or table referencing the named policy, or "" if
+// there are no references. Case-insensitive comparison matches
+// TiDB's CIStr policy-name convention.
+func (c *Catalog) findPolicyReference(name string) string {
+	target := toLower(name)
+	for _, db := range c.databases {
+		if toLower(db.PlacementPolicy) == target {
+			return fmt.Sprintf("database %q", db.Name)
+		}
+		for _, t := range db.Tables {
+			if toLower(t.PlacementPolicy) == target {
+				return fmt.Sprintf("table %q.%q", db.Name, t.Name)
+			}
+		}
+	}
+	return ""
+}
+
+// validatePolicyRef returns an error if the named policy is not
+// registered in the catalog. Empty names (no PLACEMENT POLICY clause)
+// are treated as "no reference" and return nil. Used by the table
+// and database option wiring to reject references to unknown policies
+// (TiDB error 8237 parity).
+func (c *Catalog) validatePolicyRef(name string) error {
+	if name == "" {
+		return nil
+	}
+	if c.GetPlacementPolicy(name) == nil {
+		return errUnknownPlacementPolicy(name)
+	}
 	return nil
 }
 

--- a/tidb/catalog/placement_policy.go
+++ b/tidb/catalog/placement_policy.go
@@ -124,14 +124,40 @@ func (c *Catalog) findPolicyReference(name string) string {
 // are treated as "no reference" and return nil. Used by the table
 // and database option wiring to reject references to unknown policies
 // (TiDB error 8237 parity).
+//
+// The name "default" (case-insensitive) is a TiDB sentinel meaning
+// "clear placement / inherit" and short-circuits catalog validation —
+// see pkg/ddl/placement_policy.go's defaultPlacementPolicyName check
+// in upstream. All four grammar arms that produce the policy reference
+// (`='default'`, `=default`, `=DEFAULT`, `SET DEFAULT`) collapse to the
+// same StrValue, so a single string-compare suffices.
 func (c *Catalog) validatePolicyRef(name string) error {
-	if name == "" {
+	if name == "" || isDefaultPolicyName(name) {
 		return nil
 	}
 	if c.GetPlacementPolicy(name) == nil {
 		return errUnknownPlacementPolicy(name)
 	}
 	return nil
+}
+
+// isDefaultPolicyName reports whether the given policy reference is
+// the special-cased "default" sentinel (case-insensitive). Callers
+// must treat this as a clear-policy operation, not a named reference.
+func isDefaultPolicyName(name string) bool {
+	return toLower(name) == "default"
+}
+
+// resolvePolicyRef returns the stored form of a policy reference. The
+// special-cased "default" sentinel collapses to the empty string so
+// downstream code sees "no policy" rather than a pseudo-policy named
+// "default". Matches TiDB's in-memory representation, where SET
+// PLACEMENT POLICY = default clears the ref on the table/database.
+func resolvePolicyRef(name string) string {
+	if isDefaultPolicyName(name) {
+		return ""
+	}
+	return name
 }
 
 func convertPolicyOptions(src []*nodes.PlacementPolicyOption) []*PlacementPolicyOption {

--- a/tidb/catalog/tablecmds.go
+++ b/tidb/catalog/tablecmds.go
@@ -88,6 +88,9 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 		case "auto_random_base":
 			fmt.Sscanf(opt.Value, "%d", &tbl.AutoRandomBase)
 		case "placement policy":
+			if err := c.validatePolicyRef(opt.Value); err != nil {
+				return err
+			}
 			tbl.PlacementPolicy = opt.Value
 		case "ttl":
 			col, interval, err := extractTTLParts(opt.Value)

--- a/tidb/catalog/tablecmds.go
+++ b/tidb/catalog/tablecmds.go
@@ -91,7 +91,7 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			if err := c.validatePolicyRef(opt.Value); err != nil {
 				return err
 			}
-			tbl.PlacementPolicy = opt.Value
+			tbl.PlacementPolicy = resolvePolicyRef(opt.Value)
 		case "ttl":
 			col, interval, err := extractTTLParts(opt.Value)
 			if err != nil {

--- a/tidb/catalog/tidb_container_test.go
+++ b/tidb/catalog/tidb_container_test.go
@@ -182,16 +182,11 @@ func TestTiDBCatalogContainerCrossValidation(t *testing.T) {
 			if c.setup != "" {
 				results, err := cat.Exec(c.setup, nil)
 				if err != nil {
-					// Catalog may not support PLACEMENT POLICY DDL yet — PR3
-					// stores PLACEMENT POLICY as a table attribute but does
-					// not track policies as first-class catalog objects.
-					// Skip the lockstep comparison when catalog setup fails
-					// on syntax the catalog doesn't model.
-					t.Skipf("catalog does not model setup SQL %q (deferred to future PR): %v", c.setup, err)
+					t.Fatalf("catalog rejected setup SQL %q: %v", c.setup, err)
 				}
 				for _, r := range results {
 					if r.Error != nil {
-						t.Skipf("catalog exec of setup SQL returned error %v (likely unmodeled DDL)", r.Error)
+						t.Fatalf("catalog exec error on setup %q: %v", c.setup, r.Error)
 					}
 				}
 			}

--- a/tidb/catalog/tidb_placement_policy_container_test.go
+++ b/tidb/catalog/tidb_placement_policy_container_test.go
@@ -106,6 +106,45 @@ func TestTiDBPlacementPolicyContainer(t *testing.T) {
 	}
 }
 
+// TestTiDBPlacementPolicyDefaultSentinel pins the "default"
+// special-name behavior against real TiDB. Upstream short-circuits
+// at pkg/ddl/placement_policy.go defaultPlacementPolicyName — a
+// reference to "default" must bypass policy lookup and be accepted
+// even when no policy by that name exists.
+func TestTiDBPlacementPolicyDefaultSentinel(t *testing.T) {
+	tc := startTiDBForCatalog(t)
+	mustExecTiDB(t, tc, "CREATE DATABASE IF NOT EXISTS omni_pp_default")
+	mustExecTiDB(t, tc, "USE omni_pp_default")
+	t.Cleanup(func() { _, _ = tc.db.ExecContext(tc.ctx, "DROP DATABASE IF EXISTS omni_pp_default") })
+
+	inputs := []struct {
+		label string
+		sql   string
+		drop  string
+	}{
+		{"identifier", "CREATE TABLE t_def_id (id INT) PLACEMENT POLICY = default", "DROP TABLE IF EXISTS t_def_id"},
+		{"quoted_string", "CREATE TABLE t_def_str (id INT) PLACEMENT POLICY = 'default'", "DROP TABLE IF EXISTS t_def_str"},
+		{"upper_keyword", "CREATE TABLE t_def_up (id INT) PLACEMENT POLICY = DEFAULT", "DROP TABLE IF EXISTS t_def_up"},
+	}
+	for _, in := range inputs {
+		t.Run(in.label, func(t *testing.T) {
+			// 1. TiDB must accept without any CREATE PLACEMENT POLICY default.
+			if _, err := tc.db.ExecContext(tc.ctx, in.sql); err != nil {
+				t.Fatalf("TiDB rejected sentinel form %q: %v", in.sql, err)
+			}
+			// 2. Catalog must also accept.
+			cat := New()
+			if _, err := cat.Exec("CREATE DATABASE omni_pp_default; USE omni_pp_default;", nil); err != nil {
+				t.Fatalf("cat setup: %v", err)
+			}
+			if _, err := cat.Exec(in.sql, nil); err != nil {
+				t.Fatalf("catalog rejected sentinel form %q: %v", in.sql, err)
+			}
+			_, _ = tc.db.ExecContext(tc.ctx, in.drop)
+		})
+	}
+}
+
 // TestTiDBPlacementPolicyAlterReplaceSemantics pins the claim made in
 // catalog/placement_policy.go alterPlacementPolicy: ALTER replaces the
 // option list wholesale, it does NOT merge. Uses SHOW CREATE PLACEMENT

--- a/tidb/catalog/tidb_placement_policy_container_test.go
+++ b/tidb/catalog/tidb_placement_policy_container_test.go
@@ -1,0 +1,104 @@
+package catalog
+
+import "testing"
+
+// TestTiDBPlacementPolicyContainer cross-validates that omni's
+// PLACEMENT POLICY DDL matches real TiDB v8.5.5 acceptance. Reuses the
+// startTiDBForCatalog helper from tidb_container_test.go.
+//
+// Note: TiDB requires at least some option to be present on CREATE;
+// the grammar allows zero-option policies but TiDB rejects them at
+// semantic time ("Could not create placement policy with empty info").
+// We therefore always send at least one option.
+func TestTiDBPlacementPolicyContainer(t *testing.T) {
+	tc := startTiDBForCatalog(t)
+
+	mustExecTiDB(t, tc, "CREATE DATABASE IF NOT EXISTS omni_pp_test")
+	mustExecTiDB(t, tc, "USE omni_pp_test")
+	t.Cleanup(func() { _, _ = tc.db.ExecContext(tc.ctx, "DROP DATABASE IF EXISTS omni_pp_test") })
+
+	cases := []struct {
+		name    string
+		setup   string
+		sql     string
+		cleanup string
+	}{
+		{
+			name:    "create_primary_region",
+			sql:     "CREATE PLACEMENT POLICY pp_cpr PRIMARY_REGION = 'us-east-1' REGIONS = 'us-east-1'",
+			cleanup: "DROP PLACEMENT POLICY IF EXISTS pp_cpr",
+		},
+		{
+			name:    "create_followers",
+			sql:     "CREATE PLACEMENT POLICY pp_cf FOLLOWERS = 2",
+			cleanup: "DROP PLACEMENT POLICY IF EXISTS pp_cf",
+		},
+		{
+			name:    "create_constraints_list",
+			sql:     `CREATE PLACEMENT POLICY pp_ccl CONSTRAINTS='[+region=us-east-1]'`,
+			cleanup: "DROP PLACEMENT POLICY IF EXISTS pp_ccl",
+		},
+		{
+			name:    "create_or_replace",
+			setup:   "CREATE PLACEMENT POLICY pp_or FOLLOWERS = 2",
+			sql:     "CREATE OR REPLACE PLACEMENT POLICY pp_or FOLLOWERS = 3",
+			cleanup: "DROP PLACEMENT POLICY IF EXISTS pp_or",
+		},
+		{
+			name:    "alter_placement_policy",
+			setup:   "CREATE PLACEMENT POLICY pp_alter FOLLOWERS = 2",
+			sql:     "ALTER PLACEMENT POLICY pp_alter PRIMARY_REGION = 'us-east-1' REGIONS = 'us-east-1'",
+			cleanup: "DROP PLACEMENT POLICY IF EXISTS pp_alter",
+		},
+		{
+			name:    "drop_if_exists_missing",
+			sql:     "DROP PLACEMENT POLICY IF EXISTS never_defined_pp",
+			cleanup: "",
+		},
+		{
+			// The end-to-end case that PR3b couldn't run: define a
+			// policy, then reference it from CREATE TABLE. Without
+			// Tier 1, catalog.Exec rejected the CREATE PLACEMENT
+			// POLICY line and the container test had to skip.
+			name:    "policy_then_table_reference",
+			setup:   "CREATE PLACEMENT POLICY pp_tbl PRIMARY_REGION='us-east-1' REGIONS='us-east-1'",
+			sql:     "CREATE TABLE t_pp (id INT) PLACEMENT POLICY = pp_tbl",
+			cleanup: "DROP TABLE IF EXISTS t_pp; DROP PLACEMENT POLICY IF EXISTS pp_tbl",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.setup != "" {
+				mustExecTiDB(t, tc, c.setup)
+			}
+			// 1. TiDB must accept.
+			if _, err := tc.db.ExecContext(tc.ctx, c.sql); err != nil {
+				t.Fatalf("TiDB rejected %q: %v", c.sql, err)
+			}
+			// 2. Catalog must accept through its own parser+exec.
+			cat := New()
+			catSetup := "CREATE DATABASE omni_pp_test; USE omni_pp_test;"
+			if _, err := cat.Exec(catSetup, nil); err != nil {
+				t.Fatalf("catalog setup: %v", err)
+			}
+			if c.setup != "" {
+				if _, err := cat.Exec(c.setup, nil); err != nil {
+					t.Fatalf("catalog rejected setup %q: %v", c.setup, err)
+				}
+			}
+			results, err := cat.Exec(c.sql, nil)
+			if err != nil {
+				t.Fatalf("catalog rejected %q: %v", c.sql, err)
+			}
+			for _, r := range results {
+				if r.Error != nil {
+					t.Fatalf("catalog exec error on %q: %v", c.sql, r.Error)
+				}
+			}
+			if c.cleanup != "" {
+				_, _ = tc.db.ExecContext(tc.ctx, c.cleanup)
+			}
+		})
+	}
+}

--- a/tidb/catalog/tidb_placement_policy_container_test.go
+++ b/tidb/catalog/tidb_placement_policy_container_test.go
@@ -106,6 +106,39 @@ func TestTiDBPlacementPolicyContainer(t *testing.T) {
 	}
 }
 
+// TestTiDBPlacementPolicyGrammarNegatives pins that omni and TiDB
+// agree on rejection of malformed PlacementOptionList inputs. The
+// upstream grammar at parser.y:1999-2011 requires >=1 option and
+// forbids a trailing comma; this test confirms TiDB enforces both at
+// parse time, so omni's parser enforcement is not over-strict.
+func TestTiDBPlacementPolicyGrammarNegatives(t *testing.T) {
+	tc := startTiDBForCatalog(t)
+	t.Cleanup(func() { _, _ = tc.db.ExecContext(tc.ctx, "DROP PLACEMENT POLICY IF EXISTS pp_neg") })
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"create_empty_options", "CREATE PLACEMENT POLICY pp_neg"},
+		{"create_trailing_comma", "CREATE PLACEMENT POLICY pp_neg PRIMARY_REGION = 'us',"},
+		{"alter_empty_options", "ALTER PLACEMENT POLICY pp_neg"},
+		{"alter_trailing_comma", "ALTER PLACEMENT POLICY pp_neg PRIMARY_REGION = 'us',"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := tc.db.ExecContext(tc.ctx, c.sql); err == nil {
+				t.Errorf("TiDB unexpectedly accepted malformed SQL %q", c.sql)
+			}
+			// Omni must also reject. Parse-level check is sufficient;
+			// the Exec path routes parse errors as the top-level error.
+			cat := New()
+			if _, err := cat.Exec(c.sql, nil); err == nil {
+				t.Errorf("omni unexpectedly accepted malformed SQL %q (oracle divergence)", c.sql)
+			}
+		})
+	}
+}
+
 // TestTiDBPlacementPolicyDefaultSentinel pins the "default"
 // special-name behavior against real TiDB. Upstream short-circuits
 // at pkg/ddl/placement_policy.go defaultPlacementPolicyName — a

--- a/tidb/catalog/tidb_placement_policy_container_test.go
+++ b/tidb/catalog/tidb_placement_policy_container_test.go
@@ -1,6 +1,9 @@
 package catalog
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestTiDBPlacementPolicyContainer cross-validates that omni's
 // PLACEMENT POLICY DDL matches real TiDB v8.5.5 acceptance. Reuses the
@@ -100,5 +103,52 @@ func TestTiDBPlacementPolicyContainer(t *testing.T) {
 				_, _ = tc.db.ExecContext(tc.ctx, c.cleanup)
 			}
 		})
+	}
+}
+
+// TestTiDBPlacementPolicyAlterReplaceSemantics pins the claim made in
+// catalog/placement_policy.go alterPlacementPolicy: ALTER replaces the
+// option list wholesale, it does NOT merge. Uses SHOW CREATE PLACEMENT
+// POLICY to read back actual TiDB state rather than just asserting
+// that the ALTER was accepted.
+func TestTiDBPlacementPolicyAlterReplaceSemantics(t *testing.T) {
+	tc := startTiDBForCatalog(t)
+	t.Cleanup(func() { _, _ = tc.db.ExecContext(tc.ctx, "DROP PLACEMENT POLICY IF EXISTS pp_rb") })
+
+	mustExecTiDB(t, tc, "CREATE PLACEMENT POLICY pp_rb FOLLOWERS = 2")
+	mustExecTiDB(t, tc, "ALTER PLACEMENT POLICY pp_rb PRIMARY_REGION = 'us-west-1' REGIONS = 'us-west-1'")
+
+	var name, def string
+	row := tc.db.QueryRowContext(tc.ctx, "SHOW CREATE PLACEMENT POLICY pp_rb")
+	if err := row.Scan(&name, &def); err != nil {
+		t.Fatalf("SHOW CREATE PLACEMENT POLICY: %v", err)
+	}
+	// After ALTER, FOLLOWERS=2 must be gone. Case-insensitive match
+	// since TiDB's SHOW output may uppercase keywords differently
+	// across versions.
+	low := strings.ToLower(def)
+	if strings.Contains(low, "followers") {
+		t.Errorf("ALTER did not replace option list; FOLLOWERS leaked: %s", def)
+	}
+	if !strings.Contains(low, "primary_region") {
+		t.Errorf("ALTER lost PRIMARY_REGION: %s", def)
+	}
+
+	// Now verify catalog agrees: fresh catalog, same SQL flow.
+	cat := New()
+	if _, err := cat.Exec("CREATE PLACEMENT POLICY pp_rb FOLLOWERS = 2", nil); err != nil {
+		t.Fatalf("cat CREATE: %v", err)
+	}
+	if _, err := cat.Exec("ALTER PLACEMENT POLICY pp_rb PRIMARY_REGION = 'us-west-1' REGIONS = 'us-west-1'", nil); err != nil {
+		t.Fatalf("cat ALTER: %v", err)
+	}
+	p := cat.GetPlacementPolicy("pp_rb")
+	for _, o := range p.Options {
+		if o.Name == "FOLLOWERS" {
+			t.Errorf("catalog ALTER leaked FOLLOWERS: %+v", p.Options)
+		}
+	}
+	if len(p.Options) != 2 {
+		t.Errorf("catalog ALTER result: want 2 options, got %d: %+v", len(p.Options), p.Options)
 	}
 }

--- a/tidb/catalog/wt_tidb_1_test.go
+++ b/tidb/catalog/wt_tidb_1_test.go
@@ -28,6 +28,9 @@ func TestWTTiDB_1_1_AutoRandom(t *testing.T) {
 
 func TestWTTiDB_1_2_PlacementPolicy(t *testing.T) {
 	c := wtSetup(t)
+	// Policy must be defined before a table can reference it — catalog
+	// validates refs against the first-class policy map (TiDB error 8237 parity).
+	wtExec(t, c, "CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us-east'")
 	wtExec(t, c, "CREATE TABLE t (id INT) PLACEMENT POLICY = p1")
 
 	tbl := c.GetDatabase("testdb").GetTable("t")
@@ -120,6 +123,7 @@ func TestWTTiDB_1_6b_InlineClusteredPK(t *testing.T) {
 // single-feature test only by luck.
 func TestWTTiDB_1_7_MultiFeatureInteraction(t *testing.T) {
 	c := wtSetup(t)
+	wtExec(t, c, "CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us-east'")
 	wtExec(t, c, `CREATE TABLE orders (
 		id BIGINT AUTO_RANDOM(5) PRIMARY KEY CLUSTERED,
 		created_at DATETIME,

--- a/tidb/catalog/wt_tidb_2_test.go
+++ b/tidb/catalog/wt_tidb_2_test.go
@@ -12,6 +12,10 @@ import "testing"
 // DATABASE can change it.
 func TestWTTiDB_2_1_DatabasePlacementPolicy(t *testing.T) {
 	c := New()
+	// Policies must be defined before a database can reference them.
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us'; CREATE PLACEMENT POLICY p2 PRIMARY_REGION = 'eu';", nil); err != nil {
+		t.Fatalf("CREATE POLICIES: %v", err)
+	}
 	if _, err := c.Exec("CREATE DATABASE ddb PLACEMENT POLICY = p1", nil); err != nil {
 		t.Fatalf("CREATE DATABASE: %v", err)
 	}

--- a/tidb/catalog/wt_tidb_policy_test.go
+++ b/tidb/catalog/wt_tidb_policy_test.go
@@ -138,6 +138,125 @@ func TestWTTiDBPolicy_10_DropIfExistsSilences(t *testing.T) {
 	}
 }
 
+// TestWTTiDBPolicy_AlterReplacesWholesale verifies that ALTER
+// replaces the option list rather than merging. The container test
+// asserts TiDB accepts the ALTER; this test assertions the catalog's
+// in-memory state actually reflects the replace, pinning the behavior
+// claimed in catalog/placement_policy.go's alterPlacementPolicy comment.
+func TestWTTiDBPolicy_AlterReplacesWholesale(t *testing.T) {
+	c := New()
+	wtExecRaw(t, c, "CREATE PLACEMENT POLICY p PRIMARY_REGION = 'us' FOLLOWERS = 2")
+	wtExecRaw(t, c, "ALTER PLACEMENT POLICY p PRIMARY_REGION = 'eu'")
+
+	p := c.GetPlacementPolicy("p")
+	if p == nil {
+		t.Fatal("policy missing")
+	}
+	if len(p.Options) != 1 {
+		t.Fatalf("ALTER should have replaced option list (want 1 entry), got %d: %+v", len(p.Options), p.Options)
+	}
+	if p.Options[0].Name != "PRIMARY_REGION" || p.Options[0].Value != "eu" {
+		t.Errorf("option content: %+v", p.Options[0])
+	}
+	// FOLLOWERS = 2 must be gone.
+	for _, o := range p.Options {
+		if o.Name == "FOLLOWERS" {
+			t.Error("FOLLOWERS=2 from CREATE leaked into ALTER result (merge, not replace)")
+		}
+	}
+}
+
+// TestWTTiDBPolicy_RefValidation verifies that CREATE TABLE and
+// CREATE DATABASE with an unknown policy name are rejected (TiDB
+// error 8237 parity).
+func TestWTTiDBPolicy_RefValidation(t *testing.T) {
+	c := New()
+	// No policy defined yet; table reference must fail.
+	if _, err := c.Exec("CREATE DATABASE testdb; USE testdb;", nil); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	results, err := c.Exec("CREATE TABLE t (id INT) PLACEMENT POLICY = ghost", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected unknown-policy error on CREATE TABLE referencing undefined policy")
+	}
+	// Database reference to unknown policy.
+	results, err = c.Exec("CREATE DATABASE d2 PLACEMENT POLICY = ghost", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected unknown-policy error on CREATE DATABASE referencing undefined policy")
+	}
+}
+
+// TestWTTiDBPolicy_DropInUseRejected verifies that DROP PLACEMENT
+// POLICY is rejected when any table or database still references it.
+// Mirrors TiDB error 8240.
+func TestWTTiDBPolicy_DropInUseRejected(t *testing.T) {
+	c := New()
+	wtExecRaw(t, c, "CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us'")
+	wtExecRaw(t, c, "CREATE DATABASE testdb; USE testdb;")
+	wtExecRaw(t, c, "CREATE TABLE t (id INT) PLACEMENT POLICY = p1")
+
+	// Drop must fail: table references policy.
+	results, err := c.Exec("DROP PLACEMENT POLICY p1", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected in-use error on DROP PLACEMENT POLICY with table reference")
+	}
+
+	// Policy still in catalog (DROP didn't partially succeed).
+	if c.GetPlacementPolicy("p1") == nil {
+		t.Error("failed DROP left policy removed from catalog")
+	}
+
+	// Remove the reference, DROP succeeds.
+	wtExecRaw(t, c, "DROP TABLE t")
+	if _, err := c.Exec("DROP PLACEMENT POLICY p1", nil); err != nil {
+		t.Fatalf("DROP after removing ref: %v", err)
+	}
+	if c.GetPlacementPolicy("p1") != nil {
+		t.Error("DROP did not remove policy from catalog")
+	}
+}
+
+// TestWTTiDBPolicy_DropInUseByDatabase is the DB-reference equivalent
+// of TestWTTiDBPolicy_DropInUseRejected.
+func TestWTTiDBPolicy_DropInUseByDatabase(t *testing.T) {
+	c := New()
+	wtExecRaw(t, c, "CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us'")
+	wtExecRaw(t, c, "CREATE DATABASE ddb PLACEMENT POLICY = p1")
+
+	results, err := c.Exec("DROP PLACEMENT POLICY p1", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected in-use error on DROP PLACEMENT POLICY with database reference")
+	}
+}
+
+// wtExecRaw executes SQL on an arbitrary catalog (no testdb setup),
+// fataling on any parse or exec error. Suited for tests that manage
+// their own database-creation order.
+func wtExecRaw(t *testing.T, c *Catalog, sql string) {
+	t.Helper()
+	results, err := c.Exec(sql, nil)
+	if err != nil {
+		t.Fatalf("Exec parse error on %q: %v", sql, err)
+	}
+	for _, r := range results {
+		if r.Error != nil {
+			t.Fatalf("Exec runtime error on %q (stmt %d): %v", sql, r.Index, r.Error)
+		}
+	}
+}
+
 // TestWTTiDBPolicy_11_EndToEndRoundTrip exercises the scenario that
 // PR3b left broken: defining a policy and then referencing it from a
 // CREATE TABLE. Before Tier 1, the CREATE PLACEMENT POLICY statement

--- a/tidb/catalog/wt_tidb_policy_test.go
+++ b/tidb/catalog/wt_tidb_policy_test.go
@@ -1,0 +1,172 @@
+package catalog
+
+import "testing"
+
+// Walkthrough tests for the TiDB PLACEMENT POLICY DDL added in Tier 1.
+// Each test goes through Exec() to exercise the full parser→dispatcher
+// →catalog path.
+
+func TestWTTiDBPolicy_1_Create(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us-east' REGIONS = 'us-east,us-west'", nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	p := c.GetPlacementPolicy("p1")
+	if p == nil {
+		t.Fatal("policy p1 not found after CREATE")
+	}
+	if p.Name != "p1" {
+		t.Errorf("Name = %q", p.Name)
+	}
+	if len(p.Options) != 2 {
+		t.Fatalf("want 2 options, got %d", len(p.Options))
+	}
+}
+
+func TestWTTiDBPolicy_2_CreateDuplicateErrors(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 FOLLOWERS = 2", nil); err != nil {
+		t.Fatalf("first CREATE: %v", err)
+	}
+	results, err := c.Exec("CREATE PLACEMENT POLICY p1 FOLLOWERS = 3", nil)
+	if err != nil {
+		t.Fatalf("parse error on second CREATE: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected duplicate-policy error on second CREATE without OR REPLACE / IF NOT EXISTS")
+	}
+}
+
+func TestWTTiDBPolicy_3_OrReplaceOverwrites(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 FOLLOWERS = 2", nil); err != nil {
+		t.Fatalf("first CREATE: %v", err)
+	}
+	if _, err := c.Exec("CREATE OR REPLACE PLACEMENT POLICY p1 FOLLOWERS = 5", nil); err != nil {
+		t.Fatalf("OR REPLACE: %v", err)
+	}
+	p := c.GetPlacementPolicy("p1")
+	if p == nil || len(p.Options) != 1 || p.Options[0].IntValue != 5 {
+		t.Errorf("OR REPLACE did not overwrite options: %+v", p)
+	}
+}
+
+func TestWTTiDBPolicy_4_IfNotExistsSilences(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 FOLLOWERS = 2", nil); err != nil {
+		t.Fatalf("first CREATE: %v", err)
+	}
+	results, err := c.Exec("CREATE PLACEMENT POLICY IF NOT EXISTS p1 FOLLOWERS = 9", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error != nil {
+		t.Errorf("IF NOT EXISTS should silence duplicate, got: %v", results[0].Error)
+	}
+	// Should NOT have been overwritten.
+	p := c.GetPlacementPolicy("p1")
+	if p.Options[0].IntValue != 2 {
+		t.Errorf("IF NOT EXISTS overwrote original policy")
+	}
+}
+
+func TestWTTiDBPolicy_5_AlterReplacesOptions(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us' FOLLOWERS = 2", nil); err != nil {
+		t.Fatalf("CREATE: %v", err)
+	}
+	if _, err := c.Exec("ALTER PLACEMENT POLICY p1 PRIMARY_REGION = 'eu'", nil); err != nil {
+		t.Fatalf("ALTER: %v", err)
+	}
+	p := c.GetPlacementPolicy("p1")
+	if len(p.Options) != 1 || p.Options[0].Value != "eu" {
+		t.Errorf("ALTER did not replace options: %+v", p.Options)
+	}
+}
+
+func TestWTTiDBPolicy_6_AlterUnknownErrors(t *testing.T) {
+	c := New()
+	results, err := c.Exec("ALTER PLACEMENT POLICY ghost PRIMARY_REGION = 'us'", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected unknown-policy error on ALTER with no IF EXISTS")
+	}
+}
+
+func TestWTTiDBPolicy_7_AlterIfExistsSilences(t *testing.T) {
+	c := New()
+	results, err := c.Exec("ALTER PLACEMENT POLICY IF EXISTS ghost PRIMARY_REGION = 'us'", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error != nil {
+		t.Errorf("IF EXISTS should silence missing policy, got: %v", results[0].Error)
+	}
+}
+
+func TestWTTiDBPolicy_8_Drop(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE PLACEMENT POLICY p1 FOLLOWERS = 2; DROP PLACEMENT POLICY p1", nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if c.GetPlacementPolicy("p1") != nil {
+		t.Error("policy should be gone after DROP")
+	}
+}
+
+func TestWTTiDBPolicy_9_DropUnknownErrors(t *testing.T) {
+	c := New()
+	results, err := c.Exec("DROP PLACEMENT POLICY ghost", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error == nil {
+		t.Error("expected unknown-policy error on DROP without IF EXISTS")
+	}
+}
+
+func TestWTTiDBPolicy_10_DropIfExistsSilences(t *testing.T) {
+	c := New()
+	results, err := c.Exec("DROP PLACEMENT POLICY IF EXISTS ghost", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if results[0].Error != nil {
+		t.Errorf("IF EXISTS should silence missing policy on DROP, got: %v", results[0].Error)
+	}
+}
+
+// TestWTTiDBPolicy_11_EndToEndRoundTrip exercises the scenario that
+// PR3b left broken: defining a policy and then referencing it from a
+// CREATE TABLE. Before Tier 1, the CREATE PLACEMENT POLICY statement
+// failed to parse and this whole flow was impossible.
+func TestWTTiDBPolicy_11_EndToEndRoundTrip(t *testing.T) {
+	c := New()
+	sql := `
+		CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us-east' REGIONS = 'us-east,us-west';
+		CREATE DATABASE ddb PLACEMENT POLICY = p1;
+		USE ddb;
+		CREATE TABLE t (id INT) PLACEMENT POLICY = p1;
+	`
+	results, err := c.Exec(sql, nil)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	for i, r := range results {
+		if r.Error != nil {
+			t.Fatalf("stmt %d (%q) failed: %v", i, r.SQL, r.Error)
+		}
+	}
+	if c.GetPlacementPolicy("p1") == nil {
+		t.Fatal("policy p1 not in catalog after round-trip")
+	}
+	if c.GetDatabase("ddb").PlacementPolicy != "p1" {
+		t.Errorf("database ddb did not record policy reference")
+	}
+	tbl := c.GetDatabase("ddb").GetTable("t")
+	if tbl.PlacementPolicy != "p1" {
+		t.Errorf("table t did not record policy reference")
+	}
+}

--- a/tidb/catalog/wt_tidb_policy_test.go
+++ b/tidb/catalog/wt_tidb_policy_test.go
@@ -241,6 +241,48 @@ func TestWTTiDBPolicy_DropInUseByDatabase(t *testing.T) {
 	}
 }
 
+// TestWTTiDBPolicy_DropBacktickDefaultSucceeds pins an implicit
+// consequence of the "default" sentinel: if a user backtick-creates
+// `default` as a policy, no subsequent table or database can actually
+// reference it (every textual form of "default" hits the sentinel
+// short-circuit before PolicyByName). Therefore the in-use scan on
+// DROP never fires, and DROP succeeds regardless of how many tables
+// carry `PLACEMENT POLICY = default` clauses in their DDL history.
+//
+// This is correct upstream behavior — flagged by review as worth
+// pinning so a future refactor that reorders the in-use scan vs. the
+// sentinel check can't silently break it.
+func TestWTTiDBPolicy_DropBacktickDefaultSucceeds(t *testing.T) {
+	c := wtSetup(t)
+	wtExec(t, c, "CREATE PLACEMENT POLICY `default` PRIMARY_REGION = 'us-east'")
+
+	// Create several tables that "reference" default in different
+	// textual forms. None of them actually store "default" as the ref
+	// due to resolvePolicyRef collapsing to "" — so the DROP below
+	// must still find zero references.
+	wtExec(t, c, "CREATE TABLE t1 (id INT) PLACEMENT POLICY = default")
+	wtExec(t, c, "CREATE TABLE t2 (id INT) PLACEMENT POLICY = 'default'")
+	wtExec(t, c, "CREATE TABLE t3 (id INT) PLACEMENT POLICY = DEFAULT")
+	wtExec(t, c, "CREATE TABLE t4 (id INT) PLACEMENT POLICY = `default`")
+
+	// Sanity: no table ended up with PlacementPolicy == "default".
+	db := c.GetDatabase("testdb")
+	for _, name := range []string{"t1", "t2", "t3", "t4"} {
+		if got := db.GetTable(name).PlacementPolicy; got != "" {
+			t.Errorf("%s.PlacementPolicy = %q, want empty (sentinel collapsed)", name, got)
+		}
+	}
+
+	// DROP succeeds — the in-use scan finds nothing referencing the
+	// backtick-`default` policy.
+	if _, err := c.Exec("DROP PLACEMENT POLICY `default`", nil); err != nil {
+		t.Fatalf("DROP PLACEMENT POLICY `default`: %v", err)
+	}
+	if c.GetPlacementPolicy("default") != nil {
+		t.Error("DROP did not remove backtick-`default` policy from catalog")
+	}
+}
+
 // TestWTTiDBPolicy_DefaultSentinel verifies the special-cased "default"
 // policy name: it must bypass ref validation and clear the assigned
 // policy to the empty string (matching TiDB's short-circuit at

--- a/tidb/catalog/wt_tidb_policy_test.go
+++ b/tidb/catalog/wt_tidb_policy_test.go
@@ -241,6 +241,90 @@ func TestWTTiDBPolicy_DropInUseByDatabase(t *testing.T) {
 	}
 }
 
+// TestWTTiDBPolicy_DefaultSentinel verifies the special-cased "default"
+// policy name: it must bypass ref validation and clear the assigned
+// policy to the empty string (matching TiDB's short-circuit at
+// pkg/ddl/placement_policy.go's defaultPlacementPolicyName check).
+// All three input forms — `default`, 'default', DEFAULT — collapse to
+// the same catalog result.
+func TestWTTiDBPolicy_DefaultSentinel(t *testing.T) {
+	inputs := []struct {
+		label string
+		sql   string
+	}{
+		{"identifier default", "CREATE TABLE t (id INT) PLACEMENT POLICY = default"},
+		{"quoted 'default'", "CREATE TABLE t (id INT) PLACEMENT POLICY = 'default'"},
+		// Upper-case DEFAULT is also accepted; catalog normalizes via
+		// toLower in isDefaultPolicyName.
+		{"keyword DEFAULT", "CREATE TABLE t (id INT) PLACEMENT POLICY = DEFAULT"},
+	}
+	for _, in := range inputs {
+		t.Run(in.label, func(t *testing.T) {
+			c := wtSetup(t)
+			// No policy defined; default must still work.
+			wtExec(t, c, in.sql)
+			tbl := c.GetDatabase("testdb").GetTable("t")
+			if tbl == nil {
+				t.Fatal("table not created")
+			}
+			if tbl.PlacementPolicy != "" {
+				t.Errorf("default sentinel should clear policy, got %q", tbl.PlacementPolicy)
+			}
+		})
+	}
+}
+
+// TestWTTiDBPolicy_DefaultOnDatabase verifies the sentinel works on
+// CREATE DATABASE too (same code path via validatePolicyRef +
+// resolvePolicyRef in dbcmds.go).
+func TestWTTiDBPolicy_DefaultOnDatabase(t *testing.T) {
+	c := New()
+	wtExecRaw(t, c, "CREATE DATABASE ddb PLACEMENT POLICY = default")
+	db := c.GetDatabase("ddb")
+	if db == nil {
+		t.Fatal("database not created")
+	}
+	if db.PlacementPolicy != "" {
+		t.Errorf("default sentinel should clear DB policy, got %q", db.PlacementPolicy)
+	}
+}
+
+// TestWTTiDBPolicy_DefaultClearsExisting verifies that ALTER with
+// `default` clears a previously-set policy rather than setting the
+// field to the literal string "default".
+func TestWTTiDBPolicy_DefaultClearsExisting(t *testing.T) {
+	c := wtSetup(t)
+	wtExec(t, c, "CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us'")
+	wtExec(t, c, "CREATE TABLE t (id INT) PLACEMENT POLICY = p1")
+	// Sanity.
+	if tbl := c.GetDatabase("testdb").GetTable("t"); tbl.PlacementPolicy != "p1" {
+		t.Fatalf("setup failed: %q", tbl.PlacementPolicy)
+	}
+	wtExec(t, c, "ALTER TABLE t PLACEMENT POLICY = default")
+	if tbl := c.GetDatabase("testdb").GetTable("t"); tbl.PlacementPolicy != "" {
+		t.Errorf("ALTER TABLE ... = default should clear policy, got %q", tbl.PlacementPolicy)
+	}
+}
+
+// TestWTTiDBPolicy_ExplicitDefaultPolicyShadows documents a quirk: if
+// a user literally names a policy `default` (via backtick-quoting), it
+// still won't actually be referenced by unquoted/string `default`
+// because the sentinel short-circuit fires FIRST. This matches TiDB's
+// upstream check order at placement_policy.go:~478: the defaultName
+// compare happens before PolicyByName lookup.
+func TestWTTiDBPolicy_ExplicitDefaultPolicyShadows(t *testing.T) {
+	c := wtSetup(t)
+	// Users CAN create a backtick-quoted `default` policy in TiDB, but
+	// it becomes unreachable via PLACEMENT POLICY = default — the
+	// sentinel always wins. Omni must match.
+	wtExec(t, c, "CREATE PLACEMENT POLICY `default` PRIMARY_REGION = 'us-east'")
+	wtExec(t, c, "CREATE TABLE t (id INT) PLACEMENT POLICY = default")
+	tbl := c.GetDatabase("testdb").GetTable("t")
+	if tbl.PlacementPolicy != "" {
+		t.Errorf("sentinel should win over literally-named `default` policy; got %q", tbl.PlacementPolicy)
+	}
+}
+
 // wtExecRaw executes SQL on an arbitrary catalog (no testdb setup),
 // fataling on any parse or exec error. Suited for tests that manage
 // their own database-creation order.

--- a/tidb/completion/tidb_keywords_test.go
+++ b/tidb/completion/tidb_keywords_test.go
@@ -88,6 +88,70 @@ func TestTiDBKeywords_CreateDatabasePlacement(t *testing.T) {
 	}
 }
 
+// TestTiDBKeywords_CreatePlacementPolicy asserts that PLACEMENT shows
+// up as a candidate object type after CREATE, so users can discover
+// the CREATE PLACEMENT POLICY statement via completion.
+func TestTiDBKeywords_CreatePlacementPolicy(t *testing.T) {
+	cat := catalog.New()
+
+	sql := "CREATE "
+	candidates := Complete(sql, len(sql), cat)
+
+	if !containsText(candidates, "PLACEMENT") {
+		t.Errorf("expected PLACEMENT in CREATE completion; got: %v", candidateTexts(candidates))
+	}
+}
+
+// TestTiDBKeywords_PlacementPolicyOptions asserts that PRIMARY_REGION
+// (and friends) show up as candidates inside a CREATE PLACEMENT POLICY
+// option list. The inner grammar is completely independent from CREATE
+// TABLE options, so a separate anchor test is warranted.
+func TestTiDBKeywords_PlacementPolicyOptions(t *testing.T) {
+	cat := catalog.New()
+
+	sql := "CREATE PLACEMENT POLICY p "
+	candidates := Complete(sql, len(sql), cat)
+
+	wanted := []string{
+		"PRIMARY_REGION", "REGIONS", "FOLLOWERS", "VOTERS", "LEARNERS",
+		"CONSTRAINTS", "LEADER_CONSTRAINTS", "SURVIVAL_PREFERENCES",
+	}
+	for _, w := range wanted {
+		if containsText(candidates, w) {
+			return // any-of passes
+		}
+	}
+	t.Errorf("expected at least one placement option keyword after CREATE PLACEMENT POLICY p; got none.\nAll candidates: %v", candidateTexts(candidates))
+}
+
+// TestTiDBKeywords_AutoRandomColumnConstraint — P2 bundled with Tier 1.
+// AUTO_RANDOM belongs on the column-constraint list alongside
+// AUTO_INCREMENT in TiDB CREATE TABLE syntax.
+func TestTiDBKeywords_AutoRandomColumnConstraint(t *testing.T) {
+	cat := catalog.New()
+
+	sql := "CREATE TABLE t (id BIGINT "
+	candidates := Complete(sql, len(sql), cat)
+
+	if !containsText(candidates, "AUTO_RANDOM") {
+		t.Errorf("expected AUTO_RANDOM on column-constraint completion; got: %v", candidateTexts(candidates))
+	}
+}
+
+// TestTiDBKeywords_ClusteredPKModifier — P2 bundled with Tier 1.
+// CLUSTERED / NONCLUSTERED appear after a table-level PRIMARY KEY
+// (col_list) declaration.
+func TestTiDBKeywords_ClusteredPKModifier(t *testing.T) {
+	cat := catalog.New()
+
+	sql := "CREATE TABLE t (id INT, PRIMARY KEY (id) "
+	candidates := Complete(sql, len(sql), cat)
+
+	if !containsText(candidates, "CLUSTERED") && !containsText(candidates, "NONCLUSTERED") {
+		t.Errorf("expected CLUSTERED or NONCLUSTERED after PRIMARY KEY (id); got: %v", candidateTexts(candidates))
+	}
+}
+
 // candidateTexts extracts the text of each candidate for error messages.
 func candidateTexts(cs []Candidate) []string {
 	out := make([]string, 0, len(cs))

--- a/tidb/parser/create_table.go
+++ b/tidb/parser/create_table.go
@@ -311,7 +311,13 @@ func (p *Parser) parseColumnOption(col *nodes.ColumnDef) (bool, error) {
 	// Completion: offer column option keywords.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwNOT, kwNULL, kwDEFAULT, kwAUTO_INCREMENT, kwPRIMARY, kwUNIQUE, kwCOMMENT, kwCOLLATE, kwREFERENCES, kwCHECK, kwGENERATED} {
+		for _, t := range []int{
+			kwNOT, kwNULL, kwDEFAULT, kwAUTO_INCREMENT, kwPRIMARY, kwUNIQUE,
+			kwCOMMENT, kwCOLLATE, kwREFERENCES, kwCHECK, kwGENERATED,
+			// TiDB: AUTO_RANDOM belongs on the column constraint list
+			// alongside AUTO_INCREMENT (same grammar position).
+			kwAUTO_RANDOM,
+		} {
 			p.addTokenCandidate(t)
 		}
 		return false, &ParseError{Message: "collecting"}
@@ -1088,6 +1094,20 @@ func (p *Parser) parseIndexTypeClause(constr *nodes.Constraint) {
 // parseClusteredAttr parses optional CLUSTERED/NONCLUSTERED after PRIMARY KEY.
 // Returns nil if neither keyword is present.
 func (p *Parser) parseClusteredAttr() *bool {
+	// Completion: after a PRIMARY KEY (col, ...) grammar position,
+	// TiDB accepts an optional CLUSTERED/NONCLUSTERED modifier. Offer
+	// both candidates whenever we're collecting here.
+	p.checkCursor()
+	if p.collectMode() {
+		p.addTokenCandidate(kwCLUSTERED)
+		p.addTokenCandidate(kwNONCLUSTERED)
+		// Note: don't swallow completion state with a ParseError —
+		// parseClusteredAttr is called in the middle of a larger
+		// constraint/option chain and the caller expects it to return
+		// nil when nothing matches. The completion candidates are
+		// already recorded.
+		return nil
+	}
 	if p.cur.Type == kwCLUSTERED {
 		p.advance()
 		b := true

--- a/tidb/parser/lexer.go
+++ b/tidb/parser/lexer.go
@@ -884,6 +884,22 @@ const (
 	kwTTL_JOB_INTERVAL
 	kwPLACEMENT
 	kwPOLICY
+
+	// TiDB PLACEMENT POLICY option keywords. Shared between CREATE,
+	// ALTER, and DROP PLACEMENT POLICY statements (and, for the
+	// constraint-shaped options, referenced in TiDB's placement-rule
+	// docs). All unreserved.
+	kwPRIMARY_REGION
+	kwREGIONS
+	kwFOLLOWERS
+	kwVOTERS
+	kwLEARNERS
+	kwCONSTRAINTS
+	kwLEADER_CONSTRAINTS
+	kwFOLLOWER_CONSTRAINTS
+	kwVOTER_CONSTRAINTS
+	kwLEARNER_CONSTRAINTS
+	kwSURVIVAL_PREFERENCES
 )
 
 // keywords maps lowercase keyword strings to their token types.
@@ -1704,6 +1720,19 @@ var keywords = map[string]int{
 	"ttl_job_interval":  kwTTL_JOB_INTERVAL,
 	"placement":         kwPLACEMENT,
 	"policy":            kwPOLICY,
+
+	// TiDB PLACEMENT POLICY option keywords.
+	"primary_region":       kwPRIMARY_REGION,
+	"regions":              kwREGIONS,
+	"followers":            kwFOLLOWERS,
+	"voters":               kwVOTERS,
+	"learners":             kwLEARNERS,
+	"constraints":          kwCONSTRAINTS,
+	"leader_constraints":   kwLEADER_CONSTRAINTS,
+	"follower_constraints": kwFOLLOWER_CONSTRAINTS,
+	"voter_constraints":    kwVOTER_CONSTRAINTS,
+	"learner_constraints":  kwLEARNER_CONSTRAINTS,
+	"survival_preferences": kwSURVIVAL_PREFERENCES,
 }
 
 // Token represents a lexical token.

--- a/tidb/parser/name.go
+++ b/tidb/parser/name.go
@@ -487,6 +487,19 @@ var keywordCategories = map[int]keywordCategory{
 	kwTTL_JOB_INTERVAL:  kwCatUnambiguous,
 	kwPLACEMENT:         kwCatUnambiguous,
 	kwPOLICY:            kwCatUnambiguous,
+
+	// TiDB PLACEMENT POLICY option keywords (all unreserved upstream).
+	kwPRIMARY_REGION:       kwCatUnambiguous,
+	kwREGIONS:              kwCatUnambiguous,
+	kwFOLLOWERS:            kwCatUnambiguous,
+	kwVOTERS:               kwCatUnambiguous,
+	kwLEARNERS:             kwCatUnambiguous,
+	kwCONSTRAINTS:          kwCatUnambiguous,
+	kwLEADER_CONSTRAINTS:   kwCatUnambiguous,
+	kwFOLLOWER_CONSTRAINTS: kwCatUnambiguous,
+	kwVOTER_CONSTRAINTS:    kwCatUnambiguous,
+	kwLEARNER_CONSTRAINTS:  kwCatUnambiguous,
+	kwSURVIVAL_PREFERENCES: kwCatUnambiguous,
 }
 
 // isReserved returns true if the token type is a reserved keyword that cannot

--- a/tidb/parser/placement_policy.go
+++ b/tidb/parser/placement_policy.go
@@ -1,0 +1,278 @@
+package parser
+
+import (
+	"fmt"
+
+	nodes "github.com/bytebase/omni/tidb/ast"
+)
+
+// parseCreatePlacementPolicyStmt parses CREATE [OR REPLACE] PLACEMENT
+// POLICY [IF NOT EXISTS] policy_name placement_option_list.
+//
+// Called from parseCreateDispatch after it has consumed CREATE and an
+// optional OR REPLACE; p.cur is kwPLACEMENT on entry.
+//
+// Ref: TiDB v8.5.5 parser.y:15427-15436 (CreatePolicyStmt).
+func (p *Parser) parseCreatePlacementPolicyStmt(start int, orReplace bool) (nodes.Node, error) {
+	p.advance() // consume PLACEMENT
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return nil, err
+	}
+
+	stmt := &nodes.CreatePlacementPolicyStmt{
+		Loc:       nodes.Loc{Start: start},
+		OrReplace: orReplace,
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		p.advance()
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS_KW); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
+	// Completion: after the IF NOT EXISTS clause, the user is naming a
+	// fresh policy — no candidates to offer.
+	p.checkCursor()
+	if p.collectMode() {
+		return nil, &ParseError{Message: "collecting"}
+	}
+
+	name, _, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	opts, err := p.parsePlacementOptionList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Options = opts
+
+	stmt.Loc.End = p.pos()
+	return stmt, nil
+}
+
+// parseAlterPlacementPolicyStmt parses ALTER PLACEMENT POLICY
+// [IF EXISTS] policy_name placement_option_list. Option list is shared
+// with CREATE (DirectPlacementOption).
+//
+// Called from parseAlterDispatch; p.cur is kwPLACEMENT on entry.
+//
+// Ref: TiDB v8.5.5 parser.y:15438-15446.
+func (p *Parser) parseAlterPlacementPolicyStmt(start int) (nodes.Node, error) {
+	p.advance() // consume PLACEMENT
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return nil, err
+	}
+
+	stmt := &nodes.AlterPlacementPolicyStmt{
+		Loc: nodes.Loc{Start: start},
+	}
+
+	// IF EXISTS
+	if p.cur.Type == kwIF {
+		p.advance()
+		if _, err := p.expect(kwEXISTS_KW); err != nil {
+			return nil, err
+		}
+		stmt.IfExists = true
+	}
+
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("placement_policy_ref")
+		return nil, &ParseError{Message: "collecting"}
+	}
+
+	name, _, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	opts, err := p.parsePlacementOptionList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Options = opts
+
+	stmt.Loc.End = p.pos()
+	return stmt, nil
+}
+
+// parseDropPlacementPolicyStmt parses DROP PLACEMENT POLICY
+// [IF EXISTS] policy_name. The grammar does NOT allow a comma-list of
+// policy names — unlike DROP TABLE.
+//
+// Called from parseDropDispatch; p.cur is kwPLACEMENT on entry.
+//
+// Ref: TiDB v8.5.5 parser.y:15389-15396.
+func (p *Parser) parseDropPlacementPolicyStmt(start int) (nodes.Node, error) {
+	p.advance() // consume PLACEMENT
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return nil, err
+	}
+
+	stmt := &nodes.DropPlacementPolicyStmt{
+		Loc: nodes.Loc{Start: start},
+	}
+
+	// IF EXISTS
+	if p.cur.Type == kwIF {
+		p.advance()
+		if _, err := p.expect(kwEXISTS_KW); err != nil {
+			return nil, err
+		}
+		stmt.IfExists = true
+	}
+
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("placement_policy_ref")
+		return nil, &ParseError{Message: "collecting"}
+	}
+
+	name, _, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc.End = p.pos()
+	return stmt, nil
+}
+
+// parsePlacementOptionList parses one-or-more DirectPlacementOption
+// items, separated by commas OR whitespace (the TiDB grammar allows
+// both and even a mix — parser.y:1999-2011). Returns when the next
+// token is neither a placement option keyword nor a comma.
+func (p *Parser) parsePlacementOptionList() ([]*nodes.PlacementPolicyOption, error) {
+	var opts []*nodes.PlacementPolicyOption
+	for {
+		// Completion: offer option keywords at any position in the list.
+		p.checkCursor()
+		if p.collectMode() {
+			for _, t := range placementOptionTokens {
+				p.addTokenCandidate(t)
+			}
+			return opts, &ParseError{Message: "collecting"}
+		}
+
+		if !isPlacementOptionStart(p.cur.Type) {
+			break
+		}
+		opt, err := p.parsePlacementOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+		// Optional comma separator between options.
+		if p.cur.Type == ',' {
+			p.advance()
+		}
+	}
+	return opts, nil
+}
+
+// placementOptionTokens is the closed set of keyword tokens that can
+// start a DirectPlacementOption. Kept in one place so the completion
+// walker and the option-list loop see the same set.
+var placementOptionTokens = []int{
+	kwPRIMARY_REGION, kwREGIONS, kwFOLLOWERS, kwVOTERS, kwLEARNERS,
+	kwSCHEDULE, kwCONSTRAINTS,
+	kwLEADER_CONSTRAINTS, kwFOLLOWER_CONSTRAINTS,
+	kwVOTER_CONSTRAINTS, kwLEARNER_CONSTRAINTS,
+	kwSURVIVAL_PREFERENCES,
+}
+
+func isPlacementOptionStart(t int) bool {
+	for _, k := range placementOptionTokens {
+		if t == k {
+			return true
+		}
+	}
+	return false
+}
+
+// parsePlacementOption parses a single DirectPlacementOption.
+// `=` is optional for every option per EqOpt (parser.y:5450-5452).
+func (p *Parser) parsePlacementOption() (*nodes.PlacementPolicyOption, error) {
+	start := p.pos()
+	tok := p.cur.Type
+	name := ""
+	isStringOpt := true
+	isIntOpt := false
+
+	switch tok {
+	case kwPRIMARY_REGION:
+		name = "PRIMARY_REGION"
+	case kwREGIONS:
+		name = "REGIONS"
+	case kwSCHEDULE:
+		name = "SCHEDULE"
+	case kwCONSTRAINTS:
+		name = "CONSTRAINTS"
+	case kwLEADER_CONSTRAINTS:
+		name = "LEADER_CONSTRAINTS"
+	case kwFOLLOWER_CONSTRAINTS:
+		name = "FOLLOWER_CONSTRAINTS"
+	case kwVOTER_CONSTRAINTS:
+		name = "VOTER_CONSTRAINTS"
+	case kwLEARNER_CONSTRAINTS:
+		name = "LEARNER_CONSTRAINTS"
+	case kwSURVIVAL_PREFERENCES:
+		name = "SURVIVAL_PREFERENCES"
+	case kwFOLLOWERS:
+		name = "FOLLOWERS"
+		isStringOpt = false
+		isIntOpt = true
+	case kwVOTERS:
+		name = "VOTERS"
+		isStringOpt = false
+		isIntOpt = true
+	case kwLEARNERS:
+		name = "LEARNERS"
+		isStringOpt = false
+		isIntOpt = true
+	default:
+		return nil, &ParseError{Message: fmt.Sprintf("unexpected token %d in PLACEMENT POLICY option", tok), Position: p.cur.Loc}
+	}
+	p.advance()
+	p.match('=') // optional
+
+	opt := &nodes.PlacementPolicyOption{
+		Loc:  nodes.Loc{Start: start},
+		Name: name,
+	}
+
+	if isStringOpt {
+		if p.cur.Type != tokSCONST {
+			return nil, &ParseError{Message: fmt.Sprintf("expected string literal for PLACEMENT POLICY option %s", name), Position: p.cur.Loc}
+		}
+		opt.Value = p.cur.Str
+		p.advance()
+	} else if isIntOpt {
+		if p.cur.Type != tokICONST {
+			return nil, &ParseError{Message: fmt.Sprintf("expected integer literal for PLACEMENT POLICY option %s", name), Position: p.cur.Loc}
+		}
+		if p.cur.Ival < 0 {
+			return nil, &ParseError{Message: fmt.Sprintf("%s must be non-negative", name), Position: p.cur.Loc}
+		}
+		if name == "FOLLOWERS" && p.cur.Ival == 0 {
+			// Matches upstream: parser.y:2025-2028 "FOLLOWERS must be positive".
+			return nil, &ParseError{Message: "FOLLOWERS must be positive", Position: p.cur.Loc}
+		}
+		opt.IntValue = uint64(p.cur.Ival)
+		opt.IsInt = true
+		opt.Value = fmt.Sprintf("%d", p.cur.Ival)
+		p.advance()
+	}
+	opt.Loc.End = p.pos()
+	return opt, nil
+}

--- a/tidb/parser/placement_policy.go
+++ b/tidb/parser/placement_policy.go
@@ -152,6 +152,11 @@ func (p *Parser) parseDropPlacementPolicyStmt(start int) (nodes.Node, error) {
 // items, separated by commas OR whitespace (the TiDB grammar allows
 // both and even a mix — parser.y:1999-2011). Returns when the next
 // token is neither a placement option keyword nor a comma.
+//
+// Enforces two upstream constraints that the original pass missed:
+//   - The list requires at least one option (no empty-production arm).
+//   - A comma separator REQUIRES another option to follow (no trailing
+//     comma arm). Both rules come directly from parser.y:1999-2011.
 func (p *Parser) parsePlacementOptionList() ([]*nodes.PlacementPolicyOption, error) {
 	var opts []*nodes.PlacementPolicyOption
 	for {
@@ -172,10 +177,17 @@ func (p *Parser) parsePlacementOptionList() ([]*nodes.PlacementPolicyOption, err
 			return nil, err
 		}
 		opts = append(opts, opt)
-		// Optional comma separator between options.
+		// Comma separator between options. A comma mandates another
+		// option; a trailing comma is a syntax error upstream.
 		if p.cur.Type == ',' {
 			p.advance()
+			if !isPlacementOptionStart(p.cur.Type) {
+				return nil, p.syntaxErrorAtCur()
+			}
 		}
+	}
+	if len(opts) == 0 {
+		return nil, p.syntaxErrorAtCur()
 	}
 	return opts, nil
 }

--- a/tidb/parser/stmt.go
+++ b/tidb/parser/stmt.go
@@ -402,7 +402,10 @@ func (p *Parser) parseCreateDispatch() (nodes.Node, error) {
 	// Completion: after CREATE keyword, offer object type candidates.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwTABLE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT} {
+		for _, t := range []int{
+			kwTABLE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT,
+			kwPLACEMENT, // TiDB: CREATE PLACEMENT POLICY
+		} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -465,6 +468,10 @@ func (p *Parser) parseCreateDispatch() (nodes.Node, error) {
 
 	case kwDATABASE, kwSCHEMA:
 		return p.parseCreateDatabaseStmt()
+
+	case kwPLACEMENT:
+		// CREATE [OR REPLACE] PLACEMENT POLICY [IF NOT EXISTS] name opts
+		return p.parseCreatePlacementPolicyStmt(start, orReplace)
 
 	case kwAGGREGATE:
 		// CREATE AGGREGATE FUNCTION — loadable UDF
@@ -596,7 +603,10 @@ func (p *Parser) parseAlterDispatch() (nodes.Node, error) {
 	// Completion: after ALTER keyword, offer object type candidates.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwTABLE, kwDATABASE, kwVIEW, kwFUNCTION, kwPROCEDURE, kwEVENT} {
+		for _, t := range []int{
+			kwTABLE, kwDATABASE, kwVIEW, kwFUNCTION, kwPROCEDURE, kwEVENT,
+			kwPLACEMENT, // TiDB: ALTER PLACEMENT POLICY
+		} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -617,6 +627,10 @@ func (p *Parser) parseAlterDispatch() (nodes.Node, error) {
 
 	case kwDATABASE, kwSCHEMA:
 		return p.parseAlterDatabaseStmt()
+
+	case kwPLACEMENT:
+		// ALTER PLACEMENT POLICY [IF EXISTS] name opts
+		return p.parseAlterPlacementPolicyStmt(start)
 
 	case kwUSER:
 		return p.parseAlterUserStmt()
@@ -712,7 +726,10 @@ func (p *Parser) parseDropDispatch() (nodes.Node, error) {
 	// Completion: after DROP keyword, offer object type candidates.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwTABLE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT, kwIF} {
+		for _, t := range []int{
+			kwTABLE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT, kwIF,
+			kwPLACEMENT, // TiDB: DROP PLACEMENT POLICY
+		} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -745,6 +762,10 @@ func (p *Parser) parseDropDispatch() (nodes.Node, error) {
 
 	case kwDATABASE, kwSCHEMA:
 		return p.parseDropDatabaseStmt()
+
+	case kwPLACEMENT:
+		// DROP PLACEMENT POLICY [IF EXISTS] name
+		return p.parseDropPlacementPolicyStmt(start)
 
 	case kwUSER:
 		return p.parseDropUserStmt()

--- a/tidb/parser/tidb_placement_policy_test.go
+++ b/tidb/parser/tidb_placement_policy_test.go
@@ -194,6 +194,30 @@ func TestParsePlacementPolicyDDL(t *testing.T) {
 				}
 			},
 		},
+		// Negative cases — upstream grammar at parser.y:1999-2011
+		// requires minimum 1 option and no trailing comma. TiDB
+		// itself rejects these; omni must reject too or we have
+		// silent oracle divergence.
+		{
+			name:    "error_create_empty_options",
+			sql:     "CREATE PLACEMENT POLICY p",
+			wantErr: true,
+		},
+		{
+			name:    "error_create_trailing_comma",
+			sql:     "CREATE PLACEMENT POLICY p PRIMARY_REGION = 'us',",
+			wantErr: true,
+		},
+		{
+			name:    "error_alter_empty_options",
+			sql:     "ALTER PLACEMENT POLICY p",
+			wantErr: true,
+		},
+		{
+			name:    "error_alter_trailing_comma",
+			sql:     "ALTER PLACEMENT POLICY p PRIMARY_REGION = 'us',",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tidb/parser/tidb_placement_policy_test.go
+++ b/tidb/parser/tidb_placement_policy_test.go
@@ -1,0 +1,206 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	nodes "github.com/bytebase/omni/tidb/ast"
+)
+
+// TestParsePlacementPolicyDDL covers the three new statements and the
+// surface of the shared option list. Each case asserts on AST shape,
+// not on round-trip string equality — outfuncs stability is covered by
+// writeCreatePlacementPolicyStmt / writeAlterPlacementPolicyStmt tests
+// downstream in the ast package.
+func TestParsePlacementPolicyDDL(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr bool
+		check   func(t *testing.T, list *nodes.List)
+	}{
+		{
+			name: "create_minimal",
+			sql:  "CREATE PLACEMENT POLICY p1 PRIMARY_REGION = 'us-east-1'",
+			check: func(t *testing.T, list *nodes.List) {
+				s, ok := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if !ok {
+					t.Fatalf("want CreatePlacementPolicyStmt, got %T", list.Items[0])
+				}
+				if s.Name != "p1" {
+					t.Errorf("Name = %q, want p1", s.Name)
+				}
+				if len(s.Options) != 1 || s.Options[0].Name != "PRIMARY_REGION" || s.Options[0].Value != "us-east-1" {
+					t.Errorf("options: %+v", s.Options)
+				}
+			},
+		},
+		{
+			name: "create_or_replace_if_not_exists",
+			sql:  "CREATE OR REPLACE PLACEMENT POLICY IF NOT EXISTS p1 FOLLOWERS = 3",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if !s.OrReplace {
+					t.Error("OrReplace should be true")
+				}
+				if !s.IfNotExists {
+					t.Error("IfNotExists should be true")
+				}
+				if len(s.Options) != 1 || !s.Options[0].IsInt || s.Options[0].IntValue != 3 {
+					t.Errorf("FOLLOWERS option: %+v", s.Options[0])
+				}
+			},
+		},
+		{
+			name: "create_multi_option_comma",
+			sql:  "CREATE PLACEMENT POLICY p PRIMARY_REGION='us', REGIONS='us,eu', FOLLOWERS=2",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 3 {
+					t.Fatalf("want 3 options, got %d", len(s.Options))
+				}
+			},
+		},
+		{
+			name: "create_multi_option_whitespace",
+			// TiDB's Restore output omits commas between options.
+			sql: "CREATE PLACEMENT POLICY p PRIMARY_REGION='us' REGIONS='us,eu' LEARNERS=1",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 3 {
+					t.Fatalf("want 3 options, got %d", len(s.Options))
+				}
+			},
+		},
+		{
+			name: "create_constraints_json_dict",
+			sql:  `CREATE PLACEMENT POLICY p CONSTRAINTS='{"+region=us-east-1":2,"+region=us-west-1":1}'`,
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 1 || s.Options[0].Name != "CONSTRAINTS" {
+					t.Fatalf("options: %+v", s.Options)
+				}
+				// Value is the raw string literal content (no quotes).
+				if !strings.Contains(s.Options[0].Value, "us-east-1") {
+					t.Errorf("CONSTRAINTS value lost contents: %q", s.Options[0].Value)
+				}
+			},
+		},
+		{
+			name: "create_constraints_json_list",
+			sql:  `CREATE PLACEMENT POLICY p CONSTRAINTS='[+region=us-east-1,-region=us-west-1]'`,
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if !strings.Contains(s.Options[0].Value, "+region=us-east-1") {
+					t.Errorf("CONSTRAINTS list form lost contents: %q", s.Options[0].Value)
+				}
+			},
+		},
+		{
+			name: "create_no_equals",
+			// The `=` is optional for every option per EqOpt rule.
+			sql: "CREATE PLACEMENT POLICY p PRIMARY_REGION 'us' FOLLOWERS 3",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 2 {
+					t.Fatalf("want 2 options, got %d", len(s.Options))
+				}
+			},
+		},
+		{
+			name: "create_all_constraint_variants",
+			sql: `CREATE PLACEMENT POLICY p ` +
+				`LEADER_CONSTRAINTS='[+region=us-east]' ` +
+				`FOLLOWER_CONSTRAINTS='{+region=us-west: 2}' ` +
+				`VOTER_CONSTRAINTS='[+zone=a]' ` +
+				`LEARNER_CONSTRAINTS='[+zone=b]' ` +
+				`SURVIVAL_PREFERENCES='[region, zone]'`,
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 5 {
+					t.Fatalf("want 5 options, got %d", len(s.Options))
+				}
+			},
+		},
+		{
+			// Upstream parser.y:2025-2028 rejects FOLLOWERS=0 at parse
+			// time. Our parser matches to avoid accepting SQL that real
+			// TiDB would reject.
+			name:    "error_followers_zero",
+			sql:     "CREATE PLACEMENT POLICY p FOLLOWERS = 0",
+			wantErr: true,
+		},
+		{
+			// VOTERS = 0 / LEARNERS = 0 are NOT parse errors upstream —
+			// asymmetric with FOLLOWERS, but upstream-consistent.
+			name: "voters_zero_ok",
+			sql:  "CREATE PLACEMENT POLICY p VOTERS = 0",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 1 || s.Options[0].IntValue != 0 {
+					t.Errorf("VOTERS=0 option: %+v", s.Options[0])
+				}
+			},
+		},
+		{
+			name: "alter_with_if_exists",
+			sql:  "ALTER PLACEMENT POLICY IF EXISTS p1 PRIMARY_REGION = 'us-west'",
+			check: func(t *testing.T, list *nodes.List) {
+				s, ok := list.Items[0].(*nodes.AlterPlacementPolicyStmt)
+				if !ok {
+					t.Fatalf("want AlterPlacementPolicyStmt, got %T", list.Items[0])
+				}
+				if !s.IfExists {
+					t.Error("IfExists should be true")
+				}
+				if s.Name != "p1" {
+					t.Errorf("Name = %q", s.Name)
+				}
+			},
+		},
+		{
+			name: "drop_basic",
+			sql:  "DROP PLACEMENT POLICY p1",
+			check: func(t *testing.T, list *nodes.List) {
+				s, ok := list.Items[0].(*nodes.DropPlacementPolicyStmt)
+				if !ok {
+					t.Fatalf("want DropPlacementPolicyStmt, got %T", list.Items[0])
+				}
+				if s.Name != "p1" {
+					t.Errorf("Name = %q", s.Name)
+				}
+			},
+		},
+		{
+			name: "drop_if_exists",
+			sql:  "DROP PLACEMENT POLICY IF EXISTS p1",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.DropPlacementPolicyStmt)
+				if !s.IfExists {
+					t.Error("IfExists should be true")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+			if list == nil || len(list.Items) == 0 {
+				t.Fatal("empty parse result")
+			}
+			if tt.check != nil {
+				tt.check(t, list)
+			}
+		})
+	}
+}

--- a/tidb/parser/tidb_placement_policy_test.go
+++ b/tidb/parser/tidb_placement_policy_test.go
@@ -73,6 +73,19 @@ func TestParsePlacementPolicyDDL(t *testing.T) {
 			},
 		},
 		{
+			// The upstream grammar accepts mixing comma and whitespace
+			// separators in the same option list (parser.y:2000/2004/2008).
+			// Neither comma-only nor whitespace-only covers this.
+			name: "create_multi_option_mixed_separators",
+			sql:  "CREATE PLACEMENT POLICY p PRIMARY_REGION='us', REGIONS='us,eu' FOLLOWERS=2",
+			check: func(t *testing.T, list *nodes.List) {
+				s := list.Items[0].(*nodes.CreatePlacementPolicyStmt)
+				if len(s.Options) != 3 {
+					t.Fatalf("want 3 options, got %d: %+v", len(s.Options), s.Options)
+				}
+			},
+		},
+		{
 			name: "create_constraints_json_dict",
 			sql:  `CREATE PLACEMENT POLICY p CONSTRAINTS='{"+region=us-east-1":2,"+region=us-west-1":1}'`,
 			check: func(t *testing.T, list *nodes.List) {


### PR DESCRIPTION
## Summary

Closes the asymmetry PR3b opened: parser accepted `PLACEMENT POLICY = name` references but rejected the DDL that defines the name. A TiDB schema dump of the form

```sql
CREATE PLACEMENT POLICY p1 PRIMARY_REGION='us-east-1' REGIONS='us-east-1';
CREATE TABLE t (id INT) PLACEMENT POLICY = p1;
```

now round-trips through omni end-to-end.

Branched directly off `main` at `641f913` per the no-stacking guidance after the PR3b recovery incident.

## Grammar coverage

Follows TiDB v8.5.5 authoritative source (`pkg/parser/parser.y:15389-15446` for the statements, `:2013-2066` for the shared `DirectPlacementOption` list). I fetched the actual Yacc grammar — not docs — per PR1/PR2's lesson.

Three new statements:
- `CREATE [OR REPLACE] PLACEMENT POLICY [IF NOT EXISTS] name options`
- `ALTER PLACEMENT POLICY [IF EXISTS] name options`
- `DROP PLACEMENT POLICY [IF EXISTS] name`

12 shared options (CREATE + ALTER use the identical list):
PRIMARY_REGION, REGIONS, FOLLOWERS, VOTERS, LEARNERS, SCHEDULE, CONSTRAINTS, LEADER_CONSTRAINTS, FOLLOWER_CONSTRAINTS, VOTER_CONSTRAINTS, LEARNER_CONSTRAINTS, SURVIVAL_PREFERENCES.

### Faithful upstream quirks preserved

- `=` is optional on every option (EqOpt)
- Options may be comma-separated, whitespace-separated, or mixed
- `FOLLOWERS = 0` is a parse error (`parser.y:2025-2028`); `VOTERS = 0` / `LEARNERS = 0` are NOT — asymmetric but upstream-consistent
- Duplicate options accepted at parse time (semantic-layer concern)
- JSON/list-shape constraint values stored as opaque string literal content

## Architecture

- **AST** (`tidb/ast/parsenodes.go`): 3 new Stmt nodes + `PlacementPolicyOption` node. Walker regenerated (129 cases, 258 child fields). `outfuncs.go` writers added.
- **Parser** (`tidb/parser/placement_policy.go`): dispatchers hooked into existing CREATE/ALTER/DROP routers. Lexer adds 11 new unreserved keyword tokens.
- **Catalog** (`tidb/catalog/placement_policy.go`): new `Catalog.placementPolicies` map and first-class `PlacementPolicy` object. CRUD handlers with OR REPLACE / IF NOT EXISTS / IF EXISTS matching TiDB. Errors use TiDB's 8239 (exists) / 8241 (missing) codes.
- **Completion**: PLACEMENT offered as a candidate after CREATE/ALTER/DROP. Placement-option keywords offered inside the option list. Shared `placementOptionTokens` kept in one place so parser and completion see the same set.

### Bundled P2 anchors (from PR3b review backlog)

Folded into this PR since it touches the completion walker anyway:
- `AUTO_RANDOM` added to column-constraint candidates
- `CLUSTERED` / `NONCLUSTERED` added to PK-modifier candidates

## Tests

| Scope | File | Cases |
|---|---|---|
| Parser | `tidb/parser/tidb_placement_policy_test.go` | 13 (every option shape + error cases + OR REPLACE / IF NOT EXISTS / IF EXISTS) |
| Catalog walkthrough | `tidb/catalog/wt_tidb_policy_test.go` | 11 (incl. end-to-end round-trip) |
| Container (real TiDB v8.5.5) | `tidb/catalog/tidb_placement_policy_container_test.go` | 7 |
| Completion anchors | `tidb/completion/tidb_keywords_test.go` | 4 new |

## Verification

- [x] `go build ./tidb/...` clean
- [x] `go vet ./tidb/...` clean
- [x] `go test ./tidb/... -short -count=1` passing
- [x] Container test passes 7/7 against `pingcap/tidb:v8.5.5`
- [ ] CI green on merge

## Deferred to future PRs

- ALTER DATABASE SET TIFLASH REPLICA (Tier 3 from the review ranking)
- FLASHBACK TABLE/DATABASE/CLUSTER (Tier 4 — operational DDL, defer until requested)
- `mysql/semantic/` fork (Tier 5 — no blocking use case)
- Diff + migration system port (Tier 6 — biggest effort, lowest priority per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)