### PR TITLE
fix(doris/parser): parse window function OVER clause

### DIFF
--- a/doris/ast/exprnodes.go
+++ b/doris/ast/exprnodes.go
@@ -233,12 +233,44 @@ type FuncCallExpr struct {
 	Star     bool   // COUNT(*)
 	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
 	Separator string // optional SEPARATOR value for GROUP_CONCAT
+	Over     *WindowSpec // optional OVER (...) window specification
 	Loc      Loc
 }
 
 func (n *FuncCallExpr) Tag() NodeTag { return T_FuncCallExpr }
 
 var _ Node = (*FuncCallExpr)(nil)
+
+// WindowSpec is the OVER (...) specification attached to a window function
+// call: OVER ( [PARTITION BY ...] [ORDER BY ...] [frame] ), or OVER name for a
+// named window reference. It is a plain sub-node of FuncCallExpr (not a
+// standalone Node); the walker descends into its expression children via the
+// FuncCallExpr case.
+type WindowSpec struct {
+	Name        string         // named window reference (empty for the inline form)
+	PartitionBy []Node         // PARTITION BY expressions
+	OrderBy     []*OrderByItem // ORDER BY items
+	Frame       *WindowFrame   // optional frame clause (ROWS/RANGE ...)
+	Loc         Loc
+}
+
+// WindowFrame is a window frame clause inside an OVER spec:
+//
+//	(ROWS | RANGE) frame_bound
+//	(ROWS | RANGE) BETWEEN frame_bound AND frame_bound
+//
+// A bound is one of: UNBOUNDED PRECEDING, UNBOUNDED FOLLOWING, CURRENT ROW,
+// <expr> PRECEDING, <expr> FOLLOWING. StartExpr/EndExpr are non-nil only for
+// the "<expr> PRECEDING/FOLLOWING" forms; EndType is empty for a single-bound
+// frame (no BETWEEN).
+type WindowFrame struct {
+	Unit      string // "ROWS" or "RANGE"
+	StartType string // bound kind for the start/only bound
+	StartExpr Node
+	EndType   string // bound kind for the end bound; empty if no BETWEEN
+	EndExpr   Node
+	Loc       Loc
+}
 
 // CastExpr represents CAST(expr AS type) or TRY_CAST(expr AS type).
 type CastExpr struct {

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -86,6 +86,20 @@ func walkChildren(v Visitor, node Node) {
 		for _, item := range n.OrderBy {
 			Walk(v, item)
 		}
+		if n.Over != nil {
+			walkNodes(v, n.Over.PartitionBy)
+			for _, item := range n.Over.OrderBy {
+				Walk(v, item)
+			}
+			if n.Over.Frame != nil {
+				if n.Over.Frame.StartExpr != nil {
+					Walk(v, n.Over.Frame.StartExpr)
+				}
+				if n.Over.Frame.EndExpr != nil {
+					Walk(v, n.Over.Frame.EndExpr)
+				}
+			}
+		}
 	case *CastExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.TypeName)

--- a/doris/parser/expr.go
+++ b/doris/parser/expr.go
@@ -479,7 +479,169 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 	}
 	fc.Loc.End = closeTok.Loc.End
 
+	// Optional OVER (...) window specification — turns this call into a window
+	// function. Without consuming OVER here it is left dangling, which breaks
+	// parsing wherever a specific following token is expected (e.g. the ')'
+	// closing a CTE body: WITH x AS (SELECT f() OVER (...) ... ) ...).
+	if p.cur.Kind == kwOVER {
+		over, err := p.parseWindowSpec()
+		if err != nil {
+			return nil, err
+		}
+		fc.Over = over
+		fc.Loc.End = over.Loc.End
+	}
+
 	return fc, nil
