### PR TITLE
mssql/parser: SqlScriptDOM-aligned full-text predicates and TVFs

### DIFF
--- a/mssql/ast/outfuncs.go
+++ b/mssql/ast/outfuncs.go
@@ -184,6 +184,12 @@ func writeNode(sb *strings.Builder, node Node) {
 		writeIsExpr(sb, n)
 	case *ExistsExpr:
 		writeExistsExpr(sb, n)
+	case *FullTextPredicate:
+		writeFullTextPredicate(sb, n)
+	case *FullTextTableRef:
+		writeFullTextTableRef(sb, n)
+	case *SemanticTableRef:
+		writeSemanticTableRef(sb, n)
 	case *CastExpr:
 		writeCastExpr(sb, n)
 	case *ConvertExpr:
@@ -4520,6 +4526,112 @@ func writeInsertBulkColumnDef(sb *strings.Builder, n *InsertBulkColumnDef) {
 		} else {
 			sb.WriteString(" :nullable false")
 		}
+	}
+	fmt.Fprintf(sb, " :loc %d %d}", n.Loc.Start, n.Loc.End)
+}
+
+func fullTextFuncName(f FullTextFunc) string {
+	switch f {
+	case FullTextContains:
+		return "CONTAINS"
+	case FullTextFreeText:
+		return "FREETEXT"
+	}
+	return fmt.Sprintf("FullTextFunc(%d)", int(f))
+}
+
+func semanticFuncName(f SemanticFunc) string {
+	switch f {
+	case SemanticKeyPhraseTable:
+		return "SEMANTICKEYPHRASETABLE"
+	case SemanticSimilarityTable:
+		return "SEMANTICSIMILARITYTABLE"
+	case SemanticSimilarityDetailsTable:
+		return "SEMANTICSIMILARITYDETAILSTABLE"
+	}
+	return fmt.Sprintf("SemanticFunc(%d)", int(f))
+}
+
+func writeFullTextPredicate(sb *strings.Builder, n *FullTextPredicate) {
+	sb.WriteString("{FULLTEXT-PREDICATE")
+	fmt.Fprintf(sb, " :func %s", fullTextFuncName(n.Func))
+	if n.Columns != nil {
+		sb.WriteString(" :columns ")
+		writeNode(sb, n.Columns)
+	}
+	if n.PropertyName != nil {
+		sb.WriteString(" :property ")
+		writeNode(sb, n.PropertyName)
+	}
+	if n.Value != nil {
+		sb.WriteString(" :value ")
+		writeNode(sb, n.Value)
+	}
+	if n.LanguageTerm != nil {
+		sb.WriteString(" :language ")
+		writeNode(sb, n.LanguageTerm)
+	}
+	fmt.Fprintf(sb, " :loc %d %d}", n.Loc.Start, n.Loc.End)
+}
+
+func writeFullTextTableRef(sb *strings.Builder, n *FullTextTableRef) {
+	sb.WriteString("{FULLTEXT-TABLE")
+	fmt.Fprintf(sb, " :func %s", fullTextFuncName(n.Func))
+	if n.Table != nil {
+		sb.WriteString(" :table ")
+		writeNode(sb, n.Table)
+	}
+	if n.Columns != nil {
+		sb.WriteString(" :columns ")
+		writeNode(sb, n.Columns)
+	}
+	if n.PropertyName != nil {
+		sb.WriteString(" :property ")
+		writeNode(sb, n.PropertyName)
+	}
+	if n.SearchCondition != nil {
+		sb.WriteString(" :searchCondition ")
+		writeNode(sb, n.SearchCondition)
+	}
+	if n.Language != nil {
+		sb.WriteString(" :language ")
+		writeNode(sb, n.Language)
+	}
+	if n.TopN != nil {
+		sb.WriteString(" :topN ")
+		writeNode(sb, n.TopN)
+	}
+	if n.Alias != "" {
+		fmt.Fprintf(sb, " :alias \"%s\"", escapeString(n.Alias))
+	}
+	fmt.Fprintf(sb, " :loc %d %d}", n.Loc.Start, n.Loc.End)
+}
+
+func writeSemanticTableRef(sb *strings.Builder, n *SemanticTableRef) {
+	sb.WriteString("{SEMANTIC-TABLE")
+	fmt.Fprintf(sb, " :func %s", semanticFuncName(n.Func))
+	if n.Table != nil {
+		sb.WriteString(" :table ")
+		writeNode(sb, n.Table)
+	}
+	if n.Columns != nil {
+		sb.WriteString(" :columns ")
+		writeNode(sb, n.Columns)
+	}
+	if n.SourceKey != nil {
+		sb.WriteString(" :sourceKey ")
+		writeNode(sb, n.SourceKey)
+	}
+	if n.MatchedColumn != nil {
+		sb.WriteString(" :matchedColumn ")
+		writeNode(sb, n.MatchedColumn)
+	}
+	if n.MatchedKey != nil {
+		sb.WriteString(" :matchedKey ")
+		writeNode(sb, n.MatchedKey)
+	}
+	if n.Alias != "" {
+		fmt.Fprintf(sb, " :alias \"%s\"", escapeString(n.Alias))
 	}
 	fmt.Fprintf(sb, " :loc %d %d}", n.Loc.Start, n.Loc.End)
 }

