### PR TITLE
feat(oracle): add lexer-based splitter

### DIFF
--- a/SCENARIOS-oracle-splitter.md
+++ b/SCENARIOS-oracle-splitter.md
@@ -1,0 +1,133 @@
+# Oracle Splitter Production Coverage
+
+## Phase 1: Ordinary SQL Boundaries
+
+- [x] Empty input returns no segments.
+- [x] Whitespace-only input returns no segments.
+- [x] Comment-only input returns no segments.
+- [x] A single semicolon-terminated SQL statement returns one segment without the delimiter.
+- [x] A single SQL statement without a semicolon returns one segment.
+- [x] Multiple semicolon-terminated SQL statements return separate segments.
+- [x] Mixed terminated and unterminated SQL statements return separate segments.
+- [x] Consecutive semicolons do not produce empty segments.
+- [x] Leading whitespace before SQL is preserved in segment text and range.
+- [x] Inter-statement whitespace is attached to the following segment unless it is a skipped SQL*Plus command.
+- [x] Trailing whitespace after the final statement is preserved in the final segment.
+- [x] CRLF line endings do not corrupt boundaries.
+- [x] UTF-8 comments do not corrupt byte ranges.
+- [x] Arithmetic division does not act as a slash delimiter.
+- [x] Schema-qualified and dblink-qualified names do not affect splitting.
+
+## Phase 2: Literals, Identifiers, Comments, and Hints
+
+- [x] Semicolons inside single-quoted string literals are ignored.
+- [x] Slashes inside single-quoted string literals are ignored.
+- [x] Escaped single quotes using doubled quotes are handled.
+- [x] National character literals `N'...'` are handled.
+- [x] Oracle `q'[ ... ]'` quoting is handled.
+- [x] Oracle `q'{ ... }'` quoting is handled.
+- [x] Oracle `q'( ... )'` quoting is handled.
+- [x] Oracle `q'< ... >'` quoting is handled.
+- [x] Oracle custom `q'!...!'` quoting is handled.
+- [x] Semicolons inside double-quoted identifiers are ignored.
+- [x] Slashes inside double-quoted identifiers are ignored.
+- [x] Line comments containing semicolons are ignored.
+- [x] Line comments containing slash-only visual markers are ignored.
+- [x] Block comments containing semicolons are ignored.
+- [x] Block comments containing slash-only lines are ignored.
+- [x] Nested block comments are handled.
+- [x] Hints `/*+ ... */` containing delimiters are ignored for splitting.
+
+## Phase 3: SQL*Plus Slash and Buffer Commands
+
+- [x] A slash alone on a line flushes the current SQL segment.
+- [x] A slash line with surrounding horizontal whitespace flushes the current SQL segment.
+- [x] A slash at EOF flushes the current SQL segment.
+- [x] A slash followed by non-whitespace on the same line is not a delimiter.
+- [x] A slash preceded by non-whitespace on the same line is not a delimiter.
+- [x] `RUN` alone on a line flushes the current SQL segment.
+- [x] `R` alone on a line flushes the current SQL segment.
+- [x] Slash commands with leading command lines before SQL do not produce empty segments.
+- [x] Multiple slash commands in a row do not produce empty segments.
+- [x] Slash commands after PL/SQL units do not appear in segment text.
+
+## Phase 4: Anonymous PL/SQL Blocks
+
+- [x] `BEGIN ... END;` is returned as one segment.
+- [x] `DECLARE ... BEGIN ... END;` is returned as one segment.
+- [x] Labeled anonymous blocks are returned as one segment.
+- [x] Nested anonymous blocks do not split at inner semicolons.
+- [x] Exception handlers do not split the outer block.
+- [x] `IF ... END IF;` stays inside the block.
+- [x] `CASE ... END CASE;` stays inside the block.
+- [x] `LOOP ... END LOOP;` stays inside the block.
+- [x] `WHILE ... LOOP ... END LOOP;` stays inside the block.
+- [x] `FOR ... LOOP ... END LOOP;` stays inside the block.
+- [x] `FORALL` statements stay inside the block.
+- [x] Dynamic SQL strings containing semicolons stay inside the block.
+
+## Phase 5: Stored PL/SQL Units
+
+- [x] `CREATE PROCEDURE ... END; /` is one segment.
+- [x] `CREATE OR REPLACE PROCEDURE ... END; /` is one segment.
+- [x] `CREATE EDITIONABLE PROCEDURE ... END; /` is one segment.
+- [x] `CREATE NONEDITIONABLE PROCEDURE ... END; /` is one segment.
+- [x] `CREATE FUNCTION ... END; /` is one segment.
+- [x] Function bodies with arithmetic division do not split at `/`.
+- [x] `CREATE PACKAGE ... END; /` is one segment.
+- [x] `CREATE PACKAGE BODY ... END; /` is one segment.
+- [x] Package body nested procedure bodies do not terminate the package.
+- [x] Package body nested function bodies do not terminate the package.
+- [x] `CREATE TRIGGER ... BEGIN ... END; /` is one segment.
+- [x] Compound triggers are one segment.
+- [x] `CREATE TYPE BODY ... END; /` is one segment.
+- [x] Type body member function bodies do not terminate the type body.
+- [x] Stored units followed by ordinary SQL split correctly.
+
+## Phase 6: SQL*Plus Line Commands
+
+- [x] `SET` command lines are skipped.
+- [x] `SHOW` command lines are skipped.
+- [x] `PROMPT` command lines are skipped.
+- [x] `SPOOL` command lines are skipped.
+- [x] `COLUMN` command lines are skipped.
+- [x] `BREAK` command lines are skipped.
+- [x] `COMPUTE` command lines are skipped.
+- [x] `TTITLE` and `BTITLE` command lines are skipped.
+- [x] `REPHEADER` and `REPFOOTER` command lines are skipped.
+- [x] `DEFINE` and `UNDEFINE` command lines are skipped.
+- [x] `ACCEPT` command lines are skipped.
+- [x] `VARIABLE` and `PRINT` command lines are skipped.
+- [x] `EXECUTE` command lines are skipped as SQL*Plus commands.
+- [x] `CONNECT` and `DISCONNECT` command lines are skipped.
+- [x] `EXIT` and `QUIT` command lines are skipped.
+- [x] `WHENEVER SQLERROR` command lines are skipped.
+- [x] `WHENEVER OSERROR` command lines are skipped.
+- [x] `@`, `@@`, and `START` script invocation lines are skipped.
+- [x] `REM` and `REMARK` command lines are skipped.
+- [x] `HOST` and `!` shell command lines are skipped.
+- [x] Buffer manipulation commands `LIST`, `APPEND`, `CHANGE`, `DEL`, `INPUT`, `SAVE`, `GET`, and `EDIT` are skipped.
+- [x] SQL*Plus command words inside SQL are not skipped.
+- [x] SQL*Plus command words inside PL/SQL are not skipped.
+
+## Phase 7: Soft-Fail and Safety
+
+- [x] Unterminated single-quoted strings do not panic.
+- [x] Unterminated q-quotes do not panic.
+- [x] Unterminated double-quoted identifiers do not panic.
+- [x] Unterminated block comments do not panic.
+- [x] Missing PL/SQL `END` returns a best-effort trailing segment.
+- [x] Truncated `CREATE PROCEDURE` returns a best-effort trailing segment.
+- [x] Binary-ish bytes do not panic.
+- [x] Every returned segment has a valid non-overlapping byte range.
+- [x] Every returned segment text equals `input[ByteStart:ByteEnd]`.
+- [x] Reconstructing returned ranges never includes skipped SQL*Plus command lines.
+
+## Phase 8: Facade Integration
+
+- [x] `oracle.Parse` parses splitter output from ordinary SQL scripts.
+- [x] `oracle.Parse` parses splitter output from slash-terminated PL/SQL scripts.
+- [x] `oracle.Parse` skips SQL*Plus commands before parsing.
+- [x] `oracle.Parse` preserves original byte offsets in AST locations.
+- [x] `oracle.Parse` reports start line and column based on the original script.
+- [x] `oracle.Parse` handles multiple statements around skipped command lines.

--- a/docs/plans/2026-05-09-oracle-lexer-splitter.md
+++ b/docs/plans/2026-05-09-oracle-lexer-splitter.md
@@ -1,0 +1,92 @@
+# Oracle Lexer Splitter Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a production-ready Oracle lexer-based SQL script splitter that handles SQL, PL/SQL blocks, stored units, and SQL*Plus-style slash delimiters without depending on full parsing.
+
+**Architecture:** Implement `oracle/parser.Split(sql string) []Segment` as a soft-fail lexical scanner over Oracle tokens and raw byte offsets. It should reuse Oracle lexical rules by scanning token-like boundaries, preserve source ranges, and model script delimiters and PL/SQL block boundaries with a small state machine.
+
+**Tech Stack:** Go, existing `oracle/parser` lexer/token constants, existing parser package test patterns, `go test ./oracle/...`.
+
+### Task 1: Baseline Splitter API and Ordinary SQL
+
+**Files:**
+- Create: `oracle/parser/split.go`
+- Create: `oracle/parser/split_test.go`
+
+**Steps:**
+1. Write failing tests for empty input, ordinary semicolon splitting, comments/whitespace-only filtering, and semicolons inside Oracle literals.
+2. Run `go test ./oracle/parser -run 'TestSplit' -count=1` and verify failure is due to missing `Split`.
+3. Implement `Segment`, `Empty`, and lexical splitting for ordinary SQL.
+4. Re-run the focused tests until they pass.
+
+### Task 2: SQL*Plus Slash Delimiter
+
+**Files:**
+- Modify: `oracle/parser/split.go`
+- Modify: `oracle/parser/split_test.go`
+
+**Steps:**
+1. Add failing tests for slash on its own line, slash after whitespace, slash at EOF, division expressions, and slash inside comments/literals.
+2. Implement line-alone slash detection using raw byte offsets.
+3. Re-run `go test ./oracle/parser -run 'TestSplit' -count=1`.
+
+### Task 3: PL/SQL Blocks and Stored Units
+
+**Files:**
+- Modify: `oracle/parser/split.go`
+- Modify: `oracle/parser/split_test.go`
+
+**Steps:**
+1. Add failing tests for anonymous `BEGIN...END`, `DECLARE...BEGIN...END`, nested blocks, procedure, function, package spec/body, trigger, type body, and follow-up SQL statements.
+2. Implement statement-mode tracking for PL/SQL starts and outer `END [name];`.
+3. Re-run focused tests and fix edge cases.
+
+### Task 4: Public Oracle Parse Facade
+
+**Files:**
+- Create: `oracle/parse.go`
+- Create: `oracle/parse_test.go`
+
+**Steps:**
+1. Add failing tests for `oracle.Parse` returning statements with text, AST, byte ranges, and line/column positions.
+2. Implement facade using `parser.Split` and per-segment `parser.Parse`.
+3. Re-run `go test ./oracle/... -count=1`.
+
+### Task 5: Verification
+
+**Commands:**
+- `go test ./oracle/parser -run 'TestSplit' -count=1`
+- `go test ./oracle/... -count=1`
+- If parser package failures are unrelated existing failures, capture exact failing tests and reason in the final report.
+
+### Task 6: SQL*Plus Script Commands
+
+**Files:**
+- Modify: `oracle/parser/split.go`
+- Modify: `oracle/parser/split_test.go`
+- Modify: `oracle/parse_test.go` if skipped command ranges affect facade behavior
+
+**Step 1: Write failing tests**
+
+Cover line-oriented SQL*Plus commands that must not be sent to the database parser:
+
+- Environment/output commands: `SET`, `SHOW`, `PROMPT`, `SPOOL`, `COLUMN`, `TTITLE`, `BTITLE`, `BREAK`, `COMPUTE`, `REPHEADER`, `REPFOOTER`, `CLEAR`, `PAUSE`, `HELP`.
+- Variable/input commands: `DEFINE`, `UNDEFINE`, `ACCEPT`, `VARIABLE`, `PRINT`, `EXECUTE`.
+- Script/session commands: `@`, `@@`, `START`, `CONNECT`, `DISCONNECT`, `PASSWORD`, `EXIT`, `QUIT`, `WHENEVER SQLERROR`, `WHENEVER OSERROR`, `HOST`, `!`.
+- Comment commands: `REM`, `REMARK`.
+- Buffer commands that execute or manipulate SQL buffer: `/`, `RUN`, `LIST`, `APPEND`, `CHANGE`, `DEL`, `INPUT`, `SAVE`, `GET`, `EDIT`.
+
+Expected behavior: these commands are line-local script commands and are skipped from returned SQL segments. `/` and `RUN` also flush the current segment as executable SQL/PLSQL before skipping the command line.
+
+**Step 2: Verify red**
+
+Run `go test ./oracle/parser -run 'TestSplitSQLPlusCommands' -count=1` and confirm the failures show command text leaking into SQL segments.
+
+**Step 3: Implement line-command scanner**
+
+Add raw-line command detection before token processing. When a command line starts at the current statement boundary, skip it and advance `stmtStart`. When a flushing command is found after accumulated SQL, append the segment first, then skip the command. Keep quoted SQL contents untouched by only scanning physical lines outside tokenized strings/comments.
+
+**Step 4: Verify green**
+
+Run the focused splitter tests, then `go test ./oracle/... -count=1`.

