### PR TITLE
fix(oracle): complete schema-qualified table DDL

### DIFF
--- a/oracle/parser/complete.go
+++ b/oracle/parser/complete.go
@@ -441,6 +441,14 @@ func inferOracleDDLCompletionIntent(cs *CandidateSet, allTokens []Token, before 
 			if context.Type == kwON {
 				return &CompletionIntent{ObjectKinds: oracleGrantRevokeObjectKinds(before[stmtStart:]), Qualifier: MultipartName{Schema: q}}, true
 			}
+		case kwALTER:
+			if context.Type == kwTABLE {
+				return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}, Qualifier: MultipartName{Schema: q}}, true
+			}
+		case kwTRUNCATE:
+			if context.Type == kwTABLE {
+				return &CompletionIntent{ObjectKinds: []ObjectKind{ObjectKindTable}, Qualifier: MultipartName{Schema: q}}, true
+			}
 		}
 	}
 	switch first.Type {

--- a/oracle/parser/complete_context_test.go
+++ b/oracle/parser/complete_context_test.go
@@ -400,6 +400,8 @@ func TestOracleCompletionSchemaQualifiedObjectIntent(t *testing.T) {
 		{name: "drop table", input: "DROP TABLE hr.|", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindTable}, qualifier: MultipartName{Schema: "hr"}},
 		{name: "drop view", input: "DROP VIEW hr.|", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindView}, qualifier: MultipartName{Schema: "hr"}},
 		{name: "drop sequence", input: "DROP SEQUENCE hr.|", rules: []string{"sequence_ref"}, kinds: []ObjectKind{ObjectKindSequence}, qualifier: MultipartName{Schema: "hr"}},
+		{name: "alter table", input: "ALTER TABLE hr.|", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindTable}, qualifier: MultipartName{Schema: "hr"}},
+		{name: "truncate table", input: "TRUNCATE TABLE hr.|", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindTable}, qualifier: MultipartName{Schema: "hr"}},
 		{name: "insert target", input: "INSERT INTO hr.|", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindTable}, qualifier: MultipartName{Schema: "hr"}},
 		{name: "update target", input: "UPDATE hr.| SET name = 'x'", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindTable}, qualifier: MultipartName{Schema: "hr"}},
 		{name: "delete target", input: "DELETE FROM hr.| WHERE id = 1", rules: []string{"table_ref"}, kinds: []ObjectKind{ObjectKindTable}, qualifier: MultipartName{Schema: "hr"}},


### PR DESCRIPTION
## Summary
- Add Oracle completion intent handling for `ALTER TABLE schema.|`
- Add Oracle completion intent handling for `TRUNCATE TABLE schema.|`
- Cover both cases in the schema-qualified object intent regression matrix

## Test Plan
- [x] `go test ./oracle/parser -count=1`