### PR TITLE
feat(trino/parser): data-type grammar (v2 node trino/types)

### DIFF
--- a/trino/parser/datatypes.go
+++ b/trino/parser/datatypes.go
@@ -1,0 +1,924 @@
+package parser
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the `types` DAG node: it implements Trino's `type` grammar rule
+// (and its helpers `rowField`, `typeParameter`, `intervalField`) as a
+// hand-written recursive-descent parser over the token stream, producing a
+// DataType value tree.
+//
+// Trino's legacy ANTLR `type` rule (TrinoParser.g4):
+//
+//	type
+//	    : ROW_ LPAREN_ rowField (COMMA_ rowField)* RPAREN_                  # rowType
+//	    | INTERVAL_ from=intervalField (TO_ to=intervalField)?             # intervalType
+//	    | base_=TIMESTAMP_ (LPAREN_ precision=typeParameter RPAREN_)? (WITHOUT_ TIME_ ZONE_)?  # dateTimeType
+//	    | base_=TIMESTAMP_ (LPAREN_ precision=typeParameter RPAREN_)? WITH_ TIME_ ZONE_        # dateTimeType
+//	    | base_=TIME_      (LPAREN_ precision=typeParameter RPAREN_)? (WITHOUT_ TIME_ ZONE_)?  # dateTimeType
+//	    | base_=TIME_      (LPAREN_ precision=typeParameter RPAREN_)? WITH_ TIME_ ZONE_        # dateTimeType
+//	    | DOUBLE_ PRECISION_                                               # doublePrecisionType
+//	    | ARRAY_ LT_ type GT_                                              # legacyArrayType
+//	    | MAP_ LT_ keyType=type COMMA_ valueType=type GT_                 # legacyMapType
+//	    | type ARRAY_ (LSQUARE_ INTEGER_VALUE_ RSQUARE_)?                  # arrayType
+//	    | identifier (LPAREN_ typeParameter (COMMA_ typeParameter)* RPAREN_)?  # genericType
+//	    ;
+//	rowField      : type | identifier type ;
+//	typeParameter : INTEGER_VALUE_ | type ;
+//	intervalField : YEAR_ | MONTH_ | DAY_ | HOUR_ | MINUTE_ | SECOND_ ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar. Two oracle-confirmed divergences from a naive reading
+// of the legacy rule are baked in (see the migration divergence ledger):
+//
+//	D1 (interval qualifier set). The legacy `from (TO to)?` allows ANY field TO
+//	   ANY field (e.g. SECOND TO YEAR). Trino 481 restricts `from TO to` to the
+//	   two SQL-standard families with from strictly coarser than to:
+//	   year-month {YEAR>MONTH} and day-time {DAY>HOUR>MINUTE>SECOND}; a TO
+//	   crossing families (YEAR TO DAY) or reversed (MONTH TO YEAR) is a
+//	   SYNTAX_ERROR. The single-field form `INTERVAL <field>` is accepted for
+//	   every field (it fails later as NOT_SUPPORTED for year-month single
+//	   fields, which is semantic, not syntactic).
+//
+//	D2 (INTERVAL not followed by a field is a generic type). Legacy requires a
+//	   field after INTERVAL. Trino 481 instead falls back to the genericType
+//	   path when INTERVAL is followed by `(`, `)`, `ARRAY`, or anything that is
+//	   not an intervalField keyword: `INTERVAL`, `INTERVAL(5)`, `INTERVAL ARRAY`
+//	   all parse (as the unknown type INTERVAL / INTERVAL(5) / ARRAY(INTERVAL)).
+//	   So INTERVAL only enters the intervalType branch when the next token is one
+//	   of YEAR/MONTH/DAY/HOUR/MINUTE/SECOND.
+//
+// Recursive-descent vs the ANTLR alternative ordering: the left-recursive
+// `type ARRAY` postfix is handled iteratively (parse a base type, then consume
+// zero or more trailing `ARRAY [n]` suffixes). The keyword-led alternatives
+// (ROW, INTERVAL, TIMESTAMP/TIME, DOUBLE PRECISION, ARRAY<>, MAP<>) are
+// dispatched on the leading keyword with lookahead; everything else, including
+// the type-name keywords used WITHOUT their special syntax (e.g. `ARRAY` alone,
+// `MAP` alone, `DOUBLE` alone, `ROW` alone), falls through to genericType,
+// matching Trino which treats them as ordinary type-name identifiers there.
+
+// TypeKind classifies the top-level shape of a parsed DataType. It mirrors the
+// labeled alternatives of the legacy `type` rule so downstream consumers
+// (expressions, DDL, deparse) can switch on the form without re-inspecting the
+// token text.
+type TypeKind int
+
+const (
+	// TypeGeneric is a named type with optional parenthesized parameters:
+	// `identifier (LPAREN typeParameter (COMMA typeParameter)* RPAREN)?`.
+	// Covers the overwhelming majority of Trino types — BIGINT, VARCHAR(n),
+	// DECIMAL(p,s), JSON, UUID, IPADDRESS, HYPERLOGLOG, QDIGEST(t), VARIANT,
+	// ARRAY(t)/MAP(k,v) in their parenthesized spelling, DOUBLE, etc. — because
+	// Trino's type names are plain identifiers, not reserved keywords.
+	TypeGeneric TypeKind = iota
+	// TypeRow is `ROW ( rowField (, rowField)* )`.
+	TypeRow
+	// TypeInterval is `INTERVAL from (TO to)?`.
+	TypeInterval
+	// TypeDateTime is a TIMESTAMP or TIME type with optional precision and an
+	// optional WITH/WITHOUT TIME ZONE clause.
+	TypeDateTime
+	// TypeArray is the legacy angle-bracket array `ARRAY < type >` OR the
+	// postfix `type ARRAY [n]`. The element is in ElementType.
+	TypeArray
+	// TypeMap is the legacy angle-bracket map `MAP < keyType , valueType >`.
+	// KeyType and ValueType hold the components.
+	TypeMap
+)
+
+// String returns a human-readable tag for the kind (diagnostics only).
+func (k TypeKind) String() string {
+	switch k {
+	case TypeGeneric:
+		return "Generic"
+	case TypeRow:
+		return "Row"
+	case TypeInterval:
+		return "Interval"
+	case TypeDateTime:
+		return "DateTime"
+	case TypeArray:
+		return "Array"
+	case TypeMap:
+		return "Map"
+	default:
+		return "Unknown"
+	}
+}
+
+// IntervalField enumerates the single-unit interval qualifiers
+// (intervalField rule). Ordering is the standard coarse→fine sequence and is
+// significant: a `from TO to` range is valid only when both fields share a
+// family and from precedes to (see ValidIntervalRange).
+type IntervalField int
+
+const (
+	IntervalYear IntervalField = iota
+	IntervalMonth
+	IntervalDay
+	IntervalHour
+	IntervalMinute
+	IntervalSecond
+)
+
+// String returns the SQL keyword for the interval field.
+func (f IntervalField) String() string {
+	switch f {
+	case IntervalYear:
+		return "YEAR"
+	case IntervalMonth:
+		return "MONTH"
+	case IntervalDay:
+		return "DAY"
+	case IntervalHour:
+		return "HOUR"
+	case IntervalMinute:
+		return "MINUTE"
+	case IntervalSecond:
+		return "SECOND"
+	default:
+		return "?"
+	}
+}
+
+// isYearMonth reports whether the field belongs to the year-month interval
+// family ({YEAR, MONTH}); the remaining fields form the day-time family.
+func (f IntervalField) isYearMonth() bool {
+	return f == IntervalYear || f == IntervalMonth
+}
+
+// ValidIntervalRange reports whether `INTERVAL from TO to` is a syntactically
+// valid range in Trino 481: both fields must be in the same family
+// (year-month or day-time) and from must be strictly coarser than to
+// (smaller enum value). This is the D1 divergence — the legacy grammar permits
+// every combination; Trino accepts only YEAR TO MONTH and the day-time chain
+// DAY/HOUR/MINUTE → a strictly finer day-time field.
+func ValidIntervalRange(from, to IntervalField) bool {
+	if from.isYearMonth() != to.isYearMonth() {
+		return false
+	}
+	return from < to
+}
+
+// TypeParam is one entry of a genericType parameter list. Exactly one of
+// IsInt/Type is meaningful: an INTEGER_VALUE_ parameter (e.g. the 10 in
+// DECIMAL(10,2)) sets IsInt, IntVal, and IntText; a nested type parameter
+// (e.g. the BIGINT in QDIGEST(BIGINT)) sets Type. typeParameter :=
+// INTEGER_VALUE_ | type.
+//
+// IntText preserves the integer's exact source spelling so round-trip
+// rendering is faithful even when the value overflows int64 (the lexer leaves
+// IntVal at 0 for an out-of-range INTEGER_VALUE_ but keeps the literal text).
+type TypeParam struct {
+	IsInt   bool
+	IntVal  int64
+	IntText string
+	Type    *DataType
+	Loc     ast.Loc
+}
+
+// RowField is one field of a ROW type. Name is the optional field-name
+// identifier (nil for an unnamed field); Type is the field type. rowField :=
+// type | identifier type. Integer entries (ROW(1)) are not RowFields — they are
+// parsed under the genericType "ROW" reading as TypeParams instead.
+type RowField struct {
+	Name *ast.Identifier
+	Type *DataType
+	Loc  ast.Loc
+}
+
+// DataType is a parsed Trino data type. It is a parser-package node (not an
+// ast.Node — the Trino ast tag set is closed to the ast-core node) carrying its
+// own source span; later DAG nodes (expressions, DDL) embed *DataType in their
+// ast results and deparse renders it via String.
+//
+// The active fields depend on Kind:
+//
+//	TypeGeneric  — Name, Params
+//	TypeRow      — Fields
+//	TypeInterval — IntervalFrom, IntervalTo (IntervalTo==nil for single-field)
+//	TypeDateTime — Name (TIMESTAMP|TIME), Precision, WithTimeZone, hasTimeZone
+//	TypeArray    — ElementType (legacy ARRAY<t> or postfix `t ARRAY [n]`)
+//	TypeMap      — KeyType, ValueType
+type DataType struct {
+	Kind TypeKind
+
+	// Name is the source type name. For TypeGeneric it is the identifier
+	// (source-faithful, case preserved). For TypeDateTime it is "TIMESTAMP" or
+	// "TIME". For the legacy array/map and row/interval forms it is the leading
+	// keyword ("ARRAY"/"MAP"/"ROW"/"INTERVAL") for round-tripping.
+	Name string
+
+	// Params holds a genericType parameter list (TypeGeneric only); nil when
+	// the type had no parenthesized parameters.
+	Params []TypeParam
+
+	// Fields holds the ROW field list (TypeRow only).
+	Fields []RowField
+
+	// ElementType is the element of an array (TypeArray): the inner type of a
+	// legacy ARRAY<t> or the operand of a postfix `t ARRAY`.
+	ElementType *DataType
+
+	// KeyType / ValueType are the components of a legacy MAP<k,v> (TypeMap).
+	KeyType   *DataType
+	ValueType *DataType
+
+	// IntervalFrom / IntervalTo describe an INTERVAL type (TypeInterval).
+	// IntervalTo is nil for the single-field form `INTERVAL <field>`.
+	IntervalFrom IntervalField
+	IntervalTo   *IntervalField
+
+	// Precision is the optional precision typeParameter of a TIMESTAMP/TIME
+	// (TypeDateTime); nil when absent. Trino allows precision to be an integer
+	// or (oddly) a nested type; both are captured, with Type set for the latter.
+	Precision *TypeParam
+
+	// WithTimeZone is true for a `WITH TIME ZONE` date-time type, false for
+	// `WITHOUT TIME ZONE` or no zone clause. HasTimeZoneClause distinguishes an
+	// explicit clause from the default; only meaningful for TypeDateTime.
+	WithTimeZone      bool
+	HasTimeZoneClause bool
+
+	// ArrayDim is the optional bracketed dimension of a postfix array
+	// `t ARRAY[n]`; -1 when absent. (Trino accepts the bracket syntactically
+	// but rejects it during analysis; we preserve it for fidelity.)
+	ArrayDim int
+
+	Loc ast.Loc
+}
+
+// String renders the DataType back to Trino source syntax. It is the
+// round-trip rendering downstream deparse relies on; it is not required to be
+// byte-identical to the input (case of unquoted names is preserved, but
+// inter-token spacing is normalized).
+func (t *DataType) String() string {
+	if t == nil {
+		return ""
+	}
+	var b strings.Builder
+	t.writeTo(&b)
+	return b.String()
+}
+
+func (t *DataType) writeTo(b *strings.Builder) {
+	switch t.Kind {
+	case TypeGeneric:
+		b.WriteString(t.Name)
+		if t.Params != nil {
+			b.WriteByte('(')
+			for i, p := range t.Params {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				p.writeTo(b)
+			}
+			b.WriteByte(')')
+		}
+	case TypeRow:
+		b.WriteString("ROW(")
+		for i, f := range t.Fields {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			f.writeTo(b)
+		}
+		b.WriteByte(')')
+	case TypeInterval:
+		b.WriteString("INTERVAL ")
+		b.WriteString(t.IntervalFrom.String())
+		if t.IntervalTo != nil {
+			b.WriteString(" TO ")
+			b.WriteString(t.IntervalTo.String())
+		}
+	case TypeDateTime:
+		b.WriteString(t.Name)
+		if t.Precision != nil {
+			b.WriteByte('(')
+			t.Precision.writeTo(b)
+			b.WriteByte(')')
+		}
+		if t.HasTimeZoneClause {
+			if t.WithTimeZone {
+				b.WriteString(" WITH TIME ZONE")
+			} else {
+				b.WriteString(" WITHOUT TIME ZONE")
+			}
+		}
+	case TypeArray:
+		// Render in the legacy angle-bracket form for an unambiguous round-trip
+		// (postfix `t ARRAY` and `ARRAY<t>` denote the same type).
+		b.WriteString("ARRAY<")
+		t.ElementType.writeTo(b)
+		b.WriteByte('>')
+	case TypeMap:
+		b.WriteString("MAP<")
+		t.KeyType.writeTo(b)
+		b.WriteString(", ")
+		t.ValueType.writeTo(b)
+		b.WriteByte('>')
+	}
+}
+
+func (p TypeParam) writeTo(b *strings.Builder) {
+	if p.IsInt {
+		// Prefer the exact source spelling (faithful even on int64 overflow);
+		// fall back to the parsed value if no text was captured.
+		if p.IntText != "" {
+			b.WriteString(p.IntText)
+		} else {
+			b.WriteString(strconv.FormatInt(p.IntVal, 10))
+		}
+		return
+	}
+	if p.Type != nil {
+		p.Type.writeTo(b)
+	}
+}
+
+func (f RowField) writeTo(b *strings.Builder) {
+	if f.Name != nil {
+		b.WriteString(f.Name.String())
+		b.WriteByte(' ')
+	}
+	if f.Type != nil {
+		f.Type.writeTo(b)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseType — Trino `type` rule
+// ---------------------------------------------------------------------------
+
+// parseType parses a Trino type (the `type` grammar rule) and returns it as a
+// *DataType. It is the single entry point used by every type position — CAST /
+// TRY_CAST targets, column definitions, RETURNING clauses, routine parameter
+// and RETURNS clauses, variable declarations. Returns a *ParseError if the
+// current token does not begin a valid type.
+//
+// The postfix `type ARRAY [n]` is left-recursive in the grammar; it is parsed
+// here by consuming a base type and then looping over trailing ARRAY suffixes.
+func (p *Parser) parseType() (*DataType, error) {
+	base, err := p.parseBaseType()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseArraySuffixes(base)
+}
+
+// parseArraySuffixes consumes zero or more postfix `ARRAY (LSQUARE INTEGER
+// RSQUARE)?` suffixes on an already-parsed base type, wrapping it in a
+// TypeArray for each. `t ARRAY ARRAY` nests twice; `t ARRAY[5]` records the
+// bracketed dimension.
+//
+// The bracket part is optional, but when a '[' is present the grammar requires
+// EXACTLY `[ INTEGER ]` — Trino 481 rejects `t ARRAY[]`, `t ARRAY[abc]`,
+// `t ARRAY[5` (no close), and `t ARRAY[5 6]` with a SYNTAX_ERROR, so a malformed
+// bracket here returns a *ParseError rather than being silently tolerated.
+// (Trino accepts `t ARRAY[n]` at parse time for any integer n; the bracketed
+// dimension fails later during analysis, which is semantic, not syntactic.)
+func (p *Parser) parseArraySuffixes(base *DataType) (*DataType, error) {
+	for p.cur.Kind == kwARRAY {
+		arrTok := p.advance() // consume ARRAY
+		end := arrTok.Loc.End
+		dim := -1
+		if p.cur.Kind == int('[') {
+			p.advance() // consume '['
+			if p.cur.Kind != tokInteger {
+				return nil, p.typeErrorAt("expected integer array dimension after '['")
+			}
+			dim = int(p.cur.Ival)
+			p.advance()
+			closeTok, err := p.expect(int(']'))
+			if err != nil {
+				return nil, err
+			}
+			end = closeTok.Loc.End
+		}
+		base = &DataType{
+			Kind:        TypeArray,
+			Name:        "ARRAY",
+			ElementType: base,
+			ArrayDim:    dim,
+			Loc:         ast.Loc{Start: base.Loc.Start, End: end},
+		}
+	}
+	return base, nil
+}
+
+// parseBaseType parses one `type` alternative WITHOUT the postfix-array suffix
+// (handled by parseArraySuffixes). It dispatches on the leading keyword:
+//
+//   - ROW followed by '(' → rowType.
+//   - INTERVAL followed by an intervalField keyword → intervalType (D2: any
+//     other follow-token, or none, falls through to genericType "INTERVAL").
+//   - TIMESTAMP / TIME → dateTimeType.
+//   - DOUBLE followed by PRECISION → doublePrecisionType ("DOUBLE PRECISION").
+//   - ARRAY followed by '<' → legacy ARRAY<type>.
+//   - MAP followed by '<' → legacy MAP<key,value>.
+//   - anything else (including ROW/ARRAY/MAP/DOUBLE/INTERVAL NOT followed by
+//     their special syntax) → genericType.
+func (p *Parser) parseBaseType() (*DataType, error) {
+	switch p.cur.Kind {
+	case kwROW:
+		if p.peekNext().Kind == int('(') {
+			return p.parseRowType()
+		}
+	case kwINTERVAL:
+		if isIntervalFieldKind(p.peekNext().Kind) {
+			return p.parseIntervalType()
+		}
+	case kwTIMESTAMP, kwTIME:
+		return p.parseDateTimeType()
+	case kwDOUBLE:
+		if p.peekNext().Kind == kwPRECISION {
+			return p.parseDoublePrecisionType()
+		}
+	case kwARRAY:
+		if p.peekNext().Kind == int('<') {
+			return p.parseLegacyArrayType()
+		}
+	case kwMAP:
+		if p.peekNext().Kind == int('<') {
+			return p.parseLegacyMapType()
+		}
+	}
+	return p.parseGenericType()
+}
+
+// isIntervalFieldKind reports whether kind is one of the six intervalField
+// keywords (YEAR/MONTH/DAY/HOUR/MINUTE/SECOND).
+func isIntervalFieldKind(kind TokenKind) bool {
+	switch kind {
+	case kwYEAR, kwMONTH, kwDAY, kwHOUR, kwMINUTE, kwSECOND:
+		return true
+	default:
+		return false
+	}
+}
+
+// intervalFieldFromKind maps an intervalField keyword token to its
+// IntervalField; the bool is false for a non-field kind.
+func intervalFieldFromKind(kind TokenKind) (IntervalField, bool) {
+	switch kind {
+	case kwYEAR:
+		return IntervalYear, true
+	case kwMONTH:
+		return IntervalMonth, true
+	case kwDAY:
+		return IntervalDay, true
+	case kwHOUR:
+		return IntervalHour, true
+	case kwMINUTE:
+		return IntervalMinute, true
+	case kwSECOND:
+		return IntervalSecond, true
+	default:
+		return 0, false
+	}
+}
+
+// parseGenericType parses `identifier (LPAREN typeParameter (COMMA
+// typeParameter)* RPAREN)?`. The leading identifier accepts any non-reserved
+// keyword as a type name (Trino's type names are identifiers), so ARRAY / MAP /
+// ROW / DOUBLE / INTERVAL used without their special syntax land here.
+//
+// If a '(' opens the parameter list, at least one typeParameter is required —
+// `varchar()` and `foo()` are SYNTAX_ERRORs in Trino 481.
+func (p *Parser) parseGenericType() (*DataType, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		// Re-shape the "expected identifier" message as "expected type" so
+		// diagnostics at a type position are actionable.
+		return nil, p.typeError()
+	}
+	dt := &DataType{
+		Kind: TypeGeneric,
+		Name: name.String(),
+		Loc:  name.Loc,
+	}
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		params, endLoc, err := p.parseTypeParamList()
+		if err != nil {
+			return nil, err
+		}
+		dt.Params = params
+		dt.Loc.End = endLoc.End
+	}
+	return dt, nil
+}
+
+// parseTypeParamList parses `typeParameter (COMMA typeParameter)* RPAREN` after
+// the opening '(' has been consumed. At least one parameter is required.
+// Returns the parameters and the Loc spanning through the closing ')'.
+func (p *Parser) parseTypeParamList() ([]TypeParam, ast.Loc, error) {
+	first, err := p.parseTypeParam()
+	if err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	params := []TypeParam{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseTypeParam()
+		if err != nil {
+			return nil, ast.NoLoc(), err
+		}
+		params = append(params, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	return params, closeTok.Loc, nil
+}
+
+// parseTypeParam parses one `typeParameter := INTEGER_VALUE_ | type`. An
+// integer is taken literally (DECIMAL(10,2)); anything else recurses into a
+// full type (QDIGEST(BIGINT), MAP(VARCHAR, ARRAY(INT))).
+func (p *Parser) parseTypeParam() (TypeParam, error) {
+	if p.cur.Kind == tokInteger {
+		tok := p.advance()
+		return TypeParam{IsInt: true, IntVal: tok.Ival, IntText: tok.Str, Loc: tok.Loc}, nil
+	}
+	inner, err := p.parseType()
+	if err != nil {
+		return TypeParam{}, err
+	}
+	return TypeParam{Type: inner, Loc: inner.Loc}, nil
+}
+
+// parseRowType parses a `ROW ( … )` type (the leading ROW and the '(' lookahead
+// were confirmed by the caller). Trino accepts TWO disjoint readings of the
+// parenthesized body and tries them in this order:
+//
+//  1. rowType — `rowField (, rowField)*`, where rowField is `type` or
+//     `identifier type`. NO bare integers. This is ANTLR's `rowType` alt.
+//  2. genericType "ROW" — `typeParameter (, typeParameter)*`, where a
+//     typeParameter is `INTEGER | type`. This is the genericType fallback ANTLR
+//     reaches when rowType fails, and it is the ONLY reading that admits integer
+//     entries: ROW(1), ROW(1, 2), ROW(bigint, 1) all land here.
+//
+// The readings are mutually exclusive on integers and named fields, so a body
+// that mixes them — ROW(a bigint, 1) (a named field plus an integer) — fits
+// NEITHER and is a SYNTAX_ERROR, exactly as Trino rejects it. At least one entry
+// is required (ROW() is a SYNTAX_ERROR under both readings).
+func (p *Parser) parseRowType() (*DataType, error) {
+	rowTok := p.advance() // consume ROW
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// Reading 1 — rowType (no integer fields).
+	cp := p.checkpoint()
+	if fields, closeTok, ok := p.tryRowFields(); ok {
+		return &DataType{
+			Kind:   TypeRow,
+			Name:   "ROW",
+			Fields: fields,
+			Loc:    ast.Loc{Start: rowTok.Loc.Start, End: closeTok.Loc.End},
+		}, nil
+	}
+	p.restore(cp)
+
+	// Reading 2 — genericType "ROW" with a typeParameter list (admits integers).
+	params, endLoc, err := p.parseTypeParamList()
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:   TypeGeneric,
+		Name:   "ROW",
+		Params: params,
+		Loc:    ast.Loc{Start: rowTok.Loc.Start, End: endLoc.End},
+	}, nil
+}
+
+// tryRowFields parses `rowField (, rowField)* )` after the opening '(' has been
+// consumed, returning the fields and the closing-')' token. ok is false (with
+// the cursor left wherever the attempt stopped — the caller restores) if the
+// body is not a valid rowField list, e.g. it contains a bare integer entry.
+func (p *Parser) tryRowFields() (fields []RowField, closeTok Token, ok bool) {
+	first, err := p.parseRowField()
+	if err != nil {
+		return nil, Token{}, false
+	}
+	fields = []RowField{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		f, err := p.parseRowField()
+		if err != nil {
+			return nil, Token{}, false
+		}
+		fields = append(fields, f)
+	}
+	closeTok, err = p.expect(int(')'))
+	if err != nil {
+		return nil, Token{}, false
+	}
+	return fields, closeTok, true
+}
+
+// parserCheckpoint captures enough parser+lexer state to rewind a speculative
+// parse. The lexer is fully described by its byte position and pending error
+// count (its input and baseOffset are immutable); the parser adds its current,
+// previous, and buffered-lookahead tokens.
+type parserCheckpoint struct {
+	lexPos   int
+	lexStart int
+	lexErrs  int
+	cur      Token
+	prev     Token
+	nextBuf  Token
+	hasNext  bool
+}
+
+// checkpoint snapshots the parser/lexer state for a later restore.
+func (p *Parser) checkpoint() parserCheckpoint {
+	return parserCheckpoint{
+		lexPos:   p.lexer.pos,
+		lexStart: p.lexer.start,
+		lexErrs:  len(p.lexer.errors),
+		cur:      p.cur,
+		prev:     p.prev,
+		nextBuf:  p.nextBuf,
+		hasNext:  p.hasNext,
+	}
+}
+
+// restore rewinds the parser/lexer to a previously taken checkpoint, discarding
+// any lex errors recorded after it (a speculative parse must not leak errors).
+func (p *Parser) restore(c parserCheckpoint) {
+	p.lexer.pos = c.lexPos
+	p.lexer.start = c.lexStart
+	if len(p.lexer.errors) > c.lexErrs {
+		p.lexer.errors = p.lexer.errors[:c.lexErrs]
+	}
+	p.cur = c.cur
+	p.prev = c.prev
+	p.nextBuf = c.nextBuf
+	p.hasNext = c.hasNext
+}
+
+// parseRowField parses one `rowField := type | identifier type` (the integer
+// entries of ROW(1) / ROW(1, 2) are NOT handled here — they belong to the
+// genericType "ROW" fallback the parseRowType dispatcher tries when this fails).
+//
+// The grammar is ambiguous between an unnamed `type` and a named
+// `identifier type`: a field name is itself an identifier (and may even be a
+// type keyword — `ROW(timestamp bigint)` names a field `timestamp`), while a
+// type can be multi-token (DOUBLE PRECISION, TIME WITHOUT TIME ZONE, INTERVAL
+// DAY TO SECOND, t ARRAY[5], ARRAY<…>, ARRAY(…)). Two tokens of lookahead are
+// not enough to resolve every case (`ROW(a ARRAY<int>)` names a field `a` of
+// type ARRAY<int>, but `ROW(bigint ARRAY)` is one unnamed postfix-array type —
+// the deciding token comes after ARRAY).
+//
+// Resolution follows ANTLR's alternative order — the unnamed `type` alternative
+// is listed first, so it is tried first: parse a single type and keep that
+// reading if it lands exactly on a field boundary (',' or ')'). Only if the
+// unnamed reading does not fit is the named form `identifier type` tried
+// (consume a one-token name, then a full type, again requiring a clean
+// boundary). Each attempt rewinds on failure via a parser/lexer checkpoint.
+// This accepts every Trino-481 named/unnamed field form (ROW(a), ROW(a b),
+// ROW(a, b), ROW(bigint), ROW(x bigint), ROW(timestamp bigint),
+// ROW(DOUBLE PRECISION), ROW(TIME WITHOUT TIME ZONE), ROW(INTERVAL DAY TO
+// SECOND), ROW(a ARRAY<int>), ROW(bigint ARRAY[5]); unknown type names fail
+// later at resolution, not at parse time).
+func (p *Parser) parseRowField() (RowField, error) {
+	// Attempt 1 — unnamed `type` (ANTLR's first rowField alternative).
+	cp := p.checkpoint()
+	if fieldType, err := p.parseType(); err == nil && p.atRowFieldBoundary() {
+		return RowField{Type: fieldType, Loc: fieldType.Loc}, nil
+	}
+	p.restore(cp)
+
+	// Attempt 2 — named `identifier type`. The name is a single identifier
+	// token; the type follows and must reach a field boundary.
+	if isIdentifierStart(p.cur.Kind) {
+		name := identFromToken(p.advance())
+		if fieldType, err := p.parseType(); err == nil && p.atRowFieldBoundary() {
+			return RowField{
+				Name: name,
+				Type: fieldType,
+				Loc:  ast.Loc{Start: name.Loc.Start, End: fieldType.Loc.End},
+			}, nil
+		}
+		p.restore(cp)
+	}
+
+	// Neither rowField reading fits. Return an error so the ROW dispatch can
+	// fall back to the genericType "ROW" reading (which admits integer entries,
+	// e.g. ROW(1)). The cursor is left for the caller's restore.
+	return RowField{}, p.typeErrorAt("invalid ROW field")
+}
+
+// atRowFieldBoundary reports whether the cursor sits at the end of a ROW field
+// (a ',' separating the next field or the closing ')').
+func (p *Parser) atRowFieldBoundary() bool {
+	return p.cur.Kind == int(',') || p.cur.Kind == int(')')
+}
+
+// parseIntervalType parses `INTERVAL from (TO to)?` (the caller confirmed the
+// next token is an intervalField). The D1 divergence is enforced: a TO range is
+// accepted only for valid SQL-standard qualifier pairs (ValidIntervalRange);
+// an invalid pair (e.g. SECOND TO YEAR, YEAR TO DAY) is a SYNTAX_ERROR, exactly
+// as Trino 481 rejects it.
+func (p *Parser) parseIntervalType() (*DataType, error) {
+	intervalTok := p.advance() // consume INTERVAL
+	fromTok := p.advance()     // the intervalField (confirmed by caller)
+	from, _ := intervalFieldFromKind(fromTok.Kind)
+
+	dt := &DataType{
+		Kind:         TypeInterval,
+		Name:         "INTERVAL",
+		IntervalFrom: from,
+		Loc:          ast.Loc{Start: intervalTok.Loc.Start, End: fromTok.Loc.End},
+	}
+
+	if p.cur.Kind == kwTO {
+		toTok := p.peekNext()
+		to, ok := intervalFieldFromKind(toTok.Kind)
+		if !ok {
+			// `TO` not followed by an interval field — e.g. INTERVAL DAY TO foo.
+			p.advance() // consume TO so the error points at the bad to-field
+			return nil, p.typeErrorAt("expected interval field after TO")
+		}
+		if !ValidIntervalRange(from, to) {
+			// Reversed or cross-family range — Trino rejects this at parse time.
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "invalid interval qualifier: " + from.String() + " TO " + to.String(),
+			}
+		}
+		p.advance() // consume TO
+		toEnd := p.advance()
+		toVal := to
+		dt.IntervalTo = &toVal
+		dt.Loc.End = toEnd.Loc.End
+	}
+	return dt, nil
+}
+
+// parseDateTimeType parses a TIMESTAMP or TIME type:
+// `base (LPAREN precision RPAREN)? ((WITH | WITHOUT) TIME ZONE)?`. The base
+// keyword (the caller confirmed it is TIMESTAMP or TIME) is retained verbatim
+// for round-tripping. precision is a typeParameter (integer or, oddly, a
+// nested type — Trino parses TIMESTAMP(bigint) and fails later).
+func (p *Parser) parseDateTimeType() (*DataType, error) {
+	baseTok := p.advance() // TIMESTAMP or TIME
+	name := "TIMESTAMP"
+	if baseTok.Kind == kwTIME {
+		name = "TIME"
+	}
+	dt := &DataType{
+		Kind: TypeDateTime,
+		Name: name,
+		Loc:  baseTok.Loc,
+	}
+
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		prec, err := p.parseTypeParam()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		dt.Precision = &prec
+		dt.Loc.End = closeTok.Loc.End
+	}
+
+	// Optional WITH/WITHOUT TIME ZONE.
+	if p.cur.Kind == kwWITH || p.cur.Kind == kwWITHOUT {
+		withTok := p.advance()
+		if _, err := p.expect(kwTIME); err != nil {
+			return nil, err
+		}
+		zoneTok, err := p.expect(kwZONE)
+		if err != nil {
+			return nil, err
+		}
+		dt.HasTimeZoneClause = true
+		dt.WithTimeZone = withTok.Kind == kwWITH
+		dt.Loc.End = zoneTok.Loc.End
+	}
+	return dt, nil
+}
+
+// parseDoublePrecisionType parses `DOUBLE PRECISION` (the caller confirmed both
+// keywords). Plain `DOUBLE` is handled by genericType.
+func (p *Parser) parseDoublePrecisionType() (*DataType, error) {
+	doubleTok := p.advance()    // DOUBLE
+	precisionTok := p.advance() // PRECISION
+	return &DataType{
+		Kind: TypeGeneric,
+		Name: "DOUBLE PRECISION",
+		Loc:  ast.Loc{Start: doubleTok.Loc.Start, End: precisionTok.Loc.End},
+	}, nil
+}
+
+// parseLegacyArrayType parses `ARRAY < type >` (the caller confirmed ARRAY '<').
+func (p *Parser) parseLegacyArrayType() (*DataType, error) {
+	arrTok := p.advance() // ARRAY
+	if _, err := p.expect(int('<')); err != nil {
+		return nil, err
+	}
+	elem, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	gtTok, err := p.expect(int('>'))
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:        TypeArray,
+		Name:        "ARRAY",
+		ElementType: elem,
+		ArrayDim:    -1,
+		Loc:         ast.Loc{Start: arrTok.Loc.Start, End: gtTok.Loc.End},
+	}, nil
+}
+
+// parseLegacyMapType parses `MAP < keyType , valueType >` (the caller confirmed
+// MAP '<').
+func (p *Parser) parseLegacyMapType() (*DataType, error) {
+	mapTok := p.advance() // MAP
+	if _, err := p.expect(int('<')); err != nil {
+		return nil, err
+	}
+	keyType, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+	valueType, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	gtTok, err := p.expect(int('>'))
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:      TypeMap,
+		Name:      "MAP",
+		KeyType:   keyType,
+		ValueType: valueType,
+		Loc:       ast.Loc{Start: mapTok.Loc.Start, End: gtTok.Loc.End},
+	}, nil
+}
+
+// typeError returns a *ParseError describing a missing type at the current
+// token, distinct from the generic identifier error so a type position reports
+// "expected type".
+func (p *Parser) typeError() *ParseError {
+	if p.cur.Kind == tokEOF {
+		return &ParseError{Loc: p.cur.Loc, Msg: "expected type, found end of input"}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Kind)
+	}
+	return &ParseError{Loc: p.cur.Loc, Msg: "expected type, found " + text}
+}
+
+// typeErrorAt returns a *ParseError with a custom message at the current token.
+func (p *Parser) typeErrorAt(msg string) *ParseError {
+	return &ParseError{Loc: p.cur.Loc, Msg: msg}
+}
+
+// ParseDataType parses a complete Trino type from a standalone string,
+// returning the *DataType and any ParseErrors. Trailing tokens after the type
+// are reported as an error. It is the string-input counterpart of parseType,
+// for tests and callers (catalog, deparse) that hold a type string rather than
+// a token stream. Mirrors snowflake/parser.ParseDataType and
+// ParseQualifiedName in identifiers.go.
+func ParseDataType(input string) (*DataType, []ParseError) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+
+	dt, err := p.parseType()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+	if p.cur.Kind != tokEOF {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Kind)
+		}
+		return dt, []ParseError{{Loc: p.cur.Loc, Msg: "unexpected token after type: " + text}}
+	}
+	return dt, nil
+}