+}
+
+// parseWindowSpec parses an OVER clause window specification. The OVER keyword
+// is the current token (not yet consumed):
+//
+//	OVER ( [PARTITION BY expr, ...] [ORDER BY item, ...] [frame] )
+//	OVER window_name
+func (p *Parser) parseWindowSpec() (*ast.WindowSpec, error) {
+	overTok := p.advance() // consume OVER
+	spec := &ast.WindowSpec{Loc: ast.Loc{Start: overTok.Loc.Start}}
+
+	// OVER window_name — a named-window reference (no parentheses).
+	if p.cur.Kind != int('(') {
+		name, nameLoc, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		spec.Name = name
+		spec.Loc.End = nameLoc.End
+		return spec, nil
+	}
+
+	p.advance() // consume '('
+
+	// Optional PARTITION BY.
+	if p.cur.Kind == kwPARTITION {
+		p.advance()
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		exprs, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		spec.PartitionBy = exprs
+	}
+
+	// Optional ORDER BY.
+	if p.cur.Kind == kwORDER {
+		p.advance()
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		items, err := p.parseOrderByList()
+		if err != nil {
+			return nil, err
+		}
+		spec.OrderBy = items
+	}
+
+	// Optional frame clause.
+	if p.cur.Kind == kwROWS || p.cur.Kind == kwRANGE {
+		frame, err := p.parseWindowFrame()
+		if err != nil {
+			return nil, err
+		}
+		spec.Frame = frame
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	spec.Loc.End = closeTok.Loc.End
+	return spec, nil
+}
+
+// parseWindowFrame parses a window frame clause. The ROWS/RANGE keyword is the
+// current token (not yet consumed):
+//
+//	(ROWS | RANGE) frame_bound
+//	(ROWS | RANGE) BETWEEN frame_bound AND frame_bound
+func (p *Parser) parseWindowFrame() (*ast.WindowFrame, error) {
+	unitTok := p.advance() // consume ROWS or RANGE
+	frame := &ast.WindowFrame{
+		Unit: strings.ToUpper(unitTok.Str),
+		Loc:  ast.Loc{Start: unitTok.Loc.Start},
+	}
+
+	if p.cur.Kind == kwBETWEEN {
+		p.advance()
+		startType, startExpr, err := p.parseWindowFrameBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.StartType, frame.StartExpr = startType, startExpr
+		if _, err := p.expect(kwAND); err != nil {
+			return nil, err
+		}
+		endType, endExpr, err := p.parseWindowFrameBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.EndType, frame.EndExpr = endType, endExpr
+	} else {
+		startType, startExpr, err := p.parseWindowFrameBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.StartType, frame.StartExpr = startType, startExpr
+	}
+
+	frame.Loc.End = p.prev.Loc.End
+	return frame, nil
+}
+
+// parseWindowFrameBound parses one window frame bound:
+//
+//	UNBOUNDED PRECEDING | UNBOUNDED FOLLOWING | CURRENT ROW
+//	<expr> PRECEDING | <expr> FOLLOWING
+//
+// It returns the bound kind and, for the "<expr> PRECEDING/FOLLOWING" forms,
+// the offset expression (nil otherwise).
+func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
+	switch p.cur.Kind {
+	case kwUNBOUNDED:
+		p.advance()
+		switch p.cur.Kind {
+		case kwPRECEDING:
+			p.advance()
+			return "UNBOUNDED PRECEDING", nil, nil
+		case kwFOLLOWING:
+			p.advance()
+			return "UNBOUNDED FOLLOWING", nil, nil
+		default:
+			return "", nil, &ParseError{Loc: p.cur.Loc, Msg: "expected PRECEDING or FOLLOWING after UNBOUNDED"}
+		}
+	case kwCURRENT:
+		p.advance()
+		if _, err := p.expect(kwROW); err != nil {
+			return "", nil, err
+		}
+		return "CURRENT ROW", nil, nil
+	default:
+		expr, err := p.parseExpr()
+		if err != nil {
+			return "", nil, err
+		}
+		switch p.cur.Kind {
+		case kwPRECEDING:
+			p.advance()
+			return "PRECEDING", expr, nil
+		case kwFOLLOWING:
+			p.advance()
+			return "FOLLOWING", expr, nil
+		default:
+			return "", nil, &ParseError{Loc: p.cur.Loc, Msg: "expected PRECEDING or FOLLOWING in window frame bound"}
+		}
+	}
 }
 
 // parseExprList parses a comma-separated list of expressions.