--- a/oracle/parse.go
+++ b/oracle/parse.go
@@ -1,0 +1,105 @@
+package oracle
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/oracle/ast"
+	"github.com/bytebase/omni/oracle/parser"
+)
+
+// Statement is the result of parsing a single Oracle SQL statement or PL/SQL
+// unit from a script.
+type Statement struct {
+	Text string
+	AST  ast.Node
+
+	ByteStart int
+	ByteEnd   int
+
+	Start Position
+	End   Position
+}
+
+// Position represents a location in source text.
+type Position struct {
+	Line   int
+	Column int
+}
+
+// Empty returns true if this statement has no meaningful content.
+func (s *Statement) Empty() bool {
+	return s.AST == nil
+}
+
+// Parse splits and parses an Oracle SQL script into statements.
+func Parse(sql string) ([]Statement, error) {
+	segments := parser.Split(sql)
+	if len(segments) == 0 {
+		return nil, nil
+	}
+
+	lineIndex := buildLineIndex(sql)
+	stmts := make([]Statement, 0, len(segments))
+	for _, seg := range segments {
+		list, err := parser.Parse(strings.Repeat(" ", seg.ByteStart) + seg.Text)
+		if err != nil {
+			return nil, err
+		}
+
+		var node ast.Node
+		if list != nil {
+			for _, item := range list.Items {
+				raw, ok := item.(*ast.RawStmt)
+				if ok {
+					node = raw.Stmt
+					break
+				}
+			}
+		}
+
+		contentStart := seg.ByteStart
+		for contentStart < seg.ByteEnd && isSpace(sql[contentStart]) {
+			contentStart++
+		}
+
+		stmts = append(stmts, Statement{
+			Text:      seg.Text,
+			AST:       node,
+			ByteStart: seg.ByteStart,
+			ByteEnd:   seg.ByteEnd,
+			Start:     offsetToPosition(lineIndex, contentStart),
+			End:       offsetToPosition(lineIndex, seg.ByteEnd),
+		})
+	}
+	return stmts, nil
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f'
+}
+
+type lineIndex []int
+
+func buildLineIndex(s string) lineIndex {
+	idx := lineIndex{0}
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			idx = append(idx, i+1)
+		}
+	}
+	return idx
+}
+
+func offsetToPosition(idx lineIndex, offset int) Position {
+	if offset < 0 {
+		offset = 0
+	}
+	line := 0
+	for line+1 < len(idx) && idx[line+1] <= offset {
+		line++
+	}
+	return Position{
+		Line:   line + 1,
+		Column: offset - idx[line] + 1,
+	}
+}

--- a/oracle/parse_test.go
+++ b/oracle/parse_test.go
@@ -1,0 +1,78 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/oracle/ast"
+)
+
+func TestParseSplitScript(t *testing.T) {
+	sql := "SELECT 1 FROM dual;\nBEGIN NULL; END;\n/\nSELECT 2 FROM dual;"
+
+	stmts, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(stmts) != 3 {
+		t.Fatalf("got %d statements, want 3", len(stmts))
+	}
+
+	if stmts[0].Text != "SELECT 1 FROM dual" {
+		t.Fatalf("stmt[0].Text = %q", stmts[0].Text)
+	}
+	if _, ok := stmts[0].AST.(*ast.SelectStmt); !ok {
+		t.Fatalf("stmt[0].AST = %T, want SelectStmt", stmts[0].AST)
+	}
+	if stmts[0].ByteStart != 0 || stmts[0].ByteEnd != len("SELECT 1 FROM dual") {
+		t.Fatalf("stmt[0] range = [%d,%d]", stmts[0].ByteStart, stmts[0].ByteEnd)
+	}
+	if stmts[0].Start != (Position{Line: 1, Column: 1}) {
+		t.Fatalf("stmt[0].Start = %+v", stmts[0].Start)
+	}
+
+	if stmts[1].Text != "\nBEGIN NULL; END;" {
+		t.Fatalf("stmt[1].Text = %q", stmts[1].Text)
+	}
+	if _, ok := stmts[1].AST.(*ast.PLSQLBlock); !ok {
+		t.Fatalf("stmt[1].AST = %T, want PLSQLBlock", stmts[1].AST)
+	}
+	if ast.NodeLoc(stmts[1].AST).Start != stmts[1].ByteStart+1 {
+		t.Fatalf("stmt[1] AST Loc.Start = %d, want %d", ast.NodeLoc(stmts[1].AST).Start, stmts[1].ByteStart+1)
+	}
+
+	if stmts[2].Text != "\nSELECT 2 FROM dual" {
+		t.Fatalf("stmt[2].Text = %q", stmts[2].Text)
+	}
+	if stmts[2].Start != (Position{Line: 4, Column: 1}) {
+		t.Fatalf("stmt[2].Start = %+v", stmts[2].Start)
+	}
+}
+
+func TestParseSkipsSQLPlusCommands(t *testing.T) {
+	sql := "SET DEFINE OFF\n" +
+		"PROMPT setup\n" +
+		"SELECT 1 FROM dual;\n" +
+		"SPOOL out.log\n" +
+		"SELECT 2 FROM dual;\n" +
+		"EXIT SUCCESS\n"
+
+	stmts, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("got %d statements, want 2", len(stmts))
+	}
+	if stmts[0].Text != "SELECT 1 FROM dual" {
+		t.Fatalf("stmt[0].Text = %q", stmts[0].Text)
+	}
+	if stmts[0].Start != (Position{Line: 3, Column: 1}) {
+		t.Fatalf("stmt[0].Start = %+v", stmts[0].Start)
+	}
+	if stmts[1].Text != "SELECT 2 FROM dual" {
+		t.Fatalf("stmt[1].Text = %q", stmts[1].Text)
+	}
+	if stmts[1].Start != (Position{Line: 5, Column: 1}) {
+		t.Fatalf("stmt[1].Start = %+v", stmts[1].Start)
+	}
+}

