### PR TITLE
fix(mysql): support EXPLAIN VALUES and parenthesized table lists

### DIFF
--- a/mysql/catalog/analyze_test.go
+++ b/mysql/catalog/analyze_test.go
@@ -1745,6 +1745,39 @@ func TestAnalyze_7_5_CommaJoin(t *testing.T) {
 	}
 }
 
+func TestAnalyze_7_6_ParenthesizedTableReferenceList(t *testing.T) {
+	c := setupJoinTables(t)
+	sel := parseSelect(t, `SELECT e.name, d.name FROM (employees e, departments d) WHERE e.department_id = d.id`)
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	if len(q.RangeTable) != 3 {
+		t.Fatalf("RangeTable: want 3 entries, got %d", len(q.RangeTable))
+	}
+	if q.RangeTable[0].Kind != RTERelation || q.RangeTable[0].ERef != "e" {
+		t.Errorf("RTE[0]: want RTERelation 'e', got kind=%d eref=%q", q.RangeTable[0].Kind, q.RangeTable[0].ERef)
+	}
+	if q.RangeTable[1].Kind != RTERelation || q.RangeTable[1].ERef != "d" {
+		t.Errorf("RTE[1]: want RTERelation 'd', got kind=%d eref=%q", q.RangeTable[1].Kind, q.RangeTable[1].ERef)
+	}
+	if q.RangeTable[2].Kind != RTEJoin || q.RangeTable[2].JoinType != JoinInner {
+		t.Errorf("RTE[2]: want inner RTEJoin, got kind=%d join_type=%d", q.RangeTable[2].Kind, q.RangeTable[2].JoinType)
+	}
+	if len(q.JoinTree.FromList) != 1 {
+		t.Fatalf("FromList: want 1 entry, got %d", len(q.JoinTree.FromList))
+	}
+	je, ok := q.JoinTree.FromList[0].(*JoinExprNodeQ)
+	if !ok {
+		t.Fatalf("FromList[0]: want *JoinExprNodeQ, got %T", q.JoinTree.FromList[0])
+	}
+	if je.JoinType != JoinInner {
+		t.Errorf("JoinExprNodeQ.JoinType: want JoinInner, got %d", je.JoinType)
+	}
+	if q.JoinTree.Quals == nil {
+		t.Error("JoinTree.Quals: want non-nil WHERE, got nil")
+	}
+}
+
 // --- Batch 8: USING/NATURAL ---
 
 // TestAnalyze_8_1_JoinUsing tests JOIN ... USING (col).

--- a/mysql/catalog/deparse_query_test.go
+++ b/mysql/catalog/deparse_query_test.go
@@ -221,6 +221,7 @@ func TestDeparseQuery_DeparseOutput(t *testing.T) {
 		{"order_by", "SELECT name, salary FROM employees ORDER BY salary DESC"},
 		{"limit", "SELECT name FROM employees LIMIT 10"},
 		{"distinct", "SELECT DISTINCT department_id FROM employees"},
+		{"parenthesized_table_reference_list", "SELECT e.name, d.name FROM (employees e, departments d) WHERE e.department_id = d.id"},
 	}
 
 	for _, tt := range tests {

--- a/mysql/catalog/query_span_test.go
+++ b/mysql/catalog/query_span_test.go
@@ -262,6 +262,24 @@ func TestLineage_14_4_ViewWithJoin(t *testing.T) {
 	})
 }
 
