### PR TITLE
fix(oracle): parse boolean postfix checks

### DIFF
--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -481,6 +481,27 @@ func TestParseCreateTableTableConstraints(t *testing.T) {
 	}
 }
 
+func TestParseCreateTableCheckConstraintWithOr(t *testing.T) {
+	sql := `CREATE TABLE orders (
+		order_date DATE,
+		ship_date DATE,
+		CONSTRAINT chk_ship_after_order CHECK (ship_date IS NULL OR ship_date >= order_date)
+	)`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	if ct.Constraints == nil || ct.Constraints.Len() != 1 {
+		t.Fatalf("expected 1 table constraint, got %d", ct.Constraints.Len())
+	}
+	tc := ct.Constraints.Items[0].(*ast.TableConstraint)
+	if tc.Type != ast.CONSTRAINT_CHECK {
+		t.Fatalf("expected CHECK constraint, got %d", tc.Type)
+	}
+	if _, ok := tc.Expr.(*ast.BoolExpr); !ok {
+		t.Fatalf("expected CHECK expression to parse as BoolExpr, got %T", tc.Expr)
+	}
+}
+
 // TestParseCreateTableOrReplace tests CREATE OR REPLACE TABLE (23c).
 func TestParseCreateTableOrReplace(t *testing.T) {
 	sql := `CREATE OR REPLACE TABLE t (id NUMBER)`

--- a/oracle/parser/expr.go
+++ b/oracle/parser/expr.go
@@ -4,6 +4,14 @@ import (
 	nodes "github.com/bytebase/omni/oracle/ast"
 )
 
+func exprLocStart(expr nodes.ExprNode, fallback int) int {
+	loc := nodes.NodeLoc(expr)
+	if loc.Start >= 0 {
+		return loc.Start
+	}
+	return fallback
+}
+
 // Precedence levels for Pratt parsing.
 const (
 	precNone    = 0
@@ -62,6 +70,15 @@ func (p *Parser) parseExprPrec(minPrec int) (nodes.ExprNode, error) {
 	}
 
 	for {
+		if prec, ok := p.postfixInfo(); ok && prec >= minPrec {
+			var err error
+			left, err = p.parsePostfix(left)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
 		prec, op, isBool := p.infixInfo()
 		if prec < minPrec {
 			break
@@ -84,16 +101,6 @@ func (p *Parser) parseExprPrec(minPrec int) (nodes.ExprNode, error) {
 			}
 		}
 	}
-	var parseErr700 error
-
-	left, parseErr700 = p.parsePostfix(left)
-	if parseErr700 !=
-
-		// MULTISET UNION/INTERSECT/EXCEPT
-		nil {
-		return nil, parseErr700
-	}
-
 	if p.cur.Type == kwMULTISET {
 		var parseErr701 error
 		left, parseErr701 = p.parseMultisetOp(left)
@@ -141,6 +148,21 @@ func (p *Parser) infixInfo() (int, string, bool) {
 		return precExpon, "**", false
 	}
 	return precNone, "", false
+}
+
+func (p *Parser) postfixInfo() (int, bool) {
+	switch p.cur.Type {
+	case kwIS:
+		return precIs, true
+	case kwBETWEEN, kwIN, kwLIKE, kwLIKEC, kwLIKE2, kwLIKE4:
+		return precLike, true
+	case kwNOT:
+		switch p.peekNext().Type {
+		case kwBETWEEN, kwIN, kwLIKE, kwLIKEC, kwLIKE2, kwLIKE4:
+			return precLike, true
+		}
+	}
+	return precNone, false
 }
 
 // parseBinaryInfix parses a binary infix expression.
@@ -1659,7 +1681,7 @@ func (p *Parser) parseInExpr(left nodes.ExprNode, not bool) (nodes.ExprNode, err
 //
 //	expr [NOT] LIKE pattern [ ESCAPE escape_char ]
 func (p *Parser) parseLikeExpr(left nodes.ExprNode, not bool, likeType nodes.LikeType) (nodes.ExprNode, error) {
-	start := p.pos()
+	start := exprLocStart(left, p.pos())
 	p.advance() // consume LIKE/LIKEC/LIKE2/LIKE4
 
 	pattern, parseErr744 := p.parseExprPrec(precConcat)

--- a/oracle/parser/expr_test.go
+++ b/oracle/parser/expr_test.go
@@ -336,6 +336,22 @@ func TestParseExprLikeEscape(t *testing.T) {
 	}
 }
 
+func TestParseExprLikeLocCoversLeftOperand(t *testing.T) {
+	input := "email LIKE '%@%.%'"
+	p := newTestParser(input)
+	e, err := p.parseExpr()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := e.(*ast.LikeExpr); !ok {
+		t.Fatalf("expected LikeExpr, got %T", e)
+	}
+	loc := ast.NodeLoc(e)
+	if loc.Start != 0 || loc.End != len(input) {
+		t.Fatalf("LikeExpr Loc = [%d,%d], want [0,%d]", loc.Start, loc.End, len(input))
+	}
+}
+
 // TestParseExprIsNull tests IS NULL and IS NOT NULL.
 func TestParseExprIsNull(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Parse Oracle postfix predicates (`IS`, `IN`, `BETWEEN`, `LIKE`) inside the expression precedence loop so low-precedence `AND`/`OR` can continue after them.
- Fix `LikeExpr` source locations to include the left operand.
- Add regression coverage for `CHECK (... IS NULL OR ...)` and full `LIKE` NodeLoc ranges.

## Test Plan
- [x] go test ./oracle/... -count=1