### PR TITLE
fix(oracle): parse shorthand virtual columns

### DIFF
--- a/oracle/parser/create_table.go
+++ b/oracle/parser/create_table.go
@@ -709,6 +709,17 @@ func (p *Parser) parseColumnProperties(col *nodes.ColumnDef) error {
 				return p.syntaxErrorAtCur()
 			}
 
+		case kwAS:
+			// GENERATED ALWAYS is optional for Oracle virtual columns.
+			next := p.peekNext()
+			if next.Type != '(' {
+				return nil
+			}
+			p.advance() // consume AS
+			if err := p.parseVirtualColumnExpression(col); err != nil {
+				return err
+			}
+
 		case kwGENERATED:
 			// identity_clause: GENERATED { ALWAYS | BY DEFAULT [ ON NULL ] } AS IDENTITY [ ( options ) ]
 			// virtual_column:  GENERATED ALWAYS AS ( expr ) [ VIRTUAL ]
@@ -758,18 +769,8 @@ func (p *Parser) parseColumnProperties(col *nodes.ColumnDef) error {
 					col.Identity = identity
 				} else if p.cur.Type == '(' {
 					// virtual column: AS (expr) [VIRTUAL]
-					p.advance()
-					var // consume '('
-					parseErr503 error
-					col.Virtual, parseErr503 = p.parseExpr()
-					if parseErr503 != nil {
-						return parseErr503
-					}
-					if p.cur.Type == ')' {
-						p.advance()
-					}
-					if p.cur.Type == kwVIRTUAL {
-						p.advance() // consume VIRTUAL
+					if err := p.parseVirtualColumnExpression(col); err != nil {
+						return err
 					}
 				}
 			}
@@ -886,6 +887,25 @@ func (p *Parser) parseColumnProperties(col *nodes.ColumnDef) error {
 				return nil
 			}
 		}
+	}
+	return nil
+}
+
+func (p *Parser) parseVirtualColumnExpression(col *nodes.ColumnDef) error {
+	p.advance() // consume '('
+	expr, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	if expr == nil {
+		return p.syntaxErrorAtCur()
+	}
+	col.Virtual = expr
+	if p.cur.Type == ')' {
+		p.advance()
+	}
+	if p.cur.Type == kwVIRTUAL {
+		p.advance() // consume VIRTUAL
 	}
 	return nil
 }

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -91,6 +91,48 @@ func TestCreateTableJsonKeywordStillAllowedAsIdentifier(t *testing.T) {
 	}
 }
 
+func TestCreateTableVirtualColumnShorthand(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		wantType bool
+	}{
+		{
+			name:     "without_type",
+			sql:      "CREATE TABLE t (price NUMBER, qty NUMBER, total AS (price * qty))",
+			wantType: false,
+		},
+		{
+			name:     "with_type",
+			sql:      "CREATE TABLE t (price NUMBER, qty NUMBER, total NUMBER AS (price * qty))",
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseCreateTableForP2(t, tt.sql)
+			if stmt.Columns.Len() != 3 {
+				t.Fatalf("expected 3 columns, got %d", stmt.Columns.Len())
+			}
+			col := stmt.Columns.Items[2].(*ast.ColumnDef)
+			if col.Name != "TOTAL" {
+				t.Fatalf("expected third column TOTAL, got %q", col.Name)
+			}
+			if (col.TypeName != nil) != tt.wantType {
+				t.Fatalf("TypeName presence = %v, want %v", col.TypeName != nil, tt.wantType)
+			}
+			expr, ok := col.Virtual.(*ast.BinaryExpr)
+			if !ok {
+				t.Fatalf("expected BinaryExpr virtual expression, got %T", col.Virtual)
+			}
+			if expr.Op != "*" {
+				t.Fatalf("expected multiplication virtual expression, got op %q", expr.Op)
+			}
+		})
+	}
+}
+
 func TestCreateTableIntervalPartitioning(t *testing.T) {
 	ParseAndCheck(t, `CREATE TABLE t_interval_full (d DATE)
 PARTITION BY RANGE (d)


### PR DESCRIPTION
## Summary
- Parse Oracle virtual column shorthand `column AS (expr)` as `ColumnDef.Virtual`.
- Share virtual expression parsing between shorthand and `GENERATED ALWAYS AS (...)` forms.
- Add regression coverage for typed and typeless shorthand virtual columns.

## Test Plan
- [x] `go test ./oracle/parser -run TestCreateTableVirtualColumnShorthand -count=1 -v`
- [x] `go test ./oracle/parser -count=1`
- [x] `go test ./oracle/... -count=1`
- [x] `git diff --check`