### PR TITLE
feat(trino/parser): expression grammar (v2 node trino/expressions)

### DIFF
--- a/trino/parser/expr.go
+++ b/trino/parser/expr.go
@@ -1,0 +1,1048 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the `expressions` DAG node (with function.go and predicate.go):
+// it implements Trino's expression grammar — the `expression`,
+// `booleanExpression`, `valueExpression`, and `primaryExpression` rules plus
+// their helpers — as a hand-written recursive-descent parser over the token
+// stream, producing an Expr value tree.
+//
+// Like datatypes.go's DataType, the expression nodes are PARSER-PACKAGE types
+// (Expr, not ast.Node): the Trino ast tag set is closed to the ast-core node
+// (only File/Identifier/QualifiedName), so — matching the types-node precedent —
+// expression nodes live in package parser and carry their own Loc. Later DAG
+// nodes (expr-json for the SQL/JSON functions, parser-select for the statement
+// layer, deparse, analysis) embed these Expr values.
+//
+// The legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	expression        : booleanExpression ;
+//	booleanExpression : valueExpression predicate_?              # predicated
+//	                  | NOT booleanExpression                    # logicalNot
+//	                  | booleanExpression AND booleanExpression  # and
+//	                  | booleanExpression OR  booleanExpression  # or ;
+//	valueExpression   : primaryExpression                                    # valueExpressionDefault
+//	                  | valueExpression AT timeZoneSpecifier                  # atTimeZone
+//	                  | (MINUS|PLUS) valueExpression                          # arithmeticUnary
+//	                  | valueExpression (ASTERISK|SLASH|PERCENT) valueExpression # arithmeticBinary
+//	                  | valueExpression (PLUS|MINUS) valueExpression          # arithmeticBinary
+//	                  | valueExpression CONCAT valueExpression                # concatenation ;
+//	primaryExpression : <the big literal/function/constructor/reference set> ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar. Oracle-confirmed precedence facts baked in:
+//
+//	P1 (single, non-associative predicate). A valueExpression carries AT MOST ONE
+//	   predicate suffix: `a = b = c`, `a < b < c`, `a IN (1) IN (2)`,
+//	   `a IS NULL IS NULL`, `a BETWEEN 1 AND 2 BETWEEN 3 AND 4` are all
+//	   SYNTAX_ERRORs in Trino 481. parsePredicated therefore parses one optional
+//	   predicate, never a chain.
+//	P2 (|| binds tighter than the predicate). `a || b = c` parses as `(a||b) = c`
+//	   — concatenation is inside valueExpression, the predicate compares two
+//	   valueExpressions. NOT wraps the whole predicated form (`NOT a = b` is
+//	   `NOT (a = b)`).
+//
+// Two boundary placements (node-scope decisions, recorded in the migration
+// divergence ledger as flagged-by-design, both following the doris/snowflake
+// precedent):
+//
+//	B1 (subqueries are raw-text placeholders). A subquery appearing inside an
+//	   expression — `(SELECT …)`, `EXISTS (query)`, `<cmp> ANY (query)`,
+//	   `IN (query)` — is captured as a SubqueryExpr placeholder holding the raw
+//	   text, NOT a parsed query tree. This mirrors doris/snowflake, where
+//	   expression-embedded subqueries stay placeholders even after the SELECT
+//	   parser exists; the analysis node recurses into RawText when it needs
+//	   lineage. The `query` rule belongs to parser-select.
+//	B2 (pattern-recognition window frame deferred). A function's OVER frame may,
+//	   per the legacy windowFrame rule, carry the full row-pattern subsystem
+//	   (MEASURES / PATTERN / DEFINE / SUBSET / AFTER MATCH / INITIAL|SEEK). That
+//	   subsystem is the parser-match-recognize node (row_pattern.go); this node
+//	   implements the common frame `(ROWS|RANGE|GROUPS) [BETWEEN bound AND] bound`
+//	   and leaves the pattern-frame to that node. See function.go.
+
+// ---------------------------------------------------------------------------
+// Expr node hierarchy (parser-package; not ast.Node — see file header)
+// ---------------------------------------------------------------------------
+
+// Expr is the interface implemented by every Trino expression node produced by
+// this parser. Span returns the source byte range; concrete fields are reached
+// by a Go type switch (mirroring the way DataType is consumed). Expr values are
+// embedded by later DAG nodes (parser-select, deparse, analysis).
+type Expr interface {
+	// Span returns the source byte range covered by the expression.
+	Span() ast.Loc
+	// exprNode is a marker preventing unrelated types from satisfying Expr.
+	exprNode()
+}
+
+// LiteralKind classifies a Literal.
+type LiteralKind int
+
+const (
+	// LiteralNull is the NULL keyword literal.
+	LiteralNull LiteralKind = iota
+	// LiteralBool is TRUE or FALSE.
+	LiteralBool
+	// LiteralString is a character-string literal ('…', U&'…').
+	LiteralString
+	// LiteralInteger is an INTEGER_VALUE_ number.
+	LiteralInteger
+	// LiteralDecimal is a DECIMAL_VALUE_ number.
+	LiteralDecimal
+	// LiteralDouble is a DOUBLE_VALUE_ number.
+	LiteralDouble
+	// LiteralBinary is an X'…' binary literal.
+	LiteralBinary
+)
+
+// Literal is a primaryExpression literal: NULL, a boolean, a string, a number,
+// or a binary literal. Value holds the source-faithful text (for strings, the
+// DECODED content with quotes stripped; for numbers and binary, the source
+// spelling). Unicode is the U&'…' flag for a string literal.
+type Literal struct {
+	Kind    LiteralKind
+	Value   string
+	Unicode bool // true for a U&'…' string literal
+	Loc     ast.Loc
+}
+
+func (n *Literal) Span() ast.Loc { return n.Loc }
+func (*Literal) exprNode()       {}
+
+// Parameter is the `?` positional parameter placeholder (the `parameter`
+// primaryExpression alternative).
+type Parameter struct {
+	Loc ast.Loc
+}
+
+func (n *Parameter) Span() ast.Loc { return n.Loc }
+func (*Parameter) exprNode()       {}
+
+// ColumnRef is a bare `identifier` used as a value (the columnReference
+// alternative). A dotted reference (a.b.c) is a chain of Dereference around a
+// leading ColumnRef.
+type ColumnRef struct {
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+func (n *ColumnRef) Span() ast.Loc { return n.Loc }
+func (*ColumnRef) exprNode()       {}
+
+// Dereference is `base . fieldName` (the dereference alternative): field access
+// on a row value, or one step of a dotted name. FieldName is the trailing
+// identifier.
+type Dereference struct {
+	Base      Expr
+	FieldName *ast.Identifier
+	Loc       ast.Loc
+}
+
+func (n *Dereference) Span() ast.Loc { return n.Loc }
+func (*Dereference) exprNode()       {}
+
+// Subscript is `value [ index ]` (the subscript alternative): array/map element
+// access.
+type Subscript struct {
+	Value Expr
+	Index Expr
+	Loc   ast.Loc
+}
+
+func (n *Subscript) Span() ast.Loc { return n.Loc }
+func (*Subscript) exprNode()       {}
+
+// UnaryExpr is a prefix `+`/`-` arithmetic operation (arithmeticUnary).
+type UnaryExpr struct {
+	Op      string // "+" or "-"
+	Operand Expr
+	Loc     ast.Loc
+}
+
+func (n *UnaryExpr) Span() ast.Loc { return n.Loc }
+func (*UnaryExpr) exprNode()       {}
+
+// BinaryExpr is a binary arithmetic or concatenation operation: `*` `/` `%`
+// `+` `-` `||`.
+type BinaryExpr struct {
+	Op    string
+	Left  Expr
+	Right Expr
+	Loc   ast.Loc
+}
+
+func (n *BinaryExpr) Span() ast.Loc { return n.Loc }
+func (*BinaryExpr) exprNode()       {}
+
+// LogicalExpr is a binary AND/OR (the and/or booleanExpression alternatives).
+type LogicalExpr struct {
+	Op    string // "AND" or "OR"
+	Left  Expr
+	Right Expr
+	Loc   ast.Loc
+}
+
+func (n *LogicalExpr) Span() ast.Loc { return n.Loc }
+func (*LogicalExpr) exprNode()       {}
+
+// NotExpr is `NOT booleanExpression` (logicalNot).
+type NotExpr struct {
+	Operand Expr
+	Loc     ast.Loc
+}
+
+func (n *NotExpr) Span() ast.Loc { return n.Loc }
+func (*NotExpr) exprNode()       {}
+
+// AtTimeZoneExpr is `value AT TIME ZONE specifier` (atTimeZone). Zone is either
+// a string/interval/general expression value.
+type AtTimeZoneExpr struct {
+	Value Expr
+	Zone  Expr
+	Loc   ast.Loc
+}
+
+func (n *AtTimeZoneExpr) Span() ast.Loc { return n.Loc }
+func (*AtTimeZoneExpr) exprNode()       {}
+
+// ParenExpr is a parenthesized single expression `( expression )`
+// (parenthesizedExpression).
+type ParenExpr struct {
+	Expr Expr
+	Loc  ast.Loc
+}
+
+func (n *ParenExpr) Span() ast.Loc { return n.Loc }
+func (*ParenExpr) exprNode()       {}
+
+// RowConstructor is `( e , e (, e)* )` (the parenthesized rowConstructor) or
+// `ROW ( e (, e)* )` (the keyword form). Explicit records the ROW keyword form.
+type RowConstructor struct {
+	Elements []Expr
+	Explicit bool // true for the ROW(...) spelling
+	Loc      ast.Loc
+}
+
+func (n *RowConstructor) Span() ast.Loc { return n.Loc }
+func (*RowConstructor) exprNode()       {}
+
+// ArrayConstructor is `ARRAY [ e , … ]` (arrayConstructor).
+type ArrayConstructor struct {
+	Elements []Expr
+	Loc      ast.Loc
+}
+
+func (n *ArrayConstructor) Span() ast.Loc { return n.Loc }
+func (*ArrayConstructor) exprNode()       {}
+
+// IntervalLiteral is `INTERVAL [+|-] 'string' field [TO field]`
+// (intervalLiteral / the `interval` rule). Unlike the INTERVAL *type*
+// (datatypes.go), this is a value with a string body and a sign.
+type IntervalLiteral struct {
+	Sign  string // "", "+", or "-"
+	Value string // the decoded string body
+	From  IntervalField
+	To    *IntervalField // nil for the single-field form
+	Loc   ast.Loc
+}
+
+func (n *IntervalLiteral) Span() ast.Loc { return n.Loc }
+func (*IntervalLiteral) exprNode()       {}
+
+// TypeConstructor is `name 'string'` (typeConstructor): a typed literal such as
+// `DATE '2020-01-01'`, `JSON '[1]'`, `BIGINT '7'`, or `DOUBLE PRECISION '1.5'`.
+// Name is the source type name (which may be the two-word "DOUBLE PRECISION").
+type TypeConstructor struct {
+	Name  string
+	Value string // decoded string body
+	Loc   ast.Loc
+}
+
+func (n *TypeConstructor) Span() ast.Loc { return n.Loc }
+func (*TypeConstructor) exprNode()       {}
+
+// SubqueryExpr is a placeholder for a subquery appearing inside an expression
+// (B1 in the file header). RawText is the subquery source between the
+// parentheses, trimmed; Kind records the surrounding form so the analysis node
+// can interpret it. The query is NOT parsed here.
+type SubqueryExpr struct {
+	Kind    SubqueryKind
+	RawText string
+	Loc     ast.Loc
+}
+
+func (n *SubqueryExpr) Span() ast.Loc { return n.Loc }
+func (*SubqueryExpr) exprNode()       {}
+
+// SubqueryKind records the syntactic position a subquery placeholder occupies.
+type SubqueryKind int
+
+const (
+	// SubqueryScalar is a bare `( query )` used as a scalar value.
+	SubqueryScalar SubqueryKind = iota
+	// SubqueryExists is `EXISTS ( query )`.
+	SubqueryExists
+	// SubqueryIn is the `( query )` of an `IN ( query )` predicate.
+	SubqueryIn
+	// SubqueryQuantified is the `( query )` of a quantified comparison
+	// `<op> (ALL|ANY|SOME) ( query )`.
+	SubqueryQuantified
+)
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+// ParseExpression parses a complete Trino expression from a standalone string,
+// returning the Expr and any ParseErrors. Trailing tokens after the expression
+// are reported as an error. It is the string-input counterpart of parseExpr,
+// for tests and callers that hold an expression string rather than a token
+// stream. Mirrors ParseDataType / ParseQualifiedName.
+func ParseExpression(input string) (Expr, []ParseError) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+	if p.cur.Kind != tokEOF {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Kind)
+		}
+		return expr, []ParseError{{Loc: p.cur.Loc, Msg: "unexpected token after expression: " + text}}
+	}
+	return expr, nil
+}
+
+// parseExpr parses the `expression` rule (== booleanExpression). It is the
+// single entry point used by every expression position downstream: SELECT-list
+// items, WHERE/HAVING/ON conditions, function arguments, CASE branches, GROUP
+// BY / ORDER BY keys, VALUES rows, DML SET targets.
+func (p *Parser) parseExpr() (Expr, error) {
+	return p.parseBooleanExpr()
+}
+
+// ---------------------------------------------------------------------------
+// booleanExpression — OR / AND / NOT / predicated
+// ---------------------------------------------------------------------------
+
+// parseBooleanExpr parses `booleanExpression`. Precedence (lowest first): OR,
+// then AND, then a prefix NOT, then the predicated value expression. OR and AND
+// are left-associative; they are flattened iteratively rather than recursively
+// to keep deep chains shallow on the Go stack.
+func (p *Parser) parseBooleanExpr() (Expr, error) {
+	return p.parseOr()
+}
+
+// parseOr parses `left OR right (OR right)*`, left-associative.
+func (p *Parser) parseOr() (Expr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == kwOR {
+		p.advance() // consume OR
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &LogicalExpr{
+			Op:    "OR",
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseAnd parses `left AND right (AND right)*`, left-associative.
+func (p *Parser) parseAnd() (Expr, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == kwAND {
+		p.advance() // consume AND
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = &LogicalExpr{
+			Op:    "AND",
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseNot parses `NOT booleanExpression` (prefix, right-recursive so `NOT NOT a`
+// nests) or falls through to the predicated value expression. NOT binds looser
+// than every predicate/arithmetic operator: `NOT a = b` is `NOT (a = b)`.
+func (p *Parser) parseNot() (Expr, error) {
+	if p.cur.Kind == kwNOT {
+		notTok := p.advance() // consume NOT
+		operand, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return &NotExpr{
+			Operand: operand,
+			Loc:     ast.Loc{Start: notTok.Loc.Start, End: operand.Span().End},
+		}, nil
+	}
+	return p.parsePredicated()
+}
+
+// parsePredicated parses `valueExpression predicate_?` (the predicated
+// alternative). At most ONE predicate suffix is consumed — Trino's predicate is
+// non-associative (P1 in the file header), so a second predicate is left for the
+// caller, which surfaces as a syntax error at the trailing operator. The
+// predicate-suffix parsing itself lives in predicate.go.
+func (p *Parser) parsePredicated() (Expr, error) {
+	left, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	return p.parsePredicateSuffix(left)
+}
+
+// ---------------------------------------------------------------------------
+// valueExpression — AT TIME ZONE / arithmetic / concat / unary
+// ---------------------------------------------------------------------------
+
+// parseValueExpr parses `valueExpression`. The layered precedence, tightest
+// last, is: concatenation (||) over additive (+ -) over multiplicative (* / %)
+// over a prefix unary (+ -) over the AT-TIME-ZONE postfix over primaryExpression.
+//
+// All binary operators here are left-associative and flattened iteratively. The
+// AT-TIME-ZONE postfix and the unary prefix are folded into the operand layers
+// (parseUnary / parseAtTimeZonePostfix) so they compose with arithmetic as Trino
+// accepts (`-a * b`, `a * b AT TIME ZONE 'UTC'`, `a AT TIME ZONE 'UTC' * b`).
+func (p *Parser) parseValueExpr() (Expr, error) {
+	return p.parseConcat()
+}
+
+// parseConcat parses `left || right (|| right)*`, left-associative. `||` is the
+// loosest arithmetic-level operator, so `a || b = c` groups as `(a || b) = c`
+// when the predicate suffix is later applied (P2).
+func (p *Parser) parseConcat() (Expr, error) {
+	left, err := p.parseAdditive()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == tokConcat {
+		p.advance() // consume ||
+		right, err := p.parseAdditive()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{
+			Op:    "||",
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseAdditive parses `left (+|-) right (…)*`, left-associative.
+func (p *Parser) parseAdditive() (Expr, error) {
+	left, err := p.parseMultiplicative()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == int('+') || p.cur.Kind == int('-') {
+		opTok := p.advance()
+		op := string(rune(opTok.Kind))
+		right, err := p.parseMultiplicative()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{
+			Op:    op,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseMultiplicative parses `left (*|/|%) right (…)*`, left-associative.
+func (p *Parser) parseMultiplicative() (Expr, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == int('*') || p.cur.Kind == int('/') || p.cur.Kind == int('%') {
+		opTok := p.advance()
+		op := string(rune(opTok.Kind))
+		right, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryExpr{
+			Op:    op,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseUnary parses a prefix `+`/`-` (arithmeticUnary, right-recursive so
+// `- - 1` nests) or falls through to the AT-TIME-ZONE postfix layer.
+func (p *Parser) parseUnary() (Expr, error) {
+	if p.cur.Kind == int('+') || p.cur.Kind == int('-') {
+		opTok := p.advance()
+		operand, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &UnaryExpr{
+			Op:      string(rune(opTok.Kind)),
+			Operand: operand,
+			Loc:     ast.Loc{Start: opTok.Loc.Start, End: operand.Span().End},
+		}, nil
+	}
+	return p.parseAtTimeZonePostfix()
+}
+
+// parseAtTimeZonePostfix parses a primaryExpression followed by zero or more
+// `AT TIME ZONE specifier` postfixes (atTimeZone). The specifier is
+// `TIME ZONE interval` or `TIME ZONE string` — both reduce to an expression
+// value here (an INTERVAL literal or a string), parsed by parsePrimary so the
+// interval form is captured as an IntervalLiteral.
+func (p *Parser) parseAtTimeZonePostfix() (Expr, error) {
+	expr, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == kwAT {
+		p.advance() // consume AT
+		if _, err := p.expect(kwTIME); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwZONE); err != nil {
+			return nil, err
+		}
+		zone, err := p.parsePrimary()
+		if err != nil {
+			return nil, err
+		}
+		expr = &AtTimeZoneExpr{
+			Value: expr,
+			Zone:  zone,
+			Loc:   ast.Loc{Start: expr.Span().Start, End: zone.Span().End},
+		}
+	}
+	return expr, nil
+}
+
+// ---------------------------------------------------------------------------
+// primaryExpression — atoms + postfix subscript/dereference
+// ---------------------------------------------------------------------------
+
+// parsePrimary parses one `primaryExpression`, including the left-recursive
+// postfix subscript (`[index]`) and dereference (`.field`) which are folded into
+// a loop after the atom. It dispatches keyword-led atoms (CASE, CAST, ARRAY,
+// ROW, special functions, …) and otherwise reads a literal / parameter /
+// identifier-or-function / parenthesized form via parsePrimaryAtom.
+func (p *Parser) parsePrimary() (Expr, error) {
+	atom, err := p.parsePrimaryAtom()
+	if err != nil {
+		return nil, err
+	}
+	return p.parsePostfix(atom)
+}
+
+// parsePostfix consumes zero or more `[ index ]` subscripts and `. field`
+// dereferences on an already-parsed primary, left-associative. `m['k'][1].f`
+// and `a.b[1]` both round-trip through this loop.
+//
+// A `.` is treated as a dereference only when followed by an identifier; `.*`
+// (the selectAll form) is NOT a primaryExpression and belongs to the SELECT-list
+// layer, so a `.` before `*` is left for the caller (it surfaces there).
+func (p *Parser) parsePostfix(expr Expr) (Expr, error) {
+	for {
+		switch p.cur.Kind {
+		case int('['):
+			p.advance() // consume '['
+			index, err := p.parseValueExpr()
+			if err != nil {
+				return nil, err
+			}
+			closeTok, err := p.expect(int(']'))
+			if err != nil {
+				return nil, err
+			}
+			expr = &Subscript{
+				Value: expr,
+				Index: index,
+				Loc:   ast.Loc{Start: expr.Span().Start, End: closeTok.Loc.End},
+			}
+		case int('.'):
+			// Only a `.identifier` dereference belongs here; `.*` is selectAll.
+			if !isIdentifierStart(p.peekNext().Kind) {
+				return expr, nil
+			}
+			p.advance() // consume '.'
+			field, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			expr = &Dereference{
+				Base:      expr,
+				FieldName: field,
+				Loc:       ast.Loc{Start: expr.Span().Start, End: field.Loc.End},
+			}
+		default:
+			return expr, nil
+		}
+	}
+}
+
+// parsePrimaryAtom parses a primaryExpression atom WITHOUT the postfix
+// subscript/dereference (handled by parsePostfix). It dispatches on the leading
+// token. Function-call, CAST/TRY_CAST, CASE, the special built-ins
+// (EXTRACT/SUBSTRING/TRIM/NORMALIZE/POSITION/GROUPING/LISTAGG/special-datetime),
+// and the SQL/JSON functions are routed to function.go.
+func (p *Parser) parsePrimaryAtom() (Expr, error) {
+	switch p.cur.Kind {
+	case kwNULL:
+		tok := p.advance()
+		return &Literal{Kind: LiteralNull, Value: "NULL", Loc: tok.Loc}, nil
+	case kwTRUE:
+		tok := p.advance()
+		return &Literal{Kind: LiteralBool, Value: "TRUE", Loc: tok.Loc}, nil
+	case kwFALSE:
+		tok := p.advance()
+		return &Literal{Kind: LiteralBool, Value: "FALSE", Loc: tok.Loc}, nil
+	case tokString, tokUnicodeString:
+		return p.parseStringLiteral()
+	case tokInteger:
+		tok := p.advance()
+		return &Literal{Kind: LiteralInteger, Value: tok.Str, Loc: tok.Loc}, nil
+	case tokDecimal:
+		tok := p.advance()
+		return &Literal{Kind: LiteralDecimal, Value: tok.Str, Loc: tok.Loc}, nil
+	case tokDouble:
+		tok := p.advance()
+		return &Literal{Kind: LiteralDouble, Value: tok.Str, Loc: tok.Loc}, nil
+	case tokBinaryLiteral:
+		tok := p.advance()
+		return &Literal{Kind: LiteralBinary, Value: tok.Str, Loc: tok.Loc}, nil
+	case tokQuestion, int('?'):
+		tok := p.advance()
+		return &Parameter{Loc: tok.Loc}, nil
+	case kwINTERVAL:
+		return p.parseIntervalLiteral()
+	case int('('):
+		return p.parseParenOrSubqueryOrRow()
+	case kwARRAY:
+		// ARRAY[ … ] constructor — distinct from the ARRAY type. If ARRAY is not
+		// followed by '[', it is an ordinary identifier (e.g. a column/function
+		// named ARRAY), handled by the identifier path.
+		if p.peekNext().Kind == int('[') {
+			return p.parseArrayConstructor()
+		}
+		return p.parseIdentifierOrFunction()
+	case kwROW:
+		// ROW( … ) constructor — distinct from the ROW type. ROW not followed by
+		// '(' is an ordinary identifier.
+		if p.peekNext().Kind == int('(') {
+			return p.parseRowConstructor()
+		}
+		return p.parseIdentifierOrFunction()
+	case kwCASE:
+		return p.parseCaseExpr()
+	case kwCAST, kwTRY_CAST:
+		return p.parseCast()
+	case kwEXISTS:
+		return p.parseExists()
+	case kwEXTRACT:
+		return p.parseExtract()
+	case kwTRIM:
+		return p.parseTrim()
+	case kwNORMALIZE:
+		return p.parseNormalize()
+	case kwLISTAGG:
+		return p.parseListagg()
+	case kwGROUPING:
+		return p.parseGrouping()
+	case kwJSON_EXISTS, kwJSON_VALUE, kwJSON_QUERY, kwJSON_OBJECT, kwJSON_ARRAY:
+		return p.parseJSONFunction()
+	case kwRUNNING, kwFINAL:
+		// processingMode prefix on a function call (RUNNING/FINAL last(x)),
+		// used in MATCH_RECOGNIZE measure expressions.
+		return p.parseProcessingModeFunction()
+	case kwCURRENT_DATE, kwCURRENT_USER, kwCURRENT_CATALOG, kwCURRENT_SCHEMA, kwCURRENT_PATH,
+		kwCURRENT_TIME, kwCURRENT_TIMESTAMP, kwLOCALTIME, kwLOCALTIMESTAMP:
+		return p.parseSpecialDateTimeFunction()
+	case kwDOUBLE:
+		// DOUBLE PRECISION 'literal' typeConstructor. Otherwise DOUBLE is an
+		// ordinary identifier handled by the identifier path.
+		if p.peekNext().Kind == kwPRECISION {
+			return p.parseDoublePrecisionConstructor()
+		}
+		return p.parseIdentifierOrFunction()
+	default:
+		// An identifier (or a non-reserved keyword usable as one) begins a
+		// column reference, a function call, a lambda, or a typeConstructor.
+		if isIdentifierStart(p.cur.Kind) {
+			return p.parseIdentifierOrFunction()
+		}
+		return nil, p.exprError()
+	}
+}
+
+// parseStringLiteral parses a basic or unicode string literal (string_ rule).
+// The lexer has already decoded the body and recorded whether it was a U&'…'
+// unicode string. A `UESCAPE '…'` clause, when present, has been consumed by the
+// lexer as part of the unicode-string token.
+func (p *Parser) parseStringLiteral() (Expr, error) {
+	tok := p.advance()
+	return &Literal{
+		Kind:    LiteralString,
+		Value:   tok.Str,
+		Unicode: tok.Kind == tokUnicodeString,
+		Loc:     tok.Loc,
+	}, nil
+}
+
+// parseIntervalLiteral parses `INTERVAL [+|-] 'string' field [TO field]`
+// (the `interval` rule / intervalLiteral primaryExpression). It is distinct from
+// the INTERVAL *type* (datatypes.go): a literal requires a string body and a
+// field, and allows a leading sign. The same D1 same-family/ordered qualifier
+// rule as the type applies to the optional `TO to` range.
+func (p *Parser) parseIntervalLiteral() (Expr, error) {
+	intervalTok := p.advance() // consume INTERVAL
+
+	sign := ""
+	if p.cur.Kind == int('+') || p.cur.Kind == int('-') {
+		sign = string(rune(p.advance().Kind))
+	}
+
+	if p.cur.Kind != tokString && p.cur.Kind != tokUnicodeString {
+		return nil, p.exprErrorAt("expected string literal in INTERVAL")
+	}
+	strTok := p.advance()
+
+	from, ok := intervalFieldFromKind(p.cur.Kind)
+	if !ok {
+		return nil, p.exprErrorAt("expected interval field (YEAR/MONTH/DAY/HOUR/MINUTE/SECOND)")
+	}
+	fromTok := p.advance()
+
+	lit := &IntervalLiteral{
+		Sign:  sign,
+		Value: strTok.Str,
+		From:  from,
+		Loc:   ast.Loc{Start: intervalTok.Loc.Start, End: fromTok.Loc.End},
+	}
+
+	if p.cur.Kind == kwTO {
+		toTok := p.peekNext()
+		to, ok := intervalFieldFromKind(toTok.Kind)
+		if !ok {
+			p.advance() // consume TO so the error points at the bad to-field
+			return nil, p.exprErrorAt("expected interval field after TO")
+		}
+		if !ValidIntervalRange(from, to) {
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "invalid interval qualifier: " + from.String() + " TO " + to.String(),
+			}
+		}
+		p.advance() // consume TO
+		toEnd := p.advance()
+		toVal := to
+		lit.To = &toVal
+		lit.Loc.End = toEnd.Loc.End
+	}
+	return lit, nil
+}
+
+// parseArrayConstructor parses `ARRAY [ (expression (, expression)*)? ]`
+// (arrayConstructor). The element list may be empty (`ARRAY[]`).
+func (p *Parser) parseArrayConstructor() (Expr, error) {
+	arrTok := p.advance() // consume ARRAY
+	if _, err := p.expect(int('[')); err != nil {
+		return nil, err
+	}
+	elems, closeTok, err := p.parseBracketedExprList(int(']'))
+	if err != nil {
+		return nil, err
+	}
+	return &ArrayConstructor{
+		Elements: elems,
+		Loc:      ast.Loc{Start: arrTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseRowConstructor parses the keyword form `ROW ( expression (, expression)* )`
+// (rowConstructor). The element list must be non-empty (Trino rejects ROW()).
+func (p *Parser) parseRowConstructor() (Expr, error) {
+	rowTok := p.advance() // consume ROW
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	elems := []Expr{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &RowConstructor{
+		Elements: elems,
+		Explicit: true,
+		Loc:      ast.Loc{Start: rowTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseParenOrSubqueryOrRow disambiguates a leading '(' among:
+//   - a parenthesized-parameter lambda `( (ident (, ident)*)? ) -> body`
+//     (the second lambda alternative, including the empty-parameter `() -> …`);
+//   - a subquery `( query )` → SubqueryExpr placeholder (B1), when SELECT/WITH/
+//     TABLE/VALUES follows the '(';
+//   - a parenthesized rowConstructor `( e , e (, e)* )` when a top-level comma
+//     follows the first expression;
+//   - a plain parenthesized expression `( expression )` otherwise.
+//
+// The lambda case is detected by a speculative parse of an identifier list
+// followed by `) ->`; on failure the parser rewinds and falls through to the
+// subquery/row/paren readings. This is required because `(x)` alone is a
+// ParenExpr and `(x, y)` alone is a rowConstructor — only the trailing `->`
+// distinguishes a lambda, and the deciding token lies past the ')'.
+func (p *Parser) parseParenOrSubqueryOrRow() (Expr, error) {
+	openTok := p.advance() // consume '('
+
+	if lam, ok, err := p.tryParenLambda(openTok.Loc.Start); err != nil {
+		return nil, err
+	} else if ok {
+		return lam, nil
+	}
+
+	if p.startsQuery() {
+		return p.parseSubqueryPlaceholder(openTok.Loc.Start, SubqueryScalar)
+	}
+
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Kind == int(',') {
+		// rowConstructor: ( e , e (, e)* )
+		elems := []Expr{first}
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			elems = append(elems, next)
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		return &RowConstructor{
+			Elements: elems,
+			Loc:      ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+		}, nil
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ParenExpr{
+		Expr: first,
+		Loc:  ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// tryParenLambda speculatively parses a parenthesized-parameter lambda body
+// `(ident (, ident)*)? ) -> body`, the opening '(' already consumed (its offset
+// is startOffset). It returns ok=true with the LambdaExpr when the input is a
+// lambda, ok=false (parser rewound to just after the '(') when it is not, and a
+// non-nil error only when the input WAS a lambda but its body failed to parse.
+//
+// A '(' that opens a lambda parameter list contains only identifiers and commas
+// before the ')'; the ')' must be immediately followed by '->'. Any other shape
+// (a subquery, a row/paren expression) fails the speculation and rewinds.
+func (p *Parser) tryParenLambda(startOffset int) (Expr, bool, error) {
+	cp := p.checkpoint()
+
+	var params []*ast.Identifier
+	if p.cur.Kind != int(')') {
+		if !isIdentifierStart(p.cur.Kind) {
+			p.restore(cp)
+			return nil, false, nil
+		}
+		params = append(params, identFromToken(p.advance()))
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			if !isIdentifierStart(p.cur.Kind) {
+				p.restore(cp)
+				return nil, false, nil
+			}
+			params = append(params, identFromToken(p.advance()))
+		}
+	}
+	if p.cur.Kind != int(')') || p.peekNext().Kind != tokArrow {
+		p.restore(cp)
+		return nil, false, nil
+	}
+	p.advance() // consume ')'
+	p.advance() // consume '->'
+
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, true, err
+	}
+	return &LambdaExpr{
+		Params: params,
+		Body:   body,
+		Loc:    ast.Loc{Start: startOffset, End: body.Span().End},
+	}, true, nil
+}
+
+// startsQuery reports whether the current token begins a `query` (used to
+// recognise a subquery after a '('). Trino's queryPrimary starts with SELECT,
+// WITH (cte or inline FUNCTION), TABLE, or VALUES.
+func (p *Parser) startsQuery() bool {
+	switch p.cur.Kind {
+	case kwSELECT, kwWITH, kwTABLE, kwVALUES:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseSubqueryPlaceholder consumes tokens until the matching ')' that closes a
+// subquery and returns a SubqueryExpr placeholder holding the raw inner text
+// (B1 in the file header). The opening '(' has already been consumed; startOffset
+// is its byte offset. Nested parentheses are balanced. This mirrors
+// doris/parser.parseSubqueryPlaceholder — expression-embedded subqueries are not
+// parsed into a query tree here.
+func (p *Parser) parseSubqueryPlaceholder(startOffset int, kind SubqueryKind) (*SubqueryExpr, error) {
+	depth := 1
+	subStart := p.cur.Loc.Start
+	subEnd := p.cur.Loc.Start
+	for depth > 0 && p.cur.Kind != tokEOF {
+		switch p.cur.Kind {
+		case int('('):
+			depth++
+		case int(')'):
+			depth--
+			if depth == 0 {
+				subEnd = p.cur.Loc.Start
+			}
+		}
+		if depth > 0 {
+			p.advance()
+		}
+	}
+	if depth != 0 {
+		return nil, &ParseError{Loc: p.cur.Loc, Msg: "unterminated subquery"}
+	}
+	raw := p.sourceSlice(subStart, subEnd)
+	closeTok := p.advance() // consume ')'
+	return &SubqueryExpr{
+		Kind:    kind,
+		RawText: strings.TrimSpace(raw),
+		Loc:     ast.Loc{Start: startOffset, End: closeTok.Loc.End},
+	}, nil
+}
+
+// sourceSlice returns the substring of the original input spanning the absolute
+// byte range [absStart, absEnd). It accounts for the parser's baseOffset so a
+// statement carved out of a larger document slices correctly. Out-of-range
+// inputs yield "" rather than panicking.
+func (p *Parser) sourceSlice(absStart, absEnd int) string {
+	s := absStart - p.baseOffset
+	e := absEnd - p.baseOffset
+	if s < 0 || e > len(p.input) || s > e {
+		return ""
+	}
+	return p.input[s:e]
+}
+
+// parseBracketedExprList parses `(expression (, expression)*)? closer`, returning
+// the elements and the closing token. The opening bracket has already been
+// consumed. The list may be empty (e.g. ARRAY[] or GROUPING()).
+func (p *Parser) parseBracketedExprList(closer TokenKind) ([]Expr, Token, error) {
+	if p.cur.Kind == closer {
+		closeTok := p.advance()
+		return nil, closeTok, nil
+	}
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, Token{}, err
+	}
+	elems := []Expr{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, Token{}, err
+		}
+		elems = append(elems, next)
+	}
+	closeTok, err := p.expect(closer)
+	if err != nil {
+		return nil, Token{}, err
+	}
+	return elems, closeTok, nil
+}
+
+// ---------------------------------------------------------------------------
+// errors
+// ---------------------------------------------------------------------------
+
+// exprError returns a *ParseError describing a missing expression at the current
+// token, distinct from the generic identifier/type errors so a value position
+// reports "expected expression".
+func (p *Parser) exprError() *ParseError {
+	if p.cur.Kind == tokEOF {
+		return &ParseError{Loc: p.cur.Loc, Msg: "expected expression, found end of input"}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Kind)
+	}
+	return &ParseError{Loc: p.cur.Loc, Msg: "expected expression, found " + text}
+}
+
+// exprErrorAt returns a *ParseError with a custom message at the current token.
+func (p *Parser) exprErrorAt(msg string) *ParseError {
+	return &ParseError{Loc: p.cur.Loc, Msg: msg}
+}

--- a/trino/parser/expr_structure_test.go
+++ b/trino/parser/expr_structure_test.go
@@ -1,0 +1,634 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This file is the structural correctness gate (Layer 2 of correctness-protocol.md)
+// for the expressions node. Accept/reject (expr_test.go) cannot catch wrong
+// precedence/associativity/nesting — `1 + 2 * 3` "accepts" however it groups —
+// so these tests:
+//
+//   - TestExpr_Precedence pins the exact parse-tree shape of every
+//     oracle-confirmed precedence/associativity fact (P1 single non-associative
+//     predicate, P2 || over predicate, arithmetic layering, unary, AT TIME ZONE,
+//     postfix subscript/dereference), via a compact S-expression rendering of the
+//     parsed Expr.
+//   - TestExpr_RoundTrip / TestExpr_RoundTripOracle render each accepted corpus
+//     expression back to SQL and re-parse it; the re-parse must succeed and Trino
+//     must re-accept the rendering — proving the parse captured a well-formed,
+//     valid structure.
+
+// renderSExpr renders an Expr as a parenthesized S-expression capturing operator
+// structure and nesting, for precise structural assertions. It is test-only.
+func renderSExpr(e Expr) string {
+	switch n := e.(type) {
+	case *Literal:
+		if n.Kind == LiteralString {
+			return "'" + n.Value + "'"
+		}
+		return n.Value
+	case *Parameter:
+		return "?"
+	case *ColumnRef:
+		return n.Name.String()
+	case *Dereference:
+		return fmt.Sprintf("(. %s %s)", renderSExpr(n.Base), n.FieldName.String())
+	case *Subscript:
+		return fmt.Sprintf("([] %s %s)", renderSExpr(n.Value), renderSExpr(n.Index))
+	case *UnaryExpr:
+		return fmt.Sprintf("(u%s %s)", n.Op, renderSExpr(n.Operand))
+	case *BinaryExpr:
+		return fmt.Sprintf("(%s %s %s)", n.Op, renderSExpr(n.Left), renderSExpr(n.Right))
+	case *LogicalExpr:
+		return fmt.Sprintf("(%s %s %s)", strings.ToLower(n.Op), renderSExpr(n.Left), renderSExpr(n.Right))
+	case *NotExpr:
+		return fmt.Sprintf("(not %s)", renderSExpr(n.Operand))
+	case *AtTimeZoneExpr:
+		return fmt.Sprintf("(attz %s %s)", renderSExpr(n.Value), renderSExpr(n.Zone))
+	case *ParenExpr:
+		return fmt.Sprintf("(paren %s)", renderSExpr(n.Expr))
+	case *ComparisonExpr:
+		return fmt.Sprintf("(%s %s %s)", n.Op, renderSExpr(n.Left), renderSExpr(n.Right))
+	case *BetweenExpr:
+		not := ""
+		if n.Not {
+			not = "!"
+		}
+		return fmt.Sprintf("(%sbetween %s %s %s)", not, renderSExpr(n.Value), renderSExpr(n.Lower), renderSExpr(n.Upper))
+	case *IsNullExpr:
+		not := ""
+		if n.Not {
+			not = "!"
+		}
+		return fmt.Sprintf("(%sisnull %s)", not, renderSExpr(n.Value))
+	case *IsDistinctFromExpr:
+		not := ""
+		if n.Not {
+			not = "!"
+		}
+		return fmt.Sprintf("(%sdistinct %s %s)", not, renderSExpr(n.Value), renderSExpr(n.Right))
+	case *LikeExpr:
+		not := ""
+		if n.Not {
+			not = "!"
+		}
+		return fmt.Sprintf("(%slike %s %s)", not, renderSExpr(n.Value), renderSExpr(n.Pattern))
+	default:
+		return fmt.Sprintf("<%T>", e)
+	}
+}
+
+// TestExpr_Precedence asserts the parse-tree shape of precedence- and
+// associativity-sensitive expressions. Each case fixes how the operators group.
+func TestExpr_Precedence(t *testing.T) {
+	cases := []struct {
+		expr string
+		want string
+	}{
+		// multiplicative binds tighter than additive
+		{"1 + 2 * 3", "(+ 1 (* 2 3))"},
+		{"1 * 2 + 3", "(+ (* 1 2) 3)"},
+		// additive/multiplicative are left-associative
+		{"1 - 2 - 3", "(- (- 1 2) 3)"},
+		{"1 / 2 / 3", "(/ (/ 1 2) 3)"},
+		// unary binds tighter than multiplicative; nests right
+		{"-a * b", "(* (u- a) b)"},
+		{"- - 1", "(u- (u- 1))"},
+		// || is looser than arithmetic, left-associative
+		{"a || b || c", "(|| (|| a b) c)"},
+		{"a + b || c", "(|| (+ a b) c)"},
+		// predicate sits above ||: a || b = c is (a||b) = c (P2)
+		{"a || b = c", "(= (|| a b) c)"},
+		// comparison wraps two value expressions
+		{"1 + 2 = 3", "(= (+ 1 2) 3)"},
+		// NOT wraps the whole predicated expression (loosest)
+		{"NOT a = b", "(not (= a b))"},
+		{"NOT NOT a", "(not (not a))"},
+		// AND binds tighter than OR
+		{"a OR b AND c", "(or a (and b c))"},
+		{"a AND b OR c", "(or (and a b) c)"},
+		// AND/OR left-associative
+		{"a AND b AND c", "(and (and a b) c)"},
+		// postfix subscript/dereference are left-associative and tightest
+		{"a.b.c", "(. (. a b) c)"},
+		{"a[1][2]", "([] ([] a 1) 2)"},
+		{"a.b[1]", "([] (. a b) 1)"},
+		{"m['k'].f", "(. ([] m 'k') f)"},
+		// IS NULL is a single non-associative predicate
+		{"a + b IS NULL", "(isnull (+ a b))"},
+		{"a IS NOT NULL", "(!isnull a)"},
+		// BETWEEN bounds are value expressions (the AND is the separator)
+		{"a BETWEEN 1 + 1 AND 2 * 2", "(between a (+ 1 1) (* 2 2))"},
+		// LIKE / DISTINCT FROM operate on value expressions
+		{"a IS DISTINCT FROM b + c", "(distinct a (+ b c))"},
+	}
+	for _, tc := range cases {
+		t.Run(truncateName(tc.expr), func(t *testing.T) {
+			node, errs := ParseExpression(tc.expr)
+			if len(errs) != 0 {
+				t.Fatalf("ParseExpression(%q) failed: %v", tc.expr, errs)
+			}
+			got := renderSExpr(node)
+			if got != tc.want {
+				t.Errorf("structure mismatch for %q:\n  got:  %s\n  want: %s", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// renderExpr renders an Expr back to Trino SQL for the round-trip gate. It need
+// not be byte-identical to the input (spacing/case may normalize) but must emit
+// syntactically valid, structurally faithful Trino. It is test-only; production
+// deparse is a separate DAG node.
+func renderExpr(e Expr) string {
+	var b strings.Builder
+	writeExpr(&b, e)
+	return b.String()
+}
+
+func writeExpr(b *strings.Builder, e Expr) {
+	switch n := e.(type) {
+	case *Literal:
+		switch n.Kind {
+		case LiteralString:
+			if n.Unicode {
+				b.WriteString("U&")
+			}
+			b.WriteByte('\'')
+			b.WriteString(strings.ReplaceAll(n.Value, "'", "''"))
+			b.WriteByte('\'')
+		case LiteralBinary:
+			// The lexer strips the X'…' wrapper; restore it for a valid render.
+			b.WriteString("X'")
+			b.WriteString(n.Value)
+			b.WriteByte('\'')
+		default:
+			b.WriteString(n.Value)
+		}
+	case *Parameter:
+		b.WriteByte('?')
+	case *ColumnRef:
+		b.WriteString(n.Name.String())
+	case *Dereference:
+		writeExpr(b, n.Base)
+		b.WriteByte('.')
+		b.WriteString(n.FieldName.String())
+	case *Subscript:
+		writeExpr(b, n.Value)
+		b.WriteByte('[')
+		writeExpr(b, n.Index)
+		b.WriteByte(']')
+	case *UnaryExpr:
+		b.WriteString(n.Op)
+		b.WriteByte('(')
+		writeExpr(b, n.Operand)
+		b.WriteByte(')')
+	case *BinaryExpr:
+		b.WriteByte('(')
+		writeExpr(b, n.Left)
+		b.WriteByte(' ')
+		b.WriteString(n.Op)
+		b.WriteByte(' ')
+		writeExpr(b, n.Right)
+		b.WriteByte(')')
+	case *LogicalExpr:
+		b.WriteByte('(')
+		writeExpr(b, n.Left)
+		b.WriteByte(' ')
+		b.WriteString(n.Op)
+		b.WriteByte(' ')
+		writeExpr(b, n.Right)
+		b.WriteByte(')')
+	case *NotExpr:
+		b.WriteString("(NOT ")
+		writeExpr(b, n.Operand)
+		b.WriteByte(')')
+	case *AtTimeZoneExpr:
+		b.WriteByte('(')
+		writeExpr(b, n.Value)
+		b.WriteString(" AT TIME ZONE ")
+		writeExpr(b, n.Zone)
+		b.WriteByte(')')
+	case *ParenExpr:
+		b.WriteByte('(')
+		writeExpr(b, n.Expr)
+		b.WriteByte(')')
+	case *RowConstructor:
+		if n.Explicit {
+			b.WriteString("ROW")
+		}
+		b.WriteByte('(')
+		writeExprList(b, n.Elements)
+		b.WriteByte(')')
+	case *ArrayConstructor:
+		b.WriteString("ARRAY[")
+		writeExprList(b, n.Elements)
+		b.WriteByte(']')
+	case *IntervalLiteral:
+		b.WriteString("INTERVAL ")
+		b.WriteString(n.Sign)
+		b.WriteByte('\'')
+		b.WriteString(n.Value)
+		b.WriteString("' ")
+		b.WriteString(n.From.String())
+		if n.To != nil {
+			b.WriteString(" TO ")
+			b.WriteString(n.To.String())
+		}
+	case *TypeConstructor:
+		b.WriteString(n.Name)
+		b.WriteString(" '")
+		b.WriteString(strings.ReplaceAll(n.Value, "'", "''"))
+		b.WriteByte('\'')
+	case *SubqueryExpr:
+		switch n.Kind {
+		case SubqueryExists:
+			b.WriteString("EXISTS (")
+			b.WriteString(n.RawText)
+			b.WriteByte(')')
+		default:
+			b.WriteByte('(')
+			b.WriteString(n.RawText)
+			b.WriteByte(')')
+		}
+	case *ComparisonExpr:
+		b.WriteByte('(')
+		writeExpr(b, n.Left)
+		b.WriteByte(' ')
+		b.WriteString(n.Op)
+		b.WriteByte(' ')
+		writeExpr(b, n.Right)
+		b.WriteByte(')')
+	case *QuantifiedComparisonExpr:
+		b.WriteByte('(')
+		writeExpr(b, n.Left)
+		b.WriteByte(' ')
+		b.WriteString(n.Op)
+		b.WriteByte(' ')
+		b.WriteString(n.Quantifier)
+		b.WriteString(" (")
+		b.WriteString(n.Subquery.RawText)
+		b.WriteString("))")
+	case *BetweenExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" NOT")
+		}
+		b.WriteString(" BETWEEN ")
+		writeExpr(b, n.Lower)
+		b.WriteString(" AND ")
+		writeExpr(b, n.Upper)
+	case *InListExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" NOT")
+		}
+		b.WriteString(" IN (")
+		writeExprList(b, n.List)
+		b.WriteByte(')')
+	case *InSubqueryExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" NOT")
+		}
+		b.WriteString(" IN (")
+		b.WriteString(n.Subquery.RawText)
+		b.WriteByte(')')
+	case *LikeExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" NOT")
+		}
+		b.WriteString(" LIKE ")
+		writeExpr(b, n.Pattern)
+		if n.Escape != nil {
+			b.WriteString(" ESCAPE ")
+			writeExpr(b, n.Escape)
+		}
+	case *IsNullExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" IS NOT NULL")
+		} else {
+			b.WriteString(" IS NULL")
+		}
+	case *IsDistinctFromExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" IS NOT DISTINCT FROM ")
+		} else {
+			b.WriteString(" IS DISTINCT FROM ")
+		}
+		writeExpr(b, n.Right)
+	case *CaseExpr:
+		b.WriteString("CASE")
+		if n.Operand != nil {
+			b.WriteByte(' ')
+			writeExpr(b, n.Operand)
+		}
+		for _, w := range n.Whens {
+			b.WriteString(" WHEN ")
+			writeExpr(b, w.Cond)
+			b.WriteString(" THEN ")
+			writeExpr(b, w.Result)
+		}
+		if n.Else != nil {
+			b.WriteString(" ELSE ")
+			writeExpr(b, n.Else)
+		}
+		b.WriteString(" END")
+	case *CastExpr:
+		if n.Try {
+			b.WriteString("TRY_CAST(")
+		} else {
+			b.WriteString("CAST(")
+		}
+		writeExpr(b, n.Expr)
+		b.WriteString(" AS ")
+		b.WriteString(n.Type.String())
+		b.WriteByte(')')
+	case *ExtractExpr:
+		b.WriteString("EXTRACT(")
+		b.WriteString(n.Field)
+		b.WriteString(" FROM ")
+		writeExpr(b, n.Source)
+		b.WriteByte(')')
+	case *SubstringExpr:
+		b.WriteString("SUBSTRING(")
+		writeExpr(b, n.Source)
+		b.WriteString(" FROM ")
+		writeExpr(b, n.From)
+		if n.For != nil {
+			b.WriteString(" FOR ")
+			writeExpr(b, n.For)
+		}
+		b.WriteByte(')')
+	case *TrimExpr:
+		b.WriteString("TRIM(")
+		if n.Spec != "" {
+			b.WriteString(n.Spec)
+			b.WriteByte(' ')
+		}
+		if n.Char != nil {
+			writeExpr(b, n.Char)
+			b.WriteByte(' ')
+		}
+		if n.Spec != "" || n.Char != nil {
+			b.WriteString("FROM ")
+		}
+		writeExpr(b, n.Source)
+		b.WriteByte(')')
+	case *NormalizeExpr:
+		b.WriteString("NORMALIZE(")
+		writeExpr(b, n.Source)
+		if n.Form != "" {
+			b.WriteString(", ")
+			b.WriteString(n.Form)
+		}
+		b.WriteByte(')')
+	case *PositionExpr:
+		b.WriteString("POSITION(")
+		writeExpr(b, n.Needle)
+		b.WriteString(" IN ")
+		writeExpr(b, n.Haystack)
+		b.WriteByte(')')
+	case *GroupingExpr:
+		b.WriteString("GROUPING(")
+		for i, a := range n.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(a.String())
+		}
+		b.WriteByte(')')
+	case *ListaggExpr:
+		b.WriteString("listagg(")
+		if n.Distinct {
+			b.WriteString("DISTINCT ")
+		}
+		writeExpr(b, n.Arg)
+		if n.Separator != nil {
+			b.WriteString(", ")
+			writeExpr(b, n.Separator)
+		}
+		if n.OnOverflow == "ERROR" {
+			b.WriteString(" ON OVERFLOW ERROR")
+		} else if n.OnOverflow == "TRUNCATE" {
+			b.WriteString(" ON OVERFLOW TRUNCATE WITH COUNT")
+		}
+		b.WriteString(") WITHIN GROUP (ORDER BY ")
+		writeOrderBy(b, n.WithinGroupBy)
+		b.WriteByte(')')
+		if n.Filter != nil {
+			b.WriteString(" FILTER (WHERE ")
+			writeExpr(b, n.Filter)
+			b.WriteByte(')')
+		}
+	case *SpecialFuncExpr:
+		b.WriteString(n.Name)
+		if n.Precision >= 0 {
+			b.WriteByte('(')
+			b.WriteString(strconv.Itoa(n.Precision))
+			b.WriteByte(')')
+		}
+	case *LambdaExpr:
+		if len(n.Params) == 1 {
+			b.WriteString(n.Params[0].String())
+		} else {
+			b.WriteByte('(')
+			for i, p := range n.Params {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				b.WriteString(p.String())
+			}
+			b.WriteByte(')')
+		}
+		b.WriteString(" -> ")
+		writeExpr(b, n.Body)
+	case *FuncCall:
+		writeFuncCall(b, n)
+	default:
+		b.WriteString(fmt.Sprintf("<%T>", e))
+	}
+}
+
+func writeFuncCall(b *strings.Builder, n *FuncCall) {
+	if n.ProcessingMode != "" {
+		b.WriteString(n.ProcessingMode)
+		b.WriteByte(' ')
+	}
+	b.WriteString(n.Name.String())
+	// A measure (identifier OVER ...) has no parens.
+	if !(len(n.Args) == 0 && !n.Star && (n.Over != nil || n.OverName != nil) && n.Filter == nil) {
+		b.WriteByte('(')
+		if n.Star {
+			if n.Label != nil {
+				b.WriteString(n.Label.String())
+				b.WriteByte('.')
+			}
+			b.WriteByte('*')
+		} else {
+			if n.Distinct {
+				b.WriteString("DISTINCT ")
+			}
+			writeExprList(b, n.Args)
+			if len(n.OrderBy) > 0 {
+				b.WriteString(" ORDER BY ")
+				writeOrderBy(b, n.OrderBy)
+			}
+		}
+		b.WriteByte(')')
+	}
+	if n.Filter != nil {
+		b.WriteString(" FILTER (WHERE ")
+		writeExpr(b, n.Filter)
+		b.WriteByte(')')
+	}
+	if n.NullTreatment != "" {
+		b.WriteByte(' ')
+		b.WriteString(n.NullTreatment)
+	}
+	if n.OverName != nil {
+		b.WriteString(" OVER ")
+		b.WriteString(n.OverName.String())
+	} else if n.Over != nil {
+		b.WriteString(" OVER ")
+		writeWindowSpec(b, n.Over)
+	}
+}
+
+func writeWindowSpec(b *strings.Builder, w *WindowSpec) {
+	b.WriteByte('(')
+	parts := []string{}
+	if w.ExistingName != nil {
+		parts = append(parts, w.ExistingName.String())
+	}
+	if len(w.PartitionBy) > 0 {
+		var pb strings.Builder
+		pb.WriteString("PARTITION BY ")
+		writeExprList(&pb, w.PartitionBy)
+		parts = append(parts, pb.String())
+	}
+	if len(w.OrderBy) > 0 {
+		var ob strings.Builder
+		ob.WriteString("ORDER BY ")
+		writeOrderBy(&ob, w.OrderBy)
+		parts = append(parts, ob.String())
+	}
+	if w.Frame != nil {
+		var fb strings.Builder
+		writeFrame(&fb, w.Frame)
+		parts = append(parts, fb.String())
+	}
+	b.WriteString(strings.Join(parts, " "))
+	b.WriteByte(')')
+}
+
+func writeFrame(b *strings.Builder, f *WindowFrame) {
+	b.WriteString(f.FrameType)
+	b.WriteByte(' ')
+	if f.End != nil {
+		b.WriteString("BETWEEN ")
+		writeBound(b, f.Start)
+		b.WriteString(" AND ")
+		writeBound(b, *f.End)
+	} else {
+		writeBound(b, f.Start)
+	}
+}
+
+func writeBound(b *strings.Builder, bound WindowBound) {
+	switch bound.Kind {
+	case BoundUnboundedPreceding:
+		b.WriteString("UNBOUNDED PRECEDING")
+	case BoundUnboundedFollowing:
+		b.WriteString("UNBOUNDED FOLLOWING")
+	case BoundCurrentRow:
+		b.WriteString("CURRENT ROW")
+	case BoundPreceding:
+		writeExpr(b, bound.Value)
+		b.WriteString(" PRECEDING")
+	case BoundFollowing:
+		writeExpr(b, bound.Value)
+		b.WriteString(" FOLLOWING")
+	}
+}
+
+func writeExprList(b *strings.Builder, list []Expr) {
+	for i, e := range list {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		writeExpr(b, e)
+	}
+}
+
+func writeOrderBy(b *strings.Builder, items []SortItem) {
+	for i, it := range items {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		writeExpr(b, it.Expr)
+		if it.Ordering != "" {
+			b.WriteByte(' ')
+			b.WriteString(it.Ordering)
+		}
+		if it.NullOrder != "" {
+			b.WriteString(" NULLS ")
+			b.WriteString(it.NullOrder)
+		}
+	}
+}
+
+// TestExpr_RoundTrip parses each accepted corpus expression, renders it back to
+// SQL, and re-parses the rendering; the re-parse must succeed. This proves the
+// parse produced a structurally faithful tree (a renderer round-trip is the
+// structural gate in the absence of a reference parser / production deparse).
+func TestExpr_RoundTrip(t *testing.T) {
+	for _, expr := range exprAcceptCorpus {
+		t.Run(truncateName(expr), func(t *testing.T) {
+			node, errs := ParseExpression(expr)
+			if len(errs) != 0 {
+				t.Fatalf("first parse of %q failed: %v", expr, errs)
+			}
+			rendered := renderExpr(node)
+			_, errs2 := ParseExpression(rendered)
+			if len(errs2) != 0 {
+				t.Errorf("re-parse of rendered %q (from %q) failed: %v", rendered, expr, errs2)
+			}
+		})
+	}
+}
+
+// TestExpr_RoundTripOracle verifies the rendered form of every accepted corpus
+// expression is itself accepted by Trino — proving the render emits valid Trino
+// expression syntax. Skipped without an oracle. JSON forms are not in the corpus
+// (deferred), so every entry is expected to render to valid SQL.
+func TestExpr_RoundTripOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, expr := range exprAcceptCorpus {
+		expr := expr
+		t.Run(truncateName(expr), func(t *testing.T) {
+			node, errs := ParseExpression(expr)
+			if len(errs) != 0 {
+				t.Fatalf("parse of %q failed: %v", expr, errs)
+			}
+			rendered := renderExpr(node)
+			accepted, ok := oracleAccepts(t, o, wrapExpr(rendered))
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if !accepted {
+				t.Errorf("render produced an expression Trino rejects: %q -> %q", expr, rendered)
+			}
+		})
+	}
+}

--- a/trino/parser/expr_test.go
+++ b/trino/parser/expr_test.go
@@ -1,0 +1,380 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// This file is the correctness gate for the `expressions` DAG node
+// (expr.go + function.go + predicate.go). Following correctness-protocol.md:
+//
+//   - Layer 1 (accept/reject differential): exprAcceptCorpus and exprRejectCorpus
+//     span every primaryExpression / valueExpression / booleanExpression /
+//     predicate_ alternative of TrinoParser.g4 plus oracle-discovered negatives.
+//     TestExpr_OracleDifferential is the authoritative gate: ParseExpression's
+//     accept/reject must equal Trino 481's accept/reject of `SELECT <expr>`.
+//   - Layer 2 (structural): TestExpr_Precedence pins the parse-tree shape of the
+//     oracle-confirmed precedence facts (single non-associative predicate;
+//     ||/arithmetic/unary/AT-TIME-ZONE layering), and TestExpr_RoundTrip checks a
+//     parse → render → re-parse is stable.
+//   - Completeness: every grammar alternative appears in the corpus with its
+//     oracle-derived verdict; the per-alternative checklist is the corpus comment
+//     blocks below.
+//
+// The oracle helpers (connectOracle / oracleAccepts / truncateName) live in
+// oracle_foundation_test.go and lexer_oracle_test.go.
+
+// wrapExpr wraps a bare expression in a SELECT so the live Trino oracle (which
+// speaks the statement protocol, not the standalone-expression entry) can judge
+// it. `SELECT <expr>` reaches Trino's expression parser; a COLUMN_NOT_FOUND or
+// other semantic error still counts as syntactically ACCEPTED (the oracle keys
+// only on SYNTAX_ERROR), so bare column references like `a`, `b` are fine.
+func wrapExpr(expr string) string { return "SELECT " + expr }
+
+// exprAcceptCorpus is every expression form omni must ACCEPT, organised by the
+// grammar alternative it exercises. Each is a bare expression; the oracle
+// differential wraps it as `SELECT <expr>`.
+var exprAcceptCorpus = []string{
+	// --- literals (nullLiteral/booleanLiteral/stringLiteral/numericLiteral/binaryLiteral) ---
+	"NULL",
+	"TRUE",
+	"FALSE",
+	"'a string'",
+	"'it''s escaped'",
+	"U&'\\0041'",
+	"123",
+	"1.5",
+	"1.5e10",
+	"-3",
+	"+4",
+	"X'00ff'",
+	"?", // parameter
+
+	// --- typeConstructor (identifier string_ / DOUBLE PRECISION string_) ---
+	"DATE '2020-01-01'",
+	"TIMESTAMP '2012-10-31 01:00:00'",
+	"BIGINT '7'",
+	"json '[1,2]'",
+	"DOUBLE PRECISION '1.5'",
+
+	// --- intervalLiteral (interval rule) ---
+	"INTERVAL '1' DAY",
+	"INTERVAL '1-2' YEAR TO MONTH",
+	"INTERVAL '3' HOUR",
+	"INTERVAL -'5' MINUTE",
+	"INTERVAL '1 02:03:04' DAY TO SECOND",
+
+	// --- column reference / dereference / subscript ---
+	"a",
+	"a.b.c",
+	"a[1]",
+	"m['k'][1].f",
+	"a.b[1]",
+
+	// --- arithmetic / concat / unary (valueExpression) ---
+	"a + b - c * d / e % f",
+	"a || b || c",
+	"- - 1",
+	"-a * b",
+
+	// --- AT TIME ZONE (atTimeZone) ---
+	"ts AT TIME ZONE 'UTC'",
+	"ts AT TIME ZONE INTERVAL '1' HOUR",
+	"a * b AT TIME ZONE 'UTC'",
+
+	// --- boolean (and/or/logicalNot/predicated) ---
+	"TRUE AND FALSE OR NULL",
+	"NOT a",
+	"NOT NOT a",
+	"NOT a = b",
+	"NOT a AND b",
+
+	// --- predicates (predicate_) ---
+	"a <> b",
+	"a != b",
+	"a <= b",
+	"a >= b",
+	"a < b",
+	"a > b",
+	"a = b",
+	"a = ANY (SELECT 1)",         // quantifiedComparison
+	"a < ALL (SELECT 1)",         // quantifiedComparison
+	"a > SOME (SELECT x FROM t)", // quantifiedComparison
+	"a BETWEEN 1 AND 2",          // between
+	"a NOT BETWEEN 1 AND 2",      // between (negated)
+	"a IN (1, 2, 3)",             // inList
+	"a NOT IN (1, 2, 3)",         // inList (negated)
+	"a IN (SELECT 1)",            // inSubquery
+	"a NOT IN (SELECT 1)",        // inSubquery (negated)
+	"a LIKE 'x%'",                // like
+	"a NOT LIKE 'x%'",            // like (negated)
+	"a LIKE 'x%' ESCAPE '!'",     // like + escape
+	"a IS NULL",                  // nullPredicate
+	"a IS NOT NULL",              // nullPredicate
+	"a IS DISTINCT FROM b",       // distinctFrom
+	"a IS NOT DISTINCT FROM b",   // distinctFrom (negated)
+	"a || b = c",                 // || binds tighter than predicate (P2)
+
+	// --- constructors (rowConstructor/arrayConstructor) ---
+	"(1, 2)",
+	"(1, 2, 3)",
+	"ROW(1, 'a')",
+	"ROW(1)",
+	"ARRAY[1, 2, 3]",
+	"ARRAY[]",
+	"(1)", // parenthesizedExpression
+
+	// --- subquery / exists (subqueryExpression/exists) ---
+	"(SELECT 1)",
+	"(SELECT max(x) FROM (SELECT a AS x FROM t) s)", // nested-paren placeholder
+	"EXISTS (SELECT 1)",
+	"EXISTS (SELECT * FROM t WHERE a > 0)",
+	"EXISTS (TABLE t)",
+	"EXISTS (VALUES 1)",
+	"a IN (SELECT b FROM t WHERE c IN (1, 2))", // nested IN, depth-balanced
+
+	// --- CASE (simpleCase/searchedCase) ---
+	"CASE WHEN a > 1 THEN 'hi' ELSE 'lo' END",
+	"CASE a WHEN 1 THEN 'one' WHEN 2 THEN 'two' END",
+	"CASE WHEN a THEN 1 END",
+
+	// --- CAST / TRY_CAST (cast) ---
+	"CAST(a AS varchar)",
+	"TRY_CAST(b AS bigint)",
+	"CAST(x AS ARRAY(INTEGER))",
+	"CAST(x AS ROW(a bigint, b varchar))",
+	"CAST(x AS MAP(VARCHAR, ARRAY(INTEGER)))",
+	"CAST(x AS INTERVAL DAY TO SECOND)",
+	"CAST(ts AS timestamp) AT TIME ZONE 'UTC'",
+
+	// --- function calls (functionCall + decorators) ---
+	"count(*)",
+	"count(a)",
+	"count(DISTINCT a)",
+	"my.catalog.func(1)",
+	"\"f\"(1)",
+	"coalesce(a, b, 0)",
+	"nullif(a, b)",
+	"if(a > 0, 1, 2)",
+	"count(*) FILTER (WHERE a > 0)",
+	"count(t.*)",
+	"f(t.*)",
+	"array_agg(a ORDER BY b)",
+	"array_agg(DISTINCT a ORDER BY a)",
+	"array_agg(a ORDER BY b DESC NULLS LAST)",
+	"sum(x) OVER (PARTITION BY a ORDER BY b)",
+	"sum(x) OVER ()",
+	"sum(x) OVER w",
+	"row_number() OVER ()",
+	"lag(x, 1) IGNORE NULLS OVER (ORDER BY y)",
+	"lag(x) RESPECT NULLS OVER (ORDER BY y)",
+	"count(DISTINCT a ORDER BY a) FILTER (WHERE a > 0) OVER (PARTITION BY b)",
+	"FINAL first(x)", // processingMode
+
+	// --- window frames (frameExtent/frameBound) ---
+	"sum(x) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+	"sum(x) OVER (ORDER BY b RANGE 5 PRECEDING)",
+	"sum(x) OVER (ORDER BY b GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+	"sum(x) OVER (ORDER BY b ROWS UNBOUNDED PRECEDING)",
+	"sum(x) OVER (ROWS CURRENT ROW)",
+	"sum(x) OVER (ORDER BY b RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+	"sum(x) OVER (ORDER BY b ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)",
+	// named base window (windowSpecification existingWindowName)
+	"sum(x) OVER (w ORDER BY b)",
+	"sum(x) OVER (w PARTITION BY a)",
+	"sum(x) OVER (w ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+
+	// --- measure (identifier over) ---
+	"a OVER (ORDER BY b)",
+
+	// --- lambda ---
+	"x -> x + 1",
+	"() -> 1",
+	"(x) -> x",
+	"(k, v) -> k + v",
+	"filter(arr, x -> x > 0)",
+	"reduce(a, 0, (s, x) -> s + x, s -> s)",
+
+	// --- special built-ins (extract/substring/trim/normalize/position/grouping/listagg) ---
+	"EXTRACT(YEAR FROM a)",
+	"SUBSTRING('abc' FROM 1 FOR 2)",
+	"SUBSTRING('abc' FROM 1)",
+	"TRIM(BOTH 'x' FROM 'xax')",
+	"TRIM(LEADING FROM '  x')",
+	"TRIM('y' FROM '  x  ')",
+	"TRIM('  x  ')",
+	"TRIM('abc', 'a')",
+	"NORMALIZE('abc')",
+	"NORMALIZE('abc', NFC)",
+	"POSITION('a' IN 'abc')",
+	// SUBSTRING / POSITION are non-reserved: bare column ref + comma-arg call
+	// forms are also valid (oracle-confirmed), in addition to the special syntax.
+	"substring",
+	"position",
+	"substring('abc', 1, 2)",
+	"substring('abc', 1)",
+	"position('a', 'abc')",
+	"GROUPING(a, b)",
+	"GROUPING(a)",
+	"listagg(x, ',') WITHIN GROUP (ORDER BY x)",
+	"listagg(DISTINCT x) WITHIN GROUP (ORDER BY x)",
+	"listagg(x ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY x)",
+	"listagg(x ON OVERFLOW TRUNCATE '...' WITH COUNT) WITHIN GROUP (ORDER BY x)",
+
+	// --- specialDateTimeFunction + current* set ---
+	"CURRENT_DATE",
+	"CURRENT_TIME",
+	"CURRENT_TIME(3)",
+	"CURRENT_TIMESTAMP",
+	"CURRENT_TIMESTAMP(6)",
+	"LOCALTIME",
+	"LOCALTIMESTAMP",
+	"CURRENT_USER",
+	"CURRENT_CATALOG",
+	"CURRENT_SCHEMA",
+	"CURRENT_PATH",
+}
+
+// exprRejectCorpus is every expression form omni must REJECT, with the reason
+// each is a SYNTAX_ERROR in Trino 481 (confirmed via the oracle).
+var exprRejectCorpus = []string{
+	// incomplete operators / clauses
+	"1 +",                  // dangling binary operator
+	"a AT TIME ZONE",       // missing zone
+	"CAST(1 AS)",           // missing target type
+	"a BETWEEN 1",          // missing AND upper
+	"EXTRACT(FROM a)",      // missing field
+	"TRIM(LEADING FROM)",   // missing trim source
+	"TRIM(FROM 'x')",       // bare FROM (no spec/char) — Trino rejects despite legacy grammar
+	"NORMALIZE()",          // missing source
+	"LISTAGG(x)",           // missing WITHIN GROUP
+	"ARRAY[1, 2,",          // unterminated array
+	"CASE END",             // CASE with no WHEN
+	"CASE WHEN THEN 1 END", // WHEN with no condition
+
+	// non-associative predicate chains (oracle-confirmed P1)
+	"a = b = c",
+	"a < b < c",
+	"a IN (1) IN (2)",
+	"a IS NULL IS NULL",
+	"a BETWEEN 1 AND 2 BETWEEN 3 AND 4",
+
+	// IS variants Trino does not have
+	"a IS TRUE",
+	"a IS NOT FALSE",
+	"a IS UNKNOWN",
+
+	// reserved special-function keywords reject ordinary readings
+	"trim",              // reserved: not a bare column reference
+	"extract",           // reserved: not a bare column reference
+	"extract('a', 'b')", // EXTRACT has only the `field FROM source` form
+	"listagg('a')",      // LISTAGG requires WITHIN GROUP (ORDER BY …)
+	"grouping('a')",     // GROUPING arguments are qualifiedNames, not strings
+
+	// EXISTS requires a real subquery — no empty/expression form
+	"EXISTS ()",
+	"EXISTS (1)",
+	"EXISTS (1 + 2)",
+
+	// empty paren / subquery in scalar & IN positions
+	"()",
+	"a IN ()",
+
+	// SQL/JSON functions are the expr-json node (this node rejects them as
+	// "not yet supported" — a deliberate, node-scoped non-acceptance that the
+	// oracle differential treats specially; see TestExpr_JSONDeferred).
+}
+
+// TestExpr_AcceptCorpusParses verifies omni accepts every form in
+// exprAcceptCorpus (oracle-free completeness smoke test). The oracle differential
+// proves the verdicts actually match Trino.
+func TestExpr_AcceptCorpusParses(t *testing.T) {
+	for _, expr := range exprAcceptCorpus {
+		t.Run(truncateName(expr), func(t *testing.T) {
+			node, errs := ParseExpression(expr)
+			if len(errs) != 0 {
+				t.Errorf("ParseExpression(%q) should accept, got errors: %v", expr, errs)
+			}
+			if node == nil {
+				t.Errorf("ParseExpression(%q) returned nil node", expr)
+			}
+		})
+	}
+}
+
+// TestExpr_RejectCorpusRejected verifies omni rejects every form in
+// exprRejectCorpus (required negative coverage).
+func TestExpr_RejectCorpusRejected(t *testing.T) {
+	for _, expr := range exprRejectCorpus {
+		t.Run(truncateName(expr), func(t *testing.T) {
+			_, errs := ParseExpression(expr)
+			if len(errs) == 0 {
+				t.Errorf("ParseExpression(%q) should reject, but accepted", expr)
+			}
+		})
+	}
+}
+
+// TestExpr_OracleDifferential is the authoritative accept/reject gate: for every
+// form in both corpora, omni's ParseExpression accept/reject must equal Trino
+// 481's accept/reject of `SELECT <expr>`. Skipped when no oracle is reachable.
+func TestExpr_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+
+	check := func(t *testing.T, expr string) {
+		_, errs := ParseExpression(expr)
+		omniAccepts := len(errs) == 0
+
+		trinoAccepts, ok := oracleAccepts(t, o, wrapExpr(expr))
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH expr=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				expr, omniAccepts, errs, trinoAccepts)
+		}
+	}
+
+	t.Run("accept", func(t *testing.T) {
+		for _, expr := range exprAcceptCorpus {
+			expr := expr
+			t.Run(truncateName(expr), func(t *testing.T) { check(t, expr) })
+		}
+	})
+	t.Run("reject", func(t *testing.T) {
+		for _, expr := range exprRejectCorpus {
+			expr := expr
+			t.Run(truncateName(expr), func(t *testing.T) { check(t, expr) })
+		}
+	})
+}
+
+// TestExpr_JSONDeferred documents the node-scope boundary: the SQL/JSON
+// functions are accepted by Trino but deferred to the expr-json node, so this
+// node rejects them with a "not yet supported" diagnostic. This is a deliberate
+// non-acceptance recorded in the divergence ledger; it is NOT a Trino-disagreement
+// bug. When expr-json lands, these move into the accept corpus.
+func TestExpr_JSONDeferred(t *testing.T) {
+	jsonForms := []string{
+		"JSON_EXISTS(a, 'lax $.b')",
+		"JSON_VALUE(a, 'lax $.b')",
+		"JSON_QUERY(a, 'lax $.b')",
+		"JSON_OBJECT('k' VALUE 1)",
+		"JSON_ARRAY(1, 2)",
+	}
+	for _, expr := range jsonForms {
+		t.Run(truncateName(expr), func(t *testing.T) {
+			_, errs := ParseExpression(expr)
+			if len(errs) == 0 {
+				t.Errorf("expected %q to be rejected as not-yet-supported, but accepted", expr)
+				return
+			}
+			if !strings.Contains(errs[0].Msg, "not yet supported") {
+				t.Errorf("expected a 'not yet supported' diagnostic for %q, got: %v", expr, errs[0].Msg)
+			}
+		})
+	}
+}

--- a/trino/parser/function.go
+++ b/trino/parser/function.go
@@ -1,0 +1,1400 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `expressions` DAG node (with expr.go and
+// predicate.go): it implements the function-call, special-built-in, and
+// keyword-led primaryExpression alternatives of Trino's grammar, plus the
+// inline OVER / FILTER clauses that decorate a function call.
+//
+// Covered primaryExpression alternatives (TrinoParser.g4):
+//
+//	functionCall            : processingMode? qualifiedName LPAREN_
+//	                            (label=identifier DOT_)? ASTERISK_ RPAREN_ filter? over?
+//	                        | processingMode? qualifiedName LPAREN_
+//	                            (setQuantifier? expression (COMMA_ expression)*)?
+//	                            (ORDER_ BY_ sortItem (COMMA_ sortItem)*)? RPAREN_
+//	                            filter? (nullTreatment? over)? ;
+//	measure                 : identifier over ;
+//	lambda                  : identifier RARROW_ expression
+//	                        | LPAREN_ (identifier (COMMA_ identifier)*)? RPAREN_ RARROW_ expression ;
+//	simpleCase / searchedCase, cast (CAST/TRY_CAST), exists,
+//	position, substring, trim, normalize, extract, groupingOperation,
+//	listagg, the specialDateTimeFunction / currentUser / currentCatalog /
+//	currentSchema / currentPath set, typeConstructor (identifier string_ and
+//	DOUBLE PRECISION string_).
+//
+// The SQL/JSON functions (JSON_EXISTS/JSON_VALUE/JSON_QUERY/JSON_OBJECT/
+// JSON_ARRAY and the json-path subsystem) are the SEPARATE expr-json DAG node
+// (json.go); parsePrimaryAtom routes them here to a thin parseJSONFunction stub
+// that records a "not yet supported" error until that node lands. This keeps the
+// expressions node's writes scoped to expr/function/predicate.go.
+//
+// Oracle-confirmed reservation nuance baked into the dispatch: among the
+// special built-ins, SUBSTRING and POSITION are NON-RESERVED keywords, so beyond
+// their special syntax they also parse as a bare column reference (`substring`)
+// and as ordinary comma-argument function calls (`substring('abc', 1, 2)`,
+// `position('a', 'abc')`). TRIM and NORMALIZE are reserved but still accept an
+// ordinary comma/single-argument call shape (`trim('abc')`, `normalize('abc')`),
+// which their special parsers cover. EXTRACT, LISTAGG, and GROUPING are reserved
+// and accept ONLY their special form (`extract('a','b')`, `listagg('a')`,
+// `grouping('a')` are all SYNTAX_ERRORs). parseIdentifierOrFunction therefore
+// routes SUBSTRING/POSITION through a try-special-then-fall-back path, while the
+// reserved built-ins stay on their dedicated parsers.
+//
+// Node-scope decision B2 (file header of expr.go): a function's OVER frame may,
+// per the legacy windowFrame rule, carry the full row-pattern subsystem
+// (MEASURES / PATTERN / DEFINE / SUBSET / AFTER MATCH / INITIAL|SEEK). That
+// subsystem is the parser-match-recognize node; here OVER parses the common
+// window frame `(ROWS|RANGE|GROUPS) [BETWEEN bound AND] bound` only.
+
+// ---------------------------------------------------------------------------
+// Function-call & related node types
+// ---------------------------------------------------------------------------
+
+// FuncCall is a function invocation. Name is the (possibly qualified) function
+// name. Distinct marks the `DISTINCT` setQuantifier; Star marks the `count(*)`
+// form (with optional Label for `count(t.*)`). OrderBy carries an in-aggregate
+// `ORDER BY`; Filter, NullTreatment, and Over carry the trailing decorators.
+// ProcessingMode is "", "RUNNING", or "FINAL".
+type FuncCall struct {
+	Name           *ast.QualifiedName
+	ProcessingMode string
+	Distinct       bool
+	Star           bool            // the count(*) form
+	Label          *ast.Identifier // count(t.*) label, nil otherwise
+	Args           []Expr          // ordinary argument list (nil for the star form)
+	OrderBy        []SortItem      // in-aggregate ORDER BY, nil when absent
+	Filter         Expr            // FILTER (WHERE …) condition, nil when absent
+	NullTreatment  string          // "", "IGNORE NULLS", or "RESPECT NULLS"
+	Over           *WindowSpec     // OVER clause, nil when absent
+	OverName       *ast.Identifier // OVER windowName form, nil otherwise
+	Loc            ast.Loc
+}
+
+func (n *FuncCall) Span() ast.Loc { return n.Loc }
+func (*FuncCall) exprNode()       {}
+
+// SortItem is one `expression [ASC|DESC] [NULLS FIRST|LAST]` of an ORDER BY
+// (the sortItem rule), reused by in-aggregate ORDER BY and OVER's ORDER BY.
+type SortItem struct {
+	Expr      Expr
+	Ordering  string // "", "ASC", or "DESC"
+	NullOrder string // "", "FIRST", or "LAST"
+	Loc       ast.Loc
+}
+
+// LambdaExpr is `param -> body` or `(param, …) -> body` (the lambda
+// alternatives). Params is the (possibly empty) parameter identifier list.
+type LambdaExpr struct {
+	Params []*ast.Identifier
+	Body   Expr
+	Loc    ast.Loc
+}
+
+func (n *LambdaExpr) Span() ast.Loc { return n.Loc }
+func (*LambdaExpr) exprNode()       {}
+
+// CaseExpr is a simple or searched CASE (simpleCase / searchedCase). Operand is
+// nil for searched CASE. Else is nil when no ELSE branch.
+type CaseExpr struct {
+	Operand Expr // nil for searched CASE
+	Whens   []WhenClause
+	Else    Expr // nil when absent
+	Loc     ast.Loc
+}
+
+func (n *CaseExpr) Span() ast.Loc { return n.Loc }
+func (*CaseExpr) exprNode()       {}
+
+// WhenClause is one `WHEN condition THEN result` of a CASE expression.
+type WhenClause struct {
+	Cond   Expr
+	Result Expr
+	Loc    ast.Loc
+}
+
+// CastExpr is `CAST(expr AS type)` or `TRY_CAST(expr AS type)`. Try marks the
+// TRY_CAST spelling; Type is the parsed target type (datatypes.go).
+type CastExpr struct {
+	Try  bool
+	Expr Expr
+	Type *DataType
+	Loc  ast.Loc
+}
+
+func (n *CastExpr) Span() ast.Loc { return n.Loc }
+func (*CastExpr) exprNode()       {}
+
+// ExtractExpr is `EXTRACT(field FROM source)` (extract). Field is the unit
+// identifier (YEAR, MONTH, …) kept as source text.
+type ExtractExpr struct {
+	Field  string
+	Source Expr
+	Loc    ast.Loc
+}
+
+func (n *ExtractExpr) Span() ast.Loc { return n.Loc }
+func (*ExtractExpr) exprNode()       {}
+
+// SubstringExpr is `SUBSTRING(source FROM start [FOR length])` (the SQL-standard
+// substring spelling). Length is nil when no FOR clause.
+type SubstringExpr struct {
+	Source Expr
+	From   Expr
+	For    Expr // nil when absent
+	Loc    ast.Loc
+}
+
+func (n *SubstringExpr) Span() ast.Loc { return n.Loc }
+func (*SubstringExpr) exprNode()       {}
+
+// TrimExpr is `TRIM([spec] [char] FROM source)` or `TRIM(source, char)` (the two
+// trim spellings). Spec is "", "LEADING", "TRAILING", or "BOTH"; Char is the
+// trim character (nil when absent).
+type TrimExpr struct {
+	Spec   string
+	Char   Expr // nil when absent
+	Source Expr
+	Loc    ast.Loc
+}
+
+func (n *TrimExpr) Span() ast.Loc { return n.Loc }
+func (*TrimExpr) exprNode()       {}
+
+// NormalizeExpr is `NORMALIZE(source [, form])` (normalize). Form is "" or one
+// of NFD/NFC/NFKD/NFKC.
+type NormalizeExpr struct {
+	Source Expr
+	Form   string
+	Loc    ast.Loc
+}
+
+func (n *NormalizeExpr) Span() ast.Loc { return n.Loc }
+func (*NormalizeExpr) exprNode()       {}
+
+// PositionExpr is `POSITION(needle IN haystack)` (position).
+type PositionExpr struct {
+	Needle   Expr
+	Haystack Expr
+	Loc      ast.Loc
+}
+
+func (n *PositionExpr) Span() ast.Loc { return n.Loc }
+func (*PositionExpr) exprNode()       {}
+
+// GroupingExpr is `GROUPING( qualifiedName , … )` (groupingOperation). The
+// argument list may be empty.
+type GroupingExpr struct {
+	Args []*ast.QualifiedName
+	Loc  ast.Loc
+}
+
+func (n *GroupingExpr) Span() ast.Loc { return n.Loc }
+func (*GroupingExpr) exprNode()       {}
+
+// ListaggExpr is `LISTAGG([DISTINCT] arg [, sep] [ON OVERFLOW …]) WITHIN GROUP
+// (ORDER BY …) [FILTER (WHERE …)]` (listagg). Only the syntactic shape is
+// captured; semantics are downstream.
+type ListaggExpr struct {
+	Distinct      bool
+	Arg           Expr
+	Separator     Expr   // nil when absent
+	OnOverflow    string // "", "ERROR", or "TRUNCATE"
+	WithinGroupBy []SortItem
+	Filter        Expr // FILTER (WHERE …), nil when absent
+	Loc           ast.Loc
+}
+
+func (n *ListaggExpr) Span() ast.Loc { return n.Loc }
+func (*ListaggExpr) exprNode()       {}
+
+// SpecialFuncExpr is one of the no-argument-or-precision special functions:
+// CURRENT_DATE / CURRENT_TIME[(p)] / CURRENT_TIMESTAMP[(p)] / LOCALTIME[(p)] /
+// LOCALTIMESTAMP[(p)] / CURRENT_USER / CURRENT_CATALOG / CURRENT_SCHEMA /
+// CURRENT_PATH (specialDateTimeFunction + currentUser/Catalog/Schema/Path).
+// Name is the keyword; Precision is the optional `(INTEGER)` argument (-1 when
+// absent or not allowed).
+type SpecialFuncExpr struct {
+	Name      string
+	Precision int // -1 when absent
+	Loc       ast.Loc
+}
+
+func (n *SpecialFuncExpr) Span() ast.Loc { return n.Loc }
+func (*SpecialFuncExpr) exprNode()       {}
+
+// TypeConstructorExpr alias note: the `identifier string_` typeConstructor is
+// modelled by TypeConstructor in expr.go (parseDoublePrecisionConstructor and
+// the identifier path build it).
+
+// WindowSpec is an inline OVER `( [name] [PARTITION BY …] [ORDER BY …] [frame] )`
+// (windowSpecification). ExistingName is the referenced base window name (nil
+// when absent).
+type WindowSpec struct {
+	ExistingName *ast.Identifier
+	PartitionBy  []Expr
+	OrderBy      []SortItem
+	Frame        *WindowFrame // nil when absent
+	Loc          ast.Loc
+}
+
+// WindowFrame is the common frame `frameType [BETWEEN start AND end] | frameType
+// start` (frameExtent). FrameType is ROWS/RANGE/GROUPS. End is nil for the
+// single-bound form. The pattern-recognition frame additions are deferred to
+// parser-match-recognize (B2).
+type WindowFrame struct {
+	FrameType string
+	Start     WindowBound
+	End       *WindowBound // nil for the single-bound form
+	Loc       ast.Loc
+}
+
+// WindowBound is one frame bound (frameBound). Kind is the bound shape; Value is
+// the offset expression for the bounded forms (nil otherwise).
+type WindowBound struct {
+	Kind  WindowBoundKind
+	Value Expr // for PRECEDING/FOLLOWING with an offset
+	Loc   ast.Loc
+}
+
+// WindowBoundKind enumerates the frame-bound shapes.
+type WindowBoundKind int
+
+const (
+	// BoundUnboundedPreceding is UNBOUNDED PRECEDING.
+	BoundUnboundedPreceding WindowBoundKind = iota
+	// BoundUnboundedFollowing is UNBOUNDED FOLLOWING.
+	BoundUnboundedFollowing
+	// BoundCurrentRow is CURRENT ROW.
+	BoundCurrentRow
+	// BoundPreceding is `expr PRECEDING`.
+	BoundPreceding
+	// BoundFollowing is `expr FOLLOWING`.
+	BoundFollowing
+)
+
+// ---------------------------------------------------------------------------
+// identifier-or-function dispatch
+// ---------------------------------------------------------------------------
+
+// parseIdentifierOrFunction parses a primaryExpression that begins with an
+// identifier (or a non-reserved keyword usable as one). The cases, in the order
+// they are disambiguated:
+//
+//   - bare-identifier lambda `x -> body` (lambda);
+//   - typeConstructor `name 'string'` (an identifier immediately followed by a
+//     string literal);
+//   - measure `identifier OVER (…)` (a bare identifier followed by OVER);
+//   - function call `qualifiedName ( … )` (a name followed by '(');
+//   - otherwise a column reference / dotted name (columnReference + dereference,
+//     the dereference handled by parsePostfix on the leading ColumnRef).
+//
+// A multi-part name (a.b.c) is read as a qualifiedName so `a.b.c(1)` is a single
+// function call; a trailing function-less name yields a ColumnRef for the first
+// part with the remaining parts becoming Dereferences via parsePostfix — except
+// the qualifiedName is consumed whole when a '(' follows.
+func (p *Parser) parseIdentifierOrFunction() (Expr, error) {
+	// Bare single-identifier lambda: `x -> body`. Detected before consuming the
+	// name so the identifier becomes the sole lambda parameter.
+	if p.peekNext().Kind == tokArrow {
+		nameTok := p.advance() // the parameter identifier
+		param := identFromToken(nameTok)
+		p.advance() // consume ->
+		body, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &LambdaExpr{
+			Params: []*ast.Identifier{param},
+			Body:   body,
+			Loc:    ast.Loc{Start: param.Loc.Start, End: body.Span().End},
+		}, nil
+	}
+
+	// typeConstructor: an identifier directly followed by a string literal, e.g.
+	// `DATE '2020-01-01'`, `json '[1]'`, `bigint '7'`. A non-reserved keyword
+	// name (DATE is non-reserved) is accepted as the constructor type name.
+	if nk := p.peekNext().Kind; nk == tokString || nk == tokUnicodeString {
+		nameTok := p.advance()
+		name := identFromToken(nameTok)
+		strTok := p.advance()
+		return &TypeConstructor{
+			Name:  name.String(),
+			Value: strTok.Str,
+			Loc:   ast.Loc{Start: nameTok.Loc.Start, End: strTok.Loc.End},
+		}, nil
+	}
+
+	// measure: `identifier OVER (…)` — a bare identifier (single part) decorated
+	// with an OVER window. Only applies when OVER directly follows the name.
+	if p.peekNext().Kind == kwOVER {
+		nameTok := p.advance()
+		name := identFromToken(nameTok)
+		over, overName, err := p.parseOver()
+		if err != nil {
+			return nil, err
+		}
+		end := name.Loc.End
+		if over != nil {
+			end = over.Loc.End
+		} else if overName != nil {
+			end = overName.Loc.End
+		}
+		// Model a measure as a degenerate FuncCall carrying only the OVER (no
+		// args, no parens) so downstream consumers handle it uniformly.
+		return &FuncCall{
+			Name:     &ast.QualifiedName{Parts: []*ast.Identifier{name}, Loc: name.Loc},
+			Over:     over,
+			OverName: overName,
+			Loc:      ast.Loc{Start: name.Loc.Start, End: end},
+		}, nil
+	}
+
+	// SUBSTRING and POSITION are non-reserved keywords with BOTH a special syntax
+	// (`SUBSTRING(s FROM a [FOR b])`, `POSITION(x IN y)`) AND ordinary readings —
+	// as a bare column reference (`SELECT substring`) or a comma-argument function
+	// call (`substring('abc', 1, 2)`, `position('a', 'abc')`), all oracle-accepted.
+	// Try the special form speculatively when '(' follows; on failure fall back to
+	// the ordinary identifier/function path.
+	if (p.cur.Kind == kwSUBSTRING || p.cur.Kind == kwPOSITION) && p.peekNext().Kind == int('(') {
+		isSubstring := p.cur.Kind == kwSUBSTRING
+		cp := p.checkpoint()
+		var (
+			special Expr
+			err     error
+		)
+		if isSubstring {
+			special, err = p.parseSubstring()
+		} else {
+			special, err = p.parsePosition()
+		}
+		if err == nil {
+			return special, nil
+		}
+		// Not the special form (e.g. a comma-argument call) — rewind and parse as
+		// an ordinary function call.
+		p.restore(cp)
+	}
+
+	// Read the (possibly qualified) name. A '(' immediately after makes it a
+	// function call; otherwise it is a column reference / dotted name.
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Kind == int('(') {
+		return p.parseFunctionCall(name, "")
+	}
+	return p.columnRefFromName(name), nil
+}
+
+// columnRefFromName turns a parsed qualifiedName into a ColumnRef (first part)
+// wrapped in Dereferences for any trailing parts, so `a.b.c` (no call) becomes
+// Dereference(Dereference(ColumnRef a, b), c). This keeps the dotted-name and
+// the row-field-access readings structurally identical, matching Trino where the
+// two are resolved the same way after parsing.
+func (p *Parser) columnRefFromName(name *ast.QualifiedName) Expr {
+	var expr Expr = &ColumnRef{Name: name.Parts[0], Loc: name.Parts[0].Loc}
+	for _, part := range name.Parts[1:] {
+		expr = &Dereference{
+			Base:      expr,
+			FieldName: part,
+			Loc:       ast.Loc{Start: expr.Span().Start, End: part.Loc.End},
+		}
+	}
+	return expr
+}
+
+// parseProcessingModeFunction handles a `RUNNING`/`FINAL` processingMode prefix
+// on a function call (functionCall's processingMode?). The mode keyword has been
+// detected by the caller; the function name and arguments follow.
+func (p *Parser) parseProcessingModeFunction() (Expr, error) {
+	modeTok := p.advance() // RUNNING or FINAL
+	mode := "RUNNING"
+	if modeTok.Kind == kwFINAL {
+		mode = "FINAL"
+	}
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int('(') {
+		return nil, p.exprErrorAt("expected '(' after " + mode + " function name")
+	}
+	return p.parseFunctionCall(name, mode)
+}
+
+// parseFunctionCall parses `qualifiedName ( … ) filter? (nullTreatment? over)?`
+// (both functionCall alternatives). The opening '(' is the current token. The
+// body is either the star form `(label.)? *` or an argument list optionally
+// prefixed by a setQuantifier and suffixed by an in-aggregate `ORDER BY`.
+// processingMode is "" for the common case.
+func (p *Parser) parseFunctionCall(name *ast.QualifiedName, processingMode string) (Expr, error) {
+	p.advance() // consume '('
+
+	fc := &FuncCall{
+		Name:           name,
+		ProcessingMode: processingMode,
+		Loc:            ast.Loc{Start: name.Loc.Start},
+	}
+
+	// Star form: `*` or `label.*`.
+	if p.cur.Kind == int('*') {
+		p.advance() // consume '*'
+		fc.Star = true
+	} else if isIdentifierStart(p.cur.Kind) && p.peekNext().Kind == int('.') {
+		// Possible `label.*`. Speculate: a single identifier, a dot, then '*'.
+		cp := p.checkpoint()
+		labelTok := p.advance() // identifier
+		p.advance()             // '.'
+		if p.cur.Kind == int('*') {
+			p.advance() // consume '*'
+			fc.Star = true
+			fc.Label = identFromToken(labelTok)
+		} else {
+			p.restore(cp)
+		}
+	}
+
+	if !fc.Star {
+		// setQuantifier? expression (, expression)*
+		if p.cur.Kind == kwDISTINCT {
+			p.advance()
+			fc.Distinct = true
+		} else if p.cur.Kind == kwALL {
+			p.advance() // ALL is the default; recorded by absence of Distinct
+		}
+		if p.cur.Kind != int(')') {
+			first, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			fc.Args = append(fc.Args, first)
+			for p.cur.Kind == int(',') {
+				p.advance() // consume ','
+				next, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				fc.Args = append(fc.Args, next)
+			}
+		}
+		// in-aggregate ORDER BY sortItem (, sortItem)*
+		if p.cur.Kind == kwORDER {
+			items, err := p.parseOrderByItems()
+			if err != nil {
+				return nil, err
+			}
+			fc.OrderBy = items
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	fc.Loc.End = closeTok.Loc.End
+
+	// filter?
+	if p.cur.Kind == kwFILTER {
+		filter, end, err := p.parseFilter()
+		if err != nil {
+			return nil, err
+		}
+		fc.Filter = filter
+		fc.Loc.End = end
+	}
+
+	// (nullTreatment? over)? — nullTreatment is valid only with an OVER.
+	if nt, ok := p.peekNullTreatment(); ok {
+		fc.NullTreatment = nt
+		p.consumeNullTreatment()
+	}
+	if p.cur.Kind == kwOVER {
+		over, overName, err := p.parseOver()
+		if err != nil {
+			return nil, err
+		}
+		fc.Over = over
+		fc.OverName = overName
+		if over != nil {
+			fc.Loc.End = over.Loc.End
+		} else if overName != nil {
+			fc.Loc.End = overName.Loc.End
+		}
+	}
+
+	return fc, nil
+}
+
+// peekNullTreatment reports whether the current two tokens are an `IGNORE NULLS`
+// or `RESPECT NULLS` nullTreatment, returning its canonical spelling.
+func (p *Parser) peekNullTreatment() (string, bool) {
+	if (p.cur.Kind == kwIGNORE || p.cur.Kind == kwRESPECT) && p.peekNext().Kind == kwNULLS {
+		if p.cur.Kind == kwIGNORE {
+			return "IGNORE NULLS", true
+		}
+		return "RESPECT NULLS", true
+	}
+	return "", false
+}
+
+// consumeNullTreatment consumes a confirmed `(IGNORE|RESPECT) NULLS`.
+func (p *Parser) consumeNullTreatment() {
+	p.advance() // IGNORE or RESPECT
+	p.advance() // NULLS
+}
+
+// parseFilter parses `FILTER ( WHERE booleanExpression )` (the filter rule),
+// returning the condition and the closing-')' end offset. FILTER is the current
+// token.
+func (p *Parser) parseFilter() (Expr, int, error) {
+	p.advance() // consume FILTER
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+	if _, err := p.expect(kwWHERE); err != nil {
+		return nil, 0, err
+	}
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, 0, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+	return cond, closeTok.Loc.End, nil
+}
+
+// parseOrderByItems parses `ORDER BY sortItem (, sortItem)*` (ORDER is current).
+func (p *Parser) parseOrderByItems() ([]SortItem, error) {
+	p.advance() // consume ORDER
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	first, err := p.parseSortItem()
+	if err != nil {
+		return nil, err
+	}
+	items := []SortItem{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseSortItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, next)
+	}
+	return items, nil
+}
+
+// parseSortItem parses one `expression [ASC|DESC] [NULLS FIRST|LAST]`
+// (the sortItem rule).
+func (p *Parser) parseSortItem() (SortItem, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return SortItem{}, err
+	}
+	item := SortItem{Expr: expr, Loc: ast.Loc{Start: expr.Span().Start, End: expr.Span().End}}
+	if p.cur.Kind == kwASC || p.cur.Kind == kwDESC {
+		tok := p.advance()
+		if tok.Kind == kwASC {
+			item.Ordering = "ASC"
+		} else {
+			item.Ordering = "DESC"
+		}
+		item.Loc.End = tok.Loc.End
+	}
+	if p.cur.Kind == kwNULLS {
+		p.advance() // consume NULLS
+		switch p.cur.Kind {
+		case kwFIRST:
+			tok := p.advance()
+			item.NullOrder = "FIRST"
+			item.Loc.End = tok.Loc.End
+		case kwLAST:
+			tok := p.advance()
+			item.NullOrder = "LAST"
+			item.Loc.End = tok.Loc.End
+		default:
+			return SortItem{}, p.exprErrorAt("expected FIRST or LAST after NULLS")
+		}
+	}
+	return item, nil
+}
+
+// ---------------------------------------------------------------------------
+// OVER / window specification / window frame
+// ---------------------------------------------------------------------------
+
+// parseOver parses `OVER (windowName | ( windowSpecification ))` (the over rule).
+// It returns either a *WindowSpec (the parenthesized form) or a windowName
+// identifier (the named form); exactly one is non-nil. OVER is the current token.
+func (p *Parser) parseOver() (*WindowSpec, *ast.Identifier, error) {
+	overTok := p.advance() // consume OVER
+	if p.cur.Kind == int('(') {
+		spec, err := p.parseWindowSpecification(overTok.Loc.Start)
+		if err != nil {
+			return nil, nil, err
+		}
+		return spec, nil, nil
+	}
+	// Named window: OVER windowName.
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, name, nil
+}
+
+// parseWindowSpecification parses `( [existingName] [PARTITION BY expr…]
+// [ORDER BY sortItem…] [windowFrame] )` (windowSpecification). The opening '('
+// is the current token; startOffset is the OVER keyword's offset so the span
+// covers `OVER ( … )`.
+func (p *Parser) parseWindowSpecification(startOffset int) (*WindowSpec, error) {
+	p.advance() // consume '('
+	spec := &WindowSpec{Loc: ast.Loc{Start: startOffset}}
+
+	// Optional existing window name: a leading identifier that is NOT the start
+	// of PARTITION/ORDER/a frame keyword or ')'.
+	if isIdentifierStart(p.cur.Kind) && p.cur.Kind != kwPARTITION && p.cur.Kind != kwORDER &&
+		!isFrameTypeKeyword(p.cur.Kind) {
+		spec.ExistingName = identFromToken(p.advance())
+	}
+
+	if p.cur.Kind == kwPARTITION {
+		p.advance() // consume PARTITION
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		first, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		spec.PartitionBy = append(spec.PartitionBy, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			spec.PartitionBy = append(spec.PartitionBy, next)
+		}
+	}
+
+	if p.cur.Kind == kwORDER {
+		items, err := p.parseOrderByItems()
+		if err != nil {
+			return nil, err
+		}
+		spec.OrderBy = items
+	}
+
+	if isFrameTypeKeyword(p.cur.Kind) {
+		frame, err := p.parseWindowFrame()
+		if err != nil {
+			return nil, err
+		}
+		spec.Frame = frame
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	spec.Loc.End = closeTok.Loc.End
+	return spec, nil
+}
+
+// isFrameTypeKeyword reports whether kind is a window-frame type keyword
+// (ROWS / RANGE / GROUPS).
+func isFrameTypeKeyword(kind TokenKind) bool {
+	return kind == kwROWS || kind == kwRANGE || kind == kwGROUPS
+}
+
+// parseWindowFrame parses the common frame `frameType (BETWEEN start AND end |
+// start)` (frameExtent + frameBound). The pattern-recognition frame additions
+// (MEASURES/PATTERN/DEFINE/…) are deferred to parser-match-recognize (B2); this
+// node implements only the standard frame.
+func (p *Parser) parseWindowFrame() (*WindowFrame, error) {
+	typeTok := p.advance() // ROWS / RANGE / GROUPS
+	frame := &WindowFrame{
+		FrameType: typeTok.Str,
+		Loc:       ast.Loc{Start: typeTok.Loc.Start},
+	}
+	if p.cur.Kind == kwBETWEEN {
+		p.advance() // consume BETWEEN
+		start, err := p.parseFrameBound()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwAND); err != nil {
+			return nil, err
+		}
+		end, err := p.parseFrameBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.Start = start
+		frame.End = &end
+		frame.Loc.End = end.Loc.End
+		return frame, nil
+	}
+	start, err := p.parseFrameBound()
+	if err != nil {
+		return nil, err
+	}
+	frame.Start = start
+	frame.Loc.End = start.Loc.End
+	return frame, nil
+}
+
+// parseFrameBound parses one `UNBOUNDED PRECEDING | UNBOUNDED FOLLOWING |
+// CURRENT ROW | expr (PRECEDING|FOLLOWING)` (frameBound).
+func (p *Parser) parseFrameBound() (WindowBound, error) {
+	switch p.cur.Kind {
+	case kwUNBOUNDED:
+		unbTok := p.advance() // consume UNBOUNDED
+		switch p.cur.Kind {
+		case kwPRECEDING:
+			tok := p.advance()
+			return WindowBound{Kind: BoundUnboundedPreceding, Loc: ast.Loc{Start: unbTok.Loc.Start, End: tok.Loc.End}}, nil
+		case kwFOLLOWING:
+			tok := p.advance()
+			return WindowBound{Kind: BoundUnboundedFollowing, Loc: ast.Loc{Start: unbTok.Loc.Start, End: tok.Loc.End}}, nil
+		default:
+			return WindowBound{}, p.exprErrorAt("expected PRECEDING or FOLLOWING after UNBOUNDED")
+		}
+	case kwCURRENT:
+		curTok := p.advance() // consume CURRENT
+		rowTok, err := p.expect(kwROW)
+		if err != nil {
+			return WindowBound{}, err
+		}
+		return WindowBound{Kind: BoundCurrentRow, Loc: ast.Loc{Start: curTok.Loc.Start, End: rowTok.Loc.End}}, nil
+	default:
+		expr, err := p.parseExpr()
+		if err != nil {
+			return WindowBound{}, err
+		}
+		switch p.cur.Kind {
+		case kwPRECEDING:
+			tok := p.advance()
+			return WindowBound{Kind: BoundPreceding, Value: expr, Loc: ast.Loc{Start: expr.Span().Start, End: tok.Loc.End}}, nil
+		case kwFOLLOWING:
+			tok := p.advance()
+			return WindowBound{Kind: BoundFollowing, Value: expr, Loc: ast.Loc{Start: expr.Span().Start, End: tok.Loc.End}}, nil
+		default:
+			return WindowBound{}, p.exprErrorAt("expected PRECEDING or FOLLOWING in frame bound")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// keyword-led primaryExpression atoms
+// ---------------------------------------------------------------------------
+
+// parseCaseExpr parses a simple `CASE operand WHEN … END` or searched
+// `CASE WHEN … END` (simpleCase / searchedCase). At least one WHEN is required.
+func (p *Parser) parseCaseExpr() (Expr, error) {
+	caseTok := p.advance() // consume CASE
+	ce := &CaseExpr{Loc: ast.Loc{Start: caseTok.Loc.Start}}
+
+	// Simple CASE has an operand expression before the first WHEN.
+	if p.cur.Kind != kwWHEN {
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Operand = operand
+	}
+
+	for p.cur.Kind == kwWHEN {
+		whenTok := p.advance() // consume WHEN
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		result, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Whens = append(ce.Whens, WhenClause{
+			Cond:   cond,
+			Result: result,
+			Loc:    ast.Loc{Start: whenTok.Loc.Start, End: result.Span().End},
+		})
+	}
+	if len(ce.Whens) == 0 {
+		return nil, p.exprErrorAt("expected WHEN in CASE expression")
+	}
+
+	if p.cur.Kind == kwELSE {
+		p.advance() // consume ELSE
+		elseExpr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Else = elseExpr
+	}
+
+	endTok, err := p.expect(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	ce.Loc.End = endTok.Loc.End
+	return ce, nil
+}
+
+// parseCast parses `CAST(expr AS type)` or `TRY_CAST(expr AS type)` (cast).
+func (p *Parser) parseCast() (Expr, error) {
+	castTok := p.advance() // CAST or TRY_CAST
+	try := castTok.Kind == kwTRY_CAST
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	typ, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &CastExpr{
+		Try:  try,
+		Expr: expr,
+		Type: typ,
+		Loc:  ast.Loc{Start: castTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseExists parses `EXISTS ( query )` (exists). The subquery is a raw-text
+// placeholder (B1). EXISTS strictly requires a query — `EXISTS ()`, `EXISTS (1)`,
+// `EXISTS (1 + 2)` are SYNTAX_ERRORs in Trino 481 (EXISTS has no expression
+// form), so the '(' must be followed by a query-starting token (SELECT / WITH /
+// TABLE / VALUES); otherwise it is rejected here.
+func (p *Parser) parseExists() (Expr, error) {
+	existsTok := p.advance() // consume EXISTS
+	openTok, err := p.expect(int('('))
+	if err != nil {
+		return nil, err
+	}
+	if !p.startsQuery() {
+		return nil, p.exprErrorAt("EXISTS requires a subquery")
+	}
+	subq, err := p.parseSubqueryPlaceholder(openTok.Loc.Start, SubqueryExists)
+	if err != nil {
+		return nil, err
+	}
+	subq.Loc.Start = existsTok.Loc.Start
+	return subq, nil
+}
+
+// parseExtract parses `EXTRACT( field FROM source )` (extract). field is an
+// identifier (YEAR, MONTH, TIMEZONE_HOUR, …) kept as source text.
+func (p *Parser) parseExtract() (Expr, error) {
+	extractTok := p.advance() // consume EXTRACT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	field, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	source, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ExtractExpr{
+		Field:  field.String(),
+		Source: source,
+		Loc:    ast.Loc{Start: extractTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseSubstring parses `SUBSTRING( source FROM start (FOR length)? )` (the
+// SQL-standard substring spelling). SUBSTRING is a NON-RESERVED keyword, so the
+// comma-argument form `substring(s, a, b)` and the bare column reference
+// `substring` are also valid (oracle-confirmed) and are handled by
+// parseIdentifierOrFunction, which tries this special parser first and falls back
+// to the ordinary identifier/function reading when the FROM form does not match.
+func (p *Parser) parseSubstring() (Expr, error) {
+	subTok := p.advance() // consume SUBSTRING
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	source, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	from, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	se := &SubstringExpr{Source: source, From: from, Loc: ast.Loc{Start: subTok.Loc.Start}}
+	if p.cur.Kind == kwFOR {
+		p.advance() // consume FOR
+		length, err := p.parseValueExpr()
+		if err != nil {
+			return nil, err
+		}
+		se.For = length
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	se.Loc.End = closeTok.Loc.End
+	return se, nil
+}
+
+// parseTrim parses the two TRIM spellings: `TRIM( [spec] [char] FROM source )`
+// and `TRIM( source , char )` (trim). The first reading is tried, and on failure
+// the parser rewinds and tries the comma form.
+//
+// Oracle-confirmed divergence (D-TRIM): a bare `TRIM(FROM source)` — FROM with
+// neither a trims-specification nor a trim-character before it — is a
+// SYNTAX_ERROR in Trino 481, even though the legacy grammar's
+// `(trimsSpecification? trimChar? FROM)?` permits it. FROM is accepted only when
+// preceded by a spec and/or a char (TRIM(BOTH FROM x), TRIM('y' FROM x),
+// TRIM(BOTH 'y' FROM x)); TRIM(x) and TRIM(x, y) remain valid. See tryTrimFromForm.
+func (p *Parser) parseTrim() (Expr, error) {
+	trimTok := p.advance() // consume TRIM
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// Reading 1 — `[spec] [char] FROM source`.
+	cp := p.checkpoint()
+	if te, ok := p.tryTrimFromForm(trimTok.Loc.Start); ok {
+		return te, nil
+	}
+	p.restore(cp)
+
+	// Reading 2 — `source , char`.
+	source, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+	char, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &TrimExpr{
+		Char:   char,
+		Source: source,
+		Loc:    ast.Loc{Start: trimTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// tryTrimFromForm attempts the `[spec] [char] FROM source` TRIM reading after
+// the opening '(' has been consumed, returning ok=false (cursor left for the
+// caller's restore) when it does not fit. A bare `TRIM(source)` with no FROM and
+// no comma also matches here (spec/char absent, the whole thing is the source)
+// — Trino accepts `TRIM(x)`.
+func (p *Parser) tryTrimFromForm(start int) (Expr, bool) {
+	te := &TrimExpr{Loc: ast.Loc{Start: start}}
+
+	// Optional trims specification.
+	switch p.cur.Kind {
+	case kwLEADING:
+		p.advance()
+		te.Spec = "LEADING"
+	case kwTRAILING:
+		p.advance()
+		te.Spec = "TRAILING"
+	case kwBOTH:
+		p.advance()
+		te.Spec = "BOTH"
+	}
+
+	// No spec present. A bare `FROM source` (no spec, no char) is a SYNTAX_ERROR
+	// in Trino 481 — `TRIM(FROM x)` is rejected even though the legacy grammar's
+	// `(trimsSpecification? trimChar? FROM)?` permits it (oracle-confirmed
+	// divergence). So FROM here is valid only after a char: parse a value
+	// expression first and require it to be followed by FROM or ')'.
+	if te.Spec == "" {
+		if p.cur.Kind == kwFROM {
+			// Bare FROM with nothing before it — reject this reading (and, since
+			// the comma form also cannot start with FROM, the whole TRIM is an
+			// error, which the caller surfaces).
+			return nil, false
+		}
+		first, err := p.parseValueExpr()
+		if err != nil {
+			return nil, false
+		}
+		switch p.cur.Kind {
+		case int(')'):
+			// TRIM(source)
+			closeTok := p.advance()
+			te.Source = first
+			te.Loc.End = closeTok.Loc.End
+			return te, true
+		case kwFROM:
+			// TRIM(char FROM source)
+			p.advance() // consume FROM
+			source, ok := p.tryValueExprThenClose()
+			if !ok {
+				return nil, false
+			}
+			te.Char = first
+			te.Source = source.expr
+			te.Loc.End = source.end
+			return te, true
+		default:
+			// A comma (the second TRIM form) or anything else — not this reading.
+			return nil, false
+		}
+	}
+
+	// With a spec present, an optional char then a required FROM, then source.
+	if p.cur.Kind != kwFROM {
+		char, err := p.parseValueExpr()
+		if err != nil {
+			return nil, false
+		}
+		te.Char = char
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, false
+	}
+	source, ok := p.tryValueExprThenClose()
+	if !ok {
+		return nil, false
+	}
+	te.Source = source.expr
+	te.Loc.End = source.end
+	return te, true
+}
+
+// valueExprAndEnd bundles a parsed value expression with the closing-')' end
+// offset, for the trim helper.
+type valueExprAndEnd struct {
+	expr Expr
+	end  int
+}
+
+// tryValueExprThenClose parses a value expression followed by a required ')',
+// returning ok=false (no error surfaced) when either step fails so the trim
+// reading can be abandoned.
+func (p *Parser) tryValueExprThenClose() (valueExprAndEnd, bool) {
+	expr, err := p.parseValueExpr()
+	if err != nil {
+		return valueExprAndEnd{}, false
+	}
+	if p.cur.Kind != int(')') {
+		return valueExprAndEnd{}, false
+	}
+	closeTok := p.advance()
+	return valueExprAndEnd{expr: expr, end: closeTok.Loc.End}, true
+}
+
+// parseNormalize parses `NORMALIZE( source (, form)? )` (normalize). form is one
+// of NFD/NFC/NFKD/NFKC.
+func (p *Parser) parseNormalize() (Expr, error) {
+	normTok := p.advance() // consume NORMALIZE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	source, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	ne := &NormalizeExpr{Source: source, Loc: ast.Loc{Start: normTok.Loc.Start}}
+	if p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		form, ok := normalFormText(p.cur.Kind)
+		if !ok {
+			return nil, p.exprErrorAt("expected normal form (NFD/NFC/NFKD/NFKC)")
+		}
+		p.advance()
+		ne.Form = form
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ne.Loc.End = closeTok.Loc.End
+	return ne, nil
+}
+
+// normalFormText maps a normal-form keyword kind to its spelling.
+func normalFormText(kind TokenKind) (string, bool) {
+	switch kind {
+	case kwNFD:
+		return "NFD", true
+	case kwNFC:
+		return "NFC", true
+	case kwNFKD:
+		return "NFKD", true
+	case kwNFKC:
+		return "NFKC", true
+	default:
+		return "", false
+	}
+}
+
+// parsePosition parses `POSITION( needle IN haystack )` (position). POSITION is
+// a NON-RESERVED keyword, so the comma-argument form `position('a', 'abc')` and
+// the bare column reference `position` are also valid (oracle-confirmed); like
+// SUBSTRING, parseIdentifierOrFunction tries this special parser first and falls
+// back to the ordinary reading when the IN form does not match.
+func (p *Parser) parsePosition() (Expr, error) {
+	posTok := p.advance() // consume POSITION
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	needle, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+	haystack, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &PositionExpr{
+		Needle:   needle,
+		Haystack: haystack,
+		Loc:      ast.Loc{Start: posTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseGrouping parses `GROUPING( (qualifiedName (, qualifiedName)*)? )`
+// (groupingOperation). The argument list may be empty.
+func (p *Parser) parseGrouping() (Expr, error) {
+	groupingTok := p.advance() // consume GROUPING
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	ge := &GroupingExpr{Loc: ast.Loc{Start: groupingTok.Loc.Start}}
+	if p.cur.Kind != int(')') {
+		first, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, err
+		}
+		ge.Args = append(ge.Args, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseQualifiedName()
+			if err != nil {
+				return nil, err
+			}
+			ge.Args = append(ge.Args, next)
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ge.Loc.End = closeTok.Loc.End
+	return ge, nil
+}
+
+// parseListagg parses `LISTAGG( [DISTINCT] arg (, sep)? (ON OVERFLOW
+// listAggOverflowBehavior)? ) WITHIN GROUP ( ORDER BY sortItem (, sortItem)* )
+// filter?` (listagg). The mandatory WITHIN GROUP (ORDER BY …) distinguishes
+// LISTAGG from an ordinary function call.
+func (p *Parser) parseListagg() (Expr, error) {
+	listaggTok := p.advance() // consume LISTAGG
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	la := &ListaggExpr{Loc: ast.Loc{Start: listaggTok.Loc.Start}}
+
+	if p.cur.Kind == kwDISTINCT {
+		p.advance()
+		la.Distinct = true
+	} else if p.cur.Kind == kwALL {
+		p.advance() // ALL is the default
+	}
+
+	arg, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	la.Arg = arg
+
+	if p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		sep, err := p.parseStringLiteral()
+		if err != nil {
+			return nil, err
+		}
+		la.Separator = sep
+	}
+
+	if p.cur.Kind == kwON {
+		p.advance() // consume ON
+		if _, err := p.expect(kwOVERFLOW); err != nil {
+			return nil, err
+		}
+		switch p.cur.Kind {
+		case kwERROR:
+			p.advance()
+			la.OnOverflow = "ERROR"
+		case kwTRUNCATE:
+			p.advance()
+			la.OnOverflow = "TRUNCATE"
+			// Optional truncation filler string.
+			if p.cur.Kind == tokString || p.cur.Kind == tokUnicodeString {
+				p.advance()
+			}
+			// listaggCountIndication: (WITH | WITHOUT) COUNT.
+			if p.cur.Kind == kwWITH || p.cur.Kind == kwWITHOUT {
+				p.advance()
+				if _, err := p.expect(kwCOUNT); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			return nil, p.exprErrorAt("expected ERROR or TRUNCATE after ON OVERFLOW")
+		}
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	// Mandatory WITHIN GROUP ( ORDER BY … ).
+	if _, err := p.expect(kwWITHIN); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwGROUP); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	items, err := p.parseOrderByItems()
+	if err != nil {
+		return nil, err
+	}
+	la.WithinGroupBy = items
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	la.Loc.End = closeTok.Loc.End
+
+	// Optional FILTER.
+	if p.cur.Kind == kwFILTER {
+		filter, end, err := p.parseFilter()
+		if err != nil {
+			return nil, err
+		}
+		la.Filter = filter
+		la.Loc.End = end
+	}
+	return la, nil
+}
+
+// parseSpecialDateTimeFunction parses the no-parenthesis / precision-only special
+// functions: CURRENT_DATE, CURRENT_TIME[(p)], CURRENT_TIMESTAMP[(p)],
+// LOCALTIME[(p)], LOCALTIMESTAMP[(p)], CURRENT_USER, CURRENT_CATALOG,
+// CURRENT_SCHEMA, CURRENT_PATH (specialDateTimeFunction + the current* set).
+// Only the four time functions accept an optional `(INTEGER)` precision.
+func (p *Parser) parseSpecialDateTimeFunction() (Expr, error) {
+	tok := p.advance()
+	sf := &SpecialFuncExpr{Name: tok.Str, Precision: -1, Loc: tok.Loc}
+
+	if allowsPrecision(tok.Kind) && p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		if p.cur.Kind != tokInteger {
+			return nil, p.exprErrorAt("expected integer precision")
+		}
+		precTok := p.advance()
+		sf.Precision = int(precTok.Ival)
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		sf.Loc.End = closeTok.Loc.End
+	}
+	return sf, nil
+}
+
+// allowsPrecision reports whether a special date-time keyword accepts an optional
+// `(precision)` argument (CURRENT_TIME / CURRENT_TIMESTAMP / LOCALTIME /
+// LOCALTIMESTAMP). CURRENT_DATE and the current-user/catalog/schema/path set do
+// not.
+func allowsPrecision(kind TokenKind) bool {
+	switch kind {
+	case kwCURRENT_TIME, kwCURRENT_TIMESTAMP, kwLOCALTIME, kwLOCALTIMESTAMP:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseDoublePrecisionConstructor parses `DOUBLE PRECISION 'string'`
+// (the DOUBLE PRECISION typeConstructor). The caller confirmed DOUBLE then
+// PRECISION; a string literal must follow.
+func (p *Parser) parseDoublePrecisionConstructor() (Expr, error) {
+	doubleTok := p.advance() // DOUBLE
+	p.advance()              // PRECISION
+	if p.cur.Kind != tokString && p.cur.Kind != tokUnicodeString {
+		return nil, p.exprErrorAt("expected string literal after DOUBLE PRECISION")
+	}
+	strTok := p.advance()
+	return &TypeConstructor{
+		Name:  "DOUBLE PRECISION",
+		Value: strTok.Str,
+		Loc:   ast.Loc{Start: doubleTok.Loc.Start, End: strTok.Loc.End},
+	}, nil
+}
+
+// parseJSONFunction is the dispatch stub for the SQL/JSON functions
+// (JSON_EXISTS / JSON_VALUE / JSON_QUERY / JSON_OBJECT / JSON_ARRAY). The bodies,
+// and the json-path subsystem, are the SEPARATE expr-json DAG node (json.go);
+// until it lands, this records a "not yet supported" error so callers get an
+// actionable diagnostic rather than a wrong parse. The keyword is the current
+// token.
+func (p *Parser) parseJSONFunction() (Expr, error) {
+	tok := p.cur
+	name := tok.Str
+	if name == "" {
+		name = TokenName(tok.Kind)
+	}
+	return nil, &ParseError{
+		Loc: tok.Loc,
+		Msg: "SQL/JSON function " + name + " is not yet supported",
+	}
+}

--- a/trino/parser/predicate.go
+++ b/trino/parser/predicate.go
@@ -1,0 +1,412 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `expressions` DAG node (with expr.go and
+// function.go): it implements the predicate suffix of Trino's `booleanExpression`
+// — the `predicate_` rule — that attaches to a valueExpression to form a
+// `predicated` booleanExpression.
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	predicate_
+//	    : comparisonOperator right=valueExpression                            # comparison
+//	    | comparisonOperator comparisonQuantifier LPAREN_ query RPAREN_        # quantifiedComparison
+//	    | NOT? BETWEEN_ lower=valueExpression AND_ upper=valueExpression       # between
+//	    | NOT? IN_ LPAREN_ expression (COMMA_ expression)* RPAREN_             # inList
+//	    | NOT? IN_ LPAREN_ query RPAREN_                                       # inSubquery
+//	    | NOT? LIKE_ pattern=valueExpression (ESCAPE_ escape=valueExpression)? # like
+//	    | IS_ NOT_? NULL_                                                      # nullPredicate
+//	    | IS_ NOT_? DISTINCT_ FROM_ right=valueExpression                     # distinctFrom
+//	    ;
+//	comparisonOperator  : EQ_ | NEQ_ | LT_ | LTE_ | GT_ | GTE_ ;
+//	comparisonQuantifier: ALL_ | SOME_ | ANY_ ;
+//
+// Structural nuance (quantifiedComparison vs ANY/SOME/ALL as a function): in
+// Trino 481 ANY/SOME/ALL are also non-reserved function NAMES, so after a
+// comparison operator `<op> ANY ( … )` is a quantifiedComparison only when the
+// parenthesized content is a query; otherwise `ANY(1)`, `ANY(1, 2)`, `ANY()` are
+// ordinary function calls forming the comparison's right-hand value. This node
+// builds a QuantifiedComparisonExpr with a raw-text subquery placeholder for the
+// `<op> (ANY|SOME|ALL) ( … )` shape regardless of the inner content; the
+// accept/reject verdict matches Trino in every probed case (the function-call and
+// subquery readings are both accepted), and distinguishing the two structurally
+// needs the query/expression decision that belongs to parser-select. Recorded as
+// a flagged structural boundary, not an accept/reject divergence.
+//
+// Oracle-confirmed behavior (Trino 481): the predicate is NON-ASSOCIATIVE —
+// exactly one predicate may follow a valueExpression. `a = b = c`, `a < b < c`,
+// `a IN (1) IN (2)`, `a IS NULL IS NULL`, `a BETWEEN 1 AND 2 BETWEEN 3 AND 4` are
+// all SYNTAX_ERRORs. parsePredicateSuffix therefore consumes at most one
+// predicate and never loops; a trailing predicate operator is left for the
+// caller, where it surfaces as the syntax error Trino reports. Note Trino has NO
+// `IS [NOT] TRUE/FALSE/UNKNOWN` predicate (those spellings are rejected) — only
+// IS [NOT] NULL and IS [NOT] DISTINCT FROM.
+
+// ComparisonExpr is `left <op> right` where <op> is one of = <> < <= > >=
+// (the comparison predicate). Op holds the source operator spelling.
+type ComparisonExpr struct {
+	Op    string
+	Left  Expr
+	Right Expr
+	Loc   ast.Loc
+}
+
+func (n *ComparisonExpr) Span() ast.Loc { return n.Loc }
+func (*ComparisonExpr) exprNode()       {}
+
+// QuantifiedComparisonExpr is `left <op> (ALL|SOME|ANY) ( query )`
+// (quantifiedComparison). Subquery is the raw-text placeholder (B1 in expr.go).
+type QuantifiedComparisonExpr struct {
+	Op         string // comparison operator spelling
+	Quantifier string // "ALL", "SOME", or "ANY"
+	Left       Expr
+	Subquery   *SubqueryExpr
+	Loc        ast.Loc
+}
+
+func (n *QuantifiedComparisonExpr) Span() ast.Loc { return n.Loc }
+func (*QuantifiedComparisonExpr) exprNode()       {}
+
+// BetweenExpr is `value [NOT] BETWEEN lower AND upper` (the between predicate).
+type BetweenExpr struct {
+	Not   bool
+	Value Expr
+	Lower Expr
+	Upper Expr
+	Loc   ast.Loc
+}
+
+func (n *BetweenExpr) Span() ast.Loc { return n.Loc }
+func (*BetweenExpr) exprNode()       {}
+
+// InListExpr is `value [NOT] IN ( e , … )` (the inList predicate): membership
+// against an explicit value list.
+type InListExpr struct {
+	Not   bool
+	Value Expr
+	List  []Expr
+	Loc   ast.Loc
+}
+
+func (n *InListExpr) Span() ast.Loc { return n.Loc }
+func (*InListExpr) exprNode()       {}
+
+// InSubqueryExpr is `value [NOT] IN ( query )` (the inSubquery predicate).
+// Subquery is the raw-text placeholder (B1 in expr.go).
+type InSubqueryExpr struct {
+	Not      bool
+	Value    Expr
+	Subquery *SubqueryExpr
+	Loc      ast.Loc
+}
+
+func (n *InSubqueryExpr) Span() ast.Loc { return n.Loc }
+func (*InSubqueryExpr) exprNode()       {}
+
+// LikeExpr is `value [NOT] LIKE pattern [ESCAPE escape]` (the like predicate).
+type LikeExpr struct {
+	Not     bool
+	Value   Expr
+	Pattern Expr
+	Escape  Expr // nil when no ESCAPE clause
+	Loc     ast.Loc
+}
+
+func (n *LikeExpr) Span() ast.Loc { return n.Loc }
+func (*LikeExpr) exprNode()       {}
+
+// IsNullExpr is `value IS [NOT] NULL` (the nullPredicate).
+type IsNullExpr struct {
+	Not   bool
+	Value Expr
+	Loc   ast.Loc
+}
+
+func (n *IsNullExpr) Span() ast.Loc { return n.Loc }
+func (*IsNullExpr) exprNode()       {}
+
+// IsDistinctFromExpr is `value IS [NOT] DISTINCT FROM right` (the distinctFrom
+// predicate): null-safe (in)equality.
+type IsDistinctFromExpr struct {
+	Not   bool
+	Value Expr
+	Right Expr
+	Loc   ast.Loc
+}
+
+func (n *IsDistinctFromExpr) Span() ast.Loc { return n.Loc }
+func (*IsDistinctFromExpr) exprNode()       {}
+
+// parsePredicateSuffix attaches at most one predicate to the already-parsed
+// valueExpression `left`, returning `left` unchanged when no predicate follows.
+// It is the `predicate_?` of the predicated rule; the non-associativity (one
+// predicate only, never a loop) is the oracle-confirmed Trino behavior.
+//
+// Dispatch is on the leading token of each predicate alternative:
+//   - a comparison operator (= <> < <= > >=) → comparison or, if a quantifier
+//     follows, quantifiedComparison;
+//   - NOT (followed by BETWEEN | IN | LIKE) or a bare BETWEEN/IN/LIKE;
+//   - IS (→ NULL or DISTINCT FROM).
+func (p *Parser) parsePredicateSuffix(left Expr) (Expr, error) {
+	switch p.cur.Kind {
+	case int('='), tokNotEq, int('<'), tokLessEq, int('>'), tokGreaterEq:
+		return p.parseComparison(left)
+	case kwNOT:
+		// NOT here introduces a negated BETWEEN/IN/LIKE predicate. A NOT that
+		// begins a boolean (logicalNot) was already handled in parseNot before
+		// the value expression, so reaching NOT in predicate position means a
+		// negated predicate keyword must follow.
+		switch p.peekNext().Kind {
+		case kwBETWEEN, kwIN, kwLIKE:
+			notTok := p.advance() // consume NOT
+			return p.parseNegatablePredicate(left, true, notTok.Loc)
+		default:
+			// Not a predicate NOT (e.g. `a NOT b` is malformed); leave it for the
+			// caller, which reports the error.
+			return left, nil
+		}
+	case kwBETWEEN, kwIN, kwLIKE:
+		return p.parseNegatablePredicate(left, false, ast.NoLoc())
+	case kwIS:
+		return p.parseIsPredicate(left)
+	default:
+		return left, nil
+	}
+}
+
+// parseComparison parses `<op> right` or `<op> (ALL|SOME|ANY) ( query )` after a
+// comparison operator on `left`. The quantified form is recognised when the
+// token after the operator is a comparison quantifier directly followed by '('.
+func (p *Parser) parseComparison(left Expr) (Expr, error) {
+	opTok := p.advance()
+	op := comparisonOpText(opTok)
+
+	if q, ok := comparisonQuantifierText(p.cur.Kind); ok && p.peekNext().Kind == int('(') {
+		p.advance()            // consume the quantifier
+		openTok := p.advance() // consume '('
+		subq, err := p.parseSubqueryPlaceholder(openTok.Loc.Start, SubqueryQuantified)
+		if err != nil {
+			return nil, err
+		}
+		return &QuantifiedComparisonExpr{
+			Op:         op,
+			Quantifier: q,
+			Left:       left,
+			Subquery:   subq,
+			Loc:        ast.Loc{Start: left.Span().Start, End: subq.Loc.End},
+		}, nil
+	}
+
+	right, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ComparisonExpr{
+		Op:    op,
+		Left:  left,
+		Right: right,
+		Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+	}, nil
+}
+
+// parseNegatablePredicate parses a BETWEEN / IN / LIKE predicate (already known
+// to be the current token) on `left`, with `not` set by the caller when a
+// preceding NOT was consumed. notLoc is the NOT token's Loc (valid only when not
+// is true) so the result span starts at NOT.
+func (p *Parser) parseNegatablePredicate(left Expr, not bool, notLoc ast.Loc) (Expr, error) {
+	start := left.Span().Start
+	if not {
+		start = notLoc.Start
+	}
+	switch p.cur.Kind {
+	case kwBETWEEN:
+		return p.parseBetween(left, not, start)
+	case kwIN:
+		return p.parseIn(left, not, start)
+	case kwLIKE:
+		return p.parseLike(left, not, start)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseBetween parses `BETWEEN lower AND upper` (BETWEEN already current). The
+// AND here is the BETWEEN separator, not a boolean conjunction, so both bounds
+// are valueExpressions (not full booleanExpressions).
+func (p *Parser) parseBetween(left Expr, not bool, start int) (Expr, error) {
+	p.advance() // consume BETWEEN
+	lower, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAND); err != nil {
+		return nil, err
+	}
+	upper, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &BetweenExpr{
+		Not:   not,
+		Value: left,
+		Lower: lower,
+		Upper: upper,
+		Loc:   ast.Loc{Start: start, End: upper.Span().End},
+	}, nil
+}
+
+// parseIn parses `IN ( … )` (IN already current): either an explicit value list
+// `IN ( e , … )` or a subquery `IN ( query )`, disambiguated by whether the
+// token after '(' begins a query. The list form requires at least one element.
+func (p *Parser) parseIn(left Expr, not bool, start int) (Expr, error) {
+	p.advance() // consume IN
+	openTok, err := p.expect(int('('))
+	if err != nil {
+		return nil, err
+	}
+
+	if p.startsQuery() {
+		subq, err := p.parseSubqueryPlaceholder(openTok.Loc.Start, SubqueryIn)
+		if err != nil {
+			return nil, err
+		}
+		return &InSubqueryExpr{
+			Not:      not,
+			Value:    left,
+			Subquery: subq,
+			Loc:      ast.Loc{Start: start, End: subq.Loc.End},
+		}, nil
+	}
+
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	list := []Expr{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &InListExpr{
+		Not:   not,
+		Value: left,
+		List:  list,
+		Loc:   ast.Loc{Start: start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseLike parses `LIKE pattern [ESCAPE escape]` (LIKE already current). The
+// pattern and escape are valueExpressions.
+func (p *Parser) parseLike(left Expr, not bool, start int) (Expr, error) {
+	p.advance() // consume LIKE
+	pattern, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	like := &LikeExpr{
+		Not:     not,
+		Value:   left,
+		Pattern: pattern,
+		Loc:     ast.Loc{Start: start, End: pattern.Span().End},
+	}
+	if p.cur.Kind == kwESCAPE {
+		p.advance() // consume ESCAPE
+		escape, err := p.parseValueExpr()
+		if err != nil {
+			return nil, err
+		}
+		like.Escape = escape
+		like.Loc.End = escape.Span().End
+	}
+	return like, nil
+}
+
+// parseIsPredicate parses `IS [NOT] NULL` or `IS [NOT] DISTINCT FROM right`
+// (IS already current). Trino has no other IS predicate — `IS TRUE`, `IS FALSE`,
+// `IS UNKNOWN` are SYNTAX_ERRORs, so a token other than NULL/DISTINCT after the
+// optional NOT is an error.
+func (p *Parser) parseIsPredicate(left Expr) (Expr, error) {
+	isTok := p.advance() // consume IS
+	not := false
+	if p.cur.Kind == kwNOT {
+		p.advance() // consume NOT
+		not = true
+	}
+	switch p.cur.Kind {
+	case kwNULL:
+		nullTok := p.advance()
+		return &IsNullExpr{
+			Not:   not,
+			Value: left,
+			Loc:   ast.Loc{Start: left.Span().Start, End: nullTok.Loc.End},
+		}, nil
+	case kwDISTINCT:
+		p.advance() // consume DISTINCT
+		if _, err := p.expect(kwFROM); err != nil {
+			return nil, err
+		}
+		right, err := p.parseValueExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &IsDistinctFromExpr{
+			Not:   not,
+			Value: left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}, nil
+	default:
+		// Point the error at IS so the diagnostic is actionable for the common
+		// `IS TRUE` / `IS UNKNOWN` mistake.
+		return nil, &ParseError{Loc: isTok.Loc, Msg: "expected NULL or DISTINCT FROM after IS"}
+	}
+}
+
+// comparisonOpText returns the source spelling of a comparison-operator token.
+func comparisonOpText(tok Token) string {
+	switch tok.Kind {
+	case int('='):
+		return "="
+	case tokNotEq:
+		// The lexer collapses both <> and != to tokNotEq; prefer the source text
+		// when available so deparse can echo the original spelling.
+		if tok.Str != "" {
+			return tok.Str
+		}
+		return "<>"
+	case int('<'):
+		return "<"
+	case tokLessEq:
+		return "<="
+	case int('>'):
+		return ">"
+	case tokGreaterEq:
+		return ">="
+	default:
+		return tok.Str
+	}
+}
+
+// comparisonQuantifierText maps a quantifier keyword kind to its spelling; ok is
+// false for a non-quantifier kind.
+func comparisonQuantifierText(kind TokenKind) (string, bool) {
+	switch kind {
+	case kwALL:
+		return "ALL", true
+	case kwSOME:
+		return "SOME", true
+	case kwANY:
+		return "ANY", true
+	default:
+		return "", false
+	}
+}


### PR DESCRIPTION
## Node: `trino/expressions` (v2 migration, migration id 3)

Implements Trino's expression layer — the `expression` / `booleanExpression` / `valueExpression` / `primaryExpression` grammar rules and the `predicate_` suffix — as a hand-written recursive-descent parser over the token stream, producing an `Expr` value tree. Spec: [`docs/migration/trino/analysis.md`](docs/migration/trino/analysis.md) §Tier 1 #7 + [`dag.md`](docs/migration/trino/dag.md).

Like `datatypes.go` (the `types` node), the expression nodes are **parser-package types** (`Expr`, not `ast.Node`): the Trino `ast` tag set is closed to the `ast-core` node, so — matching that precedent — they live in package `parser` and carry their own `Loc`. Depends on the merged `types` node (#184) for `parseType`/`DataType`.

### Files (writes_globs: `trino/parser/{expr,function,predicate}.go`)
- **`expr.go`** — `Expr` hierarchy + entry points (`ParseExpression` / `parseExpr`); the boolean (OR/AND/NOT/predicated) and value (`||` / additive / multiplicative / unary / `AT TIME ZONE`) precedence ladders; core `primaryExpression` atoms (literals, parameter `?`, interval literal, type constructor, column ref, dereference, subscript, paren / row / array constructors, subquery placeholder, paren-lambda).
- **`predicate.go`** — the `predicate_` suffix: comparison, quantified comparison, BETWEEN, IN-list / IN-subquery, LIKE, IS NULL, IS DISTINCT FROM. Single non-associative predicate.
- **`function.go`** — function calls (setQuantifier / in-aggregate ORDER BY / FILTER / nullTreatment / inline OVER + common window frame), CASE, CAST/TRY_CAST, EXISTS, the special built-ins (EXTRACT/SUBSTRING/TRIM/NORMALIZE/POSITION/GROUPING/LISTAGG + the special-datetime / `current*` set), lambdas, and the JSON-function dispatch stub.

## Correctness evidence (correctness-protocol.md)

Adjudicated against the **live Trino 481 oracle** (`trino/internal/trinooracle`, `http://localhost:18080`).

- **Layer 1 — accept/reject differential** (`TestExpr_OracleDifferential`): **161 accept + 31 reject** corpus cases; `ParseExpression` accept/reject must equal Trino's verdict on `SELECT <expr>`. Every `primaryExpression` / `valueExpression` / `booleanExpression` / `predicate_` alternative is represented, plus oracle-discovered negatives. ✅ green.
- **Layer 2 — structural**: `TestExpr_Precedence` pins the exact parse-tree S-expression of **24** precedence/associativity-sensitive inputs; `TestExpr_RoundTrip` + `TestExpr_RoundTripOracle` parse → render → re-parse and confirm the render is re-accepted by Trino. ✅ green.
- Negative coverage: dangling operators, malformed clauses, non-associative predicate chains, IS-variant rejections, reserved special-fn keyword misuse, EXISTS empty/expression form, empty parens. ✅ green.

`go test ./trino/parser/ -run TestExpr` is green against the oracle. (The one unrelated red in the package, `TestLexer_OracleDifferential` backtick case, is a **pre-existing** `lexer_oracle_test.go` issue already spun off as a separate task — outside this node's scope.)

## Divergences from the legacy ANTLR grammar (oracle-adjudicated)

| Case | Legacy | Trino 481 | Disposition |
|---|---|---|---|
| **P1** predicate associativity | chainable | non-associative (`a = b = c`, `a < b < c`, `a IN(1) IN(2)`, `a IS NULL IS NULL` all reject) | **confirmed** — one predicate per valueExpression |
| **D-TRIM** bare `TRIM(FROM x)` | `(spec? char? FROM)?` permits it | SYNTAX_ERROR (FROM needs a preceding spec/char) | **confirmed** — reject |
| **SUBSTRING/POSITION** | special-syntax only | non-reserved: bare column ref + comma-arg call forms also valid | **confirmed** — try-special-then-fallback |
| EXTRACT/LISTAGG/GROUPING | — | accept only their special form (`extract('a','b')`, `listagg('a')`, `grouping('a')` reject) | **confirmed** |

**Flagged boundaries (by design, doris/snowflake precedent):**
- **B1** — expression-embedded subqueries (`(SELECT…)`, `EXISTS(query)`, `IN(query)`, quantified `(query)`) are raw-text `SubqueryExpr` placeholders; the `query` rule is the `parser-select` node.
- **B2** — the pattern-recognition OVER frame (MEASURES/PATTERN/DEFINE/…) is deferred to `parser-match-recognize`; this node implements the common `(ROWS|RANGE|GROUPS) [BETWEEN …]` frame.
- **JSON** — SQL/JSON functions (JSON_EXISTS/VALUE/QUERY/OBJECT/ARRAY) are deferred to the `expr-json` node; routed to a "not yet supported" stub (`TestExpr_JSONDeferred`).
- **Quantified `ANY`/`SOME`/`ALL`** — also non-reserved function names; the placeholder gives the correct accept/reject verdict in every probed case but does not structurally distinguish `ANY(1)` (function call) from `ANY(query)` — that needs the parser-select query/expression decision. Recorded as a flagged structural boundary, not an accept/reject divergence.

## Review gate

- **Claude lens** (`/code-review`, high effort): surfaced two genuine accept/reject bugs — the SUBSTRING/POSITION over-restriction and the **EXISTS empty/expression form** (`EXISTS ()`, `EXISTS (1)` were wrongly accepted) — both fixed and regression-guarded by corpus negatives. No blockers remain.
- **Codex lens**: unavailable this wave (workspace out of credits); equivalent correctness rigor applied manually across degenerate inputs, speculation/state-leak, loop bounds, nil-deref, and span correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)