### PR TITLE
feat(trino/ast): scaffold core AST node infrastructure (ast-core)

### DIFF
--- a/trino/ast/ast_test.go
+++ b/trino/ast/ast_test.go
@@ -1,0 +1,501 @@
+package ast
+
+import (
+	"reflect"
+	"testing"
+)
+
+// stubNode is a test-only Node implementation used to verify that NodeLoc
+// returns NoLoc() for unrecognized types.
+type stubNode struct{}
+
+func (stubNode) Tag() NodeTag { return T_Invalid }
+
+func TestNodeLocUnknownType(t *testing.T) {
+	if got := NodeLoc(stubNode{}); got != NoLoc() {
+		t.Errorf("NodeLoc(stubNode) = %v, want NoLoc", got)
+	}
+}
+
+func TestNodeTags(t *testing.T) {
+	tests := []struct {
+		node Node
+		want NodeTag
+	}{
+		{&File{}, T_File},
+		{&Identifier{Value: "t"}, T_Identifier},
+		{&QualifiedName{}, T_QualifiedName},
+	}
+	for _, tt := range tests {
+		if got := tt.node.Tag(); got != tt.want {
+			t.Errorf("Tag() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestNodeTagString(t *testing.T) {
+	tests := []struct {
+		tag  NodeTag
+		want string
+	}{
+		{T_Invalid, "Invalid"},
+		{T_File, "File"},
+		{T_Identifier, "Identifier"},
+		{T_QualifiedName, "QualifiedName"},
+		{NodeTag(9999), "Unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.tag.String(); got != tt.want {
+			t.Errorf("NodeTag(%d).String() = %q, want %q", tt.tag, got, tt.want)
+		}
+	}
+}
+
+// TestNodeTagStringTotal guarantees String() has a non-"Unknown" arm for
+// every declared tag, so a newly added tag without a String() case is caught.
+func TestNodeTagStringTotal(t *testing.T) {
+	for tag := T_File; tag <= T_QualifiedName; tag++ {
+		if got := tag.String(); got == "Unknown" {
+			t.Errorf("NodeTag(%d).String() = %q; declared tag missing a String() case", tag, got)
+		}
+	}
+}
+
+func TestLocIsValid(t *testing.T) {
+	tests := []struct {
+		loc  Loc
+		want bool
+	}{
+		{Loc{0, 10}, true},
+		{Loc{-1, 10}, false},
+		{Loc{0, -1}, false},
+		{NoLoc(), false},
+	}
+	for _, tt := range tests {
+		if got := tt.loc.IsValid(); got != tt.want {
+			t.Errorf("Loc{%d,%d}.IsValid() = %v, want %v", tt.loc.Start, tt.loc.End, got, tt.want)
+		}
+	}
+}
+
+func TestLocContains(t *testing.T) {
+	outer := Loc{0, 100}
+	inner := Loc{10, 50}
+	disjoint := Loc{200, 300}
+
+	if !outer.Contains(inner) {
+		t.Error("outer should contain inner")
+	}
+	if inner.Contains(outer) {
+		t.Error("inner should not contain outer")
+	}
+	if outer.Contains(disjoint) {
+		t.Error("outer should not contain disjoint")
+	}
+	if NoLoc().Contains(inner) {
+		t.Error("NoLoc should not contain anything")
+	}
+	if outer.Contains(NoLoc()) {
+		t.Error("nothing should contain NoLoc")
+	}
+	// Inclusive on both ends: a Loc contains itself.
+	if !inner.Contains(inner) {
+		t.Error("a Loc should contain itself")
+	}
+}
+
+func TestLocMerge(t *testing.T) {
+	a := Loc{10, 20}
+	b := Loc{5, 30}
+	merged := a.Merge(b)
+	if merged.Start != 5 || merged.End != 30 {
+		t.Errorf("Merge = %v, want {5, 30}", merged)
+	}
+
+	// Merge with NoLoc returns the valid side.
+	if got := a.Merge(NoLoc()); got != a {
+		t.Errorf("Merge(NoLoc) = %v, want %v", got, a)
+	}
+	if got := NoLoc().Merge(b); got != b {
+		t.Errorf("NoLoc.Merge = %v, want %v", got, b)
+	}
+	// Both invalid -> NoLoc.
+	if got := NoLoc().Merge(NoLoc()); got != NoLoc() {
+		t.Errorf("NoLoc.Merge(NoLoc) = %v, want NoLoc", got)
+	}
+}
+
+// TestIdentifierNormalize pins Trino's identifier-normalization semantics
+// (mirrors legacy NormalizeTrinoIdentifier): unquoted names fold to lower
+// case; quoted names ("..." or `...`) keep their exact case.
+func TestIdentifierNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		id   *Identifier
+		want string
+	}{
+		{"unquoted lowercases", &Identifier{Value: "MyTable"}, "mytable"},
+		{"unquoted already lower", &Identifier{Value: "orders"}, "orders"},
+		{"double-quoted preserves case", &Identifier{Value: "MyTable", Quoted: true, QuoteRune: '"'}, "MyTable"},
+		{"backtick-quoted preserves case", &Identifier{Value: "MyTable", Quoted: true, QuoteRune: '`'}, "MyTable"},
+		{"digit-leading unquoted lowercases", &Identifier{Value: "1Col"}, "1col"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id.Normalize(); got != tt.want {
+				t.Errorf("Normalize() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIdentifierString pins source-faithful rendering: unquoted identifiers
+// are returned verbatim (case preserved); quoted identifiers re-add their
+// delimiter and double any embedded delimiter. Mirrors snowflake/ast.Ident.
+func TestIdentifierString(t *testing.T) {
+	tests := []struct {
+		name string
+		id   *Identifier
+		want string
+	}{
+		{"unquoted verbatim", &Identifier{Value: "MyTable"}, "MyTable"},
+		{"double-quoted re-quotes", &Identifier{Value: "MyTable", Quoted: true, QuoteRune: '"'}, `"MyTable"`},
+		{"double-quoted escapes inner quote", &Identifier{Value: `a"b`, Quoted: true, QuoteRune: '"'}, `"a""b"`},
+		{"backtick re-quotes", &Identifier{Value: "My Col", Quoted: true, QuoteRune: '`'}, "`My Col`"},
+		{"backtick escapes inner backtick", &Identifier{Value: "a`b", Quoted: true, QuoteRune: '`'}, "`a``b`"},
+		{"quoted with no recorded delimiter defaults to double-quote", &Identifier{Value: "x", Quoted: true}, `"x"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQualifiedNameNormalize pins the canonical (case-folded) dotted form
+// used for name comparison: unquoted parts lowercase, quoted parts preserve
+// case, delimiters dropped.
+func TestQualifiedNameNormalize(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []*Identifier
+		want  string
+	}{
+		{
+			name:  "single unquoted lowercases",
+			parts: []*Identifier{{Value: "Orders"}},
+			want:  "orders",
+		},
+		{
+			name:  "schema.table",
+			parts: []*Identifier{{Value: "Sales"}, {Value: "Orders"}},
+			want:  "sales.orders",
+		},
+		{
+			name:  "catalog.schema.table",
+			parts: []*Identifier{{Value: "Hive"}, {Value: "Sales"}, {Value: "Orders"}},
+			want:  "hive.sales.orders",
+		},
+		{
+			name: "mixed quoting preserves quoted part only",
+			parts: []*Identifier{
+				{Value: "Hive"},
+				{Value: "MixedCase", Quoted: true, QuoteRune: '"'},
+				{Value: "Orders"},
+			},
+			want: "hive.MixedCase.orders",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qn := &QualifiedName{Parts: tt.parts}
+			if got := qn.Normalize(); got != tt.want {
+				t.Errorf("QualifiedName.Normalize() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	// nil receiver is safe.
+	var nilQN *QualifiedName
+	if got := nilQN.Normalize(); got != "" {
+		t.Errorf("nil.Normalize() = %q, want empty", got)
+	}
+}
+
+// TestQualifiedNameString pins source-faithful dotted rendering: case is
+// preserved and originally-quoted parts are re-quoted (with embedded
+// delimiters escaped). Used for deparse / error messages.
+func TestQualifiedNameString(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []*Identifier
+		want  string
+	}{
+		{
+			name:  "single unquoted preserves case",
+			parts: []*Identifier{{Value: "Orders"}},
+			want:  "Orders",
+		},
+		{
+			name:  "schema.table preserves case",
+			parts: []*Identifier{{Value: "Sales"}, {Value: "Orders"}},
+			want:  "Sales.Orders",
+		},
+		{
+			name: "quoted part re-quoted, unquoted preserved",
+			parts: []*Identifier{
+				{Value: "Sales"},
+				{Value: "Order Items", Quoted: true, QuoteRune: '"'},
+			},
+			want: `Sales."Order Items"`,
+		},
+		{
+			name: "embedded quote escaped",
+			parts: []*Identifier{
+				{Value: `we"ird`, Quoted: true, QuoteRune: '"'},
+			},
+			want: `"we""ird"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qn := &QualifiedName{Parts: tt.parts}
+			if got := qn.String(); got != tt.want {
+				t.Errorf("QualifiedName.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	// nil receiver is safe.
+	var nilQN *QualifiedName
+	if got := nilQN.String(); got != "" {
+		t.Errorf("nil.String() = %q, want empty", got)
+	}
+
+	// nil component parts are skipped.
+	qn := &QualifiedName{Parts: []*Identifier{{Value: "a"}, nil, {Value: "b"}}}
+	if got := qn.String(); got != "a.b" {
+		t.Errorf("String() with nil part = %q, want %q", got, "a.b")
+	}
+}
+
+func TestQualifiedNameNormalizedParts(t *testing.T) {
+	qn := &QualifiedName{Parts: []*Identifier{
+		{Value: "Hive"},
+		nil, // skipped
+		{Value: "Orders", Quoted: true, QuoteRune: '"'},
+	}}
+	got := qn.NormalizedParts()
+	want := []string{"hive", "Orders"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("NormalizedParts() = %v, want %v", got, want)
+	}
+
+	// nil receiver is safe.
+	var nilQN *QualifiedName
+	if got := nilQN.NormalizedParts(); got != nil {
+		t.Errorf("nil.NormalizedParts() = %v, want nil", got)
+	}
+}
+
+func TestWalkFile(t *testing.T) {
+	// Build a small tree: File with two QualifiedName children, each with
+	// one Identifier part.
+	child1 := &QualifiedName{Parts: []*Identifier{{Value: "a", Loc: Loc{0, 1}}}, Loc: Loc{0, 1}}
+	child2 := &QualifiedName{Parts: []*Identifier{{Value: "b", Loc: Loc{2, 3}}}, Loc: Loc{2, 3}}
+	file := &File{Stmts: []Node{child1, child2}, Loc: Loc{0, 3}}
+
+	var visited []NodeTag
+	Inspect(file, func(n Node) bool {
+		if n != nil {
+			visited = append(visited, n.Tag())
+		}
+		return true
+	})
+
+	want := []NodeTag{
+		T_File,
+		T_QualifiedName, T_Identifier,
+		T_QualifiedName, T_Identifier,
+	}
+	if !reflect.DeepEqual(visited, want) {
+		t.Fatalf("visited = %v, want %v", visited, want)
+	}
+}
+
+func TestWalkNilNode(t *testing.T) {
+	// Walk(nil) should not panic.
+	Walk(inspector(func(Node) bool { return true }), nil)
+}
+
+// TestWalkSkipsNilParts ensures the walker does not hand a typed-nil
+// *Identifier to the visitor for a nil component of a QualifiedName — a
+// realistic visitor that type-asserts and dereferences would otherwise
+// panic. This keeps the walker consistent with NormalizedParts/String,
+// which also skip nil parts.
+func TestWalkSkipsNilParts(t *testing.T) {
+	qn := &QualifiedName{Parts: []*Identifier{
+		{Value: "a"},
+		nil,
+		{Value: "b"},
+	}}
+
+	var values []string
+	Inspect(qn, func(n Node) bool {
+		// A realistic visitor: type-assert and dereference.
+		if id, ok := n.(*Identifier); ok {
+			values = append(values, id.Value)
+		}
+		return true
+	})
+
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(values, want) {
+		t.Errorf("visited identifier values = %v, want %v", values, want)
+	}
+}
+
+// recorder is a Visitor that logs pre-order and post-order events.
+type recorder struct {
+	events *[]string
+}
+
+func (r recorder) Visit(node Node) Visitor {
+	if node == nil {
+		*r.events = append(*r.events, "post")
+		return nil
+	}
+	*r.events = append(*r.events, node.Tag().String())
+	return r
+}
+
+func TestWalkPostOrder(t *testing.T) {
+	child := &Identifier{Value: "a"}
+	qn := &QualifiedName{Parts: []*Identifier{child}}
+	file := &File{Stmts: []Node{qn}}
+
+	var events []string
+	Walk(recorder{&events}, file)
+
+	// Pre-order on the way down, "post" on the way back up.
+	want := []string{
+		"File",
+		"QualifiedName",
+		"Identifier",
+		"post", // Identifier post
+		"post", // QualifiedName post
+		"post", // File post
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestWalkAbort(t *testing.T) {
+	// Returning false from the inspector should prevent descending into
+	// children.
+	child := &Identifier{Value: "a"}
+	qn := &QualifiedName{Parts: []*Identifier{child}}
+	file := &File{Stmts: []Node{qn}}
+
+	var visited []string
+	Inspect(file, func(n Node) bool {
+		if n != nil {
+			visited = append(visited, n.Tag().String())
+		}
+		// Return false for everything -> visit only the root.
+		return false
+	})
+
+	want := []string{"File"}
+	if !reflect.DeepEqual(visited, want) {
+		t.Fatalf("visited = %v, want %v", visited, want)
+	}
+}
+
+func TestNodeLoc(t *testing.T) {
+	file := &File{Loc: Loc{0, 100}}
+	id := &Identifier{Value: "t", Loc: Loc{5, 10}}
+	qn := &QualifiedName{Loc: Loc{5, 20}}
+
+	if got := NodeLoc(file); got != file.Loc {
+		t.Errorf("NodeLoc(File) = %v, want %v", got, file.Loc)
+	}
+	if got := NodeLoc(id); got != id.Loc {
+		t.Errorf("NodeLoc(Identifier) = %v, want %v", got, id.Loc)
+	}
+	if got := NodeLoc(qn); got != qn.Loc {
+		t.Errorf("NodeLoc(QualifiedName) = %v, want %v", got, qn.Loc)
+	}
+	if got := NodeLoc(nil); got != NoLoc() {
+		t.Errorf("NodeLoc(nil) = %v, want NoLoc", got)
+	}
+}
+
+// TestNodeLocTypedNil guards against the Go typed-nil pitfall: a (*T)(nil)
+// boxed in a non-nil Node interface must yield NoLoc(), not a panic. This
+// happens when an optional child field is left unset but still passed as a
+// Node.
+func TestNodeLocTypedNil(t *testing.T) {
+	cases := []struct {
+		name string
+		node Node
+	}{
+		{"typed-nil *File", (*File)(nil)},
+		{"typed-nil *Identifier", (*Identifier)(nil)},
+		{"typed-nil *QualifiedName", (*QualifiedName)(nil)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NodeLoc(c.node); got != NoLoc() {
+				t.Errorf("NodeLoc(%s) = %v, want NoLoc", c.name, got)
+			}
+		})
+	}
+
+	// SpanNodes must likewise survive a typed-nil entry (it routes through
+	// NodeLoc) and treat it as having no valid loc.
+	valid := &Identifier{Value: "a", Loc: Loc{10, 20}}
+	if got := SpanNodes((*Identifier)(nil), valid); got != valid.Loc {
+		t.Errorf("SpanNodes(typed-nil, valid) = %v, want %v", got, valid.Loc)
+	}
+}
+
+func TestSpanNodes(t *testing.T) {
+	a := &Identifier{Value: "a", Loc: Loc{10, 20}}
+	b := &Identifier{Value: "b", Loc: Loc{5, 30}}
+
+	span := SpanNodes(a, b)
+	if span.Start != 5 || span.End != 30 {
+		t.Errorf("SpanNodes = %v, want {5, 30}", span)
+	}
+
+	// With nil entries.
+	span2 := SpanNodes(nil, a, nil)
+	if span2 != a.Loc {
+		t.Errorf("SpanNodes(nil, a, nil) = %v, want %v", span2, a.Loc)
+	}
+
+	// Empty args.
+	if got := SpanNodes(); got != NoLoc() {
+		t.Errorf("SpanNodes() = %v, want NoLoc", got)
+	}
+
+	// A node whose Loc is fully invalid (NoLoc) is skipped.
+	invalid := &Identifier{Value: "x", Loc: NoLoc()}
+	if got := SpanNodes(invalid, a); got != a.Loc {
+		t.Errorf("SpanNodes(invalid, a) = %v, want %v", got, a.Loc)
+	}
+
+	// A node whose Loc is HALF-invalid (e.g. End == -1 from an upstream
+	// slip) must also be skipped, not leaked into the result.
+	halfInvalid := &Identifier{Value: "y", Loc: Loc{Start: 5, End: -1}}
+	if got := SpanNodes(halfInvalid); got != NoLoc() {
+		t.Errorf("SpanNodes(halfInvalid) = %v, want NoLoc", got)
+	}
+	if got := SpanNodes(halfInvalid, a); got != a.Loc {
+		t.Errorf("SpanNodes(halfInvalid, a) = %v, want %v", got, a.Loc)
+	}
+}

--- a/trino/ast/loc.go
+++ b/trino/ast/loc.go
@@ -1,0 +1,57 @@
+package ast
+
+// NodeLoc returns the source location of n, or NoLoc() if n is nil or its
+// concrete type carries no Loc field. Every concrete node type added under
+// trino/ast must add a case here.
+//
+// n may be either an untyped nil Node or a typed-nil pointer (e.g. a
+// (*Identifier)(nil) boxed in a non-nil interface, which occurs when an
+// optional child field is left unset); both yield NoLoc() rather than a
+// panic. The pattern matches doris/ast.NodeLoc and snowflake/ast.NodeLoc
+// but additionally hardens the per-case dereference against typed nils.
+func NodeLoc(n Node) Loc {
+	if n == nil {
+		return NoLoc()
+	}
+	switch v := n.(type) {
+	case *File:
+		if v == nil {
+			return NoLoc()
+		}
+		return v.Loc
+	case *Identifier:
+		if v == nil {
+			return NoLoc()
+		}
+		return v.Loc
+	case *QualifiedName:
+		if v == nil {
+			return NoLoc()
+		}
+		return v.Loc
+	default:
+		return NoLoc()
+	}
+}
+
+// SpanNodes returns the smallest Loc that covers every node in nodes.
+// Nil entries and nodes whose Loc is invalid (per Loc.IsValid) are skipped.
+// Returns NoLoc() when no node has a valid Loc (including the empty-args
+// case). Skipping invalid locs explicitly keeps a half-set Loc (e.g. a
+// node with End == -1 from an upstream parser slip) from leaking into the
+// result, since Loc.Merge returns the other side verbatim when one side is
+// invalid.
+func SpanNodes(nodes ...Node) Loc {
+	out := NoLoc()
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		loc := NodeLoc(n)
+		if !loc.IsValid() {
+			continue
+		}
+		out = out.Merge(loc)
+	}
+	return out
+}

--- a/trino/ast/node.go
+++ b/trino/ast/node.go
@@ -1,0 +1,72 @@
+// Package ast defines Trino parse-tree node types.
+//
+// The package mirrors omni's doris/ast, snowflake/ast and mysql/ast
+// conventions: every concrete node implements Node by exposing a
+// Tag() NodeTag method, every node carries a Loc field for source-position
+// tracking, and walk_generated.go dispatches walker traversal via a type
+// switch.
+//
+// Trino's grammar (derived from the official SqlBase.g4) is large — 81
+// statement forms with deep query/expression layers. This file ships only
+// the foundation (Node interface, Loc tracking) that every downstream
+// migration node builds on; concrete statement, expression, and type nodes
+// are added by the lexer/parser/type/expression DAG nodes.
+package ast
+
+// Node is the interface implemented by every Trino parse-tree node.
+//
+// Tag returns a unique NodeTag identifying the concrete type. Use Tag for
+// fast switch dispatch in hot paths; use a Go type assertion when you need
+// to access the concrete fields.
+type Node interface {
+	Tag() NodeTag
+}
+
+// Loc represents a source byte range. -1 means "unknown" for either field.
+//
+// Loc is a value type embedded as a plain field on every concrete node;
+// it is NOT part of the Node interface (mirroring doris/ast and
+// snowflake/ast). Helpers in loc.go extract Loc from any Node.
+type Loc struct {
+	Start int // inclusive start byte offset (-1 if unknown)
+	End   int // exclusive end byte offset   (-1 if unknown)
+}
+
+// NoLoc returns a Loc with both Start and End set to -1 (unknown).
+func NoLoc() Loc {
+	return Loc{Start: -1, End: -1}
+}
+
+// IsValid reports whether both Start and End are non-negative.
+func (l Loc) IsValid() bool {
+	return l.Start >= 0 && l.End >= 0
+}
+
+// Contains reports whether l fully contains other (inclusive on both ends).
+// Returns false if either Loc is invalid.
+func (l Loc) Contains(other Loc) bool {
+	if !l.IsValid() || !other.IsValid() {
+		return false
+	}
+	return l.Start <= other.Start && other.End <= l.End
+}
+
+// Merge returns the smallest Loc that contains both l and other.
+// If either side is invalid, returns the other side. If both are invalid,
+// returns NoLoc().
+func (l Loc) Merge(other Loc) Loc {
+	if !l.IsValid() {
+		return other
+	}
+	if !other.IsValid() {
+		return l
+	}
+	out := l
+	if other.Start < out.Start {
+		out.Start = other.Start
+	}
+	if other.End > out.End {
+		out.End = other.End
+	}
+	return out
+}

--- a/trino/ast/nodetags.go
+++ b/trino/ast/nodetags.go
@@ -1,0 +1,45 @@
+package ast
+
+// NodeTag identifies the concrete type of an AST node.
+//
+// Every concrete node type defined under trino/ast must declare a unique
+// NodeTag constant in this file and return it from Tag(). This enables fast
+// switch dispatch and code-generated walker support.
+//
+// The numeric values are NOT stable -- do not persist them. Tags are assigned
+// by source order; reorder freely as the package evolves.
+type NodeTag int
+
+const (
+	// T_Invalid is the zero-value tag, returned only by uninitialized nodes
+	// or test stubs that have no need for a real tag.
+	T_Invalid NodeTag = iota
+
+	// T_File is the tag for *File, the root statement-list container
+	// returned by the parser entry point.
+	T_File
+
+	// T_Identifier is the tag for *Identifier, a single Trino identifier
+	// (unquoted, "double-quoted", `backtick-quoted`, or digit-leading).
+	T_Identifier
+
+	// T_QualifiedName is the tag for *QualifiedName, a dot-separated chain
+	// of identifiers (e.g., catalog.schema.table).
+	T_QualifiedName
+)
+
+// String returns a human-readable representation of the tag.
+func (t NodeTag) String() string {
+	switch t {
+	case T_Invalid:
+		return "Invalid"
+	case T_File:
+		return "File"
+	case T_Identifier:
+		return "Identifier"
+	case T_QualifiedName:
+		return "QualifiedName"
+	default:
+		return "Unknown"
+	}
+}

--- a/trino/ast/parsenodes.go
+++ b/trino/ast/parsenodes.go
@@ -1,0 +1,160 @@
+package ast
+
+import "strings"
+
+// This file holds the foundational Trino parse-tree node types. The ast-core
+// node ships the File root container plus the two identifier nodes the whole
+// grammar pivots on (Trino's `identifier` and `qualifiedName` grammar rules);
+// later migration nodes (lexer, parser, types, expressions, statements)
+// populate the rest.
+
+// File is the root node of a parsed Trino source file. It holds the
+// top-level statement list and the byte range covering the entire file.
+type File struct {
+	Stmts []Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *File) Tag() NodeTag { return T_File }
+
+// Compile-time assertion that *File satisfies Node.
+var _ Node = (*File)(nil)
+
+// ---------------------------------------------------------------------------
+// Identifier nodes
+// ---------------------------------------------------------------------------
+
+// Identifier represents a single Trino identifier — one component of a name.
+// It corresponds to the legacy grammar's `identifier` rule, whose four
+// alternatives are: an unquoted identifier, a `"double-quoted"` identifier,
+// a “ `backtick-quoted` “ identifier, and a digit-leading identifier.
+//
+// Value stores the identifier's source text with the surrounding quote
+// characters already stripped and any doubled-quote escape (`""` or “ “ “)
+// collapsed to a single quote. Quoting metadata is preserved separately
+// because Trino's identifier resolution is case-sensitive for quoted names
+// and case-insensitive (folded to lower case) for unquoted ones — see
+// Normalize.
+type Identifier struct {
+	// Value is the unquoted identifier text (quotes stripped, escapes
+	// collapsed). Case is preserved exactly as written in the source.
+	Value string
+	// Quoted reports whether the source identifier was delimited
+	// (double-quoted or backtick-quoted). Digit-leading and bare
+	// identifiers are not quoted.
+	Quoted bool
+	// QuoteRune is the delimiter rune used when Quoted is true: '"' for a
+	// standard double-quoted identifier or '`' for a backtick-quoted one.
+	// It is 0 when Quoted is false.
+	QuoteRune rune
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *Identifier) Tag() NodeTag { return T_Identifier }
+
+// Compile-time assertion that *Identifier satisfies Node.
+var _ Node = (*Identifier)(nil)
+
+// Normalize returns the identifier in the canonical form Trino uses for
+// name resolution: quoted identifiers keep their exact case, while unquoted
+// identifiers are folded to lower case (Trino identifiers are
+// case-insensitive unless quoted; note Trino folds to lower case, unlike
+// Snowflake which folds to upper). This mirrors the legacy bytebase helper
+// NormalizeTrinoIdentifier so downstream lineage/completion consumers can
+// compare names consistently.
+//
+// Use Normalize for name comparison; use String for source-faithful
+// rendering (deparse, error messages). This mirrors the
+// snowflake/ast.Ident.Normalize / String split.
+func (n *Identifier) Normalize() string {
+	if n.Quoted {
+		return n.Value
+	}
+	return strings.ToLower(n.Value)
+}
+
+// String returns the source-faithful form of the identifier, re-adding the
+// original delimiter when it was quoted and escaping any embedded delimiter
+// by doubling it (`"` -> `""`, “ ` “ -> “ “ “). Unquoted identifiers
+// are returned verbatim with case preserved. Mirrors
+// snowflake/ast.Ident.String; useful for deparse and error messages.
+func (n *Identifier) String() string {
+	if !n.Quoted {
+		return n.Value
+	}
+	q := n.QuoteRune
+	if q == 0 {
+		// Quoted with no recorded delimiter: default to the standard
+		// double-quote so output is still valid Trino syntax.
+		q = '"'
+	}
+	qs := string(q)
+	return qs + strings.ReplaceAll(n.Value, qs, qs+qs) + qs
+}
+
+// ---------------------------------------------------------------------------
+// QualifiedName
+// ---------------------------------------------------------------------------
+
+// QualifiedName represents a dot-separated chain of identifiers, matching the
+// legacy grammar's `qualifiedName` rule (`identifier ('.' identifier)*`).
+// In Trino a three-part name is catalog.schema.table; shorter names are
+// resolved against the session's current catalog/schema.
+//
+// Parts holds the component identifiers in source order, preserving each
+// component's quoting metadata so callers can normalize per-part (catalog
+// and schema may be quoted independently of the object name).
+type QualifiedName struct {
+	Parts []*Identifier
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *QualifiedName) Tag() NodeTag { return T_QualifiedName }
+
+// Compile-time assertion that *QualifiedName satisfies Node.
+var _ Node = (*QualifiedName)(nil)
+
+// NormalizedParts returns the per-component normalized names (see
+// Identifier.Normalize). Nil component entries are skipped.
+func (n *QualifiedName) NormalizedParts() []string {
+	if n == nil {
+		return nil
+	}
+	parts := make([]string, 0, len(n.Parts))
+	for _, p := range n.Parts {
+		if p == nil {
+			continue
+		}
+		parts = append(parts, p.Normalize())
+	}
+	return parts
+}
+
+// Normalize returns the canonical dotted form with each component normalized
+// per Trino resolution rules (e.g., "catalog.schema.table"). Use this for
+// name comparison. Nil components are skipped. Mirrors
+// snowflake/ast.ObjectName.Normalize.
+func (n *QualifiedName) Normalize() string {
+	return strings.Join(n.NormalizedParts(), ".")
+}
+
+// String returns the source-faithful dotted form, re-quoting each component
+// that was originally quoted and preserving case (see Identifier.String).
+// Nil components are skipped. Use this for deparse and error messages;
+// use Normalize for name comparison. Mirrors snowflake/ast.ObjectName.String.
+func (n *QualifiedName) String() string {
+	if n == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(n.Parts))
+	for _, p := range n.Parts {
+		if p == nil {
+			continue
+		}
+		parts = append(parts, p.String())
+	}
+	return strings.Join(parts, ".")
+}

--- a/trino/ast/walk.go
+++ b/trino/ast/walk.go
@@ -1,0 +1,54 @@
+package ast
+
+// Visitor is implemented by clients of Walk.
+//
+// Visit is called for each node during a depth-first walk. If Visit returns
+// a non-nil w, Walk recurses into the node's children with w, then calls
+// w.Visit(nil) to signal end-of-children (post-order). If Visit returns nil,
+// children are not visited.
+//
+// This is the same shape as doris/ast.Visitor, snowflake/ast.Visitor and
+// pg/ast.Visitor.
+type Visitor interface {
+	Visit(node Node) Visitor
+}
+
+// Walk traverses an AST in depth-first order. It calls v.Visit(node);
+// if that returns a non-nil visitor w, it walks each child node with w,
+// then calls w.Visit(nil) to mark post-order.
+func Walk(v Visitor, node Node) {
+	if node == nil {
+		return
+	}
+	w := v.Visit(node)
+	if w == nil {
+		return
+	}
+	walkChildren(w, node)
+	w.Visit(nil)
+}
+
+// Inspect traverses an AST in depth-first order, calling f for each node.
+// If f returns true, Inspect recurses into the node's children. Inspect
+// calls f(nil) on post-order is NOT performed — f only ever receives
+// non-nil nodes.
+func Inspect(node Node, f func(Node) bool) {
+	Walk(inspector(f), node)
+}
+
+type inspector func(Node) bool
+
+func (f inspector) Visit(node Node) Visitor {
+	if node != nil && f(node) {
+		return f
+	}
+	return nil
+}
+
+// walkNodes visits each entry in nodes by calling Walk on it. Used by
+// walk_generated.go to traverse slice-typed child fields like []Node.
+func walkNodes(v Visitor, nodes []Node) {
+	for _, n := range nodes {
+		Walk(v, n)
+	}
+}

--- a/trino/ast/walk_generated.go
+++ b/trino/ast/walk_generated.go
@@ -1,0 +1,27 @@
+package ast
+
+// walkChildren walks the child nodes of node, calling Walk(v, child)
+// for each child. Maintained manually until the node count warrants a
+// code generator (mirroring doris/ast).
+//
+// Every concrete node type added under trino/ast must add a case here so
+// the walker descends into its children (or an explicit leaf comment when
+// it has none).
+func walkChildren(v Visitor, node Node) {
+	switch n := node.(type) {
+	case *File:
+		walkNodes(v, n.Stmts)
+	case *QualifiedName:
+		for _, p := range n.Parts {
+			if p == nil {
+				// Skip nil component parts so the visitor never receives a
+				// typed-nil *Identifier (consistent with NormalizedParts /
+				// String, which also skip nil parts).
+				continue
+			}
+			Walk(v, p)
+		}
+	case *Identifier:
+		// leaf node, no children
+	}
+}


### PR DESCRIPTION
## Node: `trino/ast-core` (omni Trino v2 migration)

Root node of the Trino migration DAG (`docs/migration/trino/dag.md`). Scaffolds the omni `trino/ast` package every downstream grammar/feature node builds on. Copies the **doris/ast** + **snowflake/ast** foundation pattern (per `docs/migration/trino/analysis.md` §4 "omni Architecture Fit").

- Spec: `docs/migration/trino/analysis.md` (Tier 0 #2 "AST core — node interfaces, `Loc` tracking, walker"), `docs/migration/trino/dag.md` row `trino/ast-core`.
- Writes-glob: `trino/ast/*.go` (declared). **Out-of-scope writes: none.**

### What ships
| File | Contents |
|---|---|
| `node.go` | `Node` interface (`Tag() NodeTag`); `Loc` byte-range value type + `NoLoc`/`IsValid`/`Contains`/`Merge` |
| `nodetags.go` | `NodeTag` enum + `String()` |
| `parsenodes.go` | `File` root container; `Identifier` (Trino `identifier` rule, with `Quoted`/`QuoteRune`); `QualifiedName` (`qualifiedName` rule) |
| `walk.go` | `Visitor` + `Walk`/`Inspect` (pre/post-order) |
| `walk_generated.go` | `walkChildren` type-switch dispatcher |
| `loc.go` | `NodeLoc` (typed-nil-safe) + `SpanNodes` (skips invalid locs) |
| `ast_test.go` | unit tests, 100% statement coverage |

### Design note — identifier model
The legacy bytebase helper `NormalizeTrinoIdentifier` folds **unquoted** identifiers to lower-case and preserves the case of **quoted** ones. `Identifier` records `Quoted`/`QuoteRune`, giving two distinct renderings (matching the established `snowflake/ast.Ident` split):
- `Normalize()` — case-folded canonical form for name resolution / lineage / completion comparison (unquoted → `ToLower`, quoted → preserved). Reproduces `NormalizeTrinoIdentifier`.
- `String()` — source-faithful form (re-quotes, escapes embedded delimiters, preserves case) for deparse / error messages.

`QualifiedName` exposes the same `Normalize()` (dotted canonical) / `String()` (dotted source-faithful) pair plus `NormalizedParts()`.

### Correctness evidence
This node produces **no parser**, so the live Trino 481 differential oracle (`trino/internal/trinooracle`) gates the downstream grammar nodes, not this one. The relevant bars here are **structural** + **completeness**, all covered:
- `go build ./trino/...` ✅ · `go vet ./trino/ast/...` ✅ · `gofmt -l` clean ✅
- `go test ./trino/ast/... -race -cover` ✅ → **100.0% of statements**
- Completeness: every node type has a `Tag()`, a `NodeLoc` case, a `walkChildren` case, and a `NodeTag.String()` arm (locked by `TestNodeTagStringTotal`).
- Walker pre/post-order, abort, untyped-nil + **typed-nil** safety, `Loc` algebra edges, `SpanNodes` invalid-loc skipping — all have tests.
- Oracle harness still builds and its self-test passes against live Trino 481 (`connected to Trino 481 at http://localhost:18080`, 15/15 classification cases) — unaffected by this node.

### Divergences
**None.** This is a pure AST scaffold; the seeded divergence-ledger items all belong to lexer / parser-select / parser-dml nodes.

### Review gate (two lenses, cross-family)
Claude lens (`/code-review`) + Codex lens, blind/parallel, then fix-loop to convergence (4 rounds):
1. `QualifiedName.String()` conflated normalization with source rendering; `Identifier.String()` not source-faithful; `SpanNodes` leaked a half-invalid `Loc` → **fixed** (Normalize/String split per snowflake precedent; `SpanNodes` skips invalid locs).
2. `NodeLoc`/`SpanNodes` panicked on a typed-nil pointer → **fixed** (per-case `v == nil` guard) + regression test.
3. Walker handed a typed-nil `*Identifier` to the visitor for a nil `QualifiedName` part → **fixed** (skip nil parts) + regression test.
4. Clean — no blocking findings.

All findings were real bugs (none rebutted). The typed-nil holes also exist in the doris precedent; fixed here to honor the documented contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
