### PR TITLE
fix(tidb): an unknown column qualifier returns no columns, not all

### DIFF
--- a/tidb/completion/completion_test.go
+++ b/tidb/completion/completion_test.go
@@ -95,6 +95,21 @@ func TestComplete_QualifiedColumnScopedToQualifier(t *testing.T) {
 	if containsCandidate(got, "b1", CandidateColumn) {
 		t.Errorf("db1.t. must NOT offer db2.t column b1; got %v", got)
 	}
+
+	// An unknown / unmatched qualifier must narrow to no columns, not broaden to
+	// all in-scope columns.
+	got = Complete("SELECT x. FROM t1 AS a JOIN t2 AS b", len("SELECT x."), cat)
+	if containsCandidate(got, "a1", CandidateColumn) || containsCandidate(got, "b1", CandidateColumn) {
+		t.Errorf("unknown alias x. must offer no columns; got %v", got)
+	}
+	got = Complete("SELECT t3. FROM t1 JOIN t2", len("SELECT t3."), cat)
+	if containsCandidate(got, "a1", CandidateColumn) || containsCandidate(got, "b1", CandidateColumn) {
+		t.Errorf("unknown table t3. must offer no columns; got %v", got)
+	}
+	got = Complete("SELECT ghost.t. FROM db1.t JOIN db2.t", len("SELECT ghost.t."), xdb)
+	if containsCandidate(got, "a1", CandidateColumn) || containsCandidate(got, "b1", CandidateColumn) {
+		t.Errorf("unknown database ghost.t. must offer no columns; got %v", got)
+	}
 }
 
 func TestComplete_2_1_CompleteReturnsSlice(t *testing.T) {

--- a/tidb/completion/resolve.go
+++ b/tidb/completion/resolve.go
@@ -183,17 +183,22 @@ func resolveColumnRefScoped(cat *catalog.Catalog, sql string, cursorOffset int) 
 		return nil
 	}
 
-	refs := extractTableRefs(sql, cursorOffset)
-	if len(refs) == 0 {
-		return resolveColumnRef(cat)
-	}
-
 	// A qualified column reference (e.g. `a.col`, `t1.col`, or `db1.t1.col`) is
 	// restricted to the table whose alias or name matches the qualifier before the
 	// dot — and, when the qualifier names a database, whose database matches too
 	// (so `db1.t.` is not satisfied by `db2.t`). An unqualified reference uses
 	// every in-scope table.
 	qDB, qName := columnQualifier(sql, cursorOffset)
+
+	refs := extractTableRefs(sql, cursorOffset)
+	if len(refs) == 0 {
+		// With no table refs in scope, an unqualified reference falls back to all
+		// columns; a qualified one has nothing to resolve against.
+		if qName != "" {
+			return nil
+		}
+		return resolveColumnRef(cat)
+	}
 
 	seen := make(map[string]bool)
 	var result []Candidate
@@ -245,9 +250,10 @@ func resolveColumnRefScoped(cat *catalog.Catalog, sql string, cursorOffset int) 
 			}
 		}
 	}
-	// If we found refs but couldn't resolve any columns (e.g. CTE name not
-	// matching any catalog table), fall back to all columns.
-	if len(result) == 0 {
+	// An unqualified reference that resolved nothing (e.g. a CTE name with no
+	// catalog match) falls back to all columns; a qualified reference that matched
+	// no table returns no columns rather than broadening to everything.
+	if len(result) == 0 && qName == "" {
 		return resolveColumnRef(cat)
 	}
 	return result

--- a/tidb/completion/resolve.go
+++ b/tidb/completion/resolve.go
@@ -171,9 +171,11 @@ func resolveTableRef(cat *catalog.Catalog) []Candidate {
 	return result
 }
 
-// resolveColumnRefScoped returns columns scoped to the tables referenced in
-// the SQL statement. If no table refs are found, falls back to all columns
-// in the current database.
+// resolveColumnRefScoped returns columns scoped to the tables referenced in the
+// SQL statement. An unqualified reference falls back to all columns in the
+// current database when nothing else resolves; a qualified reference (e.g.
+// `a.col`) is restricted to the matching table and returns no columns when the
+// qualifier matches no in-scope table.
 func resolveColumnRefScoped(cat *catalog.Catalog, sql string, cursorOffset int) []Candidate {
 	if cat == nil {
 		return nil


### PR DESCRIPTION
## What

A qualified column reference with an *unknown* qualifier now returns no column candidates instead of broadening to every in-scope column.

`resolveColumnRefScoped` fell back to all current-database columns whenever no ref matched, so:

- `SELECT x.| FROM t1 AS a JOIN t2 AS b` (unknown alias)
- `SELECT t3.| FROM t1 JOIN t2` (unknown table)
- `SELECT ghost.t.| FROM db1.t JOIN db2.t` (unknown database)

all returned every column. The qualifier is now computed before the fallbacks, and the all-columns fallback only fires for *unqualified* references; a qualified reference that matches no table returns nothing. Unqualified behavior (including the CTE/derived all-columns best-effort) is unchanged.

## Why

Follow-up to #161; surfaced in the bytebase TiDB completion review (bytebase/bytebase#20435, BYT-9599). A mistyped qualifier should narrow to nothing, matching the prior mysql completer (which returns `[]`).

## Testing

Extended `TestComplete_QualifiedColumnScopedToQualifier` with unknown-alias / unknown-table / unknown-database negatives. `go test -short ./tidb/...` and `go vet ./tidb/...` pass.
