### PR TITLE
Bundle common PostgreSQL extension scripts

### DIFF
--- a/pg/catalog/extension_scripts.go
+++ b/pg/catalog/extension_scripts.go
@@ -8,9 +8,22 @@ package catalog
 // operators, functions, aggregates). Physical/index-only constructs like
 // CREATE OPERATOR CLASS are included when the opclass infrastructure is present.
 var extensionScripts = map[string]string{
-	"citext": citextSQL,
-	"hstore": hstoreSQL,
-	"vector": pgvectorSQL,
+	"btree_gin":     btreeGinSQL,
+	"btree_gist":    btreeGistSQL,
+	"citext":        citextSQL,
+	"cube":          cubeSQL,
+	"dblink":        dblinkSQL,
+	"earthdistance": earthdistanceSQL,
+	"fuzzystrmatch": fuzzystrmatchSQL,
+	"hstore":        hstoreSQL,
+	"intarray":      intarraySQL,
+	"ltree":         ltreeSQL,
+	"pg_trgm":       pgTrgmSQL,
+	"pgcrypto":      pgcryptoSQL,
+	"tablefunc":     tablefuncSQL,
+	"unaccent":      unaccentSQL,
+	"uuid-ossp":     uuidOSSPSQL,
+	"vector":        pgvectorSQL,
 }
 
 // citextSQL is the DDL for the citext extension (case-insensitive text type).
@@ -543,4 +556,417 @@ CREATE OPERATOR CLASS halfvec_l2_ops DEFAULT FOR TYPE halfvec USING ivfflat AS
     OPERATOR 1 <-> (halfvec, halfvec);
 CREATE OPERATOR CLASS halfvec_cosine_ops FOR TYPE halfvec USING ivfflat AS
     OPERATOR 1 <=> (halfvec, halfvec);