--- a/oracle/parser/split.go
+++ b/oracle/parser/split.go
@@ -1,0 +1,464 @@
+package parser
+
+// Segment represents a portion of Oracle SQL script text delimited by a
+// top-level semicolon or SQL*Plus-style slash command.
+type Segment struct {
+	Text      string
+	ByteStart int
+	ByteEnd   int
+}
+
+// Empty returns true if the segment contains only whitespace, semicolons, and
+// comments.
+func (s Segment) Empty() bool {
+	i := 0
+	for i < len(s.Text) {
+		switch s.Text[i] {
+		case ' ', '\t', '\n', '\r', '\f', ';':
+			i++
+			continue
+		case '-':
+			if i+1 < len(s.Text) && s.Text[i+1] == '-' {
+				i = splitSkipLineComment(s.Text, i)
+				continue
+			}
+		case '/':
+			if i+1 < len(s.Text) && s.Text[i+1] == '*' {
+				next, ok := splitSkipBlockComment(s.Text, i)
+				if !ok {
+					return false
+				}
+				i = next
+				continue
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// Split splits an Oracle SQL script into executable segments. It is deliberately
+// lexical and soft-fail: invalid or incomplete SQL still returns best-effort
+// statement boundaries.
+func Split(sql string) []Segment {
+	if sql == "" {
+		return nil
+	}
+
+	lexer := NewLexer(sql)
+	stmtStart := 0
+	var segments []Segment
+	state := splitState{}
+
+	for {
+		tok := lexer.NextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+
+		if !state.inPLSQL {
+			if cmd, ok := sqlPlusCommandAtLineStart(sql, tok); ok {
+				if cmd.flush {
+					if onlyIgnorableSQLPlusPrefix(sql, stmtStart, tok.Loc) {
+						if tok.Type == '/' && len(segments) > 0 {
+							stmtStart = lineEndBeforeBreak(sql, tok.End)
+						} else {
+							stmtStart = lineEndAfterBreak(sql, tok.End)
+						}
+					} else {
+						segments = appendSegment(segments, sql, stmtStart, trimRightSpace(sql, tok.Loc))
+						stmtStart = lineEndBeforeBreak(sql, tok.End)
+					}
+				} else if onlyIgnorableSQLPlusPrefix(sql, stmtStart, tok.Loc) {
+					stmtStart = lineEndAfterBreak(sql, tok.End)
+				}
+				lexer.pos = lineEndAfterBreak(sql, tok.End)
+				state.reset()
+				continue
+			}
+		}
+
+		state.observe(tok)
+
+		switch tok.Type {
+		case ';':
+			if state.inPLSQL {
+				if state.plsqlCanEndAtSemicolon() {
+					segments = appendSegment(segments, sql, stmtStart, tok.End)
+					stmtStart = tok.End
+					state.reset()
+				} else {
+					state.afterPLSQLSemicolon()
+				}
+			} else {
+				segments = appendSegment(segments, sql, stmtStart, tok.Loc)
+				stmtStart = tok.End
+			}
+		case '/':
+			if isSlashDelimiterLine(sql, tok.Loc, tok.End) {
+				segments = appendSegment(segments, sql, stmtStart, trimRightSpace(sql, tok.Loc))
+				stmtStart = slashNextSegmentStart(sql, tok.End)
+				state.reset()
+			}
+		}
+
+		if lexer.Err != nil {
+			break
+		}
+	}
+
+	segments = appendSegment(segments, sql, stmtStart, len(sql))
+	if len(segments) == 0 {
+		return nil
+	}
+	return segments
+}
+
+type splitPLSQLKind int
+
+const (
+	splitPLSQLNone splitPLSQLKind = iota
+	splitPLSQLBlock
+	splitPLSQLStoredUnit
+	splitPLSQLPackage
+)
+
+type splitState struct {
+	inPLSQL bool
+	kind    splitPLSQLKind
+	depth   int
+
+	pendingCreate     bool
+	pendingCreateType bool
+
+	endPending       bool
+	endFollowerWords int
+}
+
+func (s *splitState) reset() {
+	*s = splitState{}
+}
+
+func (s *splitState) observe(tok Token) {
+	if tok.Type == tokEOF {
+		return
+	}
+
+	if !s.inPLSQL {
+		s.observeTopLevel(tok)
+		return
+	}
+
+	s.observePLSQL(tok)
+}
+
+func (s *splitState) observeTopLevel(tok Token) {
+	if s.pendingCreateType {
+		if tok.Type == kwBODY {
+			s.startPLSQL(splitPLSQLPackage)
+		}
+		s.pendingCreateType = false
+	}
+
+	switch tok.Type {
+	case kwCREATE:
+		s.pendingCreate = true
+	case kwOR, kwREPLACE:
+		// CREATE OR REPLACE keeps looking for the created object type.
+	case tokIDENT:
+		if tok.Str != "EDITIONABLE" && tok.Str != "NONEDITIONABLE" {
+			s.pendingCreate = false
+		}
+	case kwPROCEDURE, kwFUNCTION, kwTRIGGER:
+		if s.pendingCreate {
+			s.startPLSQL(splitPLSQLStoredUnit)
+		}
+	case kwPACKAGE:
+		if s.pendingCreate {
+			s.startPLSQL(splitPLSQLPackage)
+		}
+	case kwTYPE:
+		if s.pendingCreate {
+			s.pendingCreateType = true
+		}
+	case kwDECLARE:
+		s.startPLSQL(splitPLSQLBlock)
+	case kwBEGIN:
+		s.startPLSQL(splitPLSQLBlock)
+		s.depth = 1
+	default:
+		if tok.Type != tokHINT {
+			s.pendingCreate = false
+		}
+	}
+}
+
+func (s *splitState) startPLSQL(kind splitPLSQLKind) {
+	s.inPLSQL = true
+	s.kind = kind
+	s.pendingCreate = false
+	s.pendingCreateType = false
+	s.endPending = false
+	s.endFollowerWords = 0
+}
+
+func (s *splitState) observePLSQL(tok Token) {
+	if s.endPending {
+		if tok.Type != ';' && isSplitWordToken(tok) {
+			s.endFollowerWords++
+		}
+		if tok.Type != ';' {
+			return
+		}
+	}
+
+	switch tok.Type {
+	case kwBEGIN, kwIF, kwCASE:
+		s.depth++
+	case kwLOOP:
+		if !s.endPending {
+			s.depth++
+		}
+	case kwEND:
+		if s.depth > 0 {
+			s.depth--
+		}
+		if s.depth == 0 {
+			s.endPending = true
+			s.endFollowerWords = 0
+		}
+	}
+}
+
+func (s *splitState) plsqlCanEndAtSemicolon() bool {
+	if !s.endPending {
+		return false
+	}
+	if s.kind == splitPLSQLPackage {
+		return false
+	}
+	return s.endFollowerWords <= 1
+}
+
+func (s *splitState) afterPLSQLSemicolon() {
+	s.endPending = false
+	s.endFollowerWords = 0
+}
+
+func isSplitWordToken(tok Token) bool {
+	return tok.Type == tokIDENT || tok.Type == tokQIDENT || tok.Type >= 2000
+}
+
+type sqlPlusCommand struct {
+	flush bool
+}
+
+func sqlPlusCommandAtLineStart(sql string, tok Token) (sqlPlusCommand, bool) {
+	lineStart := lineStartOffset(sql, tok.Loc)
+	i := skipHorizontalSpace(sql, lineStart)
+	if i != tok.Loc {
+		return sqlPlusCommand{}, false
+	}
+
+	if tok.Type == '/' && isSlashDelimiterLine(sql, tok.Loc, tok.End) {
+		return sqlPlusCommand{flush: true}, true
+	}
+	if tok.Type == '@' || tok.Type == '!' {
+		return sqlPlusCommand{}, true
+	}
+
+	word := splitTokenWord(tok)
+	if word == "" {
+		return sqlPlusCommand{}, false
+	}
+	if isSQLPlusFlushCommand(word) {
+		return sqlPlusCommand{flush: true}, true
+	}
+	if isSQLPlusLineCommand(word) {
+		return sqlPlusCommand{}, true
+	}
+	return sqlPlusCommand{}, false
+}
+
+func splitTokenWord(tok Token) string {
+	if tok.Type == tokIDENT || tok.Type >= 2000 {
+		return tok.Str
+	}
+	return ""
+}
+
+func isSQLPlusFlushCommand(word string) bool {
+	switch word {
+	case "RUN", "R":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSQLPlusLineCommand(word string) bool {
+	switch word {
+	case "ACC", "ACCEPT",
+		"APP", "APPEND", "ARG", "ARGUMENT",
+		"ARCHIVE", "ATTRIBUTE",
+		"BRE", "BREAK", "BTI", "BTITLE",
+		"CHANGE", "C", "CL", "CLEAR", "COL", "COLUMN", "COMP", "COMPUTE", "CONFIG", "CONN", "CONNECT", "COPY",
+		"DEF", "DEFINE", "DEL", "DESC", "DESCRIBE", "DISC", "DISCONNECT",
+		"ED", "EDIT", "EXEC", "EXECUTE", "EXIT",
+		"GET", "HELP", "HISTORY", "HO", "HOST",
+		"INPUT",
+		"L", "LIST",
+		"OERR",
+		"PASSW", "PASSWORD", "PAU", "PAUSE", "PING", "PRI", "PRINT", "PRO", "PROMPT",
+		"QUIT",
+		"RECOVER", "REM", "REMARK", "REPF", "REPFOOTER", "REPH", "REPHEADER",
+		"SAVE", "SET", "SHO", "SHOW", "SHUTDOWN", "SPO", "SPOOL", "STA", "START", "STARTUP", "STORE",
+		"TIMI", "TIMING", "TTI", "TTITLE",
+		"UNDEF", "UNDEFINE",
+		"VAR", "VARIABLE",
+		"WHENEVER",
+		"XQUERY":
+		return true
+	default:
+		return false
+	}
+}
+
+func onlyIgnorableSQLPlusPrefix(sql string, start, end int) bool {
+	seg := Segment{Text: sql[start:end], ByteStart: start, ByteEnd: end}
+	return seg.Empty()
+}
+
+func lineStartOffset(sql string, pos int) int {
+	if pos > len(sql) {
+		pos = len(sql)
+	}
+	for pos > 0 && sql[pos-1] != '\n' && sql[pos-1] != '\r' {
+		pos--
+	}
+	return pos
+}
+
+func skipHorizontalSpace(sql string, i int) int {
+	for i < len(sql) {
+		switch sql[i] {
+		case ' ', '\t', '\f':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func lineEndBeforeBreak(sql string, pos int) int {
+	for pos < len(sql) && sql[pos] != '\n' && sql[pos] != '\r' {
+		pos++
+	}
+	return pos
+}
+
+func lineEndAfterBreak(sql string, pos int) int {
+	pos = lineEndBeforeBreak(sql, pos)
+	if pos < len(sql) && sql[pos] == '\r' {
+		pos++
+	}
+	if pos < len(sql) && sql[pos] == '\n' {
+		pos++
+	}
+	return pos
+}
+
+func appendSegment(segments []Segment, sql string, start, end int) []Segment {
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+	if end > len(sql) {
+		end = len(sql)
+	}
+	seg := Segment{
+		Text:      sql[start:end],
+		ByteStart: start,
+		ByteEnd:   end,
+	}
+	if seg.Empty() {
+		return segments
+	}
+	return append(segments, seg)
+}
+
+func isSlashDelimiterLine(sql string, loc, end int) bool {
+	if loc < 0 || loc >= len(sql) || sql[loc] != '/' {
+		return false
+	}
+	for i := loc - 1; i >= 0 && sql[i] != '\n' && sql[i] != '\r'; i-- {
+		if sql[i] != ' ' && sql[i] != '\t' && sql[i] != '\f' {
+			return false
+		}
+	}
+	for i := end; i < len(sql) && sql[i] != '\n' && sql[i] != '\r'; i++ {
+		if sql[i] != ' ' && sql[i] != '\t' && sql[i] != '\f' {
+			return false
+		}
+	}
+	return true
+}
+
+func trimRightSpace(sql string, end int) int {
+	for end > 0 {
+		switch sql[end-1] {
+		case ' ', '\t', '\n', '\r', '\f':
+			end--
+		default:
+			return end
+		}
+	}
+	return end
+}
+
+func slashNextSegmentStart(sql string, start int) int {
+	i := start
+	for i < len(sql) {
+		switch sql[i] {
+		case ' ', '\t', '\f':
+			i++
+		case '\r', '\n':
+			return i
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func splitSkipLineComment(sql string, i int) int {
+	i += 2
+	for i < len(sql) {
+		i++
+		if sql[i-1] == '\n' {
+			break
+		}
+	}
+	return i
+}
+
+func splitSkipBlockComment(sql string, i int) (int, bool) {
+	i += 2
+	depth := 1
+	for i < len(sql) && depth > 0 {
+		switch {
+		case sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			depth++
+			i += 2
+		case sql[i] == '*' && i+1 < len(sql) && sql[i+1] == '/':
+			depth--
+			i += 2
+		default:
+			i++
+		}
+	}
+	return i, depth == 0
+}

--- a/oracle/parser/split_bytebase_test.go
+++ b/oracle/parser/split_bytebase_test.go
@@ -1,0 +1,160 @@
+package parser
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type bytebaseSplitCase struct {
+	Description string                    `yaml:"description"`
+	Input       string                    `yaml:"input"`
+	Error       string                    `yaml:"error,omitempty"`
+	Result      []bytebaseStatementResult `yaml:"result,omitempty"`
+}
+
+type bytebaseStatementResult struct {
+	Text  string              `yaml:"text"`
+	Range bytebaseRangeResult `yaml:"range"`
+	Empty bool                `yaml:"empty"`
+}
+
+type bytebaseRangeResult struct {
+	Start int `yaml:"start"`
+	End   int `yaml:"end"`
+}
+
+func TestSplitBytebasePLSQLBoundaryCompatibility(t *testing.T) {
+	data, err := os.ReadFile("testdata/bytebase_plsql_split.yaml")
+	if err != nil {
+		t.Fatalf("read Bytebase PLSQL split fixture: %v", err)
+	}
+
+	var cases []bytebaseSplitCase
+	if err := yaml.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("unmarshal Bytebase PLSQL split fixture: %v", err)
+	}
+	if len(cases) == 0 {
+		t.Fatal("Bytebase PLSQL split fixture is empty")
+	}
+
+	checked := 0
+	skippedErrors := 0
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			if tc.Error != "" {
+				skippedErrors++
+				t.Skip("Bytebase parser-level syntax error expectation is outside lexical splitter scope")
+			}
+			checked++
+
+			got := Split(tc.Input)
+			if len(got) != len(tc.Result) {
+				t.Fatalf("got %d segments %q, want %d", len(got), splitTexts(got), len(tc.Result))
+			}
+			for i, seg := range got {
+				want := tc.Result[i]
+				gotComparable := trimBytebaseTrailingHidden(seg.Text)
+				wantComparable := trimBytebaseTrailingHidden(want.Text)
+				if gotComparable != wantComparable {
+					t.Fatalf("segment[%d] comparable text = %q, want %q; raw got %q, raw want %q", i, gotComparable, wantComparable, seg.Text, want.Text)
+				}
+				if seg.ByteStart != want.Range.Start {
+					t.Fatalf("segment[%d] start = %d, want %d", i, seg.ByteStart, want.Range.Start)
+				}
+				if gotComparableEnd := seg.ByteStart + len(gotComparable); gotComparableEnd != want.Range.End {
+					t.Fatalf("segment[%d] comparable end = %d, want %d; raw range [%d,%d]", i, gotComparableEnd, want.Range.End, seg.ByteStart, seg.ByteEnd)
+				}
+				if seg.Empty() != want.Empty {
+					t.Fatalf("segment[%d] empty = %v, want %v", i, seg.Empty(), want.Empty)
+				}
+				if startsWithStatementDelimiter(seg.Text) {
+					t.Fatalf("segment[%d] starts with a statement delimiter: %q", i, seg.Text)
+				}
+			}
+		})
+	}
+
+	if checked == 0 {
+		t.Fatal("no successful Bytebase split cases checked")
+	}
+	if skippedErrors == 0 {
+		t.Fatal("fixture shape changed: expected at least one parser-level error case")
+	}
+}
+
+func trimBytebaseTrailingHidden(text string) string {
+	end := len(text)
+	for {
+		trimmed := trimRightSpace(text, end)
+		if trimmed != end {
+			end = trimmed
+			continue
+		}
+		if blockStart := bytebaseTrailingBlockCommentStart(text, end); blockStart >= 0 {
+			end = blockStart
+			continue
+		}
+		if lineStart := bytebaseTrailingLineCommentStart(text, end); lineStart >= 0 {
+			end = lineStart
+			continue
+		}
+		return text[:end]
+	}
+}
+
+func bytebaseTrailingBlockCommentStart(text string, end int) int {
+	if end < 4 || text[end-2] != '*' || text[end-1] != '/' {
+		return -1
+	}
+	for i := end - 4; i >= 0; i-- {
+		if text[i] != '/' || text[i+1] != '*' {
+			continue
+		}
+		next, ok := splitSkipBlockComment(text, i)
+		if ok && next == end {
+			return i
+		}
+	}
+	return -1
+}
+
+func bytebaseTrailingLineCommentStart(text string, end int) int {
+	lineStart := lineStartOffset(text, end)
+	for i := end - 2; i >= lineStart; i-- {
+		if text[i] == '-' && text[i+1] == '-' {
+			return i
+		}
+	}
+	return -1
+}
+
+func startsWithStatementDelimiter(text string) bool {
+	i := 0
+	for i < len(text) {
+		switch text[i] {
+		case ' ', '\t', '\n', '\r', '\f':
+			i++
+			continue
+		case '-':
+			if i+1 < len(text) && text[i+1] == '-' {
+				i = splitSkipLineComment(text, i)
+				continue
+			}
+		case '/':
+			if i+1 < len(text) && text[i+1] == '*' {
+				next, ok := splitSkipBlockComment(text, i)
+				if ok {
+					i = next
+					continue
+				}
+			}
+			return isSlashDelimiterLine(text, i, i+1)
+		case ';':
+			return true
+		}
+		return false
+	}
+	return false
+}

--- a/oracle/parser/split_golden_test.go
+++ b/oracle/parser/split_golden_test.go
@@ -1,0 +1,69 @@
+package parser
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type splitGoldenCase struct {
+	Description string                 `yaml:"description"`
+	Input       string                 `yaml:"input"`
+	Parse       bool                   `yaml:"parse,omitempty"`
+	Statements  []splitGoldenStatement `yaml:"statements"`
+}
+
+type splitGoldenStatement struct {
+	Text string `yaml:"text"`
+}
+
+func TestSplitGoldenCorpus(t *testing.T) {
+	data, err := os.ReadFile("testdata/splitter.yaml")
+	if err != nil {
+		t.Fatalf("read splitter corpus: %v", err)
+	}
+
+	var cases []splitGoldenCase
+	if err := yaml.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("unmarshal splitter corpus: %v", err)
+	}
+	if len(cases) < 80 {
+		t.Fatalf("splitter corpus has %d cases, want at least 80", len(cases))
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Description, func(t *testing.T) {
+			got := Split(tc.Input)
+			if len(got) != len(tc.Statements) {
+				t.Fatalf("got %d segments %q, want %d", len(got), splitTexts(got), len(tc.Statements))
+			}
+
+			prevEnd := 0
+			for i, seg := range got {
+				if seg.ByteStart < prevEnd {
+					t.Fatalf("segment[%d] starts at %d before previous end %d", i, seg.ByteStart, prevEnd)
+				}
+				if seg.ByteStart < 0 || seg.ByteEnd < seg.ByteStart || seg.ByteEnd > len(tc.Input) {
+					t.Fatalf("segment[%d] invalid range [%d,%d] for input length %d", i, seg.ByteStart, seg.ByteEnd, len(tc.Input))
+				}
+				if seg.Text != tc.Input[seg.ByteStart:seg.ByteEnd] {
+					t.Fatalf("segment[%d] Text does not match input range [%d,%d]", i, seg.ByteStart, seg.ByteEnd)
+				}
+				if seg.Empty() {
+					t.Fatalf("segment[%d] is empty: %q", i, seg.Text)
+				}
+				if seg.Text != tc.Statements[i].Text {
+					t.Fatalf("segment[%d] = %q, want %q", i, seg.Text, tc.Statements[i].Text)
+				}
+				if tc.Parse {
+					if _, err := Parse(strings.Repeat(" ", seg.ByteStart) + seg.Text); err != nil {
+						t.Fatalf("segment[%d] parse error: %v\ntext:\n%s", i, err, seg.Text)
+					}
+				}
+				prevEnd = seg.ByteEnd
+			}
+		})
+	}
+}

--- a/oracle/parser/split_invariant_test.go
+++ b/oracle/parser/split_invariant_test.go
@@ -1,0 +1,170 @@
+package parser
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestSplitInvariantsForCuratedScripts(t *testing.T) {
+	for _, sql := range []string{
+		"",
+		";;;",
+		"SELECT 1 FROM dual;",
+		"SELECT 'a;b' FROM dual; SELECT q'[c;d]' FROM dual;",
+		"SELECT 1 /* ; */ FROM dual; -- ;\nSELECT 2 FROM dual;",
+		"BEGIN NULL; END;\n/\nSELECT 1 FROM dual;",
+		"CREATE PACKAGE BODY pkg IS\nPROCEDURE p IS BEGIN NULL; END;\nEND pkg;\n/\n",
+		"SET DEFINE OFF\nPROMPT before ;\nSELECT 1 FROM dual;\nSPOOL out.log\nSELECT 2 FROM dual;",
+		"/\n/\nSELECT 1 FROM dual\n/\n/",
+		"SELECT 'unterminated; SELECT 2 FROM dual;",
+		"CREATE PROCEDURE p IS BEGIN NULL;",
+		string(allBytes()),
+		"SELECT 1 FROM dual;\x00\x01SELECT 2 FROM dual;",
+	} {
+		t.Run(fmt.Sprintf("%q", sql), func(t *testing.T) {
+			assertSplitInvariants(t, sql)
+		})
+	}
+}
+
+func TestSplitInvariantsForGeneratedScripts(t *testing.T) {
+	commands := []string{
+		"",
+		"SET DEFINE OFF\n",
+		"PROMPT preparing ; script\n",
+		"SPOOL install.log\n",
+		"WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK\n",
+		"REM ignored ; semicolon\n",
+		"@preflight.sql\n",
+	}
+	literals := []string{
+		"'plain'",
+		"'semi;colon'",
+		"q'[semi;colon]'",
+		`"quoted;identifier"`,
+		"/* block ; comment */ 1",
+	}
+	plsql := []string{
+		"BEGIN NULL; END;",
+		"BEGIN IF 1 = 1 THEN NULL; END IF; END;",
+		"DECLARE v NUMBER := 1; BEGIN v := v + 1; END;",
+		"CREATE PROCEDURE p IS BEGIN NULL; NULL; END;",
+		"CREATE TRIGGER trg BEFORE INSERT ON t BEGIN NULL; END;",
+	}
+
+	for i, command := range commands {
+		for j, literal := range literals {
+			for k, block := range plsql {
+				sql := command +
+					fmt.Sprintf("SELECT %s FROM dual;\n", literal) +
+					block + "\n/\n" +
+					commands[(i+j+k)%len(commands)] +
+					"SELECT 10 / 2 FROM dual;"
+				t.Run(fmt.Sprintf("command_%d_literal_%d_plsql_%d", i, j, k), func(t *testing.T) {
+					assertSplitInvariants(t, sql)
+				})
+			}
+		}
+	}
+}
+
+func TestSplitSoftFailInvariantsForGeneratedInvalidInputs(t *testing.T) {
+	fragments := []string{
+		"SELECT 1 FROM dual;",
+		"BEGIN NULL;",
+		"CREATE PROCEDURE p IS BEGIN",
+		"SELECT 'unterminated",
+		"SELECT q'[unterminated",
+		"SELECT \"unterminated",
+		"/* unterminated",
+		"\x00\x01\x02",
+		";\n/\n",
+	}
+
+	rng := rand.New(rand.NewSource(20260509))
+	for i := 0; i < 128; i++ {
+		var b strings.Builder
+		for j := 0; j < 1+rng.Intn(8); j++ {
+			b.WriteString(fragments[rng.Intn(len(fragments))])
+			switch rng.Intn(4) {
+			case 0:
+				b.WriteByte('\n')
+			case 1:
+				b.WriteByte(';')
+			case 2:
+				b.WriteString("\n/\n")
+			}
+		}
+		sql := b.String()
+		t.Run(fmt.Sprintf("generated_%03d", i), func(t *testing.T) {
+			assertSplitInvariants(t, sql)
+		})
+	}
+}
+
+func FuzzSplitInvariants(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"SELECT 1 FROM dual;",
+		"SELECT 'a;b' FROM dual; SELECT 2 FROM dual;",
+		"BEGIN NULL; END;\n/\nSELECT 1 FROM dual;",
+		"SET DEFINE OFF\nSELECT 1 FROM dual;",
+		"SELECT 'unterminated; SELECT 2 FROM dual;",
+		string(allBytes()),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, sql string) {
+		assertSplitInvariants(t, sql)
+	})
+}
+
+func assertSplitInvariants(t *testing.T, sql string) {
+	t.Helper()
+
+	var segments []Segment
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Split panicked for input %q: %v", sql, r)
+			}
+		}()
+		segments = Split(sql)
+	}()
+
+	prevEnd := 0
+	for i, seg := range segments {
+		if seg.ByteStart < prevEnd {
+			t.Fatalf("segment[%d] starts at %d before previous end %d", i, seg.ByteStart, prevEnd)
+		}
+		if seg.ByteStart < 0 || seg.ByteEnd < seg.ByteStart || seg.ByteEnd > len(sql) {
+			t.Fatalf("segment[%d] invalid range [%d,%d] for input length %d", i, seg.ByteStart, seg.ByteEnd, len(sql))
+		}
+		if seg.Text != sql[seg.ByteStart:seg.ByteEnd] {
+			t.Fatalf("segment[%d] text %q does not match input range %q", i, seg.Text, sql[seg.ByteStart:seg.ByteEnd])
+		}
+		if seg.Empty() {
+			t.Fatalf("segment[%d] is empty: %q", i, seg.Text)
+		}
+
+		resplit := Split(seg.Text)
+		if len(resplit) != 1 {
+			t.Fatalf("segment[%d] resplit into %d segments: %#v", i, len(resplit), resplit)
+		}
+		if resplit[0].Text != seg.Text {
+			t.Fatalf("segment[%d] resplit text = %q, want %q", i, resplit[0].Text, seg.Text)
+		}
+		prevEnd = seg.ByteEnd
+	}
+}
+
+func allBytes() []byte {
+	b := make([]byte, 256)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}

--- a/oracle/parser/split_test.go
+++ b/oracle/parser/split_test.go
@@ -1,0 +1,360 @@
+package parser
+
+import "testing"
+
+func TestSplitOrdinarySQL(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "empty input",
+			sql:  "",
+			want: nil,
+		},
+		{
+			name: "two semicolon statements",
+			sql:  "SELECT 1 FROM dual; SELECT 2 FROM dual;",
+			want: []string{"SELECT 1 FROM dual", " SELECT 2 FROM dual"},
+		},
+		{
+			name: "trailing statement without semicolon",
+			sql:  "SELECT 1 FROM dual; SELECT 2 FROM dual",
+			want: []string{"SELECT 1 FROM dual", " SELECT 2 FROM dual"},
+		},
+		{
+			name: "filters empty statements",
+			sql:  ";\n -- comment only\n ; SELECT 1 FROM dual;",
+			want: []string{" SELECT 1 FROM dual"},
+		},
+		{
+			name: "semicolon inside single quoted string",
+			sql:  "SELECT 'a;b' FROM dual; SELECT 1 FROM dual;",
+			want: []string{"SELECT 'a;b' FROM dual", " SELECT 1 FROM dual"},
+		},
+		{
+			name: "semicolon inside q quote",
+			sql:  "SELECT q'[a;b]' FROM dual; SELECT 1 FROM dual;",
+			want: []string{"SELECT q'[a;b]' FROM dual", " SELECT 1 FROM dual"},
+		},
+		{
+			name: "semicolon inside double quoted identifier",
+			sql:  `SELECT "a;b" FROM dual; SELECT 1 FROM dual;`,
+			want: []string{`SELECT "a;b" FROM dual`, " SELECT 1 FROM dual"},
+		},
+		{
+			name: "semicolon inside comments",
+			sql:  "SELECT 1 /* ; */ FROM dual; -- ;\nSELECT 2 FROM dual;",
+			want: []string{"SELECT 1 /* ; */ FROM dual", " -- ;\nSELECT 2 FROM dual"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitTexts(Split(tt.sql))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitSlashDelimiter(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "slash on own line separates SQL",
+			sql:  "SELECT 1 FROM dual\n/\nSELECT 2 FROM dual\n/",
+			want: []string{"SELECT 1 FROM dual", "\nSELECT 2 FROM dual"},
+		},
+		{
+			name: "slash line allows surrounding whitespace",
+			sql:  "SELECT 1 FROM dual\n  /  \nSELECT 2 FROM dual",
+			want: []string{"SELECT 1 FROM dual", "\nSELECT 2 FROM dual"},
+		},
+		{
+			name: "slash in division expression is not delimiter",
+			sql:  "SELECT 10 / 2 FROM dual; SELECT 3 FROM dual;",
+			want: []string{"SELECT 10 / 2 FROM dual", " SELECT 3 FROM dual"},
+		},
+		{
+			name: "slash in string and comment is not delimiter",
+			sql:  "SELECT '/' FROM dual; /*\n/\n*/ SELECT 2 FROM dual;",
+			want: []string{"SELECT '/' FROM dual", " /*\n/\n*/ SELECT 2 FROM dual"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitTexts(Split(tt.sql))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitRanges(t *testing.T) {
+	sql := "\nSELECT 1 FROM dual;\n  /  \nSELECT 2 FROM dual;"
+	got := Split(sql)
+	if len(got) != 2 {
+		t.Fatalf("got %d segments, want 2: %#v", len(got), got)
+	}
+	for _, seg := range got {
+		if seg.Text != sql[seg.ByteStart:seg.ByteEnd] {
+			t.Fatalf("segment range [%d,%d] extracts %q, want Text %q", seg.ByteStart, seg.ByteEnd, sql[seg.ByteStart:seg.ByteEnd], seg.Text)
+		}
+	}
+	if got[0].Text != "\nSELECT 1 FROM dual" {
+		t.Fatalf("first Text = %q", got[0].Text)
+	}
+	if got[1].Text != "\nSELECT 2 FROM dual" {
+		t.Fatalf("second Text = %q", got[1].Text)
+	}
+}
+
+func TestSplitPLSQLBlocks(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "anonymous begin end block",
+			sql:  "BEGIN NULL; END;\n/\nSELECT 1 FROM dual;",
+			want: []string{"BEGIN NULL; END;", "\nSELECT 1 FROM dual"},
+		},
+		{
+			name: "declare block with nested if",
+			sql: "DECLARE\n" +
+				"  v NUMBER := 1;\n" +
+				"BEGIN\n" +
+				"  IF v > 0 THEN\n" +
+				"    v := v + 1;\n" +
+				"  END IF;\n" +
+				"END;\n" +
+				"/\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{
+				"DECLARE\n  v NUMBER := 1;\nBEGIN\n  IF v > 0 THEN\n    v := v + 1;\n  END IF;\nEND;",
+				"\nSELECT 1 FROM dual",
+			},
+		},
+		{
+			name: "create procedure with internal statements",
+			sql: "CREATE OR REPLACE PROCEDURE p IS\n" +
+				"BEGIN\n" +
+				"  NULL;\n" +
+				"  NULL;\n" +
+				"END;\n" +
+				"/\n" +
+				"CREATE TABLE t (id NUMBER);",
+			want: []string{
+				"CREATE OR REPLACE PROCEDURE p IS\nBEGIN\n  NULL;\n  NULL;\nEND;",
+				"\nCREATE TABLE t (id NUMBER)",
+			},
+		},
+		{
+			name: "create editionable procedure",
+			sql: "CREATE OR REPLACE EDITIONABLE PROCEDURE p IS\n" +
+				"BEGIN\n" +
+				"  NULL;\n" +
+				"END;\n" +
+				"/\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{
+				"CREATE OR REPLACE EDITIONABLE PROCEDURE p IS\nBEGIN\n  NULL;\nEND;",
+				"\nSELECT 1 FROM dual",
+			},
+		},
+		{
+			name: "create type body",
+			sql: "CREATE TYPE BODY typ AS\n" +
+				"  MEMBER FUNCTION f RETURN NUMBER IS\n" +
+				"  BEGIN\n" +
+				"    RETURN 1;\n" +
+				"  END;\n" +
+				"END;\n" +
+				"/\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{
+				"CREATE TYPE BODY typ AS\n  MEMBER FUNCTION f RETURN NUMBER IS\n  BEGIN\n    RETURN 1;\n  END;\nEND;",
+				"\nSELECT 1 FROM dual",
+			},
+		},
+		{
+			name: "two package units with slash separators",
+			sql: "CREATE PACKAGE pkg IS\n" +
+				"  PROCEDURE p;\n" +
+				"END pkg;\n" +
+				"/\n" +
+				"CREATE PACKAGE BODY pkg IS\n" +
+				"  PROCEDURE p IS\n" +
+				"  BEGIN\n" +
+				"    NULL;\n" +
+				"  END;\n" +
+				"END pkg;\n" +
+				"/",
+			want: []string{
+				"CREATE PACKAGE pkg IS\n  PROCEDURE p;\nEND pkg;",
+				"\nCREATE PACKAGE BODY pkg IS\n  PROCEDURE p IS\n  BEGIN\n    NULL;\n  END;\nEND pkg;",
+			},
+		},
+		{
+			name: "create function with division expression",
+			sql: "CREATE FUNCTION f RETURN NUMBER IS\n" +
+				"BEGIN\n" +
+				"  RETURN 10 / 2;\n" +
+				"END;\n" +
+				"/\n",
+			want: []string{
+				"CREATE FUNCTION f RETURN NUMBER IS\nBEGIN\n  RETURN 10 / 2;\nEND;",
+			},
+		},
+		{
+			name: "compound trigger",
+			sql: "CREATE TRIGGER trg\n" +
+				"FOR INSERT ON t\n" +
+				"COMPOUND TRIGGER\n" +
+				"  BEFORE EACH ROW IS\n" +
+				"  BEGIN\n" +
+				"    NULL;\n" +
+				"  END BEFORE EACH ROW;\n" +
+				"END trg;\n" +
+				"/\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{
+				"CREATE TRIGGER trg\nFOR INSERT ON t\nCOMPOUND TRIGGER\n  BEFORE EACH ROW IS\n  BEGIN\n    NULL;\n  END BEFORE EACH ROW;\nEND trg;",
+				"\nSELECT 1 FROM dual",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitTexts(Split(tt.sql))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitSQLPlusCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "environment commands are skipped",
+			sql: "SET DEFINE OFF\n" +
+				"SET SERVEROUTPUT ON;\n" +
+				"PROMPT creating table;\n" +
+				"SPOOL install.log\n" +
+				"SELECT 1 FROM dual;\n" +
+				"SPOOL OFF\n" +
+				"SELECT 2 FROM dual;",
+			want: []string{"SELECT 1 FROM dual", "SELECT 2 FROM dual"},
+		},
+		{
+			name: "script and session commands are skipped",
+			sql: "CONNECT scott/tiger@db\n" +
+				"@preflight.sql\n" +
+				"@@nested/install.sql arg1 arg2\n" +
+				"START post.sql\n" +
+				"WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK\n" +
+				"SELECT 1 FROM dual;\n" +
+				"EXIT SUCCESS",
+			want: []string{"SELECT 1 FROM dual"},
+		},
+		{
+			name: "remark and host commands are skipped",
+			sql: "REM this ; is a SQL*Plus comment\n" +
+				"REMARK this is also ignored\n" +
+				"HOST echo before\n" +
+				"! echo shell\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{"SELECT 1 FROM dual"},
+		},
+		{
+			name: "formatting and variable commands are skipped",
+			sql: "COLUMN c FORMAT A20\n" +
+				"BREAK ON report\n" +
+				"COMPUTE SUM OF sal ON report\n" +
+				"TTITLE left 'Report'\n" +
+				"BTITLE off\n" +
+				"DEFINE schema_name = HR\n" +
+				"UNDEFINE schema_name\n" +
+				"ACCEPT v PROMPT 'Value: '\n" +
+				"VARIABLE rc NUMBER\n" +
+				"PRINT rc\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{"SELECT 1 FROM dual"},
+		},
+		{
+			name: "run flushes current SQL buffer",
+			sql:  "SELECT 1 FROM dual\nRUN\nSELECT 2 FROM dual;",
+			want: []string{"SELECT 1 FROM dual", "\nSELECT 2 FROM dual"},
+		},
+		{
+			name: "sqlplus command words inside SQL are not skipped",
+			sql:  "SELECT 'SET DEFINE OFF' AS txt FROM dual; SELECT prompt FROM t;",
+			want: []string{"SELECT 'SET DEFINE OFF' AS txt FROM dual", " SELECT prompt FROM t"},
+		},
+		{
+			name: "sqlplus command words in plsql are not skipped",
+			sql: "BEGIN\n" +
+				"  prompt := 'not a command';\n" +
+				"  NULL;\n" +
+				"END;\n" +
+				"/\n" +
+				"SELECT 1 FROM dual;",
+			want: []string{"BEGIN\n  prompt := 'not a command';\n  NULL;\nEND;", "\nSELECT 1 FROM dual"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitTexts(Split(tt.sql))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func splitTexts(segs []Segment) []string {
+	if len(segs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(segs))
+	for _, seg := range segs {
+		out = append(out, seg.Text)
+	}
+	return out
+}

--- a/oracle/parser/testdata/bytebase_plsql_split.yaml
+++ b/oracle/parser/testdata/bytebase_plsql_split.yaml
@@ -1,0 +1,491 @@
+- description: multiple SELECT statements
+  input: SELECT * FROM t1; SELECT * FROM t2
+  result:
+    - text: SELECT * FROM t1
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 17
+      range:
+        start: 0
+        end: 16
+      empty: false
+    - text: " SELECT * FROM t2"
+      baseline: 0
+      start:
+        line: 1
+        column: 18
+      end:
+        line: 1
+        column: 35
+      range:
+        start: 17
+        end: 34
+      empty: false
+- description: multiple statements with newlines
+  input: "\n\t\t\t\tselect * from t;\n\t\t\t\tcreate table table$1 (id int)\n\t\t\t"
+  result:
+    - text: "\n\t\t\t\tselect * from t"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 2
+        column: 20
+      range:
+        start: 0
+        end: 20
+      empty: false
+    - text: "\n\t\t\t\tcreate table table$1 (id int)"
+      baseline: 1
+      start:
+        line: 2
+        column: 21
+      end:
+        line: 3
+        column: 34
+      range:
+        start: 21
+        end: 55
+      empty: false
+- description: procedure with forward slash separator
+  input: |-
+    CREATE OR REPLACE PROCEDURE test_proc IS
+    BEGIN
+        CALL DBMS_OUTPUT.PUT_LINE('Hello');
+    END;
+    /
+  result:
+    - text: |-
+        CREATE OR REPLACE PROCEDURE test_proc IS
+        BEGIN
+            CALL DBMS_OUTPUT.PUT_LINE('Hello');
+        END;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 4
+        column: 5
+      range:
+        start: 0
+        end: 91
+      empty: false
+- description: two procedures with forward slash separator
+  input: |-
+    CREATE OR REPLACE PROCEDURE proc1 IS
+    BEGIN
+        NULL;
+    END;
+    /
+    CREATE OR REPLACE PROCEDURE proc2 IS
+    BEGIN
+        NULL;
+    END;
+    /
+  result:
+    - text: |-
+        CREATE OR REPLACE PROCEDURE proc1 IS
+        BEGIN
+            NULL;
+        END;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 4
+        column: 5
+      range:
+        start: 0
+        end: 57
+      empty: false
+    - text: "\nCREATE OR REPLACE PROCEDURE proc2 IS\nBEGIN\n    NULL;\nEND;"
+      baseline: 4
+      start:
+        line: 5
+        column: 2
+      end:
+        line: 9
+        column: 5
+      range:
+        start: 59
+        end: 117
+      empty: false
+- description: SELECT statements separated by forward slash
+  input: |-
+    SELECT * FROM t1;
+    /
+    SELECT * FROM t2;
+  result:
+    - text: SELECT * FROM t1
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 17
+      range:
+        start: 0
+        end: 16
+      empty: false
+    - text: "\nSELECT * FROM t2"
+      baseline: 1
+      start:
+        line: 2
+        column: 2
+      end:
+        line: 3
+        column: 17
+      range:
+        start: 19
+        end: 36
+      empty: false
+- description: anonymous block with forward slash
+  input: |-
+    BEGIN
+        CALL DBMS_OUTPUT.PUT_LINE('Test');
+    END;
+    /
+  result:
+    - text: |-
+        BEGIN
+            CALL DBMS_OUTPUT.PUT_LINE('Test');
+        END;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 3
+        column: 5
+      range:
+        start: 0
+        end: 49
+      empty: false
+- description: ALTER TABLE with PARTITION
+  input: |-
+    ALTER TABLE DATA.TEST
+    MODIFY PARTITION BY RANGE (TXN_DATE)
+    INTERVAL (NUMTODSINTERVAL(1, 'DAY'))
+    (
+    	PARTITION TEST_PO VALUES LESS THAN (
+    		TO_DATE('2000-01-01 00:00:00', 'SYYYY-MM-DD HH24:MI:SS', 'NLS_CALENDAR=GREGORIAN')
+    	)
+    )
+    ONLINE;
+  result:
+    - text: |-
+        ALTER TABLE DATA.TEST
+        MODIFY PARTITION BY RANGE (TXN_DATE)
+        INTERVAL (NUMTODSINTERVAL(1, 'DAY'))
+        (
+        	PARTITION TEST_PO VALUES LESS THAN (
+        		TO_DATE('2000-01-01 00:00:00', 'SYYYY-MM-DD HH24:MI:SS', 'NLS_CALENDAR=GREGORIAN')
+        	)
+        )
+        ONLINE
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 9
+        column: 7
+      range:
+        start: 0
+        end: 232
+      empty: false
+- description: CALL procedure
+  input: CALL my_procedure()
+  result:
+    - text: CALL my_procedure()
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 20
+      range:
+        start: 0
+        end: 19
+      empty: false
+- description: DROP TABLESPACE with CASCADE CONSTRAINTS
+  input: DROP TABLESPACE xxx INCLUDING CONTENTS CASCADE CONSTRAINTS
+  result:
+    - text: DROP TABLESPACE xxx INCLUDING CONTENTS CASCADE CONSTRAINTS
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 59
+      range:
+        start: 0
+        end: 58
+      empty: false
+- description: DROP TABLESPACE CASCADE alone should error
+  input: DROP TABLESPACE xxx CASCADE
+  error: "Syntax error at line 1:28 \nrelated text: DROP TABLESPACE xxx CASCADE;"
+- description: DROP TABLESPACE then CASCADE should error
+  input: DROP TABLESPACE xxx; CASCADE
+  error: "Syntax error at line 1:29 \nrelated text: DROP TABLESPACE xxx; CASCADE;"
+- description: CREATE TABLE with ROW STORE COMPRESS ADVANCED
+  input: |-
+    CREATE TABLE DATA.SMY_LAO_ACCOUNT_BLK_TXN_MTH (
+        TXN_DATE DATE,
+        TXN_NBR VARCHAR2(100 CHAR),
+        ARRANGEMENT_NBR VARCHAR2(100 CHAR),
+        TXN_NARRATIVE VARCHAR2(4000 CHAR),
+        FROM_DATE DATE,
+        TO_DATE DATE,
+        BLK_AMT NUMBER,
+        INPUTTER VARCHAR2(1000 CHAR),
+        NOTE VARCHAR2(4000 CHAR),
+        AUTHORISER VARCHAR2(1000 CHAR),
+        LAST_UPDATE_DATE DATE,
+        LAST_UPDATED_BY VARCHAR2(255 CHAR)
+    )
+    ROW STORE COMPRESS ADVANCED
+    TABLESPACE ARCHIVE_TBS
+    PCTFREE 10
+    NOLOGGING
+    PARTITION BY RANGE (TXN_DATE)
+    INTERVAL (NUMTOYMINTERVAL(1,'MONTH'))
+    (
+      PARTITION PART_01 VALUES LESS THAN (TO_DATE('2012-01-01 00:00:00', 'SYYYY-MM-DD HH24:MI:SS', 'NLS_CALENDAR=GREGORIAN'))
+        NOLOGGING
+        COMPRESS FOR OLTP
+        TABLESPACE ARCHIVE_TBS
+        PCTFREE 10
+        STORAGE (INITIAL 8388608 NEXT 1048576 MINEXTENTS 1 MAXEXTENTS 2147483645 BUFFER_POOL DEFAULT)
+    );
+  result:
+    - text: |-
+        CREATE TABLE DATA.SMY_LAO_ACCOUNT_BLK_TXN_MTH (
+            TXN_DATE DATE,
+            TXN_NBR VARCHAR2(100 CHAR),
+            ARRANGEMENT_NBR VARCHAR2(100 CHAR),
+            TXN_NARRATIVE VARCHAR2(4000 CHAR),
+            FROM_DATE DATE,
+            TO_DATE DATE,
+            BLK_AMT NUMBER,
+            INPUTTER VARCHAR2(1000 CHAR),
+            NOTE VARCHAR2(4000 CHAR),
+            AUTHORISER VARCHAR2(1000 CHAR),
+            LAST_UPDATE_DATE DATE,
+            LAST_UPDATED_BY VARCHAR2(255 CHAR)
+        )
+        ROW STORE COMPRESS ADVANCED
+        TABLESPACE ARCHIVE_TBS
+        PCTFREE 10
+        NOLOGGING
+        PARTITION BY RANGE (TXN_DATE)
+        INTERVAL (NUMTOYMINTERVAL(1,'MONTH'))
+        (
+          PARTITION PART_01 VALUES LESS THAN (TO_DATE('2012-01-01 00:00:00', 'SYYYY-MM-DD HH24:MI:SS', 'NLS_CALENDAR=GREGORIAN'))
+            NOLOGGING
+            COMPRESS FOR OLTP
+            TABLESPACE ARCHIVE_TBS
+            PCTFREE 10
+            STORAGE (INITIAL 8388608 NEXT 1048576 MINEXTENTS 1 MAXEXTENTS 2147483645 BUFFER_POOL DEFAULT)
+        )
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 28
+        column: 2
+      range:
+        start: 0
+        end: 845
+      empty: false
+- description: 'position semantic: leading newlines'
+  input: "\n\nSELECT 1 FROM dual"
+  result:
+    - text: "\n\nSELECT 1 FROM dual"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 3
+        column: 19
+      range:
+        start: 0
+        end: 20
+      empty: false
+- description: 'position semantic: leading spaces and newlines'
+  input: "\n  \n  SELECT 1 FROM dual"
+  result:
+    - text: "\n  \n  SELECT 1 FROM dual"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 3
+        column: 21
+      range:
+        start: 0
+        end: 24
+      empty: false
+- description: 'position semantic: multi-statement with leading whitespace'
+  input: "SELECT 1 FROM dual;\n\n  SELECT 2 FROM dual"
+  result:
+    - text: SELECT 1 FROM dual
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 19
+      range:
+        start: 0
+        end: 18
+      empty: false
+    - text: "\n\n  SELECT 2 FROM dual"
+      baseline: 0
+      start:
+        line: 1
+        column: 20
+      end:
+        line: 3
+        column: 21
+      range:
+        start: 19
+        end: 41
+      empty: false
+- description: 'BYT-9367: trailing semicolon with leading space does not leak (cell b)'
+  input: "insert into t values('a',1) ;\n\ninsert into t values('b',2) ;"
+  result:
+    - text: "insert into t values('a',1)"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 28
+      range:
+        start: 0
+        end: 27
+      empty: false
+    - text: "\n\ninsert into t values('b',2)"
+      baseline: 0
+      start:
+        line: 1
+        column: 30
+      end:
+        line: 3
+        column: 28
+      range:
+        start: 29
+        end: 58
+      empty: false
+- description: 'BYT-9367: trailing semicolon with leading inline comment does not leak (cell c)'
+  input: "insert into t values('a',1) /* note */ ;\ninsert into t values('b',2) ;"
+  result:
+    - text: "insert into t values('a',1)"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 28
+      range:
+        start: 0
+        end: 27
+      empty: false
+    - text: "\ninsert into t values('b',2)"
+      baseline: 0
+      start:
+        line: 1
+        column: 41
+      end:
+        line: 2
+        column: 28
+      range:
+        start: 40
+        end: 68
+      empty: false
+- description: 'BYT-9367: trailing semicolon with multiple newlines does not leak (cell d)'
+  input: "insert into t values('a',1)\n\n;\n\ninsert into t values('b',2);"
+  result:
+    - text: "insert into t values('a',1)"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 28
+      range:
+        start: 0
+        end: 27
+      empty: false
+    - text: "\n\ninsert into t values('b',2)"
+      baseline: 2
+      start:
+        line: 3
+        column: 2
+      end:
+        line: 5
+        column: 28
+      range:
+        start: 30
+        end: 59
+      empty: false
+- description: 'BYT-9367: anonymous block followed by SELECT with no separator (cell f, bail-on-default-channel)'
+  input: "BEGIN NULL; END;\nSELECT 1 FROM dual"
+  result:
+    - text: "BEGIN NULL; END;"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 17
+      range:
+        start: 0
+        end: 16
+      empty: false
+    - text: "\nSELECT 1 FROM dual"
+      baseline: 0
+      start:
+        line: 1
+        column: 17
+      end:
+        line: 2
+        column: 19
+      range:
+        start: 16
+        end: 35
+      empty: false
+- description: 'BYT-9367: trailing semicolon with leading space at EOF (cell h)'
+  input: "insert into t values('a',1) ;"
+  result:
+    - text: "insert into t values('a',1)"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 28
+      range:
+        start: 0
+        end: 27
+      empty: false

--- a/oracle/parser/testdata/splitter.yaml
+++ b/oracle/parser/testdata/splitter.yaml
@@ -1,0 +1,508 @@
+- description: empty input
+  input: ""
+  statements: []
+- description: whitespace only
+  input: " \t\n  "
+  statements: []
+- description: comment only
+  input: "-- only comment\n/* block */"
+  statements: []
+- description: single select with semicolon
+  input: "SELECT 1 FROM dual;"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: single select without semicolon
+  input: "SELECT 1 FROM dual"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: two selects with semicolons
+  input: "SELECT 1 FROM dual; SELECT 2 FROM dual;"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: " SELECT 2 FROM dual"
+- description: mixed terminated and unterminated
+  input: "SELECT 1 FROM dual; SELECT 2 FROM dual"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: " SELECT 2 FROM dual"
+- description: consecutive semicolons filtered
+  input: ";;SELECT 1 FROM dual;;;SELECT 2 FROM dual;;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "SELECT 2 FROM dual"
+- description: leading whitespace preserved
+  input: "\n  SELECT 1 FROM dual;"
+  parse: true
+  statements:
+    - text: "\n  SELECT 1 FROM dual"
+- description: interstatement whitespace attaches to next
+  input: "SELECT 1 FROM dual;\n\n  SELECT 2 FROM dual;"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\n\n  SELECT 2 FROM dual"
+- description: trailing whitespace final segment
+  input: "SELECT 1 FROM dual \n "
+  statements:
+    - text: "SELECT 1 FROM dual \n "
+- description: crlf ordinary statements
+  input: "SELECT 1 FROM dual;\r\nSELECT 2 FROM dual;\r\n"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\r\nSELECT 2 FROM dual"
+- description: utf8 comment between statements
+  input: "SELECT 1 FROM dual; -- 日本語\nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: " -- 日本語\nSELECT 2 FROM dual"
+- description: division expression
+  input: "SELECT 10 / 2 FROM dual; SELECT 3 FROM dual;"
+  statements:
+    - text: "SELECT 10 / 2 FROM dual"
+    - text: " SELECT 3 FROM dual"
+- description: schema and dblink qualified names
+  input: "SELECT owner.table_name FROM sys.dual@remote; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT owner.table_name FROM sys.dual@remote"
+    - text: " SELECT 1 FROM dual"
+- description: semicolon in single quoted literal
+  input: "SELECT 'a;b' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 'a;b' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: slash in single quoted literal
+  input: "SELECT '/' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT '/' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: doubled quote literal
+  input: "SELECT 'it''s;ok' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 'it''s;ok' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: national character literal
+  input: "SELECT N'a;b' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT N'a;b' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: q quote square
+  input: "SELECT q'[a;b/]' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT q'[a;b/]' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: q quote brace
+  input: "SELECT q'{a;b/}' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT q'{a;b/}' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: q quote paren
+  input: "SELECT q'(a;b/)' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT q'(a;b/)' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: q quote angle
+  input: "SELECT q'<a;b/>' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT q'<a;b/>' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: q quote custom delimiter
+  input: "SELECT q'!a;b/!' FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT q'!a;b/!' FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: semicolon in quoted identifier
+  input: "SELECT \"a;b\" FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT \"a;b\" FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: slash in quoted identifier
+  input: "SELECT \"/\" FROM dual; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT \"/\" FROM dual"
+    - text: " SELECT 1 FROM dual"
+- description: line comment with semicolon
+  input: "SELECT 1 FROM dual; -- ; ;\nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: " -- ; ;\nSELECT 2 FROM dual"
+- description: line comment with slash marker
+  input: "SELECT 1 FROM dual; --\n-- /\nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: " --\n-- /\nSELECT 2 FROM dual"
+- description: block comment with semicolon
+  input: "SELECT 1 /* ; */ FROM dual; SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 /* ; */ FROM dual"
+    - text: " SELECT 2 FROM dual"
+- description: block comment with slash line
+  input: "SELECT 1 FROM dual; /*\n/\n*/ SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: " /*\n/\n*/ SELECT 2 FROM dual"
+- description: nested block comment
+  input: "SELECT 1 /* outer /* inner ; */ still */ FROM dual; SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 /* outer /* inner ; */ still */ FROM dual"
+    - text: " SELECT 2 FROM dual"
+- description: hint with semicolon
+  input: "SELECT /*+ INDEX(t idx;name) */ * FROM t; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT /*+ INDEX(t idx;name) */ * FROM t"
+    - text: " SELECT 1 FROM dual"
+- description: slash delimiter simple
+  input: "SELECT 1 FROM dual\n/\nSELECT 2 FROM dual\n/"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\nSELECT 2 FROM dual"
+- description: slash delimiter with spaces
+  input: "SELECT 1 FROM dual\n  /  \nSELECT 2 FROM dual"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\nSELECT 2 FROM dual"
+- description: slash delimiter at eof
+  input: "SELECT 1 FROM dual\n/"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: slash followed by text is not delimiter
+  input: "SELECT 1 FROM dual\n/not_a_command\nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual\n/not_a_command\nSELECT 2 FROM dual"
+- description: slash preceded by text is not delimiter
+  input: "SELECT 1 FROM dual / \nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual / \nSELECT 2 FROM dual"
+- description: run flushes buffer
+  input: "SELECT 1 FROM dual\nRUN\nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\nSELECT 2 FROM dual"
+- description: r flushes buffer
+  input: "SELECT 1 FROM dual\nR\nSELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\nSELECT 2 FROM dual"
+- description: multiple slash commands filtered
+  input: "/\n/\nSELECT 1 FROM dual\n/\n/"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: anonymous begin end block
+  input: "BEGIN NULL; END;\n/\nSELECT 1 FROM dual;"
+  parse: true
+  statements:
+    - text: "BEGIN NULL; END;"
+    - text: "\nSELECT 1 FROM dual"
+- description: declare block
+  input: |-
+    DECLARE
+      v NUMBER := 1;
+    BEGIN
+      NULL;
+    END;
+    /
+  statements:
+    - text: |-
+        DECLARE
+          v NUMBER := 1;
+        BEGIN
+          NULL;
+        END;
+- description: labeled block
+  input: |-
+    <<outer>>
+    BEGIN
+      NULL;
+    END outer;
+    /
+  statements:
+    - text: |-
+        <<outer>>
+        BEGIN
+          NULL;
+        END outer;
+- description: nested anonymous block
+  input: |-
+    BEGIN
+      BEGIN
+        NULL;
+      END;
+      NULL;
+    END;
+    /
+  statements:
+    - text: |-
+        BEGIN
+          BEGIN
+            NULL;
+          END;
+          NULL;
+        END;
+- description: exception block
+  input: |-
+    BEGIN
+      NULL;
+    EXCEPTION
+      WHEN OTHERS THEN
+        NULL;
+    END;
+    /
+  statements:
+    - text: |-
+        BEGIN
+          NULL;
+        EXCEPTION
+          WHEN OTHERS THEN
+            NULL;
+        END;
+- description: if block
+  input: "BEGIN IF 1 = 1 THEN NULL; ELSE NULL; END IF; END;\n/"
+  statements:
+    - text: "BEGIN IF 1 = 1 THEN NULL; ELSE NULL; END IF; END;"
+- description: case statement block
+  input: "BEGIN CASE WHEN 1 = 1 THEN NULL; ELSE NULL; END CASE; END;\n/"
+  statements:
+    - text: "BEGIN CASE WHEN 1 = 1 THEN NULL; ELSE NULL; END CASE; END;"
+- description: basic loop block
+  input: "BEGIN LOOP NULL; EXIT; END LOOP; END;\n/"
+  statements:
+    - text: "BEGIN LOOP NULL; EXIT; END LOOP; END;"
+- description: while loop block
+  input: "BEGIN WHILE 1 = 1 LOOP NULL; EXIT; END LOOP; END;\n/"
+  statements:
+    - text: "BEGIN WHILE 1 = 1 LOOP NULL; EXIT; END LOOP; END;"
+- description: for loop block
+  input: "BEGIN FOR i IN 1..3 LOOP NULL; END LOOP; END;\n/"
+  statements:
+    - text: "BEGIN FOR i IN 1..3 LOOP NULL; END LOOP; END;"
+- description: forall block
+  input: "BEGIN FORALL i IN 1..3 INSERT INTO t VALUES (i); END;\n/"
+  statements:
+    - text: "BEGIN FORALL i IN 1..3 INSERT INTO t VALUES (i); END;"
+- description: execute immediate semicolon string
+  input: "BEGIN EXECUTE IMMEDIATE 'SELECT 1; SELECT 2'; END;\n/"
+  statements:
+    - text: "BEGIN EXECUTE IMMEDIATE 'SELECT 1; SELECT 2'; END;"
+- description: create procedure
+  input: "CREATE PROCEDURE p IS BEGIN NULL; END;\n/\nSELECT 1 FROM dual;"
+  statements:
+    - text: "CREATE PROCEDURE p IS BEGIN NULL; END;"
+    - text: "\nSELECT 1 FROM dual"
+- description: create or replace procedure
+  input: "CREATE OR REPLACE PROCEDURE p IS BEGIN NULL; END;\n/"
+  statements:
+    - text: "CREATE OR REPLACE PROCEDURE p IS BEGIN NULL; END;"
+- description: create editionable procedure
+  input: "CREATE EDITIONABLE PROCEDURE p IS BEGIN NULL; END;\n/"
+  statements:
+    - text: "CREATE EDITIONABLE PROCEDURE p IS BEGIN NULL; END;"
+- description: create noneditionable procedure
+  input: "CREATE NONEDITIONABLE PROCEDURE p IS BEGIN NULL; END;\n/"
+  statements:
+    - text: "CREATE NONEDITIONABLE PROCEDURE p IS BEGIN NULL; END;"
+- description: create function
+  input: "CREATE FUNCTION f RETURN NUMBER IS BEGIN RETURN 1; END;\n/"
+  statements:
+    - text: "CREATE FUNCTION f RETURN NUMBER IS BEGIN RETURN 1; END;"
+- description: create function division
+  input: "CREATE FUNCTION f RETURN NUMBER IS BEGIN RETURN 10 / 2; END;\n/"
+  statements:
+    - text: "CREATE FUNCTION f RETURN NUMBER IS BEGIN RETURN 10 / 2; END;"
+- description: package spec
+  input: |-
+    CREATE PACKAGE pkg IS
+      PROCEDURE p;
+      FUNCTION f RETURN NUMBER;
+    END pkg;
+    /
+  statements:
+    - text: |-
+        CREATE PACKAGE pkg IS
+          PROCEDURE p;
+          FUNCTION f RETURN NUMBER;
+        END pkg;
+- description: package body with nested procedure and function
+  input: |-
+    CREATE PACKAGE BODY pkg IS
+      PROCEDURE p IS
+      BEGIN
+        NULL;
+      END;
+      FUNCTION f RETURN NUMBER IS
+      BEGIN
+        RETURN 1;
+      END;
+    END pkg;
+    /
+  statements:
+    - text: |-
+        CREATE PACKAGE BODY pkg IS
+          PROCEDURE p IS
+          BEGIN
+            NULL;
+          END;
+          FUNCTION f RETURN NUMBER IS
+          BEGIN
+            RETURN 1;
+          END;
+        END pkg;
+- description: simple trigger
+  input: |-
+    CREATE TRIGGER trg BEFORE INSERT ON t
+    BEGIN
+      NULL;
+    END;
+    /
+    SELECT 1 FROM dual;
+  statements:
+    - text: |-
+        CREATE TRIGGER trg BEFORE INSERT ON t
+        BEGIN
+          NULL;
+        END;
+    - text: "\nSELECT 1 FROM dual"
+- description: compound trigger
+  input: |-
+    CREATE TRIGGER trg
+    FOR INSERT ON t
+    COMPOUND TRIGGER
+      BEFORE EACH ROW IS
+      BEGIN
+        NULL;
+      END BEFORE EACH ROW;
+    END trg;
+    /
+  statements:
+    - text: |-
+        CREATE TRIGGER trg
+        FOR INSERT ON t
+        COMPOUND TRIGGER
+          BEFORE EACH ROW IS
+          BEGIN
+            NULL;
+          END BEFORE EACH ROW;
+        END trg;
+- description: type body member function
+  input: |-
+    CREATE TYPE BODY typ AS
+      MEMBER FUNCTION f RETURN NUMBER IS
+      BEGIN
+        RETURN 1;
+      END;
+    END;
+    /
+  statements:
+    - text: |-
+        CREATE TYPE BODY typ AS
+          MEMBER FUNCTION f RETURN NUMBER IS
+          BEGIN
+            RETURN 1;
+          END;
+        END;
+- description: set and prompt skipped
+  input: "SET DEFINE OFF\nPROMPT hello; world\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: spool skipped between statements
+  input: "SELECT 1 FROM dual;\nSPOOL out.log\nSELECT 2 FROM dual;\nSPOOL OFF\nSELECT 3 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "SELECT 2 FROM dual"
+    - text: "SELECT 3 FROM dual"
+- description: show and column skipped
+  input: "SHOW USER\nCOLUMN c FORMAT A20\nSELECT 1 c FROM dual;"
+  statements:
+    - text: "SELECT 1 c FROM dual"
+- description: break compute titles skipped
+  input: "BREAK ON report\nCOMPUTE SUM OF sal ON report\nTTITLE left 'T'\nBTITLE off\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: define accept variable print skipped
+  input: "DEFINE x = 1\nACCEPT y PROMPT 'Y: '\nVARIABLE rc NUMBER\nPRINT rc\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: execute command skipped
+  input: "EXECUTE dbms_output.put_line('hi')\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: connect disconnect skipped
+  input: "CONNECT scott/tiger@db\nDISCONNECT\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: exit quit skipped
+  input: "SELECT 1 FROM dual;\nEXIT SUCCESS\nQUIT"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: whenever skipped
+  input: "WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK\nWHENEVER OSERROR EXIT FAILURE\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: script invocation skipped
+  input: "@pre.sql\n@@nested.sql arg\nSTART post.sql\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: rem remark skipped
+  input: "REM comment ;\nREMARK comment /\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: host bang skipped
+  input: "HOST echo hi\n! echo hi\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: buffer commands skipped
+  input: "LIST\nAPPEND text\nCHANGE /a/b/\nDEL 1\nINPUT x\nSAVE file.sql\nGET file.sql\nEDIT\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: sqlplus command words in SQL not skipped
+  input: "SELECT prompt, set_value FROM t; SELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT prompt, set_value FROM t"
+    - text: " SELECT 1 FROM dual"
+- description: sqlplus command words in plsql not skipped
+  input: "BEGIN prompt := 'x'; set_value := 1; NULL; END;\n/\nSELECT 1 FROM dual;"
+  statements:
+    - text: "BEGIN prompt := 'x'; set_value := 1; NULL; END;"
+    - text: "\nSELECT 1 FROM dual"
+- description: config history oerr ping xquery skipped
+  input: "CONFIG\nHISTORY\nOERR ORA 1\nPING db\nXQUERY 1\nSELECT 1 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+- description: unterminated single quote soft fail
+  input: "SELECT 'abc; SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 'abc; SELECT 2 FROM dual;"
+- description: unterminated q quote soft fail
+  input: "SELECT q'[abc; SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT q'[abc; SELECT 2 FROM dual;"
+- description: unterminated quoted identifier soft fail
+  input: "SELECT \"abc; SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT \"abc; SELECT 2 FROM dual;"
+- description: unterminated block comment soft fail
+  input: "SELECT 1 /* comment ; SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 /* comment ; SELECT 2 FROM dual;"
+- description: missing plsql end soft fail
+  input: "BEGIN NULL; SELECT 1 FROM dual;"
+  statements:
+    - text: "BEGIN NULL; SELECT 1 FROM dual;"
+- description: truncated create procedure soft fail
+  input: "CREATE PROCEDURE p IS BEGIN NULL;"
+  statements:
+    - text: "CREATE PROCEDURE p IS BEGIN NULL;"
+- description: binary bytes soft fail
+  input: "SELECT 1 FROM dual;\x00\x01SELECT 2 FROM dual;"
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "\x00\x01SELECT 2 FROM dual;"
+- description: skipped commands around parseable SQL
+  input: "SET TERMOUT OFF\nSELECT 1 FROM dual;\nPROMPT done\nSELECT 2 FROM dual;"
+  parse: true
+  statements:
+    - text: "SELECT 1 FROM dual"
+    - text: "SELECT 2 FROM dual"


### PR DESCRIPTION
## Summary
- Add a lexer-based Oracle script splitter with SQL, PL/SQL, SQL*Plus slash/RUN handling, and soft-fail behavior.
- Add top-level oracle.Parse integration that preserves original byte ranges and positions.
- Add comprehensive splitter coverage, including golden corpus, Bytebase boundary compatibility fixture, invariant/fuzz-seed tests, and scenario documentation.

## Test Plan
- go test ./oracle/... -count=1
- go test ./oracle/parser -run 'TestSplit' -count=1