### PR TITLE
fix(tidb): accept the BINARY modifier on character types + resolve _bin collation

### DIFF
--- a/tidb/ast/outfuncs.go
+++ b/tidb/ast/outfuncs.go
@@ -2897,6 +2897,9 @@ func writeDataType(sb *strings.Builder, n *DataType) {
 	if n.Collate != "" {
 		fmt.Fprintf(sb, " :collate %s", n.Collate)
 	}
+	if n.Binary {
+		sb.WriteString(" :binary true")
+	}
 	if len(n.EnumValues) > 0 {
 		fmt.Fprintf(sb, " :enum_values %s", strings.Join(n.EnumValues, ", "))
 	}

--- a/tidb/ast/parsenodes.go
+++ b/tidb/ast/parsenodes.go
@@ -583,6 +583,7 @@ type DataType struct {
 	Zerofill   bool
 	Charset    string   // CHARACTER SET
 	Collate    string   // COLLATE
+	Binary     bool     // standalone BINARY modifier, e.g. CHAR(10) BINARY
 	EnumValues []string // for ENUM and SET types
 	ArrayDim   int      // not used in MySQL, but here for consistency
 	SRID       int      // Spatial Reference ID for spatial types (0 = not set)

--- a/tidb/catalog/altercmds.go
+++ b/tidb/catalog/altercmds.go
@@ -841,6 +841,13 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 		if colDef.TypeName.Collate != "" {
 			col.Collation = colDef.TypeName.Collate
 		}
+
+		// MySQL converts non-ENUM/SET string columns with CHARACTER SET binary to
+		// binary types (CHAR->BINARY, VARCHAR->VARBINARY, TEXT->BLOB), like the
+		// CREATE TABLE path. ENUM/SET keep the binary charset annotation.
+		if strings.EqualFold(col.Charset, "binary") && isStringType(col.DataType) && !isEnumSetType(col.DataType) {
+			col = convertToBinaryType(col, colDef.TypeName)
+		}
 	}
 
 	// Default charset/collation for string types.
@@ -859,6 +866,15 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 				col.Collation = tbl.Collation
 			}
 		}
+	}
+
+	// Standalone BINARY modifier (CHAR(10) BINARY) → the effective charset's
+	// binary collation, matching TiDB. Resolved after the charset default above
+	// so a bare CHAR BINARY uses the table/db charset. An explicit COLLATE wins
+	// over BINARY, so only apply when no COLLATE was given.
+	if colDef.TypeName != nil && colDef.TypeName.Binary && isStringType(col.DataType) &&
+		colDef.TypeName.Collate == "" {
+		col.Collation = binModifierCollation(col.Charset)
 	}
 
 	// Top-level column properties.

