### PR TITLE
fix(mssql): improve completion collection gaps

### DIFF
--- a/mssql/parser/complete.go
+++ b/mssql/parser/complete.go
@@ -323,6 +323,11 @@ func (p *Parser) addRuleCandidate(r string) {
 	}
 }
 
+func (p *Parser) addExpressionCandidates() {
+	p.addRuleCandidate("columnref")
+	p.addRuleCandidate("func_name")
+}
+
 // addCTEPosition records a WITH clause byte offset in the candidate set.
 func (p *Parser) addCTEPosition(pos int) {
 	if p.candidates != nil {

--- a/mssql/parser/complete_bytebase_test.go
+++ b/mssql/parser/complete_bytebase_test.go
@@ -94,7 +94,12 @@ func TestCompletionBytebaseColumnReferenceSignals(t *testing.T) {
 		"SELECT Id FROM Employees HAVING |",
 		"INSERT INTO Employees SELECT | FROM Address",
 		"UPDATE Employees SET |",
+		"UPDATE Employees SET Name = |",
 		"DELETE FROM Employees WHERE |",
+		"SELECT ABS(|) FROM Employees",
+		"SELECT CONCAT(Name, |) FROM Employees",
+		"SELECT * FROM (SELECT Name, Amount FROM Sales) src PIVOT (SUM(Amount) FOR Name IN (|)) AS p",
+		"SELECT * FROM (SELECT Name, Amount FROM Sales) src UNPIVOT (Amount FOR Name IN (|)) AS u",
 	}
 
 	for _, input := range tests {
@@ -103,6 +108,53 @@ func TestCompletionBytebaseColumnReferenceSignals(t *testing.T) {
 			requireRule(t, candidates, "columnref")
 		})
 	}
+}
+
+func TestCompletionBytebaseSequenceReferenceSignals(t *testing.T) {
+	tests := []string{
+		"SELECT NEXT VALUE FOR |",
+		"INSERT INTO Orders(Id) VALUES (NEXT VALUE FOR |)",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "sequence_ref")
+		})
+	}
+}
+
+func TestCompletionBytebaseProcedureReferenceSignals(t *testing.T) {
+	tests := []string{
+		"EXEC |",
+		"EXECUTE |",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "proc_ref")
+		})
+	}
+}
+
+func TestCompletionBytebaseOpenJSONWithTypeSignals(t *testing.T) {
+	tests := []string{
+		"SELECT * FROM OPENJSON(@json) WITH (Name |)",
+		"SELECT * FROM OPENJSON(@json) WITH (Name nvarchar(100), Age |)",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "type_name")
+		})
+	}
+}
+
+func TestCompletionBytebaseIncompleteBracketIdentifierSignals(t *testing.T) {
+	_, _, candidates := collectMarked(t, "SELECT * FROM [|")
+	requireRule(t, candidates, "table_ref")
 }
 
 func TestCompletionBytebaseAsteriskQualifierSignals(t *testing.T) {

--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -700,6 +700,11 @@ func (p *Parser) parsePrimary() (nodes.ExprNode, error) {
 			return p.parseIif()
 		}
 		return p.parseIdentExpr()
+	case kwNEXT:
+		if p.peekNext().Type == kwVALUE {
+			return p.parseNextValueFor()
+		}
+		return p.parseIdentExpr()
 	case kwEXISTS:
 		return p.parseExists()
 	case kwTRY_CAST:
@@ -1158,6 +1163,36 @@ func (p *Parser) parseExists() (nodes.ExprNode, error) {
 	}, nil
 }
 
+func (p *Parser) parseNextValueFor() (nodes.ExprNode, error) {
+	loc := p.pos()
+	p.advance() // consume NEXT
+	if _, err := p.expect(kwVALUE); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFOR); err != nil {
+		return nil, err
+	}
+	if p.collectMode() {
+		p.addRuleCandidate("sequence_ref")
+		return nil, errCollecting
+	}
+	ref, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	if ref == nil {
+		return nil, p.unexpectedToken()
+	}
+	return &nodes.ColumnRef{
+		Server:   ref.Server,
+		Database: ref.Database,
+		Schema:   ref.Schema,
+		Table:    ref.Schema,
+		Column:   ref.Object,
+		Loc:      nodes.Loc{Start: loc, End: p.prevEnd()},
+	}, nil
+}
+
 // parseFuncCall parses a function call after the opening paren has been seen.
 //
 //	func_name '(' [DISTINCT] [expr_list | '*'] ')' [OVER ...]
@@ -1184,6 +1219,11 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 		return fc, nil
 	}
 
