### PR TITLE
feat(mssql): expose parser completion signals for Bytebase

### DIFF
--- a/mssql/parser/SCENARIOS-mssql-completion.md
+++ b/mssql/parser/SCENARIOS-mssql-completion.md
@@ -42,6 +42,19 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial
 - [x] `DROP |` → object type keywords (TABLE, INDEX, VIEW, PROCEDURE, FUNCTION, TRIGGER, DATABASE, SCHEMA, TYPE, SEQUENCE, SYNONYM, STATISTICS, LOGIN, USER, ROLE, IF)
 - [x] Build passes after 1.3
 
+### 1.4 Bytebase-Facing Parser API Compatibility
+
+- [x] `Tokenize(sql)` returns non-EOF tokens with stable `Loc`/`End` byte offsets for caret-token and quoted-identifier handling
+- [x] `IsIdentTokenType(tokenType)` matches T-SQL parser identifier semantics: regular/bracketed/quoted identifiers and context keywords are accepted; core keywords are rejected unless quoted
+- [x] Exported completion token aliases cover PG/MySQL adapter-style keyword checks (`SELECT`, `FROM`, `JOIN`, `ORDER`, `GO`, etc.)
+- [x] Exported aliases include Bytebase object/qualifier and clause tokens (`DATABASE`, `SCHEMA`, `TABLE`, `VIEW`, `SEQUENCE`, `COLUMN`, `BY`, `ASC`, `DESC`, `OFFSET`, `FETCH`, etc.)
+- [x] Prefix retry flow works: tokenize `SELECT * FROM dbo.Us|`, retry `Collect` at the `Us` token start, and receive `table_ref`
+- [x] Prefix retry flow works for column references: `SELECT Na| FROM Employees` and `SELECT tableAlias.Na| ...` produce `columnref`
+- [x] `CTEPositions` records `WITH` offsets for Bytebase virtual table extraction
+- [x] `SelectAliasPositions` records alias token offsets for `AS alias`, implicit aliases, and T-SQL `alias = expr`
+- [x] `GO` batch separator followed by cursor returns new top-level statement candidates
+- [x] Public API tests use `parser_test` so Bytebase-facing behavior only depends on exported parser APIs
+
 ---
 
 ## Phase 2: Completion Module (API & Resolution)
@@ -61,19 +74,19 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial
 ### 2.2 Candidate Resolution
 
 - [x] Token candidates → keyword strings (from TokenName mapping)
-- [x] "table_ref" rule → catalog tables + views
-- [x] "columnref" rule → columns from tables in scope
-- [x] "schema_ref" rule → catalog schemas
-- [x] "func_name" rule → catalog functions + built-in function names
-- [x] "proc_ref" rule → catalog procedures
-- [x] "index_ref" rule → indexes from relevant table
-- [x] "trigger_ref" rule → catalog triggers
+- [~] "table_ref" rule → parser emits rule; standalone `mssql/completion` catalog resolver is still a TODO
+- [~] "columnref" rule → parser emits rule; table refs are extracted, but catalog-backed column resolution is still a TODO
+- [~] "schema_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "func_name" rule → parser emits rule; standalone built-in/catalog function resolution is still a TODO
+- [~] "proc_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "index_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "trigger_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
 - [x] "type_name" rule → T-SQL type keywords (INT, VARCHAR, NVARCHAR, TEXT, DATETIME, DECIMAL, BIT, etc.)
-- [x] "database_ref" rule → catalog databases
-- [x] "sequence_ref" rule → catalog sequences
-- [x] "login_ref" rule → catalog logins
-- [x] "user_ref" rule → catalog users
-- [x] "role_ref" rule → catalog roles
+- [~] "database_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "sequence_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "login_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "user_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
+- [~] "role_ref" rule → parser emits rule; standalone catalog resolver is still a TODO
 
 ### 2.3 Table Reference Extraction
 
@@ -95,6 +108,17 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial
 - [x] Truncated after operator: `WHERE a >` → insert placeholder expression
 - [x] Multiple placeholder strategies tried in order
 - [x] Fallback returns best-effort results when no strategy succeeds
