### PR TITLE
feat(googlesql/parser): parse driver, dual splitters, diagnose, identifiers (v2 node parser-foundation)

### DIFF
--- a/googlesql/diagnostics/diagnostics.go
+++ b/googlesql/diagnostics/diagnostics.go
@@ -1,0 +1,150 @@
+// Package diagnostics provides a thin reporting layer over the GoogleSQL SQL
+// parser, shaping raw parse errors into structured diagnostics suitable for
+// editor integration (LSP-style), CI linting, and problem-panel display.
+//
+// GoogleSQL is the dialect shared by Google BigQuery and Google Cloud Spanner;
+// this package backs the Diagnose handler that bytebase registers for BOTH
+// engines (base.RegisterDiagnoseFunc for Engine_BIGQUERY and Engine_SPANNER).
+// Both legacy handlers are byte-identical except for the error-position base
+// (Spanner anchors at line 1), which is a thin per-engine concern handled at
+// the bytebase boundary, not here.
+//
+// The primary entry point is Analyze, which accepts a SQL string and returns a
+// slice of Diagnostic values — one per parse or lex error. Each Diagnostic
+// carries a source range (line, column, byte offset) and a human-readable
+// message, ready for use in language servers, linters, or test assertions.
+//
+// The package mirrors omni's snowflake/diagnostics conventions so the omni
+// parser family stays uniform across engines.
+package diagnostics
+
+import (
+	"github.com/bytebase/omni/googlesql/parser"
+)
+
+// Severity classifies the importance of a diagnostic.
+//
+// Only SeverityError is emitted today (all parse errors are fatal for SQL
+// execution). SeverityWarning and SeverityInfo are reserved for future
+// semantic / advisory diagnostics.
+type Severity int
+
+const (
+	// SeverityError indicates a syntax error that prevents SQL execution.
+	SeverityError Severity = iota
+	// SeverityWarning indicates a non-fatal issue (reserved for future use).
+	SeverityWarning
+	// SeverityInfo indicates an informational note (reserved for future use).
+	SeverityInfo
+)
+
+// String returns a human-readable label for a Severity value.
+func (s Severity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInfo:
+		return "info"
+	default:
+		return "unknown"
+	}
+}
+
+// Position is a point in the source text identified by line, column, and byte
+// offset. All three fields are provided so callers can choose their preferred
+// coordinate system.
+//
+// Line and Column are 1-based (the first character of a file is line 1, column
+// 1). Column is measured in bytes, not Unicode code points, matching the
+// byte-based tokenization used by the GoogleSQL lexer.
+//
+// Offset is 0-based and refers to the byte position within the full input
+// string passed to Analyze.
+type Position struct {
+	Line   int // 1-based line number
+	Column int // 1-based column (bytes from line start)
+	Offset int // 0-based byte offset within the source
+}
+
+// Range is a contiguous region of source text. Start is inclusive; End is
+// exclusive — mirroring the ast.Loc convention.
+//
+// A zero-width range (Start == End) indicates a point diagnostic where the
+// error boundary could not be determined (e.g. end-of-input errors).
+type Range struct {
+	Start Position
+	End   Position
+}
+
+// Diagnostic is a single structured error or warning produced by the parser.
+// It is intentionally shaped after the LSP Diagnostic type so consumers can
+// map it to editor underlines, problem-panel entries, or CI annotations with
+// minimal transformation.
+type Diagnostic struct {
+	// Severity is always SeverityError for syntax errors reported by the parser.
+	Severity Severity
+	// Range identifies the source region to underline.
+	Range Range
+	// Source identifies the tool that produced this diagnostic. Always
+	// "googlesql-parser" for diagnostics from this package.
+	Source string
+	// Message is the human-readable error description from the parser.
+	Message string
+}
+
+const source = "googlesql-parser"
+
+// Analyze parses sql using the GoogleSQL best-effort parser and converts every
+// parse or lex error into a Diagnostic with a populated source range.
+//
+// Returns nil when sql is syntactically valid or empty. The returned slice is
+// ordered by the byte offset at which each error was detected (parse errors in
+// statement order, then lex errors per statement, as produced by the parser).
+//
+// While the parser-foundation ships stubbed statement bodies, a syntactically
+// valid statement still produces a "not yet supported" diagnostic; those
+// disappear as later DAG nodes implement real statement parsing. Genuine lexer
+// errors (unterminated string/bytes/identifier/comment) and unknown-statement
+// errors are always reported.
+//
+// Line and column numbers are 1-based and measured in bytes. Callers that need
+// Unicode-aware column numbers should post-process the Offset field.
+func Analyze(sql string) []Diagnostic {
+	result := parser.ParseBestEffort(sql)
+	if len(result.Errors) == 0 {
+		return nil
+	}
+
+	lt := parser.NewLineTable(sql)
+	diags := make([]Diagnostic, 0, len(result.Errors))
+
+	for _, pe := range result.Errors {
+		startOff := pe.Loc.Start
+		if startOff < 0 {
+			startOff = 0
+		}
+		startLine, startCol := lt.Position(startOff)
+
+		// End offset may be unknown (-1). Fall back to the start offset so we
+		// produce a zero-width (point) diagnostic rather than a garbage range.
+		endOff := pe.Loc.End
+		if endOff < 0 {
+			endOff = startOff
+		}
+		endLine, endCol := lt.Position(endOff)
+
+		diags = append(diags, Diagnostic{
+			Severity: SeverityError,
+			Range: Range{
+				Start: Position{Line: startLine, Column: startCol, Offset: startOff},
+				End:   Position{Line: endLine, Column: endCol, Offset: endOff},
+			},
+			Source:  source,
+			Message: pe.Msg,
+		})
+	}
+
+	return diags
+}

--- a/googlesql/diagnostics/diagnostics_test.go
+++ b/googlesql/diagnostics/diagnostics_test.go
@@ -1,0 +1,146 @@
+package diagnostics
+
+import (
+	"strings"
+	"testing"
+)
+
+func assertNoDiags(t *testing.T, label string, diags []Diagnostic) {
+	t.Helper()
+	if len(diags) != 0 {
+		t.Errorf("%s: expected zero diagnostics, got %d:", label, len(diags))
+		for i, d := range diags {
+			t.Errorf("  [%d] %s", i, d.Message)
+		}
+	}
+}
+
+// --- Zero-diagnostic cases (no statement => nothing to stub or reject) ---
+
+func TestAnalyze_EmptyInput(t *testing.T) {
+	assertNoDiags(t, "empty", Analyze(""))
+}
+
+func TestAnalyze_WhitespaceOnly(t *testing.T) {
+	assertNoDiags(t, "spaces", Analyze("   "))
+	assertNoDiags(t, "newlines", Analyze("\n\n\n"))
+	assertNoDiags(t, "mixed whitespace", Analyze("  \t\n  "))
+}
+
+func TestAnalyze_CommentOnly(t *testing.T) {
+	assertNoDiags(t, "dash comment", Analyze("-- just a comment"))
+	assertNoDiags(t, "block comment", Analyze("/* just a comment */"))
+	assertNoDiags(t, "pound comment", Analyze("# pound comment"))
+}
+
+func TestAnalyze_LoneSemicolons(t *testing.T) {
+	assertNoDiags(t, "semicolons", Analyze(";;;"))
+}
+
+// --- Severity / Source / shape ---
+
+func TestSeverity_String(t *testing.T) {
+	cases := map[Severity]string{
+		SeverityError:   "error",
+		SeverityWarning: "warning",
+		SeverityInfo:    "info",
+		Severity(99):    "unknown",
+	}
+	for sev, want := range cases {
+		if got := sev.String(); got != want {
+			t.Errorf("Severity(%d).String() = %q, want %q", int(sev), got, want)
+		}
+	}
+}
+
+func TestAnalyze_StubbedStatementShape(t *testing.T) {
+	// In the parser-foundation a valid statement still produces a "not yet
+	// supported" diagnostic (the body is stubbed). Assert the diagnostic shape.
+	diags := Analyze("SELECT 1")
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+	if d.Severity != SeverityError {
+		t.Errorf("severity = %v, want SeverityError", d.Severity)
+	}
+	if d.Source != source {
+		t.Errorf("source = %q, want %q", d.Source, source)
+	}
+	if !strings.Contains(d.Message, "not yet supported") {
+		t.Errorf("message = %q, want it to mention 'not yet supported'", d.Message)
+	}
+	// SELECT starts at byte 0 => line 1, col 1.
+	if d.Range.Start.Line != 1 || d.Range.Start.Column != 1 {
+		t.Errorf("start = (%d, %d), want (1, 1)", d.Range.Start.Line, d.Range.Start.Column)
+	}
+}
+
+// --- Lex-error mapping with accurate line/column ---
+
+func TestAnalyze_UnterminatedString_Position(t *testing.T) {
+	// The unterminated string starts at byte 7 on line 1.
+	diags := Analyze("SELECT 'oops")
+	var lexDiag *Diagnostic
+	for i := range diags {
+		if strings.Contains(diags[i].Message, "unterminated string") {
+			lexDiag = &diags[i]
+		}
+	}
+	if lexDiag == nil {
+		t.Fatalf("no unterminated-string diagnostic in %+v", diags)
+	}
+	if lexDiag.Range.Start.Offset != 7 {
+		t.Errorf("start offset = %d, want 7", lexDiag.Range.Start.Offset)
+	}
+	if lexDiag.Range.Start.Line != 1 || lexDiag.Range.Start.Column != 8 {
+		t.Errorf("start = (%d, %d), want (1, 8)", lexDiag.Range.Start.Line, lexDiag.Range.Start.Column)
+	}
+}
+
+func TestAnalyze_ErrorOnSecondLine_Position(t *testing.T) {
+	// First statement is stubbed (error at line 1); the unterminated string is
+	// on line 2. Verify the multi-line offset → (line, col) mapping.
+	sql := "SELECT 1;\nSELECT 'oops"
+	diags := Analyze(sql)
+	var lexDiag *Diagnostic
+	for i := range diags {
+		if strings.Contains(diags[i].Message, "unterminated string") {
+			lexDiag = &diags[i]
+		}
+	}
+	if lexDiag == nil {
+		t.Fatalf("no unterminated-string diagnostic in %+v", diags)
+	}
+	if lexDiag.Range.Start.Line != 2 {
+		t.Errorf("start line = %d, want 2", lexDiag.Range.Start.Line)
+	}
+	// "SELECT '" — the quote is the 8th byte on line 2 => column 8.
+	if lexDiag.Range.Start.Column != 8 {
+		t.Errorf("start column = %d, want 8", lexDiag.Range.Start.Column)
+	}
+}
+
+func TestAnalyze_UnknownStatement(t *testing.T) {
+	diags := Analyze("FOOBAR BAZ")
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	if !strings.Contains(diags[0].Message, "unknown or unsupported statement") {
+		t.Errorf("message = %q, want 'unknown or unsupported statement'", diags[0].Message)
+	}
+}
+
+func TestAnalyze_RangeIsValid(t *testing.T) {
+	// End must be >= Start (never a garbage range) for every diagnostic.
+	for _, sql := range []string{"SELECT 'oops", "FOOBAR", "SELECT 1", "/* a"} {
+		for _, d := range Analyze(sql) {
+			if d.Range.End.Offset < d.Range.Start.Offset {
+				t.Errorf("Analyze(%q): End.Offset %d < Start.Offset %d", sql, d.Range.End.Offset, d.Range.Start.Offset)
+			}
+			if d.Range.Start.Line < 1 || d.Range.Start.Column < 1 {
+				t.Errorf("Analyze(%q): start (%d,%d) must be 1-based", sql, d.Range.Start.Line, d.Range.Start.Column)
+			}
+		}
+	}
+}

--- a/googlesql/parser/errors.go
+++ b/googlesql/parser/errors.go
@@ -1,0 +1,26 @@
+package parser
+
+import "github.com/bytebase/omni/googlesql/ast"
+
+// ParseError describes a single parse error with its source location.
+//
+// Loc uses the same {Start,End} byte-offset shape as LexError (tokens.go) so
+// consumers can handle lex and parse failures uniformly. Line/column
+// conversion is a caller-side concern: the diagnostics package and bytebase's
+// Diagnose map Loc.Start back to a (line, col) pair against the original
+// source via LineTable.
+//
+// ParseError is a pure data carrier: Error returns just the message. This
+// mirrors snowflake/parser.ParseError and trino/parser.ParseError so the omni
+// parser family stays uniform across engines.
+type ParseError struct {
+	Loc ast.Loc
+	Msg string
+}
+
+// Error implements the error interface, returning the message only. Callers
+// that want a formatted "msg (line N, col M)" string convert Loc.Start with a
+// LineTable.
+func (e *ParseError) Error() string {
+	return e.Msg
+}

--- a/googlesql/parser/errors_test.go
+++ b/googlesql/parser/errors_test.go
@@ -1,0 +1,28 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+func TestParseError_Error(t *testing.T) {
+	e := &ParseError{Loc: ast.Loc{Start: 3, End: 9}, Msg: "syntax error at or near FOO"}
+	if got := e.Error(); got != "syntax error at or near FOO" {
+		t.Errorf("Error() = %q, want %q", got, "syntax error at or near FOO")
+	}
+}
+
+func TestParseError_ImplementsError(t *testing.T) {
+	var err error = &ParseError{Msg: "boom"}
+	if err.Error() != "boom" {
+		t.Errorf("Error() = %q, want %q", err.Error(), "boom")
+	}
+}
+
+func TestParseError_LocPreserved(t *testing.T) {
+	e := &ParseError{Loc: ast.Loc{Start: 10, End: 14}, Msg: "x"}
+	if e.Loc != (ast.Loc{Start: 10, End: 14}) {
+		t.Errorf("Loc = %+v, want {10, 14}", e.Loc)
+	}
+}

