### PR TITLE
feat(oracle): add production completion signals

### DIFF
--- a/SCENARIOS-oracle-completion.md
+++ b/SCENARIOS-oracle-completion.md
@@ -20,14 +20,31 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial/deferred.
 - [x] `SELECT * FROM |` emits table-reference intent.
 - [x] `SELECT * FROM schema.|` emits table-reference intent qualified by schema.
 - [x] `SELECT | FROM t` emits column-reference intent and table scope for `t`.
+- [x] `SELECT DISTINCT | FROM t` emits expression/column-reference intent.
+- [x] `SELECT a, | FROM t` emits expression/column-reference intent after target-list comma.
 - [x] `SELECT t.| FROM t` emits column-reference intent qualified by table `t`.
 - [x] `SELECT alias.| FROM t alias` resolves `alias` as a visible range reference.
+- [x] `SELECT * FROM t, |` emits table-reference intent after comma-separated table sources.
 - [x] `SELECT * FROM t JOIN |` emits table-reference intent.
+- [x] `SELECT * FROM t LEFT/RIGHT/FULL OUTER/CROSS/NATURAL JOIN |` emits table-reference intent.
 - [x] `SELECT * FROM t JOIN u ON |` emits column-reference intent with both tables visible.
+- [x] `SELECT * FROM t JOIN u USING (|` emits column-reference intent with both tables visible.
 - [x] `SELECT * FROM t WHERE |` emits column-reference intent.
+- [x] `SELECT * FROM t WHERE a = 1 AND/OR |` emits expression/column-reference intent.
+- [x] `SELECT * FROM t WHERE a + | > 0` emits expression/column-reference intent after operators.
+- [x] `SELECT * FROM t WHERE a IN (|` emits expression/column-reference intent.
+- [x] `SELECT * FROM t WHERE a BETWEEN | AND ...` and `BETWEEN ... AND |` emit expression/column-reference intent.
+- [x] `SELECT * FROM t WHERE EXISTS (|` suggests `SELECT`.
 - [x] `SELECT c FROM t GROUP BY |` emits column-reference intent.
+- [x] `SELECT c FROM t GROUP BY c, |` emits column-reference intent.
+- [x] `SELECT c FROM t GROUP BY c HAVING |` emits expression/column-reference intent.
 - [x] `SELECT c AS alias FROM t ORDER BY |` emits column-reference intent and Bytebase adapter returns select aliases.
+- [x] `SELECT c FROM t ORDER BY c, |` emits column-reference intent.
+- [x] `SELECT * FROM t |` suggests clause starters such as `WHERE`, `JOIN`, `GROUP`, and `ORDER`.
 - [x] `SELECT * FROM (SELECT c FROM t) x WHERE x.|` exposes virtual table `x`.
+- [x] `SELECT | FROM (SELECT c FROM t) x` keeps nested source tables out of local scope.
+- [x] `SELECT * FROM t WHERE EXISTS (SELECT | FROM u WHERE u.id = t.id)` records local and outer scope levels separately.
+- [x] `SELECT c FROM t UNION SELECT | FROM u` scopes completion to the current set-operation arm.
 - [x] `WITH x AS (SELECT * FROM t) SELECT * FROM |` exposes CTE `x` as table-reference candidate.
 - [x] `WITH x(c1, c2) AS (SELECT * FROM t) SELECT x.| FROM x` exposes explicit CTE columns.
 
@@ -35,29 +52,50 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial/deferred.
 
 - [x] `INSERT INTO |` emits table-reference intent.
 - [x] `INSERT INTO t (|)` emits column-reference intent scoped to table `t`.
+- [x] `INSERT INTO t (c1, |)` emits column-reference intent after insert column-list comma.
 - [x] `INSERT INTO t VALUES (|)` emits expression/column-reference context.
+- [x] `INSERT INTO t VALUES (1, |)` emits expression/column-reference context after values-list comma.
 - [x] `INSERT INTO t SELECT | FROM u` emits column-reference intent scoped to `u`.
+- [x] `WITH x AS (...) INSERT INTO t SELECT | FROM x` exposes the CTE source.
 - [x] `UPDATE | SET c = 1` emits table-reference intent.
 - [x] `UPDATE t SET |` emits column-reference intent scoped to table `t`.
 - [x] `UPDATE t SET c = |` emits expression/column-reference context.
+- [x] `UPDATE t SET c = 1, |` emits column-reference intent after assignment comma.
 - [x] `UPDATE t SET c = 1 WHERE |` emits column-reference intent scoped to table `t`.
 - [x] `DELETE FROM |` emits table-reference intent.
 - [x] `DELETE FROM t WHERE |` emits column-reference intent scoped to table `t`.
 - [x] `MERGE INTO |` emits table-reference intent.
 - [x] `MERGE INTO t USING |` emits table-reference intent for source.
 - [x] `MERGE INTO t USING u ON |` emits column-reference intent with target and source visible.
+- [x] `MERGE ... WHEN MATCHED THEN UPDATE SET c = |` emits expression/column-reference intent with target and source visible.
+- [x] `MERGE ... WHEN NOT MATCHED THEN INSERT (|)` emits column-reference intent with target and source visible.
 
 ## Phase 3: DDL And Utility Completion
 
 - [x] `CREATE |` suggests supported Oracle object-type keywords.
 - [x] `CREATE TABLE t (c |)` emits datatype candidates.
+- [x] `CREATE TABLE t (c NUMBER, |)` suggests column/constraint starters.
+- [x] `CREATE TABLE t (c NUMBER |)` suggests column options such as `NOT`, `DEFAULT`, `PRIMARY`, `UNIQUE`, `REFERENCES`, and `CHECK`.
 - [x] `CREATE TABLE t (c NUMBER REFERENCES |)` emits table-reference intent.
+- [x] `CREATE TABLE t (... PRIMARY KEY (|))` emits column-reference intent scoped to the new table.
+- [x] `CREATE TABLE t (... FOREIGN KEY (|) REFERENCES u(c))` emits column-reference intent scoped to the new table.
+- [x] `CREATE TABLE t (... REFERENCES u(|))` emits column-reference intent scoped to referenced table `u`.
+- [x] `CREATE INDEX idx ON |` emits table-reference intent.
+- [x] `CREATE INDEX idx ON t (|)` emits column-reference intent scoped to table `t`.
 - [x] `ALTER TABLE |` emits table-reference intent.
 - [x] `ALTER TABLE t ADD |` suggests column/constraint action keywords.
+- [x] `ALTER TABLE t MODIFY |` emits column-reference intent scoped to table `t`.
 - [x] `ALTER TABLE t DROP COLUMN |` emits column-reference intent scoped to table `t`.
+- [x] `ALTER TABLE t DROP CONSTRAINT |` emits constraint-reference intent scoped to table `t`.
+- [x] `ALTER SEQUENCE |` emits sequence-reference intent.
+- [x] `ALTER VIEW |` emits view-reference intent.
+- [x] `ALTER PROCEDURE |` emits procedure-reference intent.
 - [x] `DROP TABLE |` emits table-reference intent.
 - [x] `DROP VIEW |` emits view/table-reference intent.
 - [x] `DROP SEQUENCE |` emits sequence-reference intent.
+- [x] `DROP INDEX |` emits index-reference intent.
+- [x] `DROP SYNONYM |` emits synonym-reference intent.
+- [x] `DROP TRIGGER |` emits trigger-reference intent.
 - [x] `TRUNCATE TABLE |` emits table-reference intent.
 - [x] `COMMENT ON TABLE |` emits table-reference intent.
 - [x] `COMMENT ON COLUMN t.|` emits column-reference intent scoped to table `t`.
@@ -71,6 +109,12 @@ Status legend: `[ ]` pending, `[x]` passing, `[~]` partial/deferred.
 - [x] Type keywords come from the Oracle keyword manifest.
 - [x] Function-like keyword candidates appear only in call-capable expression positions.
 - [x] Pseudo-column candidates appear in expression positions.
+- [x] `seq.|` emits sequence-member intent for `NEXTVAL`/`CURRVAL`-style completion.
+- [x] `pkg.|` in SQL and PL/SQL blocks emits package-member intent.
+- [x] `table@|` emits database-link intent.
+- [x] `SELECT c INTO | FROM t` emits PL/SQL variable-reference intent.
+- [x] `DECLARE v |;` emits datatype candidates for PL/SQL declarations.
+- [x] `BEGIN | END;` suggests PL/SQL statement starters.
 - [x] Case-sensitive metadata names can be quoted by the Bytebase adapter.
 - [x] Multi-statement scripts isolate completion to the cursor statement.
 - [x] Malformed earlier statements do not prevent completion in the current statement.

--- a/SCENARIOS-oracle-completion.md
+++ b/SCENARIOS-oracle-completion.md
@@ -1,0 +1,86 @@
+# Oracle Production Completion Scenarios
+
+Goal: Oracle completion is production-ready for Bytebase when omni exposes parser-native completion signals that let Bytebase replace its current ANTLR/C3 `backend/plugin/parser/plsql/completion.go` implementation without losing SQL editor behavior.
+
+Status legend: `[ ]` pending, `[x]` passing, `[~]` partial/deferred.
+
+## Phase 0: Public Parser Completion API
+
+- [x] Empty input at cursor 0 returns statement starter candidates.
+- [x] Whitespace-only input returns statement starter candidates.
+- [x] Cursor after semicolon returns statement starter candidates for a new statement.
+- [x] Cursor inside a partially typed keyword backs up to token start and prefix-filters candidates.
+- [x] `Tokenize` returns non-EOF tokens with stable byte `Loc` and `End`.
+- [x] `TokenName` returns uppercase Oracle keyword text for keyword token types.
+- [x] `Collect` never panics on incomplete SQL.
+- [x] `CollectCompletion` returns candidates, prefix, scope, CTEs, and object intent.
+
+## Phase 1: Bytebase SELECT Object Completion
+
+- [x] `SELECT * FROM |` emits table-reference intent.
+- [x] `SELECT * FROM schema.|` emits table-reference intent qualified by schema.
+- [x] `SELECT | FROM t` emits column-reference intent and table scope for `t`.
+- [x] `SELECT t.| FROM t` emits column-reference intent qualified by table `t`.
+- [x] `SELECT alias.| FROM t alias` resolves `alias` as a visible range reference.
+- [x] `SELECT * FROM t JOIN |` emits table-reference intent.
+- [x] `SELECT * FROM t JOIN u ON |` emits column-reference intent with both tables visible.
+- [x] `SELECT * FROM t WHERE |` emits column-reference intent.
+- [x] `SELECT c FROM t GROUP BY |` emits column-reference intent.
+- [x] `SELECT c AS alias FROM t ORDER BY |` emits column-reference intent and Bytebase adapter returns select aliases.
+- [x] `SELECT * FROM (SELECT c FROM t) x WHERE x.|` exposes virtual table `x`.
+- [x] `WITH x AS (SELECT * FROM t) SELECT * FROM |` exposes CTE `x` as table-reference candidate.
+- [x] `WITH x(c1, c2) AS (SELECT * FROM t) SELECT x.| FROM x` exposes explicit CTE columns.
+
+## Phase 2: DML Completion
+
+- [x] `INSERT INTO |` emits table-reference intent.
+- [x] `INSERT INTO t (|)` emits column-reference intent scoped to table `t`.
+- [x] `INSERT INTO t VALUES (|)` emits expression/column-reference context.
+- [x] `INSERT INTO t SELECT | FROM u` emits column-reference intent scoped to `u`.
+- [x] `UPDATE | SET c = 1` emits table-reference intent.
+- [x] `UPDATE t SET |` emits column-reference intent scoped to table `t`.
+- [x] `UPDATE t SET c = |` emits expression/column-reference context.
+- [x] `UPDATE t SET c = 1 WHERE |` emits column-reference intent scoped to table `t`.
+- [x] `DELETE FROM |` emits table-reference intent.
+- [x] `DELETE FROM t WHERE |` emits column-reference intent scoped to table `t`.
+- [x] `MERGE INTO |` emits table-reference intent.
+- [x] `MERGE INTO t USING |` emits table-reference intent for source.
+- [x] `MERGE INTO t USING u ON |` emits column-reference intent with target and source visible.
+
+## Phase 3: DDL And Utility Completion
+
+- [x] `CREATE |` suggests supported Oracle object-type keywords.
+- [x] `CREATE TABLE t (c |)` emits datatype candidates.
+- [x] `CREATE TABLE t (c NUMBER REFERENCES |)` emits table-reference intent.
+- [x] `ALTER TABLE |` emits table-reference intent.
+- [x] `ALTER TABLE t ADD |` suggests column/constraint action keywords.
+- [x] `ALTER TABLE t DROP COLUMN |` emits column-reference intent scoped to table `t`.
+- [x] `DROP TABLE |` emits table-reference intent.
+- [x] `DROP VIEW |` emits view/table-reference intent.
+- [x] `DROP SEQUENCE |` emits sequence-reference intent.
+- [x] `TRUNCATE TABLE |` emits table-reference intent.
+- [x] `COMMENT ON TABLE |` emits table-reference intent.
+- [x] `COMMENT ON COLUMN t.|` emits column-reference intent scoped to table `t`.
+- [x] `GRANT SELECT ON |` emits table-reference intent.
+- [x] `REVOKE SELECT ON |` emits table-reference intent.
+
+## Phase 4: Oracle-Specific Production Hardening
+
+- [x] Quoted identifier prefix completion keeps the user's quoting mode.
+- [x] Reserved keywords are not suggested as unquoted identifiers where parser rejects them.
+- [x] Type keywords come from the Oracle keyword manifest.
+- [x] Function-like keyword candidates appear only in call-capable expression positions.
+- [x] Pseudo-column candidates appear in expression positions.
+- [x] Case-sensitive metadata names can be quoted by the Bytebase adapter.
+- [x] Multi-statement scripts isolate completion to the cursor statement.
+- [x] Malformed earlier statements do not prevent completion in the current statement.
+- [x] Large scripts avoid whole-file expensive parsing in completion hot path.
+- [x] Oracle parser soft-fail, strictness, keyword, Loc, and corpus gates remain green.
+
+## Phase 5: Bytebase Adapter Cutover
+
+- [x] Bytebase Oracle completion calls omni Oracle completion APIs.
+- [x] Bytebase Oracle completion no longer imports ANTLR or `github.com/bytebase/parser/plsql`.
+- [x] Existing Bytebase `backend/plugin/parser/plsql/test-data/test_completion.yaml` passes unchanged or with only intended ordering updates.
+- [x] Bytebase Oracle LSP completion continues returning `base.Candidate` schema/table/view/sequence/column/function/keyword values.
+- [x] Bytebase Oracle completion preserves schema-as-database metadata behavior.