+
+### 2.5 Parser-Only Incomplete SQL Signals
+
+- [x] `SELECT * FROM|` and `SELECT * FROM |` → `table_ref`
+- [x] `SELECT * FROM dbo.|` → `table_ref`
+- [x] `SELECT * FROM Employees JOIN|` → `table_ref`
+- [x] `SELECT Id,|` and `SELECT Id, |` → `columnref`
+- [x] `SELECT * FROM Employees WHERE Id =|` and trailing-space variant → `columnref`
+- [x] `SELECT Id FROM Employees ORDER BY|` and trailing-space variant → `columnref`
+- [x] `WITH cte AS (|` → `SELECT`
+- [x] `WITH cte AS (...) SELECT * FROM|` → `table_ref`
 
 ---
 
@@ -391,6 +415,8 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial
 - [x] `SELECT x.| FROM t AS x` → columnref with alias resolution
 - [x] `SELECT dbo.t.| FROM dbo.t` → columnref with schema-qualified table
 - [x] `SELECT * FROM dbo.|` → table_ref within schema
+- [x] `SELECT |.* FROM Employees AS e` → columnref signal for Bytebase table/alias star qualifier completion
+- [x] `SELECT e.|* FROM Employees AS e` → columnref signal for qualified star completion
 - [x] CTE columns available: `WITH cte(a,b) AS (...) SELECT cte.| FROM cte` → columnref from CTE
 
 ### 9.2 Edge Cases

--- a/mssql/parser/complete.go
+++ b/mssql/parser/complete.go
@@ -36,6 +36,135 @@ func TokenName(tokenType int) string {
 	return ""
 }
 
