### PR TITLE
fix(mssql): refine completion object rules

### DIFF
--- a/mssql/parser/complete.go
+++ b/mssql/parser/complete.go
@@ -304,7 +304,8 @@ func (p *Parser) collectMode() bool {
 // checkCursor checks whether the current token is at or past the cursor
 // offset, and if so, enables collection mode.
 func (p *Parser) checkCursor() {
-	if p.cur.Loc >= p.cursorOff {
+	if p.cur.Loc >= p.cursorOff ||
+		(IsIdentTokenType(p.cur.Type) && p.cur.Loc < p.cursorOff && p.cursorOff <= p.cur.End) {
 		p.collecting = true
 	}
 }

--- a/mssql/parser/complete_bytebase_test.go
+++ b/mssql/parser/complete_bytebase_test.go
@@ -153,8 +153,19 @@ func TestCompletionBytebaseOpenJSONWithTypeSignals(t *testing.T) {
 }
 
 func TestCompletionBytebaseIncompleteBracketIdentifierSignals(t *testing.T) {
-	_, _, candidates := collectMarked(t, "SELECT * FROM [|")
-	requireRule(t, candidates, "table_ref")
+	tests := []string{
+		"SELECT * FROM [|",
+		"SELECT * FROM dbo.[|",
+		"SELECT * FROM \"|",
+		"SELECT * FROM dbo.\"|",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "table_ref")
+		})
+	}
 }
 
 func TestCompletionBytebaseAsteriskQualifierSignals(t *testing.T) {
@@ -219,6 +230,66 @@ func TestCompletionIncompleteSQLSignals(t *testing.T) {
 			}
 			if tt.token != 0 {
 				requireToken(t, candidates, tt.token)
+			}
+		})
+	}
+}
+
+func TestCompletionBytebaseForeignKeyColumnListSignals(t *testing.T) {
+	tests := []string{
+		"CREATE TABLE NewTable (EmployeeId INT, FOREIGN KEY (|) REFERENCES Employees(Id))",
+		"CREATE TABLE NewTable (EmployeeId INT REFERENCES Employees(|))",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "columnref")
+		})
+	}
+}
+
+func TestCompletionBytebaseNextValueForSequenceSignals(t *testing.T) {
+	tests := []string{
+		"SELECT NEXT VALUE FOR |",
+		"SELECT NEXT VALUE FOR dbo.|",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, input)
+			requireRule(t, candidates, "sequence_ref")
+			if candidates.HasRule("table_ref") {
+				t.Fatalf("NEXT VALUE FOR should not emit table_ref; got rules=%v tokens=%v", candidates.Rules, tokenNames(candidates.Tokens))
+			}
+		})
+	}
+}
+
+func TestCompletionBytebaseSchemaQualifiedObjectRefSignals(t *testing.T) {
+	tests := []struct {
+		input string
+		rule  string
+	}{
+		{input: "EXEC dbo.|", rule: "proc_ref"},
+		{input: "EXECUTE dbo.|", rule: "proc_ref"},
+		{input: "ALTER PROCEDURE dbo.|", rule: "proc_ref"},
+		{input: "ALTER FUNCTION dbo.|", rule: "func_name"},
+		{input: "ALTER SEQUENCE |", rule: "sequence_ref"},
+		{input: "ALTER SEQUENCE dbo.|", rule: "sequence_ref"},
+		{input: "DROP PROCEDURE dbo.|", rule: "proc_ref"},
+		{input: "DROP FUNCTION dbo.|", rule: "func_name"},
+		{input: "DROP SEQUENCE |", rule: "sequence_ref"},
+		{input: "DROP SEQUENCE dbo.|", rule: "sequence_ref"},
+		{input: "DROP TRIGGER dbo.|", rule: "trigger_ref"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, _, candidates := collectMarked(t, tt.input)
+			requireRule(t, candidates, tt.rule)
+			if candidates.HasRule("table_ref") {
+				t.Fatalf("%s should not emit table_ref; got rules=%v tokens=%v", tt.input, candidates.Rules, tokenNames(candidates.Tokens))
 			}
 		})
 	}

--- a/mssql/parser/create_proc.go
+++ b/mssql/parser/create_proc.go
@@ -57,7 +57,11 @@ func (p *Parser) parseCreateProcedureStmt(orAlter bool) (*nodes.CreateProcedureS
 	}
 
 	// Procedure name
