### PR TITLE
fix(tidb/parser): accept string-literal aliases in the SELECT list

### DIFF
--- a/tidb/parser/alias_test.go
+++ b/tidb/parser/alias_test.go
@@ -1,0 +1,44 @@
+package parser
+
+import "testing"
+
+// TiDB accepts a quoted string as an alias ONLY in the SELECT list (column
+// alias), matching its grammar (select_alias_ident -> ident | TEXT_STRING).
+// Unlike MySQL, TiDB rejects string-literal aliases on table refs, derived
+// tables, JSON_TABLE, and UPDATE/DELETE targets — verified on TiDB v8.5.0.
+
+func TestSelectAliasStringLiteral(t *testing.T) {
+	cases := []string{
+		`SELECT 1 AS 'start'`,
+		`SELECT 1 AS "start"`,
+		`SELECT 1 'start'`,
+		`SELECT a AS 'label', b FROM t`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Fatalf("Parse(%q) error: %v", sql, err)
+			}
+		})
+	}
+}
+
+// TestNonSelectAliasRejectsStringLiteral pins that string-literal aliases are
+// rejected everywhere TiDB rejects them — omni must not parse SQL TiDB fails.
+func TestNonSelectAliasRejectsStringLiteral(t *testing.T) {
+	cases := []string{
+		`SELECT * FROM t AS 'a'`,
+		`SELECT * FROM t 'a'`,
+		`SELECT * FROM (SELECT 1) AS 'a'`,
+		`SELECT * FROM JSON_TABLE('[]', '$' COLUMNS (v INT PATH '$')) AS 'a'`,
+		`UPDATE t AS 'a' SET a = 1`,
+		`DELETE FROM t AS 'a' WHERE a = 1`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Fatalf("Parse(%q) accepted a string-literal alias, but TiDB rejects it", sql)
+			}
+		})
+	}
+}

--- a/tidb/parser/name.go
+++ b/tidb/parser/name.go
@@ -595,6 +595,17 @@ func (p *Parser) parseIdentifier() (string, int, error) {
 	return p.parseIdent()
 }
 
+// parseIdentOrText parses an identifier OR a string literal, matching MySQL's
+// `ident_or_text` grammar rule. Used for alias positions where MySQL accepts a
+// quoted string as the alias (e.g. SELECT a AS 'x', FROM t AS 'y').
+func (p *Parser) parseIdentOrText() (string, int, error) {
+	if p.cur.Type == tokSCONST {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
+	return p.parseIdent()
+}
+
 // parseLabelIdent parses an identifier matching MySQL's `label_ident` grammar rule.
 // Accepts tokIDENT plus unambiguous, ambiguous_3, and ambiguous_4 keywords.
 // Excludes ambiguous_1 (not label, not role) and ambiguous_2 (not label).
@@ -833,7 +844,9 @@ func (p *Parser) parseTableRefWithAlias() (*nodes.TableRef, error) {
 		ref.Loc.End = p.pos()
 	}
 
-	// Optional AS alias
+	// Optional AS alias. Unlike MySQL, TiDB does NOT accept a string literal as
+	// a table alias (ident_or_text applies only to SELECT-list aliases), so this
+	// uses parseIdentifier, not parseIdentOrText.
 	if _, ok := p.match(kwAS); ok {
 		alias, _, err := p.parseIdentifier()
 		if err != nil {

--- a/tidb/parser/select.go
+++ b/tidb/parser/select.go
@@ -770,7 +770,7 @@ func (p *Parser) parseSelectExpr() (nodes.ExprNode, error) {
 	var alias string
 	if _, ok := p.match(kwAS); ok {
 		aliasLoc := p.pos()
-		name, _, err := p.parseIdent()
+		name, _, err := p.parseIdentOrText()
 		if err != nil {
 			return nil, err
 		}
@@ -778,10 +778,10 @@ func (p *Parser) parseSelectExpr() (nodes.ExprNode, error) {
 		if p.completing {
 			p.addSelectAliasPosition(aliasLoc)
 		}
-	} else if p.isIdentToken() && !p.isSelectTerminator() {
-		// Implicit alias (identifier without AS), but not if it's a keyword that starts the next clause
+	} else if (p.isIdentToken() || p.cur.Type == tokSCONST) && !p.isSelectTerminator() {
+		// Implicit alias (identifier or string literal without AS), but not if it's a keyword that starts the next clause
 		aliasLoc := p.pos()
-		alias, _, err = p.parseIdent()
+		alias, _, err = p.parseIdentOrText()
 		if err != nil {
 			return nil, err
 		}
@@ -1101,7 +1101,8 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 			Lateral: true,
 		}
 
-		// Optional alias: [AS] alias
+		// Optional alias: [AS] alias. TiDB does not accept a string-literal
+		// derived-table alias (unlike MySQL), so this uses parseIdent.
 		if _, ok := p.match(kwAS); ok {
 			alias, _, err := p.parseIdent()
 			if err != nil {
@@ -1148,7 +1149,8 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 				Select: sel,
 			}
 
-			// Optional alias: [AS] alias
+			// Optional alias: [AS] alias. TiDB does not accept a string-literal
+			// derived-table alias (unlike MySQL), so this uses parseIdent.
 			if _, ok := p.match(kwAS); ok {
 				alias, _, err := p.parseIdent()
 				if err != nil {
@@ -1275,7 +1277,8 @@ func (p *Parser) parseJsonTable() (nodes.TableExpr, error) {
 		return nil, err
 	}
 
-	// [AS] alias (required for JSON_TABLE)
+	// [AS] alias (required for JSON_TABLE). TiDB requires an identifier here,
+	// not a string literal (unlike MySQL), so this uses parseIdent.
 	p.match(kwAS)
 	alias, _, aErr := p.parseIdent()
 	if aErr != nil {


### PR DESCRIPTION
## Problem

TiDB accepts a quoted string as a **column alias in the SELECT list** (e.g. `SELECT 1 AS 'x'`, `SELECT 1 'x'`, `SELECT 1 AS "x"`), but the parser rejected it with `expected identifier`.

Found via a MySQL→TiDB parser-parity scan (MySQL fixed the broader `ident_or_text` in #102).

## Scope (TiDB ≠ MySQL here — verified on TiDB v8.5.0)

MySQL accepts string-literal aliases in *every* alias position; **TiDB does not**. Confirmed against `pingcap/tidb:v8.5.0`:

| position | TiDB |
|---|---|
| `SELECT 1 AS 'x'` / `SELECT 1 'x'` / `SELECT 1 AS "x"` | ✅ accept |
| `FROM t AS 'a'` / `FROM t 'a'` | ❌ reject (1064) |
| `FROM (SELECT 1) AS 'd'` | ❌ reject |
| `JSON_TABLE(...) AS 'jt'` | ❌ reject |
| `UPDATE t AS 'a' …` / `DELETE FROM t AS 'a' …` | ❌ reject |

So `parseIdentOrText` is applied **only** to the SELECT-list alias; table refs, derived tables, JSON_TABLE, and UPDATE/DELETE targets keep `parseIdent` (with comments documenting the divergence).

## Fix

- Add `parseIdentOrText` (accept `tokSCONST`, else `parseIdent`).
- Use it in the SELECT-list item position only.

## Testing

`tidb/parser/alias_test.go`:
- positive: `AS 'x'`, implicit `'x'`, `AS "x"`, multi-column — all accepted.
- negative: table / derived / JSON_TABLE / UPDATE / DELETE string-literal aliases — all rejected (matching TiDB).

Full `./tidb/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)