+// Tokenize runs the lexer on sql and returns all non-EOF tokens.
+// Useful for walking the token stream without a full parse.
+func Tokenize(sql string) []Token {
+	lex := NewLexer(sql)
+	var tokens []Token
+	for {
+		tok := lex.NextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+		tokens = append(tokens, tok)
+	}
+	return tokens
+}
+
+// IsIdentTokenType reports whether a token type can be used as a T-SQL
+// identifier (IDENT or context-sensitive keyword). Core keywords are not bare
+// identifiers unless quoted, in which case the lexer emits tokIDENT.
+func IsIdentTokenType(typ int) bool {
+	return typ == tokIDENT || isContextKeyword(typ)
+}
+
+// Exported token type constants for completion callers.
+const (
+	ICONST      = tokICONST
+	FCONST      = tokFCONST
+	SCONST      = tokSCONST
+	NSCONST     = tokNSCONST
+	IDENT       = tokIDENT
+	VARIABLE    = tokVARIABLE
+	SYSVARIABLE = tokSYSVARIABLE
+
+	SELECT    = kwSELECT
+	INSERT    = kwINSERT
+	UPDATE    = kwUPDATE
+	DELETE    = kwDELETE
+	MERGE     = kwMERGE
+	FROM      = kwFROM
+	WHERE     = kwWHERE
+	SET       = kwSET
+	INTO      = kwINTO
+	VALUES    = kwVALUES
+	AS        = kwAS
+	ON        = kwON
+	JOIN      = kwJOIN
+	INNER     = kwINNER
+	LEFT      = kwLEFT
+	RIGHT     = kwRIGHT
+	FULL      = kwFULL
+	CROSS     = kwCROSS
+	OUTER     = kwOUTER
+	APPLY     = kwAPPLY
+	ORDER     = kwORDER
+	GROUP     = kwGROUP
+	HAVING    = kwHAVING
+	UNION     = kwUNION
+	EXCEPT    = kwEXCEPT
+	INTERSECT = kwINTERSECT
+	FOR       = kwFOR
+	WITH      = kwWITH
+	OPTION    = kwOPTION
+	TOP       = kwTOP
+	DISTINCT  = kwDISTINCT
+	ALL       = kwALL
+	OUTPUT    = kwOUTPUT
+	BY        = kwBY
+	ASC       = kwASC
+	DESC      = kwDESC
+	OFFSET    = kwOFFSET
+	FETCH     = kwFETCH
+	NEXT      = kwNEXT
+	FIRST     = kwFIRST
+	ROW       = kwROW
+	ROWS      = kwROWS
+	ONLY      = kwONLY
+
+	CREATE   = kwCREATE
+	ALTER    = kwALTER
+	DROP     = kwDROP
+	TRUNCATE = kwTRUNCATE
+	DECLARE  = kwDECLARE
+	EXEC     = kwEXEC
+	EXECUTE  = kwEXECUTE
+	USE      = kwUSE
+	GO       = kwGO
+
+	DATABASE   = kwDATABASE
+	SCHEMA     = kwSCHEMA
+	TABLE      = kwTABLE
+	VIEW       = kwVIEW
+	SEQUENCE   = kwSEQUENCE
+	COLUMN     = kwCOLUMN
+	INDEX      = kwINDEX
+	TRIGGER    = kwTRIGGER
+	FUNCTION   = kwFUNCTION
+	PROCEDURE  = kwPROCEDURE
+	KEY        = kwKEY
+	CONSTRAINT = kwCONSTRAINT
+	PRIMARY    = kwPRIMARY
+	FOREIGN    = kwFOREIGN
+	REFERENCES = kwREFERENCES
+	DEFAULT    = kwDEFAULT
+	NULL       = kwNULL
+	NOT        = kwNOT
+	AND        = kwAND
+	OR         = kwOR
+	IS         = kwIS
+	LIKE       = kwLIKE
+	BETWEEN    = kwBETWEEN
+	EXISTS     = kwEXISTS
+	CASE       = kwCASE
+	WHEN       = kwWHEN
+	THEN       = kwTHEN
+	ELSE       = kwELSE
+	END        = kwEND
+	OVER       = kwOVER
+	PARTITION  = kwPARTITION
+	XML        = kwXML
+	JSON       = kwJSON
+	BROWSE     = kwBROWSE
+	PATH       = kwPATH
+	AUTO       = kwAUTO
+	RAW        = kwRAW
+	RECOMPILE  = kwRECOMPILE
+	OPTIMIZE   = kwOPTIMIZE
+	MAXDOP     = kwMAXDOP
+	NOLOCK     = kwNOLOCK
+)
+
 // topLevelKeywords are the statement-starting keywords offered when the cursor
 // is at an empty input or after a semicolon.
 var topLevelKeywords = []int{
@@ -56,10 +185,10 @@ type RuleCandidate struct {
 // CandidateSet holds the token and rule candidates collected during a
 // completion-mode parse.
 type CandidateSet struct {
-	Tokens []int            // token type candidates
-	Rules  []RuleCandidate  // grammar rule candidates
-	seen   map[int]bool     // dedup tokens
-	seenR  map[string]bool  // dedup rules
+	Tokens []int           // token type candidates
+	Rules  []RuleCandidate // grammar rule candidates
+	seen   map[int]bool    // dedup tokens
+	seenR  map[string]bool // dedup rules
 
 	// CTEPositions holds the byte offsets of WITH clause starts encountered
 	// before the cursor. Used to re-parse CTE definitions and extract

--- a/mssql/parser/complete_api_test.go
+++ b/mssql/parser/complete_api_test.go
@@ -1,0 +1,204 @@
+package parser_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mssql/parser"
+)
+
+func TestCompletionPublicTokenize(t *testing.T) {
+	sql := "SELECT [select], dbo.Users FROM [Order Details] WHERE id = @id"
+
+	tokens := parser.Tokenize(sql)
+	if len(tokens) == 0 {
+		t.Fatal("Tokenize returned no tokens")
+	}
+	if got := parser.TokenName(tokens[0].Type); got != "SELECT" {
+		t.Fatalf("first token = %q, want SELECT", got)
+	}
+	if tokens[len(tokens)-1].Str != "@id" {
+		t.Fatalf("last token string = %q, want @id", tokens[len(tokens)-1].Str)
+	}
+	for _, tok := range tokens {
+		if tok.Type == 0 {
+			t.Fatalf("Tokenize returned EOF token: %+v", tok)
+		}
+		if tok.End <= tok.Loc {
+			t.Fatalf("token has invalid location: %+v", tok)
+		}
+	}
+}
+
+func TestCompletionPublicIdentifierTokenPredicate(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{name: "regular identifier", sql: "customer", want: true},
+		{name: "bracketed reserved word", sql: "[FROM]", want: true},
+		{name: "double quoted identifier", sql: `"FROM"`, want: true},
+		{name: "context keyword as identifier", sql: "LOGON", want: true},
+		{name: "core keyword not bare identifier", sql: "FROM", want: false},
+		{name: "variable is not identifier", sql: "@id", want: false},
+		{name: "string literal is not identifier", sql: "'id'", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := parser.Tokenize(tt.sql)
+			if len(tokens) != 1 {
+				t.Fatalf("Tokenize(%q) returned %d tokens, want 1", tt.sql, len(tokens))
+			}
+			if got := parser.IsIdentTokenType(tokens[0].Type); got != tt.want {
+				t.Fatalf("IsIdentTokenType(%q/%d) = %v, want %v", tokens[0].Str, tokens[0].Type, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompletionPublicTokenConstants(t *testing.T) {
+	required := []struct {
+		token int
+		name  string
+	}{
+		{parser.SELECT, "SELECT"},
+		{parser.INSERT, "INSERT"},
+		{parser.UPDATE, "UPDATE"},
+		{parser.DELETE, "DELETE"},
+		{parser.FROM, "FROM"},
+		{parser.WHERE, "WHERE"},
+		{parser.SET, "SET"},
+		{parser.INTO, "INTO"},
+		{parser.VALUES, "VALUES"},
+		{parser.AS, "AS"},
+		{parser.ON, "ON"},
+		{parser.JOIN, "JOIN"},
+		{parser.INNER, "INNER"},
+		{parser.LEFT, "LEFT"},
+		{parser.RIGHT, "RIGHT"},
+		{parser.CROSS, "CROSS"},
+		{parser.FULL, "FULL"},
+		{parser.OUTER, "OUTER"},
+		{parser.ORDER, "ORDER"},
+		{parser.GROUP, "GROUP"},
+		{parser.HAVING, "HAVING"},
+		{parser.UNION, "UNION"},
+		{parser.FOR, "FOR"},
+		{parser.WITH, "WITH"},
+		{parser.GO, "GO"},
+		{parser.EXEC, "EXEC"},
+		{parser.EXECUTE, "EXECUTE"},
+		{parser.DATABASE, "DATABASE"},
+		{parser.SCHEMA, "SCHEMA"},
+		{parser.TABLE, "TABLE"},
+		{parser.VIEW, "VIEW"},
+		{parser.SEQUENCE, "SEQUENCE"},
+		{parser.COLUMN, "COLUMN"},
+		{parser.INDEX, "INDEX"},
+		{parser.TRIGGER, "TRIGGER"},
+		{parser.FUNCTION, "FUNCTION"},
+		{parser.PROCEDURE, "PROCEDURE"},
+		{parser.BY, "BY"},
+		{parser.ASC, "ASC"},
+		{parser.DESC, "DESC"},
+		{parser.OFFSET, "OFFSET"},
+		{parser.FETCH, "FETCH"},
+		{parser.NEXT, "NEXT"},
+		{parser.FIRST, "FIRST"},
+		{parser.ROW, "ROW"},
+		{parser.ROWS, "ROWS"},
+		{parser.ONLY, "ONLY"},
+		{parser.NULL, "NULL"},
+		{parser.NOT, "NOT"},
+		{parser.AND, "AND"},
+		{parser.OR, "OR"},
+		{parser.CASE, "CASE"},
+		{parser.WHEN, "WHEN"},
+		{parser.THEN, "THEN"},
+		{parser.ELSE, "ELSE"},
+		{parser.END, "END"},
+		{parser.OVER, "OVER"},
+		{parser.PARTITION, "PARTITION"},
+		{parser.XML, "XML"},
+		{parser.JSON, "JSON"},
+		{parser.BROWSE, "BROWSE"},
+		{parser.PATH, "PATH"},
+		{parser.AUTO, "AUTO"},
+		{parser.RAW, "RAW"},
+		{parser.RECOMPILE, "RECOMPILE"},
+		{parser.OPTIMIZE, "OPTIMIZE"},
+		{parser.MAXDOP, "MAXDOP"},
+		{parser.NOLOCK, "NOLOCK"},
+	}
+
+	for _, tt := range required {
+		if got := parser.TokenName(tt.token); got != tt.name {
+			t.Errorf("TokenName(%d) = %q, want %q", tt.token, got, tt.name)
+		}
+	}
+}
+
+func TestCompletionPrefixRetryAtIdentifierStart(t *testing.T) {
+	sql := "SELECT * FROM dbo.Us"
+	cursor := len(sql)
+	tokens := parser.Tokenize(sql)
+
+	var prefix parser.Token
+	found := false
+	for _, tok := range tokens {
+		if tok.End == cursor && parser.IsIdentTokenType(tok.Type) {
+			prefix = tok
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("failed to find identifier prefix token at cursor in %q", sql)
+	}
+
+	candidates := parser.Collect(sql, prefix.Loc)
+	if !candidates.HasRule("table_ref") {
+		t.Fatalf("Collect at prefix start did not return table_ref for %q", sql)
+	}
+}
+
+func TestCompletionRecordsCTEPositionsForBytebase(t *testing.T) {
+	sql := "WITH cte AS (SELECT id FROM dbo.Users) SELECT * FROM cte WHERE "
+	candidates := parser.Collect(sql, len(sql))
+
+	want := strings.Index(sql, "WITH")
+	if !slices.Contains(candidates.CTEPositions, want) {
+		t.Fatalf("CTEPositions = %v, want to contain %d", candidates.CTEPositions, want)
+	}
+}
+
+func TestCompletionRecordsSelectAliasPositionsForBytebase(t *testing.T) {
+	sql := "SELECT id AS c_id, name implicit_name, eq_name = id FROM dbo.Users ORDER BY "
+	candidates := parser.Collect(sql, len(sql))
+
+	want := []int{
+		strings.Index(sql, "c_id"),
+		strings.Index(sql, "implicit_name"),
+		strings.Index(sql, "eq_name"),
+	}
+	for _, pos := range want {
+		if !slices.Contains(candidates.SelectAliasPositions, pos) {
+			t.Fatalf("SelectAliasPositions = %v, want to contain %d", candidates.SelectAliasPositions, pos)
+		}
+	}
+}
+
+func TestCompletionAfterGoBatchSeparator(t *testing.T) {
+	sql := "SELECT 1\nGO\n"
+	candidates := parser.Collect(sql, len(sql))
+
+	required := []int{parser.SELECT, parser.INSERT, parser.UPDATE, parser.DELETE}
+	for _, tok := range required {
+		if !candidates.HasToken(tok) {
+			t.Fatalf("after GO: missing top-level keyword %s", parser.TokenName(tok))
+		}
+	}
+}

--- a/mssql/parser/complete_bytebase_test.go
+++ b/mssql/parser/complete_bytebase_test.go
@@ -1,0 +1,191 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mssql/parser"
+)
+
+func collectMarked(t *testing.T, input string) (string, int, *parser.CandidateSet) {
+	t.Helper()
+	cursor := strings.Index(input, "|")
+	if cursor < 0 {
+		t.Fatalf("input %q has no cursor marker", input)
+	}
+	sql := strings.Replace(input, "|", "", 1)
+	return sql, cursor, parser.Collect(sql, cursor)
+}
+
+func collectMarkedWithPrefixRetry(t *testing.T, input string) (string, int, *parser.CandidateSet) {
+	t.Helper()
+	sql, cursor, candidates := collectMarked(t, input)
+	if len(candidates.Rules) > 0 {
+		return sql, cursor, candidates
+	}
+
+	for _, tok := range parser.Tokenize(sql) {
+		if tok.Loc < cursor && cursor <= tok.End && parser.IsIdentTokenType(tok.Type) {
+			return sql, cursor, parser.Collect(sql, tok.Loc)
+		}
+		if tok.End == cursor && parser.IsIdentTokenType(tok.Type) {
+			return sql, cursor, parser.Collect(sql, tok.Loc)
+		}
+	}
+	return sql, cursor, candidates
+}
+
+func requireRule(t *testing.T, candidates *parser.CandidateSet, rule string) {
+	t.Helper()
+	if !candidates.HasRule(rule) {
+		t.Fatalf("missing rule %q; got rules=%v tokens=%v", rule, candidates.Rules, tokenNames(candidates.Tokens))
+	}
+}
+
+func requireToken(t *testing.T, candidates *parser.CandidateSet, token int) {
+	t.Helper()
+	if !candidates.HasToken(token) {
+		t.Fatalf("missing token %q; got rules=%v tokens=%v", parser.TokenName(token), candidates.Rules, tokenNames(candidates.Tokens))
+	}
+}
+
+func tokenNames(tokens []int) []string {
+	result := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		name := parser.TokenName(tok)
+		if name == "" {
+			name = string(rune(tok))
+		}
+		result = append(result, name)
+	}
+	return result
+}
+
+func TestCompletionBytebaseTableReferenceSignals(t *testing.T) {
+	tests := []string{
+		"select count(1) from t1 where id; SELECT * FROM |",
+		"SELECT 1\nGO\nSELECT * FROM |",
+		"SELECT * FROM dbo.|",
+		"SELECT * FROM MySchema.|",
+		"WITH MyCTE_01 AS (SELECT * FROM dbo.Employees) SELECT * FROM |",
+		"INSERT INTO |",
+		"UPDATE | SET Name = 'x'",
+		"DELETE FROM |",
+		"MERGE INTO target USING |",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "table_ref")
+		})
+	}
+}
+
+func TestCompletionBytebaseColumnReferenceSignals(t *testing.T) {
+	tests := []string{
+		"SELECT | FROM Employees",
+		"SELECT tableAlias.| FROM Employees AS tableAlias",
+		"WITH MyCTE_01 AS (SELECT * FROM dbo.Employees) SELECT MyCTE_01.| FROM MyCTE_01",
+		"SELECT * FROM Employees e JOIN Address a ON |",
+		"SELECT Id AS IdAlias, Name FROM Employees ORDER BY |",
+		"SELECT Id, Name FROM Employees WHERE |",
+		"SELECT Id FROM Employees GROUP BY |",
+		"SELECT Id FROM Employees HAVING |",
+		"INSERT INTO Employees SELECT | FROM Address",
+		"UPDATE Employees SET |",
+		"DELETE FROM Employees WHERE |",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "columnref")
+		})
+	}
+}
+
+func TestCompletionBytebaseAsteriskQualifierSignals(t *testing.T) {
+	tests := []string{
+		"SELECT |.* FROM Employees AS e",
+		"WITH MyCTE_01 AS (SELECT * FROM dbo.Employees) SELECT |.* FROM MyCTE_01 JOIN dbo.Address ON MyCTE_01.EmployeeID = dbo.Address.EmployeeID",
+		"SELECT e.|* FROM Employees AS e",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "columnref")
+		})
+	}
+}
+
+func TestCompletionBytebasePrefixRetrySignals(t *testing.T) {
+	tests := []struct {
+		input string
+		rule  string
+	}{
+		{input: "SELECT * FROM dbo.Us|", rule: "table_ref"},
+		{input: "SELECT * FROM Emp|", rule: "table_ref"},
+		{input: "SELECT tableAlias.Na| FROM Employees AS tableAlias", rule: "columnref"},
+		{input: "SELECT Na| FROM Employees", rule: "columnref"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, _, candidates := collectMarkedWithPrefixRetry(t, tt.input)
+			requireRule(t, candidates, tt.rule)
+		})
+	}
+}
+
+func TestCompletionIncompleteSQLSignals(t *testing.T) {
+	tests := []struct {
+		input string
+		rule  string
+		token int
+	}{
+		{input: "SELECT * FROM|", rule: "table_ref"},
+		{input: "SELECT * FROM |", rule: "table_ref"},
+		{input: "SELECT * FROM dbo.|", rule: "table_ref"},
+		{input: "SELECT * FROM Employees JOIN|", rule: "table_ref"},
+		{input: "SELECT Id,|", rule: "columnref"},
+		{input: "SELECT Id, |", rule: "columnref"},
+		{input: "SELECT * FROM Employees WHERE Id =|", rule: "columnref"},
+		{input: "SELECT * FROM Employees WHERE Id = |", rule: "columnref"},
+		{input: "SELECT Id FROM Employees ORDER BY|", rule: "columnref"},
+		{input: "SELECT Id FROM Employees ORDER BY |", rule: "columnref"},
+		{input: "WITH cte AS (|", token: parser.SELECT},
+		{input: "WITH cte AS (SELECT Id FROM dbo.Employees) SELECT * FROM|", rule: "table_ref"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, tt.input)
+			if tt.rule != "" {
+				requireRule(t, candidates, tt.rule)
+			}
+			if tt.token != 0 {
+				requireToken(t, candidates, tt.token)
+			}
+		})
+	}
+}
+
+func TestCompletionIncompleteSQLDoesNotFallBackToOnlyTopLevel(t *testing.T) {
+	tests := []string{
+		"SELECT * FROM|",
+		"SELECT Id,|",
+		"SELECT * FROM Employees WHERE Id =|",
+		"SELECT Id FROM Employees ORDER BY|",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			if len(candidates.Rules) == 0 {
+				t.Fatalf("expected grammar rule candidates, got only tokens=%v", tokenNames(candidates.Tokens))
+			}
+		})
+	}
+}

