### PR TITLE
fix(oracle): retain DML targets and JSON type

### DIFF
--- a/oracle/ast/loc.go
+++ b/oracle/ast/loc.go
@@ -295,6 +295,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *SubqueryRef:
 		return v.Loc
+	case *SubqueryRestrictionClause:
+		return v.Loc
 	case *LateralRef:
 		return v.Loc
 	case *JoinClause:

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -159,6 +159,8 @@ func writeNode(sb *strings.Builder, node Node) {
 		writeTableRef(sb, n)
 	case *SubqueryRef:
 		writeSubqueryRef(sb, n)
+	case *SubqueryRestrictionClause:
+		writeSubqueryRestrictionClause(sb, n)
 	case *LateralRef:
 		writeLateralRef(sb, n)
 	case *XmlTableRef:
@@ -1123,9 +1125,29 @@ func writeSubqueryRef(sb *strings.Builder, n *SubqueryRef) {
 		sb.WriteString(" :subquery ")
 		writeNode(sb, n.Subquery)
 	}
+	if n.Restriction != nil {
+		sb.WriteString(" :restriction ")
+		writeNode(sb, n.Restriction)
+	}
 	if n.Alias != nil {
 		sb.WriteString(" :alias ")
 		writeNode(sb, n.Alias)
+	}
+	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
+	sb.WriteString("}")
+}
+
+func writeSubqueryRestrictionClause(sb *strings.Builder, n *SubqueryRestrictionClause) {
+	sb.WriteString("{SUBQUERYRESTRICTION")
+	if n.ReadOnly {
+		sb.WriteString(" :readOnly true")
+	}
+	if n.CheckOption {
+		sb.WriteString(" :checkOption true")
+	}
+	if n.ConstraintName != nil {
+		sb.WriteString(" :constraintName ")
+		writeNode(sb, n.ConstraintName)
 	}
 	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
 	sb.WriteString("}")
@@ -2346,20 +2368,25 @@ func writeInsertStmt(sb *strings.Builder, n *InsertStmt) {
 
 func writeUpdateStmt(sb *strings.Builder, n *UpdateStmt) {
 	sb.WriteString("{UPDATE")
-	if n.Table != nil {
-		sb.WriteString(" :table ")
-		writeNode(sb, n.Table)
-	}
-	if n.PartitionExt != nil {
-		sb.WriteString(" :partitionExt ")
-		writeNode(sb, n.PartitionExt)
-	}
-	if n.Dblink != "" {
-		sb.WriteString(fmt.Sprintf(" :dblink %q", n.Dblink))
-	}
-	if n.Alias != nil {
-		sb.WriteString(" :alias ")
-		writeNode(sb, n.Alias)
+	if n.Target != nil {
+		sb.WriteString(" :target ")
+		writeNode(sb, n.Target)
+	} else {
+		if n.Table != nil {
+			sb.WriteString(" :table ")
+			writeNode(sb, n.Table)
+		}
+		if n.PartitionExt != nil {
+			sb.WriteString(" :partitionExt ")
+			writeNode(sb, n.PartitionExt)
+		}
+		if n.Dblink != "" {
+			sb.WriteString(fmt.Sprintf(" :dblink %q", n.Dblink))
+		}
+		if n.Alias != nil {
+			sb.WriteString(" :alias ")
+			writeNode(sb, n.Alias)
+		}
 	}
 	if n.SetClauses != nil {
 		sb.WriteString(" :setClauses ")
@@ -2391,20 +2418,25 @@ func writeUpdateStmt(sb *strings.Builder, n *UpdateStmt) {
 
 func writeDeleteStmt(sb *strings.Builder, n *DeleteStmt) {
 	sb.WriteString("{DELETE")
-	if n.Table != nil {
-		sb.WriteString(" :table ")
-		writeNode(sb, n.Table)
-	}
-	if n.PartitionExt != nil {
-		sb.WriteString(" :partitionExt ")
-		writeNode(sb, n.PartitionExt)
-	}
-	if n.Dblink != "" {
-		sb.WriteString(fmt.Sprintf(" :dblink %q", n.Dblink))
-	}
-	if n.Alias != nil {
-		sb.WriteString(" :alias ")
-		writeNode(sb, n.Alias)
+	if n.Target != nil {
+		sb.WriteString(" :target ")
+		writeNode(sb, n.Target)
+	} else {
+		if n.Table != nil {
+			sb.WriteString(" :table ")
+			writeNode(sb, n.Table)
+		}
+		if n.PartitionExt != nil {
+			sb.WriteString(" :partitionExt ")
+			writeNode(sb, n.PartitionExt)
+		}
+		if n.Dblink != "" {
+			sb.WriteString(fmt.Sprintf(" :dblink %q", n.Dblink))
+		}
+		if n.Alias != nil {
+			sb.WriteString(" :alias ")
+			writeNode(sb, n.Alias)
+		}
 	}
 	if n.WhereClause != nil {
 		sb.WriteString(" :whereClause ")

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -749,13 +749,26 @@ func (n *TableRef) tableExpr() {}
 
 // SubqueryRef represents a subquery in a FROM clause.
 type SubqueryRef struct {
-	Subquery StmtNode // the subquery
-	Alias    *Alias   // alias
-	Loc      Loc
+	Subquery    StmtNode                   // the subquery
+	Restriction *SubqueryRestrictionClause // WITH READ ONLY / WITH CHECK OPTION
+	Alias       *Alias                     // alias
+	Loc         Loc
 }
 
 func (n *SubqueryRef) nodeTag()   {}
 func (n *SubqueryRef) tableExpr() {}
+
+// SubqueryRestrictionClause represents a DML inline-view subquery restriction.
+//
+//	WITH { READ ONLY | CHECK OPTION [ CONSTRAINT constraint_name ] }
+type SubqueryRestrictionClause struct {
+	ReadOnly       bool        // WITH READ ONLY
+	CheckOption    bool        // WITH CHECK OPTION
+	ConstraintName *ObjectName // optional CONSTRAINT name
+	Loc            Loc
+}
+
+func (n *SubqueryRestrictionClause) nodeTag() {}
 
 // LateralRef represents a LATERAL inline view in FROM.
 //
@@ -1339,6 +1352,7 @@ func (n *ErrorLogClause) nodeTag() {}
 // UpdateStmt represents an UPDATE statement.
 // Ref: https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/UPDATE.html
 type UpdateStmt struct {
+	Target       TableExpr           // table, inline view, or table collection target
 	Table        *ObjectName         // table to update
 	PartitionExt *PartitionExtClause // PARTITION/SUBPARTITION extension
 	Dblink       string              // @dblink name
@@ -1372,6 +1386,7 @@ func (n *SetClause) nodeTag() {}
 // DeleteStmt represents a DELETE statement.
 // Ref: https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/DELETE.html
 type DeleteStmt struct {
+	Target       TableExpr           // table, inline view, or table collection target
 	Table        *ObjectName         // table to delete from
 	PartitionExt *PartitionExtClause // PARTITION/SUBPARTITION extension
 	Dblink       string              // @dblink name

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -748,14 +748,18 @@ func walkChildren(v Visitor, node Node) {
 			}
 		}
 	case *DeleteStmt:
-		if n.Table != nil {
-			Walk(v, n.Table)
-		}
-		if n.PartitionExt != nil {
-			Walk(v, n.PartitionExt)
-		}
-		if n.Alias != nil {
-			Walk(v, n.Alias)
+		if n.Target != nil {
+			Walk(v, n.Target)
+		} else {
+			if n.Table != nil {
+				Walk(v, n.Table)
+			}
+			if n.PartitionExt != nil {
+				Walk(v, n.PartitionExt)
+			}
+			if n.Alias != nil {
+				Walk(v, n.Alias)
+			}
 		}
 		Walk(v, n.WhereClause)
 		walkList(v, n.Returning)
@@ -1308,8 +1312,15 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Subquery)
 	case *SubqueryRef:
 		Walk(v, n.Subquery)
+		if n.Restriction != nil {
+			Walk(v, n.Restriction)
+		}
 		if n.Alias != nil {
 			Walk(v, n.Alias)
+		}
+	case *SubqueryRestrictionClause:
+		if n.ConstraintName != nil {
+			Walk(v, n.ConstraintName)
 		}
 	case *TableCollectionExpr:
 		Walk(v, n.Expr)
@@ -1368,14 +1379,18 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Alias)
 		}
 	case *UpdateStmt:
-		if n.Table != nil {
-			Walk(v, n.Table)
-		}
-		if n.PartitionExt != nil {
-			Walk(v, n.PartitionExt)
-		}
-		if n.Alias != nil {
-			Walk(v, n.Alias)
+		if n.Target != nil {
+			Walk(v, n.Target)
+		} else {
+			if n.Table != nil {
+				Walk(v, n.Table)
+			}
+			if n.PartitionExt != nil {
+				Walk(v, n.PartitionExt)
+			}
+			if n.Alias != nil {
+				Walk(v, n.Alias)
+			}
 		}
 		walkList(v, n.SetClauses)
 		walkList(v, n.FromClause)

--- a/oracle/parser/create_table.go
+++ b/oracle/parser/create_table.go
@@ -646,7 +646,7 @@ func isOracleTypeToken(tokenType int) bool {
 	switch tokenType {
 	case kwNUMBER, kwINTEGER, kwSMALLINT, kwDECIMAL, kwFLOAT,
 		kwCHAR, kwVARCHAR2, kwVARCHAR, kwNCHAR, kwNVARCHAR2,
-		kwCLOB, kwBLOB, kwNCLOB,
+		kwCLOB, kwBLOB, kwNCLOB, kwJSON,
 		kwDATE, kwTIMESTAMP, kwINTERVAL,
 		kwRAW, kwLONG, kwROWID:
 		return true

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -62,6 +62,35 @@ func TestP2CreateTableMalformedComplexOption(t *testing.T) {
 	ParseShouldFail(t, "CREATE TABLE docs (id NUMBER, doc CLOB) LOB STORE AS lob_seg")
 }
 
+func TestCreateTableJsonColumnType(t *testing.T) {
+	stmt := parseCreateTableForP2(t, "CREATE TABLE docs (id NUMBER, payload JSON)")
+	if stmt.Columns == nil || stmt.Columns.Len() != 2 {
+		t.Fatalf("expected 2 columns, got %#v", stmt.Columns)
+	}
+	col := stmt.Columns.Items[1].(*ast.ColumnDef)
+	if col.TypeName == nil || col.TypeName.Names.Len() != 1 {
+		t.Fatalf("expected JSON type name, got %#v", col.TypeName)
+	}
+	if got := col.TypeName.Names.Items[0].(*ast.String).Str; got != "JSON" {
+		t.Fatalf("expected JSON type name, got %q", got)
+	}
+}
+
+func TestCreateTableJsonKeywordStillAllowedAsIdentifier(t *testing.T) {
+	parseCreateTableForP2(t, "CREATE TABLE JSON (a NUMBER)")
+	stmt := parseCreateTableForP2(t, "CREATE TABLE t (JSON NUMBER)")
+	if stmt.Columns == nil || stmt.Columns.Len() != 1 {
+		t.Fatalf("expected 1 column, got %#v", stmt.Columns)
+	}
+	col := stmt.Columns.Items[0].(*ast.ColumnDef)
+	if col.Name != "JSON" {
+		t.Fatalf("expected column name JSON, got %q", col.Name)
+	}
+	if col.TypeName == nil || col.TypeName.Names.Items[0].(*ast.String).Str != "NUMBER" {
+		t.Fatalf("expected NUMBER type, got %#v", col.TypeName)
+	}
+}
+
 func TestCreateTableIntervalPartitioning(t *testing.T) {
 	ParseAndCheck(t, `CREATE TABLE t_interval_full (d DATE)
 PARTITION BY RANGE (d)

--- a/oracle/parser/testdata/coverage/loc_node_coverage.tsv
+++ b/oracle/parser/testdata/coverage/loc_node_coverage.tsv
@@ -141,6 +141,7 @@ node_type	family	status	fixture	notes	debt_class	approval	next_action
 *nodes.Hint	ast	covered	SELECT /*+ INDEX(t idx) */ * FROM t	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard
 *nodes.TableRef	clause	covered	SELECT * FROM t	table ref span	none	covered	keep_regression_guard
 *nodes.SubqueryRef	ast	covered	SELECT * FROM (SELECT 1 a FROM dual) q	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard
+*nodes.SubqueryRestrictionClause	clause	covered	UPDATE (SELECT a FROM t WITH CHECK OPTION CONSTRAINT ck_v) v SET a = 1	DML inline-view subquery restriction span	none	covered	keep_regression_guard
 *nodes.LateralRef	ast	covered	SELECT * FROM t, LATERAL (SELECT 1 a FROM dual) q	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard
 *nodes.JoinClause	clause	covered	SELECT * FROM t JOIN u ON t.id = u.id	join clause span	none	covered	keep_regression_guard
 *nodes.WithClause	clause	covered	WITH q AS (SELECT 1 a FROM dual) SELECT a FROM q	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard

--- a/oracle/parser/type.go
+++ b/oracle/parser/type.go
@@ -52,7 +52,7 @@ func (p *Parser) parseTypeName() (*nodes.TypeName, error) {
 			return nil, parseErr1117
 		}
 
-	case kwCLOB, kwBLOB, kwNCLOB:
+	case kwCLOB, kwBLOB, kwNCLOB, kwJSON:
 		tn.Names.Items = append(tn.Names.Items, &nodes.String{Str: p.cur.Str})
 		p.advance()
 

--- a/oracle/parser/type_test.go
+++ b/oracle/parser/type_test.go
@@ -85,7 +85,7 @@ func TestParseTypeChar(t *testing.T) {
 
 // TestParseTypeLOB tests CLOB, BLOB, NCLOB.
 func TestParseTypeLOB(t *testing.T) {
-	for _, input := range []string{"CLOB", "BLOB", "NCLOB"} {
+	for _, input := range []string{"CLOB", "BLOB", "NCLOB", "JSON"} {
 		t.Run(input, func(t *testing.T) {
 			p := newTestParser(input)
 			tn, parseErr3 := p.parseTypeName()

--- a/oracle/parser/update_delete.go
+++ b/oracle/parser/update_delete.go
@@ -4,6 +4,13 @@ import (
 	nodes "github.com/bytebase/omni/oracle/ast"
 )
 
+type dmlTargetMode int
+
+const (
+	dmlTargetUpdate dmlTargetMode = iota
+	dmlTargetDelete
+)
+
 // parseUpdateStmt parses an UPDATE statement.
 //
 // BNF: oracle/parser/bnf/UPDATE.bnf
@@ -93,61 +100,14 @@ func (p *Parser) parseUpdateStmt() (*nodes.UpdateStmt, error) {
 	}
 	var parseErr1127 error
 
-	// Table name or inline view target.
-	if p.cur.Type == '(' {
-		if parseErr1127 = p.parseDMLSubqueryTarget(); parseErr1127 != nil {
-			return nil, parseErr1127
-		}
-	} else {
-		stmt.Table, parseErr1127 = p.parseObjectName()
-		if parseErr1127 !=
-
-			// Optional alias (before partition clause, matching BNF order for UPDATE)
-			nil {
-			return nil, parseErr1127
-		}
+	stmt.Target, parseErr1127 = p.parseDMLTarget(dmlTargetUpdate)
+	if parseErr1127 != nil {
+		return nil, parseErr1127
 	}
-
-	if p.cur.Type == kwAS {
-		p.advance()
-		var parseErr1128 error
-		stmt.Alias, parseErr1128 = p.parseAlias()
-		if parseErr1128 != nil {
-			return nil, parseErr1128
-		}
-	} else if p.isTableAliasCandidate() {
-		var parseErr1129 error
-		stmt.Alias, parseErr1129 = p.parseAlias()
-		if parseErr1129 !=
-
-			// Partition extension clause
-			nil {
-			return nil, parseErr1129
-		}
+	if stmt.Target == nil {
+		return nil, p.syntaxErrorAtCur()
 	}
-
-	if p.cur.Type == kwPARTITION || p.cur.Type == kwSUBPARTITION {
-		var parseErr1130 error
-		stmt.PartitionExt, parseErr1130 = p.parsePartitionExtClause()
-		if parseErr1130 !=
-
-			// @dblink
-			nil {
-			return nil, parseErr1130
-		}
-	}
-
-	if p.cur.Type == '@' {
-		p.advance()
-		var parseErr1131 error
-		stmt.Dblink, parseErr1131 = p.parseIdentifier()
-		if parseErr1131 !=
-
-			// SET
-			nil {
-			return nil, parseErr1131
-		}
-	}
+	syncUpdateLegacyTarget(stmt)
 
 	if p.cur.Type != kwSET {
 		return nil, p.syntaxErrorAtCur()
@@ -353,44 +313,198 @@ func (p *Parser) parseSetClause() (*nodes.SetClause, error) {
 	return sc, nil
 }
 
-func (p *Parser) parseDMLSubqueryTarget() error {
+func (p *Parser) parseDMLTarget(mode dmlTargetMode) (nodes.TableExpr, error) {
+	start := p.pos()
+	if p.cur.Type == '(' {
+		return p.parseDMLSubqueryTarget(start)
+	}
+	if p.cur.Type == kwTABLE && p.peekNext().Type == '(' {
+		return p.parseTableCollectionExpr(start)
+	}
+	if !p.isIdentLike() {
+		return nil, nil
+	}
+	target := &nodes.TableRef{Loc: nodes.Loc{Start: start}}
+	var parseErr1151 error
+	target.Name, parseErr1151 = p.parseObjectName()
+	if parseErr1151 != nil {
+		return nil, parseErr1151
+	}
+	if target.Name == nil || target.Name.Name == "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	if mode == dmlTargetUpdate {
+		if parseErr1151 = p.parseDMLTargetAlias(target); parseErr1151 != nil {
+			return nil, parseErr1151
+		}
+	}
+	if p.cur.Type == kwPARTITION || p.cur.Type == kwSUBPARTITION {
+		target.PartitionExt, parseErr1151 = p.parsePartitionExtClause()
+		if parseErr1151 != nil {
+			return nil, parseErr1151
+		}
+	}
+	if p.cur.Type == '@' {
+		p.advance()
+		target.Dblink, parseErr1151 = p.parseIdentifier()
+		if parseErr1151 != nil {
+			return nil, parseErr1151
+		}
+		if target.Dblink == "" {
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	if mode == dmlTargetDelete {
+		if parseErr1151 = p.parseDMLTargetAlias(target); parseErr1151 != nil {
+			return nil, parseErr1151
+		}
+	}
+	target.Loc.End = p.prev.End
+	return target, nil
+}
+
+func (p *Parser) parseDMLTargetAlias(target *nodes.TableRef) error {
+	if p.cur.Type == kwAS {
+		p.advance()
+		alias, err := p.parseAlias()
+		if err != nil {
+			return err
+		}
+		if alias == nil {
+			return p.syntaxErrorAtCur()
+		}
+		target.Alias = alias
+		return nil
+	}
+	if p.isTableAliasCandidate() {
+		alias, err := p.parseAlias()
+		if err != nil {
+			return err
+		}
+		if alias == nil {
+			return p.syntaxErrorAtCur()
+		}
+		target.Alias = alias
+	}
+	return nil
+}
+
+func (p *Parser) parseDMLSubqueryTarget(start int) (*nodes.SubqueryRef, error) {
 	p.advance() // consume '('
 	if p.cur.Type != kwSELECT && p.cur.Type != kwWITH {
-		return p.syntaxErrorAtCur()
+		return nil, p.syntaxErrorAtCur()
 	}
-	parsedSubquery, parseErr1151 := p.parseSelectStmt()
-	if parseErr1151 != nil {
-		return parseErr1151
+	parsedSubquery, parseErr1152 := p.parseSelectStmt()
+	if parseErr1152 != nil {
+		return nil, parseErr1152
 	}
 	if parsedSubquery == nil {
-		return p.syntaxErrorAtCur()
+		return nil, p.syntaxErrorAtCur()
+	}
+	ref := &nodes.SubqueryRef{
+		Subquery: parsedSubquery,
+		Loc:      nodes.Loc{Start: start},
+	}
+	var parseErr1153 error
+	ref.Restriction, parseErr1153 = p.parseDMLSubqueryRestriction()
+	if parseErr1153 != nil {
+		return nil, parseErr1153
 	}
 	if p.cur.Type != ')' {
-		return p.syntaxErrorAtCur()
+		return nil, p.syntaxErrorAtCur()
 	}
 	p.advance()
 	if p.cur.Type == kwAS {
 		p.advance()
-		parsedAlias, parseErr1152 := p.parseAlias()
-		if parseErr1152 != nil {
-			return parseErr1152
+		parsedAlias, parseErr1154 := p.parseAlias()
+		if parseErr1154 != nil {
+			return nil, parseErr1154
 		}
 		if parsedAlias == nil {
-			return p.syntaxErrorAtCur()
+			return nil, p.syntaxErrorAtCur()
 		}
-		return nil
+		ref.Alias = parsedAlias
+		ref.Loc.End = p.prev.End
+		return ref, nil
 	}
 	if p.isTableAliasCandidate() {
-		parsedAlias, parseErr1153 := p.parseAlias()
-		if parseErr1153 != nil {
-			return parseErr1153
+		parsedAlias, parseErr1155 := p.parseAlias()
+		if parseErr1155 != nil {
+			return nil, parseErr1155
 		}
 		if parsedAlias == nil {
-			return p.syntaxErrorAtCur()
+			return nil, p.syntaxErrorAtCur()
 		}
-		return nil
+		ref.Alias = parsedAlias
 	}
-	return nil
+	ref.Loc.End = p.prev.End
+	return ref, nil
+}
+
+func (p *Parser) parseDMLSubqueryRestriction() (*nodes.SubqueryRestrictionClause, error) {
+	if p.cur.Type != kwWITH {
+		return nil, nil
+	}
+	next := p.peekNext()
+	if next.Type != kwREAD && next.Type != kwCHECK {
+		return nil, nil
+	}
+	start := p.pos()
+	p.advance() // consume WITH
+	restriction := &nodes.SubqueryRestrictionClause{Loc: nodes.Loc{Start: start}}
+	switch p.cur.Type {
+	case kwREAD:
+		p.advance()
+		if p.cur.Type != kwONLY {
+			return nil, p.syntaxErrorAtCur()
+		}
+		p.advance()
+		restriction.ReadOnly = true
+	case kwCHECK:
+		p.advance()
+		if p.cur.Type != kwOPTION {
+			return nil, p.syntaxErrorAtCur()
+		}
+		p.advance()
+		restriction.CheckOption = true
+		if p.cur.Type == kwCONSTRAINT {
+			p.advance()
+			constraintName, err := p.parseObjectName()
+			if err != nil {
+				return nil, err
+			}
+			if constraintName == nil || constraintName.Name == "" {
+				return nil, p.syntaxErrorAtCur()
+			}
+			restriction.ConstraintName = constraintName
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	restriction.Loc.End = p.prev.End
+	return restriction, nil
+}
+
+func syncUpdateLegacyTarget(stmt *nodes.UpdateStmt) {
+	target, ok := stmt.Target.(*nodes.TableRef)
+	if !ok || target == nil {
+		return
+	}
+	stmt.Table = target.Name
+	stmt.PartitionExt = target.PartitionExt
+	stmt.Dblink = target.Dblink
+	stmt.Alias = target.Alias
+}
+
+func syncDeleteLegacyTarget(stmt *nodes.DeleteStmt) {
+	target, ok := stmt.Target.(*nodes.TableRef)
+	if !ok || target == nil {
+		return
+	}
+	stmt.Table = target.Name
+	stmt.PartitionExt = target.PartitionExt
+	stmt.Dblink = target.Dblink
+	stmt.Alias = target.Alias
 }
 
 func countSubquerySetArity(sc *nodes.SetClause) (targetCount int, valueCount int, ok bool) {
@@ -480,61 +594,14 @@ func (p *Parser) parseDeleteStmt() (*nodes.DeleteStmt, error) {
 	}
 	var parseErr1143 error
 
-	// Table name or inline view target.
-	if p.cur.Type == '(' {
-		if parseErr1143 = p.parseDMLSubqueryTarget(); parseErr1143 != nil {
-			return nil, parseErr1143
-		}
-	} else {
-		stmt.Table, parseErr1143 = p.parseObjectName()
-		if parseErr1143 !=
-
-			// Partition extension clause
-			nil {
-			return nil, parseErr1143
-		}
+	stmt.Target, parseErr1143 = p.parseDMLTarget(dmlTargetDelete)
+	if parseErr1143 != nil {
+		return nil, parseErr1143
 	}
-
-	if p.cur.Type == kwPARTITION || p.cur.Type == kwSUBPARTITION {
-		var parseErr1144 error
-		stmt.PartitionExt, parseErr1144 = p.parsePartitionExtClause()
-		if parseErr1144 !=
-
-			// @dblink
-			nil {
-			return nil, parseErr1144
-		}
+	if stmt.Target == nil {
+		return nil, p.syntaxErrorAtCur()
 	}
-
-	if p.cur.Type == '@' {
-		p.advance()
-		var parseErr1145 error
-		stmt.Dblink, parseErr1145 = p.parseIdentifier()
-		if parseErr1145 !=
-
-			// Optional alias
-			nil {
-			return nil, parseErr1145
-		}
-	}
-
-	if p.cur.Type == kwAS {
-		p.advance()
-		var parseErr1146 error
-		stmt.Alias, parseErr1146 = p.parseAlias()
-		if parseErr1146 != nil {
-			return nil, parseErr1146
-		}
-	} else if p.isTableAliasCandidate() {
-		var parseErr1147 error
-		stmt.Alias, parseErr1147 = p.parseAlias()
-		if parseErr1147 !=
-
-			// WHERE
-			nil {
-			return nil, parseErr1147
-		}
-	}
+	syncDeleteLegacyTarget(stmt)
 
 	if p.cur.Type == kwWHERE {
 		p.advance()

--- a/oracle/parser/update_delete_test.go
+++ b/oracle/parser/update_delete_test.go
@@ -40,6 +40,54 @@ func TestParseUpdateWithAlias(t *testing.T) {
 	if stmt.Alias == nil || stmt.Alias.Name != "E" {
 		t.Errorf("expected alias E, got %v", stmt.Alias)
 	}
+	target, ok := stmt.Target.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("expected table target, got %T", stmt.Target)
+	}
+	if target.Name == nil || target.Name.Name != "EMPLOYEES" {
+		t.Fatalf("expected target table EMPLOYEES, got %#v", target.Name)
+	}
+	if target.Alias == nil || target.Alias.Name != "E" {
+		t.Fatalf("expected target alias E, got %#v", target.Alias)
+	}
+}
+
+func TestParseUpdateInlineViewTarget(t *testing.T) {
+	result := ParseAndCheck(t, "UPDATE (SELECT a FROM t) v SET a = 1")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.UpdateStmt)
+	target, ok := stmt.Target.(*ast.SubqueryRef)
+	if !ok {
+		t.Fatalf("expected subquery target, got %T", stmt.Target)
+	}
+	if target.Subquery == nil {
+		t.Fatal("expected retained target subquery")
+	}
+	if target.Alias == nil || target.Alias.Name != "V" {
+		t.Fatalf("expected target alias V, got %#v", target.Alias)
+	}
+	if stmt.Table != nil {
+		t.Fatalf("expected legacy Table to remain nil for inline view target, got %#v", stmt.Table)
+	}
+}
+
+func TestParseUpdateInlineViewTargetWithRestriction(t *testing.T) {
+	result := ParseAndCheck(t, "UPDATE (SELECT a FROM t WITH CHECK OPTION CONSTRAINT ck_v) v SET a = 1")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.UpdateStmt)
+	target, ok := stmt.Target.(*ast.SubqueryRef)
+	if !ok {
+		t.Fatalf("expected subquery target, got %T", stmt.Target)
+	}
+	if target.Restriction == nil {
+		t.Fatal("expected retained subquery restriction")
+	}
+	if !target.Restriction.CheckOption {
+		t.Fatalf("expected CHECK OPTION restriction, got %#v", target.Restriction)
+	}
+	if target.Restriction.ConstraintName == nil || target.Restriction.ConstraintName.Name != "CK_V" {
+		t.Fatalf("expected restriction constraint CK_V, got %#v", target.Restriction.ConstraintName)
+	}
 }
 
 // TestParseUpdateMultipleSet tests UPDATE with multiple SET clauses.
@@ -85,6 +133,51 @@ func TestParseDeleteWithAlias(t *testing.T) {
 	stmt := raw.Stmt.(*ast.DeleteStmt)
 	if stmt.Alias == nil || stmt.Alias.Name != "E" {
 		t.Errorf("expected alias E, got %v", stmt.Alias)
+	}
+	target, ok := stmt.Target.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("expected table target, got %T", stmt.Target)
+	}
+	if target.Name == nil || target.Name.Name != "EMPLOYEES" {
+		t.Fatalf("expected target table EMPLOYEES, got %#v", target.Name)
+	}
+	if target.Alias == nil || target.Alias.Name != "E" {
+		t.Fatalf("expected target alias E, got %#v", target.Alias)
+	}
+}
+
+func TestParseDeleteInlineViewTarget(t *testing.T) {
+	result := ParseAndCheck(t, "DELETE FROM (SELECT * FROM t) v WHERE id = 1")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.DeleteStmt)
+	target, ok := stmt.Target.(*ast.SubqueryRef)
+	if !ok {
+		t.Fatalf("expected subquery target, got %T", stmt.Target)
+	}
+	if target.Subquery == nil {
+		t.Fatal("expected retained target subquery")
+	}
+	if target.Alias == nil || target.Alias.Name != "V" {
+		t.Fatalf("expected target alias V, got %#v", target.Alias)
+	}
+	if stmt.Table != nil {
+		t.Fatalf("expected legacy Table to remain nil for inline view target, got %#v", stmt.Table)
+	}
+}
+
+func TestParseDeleteTableCollectionTarget(t *testing.T) {
+	result := ParseAndCheck(t, "DELETE FROM TABLE(items) i WHERE i.id = 1")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.DeleteStmt)
+	target, ok := stmt.Target.(*ast.TableCollectionExpr)
+	if !ok {
+		t.Fatalf("expected table collection target, got %T", stmt.Target)
+	}
+	if target.Expr == nil {
+		t.Fatal("expected retained collection expression")
+	}
+	if target.Alias == nil || target.Alias.Name != "I" {
+		t.Fatalf("expected target alias I, got %#v", target.Alias)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `Target` AST support for Oracle UPDATE/DELETE DML targets, retaining table, inline-view, and TABLE(collection) targets.
- Preserve inline-view subquery restrictions such as `WITH CHECK OPTION CONSTRAINT ...`.
- Accept native Oracle `JSON` column type while preserving JSON keyword identifier regressions.

## Test Plan
- [x] `go test ./oracle/... -count=1`
- [x] `go test ./... -count=1` attempted; Oracle packages passed, but the full run fails in existing TiDB/MySQL container comparison tests and a TiDB catalog timeout unrelated to this Oracle change.