### PR TITLE
fix(mssql): preserve merge using source scope

### DIFF
--- a/mssql/parser/complete_context.go
+++ b/mssql/parser/complete_context.go
@@ -641,7 +641,7 @@ func isFromClauseTerminator(typ int) bool {
 
 func isAliasBoundary(typ int) bool {
 	switch typ {
-	case kwON, kwWHERE, kwGROUP, kwHAVING, kwORDER, kwUNION, kwINTERSECT, kwEXCEPT, kwJOIN, kwAPPLY, kwWITH, kwOPTION, kwFOR:
+	case kwON, kwWHERE, kwGROUP, kwHAVING, kwORDER, kwUNION, kwINTERSECT, kwEXCEPT, kwJOIN, kwAPPLY, kwUSING, kwWITH, kwOPTION, kwFOR:
 		return true
 	default:
 		return false

--- a/mssql/parser/complete_context_test.go
+++ b/mssql/parser/complete_context_test.go
@@ -145,6 +145,26 @@ func TestCollectCompletionMergeScope(t *testing.T) {
 	}
 }
 
+func TestCollectCompletionMergeScopeBareUsingSource(t *testing.T) {
+	sql := "MERGE INTO Employees USING Address ON "
+	ctx := CollectCompletion(sql, len(sql))
+	if ctx == nil || ctx.Scope == nil {
+		t.Fatal("expected completion scope")
+	}
+	if ctx.Scope.MergeTarget == nil {
+		t.Fatal("expected merge target")
+	}
+	if got, want := *ctx.Scope.MergeTarget, (RangeReference{Kind: RangeReferenceMergeTarget, Object: "Employees"}); !sameReferenceName(got, want) || got.Kind != want.Kind {
+		t.Fatalf("merge target = %+v, want %+v", got, want)
+	}
+	if ctx.Scope.MergeSource == nil {
+		t.Fatal("expected merge source")
+	}
+	if got, want := *ctx.Scope.MergeSource, (RangeReference{Kind: RangeReferenceMergeSource, Object: "Address"}); !sameReferenceName(got, want) || got.Kind != want.Kind {
+		t.Fatalf("merge source = %+v, want %+v", got, want)
+	}
+}
+
 func TestCollectCompletionPrefixIntentAndQualifier(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- Treat `USING` as an alias boundary while collecting MSSQL completion scope.
- Preserve bare `MERGE INTO target USING source` as target + source refs instead of consuming `USING` as the target alias.
- Add regression coverage for `MERGE INTO Employees USING Address ON |`.

## Test Plan
- [x] go test ./mssql/parser -run 'TestCollectCompletionMergeScope' -count=1
- [x] go test ./mssql/... -count=1