### PR TITLE
feat(mongo): allow trailing comma in argument lists

### DIFF
--- a/mongo/parser/parser.go
+++ b/mongo/parser/parser.go
@@ -18,7 +18,7 @@ type Parser struct {
 
 // ParseResult holds the outcome of a best-effort parse.
 type ParseResult struct {
-	Nodes  []ast.Node   // successfully parsed statement nodes
+	Nodes  []ast.Node    // successfully parsed statement nodes
 	Errors []*ParseError // errors encountered during parsing
 }
 
@@ -190,6 +190,8 @@ func (p *Parser) expectIdent() (string, Token, error) {
 }
 
 // parseArguments parses a parenthesized argument list: ( expr, expr, ... )
+// A single trailing comma before the closing paren is allowed, matching the
+// behavior of mongosh / JavaScript (ES2017+).
 // Assumes the opening '(' has NOT been consumed yet.
 func (p *Parser) parseArguments() ([]ast.Node, error) {
 	if _, err := p.expect('('); err != nil {
@@ -215,6 +217,12 @@ func (p *Parser) parseArguments() ([]ast.Node, error) {
 		}
 		if _, err := p.expect(','); err != nil {
 			return nil, err
+		}
+		// Allow a single trailing comma before the closing paren:
+		//   db.coll.find({…},).sort(…)  → equivalent to db.coll.find({…}).sort(…)
+		if p.cur.Type == ')' {
+			p.advance()
+			return args, nil
 		}
 	}
 }

--- a/mongo/parsertest/collection_test.go
+++ b/mongo/parsertest/collection_test.go
@@ -307,3 +307,52 @@ func TestMultipleStatements(t *testing.T) {
 		t.Errorf("statement 2: expected b.insertOne, got %s.%s", s2.Collection, s2.Method)
 	}
 }
+
+func TestTrailingCommaInArguments(t *testing.T) {
+	// Single trailing comma after the only argument — JS / mongosh accept
+	// this and gomongoFallback events show it in the wild as
+	// db.processed_files.find({...},).sort({...}).
+	node := mustParse(t, `db.users.find({name: "alice"},)`)
+	stmt := node.(*ast.CollectionStatement)
+	if stmt.Method != "find" {
+		t.Errorf("expected 'find', got %q", stmt.Method)
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+
+	// Trailing comma after the second argument.
+	node = mustParse(t, `db.users.find({}, {name: 1},)`)
+	stmt = node.(*ast.CollectionStatement)
+	if len(stmt.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(stmt.Args))
+	}
+
+	// Trailing comma combined with a chained cursor method — exact shape
+	// from the gomongoFallback events.
+	node = mustParse(t, `db.processed_files.find({_id: "x"},).sort({created_at: -1})`)
+	stmt = node.(*ast.CollectionStatement)
+	if len(stmt.Args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(stmt.Args))
+	}
+	if len(stmt.CursorMethods) != 1 || stmt.CursorMethods[0].Method != "sort" {
+		t.Errorf("expected one .sort() cursor method, got %+v", stmt.CursorMethods)
+	}
+
+	// Cursor-method argument list also tolerates a trailing comma.
+	node = mustParse(t, `db.users.find().limit(10,)`)
+	stmt = node.(*ast.CollectionStatement)
+	if len(stmt.CursorMethods) != 1 {
+		t.Fatalf("expected 1 cursor method, got %d", len(stmt.CursorMethods))
+	}
+}
+
+func TestArgumentListErrors(t *testing.T) {
+	// A bare comma (no argument before it) is still an error — we only
+	// accept ONE trailing comma after a real argument.
+	mustFail(t, `db.users.find(,)`)
+	// A leading comma is an error.
+	mustFail(t, `db.users.find(, {a: 1})`)
+	// Two commas in a row are an error.
+	mustFail(t, `db.users.find({a: 1},,)`)
+}


### PR DESCRIPTION
## Summary
- Accept a single trailing comma in function-call argument lists in the mongo parser, matching mongosh / JS ES2017+ behavior.
- The wild shape — `db.coll.find({…},).sort({…})` — comes up in production telemetry from editors and code formatters; previously the parser rejected the trailing `,` with `expected ,, got ")"`.

## Behavior
- `db.coll.find({a: 1},)` → ok
- `db.coll.find({}, {a: 1},)` → ok
- `db.coll.find({a: 1},).sort({a: 1})` → ok (cursor chain unaffected)
- `db.coll.find().limit(10,)` → ok (cursor-method args also tolerate it)
- `db.coll.find(,)` / `db.coll.find(, {a: 1})` / `db.coll.find({a: 1},,)` → still error

## Test plan
- [x] New `TestTrailingCommaInArguments` covers all four success shapes including the exact wild case.
- [x] New `TestArgumentListErrors` confirms bare/leading/consecutive commas still fail.
- [x] Full `go test ./mongo/...` passes (analysis, catalog, completion, parsertest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)