### PR TITLE
feat(oracle): expose Bytebase query clause AST

### DIFF
--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -857,11 +857,36 @@ type PivotClause struct {
 	ForCols  *List    // FOR (col1, col2, ...) multi-column
 	InList   *List    // IN list
 	Alias    *Alias   // optional alias
-	Loc      Loc
+	Source   TableExpr
+
+	// Typed fields for query span/lineage consumers. These mirror the legacy
+	// fields above but avoid ad hoc ResTarget/FuncCall tuple encodings.
+	Aggregates *List // list of *PivotAggregate
+	ForColumns *List // list of ExprNode
+	InItems    *List // list of *PivotInItem
+	Loc        Loc
 }
 
 func (n *PivotClause) nodeTag()   {}
 func (n *PivotClause) tableExpr() {}
+
+// PivotAggregate represents one aggregate item in a PIVOT clause.
+type PivotAggregate struct {
+	Expr  ExprNode
+	Alias string
+	Loc   Loc
+}
+
+func (n *PivotAggregate) nodeTag() {}
+
+// PivotInItem represents one item in a PIVOT IN list.
+type PivotInItem struct {
+	Values *List // list of ExprNode
+	Alias  string
+	Loc    Loc
+}
+
+func (n *PivotInItem) nodeTag() {}
 
 // UnpivotClause represents an UNPIVOT clause.
 type UnpivotClause struct {
@@ -870,11 +895,27 @@ type UnpivotClause struct {
 	InList       *List    // IN list
 	IncludeNulls bool     // INCLUDE NULLS
 	Alias        *Alias   // optional alias
-	Loc          Loc      // start location
+	Source       TableExpr
+
+	// Typed fields for query span/lineage consumers.
+	ValueColumns  *List    // list of ExprNode
+	PivotColumn   ExprNode // FOR label column
+	InputMappings *List    // list of *UnpivotInItem
+	Loc           Loc      // start location
 }
 
 func (n *UnpivotClause) nodeTag()   {}
 func (n *UnpivotClause) tableExpr() {}
+
+// UnpivotInItem represents one source-column to label mapping in UNPIVOT.
+type UnpivotInItem struct {
+	InputColumns *List // list of ExprNode
+	Label        ExprNode
+	Alias        string
+	Loc          Loc
+}
+
+func (n *UnpivotInItem) nodeTag() {}
 
 // ---------------------------------------------------------------------------
 // WITH clause (subquery factoring)
@@ -1082,11 +1123,21 @@ func (n *ModelRulesClause) nodeTag() {}
 //	    measure_column [ dimension_conditions ] = expr
 type ModelRule struct {
 	CellRef ExprNode // left side (cell reference with dimension subscripts)
+	Cell    *ModelCellReference
 	Expr    ExprNode // right side value expression
 	Loc     Loc
 }
 
 func (n *ModelRule) nodeTag() {}
+
+// ModelCellReference represents a typed MODEL cell reference.
+type ModelCellReference struct {
+	Measure    string
+	Dimensions *List // list of ExprNode
+	Loc        Loc
+}
+
+func (n *ModelCellReference) nodeTag() {}
 
 // ModelForLoop represents FOR loop in model cell assignment.
 //
@@ -1198,10 +1249,14 @@ func (n *PartitionExtClause) nodeTag() {}
 
 // TableCollectionExpr represents TABLE(collection_expression) [(+)] in FROM.
 type TableCollectionExpr struct {
-	Expr      ExprNode // collection expression
-	OuterJoin bool     // (+) specified
-	Alias     *Alias   // optional alias
-	Loc       Loc
+	Expr           ExprNode // collection expression
+	FunctionCall   *FuncCallExpr
+	CollectionExpr ExprNode
+	ColumnAliases  *List       // optional table column aliases
+	ReturnType     *ObjectName // optional externally-populated return type
+	OuterJoin      bool        // (+) specified
+	Alias          *Alias      // optional alias
+	Loc            Loc
 }
 
 func (n *TableCollectionExpr) nodeTag()   {}
@@ -1213,6 +1268,7 @@ func (n *TableCollectionExpr) tableExpr() {}
 
 // MatchRecognizeClause represents a MATCH_RECOGNIZE clause on a table reference.
 type MatchRecognizeClause struct {
+	Source       TableExpr
 	PartitionBy  *List  // PARTITION BY columns
 	OrderBy      *List  // ORDER BY columns (list of *SortBy)
 	Measures     *List  // MEASURES (list of *ResTarget)
@@ -1692,6 +1748,10 @@ type CreateIndexStmt struct {
 	// Indexing clause
 	IndexingFull    bool // INDEXING FULL
 	IndexingPartial bool // INDEXING PARTIAL
+	LocalPartition  string
+	GlobalPartition string
+	StorageSpec     string
+	AnnotationsSpec string
 	Options         *List
 	Loc             Loc // start location
 }
@@ -1956,16 +2016,27 @@ type CreateTriggerStmt struct {
 	Timing         TriggerTiming // BEFORE/AFTER/INSTEAD OF
 	Events         *List         // trigger events (list of TriggerEvent)
 	Table          *ObjectName   // ON table
-	ForEachRow     bool          // FOR EACH ROW
-	When           ExprNode      // WHEN condition
-	Body           StmtNode      // trigger body
-	Compound       bool          // COMPOUND TRIGGER
-	Enable         bool          // ENABLE (default true)
-	Loc            Loc           // start location
+	Referencing    *TriggerReferencingClause
+	ForEachRow     bool     // FOR EACH ROW
+	When           ExprNode // WHEN condition
+	Body           StmtNode // trigger body
+	Compound       bool     // COMPOUND TRIGGER
+	Enable         bool     // ENABLE (default true)
+	Loc            Loc      // start location
 }
 
 func (n *CreateTriggerStmt) nodeTag()  {}
 func (n *CreateTriggerStmt) stmtNode() {}
+
+// TriggerReferencingClause represents REFERENCING OLD/NEW/PARENT aliases.
+type TriggerReferencingClause struct {
+	OldAlias    string
+	NewAlias    string
+	ParentAlias string
+	Loc         Loc
+}
+
+func (n *TriggerReferencingClause) nodeTag() {}
 
 // ---------------------------------------------------------------------------
 // TRUNCATE statement

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -681,6 +681,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.Table != nil {
 			Walk(v, n.Table)
 		}
+		if n.Referencing != nil {
+			Walk(v, n.Referencing)
+		}
 		Walk(v, n.When)
 		Walk(v, n.Body)
 	case *CreateTypeStmt:
@@ -748,18 +751,15 @@ func walkChildren(v Visitor, node Node) {
 			}
 		}
 	case *DeleteStmt:
-		if n.Target != nil {
-			Walk(v, n.Target)
-		} else {
-			if n.Table != nil {
-				Walk(v, n.Table)
-			}
-			if n.PartitionExt != nil {
-				Walk(v, n.PartitionExt)
-			}
-			if n.Alias != nil {
-				Walk(v, n.Alias)
-			}
+		Walk(v, n.Target)
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
+		if n.PartitionExt != nil {
+			Walk(v, n.PartitionExt)
+		}
+		if n.Alias != nil {
+			Walk(v, n.Alias)
 		}
 		Walk(v, n.WhereClause)
 		walkList(v, n.Returning)
@@ -1003,6 +1003,7 @@ func walkChildren(v Visitor, node Node) {
 		}
 		Walk(v, n.Wait)
 	case *MatchRecognizeClause:
+		Walk(v, n.Source)
 		walkList(v, n.PartitionBy)
 		walkList(v, n.OrderBy)
 		walkList(v, n.Measures)
@@ -1036,6 +1037,8 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.ErrorLog)
 		}
 		walkList(v, n.Hints)
