### PR TITLE
fix(pg): preserve analyzer scope across set operations

### DIFF
--- a/pg/catalog/analyze.go
+++ b/pg/catalog/analyze.go
@@ -18,19 +18,9 @@ func (c *Catalog) analyzeSelectStmt(stmt *nodes.SelectStmt) (*Query, error) {
 
 	// Set operation.
 	if stmt.Op != nodes.SETOP_NONE {
-		q, err := c.analyzeSetOp(stmt)
-		if err != nil {
-			return nil, err
-		}
-		// WITH clause on set-op queries attaches at the top level.
-		// pg: src/backend/parser/analyze.c — transformSetOperationStmt
-		if stmt.WithClause != nil {
-			ac := &analyzeCtx{catalog: c, query: q}
-			if err := ac.analyzeCTEs(stmt.WithClause); err != nil {
-				return nil, err
-			}
-		}
-		return q, nil
+		q := &Query{}
+		ac := &analyzeCtx{catalog: c, query: q}
+		return ac.analyzeSetOp(stmt)
 	}
 
 	return c.analyzeSimpleSelect(stmt)
@@ -39,17 +29,32 @@ func (c *Catalog) analyzeSelectStmt(stmt *nodes.SelectStmt) (*Query, error) {
 // analyzeSetOp handles UNION/INTERSECT/EXCEPT.
 //
 // pg: src/backend/parser/analyze.c — transformSetOperationStmt
-func (c *Catalog) analyzeSetOp(stmt *nodes.SelectStmt) (*Query, error) {
-	lQuery, err := c.analyzeSelectStmt(stmt.Larg)
+func (ac *analyzeCtx) analyzeSetOp(stmt *nodes.SelectStmt) (*Query, error) {
+	if ac.query == nil {
+		ac.query = &Query{}
+	}
+	q := ac.query
+
+	// WITH belongs to the set-operation query as a whole and must be visible to
+	// each branch while it is analyzed.
+	if stmt.WithClause != nil {
+		if err := ac.analyzeCTEs(stmt.WithClause); err != nil {
+			return nil, err
+		}
+	}
+
+	lQuery, err := ac.analyzeSubSelectWithOptions(stmt.Larg, false)
 	if err != nil {
 		return nil, err
 	}
-	rQuery, err := c.analyzeSelectStmt(stmt.Rarg)
+	rQuery, err := ac.analyzeSubSelectWithOptions(stmt.Rarg, false)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(lQuery.TargetList) != len(rQuery.TargetList) {
+	lOutput := nonJunkTargetEntries(lQuery.TargetList)
+	rOutput := nonJunkTargetEntries(rQuery.TargetList)
+	if len(lOutput) != len(rOutput) {
 		return nil, &Error{
 			Code:    CodeDatatypeMismatch,
 			Message: fmt.Sprintf("each %s query must have the same number of columns", setOpKeyword(stmt.Op)),
@@ -63,15 +68,15 @@ func (c *Catalog) analyzeSetOp(stmt *nodes.SelectStmt) (*Query, error) {
 	// For non-UNKNOWN types: verify coercibility but don't modify the branch expr
 	// (the deparser shows branches as-is). For UNKNOWN Const: coerce by changing
 	// the Const's type, matching PG's coerce_type behavior.
-	tlist := make([]*TargetEntry, len(lQuery.TargetList))
-	for i := range lQuery.TargetList {
-		lte := lQuery.TargetList[i]
-		rte := rQuery.TargetList[i]
+	tlist := make([]*TargetEntry, len(lOutput))
+	for i := range lOutput {
+		lte := lOutput[i]
+		rte := rOutput[i]
 
 		lTypeOID := lte.Expr.exprType()
 		rTypeOID := rte.Expr.exprType()
 
-		common, err := c.selectCommonType([]AnalyzedExpr{lte.Expr, rte.Expr}, setOpKeyword(stmt.Op))
+		common, err := ac.catalog.selectCommonType([]AnalyzedExpr{lte.Expr, rte.Expr}, setOpKeyword(stmt.Op))
 		if err != nil {
 			return nil, err
 		}
@@ -79,11 +84,11 @@ func (c *Catalog) analyzeSetOp(stmt *nodes.SelectStmt) (*Query, error) {
 		// Left branch coercion.
 		// pg: src/backend/parser/analyze.c — transformSetOperationTree (coercion loop)
 		if lTypeOID != UNKNOWNOID {
-			if _, err := c.coerceToTargetType(lte.Expr, lTypeOID, common, 'i'); err != nil {
+			if _, err := ac.catalog.coerceToTargetType(lte.Expr, lTypeOID, common, 'i'); err != nil {
 				return nil, err
 			}
 		} else if _, ok := lte.Expr.(*ConstExpr); ok {
-			coerced, err := c.coerceToTargetType(lte.Expr, lTypeOID, common, 'i')
+			coerced, err := ac.catalog.coerceToTargetType(lte.Expr, lTypeOID, common, 'i')
 			if err != nil {
 				return nil, err
 			}
@@ -92,11 +97,11 @@ func (c *Catalog) analyzeSetOp(stmt *nodes.SelectStmt) (*Query, error) {
 
 		// Right branch coercion.
 		if rTypeOID != UNKNOWNOID {
-			if _, err := c.coerceToTargetType(rte.Expr, rTypeOID, common, 'i'); err != nil {
+			if _, err := ac.catalog.coerceToTargetType(rte.Expr, rTypeOID, common, 'i'); err != nil {
 				return nil, err
 			}
 		} else if _, ok := rte.Expr.(*ConstExpr); ok {
-			coerced, err := c.coerceToTargetType(rte.Expr, rTypeOID, common, 'i')
+			coerced, err := ac.catalog.coerceToTargetType(rte.Expr, rTypeOID, common, 'i')
 			if err != nil {
 				return nil, err
 			}
@@ -116,13 +121,23 @@ func (c *Catalog) analyzeSetOp(stmt *nodes.SelectStmt) (*Query, error) {
 		}
 	}
 
-	return &Query{
-		TargetList: tlist,
-		SetOp:      op,
-		AllSetOp:   stmt.All,
-		LArg:       lQuery,
-		RArg:       rQuery,
-	}, nil
+	q.TargetList = tlist
+	q.SetOp = op
+	q.AllSetOp = stmt.All
+	q.LArg = lQuery
+	q.RArg = rQuery
+	return q, nil
+}
+
+func nonJunkTargetEntries(tlist []*TargetEntry) []*TargetEntry {
+	output := make([]*TargetEntry, 0, len(tlist))
+	for _, te := range tlist {
+		if te == nil || te.ResJunk {
+			continue
+		}
+		output = append(output, te)
+	}
+	return output
 }
 
 // analyzeSimpleSelect handles a simple (non-set-op) SELECT.
@@ -670,11 +685,12 @@ func (ac *analyzeCtx) transformRangeSubselect(rs *nodes.RangeSubselect) (JoinNod
 		alias = rs.Alias.Aliasname
 	}
 
-	colNames := make([]string, len(subQuery.TargetList))
-	colTypes := make([]uint32, len(subQuery.TargetList))
-	colTypMods := make([]int32, len(subQuery.TargetList))
-	colCollations := make([]uint32, len(subQuery.TargetList))
-	for i, te := range subQuery.TargetList {
+	outputTargetList := nonJunkTargetEntries(subQuery.TargetList)
+	colNames := make([]string, len(outputTargetList))
+	colTypes := make([]uint32, len(outputTargetList))
+	colTypMods := make([]int32, len(outputTargetList))
+	colCollations := make([]uint32, len(outputTargetList))
+	for i, te := range outputTargetList {
 		colNames[i] = te.ResName
 		colTypes[i] = te.Expr.exprType()
 		colTypMods[i] = -1 // typmod lost through subquery
@@ -1293,6 +1309,26 @@ func (ac *analyzeCtx) transformColumnRef(cr *nodes.ColumnRef) (AnalyzedExpr, err
 // If the column is not found in the current query's range table, and a parent
 // context exists, it searches the parent for correlated subquery references.
 func (ac *analyzeCtx) resolveColumnRef(tableName, colName string) (*VarExpr, error) {
+	if tableName == "" && ac.query.JoinTree != nil && len(ac.query.JoinTree.FromList) > 0 {
+		var found *VarExpr
+		for _, jn := range ac.query.JoinTree.FromList {
+			v, ambiguous := ac.findVarInVisibleJoinNode(jn, colName)
+			if ambiguous {
+				return nil, errAmbiguousColumn(colName)
+			}
+			if v == nil {
+				continue
+			}
+			if found != nil {
+				return nil, errAmbiguousColumn(colName)
+			}
+			found = v
+		}
+		if found != nil {
+			return found, nil
+		}
+	}
+
 	var found *VarExpr
 	for rtIdx, rte := range ac.query.RangeTable {
 		if tableName != "" && rte.ERef != tableName {
@@ -1322,11 +1358,17 @@ func (ac *analyzeCtx) resolveColumnRef(tableName, colName string) (*VarExpr, err
 		}
 	}
 
-	if found == nil && ac.parent != nil && !ac.disallowParentCols {
+	if found == nil && ac.parent != nil {
 		// Try resolving in parent context (correlated subquery).
 		// pg: src/backend/parser/parse_expr.c — transformColumnRef
 		// PG walks up the namespace chain to find outer references.
-		outerVar, err := ac.parent.resolveColumnRef(tableName, colName)
+		var outerVar *VarExpr
+		var err error
+		if ac.disallowParentCols {
+			outerVar, err = ac.parent.resolveColumnRefAboveLocal(tableName, colName)
+		} else {
+			outerVar, err = ac.parent.resolveColumnRef(tableName, colName)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1358,6 +1400,67 @@ func (ac *analyzeCtx) resolveColumnRef(tableName, colName string) (*VarExpr, err
 		return nil, errUndefinedColumn(colName)
 	}
 	return found, nil
+}
+
+func (ac *analyzeCtx) resolveColumnRefAboveLocal(tableName, colName string) (*VarExpr, error) {
+	if ac.parent == nil {
+		if tableName != "" {
+			return nil, errUndefinedTable(tableName)
+		}
+		return nil, errUndefinedColumn(colName)
+	}
+	outerVar, err := ac.parent.resolveColumnRef(tableName, colName)
+	if err != nil {
+		return nil, err
+	}
+	return &VarExpr{
+		RangeIdx:  outerVar.RangeIdx,
+		AttNum:    outerVar.AttNum,
+		TypeOID:   outerVar.TypeOID,
+		TypeMod:   outerVar.TypeMod,
+		Collation: outerVar.Collation,
+		LevelsUp:  outerVar.LevelsUp + 1,
+	}, nil
+}
+
+func (ac *analyzeCtx) findVarInVisibleJoinNode(jn JoinNode, colName string) (*VarExpr, bool) {
+	switch v := jn.(type) {
+	case *RangeTableRef:
+		return ac.findVarInRTE(v.RTIndex, colName)
+	case *JoinExprNode:
+		return ac.findVarInRTE(v.RTIndex, colName)
+	default:
+		return nil, false
+	}
+}
+
+func (ac *analyzeCtx) findVarInRTE(rtIdx int, colName string) (*VarExpr, bool) {
+	if rtIdx < 0 || rtIdx >= len(ac.query.RangeTable) {
+		return nil, false
+	}
+	rte := ac.query.RangeTable[rtIdx]
+	var found *VarExpr
+	for colIdx, cn := range rte.ColNames {
+		if cn != colName {
+			continue
+		}
+		var coll uint32
+		if colIdx < len(rte.ColCollations) {
+			coll = rte.ColCollations[colIdx]
+		}
+		v := &VarExpr{
+			RangeIdx:  rtIdx,
+			AttNum:    int16(colIdx + 1),
+			TypeOID:   rte.ColTypes[colIdx],
+			TypeMod:   rte.ColTypMods[colIdx],
+			Collation: coll,
+		}
+		if found != nil {
+			return nil, true
+		}
+		found = v
+	}
+	return found, false
 }
 
 // transformAConst transforms a constant value.
@@ -1937,7 +2040,8 @@ func (ac *analyzeCtx) transformSubLink(sl *nodes.SubLink) (AnalyzedExpr, error) 
 			ResultType:  BOOLOID,
 		}, nil
 	case nodes.ANY_SUBLINK:
-		if len(subQuery.TargetList) != 1 {
+		outputTargetList := nonJunkTargetEntries(subQuery.TargetList)
+		if len(outputTargetList) != 1 {
 			return nil, &Error{Code: CodeTooManyColumns, Message: "subquery must return only one column"}
 		}
 		var testExpr AnalyzedExpr
@@ -1954,7 +2058,8 @@ func (ac *analyzeCtx) transformSubLink(sl *nodes.SubLink) (AnalyzedExpr, error) 
 			ResultType:  BOOLOID,
 		}, nil
 	case nodes.ALL_SUBLINK:
-		if len(subQuery.TargetList) != 1 {
+		outputTargetList := nonJunkTargetEntries(subQuery.TargetList)
+		if len(outputTargetList) != 1 {
 			return nil, &Error{Code: CodeTooManyColumns, Message: "subquery must return only one column"}
 		}
 		var testExpr AnalyzedExpr
@@ -1972,13 +2077,14 @@ func (ac *analyzeCtx) transformSubLink(sl *nodes.SubLink) (AnalyzedExpr, error) 
 		}, nil
 	default:
 		// EXPR_SUBLINK (scalar subquery)
-		if len(subQuery.TargetList) != 1 {
+		outputTargetList := nonJunkTargetEntries(subQuery.TargetList)
+		if len(outputTargetList) != 1 {
 			return nil, &Error{Code: CodeTooManyColumns, Message: "subquery must return only one column"}
 		}
 		return &SubLinkExpr{
 			SubLinkType: SubLinkExprType,
 			SubQuery:    subQuery,
-			ResultType:  subQuery.TargetList[0].Expr.exprType(),
+			ResultType:  outputTargetList[0].Expr.exprType(),
 		}, nil
 	}
 }
@@ -2010,9 +2116,16 @@ func (ac *analyzeCtx) analyzeSubSelectWithOptions(stmt *nodes.SelectStmt, disall
 		return nil, fmt.Errorf("NULL select statement")
 	}
 
-	// Set operation — analyze recursively without parent context on branches.
+	// Set operation — keep the current parent/CTE context visible to branches.
 	if stmt.Op != nodes.SETOP_NONE {
-		return ac.catalog.analyzeSetOp(stmt)
+		q := &Query{}
+		subAc := &analyzeCtx{
+			catalog:            ac.catalog,
+			query:              q,
+			parent:             ac,
+			disallowParentCols: disallowParentCols,
+		}
+		return subAc.analyzeSetOp(stmt)
 	}
 
 	// Simple SELECT with parent context.
@@ -3090,7 +3203,7 @@ func (ac *analyzeCtx) analyzeCTEs(withClause *nodes.WithClause) error {
 			ac.catalog.visibleCTEs = ac.query.CTEList
 
 			// 5. Now analyze the full UNION — the recursive term can see the CTE.
-			fullQuery, err := ac.catalog.analyzeSetOp(sub)
+			fullQuery, err := ac.analyzeSubSelect(sub)
 
 			// Clear visibleCTEs regardless of error.
 			ac.catalog.visibleCTEs = nil

--- a/pg/catalog/exec.go
+++ b/pg/catalog/exec.go
@@ -45,6 +45,13 @@ func (c *Catalog) Exec(sql string, opts *ExecOptions) ([]ExecResult, error) {
 	// Build line number index for offset→line conversion.
 	lineIndex := buildLineIndex(sql)
 
+	// Schema dumps are often not strictly executable order. Pre-declare
+	// CREATE OR REPLACE functions when possible so earlier views can resolve
+	// RETURNS TABLE/OUT columns during analysis. Errors are still surfaced
+	// during normal statement execution below.
+	predeclaredFunctions := make(map[int]bool)
+	firstFunctionIndex := firstFunctionDefinitionIndexes(list)
+
 	continueOnError := false
 	if opts != nil {
 		continueOnError = opts.ContinueOnError
@@ -55,13 +62,10 @@ func (c *Catalog) Exec(sql string, opts *ExecOptions) ([]ExecResult, error) {
 		// Drain any leftover warnings from previous operations.
 		c.DrainWarnings()
 
+		c.predeclareReplaceableFunctions(list, predeclaredFunctions, firstFunctionIndex)
+
 		// Unwrap RawStmt if present.
-		var stmt nodes.Node
-		if raw, ok := item.(*nodes.RawStmt); ok {
-			stmt = raw.Stmt
-		} else {
-			stmt = item
-		}
+		stmt := unwrapRawStmt(item)
 
 		// Determine SQL text and line number for this statement.
 		stmtSQL := ""
@@ -96,6 +100,48 @@ func (c *Catalog) Exec(sql string, opts *ExecOptions) ([]ExecResult, error) {
 		}
 	}
 	return results, nil
+}
+
+func firstFunctionDefinitionIndexes(list *nodes.List) map[string]int {
+	first := make(map[string]int)
+	for i, item := range list.Items {
+		fn, ok := unwrapRawStmt(item).(*nodes.CreateFunctionStmt)
+		if !ok {
+			continue
+		}
+		identity := functionIdentity(fn)
+		if _, exists := first[identity]; !exists {
+			first[identity] = i
+		}
+	}
+	return first
+}
+
+func (c *Catalog) predeclareReplaceableFunctions(list *nodes.List, predeclared map[int]bool, firstFunctionIndex map[string]int) {
+	for i, item := range list.Items {
+		if predeclared[i] {
+			continue
+		}
+		stmt := unwrapRawStmt(item)
+		fn, ok := stmt.(*nodes.CreateFunctionStmt)
+		if !ok || !fn.IsOrReplace {
+			continue
+		}
+		if firstFunctionIndex[functionIdentity(fn)] != i {
+			continue
+		}
+		if err := c.CreateFunctionStmt(fn); err == nil {
+			predeclared[i] = true
+		}
+		c.DrainWarnings()
+	}
+}
+
+func unwrapRawStmt(item nodes.Node) nodes.Node {
+	if raw, ok := item.(*nodes.RawStmt); ok {
+		return raw.Stmt
+	}
+	return item
 }
 
 // isDML returns true for statements that are not utility statements

--- a/pg/catalog/scope_regression_test.go
+++ b/pg/catalog/scope_regression_test.go
@@ -1,0 +1,196 @@
+package catalog
+
+import "testing"
+
+func TestPGAnalyzerScopeRegressions(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "lateral_setop_can_see_prior_lateral_alias",
+			sql: `
+				CREATE TABLE clips (body text);
+				CREATE VIEW v_lateral_setop AS
+					SELECT exp.token
+					FROM clips c
+					CROSS JOIN LATERAL (
+						SELECT lower(c.body) AS norm
+					) sp
+					LEFT JOIN LATERAL (
+						SELECT x.token
+						FROM (
+							SELECT regexp_split_to_table(COALESCE(sp.norm, ''), ',') AS token
+							UNION ALL
+							SELECT regexp_split_to_table(COALESCE(sp.norm, ''), ';') AS token
+						) x
+					) exp ON true;
+			`,
+		},
+		{
+			name: "derived_table_output_alias_visible_without_inner_join_leak",
+			sql: `
+				CREATE TABLE assortment_source (assortment_sku integer);
+				CREATE TABLE group_source (a_group integer);
+				CREATE VIEW v_derived_alias AS
+					SELECT assortment_sku, a_group, row_num
+					FROM (
+						SELECT
+							a.assortment_sku,
+							group_join.a_group AS a_group,
+							row_number() OVER () AS row_num
+						FROM assortment_source a
+						JOIN group_source group_join ON true
+					) abc;
+			`,
+		},
+		{
+			name: "derived_table_does_not_expose_group_by_resjunk_alias",
+			sql: `
+				CREATE TABLE item_master_scope (assortment_sku integer, item_number numeric);
+				CREATE TABLE group_source_scope (representative_item_number bigint, a_group text);
+				CREATE VIEW v_derived_alias_group_by AS
+					SELECT assortment_sku, a_group, row_num
+					FROM (
+						SELECT
+							im.assortment_sku,
+							group_join.a_group::character varying AS a_group,
+							row_number() OVER (
+								PARTITION BY im.assortment_sku
+								ORDER BY group_join.a_group::character varying
+							) AS row_num
+						FROM item_master_scope im
+						JOIN (
+							SELECT representative_item_number, a_group
+							FROM group_source_scope
+						) group_join ON im.item_number = group_join.representative_item_number::numeric
+						GROUP BY im.assortment_sku, group_join.a_group::character varying
+					) abc
+					WHERE row_num = 1;
+			`,
+		},
+		{
+			name: "unqualified_column_from_join_not_duplicated_by_join_rte",
+			sql: `
+				CREATE TABLE left_source (id integer);
+				CREATE TABLE right_source (a_group integer);
+				CREATE VIEW v_join_unqualified AS
+					SELECT a_group
+					FROM left_source l
+					JOIN right_source r ON true;
+			`,
+		},
+		{
+			name: "top_level_with_visible_to_setop_branches",
+			sql: `
+				CREATE TABLE cte_source (id integer);
+				CREATE VIEW v_cte_setop AS
+					WITH core_hi_items AS (
+						SELECT id FROM cte_source
+					)
+					SELECT id FROM core_hi_items
+					UNION ALL
+					SELECT id FROM core_hi_items;
+			`,
+		},
+		{
+			name: "setop_column_count_ignores_branch_resjunk_targets",
+			sql: `
+				CREATE TABLE union_source (id integer, sort_key integer);
+				CREATE VIEW v_union_branch_order AS
+					(SELECT id FROM union_source ORDER BY sort_key)
+					UNION ALL
+					SELECT id FROM union_source;
+			`,
+		},
+		{
+			name: "sublink_column_count_ignores_order_by_resjunk_targets",
+			sql: `
+				CREATE TABLE sublink_source (id integer, sort_key integer, new_value text);
+				CREATE VIEW v_scalar_sublink_order AS
+					SELECT (
+						SELECT new_value
+						FROM sublink_source inner_source
+						ORDER BY inner_source.sort_key DESC
+						LIMIT 1
+					) AS latest_value
+					FROM sublink_source outer_source;
+				CREATE VIEW v_any_sublink_order AS
+					SELECT id
+					FROM sublink_source outer_source
+					WHERE id IN (
+						SELECT id
+						FROM sublink_source inner_source
+						GROUP BY id
+						ORDER BY count(*) DESC
+					);
+			`,
+		},
+		{
+			name: "materialized_view_with_cte_visible_to_setop_branches",
+			sql: `
+				CREATE TABLE mat_cte_source (id integer);
+				CREATE MATERIALIZED VIEW mv_cte_setop AS
+					WITH lagged_data AS (
+						SELECT id FROM mat_cte_source
+					)
+					SELECT id FROM lagged_data
+					UNION ALL
+					SELECT id FROM lagged_data;
+			`,
+		},
+		{
+			name: "schema_record_function_with_column_definition_list",
+			sql: `
+				CREATE SCHEMA redshift;
+				CREATE FUNCTION redshift.week_item_data()
+				RETURNS SETOF record
+				LANGUAGE sql
+				AS $$
+					SELECT 1::integer, 'sku-1'::text;
+				$$;
+				CREATE VIEW v_week_item_data AS
+					SELECT wid.week_id, wid.sku
+					FROM redshift.week_item_data() wid(week_id integer, sku text);
+			`,
+		},
+		{
+			name: "schema_returns_table_function_available_to_earlier_view",
+			sql: `
+				CREATE SCHEMA redshift;
+				CREATE VIEW v_week_item_data_before_function AS
+					SELECT wid.ad_end_date, wid.lob
+					FROM redshift.week_item_data() wid(ad_end_date, lob);
+				CREATE OR REPLACE FUNCTION redshift.week_item_data()
+				RETURNS TABLE(ad_end_date date, lob text)
+				LANGUAGE plpgsql
+				AS $$ BEGIN RETURN; END; $$;
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := LoadSQL(tt.sql); err != nil {
+				t.Fatalf("LoadSQL failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestPGAnalyzerScopeRejectsNonLateralSetopSiblingReference(t *testing.T) {
+	_, err := LoadSQL(`
+		CREATE TABLE non_lateral_base (id integer);
+		CREATE VIEW v_non_lateral_setop AS
+			SELECT s.id
+			FROM non_lateral_base b,
+			     (
+				     SELECT b.id AS id
+				     UNION ALL
+				     SELECT b.id AS id
+			     ) s;
+	`)
+	if err == nil {
+		t.Fatal("LoadSQL unexpectedly accepted non-LATERAL set-op reference to sibling alias")
+	}
+}


### PR DESCRIPTION
## Summary
- preserve analyzer parent/CTE scope while analyzing set-operation branches, including complex LATERAL chains
- ignore resjunk target entries when exposing derived-table columns and validating set-op/sublink output arity
- predeclare eligible `CREATE OR REPLACE FUNCTION` statements in schema dumps so earlier views can resolve `RETURNS TABLE` output columns
- add focused PG analyzer scope regressions for LATERAL set-ops, derived-table alias leakage, CTE set-ops, sublink arity, and table functions

## Test Plan
- `go test ./pg/... -skip Container -count=1`
