### PR TITLE
feat(trino/deparse): schema definition SDL (v2 node trino/deparse)

### DIFF
--- a/trino/deparse/deparse.go
+++ b/trino/deparse/deparse.go
@@ -1,0 +1,74 @@
+package deparse
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetDatabaseDefinition renders the schema metadata as the CREATE TABLE SDL
+// that recreates it. It is the omni-side implementation of the bytebase
+// schema.GetDatabaseDefinition contract for the Trino engine.
+//
+// The output is one CREATE TABLE statement per table, in schema-then-table
+// snapshot order, each separated by a blank line and terminated with the same
+// trailing "\n\n" the bytebase source emits (so the generated dump is
+// byte-identical to the legacy implementation). Names are written verbatim,
+// always double-quoted; column types are emitted as-is. Non-nullable columns
+// get a trailing " NOT NULL".
+//
+// A nil metadata, or a metadata with no tables, yields the empty string. The
+// (string, error) signature mirrors the bytebase schema.GetDatabaseDefinition
+// contract the bytebase-switch node adapts; the error is always nil today, but
+// callers must still check it.
+func GetDatabaseDefinition(metadata *DatabaseSchemaMetadata) (string, error) {
+	if metadata == nil {
+		return "", nil
+	}
+
+	var buf strings.Builder
+	for _, schema := range metadata.Schemas {
+		if schema == nil {
+			continue
+		}
+		for _, table := range schema.Tables {
+			if table == nil {
+				continue
+			}
+			writeCreateTable(&buf, schema.Name, table)
+			buf.WriteString("\n\n")
+		}
+	}
+
+	return buf.String(), nil
+}
+
+// writeCreateTable appends a single CREATE TABLE statement for table (qualified
+// by schemaName) to buf. It does not append the inter-statement blank line; the
+// caller does. The emitted form is:
+//
+//	CREATE TABLE IF NOT EXISTS "schema"."table" (
+//	    "col1" type1 NOT NULL,
+//	    "col2" type2
+//	);
+//
+// matching the legacy bytebase plugin/schema/trino output exactly, including the
+// four-space column indent and the leading newline before the closing paren
+// (which, for a table with no columns, leaves a blank line inside the parens).
+func writeCreateTable(buf *strings.Builder, schemaName string, table *TableMetadata) {
+	fmt.Fprintf(buf, "CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (\n", schemaName, table.Name)
+
+	columnDefs := make([]string, 0, len(table.Columns))
+	for _, column := range table.Columns {
+		if column == nil {
+			continue
+		}
+		nullable := ""
+		if !column.Nullable {
+			nullable = " NOT NULL"
+		}
+		columnDefs = append(columnDefs, fmt.Sprintf("    \"%s\" %s%s", column.Name, column.Type, nullable))
+	}
+
+	buf.WriteString(strings.Join(columnDefs, ",\n"))
+	buf.WriteString("\n);")
+}