--- a/googlesql/parser/identifiers.go
+++ b/googlesql/parser/identifiers.go
@@ -1,0 +1,83 @@
+package parser
+
+import "strings"
+
+// This file ships the GoogleSQL identifier foundation: string-level
+// normalization (the byte-for-byte port of the legacy bytebase
+// unquoteIdentifierByText helper that the bigquery/spanner query-span
+// extractors use to canonicalize name parts) plus the token-level identifier
+// predicates the statement dispatcher and later grammar nodes (expressions,
+// types, SELECT, DDL, DML) consume.
+//
+// It deliberately does NOT build AST identifier nodes: the GoogleSQL AST
+// (googlesql/ast) ships only the File root container in the foundation; the
+// concrete Identifier / path-expression node types and their token→node parse
+// functions are owned by the expressions node. The predicates here are the
+// shared, node-independent half (which tokens may begin / continue an
+// identifier), kept in the foundation so every downstream grammar node agrees
+// on the rule.
+//
+// GoogleSQL identifier rules (GoogleSQLLexer.g4 + GoogleSQLParser.g4):
+//
+//   - UNQUOTED_IDENTIFIER: [A-Za-z_][A-Za-z0-9_]*  (case-insensitive,
+//     normalized to lower case by Spanner/BigQuery name resolution — but the
+//     parser preserves the source spelling; folding is a resolution concern).
+//   - `backtick`-quoted IDENTIFIER: any text; the lexer strips the backticks
+//     and emits tokIdentifier with the body in Token.Str.
+//   - A NON-reserved word-keyword may stand in as an identifier
+//     (GoogleSQLParser.g4 common_keyword_as_identifier / keyword_as_identifier).
+//     The reserved/non-reserved split lives in keywords.go (IsReservedKeyword).
+
+// isIdentifierStart reports whether tokenType may begin an identifier in a
+// position where keyword-as-identifier is allowed (the common case in
+// GoogleSQL paths and aliases):
+//   - tokIdentifier: an UNQUOTED_IDENTIFIER or a `backtick`-quoted identifier
+//     (the lexer collapses both to tokIdentifier).
+//   - a non-reserved word-keyword (tokenType >= keywordBase and not reserved).
+//
+// Reserved keywords are excluded: GoogleSQL rejects a reserved word as a bare
+// identifier (it must be backtick-quoted, which the lexer would have tokenized
+// as tokIdentifier). The lexer never enforces the reserved split — it always
+// emits the kw* token for a keyword — so this predicate is where the parser
+// applies it.
+func isIdentifierStart(tokenType int) bool {
+	if tokenType == tokIdentifier {
+		return true
+	}
+	return tokenType >= keywordBase && !keywordReserved[tokenType]
+}
+
+// isAnyKeywordIdentifier reports whether tokenType may stand in as an
+// identifier when EVERY word-keyword — reserved or not — is permitted. A few
+// GoogleSQL contexts (notably dotted path components after the first, and
+// generic-entity object kinds) accept reserved keywords as name parts. Callers
+// that must follow the strict identifier rule use isIdentifierStart instead;
+// this predicate is the permissive variant for those name-part positions.
+func isAnyKeywordIdentifier(tokenType int) bool {
+	return tokenType == tokIdentifier || tokenType >= keywordBase
+}
+
+// NormalizeGoogleSQLIdentifier returns the canonical form of a single
+// GoogleSQL identifier given its raw source spelling. A `backtick`-quoted
+// identifier (at least two backticks with content between them) has its
+// surrounding backticks stripped; any other spelling is returned unchanged.
+//
+// This is a byte-for-byte port of the legacy bytebase unquoteIdentifierByText
+// helper (backend/plugin/parser/{bigquery,spanner}/query_span_extractor.go) so
+// the cutover keeps name comparison (field lineage, data-access-control name
+// resolution, masking) identical to the ANTLR path. In particular it
+// intentionally matches legacy by:
+//   - stripping ONLY surrounding backticks (the legacy `len >= 3 && hasPrefix
+//     "`" && hasSuffix "`"` guard, which leaves a lone "`" or "“" untouched),
+//   - NOT lower-casing (GoogleSQL unquoted identifiers ARE case-insensitive for
+//     resolution, but the legacy extractor preserved the source case here and
+//     left case-folding to the metadata layer; preserving that avoids a silent
+//     behavior change), and
+//   - NOT collapsing any backslash escape inside the backticks (the legacy
+//     helper sliced the inter-backtick bytes verbatim).
+func NormalizeGoogleSQLIdentifier(raw string) string {
+	if len(raw) >= 3 && strings.HasPrefix(raw, "`") && strings.HasSuffix(raw, "`") {
+		return raw[1 : len(raw)-1]
+	}
+	return raw
+}