--- a/mssql/parser/name.go
+++ b/mssql/parser/name.go
@@ -218,6 +218,11 @@ func (p *Parser) parseIdentExpr() (nodes.ExprNode, error) {
 	loc := p.pos()
 	name := p.cur.Str
 	p.advance()
+	if p.collectMode() && p.cursorOff <= p.prev.End {
+		p.addRuleCandidate("columnref")
+		p.addRuleCandidate("func_name")
+		return nil, errCollecting
+	}
 
 	// Function call: ident(...)
 	if p.cur.Type == '(' {
@@ -278,6 +283,11 @@ func (p *Parser) parseQualifiedRef(first string, loc int) (nodes.ExprNode, error
 	parts := []string{first}
 	for p.cur.Type == '.' {
 		p.advance() // consume .
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addTokenCandidate('*')
+			return nil, errCollecting
+		}
 
 		// Check for table.* or schema.table.*
 		if p.cur.Type == '*' {
@@ -297,6 +307,10 @@ func (p *Parser) parseQualifiedRef(first string, loc int) (nodes.ExprNode, error
 		if p.isIdentLike() {
 			partName := p.cur.Str
 			p.advance()
+			if p.collectMode() && p.cursorOff <= p.prev.End {
+				p.addRuleCandidate("columnref")
+				return nil, errCollecting
+			}
 
 			// Check if this part is followed by '(' -- meaning it's a function call
 			// e.g., schema.function(args)

--- a/mssql/parser/select.go
+++ b/mssql/parser/select.go
@@ -661,6 +661,7 @@ func (p *Parser) parseTargetList() (*nodes.List, error) {
 				continue
 			}
 			if p.isIdentLike() && !p.isBareAliasExcluded() {
+				aliasLoc := p.pos()
 				alias := p.cur.Str
 				p.advance() // consume ident
 				p.advance() // consume =
@@ -673,6 +674,9 @@ func (p *Parser) parseTargetList() (*nodes.List, error) {
 					Val:  rhs,
 					Loc:  nodes.Loc{Start: targetLoc, End: p.prevEnd()},
 				})
+				if p.completing {
+					p.addSelectAliasPosition(aliasLoc)
+				}
 				if _, ok := p.match(','); !ok {
 					break
 				}
@@ -701,12 +705,20 @@ func (p *Parser) parseTargetList() (*nodes.List, error) {
 		// as tokIDENT and thus already passes isIdentLike.
 		if _, ok := p.match(kwAS); ok {
 			if p.isIdentLike() {
+				aliasLoc := p.pos()
 				target.Name = p.cur.Str
 				p.advance()
+				if p.completing {
+					p.addSelectAliasPosition(aliasLoc)
+				}
 			}
 		} else if p.isIdentLike() && !p.isBareAliasExcluded() {
+			aliasLoc := p.pos()
 			target.Name = p.cur.Str
 			p.advance()
+			if p.completing {
+				p.addSelectAliasPosition(aliasLoc)
+			}
 		}
 		target.Loc.End = p.prevEnd()
 		targets = append(targets, target)


### PR DESCRIPTION
## Summary
- expose MSSQL parser Tokenize, identifier-token predicate, and completion token aliases for Bytebase-style adapters
- record SELECT alias positions and emit columnref signals for identifier/qualified identifier completion
- add Bytebase-facing parser completion tests for table refs, column refs, star qualifiers, prefix retry, CTEs, GO, and incomplete SQL

## Tests
- go test ./mssql/parser -run 'TestCompletion(Bytebase|Incomplete|Public)' -count=1
- go test ./mssql/parser -run 'Test.*Complete|TestCompletion' -count=1
- go test ./mssql/completion -count=1
- go test ./mssql/parser ./mssql/completion -count=1
- go test -cover ./mssql/parser ./mssql/completion