### PR TITLE
fix(oracle): preserve SQLPlus line commands in splitter

### DIFF
--- a/SCENARIOS-oracle-splitter.md
+++ b/SCENARIOS-oracle-splitter.md
@@ -11,7 +11,7 @@
 - [x] Mixed terminated and unterminated SQL statements return separate segments.
 - [x] Consecutive semicolons do not produce empty segments.
 - [x] Leading whitespace before SQL is preserved in segment text and range.
-- [x] Inter-statement whitespace is attached to the following segment unless it is a skipped SQL*Plus command.
+- [x] Inter-statement whitespace is attached to the following segment unless it is consumed as a SQL*Plus line-command delimiter.
 - [x] Trailing whitespace after the final statement is preserved in the final segment.
 - [x] CRLF line endings do not corrupt boundaries.
 - [x] UTF-8 comments do not corrupt byte ranges.
@@ -86,29 +86,29 @@
 
 ## Phase 6: SQL*Plus Line Commands
 
-- [x] `SET` command lines are skipped.
-- [x] `SHOW` command lines are skipped.
-- [x] `PROMPT` command lines are skipped.
-- [x] `SPOOL` command lines are skipped.
-- [x] `COLUMN` command lines are skipped.
-- [x] `BREAK` command lines are skipped.
-- [x] `COMPUTE` command lines are skipped.
-- [x] `TTITLE` and `BTITLE` command lines are skipped.
-- [x] `REPHEADER` and `REPFOOTER` command lines are skipped.
-- [x] `DEFINE` and `UNDEFINE` command lines are skipped.
-- [x] `ACCEPT` command lines are skipped.
-- [x] `VARIABLE` and `PRINT` command lines are skipped.
-- [x] `EXECUTE` command lines are skipped as SQL*Plus commands.
-- [x] `CONNECT` and `DISCONNECT` command lines are skipped.
-- [x] `EXIT` and `QUIT` command lines are skipped.
-- [x] `WHENEVER SQLERROR` command lines are skipped.
-- [x] `WHENEVER OSERROR` command lines are skipped.
-- [x] `@`, `@@`, and `START` script invocation lines are skipped.
-- [x] `REM` and `REMARK` command lines are skipped.
-- [x] `HOST` and `!` shell command lines are skipped.
-- [x] Buffer manipulation commands `LIST`, `APPEND`, `CHANGE`, `DEL`, `INPUT`, `SAVE`, `GET`, and `EDIT` are skipped.
-- [x] SQL*Plus command words inside SQL are not skipped.
-- [x] SQL*Plus command words inside PL/SQL are not skipped.
+- [x] `SET` command lines are returned as line segments.
+- [x] `SHOW` command lines are returned as line segments.
+- [x] `PROMPT` command lines are returned as line segments, including embedded semicolons.
+- [x] `SPOOL` command lines are returned as line segments.
+- [x] `COLUMN` command lines are returned as line segments.
+- [x] `BREAK` command lines are returned as line segments.
+- [x] `COMPUTE` command lines are returned as line segments.
+- [x] `TTITLE` and `BTITLE` command lines are returned as line segments.
+- [x] `REPHEADER` and `REPFOOTER` command lines are returned as line segments.
+- [x] `DEFINE` and `UNDEFINE` command lines are returned as line segments.
+- [x] `ACCEPT` command lines are returned as line segments.
+- [x] `VARIABLE` and `PRINT` command lines are returned as line segments.
+- [x] `EXECUTE` command lines are returned as line segments.
+- [x] `CONNECT` and `DISCONNECT` command lines are returned as line segments.
+- [x] `EXIT` and `QUIT` command lines are returned as line segments.
+- [x] `WHENEVER SQLERROR` command lines are returned as line segments.
+- [x] `WHENEVER OSERROR` command lines are returned as line segments.
+- [x] `@`, `@@`, and `START` script invocation lines are returned as line segments.
+- [x] `REM` and `REMARK` command lines are returned as line segments.
+- [x] `HOST` and `!` shell command lines are returned as line segments.
+- [x] Buffer manipulation commands `LIST`, `APPEND`, `CHANGE`, `DEL`, `INPUT`, `SAVE`, `GET`, and `EDIT` are returned as line segments.
+- [x] SQL*Plus command words inside SQL are not treated as line commands.
+- [x] SQL*Plus command words inside PL/SQL are not treated as line commands.
 
 ## Phase 7: Soft-Fail and Safety
 