--- a/googlesql/parser/identifiers_test.go
+++ b/googlesql/parser/identifiers_test.go
@@ -1,0 +1,88 @@
+package parser
+
+import "testing"
+
+// TestNormalizeGoogleSQLIdentifier locks the byte-for-byte parity with the
+// legacy bytebase unquoteIdentifierByText helper that the bigquery/spanner
+// query-span extractors use. The legacy guard is:
+//
+//	len >= 3 && hasPrefix "`" && hasSuffix "`"  =>  strip the surrounding backticks
+//	otherwise                                   =>  return unchanged
+func TestNormalizeGoogleSQLIdentifier(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare", "users", "users"},
+		{"bare_mixed_case_preserved", "MyTable", "MyTable"}, // legacy did NOT lower-case here
+		{"backtick_quoted", "`my table`", "my table"},
+		{"backtick_with_dot", "`project.dataset.table`", "project.dataset.table"},
+		{"backtick_min_len3", "`a`", "a"},
+		// len < 3 guard: a lone or doubled backtick is NOT stripped.
+		{"single_backtick", "`", "`"},
+		{"empty_backticks_len2", "``", "``"},
+		{"empty", "", ""},
+		// Only SURROUNDING backticks are stripped; an interior backtick stays.
+		{"interior_backtick", "a`b", "a`b"},
+		// No lower-casing, no escape collapsing (legacy sliced verbatim).
+		{"backtick_with_backslash", "`a\\`b`", "a\\`b"},
+		{"prefix_only", "`abc", "`abc"},
+		{"suffix_only", "abc`", "abc`"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeGoogleSQLIdentifier(c.in); got != c.want {
+				t.Errorf("NormalizeGoogleSQLIdentifier(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsIdentifierStart(t *testing.T) {
+	// A plain identifier token (also covers backtick idents, which the lexer
+	// collapses to tokIdentifier).
+	if !isIdentifierStart(tokIdentifier) {
+		t.Error("isIdentifierStart(tokIdentifier) = false, want true")
+	}
+	// A non-reserved keyword may stand in as an identifier.
+	if !isIdentifierStart(kwOPTIONS) { // OPTIONS is non-reserved
+		t.Error("isIdentifierStart(kwOPTIONS) = false, want true (non-reserved keyword)")
+	}
+	if keywordReserved[kwOPTIONS] {
+		t.Fatal("test premise wrong: kwOPTIONS should be non-reserved")
+	}
+	// A reserved keyword may NOT be a bare identifier.
+	if isIdentifierStart(kwSELECT) {
+		t.Error("isIdentifierStart(kwSELECT) = true, want false (reserved)")
+	}
+	if !keywordReserved[kwSELECT] {
+		t.Fatal("test premise wrong: kwSELECT should be reserved")
+	}
+	// Non-identifier tokens.
+	for _, tk := range []int{tokEOF, tokInteger, tokString, int('('), int('@')} {
+		if isIdentifierStart(tk) {
+			t.Errorf("isIdentifierStart(%s) = true, want false", TokenName(tk))
+		}
+	}
+}
+
+func TestIsAnyKeywordIdentifier(t *testing.T) {
+	// The permissive variant accepts ANY keyword, reserved or not, plus
+	// tokIdentifier.
+	if !isAnyKeywordIdentifier(tokIdentifier) {
+		t.Error("isAnyKeywordIdentifier(tokIdentifier) = false, want true")
+	}
+	if !isAnyKeywordIdentifier(kwSELECT) { // reserved
+		t.Error("isAnyKeywordIdentifier(kwSELECT) = false, want true (any keyword allowed)")
+	}
+	if !isAnyKeywordIdentifier(kwOPTIONS) { // non-reserved
+		t.Error("isAnyKeywordIdentifier(kwOPTIONS) = false, want true")
+	}
+	// Non-keyword, non-identifier tokens are still rejected.
+	for _, tk := range []int{tokEOF, tokInteger, int('.'), int('@')} {
+		if isAnyKeywordIdentifier(tk) {
+			t.Errorf("isAnyKeywordIdentifier(%s) = true, want false", TokenName(tk))
+		}
+	}
+}

--- a/googlesql/parser/linetable.go
+++ b/googlesql/parser/linetable.go
@@ -1,0 +1,83 @@
+package parser
+
+// LineTable provides O(log n) byte-offset → (line, column) conversion for a
+// single source string. Construct once per input, then call Position
+// repeatedly.
+//
+// It backs the diagnostics package (which maps a ParseError's byte-offset Loc
+// to the 1-based line/column LSP diagnostics expect) and any consumer that
+// needs positions rather than raw offsets. The googlesql lexer and parser work
+// purely in byte offsets; this is the single place offsets become line/column.
+//
+// Handles LF, CRLF, and bare-CR line endings. Each of the following is treated
+// as exactly ONE line break:
+//   - "\n"   (Unix / LF)
+//   - "\r\n" (Windows / CRLF)
+//   - "\r"   (classic Mac / bare CR)
+//
+// Lines and columns are 1-based and measured in bytes (not runes). Position is
+// a byte count, so a single multi-byte UTF-8 character occupies multiple
+// column positions. This matches the byte-based tokenization used by the
+// GoogleSQL lexer.
+type LineTable struct {
+	// lineStarts[i] is the byte offset of the start of line (i+1).
+	// lineStarts[0] is always 0 (line 1 starts at the beginning of input).
+	lineStarts []int
+}
+
+// NewLineTable builds a LineTable for the given input. O(n) time and
+// O(lines) space.
+func NewLineTable(input string) *LineTable {
+	// Line 1 always starts at byte 0.
+	starts := []int{0}
+	for i := 0; i < len(input); i++ {
+		switch input[i] {
+		case '\n':
+			// LF line break. Next line starts at i+1.
+			starts = append(starts, i+1)
+		case '\r':
+			if i+1 < len(input) && input[i+1] == '\n' {
+				// CRLF. Skip the \n and start the next line at i+2.
+				starts = append(starts, i+2)
+				i++ // consume the \n so we don't double-count it
+			} else {
+				// Bare CR. Next line starts at i+1.
+				starts = append(starts, i+1)
+			}
+		}
+	}
+	return &LineTable{lineStarts: starts}
+}
+
+// Position returns the 1-based (line, column) for the given byte offset.
+//
+// If byteOffset is negative, returns (1, 1). If byteOffset exceeds the length
+// of the input, the line is the last line of input and the column continues
+// past the end of that line (e.g. for input "abc", Position(100) returns
+// (1, 101)) — the column count is monotonic and unbounded beyond EOF. Callers
+// that want an EOF-clamped position should min() the offset against len(input)
+// before calling.
+//
+// Column is measured in bytes: a byte offset at the start of a line returns
+// column 1; the byte after returns column 2; and so on.
+func (lt *LineTable) Position(byteOffset int) (line, col int) {
+	if byteOffset < 0 {
+		return 1, 1
+	}
+	if len(lt.lineStarts) == 0 {
+		return 1, 1
+	}
+	// Binary search for the largest index i such that lineStarts[i] <= byteOffset.
+	lo, hi := 0, len(lt.lineStarts)-1
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if lt.lineStarts[mid] <= byteOffset {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	line = lo + 1                            // 1-based line number
+	col = byteOffset - lt.lineStarts[lo] + 1 // 1-based column
+	return line, col
+}

--- a/googlesql/parser/linetable_test.go
+++ b/googlesql/parser/linetable_test.go
@@ -1,0 +1,125 @@
+package parser
+
+import "testing"
+
+func TestLineTable_Empty(t *testing.T) {
+	lt := NewLineTable("")
+	line, col := lt.Position(0)
+	if line != 1 || col != 1 {
+		t.Errorf("Position(0) on empty input = (%d, %d), want (1, 1)", line, col)
+	}
+}
+
+func TestLineTable_SingleLine(t *testing.T) {
+	lt := NewLineTable("SELECT")
+	cases := []struct {
+		offset            int
+		wantLine, wantCol int
+	}{
+		{0, 1, 1}, // 'S'
+		{1, 1, 2}, // 'E'
+		{5, 1, 6}, // 'T'
+		{6, 1, 7}, // just past end
+	}
+	for _, c := range cases {
+		line, col := lt.Position(c.offset)
+		if line != c.wantLine || col != c.wantCol {
+			t.Errorf("Position(%d) = (%d, %d), want (%d, %d)", c.offset, line, col, c.wantLine, c.wantCol)
+		}
+	}
+}
+
+func TestLineTable_LF(t *testing.T) {
+	// "a\nb\nc": a=0 \n=1 b=2 \n=3 c=4
+	lt := NewLineTable("a\nb\nc")
+	cases := []struct {
+		offset            int
+		wantLine, wantCol int
+	}{
+		{0, 1, 1}, // 'a'
+		{1, 1, 2}, // '\n' (still line 1)
+		{2, 2, 1}, // 'b'
+		{3, 2, 2}, // '\n'
+		{4, 3, 1}, // 'c'
+	}
+	for _, c := range cases {
+		line, col := lt.Position(c.offset)
+		if line != c.wantLine || col != c.wantCol {
+			t.Errorf("Position(%d) = (%d, %d), want (%d, %d)", c.offset, line, col, c.wantLine, c.wantCol)
+		}
+	}
+}
+
+func TestLineTable_CRLF(t *testing.T) {
+	// "a\r\nb\r\nc": a=0 \r=1 \n=2 b=3 \r=4 \n=5 c=6 — CRLF is ONE break.
+	lt := NewLineTable("a\r\nb\r\nc")
+	cases := []struct {
+		offset            int
+		wantLine, wantCol int
+	}{
+		{0, 1, 1}, {1, 1, 2}, {2, 1, 3}, // line 1: a \r \n
+		{3, 2, 1}, {4, 2, 2}, {5, 2, 3}, // line 2: b \r \n
+		{6, 3, 1}, // line 3: c
+	}
+	for _, c := range cases {
+		line, col := lt.Position(c.offset)
+		if line != c.wantLine || col != c.wantCol {
+			t.Errorf("Position(%d) = (%d, %d), want (%d, %d)", c.offset, line, col, c.wantLine, c.wantCol)
+		}
+	}
+}
+
+func TestLineTable_BareCR(t *testing.T) {
+	// "a\rb\rc": a=0 \r=1 b=2 \r=3 c=4 — bare CR is ONE break.
+	lt := NewLineTable("a\rb\rc")
+	cases := []struct {
+		offset            int
+		wantLine, wantCol int
+	}{
+		{0, 1, 1}, {1, 1, 2}, {2, 2, 1}, {3, 2, 2}, {4, 3, 1},
+	}
+	for _, c := range cases {
+		line, col := lt.Position(c.offset)
+		if line != c.wantLine || col != c.wantCol {
+			t.Errorf("Position(%d) = (%d, %d), want (%d, %d)", c.offset, line, col, c.wantLine, c.wantCol)
+		}
+	}
+}
+
+func TestLineTable_NegativeOffset(t *testing.T) {
+	lt := NewLineTable("abc")
+	line, col := lt.Position(-1)
+	if line != 1 || col != 1 {
+		t.Errorf("Position(-1) = (%d, %d), want (1, 1)", line, col)
+	}
+}
+
+func TestLineTable_BeyondEOF(t *testing.T) {
+	// Column continues past end of the last line, monotonic and unbounded.
+	lt := NewLineTable("abc")
+	line, col := lt.Position(100)
+	if line != 1 || col != 101 {
+		t.Errorf("Position(100) = (%d, %d), want (1, 101)", line, col)
+	}
+}
+
+func TestLineTable_BeyondEOF_MultiLine(t *testing.T) {
+	// "ab\ncd": last line starts at offset 3; an offset of 10 is on line 2.
+	lt := NewLineTable("ab\ncd")
+	line, col := lt.Position(10)
+	if line != 2 {
+		t.Errorf("Position(10) line = %d, want 2", line)
+	}
+	if col != 10-3+1 {
+		t.Errorf("Position(10) col = %d, want %d", col, 10-3+1)
+	}
+}
+
+func TestLineTable_MultiByteUTF8_ColumnsAreBytes(t *testing.T) {
+	// "é" is 2 bytes (0xC3 0xA9); the following 'x' is at byte offset 2.
+	lt := NewLineTable("éx")
+	line, col := lt.Position(2)
+	if line != 1 || col != 3 {
+		t.Errorf("Position(2) = (%d, %d), want (1, 3) — columns are bytes", line, col)
+	}
+}

--- a/googlesql/parser/parser.go
+++ b/googlesql/parser/parser.go
@@ -1,0 +1,560 @@
+// Package parser implements a hand-written recursive-descent parser for
+// GoogleSQL — the SQL dialect shared by Google BigQuery and Google Cloud
+// Spanner. One omni parser serves both engines; the grammar is a hand-port of
+// Google's open-source ZetaSQL reference (the same lineage as the legacy ANTLR
+// GoogleSQLParser.g4, 625 rules).
+//
+// This file is the parser-foundation node. It ships:
+//   - the Parser struct + token-cursor primitives (advance / peek / peekNext /
+//     match / expect),
+//   - the public Parse / ParseBestEffort entry points and the per-segment
+//     driver (parseSingle),
+//   - the leading statement-level-hint skip (@{...} / @N), and
+//   - the top-level statement-dispatch switch (parseStmt) enumerating every
+//     first-keyword of GoogleSQL's sql_statement_body.
+//
+// Per-statement parsing is STUBBED here — the foundation ships only the
+// dispatch framework. Every dispatch case routes to a real parse function or,
+// where that function does not yet exist, to the unsupported helper which
+// records a "not yet supported" ParseError. Later DAG nodes (types,
+// expressions, parser-select, parser-ddl, parser-dml, …) REPLACE individual
+// dispatch-case bodies with concrete parsers that build real ast.Node trees.
+//
+// The dispatch switch enumerates every first-keyword of the grammar's
+// sql_statement_body so bytebase's Diagnose — which runs on every statement —
+// never emits a false "unknown statement" diagnostic for syntactically valid
+// GoogleSQL. Reaching a stubbed case is correct foundation behavior; reaching
+// the default (unknown) branch for a valid statement is a bug.
+//
+// The package mirrors omni's snowflake/parser and trino/parser conventions: a
+// stateless Lexer feeds the Parser one Token{Type, Str, Ival, Loc} at a time
+// with two-token lookahead, and source positions are byte offsets.
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Parser is a recursive-descent parser for GoogleSQL. It operates on a single
+// segment of input (one top-level statement produced by Split) at a time;
+// callers should use Parse or ParseBestEffort instead of constructing Parsers
+// directly.
+type Parser struct {
+	lexer      *Lexer
+	input      string       // the segment text (used for error reporting)
+	baseOffset int          // absolute offset of input within the original source
+	cur        Token        // current token
+	prev       Token        // previous token (for error context)
+	nextBuf    Token        // buffered lookahead token
+	hasNext    bool         // whether nextBuf is valid
+	errors     []ParseError // collected errors for best-effort mode
+}
+
+// advance consumes the current token and moves to the next one. Returns the
+// token that was just consumed (the new "previous" token).
+func (p *Parser) advance() Token {
+	p.prev = p.cur
+	if p.hasNext {
+		p.cur = p.nextBuf
+		p.hasNext = false
+	} else {
+		p.cur = p.lexer.NextToken()
+	}
+	return p.prev
+}
+
+// peek returns the current token without consuming it.
+func (p *Parser) peek() Token {
+	return p.cur
+}
+
+// peekNext returns the token AFTER the current one without consuming it
+// (one-token lookahead beyond cur). Used to disambiguate based on the token
+// following the current position.
+func (p *Parser) peekNext() Token {
+	if !p.hasNext {
+		p.nextBuf = p.lexer.NextToken()
+		p.hasNext = true
+	}
+	return p.nextBuf
+}
+
+// match tries each given token type; if cur matches any, it is consumed and
+// returned with ok == true. Used for optional tokens.
+func (p *Parser) match(types ...int) (Token, bool) {
+	for _, t := range types {
+		if p.cur.Type == t {
+			return p.advance(), true
+		}
+	}
+	return Token{}, false
+}
+
+// expect consumes the current token if it matches the expected type. Otherwise
+// returns a ParseError describing the mismatch (without consuming anything).
+func (p *Parser) expect(tokenType int) (Token, error) {
+	if p.cur.Type == tokenType {
+		return p.advance(), nil
+	}
+	return Token{}, p.syntaxErrorAtCur()
+}
+
+// syntaxErrorAtCur returns a *ParseError describing a syntax error at the
+// current token position. At EOF the message says "at end of input"; otherwise
+// "at or near X", where X is the token's source text or, for value-less tokens
+// (operators, EOF), its symbolic name.
+func (p *Parser) syntaxErrorAtCur() *ParseError {
+	var msg string
+	if p.cur.Type == tokEOF {
+		msg = "syntax error at end of input"
+	} else {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Type)
+		}
+		msg = "syntax error at or near " + text
+	}
+	return &ParseError{
+		Loc: p.cur.Loc,
+		Msg: msg,
+	}
+}
+
+// skipToNextStatement advances the parser past the current erroneous statement
+// to the next ';' at bracket-depth 0 within the current segment, or to tokEOF.
+// Always consumes at least one token to guarantee forward progress.
+//
+// Because Parse pre-segments the input with Split, each segment usually
+// contains a single statement, so skipToNextStatement's typical behavior is to
+// advance to EOF.
+func (p *Parser) skipToNextStatement() {
+	// Always consume at least one token to avoid infinite loops.
+	if p.cur.Type != tokEOF {
+		p.advance()
+	}
+	depth := 0
+	for p.cur.Type != tokEOF {
+		switch p.cur.Type {
+		case int('('), int('['), int('{'):
+			depth++
+		case int(')'), int(']'), int('}'):
+			if depth > 0 {
+				depth--
+			}
+		case int(';'):
+			if depth == 0 {
+				p.advance()
+				return
+			}
+		}
+		p.advance()
+	}
+}
+
+// unsupported emits a "<name> statement parsing is not yet supported"
+// ParseError at the current token, skips to the next statement boundary, and
+// returns (nil, err). Used by every stubbed dispatch case in the foundation.
+//
+// Later DAG nodes REPLACE individual dispatch cases with real parse functions.
+// Those functions do NOT call unsupported — they consume tokens and build real
+// ast.Node values.
+func (p *Parser) unsupported(name string) (ast.Node, error) {
+	err := &ParseError{
+		Loc: p.cur.Loc,
+		Msg: name + " statement parsing is not yet supported",
+	}
+	p.skipToNextStatement()
+	return nil, err
+}
+
+// unknownStatementError reports a statement that starts with a token the
+// dispatch switch does not recognize. Called from the default branch of
+// parseStmt. Distinct from unsupported so Diagnose can tell "valid GoogleSQL,
+// not yet implemented" apart from "not valid GoogleSQL".
+func (p *Parser) unknownStatementError() *ParseError {
+	if p.cur.Type == tokEOF {
+		return &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "syntax error at end of input",
+		}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Type)
+	}
+	return &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "unknown or unsupported statement starting with " + text,
+	}
+}
+
+// skipStatementLevelHint consumes a leading statement-level hint, if present,
+// so dispatch sees the real statement keyword. GoogleSQL allows an optional
+// statement_level_hint before sql_statement_body:
+//
+//	@<int>                         simple hint
+//	@{ entry, ... }                hint body
+//	@[ <int> @] { entry, ... }     hint body with a leading int
+//
+// (The lexer emits '@' as the single-char AT_SYMBOL token; '@@' — the
+// system-variable prefix — is a different token, tokAtAt, and is NOT a hint.)
+//
+// The foundation only SKIPS the hint to reach the statement keyword; building
+// the hint AST is owned by a later node. Skipping is brace-balanced so a ';'
+// inside the hint body never leaks (Split already keeps the hint with its
+// statement). skipStatementLevelHint only advances over a well-formed-looking
+// prefix and otherwise leaves cur untouched.
+//
+// It returns a *ParseError when the hint body is UNTERMINATED — an `@{` (or
+// `@[…@]{`) whose closing '}' never arrives before EOF. Without this, an
+// unterminated hint would be silently consumed to EOF and the (invalid)
+// statement would draw no diagnostic at all, which bytebase's Diagnose must not
+// allow (oracle: Spanner rejects a malformed hint such as `@{}` / `@` with a
+// syntax error). Returns nil when there is no hint or the hint body closes
+// cleanly.
+func (p *Parser) skipStatementLevelHint() *ParseError {
+	if p.cur.Type != int('@') {
+		return nil
+	}
+	hintStart := p.cur.Loc
+	next := p.peekNext()
+	switch {
+	case next.Type == int('{'):
+		p.advance() // consume '@'
+		return p.skipBalancedBraces(hintStart)
+	case next.Type == int('['):
+		// @[ int @] { ... }
+		p.advance() // consume '@'
+		p.advance() // consume '['
+		// Skip up to the matching @] then the brace body.
+		for p.cur.Type != tokEOF && p.cur.Type != int(']') {
+			p.advance()
+		}
+		if p.cur.Type != int(']') {
+			return &ParseError{Loc: hintStart, Msg: "unterminated statement hint"}
+		}
+		p.advance() // consume ']'
+		if p.cur.Type == int('{') {
+			return p.skipBalancedBraces(hintStart)
+		}
+		// `@[ … @]` with no following `{` body: a hint preamble must carry a
+		// brace body, so this is malformed.
+		return &ParseError{Loc: hintStart, Msg: "unterminated statement hint"}
+	case next.Type == tokInteger:
+		p.advance() // consume '@'
+		p.advance() // consume the int
+	}
+	return nil
+}
+
+// skipBalancedBraces consumes a '{' ... '}' run with balanced nesting starting
+// at the current token (which must be '{'). Returns a *ParseError anchored at
+// hintStart if EOF is reached before the matching '}' (unterminated hint);
+// returns nil on a clean close or when cur is not '{'.
+func (p *Parser) skipBalancedBraces(hintStart ast.Loc) *ParseError {
+	if p.cur.Type != int('{') {
+		return nil
+	}
+	depth := 0
+	for p.cur.Type != tokEOF {
+		switch p.cur.Type {
+		case int('{'):
+			depth++
+		case int('}'):
+			depth--
+			if depth == 0 {
+				p.advance()
+				return nil
+			}
+		}
+		p.advance()
+	}
+	return &ParseError{Loc: hintStart, Msg: "unterminated statement hint"}
+}
+
+// parseStmt parses one top-level statement by dispatching on the leading
+// keyword(s). The arms enumerate the first-token vocabulary of GoogleSQL's
+// sql_statement_body (antlr_rules.md §4): query (SELECT / WITH / GRAPH / '(' /
+// statement-hinted), DDL, DML, DCL, transactions, batch, and utility/metadata
+// statements. For the foundation every arm routes to the unsupported stub;
+// later nodes replace the bodies.
+//
+// CREATE / DROP / ALTER / SET / SHOW / DESCRIBE / EXPORT etc. are
+// second-keyword-dispatched in the grammar; the foundation keeps the dispatch
+// flat (one stub per leading keyword) because the per-object parsers do not
+// exist yet. Later nodes introduce the inner switches (compare doris/parser.go
+// CREATE/DROP/ALTER fan-out) as they add object parsers.
+//
+// Procedural-script statements (IF / CASE / WHILE / LOOP / REPEAT / FOR /
+// DECLARE / BREAK / LEAVE / CONTINUE / ITERATE / RETURN / RAISE, BEGIN…END
+// block) are legal only inside a procedural body (statement_list), not as a
+// top-level sql_statement_body — EXCEPT the BEGIN…END block, which is itself a
+// script statement that can be the body of a script. The dispatcher recognizes
+// them at top level so a standalone script fragment fed to Diagnose is reported
+// as "not yet supported" rather than "unknown statement".
+func (p *Parser) parseStmt() (ast.Node, error) {
+	switch p.cur.Type {
+	// --- Query (query_statement / GQL) ---
+	case kwSELECT:
+		return p.unsupported("SELECT")
+	case kwWITH:
+		// WITH cte... query  (also WITH RECURSIVE, and the WITH-pipe error alt).
+		return p.unsupported("WITH")
+	case kwGRAPH:
+		// GQL graph query: GRAPH <name> <gql ops>.
+		return p.unsupported("GRAPH")
+	case int('('):
+		// Parenthesized query at top level, e.g. (SELECT 1) UNION ALL (SELECT 2).
+		return p.unsupported("query")
+	case kwFROM:
+		// FROM-first query head. The legacy grammar recognizes a leading FROM as
+		// a query (query_without_pipe_operators' `with_clause? from_clause` alt)
+		// and then emits "Syntax error: Unexpected FROM" — i.e. FROM is a query-
+		// statement head that the query rule itself rejects (oracle-confirmed:
+		// Spanner rejects `FROM t` as a syntax error). Recognizing it here (vs the
+		// unknown branch) keeps the head with the query family; the precise
+		// "Unexpected FROM" rejection is produced by the query node that replaces
+		// this case. See the parser-foundation divergence ledger.
+		return p.unsupported("FROM")
+
+	// --- DDL ---
+	case kwCREATE:
+		return p.unsupported("CREATE")
+	case kwALTER:
+		return p.unsupported("ALTER")
+	case kwDROP:
+		return p.unsupported("DROP")
+	case kwRENAME:
+		return p.unsupported("RENAME")
+	case kwUNDROP:
+		return p.unsupported("UNDROP")
+	case kwTRUNCATE:
+		return p.unsupported("TRUNCATE")
+	case kwDEFINE:
+		// DEFINE TABLE (DEFINE MACRO is intentionally unimplemented — a
+		// reserved error alt in the legacy grammar).
+		return p.unsupported("DEFINE")
+
+	// --- DML ---
+	case kwINSERT:
+		return p.unsupported("INSERT")
+	case kwUPDATE:
+		return p.unsupported("UPDATE")
+	case kwDELETE:
+		return p.unsupported("DELETE")
+	case kwMERGE:
+		return p.unsupported("MERGE")
+
+	// --- DCL ---
+	case kwGRANT:
+		return p.unsupported("GRANT")
+	case kwREVOKE:
+		return p.unsupported("REVOKE")
+
+	// --- Transactions / batch / session ---
+	case kwBEGIN:
+		// BEGIN [TRANSACTION] (TCL) OR a procedural BEGIN…END block.
+		return p.unsupported("BEGIN")
+	case kwSTART:
+		// START TRANSACTION | START BATCH.
+		return p.unsupported("START")
+	case kwCOMMIT:
+		return p.unsupported("COMMIT")
+	case kwROLLBACK:
+		return p.unsupported("ROLLBACK")
+	case kwSET:
+		return p.unsupported("SET")
+	case kwRUN:
+		return p.unsupported("RUN BATCH")
+	case kwABORT:
+		return p.unsupported("ABORT BATCH")
+
+	// --- Utility / metadata ---
+	case kwEXPLAIN:
+		return p.unsupported("EXPLAIN")
+	case kwDESCRIBE:
+		return p.unsupported("DESCRIBE")
+	case kwDESC:
+		return p.unsupported("DESC")
+	case kwSHOW:
+		return p.unsupported("SHOW")
+	case kwANALYZE:
+		return p.unsupported("ANALYZE")
+	case kwASSERT:
+		return p.unsupported("ASSERT")
+	case kwCALL:
+		return p.unsupported("CALL")
+	case kwEXECUTE:
+		// EXECUTE IMMEDIATE.
+		return p.unsupported("EXECUTE")
+	case kwIMPORT:
+		return p.unsupported("IMPORT")
+	case kwMODULE:
+		return p.unsupported("MODULE")
+	case kwEXPORT:
+		// EXPORT DATA | EXPORT MODEL | EXPORT … METADATA.
+		return p.unsupported("EXPORT")
+	case kwLOAD:
+		// LOAD DATA FROM FILES.
+		return p.unsupported("LOAD")
+	case kwCLONE:
+		// CLONE DATA.
+		return p.unsupported("CLONE")
+
+	// --- Procedural / scripting (legal inside a script body; recognized at
+	// top level so a script fragment is reported as unsupported, not unknown) ---
+	case kwIF:
+		return p.unsupported("IF")
+	case kwCASE:
+		return p.unsupported("CASE")
+	case kwWHILE:
+		return p.unsupported("WHILE")
+	case kwLOOP:
+		return p.unsupported("LOOP")
+	case kwREPEAT:
+		return p.unsupported("REPEAT")
+	case kwFOR:
+		return p.unsupported("FOR")
+	case kwDECLARE:
+		return p.unsupported("DECLARE")
+	case kwBREAK:
+		return p.unsupported("BREAK")
+	case kwLEAVE:
+		return p.unsupported("LEAVE")
+	case kwCONTINUE:
+		return p.unsupported("CONTINUE")
+	case kwITERATE:
+		return p.unsupported("ITERATE")
+	case kwRETURN:
+		return p.unsupported("RETURN")
+	case kwRAISE:
+		return p.unsupported("RAISE")
+
+	default:
+		return nil, p.unknownStatementError()
+	}
+}
+
+// ParseResult holds the outcome of a best-effort parse. File contains every
+// statement that parsed successfully (empty while statement bodies are
+// stubbed); Errors contains every ParseError encountered, including LexErrors
+// promoted from the underlying Lexer.
+type ParseResult struct {
+	File   *ast.File
+	Errors []ParseError
+}
+
+// Parse is the public entry point. It returns the parsed File plus every error
+// encountered. The File always reflects whatever statements parsed
+// successfully — even in the error case it may be non-empty.
+//
+// The signature returns all errors (matching snowflake/trino parser.Parse)
+// rather than a single error: bytebase's Diagnose needs the complete diagnostic
+// set, and a multi-statement script can fail in several places at once.
+func Parse(input string) (*ast.File, []ParseError) {
+	result := ParseBestEffort(input)
+	return result.File, result.Errors
+}
+
+// ParseBestEffort runs Split to segment the input, then parses each segment via
+// parseSingle. Per-segment parse errors are collected; every successfully-parsed
+// statement is appended to the result File. This is the canonical entry point
+// for the bytebase consumers (Diagnose, query-type classification, query-span
+// extraction) that need partial results plus diagnostics.
+//
+// Split (the block-aware variant) is used so a procedural BEGIN/END body is fed
+// to parseSingle whole. The BigQuery lexer-split semantics are available via
+// SplitFlat for the bytebase-switch node when it wires the splitter map; the
+// parse driver itself uses the block-aware split.
+//
+// Lex errors are collected from a SINGLE full-input lexer pass (collectLexErrors)
+// rather than per segment. Lexing is a whole-input property and the full pass is
+// complete: it reports every unterminated string/bytes/identifier/comment and
+// invalid byte regardless of (a) which statement it lands in, (b) whether the
+// per-statement parser stopped early on the first error-recovery boundary, or
+// (c) whether Split dropped the containing chunk as "empty" (an unterminated
+// block comment lexes to EOF, so its segment is filtered — yet the lex error
+// must still surface). Parse errors precede lex errors in the result.
+func ParseBestEffort(input string) *ParseResult {
+	file := &ast.File{Loc: ast.Loc{Start: 0, End: len(input)}}
+	result := &ParseResult{File: file}
+
+	for _, seg := range Split(input) {
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if node != nil {
+			file.Stmts = append(file.Stmts, node)
+		}
+		result.Errors = append(result.Errors, errs...)
+	}
+
+	// Append lex errors from one authoritative full-input pass (absolute
+	// offsets). Done after parse errors so a statement's syntactic complaint
+	// reads before its lexical one.
+	result.Errors = append(result.Errors, collectLexErrors(input)...)
+
+	return result
+}
+
+// collectLexErrors runs the lexer over the entire input to EOF and returns every
+// lex error as a ParseError with absolute byte offsets. It is the single source
+// of lex diagnostics for ParseBestEffort: a full pass cannot miss an error the
+// way the per-segment parse path can (early recovery-stop, empty-segment
+// filtering). The lexer hides string/bytes/identifier/comment content, so this
+// pass sees exactly the same token stream the per-segment lexers would, only
+// complete.
+func collectLexErrors(input string) []ParseError {
+	_, lexErrs := Tokenize(input)
+	if len(lexErrs) == 0 {
+		return nil
+	}
+	out := make([]ParseError, len(lexErrs))
+	for i, le := range lexErrs {
+		out[i] = ParseError{Loc: le.Loc, Msg: le.Msg}
+	}
+	return out
+}
+
+// parseSingle parses one segment (one top-level statement) into a single
+// ast.Node. Returns (node, errors) where node may be nil if the segment failed
+// to parse and errors lists the ParseErrors from PARSING this segment.
+//
+// Lex errors are NOT promoted here — they are collected once over the whole
+// input by ParseBestEffort (see collectLexErrors) so none is lost to an early
+// recovery-stop within this segment or to Split dropping an error-only chunk.
+//
+// segText is the statement text without the trailing ';' (from Segment.Text).
+// baseOffset is segText's byte offset within the original input; it is passed
+// to NewLexerWithOffset so token and error Loc values stay absolute.
+func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
+	p := &Parser{
+		lexer:      NewLexerWithOffset(segText, baseOffset),
+		input:      segText,
+		baseOffset: baseOffset,
+	}
+	p.advance() // prime cur with the first token
+
+	var result ast.Node
+	if p.cur.Type != tokEOF {
+		if hintErr := p.skipStatementLevelHint(); hintErr != nil {
+			// An unterminated hint consumed the rest of the segment; record the
+			// diagnostic and stop (cur is at EOF, so dispatch is skipped below).
+			p.errors = append(p.errors, *hintErr)
+		}
+	}
+	if p.cur.Type != tokEOF {
+		node, err := p.parseStmt()
+		if err != nil {
+			if pe, ok := err.(*ParseError); ok {
+				p.errors = append(p.errors, *pe)
+			} else {
+				p.errors = append(p.errors, ParseError{
+					Loc: p.cur.Loc,
+					Msg: err.Error(),
+				})
+			}
+		}
+		result = node
+	}
+
+	return result, p.errors
+}