--- a/doris/parser/window_test.go
+++ b/doris/parser/window_test.go
@@ -1,0 +1,91 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/doris/ast"
+)
+
+func parseOneSelect(t *testing.T, input string) *ast.SelectStmt {
+	t.Helper()
+	file, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("Parse(%q) errors: %v", input, errs)
+	}
+	if len(file.Stmts) == 0 {
+		t.Fatalf("Parse(%q): no statements", input)
+	}
+	sel, ok := file.Stmts[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): got %T, want *ast.SelectStmt", input, file.Stmts[0])
+	}
+	return sel
+}
+
+// A window function in a top-level SELECT must be fully consumed, so the
+// trailing FROM clause is reachable and the OVER spec is captured.
+func TestWindowFunctionTopLevel(t *testing.T) {
+	sel := parseOneSelect(t, "SELECT region, ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn FROM sales")
+
+	if len(sel.From) != 1 {
+		t.Fatalf("From = %d items, want 1 (FROM must parse after the window function)", len(sel.From))
+	}
+	if len(sel.Items) != 2 {
+		t.Fatalf("Items = %d, want 2", len(sel.Items))
+	}
+	fc, ok := sel.Items[1].Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("Items[1].Expr = %T, want *ast.FuncCallExpr", sel.Items[1].Expr)
+	}
+	if fc.Over == nil {
+		t.Fatal("FuncCallExpr.Over = nil, want non-nil window spec")
+	}
+	if len(fc.Over.PartitionBy) != 1 {
+		t.Errorf("Over.PartitionBy = %d, want 1", len(fc.Over.PartitionBy))
+	}
+	if len(fc.Over.OrderBy) != 1 {
+		t.Errorf("Over.OrderBy = %d, want 1", len(fc.Over.OrderBy))
+	}
+	if sel.Items[1].Alias != "rn" {
+		t.Errorf("Items[1].Alias = %q, want %q", sel.Items[1].Alias, "rn")
+	}
+}
+
+// Regression for BYT-9636: a window function inside a CTE body used to fail
+// with "syntax error at or near OVER" because OVER was never consumed, so the
+// CTE's closing ')' collided with it.
+func TestWindowFunctionInCTE(t *testing.T) {
+	input := "WITH ranked AS (SELECT region, ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn FROM sales) SELECT region FROM ranked WHERE rn = 1"
+	file, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("Parse(%q) errors: %v", input, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Stmts = %d, want 1", len(file.Stmts))
+	}
+}
+
+func TestWindowFunctionFrame(t *testing.T) {
+	sel := parseOneSelect(t, "SELECT SUM(amount) OVER (PARTITION BY region ORDER BY sale_date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM sales")
+	fc, ok := sel.Items[0].Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.FuncCallExpr", sel.Items[0].Expr)
+	}
+	if fc.Over == nil || fc.Over.Frame == nil {
+		t.Fatal("expected non-nil Over.Frame")
+	}
+	if fc.Over.Frame.Unit != "ROWS" {
+		t.Errorf("Frame.Unit = %q, want ROWS", fc.Over.Frame.Unit)
+	}
+}
+
+func TestWindowFunctionEmptyOver(t *testing.T) {
+	sel := parseOneSelect(t, "SELECT RANK() OVER () FROM sales")
+	fc, ok := sel.Items[0].Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.FuncCallExpr", sel.Items[0].Expr)
+	}
+	if fc.Over == nil {
+		t.Fatal("Over = nil, want non-nil for empty OVER ()")
+	}
+}


### PR DESCRIPTION
## Summary

The omni Doris parser never consumed a window function's `OVER (...)` clause. In a top-level SELECT the dangling `OVER` was silently tolerated (but the trailing `FROM` clause was then dropped); **inside a CTE body it collided with the `)` that closes the CTE**, producing `syntax error at or near OVER` and blocking otherwise-valid queries — e.g. in the bytebase SQL editor against a live Doris instance:

```sql
WITH ranked AS (
  SELECT region, ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn
  FROM sales)
SELECT region FROM ranked WHERE rn = 1;
```

Doris itself runs this fine; omni rejected it. Affects Doris **and** StarRocks (shared parser).

## Fix

`parseFuncCall` now parses an optional `OVER` specification into a new `FuncCallExpr.Over` (`*ast.WindowSpec`):

- `PARTITION BY` expressions
- `ORDER BY` items
- a `ROWS` / `RANGE` frame (incl. `BETWEEN … AND …`, `UNBOUNDED PRECEDING/FOLLOWING`, `CURRENT ROW`, `<expr> PRECEDING/FOLLOWING`)
- the named-window `OVER name` form

The AST walker descends into the window's partition/order/frame expressions, so query-span / lineage sees those columns.

## Tests

`doris/parser/window_test.go` adds coverage:

- window function **inside a CTE** (the regression) now parses
- top-level window: `Over` is captured **and** the trailing `FROM` is reachable
- frame clause (`ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`)
- empty `OVER ()`

`go test ./doris/...` is green. Verified against the exact entry bytebase calls (`parser.Parse`, via `parseDorisStatements`) — the previously-failing query now parses.

Fixes BYT-9636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