@@ -121,13 +121,13 @@
 - [x] Binary-ish bytes do not panic.
 - [x] Every returned segment has a valid non-overlapping byte range.
 - [x] Every returned segment text equals `input[ByteStart:ByteEnd]`.
-- [x] Reconstructing returned ranges never includes skipped SQL*Plus command lines.
+- [x] Reconstructing returned ranges includes SQL*Plus command lines as their own segments.
 
 ## Phase 8: Facade Integration
 
 - [x] `oracle.Parse` parses splitter output from ordinary SQL scripts.
 - [x] `oracle.Parse` parses splitter output from slash-terminated PL/SQL scripts.
-- [x] `oracle.Parse` skips SQL*Plus commands before parsing.
+- [x] `oracle.Parse` returns parser errors for SQL*Plus command segments instead of silently skipping them.
 - [x] `oracle.Parse` preserves original byte offsets in AST locations.
 - [x] `oracle.Parse` reports start line and column based on the original script.
-- [x] `oracle.Parse` handles multiple statements around skipped command lines.
+- [x] `oracle.Parse` handles multiple ordinary SQL statements around slash-delimited PL/SQL blocks.

--- a/oracle/parse_test.go
+++ b/oracle/parse_test.go
@@ -48,7 +48,7 @@ func TestParseSplitScript(t *testing.T) {
 	}
 }
 