+	if p.collectMode() {
+		p.addExpressionCandidates()
+		return nil, errCollecting
+	}
+
 	if p.cur.Type == ')' {
 		p.advance()
 		if p.cur.Type == kwOVER {
@@ -1202,6 +1242,10 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 	}
 
 	args, err := p.parseCommaList(')', commaListAllowEmpty, func() (nodes.Node, error) {
+		if p.collectMode() {
+			p.addExpressionCandidates()
+			return nil, errCollecting
+		}
 		arg, err := p.parseExpr()
 		if err != nil {
 			return nil, err

--- a/mssql/parser/lexer.go
+++ b/mssql/parser/lexer.go
@@ -1586,7 +1586,7 @@ func (l *Lexer) lexBracketedIdent() Token {
 		l.pos++
 	}
 	l.Err = fmt.Errorf("unterminated bracketed identifier")
-	return Token{Type: tokEOF, Loc: l.start}
+	return Token{Type: tokIDENT, Str: buf.String(), Loc: l.start}
 }
 
 func (l *Lexer) lexQuotedIdent() Token {

--- a/mssql/parser/list.go
+++ b/mssql/parser/list.go
@@ -66,6 +66,10 @@ func (p *Parser) parseCommaList(
 	parseItem func() (nodes.Node, error),
 ) ([]nodes.Node, error) {
 	if p.cur.Type == end {
+		if p.collectMode() {
+			_, err := parseItem()
+			return nil, err
+		}
 		if flags&commaListAllowEmpty == 0 {
 			return nil, p.unexpectedToken()
 		}
@@ -94,6 +98,9 @@ func (p *Parser) parseCommaList(
 		// emit completion candidates via errCollecting; it must otherwise
 		// return an error if there is no item to parse.
 		if p.cur.Type == end {
+			if p.collectMode() {
+				continue
+			}
 			if flags&commaListAllowTrail == 0 {
 				return nil, p.unexpectedToken()
 			}

--- a/mssql/parser/name.go
+++ b/mssql/parser/name.go
@@ -70,6 +70,10 @@ func (p *Parser) parseTableRef() (*nodes.TableRef, error) {
 	if !ok {
 		return nil, nil
 	}
+	if p.collectMode() && p.cursorOff <= p.prev.End {
+		p.addRuleCandidate("table_ref")
+		return nil, errCollecting
+	}
 
 	ref := &nodes.TableRef{
 		Object: name,
@@ -415,6 +419,11 @@ func (p *Parser) parseFuncCallWithSchema(schema, funcName string, loc int) (node
 		return fc, nil
 	}
 
+	if p.collectMode() {
+		p.addExpressionCandidates()
+		return nil, errCollecting
+	}
+
 	if p.cur.Type == ')' {
 		p.advance()
 		if p.cur.Type == kwOVER {
@@ -430,10 +439,18 @@ func (p *Parser) parseFuncCallWithSchema(schema, funcName string, loc int) (node
 
 	var args []nodes.Node
 	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		if p.collectMode() {
+			p.addExpressionCandidates()
+			return nil, errCollecting
+		}
 		arg, _ := p.parseExpr()
 		args = append(args, arg)
 		if _, ok := p.match(','); !ok {
 			break
+		}
+		if p.collectMode() {
+			p.addExpressionCandidates()
+			return nil, errCollecting
 		}
 	}
 	fc.Args = &nodes.List{Items: args}

--- a/mssql/parser/rowset_functions.go
+++ b/mssql/parser/rowset_functions.go
@@ -82,6 +82,10 @@ func (p *Parser) parseRowsetWithClause() (*nodes.List, error) {
 		if !ok {
 			return nil, p.unexpectedToken()
 		}
+		if p.collectMode() {
+			p.addRuleCandidate("type_name")
+			return nil, errCollecting
+		}
 		dt, _ := p.parseDataType()
 		col := &nodes.ColumnDef{
 			Name:     colName,

--- a/mssql/parser/select.go
+++ b/mssql/parser/select.go
@@ -1031,6 +1031,10 @@ func (p *Parser) parsePivotExpr(source nodes.TableExpr) (*nodes.PivotExpr, error
 	if _, ok := p.match(kwIN); ok {
 		if _, err := p.expect('('); err == nil {
 			vals, err := p.parseCommaList(')', commaListStrict, func() (nodes.Node, error) {
+				if p.collectMode() {
+					p.addRuleCandidate("columnref")
+					return nil, errCollecting
+				}
 				name, ok := p.parseIdentifier()
 				if !ok {
 					return nil, p.unexpectedToken()
@@ -1095,6 +1099,10 @@ func (p *Parser) parseUnpivotExpr(source nodes.TableExpr) (*nodes.UnpivotExpr, e
 	if _, ok := p.match(kwIN); ok {
 		if _, err := p.expect('('); err == nil {
 			cols, err := p.parseCommaList(')', commaListStrict, func() (nodes.Node, error) {
+				if p.collectMode() {
+					p.addRuleCandidate("columnref")
+					return nil, errCollecting
+				}
 				name, ok := p.parseIdentifier()
 				if !ok {
 					return nil, p.unexpectedToken()

--- a/mssql/parser/update_delete.go
+++ b/mssql/parser/update_delete.go
@@ -426,6 +426,10 @@ func (p *Parser) parseSetClause() (*nodes.SetExpr, error) {
 	} else if _, err := p.expect('='); err != nil {
 		return nil, nil
 	}
+	if p.collectMode() {
+		p.addExpressionCandidates()
+		return nil, errCollecting
+	}
 
 	val, err := p.parseExpr()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add Bytebase-facing regression tests for MSSQL completion gaps.
- Emit columnref/type_name/sequence_ref candidates in missing parser collection contexts.
- Treat unterminated bracket identifiers as identifier tokens for completion recovery.

## Test Plan
- go test -count=1 ./mssql/...
- git diff --check