### PR TITLE
feat(mssql): expose completion context scope

### DIFF
--- a/mssql/completion.go
+++ b/mssql/completion.go
@@ -1,0 +1,57 @@
+package mssql
+
+import "github.com/bytebase/omni/mssql/parser"
+
+// CompletionContext is the parser-native context for SQL completion.
+type CompletionContext = parser.CompletionContext
+
+// CompletionIntent describes the object class and qualifier implied by the
+// grammar position at the cursor.
+type CompletionIntent = parser.CompletionIntent
+
+// ObjectKind classifies catalog object completion intent.
+type ObjectKind = parser.ObjectKind
+
+// MultipartName is a partially typed MSSQL object name.
+type MultipartName = parser.MultipartName
+
+// ScopeSnapshot describes relation scope visible at a cursor.
+type ScopeSnapshot = parser.ScopeSnapshot
+
+// RangeReference is a syntax-level table expression reference.
+type RangeReference = parser.RangeReference
+
+// RangeReferenceKind classifies a range-table entry visible to completion.
+type RangeReferenceKind = parser.RangeReferenceKind
+
+const (
+	ObjectKindUnknown   = parser.ObjectKindUnknown
+	ObjectKindDatabase  = parser.ObjectKindDatabase
+	ObjectKindSchema    = parser.ObjectKindSchema
+	ObjectKindTable     = parser.ObjectKindTable
+	ObjectKindView      = parser.ObjectKindView
+	ObjectKindSequence  = parser.ObjectKindSequence
+	ObjectKindProcedure = parser.ObjectKindProcedure
+	ObjectKindFunction  = parser.ObjectKindFunction
+	ObjectKindType      = parser.ObjectKindType
+	ObjectKindColumn    = parser.ObjectKindColumn
+)
+
+const (
+	RangeReferenceRelation      = parser.RangeReferenceRelation
+	RangeReferenceSubquery      = parser.RangeReferenceSubquery
+	RangeReferenceFunction      = parser.RangeReferenceFunction
+	RangeReferenceJoinAlias     = parser.RangeReferenceJoinAlias
+	RangeReferenceCTE           = parser.RangeReferenceCTE
+	RangeReferenceValues        = parser.RangeReferenceValues
+	RangeReferenceTableVariable = parser.RangeReferenceTableVariable
+	RangeReferenceDMLTarget     = parser.RangeReferenceDMLTarget
+	RangeReferenceMergeTarget   = parser.RangeReferenceMergeTarget
+	RangeReferenceMergeSource   = parser.RangeReferenceMergeSource
+)
+
+// CollectCompletion returns completion candidates plus a best-effort visible
+// relation scope at cursorOffset. Ordinary Parse remains strict.
+func CollectCompletion(sql string, cursorOffset int) *CompletionContext {
+	return parser.CollectCompletion(sql, cursorOffset)
+}

