### PR TITLE
feat(trino/parser): parser entry, split, diagnose, identifiers (v2 node parser-foundation)

### DIFF
--- a/trino/parser/diagnose.go
+++ b/trino/parser/diagnose.go
@@ -1,0 +1,35 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// Diagnostic represents one syntax diagnostic (error) with its source position.
+// It is the parser-facing shape that bytebase's Diagnose handler maps to LSP
+// diagnostics, converting Loc byte offsets to line/column against the source.
+type Diagnostic struct {
+	Msg string
+	Loc ast.Loc
+}
+
+// Diagnose parses input and returns every syntax error as a Diagnostic. It
+// drives the public Parse, so it inherits Parse's best-effort behavior: errors
+// from every statement segment are collected (not just the first), and
+// LexErrors promoted during parsing are included.
+//
+// This backs bytebase's RegisterDiagnoseFunc consumer, which runs on every
+// editor keystroke and must not emit false positives for valid Trino. While
+// statement bodies are stubbed in the parser-foundation node, syntactically
+// valid statements still produce a "not yet supported" diagnostic; those
+// disappear as later DAG nodes (types, expressions, select, ddl, dml, …)
+// implement real statement parsing. Genuine lexer errors (unterminated
+// string/identifier/comment) and unknown-statement errors are always reported.
+func Diagnose(input string) []Diagnostic {
+	_, errs := Parse(input)
+	if len(errs) == 0 {
+		return nil
+	}
+	diags := make([]Diagnostic, len(errs))
+	for i, e := range errs {
+		diags[i] = Diagnostic{Msg: e.Msg, Loc: e.Loc}
+	}
+	return diags
+}

--- a/trino/parser/diagnose_test.go
+++ b/trino/parser/diagnose_test.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiagnose_CleanInputNoStubNoise verifies the wiring shape: Diagnose runs
+// Parse and surfaces ParseErrors as Diagnostics. While statement bodies are
+// stubbed, even valid SQL yields a "not yet supported" diagnostic — those
+// vanish as later DAG nodes implement real parsing. This test asserts the
+// count/shape relationship, not zero diagnostics.
+func TestDiagnose_StubbedStatementProducesDiagnostic(t *testing.T) {
+	diags := Diagnose("SELECT 1")
+	if len(diags) != 1 {
+		t.Fatalf("got %d diagnostics, want 1: %+v", len(diags), diags)
+	}
+	if !strings.Contains(diags[0].Msg, "not yet supported") {
+		t.Errorf("Msg = %q, want 'not yet supported'", diags[0].Msg)
+	}
+}
+
+// TestDiagnose_LexError verifies a lexer error (unterminated string) surfaces
+// as a diagnostic with a position.
+func TestDiagnose_LexError(t *testing.T) {
+	diags := Diagnose("SELECT 'oops")
+	if len(diags) == 0 {
+		t.Fatal("want at least one diagnostic for unterminated string, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Msg, "unterminated string") {
+			found = true
+			if !d.Loc.IsValid() {
+				t.Errorf("diagnostic %q has invalid Loc %+v", d.Msg, d.Loc)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("diagnostics = %+v, want one mentioning 'unterminated string'", diags)
+	}
+}
+
+// TestDiagnose_EmptyInput verifies clean empty input yields no diagnostics.
+func TestDiagnose_EmptyInput(t *testing.T) {
+	if diags := Diagnose("   \n-- c\n"); len(diags) != 0 {
+		t.Errorf("got %+v, want no diagnostics", diags)
+	}
+}
+
+// TestDiagnose_MultipleStatements verifies diagnostics are collected across all
+// segments (each stubbed statement yields its own).
+func TestDiagnose_MultipleStatements(t *testing.T) {
+	diags := Diagnose("SELECT 1; INSERT INTO t VALUES (1); DELETE FROM t")
+	if len(diags) != 3 {
+		t.Fatalf("got %d diagnostics, want 3: %+v", len(diags), diags)
+	}
+}
+
+// TestDiagnose_UnknownStatement verifies an unrecognized leading token yields
+// an "unknown or unsupported statement" diagnostic (distinct from the
+// "not yet supported" stub message).
+func TestDiagnose_UnknownStatement(t *testing.T) {
+	diags := Diagnose("FROBNICATE foo")
+	if len(diags) != 1 {
+		t.Fatalf("got %d diagnostics, want 1: %+v", len(diags), diags)
+	}
+	if !strings.Contains(diags[0].Msg, "unknown or unsupported statement") {
+		t.Errorf("Msg = %q, want 'unknown or unsupported statement'", diags[0].Msg)
+	}
+}

--- a/trino/parser/errors.go
+++ b/trino/parser/errors.go
@@ -1,0 +1,25 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// ParseError describes a single parse error with its source location.
+//
+// Loc uses the same {Start,End} byte-offset shape as LexError (tokens.go) so
+// consumers can handle lex and parse failures uniformly. Line/column
+// conversion is a caller-side concern; bytebase's Diagnose maps Loc.Start back
+// to a (line, col) pair against the original source.
+//
+// ParseError is a pure data carrier: Error returns just the message. This
+// mirrors snowflake/parser.ParseError and doris/parser.ParseError so the omni
+// parser family stays uniform across engines.
+type ParseError struct {
+	Loc ast.Loc
+	Msg string
+}
+
+// Error implements the error interface, returning the message only. Callers
+// that want a formatted "msg (line N, col M)" string convert Loc.Start with a
+// line table.
+func (e *ParseError) Error() string {
+	return e.Msg
+}

--- a/trino/parser/errors_test.go
+++ b/trino/parser/errors_test.go
@@ -1,0 +1,25 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// TestParseError_Error verifies ParseError implements error by returning its
+// message verbatim, leaving line/column conversion to a caller-side LineTable.
+func TestParseError_Error(t *testing.T) {
+	pe := &ParseError{Loc: ast.Loc{Start: 7, End: 13}, Msg: "syntax error at or near FROM"}
+	if got := pe.Error(); got != "syntax error at or near FROM" {
+		t.Fatalf("ParseError.Error() = %q, want %q", got, "syntax error at or near FROM")
+	}
+}
+
+// TestParseError_IsErrorInterface verifies *ParseError satisfies the error
+// interface so Parse can return it polymorphically.
+func TestParseError_IsErrorInterface(t *testing.T) {
+	var err error = &ParseError{Msg: "boom"}
+	if err.Error() != "boom" {
+		t.Fatalf("error.Error() = %q, want %q", err.Error(), "boom")
+	}
+}

--- a/trino/parser/identifiers.go
+++ b/trino/parser/identifiers.go
@@ -1,0 +1,190 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file implements Trino's `identifier` and `qualifiedName` grammar rules
+// over the token stream, plus the exported name helpers bytebase's parser
+// consumers rely on (NormalizeTrinoIdentifier, ExtractQualifiedNameParts).
+//
+// Trino's grammar:
+//
+//	identifier
+//	    : IDENTIFIER_            # unquotedIdentifier
+//	    | QUOTED_IDENTIFIER_     # quotedIdentifier
+//	    | nonReserved            # unquotedIdentifier
+//	    | BACKQUOTED_IDENTIFIER_ # backQuotedIdentifier
+//	    | DIGIT_IDENTIFIER_      # digitIdentifier
+//	    ;
+//	qualifiedName : identifier (DOT_ identifier)* ;
+//
+// Three oracle-adjudicated divergences from a literal reading of that rule are
+// baked in (see the migration divergence ledger):
+//
+//  1. DIGIT_IDENTIFIER_ (e.g. 1abc) is NOT accepted, despite the grammar
+//     alternative: Trino 481 rejects unquoted digit-leading identifiers in
+//     every position (table/column/dotted), so isIdentifierStart excludes
+//     tokDigitIdent. A digit-leading name must be double-quoted.
+//  2. BACKQUOTED_IDENTIFIER_ (`backtick` quoting) is NOT accepted, despite the
+//     grammar alternative: Trino 481 rejects backtick-quoted identifiers
+//     everywhere (only "double-quotes" are valid identifier quoting). The lexer
+//     still tokenizes backticks (tokBackquotedIdent) — that is the lexer node's
+//     concern — but the grammar rejects them, so isIdentifierStart excludes it.
+//  3. qualifiedName applies the SAME identifier rule to every part — a reserved
+//     keyword is rejected as a name part whether it is first or follows a dot.
+//     (doris/snowflake accept reserved words post-dot; Trino does not.)
+
+// isIdentifierStart reports whether kind may begin an identifier per Trino's
+// `identifier` rule, as adjudicated by the Trino 481 oracle:
+//   - tokIdent: unquoted IDENTIFIER_
+//   - tokQuotedIdent: "double-quoted" QUOTED_IDENTIFIER_
+//   - a non-reserved keyword (kind >= 700 && !IsReserved)
+//
+// tokDigitIdent and tokBackquotedIdent are deliberately excluded — Trino 481
+// rejects both despite their presence in the legacy grammar. See the file
+// header divergence notes.
+func isIdentifierStart(kind TokenKind) bool {
+	switch kind {
+	case tokIdent, tokQuotedIdent:
+		return true
+	default:
+		return kind >= 700 && !IsReserved(kind)
+	}
+}
+
+// identFromToken builds an ast.Identifier from a token already confirmed to be
+// an identifier start (per isIdentifierStart). A double-quoted token carries
+// the '"' quote rune; bare and non-reserved-keyword tokens are unquoted.
+func identFromToken(tok Token) *ast.Identifier {
+	if tok.Kind == tokQuotedIdent {
+		return &ast.Identifier{Value: tok.Str, Quoted: true, QuoteRune: '"', Loc: tok.Loc}
+	}
+	// tokIdent or a non-reserved keyword: unquoted, source text in Str.
+	return &ast.Identifier{Value: tok.Str, Quoted: false, Loc: tok.Loc}
+}
+
+// parseIdentifier parses one identifier (Trino's `identifier` rule) and returns
+// it as an *ast.Identifier. Returns a *ParseError if the current token is not a
+// valid identifier start.
+//
+// Quoting metadata is preserved so callers can normalize per Trino's rules
+// (case-insensitive for unquoted, case-sensitive for quoted) via
+// ast.Identifier.Normalize.
+func (p *Parser) parseIdentifier() (*ast.Identifier, error) {
+	if !isIdentifierStart(p.cur.Kind) {
+		return nil, p.identifierError()
+	}
+	return identFromToken(p.advance()), nil
+}
+
+// identifierError returns a *ParseError describing a missing identifier at the
+// current token, with a message distinct from the generic syntax error so
+// diagnostics are actionable.
+func (p *Parser) identifierError() *ParseError {
+	if p.cur.Kind == tokEOF {
+		return &ParseError{Loc: p.cur.Loc, Msg: "expected identifier, found end of input"}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Kind)
+	}
+	return &ParseError{Loc: p.cur.Loc, Msg: "expected identifier, found " + text}
+}
+
+// parseQualifiedName parses a dot-separated chain of identifiers (Trino's
+// `qualifiedName` rule) and returns an *ast.QualifiedName. Every part is parsed
+// with the same identifier rule, so a reserved keyword is rejected in every
+// position (see the file header divergence note).
+//
+// A '.' inside a qualifiedName always commits to another part: once the dot is
+// consumed, a valid identifier MUST follow, otherwise parsing errors. This
+// matches Trino, which rejects `s.from` / `t.1abc` (reserved or digit-leading
+// name part) with a syntax error rather than stopping at the first part. The
+// all-columns form `t.*` is a separate primaryExpression rule, not a
+// qualifiedName, so it never reaches here.
+func (p *Parser) parseQualifiedName() (*ast.QualifiedName, error) {
+	first, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	qn := &ast.QualifiedName{
+		Parts: []*ast.Identifier{first},
+		Loc:   first.Loc,
+	}
+	for p.cur.Kind == int('.') {
+		p.advance() // consume '.' — an identifier must follow
+		part, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		qn.Parts = append(qn.Parts, part)
+		qn.Loc.End = part.Loc.End
+	}
+	return qn, nil
+}
+
+// NormalizeTrinoIdentifier returns the canonical form of a single Trino
+// identifier given its raw source spelling (with or without surrounding
+// quotes). A "double-quoted" identifier has its surrounding quotes removed and
+// its case preserved; any other spelling folds to lower case (Trino unquoted
+// identifiers are case-insensitive).
+//
+// This is a byte-for-byte port of the legacy bytebase NormalizeTrinoIdentifier
+// helper so the bytebase consumers (lineage, completion, data-access-control
+// name resolution) compare names exactly as before. In particular it
+// intentionally matches legacy by:
+//   - stripping ONLY surrounding double-quotes (a backtick-quoted spelling is
+//     lower-cased whole — backticks are not valid Trino identifier quoting
+//     anyway; see the divergence ledger), and
+//   - NOT collapsing a doubled-quote ("") escape, mirroring legacy's plain
+//     slice of the inter-quote bytes.
+//
+// Callers that have an already-lexed token should use ast.Identifier.Normalize
+// instead, which collapses the "" escape from the decoded Value.
+func NormalizeTrinoIdentifier(raw string) string {
+	if strings.HasPrefix(raw, `"`) && strings.HasSuffix(raw, `"`) && len(raw) >= 2 {
+		return raw[1 : len(raw)-1]
+	}
+	return strings.ToLower(raw)
+}
+
+// ExtractQualifiedNameParts parses a dotted name string and returns its
+// per-component normalized parts (see ast.QualifiedName.NormalizedParts). It is
+// the string-input counterpart of parseQualifiedName, for callers (catalog
+// lookups, lineage) that hold a name string rather than a token stream. Mirrors
+// the legacy bytebase ExtractQualifiedNameParts helper.
+func ExtractQualifiedNameParts(input string) ([]string, error) {
+	qn, errs := ParseQualifiedName(input)
+	if len(errs) > 0 {
+		return nil, &errs[0]
+	}
+	return qn.NormalizedParts(), nil
+}
+
+// ParseQualifiedName parses a complete qualified name from a standalone string,
+// returning the *ast.QualifiedName and any ParseErrors. Trailing tokens after
+// the name are reported as an error. Useful for catalog lookups and tests that
+// have a name string but no token stream.
+func ParseQualifiedName(input string) (*ast.QualifiedName, []ParseError) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+
+	qn, err := p.parseQualifiedName()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+	if p.cur.Kind != tokEOF {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Kind)
+		}
+		return qn, []ParseError{{Loc: p.cur.Loc, Msg: "unexpected token after qualified name: " + text}}
+	}
+	return qn, nil
+}