-	name, err := p.parseTableRef()
+	nameRule := "identifier"
+	if orAlter {
+		nameRule = "proc_ref"
+	}
+	name, err := p.parseObjectRef(nameRule)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +278,11 @@ func (p *Parser) parseCreateFunctionStmt(orAlter bool) (*nodes.CreateFunctionStm
 	}
 
 	// Function name
-	name, err := p.parseTableRef()
+	nameRule := "identifier"
+	if orAlter {
+		nameRule = "func_name"
+	}
+	name, err := p.parseObjectRef(nameRule)
 	if err != nil {
 		return nil, err
 	}

--- a/mssql/parser/create_sequence.go
+++ b/mssql/parser/create_sequence.go
@@ -51,8 +51,12 @@ func (p *Parser) parseCreateSequenceStmt() (*nodes.CreateSequenceStmt, error) {
 //	    [ { CACHE [ <constant> ] } | { NO CACHE } ]
 func (p *Parser) parseAlterSequenceStmt() (*nodes.AlterSequenceStmt, error) {
 	stmt := &nodes.AlterSequenceStmt{}
+	if p.collectMode() {
+		p.addRuleCandidate("sequence_ref")
+		return nil, errCollecting
+	}
 	var err error
-	stmt.Name, err = p.parseTableRef()
+	stmt.Name, err = p.parseSequenceRef()
 	if err != nil {
 		return nil, err
 	}

--- a/mssql/parser/create_table.go
+++ b/mssql/parser/create_table.go
@@ -236,7 +236,7 @@ func (p *Parser) parseCreateTableStmt() (*nodes.CreateTableStmt, error) {
 	// TEXTIMAGE_ON filegroup
 	if p.cur.Type == kwTEXTIMAGE_ON {
 		p.advance()
-		if (p.isIdentLike() || p.cur.Type == kwPRIMARY) {
+		if p.isIdentLike() || p.cur.Type == kwPRIMARY {
 			stmt.TextImageOn = p.cur.Str
 			p.advance()
 		}
@@ -245,7 +245,7 @@ func (p *Parser) parseCreateTableStmt() (*nodes.CreateTableStmt, error) {
 	// FILESTREAM_ON filegroup
 	if p.cur.Type == kwFILESTREAM_ON {
 		p.advance()
-		if (p.isIdentLike() || p.cur.Type == kwPRIMARY) {
+		if p.isIdentLike() || p.cur.Type == kwPRIMARY {
 			stmt.FilestreamOn = p.cur.Str
 			p.advance()
 		}
@@ -1486,7 +1486,7 @@ trailingOptions:
 	// [ FILESTREAM_ON { ... } ]
 	if p.cur.Type == kwFILESTREAM_ON {
 		p.advance()
-		if (p.isIdentLike() || p.cur.Type == kwPRIMARY) {
+		if p.isIdentLike() || p.cur.Type == kwPRIMARY {
 			idx.FilestreamOn = p.cur.Str
 			p.advance()
 		}
@@ -1859,7 +1859,15 @@ func (p *Parser) parseCTASOption() (*nodes.TableOption, error) {
 // parseParenIdentList parses (ident, ident, ...).
 func (p *Parser) parseParenIdentList() (*nodes.List, error) {
 	p.advance() // consume (
+	if p.collectMode() {
+		p.addRuleCandidate("columnref")
+		return nil, errCollecting
+	}
 	items, err := p.parseCommaList(')', commaListStrict, func() (nodes.Node, error) {
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			return nil, errCollecting
+		}
 		name, ok := p.parseIdentifier()
 		if !ok {
 			return nil, p.unexpectedToken()

--- a/mssql/parser/drop.go
+++ b/mssql/parser/drop.go
@@ -190,14 +190,19 @@ func (p *Parser) parseDropStmt() (*nodes.DropStmt, error) {
 			p.addRuleCandidate("view_name")
 		case nodes.DropIndex:
 			p.addRuleCandidate("index_name")
+			p.addRuleCandidate("index_ref")
 		case nodes.DropProcedure:
 			p.addRuleCandidate("proc_name")
+			p.addRuleCandidate("proc_ref")
 		case nodes.DropFunction:
 			p.addRuleCandidate("func_name")
 		case nodes.DropDatabase:
 			p.addRuleCandidate("database_ref")
 		case nodes.DropTrigger:
 			p.addRuleCandidate("trigger_name")
+			p.addRuleCandidate("trigger_ref")
+		case nodes.DropSequence:
+			p.addRuleCandidate("sequence_ref")
 		default:
 			p.addRuleCandidate("identifier")
 		}
@@ -220,7 +225,7 @@ func (p *Parser) parseDropStmt() (*nodes.DropStmt, error) {
 		}
 	} else {
 		for {
-			name, _ := p.parseTableRef()
+			name, _ := p.parseObjectRef(dropObjectCompletionRule(stmt.ObjectType))
 			if name == nil {
 				break
 			}
@@ -293,4 +298,27 @@ func (p *Parser) parseDropStmt() (*nodes.DropStmt, error) {
 
 	stmt.Loc.End = p.prevEnd()
 	return stmt, nil
+}
+
+func dropObjectCompletionRule(objectType nodes.DropObjectType) string {
+	switch objectType {
+	case nodes.DropTable:
+		return "table_ref"
+	case nodes.DropView, nodes.DropMaterializedView:
+		return "view_name"
+	case nodes.DropIndex:
+		return "index_ref"
+	case nodes.DropProcedure:
+		return "proc_ref"
+	case nodes.DropFunction:
+		return "func_name"
+	case nodes.DropDatabase:
+		return "database_ref"
+	case nodes.DropTrigger:
+		return "trigger_ref"
+	case nodes.DropSequence:
+		return "sequence_ref"
+	default:
+		return "identifier"
+	}
 }

--- a/mssql/parser/execute.go
+++ b/mssql/parser/execute.go
@@ -104,7 +104,7 @@ func (p *Parser) parseExecStmt() (*nodes.ExecStmt, error) {
 	}
 
 	// Procedure name
-	name, err := p.parseTableRef()
+	name, err := p.parseObjectRef("proc_ref")
 	if err != nil {
 		return nil, err
 	}

--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -1176,7 +1176,7 @@ func (p *Parser) parseNextValueFor() (nodes.ExprNode, error) {
 		p.addRuleCandidate("sequence_ref")
 		return nil, errCollecting
 	}
-	ref, err := p.parseTableRef()
+	ref, err := p.parseSequenceRef()
 	if err != nil {
 		return nil, err
 	}

--- a/mssql/parser/lexer.go
+++ b/mssql/parser/lexer.go
@@ -1612,7 +1612,7 @@ func (l *Lexer) lexQuotedIdent() Token {
 		l.pos++
 	}
 	l.Err = fmt.Errorf("unterminated quoted identifier")
-	return Token{Type: tokEOF, Loc: l.start}
+	return Token{Type: tokIDENT, Str: buf.String(), Loc: l.start}
 }
 
 func (l *Lexer) lexVariable() Token {

--- a/mssql/parser/name.go
+++ b/mssql/parser/name.go
@@ -64,6 +64,12 @@ func (p *Parser) parseIdentifier() (string, bool) {
 //	                 | [ schema_name . ]
 //	                 object_name
 func (p *Parser) parseTableRef() (*nodes.TableRef, error) {
+	return p.parseObjectRef("table_ref")
+}
+
+// parseObjectRef parses a qualified object name and emits completionRule after
+// a dot in that qualified name. Use parseTableRef for normal table contexts.
+func (p *Parser) parseObjectRef(completionRule string) (*nodes.TableRef, error) {
 	loc := p.pos()
 
 	name, ok := p.parseIdentifier()
@@ -84,9 +90,9 @@ func (p *Parser) parseTableRef() (*nodes.TableRef, error) {
 	parts := []string{name}
 	for p.cur.Type == '.' {
 		p.advance() // consume .
-		// Completion: after dot in qualified name → table_ref (schema-qualified)
+		// Completion: after dot in qualified name → caller-specific object rule.
 		if p.collectMode() {
-			p.addRuleCandidate("table_ref")
+			p.addRuleCandidate(completionRule)
 			return nil, errCollecting
 		}
 		part, ok := p.parseIdentifier()
@@ -118,6 +124,13 @@ func (p *Parser) parseTableRef() (*nodes.TableRef, error) {
 
 	ref.Loc.End = p.prevEnd()
 	return ref, nil
+}
+
+// parseSequenceRef parses a qualified sequence name for NEXT VALUE FOR.
+// Shape is the same as other schema object names, but completion must surface
+// sequence_ref rather than the generic table_ref rule.
+func (p *Parser) parseSequenceRef() (*nodes.TableRef, error) {
+	return p.parseObjectRef("sequence_ref")
 }
 
 // parseVariableTableSource parses a T-SQL table variable used as a table source


### PR DESCRIPTION
## Summary
- add MSSQL completion signals for FK column lists and REFERENCES target columns
- emit sequence/procedure/function/trigger-specific rules for schema-qualified object completion
- tolerate incomplete bracketed and quoted identifiers during completion

## Test Plan
- go test ./mssql/... -count=1