+`
+
+// ltreeSQL is the DDL subset for the ltree extension.
+// Derived from contrib/ltree/ltree--1.1.sql through ltree--1.2--1.3.sql.
+const ltreeSQL = `
+CREATE FUNCTION ltree_in(cstring) RETURNS ltree AS 'ltree_in' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_out(ltree) RETURNS cstring AS 'ltree_out' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_recv(internal) RETURNS ltree AS 'ltree_recv' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_send(ltree) RETURNS bytea AS 'ltree_send' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE TYPE ltree (INPUT = ltree_in, OUTPUT = ltree_out, RECEIVE = ltree_recv, SEND = ltree_send, INTERNALLENGTH = VARIABLE, STORAGE = extended);
+
+CREATE FUNCTION lquery_in(cstring) RETURNS lquery AS 'lquery_in' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION lquery_out(lquery) RETURNS cstring AS 'lquery_out' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION lquery_recv(internal) RETURNS lquery AS 'lquery_recv' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION lquery_send(lquery) RETURNS bytea AS 'lquery_send' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE TYPE lquery (INPUT = lquery_in, OUTPUT = lquery_out, RECEIVE = lquery_recv, SEND = lquery_send, INTERNALLENGTH = VARIABLE, STORAGE = extended);
+
+CREATE FUNCTION ltxtq_in(cstring) RETURNS ltxtquery AS 'ltxtq_in' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltxtq_out(ltxtquery) RETURNS cstring AS 'ltxtq_out' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltxtq_recv(internal) RETURNS ltxtquery AS 'ltxtq_recv' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltxtq_send(ltxtquery) RETURNS bytea AS 'ltxtq_send' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE TYPE ltxtquery (INPUT = ltxtq_in, OUTPUT = ltxtq_out, RECEIVE = ltxtq_recv, SEND = ltxtq_send, INTERNALLENGTH = VARIABLE, STORAGE = extended);
+
+CREATE FUNCTION ltree_gist_in(cstring) RETURNS ltree_gist AS 'ltree_gist_in' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_gist_out(ltree_gist) RETURNS cstring AS 'ltree_gist_out' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE TYPE ltree_gist (INPUT = ltree_gist_in, OUTPUT = ltree_gist_out, INTERNALLENGTH = VARIABLE, STORAGE = plain);
+
+CREATE FUNCTION ltree_cmp(ltree, ltree) RETURNS integer AS 'ltree_cmp' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_lt(ltree, ltree) RETURNS boolean AS 'ltree_lt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_le(ltree, ltree) RETURNS boolean AS 'ltree_le' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_eq(ltree, ltree) RETURNS boolean AS 'ltree_eq' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_ge(ltree, ltree) RETURNS boolean AS 'ltree_ge' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_gt(ltree, ltree) RETURNS boolean AS 'ltree_gt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_ne(ltree, ltree) RETURNS boolean AS 'ltree_ne' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR < (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_lt, COMMUTATOR = >, NEGATOR = >=);
+CREATE OPERATOR <= (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_le, COMMUTATOR = >=, NEGATOR = >);
+CREATE OPERATOR = (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_eq, COMMUTATOR = =, NEGATOR = <>, HASHES, MERGES);
+CREATE OPERATOR <> (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_ne, COMMUTATOR = <>, NEGATOR = =);
+CREATE OPERATOR >= (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_ge, COMMUTATOR = <=, NEGATOR = <);
+CREATE OPERATOR > (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_gt, COMMUTATOR = <, NEGATOR = <=);
+
+CREATE FUNCTION subltree(ltree, integer, integer) RETURNS ltree AS 'subltree' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION subpath(ltree, integer, integer) RETURNS ltree AS 'subpath' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION subpath(ltree, integer) RETURNS ltree AS 'subpath' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION nlevel(ltree) RETURNS integer AS 'nlevel' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree2text(ltree) RETURNS text AS 'ltree2text' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION text2ltree(text) RETURNS ltree AS 'text2ltree' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_isparent(ltree, ltree) RETURNS boolean AS 'ltree_isparent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_risparent(ltree, ltree) RETURNS boolean AS 'ltree_risparent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_addltree(ltree, ltree) RETURNS ltree AS 'ltree_addltree' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_addtext(ltree, text) RETURNS ltree AS 'ltree_addtext' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_textadd(text, ltree) RETURNS ltree AS 'ltree_textadd' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR @> (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_isparent, COMMUTATOR = <@);
+CREATE OPERATOR <@ (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_risparent, COMMUTATOR = @>);
+CREATE OPERATOR || (LEFTARG = ltree, RIGHTARG = ltree, PROCEDURE = ltree_addltree);
+CREATE OPERATOR || (LEFTARG = ltree, RIGHTARG = text, PROCEDURE = ltree_addtext);
+CREATE OPERATOR || (LEFTARG = text, RIGHTARG = ltree, PROCEDURE = ltree_textadd);
+
+CREATE FUNCTION ltq_regex(ltree, lquery) RETURNS boolean AS 'ltq_regex' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltq_rregex(lquery, ltree) RETURNS boolean AS 'ltq_rregex' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION lt_q_regex(ltree, lquery[]) RETURNS boolean AS 'lt_q_regex' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION lt_q_rregex(lquery[], ltree) RETURNS boolean AS 'lt_q_rregex' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltxtq_exec(ltree, ltxtquery) RETURNS boolean AS 'ltxtq_exec' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltxtq_rexec(ltxtquery, ltree) RETURNS boolean AS 'ltxtq_rexec' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR ~ (LEFTARG = ltree, RIGHTARG = lquery, PROCEDURE = ltq_regex, COMMUTATOR = ~);
+CREATE OPERATOR ~ (LEFTARG = lquery, RIGHTARG = ltree, PROCEDURE = ltq_rregex, COMMUTATOR = ~);
+CREATE OPERATOR ? (LEFTARG = ltree, RIGHTARG = lquery[], PROCEDURE = lt_q_regex, COMMUTATOR = ?);
+CREATE OPERATOR ? (LEFTARG = lquery[], RIGHTARG = ltree, PROCEDURE = lt_q_rregex, COMMUTATOR = ?);
+CREATE OPERATOR @ (LEFTARG = ltree, RIGHTARG = ltxtquery, PROCEDURE = ltxtq_exec, COMMUTATOR = @);
+CREATE OPERATOR @ (LEFTARG = ltxtquery, RIGHTARG = ltree, PROCEDURE = ltxtq_rexec, COMMUTATOR = @);
+
+CREATE FUNCTION ltree_consistent(internal, ltree, smallint, oid, internal) RETURNS boolean AS 'ltree_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_union(internal, internal) RETURNS ltree_gist AS 'ltree_union' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_compress(internal) RETURNS internal AS 'ltree_compress' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_decompress(internal) RETURNS internal AS 'ltree_decompress' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_penalty(internal, internal, internal) RETURNS internal AS 'ltree_penalty' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_picksplit(internal, internal) RETURNS internal AS 'ltree_picksplit' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ltree_same(ltree_gist, ltree_gist, internal) RETURNS internal AS 'ltree_same' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION hash_ltree(ltree) RETURNS integer AS 'hash_ltree' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION hash_ltree_extended(ltree, bigint) RETURNS bigint AS 'hash_ltree_extended' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR CLASS ltree_ops DEFAULT FOR TYPE ltree USING btree AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 ltree_cmp(ltree, ltree);
+CREATE OPERATOR CLASS gist_ltree_ops DEFAULT FOR TYPE ltree USING gist AS OPERATOR 10 @>, OPERATOR 11 <@, OPERATOR 12 ~ (ltree, lquery), OPERATOR 14 @ (ltree, ltxtquery), FUNCTION 1 ltree_consistent(internal, ltree, smallint, oid, internal), STORAGE ltree_gist;
+CREATE OPERATOR CLASS hash_ltree_ops DEFAULT FOR TYPE ltree USING hash AS OPERATOR 1 =, FUNCTION 1 hash_ltree(ltree);
+`
+
+// dblinkSQL is the DDL subset for the dblink extension.
+// Derived from contrib/dblink/dblink--1.2.sql.
+const dblinkSQL = `
+CREATE FUNCTION dblink_connect(text) RETURNS text AS 'dblink_connect' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_connect(text, text) RETURNS text AS 'dblink_connect' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_disconnect() RETURNS text AS 'dblink_disconnect' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_disconnect(text) RETURNS text AS 'dblink_disconnect' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_open(text, text) RETURNS text AS 'dblink_open' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_open(text, text, boolean) RETURNS text AS 'dblink_open' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_open(text, text, text) RETURNS text AS 'dblink_open' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_open(text, text, text, boolean) RETURNS text AS 'dblink_open' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_fetch(text, integer) RETURNS SETOF record AS 'dblink_fetch' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_fetch(text, integer, boolean) RETURNS SETOF record AS 'dblink_fetch' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_fetch(text, text, integer) RETURNS SETOF record AS 'dblink_fetch' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_fetch(text, text, integer, boolean) RETURNS SETOF record AS 'dblink_fetch' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_close(text) RETURNS text AS 'dblink_close' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_close(text, boolean) RETURNS text AS 'dblink_close' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_close(text, text) RETURNS text AS 'dblink_close' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_close(text, text, boolean) RETURNS text AS 'dblink_close' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink(text, text) RETURNS SETOF record AS 'dblink_record' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink(text, text, boolean) RETURNS SETOF record AS 'dblink_record' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink(text) RETURNS SETOF record AS 'dblink_record' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink(text, boolean) RETURNS SETOF record AS 'dblink_record' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_exec(text, text) RETURNS text AS 'dblink_exec' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_exec(text, text, boolean) RETURNS text AS 'dblink_exec' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_exec(text) RETURNS text AS 'dblink_exec' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_exec(text, boolean) RETURNS text AS 'dblink_exec' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE TYPE dblink_pkey_results AS (position integer, colname text);
+CREATE FUNCTION dblink_get_pkey(text) RETURNS SETOF dblink_pkey_results AS 'dblink_get_pkey' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_build_sql_insert(text, int2vector, integer, text[], text[]) RETURNS text AS 'dblink_build_sql_insert' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_build_sql_delete(text, int2vector, integer, text[]) RETURNS text AS 'dblink_build_sql_delete' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_build_sql_update(text, int2vector, integer, text[], text[]) RETURNS text AS 'dblink_build_sql_update' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_current_query() RETURNS text AS 'dblink_current_query' LANGUAGE C PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_send_query(text, text) RETURNS integer AS 'dblink_send_query' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_is_busy(text) RETURNS integer AS 'dblink_is_busy' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_get_result(text) RETURNS SETOF record AS 'dblink_get_result' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_get_result(text, boolean) RETURNS SETOF record AS 'dblink_get_result' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_get_connections() RETURNS text[] AS 'dblink_get_connections' LANGUAGE C PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_cancel_query(text) RETURNS text AS 'dblink_cancel_query' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_error_message(text) RETURNS text AS 'dblink_error_message' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_get_notify() RETURNS SETOF record AS 'dblink_get_notify' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_get_notify(text) RETURNS SETOF record AS 'dblink_get_notify' LANGUAGE C STRICT PARALLEL RESTRICTED;
+CREATE FUNCTION dblink_fdw_validator(text[], oid) RETURNS void AS 'dblink_fdw_validator' LANGUAGE C STRICT PARALLEL SAFE;
+CREATE FOREIGN DATA WRAPPER dblink_fdw VALIDATOR dblink_fdw_validator;
+`
+
+// intarraySQL is the DDL subset for the intarray extension.
+// Derived from contrib/intarray/intarray--1.5.sql.
+const intarraySQL = `
+CREATE FUNCTION sort(integer[]) RETURNS integer[] AS 'sort' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION sort(integer[], text) RETURNS integer[] AS 'sort' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uniq(integer[]) RETURNS integer[] AS 'uniq' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION idx(integer[], integer) RETURNS integer AS 'idx' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION subarray(integer[], integer, integer) RETURNS integer[] AS 'subarray' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION icount(integer[]) RETURNS integer AS 'icount' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_push_elem(integer[], integer) RETURNS integer[] AS 'intarray_push_elem' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_push_array(integer[], integer[]) RETURNS integer[] AS 'intarray_push_array' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_del_elem(integer[], integer) RETURNS integer[] AS 'intarray_del_elem' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intset(integer) RETURNS integer[] AS 'intset' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_union(integer[], integer[]) RETURNS integer[] AS 'intarray_union' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_inter(integer[], integer[]) RETURNS integer[] AS 'intarray_inter' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_contained(integer[], integer[]) RETURNS boolean AS 'intarray_contained' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_contains(integer[], integer[]) RETURNS boolean AS 'intarray_contains' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION intarray_overlap(integer[], integer[]) RETURNS boolean AS 'intarray_overlap' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR @> (LEFTARG = integer[], RIGHTARG = integer[], PROCEDURE = intarray_contains, COMMUTATOR = <@);
+CREATE OPERATOR <@ (LEFTARG = integer[], RIGHTARG = integer[], PROCEDURE = intarray_contained, COMMUTATOR = @>);
+CREATE OPERATOR && (LEFTARG = integer[], RIGHTARG = integer[], PROCEDURE = intarray_overlap, COMMUTATOR = &&);
+CREATE OPERATOR + (LEFTARG = integer[], RIGHTARG = integer, PROCEDURE = intarray_push_elem);
+CREATE OPERATOR + (LEFTARG = integer[], RIGHTARG = integer[], PROCEDURE = intarray_push_array);
+CREATE OPERATOR - (LEFTARG = integer[], RIGHTARG = integer, PROCEDURE = intarray_del_elem);
+CREATE OPERATOR | (LEFTARG = integer[], RIGHTARG = integer[], PROCEDURE = intarray_union, COMMUTATOR = |);
+CREATE OPERATOR & (LEFTARG = integer[], RIGHTARG = integer[], PROCEDURE = intarray_inter, COMMUTATOR = &);
+
+CREATE FUNCTION ginint4_queryextract(integer[], internal, smallint, internal, internal, internal, internal) RETURNS internal AS 'ginint4_queryextract' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ginint4_consistent(internal, smallint, integer[], integer, internal, internal, internal, internal) RETURNS boolean AS 'ginint4_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_consistent(internal, integer[], smallint, oid, internal) RETURNS boolean AS 'g_int_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_union(internal, internal) RETURNS integer[] AS 'g_int_union' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_compress(internal) RETURNS internal AS 'g_int_compress' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_decompress(internal) RETURNS internal AS 'g_int_decompress' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_penalty(internal, internal, internal) RETURNS internal AS 'g_int_penalty' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_picksplit(internal, internal) RETURNS internal AS 'g_int_picksplit' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_int_same(integer[], integer[], internal) RETURNS internal AS 'g_int_same' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR CLASS gist__int_ops DEFAULT FOR TYPE integer[] USING gist AS OPERATOR 3 &&, OPERATOR 6 =, OPERATOR 7 @>, OPERATOR 8 <@, FUNCTION 1 g_int_consistent(internal, integer[], smallint, oid, internal);
+CREATE OPERATOR CLASS gin__int_ops DEFAULT FOR TYPE integer[] USING gin AS OPERATOR 3 &&, OPERATOR 6 =, OPERATOR 7 @>, OPERATOR 8 <@, FUNCTION 1 ginint4_queryextract(integer[], internal, smallint, internal, internal, internal, internal);
+`
+
+// pgTrgmSQL is the DDL subset for the pg_trgm extension.
+// Derived from contrib/pg_trgm/pg_trgm--1.6.sql.
+const pgTrgmSQL = `
+CREATE FUNCTION set_limit(real) RETURNS real AS 'set_limit' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION show_limit() RETURNS real AS 'show_limit' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION show_trgm(text) RETURNS text[] AS 'show_trgm' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION similarity(text, text) RETURNS real AS 'similarity' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION similarity_op(text, text) RETURNS boolean AS 'similarity_op' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION word_similarity(text, text) RETURNS real AS 'word_similarity' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION word_similarity_op(text, text) RETURNS boolean AS 'word_similarity_op' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION strict_word_similarity(text, text) RETURNS real AS 'strict_word_similarity' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION strict_word_similarity_op(text, text) RETURNS boolean AS 'strict_word_similarity_op' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION similarity_dist(text, text) RETURNS real AS 'similarity_dist' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION word_similarity_dist_op(text, text) RETURNS real AS 'word_similarity_dist_op' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION strict_word_similarity_dist_op(text, text) RETURNS real AS 'strict_word_similarity_dist_op' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR % (LEFTARG = text, RIGHTARG = text, PROCEDURE = similarity_op, COMMUTATOR = %);
+CREATE OPERATOR <% (LEFTARG = text, RIGHTARG = text, PROCEDURE = word_similarity_op);
+CREATE OPERATOR %> (LEFTARG = text, RIGHTARG = text, PROCEDURE = word_similarity_op);
+CREATE OPERATOR <<% (LEFTARG = text, RIGHTARG = text, PROCEDURE = strict_word_similarity_op);
+CREATE OPERATOR %>> (LEFTARG = text, RIGHTARG = text, PROCEDURE = strict_word_similarity_op);
+CREATE OPERATOR <-> (LEFTARG = text, RIGHTARG = text, PROCEDURE = similarity_dist, COMMUTATOR = <->);
+CREATE OPERATOR <<-> (LEFTARG = text, RIGHTARG = text, PROCEDURE = word_similarity_dist_op);
+CREATE OPERATOR <->> (LEFTARG = text, RIGHTARG = text, PROCEDURE = word_similarity_dist_op);
+CREATE OPERATOR <<<-> (LEFTARG = text, RIGHTARG = text, PROCEDURE = strict_word_similarity_dist_op);
+CREATE OPERATOR <->>> (LEFTARG = text, RIGHTARG = text, PROCEDURE = strict_word_similarity_dist_op);
+
+CREATE FUNCTION gtrgm_in(cstring) RETURNS gtrgm AS 'gtrgm_in' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_out(gtrgm) RETURNS cstring AS 'gtrgm_out' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE TYPE gtrgm (INPUT = gtrgm_in, OUTPUT = gtrgm_out, INTERNALLENGTH = VARIABLE, STORAGE = plain);
+CREATE FUNCTION gtrgm_consistent(internal, text, smallint, oid, internal) RETURNS boolean AS 'gtrgm_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_union(internal, internal) RETURNS gtrgm AS 'gtrgm_union' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_compress(internal) RETURNS internal AS 'gtrgm_compress' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_decompress(internal) RETURNS internal AS 'gtrgm_decompress' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_penalty(internal, internal, internal) RETURNS internal AS 'gtrgm_penalty' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_picksplit(internal, internal) RETURNS internal AS 'gtrgm_picksplit' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gtrgm_same(gtrgm, gtrgm, internal) RETURNS internal AS 'gtrgm_same' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_value_trgm(text, internal) RETURNS internal AS 'gin_extract_value_trgm' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_query_trgm(text, internal, smallint, internal, internal, internal, internal) RETURNS internal AS 'gin_extract_query_trgm' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_trgm_consistent(internal, smallint, text, integer, internal, internal, internal, internal) RETURNS boolean AS 'gin_trgm_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR CLASS gist_trgm_ops DEFAULT FOR TYPE text USING gist AS OPERATOR 1 %, FUNCTION 1 gtrgm_consistent(internal, text, smallint, oid, internal), STORAGE gtrgm;
+CREATE OPERATOR CLASS gin_trgm_ops FOR TYPE text USING gin AS OPERATOR 1 %, FUNCTION 1 gin_extract_value_trgm(text, internal);
+`
+
+// uuidOSSPSQL is the DDL subset for the uuid-ossp extension.
+// Derived from contrib/uuid-ossp/uuid-ossp--1.1.sql.
+const uuidOSSPSQL = `
+CREATE FUNCTION uuid_nil() RETURNS uuid AS 'uuid_nil' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uuid_ns_dns() RETURNS uuid AS 'uuid_ns_dns' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uuid_ns_url() RETURNS uuid AS 'uuid_ns_url' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uuid_ns_oid() RETURNS uuid AS 'uuid_ns_oid' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uuid_ns_x500() RETURNS uuid AS 'uuid_ns_x500' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uuid_generate_v1() RETURNS uuid AS 'uuid_generate_v1' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION uuid_generate_v1mc() RETURNS uuid AS 'uuid_generate_v1mc' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION uuid_generate_v3(uuid, text) RETURNS uuid AS 'uuid_generate_v3' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION uuid_generate_v4() RETURNS uuid AS 'uuid_generate_v4' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION uuid_generate_v5(uuid, text) RETURNS uuid AS 'uuid_generate_v5' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+`
+
+// pgcryptoSQL is the DDL subset for the pgcrypto extension.
+// Derived from contrib/pgcrypto/pgcrypto--1.3.sql.
+const pgcryptoSQL = `
+CREATE FUNCTION digest(bytea, text) RETURNS bytea AS 'pg_digest' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION digest(text, text) RETURNS bytea AS 'pg_digest' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION hmac(bytea, bytea, text) RETURNS bytea AS 'pg_hmac' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION hmac(text, text, text) RETURNS bytea AS 'pg_hmac' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION crypt(text, text) RETURNS text AS 'pg_crypt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gen_salt(text) RETURNS text AS 'pg_gen_salt' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION gen_salt(text, integer) RETURNS text AS 'pg_gen_salt_rounds' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION encrypt(bytea, bytea, text) RETURNS bytea AS 'pg_encrypt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION decrypt(bytea, bytea, text) RETURNS bytea AS 'pg_decrypt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION encrypt_iv(bytea, bytea, bytea, text) RETURNS bytea AS 'pg_encrypt_iv' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION decrypt_iv(bytea, bytea, bytea, text) RETURNS bytea AS 'pg_decrypt_iv' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gen_random_bytes(integer) RETURNS bytea AS 'pg_random_bytes' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION gen_random_uuid() RETURNS uuid AS 'pg_random_uuid' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION armor(bytea) RETURNS text AS 'pg_armor' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION dearmor(text) RETURNS bytea AS 'pg_dearmor' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION pgp_sym_encrypt(text, text) RETURNS bytea AS 'pgp_sym_encrypt_text' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_sym_encrypt_bytea(bytea, text) RETURNS bytea AS 'pgp_sym_encrypt_bytea' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_sym_decrypt(bytea, text) RETURNS text AS 'pgp_sym_decrypt_text' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_sym_decrypt_bytea(bytea, text) RETURNS bytea AS 'pgp_sym_decrypt_bytea' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_pub_encrypt(text, bytea) RETURNS bytea AS 'pgp_pub_encrypt_text' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_pub_encrypt_bytea(bytea, bytea) RETURNS bytea AS 'pgp_pub_encrypt_bytea' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_pub_decrypt(bytea, bytea) RETURNS text AS 'pgp_pub_decrypt_text' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION pgp_pub_decrypt_bytea(bytea, bytea) RETURNS bytea AS 'pgp_pub_decrypt_bytea' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+`
+
+// btreeGistSQL is the DDL subset for the btree_gist extension.
+// Derived from contrib/btree_gist/btree_gist--1.2.sql through btree_gist--1.7.sql.
+const btreeGistSQL = `
+CREATE FUNCTION gbt_int4_consistent(internal, integer, smallint, oid, internal) RETURNS boolean AS 'gbt_int4_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gbt_text_consistent(internal, text, smallint, oid, internal) RETURNS boolean AS 'gbt_text_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gbt_ts_consistent(internal, timestamp, smallint, oid, internal) RETURNS boolean AS 'gbt_ts_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR CLASS gist_int4_ops DEFAULT FOR TYPE integer USING gist AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 gbt_int4_consistent(internal, integer, smallint, oid, internal);
+CREATE OPERATOR CLASS gist_text_ops DEFAULT FOR TYPE text USING gist AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 gbt_text_consistent(internal, text, smallint, oid, internal);
+CREATE OPERATOR CLASS gist_timestamp_ops DEFAULT FOR TYPE timestamp USING gist AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 gbt_ts_consistent(internal, timestamp, smallint, oid, internal);
+`
+
+// btreeGinSQL is the DDL subset for the btree_gin extension.
+// Derived from contrib/btree_gin/btree_gin--1.0.sql through btree_gin--1.3.sql.
+const btreeGinSQL = `
+CREATE FUNCTION gin_btree_consistent(internal, smallint, anyelement, integer, internal, internal) RETURNS boolean AS 'gin_btree_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_value_int4(integer, internal) RETURNS internal AS 'gin_extract_value_int4' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_query_int4(integer, internal, smallint, internal, internal) RETURNS internal AS 'gin_extract_query_int4' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_compare_prefix_int4(integer, integer, smallint, internal) RETURNS integer AS 'gin_compare_prefix_int4' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_value_text(text, internal) RETURNS internal AS 'gin_extract_value_text' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_query_text(text, internal, smallint, internal, internal) RETURNS internal AS 'gin_extract_query_text' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_compare_prefix_text(text, text, smallint, internal) RETURNS integer AS 'gin_compare_prefix_text' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_value_numeric(numeric, internal) RETURNS internal AS 'gin_extract_value_numeric' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_extract_query_numeric(numeric, internal, smallint, internal, internal) RETURNS internal AS 'gin_extract_query_numeric' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_compare_prefix_numeric(numeric, numeric, smallint, internal) RETURNS integer AS 'gin_compare_prefix_numeric' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gin_numeric_cmp(numeric, numeric) RETURNS integer AS 'gin_numeric_cmp' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR CLASS int4_ops DEFAULT FOR TYPE integer USING gin AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 2 gin_extract_value_int4(integer, internal);
+CREATE OPERATOR CLASS text_ops DEFAULT FOR TYPE text USING gin AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 2 gin_extract_value_text(text, internal);
+CREATE OPERATOR CLASS numeric_ops DEFAULT FOR TYPE numeric USING gin AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 2 gin_extract_value_numeric(numeric, internal);
+`
+
+// cubeSQL is the DDL subset for the cube extension.
+// Derived from contrib/cube/cube--1.2.sql through cube--1.5.sql.
+const cubeSQL = `
+CREATE FUNCTION cube_in(cstring) RETURNS cube AS 'cube_in' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_out(cube) RETURNS cstring AS 'cube_out' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_recv(internal) RETURNS cube AS 'cube_recv' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_send(cube) RETURNS bytea AS 'cube_send' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE TYPE cube (INPUT = cube_in, OUTPUT = cube_out, RECEIVE = cube_recv, SEND = cube_send, INTERNALLENGTH = VARIABLE, STORAGE = plain);
+
+CREATE FUNCTION cube(double precision[], double precision[]) RETURNS cube AS 'cube_a_f8_f8' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube(double precision[]) RETURNS cube AS 'cube_a_f8' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube(double precision) RETURNS cube AS 'cube_f8' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube(double precision, double precision) RETURNS cube AS 'cube_f8_f8' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube(cube, double precision) RETURNS cube AS 'cube_c_f8' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube(cube, double precision, double precision) RETURNS cube AS 'cube_c_f8_f8' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION cube_eq(cube, cube) RETURNS boolean AS 'cube_eq' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_ne(cube, cube) RETURNS boolean AS 'cube_ne' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_lt(cube, cube) RETURNS boolean AS 'cube_lt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_gt(cube, cube) RETURNS boolean AS 'cube_gt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_le(cube, cube) RETURNS boolean AS 'cube_le' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_ge(cube, cube) RETURNS boolean AS 'cube_ge' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_cmp(cube, cube) RETURNS integer AS 'cube_cmp' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_contains(cube, cube) RETURNS boolean AS 'cube_contains' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_contained(cube, cube) RETURNS boolean AS 'cube_contained' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_overlap(cube, cube) RETURNS boolean AS 'cube_overlap' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_union(cube, cube) RETURNS cube AS 'cube_union' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_inter(cube, cube) RETURNS cube AS 'cube_inter' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_size(cube) RETURNS double precision AS 'cube_size' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_distance(cube, cube) RETURNS double precision AS 'cube_distance' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION distance_chebyshev(cube, cube) RETURNS double precision AS 'distance_chebyshev' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION distance_taxicab(cube, cube) RETURNS double precision AS 'distance_taxicab' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_dim(cube) RETURNS integer AS 'cube_dim' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_ll_coord(cube, integer) RETURNS double precision AS 'cube_ll_coord' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_ur_coord(cube, integer) RETURNS double precision AS 'cube_ur_coord' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_coord(cube, integer) RETURNS double precision AS 'cube_coord' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_is_point(cube) RETURNS boolean AS 'cube_is_point' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION cube_enlarge(cube, double precision, integer) RETURNS cube AS 'cube_enlarge' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR < (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_lt, COMMUTATOR = >, NEGATOR = >=);
+CREATE OPERATOR > (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_gt, COMMUTATOR = <, NEGATOR = <=);
+CREATE OPERATOR <= (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_le, COMMUTATOR = >=, NEGATOR = >);
+CREATE OPERATOR >= (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_ge, COMMUTATOR = <=, NEGATOR = <);
+CREATE OPERATOR = (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_eq, COMMUTATOR = =, NEGATOR = <>, HASHES, MERGES);
+CREATE OPERATOR <> (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_ne, COMMUTATOR = <>, NEGATOR = =);
+CREATE OPERATOR && (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_overlap, COMMUTATOR = &&);
+CREATE OPERATOR @> (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_contains, COMMUTATOR = <@);
+CREATE OPERATOR <@ (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_contained, COMMUTATOR = @>);
+CREATE OPERATOR <#> (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = distance_taxicab, COMMUTATOR = <#>);
+CREATE OPERATOR <-> (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = cube_distance, COMMUTATOR = <->);
+CREATE OPERATOR <=> (LEFTARG = cube, RIGHTARG = cube, PROCEDURE = distance_chebyshev, COMMUTATOR = <=>);
+
+CREATE FUNCTION g_cube_consistent(internal, cube, smallint, oid, internal) RETURNS boolean AS 'g_cube_consistent' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION g_cube_distance(internal, cube, smallint, oid, internal) RETURNS double precision AS 'g_cube_distance' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+
+CREATE OPERATOR CLASS cube_ops DEFAULT FOR TYPE cube USING btree AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 cube_cmp(cube, cube);
+CREATE OPERATOR CLASS gist_cube_ops DEFAULT FOR TYPE cube USING gist AS OPERATOR 3 &&, OPERATOR 6 =, OPERATOR 7 @>, OPERATOR 8 <@, OPERATOR 17 <-> (cube, cube), FUNCTION 1 g_cube_consistent(internal, cube, smallint, oid, internal);
+`
+
+// earthdistanceSQL is the DDL subset for the earthdistance extension.
+// Derived from contrib/earthdistance/earthdistance--1.1.sql through earthdistance--1.2.sql.
+const earthdistanceSQL = `
+CREATE DOMAIN earth AS cube;
+CREATE FUNCTION earth() RETURNS double precision AS 'earth' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION sec_to_gc(double precision) RETURNS double precision AS 'sec_to_gc' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION gc_to_sec(double precision) RETURNS double precision AS 'gc_to_sec' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION ll_to_earth(double precision, double precision) RETURNS earth AS 'll_to_earth' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION latitude(earth) RETURNS double precision AS 'latitude' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION longitude(earth) RETURNS double precision AS 'longitude' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION earth_distance(earth, earth) RETURNS double precision AS 'earth_distance' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION earth_box(earth, double precision) RETURNS cube AS 'earth_box' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION geo_distance(point, point) RETURNS double precision AS 'geo_distance' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE OPERATOR <@> (LEFTARG = point, RIGHTARG = point, PROCEDURE = geo_distance, COMMUTATOR = <@>);
+`
+
+// tablefuncSQL is the DDL subset for the tablefunc extension.
+// Derived from contrib/tablefunc/tablefunc--1.0.sql.
+const tablefuncSQL = `
+CREATE FUNCTION normal_rand(integer, double precision, double precision) RETURNS SETOF double precision AS 'normal_rand' LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+CREATE FUNCTION crosstab(text) RETURNS SETOF record AS 'crosstab' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE TYPE tablefunc_crosstab_2 AS (row_name text, category_1 text, category_2 text);
+CREATE TYPE tablefunc_crosstab_3 AS (row_name text, category_1 text, category_2 text, category_3 text);
+CREATE TYPE tablefunc_crosstab_4 AS (row_name text, category_1 text, category_2 text, category_3 text, category_4 text);
+CREATE FUNCTION crosstab2(text) RETURNS SETOF tablefunc_crosstab_2 AS 'crosstab' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION crosstab3(text) RETURNS SETOF tablefunc_crosstab_3 AS 'crosstab' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION crosstab4(text) RETURNS SETOF tablefunc_crosstab_4 AS 'crosstab' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION crosstab(text, integer) RETURNS SETOF record AS 'crosstab' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION crosstab(text, text) RETURNS SETOF record AS 'crosstab_hash' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION connectby(text, text, text, text, integer, text) RETURNS SETOF record AS 'connectby_text' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION connectby(text, text, text, text, integer) RETURNS SETOF record AS 'connectby_text' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION connectby(text, text, text, text, text, integer, text) RETURNS SETOF record AS 'connectby_text_serial' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION connectby(text, text, text, text, text, integer) RETURNS SETOF record AS 'connectby_text_serial' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+`
+
+// unaccentSQL is the DDL subset for the unaccent extension.
+// Derived from contrib/unaccent/unaccent--1.1.sql.
+const unaccentSQL = `
+CREATE FUNCTION unaccent(regdictionary, text) RETURNS text AS 'unaccent_dict' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION unaccent(text) RETURNS text AS 'unaccent_dict' LANGUAGE C STRICT STABLE PARALLEL SAFE;
+CREATE FUNCTION unaccent_init(internal) RETURNS internal AS 'unaccent_init' LANGUAGE C PARALLEL SAFE;
+CREATE FUNCTION unaccent_lexize(internal, internal, internal, internal) RETURNS internal AS 'unaccent_lexize' LANGUAGE C PARALLEL SAFE;
+`
+
+// fuzzystrmatchSQL is the DDL subset for the fuzzystrmatch extension.
+// Derived from contrib/fuzzystrmatch/fuzzystrmatch--1.1.sql through fuzzystrmatch--1.2.sql.
+const fuzzystrmatchSQL = `
+CREATE FUNCTION levenshtein(text, text) RETURNS integer AS 'levenshtein' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION levenshtein(text, text, integer, integer, integer) RETURNS integer AS 'levenshtein_with_costs' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION levenshtein_less_equal(text, text, integer) RETURNS integer AS 'levenshtein_less_equal' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION levenshtein_less_equal(text, text, integer, integer, integer, integer) RETURNS integer AS 'levenshtein_less_equal_with_costs' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION metaphone(text, integer) RETURNS text AS 'metaphone' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION soundex(text) RETURNS text AS 'soundex' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION text_soundex(text) RETURNS text AS 'soundex' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION difference(text, text) RETURNS integer AS 'difference' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION dmetaphone(text) RETURNS text AS 'dmetaphone' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION dmetaphone_alt(text) RETURNS text AS 'dmetaphone_alt' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 `

