### PR TITLE
fix(mssql): harden loc precision parsing

### DIFF
--- a/docs/plans/2026-05-07-mssql-expression-loc-hardening.md
+++ b/docs/plans/2026-05-07-mssql-expression-loc-hardening.md
@@ -1,0 +1,365 @@
+# MSSQL Expression Loc Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make MSSQL expression `Loc` ranges reliable enough for lossless source extraction of CHECK constraints, DEFAULT expressions, function calls, and column references.
+
+**Architecture:** First add the MSSQL equivalent of Doris/Snowflake `ast.NodeLoc` helpers so parser code has one canonical way to read child ranges. Then add exact source-slice regression tests for the reported MSSQL failures and fix parser construction sites to use child-node starts and consumed-token ends.
+
+**Tech Stack:** Go, `github.com/bytebase/omni/mssql/ast`, `github.com/bytebase/omni/mssql/parser`, standard `go test`.
+
+### Task 1: Add MSSQL AST Loc Helpers
+
+**Files:**
+- Create: `mssql/ast/loc.go`
+- Modify: `mssql/ast/node.go`
+- Test: `mssql/ast/loc_test.go`
+
+**Step 1: Add failing tests**
+
+Create `mssql/ast/loc_test.go` with focused tests for:
+
+```go
+func TestLocMethods(t *testing.T) {
+	if (Loc{Start: 1, End: 3}).IsValid() != true { t.Fatal("valid loc") }
+	if (Loc{Start: 1, End: -1}).IsValid() != false { t.Fatal("invalid loc") }
+	if got := (Loc{Start: 4, End: 8}).Merge(Loc{Start: 1, End: 5}); got != (Loc{Start: 1, End: 8}) {
+		t.Fatalf("Merge = %+v", got)
+	}
+}
+
+func TestNodeLocExpressions(t *testing.T) {
+	cases := []struct {
+		name string
+		node Node
+		want Loc
+	}{
+		{"BinaryExpr", &BinaryExpr{Loc: Loc{Start: 1, End: 2}}, Loc{Start: 1, End: 2}},
+		{"FuncCallExpr", &FuncCallExpr{Loc: Loc{Start: 2, End: 5}}, Loc{Start: 2, End: 5}},
+		{"ColumnRef", &ColumnRef{Loc: Loc{Start: 3, End: 4}}, Loc{Start: 3, End: 4}},
+		{"LikeExpr", &LikeExpr{Loc: Loc{Start: 4, End: 9}}, Loc{Start: 4, End: 9}},
+	}
+	for _, tt := range cases {
+		if got := NodeLoc(tt.node); got != tt.want {
+			t.Fatalf("%s NodeLoc = %+v, want %+v", tt.name, got, tt.want)
+		}
+	}
+}
+```
+
+**Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+go test ./mssql/ast -run 'TestLocMethods|TestNodeLocExpressions' -count=1
+```
+
+Expected: compile failure because `Loc.IsValid`, `Loc.Merge`, and `NodeLoc` do not exist.
+
+**Step 3: Implement helpers**
+
+In `mssql/ast/node.go`, add:
+
+```go
+func (l Loc) IsValid() bool {
+	return l.Start >= 0 && l.End >= 0
+}
+
+func (l Loc) Merge(other Loc) Loc {
+	if !l.IsValid() { return other }
+	if !other.IsValid() { return l }
+	out := l
+	if other.Start < out.Start { out.Start = other.Start }
+	if other.End > out.End { out.End = other.End }
+	return out
+}
+```
+
+Create `mssql/ast/loc.go` mirroring `doris/ast/loc.go` and `snowflake/ast/loc.go`, but scoped at least to all expression nodes used by `mssql/parser/expr.go` and `mssql/parser/name.go`: `BinaryExpr`, `UnaryExpr`, `FuncCallExpr`, `CaseExpr`, `CaseWhen`, `BetweenExpr`, `InExpr`, `LikeExpr`, `IsExpr`, `ExistsExpr`, `FullTextPredicate`, `CastExpr`, `ConvertExpr`, `TryCastExpr`, `TryConvertExpr`, `CoalesceExpr`, `NullifExpr`, `IifExpr`, `ColumnRef`, `VariableRef`, `StarExpr`, `Literal`, `SubqueryExpr`, `SubqueryComparisonExpr`, `CollateExpr`, `AtTimeZoneExpr`, `ParenExpr`, `MethodCallExpr`, `GroupingSetsExpr`, `RollupExpr`, and `CubeExpr`.
+
+Also add:
+
+```go
+func SpanNodes(nodes ...Node) Loc {
+	out := NoLoc()
+	for _, n := range nodes {
+		if n == nil { continue }
+		out = out.Merge(NodeLoc(n))
+	}
+	return out
+}
+```
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+go test ./mssql/ast -run 'TestLocMethods|TestNodeLocExpressions' -count=1
+```
+
+Expected: pass.
+
+### Task 2: Add Exact Expression Slice Regression Tests
+
+**Files:**
+- Modify: `mssql/parser/loc_precision_test.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Write failing SELECT-expression tests**
+
+Add a table-driven test named `TestMSSQLLocPrecision_ExpressionRanges` that parses each SQL, unwraps the first `*ast.ResTarget`, gets `ast.NodeLoc(rt.Val)`, and compares `sql[loc.Start:loc.End]` to `want`.
+
+Use these cases:
+
+```go
+{"SELECT c > 0", "c > 0"},
+{"SELECT c IN (1, 2)", "c IN (1, 2)"},
+{"SELECT c BETWEEN 1 AND 2", "c BETWEEN 1 AND 2"},
+{"SELECT c LIKE 'x%'", "c LIKE 'x%'"},
+{"SELECT c IS NOT NULL", "c IS NOT NULL"},
+{"SELECT a + b * c", "a + b * c"},
+{"SELECT a = 1 AND b = 2", "a = 1 AND b = 2"},
+{"SELECT name COLLATE Latin1_General_CI_AS LIKE 'A%'", "name COLLATE Latin1_General_CI_AS LIKE 'A%'"},
+{"SELECT dt AT TIME ZONE 'UTC'", "dt AT TIME ZONE 'UTC'"},
+```
+
+**Step 2: Write failing CHECK-expression tests**
+
+Add `TestMSSQLLocPrecision_CheckConstraintExpressionRanges` with both table-level and column-level constraints:
+
+```sql
+CREATE TABLE t (c int, CONSTRAINT ck CHECK (c > 0))
+CREATE TABLE t (c int CHECK (c IN (1, 2)))
+```
+
+Extract `ConstraintDef.Expr`, call `ast.NodeLoc`, and assert exact slices `c > 0` and `c IN (1, 2)`.
+
+**Step 3: Run tests to verify RED**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_ExpressionRanges|TestMSSQLLocPrecision_CheckConstraintExpressionRanges' -count=1
+```
+
+Expected: failures showing operator-only slices like `> 0`, `IN (...)`, `AND b = 2`, `LIKE 'A%'`, and `AT TIME ZONE 'UTC'`.
+
+### Task 3: Fix Infix And Postfix Expression Loc Construction
+
+**Files:**
+- Modify: `mssql/parser/expr.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Add small parser helper**
+
+Add near the top of `expr.go`:
+
+```go
+func exprStart(expr nodes.ExprNode, fallback int) int {
+	loc := nodes.NodeLoc(expr)
+	if loc.Start >= 0 {
+		return loc.Start
+	}
+	return fallback
+}
+```
+
+**Step 2: Update binary operator layers**
+
+In `parseOr`, `parseAnd`, `parseAddition`, and `parseMultiplication`, keep the local operator `loc` for fallback but build nodes with:
+
+```go
+Loc: nodes.Loc{Start: exprStart(left, loc), End: nodes.NodeLoc(right).End}
+```
+
+If `nodes.NodeLoc(right).End` is invalid, keep `p.prevEnd()` as fallback.
+
+**Step 3: Update predicate/comparison nodes**
+
+In `parseComparison`, set `start := exprStart(left, loc)` for all of:
+
+- `IsExpr`
+- `BetweenExpr`
+- `InExpr` value-list form
+- `InExpr` subquery form
+- `LikeExpr`, including `ESCAPE`
+- `SubqueryComparisonExpr`
+- plain comparison `BinaryExpr`
+
+Each outer predicate node should end at the consumed right-hand side token or closing paren: use `p.prevEnd()` after `expect(')')` or after parsing the right expression.
+
+**Step 4: Update postfix nodes**
+
+In `parseCollateExpr` and `parseAtTimeZoneExpr`, set `Loc.Start` from the left expression, not from the postfix keyword:
+
+```go
+Loc: nodes.Loc{Start: exprStart(expr, loc), End: p.prevEnd()}
+```
+
+**Step 5: Verify**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_ExpressionRanges|TestMSSQLLocPrecision_CheckConstraintExpressionRanges' -count=1
+```
+
+Expected: pass.
+
+### Task 4: Add Function Call And ColumnRef Regression Tests
+
+**Files:**
+- Modify: `mssql/parser/loc_precision_test.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Write failing function call tests**
+
+Add `TestMSSQLLocPrecision_FunctionCallRanges` using:
+
+```sql
+CREATE TABLE t (
+  d datetime2 DEFAULT SYSDATETIME(),
+  e int DEFAULT dbo.f(),
+  c int DEFAULT COUNT(*)
+)
+```
+
+Extract each column `DefaultExpr`, assert it is `*ast.FuncCallExpr`, and assert exact slices:
+
+```go
+[]string{"SYSDATETIME()", "dbo.f()", "COUNT(*)"}
+```
+
+Also include a SELECT target case with suffixes:
+
+```sql
+SELECT STRING_AGG(name, ',') WITHIN GROUP (ORDER BY name)
+SELECT SUM(x) OVER (PARTITION BY y)
+```
+
+The `FuncCallExpr.Loc` should cover the suffix if the suffix is part of the same function expression.
+
+**Step 2: Write failing column reference tests**
+
+Add `TestMSSQLLocPrecision_ColumnRefRanges` using:
+
+```sql
+SELECT c, t.c, dbo.t.c, t.*
+```
+
+Assert exact slices for `ColumnRef`/`StarExpr`: `c`, `t.c`, `dbo.t.c`, `t.*`.
+
+**Step 3: Run tests to verify RED**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_FunctionCallRanges|TestMSSQLLocPrecision_ColumnRefRanges' -count=1
+```
+
+Expected: failures showing `SYSDATETIME(`, `COUNT(`, schema-qualified `End=-1`, and column refs with `End=-1`.
+
+### Task 5: Fix Function Call And Column Reference Loc Ends
+
+**Files:**
+- Modify: `mssql/parser/name.go`
+- Modify: `mssql/parser/expr.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Fix simple and qualified column refs**
+
+In `parseIdentExpr`, simple `ColumnRef` should use:
+
+```go
+Loc: nodes.Loc{Start: loc, End: p.prevEnd()}
+```
+
+In `parseQualifiedRef`, set the returned `ColumnRef` and `StarExpr` `Loc.End` to `p.prevEnd()`.
+
+**Step 2: Fix simple function calls**
+
+In `parseFuncCall`, capture `nameEnd := p.prevEnd()` before consuming `(`. Set:
+
+```go
+fc.Name.Loc.End = nameEnd
+fc.Loc.End = p.prevEnd()
+```
+
+after every successful close paren path, including `COUNT(*)`, empty-argument calls, and normal argument calls. After parsing optional `WITHIN GROUP` or `OVER`, update `fc.Loc.End = p.prevEnd()` again so the full function expression is covered.
+
+**Step 3: Fix schema-qualified function calls**
+
+In `parseFuncCallWithSchema`, capture `nameEnd := p.prevEnd()` before consuming `(`. Set `fc.Name.Loc.End = nameEnd` and mirror the same `fc.Loc.End` updates as simple calls.
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_FunctionCallRanges|TestMSSQLLocPrecision_ColumnRefRanges' -count=1
+```
+
+Expected: pass.
+
+### Task 6: Add A Loc Coverage Guard For Expression Nodes
+
+**Files:**
+- Modify: `mssql/parser/loc_precision_test.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Add structural guard**
+
+Add a small guard that parses representative expressions and walks them with `ast.Walk`, failing if any expression node under the target expression has `Loc.Start < 0` or `Loc.End < Loc.Start`, except for known synthetic nodes if any are found and documented.
+
+Representative SQL:
+
+```sql
+SELECT (a + b) * dbo.f(c) WHERE c IS NOT NULL
+SELECT CASE WHEN c BETWEEN 1 AND 2 THEN SYSDATETIME() ELSE dbo.f() END
+```
+
+**Step 2: Verify**
+
+Run:
+
+```bash
+go test ./mssql/parser -run TestMSSQLLocPrecision_ExpressionNodeLocCompleteness -count=1
+```
+
+Expected after previous fixes: pass. If it fails on unrelated AST shapes, document and narrow the guard to expression nodes touched by this plan.
+
+### Task 7: Full Verification
+
+**Files:**
+- No changes
+- Test: affected packages
+
+**Step 1: Run all precision tests**
+
+```bash
+go test ./mssql/parser -run TestMSSQLLocPrecision -count=1
+```
+
+Expected: pass.
+
+**Step 2: Run existing expression tests**
+
+```bash
+go test ./mssql/parser -run 'TestParseComparison|TestParseBoolean|TestParseIsNull|TestParseBetween|TestParseIn|TestParseLike|TestParseFunctions|TestParseCreateTable|TestLoc_Expressions' -count=1
+```
+
+Expected: pass. Note `TestLoc_Expressions` is in package `./mssql`, so if the exact regex does not select it from `./mssql/parser`, run `go test ./mssql -run TestLoc_Expressions -count=1`.
+
+**Step 3: Run package verification**
+
+```bash
+go test ./mssql/ast ./mssql/parser ./mssql -count=1
+```
+
+Expected: pass.
+
+### Risk Notes
+
+This intentionally changes `Loc.Start` for existing expression nodes from operator-only to full-expression ranges. That is the desired contract for lossless metadata extraction, but any code depending on operator-only spans will observe different offsets. Keep the change scoped to expression nodes and exact source-slice tests; do not attempt to clean up every `End=-1` statement or DDL node in the same pass.

--- a/docs/plans/2026-05-07-mssql-spatial-loc-fixes.md
+++ b/docs/plans/2026-05-07-mssql-spatial-loc-fixes.md
@@ -1,0 +1,369 @@
+# MSSQL Spatial Index And Expression Loc Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve MSSQL spatial index nested option values and make expression `Loc` ranges cover the complete parsed expression.
+
+**Architecture:** Keep the fixes in the MSSQL parser layer, where token source spans are known. Add precise regression tests first, then adjust parser location construction and nested option value consumption without changing AST shapes.
+
+**Tech Stack:** Go, `github.com/bytebase/omni/mssql/parser`, `github.com/bytebase/omni/mssql/ast`, standard `go test`.
+
+### Task 1: Add Spatial Option Regression Tests
+
+**Files:**
+- Create: `mssql/parser/loc_precision_test.go`
+- Modify: none
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Write failing tests**
+
+Add a parser test that parses:
+
+```sql
+CREATE SPATIAL INDEX SI_t ON dbo.t (geom) USING GEOMETRY_GRID
+WITH (
+  BOUNDING_BOX = (0, 0, 100, 100),
+  GRIDS = (LEVEL_1 = LOW, LEVEL_2 = MEDIUM, LEVEL_3 = HIGH, LEVEL_4 = HIGH),
+  CELLS_PER_OBJECT = 16
+)
+```
+
+Assert `CreateSpatialIndexStmt.Options.Items` contains exactly:
+
+```go
+[]string{
+  "BOUNDING_BOX=(0, 0, 100, 100)",
+  "GRIDS=(LEVEL_1 = LOW, LEVEL_2 = MEDIUM, LEVEL_3 = HIGH, LEVEL_4 = HIGH)",
+  "CELLS_PER_OBJECT=16",
+}
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+go test ./mssql/parser -run TestMSSQLLocPrecision_SpatialIndexNestedOptions -count=1
+```
+
+Expected before fix: failure showing `BOUNDING_BOX=` and `GRIDS=`.
+
+### Task 2: Preserve Parenthesized Index Option Values
+
+**Files:**
+- Modify: `mssql/parser/alter_objects.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Add a local helper**
+
+Add a helper near `parseAlterIndexOptions`:
+
+```go
+func (p *Parser) consumeBalancedValueText() (string, error) {
+	start := p.pos()
+	depth := 0
+	for p.cur.Type != tokEOF {
+		if p.cur.Type == '(' {
+			depth++
+		} else if p.cur.Type == ')' {
+			depth--
+			p.advance()
+			if depth == 0 {
+				return strings.TrimSpace(p.source[start:p.prevEnd()]), nil
+			}
+			continue
+		}
+		p.advance()
+	}
+	return strings.TrimSpace(p.source[start:p.prevEnd()]), nil
+}
+```
+
+**Step 2: Use it only for value parentheses**
+
+In the `else if p.cur.Type == '('` branch under `option_name = value`, replace the current “skip nested parens” loop with:
+
+```go
+var err error
+val, err = p.consumeBalancedValueText()
+if err != nil {
+	return nil, err
+}
+```
+
+Keep simple scalar values normalized as today (`FILLFACTOR=80`, `ALLOW_ROW_LOCKS=ON`) to avoid unnecessary golden churn.
+
+**Step 3: Verify**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_SpatialIndexNestedOptions|TestParseAlterIndexOptionsDepth' -count=1
+```
+
+Expected after fix: both tests pass.
+
+### Task 3: Add Expression Loc Regression Tests
+
+**Files:**
+- Modify: `mssql/parser/loc_precision_test.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Write failing tests**
+
+Add table-driven tests for these target expressions and exact source slices:
+
+```go
+[]struct{
+	sql string
+	want string
+}{
+	{"SELECT c > 0", "c > 0"},
+	{"SELECT c IN (1, 2)", "c IN (1, 2)"},
+	{"SELECT c BETWEEN 1 AND 2", "c BETWEEN 1 AND 2"},
+	{"SELECT c LIKE 'x%'", "c LIKE 'x%'"},
+	{"SELECT c IS NOT NULL", "c IS NOT NULL"},
+	{"SELECT a + b * c", "a + b * c"},
+	{"SELECT a = 1 AND b = 2", "a = 1 AND b = 2"},
+}
+```
+
+Unwrap the first `ResTarget` and assert the expression node `Loc` slice equals `want`.
+
+**Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+go test ./mssql/parser -run TestMSSQLLocPrecision_ExpressionRanges -count=1
+```
+
+Expected before fix: comparison/predicate/binary expressions start at the operator.
+
+### Task 4: Fix Expression Start Ranges
+
+**Files:**
+- Modify: `mssql/parser/expr.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Add parser-side Loc helpers**
+
+Add helpers in `expr.go`:
+
+```go
+func exprLocStart(expr nodes.ExprNode, fallback int) int {
+	if loc, ok := exprLoc(expr); ok && loc.Start >= 0 {
+		return loc.Start
+	}
+	return fallback
+}
+
+func exprLoc(expr nodes.ExprNode) (nodes.Loc, bool) {
+	switch e := expr.(type) {
+	case *nodes.BinaryExpr:
+		return e.Loc, true
+	case *nodes.UnaryExpr:
+		return e.Loc, true
+	case *nodes.FuncCallExpr:
+		return e.Loc, true
+	case *nodes.CaseExpr:
+		return e.Loc, true
+	case *nodes.BetweenExpr:
+		return e.Loc, true
+	case *nodes.InExpr:
+		return e.Loc, true
+	case *nodes.LikeExpr:
+		return e.Loc, true
+	case *nodes.IsExpr:
+		return e.Loc, true
+	case *nodes.ExistsExpr:
+		return e.Loc, true
+	case *nodes.CastExpr:
+		return e.Loc, true
+	case *nodes.ConvertExpr:
+		return e.Loc, true
+	case *nodes.TryCastExpr:
+		return e.Loc, true
+	case *nodes.TryConvertExpr:
+		return e.Loc, true
+	case *nodes.CoalesceExpr:
+		return e.Loc, true
+	case *nodes.NullifExpr:
+		return e.Loc, true
+	case *nodes.IifExpr:
+		return e.Loc, true
+	case *nodes.ColumnRef:
+		return e.Loc, true
+	case *nodes.VariableRef:
+		return e.Loc, true
+	case *nodes.StarExpr:
+		return e.Loc, true
+	case *nodes.Literal:
+		return e.Loc, true
+	case *nodes.SubqueryExpr:
+		return e.Loc, true
+	case *nodes.SubqueryComparisonExpr:
+		return e.Loc, true
+	case *nodes.CollateExpr:
+		return e.Loc, true
+	case *nodes.AtTimeZoneExpr:
+		return e.Loc, true
+	case *nodes.ParenExpr:
+		return e.Loc, true
+	}
+	return nodes.Loc{}, false
+}
+```
+
+**Step 2: Update infix and predicate nodes**
+
+In `parseOr`, `parseAnd`, `parseAddition`, `parseMultiplication`, and `parseComparison`, construct expression nodes with:
+
+```go
+Loc: nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()}
+```
+
+Use the same start logic for `IsExpr`, `BetweenExpr`, `InExpr`, `LikeExpr`, `BinaryExpr`, and `SubqueryComparisonExpr`.
+
+**Step 3: Update postfix nodes**
+
+In `parseCollateExpr` and `parseAtTimeZoneExpr`, use the left expression start:
+
+```go
+start := exprLocStart(expr, loc)
+```
+
+Then set the node `Loc.Start` to `start`.
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+go test ./mssql/parser -run TestMSSQLLocPrecision_ExpressionRanges -count=1
+```
+
+Expected after fix: exact source slices match all cases.
+
+### Task 5: Add Function And ColumnRef Loc Regression Tests
+
+**Files:**
+- Modify: `mssql/parser/loc_precision_test.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Write failing tests**
+
+Add tests for:
+
+```sql
+CREATE TABLE t (
+  d datetime2 DEFAULT SYSDATETIME(),
+  e int DEFAULT dbo.f()
+)
+```
+
+Assert both default `FuncCallExpr.Loc` slices are `SYSDATETIME()` and `dbo.f()`.
+
+Add tests for:
+
+```sql
+SELECT c, t.c, dbo.t.c
+```
+
+Assert every `ColumnRef.Loc.End` is non-negative and slices are `c`, `t.c`, and `dbo.t.c`.
+
+**Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_FunctionCallRanges|TestMSSQLLocPrecision_ColumnRefRanges' -count=1
+```
+
+Expected before fix: simple function misses `)`, schema-qualified function has `End=-1`, and column refs have `End=-1`.
+
+### Task 6: Fix Function Call And ColumnRef End Ranges
+
+**Files:**
+- Modify: `mssql/parser/name.go`
+- Modify: `mssql/parser/expr.go`
+- Test: `mssql/parser/loc_precision_test.go`
+
+**Step 1: Fix simple `ColumnRef`**
+
+In `parseIdentExpr`, return:
+
+```go
+return &nodes.ColumnRef{
+	Column: name,
+	Loc:    nodes.Loc{Start: loc, End: p.prevEnd()},
+}, nil
+```
+
+**Step 2: Fix qualified `ColumnRef` and `StarExpr`**
+
+In `parseQualifiedRef`, set:
+
+```go
+Loc: nodes.Loc{Start: loc, End: p.prevEnd()}
+```
+
+on the returned `ColumnRef` and qualified `StarExpr`.
+
+**Step 3: Fix simple function call**
+
+In `parseFuncCall`, preserve `nameEnd := p.prevEnd()` before consuming `(`, set `fc.Name.Loc.End = nameEnd`, and after every successful `expect(')')` or closing-paren `advance`, set:
+
+```go
+fc.Loc.End = p.prevEnd()
+```
+
+After parsing optional `WITHIN GROUP` or `OVER`, set `fc.Loc.End = p.prevEnd()` again so the node covers the full function expression including suffixes.
+
+**Step 4: Fix schema-qualified function call**
+
+In `parseFuncCallWithSchema`, preserve `nameEnd := p.prevEnd()` before consuming `(`, set both `fc.Name.Loc.End` and `fc.Loc.End` using the same rules as simple calls.
+
+**Step 5: Verify**
+
+Run:
+
+```bash
+go test ./mssql/parser -run 'TestMSSQLLocPrecision_FunctionCallRanges|TestMSSQLLocPrecision_ColumnRefRanges' -count=1
+```
+
+Expected after fix: exact slices match.
+
+### Task 7: Run Focused And Package Verification
+
+**Files:**
+- No changes
+- Test: full MSSQL parser package
+
+**Step 1: Run all precision regressions**
+
+```bash
+go test ./mssql/parser -run TestMSSQLLocPrecision -count=1
+```
+
+Expected: pass.
+
+**Step 2: Run existing affected tests**
+
+```bash
+go test ./mssql/parser -run 'TestParseAlterIndexOptionsDepth|TestParseCreateIndexStatements|TestParseFunctions|TestParseComparison|TestParseBoolean|TestParseIsNull|TestParseBetween|TestParseIn|TestParseLike' -count=1
+```
+
+Expected: pass.
+
+**Step 3: Run package tests**
+
+```bash
+go test ./mssql/parser ./mssql -count=1
+```
+
+Expected: pass.
+
+### Risk Notes
+
+The main compatibility risk is `ast.String` option serialization. Keep scalar index options exactly normalized as before and only fill previously empty parenthesized values. The main Loc risk is code that accidentally depended on operator-only ranges; that behavior is incorrect for lossless extraction, and focused Loc tests should make the intended contract explicit.

--- a/mssql/ast/loc.go
+++ b/mssql/ast/loc.go
@@ -1,0 +1,132 @@
+package ast
+
+import "reflect"
+
+// NodeLoc returns the source location of n, or NoLoc() if n is nil or its
+// concrete type carries no Loc field.
+func NodeLoc(n Node) Loc {
+	if n == nil {
+		return NoLoc()
+	}
+	switch v := n.(type) {
+	case *List:
+		return SpanNodes(v.Items...)
+	case *SelectStmt:
+		return v.Loc
+	case *ResTarget:
+		return v.Loc
+	case *BinaryExpr:
+		return v.Loc
+	case *UnaryExpr:
+		return v.Loc
+	case *FuncCallExpr:
+		return v.Loc
+	case *CaseExpr:
+		return v.Loc
+	case *CaseWhen:
+		return v.Loc
+	case *BetweenExpr:
+		return v.Loc
+	case *InExpr:
+		return v.Loc
+	case *LikeExpr:
+		return v.Loc
+	case *IsExpr:
+		return v.Loc
+	case *ExistsExpr:
+		return v.Loc
+	case *FullTextPredicate:
+		return v.Loc
+	case *CastExpr:
+		return v.Loc
+	case *ConvertExpr:
+		return v.Loc
+	case *TryCastExpr:
+		return v.Loc
+	case *TryConvertExpr:
+		return v.Loc
+	case *CoalesceExpr:
+		return v.Loc
+	case *NullifExpr:
+		return v.Loc
+	case *IifExpr:
+		return v.Loc
+	case *ColumnRef:
+		return v.Loc
+	case *VariableRef:
+		return v.Loc
+	case *StarExpr:
+		return v.Loc
+	case *Literal:
+		return v.Loc
+	case *SubqueryExpr:
+		return v.Loc
+	case *SubqueryComparisonExpr:
+		return v.Loc
+	case *CollateExpr:
+		return v.Loc
+	case *AtTimeZoneExpr:
+		return v.Loc
+	case *ParenExpr:
+		return v.Loc
+	case *TableRef:
+		return v.Loc
+	case *DataType:
+		return v.Loc
+	case *OrderByItem:
+		return v.Loc
+	case *OverClause:
+		return v.Loc
+	case *CurrentOfExpr:
+		return v.Loc
+	case *MethodCallExpr:
+		return v.Loc
+	case *GroupingSetsExpr:
+		return v.Loc
+	case *RollupExpr:
+		return v.Loc
+	case *CubeExpr:
+		return v.Loc
+	default:
+		return nodeLocFromField(n)
+	}
+}
+
+func nodeLocFromField(n Node) Loc {
+	v := reflect.ValueOf(n)
+	if !v.IsValid() {
+		return NoLoc()
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return NoLoc()
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return NoLoc()
+	}
+	field := v.FieldByName("Loc")
+	if !field.IsValid() || field.Type() != reflect.TypeOf(Loc{}) {
+		return NoLoc()
+	}
+	loc, ok := field.Interface().(Loc)
+	if !ok {
+		return NoLoc()
+	}
+	return loc
+}
+
+// SpanNodes returns the smallest Loc that covers every node in nodes.
+// Nil entries and nodes whose Loc is invalid are skipped. Returns NoLoc()
+// when no node has a valid Loc.
+func SpanNodes(nodes ...Node) Loc {
+	out := NoLoc()
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		out = out.Merge(NodeLoc(n))
+	}
+	return out
+}

--- a/mssql/ast/loc_test.go
+++ b/mssql/ast/loc_test.go
@@ -1,0 +1,157 @@
+package ast
+
+import (
+	goast "go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestLocMethods(t *testing.T) {
+	if !(Loc{Start: 1, End: 3}).IsValid() {
+		t.Fatal("expected loc with non-negative start/end to be valid")
+	}
+	if (Loc{Start: 1, End: -1}).IsValid() {
+		t.Fatal("expected loc with negative end to be invalid")
+	}
+	if got := (Loc{Start: 4, End: 8}).Merge(Loc{Start: 1, End: 5}); got != (Loc{Start: 1, End: 8}) {
+		t.Fatalf("Merge = %+v, want {Start:1 End:8}", got)
+	}
+}
+
+func TestNodeLocExpressions(t *testing.T) {
+	tests := []struct {
+		name string
+		node Node
+		want Loc
+	}{
+		{"BinaryExpr", &BinaryExpr{Loc: Loc{Start: 1, End: 2}}, Loc{Start: 1, End: 2}},
+		{"FuncCallExpr", &FuncCallExpr{Loc: Loc{Start: 2, End: 5}}, Loc{Start: 2, End: 5}},
+		{"ColumnRef", &ColumnRef{Loc: Loc{Start: 3, End: 4}}, Loc{Start: 3, End: 4}},
+		{"LikeExpr", &LikeExpr{Loc: Loc{Start: 4, End: 9}}, Loc{Start: 4, End: 9}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NodeLoc(tt.node); got != tt.want {
+				t.Fatalf("NodeLoc = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeLocCoversLocBearingNodes(t *testing.T) {
+	locBearing := locBearingStructs(t)
+	if len(locBearing) == 0 {
+		t.Fatal("expected at least one Loc-bearing AST node")
+	}
+	if genericNodeLocFallbackWorks() {
+		return
+	}
+
+	covered := nodeLocTypeSwitchCases(t)
+
+	var missing []string
+	for _, name := range locBearing {
+		if !covered[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("NodeLoc missing Loc-bearing node types: %s", strings.Join(missing, ", "))
+	}
+}
+
+type nodeLocFallbackStub struct {
+	Loc Loc
+}
+
+func (*nodeLocFallbackStub) nodeTag() {}
+
+func genericNodeLocFallbackWorks() bool {
+	loc := Loc{Start: 11, End: 17}
+	return NodeLoc(&nodeLocFallbackStub{Loc: loc}) == loc
+}
+
+func locBearingStructs(t *testing.T) []string {
+	t.Helper()
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*goast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*goast.TypeSpec)
+				if !ok || ts.Name.Name == "Loc" {
+					continue
+				}
+				st, ok := ts.Type.(*goast.StructType)
+				if !ok || !structHasLocField(st) {
+					continue
+				}
+				names = append(names, ts.Name.Name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func structHasLocField(st *goast.StructType) bool {
+	for _, field := range st.Fields.List {
+		ident, ok := field.Type.(*goast.Ident)
+		if !ok || ident.Name != "Loc" {
+			continue
+		}
+		for _, name := range field.Names {
+			if name.Name == "Loc" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nodeLocTypeSwitchCases(t *testing.T) map[string]bool {
+	t.Helper()
+
+	f, err := parser.ParseFile(token.NewFileSet(), "loc.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse loc.go: %v", err)
+	}
+	covered := make(map[string]bool)
+	goast.Inspect(f, func(n goast.Node) bool {
+		cc, ok := n.(*goast.CaseClause)
+		if !ok {
+			return true
+		}
+		for _, expr := range cc.List {
+			star, ok := expr.(*goast.StarExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := star.X.(*goast.Ident)
+			if ok {
+				covered[ident.Name] = true
+			}
+		}
+		return true
+	})
+	return covered
+}

--- a/mssql/ast/node.go
+++ b/mssql/ast/node.go
@@ -37,6 +37,31 @@ func NoLoc() Loc {
 	return Loc{Start: -1, End: -1}
 }
 
+// IsValid reports whether both Start and End are non-negative.
+func (l Loc) IsValid() bool {
+	return l.Start >= 0 && l.End >= 0
+}
+
+// Merge returns the smallest Loc that contains both l and other.
+// If either side is invalid, returns the other side. If both are invalid,
+// returns NoLoc().
+func (l Loc) Merge(other Loc) Loc {
+	if !l.IsValid() {
+		return other
+	}
+	if !other.IsValid() {
+		return l
+	}
+	out := l
+	if other.Start < out.Start {
+		out.Start = other.Start
+	}
+	if other.End > out.End {
+		out.End = other.End
+	}
+	return out
+}
+
 // List represents a generic list of nodes.
 type List struct {
 	Items []Node

--- a/mssql/ast/outfuncs.go
+++ b/mssql/ast/outfuncs.go
@@ -4075,6 +4075,10 @@ func writeCreateSpatialIndexStmt(sb *strings.Builder, n *CreateSpatialIndexStmt)
 	if n.SpatialColumn != "" {
 		fmt.Fprintf(sb, " :spatialColumn \"%s\"", escapeString(n.SpatialColumn))
 	}
+	if n.SpatialColumnRef != nil {
+		sb.WriteString(" :spatialColumnRef ")
+		writeNode(sb, n.SpatialColumnRef)
+	}
 	if n.Using != "" {
 		fmt.Fprintf(sb, " :using \"%s\"", escapeString(n.Using))
 	}

--- a/mssql/ast/parsenodes.go
+++ b/mssql/ast/parsenodes.go
@@ -3273,13 +3273,14 @@ func (n *CreateSelectiveXmlIndexStmt) stmtNode() {}
 //
 // Ref: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-spatial-index-transact-sql
 type CreateSpatialIndexStmt struct {
-	Name          string    // index name
-	Table         *TableRef // ON table
-	SpatialColumn string    // (spatial_column)
-	Using         string    // USING tessellation type (GEOMETRY_GRID, etc.)
-	Options       *List     // WITH (options)
-	OnFileGroup   string    // ON filegroup
-	Loc           Loc
+	Name             string     // index name
+	Table            *TableRef  // ON table
+	SpatialColumn    string     // (spatial_column)
+	SpatialColumnRef *ColumnRef // loc-bearing spatial column reference
+	Using            string     // USING tessellation type (GEOMETRY_GRID, etc.)
+	Options          *List      // WITH (options)
+	OnFileGroup      string     // ON filegroup
+	Loc              Loc
 }
 
 func (n *CreateSpatialIndexStmt) nodeTag()  {}

--- a/mssql/ast/walk_generated.go
+++ b/mssql/ast/walk_generated.go
@@ -283,6 +283,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.Table != nil {
 			Walk(v, n.Table)
 		}
+		if n.SpatialColumnRef != nil {
+			Walk(v, n.SpatialColumnRef)
+		}
 		walkList(v, n.Options)
 	case *CreateStatisticsStmt:
 		if n.Table != nil {

--- a/mssql/loc_precision_matrix_test.go
+++ b/mssql/loc_precision_matrix_test.go
@@ -1,0 +1,85 @@
+package mssql
+
+import "testing"
+
+func TestMSSQLPublicParseLocPrecisionMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		wantTexts  []string
+		wantStarts []Position
+		wantEnds   []Position
+	}{
+		{
+			name:       "single statement text and positions",
+			sql:        "SELECT 1",
+			wantTexts:  []string{"SELECT 1"},
+			wantStarts: []Position{{Line: 1, Column: 1}},
+			wantEnds:   []Position{{Line: 1, Column: 9}},
+		},
+		{
+			name:       "leading whitespace start position",
+			sql:        " \n\tSELECT 1",
+			wantTexts:  []string{" \n\tSELECT 1"},
+			wantStarts: []Position{{Line: 2, Column: 2}},
+			wantEnds:   []Position{{Line: 2, Column: 10}},
+		},
+		{
+			name:       "multi statement text",
+			sql:        "SELECT 1; SELECT 2",
+			wantTexts:  []string{"SELECT 1;", " SELECT 2"},
+			wantStarts: []Position{{Line: 1, Column: 1}, {Line: 1, Column: 11}},
+			wantEnds:   []Position{{Line: 1, Column: 10}, {Line: 1, Column: 19}},
+		},
+		{
+			name:       "tabs and unicode use byte columns",
+			sql:        "\tSELECT N'你好'",
+			wantTexts:  []string{"\tSELECT N'你好'"},
+			wantStarts: []Position{{Line: 1, Column: 2}},
+			wantEnds:   []Position{{Line: 1, Column: 18}},
+		},
+		{
+			name:       "go batch separator",
+			sql:        "SELECT 1\nGO\nSELECT 2",
+			wantTexts:  []string{"SELECT 1", "\nGO\nSELECT 2"},
+			wantStarts: []Position{{Line: 1, Column: 1}, {Line: 3, Column: 1}},
+			wantEnds:   []Position{{Line: 1, Column: 9}, {Line: 3, Column: 9}},
+		},
+		{
+			name:       "empty statements skipped",
+			sql:        ";;SELECT 1",
+			wantTexts:  []string{";;SELECT 1"},
+			wantStarts: []Position{{Line: 1, Column: 3}},
+			wantEnds:   []Position{{Line: 1, Column: 11}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmts, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("Parse returned error: %v", err)
+			}
+			if len(stmts) != len(tt.wantTexts) {
+				t.Fatalf("statement count = %d, want %d: %#v", len(stmts), len(tt.wantTexts), stmts)
+			}
+			for i, stmt := range stmts {
+				if stmt.Text != tt.wantTexts[i] {
+					t.Fatalf("stmt[%d].Text = %q, want %q", i, stmt.Text, tt.wantTexts[i])
+				}
+				if stmt.ByteStart < 0 || stmt.ByteEnd < stmt.ByteStart || stmt.ByteEnd > len(tt.sql) {
+					t.Fatalf("stmt[%d] byte range invalid: %d:%d", i, stmt.ByteStart, stmt.ByteEnd)
+				}
+				if stmt.Text != tt.sql[stmt.ByteStart:stmt.ByteEnd] {
+					t.Fatalf("stmt[%d].Text does not match byte range %d:%d", i, stmt.ByteStart, stmt.ByteEnd)
+				}
+				if stmt.Start != tt.wantStarts[i] {
+					t.Fatalf("stmt[%d].Start = %+v, want %+v", i, stmt.Start, tt.wantStarts[i])
+				}
+				if stmt.End != tt.wantEnds[i] {
+					t.Fatalf("stmt[%d].End = %+v, want %+v", i, stmt.End, tt.wantEnds[i])
+				}
+			}
+		})
+	}
+}

--- a/mssql/parse.go
+++ b/mssql/parse.go
@@ -58,6 +58,9 @@ func Parse(sql string) ([]Statement, error) {
 		if item == nil {
 			continue
 		}
+		if _, ok := item.(*ast.GoStmt); ok {
+			continue
+		}
 
 		loc := nodeLoc(item)
 
@@ -78,10 +81,14 @@ func Parse(sql string) ([]Statement, error) {
 			end = j + 1
 		}
 
-		// Start position points to the first non-whitespace character.
-		contentStart := start
-		for contentStart < end && isSpace(sql[contentStart]) {
-			contentStart++
+		// Start position points to the AST node start, while Text preserves any
+		// preceding separators that belong to this statement segment.
+		contentStart := loc.Start
+		if contentStart < start || contentStart > end {
+			contentStart = start
+			for contentStart < end && isSpace(sql[contentStart]) {
+				contentStart++
+			}
 		}
 
 		stmts = append(stmts, Statement{

--- a/mssql/parser/SCENARIOS-mssql-loc-precision.md
+++ b/mssql/parser/SCENARIOS-mssql-loc-precision.md
@@ -1,0 +1,252 @@
+# MSSQL Loc Precision Scenarios
+
+> Goal: every AST node used for source extraction has a valid byte range whose slice is the complete original SQL fragment for that node.
+> Verification: parser tests compare `sql[Loc.Start:Loc.End]` with the exact expected fragment, and traversal guards assert valid child locations stay in range.
+> Status: [ ] pending, [x] covered by current precision tests, [~] partially covered by representative or statement-level tests.
+
+This matrix is stricter than `SCENARIOS-mssql-loc.md`: file-level migration from `p.pos()` to `p.prevEnd()` is not enough. A scenario only counts when the exact node slice is verified.
+
+---
+
+## Phase 1: Loc Access Contract
+
+### 1.1 AST Loc Helpers
+
+- [x] `Loc{Start: 1, End: 3}` is valid.
+- [x] `Loc{Start: 1, End: -1}` is invalid.
+- [x] Merging `{4,8}` with `{1,5}` returns `{1,8}`.
+- [x] `NodeLoc` returns `BinaryExpr.Loc`.
+- [x] `NodeLoc` returns `FuncCallExpr.Loc`.
+- [x] `NodeLoc` returns `ColumnRef.Loc`.
+- [x] `NodeLoc` returns `LikeExpr.Loc`.
+- [x] Every AST struct with a `Loc Loc` field is covered by `NodeLoc` either directly or through the generic Loc-field fallback.
+- [x] `SpanNodes` ignores nil and invalid nodes while spanning valid nodes.
+
+### 1.2 Universal Loc Invariants
+
+- [x] For every exact-slice scenario, `Loc.Start >= 0`.
+- [x] For every exact-slice scenario, `Loc.End >= 0`.
+- [x] For every exact-slice scenario, `Loc.Start <= Loc.End`.
+- [x] For every exact-slice scenario, `Loc.End <= len(sql)`.
+- [x] For every exact-slice scenario, each child node slice is contained inside its parent node slice.
+- [x] Leading whitespace before a statement is not included in the statement node slice.
+- [x] Trailing semicolon behavior is consistent across statement nodes.
+- [x] Multi-line source preserves byte offsets across newline boundaries.
+- [x] Unicode source keeps byte-offset columns, not rune columns.
+
+---
+
+## Phase 2: Core Expression Exact Slices
+
+### 2.1 Comparison And Predicate Expressions
+
+- [x] `SELECT c > 0` slices `BinaryExpr` as `c > 0`.
+- [x] `SELECT c IN (1, 2)` slices `InExpr` as `c IN (1, 2)`.
+- [x] `SELECT c BETWEEN 1 AND 2` slices `BetweenExpr` as `c BETWEEN 1 AND 2`.
+- [x] `SELECT c LIKE 'x%'` slices `LikeExpr` as `c LIKE 'x%'`.
+- [x] `SELECT c IS NOT NULL` slices `IsExpr` as `c IS NOT NULL`.
+- [x] `SELECT c NOT IN (1, 2)` slices `InExpr` as `c NOT IN (1, 2)`.
+- [x] `SELECT c NOT BETWEEN 1 AND 2` slices `BetweenExpr` as `c NOT BETWEEN 1 AND 2`.
+- [x] `SELECT c NOT LIKE 'x%' ESCAPE '\'` slices `LikeExpr` as `c NOT LIKE 'x%' ESCAPE '\'`.
+- [x] `SELECT * FROM t WHERE c = ANY (SELECT x FROM s)` slices `SubqueryComparisonExpr` as `c = ANY (SELECT x FROM s)`.
+- [x] `SELECT c IN (SELECT x FROM s)` slices `InExpr` as `c IN (SELECT x FROM s)`.
+
+### 2.2 Boolean And Arithmetic Expressions
+
+- [x] `SELECT a + b * c` slices the outer `BinaryExpr` as `a + b * c`.
+- [x] `SELECT (a = 1) AND (b = 2)` slices the outer `BinaryExpr` as `(a = 1) AND (b = 2)`.
+- [x] `SELECT a OR b AND c` slices the outer `BinaryExpr` as `a OR b AND c`.
+- [x] `SELECT a - b + c` slices the outer `BinaryExpr` as `a - b + c`.
+- [x] `SELECT a / b % c` slices the outer `BinaryExpr` as `a / b % c`.
+- [x] `SELECT -c` slices `UnaryExpr` as `-c`.
+- [x] `SELECT NOT (c > 0)` slices `UnaryExpr` as `NOT (c > 0)`.
+- [x] `SELECT (a + b)` slices `ParenExpr` as `(a + b)`.
+
+### 2.3 Postfix Expressions
+
+- [x] `SELECT name COLLATE Latin1_General_CI_AS LIKE 'A%'` slices `LikeExpr` as `name COLLATE Latin1_General_CI_AS LIKE 'A%'`.
+- [x] `SELECT dt AT TIME ZONE 'UTC'` slices `AtTimeZoneExpr` as `dt AT TIME ZONE 'UTC'`.
+- [x] `SELECT name COLLATE database_default` slices `CollateExpr` as `name COLLATE database_default`.
+- [x] `SELECT dt AT TIME ZONE 'UTC' AT TIME ZONE 'Pacific Standard Time'` slices the outer `AtTimeZoneExpr` as the full chain.
+
+### 2.4 Function And Built-in Expressions
+
+- [x] `SELECT SYSDATETIME()` slices `FuncCallExpr` as `SYSDATETIME()`.
+- [x] `SELECT COUNT(*)` slices `FuncCallExpr` as `COUNT(*)`.
+- [x] `SELECT STRING_AGG(name, ',') WITHIN GROUP (ORDER BY name)` slices `FuncCallExpr` as the full `WITHIN GROUP` call.
+- [x] `SELECT SUM(x) OVER (PARTITION BY y)` slices `FuncCallExpr` as the full windowed call.
+- [x] `SELECT COUNT(DISTINCT c)` slices `FuncCallExpr` as `COUNT(DISTINCT c)`.
+- [x] `SELECT CAST(c AS int)` slices `CastExpr` as `CAST(c AS int)`.
+- [x] `SELECT CONVERT(varchar(20), c, 126)` slices `ConvertExpr` as `CONVERT(varchar(20), c, 126)`.
+- [x] `SELECT TRY_CAST(c AS int)` slices `TryCastExpr` as `TRY_CAST(c AS int)`.
+- [x] `SELECT TRY_CONVERT(int, c)` slices `TryConvertExpr` as `TRY_CONVERT(int, c)`.
+- [x] `SELECT COALESCE(a, b, c)` slices `CoalesceExpr` as `COALESCE(a, b, c)`.
+- [x] `SELECT NULLIF(a, b)` slices `NullifExpr` as `NULLIF(a, b)`.
+- [x] `SELECT IIF(c > 0, 1, 0)` slices `IifExpr` as `IIF(c > 0, 1, 0)`.
+
+### 2.5 CASE, Subquery, And Specialty Expressions
+
+- [x] `SELECT CASE WHEN c > 0 THEN 1 ELSE 0 END` slices `CaseExpr` as the full CASE expression.
+- [x] In `CASE WHEN c > 0 THEN 1 END`, `CaseWhen` slices as `WHEN c > 0 THEN 1`.
+- [x] `SELECT EXISTS (SELECT 1 FROM t)` slices `ExistsExpr` as `EXISTS (SELECT 1 FROM t)`.
+- [x] `SELECT (SELECT 1)` slices `SubqueryExpr` as `(SELECT 1)`.
+- [x] `SELECT CURRENT OF cur` slices `CurrentOfExpr` as `CURRENT OF cur`.
+- [x] `SELECT geography::Point(1, 2, 4326)` slices `MethodCallExpr` as `geography::Point(1, 2, 4326)`.
+- [x] `GROUP BY GROUPING SETS ((a), (b))` slices `GroupingSetsExpr` as the full grouping sets expression.
+- [x] `GROUP BY ROLLUP (a, b)` slices `RollupExpr` as `ROLLUP (a, b)`.
+- [x] `GROUP BY CUBE (a, b)` slices `CubeExpr` as `CUBE (a, b)`.
+
+---
+
+## Phase 3: Names, References, And Types
+
+### 3.1 Column And Variable References
+
+- [x] `SELECT c` slices `ColumnRef` as `c`.
+- [x] `SELECT t.c` slices `ColumnRef` as `t.c`.
+- [x] `SELECT dbo.t.c` slices `ColumnRef` as `dbo.t.c`.
+- [x] `SELECT t.*` slices `StarExpr` as `t.*`.
+- [x] `SELECT db.dbo.t.c` slices `ColumnRef` as `db.dbo.t.c`.
+- [x] `SELECT server.db.dbo.t.c` slices `ColumnRef` as `server.db.dbo.t.c`.
+- [x] `SELECT @v` slices `VariableRef` as `@v`.
+- [x] `SELECT @@ROWCOUNT` slices `VariableRef` as `@@ROWCOUNT`.
+
+### 3.2 Table References
+
+- [x] `SELECT * FROM t` slices `TableRef` as `t`.
+- [x] `SELECT * FROM dbo.t` slices `TableRef` as `dbo.t`.
+- [x] `SELECT * FROM db.dbo.t` slices `TableRef` as `db.dbo.t`.
+- [x] `SELECT * FROM @t` slices `TableVarRef` as `@t`.
+- [x] `SELECT * FROM @x.nodes('/r') n(c)` slices `TableVarMethodCallRef` as `@x.nodes('/r') n(c)`.
+- [x] `SELECT * FROM t AS x` slices `TableRef` as `t AS x`.
+- [x] `SELECT * FROM OPENROWSET(...)` slices table-valued `FuncCallExpr` or rowset table ref as the full rowset function.
+
+### 3.3 Data Types
+
+- [x] `CREATE TABLE t (c int)` slices `DataType` as `int`.
+- [x] `CREATE TABLE t (c varchar(50))` slices `DataType` as `varchar(50)`.
+- [x] `CREATE TABLE t (c decimal(10, 2))` slices `DataType` as `decimal(10, 2)`.
+- [x] `CREATE TABLE t (c nvarchar(max))` slices `DataType` as `nvarchar(max)`.
+- [x] `CREATE TABLE t (c dbo.MyType)` slices `DataType` as `dbo.MyType`.
+
+---
+
+## Phase 4: CREATE TABLE Metadata Extraction
+
+### 4.1 Column Definitions
+
+- [x] `CREATE TABLE t (c int)` slices `ColumnDef` as `c int`.
+- [x] `CREATE TABLE t (c int NULL)` slices `NullableSpec` as `NULL`.
+- [x] `CREATE TABLE t (c int NOT NULL)` slices `NullableSpec` as `NOT NULL`.
+- [x] `CREATE TABLE t (id int IDENTITY(1,1))` slices `IdentitySpec` as `IDENTITY(1,1)`.
+- [x] `CREATE TABLE t (c AS (a + b))` slices `ComputedColumnDef.Expr` as `a + b`.
+- [x] `CREATE TABLE t (c AS (a + b) PERSISTED)` slices `ComputedColumnDef` as `AS (a + b) PERSISTED`.
+
+### 4.2 DEFAULT And CHECK Constraints
+
+- [x] `CREATE TABLE t (d datetime2 DEFAULT SYSDATETIME())` slices default `FuncCallExpr` as `SYSDATETIME()`.
+- [x] `CREATE TABLE t (e int DEFAULT dbo.f())` slices default `FuncCallExpr` as `dbo.f()`.
+- [x] `CREATE TABLE t (c int DEFAULT COUNT(*))` slices default `FuncCallExpr` as `COUNT(*)`.
+- [x] `CREATE TABLE t (c int, CONSTRAINT ck CHECK (c > 0))` slices CHECK expression as `c > 0`.
+- [x] `CREATE TABLE t (c int CHECK (c IN (1, 2)))` slices CHECK expression as `c IN (1, 2)`.
+- [x] `CREATE TABLE t (c int CONSTRAINT df DEFAULT (0))` slices `ConstraintDef.Expr` as `0`.
+- [x] `CREATE TABLE t (c int CONSTRAINT ck CHECK (c BETWEEN 1 AND 10))` slices `ConstraintDef.Expr` as `c BETWEEN 1 AND 10`.
+
+### 4.3 Table Constraints And Options
+
+- [x] Primary key constraint slices `ConstraintDef` as the full `CONSTRAINT ... PRIMARY KEY (...)` fragment.
+- [x] Unique constraint slices `ConstraintDef` as the full `CONSTRAINT ... UNIQUE (...)` fragment.
+- [x] Foreign key constraint slices `ConstraintDef` as the full `FOREIGN KEY ... REFERENCES ...` fragment.
+- [x] Edge constraint slices `ConstraintDef` as the full edge constraint fragment.
+- [x] Memory optimized table option slices `TableOption` as `MEMORY_OPTIMIZED = ON`.
+- [x] System versioning option slices `TableOption` as the full `SYSTEM_VERSIONING = ON (...)` fragment.
+- [x] Inline index slices `InlineIndexDef` as the full `INDEX ...` fragment.
+- [x] Inline index column slices `IndexColumn` as the full column item.
+
+---
+
+## Phase 5: Index, Spatial, Fulltext, And Search Metadata
+
+### 5.1 Index Definitions
+
+- [x] `CREATE INDEX ix ON t (c)` slices `CreateIndexStmt` as the full statement.
+- [x] `CREATE INDEX ix ON t (c DESC)` slices `IndexColumn` as `c DESC`.
+- [x] `CREATE INDEX ix ON t (c) INCLUDE (d)` slices included `IndexColumn` as `d`.
+- [x] `CREATE INDEX ix ON t (c) WHERE c > 0` slices filter predicate as `c > 0`.
+- [x] `CREATE INDEX ix ON t (c) WITH (FILLFACTOR = 90)` preserves exact option text.
+- [x] `ALTER INDEX ix ON t REBUILD WITH (ONLINE = ON)` preserves exact option text.
+
+### 5.2 Spatial Index Definitions
+
+- [x] `CREATE SPATIAL INDEX ... WITH (BOUNDING_BOX = (...))` preserves `BOUNDING_BOX=(...)`.
+- [x] `CREATE SPATIAL INDEX ... WITH (GRIDS = (...))` preserves `GRIDS=(...)`.
+- [x] `CREATE SPATIAL INDEX ... WITH (CELLS_PER_OBJECT = 16)` preserves `CELLS_PER_OBJECT=16`.
+- [x] Spatial index column expression slices as the geometry/geography column reference.
+- [x] Spatial index `USING GEOMETRY_GRID` slices the tessellation scheme correctly.
+- [x] Spatial index `USING GEOGRAPHY_AUTO_GRID` slices the tessellation scheme correctly.
+
+### 5.3 Fulltext And Search
+
+- [x] `CREATE FULLTEXT INDEX ON t(c) KEY INDEX pk` slices `CreateFulltextIndexStmt` as the full statement.
+- [x] Fulltext indexed column slices as the full column item.
+- [x] `CONTAINS(c, 'term')` slices `FullTextPredicate` as `CONTAINS(c, 'term')`.
+- [x] `FREETEXT(c, 'term')` slices `FullTextPredicate` as `FREETEXT(c, 'term')`.
+- [x] `CONTAINSTABLE(t, c, 'term')` slices `FullTextTableRef` as the full table-valued search function.
+- [x] `SEMANTICSIMILARITYTABLE(t, c, source_key)` slices `SemanticTableRef` as the full table-valued semantic function.
+
+---
+
+## Phase 6: SELECT And DML Clause Extraction
+
+### 6.1 SELECT Clauses
+
+- [x] `SELECT a AS x` slices `ResTarget` as `a AS x`.
+- [x] `SELECT @v = a` slices `SelectAssign` as `@v = a`.
+- [x] `SELECT TOP (10) a FROM t` slices `TopClause` as `TOP (10)`.
+- [x] `SELECT a FROM t WHERE a > 0` slices `WhereClause` expression as `a > 0`.
+- [x] `SELECT a FROM t ORDER BY a DESC` slices `OrderByItem` as `a DESC`.
+- [x] `SELECT a FROM t OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY` slices `FetchClause` as `FETCH NEXT 5 ROWS ONLY`.
+- [x] `SELECT a FROM t FOR XML PATH` slices `ForClause` as `FOR XML PATH`.
+- [x] `WITH cte AS (SELECT 1) SELECT * FROM cte` slices `CommonTableExpr` as `cte AS (SELECT 1)`.
+- [x] `WITH XMLNAMESPACES (...) SELECT ...` slices `XmlNamespaceDecl` as the full namespace declaration.
+
+### 6.2 JOIN, WINDOW, GROUPING
+
+- [x] `SELECT * FROM a JOIN b ON a.id = b.id` slices `JoinClause` as `a JOIN b ON a.id = b.id`.
+- [x] `SELECT * FROM a CROSS APPLY fn(a.id)` slices `JoinClause` as `a CROSS APPLY fn(a.id)`.
+- [x] `SELECT SUM(x) OVER (PARTITION BY y ORDER BY z ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)` slices `OverClause` as the full OVER clause.
+- [x] Window frame slices `WindowFrame` as `ROWS BETWEEN 1 PRECEDING AND CURRENT ROW`.
+- [x] Window bound slices `WindowBound` as `1 PRECEDING`.
+- [x] Named window definition slices `WindowDef` as the full `WINDOW name AS (...)` fragment.
+
+### 6.3 INSERT, UPDATE, DELETE, MERGE
+
+- [x] `INSERT INTO t (a) VALUES (1)` slices `InsertStmt` as the full statement.
+- [x] `VALUES (1), (2)` slices `ValuesClause` as the full values fragment.
+- [x] `UPDATE t SET a = 1 WHERE b = 2` slices `UpdateStmt` as the full statement.
+- [x] `DELETE FROM t WHERE a = 1` slices `DeleteStmt` as the full statement.
+- [x] `OUTPUT inserted.a INTO audit` slices `OutputClause` as the full OUTPUT fragment.
+- [x] `MERGE ... WHEN MATCHED THEN UPDATE ...` slices each `MergeWhenClause` as its full WHEN clause.
+- [x] `MergeUpdateAction` slices as the full update action.
+- [x] `MergeInsertAction` slices as the full insert action.
+- [x] `MergeDeleteAction` slices as `DELETE`.
+
+---
+
+## Phase 7: Top-Level Statement And Public API Exactness
+
+### 7.1 Statement Ranges
+
+- [x] Every DML statement scenario has a valid top-level statement Loc.
+- [x] Every DDL statement scenario has a valid top-level statement Loc.
+- [x] Every security/admin statement scenario has a valid top-level statement Loc.
+- [x] Multi-statement SQL produces non-overlapping statement ranges.
+- [x] `GO` batch separators do not corrupt following statement ranges.
+- [x] Empty statements between semicolons do not produce invalid Loc for real statements.
+
+### 7.2 Public API Ranges
+
+- [x] Public `mssql.Parse` returns `Statement.Text` matching `sql[ByteStart:ByteEnd]`.
+- [x] Public `mssql.Parse` returns line/column start matching `ByteStart`.
+- [x] Public `mssql.Parse` returns line/column end matching `ByteEnd`.
+- [x] Public `mssql.Parse` keeps byte-based columns for tabs and Unicode content.

--- a/mssql/parser/alter_objects.go
+++ b/mssql/parser/alter_objects.go
@@ -1079,20 +1079,7 @@ func (p *Parser) parseAlterIndexOptions() (*nodes.List, error) {
 					p.advance()
 				} else if p.cur.Type == '(' {
 					// Nested parenthesized value like BOUNDING_BOX = (0, 0, 100, 100)
-					depth := 1
-					p.advance() // consume '('
-					for depth > 0 && p.cur.Type != tokEOF {
-						if p.cur.Type == '(' {
-							depth++
-						} else if p.cur.Type == ')' {
-							depth--
-							if depth == 0 {
-								p.advance()
-								break
-							}
-						}
-						p.advance()
-					}
+					val = p.consumeBalancedValueText()
 				}
 				opts.Items = append(opts.Items, &nodes.String{Str: name + "=" + val})
 			} else {
@@ -1140,4 +1127,23 @@ func (p *Parser) parseAlterIndexOptions() (*nodes.List, error) {
 
 	p.match(')') // consume ')'
 	return opts, nil
+}
+
+func (p *Parser) consumeBalancedValueText() string {
+	start := p.pos()
+	depth := 0
+	for p.cur.Type != tokEOF {
+		if p.cur.Type == '(' {
+			depth++
+		} else if p.cur.Type == ')' {
+			depth--
+			p.advance()
+			if depth == 0 {
+				return strings.TrimSpace(p.source[start:p.prevEnd()])
+			}
+			continue
+		}
+		p.advance()
+	}
+	return strings.TrimSpace(p.source[start:p.prevEnd()])
 }

--- a/mssql/parser/create_index.go
+++ b/mssql/parser/create_index.go
@@ -99,7 +99,7 @@ func (p *Parser) parseCreateIndexStmt(unique bool) (*nodes.CreateIndexStmt, erro
 		p.advance()
 		if p.cur.Type == '(' {
 			var err error
-			stmt.IncludeCols, err = p.parseParenIdentList()
+			stmt.IncludeCols, err = p.parseIndexColumnList()
 			if err != nil {
 				return nil, err
 			}
@@ -195,7 +195,7 @@ func (p *Parser) parseIndexColumnList() (*nodes.List, error) {
 		return &nodes.IndexColumn{
 			Name:    name,
 			SortDir: dir,
-			Loc:     nodes.Loc{Start: loc, End: -1},
+			Loc:     nodes.Loc{Start: loc, End: p.prevEnd()},
 		}, nil
 	})
 	if err != nil {
@@ -399,8 +399,13 @@ func (p *Parser) parseCreateSpatialIndexStmt() (*nodes.CreateSpatialIndexStmt, e
 	// (spatial_column)
 	if p.cur.Type == '(' {
 		p.advance()
+		colLoc := p.pos()
 		col, _ := p.parseIdentifier()
 		stmt.SpatialColumn = col
+		stmt.SpatialColumnRef = &nodes.ColumnRef{
+			Column: col,
+			Loc:    nodes.Loc{Start: colLoc, End: p.prevEnd()},
+		}
 		p.match(')')
 	}
 
@@ -423,7 +428,7 @@ func (p *Parser) parseCreateSpatialIndexStmt() (*nodes.CreateSpatialIndexStmt, e
 
 	// ON filegroup
 	if _, ok := p.match(kwON); ok {
-		if (p.isIdentLike() || p.cur.Type == kwPRIMARY) {
+		if p.isIdentLike() || p.cur.Type == kwPRIMARY {
 			stmt.OnFileGroup = p.cur.Str
 			p.advance()
 		}
@@ -651,7 +656,7 @@ func (p *Parser) parseCreateJsonIndexStmt() (*nodes.CreateJsonIndexStmt, error) 
 
 	// ON filegroup
 	if _, ok := p.match(kwON); ok {
-		if (p.isIdentLike() || p.cur.Type == kwPRIMARY) {
+		if p.isIdentLike() || p.cur.Type == kwPRIMARY {
 			stmt.OnFileGroup = p.cur.Str
 			p.advance()
 		}
@@ -715,7 +720,7 @@ func (p *Parser) parseCreateVectorIndexStmt() (*nodes.CreateVectorIndexStmt, err
 
 	// ON filegroup
 	if _, ok := p.match(kwON); ok {
-		if (p.isIdentLike() || p.cur.Type == kwPRIMARY) {
+		if p.isIdentLike() || p.cur.Type == kwPRIMARY {
 			stmt.OnFileGroup = p.cur.Str
 			p.advance()
 		}

--- a/mssql/parser/create_table.go
+++ b/mssql/parser/create_table.go
@@ -485,8 +485,8 @@ func (p *Parser) parseColumnDef() (*nodes.ColumnDef, error) {
 
 	// Check for computed column: name AS expr [ PERSISTED [ NOT NULL ] ]
 	if p.cur.Type == kwAS {
-		p.advance()
 		compLoc := p.pos()
+		p.advance()
 		expr, err := p.parseExpr()
 		if err != nil {
 			return nil, err
@@ -507,7 +507,7 @@ func (p *Parser) parseColumnDef() (*nodes.ColumnDef, error) {
 			Expr:      expr,
 			Persisted: persisted,
 			NotNull:   notNull,
-			Loc:       nodes.Loc{Start: compLoc, End: -1},
+			Loc:       nodes.Loc{Start: compLoc, End: p.prevEnd()},
 		}
 		// Computed columns can also have column constraints (PK, UNIQUE, etc.)
 		for p.cur.Type == kwCONSTRAINT || p.cur.Type == kwPRIMARY || p.cur.Type == kwUNIQUE ||
@@ -666,9 +666,10 @@ func (p *Parser) parseColumnDef() (*nodes.ColumnDef, error) {
 		if p.cur.Type == kwNOT {
 			next := p.peekNext()
 			if next.Type == kwNULL {
+				nullLoc := p.pos()
 				p.advance() // NOT
 				p.advance() // NULL
-				col.Nullable = &nodes.NullableSpec{NotNull: true, Loc: nodes.Loc{Start: p.pos(), End: -1}}
+				col.Nullable = &nodes.NullableSpec{NotNull: true, Loc: nodes.Loc{Start: nullLoc, End: p.prevEnd()}}
 				consumed = true
 			} else if next.Type == kwFOR {
 				p.advance() // NOT
@@ -683,8 +684,9 @@ func (p *Parser) parseColumnDef() (*nodes.ColumnDef, error) {
 
 		// NULL
 		if p.cur.Type == kwNULL {
+			nullLoc := p.pos()
 			p.advance()
-			col.Nullable = &nodes.NullableSpec{NotNull: false, Loc: nodes.Loc{Start: p.pos(), End: -1}}
+			col.Nullable = &nodes.NullableSpec{NotNull: false, Loc: nodes.Loc{Start: nullLoc, End: p.prevEnd()}}
 			consumed = true
 		}
 

--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -16,6 +16,14 @@ func (p *Parser) parseExpr() (nodes.ExprNode, error) {
 	return p.parseOr()
 }
 
+func exprLocStart(expr nodes.ExprNode, fallback int) int {
+	loc := nodes.NodeLoc(expr)
+	if loc.Start >= 0 {
+		return loc.Start
+	}
+	return fallback
+}
+
 // parseOr parses OR expressions (lowest precedence).
 //
 //	or_expr = and_expr { OR and_expr }
@@ -44,7 +52,7 @@ func (p *Parser) parseOr() (nodes.ExprNode, error) {
 			Op:    nodes.BinOpOr,
 			Left:  left,
 			Right: right,
-			Loc:   nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:   nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}
 	}
 	return left, nil
@@ -78,7 +86,7 @@ func (p *Parser) parseAnd() (nodes.ExprNode, error) {
 			Op:    nodes.BinOpAnd,
 			Left:  left,
 			Right: right,
-			Loc:   nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:   nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}
 	}
 	return left, nil
@@ -163,7 +171,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 			return &nodes.IsExpr{
 				Expr:     left,
 				TestType: testType,
-				Loc:      nodes.Loc{Start: loc, End: p.prevEnd()},
+				Loc:      nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 			}, nil
 		}
 	}
@@ -211,7 +219,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 			Low:  low,
 			High: high,
 			Not:  not,
-			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:  nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}, nil
 	}
 
@@ -245,7 +253,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 				Expr:     left,
 				Subquery: &nodes.SubqueryExpr{Query: sub, Loc: nodes.Loc{Start: loc, End: p.prevEnd()}},
 				Not:      not,
-				Loc:      nodes.Loc{Start: loc, End: p.prevEnd()},
+				Loc:      nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 			}, nil
 		}
 		items, err := p.parseCommaList(')', commaListStrict, func() (nodes.Node, error) {
@@ -274,7 +282,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 			Expr: left,
 			List: &nodes.List{Items: items},
 			Not:  not,
-			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:  nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}, nil
 	}
 
@@ -313,7 +321,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 			Pattern: pattern,
 			Escape:  escape,
 			Not:     not,
-			Loc:     nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:     nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}, nil
 	}
 
@@ -346,7 +354,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 					Op:         op,
 					Quantifier: quantifier,
 					Subquery:   subquery,
-					Loc:        nodes.Loc{Start: loc, End: p.prevEnd()},
+					Loc:        nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 				}, nil
 			}
 		}
@@ -362,7 +370,7 @@ func (p *Parser) parseComparison() (nodes.ExprNode, error) {
 			Op:    op,
 			Left:  left,
 			Right: right,
-			Loc:   nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:   nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}, nil
 	}
 
@@ -433,7 +441,7 @@ func (p *Parser) parseAddition() (nodes.ExprNode, error) {
 			Op:    op,
 			Left:  left,
 			Right: right,
-			Loc:   nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:   nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}
 	}
 	// Postfix COLLATE / AT TIME ZONE (may be chained)
@@ -480,7 +488,7 @@ func (p *Parser) parseCollateExpr(expr nodes.ExprNode) (nodes.ExprNode, error) {
 	node := &nodes.CollateExpr{
 		Expr:      expr,
 		Collation: collation,
-		Loc:       nodes.Loc{Start: loc, End: p.prevEnd()},
+		Loc:       nodes.Loc{Start: exprLocStart(expr, loc), End: p.prevEnd()},
 	}
 	node.Loc.End = p.prevEnd()
 	return node, nil
@@ -515,7 +523,7 @@ func (p *Parser) parseAtTimeZoneExpr(expr nodes.ExprNode) (nodes.ExprNode, error
 	node := &nodes.AtTimeZoneExpr{
 		Expr:     expr,
 		TimeZone: tz,
-		Loc:      nodes.Loc{Start: loc, End: p.prevEnd()},
+		Loc:      nodes.Loc{Start: exprLocStart(expr, loc), End: p.prevEnd()},
 	}
 	node.Loc.End = p.prevEnd()
 	return node, nil
@@ -557,7 +565,7 @@ func (p *Parser) parseMultiplication() (nodes.ExprNode, error) {
 			Op:    op,
 			Left:  left,
 			Right: right,
-			Loc:   nodes.Loc{Start: loc, End: p.prevEnd()},
+			Loc:   nodes.Loc{Start: exprLocStart(left, loc), End: p.prevEnd()},
 		}
 	}
 	return left, nil
@@ -1243,11 +1251,12 @@ func (p *Parser) parseNextValueFor() (nodes.ExprNode, error) {
 //
 //	func_name '(' [DISTINCT] [expr_list | '*'] ')' [OVER ...]
 func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
+	nameEnd := p.prevEnd()
 	p.advance() // consume (
 
 	fc := &nodes.FuncCallExpr{
-		Name: &nodes.TableRef{Object: name, Loc: nodes.Loc{Start: loc, End: p.prevEnd()}},
-		Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
+		Name: &nodes.TableRef{Object: name, Loc: nodes.Loc{Start: loc, End: nameEnd}},
+		Loc:  nodes.Loc{Start: loc, End: -1},
 	}
 
 	// COUNT(*) special case
@@ -1255,12 +1264,14 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 		p.advance()
 		fc.Star = true
 		_, _ = p.expect(')')
+		fc.Loc.End = p.prevEnd()
 		if p.cur.Type == kwOVER {
 			var err error
 			fc.Over, err = p.parseOverClause()
 			if err != nil {
 				return nil, err
 			}
+			fc.Loc.End = p.prevEnd()
 		}
 		return fc, nil
 	}
@@ -1272,12 +1283,14 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 
 	if p.cur.Type == ')' {
 		p.advance()
+		fc.Loc.End = p.prevEnd()
 		if p.cur.Type == kwOVER {
 			var err error
 			fc.Over, err = p.parseOverClause()
 			if err != nil {
 				return nil, err
 			}
+			fc.Loc.End = p.prevEnd()
 		}
 		return fc, nil
 	}
@@ -1309,6 +1322,7 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
+	fc.Loc.End = p.prevEnd()
 
 	// Check for WITHIN GROUP (ORDER BY ...) clause
 	//
@@ -1321,6 +1335,7 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 		if err != nil {
 			return nil, err
 		}
+		fc.Loc.End = p.prevEnd()
 	}
 
 	// Check for OVER clause
@@ -1330,6 +1345,7 @@ func (p *Parser) parseFuncCall(name string, loc int) (nodes.ExprNode, error) {
 		if err != nil {
 			return nil, err
 		}
+		fc.Loc.End = p.prevEnd()
 	}
 
 	return fc, nil
@@ -1361,6 +1377,7 @@ func (p *Parser) parseWithinGroupClause() (*nodes.List, error) {
 
 	var orders []nodes.Node
 	for {
+		oloc := p.pos()
 		expr, err := p.parseExpr()
 		if err != nil {
 			return nil, err
@@ -1374,7 +1391,7 @@ func (p *Parser) parseWithinGroupClause() (*nodes.List, error) {
 		orders = append(orders, &nodes.OrderByItem{
 			Expr:    expr,
 			SortDir: dir,
-			Loc:     nodes.Loc{Start: p.pos(), End: p.prevEnd()},
+			Loc:     nodes.Loc{Start: oloc, End: p.prevEnd()},
 		})
 		if _, ok := p.match(','); !ok {
 			break
@@ -1485,6 +1502,7 @@ func (p *Parser) parseOverClause() (*nodes.OverClause, error) {
 		}
 		var orders []nodes.Node
 		for {
+			oloc := p.pos()
 			expr, err := p.parseExpr()
 			if err != nil {
 				return nil, err
@@ -1498,7 +1516,7 @@ func (p *Parser) parseOverClause() (*nodes.OverClause, error) {
 			orders = append(orders, &nodes.OrderByItem{
 				Expr:    expr,
 				SortDir: dir,
-				Loc:     nodes.Loc{Start: p.pos(), End: p.prevEnd()},
+				Loc:     nodes.Loc{Start: oloc, End: p.prevEnd()},
 			})
 			if _, ok := p.match(','); !ok {
 				break
@@ -1516,8 +1534,8 @@ func (p *Parser) parseOverClause() (*nodes.OverClause, error) {
 		}
 	}
 
-	over.Loc.End = p.prevEnd()
 	_, _ = p.expect(')')
+	over.Loc.End = p.prevEnd()
 	return over, nil
 }
 

--- a/mssql/parser/fulltext.go
+++ b/mssql/parser/fulltext.go
@@ -60,7 +60,7 @@ func (p *Parser) parseCreateFulltextIndexStmt() (*nodes.CreateFulltextIndexStmt,
 
 	// ON table_name
 	if _, ok := p.match(kwON); ok {
-		stmt.Table , _ = p.parseTableRef()
+		stmt.Table, _ = p.parseTableRef()
 	}
 
 	// Column list
@@ -69,8 +69,13 @@ func (p *Parser) parseCreateFulltextIndexStmt() (*nodes.CreateFulltextIndexStmt,
 		var cols []nodes.Node
 		for p.cur.Type != ')' && p.cur.Type != tokEOF {
 			if p.isIdentLike() {
+				colLoc := p.pos()
 				col := p.cur.Str
 				p.advance()
+				colRef := &nodes.ColumnRef{
+					Column: col,
+					Loc:    nodes.Loc{Start: colLoc, End: p.prevEnd()},
+				}
 				// TYPE COLUMN type_col_name
 				if p.cur.Type == kwTYPE {
 					p.advance()
@@ -92,7 +97,7 @@ func (p *Parser) parseCreateFulltextIndexStmt() (*nodes.CreateFulltextIndexStmt,
 				if p.cur.Type == kwSTATISTICAL_SEMANTICS {
 					p.advance()
 				}
-				cols = append(cols, &nodes.String{Str: col})
+				cols = append(cols, colRef)
 			}
 			if _, ok := p.match(','); !ok {
 				break
@@ -223,7 +228,7 @@ func (p *Parser) parseAlterFulltextIndexStmt() (*nodes.AlterFulltextIndexStmt, e
 
 	// ON table_name
 	if _, ok := p.match(kwON); ok {
-		stmt.Table , _ = p.parseTableRef()
+		stmt.Table, _ = p.parseTableRef()
 	}
 
 	// Action dispatch

--- a/mssql/parser/loc_precision_matrix_test.go
+++ b/mssql/parser/loc_precision_matrix_test.go
@@ -1,0 +1,338 @@
+package parser
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mssql/ast"
+)
+
+type locMatrixCase struct {
+	name     string
+	sql      string
+	typeName string
+	index    int
+	want     string
+}
+
+var locPrecisionMatrixExactSliceCases = []locMatrixCase{
+	// Universal statement/source invariants.
+	{name: "leading whitespace select stmt", sql: "  \n\tSELECT 1", typeName: "SelectStmt", want: "SELECT 1"},
+	{name: "statement semicolon excluded from ast loc", sql: "SELECT 1;", typeName: "SelectStmt", want: "SELECT 1"},
+	{name: "multiline select stmt", sql: "SELECT\n  1", typeName: "SelectStmt", want: "SELECT\n  1"},
+	{name: "unicode byte range select stmt", sql: "SELECT N'你好'", typeName: "SelectStmt", want: "SELECT N'你好'"},
+
+	// Comparison and predicates.
+	{name: "not in", sql: "SELECT c NOT IN (1, 2)", typeName: "InExpr", want: "c NOT IN (1, 2)"},
+	{name: "not between", sql: "SELECT c NOT BETWEEN 1 AND 2", typeName: "BetweenExpr", want: "c NOT BETWEEN 1 AND 2"},
+	{name: "not like escape", sql: "SELECT c NOT LIKE 'x%' ESCAPE '\\'", typeName: "LikeExpr", want: "c NOT LIKE 'x%' ESCAPE '\\'"},
+	{name: "equals any subquery", sql: "SELECT * FROM t WHERE c = ANY (SELECT x FROM s)", typeName: "SubqueryComparisonExpr", want: "c = ANY (SELECT x FROM s)"},
+	{name: "in subquery", sql: "SELECT c IN (SELECT x FROM s)", typeName: "InExpr", want: "c IN (SELECT x FROM s)"},
+
+	// Boolean and arithmetic.
+	{name: "or and precedence", sql: "SELECT a OR b AND c", typeName: "BinaryExpr", want: "a OR b AND c"},
+	{name: "add subtract chain", sql: "SELECT a - b + c", typeName: "BinaryExpr", want: "a - b + c"},
+	{name: "divide modulo chain", sql: "SELECT a / b % c", typeName: "BinaryExpr", want: "a / b % c"},
+	{name: "unary minus", sql: "SELECT -c", typeName: "UnaryExpr", want: "-c"},
+	{name: "unary not", sql: "SELECT NOT (c > 0)", typeName: "UnaryExpr", want: "NOT (c > 0)"},
+	{name: "paren expr", sql: "SELECT (a + b)", typeName: "ParenExpr", want: "(a + b)"},
+
+	// Postfix expressions.
+	{name: "collate database_default", sql: "SELECT name COLLATE database_default", typeName: "CollateExpr", want: "name COLLATE database_default"},
+	{name: "at time zone chain", sql: "SELECT dt AT TIME ZONE 'UTC' AT TIME ZONE 'Pacific Standard Time'", typeName: "AtTimeZoneExpr", want: "dt AT TIME ZONE 'UTC' AT TIME ZONE 'Pacific Standard Time'"},
+
+	// Functions and built-ins.
+	{name: "count distinct", sql: "SELECT COUNT(DISTINCT c)", typeName: "FuncCallExpr", want: "COUNT(DISTINCT c)"},
+	{name: "cast", sql: "SELECT CAST(c AS int)", typeName: "CastExpr", want: "CAST(c AS int)"},
+	{name: "convert", sql: "SELECT CONVERT(varchar(20), c, 126)", typeName: "ConvertExpr", want: "CONVERT(varchar(20), c, 126)"},
+	{name: "try cast", sql: "SELECT TRY_CAST(c AS int)", typeName: "TryCastExpr", want: "TRY_CAST(c AS int)"},
+	{name: "try convert", sql: "SELECT TRY_CONVERT(int, c)", typeName: "TryConvertExpr", want: "TRY_CONVERT(int, c)"},
+	{name: "coalesce", sql: "SELECT COALESCE(a, b, c)", typeName: "CoalesceExpr", want: "COALESCE(a, b, c)"},
+	{name: "nullif", sql: "SELECT NULLIF(a, b)", typeName: "NullifExpr", want: "NULLIF(a, b)"},
+	{name: "iif", sql: "SELECT IIF(c > 0, 1, 0)", typeName: "IifExpr", want: "IIF(c > 0, 1, 0)"},
+
+	// CASE, subquery, and specialty expressions.
+	{name: "case expr", sql: "SELECT CASE WHEN c > 0 THEN 1 ELSE 0 END", typeName: "CaseExpr", want: "CASE WHEN c > 0 THEN 1 ELSE 0 END"},
+	{name: "case when", sql: "SELECT CASE WHEN c > 0 THEN 1 END", typeName: "CaseWhen", want: "WHEN c > 0 THEN 1"},
+	{name: "exists", sql: "SELECT * FROM t WHERE EXISTS (SELECT 1 FROM s)", typeName: "ExistsExpr", want: "EXISTS (SELECT 1 FROM s)"},
+	{name: "scalar subquery", sql: "SELECT (SELECT 1)", typeName: "SubqueryExpr", want: "(SELECT 1)"},
+	{name: "current of", sql: "DELETE FROM t WHERE CURRENT OF cur", typeName: "CurrentOfExpr", want: "CURRENT OF cur"},
+	{name: "method call", sql: "SELECT geography::Point(1, 2, 4326)", typeName: "MethodCallExpr", want: "geography::Point(1, 2, 4326)"},
+	{name: "grouping sets", sql: "SELECT SUM(c) FROM t GROUP BY GROUPING SETS ((a), (b))", typeName: "GroupingSetsExpr", want: "GROUPING SETS ((a), (b))"},
+	{name: "rollup", sql: "SELECT SUM(c) FROM t GROUP BY ROLLUP (a, b)", typeName: "RollupExpr", want: "ROLLUP (a, b)"},
+	{name: "cube", sql: "SELECT SUM(c) FROM t GROUP BY CUBE (a, b)", typeName: "CubeExpr", want: "CUBE (a, b)"},
+
+	// Column and variable references.
+	{name: "four part column", sql: "SELECT db.dbo.t.c", typeName: "ColumnRef", want: "db.dbo.t.c"},
+	{name: "five part column", sql: "SELECT server.db.dbo.t.c", typeName: "ColumnRef", want: "server.db.dbo.t.c"},
+	{name: "variable ref", sql: "SELECT @v", typeName: "VariableRef", want: "@v"},
+	{name: "system variable ref", sql: "SELECT @@ROWCOUNT", typeName: "VariableRef", want: "@@ROWCOUNT"},
+
+	// Table references.
+	{name: "table ref", sql: "SELECT * FROM t", typeName: "TableRef", want: "t"},
+	{name: "schema table ref", sql: "SELECT * FROM dbo.t", typeName: "TableRef", want: "dbo.t"},
+	{name: "database schema table ref", sql: "SELECT * FROM db.dbo.t", typeName: "TableRef", want: "db.dbo.t"},
+	{name: "table variable ref", sql: "SELECT * FROM @t", typeName: "TableVarRef", want: "@t"},
+	{name: "table variable method ref", sql: "SELECT * FROM @x.nodes('/r') n(c)", typeName: "TableVarMethodCallRef", want: "@x.nodes('/r') n(c)"},
+	{name: "aliased table ref", sql: "SELECT * FROM t AS x", typeName: "TableRef", want: "t AS x"},
+	{name: "openrowset table func", sql: "SELECT * FROM OPENROWSET('SQLNCLI', 'server=srv', 'SELECT 1') AS r", typeName: "FuncCallExpr", want: "OPENROWSET('SQLNCLI', 'server=srv', 'SELECT 1')"},
+
+	// Data types.
+	{name: "datatype int", sql: "CREATE TABLE t (c int)", typeName: "DataType", want: "int"},
+	{name: "datatype varchar length", sql: "CREATE TABLE t (c varchar(50))", typeName: "DataType", want: "varchar(50)"},
+	{name: "datatype decimal", sql: "CREATE TABLE t (c decimal(10, 2))", typeName: "DataType", want: "decimal(10, 2)"},
+	{name: "datatype nvarchar max", sql: "CREATE TABLE t (c nvarchar(max))", typeName: "DataType", want: "nvarchar(max)"},
+	{name: "datatype schema type", sql: "CREATE TABLE t (c dbo.MyType)", typeName: "DataType", want: "dbo.MyType"},
+
+	// CREATE TABLE metadata.
+	{name: "column def", sql: "CREATE TABLE t (c int)", typeName: "ColumnDef", want: "c int"},
+	{name: "nullable null", sql: "CREATE TABLE t (c int NULL)", typeName: "NullableSpec", want: "NULL"},
+	{name: "nullable not null", sql: "CREATE TABLE t (c int NOT NULL)", typeName: "NullableSpec", want: "NOT NULL"},
+	{name: "identity", sql: "CREATE TABLE t (id int IDENTITY(1,1))", typeName: "IdentitySpec", want: "IDENTITY(1,1)"},
+	{name: "computed expr", sql: "CREATE TABLE t (c AS (a + b))", typeName: "BinaryExpr", want: "a + b"},
+	{name: "computed def persisted", sql: "CREATE TABLE t (c AS (a + b) PERSISTED)", typeName: "ComputedColumnDef", want: "AS (a + b) PERSISTED"},
+	{name: "default constraint expr", sql: "CREATE TABLE t (c int CONSTRAINT df DEFAULT (0))", typeName: "Literal", want: "0"},
+	{name: "check constraint between expr", sql: "CREATE TABLE t (c int CONSTRAINT ck CHECK (c BETWEEN 1 AND 10))", typeName: "BetweenExpr", want: "c BETWEEN 1 AND 10"},
+	{name: "primary key constraint", sql: "CREATE TABLE t (c int, CONSTRAINT pk PRIMARY KEY (c))", typeName: "ConstraintDef", want: "CONSTRAINT pk PRIMARY KEY (c)"},
+	{name: "unique constraint", sql: "CREATE TABLE t (c int, CONSTRAINT uq UNIQUE (c))", typeName: "ConstraintDef", want: "CONSTRAINT uq UNIQUE (c)"},
+	{name: "foreign key constraint", sql: "CREATE TABLE t (c int, FOREIGN KEY (c) REFERENCES p(id))", typeName: "ConstraintDef", want: "FOREIGN KEY (c) REFERENCES p(id)"},
+	{name: "edge constraint", sql: "CREATE TABLE edge_t AS EDGE (CONSTRAINT ec CONNECTION (dbo.a TO dbo.b))", typeName: "ConstraintDef", want: "CONSTRAINT ec CONNECTION (dbo.a TO dbo.b)"},
+	{name: "memory optimized option", sql: "CREATE TABLE t (c int) WITH (MEMORY_OPTIMIZED = ON)", typeName: "TableOption", want: "MEMORY_OPTIMIZED = ON"},
+	{name: "system versioning option", sql: "CREATE TABLE t (id int, valid_from datetime2 GENERATED ALWAYS AS ROW START, valid_to datetime2 GENERATED ALWAYS AS ROW END, PERIOD FOR SYSTEM_TIME (valid_from, valid_to)) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.t_history))", typeName: "TableOption", want: "SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.t_history)"},
+	{name: "inline index", sql: "CREATE TABLE t (c int, INDEX ix (c))", typeName: "InlineIndexDef", want: "INDEX ix (c)"},
+	{name: "inline index column", sql: "CREATE TABLE t (c int, INDEX ix (c DESC))", typeName: "IndexColumn", want: "c DESC"},
+
+	// Index, spatial, fulltext, and search metadata.
+	{name: "create index stmt", sql: "CREATE INDEX ix ON t (c)", typeName: "CreateIndexStmt", want: "CREATE INDEX ix ON t (c)"},
+	{name: "create index column desc", sql: "CREATE INDEX ix ON t (c DESC)", typeName: "IndexColumn", want: "c DESC"},
+	{name: "create index include column", sql: "CREATE INDEX ix ON t (c) INCLUDE (d)", typeName: "IndexColumn", index: 1, want: "d"},
+	{name: "create index filter", sql: "CREATE INDEX ix ON t (c) WHERE c > 0", typeName: "BinaryExpr", want: "c > 0"},
+	{name: "spatial index column", sql: "CREATE SPATIAL INDEX six ON dbo.t (geom) USING GEOMETRY_GRID", typeName: "ColumnRef", want: "geom"},
+	{name: "spatial geometry grid stmt", sql: "CREATE SPATIAL INDEX six ON dbo.t (geom) USING GEOMETRY_GRID", typeName: "CreateSpatialIndexStmt", want: "CREATE SPATIAL INDEX six ON dbo.t (geom) USING GEOMETRY_GRID"},
+	{name: "spatial geography auto grid stmt", sql: "CREATE SPATIAL INDEX six ON dbo.t (geom) USING GEOGRAPHY_AUTO_GRID", typeName: "CreateSpatialIndexStmt", want: "CREATE SPATIAL INDEX six ON dbo.t (geom) USING GEOGRAPHY_AUTO_GRID"},
+	{name: "create fulltext stmt", sql: "CREATE FULLTEXT INDEX ON t(c) KEY INDEX pk", typeName: "CreateFulltextIndexStmt", want: "CREATE FULLTEXT INDEX ON t(c) KEY INDEX pk"},
+	{name: "fulltext indexed column", sql: "CREATE FULLTEXT INDEX ON t(c) KEY INDEX pk", typeName: "ColumnRef", want: "c"},
+	{name: "contains predicate", sql: "SELECT * FROM t WHERE CONTAINS(c, 'term')", typeName: "FullTextPredicate", want: "CONTAINS(c, 'term')"},
+	{name: "freetext predicate", sql: "SELECT * FROM t WHERE FREETEXT(c, 'term')", typeName: "FullTextPredicate", want: "FREETEXT(c, 'term')"},
+	{name: "containstable ref", sql: "SELECT * FROM CONTAINSTABLE(t, c, 'term') ct", typeName: "FullTextTableRef", want: "CONTAINSTABLE(t, c, 'term') ct"},
+	{name: "semantic similarity ref", sql: "SELECT * FROM SEMANTICSIMILARITYTABLE(t, c, source_key) s", typeName: "SemanticTableRef", want: "SEMANTICSIMILARITYTABLE(t, c, source_key) s"},
+
+	// SELECT clauses.
+	{name: "res target alias", sql: "SELECT a AS x", typeName: "ResTarget", want: "a AS x"},
+	{name: "select assign", sql: "SELECT @v = a", typeName: "SelectAssign", want: "@v = a"},
+	{name: "top clause", sql: "SELECT TOP (10) a FROM t", typeName: "TopClause", want: "TOP (10)"},
+	{name: "where expression", sql: "SELECT a FROM t WHERE a > 0", typeName: "BinaryExpr", want: "a > 0"},
+	{name: "order by item", sql: "SELECT a FROM t ORDER BY a DESC", typeName: "OrderByItem", want: "a DESC"},
+	{name: "fetch clause", sql: "SELECT a FROM t ORDER BY a OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY", typeName: "FetchClause", want: "FETCH NEXT 5 ROWS ONLY"},
+	{name: "for xml clause", sql: "SELECT a FROM t FOR XML PATH", typeName: "ForClause", want: "FOR XML PATH"},
+	{name: "common table expr", sql: "WITH cte AS (SELECT 1) SELECT * FROM cte", typeName: "CommonTableExpr", want: "cte AS (SELECT 1)"},
+	{name: "xml namespace decl", sql: "WITH XMLNAMESPACES ('http://example.com' AS ns) SELECT 1", typeName: "XmlNamespaceDecl", want: "'http://example.com' AS ns"},
+
+	// JOIN, WINDOW, GROUPING.
+	{name: "join clause", sql: "SELECT * FROM a JOIN b ON a.id = b.id", typeName: "JoinClause", want: "a JOIN b ON a.id = b.id"},
+	{name: "cross apply clause", sql: "SELECT * FROM a CROSS APPLY fn(a.id) f", typeName: "JoinClause", want: "a CROSS APPLY fn(a.id) f"},
+	{name: "over full clause", sql: "SELECT SUM(x) OVER (PARTITION BY y ORDER BY z ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM t", typeName: "OverClause", want: "OVER (PARTITION BY y ORDER BY z ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)"},
+	{name: "window frame", sql: "SELECT SUM(x) OVER (ORDER BY z ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM t", typeName: "WindowFrame", want: "ROWS BETWEEN 1 PRECEDING AND CURRENT ROW"},
+	{name: "window bound", sql: "SELECT SUM(x) OVER (ORDER BY z ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM t", typeName: "WindowBound", want: "1 PRECEDING"},
+	{name: "window def", sql: "SELECT SUM(x) OVER w FROM t WINDOW w AS (PARTITION BY y)", typeName: "WindowDef", want: "w AS (PARTITION BY y)"},
+
+	// DML.
+	{name: "insert stmt", sql: "INSERT INTO t (a) VALUES (1)", typeName: "InsertStmt", want: "INSERT INTO t (a) VALUES (1)"},
+	{name: "values clause", sql: "INSERT INTO t (a) VALUES (1), (2)", typeName: "ValuesClause", want: "VALUES (1), (2)"},
+	{name: "update stmt", sql: "UPDATE t SET a = 1 WHERE b = 2", typeName: "UpdateStmt", want: "UPDATE t SET a = 1 WHERE b = 2"},
+	{name: "delete stmt", sql: "DELETE FROM t WHERE a = 1", typeName: "DeleteStmt", want: "DELETE FROM t WHERE a = 1"},
+	{name: "output clause", sql: "UPDATE t SET a = 1 OUTPUT inserted.a INTO audit WHERE b = 2", typeName: "OutputClause", want: "OUTPUT inserted.a INTO audit"},
+	{name: "merge when matched", sql: "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a;", typeName: "MergeWhenClause", want: "WHEN MATCHED THEN UPDATE SET a = s.a"},
+	{name: "merge update action", sql: "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a;", typeName: "MergeUpdateAction", want: "UPDATE SET a = s.a"},
+	{name: "merge insert action", sql: "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED THEN INSERT (a) VALUES (s.a);", typeName: "MergeInsertAction", want: "INSERT (a) VALUES (s.a)"},
+	{name: "merge delete action", sql: "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE;", typeName: "MergeDeleteAction", want: "DELETE"},
+
+	// Top-level statement families.
+	{name: "ddl statement", sql: "CREATE VIEW v AS SELECT 1", typeName: "CreateViewStmt", want: "CREATE VIEW v AS SELECT 1"},
+	{name: "security statement", sql: "CREATE LOGIN testLogin WITH PASSWORD = 'P@ssw0rd'", typeName: "SecurityStmt", want: "CREATE LOGIN testLogin WITH PASSWORD = 'P@ssw0rd'"},
+	{name: "admin statement", sql: "DBCC CHECKDB", typeName: "DbccStmt", want: "DBCC CHECKDB"},
+}
+
+func TestMSSQLLocPrecisionMatrix_ExactSlices(t *testing.T) {
+	for _, tt := range locPrecisionMatrixExactSliceCases {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("parse failure: %v", err)
+			}
+			node := nthNodeByType(list, tt.typeName, tt.index)
+			if node == nil {
+				t.Fatalf("node %s[%d] not found; available types: %s", tt.typeName, tt.index, strings.Join(nodeTypeNames(list), ", "))
+			}
+			loc := ast.NodeLoc(node)
+			if !loc.IsValid() {
+				t.Fatalf("%s loc invalid: %+v", tt.typeName, loc)
+			}
+			if loc.Start > len(tt.sql) || loc.End > len(tt.sql) || loc.Start > loc.End {
+				t.Fatalf("%s loc out of range: %+v for SQL length %d", tt.typeName, loc, len(tt.sql))
+			}
+			if got := tt.sql[loc.Start:loc.End]; got != tt.want {
+				t.Fatalf("%s slice = %q, want %q (loc=%+v)", tt.typeName, got, tt.want, loc)
+			}
+		})
+	}
+}
+
+func TestMSSQLLocPrecisionMatrix_OptionText(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "create index fillfactor",
+			sql:  "CREATE INDEX ix ON t (c) WITH (FILLFACTOR = 90)",
+			want: []string{"FILLFACTOR=90"},
+		},
+		{
+			name: "alter index online",
+			sql:  "ALTER INDEX ix ON t REBUILD WITH (ONLINE = ON)",
+			want: []string{"ONLINE=ON"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("parse failure: %v", err)
+			}
+			var got []string
+			ast.Inspect(list, func(n ast.Node) bool {
+				if s, ok := n.(*ast.String); ok {
+					got = append(got, s.Str)
+				}
+				return true
+			})
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("option strings = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSSQLLocPrecisionMatrix_ChildLocsWithinParent(t *testing.T) {
+	for _, tt := range locPrecisionMatrixExactSliceCases {
+		t.Run(tt.name, func(t *testing.T) {
+			list, err := Parse(tt.sql)
+			if err != nil {
+				t.Fatalf("parse failure: %v", err)
+			}
+			assertChildLocsWithinParent(t, tt.sql, list)
+		})
+	}
+}
+
+func nthNodeByType(root ast.Node, typeName string, index int) ast.Node {
+	var matches []ast.Node
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == nil {
+			return true
+		}
+		t := reflect.TypeOf(n)
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		if t.Name() == typeName {
+			matches = append(matches, n)
+		}
+		return true
+	})
+	if len(matches) == 0 {
+		return nil
+	}
+	if index < 0 {
+		index = len(matches) + index
+	}
+	if index < 0 || index >= len(matches) {
+		return nil
+	}
+	return matches[index]
+}
+
+func nodeTypeNames(root ast.Node) []string {
+	seen := make(map[string]bool)
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == nil {
+			return true
+		}
+		t := reflect.TypeOf(n)
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		seen[t.Name()] = true
+		return true
+	})
+	var names []string
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func assertChildLocsWithinParent(t *testing.T, sql string, root ast.Node) {
+	t.Helper()
+
+	type frame struct {
+		node ast.Node
+		loc  ast.Loc
+	}
+	var stack []frame
+	ast.Walk(locContainmentVisitor{
+		enter: func(n ast.Node) {
+			loc := ast.NodeLoc(n)
+			if !loc.IsValid() {
+				stack = append(stack, frame{node: n, loc: loc})
+				return
+			}
+			if loc.Start > len(sql) || loc.End > len(sql) || loc.Start > loc.End {
+				t.Errorf("%T loc out of range: %+v", n, loc)
+			}
+			for i := len(stack) - 1; i >= 0; i-- {
+				parent := stack[i]
+				if !parent.loc.IsValid() {
+					continue
+				}
+				if loc.Start < parent.loc.Start || loc.End > parent.loc.End {
+					t.Errorf("%T loc %+v (%q) outside parent %T loc %+v (%q)",
+						n, loc, locSliceForMessage(sql, loc), parent.node, parent.loc, locSliceForMessage(sql, parent.loc))
+				}
+				break
+			}
+			stack = append(stack, frame{node: n, loc: loc})
+		},
+		leave: func() {
+			stack = stack[:len(stack)-1]
+		},
+	}, root)
+}
+
+func locSliceForMessage(sql string, loc ast.Loc) string {
+	if !loc.IsValid() || loc.Start > len(sql) || loc.End > len(sql) || loc.Start > loc.End {
+		return fmt.Sprintf("<bad %+v>", loc)
+	}
+	return sql[loc.Start:loc.End]
+}
+
+type locContainmentVisitor struct {
+	enter func(ast.Node)
+	leave func()
+}
+
+func (v locContainmentVisitor) Visit(n ast.Node) ast.Visitor {
+	if n == nil {
+		v.leave()
+		return nil
+	}
+	v.enter(n)
+	return v
+}

--- a/mssql/parser/loc_precision_test.go
+++ b/mssql/parser/loc_precision_test.go
@@ -1,0 +1,249 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bytebase/omni/mssql/ast"
+)
+
+func TestMSSQLLocPrecision_SpatialIndexNestedOptions(t *testing.T) {
+	sql := `CREATE SPATIAL INDEX SI_t ON dbo.t (geom) USING GEOMETRY_GRID WITH (BOUNDING_BOX = (0, 0, 100, 100), GRIDS = (LEVEL_1 = LOW, LEVEL_2 = MEDIUM, LEVEL_3 = HIGH, LEVEL_4 = HIGH), CELLS_PER_OBJECT = 16)`
+
+	result := ParseAndCheck(t, sql)
+	stmt, ok := result.Items[0].(*ast.CreateSpatialIndexStmt)
+	if !ok {
+		t.Fatalf("stmt type = %T, want *ast.CreateSpatialIndexStmt", result.Items[0])
+	}
+	if stmt.Options == nil {
+		t.Fatal("expected spatial index options")
+	}
+
+	var got []string
+	for _, item := range stmt.Options.Items {
+		opt, ok := item.(*ast.String)
+		if !ok {
+			t.Fatalf("option type = %T, want *ast.String", item)
+		}
+		got = append(got, opt.Str)
+	}
+
+	want := []string{
+		"BOUNDING_BOX=(0, 0, 100, 100)",
+		"GRIDS=(LEVEL_1 = LOW, LEVEL_2 = MEDIUM, LEVEL_3 = HIGH, LEVEL_4 = HIGH)",
+		"CELLS_PER_OBJECT=16",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("options = %#v, want %#v", got, want)
+	}
+}
+
+func TestMSSQLLocPrecision_ExpressionRanges(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{sql: "SELECT c > 0", want: "c > 0"},
+		{sql: "SELECT c IN (1, 2)", want: "c IN (1, 2)"},
+		{sql: "SELECT c BETWEEN 1 AND 2", want: "c BETWEEN 1 AND 2"},
+		{sql: "SELECT c LIKE 'x%'", want: "c LIKE 'x%'"},
+		{sql: "SELECT c IS NOT NULL", want: "c IS NOT NULL"},
+		{sql: "SELECT a + b * c", want: "a + b * c"},
+		{sql: "SELECT (a = 1) AND (b = 2)", want: "(a = 1) AND (b = 2)"},
+		{
+			sql:  "SELECT name COLLATE Latin1_General_CI_AS LIKE 'A%'",
+			want: "name COLLATE Latin1_General_CI_AS LIKE 'A%'",
+		},
+		{sql: "SELECT dt AT TIME ZONE 'UTC'", want: "dt AT TIME ZONE 'UTC'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			expr := firstSelectTargetExpr(t, tt.sql)
+			if got := locText(t, tt.sql, ast.NodeLoc(expr)); got != tt.want {
+				t.Fatalf("loc text = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSSQLLocPrecision_CheckConstraintExpressionRanges(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{
+			sql:  "CREATE TABLE t (c int, CONSTRAINT ck CHECK (c > 0))",
+			want: "c > 0",
+		},
+		{
+			sql:  "CREATE TABLE t (c int CHECK (c IN (1, 2)))",
+			want: "c IN (1, 2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			var checkExpr ast.ExprNode
+			ast.Inspect(ParseAndCheck(t, tt.sql), func(n ast.Node) bool {
+				constraint, ok := n.(*ast.ConstraintDef)
+				if ok && constraint.Type == ast.ConstraintCheck && checkExpr == nil {
+					checkExpr = constraint.Expr
+					return false
+				}
+				return true
+			})
+			if checkExpr == nil {
+				t.Fatal("expected CHECK constraint expression")
+			}
+			if got := locText(t, tt.sql, ast.NodeLoc(checkExpr)); got != tt.want {
+				t.Fatalf("loc text = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSSQLLocPrecision_FuncCallRanges(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{sql: "SELECT SYSDATETIME()", want: "SYSDATETIME()"},
+		{sql: "SELECT COUNT(*)", want: "COUNT(*)"},
+		{
+			sql:  "SELECT STRING_AGG(name, ',') WITHIN GROUP (ORDER BY name)",
+			want: "STRING_AGG(name, ',') WITHIN GROUP (ORDER BY name)",
+		},
+		{
+			sql:  "SELECT SUM(x) OVER (PARTITION BY y)",
+			want: "SUM(x) OVER (PARTITION BY y)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			expr := firstSelectTargetExpr(t, tt.sql)
+			if got := locText(t, tt.sql, ast.NodeLoc(expr)); got != tt.want {
+				t.Fatalf("loc text = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSSQLLocPrecision_DefaultFuncCallRanges(t *testing.T) {
+	sql := "CREATE TABLE t (d datetime2 DEFAULT SYSDATETIME(), e int DEFAULT dbo.f(), c int DEFAULT COUNT(*))"
+
+	var got []string
+	ast.Inspect(ParseAndCheck(t, sql), func(n ast.Node) bool {
+		column, ok := n.(*ast.ColumnDef)
+		if !ok {
+			return true
+		}
+		if fc, ok := column.DefaultExpr.(*ast.FuncCallExpr); ok {
+			got = append(got, locText(t, sql, fc.Loc))
+		}
+		return true
+	})
+
+	want := []string{"SYSDATETIME()", "dbo.f()", "COUNT(*)"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("function loc texts = %#v, want %#v", got, want)
+	}
+}
+
+func TestMSSQLLocPrecision_ColumnRefRanges(t *testing.T) {
+	sql := "SELECT c, t.c, dbo.t.c, t.*"
+
+	result := ParseAndCheck(t, sql)
+	stmt := result.Items[0].(*ast.SelectStmt)
+	var got []string
+	for _, item := range stmt.TargetList.Items {
+		target := item.(*ast.ResTarget)
+		got = append(got, locText(t, sql, ast.NodeLoc(target.Val)))
+	}
+
+	want := []string{"c", "t.c", "dbo.t.c", "t.*"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("column loc texts = %#v, want %#v", got, want)
+	}
+}
+
+func TestMSSQLLocPrecision_ExpressionNodeLocCompleteness(t *testing.T) {
+	tests := []string{
+		"SELECT (a + b) * dbo.f(c) FROM t WHERE c IS NOT NULL",
+		"CREATE TABLE t (c int CHECK (CASE WHEN c BETWEEN 1 AND 2 THEN dbo.f(c) ELSE SYSDATETIME() END IS NOT NULL))",
+	}
+
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			ast.Inspect(ParseAndCheck(t, sql), func(n ast.Node) bool {
+				if !locPrecisionExprNode(n) {
+					return true
+				}
+				loc := ast.NodeLoc(n)
+				if !loc.IsValid() {
+					t.Errorf("%T has invalid loc: %+v", n, loc)
+					return true
+				}
+				if loc.Start > len(sql) || loc.End > len(sql) || loc.Start > loc.End {
+					t.Errorf("%T has out-of-range loc: %+v", n, loc)
+				}
+				return true
+			})
+		})
+	}
+}
+
+func locPrecisionExprNode(n ast.Node) bool {
+	switch n.(type) {
+	case *ast.AtTimeZoneExpr,
+		*ast.BetweenExpr,
+		*ast.BinaryExpr,
+		*ast.CaseExpr,
+		*ast.CaseWhen,
+		*ast.ColumnRef,
+		*ast.CollateExpr,
+		*ast.FuncCallExpr,
+		*ast.InExpr,
+		*ast.IsExpr,
+		*ast.LikeExpr,
+		*ast.Literal,
+		*ast.ParenExpr,
+		*ast.StarExpr,
+		*ast.UnaryExpr,
+		*ast.VariableRef:
+		return true
+	default:
+		return false
+	}
+}
+
+func firstSelectTargetExpr(t *testing.T, sql string) ast.ExprNode {
+	t.Helper()
+
+	result := ParseAndCheck(t, sql)
+	stmt, ok := result.Items[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("stmt type = %T, want *ast.SelectStmt", result.Items[0])
+	}
+	if stmt.TargetList == nil || len(stmt.TargetList.Items) == 0 {
+		t.Fatal("expected SELECT target")
+	}
+	target, ok := stmt.TargetList.Items[0].(*ast.ResTarget)
+	if !ok {
+		t.Fatalf("target type = %T, want *ast.ResTarget", stmt.TargetList.Items[0])
+	}
+	return target.Val
+}
+
+func locText(t *testing.T, sql string, loc ast.Loc) string {
+	t.Helper()
+
+	if !loc.IsValid() {
+		t.Fatalf("invalid loc: %+v", loc)
+	}
+	if loc.Start > len(sql) || loc.End > len(sql) || loc.Start > loc.End {
+		t.Fatalf("loc out of range: %+v for %q", loc, sql)
+	}
+	return sql[loc.Start:loc.End]
+}

--- a/mssql/parser/merge.go
+++ b/mssql/parser/merge.go
@@ -240,6 +240,7 @@ func (p *Parser) parseMergeWhenClause() (*nodes.MergeWhenClause, error) {
 	// Action: UPDATE SET, DELETE, or INSERT
 	switch {
 	case p.cur.Type == kwUPDATE:
+		actionLoc := p.pos()
 		p.advance() // consume UPDATE
 		p.match(kwSET)
 		setList, err := p.parseSetClauseList()
@@ -248,13 +249,13 @@ func (p *Parser) parseMergeWhenClause() (*nodes.MergeWhenClause, error) {
 		}
 		wc.Action = &nodes.MergeUpdateAction{
 			SetClause: setList,
-			Loc:       nodes.Loc{Start: loc, End: -1},
+			Loc:       nodes.Loc{Start: actionLoc, End: p.prevEnd()},
 		}
 	case p.cur.Type == kwDELETE:
 		delLoc := p.pos()
 		p.advance() // consume DELETE
 		wc.Action = &nodes.MergeDeleteAction{
-			Loc: nodes.Loc{Start: delLoc, End: -1},
+			Loc: nodes.Loc{Start: delLoc, End: p.prevEnd()},
 		}
 	case p.cur.Type == kwINSERT:
 		action, err := p.parseMergeInsertAction()

--- a/mssql/parser/name.go
+++ b/mssql/parser/name.go
@@ -288,7 +288,7 @@ func (p *Parser) parseIdentExpr() (nodes.ExprNode, error) {
 	// Simple column reference
 	return &nodes.ColumnRef{
 		Column: name,
-		Loc:    nodes.Loc{Start: loc, End: -1},
+		Loc:    nodes.Loc{Start: loc, End: p.prevEnd()},
 	}, nil
 }
 
@@ -316,7 +316,7 @@ func (p *Parser) parseQualifiedRef(first string, loc int) (nodes.ExprNode, error
 			}
 			return &nodes.StarExpr{
 				Qualifier: qualifier,
-				Loc:       nodes.Loc{Start: loc, End: -1},
+				Loc:       nodes.Loc{Start: loc, End: p.prevEnd()},
 			}, nil
 		}
 
@@ -383,7 +383,7 @@ func (p *Parser) parseQualifiedRef(first string, loc int) (nodes.ExprNode, error
 		}
 	}
 
-	ref := &nodes.ColumnRef{Loc: nodes.Loc{Start: loc, End: -1}}
+	ref := &nodes.ColumnRef{Loc: nodes.Loc{Start: loc, End: p.prevEnd()}}
 	switch len(parts) {
 	case 1:
 		ref.Column = parts[0]
@@ -412,10 +412,11 @@ func (p *Parser) parseQualifiedRef(first string, loc int) (nodes.ExprNode, error
 // parseFuncCallWithSchema parses a schema-qualified function call.
 // schema.func(args)
 func (p *Parser) parseFuncCallWithSchema(schema, funcName string, loc int) (nodes.ExprNode, error) {
+	nameEnd := p.prevEnd()
 	p.advance() // consume (
 
 	fc := &nodes.FuncCallExpr{
-		Name: &nodes.TableRef{Schema: schema, Object: funcName, Loc: nodes.Loc{Start: loc, End: -1}},
+		Name: &nodes.TableRef{Schema: schema, Object: funcName, Loc: nodes.Loc{Start: loc, End: nameEnd}},
 		Loc:  nodes.Loc{Start: loc, End: -1},
 	}
 
@@ -426,8 +427,10 @@ func (p *Parser) parseFuncCallWithSchema(schema, funcName string, loc int) (node
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
+		fc.Loc.End = p.prevEnd()
 		if p.cur.Type == kwOVER {
 			fc.Over, _ = p.parseOverClause()
+			fc.Loc.End = p.prevEnd()
 		}
 		return fc, nil
 	}
@@ -439,8 +442,10 @@ func (p *Parser) parseFuncCallWithSchema(schema, funcName string, loc int) (node
 
 	if p.cur.Type == ')' {
 		p.advance()
+		fc.Loc.End = p.prevEnd()
 		if p.cur.Type == kwOVER {
 			fc.Over, _ = p.parseOverClause()
+			fc.Loc.End = p.prevEnd()
 		}
 		return fc, nil
 	}
@@ -470,10 +475,12 @@ func (p *Parser) parseFuncCallWithSchema(schema, funcName string, loc int) (node
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
+	fc.Loc.End = p.prevEnd()
 
 	// Check for OVER clause
 	if p.cur.Type == kwOVER {
 		fc.Over, _ = p.parseOverClause()
+		fc.Loc.End = p.prevEnd()
 	}
 
 	return fc, nil

--- a/mssql/parser/rowset_functions.go
+++ b/mssql/parser/rowset_functions.go
@@ -13,11 +13,12 @@ func (p *Parser) parseRowsetFunction() (nodes.TableExpr, error) {
 	loc := p.pos()
 	funcName := p.cur.Str
 	p.advance() // consume the keyword
+	nameEnd := p.prevEnd()
 
 	// OPENDATASOURCE('provider', 'connstr').db.schema.table - special case
 	if p.cur.Type == '(' {
 		fc := &nodes.FuncCallExpr{
-			Name: &nodes.TableRef{Object: funcName, Loc: nodes.Loc{Start: loc, End: -1}},
+			Name: &nodes.TableRef{Object: funcName, Loc: nodes.Loc{Start: loc, End: nameEnd}},
 			Loc:  nodes.Loc{Start: loc, End: -1},
 		}
 		p.advance() // consume (
@@ -41,6 +42,7 @@ func (p *Parser) parseRowsetFunction() (nodes.TableExpr, error) {
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
+		fc.Loc.End = p.prevEnd()
 
 		// WITH clause for OPENJSON and OPENXML
 		var withClause *nodes.List
@@ -54,22 +56,23 @@ func (p *Parser) parseRowsetFunction() (nodes.TableExpr, error) {
 		}
 
 		alias := p.parseOptionalAlias()
+		aliasEnd := p.prevEnd()
 
 		return &nodes.AliasedTableRef{
 			Table:   fc,
 			Alias:   alias,
 			Columns: withClause,
-			Loc:     nodes.Loc{Start: loc, End: -1},
+			Loc:     nodes.Loc{Start: loc, End: aliasEnd},
 		}, nil
 	}
 
 	// Shouldn't happen but handle gracefully
 	return &nodes.AliasedTableRef{
 		Table: &nodes.FuncCallExpr{
-			Name: &nodes.TableRef{Object: funcName, Loc: nodes.Loc{Start: loc, End: -1}},
-			Loc:  nodes.Loc{Start: loc, End: -1},
+			Name: &nodes.TableRef{Object: funcName, Loc: nodes.Loc{Start: loc, End: nameEnd}},
+			Loc:  nodes.Loc{Start: loc, End: nameEnd},
 		},
-		Loc: nodes.Loc{Start: loc, End: -1},
+		Loc: nodes.Loc{Start: loc, End: nameEnd},
 	}, nil
 }
 

--- a/mssql/parser/search_functions.go
+++ b/mssql/parser/search_functions.go
@@ -531,6 +531,17 @@ func (p *Parser) parseSemanticKey() (nodes.ExprNode, error) {
 			Name: tok.Str,
 			Loc:  nodes.Loc{Start: loc, End: p.prevEnd()},
 		}, nil
+	case tokIDENT:
+		if neg {
+			return nil, p.unexpectedToken()
+		}
+		return p.parseIdentExpr()
+	}
+	if isContextKeyword(p.cur.Type) {
+		if neg {
+			return nil, p.unexpectedToken()
+		}
+		return p.parseIdentExpr()
 	}
 	return nil, p.unexpectedToken()
 }

--- a/mssql/parser/select.go
+++ b/mssql/parser/select.go
@@ -307,7 +307,7 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 			}
 			stmt.FetchClause = &nodes.FetchClause{
 				Count: count,
-				Loc:   nodes.Loc{Start: fetchLoc, End: -1},
+				Loc:   nodes.Loc{Start: fetchLoc, End: p.prevEnd()},
 			}
 		}
 	}
@@ -809,11 +809,15 @@ func (p *Parser) parseTableSource() (nodes.TableExpr, error) {
 		if right == nil {
 			return nil, p.unexpectedToken()
 		}
+		start := nodes.NodeLoc(left).Start
+		if start < 0 {
+			start = joinLoc
+		}
 		join := &nodes.JoinClause{
 			Type:  jt,
 			Left:  left,
 			Right: right,
-			Loc:   nodes.Loc{Start: joinLoc, End: -1},
+			Loc:   nodes.Loc{Start: start, End: -1},
 		}
 		// ON condition (not for CROSS JOIN / CROSS APPLY / OUTER APPLY)
 		if jt != nodes.JoinCross && jt != nodes.JoinCrossApply && jt != nodes.JoinOuterApply {
@@ -969,6 +973,7 @@ func (p *Parser) parsePrimaryTableSource() (nodes.TableExpr, error) {
 	alias := p.parseOptionalAlias()
 	if alias != "" {
 		ref.Alias = alias
+		ref.Loc.End = p.prevEnd()
 	}
 
 	// Table hints: WITH (NOLOCK), WITH (INDEX(idx1)), etc.
@@ -977,6 +982,7 @@ func (p *Parser) parsePrimaryTableSource() (nodes.TableExpr, error) {
 		if err != nil {
 			return nil, err
 		}
+		ref.Loc.End = p.prevEnd()
 	}
 
 	return p.parsePivotUnpivot(ref)
@@ -1207,16 +1213,18 @@ func (p *Parser) parseTableValuedFunction(ref *nodes.TableRef) (nodes.TableExpr,
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
+	fc.Loc.End = p.prevEnd()
 
 	alias, cols, err := p.parseAliasAndOptionalColumnList()
 	if err != nil {
 		return nil, err
 	}
+	aliasEnd := p.prevEnd()
 	return &nodes.AliasedTableRef{
 		Table:   fc,
 		Alias:   alias,
 		Columns: cols,
-		Loc:     nodes.Loc{Start: loc, End: -1},
+		Loc:     nodes.Loc{Start: loc, End: aliasEnd},
 	}, nil
 }
 
@@ -1852,7 +1860,7 @@ func (p *Parser) parseOrderByList() (*nodes.List, error) {
 		items = append(items, &nodes.OrderByItem{
 			Expr:    expr,
 			SortDir: dir,
-			Loc:     nodes.Loc{Start: oloc, End: -1},
+			Loc:     nodes.Loc{Start: oloc, End: p.prevEnd()},
 		})
 		if _, ok := p.match(','); !ok {
 			break


### PR DESCRIPTION
## Summary
- Preserve nested spatial index option values and expose a loc-bearing spatial column reference.
- Add MSSQL AST Loc helpers and harden expression/function/reference Loc ranges for exact source extraction.
- Add parser and public API Loc precision matrices covering 154 scenarios with child containment checks.

## Test Plan
- go test ./mssql/parser -run TestMSSQLLocPrecisionMatrix -count=1
- go test ./mssql/... -count=1
- git diff --check