--- a/trino/parser/identifiers_test.go
+++ b/trino/parser/identifiers_test.go
@@ -1,0 +1,237 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// parseIdentFrom is a tiny harness: it lexes input, primes a Parser, and runs
+// the given parse method, returning the result and the parser so callers can
+// inspect the trailing token.
+func newParserForTest(input string) *Parser {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	return p
+}
+
+// TestParseIdentifier_Bare verifies an unquoted identifier parses with Quoted
+// false and case preserved.
+func TestParseIdentifier_Bare(t *testing.T) {
+	p := newParserForTest("MyCol")
+	id, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("parseIdentifier: %v", err)
+	}
+	if id.Value != "MyCol" || id.Quoted {
+		t.Errorf("got {Value:%q Quoted:%v}, want {MyCol false}", id.Value, id.Quoted)
+	}
+	if id.Loc.Start != 0 || id.Loc.End != 5 {
+		t.Errorf("Loc = %+v, want [0,5)", id.Loc)
+	}
+}
+
+// TestParseIdentifier_DoubleQuoted verifies a "double-quoted" identifier parses
+// with Quoted true, QuoteRune '"', and the surrounding quotes stripped.
+func TestParseIdentifier_DoubleQuoted(t *testing.T) {
+	p := newParserForTest(`"My Col"`)
+	id, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("parseIdentifier: %v", err)
+	}
+	if id.Value != "My Col" || !id.Quoted || id.QuoteRune != '"' {
+		t.Errorf("got {Value:%q Quoted:%v Quote:%q}, want {My Col true \"}", id.Value, id.Quoted, string(id.QuoteRune))
+	}
+}
+
+// TestParseIdentifier_BackquotedRejected verifies a `backtick`-quoted token is
+// REJECTED as an identifier. The legacy grammar lists BACKQUOTED_IDENTIFIER_,
+// and the lexer still tokenizes it, but Trino 481 rejects backtick quoting
+// everywhere (oracle-confirmed: `SELECT * FROM `+"`bt table`"+` SYNTAX_ERROR).
+// Only "double-quotes" are valid identifier quoting. See divergence ledger.
+func TestParseIdentifier_BackquotedRejected(t *testing.T) {
+	p := newParserForTest("`bt col`")
+	if _, err := p.parseIdentifier(); err == nil {
+		t.Fatal("parseIdentifier(`bt col`): want error (backtick rejected by Trino 481), got nil")
+	}
+}
+
+// TestParseIdentifier_NonReservedKeyword verifies a non-reserved keyword (e.g.
+// ZONE) is accepted as an identifier in the first position. The legacy
+// non_reserved.sql example "SELECT zone FROM t" exercises exactly this.
+func TestParseIdentifier_NonReservedKeyword(t *testing.T) {
+	p := newParserForTest("zone")
+	id, err := p.parseIdentifier()
+	if err != nil {
+		t.Fatalf("parseIdentifier(zone): %v", err)
+	}
+	if id.Value != "zone" || id.Quoted {
+		t.Errorf("got {Value:%q Quoted:%v}, want {zone false}", id.Value, id.Quoted)
+	}
+}
+
+// TestParseIdentifier_ReservedKeywordRejected verifies a reserved keyword (e.g.
+// FROM) is NOT accepted as a bare identifier in the first position.
+func TestParseIdentifier_ReservedKeywordRejected(t *testing.T) {
+	p := newParserForTest("from")
+	if _, err := p.parseIdentifier(); err == nil {
+		t.Fatal("parseIdentifier(from): want error (FROM is reserved), got nil")
+	}
+}
+
+// TestParseIdentifier_DigitLeadingRejected verifies a digit-leading identifier
+// (DIGIT_IDENTIFIER_, e.g. 1abc) is REJECTED in identifier position. Although
+// the legacy TrinoParser.g4 `identifier` rule lists DIGIT_IDENTIFIER_ as an
+// alternative, Trino 481 rejects unquoted digit-leading identifiers everywhere
+// (oracle-confirmed: `SELECT * FROM 1abc`, `CREATE TABLE 1abc (x int)`,
+// `SELECT t.1abc FROM t` all SYNTAX_ERROR). See divergence ledger.
+func TestParseIdentifier_DigitLeadingRejected(t *testing.T) {
+	p := newParserForTest("1abc")
+	if _, err := p.parseIdentifier(); err == nil {
+		t.Fatal("parseIdentifier(1abc): want error (digit-leading rejected by Trino 481), got nil")
+	}
+}
+
+// TestParseQualifiedName_OnePart verifies a single-part name.
+func TestParseQualifiedName_OnePart(t *testing.T) {
+	p := newParserForTest("orders")
+	qn, err := p.parseQualifiedName()
+	if err != nil {
+		t.Fatalf("parseQualifiedName: %v", err)
+	}
+	if got := qn.Normalize(); got != "orders" {
+		t.Errorf("Normalize = %q, want %q", got, "orders")
+	}
+	if len(qn.Parts) != 1 {
+		t.Errorf("len(Parts) = %d, want 1", len(qn.Parts))
+	}
+}
+
+// TestParseQualifiedName_ThreeParts verifies catalog.schema.table with mixed
+// quoting normalizes correctly (unquoted lowered, quoted preserved).
+func TestParseQualifiedName_ThreeParts(t *testing.T) {
+	p := newParserForTest(`Cat."My Schema".TBL`)
+	qn, err := p.parseQualifiedName()
+	if err != nil {
+		t.Fatalf("parseQualifiedName: %v", err)
+	}
+	if len(qn.Parts) != 3 {
+		t.Fatalf("len(Parts) = %d, want 3", len(qn.Parts))
+	}
+	if got := qn.Normalize(); got != "cat.My Schema.tbl" {
+		t.Errorf("Normalize = %q, want %q", got, "cat.My Schema.tbl")
+	}
+}
+
+// TestParseQualifiedName_ReservedAfterDotRejected verifies a reserved keyword
+// is REJECTED as a qualifiedName part even after a dot. Trino's grammar is
+// `qualifiedName : identifier (DOT_ identifier)*` and `identifier` has no
+// reserved-word alternative, so reserved words are rejected in every position
+// (oracle-confirmed: `SELECT s.from FROM t`, `SELECT id FROM public.order`
+// both SYNTAX_ERROR). This is unlike doris/snowflake, which accept reserved
+// words post-dot. See divergence ledger.
+func TestParseQualifiedName_ReservedAfterDotRejected(t *testing.T) {
+	p := newParserForTest("s.from")
+	if _, err := p.parseQualifiedName(); err == nil {
+		t.Fatal("parseQualifiedName(s.from): want error (FROM reserved, rejected as name part), got nil")
+	}
+}
+
+// TestParseQualifiedName_NonReservedAfterDot verifies a non-reserved keyword
+// (ZONE) IS accepted as a dotted name part (oracle: `SELECT t.zone FROM t`
+// ACCEPT).
+func TestParseQualifiedName_NonReservedAfterDot(t *testing.T) {
+	p := newParserForTest("t.zone")
+	qn, err := p.parseQualifiedName()
+	if err != nil {
+		t.Fatalf("parseQualifiedName(t.zone): %v", err)
+	}
+	if got := qn.Normalize(); got != "t.zone" {
+		t.Errorf("Normalize = %q, want %q", got, "t.zone")
+	}
+}
+
+// TestNormalizeTrinoIdentifier verifies the exported normalizer is a faithful
+// port of the legacy bytebase helper: unquoted (and backtick) spellings fold to
+// lower case, only surrounding double-quotes are stripped (case preserved), and
+// a doubled-quote escape is NOT collapsed (legacy slices the inter-quote bytes
+// verbatim).
+func TestNormalizeTrinoIdentifier(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"MyCol", "mycol"},
+		{`"MyCol"`, "MyCol"},
+		{"UPPER", "upper"},
+		{`"keep THIS"`, "keep THIS"},
+		// Legacy parity: backticks are NOT stripped (not valid Trino quoting);
+		// the whole spelling is lower-cased.
+		{"`MyCol`", "`mycol`"},
+		// Legacy parity: the "" escape is left as-is, not collapsed to ".
+		{`"a""b"`, `a""b`},
+	}
+	for _, c := range cases {
+		if got := NormalizeTrinoIdentifier(c.in); got != c.want {
+			t.Errorf("NormalizeTrinoIdentifier(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestExtractQualifiedNameParts verifies the exported helper splits a dotted
+// name into normalized parts, handling quoting per Trino rules. Mirrors the
+// legacy bytebase ExtractQualifiedNameParts helper.
+func TestExtractQualifiedNameParts(t *testing.T) {
+	parts, err := ExtractQualifiedNameParts(`Cat."My Schema".TBL`)
+	if err != nil {
+		t.Fatalf("ExtractQualifiedNameParts: %v", err)
+	}
+	want := []string{"cat", "My Schema", "tbl"}
+	if len(parts) != len(want) {
+		t.Fatalf("got %v, want %v", parts, want)
+	}
+	for i := range want {
+		if parts[i] != want[i] {
+			t.Errorf("part %d = %q, want %q", i, parts[i], want[i])
+		}
+	}
+}
+
+// TestParseQualifiedNameString verifies the standalone ParseQualifiedName entry
+// returns a node whose String() is source-faithful (re-quoting preserved).
+func TestParseQualifiedNameString(t *testing.T) {
+	qn, errs := ParseQualifiedName(`a."B c".d`)
+	if len(errs) != 0 {
+		t.Fatalf("ParseQualifiedName: %v", errs)
+	}
+	if got := qn.String(); got != `a."B c".d` {
+		t.Errorf("String = %q, want %q", got, `a."B c".d`)
+	}
+}
+
+// TestParseQualifiedName_TrailingTokens verifies ParseQualifiedName reports an
+// error when input has tokens after the name.
+func TestParseQualifiedName_TrailingTokens(t *testing.T) {
+	_, errs := ParseQualifiedName("a b")
+	if len(errs) == 0 {
+		t.Fatal("ParseQualifiedName(\"a b\"): want trailing-token error, got none")
+	}
+}
+
+// TestParseQualifiedName_LocSpansAllParts checks the qualified-name Loc covers
+// from the first part start to the last part end.
+func TestParseQualifiedName_LocSpansAllParts(t *testing.T) {
+	in := "cat.sch.tbl"
+	p := newParserForTest(in)
+	qn, err := p.parseQualifiedName()
+	if err != nil {
+		t.Fatalf("parseQualifiedName: %v", err)
+	}
+	if qn.Loc.Start != 0 || qn.Loc.End != len(in) {
+		t.Errorf("Loc = %+v, want [0,%d)", qn.Loc, len(in))
+	}
+	if !qn.Loc.IsValid() {
+		t.Error("Loc should be valid")
+	}
+	_ = ast.NoLoc()
+}

--- a/trino/parser/oracle_foundation_test.go
+++ b/trino/parser/oracle_foundation_test.go
@@ -1,0 +1,287 @@
+package parser
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bytebase/omni/trino/internal/trinooracle"
+)
+
+// This file is the parser-foundation node's slice of the differential-oracle
+// gate (correctness-protocol.md). The foundation ships the parser entry point,
+// the statement splitter, identifier/qualifiedName parsing, and diagnostics —
+// but every *statement body* is still stubbed (parseStmt routes to
+// unsupported), so a naive "omni Parse accept == Trino accept" differential is
+// not yet meaningful: omni rejects every valid statement with "not yet
+// supported" until later DAG nodes implement the bodies.
+//
+// What the foundation CAN adjudicate against the live oracle, and does here:
+//
+//  1. Identifier / qualifiedName accept-reject. This is the only grammar the
+//     foundation actually decides. For each candidate name we compare
+//     ParseQualifiedName's verdict to Trino's verdict for the name used in an
+//     unambiguous qualifiedName position (`SELECT * FROM <name>`). Both
+//     positive and negative (reserved/digit-leading) cases are covered, as the
+//     protocol requires.
+//  2. Splitter round-trip. For multi-statement inputs, each segment Split
+//     produces must be a statement Trino accepts on its own — proving Split
+//     cut on real statement boundaries and never mid-statement (including
+//     inside string/comment/quoted-identifier and a CREATE FUNCTION routine
+//     body).
+//  3. Robustness. Parse/Diagnose must terminate without panic on every
+//     accepted corpus statement and never invent a lex error there.
+//
+// All oracle-backed subtests skip cleanly when no Trino is reachable, matching
+// the harness convention; the robustness sweep runs oracle-free too.
+
+// connectOracle dials the live Trino oracle, skipping the test when it is
+// unreachable. Shared by the oracle-backed subtests below.
+func connectOracle(t *testing.T) *trinooracle.Oracle {
+	t.Helper()
+	o := trinooracle.Connect("")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ver, err := o.Ping(ctx)
+	if err != nil {
+		t.Skipf("trino oracle not reachable (start: docker run -d -p 18080:8080 %s): %v",
+			trinooracle.DefaultImage, err)
+	}
+	t.Logf("connected to Trino %s", ver)
+	return o
+}
+
+// oracleAccepts asks the oracle whether Trino syntactically accepts sql,
+// treating an oracle transport error as a skip signal (returns ok=false).
+func oracleAccepts(t *testing.T, o *trinooracle.Oracle, sql string) (accepted, ok bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := o.CheckSyntax(ctx, sql)
+	if err != nil {
+		return false, false
+	}
+	return res.Accepted, true
+}
+
+// qualifiedNameCandidates spans the foundation's identifier/qualifiedName
+// grammar surface: unquoted/quoted/back-quoted, non-reserved keywords as
+// identifiers, multi-part names, reserved-word rejection, and the
+// digit-leading rejection adjudicated by the oracle. Each is a name only;
+// the differential wraps it as `SELECT * FROM <name>`.
+var qualifiedNameCandidates = []string{
+	// accepted
+	"t",
+	"orders",
+	"public.orders",
+	"tpch.sf1.nation",
+	`"My Table"`,
+	`"public"."order"`,
+	`cat."My Schema".tbl`,
+	"zone",      // non-reserved keyword as identifier
+	"t.zone",    // non-reserved after dot
+	"including", // non-reserved keyword
+	// rejected
+	"from",         // reserved bare
+	"select",       // reserved bare
+	"s.from",       // reserved after dot
+	"public.order", // reserved after dot
+	"1abc",         // digit-leading (oracle rejects despite legacy grammar)
+	"t.1abc",       // digit-leading after dot
+	"`bt table`",   // backtick quoting (oracle rejects despite legacy grammar)
+	"t.",           // trailing dot
+}
+
+// TestFoundation_QualifiedNameDifferential cross-checks ParseQualifiedName
+// against the live Trino oracle for every candidate name, using the
+// `SELECT * FROM <name>` context to make the name a qualifiedName. omni's
+// accept/reject of the standalone name must equal Trino's accept/reject of the
+// wrapped statement.
+func TestFoundation_QualifiedNameDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, name := range qualifiedNameCandidates {
+		name := name
+		t.Run(truncateName(name), func(t *testing.T) {
+			_, errs := ParseQualifiedName(name)
+			omniAccepts := len(errs) == 0
+
+			trinoAccepts, ok := oracleAccepts(t, o, "SELECT * FROM "+name)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if omniAccepts != trinoAccepts {
+				t.Errorf("MISMATCH name=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+					name, omniAccepts, errs, trinoAccepts)
+			}
+		})
+	}
+}
+
+// multiStatementCorpus exercises the splitter on inputs with several top-level
+// statements, including ';' hidden inside strings, comments, quoted
+// identifiers, and a CREATE FUNCTION routine body. Each entry lists the input
+// and the statements Split must produce (each of which must independently be
+// accepted by Trino).
+var multiStatementCorpus = []struct {
+	name      string
+	input     string
+	wantStmts []string
+}{
+	{
+		name:      "two_selects",
+		input:     "SELECT 1; SELECT 2",
+		wantStmts: []string{"SELECT 1", " SELECT 2"},
+	},
+	{
+		name:      "trailing_semicolon",
+		input:     "SELECT 1;",
+		wantStmts: []string{"SELECT 1"},
+	},
+	{
+		name:      "semicolon_in_string",
+		input:     "SELECT 'a;b' AS c; SELECT 2",
+		wantStmts: []string{"SELECT 'a;b' AS c", " SELECT 2"},
+	},
+	{
+		name:      "semicolon_in_quoted_ident",
+		input:     `SELECT 1 AS "a;b"; SELECT 2`,
+		wantStmts: []string{`SELECT 1 AS "a;b"`, " SELECT 2"},
+	},
+	{
+		name:      "semicolon_in_line_comment",
+		input:     "SELECT 1 -- a;b\n; SELECT 2",
+		wantStmts: []string{"SELECT 1 -- a;b\n", " SELECT 2"},
+	},
+	{
+		name:      "semicolon_in_block_comment",
+		input:     "SELECT 1 /* a;b */; SELECT 2",
+		wantStmts: []string{"SELECT 1 /* a;b */", " SELECT 2"},
+	},
+	{
+		name:      "ddl_then_dml",
+		input:     "CREATE SCHEMA s; DROP SCHEMA s",
+		wantStmts: []string{"CREATE SCHEMA s", " DROP SCHEMA s"},
+	},
+	{
+		name: "create_function_routine_body_not_split",
+		// The ';' separating the routine's control statements must NOT split
+		// the CREATE FUNCTION into pieces; it is one statement.
+		input:     "CREATE FUNCTION test.default.f(x integer) RETURNS integer BEGIN RETURN x * 2; END",
+		wantStmts: []string{"CREATE FUNCTION test.default.f(x integer) RETURNS integer BEGIN RETURN x * 2; END"},
+	},
+	{
+		name: "create_function_nested_if_not_split",
+		// A nested IF (with its own internal ';') inside the BEGIN block keeps
+		// the whole CREATE FUNCTION as a single segment.
+		input:     "CREATE FUNCTION test.default.g(x integer) RETURNS integer BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END",
+		wantStmts: []string{"CREATE FUNCTION test.default.g(x integer) RETURNS integer BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END"},
+	},
+	{
+		name: "inline_routine_bare_return_then_select",
+		// WITH FUNCTION with a bare RETURN body (no block): the inline-routine
+		// query is one statement, and a trailing ';' splits the next.
+		input:     "WITH FUNCTION f(x integer) RETURNS integer RETURN x * 2 SELECT f(1); SELECT 2",
+		wantStmts: []string{"WITH FUNCTION f(x integer) RETURNS integer RETURN x * 2 SELECT f(1)", " SELECT 2"},
+	},
+	{
+		name: "function_typed_end_closer_then_split",
+		// A typed END IF closer inside the routine body must keep depth
+		// balanced so the ';' ending the CREATE FUNCTION splits the trailing
+		// SELECT off (both segments independently Trino-accepted).
+		input:     "CREATE FUNCTION test.default.g(x integer) RETURNS integer BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END; SELECT 2",
+		wantStmts: []string{"CREATE FUNCTION test.default.g(x integer) RETURNS integer BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END", " SELECT 2"},
+	},
+}
+
+// TestFoundation_SplitMatchesCount verifies (oracle-free) that Split produces
+// the expected segment text for each multi-statement input.
+func TestFoundation_SplitMatchesCount(t *testing.T) {
+	for _, tc := range multiStatementCorpus {
+		t.Run(tc.name, func(t *testing.T) {
+			segs := Split(tc.input)
+			if len(segs) != len(tc.wantStmts) {
+				t.Fatalf("Split(%q): got %d segments, want %d: %+v",
+					tc.input, len(segs), len(tc.wantStmts), segs)
+			}
+			for i, seg := range segs {
+				if seg.Text != tc.wantStmts[i] {
+					t.Errorf("segment %d Text = %q, want %q", i, seg.Text, tc.wantStmts[i])
+				}
+				// The byte range must address exactly the segment text.
+				if got := tc.input[seg.ByteStart:seg.ByteEnd]; got != seg.Text {
+					t.Errorf("segment %d range [%d,%d) -> %q, want %q",
+						i, seg.ByteStart, seg.ByteEnd, got, seg.Text)
+				}
+			}
+		})
+	}
+}
+
+// TestFoundation_SplitRoundTripOracle verifies each statement Split produces is
+// independently accepted by Trino — proving Split cut on real boundaries and
+// never mid-statement. Skipped without an oracle.
+func TestFoundation_SplitRoundTripOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, tc := range multiStatementCorpus {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for _, seg := range Split(tc.input) {
+				accepted, ok := oracleAccepts(t, o, seg.Text)
+				if !ok {
+					t.Skip("oracle unreachable for this case")
+				}
+				if !accepted {
+					t.Errorf("Split produced a segment Trino rejects: %q (from input %q)", seg.Text, tc.input)
+				}
+			}
+		})
+	}
+}
+
+// TestFoundation_ParseRobustnessOnCorpus runs Parse and Diagnose over the
+// shared oracleCorpus (real Trino 481 SQL) and asserts they always terminate
+// without panic and never invent a lex error on accepted SQL. It is oracle-free
+// (the corpus is curated all-accept) and complements the oracle differential.
+func TestFoundation_ParseRobustnessOnCorpus(t *testing.T) {
+	for _, sql := range oracleCorpus {
+		// Parse must not panic and must always return a non-nil File.
+		file, _ := Parse(sql)
+		if file == nil {
+			t.Errorf("Parse(%q) returned nil File", sql)
+		}
+		// Diagnose must not panic.
+		_ = Diagnose(sql)
+		// On accepted corpus SQL the lexer must not invent a hard error; any
+		// diagnostic must be a "not yet supported" stub (parseStmt), never a
+		// lex error. (lexerHasHardError lives in lexer_oracle_test.go.)
+		if bad, errs := lexerHasHardError(sql); bad {
+			t.Errorf("foundation: spurious lex error on accepted corpus SQL %q: %v", sql, errs)
+		}
+	}
+}
+
+// TestFoundation_NegativeInputsRejected feeds malformed SQL the engine rejects
+// and asserts the foundation reports a diagnostic for each (never silently
+// accepts). Required negative coverage per the correctness protocol.
+func TestFoundation_NegativeInputsRejected(t *testing.T) {
+	negatives := []string{
+		"SELECT 'unterminated",   // lex error: unterminated string
+		`SELECT "unterminated`,   // lex error: unterminated quoted ident
+		"SELECT X'00",            // lex error: unterminated binary literal
+		"SELECT /* unterminated", // lex error: unterminated comment
+		"FROBNICATE foo",         // unknown statement keyword
+		"\x00",                   // unrecognized character
+	}
+	for _, sql := range negatives {
+		diags := Diagnose(sql)
+		if len(diags) == 0 {
+			t.Errorf("Diagnose(%q): want at least one diagnostic, got none", sql)
+		}
+	}
+}

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -1,0 +1,372 @@
+// Package parser implements a hand-written recursive-descent parser for Trino
+// SQL (Trino 481 grammar, derived from the official SqlBase.g4).
+//
+// This file is the parser-foundation node: it ships the Parser struct, the
+// token-cursor primitives (advance / peek / peekNext / match / expect), the
+// public Parse / ParseBestEffort entry points, the per-segment driver
+// (parseSingle), and the top-level statement-dispatch switch (parseStmt).
+//
+// Per-statement parsing is STUBBED here — the foundation ships only the
+// dispatch framework. Every dispatch case routes to a real parse function or,
+// where that function does not yet exist, to the unsupported helper which
+// records a "not yet supported" ParseError. Later DAG nodes (types,
+// expressions, parser-select, parser-ddl, parser-dml, …) REPLACE individual
+// dispatch-case bodies with concrete parsers that build real ast.Node trees.
+//
+// The dispatch switch enumerates every first-keyword of Trino's `statement`
+// and `rootQuery`/`queryPrimary` grammar rules so that bytebase's Diagnose —
+// which runs on every statement — never emits a false "unknown statement"
+// diagnostic for syntactically valid Trino. Reaching a stubbed case is correct
+// foundation behavior; reaching the default (unknown) branch for a valid
+// statement is a bug.
+//
+// The package mirrors omni's doris/parser and snowflake/parser conventions: a
+// stateless Lexer feeds the Parser one Token{Kind, Str, Ival, Loc} at a time
+// with two-token lookahead, and source positions are byte offsets.
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// Parser is a recursive-descent parser for Trino SQL. It operates on a single
+// segment of input (one top-level statement produced by Split) at a time;
+// callers should use Parse or ParseBestEffort instead of constructing Parsers
+// directly.
+type Parser struct {
+	lexer      *Lexer
+	input      string       // the segment text (used for error reporting)
+	baseOffset int          // absolute offset of input within the original source
+	cur        Token        // current token
+	prev       Token        // previous token (for error context)
+	nextBuf    Token        // buffered lookahead token
+	hasNext    bool         // whether nextBuf is valid
+	errors     []ParseError // collected errors for best-effort mode
+}
+
+// advance consumes the current token and moves to the next one. Returns the
+// token that was just consumed (the new "previous" token).
+func (p *Parser) advance() Token {
+	p.prev = p.cur
+	if p.hasNext {
+		p.cur = p.nextBuf
+		p.hasNext = false
+	} else {
+		p.cur = p.lexer.NextToken()
+	}
+	return p.prev
+}
+
+// peek returns the current token without consuming it.
+func (p *Parser) peek() Token {
+	return p.cur
+}
+
+// peekNext returns the token AFTER the current one without consuming it
+// (one-token lookahead beyond cur). Used to disambiguate based on the token
+// following the current position.
+func (p *Parser) peekNext() Token {
+	if !p.hasNext {
+		p.nextBuf = p.lexer.NextToken()
+		p.hasNext = true
+	}
+	return p.nextBuf
+}
+
+// match tries each given token kind; if cur matches any, it is consumed and
+// returned with ok == true. Used for optional tokens.
+func (p *Parser) match(kinds ...TokenKind) (Token, bool) {
+	for _, k := range kinds {
+		if p.cur.Kind == k {
+			return p.advance(), true
+		}
+	}
+	return Token{}, false
+}
+
+// expect consumes the current token if it matches the expected kind. Otherwise
+// returns a ParseError describing the mismatch (without consuming anything).
+func (p *Parser) expect(kind TokenKind) (Token, error) {
+	if p.cur.Kind == kind {
+		return p.advance(), nil
+	}
+	return Token{}, p.syntaxErrorAtCur()
+}
+
+// syntaxErrorAtCur returns a *ParseError describing a syntax error at the
+// current token position. At EOF the message says "at end of input"; otherwise
+// "at or near X", where X is the token's source text or, for value-less tokens
+// (operators, EOF), its symbolic name.
+func (p *Parser) syntaxErrorAtCur() *ParseError {
+	var msg string
+	if p.cur.Kind == tokEOF {
+		msg = "syntax error at end of input"
+	} else {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Kind)
+		}
+		msg = "syntax error at or near " + text
+	}
+	return &ParseError{
+		Loc: p.cur.Loc,
+		Msg: msg,
+	}
+}
+
+// skipToNextStatement advances the parser past the current erroneous statement
+// to the next ';' at bracket-depth 0 within the current segment, or to tokEOF.
+// Always consumes at least one token to guarantee forward progress.
+//
+// Because Parse pre-segments the input with Split, each segment usually
+// contains a single statement, so skipToNextStatement's typical behavior is to
+// advance to EOF.
+func (p *Parser) skipToNextStatement() {
+	// Always consume at least one token to avoid infinite loops.
+	if p.cur.Kind != tokEOF {
+		p.advance()
+	}
+	depth := 0
+	for p.cur.Kind != tokEOF {
+		switch p.cur.Kind {
+		case int('('), int('['), int('{'):
+			depth++
+		case int(')'), int(']'), int('}'):
+			if depth > 0 {
+				depth--
+			}
+		case int(';'):
+			if depth == 0 {
+				p.advance()
+				return
+			}
+		}
+		p.advance()
+	}
+}
+
+// unsupported emits a "<name> statement parsing is not yet supported"
+// ParseError at the current token, skips to the next statement boundary, and
+// returns (nil, err). Used by every stubbed dispatch case in the foundation.
+//
+// Later DAG nodes REPLACE individual dispatch cases with real parse functions.
+// Those functions do NOT call unsupported — they consume tokens and build real
+// ast.Node values.
+func (p *Parser) unsupported(name string) (ast.Node, error) {
+	err := &ParseError{
+		Loc: p.cur.Loc,
+		Msg: name + " statement parsing is not yet supported",
+	}
+	p.skipToNextStatement()
+	return nil, err
+}
+
+// unknownStatementError reports a statement that starts with a token the
+// dispatch switch does not recognize. Called from the default branch of
+// parseStmt. Distinct from unsupported so Diagnose can tell "valid Trino, not
+// yet implemented" apart from "not valid Trino".
+func (p *Parser) unknownStatementError() *ParseError {
+	if p.cur.Kind == tokEOF {
+		return &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "syntax error at end of input",
+		}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Kind)
+	}
+	return &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "unknown or unsupported statement starting with " + text,
+	}
+}
+
+// parseStmt parses one top-level statement by dispatching on the leading
+// keyword(s). The arms enumerate the first-token vocabulary of Trino's
+// `statement` rule plus the query-starting tokens of `rootQuery` /
+// `queryPrimary` (SELECT, WITH, TABLE, VALUES, '('). For the foundation every
+// arm routes to the unsupported stub; later nodes replace the bodies.
+//
+// CREATE / DROP / ALTER / SET / RESET / COMMENT / DESCRIBE / SHOW are
+// second-keyword-dispatched in the grammar; the foundation keeps the dispatch
+// flat (one stub per leading keyword) because the per-object parsers do not
+// exist yet. Later nodes will introduce the inner switches (compare
+// doris/parser.go's CREATE/DROP/ALTER fan-out) as they add object parsers.
+func (p *Parser) parseStmt() (ast.Node, error) {
+	switch p.cur.Kind {
+	// --- Query (rootQuery / queryPrimary leading tokens) ---
+	case kwSELECT:
+		return p.unsupported("SELECT")
+	case kwWITH:
+		// WITH cte... query  OR  WITH FUNCTION ... query (inline routine).
+		return p.unsupported("WITH")
+	case kwTABLE:
+		// TABLE qualifiedName — a query primary, e.g. `TABLE t`.
+		return p.unsupported("TABLE")
+	case kwVALUES:
+		return p.unsupported("VALUES")
+	case int('('):
+		// Parenthesized query expression at top level, e.g. (SELECT 1) UNION (SELECT 2).
+		return p.unsupported("query")
+
+	// --- Session / catalog context ---
+	case kwUSE:
+		return p.unsupported("USE")
+
+	// --- DDL ---
+	case kwCREATE:
+		return p.unsupported("CREATE")
+	case kwDROP:
+		return p.unsupported("DROP")
+	case kwALTER:
+		return p.unsupported("ALTER")
+	case kwCOMMENT:
+		return p.unsupported("COMMENT")
+	case kwANALYZE:
+		return p.unsupported("ANALYZE")
+	case kwREFRESH:
+		return p.unsupported("REFRESH")
+
+	// --- DML ---
+	case kwINSERT:
+		return p.unsupported("INSERT")
+	case kwDELETE:
+		return p.unsupported("DELETE")
+	case kwUPDATE:
+		return p.unsupported("UPDATE")
+	case kwMERGE:
+		return p.unsupported("MERGE")
+	case kwTRUNCATE:
+		return p.unsupported("TRUNCATE")
+
+	// --- Procedures ---
+	case kwCALL:
+		return p.unsupported("CALL")
+
+	// --- DCL (roles / privileges) ---
+	case kwGRANT:
+		return p.unsupported("GRANT")
+	case kwREVOKE:
+		return p.unsupported("REVOKE")
+	case kwDENY:
+		return p.unsupported("DENY")
+
+	// --- Session / path / time zone ---
+	case kwSET:
+		return p.unsupported("SET")
+	case kwRESET:
+		return p.unsupported("RESET")
+
+	// --- Inspection ---
+	case kwSHOW:
+		return p.unsupported("SHOW")
+	case kwEXPLAIN:
+		return p.unsupported("EXPLAIN")
+	case kwDESCRIBE:
+		return p.unsupported("DESCRIBE")
+	case kwDESC:
+		return p.unsupported("DESC")
+
+	// --- Transactions ---
+	case kwSTART:
+		return p.unsupported("START TRANSACTION")
+	case kwCOMMIT:
+		return p.unsupported("COMMIT")
+	case kwROLLBACK:
+		return p.unsupported("ROLLBACK")
+
+	// --- Prepared statements ---
+	case kwPREPARE:
+		return p.unsupported("PREPARE")
+	case kwDEALLOCATE:
+		return p.unsupported("DEALLOCATE")
+	case kwEXECUTE:
+		return p.unsupported("EXECUTE")
+
+	default:
+		return nil, p.unknownStatementError()
+	}
+}
+
+// ParseResult holds the outcome of a best-effort parse. File contains every
+// statement that parsed successfully (empty while statement bodies are
+// stubbed); Errors contains every ParseError encountered, including LexErrors
+// promoted from the underlying Lexer.
+type ParseResult struct {
+	File   *ast.File
+	Errors []ParseError
+}
+
+// Parse is the public entry point. It returns the parsed File plus every error
+// encountered. The File always reflects whatever statements parsed
+// successfully — even in the error case it may be non-empty.
+//
+// The signature returns all errors (matching doris/parser.Parse) rather than a
+// single error: bytebase's Diagnose needs the complete diagnostic set, and a
+// multi-statement script can fail in several places at once.
+func Parse(input string) (*ast.File, []ParseError) {
+	result := ParseBestEffort(input)
+	return result.File, result.Errors
+}
+
+// ParseBestEffort runs Split to segment the input, then parses each segment via
+// parseSingle. Per-segment errors are collected; every successfully-parsed
+// statement is appended to the result File. This is the canonical entry point
+// for the bytebase consumers (Diagnose, query-type classification, query-span
+// extraction) that need partial results plus diagnostics.
+func ParseBestEffort(input string) *ParseResult {
+	file := &ast.File{Loc: ast.Loc{Start: 0, End: len(input)}}
+	result := &ParseResult{File: file}
+
+	for _, seg := range Split(input) {
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if node != nil {
+			file.Stmts = append(file.Stmts, node)
+		}
+		result.Errors = append(result.Errors, errs...)
+	}
+
+	return result
+}
+
+// parseSingle parses one segment (one top-level statement) into a single
+// ast.Node. Returns (node, errors) where node may be nil if the segment failed
+// to parse and errors lists every ParseError encountered, including LexErrors
+// promoted from the underlying Lexer.
+//
+// segText is the statement text without the trailing ';' (from Segment.Text).
+// baseOffset is segText's byte offset within the original input; it is passed
+// to NewLexerWithOffset so token and error Loc values stay absolute.
+func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
+	p := &Parser{
+		lexer:      NewLexerWithOffset(segText, baseOffset),
+		input:      segText,
+		baseOffset: baseOffset,
+	}
+	p.advance() // prime cur with the first token
+
+	var result ast.Node
+	if p.cur.Kind != tokEOF {
+		node, err := p.parseStmt()
+		if err != nil {
+			if pe, ok := err.(*ParseError); ok {
+				p.errors = append(p.errors, *pe)
+			} else {
+				p.errors = append(p.errors, ParseError{
+					Loc: p.cur.Loc,
+					Msg: err.Error(),
+				})
+			}
+		}
+		result = node
+	}
+
+	// Promote any lex errors into ParseErrors. The Lexer's Errors() getter
+	// returns positions already shifted by baseOffset.
+	for _, le := range p.lexer.Errors() {
+		p.errors = append(p.errors, ParseError{Loc: le.Loc, Msg: le.Msg})
+	}
+
+	return result, p.errors
+}