+func TestLineage_14_4b_ParenthesizedTableReferenceList(t *testing.T) {
+	c := wtSetup(t)
+	wtExec(t, c, `
+		CREATE TABLE employees (id INT, name VARCHAR(100), department_id INT);
+		CREATE TABLE departments (id INT, name VARCHAR(100));
+	`)
+
+	sel := parseSelect(t, `SELECT e.name AS employee_name, d.name AS department_name FROM (employees e, departments d) WHERE e.department_id = d.id`)
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	lineage := collectColumnLineage(c, q)
+	assertLineage(t, lineage, []resultLineage{
+		{Name: "employee_name", SourceCols: []columnLineage{{DB: "testdb", Table: "employees", Column: "name"}}},
+		{Name: "department_name", SourceCols: []columnLineage{{DB: "testdb", Table: "departments", Column: "name"}}},
+	})
+}
+
 // TestLineage_14_5_TemptableView tests that TEMPTABLE views remain opaque.
 func TestLineage_14_5_TemptableView(t *testing.T) {
 	c := wtSetup(t)

--- a/mysql/completion/SCENARIOS-completion.md
+++ b/mysql/completion/SCENARIOS-completion.md
@@ -371,7 +371,7 @@ so that Phase 3+ instrumentation can be tested end-to-end.
 [x] `GRANT SELECT ON |` → table_ref (or database.*)
 [x] `GRANT SELECT ON t TO |` → user context
 [x] `REVOKE SELECT ON |` → table_ref
-[x] `EXPLAIN |` → keyword candidates (SELECT, INSERT, UPDATE, DELETE, FORMAT)
+[x] `EXPLAIN |` → keyword candidates (ANALYZE, FORMAT, FOR, SELECT, TABLE, INSERT, UPDATE, DELETE, REPLACE, VALUES)
 [x] `EXPLAIN SELECT |` → same as SELECT instrumentation
 [x] `PREPARE stmt FROM |` → string context
 [x] `EXECUTE |` → prepared statement name

--- a/mysql/completion/refs_test.go
+++ b/mysql/completion/refs_test.go
@@ -11,10 +11,10 @@ func TestExtractTableRefs(t *testing.T) {
 		name       string
 		sql        string
 		offset     int
-		wantTables []string            // expected table names
-		wantAlias  map[string]string    // table -> alias (optional)
-		wantDB     map[string]string    // table -> database (optional)
-		wantAbsent []string            // tables that should NOT appear
+		wantTables []string          // expected table names
+		wantAlias  map[string]string // table -> alias (optional)
+		wantDB     map[string]string // table -> database (optional)
+		wantAbsent []string          // tables that should NOT appear
 	}{
 		{
 			name:       "simple_select",
@@ -33,6 +33,12 @@ func TestExtractTableRefs(t *testing.T) {
 			name:       "join",
 			sql:        "SELECT * FROM t1 JOIN t2 ON t1.a = t2.a WHERE ",
 			offset:     46,
+			wantTables: []string{"t1", "t2"},
+		},
+		{
+			name:       "parenthesized_table_reference_list",
+			sql:        "SELECT * FROM (t1, t2) WHERE ",
+			offset:     29,
 			wantTables: []string{"t1", "t2"},
 		},
 		{

--- a/mysql/deparse/deparse_test.go
+++ b/mysql/deparse/deparse_test.go
@@ -210,7 +210,7 @@ func TestDeparse_Section_2_2_ComparisonOperators(t *testing.T) {
 		// Basic comparison operators
 		{"equal", "a = b", "(`a` = `b`)"},
 		{"not_equal_angle", "a <> b", "(`a` <> `b`)"},
-		{"not_equal_bang", "a != b", "(`a` <> `b`)"},          // != normalized to <>
+		{"not_equal_bang", "a != b", "(`a` <> `b`)"}, // != normalized to <>
 		{"greater", "a > b", "(`a` > `b`)"},
 		{"less", "a < b", "(`a` < `b`)"},
 		{"greater_or_equal", "a >= b", "(`a` >= `b`)"},
@@ -956,8 +956,12 @@ func TestDeparseSelect_Section_5_2_FromClause(t *testing.T) {
 		{"table_alias_without_as", "SELECT a FROM t t1", "select `a` AS `a` from `t` `t1`"},
 		// Multiple tables (implicit cross join) → explicit join with parens
 		{"implicit_cross_join", "SELECT a FROM t1, t2", "select `a` AS `a` from (`t1` join `t2`)"},
+		// Parenthesized table reference list follows MySQL's nested-join semantics.
+		{"parenthesized_table_reference_list", "SELECT a FROM (t1, t2)", "select `a` AS `a` from (`t1` join `t2`)"},
 		// Three tables implicit cross join
 		{"implicit_cross_join_3", "SELECT a FROM t1, t2, t3", "select `a` AS `a` from ((`t1` join `t2`) join `t3`)"},
+		// Three-table parenthesized list folds left like the existing join tree.
+		{"parenthesized_table_reference_list_3", "SELECT a FROM (t1, t2, t3)", "select `a` AS `a` from ((`t1` join `t2`) join `t3`)"},
 	}
 
 	for _, tc := range cases {

--- a/mysql/parser/compare_test.go
+++ b/mysql/parser/compare_test.go
@@ -1215,6 +1215,51 @@ func TestParseSelectJoin(t *testing.T) {
 	}
 }
 
+func TestParseParenthesizedTableReferenceList(t *testing.T) {
+	t.Run("two tables fold to inner join", func(t *testing.T) {
+		sel := parseSelect(t, "SELECT * FROM (t1, t2)")
+		if len(sel.From) != 1 {
+			t.Fatalf("from count = %d, want 1", len(sel.From))
+		}
+		jc, ok := sel.From[0].(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("expected *ast.JoinClause, got %T", sel.From[0])
+		}
+		if jc.Type != ast.JoinInner {
+			t.Fatalf("join type = %d, want JoinInner", jc.Type)
+		}
+		left, ok := jc.Left.(*ast.TableRef)
+		if !ok || left.Name != "t1" {
+			t.Fatalf("left = %#v, want table t1", jc.Left)
+		}
+		right, ok := jc.Right.(*ast.TableRef)
+		if !ok || right.Name != "t2" {
+			t.Fatalf("right = %#v, want table t2", jc.Right)
+		}
+	})
+
+	t.Run("list can be right side of outer join", func(t *testing.T) {
+		sel := parseSelect(t, "SELECT * FROM t0 LEFT JOIN (t1, t2) ON t0.id = t1.id")
+		if len(sel.From) != 1 {
+			t.Fatalf("from count = %d, want 1", len(sel.From))
+		}
+		outer, ok := sel.From[0].(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("expected outer *ast.JoinClause, got %T", sel.From[0])
+		}
+		if outer.Type != ast.JoinLeft {
+			t.Fatalf("outer join type = %d, want JoinLeft", outer.Type)
+		}
+		inner, ok := outer.Right.(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("outer right = %T, want *ast.JoinClause", outer.Right)
+		}
+		if inner.Type != ast.JoinInner {
+			t.Fatalf("inner join type = %d, want JoinInner", inner.Type)
+		}
+	})
+}
+
 // TestParseSelectGroupBy tests SELECT with GROUP BY clause.
 func TestParseSelectGroupBy(t *testing.T) {
 	sel := parseSelect(t, "SELECT dept, COUNT(*) FROM emp GROUP BY dept HAVING COUNT(*) > 1")
@@ -4849,6 +4894,25 @@ func TestParseExplain(t *testing.T) {
 		}
 	})
 
+	t.Run("explain analyze values", func(t *testing.T) {
+		p := &Parser{lexer: NewLexer("EXPLAIN ANALYZE VALUES ROW(1, 2)")}
+		p.advance()
+		stmt, err := p.parseExplainStmt()
+		if err != nil {
+			t.Fatalf("parseExplainStmt error: %v", err)
+		}
+		if !stmt.Analyze {
+			t.Error("Analyze = false, want true")
+		}
+		values, ok := stmt.Stmt.(*ast.ValuesStmt)
+		if !ok {
+			t.Fatalf("Stmt type = %T, want *ast.ValuesStmt", stmt.Stmt)
+		}
+		if len(values.Rows) != 1 || len(values.Rows[0]) != 2 {
+			t.Fatalf("VALUES rows shape = %#v, want one ROW with two expressions", values.Rows)
+		}
+	})
+
 	t.Run("explain extended select", func(t *testing.T) {
 		p := &Parser{lexer: NewLexer("EXPLAIN EXTENDED SELECT * FROM t1")}
 		p.advance()
@@ -5500,7 +5564,7 @@ DELIMITER ;`,
 			bodySuffix: "END",
 		},
 		{
-			name: "function RETURNS with single RETURN body (no BEGIN)",
+			name:       "function RETURNS with single RETURN body (no BEGIN)",
 			sql:        `CREATE FUNCTION f_simple(a INT) RETURNS INT RETURN a + 1`,
 			wantStmts:  1,
 			bodySuffix: "a + 1",

--- a/mysql/parser/complete_test.go
+++ b/mysql/parser/complete_test.go
@@ -249,6 +249,21 @@ func TestCollectReplaceInto(t *testing.T) {
 	}
 }
 
+func TestCollectExplainKeywords(t *testing.T) {
+	cs := Collect("EXPLAIN ", 8)
+	if cs == nil {
+		t.Fatal("expected non-nil candidates")
+	}
+	for _, tok := range []int{
+		kwANALYZE, kwEXTENDED, kwPARTITIONS, kwFORMAT, kwFOR,
+		kwSELECT, kwTABLE, kwINSERT, kwUPDATE, kwDELETE, kwREPLACE, kwVALUES,
+	} {
+		if !cs.HasToken(tok) {
+			t.Errorf("missing EXPLAIN keyword: %s", TokenName(tok))
+		}
+	}
+}
+
 // --- UPDATE positions ---
 
 func TestCollectUpdateTable(t *testing.T) {

--- a/mysql/parser/select.go
+++ b/mysql/parser/select.go
@@ -877,6 +877,22 @@ func (p *Parser) parseTableReferenceList() ([]nodes.TableExpr, error) {
 	return refs, nil
 }
 
+func foldTableReferenceList(refs []nodes.TableExpr, end int) nodes.TableExpr {
+	if len(refs) == 0 {
+		return nil
+	}
+	left := refs[0]
+	for i := 1; i < len(refs); i++ {
+		left = &nodes.JoinClause{
+			Loc:   nodes.Loc{Start: tableExprLoc(left), End: end},
+			Type:  nodes.JoinInner,
+			Left:  left,
+			Right: refs[i],
+		}
+	}
+	return left
+}
+
 // parseTableReference parses a table reference (table_factor with optional joins).
 func (p *Parser) parseTableReference() (nodes.TableExpr, error) {
 	left, err := p.parseTableFactor()
@@ -1160,15 +1176,15 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 			return sub, nil
 		}
 
-		// Parenthesized table reference
-		ref, err := p.parseTableReference()
+		// Parenthesized table references use MySQL nested-join semantics.
+		refs, err := p.parseTableReferenceList()
 		if err != nil {
 			return nil, err
 		}
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
-		return ref, nil
+		return foldTableReferenceList(refs, p.pos()), nil
 	}
 
 	// JSON_TABLE(expr, path COLUMNS (...)) AS alias
@@ -1917,6 +1933,8 @@ func tableExprLoc(te nodes.TableExpr) int {
 	case *nodes.JoinClause:
 		return t.Loc.Start
 	case *nodes.SubqueryExpr:
+		return t.Loc.Start
+	case *nodes.JsonTableExpr:
 		return t.Loc.Start
 	}
 	return 0

--- a/mysql/parser/set_show.go
+++ b/mysql/parser/set_show.go
@@ -1510,10 +1510,10 @@ func (p *Parser) parseUseStmt() (*nodes.UseStmt, error) {
 //
 //	{EXPLAIN | DESCRIBE | DESC} tbl_name [col_name | wild]
 //	{EXPLAIN | DESCRIBE | DESC} [explain_type] {explainable_stmt | FOR CONNECTION connection_id}
-//	{EXPLAIN | DESCRIBE | DESC} ANALYZE [explain_type] select_stmt
+//	{EXPLAIN | DESCRIBE | DESC} ANALYZE [explain_type] explainable_stmt
 //	explain_type: { FORMAT = format_name }
 //	format_name: { TRADITIONAL | JSON | TREE }
-//	explainable_stmt: { SELECT | TABLE | DELETE | INSERT | REPLACE | UPDATE }
+//	explainable_stmt: { SELECT | TABLE | VALUES | DELETE | INSERT | REPLACE | UPDATE }
 func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 	start := p.pos()
 	isDescribe := p.cur.Type == kwDESCRIBE || p.cur.Type == kwDESC
@@ -1608,7 +1608,10 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 	// Completion: after EXPLAIN [options], offer explainable statement keywords.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwSELECT, kwINSERT, kwUPDATE, kwDELETE} {
+		for _, t := range []int{
+			kwANALYZE, kwEXTENDED, kwPARTITIONS, kwFORMAT, kwFOR,
+			kwSELECT, kwTABLE, kwINSERT, kwUPDATE, kwDELETE, kwREPLACE, kwVALUES,
+		} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -1652,6 +1655,12 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 			return nil, err
 		}
 		stmt.Stmt = tbl
+	case kwVALUES:
+		vals, err := p.parseValuesStmt()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Stmt = vals
 	default:
 		// For other tokens, try to parse as a table ref (EXPLAIN table_name)
 		ref, err := p.parseTableRef()

--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -1745,6 +1745,39 @@ func TestAnalyze_7_5_CommaJoin(t *testing.T) {
 	}
 }
 
+func TestAnalyze_7_6_ParenthesizedTableReferenceList(t *testing.T) {
+	c := setupJoinTables(t)
+	sel := parseSelect(t, `SELECT e.name, d.name FROM (employees e, departments d) WHERE e.department_id = d.id`)
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	if len(q.RangeTable) != 3 {
+		t.Fatalf("RangeTable: want 3 entries, got %d", len(q.RangeTable))
+	}
+	if q.RangeTable[0].Kind != RTERelation || q.RangeTable[0].ERef != "e" {
+		t.Errorf("RTE[0]: want RTERelation 'e', got kind=%d eref=%q", q.RangeTable[0].Kind, q.RangeTable[0].ERef)
+	}
+	if q.RangeTable[1].Kind != RTERelation || q.RangeTable[1].ERef != "d" {
+		t.Errorf("RTE[1]: want RTERelation 'd', got kind=%d eref=%q", q.RangeTable[1].Kind, q.RangeTable[1].ERef)
+	}
+	if q.RangeTable[2].Kind != RTEJoin || q.RangeTable[2].JoinType != JoinInner {
+		t.Errorf("RTE[2]: want inner RTEJoin, got kind=%d join_type=%d", q.RangeTable[2].Kind, q.RangeTable[2].JoinType)
+	}
+	if len(q.JoinTree.FromList) != 1 {
+		t.Fatalf("FromList: want 1 entry, got %d", len(q.JoinTree.FromList))
+	}
+	je, ok := q.JoinTree.FromList[0].(*JoinExprNodeQ)
+	if !ok {
+		t.Fatalf("FromList[0]: want *JoinExprNodeQ, got %T", q.JoinTree.FromList[0])
+	}
+	if je.JoinType != JoinInner {
+		t.Errorf("JoinExprNodeQ.JoinType: want JoinInner, got %d", je.JoinType)
+	}
+	if q.JoinTree.Quals == nil {
+		t.Error("JoinTree.Quals: want non-nil WHERE, got nil")
+	}
+}
+
 // --- Batch 8: USING/NATURAL ---
 
 // TestAnalyze_8_1_JoinUsing tests JOIN ... USING (col).

--- a/tidb/catalog/deparse_query_test.go
+++ b/tidb/catalog/deparse_query_test.go
@@ -221,6 +221,7 @@ func TestDeparseQuery_DeparseOutput(t *testing.T) {
 		{"order_by", "SELECT name, salary FROM employees ORDER BY salary DESC"},
 		{"limit", "SELECT name FROM employees LIMIT 10"},
 		{"distinct", "SELECT DISTINCT department_id FROM employees"},
+		{"parenthesized_table_reference_list", "SELECT e.name, d.name FROM (employees e, departments d) WHERE e.department_id = d.id"},
 	}
 
 	for _, tt := range tests {

--- a/tidb/catalog/query_span_test.go
+++ b/tidb/catalog/query_span_test.go
@@ -262,6 +262,24 @@ func TestLineage_14_4_ViewWithJoin(t *testing.T) {
 	})
 }
 
+func TestLineage_14_4b_ParenthesizedTableReferenceList(t *testing.T) {
+	c := wtSetup(t)
+	wtExec(t, c, `
+		CREATE TABLE employees (id INT, name VARCHAR(100), department_id INT);
+		CREATE TABLE departments (id INT, name VARCHAR(100));
+	`)
+
+	sel := parseSelect(t, `SELECT e.name AS employee_name, d.name AS department_name FROM (employees e, departments d) WHERE e.department_id = d.id`)
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	lineage := collectColumnLineage(c, q)
+	assertLineage(t, lineage, []resultLineage{
+		{Name: "employee_name", SourceCols: []columnLineage{{DB: "testdb", Table: "employees", Column: "name"}}},
+		{Name: "department_name", SourceCols: []columnLineage{{DB: "testdb", Table: "departments", Column: "name"}}},
+	})
+}
+
 // TestLineage_14_5_TemptableView tests that TEMPTABLE views remain opaque.
 func TestLineage_14_5_TemptableView(t *testing.T) {
 	c := wtSetup(t)

--- a/tidb/completion/SCENARIOS-completion.md
+++ b/tidb/completion/SCENARIOS-completion.md
@@ -371,7 +371,7 @@ so that Phase 3+ instrumentation can be tested end-to-end.
 [x] `GRANT SELECT ON |` → table_ref (or database.*)
 [x] `GRANT SELECT ON t TO |` → user context
 [x] `REVOKE SELECT ON |` → table_ref
-[x] `EXPLAIN |` → keyword candidates (SELECT, INSERT, UPDATE, DELETE, FORMAT)
+[x] `EXPLAIN |` → keyword candidates (ANALYZE, FORMAT, FOR, SELECT, TABLE, INSERT, UPDATE, DELETE, REPLACE, VALUES)
 [x] `EXPLAIN SELECT |` → same as SELECT instrumentation
 [x] `PREPARE stmt FROM |` → string context
 [x] `EXECUTE |` → prepared statement name

--- a/tidb/completion/refs_test.go
+++ b/tidb/completion/refs_test.go
@@ -11,10 +11,10 @@ func TestExtractTableRefs(t *testing.T) {
 		name       string
 		sql        string
 		offset     int
-		wantTables []string            // expected table names
-		wantAlias  map[string]string    // table -> alias (optional)
-		wantDB     map[string]string    // table -> database (optional)
-		wantAbsent []string            // tables that should NOT appear
+		wantTables []string          // expected table names
+		wantAlias  map[string]string // table -> alias (optional)
+		wantDB     map[string]string // table -> database (optional)
+		wantAbsent []string          // tables that should NOT appear
 	}{
 		{
 			name:       "simple_select",
@@ -33,6 +33,12 @@ func TestExtractTableRefs(t *testing.T) {
 			name:       "join",
 			sql:        "SELECT * FROM t1 JOIN t2 ON t1.a = t2.a WHERE ",
 			offset:     46,
+			wantTables: []string{"t1", "t2"},
+		},
+		{
+			name:       "parenthesized_table_reference_list",
+			sql:        "SELECT * FROM (t1, t2) WHERE ",
+			offset:     29,
 			wantTables: []string{"t1", "t2"},
 		},
 		{

--- a/tidb/deparse/deparse_test.go
+++ b/tidb/deparse/deparse_test.go
@@ -210,7 +210,7 @@ func TestDeparse_Section_2_2_ComparisonOperators(t *testing.T) {
 		// Basic comparison operators
 		{"equal", "a = b", "(`a` = `b`)"},
 		{"not_equal_angle", "a <> b", "(`a` <> `b`)"},
-		{"not_equal_bang", "a != b", "(`a` <> `b`)"},          // != normalized to <>
+		{"not_equal_bang", "a != b", "(`a` <> `b`)"}, // != normalized to <>
 		{"greater", "a > b", "(`a` > `b`)"},
 		{"less", "a < b", "(`a` < `b`)"},
 		{"greater_or_equal", "a >= b", "(`a` >= `b`)"},
@@ -956,8 +956,12 @@ func TestDeparseSelect_Section_5_2_FromClause(t *testing.T) {
 		{"table_alias_without_as", "SELECT a FROM t t1", "select `a` AS `a` from `t` `t1`"},
 		// Multiple tables (implicit cross join) → explicit join with parens
 		{"implicit_cross_join", "SELECT a FROM t1, t2", "select `a` AS `a` from (`t1` join `t2`)"},
+		// Parenthesized table reference list follows MySQL's nested-join semantics.
+		{"parenthesized_table_reference_list", "SELECT a FROM (t1, t2)", "select `a` AS `a` from (`t1` join `t2`)"},
 		// Three tables implicit cross join
 		{"implicit_cross_join_3", "SELECT a FROM t1, t2, t3", "select `a` AS `a` from ((`t1` join `t2`) join `t3`)"},
+		// Three-table parenthesized list folds left like the existing join tree.
+		{"parenthesized_table_reference_list_3", "SELECT a FROM (t1, t2, t3)", "select `a` AS `a` from ((`t1` join `t2`) join `t3`)"},
 	}
 
 	for _, tc := range cases {

--- a/tidb/parser/compare_test.go
+++ b/tidb/parser/compare_test.go
@@ -1215,6 +1215,51 @@ func TestParseSelectJoin(t *testing.T) {
 	}
 }
 
+func TestParseParenthesizedTableReferenceList(t *testing.T) {
+	t.Run("two tables fold to inner join", func(t *testing.T) {
+		sel := parseSelect(t, "SELECT * FROM (t1, t2)")
+		if len(sel.From) != 1 {
+			t.Fatalf("from count = %d, want 1", len(sel.From))
+		}
+		jc, ok := sel.From[0].(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("expected *ast.JoinClause, got %T", sel.From[0])
+		}
+		if jc.Type != ast.JoinInner {
+			t.Fatalf("join type = %d, want JoinInner", jc.Type)
+		}
+		left, ok := jc.Left.(*ast.TableRef)
+		if !ok || left.Name != "t1" {
+			t.Fatalf("left = %#v, want table t1", jc.Left)
+		}
+		right, ok := jc.Right.(*ast.TableRef)
+		if !ok || right.Name != "t2" {
+			t.Fatalf("right = %#v, want table t2", jc.Right)
+		}
+	})
+
+	t.Run("list can be right side of outer join", func(t *testing.T) {
+		sel := parseSelect(t, "SELECT * FROM t0 LEFT JOIN (t1, t2) ON t0.id = t1.id")
+		if len(sel.From) != 1 {
+			t.Fatalf("from count = %d, want 1", len(sel.From))
+		}
+		outer, ok := sel.From[0].(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("expected outer *ast.JoinClause, got %T", sel.From[0])
+		}
+		if outer.Type != ast.JoinLeft {
+			t.Fatalf("outer join type = %d, want JoinLeft", outer.Type)
+		}
+		inner, ok := outer.Right.(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("outer right = %T, want *ast.JoinClause", outer.Right)
+		}
+		if inner.Type != ast.JoinInner {
+			t.Fatalf("inner join type = %d, want JoinInner", inner.Type)
+		}
+	})
+}
+
 // TestParseSelectGroupBy tests SELECT with GROUP BY clause.
 func TestParseSelectGroupBy(t *testing.T) {
 	sel := parseSelect(t, "SELECT dept, COUNT(*) FROM emp GROUP BY dept HAVING COUNT(*) > 1")
@@ -4846,6 +4891,25 @@ func TestParseExplain(t *testing.T) {
 		}
 		if _, ok := stmt.Stmt.(*ast.SelectStmt); !ok {
 			t.Errorf("Stmt type = %T, want *ast.SelectStmt", stmt.Stmt)
+		}
+	})
+
+	t.Run("explain analyze values", func(t *testing.T) {
+		p := &Parser{lexer: NewLexer("EXPLAIN ANALYZE VALUES ROW(1, 2)")}
+		p.advance()
+		stmt, err := p.parseExplainStmt()
+		if err != nil {
+			t.Fatalf("parseExplainStmt error: %v", err)
+		}
+		if !stmt.Analyze {
+			t.Error("Analyze = false, want true")
+		}
+		values, ok := stmt.Stmt.(*ast.ValuesStmt)
+		if !ok {
+			t.Fatalf("Stmt type = %T, want *ast.ValuesStmt", stmt.Stmt)
+		}
+		if len(values.Rows) != 1 || len(values.Rows[0]) != 2 {
+			t.Fatalf("VALUES rows shape = %#v, want one ROW with two expressions", values.Rows)
 		}
 	})
 

--- a/tidb/parser/complete_test.go
+++ b/tidb/parser/complete_test.go
@@ -249,6 +249,21 @@ func TestCollectReplaceInto(t *testing.T) {
 	}
 }
 
+func TestCollectExplainKeywords(t *testing.T) {
+	cs := Collect("EXPLAIN ", 8)
+	if cs == nil {
+		t.Fatal("expected non-nil candidates")
+	}
+	for _, tok := range []int{
+		kwANALYZE, kwEXTENDED, kwPARTITIONS, kwFORMAT, kwFOR,
+		kwSELECT, kwTABLE, kwINSERT, kwUPDATE, kwDELETE, kwREPLACE, kwVALUES,
+	} {
+		if !cs.HasToken(tok) {
+			t.Errorf("missing EXPLAIN keyword: %s", TokenName(tok))
+		}
+	}
+}
+
 // --- UPDATE positions ---
 
 func TestCollectUpdateTable(t *testing.T) {

--- a/tidb/parser/select.go
+++ b/tidb/parser/select.go
@@ -877,6 +877,22 @@ func (p *Parser) parseTableReferenceList() ([]nodes.TableExpr, error) {
 	return refs, nil
 }
 
+func foldTableReferenceList(refs []nodes.TableExpr, end int) nodes.TableExpr {
+	if len(refs) == 0 {
+		return nil
+	}
+	left := refs[0]
+	for i := 1; i < len(refs); i++ {
+		left = &nodes.JoinClause{
+			Loc:   nodes.Loc{Start: tableExprLoc(left), End: end},
+			Type:  nodes.JoinInner,
+			Left:  left,
+			Right: refs[i],
+		}
+	}
+	return left
+}
+
 // parseTableReference parses a table reference (table_factor with optional joins).
 func (p *Parser) parseTableReference() (nodes.TableExpr, error) {
 	left, err := p.parseTableFactor()
@@ -1160,15 +1176,15 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 			return sub, nil
 		}
 
-		// Parenthesized table reference
-		ref, err := p.parseTableReference()
+		// Parenthesized table references use MySQL nested-join semantics.
+		refs, err := p.parseTableReferenceList()
 		if err != nil {
 			return nil, err
 		}
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
-		return ref, nil
+		return foldTableReferenceList(refs, p.pos()), nil
 	}
 
 	// JSON_TABLE(expr, path COLUMNS (...)) AS alias
@@ -1904,6 +1920,8 @@ func tableExprLoc(te nodes.TableExpr) int {
 	case *nodes.JoinClause:
 		return t.Loc.Start
 	case *nodes.SubqueryExpr:
+		return t.Loc.Start
+	case *nodes.JsonTableExpr:
 		return t.Loc.Start
 	}
 	return 0

--- a/tidb/parser/set_show.go
+++ b/tidb/parser/set_show.go
@@ -1489,10 +1489,10 @@ func (p *Parser) parseUseStmt() (*nodes.UseStmt, error) {
 //
 //	{EXPLAIN | DESCRIBE | DESC} tbl_name [col_name | wild]
 //	{EXPLAIN | DESCRIBE | DESC} [explain_type] {explainable_stmt | FOR CONNECTION connection_id}
-//	{EXPLAIN | DESCRIBE | DESC} ANALYZE [explain_type] select_stmt
+//	{EXPLAIN | DESCRIBE | DESC} ANALYZE [explain_type] explainable_stmt
 //	explain_type: { FORMAT = format_name }
 //	format_name: { TRADITIONAL | JSON | TREE }
-//	explainable_stmt: { SELECT | TABLE | DELETE | INSERT | REPLACE | UPDATE }
+//	explainable_stmt: { SELECT | TABLE | VALUES | DELETE | INSERT | REPLACE | UPDATE }
 func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 	start := p.pos()
 	isDescribe := p.cur.Type == kwDESCRIBE || p.cur.Type == kwDESC
@@ -1587,7 +1587,10 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 	// Completion: after EXPLAIN [options], offer explainable statement keywords.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwSELECT, kwINSERT, kwUPDATE, kwDELETE} {
+		for _, t := range []int{
+			kwANALYZE, kwEXTENDED, kwPARTITIONS, kwFORMAT, kwFOR,
+			kwSELECT, kwTABLE, kwINSERT, kwUPDATE, kwDELETE, kwREPLACE, kwVALUES,
+		} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -1631,6 +1634,12 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 			return nil, err
 		}
 		stmt.Stmt = tbl
+	case kwVALUES:
+		vals, err := p.parseValuesStmt()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Stmt = vals
 	default:
 		// For other tokens, try to parse as a table ref (EXPLAIN table_name)
 		ref, err := p.parseTableRef()


### PR DESCRIPTION
## Summary
- Support `EXPLAIN ANALYZE VALUES ROW(...)` in MySQL/TiDB parsers by routing `VALUES` through the existing `ValuesStmt` path.
- Support parenthesized table reference lists such as `FROM (t1, t2)` by folding them into existing inner join AST nodes.
- Add parser, deparse, catalog/query-span, and completion coverage for both MySQL and TiDB; update EXPLAIN completion candidates.

## Test Plan
- `go test ./mysql/parser ./mysql/deparse ./mysql/completion ./tidb/parser ./tidb/deparse ./tidb/completion -count=1`
- `go test ./mysql/catalog ./tidb/catalog -run 'TestAnalyze_7_6_ParenthesizedTableReferenceList|TestLineage_14_4b_ParenthesizedTableReferenceList|TestDeparseQuery_DeparseOutput' -count=1`\n- Compared `go test ./mysql/catalog ./tidb/catalog -skip 'Container|container' -count=1 -json` against clean HEAD baseline: no new failures in current branch.