--- a/tidb/catalog/binary_modifier_test.go
+++ b/tidb/catalog/binary_modifier_test.go
@@ -1,0 +1,100 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBinaryModifierCollationResolution pins how the standalone BINARY modifier
+// resolves to a collation, verified against TiDB v8.5.0:
+//   - BINARY → {charset}_bin (using the effective charset)
+//   - an explicit COLLATE wins over BINARY
+//   - CHARACTER SET binary → collation `binary` (NOT binary_bin)
+func TestBinaryModifierCollationResolution(t *testing.T) {
+	c := New()
+	results, err := c.Exec(`CREATE DATABASE testdb; USE testdb;
+CREATE TABLE t (
+  a CHAR(10) BINARY,
+  b VARCHAR(10) CHARACTER SET latin1 BINARY,
+  c VARCHAR(10) CHARACTER SET utf8mb4 BINARY COLLATE utf8mb4_unicode_ci,
+  d ENUM('x','y') CHARACTER SET binary BINARY,
+  e SET('x') CHARACTER SET binary BINARY
+) DEFAULT CHARSET=utf8mb4;`, nil)
+	if err != nil {
+		t.Fatalf("exec parse error: %v", err)
+	}
+	for _, r := range results {
+		if r.Error != nil {
+			t.Fatalf("exec error on stmt %d: %v", r.Index, r.Error)
+		}
+	}
+
+	tbl := c.GetDatabase("testdb").GetTable("t")
+	if tbl == nil {
+		t.Fatal("table t not found")
+	}
+	want := map[string]string{
+		"a": "utf8mb4_bin",        // BINARY → effective (db) charset utf8mb4 → utf8mb4_bin
+		"b": "latin1_bin",         // explicit charset latin1 → latin1_bin
+		"c": "utf8mb4_unicode_ci", // explicit COLLATE wins over BINARY
+		"d": "binary",             // CHARACTER SET binary → binary, not binary_bin
+		"e": "binary",
+	}
+	for col, exp := range want {
+		got := tbl.GetColumn(col)
+		if got == nil {
+			t.Errorf("column %s not found", col)
+			continue
+		}
+		if strings.ToLower(got.Collation) != exp {
+			t.Errorf("column %s: got collation %q, want %q", col, got.Collation, exp)
+		}
+	}
+}
+
+// TestCharsetBinaryConvertsToBinaryType pins that a non-ENUM/SET string column
+// with CHARACTER SET binary (with or without the BINARY modifier) becomes a
+// binary type with no charset/collation — in BOTH the CREATE and ALTER paths.
+func TestCharsetBinaryConvertsToBinaryType(t *testing.T) {
+	c := New()
+	exec := func(ddl string) {
+		t.Helper()
+		results, err := c.Exec(ddl, nil)
+		if err != nil {
+			t.Fatalf("exec parse error: %v", err)
+		}
+		for _, r := range results {
+			if r.Error != nil {
+				t.Fatalf("exec error on stmt %d: %v", r.Index, r.Error)
+			}
+		}
+	}
+	exec(`CREATE DATABASE testdb; USE testdb;`)
+	exec(`CREATE TABLE t (
+  a CHAR(10) CHARACTER SET binary BINARY,
+  b VARCHAR(10) CHARACTER SET binary,
+  c TEXT CHARACTER SET binary
+);`)
+	// ALTER ADD must apply the same conversion as CREATE.
+	exec(`ALTER TABLE t ADD d CHAR(10) CHARACTER SET binary BINARY;`)
+	exec(`ALTER TABLE t ADD e CHAR(10) CHARACTER SET binary;`)
+
+	tbl := c.GetDatabase("testdb").GetTable("t")
+	if tbl == nil {
+		t.Fatal("table t not found")
+	}
+	wantType := map[string]string{"a": "binary", "b": "varbinary", "c": "blob", "d": "binary", "e": "binary"}
+	for col, exp := range wantType {
+		got := tbl.GetColumn(col)
+		if got == nil {
+			t.Errorf("column %s not found", col)
+			continue
+		}
+		if strings.ToLower(got.DataType) != exp {
+			t.Errorf("column %s: got type %q, want %q", col, got.DataType, exp)
+		}
+		if got.Charset != "" || got.Collation != "" {
+			t.Errorf("column %s: binary type must have no charset/collation, got charset=%q collation=%q", col, got.Charset, got.Collation)
+		}
+	}
+}

--- a/tidb/catalog/show.go
+++ b/tidb/catalog/show.go
@@ -57,6 +57,16 @@ var defaultCollationForCharset = map[string]string{
 	"armscii8": "armscii8_general_ci",
 }
 
+// binModifierCollation returns the collation the standalone BINARY modifier
+// resolves to for the given charset: {charset}_bin, except the `binary` charset
+// whose binary collation is `binary` (not `binary_bin`). Matches TiDB.
+func binModifierCollation(charset string) string {
+	if toLower(charset) == "binary" {
+		return "binary"
+	}
+	return toLower(charset) + "_bin"
+}
+
 // ShowCreateTable produces MySQL 8.0-compatible SHOW CREATE TABLE output.
 // Returns "" if the database or table does not exist.
 func (c *Catalog) ShowCreateTable(database, table string) string {

--- a/tidb/catalog/tablecmds.go
+++ b/tidb/catalog/tablecmds.go
@@ -222,6 +222,15 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			}
 		}
 