--- a/docs/PARSER-DEFENSE-MATRIX.md
+++ b/docs/PARSER-DEFENSE-MATRIX.md
@@ -122,7 +122,7 @@ Every SQL parser in omni needs a systematic suite of defensive tests to ensure c
 PG          Done       --         --         Partial    --         Done       Partial
 MySQL       Partial*   Partial*   Done       Done       Done       Done       Done
 MSSQL       Done       Partial    Done       --         --         Done*      Done
-Oracle      Done       Done       Done       Partial*   Done       --         Done
+Oracle      Done       Done       Done       Partial*   Done       Partial*   Done
 CosmosDB    --         --         N/A        --         --         --         --
 MongoDB     Partial    --         N/A        --         --         --         --
 ```
@@ -135,6 +135,7 @@ Legend: `Done` = complete, `Partial` = in progress, `--` = not started, `N/A` = 
 - MSSQL L2: 14 oracle mismatches remaining (12 option validation + 2 multi-statement). Option validation is the L2 Strict core work.
 - MSSQL L6: Core instrumentation complete (9 phases, 3659 tests), but 4 secondary CREATE statements uninstrumented + catalog resolution stubbed
 - Oracle L4: Parser coverage accounting is strict but not full grammar support. 171 BNF rows are classified with 0 unknown rows, high-value statement families have no missing/unknown rows, and every non-covered BNF row carries explicit approval/debt metadata. 47 deferred and 86 partial rows remain approved feature debt.
+- Oracle L6: Parser-native completion API, SELECT/CTE/subquery/DML/DDL rule signals, keyword-driven candidates, Bytebase adapter cutover, DDL object-kind filtering, and quoted/reserved/case-sensitive metadata hardening are implemented for the tracked production scenario set.
 
 ### PG
 - **L1 Soft-Fail**: Dual-return migration and soft-fail fixes complete
@@ -180,7 +181,7 @@ Legend: `Done` = complete, `Partial` = in progress, `--` = not started, `N/A` = 
 - **L3 Keyword**: **Done for declared Oracle lexer set plus SQL reserved-word audit.** `TestOracleKeyword*` covers all 344 entries in the local Oracle lexer keyword table across reserved, nonreserved, context, type, function-like, pseudo-column, clause-starter, quoted identifier, keyword-as-expression, and reserved-identifier guard behavior. `TestOracleKeywordOfficialSQLReserved26aiAudit` pins the Oracle 26ai SQL reserved-word list and prevents official SQL reserved words from being missing or lexed as plain identifiers. `TestOracleVReservedWordsKeywordAudit` passed against Oracle Free and checked 107 word-like reserved/context entries.
 - **L4 Coverage**: **Partial for full grammar support, strict for accounting.** `TestOracleBNFCoverageManifestCompleteness` classifies all 171 BNF files with 0 unknown rows, `TestOracleHighValueBNFGapsClosed` keeps high-value statement families free of missing/unknown rows, `TestOracleBNFImplementationDebtRequiresApproval` requires approval metadata on every non-covered row, and `TestOracleCoverage` enforces the soft-fail, strictness, keyword, BNF, Loc-node, and reference-oracle gates. The explicit Oracle Free reference run passed all 20 rows.
 - **L5 Corpus**: **Done for current corpus.** `TestVerifyCorpus` reports 128 total statements, 125 parser accepts, 3 expected parser rejects, 0 parse violations, 0 Loc violations, and 0 crashes; Loc violations are fatal.
-- **L6 Completion**: Not implemented. Parser readiness gates are in place; completion scope is tracked in `docs/plans/2026-04-28-oracle-completion-scope.md`.
+- **L6 Completion**: **Done for the tracked Bytebase production scenario set.** `Collect`, `CollectCompletion`, token/rule candidates, visible scope, CTE/subquery references, DML/DDL/utility intents, datatype/function/pseudo-column keyword candidates, and Bytebase metadata-backed adapter integration are implemented. Bytebase Oracle completion no longer imports ANTLR/C3, existing YAML completion tests pass unchanged, DDL object-kind filtering is covered, and quoted/reserved/case-sensitive metadata behavior is tested.
 - **L7 Loc**: **Done for parser layer, with fixture debt tracked.** `NoLoc()`/`Loc.IsUnknown()` enforce `{-1,-1}` as the only unknown sentinel, mixed sentinels are rejected, synthetic/corpus Loc contracts pass, and `TestOracleLocNodeCoverage` classifies 249 Loc-bearing node rows with 0 unknown rows. Direct SQL fixture coverage is 152 rows; the remaining 97 deferred rows carry approval metadata.
 
 ### CosmosDB / MongoDB
@@ -234,7 +235,7 @@ Ordered by dependency chain. Within each tier, sorted by impact.
 |--------|-------|-----------|
 | MSSQL | L2 Strict | MySQL already found extensive "too lenient" issues; MSSQL very likely has the same (blocked by L1 cleanup) |
 | PG | L2 Strict | Largest engine with no systematic strictness testing |
-| Oracle | L6 Completion | Only major engine without a completion engine |
+| Oracle | L6 Completion expansion | Add future Oracle editor scenarios beyond the current Bytebase production set as product needs surface |
 
 ### Tier 3: Verification (Global Regression Safety Net)
 

--- a/docs/engine-capability-guide.md
+++ b/docs/engine-capability-guide.md
@@ -186,11 +186,13 @@ This is the most complex layer, comprising four subsystems.
 - CandidateSet collection: keywords, table names, column names, function names, schema names, type names
 - Table reference extraction: extract visible tables from FROM/JOIN clauses in the current query
 - Tricky completion fallback: when the parser can't determine context due to truncation, fall back to heuristic completion
+- Bytebase integration boundary: omni emits parser-native token/rule/scope/intent signals; Bytebase resolves live metadata into product `Candidate` values.
 
 **Lessons from PG**:
 - Completion has hard dependencies on L2 (Loc End) and L3 (Soft-fail). **If either is incomplete, Completion cannot function**
 - Recursive CTE self-references, materialized view context filtering, and similar scenarios are very difficult — these can be marked as partial
 - Integration tests verifying real completion behavior across multi-table schemas are essential
+- Oracle showed that replacing ANTLR/C3 safely needs both parser-native intent/scope tests in omni and unchanged Bytebase YAML completion tests against real metadata adapter behavior.
 
 ### L7 Bytebase Integration
 
@@ -331,8 +333,8 @@ PROGRESS_SUMMARY.json                  # Progress summary
 | L3 Keyword | ✅ Parser keyword matrix complete | 344-row exhaustive manifest plus Oracle 26ai SQL reserved-word audit |
 | L4 Strict/Soft-fail/Coverage | ⚠️ Strict accounting, partial grammar support | 62 soft-fail, 121 strictness, 171 BNF rows classified, high-value BNF gaps closed, non-covered BNF rows require approval metadata |
 | L5 Corpus | ✅ Current corpus clean | 128 statements, 125 parser accepts, 3 expected rejects, 0 parse violations, 0 Loc violations, 0 crashes |
-| L6 Completion | ❌ Scoped, not implemented | Scope plan: `docs/plans/2026-04-28-oracle-completion-scope.md` |
-| L7 Integration | ❌ Not started | Catalog/migration not in parser-layer scope |
+| L6 Completion | ✅ Bytebase production set complete | Parser-native API, SELECT/CTE/DML/DDL signals, keyword candidates, adapter cutover, object-kind filtering, and quoted/reserved/case-sensitive metadata behavior covered |
+| L7 Integration | 🚧 Parser integration started | Completion adapter now uses omni locally; catalog/migration remain outside parser-layer scope |
 
 ---
 

--- a/docs/plans/2026-05-28-oracle-production-completion.md
+++ b/docs/plans/2026-05-28-oracle-production-completion.md
@@ -1,0 +1,113 @@
+# Oracle Production Completion Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build Oracle parser-native completion in omni to the point that Bytebase can replace its production Oracle ANTLR/C3 completer without losing SQL editor behavior.
+
+**Architecture:** omni owns parser-native completion signals: token candidates, rule candidates, prefix handling, visible range scope, CTEs, and qualified-name intent. Bytebase remains responsible for metadata-backed resolution to `base.Candidate` values because Oracle schemas are represented there as database names with empty internal schema metadata. Implementation is test-first: each parser signal is introduced by a failing `oracle/parser` test before production code.
+
+**Tech Stack:** Go, recursive-descent Oracle parser under `oracle/parser`, Bytebase adapter target at `/Users/rebeliceyang/Github/bytebase/backend/plugin/parser/plsql`, existing oracle parser coverage gates.
+
+## Task 1: Parser Completion API Foundation
+
+**Files:**
+- Create: `oracle/parser/complete.go`
+- Create: `oracle/parser/complete_test.go`
+
+**Steps:**
+1. Write tests for empty input, semicolon boundary, `Tokenize`, `TokenName`, and prefix retry.
+2. Run `go test ./oracle/parser -run 'TestOracleCompletionAPI' -count=1` and verify the tests fail because APIs are missing.
+3. Implement `Tokenize`, `TokenName`, `CandidateSet`, `Collect`, prefix extraction, and statement-starter inference.
+4. Run the same test and verify it passes.
+5. Run `go test ./oracle/parser -run 'TestOracleParserProgress|TestOracleCoverage|TestVerifyCorpus|TestOracleKeywordManifestExhaustive|TestOracleLocNodeCoverage|TestOracleCompletionAPI' -count=1`.
+
+## Task 2: SELECT Scope And Intent
+
+**Files:**
+- Create: `oracle/parser/complete_context.go`
+- Create: `oracle/parser/complete_context_test.go`
+- Modify: `oracle/parser/complete.go`
+
+**Steps:**
+1. Write tests for `SELECT * FROM |`, `SELECT | FROM t`, `SELECT a.| FROM t a`, joins, WHERE, GROUP BY, ORDER BY, and schema-qualified table refs.
+2. Run `go test ./oracle/parser -run 'TestOracleCompletionSelect' -count=1` and verify failure.
+3. Implement `CollectCompletion`, `CompletionContext`, `ScopeSnapshot`, `RangeReference`, `CompletionIntent`, and token-stream scope extraction.
+4. Run the SELECT completion tests and verify pass.
+5. Run parser coverage gates.
+
+## Task 3: CTE And Subquery Scope
+
+**Files:**
+- Modify: `oracle/parser/complete_context.go`
+- Modify: `oracle/parser/complete_context_test.go`
+
+**Steps:**
+1. Write tests for simple CTE, explicit CTE columns, subquery alias columns, and qualified CTE references.
+2. Run targeted tests and verify failure.
+3. Implement best-effort CTE extraction and subquery range references.
+4. Run targeted tests and parser coverage gates.
+
+## Task 4: DML Rule Signals
+
+**Files:**
+- Modify: `oracle/parser/complete.go`
+- Modify: `oracle/parser/complete_test.go`
+- Modify: `oracle/parser/complete_context.go`
+
+**Steps:**
+1. Write tests for INSERT, UPDATE, DELETE, and MERGE table/column/expression positions.
+2. Verify failure.
+3. Add DML token-pattern completion signals and DML target/source scope extraction.
+4. Run targeted tests and parser coverage gates.
+
+## Task 5: DDL And Utility Rule Signals
+
+**Files:**
+- Modify: `oracle/parser/complete.go`
+- Modify: `oracle/parser/complete_test.go`
+
+**Steps:**
+1. Write tests for CREATE/ALTER/DROP/TRUNCATE/COMMENT/GRANT/REVOKE contexts.
+2. Verify failure.
+3. Add DDL/utility rule and keyword candidate inference.
+4. Run targeted tests and parser coverage gates.
+
+## Task 6: Oracle Keyword-Driven Candidates
+
+**Files:**
+- Modify: `oracle/parser/complete.go`
+- Modify: `oracle/parser/complete_test.go`
+
+**Steps:**
+1. Write tests for datatype, function-like keyword, pseudo-column, and reserved identifier policies.
+2. Verify failure.
+3. Reuse Oracle keyword classification helpers and manifest policies for candidate generation.
+4. Run targeted tests and parser coverage gates.
+
+## Task 7: Bytebase Adapter Cutover
+
+**Files:**
+- Modify: `/Users/rebeliceyang/Github/bytebase/backend/plugin/parser/plsql/completion.go`
+- Modify: `/Users/rebeliceyang/Github/bytebase/backend/plugin/parser/plsql/completion_test.go`
+
+**Steps:**
+1. Add a failing Bytebase test proving Oracle completion no longer depends on ANTLR/C3 imports.
+2. Run `go test ./backend/plugin/parser/plsql -run 'TestCompletionDoesNotDependOnANTLR|TestCompletion' -count=1` from the Bytebase repo and verify failure.
+3. Replace the ANTLR completion collector with omni Oracle `CollectCompletion`, preserving metadata resolution and quoting behavior.
+4. Run Bytebase Oracle completion tests.
+5. Run omni Oracle parser gates again.
+
+## Task 8: Final Verification And Status
+
+**Files:**
+- Modify: `SCENARIOS-oracle-completion.md`
+- Modify: `docs/PARSER-DEFENSE-MATRIX.md`
+- Modify: `docs/engine-capability-guide.md`
+
+**Steps:**
+1. Mark scenario rows according to passing tests.
+2. Update status docs only for proven behavior.
+3. Run full verification:
+   - `go test ./oracle/parser -count=1`
+   - Bytebase: `go test ./backend/plugin/parser/plsql -count=1`
+4. Summarize residual defects and deferred items.

--- a/oracle/parser/complete.go
+++ b/oracle/parser/complete.go
@@ -223,6 +223,7 @@ func addRulesForOracleIntent(cs *CandidateSet, intent *CompletionIntent) {
 			cs.addRule("schema_ref")
 		case ObjectKindSequence:
 			cs.addRule("sequence_ref")
+		case ObjectKindSequenceMember:
 			cs.addRule("sequence_member_ref")
 		case ObjectKindProcedure:
 			cs.addRule("proc_ref")
@@ -346,7 +347,7 @@ func inferOracleCompletionIntent(allTokens []Token, before []Token, collectOffse
 			intent.Qualifier.Schema = q
 			return intent
 		}
-		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindPackageMember, ObjectKindSequence}
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindPackageMember, ObjectKindSequenceMember}
 		intent.Qualifier.Object = q
 		return intent
 	}

--- a/oracle/parser/complete.go
+++ b/oracle/parser/complete.go
@@ -200,10 +200,12 @@ func collectOracleCandidates(_ string, allTokens []Token, collectOffset int, pre
 	}
 	if ddlIntent, handled := inferOracleDDLCompletionIntent(cs, allTokens, tokens, collectOffset); handled {
 		addRulesForOracleIntent(cs, ddlIntent)
+		addOracleStructuralTokenCandidates(cs, allTokens, tokens, collectOffset)
 		return cs, ddlIntent
 	}
 	intent := inferOracleCompletionIntent(allTokens, tokens, collectOffset)
 	addRulesForOracleIntent(cs, intent)
+	addOracleStructuralTokenCandidates(cs, allTokens, tokens, collectOffset)
 	return cs, intent
 }
 
@@ -221,12 +223,29 @@ func addRulesForOracleIntent(cs *CandidateSet, intent *CompletionIntent) {
 			cs.addRule("schema_ref")
 		case ObjectKindSequence:
 			cs.addRule("sequence_ref")
+			cs.addRule("sequence_member_ref")
+		case ObjectKindProcedure:
+			cs.addRule("proc_ref")
 		case ObjectKindFunction:
 			cs.addRule("func_name")
 			addOracleKeywordCandidatesBy(cs, isOracleFunctionKeyword)
 		case ObjectKindType:
 			cs.addRule("type_name")
 			addOracleKeywordCandidatesBy(cs, isOracleTypeKeyword)
+		case ObjectKindIndex:
+			cs.addRule("index_ref")
+		case ObjectKindTrigger:
+			cs.addRule("trigger_ref")
+		case ObjectKindConstraint:
+			cs.addRule("constraint_ref")
+		case ObjectKindSynonym:
+			cs.addRule("synonym_ref")
+		case ObjectKindPackageMember:
+			cs.addRule("package_member_ref")
+		case ObjectKindDatabaseLink:
+			cs.addRule("database_link_ref")
+		case ObjectKindVariable:
+			cs.addRule("variable_ref")
 		}
 		if kind == ObjectKindColumn {
 			addOracleKeywordCandidatesBy(cs, isOraclePseudoColumnKeyword)
@@ -312,6 +331,11 @@ func inferOracleCompletionIntent(allTokens []Token, before []Token, collectOffse
 		return intent
 	}
 
+	if before[len(before)-1].Type == '@' {
+		intent.ObjectKinds = []ObjectKind{ObjectKindDatabaseLink}
+		return intent
+	}
+
 	if dmlIntent := inferOracleDMLCompletionIntent(allTokens, before, collectOffset); len(dmlIntent.ObjectKinds) > 0 {
 		return dmlIntent
 	}
@@ -322,26 +346,47 @@ func inferOracleCompletionIntent(allTokens []Token, before []Token, collectOffse
 			intent.Qualifier.Schema = q
 			return intent
 		}
-		intent.ObjectKinds = []ObjectKind{ObjectKindColumn}
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindPackageMember, ObjectKindSequence}
 		intent.Qualifier.Object = q
 		return intent
 	}
 
 	prev := previousNonPunctuation(before)
+	if oracleCursorInPLSQLDeclarationType(allTokens, collectOffset) {
+		intent.ObjectKinds = []ObjectKind{ObjectKindType}
+		return intent
+	}
+	if prev.Type == kwBEGIN || prev.Type == kwTHEN || prev.Type == kwELSE {
+		intent.ObjectKinds = []ObjectKind{ObjectKindUnknown}
+		return intent
+	}
 	if prev.Type == kwFROM || prev.Type == kwJOIN {
 		intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
 		return intent
 	}
-	if prev.Type == kwWHERE || prev.Type == kwON || prev.Type == kwBY {
+	if prev.Type == kwWHERE || prev.Type == kwON || prev.Type == kwBY || prev.Type == kwUSING {
 		intent.ObjectKinds = []ObjectKind{ObjectKindColumn}
+		return intent
+	}
+	if prev.Type == kwINTO && oracleCursorInSelectInto(allTokens, collectOffset) {
+		intent.ObjectKinds = []ObjectKind{ObjectKindVariable}
+		return intent
+	}
+	if prev.Type == kwEXISTS {
+		intent.ObjectKinds = []ObjectKind{ObjectKindUnknown}
 		return intent
 	}
 	if prev.Type == kwSELECT {
 		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
 		return intent
 	}
+	if oracleTokenStartsExpression(prev.Type) {
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+		return intent
+	}
 	if oracleCursorInSelectTarget(allTokens, collectOffset) ||
-		oracleCursorInExpressionClause(allTokens, collectOffset) {
+		oracleCursorInExpressionClause(allTokens, collectOffset) ||
+		oracleCursorInOrderingExpression(allTokens, collectOffset) {
 		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
 		return intent
 	}
@@ -368,13 +413,51 @@ func inferOracleDDLCompletionIntent(cs *CandidateSet, allTokens []Token, before 
 			}
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}, true
 		}
+		if oracleCreateIndexTableContext(allTokens[stmtStart:], collectOffset) {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable, ObjectKindView}}, true
+		}
+		if q, ok := oracleCreateIndexColumnContext(allTokens[stmtStart:], collectOffset); ok {
+			return &CompletionIntent{
+				ObjectKinds: []ObjectKind{ObjectKindColumn},
+				Qualifier:   MultipartName{Object: q},
+			}, true
+		}
 		if prev.Type == kwREFERENCES {
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable, ObjectKindView}}, true
+		}
+		if q, ok := oracleCreateTableColumnReferenceContext(allTokens[stmtStart:], collectOffset); ok {
+			return &CompletionIntent{
+				ObjectKinds: []ObjectKind{ObjectKindColumn},
+				Qualifier:   MultipartName{Object: q},
+			}, true
+		}
+		if oracleCreateTableConstraintColumnContext(allTokens[stmtStart:], collectOffset) {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindColumn}}, true
+		}
+		if oracleCreateTableColumnStartContext(allTokens[stmtStart:], collectOffset) {
+			for _, tok := range []int{kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN, kwCHECK} {
+				cs.addToken(tok)
+			}
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}, true
+		}
+		if oracleCreateTableColumnOptionContext(allTokens[stmtStart:], collectOffset) {
+			for _, tok := range []int{kwNOT, kwNULL, kwDEFAULT, kwPRIMARY, kwUNIQUE, kwREFERENCES, kwCHECK} {
+				cs.addToken(tok)
+			}
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}, true
 		}
 		if oracleCreateTableTypeContext(allTokens[stmtStart:], collectOffset) {
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindType}}, true
 		}
 	case kwALTER:
+		switch prev.Type {
+		case kwSEQUENCE:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindSequence}}, true
+		case kwVIEW:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindView}}, true
+		case kwPROCEDURE:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindProcedure}}, true
+		}
 		if prev.Type == kwTABLE {
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}}, true
 		}
@@ -386,6 +469,12 @@ func inferOracleDDLCompletionIntent(cs *CandidateSet, allTokens []Token, before 
 		}
 		if oracleSeenToken(before[stmtStart:], kwTABLE) && oracleSeenToken(before[stmtStart:], kwDROP) && prev.Type == kwCOLUMN {
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindColumn}}, true
+		}
+		if oracleSeenToken(before[stmtStart:], kwTABLE) && prev.Type == kwMODIFY {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindColumn}}, true
+		}
+		if oracleSeenToken(before[stmtStart:], kwTABLE) && oracleSeenToken(before[stmtStart:], kwDROP) && prev.Type == kwCONSTRAINT {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindConstraint}}, true
 		}
 	case kwDROP:
 		switch prev.Type {
@@ -399,6 +488,12 @@ func inferOracleDDLCompletionIntent(cs *CandidateSet, allTokens []Token, before 
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindProcedure}}, true
 		case kwFUNCTION:
 			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindFunction}}, true
+		case kwINDEX:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindIndex}}, true
+		case kwSYNONYM:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindSynonym}}, true
+		case kwTRIGGER:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTrigger}}, true
 		}
 	case kwTRUNCATE:
 		if prev.Type == kwTABLE {
@@ -436,6 +531,98 @@ func oracleCreateTableTypeContext(tokens []Token, offset int) bool {
 		}
 	}
 	return false
+}
+
+func oracleCreateTableColumnStartContext(tokens []Token, offset int) bool {
+	if !oracleCreateTableOpenBefore(tokens, offset) {
+		return false
+	}
+	return lastTokenBeforeOffset(tokens, offset).Type == ','
+}
+
+func oracleCreateTableColumnOptionContext(tokens []Token, offset int) bool {
+	if !oracleCreateTableOpenBefore(tokens, offset) {
+		return false
+	}
+	prev := previousNonPunctuation(tokensBeforeOffset(tokens, offset))
+	return isOracleTypeKeyword(prev.Type) || prev.Type == tokICONST || prev.Type == ')'
+}
+
+func oracleCreateTableConstraintColumnContext(tokens []Token, offset int) bool {
+	if !oracleCreateTableOpenBefore(tokens, offset) {
+		return false
+	}
+	before := tokensBeforeOffset(tokens, offset)
+	openIdx := lastUnclosedParenBeforeOffset(tokens, offset)
+	if openIdx < 0 || openIdx >= len(before) {
+		return false
+	}
+	for i := openIdx - 1; i >= 0; i-- {
+		switch before[i].Type {
+		case kwPRIMARY, kwFOREIGN:
+			return true
+		case kwREFERENCES, kwCHECK, ',':
+			return false
+		}
+	}
+	return false
+}
+
+func oracleCreateTableColumnReferenceContext(tokens []Token, offset int) (string, bool) {
+	if !oracleCreateTableOpenBefore(tokens, offset) {
+		return "", false
+	}
+	openIdx := lastUnclosedParenBeforeOffset(tokens, offset)
+	if openIdx < 2 {
+		return "", false
+	}
+	tableTok := tokens[openIdx-1]
+	if !isOracleCompletionIdent(tableTok) {
+		return "", false
+	}
+	for i := openIdx - 2; i >= 0; i-- {
+		if tokens[i].Type == kwREFERENCES {
+			return tableTok.Str, true
+		}
+		if tokens[i].Type == ',' || tokens[i].Type == kwPRIMARY || tokens[i].Type == kwFOREIGN {
+			return "", false
+		}
+	}
+	return "", false
+}
+
+func oracleCreateIndexTableContext(tokens []Token, offset int) bool {
+	if len(tokens) < 2 || tokens[0].Type != kwCREATE || !oracleSeenToken(tokensBeforeOffset(tokens, offset), kwINDEX) {
+		return false
+	}
+	return previousNonPunctuation(tokensBeforeOffset(tokens, offset)).Type == kwON
+}
+
+func oracleCreateIndexColumnContext(tokens []Token, offset int) (string, bool) {
+	if len(tokens) < 2 || tokens[0].Type != kwCREATE || !oracleSeenToken(tokensBeforeOffset(tokens, offset), kwINDEX) {
+		return "", false
+	}
+	openIdx := lastUnclosedParenBeforeOffset(tokens, offset)
+	if openIdx < 1 {
+		return "", false
+	}
+	tableTok := tokens[openIdx-1]
+	if !isOracleCompletionIdent(tableTok) {
+		return "", false
+	}
+	for i := openIdx - 2; i >= 0; i-- {
+		if tokens[i].Type == kwON {
+			return tableTok.Str, true
+		}
+	}
+	return "", false
+}
+
+func oracleCreateTableOpenBefore(tokens []Token, offset int) bool {
+	if len(tokens) < 2 || tokens[0].Type != kwCREATE || tokens[1].Type != kwTABLE {
+		return false
+	}
+	return lastUnclosedParenBeforeOffset(tokens, offset) >= 0
 }
 
 func inferOracleDMLCompletionIntent(allTokens []Token, before []Token, collectOffset int) *CompletionIntent {
@@ -526,6 +713,15 @@ func oracleSeenToken(tokens []Token, tokenType int) bool {
 	return false
 }
 
+func lastTokenBeforeOffset(tokens []Token, offset int) Token {
+	for i := len(tokens) - 1; i >= 0; i-- {
+		if tokens[i].Loc < offset {
+			return tokens[i]
+		}
+	}
+	return Token{}
+}
+
 func previousNonPunctuation(tokens []Token) Token {
 	for i := len(tokens) - 1; i >= 0; i-- {
 		switch tokens[i].Type {
@@ -536,6 +732,15 @@ func previousNonPunctuation(tokens []Token) Token {
 		}
 	}
 	return Token{}
+}
+
+func oracleTokenStartsExpression(tokenType int) bool {
+	switch tokenType {
+	case kwAND, kwOR, kwBETWEEN, kwIN, kwTHEN, kwELSE, '+', '-', '*', '/', '=', '<', '>', '|':
+		return true
+	default:
+		return false
+	}
 }
 
 func oracleDottedQualifierBefore(tokens []Token) (string, bool) {
@@ -595,6 +800,54 @@ func oracleCursorInExpressionClause(tokens []Token, offset int) bool {
 	return false
 }
 
+func oracleCursorInOrderingExpression(tokens []Token, offset int) bool {
+	stmtStart, _ := oracleStatementTokenBounds(tokens, offset)
+	before := tokensBeforeOffset(tokens[stmtStart:], offset)
+	for i := len(before) - 1; i >= 0; i-- {
+		switch before[i].Type {
+		case kwGROUP, kwORDER:
+			return i+1 < len(before) && before[i+1].Type == kwBY
+		case kwWHERE, kwFROM, kwJOIN, kwHAVING, kwON, kwUNION, kwINTERSECT, kwMINUS:
+			return false
+		}
+	}
+	return false
+}
+
+func oracleCursorInSelectInto(tokens []Token, offset int) bool {
+	stmtStart, stmtEnd := oracleStatementTokenBounds(tokens, offset)
+	seenSelect := false
+	for i := stmtStart; i < stmtEnd; i++ {
+		if tokens[i].Loc >= offset {
+			break
+		}
+		switch tokens[i].Type {
+		case kwSELECT:
+			seenSelect = true
+		case kwFROM:
+			return false
+		case kwINTO:
+			return seenSelect
+		}
+	}
+	return false
+}
+
+func oracleCursorInPLSQLDeclarationType(tokens []Token, offset int) bool {
+	stmtStart, stmtEnd := oracleStatementTokenBounds(tokens, offset)
+	if stmtStart >= stmtEnd || tokens[stmtStart].Type != kwDECLARE {
+		return false
+	}
+	before := tokensBeforeOffset(tokens[stmtStart:stmtEnd], offset)
+	for _, tok := range before {
+		if tok.Type == kwBEGIN {
+			return false
+		}
+	}
+	prev := previousNonPunctuation(before)
+	return isOracleCompletionIdent(prev)
+}
+
 func oracleCursorInTableRef(tokens []Token, offset int) bool {
 	stmtStart, stmtEnd := oracleStatementTokenBounds(tokens, offset)
 	depth := 0
@@ -625,4 +878,79 @@ func oracleCursorInTableRef(tokens []Token, offset int) bool {
 		}
 	}
 	return lastClause == kwFROM || lastClause == kwJOIN
+}
+
+func addOracleStructuralTokenCandidates(cs *CandidateSet, allTokens []Token, before []Token, offset int) {
+	prev := previousNonPunctuation(before)
+	switch prev.Type {
+	case kwEXISTS:
+		cs.addToken(kwSELECT)
+	case kwBEGIN, kwTHEN, kwELSE:
+		for _, tok := range []int{kwSELECT, kwINSERT, kwUPDATE, kwDELETE, kwMERGE, kwNULL, kwBEGIN} {
+			cs.addToken(tok)
+		}
+	}
+	if oracleCursorAfterFromRelation(allTokens, offset) {
+		for _, tok := range []int{kwWHERE, kwJOIN, kwGROUP, kwORDER, kwHAVING} {
+			cs.addToken(tok)
+		}
+	}
+}
+
+func oracleCursorAfterFromRelation(tokens []Token, offset int) bool {
+	stmtStart, stmtEnd := oracleStatementTokenBounds(tokens, offset)
+	depth := 0
+	lastFromOrJoin := -1
+	lastBoundary := -1
+	for i := stmtStart; i < stmtEnd; i++ {
+		if tokens[i].Loc >= offset {
+			break
+		}
+		switch tokens[i].Type {
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		switch tokens[i].Type {
+		case kwFROM, kwJOIN:
+			lastFromOrJoin = i
+			lastBoundary = -1
+		case kwWHERE, kwON, kwUSING, kwGROUP, kwHAVING, kwORDER, kwUNION, kwINTERSECT, kwMINUS:
+			lastBoundary = i
+		}
+	}
+	if lastFromOrJoin < 0 || lastBoundary > lastFromOrJoin {
+		return false
+	}
+	_, _, ok := parseOracleRangeReference(tokens, lastFromOrJoin+1)
+	return ok
+}
+
+func lastUnclosedParenBeforeOffset(tokens []Token, offset int) int {
+	var stack []int
+	for i, tok := range tokens {
+		if tok.Loc >= offset {
+			break
+		}
+		switch tok.Type {
+		case '(':
+			stack = append(stack, i)
+		case ')':
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	if len(stack) == 0 {
+		return -1
+	}
+	return stack[len(stack)-1]
 }

--- a/oracle/parser/complete.go
+++ b/oracle/parser/complete.go
@@ -1,0 +1,628 @@
+package parser
+
+import (
+	"sort"
+	"strings"
+)
+
+// Exported token aliases used by completion callers and tests.
+const (
+	IDENT = tokIDENT
+
+	SELECT    = kwSELECT
+	INSERT    = kwINSERT
+	UPDATE    = kwUPDATE
+	DELETE    = kwDELETE
+	MERGE     = kwMERGE
+	CREATE    = kwCREATE
+	ALTER     = kwALTER
+	DROP      = kwDROP
+	TRUNCATE  = kwTRUNCATE
+	COMMENT   = kwCOMMENT
+	GRANT     = kwGRANT
+	REVOKE    = kwREVOKE
+	COMMIT    = kwCOMMIT
+	ROLLBACK  = kwROLLBACK
+	SAVEPOINT = kwSAVEPOINT
+	SET       = kwSET
+	BEGIN     = kwBEGIN
+	DECLARE   = kwDECLARE
+	WITH      = kwWITH
+
+	FROM      = kwFROM
+	WHERE     = kwWHERE
+	GROUP     = kwGROUP
+	HAVING    = kwHAVING
+	ORDER     = kwORDER
+	BY        = kwBY
+	AS        = kwAS
+	JOIN      = kwJOIN
+	ON        = kwON
+	USING     = kwUSING
+	UNION     = kwUNION
+	INTERSECT = kwINTERSECT
+	MINUS     = kwMINUS
+	OFFSET    = kwOFFSET
+	FETCH     = kwFETCH
+
+	TABLE     = kwTABLE
+	VIEW      = kwVIEW
+	SEQUENCE  = kwSEQUENCE
+	SYNONYM   = kwSYNONYM
+	INDEX     = kwINDEX
+	USER      = kwUSER
+	ROLE      = kwROLE
+	TYPE      = kwTYPE
+	PACKAGE   = kwPACKAGE
+	PROCEDURE = kwPROCEDURE
+	FUNCTION  = kwFUNCTION
+	TRIGGER   = kwTRIGGER
+)
+
+var reverseOracleKeywordMap map[int]string
+
+func initReverseOracleKeywordMap() {
+	reverseOracleKeywordMap = make(map[int]string, len(oracleKeywords))
+	for word, tok := range oracleKeywords {
+		reverseOracleKeywordMap[tok] = strings.ToUpper(word)
+	}
+}
+
+// TokenName returns the SQL keyword string for a token type, or "" when the
+// token is not a keyword useful for completion.
+func TokenName(tokenType int) string {
+	if tokenType > 0 && tokenType < 256 {
+		return string(rune(tokenType))
+	}
+	if reverseOracleKeywordMap == nil {
+		initReverseOracleKeywordMap()
+	}
+	if name, ok := reverseOracleKeywordMap[tokenType]; ok {
+		return name
+	}
+	switch tokenType {
+	case tokIDENT, tokQIDENT, tokICONST, tokFCONST, tokSCONST, tokNCHARLIT, tokBIND:
+		return ""
+	}
+	return ""
+}
+
+// IsReservedKeyword reports whether word is an Oracle SQL reserved word that
+// cannot be used as a nonquoted identifier.
+func IsReservedKeyword(word string) bool {
+	if reverseOracleKeywordMap == nil {
+		initReverseOracleKeywordMap()
+	}
+	tok, ok := oracleKeywords[strings.ToUpper(word)]
+	if !ok {
+		return false
+	}
+	return isOracleSQLReservedKeyword(Token{Type: tok, Str: strings.ToUpper(word)})
+}
+
+// Tokenize runs the Oracle lexer and returns all non-EOF tokens.
+func Tokenize(sql string) []Token {
+	lex := NewLexer(sql)
+	var tokens []Token
+	for {
+		tok := lex.NextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+		tokens = append(tokens, tok)
+	}
+	return tokens
+}
+
+// RuleCandidate represents a grammar rule candidate at the completion cursor.
+type RuleCandidate struct {
+	Rule string
+}
+
+// CandidateSet holds token and rule candidates collected for completion.
+type CandidateSet struct {
+	Tokens []int
+	Rules  []RuleCandidate
+	seen   map[int]bool
+	seenR  map[string]bool
+}
+
+func newCandidateSet() *CandidateSet {
+	return &CandidateSet{
+		seen:  make(map[int]bool),
+		seenR: make(map[string]bool),
+	}
+}
+
+func (cs *CandidateSet) addToken(t int) {
+	if cs == nil || cs.seen[t] {
+		return
+	}
+	cs.seen[t] = true
+	cs.Tokens = append(cs.Tokens, t)
+}
+
+func (cs *CandidateSet) addRule(rule string) {
+	if cs == nil || cs.seenR[rule] {
+		return
+	}
+	cs.seenR[rule] = true
+	cs.Rules = append(cs.Rules, RuleCandidate{Rule: rule})
+}
+
+// HasToken reports whether the candidate set contains a token type.
+func (cs *CandidateSet) HasToken(t int) bool {
+	return cs != nil && cs.seen[t]
+}
+
+// HasRule reports whether the candidate set contains a grammar rule.
+func (cs *CandidateSet) HasRule(rule string) bool {
+	return cs != nil && cs.seenR[rule]
+}
+
+var oracleTopLevelCompletionTokens = []int{
+	kwSELECT, kwINSERT, kwUPDATE, kwDELETE, kwMERGE, kwCREATE, kwALTER, kwDROP,
+	kwTRUNCATE, kwCOMMENT, kwGRANT, kwREVOKE, kwCOMMIT, kwROLLBACK, kwSAVEPOINT,
+	kwSET, kwBEGIN, kwDECLARE, kwWITH, kwCALL, kwEXPLAIN, kwLOCK, kwRENAME,
+}
+
+// Collect returns parser-native completion candidates for sql at cursorOffset.
+//
+// The initial implementation is deliberately conservative: it provides stable
+// top-level token candidates and a few structural rule signals. Later phases add
+// deeper clause and scope instrumentation.
+func Collect(sql string, cursorOffset int) *CandidateSet {
+	if cursorOffset < 0 {
+		cursorOffset = 0
+	}
+	if cursorOffset > len(sql) {
+		cursorOffset = len(sql)
+	}
+
+	prefix := completionPrefix(sql, cursorOffset)
+	collectOffset := cursorOffset - len(prefix)
+	cs, _ := collectOracleCandidates(sql, Tokenize(sql), collectOffset, prefix)
+	return cs
+}
+
+func collectOracleCandidates(_ string, allTokens []Token, collectOffset int, prefix string) (*CandidateSet, *CompletionIntent) {
+	cs := newCandidateSet()
+	tokens := tokensBeforeOffset(allTokens, collectOffset)
+	if atOracleStatementStart(tokens) {
+		addTopLevelCandidates(cs)
+		return cs, &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}
+	}
+
+	// Partial top-level keyword, e.g. SEL|.
+	if len(tokens) == 0 && prefix != "" {
+		addTopLevelCandidates(cs)
+		return cs, &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}
+	}
+	if ddlIntent, handled := inferOracleDDLCompletionIntent(cs, allTokens, tokens, collectOffset); handled {
+		addRulesForOracleIntent(cs, ddlIntent)
+		return cs, ddlIntent
+	}
+	intent := inferOracleCompletionIntent(allTokens, tokens, collectOffset)
+	addRulesForOracleIntent(cs, intent)
+	return cs, intent
+}
+
+func addRulesForOracleIntent(cs *CandidateSet, intent *CompletionIntent) {
+	if intent == nil {
+		return
+	}
+	for _, kind := range intent.ObjectKinds {
+		switch kind {
+		case ObjectKindTable, ObjectKindView:
+			cs.addRule("table_ref")
+		case ObjectKindColumn:
+			cs.addRule("columnref")
+		case ObjectKindSchema:
+			cs.addRule("schema_ref")
+		case ObjectKindSequence:
+			cs.addRule("sequence_ref")
+		case ObjectKindFunction:
+			cs.addRule("func_name")
+			addOracleKeywordCandidatesBy(cs, isOracleFunctionKeyword)
+		case ObjectKindType:
+			cs.addRule("type_name")
+			addOracleKeywordCandidatesBy(cs, isOracleTypeKeyword)
+		}
+		if kind == ObjectKindColumn {
+			addOracleKeywordCandidatesBy(cs, isOraclePseudoColumnKeyword)
+		}
+	}
+}
+
+func addOracleKeywordCandidatesBy(cs *CandidateSet, pred func(int) bool) {
+	tokens := make([]int, 0)
+	for _, tok := range oracleKeywords {
+		if pred(tok) {
+			tokens = append(tokens, tok)
+		}
+	}
+	sort.Slice(tokens, func(i, j int) bool {
+		return TokenName(tokens[i]) < TokenName(tokens[j])
+	})
+	for _, tok := range tokens {
+		cs.addToken(tok)
+	}
+}
+
+func completionPrefix(sql string, cursorOffset int) string {
+	if cursorOffset > len(sql) {
+		cursorOffset = len(sql)
+	}
+	if cursorOffset < 0 {
+		cursorOffset = 0
+	}
+	i := cursorOffset
+	for i > 0 {
+		c := sql[i-1]
+		if isCompletionIdentByte(c) {
+			i--
+			continue
+		}
+		break
+	}
+	return sql[i:cursorOffset]
+}
+
+func isCompletionIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_' || c == '$' || c == '#'
+}
+
+func tokensBeforeOffset(tokens []Token, offset int) []Token {
+	result := tokens[:0]
+	for _, tok := range tokens {
+		if tok.Loc >= offset {
+			break
+		}
+		result = append(result, tok)
+	}
+	return result
+}
+
+func atOracleStatementStart(tokens []Token) bool {
+	for i := len(tokens) - 1; i >= 0; i-- {
+		switch tokens[i].Type {
+		case ';':
+			return true
+		case tokEOF:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func addTopLevelCandidates(cs *CandidateSet) {
+	for _, tok := range oracleTopLevelCompletionTokens {
+		cs.addToken(tok)
+	}
+}
+
+func inferOracleCompletionIntent(allTokens []Token, before []Token, collectOffset int) *CompletionIntent {
+	intent := &CompletionIntent{}
+	if len(before) == 0 {
+		return intent
+	}
+
+	if dmlIntent := inferOracleDMLCompletionIntent(allTokens, before, collectOffset); len(dmlIntent.ObjectKinds) > 0 {
+		return dmlIntent
+	}
+
+	if q, ok := oracleDottedQualifierBefore(before); ok {
+		if oracleCursorInTableRef(allTokens, collectOffset) {
+			intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+			intent.Qualifier.Schema = q
+			return intent
+		}
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn}
+		intent.Qualifier.Object = q
+		return intent
+	}
+
+	prev := previousNonPunctuation(before)
+	if prev.Type == kwFROM || prev.Type == kwJOIN {
+		intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+		return intent
+	}
+	if prev.Type == kwWHERE || prev.Type == kwON || prev.Type == kwBY {
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn}
+		return intent
+	}
+	if prev.Type == kwSELECT {
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+		return intent
+	}
+	if oracleCursorInSelectTarget(allTokens, collectOffset) ||
+		oracleCursorInExpressionClause(allTokens, collectOffset) {
+		intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+		return intent
+	}
+	if oracleCursorInTableRef(allTokens, collectOffset) {
+		intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+		return intent
+	}
+	return intent
+}
+
+func inferOracleDDLCompletionIntent(cs *CandidateSet, allTokens []Token, before []Token, collectOffset int) (*CompletionIntent, bool) {
+	intent := &CompletionIntent{}
+	stmtStart, _ := oracleStatementTokenBounds(allTokens, collectOffset)
+	if stmtStart >= len(allTokens) {
+		return intent, false
+	}
+	first := allTokens[stmtStart]
+	prev := previousNonPunctuation(before)
+	switch first.Type {
+	case kwCREATE:
+		if prev.Type == kwCREATE {
+			for _, tok := range []int{kwTABLE, kwVIEW, kwINDEX, kwSEQUENCE, kwSYNONYM, kwPROCEDURE, kwFUNCTION, kwPACKAGE, kwTRIGGER, kwUSER, kwROLE, kwTYPE} {
+				cs.addToken(tok)
+			}
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}, true
+		}
+		if prev.Type == kwREFERENCES {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable, ObjectKindView}}, true
+		}
+		if oracleCreateTableTypeContext(allTokens[stmtStart:], collectOffset) {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindType}}, true
+		}
+	case kwALTER:
+		if prev.Type == kwTABLE {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}}, true
+		}
+		if oracleSeenToken(before[stmtStart:], kwTABLE) && prev.Type == kwADD {
+			for _, tok := range []int{kwCOLUMN, kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN, kwCHECK} {
+				cs.addToken(tok)
+			}
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindUnknown}}, true
+		}
+		if oracleSeenToken(before[stmtStart:], kwTABLE) && oracleSeenToken(before[stmtStart:], kwDROP) && prev.Type == kwCOLUMN {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindColumn}}, true
+		}
+	case kwDROP:
+		switch prev.Type {
+		case kwTABLE:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}}, true
+		case kwVIEW:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindView}}, true
+		case kwSEQUENCE:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindSequence}}, true
+		case kwPROCEDURE:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindProcedure}}, true
+		case kwFUNCTION:
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindFunction}}, true
+		}
+	case kwTRUNCATE:
+		if prev.Type == kwTABLE {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}}, true
+		}
+	case kwCOMMENT:
+		if q, ok := oracleDottedQualifierBefore(before); ok && oracleSeenToken(before[stmtStart:], kwCOLUMN) {
+			return &CompletionIntent{
+				ObjectKinds: []ObjectKind{ObjectKindColumn},
+				Qualifier:   MultipartName{Object: q},
+			}, true
+		}
+		if prev.Type == kwTABLE {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}}, true
+		}
+	case kwGRANT, kwREVOKE:
+		if prev.Type == kwON {
+			return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable, ObjectKindView}}, true
+		}
+	}
+	return intent, false
+}
+
+func oracleCreateTableTypeContext(tokens []Token, offset int) bool {
+	if len(tokens) < 2 || tokens[0].Type != kwCREATE || tokens[1].Type != kwTABLE {
+		return false
+	}
+	for i := 2; i < len(tokens); i++ {
+		if tokens[i].Loc >= offset {
+			return false
+		}
+		if tokens[i].Type == '(' {
+			closeIdx := oracleMatchingParen(tokens, i)
+			return closeIdx < 0 || tokens[closeIdx].Loc >= offset
+		}
+	}
+	return false
+}
+
+func inferOracleDMLCompletionIntent(allTokens []Token, before []Token, collectOffset int) *CompletionIntent {
+	intent := &CompletionIntent{}
+	stmtStart, _ := oracleStatementTokenBounds(allTokens, collectOffset)
+	if stmtStart >= len(allTokens) {
+		return intent
+	}
+	first := allTokens[stmtStart]
+	prev := previousNonPunctuation(before)
+	switch first.Type {
+	case kwINSERT:
+		if prev.Type == kwINTO {
+			intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+			return intent
+		}
+		if oracleInsertColumnListContext(allTokens[stmtStart:], collectOffset) {
+			intent.ObjectKinds = []ObjectKind{ObjectKindColumn}
+			return intent
+		}
+		if oracleSeenToken(before[stmtStart:], kwVALUES) {
+			intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+			return intent
+		}
+	case kwUPDATE:
+		if prev.Type == kwUPDATE {
+			intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+			return intent
+		}
+		if oracleSeenToken(before[stmtStart:], kwSET) || prev.Type == kwWHERE {
+			intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+			return intent
+		}
+	case kwDELETE:
+		if prev.Type == kwFROM {
+			intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+			return intent
+		}
+		if prev.Type == kwWHERE || oracleSeenToken(before[stmtStart:], kwWHERE) {
+			intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+			return intent
+		}
+	case kwMERGE:
+		if prev.Type == kwINTO || prev.Type == kwUSING {
+			intent.ObjectKinds = []ObjectKind{ObjectKindTable, ObjectKindView}
+			return intent
+		}
+		if prev.Type == kwON || oracleSeenToken(before[stmtStart:], kwON) {
+			intent.ObjectKinds = []ObjectKind{ObjectKindColumn, ObjectKindFunction}
+			return intent
+		}
+	}
+	return intent
+}
+
+func oracleInsertColumnListContext(tokens []Token, offset int) bool {
+	intoIdx := -1
+	for i, tok := range tokens {
+		if tok.Type == kwINTO {
+			intoIdx = i
+			break
+		}
+	}
+	if intoIdx < 0 {
+		return false
+	}
+	for i := intoIdx + 1; i < len(tokens); i++ {
+		if tokens[i].Loc >= offset {
+			return false
+		}
+		if tokens[i].Type == '(' {
+			closeIdx := oracleMatchingParen(tokens, i)
+			return closeIdx < 0 || tokens[closeIdx].Loc >= offset
+		}
+		if tokens[i].Type == kwVALUES || tokens[i].Type == kwSELECT {
+			return false
+		}
+	}
+	return false
+}
+
+func oracleSeenToken(tokens []Token, tokenType int) bool {
+	for _, tok := range tokens {
+		if tok.Type == tokenType {
+			return true
+		}
+	}
+	return false
+}
+
+func previousNonPunctuation(tokens []Token) Token {
+	for i := len(tokens) - 1; i >= 0; i-- {
+		switch tokens[i].Type {
+		case ',', '(', ')':
+			continue
+		default:
+			return tokens[i]
+		}
+	}
+	return Token{}
+}
+
+func oracleDottedQualifierBefore(tokens []Token) (string, bool) {
+	if len(tokens) < 2 || tokens[len(tokens)-1].Type != '.' {
+		return "", false
+	}
+	qualifier := tokens[len(tokens)-2]
+	if !isOracleCompletionIdent(qualifier) {
+		return "", false
+	}
+	return qualifier.Str, true
+}
+
+func oracleCursorInSelectTarget(tokens []Token, offset int) bool {
+	stmtStart, stmtEnd := oracleStatementTokenBounds(tokens, offset)
+	selectIdx := -1
+	for i := stmtStart; i < stmtEnd; i++ {
+		if tokens[i].Type == kwSELECT && tokens[i].Loc < offset {
+			selectIdx = i
+		}
+	}
+	if selectIdx < 0 {
+		return false
+	}
+	for i := selectIdx + 1; i < stmtEnd; i++ {
+		if tokens[i].Loc >= offset {
+			break
+		}
+		if tokens[i].Type == kwFROM {
+			return false
+		}
+	}
+	for i := selectIdx + 1; i < stmtEnd; i++ {
+		if tokens[i].Loc >= offset {
+			return true
+		}
+		if tokens[i].Type == kwFROM {
+			return true
+		}
+	}
+	return false
+}
+
+func oracleCursorInExpressionClause(tokens []Token, offset int) bool {
+	stmtStart, _ := oracleStatementTokenBounds(tokens, offset)
+	for i := len(tokens) - 1; i >= stmtStart; i-- {
+		if tokens[i].Loc >= offset {
+			continue
+		}
+		switch tokens[i].Type {
+		case kwWHERE, kwON, kwHAVING:
+			return true
+		case kwFROM, kwJOIN, kwGROUP, kwORDER:
+			return false
+		}
+	}
+	return false
+}
+
+func oracleCursorInTableRef(tokens []Token, offset int) bool {
+	stmtStart, stmtEnd := oracleStatementTokenBounds(tokens, offset)
+	depth := 0
+	lastClause := 0
+	for i := stmtStart; i < stmtEnd; i++ {
+		if tokens[i].Loc >= offset {
+			break
+		}
+		switch tokens[i].Type {
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		switch tokens[i].Type {
+		case kwFROM, kwJOIN:
+			lastClause = tokens[i].Type
+		case kwWHERE, kwON, kwGROUP, kwHAVING, kwORDER, kwCONNECT, kwSTART,
+			kwUNION, kwINTERSECT, kwMINUS, kwOFFSET, kwFETCH:
+			lastClause = tokens[i].Type
+		}
+	}
+	return lastClause == kwFROM || lastClause == kwJOIN
+}

--- a/oracle/parser/complete_context.go
+++ b/oracle/parser/complete_context.go
@@ -1,0 +1,469 @@
+package parser
+
+import nodes "github.com/bytebase/omni/oracle/ast"
+
+// CompletionContext is Oracle parser-native completion state.
+type CompletionContext struct {
+	Candidates *CandidateSet
+	Scope      *ScopeSnapshot
+	CTEs       []RangeReference
+	Prefix     string
+	Intent     *CompletionIntent
+}
+
+// CompletionIntent describes the object class and qualifier implied by the
+// cursor position.
+type CompletionIntent struct {
+	ObjectKinds []ObjectKind
+	Qualifier   MultipartName
+}
+
+// ObjectKind classifies catalog object completion intent.
+type ObjectKind int
+
+const (
+	ObjectKindUnknown ObjectKind = iota
+	ObjectKindSchema
+	ObjectKindTable
+	ObjectKindView
+	ObjectKindSequence
+	ObjectKindProcedure
+	ObjectKindFunction
+	ObjectKindPackage
+	ObjectKindType
+	ObjectKindColumn
+	ObjectKindIndex
+	ObjectKindTrigger
+	ObjectKindUser
+	ObjectKindRole
+)
+
+// MultipartName is a partially typed Oracle object name.
+type MultipartName struct {
+	Schema string
+	Object string
+}
+
+// ScopeSnapshot describes relation scope visible at the cursor.
+type ScopeSnapshot struct {
+	References      []RangeReference
+	LocalReferences []RangeReference
+	OuterReferences [][]RangeReference
+}
+
+// RangeReferenceKind classifies a range-table entry visible to completion.
+type RangeReferenceKind int
+
+const (
+	RangeReferenceRelation RangeReferenceKind = iota
+	RangeReferenceSubquery
+	RangeReferenceJoinAlias
+	RangeReferenceCTE
+	RangeReferenceDMLTarget
+	RangeReferenceMergeSource
+)
+
+// RangeReference is a syntax-level table expression reference. It deliberately
+// avoids catalog metadata; Bytebase resolves metadata from its own store.
+type RangeReference struct {
+	Kind   RangeReferenceKind
+	Schema string
+	Name   string
+	Alias  string
+
+	Columns []string
+
+	Loc     nodes.Loc
+	BodyLoc nodes.Loc
+}
+
+// CollectCompletion returns parser candidates plus best-effort visible scope
+// and object intent at cursorOffset.
+func CollectCompletion(sql string, cursorOffset int) *CompletionContext {
+	if cursorOffset < 0 {
+		cursorOffset = 0
+	}
+	if cursorOffset > len(sql) {
+		cursorOffset = len(sql)
+	}
+	prefix := completionPrefix(sql, cursorOffset)
+	collectOffset := cursorOffset - len(prefix)
+	tokens := Tokenize(sql)
+	candidates, intent := collectOracleCandidates(sql, tokens, collectOffset, prefix)
+	scope, ctes := collectOracleScopeAndCTEs(tokens, cursorOffset)
+	return &CompletionContext{
+		Candidates: candidates,
+		Scope:      scope,
+		CTEs:       ctes,
+		Prefix:     prefix,
+		Intent:     intent,
+	}
+}
+
+func collectOracleScope(tokens []Token, cursorOffset int) *ScopeSnapshot {
+	scope, _ := collectOracleScopeAndCTEs(tokens, cursorOffset)
+	return scope
+}
+
+func collectOracleScopeAndCTEs(tokens []Token, cursorOffset int) (*ScopeSnapshot, []RangeReference) {
+	start, end := oracleStatementTokenBounds(tokens, cursorOffset)
+	stmtTokens := tokens[start:end]
+	ctes := collectOracleCTEs(stmtTokens)
+	refs := collectOracleSelectRefs(stmtTokens)
+	refs = append(refs, collectOracleDMLRefs(stmtTokens)...)
+	refs = append(refs, collectOracleDDLRefs(stmtTokens)...)
+	refs = append(append([]RangeReference{}, ctes...), refs...)
+	return &ScopeSnapshot{
+		References:      refs,
+		LocalReferences: refs,
+	}, ctes
+}
+
+func collectOracleDDLRefs(tokens []Token) []RangeReference {
+	first := firstOracleNonTerminator(tokens)
+	if first < 0 {
+		return nil
+	}
+	switch tokens[first].Type {
+	case kwALTER:
+		for i := first + 1; i < len(tokens); i++ {
+			if tokens[i].Type == kwTABLE {
+				_, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					return []RangeReference{ref}
+				}
+				break
+			}
+		}
+	case kwCOMMENT:
+		for i := first + 1; i+3 < len(tokens); i++ {
+			if tokens[i].Type == kwON && tokens[i+1].Type == kwCOLUMN && isOracleCompletionIdent(tokens[i+2]) && tokens[i+3].Type == '.' {
+				ref := RangeReference{
+					Kind:  RangeReferenceRelation,
+					Name:  tokens[i+2].Str,
+					Alias: tokens[i+2].Str,
+					Loc:   nodes.Loc{Start: tokens[i+2].Loc, End: tokens[i+2].End},
+				}
+				return []RangeReference{ref}
+			}
+		}
+	}
+	return nil
+}
+
+func collectOracleDMLRefs(tokens []Token) []RangeReference {
+	first := firstOracleNonTerminator(tokens)
+	if first < 0 {
+		return nil
+	}
+	switch tokens[first].Type {
+	case kwUPDATE:
+		_, ref, ok := parseOracleRangeReference(tokens, first+1)
+		if ok {
+			ref.Kind = RangeReferenceDMLTarget
+			return []RangeReference{ref}
+		}
+	case kwINSERT:
+		for i := first + 1; i < len(tokens); i++ {
+			if tokens[i].Type == kwINTO {
+				_, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					ref.Kind = RangeReferenceDMLTarget
+					return []RangeReference{ref}
+				}
+				break
+			}
+		}
+	case kwDELETE:
+		for i := first + 1; i < len(tokens); i++ {
+			if tokens[i].Type == kwFROM {
+				_, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					ref.Kind = RangeReferenceDMLTarget
+					return []RangeReference{ref}
+				}
+				break
+			}
+		}
+	case kwMERGE:
+		var refs []RangeReference
+		for i := first + 1; i < len(tokens); i++ {
+			switch tokens[i].Type {
+			case kwINTO:
+				next, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					ref.Kind = RangeReferenceDMLTarget
+					refs = append(refs, ref)
+					i = next - 1
+				}
+			case kwUSING:
+				next, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					ref.Kind = RangeReferenceMergeSource
+					refs = append(refs, ref)
+					i = next - 1
+				}
+			}
+		}
+		return refs
+	}
+	return nil
+}
+
+func oracleStatementTokenBounds(tokens []Token, cursorOffset int) (int, int) {
+	start := 0
+	for i, tok := range tokens {
+		if tok.Loc >= cursorOffset {
+			break
+		}
+		if tok.Type == ';' {
+			start = i + 1
+		}
+	}
+	end := len(tokens)
+	for i := start; i < len(tokens); i++ {
+		if tokens[i].Loc < cursorOffset {
+			continue
+		}
+		if tokens[i].Type == ';' {
+			end = i
+			break
+		}
+	}
+	return start, end
+}
+
+func collectOracleSelectRefs(tokens []Token) []RangeReference {
+	var refs []RangeReference
+	for i := 0; i < len(tokens); i++ {
+		switch tokens[i].Type {
+		case kwFROM, kwJOIN:
+			next, ref, ok := parseOracleRangeReference(tokens, i+1)
+			if ok {
+				refs = append(refs, ref)
+				i = next - 1
+			}
+		}
+	}
+	return refs
+}
+
+func parseOracleRangeReference(tokens []Token, i int) (int, RangeReference, bool) {
+	for i < len(tokens) && tokens[i].Type == ',' {
+		i++
+	}
+	if i >= len(tokens) {
+		return i, RangeReference{}, false
+	}
+	if tokens[i].Type == '(' {
+		return parseOracleSubqueryRangeReference(tokens, i)
+	}
+	if !isOracleCompletionIdent(tokens[i]) {
+		return i, RangeReference{}, false
+	}
+
+	startTok := tokens[i]
+	parts := []Token{tokens[i]}
+	i++
+	for i+1 < len(tokens) && tokens[i].Type == '.' && isOracleCompletionIdent(tokens[i+1]) {
+		parts = append(parts, tokens[i+1])
+		i += 2
+	}
+
+	ref := RangeReference{
+		Kind: RangeReferenceRelation,
+		Loc:  nodes.Loc{Start: startTok.Loc, End: parts[len(parts)-1].End},
+	}
+	switch len(parts) {
+	case 1:
+		ref.Name = parts[0].Str
+	default:
+		ref.Schema = parts[len(parts)-2].Str
+		ref.Name = parts[len(parts)-1].Str
+	}
+
+	if i < len(tokens) && tokens[i].Type == kwAS {
+		i++
+	}
+	if i < len(tokens) && isOracleCompletionIdent(tokens[i]) && !isOracleCompletionClauseBoundary(tokens[i].Type) {
+		ref.Alias = tokens[i].Str
+		ref.Loc.End = tokens[i].End
+		i++
+	}
+	if ref.Alias == "" {
+		ref.Alias = ref.Name
+	}
+	return i, ref, true
+}
+
+func parseOracleSubqueryRangeReference(tokens []Token, i int) (int, RangeReference, bool) {
+	closeIdx := oracleMatchingParen(tokens, i)
+	if closeIdx < 0 {
+		return i, RangeReference{}, false
+	}
+	aliasIdx := closeIdx + 1
+	if aliasIdx < len(tokens) && tokens[aliasIdx].Type == kwAS {
+		aliasIdx++
+	}
+	if aliasIdx >= len(tokens) || !isOracleCompletionIdent(tokens[aliasIdx]) {
+		return closeIdx + 1, RangeReference{}, false
+	}
+	ref := RangeReference{
+		Kind:    RangeReferenceSubquery,
+		Name:    tokens[aliasIdx].Str,
+		Alias:   tokens[aliasIdx].Str,
+		Columns: extractOracleSelectListColumns(tokens[i+1 : closeIdx]),
+		Loc:     nodes.Loc{Start: tokens[i].Loc, End: tokens[aliasIdx].End},
+		BodyLoc: nodes.Loc{Start: tokens[i].End, End: tokens[closeIdx].Loc},
+	}
+	return aliasIdx + 1, ref, true
+}
+
+func collectOracleCTEs(tokens []Token) []RangeReference {
+	first := firstOracleNonTerminator(tokens)
+	if first < 0 || tokens[first].Type != kwWITH {
+		return nil
+	}
+	var refs []RangeReference
+	i := first + 1
+	for i < len(tokens) {
+		if !isOracleCompletionIdent(tokens[i]) {
+			break
+		}
+		nameTok := tokens[i]
+		ref := RangeReference{
+			Kind:  RangeReferenceCTE,
+			Name:  nameTok.Str,
+			Alias: nameTok.Str,
+			Loc:   nodes.Loc{Start: nameTok.Loc, End: nameTok.End},
+		}
+		i++
+		if i < len(tokens) && tokens[i].Type == '(' {
+			closeIdx := oracleMatchingParen(tokens, i)
+			if closeIdx < 0 {
+				break
+			}
+			ref.Columns = extractOracleNameList(tokens[i+1 : closeIdx])
+			ref.Loc.End = tokens[closeIdx].End
+			i = closeIdx + 1
+		}
+		if i >= len(tokens) || tokens[i].Type != kwAS {
+			break
+		}
+		i++
+		if i >= len(tokens) || tokens[i].Type != '(' {
+			break
+		}
+		closeIdx := oracleMatchingParen(tokens, i)
+		if closeIdx < 0 {
+			break
+		}
+		if len(ref.Columns) == 0 {
+			ref.Columns = extractOracleSelectListColumns(tokens[i+1 : closeIdx])
+		}
+		ref.BodyLoc = nodes.Loc{Start: tokens[i].End, End: tokens[closeIdx].Loc}
+		ref.Loc.End = tokens[closeIdx].End
+		refs = append(refs, ref)
+		i = closeIdx + 1
+		if i < len(tokens) && tokens[i].Type == ',' {
+			i++
+			continue
+		}
+		break
+	}
+	return refs
+}
+
+func firstOracleNonTerminator(tokens []Token) int {
+	for i, tok := range tokens {
+		if tok.Type != ';' {
+			return i
+		}
+	}
+	return -1
+}
+
+func oracleMatchingParen(tokens []Token, openIdx int) int {
+	if openIdx < 0 || openIdx >= len(tokens) || tokens[openIdx].Type != '(' {
+		return -1
+	}
+	depth := 0
+	for i := openIdx; i < len(tokens); i++ {
+		switch tokens[i].Type {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func extractOracleNameList(tokens []Token) []string {
+	var names []string
+	for _, tok := range tokens {
+		if isOracleCompletionIdent(tok) {
+			names = append(names, tok.Str)
+		}
+	}
+	return names
+}
+
+func extractOracleSelectListColumns(tokens []Token) []string {
+	selectIdx := -1
+	for i, tok := range tokens {
+		if tok.Type == kwSELECT {
+			selectIdx = i
+			break
+		}
+	}
+	if selectIdx < 0 {
+		return nil
+	}
+	var names []string
+	depth := 0
+	for i := selectIdx + 1; i < len(tokens); i++ {
+		tok := tokens[i]
+		switch tok.Type {
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth == 0 && tok.Type == kwFROM {
+			break
+		}
+		if depth == 0 && isOracleCompletionIdent(tok) {
+			names = append(names, tok.Str)
+			for i+1 < len(tokens) && tokens[i+1].Type != ',' && tokens[i+1].Type != kwFROM {
+				i++
+			}
+		}
+	}
+	return names
+}
+
+func isOracleCompletionIdent(tok Token) bool {
+	if tok.Type == tokIDENT || tok.Type == tokQIDENT {
+		return true
+	}
+	return tok.Type >= 2000 && !isOracleSQLReservedKeyword(tok)
+}
+
+func isOracleCompletionClauseBoundary(tokenType int) bool {
+	switch tokenType {
+	case kwWHERE, kwGROUP, kwHAVING, kwORDER, kwCONNECT, kwSTART, kwUNION,
+		kwINTERSECT, kwMINUS, kwOFFSET, kwFETCH, kwJOIN, kwON, kwUSING,
+		kwLEFT, kwRIGHT, kwFULL, kwCROSS, kwINNER, kwOUTER:
+		return true
+	default:
+		return false
+	}
+}

--- a/oracle/parser/complete_context.go
+++ b/oracle/parser/complete_context.go
@@ -34,6 +34,11 @@ const (
 	ObjectKindColumn
 	ObjectKindIndex
 	ObjectKindTrigger
+	ObjectKindConstraint
+	ObjectKindSynonym
+	ObjectKindPackageMember
+	ObjectKindDatabaseLink
+	ObjectKindVariable
 	ObjectKindUser
 	ObjectKindRole
 )
@@ -113,9 +118,17 @@ func collectOracleScopeAndCTEs(tokens []Token, cursorOffset int) (*ScopeSnapshot
 	refs = append(refs, collectOracleDMLRefs(stmtTokens)...)
 	refs = append(refs, collectOracleDDLRefs(stmtTokens)...)
 	refs = append(append([]RangeReference{}, ctes...), refs...)
+	localRefs := refs
+	outerRefs := [][]RangeReference(nil)
+	if selectIdx, selectDepth, ok := innermostOracleSelectBeforeCursor(stmtTokens, cursorOffset); ok {
+		armStart, armEnd := oracleSelectArmBounds(stmtTokens, selectIdx, selectDepth)
+		localRefs = collectOracleSelectRefsInRange(stmtTokens, armStart, armEnd, selectDepth)
+		outerRefs = collectOracleOuterSelectRefs(stmtTokens, cursorOffset, selectDepth)
+	}
 	return &ScopeSnapshot{
 		References:      refs,
-		LocalReferences: refs,
+		LocalReferences: localRefs,
+		OuterReferences: outerRefs,
 	}, ctes
 }
 
@@ -125,6 +138,29 @@ func collectOracleDDLRefs(tokens []Token) []RangeReference {
 		return nil
 	}
 	switch tokens[first].Type {
+	case kwCREATE:
+		var refs []RangeReference
+		if first+2 < len(tokens) && tokens[first+1].Type == kwTABLE {
+			_, ref, ok := parseOracleRangeReference(tokens, first+2)
+			if ok {
+				refs = append(refs, ref)
+			}
+		}
+		for i := first + 1; i < len(tokens); i++ {
+			if tokens[i].Type == kwON {
+				_, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					refs = append(refs, ref)
+				}
+			}
+			if tokens[i].Type == kwREFERENCES {
+				_, ref, ok := parseOracleRangeReference(tokens, i+1)
+				if ok {
+					refs = append(refs, ref)
+				}
+			}
+		}
+		return refs
 	case kwALTER:
 		for i := first + 1; i < len(tokens); i++ {
 			if tokens[i].Type == kwTABLE {
@@ -234,8 +270,33 @@ func oracleStatementTokenBounds(tokens []Token, cursorOffset int) (int, int) {
 }
 
 func collectOracleSelectRefs(tokens []Token) []RangeReference {
+	return collectOracleSelectRefsAtDepth(tokens, -1)
+}
+
+func collectOracleSelectRefsAtDepth(tokens []Token, wantDepth int) []RangeReference {
+	return collectOracleSelectRefsInRange(tokens, 0, len(tokens), wantDepth)
+}
+
+func collectOracleSelectRefsInRange(tokens []Token, start int, end int, wantDepth int) []RangeReference {
 	var refs []RangeReference
+	depth := 0
 	for i := 0; i < len(tokens); i++ {
+		switch tokens[i].Type {
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if wantDepth >= 0 && depth != wantDepth {
+			continue
+		}
+		if i < start || i >= end {
+			continue
+		}
 		switch tokens[i].Type {
 		case kwFROM, kwJOIN:
 			next, ref, ok := parseOracleRangeReference(tokens, i+1)
@@ -246,6 +307,125 @@ func collectOracleSelectRefs(tokens []Token) []RangeReference {
 		}
 	}
 	return refs
+}
+
+func innermostOracleSelectBeforeCursor(tokens []Token, cursorOffset int) (int, int, bool) {
+	depth := 0
+	bestIdx := -1
+	bestDepth := -1
+	for i, tok := range tokens {
+		if tok.Loc >= cursorOffset {
+			break
+		}
+		switch tok.Type {
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		case kwSELECT:
+			bestIdx = i
+			bestDepth = depth
+		}
+	}
+	if bestIdx < 0 {
+		return 0, 0, false
+	}
+	return bestIdx, bestDepth, true
+}
+
+func oracleSelectArmBounds(tokens []Token, selectIdx int, selectDepth int) (int, int) {
+	start := selectIdx
+	depth := 0
+	for i := 0; i < len(tokens); i++ {
+		if i >= selectIdx {
+			break
+		}
+		switch tokens[i].Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case kwUNION, kwINTERSECT, kwMINUS:
+			if depth == selectDepth {
+				start = i + 1
+			}
+		}
+	}
+	end := len(tokens)
+	depth = 0
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		if i > selectIdx && depth < selectDepth {
+			end = i
+			break
+		}
+		if i > selectIdx && depth == selectDepth {
+			switch tok.Type {
+			case kwUNION, kwINTERSECT, kwMINUS:
+				end = i
+				return start, end
+			}
+		}
+		switch tok.Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return start, end
+}
+
+func collectOracleOuterSelectRefs(tokens []Token, cursorOffset int, innerDepth int) [][]RangeReference {
+	if innerDepth <= 0 {
+		return nil
+	}
+	type selectAtDepth struct {
+		idx   int
+		depth int
+	}
+	latest := make(map[int]selectAtDepth)
+	depth := 0
+	for i, tok := range tokens {
+		if tok.Loc >= cursorOffset {
+			break
+		}
+		switch tok.Type {
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		case kwSELECT:
+			if depth < innerDepth {
+				latest[depth] = selectAtDepth{idx: i, depth: depth}
+			}
+		}
+	}
+	var levels [][]RangeReference
+	for d := innerDepth - 1; d >= 0; d-- {
+		sel, ok := latest[d]
+		if !ok {
+			continue
+		}
+		start, end := oracleSelectArmBounds(tokens, sel.idx, sel.depth)
+		refs := collectOracleSelectRefsInRange(tokens, start, end, sel.depth)
+		if len(refs) > 0 {
+			levels = append(levels, refs)
+		}
+	}
+	return levels
 }
 
 func parseOracleRangeReference(tokens []Token, i int) (int, RangeReference, bool) {

--- a/oracle/parser/complete_context.go
+++ b/oracle/parser/complete_context.go
@@ -36,6 +36,7 @@ const (
 	ObjectKindTrigger
 	ObjectKindConstraint
 	ObjectKindSynonym
+	ObjectKindSequenceMember
 	ObjectKindPackageMember
 	ObjectKindDatabaseLink
 	ObjectKindVariable

--- a/oracle/parser/complete_context_test.go
+++ b/oracle/parser/complete_context_test.go
@@ -1,0 +1,307 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOracleCompletionSelectTableReferenceSignals(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		qualifier MultipartName
+	}{
+		{name: "from", input: "SELECT * FROM |"},
+		{name: "join", input: "SELECT * FROM t JOIN |"},
+		{name: "schema qualified", input: "SELECT * FROM schema1.|", qualifier: MultipartName{Schema: "schema1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireCompletionRule(t, ctx.Candidates, "table_ref")
+			requireObjectKind(t, ctx.Intent, ObjectKindTable)
+			if tt.qualifier.Schema != "" && !strings.EqualFold(ctx.Intent.Qualifier.Schema, tt.qualifier.Schema) {
+				t.Fatalf("schema qualifier = %q, want %q", ctx.Intent.Qualifier.Schema, tt.qualifier.Schema)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionSelectColumnReferenceSignals(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		qualifier MultipartName
+		refs      []string
+	}{
+		{name: "target list", input: "SELECT | FROM employees", refs: []string{"employees"}},
+		{name: "qualified alias", input: "SELECT e.| FROM employees e", qualifier: MultipartName{Object: "e"}, refs: []string{"e"}},
+		{name: "join on", input: "SELECT * FROM employees e JOIN departments d ON |", refs: []string{"e", "d"}},
+		{name: "where", input: "SELECT * FROM employees e WHERE |", refs: []string{"e"}},
+		{name: "group by", input: "SELECT id FROM employees e GROUP BY |", refs: []string{"e"}},
+		{name: "order by", input: "SELECT id AS eid FROM employees e ORDER BY |", refs: []string{"e"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireCompletionRule(t, ctx.Candidates, "columnref")
+			requireObjectKind(t, ctx.Intent, ObjectKindColumn)
+			if tt.qualifier.Object != "" && !strings.EqualFold(ctx.Intent.Qualifier.Object, tt.qualifier.Object) {
+				t.Fatalf("object qualifier = %q, want %q", ctx.Intent.Qualifier.Object, tt.qualifier.Object)
+			}
+			for _, ref := range tt.refs {
+				requireRangeReference(t, ctx.Scope, ref)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionCTEAndSubqueryScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		ref     string
+		columns []string
+	}{
+		{
+			name:  "cte table reference",
+			input: "WITH x AS (SELECT * FROM employees) SELECT * FROM |",
+			ref:   "x",
+		},
+		{
+			name:    "explicit cte columns",
+			input:   "WITH x(x1, x2) AS (SELECT * FROM employees) SELECT x.| FROM x",
+			ref:     "x",
+			columns: []string{"x1", "x2"},
+		},
+		{
+			name:    "subquery alias columns",
+			input:   "SELECT src.| FROM (SELECT c1, c2 FROM employees) src",
+			ref:     "src",
+			columns: []string{"c1", "c2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireRangeReference(t, ctx.Scope, tt.ref)
+			if len(tt.columns) > 0 {
+				ref := findRangeReference(t, ctx.Scope, tt.ref)
+				for _, col := range tt.columns {
+					requireColumnName(t, ref.Columns, col)
+				}
+			}
+		})
+	}
+}
+
+func TestOracleCompletionDMLSignals(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		rule  string
+		kind  ObjectKind
+		refs  []string
+	}{
+		{name: "insert table", input: "INSERT INTO |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "insert column list", input: "INSERT INTO employees (|)", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "insert values expression", input: "INSERT INTO employees VALUES (|)", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "insert select source", input: "INSERT INTO employees SELECT | FROM departments", rule: "columnref", kind: ObjectKindColumn, refs: []string{"departments"}},
+		{name: "update table", input: "UPDATE | SET name = 'x'", rule: "table_ref", kind: ObjectKindTable},
+		{name: "update set column", input: "UPDATE employees SET |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "update set expression", input: "UPDATE employees SET name = |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "update where", input: "UPDATE employees SET name = 'x' WHERE |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "delete table", input: "DELETE FROM |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "delete where", input: "DELETE FROM employees WHERE |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "merge target", input: "MERGE INTO |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "merge source", input: "MERGE INTO employees e USING |", rule: "table_ref", kind: ObjectKindTable, refs: []string{"e"}},
+		{name: "merge on", input: "MERGE INTO employees e USING departments d ON |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e", "d"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireCompletionRule(t, ctx.Candidates, tt.rule)
+			requireObjectKind(t, ctx.Intent, tt.kind)
+			for _, ref := range tt.refs {
+				requireRangeReference(t, ctx.Scope, ref)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionDDLAndUtilitySignals(t *testing.T) {
+	t.Run("create object types", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "CREATE |")
+		for _, tok := range []int{TABLE, VIEW, INDEX, SEQUENCE, SYNONYM, PROCEDURE, FUNCTION, PACKAGE, TRIGGER, USER, ROLE} {
+			if !ctx.Candidates.HasToken(tok) {
+				t.Fatalf("missing CREATE candidate %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+			}
+		}
+	})
+
+	tests := []struct {
+		name  string
+		input string
+		rule  string
+		kind  ObjectKind
+		refs  []string
+	}{
+		{name: "create table datatype", input: "CREATE TABLE employees (name |)", rule: "type_name", kind: ObjectKindType},
+		{name: "create table references", input: "CREATE TABLE employees (dept_id NUMBER REFERENCES |)", rule: "table_ref", kind: ObjectKindTable},
+		{name: "alter table", input: "ALTER TABLE |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "alter drop column", input: "ALTER TABLE employees DROP COLUMN |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "drop table", input: "DROP TABLE |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "drop view", input: "DROP VIEW |", rule: "table_ref", kind: ObjectKindView},
+		{name: "drop sequence", input: "DROP SEQUENCE |", rule: "sequence_ref", kind: ObjectKindSequence},
+		{name: "truncate table", input: "TRUNCATE TABLE |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "comment table", input: "COMMENT ON TABLE |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "comment column", input: "COMMENT ON COLUMN employees.|", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "grant on object", input: "GRANT SELECT ON |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "revoke on object", input: "REVOKE SELECT ON |", rule: "table_ref", kind: ObjectKindTable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireCompletionRule(t, ctx.Candidates, tt.rule)
+			requireObjectKind(t, ctx.Intent, tt.kind)
+			for _, ref := range tt.refs {
+				requireRangeReference(t, ctx.Scope, ref)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionAlterTableAddCandidates(t *testing.T) {
+	ctx := collectCompletionMarked(t, "ALTER TABLE employees ADD |")
+	for _, tok := range []int{kwCOLUMN, kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN, kwCHECK} {
+		if !ctx.Candidates.HasToken(tok) {
+			t.Fatalf("missing ALTER TABLE ADD candidate %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+		}
+	}
+}
+
+func TestOracleCompletionObjectKindSpecificDDL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      ObjectKind
+		notWanted ObjectKind
+	}{
+		{name: "drop table", input: "DROP TABLE |", want: ObjectKindTable, notWanted: ObjectKindView},
+		{name: "drop view", input: "DROP VIEW |", want: ObjectKindView, notWanted: ObjectKindTable},
+		{name: "comment table", input: "COMMENT ON TABLE |", want: ObjectKindTable, notWanted: ObjectKindSequence},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireObjectKind(t, ctx.Intent, tt.want)
+			if hasObjectKind(ctx.Intent, tt.notWanted) {
+				t.Fatalf("intent kinds = %v, should not include %v", ctx.Intent.ObjectKinds, tt.notWanted)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionKeywordDrivenCandidates(t *testing.T) {
+	t.Run("datatype context", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "CREATE TABLE employees (name |)")
+		for _, tok := range []int{kwNUMBER, kwVARCHAR2, kwDATE, kwTIMESTAMP} {
+			if !ctx.Candidates.HasToken(tok) {
+				t.Fatalf("missing datatype candidate %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+			}
+		}
+	})
+
+	t.Run("expression context", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "SELECT | FROM dual")
+		for _, tok := range []int{kwCAST, kwDECODE, kwJSON_VALUE, kwROWNUM, kwSYSDATE} {
+			if !ctx.Candidates.HasToken(tok) {
+				t.Fatalf("missing expression candidate %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+			}
+		}
+	})
+}
+
+func collectCompletionMarked(t *testing.T, input string) *CompletionContext {
+	t.Helper()
+	cursor := strings.Index(input, "|")
+	if cursor < 0 {
+		t.Fatalf("input %q has no cursor marker", input)
+	}
+	sql := strings.Replace(input, "|", "", 1)
+	ctx := CollectCompletion(sql, cursor)
+	if ctx == nil {
+		t.Fatal("CollectCompletion returned nil")
+	}
+	if ctx.Candidates == nil {
+		t.Fatal("CollectCompletion returned nil Candidates")
+	}
+	if ctx.Scope == nil {
+		t.Fatal("CollectCompletion returned nil Scope")
+	}
+	return ctx
+}
+
+func requireCompletionRule(t *testing.T, cs *CandidateSet, rule string) {
+	t.Helper()
+	if !cs.HasRule(rule) {
+		t.Fatalf("missing rule %q; got rules=%v tokens=%v", rule, cs.Rules, tokenNamesForTest(cs.Tokens))
+	}
+}
+
+func requireObjectKind(t *testing.T, intent *CompletionIntent, kind ObjectKind) {
+	t.Helper()
+	if intent == nil {
+		t.Fatalf("nil completion intent; want kind %v", kind)
+	}
+	for _, got := range intent.ObjectKinds {
+		if got == kind {
+			return
+		}
+	}
+	t.Fatalf("intent kinds = %v, want %v", intent.ObjectKinds, kind)
+}
+
+func hasObjectKind(intent *CompletionIntent, kind ObjectKind) bool {
+	if intent == nil {
+		return false
+	}
+	for _, got := range intent.ObjectKinds {
+		if got == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func requireRangeReference(t *testing.T, scope *ScopeSnapshot, aliasOrName string) {
+	t.Helper()
+	_ = findRangeReference(t, scope, aliasOrName)
+}
+
+func findRangeReference(t *testing.T, scope *ScopeSnapshot, aliasOrName string) RangeReference {
+	t.Helper()
+	for _, ref := range scope.References {
+		if strings.EqualFold(ref.Alias, aliasOrName) || strings.EqualFold(ref.Name, aliasOrName) {
+			return ref
+		}
+	}
+	t.Fatalf("missing range reference %q in %#v", aliasOrName, scope.References)
+	return RangeReference{}
+}
+
+func requireColumnName(t *testing.T, columns []string, want string) {
+	t.Helper()
+	for _, got := range columns {
+		if strings.EqualFold(got, want) {
+			return
+		}
+	}
+	t.Fatalf("missing column %q in %v", want, columns)
+}

--- a/oracle/parser/complete_expansion_test.go
+++ b/oracle/parser/complete_expansion_test.go
@@ -1,0 +1,247 @@
+package parser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestOracleCompletionSelectExpansionSignals(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		rule   string
+		kind   ObjectKind
+		tokens []int
+		refs   []string
+	}{
+		{name: "target comma", input: "SELECT a, | FROM employees", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "distinct target", input: "SELECT DISTINCT | FROM employees", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "from comma", input: "SELECT * FROM employees, |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "left join", input: "SELECT * FROM employees e LEFT JOIN |", rule: "table_ref", kind: ObjectKindTable, refs: []string{"e"}},
+		{name: "right join", input: "SELECT * FROM employees e RIGHT JOIN |", rule: "table_ref", kind: ObjectKindTable, refs: []string{"e"}},
+		{name: "full outer join", input: "SELECT * FROM employees e FULL OUTER JOIN |", rule: "table_ref", kind: ObjectKindTable, refs: []string{"e"}},
+		{name: "cross join", input: "SELECT * FROM employees e CROSS JOIN |", rule: "table_ref", kind: ObjectKindTable, refs: []string{"e"}},
+		{name: "natural join", input: "SELECT * FROM employees e NATURAL JOIN |", rule: "table_ref", kind: ObjectKindTable, refs: []string{"e"}},
+		{name: "join using", input: "SELECT * FROM employees e JOIN departments d USING (|", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e", "d"}},
+		{name: "where and", input: "SELECT * FROM employees e WHERE id = 1 AND |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "where or", input: "SELECT * FROM employees e WHERE id = 1 OR |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "where operator", input: "SELECT * FROM employees e WHERE salary + | > 0", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "in list", input: "SELECT * FROM employees e WHERE id IN (|", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "between start", input: "SELECT * FROM employees e WHERE salary BETWEEN |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "between end", input: "SELECT * FROM employees e WHERE salary BETWEEN 1 AND |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "exists subquery", input: "SELECT * FROM employees e WHERE EXISTS (|", tokens: []int{SELECT}, refs: []string{"e"}},
+		{name: "group comma", input: "SELECT id FROM employees e GROUP BY id, |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "having", input: "SELECT id FROM employees e GROUP BY id HAVING |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "order comma", input: "SELECT id FROM employees e ORDER BY id, |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"e"}},
+		{name: "from table clause keywords", input: "SELECT * FROM employees |", tokens: []int{WHERE, JOIN, GROUP, ORDER}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			if tt.rule != "" {
+				requireCompletionRule(t, ctx.Candidates, tt.rule)
+			}
+			if tt.kind != ObjectKindUnknown {
+				requireObjectKind(t, ctx.Intent, tt.kind)
+			}
+			for _, tok := range tt.tokens {
+				if !ctx.Candidates.HasToken(tok) {
+					t.Fatalf("missing token %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+				}
+			}
+			for _, ref := range tt.refs {
+				requireRangeReference(t, ctx.Scope, ref)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionScopeExpansion(t *testing.T) {
+	t.Run("incomplete join keeps left scope", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "SELECT * FROM employees e JOIN |")
+		if got, want := oracleRefNames(ctx.Scope.LocalReferences), []string{"e"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("local refs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("subquery inner table does not leak into outer table refs", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "SELECT | FROM (SELECT salary FROM payroll) p")
+		if got, want := oracleRefNames(ctx.Scope.LocalReferences), []string{"p"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("local refs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("nested subquery records outer references", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "SELECT * FROM employees e WHERE EXISTS (SELECT | FROM departments d WHERE d.id = e.id)")
+		if got, want := oracleRefNames(ctx.Scope.LocalReferences), []string{"d"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("local refs = %v, want %v", got, want)
+		}
+		if len(ctx.Scope.OuterReferences) != 1 {
+			t.Fatalf("outer reference levels = %d, want 1", len(ctx.Scope.OuterReferences))
+		}
+		if got, want := oracleRefNames(ctx.Scope.OuterReferences[0]), []string{"e"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("outer refs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("union uses current arm scope", func(t *testing.T) {
+		ctx := collectCompletionMarked(t, "SELECT id FROM employees UNION SELECT | FROM departments")
+		if got, want := oracleRefNames(ctx.Scope.LocalReferences), []string{"departments"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("local refs = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestOracleCompletionDMLExpansionSignals(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		refs  []string
+	}{
+		{name: "insert column comma", input: "INSERT INTO employees (id, |)", refs: []string{"employees"}},
+		{name: "insert values comma", input: "INSERT INTO employees VALUES (1, |)", refs: []string{"employees"}},
+		{name: "insert select with cte", input: "WITH x AS (SELECT id FROM departments) INSERT INTO employees SELECT | FROM x", refs: []string{"x"}},
+		{name: "update assignment comma", input: "UPDATE employees SET id = 1, |", refs: []string{"employees"}},
+		{name: "merge update set", input: "MERGE INTO employees e USING departments d ON e.id = d.id WHEN MATCHED THEN UPDATE SET name = |", refs: []string{"e", "d"}},
+		{name: "merge insert column list", input: "MERGE INTO employees e USING departments d ON e.id = d.id WHEN NOT MATCHED THEN INSERT (|)", refs: []string{"e", "d"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireCompletionRule(t, ctx.Candidates, "columnref")
+			requireObjectKind(t, ctx.Intent, ObjectKindColumn)
+			for _, ref := range tt.refs {
+				requireRangeReference(t, ctx.Scope, ref)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionDDLExpansionSignals(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		rule   string
+		kind   ObjectKind
+		tokens []int
+		refs   []string
+	}{
+		{name: "create table column comma", input: "CREATE TABLE t (id NUMBER, |)", tokens: []int{kwCONSTRAINT, kwPRIMARY, kwUNIQUE, kwFOREIGN, kwCHECK}},
+		{name: "create table column options", input: "CREATE TABLE t (id NUMBER |)", tokens: []int{kwNOT, kwNULL, kwDEFAULT, kwPRIMARY, kwUNIQUE, kwREFERENCES, kwCHECK}},
+		{name: "primary key columns", input: "CREATE TABLE t (id NUMBER, CONSTRAINT pk PRIMARY KEY (|))", rule: "columnref", kind: ObjectKindColumn, refs: []string{"t"}},
+		{name: "foreign key columns", input: "CREATE TABLE t (dept_id NUMBER, FOREIGN KEY (|) REFERENCES departments(id))", rule: "columnref", kind: ObjectKindColumn, refs: []string{"t"}},
+		{name: "referenced columns", input: "CREATE TABLE t (dept_id NUMBER REFERENCES departments(|))", rule: "columnref", kind: ObjectKindColumn, refs: []string{"departments"}},
+		{name: "alter modify column", input: "ALTER TABLE employees MODIFY |", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "alter drop constraint", input: "ALTER TABLE employees DROP CONSTRAINT |", rule: "constraint_ref", kind: ObjectKindConstraint, refs: []string{"employees"}},
+		{name: "create index table", input: "CREATE INDEX idx ON |", rule: "table_ref", kind: ObjectKindTable},
+		{name: "create index columns", input: "CREATE INDEX idx ON employees (|)", rule: "columnref", kind: ObjectKindColumn, refs: []string{"employees"}},
+		{name: "drop index", input: "DROP INDEX |", rule: "index_ref", kind: ObjectKindIndex},
+		{name: "drop synonym", input: "DROP SYNONYM |", rule: "synonym_ref", kind: ObjectKindSynonym},
+		{name: "drop trigger", input: "DROP TRIGGER |", rule: "trigger_ref", kind: ObjectKindTrigger},
+		{name: "alter sequence", input: "ALTER SEQUENCE |", rule: "sequence_ref", kind: ObjectKindSequence},
+		{name: "alter view", input: "ALTER VIEW |", rule: "table_ref", kind: ObjectKindView},
+		{name: "alter procedure", input: "ALTER PROCEDURE |", rule: "proc_ref", kind: ObjectKindProcedure},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			if tt.rule != "" {
+				requireCompletionRule(t, ctx.Candidates, tt.rule)
+			}
+			if tt.kind != ObjectKindUnknown {
+				requireObjectKind(t, ctx.Intent, tt.kind)
+			}
+			for _, tok := range tt.tokens {
+				if !ctx.Candidates.HasToken(tok) {
+					t.Fatalf("missing token %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+				}
+			}
+			for _, ref := range tt.refs {
+				requireRangeReference(t, ctx.Scope, ref)
+			}
+		})
+	}
+}
+
+func TestOracleCompletionOracleSpecificSignals(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		rule      string
+		kind      ObjectKind
+		qualifier MultipartName
+		tokens    []int
+	}{
+		{name: "sequence nextval member", input: "SELECT seq.| FROM dual", rule: "sequence_member_ref", kind: ObjectKindSequence, qualifier: MultipartName{Object: "seq"}},
+		{name: "schema package member", input: "SELECT pkg.| FROM dual", rule: "package_member_ref", kind: ObjectKindPackageMember, qualifier: MultipartName{Object: "pkg"}},
+		{name: "package procedure call", input: "BEGIN pkg.|; END;", rule: "package_member_ref", kind: ObjectKindPackageMember, qualifier: MultipartName{Object: "pkg"}},
+		{name: "table db link", input: "SELECT * FROM employees@|", rule: "database_link_ref", kind: ObjectKindDatabaseLink},
+		{name: "select into variable", input: "SELECT id INTO | FROM employees", rule: "variable_ref", kind: ObjectKindVariable},
+		{name: "plsql declaration type", input: "DECLARE v |; BEGIN NULL; END;", rule: "type_name", kind: ObjectKindType},
+		{name: "plsql block statement", input: "BEGIN | END;", tokens: []int{SELECT, INSERT, UPDATE, DELETE}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			if tt.rule != "" {
+				requireCompletionRule(t, ctx.Candidates, tt.rule)
+			}
+			if tt.kind != ObjectKindUnknown {
+				requireObjectKind(t, ctx.Intent, tt.kind)
+			}
+			if tt.qualifier != (MultipartName{}) && !equalMultipartNameFold(ctx.Intent.Qualifier, tt.qualifier) {
+				t.Fatalf("qualifier = %+v, want %+v", ctx.Intent.Qualifier, tt.qualifier)
+			}
+			for _, tok := range tt.tokens {
+				if !ctx.Candidates.HasToken(tok) {
+					t.Fatalf("missing token %q; got %v", TokenName(tok), tokenNamesForTest(ctx.Candidates.Tokens))
+				}
+			}
+		})
+	}
+}
+
+func TestOracleCompletionPrefixExpansion(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		rule      string
+		prefix    string
+		qualifier MultipartName
+	}{
+		{name: "table prefix", input: "SELECT * FROM emp|", rule: "table_ref", prefix: "emp"},
+		{name: "schema table prefix", input: "SELECT * FROM hr.emp|", rule: "table_ref", prefix: "emp", qualifier: MultipartName{Schema: "hr"}},
+		{name: "column prefix", input: "SELECT e.na| FROM employees e", rule: "columnref", prefix: "na", qualifier: MultipartName{Object: "e"}},
+		{name: "quoted table prefix", input: "SELECT * FROM \"Camel|", rule: "table_ref", prefix: "Camel"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := collectCompletionMarked(t, tt.input)
+			requireCompletionRule(t, ctx.Candidates, tt.rule)
+			if ctx.Prefix != tt.prefix {
+				t.Fatalf("prefix = %q, want %q", ctx.Prefix, tt.prefix)
+			}
+			if tt.qualifier != (MultipartName{}) && !equalMultipartNameFold(ctx.Intent.Qualifier, tt.qualifier) {
+				t.Fatalf("qualifier = %+v, want %+v", ctx.Intent.Qualifier, tt.qualifier)
+			}
+		})
+	}
+}
+
+func oracleRefNames(refs []RangeReference) []string {
+	var names []string
+	for _, ref := range refs {
+		if ref.Alias != "" {
+			names = append(names, strings.ToLower(ref.Alias))
+			continue
+		}
+		names = append(names, strings.ToLower(ref.Name))
+	}
+	return names
+}
+
+func equalMultipartNameFold(got MultipartName, want MultipartName) bool {
+	return strings.EqualFold(got.Schema, want.Schema) && strings.EqualFold(got.Object, want.Object)
+}

--- a/oracle/parser/complete_expansion_test.go
+++ b/oracle/parser/complete_expansion_test.go
@@ -174,7 +174,7 @@ func TestOracleCompletionOracleSpecificSignals(t *testing.T) {
 		qualifier MultipartName
 		tokens    []int
 	}{
-		{name: "sequence nextval member", input: "SELECT seq.| FROM dual", rule: "sequence_member_ref", kind: ObjectKindSequence, qualifier: MultipartName{Object: "seq"}},
+		{name: "sequence nextval member", input: "SELECT seq.| FROM dual", rule: "sequence_member_ref", kind: ObjectKindSequenceMember, qualifier: MultipartName{Object: "seq"}},
 		{name: "schema package member", input: "SELECT pkg.| FROM dual", rule: "package_member_ref", kind: ObjectKindPackageMember, qualifier: MultipartName{Object: "pkg"}},
 		{name: "package procedure call", input: "BEGIN pkg.|; END;", rule: "package_member_ref", kind: ObjectKindPackageMember, qualifier: MultipartName{Object: "pkg"}},
 		{name: "table db link", input: "SELECT * FROM employees@|", rule: "database_link_ref", kind: ObjectKindDatabaseLink},

--- a/oracle/parser/complete_test.go
+++ b/oracle/parser/complete_test.go
@@ -1,0 +1,68 @@
+package parser
+
+import "testing"
+
+func TestOracleCompletionAPIStatementStarters(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		pos  int
+	}{
+		{name: "empty", sql: "", pos: 0},
+		{name: "whitespace", sql: " \n\t", pos: 3},
+		{name: "after semicolon", sql: "SELECT 1 FROM dual; ", pos: len("SELECT 1 FROM dual; ")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := Collect(tt.sql, tt.pos)
+			if cs == nil {
+				t.Fatal("Collect returned nil")
+			}
+			for _, tok := range []int{SELECT, INSERT, UPDATE, DELETE, MERGE, CREATE, ALTER, DROP} {
+				if !cs.HasToken(tok) {
+					t.Fatalf("missing statement starter %q; got tokens=%v rules=%v", TokenName(tok), tokenNamesForTest(cs.Tokens), cs.Rules)
+				}
+			}
+		})
+	}
+}
+
+func TestOracleCompletionAPITokenizeAndTokenName(t *testing.T) {
+	tokens := Tokenize("SELECT * FROM dual")
+	if len(tokens) != 4 {
+		t.Fatalf("Tokenize returned %d tokens, want 4: %#v", len(tokens), tokens)
+	}
+	if tokens[0].Type != SELECT || tokens[0].Loc != 0 || tokens[0].End != len("SELECT") {
+		t.Fatalf("first token = %#v, want SELECT at [0,%d)", tokens[0], len("SELECT"))
+	}
+	if got := TokenName(SELECT); got != "SELECT" {
+		t.Fatalf("TokenName(SELECT) = %q, want SELECT", got)
+	}
+	if got := TokenName(tokIDENT); got != "" {
+		t.Fatalf("TokenName(tokIDENT) = %q, want empty", got)
+	}
+}
+
+func TestOracleCompletionAPIPrefixRetry(t *testing.T) {
+	sql := "SEL"
+	cs := Collect(sql, len(sql))
+	if cs == nil {
+		t.Fatal("Collect returned nil")
+	}
+	if !cs.HasToken(SELECT) {
+		t.Fatalf("missing SELECT for partial keyword; got tokens=%v rules=%v", tokenNamesForTest(cs.Tokens), cs.Rules)
+	}
+}
+
+func tokenNamesForTest(tokens []int) []string {
+	result := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		name := TokenName(tok)
+		if name == "" && tok > 0 && tok < 256 {
+			name = string(rune(tok))
+		}
+		result = append(result, name)
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- Add parser-native Oracle completion context for Bytebase: candidates, prefix, scope, CTEs, and object intent.
- Cover SELECT, CTE/subquery scope, DML, DDL, PL/SQL, package/sequence member, database-link, prefix, and Oracle-specific completion scenarios.
- Document the expanded production scenario matrix for Oracle completion.

## Test Plan
- `go test ./oracle/parser -count=1`
- Bytebase integration checked separately with `go test ./backend/plugin/parser/plsql -count=1` after bumping to this omni commit.
