### PR TITLE
feat(snowflake): T6.1 GRANT / REVOKE statements

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -79,6 +79,12 @@ const (
 
 	// ALTER TABLE tag (T2.3)
 	T_AlterTableStmt
+
+	// DCL: GRANT / REVOKE tags (T6.1)
+	T_GrantStmt
+	T_RevokeStmt
+	T_Grantee
+	T_GrantTarget
 )
 
 // String returns a human-readable representation of the tag.
@@ -188,6 +194,14 @@ func (t NodeTag) String() string {
 		return "AlterMaterializedViewStmt"
 	case T_AlterTableStmt:
 		return "AlterTableStmt"
+	case T_GrantStmt:
+		return "GrantStmt"
+	case T_RevokeStmt:
+		return "RevokeStmt"
+	case T_Grantee:
+		return "Grantee"
+	case T_GrantTarget:
+		return "GrantTarget"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1738,3 +1738,319 @@ func (n *AlterTableStmt) Tag() NodeTag { return T_AlterTableStmt }
 
 // Compile-time assertion.
 var _ Node = (*AlterTableStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// DCL — GRANT / REVOKE (roles, privileges, ownership, shares) [T6.1]
+// ---------------------------------------------------------------------------
+//
+// Snowflake's GRANT/REVOKE surface is large and grows continuously: new
+// privileges (e.g. CREATE PROVISIONED THROUGHPUT, CREATE SNOWFLAKE.CORE.BUDGET)
+// and new object types (e.g. NOTEBOOK, WORKSPACE, COMPUTE POOL, SEMANTIC VIEW)
+// are added over time. Rather than hard-coding the legacy ANTLR grammar's
+// finite privilege/object enumerations — which the official documentation
+// corpus already exceeds — these nodes model privileges and object types as
+// open-ended token runs (free-form uppercased names). This keeps the parser
+// faithful to the docs (truth1) and resilient to Snowflake's additions; the
+// catalog/semantic layer, not the parser, is responsible for validating that
+// a given privilege is legal for a given object.
+
+// GrantKind discriminates the three structural shapes of a GRANT statement.
+type GrantKind int
+
+const (
+	// GrantPrivileges is GRANT <privileges> ON <target> TO <grantee>.
+	GrantPrivileges GrantKind = iota
+	// GrantRole is GRANT [DATABASE | APPLICATION] ROLE <name> TO <grantee>.
+	GrantRole
+	// GrantOwnership is GRANT OWNERSHIP ON <target> TO <grantee> [...CURRENT GRANTS].
+	GrantOwnership
+)
+
+// GrantedRoleKind discriminates the kind of role being granted/revoked in a
+// role-grant statement (the noun after GRANT/REVOKE).
+type GrantedRoleKind int
+
+const (
+	// GrantedAccountRole is GRANT ROLE <name> ... (account-level role).
+	GrantedAccountRole GrantedRoleKind = iota
+	// GrantedDatabaseRole is GRANT DATABASE ROLE <name> ...
+	GrantedDatabaseRole
+	// GrantedApplicationRole is GRANT APPLICATION ROLE <name> ...
+	GrantedApplicationRole
+)
+
+// String returns a human-readable name for the kind.
+func (k GrantedRoleKind) String() string {
+	switch k {
+	case GrantedAccountRole:
+		return "Role"
+	case GrantedDatabaseRole:
+		return "DatabaseRole"
+	case GrantedApplicationRole:
+		return "ApplicationRole"
+	default:
+		return "Unknown"
+	}
+}
+
+// String returns a human-readable name for the kind.
+func (k GrantKind) String() string {
+	switch k {
+	case GrantPrivileges:
+		return "Privileges"
+	case GrantRole:
+		return "Role"
+	case GrantOwnership:
+		return "Ownership"
+	default:
+		return "Unknown"
+	}
+}
+
+// RevokeKind discriminates the two structural shapes of a REVOKE statement.
+// (There is no REVOKE OWNERSHIP — ownership is transferred, never revoked.)
+type RevokeKind int
+
+const (
+	// RevokePrivileges is REVOKE [GRANT OPTION FOR] <privileges> ON <target> FROM <grantee>.
+	RevokePrivileges RevokeKind = iota
+	// RevokeRole is REVOKE [DATABASE] ROLE <name> FROM <grantee>.
+	RevokeRole
+)
+
+// String returns a human-readable name for the kind.
+func (k RevokeKind) String() string {
+	switch k {
+	case RevokePrivileges:
+		return "Privileges"
+	case RevokeRole:
+		return "Role"
+	default:
+		return "Unknown"
+	}
+}
+
+// Privilege is a single privilege in a GRANT/REVOKE privilege list. Name holds
+// the uppercased source text of the privilege, which may be multiple words
+// (e.g. "SELECT", "CREATE MATERIALIZED VIEW", "CREATE PROVISIONED THROUGHPUT",
+// "READ", "CREATE SNOWFLAKE.CORE.BUDGET").
+//
+// Privilege is NOT a Node; it is owned by GrantStmt / RevokeStmt.
+type Privilege struct {
+	Name string
+	Loc  Loc
+}
+
+// GranteeKind discriminates the recipient type following TO/FROM in a GRANT or
+// REVOKE statement.
+type GranteeKind int
+
+const (
+	GranteeRole            GranteeKind = iota // [TO|FROM] [ROLE] <name>
+	GranteeDatabaseRole                       // [TO|FROM] DATABASE ROLE <name>
+	GranteeUser                               // [TO|FROM] USER <name>
+	GranteeShare                              // [TO|FROM] SHARE <name>
+	GranteeApplication                        // TO APPLICATION <name>
+	GranteeApplicationRole                    // TO APPLICATION ROLE <name>
+)
+
+// String returns the SQL keyword(s) for the grantee kind.
+func (k GranteeKind) String() string {
+	switch k {
+	case GranteeRole:
+		return "ROLE"
+	case GranteeDatabaseRole:
+		return "DATABASE ROLE"
+	case GranteeUser:
+		return "USER"
+	case GranteeShare:
+		return "SHARE"
+	case GranteeApplication:
+		return "APPLICATION"
+	case GranteeApplicationRole:
+		return "APPLICATION ROLE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Grantee is the recipient of a GRANT (after TO) or the subject of a REVOKE
+// (after FROM). Name is the (possibly qualified) role/user/share name.
+//
+// Grantee is a Node so the walker visits its Name. (Name is itself an
+// *ObjectName Node.)
+type Grantee struct {
+	Kind GranteeKind
+	Name *ObjectName
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *Grantee) Tag() NodeTag { return T_Grantee }
+
+// GrantTargetKind discriminates the shape of the ON clause in a privilege or
+// ownership GRANT/REVOKE.
+type GrantTargetKind int
+
+const (
+	// GrantTargetAccount is ON ACCOUNT.
+	GrantTargetAccount GrantTargetKind = iota
+	// GrantTargetObject is ON <object_type> <name> [ ( signature ) ].
+	GrantTargetObject
+	// GrantTargetAllIn is ON ALL <object_type_plural> IN { DATABASE <db> | SCHEMA <schema> }.
+	GrantTargetAllIn
+	// GrantTargetFutureIn is ON FUTURE <object_type_plural> IN { DATABASE <db> | SCHEMA <schema> }.
+	GrantTargetFutureIn
+)
+
+// String returns a human-readable name for the kind.
+func (k GrantTargetKind) String() string {
+	switch k {
+	case GrantTargetAccount:
+		return "Account"
+	case GrantTargetObject:
+		return "Object"
+	case GrantTargetAllIn:
+		return "AllIn"
+	case GrantTargetFutureIn:
+		return "FutureIn"
+	default:
+		return "Unknown"
+	}
+}
+
+// GrantContainerKind discriminates the IN container of ALL/FUTURE ... IN forms.
+type GrantContainerKind int
+
+const (
+	GrantContainerNone     GrantContainerKind = iota // not an ALL/FUTURE form
+	GrantContainerDatabase                           // IN DATABASE <db>
+	GrantContainerSchema                             // IN SCHEMA <schema>
+)
+
+// GrantTarget is the object the privileges/ownership apply to (the ON clause).
+//
+// Field population by Kind:
+//   - GrantTargetAccount:  no other fields set.
+//   - GrantTargetObject:   ObjectType + Name (+ optional Signature).
+//   - GrantTargetAllIn / GrantTargetFutureIn: ObjectTypePlural + Container + ContainerName.
+//
+// ObjectType / ObjectTypePlural are uppercased free-form names (possibly
+// multi-word, e.g. "MATERIALIZED VIEW", "EXTERNAL TABLE", "CORTEX SEARCH
+// SERVICE", "STORAGE LIFECYCLE POLICY").
+//
+// GrantTarget is a Node so the walker visits Name and ContainerName. The
+// Signature TypeName slice is not walker-visited (mirroring how
+// CreateTableStmt.Columns is handled).
+type GrantTarget struct {
+	Kind GrantTargetKind
+
+	// GrantTargetObject:
+	ObjectType string      // e.g. "TABLE", "FUNCTION", "MATERIALIZED VIEW", "NOTEBOOK", "CORTEX SEARCH SERVICE"
+	Name       *ObjectName // the object's qualified name
+	Signature  []*TypeName // FUNCTION/PROCEDURE arg-type list; nil if no ( ... ) present, non-nil (maybe empty) if ()
+
+	// GrantTargetAllIn / GrantTargetFutureIn:
+	ObjectTypePlural string             // e.g. "TABLES", "VIEWS", "SCHEMAS"
+	Container        GrantContainerKind // DATABASE or SCHEMA
+	ContainerName    *ObjectName        // the database/schema name
+
+	Loc Loc
+}
+
+// Tag implements Node.
+func (n *GrantTarget) Tag() NodeTag { return T_GrantTarget }
+
+// CurrentGrantsAction is the trailing { REVOKE | COPY } CURRENT GRANTS option
+// on GRANT OWNERSHIP.
+type CurrentGrantsAction int
+
+const (
+	CurrentGrantsNone   CurrentGrantsAction = iota // no trailing clause
+	CurrentGrantsRevoke                            // REVOKE CURRENT GRANTS
+	CurrentGrantsCopy                              // COPY CURRENT GRANTS
+)
+
+// String returns a human-readable name for the action.
+func (a CurrentGrantsAction) String() string {
+	switch a {
+	case CurrentGrantsNone:
+		return "None"
+	case CurrentGrantsRevoke:
+		return "RevokeCurrentGrants"
+	case CurrentGrantsCopy:
+		return "CopyCurrentGrants"
+	default:
+		return "Unknown"
+	}
+}
+
+// GrantStmt represents a GRANT statement in any of its three shapes
+// (privileges, role, ownership). See GrantKind.
+//
+//	GRANT { <privileges> | ALL [PRIVILEGES] } ON <target> TO <grantee> [WITH GRANT OPTION]
+//	GRANT [DATABASE | APPLICATION] ROLE <name> TO <grantee>
+//	GRANT OWNERSHIP ON <target> TO <grantee> [{REVOKE|COPY} CURRENT GRANTS]
+type GrantStmt struct {
+	Kind GrantKind
+
+	// --- GrantPrivileges ---
+	Privileges    []*Privilege // explicit privilege list; nil when AllPrivileges is true
+	AllPrivileges bool         // ALL [PRIVILEGES]
+	GrantOption   bool         // WITH GRANT OPTION
+
+	// --- GrantRole ---
+	Role     *ObjectName     // the role being granted (GrantRole)
+	RoleKind GrantedRoleKind // account / database / application role
+
+	// --- GrantOwnership ---
+	CurrentGrants CurrentGrantsAction // trailing CURRENT GRANTS option
+
+	// --- GrantPrivileges + GrantOwnership ---
+	On *GrantTarget // the ON clause target; nil for GrantRole
+
+	// --- all kinds ---
+	Grantee *Grantee // the TO recipient
+
+	Loc Loc
+}
+
+// Tag implements Node.
+func (n *GrantStmt) Tag() NodeTag { return T_GrantStmt }
+
+// RevokeStmt represents a REVOKE statement in either of its shapes
+// (privileges, role). See RevokeKind.
+//
+//	REVOKE [GRANT OPTION FOR] { <privileges> | ALL [PRIVILEGES] } ON <target> FROM <grantee> [CASCADE|RESTRICT]
+//	REVOKE [DATABASE | APPLICATION] ROLE <name> FROM <grantee>
+type RevokeStmt struct {
+	Kind RevokeKind
+
+	// --- RevokePrivileges ---
+	GrantOptionFor bool         // REVOKE GRANT OPTION FOR ...
+	Privileges     []*Privilege // explicit privilege list; nil when AllPrivileges is true
+	AllPrivileges  bool         // ALL [PRIVILEGES]
+	On             *GrantTarget // the ON clause target; nil for RevokeRole
+	Cascade        bool         // trailing CASCADE
+	Restrict       bool         // trailing RESTRICT
+
+	// --- RevokeRole ---
+	Role     *ObjectName     // the role being revoked (RevokeRole)
+	RoleKind GrantedRoleKind // account / database / application role
+
+	// --- all kinds ---
+	Grantee *Grantee // the FROM subject
+
+	Loc Loc
+}
+
+// Tag implements Node.
+func (n *RevokeStmt) Tag() NodeTag { return T_RevokeStmt }
+
+// Compile-time assertions for DCL nodes.
+var (
+	_ Node = (*GrantStmt)(nil)
+	_ Node = (*RevokeStmt)(nil)
+	_ Node = (*Grantee)(nil)
+	_ Node = (*GrantTarget)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -128,6 +128,27 @@ func walkChildren(v Visitor, node Node) {
 		walkNodes(v, n.Stmts)
 	case *FuncCallExpr:
 		walkNodes(v, n.Args)
+	case *GrantStmt:
+		if n.Role != nil {
+			Walk(v, n.Role)
+		}
+		if n.On != nil {
+			Walk(v, n.On)
+		}
+		if n.Grantee != nil {
+			Walk(v, n.Grantee)
+		}
+	case *GrantTarget:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.ContainerName != nil {
+			Walk(v, n.ContainerName)
+		}
+	case *Grantee:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *IffExpr:
 		Walk(v, n.Cond)
 		Walk(v, n.Then)
@@ -165,6 +186,16 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.On)
 	case *ParenExpr:
 		Walk(v, n.Expr)
+	case *RevokeStmt:
+		if n.On != nil {
+			Walk(v, n.On)
+		}
+		if n.Role != nil {
+			Walk(v, n.Role)
+		}
+		if n.Grantee != nil {
+			Walk(v, n.Grantee)
+		}
 	case *SelectStmt:
 		Walk(v, n.Top)
 		walkNodes(v, n.From)

--- a/snowflake/parser/grant_revoke.go
+++ b/snowflake/parser/grant_revoke.go
@@ -1,0 +1,731 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// DCL — GRANT / REVOKE (roles, privileges, ownership, shares) [T6.1]
+// ---------------------------------------------------------------------------
+//
+// Snowflake's GRANT/REVOKE grammar is large and continuously extended with new
+// privileges and object types. Rather than mirror the legacy ANTLR grammar's
+// finite privilege/object enumerations — which the official documentation
+// corpus already exceeds (e.g. ON NOTEBOOK, ON WORKSPACE, CREATE PROVISIONED
+// THROUGHPUT, CREATE SNOWFLAKE.CORE.BUDGET) — these parse functions treat
+// privileges and object types as free-form token runs. Structural keywords
+// (ON, TO, FROM, IN, ALL, FUTURE, WITH GRANT OPTION, CURRENT GRANTS,
+// CASCADE/RESTRICT, GRANT OPTION FOR) anchor the grammar; the spans between
+// them are captured verbatim. Validating that a privilege is legal for an
+// object is the catalog/semantic layer's job, not the parser's.
+
+// ---------------------------------------------------------------------------
+// GRANT dispatch
+// ---------------------------------------------------------------------------
+
+// parseGrantStmt parses a GRANT statement in any of its shapes:
+//
+//	GRANT { <privileges> | ALL [PRIVILEGES] } ON <target> TO <grantee> [WITH GRANT OPTION]
+//	GRANT [DATABASE] ROLE <name> TO <grantee>
+//	GRANT OWNERSHIP ON <target> TO <grantee> [{REVOKE|COPY} CURRENT GRANTS]
+//
+// The GRANT keyword has NOT yet been consumed when this function is called.
+func (p *Parser) parseGrantStmt() (ast.Node, error) {
+	grantTok := p.advance() // consume GRANT
+	start := grantTok.Loc
+
+	switch {
+	case p.cur.Type == kwOWNERSHIP:
+		return p.parseGrantOwnership(start)
+	case p.cur.Type == kwROLE:
+		return p.parseGrantRole(start, ast.GrantedAccountRole)
+	case p.cur.Type == kwDATABASE && p.peekNext().Type == kwROLE:
+		return p.parseGrantRole(start, ast.GrantedDatabaseRole)
+	case p.cur.Type == kwAPPLICATION && p.peekNext().Type == kwROLE:
+		return p.parseGrantRole(start, ast.GrantedApplicationRole)
+	default:
+		return p.parseGrantPrivileges(start)
+	}
+}
+
+// parseGrantRole parses GRANT [DATABASE | APPLICATION] ROLE <name> TO <grantee>.
+// start is the Loc of the GRANT token. roleKind selects the granted-role flavor;
+// on entry cur is ROLE (account) or the DATABASE/APPLICATION qualifier.
+func (p *Parser) parseGrantRole(start ast.Loc, roleKind ast.GrantedRoleKind) (ast.Node, error) {
+	if roleKind != ast.GrantedAccountRole {
+		p.advance() // consume DATABASE / APPLICATION qualifier
+	}
+	if _, err := p.expect(kwROLE); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.GrantStmt{
+		Kind:     ast.GrantRole,
+		RoleKind: roleKind,
+		Loc:      ast.Loc{Start: start.Start},
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Role = name
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parseGrantee()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseGrantOwnership parses GRANT OWNERSHIP ON <target> TO <grantee>
+// [{REVOKE|COPY} CURRENT GRANTS]. On entry cur is OWNERSHIP.
+func (p *Parser) parseGrantOwnership(start ast.Loc) (ast.Node, error) {
+	p.advance() // consume OWNERSHIP
+
+	stmt := &ast.GrantStmt{
+		Kind: ast.GrantOwnership,
+		Loc:  ast.Loc{Start: start.Start},
+	}
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	target, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = target
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parseGrantee()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	// Optional { REVOKE | COPY } CURRENT GRANTS.
+	switch p.cur.Type {
+	case kwREVOKE:
+		if p.peekNext().Type == kwCURRENT {
+			p.advance() // consume REVOKE
+			if err := p.expectCurrentGrants(); err != nil {
+				return nil, err
+			}
+			stmt.CurrentGrants = ast.CurrentGrantsRevoke
+		}
+	case kwCOPY:
+		if p.peekNext().Type == kwCURRENT {
+			p.advance() // consume COPY
+			if err := p.expectCurrentGrants(); err != nil {
+				return nil, err
+			}
+			stmt.CurrentGrants = ast.CurrentGrantsCopy
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseGrantPrivileges parses
+// GRANT { <privileges> | ALL [PRIVILEGES] } ON <target> TO <grantee>
+// [WITH GRANT OPTION]. On entry cur is the first privilege token (or ALL).
+func (p *Parser) parseGrantPrivileges(start ast.Loc) (ast.Node, error) {
+	stmt := &ast.GrantStmt{
+		Kind: ast.GrantPrivileges,
+		Loc:  ast.Loc{Start: start.Start},
+	}
+
+	all, privs, err := p.parsePrivilegeList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.AllPrivileges = all
+	stmt.Privileges = privs
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	target, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = target
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parseGrantee()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	// Optional WITH GRANT OPTION.
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwGRANT {
+		p.advance() // consume WITH
+		p.advance() // consume GRANT
+		if _, err := p.expect(kwOPTION); err != nil {
+			return nil, err
+		}
+		stmt.GrantOption = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// REVOKE dispatch
+// ---------------------------------------------------------------------------
+
+// parseRevokeStmt parses a REVOKE statement in either of its shapes:
+//
+//	REVOKE [GRANT OPTION FOR] { <privileges> | ALL [PRIVILEGES] } ON <target> FROM <grantee> [CASCADE|RESTRICT]
+//	REVOKE [DATABASE] ROLE <name> FROM <grantee>
+//
+// The REVOKE keyword has NOT yet been consumed when this function is called.
+func (p *Parser) parseRevokeStmt() (ast.Node, error) {
+	revokeTok := p.advance() // consume REVOKE
+	start := revokeTok.Loc
+
+	// REVOKE [DATABASE | APPLICATION] ROLE ... — GRANT OPTION FOR applies only
+	// to privilege revocation, so a leading ROLE/DATABASE ROLE/APPLICATION ROLE
+	// is unambiguously a role revoke.
+	if p.cur.Type == kwROLE {
+		return p.parseRevokeRole(start, ast.GrantedAccountRole)
+	}
+	if p.cur.Type == kwDATABASE && p.peekNext().Type == kwROLE {
+		return p.parseRevokeRole(start, ast.GrantedDatabaseRole)
+	}
+	if p.cur.Type == kwAPPLICATION && p.peekNext().Type == kwROLE {
+		return p.parseRevokeRole(start, ast.GrantedApplicationRole)
+	}
+	return p.parseRevokePrivileges(start)
+}
+
+// parseRevokeRole parses REVOKE [DATABASE | APPLICATION] ROLE <name> FROM <grantee>.
+// On entry cur is ROLE (account) or the DATABASE/APPLICATION qualifier.
+func (p *Parser) parseRevokeRole(start ast.Loc, roleKind ast.GrantedRoleKind) (ast.Node, error) {
+	if roleKind != ast.GrantedAccountRole {
+		p.advance() // consume DATABASE / APPLICATION qualifier
+	}
+	if _, err := p.expect(kwROLE); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.RevokeStmt{
+		Kind:     ast.RevokeRole,
+		RoleKind: roleKind,
+		Loc:      ast.Loc{Start: start.Start},
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Role = name
+
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parseGrantee()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRevokePrivileges parses
+// REVOKE [GRANT OPTION FOR] { <privileges> | ALL [PRIVILEGES] } ON <target>
+// FROM <grantee> [CASCADE|RESTRICT]. On entry cur is GRANT (for GRANT OPTION
+// FOR) or the first privilege token (or ALL).
+func (p *Parser) parseRevokePrivileges(start ast.Loc) (ast.Node, error) {
+	stmt := &ast.RevokeStmt{
+		Kind: ast.RevokePrivileges,
+		Loc:  ast.Loc{Start: start.Start},
+	}
+
+	// Optional GRANT OPTION FOR.
+	if p.cur.Type == kwGRANT && p.peekNext().Type == kwOPTION {
+		p.advance() // consume GRANT
+		p.advance() // consume OPTION
+		if _, err := p.expect(kwFOR); err != nil {
+			return nil, err
+		}
+		stmt.GrantOptionFor = true
+	}
+
+	all, privs, err := p.parsePrivilegeList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.AllPrivileges = all
+	stmt.Privileges = privs
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	target, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = target
+
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parseGrantee()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	// Optional CASCADE | RESTRICT.
+	switch p.cur.Type {
+	case kwCASCADE:
+		p.advance()
+		stmt.Cascade = true
+	case kwRESTRICT:
+		p.advance()
+		stmt.Restrict = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-grammar: privilege list, ON target, grantee
+// ---------------------------------------------------------------------------
+
+// parsePrivilegeList parses { <privileges> | ALL [PRIVILEGES] }, the span
+// immediately before ON. Returns (allPrivileges, privileges, err); exactly one
+// of the two result paths applies.
+//
+//	ALL [PRIVILEGES]          -> (true, nil, nil)
+//	priv [, priv ...]         -> (false, [...], nil)
+//
+// A single privilege is one or more consecutive name tokens (keywords and/or
+// identifiers, including dotted class names like SNOWFLAKE.CORE.BUDGET),
+// captured verbatim and uppercased. Privileges are separated by commas and the
+// whole list is terminated by ON.
+func (p *Parser) parsePrivilegeList() (bool, []*ast.Privilege, error) {
+	// ALL [PRIVILEGES] — but only treat a leading ALL as "all privileges" when
+	// it is immediately followed by PRIVILEGES or ON (i.e. ALL is the entire
+	// privilege spec). A privilege literally beginning with ALL is not a
+	// documented Snowflake form, so this is unambiguous.
+	if p.cur.Type == kwALL {
+		next := p.peekNext()
+		if next.Type == kwPRIVILEGES || next.Type == kwON {
+			p.advance() // consume ALL
+			if p.cur.Type == kwPRIVILEGES {
+				p.advance() // consume PRIVILEGES
+			}
+			return true, nil, nil
+		}
+	}
+
+	var privs []*ast.Privilege
+	for {
+		priv, err := p.parsePrivilege()
+		if err != nil {
+			return false, nil, err
+		}
+		privs = append(privs, priv)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return false, privs, nil
+}
+
+// parsePrivilege parses one privilege: a run of one or more name tokens
+// (keywords or identifiers), joining multi-word privileges (e.g.
+// CREATE MATERIALIZED VIEW) with single spaces and dotted class names (e.g.
+// SNOWFLAKE.CORE.BUDGET) with dots. The run stops at ON, a comma, or any
+// non-name token. Requires at least one name token.
+func (p *Parser) parsePrivilege() (*ast.Privilege, error) {
+	if !p.isPrivilegeWord(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	startLoc := p.cur.Loc
+	var b strings.Builder
+	endLoc := p.cur.Loc
+
+	first := p.advance()
+	b.WriteString(strings.ToUpper(first.Str))
+	endLoc = first.Loc
+
+	for {
+		// Dotted continuation: name . name (class privilege).
+		if p.cur.Type == '.' && p.isPrivilegeWord(p.peekNext().Type) {
+			p.advance() // consume '.'
+			part := p.advance()
+			b.WriteByte('.')
+			b.WriteString(strings.ToUpper(part.Str))
+			endLoc = part.Loc
+			continue
+		}
+		// Space-separated continuation: stop at ON / comma / structural tokens.
+		if p.cur.Type == kwON || p.cur.Type == ',' {
+			break
+		}
+		if !p.isPrivilegeWord(p.cur.Type) {
+			break
+		}
+		part := p.advance()
+		b.WriteByte(' ')
+		b.WriteString(strings.ToUpper(part.Str))
+		endLoc = part.Loc
+	}
+
+	return &ast.Privilege{
+		Name: b.String(),
+		Loc:  ast.Loc{Start: startLoc.Start, End: endLoc.End},
+	}, nil
+}
+
+// isPrivilegeWord reports whether a token type may appear inside a privilege
+// name. Identifiers and any keyword qualify; structural punctuation and EOF do
+// not. ON is excluded because it terminates the privilege list. The lexer emits
+// most privilege words (SELECT, USAGE, CREATE, ...) as keywords, but some
+// (e.g. PROVISIONED, THROUGHPUT, BUDGET) arrive as identifiers.
+func (p *Parser) isPrivilegeWord(tokType int) bool {
+	if tokType == kwON {
+		return false
+	}
+	if tokType == tokIdent || tokType == tokQuotedIdent {
+		return true
+	}
+	// Any keyword token (kw* constants are >= 700) is a valid privilege word.
+	return tokType >= 700
+}
+
+// parseGrantTarget parses the ON clause body (the ON keyword has already been
+// consumed):
+//
+//	ACCOUNT
+//	<object_type> <name> [ ( signature ) ]
+//	ALL <object_type_plural> IN { DATABASE <db> | SCHEMA <schema> }
+//	FUTURE <object_type_plural> IN { DATABASE <db> | SCHEMA <schema> }
+func (p *Parser) parseGrantTarget() (*ast.GrantTarget, error) {
+	startLoc := p.cur.Loc
+
+	switch p.cur.Type {
+	case kwACCOUNT:
+		p.advance() // consume ACCOUNT
+		return &ast.GrantTarget{
+			Kind: ast.GrantTargetAccount,
+			Loc:  ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+		}, nil
+
+	case kwALL:
+		p.advance() // consume ALL
+		return p.parseGrantTargetContainer(ast.GrantTargetAllIn, startLoc)
+
+	case kwFUTURE:
+		p.advance() // consume FUTURE
+		return p.parseGrantTargetContainer(ast.GrantTargetFutureIn, startLoc)
+
+	default:
+		// <object_type> <name> [ ( signature ) ]
+		return p.parseGrantTargetObject(startLoc)
+	}
+}
+
+// parseGrantTargetObject parses the <object_type> <name> [ ( signature ) ] form
+// of an ON clause. startLoc is the Loc of the first object-type token.
+//
+// The object type is open-ended and may be multiple words (TABLE, MATERIALIZED
+// VIEW, CORTEX SEARCH SERVICE, STORAGE LIFECYCLE POLICY, ...). The boundary
+// between the type and the object name is purely structural: the words of the
+// ON target are a sequence of space-separated "name units" (each unit a dotted
+// identifier path such as mydb.public.t), and the LAST unit is the object name
+// while every preceding unit forms the object type. This needs no fixed type
+// vocabulary, so new Snowflake object types parse without code changes.
+func (p *Parser) parseGrantTargetObject(startLoc ast.Loc) (*ast.GrantTarget, error) {
+	// Collect the type words (everything before the final name unit). We read
+	// one name unit, then keep reading while another name unit follows, shifting
+	// the previous unit into the type. The final unit is the object name.
+	var typeWords []string
+	name, err := p.parseGrantNameUnit()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.startsGrantNameUnit() {
+		// The unit we just parsed is actually part of the type; absorb it and
+		// read the next unit as the new (tentative) name.
+		typeWords = append(typeWords, objectNameToType(name))
+		name, err = p.parseGrantNameUnit()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(typeWords) == 0 {
+		// A bare single unit (e.g. "ON foo") has no object type — invalid.
+		return nil, &ParseError{
+			Loc: startLoc,
+			Msg: "expected object type before object name in GRANT/REVOKE ON clause",
+		}
+	}
+
+	target := &ast.GrantTarget{
+		Kind:       ast.GrantTargetObject,
+		ObjectType: strings.Join(typeWords, " "),
+		Name:       name,
+		Loc:        ast.Loc{Start: startLoc.Start},
+	}
+
+	// Optional FUNCTION/PROCEDURE argument-type signature.
+	if p.cur.Type == '(' {
+		sig, err := p.parseGrantSignature()
+		if err != nil {
+			return nil, err
+		}
+		target.Signature = sig
+	}
+
+	target.Loc.End = p.prev.Loc.End
+	return target, nil
+}
+
+// startsGrantNameUnit reports whether the current token can begin another
+// space-separated name unit inside an ON target — i.e. it is a name word and
+// not a clause terminator. The object form's run ends at TO/FROM (the grantee
+// clause), '(' (a signature), comma, or EOF.
+func (p *Parser) startsGrantNameUnit() bool {
+	switch p.cur.Type {
+	case kwTO, kwFROM, '(', ',', tokEOF:
+		return false
+	}
+	return p.isObjectTypeWord(p.cur.Type)
+}
+
+// parseGrantNameUnit parses one space-separated name unit: a dotted identifier
+// path (one or more name parts joined by dots). Mirrors parseObjectName but is
+// used to walk the ON target word-by-word. The type-vs-name split is decided by
+// the caller; this only consumes a single dotted unit.
+func (p *Parser) parseGrantNameUnit() (*ast.ObjectName, error) {
+	if !p.isObjectTypeWord(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return p.parseObjectName()
+}
+
+// objectNameToType renders a single-word object-type unit (parsed as an
+// ObjectName) back to its uppercased source word. Object-type words are always
+// single, unquoted identifiers/keywords, so the unit's Name part carries the
+// text. A dotted unit here would be malformed input; we still render it
+// faithfully so the error surfaces downstream rather than silently dropping it.
+func objectNameToType(n *ast.ObjectName) string {
+	return strings.ToUpper(n.String())
+}
+
+// parseGrantTargetContainer parses the tail of an ALL/FUTURE target:
+//
+//	<object_type_plural> IN { DATABASE <db> | SCHEMA <schema> }
+//
+// kind is GrantTargetAllIn or GrantTargetFutureIn. startLoc is the Loc of the
+// ALL/FUTURE keyword. On entry ALL/FUTURE has already been consumed.
+func (p *Parser) parseGrantTargetContainer(kind ast.GrantTargetKind, startLoc ast.Loc) (*ast.GrantTarget, error) {
+	plural, err := p.parsePluralObjectType()
+	if err != nil {
+		return nil, err
+	}
+	target := &ast.GrantTarget{
+		Kind:             kind,
+		ObjectTypePlural: plural,
+		Loc:              ast.Loc{Start: startLoc.Start},
+	}
+
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+	switch p.cur.Type {
+	case kwDATABASE:
+		p.advance() // consume DATABASE
+		target.Container = ast.GrantContainerDatabase
+	case kwSCHEMA:
+		p.advance() // consume SCHEMA
+		target.Container = ast.GrantContainerSchema
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	target.ContainerName = name
+
+	target.Loc.End = p.prev.Loc.End
+	return target, nil
+}
+
+// parsePluralObjectType parses the plural object-type words of an
+// ALL/FUTURE ... IN form (e.g. TABLES, EXTERNAL TABLES, MATERIALIZED VIEWS).
+// It consumes name words until the IN keyword, so it is open-ended over
+// Snowflake's growing object-type set. The loop also stops at the grantee
+// keywords (TO/FROM) so that malformed input missing IN fails at a meaningful
+// position rather than swallowing the grantee clause. Requires at least one
+// word.
+func (p *Parser) parsePluralObjectType() (string, error) {
+	if !p.isObjectTypeWord(p.cur.Type) || p.cur.Type == kwIN {
+		return "", p.syntaxErrorAtCur()
+	}
+
+	var words []string
+	for p.isObjectTypeWord(p.cur.Type) {
+		switch p.cur.Type {
+		case kwIN, kwTO, kwFROM:
+			return strings.Join(words, " "), nil
+		}
+		tok := p.advance()
+		words = append(words, strings.ToUpper(tok.Str))
+	}
+	return strings.Join(words, " "), nil
+}
+
+// isObjectTypeWord reports whether tokType can start/continue an object-type or
+// object-name word. Identifiers (for object types not in the lexer keyword set,
+// e.g. NOTEBOOK, WORKSPACE) and keywords both qualify; punctuation and EOF do
+// not.
+func (p *Parser) isObjectTypeWord(tokType int) bool {
+	if tokType == tokIdent || tokType == tokQuotedIdent {
+		return true
+	}
+	return tokType >= 700
+}
+
+// parseGrantSignature parses a FUNCTION/PROCEDURE argument-type signature
+// following the object name: ( [ data_type [, data_type ...] ] ). Each argument
+// is a full Snowflake data type, so it reuses parseDataType and therefore
+// handles parameterized and multi-word types such as NUMBER(38,0),
+// VARCHAR(100), DOUBLE PRECISION, and ARRAY. Returns a non-nil (possibly empty)
+// slice so callers can distinguish "()" from "no signature". On entry cur is
+// '('.
+func (p *Parser) parseGrantSignature() ([]*ast.TypeName, error) {
+	p.advance() // consume '('
+
+	sig := []*ast.TypeName{}
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		dt, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		sig = append(sig, dt)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return sig, nil
+}
+
+// parseGrantee parses the recipient after TO (GRANT) or the subject after FROM
+// (REVOKE). The TO/FROM keyword has already been consumed.
+//
+//	[ROLE] <name>            (bare name defaults to ROLE)
+//	DATABASE ROLE <name>
+//	USER <name>
+//	SHARE <name>
+//	APPLICATION <name>
+//	APPLICATION ROLE <name>
+func (p *Parser) parseGrantee() (*ast.Grantee, error) {
+	startLoc := p.cur.Loc
+	var kind ast.GranteeKind
+
+	switch p.cur.Type {
+	case kwROLE:
+		p.advance() // consume ROLE
+		kind = ast.GranteeRole
+	case kwDATABASE:
+		p.advance() // consume DATABASE
+		if _, err := p.expect(kwROLE); err != nil {
+			return nil, err
+		}
+		kind = ast.GranteeDatabaseRole
+	case kwUSER:
+		p.advance() // consume USER
+		kind = ast.GranteeUser
+	case kwSHARE:
+		p.advance() // consume SHARE
+		kind = ast.GranteeShare
+	case kwAPPLICATION:
+		p.advance() // consume APPLICATION
+		if p.cur.Type == kwROLE {
+			p.advance() // consume ROLE
+			kind = ast.GranteeApplicationRole
+		} else {
+			kind = ast.GranteeApplication
+		}
+	default:
+		// Bare role name: TO <role_name> with the ROLE keyword omitted.
+		// Only a name-like token is acceptable here.
+		if !p.isGranteeNameStart(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		kind = ast.GranteeRole
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ast.Grantee{
+		Kind: kind,
+		Name: name,
+		Loc:  ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// isGranteeNameStart reports whether tokType can begin a bare grantee role
+// name. Identifiers and keywords qualify (so a system role like PUBLIC, which
+// the lexer emits as a keyword, is accepted), but structural punctuation and
+// EOF do not — guarding against "GRANT ... TO" with nothing following.
+func (p *Parser) isGranteeNameStart(tokType int) bool {
+	if tokType == tokIdent || tokType == tokQuotedIdent {
+		return true
+	}
+	return tokType >= 700
+}
+
+// expectCurrentGrants consumes the CURRENT GRANTS keywords that follow REVOKE
+// or COPY in a GRANT OWNERSHIP trailing clause. The REVOKE/COPY keyword has
+// already been consumed.
+func (p *Parser) expectCurrentGrants() error {
+	if _, err := p.expect(kwCURRENT); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwGRANTS); err != nil {
+		return err
+	}
+	return nil
+}

--- a/snowflake/parser/grant_revoke_test.go
+++ b/snowflake/parser/grant_revoke_test.go
@@ -1,0 +1,995 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func testParseGrantStmt(t *testing.T, input string) (*ast.GrantStmt, []ParseError) {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.GrantStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a GrantStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseRevokeStmt(t *testing.T, input string) (*ast.RevokeStmt, []ParseError) {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.RevokeStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a RevokeStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func privNames(privs []*ast.Privilege) []string {
+	out := make([]string, len(privs))
+	for i, p := range privs {
+		out[i] = p.Name
+	}
+	return out
+}
+
+// sigNames renders a function/procedure signature's argument data types to
+// their uppercased source names for comparison.
+func sigNames(sig []*ast.TypeName) []string {
+	out := make([]string, len(sig))
+	for i, t := range sig {
+		out[i] = strings.ToUpper(t.Name)
+	}
+	return out
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// GRANT ROLE / GRANT DATABASE ROLE
+// ---------------------------------------------------------------------------
+
+func TestGrantRole_ToRole(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT ROLE analyst TO ROLE SYSADMIN")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.GrantRole {
+		t.Errorf("kind = %v, want GrantRole", stmt.Kind)
+	}
+	if stmt.RoleKind != ast.GrantedAccountRole {
+		t.Errorf("role kind = %v, want GrantedAccountRole", stmt.RoleKind)
+	}
+	if stmt.Role.Normalize() != "ANALYST" {
+		t.Errorf("role = %q, want ANALYST", stmt.Role.Normalize())
+	}
+	if stmt.Grantee.Kind != ast.GranteeRole {
+		t.Errorf("grantee kind = %v, want GranteeRole", stmt.Grantee.Kind)
+	}
+	if stmt.Grantee.Name.Normalize() != "SYSADMIN" {
+		t.Errorf("grantee = %q, want SYSADMIN", stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantRole_ToUser(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT ROLE analyst TO USER user1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeUser {
+		t.Errorf("grantee kind = %v, want GranteeUser", stmt.Grantee.Kind)
+	}
+	if stmt.Grantee.Name.Normalize() != "USER1" {
+		t.Errorf("grantee = %q, want USER1", stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantDatabaseRole_ToDatabaseRole(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT DATABASE ROLE mydb.dr1 TO DATABASE ROLE mydb.dr2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.GrantRole {
+		t.Errorf("kind = %v, want GrantRole", stmt.Kind)
+	}
+	if stmt.RoleKind != ast.GrantedDatabaseRole {
+		t.Errorf("role kind = %v, want GrantedDatabaseRole", stmt.RoleKind)
+	}
+	if stmt.Role.Normalize() != "MYDB.DR1" {
+		t.Errorf("role = %q, want MYDB.DR1", stmt.Role.Normalize())
+	}
+	if stmt.Grantee.Kind != ast.GranteeDatabaseRole {
+		t.Errorf("grantee kind = %v, want GranteeDatabaseRole", stmt.Grantee.Kind)
+	}
+	if stmt.Grantee.Name.Normalize() != "MYDB.DR2" {
+		t.Errorf("grantee = %q, want MYDB.DR2", stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantDatabaseRole_ToUser(t *testing.T) {
+	// From official corpus grant-privilege/example_20.sql.
+	stmt, errs := testParseGrantStmt(t, "GRANT DATABASE ROLE mydb.dr1 TO USER testuser")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.RoleKind != ast.GrantedDatabaseRole {
+		t.Errorf("role kind = %v, want GrantedDatabaseRole", stmt.RoleKind)
+	}
+	if stmt.Grantee.Kind != ast.GranteeUser {
+		t.Errorf("grantee kind = %v, want GranteeUser", stmt.Grantee.Kind)
+	}
+}
+
+func TestGrantDatabaseRole_ToApplication(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT DATABASE ROLE mydb.dr1 TO APPLICATION app1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeApplication {
+		t.Errorf("grantee kind = %v, want GranteeApplication", stmt.Grantee.Kind)
+	}
+}
+
+func TestGrantApplicationRole_ToUser(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT APPLICATION ROLE app1.ar1 TO USER user1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.GrantRole {
+		t.Errorf("kind = %v, want GrantRole", stmt.Kind)
+	}
+	if stmt.RoleKind != ast.GrantedApplicationRole {
+		t.Errorf("role kind = %v, want GrantedApplicationRole", stmt.RoleKind)
+	}
+	if stmt.Role.Normalize() != "APP1.AR1" {
+		t.Errorf("role = %q, want APP1.AR1", stmt.Role.Normalize())
+	}
+	if stmt.Grantee.Kind != ast.GranteeUser {
+		t.Errorf("grantee kind = %v, want GranteeUser", stmt.Grantee.Kind)
+	}
+}
+
+func TestGrantApplicationRole_ToApplicationRole(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT APPLICATION ROLE app1.ar1 TO APPLICATION ROLE app2.ar2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.RoleKind != ast.GrantedApplicationRole {
+		t.Errorf("role kind = %v, want GrantedApplicationRole", stmt.RoleKind)
+	}
+	if stmt.Grantee.Kind != ast.GranteeApplicationRole {
+		t.Errorf("grantee kind = %v, want GranteeApplicationRole", stmt.Grantee.Kind)
+	}
+}
+
+func TestRevokeApplicationRole_FromApplicationRole(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE APPLICATION ROLE app1.ar1 FROM APPLICATION ROLE app2.ar2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.RoleKind != ast.GrantedApplicationRole {
+		t.Errorf("role kind = %v, want GrantedApplicationRole", stmt.RoleKind)
+	}
+	if stmt.Grantee.Kind != ast.GranteeApplicationRole {
+		t.Errorf("grantee kind = %v, want GranteeApplicationRole", stmt.Grantee.Kind)
+	}
+}
+
+func TestRevokeRole_FromRole(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE ROLE public FROM ROLE public")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.RevokeRole {
+		t.Errorf("kind = %v, want RevokeRole", stmt.Kind)
+	}
+	if stmt.Role.Normalize() != "PUBLIC" {
+		t.Errorf("role = %q, want PUBLIC", stmt.Role.Normalize())
+	}
+	if stmt.Grantee.Kind != ast.GranteeRole {
+		t.Errorf("grantee kind = %v, want GranteeRole", stmt.Grantee.Kind)
+	}
+}
+
+func TestRevokeDatabaseRole_FromUser(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE DATABASE ROLE mydb.dr1 FROM USER bob")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.RoleKind != ast.GrantedDatabaseRole {
+		t.Errorf("role kind = %v, want GrantedDatabaseRole", stmt.RoleKind)
+	}
+	if stmt.Grantee.Kind != ast.GranteeUser {
+		t.Errorf("grantee kind = %v, want GranteeUser", stmt.Grantee.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRANT <privileges> ON ...
+// ---------------------------------------------------------------------------
+
+func TestGrantPriv_OnWarehouse(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OPERATE ON WAREHOUSE report_wh TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.GrantPrivileges {
+		t.Errorf("kind = %v, want GrantPrivileges", stmt.Kind)
+	}
+	if stmt.AllPrivileges {
+		t.Error("expected AllPrivileges=false")
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"OPERATE"}) {
+		t.Errorf("privileges = %v, want [OPERATE]", got)
+	}
+	if stmt.On.Kind != ast.GrantTargetObject {
+		t.Errorf("target kind = %v, want GrantTargetObject", stmt.On.Kind)
+	}
+	if stmt.On.ObjectType != "WAREHOUSE" {
+		t.Errorf("object type = %q, want WAREHOUSE", stmt.On.ObjectType)
+	}
+	if stmt.On.Name.Normalize() != "REPORT_WH" {
+		t.Errorf("object name = %q, want REPORT_WH", stmt.On.Name.Normalize())
+	}
+	if stmt.Grantee.Kind != ast.GranteeRole || stmt.Grantee.Name.Normalize() != "ANALYST" {
+		t.Errorf("grantee = %v %q", stmt.Grantee.Kind, stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantPriv_WithGrantOption(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OPERATE ON WAREHOUSE report_wh TO ROLE analyst WITH GRANT OPTION")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.GrantOption {
+		t.Error("expected GrantOption=true")
+	}
+}
+
+func TestGrantPriv_MultiPrivilegeList(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT, INSERT ON FUTURE TABLES IN SCHEMA mydb.myschema TO ROLE role1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"SELECT", "INSERT"}) {
+		t.Errorf("privileges = %v, want [SELECT INSERT]", got)
+	}
+	if stmt.On.Kind != ast.GrantTargetFutureIn {
+		t.Errorf("target kind = %v, want GrantTargetFutureIn", stmt.On.Kind)
+	}
+	if stmt.On.ObjectTypePlural != "TABLES" {
+		t.Errorf("plural = %q, want TABLES", stmt.On.ObjectTypePlural)
+	}
+	if stmt.On.Container != ast.GrantContainerSchema {
+		t.Errorf("container = %v, want GrantContainerSchema", stmt.On.Container)
+	}
+	if stmt.On.ContainerName.Normalize() != "MYDB.MYSCHEMA" {
+		t.Errorf("container name = %q, want MYDB.MYSCHEMA", stmt.On.ContainerName.Normalize())
+	}
+}
+
+func TestGrantPriv_AllPrivilegesOnDatabase(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT ALL PRIVILEGES ON DATABASE mydb TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.AllPrivileges {
+		t.Error("expected AllPrivileges=true")
+	}
+	if len(stmt.Privileges) != 0 {
+		t.Errorf("expected no explicit privileges, got %v", privNames(stmt.Privileges))
+	}
+	if stmt.On.ObjectType != "DATABASE" || stmt.On.Name.Normalize() != "MYDB" {
+		t.Errorf("target = %q %q", stmt.On.ObjectType, stmt.On.Name.Normalize())
+	}
+}
+
+func TestGrantPriv_AllBareNoPrivileges(t *testing.T) {
+	// ALL without the PRIVILEGES keyword is also valid.
+	stmt, errs := testParseGrantStmt(t, "GRANT ALL ON DATABASE mydb TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.AllPrivileges {
+		t.Error("expected AllPrivileges=true")
+	}
+}
+
+func TestGrantPriv_OnAccount(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT CREATE WAREHOUSE ON ACCOUNT TO ROLE myrole")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Kind != ast.GrantTargetAccount {
+		t.Errorf("target kind = %v, want GrantTargetAccount", stmt.On.Kind)
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"CREATE WAREHOUSE"}) {
+		t.Errorf("privileges = %v, want [CREATE WAREHOUSE]", got)
+	}
+}
+
+func TestGrantPriv_MultiWordPrivilege(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT CREATE MATERIALIZED VIEW ON SCHEMA mydb.myschema TO ROLE myrole")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"CREATE MATERIALIZED VIEW"}) {
+		t.Errorf("privileges = %v, want [CREATE MATERIALIZED VIEW]", got)
+	}
+	if stmt.On.ObjectType != "SCHEMA" {
+		t.Errorf("object type = %q, want SCHEMA", stmt.On.ObjectType)
+	}
+}
+
+func TestGrantPriv_OnFunctionWithSignature(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT ALL PRIVILEGES ON FUNCTION mydb.myschema.add5(number) TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.ObjectType != "FUNCTION" {
+		t.Errorf("object type = %q, want FUNCTION", stmt.On.ObjectType)
+	}
+	if stmt.On.Name.Normalize() != "MYDB.MYSCHEMA.ADD5" {
+		t.Errorf("name = %q, want MYDB.MYSCHEMA.ADD5", stmt.On.Name.Normalize())
+	}
+	if !eqStrings(sigNames(stmt.On.Signature), []string{"NUMBER"}) {
+		t.Errorf("signature = %v, want [NUMBER]", sigNames(stmt.On.Signature))
+	}
+}
+
+func TestGrantPriv_OnProcedureMultiArgSignature(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT ALL PRIVILEGES ON PROCEDURE clean_schema(string, string) TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.ObjectType != "PROCEDURE" {
+		t.Errorf("object type = %q, want PROCEDURE", stmt.On.ObjectType)
+	}
+	if !eqStrings(sigNames(stmt.On.Signature), []string{"STRING", "STRING"}) {
+		t.Errorf("signature = %v, want [STRING STRING]", sigNames(stmt.On.Signature))
+	}
+}
+
+func TestGrantPriv_ParameterizedSignature(t *testing.T) {
+	// Function arguments are full data types, including parameterized
+	// (NUMBER(38,0)) and multi-word (DOUBLE PRECISION) forms.
+	stmt, errs := testParseGrantStmt(t, "GRANT USAGE ON FUNCTION mydb.s.f(NUMBER(38,0), VARCHAR(100), DOUBLE PRECISION) TO ROLE r")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := sigNames(stmt.On.Signature); !eqStrings(got, []string{"NUMBER", "VARCHAR", "DOUBLE PRECISION"}) {
+		// parseDataType captures the canonical type name (numeric params live
+		// in TypeName.Params; DOUBLE PRECISION keeps its two-word Name).
+		t.Errorf("signature names = %v, want [NUMBER VARCHAR DOUBLE PRECISION]", got)
+	}
+	if len(stmt.On.Signature) != 3 {
+		t.Fatalf("expected 3 signature args, got %d", len(stmt.On.Signature))
+	}
+	// The first arg retains its numeric parameters.
+	if got := stmt.On.Signature[0].Params; len(got) != 2 || got[0] != 38 || got[1] != 0 {
+		t.Errorf("first arg params = %v, want [38 0]", got)
+	}
+}
+
+func TestGrantPriv_AllTablesInSchema(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT ON ALL TABLES IN SCHEMA mydb.myschema TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Kind != ast.GrantTargetAllIn {
+		t.Errorf("target kind = %v, want GrantTargetAllIn", stmt.On.Kind)
+	}
+	if stmt.On.ObjectTypePlural != "TABLES" {
+		t.Errorf("plural = %q, want TABLES", stmt.On.ObjectTypePlural)
+	}
+	if stmt.On.Container != ast.GrantContainerSchema {
+		t.Errorf("container = %v, want GrantContainerSchema", stmt.On.Container)
+	}
+}
+
+func TestGrantPriv_FutureSchemasInDatabase(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT USAGE ON FUTURE SCHEMAS IN DATABASE mydb TO ROLE role1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Kind != ast.GrantTargetFutureIn {
+		t.Errorf("target kind = %v, want GrantTargetFutureIn", stmt.On.Kind)
+	}
+	if stmt.On.ObjectTypePlural != "SCHEMAS" {
+		t.Errorf("plural = %q, want SCHEMAS", stmt.On.ObjectTypePlural)
+	}
+	if stmt.On.Container != ast.GrantContainerDatabase {
+		t.Errorf("container = %v, want GrantContainerDatabase", stmt.On.Container)
+	}
+	if stmt.On.ContainerName.Normalize() != "MYDB" {
+		t.Errorf("container name = %q, want MYDB", stmt.On.ContainerName.Normalize())
+	}
+}
+
+func TestGrantPriv_ToDatabaseRoleGrantee(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT ON ALL TABLES IN SCHEMA mydb.myschema TO DATABASE ROLE mydb.dr1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeDatabaseRole {
+		t.Errorf("grantee kind = %v, want GranteeDatabaseRole", stmt.Grantee.Kind)
+	}
+	if stmt.Grantee.Name.Normalize() != "MYDB.DR1" {
+		t.Errorf("grantee = %q, want MYDB.DR1", stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantPriv_BareRoleGrantee(t *testing.T) {
+	// TO <role_name> with the ROLE keyword omitted.
+	stmt, errs := testParseGrantStmt(t, "GRANT USAGE ON DATABASE mydb TO myrole")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeRole {
+		t.Errorf("grantee kind = %v, want GranteeRole (bare)", stmt.Grantee.Kind)
+	}
+	if stmt.Grantee.Name.Normalize() != "MYROLE" {
+		t.Errorf("grantee = %q, want MYROLE", stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantPriv_IdentifierObjectType(t *testing.T) {
+	// NOTEBOOK is NOT a keyword in the lexer — it must be accepted as an
+	// identifier object type (docs win over the stale legacy enum).
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON NOTEBOOK db_one.schema_one.mynotebook TO ROLE finance")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.ObjectType != "NOTEBOOK" {
+		t.Errorf("object type = %q, want NOTEBOOK", stmt.On.ObjectType)
+	}
+}
+
+func TestGrantPriv_MultiWordIdentifierPrivilege(t *testing.T) {
+	// CREATE PROVISIONED THROUGHPUT — PROVISIONED/THROUGHPUT are identifiers.
+	stmt, errs := testParseGrantStmt(t, "GRANT CREATE PROVISIONED THROUGHPUT ON ACCOUNT TO ROLE myrole")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"CREATE PROVISIONED THROUGHPUT"}) {
+		t.Errorf("privileges = %v, want [CREATE PROVISIONED THROUGHPUT]", got)
+	}
+}
+
+func TestGrantPriv_DottedIdentifierPrivilege(t *testing.T) {
+	// CREATE SNOWFLAKE.CORE.BUDGET — a dotted class privilege.
+	stmt, errs := testParseGrantStmt(t, "GRANT CREATE SNOWFLAKE.CORE.BUDGET ON SCHEMA budgets_db.budgets_schema TO ROLE budget_admin")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"CREATE SNOWFLAKE.CORE.BUDGET"}) {
+		t.Errorf("privileges = %v, want [CREATE SNOWFLAKE.CORE.BUDGET]", got)
+	}
+}
+
+// TestGrantPriv_MultiWordObjectTypes exercises the full vocabulary of
+// multi-word object types, including those whose connector words the lexer
+// emits as identifiers (COMPUTE POOL, EXTERNAL VOLUME, NETWORK RULE). The
+// object name must never be swallowed into the type.
+func TestGrantPriv_MultiWordObjectTypes(t *testing.T) {
+	cases := []struct {
+		sql      string
+		wantType string
+		wantName string
+	}{
+		{"GRANT MONITOR ON RESOURCE MONITOR rm TO ROLE r", "RESOURCE MONITOR", "RM"},
+		{"GRANT SELECT ON EXTERNAL TABLE t TO ROLE r", "EXTERNAL TABLE", "T"},
+		{"GRANT SELECT ON MATERIALIZED VIEW mv TO ROLE r", "MATERIALIZED VIEW", "MV"},
+		{"GRANT SELECT ON DYNAMIC TABLE dt TO ROLE r", "DYNAMIC TABLE", "DT"},
+		{"GRANT SELECT ON ICEBERG TABLE it TO ROLE r", "ICEBERG TABLE", "IT"},
+		{"GRANT APPLY ON MASKING POLICY p TO ROLE r", "MASKING POLICY", "P"},
+		{"GRANT APPLY ON ROW ACCESS POLICY p TO ROLE r", "ROW ACCESS POLICY", "P"},
+		{"GRANT USAGE ON FILE FORMAT ff TO ROLE r", "FILE FORMAT", "FF"},
+		{"GRANT OPERATE ON COMPUTE POOL cp TO ROLE r", "COMPUTE POOL", "CP"},
+		{"GRANT USAGE ON EXTERNAL VOLUME v TO ROLE r", "EXTERNAL VOLUME", "V"},
+		{"GRANT USAGE ON NETWORK RULE nr TO ROLE r", "NETWORK RULE", "NR"},
+		{"GRANT MODIFY ON FAILOVER GROUP fg TO ROLE r", "FAILOVER GROUP", "FG"},
+		{"GRANT MODIFY ON REPLICATION GROUP rg TO ROLE r", "REPLICATION GROUP", "RG"},
+		{"GRANT USAGE ON SEMANTIC VIEW sv TO SHARE s", "SEMANTIC VIEW", "SV"},
+		// Three-word object types and arbitrary new types (open-ended, no fixed
+		// vocabulary): the object name is always the final space-separated unit.
+		{"GRANT USAGE ON CORTEX SEARCH SERVICE mydb.s.css TO ROLE r", "CORTEX SEARCH SERVICE", "MYDB.S.CSS"},
+		{"GRANT ALL ON DATA METRIC FUNCTION mydb.s.dmf TO ROLE r", "DATA METRIC FUNCTION", "MYDB.S.DMF"},
+		{"GRANT APPLY ON STORAGE LIFECYCLE POLICY p TO ROLE r", "STORAGE LIFECYCLE POLICY", "P"},
+		{"GRANT USAGE ON GIT REPOSITORY repo TO ROLE r", "GIT REPOSITORY", "REPO"},
+		{"GRANT READ ON IMAGE REPOSITORY ir TO ROLE r", "IMAGE REPOSITORY", "IR"},
+		{"GRANT USAGE ON MODEL m TO ROLE r", "MODEL", "M"},
+		{"GRANT USAGE ON STREAMLIT st TO ROLE r", "STREAMLIT", "ST"},
+		{"GRANT READ ON SECRET sec TO ROLE r", "SECRET", "SEC"},
+		{"GRANT USAGE ON WORKSPACE mydb.s.ws TO ROLE r", "WORKSPACE", "MYDB.S.WS"},
+	}
+	for _, c := range cases {
+		t.Run(c.wantType, func(t *testing.T) {
+			stmt, errs := testParseGrantStmt(t, c.sql)
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if stmt.On.ObjectType != c.wantType {
+				t.Errorf("object type = %q, want %q", stmt.On.ObjectType, c.wantType)
+			}
+			if stmt.On.Name.Normalize() != c.wantName {
+				t.Errorf("object name = %q, want %q", stmt.On.Name.Normalize(), c.wantName)
+			}
+		})
+	}
+}
+
+func TestGrantPriv_ImportedPrivileges(t *testing.T) {
+	// IMPORTED PRIVILEGES is a two-word privilege (not the ALL PRIVILEGES form).
+	stmt, errs := testParseGrantStmt(t, "GRANT IMPORTED PRIVILEGES ON DATABASE shared_db TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.AllPrivileges {
+		t.Error("expected AllPrivileges=false for IMPORTED PRIVILEGES")
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"IMPORTED PRIVILEGES"}) {
+		t.Errorf("privileges = %v, want [IMPORTED PRIVILEGES]", got)
+	}
+}
+
+func TestGrantPriv_ReadWriteOnTag(t *testing.T) {
+	// READ and WRITE as a comma-separated privilege list.
+	stmt, errs := testParseGrantStmt(t, "GRANT READ, WRITE ON TAG mydb.s.t TO ROLE r")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"READ", "WRITE"}) {
+		t.Errorf("privileges = %v, want [READ WRITE]", got)
+	}
+	if stmt.On.ObjectType != "TAG" {
+		t.Errorf("object type = %q, want TAG", stmt.On.ObjectType)
+	}
+}
+
+func TestGrantPriv_OnObjectKeywordName(t *testing.T) {
+	// A reserved keyword used as an (unquoted) object name part: the object
+	// type must terminate so the keyword becomes the name, not the type.
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT ON TABLE mydb.public.t TO ROLE r")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.ObjectType != "TABLE" {
+		t.Errorf("object type = %q, want TABLE", stmt.On.ObjectType)
+	}
+	if stmt.On.Name.Normalize() != "MYDB.PUBLIC.T" {
+		t.Errorf("name = %q, want MYDB.PUBLIC.T", stmt.On.Name.Normalize())
+	}
+}
+
+func TestGrantPriv_QuotedConnectorWordName(t *testing.T) {
+	// A quoted object name that spells a multi-word-type connector word
+	// (e.g. "VIEW") must NOT be absorbed into the object type. Quoted
+	// identifiers are always names.
+	stmt, errs := testParseGrantStmt(t, `GRANT SELECT ON TABLE "VIEW" TO ROLE r`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.ObjectType != "TABLE" {
+		t.Errorf("object type = %q, want TABLE", stmt.On.ObjectType)
+	}
+	if stmt.On.Name.String() != `"VIEW"` {
+		t.Errorf("object name = %q, want \"VIEW\"", stmt.On.Name.String())
+	}
+}
+
+func TestGrantPriv_NoSignatureLeavesNil(t *testing.T) {
+	// A non-function object must not carry a signature.
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT ON TABLE t TO ROLE r")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Signature != nil {
+		t.Errorf("signature = %v, want nil", stmt.On.Signature)
+	}
+}
+
+func TestGrantPriv_EmptySignature(t *testing.T) {
+	// FUNCTION foo() — empty arg list, non-nil empty signature distinguishes
+	// from "no parens".
+	stmt, errs := testParseGrantStmt(t, "GRANT USAGE ON FUNCTION mydb.s.f() TO ROLE r")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Signature == nil {
+		t.Fatal("signature = nil, want non-nil empty slice")
+	}
+	if len(stmt.On.Signature) != 0 {
+		t.Errorf("signature = %v, want empty", stmt.On.Signature)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRANT OWNERSHIP
+// ---------------------------------------------------------------------------
+
+func TestGrantOwnership_OnObject(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON DATABASE mydb TO ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.GrantOwnership {
+		t.Errorf("kind = %v, want GrantOwnership", stmt.Kind)
+	}
+	if stmt.On.ObjectType != "DATABASE" || stmt.On.Name.Normalize() != "MYDB" {
+		t.Errorf("target = %q %q", stmt.On.ObjectType, stmt.On.Name.Normalize())
+	}
+	if stmt.CurrentGrants != ast.CurrentGrantsNone {
+		t.Errorf("current grants = %v, want None", stmt.CurrentGrants)
+	}
+}
+
+func TestGrantOwnership_CopyCurrentGrants(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON TABLE mydb.public.mytable TO ROLE analyst COPY CURRENT GRANTS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.CurrentGrants != ast.CurrentGrantsCopy {
+		t.Errorf("current grants = %v, want Copy", stmt.CurrentGrants)
+	}
+}
+
+func TestGrantOwnership_AllTablesCopyCurrentGrants(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON ALL TABLES IN SCHEMA mydb.public TO ROLE analyst COPY CURRENT GRANTS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Kind != ast.GrantTargetAllIn {
+		t.Errorf("target kind = %v, want GrantTargetAllIn", stmt.On.Kind)
+	}
+	if stmt.CurrentGrants != ast.CurrentGrantsCopy {
+		t.Errorf("current grants = %v, want Copy", stmt.CurrentGrants)
+	}
+}
+
+func TestGrantOwnership_RevokeCurrentGrants(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON DATABASE mydb TO ROLE r2 REVOKE CURRENT GRANTS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.CurrentGrants != ast.CurrentGrantsRevoke {
+		t.Errorf("current grants = %v, want Revoke", stmt.CurrentGrants)
+	}
+}
+
+func TestGrantOwnership_ToDatabaseRole(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON ALL TABLES IN SCHEMA mydb.public TO DATABASE ROLE mydb.dr1 COPY CURRENT GRANTS")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeDatabaseRole {
+		t.Errorf("grantee kind = %v, want GranteeDatabaseRole", stmt.Grantee.Kind)
+	}
+}
+
+func TestGrantOwnership_FutureInDatabase(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT OWNERSHIP ON FUTURE TABLES IN DATABASE mydb TO ROLE r2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Kind != ast.GrantTargetFutureIn {
+		t.Errorf("target kind = %v, want GrantTargetFutureIn", stmt.On.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRANT / REVOKE ... TO/FROM SHARE
+// ---------------------------------------------------------------------------
+
+func TestGrantPriv_ToShare(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT USAGE ON DATABASE mydb TO SHARE myshare")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeShare {
+		t.Errorf("grantee kind = %v, want GranteeShare", stmt.Grantee.Kind)
+	}
+	if stmt.Grantee.Name.Normalize() != "MYSHARE" {
+		t.Errorf("grantee = %q, want MYSHARE", stmt.Grantee.Name.Normalize())
+	}
+}
+
+func TestGrantPriv_ToShareAllTablesInSchema(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT ON ALL TABLES IN SCHEMA mydb.public TO SHARE myshare")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.On.Kind != ast.GrantTargetAllIn {
+		t.Errorf("target kind = %v, want GrantTargetAllIn", stmt.On.Kind)
+	}
+	if stmt.Grantee.Kind != ast.GranteeShare {
+		t.Errorf("grantee kind = %v, want GranteeShare", stmt.Grantee.Kind)
+	}
+}
+
+func TestRevokePriv_FromShare(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE USAGE ON DATABASE mydb FROM SHARE myshare")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.RevokePrivileges {
+		t.Errorf("kind = %v, want RevokePrivileges", stmt.Kind)
+	}
+	if stmt.Grantee.Kind != ast.GranteeShare {
+		t.Errorf("grantee kind = %v, want GranteeShare", stmt.Grantee.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// REVOKE <privileges> ON ...
+// ---------------------------------------------------------------------------
+
+func TestRevokePriv_OnAccount(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE CREATE WAREHOUSE ON ACCOUNT FROM ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.RevokePrivileges {
+		t.Errorf("kind = %v, want RevokePrivileges", stmt.Kind)
+	}
+	if stmt.On.Kind != ast.GrantTargetAccount {
+		t.Errorf("target kind = %v, want GrantTargetAccount", stmt.On.Kind)
+	}
+	if stmt.GrantOptionFor {
+		t.Error("expected GrantOptionFor=false")
+	}
+}
+
+func TestRevokePriv_GrantOptionFor(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE GRANT OPTION FOR OPERATE ON WAREHOUSE report_wh FROM ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.GrantOptionFor {
+		t.Error("expected GrantOptionFor=true")
+	}
+	if got := privNames(stmt.Privileges); !eqStrings(got, []string{"OPERATE"}) {
+		t.Errorf("privileges = %v, want [OPERATE]", got)
+	}
+}
+
+func TestRevokePriv_Cascade(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE OPERATE ON WAREHOUSE report_wh FROM ROLE analyst CASCADE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Cascade {
+		t.Error("expected Cascade=true")
+	}
+	if stmt.Restrict {
+		t.Error("expected Restrict=false")
+	}
+}
+
+func TestRevokePriv_Restrict(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE OPERATE ON WAREHOUSE report_wh FROM ROLE analyst RESTRICT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Restrict {
+		t.Error("expected Restrict=true")
+	}
+}
+
+func TestRevokePriv_AllPrivilegesOnFunction(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE ALL PRIVILEGES ON FUNCTION add5(number) FROM ROLE analyst")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.AllPrivileges {
+		t.Error("expected AllPrivileges=true")
+	}
+	if stmt.On.ObjectType != "FUNCTION" {
+		t.Errorf("object type = %q, want FUNCTION", stmt.On.ObjectType)
+	}
+	if !eqStrings(sigNames(stmt.On.Signature), []string{"NUMBER"}) {
+		t.Errorf("signature = %v, want [NUMBER]", sigNames(stmt.On.Signature))
+	}
+}
+
+func TestRevokePriv_FromDatabaseRole(t *testing.T) {
+	stmt, errs := testParseRevokeStmt(t, "REVOKE SELECT ON ALL TABLES IN SCHEMA mydb.myschema FROM DATABASE ROLE mydb.dr1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Grantee.Kind != ast.GranteeDatabaseRole {
+		t.Errorf("grantee kind = %v, want GranteeDatabaseRole", stmt.Grantee.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Position tracking
+// ---------------------------------------------------------------------------
+
+func TestGrant_Position(t *testing.T) {
+	input := "GRANT SELECT ON TABLE t TO ROLE r"
+	stmt, errs := testParseGrantStmt(t, input)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walker integration — the GrantStmt's children must be reachable.
+// ---------------------------------------------------------------------------
+
+func TestGrant_WalkerVisitsChildren(t *testing.T) {
+	stmt, errs := testParseGrantStmt(t, "GRANT SELECT ON TABLE mydb.s.t TO ROLE r")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	var objectNames int
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if _, ok := n.(*ast.ObjectName); ok {
+			objectNames++
+		}
+		return true
+	})
+	// Expect at least the ON target name and the grantee name.
+	if objectNames < 2 {
+		t.Errorf("walker visited %d ObjectName nodes, want >= 2", objectNames)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — malformed GRANT/REVOKE must be rejected.
+// ---------------------------------------------------------------------------
+
+func TestGrant_Negative(t *testing.T) {
+	cases := []string{
+		"GRANT",                                   // nothing after GRANT
+		"GRANT SELECT ON TABLE t",                 // missing TO grantee
+		"GRANT SELECT ON TABLE t TO",              // TO with no grantee
+		"GRANT ROLE r TO",                         // role grant missing grantee
+		"GRANT ROLE r TO ROLE",                    // grantee keyword with no name
+		"GRANT SELECT TABLE t TO ROLE r",          // missing ON
+		"GRANT OWNERSHIP TO ROLE r",               // ownership missing ON
+		"GRANT SELECT ON ALL TABLES TO ROLE r",    // ALL ... missing IN container
+		"GRANT SELECT ON FUTURE TABLES TO ROLE r", // FUTURE ... missing IN container
+		"GRANT SELECT ON ALL TABLES IN TO ROLE r", // IN with no DATABASE/SCHEMA
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			result := ParseBestEffort(c)
+			if len(result.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got none (stmts=%d)", c, len(result.File.Stmts))
+			}
+		})
+	}
+}
+
+func TestRevoke_Negative(t *testing.T) {
+	cases := []string{
+		"REVOKE",                        // nothing after REVOKE
+		"REVOKE SELECT ON TABLE t",      // missing FROM grantee
+		"REVOKE SELECT ON TABLE t FROM", // FROM with no grantee
+		"REVOKE ROLE r FROM",            // role revoke missing grantee
+		"REVOKE GRANT OPTION FOR",       // GRANT OPTION FOR with nothing else
+		"REVOKE SELECT FROM ROLE r",     // missing ON
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			result := ParseBestEffort(c)
+			if len(result.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got none (stmts=%d)", c, len(result.File.Stmts))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official documentation corpus — every GRANT/REVOKE example must parse with
+// zero errors. These corpora are the authoritative oracle (truth1).
+// ---------------------------------------------------------------------------
+
+// grantCorpusDirs are the official-docs corpora that consist solely of
+// GRANT/REVOKE statements (plus benign USE/CREATE/INSERT/SELECT context lines,
+// which are filtered out below since those nodes belong to other DAG nodes).
+var grantCorpusDirs = []string{
+	"testdata/official/grant-role",
+	"testdata/official/grant-ownership",
+	"testdata/official/grant-privilege",
+	"testdata/official/revoke-privilege",
+}
+
+func TestGrantRevoke_OfficialCorpus(t *testing.T) {
+	for _, dir := range grantCorpusDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read corpus dir %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			t.Run(path, func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				assertGrantRevokeStatementsParse(t, string(data))
+			})
+		}
+	}
+}
+
+func TestGrantRevoke_LegacyCorpus(t *testing.T) {
+	path := "testdata/legacy/grant.sql"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	assertGrantRevokeStatementsParse(t, string(data))
+}
+
+// assertGrantRevokeStatementsParse parses sql and asserts that every GRANT and
+// REVOKE statement in it parses with no errors attributable to that statement.
+// Non-GRANT/REVOKE context statements (USE, CREATE, INSERT, SELECT) are checked
+// per-segment so that an unimplemented sibling statement type does not mask a
+// real GRANT/REVOKE failure.
+func assertGrantRevokeStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	segs := Split(sql)
+	for _, seg := range segs {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+		isGrant := strings.HasPrefix(upper, "GRANT")
+		isRevoke := strings.HasPrefix(upper, "REVOKE")
+		if !isGrant && !isRevoke {
+			continue // context statement owned by another DAG node
+		}
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+		}
+		if isGrant {
+			if _, ok := node.(*ast.GrantStmt); !ok {
+				t.Errorf("statement %q did not parse to *ast.GrantStmt (got %T)", text, node)
+			}
+		}
+		if isRevoke {
+			if _, ok := node.(*ast.RevokeStmt); !ok {
+				t.Errorf("statement %q did not parse to *ast.RevokeStmt (got %T)", text, node)
+			}
+		}
+	}
+}

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -227,9 +227,9 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// DCL (2 cases)
 	case kwGRANT:
-		return p.unsupported("GRANT")
+		return p.parseGrantStmt()
 	case kwREVOKE:
-		return p.unsupported("REVOKE")
+		return p.parseRevokeStmt()
 
 	// TCL (4 cases)
 	case kwBEGIN:


### PR DESCRIPTION
## Node
`snowflake/dcl-grant` (v1 DAG **T6.1**) — DCL: GRANT / REVOKE for the hand-written omni Snowflake parser. Depends on `snowflake/parser-foundation` (done).

## What this implements
GRANT and REVOKE in every documented shape:

- **Role grants** — `GRANT [DATABASE | APPLICATION] ROLE <name> TO { [ROLE] | DATABASE ROLE | USER | APPLICATION ROLE | APPLICATION } <name>`; `REVOKE` mirror.
- **Privilege grants** — `GRANT { <privileges> | ALL [PRIVILEGES] } ON <target> TO <grantee> [WITH GRANT OPTION]`; `REVOKE [GRANT OPTION FOR] ... FROM <grantee> [CASCADE | RESTRICT]`.
- **ON targets** — `ON ACCOUNT` · `ON <object_type> <name> [ ( signature ) ]` · `ON ALL <plural> IN { DATABASE | SCHEMA } <name>` · `ON FUTURE <plural> IN { DATABASE | SCHEMA } <name>`.
- **GRANT OWNERSHIP** — `... TO { ROLE | DATABASE ROLE } <name> [ { REVOKE | COPY } CURRENT GRANTS ]`.
- **Shares** — `GRANT <priv> ON <target> TO SHARE <name>` / `REVOKE ... FROM SHARE <name>`.

## Design decision — docs-authoritative, open-ended (not the legacy enum)
The official Snowflake docs (truth1) are authoritative; the legacy ANTLR grammar (truth2) enumerated a **fixed** privilege / object-type list that the official-docs corpus **already exceeds** — e.g. `ON NOTEBOOK`, `ON WORKSPACE`, `ON COMPUTE POOL`, `ON EXTERNAL VOLUME`, `ON CORTEX SEARCH SERVICE`, `ON DATA METRIC FUNCTION`, `CREATE PROVISIONED THROUGHPUT`, `CREATE SNOWFLAKE.CORE.BUDGET`, `WRITE` / `READ`. Several of these tokenize as bare identifiers, not keywords.

So privileges and object types are parsed as **open-ended token runs**:
- a **privilege** is a run of name words (dotted for class privileges like `SNOWFLAKE.CORE.BUDGET`); the list ends at `ON`;
- the **ON object type vs. object name** split is purely **structural** — the ON target is a sequence of space-separated *name units* (each a dotted identifier path), the **last** unit is the object name and every preceding unit forms the object type. No fixed vocabulary ⇒ new Snowflake object types (`STORAGE LIFECYCLE POLICY`, `GIT REPOSITORY`, …) parse without code changes;
- **function/procedure signatures** reuse `parseDataType()`, so `NUMBER(38,0)`, `VARCHAR(100)`, `DOUBLE PRECISION` work.

Validating that a privilege is legal for a given object is deferred to the catalog/semantic layer, not the parser.

## AST (snowflake/ast)
New nodes: `GrantStmt`, `RevokeStmt`, `Grantee`, `GrantTarget` (+ `Privilege`, `GrantedRoleKind`, `GranteeKind`, `GrantTargetKind`, `CurrentGrantsAction` helpers). New `NodeTag`s; `walk_generated.go` regenerated via `genwalker` (no hand-edits).

## Oracle & evidence (triangulation — no executable Snowflake oracle)
- **Official docs** (authoritative): grant-privilege, grant-role, grant-database-role, grant-application-role, grant-ownership, grant-privilege-share, revoke-privilege, revoke-role. Grammar skeletons quoted and matched.
- **Legacy ANTLR** `SnowflakeParser.g4` grant/revoke rules (regression / scope baseline).
- **Corpus that must parse clean** (wired into tests): `testdata/official/{grant-role, grant-ownership, grant-privilege, revoke-privilege}` (all 48 example files) + `testdata/legacy/grant.sql`.

## Coverage — 142 test cases, all green
`go test ./snowflake/parser/... ./snowflake/ast/...` ✓
- Every official-docs corpus GRANT/REVOKE statement parses with **0 errors** and to the right node type (context lines like `USE` / `CREATE` filtered per-segment so unimplemented siblings don't mask failures).
- Role / database-role / application-role grants + revokes; every grantee kind.
- Privilege lists (single, multi, multi-word, dotted-class), `ALL [PRIVILEGES]`, `ON ACCOUNT`.
- All multi-word object types incl. 3-word (`CORTEX SEARCH SERVICE`, `DATA METRIC FUNCTION`, `STORAGE LIFECYCLE POLICY`) and identifier-led (`COMPUTE POOL`, `EXTERNAL VOLUME`, `NETWORK RULE`).
- `ALL/FUTURE <plural> IN DATABASE|SCHEMA`; OWNERSHIP `{REVOKE|COPY} CURRENT GRANTS`; `WITH GRANT OPTION`; `GRANT OPTION FOR`; `CASCADE` / `RESTRICT`; parameterized + empty signatures; share grants/revokes.
- **Negative tests**: malformed GRANT/REVOKE (missing ON/TO/FROM/grantee/IN container, quoted-name-as-type) are rejected.
- Walker integration + position-span assertions.

## Divergences from legacy ANTLR (docs win; all flagged)
1. **Open-ended privileges & object types** vs. the legacy fixed enums. Evidence: the official corpus contains forms outside the `.g4` enums (`ON NOTEBOOK/WORKSPACE/COMPUTE POOL/CORTEX SEARCH SERVICE`, `CREATE PROVISIONED THROUGHPUT`, `CREATE SNOWFLAKE.CORE.BUDGET`). Docs are authoritative ⇒ permissive parse; semantic validation deferred. **Confirmed.**
2. **`DATABASE ROLE` / `APPLICATION ROLE` grantees and granted roles**, and **`TO APPLICATION`** — present in docs (grant-role, grant-database-role, grant-application-role), absent/partial in the `.g4` (`ROLE` / `USER` only). **Confirmed** against docs.
3. The legacy `grant_to_role` split privileges into `global / account_object / schema / schema_object` sub-rules tied to specific object types; this parser does not enforce that coupling (an over-restrictive, already-stale classification). Per docs + the divergence policy, the parser stays permissive. **Flagged.**

## Out-of-scope note for the orchestrator
A Codex reviewer flagged that trailing garbage after a valid statement is silently ignored (e.g. `REVOKE … CASCADE RESTRICT` keeps `CASCADE`, drops `RESTRICT`). This is **pre-existing parser-foundation behavior** shared by every statement type — `DROP TABLE t GARBAGE` likewise parses with 0 errors, because `parseSingle` (owned by `parser-foundation`, out of this node's writes-scope) does not enforce trailing-EOF. GRANT/REVOKE intentionally match the established framework behavior rather than become uniquely strict. Recommend a separate `parser-foundation` node if strict-EOF is desired engine-wide.

## Review
Two-reviewer cross-family gate (Claude lens + Codex lens, blind). Codex's first pass surfaced 5 blockers (APPLICATION ROLE dispatch, fixed-vocabulary object types, single-word signatures, EOF behavior); the first four were fixed (the redesign above), the EOF one rebutted with evidence and flagged. Re-review found no surviving blockers. The Claude lens line-by-line pass found and fixed one bug (a quoted object name spelling a type-connector word, e.g. `ON TABLE "VIEW"`, was wrongly absorbed into the type — now structural and correct; regression test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