+	case *ModelCellReference:
+		walkList(v, n.Dimensions)
 	case *ModelClause:
 		if n.CellRefOptions != nil {
 			Walk(v, n.CellRefOptions)
@@ -1083,6 +1086,9 @@ func walkChildren(v Visitor, node Node) {
 		}
 	case *ModelRule:
 		Walk(v, n.CellRef)
+		if n.Cell != nil {
+			Walk(v, n.Cell)
+		}
 		Walk(v, n.Expr)
 	case *ModelRulesClause:
 		Walk(v, n.Iterate)
@@ -1202,6 +1208,8 @@ func walkChildren(v Visitor, node Node) {
 		walkList(v, n.Values)
 	case *PartitionExtClause:
 		walkList(v, n.Keys)
+	case *PivotAggregate:
+		Walk(v, n.Expr)
 	case *PivotClause:
 		walkList(v, n.AggFuncs)
 		Walk(v, n.ForCol)
@@ -1210,6 +1218,12 @@ func walkChildren(v Visitor, node Node) {
 		if n.Alias != nil {
 			Walk(v, n.Alias)
 		}
+		Walk(v, n.Source)
+		walkList(v, n.Aggregates)
+		walkList(v, n.ForColumns)
+		walkList(v, n.InItems)
+	case *PivotInItem:
+		walkList(v, n.Values)
 	case *PurgeStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -1324,6 +1338,14 @@ func walkChildren(v Visitor, node Node) {
 		}
 	case *TableCollectionExpr:
 		Walk(v, n.Expr)
+		if n.FunctionCall != nil {
+			Walk(v, n.FunctionCall)
+		}
+		Walk(v, n.CollectionExpr)
+		walkList(v, n.ColumnAliases)
+		if n.ReturnType != nil {
+			Walk(v, n.ReturnType)
+		}
 		if n.Alias != nil {
 			Walk(v, n.Alias)
 		}
@@ -1378,19 +1400,23 @@ func walkChildren(v Visitor, node Node) {
 		if n.Alias != nil {
 			Walk(v, n.Alias)
 		}
+		Walk(v, n.Source)
+		walkList(v, n.ValueColumns)
+		Walk(v, n.PivotColumn)
+		walkList(v, n.InputMappings)
+	case *UnpivotInItem:
+		walkList(v, n.InputColumns)
+		Walk(v, n.Label)
 	case *UpdateStmt:
-		if n.Target != nil {
-			Walk(v, n.Target)
-		} else {
-			if n.Table != nil {
-				Walk(v, n.Table)
-			}
-			if n.PartitionExt != nil {
-				Walk(v, n.PartitionExt)
-			}
-			if n.Alias != nil {
-				Walk(v, n.Alias)
-			}
+		Walk(v, n.Target)
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
+		if n.PartitionExt != nil {
+			Walk(v, n.PartitionExt)
+		}
+		if n.Alias != nil {
+			Walk(v, n.Alias)
 		}
 		walkList(v, n.SetClauses)
 		walkList(v, n.FromClause)

--- a/oracle/parser/bytebase_oracle_ast_test.go
+++ b/oracle/parser/bytebase_oracle_ast_test.go
@@ -1,0 +1,184 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/oracle/ast"
+)
+
+func rawStmt(t *testing.T, sql string) ast.StmtNode {
+	t.Helper()
+	result := ParseAndCheck(t, sql)
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 statement, got %d", result.Len())
+	}
+	raw := result.Items[0].(*ast.RawStmt)
+	return raw.Stmt
+}
+
+func TestBytebaseCreateTriggerReferencingOldNew(t *testing.T) {
+	stmt, ok := rawStmt(t, `CREATE OR REPLACE TRIGGER audit_emp
+AFTER UPDATE ON employees
+REFERENCING OLD AS old_row NEW AS new_row
+FOR EACH ROW
+BEGIN
+  NULL;
+END;`).(*ast.CreateTriggerStmt)
+	if !ok {
+		t.Fatalf("expected CreateTriggerStmt")
+	}
+
+	if stmt.Referencing == nil {
+		t.Fatal("expected REFERENCING clause")
+	}
+	if stmt.Referencing.OldAlias != "OLD_ROW" {
+		t.Fatalf("old alias = %q, want OLD_ROW", stmt.Referencing.OldAlias)
+	}
+	if stmt.Referencing.NewAlias != "NEW_ROW" {
+		t.Fatalf("new alias = %q, want NEW_ROW", stmt.Referencing.NewAlias)
+	}
+	if !stmt.ForEachRow {
+		t.Fatal("expected FOR EACH ROW")
+	}
+}
+
+func TestBytebasePivotTypedOutputShape(t *testing.T) {
+	stmt, ok := rawStmt(t, `SELECT * FROM sales PIVOT (SUM(amount) AS total, COUNT(*) AS cnt FOR quarter IN ('Q1' AS q1, 'Q2' AS q2))`).(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected SelectStmt")
+	}
+
+	if stmt.Pivot == nil {
+		t.Fatal("expected PIVOT")
+	}
+	if stmt.Pivot.Aggregates == nil || stmt.Pivot.Aggregates.Len() != 2 {
+		t.Fatalf("expected 2 typed aggregates, got %v", stmt.Pivot.Aggregates)
+	}
+	agg := stmt.Pivot.Aggregates.Items[0].(*ast.PivotAggregate)
+	if agg.Alias != "TOTAL" {
+		t.Fatalf("aggregate alias = %q, want TOTAL", agg.Alias)
+	}
+	if stmt.Pivot.InItems == nil || stmt.Pivot.InItems.Len() != 2 {
+		t.Fatalf("expected 2 pivot in-items, got %v", stmt.Pivot.InItems)
+	}
+	in := stmt.Pivot.InItems.Items[0].(*ast.PivotInItem)
+	if in.Alias != "Q1" || in.Values == nil || in.Values.Len() != 1 {
+		t.Fatalf("unexpected pivot in-item: %+v", in)
+	}
+	if stmt.Pivot.Source == nil {
+		t.Fatal("expected PIVOT source table expression")
+	}
+}
+
+func TestBytebaseUnpivotTypedMappings(t *testing.T) {
+	stmt, ok := rawStmt(t, `SELECT * FROM quarterly_sales UNPIVOT INCLUDE NULLS ((sales, cost) FOR quarter IN ((q1_sales, q1_cost) AS 'Q1', (q2_sales, q2_cost) AS 'Q2'))`).(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected SelectStmt")
+	}
+
+	if stmt.Unpivot == nil {
+		t.Fatal("expected UNPIVOT")
+	}
+	if stmt.Unpivot.ValueColumns == nil || stmt.Unpivot.ValueColumns.Len() != 2 {
+		t.Fatalf("expected 2 value columns, got %v", stmt.Unpivot.ValueColumns)
+	}
+	if stmt.Unpivot.InputMappings == nil || stmt.Unpivot.InputMappings.Len() != 2 {
+		t.Fatalf("expected 2 input mappings, got %v", stmt.Unpivot.InputMappings)
+	}
+	mapping := stmt.Unpivot.InputMappings.Items[0].(*ast.UnpivotInItem)
+	if mapping.InputColumns == nil || mapping.InputColumns.Len() != 2 {
+		t.Fatalf("expected 2 input columns, got %v", mapping.InputColumns)
+	}
+	if mapping.Alias != "Q1" {
+		t.Fatalf("mapping alias = %q, want Q1", mapping.Alias)
+	}
+	if stmt.Unpivot.Source == nil {
+		t.Fatal("expected UNPIVOT source table expression")
+	}
+}
+
+func TestBytebaseModelRuleCellReference(t *testing.T) {
+	stmt, ok := rawStmt(t, `SELECT * FROM sales MODEL DIMENSION BY (product AS p) MEASURES (amount AS amt) RULES (amt[p] = amt[p])`).(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected SelectStmt")
+	}
+
+	if stmt.ModelClause == nil || stmt.ModelClause.MainModel == nil {
+		t.Fatal("expected MODEL main model")
+	}
+	measures := stmt.ModelClause.MainModel.ColumnClauses.Measures
+	if measures == nil || measures.Len() != 1 {
+		t.Fatalf("expected one measure, got %v", measures)
+	}
+	rules := stmt.ModelClause.MainModel.RulesClause.Rules
+	if rules == nil || rules.Len() != 1 {
+		t.Fatalf("expected one rule, got %v", rules)
+	}
+	rule := rules.Items[0].(*ast.ModelRule)
+	if rule.Cell == nil {
+		t.Fatal("expected typed model cell reference")
+	}
+	if rule.Cell.Measure != "AMT" || rule.Cell.Dimensions == nil || rule.Cell.Dimensions.Len() != 1 {
+		t.Fatalf("unexpected model cell: %+v", rule.Cell)
+	}
+}
+
+func TestBytebaseTableCollectionTypedCallAndColumnAliases(t *testing.T) {
+	stmt, ok := rawStmt(t, `SELECT * FROM TABLE(pkg.get_employees(10)) e (employee_id, employee_name)`).(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected SelectStmt")
+	}
+	ref := stmt.FromClause.Items[0].(*ast.TableCollectionExpr)
+
+	if ref.FunctionCall == nil {
+		t.Fatal("expected TABLE() function call")
+	}
+	if ref.Alias == nil || ref.Alias.Name != "E" {
+		t.Fatalf("alias = %+v, want E", ref.Alias)
+	}
+	if ref.ColumnAliases == nil || ref.ColumnAliases.Len() != 2 {
+		t.Fatalf("expected 2 column aliases, got %v", ref.ColumnAliases)
+	}
+}
+
+func TestBytebaseMatchRecognizeSourceAndMeasures(t *testing.T) {
+	stmt, ok := rawStmt(t, `SELECT * FROM trades MATCH_RECOGNIZE (
+  PARTITION BY account_id
+  ORDER BY trade_time
+  MEASURES FIRST(price) AS first_price, LAST(price) AS last_price
+  ONE ROW PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.price > A.price
+) mr`).(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected SelectStmt")
+	}
+	ref := stmt.FromClause.Items[0].(*ast.MatchRecognizeClause)
+
+	if ref.Source == nil {
+		t.Fatal("expected MATCH_RECOGNIZE source table expression")
+	}
+	if ref.Measures == nil || ref.Measures.Len() != 2 {
+		t.Fatalf("expected 2 measures, got %v", ref.Measures)
+	}
+	if ref.Alias == nil || ref.Alias.Name != "MR" {
+		t.Fatalf("alias = %+v, want MR", ref.Alias)
+	}
+}
+
+func TestBytebaseCreateIndexTypedAdvancedMetadata(t *testing.T) {
+	stmt, ok := rawStmt(t, `CREATE INDEX ix_sales ON sales (sale_date) LOCAL STORE IN (ts1, ts2) STORAGE (INITIAL 64K) ANNOTATIONS (classification 'pii')`).(*ast.CreateIndexStmt)
+	if !ok {
+		t.Fatalf("expected CreateIndexStmt")
+	}
+
+	if stmt.LocalPartition == "" {
+		t.Fatal("expected typed LOCAL partition payload")
+	}
+	if stmt.StorageSpec == "" {
+		t.Fatal("expected typed STORAGE payload")
+	}
+	if stmt.AnnotationsSpec == "" {
+		t.Fatal("expected typed ANNOTATIONS payload")
+	}
+}

--- a/oracle/parser/create_index.go
+++ b/oracle/parser/create_index.go
@@ -268,12 +268,14 @@ func (p *Parser) parseCreateIndexAttributes(stmt *nodes.CreateIndexStmt) error {
 			stmt.Local = true
 			p.advance()
 			value := p.collectCreateIndexOptionValue()
+			stmt.LocalPartition = value
 			appendCreateIndexOption(stmt, "LOCAL", value, nodes.Loc{Start: optStart, End: p.prev.End})
 		case kwGLOBAL:
 			optStart := p.pos()
 			stmt.Global = true
 			p.advance()
 			value := p.collectCreateIndexOptionValue()
+			stmt.GlobalPartition = value
 			appendCreateIndexOption(stmt, "GLOBAL", value, nodes.Loc{Start: optStart, End: p.prev.End})
 		case kwONLINE:
 			stmt.Online = true
@@ -369,6 +371,7 @@ func (p *Parser) parseCreateIndexAttributes(stmt *nodes.CreateIndexStmt) error {
 					stmt.Local = true
 					p.advance()
 					value := p.collectCreateIndexOptionValue()
+					stmt.LocalPartition = value
 					appendCreateIndexOption(stmt, "LOCAL", value, nodes.Loc{Start: optStart, End: p.prev.End})
 				}
 				// Optional parallel_clause
@@ -426,11 +429,13 @@ func (p *Parser) parseCreateIndexAttributes(stmt *nodes.CreateIndexStmt) error {
 					return p.syntaxErrorAtCur()
 				}
 				value := p.collectCreateIndexOptionValue()
+				stmt.StorageSpec = value
 				appendCreateIndexOption(stmt, "STORAGE", value, nodes.Loc{Start: optStart, End: p.prev.End})
 			} else if p.isIdentLikeStr("ANNOTATIONS") {
 				optStart := p.pos()
 				p.advance()
 				value := p.collectCreateIndexOptionValue()
+				stmt.AnnotationsSpec = value
 				appendCreateIndexOption(stmt, "ANNOTATIONS", value, nodes.Loc{Start: optStart, End: p.prev.End})
 			} else {
 				return nil

--- a/oracle/parser/create_trigger.go
+++ b/oracle/parser/create_trigger.go
@@ -102,6 +102,14 @@ func (p *Parser) parseCreateTriggerStmt(start int, orReplace, ifNotExists, editi
 		}
 	}
 
+	if p.isIdentLikeStr("REFERENCING") {
+		var parseErr568 error
+		stmt.Referencing, parseErr568 = p.parseTriggerReferencingClause()
+		if parseErr568 != nil {
+			return nil, parseErr568
+		}
+	}
+
 	if p.cur.Type == kwFOR {
 		p.advance() // consume FOR
 		if p.cur.Type == kwEACH {
@@ -119,10 +127,10 @@ func (p *Parser) parseCreateTriggerStmt(start int, orReplace, ifNotExists, editi
 		if p.cur.Type == '(' {
 			p.advance()
 			var // consume '('
-			parseErr568 error
-			stmt.When, parseErr568 = p.parseExpr()
-			if parseErr568 != nil {
-				return nil, parseErr568
+			parseErr569 error
+			stmt.When, parseErr569 = p.parseExpr()
+			if parseErr569 != nil {
+				return nil, parseErr569
 			}
 			if p.cur.Type == ')' {
 				p.advance() // consume ')'
@@ -174,24 +182,67 @@ func (p *Parser) parseCreateTriggerStmt(start int, orReplace, ifNotExists, editi
 	if p.isIdentLikeStr("CALL") {
 		p.advance() // consume CALL
 		// Parse the routine name as an object name, wrap as a simple expression
-		callName, parseErr569 := p.parseObjectName()
-		if parseErr569 != nil {
-			return nil, parseErr569
+		callName, parseErr570 := p.parseObjectName()
+		if parseErr570 != nil {
+			return nil, parseErr570
 		}
 		stmt.Body = &nodes.PLSQLBlock{
 			Label: "CALL:" + callName.Name,
 			Loc:   callName.Loc,
 		}
 	} else if p.cur.Type == kwDECLARE || p.cur.Type == kwBEGIN || p.cur.Type == tokLABELOPEN {
-		var parseErr570 error
-		stmt.Body, parseErr570 = p.parsePLSQLBlock()
-		if parseErr570 != nil {
-			return nil, parseErr570
+		var parseErr571 error
+		stmt.Body, parseErr571 = p.parsePLSQLBlock()
+		if parseErr571 != nil {
+			return nil, parseErr571
 		}
 	}
 
 	stmt.Loc.End = p.prev.End
 	return stmt, nil
+}
+
+func (p *Parser) parseTriggerReferencingClause() (*nodes.TriggerReferencingClause, error) {
+	start := p.pos()
+	p.advance() // consume REFERENCING
+	clause := &nodes.TriggerReferencingClause{Loc: nodes.Loc{Start: start}}
+	for {
+		if p.isIdentLikeStr("OLD") {
+			p.advance()
+			if p.cur.Type == kwAS {
+				p.advance()
+			}
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			clause.OldAlias = name
+		} else if p.isIdentLikeStr("NEW") {
+			p.advance()
+			if p.cur.Type == kwAS {
+				p.advance()
+			}
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			clause.NewAlias = name
+		} else if p.isIdentLikeStr("PARENT") {
+			p.advance()
+			if p.cur.Type == kwAS {
+				p.advance()
+			}
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			clause.ParentAlias = name
+		} else {
+			break
+		}
+	}
+	clause.Loc.End = p.prev.End
+	return clause, nil
 }
 
 // parseTriggerEvent parses a single trigger event:

--- a/oracle/parser/select.go
+++ b/oracle/parser/select.go
@@ -144,6 +144,11 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 		if parseErr945 != nil {
 			return nil, parseErr945
 		}
+		if sel.FromClause != nil && sel.FromClause.Len() > 0 {
+			if src, ok := sel.FromClause.Items[sel.FromClause.Len()-1].(nodes.TableExpr); ok {
+				sel.Pivot.Source = src
+			}
+		}
 	} else if p.cur.Type == kwUNPIVOT {
 		var parseErr946 error
 		sel.Unpivot, parseErr946 = p.parseUnpivotClause()
@@ -152,6 +157,11 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 			// WHERE
 			nil {
 			return nil, parseErr946
+		}
+		if sel.FromClause != nil && sel.FromClause.Len() > 0 {
+			if src, ok := sel.FromClause.Items[sel.FromClause.Len()-1].(nodes.TableExpr); ok {
+				sel.Unpivot.Source = src
+			}
 		}
 	}
 
@@ -740,7 +750,7 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 		if mrClause, ok := mrRef.(*nodes.MatchRecognizeClause); ok {
 			// Wrap: the table ref becomes the left side of a join-like construct
 			// For simplicity, return the MATCH_RECOGNIZE with the table ref embedded
-			_ = mrClause // MATCH_RECOGNIZE is returned directly
+			mrClause.Source = tr
 			return mrRef, nil
 		}
 	}
@@ -2134,6 +2144,7 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 
 	// Parse aggregate function list (before FOR keyword)
 	pc.AggFuncs = &nodes.List{}
+	pc.Aggregates = &nodes.List{}
 	for {
 		agg, parseErr1030 := p.parseResTarget()
 		if parseErr1030 != nil {
@@ -2141,6 +2152,11 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 		}
 		if agg != nil {
 			pc.AggFuncs.Items = append(pc.AggFuncs.Items, agg)
+			pc.Aggregates.Items = append(pc.Aggregates.Items, &nodes.PivotAggregate{
+				Expr:  agg.Expr,
+				Alias: agg.Name,
+				Loc:   agg.Loc,
+			})
 		}
 		if p.cur.Type != ',' {
 			break
@@ -2161,6 +2177,7 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 	// FOR column | ( column, column, ... )
 	if p.cur.Type == kwFOR {
 		p.advance() // consume FOR
+		pc.ForColumns = &nodes.List{}
 		if p.cur.Type == '(' {
 			// Multi-column: ( col1, col2, ... )
 			p.advance() // consume '('
@@ -2172,6 +2189,7 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 				}
 				if col != nil {
 					colList.Items = append(colList.Items, col)
+					pc.ForColumns.Items = append(pc.ForColumns.Items, col)
 				}
 				if p.cur.Type != ',' {
 					break
@@ -2197,6 +2215,9 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 				// IN ( ... )
 				nil {
 				return nil, parseErr1032
+			}
+			if pc.ForCol != nil {
+				pc.ForColumns.Items = append(pc.ForColumns.Items, pc.ForCol)
 			}
 		}
 	}
@@ -2231,7 +2252,7 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 				p.advance()
 				var // consume '('
 				parseErr1034 error
-				pc.InList, parseErr1034 = p.parsePivotInList()
+				pc.InList, pc.InItems, parseErr1034 = p.parsePivotInList()
 				if parseErr1034 != nil {
 					return nil, parseErr1034
 				}
@@ -2252,18 +2273,20 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 
 // parsePivotInList parses the IN list of a PIVOT clause.
 // Each item is: expr [ [ AS ] c_alias ] | ( expr, expr, ... ) [ [ AS ] c_alias ]
-func (p *Parser) parsePivotInList() (*nodes.List, error) {
+func (p *Parser) parsePivotInList() (*nodes.List, *nodes.List, error) {
 	list := &nodes.List{}
+	items := &nodes.List{}
 	for {
 		start := p.pos()
 		var expr nodes.ExprNode
+		values := &nodes.List{}
 
 		if p.cur.Type == '(' {
 			// Tuple value: ( expr, expr, ... )
 			p.advance() // consume '('
 			tupleList, parseErr1035 := p.parseExprList()
 			if parseErr1035 != nil {
-				return nil, parseErr1035
+				return nil, nil, parseErr1035
 			}
 			if p.cur.Type == ')' {
 				p.advance()
@@ -2273,6 +2296,7 @@ func (p *Parser) parsePivotInList() (*nodes.List, error) {
 			if tupleList.Len() == 1 {
 				if e, ok := tupleList.Items[0].(nodes.ExprNode); ok {
 					expr = &nodes.ParenExpr{Expr: e, Loc: nodes.Loc{Start: start, End: p.prev.End}}
+					values.Items = append(values.Items, e)
 				}
 			} else {
 				// Use a FuncCallExpr with empty name to represent a row/tuple
@@ -2282,12 +2306,16 @@ func (p *Parser) parsePivotInList() (*nodes.List, error) {
 					Args:     args,
 					Loc:      nodes.Loc{Start: start, End: p.prev.End},
 				}
+				values.Items = append(values.Items, tupleList.Items...)
 			}
 		} else {
 			var parseErr1036 error
 			expr, parseErr1036 = p.parseExpr()
 			if parseErr1036 != nil {
-				return nil, parseErr1036
+				return nil, nil, parseErr1036
+			}
+			if expr != nil {
+				values.Items = append(values.Items, expr)
 			}
 		}
 
@@ -2306,22 +2334,76 @@ func (p *Parser) parsePivotInList() (*nodes.List, error) {
 			var parseErr1037 error
 			rt.Name, parseErr1037 = p.parseIdentifier()
 			if parseErr1037 != nil {
-				return nil, parseErr1037
+				return nil, nil, parseErr1037
 			}
 		} else if p.isAliasCandidate() {
 			var parseErr1038 error
 			rt.Name, parseErr1038 = p.parseIdentifier()
 			if parseErr1038 != nil {
-				return nil, parseErr1038
+				return nil, nil, parseErr1038
 			}
 		}
 
 		rt.Loc.End = p.prev.End
 		list.Items = append(list.Items, rt)
+		items.Items = append(items.Items, &nodes.PivotInItem{
+			Values: values,
+			Alias:  rt.Name,
+			Loc:    rt.Loc,
+		})
 
 		if p.cur.Type != ',' {
 			break
 		}
+		p.advance()
+	}
+	return list, items, nil
+}
+
+func (p *Parser) parseColumnRefListInOptionalParens() (*nodes.List, error) {
+	list := &nodes.List{}
+	hasParens := p.cur.Type == '('
+	if hasParens {
+		p.advance()
+	}
+	for {
+		col, err := p.parseColumnRef()
+		if err != nil {
+			return nil, err
+		}
+		if col == nil || col.Column == "" {
+			break
+		}
+		list.Items = append(list.Items, col)
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance()
+	}
+	if hasParens && p.cur.Type == ')' {
+		p.advance()
+	}
+	return list, nil
+}
+
+func (p *Parser) parseIdentifierListInParens() (*nodes.List, error) {
+	list := &nodes.List{}
+	if p.cur.Type != '(' {
+		return list, nil
+	}
+	p.advance()
+	for {
+		name, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		list.Items = append(list.Items, &nodes.String{Str: name})
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance()
+	}
+	if p.cur.Type == ')' {
 		p.advance()
 	}
 	return list, nil
@@ -2370,24 +2452,25 @@ func (p *Parser) parseUnpivotClause() (*nodes.UnpivotClause, error) {
 	parseErr1039 error
 
 	// Value column(s)
-	uc.ValueCol, parseErr1039 = p.parseColumnRef()
-	if parseErr1039 !=
-
-		// FOR pivot_column(s)
-		nil {
+	uc.ValueColumns, parseErr1039 = p.parseColumnRefListInOptionalParens()
+	if parseErr1039 != nil {
 		return nil, parseErr1039
+	}
+	if uc.ValueColumns != nil && uc.ValueColumns.Len() > 0 {
+		uc.ValueCol, _ = uc.ValueColumns.Items[0].(nodes.ExprNode)
 	}
 
 	if p.cur.Type == kwFOR {
 		p.advance()
 		var parseErr1040 error
-		uc.PivotCol, parseErr1040 = p.parseColumnRef()
+		uc.PivotColumn, parseErr1040 = p.parseColumnRef()
 		if parseErr1040 !=
 
 			// IN ( column [ AS literal ], ... )
 			nil {
 			return nil, parseErr1040
 		}
+		uc.PivotCol = uc.PivotColumn
 	}
 
 	if p.cur.Type == kwIN {
@@ -2395,24 +2478,35 @@ func (p *Parser) parseUnpivotClause() (*nodes.UnpivotClause, error) {
 		if p.cur.Type == '(' {
 			p.advance()
 			uc.InList = &nodes.List{}
+			uc.InputMappings = &nodes.List{}
 			for {
 				start := p.pos()
-				col, parseErr1041 := p.parseColumnRef()
+				inputCols, parseErr1041 := p.parseColumnRefListInOptionalParens()
 				if parseErr1041 != nil {
 					return nil, parseErr1041
 				}
-				if col == nil || col.Column == "" {
+				if inputCols == nil || inputCols.Len() == 0 {
 					break
 				}
+				col, _ := inputCols.Items[0].(nodes.ExprNode)
 				rt := &nodes.ResTarget{
 					Expr: col,
 					Loc:  nodes.Loc{Start: start},
+				}
+				item := &nodes.UnpivotInItem{
+					InputColumns: inputCols,
+					Loc:          nodes.Loc{Start: start},
 				}
 				// Optional AS alias (can be identifier or string literal)
 				if p.cur.Type == kwAS {
 					p.advance()
 					if p.cur.Type == tokSCONST {
 						rt.Name = p.cur.Str
+						item.Alias = p.cur.Str
+						item.Label = &nodes.StringLiteral{
+							Val: p.cur.Str,
+							Loc: nodes.Loc{Start: p.pos(), End: p.cur.End},
+						}
 						p.advance()
 					} else {
 						var parseErr1042 error
@@ -2420,10 +2514,14 @@ func (p *Parser) parseUnpivotClause() (*nodes.UnpivotClause, error) {
 						if parseErr1042 != nil {
 							return nil, parseErr1042
 						}
+						item.Alias = rt.Name
+						item.Label = &nodes.ColumnRef{Column: rt.Name, Loc: nodes.Loc{Start: start, End: p.prev.End}}
 					}
 				}
 				rt.Loc.End = p.prev.End
+				item.Loc.End = p.prev.End
 				uc.InList.Items = append(uc.InList.Items, rt)
+				uc.InputMappings.Items = append(uc.InputMappings.Items, item)
 				if p.cur.Type != ',' {
 					break
 				}
@@ -2894,7 +2992,7 @@ func (p *Parser) parseModelRule() (*nodes.ModelRule, error) {
 
 	// Parse the left side: measure_column [ dim_subscripts ]
 	// The left side is an identifier (possibly qualified) followed by [ subscripts ]
-	cellRef, parseErr1061 := p.parseModelCellRef()
+	cellRef, cell, parseErr1061 := p.parseModelCellRef()
 	if parseErr1061 != nil {
 		return nil, parseErr1061
 	}
@@ -2904,6 +3002,7 @@ func (p *Parser) parseModelRule() (*nodes.ModelRule, error) {
 
 	rule := &nodes.ModelRule{
 		CellRef: cellRef,
+		Cell:    cell,
 		Loc:     nodes.Loc{Start: start},
 	}
 
@@ -2923,16 +3022,16 @@ func (p *Parser) parseModelRule() (*nodes.ModelRule, error) {
 
 // parseModelCellRef parses a model cell reference: measure[dim1, dim2, ...].
 // Dimension subscripts can be expressions, ANY, or FOR loops (single/multi column).
-func (p *Parser) parseModelCellRef() (nodes.ExprNode, error) {
+func (p *Parser) parseModelCellRef() (nodes.ExprNode, *nodes.ModelCellReference, error) {
 	start := p.pos()
 
 	// Parse the measure column name as a column reference
 	if !p.isIdentLike() {
-		return nil, nil
+		return nil, nil, nil
 	}
 	name, parseErr1063 := p.parseIdentifier()
 	if parseErr1063 != nil {
-		return nil, parseErr1063
+		return nil, nil, parseErr1063
 	}
 	col := &nodes.ColumnRef{
 		Column: name,
@@ -2941,7 +3040,11 @@ func (p *Parser) parseModelCellRef() (nodes.ExprNode, error) {
 
 	// [ dim_subscripts ]
 	if p.cur.Type != '[' {
-		return col, nil
+		return col, &nodes.ModelCellReference{
+			Measure:    name,
+			Dimensions: &nodes.List{},
+			Loc:        col.Loc,
+		}, nil
 	}
 	p.advance() // consume '['
 
@@ -2953,7 +3056,7 @@ func (p *Parser) parseModelCellRef() (nodes.ExprNode, error) {
 		}
 		expr, parseErr1064 := p.parseExpr()
 		if parseErr1064 != nil {
-			return nil, parseErr1064
+			return nil, nil, parseErr1064
 		}
 		if expr == nil {
 			break
@@ -2970,10 +3073,15 @@ func (p *Parser) parseModelCellRef() (nodes.ExprNode, error) {
 	}
 
 	// Represent as a FuncCallExpr with the column name and subscript args
-	return &nodes.FuncCallExpr{
+	fn := &nodes.FuncCallExpr{
 		FuncName: &nodes.ObjectName{Name: name, Loc: nodes.Loc{Start: start, End: p.prev.End}},
 		Args:     args,
 		Loc:      nodes.Loc{Start: start, End: p.prev.End},
+	}
+	return fn, &nodes.ModelCellReference{
+		Measure:    name,
+		Dimensions: args,
+		Loc:        fn.Loc,
 	}, nil
 }
 
@@ -3342,6 +3450,11 @@ func (p *Parser) parseTableCollectionExpr(start int) (nodes.TableExpr, error) {
 		if parseErr1080 != nil {
 			return nil, parseErr1080
 		}
+		if fn, ok := tc.Expr.(*nodes.FuncCallExpr); ok {
+			tc.FunctionCall = fn
+		} else {
+			tc.CollectionExpr = tc.Expr
+		}
 		if p.cur.Type == ')' {
 			p.advance()
 		}
@@ -3370,6 +3483,16 @@ func (p *Parser) parseTableCollectionExpr(start int) (nodes.TableExpr, error) {
 		tc.Alias, parseErr1082 = p.parseAlias()
 		if parseErr1082 != nil {
 			return nil, parseErr1082
+		}
+	}
+	if p.cur.Type == '(' {
+		cols, parseErr1083 := p.parseIdentifierListInParens()
+		if parseErr1083 != nil {
+			return nil, parseErr1083
+		}
+		tc.ColumnAliases = cols
+		if tc.Alias != nil {
+			tc.Alias.Cols = cols
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add Oracle trigger `REFERENCING OLD/NEW/PARENT` AST support and parser handling.
- Expose typed Oracle AST structures for PIVOT, UNPIVOT, MODEL rule cells, TABLE(collection), and MATCH_RECOGNIZE to support Bytebase query span/lineage consumers.
- Add typed create-index metadata payloads for advanced local/global/storage/annotations options while preserving existing raw options.

## Test Plan
- [x] `go test ./oracle/...`
- [x] `git diff --check`

Note: `go test ./...` was also attempted, but the run stalled in a non-Oracle `tidb/catalog.test` process after Oracle and many other packages had already passed; the Oracle-targeted suite completed successfully.