--- a/trino/deparse/deparse_test.go
+++ b/trino/deparse/deparse_test.go
@@ -1,0 +1,215 @@
+package deparse
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetDatabaseDefinition is the differential-vs-legacy gate: the omni output
+// must be byte-identical to the legacy bytebase plugin/schema/trino
+// GetDatabaseDefinition output. The first three cases are lifted verbatim
+// (inputs and expected strings) from
+// bytebase/backend/plugin/schema/trino/get_database_definition_test.go so any
+// drift from the legacy format fails here. The remaining cases extend coverage
+// to inputs the legacy suite never exercised (multiple tables, multiple
+// schemas, ordering, and nil/empty handling).
+func TestGetDatabaseDefinition(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *DatabaseSchemaMetadata
+		expected string
+	}{
+		{
+			// Verbatim from the legacy suite: a non-nullable bigint and a
+			// nullable varchar, in declaration order.
+			name: "simple table (legacy golden)",
+			metadata: oneTable("testcatalog", "testschema", &TableMetadata{
+				Name: "testtable",
+				Columns: []*ColumnMetadata{
+					{Name: "id", Type: "bigint", Nullable: false},
+					{Name: "name", Type: "varchar", Nullable: true},
+				},
+			}),
+			expected: `CREATE TABLE IF NOT EXISTS "testschema"."testtable" (
+    "id" bigint NOT NULL,
+    "name" varchar
+);
+
+`,
+		},
+		{
+			// Verbatim from the legacy suite: a table with no columns still
+			// emits the parens with the blank line the legacy format leaves.
+			name: "empty columns (legacy golden)",
+			metadata: oneTable("testcatalog", "testschema", &TableMetadata{
+				Name:    "empty_table",
+				Columns: []*ColumnMetadata{},
+			}),
+			expected: `CREATE TABLE IF NOT EXISTS "testschema"."empty_table" (
+
+);
+
+`,
+		},
+		{
+			// Verbatim from the legacy suite: special characters in identifiers
+			// are emitted as-is inside the double quotes (no escaping), exactly
+			// like the legacy source.
+			name: "special characters in identifiers (legacy golden)",
+			metadata: oneTable("test-catalog", "test_schema", &TableMetadata{
+				Name: "test.table",
+				Columns: []*ColumnMetadata{
+					{Name: "id-field", Type: "bigint", Nullable: false},
+				},
+			}),
+			expected: `CREATE TABLE IF NOT EXISTS "test_schema"."test.table" (
+    "id-field" bigint NOT NULL
+);
+
+`,
+		},
+		{
+			// Two tables in one schema render in snapshot order, each as its own
+			// statement separated by the trailing blank line.
+			name: "multiple tables preserve order",
+			metadata: &DatabaseSchemaMetadata{
+				Name: "cat",
+				Schemas: []*SchemaMetadata{
+					{
+						Name: "s",
+						Tables: []*TableMetadata{
+							{Name: "first", Columns: []*ColumnMetadata{{Name: "a", Type: "integer", Nullable: false}}},
+							{Name: "second", Columns: []*ColumnMetadata{{Name: "b", Type: "varchar", Nullable: true}}},
+						},
+					},
+				},
+			},
+			expected: `CREATE TABLE IF NOT EXISTS "s"."first" (
+    "a" integer NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "s"."second" (
+    "b" varchar
+);
+
+`,
+		},
+		{
+			// Tables from multiple schemas render schema-by-schema in snapshot
+			// order, qualified by their own schema name.
+			name: "multiple schemas",
+			metadata: &DatabaseSchemaMetadata{
+				Name: "cat",
+				Schemas: []*SchemaMetadata{
+					{Name: "s1", Tables: []*TableMetadata{{Name: "t1", Columns: []*ColumnMetadata{{Name: "c1", Type: "bigint", Nullable: false}}}}},
+					{Name: "s2", Tables: []*TableMetadata{{Name: "t2", Columns: []*ColumnMetadata{{Name: "c2", Type: "double", Nullable: true}}}}},
+				},
+			},
+			expected: `CREATE TABLE IF NOT EXISTS "s1"."t1" (
+    "c1" bigint NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "s2"."t2" (
+    "c2" double
+);
+
+`,
+		},
+		{
+			// A schema with no tables contributes nothing.
+			name:     "schema with no tables",
+			metadata: &DatabaseSchemaMetadata{Name: "cat", Schemas: []*SchemaMetadata{{Name: "empty"}}},
+			expected: "",
+		},
+		{
+			// No schemas at all yields the empty string.
+			name:     "no schemas",
+			metadata: &DatabaseSchemaMetadata{Name: "cat"},
+			expected: "",
+		},
+		{
+			// A nil metadata is handled gracefully (the legacy source would
+			// panic on nil; the omni version returns empty instead).
+			name:     "nil metadata",
+			metadata: nil,
+			expected: "",
+		},
+		{
+			// nil entries in the slices are skipped rather than panicking.
+			name: "nil schema, table, and column entries are skipped",
+			metadata: &DatabaseSchemaMetadata{
+				Name: "cat",
+				Schemas: []*SchemaMetadata{
+					nil,
+					{
+						Name: "s",
+						Tables: []*TableMetadata{
+							nil,
+							{Name: "t", Columns: []*ColumnMetadata{nil, {Name: "c", Type: "integer", Nullable: false}}},
+						},
+					},
+				},
+			},
+			expected: `CREATE TABLE IF NOT EXISTS "s"."t" (
+    "c" integer NOT NULL
+);
+
+`,
+		},
+	}
+
+	a := require.New(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			result, err := GetDatabaseDefinition(tt.metadata)
+			a.NoError(err)
+			a.Equal(tt.expected, result, tt.name)
+		})
+	}
+}
+
+// TestWriteCreateTable pins the single-statement renderer, mirroring the legacy
+// TestWriteCreateTable (same input, same expected — no trailing blank line, the
+// caller adds that).
+func TestWriteCreateTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   string
+		table    *TableMetadata
+		expected string
+	}{
+		{
+			name:   "simple table (legacy golden)",
+			schema: "schema",
+			table: &TableMetadata{
+				Name:    "table",
+				Columns: []*ColumnMetadata{{Name: "col1", Type: "integer", Nullable: false}},
+			},
+			expected: `CREATE TABLE IF NOT EXISTS "schema"."table" (
+    "col1" integer NOT NULL
+);`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			writeCreateTable(&buf, tt.schema, tt.table)
+			assert.Equal(t, tt.expected, buf.String())
+		})
+	}
+}
+
+// oneTable builds a DatabaseSchemaMetadata holding a single schema with a single
+// table, matching how the legacy test assembled its fixtures.
+func oneTable(catalog, schema string, table *TableMetadata) *DatabaseSchemaMetadata {
+	return &DatabaseSchemaMetadata{
+		Name: catalog,
+		Schemas: []*SchemaMetadata{
+			{Name: schema, Tables: []*TableMetadata{table}},
+		},
+	}
+}