--- a/mssql/ast/parsenodes.go
+++ b/mssql/ast/parsenodes.go
@@ -1727,6 +1727,38 @@ type ExistsExpr struct {
 func (n *ExistsExpr) nodeTag()  {}
 func (n *ExistsExpr) exprNode() {}
 
+// FullTextFunc enumerates the full-text function variants used by both
+// FullTextPredicate (CONTAINS / FREETEXT) and FullTextTableRef
+// (CONTAINSTABLE / FREETEXTTABLE). Mirrors SqlScriptDOM's FullTextFunctionType.
+type FullTextFunc int
+
+const (
+	FullTextContains FullTextFunc = iota
+	FullTextFreeText
+)
+
+// FullTextPredicate represents the T-SQL full-text boolean predicate:
+//
+//	CONTAINS ( { column | (col, …) | * | PROPERTY(col, 'name') }, value [, LANGUAGE lang] )
+//	FREETEXT ( { column | (col, …) | * | PROPERTY(col, 'name') }, value [, LANGUAGE lang] )
+//
+// This is a <search_condition> production, not a scalar expression —
+// it is only valid in boolean contexts (WHERE, HAVING, ON, CHECK, etc.),
+// matching SqlScriptDOM's FullTextPredicate fragment.
+//
+// Ref: TSql170.g: fulltextPredicate
+type FullTextPredicate struct {
+	Func         FullTextFunc
+	Columns      *List    // items: *ColumnRef or *StarExpr
+	PropertyName *Literal // set when PROPERTY(col, 'name') was used; else nil
+	Value        ExprNode // *Literal (string) or *VariableRef
+	LanguageTerm ExprNode // optional LANGUAGE <expr>
+	Loc          Loc
+}
+
+func (n *FullTextPredicate) nodeTag()  {}
+func (n *FullTextPredicate) exprNode() {}
+
 // CastExpr represents CAST(expr AS type).
 type CastExpr struct {
 	Expr     ExprNode
@@ -1962,6 +1994,63 @@ type TableVarMethodCallRef struct {
 
 func (n *TableVarMethodCallRef) nodeTag()   {}
 func (n *TableVarMethodCallRef) tableExpr() {}
+
+// FullTextTableRef represents the T-SQL full-text rowset functions used as
+// table sources:
+//
+//	CONTAINSTABLE ( table, { col | (col,…) | * | PROPERTY(col,'name') }, value
+//	               [, LANGUAGE lang] [, top_n] )
+//	FREETEXTTABLE ( …same… )
+//
+// Mirrors SqlScriptDOM FullTextTableReference (TSql170.g: fulltextTableReference).
+type FullTextTableRef struct {
+	Func            FullTextFunc
+	Table           *TableRef
+	Columns         *List    // items: *ColumnRef or *StarExpr
+	PropertyName    *Literal // set when PROPERTY(col, 'name') was used; else nil
+	SearchCondition ExprNode // *Literal (string) or *VariableRef
+	Language        ExprNode // optional LANGUAGE <expr>
+	TopN            ExprNode // optional integer literal or variable
+	Alias           string
+	Loc             Loc
+}
+
+func (n *FullTextTableRef) nodeTag()   {}
+func (n *FullTextTableRef) tableExpr() {}
+
+// SemanticFunc enumerates the T-SQL semantic table-valued functions.
+// Mirrors SqlScriptDOM's SemanticFunctionType.
+type SemanticFunc int
+
+const (
+	SemanticKeyPhraseTable SemanticFunc = iota
+	SemanticSimilarityTable
+	SemanticSimilarityDetailsTable
+)
+
+// SemanticTableRef represents the T-SQL semantic table-valued functions used
+// as table sources:
+//
+//	SEMANTICKEYPHRASETABLE            ( table, { col | (col,…) | * } [, source_key] )
+//	SEMANTICSIMILARITYTABLE           ( table, { col | (col,…) | * }, source_key )
+//	SEMANTICSIMILARITYDETAILSTABLE    ( table, source_column, source_key,
+//	                                    matched_column, matched_key )
+//
+// Mirrors SqlScriptDOM SemanticTableReference (TSql170.g: semanticTableReference
+// and friends).
+type SemanticTableRef struct {
+	Func          SemanticFunc
+	Table         *TableRef
+	Columns       *List      // KeyPhrase/Similarity column list, or single-source-column for Details
+	SourceKey     ExprNode   // optional for KeyPhrase, required for Similarity and Details
+	MatchedColumn *ColumnRef // only set for Details
+	MatchedKey    ExprNode   // only set for Details
+	Alias         string
+	Loc           Loc
+}
+
+func (n *SemanticTableRef) nodeTag()   {}
+func (n *SemanticTableRef) tableExpr() {}
 
 // DataType represents a T-SQL data type reference.
 type DataType struct {

--- a/mssql/ast/walk_generated.go
+++ b/mssql/ast/walk_generated.go
@@ -438,6 +438,24 @@ func walkChildren(v Visitor, node Node) {
 	case *FetchCursorStmt:
 		Walk(v, n.FetchOffset)
 		walkList(v, n.IntoVars)
+	case *FullTextPredicate:
+		walkList(v, n.Columns)
+		if n.PropertyName != nil {
+			Walk(v, n.PropertyName)
+		}
+		Walk(v, n.Value)
+		Walk(v, n.LanguageTerm)
+	case *FullTextTableRef:
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
+		walkList(v, n.Columns)
+		if n.PropertyName != nil {
+			Walk(v, n.PropertyName)
+		}
+		Walk(v, n.SearchCondition)
+		Walk(v, n.Language)
+		Walk(v, n.TopN)
 	case *FuncCallExpr:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -679,6 +697,16 @@ func walkChildren(v Visitor, node Node) {
 		if n.Rarg != nil {
 			Walk(v, n.Rarg)
 		}
+	case *SemanticTableRef:
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
+		walkList(v, n.Columns)
+		Walk(v, n.SourceKey)
+		if n.MatchedColumn != nil {
+			Walk(v, n.MatchedColumn)
+		}
+		Walk(v, n.MatchedKey)
 	case *SensitivityClassificationStmt:
 		walkList(v, n.Columns)
 		walkList(v, n.Options)

--- a/mssql/parser/control_flow.go
+++ b/mssql/parser/control_flow.go
@@ -28,7 +28,9 @@ func (p *Parser) parseIfStmt() (*nodes.IfStmt, error) {
 		Loc: nodes.Loc{Start: loc, End: -1},
 	}
 
+	p.enterSearchCondition()
 	cond, err := p.parseExpr()
+	p.leaveSearchCondition()
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +81,9 @@ func (p *Parser) parseWhileStmt() (*nodes.WhileStmt, error) {
 		Loc: nodes.Loc{Start: loc, End: -1},
 	}
 
+	p.enterSearchCondition()
 	cond, err := p.parseExpr()
+	p.leaveSearchCondition()
 	if err != nil {
 		return nil, err
 	}

--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -86,7 +86,9 @@ func (p *Parser) parseAnd() (nodes.ExprNode, error) {
 
 // parseNot parses NOT expressions.
 //
-//	not_expr = NOT not_expr | comparison_expr
+//	not_expr = NOT not_expr
+//	         | fulltext_predicate   -- CONTAINS(...) / FREETEXT(...)
+//	         | comparison_expr
 func (p *Parser) parseNot() (nodes.ExprNode, error) {
 	if p.cur.Type == kwNOT {
 		loc := p.pos()
@@ -103,6 +105,9 @@ func (p *Parser) parseNot() (nodes.ExprNode, error) {
 			Operand: operand,
 			Loc:     nodes.Loc{Start: loc, End: p.prevEnd()},
 		}, nil
+	}
+	if p.inSearchCondition() && (p.cur.Type == kwCONTAINS || p.cur.Type == kwFREETEXT) {
+		return p.parseFullTextPredicate()
 	}
 	return p.parseComparison()
 }
@@ -935,7 +940,16 @@ func (p *Parser) parseCaseExpr() (nodes.ExprNode, error) {
 			p.addRuleCandidate("func_name")
 			return nil, errCollecting
 		}
+		// In a searched CASE (no arg) the WHEN predicate is a
+		// <search_condition>. In a simple CASE (with arg) it is a
+		// scalar expression compared against arg.
+		if arg == nil {
+			p.enterSearchCondition()
+		}
 		cond, err := p.parseExpr()
+		if arg == nil {
+			p.leaveSearchCondition()
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/mssql/parser/keyword_callable_test.go
+++ b/mssql/parser/keyword_callable_test.go
@@ -1,0 +1,243 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file is the regression guard for the "callable CoreKeyword" design.
+//
+// Background: prior to the 2026-04 parser-optimize refactor, omni's
+// parsePrimary() default branch fell through to parseIdentExpr() for ANY
+// keyword whose string was non-empty. That silently routed CORE keyword
+// tokens like CONTAINS / FREETEXT into a FuncCallExpr shape and hid the
+// fact that the explicit case list in parsePrimary was incomplete. When
+// the refactor tightened the default branch to ContextKeyword only,
+// CONTAINS / FREETEXT started failing to parse — an invisible regression
+// for multiple call-sites at once.
+//
+// The fix landed in search_functions.go adds dedicated AST nodes and
+// parse functions aligned with SqlScriptDOM's grammar. This file
+// institutionalises the alignment: every T-SQL keyword that looks like a
+// function call has an explicit role in the parser's dispatch tables, and
+// this manifest-driven test asserts that each keyword parses in its
+// declared context AND fails in all the others.
+//
+// If you add a new CoreKeyword-callable (e.g. a future TVF that becomes a
+// reserved keyword), add it to the manifest below. Tests will then guide
+// you to the correct dispatch site.
+
+// keywordRole classifies where a Core keyword is allowed to appear in a
+// function-call-like position.
+type keywordRole int
+
+const (
+	// roleExprScalar — callable in scalar expression positions, typically
+	// produces a dedicated scalar AST (CAST/CONVERT/CASE/...) or, absent
+	// a custom parser, a FuncCallExpr.
+	roleExprScalar keywordRole = iota
+	// roleFullTextPredicate — valid only inside <search_condition> (WHERE /
+	// HAVING / JOIN ON / CASE WHEN / ...), produces ast.FullTextPredicate.
+	// CONTAINS, FREETEXT.
+	roleFullTextPredicate
+	// roleRowsetTable — rowset function, valid only as a FROM table source,
+	// produces a FuncCallExpr-based AliasedTableRef. OPENROWSET / OPENQUERY
+	// / OPENJSON / OPENDATASOURCE / OPENXML.
+	roleRowsetTable
+	// roleFullTextTable — valid only as a FROM table source, produces
+	// ast.FullTextTableRef. CONTAINSTABLE, FREETEXTTABLE.
+	roleFullTextTable
+	// roleSemanticTable — valid only as a FROM table source, produces
+	// ast.SemanticTableRef. SEMANTICKEYPHRASETABLE /
+	// SEMANTICSIMILARITYTABLE / SEMANTICSIMILARITYDETAILSTABLE.
+	roleSemanticTable
+)
+
+type callableKeyword struct {
+	keyword string
+	role    keywordRole
+	// acceptSample is a SQL snippet that exercises the keyword in its
+	// declared context. It must parse without error.
+	acceptSample string
+	// alsoScalar is true for FROM-side callables that SqlScriptDOM also
+	// happens to accept as generic scalar FunctionCall in expression
+	// position. OPENJSON is the canonical example: it is a ContextKeyword
+	// (not reserved) so `SELECT OPENJSON(…)` parses as a scalar
+	// FunctionCall. Keywords with alsoScalar=true are exempt from the
+	// scalar-rejection half of TestCallableKeywordRoleRejection.
+	alsoScalar bool
+}
+
+// callableKeywordManifest is the single source of truth for which CoreKeyword
+// tokens are legal as function-call-like callables and what role they fill.
+var callableKeywordManifest = []callableKeyword{
+	// --- roleExprScalar (scalar-expression callables) ---
+	{keyword: "CAST", role: roleExprScalar, acceptSample: "SELECT CAST(1 AS INT)"},
+	{keyword: "CONVERT", role: roleExprScalar, acceptSample: "SELECT CONVERT(VARCHAR, 1)"},
+	{keyword: "TRY_CAST", role: roleExprScalar, acceptSample: "SELECT TRY_CAST('1' AS INT)"},
+	{keyword: "TRY_CONVERT", role: roleExprScalar, acceptSample: "SELECT TRY_CONVERT(INT, '1')"},
+	{keyword: "COALESCE", role: roleExprScalar, acceptSample: "SELECT COALESCE(1, 2)"},
+	{keyword: "NULLIF", role: roleExprScalar, acceptSample: "SELECT NULLIF(1, 2)"},
+	{keyword: "IIF", role: roleExprScalar, acceptSample: "SELECT IIF(1 = 1, 1, 0)"},
+	// --- roleFullTextPredicate ---
+	{keyword: "CONTAINS", role: roleFullTextPredicate, acceptSample: "SELECT 1 FROM t WHERE CONTAINS(b, 'foo')"},
+	{keyword: "FREETEXT", role: roleFullTextPredicate, acceptSample: "SELECT 1 FROM t WHERE FREETEXT(b, 'foo')"},
+	// --- roleRowsetTable ---
+	//
+	// The accept samples below are the minimal legal shape that exercises
+	// each keyword's dispatch in parsePrimaryTableSource. Richer forms
+	// (OPENROWSET BULK, OPENDATASOURCE.db.schema.tbl chains) are separately
+	// tested elsewhere and are out of scope for this regression guard.
+	{keyword: "OPENROWSET", role: roleRowsetTable, acceptSample: "SELECT * FROM OPENROWSET('SQLNCLI', 'srv', 'SELECT 1')"},
+	{keyword: "OPENQUERY", role: roleRowsetTable, acceptSample: "SELECT * FROM OPENQUERY(srv, 'SELECT 1')"},
+	// OPENJSON is a ContextKeyword in SqlScriptDOM: scalar `SELECT
+	// OPENJSON(...)` parses as a generic FunctionCall there, so omni
+	// mirrors that behavior. Special-path dispatch in FROM.
+	{keyword: "OPENJSON", role: roleRowsetTable, acceptSample: "SELECT * FROM OPENJSON(@j)", alsoScalar: true},
+	{keyword: "OPENDATASOURCE", role: roleRowsetTable, acceptSample: "SELECT * FROM OPENDATASOURCE('SQLNCLI', 'conn')"},
+	{keyword: "OPENXML", role: roleRowsetTable, acceptSample: "SELECT * FROM OPENXML(@h, 'x')"},
+	// --- roleFullTextTable ---
+	{keyword: "CONTAINSTABLE", role: roleFullTextTable, acceptSample: "SELECT * FROM CONTAINSTABLE(t, b, 'foo') ct"},
+	{keyword: "FREETEXTTABLE", role: roleFullTextTable, acceptSample: "SELECT * FROM FREETEXTTABLE(t, b, 'foo') ft"},
+	// --- roleSemanticTable ---
+	{keyword: "SEMANTICKEYPHRASETABLE", role: roleSemanticTable, acceptSample: "SELECT * FROM SEMANTICKEYPHRASETABLE(t, b) s"},
+	{keyword: "SEMANTICSIMILARITYTABLE", role: roleSemanticTable, acceptSample: "SELECT * FROM SEMANTICSIMILARITYTABLE(t, b, 1) s"},
+	{keyword: "SEMANTICSIMILARITYDETAILSTABLE", role: roleSemanticTable, acceptSample: "SELECT * FROM SEMANTICSIMILARITYDETAILSTABLE(t, a, 1, b, 2) s"},
+}
+
+// rejectContexts are the "wrong-context" shapes we spray each keyword into
+// to prove the parser rejects it outside its declared role.
+type rejectContext struct {
+	name   string
+	render func(keyword string) string
+	// allowRoles is the set of roles that are allowed to use this context.
+	// A keyword whose role is in this set is skipped for this context
+	// (because the context matches its declared role).
+	allowRoles []keywordRole
+}
+
+var rejectContexts = []rejectContext{
+	{
+		name:   "scalar-select-list",
+		render: func(k string) string { return "SELECT " + k + "(1, 'x')" },
+		// CAST-family produce their own statement-level scalar
+		// expressions; full-text predicates and rowset/table functions
+		// must not appear here.
+		allowRoles: []keywordRole{roleExprScalar},
+	},
+	{
+		name:   "scalar-func-arg",
+		render: func(k string) string { return "SELECT COALESCE(" + k + "(a, 'x'), 0)" },
+		// Wrapping in another scalar function is still scalar position —
+		// only expr-scalar callables are legal here (and CAST/CONVERT
+		// take special-shaped args not `a, 'x'`; the wrapping test is
+		// intentionally permissive for scalar callables so we skip
+		// failure assertion for roleExprScalar here by listing it as
+		// "allowed").
+		allowRoles: []keywordRole{roleExprScalar},
+	},
+	{
+		name:   "from-table-source",
+		render: func(k string) string { return "SELECT * FROM " + k + "(1, 2)" },
+		allowRoles: []keywordRole{
+			roleRowsetTable,
+			roleFullTextTable,
+			roleSemanticTable,
+			// Note: expr-scalar callables have degenerate function-call
+			// syntax and would be treated as TVFs by the FROM path. We
+			// still expect them to fail here because the args don't
+			// match their expected grammar — except COALESCE/NULLIF/IIF
+			// which are variadic-ish. Skip CAST/CONVERT/TRY_CAST/
+			// TRY_CONVERT via allow for roleExprScalar — COALESCE etc.
+			// failing here is fine even if allowed, we only assert
+			// *rejections* for keywords NOT in allowRoles.
+			roleExprScalar,
+		},
+	},
+}
+
+// TestCallableKeywordManifest asserts each manifest entry parses in its
+// declared accepting context.
+func TestCallableKeywordManifest(t *testing.T) {
+	for _, entry := range callableKeywordManifest {
+		t.Run(entry.keyword+"/accept", func(t *testing.T) {
+			_, err := Parse(entry.acceptSample)
+			if err != nil {
+				t.Fatalf("accept-context parse failed for %s: %v\nSQL: %s",
+					entry.keyword, err, entry.acceptSample)
+			}
+		})
+	}
+}
+
+// TestCallableKeywordRoleRejection asserts each keyword is rejected in
+// every context NOT in its declared role. This catches future drift where
+// a refactor either widens a dispatch silently (letting a predicate into
+// scalar position) or narrows one and breaks an accepted keyword.
+func TestCallableKeywordRoleRejection(t *testing.T) {
+	for _, entry := range callableKeywordManifest {
+		for _, ctx := range rejectContexts {
+			if roleIn(entry.role, ctx.allowRoles) {
+				continue
+			}
+			// Hybrid scalar/FROM keywords (OPENJSON today) are also
+			// legal as generic scalar FunctionCalls.
+			if entry.alsoScalar && strings.HasPrefix(ctx.name, "scalar-") {
+				continue
+			}
+			sql := ctx.render(entry.keyword)
+			name := entry.keyword + "/" + ctx.name
+			t.Run(name, func(t *testing.T) {
+				_, err := Parse(sql)
+				if err == nil {
+					t.Errorf("keyword %s must be rejected in context %s\nSQL: %s",
+						entry.keyword, ctx.name, sql)
+				}
+			})
+		}
+	}
+}
+
+// TestCallableKeywordManifestIsExhaustive enforces that every CoreKeyword
+// whose lowercase form ends in a "callable-like" suffix (`table`) or is in
+// the hand-picked tripwire list is listed in callableKeywordManifest. This
+// is the drift detector: if someone adds a new `*TABLE` CoreKeyword and
+// forgets to wire it, this test tells them where to look.
+func TestCallableKeywordManifestIsExhaustive(t *testing.T) {
+	// Build a lookup from the manifest.
+	have := map[string]bool{}
+	for _, e := range callableKeywordManifest {
+		have[strings.ToLower(e.keyword)] = true
+	}
+	// Hand-picked tripwire list — historically all of these were
+	// CoreKeyword function-call-like tokens. If a new keyword fits any
+	// of these patterns add it to the manifest.
+	tripwire := []string{}
+	for _, kw := range sqlServerCoreKeywords {
+		lw := strings.ToLower(kw)
+		// Tripwire 1: every "*table" keyword in SqlScriptDOM is a TVF.
+		if strings.HasSuffix(lw, "table") && lw != "table" {
+			tripwire = append(tripwire, lw)
+		}
+		// Tripwire 2: the OPEN* family.
+		if strings.HasPrefix(lw, "open") && lw != "open" {
+			tripwire = append(tripwire, lw)
+		}
+	}
+	for _, kw := range tripwire {
+		if !have[kw] {
+			t.Errorf("CoreKeyword %q fits a known callable pattern but is not in callableKeywordManifest. "+
+				"Either add a manifest entry with the correct role or document why it is not a callable.",
+				kw)
+		}
+	}
+}
+
+func roleIn(r keywordRole, set []keywordRole) bool {
+	for _, x := range set {
+		if x == r {
+			return true
+		}
+	}
+	return false
+}

--- a/mssql/parser/merge.go
+++ b/mssql/parser/merge.go
@@ -212,7 +212,9 @@ func (p *Parser) parseMergeWhenClause() (*nodes.MergeWhenClause, error) {
 
 	// Optional AND condition
 	if _, ok := p.match(kwAND); ok {
+		p.enterSearchCondition()
 		cond, err := p.parseExpr()
+		p.leaveSearchCondition()
 		if err != nil {
 			return nil, err
 		}

--- a/mssql/parser/parser.go
+++ b/mssql/parser/parser.go
@@ -25,7 +25,26 @@ type Parser struct {
 	candidates *CandidateSet // collected candidates
 	collecting bool          // true once cursor position has been reached
 	maxCollect int           // max candidates before stopping
+
+	// searchCondDepth is non-zero while parsing a T-SQL <search_condition>
+	// (WHERE / HAVING / JOIN ON / CASE WHEN / MERGE WHEN / IF / WHILE /
+	// CHECK). Full-text predicates (CONTAINS / FREETEXT) are only allowed
+	// when this depth is > 0, matching SqlScriptDOM's separation of
+	// booleanExpressionWithFlags from expressionWithFlags.
+	searchCondDepth int
 }
+
+// enterSearchCondition / leaveSearchCondition push and pop the boolean
+// search-condition context. Use as:
+//
+//	p.enterSearchCondition(); defer p.leaveSearchCondition()
+//	expr, err := p.parseExpr()
+func (p *Parser) enterSearchCondition() { p.searchCondDepth++ }
+func (p *Parser) leaveSearchCondition() { p.searchCondDepth-- }
+
+// inSearchCondition reports whether we are currently parsing a search
+// condition (WHERE-like boolean context).
+func (p *Parser) inSearchCondition() bool { return p.searchCondDepth > 0 }
 
 // Parse parses a T-SQL string into an AST list.
 // Currently supports basic infrastructure; statement dispatch will be

--- a/mssql/parser/scriptdom_harness_test.go
+++ b/mssql/parser/scriptdom_harness_test.go
@@ -212,6 +212,18 @@ func omniTableRef(n ast.Node) any {
 		return omniAliasedTable(v)
 	case *ast.SubqueryExpr:
 		return map[string]any{"kind": "QueryDerivedTable"}
+	case *ast.FullTextTableRef:
+		out := map[string]any{"kind": "FullTextTableReference"}
+		if v.Alias != "" {
+			out["alias"] = v.Alias
+		}
+		return out
+	case *ast.SemanticTableRef:
+		out := map[string]any{"kind": "SemanticTableReference"}
+		if v.Alias != "" {
+			out["alias"] = v.Alias
+		}
+		return out
 	case *ast.JoinClause:
 		left := omniTableRef(v.Left)
 		right := omniTableRef(v.Right)
@@ -374,6 +386,14 @@ func TestScriptDOMDiff(t *testing.T) {
 		{name: "openjson-with", sql: `SELECT * FROM OPENJSON(@j) WITH (id int '$.id', name nvarchar(50) '$.name') AS t`},
 		{name: "subquery-alias-no-cols", sql: `SELECT * FROM (SELECT a FROM t) AS x`},
 		{name: "plain-named-table", sql: `SELECT a FROM t`},
+		// Full-text / semantic table references — shape kind must match
+		// SqlScriptDOM's FullTextTableReference / SemanticTableReference.
+		{name: "fulltext-containstable", sql: `SELECT * FROM CONTAINSTABLE(t, b, 'foo') ct`},
+		{name: "fulltext-freetexttable", sql: `SELECT * FROM FREETEXTTABLE(t, (a, b), 'foo') ft`},
+		{name: "fulltext-containstable-lang-topn", sql: `SELECT * FROM CONTAINSTABLE(t, b, 'foo', LANGUAGE 'English', 10) ct`},
+		{name: "semantic-keyphrase", sql: `SELECT * FROM SEMANTICKEYPHRASETABLE(t, b) s`},
+		{name: "semantic-similarity", sql: `SELECT * FROM SEMANTICSIMILARITYTABLE(t, (a, b), 1) s`},
+		{name: "semantic-similarity-details", sql: `SELECT * FROM SEMANTICSIMILARITYDETAILSTABLE(t, a, 1, b, 2) s`},
 	}
 
 	for _, f := range fixtures {
@@ -486,6 +506,13 @@ func TestScriptDOMRejectAlignment(t *testing.T) {
 		{"enum/assembly-permset-bogus", `CREATE ASSEMBLY a FROM 'x' WITH PERMISSION_SET = BOGUS`},
 		{"enum/for-xml-bogus", `SELECT * FROM t FOR XML BOGUS`},
 		{"enum/for-json-bogus", `SELECT * FROM t FOR JSON BOGUS`},
+		// Full-text predicates (CONTAINS / FREETEXT) are a <search_condition>
+		// production — not a scalar expression. SqlScriptDOM rejects them
+		// outside boolean positions; omni must too.
+		{"fulltext/contains-in-select-list", `SELECT CONTAINS(b, 'foo')`},
+		{"fulltext/freetext-in-select-list", `SELECT FREETEXT(b, 'foo')`},
+		{"fulltext/contains-in-scalar-subquery", `SELECT c FROM t WHERE b > (SELECT CONTAINS(col, 'x') FROM u)`},
+		{"fulltext/contains-as-func-arg", `SELECT COALESCE(CONTAINS(b, 'foo'), 0)`},
 	}
 
 	for _, f := range fixtures {

--- a/mssql/parser/search_functions.go
+++ b/mssql/parser/search_functions.go
@@ -1,0 +1,536 @@
+// Package parser - search_functions.go parses T-SQL full-text search
+// predicates and semantic / full-text rowset functions:
+//
+//	CONTAINS / FREETEXT                       (search_condition predicate)
+//	CONTAINSTABLE / FREETEXTTABLE             (FROM table source)
+//	SEMANTICKEYPHRASETABLE /
+//	  SEMANTICSIMILARITYTABLE /
+//	  SEMANTICSIMILARITYDETAILSTABLE          (FROM table source)
+//
+// These keywords are all CoreKeyword tokens in T-SQL: they can only appear
+// at the specific grammar positions handled below. They are NOT generic
+// function-call scalar expressions.
+//
+// AST aligns with SqlScriptDOM:
+//
+//	FullTextPredicate     -> ast.FullTextPredicate
+//	FullTextTableReference-> ast.FullTextTableRef
+//	SemanticTableReference-> ast.SemanticTableRef
+//
+// Grammar references: TSql170.g: fulltextPredicate, fulltextTableReference,
+// semanticKeyPhraseTableReference, semanticSimilarityTableReference,
+// semanticSimilarityDetailsTableReference.
+package parser
+
+import (
+	"strings"
+
+	nodes "github.com/bytebase/omni/mssql/ast"
+)
+
+// parseFullTextPredicate parses a CONTAINS(...) or FREETEXT(...) predicate.
+// Caller must ensure the current token is kwCONTAINS or kwFREETEXT.
+//
+//	fulltext_predicate =
+//	    ( CONTAINS | FREETEXT ) '('
+//	        ( column_ref
+//	        | '*'
+//	        | '(' ( '*' | column_ref ( ',' column_ref )* ) ')'
+//	        | PROPERTY '(' column_ref ',' string_literal ')'
+//	        ) ','
+//	        ( string_literal | variable )
+//	        [ ',' LANGUAGE language_term ]
+//	    ')'
+func (p *Parser) parseFullTextPredicate() (nodes.ExprNode, error) {
+	loc := p.pos()
+	result := &nodes.FullTextPredicate{Loc: nodes.Loc{Start: loc, End: -1}}
+	switch p.cur.Type {
+	case kwCONTAINS:
+		result.Func = nodes.FullTextContains
+	case kwFREETEXT:
+		result.Func = nodes.FullTextFreeText
+	default:
+		return nil, p.unexpectedToken()
+	}
+	p.advance() // consume CONTAINS / FREETEXT
+
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	cols, propName, err := p.parseFullTextColumnsArg()
+	if err != nil {
+		return nil, err
+	}
+	result.Columns = cols
+	result.PropertyName = propName
+
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+
+	val, err := p.parseFullTextValue()
+	if err != nil {
+		return nil, err
+	}
+	result.Value = val
+
+	// Optional LANGUAGE <expr>
+	if _, ok := p.match(','); ok {
+		if _, err := p.expect(kwLANGUAGE); err != nil {
+			return nil, err
+		}
+		lang, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if lang == nil {
+			return nil, p.unexpectedToken()
+		}
+		result.LanguageTerm = lang
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	result.Loc.End = p.prevEnd()
+	return result, nil
+}
+
+// parseFullTextColumnsArg parses the column portion of a full-text predicate
+// or full-text table reference. Handles:
+//   - single column reference
+//   - '*'
+//   - '(' col_list ')' or '(' '*' ')'
+//   - PROPERTY '(' col_ref ',' string_literal ')'
+//
+// Returns the columns list and, when PROPERTY was used, the property-name
+// literal (else nil).
+func (p *Parser) parseFullTextColumnsArg() (*nodes.List, *nodes.Literal, error) {
+	// PROPERTY ( col_ref , string_literal )
+	if p.cur.Type == kwPROPERTY && p.peekNext().Type == '(' {
+		p.advance() // PROPERTY
+		p.advance() // (
+		col, err := p.parseFullTextColumn()
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, err := p.expect(','); err != nil {
+			return nil, nil, err
+		}
+		lit, err := p.parseStringLiteral()
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, nil, err
+		}
+		return &nodes.List{Items: []nodes.Node{col}}, lit, nil
+	}
+
+	// '(' ... ')'
+	if p.cur.Type == '(' {
+		p.advance()
+		var items []nodes.Node
+		for {
+			col, err := p.parseFullTextColumn()
+			if err != nil {
+				return nil, nil, err
+			}
+			items = append(items, col)
+			if _, ok := p.match(','); !ok {
+				break
+			}
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, nil, err
+		}
+		return &nodes.List{Items: items}, nil, nil
+	}
+
+	// Single column or star
+	col, err := p.parseFullTextColumn()
+	if err != nil {
+		return nil, nil, err
+	}
+	return &nodes.List{Items: []nodes.Node{col}}, nil, nil
+}
+
+// parseFullTextColumn parses one of:
+//   - '*'
+//   - [schema.]column  (qualified column reference)
+func (p *Parser) parseFullTextColumn() (nodes.ExprNode, error) {
+	if p.cur.Type == '*' {
+		loc := p.pos()
+		tok := p.advance()
+		_ = tok
+		return &nodes.StarExpr{
+			Loc: nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	}
+	loc := p.pos()
+	name, ok := p.parseIdentifier()
+	if !ok {
+		return nil, p.unexpectedToken()
+	}
+	ref := &nodes.ColumnRef{Column: name, Loc: nodes.Loc{Start: loc, End: -1}}
+	for p.cur.Type == '.' {
+		p.advance()
+		if p.cur.Type == '*' {
+			p.advance()
+			star := &nodes.StarExpr{
+				Qualifier: ref.Column,
+				Loc:       nodes.Loc{Start: loc, End: p.prevEnd()},
+			}
+			return star, nil
+		}
+		part, ok := p.parseIdentifier()
+		if !ok {
+			return nil, p.unexpectedToken()
+		}
+		// Shift parts left: old Column becomes Table, etc.
+		ref.Server = ref.Database
+		ref.Database = ref.Schema
+		ref.Schema = ref.Table
+		ref.Table = ref.Column
+		ref.Column = part
+	}
+	ref.Loc.End = p.prevEnd()
+	return ref, nil
+}
+
+// parseStringLiteral consumes a string literal token and returns a *Literal.
+func (p *Parser) parseStringLiteral() (*nodes.Literal, error) {
+	loc := p.pos()
+	switch p.cur.Type {
+	case tokSCONST:
+		tok := p.advance()
+		return &nodes.Literal{
+			Type: nodes.LitString,
+			Str:  tok.Str,
+			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	case tokNSCONST:
+		tok := p.advance()
+		return &nodes.Literal{
+			Type:    nodes.LitString,
+			Str:     tok.Str,
+			IsNChar: true,
+			Loc:     nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	}
+	return nil, p.unexpectedToken()
+}
+
+// parseFullTextValue parses the search value: a string literal or a variable.
+func (p *Parser) parseFullTextValue() (nodes.ExprNode, error) {
+	switch p.cur.Type {
+	case tokSCONST, tokNSCONST:
+		return p.parseStringLiteral()
+	case tokVARIABLE:
+		loc := p.pos()
+		tok := p.advance()
+		return &nodes.VariableRef{
+			Name: tok.Str,
+			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	}
+	return nil, p.unexpectedToken()
+}
+
+// parseFullTextTableRef parses CONTAINSTABLE(...) / FREETEXTTABLE(...) used as
+// a table source. Caller must ensure the current token is kwCONTAINSTABLE or
+// kwFREETEXTTABLE.
+//
+//	fulltext_table_ref =
+//	    ( CONTAINSTABLE | FREETEXTTABLE ) '('
+//	        table_ref ','
+//	        columns_arg ','                    -- same shapes as fulltext_predicate
+//	        ( string_literal | variable )
+//	        [ ',' LANGUAGE language_term ]     -- order of TopN and LANGUAGE may swap
+//	        [ ',' ( integer_literal | variable ) ]
+//	    ')' [ [AS] alias ]
+func (p *Parser) parseFullTextTableRef() (nodes.TableExpr, error) {
+	loc := p.pos()
+	result := &nodes.FullTextTableRef{Loc: nodes.Loc{Start: loc, End: -1}}
+	switch p.cur.Type {
+	case kwCONTAINSTABLE:
+		result.Func = nodes.FullTextContains
+	case kwFREETEXTTABLE:
+		result.Func = nodes.FullTextFreeText
+	default:
+		return nil, p.unexpectedToken()
+	}
+	p.advance() // consume the function keyword
+
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	tbl, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	if tbl == nil {
+		return nil, p.unexpectedToken()
+	}
+	result.Table = tbl
+
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+
+	cols, propName, err := p.parseFullTextColumnsArg()
+	if err != nil {
+		return nil, err
+	}
+	result.Columns = cols
+	result.PropertyName = propName
+
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+	sc, err := p.parseFullTextValue()
+	if err != nil {
+		return nil, err
+	}
+	result.SearchCondition = sc
+
+	// Options: LANGUAGE <expr> and/or integer TopN, in either order.
+	for _, ok := p.match(','); ok; _, ok = p.match(',') {
+		switch {
+		case p.cur.Type == kwLANGUAGE:
+			if result.Language != nil {
+				return nil, p.unexpectedToken()
+			}
+			p.advance()
+			lang, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			if lang == nil {
+				return nil, p.unexpectedToken()
+			}
+			result.Language = lang
+		default:
+			if result.TopN != nil {
+				return nil, p.unexpectedToken()
+			}
+			topN, err := p.parseFullTextTopN()
+			if err != nil {
+				return nil, err
+			}
+			result.TopN = topN
+		}
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	result.Alias = p.parseOptionalAlias()
+	result.Loc.End = p.prevEnd()
+	return result, nil
+}
+
+// parseFullTextTopN parses the optional top-N integer-or-variable argument
+// to CONTAINSTABLE/FREETEXTTABLE.
+func (p *Parser) parseFullTextTopN() (nodes.ExprNode, error) {
+	loc := p.pos()
+	switch p.cur.Type {
+	case tokICONST:
+		tok := p.advance()
+		return &nodes.Literal{
+			Type: nodes.LitInteger,
+			Ival: tok.Ival,
+			Str:  tok.Str,
+			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	case tokVARIABLE:
+		tok := p.advance()
+		return &nodes.VariableRef{
+			Name: tok.Str,
+			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	case '-':
+		// Negative integer — allow for symmetry; SqlScriptDOM's
+		// possibleNegativeConstant accepts '-' prefix for semantic table args
+		// but not here; reject to stay strict.
+		return nil, p.unexpectedToken()
+	}
+	return nil, p.unexpectedToken()
+}
+
+// parseSemanticTableRef parses one of SEMANTICKEYPHRASETABLE /
+// SEMANTICSIMILARITYTABLE / SEMANTICSIMILARITYDETAILSTABLE. Caller must
+// ensure the current token is one of those keywords.
+//
+//	semantic_key_phrase_table =
+//	    SEMANTICKEYPHRASETABLE '(' table_ref ','
+//	        ( column | '*' | '(' col_list ')' )
+//	        [ ',' integer_or_variable ]
+//	    ')' [ [AS] alias ]
+//
+//	semantic_similarity_table =
+//	    SEMANTICSIMILARITYTABLE '(' table_ref ','
+//	        ( column | '*' | '(' col_list ')' ) ','
+//	        integer_or_variable
+//	    ')' [ [AS] alias ]
+//
+//	semantic_similarity_details_table =
+//	    SEMANTICSIMILARITYDETAILSTABLE '(' table_ref ','
+//	        column ',' integer_or_variable ','
+//	        column ',' integer_or_variable
+//	    ')' [ [AS] alias ]
+func (p *Parser) parseSemanticTableRef() (nodes.TableExpr, error) {
+	loc := p.pos()
+	result := &nodes.SemanticTableRef{Loc: nodes.Loc{Start: loc, End: -1}}
+	var kind nodes.SemanticFunc
+	switch p.cur.Type {
+	case kwSEMANTICKEYPHRASETABLE:
+		kind = nodes.SemanticKeyPhraseTable
+	case kwSEMANTICSIMILARITYTABLE:
+		kind = nodes.SemanticSimilarityTable
+	case kwSEMANTICSIMILARITYDETAILSTABLE:
+		kind = nodes.SemanticSimilarityDetailsTable
+	default:
+		return nil, p.unexpectedToken()
+	}
+	result.Func = kind
+	p.advance()
+
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	tbl, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	if tbl == nil {
+		return nil, p.unexpectedToken()
+	}
+	result.Table = tbl
+
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+
+	switch kind {
+	case nodes.SemanticKeyPhraseTable:
+		cols, _, err := p.parseFullTextColumnsArg()
+		if err != nil {
+			return nil, err
+		}
+		result.Columns = cols
+		// Optional , source_key
+		if _, ok := p.match(','); ok {
+			sk, err := p.parseSemanticKey()
+			if err != nil {
+				return nil, err
+			}
+			result.SourceKey = sk
+		}
+	case nodes.SemanticSimilarityTable:
+		cols, _, err := p.parseFullTextColumnsArg()
+		if err != nil {
+			return nil, err
+		}
+		result.Columns = cols
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+		sk, err := p.parseSemanticKey()
+		if err != nil {
+			return nil, err
+		}
+		result.SourceKey = sk
+	case nodes.SemanticSimilarityDetailsTable:
+		// source_column , source_key , matched_column , matched_key
+		srcCol, err := p.parseFullTextColumn()
+		if err != nil {
+			return nil, err
+		}
+		srcRef, ok := srcCol.(*nodes.ColumnRef)
+		if !ok {
+			return nil, p.unexpectedToken()
+		}
+		result.Columns = &nodes.List{Items: []nodes.Node{srcCol}}
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+		sk, err := p.parseSemanticKey()
+		if err != nil {
+			return nil, err
+		}
+		result.SourceKey = sk
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+		matchedCol, err := p.parseFullTextColumn()
+		if err != nil {
+			return nil, err
+		}
+		matchedRef, ok := matchedCol.(*nodes.ColumnRef)
+		if !ok {
+			return nil, p.unexpectedToken()
+		}
+		result.MatchedColumn = matchedRef
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+		mk, err := p.parseSemanticKey()
+		if err != nil {
+			return nil, err
+		}
+		result.MatchedKey = mk
+		_ = srcRef
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	result.Alias = p.parseOptionalAlias()
+	result.Loc.End = p.prevEnd()
+	return result, nil
+}
+
+// parseSemanticKey parses a "possibleNegativeConstant"-style value used for
+// source_key / matched_key arguments in semantic table functions. In practice
+// this is a signed integer literal or a variable reference.
+func (p *Parser) parseSemanticKey() (nodes.ExprNode, error) {
+	loc := p.pos()
+	neg := false
+	if p.cur.Type == '-' {
+		neg = true
+		p.advance()
+	} else if p.cur.Type == '+' {
+		p.advance()
+	}
+	switch p.cur.Type {
+	case tokICONST:
+		tok := p.advance()
+		ival := tok.Ival
+		str := tok.Str
+		if neg {
+			ival = -ival
+			if !strings.HasPrefix(str, "-") {
+				str = "-" + str
+			}
+		}
+		return &nodes.Literal{
+			Type: nodes.LitInteger,
+			Ival: ival,
+			Str:  str,
+			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	case tokVARIABLE:
+		if neg {
+			return nil, p.unexpectedToken()
+		}
+		tok := p.advance()
+		return &nodes.VariableRef{
+			Name: tok.Str,
+			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		}, nil
+	}
+	return nil, p.unexpectedToken()
+}

--- a/mssql/parser/search_functions_test.go
+++ b/mssql/parser/search_functions_test.go
@@ -1,0 +1,522 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mssql/ast"
+)
+
+// TestFullTextPredicate verifies CONTAINS / FREETEXT parse as FullTextPredicate
+// inside a WHERE search condition, matching SqlScriptDOM's FullTextPredicate
+// shape.
+func TestFullTextPredicate(t *testing.T) {
+	tests := []struct {
+		name           string
+		sql            string
+		wantFunc       ast.FullTextFunc
+		wantColCount   int
+		wantStarIdx    []int // indices in Columns that should be StarExpr
+		wantProperty   string
+		wantValue      string // expected Literal.Str or Variable.Name when value is a variable
+		wantValueVar   bool
+		wantLanguage   string // empty => expect no LanguageTerm
+		wantLanguageN  bool   // language is N'...'
+	}{
+		{
+			name:         "contains-single-col",
+			sql:          "SELECT * FROM t WHERE CONTAINS(b, 'foo')",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantValue:    "foo",
+		},
+		{
+			name:         "freetext-single-col",
+			sql:          "SELECT * FROM t WHERE FREETEXT(b, 'foo')",
+			wantFunc:     ast.FullTextFreeText,
+			wantColCount: 1,
+			wantValue:    "foo",
+		},
+		{
+			name:         "contains-star",
+			sql:          "SELECT * FROM t WHERE CONTAINS(*, 'foo')",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantStarIdx:  []int{0},
+			wantValue:    "foo",
+		},
+		{
+			name:         "contains-paren-list",
+			sql:          "SELECT * FROM t WHERE CONTAINS((a, b), 'foo')",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 2,
+			wantValue:    "foo",
+		},
+		{
+			name:         "contains-paren-star",
+			sql:          "SELECT * FROM t WHERE CONTAINS((*), 'foo')",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantStarIdx:  []int{0},
+			wantValue:    "foo",
+		},
+		{
+			name:         "contains-property",
+			sql:          "SELECT * FROM t WHERE CONTAINS(PROPERTY(b, 'Title'), 'foo')",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantProperty: "Title",
+			wantValue:    "foo",
+		},
+		{
+			name:         "contains-language",
+			sql:          "SELECT * FROM t WHERE CONTAINS((a, b), 'foo', LANGUAGE 'English')",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 2,
+			wantValue:    "foo",
+			wantLanguage: "English",
+		},
+		{
+			name:         "contains-variable-value",
+			sql:          "DECLARE @v NVARCHAR(100); SELECT * FROM t WHERE CONTAINS(b, @v)",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantValue:    "@v",
+			wantValueVar: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			pred := findFullTextPredicate(t, list)
+			if pred == nil {
+				t.Fatalf("no FullTextPredicate in parse tree: %s", ast.NodeToString(list))
+			}
+			if pred.Func != tt.wantFunc {
+				t.Errorf("func = %v, want %v", pred.Func, tt.wantFunc)
+			}
+			if pred.Columns == nil {
+				t.Fatalf("Columns is nil")
+			}
+			if got := len(pred.Columns.Items); got != tt.wantColCount {
+				t.Errorf("Columns len = %d, want %d", got, tt.wantColCount)
+			}
+			for _, idx := range tt.wantStarIdx {
+				if idx >= len(pred.Columns.Items) {
+					t.Errorf("expected star at idx %d but list too short", idx)
+					continue
+				}
+				if _, ok := pred.Columns.Items[idx].(*ast.StarExpr); !ok {
+					t.Errorf("Columns[%d] = %T, want *StarExpr", idx, pred.Columns.Items[idx])
+				}
+			}
+			if tt.wantProperty != "" {
+				if pred.PropertyName == nil {
+					t.Errorf("PropertyName is nil, want literal %q", tt.wantProperty)
+				} else if pred.PropertyName.Str != tt.wantProperty {
+					t.Errorf("PropertyName = %q, want %q", pred.PropertyName.Str, tt.wantProperty)
+				}
+			} else if pred.PropertyName != nil {
+				t.Errorf("PropertyName = %q, want nil", pred.PropertyName.Str)
+			}
+			if tt.wantValueVar {
+				v, ok := pred.Value.(*ast.VariableRef)
+				if !ok {
+					t.Fatalf("Value = %T, want *VariableRef", pred.Value)
+				}
+				if v.Name != tt.wantValue {
+					t.Errorf("Value.Name = %q, want %q", v.Name, tt.wantValue)
+				}
+			} else {
+				lit, ok := pred.Value.(*ast.Literal)
+				if !ok {
+					t.Fatalf("Value = %T, want *Literal", pred.Value)
+				}
+				if lit.Str != tt.wantValue {
+					t.Errorf("Value.Str = %q, want %q", lit.Str, tt.wantValue)
+				}
+			}
+			if tt.wantLanguage != "" {
+				lit, ok := pred.LanguageTerm.(*ast.Literal)
+				if !ok {
+					t.Fatalf("LanguageTerm = %T, want *Literal", pred.LanguageTerm)
+				}
+				if lit.Str != tt.wantLanguage {
+					t.Errorf("LanguageTerm = %q, want %q", lit.Str, tt.wantLanguage)
+				}
+			} else if pred.LanguageTerm != nil {
+				t.Errorf("LanguageTerm = %v, want nil", pred.LanguageTerm)
+			}
+			if pred.Loc.Start < 0 || pred.Loc.End < 0 {
+				t.Errorf("Loc not populated: %+v", pred.Loc)
+			}
+		})
+	}
+}
+
+// TestFullTextPredicateRejectsAsScalar verifies that CONTAINS/FREETEXT
+// CANNOT appear as a scalar expression — they are only valid inside
+// search_condition positions. This matches SqlScriptDOM's behavior.
+func TestFullTextPredicateRejectsAsScalar(t *testing.T) {
+	rejects := []string{
+		// bare scalar
+		"SELECT CONTAINS(b, 'foo')",
+		"SELECT FREETEXT(b, 'foo')",
+		// nested inside subquery select list
+		"SELECT c FROM t WHERE b > (SELECT CONTAINS(col, 'x') FROM u)",
+		// arithmetic context
+		"SELECT 1 + CONTAINS(b, 'foo')",
+		// function arg
+		"SELECT COALESCE(CONTAINS(b, 'foo'), 0)",
+	}
+	for _, sql := range rejects {
+		t.Run(sql, func(t *testing.T) {
+			_, err := Parse(sql)
+			if err == nil {
+				t.Errorf("Parse(%q): expected error but got nil", sql)
+			}
+		})
+	}
+}
+
+// TestFullTextPredicateWithNot verifies that NOT CONTAINS(...) produces a
+// UnaryNot wrapping a FullTextPredicate, matching SqlScriptDOM's
+// BooleanNotExpression{Expression: FullTextPredicate} layout.
+func TestFullTextPredicateWithNot(t *testing.T) {
+	sql := "SELECT * FROM t WHERE NOT CONTAINS(b, 'foo')"
+	list, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sel, ok := list.Items[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("stmt = %T, want SelectStmt", list.Items[0])
+	}
+	unary, ok := sel.WhereClause.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("WhereClause = %T, want *UnaryExpr (NOT)", sel.WhereClause)
+	}
+	if unary.Op != ast.UnaryNot {
+		t.Errorf("UnaryExpr.Op = %v, want UnaryNot", unary.Op)
+	}
+	if _, ok := unary.Operand.(*ast.FullTextPredicate); !ok {
+		t.Errorf("operand = %T, want *FullTextPredicate", unary.Operand)
+	}
+}
+
+// TestFullTextTableRef verifies CONTAINSTABLE / FREETEXTTABLE parse to a
+// FullTextTableRef in FROM position.
+func TestFullTextTableRef(t *testing.T) {
+	tests := []struct {
+		name         string
+		sql          string
+		wantFunc     ast.FullTextFunc
+		wantColCount int
+		wantProperty string
+		wantSC       string
+		wantAlias    string
+		wantLanguage string
+		wantTopN     int64
+		hasTopN      bool
+	}{
+		{
+			name:         "containstable-single",
+			sql:          "SELECT * FROM CONTAINSTABLE(t, b, 'foo') ct",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantSC:       "foo",
+			wantAlias:    "ct",
+		},
+		{
+			name:         "freetexttable-paren-list",
+			sql:          "SELECT * FROM FREETEXTTABLE(t, (a, b), 'foo') ft",
+			wantFunc:     ast.FullTextFreeText,
+			wantColCount: 2,
+			wantSC:       "foo",
+			wantAlias:    "ft",
+		},
+		{
+			name:         "containstable-language-topn",
+			sql:          "SELECT * FROM CONTAINSTABLE(t, (a, b), 'foo', LANGUAGE 'English', 10) ct",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 2,
+			wantSC:       "foo",
+			wantAlias:    "ct",
+			wantLanguage: "English",
+			wantTopN:     10,
+			hasTopN:      true,
+		},
+		{
+			name:         "containstable-topn-language",
+			sql:          "SELECT * FROM CONTAINSTABLE(t, b, 'foo', 5, LANGUAGE 'English') ct",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantSC:       "foo",
+			wantAlias:    "ct",
+			wantLanguage: "English",
+			wantTopN:     5,
+			hasTopN:      true,
+		},
+		{
+			name:         "containstable-property",
+			sql:          "SELECT * FROM CONTAINSTABLE(t, PROPERTY(b, 'Title'), 'foo') ct",
+			wantFunc:     ast.FullTextContains,
+			wantColCount: 1,
+			wantProperty: "Title",
+			wantSC:       "foo",
+			wantAlias:    "ct",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			ref := findFullTextTableRef(t, list)
+			if ref == nil {
+				t.Fatalf("no FullTextTableRef in parse tree: %s", ast.NodeToString(list))
+			}
+			if ref.Func != tt.wantFunc {
+				t.Errorf("Func = %v, want %v", ref.Func, tt.wantFunc)
+			}
+			if ref.Table == nil || ref.Table.Object == "" {
+				t.Errorf("Table missing: %+v", ref.Table)
+			}
+			if ref.Columns == nil || len(ref.Columns.Items) != tt.wantColCount {
+				got := 0
+				if ref.Columns != nil {
+					got = len(ref.Columns.Items)
+				}
+				t.Errorf("Columns len = %d, want %d", got, tt.wantColCount)
+			}
+			if tt.wantProperty != "" {
+				if ref.PropertyName == nil {
+					t.Errorf("PropertyName = nil, want %q", tt.wantProperty)
+				} else if ref.PropertyName.Str != tt.wantProperty {
+					t.Errorf("PropertyName = %q, want %q", ref.PropertyName.Str, tt.wantProperty)
+				}
+			} else if ref.PropertyName != nil {
+				t.Errorf("PropertyName = %q, want nil", ref.PropertyName.Str)
+			}
+			if lit, ok := ref.SearchCondition.(*ast.Literal); ok {
+				if lit.Str != tt.wantSC {
+					t.Errorf("SearchCondition = %q, want %q", lit.Str, tt.wantSC)
+				}
+			} else {
+				t.Errorf("SearchCondition = %T, want *Literal", ref.SearchCondition)
+			}
+			if tt.wantAlias != "" && ref.Alias != tt.wantAlias {
+				t.Errorf("Alias = %q, want %q", ref.Alias, tt.wantAlias)
+			}
+			if tt.wantLanguage != "" {
+				lit, ok := ref.Language.(*ast.Literal)
+				if !ok || lit.Str != tt.wantLanguage {
+					t.Errorf("Language = %v, want %q", ref.Language, tt.wantLanguage)
+				}
+			} else if ref.Language != nil {
+				t.Errorf("Language = %v, want nil", ref.Language)
+			}
+			if tt.hasTopN {
+				lit, ok := ref.TopN.(*ast.Literal)
+				if !ok || lit.Ival != tt.wantTopN {
+					t.Errorf("TopN = %v, want %d", ref.TopN, tt.wantTopN)
+				}
+			} else if ref.TopN != nil {
+				t.Errorf("TopN = %v, want nil", ref.TopN)
+			}
+		})
+	}
+}
+
+// TestSemanticTableRef verifies the three semantic TVFs parse correctly.
+func TestSemanticTableRef(t *testing.T) {
+	tests := []struct {
+		name            string
+		sql             string
+		wantFunc        ast.SemanticFunc
+		wantColCount    int
+		wantSourceKey   int64
+		wantHasKey      bool
+		wantMatchedCol  string
+		wantMatchedKey  int64
+		wantAlias       string
+	}{
+		{
+			name:         "keyphrase-no-key",
+			sql:          "SELECT * FROM SEMANTICKEYPHRASETABLE(t, b) s",
+			wantFunc:     ast.SemanticKeyPhraseTable,
+			wantColCount: 1,
+			wantAlias:    "s",
+		},
+		{
+			name:          "keyphrase-with-key",
+			sql:           "SELECT * FROM SEMANTICKEYPHRASETABLE(t, b, 1) s",
+			wantFunc:      ast.SemanticKeyPhraseTable,
+			wantColCount:  1,
+			wantSourceKey: 1,
+			wantHasKey:    true,
+			wantAlias:     "s",
+		},
+		{
+			name:          "similarity",
+			sql:           "SELECT * FROM SEMANTICSIMILARITYTABLE(t, (a, b), 1) s",
+			wantFunc:      ast.SemanticSimilarityTable,
+			wantColCount:  2,
+			wantSourceKey: 1,
+			wantHasKey:    true,
+			wantAlias:     "s",
+		},
+		{
+			name:           "similarity-details",
+			sql:            "SELECT * FROM SEMANTICSIMILARITYDETAILSTABLE(t, a, 1, b, 2) s",
+			wantFunc:       ast.SemanticSimilarityDetailsTable,
+			wantColCount:   1,
+			wantSourceKey:  1,
+			wantHasKey:     true,
+			wantMatchedCol: "b",
+			wantMatchedKey: 2,
+			wantAlias:      "s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			ref := findSemanticTableRef(t, list)
+			if ref == nil {
+				t.Fatalf("no SemanticTableRef in parse tree: %s", ast.NodeToString(list))
+			}
+			if ref.Func != tt.wantFunc {
+				t.Errorf("Func = %v, want %v", ref.Func, tt.wantFunc)
+			}
+			if ref.Table == nil || ref.Table.Object == "" {
+				t.Errorf("Table missing: %+v", ref.Table)
+			}
+			if ref.Columns == nil || len(ref.Columns.Items) != tt.wantColCount {
+				got := 0
+				if ref.Columns != nil {
+					got = len(ref.Columns.Items)
+				}
+				t.Errorf("Columns len = %d, want %d", got, tt.wantColCount)
+			}
+			if tt.wantHasKey {
+				lit, ok := ref.SourceKey.(*ast.Literal)
+				if !ok || lit.Ival != tt.wantSourceKey {
+					t.Errorf("SourceKey = %v, want %d", ref.SourceKey, tt.wantSourceKey)
+				}
+			} else if ref.SourceKey != nil {
+				t.Errorf("SourceKey = %v, want nil", ref.SourceKey)
+			}
+			if tt.wantMatchedCol != "" {
+				if ref.MatchedColumn == nil {
+					t.Errorf("MatchedColumn = nil, want %q", tt.wantMatchedCol)
+				} else if ref.MatchedColumn.Column != tt.wantMatchedCol {
+					t.Errorf("MatchedColumn = %q, want %q", ref.MatchedColumn.Column, tt.wantMatchedCol)
+				}
+				lit, ok := ref.MatchedKey.(*ast.Literal)
+				if !ok || lit.Ival != tt.wantMatchedKey {
+					t.Errorf("MatchedKey = %v, want %d", ref.MatchedKey, tt.wantMatchedKey)
+				}
+			}
+			if tt.wantAlias != "" && ref.Alias != tt.wantAlias {
+				t.Errorf("Alias = %q, want %q", ref.Alias, tt.wantAlias)
+			}
+		})
+	}
+}
+
+// TestSearchFunctionSerialization verifies NodeToString round-trips through
+// the outfuncs tag table — this is the regression lever that tripped the
+// original CONTAINS regression (a node that the parser produced but outfuncs
+// didn't know about would either panic or dump {UNKNOWN TYPE …}).
+func TestSearchFunctionSerialization(t *testing.T) {
+	sqls := []string{
+		"SELECT * FROM t WHERE CONTAINS(b, 'foo')",
+		"SELECT * FROM t WHERE FREETEXT((a, b), 'foo', LANGUAGE 'English')",
+		"SELECT * FROM t WHERE CONTAINS(PROPERTY(b, 'Title'), 'foo')",
+		"SELECT * FROM CONTAINSTABLE(t, b, 'foo') ct",
+		"SELECT * FROM FREETEXTTABLE(t, (a,b), 'foo', LANGUAGE 'English', 10) ft",
+		"SELECT * FROM SEMANTICKEYPHRASETABLE(t, b, 1) s",
+		"SELECT * FROM SEMANTICSIMILARITYTABLE(t, (a, b), 1) s",
+		"SELECT * FROM SEMANTICSIMILARITYDETAILSTABLE(t, a, 1, b, 2) s",
+	}
+	for _, sql := range sqls {
+		t.Run(sql, func(t *testing.T) {
+			list, err := Parse(sql)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			for _, stmt := range list.Items {
+				s := ast.NodeToString(stmt)
+				if strings.Contains(s, "UNKNOWN TYPE") {
+					t.Errorf("NodeToString produced UNKNOWN TYPE sentinel: %s", s)
+				}
+				if s == "" {
+					t.Errorf("NodeToString returned empty string")
+				}
+			}
+		})
+	}
+}
+
+// --- find helpers ---
+
+func findFullTextPredicate(t *testing.T, list *ast.List) *ast.FullTextPredicate {
+	t.Helper()
+	var found *ast.FullTextPredicate
+	ast.Walk(visitorFunc(func(n ast.Node) bool {
+		if p, ok := n.(*ast.FullTextPredicate); ok {
+			found = p
+			return false
+		}
+		return true
+	}), list)
+	return found
+}
+
+func findFullTextTableRef(t *testing.T, list *ast.List) *ast.FullTextTableRef {
+	t.Helper()
+	var found *ast.FullTextTableRef
+	ast.Walk(visitorFunc(func(n ast.Node) bool {
+		if r, ok := n.(*ast.FullTextTableRef); ok {
+			found = r
+			return false
+		}
+		return true
+	}), list)
+	return found
+}
+
+func findSemanticTableRef(t *testing.T, list *ast.List) *ast.SemanticTableRef {
+	t.Helper()
+	var found *ast.SemanticTableRef
+	ast.Walk(visitorFunc(func(n ast.Node) bool {
+		if r, ok := n.(*ast.SemanticTableRef); ok {
+			found = r
+			return false
+		}
+		return true
+	}), list)
+	return found
+}
+
+type visitorFunc func(ast.Node) bool
+
+func (f visitorFunc) Visit(n ast.Node) ast.Visitor {
+	if n == nil {
+		return nil
+	}
+	if f(n) {
+		return f
+	}
+	return nil
+}

--- a/mssql/parser/select.go
+++ b/mssql/parser/select.go
@@ -34,6 +34,15 @@ import (
 //	    [ HAVING <search_condition> ]
 //	    [ WINDOW windowDefinition [ , windowDefinition ]* ]
 func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
+	// Entering a SELECT (top-level or subquery) resets the search-condition
+	// depth so that the select list / scalar subexpressions are parsed as
+	// scalar expressions even if we entered from an outer WHERE or HAVING.
+	// The SELECT's own WHERE / HAVING / JOIN ON clauses will increment the
+	// depth back for their duration.
+	savedDepth := p.searchCondDepth
+	p.searchCondDepth = 0
+	defer func() { p.searchCondDepth = savedDepth }()
+
 	loc := p.pos()
 
 	// WITH clause (CTE)
@@ -163,7 +172,9 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 			p.addRuleCandidate("func_name")
 			return nil, errCollecting
 		}
+		p.enterSearchCondition()
 		stmt.WhereClause, err = p.parseExpr()
+		p.leaveSearchCondition()
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +225,9 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 			p.addRuleCandidate("func_name")
 			return nil, errCollecting
 		}
+		p.enterSearchCondition()
 		stmt.HavingClause, err = p.parseExpr()
+		p.leaveSearchCondition()
 		if err != nil {
 			return nil, err
 		}
@@ -799,7 +812,9 @@ func (p *Parser) parseTableSource() (nodes.TableExpr, error) {
 					p.addRuleCandidate("func_name")
 					return nil, errCollecting
 				}
+				p.enterSearchCondition()
 				join.Condition, err = p.parseExpr()
+				p.leaveSearchCondition()
 				if err != nil {
 					return nil, err
 				}
@@ -873,6 +888,19 @@ func (p *Parser) parsePrimaryTableSource() (nodes.TableExpr, error) {
 	if p.cur.Type == kwOPENROWSET || p.cur.Type == kwOPENQUERY || p.cur.Type == kwOPENJSON ||
 		p.cur.Type == kwOPENDATASOURCE || p.cur.Type == kwOPENXML {
 		return p.parseRowsetFunction()
+	}
+
+	// Full-text rowset functions: CONTAINSTABLE, FREETEXTTABLE
+	if p.cur.Type == kwCONTAINSTABLE || p.cur.Type == kwFREETEXTTABLE {
+		return p.parseFullTextTableRef()
+	}
+
+	// Semantic table functions: SEMANTICKEYPHRASETABLE,
+	// SEMANTICSIMILARITYTABLE, SEMANTICSIMILARITYDETAILSTABLE
+	if p.cur.Type == kwSEMANTICKEYPHRASETABLE ||
+		p.cur.Type == kwSEMANTICSIMILARITYTABLE ||
+		p.cur.Type == kwSEMANTICSIMILARITYDETAILSTABLE {
+		return p.parseSemanticTableRef()
 	}
 
 	// T-SQL table variable: @t [alias] or @t.Method(args) [alias (cols)]

--- a/mssql/parser/update_delete.go
+++ b/mssql/parser/update_delete.go
@@ -306,6 +306,8 @@ func (p *Parser) parseWhereClauseBody() (nodes.ExprNode, error) {
 			}, nil
 		}
 	}
+	p.enterSearchCondition()
+	defer p.leaveSearchCondition()
 	return p.parseExpr()
 }
 


### PR DESCRIPTION
## Summary

- Restores `WHERE CONTAINS(...)` / `WHERE FREETEXT(...)` parsing (silent regression after the parsePrimary default branch was tightened to ContextKeyword only) — and goes the rest of the way: aligns AST shape and acceptance with SqlScriptDOM's `FullTextPredicate`, `FullTextTableReference`, `SemanticTableReference` instead of the prior generic-FuncCallExpr fallback.
- Adds dedicated parsers for the FROM-side full-text and semantic table-valued functions that were also failing (`CONTAINSTABLE`, `FREETEXTTABLE`, `SEMANTICKEYPHRASETABLE`, `SEMANTICSIMILARITYTABLE`, `SEMANTICSIMILARITYDETAILSTABLE`).
- Adds a manifest-based regression guard so this class of "silently allowed in the wrong context" bug cannot recur for any callable CoreKeyword.

## Why

The earlier optimize pass narrowed `parsePrimary`'s default fallthrough from `isAnyKeywordIdent()` (any keyword) to `isContextKeyword()`. CoreKeyword tokens like `CONTAINS` / `FREETEXT` had been silently relying on that fallback to reach `parseIdentExpr` and produce a `FuncCallExpr` — which itself was a misalignment with SqlScriptDOM, not "the right behavior we lost." SqlScriptDOM models these as dedicated boolean / table-reference fragments with structured fields (`FullTextFunctionType`, `Columns`, `Value`, `LanguageTerm`, `PropertyName`, `TopN`, `MatchedColumn` / `MatchedKey`, …), and rejects them in scalar position. This PR brings omni in line.

## What changed

**3 new AST nodes** (`mssql/ast/parsenodes.go`, regen'd `walk_generated.go`, hand-written outfuncs):

- `FullTextPredicate` — `CONTAINS` / `FREETEXT` as `<search_condition>` boolean
- `FullTextTableRef` — `CONTAINSTABLE` / `FREETEXTTABLE` as FROM TVF
- `SemanticTableRef` — `SEMANTIC*TABLE` family as FROM TVF

**3 new parsers** (`mssql/parser/search_functions.go`):

- Full column shape support (single column, `*`, paren list, `PROPERTY(col, 'name')`)
- Optional `LANGUAGE <expr>` and `TopN`
- String literal or variable for the search value
- `SemanticSimilarityDetailsTable`'s 5-arg form (source/matched column + key)

**Boolean / scalar context distinction** (the systemic part):

- New `Parser.searchCondDepth` counter with `enterSearchCondition` / `leaveSearchCondition`
- Pushed at WHERE, HAVING, JOIN ON, searched CASE WHEN, IF, WHILE, MERGE WHEN AND, UPDATE/DELETE WHERE
- `parseSelectStmt` saves and resets to 0 at entry so nested subqueries get a fresh scalar context
- `parseNot` only accepts `CONTAINS` / `FREETEXT` while the depth is positive — matches SqlScriptDOM's `booleanExpressionWithFlags` vs `expressionWithFlags` separation
- `parsePrimaryTableSource` dispatches `CONTAINSTABLE` / `FREETEXTTABLE` / `SEMANTIC*` to the new parsers

**Regression guard** (`mssql/parser/keyword_callable_test.go`):

A single manifest classifies every callable CoreKeyword into roles (`roleExprScalar`, `roleFullTextPredicate`, `roleRowsetTable`, `roleFullTextTable`, `roleSemanticTable`). Three tests:

1. each keyword parses in its declared context
2. each keyword is rejected in every other context — directly catches the class of silent-allow bug this PR fixes
3. tripwires `*table` and `open*` CoreKeywords against the manifest so a new keyword cannot land without its dispatch wired

## Test plan

- [x] `go test ./mssql/... -count=1` (full mssql suite, parser ~55s) — all green
- [x] `go test ./mssql/parser/ -tags scriptdom -count=1` (SqlScriptDOM oracle diff + reject alignment) — all green
- [x] New scriptdom fixtures cover FROM-side AST shape (CONTAINSTABLE / FREETEXTTABLE / SEMANTIC* — kind matches `FullTextTableReference` / `SemanticTableReference`)
- [x] New scriptdom reject fixtures cover scalar-position CONTAINS / FREETEXT (in select list, in scalar subquery, as function arg) — omni rejects in lockstep with SqlScriptDOM
- [x] `keyword_callable_test.go` manifest tests pass and tripwire is exhaustive across the current `sqlServerCoreKeywords` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)