### PR TITLE
fix(mssql): preserve GO in public parse

### DIFF
--- a/mssql/loc_precision_matrix_test.go
+++ b/mssql/loc_precision_matrix_test.go
@@ -41,9 +41,9 @@ func TestMSSQLPublicParseLocPrecisionMatrix(t *testing.T) {
 		{
 			name:       "go batch separator",
 			sql:        "SELECT 1\nGO\nSELECT 2",
-			wantTexts:  []string{"SELECT 1", "\nGO\nSELECT 2"},
-			wantStarts: []Position{{Line: 1, Column: 1}, {Line: 3, Column: 1}},
-			wantEnds:   []Position{{Line: 1, Column: 9}, {Line: 3, Column: 9}},
+			wantTexts:  []string{"SELECT 1", "\nGO", "\nSELECT 2"},
+			wantStarts: []Position{{Line: 1, Column: 1}, {Line: 2, Column: 1}, {Line: 3, Column: 1}},
+			wantEnds:   []Position{{Line: 1, Column: 9}, {Line: 2, Column: 3}, {Line: 3, Column: 9}},
 		},
 		{
 			name:       "empty statements skipped",

--- a/mssql/parse.go
+++ b/mssql/parse.go
@@ -58,9 +58,6 @@ func Parse(sql string) ([]Statement, error) {
 		if item == nil {
 			continue
 		}
-		if _, ok := item.(*ast.GoStmt); ok {
-			continue
-		}
 
 		loc := nodeLoc(item)
 


### PR DESCRIPTION
## Summary
- Restore public mssql.Parse behavior so GO batch separators are returned as independent statements.
- Update the public Parse Loc matrix to assert GO has its own text and source location.

## Test Plan
- go test ./mssql -run TestMSSQLPublicParseLocPrecisionMatrix -count=1
- go test ./mssql/... -count=1
- git diff --check