-func TestParseSkipsSQLPlusCommands(t *testing.T) {
+func TestParseReturnsErrorForSQLPlusCommands(t *testing.T) {
 	sql := "SET DEFINE OFF\n" +
 		"PROMPT setup\n" +
 		"SELECT 1 FROM dual;\n" +
@@ -56,23 +56,7 @@ func TestParseSkipsSQLPlusCommands(t *testing.T) {
 		"SELECT 2 FROM dual;\n" +
 		"EXIT SUCCESS\n"
 
-	stmts, err := Parse(sql)
-	if err != nil {
-		t.Fatalf("Parse() error = %v", err)
-	}
-	if len(stmts) != 2 {
-		t.Fatalf("got %d statements, want 2", len(stmts))
-	}
-	if stmts[0].Text != "SELECT 1 FROM dual" {
-		t.Fatalf("stmt[0].Text = %q", stmts[0].Text)
-	}
-	if stmts[0].Start != (Position{Line: 3, Column: 1}) {
-		t.Fatalf("stmt[0].Start = %+v", stmts[0].Start)
-	}
-	if stmts[1].Text != "SELECT 2 FROM dual" {
-		t.Fatalf("stmt[1].Text = %q", stmts[1].Text)
-	}
-	if stmts[1].Start != (Position{Line: 5, Column: 1}) {
-		t.Fatalf("stmt[1].Start = %+v", stmts[1].Start)
+	if _, err := Parse(sql); err == nil {
+		t.Fatal("Parse() error = nil, want SQL*Plus command parse error")
 	}
 }

--- a/oracle/parser/split.go
+++ b/oracle/parser/split.go
@@ -37,7 +37,7 @@ func (s Segment) Empty() bool {
 	return true
 }
 
-// Split splits an Oracle SQL script into executable segments. It is deliberately
+// Split splits an Oracle SQL script into source segments. It is deliberately
 // lexical and soft-fail: invalid or incomplete SQL still returns best-effort
 // statement boundaries.
 func Split(sql string) []Segment {
@@ -69,8 +69,16 @@ func Split(sql string) []Segment {
 						segments = appendSegment(segments, sql, stmtStart, trimRightSpace(sql, tok.Loc))
 						stmtStart = lineEndBeforeBreak(sql, tok.End)
 					}
-				} else if onlyIgnorableSQLPlusPrefix(sql, stmtStart, tok.Loc) {
-					stmtStart = lineEndAfterBreak(sql, tok.End)
+				} else {
+					lineEnd := lineEndBeforeBreak(sql, tok.End)
+					nextStart := lineEndAfterBreak(sql, tok.End)
+					commandStart := stmtStart
+					if !onlyIgnorableSQLPlusPrefix(sql, stmtStart, tok.Loc) {
+						segments = appendSegment(segments, sql, stmtStart, trimRightSpace(sql, tok.Loc))
+						commandStart = lineStartOffset(sql, tok.Loc)
+					}
+					segments = appendSegment(segments, sql, commandStart, lineEnd)
+					stmtStart = nextStart
 				}
 				lexer.pos = lineEndAfterBreak(sql, tok.End)
 				state.reset()

--- a/oracle/parser/split_test.go
+++ b/oracle/parser/split_test.go
@@ -266,7 +266,7 @@ func TestSplitSQLPlusCommands(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "environment commands are skipped",
+			name: "environment commands are returned as line segments",
 			sql: "SET DEFINE OFF\n" +
 				"SET SERVEROUTPUT ON;\n" +
 				"PROMPT creating table;\n" +
@@ -274,10 +274,18 @@ func TestSplitSQLPlusCommands(t *testing.T) {
 				"SELECT 1 FROM dual;\n" +
 				"SPOOL OFF\n" +
 				"SELECT 2 FROM dual;",
-			want: []string{"SELECT 1 FROM dual", "SELECT 2 FROM dual"},
+			want: []string{
+				"SET DEFINE OFF",
+				"SET SERVEROUTPUT ON;",
+				"PROMPT creating table;",
+				"SPOOL install.log",
+				"SELECT 1 FROM dual",
+				"\nSPOOL OFF",
+				"SELECT 2 FROM dual",
+			},
 		},
 		{
-			name: "script and session commands are skipped",
+			name: "script and session commands are returned as line segments",
 			sql: "CONNECT scott/tiger@db\n" +
 				"@preflight.sql\n" +
 				"@@nested/install.sql arg1 arg2\n" +
@@ -285,19 +293,33 @@ func TestSplitSQLPlusCommands(t *testing.T) {
 				"WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK\n" +
 				"SELECT 1 FROM dual;\n" +
 				"EXIT SUCCESS",
-			want: []string{"SELECT 1 FROM dual"},
+			want: []string{
+				"CONNECT scott/tiger@db",
+				"@preflight.sql",
+				"@@nested/install.sql arg1 arg2",
+				"START post.sql",
+				"WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK",
+				"SELECT 1 FROM dual",
+				"\nEXIT SUCCESS",
+			},
 		},
 		{
-			name: "remark and host commands are skipped",
+			name: "remark and host commands are returned as line segments",
 			sql: "REM this ; is a SQL*Plus comment\n" +
 				"REMARK this is also ignored\n" +
 				"HOST echo before\n" +
 				"! echo shell\n" +
 				"SELECT 1 FROM dual;",
-			want: []string{"SELECT 1 FROM dual"},
+			want: []string{
+				"REM this ; is a SQL*Plus comment",
+				"REMARK this is also ignored",
+				"HOST echo before",
+				"! echo shell",
+				"SELECT 1 FROM dual",
+			},
 		},
 		{
-			name: "formatting and variable commands are skipped",
+			name: "formatting and variable commands are returned as line segments",
 			sql: "COLUMN c FORMAT A20\n" +
 				"BREAK ON report\n" +
 				"COMPUTE SUM OF sal ON report\n" +
@@ -309,7 +331,19 @@ func TestSplitSQLPlusCommands(t *testing.T) {
 				"VARIABLE rc NUMBER\n" +
 				"PRINT rc\n" +
 				"SELECT 1 FROM dual;",
-			want: []string{"SELECT 1 FROM dual"},
+			want: []string{
+				"COLUMN c FORMAT A20",
+				"BREAK ON report",
+				"COMPUTE SUM OF sal ON report",
+				"TTITLE left 'Report'",
+				"BTITLE off",
+				"DEFINE schema_name = HR",
+				"UNDEFINE schema_name",
+				"ACCEPT v PROMPT 'Value: '",
+				"VARIABLE rc NUMBER",
+				"PRINT rc",
+				"SELECT 1 FROM dual",
+			},
 		},
 		{
 			name: "run flushes current SQL buffer",

--- a/oracle/parser/testdata/splitter.yaml
+++ b/oracle/parser/testdata/splitter.yaml
@@ -403,59 +403,95 @@
             RETURN 1;
           END;
         END;
-- description: set and prompt skipped
+- description: set and prompt returned as line segments
   input: "SET DEFINE OFF\nPROMPT hello; world\nSELECT 1 FROM dual;"
   statements:
+    - text: "SET DEFINE OFF"
+    - text: "PROMPT hello; world"
     - text: "SELECT 1 FROM dual"
-- description: spool skipped between statements
+- description: spool returned as line segments between statements
   input: "SELECT 1 FROM dual;\nSPOOL out.log\nSELECT 2 FROM dual;\nSPOOL OFF\nSELECT 3 FROM dual;"
   statements:
     - text: "SELECT 1 FROM dual"
+    - text: "\nSPOOL out.log"
     - text: "SELECT 2 FROM dual"
+    - text: "\nSPOOL OFF"
     - text: "SELECT 3 FROM dual"
-- description: show and column skipped
+- description: show and column returned as line segments
   input: "SHOW USER\nCOLUMN c FORMAT A20\nSELECT 1 c FROM dual;"
   statements:
+    - text: "SHOW USER"
+    - text: "COLUMN c FORMAT A20"
     - text: "SELECT 1 c FROM dual"
-- description: break compute titles skipped
+- description: break compute titles returned as line segments
   input: "BREAK ON report\nCOMPUTE SUM OF sal ON report\nTTITLE left 'T'\nBTITLE off\nSELECT 1 FROM dual;"
   statements:
+    - text: "BREAK ON report"
+    - text: "COMPUTE SUM OF sal ON report"
+    - text: "TTITLE left 'T'"
+    - text: "BTITLE off"
     - text: "SELECT 1 FROM dual"
-- description: define accept variable print skipped
+- description: define accept variable print returned as line segments
   input: "DEFINE x = 1\nACCEPT y PROMPT 'Y: '\nVARIABLE rc NUMBER\nPRINT rc\nSELECT 1 FROM dual;"
   statements:
+    - text: "DEFINE x = 1"
+    - text: "ACCEPT y PROMPT 'Y: '"
+    - text: "VARIABLE rc NUMBER"
+    - text: "PRINT rc"
     - text: "SELECT 1 FROM dual"
-- description: execute command skipped
+- description: execute command returned as line segment
   input: "EXECUTE dbms_output.put_line('hi')\nSELECT 1 FROM dual;"
   statements:
+    - text: "EXECUTE dbms_output.put_line('hi')"
     - text: "SELECT 1 FROM dual"
-- description: connect disconnect skipped
+- description: connect disconnect returned as line segments
   input: "CONNECT scott/tiger@db\nDISCONNECT\nSELECT 1 FROM dual;"
   statements:
+    - text: "CONNECT scott/tiger@db"
+    - text: "DISCONNECT"
     - text: "SELECT 1 FROM dual"
-- description: exit quit skipped
+- description: exit quit returned as line segments
   input: "SELECT 1 FROM dual;\nEXIT SUCCESS\nQUIT"
   statements:
     - text: "SELECT 1 FROM dual"
-- description: whenever skipped
+    - text: "\nEXIT SUCCESS"
+    - text: "QUIT"
+- description: whenever returned as line segments
   input: "WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK\nWHENEVER OSERROR EXIT FAILURE\nSELECT 1 FROM dual;"
   statements:
+    - text: "WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK"
+    - text: "WHENEVER OSERROR EXIT FAILURE"
     - text: "SELECT 1 FROM dual"
-- description: script invocation skipped
+- description: script invocation returned as line segments
   input: "@pre.sql\n@@nested.sql arg\nSTART post.sql\nSELECT 1 FROM dual;"
   statements:
+    - text: "@pre.sql"
+    - text: "@@nested.sql arg"
+    - text: "START post.sql"
     - text: "SELECT 1 FROM dual"
-- description: rem remark skipped
+- description: rem remark returned as line segments
   input: "REM comment ;\nREMARK comment /\nSELECT 1 FROM dual;"
   statements:
+    - text: "REM comment ;"
+    - text: "REMARK comment /"
     - text: "SELECT 1 FROM dual"
-- description: host bang skipped
+- description: host bang returned as line segments
   input: "HOST echo hi\n! echo hi\nSELECT 1 FROM dual;"
   statements:
+    - text: "HOST echo hi"
+    - text: "! echo hi"
     - text: "SELECT 1 FROM dual"
-- description: buffer commands skipped
+- description: buffer commands returned as line segments
   input: "LIST\nAPPEND text\nCHANGE /a/b/\nDEL 1\nINPUT x\nSAVE file.sql\nGET file.sql\nEDIT\nSELECT 1 FROM dual;"
   statements:
+    - text: "LIST"
+    - text: "APPEND text"
+    - text: "CHANGE /a/b/"
+    - text: "DEL 1"
+    - text: "INPUT x"
+    - text: "SAVE file.sql"
+    - text: "GET file.sql"
+    - text: "EDIT"
     - text: "SELECT 1 FROM dual"
 - description: sqlplus command words in SQL not skipped
   input: "SELECT prompt, set_value FROM t; SELECT 1 FROM dual;"
@@ -467,9 +503,14 @@
   statements:
     - text: "BEGIN prompt := 'x'; set_value := 1; NULL; END;"
     - text: "\nSELECT 1 FROM dual"
-- description: config history oerr ping xquery skipped
+- description: config history oerr ping xquery returned as line segments
   input: "CONFIG\nHISTORY\nOERR ORA 1\nPING db\nXQUERY 1\nSELECT 1 FROM dual;"
   statements:
+    - text: "CONFIG"
+    - text: "HISTORY"
+    - text: "OERR ORA 1"
+    - text: "PING db"
+    - text: "XQUERY 1"
     - text: "SELECT 1 FROM dual"
 - description: unterminated single quote soft fail
   input: "SELECT 'abc; SELECT 2 FROM dual;"
@@ -500,9 +541,10 @@
   statements:
     - text: "SELECT 1 FROM dual"
     - text: "\x00\x01SELECT 2 FROM dual;"
-- description: skipped commands around parseable SQL
+- description: line commands around SQL are returned
   input: "SET TERMOUT OFF\nSELECT 1 FROM dual;\nPROMPT done\nSELECT 2 FROM dual;"
-  parse: true
   statements:
+    - text: "SET TERMOUT OFF"
     - text: "SELECT 1 FROM dual"
+    - text: "\nPROMPT done"
     - text: "SELECT 2 FROM dual"


### PR DESCRIPTION
## Summary
- Return SQL*Plus line commands such as SET, PROMPT, SPOOL, @, and ! as splitter segments instead of skipping them.
- Add `SegmentKind` classification so callers can distinguish `SegmentSQL` from `SegmentSQLPlusCommand` without duplicating SQL*Plus command detection.
- Keep slash/RUN/R buffer flush handling while treating command-line semicolons as part of the line segment.
- Update splitter golden cases, facade behavior tests, and scenario coverage notes for the new boundary.

## Test Plan
- go test ./oracle/... -count=1
- git diff --check