--- a/pg/catalog/extension_test.go
+++ b/pg/catalog/extension_test.go
@@ -655,6 +655,185 @@ func TestCreateExtension_PGVector_Index(t *testing.T) {
 	}
 }
 
+func TestCreateExtension_Ltree(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION ltree;`)
+
+	ltreeOID := lookupTypeOID(t, c, "ltree")
+	lqueryOID := lookupTypeOID(t, c, "lquery")
+	ltxtqueryOID := lookupTypeOID(t, c, "ltxtquery")
+	ltreeGistOID := lookupTypeOID(t, c, "ltree_gist")
+	if bt := c.TypeByOID(ltreeOID); bt == nil || !bt.IsDefined {
+		t.Fatal("expected ltree type to be fully defined")
+	}
+	if ops := c.LookupOperatorExact("<@", ltreeOID, ltreeOID); len(ops) == 0 {
+		t.Error("expected <@ operator for ltree")
+	}
+	if ops := c.LookupOperatorExact("~", ltreeOID, lqueryOID); len(ops) == 0 {
+		t.Error("expected ~ operator for ltree/lquery")
+	}
+	if ops := c.LookupOperatorExact("@", ltreeOID, ltxtqueryOID); len(ops) == 0 {
+		t.Error("expected @ operator for ltree/ltxtquery")
+	}
+	if bt := c.TypeByOID(ltreeGistOID); bt == nil || !bt.IsDefined {
+		t.Fatal("expected ltree_gist type to be fully defined")
+	}
+	gist := c.LookupAccessMethod("gist")
+	if gist == nil {
+		t.Fatal("expected gist access method")
+	}
+	if opc := c.opClassByKey[opClassKey{amOID: gist.OID, typeOID: ltreeOID}]; opc == nil || opc.Name != "gist_ltree_ops" {
+		t.Fatalf("expected default gist_ltree_ops opclass, got %#v", opc)
+	}
+}
+
+func TestCreateExtension_Dblink(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION dblink;`)
+
+	assertProcSignature(t, c, "dblink", RECORDOID, true, TEXTOID, TEXTOID)
+	assertProcSignature(t, c, "dblink_exec", TEXTOID, false, TEXTOID, TEXTOID)
+	assertProcSignature(t, c, "dblink_get_result", RECORDOID, true, TEXTOID)
+	assertProcSignature(t, c, "dblink_get_notify", RECORDOID, true)
+
+	resultOID := lookupTypeOID(t, c, "dblink_pkey_results")
+	if bt := c.TypeByOID(resultOID); bt == nil || !bt.IsDefined || bt.Type != TYPTYPE_COMPOSITE {
+		t.Fatalf("expected dblink_pkey_results composite type, got %#v", bt)
+	}
+}
+
+func TestCreateExtension_Intarray(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION intarray;`)
+
+	assertProcSignature(t, c, "sort", INT4ARRAYOID, false, INT4ARRAYOID)
+	assertProcSignature(t, c, "uniq", INT4ARRAYOID, false, INT4ARRAYOID)
+	if ops := c.LookupOperatorExact("@>", INT4ARRAYOID, INT4ARRAYOID); len(ops) == 0 {
+		t.Error("expected @> operator for intarray")
+	}
+	gin := c.LookupAccessMethod("gin")
+	if gin == nil {
+		t.Fatal("expected gin access method")
+	}
+	if opc := c.opClassByKey[opClassKey{amOID: gin.OID, typeOID: INT4ARRAYOID}]; opc == nil || opc.Name != "gin__int_ops" {
+		t.Fatalf("expected default gin__int_ops opclass, got %#v", opc)
+	}
+}
+
+func TestCreateExtension_PgTrgm(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION pg_trgm;`)
+
+	assertProcSignature(t, c, "similarity", FLOAT4OID, false, TEXTOID, TEXTOID)
+	assertProcSignature(t, c, "show_trgm", TEXTARRAYOID, false, TEXTOID)
+	if ops := c.LookupOperatorExact("%", TEXTOID, TEXTOID); len(ops) == 0 {
+		t.Error("expected % operator for pg_trgm")
+	}
+	gist := c.LookupAccessMethod("gist")
+	if gist == nil {
+		t.Fatal("expected gist access method")
+	}
+	if opc := c.opClassByKey[opClassKey{amOID: gist.OID, typeOID: TEXTOID}]; opc == nil || opc.Name != "gist_trgm_ops" {
+		t.Fatalf("expected default gist_trgm_ops opclass, got %#v", opc)
+	}
+}
+
+func TestCreateExtension_UUIDOSSP(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION "uuid-ossp";`)
+
+	assertProcSignature(t, c, "uuid_generate_v1", UUIDOID, false)
+	assertProcSignature(t, c, "uuid_generate_v4", UUIDOID, false)
+	assertProcSignature(t, c, "uuid_generate_v5", UUIDOID, false, UUIDOID, TEXTOID)
+}
+
+func TestCreateExtension_PGCrypto(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION pgcrypto;`)
+
+	assertProcSignature(t, c, "gen_random_uuid", UUIDOID, false)
+	assertProcSignature(t, c, "digest", BYTEAOID, false, BYTEAOID, TEXTOID)
+	assertProcSignature(t, c, "hmac", BYTEAOID, false, BYTEAOID, BYTEAOID, TEXTOID)
+	assertProcSignature(t, c, "crypt", TEXTOID, false, TEXTOID, TEXTOID)
+}
+
+func TestCreateExtension_BtreeGist(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION btree_gist;`)
+
+	assertDefaultOpClass(t, c, "gist", INT4OID, "gist_int4_ops")
+	assertDefaultOpClass(t, c, "gist", TEXTOID, "gist_text_ops")
+	assertDefaultOpClass(t, c, "gist", TIMESTAMPOID, "gist_timestamp_ops")
+	assertProcSignature(t, c, "gbt_int4_consistent", BOOLOID, false, INTERNALOID, INT4OID, INT2OID, OIDOID, INTERNALOID)
+}
+
+func TestCreateExtension_BtreeGin(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION btree_gin;`)
+
+	assertDefaultOpClass(t, c, "gin", INT4OID, "int4_ops")
+	assertDefaultOpClass(t, c, "gin", TEXTOID, "text_ops")
+	assertDefaultOpClass(t, c, "gin", NUMERICOID, "numeric_ops")
+	assertProcSignature(t, c, "gin_extract_value_int4", INTERNALOID, false, INT4OID, INTERNALOID)
+}
+
+func TestCreateExtension_Cube(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION cube;`)
+
+	cubeOID := lookupTypeOID(t, c, "cube")
+	if bt := c.TypeByOID(cubeOID); bt == nil || !bt.IsDefined {
+		t.Fatal("expected cube type to be fully defined")
+	}
+	assertProcSignature(t, c, "cube_distance", FLOAT8OID, false, cubeOID, cubeOID)
+	if ops := c.LookupOperatorExact("@>", cubeOID, cubeOID); len(ops) == 0 {
+		t.Error("expected @> operator for cube")
+	}
+	assertDefaultOpClass(t, c, "gist", cubeOID, "gist_cube_ops")
+}
+
+func TestCreateExtension_Earthdistance(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION cube; CREATE EXTENSION earthdistance;`)
+
+	earthOID := lookupTypeOID(t, c, "earth")
+	assertProcSignature(t, c, "ll_to_earth", earthOID, false, FLOAT8OID, FLOAT8OID)
+	assertProcSignature(t, c, "earth_distance", FLOAT8OID, false, earthOID, earthOID)
+	if ops := c.LookupOperatorExact("<@>", POINTOID, POINTOID); len(ops) == 0 {
+		t.Error("expected <@> operator for point")
+	}
+}
+
+func TestCreateExtension_Tablefunc(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION tablefunc;`)
+
+	assertProcSignature(t, c, "normal_rand", FLOAT8OID, true, INT4OID, FLOAT8OID, FLOAT8OID)
+	assertProcSignature(t, c, "crosstab", RECORDOID, true, TEXTOID)
+	assertProcSignature(t, c, "connectby", RECORDOID, true, TEXTOID, TEXTOID, TEXTOID, TEXTOID, INT4OID)
+	ct2OID := lookupTypeOID(t, c, "tablefunc_crosstab_2")
+	assertProcSignature(t, c, "crosstab2", ct2OID, true, TEXTOID)
+}
+
+func TestCreateExtension_Unaccent(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION unaccent;`)
+
+	assertProcSignature(t, c, "unaccent", TEXTOID, false, TEXTOID)
+	assertProcSignature(t, c, "unaccent", TEXTOID, false, REGDICTIONARYOID, TEXTOID)
+	assertProcSignature(t, c, "unaccent_lexize", INTERNALOID, false, INTERNALOID, INTERNALOID, INTERNALOID, INTERNALOID)
+}
+
+func TestCreateExtension_Fuzzystrmatch(t *testing.T) {
+	c := New()
+	execSQL(t, c, `CREATE EXTENSION fuzzystrmatch;`)
+
+	assertProcSignature(t, c, "levenshtein", INT4OID, false, TEXTOID, TEXTOID)
+	assertProcSignature(t, c, "levenshtein_less_equal", INT4OID, false, TEXTOID, TEXTOID, INT4OID)
+	assertProcSignature(t, c, "soundex", TEXTOID, false, TEXTOID)
+	assertProcSignature(t, c, "dmetaphone_alt", TEXTOID, false, TEXTOID)
+}
+
 func TestRegisterExtensionSQL(t *testing.T) {
 	// Register a custom extension.
 	RegisterExtensionSQL("my_ext", `
@@ -766,4 +945,36 @@ func lookupTypeOID(t *testing.T, c *Catalog, name string) uint32 {
 		t.Fatalf("type %q not found: %v", name, err)
 	}
 	return oid
+}
+
+func assertProcSignature(t *testing.T, c *Catalog, name string, retType uint32, retSet bool, argTypes ...uint32) {
+	t.Helper()
+	for _, p := range c.LookupProcByName(name) {
+		if p.RetType != retType || p.RetSet != retSet || len(p.ArgTypes) != len(argTypes) {
+			continue
+		}
+		matches := true
+		for i, oid := range argTypes {
+			if p.ArgTypes[i] != oid {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+	t.Fatalf("expected function %s(%s) returns %d set=%v", name, oidListString(argTypes), retType, retSet)
+}
+
+func assertDefaultOpClass(t *testing.T, c *Catalog, amName string, typeOID uint32, className string) {
+	t.Helper()
+	am := c.LookupAccessMethod(amName)
+	if am == nil {
+		t.Fatalf("expected %s access method", amName)
+	}
+	opc := c.opClassByKey[opClassKey{amOID: am.OID, typeOID: typeOID}]
+	if opc == nil || opc.Name != className {
+		t.Fatalf("expected default %s opclass for type %d using %s, got %#v", className, typeOID, amName, opc)
+	}
 }


### PR DESCRIPTION
## Summary
- register semantic-subset bundled SQL for common PostgreSQL contrib extensions, including ltree, dblink, pg_trgm, pgcrypto, uuid-ossp, intarray, btree_gist, btree_gin, cube, earthdistance, tablefunc, unaccent, and fuzzystrmatch
- add catalog regression coverage for extension-provided types, function signatures, operators, and default opclasses
- keep scripts scoped to DDL semantic analysis rather than runtime/planner fidelity

## Test Plan
- go test -count=1 ./pg/catalog
- go test -count=1 ./pg/parser ./pg/parsertest
- git diff --check