--- a/trino/parser/datatypes_test.go
+++ b/trino/parser/datatypes_test.go
@@ -1,0 +1,756 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the `types` node's correctness gate. It has three layers, in
+// order of authority (correctness-protocol.md):
+//
+//  1. Structural unit tests — assert ParseDataType builds the right DataType
+//     shape (Kind, Name, params, nesting, interval fields, time-zone flags) for
+//     representative inputs. These pin the AST contract downstream nodes embed.
+//
+//  2. Differential oracle gate — the authoritative accept/reject check. Each
+//     type is wrapped as `CAST(NULL AS <type>)` (the canonical type position)
+//     and omni's accept/reject of the standalone type must equal Trino 481's
+//     accept/reject of the wrapped statement. The corpus carries BOTH accepted
+//     types (every documented form + legacy forms) and rejected ones (negative
+//     coverage: empty parens, reversed/cross-family interval ranges, malformed
+//     angle brackets, trailing commas). Classification keys on SYNTAX_ERROR
+//     only — TYPE_MISMATCH / NOT_SUPPORTED / GENERIC_INTERNAL_ERROR all mean
+//     Trino's grammar ACCEPTED and the failure is semantic.
+//
+//  3. Deparse round-trip — parse → String() → re-parse must yield an equal
+//     accept verdict and a stable structure, and the re-rendered type must
+//     still be accepted by the oracle. This is the structural gate (no
+//     reference parser exists for Trino types).
+//
+// All oracle-backed subtests skip cleanly when no Trino is reachable.
+
+// ---------------------------------------------------------------------------
+// Layer 1 — structural unit tests
+// ---------------------------------------------------------------------------
+
+func TestDataType_Structure(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, dt *DataType)
+	}{
+		{
+			name:  "generic_no_params",
+			input: "bigint",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeGeneric || dt.Name != "bigint" || dt.Params != nil {
+					t.Errorf("got Kind=%v Name=%q Params=%v", dt.Kind, dt.Name, dt.Params)
+				}
+			},
+		},
+		{
+			name:  "generic_one_int_param",
+			input: "varchar(100)",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeGeneric || dt.Name != "varchar" || len(dt.Params) != 1 {
+					t.Fatalf("got Kind=%v Name=%q Params=%v", dt.Kind, dt.Name, dt.Params)
+				}
+				if !dt.Params[0].IsInt || dt.Params[0].IntVal != 100 {
+					t.Errorf("param[0]=%+v, want int 100", dt.Params[0])
+				}
+			},
+		},
+		{
+			name:  "generic_two_int_params",
+			input: "decimal(38, 10)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Params) != 2 || !dt.Params[0].IsInt || dt.Params[0].IntVal != 38 ||
+					!dt.Params[1].IsInt || dt.Params[1].IntVal != 10 {
+					t.Errorf("params=%+v, want [38 10]", dt.Params)
+				}
+			},
+		},
+		{
+			// An int parameter beyond int64 range keeps its exact source text so
+			// String() round-trips it faithfully (regression: the cross-review
+			// gate flagged that rendering from the parsed value alone prints 0).
+			name:  "generic_overflow_int_param",
+			input: "decimal(9223372036854775808)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Params) != 1 || !dt.Params[0].IsInt {
+					t.Fatalf("params=%+v", dt.Params)
+				}
+				if dt.Params[0].IntText != "9223372036854775808" {
+					t.Errorf("IntText=%q, want exact source", dt.Params[0].IntText)
+				}
+				if got := dt.String(); got != "decimal(9223372036854775808)" {
+					t.Errorf("String()=%q, want decimal(9223372036854775808)", got)
+				}
+			},
+		},
+		{
+			name:  "generic_nested_type_param",
+			input: "qdigest(bigint)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Params) != 1 || dt.Params[0].IsInt || dt.Params[0].Type == nil {
+					t.Fatalf("params=%+v, want one nested-type param", dt.Params)
+				}
+				if dt.Params[0].Type.Name != "bigint" {
+					t.Errorf("nested param type=%q, want bigint", dt.Params[0].Type.Name)
+				}
+			},
+		},
+		{
+			name:  "double_precision",
+			input: "double precision",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeGeneric || dt.Name != "DOUBLE PRECISION" {
+					t.Errorf("got Kind=%v Name=%q, want Generic DOUBLE PRECISION", dt.Kind, dt.Name)
+				}
+			},
+		},
+		{
+			name:  "double_alone_is_generic",
+			input: "double",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeGeneric || dt.Name != "double" {
+					t.Errorf("got Kind=%v Name=%q, want Generic double", dt.Kind, dt.Name)
+				}
+			},
+		},
+		{
+			name:  "row_named_fields",
+			input: "ROW(x bigint, y double)",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeRow || len(dt.Fields) != 2 {
+					t.Fatalf("got Kind=%v Fields=%+v", dt.Kind, dt.Fields)
+				}
+				if dt.Fields[0].Name == nil || dt.Fields[0].Name.Value != "x" || dt.Fields[0].Type.Name != "bigint" {
+					t.Errorf("field0=%+v, want name x type bigint", dt.Fields[0])
+				}
+				if dt.Fields[1].Name == nil || dt.Fields[1].Name.Value != "y" {
+					t.Errorf("field1=%+v, want name y", dt.Fields[1])
+				}
+			},
+		},
+		{
+			name:  "row_unnamed_fields",
+			input: "ROW(bigint, varchar)",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeRow || len(dt.Fields) != 2 {
+					t.Fatalf("got Kind=%v Fields=%+v", dt.Kind, dt.Fields)
+				}
+				if dt.Fields[0].Name != nil || dt.Fields[0].Type.Name != "bigint" {
+					t.Errorf("field0=%+v, want unnamed bigint", dt.Fields[0])
+				}
+			},
+		},
+		{
+			name:  "row_quoted_field_name",
+			input: `ROW("x y" bigint)`,
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Fields) != 1 || dt.Fields[0].Name == nil || !dt.Fields[0].Name.Quoted ||
+					dt.Fields[0].Name.Value != "x y" {
+					t.Errorf("field0=%+v, want quoted name 'x y'", dt.Fields[0])
+				}
+			},
+		},
+		{
+			name:  "row_nested_type_field",
+			input: "ROW(a ARRAY(int))",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Fields) != 1 || dt.Fields[0].Name == nil || dt.Fields[0].Name.Value != "a" {
+					t.Fatalf("fields=%+v", dt.Fields)
+				}
+				ft := dt.Fields[0].Type
+				if ft == nil || ft.Kind != TypeGeneric || ft.Name != "ARRAY" || len(ft.Params) != 1 {
+					t.Errorf("field type=%+v, want generic ARRAY(int)", ft)
+				}
+			},
+		},
+		{
+			// Unnamed field whose type is a multi-token dateTimeType: the leading
+			// TIME must be parsed as the type, NOT consumed as a field name.
+			name:  "row_unnamed_datetime_field",
+			input: "ROW(TIME WITHOUT TIME ZONE)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Fields) != 1 {
+					t.Fatalf("fields=%+v", dt.Fields)
+				}
+				f := dt.Fields[0]
+				if f.Name != nil {
+					t.Errorf("field should be unnamed, got name=%v", f.Name)
+				}
+				if f.Type == nil || f.Type.Kind != TypeDateTime || f.Type.Name != "TIME" || f.Type.WithTimeZone {
+					t.Errorf("field type=%+v, want unnamed TIME WITHOUT TIME ZONE", f.Type)
+				}
+			},
+		},
+		{
+			// Unnamed field whose type is a multi-token intervalType.
+			name:  "row_unnamed_interval_field",
+			input: "ROW(INTERVAL DAY TO SECOND)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Fields) != 1 || dt.Fields[0].Name != nil {
+					t.Fatalf("fields=%+v, want one unnamed field", dt.Fields)
+				}
+				ft := dt.Fields[0].Type
+				if ft == nil || ft.Kind != TypeInterval || ft.IntervalFrom != IntervalDay ||
+					ft.IntervalTo == nil || *ft.IntervalTo != IntervalSecond {
+					t.Errorf("field type=%+v, want INTERVAL DAY TO SECOND", ft)
+				}
+			},
+		},
+		{
+			// Named field whose type is a legacy angle-bracket array: `a` is the
+			// name, ARRAY<int> the type (needs >2-token disambiguation).
+			name:  "row_named_legacy_array_field",
+			input: "ROW(a ARRAY<int>)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Fields) != 1 || dt.Fields[0].Name == nil || dt.Fields[0].Name.Value != "a" {
+					t.Fatalf("fields=%+v", dt.Fields)
+				}
+				ft := dt.Fields[0].Type
+				if ft == nil || ft.Kind != TypeArray || ft.ElementType == nil || ft.ElementType.Name != "int" {
+					t.Errorf("field type=%+v, want ARRAY<int>", ft)
+				}
+			},
+		},
+		{
+			// Unnamed DOUBLE PRECISION field (ANTLR's unnamed alt is tried first,
+			// so this is one type, not name 'double' + type 'precision').
+			name:  "row_unnamed_double_precision_field",
+			input: "ROW(double precision)",
+			check: func(t *testing.T, dt *DataType) {
+				if len(dt.Fields) != 1 || dt.Fields[0].Name != nil {
+					t.Fatalf("fields=%+v, want one unnamed field", dt.Fields)
+				}
+				if dt.Fields[0].Type.Name != "DOUBLE PRECISION" {
+					t.Errorf("field type name=%q, want DOUBLE PRECISION", dt.Fields[0].Type.Name)
+				}
+			},
+		},
+		{
+			// An all-integer ROW body has no valid rowField reading (rowField has
+			// no integer alternative), so it falls back to the genericType "ROW"
+			// reading with INTEGER typeParameters — NOT a TypeRow.
+			name:  "row_all_integers_is_generic",
+			input: "ROW(1, 2)",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeGeneric || dt.Name != "ROW" || len(dt.Params) != 2 {
+					t.Fatalf("got Kind=%v Name=%q Params=%+v, want generic ROW(1,2)", dt.Kind, dt.Name, dt.Params)
+				}
+				if !dt.Params[0].IsInt || dt.Params[0].IntVal != 1 || !dt.Params[1].IsInt || dt.Params[1].IntVal != 2 {
+					t.Errorf("params=%+v, want int [1 2]", dt.Params)
+				}
+			},
+		},
+		{
+			name:  "interval_single_field",
+			input: "INTERVAL DAY",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeInterval || dt.IntervalFrom != IntervalDay || dt.IntervalTo != nil {
+					t.Errorf("got Kind=%v from=%v to=%v", dt.Kind, dt.IntervalFrom, dt.IntervalTo)
+				}
+			},
+		},
+		{
+			name:  "interval_range",
+			input: "INTERVAL DAY TO SECOND",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeInterval || dt.IntervalFrom != IntervalDay ||
+					dt.IntervalTo == nil || *dt.IntervalTo != IntervalSecond {
+					t.Errorf("got Kind=%v from=%v to=%v", dt.Kind, dt.IntervalFrom, dt.IntervalTo)
+				}
+			},
+		},
+		{
+			name:  "interval_year_to_month",
+			input: "INTERVAL YEAR TO MONTH",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.IntervalFrom != IntervalYear || dt.IntervalTo == nil || *dt.IntervalTo != IntervalMonth {
+					t.Errorf("got from=%v to=%v", dt.IntervalFrom, dt.IntervalTo)
+				}
+			},
+		},
+		{
+			name:  "interval_bare_is_generic",
+			input: "INTERVAL",
+			check: func(t *testing.T, dt *DataType) {
+				// D2: bare INTERVAL (no field) falls through to genericType.
+				if dt.Kind != TypeGeneric || dt.Name != "INTERVAL" {
+					t.Errorf("got Kind=%v Name=%q, want Generic INTERVAL", dt.Kind, dt.Name)
+				}
+			},
+		},
+		{
+			name:  "interval_paren_is_generic",
+			input: "INTERVAL(5)",
+			check: func(t *testing.T, dt *DataType) {
+				// D2: INTERVAL '(' is genericType, not intervalType.
+				if dt.Kind != TypeGeneric || dt.Name != "INTERVAL" || len(dt.Params) != 1 {
+					t.Errorf("got Kind=%v Name=%q params=%+v", dt.Kind, dt.Name, dt.Params)
+				}
+			},
+		},
+		{
+			name:  "timestamp_bare",
+			input: "TIMESTAMP",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeDateTime || dt.Name != "TIMESTAMP" || dt.Precision != nil || dt.HasTimeZoneClause {
+					t.Errorf("got %+v", dt)
+				}
+			},
+		},
+		{
+			name:  "timestamp_precision_with_tz",
+			input: "TIMESTAMP(6) WITH TIME ZONE",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeDateTime || dt.Precision == nil || !dt.Precision.IsInt || dt.Precision.IntVal != 6 {
+					t.Fatalf("precision=%+v", dt.Precision)
+				}
+				if !dt.HasTimeZoneClause || !dt.WithTimeZone {
+					t.Errorf("tz: has=%v with=%v, want true/true", dt.HasTimeZoneClause, dt.WithTimeZone)
+				}
+			},
+		},
+		{
+			name:  "time_without_tz",
+			input: "TIME WITHOUT TIME ZONE",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Name != "TIME" || !dt.HasTimeZoneClause || dt.WithTimeZone {
+					t.Errorf("got Name=%q has=%v with=%v", dt.Name, dt.HasTimeZoneClause, dt.WithTimeZone)
+				}
+			},
+		},
+		{
+			name:  "legacy_array",
+			input: "ARRAY<bigint>",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeArray || dt.ElementType == nil || dt.ElementType.Name != "bigint" {
+					t.Errorf("got %+v", dt)
+				}
+			},
+		},
+		{
+			name:  "legacy_map",
+			input: "MAP<varchar, integer>",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeMap || dt.KeyType == nil || dt.KeyType.Name != "varchar" ||
+					dt.ValueType == nil || dt.ValueType.Name != "integer" {
+					t.Errorf("got %+v", dt)
+				}
+			},
+		},
+		{
+			name:  "array_paren_is_generic",
+			input: "ARRAY(bigint)",
+			check: func(t *testing.T, dt *DataType) {
+				// ARRAY '(' → genericType ARRAY with a nested-type param.
+				if dt.Kind != TypeGeneric || dt.Name != "ARRAY" || len(dt.Params) != 1 || dt.Params[0].Type == nil {
+					t.Errorf("got %+v", dt)
+				}
+			},
+		},
+		{
+			name:  "postfix_array",
+			input: "bigint ARRAY",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeArray || dt.ElementType == nil || dt.ElementType.Name != "bigint" {
+					t.Errorf("got %+v", dt)
+				}
+			},
+		},
+		{
+			name:  "postfix_array_with_dim",
+			input: "bigint ARRAY[5]",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeArray || dt.ArrayDim != 5 {
+					t.Errorf("got Kind=%v dim=%d", dt.Kind, dt.ArrayDim)
+				}
+			},
+		},
+		{
+			name:  "postfix_array_nested",
+			input: "bigint ARRAY ARRAY",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeArray || dt.ElementType == nil || dt.ElementType.Kind != TypeArray {
+					t.Fatalf("got %+v", dt)
+				}
+				if dt.ElementType.ElementType == nil || dt.ElementType.ElementType.Name != "bigint" {
+					t.Errorf("inner element=%+v", dt.ElementType.ElementType)
+				}
+			},
+		},
+		{
+			name:  "nested_array_of_array_paren",
+			input: "ARRAY(ARRAY(bigint))",
+			check: func(t *testing.T, dt *DataType) {
+				if dt.Kind != TypeGeneric || len(dt.Params) != 1 || dt.Params[0].Type == nil {
+					t.Fatalf("got %+v", dt)
+				}
+				inner := dt.Params[0].Type
+				if inner.Kind != TypeGeneric || inner.Name != "ARRAY" {
+					t.Errorf("inner=%+v, want generic ARRAY", inner)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dt, errs := ParseDataType(tc.input)
+			if len(errs) != 0 {
+				t.Fatalf("ParseDataType(%q) errors: %v", tc.input, errs)
+			}
+			if dt == nil {
+				t.Fatalf("ParseDataType(%q) returned nil", tc.input)
+			}
+			tc.check(t, dt)
+		})
+	}
+}
+
+// TestDataType_LocSpan asserts the parsed type's Loc covers exactly the type
+// text (no leading/trailing slop), which downstream completion/diagnostics
+// depend on for accurate ranges.
+func TestDataType_LocSpan(t *testing.T) {
+	for _, input := range []string{
+		"bigint",
+		"varchar(100)",
+		"decimal(38, 10)",
+		"ROW(x bigint, y double)",
+		"INTERVAL DAY TO SECOND",
+		"TIMESTAMP(6) WITH TIME ZONE",
+		"ARRAY<bigint>",
+		"MAP<varchar, integer>",
+		"bigint ARRAY[5]",
+		"double precision",
+	} {
+		t.Run(truncateName(input), func(t *testing.T) {
+			dt, errs := ParseDataType(input)
+			if len(errs) != 0 {
+				t.Fatalf("errors: %v", errs)
+			}
+			if dt.Loc.Start != 0 || dt.Loc.End != len(input) {
+				t.Errorf("Loc=%+v, want [0,%d) covering %q", dt.Loc, len(input), input)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — differential oracle corpus
+// ---------------------------------------------------------------------------
+
+// typeAcceptCorpus lists types Trino 481 accepts syntactically (it may still
+// fail later semantically — that is fine, classification keys on SYNTAX_ERROR).
+// It covers every documented type form (truth1) plus the legacy ARRAY<>/MAP<>
+// spellings and the postfix-array forms.
+var typeAcceptCorpus = []string{
+	// --- generic scalar types (type names are identifiers, not keywords) ---
+	"boolean",
+	"tinyint", "smallint", "integer", "int", "bigint",
+	"real", "double", "double precision",
+	"decimal", "decimal(38)", "decimal(38, 10)",
+	"varchar", "varchar(100)", "char", "char(10)",
+	"varbinary",
+	"json", "variant",
+	"date",
+	"uuid", "ipaddress",
+	"hyperloglog", "p4hyperloglog", "tdigest", "setdigest",
+	"qdigest(bigint)", "qdigest(double)",
+	// quoted type name
+	`"varchar"(10)`,
+	// --- time / timestamp with precision and time zone ---
+	"time", "time(3)", "time with time zone", "time(6) with time zone",
+	"time without time zone",
+	"timestamp", "timestamp(6)", "timestamp with time zone",
+	"timestamp(9) with time zone", "timestamp without time zone",
+	// --- interval (single field + valid ranges; D1) ---
+	"interval year", "interval month", "interval day",
+	"interval hour", "interval minute", "interval second",
+	"interval year to month",
+	"interval day to hour", "interval day to minute", "interval day to second",
+	"interval hour to minute", "interval hour to second",
+	"interval minute to second",
+	// D2: INTERVAL not followed by a field is a generic type name
+	"interval", "interval(5)", "interval array",
+	// --- ROW (named, unnamed, nested, quoted, integer-spelling backtrack) ---
+	"ROW(x bigint, y double)",
+	"ROW(bigint, double)",
+	"ROW(bigint)",
+	`ROW("x y" bigint)`,
+	"ROW(a ARRAY(int))",
+	"ROW(a int ARRAY)",
+	"ROW(x map(varchar, int))",
+	"ROW(a double precision)",
+	"ROW(a row(b int))",
+	"ROW(1)",    // backtracks into genericType typeParameter
+	"ROW(a b)",  // both identifiers (a=name, b=type)
+	"ROW(a, b)", // two unnamed generic fields
+	"ROW(a bigint, b)",
+	"row(x double precision)",
+	// ALL-typeParameter ROW bodies (every entry is INTEGER | bare type) fall
+	// back to the genericType "ROW" reading, which is the only one that admits
+	// integers. Mixing an integer with a NAMED field fits neither reading and is
+	// a reject (see typeRejectCorpus).
+	"ROW(1, 2)",
+	"ROW(bigint, 1)",
+	"ROW(varchar(10), 5)",
+	"ROW(5, 10, 15)",
+	// fields whose (unnamed) type is a structural/keyword type, and the
+	// converse where a type keyword serves as a field NAME — accept/reject must
+	// match regardless of how omni assigns names internally.
+	"ROW(timestamp)",
+	"ROW(interval day)",
+	"ROW(double precision)",
+	"ROW(array<int>)",
+	"ROW(map<int, int>)",
+	"ROW(time bigint)",      // 'time' keyword as a field NAME
+	"ROW(timestamp bigint)", // 'timestamp' keyword as a field NAME
+	"ROW(array bigint)",     // 'array' keyword as a field NAME
+	"ROW(a bigint array)",   // named field of a postfix-array type
+	"ROW(bigint array)",     // unnamed postfix-array field
+	"ROW(a timestamp(3) with time zone)",
+	"ROW(a interval day to second)",
+	// UNNAMED multi-token field types — the leading keyword must be taken as a
+	// type, not over-consumed as a field name (regression: caught by the
+	// cross-review gate; a 2-token lookahead heuristic mis-rejected these).
+	"ROW(TIME WITHOUT TIME ZONE)",
+	"ROW(TIMESTAMP WITH TIME ZONE)",
+	"ROW(INTERVAL DAY TO SECOND)",
+	"ROW(BIGINT ARRAY[5])",
+	"ROW(DOUBLE PRECISION)",
+	"ROW(a ARRAY<int>)", // named field whose type is a legacy angle-bracket array
+	"ROW(a ARRAY(int))", // named field whose type is a paren array
+	"ROW(x TIME WITHOUT TIME ZONE, y INTERVAL DAY TO SECOND)",
+	// many-field ROW mixing named/unnamed, parameterized, and multi-token types
+	// (exercises the speculative name/type backtracking across several fields).
+	"ROW(a int, b varchar(10), c TIMESTAMP WITH TIME ZONE, d INTERVAL DAY TO SECOND, e ARRAY<int>)",
+	"ROW(a ARRAY<int>, b ARRAY(int), c bigint ARRAY[5])",
+	// --- ARRAY / MAP, both legacy <> and modern () spellings ---
+	"ARRAY<bigint>",
+	"ARRAY(bigint)",
+	"ARRAY(ARRAY(bigint))",
+	"ARRAY<ARRAY<bigint>>",
+	"MAP<varchar, integer>",
+	"MAP(varchar, integer)",
+	"MAP(varchar, ARRAY(bigint))",
+	"MAP<varchar, ARRAY<bigint>>",
+	"ARRAY(ROW(a bigint, b varchar))",
+	// --- postfix array ---
+	"bigint ARRAY",
+	"bigint ARRAY ARRAY",
+	"bigint ARRAY[5]",
+	"decimal(10, 2) ARRAY",
+	"INTERVAL DAY TO SECOND ARRAY",
+	"TIMESTAMP(3) WITH TIME ZONE ARRAY",
+	// --- nested combinations ---
+	"MAP(varchar, ROW(a bigint, b ARRAY(double)))",
+	"ARRAY(MAP(varchar, bigint))",
+}
+
+// typeRejectCorpus lists types Trino 481 rejects with SYNTAX_ERROR. This is the
+// required negative coverage: without it the parser could be over-permissive
+// and still pass every accept case.
+var typeRejectCorpus = []string{
+	// empty parameter lists
+	"varchar()",
+	"foo()",
+	"bigint()",
+	// empty / malformed ROW
+	"ROW()",
+	"ROW(a bigint,)",           // trailing comma
+	"ROW(a b c)",               // three bare tokens: a name + type leaves a dangling token
+	"ROW(a varchar(10) extra)", // parameterized field type followed by a stray token
+	"ROW(a bigint, 1)",         // named field mixed with an integer fits neither ROW reading
+	"ROW(1, a bigint)",         // integer mixed with a named field
+	"ROW(x bigint, y 5)",       // 'y 5' is neither a rowField nor a typeParameter
+	"ROW(varchar(10) x, 5)",    // a named field forces rowType, which rejects the integer
+	// D1: reversed / cross-family interval ranges
+	"interval month to year",
+	"interval year to day",
+	"interval day to year",
+	"interval second to year",
+	"interval second to minute",
+	"interval to second", // TO not preceded by a field (INTERVAL '(' path? actually INTERVAL TO)
+	// malformed angle brackets
+	"MAP<varchar>",  // map needs two components
+	"MAP<varchar,>", // missing value type
+	"ARRAY<>",       // empty element
+	"ROW<bigint>",   // ROW uses parens, not angle brackets
+	// stray time-zone tokens
+	"timestamp with zone",    // missing TIME
+	"timestamp without zone", // missing TIME
+	"double precision precision",
+	// malformed postfix-array brackets: `[` requires exactly `[ INTEGER ]`
+	"bigint ARRAY[]",    // empty brackets
+	"bigint ARRAY[abc]", // non-integer dimension
+	"bigint ARRAY[5",    // missing close bracket
+	"bigint ARRAY[5 6]", // extra token in brackets
+}
+
+// wrapType embeds a type in the canonical type position for the oracle: a
+// CAST target inside a SELECT (a bare `CAST(...)` is not a statement and Trino
+// rejects it before reaching the type grammar).
+func wrapType(typ string) string { return "SELECT CAST(NULL AS " + typ + ")" }
+
+// TestDataType_AcceptCorpusParses verifies (oracle-free) that omni accepts
+// every type in typeAcceptCorpus when wrapped in a SELECT CAST. This is the
+// completeness smoke test; the oracle differential below proves the verdicts
+// actually agree with Trino.
+//
+// Note: the wrapped statement reaches omni's CAST/SELECT parsing, which is NOT
+// implemented in this node — so we exercise ParseDataType directly on the bare
+// type instead, which is exactly the function this node ships.
+func TestDataType_AcceptCorpusParses(t *testing.T) {
+	for _, typ := range typeAcceptCorpus {
+		t.Run(truncateName(typ), func(t *testing.T) {
+			dt, errs := ParseDataType(typ)
+			if len(errs) != 0 {
+				t.Errorf("ParseDataType(%q) should accept, got errors: %v", typ, errs)
+			}
+			if dt == nil {
+				t.Errorf("ParseDataType(%q) returned nil", typ)
+			}
+		})
+	}
+}
+
+// TestDataType_RejectCorpusRejected verifies omni rejects every type in
+// typeRejectCorpus (negative coverage). ParseDataType must surface at least one
+// error for each.
+func TestDataType_RejectCorpusRejected(t *testing.T) {
+	for _, typ := range typeRejectCorpus {
+		t.Run(truncateName(typ), func(t *testing.T) {
+			_, errs := ParseDataType(typ)
+			if len(errs) == 0 {
+				t.Errorf("ParseDataType(%q) should reject, but accepted", typ)
+			}
+		})
+	}
+}
+
+// TestDataType_OracleDifferential is the authoritative gate: for every type in
+// both corpora, omni's ParseDataType accept/reject must equal Trino 481's
+// accept/reject of `CAST(NULL AS <type>)`. Skipped when no oracle is reachable.
+func TestDataType_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+
+	check := func(t *testing.T, typ string) {
+		_, errs := ParseDataType(typ)
+		omniAccepts := len(errs) == 0
+
+		trinoAccepts, ok := oracleAccepts(t, o, wrapType(typ))
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH type=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				typ, omniAccepts, errs, trinoAccepts)
+		}
+	}
+
+	t.Run("accept", func(t *testing.T) {
+		for _, typ := range typeAcceptCorpus {
+			typ := typ
+			t.Run(truncateName(typ), func(t *testing.T) { check(t, typ) })
+		}
+	})
+	t.Run("reject", func(t *testing.T) {
+		for _, typ := range typeRejectCorpus {
+			typ := typ
+			t.Run(truncateName(typ), func(t *testing.T) { check(t, typ) })
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3 — deparse round-trip (structural gate)
+// ---------------------------------------------------------------------------
+
+// TestDataType_RoundTrip parses each accepted type, renders it via String(),
+// re-parses the rendering, and asserts the re-parse also succeeds and yields
+// the same top-level Kind. This is the structural correctness gate in the
+// absence of a reference type parser.
+func TestDataType_RoundTrip(t *testing.T) {
+	for _, typ := range typeAcceptCorpus {
+		t.Run(truncateName(typ), func(t *testing.T) {
+			dt, errs := ParseDataType(typ)
+			if len(errs) != 0 {
+				t.Fatalf("first parse of %q failed: %v", typ, errs)
+			}
+			rendered := dt.String()
+			dt2, errs2 := ParseDataType(rendered)
+			if len(errs2) != 0 {
+				t.Fatalf("re-parse of rendered %q (from %q) failed: %v", rendered, typ, errs2)
+			}
+			if dt2.Kind != dt.Kind {
+				t.Errorf("round-trip changed Kind: %q -> %q (%v -> %v)", typ, rendered, dt.Kind, dt2.Kind)
+			}
+		})
+	}
+}
+
+// TestDataType_RoundTripOracle verifies the String() rendering of every
+// accepted type is itself accepted by Trino — proving deparse emits valid Trino
+// type syntax. Skipped without an oracle.
+func TestDataType_RoundTripOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, typ := range typeAcceptCorpus {
+		typ := typ
+		t.Run(truncateName(typ), func(t *testing.T) {
+			dt, errs := ParseDataType(typ)
+			if len(errs) != 0 {
+				t.Fatalf("parse of %q failed: %v", typ, errs)
+			}
+			rendered := dt.String()
+			accepted, ok := oracleAccepts(t, o, wrapType(rendered))
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if !accepted {
+				t.Errorf("deparse produced a type Trino rejects: %q -> %q", typ, rendered)
+			}
+		})
+	}
+}
+
+// TestValidIntervalRange unit-checks the D1 qualifier table directly (the
+// oracle differential validates it end-to-end, but a focused unit test pins the
+// exact rule so a regression is obvious).
+func TestValidIntervalRange(t *testing.T) {
+	valid := [][2]IntervalField{
+		{IntervalYear, IntervalMonth},
+		{IntervalDay, IntervalHour},
+		{IntervalDay, IntervalMinute},
+		{IntervalDay, IntervalSecond},
+		{IntervalHour, IntervalMinute},
+		{IntervalHour, IntervalSecond},
+		{IntervalMinute, IntervalSecond},
+	}
+	invalid := [][2]IntervalField{
+		{IntervalMonth, IntervalYear}, // reversed
+		{IntervalYear, IntervalDay},   // cross-family
+		{IntervalDay, IntervalYear},   // cross-family reversed
+		{IntervalSecond, IntervalMinute},
+		{IntervalYear, IntervalYear}, // not strictly coarser
+		{IntervalDay, IntervalDay},
+	}
+	for _, p := range valid {
+		if !ValidIntervalRange(p[0], p[1]) {
+			t.Errorf("ValidIntervalRange(%v, %v) = false, want true", p[0], p[1])
+		}
+	}
+	for _, p := range invalid {
+		if ValidIntervalRange(p[0], p[1]) {
+			t.Errorf("ValidIntervalRange(%v, %v) = true, want false", p[0], p[1])
+		}
+	}
+}


### PR DESCRIPTION
## v2 node: `trino/types`

Implements Trino 481's `type` grammar rule as a hand-written recursive-descent parser, the Tier-1 type layer of the omni Trino migration. Single new production file `trino/parser/datatypes.go` (+ tests); no other files touched.

### Scope (writes_globs `trino/parser/datatypes.go`)

`parseType` + helpers cover every alternative of the legacy `type` rule, adjudicated against the **live Trino 481 oracle** (`trino/internal/trinooracle`):

- **genericType** — `identifier (typeParameter,…)`; covers BIGINT/VARCHAR(n)/DECIMAL(p,s)/JSON/UUID/IPADDRESS/HYPERLOGLOG/QDIGEST(t)/VARIANT/… and the parenthesized `ARRAY(t)`/`MAP(k,v)` spellings (Trino type names are plain identifiers, not keywords).
- **rowType** — `ROW(rowField,…)`, named + unnamed + nested + quoted fields.
- **intervalType** — `INTERVAL from (TO to)?`.
- **dateTimeType** — `TIMESTAMP`/`TIME` with optional precision and `WITH`/`WITHOUT TIME ZONE`.
- **doublePrecisionType** — `DOUBLE PRECISION`.
- **legacy `ARRAY<t>` / `MAP<k,v>`** (angle brackets) and the **postfix `t ARRAY[n]`**.

`DataType` (the parsed type node, with `String()` round-trip rendering), `TypeKind`, `IntervalField`, `RowField`, `TypeParam`, and the public `ParseDataType(string)` entry point live in the parser package — the trino `ast` tag set is closed by the already-merged ast-core node and is out of this node's scope, so (per the dag's `writes_globs`) the richer type node is owned by the parser package and embedded by the downstream `expressions`/`parser-ddl`/`deparse` consumers.

### Correctness (oracle differential gate)

`TestDataType_OracleDifferential` runs ~90 accept + ~25 reject cases through the live Trino 481 oracle; omni's accept/reject of each standalone type equals Trino's verdict for `SELECT CAST(NULL AS <type>)`. Classification keys **only** on Trino `SYNTAX_ERROR` — `TYPE_MISMATCH`/`NOT_SUPPORTED`/`GENERIC_INTERNAL_ERROR` all mean the grammar accepted. Required negative coverage included (empty parens, reversed/cross-family interval ranges, malformed angle brackets, malformed array brackets, trailing commas). A deparse round-trip (`parse → String() → re-parse`, and the rendering re-accepted by the oracle) is the structural gate. All gated tests skip cleanly without an oracle.

### Divergences (oracle-confirmed; logged to the ledger)

1. **Interval qualifier set.** Legacy `from (TO to)?` accepts any field→any field; Trino 481 restricts a `TO` range to the SQL-standard families (year-month {YEAR>MONTH}, day-time {DAY>HOUR>MINUTE>SECOND}, from strictly coarser than to). `SECOND TO YEAR` / `YEAR TO DAY` / `MONTH TO YEAR` are SYNTAX_ERRORs. Single-field `INTERVAL <field>` accepted for all six. Implemented via `ValidIntervalRange`.
2. **`INTERVAL` not followed by a field is a generic type.** `INTERVAL`, `INTERVAL(5)`, `INTERVAL ARRAY` parse as the unknown type `INTERVAL` / `INTERVAL(5)` / `ARRAY(INTERVAL)` (oracle: TYPE_MISMATCH = parse-accepted); `INTERVAL` only enters intervalType when the next token is an interval field.
3. **Postfix array bracket requires exactly `[ INTEGER ]`.** `t ARRAY[]`, `t ARRAY[abc]`, `t ARRAY[5` (no close), `t ARRAY[5 6]` are SYNTAX_ERRORs; a well-formed `t ARRAY[n]` parses for any n (the dimension fails later in analysis). Found and fixed during the cross-review gate.

### Review

Two-reviewer cross gate (Claude `/code-review` + Codex). Findings addressed:
- ROW unnamed **multi-token field types** (`ROW(TIME WITHOUT TIME ZONE)`, `ROW(INTERVAL DAY TO SECOND)`, `ROW(BIGINT ARRAY[5])`) were mis-rejected by a 2-token-lookahead heuristic → reworked to **speculative backtracking** (try the unnamed `type` reading first, then named `identifier type`, rewinding via a parser/lexer checkpoint; accept only when the reading lands on `,`/`)`). Oracle-verified; regression cases added.
- Malformed postfix-array brackets accepted → now rejected (divergence 3).
- Integer typeParameter beyond int64 rendered as `0` in round-trip → `TypeParam` now preserves the exact source text (`IntText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
