### PR TITLE
feat(trino/catalog): metadata model & name resolution (v2 node trino/catalog)

### DIFF
--- a/trino/catalog/catalog.go
+++ b/trino/catalog/catalog.go
@@ -1,0 +1,119 @@
+// Package catalog provides in-memory metadata context for Trino
+// auto-completion and query-span/lineage analysis.
+//
+// Unlike the flat partiql (DynamoDB tables) and mongo (collections) catalogs,
+// Trino has a three-level object namespace — catalog -> schema -> table/view
+// -> column. A fully-qualified Trino name is catalog.schema.table; shorter
+// names resolve against the session's current catalog and schema (set via
+// USE catalog.schema). This package models that hierarchy and exposes the
+// read API the completion package needs (catalog/schema/table/view/column
+// candidates and qualified-name resolution).
+//
+// # Identifier normalization (the load-bearing contract)
+//
+// Trino folds unquoted identifiers to lower case and preserves the case of
+// double-quoted identifiers; quoted names are therefore case-sensitive. This
+// catalog stores and looks up every name by its already-normalized form and
+// performs no folding of its own — that keeps it from double-folding a name
+// like "MyView" (the case-preserved result of normalizing a quoted "MyView").
+//
+// Callers normalize once, at the boundary:
+//   - With a parsed ast.Identifier / ast.QualifiedName, use the *Ident methods
+//     or pass id.Normalize() / qn.NormalizedParts() — the AST node carries the
+//     quoting metadata.
+//   - With raw source text (e.g. names from a DatabaseMetadata snapshot or a
+//     test fixture), call the package Normalize function first.
+//
+// The package depends only on trino/ast for that normalization contract; it
+// does not depend on the parser.
+package catalog
+
+import (
+	"sort"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// Catalog is the in-memory Trino catalog: the top of the
+// catalog -> schema -> table/view -> column hierarchy. It also carries the
+// session's current catalog and schema, used to resolve unqualified and
+// partially-qualified names the way Trino does.
+//
+// Catalog is not safe for concurrent mutation; build it once (e.g. from a
+// DatabaseMetadata snapshot) and then read from it.
+type Catalog struct {
+	// databases maps a normalized catalog name to its Database. Trino calls
+	// the top-level namespace a "catalog"; we name the Go type Database to
+	// stay consistent with the mysql/tidb catalog packages, but every
+	// user-facing accessor uses Trino's "catalog" terminology.
+	databases map[string]*Database
+
+	// currentCatalog and currentSchema hold the session context set by
+	// USE catalog.schema (or USE schema). They default to empty, meaning
+	// "no session catalog/schema selected"; resolution of unqualified names
+	// then fails rather than guessing.
+	currentCatalog string
+	currentSchema  string
+}
+
+// New creates an empty Catalog with no session catalog or schema selected.
+func New() *Catalog {
+	return &Catalog{databases: make(map[string]*Database)}
+}
+
+// SetCurrentCatalog records the session's current catalog (as set by
+// USE catalog.schema). name must already be normalized.
+func (c *Catalog) SetCurrentCatalog(name string) { c.currentCatalog = name }
+
+// CurrentCatalog returns the session's current catalog name (normalized), or
+// "" if none is selected.
+func (c *Catalog) CurrentCatalog() string { return c.currentCatalog }
+
+// SetCurrentSchema records the session's current schema. name must already be
+// normalized.
+func (c *Catalog) SetCurrentSchema(name string) { c.currentSchema = name }
+
+// CurrentSchema returns the session's current schema name (normalized), or
+// "" if none is selected.
+func (c *Catalog) CurrentSchema() string { return c.currentSchema }
+
+// EnsureCatalog returns the named catalog, creating and registering an empty
+// one if it does not already exist. name must already be normalized (see the
+// package doc); use EnsureCatalogIdent when you hold a parsed ast.Identifier.
+func (c *Catalog) EnsureCatalog(name string) *Database {
+	if db, ok := c.databases[name]; ok {
+		return db
+	}
+	db := newDatabase(name)
+	c.databases[name] = db
+	return db
+}
+
+// EnsureCatalogIdent is EnsureCatalog keyed by a parsed identifier, using the
+// AST node's quote-aware normalization.
+func (c *Catalog) EnsureCatalogIdent(id *ast.Identifier) *Database {
+	return c.EnsureCatalog(normalizeIdent(id))
+}
+
+// GetCatalog returns the named catalog, or nil if it is not registered. name
+// must already be normalized.
+func (c *Catalog) GetCatalog(name string) *Database {
+	return c.databases[name]
+}
+
+// HasCatalog reports whether the named (normalized) catalog is registered.
+func (c *Catalog) HasCatalog(name string) bool {
+	_, ok := c.databases[name]
+	return ok
+}
+
+// Catalogs returns the normalized names of all registered catalogs in sorted
+// order. The slice is freshly allocated and safe for the caller to retain.
+func (c *Catalog) Catalogs() []string {
+	result := make([]string, 0, len(c.databases))
+	for name := range c.databases {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/trino/catalog/catalog_test.go
+++ b/trino/catalog/catalog_test.go
@@ -1,0 +1,307 @@
+package catalog_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// --- normalization boundary --------------------------------------------------
+
+// TestNormalize pins the load-bearing Trino semantic mirrored by this package:
+// unquoted identifiers fold to lower case; double-quoted identifiers keep their
+// case (and lose the quotes). It must agree with ast.Identifier.Normalize,
+// which is what the parser feeds the catalog.
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"NATION", "nation"},
+		{"nation", "nation"},
+		{"MyTable", "mytable"},
+		{`"MyTable"`, "MyTable"}, // quoted preserves case
+		{`"lower"`, "lower"},     // quoted, already lower
+		{`""`, ""},               // empty quoted identifier
+		{`"a""b"`, `a""b`},       // strips only outer quotes; embedded "" not collapsed (route quoted source tokens through the AST)
+		{"1Col", "1col"},         // digit-leading unquoted folds
+	}
+	for _, tt := range tests {
+		if got := catalog.Normalize(tt.in); got != tt.want {
+			t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestNormalizeMatchesASTIdentifier proves the package Normalize and the
+// EnsureCatalogIdent path agree with ast.Identifier.Normalize for both quoted
+// and unquoted identifiers — the interop contract with the parser.
+func TestNormalizeMatchesASTIdentifier(t *testing.T) {
+	cases := []struct {
+		raw string
+		id  *ast.Identifier
+	}{
+		{"MyTable", &ast.Identifier{Value: "MyTable"}},
+		{`"MyTable"`, &ast.Identifier{Value: "MyTable", Quoted: true, QuoteRune: '"'}},
+		{"orders", &ast.Identifier{Value: "orders"}},
+	}
+	for _, tc := range cases {
+		if catalog.Normalize(tc.raw) != tc.id.Normalize() {
+			t.Errorf("Normalize(%q)=%q disagrees with ast.Identifier.Normalize()=%q",
+				tc.raw, catalog.Normalize(tc.raw), tc.id.Normalize())
+		}
+	}
+}
+
+// --- top-level Catalog -------------------------------------------------------
+
+func TestNewCatalogEmpty(t *testing.T) {
+	c := catalog.New()
+	if got := c.Catalogs(); len(got) != 0 {
+		t.Errorf("new catalog Catalogs() = %v, want empty", got)
+	}
+	if c.HasCatalog("tpch") {
+		t.Error("HasCatalog returned true on empty catalog")
+	}
+	if c.GetCatalog("tpch") != nil {
+		t.Error("GetCatalog returned non-nil on empty catalog")
+	}
+	if c.CurrentCatalog() != "" {
+		t.Errorf("CurrentCatalog() = %q, want empty", c.CurrentCatalog())
+	}
+	if c.CurrentSchema() != "" {
+		t.Errorf("CurrentSchema() = %q, want empty", c.CurrentSchema())
+	}
+}
+
+func TestEnsureCatalogIdempotent(t *testing.T) {
+	c := catalog.New()
+	a := c.EnsureCatalog("tpch")
+	b := c.EnsureCatalog("tpch")
+	if a != b {
+		t.Error("EnsureCatalog returned a different instance on second call")
+	}
+	if got := c.Catalogs(); !slices.Equal(got, []string{"tpch"}) {
+		t.Errorf("Catalogs() = %v, want [tpch]", got)
+	}
+}
+
+func TestCatalogsSortedAndDeduped(t *testing.T) {
+	c := catalog.New()
+	c.EnsureCatalog("tpch")
+	c.EnsureCatalog("memory")
+	c.EnsureCatalog("system")
+	c.EnsureCatalog("memory") // dup
+	got := c.Catalogs()
+	want := []string{"memory", "system", "tpch"}
+	if !slices.Equal(got, want) {
+		t.Errorf("Catalogs() = %v, want %v", got, want)
+	}
+}
+
+// TestEnsureCatalogIdent exercises the quote-aware AST boundary: an unquoted
+// identifier folds, a quoted one preserves case, and the two are distinct
+// catalogs.
+func TestEnsureCatalogIdent(t *testing.T) {
+	c := catalog.New()
+	c.EnsureCatalogIdent(&ast.Identifier{Value: "TPCH"})                               // -> "tpch"
+	c.EnsureCatalogIdent(&ast.Identifier{Value: "Hive", Quoted: true, QuoteRune: '"'}) // -> "Hive"
+	if !c.HasCatalog("tpch") {
+		t.Error("unquoted TPCH did not fold to tpch")
+	}
+	if !c.HasCatalog("Hive") {
+		t.Error("quoted Hive did not preserve case")
+	}
+	if c.HasCatalog("hive") {
+		t.Error("quoted Hive must not match lower-cased hive")
+	}
+	if got := c.Catalogs(); !slices.Equal(got, []string{"Hive", "tpch"}) {
+		t.Errorf("Catalogs() = %v, want [Hive tpch]", got)
+	}
+}
+
+// --- Database (catalog) -> Schema -------------------------------------------
+
+func TestSchemasSorted(t *testing.T) {
+	c := catalog.New()
+	db := c.EnsureCatalog("tpch")
+	db.EnsureSchema("sf100")
+	db.EnsureSchema("sf1")
+	db.EnsureSchema("tiny")
+	if got := db.Schemas(); !slices.Equal(got, []string{"sf1", "sf100", "tiny"}) {
+		t.Errorf("Schemas() = %v, want [sf1 sf100 tiny]", got)
+	}
+	if !db.HasSchema("sf1") {
+		t.Error("HasSchema(sf1) false")
+	}
+	if db.GetSchema("missing") != nil {
+		t.Error("GetSchema(missing) non-nil")
+	}
+}
+
+func TestEnsureSchemaIdempotent(t *testing.T) {
+	db := catalog.New().EnsureCatalog("tpch")
+	a := db.EnsureSchema("sf1")
+	b := db.EnsureSchema("sf1")
+	if a != b {
+		t.Error("EnsureSchema returned a different instance on second call")
+	}
+}
+
+// --- Schema -> Table / View / Column ----------------------------------------
+
+func TestTablesAndColumns(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("tpch").EnsureSchema("sf1")
+	sch.AddTable("nation",
+		catalog.NewColumn("nationkey", "bigint", false),
+		catalog.NewColumn("name", "varchar(25)", false),
+		catalog.NewColumn("comment", "varchar(152)", true),
+	)
+
+	if got := sch.Tables(); !slices.Equal(got, []string{"nation"}) {
+		t.Errorf("Tables() = %v, want [nation]", got)
+	}
+	if !sch.HasTable("nation") {
+		t.Error("HasTable(nation) false")
+	}
+
+	tbl := sch.GetTable("nation")
+	if tbl == nil {
+		t.Fatal("GetTable(nation) nil")
+	}
+	// Column order is ordinal (matters for SELECT *).
+	if got := tbl.ColumnNames(); !slices.Equal(got, []string{"nationkey", "name", "comment"}) {
+		t.Errorf("ColumnNames() = %v, want [nationkey name comment]", got)
+	}
+	// Columns() returns the ordinal-ordered column slice.
+	if cols := tbl.Columns(); len(cols) != 3 || cols[0].Name != "nationkey" {
+		t.Errorf("Columns() = %v, want 3 columns starting with nationkey", cols)
+	}
+	if !tbl.HasColumn("name") {
+		t.Error("HasColumn(name) false")
+	}
+	if tbl.HasColumn("missing") {
+		t.Error("HasColumn(missing) true")
+	}
+	col := tbl.GetColumn("name")
+	if col == nil {
+		t.Fatal("GetColumn(name) nil")
+	}
+	if col.Type != "varchar(25)" {
+		t.Errorf("col.Type = %q, want varchar(25)", col.Type)
+	}
+	if !tbl.GetColumn("comment").Nullable {
+		t.Error("comment column should be nullable")
+	}
+	if tbl.GetColumn("missing") != nil {
+		t.Error("GetColumn(missing) non-nil")
+	}
+	if tbl.Schema() != sch {
+		t.Error("Table.Schema() back-reference wrong")
+	}
+}
+
+// TestNilGuards exercises the defensive nil paths: a nil column passed to
+// AddTable is skipped, and EnsureCatalogIdent(nil) keys on the empty name.
+func TestNilGuards(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("c").EnsureSchema("s")
+	tbl := sch.AddTable("t", catalog.NewColumn("a", "bigint", false), nil)
+	if got := tbl.ColumnNames(); !slices.Equal(got, []string{"a"}) {
+		t.Errorf("ColumnNames() = %v, want [a] (nil column skipped)", got)
+	}
+
+	c := catalog.New()
+	db := c.EnsureCatalogIdent(nil) // normalizes to ""
+	if db == nil {
+		t.Fatal("EnsureCatalogIdent(nil) returned nil")
+	}
+	if !c.HasCatalog("") {
+		t.Error(`EnsureCatalogIdent(nil) should register the "" catalog`)
+	}
+}
+
+func TestAddTableReplaces(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("c").EnsureSchema("s")
+	sch.AddTable("t", catalog.NewColumn("a", "bigint", false))
+	sch.AddTable("t", catalog.NewColumn("b", "varchar", false)) // same name
+	if got := sch.Tables(); !slices.Equal(got, []string{"t"}) {
+		t.Errorf("Tables() = %v, want [t] (replaced not duplicated)", got)
+	}
+	tbl := sch.GetTable("t")
+	if got := tbl.ColumnNames(); !slices.Equal(got, []string{"b"}) {
+		t.Errorf("ColumnNames() = %v, want [b] (last definition wins)", got)
+	}
+}
+
+func TestViews(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("c").EnsureSchema("s")
+	sch.AddView("active_users",
+		catalog.NewColumn("id", "bigint", false),
+		catalog.NewColumn("email", "varchar", true),
+	)
+	if got := sch.Views(); !slices.Equal(got, []string{"active_users"}) {
+		t.Errorf("Views() = %v, want [active_users]", got)
+	}
+	if !sch.HasView("active_users") {
+		t.Error("HasView(active_users) false")
+	}
+	v := sch.GetView("active_users")
+	if v == nil {
+		t.Fatal("GetView(active_users) nil")
+	}
+	if got := v.ColumnNames(); !slices.Equal(got, []string{"id", "email"}) {
+		t.Errorf("view ColumnNames() = %v, want [id email]", got)
+	}
+	if cols := v.Columns(); len(cols) != 2 || cols[0].Name != "id" {
+		t.Errorf("view Columns() = %v, want 2 columns starting with id", cols)
+	}
+	if v.Schema() != sch {
+		t.Error("View.Schema() back-reference wrong")
+	}
+	// A view is not a table.
+	if sch.HasTable("active_users") {
+		t.Error("HasTable returned true for a view name")
+	}
+	if sch.GetView("missing") != nil {
+		t.Error("GetView(missing) non-nil")
+	}
+}
+
+func TestRelationsMergesAndDedups(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("c").EnsureSchema("s")
+	sch.AddTable("orders")
+	sch.AddTable("lineitem")
+	sch.AddView("orders_summary")
+	sch.AddView("orders") // shares a name with the table; Relations dedups
+	got := sch.Relations()
+	want := []string{"lineitem", "orders", "orders_summary"}
+	if !slices.Equal(got, want) {
+		t.Errorf("Relations() = %v, want %v", got, want)
+	}
+}
+
+func TestEmptyTableNoColumns(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("c").EnsureSchema("s")
+	tbl := sch.AddTable("empty")
+	if got := tbl.ColumnNames(); len(got) != 0 {
+		t.Errorf("ColumnNames() = %v, want empty", got)
+	}
+	if len(tbl.Columns()) != 0 {
+		t.Error("Columns() not empty for a no-column table")
+	}
+}
+
+// TestQuotedNameDistinctFromUnquoted proves the catalog keeps a case-sensitive
+// quoted name distinct from its lower-cased unquoted sibling — the behavior
+// blind internal lowercasing would have destroyed.
+func TestQuotedNameDistinctFromUnquoted(t *testing.T) {
+	sch := catalog.New().EnsureCatalog("c").EnsureSchema("s")
+	// Caller normalizes at the boundary: "MyTable" (unquoted) -> mytable;
+	// "\"MyTable\"" (quoted) -> MyTable.
+	sch.AddTable(catalog.Normalize("MyTable"))   // "mytable"
+	sch.AddTable(catalog.Normalize(`"MyTable"`)) // "MyTable"
+	if got := sch.Tables(); !slices.Equal(got, []string{"MyTable", "mytable"}) {
+		t.Errorf("Tables() = %v, want [MyTable mytable] (quoted distinct from unquoted)", got)
+	}
+}

--- a/trino/catalog/database.go
+++ b/trino/catalog/database.go
@@ -1,0 +1,102 @@
+package catalog
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// Database is one Trino catalog: the second level of the
+// catalog -> schema -> table/view hierarchy. It owns a set of schemas keyed
+// by normalized name.
+//
+// The Go type is named Database (rather than Catalog) to keep the package's
+// internal hierarchy distinct from the top-level Catalog container and to
+// mirror the mysql/tidb catalog packages; user-facing API uses Trino's
+// "catalog" terminology (see Catalog.GetCatalog / Catalog.EnsureCatalog).
+type Database struct {
+	// Name is the normalized catalog name.
+	Name string
+	// schemas maps a normalized schema name to its Schema.
+	schemas map[string]*Schema
+}
+
+// newDatabase creates an empty catalog with the given (already-normalized)
+// name.
+func newDatabase(name string) *Database {
+	return &Database{Name: name, schemas: make(map[string]*Schema)}
+}
+
+// EnsureSchema returns the named schema, creating and registering an empty one
+// if it does not already exist. name must already be normalized (see the
+// package doc on Normalize); pass ast.Identifier.Normalize() output or a
+// Normalize() result, not raw source text.
+func (d *Database) EnsureSchema(name string) *Schema {
+	if s, ok := d.schemas[name]; ok {
+		return s
+	}
+	s := newSchema(name)
+	d.schemas[name] = s
+	return s
+}
+
+// GetSchema returns the named schema, or nil if it is not registered. name
+// must already be normalized.
+func (d *Database) GetSchema(name string) *Schema {
+	return d.schemas[name]
+}
+
+// HasSchema reports whether the named (normalized) schema is registered.
+func (d *Database) HasSchema(name string) bool {
+	_, ok := d.schemas[name]
+	return ok
+}
+
+// Schemas returns the normalized names of all schemas in this catalog in
+// sorted order.
+func (d *Database) Schemas() []string {
+	result := make([]string, 0, len(d.schemas))
+	for name := range d.schemas {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// Normalize folds a raw Trino identifier to the canonical form used for name
+// resolution and as the key in this catalog. It mirrors the legacy bytebase
+// NormalizeTrinoIdentifier and ast.Identifier.Normalize: a double-quoted
+// identifier ("...") has its quotes stripped and its case preserved (quoted
+// identifiers are case-sensitive in Trino), while any other (unquoted)
+// identifier is folded to lower case.
+//
+// Use Normalize once, at the boundary, when you hold raw source text. Do not
+// call it on a string that is already normalized — an already-folded name like
+// "MyView" (the case-preserved result of normalizing the quoted "MyView")
+// contains no surrounding quotes, so a second Normalize would wrongly lower it.
+// Callers that have a parsed ast.Identifier should prefer the *Ident methods
+// (e.g. Catalog.EnsureCatalogIdent) or pass id.Normalize() directly, since the
+// AST node carries the quoting metadata this string helper has to re-derive
+// from literal quote characters. In particular this string form only strips
+// the outer quotes; it does not collapse an embedded doubled-quote escape
+// (`""`), because a raw metadata/identifier name is not a re-quoted source
+// token. Pass DatabaseMetadata names (which arrive unquoted) and unquoted
+// source text here; route quoted source tokens through the AST.
+//
+// The empty quoted identifier `""` normalizes to the empty string.
+func Normalize(ident string) string {
+	if len(ident) >= 2 && strings.HasPrefix(ident, `"`) && strings.HasSuffix(ident, `"`) {
+		return ident[1 : len(ident)-1]
+	}
+	return strings.ToLower(ident)
+}
+
+// normalizeIdent returns the catalog key for a parsed identifier, deferring to
+// the AST node's own quote-aware normalization. A nil identifier yields "".
+func normalizeIdent(id *ast.Identifier) string {
+	if id == nil {
+		return ""
+	}
+	return id.Normalize()
+}

--- a/trino/catalog/resolve.go
+++ b/trino/catalog/resolve.go
@@ -1,0 +1,96 @@
+package catalog
+
+import "github.com/bytebase/omni/trino/ast"
+
+// ResolvedRelation is the outcome of resolving a qualified name to a relation.
+// Exactly one of Table or View is non-nil when Found is true; both are nil
+// when Found is false. The Catalog/Schema fields record the (normalized)
+// container the name resolved against, which completion uses to offer sibling
+// candidates.
+type ResolvedRelation struct {
+	Catalog string
+	Schema  string
+	Table   *Table
+	View    *View
+	Found   bool
+}
+
+// ColumnNames returns the resolved relation's column names in order, or nil if
+// nothing was found.
+func (r ResolvedRelation) ColumnNames() []string {
+	switch {
+	case r.Table != nil:
+		return r.Table.ColumnNames()
+	case r.View != nil:
+		return r.View.ColumnNames()
+	default:
+		return nil
+	}
+}
+
+// ResolveRelation resolves a dotted name to a table or view, applying Trino's
+// name-resolution rules against the session's current catalog and schema:
+//
+//   - 1 part  [object]                  -> currentCatalog.currentSchema.object
+//   - 2 parts [schema, object]          -> currentCatalog.schema.object
+//   - 3 parts [catalog, schema, object] -> catalog.schema.object
+//
+// parts must already be normalized — pass ast.QualifiedName.NormalizedParts()
+// (or ResolveQualifiedName, which does that for you). Resolution prefers a
+// table over a view when both exist under the resolved name (the same
+// precedence as Schema.Relations). A name with zero or more than three parts,
+// or one whose required session context is unset, yields Found == false.
+func (c *Catalog) ResolveRelation(parts []string) ResolvedRelation {
+	catalogName, schemaName, objectName, ok := c.resolveContainer(parts)
+	if !ok {
+		return ResolvedRelation{}
+	}
+	db := c.GetCatalog(catalogName)
+	if db == nil {
+		return ResolvedRelation{}
+	}
+	sch := db.GetSchema(schemaName)
+	if sch == nil {
+		return ResolvedRelation{}
+	}
+	if t := sch.GetTable(objectName); t != nil {
+		return ResolvedRelation{Catalog: db.Name, Schema: sch.Name, Table: t, Found: true}
+	}
+	if v := sch.GetView(objectName); v != nil {
+		return ResolvedRelation{Catalog: db.Name, Schema: sch.Name, View: v, Found: true}
+	}
+	return ResolvedRelation{}
+}
+
+// ResolveQualifiedName resolves a parsed qualified name, normalizing each
+// component via the AST node's quote-aware rules before applying the same
+// resolution as ResolveRelation. A nil name yields Found == false.
+func (c *Catalog) ResolveQualifiedName(qn *ast.QualifiedName) ResolvedRelation {
+	if qn == nil {
+		return ResolvedRelation{}
+	}
+	return c.ResolveRelation(qn.NormalizedParts())
+}
+
+// resolveContainer maps the (normalized) dotted name parts to a fully-qualified
+// (catalog, schema, object) triple using the session context, returning
+// ok == false when the part count is unsupported or the required session
+// context is missing.
+func (c *Catalog) resolveContainer(parts []string) (catalogName, schemaName, objectName string, ok bool) {
+	switch len(parts) {
+	case 1:
+		if c.currentCatalog == "" || c.currentSchema == "" {
+			return "", "", "", false
+		}
+		return c.currentCatalog, c.currentSchema, parts[0], true
+	case 2:
+		if c.currentCatalog == "" {
+			return "", "", "", false
+		}
+		return c.currentCatalog, parts[0], parts[1], true
+	case 3:
+		return parts[0], parts[1], parts[2], true
+	default:
+		return "", "", "", false
+	}
+}

--- a/trino/catalog/resolve_test.go
+++ b/trino/catalog/resolve_test.go
@@ -1,0 +1,201 @@
+package catalog_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// buildResolveFixture creates a catalog tpch.sf1 with a "nation" table and an
+// "orders_view" view, plus a second catalog hive.default.events table, so the
+// resolution tests can exercise 1/2/3-part names and cross-catalog lookups.
+func buildResolveFixture() *catalog.Catalog {
+	c := catalog.New()
+	sf1 := c.EnsureCatalog("tpch").EnsureSchema("sf1")
+	sf1.AddTable("nation",
+		catalog.NewColumn("nationkey", "bigint", false),
+		catalog.NewColumn("name", "varchar(25)", false),
+	)
+	sf1.AddView("orders_view", catalog.NewColumn("total", "double", true))
+
+	c.EnsureCatalog("hive").EnsureSchema("default").
+		AddTable("events", catalog.NewColumn("ts", "timestamp", false))
+	return c
+}
+
+func TestResolveThreePart(t *testing.T) {
+	c := buildResolveFixture()
+	// Fully-qualified: independent of session context.
+	r := c.ResolveRelation([]string{"tpch", "sf1", "nation"})
+	if !r.Found || r.Table == nil {
+		t.Fatalf("3-part resolve of tpch.sf1.nation failed: %+v", r)
+	}
+	if r.Catalog != "tpch" || r.Schema != "sf1" || r.Table.Name != "nation" {
+		t.Errorf("resolved to %s.%s.%s, want tpch.sf1.nation", r.Catalog, r.Schema, r.Table.Name)
+	}
+	if got := r.ColumnNames(); !slices.Equal(got, []string{"nationkey", "name"}) {
+		t.Errorf("ColumnNames() = %v, want [nationkey name]", got)
+	}
+}
+
+func TestResolveThreePartCrossCatalog(t *testing.T) {
+	c := buildResolveFixture()
+	// Session points at tpch, but a 3-part name reaches hive.
+	c.SetCurrentCatalog("tpch")
+	c.SetCurrentSchema("sf1")
+	r := c.ResolveRelation([]string{"hive", "default", "events"})
+	if !r.Found || r.Table == nil || r.Catalog != "hive" {
+		t.Fatalf("3-part cross-catalog resolve failed: %+v", r)
+	}
+}
+
+func TestResolveTwoPartUsesCurrentCatalog(t *testing.T) {
+	c := buildResolveFixture()
+	c.SetCurrentCatalog("tpch")
+	r := c.ResolveRelation([]string{"sf1", "nation"})
+	if !r.Found || r.Table == nil {
+		t.Fatalf("2-part resolve of sf1.nation (current catalog tpch) failed: %+v", r)
+	}
+	if r.Catalog != "tpch" || r.Schema != "sf1" {
+		t.Errorf("resolved to %s.%s, want tpch.sf1", r.Catalog, r.Schema)
+	}
+}
+
+func TestResolveTwoPartNoCurrentCatalog(t *testing.T) {
+	c := buildResolveFixture()
+	// No current catalog set -> a 2-part name cannot resolve.
+	r := c.ResolveRelation([]string{"sf1", "nation"})
+	if r.Found {
+		t.Errorf("2-part resolve should fail with no current catalog, got %+v", r)
+	}
+	if r.ColumnNames() != nil {
+		t.Error("ColumnNames() should be nil for an unresolved relation")
+	}
+}
+
+func TestResolveOnePartUsesSession(t *testing.T) {
+	c := buildResolveFixture()
+	c.SetCurrentCatalog("tpch")
+	c.SetCurrentSchema("sf1")
+	r := c.ResolveRelation([]string{"nation"})
+	if !r.Found || r.Table == nil {
+		t.Fatalf("1-part resolve of nation (session tpch.sf1) failed: %+v", r)
+	}
+	if r.Catalog != "tpch" || r.Schema != "sf1" || r.Table.Name != "nation" {
+		t.Errorf("resolved to %s.%s.%s, want tpch.sf1.nation", r.Catalog, r.Schema, r.Table.Name)
+	}
+}
+
+func TestResolveOnePartMissingSchema(t *testing.T) {
+	c := buildResolveFixture()
+	c.SetCurrentCatalog("tpch") // schema NOT set
+	r := c.ResolveRelation([]string{"nation"})
+	if r.Found {
+		t.Errorf("1-part resolve should fail with no current schema, got %+v", r)
+	}
+}
+
+func TestResolveViaView(t *testing.T) {
+	c := buildResolveFixture()
+	c.SetCurrentCatalog("tpch")
+	c.SetCurrentSchema("sf1")
+	r := c.ResolveRelation([]string{"orders_view"})
+	if !r.Found || r.View == nil {
+		t.Fatalf("1-part resolve of a view failed: %+v", r)
+	}
+	if r.Table != nil {
+		t.Error("a view resolution must leave Table nil")
+	}
+	if got := r.ColumnNames(); !slices.Equal(got, []string{"total"}) {
+		t.Errorf("view ColumnNames() = %v, want [total]", got)
+	}
+}
+
+// TestResolveTablePreferredOverView pins the table-over-view precedence when a
+// schema holds both names (matches Schema.Relations dedup ordering).
+func TestResolveTablePreferredOverView(t *testing.T) {
+	c := catalog.New()
+	s := c.EnsureCatalog("c").EnsureSchema("s")
+	s.AddTable("dup", catalog.NewColumn("tcol", "bigint", false))
+	s.AddView("dup", catalog.NewColumn("vcol", "bigint", false))
+	c.SetCurrentCatalog("c")
+	c.SetCurrentSchema("s")
+	r := c.ResolveRelation([]string{"dup"})
+	if !r.Found || r.Table == nil || r.View != nil {
+		t.Fatalf("table should be preferred over a same-named view: %+v", r)
+	}
+}
+
+func TestResolveUnknownNames(t *testing.T) {
+	c := buildResolveFixture()
+	c.SetCurrentCatalog("tpch")
+	c.SetCurrentSchema("sf1")
+	cases := [][]string{
+		{"nope"},                      // unknown table in valid schema
+		{"missing_schema", "nation"},  // unknown schema
+		{"nope", "sf1", "nation"},     // unknown catalog
+		{"tpch", "missing", "nation"}, // unknown schema (3-part)
+		{"tpch", "sf1", "nope"},       // unknown table (3-part)
+	}
+	for _, parts := range cases {
+		if r := c.ResolveRelation(parts); r.Found {
+			t.Errorf("ResolveRelation(%v) unexpectedly found %+v", parts, r)
+		}
+	}
+}
+
+func TestResolvePartCountBounds(t *testing.T) {
+	c := buildResolveFixture()
+	c.SetCurrentCatalog("tpch")
+	c.SetCurrentSchema("sf1")
+	// Zero parts and >3 parts are unsupported.
+	if r := c.ResolveRelation(nil); r.Found {
+		t.Errorf("ResolveRelation(nil) found %+v", r)
+	}
+	if r := c.ResolveRelation([]string{}); r.Found {
+		t.Errorf("ResolveRelation([]) found %+v", r)
+	}
+	if r := c.ResolveRelation([]string{"a", "b", "c", "d"}); r.Found {
+		t.Errorf("ResolveRelation(4 parts) found %+v", r)
+	}
+}
+
+// TestResolveQualifiedNameAST drives resolution from real ast.QualifiedName
+// nodes, proving the catalog interoperates with parser output: unquoted parts
+// fold (so "TPCH"."SF1"."NATION" written unquoted resolves to tpch.sf1.nation),
+// and a quoted part is matched case-sensitively.
+func TestResolveQualifiedNameAST(t *testing.T) {
+	c := buildResolveFixture()
+
+	// Unquoted, mixed-case 3-part name -> folds and resolves.
+	qn := &ast.QualifiedName{Parts: []*ast.Identifier{
+		{Value: "TPCH"}, {Value: "Sf1"}, {Value: "Nation"},
+	}}
+	if r := c.ResolveQualifiedName(qn); !r.Found || r.Table == nil {
+		t.Fatalf("ResolveQualifiedName(unquoted mixed case) failed: %+v", r)
+	}
+
+	// 1-part unquoted name with session context.
+	c.SetCurrentCatalog("tpch")
+	c.SetCurrentSchema("sf1")
+	one := &ast.QualifiedName{Parts: []*ast.Identifier{{Value: "NATION"}}}
+	if r := c.ResolveQualifiedName(one); !r.Found || r.Table == nil {
+		t.Fatalf("ResolveQualifiedName(1-part) failed: %+v", r)
+	}
+
+	// A quoted, case-mismatched component must NOT resolve to the lower-cased
+	// stored object (quoted identifiers are case-sensitive).
+	quoted := &ast.QualifiedName{Parts: []*ast.Identifier{
+		{Value: "TPCH"}, {Value: "SF1", Quoted: true, QuoteRune: '"'}, {Value: "nation"},
+	}}
+	if r := c.ResolveQualifiedName(quoted); r.Found {
+		t.Errorf("quoted SF1 should not match stored sf1, got %+v", r)
+	}
+
+	// Nil qualified name.
+	if r := c.ResolveQualifiedName(nil); r.Found {
+		t.Errorf("ResolveQualifiedName(nil) found %+v", r)
+	}
+}

--- a/trino/catalog/review_test.go
+++ b/trino/catalog/review_test.go
@@ -1,0 +1,74 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAddTableDuplicateColumnReplaced pins addColumn's replace-in-place
+// behavior: a duplicate (already-normalized) column name must update the
+// existing column rather than append a phantom second entry, so the ordinal
+// column list never contains duplicates.
+func TestAddTableDuplicateColumnReplaced(t *testing.T) {
+	s := newSchema("s")
+	tbl := s.AddTable("t",
+		NewColumn("a", "bigint", false),
+		NewColumn("b", "varchar", true),
+		NewColumn("a", "double", true), // duplicate of "a"
+	)
+
+	if got, want := tbl.ColumnNames(), []string{"a", "b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ColumnNames() = %v, want %v (no duplicate, position preserved)", got, want)
+	}
+	if got := len(tbl.Columns()); got != 2 {
+		t.Errorf("len(Columns()) = %d, want 2", got)
+	}
+	// Last definition wins for the column's metadata.
+	if col := tbl.GetColumn("a"); col == nil || col.Type != "double" || !col.Nullable {
+		t.Errorf("GetColumn(\"a\") = %+v, want last definition {double, nullable}", col)
+	}
+}
+
+// TestAddViewNilColumnsFiltered ensures AddView drops nil column arguments (as
+// AddTable does via addColumn), so ColumnNames never dereferences a nil column.
+func TestAddViewNilColumnsFiltered(t *testing.T) {
+	s := newSchema("s")
+	v := s.AddView("v", nil, NewColumn("x", "integer", false), nil)
+
+	if got, want := v.ColumnNames(), []string{"x"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ColumnNames() = %v, want %v (nils filtered)", got, want)
+	}
+	// Must not panic on an all-nil view either.
+	empty := s.AddView("empty", nil, nil)
+	if got := empty.ColumnNames(); len(got) != 0 {
+		t.Errorf("ColumnNames() = %v, want empty", got)
+	}
+}
+
+// TestAddViewReplaces pins last-definition-wins for AddView, mirroring the
+// documented AddTable replacement semantics.
+func TestAddViewReplaces(t *testing.T) {
+	s := newSchema("s")
+	s.AddView("v", NewColumn("old", "integer", false))
+	v := s.AddView("v", NewColumn("new1", "varchar", true), NewColumn("new2", "bigint", false))
+
+	if got, want := v.ColumnNames(), []string{"new1", "new2"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ColumnNames() = %v, want %v (last definition wins)", got, want)
+	}
+	if got := s.GetView("v"); got == nil || !reflect.DeepEqual(got.ColumnNames(), []string{"new1", "new2"}) {
+		t.Errorf("GetView(\"v\") did not reflect the replacement: %+v", got)
+	}
+}
+
+// TestResolveOnePartMissingCatalog covers the 1-part resolution branch when the
+// current schema is set but the current catalog is not — it must fail closed
+// (Found == false) rather than resolve against an empty catalog key.
+func TestResolveOnePartMissingCatalog(t *testing.T) {
+	c := New()
+	c.EnsureCatalog("tpch").EnsureSchema("sf1").AddTable("nation", NewColumn("n", "bigint", false))
+	c.SetCurrentSchema("sf1") // current catalog deliberately left unset
+
+	if r := c.ResolveRelation([]string{"nation"}); r.Found {
+		t.Errorf("ResolveRelation([nation]) with no current catalog = %+v, want Found=false", r)
+	}
+}

--- a/trino/catalog/schema.go
+++ b/trino/catalog/schema.go
@@ -1,0 +1,119 @@
+package catalog
+
+import "sort"
+
+// Schema is one Trino schema: the third level of the
+// catalog -> schema -> table/view hierarchy. A schema owns tables and views,
+// each keyed by normalized name. Trino keeps tables and views in the same
+// name space (you cannot have a table and a view with the same name in one
+// schema); this catalog stores them in separate maps for direct lookup, and
+// Relations() merges them into the single de-duplicated relation candidate set
+// completion offers after FROM / JOIN.
+//
+// All name arguments must already be normalized (see the package doc on
+// Normalize).
+type Schema struct {
+	// Name is the normalized schema name.
+	Name string
+	// tables maps a normalized table name to its Table.
+	tables map[string]*Table
+	// views maps a normalized view name to its View.
+	views map[string]*View
+}
+
+// newSchema creates an empty schema with the given (already-normalized) name.
+func newSchema(name string) *Schema {
+	return &Schema{
+		Name:   name,
+		tables: make(map[string]*Table),
+		views:  make(map[string]*View),
+	}
+}
+
+// AddTable registers a table with the given (normalized) name and columns,
+// returning the created Table. If a table with the same name already exists it
+// is replaced (last definition wins, matching how a fresh metadata snapshot is
+// loaded).
+func (s *Schema) AddTable(name string, columns ...*Column) *Table {
+	t := &Table{Name: name, schema: s, colByName: make(map[string]int)}
+	for _, col := range columns {
+		t.addColumn(col)
+	}
+	s.tables[name] = t
+	return t
+}
+
+// GetTable returns the named (normalized) table, or nil if it is not
+// registered.
+func (s *Schema) GetTable(name string) *Table {
+	return s.tables[name]
+}
+
+// HasTable reports whether the named (normalized) table is registered.
+func (s *Schema) HasTable(name string) bool {
+	_, ok := s.tables[name]
+	return ok
+}
+
+// Tables returns the normalized names of all tables in this schema in sorted
+// order.
+func (s *Schema) Tables() []string {
+	result := make([]string, 0, len(s.tables))
+	for name := range s.tables {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// AddView registers a view with the given (normalized) name and columns,
+// returning the created View. If a view with the same name already exists it
+// is replaced.
+func (s *Schema) AddView(name string, columns ...*Column) *View {
+	v := &View{Name: name, schema: s}
+	v.columns = append(v.columns, columns...)
+	s.views[name] = v
+	return v
+}
+
+// GetView returns the named (normalized) view, or nil if it is not registered.
+func (s *Schema) GetView(name string) *View {
+	return s.views[name]
+}
+
+// HasView reports whether the named (normalized) view is registered.
+func (s *Schema) HasView(name string) bool {
+	_, ok := s.views[name]
+	return ok
+}
+
+// Views returns the normalized names of all views in this schema in sorted
+// order.
+func (s *Schema) Views() []string {
+	result := make([]string, 0, len(s.views))
+	for name := range s.views {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// Relations returns the normalized names of all tables and views in this
+// schema in sorted order, de-duplicated (a name present as both a table and a
+// view appears once). This is the set of relation candidates completion offers
+// after FROM / JOIN.
+func (s *Schema) Relations() []string {
+	seen := make(map[string]struct{}, len(s.tables)+len(s.views))
+	for name := range s.tables {
+		seen[name] = struct{}{}
+	}
+	for name := range s.views {
+		seen[name] = struct{}{}
+	}
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/trino/catalog/schema.go
+++ b/trino/catalog/schema.go
@@ -71,7 +71,11 @@ func (s *Schema) Tables() []string {
 // is replaced.
 func (s *Schema) AddView(name string, columns ...*Column) *View {
 	v := &View{Name: name, schema: s}
-	v.columns = append(v.columns, columns...)
+	for _, col := range columns {
+		if col != nil {
+			v.columns = append(v.columns, col)
+		}
+	}
 	s.views[name] = v
 	return v
 }

--- a/trino/catalog/table.go
+++ b/trino/catalog/table.go
@@ -24,11 +24,15 @@ type Table struct {
 func (t *Table) Schema() *Schema { return t.schema }
 
 // addColumn appends a column, recording its index by its (already-normalized)
-// name. A duplicate name keeps the first column's position but updates the
-// index to point at the latest definition; callers loading a metadata snapshot
-// should not supply duplicates.
+// name. A duplicate name replaces the existing column in place (last definition
+// wins) so the ordinal column list never contains duplicates; callers loading a
+// metadata snapshot should not supply duplicates.
 func (t *Table) addColumn(col *Column) {
 	if col == nil {
+		return
+	}
+	if idx, ok := t.colByName[col.Name]; ok {
+		t.columns[idx] = col
 		return
 	}
 	t.colByName[col.Name] = len(t.columns)

--- a/trino/catalog/table.go
+++ b/trino/catalog/table.go
@@ -1,0 +1,114 @@
+package catalog
+
+// Table is a Trino table: the leaf of the
+// catalog -> schema -> table -> column hierarchy. It holds an ordered column
+// list (ordinal position matters for SELECT * expansion and positional
+// references) plus a normalized-name index for O(1) lookup.
+//
+// All name arguments must already be normalized (see the package doc on
+// Normalize).
+type Table struct {
+	// Name is the normalized table name.
+	Name string
+	// schema back-references the owning schema (nil only for a detached
+	// table constructed directly in a test).
+	schema *Schema
+	// columns are the table's columns in definition (ordinal) order.
+	columns []*Column
+	// colByName maps a normalized column name to its index in columns.
+	colByName map[string]int
+}
+
+// Schema returns the schema that owns this table, or nil if the table was
+// constructed detached.
+func (t *Table) Schema() *Schema { return t.schema }
+
+// addColumn appends a column, recording its index by its (already-normalized)
+// name. A duplicate name keeps the first column's position but updates the
+// index to point at the latest definition; callers loading a metadata snapshot
+// should not supply duplicates.
+func (t *Table) addColumn(col *Column) {
+	if col == nil {
+		return
+	}
+	t.colByName[col.Name] = len(t.columns)
+	t.columns = append(t.columns, col)
+}
+
+// Columns returns the table's columns in ordinal order. The returned slice
+// shares backing storage with the table; callers must not mutate it.
+func (t *Table) Columns() []*Column { return t.columns }
+
+// GetColumn returns the named (normalized) column, or nil if the table has no
+// such column.
+func (t *Table) GetColumn(name string) *Column {
+	idx, ok := t.colByName[name]
+	if !ok {
+		return nil
+	}
+	return t.columns[idx]
+}
+
+// HasColumn reports whether the table has a column with the given (normalized)
+// name.
+func (t *Table) HasColumn(name string) bool {
+	_, ok := t.colByName[name]
+	return ok
+}
+
+// ColumnNames returns the table's column names in ordinal order (the order
+// completion offers them and SELECT * expands them). Names are normalized.
+func (t *Table) ColumnNames() []string {
+	result := make([]string, len(t.columns))
+	for i, col := range t.columns {
+		result[i] = col.Name
+	}
+	return result
+}
+
+// View is a Trino view (including materialized views). For completion and
+// lineage purposes a view exposes a column list just like a table; this
+// catalog does not retain the view's defining query.
+type View struct {
+	// Name is the normalized view name.
+	Name string
+	// schema back-references the owning schema.
+	schema *Schema
+	// columns are the view's output columns in order.
+	columns []*Column
+}
+
+// Schema returns the schema that owns this view, or nil if detached.
+func (v *View) Schema() *Schema { return v.schema }
+
+// Columns returns the view's output columns in order. The returned slice
+// shares backing storage; callers must not mutate it.
+func (v *View) Columns() []*Column { return v.columns }
+
+// ColumnNames returns the view's output column names in order (normalized).
+func (v *View) ColumnNames() []string {
+	result := make([]string, len(v.columns))
+	for i, col := range v.columns {
+		result[i] = col.Name
+	}
+	return result
+}
+
+// Column is a single table or view column. It carries the metadata completion
+// and lineage need: a normalized name, the Trino type text, and nullability.
+type Column struct {
+	// Name is the normalized column name.
+	Name string
+	// Type is the column's Trino type rendered as text (e.g. "varchar(10)",
+	// "bigint", "array(integer)"). It is informational for completion and
+	// not parsed here.
+	Type string
+	// Nullable reports whether the column accepts NULL.
+	Nullable bool
+}
+
+// NewColumn constructs a Column. name must already be normalized (see the
+// package doc on Normalize); it is used verbatim as the column's lookup key.
+func NewColumn(name, typ string, nullable bool) *Column {
+	return &Column{Name: name, Type: typ, Nullable: nullable}
+}


### PR DESCRIPTION
DAG node **trino/catalog** (layer 1). Hand-written catalog metadata model that `trino/completion` and `trino/analysis` (query span) build on.

## Contents
- `catalog.go` / `database.go` / `schema.go` / `table.go` — `Catalog → Database → Schema → Table → Column` hierarchy with Trino identifier normalization (unquoted → lowercase, quoted → preserved).
- `resolve.go` — qualified-name resolution (`catalog.schema.table` / `schema.table` / `table`) against a default namespace.
- `catalog_test.go` / `resolve_test.go` — unit tests; `go build` + `go test ./trino/catalog/` green, `vet`/`gofmt` clean.

## Provenance
Salvaged from the wave-2 worker that completed a building, passing implementation but was terminated before opening its PR. Rebased onto current `main` (post `ast-core` #173, `lexer` #175) and put through a code review before merge.

No oracle dependency (pure metadata model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)