+		// Standalone BINARY modifier (CHAR(10) BINARY) → the effective charset's
+		// binary collation, matching TiDB. Resolved after the charset default
+		// above so a bare CHAR BINARY uses the table/db charset. An explicit
+		// COLLATE wins over BINARY, so only apply when no COLLATE was given.
+		if colDef.TypeName != nil && colDef.TypeName.Binary && isStringType(col.DataType) &&
+			colDef.TypeName.Collate == "" {
+			col.Collation = binModifierCollation(col.Charset)
+		}
+
 		// Top-level column properties.
 		if colDef.TypeName != nil && colDef.TypeName.SRID != 0 {
 			col.SRID = colDef.TypeName.SRID

--- a/tidb/parser/binary_modifier_test.go
+++ b/tidb/parser/binary_modifier_test.go
@@ -1,0 +1,101 @@
+package parser
+
+import "testing"
+
+// The standalone BINARY modifier (CHAR(10) BINARY — shorthand for the charset's
+// _bin collation). TiDB accepts it on character types (CHAR/VARCHAR/TEXT
+// variants, ENUM, SET, NCHAR/NVARCHAR) in any order relative to CHARACTER SET /
+// COLLATE, and rejects it on BLOB/VARBINARY. Verified on TiDB v8.5.0.
+
+func TestCharBinaryModifierAccepted(t *testing.T) {
+	cases := []string{
+		`CREATE TABLE t (a CHAR(5) BINARY)`,
+		`CREATE TABLE t (a CHAR BINARY)`,
+		`CREATE TABLE t (a VARCHAR(5) BINARY)`,
+		`CREATE TABLE t (a TEXT BINARY)`,
+		`CREATE TABLE t (a TINYTEXT BINARY)`,
+		`CREATE TABLE t (a LONGTEXT BINARY)`,
+		`CREATE TABLE t (a ENUM('x','y') BINARY)`,
+		`CREATE TABLE t (a SET('x') BINARY)`,
+		`CREATE TABLE t (a NCHAR(5) BINARY)`,
+		`CREATE TABLE t (a NVARCHAR(5) BINARY)`,
+		// BINARY in any order relative to CHARACTER SET / COLLATE.
+		`CREATE TABLE t (a CHAR(5) CHARACTER SET utf8mb4 BINARY)`,
+		`CREATE TABLE t (a CHAR(5) BINARY CHARACTER SET utf8mb4)`,
+		`CREATE TABLE t (a CHAR(5) BINARY COLLATE utf8mb4_bin)`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Fatalf("Parse(%q) error: %v", sql, err)
+			}
+		})
+	}
+}
+
+func TestBinaryTypeBinaryModifierRejected(t *testing.T) {
+	// TiDB rejects the BINARY modifier on binary types (they have no charset).
+	cases := []string{
+		`CREATE TABLE t (a BLOB BINARY)`,
+		`CREATE TABLE t (a TINYBLOB BINARY)`,
+		`CREATE TABLE t (a VARBINARY(5) BINARY)`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Fatalf("Parse(%q) accepted BINARY on a binary type, but TiDB rejects it", sql)
+			}
+		})
+	}
+}
+
+// BINARY and CHARACTER SET may appear in any order, but COLLATE comes LAST —
+// TiDB rejects BINARY after COLLATE.
+func TestBinaryCollateOrdering(t *testing.T) {
+	accept := []string{
+		`CREATE TABLE t (a CHAR(5) CHARACTER SET utf8mb4 BINARY COLLATE utf8mb4_bin)`,
+		`CREATE TABLE t (a CHAR(5) BINARY COLLATE utf8mb4_bin)`,
+		`CREATE TABLE t (a CHAR(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin)`,
+	}
+	reject := []string{
+		`CREATE TABLE t (a CHAR(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin BINARY)`,
+		`CREATE TABLE t (a CHAR(5) COLLATE utf8mb4_bin BINARY)`,
+	}
+	for _, sql := range accept {
+		t.Run("accept/"+sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Fatalf("Parse(%q) error: %v", sql, err)
+			}
+		})
+	}
+	for _, sql := range reject {
+		t.Run("reject/"+sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Fatalf("Parse(%q) accepted BINARY after COLLATE, but TiDB rejects it", sql)
+			}
+		})
+	}
+}
+
+// CHARACTER SET and the standalone BINARY modifier may each appear at most once;
+// TiDB rejects repeats. `CHARACTER SET binary BINARY` is NOT a repeat — the
+// first `binary` is the charset name, the second is the modifier.
+func TestRepeatedCharsetBinaryRejected(t *testing.T) {
+	reject := []string{
+		`CREATE TABLE t (a CHAR(5) BINARY BINARY)`,
+		`CREATE TABLE t (a CHAR(5) BINARY CHARACTER SET utf8mb4 BINARY)`,
+		`CREATE TABLE t (a CHAR(5) CHARACTER SET utf8mb4 BINARY BINARY)`,
+		`CREATE TABLE t (a CHAR(5) CHARACTER SET utf8mb4 CHARACTER SET latin1)`,
+	}
+	for _, sql := range reject {
+		t.Run("reject/"+sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Fatalf("Parse(%q) accepted a repeated charset/BINARY modifier, but TiDB rejects it", sql)
+			}
+		})
+	}
+	// charset name `binary` followed by the BINARY modifier is valid.
+	if _, err := Parse(`CREATE TABLE t (a CHAR(5) CHARACTER SET binary BINARY)`); err != nil {
+		t.Fatalf("CHARACTER SET binary BINARY should parse: %v", err)
+	}
+}

