### PR TITLE
feat(trino): bootstrap v2 migration — analysis, oracle harness, DAG

### DIFF
--- a/docs/migration/trino/analysis.md
+++ b/docs/migration/trino/analysis.md
@@ -1,0 +1,275 @@
+# Trino Migration Analysis
+
+Migration target: full coverage of the legacy ANTLR4 `bytebase/parser/trino` grammar
+by a hand-written recursive-descent parser under `omni/trino`, adjudicated for
+correctness against a **live Trino 481 oracle** (Docker). Bytebase consumption is
+used to **prioritize** the order of work; it is never used to **scope down**
+legacy parser features.
+
+Sources analyzed:
+
+- **Legacy parser (truth2):** `/Users/h3n4l/OpenSource/parser/trino` — `TrinoParser.g4`
+  (1,132 lines, 128 rules, 81 statement-rule labeled alternatives), `TrinoLexer.g4`
+  (397 lines, ~220 keyword tokens, no lexer modes). Apache-2.0, derived from Trino's
+  official `SqlBase.g4`. Catalog: [`antlr_rules.md`](antlr_rules.md).
+- **Documented syntax (truth1):** Trino 481 official docs (`trino.io/docs/current`),
+  ~172 syntax forms across [`truth1/ddl.md`](truth1/ddl.md) (38),
+  [`truth1/query-dml.md`](truth1/query-dml.md) (40),
+  [`truth1/types-expr-functions.md`](truth1/types-expr-functions.md) (51),
+  [`truth1/admin-utility.md`](truth1/admin-utility.md) (43).
+- **Oracle:** live Trino 481 via Docker, Tier 2. [`oracle.md`](oracle.md) +
+  harness at `trino/internal/trinooracle`.
+- **Bytebase consumption (contract):** `backend/plugin/parser/trino`,
+  `backend/plugin/schema/trino`, `backend/plugin/db/trino`. Full surface in
+  [`contract.md`](contract.md).
+
+---
+
+## 1. Scope and Significance
+
+Trino (formerly PrestoSQL) is a distributed SQL query engine. The grammar is a
+**full, standards-aligned SQL surface** — substantially larger than partiql and,
+in query/expression depth, richer than doris:
+
+- **81 statement forms**: full DDL (TABLE/SCHEMA/VIEW/MATERIALIZED VIEW/CATALOG/
+  ROLE/FUNCTION), DML (INSERT/DELETE/UPDATE/MERGE/TRUNCATE), DCL (GRANT/REVOKE/
+  DENY/roles), admin/session (USE/SET SESSION/SET ROLE/SET PATH/SET TIME ZONE),
+  transactions, prepared statements (PREPARE/EXECUTE/DEALLOCATE), SHOW family,
+  EXPLAIN, CALL, ANALYZE.
+- **Deep query layer**: CTEs (incl. `WITH RECURSIVE`), set operations, all JOIN
+  types, `GROUP BY` with `GROUPING SETS`/`CUBE`/`ROLLUP`, named `WINDOW` + full
+  frame syntax (`ROWS`/`RANGE`/`GROUPS`), `ORDER BY`/`OFFSET`/`LIMIT`/`FETCH … WITH TIES`.
+- **Large Trino-specific features** (no analogue in other omni engines):
+  - **`MATCH_RECOGNIZE`** row-pattern recognition (PATTERN/DEFINE/MEASURES/SUBSET/
+    AFTER MATCH SKIP/row-pattern quantifiers & anchors) — a grammar subsystem on its own.
+  - **Polymorphic table functions** `TABLE(func(...) [PARTITION BY] [COPARTITION] ...)`.
+  - **SQL/JSON**: `JSON_EXISTS/JSON_QUERY/JSON_VALUE/JSON_OBJECT/JSON_ARRAY` with
+    JSON-path invocation, `PASSING`, and behavior clauses.
+  - **Inline SQL routines**: `CREATE FUNCTION` / `WITH FUNCTION` with a full
+    control-flow body language (`BEGIN/END`, `IF`, `CASE`, `LOOP`, `WHILE`, `REPEAT`,
+    `ITERATE`, `LEAVE`, `DECLARE`).
+  - **Time travel**: `FOR (TIMESTAMP|VERSION) AS OF` (`queryPeriod`).
+  - Lambda expressions (`x -> expr`), `ARRAY[...]`/`ROW(...)`/subscript/dereference,
+    `LISTAGG ... WITHIN GROUP`, `AT TIME ZONE`, `UNNEST [WITH ORDINALITY]`, `LATERAL`,
+    `TABLESAMPLE`.
+
+Because bytebase's `Diagnose` (P0) runs on **every** statement and must not emit
+false syntax errors, the omni parser must accept the **entire** legacy grammar
+before the import switch — grammar breadth is itself P0. Priority below governs
+*ordering*, not scope.
+
+---
+
+## 2. Bytebase Contract (the must-work surface)
+
+Engine: `storepb.Engine_TRINO = 24`. **No** separate Presto engine. The DB driver
+(`plugin/db/trino`) does **not** call the parser directly; all dispatch is via the
+`base.*` registry. Full detail in [`contract.md`](contract.md).
+
+| Registered API | Handler | Consumed by (runtime) | P0 |
+|---|---|---|---|
+| `RegisterSplitterFunc` | `SplitSQL` | every query execute, export, LSP | **YES** |
+| `RegisterQueryValidator` | `validateQuery` | SQL-editor read-only guard | **YES** |
+| `RegisterGetQuerySpan` | `GetQuerySpan` | **masking** + lineage + export ACL | **YES** |
+| `RegisterCompleteFunc` | `Completion` | LSP autocomplete (`EngineSupportAutoComplete=true`) | **YES** |
+| `RegisterDiagnoseFunc` | `Diagnose` | LSP inline diagnostics (every keystroke) | **YES** |
+| `schema.RegisterGetDatabaseDefinition` | `GetDatabaseDefinition` | schema dump / SDL | **YES** |
+
+**Not registered** (not gaps): `ParseStatementsFunc` (Trino uses internal
+`ParseTrino`), `StatementRangesFunc`, `QueryTypeFunc` (internal helper),
+`ChangedResourcesGetter`, `TransformDMLToSelect`, `GenerateRestoreSQL`, masking
+advisors, SchemaDiff.
+
+**Consumption depth notes:**
+- `GetQuerySpan` is the heaviest consumer: extracts `SourceColumns` (base-table
+  column lineage for masking), `PredicateColumns` (WHERE/JOIN-ON/USING columns;
+  computed but enforcement gated to MSSQL only today), and per-result-column spans
+  with deferred `SELECT *` expansion. Walks SELECT/CTE/JOIN/UNNEST/LATERAL and
+  recurses into subqueries. Requires a real SELECT + expression AST with table/
+  column resolution against `DatabaseMetadata`.
+- `Completion` is a ~1730-line c3 (`CodeCompletionCore`) implementation; preferred
+  rules `identifier` + `qualifiedName`; produces catalog/schema/table/column/keyword
+  candidates; re-parses FROM clauses and uses `GetQuerySpan` to resolve CTE/subquery
+  column names. Depends on the parser's rule indices and a catalog.
+- `validateQuery` and `query_type` classify SELECT / EXPLAIN / `SelectInfoSchema`
+  (system/information_schema) / DML / DDL.
+- `GetDatabaseDefinition` emits `CREATE TABLE` SDL from `DatabaseSchemaMetadata` —
+  metadata→DDL, largely independent of the parser.
+
+---
+
+## 3. Legacy Parse API (truth2)
+
+```go
+parser.NewTrinoLexer(antlr.CharStream) *TrinoLexer
+parser.NewTrinoParser(antlr.TokenStream) *TrinoParser
+(*TrinoParser).SingleStatement() ISingleStatementContext   // primary entry
+(*TrinoParser).Parse() IParseContext                        // statements* EOF
+```
+
+Bytebase wrappers (`plugin/parser/trino`): `ParseTrino(sql) ([]*base.ANTLRAST, error)`
+(internal), `SplitSQL`, `validateQuery`, `GetQuerySpan`, `Completion`, `Diagnose`,
+plus exported helpers `NormalizeTrinoIdentifier`, `ExtractQualifiedNameParts`,
+`ExtractDatabaseSchemaName`. AST = ANTLR-generated context graph (~128 rule
+contexts + labeled-alternative contexts). The omni AST will be hand-written and
+need only preserve the semantic distinctions consumers care about.
+
+---
+
+## 4. omni Architecture Fit
+
+omni engines are hand-written recursive-descent parsers (stateless lexer producing
+`Token{Type,Str,Loc,End}`, parser with 2-token lookahead, AST nodes carrying
+`Loc{Start,End}` byte offsets). Reference engines: `pg/` (most mature ast/parser
+split), `mysql/` (DDL-heavy statement dispatch + c3 completion + live-DB oracle in
+`mysql/parser/oracle_test.go`). Target package layout:
+
+```
+trino/
+  ast/                 # AST node types, Loc tracking, walker
+  parser/              # lexer + recursive-descent parser + statement splitter + Parse() entry
+    testdata/
+      legacy/          # lifted from bytebase/parser/trino/examples (94 .sql files)
+      official/        # from Trino 481 docs (truth1)
+  analysis/            # query span: lineage (SourceColumns) + predicate columns
+  completion/          # c3-style completion (preferred rules: identifier, qualifiedName)
+  internal/trinooracle/  # ✅ BUILT — differential oracle (Trino REST client + self-test)
+```
+
+`GetDatabaseDefinition` (metadata→SDL) currently lives in bytebase
+`plugin/schema/trino`; planning to decide whether it moves to `trino/deparse` or
+stays in bytebase (it does not depend on the omni parser).
+
+---
+
+## 5. Divergences (docs/oracle vs legacy grammar) — for the ledger
+
+The legacy ANTLR grammar (truth2) **lags Trino 481** (truth1 + oracle). Oracle-
+adjudicated findings to seed the divergence ledger:
+
+| # | Case | Legacy grammar | Trino 481 (oracle) | Disposition | Confidence |
+|---|---|---|---|---|---|
+| 1 | `NEAREST JOIN` | absent | **REJECT-SYNTAX** | docs-crawl **error**; discard `join-nearest` from truth1 | high |
+| 2 | `COLON_` token literal `'_:'` | `'_:'` (bug) | `:` | implement `:`; legacy literal is a copy/paste bug | high |
+| 3 | `JSON_TABLE` | **absent** from `primaryExpression`/`relationPrimary` | exists (481) | docs-ahead-of-legacy; P1/P2 extension — planning decides | high |
+| 4 | `WITH SESSION prop = v SELECT …` | absent (`with` = CTE only) | ACCEPT (sem) | docs-ahead-of-legacy; P1 extension | high |
+| 5 | DML branch `INTO tbl@branch` | absent | ACCEPT (sem `BRANCH_NOT_FOUND`) | docs-ahead-of-legacy; P1 extension | high |
+| 6 | set-op `UNION CORRESPONDING` | `setQuantifier` = DISTINCT/ALL only | ACCEPT | docs-ahead-of-legacy; P1 extension | high |
+| 7 | `GROUP BY ALL` / `GROUP BY AUTO` | `groupBy` has `setQuantifier` (ALL) | both ACCEPT (AUTO clean, ALL semantic) | verify exact semantics vs identifier-named-`all`/`auto` | medium |
+| 8 | `SKIP_`, `TRY_CAST_`, explicit `DOT_`/`COMMA_` | local additions vs official `SqlBase.g4` | n/a | lexer-shape divergences; reconcile token model during lexer node | medium |
+
+Target policy (per doris/partiql convention): implement the **legacy grammar
+scope** correctly (oracle-adjudicated), and treat docs-ahead-of-legacy items
+(#3–#6) as explicit P1 extensions the planner can include since the oracle proves
+them real in 481. Discard #1.
+
+---
+
+## 6. Priority Ranking (ordering within full-parity scope)
+
+P0 = required before bytebase can switch its imports (all 81 statement forms must
+parse without error for `Diagnose`/`SplitSQL`/`validateQuery`). P1 = legacy-parity
+/ docs-ahead items not blocking the switch.
+
+### Tier 0 — Foundation (blocks everything) · P0
+1. **Lexer** — ~220 case-insensitive keywords, reserved vs `nonReserved` split,
+   identifiers (unquoted/`"quoted"`/`` `backtick` ``/digit-leading), `U&'...'` unicode
+   strings, `X'...'` binary, numeric (int/decimal/double), operators, `||`, `=>`/`->`,
+   `{-`/`-}`, comments (hidden channel), `;`. Position metadata for splitter.
+2. **AST core** — node interfaces, `Loc` tracking, walker.
+3. **Statement splitter** — token-driven (`;`); drives `base.SplitMultiSQL`.
+4. **Parser entry + Diagnose** — `Parse`/`ParseTrino`; error collection with positions.
+
+### Tier 1 — Identifiers, types, expressions · P0
+5. **`qualifiedName` / `identifier`** + normalization; `nonReserved` keyword-as-identifier.
+6. **Type grammar** — `genericType`, `arrayType`/`ARRAY<>`, `MAP<>`, `ROW(...)`,
+   `INTERVAL ... TO ...`, `TIMESTAMP/TIME [(p)] [WITH[OUT] TIME ZONE]`, `DOUBLE PRECISION`,
+   `DECIMAL(p,s)`, plus Trino types (JSON, IPADDRESS, UUID, HLL, *digest, VARIANT).
+7. **Expression layer** — precedence-climbing `booleanExpression`→`valueExpression`→
+   `primaryExpression`: predicates (`comparison`/`quantifiedComparison`/`BETWEEN`/`IN`
+   list+subquery/`LIKE`/`IS [NOT] NULL`/`IS [NOT] DISTINCT FROM`), arithmetic/concat/
+   `AT TIME ZONE`, and the big `primaryExpression` set (literals, `CASE`, `CAST`/`TRY_CAST`,
+   function calls with `FILTER`/`ORDER BY`/`nullTreatment`/`OVER`, `LISTAGG`, lambda,
+   `ARRAY[]`/`ROW()`/subscript/dereference, `EXISTS`/subquery, `EXTRACT`/`SUBSTRING`/
+   `TRIM`/`NORMALIZE`/`POSITION`, special datetime fns, `GROUPING`, **JSON functions**).
+
+### Tier 2 — SELECT core · P0
+8. **`querySpecification`** — SELECT list (`selectSingle`/`selectAll`), `FROM`,
+   `relation`/`joinType`/`joinCriteria` (CROSS/INNER/LEFT/RIGHT/FULL/NATURAL), `WHERE`,
+   `GROUP BY` (+ `GROUPING SETS`/`CUBE`/`ROLLUP`), `HAVING`, `WINDOW` + frames.
+9. **`queryNoWith` wrapper** — `ORDER BY`/`OFFSET`/`LIMIT`/`FETCH FIRST … ONLY|WITH TIES`.
+10. **Set operations** (`UNION`/`INTERSECT`/`EXCEPT` [ALL|DISTINCT]).
+11. **CTEs** (`with`/`namedQuery`, `WITH RECURSIVE`).
+12. **Relation primaries** — subquery, `UNNEST [WITH ORDINALITY]`, `LATERAL`,
+    `TABLE(tableFunctionCall …)`, `TABLESAMPLE`, `queryPeriod` time travel.
+13. **`MATCH_RECOGNIZE`** — full row-pattern subsystem (own node).
+
+### Tier 3 — Query span analysis · P0 (heaviest consumer)
+14. **`analysis` package** — `GetQuerySpan` parity: table/column lineage,
+    `SELECT *` expansion, CTE tracking, set-op column merge, subquery recursion,
+    JOIN/UNNEST/LATERAL source resolution, predicate-column extraction.
+
+### Tier 4 — DML + classification · P0
+15. **DML** — `INSERT`, `DELETE`, `UPDATE`, `MERGE` (`mergeCase`), `TRUNCATE`,
+    `tableExecute`, `refreshMaterializedView`.
+16. **Statement classification** — `query_type` parity (Select/Explain/
+    SelectInfoSchema/DML/DDL) + `validateQuery` read-only guard.
+
+### Tier 5 — DDL · P0
+17. CREATE/DROP/ALTER **TABLE** (incl. `CREATE TABLE AS`, `columnDefinition`,
+    `likeClause`, properties), **SCHEMA**, **VIEW**, **MATERIALIZED VIEW** (`GRACE PERIOD`),
+    **CATALOG**, **COMMENT ON**, **ANALYZE**.
+18. **Functions** — `CREATE [OR REPLACE] FUNCTION` / `DROP FUNCTION` with the full
+    `controlStatement` routine body; `WITH FUNCTION` inline.
+
+### Tier 6 — Admin / session / txn / prepared / DCL · P0
+19. `USE`, `SET`/`RESET SESSION`, `SET SESSION AUTHORIZATION`, `SET ROLE`, `SET PATH`,
+    `SET TIME ZONE`; `SHOW` family; `DESCRIBE`/`DESC`; `EXPLAIN`/`EXPLAIN ANALYZE`;
+    `PREPARE`/`EXECUTE`/`EXECUTE IMMEDIATE`/`DEALLOCATE`/`DESCRIBE INPUT|OUTPUT`;
+    `START TRANSACTION`/`COMMIT`/`ROLLBACK`; `CREATE/DROP ROLE`, `GRANT`/`REVOKE`/`DENY`;
+    `CALL`.
+
+### Tier 7 — Completion · P0
+20. **`completion` package** — c3 over the omni parser (preferred rules identifier,
+    qualifiedName), catalog/schema/table/column/keyword candidates, FROM-scope and
+    CTE/subquery resolution.
+
+### Tier 8 — Schema definition · P0
+21. **`GetDatabaseDefinition`** parity (metadata→`CREATE TABLE` SDL). Parser-independent.
+
+### P1 — docs-ahead-of-legacy extensions (oracle-proven real in 481)
+22. `JSON_TABLE`; `WITH SESSION`; DML `@branch`; `UNION/INTERSECT/EXCEPT CORRESPONDING`.
+    (Discard `NEAREST JOIN` — oracle rejects it.)
+
+---
+
+## 7. Test Corpus Strategy
+
+- **Corpus A — legacy examples (regression baseline):** lift the 95 `.sql` files
+  from `/Users/h3n4l/OpenSource/parser/trino/examples/` into `trino/parser/testdata/legacy/`.
+- **Corpus B — official 481 docs (truth1):** every `example_sql` captured in the
+  four `truth1/*.md` files, cross-referenced to the grammar rule it exercises.
+- **Differential gate:** each grammar node runs its corpus through
+  `trino/internal/trinooracle` (`assertOracleMatch`: omni `Parse` accept/reject ==
+  Trino 481 accept/reject). The oracle self-test (`TestOracleClassification`,
+  15 cases) already passes against Trino 481; it is gated/skipped without a server.
+
+---
+
+## 8. Notes for Planning
+
+- **Grammar breadth is P0.** `Diagnose` runs on every statement, so all 81 forms
+  must parse cleanly before the import switch. Sequence by dependency (foundation →
+  expr → select → analysis → statements), but don't drop forms.
+- **Three oversized subsystems** deserve their own DAG nodes: `MATCH_RECOGNIZE`,
+  SQL/JSON functions+path, and the `CREATE FUNCTION` routine body language.
+- **`GetQuerySpan` (Tier 3) is the critical-path consumer** for masking — it needs
+  the full SELECT+expression AST and column resolution. It gates the masking feature.
+- **Completion depends on the parser's rule-index model** (c3). The omni parser must
+  expose rule indices / a completion-core integration analogous to mysql/tsql.
+- **Live oracle available** (Trino 481, Docker) — every node should adjudicate
+  accept/reject mechanically rather than by judgment. This is the highest-leverage
+  correctness asset; prefer it over antlr-faithfulness where the two conflict
+  (see §5 divergences).
+- **`GetDatabaseDefinition`** is parser-independent; can be done in parallel and may
+  remain in bytebase.

--- a/docs/migration/trino/antlr_rules.md
+++ b/docs/migration/trino/antlr_rules.md
@@ -1,0 +1,394 @@
+# Trino ANTLR4 Legacy Grammar Catalog (truth2)
+
+> truth2 — legacy grammar baseline. Present-in-grammar for all entries.
+> This is a HINT about scope, not an oracle.
+
+## 1. Header
+
+**License**: Apache License 2.0 (stated in both .g4 file headers).
+
+**Grammar provenance**:
+- `TrinoParser.g4` — parser grammar, tokenVocab = TrinoLexer; antlr-format directives present; ~1132 lines, 128 rules.
+- `TrinoLexer.g4` — lexer grammar, caseInsensitive = true; ~397 lines; no lexer modes.
+- The `SKIP_` token carries an inline comment: `// Missing SKIP in official g4` — indicating this grammar diverges from upstream Trino's published g4 by adding `SKIP_` and several punctuation tokens (`DOT_`, `COLON_`, `COMMA_`) not present in the official file. The `TRY_CAST_` keyword is also a local extension.
+- The `COLON_` token literal is `'_:'` which appears to be a local bug/quirk vs the expected `':'`.
+
+**Entry rules**:
+- `parse` — top-level entry; accepts `statements* EOF`.
+- `statements` — dispatches to one of: `singleStatement`, `standaloneExpression`, `standalonePathSpecification`, `standaloneType`, `standaloneRowPattern`, `standaloneFunctionSpecification`.
+- `singleStatement` — `statement SEMICOLON_`.
+- `standaloneExpression` — `expression SEMICOLON_`.
+- `standalonePathSpecification` — `pathSpecification SEMICOLON_`.
+- `standaloneType` — `type SEMICOLON_`.
+- `standaloneRowPattern` — `rowPattern SEMICOLON_?`.
+- `standaloneFunctionSpecification` — `functionSpecification SEMICOLON_`.
+
+**Total parser rule count**: 128 rules (per header comment).
+
+---
+
+## 2. Statement Catalog
+
+The `statement` rule is the central dispatch rule with 67 labeled alternatives listed below. Each entry gives: label, one-line syntax description, category.
+
+| # | Label | Syntax description | Category |
+|---|-------|--------------------|----------|
+| 1 | `statementDefault` | Bare `rootQuery` (SELECT/WITH query as a statement) | DQL-wrapper |
+| 2 | `use` | `USE schema` — set current schema | admin-session |
+| 3 | `use` | `USE catalog.schema` — set current catalog and schema (same label, second alternative) | admin-session |
+| 4 | `createCatalog` | `CREATE CATALOG [IF NOT EXISTS] name USING connector [COMMENT …] [AUTHORIZATION …] [WITH …]` | DDL |
+| 5 | `dropCatalog` | `DROP CATALOG [IF EXISTS] name [CASCADE\|RESTRICT]` | DDL |
+| 6 | `createSchema` | `CREATE SCHEMA [IF NOT EXISTS] qualifiedName [AUTHORIZATION …] [WITH …]` | DDL |
+| 7 | `dropSchema` | `DROP SCHEMA [IF EXISTS] qualifiedName [CASCADE\|RESTRICT]` | DDL |
+| 8 | `renameSchema` | `ALTER SCHEMA qualifiedName RENAME TO identifier` | DDL |
+| 9 | `setSchemaAuthorization` | `ALTER SCHEMA qualifiedName SET AUTHORIZATION principal` | DDL |
+| 10 | `createTableAsSelect` | `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] qualifiedName [cols] [COMMENT …] [WITH …] AS (rootQuery) [WITH [NO] DATA]` | DDL |
+| 11 | `createTable` | `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] qualifiedName (tableElement, …) [COMMENT …] [WITH …]` | DDL |
+| 12 | `dropTable` | `DROP TABLE [IF EXISTS] qualifiedName` | DDL |
+| 13 | `insertInto` | `INSERT INTO qualifiedName [columnAliases] rootQuery` | DML |
+| 14 | `delete` | `DELETE FROM qualifiedName [WHERE booleanExpression]` | DML |
+| 15 | `truncateTable` | `TRUNCATE TABLE qualifiedName` | DML |
+| 16 | `commentTable` | `COMMENT ON TABLE qualifiedName IS (string \| NULL)` | DDL |
+| 17 | `commentView` | `COMMENT ON VIEW qualifiedName IS (string \| NULL)` | DDL |
+| 18 | `commentColumn` | `COMMENT ON COLUMN qualifiedName IS (string \| NULL)` | DDL |
+| 19 | `renameTable` | `ALTER TABLE [IF EXISTS] from RENAME TO to` | DDL |
+| 20 | `addColumn` | `ALTER TABLE [IF EXISTS] tableName ADD COLUMN [IF NOT EXISTS] columnDefinition` | DDL |
+| 21 | `renameColumn` | `ALTER TABLE [IF EXISTS] tableName RENAME COLUMN [IF EXISTS] from TO to` | DDL |
+| 22 | `dropColumn` | `ALTER TABLE [IF EXISTS] tableName DROP COLUMN [IF EXISTS] column` | DDL |
+| 23 | `setColumnType` | `ALTER TABLE [IF EXISTS] tableName ALTER COLUMN columnName SET DATA TYPE type` | DDL |
+| 24 | `setTableAuthorization` | `ALTER TABLE tableName SET AUTHORIZATION principal` | DDL |
+| 25 | `setTableProperties` | `ALTER TABLE tableName SET PROPERTIES propertyAssignments` | DDL |
+| 26 | `tableExecute` | `ALTER TABLE tableName EXECUTE procedureName [(args)] [WHERE …]` | DML |
+| 27 | `analyze` | `ANALYZE qualifiedName [WITH properties]` | utility |
+| 28 | `createMaterializedView` | `CREATE [OR REPLACE] MATERIALIZED VIEW [IF NOT EXISTS] qualifiedName [GRACE PERIOD interval] [COMMENT …] [WITH …] AS rootQuery` | DDL |
+| 29 | `createView` | `CREATE [OR REPLACE] VIEW qualifiedName [COMMENT …] [SECURITY DEFINER\|INVOKER] AS rootQuery` | DDL |
+| 30 | `refreshMaterializedView` | `REFRESH MATERIALIZED VIEW qualifiedName` | DML |
+| 31 | `dropMaterializedView` | `DROP MATERIALIZED VIEW [IF EXISTS] qualifiedName` | DDL |
+| 32 | `renameMaterializedView` | `ALTER MATERIALIZED VIEW [IF EXISTS] from RENAME TO to` | DDL |
+| 33 | `setMaterializedViewProperties` | `ALTER MATERIALIZED VIEW qualifiedName SET PROPERTIES propertyAssignments` | DDL |
+| 34 | `dropView` | `DROP VIEW [IF EXISTS] qualifiedName` | DDL |
+| 35 | `renameView` | `ALTER VIEW from RENAME TO to` | DDL |
+| 36 | `setViewAuthorization` | `ALTER VIEW from SET AUTHORIZATION principal` | DDL |
+| 37 | `call` | `CALL qualifiedName(callArgument, …)` — stored procedure call | utility |
+| 38 | `createFunction` | `CREATE [OR REPLACE] functionSpecification` — inline SQL function | DDL |
+| 39 | `dropFunction` | `DROP FUNCTION [IF EXISTS] functionDeclaration` | DDL |
+| 40 | `createRole` | `CREATE ROLE name [WITH ADMIN grantor] [IN catalog]` | DCL |
+| 41 | `dropRole` | `DROP ROLE name [IN catalog]` | DCL |
+| 42 | `grantRoles` | `GRANT roles TO principal(s) [WITH ADMIN OPTION] [GRANTED BY grantor] [IN catalog]` | DCL |
+| 43 | `revokeRoles` | `REVOKE [ADMIN OPTION FOR] roles FROM principal(s) [GRANTED BY grantor] [IN catalog]` | DCL |
+| 44 | `setRole` | `SET ROLE (ALL \| NONE \| identifier) [IN catalog]` | DCL |
+| 45 | `grant` | `GRANT privilege(s)\|ALL PRIVILEGES ON [SCHEMA\|TABLE] qualifiedName TO principal [WITH GRANT OPTION]` | DCL |
+| 46 | `deny` | `DENY privilege(s)\|ALL PRIVILEGES ON [SCHEMA\|TABLE] qualifiedName TO principal` | DCL |
+| 47 | `revoke` | `REVOKE [GRANT OPTION FOR] privilege(s)\|ALL PRIVILEGES ON [SCHEMA\|TABLE] qualifiedName FROM principal` | DCL |
+| 48 | `showGrants` | `SHOW GRANTS [ON TABLE? qualifiedName]` | utility |
+| 49 | `explain` | `EXPLAIN [(options)] statement` — shows query plan | utility |
+| 50 | `explainAnalyze` | `EXPLAIN ANALYZE [VERBOSE] statement` — executes and shows actual plan | utility |
+| 51 | `showCreateTable` | `SHOW CREATE TABLE qualifiedName` | utility |
+| 52 | `showCreateSchema` | `SHOW CREATE SCHEMA qualifiedName` | utility |
+| 53 | `showCreateView` | `SHOW CREATE VIEW qualifiedName` | utility |
+| 54 | `showCreateMaterializedView` | `SHOW CREATE MATERIALIZED VIEW qualifiedName` | utility |
+| 55 | `showTables` | `SHOW TABLES [(FROM\|IN) qualifiedName] [LIKE pattern [ESCAPE escape]]` | utility |
+| 56 | `showSchemas` | `SHOW SCHEMAS [(FROM\|IN) identifier] [LIKE pattern [ESCAPE escape]]` | utility |
+| 57 | `showCatalogs` | `SHOW CATALOGS [LIKE pattern [ESCAPE escape]]` | utility |
+| 58 | `showColumns` | `SHOW COLUMNS (FROM\|IN) qualifiedName? [LIKE pattern [ESCAPE escape]]` (also triggered by `DESCRIBE` and `DESC`) | utility |
+| 59 | `showStats` | `SHOW STATS FOR qualifiedName` | utility |
+| 60 | `showStatsForQuery` | `SHOW STATS FOR (rootQuery)` | utility |
+| 61 | `showRoles` | `SHOW [CURRENT] ROLES [(FROM\|IN) identifier]` | utility |
+| 62 | `showRoleGrants` | `SHOW ROLE GRANTS [(FROM\|IN) identifier]` | utility |
+| 63 | `showFunctions` | `SHOW FUNCTIONS [(FROM\|IN) qualifiedName] [LIKE pattern [ESCAPE escape]]` | utility |
+| 64 | `showSession` | `SHOW SESSION [LIKE pattern [ESCAPE escape]]` | utility |
+| 65 | `setSessionAuthorization` | `SET SESSION AUTHORIZATION authorizationUser` | admin-session |
+| 66 | `resetSessionAuthorization` | `RESET SESSION AUTHORIZATION` | admin-session |
+| 67 | `setSession` | `SET SESSION qualifiedName = expression` — set session property | admin-session |
+| 68 | `resetSession` | `RESET SESSION qualifiedName` | admin-session |
+| 69 | `startTransaction` | `START TRANSACTION [transactionMode, …]` | transaction |
+| 70 | `commit` | `COMMIT [WORK]` | transaction |
+| 71 | `rollback` | `ROLLBACK [WORK]` | transaction |
+| 72 | `prepare` | `PREPARE identifier FROM statement` | prepared |
+| 73 | `deallocate` | `DEALLOCATE PREPARE identifier` | prepared |
+| 74 | `execute` | `EXECUTE identifier [USING expression, …]` | prepared |
+| 75 | `executeImmediate` | `EXECUTE IMMEDIATE string [USING expression, …]` | prepared |
+| 76 | `describeInput` | `DESCRIBE INPUT identifier` | prepared |
+| 77 | `describeOutput` | `DESCRIBE OUTPUT identifier` | prepared |
+| 78 | `setPath` | `SET PATH pathSpecification` | admin-session |
+| 79 | `setTimeZone` | `SET TIME ZONE (LOCAL \| expression)` | admin-session |
+| 80 | `update` | `UPDATE qualifiedName SET col=expr, … [WHERE …]` | DML |
+| 81 | `merge` | `MERGE INTO qualifiedName [AS alias] USING relation ON expr mergeCase+` | DML |
+
+**Total statement-rule labeled alternatives: 81**
+
+Note: `showColumns` appears three times in the grammar (`SHOW COLUMNS`, `DESCRIBE`, `DESC`) but all share the same label — counted as one unique label with 3 grammar alternatives.
+
+---
+
+## 3. Query / SELECT Rules
+
+| Rule | Description |
+|------|-------------|
+| `rootQuery` | Top-level query wrapper: optional `withFunction` (inline SQL functions) then `query`. |
+| `withFunction` | `WITH functionSpecification, …` — inline function definitions preceding a query (Trino extension). |
+| `query` | Optional `with` CTE clause then `queryNoWith`. |
+| `with` | `WITH [RECURSIVE] namedQuery, …` — CTE list. |
+| `namedQuery` | `name [(columns)] AS (query)` — a single CTE definition. |
+| `queryNoWith` | Core SELECT body: `queryTerm [ORDER BY …] [OFFSET …] [LIMIT … \| FETCH FIRST … ONLY\|WITH TIES]`. |
+| `limitRowCount` | `ALL` or a `rowCount`; used for LIMIT clause. |
+| `rowCount` | `INTEGER_VALUE` or `?` (positional parameter); used in LIMIT/OFFSET/FETCH. |
+| `queryTerm` | Labeled alternatives: `queryTermDefault` (single primary), `setOperation` (INTERSECT / UNION / EXCEPT with optional setQuantifier). |
+| `queryPrimary` | Labeled alternatives: `queryPrimaryDefault` (querySpecification), `table` (TABLE qualifiedName), `inlineTable` (VALUES expr, …), `subquery` (parenthesized queryNoWith). |
+| `querySpecification` | Full SELECT: `SELECT [setQuantifier] selectItem, … [FROM relation, …] [WHERE …] [GROUP BY …] [HAVING …] [WINDOW …]`. |
+| `setQuantifier` | `DISTINCT` or `ALL`. |
+| `selectItem` | Labeled alternatives: `selectSingle` (expression [AS alias]), `selectAll` (qualified.* [AS (cols)] or bare *). |
+| `as_column_alias` | `[AS] column_alias` — optional alias marker. |
+| `column_alias` | Single `identifier` used as a column alias. |
+| `sortItem` | `expression [ASC\|DESC] [NULLS FIRST\|LAST]`. |
+| `groupBy` | `[setQuantifier] groupingElement, …`. |
+| `groupingElement` | Labeled alternatives: `singleGroupingSet` (groupingSet), `rollup` (ROLLUP(…)), `cube` (CUBE(…)), `multipleGroupingSets` (GROUPING SETS(…)). |
+| `groupingSet` | `(expr, …)` or bare `expr`. |
+| `windowDefinition` | `name AS (windowSpecification)` — named window definition. |
+| `windowSpecification` | Optional existing-window-name, PARTITION BY, ORDER BY, and windowFrame. |
+| `over` | `OVER (windowName \| (windowSpecification))` — window clause on a function call. |
+| `windowFrame` | Optional MEASURES, frameExtent, AFTER MATCH skipTo, INITIAL/SEEK, PATTERN, SUBSET, DEFINE — MATCH_RECOGNIZE frame extension. |
+| `frameExtent` | RANGE/ROWS/GROUPS with single or BETWEEN frameBound pair. |
+| `frameBound` | Labeled alternatives: `unboundedFrame` (UNBOUNDED PRECEDING/FOLLOWING), `currentRowBound` (CURRENT ROW), `boundedFrame` (expr PRECEDING/FOLLOWING). |
+| `relation` | Labeled alternatives: `joinRelation` (CROSS JOIN / typed JOIN / NATURAL JOIN), `relationDefault` (sampledRelation). |
+| `joinType` | INNER (optional), or LEFT/RIGHT/FULL [OUTER]. |
+| `joinCriteria` | `ON booleanExpression` or `USING (identifier, …)`. |
+| `sampledRelation` | `patternRecognition [TABLESAMPLE sampleType (percentage)]`. |
+| `sampleType` | `BERNOULLI` or `SYSTEM`. |
+| `aliasedRelation` | `relationPrimary [AS? identifier [columnAliases]]`. |
+| `relationPrimary` | Labeled alternatives: `tableName` (qualifiedName [queryPeriod]), `subqueryRelation` ((query)), `unnest` (UNNEST(…) [WITH ORDINALITY]), `lateral` (LATERAL (query)), `tableFunctionInvocation` (TABLE(tableFunctionCall)), `parenthesizedRelation` ((relation)). |
+| `queryPeriod` | `FOR rangeType AS OF end` — time-travel clause (FOR TIMESTAMP\|VERSION AS OF expr). |
+| `rangeType` | `TIMESTAMP` or `VERSION`. |
+| `tableFunctionCall` | `qualifiedName(tableFunctionArgument, … [COPARTITION copartitionTables, …])` — polymorphic table function invocation. |
+| `tableFunctionArgument` | Optional named (`identifier =>`), then `tableArgument`, `descriptorArgument`, or `expression`. |
+| `tableArgument` | `TABLE(qualifiedName\|query) [PARTITION BY …] [PRUNE/KEEP WHEN EMPTY] [ORDER BY …]`. |
+| `tableArgumentRelation` | Labeled alternatives: `tableArgumentTable` (TABLE(qualifiedName)), `tableArgumentQuery` (TABLE(query)). |
+| `descriptorArgument` | `DESCRIPTOR(field, …)` or `CAST(NULL AS DESCRIPTOR)`. |
+| `descriptorField` | `identifier [type]`. |
+| `copartitionTables` | `(qualifiedName, qualifiedName, …)` — list of co-partitioned table names. |
+| `patternRecognition` | `aliasedRelation [MATCH_RECOGNIZE (…)]` — MATCH_RECOGNIZE clause wrapper. |
+| `measureDefinition` | `expression AS identifier` — MEASURES clause entry. |
+| `rowsPerMatch` | `ONE ROW PER MATCH` or `ALL ROWS PER MATCH [emptyMatchHandling]`. |
+| `emptyMatchHandling` | `SHOW EMPTY MATCHES`, `OMIT EMPTY MATCHES`, or `WITH UNMATCHED ROWS`. |
+| `skipTo` | `SKIP TO (NEXT ROW \| [FIRST\|LAST] identifier \| PAST LAST ROW)` — AFTER MATCH skip strategy. |
+| `subsetDefinition` | `name = (identifier, …)` — SUBSET union definition. |
+| `variableDefinition` | `identifier AS expression` — DEFINE clause entry. |
+| `rowPattern` | Labeled alternatives: `quantifiedPrimary` (patternPrimary [patternQuantifier]), `patternConcatenation` (rowPattern rowPattern), `patternAlternation` (rowPattern \| rowPattern). |
+| `patternPrimary` | Labeled alternatives: `patternVariable` (identifier), `emptyPattern` (()), `patternPermutation` (PERMUTE(…)), `groupedPattern` ((rowPattern)), `partitionStartAnchor` (^), `partitionEndAnchor` ($), `excludedPattern` ({- rowPattern -}). |
+| `patternQuantifier` | Labeled alternatives: `zeroOrMoreQuantifier` (* [?]), `oneOrMoreQuantifier` (+ [?]), `zeroOrOneQuantifier` (? [?]), `rangeQuantifier` ({n} [?] or {m,n} [?]). |
+
+---
+
+## 4. Expression Rules
+
+| Rule | Description |
+|------|-------------|
+| `expression` | Top-level expression; simply delegates to `booleanExpression`. |
+| `booleanExpression` | Labeled alternatives: `predicated` (valueExpression [predicate_]), `logicalNot` (NOT booleanExpression), `and` (booleanExpression AND booleanExpression), `or` (booleanExpression OR booleanExpression). |
+| `predicate_` | Predicate suffixes (workaround for ANTLR4 issue #780). Labeled alternatives: `comparison` (comparisonOperator valueExpression), `quantifiedComparison` (op quantifier (query)), `between` ([NOT] BETWEEN lower AND upper), `inList` ([NOT] IN (expr, …)), `inSubquery` ([NOT] IN (query)), `like` ([NOT] LIKE pattern [ESCAPE escape]), `nullPredicate` (IS [NOT] NULL), `distinctFrom` (IS [NOT] DISTINCT FROM valueExpression). |
+| `valueExpression` | Labeled alternatives: `valueExpressionDefault` (primaryExpression), `atTimeZone` (valueExpression AT timeZoneSpecifier), `arithmeticUnary` (- \| + valueExpression), `arithmeticBinary` (left * / % right, or left + - right), `concatenation` (left \|\| right). |
+| `primaryExpression` | Large labeled rule for primary expressions. Labeled alternatives: |
+| | `nullLiteral` — `NULL` |
+| | `intervalLiteral` — `interval` |
+| | `typeConstructor` — `identifier string_` or `DOUBLE PRECISION string_` |
+| | `numericLiteral` — `number` |
+| | `booleanLiteral` — `booleanValue` (TRUE/FALSE) |
+| | `stringLiteral` — `string_` |
+| | `binaryLiteral` — `BINARY_LITERAL` |
+| | `parameter` — `?` |
+| | `position` — `POSITION(valueExpression IN valueExpression)` |
+| | `rowConstructor` — `(expr, expr, …)` or `ROW(expr, …)` |
+| | `listagg` — `LISTAGG([DISTINCT] expr [, sep] [ON OVERFLOW …]) WITHIN GROUP (ORDER BY …) [FILTER …]` |
+| | `functionCall` — `[processingMode] qualifiedName([DISTINCT\|ALL] expr, … [ORDER BY …]) [FILTER] [nullTreatment] [OVER]` (two alternatives: with `*` argument and without) |
+| | `measure` — `identifier OVER` — MATCH_RECOGNIZE measure reference |
+| | `lambda` — `identifier -> expr` or `(identifiers) -> expr` |
+| | `subqueryExpression` — `(query)` |
+| | `exists` — `EXISTS(query)` |
+| | `simpleCase` — `CASE expr WHEN … [ELSE …] END` |
+| | `searchedCase` — `CASE WHEN … [ELSE …] END` |
+| | `cast` — `CAST(expr AS type)` or `TRY_CAST(expr AS type)` |
+| | `arrayConstructor` — `ARRAY[expr, …]` |
+| | `subscript` — `primaryExpression[valueExpression]` |
+| | `columnReference` — bare `identifier` |
+| | `dereference` — `primaryExpression.identifier` |
+| | `specialDateTimeFunction` — CURRENT_DATE, CURRENT_TIME[(p)], CURRENT_TIMESTAMP[(p)], LOCALTIME[(p)], LOCALTIMESTAMP[(p)] |
+| | `currentUser` — `CURRENT_USER` |
+| | `currentCatalog` — `CURRENT_CATALOG` |
+| | `currentSchema` — `CURRENT_SCHEMA` |
+| | `currentPath` — `CURRENT_PATH` |
+| | `trim` — `TRIM([LEADING\|TRAILING\|BOTH] [trimChar FROM] trimSource)` or `TRIM(source, char)` |
+| | `substring` — `SUBSTRING(expr FROM expr [FOR expr])` |
+| | `normalize` — `NORMALIZE(expr [, normalForm])` |
+| | `extract` — `EXTRACT(field FROM expr)` |
+| | `parenthesizedExpression` — `(expr)` |
+| | `groupingOperation` — `GROUPING(qualifiedName, …)` |
+| | `jsonExists` — `JSON_EXISTS(jsonPathInvocation [errorBehavior ON ERROR])` |
+| | `jsonValue` — `JSON_VALUE(jsonPathInvocation [RETURNING type] [ON EMPTY] [ON ERROR])` |
+| | `jsonQuery` — `JSON_QUERY(jsonPathInvocation [RETURNING type] [WRAPPER] [QUOTES] [ON EMPTY] [ON ERROR])` |
+| | `jsonObject` — `JSON_OBJECT([members] [NULL\|ABSENT ON NULL] [UNIQUE KEYS] [RETURNING type])` |
+| | `jsonArray` — `JSON_ARRAY([values] [NULL\|ABSENT ON NULL] [RETURNING type])` |
+| `jsonPathInvocation` | `jsonValueExpression, path [PASSING jsonArgument, …]` — JSON path with optional PASSING arguments. |
+| `jsonValueExpression` | `expression [FORMAT jsonRepresentation]` — expression optionally with JSON format. |
+| `jsonRepresentation` | `JSON [ENCODING UTF8\|UTF16\|UTF32]` — JSON format with optional encoding; TODO comment in grammar for implementation-defined options. |
+| `jsonArgument` | `jsonValueExpression AS identifier` — named JSON path argument. |
+| `jsonExistsErrorBehavior` | `TRUE \| FALSE \| UNKNOWN \| ERROR` — ON ERROR behavior for JSON_EXISTS. |
+| `jsonValueBehavior` | `ERROR \| NULL \| DEFAULT expression` — ON EMPTY/ERROR behavior for JSON_VALUE. |
+| `jsonQueryWrapperBehavior` | `WITHOUT [ARRAY] \| WITH [CONDITIONAL\|UNCONDITIONAL] [ARRAY]` — WRAPPER clause for JSON_QUERY. |
+| `jsonQueryBehavior` | `ERROR \| NULL \| EMPTY (ARRAY\|OBJECT)` — ON EMPTY/ERROR behavior for JSON_QUERY. |
+| `jsonObjectMember` | `[KEY] expr VALUE jsonValueExpression` or `expr : jsonValueExpression` — key-value pair in JSON_OBJECT. |
+| `processingMode` | `RUNNING` or `FINAL` — MATCH_RECOGNIZE processing mode for function calls. |
+| `nullTreatment` | `IGNORE NULLS` or `RESPECT NULLS` — null handling for window functions. |
+| `comparisonOperator` | One of `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`. |
+| `comparisonQuantifier` | `ALL`, `SOME`, or `ANY`. |
+| `booleanValue` | `TRUE` or `FALSE`. |
+| `whenClause` | `WHEN condition THEN result` — used in CASE expressions. |
+| `filter` | `FILTER (WHERE booleanExpression)` — aggregate filter clause. |
+| `timeZoneSpecifier` | Labeled: `timeZoneInterval` (TIME ZONE interval), `timeZoneString` (TIME ZONE string_). |
+| `trimsSpecification` | `LEADING`, `TRAILING`, or `BOTH` — TRIM direction. |
+| `listAggOverflowBehavior` | `ERROR` or `TRUNCATE [string] listaggCountIndication` — LISTAGG overflow handling. |
+| `listaggCountIndication` | `(WITH \| WITHOUT) COUNT` — whether to include count in LISTAGG truncation. |
+| `normalForm` | `NFD`, `NFC`, `NFKD`, or `NFKC` — Unicode normal form for NORMALIZE. |
+| `updateAssignment` | `identifier = expression` — single SET assignment in UPDATE. |
+| `mergeCase` | Labeled alternatives: `mergeUpdate` (WHEN MATCHED … THEN UPDATE SET …), `mergeDelete` (WHEN MATCHED … THEN DELETE), `mergeInsert` (WHEN NOT MATCHED … THEN INSERT … VALUES …). |
+| `explainOption` | Labeled alternatives: `explainFormat` (FORMAT TEXT\|GRAPHVIZ\|JSON), `explainType` (TYPE LOGICAL\|DISTRIBUTED\|VALIDATE\|IO). |
+| `transactionMode` | Labeled alternatives: `isolationLevel` (ISOLATION LEVEL levelOfIsolation), `transactionAccessMode` (READ ONLY\|WRITE). |
+| `levelOfIsolation` | Labeled alternatives: `readUncommitted`, `readCommitted`, `repeatableRead`, `serializable`. |
+
+---
+
+## 5. Type / Literal / Misc Rules
+
+### Types
+
+| Rule | Description |
+|------|-------------|
+| `type` | Labeled alternatives: `rowType` (ROW(rowField, …)), `intervalType` (INTERVAL field [TO field]), `dateTimeType` (TIMESTAMP/TIME [(p)] [WITHOUT\|WITH TIME ZONE]), `doublePrecisionType` (DOUBLE PRECISION), `legacyArrayType` (ARRAY\<type\>), `legacyMapType` (MAP\<keyType, valueType\>), `arrayType` (type ARRAY [size]), `genericType` (identifier [(typeParameter, …)]). |
+| `rowField` | Bare `type` or named `identifier type`. |
+| `typeParameter` | `INTEGER_VALUE` or `type`. |
+
+### Identifiers
+
+| Rule | Description |
+|------|-------------|
+| `qualifiedName` | `identifier (. identifier)*` — dotted-path name. |
+| `identifier` | Labeled alternatives: `unquotedIdentifier` (IDENTIFIER_ or nonReserved keyword), `quotedIdentifier` (double-quoted), `backQuotedIdentifier` (backtick-quoted), `digitIdentifier` (starts with digit). |
+| `nonReserved` | Flat list of ~150 keyword tokens usable as identifiers; all Trino-specific reserved-word exemptions are here (e.g., ARRAY, MAP, SHOW, GRANT, MERGE, MATCH_RECOGNIZE, JSON, …). |
+
+### Strings / Numbers / Literals
+
+| Rule | Description |
+|------|-------------|
+| `string_` | Labeled alternatives: `basicStringLiteral` (single-quoted STRING_), `unicodeStringLiteral` (U&'…' [UESCAPE '…']). |
+| `number` | Labeled alternatives: `decimalLiteral` ([−] DECIMAL_VALUE_), `doubleLiteral` ([−] DOUBLE_VALUE_), `integerLiteral` ([−] INTEGER_VALUE_). |
+| `interval` | `INTERVAL [sign] string_ from [TO to]` — interval literal. |
+| `intervalField` | `YEAR \| MONTH \| DAY \| HOUR \| MINUTE \| SECOND`. |
+| `booleanValue` | `TRUE` or `FALSE`. |
+
+### DCL / Privilege / Role / Principal
+
+| Rule | Description |
+|------|-------------|
+| `privilege` | One of `CREATE`, `SELECT`, `DELETE`, `INSERT`, `UPDATE`. |
+| `roles` | `identifier (, identifier)*` — role name list. |
+| `grantor` | Labeled: `specifiedPrincipal` (principal), `currentUserGrantor` (CURRENT_USER), `currentRoleGrantor` (CURRENT_ROLE). |
+| `principal` | Labeled: `unspecifiedPrincipal` (identifier), `userPrincipal` (USER identifier), `rolePrincipal` (ROLE identifier). |
+| `authorizationUser` | Labeled: `identifierUser` (identifier), `stringUser` (string_). |
+
+### Table / Column / Property
+
+| Rule | Description |
+|------|-------------|
+| `tableElement` | `columnDefinition` or `likeClause`. |
+| `columnDefinition` | `identifier type [NOT NULL] [COMMENT string] [WITH properties]`. |
+| `likeClause` | `LIKE qualifiedName [(INCLUDING\|EXCLUDING) PROPERTIES]`. |
+| `properties` | `(propertyAssignments)`. |
+| `propertyAssignments` | `property (, property)*`. |
+| `property` | `identifier = propertyValue`. |
+| `propertyValue` | Labeled: `defaultPropertyValue` (DEFAULT), `nonDefaultPropertyValue` (expression). |
+
+### Function / Routine Rules
+
+| Rule | Description |
+|------|-------------|
+| `functionSpecification` | `FUNCTION functionDeclaration returnsClause routineCharacteristic* controlStatement`. |
+| `functionDeclaration` | `qualifiedName([parameterDeclaration, …])` — function signature. |
+| `parameterDeclaration` | Optional `identifier` then `type` — parameter declaration. |
+| `returnsClause` | `RETURNS type`. |
+| `routineCharacteristic` | Labeled alternatives: `languageCharacteristic` (LANGUAGE identifier), `deterministicCharacteristic` ([NOT] DETERMINISTIC), `returnsNullOnNullInputCharacteristic` (RETURNS NULL ON NULL INPUT), `calledOnNullInputCharacteristic` (CALLED ON NULL INPUT), `securityCharacteristic` (SECURITY DEFINER\|INVOKER), `commentCharacteristic` (COMMENT string_). |
+| `controlStatement` | Labeled alternatives: `returnStatement` (RETURN), `assignmentStatement` (SET id = expr), `simpleCaseStatement` (CASE expr … END CASE), `searchedCaseStatement` (CASE … END CASE), `ifStatement` (IF … THEN … [ELSEIF] [ELSE] END IF), `iterateStatement` (ITERATE label), `leaveStatement` (LEAVE label), `compoundStatement` (BEGIN … END), `loopStatement` ([label:] LOOP … END LOOP), `whileStatement` ([label:] WHILE … DO … END WHILE), `repeatStatement` ([label:] REPEAT … UNTIL … END REPEAT). |
+| `caseStatementWhenClause` | `WHEN expression THEN sqlStatementList` — for case control statements. |
+| `elseIfClause` | `ELSEIF expression THEN sqlStatementList`. |
+| `elseClause` | `ELSE sqlStatementList`. |
+| `variableDeclaration` | `DECLARE identifier(s) type [DEFAULT valueExpression]`. |
+| `sqlStatementList` | `(controlStatement SEMICOLON_)+`. |
+
+### Call / Path Arguments
+
+| Rule | Description |
+|------|-------------|
+| `callArgument` | Labeled: `positionalArgument` (expression), `namedArgument` (identifier => expression). |
+| `pathElement` | Labeled: `qualifiedArgument` (identifier.identifier), `unqualifiedArgument` (identifier). |
+| `pathSpecification` | `pathElement (, pathElement)*` — SET PATH argument. |
+
+---
+
+## 6. Lexer Summary
+
+### Token categories
+
+**Keywords** (reserved and non-reserved combined): approximately 220 keyword tokens, all case-insensitive (`caseInsensitive = true` in lexer options). Reserved keywords (those NOT listed in `nonReserved`) include: ALTER, AND, AS, BETWEEN, BY, CASE, CAST, CONSTRAINT, CROSS, CUBE, DEALLOCATE, DELETE, DESCRIBE, DISTINCT, DROP, ELSE, END, ESCAPE, EXCEPT, EXECUTE, EXISTS, EXTRACT, FALSE, FETCH, FOR, FROM, FULL, GROUP, GROUPING, HAVING, IN, INNER, INSERT, INTERSECT, INTO, IS, JOIN, LATERAL, LEFT, LIKE, MERGE, NATURAL, NORMALIZE, NOT, NULL, NULLIF, ON, OR, ORDER, OUTER, PREPARE, RECURSIVE, RIGHT, ROLLUP, ROW, SELECT, SKIP, SUBSTRING, TABLE, THEN, TRIM, TRUE, UNION, UNNEST, UESCAPE, USING, VALUES, WHEN, WHERE, WITH, and the compound keywords (CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, LOCALTIME, LOCALTIMESTAMP, CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA, CURRENT_PATH, CURRENT_ROLE, JSON_ARRAY, JSON_EXISTS, JSON_OBJECT, JSON_QUERY, JSON_TABLE, JSON_VALUE, MATCH_RECOGNIZE, TRY_CAST, LISTAGG, NORMALIZE).
+
+**Non-reserved keywords** (~150 tokens listed in the `nonReserved` parser rule): can be used as unquoted identifiers. Examples: ABSENT, ADD, ADMIN, AFTER, ALL, ANALYZE, ANY, ARRAY, ASC, AT, AUTHORIZATION, BEGIN, BERNOULLI, BOTH, CALL, CALLED, CASCADE, CATALOG, CATALOGS, COLUMN, COLUMNS, COMMENT, COMMIT, COMMITTED, CONDITIONAL, COPARTITION, COUNT, CURRENT, DATA, DATE, DAY, DECLARE, DEFAULT, DEFINE, DEFINER, DENY, DESC, DESCRIPTOR, DETERMINISTIC, DISTRIBUTED, DO, DOUBLE, ELSEIF, EMPTY, ENCODING, ERROR, EXCLUDING, EXPLAIN, FETCH, FILTER, FINAL, FIRST, FOLLOWING, FORMAT, FUNCTION, FUNCTIONS, GRACE, GRANT, GRANTED, GRANTS, GRAPHVIZ, GROUPS, HOUR, IF, IGNORE, IMMEDIATE, INCLUDING, INITIAL, INPUT, INTERVAL, INVOKER, IO, ITERATE, ISOLATION, JSON, KEEP, KEY, KEYS, LANGUAGE, LAST, LATERAL, LEADING, LEAVE, LEVEL, LIMIT, LOCAL, LOGICAL, LOOP, MAP, MATCH, MATCHED, MATCHES, MATCH_RECOGNIZE, MATERIALIZED, MEASURES, MERGE, MINUTE, MONTH, NESTED, NEXT, NFC, NFD, NFKC, NFKD, NO, NONE, NULLIF, NULLS, OBJECT, OF, OFFSET, OMIT, ONE, ONLY, OPTION, ORDINALITY, OUTPUT, OVER, OVERFLOW, PARTITION, PARTITIONS, PASSING, PAST, PATH, PATTERN, PER, PERIOD, PERMUTE, PLAN, POSITION, PRECEDING, PRECISION, PRIVILEGES, PROPERTIES, PRUNE, QUOTES, RANGE, READ, REFRESH, RENAME, REPEAT, REPEATABLE, REPLACE, RESET, RESPECT, RESTRICT, RETURN, RETURNING, RETURNS, REVOKE, ROLE, ROLES, ROLLBACK, ROW, ROWS, RUNNING, SCALAR, SCHEMA, SCHEMAS, SECOND, SECURITY, SEEK, SERIALIZABLE, SESSION, SET, SETS, SHOW, SOME, START, STATS, SUBSET, SUBSTRING, SYSTEM, TABLES, TABLESAMPLE, TEXT, TEXT_STRING (='STRING'), TIES, TIME, TIMESTAMP, TO, TRAILING, TRANSACTION, TRUNCATE, TRY_CAST, TYPE, UNBOUNDED, UNCOMMITTED, UNCONDITIONAL, UNIQUE, UNKNOWN, UNMATCHED, UNTIL, UPDATE, USE, USER, UTF16, UTF32, UTF8, VALIDATE, VALUE, VERBOSE, VERSION, VIEW, WHILE, WINDOW, WITHIN, WITHOUT, WORK, WRAPPER, WRITE, YEAR, ZONE.
+
+**Comparison / arithmetic operators**:
+`=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`, `+`, `-`, `*`, `/`, `%`, `||` (CONCAT_), `?`.
+
+**Punctuation / delimiters**:
+- `SEMICOLON_` = `;`
+- `DOT_` = `.` (added locally, not in official g4)
+- `COLON_` = `'_:'` (local addition; literal appears to be a bug — likely intended as `:`)
+- `COMMA_` = `,` (added locally)
+- `LPAREN_` = `(`, `RPAREN_` = `)`
+- `LSQUARE_` = `[`, `RSQUARE_` = `]`
+- `LCURLY_` = `{`, `RCURLY_` = `}`
+- `LCURLYHYPHEN_` = `{-`, `RCURLYHYPHEN_` = `-}` (for MATCH_RECOGNIZE excluded patterns)
+- `LARROW_` = `<-`, `RARROW_` = `->`, `RDOUBLEARROW_` = `=>`
+- `VBAR_` = `|`, `DOLLAR_` = `$`, `CARET_` = `^`
+
+**Lexer modes**: None. Single default mode throughout.
+
+### Literals / identifiers
+
+| Token | Pattern | Notes |
+|-------|---------|-------|
+| `STRING_` | `'...'` with `''` escape | Single-quoted string literal |
+| `UNICODE_STRING_` | `U&'...' [UESCAPE '...']` | Unicode string literal |
+| `BINARY_LITERAL_` | `X'...'` | Hex binary literal; content validated at AST construction time |
+| `INTEGER_VALUE_` | `[0-9]+` | Integer literal |
+| `DECIMAL_VALUE_` | `digits.digits` or `.digits` | Decimal literal |
+| `DOUBLE_VALUE_` | `digits[.digits]E[+-]digits` | Double/float literal with exponent |
+| `IDENTIFIER_` | `[A-Za-z_][A-Za-z0-9_]*` | Regular unquoted identifier |
+| `DIGIT_IDENTIFIER_` | `[0-9][A-Za-z0-9_]+` | Identifier starting with a digit |
+| `QUOTED_IDENTIFIER_` | `"..."` with `""` escape | Double-quoted identifier |
+| `BACKQUOTED_IDENTIFIER_` | `` `...` `` with ``` `` ``` escape | Backtick-quoted identifier |
+
+### Comments / whitespace
+
+| Token | Pattern | Channel |
+|-------|---------|---------|
+| `SIMPLE_COMMENT_` | `--` to end of line | HIDDEN |
+| `BRACKETED_COMMENT_` | `/* ... */` (non-greedy) | HIDDEN |
+| `WS_` | `[ \r\n\t]+` | HIDDEN |
+| `UNRECOGNIZED_` | `.` (catch-all) | default (for delimiter splitting) |
+
+### Naming convention
+
+All tokens use a trailing underscore suffix (e.g., `SELECT_`, `LPAREN_`, `INTEGER_VALUE_`, `IDENTIFIER_`). This is a deliberate convention in this grammar variant to avoid conflicts with ANTLR4 reserved names and Go/target-language keywords. Fragment rules (`EXPONENT_`, `DIGIT_`, `LETTER_`) also carry the suffix.
+
+### Local divergences from official Trino g4
+
+- `SKIP_` keyword added with comment `// Missing SKIP in official g4`.
+- `DOT_`, `COLON_`, `COMMA_` punctuation tokens added locally (official g4 inlines these as literals in parser rules).
+- `TRY_CAST_` is a compound keyword token (official g4 treats it as `TRY` `(` `CAST` `...` `)` at the parser level).
+- `COLON_` literal is `'_:'` — likely a copy/paste artifact; semantically should be `':'`.
+- `TEXT_STRING_` maps to the keyword `'STRING'` (the Trino `STRING` type alias), which shadows the token name to avoid collision with the `STRING_` literal token.

--- a/docs/migration/trino/contract.md
+++ b/docs/migration/trino/contract.md
@@ -1,0 +1,301 @@
+# Trino Parser Migration Contract
+
+## 1. Engine Mapping
+
+| Field | Value |
+|---|---|
+| storepb.Engine value | `Engine_TRINO = 24` |
+| v1pb.Engine value | `Engine_TRINO = 24` (same ordinal) |
+| Presto | **No** separate engine constant exists. There is no `Engine_PRESTO`. Trino is the only engine value, and all bytebase Trino support is gated on `Engine_TRINO`. |
+| Legacy parser import path | `github.com/bytebase/parser/trino` (ANTLR4-generated lexer + parser) |
+| Bytebase parser package | `github.com/bytebase/bytebase/backend/plugin/parser/trino` |
+| Bytebase schema plugin | `github.com/bytebase/bytebase/backend/plugin/schema/trino` |
+| Bytebase DB driver | `github.com/bytebase/bytebase/backend/plugin/db/trino` |
+| Side-loaded by | `backend/server/ultimate.go` via blank import of both `plugin/parser/trino` and `plugin/schema/trino` |
+
+---
+
+## 2. Registered Functions Table
+
+All registrations happen in `init()` blocks inside the bytebase `plugin/parser/trino` package. The schema plugin registers separately.
+
+| Registration call | Engine key | Handler | Source file |
+|---|---|---|---|
+| `base.RegisterSplitterFunc` | `Engine_TRINO` | `SplitSQL` | `split.go:13` |
+| `base.RegisterQueryValidator` | `Engine_TRINO` | `validateQuery` | `query.go:9` |
+| `base.RegisterGetQuerySpan` | `Engine_TRINO` | `GetQuerySpan` | `query_span.go:13` |
+| `base.RegisterCompleteFunc` | `Engine_TRINO` | `Completion` | `completion.go:18` |
+| `base.RegisterDiagnoseFunc` | `Engine_TRINO` | `Diagnose` | `diagnose.go:16` |
+| `schema.RegisterGetDatabaseDefinition` | `Engine_TRINO` | `GetDatabaseDefinition` | `plugin/schema/trino/get_database_definition.go:12` |
+
+**Not registered for Trino:**
+- `RegisterParseStatementsFunc` — not present; Trino uses `ParseTrino` internally.
+- `RegisterStatementRangesFunc` — not registered; `base.GetStatementRanges` returns empty for Trino.
+- `RegisterQueryTypeFunc` / `RegisterStatementTypeGettersFunc` — not a base-registered hook; `getQueryType` / `GetStatementType` are package-internal helpers.
+- `RegisterChangedResourcesGetter` — not registered.
+- `RegisterTransformDMLToSelect` — not registered.
+- `RegisterGenerateRestoreSQL` — not registered.
+- SchemaDiff / masking advisor / plan-check — not registered.
+
+---
+
+## 3. Entry-Point Signatures
+
+### 3.1 SplitSQL (split.go)
+
+```go
+func SplitSQL(statement string) ([]base.Statement, error)
+```
+
+Splits a multi-statement string into individual `base.Statement` values with byte range and position metadata. Tries parser-based splitting first (`splitByParser`), falls back to `tokenizer.NewTokenizer(...).SplitStandardMultiSQL()` on error.
+
+### 3.2 validateQuery (query.go)
+
+```go
+func validateQuery(statement string) (bool, bool, error)
+// registered as base.ValidateSQLForEditorFunc
+// returns (canRunInReadOnly bool, returnsData bool, error)
+```
+
+Parses the full statement, classifies each sub-statement as SELECT/EXPLAIN/SelectInfoSchema (readonly+returns-data), or DML/DDL (not readonly). Returns `(false, false, nil)` on first non-read-only statement. EXPLAIN ANALYZE of a SELECT is allowed.
+
+### 3.3 GetQuerySpan (query_span.go)
+
+```go
+func GetQuerySpan(
+    ctx context.Context,
+    gCtx base.GetQuerySpanContext,
+    stmt base.Statement,
+    database, schema string,
+    ignoreCaseSensitive bool,
+) (*base.QuerySpan, error)
+```
+
+Entry point registered with `base.RegisterGetQuerySpan`. Creates a `querySpanExtractor`, calls `extractor.getQuerySpan(ctx, stmt.Text)`, wraps errors.
+
+### 3.4 Completion (completion.go)
+
+```go
+func Completion(
+    ctx context.Context,
+    cCtx base.CompletionContext,
+    statement string,
+    caretLine int,
+    caretOffset int,
+) ([]base.Candidate, error)
+```
+
+Tries `NewStandardCompleter` first; if it returns empty results, retries with `NewTrickyCompleter` (which additionally calls `skipHeadingSQLWithoutSemicolon`). Both use `base.CodeCompletionCore` (c3 algorithm).
+
+### 3.5 Diagnose (diagnose.go)
+
+```go
+func Diagnose(
+    _ context.Context,
+    _ base.DiagnoseContext,
+    statement string,
+) ([]base.Diagnostic, error)
+```
+
+Parses `statement` with ANTLR. If any lexer or parser error listener fires, converts the `base.SyntaxError` to a `base.Diagnostic` via `base.ConvertSyntaxErrorToDiagnostic`. Returns empty slice on success.
+
+### 3.6 ParseTrino (trino.go — internal, not base-registered)
+
+```go
+func ParseTrino(sql string) ([]*base.ANTLRAST, error)
+```
+
+Splits the SQL with `SplitSQL`, then calls `parseSingleTrino` for each non-empty statement. Each result is a `*base.ANTLRAST{StartPosition, Tree, Tokens}` where `Tree` is the ANTLR `SingleStatementContext`.
+
+### 3.7 getQueryType / GetStatementType (query_type.go — internal)
+
+```go
+func getQueryType(node any) (base.QueryType, bool)
+// returns (queryType, isExplainAnalyze)
+
+func GetStatementType(tree any) StatementType
+// returns a package-local StatementType constant
+```
+
+`getQueryType` walks the ANTLR tree using `queryTypeListener`, mapping statement kinds to `base.Select`, `base.Explain`, `base.SelectInfoSchema`, `base.DML`, `base.DDL`. Used by `validateQuery` and `getQuerySpan`.
+
+### 3.8 GetDatabaseDefinition (plugin/schema/trino)
+
+```go
+func GetDatabaseDefinition(
+    _ schema.GetDefinitionContext,
+    metadata *storepb.DatabaseSchemaMetadata,
+) (string, error)
+```
+
+Emits `CREATE TABLE IF NOT EXISTS "schema"."table" (...)` DDL from `DatabaseSchemaMetadata`. Called by `db/trino/dump.go` `(*Driver).Dump(...)`.
+
+### 3.9 Exported helpers (trino.go — consumed by query_span_* internally)
+
+```go
+func NormalizeTrinoIdentifier(ident string) string
+func ExtractQualifiedNameParts(ctx parser.IQualifiedNameContext) []string
+func ExtractDatabaseSchemaName(ctx parser.IQualifiedNameContext, defaultDatabase, defaultSchema string) (string, string, string)
+```
+
+Not registered with `base`; used only within the parser package.
+
+---
+
+## 4. Capability Deep-Dive
+
+### 4.1 query_span: extractor + listener + predicate
+
+**Files:** `query_span_extractor.go`, `query_span_listener.go`, `query_span_predicate.go`
+
+**What it extracts:**
+- `SourceColumns base.SourceColumnSet` — fully-qualified `{Database, Schema, Table, Column}` tuples for every column accessed by the query. For SELECT queries, columns are resolved to their originating base-table columns via `getDatabaseMetadata`.
+- `PredicateColumns base.SourceColumnSet` — columns appearing in WHERE / JOIN ON / JOIN USING predicates. Used by bytebase masking to detect when a sensitive column is used as a filter key.
+- `Results []base.QuerySpanResult` — one entry per output column with `Name`, `SourceColumns`, `IsPlainField`, `SelectAsterisk`. SELECT * is deferred and expanded after all table sources are resolved.
+
+**Walking strategy:**
+1. `getQuerySpan` calls `ParseTrino`, checks query type. Non-SELECT/EXPLAIN queries return a basic span with just the accessed tables (via `extractAccessedTables`).
+2. For SELECT: creates a `trinoQuerySpanListener`, walks the parse tree with `antlr.ParseTreeWalkerDefault.Walk`.
+3. Listener methods: `EnterQuery` (WITH/CTE), `EnterTableName` (resolves table to metadata, builds `PhysicalTable` with column list), `EnterSelectSingle` / `EnterSelectAll` (builds result column entries), `EnterQuerySpecification` (WHERE predicates), `EnterJoinCriteria` (JOIN predicates), `EnterUnnest`, `EnterLateral`.
+4. Post-walk: `expandTableReferencesToColumns` → `expandPredicateColumns` → `expandSelectAsteriskResults`.
+
+**Metadata access:** `getDatabaseMetadata` calls `gCtx.GetDatabaseMetadataFunc` and caches results in `metaCache`. On `ResourceNotFoundError` the span still returns with `NotFoundError` set (not a hard error).
+
+**Subquery handling:** `extractPredicateColumnFromSubquery` recursively creates a new `querySpanExtractor` and calls `getQuerySpan` on the subquery text. Predicate columns and result columns from subqueries are merged into the outer extractor.
+
+**LATERAL / UNNEST:** dedicated ANTLR listener hooks create `PseudoTable` entries in `tableSourcesFrom` and propagate outer table sources for correlated column resolution.
+
+**AST interfaces used:** `parser.IQualifiedNameContext`, `parser.IQueryContext`, `parser.IBooleanExpressionContext`, `parser.IJoinCriteriaContext`, `parser.TableNameContext`, `parser.QuerySpecificationContext`, `parser.SelectSingleContext`, `parser.SelectAllContext`, `parser.UnnestContext`, `parser.LateralContext` — all from `github.com/bytebase/parser/trino`.
+
+### 4.2 Completion (completion.go — ~1730 lines)
+
+**Strategy:** ANTLR3-style `CodeCompletionCore` (c3 / follow-set algorithm), identical in structure to other engines (TSQL, Redshift).
+
+**preferredRules:**
+```go
+preferredRules = map[int]bool{
+    trinoparser.TrinoParserRULE_identifier:    true,
+    trinoparser.TrinoParserRULE_qualifiedName: true,
+}
+```
+
+**ignoredTokens:** All identifier token types (IDENTIFIER, QUOTED_IDENTIFIER, DIGIT_IDENTIFIER, BACKTICK_IDENTIFIER), all literals (STRING, UNICODE_STRING, DECIMAL_VALUE, DOUBLE_VALUE, INTEGER_VALUE, BINARY_LITERAL), QUESTION_MARK, all operators and punctuation, EOF.
+
+**Candidate types produced:** keywords, catalogs (`CandidateTypeDatabase`), schemas, tables, columns, views. Functions are categorized but the `functionEntries` map is never populated (placeholder).
+
+**Two-pass strategy:**
+1. `NewStandardCompleter` → `skipHeadingSQLs` (skip statements before caret)
+2. `NewTrickyCompleter` → additionally `skipHeadingSQLWithoutSemicolon` (finds last `SELECT` at column 0)
+
+**Table reference collection:** `collectLeadingTableReferences` / `collectRemainingTableReferences` scan the token stream for `FROM` tokens and parse each FROM clause with `parseTableReferences` (re-parses from the FROM keyword using `parser.Relation()`). Alias resolution handled by `tableRefListener`.
+
+**CTE extraction:** `fetchCommonTableExpression` walks the full statement tree with `cteExtractor` listener. When no column aliases are specified for a CTE, it calls `GetQuerySpan` to derive column names.
+
+**Subquery columns:** `tableRefListener.ExitSubquery` calls `GetQuerySpan(SELECT * FROM (<subquery>))` to derive column names for subquery aliases.
+
+**Context determination:** `determineQualifiedNameContext` / `determineColumnReference` walk backward from the caret through the token stream to find dot-separated identifier chains, then return multiple possible `objectRefContext` interpretations (catalog.schema, schema.object, object.column) which are all tried.
+
+**Identity quoting:** `quotedIdentifierIfNeeded` adds `"..."` if the identifier starts with a non-letter/underscore or contains non-word characters. Caret-inside-quoted-token is detected and suppressed.
+
+### 4.3 query_type.go — Statement Classification
+
+**Two classifiers:**
+
+`getQueryType(node any) (base.QueryType, bool)` — used internally by `validateQuery` and `getQuerySpan`. Returns one of: `base.Select`, `base.Explain`, `base.SelectInfoSchema`, `base.DML`, `base.DDL`, `base.QueryTypeUnknown`. Second bool is `isExplainAnalyze`.
+
+`GetStatementType(tree any) StatementType` — returns a package-local enum (Select, Explain, Insert, Update, Delete, Merge, CreateTable, CreateView, AlterTable, DropTable, DropView, CreateSchema, DropSchema, RenameTable, CreateTableAsSelect, Set, Show, Unsupported). Not used by any external caller currently, and not registered with base.
+
+System schema detection: `containsSystemSchema` checks for `system.`, `information_schema.`, `$system.`, `catalog.`, `metadata.` prefixes (case-insensitive substring match) to classify queries as `SelectInfoSchema`.
+
+### 4.4 diagnose.go — Syntax Diagnostics
+
+`Diagnose` calls `parseTrinoStatement` which constructs a fresh ANTLR lexer + parser with `BuildParseTrees = false` (for speed), attaches `base.ParseErrorListener` on both, parses via `p.SingleStatement()`, and returns the first error as a `base.Diagnostic`. The function always returns a non-nil `[]base.Diagnostic` slice (possibly empty).
+
+---
+
+## 5. External Call Sites
+
+The parser package is loaded purely through blank imports. All runtime dispatch goes through `base.*` functions keyed on engine.
+
+### SQL Editor / Query API (`backend/api/v1/sql_service.go`)
+
+| Call | Line(s) | Which registered API | Runtime-critical |
+|---|---|---|---|
+| `parserbase.SplitMultiSQL(instance.Metadata.GetEngine(), statement)` | 781, 789, 1089 | `RegisterSplitterFunc` → `SplitSQL` | **YES** — executed for every query submitted by a Trino instance |
+| `parserbase.GetQuerySpan(ctx, gCtx, engine, statements, ...)` | 571–580, 674–683 | `RegisterGetQuerySpan` → `GetQuerySpan` | **YES** — called for masking and predicate-column checks on SELECT queries |
+| `parserbase.ValidateSQLForEditor(engine, statement)` (via `validateQueryRequest`) | 1686 | `RegisterQueryValidator` → `validateQuery` | **YES** — called before every query execution to reject non-read-only statements |
+
+### Query Statement Classification (`backend/api/v1/query_statement_classification.go`)
+
+| Call | Line | Which API | Critical |
+|---|---|---|---|
+| `parserbase.SplitMultiSQL(engine, statement)` | 45 | `SplitSQL` | YES |
+| `parserbase.GetQuerySpan(ctx, ..., engine, statements, ...)` | 49 | `GetQuerySpan` | YES |
+| `parserbase.ValidateSQLForEditor(engine, statement)` | 11 | `validateQuery` | YES |
+
+### LSP Completion (`backend/api/lsp/completion.go`)
+
+| Call | Line | Which API | Critical |
+|---|---|---|---|
+| `parserbase.Completion(ctx, engine, cCtx, statement, caretLine, caretOffset)` | 58 | `RegisterCompleteFunc` → `Completion` | YES — gated by `common.EngineSupportAutoComplete` which returns `true` for `Engine_TRINO` |
+
+### LSP Diagnostics (`backend/api/lsp/performance_optimizer.go`)
+
+| Call | Line | Which API | Critical |
+|---|---|---|---|
+| `base.Diagnose(ctx, base.DiagnoseContext{}, engineType, content)` | 119 | `RegisterDiagnoseFunc` → `Diagnose` | YES — called for every text document change in the LSP |
+
+### Export / Resource Extraction (`backend/component/export/resources.go`)
+
+| Call | Line(s) | Which API | Critical |
+|---|---|---|---|
+| `base.SplitMultiSQL(engine, statement)` | 62, 169, 241 | `SplitSQL` | YES — runs on every data export |
+| `base.GetQuerySpan(ctx, gCtx, engine, statements, ...)` | 66, 173, 245 | `GetQuerySpan` | YES |
+
+### DB Driver — Dump (`backend/plugin/db/trino/dump.go`)
+
+| Call | Line | Which API | Critical |
+|---|---|---|---|
+| `schema.GetDatabaseDefinition(storepb.Engine_TRINO, ...)` | 15 | `schema.RegisterGetDatabaseDefinition` → `GetDatabaseDefinition` | YES — called when dumping the Trino schema |
+
+### DB Driver — trino.go, sync.go, query.go
+
+The DB driver (`backend/plugin/db/trino/`) does **not** call any function from `backend/plugin/parser/trino` directly. It uses `util.SanitizeSQL` (a simple sanitizer, not the parser-based splitter) in `Execute`, and `util.RowsToQueryResult` for query results. The parser is reached only through the `base.*` dispatch layer.
+
+### Masking
+
+`common.EngineSupportMasking(Engine_TRINO)` returns `true` (`backend/common/engine.go:102`). This means `sql_service.go` will call `GetQuerySpan` and then `masker.MaskQueryResults` using `span.SourceColumns`. `PredicateColumns` are computed but predicate-column enforcement is only enabled for `Engine_MSSQL` (`predicate_columns_check.go:132`), so Trino predicate columns are extracted but not yet enforced.
+
+---
+
+## 6. Contract Entries
+
+| Symbol | Signature | Callers | P0 consumed |
+|---|---|---|---|
+| `SplitSQL` | `func(statement string) ([]base.Statement, error)` | `sql_service.go:781,789,1089`; `query_statement_classification.go:45`; `export/resources.go:62,169,241`; LSP completion internally | **YES** |
+| `validateQuery` | `func(statement string) (bool, bool, error)` | `sql_service.go:1686`; `query_statement_classification.go:11`; `sql_service.go:1840` | **YES** |
+| `GetQuerySpan` | `func(ctx context.Context, gCtx base.GetQuerySpanContext, stmt base.Statement, database, schema string, ignoreCaseSensitive bool) (*base.QuerySpan, error)` | `sql_service.go:571,674`; `query_statement_classification.go:49`; `export/resources.go:66,173,245`; `completion.go:1397,1499` (internal) | **YES** |
+| `Completion` | `func(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) ([]base.Candidate, error)` | `lsp/completion.go:58` | **YES** |
+| `Diagnose` | `func(_ context.Context, _ base.DiagnoseContext, statement string) ([]base.Diagnostic, error)` | `lsp/performance_optimizer.go:119` | **YES** |
+| `GetDatabaseDefinition` | `func(_ schema.GetDefinitionContext, metadata *storepb.DatabaseSchemaMetadata) (string, error)` | `db/trino/dump.go:15` | **YES** |
+| `ParseTrino` | `func(sql string) ([]*base.ANTLRAST, error)` | Internal only (`query_span_extractor.go`, `query.go`, `diagnose.go`) | No (internal helper) |
+| `getQueryType` | `func(node any) (base.QueryType, bool)` | Internal only | No (internal) |
+| `GetStatementType` | `func(tree any) StatementType` | Internal only — not called by any external package | No |
+| `NormalizeTrinoIdentifier` | `func(ident string) string` | Internal only | No |
+| `ExtractQualifiedNameParts` | `func(ctx parser.IQualifiedNameContext) []string` | Internal only | No |
+| `ExtractDatabaseSchemaName` | `func(ctx parser.IQualifiedNameContext, defaultDatabase, defaultSchema string) (string, string, string)` | Internal only | No |
+
+### P0 summary
+
+All six registered handlers are P0 — they are invoked at runtime by real bytebase features whenever a Trino instance is connected:
+
+1. **`SplitSQL`** — mandatory for every query execute, export, and LSP session.
+2. **`validateQuery`** — mandatory read-only guard on the SQL editor.
+3. **`GetQuerySpan`** — mandatory for masking, resource extraction, and export ACL.
+4. **`Completion`** — mandatory for LSP autocomplete (gated by `EngineSupportAutoComplete=true`).
+5. **`Diagnose`** — mandatory for LSP inline diagnostics.
+6. **`GetDatabaseDefinition`** (schema plugin) — mandatory for schema dump / SDL generation.
+
+`GetStatementRangesFunc` is **not registered** for Trino (the base dispatcher returns an empty range list); this is **not** a gap that blocks the import switch.
+
+There are no masking-specific registrations (no `ExtractChangedResourcesFunc`, no schema diff, no plan-check advisors) for Trino, so those features are absent and not part of the P0 surface.

--- a/docs/migration/trino/dag.md
+++ b/docs/migration/trino/dag.md
@@ -1,0 +1,86 @@
+# Trino Migration DAG
+
+Seeded into the v2 SQLite store (`omni-v2-migration.db`, migration id 3,
+`dag_version = v2-2026-06-02`, `oracle_tier = docker`) on 2026-06-02. The store is
+the source of truth the orchestrator schedules from; this file is the readable
+companion. Built from [`analysis.md`](analysis.md).
+
+**18 nodes** (14 P0 · 4 P1), **30 deps**, **7 divergences**. Single root
+(`ast-core`); 9 merge layers; acyclic. P0 = required for the bytebase import
+switch; P1 = legacy-parity / advanced, deferrable but in scope.
+
+## Nodes
+
+| Node | Kind | P0 | Depends on (merged) | Writes |
+|---|---|---|---|---|
+| `trino/ast-core` | grammar | ✅ | — | `trino/ast/*.go` |
+| `trino/lexer` | grammar | ✅ | ast-core | `trino/parser/{lexer,keywords,tokens}.go` |
+| `trino/parser-foundation` | grammar | ✅ | ast-core, lexer | `trino/parser/{parser,errors,split,diagnose,identifiers}.go` |
+| `trino/types` | grammar | ✅ | parser-foundation | `trino/parser/datatypes.go` |
+| `trino/expressions` | grammar | ✅ | types | `trino/parser/{expr,function,predicate}.go` |
+| `trino/expr-json` | grammar | ✅ | expressions | `trino/parser/json.go` |
+| `trino/parser-select` | grammar | ✅ | expressions | `trino/parser/{select,relation,ctes,window,setops}.go` |
+| `trino/parser-match-recognize` | grammar | — | parser-select | `trino/parser/{match_recognize,row_pattern}.go` |
+| `trino/parser-ddl` | grammar | ✅ | parser-select, types | `trino/parser/{create_table,alter_table,drop,schema_view,catalog_ddl,comment_analyze}.go` |
+| `trino/parser-dml` | grammar | ✅ | parser-select | `trino/parser/{insert,update_delete,merge}.go` |
+| `trino/parser-routines` | grammar | — | expressions, parser-select | `trino/parser/{function_def,routine_body}.go` |
+| `trino/parser-dcl-tcl` | grammar | — | parser-foundation, expressions | `trino/parser/{grant_revoke,transaction,prepared}.go` |
+| `trino/parser-utility` | grammar | — | parser-foundation, expressions | `trino/parser/{show,session,explain_call}.go` |
+| `trino/catalog` | feature | ✅ | ast-core | `trino/catalog/*.go` |
+| `trino/analysis` | feature | ✅ | parser-foundation, parser-select | `trino/analysis/*.go` |
+| `trino/completion` | feature | ✅ | parser-select, catalog, analysis | `trino/completion/*.go` |
+| `trino/deparse` | feature | ✅ | ast-core, types | `trino/deparse/*.go` |
+| `trino/bytebase-switch` | feature | ✅ | analysis, completion, deparse, parser-ddl, parser-dml | `bytebase:backend/plugin/{parser,schema}/trino/**` |
+
+## Merge layers (parallelization)
+
+The orchestrator drains one merge-layer per fire (deps must be *merged*). Within a
+layer, nodes with non-overlapping `writes` globs run concurrently.
+
+| Layer | Nodes |
+|---|---|
+| 0 | ast-core |
+| 1 | catalog, lexer |
+| 2 | parser-foundation |
+| 3 | types |
+| 4 | deparse, expressions |
+| 5 | expr-json, parser-select, parser-dcl-tcl, parser-utility |
+| 6 | analysis, parser-ddl, parser-dml, parser-match-recognize, parser-routines |
+| 7 | completion |
+| 8 | bytebase-switch (INTEGRATE — human-guided, not auto-dispatched) |
+
+Note: all `trino/parser/*` nodes write distinct files, so they are co-schedulable
+within a layer; they serialize only via the dep edges above.
+
+## Mapping to the consumed contract (P0 rationale)
+
+| bytebase P0 API | satisfied by |
+|---|---|
+| `SplitSQL` | lexer, parser-foundation |
+| `validateQuery` / query-type | parser-foundation, parser-select, analysis |
+| `GetQuerySpan` (masking + lineage) | parser-select, expressions, analysis |
+| `Completion` (c3) | parser-select, catalog, completion |
+| `Diagnose` | parser-foundation (+ all statement parsers for clean coverage) |
+| `GetDatabaseDefinition` | deparse |
+
+Deferred (P1) nodes — match-recognize, routines, dcl-tcl, utility — are rarer
+statement/expression forms; the import switch (`bytebase-switch`) depends only on
+the P0 consumed-feature path, matching the doris precedent.
+
+## Divergence ledger (seeded, oracle-adjudicated)
+
+| Node | Case | Status | Disposition |
+|---|---|---|---|
+| parser-select | NEAREST JOIN | confirmed | docs-crawl error — exclude |
+| lexer | `COLON_` literal `_:` | confirmed | implement `:` |
+| parser-select | JSON_TABLE | flagged | P1 extension (docs-ahead) |
+| parser-select | WITH SESSION | flagged | P1 extension (docs-ahead) |
+| parser-dml | DML `@branch` | flagged | P1 extension (docs-ahead) |
+| parser-select | set-op CORRESPONDING | flagged | P1 extension (docs-ahead) |
+| parser-select | GROUP BY ALL/AUTO | proposed | pin semantics via oracle |
+
+## Next
+
+Hand back to `omni-engine-v2-migration` to run EXECUTE waves. First fire's ready-set
+is `trino/ast-core`; draining proceeds layer-by-layer. Every grammar node validates
+against the live Trino 481 oracle via `trino/internal/trinooracle`.

--- a/docs/migration/trino/oracle.md
+++ b/docs/migration/trino/oracle.md
@@ -1,0 +1,43 @@
+# Trino Oracle
+
+| Field | Value |
+|---|---|
+| **engine** | `trino` (`storepb.Engine_TRINO`, value 24; no separate Presto engine) |
+| **tier** | **2 — Docker** (live local Trino server). Far stronger than antlr-fallback; flips correctness from judgment to mechanical comparison. |
+| **version** | **Trino 481** (`trinodb/trino:latest`, image id `5b5e0a97f599`, pulled 2026-06-02). Matches the `trino.io/docs/current` corpus used for truth1. |
+| **access** | `docker run -d --name trino-oracle -p 18080:8080 trinodb/trino:latest` |
+| **client** | Go REST client at `trino/internal/trinooracle` (`Oracle.CheckSyntax`). Connects to `$TRINO_ORACLE_URL` (default `http://localhost:18080`). `StartContainer` auto-starts a disposable server via testcontainers for CI. |
+| **syntax_reject_signal** | REST statement error object with **`errorName == "SYNTAX_ERROR"`** (`errorCode` 1, `errorType` `USER_ERROR`). This — and only this — means Trino's parser rejected the input. |
+| **semantic_error_examples** | Grammar **accepted**, failed later: `TABLE_NOT_FOUND` (46), `CATALOG_NOT_FOUND` (44), `COLUMN_NOT_FOUND` (47), `NOT_SUPPORTED` (13, e.g. memory-connector `MERGE`), `TYPE_MISMATCH`. Any non-`SYNTAX_ERROR` outcome (including success) = accepted. |
+| **catalogs** | `memory` (supports CREATE/INSERT → DDL/DML probing), `tpch` + `tpcds` (real tables/columns → query-span & lineage probing), `system`, `jmx`. Harness defaults to `memory.default`. |
+
+## How classification works
+
+Trino runs parse → analyze → plan → execute. A `SYNTAX_ERROR` is raised during
+parse, before analysis. The oracle submits the statement over `/v1/statement`,
+follows `nextUri`, and reads `stats.state`:
+
+- `error.errorName == "SYNTAX_ERROR"` → **rejected**.
+- any other `error.errorName`, or reaching `RUNNING`/`FINISHED` → **accepted**.
+
+Once the query reaches `RUNNING`, parsing+planning have demonstrably succeeded,
+so the client cancels (`DELETE nextUri`) to avoid streaming result data. This
+keeps even `SELECT … FROM tpch.sf1.*` checks sub-second.
+
+## Notes
+
+- **Robust to side effects.** Because classification keys on `SYNTAX_ERROR`, the
+  oracle may *execute* a DDL/DML statement against the disposable `memory`
+  catalog (e.g. actually create a table). That never changes the syntax verdict.
+  Grammar-node authors who want a pure parse with no execution can wrap an
+  EXPLAIN-able statement in `EXPLAIN …` (not universal — many utility/DDL forms
+  are not EXPLAIN-able), but it is not required for syntax classification.
+- **Boot time.** The Trino JVM takes ~40–60s to become ready (`/v1/info` →
+  `starting:false`). Prefer one long-lived container + `TRINO_ORACLE_URL` for
+  iterative work; `StartContainer` (≈1 min) is for self-contained CI.
+- **Gating.** `TestOracleClassification` (15 cases) skips cleanly in `-short`
+  mode or when no oracle is reachable, so `go test ./...` stays green without a
+  running Trino.
+- **Verified.** `go vet ./trino/...` clean; self-test green against Trino 481
+  (valid / Trino-specific / semantic-accept / syntax-reject all classified
+  correctly).

--- a/docs/migration/trino/truth1/admin-utility.md
+++ b/docs/migration/trino/truth1/admin-utility.md
@@ -1,0 +1,818 @@
+# Trino 481 — Administrative / Session / Transaction / Prepared-Statement / Utility Statements
+
+---
+
+## use
+
+- **syntax:**
+  ```
+  USE catalog.schema
+  USE schema
+  ```
+- **source_url:** https://trino.io/docs/current/sql/use.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  USE hive.finance;
+  USE information_schema;
+  ```
+- **notes:** Two forms: explicit `catalog.schema` or schema-only (resolves against the current catalog). Updates the session scope for subsequent queries.
+
+---
+
+## set-session
+
+- **syntax:**
+  ```
+  SET SESSION name = expression
+  SET SESSION catalog.name = expression
+  ```
+- **source_url:** https://trino.io/docs/current/sql/set-session.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SET SESSION query_max_run_time = '10m';
+  SET SESSION example.incremental_refresh_enabled = false;
+  ```
+- **notes:** System session properties apply cluster-wide; catalog session properties are connector-defined and must be prefixed with the catalog name. Changes are session-scoped and are lost when the session ends.
+
+---
+
+## reset-session
+
+- **syntax:**
+  ```
+  RESET SESSION name
+  RESET SESSION catalog.name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/reset-session.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  RESET SESSION query_max_run_time;
+  RESET SESSION hive.optimized_reader_enabled;
+  ```
+- **notes:** Restores the named property to its default value. Catalog-scoped properties use dot notation `catalog.name`.
+
+---
+
+## set-session-authorization
+
+- **syntax:**
+  ```
+  SET SESSION AUTHORIZATION username
+  ```
+- **source_url:** https://trino.io/docs/current/sql/set-session-authorization.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SET SESSION AUTHORIZATION 'John';
+  SET SESSION AUTHORIZATION "John";
+  SET SESSION AUTHORIZATION John;
+  ```
+- **notes:** Changes the current user of the session. The original connecting user must have impersonation privileges for the target user (configured in system access control). All three quoting styles (single quotes, double quotes, or unquoted) are accepted.
+
+---
+
+## reset-session-authorization
+
+- **syntax:**
+  ```
+  RESET SESSION AUTHORIZATION
+  ```
+- **source_url:** https://trino.io/docs/current/sql/reset-session-authorization.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  RESET SESSION AUTHORIZATION;
+  ```
+- **notes:** Resets the current authorization user back to the original user (the authenticated principal or the session user provided by the client). No arguments. Counterpart to `SET SESSION AUTHORIZATION`.
+
+---
+
+## set-role
+
+- **syntax:**
+  ```
+  SET ROLE ( role | ALL | NONE )
+  [ IN catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/set-role.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SET ROLE admin;
+  SET ROLE ALL;
+  SET ROLE NONE;
+  SET ROLE analyst IN hive;
+  ```
+- **notes:** `SET ROLE role` activates a specific role (user must have a grant for it); `ALL` activates every granted role; `NONE` deactivates all roles. Optional `IN catalog` restricts the effect to a specific catalog. Some connectors do not support role management.
+
+---
+
+## set-path
+
+- **syntax:**
+  ```
+  SET PATH path-element[, ...]
+  ```
+  where each path-element is `catalog.schema` or `schema`.
+- **source_url:** https://trino.io/docs/current/sql/set-path.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SET PATH example.system;
+  ```
+- **notes:** Defines a collection of catalog/schema paths for function lookup in the current session. Allows unqualified function references without full `catalog.schema.function` paths. Both `catalog.schema` and bare `schema` (resolved against current catalog) are valid path elements. Session-scoped.
+
+---
+
+## set-time-zone
+
+- **syntax:**
+  ```
+  SET TIME ZONE LOCAL
+  SET TIME ZONE expression
+  ```
+- **source_url:** https://trino.io/docs/current/sql/set-time-zone.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SET TIME ZONE LOCAL;
+  SET TIME ZONE '-08:00';
+  SET TIME ZONE INTERVAL '10' HOUR;
+  SET TIME ZONE INTERVAL -'08:00' HOUR TO MINUTE;
+  SET TIME ZONE 'America/Los_Angeles';
+  SET TIME ZONE concat_ws('/', 'America', 'Los_Angeles');
+  ```
+- **notes:** `LOCAL` resets to the initial session time zone. The expression can be a region-based ID string (e.g., `'America/Los_Angeles'`), a UTC-offset string (e.g., `'-08:00'`), or an interval expression (UTC offset range −14 to +14 hours). Has no effect if the `sql.forced-session-time-zone` configuration property is set.
+
+---
+
+## create-role
+
+- **syntax:**
+  ```
+  CREATE ROLE role_name
+  [ WITH ADMIN ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
+  [ IN catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-role.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CREATE ROLE admin;
+  CREATE ROLE moderator WITH ADMIN USER bob;
+  ```
+- **notes:** Optional `WITH ADMIN` clause designates a role administrator; without it the current user becomes admin. Optional `IN catalog` scopes the role to a specific catalog. Some connectors do not support role management.
+
+---
+
+## drop-role
+
+- **syntax:**
+  ```
+  DROP ROLE [ IF EXISTS ] role_name
+  [ IN catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-role.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DROP ROLE admin;
+  DROP ROLE IF EXISTS analyst IN hive;
+  ```
+- **notes:** Requires admin privileges on the role. `IF EXISTS` suppresses errors when the role does not exist. `IN catalog` scopes to a catalog-level role. Some connectors do not support role management.
+
+---
+
+## grant-privilege
+
+- **syntax:**
+  ```
+  GRANT ( privilege [, ...] | ( ALL PRIVILEGES ) )
+  ON [ BRANCH branch_name IN ] ( table_name | TABLE table_name | SCHEMA schema_name )
+  TO ( user | USER user | ROLE role )
+  [ WITH GRANT OPTION ]
+  ```
+  where `privilege` is one of: `SELECT`, `INSERT`, `UPDATE`, `DELETE`.
+- **source_url:** https://trino.io/docs/current/sql/grant.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  GRANT INSERT, SELECT ON orders TO alice;
+  GRANT DELETE ON SCHEMA finance TO bob;
+  GRANT SELECT ON nation TO alice WITH GRANT OPTION;
+  GRANT SELECT ON orders TO ROLE PUBLIC;
+  GRANT INSERT ON BRANCH audit IN orders TO alice;
+  ```
+- **notes:** `ALL PRIVILEGES` covers DELETE, INSERT, UPDATE, and SELECT. Granting on a table applies to all current and future columns; granting on a schema applies to all columns of all current and future tables in the schema. `WITH GRANT OPTION` allows the grantee to further grant privileges. Granting to `ROLE PUBLIC` affects all users. The optional `BRANCH branch_name IN` targets a specific branch of a versioned table. Some connectors have no support for `GRANT`.
+
+---
+
+## grant-role
+
+- **syntax:**
+  ```
+  GRANT role_name [, ...]
+  TO ( user | USER user_name | ROLE role_name ) [, ...]
+  [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
+  [ WITH ADMIN OPTION ]
+  [ IN catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/grant-roles.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  GRANT bar TO USER foo;
+  GRANT bar, foo TO USER baz, ROLE qux WITH ADMIN OPTION;
+  ```
+- **notes:** Grants one or more roles to one or more principals. `WITH ADMIN OPTION` allows recipients to grant the role to others. `GRANTED BY` designates which principal acts as grantor; defaults to current user. `IN catalog` scopes to catalog-specific roles. The executing user must be a role admin or possess the grant option. Some connectors do not support role management.
+
+---
+
+## revoke-privilege
+
+- **syntax:**
+  ```
+  REVOKE [ GRANT OPTION FOR ]
+  ( privilege [, ...] | ALL PRIVILEGES )
+  ON [ BRANCH branch_name IN ] ( table_name | TABLE table_name | SCHEMA schema_name )
+  FROM ( user | USER user | ROLE role )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/revoke.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  REVOKE INSERT, SELECT ON orders FROM alice;
+  REVOKE DELETE ON SCHEMA finance FROM bob;
+  REVOKE GRANT OPTION FOR SELECT ON nation FROM ROLE PUBLIC;
+  REVOKE ALL PRIVILEGES ON test FROM alice;
+  REVOKE INSERT ON BRANCH audit IN orders FROM alice;
+  ```
+- **notes:** `GRANT OPTION FOR` removes only the right to grant privileges, leaving the privilege itself intact. Revoking from `ROLE PUBLIC` affects only that role assignment; users may still retain directly-granted or other role-based permissions. Revoke on a table affects all columns; revoke on a schema affects all columns of all tables. The executor must hold the privileges being revoked AND the grant option. Some connectors have no support for `REVOKE`.
+
+---
+
+## revoke-role
+
+- **syntax:**
+  ```
+  REVOKE
+  [ ADMIN OPTION FOR ]
+  role_name [, ...]
+  FROM ( user | USER user | ROLE role ) [, ...]
+  [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
+  [ IN catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/revoke-roles.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  REVOKE bar FROM USER foo;
+  REVOKE ADMIN OPTION FOR bar, foo FROM USER baz, ROLE qux;
+  ```
+- **notes:** `ADMIN OPTION FOR` revokes only the grant permission without removing the role assignment itself. `GRANTED BY` designates the revoker principal; defaults to current user. `IN catalog` scopes to catalog-level roles. Executor must be role admin or hold the grant option. Some connectors do not support role management.
+
+---
+
+## deny
+
+- **syntax:**
+  ```
+  DENY ( privilege [, ...] | ( ALL PRIVILEGES ) )
+  ON [ BRANCH branch_name IN ] ( table_name | TABLE table_name | SCHEMA schema_name )
+  TO ( user | USER user | ROLE role )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/deny.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DENY INSERT, SELECT ON orders TO alice;
+  DENY DELETE ON SCHEMA finance TO bob;
+  DENY SELECT ON orders TO ROLE PUBLIC;
+  DENY INSERT ON BRANCH audit IN orders TO alice;
+  ```
+- **notes:** Explicitly rejects specified privileges. On a table, denies on all current and future columns; on a schema, denies on all columns of all current and future tables. The default Trino system access controls and connectors have no support for `DENY`; custom connector/access-control implementation is required. Supports branch-specific denials via the `BRANCH branch_name IN` clause.
+
+---
+
+## show-grants
+
+- **syntax:**
+  ```
+  SHOW GRANTS [ ON [ TABLE ] table_name ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-grants.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW GRANTS ON TABLE orders;
+  SHOW GRANTS;
+  ```
+- **notes:** Without `ON`, shows grants for the current user across all tables in all schemas of the current catalog. Requires the current catalog to be set. Authentication must be enabled. Not all connectors support this statement.
+
+---
+
+## show-roles
+
+- **syntax:**
+  ```
+  SHOW [ CURRENT ] ROLES [ FROM catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-roles.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW ROLES;
+  SHOW ROLES FROM hive;
+  SHOW CURRENT ROLES;
+  SHOW CURRENT ROLES FROM hive;
+  ```
+- **notes:** Without `CURRENT`, lists all system roles or all roles in the specified catalog. With `CURRENT`, lists only the enabled/active roles for the session. `FROM catalog` scopes to a specific catalog.
+
+---
+
+## show-role-grants
+
+- **syntax:**
+  ```
+  SHOW ROLE GRANTS [ FROM catalog ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-role-grants.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW ROLE GRANTS;
+  SHOW ROLE GRANTS FROM hive;
+  ```
+- **notes:** Lists non-recursively the system roles (or catalog roles) that have been directly granted to the current session user. Does not enumerate transitively inherited roles.
+
+---
+
+## show-catalogs
+
+- **syntax:**
+  ```
+  SHOW CATALOGS [ LIKE pattern ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-catalogs.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW CATALOGS;
+  SHOW CATALOGS LIKE 't%';
+  ```
+- **notes:** Without `LIKE`, returns all available catalogs. The `LIKE` clause uses standard SQL pattern syntax for filtering.
+
+---
+
+## show-schemas
+
+- **syntax:**
+  ```
+  SHOW SCHEMAS [ FROM catalog ] [ LIKE pattern ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-schemas.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW SCHEMAS;
+  SHOW SCHEMAS FROM tpch;
+  SHOW SCHEMAS FROM tpch LIKE '__3%';
+  ```
+- **notes:** Without `FROM`, uses the current catalog. The `LIKE` clause supports `_` (single-character wildcard) and `%` (multi-character wildcard).
+
+---
+
+## show-tables
+
+- **syntax:**
+  ```
+  SHOW TABLES [ FROM schema ] [ LIKE pattern ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-tables.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW TABLES;
+  SHOW TABLES FROM tpch.tiny;
+  SHOW TABLES FROM tpch.tiny LIKE 'p%';
+  ```
+- **notes:** Returns both tables and views together. `FROM schema` accepts a fully qualified `catalog.schema` form, enabling cross-catalog queries. Without `FROM`, uses the current schema. The `LIKE` clause filters by name pattern.
+
+---
+
+## show-columns
+
+- **syntax:**
+  ```
+  SHOW COLUMNS FROM table [ LIKE pattern ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-columns.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW COLUMNS FROM nation;
+  SHOW COLUMNS FROM nation LIKE '%key';
+  ```
+- **notes:** Returns columns: `Column`, `Type`, `Extra`, `Comment`. The optional `LIKE` clause filters the result to a subset of columns.
+
+---
+
+## show-create-table
+
+- **syntax:**
+  ```
+  SHOW CREATE TABLE table_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-create-table.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW CREATE TABLE sf1.orders;
+  ```
+- **notes:** Returns the `CREATE TABLE` statement that would recreate the table, including column definitions, data types, and connector-specific `WITH` properties (e.g., `format`, `partitioned_by`).
+
+---
+
+## show-create-view
+
+- **syntax:**
+  ```
+  SHOW CREATE VIEW view_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-create-view.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW CREATE VIEW my_view;
+  ```
+- **notes:** Returns the `CREATE VIEW` statement that defines the specified view. No additional options.
+
+---
+
+## show-create-schema
+
+- **syntax:**
+  ```
+  SHOW CREATE SCHEMA schema_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-create-schema.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW CREATE SCHEMA hive.web;
+  ```
+- **notes:** Returns the `CREATE SCHEMA` statement that would recreate the schema. No additional options.
+
+---
+
+## show-create-materialized-view
+
+- **syntax:**
+  ```
+  SHOW CREATE MATERIALIZED VIEW view_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-create-materialized-view.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW CREATE MATERIALIZED VIEW my_mv;
+  ```
+- **notes:** Returns the `CREATE MATERIALIZED VIEW` statement that defines the specified materialized view.
+
+---
+
+## show-create-function
+
+- **syntax:**
+  ```
+  SHOW CREATE FUNCTION function_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-create-function.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW CREATE FUNCTION example.default.meaning_of_life;
+  ```
+- **notes:** Displays the `CREATE FUNCTION` statement for a user-defined function. The function name should be fully qualified (`catalog.schema.function`).
+
+---
+
+## show-functions
+
+- **syntax:**
+  ```
+  SHOW FUNCTIONS [ FROM schema ] [ LIKE pattern ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-functions.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW FUNCTIONS FROM example.default;
+  SHOW FUNCTIONS LIKE 'array%';
+  SHOW FUNCTIONS LIKE 'cf%';
+  ```
+- **notes:** Lists built-in, plugin, and user-defined functions. Result columns: `Function`, `Return Type`, `Argument Types`, `Function Type`, `Deterministic`, `Description`. `FROM schema` must use `catalog.schema` fully qualified form. `LIKE` filters by function name.
+
+---
+
+## show-session
+
+- **syntax:**
+  ```
+  SHOW SESSION [ LIKE pattern ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-session.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW SESSION;
+  SHOW SESSION LIKE 'query%';
+  ```
+- **notes:** Displays current session properties and their values. Without `LIKE`, shows all properties. Read-only diagnostic statement.
+
+---
+
+## show-stats
+
+- **syntax:**
+  ```
+  SHOW STATS FOR table
+  SHOW STATS FOR ( query )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/show-stats.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SHOW STATS FOR nation;
+  SHOW STATS FOR (SELECT * FROM nation WHERE regionkey = 1);
+  ```
+- **notes:** Returns approximate statistics with one row per column plus a summary row (identified by `NULL` in `column_name`). Result columns: `column_name`, `data_size` (string types only), `distinct_values_count`, `nulls_fractions`, `row_count` (summary row only), `low_value`, `high_value` (DATE/numeric types). Returns `NULL` for any statistics that are unavailable or not populated on the data source.
+
+---
+
+## describe
+
+- **syntax:**
+  ```
+  DESCRIBE table_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/describe.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DESCRIBE nation;
+  ```
+- **notes:** `DESCRIBE` is an alias for `SHOW COLUMNS`. Returns the same result set: `Column`, `Type`, `Extra`, `Comment`. `DESC` is also accepted as a short form.
+
+---
+
+## describe-input
+
+- **syntax:**
+  ```
+  DESCRIBE INPUT statement_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/describe-input.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  PREPARE my_select1 FROM
+  SELECT ? FROM nation WHERE regionkey = ? AND name < ?;
+  DESCRIBE INPUT my_select1;
+
+  PREPARE my_select2 FROM
+  SELECT * FROM nation;
+  DESCRIBE INPUT my_select2;
+  ```
+- **notes:** Lists input parameters (`?` placeholders) of a prepared statement with zero-based `Position` and `Type`. Parameters with indeterminate types are shown as `unknown`. Returns empty result set if the prepared statement has no parameters.
+
+---
+
+## describe-output
+
+- **syntax:**
+  ```
+  DESCRIBE OUTPUT statement_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/describe-output.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  PREPARE my_select1 FROM
+  SELECT * FROM nation;
+  DESCRIBE OUTPUT my_select1;
+
+  PREPARE my_select2 FROM
+  SELECT count(*) as my_count, 1+2 FROM nation;
+  DESCRIBE OUTPUT my_select2;
+
+  PREPARE my_create FROM
+  CREATE TABLE foo AS SELECT * FROM nation;
+  DESCRIBE OUTPUT my_create;
+
+  DESCRIBE OUTPUT (SELECT *, n_name AS "name" FROM nation);
+  ```
+- **notes:** Lists output columns of a prepared statement (or an inline query). Result columns: column name/alias, catalog, schema, table, type, type size in bytes, aliased (boolean). For DDL-like statements (e.g., `CREATE TABLE AS`), returns a single `rows` column. The fourth form (`DESCRIBE OUTPUT (query)`) works without a prior `PREPARE`.
+
+---
+
+## explain
+
+- **syntax:**
+  ```
+  EXPLAIN [ ( option [, ...] ) ] statement
+
+  where option can be one of:
+      FORMAT { TEXT | GRAPHVIZ | JSON }
+      TYPE { LOGICAL | DISTRIBUTED | VALIDATE | IO }
+  ```
+- **source_url:** https://trino.io/docs/current/sql/explain.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  EXPLAIN (TYPE LOGICAL) SELECT regionkey, count(*) FROM nation GROUP BY 1;
+  EXPLAIN (TYPE LOGICAL, FORMAT JSON) SELECT regionkey, count(*) FROM nation GROUP BY 1;
+  EXPLAIN (TYPE DISTRIBUTED) SELECT regionkey, count(*) FROM nation GROUP BY 1;
+  EXPLAIN (TYPE DISTRIBUTED, FORMAT JSON) SELECT regionkey, count(*) FROM nation GROUP BY 1;
+  EXPLAIN (TYPE VALIDATE) SELECT regionkey, count(*) FROM nation GROUP BY 1;
+  EXPLAIN (TYPE IO, FORMAT JSON) INSERT INTO test_lineitem SELECT * FROM lineitem WHERE shipdate = '2020-02-01' AND quantity > 10;
+  ```
+- **notes:** Default TYPE is `DISTRIBUTED`; default FORMAT is `TEXT`. `TYPE LOGICAL` is deprecated and will be removed in a future release (use `DISTRIBUTED` instead). `TYPE VALIDATE` returns a boolean (`true`/`false`) indicating whether the statement is valid. `TYPE IO` (JSON only) provides input/output object details. JSON output format is not guaranteed to be backward compatible across Trino versions. Fragment types in distributed plans: `SINGLE`, `HASH`, `ROUND_ROBIN`, `BROADCAST`, `SOURCE`.
+
+---
+
+## explain-analyze
+
+- **syntax:**
+  ```
+  EXPLAIN ANALYZE [ VERBOSE ] statement
+  ```
+- **source_url:** https://trino.io/docs/current/sql/explain-analyze.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  EXPLAIN ANALYZE SELECT count(*), clerk FROM orders
+  WHERE orderdate > date '1995-01-01' GROUP BY clerk;
+
+  EXPLAIN ANALYZE VERBOSE SELECT count(clerk) OVER() FROM orders
+  WHERE orderdate > date '1995-01-01';
+  ```
+- **notes:** Executes the statement and displays the distributed execution plan with actual runtime statistics (CPU time, wall time, input/output rows/bytes per plan node). `VERBOSE` adds detailed low-level statistics (e.g., percentile distributions of CPU time, input rows, scheduled time, active drivers) that may require knowledge of Trino internals to interpret. Stats may not be entirely accurate for queries that complete quickly.
+
+---
+
+## prepare
+
+- **syntax:**
+  ```
+  PREPARE statement_name FROM statement
+  ```
+- **source_url:** https://trino.io/docs/current/sql/prepare.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  PREPARE my_select1 FROM SELECT * FROM nation;
+
+  PREPARE my_select2 FROM
+  SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?;
+
+  PREPARE my_insert FROM
+  INSERT INTO cities VALUES (1, 'San Francisco');
+  ```
+- **notes:** Saves a query in the session under `statement_name` for later execution. Parameters use `?` placeholders. Session-scoped; disappears when the session ends or is removed with `DEALLOCATE PREPARE`.
+
+---
+
+## execute
+
+- **syntax:**
+  ```
+  EXECUTE statement_name [ USING parameter1 [ , parameter2, ... ] ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/execute.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  PREPARE my_select1 FROM SELECT name FROM nation;
+  EXECUTE my_select1;
+
+  PREPARE my_select2 FROM
+  SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?;
+  EXECUTE my_select2 USING 1, 3;
+  ```
+- **notes:** Runs a previously prepared statement. Parameters are supplied positionally via `USING`. The second example is equivalent to `SELECT name FROM nation WHERE regionkey = 1 AND nationkey < 3`.
+
+---
+
+## execute-immediate
+
+- **syntax:**
+  ```
+  EXECUTE IMMEDIATE 'statement' [ USING parameter1 [ , parameter2, ... ] ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/execute-immediate.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  EXECUTE IMMEDIATE 'SELECT name FROM nation';
+
+  EXECUTE IMMEDIATE
+  'SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?'
+  USING 1, 3;
+  ```
+- **notes:** Executes a SQL string directly without the need for a prior `PREPARE` or subsequent `DEALLOCATE PREPARE`. Combines the full prepare-execute-deallocate lifecycle into one statement. Parameters use `?` placeholders supplied positionally via `USING`.
+
+---
+
+## deallocate-prepare
+
+- **syntax:**
+  ```
+  DEALLOCATE PREPARE statement_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/deallocate-prepare.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DEALLOCATE PREPARE my_query;
+  ```
+- **notes:** Removes a named prepared statement from the current session's list. After deallocation, the statement name is no longer available for `EXECUTE` or `DESCRIBE INPUT/OUTPUT`.
+
+---
+
+## start-transaction
+
+- **syntax:**
+  ```
+  START TRANSACTION [ mode [, ...] ]
+
+  where mode is one of:
+      ISOLATION LEVEL { READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE }
+      READ { ONLY | WRITE }
+  ```
+- **source_url:** https://trino.io/docs/current/sql/start-transaction.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  START TRANSACTION;
+  START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+  START TRANSACTION READ WRITE;
+  START TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY;
+  START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE;
+  ```
+- **notes:** Starts a new transaction for the current session. Multiple modes can be combined in one statement (comma-separated). All four isolation levels are syntactically supported; connector support varies.
+
+---
+
+## commit
+
+- **syntax:**
+  ```
+  COMMIT [ WORK ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/commit.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  COMMIT;
+  COMMIT WORK;
+  ```
+- **notes:** Commits the current transaction, making all changes permanent. The `WORK` keyword is optional and has no functional effect.
+
+---
+
+## rollback
+
+- **syntax:**
+  ```
+  ROLLBACK [ WORK ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/rollback.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  ROLLBACK;
+  ROLLBACK WORK;
+  ```
+- **notes:** Rolls back the current transaction, discarding all changes. The `WORK` keyword is optional and has no functional effect.
+
+---
+
+## call
+
+- **syntax:**
+  ```
+  CALL procedure_name ( [ name => ] expression [, ...] )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/call.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CALL test(123, 'apple');
+  CALL test(name => 'apple', id => 123);
+  CALL catalog.schema.test();
+  ```
+- **notes:** Invokes connector-provided procedures for data manipulation or administrative tasks. Both positional and named (`name => value`) argument styles are supported. Procedure name can be fully qualified as `catalog.schema.procedure`. Note: stored procedures from external databases (e.g., PostgreSQL) are not callable via `CALL`; only Trino connector-defined procedures work.

--- a/docs/migration/trino/truth1/ddl.md
+++ b/docs/migration/trino/truth1/ddl.md
@@ -1,0 +1,827 @@
+# Trino DDL/Schema Syntax Reference — crawled from trino.io/docs/current/ (Trino 481, "current")
+
+---
+
+## create-schema
+
+- **syntax:**
+  ```
+  CREATE SCHEMA [ IF NOT EXISTS ] schema_name
+  [ AUTHORIZATION ( user | USER user | ROLE role ) ]
+  [ WITH ( property_name = expression [, ...] ) ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-schema.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE SCHEMA web;
+
+  CREATE SCHEMA hive.sales;
+
+  CREATE SCHEMA IF NOT EXISTS traffic;
+
+  CREATE SCHEMA web AUTHORIZATION alice;
+
+  CREATE SCHEMA web AUTHORIZATION alice WITH ( LOCATION = '/hive/data/web' );
+
+  CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC;
+
+  CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC WITH ( LOCATION = '/hive/data/web' );
+  ```
+- **notes:** `IF NOT EXISTS` suppresses error if schema already exists. `AUTHORIZATION` accepts bare user name, `USER user`, or `ROLE role` (including `ROLE PUBLIC`). `WITH` passes connector-specific properties (e.g. `LOCATION`).
+
+---
+
+## drop-schema
+
+- **syntax:**
+  ```
+  DROP SCHEMA [ IF EXISTS ] schema_name [ CASCADE | RESTRICT ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-schema.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  DROP SCHEMA web;
+
+  DROP SCHEMA IF EXISTS sales;
+
+  DROP SCHEMA archive CASCADE;
+
+  DROP SCHEMA archive RESTRICT;
+  ```
+- **notes:** Schema must be empty unless `CASCADE` is specified. `CASCADE` removes the schema together with all contained objects. `RESTRICT` (default behavior) only succeeds when schema is empty.
+
+---
+
+## alter-schema-rename
+
+- **syntax:**
+  ```
+  ALTER SCHEMA name RENAME TO new_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-schema.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER SCHEMA web RENAME TO traffic;
+  ```
+- **notes:** Renames the schema to a new identifier.
+
+---
+
+## alter-schema-set-authorization
+
+- **syntax:**
+  ```
+  ALTER SCHEMA name SET AUTHORIZATION ( user | USER user | ROLE role )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-schema.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER SCHEMA web SET AUTHORIZATION alice;
+
+  ALTER SCHEMA web SET AUTHORIZATION ROLE PUBLIC;
+  ```
+- **notes:** Transfers ownership to a user or role. Accepts bare user name, `USER user`, or `ROLE role`.
+
+---
+
+## create-table
+
+- **syntax:**
+  ```
+  CREATE [ OR REPLACE ] TABLE [ IF NOT EXISTS ]
+  table_name (
+    { column_name data_type [ DEFAULT default ] [ NOT NULL ]
+        [ COMMENT comment ]
+        [ WITH ( property_name = expression [, ...] ) ]
+    | LIKE existing_table_name
+        [ { INCLUDING | EXCLUDING } PROPERTIES ]
+    }
+    [, ...]
+  )
+  [ COMMENT table_comment ]
+  [ WITH ( property_name = expression [, ...] ) ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE TABLE orders (
+    orderkey bigint,
+    orderstatus varchar,
+    totalprice double,
+    orderdate date
+  )
+  WITH (format = 'ORC');
+
+  CREATE TABLE IF NOT EXISTS orders (
+    orderkey bigint,
+    orderstatus varchar,
+    totalprice double COMMENT 'Price in cents.',
+    orderdate date,
+    status varchar DEFAULT 'created'
+  )
+  COMMENT 'A table to keep track of orders.';
+
+  CREATE TABLE bigger_orders (
+    another_orderkey bigint,
+    LIKE orders,
+    another_orderdate date
+  );
+  ```
+- **notes:** `OR REPLACE` support is connector-dependent. Multiple `LIKE` clauses are allowed. `INCLUDING PROPERTIES` copies table properties from the source table; default is `EXCLUDING PROPERTIES`. Column-level `WITH` sets per-column connector properties. Available table properties can be discovered via `SELECT * FROM system.metadata.table_properties`.
+
+---
+
+## create-table-as
+
+- **syntax:**
+  ```
+  CREATE [ OR REPLACE ] TABLE [ IF NOT EXISTS ] table_name [ ( column_alias, ... ) ]
+  [ COMMENT table_comment ]
+  [ WITH ( property_name = expression [, ...] ) ]
+  AS query
+  [ WITH [ NO ] DATA ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-table-as.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE TABLE orders_column_aliased (order_date, total_price)
+  AS
+  SELECT orderdate, totalprice
+  FROM orders;
+
+  CREATE TABLE orders_by_date
+  COMMENT 'Summary of orders by date'
+  WITH (format = 'ORC')
+  AS
+  SELECT orderdate, sum(totalprice) AS price
+  FROM orders
+  GROUP BY orderdate;
+
+  CREATE TABLE IF NOT EXISTS orders_by_date AS
+  SELECT orderdate, sum(totalprice) AS price
+  FROM orders
+  GROUP BY orderdate;
+
+  CREATE TABLE empty_nation AS
+  SELECT *
+  FROM nation
+  WITH NO DATA;
+  ```
+- **notes:** `OR REPLACE` and `IF NOT EXISTS` cannot be used together. `WITH NO DATA` creates the table structure without inserting rows. Column aliases in the parenthesized list rename the SELECT output columns.
+
+---
+
+## drop-table
+
+- **syntax:**
+  ```
+  DROP TABLE [ IF EXISTS ] table_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  DROP TABLE orders_by_date;
+
+  DROP TABLE IF EXISTS orders_by_date;
+  ```
+- **notes:** `IF EXISTS` suppresses errors when the table does not exist. Does not suppress errors if a view with the same name exists.
+
+---
+
+## alter-table-rename
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name RENAME TO new_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users RENAME TO people;
+
+  ALTER TABLE IF EXISTS users RENAME TO people;
+  ```
+- **notes:** `IF EXISTS` suppresses errors if the table does not exist.
+
+---
+
+## alter-table-add-column
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name ADD COLUMN [ IF NOT EXISTS ] column_name data_type
+    [ DEFAULT default ] [ NOT NULL ] [ COMMENT comment ]
+    [ WITH ( property_name = expression [, ...] ) ]
+    [ FIRST | LAST | AFTER after_column_name ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users ADD COLUMN zip varchar;
+
+  ALTER TABLE users ADD COLUMN zip varchar DEFAULT '90210';
+
+  ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS zip varchar;
+
+  ALTER TABLE users ADD COLUMN id varchar FIRST;
+
+  ALTER TABLE users ADD COLUMN zip varchar AFTER country;
+  ```
+- **notes:** `IF NOT EXISTS` on the column name suppresses errors if the column already exists. Column position can be controlled with `FIRST`, `LAST`, or `AFTER column_name`. Column-level `WITH` sets connector-specific column properties.
+
+---
+
+## alter-table-drop-column
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name DROP COLUMN [ IF EXISTS ] column_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users DROP COLUMN zip;
+
+  ALTER TABLE IF EXISTS users DROP COLUMN IF EXISTS zip;
+  ```
+- **notes:** Both `IF EXISTS` modifiers are independent; each suppresses the respective "not found" error.
+
+---
+
+## alter-table-rename-column
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name RENAME COLUMN [ IF EXISTS ] old_name TO new_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users RENAME COLUMN id TO user_id;
+
+  ALTER TABLE IF EXISTS users RENAME COLUMN IF EXISTS id TO user_id;
+  ```
+- **notes:** `IF EXISTS` on the column suppresses errors if the column does not exist.
+
+---
+
+## alter-table-alter-column-set-default
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name ALTER COLUMN column_name SET DEFAULT expression
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active';
+  ```
+- **notes:** Sets a default value on an existing column.
+
+---
+
+## alter-table-alter-column-drop-default
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name ALTER COLUMN column_name DROP DEFAULT
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users ALTER COLUMN status DROP DEFAULT;
+  ```
+- **notes:** Removes the default value from an existing column.
+
+---
+
+## alter-table-alter-column-set-data-type
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name ALTER COLUMN column_name SET DATA TYPE new_type
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users ALTER COLUMN id SET DATA TYPE bigint;
+  ```
+- **notes:** Changes the data type of an existing column. Connector support varies.
+
+---
+
+## alter-table-alter-column-drop-not-null
+
+- **syntax:**
+  ```
+  ALTER TABLE [ IF EXISTS ] name ALTER COLUMN column_name DROP NOT NULL
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE users ALTER COLUMN id DROP NOT NULL;
+  ```
+- **notes:** Removes the `NOT NULL` constraint from an existing column.
+
+---
+
+## alter-table-set-authorization
+
+- **syntax:**
+  ```
+  ALTER TABLE name SET AUTHORIZATION ( user | USER user | ROLE role )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE people SET AUTHORIZATION alice;
+
+  ALTER TABLE people SET AUTHORIZATION ROLE PUBLIC;
+  ```
+- **notes:** `IF EXISTS` is not documented for this sub-form. Accepts bare user name, `USER user`, or `ROLE role`.
+
+---
+
+## alter-table-set-properties
+
+- **syntax:**
+  ```
+  ALTER TABLE name SET PROPERTIES property_name = expression [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE people SET PROPERTIES x = 'y';
+
+  ALTER TABLE people SET PROPERTIES foo = 123, "foo bar" = 456;
+
+  ALTER TABLE people SET PROPERTIES x = DEFAULT;
+  ```
+- **notes:** `DEFAULT` keyword resets a property to its default value. Omitting a property leaves it unchanged. `IF EXISTS` is not documented for this sub-form.
+
+---
+
+## alter-table-execute
+
+- **syntax:**
+  ```
+  ALTER TABLE name EXECUTE command [ ( parameter => expression [, ... ] ) ]
+      [ WHERE expression ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-table.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER TABLE example.test.test_table EXECUTE optimize(file_size_threshold => '16MB');
+  ```
+- **notes:** Named parameters use the `=>` operator. The optional `WHERE` clause restricts which partitions or rows the procedure operates on. `IF EXISTS` is not documented for this sub-form.
+
+---
+
+## truncate-table
+
+- **syntax:**
+  ```
+  TRUNCATE TABLE table_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/truncate.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  TRUNCATE TABLE orders;
+  ```
+- **notes:** Deletes all rows from a table. No `IF EXISTS` or `CASCADE` clauses are documented.
+
+---
+
+## comment-on-table
+
+- **syntax:**
+  ```
+  COMMENT ON TABLE name IS 'comments'
+  ```
+- **source_url:** https://trino.io/docs/current/sql/comment.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  COMMENT ON TABLE users IS 'master table';
+
+  COMMENT ON TABLE users IS NULL;
+  ```
+- **notes:** Setting the comment to `NULL` removes the existing comment.
+
+---
+
+## comment-on-view
+
+- **syntax:**
+  ```
+  COMMENT ON VIEW name IS 'comments'
+  ```
+- **source_url:** https://trino.io/docs/current/sql/comment.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  COMMENT ON VIEW users IS 'master view';
+
+  COMMENT ON VIEW users IS NULL;
+  ```
+- **notes:** Setting the comment to `NULL` removes the existing comment.
+
+---
+
+## comment-on-column
+
+- **syntax:**
+  ```
+  COMMENT ON COLUMN name IS 'comments'
+  ```
+- **source_url:** https://trino.io/docs/current/sql/comment.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  COMMENT ON COLUMN users.name IS 'full name';
+
+  COMMENT ON COLUMN users.name IS NULL;
+  ```
+- **notes:** `name` is a qualified column reference in the form `table.column` or `catalog.schema.table.column`. Setting the comment to `NULL` removes the existing comment.
+
+---
+
+## create-view
+
+- **syntax:**
+  ```
+  CREATE [ OR REPLACE ] VIEW view_name
+  [ COMMENT view_comment ]
+  [ SECURITY { DEFINER | INVOKER } ]
+  AS query
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE VIEW test AS
+  SELECT orderkey, orderstatus, totalprice / 2 AS half
+  FROM orders;
+
+  CREATE VIEW test_with_comment
+  COMMENT 'A view to keep track of orders.'
+  AS
+  SELECT orderkey, orderstatus, totalprice
+  FROM orders;
+
+  CREATE OR REPLACE VIEW test AS
+  SELECT orderkey, orderstatus, totalprice / 4 AS quarter
+  FROM orders;
+  ```
+- **notes:** `SECURITY DEFINER` (default) executes the view query with the view creator's permissions. `SECURITY INVOKER` uses the executing user's permissions. The `current_user` function always returns the actual query executor regardless of security mode.
+
+---
+
+## drop-view
+
+- **syntax:**
+  ```
+  DROP VIEW [ IF EXISTS ] view_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  DROP VIEW orders_by_date;
+
+  DROP VIEW IF EXISTS orders_by_date;
+  ```
+- **notes:** `IF EXISTS` suppresses errors when the view does not exist.
+
+---
+
+## alter-view-rename
+
+- **syntax:**
+  ```
+  ALTER VIEW name RENAME TO new_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER VIEW people RENAME TO users;
+  ```
+- **notes:** Renames an existing view.
+
+---
+
+## alter-view-refresh
+
+- **syntax:**
+  ```
+  ALTER VIEW name REFRESH
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER VIEW people REFRESH;
+  ```
+- **notes:** Refreshes the view's definition or cached metadata. Connector support varies.
+
+---
+
+## alter-view-set-authorization
+
+- **syntax:**
+  ```
+  ALTER VIEW name SET AUTHORIZATION ( user | USER user | ROLE role )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER VIEW people SET AUTHORIZATION alice;
+  ```
+- **notes:** Transfers ownership of the view to a user or role.
+
+---
+
+## create-materialized-view
+
+- **syntax:**
+  ```
+  CREATE [ OR REPLACE ] MATERIALIZED VIEW
+  [ IF NOT EXISTS ] view_name
+  [ GRACE PERIOD interval ]
+  [ WHEN STALE ( INLINE | FAIL ) ]
+  [ COMMENT string ]
+  [ WITH ( property_name = expression [, ...] ) ]
+  AS query
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-materialized-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE MATERIALIZED VIEW cancelled_orders
+  AS
+      SELECT orderkey, totalprice
+      FROM orders
+      WHERE orderstatus = 3;
+
+  CREATE OR REPLACE MATERIALIZED VIEW order_totals_by_date
+  AS
+      SELECT orderdate, sum(totalprice) AS price
+      FROM orders
+      GROUP BY orderdate;
+
+  CREATE MATERIALIZED VIEW orders_nation_mkgsegment
+  COMMENT 'Orders with nation and market segment data'
+  WITH ( partitioning = ARRAY['mktsegment', 'nationkey'] )
+  AS
+      SELECT o.*, c.nationkey, c.mktsegment
+      FROM orders AS o
+      JOIN customer AS c
+      ON o.custkey = c.custkey;
+
+  CREATE MATERIALIZED VIEW orders_summary
+  GRACE PERIOD INTERVAL '1' HOUR
+  WHEN STALE FAIL
+  AS
+      SELECT orderdate, sum(totalprice) AS price
+      FROM orders
+      GROUP BY orderdate;
+
+  CREATE MATERIALIZED VIEW orders_summary
+  GRACE PERIOD INTERVAL '1' HOUR
+  WHEN STALE INLINE
+  AS
+      SELECT orderdate, sum(totalprice) AS price
+      FROM orders
+      GROUP BY orderdate;
+  ```
+- **notes:** `OR REPLACE` and `IF NOT EXISTS` are mutually exclusive. A `REFRESH MATERIALIZED VIEW` must be issued after creation to populate data; the view is empty until refreshed. `GRACE PERIOD` specifies how long materialized data is considered fresh before recomputation; defaults to infinity if omitted. `WHEN STALE INLINE` (default) falls back to live computation when data is stale; `WHEN STALE FAIL` raises an error instead. Both `GRACE PERIOD` and `WHEN STALE` require connector support.
+
+---
+
+## drop-materialized-view
+
+- **syntax:**
+  ```
+  DROP MATERIALIZED VIEW [ IF EXISTS ] view_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-materialized-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  DROP MATERIALIZED VIEW orders_by_date;
+
+  DROP MATERIALIZED VIEW IF EXISTS orders_by_date;
+  ```
+- **notes:** `IF EXISTS` suppresses errors when the materialized view does not exist.
+
+---
+
+## alter-materialized-view-rename
+
+- **syntax:**
+  ```
+  ALTER MATERIALIZED VIEW [ IF EXISTS ] name RENAME TO new_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-materialized-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER MATERIALIZED VIEW people RENAME TO users;
+
+  ALTER MATERIALIZED VIEW IF EXISTS people RENAME TO users;
+  ```
+- **notes:** `IF EXISTS` suppresses errors when the materialized view does not exist.
+
+---
+
+## alter-materialized-view-set-properties
+
+- **syntax:**
+  ```
+  ALTER MATERIALIZED VIEW name SET PROPERTIES property_name = expression [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-materialized-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER MATERIALIZED VIEW people SET PROPERTIES x = 'y';
+
+  ALTER MATERIALIZED VIEW people SET PROPERTIES foo = 123, "foo bar" = 456;
+
+  ALTER MATERIALIZED VIEW people SET PROPERTIES x = DEFAULT;
+  ```
+- **notes:** `DEFAULT` keyword resets a property to its connector-default value. Omitting a property leaves it unchanged. Connector support varies.
+
+---
+
+## alter-materialized-view-set-authorization
+
+- **syntax:**
+  ```
+  ALTER MATERIALIZED VIEW name SET AUTHORIZATION ( user | USER user | ROLE role )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/alter-materialized-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ALTER MATERIALIZED VIEW people SET AUTHORIZATION alice;
+  ```
+- **notes:** Transfers ownership of the materialized view to a user or role.
+
+---
+
+## refresh-materialized-view
+
+- **syntax:**
+  ```
+  REFRESH MATERIALIZED VIEW view_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/refresh-materialized-view.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  REFRESH MATERIALIZED VIEW orders_by_date;
+  ```
+- **notes:** Required after `CREATE MATERIALIZED VIEW` to populate data. Subsequent refreshes may be less expensive if the underlying data has not changed and the connector implements change-awareness. The entire view contents are replaced; no filtering is possible in this statement.
+
+---
+
+## create-catalog
+
+- **syntax:**
+  ```
+  CREATE CATALOG catalog_name
+  USING connector_name
+  [ WITH ( property_name = expression [, ...] ) ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-catalog.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE CATALOG tpch USING tpch;
+
+  CREATE CATALOG brain USING memory
+  WITH ("memory.max-data-per-node" = '128MB');
+
+  CREATE CATALOG example USING postgresql
+  WITH (
+    "connection-url" = 'jdbc:pg:localhost:5432',
+    "connection-user" = '${ENV:POSTGRES_USER}',
+    "connection-password" = '${ENV:POSTGRES_PASSWORD}',
+    "case-insensitive-name-matching" = 'true'
+  );
+  ```
+- **notes:** Requires catalog management type `dynamic`. Property names containing hyphens or other special characters must be double-quoted. All property values are varchars in single quotes (including numeric and boolean values). Environmental variable references use `${ENV:VARIABLE_NAME}` syntax. The full query including credentials is logged and visible in the Web UI.
+
+---
+
+## drop-catalog
+
+- **syntax:**
+  ```
+  DROP CATALOG catalog_name
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-catalog.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  DROP CATALOG example;
+  ```
+- **notes:** Requires catalog management type `dynamic`. Does not stop queries already running against the catalog. Several connectors (Hive, Iceberg, Delta Lake, Hudi) may fail to fully release HDFS/S3/GCS/Azure resources on drop. No `IF EXISTS` clause is documented.
+
+---
+
+## create-function
+
+- **syntax:**
+  ```
+  CREATE [ OR REPLACE ] FUNCTION udf_name ( [ parameter_name data_type [, ...] ] )
+    RETURNS return_type
+    [ LANGUAGE language ]
+    [ DETERMINISTIC | NOT DETERMINISTIC ]
+    [ RETURNS NULL ON NULL INPUT | CALLED ON NULL INPUT ]
+    [ SECURITY { DEFINER | INVOKER } ]
+    [ COMMENT description ]
+    [ WITH ( property_name = expression [, ...] ) ]
+    { RETURN expression | BEGIN statements END }
+  ```
+- **source_url:** https://trino.io/docs/current/sql/create-function.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  CREATE FUNCTION example.default.meaning_of_life()
+    RETURNS bigint
+    BEGIN
+      RETURN 42;
+    END;
+
+  CREATE FUNCTION meaning_of_life() RETURNS bigint RETURN 42;
+  ```
+- **notes:** Function name must be fully qualified (`catalog.schema.function`) unless default UDF storage catalog/schema is configured. `OR REPLACE` replaces an existing UDF without error. Supported languages include `SQL` and `PYTHON` by default. `RETURNS NULL ON NULL INPUT` skips execution when any parameter is NULL; `CALLED ON NULL INPUT` (default) executes normally with NULL values. `SECURITY DEFINER` uses the creator's permissions; `SECURITY INVOKER` uses the caller's permissions (catalog UDFs only). `WITH` passes language-specific properties (e.g. Python handler name). The connector backing the catalog must support UDF storage.
+
+---
+
+## drop-function
+
+- **syntax:**
+  ```
+  DROP FUNCTION [ IF EXISTS ] udf_name ( [ [ parameter_name ] data_type [, ...] ] )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/drop-function.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  DROP FUNCTION example.default.meaning_of_life();
+
+  DROP FUNCTION multiply_by_two(bigint);
+
+  DROP FUNCTION meaning_of_life();
+  ```
+- **notes:** Function name must be fully qualified unless default UDF storage catalog/schema is configured. Parameter data types must be included when the UDF accepts parameters (to disambiguate overloads). `IF EXISTS` suppresses errors when the function does not exist.
+
+---
+
+## analyze
+
+- **syntax:**
+  ```
+  ANALYZE table_name [ WITH ( property_name = expression [, ...] ) ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/analyze.html
+- **version:** 481 (current)
+- **example_sql:**
+  ```sql
+  ANALYZE web;
+
+  ANALYZE hive.default.stores;
+
+  ANALYZE hive.default.sales WITH (partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']]);
+
+  ANALYZE hive.default.customers WITH (partitions = ARRAY[ARRAY['CA', 'San Francisco'], ARRAY['NY', 'NY']]);
+
+  ANALYZE hive.default.sales WITH (
+      partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']],
+      columns = ARRAY['department', 'product_id']);
+  ```
+- **notes:** Collects table and column statistics for the query optimizer. The `WITH` clause is connector-specific; available properties can be discovered via `SELECT * FROM system.metadata.analyze_properties`. The `partitions` property accepts a nested array where each inner array is one partition key tuple. The `columns` property restricts statistics collection to specific columns.

--- a/docs/migration/trino/truth1/query-dml.md
+++ b/docs/migration/trino/truth1/query-dml.md
@@ -1,0 +1,1287 @@
+# Trino Query & DML Syntax Corpus — source: Trino 481 (current), https://trino.io/docs/current/
+
+---
+
+## select-full-syntax
+
+- **syntax:**
+```
+[ WITH SESSION [ name = expression [, ...] ]
+[ WITH [ FUNCTION udf ] [, ...] ]
+[ WITH [ RECURSIVE ] with_query [, ...] ]
+SELECT [ ALL | DISTINCT ] select_expression [, ...]
+[ FROM from_item [, ...] ]
+[ WHERE condition ]
+[ GROUP BY [ ALL | DISTINCT ] grouping_element [, ...] ]
+[ HAVING condition ]
+[ WINDOW window_definition_list ]
+[ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]
+[ ORDER BY expression [ ASC | DESC ] [, ...] ]
+[ OFFSET count [ ROW | ROWS ] ]
+[ LIMIT { count | ALL } ]
+[ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES } ]
+```
+
+  where `from_item` is one of:
+```
+table_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+
+from_item join_type from_item
+  [ ON join_condition | USING ( join_column [, ...] ) ]
+
+table_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+  MATCH_RECOGNIZE pattern_recognition_specification
+    [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+
+TABLE (table_function_invocation) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+```
+
+  where `join_type` is one of:
+```
+[ INNER ] JOIN
+LEFT [ OUTER ] JOIN
+RIGHT [ OUTER ] JOIN
+FULL [ OUTER ] JOIN
+CROSS JOIN
+```
+
+  where `grouping_element` is one of:
+```
+()
+expression
+AUTO
+GROUPING SETS ( ( column [, ...] ) [, ...] )
+CUBE ( column [, ...] )
+ROLLUP ( column [, ...] )
+```
+
+  where `select_expression` is one of:
+```
+expression [ [ AS ] column_alias ]
+row_expression.* [ AS ( column_alias [, ...] ) ]
+relation.*
+*
+```
+
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT * FROM orders WHERE totalprice > 1000 ORDER BY orderdate DESC LIMIT 10;
+```
+- **notes:** The WITH SESSION, WITH FUNCTION, and WITH RECURSIVE clauses precede the SELECT keyword. Multiple from_items separated by commas produce a cross join. The WINDOW clause defines named windows; set operations (UNION/INTERSECT/EXCEPT) appear between the WINDOW clause and ORDER BY.
+
+---
+
+## select-clause
+
+- **syntax:**
+```
+SELECT [ ALL | DISTINCT ] select_expression [, ...]
+
+select_expression is one of:
+    expression [ [ AS ] column_alias ]
+    row_expression.* [ AS ( column_alias [, ...] ) ]
+    relation.*
+    *
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#select-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- ROW type wildcard expansion with aliases
+SELECT (CAST(ROW(1, true) AS ROW(field1 bigint, field2 boolean))).* AS (alias1, alias2);
+```
+- **notes:** `SELECT ALL` is the default (returns all rows including duplicates). `SELECT DISTINCT` removes duplicates. The `row_expression.*` form expands a ROW-typed expression into individual columns and supports renaming via `AS (col_alias [, ...])`. `relation.*` expands all columns of a named relation.
+
+---
+
+## from-clause
+
+- **syntax:**
+```
+FROM from_item [, ...]
+
+from_item is one of:
+    table_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    from_item join_type from_item [ ON join_condition | USING ( join_column [, ...] ) ]
+    table_name MATCH_RECOGNIZE ( ... ) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    TABLE (table_function_invocation) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    UNNEST ( array_or_map [, ...] ) [ WITH ORDINALITY ] [ AS alias ( column_alias [, ...] ) ]
+    LATERAL ( subquery ) [ AS alias ]
+    table_name TABLESAMPLE { BERNOULLI | SYSTEM } ( percentage )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#from-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT n.name, r.name FROM nation AS n CROSS JOIN region AS r;
+```
+- **notes:** Multiple from_items separated by commas are equivalent to CROSS JOIN. UNNEST, LATERAL, TABLESAMPLE, JSON_TABLE, and NEAREST are additional FROM constructs described in dedicated sections.
+
+---
+
+## join-cross
+
+- **syntax:**
+```
+from_item CROSS JOIN from_item
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#cross-join
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT *
+FROM nation
+CROSS JOIN region;
+
+SELECT n.name AS nation, r.name AS region
+FROM nation AS n
+CROSS JOIN region AS r
+ORDER BY 1, 2;
+
+-- Equivalent comma syntax
+SELECT *
+FROM nation, region;
+```
+- **notes:** Produces the Cartesian product of the two relations. Comma-separated FROM items are syntactic sugar for CROSS JOIN.
+
+---
+
+## join-inner
+
+- **syntax:**
+```
+from_item [ INNER ] JOIN from_item { ON join_condition | USING ( join_column [, ...] ) }
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#join-types
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT o.*, l.*
+FROM orders o
+JOIN lineitem l ON o.orderkey = l.orderkey;
+
+SELECT *
+FROM orders
+JOIN lineitem USING (orderkey);
+```
+- **notes:** The INNER keyword is optional. Both ON and USING conditions are supported.
+
+---
+
+## join-left-right-full-outer
+
+- **syntax:**
+```
+from_item LEFT  [ OUTER ] JOIN from_item { ON join_condition | USING ( join_column [, ...] ) }
+from_item RIGHT [ OUTER ] JOIN from_item { ON join_condition | USING ( join_column [, ...] ) }
+from_item FULL  [ OUTER ] JOIN from_item { ON join_condition | USING ( join_column [, ...] ) }
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#join-types
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT o.orderkey, l.partkey
+FROM orders o
+LEFT JOIN lineitem l ON o.orderkey = l.orderkey;
+```
+- **notes:** The OUTER keyword is optional for all three forms. LEFT/RIGHT retain all rows from the respective side, padding with NULLs on the other side. FULL OUTER retains all rows from both sides.
+
+---
+
+## join-lateral
+
+- **syntax:**
+```
+from_item CROSS JOIN LATERAL ( subquery ) [ [ AS ] alias ]
+from_item LEFT  JOIN LATERAL ( subquery ) [ [ AS ] alias ] ON TRUE
+from_item FULL  JOIN LATERAL ( subquery ) [ [ AS ] alias ] ON TRUE
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#lateral
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name, x, y
+FROM nation
+CROSS JOIN LATERAL (SELECT name || ' :-' AS x)
+CROSS JOIN LATERAL (SELECT x || ')' AS y);
+```
+- **notes:** LATERAL allows a subquery in the FROM clause to reference columns from FROM items that precede it. When LATERAL appears on the right side of a FULL JOIN, the only condition supported is ON TRUE.
+
+---
+
+## join-nearest
+
+- **syntax:**
+```
+from_item CROSS JOIN NEAREST (
+    FROM relation
+    [ WHERE condition ]
+    MATCH comparison
+)
+
+from_item INNER JOIN NEAREST (
+    FROM relation
+    [ WHERE condition ]
+    MATCH comparison
+) ON TRUE
+
+from_item LEFT JOIN NEAREST (
+    FROM relation
+    [ WHERE condition ]
+    MATCH comparison
+) ON TRUE
+```
+
+  where `comparison` uses one of the operators: `<`, `<=`, `>`, `>=`
+
+- **source_url:** https://trino.io/docs/current/sql/select.html#nearest
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT trades.symbol, trades.ts, quotes.price
+FROM trades
+CROSS JOIN NEAREST (
+    FROM quotes
+    WHERE quotes.symbol = trades.symbol
+    MATCH quotes.ts <= trades.ts
+);
+
+SELECT trades.symbol, quotes.price
+FROM trades
+LEFT JOIN NEAREST (
+    FROM quotes
+    WHERE quotes.symbol = trades.symbol
+    MATCH quotes.ts >= trades.ts
+) ON TRUE;
+```
+- **notes:** NEAREST selects at most one row from the inner relation per left-side row. The MATCH clause is required and uses a directional comparison: `<`/`<=` select the closest row whose match key is smaller (or equal); `>`/`>=` select the closest row whose match key is larger (or equal). The matching direction also determines ordering of candidate rows.
+
+---
+
+## unnest
+
+- **syntax:**
+```
+UNNEST ( array_or_map_expression [, ...] ) [ WITH ORDINALITY ]
+    [ AS table_alias ( column_alias [, ...] ) ]
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#unnest
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Expand a single array
+SELECT * FROM UNNEST(ARRAY[1,2]) AS t(number);
+
+-- Expand a map into key-value columns
+SELECT * FROM UNNEST(
+    map_from_entries(ARRAY[('SQL',1974),('Java', 1995)])
+) AS t(language, first_appeared_year);
+
+-- WITH ORDINALITY adds a row-number column
+SELECT a, b, rownumber
+FROM UNNEST(ARRAY[2, 5], ARRAY[7, 8, 9]) WITH ORDINALITY AS t(a, b, rownumber);
+
+-- CROSS JOIN UNNEST to expand a column
+SELECT student, score
+FROM (
+   VALUES
+      ('John', ARRAY[7, 10, 9]),
+      ('Mary', ARRAY[4, 8, 9])
+) AS tests (student, scores)
+CROSS JOIN UNNEST(scores) AS t(score);
+
+-- Multiple arrays: null-padded to longest
+SELECT numbers, animals, n, a
+FROM (
+  VALUES
+    (ARRAY[2, 5], ARRAY['dog', 'cat', 'bird']),
+    (ARRAY[7, 8, 9], ARRAY['cow', 'pig'])
+) AS x (numbers, animals)
+CROSS JOIN UNNEST(numbers, animals) AS t (n, a);
+
+-- LEFT JOIN to preserve rows with empty/null arrays
+SELECT runner, checkpoint
+FROM (
+   VALUES
+      ('Joe', ARRAY[10, 20, 30, 42]),
+      ('Roger', ARRAY[10]),
+      ('Dave', ARRAY[]),
+      ('Levi', NULL)
+) AS marathon (runner, checkpoints)
+LEFT JOIN UNNEST(checkpoints) AS t(checkpoint) ON TRUE;
+
+-- ROW type expansion
+SELECT *
+FROM UNNEST(
+    ARRAY[ROW('Java', 1995), ROW('SQL', 1974)],
+    ARRAY[ROW(false), ROW(true)]
+) AS t(language, first_appeared_year, declarative);
+```
+- **notes:** UNNEST can expand ARRAY (one output column) or MAP (two output columns: key, value). Multiple array arguments are expanded side-by-side with NULL padding for shorter arrays. WITH ORDINALITY appends a row-number column. LEFT JOIN UNNEST ON TRUE preserves source rows with empty arrays or NULL arrays. The only condition supported with LEFT JOIN UNNEST is ON TRUE.
+
+---
+
+## tablesample
+
+- **syntax:**
+```
+table_name [ [ AS ] alias ] TABLESAMPLE { BERNOULLI | SYSTEM } ( percentage )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#tablesample
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT *
+FROM users TABLESAMPLE BERNOULLI (50);
+
+SELECT *
+FROM users TABLESAMPLE SYSTEM (75);
+
+SELECT o.*, i.*
+FROM orders o TABLESAMPLE SYSTEM (10)
+JOIN lineitem i TABLESAMPLE BERNOULLI (40)
+  ON o.orderkey = i.orderkey;
+```
+- **notes:** BERNOULLI samples each row independently with the given probability percentage (0–100). SYSTEM divides the table into logical segments and samples at segment granularity. Neither method guarantees an exact row count. Percentage is a numeric literal from 0 to 100. Both methods can be combined in a single query across multiple tables.
+
+---
+
+## table-function-invocation
+
+- **syntax:**
+```
+TABLE ( table_function_invocation ) [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+
+table_function_invocation:
+    [ catalog_name. ] [ schema_name. ] function_name ( [ argument [, ...] ] )
+
+argument:
+    scalar_argument
+  | descriptor_argument
+  | table_argument
+
+scalar_argument:
+    [ argument_name => ] expression
+
+descriptor_argument:
+    [ argument_name => ] DESCRIPTOR ( field_name [ data_type ] [, ...] )
+  | [ argument_name => ] CAST ( NULL AS DESCRIPTOR )
+
+table_argument:
+    [ argument_name => ] TABLE ( { table_name | query } )
+        [ PARTITION BY { column [, ...] | { HASH | RANGE } ON ( column [, ...] ) } ]
+        [ { KEEP | PRUNE } WHEN EMPTY ]
+        [ ORDER BY column [, ...] ]
+```
+- **source_url:** https://trino.io/docs/current/functions/table.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Built-in: exclude_columns
+SELECT *
+FROM TABLE(exclude_columns(
+    input => TABLE(orders),
+    columns => DESCRIPTOR(clerk, comment)));
+
+-- Built-in: sequence
+SELECT *
+FROM TABLE(sequence(
+    start => 1000000,
+    stop => -2000000,
+    step => -3));
+
+-- Named arguments (any order)
+SELECT * FROM TABLE(my_function(row_count => 100, column_count => 1));
+
+-- Positional arguments
+SELECT * FROM TABLE(my_function(1, 100));
+
+-- Schema-qualified
+SELECT * FROM TABLE(schema_name.my_function(1, 100));
+SELECT * FROM TABLE(catalog_name.schema_name.my_function(1, 100));
+
+-- With parameters
+PREPARE stmt FROM SELECT * FROM TABLE(my_function(row_count => ? + 1, column_count => ?));
+EXECUTE stmt USING 100, 1;
+
+-- Table argument with partitioning and ordering
+SELECT * FROM TABLE(my_function(
+    input => TABLE(orders)
+        PARTITION BY orderstatus
+        KEEP WHEN EMPTY
+        ORDER BY orderdate
+));
+```
+- **notes:** Arguments may be passed by name (named => value) or positionally. DESCRIPTOR arguments describe schemas with optional type information; CAST(NULL AS DESCRIPTOR) passes an empty descriptor. Table arguments support PARTITION BY (with optional HASH or RANGE strategy), KEEP/PRUNE WHEN EMPTY (controls whether the function executes when the table argument is empty), and ORDER BY. The COPARTITION clause (for co-partitioning multiple table arguments) is referenced in the developer API but is not explicitly documented in the user-facing SQL reference for Trino 481.
+
+---
+
+## where-clause
+
+- **syntax:**
+```
+WHERE condition
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#where-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name FROM nation WHERE regionkey = 1;
+
+SELECT name FROM nation
+WHERE EXISTS (
+     SELECT *
+     FROM region
+     WHERE region.regionkey = nation.regionkey
+);
+
+SELECT name FROM nation
+WHERE regionkey IN (
+     SELECT regionkey
+     FROM region
+     WHERE name = 'AMERICA' OR name = 'AFRICA'
+);
+
+SELECT name FROM nation
+WHERE regionkey = (SELECT max(regionkey) FROM region);
+```
+- **notes:** The WHERE clause filters rows before grouping. It supports all standard predicates including EXISTS, IN, ANY/ALL quantified comparisons, and scalar subqueries.
+
+---
+
+## subquery-exists
+
+- **syntax:**
+```
+EXISTS ( subquery )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#exists
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name
+FROM nation
+WHERE EXISTS (
+     SELECT *
+     FROM region
+     WHERE region.regionkey = nation.regionkey
+);
+```
+- **notes:** Returns TRUE if the subquery produces at least one row. Correlated EXISTS subqueries referencing outer query columns are supported.
+
+---
+
+## subquery-in
+
+- **syntax:**
+```
+expression IN ( subquery )
+expression NOT IN ( subquery )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#in-predicate
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name
+FROM nation
+WHERE regionkey IN (
+     SELECT regionkey
+     FROM region
+     WHERE name = 'AMERICA' OR name = 'AFRICA'
+);
+```
+- **notes:** The subquery must produce exactly one column. Tests whether the expression equals any value returned by the subquery.
+
+---
+
+## subquery-scalar
+
+- **syntax:**
+```
+( subquery )   -- used as a scalar expression
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#scalar-subquery
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name
+FROM nation
+WHERE regionkey = (SELECT max(regionkey) FROM region);
+```
+- **notes:** A scalar subquery returns zero or one row. If it returns zero rows, the result is NULL. If it returns more than one row, a runtime error is raised. Currently only a single column may be returned from a scalar subquery.
+
+---
+
+## group-by
+
+- **syntax:**
+```
+GROUP BY [ ALL | DISTINCT ] grouping_element [, ...]
+
+grouping_element is one of:
+    ()
+    expression
+    AUTO
+    GROUPING SETS ( ( column [, ...] ) [, ...] )
+    CUBE ( column [, ...] )
+    ROLLUP ( column [, ...] )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#group-by-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT count(*), mktsegment, nationkey,
+       CAST(sum(acctbal) AS bigint) AS totalbal
+FROM customer
+GROUP BY mktsegment, nationkey
+HAVING sum(acctbal) > 5700000
+ORDER BY totalbal DESC;
+```
+- **notes:** The ALL and DISTINCT quantifiers control deduplication when multiple complex grouping elements (CUBE, ROLLUP, GROUPING SETS) are combined. ALL (default) produces all combinations including duplicates. DISTINCT eliminates redundant grouping sets. Grouping expressions may reference column names or expressions from the SELECT list.
+
+---
+
+## group-by-auto
+
+- **syntax:**
+```
+GROUP BY AUTO
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#group-by-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT mktsegment, sum(acctbal) FROM shipping GROUP BY AUTO;
+```
+- **notes:** The AUTO keyword instructs Trino to automatically determine grouping columns. Any column in the SELECT list that is not part of an aggregate function is implicitly treated as a grouping column. Equivalent to listing all non-aggregate SELECT columns explicitly in GROUP BY.
+
+---
+
+## group-by-grouping-sets
+
+- **syntax:**
+```
+GROUP BY GROUPING SETS ( ( column [, ...] ) [, ...] )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#grouping-sets
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT origin_state, origin_zip, destination_state, sum(package_weight)
+FROM shipping
+GROUP BY GROUPING SETS (
+    (origin_state),
+    (origin_state, origin_zip),
+    (destination_state));
+```
+- **notes:** Equivalent to a UNION ALL of multiple GROUP BY queries, one per listed grouping set. Columns not in a given grouping set are set to NULL for that set's rows.
+
+---
+
+## group-by-cube
+
+- **syntax:**
+```
+GROUP BY CUBE ( column [, ...] )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#cube
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT origin_state, destination_state, sum(package_weight)
+FROM shipping
+GROUP BY CUBE (origin_state, destination_state);
+```
+- **notes:** CUBE generates all possible grouping sets (power set) for the given columns. For N columns, generates 2^N grouping sets. Equivalent to GROUPING SETS of all subsets including the empty set ().
+
+---
+
+## group-by-rollup
+
+- **syntax:**
+```
+GROUP BY ROLLUP ( column [, ...] )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#rollup
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT origin_state, origin_zip, sum(package_weight)
+FROM shipping
+GROUP BY ROLLUP (origin_state, origin_zip);
+```
+- **notes:** ROLLUP generates hierarchical subtotals. For columns (c1, c2, ..., cN) it generates N+1 grouping sets: (c1, c2, ..., cN), (c1, c2, ..., c(N-1)), ..., (c1), (). Useful for computing totals and subtotals in a hierarchy.
+
+---
+
+## group-by-all-distinct
+
+- **syntax:**
+```
+GROUP BY ALL  grouping_element [, ...]
+GROUP BY DISTINCT grouping_element [, ...]
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#grouping-sets
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT origin_state, destination_state, origin_zip, sum(package_weight)
+FROM shipping
+GROUP BY ALL
+    CUBE (origin_state, destination_state),
+    ROLLUP (origin_state, origin_zip);
+
+SELECT origin_state, destination_state, origin_zip, sum(package_weight)
+FROM shipping
+GROUP BY DISTINCT
+    CUBE (origin_state, destination_state),
+    ROLLUP (origin_state, origin_zip);
+```
+- **notes:** When multiple complex grouping elements are combined, ALL (default) takes the cross-product and retains all combinations including duplicates; DISTINCT deduplicates the resulting grouping sets. These quantifiers apply to the overall GROUP BY, not to individual grouping elements.
+
+---
+
+## grouping-function
+
+- **syntax:**
+```
+grouping ( column [, ...] ) -> bigint
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#grouping-operation
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT origin_state, origin_zip, destination_state, sum(package_weight),
+       grouping(origin_state, origin_zip, destination_state)
+FROM shipping
+GROUP BY GROUPING SETS (
+    (origin_state),
+    (origin_state, origin_zip),
+    (destination_state)
+);
+```
+- **notes:** Returns a bitmask as a bigint indicating which columns are present in the current grouping. Bits are assigned right-to-left (rightmost argument = least-significant bit). Bit value 0 means the column IS in the grouping; 1 means it is NOT. Must be used with GROUPING SETS, ROLLUP, CUBE, or GROUP BY.
+
+---
+
+## having-clause
+
+- **syntax:**
+```
+HAVING condition
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#having-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT count(*), mktsegment, nationkey,
+       CAST(sum(acctbal) AS bigint) AS totalbal
+FROM customer
+GROUP BY mktsegment, nationkey
+HAVING sum(acctbal) > 5700000
+ORDER BY totalbal DESC;
+```
+- **notes:** HAVING filters groups after aggregation, in conjunction with GROUP BY and aggregate functions. The HAVING condition is evaluated after grouping but before projection in the SELECT list.
+
+---
+
+## window-clause
+
+- **syntax:**
+```
+WINDOW window_definition_list
+
+window_definition_list:
+    window_name AS ( window_specification ) [, ...]
+
+window_specification:
+    [ existing_window_name ]
+    [ PARTITION BY expression [, ...] ]
+    [ ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
+    [ { ROWS | RANGE | GROUPS }
+        { UNBOUNDED PRECEDING
+        | expression PRECEDING
+        | CURRENT ROW
+        | BETWEEN frame_bound AND frame_bound }
+    ]
+
+frame_bound:
+    UNBOUNDED PRECEDING
+  | expression PRECEDING
+  | CURRENT ROW
+  | expression FOLLOWING
+  | UNBOUNDED FOLLOWING
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#window-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT orderkey, clerk, totalprice,
+      rank() OVER w AS rnk
+FROM orders
+WINDOW w AS (PARTITION BY clerk ORDER BY totalprice DESC)
+ORDER BY count() OVER w, clerk, rnk;
+
+-- Aggregate as window function (rolling sum)
+-- sum(totalprice) OVER (PARTITION BY clerk ORDER BY orderdate) AS rolling_sum
+```
+- **notes:** Named windows defined in WINDOW can be referenced in the SELECT list and ORDER BY via `OVER window_name`. Window specifications may inherit from another named window (by including the existing window name as the first element). All components (partition, ordering, frame) are optional. Default frame when ORDER BY is present: `RANGE UNBOUNDED PRECEDING` (equivalent to `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`). Without ORDER BY, default frame is all rows. Row pattern recognition clauses are supported within window specifications. Aggregate functions can be used as window functions by adding an OVER clause.
+
+---
+
+## union
+
+- **syntax:**
+```
+query UNION [ ALL | DISTINCT ] [ CORRESPONDING ] query
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#union-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT 13
+UNION
+SELECT 42;
+
+-- UNION (deduplicates): returns 13, 42
+SELECT 13
+UNION
+SELECT * FROM (VALUES 42, 13);
+
+-- UNION ALL (preserves duplicates): returns 13, 42, 13
+SELECT 13
+UNION ALL
+SELECT * FROM (VALUES 42, 13);
+
+-- CORRESPONDING: match columns by name instead of position
+SELECT * FROM (VALUES (1, 'alice')) AS t(id, name)
+UNION ALL CORRESPONDING
+SELECT * FROM (VALUES ('bob', 2)) AS t(name, id);
+```
+- **notes:** Default (without ALL or DISTINCT) is DISTINCT, which deduplicates. CORRESPONDING matches output columns by name rather than ordinal position, allowing queries with different column orderings to be combined. Multiple set operations are processed left to right; INTERSECT binds more tightly than UNION and EXCEPT.
+
+---
+
+## intersect
+
+- **syntax:**
+```
+query INTERSECT [ ALL | DISTINCT ] [ CORRESPONDING ] query
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#intersect-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT * FROM (VALUES 13, 42)
+INTERSECT
+SELECT 13;
+
+-- CORRESPONDING variant
+SELECT * FROM (VALUES (1, 'alice')) AS t(id, name)
+INTERSECT CORRESPONDING
+SELECT * FROM (VALUES ('alice', 1)) AS t(name, id);
+```
+- **notes:** Returns only rows present in both result sets. Default is DISTINCT. INTERSECT binds more tightly than UNION and EXCEPT when used without parentheses.
+
+---
+
+## except
+
+- **syntax:**
+```
+query EXCEPT [ ALL | DISTINCT ] [ CORRESPONDING ] query
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#except-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT * FROM (VALUES 13, 42)
+EXCEPT
+SELECT 13;
+
+-- CORRESPONDING variant
+SELECT * FROM (VALUES (1, 'alice'), (2, 'bob')) AS t(id, name)
+EXCEPT CORRESPONDING
+SELECT * FROM (VALUES ('alice', 1)) AS t(name, id);
+```
+- **notes:** Returns rows from the first query that do not appear in the second query. Default is DISTINCT. CORRESPONDING matches columns by name.
+
+---
+
+## order-by
+
+- **syntax:**
+```
+ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...]
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#order-by-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name FROM nation ORDER BY name OFFSET 22;
+
+SELECT count(*), mktsegment, nationkey,
+       CAST(sum(acctbal) AS bigint) AS totalbal
+FROM customer
+GROUP BY mktsegment, nationkey
+HAVING sum(acctbal) > 5700000
+ORDER BY totalbal DESC;
+```
+- **notes:** Default sort direction is ASC. Default null ordering is NULLS LAST regardless of direction. Expressions may be output column aliases, ordinal positions (starting at 1), or arbitrary expressions. Per SQL specification, an ORDER BY clause only affects ordering for the immediately containing query; Trino drops redundant ORDER BY in subqueries or INSERT to avoid performance overhead.
+
+---
+
+## offset
+
+- **syntax:**
+```
+OFFSET count [ ROW | ROWS ]
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#offset-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT name FROM nation ORDER BY name OFFSET 22;
+
+SELECT * FROM (VALUES 5, 2, 4, 1, 3) t(x) ORDER BY x OFFSET 2 LIMIT 2;
+```
+- **notes:** Discards the first `count` rows from the result. If ORDER BY is present, OFFSET applies to the sorted result and the remaining set stays sorted. ROW and ROWS are interchangeable noise words.
+
+---
+
+## limit
+
+- **syntax:**
+```
+LIMIT { count | ALL }
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#limit-or-fetch-first-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+SELECT orderdate FROM orders LIMIT 5;
+
+SELECT * FROM (VALUES 5, 2, 4, 1, 3) t(x) ORDER BY x OFFSET 2 LIMIT 2;
+```
+- **notes:** `LIMIT ALL` returns all rows (equivalent to omitting LIMIT). LIMIT is processed after ORDER BY and OFFSET.
+
+---
+
+## fetch-first
+
+- **syntax:**
+```
+FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES }
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#limit-or-fetch-first-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Default count of 1 (FETCH FIRST ROW ONLY)
+SELECT orderdate FROM orders FETCH FIRST ROW ONLY;
+
+-- WITH TIES includes all rows tied with the last included row
+SELECT name, regionkey
+FROM nation
+ORDER BY regionkey FETCH FIRST ROW WITH TIES;
+```
+- **notes:** FIRST and NEXT are interchangeable. ROW and ROWS are interchangeable. If count is omitted, it defaults to 1. WITH TIES requires ORDER BY to be present; it returns the specified number of leading rows plus any additional rows that tie with the last row according to the ORDER BY. ONLY and WITH TIES are mutually exclusive.
+
+---
+
+## with-cte
+
+- **syntax:**
+```
+WITH [ RECURSIVE ] with_query [, ...]
+SELECT ...
+
+with_query:
+    query_name [ ( column_name [, ...] ) ] AS ( query )
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#with-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Single CTE
+WITH x AS (SELECT a, MAX(b) AS b FROM t GROUP BY a)
+SELECT a, b FROM x;
+
+-- Multiple CTEs
+WITH
+  t1 AS (SELECT a, MAX(b) AS b FROM x GROUP BY a),
+  t2 AS (SELECT a, AVG(d) AS d FROM y GROUP BY a)
+SELECT t1.*, t2.*
+FROM t1
+JOIN t2 ON t1.a = t2.a;
+
+-- Chained CTEs (each can reference prior CTEs)
+WITH
+  x AS (SELECT a FROM t),
+  y AS (SELECT a AS b FROM x),
+  z AS (SELECT b AS c FROM y)
+SELECT c FROM z;
+```
+- **notes:** CTEs define named relations available within the query scope. Currently, the SQL for a CTE is inlined wherever the named relation is used; if referenced multiple times in a non-deterministic query, results may differ across uses. Forward references (a CTE referencing a later CTE) are not allowed.
+
+---
+
+## with-recursive
+
+- **syntax:**
+```
+WITH RECURSIVE with_query [, ...]
+SELECT ...
+
+-- Recursive with_query shape (required):
+query_name ( column_name [, ...] ) AS (
+    non_recursive_base_query
+    UNION ALL
+    recursive_step_query_referencing_query_name
+)
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#with-recursive-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+WITH RECURSIVE t(n) AS (
+    VALUES (1)
+    UNION ALL
+    SELECT n + 1 FROM t WHERE n < 4
+)
+SELECT sum(n) FROM t;
+-- Result: 10 (1 + 2 + 3 + 4)
+```
+- **notes:** Experimental feature. The recursive query must be shaped as UNION of exactly two parts: a non-recursive base and a recursive step. Column aliases are mandatory for all recursive WITH queries. Types of columns returned by the step relation must be coercible to the base relation types. Outer joins, non-UNION set operations, LIMIT, and certain other clauses are restricted in the step relation. Default recursion depth is 10, controlled by session property `max_recursion_depth`. Query plan size grows quadratically with recursion depth.
+
+---
+
+## with-session
+
+- **syntax:**
+```
+WITH SESSION name = expression [, ...]
+SELECT ...
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#with-session-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+WITH
+  SESSION
+    query_max_execution_time='2h',
+    example.query_partition_filter_required=true
+SELECT *
+FROM example.default.thetable
+LIMIT 100;
+```
+- **notes:** WITH SESSION sets session and catalog session properties for the duration of the current SELECT statement only. Values override any other configuration and session property settings. Catalog-qualified properties use the form `catalog.property_name = value`.
+
+---
+
+## with-function
+
+- **syntax:**
+```
+WITH FUNCTION function_name ( [ parameter_name data_type [, ...] ] )
+    RETURNS return_type
+    RETURN expression
+[, FUNCTION ... ]
+SELECT ...
+```
+- **source_url:** https://trino.io/docs/current/sql/select.html#with-function-clause
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+WITH 
+  FUNCTION hello(name varchar)
+    RETURNS varchar
+    RETURN format('Hello %s!', name),
+  FUNCTION bye(name varchar)
+    RETURNS varchar
+    RETURN format('Bye %s!', name)
+SELECT hello('Finn') || ' and ' || bye('Joe');
+-- Result: Hello Finn! and Bye Joe!
+```
+- **notes:** Inline user-defined functions defined with WITH FUNCTION are available only within the current SELECT statement. Multiple functions are separated by commas after the FUNCTION keyword list.
+
+---
+
+## values
+
+- **syntax:**
+```
+VALUES row [, ...]
+
+row:
+    expression
+  | ( column_expression [, ...] )
+```
+- **source_url:** https://trino.io/docs/current/sql/values.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Single column, three rows
+VALUES 1, 2, 3
+
+-- Two columns, three rows
+VALUES (1, 'a'), (2, 'b'), (3, 'c')
+
+-- With column aliases via AS
+SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t (id, name)
+
+-- In CREATE TABLE AS
+CREATE TABLE example AS
+SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t (id, name)
+```
+- **notes:** VALUES defines a literal inline table. It can be used anywhere a query can appear: in FROM clause, as the source for INSERT, as a standalone statement, or nested inside CTEs. Creates an anonymous table; columns can be named with an AS clause and column alias list.
+
+---
+
+## match-recognize
+
+- **syntax:**
+```
+table_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+MATCH_RECOGNIZE (
+  [ PARTITION BY column [, ...] ]
+  [ ORDER BY column [, ...] ]
+  [ MEASURES measure_definition [, ...] ]
+  [ rows_per_match ]
+  [ AFTER MATCH skip_to ]
+  PATTERN ( row_pattern )
+  [ SUBSET subset_definition [, ...] ]
+  DEFINE variable_definition [, ...]
+)
+[ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+
+rows_per_match:
+    ONE ROW PER MATCH
+  | ALL ROWS PER MATCH
+  | ALL ROWS PER MATCH SHOW EMPTY MATCHES
+  | ALL ROWS PER MATCH OMIT EMPTY MATCHES
+  | ALL ROWS PER MATCH WITH UNMATCHED ROWS
+
+skip_to:
+    AFTER MATCH SKIP PAST LAST ROW
+  | AFTER MATCH SKIP TO NEXT ROW
+  | AFTER MATCH SKIP TO [ FIRST | LAST ] pattern_variable
+
+row_pattern (elements):
+    A B+ C+ D+                    -- concatenation
+  | A | B | C                     -- alternation (one component matches)
+  | PERMUTE(A, B, C)              -- permutation (all in any order)
+  | ( row_pattern )               -- grouping
+  | ^                             -- anchor to partition start
+  | $                             -- anchor to partition end
+  | ()                            -- empty pattern
+  | {- row_pattern -}             -- exclude from output
+
+quantifiers (append to pattern element):
+    *       -- zero or more (greedy)
+    +       -- one or more (greedy)
+    ?       -- zero or one (greedy)
+    {n}     -- exactly n
+    {m, n}  -- between m and n
+    {, n}   -- up to n (0 to n)
+    {m, }   -- at least m
+    {,}     -- zero or more (same as *)
+    -- append ? to any quantifier for reluctant (non-greedy) matching
+
+measure_definition:
+    expression AS measure_name
+
+subset_definition:
+    subset_variable = ( primary_variable [, ...] )
+
+variable_definition:
+    primary_variable AS boolean_expression
+```
+- **source_url:** https://trino.io/docs/current/sql/match-recognize.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- V-shape price pattern detection
+SELECT * FROM orders MATCH_RECOGNIZE(
+  PARTITION BY custkey
+  ORDER BY orderdate
+  MEASURES
+    A.totalprice AS starting_price,
+    LAST(B.totalprice) AS bottom_price,
+    LAST(U.totalprice) AS top_price
+  ONE ROW PER MATCH
+  AFTER MATCH SKIP PAST LAST ROW
+  PATTERN (A B+ C+ D+)
+  SUBSET U = (C, D)
+  DEFINE
+    B AS totalprice < PREV(totalprice),
+    C AS totalprice > PREV(totalprice) AND totalprice <= A.totalprice,
+    D AS totalprice > PREV(totalprice)
+)
+```
+- **notes:** PARTITION BY divides the input into independent sections processed separately (analogous to window function partitioning). ORDER BY determines matching order (e.g. by date for temporal patterns). MEASURES defines scalar output columns; use FINAL before navigation functions to evaluate with complete match visibility (MEASURES only; RUNNING is default for both DEFINE and MEASURES). ONE ROW PER MATCH (default) outputs one row per match; ALL ROWS PER MATCH outputs one row per matched row with optional handling of empty matches and unmatched rows. SUBSET defines union variables grouping multiple primary variables for convenience. DEFINE assigns boolean conditions to primary pattern variables; variables without explicit definitions implicitly match all rows. Navigation functions: FIRST(expr, offset)/LAST(expr, offset) navigate logically from first/last occurrence of a variable; PREV(expr, offset)/NEXT(expr, offset) navigate physically (default offset=1 for PREV/NEXT, 0 for FIRST/LAST). CLASSIFIER() returns the matched variable name as varchar; MATCH_NUMBER() returns the sequential match number as bigint. Standard aggregate functions can be applied over match rows using variable prefix syntax (e.g. count(A.*), avg(B.price)).
+
+---
+
+## insert
+
+- **syntax:**
+```
+INSERT INTO table_name [ @ branch_name ] [ ( column [, ...] ) ] query
+```
+
+  where `query` is a SELECT statement or VALUES clause.
+
+- **source_url:** https://trino.io/docs/current/sql/insert.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Insert from another table
+INSERT INTO orders
+SELECT * FROM new_orders;
+
+-- Insert a single row with VALUES
+INSERT INTO cities VALUES (1, 'San Francisco');
+
+-- Insert multiple rows
+INSERT INTO cities VALUES (2, 'San Jose'), (3, 'Oakland');
+
+-- With explicit column list
+INSERT INTO nation (nationkey, name, regionkey, comment)
+VALUES (26, 'POLAND', 3, 'no comment');
+
+-- Omitting a column (receives NULL)
+INSERT INTO nation (nationkey, name, regionkey)
+VALUES (26, 'POLAND', 3);
+
+-- Insert into a branched table
+INSERT INTO cities @ audit VALUES (1, 'San Francisco');
+```
+- **notes:** If a column list is specified, it must exactly match the columns produced by the query. Unlisted columns in the target table receive NULL. If no column list is provided, the query columns must exactly match the table columns in number and type.
+
+---
+
+## delete
+
+- **syntax:**
+```
+DELETE FROM table_name [ @ branch_name ] [ WHERE condition ]
+```
+- **source_url:** https://trino.io/docs/current/sql/delete.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Delete with a simple condition
+DELETE FROM lineitem WHERE shipmode = 'AIR';
+
+-- Delete with a subquery condition
+DELETE FROM lineitem
+WHERE orderkey IN (SELECT orderkey FROM orders WHERE priority = 'LOW');
+
+-- Delete all rows (no WHERE)
+DELETE FROM orders;
+
+-- Delete from a specific branch
+DELETE FROM orders @ audit;
+```
+- **notes:** Without WHERE, all rows are deleted. Connector support for DELETE varies; see connector-specific documentation.
+
+---
+
+## update
+
+- **syntax:**
+```
+UPDATE table_name [ @ branch_name ]
+SET column = expression [, ...]
+[ WHERE condition ]
+```
+- **source_url:** https://trino.io/docs/current/sql/update.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Basic conditional update
+UPDATE purchases
+SET status = 'OVERDUE'
+WHERE ship_date IS NULL;
+
+-- Multiple column assignment
+UPDATE customers
+SET account_manager = 'John Henry', assign_date = now();
+
+-- Subquery-based update
+UPDATE new_hires
+SET manager = (
+  SELECT e.name
+  FROM employees e
+  WHERE e.employee_id = new_hires.manager_id
+);
+
+-- Branch-specific update
+UPDATE purchases @ audit
+SET status = 'OVERDUE'
+WHERE ship_date IS NULL;
+```
+- **notes:** All column update expressions for a matching row are evaluated before any column value is changed. Type coercions (e.g., numeric widening) are applied automatically when expression and column types differ. Connector support for UPDATE varies; see connector-specific documentation.
+
+---
+
+## merge
+
+- **syntax:**
+```
+MERGE INTO target_table [ @ branch_name ] [ [ AS ] target_alias ]
+USING { source_table | query } [ [ AS ] source_alias ]
+ON search_condition
+when_clause [...]
+
+when_clause is one of:
+    WHEN MATCHED [ AND condition ]
+        THEN DELETE
+
+    WHEN MATCHED [ AND condition ]
+        THEN UPDATE SET ( column = expression [, ...] )
+
+    WHEN NOT MATCHED [ AND condition ]
+        THEN INSERT [ ( column [, ...] ) ] VALUES ( expression [, ...] )
+```
+- **source_url:** https://trino.io/docs/current/sql/merge.html
+- **version:** Trino 481 (current)
+- **example_sql:**
+```sql
+-- Simple matched delete
+MERGE INTO accounts t USING monthly_accounts_update s
+    ON t.customer = s.customer
+    WHEN MATCHED
+        THEN DELETE
+
+-- Update matched rows, insert unmatched
+MERGE INTO accounts t USING monthly_accounts_update s
+    ON (t.customer = s.customer)
+    WHEN MATCHED
+        THEN UPDATE SET purchases = s.purchases + t.purchases
+    WHEN NOT MATCHED
+        THEN INSERT (customer, purchases, address)
+              VALUES(s.customer, s.purchases, s.address)
+
+-- Multiple WHEN clauses with conditions
+MERGE INTO accounts t USING monthly_accounts_update s
+    ON (t.customer = s.customer)
+    WHEN MATCHED AND s.address = 'Centreville'
+        THEN DELETE
+    WHEN MATCHED
+        THEN UPDATE
+            SET purchases = s.purchases + t.purchases, address = s.address
+    WHEN NOT MATCHED
+        THEN INSERT (customer, purchases, address)
+              VALUES(s.customer, s.purchases, s.address)
+
+-- Branch-qualified target
+MERGE INTO accounts @ audit t USING monthly_accounts_update s
+    ON t.customer = s.customer
+    WHEN MATCHED
+        THEN DELETE
+```
+- **notes:** WHEN clauses are processed in order; only the first matching clause executes for each source row. The query fails if a single target table row matches more than one source row. UPDATE expressions may reference both target and source columns; INSERT (NOT MATCHED) expressions reference only source columns. Only connectors that support MERGE can serve as the target; any connector supporting SELECT may serve as the source. The optional column list in INSERT specifies which target columns to populate; unlisted columns receive NULL.

--- a/docs/migration/trino/truth1/types-expr-functions.md
+++ b/docs/migration/trino/truth1/types-expr-functions.md
@@ -1,0 +1,1867 @@
+# Trino 481 — Parser-Relevant Syntax Corpus (truth1)
+<!-- Source: https://trino.io/docs/current/ — Trino version 481 -->
+
+---
+
+## boolean-type
+- **syntax:**
+  ```
+  BOOLEAN
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(1 AS BOOLEAN)
+  true
+  false
+  ```
+- **notes:** Literals are unquoted keywords `true` / `false`.
+
+---
+
+## integer-types
+- **syntax:**
+  ```
+  TINYINT
+  SMALLINT
+  INTEGER
+  INT
+  BIGINT
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(x AS TINYINT)
+  CAST(x AS SMALLINT)
+  CAST(x AS INTEGER)
+  CAST(x AS BIGINT)
+  ```
+- **notes:** `INT` is an alias for `INTEGER`. Range: TINYINT -2^7..2^7-1; SMALLINT -2^15..2^15-1; INTEGER -2^31..2^31-1; BIGINT -2^63..2^63-1.
+
+---
+
+## float-types
+- **syntax:**
+  ```
+  REAL
+  DOUBLE
+  NUMBER
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(x AS REAL)
+  CAST(x AS DOUBLE)
+  REAL '10.3'
+  DOUBLE '10.3'
+  NUMBER 'Infinity'
+  NUMBER 'NaN'
+  ```
+- **notes:** `REAL` is 32-bit IEEE 754; `DOUBLE` is 64-bit IEEE 754. `NUMBER` is a Trino extension supporting ≥50 decimal digits and special values `Infinity`, `-Infinity`, `NaN`. Typed literal syntax `REAL 'value'` and `DOUBLE 'value'` is supported.
+
+---
+
+## decimal-type
+- **syntax:**
+  ```
+  DECIMAL(precision [, scale])
+  DECIMAL(precision)
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(x AS DECIMAL(10, 2))
+  DECIMAL '10.3'
+  1.1
+  ```
+- **notes:** `precision` = total significant digits (max 38); `scale` = fractional digits (defaults to 0). Typed literal `DECIMAL 'value'` is valid syntax. Plain decimal literals like `1.1` are typed as DECIMAL.
+
+---
+
+## varchar-char-types
+- **syntax:**
+  ```
+  VARCHAR
+  VARCHAR(n)
+  CHAR
+  CHAR(n)
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(x AS VARCHAR(100))
+  CAST(x AS CHAR(10))
+  ```
+- **notes:** `VARCHAR` without length is unbounded. `CHAR` without length defaults to 1. `CHAR` is fixed-length (right-padded with spaces).
+
+---
+
+## varbinary-type
+- **syntax:**
+  ```
+  VARBINARY
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  X'65683F'
+  CAST('hello' AS VARBINARY)
+  ```
+- **notes:** Variable-length binary data.
+
+---
+
+## json-type
+- **syntax:**
+  ```
+  JSON
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST('{"a":1}' AS JSON)
+  ```
+- **notes:** Represents a JSON value.
+
+---
+
+## variant-type
+- **syntax:**
+  ```
+  VARIANT
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(JSON '{"a": 1, "b": [true, null]}' AS VARIANT)
+  ```
+- **notes:** Semi-structured type supporting object, array, string, number, boolean, null, date/time values.
+
+---
+
+## date-type
+- **syntax:**
+  ```
+  DATE
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DATE '2001-08-22'
+  CAST('2001-08-22' AS DATE)
+  ```
+- **notes:** Calendar date (no time component).
+
+---
+
+## time-type
+- **syntax:**
+  ```
+  TIME
+  TIME(P)
+  TIME WITH TIME ZONE
+  TIME(P) WITH TIME ZONE
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  TIME '01:02:03.456'
+  CAST('01:02:03' AS TIME(6))
+  CAST('01:02:03+05:30' AS TIME WITH TIME ZONE)
+  ```
+- **notes:** `TIME` is an alias for `TIME(3)`. `P` is precision 0–12 (picosecond support). `WITH TIME ZONE` variant stores timezone offset.
+
+---
+
+## timestamp-type
+- **syntax:**
+  ```
+  TIMESTAMP
+  TIMESTAMP(P)
+  TIMESTAMP WITH TIME ZONE
+  TIMESTAMP(P) WITH TIME ZONE
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  TIMESTAMP '2020-06-10 15:55:23.383345'
+  TIMESTAMP '2001-08-22 03:04:05.321 UTC'
+  CAST('2001-08-22 03:04:05' AS TIMESTAMP(6) WITH TIME ZONE)
+  ```
+- **notes:** `TIMESTAMP` is alias for `TIMESTAMP(3)`. `TIMESTAMP WITH TIME ZONE` is alias for `TIMESTAMP(3) WITH TIME ZONE`. `P` ranges 0–12.
+
+---
+
+## interval-type
+- **syntax:**
+  ```
+  INTERVAL YEAR TO MONTH
+  INTERVAL DAY TO SECOND
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  INTERVAL '3' MONTH
+  INTERVAL '2' DAY
+  INTERVAL '1' YEAR
+  ```
+- **notes:** Two distinct interval types: year-month and day-second. The literal syntax uses a quoted value and a single unit keyword (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND).
+
+---
+
+## array-type
+- **syntax:**
+  ```
+  ARRAY(element_type)
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(ARRAY[1,2,3] AS ARRAY(BIGINT))
+  ARRAY['foo', 'bar']
+  ```
+- **notes:** Type spec uses parentheses `ARRAY(T)`; the constructor uses brackets `ARRAY[...]`. See also `array-constructor`.
+
+---
+
+## map-type
+- **syntax:**
+  ```
+  MAP(key_type, value_type)
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(MAP(ARRAY['a','b'], ARRAY[1,2]) AS MAP(VARCHAR, INTEGER))
+  ```
+- **notes:** Both key and value types are required.
+
+---
+
+## row-type
+- **syntax:**
+  ```
+  ROW(field_name type [, field_name type] ...)
+  ROW(type [, type] ...)
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))
+  ROW(1, 2e0)
+  CAST(ROW('hello', 42) AS ROW(name VARCHAR, age INTEGER))
+  ```
+- **notes:** Fields may be named or unnamed. Named form: `ROW(field_name type, ...)`. Unnamed form: `ROW(type, ...)`. Field access uses `.field_name` notation on named rows.
+
+---
+
+## ipaddress-type
+- **syntax:**
+  ```
+  IPADDRESS
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  IPADDRESS '10.0.0.1'
+  IPADDRESS '2001:db8::1'
+  CAST('10.0.0.1' AS IPADDRESS)
+  ```
+- **notes:** Stores IPv4 and IPv6 addresses. Typed literal `IPADDRESS 'string'` is valid syntax.
+
+---
+
+## uuid-type
+- **syntax:**
+  ```
+  UUID
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59'
+  CAST('12151fd2-7586-11e9-8f9e-2a86e4085a59' AS UUID)
+  ```
+- **notes:** RFC 4122 format. Typed literal `UUID 'string'` is valid.
+
+---
+
+## sketch-types
+- **syntax:**
+  ```
+  HyperLogLog
+  P4HyperLogLog
+  SetDigest
+  QDigest(type)
+  TDigest
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST(approx_set(x) AS HyperLogLog)
+  CAST(approx_set(x) AS P4HyperLogLog)
+  make_set_digest(x)
+  ```
+- **notes:** These are opaque internal sketch/digest types. `QDigest` is parameterized. `SetDigest` encapsulates HyperLogLog + MinHash.
+
+---
+
+## integer-literal
+- **syntax:**
+  ```
+  decimal_literal        ::= [0-9][0-9_]*
+  hex_literal            ::= 0x[0-9a-fA-F][0-9a-fA-F_]*
+  octal_literal          ::= 0o[0-7][0-7_]*
+  binary_literal         ::= 0b[01][01_]*
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  42
+  123_456
+  0x0A
+  0o40
+  0b1001
+  ```
+- **notes:** Underscores are allowed as digit separators but cannot be leading, trailing, or consecutive.
+
+---
+
+## float-literal
+- **syntax:**
+  ```
+  floating_point_literal ::= digit+ '.' digit* exponent?
+                           | '.' digit+ exponent?
+                           | digit+ exponent
+  exponent               ::= [eE] [+-]? digit+
+  typed_float_literal    ::= REAL 'string' | DOUBLE 'string'
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  1.03e1
+  10.3e0
+  REAL '10.3'
+  DOUBLE '10.3'
+  NUMBER 'Infinity'
+  ```
+- **notes:** Typed literal syntax (`REAL 'value'`, `DOUBLE 'value'`) is distinct from function-call CAST.
+
+---
+
+## string-literal
+- **syntax:**
+  ```
+  string_literal          ::= ''' ( non_single_quote | "''" )* '''
+  unicode_literal         ::= U&''' ( unicode_char | escape_sequence )* ''' [ UESCAPE 'escape_char' ]
+  unicode_escape_sequence ::= '\' hex_digit{4}
+                            | '\+' hex_digit{6}
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  'Hello winter !'
+  'I am big, it''s the pictures that got small!'
+  U&'Hello winter \2603 !'
+  U&'Hello winter #2603 !' UESCAPE '#'
+  U&'\+01F600'
+  ```
+- **notes:** Single quotes are escaped by doubling. Unicode literals use `U&'...'` prefix; the escape character defaults to `\` but can be changed with `UESCAPE 'c'`. Six-digit codepoints use `\+` prefix.
+
+---
+
+## binary-literal
+- **syntax:**
+  ```
+  binary_literal ::= X''' hex_pairs* '''
+  hex_pairs      ::= [0-9a-fA-F]{2}
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  X'65683F'
+  X'FFFF 0FFF  3FFF FFFF'
+  ```
+- **notes:** Whitespace within the hex string is ignored. Each pair of hex digits forms one byte.
+
+---
+
+## datetime-literals
+- **syntax:**
+  ```
+  date_literal      ::= DATE 'yyyy-MM-dd'
+  time_literal      ::= TIME 'HH:mm:ss[.SSS]'
+  timestamp_literal ::= TIMESTAMP 'yyyy-MM-dd HH:mm:ss[.SSS] [timezone]'
+  interval_literal  ::= INTERVAL 'value' unit
+  unit              ::= YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
+  ```
+- **source_url:** https://trino.io/docs/current/functions/datetime.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DATE '2001-08-22'
+  TIME '01:02:03.456'
+  TIMESTAMP '2020-06-10 15:55:23.383345'
+  TIMESTAMP '2001-08-22 03:04:05.321 UTC'
+  INTERVAL '3' MONTH
+  INTERVAL '2' DAY
+  ```
+- **notes:** The `INTERVAL` literal takes a single unit keyword (not `YEAR TO MONTH` compound). Compound interval types appear in type declarations, not literals.
+
+---
+
+## null-literal
+- **syntax:**
+  ```
+  NULL
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT NULL
+  COALESCE(x, NULL)
+  ```
+- **notes:** NULL is the only value of the unknown type.
+
+---
+
+## arithmetic-operators
+- **syntax:**
+  ```
+  expr + expr
+  expr - expr
+  expr * expr
+  expr / expr
+  expr % expr
+  + expr          (unary plus)
+  - expr          (unary minus)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/math.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  1 + 2
+  10 - 3
+  4 * 5
+  10 / 3
+  10 % 3
+  -x
+  ```
+- **notes:** Integer division truncates toward zero. Standard SQL precedence: `*`, `/`, `%` bind tighter than `+`, `-`.
+
+---
+
+## comparison-operators
+- **syntax:**
+  ```
+  expr = expr
+  expr <> expr
+  expr != expr
+  expr < expr
+  expr > expr
+  expr <= expr
+  expr >= expr
+  expr IS DISTINCT FROM expr
+  expr IS NOT DISTINCT FROM expr
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  a = b
+  a <> b
+  a != b
+  a < b
+  a IS DISTINCT FROM b
+  NULL IS NOT DISTINCT FROM NULL   -- returns true
+  ```
+- **notes:** `!=` is non-standard but accepted. `IS DISTINCT FROM` treats NULL as a known value; always returns TRUE or FALSE (never NULL). `IS NOT DISTINCT FROM` is the NULL-safe equality.
+
+---
+
+## logical-operators
+- **syntax:**
+  ```
+  expr AND expr
+  expr OR expr
+  NOT expr
+  ```
+- **source_url:** https://trino.io/docs/current/functions/logical.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  a AND b
+  a OR b
+  NOT a
+  a AND (b OR c)
+  ```
+- **notes:** Precedence (high to low): NOT > AND > OR. NULL propagation: `AND` returns FALSE if either operand is FALSE; `OR` returns TRUE if either operand is TRUE; `NOT NULL` = NULL.
+
+---
+
+## string-concat-operator
+- **syntax:**
+  ```
+  string1 || string2
+  array1  || array2
+  array1  || element
+  element || array1
+  ```
+- **source_url:** https://trino.io/docs/current/functions/string.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  'foo' || 'bar'
+  ARRAY[1,2] || ARRAY[3]
+  ARRAY[1,2] || 3
+  ```
+- **notes:** `||` is overloaded for both string concatenation and array concatenation/element append.
+
+---
+
+## array-subscript
+- **syntax:**
+  ```
+  array_expr [ index ]
+  ```
+- **source_url:** https://trino.io/docs/current/functions/array.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  my_array[1]
+  ARRAY[1, 1.2, 4][2]
+  ```
+- **notes:** Array indices are 1-based. Returns NULL if index is out of bounds.
+
+---
+
+## row-field-access
+- **syntax:**
+  ```
+  row_expr . field_name
+  row_expr . "quoted_field_name"
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  row_col.name
+  CAST(ROW(1, 'a') AS ROW(id BIGINT, label VARCHAR)).label
+  ```
+- **notes:** Field access uses dot notation on ROW values with named fields.
+
+---
+
+## between-predicate
+- **syntax:**
+  ```
+  value BETWEEN min AND max
+  value NOT BETWEEN min AND max
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  3 BETWEEN 2 AND 6
+  x NOT BETWEEN 1 AND 10
+  ```
+- **notes:** Equivalent to `value >= min AND value <= max`. Inclusive on both ends.
+
+---
+
+## in-predicate
+- **syntax:**
+  ```
+  value [NOT] IN ( value_list )
+  value [NOT] IN ( subquery )
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  name IN ('AMERICA', 'EUROPE')
+  id NOT IN (1, 2, 3)
+  dept_id IN (SELECT id FROM departments)
+  ```
+- **notes:** Works with both literal lists and subqueries returning a single column.
+
+---
+
+## like-predicate
+- **syntax:**
+  ```
+  string [NOT] LIKE pattern [ESCAPE escape_char]
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  continent LIKE 'E%'
+  name LIKE 'J_ne'
+  path LIKE '%\%%' ESCAPE '\'
+  name NOT LIKE '%test%'
+  ```
+- **notes:** `%` matches zero or more characters; `_` matches exactly one character. `ESCAPE` defines the escape character for literal `%` and `_`.
+
+---
+
+## quantified-comparison
+- **syntax:**
+  ```
+  expression operator { ALL | ANY | SOME } ( subquery )
+  operator ::= = | <> | != | < | > | <= | >=
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  x = ANY (SELECT col FROM t)
+  x <> ALL (SELECT col FROM t)
+  x < SOME (SELECT col FROM t)
+  ```
+- **notes:** `ANY` and `SOME` are synonyms. `= ANY (subquery)` is equivalent to `IN (subquery)`. `<> ALL (subquery)` is equivalent to `NOT IN (subquery)`.
+
+---
+
+## is-null-predicate
+- **syntax:**
+  ```
+  expr IS NULL
+  expr IS NOT NULL
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  x IS NULL
+  x IS NOT NULL
+  ```
+- **notes:** Always returns TRUE or FALSE (never NULL).
+
+---
+
+## exists-predicate
+- **syntax:**
+  ```
+  EXISTS ( subquery )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  WHERE EXISTS (SELECT * FROM orders WHERE customer_id = c.id)
+  ```
+- **notes:** Returns TRUE if subquery produces at least one row.
+
+---
+
+## case-expression
+- **syntax:**
+  ```sql
+  -- Simple (value) form:
+  CASE expression
+      WHEN value THEN result
+      [ WHEN value THEN result ] ...
+      [ ELSE result ]
+  END
+
+  -- Searched form:
+  CASE
+      WHEN condition THEN result
+      [ WHEN condition THEN result ] ...
+      [ ELSE result ]
+  END
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conditional.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CASE status WHEN 1 THEN 'active' WHEN 0 THEN 'inactive' ELSE 'unknown' END
+  CASE WHEN score >= 90 THEN 'A' WHEN score >= 80 THEN 'B' ELSE 'C' END
+  ```
+- **notes:** Simple form compares expression to each WHEN value for equality. Searched form evaluates boolean conditions. ELSE is optional; without ELSE returns NULL when no condition matches.
+
+---
+
+## if-expression
+- **syntax:**
+  ```
+  if(condition, true_value)
+  if(condition, true_value, false_value)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conditional.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  if(x > 0, x, -x)
+  if(name IS NULL, 'unknown', name)
+  ```
+- **notes:** Two-argument form returns NULL when condition is false. Three-argument form returns false_value when condition is false.
+
+---
+
+## coalesce-expression
+- **syntax:**
+  ```
+  COALESCE(value1, value2 [, ...])
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conditional.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  COALESCE(a, b, 0)
+  COALESCE(name, 'unknown')
+  ```
+- **notes:** Returns the first non-NULL argument. Evaluates arguments left to right; stops at first non-NULL.
+
+---
+
+## nullif-expression
+- **syntax:**
+  ```
+  NULLIF(value1, value2)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conditional.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  NULLIF(x, 0)
+  NULLIF(status, 'unknown')
+  ```
+- **notes:** Returns NULL if value1 = value2; otherwise returns value1.
+
+---
+
+## try-expression
+- **syntax:**
+  ```
+  TRY(expression)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conditional.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  TRY(1 / 0)
+  TRY(CAST(x AS INTEGER))
+  TRY(json_parse(bad_json))
+  ```
+- **notes:** Evaluates expression and returns NULL on certain errors: division by zero, invalid casts, numeric overflow, JSON parsing errors. Does NOT suppress all errors.
+
+---
+
+## cast-expression
+- **syntax:**
+  ```
+  CAST(value AS type)
+  TRY_CAST(value AS type)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conversion.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  CAST('123' AS BIGINT)
+  CAST(x AS DECIMAL(10, 2))
+  CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))
+  TRY_CAST('abc' AS INTEGER)
+  ```
+- **notes:** `TRY_CAST` returns NULL instead of raising an error on failed conversions. `type` is any Trino data type expression.
+
+---
+
+## greatest-least
+- **syntax:**
+  ```
+  GREATEST(value1, value2 [, ...])
+  LEAST(value1, value2 [, ...])
+  ```
+- **source_url:** https://trino.io/docs/current/functions/comparison.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  GREATEST(1, 2, 3)
+  LEAST(a, b, c)
+  ```
+- **notes:** Returns NULL if ANY argument is NULL. Return type is the common supertype of all arguments.
+
+---
+
+## lambda-expression
+- **syntax:**
+  ```
+  identifier -> expression
+  ( identifier [, identifier] ... ) -> expression
+  ```
+- **source_url:** https://trino.io/docs/current/functions/lambda.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  transform(ARRAY[1,2,3], x -> x * 2)
+  filter(ARRAY[1,2,3], x -> x > 1)
+  reduce(ARRAY[1,2,3], 0, (acc, x) -> acc + x, acc -> acc)
+  zip_with(ARRAY[1,2], ARRAY[3,4], (x, y) -> x + y)
+  x -> a * x + b
+  ```
+- **notes:** Single-argument lambdas do not require parentheses. Multi-argument lambdas require parentheses. Lambdas can capture outer-scope columns. Subqueries and aggregations are NOT allowed inside lambda bodies.
+
+---
+
+## array-constructor
+- **syntax:**
+  ```
+  ARRAY [ element [, element] ... ]
+  ARRAY []
+  ```
+- **source_url:** https://trino.io/docs/current/functions/array.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  ARRAY[1, 2, 4]
+  ARRAY['foo', 'bar', 'bazz']
+  ARRAY[]
+  ```
+- **notes:** The constructor uses square brackets `ARRAY[...]`. The type spec uses parentheses `ARRAY(T)`. Distinct syntactic forms.
+
+---
+
+## row-constructor
+- **syntax:**
+  ```
+  ROW( value [, value] ... )
+  ( value [, value] ... )
+  ```
+- **source_url:** https://trino.io/docs/current/language/types.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  ROW(1, 2e0)
+  CAST(ROW(1, 2.0) AS ROW(x BIGINT, y DOUBLE))
+  ```
+- **notes:** `ROW(...)` keyword is explicit; the short form `(v1, v2)` may also produce a row in expression contexts. Commonly combined with CAST to name fields.
+
+---
+
+## map-constructor
+- **syntax:**
+  ```
+  MAP(ARRAY[key ...], ARRAY[value ...])
+  MAP()
+  ```
+- **source_url:** https://trino.io/docs/current/functions/map.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  MAP(ARRAY[1, 3], ARRAY[2, 4])
+  MAP(ARRAY['foo', 'bar'], ARRAY[1, 2])
+  MAP()
+  ```
+- **notes:** No SQL-standard map literal syntax. Maps are built via the `MAP(keys_array, values_array)` constructor function. `MAP()` returns an empty map.
+
+---
+
+## at-time-zone
+- **syntax:**
+  ```
+  timestamp_expr AT TIME ZONE timezone_str
+  ```
+- **source_url:** https://trino.io/docs/current/functions/datetime.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  TIMESTAMP '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles'
+  current_timestamp AT TIME ZONE 'Europe/Paris'
+  ```
+- **notes:** Converts a TIMESTAMP WITH TIME ZONE to another timezone. `timezone_str` is a varchar timezone name or offset.
+
+---
+
+## current-datetime-functions
+- **syntax:**
+  ```
+  CURRENT_DATE
+  CURRENT_TIME
+  CURRENT_TIMESTAMP
+  LOCALTIME
+  LOCALTIMESTAMP
+  current_timestamp(p)
+  localtimestamp(p)
+  localtime(p)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/datetime.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT CURRENT_DATE
+  SELECT CURRENT_TIMESTAMP
+  SELECT LOCALTIME
+  SELECT LOCALTIMESTAMP
+  SELECT current_timestamp(6)
+  ```
+- **notes:** `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP`, `LOCALTIME`, `LOCALTIMESTAMP` require NO parentheses (SQL standard). The precision-parameterized forms `current_timestamp(p)` and `localtimestamp(p)` use function-call syntax.
+
+---
+
+## extract-function
+- **syntax:**
+  ```
+  EXTRACT( field FROM expr )
+  field ::= YEAR | QUARTER | MONTH | WEEK | DAY | DAY_OF_MONTH
+          | DAY_OF_WEEK | DOW | DAY_OF_YEAR | DOY
+          | YEAR_OF_WEEK | YOW
+          | HOUR | MINUTE | SECOND
+          | TIMEZONE_HOUR | TIMEZONE_MINUTE
+  ```
+- **source_url:** https://trino.io/docs/current/functions/datetime.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  EXTRACT(YEAR FROM TIMESTAMP '2022-10-20 05:10:00')
+  EXTRACT(DOW FROM DATE '2022-10-20')
+  EXTRACT(HOUR FROM CURRENT_TIMESTAMP)
+  ```
+- **notes:** Returns BIGINT. `DOW` is an alias for `DAY_OF_WEEK` (ISO: 1=Monday). `YOW` and `YEAR_OF_WEEK` refer to ISO week-year. `TIMEZONE_HOUR` and `TIMEZONE_MINUTE` apply to `TIMESTAMP WITH TIME ZONE` and `TIME WITH TIME ZONE` values.
+
+---
+
+## substring-function
+- **syntax:**
+  ```
+  substring(string, start)
+  substring(string, start, length)
+  substr(string, start)
+  substr(string, start, length)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/string.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  substring('hello world', 7)
+  substring('hello world', 1, 5)
+  substr('abc', 2, 2)
+  ```
+- **notes:** Positions are 1-based. Negative `start` is relative to end of string. `substr` is an alias for `substring`. The SQL-standard `SUBSTRING(x FROM start FOR length)` form is NOT documented for Trino; use the function-call form.
+
+---
+
+## trim-function
+- **syntax:**
+  ```
+  trim(string)
+  trim([ { LEADING | TRAILING | BOTH } ] [ chars ] FROM source)
+  ltrim(string)
+  rtrim(string)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/string.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  trim('  hello  ')
+  trim(LEADING FROM '  abcd')
+  trim(BOTH '$' FROM '$var$')
+  trim(TRAILING '!' FROM '!foo!')
+  ltrim('  hello')
+  rtrim('hello  ')
+  ```
+- **notes:** The special-form `TRIM([spec] [chars] FROM source)` supports `LEADING`, `TRAILING`, or `BOTH` (default). The `chars` argument specifies the character set to remove (defaults to whitespace). This is SQL-standard syntax, not a function call.
+
+---
+
+## position-function
+- **syntax:**
+  ```
+  POSITION(substring IN string)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/string.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  POSITION('lo' IN 'hello world')
+  POSITION('x' IN 'abcdef')
+  ```
+- **notes:** SQL-standard special-form syntax (not `position(a, b)`). Returns 1-based position of first occurrence; returns 0 if not found.
+
+---
+
+## normalize-function
+- **syntax:**
+  ```
+  NORMALIZE(string [, form])
+  form ::= NFD | NFC | NFKD | NFKC
+  ```
+- **source_url:** https://trino.io/docs/current/functions/string.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  NORMALIZE('café', NFC)
+  NORMALIZE(name, NFKD)
+  NORMALIZE('hello')
+  ```
+- **notes:** Unicode normalization special-form. `form` is an unquoted keyword (not a string). Defaults to NFC if form is omitted.
+
+---
+
+## aggregate-call-syntax
+- **syntax:**
+  ```
+  aggregate_function(expr [, expr] ...)
+  aggregate_function(DISTINCT expr)
+  aggregate_function(expr [ORDER BY sort_item [, ...]])
+  aggregate_function(expr) FILTER (WHERE condition)
+  aggregate_function(expr [ORDER BY ...]) FILTER (WHERE condition)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/aggregate.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  count(*)
+  count(DISTINCT user_id)
+  array_agg(x ORDER BY y DESC)
+  array_agg(x ORDER BY x, y, z)
+  count(*) FILTER (WHERE petal_length_cm > 4)
+  sum(amount) FILTER (WHERE status = 'paid')
+  ```
+- **notes:** `ORDER BY` inside aggregate controls ordering for order-sensitive aggregates (`array_agg`, `string_agg`, etc.). `FILTER (WHERE ...)` removes rows before aggregation. `DISTINCT` is supported inside aggregates.
+
+---
+
+## listagg-syntax
+- **syntax:**
+  ```
+  LISTAGG( expression [, separator]
+           [ON OVERFLOW { ERROR
+                        | TRUNCATE [filler_string] { WITH | WITHOUT } COUNT }]
+  )
+  WITHIN GROUP (ORDER BY sort_item [, ...])
+  [FILTER (WHERE condition)]
+  ```
+- **source_url:** https://trino.io/docs/current/functions/aggregate.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  LISTAGG(value, ',') WITHIN GROUP (ORDER BY value)
+  LISTAGG(value, ',' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY id)
+  LISTAGG(value, ',' ON OVERFLOW TRUNCATE '.....' WITH COUNT)
+      WITHIN GROUP (ORDER BY value)
+      FILTER (WHERE value IS NOT NULL)
+  ```
+- **notes:** `WITHIN GROUP (ORDER BY ...)` is required. `ON OVERFLOW ERROR` is the default (throws when output exceeds 1,048,576 bytes). `TRUNCATE` appends `filler_string` (default `'...'`) and optionally appends the overflow count. This is an SQL-standard ordered-set aggregate.
+
+---
+
+## window-function-syntax
+- **syntax:**
+  ```
+  function_name([args]) OVER (window_specification)
+  function_name([args]) OVER window_name
+
+  window_specification ::=
+      [ existing_window_name ]
+      [ PARTITION BY partition_expr [, ...] ]
+      [ ORDER BY sort_expr [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
+      [ frame_clause ]
+
+  frame_clause ::=
+      { ROWS | RANGE | GROUPS }
+      { frame_start | BETWEEN frame_start AND frame_end }
+      [ { EXCLUDE CURRENT ROW
+        | EXCLUDE GROUP
+        | EXCLUDE TIES
+        | EXCLUDE NO OTHERS } ]
+
+  frame_start / frame_end ::=
+      UNBOUNDED PRECEDING
+    | offset PRECEDING
+    | CURRENT ROW
+    | offset FOLLOWING
+    | UNBOUNDED FOLLOWING
+  ```
+- **source_url:** https://trino.io/docs/current/functions/window.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  rank() OVER (PARTITION BY dept ORDER BY salary DESC)
+  sum(amount) OVER (PARTITION BY user_id ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+  first_value(x) OVER w
+  lead(x, 2, 0) OVER (ORDER BY ts)
+  nth_value(x, 3) IGNORE NULLS OVER (ORDER BY id)
+  ```
+- **notes:** Default frame is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` when ORDER BY is present. `ROWS` uses physical row offsets; `RANGE` uses logical value ranges; `GROUPS` uses peer groups. Ranking functions (`rank()`, `dense_rank()`, `row_number()`, `ntile()`, `percent_rank()`, `cume_dist()`) do NOT accept a frame clause.
+
+---
+
+## null-treatment-in-window
+- **syntax:**
+  ```
+  function_name(expr) { IGNORE NULLS | RESPECT NULLS } OVER (window_specification)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/window.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  first_value(x) IGNORE NULLS OVER (ORDER BY id)
+  last_value(x) RESPECT NULLS OVER (PARTITION BY dept ORDER BY ts)
+  nth_value(x, 2) IGNORE NULLS OVER (ORDER BY id)
+  lead(x) IGNORE NULLS OVER (ORDER BY id)
+  lag(x) IGNORE NULLS OVER (ORDER BY id)
+  ```
+- **notes:** Applies to value window functions: `first_value`, `last_value`, `nth_value`, `lead`, `lag`. `RESPECT NULLS` is the default. The clause appears between the function call and the OVER keyword.
+
+---
+
+## window-definition-clause
+- **syntax:**
+  ```
+  WINDOW window_name AS (window_specification) [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT rank() OVER w, sum(x) OVER w
+  FROM t
+  WINDOW w AS (PARTITION BY dept ORDER BY salary DESC)
+  ```
+- **notes:** Named window definitions appear in the `WINDOW` clause of SELECT. Can be referenced by name in the `OVER window_name` form in both SELECT and ORDER BY clauses.
+
+---
+
+## window-ranking-functions
+- **syntax:**
+  ```
+  cume_dist()
+  dense_rank()
+  ntile(n)
+  percent_rank()
+  rank()
+  row_number()
+  ```
+- **source_url:** https://trino.io/docs/current/functions/window.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  rank() OVER (PARTITION BY dept ORDER BY salary DESC)
+  dense_rank() OVER (ORDER BY score DESC)
+  ntile(4) OVER (ORDER BY amount DESC)
+  row_number() OVER (ORDER BY id)
+  ```
+- **notes:** These functions require OVER clause. Frame clause is NOT allowed for ranking functions.
+
+---
+
+## window-value-functions
+- **syntax:**
+  ```
+  first_value(x) [{ IGNORE NULLS | RESPECT NULLS }] OVER (...)
+  last_value(x)  [{ IGNORE NULLS | RESPECT NULLS }] OVER (...)
+  nth_value(x, offset) [{ IGNORE NULLS | RESPECT NULLS }] OVER (...)
+  lead(x [, offset [, default_value]]) [{ IGNORE NULLS | RESPECT NULLS }] OVER (...)
+  lag(x [, offset [, default_value]])  [{ IGNORE NULLS | RESPECT NULLS }] OVER (...)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/window.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  first_value(amount) OVER (PARTITION BY user ORDER BY ts)
+  last_value(amount) IGNORE NULLS OVER (ORDER BY ts)
+  nth_value(amount, 3) OVER (ORDER BY ts)
+  lead(amount, 1, 0) OVER (ORDER BY ts)
+  lag(amount) OVER (PARTITION BY user ORDER BY ts)
+  ```
+- **notes:** `offset` defaults to 1 for lead/lag; `default_value` defaults to NULL.
+
+---
+
+## json-exists
+- **syntax:**
+  ```
+  JSON_EXISTS(
+      json_input [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]],
+      json_path
+      [PASSING json_argument AS parameter_name [, ...]]
+      [{ TRUE | FALSE | UNKNOWN | ERROR } ON ERROR]
+  )
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  JSON_EXISTS(description, 'lax $.children[*]?(@ > 10)')
+  JSON_EXISTS(doc, 'strict $.name' PASSING 'Alice' AS name_param)
+  JSON_EXISTS(col, '$.x' FALSE ON ERROR)
+  ```
+- **notes:** Returns BOOLEAN. Default ON ERROR is FALSE. Handles both input conversion errors and JSON path evaluation errors.
+
+---
+
+## json-query
+- **syntax:**
+  ```
+  JSON_QUERY(
+      json_input [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]],
+      json_path
+      [PASSING json_argument AS parameter_name [, ...]]
+      [RETURNING type [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]]]
+      [WITHOUT [ARRAY] WRAPPER
+       | WITH [{ CONDITIONAL | UNCONDITIONAL }] [ARRAY] WRAPPER]
+      [{ KEEP | OMIT } QUOTES [ON SCALAR STRING]]
+      [{ ERROR | NULL | EMPTY ARRAY | EMPTY OBJECT } ON EMPTY]
+      [{ ERROR | NULL | EMPTY ARRAY | EMPTY OBJECT } ON ERROR]
+  )
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  JSON_QUERY(description, 'lax $.children[last]' WITH ARRAY WRAPPER)
+  JSON_QUERY(doc, 'strict $.tags' RETURNING varchar)
+  JSON_QUERY(col, 'lax $.x' OMIT QUOTES ON SCALAR STRING NULL ON EMPTY)
+  ```
+- **notes:** Default RETURNING is varchar. `WITH ARRAY WRAPPER` wraps result in a JSON array. `KEEP/OMIT QUOTES` applies to scalar string extraction. Default ON EMPTY and ON ERROR both return NULL.
+
+---
+
+## json-value
+- **syntax:**
+  ```
+  JSON_VALUE(
+      json_input [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]],
+      json_path
+      [PASSING json_argument AS parameter_name [, ...]]
+      [RETURNING type]
+      [{ ERROR | NULL | DEFAULT expression } ON EMPTY]
+      [{ ERROR | NULL | DEFAULT expression } ON ERROR]
+  )
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  JSON_VALUE(description, 'lax $.children[0]' RETURNING tinyint)
+  JSON_VALUE(doc, '$.name' DEFAULT 'unknown' ON EMPTY)
+  JSON_VALUE(col, 'strict $.id' ERROR ON ERROR)
+  ```
+- **notes:** Extracts a scalar SQL value. Default RETURNING is varchar. `DEFAULT expression` is only evaluated when the ON EMPTY or ON ERROR branch is taken. Subqueries not supported in DEFAULT.
+
+---
+
+## json-object
+- **syntax:**
+  ```
+  JSON_OBJECT(
+      [ key_value [, ...]
+        [{ NULL ON NULL | ABSENT ON NULL }] ],
+      [{ WITH UNIQUE [KEYS] | WITHOUT UNIQUE [KEYS] }]
+      [RETURNING type [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]]]
+  )
+
+  key_value ::=
+      'key' : value
+    | KEY 'key' VALUE value
+    | 'key' VALUE value
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  JSON_OBJECT('x' : true, 'y' : 1.2, 'z' : 'text')
+  JSON_OBJECT(KEY 'name' VALUE 'Alice', KEY 'age' VALUE 30)
+  JSON_OBJECT('x' : null, 'y' : 1 ABSENT ON NULL)
+  JSON_OBJECT('a' : 1 WITH UNIQUE KEYS)
+  ```
+- **notes:** Default null handling for values is `NULL ON NULL` (includes JSON nulls). `WITH UNIQUE KEYS` enforces uniqueness and may throw on duplicates. Keys must be character strings; never NULL.
+
+---
+
+## json-array
+- **syntax:**
+  ```
+  JSON_ARRAY(
+      [ array_element [, ...]
+        [{ NULL ON NULL | ABSENT ON NULL }] ],
+      [RETURNING type [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]]]
+  )
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  JSON_ARRAY(true, 12e-1, 'text')
+  JSON_ARRAY(true, null, 1)
+  JSON_ARRAY(1, 2, 3 NULL ON NULL)
+  JSON_ARRAY(x, y RETURNING varbinary FORMAT JSON ENCODING UTF8)
+  ```
+- **notes:** Default null handling is `ABSENT ON NULL` (omits nulls). `NULL ON NULL` includes JSON nulls. Default RETURNING is varchar.
+
+---
+
+## json-table
+- **syntax:**
+  ```
+  JSON_TABLE(
+      json_input,
+      json_path [AS path_name]
+      [PASSING value AS parameter_name [, ...]]
+      COLUMNS ( column_definition [, ...] )
+      [PLAN (json_table_specific_plan)
+       | PLAN DEFAULT (json_table_default_plan)]
+      [{ ERROR | EMPTY } ON ERROR]
+  )
+
+  column_definition ::=
+      column_name FOR ORDINALITY
+    | column_name type
+        [FORMAT JSON [ENCODING { UTF8 | UTF16 | UTF32 }]]
+        [PATH json_path]
+        [{ WITHOUT | WITH { CONDITIONAL | UNCONDITIONAL } } [ARRAY] WRAPPER]
+        [{ KEEP | OMIT } QUOTES [ON SCALAR STRING]]
+        [{ ERROR | NULL | EMPTY { [ARRAY] | OBJECT } | DEFAULT expression } ON EMPTY]
+        [{ ERROR | NULL | DEFAULT expression } ON ERROR]
+    | NESTED [PATH] json_path [AS path_name]
+        COLUMNS ( column_definition [, ...] )
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT * FROM json_table(
+      '[{"id":1,"name":"Africa"},{"id":2,"name":"Americas"}]',
+      'strict $' COLUMNS (
+          NESTED PATH 'strict $[*]' COLUMNS (
+              id integer PATH 'strict $.id',
+              name varchar PATH 'strict $.name'
+          )
+      )
+  )
+
+  SELECT * FROM json_table(
+      doc, 'lax $.items[*]'
+      COLUMNS (
+          ord FOR ORDINALITY,
+          item_id bigint PATH 'lax $.id' NULL ON EMPTY,
+          item_name varchar PATH 'lax $.name' DEFAULT 'unknown' ON EMPTY
+      )
+      EMPTY ON ERROR
+  )
+  ```
+- **notes:** `FOR ORDINALITY` adds a 1-based row counter. `NESTED [PATH]` descends into nested JSON arrays/objects. `PLAN` clause controls join strategy between NESTED paths (OUTER, INNER, CROSS, UNION). `ON ERROR` at table level: `ERROR` throws; `EMPTY` returns no rows.
+
+---
+
+## json-path-syntax
+- **syntax:**
+  ```
+  path_mode ::= strict | lax
+
+  json_path ::= path_mode path_expression
+
+  path_expression ::=
+      $                                 -- context variable
+    | $ parameter_name                  -- named variable from PASSING
+    | @                                 -- current item (in filter)
+    | last                              -- last array index
+    | path_expression . member_name     -- member accessor
+    | path_expression . "member_name"   -- quoted member accessor
+    | path_expression . *               -- wildcard member
+    | path_expression .. member_name    -- descendant member
+    | path_expression [ subscript ]     -- array subscript (0-based)
+    | path_expression [ n to m ]        -- array range
+    | path_expression [ * ]             -- wildcard array
+    | path_expression ? ( filter_expr ) -- filter predicate
+    | path_expression . method()        -- item method
+    | ( path_expression )               -- grouping
+    | unary_op path_expression
+    | path_expression binary_op path_expression
+
+  method ::= double() | ceiling() | floor() | abs()
+           | keyvalue() | type() | size()
+
+  unary_op ::= + | -
+  binary_op ::= + | - | * | / | %
+
+  filter_expr ::=
+      filter_expr && filter_expr
+    | filter_expr || filter_expr
+    | ! filter_expr
+    | exists ( path_expression )
+    | path_expression starts with "text"
+    | ( filter_expr ) is unknown
+    | path_expression == path_expression
+    | path_expression <> path_expression
+    | path_expression != path_expression
+    | path_expression < path_expression
+    | path_expression > path_expression
+    | path_expression <= path_expression
+    | path_expression >= path_expression
+  ```
+- **source_url:** https://trino.io/docs/current/functions/json.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  'lax $.children[*]?(@ > 10)'
+  'strict $[*].name'
+  'lax $.items[0 to 2]'
+  'lax $.*'
+  'lax $.x.abs()'
+  'lax $[*]?(@ starts with "A")'
+  ```
+- **notes:** `lax` mode auto-wraps/unwraps arrays and suppresses structural errors. `strict` mode requires exact schema match. Array subscripts are 0-based in JSON path (unlike SQL 1-based). `last` refers to the last array index. Descendant `..key` traverses all levels.
+
+---
+
+## select-synopsis
+- **syntax:**
+  ```
+  [ WITH SESSION [ name = expression [, ...] ] ]
+  [ WITH [ FUNCTION udf ] [, ...] ]
+  [ WITH [ RECURSIVE ] with_query [, ...] ]
+  SELECT [ ALL | DISTINCT ] select_expression [, ...]
+  [ FROM from_item [, ...] ]
+  [ WHERE condition ]
+  [ GROUP BY [ ALL | DISTINCT ] grouping_element [, ...] ]
+  [ HAVING condition ]
+  [ WINDOW window_definition_list ]
+  [ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] select ]
+  [ ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...] ]
+  [ OFFSET count [ ROW | ROWS ] ]
+  [ LIMIT { count | ALL } ]
+  [ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES } ]
+
+  select_expression ::=
+      expression [ [ AS ] column_alias ]
+    | row_expression . * [ AS ( column_alias [, ...] ) ]
+    | relation . *
+    | *
+
+  from_item ::=
+      table_name [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
+    | from_item join_type from_item [ ON condition | USING ( column [, ...] ) ]
+    | from_item CROSS JOIN from_item
+    | LATERAL ( subquery ) [ AS alias ]
+    | UNNEST ( array_or_map_expr ) [ WITH ORDINALITY ] [ AS alias ( col [, ...] ) ]
+    | JSON_TABLE ( ... )
+    | TABLE ( table_function_invocation ) [ AS alias ]
+    | MATCH_RECOGNIZE ( ... )
+
+  join_type ::=
+      [ INNER ] JOIN
+    | LEFT [ OUTER ] JOIN
+    | RIGHT [ OUTER ] JOIN
+    | FULL [ OUTER ] JOIN
+    | CROSS JOIN
+
+  grouping_element ::=
+      expression
+    | GROUPING SETS ( ( expression [, ...] ) [, ...] )
+    | CUBE ( expression [, ...] )
+    | ROLLUP ( expression [, ...] )
+
+  with_query ::= name [ ( col [, ...] ) ] AS ( query )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT name, count(*) FROM orders GROUP BY name HAVING count(*) > 1
+  SELECT DISTINCT dept FROM employees ORDER BY dept NULLS LAST
+  SELECT * FROM t LIMIT 10 OFFSET 5
+  FETCH FIRST 5 ROWS WITH TIES
+  ```
+- **notes:** `WITH RECURSIVE` supports recursive CTEs with UNION shape. `GROUP BY ALL` infers non-aggregated columns. `GROUP BY DISTINCT` removes duplicate grouping sets. `OFFSET` uses `ROW` or `ROWS` keyword (both accepted). `FETCH FIRST` is an alternative to LIMIT.
+
+---
+
+## cte-syntax
+- **syntax:**
+  ```
+  WITH [ RECURSIVE ] cte_name [ ( col_name [, ...] ) ] AS ( query )
+                   [, cte_name ...] ...
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  WITH orders_cte AS (SELECT * FROM orders WHERE status = 'open')
+  SELECT * FROM orders_cte
+
+  WITH RECURSIVE t(n) AS (
+      VALUES (1)
+      UNION ALL
+      SELECT n + 1 FROM t WHERE n < 4
+  )
+  SELECT * FROM t
+  ```
+- **notes:** `WITH RECURSIVE` requires UNION shape (base case UNION ALL recursive step). Default max recursion depth is 10 (configurable via `max_recursion_depth` session property). Multiple CTEs are comma-separated; later ones may reference earlier.
+
+---
+
+## unnest-syntax
+- **syntax:**
+  ```
+  UNNEST( array_or_map_expr [, ...] ) [ WITH ORDINALITY ] [ AS alias ( col [, ...] ) ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT * FROM UNNEST(ARRAY[1,2,3]) AS t(x)
+  SELECT * FROM UNNEST(ARRAY['a','b'], ARRAY[1,2]) WITH ORDINALITY AS t(s, n, ord)
+  SELECT * FROM t CROSS JOIN UNNEST(t.tags) AS u(tag)
+  ```
+- **notes:** Arrays expand to single columns; maps expand to key and value columns. `WITH ORDINALITY` adds a 1-based row number column. Multiple arrays are expanded side by side with NULL padding for shorter arrays.
+
+---
+
+## tablesample-syntax
+- **syntax:**
+  ```
+  table_name TABLESAMPLE { BERNOULLI | SYSTEM } ( percentage )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT * FROM orders TABLESAMPLE BERNOULLI (10)
+  SELECT * FROM orders TABLESAMPLE SYSTEM (1)
+  ```
+- **notes:** `BERNOULLI` does probabilistic row-level sampling (scans all blocks). `SYSTEM` does segment-level sampling (connector-dependent, faster but less precise). `percentage` is 0–100.
+
+---
+
+## lateral-syntax
+- **syntax:**
+  ```
+  LATERAL ( subquery ) [ AS alias ]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT * FROM orders o, LATERAL (SELECT max(amount) FROM items WHERE order_id = o.id) AS m(max_amt)
+  ```
+- **notes:** `LATERAL` allows the subquery to reference columns from preceding FROM items (correlated subquery in FROM). Used to produce one result per row of the outer query.
+
+---
+
+## subquery-expressions
+- **syntax:**
+  ```
+  EXISTS ( subquery )
+  expr IN ( subquery )
+  expr = ( subquery )          -- scalar subquery
+  expr operator ANY/ALL/SOME ( subquery )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  WHERE EXISTS (SELECT 1 FROM t WHERE t.id = outer.id)
+  WHERE dept_id IN (SELECT id FROM departments)
+  WHERE amount = (SELECT max(amount) FROM orders)
+  ```
+- **notes:** Scalar subqueries return zero or one row; returning more than one row is an error. Returns NULL if zero rows returned.
+
+---
+
+## datetime-arithmetic-operators
+- **syntax:**
+  ```
+  date      + interval  → date
+  date      - interval  → date
+  timestamp + interval  → timestamp
+  timestamp - interval  → timestamp
+  interval  + interval  → interval
+  interval  - interval  → interval
+  ```
+- **source_url:** https://trino.io/docs/current/functions/datetime.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  DATE '2012-08-08' + INTERVAL '2' DAY
+  TIMESTAMP '2020-01-01 00:00:00' - INTERVAL '1' HOUR
+  ```
+- **notes:** Date/time arithmetic uses the INTERVAL literal form. No date - date subtraction syntax; use `date_diff()` for that.
+
+---
+
+## match-recognize-syntax
+- **syntax:**
+  ```
+  MATCH_RECOGNIZE (
+      [ PARTITION BY column [, ...] ]
+      [ ORDER BY column [, ...] ]
+      [ MEASURES measure_definition [, ...] ]
+      [ rows_per_match ]
+      [ AFTER MATCH skip_to ]
+      PATTERN ( row_pattern )
+      [ SUBSET subset_definition [, ...] ]
+      DEFINE variable_definition [, ...]
+  )
+
+  rows_per_match ::=
+      ONE ROW PER MATCH
+    | ALL ROWS PER MATCH [ SHOW EMPTY MATCHES
+                          | OMIT EMPTY MATCHES
+                          | WITH UNMATCHED ROWS ]
+
+  skip_to ::=
+      SKIP PAST LAST ROW
+    | SKIP TO NEXT ROW
+    | SKIP TO [ FIRST | LAST ] pattern_variable
+
+  row_pattern ::= pattern_element [ | pattern_element ] ...
+  pattern_element ::= pattern_term [ pattern_quantifier ]
+  pattern_quantifier ::= * | + | ? | { n } | { n, m } | { n, } | { , m }
+
+  -- anchors: ^ (start of partition), $ (end of partition)
+  -- pattern grouping: ( row_pattern )
+  ```
+- **source_url:** https://trino.io/docs/current/sql/match-recognize.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT * FROM orders
+  MATCH_RECOGNIZE (
+      PARTITION BY customer_id
+      ORDER BY order_date
+      MEASURES A.totalprice AS starting_price, LAST(B.totalprice) AS bottom_price
+      ONE ROW PER MATCH
+      AFTER MATCH SKIP PAST LAST ROW
+      PATTERN (A B+ C*)
+      DEFINE B AS B.totalprice < PREV(B.totalprice),
+             C AS C.totalprice > PREV(C.totalprice)
+  )
+  ```
+- **notes:** Used in the FROM clause for row-pattern recognition. `MEASURES` specifies output columns. `SUBSET` declares union pattern variables. Default is `ONE ROW PER MATCH` and `SKIP PAST LAST ROW`.
+
+---
+
+## bitwise-functions
+- **syntax:**
+  ```
+  bit_count(x, bits)
+  bitwise_and(x, y)
+  bitwise_or(x, y)
+  bitwise_xor(x, y)
+  bitwise_not(x)
+  bitwise_left_shift(value, shift)
+  bitwise_right_shift(value, shift)
+  bitwise_right_shift_arithmetic(value, shift)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/bitwise.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  bitwise_and(19, 25)
+  bitwise_or(19, 25)
+  bitwise_not(19)
+  bitwise_left_shift(1, 2)
+  bitwise_right_shift(8, 3)
+  ```
+- **notes:** Trino does NOT document symbolic infix operators `&`, `|`, `^`, `~` for bitwise operations. All bitwise operations are performed via named functions. All take and return BIGINT.
+
+---
+
+## typeof-function
+- **syntax:**
+  ```
+  typeof(expr)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conversion.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  typeof(123)           -- 'integer'
+  typeof('cat')         -- 'varchar(3)'
+  typeof(ARRAY[1,2,3])  -- 'array(integer)'
+  ```
+- **notes:** Returns the type name as varchar. Useful for dynamic type inspection.
+
+---
+
+## format-function
+- **syntax:**
+  ```
+  format(format_string, args ...)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/conversion.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  format('%s%%', 123)        -- '123%'
+  format('%.5f', pi())       -- '3.14159'
+  format('%03d', 8)          -- '008'
+  ```
+- **notes:** Uses Java `Formatter` syntax for format strings. Not SQL-standard.
+
+---
+
+## geospatial-constructors
+- **syntax:**
+  ```
+  ST_GeometryFromText(wkt_string)
+  ST_Point(longitude, latitude)
+  ST_LineString(array_of_points)
+  ST_Polygon(wkt_string)
+  ST_GeomFromBinary(wkb_varbinary)
+  ```
+- **source_url:** https://trino.io/docs/current/functions/geospatial.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  ST_GeometryFromText('POINT (0 0)')
+  ST_GeometryFromText('LINESTRING (0 0, 1 1, 1 2)')
+  ST_GeometryFromText('POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))')
+  ST_Point(-73.9857, 40.7484)
+  ```
+- **notes:** Trino geospatial uses WKT (Well-Known Text) strings for geometry literals. There is no native SQL geometry literal syntax (no `GEOMETRY '...'` typed literal). The `GEOMETRY` and `SphericalGeography` types exist but are accessed only through constructor functions.
+
+---
+
+## order-by-syntax
+- **syntax:**
+  ```
+  ORDER BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  ORDER BY salary DESC NULLS LAST
+  ORDER BY name ASC NULLS FIRST
+  ORDER BY 1, 2 DESC
+  ```
+- **notes:** Default is ASC. Default null ordering is `NULLS LAST` regardless of direction. Column positions (1-based integers) are supported in ORDER BY.
+
+---
+
+## fetch-offset-limit
+- **syntax:**
+  ```
+  OFFSET count [ ROW | ROWS ]
+  LIMIT { count | ALL }
+  FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } { ONLY | WITH TIES }
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT * FROM t LIMIT 10
+  SELECT * FROM t LIMIT ALL
+  SELECT * FROM t OFFSET 5 ROWS
+  SELECT * FROM t FETCH FIRST 10 ROWS ONLY
+  SELECT * FROM t ORDER BY score DESC FETCH FIRST 3 ROWS WITH TIES
+  ```
+- **notes:** `LIMIT` and `FETCH FIRST` are alternatives; cannot use both. `WITH TIES` requires ORDER BY and returns additional rows that tie with the last selected row. `ROW`/`ROWS` are interchangeable keywords.
+
+---
+
+## grouping-sets-syntax
+- **syntax:**
+  ```
+  GROUP BY GROUPING SETS ( ( expr [, ...] ) [, ...] )
+  GROUP BY CUBE ( expr [, ...] )
+  GROUP BY ROLLUP ( expr [, ...] )
+  GROUP BY [ ALL | DISTINCT ] expr [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  GROUP BY GROUPING SETS ((dept, year), (dept), ())
+  GROUP BY CUBE (dept, year, quarter)
+  GROUP BY ROLLUP (continent, country, city)
+  GROUP BY ALL dept, year
+  GROUP BY DISTINCT GROUPING SETS ((a,b), (a), ())
+  ```
+- **notes:** `CUBE(a,b,c)` generates all 2^n grouping sets. `ROLLUP(a,b,c)` generates n+1 hierarchical subtotals. `GROUP BY ALL` (Trino extension) infers grouping from non-aggregated SELECT columns. `GROUP BY DISTINCT` removes duplicate grouping combinations.
+
+---
+
+## set-operations
+- **syntax:**
+  ```
+  query { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] query
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  SELECT a FROM t1 UNION ALL SELECT a FROM t2
+  SELECT a FROM t1 INTERSECT SELECT a FROM t2
+  SELECT a FROM t1 EXCEPT DISTINCT SELECT a FROM t2
+  ```
+- **notes:** Default is `DISTINCT` (deduplication). `ALL` preserves duplicates. Standard SQL precedence: INTERSECT binds tighter than UNION/EXCEPT.
+
+---
+
+## values-clause
+- **syntax:**
+  ```
+  VALUES row_value [, row_value ...]
+  row_value ::= ( expr [, expr] ... ) | expr
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  VALUES (1, 'a'), (2, 'b'), (3, 'c')
+  VALUES 1, 2, 3
+  WITH t(n) AS (VALUES (1) UNION ALL SELECT n+1 FROM t WHERE n < 5)
+  SELECT * FROM (VALUES (1,'foo'), (2,'bar')) AS t(id, name)
+  ```
+- **notes:** `VALUES` can be used as a standalone statement, in CTEs, or as a derived table in FROM.
+
+---
+
+## with-session-clause
+- **syntax:**
+  ```
+  WITH SESSION name = expression [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  WITH SESSION max_recursion_depth = 20
+  SELECT ...
+  ```
+- **notes:** Trino extension that sets session properties for the duration of the query. Appears before the main CTE/SELECT clause.
+
+---
+
+## with-function-clause
+- **syntax:**
+  ```
+  WITH [ FUNCTION function_name (...) RETURNS type ... ] [, ...]
+  ```
+- **source_url:** https://trino.io/docs/current/sql/select.html
+- **version:** Trino 481
+- **example_sql:**
+  ```sql
+  WITH FUNCTION double_it(x INTEGER) RETURNS INTEGER
+      RETURN x * 2
+  SELECT double_it(val) FROM t
+  ```
+- **notes:** Trino extension allowing inline UDF definitions scoped to the query. The UDF is declared inline before the main SELECT.

--- a/trino/internal/trinooracle/container.go
+++ b/trino/internal/trinooracle/container.go
@@ -1,0 +1,64 @@
+package trinooracle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// DefaultImage is the Trino image used by StartContainer.
+const DefaultImage = "trinodb/trino:latest"
+
+// StartContainer starts a disposable Trino server via testcontainers and returns
+// an Oracle pointed at it plus a terminate func. Trino's JVM takes ~30-60s to
+// become ready, so for iterative local testing prefer a long-lived container and
+// Connect(URLFromEnv()); use StartContainer for self-contained CI runs.
+func StartContainer(ctx context.Context, opts ...Option) (oracle *Oracle, terminate func(), err error) {
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        DefaultImage,
+			ExposedPorts: []string{"8080/tcp"},
+		},
+		Started: true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	terminate = func() { _ = testcontainers.TerminateContainer(c) }
+
+	host, err := c.Host(ctx)
+	if err != nil {
+		terminate()
+		return nil, nil, err
+	}
+	port, err := c.MappedPort(ctx, "8080/tcp")
+	if err != nil {
+		terminate()
+		return nil, nil, err
+	}
+	o := Connect(fmt.Sprintf("http://%s:%s", host, port.Port()), opts...)
+
+	// GenericContainer returns once the process is up; poll until Trino reports
+	// it has finished starting.
+	deadline := time.Now().Add(3 * time.Minute)
+	for {
+		pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, perr := o.Ping(pingCtx)
+		cancel()
+		if perr == nil {
+			return o, terminate, nil
+		}
+		if time.Now().After(deadline) {
+			terminate()
+			return nil, nil, fmt.Errorf("trino did not become ready within timeout: %w", perr)
+		}
+		select {
+		case <-ctx.Done():
+			terminate()
+			return nil, nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/trino/internal/trinooracle/oracle.go
+++ b/trino/internal/trinooracle/oracle.go
@@ -1,0 +1,292 @@
+// Package trinooracle is the differential-testing oracle for the omni Trino
+// parser. It talks to a live Trino server over the REST statement protocol and
+// classifies a statement as syntactically ACCEPTED or REJECTED by Trino's own
+// parser.
+//
+// The classification rule is the heart of the oracle: Trino raises errorName
+// "SYNTAX_ERROR" (errorCode 1, errorType USER_ERROR) when, and only when, its
+// parser rejects the input. Every other outcome — success, TABLE_NOT_FOUND,
+// CATALOG_NOT_FOUND, COLUMN_NOT_FOUND, NOT_SUPPORTED, TYPE_MISMATCH, … — means
+// the grammar ACCEPTED the statement and it failed (or succeeded) at a later,
+// semantic stage. This mirrors the MySQL oracle's use of error code 1064.
+//
+// A grammar node wires the differential like so (in package parser, test only):
+//
+//	func assertOracleMatch(t *testing.T, o *trinooracle.Oracle, sql string) {
+//	    _, omniErr := Parse(sql)
+//	    res, err := o.CheckSyntax(context.Background(), sql)
+//	    if err != nil { t.Skipf("oracle unreachable: %v", err) }
+//	    if (omniErr == nil) != res.Accepted {
+//	        t.Errorf("MISMATCH %q: omni accepts=%v (err=%v), trino accepts=%v (%s)",
+//	            sql, omniErr == nil, omniErr, res.Accepted, res.ErrorName)
+//	    }
+//	}
+//
+// Because classification keys on SYNTAX_ERROR, the oracle may *execute* a DDL or
+// DML statement (e.g. against the memory catalog) as a side effect; that is
+// harmless for syntax classification and the oracle container is disposable.
+package trinooracle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// DefaultURL is the conventional local Trino oracle endpoint. Start one with:
+//
+//	docker run -d --name trino-oracle -p 18080:8080 trinodb/trino:latest
+const DefaultURL = "http://localhost:18080"
+
+// EnvURL is the environment variable that overrides the oracle endpoint.
+const EnvURL = "TRINO_ORACLE_URL"
+
+// syntaxErrorName is Trino's errorName for a parser rejection.
+const syntaxErrorName = "SYNTAX_ERROR"
+
+// Oracle is a client for a live Trino server used as a syntax oracle.
+type Oracle struct {
+	baseURL string
+	user    string
+	catalog string
+	schema  string
+	client  *http.Client
+}
+
+// Option configures an Oracle.
+type Option func(*Oracle)
+
+// WithUser sets the Trino user sent in X-Trino-User.
+func WithUser(user string) Option { return func(o *Oracle) { o.user = user } }
+
+// WithDefaultNamespace sets the default catalog and schema so that
+// catalog/schema-relative statements resolve far enough to distinguish syntax
+// errors from semantic ones.
+func WithDefaultNamespace(catalog, schema string) Option {
+	return func(o *Oracle) { o.catalog, o.schema = catalog, schema }
+}
+
+// WithHTTPClient overrides the HTTP client (e.g. to change timeouts).
+func WithHTTPClient(c *http.Client) Option { return func(o *Oracle) { o.client = c } }
+
+// Connect returns an Oracle pointed at baseURL. If baseURL is empty it falls
+// back to $TRINO_ORACLE_URL and then to DefaultURL. Connect does not perform
+// any I/O; call Ping to verify reachability.
+func Connect(baseURL string, opts ...Option) *Oracle {
+	if baseURL == "" {
+		baseURL = URLFromEnv()
+	}
+	if baseURL == "" {
+		baseURL = DefaultURL
+	}
+	o := &Oracle{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		user:    "omni-oracle",
+		catalog: "memory",
+		schema:  "default",
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// URLFromEnv returns the value of $TRINO_ORACLE_URL (possibly empty).
+func URLFromEnv() string { return os.Getenv(EnvURL) }
+
+// Result is the outcome of a syntax check.
+type Result struct {
+	// Accepted is true if Trino's parser accepted the statement (no SYNTAX_ERROR).
+	Accepted bool
+	// ErrorName is Trino's errorName, "" when the statement ran without error.
+	ErrorName string
+	// ErrorCode is Trino's numeric errorCode (0 when no error).
+	ErrorCode int
+	// Message is Trino's error message, if any.
+	Message string
+}
+
+// info models the GET /v1/info response.
+type info struct {
+	Starting    bool `json:"starting"`
+	NodeVersion struct {
+		Version string `json:"version"`
+	} `json:"nodeVersion"`
+}
+
+// queryResp models the relevant fields of a /v1/statement response.
+type queryResp struct {
+	ID      string `json:"id"`
+	NextURI string `json:"nextUri"`
+	Stats   struct {
+		State string `json:"state"`
+	} `json:"stats"`
+	Error *struct {
+		Message   string `json:"message"`
+		ErrorCode int    `json:"errorCode"`
+		ErrorName string `json:"errorName"`
+		ErrorType string `json:"errorType"`
+	} `json:"error"`
+}
+
+// Ping verifies the server is reachable and finished starting, returning the
+// server version on success.
+func (o *Oracle) Ping(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.baseURL+"/v1/info", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("trino /v1/info: status %d", resp.StatusCode)
+	}
+	var in info
+	if err := json.NewDecoder(resp.Body).Decode(&in); err != nil {
+		return "", err
+	}
+	if in.Starting {
+		return in.NodeVersion.Version, fmt.Errorf("trino is still starting")
+	}
+	return in.NodeVersion.Version, nil
+}
+
+// CheckSyntax submits sql to Trino and reports whether its parser accepted it.
+// It follows the statement to the point where parsing and planning are known to
+// have completed, then cancels any remaining execution so large result sets are
+// not streamed.
+func (o *Oracle) CheckSyntax(ctx context.Context, sql string) (Result, error) {
+	resp, err := o.post(ctx, sql)
+	if err != nil {
+		return Result{}, err
+	}
+	for i := 0; i < 10000; i++ {
+		if resp.Error != nil {
+			return Result{
+				Accepted:  resp.Error.ErrorName != syntaxErrorName,
+				ErrorName: resp.Error.ErrorName,
+				ErrorCode: resp.Error.ErrorCode,
+				Message:   resp.Error.Message,
+			}, nil
+		}
+		// Once the query reaches RUNNING or FINISHED, parsing+analysis+planning
+		// have all succeeded, so the statement was syntactically accepted.
+		switch resp.Stats.State {
+		case "RUNNING", "FINISHED":
+			if resp.NextURI != "" {
+				o.cancel(resp.NextURI)
+			}
+			return Result{Accepted: true}, nil
+		}
+		if resp.NextURI == "" {
+			return Result{Accepted: true}, nil
+		}
+		select {
+		case <-ctx.Done():
+			return Result{}, ctx.Err()
+		case <-time.After(20 * time.Millisecond):
+		}
+		if resp, err = o.get(ctx, resp.NextURI); err != nil {
+			return Result{}, err
+		}
+	}
+	return Result{}, fmt.Errorf("trino: statement %q did not settle", truncate(sql, 60))
+}
+
+// Accepts is a convenience wrapper returning only the accept/reject verdict.
+func (o *Oracle) Accepts(ctx context.Context, sql string) (bool, error) {
+	res, err := o.CheckSyntax(ctx, sql)
+	if err != nil {
+		return false, err
+	}
+	return res.Accepted, nil
+}
+
+func (o *Oracle) post(ctx context.Context, sql string) (queryResp, error) {
+	// Trino can answer 503 SERVER_STARTING_UP briefly; retry a few times.
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/v1/statement", bytes.NewBufferString(sql))
+		if err != nil {
+			return queryResp{}, err
+		}
+		req.Header.Set("X-Trino-User", o.user)
+		req.Header.Set("X-Trino-Catalog", o.catalog)
+		req.Header.Set("X-Trino-Schema", o.schema)
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := o.client.Do(req)
+		if err != nil {
+			return queryResp{}, err
+		}
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("trino /v1/statement: 503")
+			select {
+			case <-ctx.Done():
+				return queryResp{}, ctx.Err()
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		return decode(resp)
+	}
+	return queryResp{}, lastErr
+}
+
+func (o *Oracle) get(ctx context.Context, uri string) (queryResp, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return queryResp{}, err
+	}
+	req.Header.Set("X-Trino-User", o.user)
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return queryResp{}, err
+	}
+	return decode(resp)
+}
+
+// cancel best-effort terminates a running query so result data is not streamed.
+func (o *Oracle) cancel(uri string) {
+	req, err := http.NewRequest(http.MethodDelete, uri, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("X-Trino-User", o.user)
+	if resp, err := o.client.Do(req); err == nil {
+		resp.Body.Close()
+	}
+}
+
+func decode(resp *http.Response) (queryResp, error) {
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return queryResp{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return queryResp{}, fmt.Errorf("trino: status %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	var qr queryResp
+	if err := json.Unmarshal(body, &qr); err != nil {
+		return queryResp{}, fmt.Errorf("trino: decode response: %w", err)
+	}
+	return qr, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/trino/internal/trinooracle/oracle_test.go
+++ b/trino/internal/trinooracle/oracle_test.go
@@ -1,0 +1,77 @@
+package trinooracle
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// testOracle connects to a live Trino server for differential testing. It
+// prefers $TRINO_ORACLE_URL, falling back to DefaultURL. The test is skipped
+// (not failed) in -short mode or when no oracle is reachable, so the suite stays
+// green without a running Trino while exercising the real classifier when one is
+// up. Start one with:
+//
+//	docker run -d --name trino-oracle -p 18080:8080 trinodb/trino:latest
+func testOracle(t *testing.T) *Oracle {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := Connect("")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ver, err := o.Ping(ctx)
+	if err != nil {
+		t.Skipf("trino oracle not reachable at %s (start: docker run -d -p 18080:8080 %s): %v", o.baseURL, DefaultImage, err)
+	}
+	t.Logf("connected to Trino %s at %s", ver, o.baseURL)
+	return o
+}
+
+// TestOracleClassification proves the oracle distinguishes a Trino parser
+// rejection (SYNTAX_ERROR) from grammar-accepted statements that fail for
+// semantic reasons (missing table/catalog/column, unsupported feature) or
+// succeed. This is the contract every grammar node relies on.
+func TestOracleClassification(t *testing.T) {
+	o := testOracle(t)
+	cases := []struct {
+		name     string
+		sql      string
+		accepted bool
+	}{
+		// Accepted: valid syntax.
+		{"valid-trivial", "SELECT 1", true},
+		{"valid-tpch", "SELECT name FROM tpch.sf1.nation", true},
+		{"show-catalogs", "SHOW CATALOGS", true},
+		{"explain", "EXPLAIN SELECT 1", true},
+		{"ddl-create-memory", "CREATE TABLE memory.default.omni_oracle_probe (x integer)", true},
+		// Trino-specific syntax must be accepted.
+		{"match-recognize", "SELECT * FROM tpch.sf1.orders MATCH_RECOGNIZE (PARTITION BY orderkey ORDER BY orderdate MEASURES A.totalprice AS p PATTERN (A+) DEFINE A AS true)", true},
+		{"group-by-rollup", "SELECT nationkey, count(*) FROM tpch.sf1.nation GROUP BY ROLLUP (nationkey)", true},
+		{"lambda", "SELECT filter(ARRAY[1,2,3], x -> x > 1)", true},
+		// Accepted by the parser but rejected at a semantic stage (NOT syntax).
+		{"semantic-no-table", "SELECT * FROM no_such_table_xyz", true},
+		{"semantic-no-catalog", "SELECT * FROM nocat.nosch.notbl", true},
+		{"semantic-no-column", "SELECT bogus_col FROM tpch.sf1.nation", true},
+		// Rejected: genuine syntax errors.
+		{"syntax-misspell", "SELCT 1", false},
+		{"syntax-dangling-from", "SELECT * FROM", false},
+		{"syntax-bad-paren", "SELECT (1 +", false},
+		{"syntax-ddl-garbage", "CREATE TABLE memory.default.t (x intGAR-BAGE !!!)", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			res, err := o.CheckSyntax(ctx, tc.sql)
+			if err != nil {
+				t.Fatalf("CheckSyntax(%q): %v", tc.sql, err)
+			}
+			if res.Accepted != tc.accepted {
+				t.Errorf("CheckSyntax(%q): accepted=%v (errorName=%q code=%d), want accepted=%v",
+					tc.sql, res.Accepted, res.ErrorName, res.ErrorCode, tc.accepted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ANALYZE + PLAN foundation for the Trino engine migration (legacy `bytebase/parser/trino` → omni hand-written parser).

## What's here
- **`docs/migration/trino/`** — analysis corpus: `analysis.md`, `antlr_rules.md` (128 rules / 81 statement forms), `truth1/` (172 documented Trino 481 forms), `contract.md` (6 P0 bytebase APIs), `oracle.md`, `dag.md` (18-node DAG).
- **`trino/internal/trinooracle/`** — differential oracle: a Trino REST client classifying `SYNTAX_ERROR` vs semantic errors against a live Trino 481 server, with testcontainers auto-start and a gated 15-case self-test (green vs Trino 481). Reused by every grammar node.

## Notes
- No new dependencies (testcontainers-go already present).
- `go build/vet ./trino/...` clean; `gofmt` clean.
- DAG seeded into the v2 SQLite migration store (validated acyclic, 9 merge layers, root `trino/ast-core`).
- This is the migration's foundation PR; per-node implementation PRs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)