--- a/googlesql/parser/parser.go
+++ b/googlesql/parser/parser.go
@@ -205,13 +205,19 @@ func (p *Parser) unknownStatementError() *ParseError {
 // statement). skipStatementLevelHint only advances over a well-formed-looking
 // prefix and otherwise leaves cur untouched.
 //
-// It returns a *ParseError when the hint body is UNTERMINATED — an `@{` (or
-// `@[…@]{`) whose closing '}' never arrives before EOF. Without this, an
-// unterminated hint would be silently consumed to EOF and the (invalid)
-// statement would draw no diagnostic at all, which bytebase's Diagnose must not
-// allow (oracle: Spanner rejects a malformed hint such as `@{}` / `@` with a
-// syntax error). Returns nil when there is no hint or the hint body closes
-// cleanly.
+// It returns a *ParseError when the hint body is malformed in a way that would
+// otherwise be silently swallowed to EOF, leaving the (invalid) statement with
+// no diagnostic at all — which bytebase's Diagnose must not allow:
+//   - UNTERMINATED — an `@{` (or `@[…@]{`) whose closing '}' never arrives
+//     before EOF.
+//   - EMPTY — a balanced but entry-less `@{}` (or `@[…@]{}`). GoogleSQL requires
+//     at least one hint entry (oracle: the Spanner emulator rejects `@{}` with
+//     `Syntax error: Unexpected "}"`).
+//
+// Returns nil when there is no hint or the hint body is non-empty and closes
+// cleanly. (The body's internal `key=value` entry shape is NOT validated here —
+// that is the later hint-parsing node's job; the foundation only enforces
+// termination and non-emptiness so dispatch can safely reach the statement.)
 func (p *Parser) skipStatementLevelHint() *ParseError {
 	if p.cur.Type != int('@') {
 		return nil
@@ -248,12 +254,31 @@ func (p *Parser) skipStatementLevelHint() *ParseError {
 }
 
 // skipBalancedBraces consumes a '{' ... '}' run with balanced nesting starting
-// at the current token (which must be '{'). Returns a *ParseError anchored at
-// hintStart if EOF is reached before the matching '}' (unterminated hint);
-// returns nil on a clean close or when cur is not '{'.
+// at the current token (which must be '{'). It returns a *ParseError anchored at
+// hintStart when:
+//   - EOF is reached before the matching '}' (an unterminated hint), or
+//   - the body is EMPTY — the closing '}' immediately follows the opening '{'
+//     with nothing but whitespace/comments between (the lexer drops both). A
+//     GoogleSQL hint requires at least one entry, so `@{}` is a syntax error
+//     (oracle: the Spanner emulator rejects `@{} SELECT 1` with
+//     `Syntax error: Unexpected "}"`). Without this guard the empty hint is
+//     skipped, dispatch reaches EOF, and the invalid input draws no diagnostic.
+//
+// It returns nil on a clean close of a non-empty body, or when cur is not '{'.
+// Validating the body's internal `key=value` entry shape is deferred to the
+// later hint-parsing node; this only enforces non-emptiness and termination.
 func (p *Parser) skipBalancedBraces(hintStart ast.Loc) *ParseError {
 	if p.cur.Type != int('{') {
 		return nil
+	}
+	// Empty body: the closing '}' immediately follows the opening '{' (the lexer
+	// has already dropped any whitespace/comments between them). Detect it by the
+	// token right after '{' rather than by counting interior tokens, so a body
+	// that merely STARTS with a brace (e.g. `@{{…}}`) is treated as non-empty —
+	// its malformed `key=value` shape is the later hint node's concern, not an
+	// emptiness error.
+	if p.peekNext().Type == int('}') {
+		return &ParseError{Loc: hintStart, Msg: "empty statement hint"}
 	}
 	depth := 0
 	for p.cur.Type != tokEOF {

--- a/googlesql/parser/parser_test.go
+++ b/googlesql/parser/parser_test.go
@@ -1,0 +1,297 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParse_EmptyInput verifies that parsing empty or whitespace/comment-only
+// input yields a non-nil File with no statements and no errors.
+func TestParse_EmptyInput(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\t ", "-- just a comment\n", "/* block */", "# pound\n", ";", ";;"} {
+		file, errs := Parse(in)
+		if file == nil {
+			t.Fatalf("Parse(%q): File is nil", in)
+		}
+		if len(file.Stmts) != 0 {
+			t.Errorf("Parse(%q): got %d stmts, want 0", in, len(file.Stmts))
+		}
+		if len(errs) != 0 {
+			t.Errorf("Parse(%q): got errors %v, want none", in, errs)
+		}
+	}
+}
+
+// TestParse_FileLocCoversInput verifies the File node spans the whole input.
+func TestParse_FileLocCoversInput(t *testing.T) {
+	in := "SELECT 1; SELECT 2"
+	file, _ := Parse(in)
+	if file.Loc.Start != 0 || file.Loc.End != len(in) {
+		t.Errorf("File.Loc = %+v, want {0, %d}", file.Loc, len(in))
+	}
+}
+
+// TestParse_UnknownStatement verifies a statement starting with a token the
+// dispatch switch does not recognize produces a parse error (not a panic, not
+// silent acceptance).
+func TestParse_UnknownStatement(t *testing.T) {
+	_, errs := Parse("FOOBAR 1 2 3")
+	if len(errs) == 0 {
+		t.Fatal("Parse(\"FOOBAR ...\"): want a parse error, got none")
+	}
+	if !strings.Contains(errs[0].Msg, "unknown or unsupported statement") {
+		t.Errorf("error = %q, want it to mention 'unknown or unsupported statement'", errs[0].Msg)
+	}
+}
+
+// TestParse_KnownStatementUnsupported verifies a statement whose leading
+// keyword IS in the dispatch switch but whose body is stubbed yields a "not yet
+// supported" diagnostic rather than an "unknown statement" one. The foundation
+// ships dispatch only; concrete statement parsers arrive in later DAG nodes.
+func TestParse_KnownStatementUnsupported(t *testing.T) {
+	_, errs := Parse("SELECT 1")
+	if len(errs) != 1 {
+		t.Fatalf("Parse(\"SELECT 1\"): got %d errors, want 1: %v", len(errs), errs)
+	}
+	if !strings.Contains(errs[0].Msg, "not yet supported") {
+		t.Errorf("error = %q, want 'not yet supported'", errs[0].Msg)
+	}
+	if !strings.HasPrefix(errs[0].Msg, "SELECT ") {
+		t.Errorf("error = %q, want it to name the SELECT statement", errs[0].Msg)
+	}
+}
+
+// TestParse_MultiStatementErrorsCollected verifies ParseBestEffort collects
+// errors from every segment, not just the first.
+func TestParse_MultiStatementErrorsCollected(t *testing.T) {
+	res := ParseBestEffort("SELECT 1; INSERT INTO t VALUES (1); UPDATE t SET x=1")
+	if got := len(res.Errors); got != 3 {
+		t.Fatalf("ParseBestEffort: got %d errors, want 3: %v", got, res.Errors)
+	}
+}
+
+// TestParse_LexErrorPromoted verifies a lexer-level failure (unterminated
+// string) surfaces as a parse error with a position, so Diagnose can report it.
+func TestParse_LexErrorPromoted(t *testing.T) {
+	_, errs := Parse("SELECT 'unterminated")
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Msg, errUnterminatedString) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("errors = %v, want one mentioning %q", errs, errUnterminatedString)
+	}
+}
+
+// TestParse_LexErrorPositionAbsolute verifies a lex error in the SECOND
+// statement carries an absolute byte offset (NewLexerWithOffset shift), not a
+// segment-local one.
+func TestParse_LexErrorPositionAbsolute(t *testing.T) {
+	// The unterminated string begins at byte offset 17 in the full input.
+	in := "SELECT 1;\nSELECT 'oops"
+	want := strings.Index(in, "'oops")
+	_, errs := Parse(in)
+	var lexErr *ParseError
+	for i := range errs {
+		if strings.Contains(errs[i].Msg, errUnterminatedString) {
+			lexErr = &errs[i]
+		}
+	}
+	if lexErr == nil {
+		t.Fatalf("no unterminated-string error in %v", errs)
+	}
+	if lexErr.Loc.Start != want {
+		t.Errorf("lex error Loc.Start = %d, want %d (absolute offset)", lexErr.Loc.Start, want)
+	}
+}
+
+// TestParse_StrictReturnsAllErrors verifies the strict Parse entry returns the
+// full error slice (matching snowflake/trino Parse, which return []ParseError).
+func TestParse_StrictReturnsAllErrors(t *testing.T) {
+	_, errs := Parse("FOOBAR; BAZBAR")
+	if len(errs) != 2 {
+		t.Fatalf("Parse: got %d errors, want 2: %v", len(errs), errs)
+	}
+}
+
+// TestParse_UnterminatedCommentReported verifies a whole-input unterminated
+// block comment surfaces a diagnostic. The comment lexes to EOF, so Split drops
+// its (empty) segment — but the lex error must still be reported, because
+// bytebase's Diagnose promises to flag every lexer error. Lex errors are
+// therefore collected from a single full-input pass, not per surviving segment.
+func TestParse_UnterminatedCommentReported(t *testing.T) {
+	cases := []string{
+		"/* unterminated",            // whole input is the bad comment
+		"SELECT 1; /* unterminated",  // bad comment after a (dropped) trailing chunk
+		"/* bad */ SELECT 1 /* also", // a closed comment then an unterminated one
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, errs := Parse(in)
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e.Msg, errUnterminatedComment) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Parse(%q): no unterminated-comment diagnostic in %v", in, errs)
+			}
+		})
+	}
+}
+
+// TestParse_LexErrorAfterRecoveryStopReported verifies a lex error positioned
+// AFTER the point where statement error-recovery stops is still reported. The
+// per-statement parser stops at the first ';' boundary on an unsupported/invalid
+// statement, so a pull-based per-segment lexer would never reach a later
+// unterminated string; the full-input lex pass catches it.
+func TestParse_LexErrorAfterRecoveryStopReported(t *testing.T) {
+	cases := []string{
+		"CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 'oops", // unterminated string deep in a block segment
+		"FOOBAR a b c 'oops", // unknown stmt, then a late unterminated string
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, errs := Parse(in)
+			found := false
+			for _, e := range errs {
+				if strings.Contains(e.Msg, errUnterminatedString) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Parse(%q): no unterminated-string diagnostic in %v", in, errs)
+			}
+		})
+	}
+}
+
+// TestParse_UnterminatedHintReported verifies a malformed statement-level hint
+// whose body never closes (`@{ … <EOF>` or `@[ … @] { … <EOF>`) yields a
+// diagnostic rather than silently swallowing the statement. Without it, the hint
+// skip would consume to EOF and dispatch would never run, so an invalid input
+// would draw no diagnostic at all (oracle: Spanner rejects malformed hints).
+func TestParse_UnterminatedHintReported(t *testing.T) {
+	bad := []string{"@{k=1 SELECT 1", "@{", "@{a={b=1}", "@[5@]{k=1", "@[5@] SELECT 1"}
+	for _, in := range bad {
+		t.Run("bad/"+in, func(t *testing.T) {
+			_, errs := Parse(in)
+			if len(errs) == 0 || !strings.Contains(errs[0].Msg, "unterminated statement hint") {
+				t.Errorf("Parse(%q): want an unterminated-hint diagnostic, got %v", in, errs)
+			}
+		})
+	}
+	// A well-formed hint must NOT be flagged; it should dispatch to the (stubbed)
+	// statement keyword after the hint.
+	good := []string{"@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT 1", "@5 SELECT 1", "@[5@]{key=1} SELECT 1"}
+	for _, in := range good {
+		t.Run("good/"+in, func(t *testing.T) {
+			_, errs := Parse(in)
+			for _, e := range errs {
+				if strings.Contains(e.Msg, "unterminated statement hint") {
+					t.Errorf("Parse(%q): well-formed hint wrongly flagged: %v", in, errs)
+				}
+			}
+		})
+	}
+}
+
+// dispatchPrefix is one representative leading token sequence per documented
+// GoogleSQL top-level statement kind (antlr_rules.md §4: sql_statement_body
+// alternatives + the procedural-script forms recognized at top level). The body
+// after the keyword does not matter — the foundation stubs it — so we only need
+// the leading keyword(s) to land in a real dispatch case rather than default.
+var dispatchPrefixes = []string{
+	// Query / GQL.
+	"SELECT", "WITH", "GRAPH", "FROM", "(",
+	// DDL.
+	"CREATE", "ALTER", "DROP", "RENAME", "UNDROP", "TRUNCATE", "DEFINE",
+	// DML.
+	"INSERT", "UPDATE", "DELETE", "MERGE",
+	// DCL.
+	"GRANT", "REVOKE",
+	// Transactions / batch / session.
+	"BEGIN", "START", "COMMIT", "ROLLBACK", "SET", "RUN", "ABORT",
+	// Utility / metadata.
+	"EXPLAIN", "DESCRIBE", "DESC", "SHOW", "ANALYZE", "ASSERT", "CALL",
+	"EXECUTE", "IMPORT", "MODULE", "EXPORT", "LOAD", "CLONE",
+	// Procedural / scripting (recognized at top level).
+	"IF", "CASE", "WHILE", "LOOP", "REPEAT", "FOR", "DECLARE", "BREAK",
+	"LEAVE", "CONTINUE", "ITERATE", "RETURN", "RAISE",
+}
+
+// TestParse_DispatchKeywordsRecognized verifies every documented top-level
+// statement keyword is routed by the dispatch switch — it produces a "not yet
+// supported" (stubbed) error, NOT an "unknown statement" error. This is the
+// foundation's completeness contract: all statement forms must be reachable so
+// bytebase's Diagnose never emits a false "unknown statement" diagnostic for
+// valid GoogleSQL.
+func TestParse_DispatchKeywordsRecognized(t *testing.T) {
+	for _, p := range dispatchPrefixes {
+		t.Run(p, func(t *testing.T) {
+			sql := p + " x" // minimal tail; the leading token is the keyword
+			_, errs := Parse(sql)
+			for _, e := range errs {
+				if strings.Contains(e.Msg, "unknown or unsupported statement") {
+					t.Errorf("Parse(%q): leading keyword %q hit the UNKNOWN branch; "+
+						"it must be in the dispatch switch (got %q)", sql, p, e.Msg)
+				}
+			}
+		})
+	}
+}
+
+// TestParse_StatementLevelHintSkipped verifies a leading statement-level hint
+// (@{...} / @N / @[N@]{...}) is skipped so dispatch sees the real statement
+// keyword. Without the skip, `@{...} SELECT` would be reported as an unknown
+// statement starting with '@'.
+func TestParse_StatementLevelHintSkipped(t *testing.T) {
+	cases := []string{
+		"@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT 1",
+		"@{OPTIMIZER_VERSION=2, OPTIMIZER_STATISTICS_PACKAGE='auto'} SELECT * FROM T",
+		"@5 SELECT 1",
+		"@[5@]{key=1} SELECT 1",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) != 1 {
+				t.Fatalf("Parse(%q): got %d errors, want 1: %v", sql, len(errs), errs)
+			}
+			if strings.Contains(errs[0].Msg, "unknown or unsupported statement") {
+				t.Errorf("Parse(%q): hit UNKNOWN branch; hint not skipped: %q", sql, errs[0].Msg)
+			}
+			if !strings.HasPrefix(errs[0].Msg, "SELECT ") {
+				t.Errorf("Parse(%q): error = %q, want it to dispatch to SELECT after the hint", sql, errs[0].Msg)
+			}
+		})
+	}
+}
+
+// TestParse_NoStmtsWhileStubbed documents the foundation invariant: because
+// every dispatch case is stubbed, no statement parses to a real AST node yet,
+// so File.Stmts stays empty even for valid SQL. Later nodes flip this as they
+// replace dispatch-case bodies.
+func TestParse_NoStmtsWhileStubbed(t *testing.T) {
+	file, _ := Parse("SELECT 1; INSERT INTO t VALUES (1)")
+	if len(file.Stmts) != 0 {
+		t.Errorf("File.Stmts = %d, want 0 (all bodies stubbed in the foundation)", len(file.Stmts))
+	}
+}
+
+// TestParse_ProceduralBodyParsedAsOneSegment verifies the parse driver feeds a
+// procedural BEGIN/END body to a single parseSingle call (block-aware Split),
+// so a stored procedure yields exactly one "not yet supported" error, not one
+// per inner statement.
+func TestParse_ProceduralBodyParsedAsOneSegment(t *testing.T) {
+	res := ParseBestEffort("CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 2; END")
+	if len(res.Errors) != 1 {
+		t.Fatalf("got %d errors, want 1 (block is one segment): %v", len(res.Errors), res.Errors)
+	}
+	if !strings.HasPrefix(res.Errors[0].Msg, "CREATE ") {
+		t.Errorf("error = %q, want it to dispatch on CREATE", res.Errors[0].Msg)
+	}
+}