--- a/mssql/completion/refs.go
+++ b/mssql/completion/refs.go
@@ -9,9 +9,11 @@ import (
 
 // TableRef is a table reference found in a FROM clause or DML target.
 type TableRef struct {
-	Schema string
-	Table  string
-	Alias  string
+	Server   string
+	Database string
+	Schema   string
+	Table    string
+	Alias    string
 }
 
 // extractTableRefs parses the SQL and returns table references visible at cursor.
@@ -26,6 +28,10 @@ func extractTableRefs(sql string, cursorOffset int) (refs []TableRef) {
 }
 
 func extractTableRefsInner(sql string, cursorOffset int) []TableRef {
+	if refs := extractTableRefsFromCompletionScope(sql, cursorOffset); len(refs) > 0 {
+		return refs
+	}
+
 	list, err := parser.Parse(sql)
 	if err != nil || list == nil || len(list.Items) == 0 {
 		// Fallback: try appending a placeholder to make incomplete SQL parseable.
@@ -49,6 +55,31 @@ func extractTableRefsInner(sql string, cursorOffset int) []TableRef {
 	}
 	if len(refs) == 0 {
 		return extractTableRefsLexer(sql, cursorOffset)
+	}
+	return refs
+}
+
+func extractTableRefsFromCompletionScope(sql string, cursorOffset int) []TableRef {
+	ctx := parser.CollectCompletion(sql, cursorOffset)
+	if ctx == nil || ctx.Scope == nil {
+		return nil
+	}
+	var refs []TableRef
+	for _, ref := range ctx.Scope.LocalReferences {
+		table := ref.Object
+		if table == "" {
+			table = ref.Alias
+		}
+		if table == "" {
+			continue
+		}
+		refs = append(refs, TableRef{
+			Server:   ref.Server,
+			Database: ref.Database,
+			Schema:   ref.Schema,
+			Table:    table,
+			Alias:    ref.Alias,
+		})
 	}
 	return refs
 }
@@ -219,9 +250,11 @@ func collectFromWithClause(w *ast.WithClause) []TableRef {
 // astTableRefToRef converts an ast.TableRef to a completion TableRef.
 func astTableRefToRef(r *ast.TableRef) TableRef {
 	return TableRef{
-		Schema: r.Schema,
-		Table:  r.Object,
-		Alias:  r.Alias,
+		Server:   r.Server,
+		Database: r.Database,
+		Schema:   r.Schema,
+		Table:    r.Object,
+		Alias:    r.Alias,
 	}
 }
 

--- a/mssql/completion/refs_test.go
+++ b/mssql/completion/refs_test.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -102,6 +103,21 @@ func TestExtractTableRefs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestExtractTableRefsUsesCompletionScopeCurrentSetOperationArm(t *testing.T) {
+	sql := "SELECT Id FROM Employees UNION SELECT EmployeeId FROM Address UNION SELECT  FROM MySchema.SalaryLevel"
+	cursor := strings.Index(sql, " FROM MySchema.SalaryLevel")
+	got := extractTableRefs(sql, cursor)
+	want := []TableRef{{Schema: "MySchema", Table: "SalaryLevel"}}
+	if len(got) != len(want) {
+		t.Fatalf("extractTableRefs(%q): got %d refs, want %d\n  got:  %+v\n  want: %+v", sql, len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].Schema != want[i].Schema || got[i].Table != want[i].Table || got[i].Alias != want[i].Alias {
+			t.Fatalf("extractTableRefs(%q)[%d] = %+v, want %+v", sql, i, got[i], want[i])
+		}
 	}
 }
 

--- a/mssql/completion_context_test.go
+++ b/mssql/completion_context_test.go
@@ -1,0 +1,17 @@
+package mssql
+
+import "testing"
+
+func TestCollectCompletionWrapper(t *testing.T) {
+	sql := "SELECT v. FROM (VALUES (1, 'a')) AS v(Id, Label)"
+	ctx := CollectCompletion(sql, len("SELECT v."))
+	if ctx == nil || ctx.Candidates == nil || ctx.Scope == nil {
+		t.Fatal("expected completion context")
+	}
+	if len(ctx.Scope.LocalReferences) != 1 {
+		t.Fatalf("local reference count = %d, want 1", len(ctx.Scope.LocalReferences))
+	}
+	if ctx.Scope.LocalReferences[0].Kind != RangeReferenceValues {
+		t.Fatalf("reference kind = %v, want values", ctx.Scope.LocalReferences[0].Kind)
+	}
+}

--- a/mssql/parser/complete_bytebase_test.go
+++ b/mssql/parser/complete_bytebase_test.go
@@ -88,10 +88,16 @@ func TestCompletionBytebaseColumnReferenceSignals(t *testing.T) {
 		"SELECT tableAlias.| FROM Employees AS tableAlias",
 		"WITH MyCTE_01 AS (SELECT * FROM dbo.Employees) SELECT MyCTE_01.| FROM MyCTE_01",
 		"SELECT * FROM Employees e JOIN Address a ON |",
+		"SELECT * FROM Employees e LEFT JOIN MySchema.SalaryLevel s ON s.|",
 		"SELECT Id AS IdAlias, Name FROM Employees ORDER BY |",
 		"SELECT Id, Name FROM Employees WHERE |",
+		"SELECT * FROM Employees WHERE Id IN (1, |)",
+		"SELECT * FROM Employees WHERE NOT |",
+		"SELECT * FROM Employees WHERE Id + | > 0",
 		"SELECT Id FROM Employees GROUP BY |",
 		"SELECT Id FROM Employees HAVING |",
+		"SELECT COALESCE(NULL, |) FROM Employees",
+		"SELECT CONVERT(INT, |) FROM Employees",
 		"INSERT INTO Employees SELECT | FROM Address",
 		"UPDATE Employees SET |",
 		"UPDATE Employees SET Name = |",
@@ -142,6 +148,7 @@ func TestCompletionBytebaseOpenJSONWithTypeSignals(t *testing.T) {
 	tests := []string{
 		"SELECT * FROM OPENJSON(@json) WITH (Name |)",
 		"SELECT * FROM OPENJSON(@json) WITH (Name nvarchar(100), Age |)",
+		"CREATE PROCEDURE p @Name | AS SELECT 1",
 	}
 
 	for _, input := range tests {
@@ -209,6 +216,8 @@ func TestCompletionIncompleteSQLSignals(t *testing.T) {
 		{input: "SELECT Id FROM Employees ORDER BY |", rule: "columnref"},
 		{input: "WITH cte AS (|", token: parser.SELECT},
 		{input: "WITH cte AS (SELECT Id FROM dbo.Employees) SELECT * FROM|", rule: "table_ref"},
+		{input: "ALTER TABLE Employees ADD CONSTRAINT fk FOREIGN KEY (Id) REFERENCES |", rule: "table_ref"},
+		{input: "DROP VIEW MySchema.|", rule: "table_ref"},
 	}
 
 	for _, tt := range tests {

--- a/mssql/parser/complete_bytebase_test.go
+++ b/mssql/parser/complete_bytebase_test.go
@@ -42,6 +42,16 @@ func requireRule(t *testing.T, candidates *parser.CandidateSet, rule string) {
 	}
 }
 
+func requireAnyRule(t *testing.T, candidates *parser.CandidateSet, rules ...string) {
+	t.Helper()
+	for _, rule := range rules {
+		if candidates.HasRule(rule) {
+			return
+		}
+	}
+	t.Fatalf("missing any rule %v; got rules=%v tokens=%v", rules, candidates.Rules, tokenNames(candidates.Tokens))
+}
+
 func requireToken(t *testing.T, candidates *parser.CandidateSet, token int) {
 	t.Helper()
 	if !candidates.HasToken(token) {
@@ -200,9 +210,10 @@ func TestCompletionBytebasePrefixRetrySignals(t *testing.T) {
 
 func TestCompletionIncompleteSQLSignals(t *testing.T) {
 	tests := []struct {
-		input string
-		rule  string
-		token int
+		input    string
+		rule     string
+		anyRules []string
+		token    int
 	}{
 		{input: "SELECT * FROM|", rule: "table_ref"},
 		{input: "SELECT * FROM |", rule: "table_ref"},
@@ -217,7 +228,7 @@ func TestCompletionIncompleteSQLSignals(t *testing.T) {
 		{input: "WITH cte AS (|", token: parser.SELECT},
 		{input: "WITH cte AS (SELECT Id FROM dbo.Employees) SELECT * FROM|", rule: "table_ref"},
 		{input: "ALTER TABLE Employees ADD CONSTRAINT fk FOREIGN KEY (Id) REFERENCES |", rule: "table_ref"},
-		{input: "DROP VIEW MySchema.|", rule: "table_ref"},
+		{input: "DROP VIEW MySchema.|", anyRules: []string{"view_name", "table_ref"}},
 	}
 
 	for _, tt := range tests {
@@ -225,6 +236,9 @@ func TestCompletionIncompleteSQLSignals(t *testing.T) {
 			_, _, candidates := collectMarked(t, tt.input)
 			if tt.rule != "" {
 				requireRule(t, candidates, tt.rule)
+			}
+			if len(tt.anyRules) > 0 {
+				requireAnyRule(t, candidates, tt.anyRules...)
 			}
 			if tt.token != 0 {
 				requireToken(t, candidates, tt.token)

--- a/mssql/parser/complete_context.go
+++ b/mssql/parser/complete_context.go
@@ -1,0 +1,805 @@
+package parser
+
+import nodes "github.com/bytebase/omni/mssql/ast"
+
+// CompletionContext is the parser-native context for SQL completion.
+//
+// Candidates contains grammar candidates at the cursor. Scope is a best-effort
+// snapshot of range references visible to expression completion at the cursor.
+// This is completion-only state; ordinary Parse remains strict.
+type CompletionContext struct {
+	Candidates *CandidateSet
+	Scope      *ScopeSnapshot
+	CTEs       []RangeReference
+	Prefix     string
+	Intent     *CompletionIntent
+}
+
+// CompletionIntent describes the object class and qualifier implied by the
+// grammar position at the cursor.
+type CompletionIntent struct {
+	ObjectKinds []ObjectKind
+	Qualifier   MultipartName
+}
+
+// ObjectKind classifies catalog object completion intent.
+type ObjectKind int
+
+const (
+	ObjectKindUnknown ObjectKind = iota
+	ObjectKindDatabase
+	ObjectKindSchema
+	ObjectKindTable
+	ObjectKindView
+	ObjectKindSequence
+	ObjectKindProcedure
+	ObjectKindFunction
+	ObjectKindType
+	ObjectKindColumn
+)
+
+// MultipartName is a partially typed MSSQL object name.
+type MultipartName struct {
+	Server   string
+	Database string
+	Schema   string
+	Object   string
+}
+
+// ScopeSnapshot describes relation scope visible at a cursor.
+type ScopeSnapshot struct {
+	References      []RangeReference
+	LocalReferences []RangeReference
+	OuterReferences [][]RangeReference
+
+	DMLTarget   *RangeReference
+	MergeTarget *RangeReference
+	MergeSource *RangeReference
+}
+
+// RangeReferenceKind classifies a range-table entry visible to completion.
+type RangeReferenceKind int
+
+const (
+	RangeReferenceRelation RangeReferenceKind = iota
+	RangeReferenceSubquery
+	RangeReferenceFunction
+	RangeReferenceJoinAlias
+	RangeReferenceCTE
+	RangeReferenceValues
+	RangeReferenceTableVariable
+	RangeReferenceDMLTarget
+	RangeReferenceMergeTarget
+	RangeReferenceMergeSource
+)
+
+// RangeReference is a syntax-level table expression reference. It deliberately
+// avoids catalog metadata; callers resolve relation kinds and columns
+// themselves.
+type RangeReference struct {
+	Kind RangeReferenceKind
+
+	Server   string
+	Database string
+	Schema   string
+	Object   string
+	Alias    string
+
+	Columns      []string
+	AliasColumns []string
+
+	Loc     nodes.Loc
+	BodyLoc nodes.Loc
+}
+
+// CollectCompletion returns completion candidates plus a best-effort visible
+// relation scope at cursorOffset.
+func CollectCompletion(sql string, cursorOffset int) *CompletionContext {
+	if cursorOffset < 0 {
+		cursorOffset = 0
+	}
+	if cursorOffset > len(sql) {
+		cursorOffset = len(sql)
+	}
+	prefix := completionPrefix(sql, cursorOffset)
+	collectOffset := cursorOffset - len(prefix)
+	candidates := Collect(sql, collectOffset)
+	scope, ctes := collectCompletionScopeAndCTEs(sql, cursorOffset)
+	return &CompletionContext{
+		Candidates: candidates,
+		Scope:      scope,
+		CTEs:       ctes,
+		Prefix:     prefix,
+		Intent:     collectCompletionIntent(candidates, Tokenize(sql), collectOffset),
+	}
+}
+
+type completionScopeToken struct {
+	Token
+	depth int
+}
+
+func collectCompletionScope(sql string, cursorOffset int) *ScopeSnapshot {
+	scope, _ := collectCompletionScopeAndCTEs(sql, cursorOffset)
+	return scope
+}
+
+func collectCompletionScopeAndCTEs(sql string, cursorOffset int) (*ScopeSnapshot, []RangeReference) {
+	tokens := completionScopeTokens(Tokenize(sql))
+	start, end := statementTokenBounds(tokens, cursorOffset)
+	if start >= end {
+		return &ScopeSnapshot{}, nil
+	}
+
+	stmtTokens := tokens[start:end]
+	ctes, mainStart := collectCTEs(stmtTokens)
+	cteMap := rangeReferenceMap(ctes)
+	if scope := collectDMLScope(stmtTokens[mainStart:], cteMap); scope != nil {
+		return scope, ctes
+	}
+	return collectSelectScope(stmtTokens[mainStart:], cursorOffset, cteMap), ctes
+}
+
+func completionScopeTokens(tokens []Token) []completionScopeToken {
+	depth := 0
+	result := make([]completionScopeToken, 0, len(tokens))
+	for _, tok := range tokens {
+		result = append(result, completionScopeToken{Token: tok, depth: depth})
+		switch tok.Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return result
+}
+
+func statementTokenBounds(tokens []completionScopeToken, cursorOffset int) (int, int) {
+	start := 0
+	for i, tok := range tokens {
+		if tok.Loc >= cursorOffset {
+			break
+		}
+		if tok.Type == ';' || tok.Type == kwGO {
+			start = i + 1
+		}
+	}
+	end := len(tokens)
+	for i := start; i < len(tokens); i++ {
+		if tokens[i].Loc < cursorOffset {
+			continue
+		}
+		if tokens[i].Type == ';' || tokens[i].Type == kwGO {
+			end = i
+			break
+		}
+	}
+	return start, end
+}
+
+func collectCTEs(tokens []completionScopeToken) ([]RangeReference, int) {
+	first := firstNonTerminator(tokens)
+	if first < 0 || tokens[first].Type != kwWITH {
+		return nil, 0
+	}
+	var ctes []RangeReference
+	idx := first + 1
+	depth := tokens[first].depth
+	for idx < len(tokens) {
+		if tokens[idx].depth != depth || !IsIdentTokenType(tokens[idx].Type) {
+			break
+		}
+		nameIdx := idx
+		name := tokens[idx].Str
+		idx++
+		var columns []string
+		if idx < len(tokens) && tokens[idx].depth == depth && tokens[idx].Type == '(' {
+			closeIdx := matchingParen(tokens, idx)
+			if closeIdx < 0 {
+				break
+			}
+			for i := idx + 1; i < closeIdx; i++ {
+				if IsIdentTokenType(tokens[i].Type) {
+					columns = append(columns, tokens[i].Str)
+				}
+			}
+			idx = closeIdx + 1
+		}
+		if idx >= len(tokens) || tokens[idx].Type != kwAS {
+			break
+		}
+		idx++
+		if idx >= len(tokens) || tokens[idx].Type != '(' {
+			break
+		}
+		closeIdx := matchingParen(tokens, idx)
+		if closeIdx < 0 {
+			break
+		}
+		ctes = append(ctes, RangeReference{
+			Kind:    RangeReferenceCTE,
+			Object:  name,
+			Columns: columns,
+			Loc:     tokenLoc(tokens[nameIdx], tokens[closeIdx]),
+			BodyLoc: tokenLoc(tokens[idx], tokens[closeIdx]),
+		})
+		idx = closeIdx + 1
+		if idx < len(tokens) && tokens[idx].depth == depth && tokens[idx].Type == ',' {
+			idx++
+			continue
+		}
+		break
+	}
+	return ctes, idx
+}
+
+func rangeReferenceMap(refs []RangeReference) map[string]RangeReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	result := make(map[string]RangeReference, len(refs))
+	for _, ref := range refs {
+		result[foldName(ref.Object)] = ref
+	}
+	return result
+}
+
+func collectDMLScope(tokens []completionScopeToken, ctes map[string]RangeReference) *ScopeSnapshot {
+	first := firstNonTerminator(tokens)
+	if first < 0 {
+		return nil
+	}
+	switch tokens[first].Type {
+	case kwUPDATE:
+		return collectUpdateScope(tokens, first, ctes)
+	case kwDELETE:
+		return collectDeleteScope(tokens, first, ctes)
+	case kwMERGE:
+		return collectMergeScope(tokens, first, ctes)
+	default:
+		return nil
+	}
+}
+
+func collectUpdateScope(tokens []completionScopeToken, updateIdx int, ctes map[string]RangeReference) *ScopeSnapshot {
+	idx := skipTopClause(tokens, updateIdx+1, tokens[updateIdx].depth)
+	target, next, ok := parseRangeReference(tokens, idx)
+	if !ok {
+		return nil
+	}
+	target.Kind = RangeReferenceDMLTarget
+	target.Loc = tokenLoc(tokens[idx], tokens[next-1])
+	target.Alias, target.AliasColumns, next = parseAliasAndColumns(tokens, next, tokens[idx].depth)
+	local := []RangeReference{target}
+	if fromIdx := findKeywordAtDepth(tokens, kwFROM, next, len(tokens), tokens[updateIdx].depth); fromIdx >= 0 {
+		local = append(local, parseFromReferences(tokens, fromIdx+1, len(tokens), tokens[fromIdx].depth, ctes)...)
+	}
+	return scopeWithDMLTarget(local, target)
+}
+
+func collectDeleteScope(tokens []completionScopeToken, deleteIdx int, ctes map[string]RangeReference) *ScopeSnapshot {
+	idx := skipTopClause(tokens, deleteIdx+1, tokens[deleteIdx].depth)
+	if idx < len(tokens) && tokens[idx].Type == kwFROM {
+		idx++
+	}
+	target, next, ok := parseRangeReference(tokens, idx)
+	if !ok {
+		return nil
+	}
+	target.Kind = RangeReferenceDMLTarget
+	target.Loc = tokenLoc(tokens[idx], tokens[next-1])
+	target.Alias, target.AliasColumns, next = parseAliasAndColumns(tokens, next, tokens[idx].depth)
+	local := []RangeReference{target}
+	// DELETE alias FROM ... has a second FROM that carries the real range scope.
+	if fromIdx := findKeywordAtDepth(tokens, kwFROM, next, len(tokens), tokens[deleteIdx].depth); fromIdx >= 0 {
+		local = append(local, parseFromReferences(tokens, fromIdx+1, len(tokens), tokens[fromIdx].depth, ctes)...)
+	}
+	return scopeWithDMLTarget(local, target)
+}
+
+func collectMergeScope(tokens []completionScopeToken, mergeIdx int, _ map[string]RangeReference) *ScopeSnapshot {
+	idx := mergeIdx + 1
+	if idx < len(tokens) && tokens[idx].Type == kwINTO {
+		idx++
+	}
+	target, next, ok := parseRangeReference(tokens, idx)
+	if !ok {
+		return nil
+	}
+	target.Kind = RangeReferenceMergeTarget
+	target.Alias, target.AliasColumns, next = parseAliasAndColumns(tokens, next, tokens[idx].depth)
+	usingIdx := findKeywordAtDepth(tokens, kwUSING, next, len(tokens), tokens[mergeIdx].depth)
+	local := []RangeReference{target}
+	var source *RangeReference
+	if usingIdx >= 0 {
+		src, srcNext, ok := parseRangeReference(tokens, usingIdx+1)
+		if ok {
+			src.Kind = RangeReferenceMergeSource
+			src.Alias, src.AliasColumns, srcNext = parseAliasAndColumns(tokens, srcNext, tokens[usingIdx].depth)
+			src.Loc.End = tokens[srcNext-1].End
+			source = &src
+			local = append(local, src)
+		}
+	}
+	scope := &ScopeSnapshot{
+		References:      append([]RangeReference{}, local...),
+		LocalReferences: local,
+		MergeTarget:     &target,
+		MergeSource:     source,
+	}
+	return scope
+}
+
+func collectSelectScope(tokens []completionScopeToken, cursorOffset int, ctes map[string]RangeReference) *ScopeSnapshot {
+	frames := selectFramesForCursor(tokens, cursorOffset, ctes)
+	if len(frames) == 0 {
+		return &ScopeSnapshot{}
+	}
+	innermost := frames[len(frames)-1]
+	var outerRefs [][]RangeReference
+	for i := len(frames) - 2; i >= 0; i-- {
+		if len(frames[i].localRefs) > 0 {
+			outerRefs = append(outerRefs, frames[i].localRefs)
+		}
+	}
+	refs := append([]RangeReference{}, innermost.localRefs...)
+	for _, level := range outerRefs {
+		refs = append(refs, level...)
+	}
+	return &ScopeSnapshot{
+		References:      refs,
+		LocalReferences: innermost.localRefs,
+		OuterReferences: outerRefs,
+	}
+}
+
+type completionSelectFrame struct {
+	selectIdx int
+	localRefs []RangeReference
+}
+
+func selectFramesForCursor(tokens []completionScopeToken, cursorOffset int, ctes map[string]RangeReference) []completionSelectFrame {
+	cursorDepth := 0
+	for _, tok := range tokens {
+		if tok.Loc >= cursorOffset {
+			break
+		}
+		switch tok.Type {
+		case '(':
+			cursorDepth++
+		case ')':
+			if cursorDepth > 0 {
+				cursorDepth--
+			}
+		}
+	}
+	var frames []completionSelectFrame
+	for i, tok := range tokens {
+		if tok.Loc > cursorOffset {
+			break
+		}
+		if tok.Type != kwSELECT || tok.depth > cursorDepth {
+			continue
+		}
+		depth := tok.depth
+		armEnd := selectArmEnd(tokens, i+1, depth)
+		if armEnd < len(tokens) && tokens[armEnd].Loc < cursorOffset {
+			continue
+		}
+		fromIdx := findKeywordAtDepth(tokens, kwFROM, i+1, armEnd, depth)
+		var local []RangeReference
+		if fromIdx >= 0 {
+			local = parseFromReferences(tokens, fromIdx+1, armEnd, depth, ctes)
+		}
+		frames = append(frames, completionSelectFrame{selectIdx: i, localRefs: local})
+	}
+	return frames
+}
+
+func selectArmEnd(tokens []completionScopeToken, start, depth int) int {
+	for i := start; i < len(tokens); i++ {
+		if tokens[i].depth != depth {
+			continue
+		}
+		switch tokens[i].Type {
+		case kwUNION, kwINTERSECT, kwEXCEPT:
+			return i
+		}
+	}
+	return len(tokens)
+}
+
+func parseFromReferences(tokens []completionScopeToken, start, end, depth int, ctes map[string]RangeReference) []RangeReference {
+	var refs []RangeReference
+	expectSource := true
+	for i := start; i < end; {
+		tok := tokens[i]
+		if tok.depth == depth && isFromClauseTerminator(tok.Type) {
+			break
+		}
+		if tok.depth != depth {
+			i++
+			continue
+		}
+		if expectSource {
+			ref, next, ok := parseTableSource(tokens, i, ctes)
+			if ok {
+				refs = append(refs, ref)
+				i = next
+				expectSource = false
+				continue
+			}
+		}
+		if tok.Type == ',' || tok.Type == kwJOIN || tok.Type == kwAPPLY {
+			expectSource = true
+		}
+		i++
+	}
+	return refs
+}
+
+func parseTableSource(tokens []completionScopeToken, idx int, ctes map[string]RangeReference) (RangeReference, int, bool) {
+	if idx >= len(tokens) {
+		return RangeReference{}, idx, false
+	}
+	if tokens[idx].Type == '(' {
+		return parseParenthesizedTableSource(tokens, idx)
+	}
+	ref, next, ok := parseRangeReference(tokens, idx)
+	if !ok {
+		return RangeReference{}, idx, false
+	}
+	if ref.Schema == "" {
+		if cte, ok := ctes[foldName(ref.Object)]; ok {
+			ref.Kind = RangeReferenceCTE
+			ref.Columns = append([]string{}, cte.Columns...)
+			ref.AliasColumns = append([]string{}, cte.Columns...)
+		}
+	}
+	ref.Loc = tokenLoc(tokens[idx], tokens[next-1])
+	ref.Alias, ref.AliasColumns, next = parseAliasAndColumns(tokens, next, tokens[idx].depth)
+	if len(ref.AliasColumns) > 0 {
+		ref.Columns = append([]string{}, ref.AliasColumns...)
+	}
+	return ref, next, true
+}
+
+func parseParenthesizedTableSource(tokens []completionScopeToken, idx int) (RangeReference, int, bool) {
+	closeIdx := matchingParen(tokens, idx)
+	if closeIdx < 0 {
+		return RangeReference{}, idx, false
+	}
+	ref := RangeReference{
+		Kind:    RangeReferenceSubquery,
+		BodyLoc: tokenLoc(tokens[idx], tokens[closeIdx]),
+		Loc:     tokenLoc(tokens[idx], tokens[closeIdx]),
+	}
+	if idx+1 < len(tokens) && tokens[idx+1].Type == kwVALUES {
+		ref.Kind = RangeReferenceValues
+	}
+	alias, columns, next := parseAliasAndColumns(tokens, closeIdx+1, tokens[idx].depth)
+	ref.Alias = alias
+	ref.Object = alias
+	ref.Columns = columns
+	ref.AliasColumns = columns
+	if next > closeIdx+1 {
+		ref.Loc.End = tokens[next-1].End
+	}
+	return ref, next, alias != ""
+}
+
+func parseRangeReference(tokens []completionScopeToken, idx int) (RangeReference, int, bool) {
+	if idx >= len(tokens) {
+		return RangeReference{}, idx, false
+	}
+	if tokens[idx].Type == tokVARIABLE {
+		name := tokens[idx].Str
+		return RangeReference{
+			Kind:   RangeReferenceTableVariable,
+			Object: name,
+			Alias:  name,
+			Loc:    tokenLoc(tokens[idx], tokens[idx]),
+		}, idx + 1, true
+	}
+	if !IsIdentTokenType(tokens[idx].Type) {
+		return RangeReference{}, idx, false
+	}
+
+	var parts []string
+	i := idx
+	for i < len(tokens) && IsIdentTokenType(tokens[i].Type) {
+		parts = append(parts, tokens[i].Str)
+		if i+2 >= len(tokens) || tokens[i+1].Type != '.' || !IsIdentTokenType(tokens[i+2].Type) {
+			i++
+			break
+		}
+		i += 2
+	}
+	ref := RangeReference{Kind: RangeReferenceRelation, Loc: tokenLoc(tokens[idx], tokens[i-1])}
+	switch len(parts) {
+	case 1:
+		ref.Object = parts[0]
+	case 2:
+		ref.Schema = parts[0]
+		ref.Object = parts[1]
+	case 3:
+		ref.Database = parts[0]
+		ref.Schema = parts[1]
+		ref.Object = parts[2]
+	default:
+		ref.Server = parts[len(parts)-4]
+		ref.Database = parts[len(parts)-3]
+		ref.Schema = parts[len(parts)-2]
+		ref.Object = parts[len(parts)-1]
+	}
+	return ref, i, true
+}
+
+func parseAliasAndColumns(tokens []completionScopeToken, idx, depth int) (string, []string, int) {
+	if idx < len(tokens) && tokens[idx].depth == depth && tokens[idx].Type == kwAS {
+		idx++
+	}
+	if idx >= len(tokens) || tokens[idx].depth != depth || !IsIdentTokenType(tokens[idx].Type) {
+		return "", nil, idx
+	}
+	if isAliasBoundary(tokens[idx].Type) {
+		return "", nil, idx
+	}
+	alias := tokens[idx].Str
+	idx++
+	var columns []string
+	if idx < len(tokens) && tokens[idx].depth == depth && tokens[idx].Type == '(' {
+		closeIdx := matchingParen(tokens, idx)
+		if closeIdx >= 0 {
+			for i := idx + 1; i < closeIdx; i++ {
+				if IsIdentTokenType(tokens[i].Type) {
+					columns = append(columns, tokens[i].Str)
+				}
+			}
+			idx = closeIdx + 1
+		}
+	}
+	return alias, columns, idx
+}
+
+func scopeWithDMLTarget(local []RangeReference, target RangeReference) *ScopeSnapshot {
+	return &ScopeSnapshot{
+		References:      append([]RangeReference{}, local...),
+		LocalReferences: local,
+		DMLTarget:       &target,
+	}
+}
+
+func skipTopClause(tokens []completionScopeToken, idx, depth int) int {
+	if idx >= len(tokens) || tokens[idx].Type != kwTOP {
+		return idx
+	}
+	idx++
+	if idx < len(tokens) && tokens[idx].Type == '(' {
+		if closeIdx := matchingParen(tokens, idx); closeIdx >= 0 {
+			return closeIdx + 1
+		}
+	}
+	if idx < len(tokens) && tokens[idx].depth == depth {
+		return idx + 1
+	}
+	return idx
+}
+
+func findKeywordAtDepth(tokens []completionScopeToken, typ, start, end, depth int) int {
+	for i := start; i < end && i < len(tokens); i++ {
+		if tokens[i].depth == depth && tokens[i].Type == typ {
+			return i
+		}
+	}
+	return -1
+}
+
+func firstNonTerminator(tokens []completionScopeToken) int {
+	for i, tok := range tokens {
+		if tok.Type != ';' && tok.Type != kwGO {
+			return i
+		}
+	}
+	return -1
+}
+
+func matchingParen(tokens []completionScopeToken, openIdx int) int {
+	if openIdx >= len(tokens) || tokens[openIdx].Type != '(' {
+		return -1
+	}
+	balance := 0
+	for i := openIdx; i < len(tokens); i++ {
+		switch tokens[i].Type {
+		case '(':
+			balance++
+		case ')':
+			balance--
+			if balance == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func tokenLoc(first, last completionScopeToken) nodes.Loc {
+	return nodes.Loc{Start: first.Loc, End: last.End}
+}
+
+func isFromClauseTerminator(typ int) bool {
+	switch typ {
+	case kwWHERE, kwGROUP, kwHAVING, kwORDER, kwUNION, kwINTERSECT, kwEXCEPT, kwOPTION, kwFOR:
+		return true
+	default:
+		return false
+	}
+}
+
+func isAliasBoundary(typ int) bool {
+	switch typ {
+	case kwON, kwWHERE, kwGROUP, kwHAVING, kwORDER, kwUNION, kwINTERSECT, kwEXCEPT, kwJOIN, kwAPPLY, kwWITH, kwOPTION, kwFOR:
+		return true
+	default:
+		return false
+	}
+}
+
+func completionPrefix(sql string, cursorOffset int) string {
+	i := cursorOffset
+	for i > 0 {
+		c := sql[i-1]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+			i--
+			continue
+		}
+		break
+	}
+	return sql[i:cursorOffset]
+}
+
+func collectCompletionIntent(candidates *CandidateSet, tokens []Token, collectOffset int) *CompletionIntent {
+	if candidates == nil {
+		return nil
+	}
+	kinds := objectKindsForCandidates(candidates)
+	if contextKind, ok := contextObjectKind(tokens, collectOffset); ok {
+		if shouldOverrideObjectKindsWithContext(kinds, contextKind) {
+			kinds = appendObjectKind(nil, contextKind)
+		}
+	}
+	if len(kinds) == 0 {
+		return nil
+	}
+	return &CompletionIntent{
+		ObjectKinds: kinds,
+		Qualifier:   qualifierBeforeOffset(tokens, collectOffset),
+	}
+}
+
+func shouldOverrideObjectKindsWithContext(kinds []ObjectKind, contextKind ObjectKind) bool {
+	if contextKind == ObjectKindUnknown {
+		return false
+	}
+	if len(kinds) == 0 {
+		return true
+	}
+	return len(kinds) == 1 && kinds[0] == ObjectKindTable && contextKind != ObjectKindTable
+}
+
+func objectKindsForCandidates(candidates *CandidateSet) []ObjectKind {
+	var kinds []ObjectKind
+	for _, rc := range candidates.Rules {
+		switch rc.Rule {
+		case "database_ref":
+			kinds = appendObjectKind(kinds, ObjectKindDatabase)
+		case "schema_ref":
+			kinds = appendObjectKind(kinds, ObjectKindSchema)
+		case "table_ref":
+			kinds = appendObjectKind(kinds, ObjectKindTable)
+		case "view_name", "view_ref":
+			kinds = appendObjectKind(kinds, ObjectKindView)
+		case "sequence_ref":
+			kinds = appendObjectKind(kinds, ObjectKindSequence)
+		case "proc_name", "proc_ref":
+			kinds = appendObjectKind(kinds, ObjectKindProcedure)
+		case "func_name":
+			kinds = appendObjectKind(kinds, ObjectKindFunction)
+		case "type_name":
+			kinds = appendObjectKind(kinds, ObjectKindType)
+		case "columnref", "cte_column_name":
+			kinds = appendObjectKind(kinds, ObjectKindColumn)
+		}
+	}
+	return kinds
+}
+
+func appendObjectKind(kinds []ObjectKind, kind ObjectKind) []ObjectKind {
+	for _, existing := range kinds {
+		if existing == kind {
+			return kinds
+		}
+	}
+	return append(kinds, kind)
+}
+
+func contextObjectKind(tokens []Token, collectOffset int) (ObjectKind, bool) {
+	for i := len(tokens) - 1; i >= 0; i-- {
+		if tokens[i].Loc >= collectOffset {
+			continue
+		}
+		switch tokens[i].Type {
+		case kwTABLE:
+			return ObjectKindTable, true
+		case kwVIEW:
+			return ObjectKindView, true
+		case kwSEQUENCE:
+			return ObjectKindSequence, true
+		case kwPROCEDURE, kwPROC:
+			return ObjectKindProcedure, true
+		case kwFUNCTION:
+			return ObjectKindFunction, true
+		case kwTYPE:
+			return ObjectKindType, true
+		case kwDATABASE:
+			return ObjectKindDatabase, true
+		case kwSCHEMA:
+			return ObjectKindSchema, true
+		case kwFROM, kwJOIN, kwINTO, kwUSING, kwFOR, kwREFERENCES, kwEXEC, kwEXECUTE, kwDROP, kwCREATE, kwALTER:
+			return ObjectKindUnknown, false
+		}
+	}
+	return ObjectKindUnknown, false
+}
+
+func qualifierBeforeOffset(tokens []Token, collectOffset int) MultipartName {
+	idx := -1
+	for i, tok := range tokens {
+		if tok.Loc >= collectOffset {
+			break
+		}
+		idx = i
+	}
+	var parts []string
+	if idx >= 0 && tokens[idx].Type == '.' {
+		idx--
+		for idx >= 0 && IsIdentTokenType(tokens[idx].Type) {
+			parts = append([]string{tokens[idx].Str}, parts...)
+			if idx-1 < 0 || tokens[idx-1].Type != '.' {
+				break
+			}
+			idx -= 2
+		}
+	}
+	switch len(parts) {
+	case 1:
+		return MultipartName{Schema: parts[0]}
+	case 2:
+		return MultipartName{Database: parts[0], Schema: parts[1]}
+	case 3:
+		return MultipartName{Server: parts[0], Database: parts[1], Schema: parts[2]}
+	default:
+		if len(parts) > 3 {
+			return MultipartName{Server: parts[len(parts)-3], Database: parts[len(parts)-2], Schema: parts[len(parts)-1]}
+		}
+		return MultipartName{}
+	}
+}
+
+func foldName(name string) string {
+	if name == "" {
+		return ""
+	}
+	buf := make([]byte, len(name))
+	for i := range name {
+		c := name[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		buf[i] = c
+	}
+	return string(buf)
+}

--- a/mssql/parser/complete_context_test.go
+++ b/mssql/parser/complete_context_test.go
@@ -1,0 +1,231 @@
+package parser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCollectCompletionUpdateTargetScopeUsesQualifiedDMLTarget(t *testing.T) {
+	sql := "UPDATE School.dbo.Student SET "
+	ctx := CollectCompletion(sql, len(sql))
+	if ctx == nil || ctx.Candidates == nil || ctx.Scope == nil {
+		t.Fatal("expected completion context")
+	}
+	if !ctx.Candidates.HasRule("columnref") {
+		t.Fatal("expected columnref candidate")
+	}
+	if ctx.Scope.DMLTarget == nil {
+		t.Fatal("expected DML target")
+	}
+	if got, want := *ctx.Scope.DMLTarget, (RangeReference{Kind: RangeReferenceDMLTarget, Database: "School", Schema: "dbo", Object: "Student"}); !sameReferenceName(got, want) || got.Kind != want.Kind {
+		t.Fatalf("DML target = %+v, want %+v", got, want)
+	}
+	if got, want := refObjects(ctx.Scope.LocalReferences), []string{"Student"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("local references = %v, want %v", got, want)
+	}
+}
+
+func TestCollectCompletionDeleteTargetScopeUsesQualifiedDMLTarget(t *testing.T) {
+	sql := "DELETE FROM School.dbo.Student WHERE "
+	ctx := CollectCompletion(sql, len(sql))
+	if ctx == nil || ctx.Scope == nil || ctx.Scope.DMLTarget == nil {
+		t.Fatal("expected DML target")
+	}
+	if got, want := *ctx.Scope.DMLTarget, (RangeReference{Kind: RangeReferenceDMLTarget, Database: "School", Schema: "dbo", Object: "Student"}); !sameReferenceName(got, want) || got.Kind != want.Kind {
+		t.Fatalf("DML target = %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectCompletionSetOperationUsesCursorArmScope(t *testing.T) {
+	sql := "SELECT Id FROM Employees UNION SELECT EmployeeId FROM Address UNION SELECT  FROM MySchema.SalaryLevel"
+	cursor := strings.Index(sql, " FROM MySchema.SalaryLevel")
+	if cursor < 0 {
+		t.Fatal("test SQL missing cursor marker")
+	}
+	ctx := CollectCompletion(sql, cursor)
+	if ctx == nil || ctx.Scope == nil {
+		t.Fatal("expected completion scope")
+	}
+	if got, want := refObjects(ctx.Scope.LocalReferences), []string{"SalaryLevel"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("local references = %v, want %v", got, want)
+	}
+	if len(ctx.Scope.OuterReferences) != 0 {
+		t.Fatalf("outer references = %v, want none", ctx.Scope.OuterReferences)
+	}
+}
+
+func TestCollectCompletionValuesDerivedTableAliasColumns(t *testing.T) {
+	sql := "SELECT v. FROM (VALUES (1, 'a')) AS v(Id, Label)"
+	cursor := strings.Index(sql, " FROM")
+	if cursor < 0 {
+		t.Fatal("test SQL missing cursor marker")
+	}
+	ctx := CollectCompletion(sql, cursor)
+	if ctx == nil || ctx.Scope == nil {
+		t.Fatal("expected completion scope")
+	}
+	if got, want := len(ctx.Scope.LocalReferences), 1; got != want {
+		t.Fatalf("local reference count = %d, want %d", got, want)
+	}
+	ref := ctx.Scope.LocalReferences[0]
+	if ref.Kind != RangeReferenceValues {
+		t.Fatalf("reference kind = %v, want values", ref.Kind)
+	}
+	if ref.Alias != "v" {
+		t.Fatalf("alias = %q, want v", ref.Alias)
+	}
+	if got, want := ref.Columns, []string{"Id", "Label"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("columns = %v, want %v", got, want)
+	}
+}
+
+func TestCollectCompletionCTEDefinitionsAndReferenceScope(t *testing.T) {
+	sql := "WITH cte(Id, Label) AS (SELECT Id, Name FROM dbo.Employees) SELECT  FROM cte"
+	cursor := strings.Index(sql, " FROM cte")
+	if cursor < 0 {
+		t.Fatal("test SQL missing cursor marker")
+	}
+	ctx := CollectCompletion(sql, cursor)
+	if ctx == nil || ctx.Scope == nil {
+		t.Fatal("expected completion scope")
+	}
+	if got, want := len(ctx.CTEs), 1; got != want {
+		t.Fatalf("CTE count = %d, want %d", got, want)
+	}
+	if ctx.CTEs[0].Kind != RangeReferenceCTE || ctx.CTEs[0].Object != "cte" {
+		t.Fatalf("CTE = %+v, want cte reference", ctx.CTEs[0])
+	}
+	if got, want := ctx.CTEs[0].Columns, []string{"Id", "Label"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CTE columns = %v, want %v", got, want)
+	}
+	if got, want := len(ctx.Scope.LocalReferences), 1; got != want {
+		t.Fatalf("local reference count = %d, want %d", got, want)
+	}
+	if ref := ctx.Scope.LocalReferences[0]; ref.Kind != RangeReferenceCTE || ref.Object != "cte" {
+		t.Fatalf("local reference = %+v, want CTE cte", ref)
+	}
+}
+
+func TestCollectCompletionNestedSelectOuterReferences(t *testing.T) {
+	sql := "SELECT * FROM Employees e WHERE EXISTS (SELECT 1 FROM Address a WHERE a.EmployeeId = e.)"
+	cursor := strings.Index(sql, "e.)") + len("e.")
+	ctx := CollectCompletion(sql, cursor)
+	if ctx == nil || ctx.Scope == nil {
+		t.Fatal("expected completion scope")
+	}
+	if got, want := refObjects(ctx.Scope.LocalReferences), []string{"Address"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("local references = %v, want %v", got, want)
+	}
+	if got, want := len(ctx.Scope.OuterReferences), 1; got != want {
+		t.Fatalf("outer reference levels = %d, want %d", got, want)
+	}
+	if got, want := refObjects(ctx.Scope.OuterReferences[0]), []string{"Employees"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("outer references = %v, want %v", got, want)
+	}
+}
+
+func TestCollectCompletionMergeScope(t *testing.T) {
+	sql := "MERGE INTO dbo.Target AS t USING School.dbo.Source AS s ON s.Id = t.Id WHEN MATCHED THEN UPDATE SET Name = "
+	ctx := CollectCompletion(sql, len(sql))
+	if ctx == nil || ctx.Scope == nil {
+		t.Fatal("expected completion scope")
+	}
+	if ctx.Scope.MergeTarget == nil {
+		t.Fatal("expected merge target")
+	}
+	if got, want := *ctx.Scope.MergeTarget, (RangeReference{Kind: RangeReferenceMergeTarget, Schema: "dbo", Object: "Target", Alias: "t"}); !sameReferenceName(got, want) || got.Kind != want.Kind {
+		t.Fatalf("merge target = %+v, want %+v", got, want)
+	}
+	if ctx.Scope.MergeSource == nil {
+		t.Fatal("expected merge source")
+	}
+	if got, want := *ctx.Scope.MergeSource, (RangeReference{Kind: RangeReferenceMergeSource, Database: "School", Schema: "dbo", Object: "Source", Alias: "s"}); !sameReferenceName(got, want) || got.Kind != want.Kind {
+		t.Fatalf("merge source = %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectCompletionPrefixIntentAndQualifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		prefix    string
+		kind      ObjectKind
+		qualifier MultipartName
+	}{
+		{
+			name:   "sequence prefix",
+			input:  "SELECT NEXT VALUE FOR Employee|",
+			prefix: "Employee",
+			kind:   ObjectKindSequence,
+		},
+		{
+			name:   "table schema qualifier",
+			input:  "SELECT * FROM dbo.Us|",
+			prefix: "Us",
+			kind:   ObjectKindTable,
+			qualifier: MultipartName{
+				Schema: "dbo",
+			},
+		},
+		{
+			name:   "view schema qualifier",
+			input:  "DROP VIEW MySchema.|",
+			prefix: "",
+			kind:   ObjectKindView,
+			qualifier: MultipartName{
+				Schema: "MySchema",
+			},
+		},
+		{
+			name:   "procedure parameter type",
+			input:  "CREATE PROCEDURE p @Name | AS SELECT 1",
+			prefix: "",
+			kind:   ObjectKindType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := strings.Replace(tt.input, "|", "", 1)
+			cursor := strings.Index(tt.input, "|")
+			ctx := CollectCompletion(sql, cursor)
+			if ctx == nil {
+				t.Fatal("expected completion context")
+			}
+			if ctx.Prefix != tt.prefix {
+				t.Fatalf("prefix = %q, want %q", ctx.Prefix, tt.prefix)
+			}
+			if ctx.Intent == nil {
+				t.Fatal("expected completion intent")
+			}
+			if !hasObjectKind(ctx.Intent.ObjectKinds, tt.kind) {
+				t.Fatalf("object kinds = %v, want %v", ctx.Intent.ObjectKinds, tt.kind)
+			}
+			if ctx.Intent.Qualifier != tt.qualifier {
+				t.Fatalf("qualifier = %+v, want %+v", ctx.Intent.Qualifier, tt.qualifier)
+			}
+		})
+	}
+}
+
+func refObjects(refs []RangeReference) []string {
+	var out []string
+	for _, ref := range refs {
+		out = append(out, ref.Object)
+	}
+	return out
+}
+
+func hasObjectKind(kinds []ObjectKind, want ObjectKind) bool {
+	for _, got := range kinds {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sameReferenceName(a, b RangeReference) bool {
+	return a.Server == b.Server && a.Database == b.Database && a.Schema == b.Schema && a.Object == b.Object && a.Alias == b.Alias
+}

--- a/mssql/parser/create_table.go
+++ b/mssql/parser/create_table.go
@@ -1198,6 +1198,10 @@ func (p *Parser) parseTableConstraint() (*nodes.ConstraintDef, error) {
 			}
 		}
 		if _, ok := p.match(kwREFERENCES); ok {
+			if p.collectMode() {
+				p.addRuleCandidate("table_ref")
+				return nil, errCollecting
+			}
 			var refErr error
 			cd.RefTable, refErr = p.parseTableRef()
 			if refErr != nil {

--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -93,6 +93,11 @@ func (p *Parser) parseNot() (nodes.ExprNode, error) {
 	if p.cur.Type == kwNOT {
 		loc := p.pos()
 		p.advance()
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addRuleCandidate("func_name")
+			return nil, errCollecting
+		}
 		operand, err := p.parseNot()
 		if err != nil {
 			return nil, err
@@ -244,6 +249,12 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 			}, nil
 		}
 		items, err := p.parseCommaList(')', commaListStrict, func() (nodes.Node, error) {
+			if p.collectMode() {
+				p.addRuleCandidate("columnref")
+				p.addRuleCandidate("func_name")
+				p.addTokenCandidate(kwSELECT)
+				return nil, errCollecting
+			}
 			expr, err := p.parseExpr()
 			if err != nil {
 				return nil, err
@@ -406,6 +417,11 @@ func (p *Parser) parseAddition() (nodes.ExprNode, error) {
 			op = nodes.BinOpBitXor
 		}
 		p.advance()
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addRuleCandidate("func_name")
+			return nil, errCollecting
+		}
 		right, err := p.parseMultiplication()
 		if err != nil {
 			return nil, err
@@ -525,6 +541,11 @@ func (p *Parser) parseMultiplication() (nodes.ExprNode, error) {
 			op = nodes.BinOpMod
 		}
 		p.advance()
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addRuleCandidate("func_name")
+			return nil, errCollecting
+		}
 		right, err := p.parseUnary()
 		if err != nil {
 			return nil, err
@@ -850,12 +871,22 @@ func (p *Parser) parseConvert() (nodes.ExprNode, error) {
 	if _, err := p.expect(','); err != nil {
 		return nil, err
 	}
+	if p.collectMode() {
+		p.addRuleCandidate("columnref")
+		p.addRuleCandidate("func_name")
+		return nil, errCollecting
+	}
 	expr, err := p.parseExpr()
 	if err != nil {
 		return nil, err
 	}
 	var style nodes.ExprNode
 	if _, ok := p.match(','); ok {
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addRuleCandidate("func_name")
+			return nil, errCollecting
+		}
 		style, err = p.parseExpr()
 		if err != nil {
 			return nil, err
@@ -896,12 +927,22 @@ func (p *Parser) parseTryConvert() (nodes.ExprNode, error) {
 	if _, err := p.expect(','); err != nil {
 		return nil, err
 	}
+	if p.collectMode() {
+		p.addRuleCandidate("columnref")
+		p.addRuleCandidate("func_name")
+		return nil, errCollecting
+	}
 	expr, err := p.parseExpr()
 	if err != nil {
 		return nil, err
 	}
 	var style nodes.ExprNode
 	if _, ok := p.match(','); ok {
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addRuleCandidate("func_name")
+			return nil, errCollecting
+		}
 		style, err = p.parseExpr()
 		if err != nil {
 			return nil, err
@@ -1038,6 +1079,11 @@ func (p *Parser) parseCoalesce() (nodes.ExprNode, error) {
 		args = append(args, arg)
 		if _, ok := p.match(','); !ok {
 			break
+		}
+		if p.collectMode() {
+			p.addRuleCandidate("columnref")
+			p.addRuleCandidate("func_name")
+			return nil, errCollecting
 		}
 	}
 	_, _ = p.expect(')')

--- a/mssql/parser/type.go
+++ b/mssql/parser/type.go
@@ -19,6 +19,10 @@ import (
 //	          | user_defined_type
 func (p *Parser) parseDataType() (*nodes.DataType, error) {
 	loc := p.pos()
+	if p.collectMode() {
+		p.addRuleCandidate("type_name")
+		return nil, errCollecting
+	}
 
 	// Get type name - could be keyword (INT, VARCHAR, etc.) or identifier
 	var name string


### PR DESCRIPTION
## Summary
- Add MSSQL parser-native CollectCompletion context with prefix, intent, CTEs, and visible scope snapshots.
- Track DML target, MERGE target/source, CTE refs, outer refs, set-op current arm scope, and VALUES derived table alias columns.
- Route MSSQL completion table-ref extraction through the parser completion scope to avoid set-op reference leakage.

## Test Plan
- [x] go test ./mssql/... -count=1