--- a/trino/deparse/metadata.go
+++ b/trino/deparse/metadata.go
@@ -1,0 +1,72 @@
+// Package deparse renders Trino schema metadata back into SQL data-definition
+// language (SDL). Its entry point, GetDatabaseDefinition, is the omni-side
+// implementation of the bytebase schema.GetDatabaseDefinition contract for the
+// Trino engine: given a snapshot of a database's schemas/tables/columns it
+// produces the CREATE TABLE statements that recreate them.
+//
+// # Why a deparse package, not the catalog
+//
+// trino/catalog also models the catalog -> schema -> table -> column hierarchy,
+// but it is built for name resolution and completion: it folds identifiers to a
+// normalized form and returns names in sorted order. SDL generation must do the
+// opposite — it must preserve the metadata snapshot's original table/column
+// order and emit names verbatim (the bytebase source quotes column.Name and
+// table.Name exactly as given, never normalized). So deparse takes its own
+// ordered, verbatim metadata model rather than reading from the catalog.
+//
+// # The metadata model
+//
+// The types below mirror, field-for-field, the subset of bytebase's
+// storepb.DatabaseSchemaMetadata that the Trino schema dump consumes
+// (DatabaseSchemaMetadata.Schemas, SchemaMetadata.{Name,Tables},
+// TableMetadata.{Name,Columns}, ColumnMetadata.{Name,Type,Nullable}). Keeping
+// an omni-native copy lets the deparser live in the omni module without
+// importing bytebase's generated protobuf; the bytebase-switch node maps the
+// storepb structs onto these one-to-one when it wires GetDatabaseDefinition
+// into plugin/schema/trino.
+package deparse
+
+// DatabaseSchemaMetadata is a snapshot of one Trino database (catalog) used as
+// the input to GetDatabaseDefinition. Only the fields the Trino SDL dump reads
+// are modeled; the storepb message carries more (collation, owner, extensions,
+// …) that the Trino dump ignores.
+type DatabaseSchemaMetadata struct {
+	// Name is the catalog name. The Trino SDL dump does not emit it (CREATE
+	// TABLE names are schema.table), but it is kept to mirror the storepb shape
+	// and identify the snapshot.
+	Name string
+	// Schemas are the database's schemas, in snapshot order.
+	Schemas []*SchemaMetadata
+}
+
+// SchemaMetadata is one schema (the second level Trino exposes as the leading
+// part of a CREATE TABLE name).
+type SchemaMetadata struct {
+	// Name is the schema name, emitted verbatim (double-quoted) as the first
+	// qualifier of every CREATE TABLE.
+	Name string
+	// Tables are the schema's tables, in snapshot order; each becomes one
+	// CREATE TABLE statement.
+	Tables []*TableMetadata
+}
+
+// TableMetadata is one table; it renders to a single CREATE TABLE statement.
+type TableMetadata struct {
+	// Name is the table name, emitted verbatim (double-quoted).
+	Name string
+	// Columns are the table's columns, in ordinal order; the order is preserved
+	// in the emitted column list.
+	Columns []*ColumnMetadata
+}
+
+// ColumnMetadata is one column of a table.
+type ColumnMetadata struct {
+	// Name is the column name, emitted verbatim (double-quoted).
+	Name string
+	// Type is the Trino type rendered as text (e.g. "bigint", "varchar",
+	// "array(integer)"). It is emitted verbatim and not re-parsed.
+	Type string
+	// Nullable reports whether the column accepts NULL. A non-nullable column
+	// gets a trailing NOT NULL.
+	Nullable bool
+}

