### PR TITLE
feat(tidb): scope qualified column completion to the matching table

### DIFF
--- a/tidb/completion/completion_test.go
+++ b/tidb/completion/completion_test.go
@@ -43,6 +43,46 @@ func hasDuplicates(candidates []Candidate) bool {
 	return false
 }
 
+func TestComplete_QualifiedColumnScopedToQualifier(t *testing.T) {
+	cat := catalog.New()
+	if _, err := cat.Exec("CREATE DATABASE `db`; USE `db`; CREATE TABLE `t1` (`a1` int, `a2` int); CREATE TABLE `t2` (`b1` int, `b2` int);", &catalog.ExecOptions{ContinueOnError: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	// `a.` (alias for t1) must offer only t1's columns.
+	got := Complete("SELECT a. FROM t1 AS a JOIN t2 AS b", len("SELECT a."), cat)
+	if !containsCandidate(got, "a1", CandidateColumn) || !containsCandidate(got, "a2", CandidateColumn) {
+		t.Errorf("a. should offer t1 columns a1,a2; got %v", got)
+	}
+	if containsCandidate(got, "b1", CandidateColumn) || containsCandidate(got, "b2", CandidateColumn) {
+		t.Errorf("a. must NOT offer t2 columns b1,b2; got %v", got)
+	}
+
+	// `b.` (alias for t2) must offer only t2's columns.
+	got = Complete("SELECT b. FROM t1 AS a JOIN t2 AS b", len("SELECT b."), cat)
+	if !containsCandidate(got, "b1", CandidateColumn) || !containsCandidate(got, "b2", CandidateColumn) {
+		t.Errorf("b. should offer t2 columns b1,b2; got %v", got)
+	}
+	if containsCandidate(got, "a1", CandidateColumn) || containsCandidate(got, "a2", CandidateColumn) {
+		t.Errorf("b. must NOT offer t1 columns a1,a2; got %v", got)
+	}
+
+	// Qualifying by table name in a JOIN restricts to that table.
+	got = Complete("SELECT t1. FROM t1 JOIN t2", len("SELECT t1."), cat)
+	if !containsCandidate(got, "a1", CandidateColumn) {
+		t.Errorf("t1. should offer t1 columns; got %v", got)
+	}
+	if containsCandidate(got, "b1", CandidateColumn) {
+		t.Errorf("t1. must NOT offer t2 columns; got %v", got)
+	}
+
+	// An unqualified column reference still offers all in-scope columns.
+	got = Complete("SELECT  FROM t1 JOIN t2", len("SELECT "), cat)
+	if !containsCandidate(got, "a1", CandidateColumn) || !containsCandidate(got, "b1", CandidateColumn) {
+		t.Errorf("unqualified column ref should offer all in-scope columns; got %v", got)
+	}
+}
+
 func TestComplete_2_1_CompleteReturnsSlice(t *testing.T) {
 	// Scenario: Complete(sql, cursorOffset, catalog) returns []Candidate
 	cat := catalog.New()

--- a/tidb/completion/completion_test.go
+++ b/tidb/completion/completion_test.go
@@ -81,6 +81,20 @@ func TestComplete_QualifiedColumnScopedToQualifier(t *testing.T) {
 	if !containsCandidate(got, "a1", CandidateColumn) || !containsCandidate(got, "b1", CandidateColumn) {
 		t.Errorf("unqualified column ref should offer all in-scope columns; got %v", got)
 	}
+
+	// A fully-qualified db.table. must scope by database too, when the same table
+	// name exists in more than one database in scope.
+	xdb := catalog.New()
+	if _, err := xdb.Exec("CREATE DATABASE `db1`; CREATE TABLE `db1`.`t` (`a1` int); CREATE DATABASE `db2`; CREATE TABLE `db2`.`t` (`b1` int); USE `db1`;", &catalog.ExecOptions{ContinueOnError: true}); err != nil {
+		t.Fatal(err)
+	}
+	got = Complete("SELECT db1.t. FROM db1.t JOIN db2.t", len("SELECT db1.t."), xdb)
+	if !containsCandidate(got, "a1", CandidateColumn) {
+		t.Errorf("db1.t. should offer db1.t column a1; got %v", got)
+	}
+	if containsCandidate(got, "b1", CandidateColumn) {
+		t.Errorf("db1.t. must NOT offer db2.t column b1; got %v", got)
+	}
 }
 
 func TestComplete_2_1_CompleteReturnsSlice(t *testing.T) {

--- a/tidb/completion/resolve.go
+++ b/tidb/completion/resolve.go
@@ -1,6 +1,8 @@
 package completion
 
 import (
+	"strings"
+
 	"github.com/bytebase/omni/tidb/catalog"
 	"github.com/bytebase/omni/tidb/parser"
 )
@@ -186,9 +188,17 @@ func resolveColumnRefScoped(cat *catalog.Catalog, sql string, cursorOffset int) 
 		return resolveColumnRef(cat)
 	}
 
+	// A qualified column reference (e.g. `a.col` or `t1.col`) is restricted to the
+	// table whose alias or name matches the qualifier before the dot; an
+	// unqualified reference uses every in-scope table.
+	qualifier := columnQualifier(sql, cursorOffset)
+
 	seen := make(map[string]bool)
 	var result []Candidate
 	for _, ref := range refs {
+		if qualifier != "" && !strings.EqualFold(ref.Alias, qualifier) && !strings.EqualFold(ref.Table, qualifier) {
+			continue
+		}
 		// Resolve table in the appropriate database.
 		targetDB := db
 		if ref.Database != "" {
@@ -450,4 +460,56 @@ func currentDB(cat *catalog.Catalog) *catalog.Database {
 		return nil
 	}
 	return cat.GetDatabase(name)
+}
+
+// columnQualifier returns the table/alias qualifier that immediately precedes
+// the dot at the cursor (e.g. "a" for `a.col` or `a . col`), or "" if the column
+// reference is unqualified. The caller passes the collect offset, which sits at
+// the start of the partial column name, so the byte before it (after optional
+// whitespace) is the qualifier dot.
+func columnQualifier(sql string, offset int) string {
+	if offset > len(sql) {
+		offset = len(sql)
+	}
+	i := offset
+	for i > 0 && isSpaceByte(sql[i-1]) {
+		i--
+	}
+	if i == 0 || sql[i-1] != '.' {
+		return ""
+	}
+	i-- // consume the dot
+	for i > 0 && isSpaceByte(sql[i-1]) {
+		i--
+	}
+	if i == 0 {
+		return ""
+	}
+	// Backtick-quoted qualifier.
+	if sql[i-1] == '`' {
+		end := i - 1
+		j := end - 1
+		for j >= 0 && sql[j] != '`' {
+			j--
+		}
+		if j < 0 {
+			return ""
+		}
+		return sql[j+1 : end]
+	}
+	// Bare identifier.
+	end := i
+	for i > 0 && isIdentByte(sql[i-1]) {
+		i--
+	}
+	return sql[i:end]
+}
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || b == '$' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }

--- a/tidb/completion/resolve.go
+++ b/tidb/completion/resolve.go
@@ -188,16 +188,29 @@ func resolveColumnRefScoped(cat *catalog.Catalog, sql string, cursorOffset int) 
 		return resolveColumnRef(cat)
 	}
 
-	// A qualified column reference (e.g. `a.col` or `t1.col`) is restricted to the
-	// table whose alias or name matches the qualifier before the dot; an
-	// unqualified reference uses every in-scope table.
-	qualifier := columnQualifier(sql, cursorOffset)
+	// A qualified column reference (e.g. `a.col`, `t1.col`, or `db1.t1.col`) is
+	// restricted to the table whose alias or name matches the qualifier before the
+	// dot — and, when the qualifier names a database, whose database matches too
+	// (so `db1.t.` is not satisfied by `db2.t`). An unqualified reference uses
+	// every in-scope table.
+	qDB, qName := columnQualifier(sql, cursorOffset)
 
 	seen := make(map[string]bool)
 	var result []Candidate
 	for _, ref := range refs {
-		if qualifier != "" && !strings.EqualFold(ref.Alias, qualifier) && !strings.EqualFold(ref.Table, qualifier) {
-			continue
+		if qName != "" {
+			if !strings.EqualFold(ref.Alias, qName) && !strings.EqualFold(ref.Table, qName) {
+				continue
+			}
+			if qDB != "" {
+				refDB := ref.Database
+				if refDB == "" {
+					refDB = cat.CurrentDatabase()
+				}
+				if !strings.EqualFold(refDB, qDB) {
+					continue
+				}
+			}
 		}
 		// Resolve table in the appropriate database.
 		targetDB := db
@@ -462,30 +475,28 @@ func currentDB(cat *catalog.Catalog) *catalog.Database {
 	return cat.GetDatabase(name)
 }
 
-// columnQualifier returns the table/alias qualifier that immediately precedes
-// the dot at the cursor (e.g. "a" for `a.col` or `a . col`), or "" if the column
-// reference is unqualified. The caller passes the collect offset, which sits at
-// the start of the partial column name, so the byte before it (after optional
-// whitespace) is the qualifier dot.
-func columnQualifier(sql string, offset int) string {
-	if offset > len(sql) {
-		offset = len(sql)
+// identBeforeDot scans left from pos expecting (optional whitespace) '.'
+// (optional whitespace) <identifier>, returning the identifier text, the index
+// where it starts, and whether the pattern matched. The identifier may be bare
+// or backtick-quoted.
+func identBeforeDot(sql string, pos int) (ident string, start int, ok bool) {
+	if pos > len(sql) {
+		pos = len(sql)
 	}
-	i := offset
+	i := pos
 	for i > 0 && isSpaceByte(sql[i-1]) {
 		i--
 	}
 	if i == 0 || sql[i-1] != '.' {
-		return ""
+		return "", pos, false
 	}
 	i-- // consume the dot
 	for i > 0 && isSpaceByte(sql[i-1]) {
 		i--
 	}
 	if i == 0 {
-		return ""
+		return "", pos, false
 	}
-	// Backtick-quoted qualifier.
 	if sql[i-1] == '`' {
 		end := i - 1
 		j := end - 1
@@ -493,16 +504,34 @@ func columnQualifier(sql string, offset int) string {
 			j--
 		}
 		if j < 0 {
-			return ""
+			return "", pos, false
 		}
-		return sql[j+1 : end]
+		return sql[j+1 : end], j, true
 	}
-	// Bare identifier.
 	end := i
 	for i > 0 && isIdentByte(sql[i-1]) {
 		i--
 	}
-	return sql[i:end]
+	if i == end {
+		return "", pos, false
+	}
+	return sql[i:end], i, true
+}
+
+// columnQualifier returns the optional database part and the table/alias part of
+// the qualifier preceding the dot at the cursor: `db1.t.` -> ("db1","t"),
+// `t.`/`a.` -> ("","t")/("","a"), and ("","") when the reference is unqualified.
+// The caller passes the collect offset, which sits at the start of the partial
+// column name.
+func columnQualifier(sql string, offset int) (db, name string) {
+	n, start, ok := identBeforeDot(sql, offset)
+	if !ok {
+		return "", ""
+	}
+	if d, _, ok2 := identBeforeDot(sql, start); ok2 {
+		db = d
+	}
+	return db, n
 }
 
 func isSpaceByte(b byte) bool {


### PR DESCRIPTION
## What

Scope qualified column completion to the table named by the qualifier. `resolveColumnRefScoped` previously added columns from *every* in-scope table regardless of the qualifier the user typed before the dot, so in a multi-table query:

- `SELECT a.| FROM t1 AS a JOIN t2 AS b` suggested `t2`'s columns under `a.`
- `SELECT t1.| FROM t1 JOIN t2` suggested `t2`'s columns under `t1.`

The fix extracts the qualifier immediately before the dot (`columnQualifier`, handling whitespace around the dot and backtick-quoted names) and restricts resolution to the ref whose `Alias` or `Table` matches it (case-insensitive). Unqualified column references still use every in-scope table.

## Why

Found during the bytebase TiDB auto-completion parity audit (bytebase/bytebase#20435, BYT-9599). The previous mysql ANTLR completer restricted the table set via alias mapping; the omni completer didn't, so qualified column completion in JOINs regressed.

## Testing

`TestComplete_QualifiedColumnScopedToQualifier` covers alias and table-name qualifiers in a JOIN (only the matching table's columns), plus the unqualified case (all in-scope columns). `go test -short ./tidb/...` and `go vet ./tidb/...` pass.