--- a/googlesql/parser/parser_test.go
+++ b/googlesql/parser/parser_test.go
@@ -199,6 +199,43 @@ func TestParse_UnterminatedHintReported(t *testing.T) {
 	}
 }
 
+// TestParse_EmptyHintReported verifies a balanced but EMPTY statement-level hint
+// body (`@{}`, or whitespace/comment-only between the braces) draws a diagnostic
+// rather than being silently consumed. GoogleSQL requires at least one hint
+// entry: oracle-confirmed against the Spanner emulator, `@{} SELECT 1` rejects
+// with `Syntax error: Unexpected "}"`. Without this check the empty hint is
+// skipped, parseSingle reaches EOF, and the (invalid) input draws no diagnostic
+// at all — which bytebase's Diagnose must not allow.
+func TestParse_EmptyHintReported(t *testing.T) {
+	// Empty hint bodies — must be flagged.
+	bad := []string{"@{}", "@{} SELECT 1", "@{   }", "@{ /* c */ } SELECT 1", "@[5@]{}", "@[5@]{} SELECT 1"}
+	for _, in := range bad {
+		t.Run("empty/"+in, func(t *testing.T) {
+			_, errs := Parse(in)
+			if len(errs) == 0 || !strings.Contains(errs[0].Msg, "empty statement hint") {
+				t.Errorf("Parse(%q): want an empty-hint diagnostic, got %v", in, errs)
+			}
+		})
+	}
+	// A hint with content between the braces is NOT empty: the foundation only
+	// SKIPS the hint to reach the statement keyword (validating the entry's
+	// internal `key=value` shape is the hint-parsing node's job). So `@{k} …`
+	// must dispatch to the statement, not draw an empty-hint diagnostic. (The
+	// oracle does ultimately reject `@{k}` for a missing `=value`, but that is a
+	// deeper hint-body parse the foundation deliberately defers.)
+	nonEmpty := []string{"@{k} SELECT 1", "@{k=1} SELECT 1", "@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT 1"}
+	for _, in := range nonEmpty {
+		t.Run("nonempty/"+in, func(t *testing.T) {
+			_, errs := Parse(in)
+			for _, e := range errs {
+				if strings.Contains(e.Msg, "empty statement hint") {
+					t.Errorf("Parse(%q): non-empty hint wrongly flagged as empty: %v", in, errs)
+				}
+			}
+		})
+	}
+}
+
 // dispatchPrefix is one representative leading token sequence per documented
 // GoogleSQL top-level statement kind (antlr_rules.md §4: sql_statement_body
 // alternatives + the procedural-script forms recognized at top level). The body