--- a/tidb/parser/type.go
+++ b/tidb/parser/type.go
@@ -430,25 +430,64 @@ func (p *Parser) parseUnsignedZerofill(dt *nodes.DataType) {
 	}
 }
 
-// parseCharsetCollate parses optional CHARACTER SET and COLLATE clauses.
+// parseCharsetCollate parses optional CHARACTER SET / CHARSET clauses, the
+// standalone BINARY modifier (e.g. CHAR(10) BINARY), and an optional COLLATE.
+// CHARACTER SET and BINARY may appear in any order, but COLLATE comes LAST:
+// TiDB accepts `CHARACTER SET x BINARY COLLATE y` and `BINARY COLLATE y` but
+// REJECTS `COLLATE y BINARY` and `CHARACTER SET x COLLATE y BINARY` (BINARY
+// after COLLATE). So charset/BINARY are consumed in a loop, then a single
+// trailing COLLATE — a BINARY after COLLATE is left for the caller to reject.
+//
+// Only the character types (CHAR/VARCHAR/TEXT/ENUM/SET/NCHAR/...) call this, so
+// BINARY is naturally not accepted on BLOB/VARBINARY, matching TiDB.
+//
+// charset/collation names can be `binary`, which is a reserved keyword, so we
+// use parseKeywordOrIdent to accept keyword tokens as names.
 func (p *Parser) parseCharsetCollate(dt *nodes.DataType) {
-	// CHARACTER SET charset_name | CHARSET charset_name
-	// charset/collation names can be `binary`, which is a reserved keyword,
-	// so we use parseKeywordOrIdent to accept keyword tokens as names.
-	if _, ok := p.match(kwCHARSET); ok {
-		if p.isIdentToken() || p.cur.Type == kwBINARY {
-			dt.Charset, _, _ = p.parseKeywordOrIdent()
-		}
-	} else if p.cur.Type == kwCHARACTER {
-		p.advance()
-		if _, ok := p.match(kwSET); ok {
+	// Each of CHARACTER SET and the standalone BINARY modifier may appear at most
+	// once; a repeat is left for the caller to reject (TiDB rejects e.g.
+	// `BINARY BINARY` and `CHARACTER SET x CHARACTER SET y`). Note that
+	// `CHARACTER SET binary BINARY` is still valid — the first `binary` is the
+	// charset name (consumed by parseKeywordOrIdent), the second is the modifier.
+	charsetSeen := false
+	binarySeen := false
+charsetBinary:
+	for {
+		switch p.cur.Type {
+		case kwCHARSET:
+			if charsetSeen {
+				break charsetBinary
+			}
+			charsetSeen = true
+			p.advance()
 			if p.isIdentToken() || p.cur.Type == kwBINARY {
 				dt.Charset, _, _ = p.parseKeywordOrIdent()
 			}
+		case kwCHARACTER:
+			if charsetSeen {
+				break charsetBinary
+			}
+			p.advance()
+			if _, ok := p.match(kwSET); !ok {
+				return
+			}
+			charsetSeen = true
+			if p.isIdentToken() || p.cur.Type == kwBINARY {
+				dt.Charset, _, _ = p.parseKeywordOrIdent()
+			}
+		case kwBINARY:
+			if binarySeen {
+				break charsetBinary
+			}
+			binarySeen = true
+			p.advance()
+			dt.Binary = true
+		default:
+			break charsetBinary
 		}
 	}
 
-	// COLLATE collation_name
+	// COLLATE collation_name — must come after any CHARACTER SET / BINARY.
 	if _, ok := p.match(kwCOLLATE); ok {
 		if p.isIdentToken() || p.cur.Type == kwBINARY {
 			dt.Collate, _, _ = p.parseKeywordOrIdent()


### PR DESCRIPTION
## Problem

TiDB accepts the standalone `BINARY` modifier on character types — `CHAR(10) BINARY`, `VARCHAR(5) BINARY`, `TEXT BINARY`, `ENUM(...) BINARY`, `NCHAR(5) BINARY` — as shorthand for the charset's `_bin` collation, but the parser rejected it with `unexpected token`. Found via a MySQL→TiDB parser-parity scan.

## Scope (verified on TiDB v8.5.0)

**Types** — accepted on character types; rejected on `BLOB`/`TINYBLOB`/`VARBINARY` (no charset). Only character types call `parseCharsetCollate`, so this is automatic.

**Ordering** — `CHARACTER SET` and `BINARY` may appear in any order, but `COLLATE` comes **last**:
| form | TiDB |
|---|---|
| `CHARACTER SET x BINARY COLLATE y`, `BINARY COLLATE y` | ✅ |
| `CHARACTER SET x COLLATE y BINARY`, `COLLATE y BINARY` | ❌ |

**Collation resolution** — `BINARY` resolves to `{effective-charset}_bin`: `CHAR(10) BINARY` → `utf8mb4_bin`, `VARCHAR(10) CHARACTER SET latin1 BINARY` → `latin1_bin`.

## Fix

- **Parser** (`type.go`): `parseCharsetCollate` consumes `CHARACTER SET`/`BINARY` in any order, then a single trailing `COLLATE` — so `BINARY` after `COLLATE` is rejected, matching TiDB. Sets `DataType.Binary` (emitted in AST output).
- **Catalog** (`tablecmds.go` create + `altercmds.go` `buildColumnFromDef`): resolve `dt.Binary` → `{charset}_bin` **after** the effective charset is determined (a bare `CHAR BINARY` uses the table/db charset). Without this the DDL parsed but recorded the wrong collation — accepted-but-wrong metadata, worse than the old rejection.

## Testing

- Parser: `binary_modifier_test.go` — accepted character-type forms (all orders), rejected binary types, and the BINARY/COLLATE ordering (accept/reject).
- Catalog: scenario `4_6_binary_modifier_bin_collation` now **passes** (`CHAR(10) BINARY` → utf8mb4_bin, `VARCHAR(10) CHARACTER SET latin1 BINARY` → latin1_bin).
- The other C4 scenario failures (4_3/4_5/4_8/4_9/4_11) are **pre-existing on main** (charset normalization / NATIONAL / index-prefix), unrelated to BINARY — verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update:** each of `CHARACTER SET` / `BINARY` may appear at most once — TiDB rejects `BINARY BINARY`, `CHARACTER SET x CHARACTER SET y`, etc. (a repeat is left unconsumed so the caller rejects it). `CHARACTER SET binary BINARY` stays valid — the first `binary` is the charset name, the second the modifier.

**Update:** CHARACTER SET binary BINARY (and plain CHARACTER SET binary) on a non-ENUM/SET string column converts to a binary type (CHAR->binary, VARCHAR->varbinary, TEXT->blob) with no charset/collation — now applied in the ALTER path too (buildColumnFromDef), matching the CREATE path and TiDB v8.5.0.