--- a/trino/parser/parser_test.go
+++ b/trino/parser/parser_test.go
@@ -1,0 +1,125 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParse_EmptyInput verifies that parsing empty or whitespace-only input
+// yields a non-nil File with no statements and no errors.
+func TestParse_EmptyInput(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\t ", "-- just a comment\n", "/* block */"} {
+		file, errs := Parse(in)
+		if file == nil {
+			t.Fatalf("Parse(%q): File is nil", in)
+		}
+		if len(file.Stmts) != 0 {
+			t.Errorf("Parse(%q): got %d stmts, want 0", in, len(file.Stmts))
+		}
+		if len(errs) != 0 {
+			t.Errorf("Parse(%q): got errors %v, want none", in, errs)
+		}
+	}
+}
+
+// TestParse_UnknownStatement verifies a statement starting with a token the
+// dispatch switch does not recognize produces a parse error (not a panic, not
+// silent acceptance).
+func TestParse_UnknownStatement(t *testing.T) {
+	file, errs := Parse("FOOBAR 1 2 3")
+	if file == nil {
+		t.Fatal("Parse: File is nil")
+	}
+	if len(errs) == 0 {
+		t.Fatal("Parse(\"FOOBAR ...\"): want a parse error, got none")
+	}
+	if !strings.Contains(errs[0].Msg, "unknown or unsupported statement") {
+		t.Errorf("error = %q, want it to mention 'unknown or unsupported statement'", errs[0].Msg)
+	}
+}
+
+// TestParse_KnownStatementUnsupported verifies that a statement whose leading
+// keyword IS in the dispatch switch but whose body is stubbed yields a
+// "not yet supported" diagnostic rather than an "unknown statement" one. The
+// foundation node ships dispatch only; concrete statement parsers arrive in
+// later DAG nodes.
+func TestParse_KnownStatementUnsupported(t *testing.T) {
+	file, errs := Parse("SELECT 1")
+	if file == nil {
+		t.Fatal("Parse: File is nil")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("Parse(\"SELECT 1\"): got %d errors, want 1: %v", len(errs), errs)
+	}
+	if !strings.Contains(errs[0].Msg, "not yet supported") {
+		t.Errorf("error = %q, want it to mention 'not yet supported'", errs[0].Msg)
+	}
+}
+
+// TestParse_MultiStatementErrorsCollected verifies that ParseBestEffort
+// collects errors from every segment, not just the first. Two stubbed
+// statements separated by ';' must yield two errors.
+func TestParse_MultiStatementErrorsCollected(t *testing.T) {
+	res := ParseBestEffort("SELECT 1; INSERT INTO t VALUES (1)")
+	if got := len(res.Errors); got != 2 {
+		t.Fatalf("ParseBestEffort: got %d errors, want 2: %v", got, res.Errors)
+	}
+}
+
+// TestParse_LexErrorPromoted verifies that a lexer-level failure (unterminated
+// string) surfaces as a parse error with a position, so Diagnose can report it.
+func TestParse_LexErrorPromoted(t *testing.T) {
+	_, errs := Parse("SELECT 'unterminated")
+	if len(errs) == 0 {
+		t.Fatal("Parse with unterminated string: want a (lex-promoted) error, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Msg, "unterminated string") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("errors = %v, want one mentioning 'unterminated string'", errs)
+	}
+}
+
+// TestParse_StrictReturnsAllErrors verifies the strict Parse entry returns the
+// full error slice (matching doris's Parse signature, which returns
+// []ParseError rather than a single error).
+func TestParse_StrictReturnsAllErrors(t *testing.T) {
+	_, errs := Parse("FOOBAR; BAZBAR")
+	if len(errs) != 2 {
+		t.Fatalf("Parse: got %d errors, want 2: %v", len(errs), errs)
+	}
+}
+
+// TestParse_DispatchKeywordsRecognized verifies that every documented top-level
+// statement keyword is routed by the dispatch switch — i.e. it produces a
+// "not yet supported" (stubbed) error, NOT an "unknown statement" error. This
+// is the foundation's completeness contract: all 81 statement forms must be
+// reachable for Diagnose to avoid false "unknown statement" diagnostics.
+func TestParse_DispatchKeywordsRecognized(t *testing.T) {
+	// One representative prefix per first-keyword in the grammar's `statement`
+	// and `rootQuery`/`queryPrimary` rules. The body after the keyword does not
+	// matter — the foundation stubs the body — so we only need the leading
+	// keyword(s) to land in a real dispatch case rather than the default.
+	prefixes := []string{
+		"SELECT", "WITH", "TABLE", "VALUES", "(",
+		"USE", "CREATE", "DROP", "ALTER", "INSERT", "DELETE", "UPDATE",
+		"MERGE", "TRUNCATE", "COMMENT", "ANALYZE", "REFRESH", "CALL",
+		"GRANT", "REVOKE", "DENY", "SET", "RESET", "SHOW", "EXPLAIN",
+		"DESCRIBE", "DESC", "START", "COMMIT", "ROLLBACK", "PREPARE",
+		"DEALLOCATE", "EXECUTE",
+	}
+	for _, p := range prefixes {
+		// Use a minimal-but-plausible tail so the leading token is the keyword.
+		sql := p + " x"
+		_, errs := Parse(sql)
+		for _, e := range errs {
+			if strings.Contains(e.Msg, "unknown or unsupported statement") {
+				t.Errorf("keyword %q routed to default (unknown) dispatch: %q -> %q", p, sql, e.Msg)
+			}
+		}
+	}
+}

--- a/trino/parser/split.go
+++ b/trino/parser/split.go
@@ -1,0 +1,190 @@
+package parser
+
+// Segment represents one top-level SQL statement extracted from a source
+// string.
+//
+// Text is the raw substring of the input from ByteStart (inclusive) to ByteEnd
+// (exclusive). It is NOT trimmed — leading/trailing whitespace and comments are
+// preserved verbatim. The trailing ';' delimiter (if present) is NOT part of
+// Text or ByteEnd; it lives between this segment's ByteEnd and the next
+// segment's ByteStart.
+type Segment struct {
+	Text      string // raw text of the statement (no trailing semicolon)
+	ByteStart int    // inclusive start byte offset in the original source
+	ByteEnd   int    // exclusive end byte offset; points AT the trailing ';' if present, else at len(input)
+}
+
+// Empty reports whether the segment contains no meaningful SQL content — only
+// whitespace and comments. It re-lexes Text and checks whether the first token
+// is tokEOF. Empty segments are filtered out by Split.
+func (s Segment) Empty() bool {
+	return NewLexer(s.Text).NextToken().Kind == tokEOF
+}
+
+// splitState is the state-machine state for Split.
+type splitState int
+
+const (
+	stateTop    splitState = iota // between statements / inside a non-routine statement
+	stateInBody                   // inside a CREATE/WITH FUNCTION routine body
+)
+
+// Split extracts top-level SQL statements from input.
+//
+// The returned slice contains one Segment per non-empty statement. Empty
+// statements (lone semicolons, comment-only chunks) are filtered out. Split is
+// infallible — it always returns a result even for malformed input; lexing
+// errors are suppressed here (callers who need them use NewLexer(input).Errors()
+// or Parse, which promotes lex errors to diagnostics).
+//
+// The lexer already hides string/identifier/comment content, so a ';' inside a
+// '...' / U&'...' / X'...' literal, a "..." / `...` quoted identifier, or a
+// line/bracketed comment is never seen as a delimiter here.
+//
+// The one Trino construct whose body legitimately contains top-level ';' is an
+// inline SQL routine: CREATE [OR REPLACE] FUNCTION ... <controlStatement> and
+// WITH FUNCTION ... <controlStatement>. A routine's controlStatement may be a
+// bare `RETURN expr` (no ';', no block) or an END-terminated block
+// (BEGIN..END, IF..END IF, CASE..END CASE, LOOP..END LOOP, WHILE..END WHILE,
+// REPEAT..END REPEAT), and blocks nest. Split tracks routine-body context so
+// the ';' separating control statements inside such a body does not split the
+// CREATE/WITH FUNCTION into pieces.
+//
+// A top-level BEGIN is NOT treated as a block opener: in Trino a statement-
+// leading BEGIN is a transaction start (BEGIN [WORK|TRANSACTION]); the routine
+// BEGIN only ever appears after `FUNCTION ... RETURNS <type>`, i.e. inside a
+// function-definition statement, which is exactly the context stateInBody
+// tracks.
+func Split(input string) []Segment {
+	if len(input) == 0 {
+		return nil
+	}
+
+	l := NewLexer(input)
+	var segments []Segment
+	stmtStart := 0
+	state := stateTop
+	depth := 0 // END-block nesting depth while in stateInBody
+
+	// isFunctionDef reports whether the current statement is an inline-routine
+	// definition whose body we must keep whole. It is decided from the
+	// statement's leading keywords and cleared at each statement boundary.
+	isFunctionDef := false
+	// stmtTokenIdx counts meaningful tokens seen in the current statement, and
+	// firstKind records the statement's first token kind; together they drive
+	// the position-precise recognition of the `CREATE [OR REPLACE] FUNCTION` /
+	// `WITH FUNCTION` prefix, so a FUNCTION keyword appearing LATER in a
+	// statement (e.g. a column named `function` in a CTE) or after a different
+	// leading keyword (e.g. `DROP FUNCTION`) is never mistaken for a routine
+	// body whose internal ';' must be preserved.
+	stmtTokenIdx := 0
+	firstKind := tokInvalid
+	// prevWasEnd is set inside a routine body immediately after an END token so
+	// the keyword that completes a typed block closer — END IF / END CASE /
+	// END LOOP / END WHILE / END REPEAT — is recognized as the closer's suffix
+	// rather than miscounted as a NEW block opener (which would desync depth and
+	// swallow the statement-terminating ';' after the routine).
+	prevWasEnd := false
+
+	emit := func(end int) {
+		seg := Segment{
+			Text:      input[stmtStart:end],
+			ByteStart: stmtStart,
+			ByteEnd:   end,
+		}
+		if !seg.Empty() {
+			segments = append(segments, seg)
+		}
+	}
+
+	// markRoutineIfPrefix sets isFunctionDef when tok at position idx completes
+	// an inline-routine prefix that can carry a control-flow body:
+	//   WITH FUNCTION ...                 (FUNCTION at idx 1, first kind WITH)
+	//   CREATE FUNCTION ...               (FUNCTION at idx 1, first kind CREATE)
+	//   CREATE OR REPLACE FUNCTION ...    (FUNCTION at idx 3, first kind CREATE)
+	// Only CREATE and WITH can introduce a routine body, so other leading
+	// keywords (DROP FUNCTION, SHOW FUNCTIONS) are excluded.
+	markRoutineIfPrefix := func(idx int, kind TokenKind) {
+		if kind != kwFUNCTION {
+			return
+		}
+		switch {
+		case idx == 1 && (firstKind == kwWITH || firstKind == kwCREATE):
+			isFunctionDef = true
+		case idx == 3 && firstKind == kwCREATE:
+			isFunctionDef = true
+		}
+	}
+
+	for {
+		tok := l.NextToken()
+		if tok.Kind == tokEOF {
+			break
+		}
+
+		switch state {
+		case stateTop:
+			if stmtTokenIdx == 0 {
+				firstKind = tok.Kind
+			}
+			markRoutineIfPrefix(stmtTokenIdx, tok.Kind)
+
+			switch tok.Kind {
+			case kwBEGIN, kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT:
+				// Block openers count only inside a function definition; a
+				// top-level BEGIN/IF/CASE outside a routine is either a
+				// transaction start (BEGIN) or not a statement opener at all.
+				if isFunctionDef {
+					state = stateInBody
+					depth = 1
+				}
+			case int(';'):
+				emit(tok.Loc.Start)
+				stmtStart = tok.Loc.End
+				isFunctionDef = false
+				firstKind = tokInvalid
+				stmtTokenIdx = -1 // becomes 0 after the increment below
+			}
+
+		case stateInBody:
+			switch tok.Kind {
+			case kwBEGIN, kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT:
+				// A block keyword right after END is the suffix of a typed
+				// closer (END IF / END CASE / …), not a new block opener.
+				if prevWasEnd {
+					prevWasEnd = false
+				} else {
+					depth++
+				}
+			case kwEND:
+				prevWasEnd = true
+				if depth > 0 {
+					depth--
+					if depth == 0 {
+						state = stateTop
+						// The routine body block is closed. Clear the
+						// function-definition flag so any control keyword
+						// (e.g. a CASE expression) in the trailing query of a
+						// `WITH FUNCTION ... <body> <query>` statement is NOT
+						// re-treated as a routine block opener.
+						isFunctionDef = false
+						prevWasEnd = false
+					}
+				}
+			default:
+				prevWasEnd = false
+			}
+			// ';' and every other token are absorbed inside the routine body.
+		}
+
+		stmtTokenIdx++
+	}
+
+	// Trailing segment — whatever remains after the last ';' (or the whole
+	// input when there was none). ByteEnd is len(input) here.
+	if stmtStart < len(input) {
+		emit(len(input))
+	}
+
+	return segments
+}

--- a/trino/parser/split_test.go
+++ b/trino/parser/split_test.go
@@ -1,0 +1,226 @@
+package parser
+
+import "testing"
+
+// TestSplit_Single verifies a single statement (no trailing semicolon) yields
+// one segment spanning the whole input.
+func TestSplit_Single(t *testing.T) {
+	segs := Split("SELECT 1")
+	if len(segs) != 1 {
+		t.Fatalf("got %d segments, want 1: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "SELECT 1" {
+		t.Errorf("Text = %q, want %q", segs[0].Text, "SELECT 1")
+	}
+	if segs[0].ByteStart != 0 || segs[0].ByteEnd != len("SELECT 1") {
+		t.Errorf("range = [%d,%d), want [0,%d)", segs[0].ByteStart, segs[0].ByteEnd, len("SELECT 1"))
+	}
+}
+
+// TestSplit_TwoStatements verifies splitting on a top-level semicolon, with the
+// delimiter excluded from each segment's text/range.
+func TestSplit_TwoStatements(t *testing.T) {
+	in := "SELECT 1; SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "SELECT 1" {
+		t.Errorf("seg[0].Text = %q, want %q", segs[0].Text, "SELECT 1")
+	}
+	if segs[1].Text != " SELECT 2" {
+		t.Errorf("seg[1].Text = %q, want %q", segs[1].Text, " SELECT 2")
+	}
+	// The ';' is at index 8: seg[0] stops before it, seg[1] starts after it.
+	if segs[0].ByteEnd != 8 {
+		t.Errorf("seg[0].ByteEnd = %d, want 8", segs[0].ByteEnd)
+	}
+	if segs[1].ByteStart != 9 {
+		t.Errorf("seg[1].ByteStart = %d, want 9", segs[1].ByteStart)
+	}
+}
+
+// TestSplit_EmptySegmentsFiltered verifies lone semicolons and comment-only
+// chunks produce no segments.
+func TestSplit_EmptySegmentsFiltered(t *testing.T) {
+	for _, in := range []string{";", ";;;", "  ;  ", "-- c\n;", "/* c */", ""} {
+		segs := Split(in)
+		if len(segs) != 0 {
+			t.Errorf("Split(%q): got %d segments, want 0: %+v", in, len(segs), segs)
+		}
+	}
+}
+
+// TestSplit_SemicolonInString verifies a ';' inside a single-quoted string
+// literal does NOT split the statement.
+func TestSplit_SemicolonInString(t *testing.T) {
+	in := "SELECT 'a;b' FROM t; SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "SELECT 'a;b' FROM t" {
+		t.Errorf("seg[0].Text = %q, want %q", segs[0].Text, "SELECT 'a;b' FROM t")
+	}
+}
+
+// TestSplit_SemicolonInQuotedIdent verifies a ';' inside a double-quoted
+// identifier does NOT split.
+func TestSplit_SemicolonInQuotedIdent(t *testing.T) {
+	in := `SELECT "a;b" FROM t; SELECT 2`
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+	if segs[0].Text != `SELECT "a;b" FROM t` {
+		t.Errorf("seg[0].Text = %q, want %q", segs[0].Text, `SELECT "a;b" FROM t`)
+	}
+}
+
+// TestSplit_SemicolonInComment verifies a ';' inside a line or block comment
+// does NOT split.
+func TestSplit_SemicolonInComment(t *testing.T) {
+	in := "SELECT 1 -- a;b\n; SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("line comment: got %d segments, want 2: %+v", len(segs), segs)
+	}
+	in2 := "SELECT 1 /* a;b */; SELECT 2"
+	segs2 := Split(in2)
+	if len(segs2) != 2 {
+		t.Fatalf("block comment: got %d segments, want 2: %+v", len(segs2), segs2)
+	}
+}
+
+// TestSplit_TrailingSemicolon verifies a single statement with a trailing ';'
+// yields exactly one segment (the empty trailing chunk is filtered).
+func TestSplit_TrailingSemicolon(t *testing.T) {
+	segs := Split("SELECT 1;")
+	if len(segs) != 1 {
+		t.Fatalf("got %d segments, want 1: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "SELECT 1" {
+		t.Errorf("Text = %q, want %q", segs[0].Text, "SELECT 1")
+	}
+}
+
+// TestSplit_RoutineBodyNotSplit verifies that a ';' inside a CREATE FUNCTION
+// routine body (BEGIN ... END) does NOT split the statement. The whole
+// CREATE FUNCTION must remain a single segment.
+func TestSplit_RoutineBodyNotSplit(t *testing.T) {
+	in := "CREATE FUNCTION f() RETURNS int BEGIN DECLARE x int; SET x = 1; RETURN x; END"
+	segs := Split(in)
+	if len(segs) != 1 {
+		t.Fatalf("got %d segments, want 1 (routine body must not split): %+v", len(segs), segs)
+	}
+}
+
+// TestSplit_StartTransactionNotABlock verifies that a top-level BEGIN that is a
+// transaction start (e.g. "BEGIN; SELECT 1") still splits normally — BEGIN as
+// a TCL transaction-start is NOT a compound block opener.
+func TestSplit_StartTransactionNotABlock(t *testing.T) {
+	in := "START TRANSACTION; SELECT 1; COMMIT"
+	segs := Split(in)
+	if len(segs) != 3 {
+		t.Fatalf("got %d segments, want 3: %+v", len(segs), segs)
+	}
+}
+
+// TestSplit_EmptyInput verifies Split returns nil for empty input.
+func TestSplit_EmptyInput(t *testing.T) {
+	if segs := Split(""); segs != nil {
+		t.Errorf("Split(\"\") = %+v, want nil", segs)
+	}
+}
+
+// TestSplit_InlineRoutineBareReturnThenSplit verifies that a WITH FUNCTION
+// whose body is a bare RETURN (no BEGIN block) does not swallow the following
+// statement's ';'. The inline-routine query is one statement; a second
+// statement after ';' must split off.
+func TestSplit_InlineRoutineBareReturnThenSplit(t *testing.T) {
+	in := "WITH FUNCTION f(x integer) RETURNS integer RETURN x * 2 SELECT f(1); SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "WITH FUNCTION f(x integer) RETURNS integer RETURN x * 2 SELECT f(1)" {
+		t.Errorf("seg[0].Text = %q", segs[0].Text)
+	}
+}
+
+// TestSplit_CaseExpressionNotABlock verifies a CASE expression in a normal
+// query (not a routine body) does NOT confuse the splitter: a ';' after the
+// CASE still splits.
+func TestSplit_CaseExpressionNotABlock(t *testing.T) {
+	in := "SELECT CASE WHEN a THEN 1 ELSE 2 END FROM t; SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+}
+
+// TestSplit_DropFunctionNotARoutineBody verifies DROP FUNCTION (FUNCTION at the
+// same token index as a routine definition, but a different leading keyword) is
+// NOT treated as having a control-flow body — a following ';' splits normally.
+func TestSplit_DropFunctionNotARoutineBody(t *testing.T) {
+	in := "DROP FUNCTION f; SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+}
+
+// TestSplit_FunctionAsColumnNameNotARoutine verifies the non-reserved keyword
+// FUNCTION used as a column name inside a CTE does not trip routine-body
+// detection: the ';' after a CASE expression still splits.
+func TestSplit_FunctionAsColumnNameNotARoutine(t *testing.T) {
+	in := "WITH t AS (SELECT 1 AS function) SELECT CASE WHEN x THEN 1 END FROM t; SELECT 2"
+	segs := Split(in)
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2: %+v", len(segs), segs)
+	}
+}
+
+// TestSplit_NestedFunctionBlocksOneSegment verifies a CREATE FUNCTION with a
+// nested IF inside its BEGIN block (each with its own internal ';') remains a
+// single segment.
+func TestSplit_NestedFunctionBlocksOneSegment(t *testing.T) {
+	in := "CREATE FUNCTION g(x integer) RETURNS integer BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END"
+	segs := Split(in)
+	if len(segs) != 1 {
+		t.Fatalf("got %d segments, want 1 (nested blocks must not split): %+v", len(segs), segs)
+	}
+}
+
+// TestSplit_TypedEndClosersThenSplit verifies typed block closers
+// (END IF / END CASE / END WHILE / END LOOP / END REPEAT) inside a routine body
+// keep depth tracking balanced, so a ';' that terminates the CREATE FUNCTION
+// still splits the following statement off. Regression for an END-suffix
+// miscount that swallowed the post-routine ';'.
+func TestSplit_TypedEndClosersThenSplit(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   string
+	}{
+		{"END IF", "CREATE FUNCTION g(x int) RETURNS int BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END; SELECT 2"},
+		{"END CASE", "CREATE FUNCTION g(x int) RETURNS int BEGIN CASE WHEN x > 0 THEN RETURN 1; ELSE RETURN 0; END CASE; END; SELECT 2"},
+		{"END WHILE", "CREATE FUNCTION h(x int) RETURNS int BEGIN DECLARE i int DEFAULT 0; WHILE i < x DO SET i = i + 1; END WHILE; RETURN i; END; SELECT 9"},
+		{"END LOOP + nested END IF", "CREATE FUNCTION lp() RETURNS int BEGIN DECLARE i int DEFAULT 0; abc: LOOP SET i = i + 1; IF i > 10 THEN LEAVE abc; END IF; END LOOP; RETURN i; END; SELECT 1"},
+	}
+	for _, c := range cases {
+		segs := Split(c.in)
+		if len(segs) != 2 {
+			t.Errorf("[%s] got %d segments, want 2 (routine + trailing SELECT): %+v", c.desc, len(segs), segs)
+		}
+	}
+}
+
+// TestSegment_Empty verifies the Empty predicate.
+func TestSegment_Empty(t *testing.T) {
+	if !(Segment{Text: "  -- x\n "}).Empty() {
+		t.Error("comment/whitespace-only segment should be Empty")
+	}
+	if (Segment{Text: "SELECT 1"}).Empty() {
+		t.Error("statement segment should not be Empty")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **`trino/parser-foundation`** v2 migration node (migration id 3, `dag_version v2-2026-06-02`): the recursive-descent parser entry point and dispatch framework, the token-driven statement splitter, syntax diagnostics, the identifier / `qualifiedName` grammar, and the `ParseError` type. Builds on the merged `ast-core` (#173) and `lexer` (#175) nodes.

Per-statement parsing is **stubbed** — `parseStmt` routes every top-level statement keyword (and the query leaders `SELECT`/`WITH`/`TABLE`/`VALUES`/`(`) to a `unsupported(...)` stub. Later DAG nodes (`types`, `expressions`, `parser-select`, `parser-ddl`, `parser-dml`, …) replace individual dispatch-case bodies with real parsers. Reaching a stub is correct foundation behavior; reaching the `default` (unknown-statement) branch for valid Trino is a bug, and a grammar-derived test guards that every statement-leading keyword routes to a real case.

Spec: [`docs/migration/trino/analysis.md`](docs/migration/trino/analysis.md) §6 Tier 0/1, [`docs/migration/trino/dag.md`](docs/migration/trino/dag.md) (`trino/parser-foundation` row). Reference pattern: `doris/parser` and `snowflake/parser`.

## Files (node `writes_globs`)

| File | Contents |
|---|---|
| `parser.go` | `Parser` cursor primitives (`advance`/`peek`/`peekNext`/`match`/`expect`); `Parse` / `ParseBestEffort` / `parseSingle`; `parseStmt` dispatch over the full `statement` rule + query leaders. |
| `errors.go` | `ParseError{Loc, Msg}` (the lexer's `LexError` already lives in `tokens.go`). |
| `split.go` | `Segment` + `Split`; routine-body-aware so a `;` inside a `CREATE`/`WITH FUNCTION` control-flow body (`BEGIN`/`IF`/`CASE`/`LOOP`/`WHILE`/`REPEAT` … `END`) does not split the statement. |
| `diagnose.go` | `Diagnostic` + `Diagnose`, backing bytebase `RegisterDiagnoseFunc`. |
| `identifiers.go` | `parseIdentifier` / `parseQualifiedName` + exported `NormalizeTrinoIdentifier` / `ExtractQualifiedNameParts` / `ParseQualifiedName` (the legacy bytebase helper surface). |

Plus the accompanying `*_test.go` files (51 test functions).

## Correctness — proven against the live Trino 481 oracle

Adjudicated with `trino/internal/trinooracle` (Trino 481, errorName `SYNTAX_ERROR` ⇒ reject; every other outcome ⇒ accept). Oracle tests skip in `-short` and when no server is reachable; the CI command `go test -short ./...` is fully green.

- **`qualifiedName` accept/reject differential** — for each candidate name, omni's `ParseQualifiedName` verdict is compared to Trino's verdict for `SELECT * FROM <name>`. Positive (unquoted/quoted/multi-part/non-reserved-keyword) and negative (reserved, digit-leading, backtick, trailing-dot) cases all match.
- **Splitter round-trip** — every segment `Split` produces is fed back to Trino and must be independently accepted, proving cuts land on real statement boundaries (including `;` inside strings/comments/quoted-identifiers and a `CREATE FUNCTION` routine body with typed `END IF`/`END CASE`/`END WHILE`/`END LOOP` closers).
- **Robustness + negative coverage** — `Parse`/`Diagnose` terminate without panic on the shared 481 corpus and never invent a lex error there; malformed inputs (unterminated string/ident/binary/comment, unknown statement, NUL byte) each produce a diagnostic.

## Divergences from the legacy `TrinoParser.g4` (oracle-confirmed, in the ledger)

The legacy grammar lags Trino 481; each below is adjudicated by the live oracle, recorded as a `confirmed` divergence:

1. **`DIGIT_IDENTIFIER_` (`1abc`) rejected** in identifier position. The grammar's `identifier` rule lists it, but Trino 481 rejects unquoted digit-leading names everywhere (`SELECT * FROM 1abc`, `CREATE TABLE 1abc (…)`, `SELECT t.1abc` all `SYNTAX_ERROR`; quoting fixes it).
2. **`BACKQUOTED_IDENTIFIER_` (`` `x` ``) rejected** as an identifier. The grammar lists it and the lexer still tokenizes it, but Trino 481 rejects backtick quoting everywhere — only `"double-quotes"` are valid identifier quoting.
3. **`qualifiedName` applies the `identifier` rule to every part** — a reserved keyword is rejected as a name part whether first or after a dot (`s.from`, `public.order` → `SYNTAX_ERROR`), unlike the doris/snowflake reference parsers which accept reserved words post-dot. Non-reserved keywords (e.g. `t.zone`) are accepted.
4. **Top-level `BEGIN` / `BEGIN WORK` / `BEGIN TRANSACTION` is NOT a statement** — Trino 481 rejects it with `SYNTAX_ERROR` (unlike PostgreSQL/MySQL); `START TRANSACTION` is the only transaction-start form. `parseStmt` therefore has no top-level `BEGIN` arm, and the splitter treats a statement-leading `BEGIN` as a block opener only inside a `CREATE`/`WITH FUNCTION` definition.

## Review

Cross-reviewed for correctness + divergence audit. The review caught and fixed two real splitter bugs before this PR: (a) typed `END IF`/`END CASE`/… closers desynced the routine-body depth counter and swallowed the statement-terminating `;`; (b) a `FUNCTION` keyword appearing later in a statement (e.g. a column named `function` in a CTE) or after `DROP` was mis-detected as a routine body — both now position-precise with regression tests. `NormalizeTrinoIdentifier` was aligned to be a byte-for-byte port of the legacy bytebase helper.

## Scope

Touches only the node's `writes_globs` (`parser.go`, `errors.go`, `split.go`, `diagnose.go`, `identifiers.go`) plus their tests. No out-of-scope production writes.

> Note: `TestLexer_OracleDifferential` (the **`lexer`** node's file, out of scope here) has a pre-existing latent failure against a live oracle — one corpus entry uses a `` `backtick` `` identifier, which divergence #2 shows Trino 481 rejects. It skips under `-short` (CI), so it does not affect this PR's CI. Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)