--- a/trino/deparse/oracle_test.go
+++ b/trino/deparse/oracle_test.go
@@ -1,0 +1,163 @@
+package deparse
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytebase/omni/trino/internal/trinooracle"
+)
+
+// connectOracle dials the live Trino oracle for the round-trip gate, mirroring
+// the skip discipline the parser nodes use: skipped (not failed) in -short mode
+// or when no Trino server is reachable, so the suite stays green offline while
+// exercising the real parser when a server is up. Start one with:
+//
+//	docker run -d --name trino-oracle -p 18080:8080 trinodb/trino:latest
+func connectOracle(t *testing.T) *trinooracle.Oracle {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := trinooracle.Connect("")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ver, err := o.Ping(ctx)
+	if err != nil {
+		t.Skipf("trino oracle not reachable (start a Trino server and set %s if needed): %v", trinooracle.EnvURL, err)
+	}
+	t.Logf("connected to Trino %s", ver)
+	return o
+}
+
+// TestGeneratedSDLParsesOnTrino is the deparse round-trip / structural gate
+// required by the correctness protocol for a metadata->SDL emitter: every
+// CREATE TABLE the deparser emits must be accepted by the real Trino 481 parser.
+// This proves the output is genuine, parseable Trino DDL rather than merely
+// byte-matching a (possibly buggy) legacy expectation.
+//
+// We assert acceptance, not successful execution: Trino accepts the syntax but
+// then fails semantically (e.g. SCHEMA_NOT_FOUND in the memory catalog), which
+// the oracle classifies as Accepted=true. We deliberately do not feed the
+// special-characters legacy case here — `test.table` parses as a three-part
+// name and `id-field` is not a legal column type — because that case validates
+// the *format*, not Trino-acceptability; its acceptance is covered by the
+// golden test, and Trino-shaped variants are checked below.
+func TestGeneratedSDLParsesOnTrino(t *testing.T) {
+	o := connectOracle(t)
+
+	tables := []*TableMetadata{
+		{
+			Name: "testtable",
+			Columns: []*ColumnMetadata{
+				{Name: "id", Type: "bigint", Nullable: false},
+				{Name: "name", Type: "varchar", Nullable: true},
+			},
+		},
+		{
+			// Empty-column table: Trino rejects "CREATE TABLE t ()" (a table
+			// needs at least one column or a column-less form is invalid), so
+			// this exercises the negative side of the round trip below, not here.
+			Name: "single_col",
+			Columns: []*ColumnMetadata{
+				{Name: "c", Type: "integer", Nullable: false},
+			},
+		},
+		{
+			// A spread of common Trino types, including parameterized and
+			// nested ones, to make sure the verbatim type text round-trips.
+			Name: "typed",
+			Columns: []*ColumnMetadata{
+				{Name: "a", Type: "varchar(10)", Nullable: false},
+				{Name: "b", Type: "decimal(10,2)", Nullable: true},
+				{Name: "c", Type: "array(integer)", Nullable: true},
+				{Name: "d", Type: "map(varchar, bigint)", Nullable: true},
+				{Name: "e", Type: "row(x integer, y varchar)", Nullable: true},
+				{Name: "f", Type: "timestamp(3) with time zone", Nullable: true},
+			},
+		},
+		{
+			// A quoted identifier whose normalized form is case-sensitive: the
+			// double quotes the deparser always adds are exactly what preserves
+			// "MixedCase" and a reserved word like "table" used as a column.
+			Name: "MixedCase",
+			Columns: []*ColumnMetadata{
+				{Name: "MixedCol", Type: "bigint", Nullable: false},
+				{Name: "table", Type: "varchar", Nullable: true},
+			},
+		},
+	}
+
+	for _, table := range tables {
+		t.Run(table.Name, func(t *testing.T) {
+			ddl, err := GetDatabaseDefinition(oneTable("memory", "default", table))
+			if err != nil {
+				t.Fatalf("GetDatabaseDefinition: %v", err)
+			}
+			for _, stmt := range splitStatements(ddl) {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				res, err := o.CheckSyntax(ctx, stmt)
+				cancel()
+				if err != nil {
+					t.Fatalf("oracle CheckSyntax(%q): %v", stmt, err)
+				}
+				if !res.Accepted {
+					t.Errorf("Trino rejected generated SDL as a syntax error:\n%s\nerrorName=%q code=%d msg=%s",
+						stmt, res.ErrorName, res.ErrorCode, res.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestEmptyColumnTableRejectedByTrino documents an honest limitation of the
+// legacy format that the round-trip surfaces: a table with no columns renders
+// to `CREATE TABLE ... ()`, which Trino's parser rejects as a SYNTAX_ERROR. The
+// deparser reproduces the legacy byte-output (proven by the golden test), but
+// that particular output is not executable Trino. We assert the rejection so
+// the limitation is recorded, not hidden; it is flagged in the divergence
+// ledger as an inherited-legacy issue, not a regression introduced here.
+func TestEmptyColumnTableRejectedByTrino(t *testing.T) {
+	o := connectOracle(t)
+
+	ddl, err := GetDatabaseDefinition(oneTable("memory", "default", &TableMetadata{
+		Name:    "empty_table",
+		Columns: nil,
+	}))
+	if err != nil {
+		t.Fatalf("GetDatabaseDefinition: %v", err)
+	}
+	stmts := splitStatements(ddl)
+	if len(stmts) != 1 {
+		t.Fatalf("expected one statement, got %d: %q", len(stmts), ddl)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := o.CheckSyntax(ctx, stmts[0])
+	if err != nil {
+		t.Fatalf("oracle CheckSyntax(%q): %v", stmts[0], err)
+	}
+	if res.Accepted {
+		t.Errorf("expected Trino to reject the column-less CREATE TABLE, but it was accepted:\n%s", stmts[0])
+	}
+	if res.ErrorName != "SYNTAX_ERROR" {
+		t.Errorf("expected SYNTAX_ERROR for column-less CREATE TABLE, got errorName=%q (msg=%s)", res.ErrorName, res.Message)
+	}
+}
+
+// splitStatements breaks the multi-statement deparse output into individual
+// trimmed CREATE TABLE statements, dropping the trailing blank lines. The
+// deparser terminates each statement with ";" and separates them with "\n\n",
+// so splitting on ";" and trimming is sufficient for the simple, generated DDL
+// the deparser emits.
+func splitStatements(ddl string) []string {
+	var out []string
+	for _, part := range strings.Split(ddl, ";") {
+		s := strings.TrimSpace(part)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Node: `trino/deparse` (v2 migration, feature)

Implements the omni-side **`GetDatabaseDefinition`** for the Trino engine — render a database metadata snapshot into the `CREATE TABLE` SDL that recreates it. This is the metadata→DDL feature bytebase currently keeps in `plugin/schema/trino`; the `bytebase-switch` node will wire this package in.

Spec: `docs/migration/trino/{dag.md,analysis.md,contract.md}` (node row `trino/deparse`, writes `trino/deparse/*.go`). Source-of-truth: `bytebase/backend/plugin/schema/trino/get_database_definition.go`.

### What's here
- **`metadata.go`** — an omni-native, **ordered, verbatim** metadata model (`DatabaseSchemaMetadata` / `SchemaMetadata` / `TableMetadata` / `ColumnMetadata`) mirroring the `storepb` fields the Trino dump reads. `trino/catalog` already models the same hierarchy but folds identifiers and returns names *sorted* — wrong for SDL, which must preserve snapshot order and emit names verbatim. So deparse takes its own input model; `bytebase-switch` maps `storepb`→these one-to-one (no bytebase-protobuf import in omni).
- **`deparse.go`** — `GetDatabaseDefinition(metadata) (string, error)` producing output **byte-identical** to the legacy bytebase source. nil metadata / nil slice entries are handled gracefully (legacy would panic).

### Proof (correctness protocol — feature node)
- **Differential vs legacy (byte-for-byte):** the three legacy golden cases (inputs + expected strings) are lifted **verbatim** from `get_database_definition_test.go` and pass exactly, plus backfilled multi-table / multi-schema / nil-handling cases the legacy suite never had.
- **Deparse round-trip / structural gate (live Trino 481 oracle):** every generated `CREATE TABLE` is **accepted** by Trino's own parser — simple, parameterized + nested types (`varchar(10)`, `decimal(10,2)`, `array(integer)`, `map(...)`, `row(...)`, `timestamp(3) with time zone`), and mixed-case + reserved-word-as-column (proves the always-on double-quoting is correct). Skipped offline / in `-short`.

```
ok  github.com/bytebase/omni/trino/deparse   (golden + oracle round-trip, all PASS)
```

### Divergences
| Case | Disposition |
|---|---|
| Column-less table → `CREATE TABLE ... ()` → Trino 481 `SYNTAX_ERROR` | **flagged** (inherited-legacy, oracle-confirmed) |

This is **not a regression**: the output is byte-identical to the legacy `GetDatabaseDefinition` (proven by the golden test); the limitation is inherited. `TestEmptyColumnTableRejectedByTrino` asserts the rejection so it is recorded, not hidden.

### Review
- **Claude lens** (`/code-review`, high): one cleanup finding (dead always-nil `strings.Builder` error paths from the legacy copy) → fixed to match omni house style (`snowflake/deparse/writer.go`); golden tests unchanged → behavior-preserving.
- **Codex lens** (`codex exec review --base main`): "No actionable defects were found"; ran `go test ./trino/...` independently, all green.

### Scope
Touches only `trino/deparse/*.go` (4 files). No out-of-scope writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)