--- a/googlesql/parser/split.go
+++ b/googlesql/parser/split.go
@@ -111,15 +111,24 @@ func SplitFlat(input string) []Segment {
 //     (END IF / END CASE / END LOOP / END WHILE / END REPEAT / END FOR).
 //   - Blocks nest; an inner block's END only closes that inner block.
 //
-// A top-level BEGIN is ambiguous: BEGIN [TRANSACTION|WORK] is a transaction
-// start (TCL), while BEGIN ... END is a procedural block. One-token lookahead
-// after BEGIN disambiguates: a TCL follower (';', EOF, TRANSACTION) keeps the
-// statement flat; anything else opens a block. (CASE is doubly ambiguous — it
-// is also an expression; but a CASE expression's END never carries a trailing
-// ';' issue at top level because the surrounding query splits on its own ';'.
-// The block-aware closer counting is harmless for the expression form: a CASE
-// expression with no internal ';' splits identically either way, which the
-// legacy split_begin_end_test.go relies on.)
+// CRITICAL — a block opener is recognized only at a STATEMENT-LEADING position.
+// IF/CASE/LOOP/WHILE/REPEAT/FOR are ordinary syntax mid-statement (a function
+// call `IF(x,1,2)`, a query clause `FOR UPDATE`, a guard `IF NOT EXISTS`, a
+// keyword-as-alias, or a CASE expression), so opening a block on ANY occurrence
+// would flip a plain `SELECT IF(x,1,2); SELECT 1` into block mode and absorb the
+// next statement's ';'. These keywords therefore open a block only when they
+// begin a statement (input start, or right after a top-level ';'); everywhere
+// else they stay flat. This also keeps a stray top-level closer suffix (the IF
+// in `END IF`) from reopening a block, since it is never statement-leading.
+//
+// BEGIN is the exception: it opens a block position-INDEPENDENTLY because the
+// canonical `CREATE PROCEDURE … BEGIN` is mid-statement. A top-level BEGIN is
+// still ambiguous (BEGIN [TRANSACTION|WORK] is a TCL transaction start, BEGIN …
+// END is a block), so one-token lookahead after BEGIN disambiguates: a TCL
+// follower (';', EOF, TRANSACTION, READ, ISOLATION) keeps it flat; anything else
+// opens a block. (CASE, which is also an expression, no longer needs the
+// "harmless closer-counting" argument the legacy split_begin_end_test.go relied
+// on — a mid-statement CASE expression simply never opens a block now.)
 func Split(input string) []Segment {
 	if len(input) == 0 {
 		return nil
@@ -131,11 +140,38 @@ func Split(input string) []Segment {
 	state := stateTop
 	depth := 0 // block-nesting depth while in stateInBlock
 
-	// prevWasEnd is set immediately after an END token so a block keyword that
-	// completes a typed closer — END IF / END CASE / END LOOP / END WHILE /
-	// END REPEAT / END FOR — is recognized as the closer's suffix rather than
-	// miscounted as a NEW block opener (which would desync depth and swallow
-	// the statement-terminating ';' after the block).
+	// atStmtStart reports whether the next TOP-LEVEL token begins a new
+	// statement — true at input start and immediately after a top-level ';'. It
+	// is the gate for the control-flow block OPENERS at the top level: IF / CASE
+	// / LOOP / WHILE / REPEAT / FOR open a procedural block ONLY when they are
+	// statement-leading. Mid-statement the SAME keywords are ordinary syntax — a
+	// function call (IF(x,1,2)), a query clause (FOR UPDATE), a guard (IF NOT
+	// EXISTS), a keyword-as-alias, or a CASE/IF expression — and must NOT flip
+	// the splitter into block mode (which would absorb the next statement's
+	// terminating ';'). It also makes a stray top-level closer suffix (the IF in
+	// `END IF`) a no-op, since that suffix is never statement-leading.
+	//
+	// NOTE the scope: atStmtStart gates only the TOP-LEVEL openers. Inside an
+	// already-open block body (stateInBlock) every BEGIN/IF/CASE/LOOP/WHILE/
+	// REPEAT/FOR still counts as a nesting opener and every END as a closer (the
+	// classic balanced count). That counting is correct for well-formed nesting
+	// and self-balances for a CASE expression (CASE … END), which is all the
+	// Spanner consumer of block-aware Split needs — Spanner has no stored
+	// procedures, so a procedure body with a bare mid-statement IF(...)/FOR
+	// clause is invalid Spanner input and out of scope here. Applying the
+	// statement-position rule INSIDE a block is unsafe without full parsing,
+	// because THEN/ELSE introduce a statement list in a procedural IF/CASE but a
+	// value expression in a CASE *expression* (e.g. the IF(...) in
+	// `CASE WHEN x THEN IF(a,b,c) ELSE 0 END` must NOT open a block).
+	atStmtStart := true
+
+	// prevWasEnd is set immediately after an END token INSIDE a block so a block
+	// keyword that completes a typed closer — END IF / END CASE / END LOOP /
+	// END WHILE / END REPEAT / END FOR — is recognized as the closer's suffix
+	// rather than miscounted as a NEW (nested) block opener, which would desync
+	// depth and swallow the statement-terminating ';' after the block. (At the
+	// TOP level the statement-position gate above already prevents a closer
+	// suffix from reopening, so prevWasEnd is purely a stateInBlock concern.)
 	prevWasEnd := false
 
 	// We need one-token lookahead after a top-level BEGIN to tell a
@@ -174,32 +210,41 @@ func Split(input string) []Segment {
 		switch state {
 		case stateTop:
 			switch tok.Type {
-			case kwBEGIN, kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT, kwFOR:
-				switch {
-				case prevWasEnd:
-					// This block keyword immediately follows the END that closed
-					// the OUTERMOST block (depth 1→0), so it is the suffix of a
-					// typed closer (END IF / END CASE / END LOOP / …), not a new
-					// opener. Consume it without reopening. Without this, a typed
-					// closer at the top level would re-enter a block and swallow
-					// the statement-terminating ';' that follows.
-					prevWasEnd = false
-				case tok.Type == kwBEGIN && isTCLBeginFollower(peekToken()):
-					// BEGIN [TRANSACTION] is a transaction start — stay flat. The
-					// buffered follower is returned by the next nextToken() and
-					// handled normally (including the ';' emission path).
-				default:
-					// A top-level control-flow opener begins a procedural block
-					// body whose internal ';' must be kept whole.
+			case kwBEGIN:
+				// BEGIN opens a procedural block whenever the following token is
+				// not a TCL follower — this is position-INDEPENDENT, because
+				// `CREATE PROCEDURE … BEGIN` is mid-statement yet must open a
+				// block, while a top-level `BEGIN [TRANSACTION]` is a flat
+				// transaction start. (A bare kwBEGIN never appears mid-statement
+				// except as a block opener; an identifier spelled `begin` lexes
+				// to tokIdentifier, not kwBEGIN.) The buffered follower is
+				// returned by the next nextToken() and handled normally.
+				if !isTCLBeginFollower(peekToken()) {
 					state = stateInBlock
 					depth = 1
+					prevWasEnd = false
 				}
+				atStmtStart = false
+			case kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT, kwFOR:
+				// A control-flow keyword opens a procedural block ONLY when it is
+				// statement-leading. Mid-statement the same keyword is ordinary
+				// syntax (IF(...) call, FOR UPDATE clause, IF NOT EXISTS guard,
+				// keyword-as-alias, CASE expression) and must stay flat so the
+				// next ';' still splits. A stray top-level closer suffix (the IF
+				// in `END IF`) is likewise not statement-leading, so it cannot
+				// reopen a block.
+				if atStmtStart {
+					state = stateInBlock
+					depth = 1
+					prevWasEnd = false
+				}
+				atStmtStart = false
 			case int(';'):
-				prevWasEnd = false
 				emit(tok.Loc.Start)
 				stmtStart = tok.Loc.End
+				atStmtStart = true
 			default:
-				prevWasEnd = false
+				atStmtStart = false
 			}
 
 		case stateInBlock:
@@ -217,10 +262,13 @@ func Split(input string) []Segment {
 				if depth > 0 {
 					depth--
 					if depth == 0 {
-						// Return to stateTop but KEEP prevWasEnd set: a typed
-						// closer's suffix keyword (END IF / END WHILE / …) may
-						// follow and must be recognized as the suffix by the
-						// stateTop arm above, not mistaken for a new opener.
+						// Return to stateTop. atStmtStart is still false (it was
+						// cleared when this block opened and stateInBlock never
+						// sets it), so a typed closer's suffix keyword that
+						// follows (END IF / END WHILE / …) is correctly seen as
+						// non-statement-leading by the stateTop arm above and
+						// cannot reopen a block. The next top-level ';' is the
+						// only thing that re-arms atStmtStart.
 						state = stateTop
 					}
 				}

--- a/googlesql/parser/split.go
+++ b/googlesql/parser/split.go
@@ -1,0 +1,266 @@
+package parser
+
+// This file ships the GoogleSQL statement splitters. GoogleSQL is consumed by
+// two bytebase engines whose legacy splitters DIVERGE (see the migration
+// contract, §4 "Statement split"):
+//
+//   - BigQuery uses a pure lexer/token split — every top-level ';' ends a
+//     statement (base.SplitSQLByLexer over the GoogleSQL lexer). BigQuery's
+//     editor surface is single statements / scripts without nested control
+//     flow at this layer.
+//   - Spanner uses a parse-tree split that keeps procedural BEGIN/END (and
+//     IF/CASE/LOOP/WHILE/REPEAT/FOR) blocks whole so a ';' separating control
+//     statements inside a stored-procedure body does not split the CREATE
+//     PROCEDURE into pieces (see the legacy split_begin_end_test.go).
+//
+// The foundation ships BOTH as pure functions over Segment so the
+// bytebase-switch node can wire each engine to the matching variant:
+//
+//   - Split      — block-aware (Spanner semantics; also correct for BigQuery
+//                  scripting, since a flat split is the degenerate case when
+//                  no block keywords appear).
+//   - SplitFlat  — pure lexer split on every top-level ';' (BigQuery
+//                  semantics).
+//
+// Both reuse the hand-written Lexer, which already hides string / bytes /
+// backtick-identifier / comment content, so a ';' inside a literal, a quoted
+// identifier, or a comment is never mistaken for a delimiter.
+
+// Segment represents one top-level SQL statement extracted from a source
+// string.
+//
+// Text is the raw substring of the input from ByteStart (inclusive) to ByteEnd
+// (exclusive). It is NOT trimmed — leading/trailing whitespace and comments are
+// preserved verbatim. The trailing ';' delimiter (if present) is NOT part of
+// Text or ByteEnd; it lives between this segment's ByteEnd and the next
+// segment's ByteStart.
+type Segment struct {
+	Text      string // raw text of the statement (no trailing semicolon)
+	ByteStart int    // inclusive start byte offset in the original source
+	ByteEnd   int    // exclusive end byte offset; points AT the trailing ';' if present, else at len(input)
+}
+
+// Empty reports whether the segment contains no meaningful SQL content — only
+// whitespace and comments. It re-lexes Text and checks whether the first token
+// is tokEOF. Empty segments are filtered out by both splitters.
+func (s Segment) Empty() bool {
+	return NewLexer(s.Text).NextToken().Type == tokEOF
+}
+
+// splitState is the state-machine state for the block-aware Split.
+type splitState int
+
+const (
+	stateTop     splitState = iota // between statements / inside a non-block statement
+	stateInBlock                   // inside a procedural BEGIN/IF/CASE/LOOP/WHILE/REPEAT/FOR block body
+)
+
+// SplitFlat splits input on every top-level ';' — the BigQuery lexer-split
+// semantics. It mirrors the legacy bigquery.SplitSQL (base.SplitSQLByLexer over
+// the GoogleSQL lexer): control-flow keywords are NOT treated specially, so a
+// ';' inside a procedural body WOULD split (BigQuery's wired surface does not
+// rely on block-aware splitting at this layer).
+//
+// The returned slice contains one Segment per non-empty statement; empty
+// statements (lone semicolons, comment-only chunks) are filtered out. SplitFlat
+// is infallible — lexing errors are suppressed here; callers who need them use
+// NewLexer(input).Errors() or Parse, which promotes lex errors to diagnostics.
+func SplitFlat(input string) []Segment {
+	if len(input) == 0 {
+		return nil
+	}
+	l := NewLexer(input)
+	var segments []Segment
+	stmtStart := 0
+
+	emit := func(end int) {
+		seg := Segment{Text: input[stmtStart:end], ByteStart: stmtStart, ByteEnd: end}
+		if !seg.Empty() {
+			segments = append(segments, seg)
+		}
+	}
+
+	for {
+		tok := l.NextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+		if tok.Type == int(';') {
+			emit(tok.Loc.Start)
+			stmtStart = tok.Loc.End
+		}
+	}
+	if stmtStart < len(input) {
+		emit(len(input))
+	}
+	return segments
+}
+
+// Split extracts top-level SQL statements from input, keeping procedural
+// BEGIN/END (and IF/CASE/LOOP/WHILE/REPEAT/FOR) blocks whole — the Spanner
+// parse-tree-split semantics. A ';' that separates control statements inside a
+// stored-procedure body does not split the enclosing statement.
+//
+// The returned slice contains one Segment per non-empty statement; empty
+// statements (lone semicolons, comment-only chunks) are filtered out. Split is
+// infallible (lexing errors are suppressed here, as in SplitFlat).
+//
+// Block model (GoogleSQLParser.g4 procedural statements):
+//   - Openers: BEGIN, IF, CASE, LOOP, WHILE, REPEAT, FOR.
+//   - Closer: END, optionally followed by the block-kind keyword
+//     (END IF / END CASE / END LOOP / END WHILE / END REPEAT / END FOR).
+//   - Blocks nest; an inner block's END only closes that inner block.
+//
+// A top-level BEGIN is ambiguous: BEGIN [TRANSACTION|WORK] is a transaction
+// start (TCL), while BEGIN ... END is a procedural block. One-token lookahead
+// after BEGIN disambiguates: a TCL follower (';', EOF, TRANSACTION) keeps the
+// statement flat; anything else opens a block. (CASE is doubly ambiguous — it
+// is also an expression; but a CASE expression's END never carries a trailing
+// ';' issue at top level because the surrounding query splits on its own ';'.
+// The block-aware closer counting is harmless for the expression form: a CASE
+// expression with no internal ';' splits identically either way, which the
+// legacy split_begin_end_test.go relies on.)
+func Split(input string) []Segment {
+	if len(input) == 0 {
+		return nil
+	}
+
+	l := NewLexer(input)
+	var segments []Segment
+	stmtStart := 0
+	state := stateTop
+	depth := 0 // block-nesting depth while in stateInBlock
+
+	// prevWasEnd is set immediately after an END token so a block keyword that
+	// completes a typed closer — END IF / END CASE / END LOOP / END WHILE /
+	// END REPEAT / END FOR — is recognized as the closer's suffix rather than
+	// miscounted as a NEW block opener (which would desync depth and swallow
+	// the statement-terminating ';' after the block).
+	prevWasEnd := false
+
+	// We need one-token lookahead after a top-level BEGIN to tell a
+	// transaction-start (TCL) from a procedural block opener. A one-slot
+	// buffered lookahead does this without disturbing the main scan.
+	var pending *Token
+	nextToken := func() Token {
+		if pending != nil {
+			t := *pending
+			pending = nil
+			return t
+		}
+		return l.NextToken()
+	}
+	peekToken := func() Token {
+		if pending == nil {
+			t := l.NextToken()
+			pending = &t
+		}
+		return *pending
+	}
+
+	emit := func(end int) {
+		seg := Segment{Text: input[stmtStart:end], ByteStart: stmtStart, ByteEnd: end}
+		if !seg.Empty() {
+			segments = append(segments, seg)
+		}
+	}
+
+	for {
+		tok := nextToken()
+		if tok.Type == tokEOF {
+			break
+		}
+
+		switch state {
+		case stateTop:
+			switch tok.Type {
+			case kwBEGIN, kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT, kwFOR:
+				switch {
+				case prevWasEnd:
+					// This block keyword immediately follows the END that closed
+					// the OUTERMOST block (depth 1→0), so it is the suffix of a
+					// typed closer (END IF / END CASE / END LOOP / …), not a new
+					// opener. Consume it without reopening. Without this, a typed
+					// closer at the top level would re-enter a block and swallow
+					// the statement-terminating ';' that follows.
+					prevWasEnd = false
+				case tok.Type == kwBEGIN && isTCLBeginFollower(peekToken()):
+					// BEGIN [TRANSACTION] is a transaction start — stay flat. The
+					// buffered follower is returned by the next nextToken() and
+					// handled normally (including the ';' emission path).
+				default:
+					// A top-level control-flow opener begins a procedural block
+					// body whose internal ';' must be kept whole.
+					state = stateInBlock
+					depth = 1
+				}
+			case int(';'):
+				prevWasEnd = false
+				emit(tok.Loc.Start)
+				stmtStart = tok.Loc.End
+			default:
+				prevWasEnd = false
+			}
+
+		case stateInBlock:
+			switch tok.Type {
+			case kwBEGIN, kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT, kwFOR:
+				// A block keyword right after END is the suffix of a typed
+				// closer (END IF / END CASE / …), not a new opener.
+				if prevWasEnd {
+					prevWasEnd = false
+				} else {
+					depth++
+				}
+			case kwEND:
+				prevWasEnd = true
+				if depth > 0 {
+					depth--
+					if depth == 0 {
+						// Return to stateTop but KEEP prevWasEnd set: a typed
+						// closer's suffix keyword (END IF / END WHILE / …) may
+						// follow and must be recognized as the suffix by the
+						// stateTop arm above, not mistaken for a new opener.
+						state = stateTop
+					}
+				}
+			default:
+				prevWasEnd = false
+			}
+			// ';' and every other token are absorbed inside the block body.
+		}
+	}
+
+	// Trailing segment — whatever remains after the last ';' (or the whole
+	// input when there was none). ByteEnd is len(input) here.
+	if stmtStart < len(input) {
+		emit(len(input))
+	}
+
+	return segments
+}
+
+// isTCLBeginFollower reports whether tok, appearing immediately after a
+// top-level BEGIN keyword, indicates a transaction start (TCL) rather than a
+// procedural block opener.
+//
+// GoogleSQL begin_statement: begin_transaction_keywords transaction_mode_list?
+// where begin_transaction_keywords is `BEGIN [TRANSACTION]` and a
+// transaction_mode begins with READ (READ ONLY | READ WRITE) or ISOLATION
+// (ISOLATION LEVEL <id>). So a BEGIN is a transaction start when it is
+// immediately followed by:
+//   - ';' or EOF                 — a bare `BEGIN;` / `BEGIN`
+//   - TRANSACTION                — `BEGIN TRANSACTION ...`
+//   - READ / ISOLATION           — `BEGIN READ ONLY|WRITE`, `BEGIN ISOLATION LEVEL ...`
+//     (the optional TRANSACTION keyword may be omitted, so a mode list can
+//     follow BEGIN directly — oracle-confirmed against the Spanner emulator).
+//
+// Anything else after BEGIN (a DECLARE, a SELECT, an IF, ...) opens a
+// procedural begin_end_block, whose internal ';' must be kept whole.
+func isTCLBeginFollower(tok Token) bool {
+	switch tok.Type {
+	case int(';'), tokEOF, kwTRANSACTION, kwREAD, kwISOLATION:
+		return true
+	}
+	return false
+}

--- a/googlesql/parser/split_test.go
+++ b/googlesql/parser/split_test.go
@@ -283,6 +283,84 @@ func TestSplit_TopLevelTypedCloserDoesNotReopen(t *testing.T) {
 	}
 }
 
+// A control-flow keyword (IF / CASE / LOOP / WHILE / REPEAT / FOR) that appears
+// MID-statement — as a function call (IF(...)), a query clause (FOR UPDATE), a
+// guard (IF NOT EXISTS), or an expression (CASE … END) — must NOT be mistaken
+// for a procedural block opener. Only a STATEMENT-LEADING occurrence opens a
+// block. Otherwise the splitter flips into block mode and swallows the next
+// statement's terminating ';'. These are all common valid forms and SplitSQL is
+// P0 for both BigQuery and Spanner, so a misread here mis-splits real input.
+// (Oracle-confirmed against the Spanner emulator: `SELECT IF(x,1,2)`,
+// `SELECT a FROM t FOR UPDATE`, `CREATE SCHEMA IF NOT EXISTS s`, and
+// `SELECT CASE WHEN x THEN 1 ELSE 2 END` each parse as ONE statement.)
+func TestSplit_MidStatementControlKeywordIsNotBlock(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"if_function_call", "SELECT IF(x, 1, 2) AS c; SELECT 1"},
+		{"for_update_clause", "SELECT a FROM t FOR UPDATE; SELECT 1"},
+		{"if_not_exists_guard", "CREATE SCHEMA IF NOT EXISTS s; SELECT 1"},
+		{"case_expression", "SELECT CASE WHEN x THEN 1 ELSE 2 END; SELECT 1"},
+		{"while_as_alias", "SELECT 1 AS while; SELECT 2"},
+		{"if_in_where", "SELECT 1 WHERE IF(a, b, c); SELECT 2"},
+		// A CASE-expression branch may itself contain a control-flow keyword used
+		// as an expression (an IF(...) call, a nested CASE). Neither the inner
+		// keyword nor the CASE's own END is statement-leading, so the whole CASE
+		// expression stays one statement. (Oracle-confirmed: both parse as a
+		// single accepted query.) These guard against over-eagerly treating a
+		// CASE branch's THEN/ELSE as a procedural statement-list introducer.
+		{"if_call_in_case_branch", "SELECT CASE WHEN x THEN IF(a, b, c) ELSE 0 END; SELECT 1"},
+		{"nested_case_expression", "SELECT CASE WHEN x THEN CASE WHEN y THEN 1 END END; SELECT 1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Split(c.input)
+			if len(got) != 2 {
+				t.Fatalf("Split(%q) = %d segments, want 2 (mid-statement control keyword opened a block): %+v", c.input, len(got), got)
+			}
+			if strings.TrimSpace(got[1].Text) != "SELECT 1" && strings.TrimSpace(got[1].Text) != "SELECT 2" {
+				t.Errorf("segment[1] = %q, want the trailing SELECT", got[1].Text)
+			}
+			// Split must agree with the flat lexer split here: there is no real
+			// procedural block, so both see exactly two top-level statements.
+			if flat := SplitFlat(c.input); len(flat) != 2 {
+				t.Errorf("SplitFlat(%q) = %d segments, want 2: %+v", c.input, len(flat), flat)
+			}
+		})
+	}
+}
+
+// A stray top-level typed closer (`END IF` / `END WHILE` / …) that opens no
+// preceding block must NOT itself reopen a block and swallow the next
+// statement's ';'. (Invalid GoogleSQL, but the splitter is documented
+// best-effort/infallible and must never drop a following statement.) This is the
+// statement-position rule applied to the closer-suffix keyword: `IF` after a
+// stray top-level `END` is not statement-leading, so it cannot open a block.
+func TestSplit_StrayTopLevelCloserDoesNotSwallow(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"end_if", "END IF; SELECT 1"},
+		{"end_while", "END WHILE; SELECT 1"},
+		{"end_loop", "END LOOP; SELECT 1"},
+		{"end_for", "END FOR; SELECT 1"},
+		{"bare_end", "END; SELECT 1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Split(c.input)
+			if len(got) != 2 {
+				t.Fatalf("Split(%q) = %d segments, want 2 (stray closer swallowed the next statement): %+v", c.input, len(got), got)
+			}
+			if strings.TrimSpace(got[1].Text) != "SELECT 1" {
+				t.Errorf("segment[1] = %q, want ' SELECT 1'", got[1].Text)
+			}
+		})
+	}
+}
+
 // Every block kind's typed closer (END IF / END WHILE / END LOOP / END REPEAT /
 // END FOR / bare END) must be recognized so the closer's trailing keyword is not
 // miscounted as a NEW block opener (which would desync depth and swallow the

--- a/googlesql/parser/split_test.go
+++ b/googlesql/parser/split_test.go
@@ -1,0 +1,392 @@
+package parser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// runSplitCases asserts Split(input) returns exactly the expected Segment list.
+func runSplitCases(t *testing.T, split func(string) []Segment, cases []struct {
+	name  string
+	input string
+	want  []Segment
+}) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := split(c.input)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("split(%q) mismatch\n got: %+v\nwant: %+v", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSplit_Empty(t *testing.T) {
+	if got := Split(""); got != nil {
+		t.Errorf("Split(\"\") = %+v, want nil", got)
+	}
+	if got := SplitFlat(""); got != nil {
+		t.Errorf("SplitFlat(\"\") = %+v, want nil", got)
+	}
+}
+
+func TestSplit_Basic(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{
+			name:  "single_no_semicolon",
+			input: "SELECT 1",
+			want:  []Segment{{Text: "SELECT 1", ByteStart: 0, ByteEnd: 8}},
+		},
+		{
+			name:  "single_trailing_semicolon",
+			input: "SELECT 1;",
+			want:  []Segment{{Text: "SELECT 1", ByteStart: 0, ByteEnd: 8}},
+		},
+		{
+			name:  "two_statements",
+			input: "SELECT 1; SELECT 2",
+			want: []Segment{
+				{Text: "SELECT 1", ByteStart: 0, ByteEnd: 8},
+				{Text: " SELECT 2", ByteStart: 9, ByteEnd: 18},
+			},
+		},
+		{
+			name:  "lone_semicolons_filtered",
+			input: ";;;",
+			want:  nil,
+		},
+		{
+			name:  "blank_between_filtered",
+			input: "SELECT 1;;SELECT 2",
+			want: []Segment{
+				{Text: "SELECT 1", ByteStart: 0, ByteEnd: 8},
+				{Text: "SELECT 2", ByteStart: 10, ByteEnd: 18},
+			},
+		},
+	}
+	t.Run("Split", func(t *testing.T) { runSplitCases(t, Split, cases) })
+	t.Run("SplitFlat", func(t *testing.T) { runSplitCases(t, SplitFlat, cases) })
+}
+
+// Semicolons hidden inside strings/bytes/backtick-identifiers/comments must NOT
+// split. Both variants share the lexer, so both behave identically here.
+func TestSplit_SemicolonInHiddenContent(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{
+			name:  "semicolon_in_single_quote",
+			input: "SELECT ';';SELECT 2",
+			want: []Segment{
+				{Text: "SELECT ';'", ByteStart: 0, ByteEnd: 10},
+				{Text: "SELECT 2", ByteStart: 11, ByteEnd: 19},
+			},
+		},
+		{
+			name:  "semicolon_in_triple_quote",
+			input: "SELECT '''a;b''';SELECT 2",
+			want: []Segment{
+				{Text: "SELECT '''a;b'''", ByteStart: 0, ByteEnd: 16},
+				{Text: "SELECT 2", ByteStart: 17, ByteEnd: 25},
+			},
+		},
+		{
+			name:  "semicolon_in_backtick_ident",
+			input: "SELECT `a;b`;SELECT 2",
+			want: []Segment{
+				{Text: "SELECT `a;b`", ByteStart: 0, ByteEnd: 12},
+				{Text: "SELECT 2", ByteStart: 13, ByteEnd: 21},
+			},
+		},
+		{
+			name:  "semicolon_in_dash_comment",
+			input: "SELECT 1 -- a;b\n;SELECT 2",
+			want: []Segment{
+				{Text: "SELECT 1 -- a;b\n", ByteStart: 0, ByteEnd: 16},
+				{Text: "SELECT 2", ByteStart: 17, ByteEnd: 25},
+			},
+		},
+		{
+			name:  "semicolon_in_block_comment",
+			input: "SELECT 1 /* a;b */;SELECT 2",
+			want: []Segment{
+				{Text: "SELECT 1 /* a;b */", ByteStart: 0, ByteEnd: 18},
+				{Text: "SELECT 2", ByteStart: 19, ByteEnd: 27},
+			},
+		},
+		{
+			name:  "semicolon_in_pound_comment",
+			input: "SELECT 1 # a;b\n;SELECT 2",
+			want: []Segment{
+				{Text: "SELECT 1 # a;b\n", ByteStart: 0, ByteEnd: 15},
+				{Text: "SELECT 2", ByteStart: 16, ByteEnd: 24},
+			},
+		},
+	}
+	t.Run("Split", func(t *testing.T) { runSplitCases(t, Split, cases) })
+	t.Run("SplitFlat", func(t *testing.T) { runSplitCases(t, SplitFlat, cases) })
+}
+
+// Block-aware Split keeps procedural BEGIN/END (and IF/CASE/LOOP/WHILE/REPEAT/
+// FOR) blocks whole; SplitFlat (BigQuery lexer-split) does not.
+func TestSplit_BeginEndBlock(t *testing.T) {
+	// A stored-procedure body with internal ';' separators.
+	const proc = "CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 2; END"
+
+	t.Run("Split_keeps_block_whole", func(t *testing.T) {
+		got := Split(proc)
+		if len(got) != 1 {
+			t.Fatalf("Split kept %d segments, want 1 (block whole): %+v", len(got), got)
+		}
+		if got[0].Text != proc {
+			t.Errorf("Split segment = %q, want whole proc", got[0].Text)
+		}
+	})
+
+	t.Run("Split_block_then_next_statement", func(t *testing.T) {
+		input := proc + "; SELECT 99"
+		got := Split(input)
+		if len(got) != 2 {
+			t.Fatalf("Split kept %d segments, want 2: %+v", len(got), got)
+		}
+		if got[0].Text != proc {
+			t.Errorf("segment[0] = %q, want whole proc", got[0].Text)
+		}
+		if strings.TrimSpace(got[1].Text) != "SELECT 99" {
+			t.Errorf("segment[1] = %q, want ' SELECT 99'", got[1].Text)
+		}
+	})
+
+	t.Run("SplitFlat_splits_inside_block", func(t *testing.T) {
+		// BigQuery lexer-split splits on every ';', including those inside the
+		// procedure body.
+		got := SplitFlat(proc)
+		if len(got) != 3 {
+			t.Fatalf("SplitFlat kept %d segments, want 3 (splits on inner ';'): %+v", len(got), got)
+		}
+	})
+
+	t.Run("nested_blocks", func(t *testing.T) {
+		// IF nested inside BEGIN; depth must balance back to 0 only at the
+		// outer END.
+		input := "CREATE PROCEDURE p() BEGIN IF x THEN SELECT 1; END IF; SELECT 2; END; SELECT 3"
+		got := Split(input)
+		if len(got) != 2 {
+			t.Fatalf("Split kept %d segments, want 2: %+v", len(got), got)
+		}
+		if !strings.Contains(got[0].Text, "END IF") || !strings.HasSuffix(strings.TrimSpace(got[0].Text), "END") {
+			t.Errorf("segment[0] = %q, want whole nested-block proc", got[0].Text)
+		}
+		if strings.TrimSpace(got[1].Text) != "SELECT 3" {
+			t.Errorf("segment[1] = %q, want ' SELECT 3'", got[1].Text)
+		}
+	})
+}
+
+// Port of the legacy spanner split_begin_end_test.go: a CASE *expression* (no
+// internal ';') must split identically under both variants because the
+// surrounding query's terminating ';' is the only delimiter.
+func TestSplit_CaseExpressionNoInternalSemicolon(t *testing.T) {
+	statement := "SELECT\n  CASE\n    WHEN status = 'active' THEN 1\n    WHEN status = 'inactive' THEN 0\n  END\nFROM users;\nSELECT * FROM orders;"
+
+	for _, variant := range []struct {
+		name  string
+		split func(string) []Segment
+	}{
+		{"Split", Split},
+		{"SplitFlat", SplitFlat},
+	} {
+		t.Run(variant.name, func(t *testing.T) {
+			list := variant.split(statement)
+			if len(list) != 2 {
+				t.Fatalf("%s produced %d segments, want 2: %+v", variant.name, len(list), list)
+			}
+			if !strings.Contains(list[0].Text, "CASE") || !strings.Contains(list[0].Text, "END") {
+				t.Errorf("segment[0] = %q, want to contain CASE..END", list[0].Text)
+			}
+			if !strings.Contains(list[1].Text, "SELECT * FROM orders") {
+				t.Errorf("segment[1] = %q, want 'SELECT * FROM orders'", list[1].Text)
+			}
+		})
+	}
+}
+
+// A top-level BEGIN that starts a transaction (BEGIN; / BEGIN TRANSACTION) must
+// NOT be treated as a block opener — otherwise the splitter would swallow the
+// rest of the script.
+func TestSplit_BeginTransactionIsNotBlock(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"begin_semicolon", "BEGIN; SELECT 1; COMMIT", 3},
+		{"begin_transaction", "BEGIN TRANSACTION; SELECT 1; COMMIT", 3},
+		// begin_statement: begin_transaction_keywords transaction_mode_list?,
+		// where a transaction_mode begins with READ or ISOLATION and the optional
+		// TRANSACTION keyword may be omitted. So `BEGIN READ ONLY` / `BEGIN
+		// ISOLATION LEVEL ...` are flat transaction starts, NOT procedural block
+		// openers (oracle-confirmed: Spanner parses each as BeginStatement). If
+		// the splitter misread these as block openers it would swallow the rest
+		// of the script into one segment.
+		{"begin_read_only", "BEGIN READ ONLY; SELECT 1; COMMIT", 3},
+		{"begin_read_write", "BEGIN READ WRITE; SELECT 1; COMMIT", 3},
+		{"begin_isolation_level", "BEGIN ISOLATION LEVEL SERIALIZABLE; SELECT 1; COMMIT", 3},
+		{"begin_transaction_read_only", "BEGIN TRANSACTION READ ONLY; SELECT 1; COMMIT", 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Split(c.input); len(got) != c.want {
+				t.Errorf("Split(%q) = %d segments, want %d: %+v", c.input, len(got), c.want, got)
+			}
+		})
+	}
+}
+
+// A typed block closer (END IF / END WHILE / …) at the TOP level — i.e. closing
+// the outermost block back to depth 0 — must be recognized as the closer's
+// suffix, NOT mistaken for a new top-level block opener. Otherwise the trailing
+// statement-terminating ';' would be swallowed into the block's segment. (These
+// bare top-level procedural forms are not themselves valid GoogleSQL, but the
+// splitter is best-effort and infallible, so its boundary handling must stay
+// consistent regardless of nesting depth.)
+func TestSplit_TopLevelTypedCloserDoesNotReopen(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"if", "IF x THEN SELECT 1; END IF; SELECT 2"},
+		{"while", "WHILE x DO SELECT 1; END WHILE; SELECT 2"},
+		{"loop", "LOOP SELECT 1; END LOOP; SELECT 2"},
+		{"repeat", "REPEAT SELECT 1; UNTIL x END REPEAT; SELECT 2"},
+		{"for", "FOR r IN (SELECT 1) DO SELECT r; END FOR; SELECT 2"},
+		{"case", "CASE WHEN x THEN SELECT 1; END CASE; SELECT 2"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Split(c.input)
+			if len(got) != 2 {
+				t.Fatalf("Split(%q) = %d segments, want 2 (typed closer reopened a block): %+v", c.input, len(got), got)
+			}
+			if strings.TrimSpace(got[1].Text) != "SELECT 2" {
+				t.Errorf("segment[1] = %q, want ' SELECT 2'", got[1].Text)
+			}
+		})
+	}
+}
+
+// Every block kind's typed closer (END IF / END WHILE / END LOOP / END REPEAT /
+// END FOR / bare END) must be recognized so the closer's trailing keyword is not
+// miscounted as a NEW block opener (which would desync depth and swallow the
+// statement-terminating ';' after the procedure body). Each procedure has an
+// internal ';' that must stay inside the single segment.
+func TestSplit_TypedClosersBalanceDepth(t *testing.T) {
+	cases := []struct {
+		name string
+		body string // the control block inside CREATE PROCEDURE p() <body>
+	}{
+		{"if_end_if", "BEGIN IF x THEN SELECT 1; END IF; END"},
+		{"while_end_while", "BEGIN WHILE x DO SELECT 1; END WHILE; END"},
+		{"loop_end_loop", "BEGIN LOOP SELECT 1; LEAVE; END LOOP; END"},
+		{"repeat_end_repeat", "BEGIN REPEAT SELECT 1; UNTIL x END REPEAT; END"},
+		{"for_end_for", "BEGIN FOR r IN (SELECT 1) DO SELECT r; END FOR; END"},
+		{"nested_if_in_while", "BEGIN WHILE x DO IF y THEN SELECT 1; END IF; END WHILE; END"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// The whole proc is one statement; a trailing ';' then a SELECT is the
+			// second. If a typed closer were miscounted, the depth would never
+			// return to 0 and the trailing ';' + SELECT would be swallowed.
+			input := "CREATE PROCEDURE p() " + c.body + "; SELECT 99"
+			got := Split(input)
+			if len(got) != 2 {
+				t.Fatalf("Split(%q) = %d segments, want 2: %+v", input, len(got), got)
+			}
+			if strings.TrimSpace(got[1].Text) != "SELECT 99" {
+				t.Errorf("segment[1] = %q, want ' SELECT 99' (typed closer desynced depth)", got[1].Text)
+			}
+		})
+	}
+}
+
+// On a transaction-control script (BEGIN [TRANSACTION] is flat, not a block),
+// Split and SplitFlat must agree segment-for-segment: there is no procedural
+// block to keep whole, so the block-aware path degenerates to the flat path.
+// Oracle-confirmed: the Spanner emulator parses `BEGIN`, `SELECT 1`, and
+// `COMMIT` as three independent statements.
+func TestSplit_TCLScriptMatchesFlat(t *testing.T) {
+	inputs := []string{
+		"BEGIN; SELECT 1; COMMIT",
+		"BEGIN TRANSACTION; UPDATE t SET x=1; COMMIT;",
+		"START TRANSACTION; INSERT INTO t VALUES (1); ROLLBACK",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			block := Split(in)
+			flat := SplitFlat(in)
+			if !reflect.DeepEqual(block, flat) {
+				t.Errorf("Split and SplitFlat disagree on a TCL script\n input: %q\n Split:     %+v\n SplitFlat: %+v", in, block, flat)
+			}
+		})
+	}
+}
+
+// Round-trip: re-joining segment texts with the original delimiters must
+// reconstruct the input (the offsets are correct and lossless).
+func TestSplit_OffsetsAreLossless(t *testing.T) {
+	inputs := []string{
+		"SELECT 1; SELECT 2; SELECT 3",
+		"  SELECT 1 ;\n SELECT 2 ;",
+		"SELECT ';' ; SELECT `a;b`",
+		"CREATE PROCEDURE p() BEGIN SELECT 1; END; SELECT 2",
+	}
+	for _, in := range inputs {
+		for _, variant := range []struct {
+			name  string
+			split func(string) []Segment
+		}{{"Split", Split}, {"SplitFlat", SplitFlat}} {
+			t.Run(variant.name+"/"+in, func(t *testing.T) {
+				for _, seg := range variant.split(in) {
+					// Each segment's Text must equal the input slice it claims.
+					if seg.Text != in[seg.ByteStart:seg.ByteEnd] {
+						t.Errorf("segment Text %q != input[%d:%d] %q",
+							seg.Text, seg.ByteStart, seg.ByteEnd, in[seg.ByteStart:seg.ByteEnd])
+					}
+					// ByteEnd must point at a ';' or len(input) (the delimiter
+					// is never part of Text).
+					if seg.ByteEnd < len(in) && in[seg.ByteEnd] != ';' {
+						t.Errorf("segment ByteEnd %d points at %q, want ';' or EOF", seg.ByteEnd, in[seg.ByteEnd])
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestSegment_Empty(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"", true},
+		{"   ", true},
+		{"-- only a comment\n", true},
+		{"/* block */", true},
+		{"# pound\n", true},
+		{"SELECT 1", false},
+		{"  x  ", false},
+	}
+	for _, c := range cases {
+		if got := (Segment{Text: c.text}).Empty(); got != c.want {
+			t.Errorf("Segment{%q}.Empty() = %v, want %v", c.text, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Node: `googlesql/parser-foundation`

The GoogleSQL **parser-foundation** unit of the omni `googlesql` engine migration (one parser serves bytebase **BigQuery + Spanner**; the grammar is a hand-port of Google's open-source ZetaSQL). Ships the parse driver + statement dispatch, **both** statement-splitter variants, parse-error collection, the `diagnostics` package (Diagnose), identifier normalization, and the byte-offset→line/column table.

Depends on (merged): `googlesql/ast-core` (#176), `googlesql/lexer` (#180). Analysis foundation: #174.

### What's here (all within the node's writes-globs)

| File | Role |
|---|---|
| `googlesql/parser/parser.go` | `Parser` struct + token-cursor primitives; `Parse`/`ParseBestEffort`; per-segment `parseSingle`; statement-level hint skip (`@{…}` / `@N` / `@[N@]{…}`); `parseStmt` dispatch switch |
| `googlesql/parser/split.go` | `SplitFlat` (BigQuery pure lexer/`;`-split) + `Split` (Spanner block-aware) over `Segment{Text,ByteStart,ByteEnd}` |
| `googlesql/parser/errors.go` | `ParseError{Loc,Msg}` (implements `error`) |
| `googlesql/parser/identifiers.go` | `NormalizeGoogleSQLIdentifier` (byte-for-byte port of legacy `unquoteIdentifierByText`) + `isIdentifierStart`/`isAnyKeywordIdentifier` |
| `googlesql/parser/linetable.go` | O(log n) byte-offset→(line,col); LF/CRLF/bare-CR aware |
| `googlesql/diagnostics/diagnostics.go` | `Analyze()` → LSP-style `Diagnostic`s; mirrors `snowflake/diagnostics` |

**Statement bodies are intentionally stubbed.** `parseStmt` dispatches every leading keyword to a `"not yet supported"` stub; the `default` branch emits `"unknown or unsupported statement"`. Reaching a stub is correct foundation behavior; reaching the unknown branch for a *valid* statement would be a bug. Later DAG nodes (types, expressions, parser-select/ddl/dml, …) replace the stub bodies. Reference pattern: `trino/parser` foundation (#179) + `snowflake/diagnostics`.

### Correctness (PROVE)

- **Dispatch completeness — verified against `GoogleSQLParser.g4` §`sql_statement_body`.** All **53** SQL statement leading keywords + the **12** procedural script-statement forms are reachable in `parseStmt` (incl. BEGIN/START/COMMIT/ROLLBACK/SET/RUN/ABORT, EXPLAIN/DESCRIBE/DESC/SHOW/ANALYZE/ASSERT/CALL/EXECUTE/IMPORT/MODULE/EXPORT/LOAD/CLONE, GRANT/REVOKE, GRAPH, and the IF/CASE/WHILE/LOOP/REPEAT/FOR/DECLARE/BREAK/LEAVE/CONTINUE/ITERATE/RETURN/RAISE script forms). `TestParse_DispatchKeywordsRecognized` asserts each routes to a stub, never the unknown branch.
- **Live Spanner-emulator oracle** (`spanner-emulator@sha256:caf1bd24`, gRPC :9010) confirmed: valid heads (SELECT/INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/RENAME/GRANT/REVOKE/SET/CALL/ANALYZE/GRAPH/BEGIN/COMMIT/ROLLBACK) ACCEPT; garbage leading tokens (`FOOBAR`, `12345`) REJECT (→ unknown branch); and critically **`BEGIN SELECT 1; SELECT 2; END` parses as ONE statement**, validating that the block-aware `Split` keeps procedural blocks whole.
- **Splitter** — `Split` reproduces the legacy Spanner parse-tree-split boundary outcome via a token-level block-depth state machine (no full parse); ported the legacy `split_begin_end_test.go` CASE-expression case; offsets lossless (`TestSplit_OffsetsAreLossless`).
- Adversarial no-panic/no-hang sweep over malformed hints, unbalanced braces, deep nesting, null bytes, unterminated literals.
- `go test ./googlesql/parser/... ./googlesql/diagnostics/...` — **green** (race + vet + gofmt clean). 51 test funcs in the node's files.

### Review (two-reviewer cross-family gate)

- **Codex lens** (round 1) found **5 blockers** — all fixed, each with a permanent regression test:
  1. top-level typed closer (`END IF`/…) reopened a block → swallowed the trailing `;` (`prevWasEnd` now kept across the depth-1→0 transition; the `stateTop` arm consumes the closer suffix).
  2. `BEGIN READ ONLY` / `BEGIN ISOLATION LEVEL …` misclassified as block openers → `isTCLBeginFollower` now accepts `READ`/`ISOLATION` (oracle-confirmed flat).
  3. unterminated block comment dropped (Split filters the empty segment) → lex errors now collected from **one full-input pass** (`collectLexErrors`).
  4. lex error after an early recovery-stop dropped → same full-input pass.
  5. unterminated `@{…}` hint silently consumed to EOF → `skipStatementLevelHint`/`skipBalancedBraces` now return an `"unterminated statement hint"` ParseError.
- **Claude lens** — line-by-line + removed-behavior + cross-file passes: no blockers. Re-verified the fixes introduce no regression (back-to-back `BEGIN…END; BEGIN…END` blocks split correctly; no lex-error double-counting; nested-brace hints skip cleanly).

### Divergences (recorded in the migration divergence ledger)

| Case | Disposition |
|---|---|
| Dispatch recognizes FROM-first query head + bare procedural keywords at top level → stub (Spanner syntax-rejects; legacy grammar recognizes them as heads) | flagged — cosmetic for the foundation (both yield a diagnostic); precise rejection deferred to query/scripting nodes |
| `Segment` excludes the trailing `;` (legacy `base.Statement` includes it) | flagged — reconciled by the downstream `bytebase-switch` node; offsets lossless |
| Block-aware `Split` keeps `BEGIN…END` whole | confirmed (oracle) |
| `BEGIN` transaction-mode forms split flat | confirmed (oracle + grammar) |
| Diagnose surfaces lex errors via a single full-input pass | confirmed (review fix) |

Note: `trino/parser` foundation (#179) shares the same latent lex-error-surfacing gaps (per-segment promotion; `Empty()` dropping comment-error segments) — candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)