### PR TITLE
feat(trino/parser): SQL/JSON functions & path (v2 node trino/expr-json)

### DIFF
--- a/trino/parser/expr_test.go
+++ b/trino/parser/expr_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -280,9 +279,9 @@ var exprRejectCorpus = []string{
 	"()",
 	"a IN ()",
 
-	// SQL/JSON functions are the expr-json node (this node rejects them as
-	// "not yet supported" — a deliberate, node-scoped non-acceptance that the
-	// oracle differential treats specially; see TestExpr_JSONDeferred).
+	// SQL/JSON functions (JSON_EXISTS/JSON_VALUE/JSON_QUERY/JSON_OBJECT/
+	// JSON_ARRAY) are the expr-json node; their accept/reject corpus and oracle
+	// differential live in json_test.go (jsonAcceptCorpus / jsonRejectCorpus).
 }
 
 // TestExpr_AcceptCorpusParses verifies omni accepts every form in
@@ -352,29 +351,8 @@ func TestExpr_OracleDifferential(t *testing.T) {
 	})
 }
 
-// TestExpr_JSONDeferred documents the node-scope boundary: the SQL/JSON
-// functions are accepted by Trino but deferred to the expr-json node, so this
-// node rejects them with a "not yet supported" diagnostic. This is a deliberate
-// non-acceptance recorded in the divergence ledger; it is NOT a Trino-disagreement
-// bug. When expr-json lands, these move into the accept corpus.
-func TestExpr_JSONDeferred(t *testing.T) {
-	jsonForms := []string{
-		"JSON_EXISTS(a, 'lax $.b')",
-		"JSON_VALUE(a, 'lax $.b')",
-		"JSON_QUERY(a, 'lax $.b')",
-		"JSON_OBJECT('k' VALUE 1)",
-		"JSON_ARRAY(1, 2)",
-	}
-	for _, expr := range jsonForms {
-		t.Run(truncateName(expr), func(t *testing.T) {
-			_, errs := ParseExpression(expr)
-			if len(errs) == 0 {
-				t.Errorf("expected %q to be rejected as not-yet-supported, but accepted", expr)
-				return
-			}
-			if !strings.Contains(errs[0].Msg, "not yet supported") {
-				t.Errorf("expected a 'not yet supported' diagnostic for %q, got: %v", expr, errs[0].Msg)
-			}
-		})
-	}
-}
+// The SQL/JSON functions (JSON_EXISTS/JSON_VALUE/JSON_QUERY/JSON_OBJECT/
+// JSON_ARRAY) were a deliberate node-scoped non-acceptance in the expressions
+// node (a "not yet supported" stub). The expr-json node (json.go) now parses
+// them; their accept/reject corpus, oracle differential, and structural
+// assertions live in json_test.go.

--- a/trino/parser/function.go
+++ b/trino/parser/function.go
@@ -26,9 +26,9 @@ import "github.com/bytebase/omni/trino/ast"
 //
 // The SQL/JSON functions (JSON_EXISTS/JSON_VALUE/JSON_QUERY/JSON_OBJECT/
 // JSON_ARRAY and the json-path subsystem) are the SEPARATE expr-json DAG node
-// (json.go); parsePrimaryAtom routes them here to a thin parseJSONFunction stub
-// that records a "not yet supported" error until that node lands. This keeps the
-// expressions node's writes scoped to expr/function/predicate.go.
+// (json.go); parsePrimaryAtom routes them to parseJSONFunction, which lives in
+// json.go. (During the expressions node this was a thin "not yet supported"
+// stub here; the expr-json node replaced it with the real parser in json.go.)
 //
 // Oracle-confirmed reservation nuance baked into the dispatch: among the
 // special built-ins, SUBSTRING and POSITION are NON-RESERVED keywords, so beyond
@@ -1381,20 +1381,5 @@ func (p *Parser) parseDoublePrecisionConstructor() (Expr, error) {
 	}, nil
 }
 
-// parseJSONFunction is the dispatch stub for the SQL/JSON functions
-// (JSON_EXISTS / JSON_VALUE / JSON_QUERY / JSON_OBJECT / JSON_ARRAY). The bodies,
-// and the json-path subsystem, are the SEPARATE expr-json DAG node (json.go);
-// until it lands, this records a "not yet supported" error so callers get an
-// actionable diagnostic rather than a wrong parse. The keyword is the current
-// token.
-func (p *Parser) parseJSONFunction() (Expr, error) {
-	tok := p.cur
-	name := tok.Str
-	if name == "" {
-		name = TokenName(tok.Kind)
-	}
-	return nil, &ParseError{
-		Loc: tok.Loc,
-		Msg: "SQL/JSON function " + name + " is not yet supported",
-	}
-}
+// parseJSONFunction (the SQL/JSON function dispatcher) lives in json.go (the
+// expr-json DAG node). parsePrimaryAtom's JSON_* dispatch calls it from there.

--- a/trino/parser/json.go
+++ b/trino/parser/json.go
@@ -1,0 +1,1002 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is the `expr-json` DAG node: it implements Trino's SQL/JSON
+// function family — JSON_EXISTS / JSON_VALUE / JSON_QUERY / JSON_OBJECT /
+// JSON_ARRAY — and the shared json-path-invocation subsystem they embed
+// (jsonPathInvocation, jsonValueExpression, jsonRepresentation, jsonArgument,
+// and the per-function behavior clauses). It depends on the `expressions` node
+// (expr.go / function.go / predicate.go): the dispatch in parsePrimaryAtom
+// (expr.go) routes the five reserved JSON_* keywords here via parseJSONFunction,
+// and the bodies reuse parseExpr / parseValueExpr / parseType / parseIdentifier
+// from that node. JSON_TABLE is deliberately NOT here — it is a relationPrimary
+// / primaryExpression form owned by parser-select (a P1 extension), not part of
+// this node.
+//
+// The legacy ANTLR grammar (TrinoParser.g4) the implementation tracks, as the
+// five primaryExpression alternatives plus their helper rules:
+//
+//	jsonExists : JSON_EXISTS_ LPAREN_ jsonPathInvocation
+//	               (jsonExistsErrorBehavior ON_ ERROR_)? RPAREN_ ;
+//	jsonValue  : JSON_VALUE_ LPAREN_ jsonPathInvocation (RETURNING_ type)?
+//	               (emptyBehavior = jsonValueBehavior ON_ EMPTY_)?
+//	               (errorBehavior = jsonValueBehavior ON_ ERROR_)? RPAREN_ ;
+//	jsonQuery  : JSON_QUERY_ LPAREN_ jsonPathInvocation
+//	               (RETURNING_ type (FORMAT_ jsonRepresentation)?)?
+//	               (jsonQueryWrapperBehavior WRAPPER_)?
+//	               ((KEEP_ | OMIT_) QUOTES_ (ON_ SCALAR_ TEXT_STRING_)?)?
+//	               (emptyBehavior = jsonQueryBehavior ON_ EMPTY_)?
+//	               (errorBehavior = jsonQueryBehavior ON_ ERROR_)? RPAREN_ ;
+//	jsonObject : JSON_OBJECT_ LPAREN_
+//	               ( jsonObjectMember (COMMA_ jsonObjectMember)*
+//	                 (NULL_ ON_ NULL_ | ABSENT_ ON_ NULL_)?
+//	                 (WITH_ UNIQUE_ KEYS_? | WITHOUT_ UNIQUE_ KEYS_?)? )?
+//	               (RETURNING_ type (FORMAT_ jsonRepresentation)?)? RPAREN_ ;
+//	jsonArray  : JSON_ARRAY_ LPAREN_
+//	               ( jsonValueExpression (COMMA_ jsonValueExpression)*
+//	                 (NULL_ ON_ NULL_ | ABSENT_ ON_ NULL_)? )?
+//	               (RETURNING_ type (FORMAT_ jsonRepresentation)?)? RPAREN_ ;
+//
+//	jsonPathInvocation : jsonValueExpression COMMA_ path = string_
+//	                       (PASSING_ jsonArgument (COMMA_ jsonArgument)*)? ;
+//	jsonValueExpression : expression (FORMAT_ jsonRepresentation)? ;
+//	jsonRepresentation  : JSON_ (ENCODING_ (UTF8_ | UTF16_ | UTF32_))? ;
+//	jsonArgument        : jsonValueExpression AS_ identifier ;
+//	jsonObjectMember    : KEY_? expression VALUE_ jsonValueExpression
+//	                    | expression COLON_ jsonValueExpression ;
+//	jsonExistsErrorBehavior : TRUE_ | FALSE_ | UNKNOWN_ | ERROR_ ;
+//	jsonValueBehavior       : ERROR_ | NULL_ | DEFAULT_ expression ;
+//	jsonQueryWrapperBehavior: WITHOUT_ ARRAY_? | WITH_ (CONDITIONAL_|UNCONDITIONAL_)? ARRAY_? ;
+//	jsonQueryBehavior       : ERROR_ | NULL_ | EMPTY_ (ARRAY_ | OBJECT_) ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar (json_test.go's oracle differential is the gate).
+// Oracle-confirmed facts baked into the parser:
+//
+//	J1 (clause ordering is FIXED, not free). Each function's optional clauses
+//	   appear in exactly the grammar order. `JSON_QUERY(c,'$.x' KEEP QUOTES WITH
+//	   ARRAY WRAPPER)` (QUOTES before WRAPPER) and `JSON_VALUE(c,'$.x' NULL ON
+//	   ERROR ERROR ON EMPTY)` (ON ERROR before ON EMPTY) are SYNTAX_ERRORs in
+//	   Trino 481. The parsers therefore read the clauses positionally.
+//	J2 (path is a string LITERAL, not an expression). The path after the comma
+//	   must be a string literal: `JSON_EXISTS(c, somecol)` and
+//	   `JSON_VALUE(c,'$.x' || 'y')` are SYNTAX_ERRORs. parseJSONPathInvocation
+//	   requires a string token for the path.
+//	J3 (the five JSON_* names are RESERVED). Unlike SUBSTRING/POSITION, the
+//	   JSON_* function keywords cannot be bare column references (`SELECT
+//	   json_exists` is a SYNTAX_ERROR), so the dispatch from parsePrimaryAtom is
+//	   unambiguous — no try-special-then-fall-back path is needed.
+//	J4 (jsonObjectMember KEY is a backtracking-optional keyword). `KEY` is
+//	   non-reserved, so `JSON_OBJECT(KEY VALUE 1)` parses KEY as the key
+//	   *expression* (COLUMN key), while `JSON_OBJECT(KEY 'x' VALUE 1)` parses KEY
+//	   as the leading keyword and 'x' as the expression. parseJSONObjectMember
+//	   speculatively consumes a leading KEY and, if the result is not a valid
+//	   `expr VALUE value`, rewinds and parses the member without it.
+//	J5 (NULL is both a literal element and the start of NULL ON NULL). In
+//	   JSON_ARRAY, `JSON_ARRAY(NULL)` is a single NULL element while
+//	   `JSON_ARRAY(1 NULL ON NULL)` is element 1 with NULL-ON-NULL handling, and
+//	   `JSON_ARRAY(NULL ON NULL)` is a SYNTAX_ERROR (the leading NULL is consumed
+//	   as the element, leaving a dangling ON). The element list is parsed first
+//	   (greedily taking a leading NULL/ABSENT-free value), then the null-handling
+//	   clause is recognized only AFTER the comma-separated list.
+
+// ---------------------------------------------------------------------------
+// SQL/JSON node types (parser-package Expr values; see expr.go file header)
+// ---------------------------------------------------------------------------
+
+// JSONPathInvocation is the shared `jsonValueExpression , path [PASSING …]`
+// head of every SQL/JSON function (jsonPathInvocation). Input is the JSON input
+// value expression (with its optional FORMAT); Path is the decoded path string
+// literal; Passing carries the named PASSING arguments (nil when absent).
+type JSONPathInvocation struct {
+	Input   *JSONValueExpr
+	Path    string // decoded path string-literal content
+	Passing []JSONArgument
+	Loc     ast.Loc
+}
+
+// JSONValueExpr is `expression [FORMAT jsonRepresentation]` (jsonValueExpression):
+// an ordinary expression optionally tagged with an input/output JSON format.
+// Format is nil when no FORMAT clause is present.
+type JSONValueExpr struct {
+	Expr   Expr
+	Format *JSONFormat // nil when absent
+	Loc    ast.Loc
+}
+
+// JSONFormat is `FORMAT JSON [ENCODING (UTF8|UTF16|UTF32)]` (jsonRepresentation).
+// Only the JSON representation keyword is accepted by Trino 481; Encoding is ""
+// when no ENCODING clause is present, else "UTF8"/"UTF16"/"UTF32".
+type JSONFormat struct {
+	Encoding string // "", "UTF8", "UTF16", or "UTF32"
+	Loc      ast.Loc
+}
+
+// JSONArgument is one `jsonValueExpression AS identifier` PASSING argument
+// (jsonArgument).
+type JSONArgument struct {
+	Value *JSONValueExpr
+	Name  *ast.Identifier
+	Loc   ast.Loc
+}
+
+// JSONExistsExpr is `JSON_EXISTS(jsonPathInvocation [behavior ON ERROR])`
+// (jsonExists). OnError is "", "TRUE", "FALSE", "UNKNOWN", or "ERROR".
+type JSONExistsExpr struct {
+	Path    *JSONPathInvocation
+	OnError string // jsonExistsErrorBehavior, "" when absent
+	Loc     ast.Loc
+}
+
+func (n *JSONExistsExpr) Span() ast.Loc { return n.Loc }
+func (*JSONExistsExpr) exprNode()       {}
+
+// JSONValueFunc is `JSON_VALUE(jsonPathInvocation [RETURNING type]
+// [behavior ON EMPTY] [behavior ON ERROR])` (jsonValue). Returning is the
+// optional RETURNING type (nil when absent). OnEmpty/OnError are the optional
+// jsonValueBehavior clauses (nil when absent).
+type JSONValueFunc struct {
+	Path      *JSONPathInvocation
+	Returning *DataType // nil when absent
+	OnEmpty   *JSONValueBehavior
+	OnError   *JSONValueBehavior
+	Loc       ast.Loc
+}
+
+func (n *JSONValueFunc) Span() ast.Loc { return n.Loc }
+func (*JSONValueFunc) exprNode()       {}
+
+// JSONValueBehavior is one `ERROR | NULL | DEFAULT expression` clause of
+// JSON_VALUE's ON EMPTY / ON ERROR (jsonValueBehavior). Kind is "ERROR",
+// "NULL", or "DEFAULT"; Default is the expression for the DEFAULT form (nil
+// otherwise).
+type JSONValueBehavior struct {
+	Kind    string // "ERROR", "NULL", or "DEFAULT"
+	Default Expr   // non-nil only for the DEFAULT form
+	Loc     ast.Loc
+}
+
+// JSONQueryFunc is `JSON_QUERY(jsonPathInvocation [RETURNING type [FORMAT …]]
+// [wrapper WRAPPER] [(KEEP|OMIT) QUOTES [ON SCALAR STRING]] [behavior ON EMPTY]
+// [behavior ON ERROR])` (jsonQuery).
+type JSONQueryFunc struct {
+	Path            *JSONPathInvocation
+	Returning       *DataType   // nil when absent
+	ReturningFormat *JSONFormat // FORMAT after RETURNING type, nil when absent
+	Wrapper         string      // "", "WITHOUT", "WITH", "WITH CONDITIONAL", "WITH UNCONDITIONAL"
+	WrapperArray    bool        // the ARRAY keyword was present on the WRAPPER clause
+	Quotes          string      // "", "KEEP", or "OMIT"
+	QuotesOnScalar  bool        // the ON SCALAR STRING suffix was present on the QUOTES clause
+	OnEmpty         *JSONQueryBehavior
+	OnError         *JSONQueryBehavior
+	Loc             ast.Loc
+}
+
+func (n *JSONQueryFunc) Span() ast.Loc { return n.Loc }
+func (*JSONQueryFunc) exprNode()       {}
+
+// JSONQueryBehavior is one `ERROR | NULL | EMPTY (ARRAY|OBJECT)` clause of
+// JSON_QUERY's ON EMPTY / ON ERROR (jsonQueryBehavior). Kind is "ERROR",
+// "NULL", "EMPTY ARRAY", or "EMPTY OBJECT".
+type JSONQueryBehavior struct {
+	Kind string // "ERROR", "NULL", "EMPTY ARRAY", or "EMPTY OBJECT"
+	Loc  ast.Loc
+}
+
+// JSONObjectExpr is `JSON_OBJECT([members] [null-handling] [uniqueness]
+// [RETURNING type [FORMAT …]])` (jsonObject). Members is the (possibly empty)
+// key/value member list. NullHandling is "", "NULL ON NULL", or "ABSENT ON
+// NULL". Uniqueness is "", "WITH UNIQUE", or "WITHOUT UNIQUE" (with the trailing
+// optional KEYS captured by UniqueKeys).
+type JSONObjectExpr struct {
+	Members         []JSONObjectMember
+	NullHandling    string // "", "NULL ON NULL", or "ABSENT ON NULL"
+	Uniqueness      string // "", "WITH UNIQUE", or "WITHOUT UNIQUE"
+	UniqueKeys      bool   // the trailing KEYS keyword was present
+	Returning       *DataType
+	ReturningFormat *JSONFormat
+	Loc             ast.Loc
+}
+
+func (n *JSONObjectExpr) Span() ast.Loc { return n.Loc }
+func (*JSONObjectExpr) exprNode()       {}
+
+// JSONObjectMember is one key/value pair of JSON_OBJECT (jsonObjectMember).
+// Key is the key expression; Value is the value (jsonValueExpression). KeyKeyword
+// records whether the explicit leading `KEY` keyword was used; Separator is ":"
+// (the colon form) or "VALUE" (the KEY?/VALUE form).
+type JSONObjectMember struct {
+	KeyKeyword bool   // explicit leading KEY keyword
+	Key        Expr   // key expression
+	Separator  string // ":" or "VALUE"
+	Value      *JSONValueExpr
+	Loc        ast.Loc
+}
+
+// JSONArrayExpr is `JSON_ARRAY([elements] [null-handling] [RETURNING type
+// [FORMAT …]])` (jsonArray). Elements is the (possibly empty) element list.
+// NullHandling is "", "NULL ON NULL", or "ABSENT ON NULL".
+type JSONArrayExpr struct {
+	Elements        []*JSONValueExpr
+	NullHandling    string // "", "NULL ON NULL", or "ABSENT ON NULL"
+	Returning       *DataType
+	ReturningFormat *JSONFormat
+	Loc             ast.Loc
+}
+
+func (n *JSONArrayExpr) Span() ast.Loc { return n.Loc }
+func (*JSONArrayExpr) exprNode()       {}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+// parseJSONFunction is the entry point for the five SQL/JSON functions, invoked
+// by parsePrimaryAtom (expr.go) on a leading JSON_EXISTS / JSON_VALUE /
+// JSON_QUERY / JSON_OBJECT / JSON_ARRAY keyword. Because those names are
+// reserved (J3), the leading keyword unambiguously selects the function.
+func (p *Parser) parseJSONFunction() (Expr, error) {
+	switch p.cur.Kind {
+	case kwJSON_EXISTS:
+		return p.parseJSONExists()
+	case kwJSON_VALUE:
+		return p.parseJSONValue()
+	case kwJSON_QUERY:
+		return p.parseJSONQuery()
+	case kwJSON_OBJECT:
+		return p.parseJSONObject()
+	case kwJSON_ARRAY:
+		return p.parseJSONArray()
+	default:
+		// Unreachable via parsePrimaryAtom's dispatch; defensive.
+		return nil, p.exprErrorAt("expected a SQL/JSON function")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON_EXISTS
+// ---------------------------------------------------------------------------
+
+// parseJSONExists parses `JSON_EXISTS( jsonPathInvocation (behavior ON ERROR)? )`
+// (jsonExists). The leading JSON_EXISTS keyword is the current token.
+func (p *Parser) parseJSONExists() (Expr, error) {
+	startTok := p.advance() // consume JSON_EXISTS
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	path, err := p.parseJSONPathInvocation()
+	if err != nil {
+		return nil, err
+	}
+	je := &JSONExistsExpr{Path: path, Loc: ast.Loc{Start: startTok.Loc.Start}}
+
+	// (jsonExistsErrorBehavior ON ERROR)?
+	if behavior, ok := jsonExistsErrorBehaviorText(p.cur.Kind); ok && p.peekNext().Kind == kwON {
+		p.advance() // behavior keyword
+		p.advance() // ON
+		if _, err := p.expect(kwERROR); err != nil {
+			return nil, err
+		}
+		je.OnError = behavior
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	je.Loc.End = closeTok.Loc.End
+	return je, nil
+}
+
+// jsonExistsErrorBehaviorText maps a jsonExistsErrorBehavior keyword to its
+// canonical spelling (TRUE | FALSE | UNKNOWN | ERROR).
+func jsonExistsErrorBehaviorText(kind TokenKind) (string, bool) {
+	switch kind {
+	case kwTRUE:
+		return "TRUE", true
+	case kwFALSE:
+		return "FALSE", true
+	case kwUNKNOWN:
+		return "UNKNOWN", true
+	case kwERROR:
+		return "ERROR", true
+	default:
+		return "", false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON_VALUE
+// ---------------------------------------------------------------------------
+
+// parseJSONValue parses `JSON_VALUE( jsonPathInvocation (RETURNING type)?
+// (behavior ON EMPTY)? (behavior ON ERROR)? )` (jsonValue). The clause order is
+// fixed (J1). The leading JSON_VALUE keyword is the current token.
+func (p *Parser) parseJSONValue() (Expr, error) {
+	startTok := p.advance() // consume JSON_VALUE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	path, err := p.parseJSONPathInvocation()
+	if err != nil {
+		return nil, err
+	}
+	jv := &JSONValueFunc{Path: path, Loc: ast.Loc{Start: startTok.Loc.Start}}
+
+	// (RETURNING type)?
+	if p.cur.Kind == kwRETURNING {
+		p.advance() // consume RETURNING
+		typ, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		jv.Returning = typ
+	}
+
+	// (emptyBehavior ON EMPTY)? (errorBehavior ON ERROR)?  — each clause is
+	// self-identifying via its trailing ON EMPTY / ON ERROR. The grammar fixes
+	// EMPTY before ERROR (J1): an ON ERROR clause cannot precede an ON EMPTY one.
+	for p.startsJSONValueBehavior() {
+		behavior, slot, err := p.parseJSONValueBehaviorClause()
+		if err != nil {
+			return nil, err
+		}
+		switch slot {
+		case kwEMPTY:
+			if jv.OnEmpty != nil || jv.OnError != nil {
+				return nil, p.exprErrorAt("duplicate or misordered ON EMPTY in JSON_VALUE")
+			}
+			jv.OnEmpty = behavior
+		case kwERROR:
+			if jv.OnError != nil {
+				return nil, p.exprErrorAt("duplicate ON ERROR in JSON_VALUE")
+			}
+			jv.OnError = behavior
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	jv.Loc.End = closeTok.Loc.End
+	return jv, nil
+}
+
+// startsJSONValueBehavior reports whether the current token begins a
+// jsonValueBehavior clause (ERROR | NULL | DEFAULT).
+func (p *Parser) startsJSONValueBehavior() bool {
+	switch p.cur.Kind {
+	case kwERROR, kwNULL, kwDEFAULT:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseJSONValueBehaviorClause parses one `(ERROR | NULL | DEFAULT expression)
+// ON (EMPTY | ERROR)` clause (jsonValueBehavior + its ON tail), returning the
+// behavior and which slot (kwEMPTY or kwERROR) it fills. The slot is read from
+// the trailing keyword so the two clauses are disambiguated regardless of
+// order; ordering itself is enforced by the caller (J1).
+func (p *Parser) parseJSONValueBehaviorClause() (*JSONValueBehavior, TokenKind, error) {
+	startTok := p.cur
+	var b *JSONValueBehavior
+	switch p.cur.Kind {
+	case kwERROR:
+		p.advance()
+		b = &JSONValueBehavior{Kind: "ERROR", Loc: startTok.Loc}
+	case kwNULL:
+		p.advance()
+		b = &JSONValueBehavior{Kind: "NULL", Loc: startTok.Loc}
+	case kwDEFAULT:
+		p.advance()
+		def, err := p.parseExpr()
+		if err != nil {
+			return nil, 0, err
+		}
+		b = &JSONValueBehavior{Kind: "DEFAULT", Default: def, Loc: ast.Loc{Start: startTok.Loc.Start, End: def.Span().End}}
+	default:
+		return nil, 0, p.exprErrorAt("expected ERROR, NULL, or DEFAULT")
+	}
+	slot, err := p.expectOnSlot()
+	if err != nil {
+		return nil, 0, err
+	}
+	return b, slot, nil
+}
+
+// expectOnSlot consumes the required `ON (EMPTY | ERROR)` tail of a behavior
+// clause and returns the slot keyword (kwEMPTY or kwERROR). It errors if ON is
+// missing or the keyword is neither EMPTY nor ERROR.
+func (p *Parser) expectOnSlot() (TokenKind, error) {
+	if _, err := p.expect(kwON); err != nil {
+		return 0, err
+	}
+	switch p.cur.Kind {
+	case kwEMPTY:
+		p.advance()
+		return kwEMPTY, nil
+	case kwERROR:
+		p.advance()
+		return kwERROR, nil
+	default:
+		return 0, p.exprErrorAt("expected EMPTY or ERROR after ON")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON_QUERY
+// ---------------------------------------------------------------------------
+
+// parseJSONQuery parses `JSON_QUERY( jsonPathInvocation
+// (RETURNING type (FORMAT jsonRepresentation)?)? (wrapper WRAPPER)?
+// ((KEEP|OMIT) QUOTES (ON SCALAR STRING)?)? (behavior ON EMPTY)?
+// (behavior ON ERROR)? )` (jsonQuery). The clause order is fixed (J1). The
+// leading JSON_QUERY keyword is the current token.
+func (p *Parser) parseJSONQuery() (Expr, error) {
+	startTok := p.advance() // consume JSON_QUERY
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	path, err := p.parseJSONPathInvocation()
+	if err != nil {
+		return nil, err
+	}
+	jq := &JSONQueryFunc{Path: path, Loc: ast.Loc{Start: startTok.Loc.Start}}
+
+	// (RETURNING type (FORMAT jsonRepresentation)?)?
+	if p.cur.Kind == kwRETURNING {
+		p.advance() // consume RETURNING
+		typ, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		jq.Returning = typ
+		if p.cur.Kind == kwFORMAT {
+			format, err := p.parseJSONFormat()
+			if err != nil {
+				return nil, err
+			}
+			jq.ReturningFormat = format
+		}
+	}
+
+	// (jsonQueryWrapperBehavior WRAPPER)?
+	if wrapper, array, ok := p.tryJSONQueryWrapper(); ok {
+		jq.Wrapper = wrapper
+		jq.WrapperArray = array
+		if _, err := p.expect(kwWRAPPER); err != nil {
+			return nil, err
+		}
+	}
+
+	// ((KEEP | OMIT) QUOTES (ON SCALAR STRING)?)?
+	if p.cur.Kind == kwKEEP || p.cur.Kind == kwOMIT {
+		if p.cur.Kind == kwKEEP {
+			jq.Quotes = "KEEP"
+		} else {
+			jq.Quotes = "OMIT"
+		}
+		p.advance() // KEEP or OMIT
+		if _, err := p.expect(kwQUOTES); err != nil {
+			return nil, err
+		}
+		// (ON SCALAR STRING)?
+		if p.cur.Kind == kwON && p.peekNext().Kind == kwSCALAR {
+			p.advance() // ON
+			p.advance() // SCALAR
+			if _, err := p.expect(kwSTRING); err != nil {
+				return nil, err
+			}
+			jq.QuotesOnScalar = true
+		}
+	}
+
+	// (emptyBehavior ON EMPTY)? (errorBehavior ON ERROR)?  — each clause is
+	// self-identifying via its trailing ON EMPTY / ON ERROR, with EMPTY fixed
+	// before ERROR (J1).
+	for p.startsJSONQueryBehavior() {
+		behavior, slot, err := p.parseJSONQueryBehaviorClause()
+		if err != nil {
+			return nil, err
+		}
+		switch slot {
+		case kwEMPTY:
+			if jq.OnEmpty != nil || jq.OnError != nil {
+				return nil, p.exprErrorAt("duplicate or misordered ON EMPTY in JSON_QUERY")
+			}
+			jq.OnEmpty = behavior
+		case kwERROR:
+			if jq.OnError != nil {
+				return nil, p.exprErrorAt("duplicate ON ERROR in JSON_QUERY")
+			}
+			jq.OnError = behavior
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	jq.Loc.End = closeTok.Loc.End
+	return jq, nil
+}
+
+// tryJSONQueryWrapper recognizes an optional jsonQueryWrapperBehavior prefix
+// (`WITHOUT [ARRAY]` | `WITH [CONDITIONAL|UNCONDITIONAL] [ARRAY]`) WITHOUT
+// consuming the trailing WRAPPER keyword (the caller consumes it). It returns
+// ok=false when the current token is neither WITHOUT nor WITH. When ok, it has
+// consumed the behavior tokens (WITHOUT/WITH, the optional conditionality, and
+// the optional ARRAY) and returns the canonical wrapper spelling plus whether
+// ARRAY was present.
+//
+// WITH/WITHOUT are reserved keywords that begin no other JSON_QUERY clause, so
+// recognizing them here is unambiguous; the required WRAPPER keyword that must
+// follow is enforced by the caller's expect.
+func (p *Parser) tryJSONQueryWrapper() (wrapper string, array bool, ok bool) {
+	switch p.cur.Kind {
+	case kwWITHOUT:
+		p.advance() // WITHOUT
+		if p.cur.Kind == kwARRAY {
+			p.advance()
+			array = true
+		}
+		return "WITHOUT", array, true
+	case kwWITH:
+		p.advance() // WITH
+		wrapper = "WITH"
+		switch p.cur.Kind {
+		case kwCONDITIONAL:
+			p.advance()
+			wrapper = "WITH CONDITIONAL"
+		case kwUNCONDITIONAL:
+			p.advance()
+			wrapper = "WITH UNCONDITIONAL"
+		}
+		if p.cur.Kind == kwARRAY {
+			p.advance()
+			array = true
+		}
+		return wrapper, array, true
+	default:
+		return "", false, false
+	}
+}
+
+// startsJSONQueryBehavior reports whether the current token begins a
+// jsonQueryBehavior clause (ERROR | NULL | EMPTY …).
+func (p *Parser) startsJSONQueryBehavior() bool {
+	switch p.cur.Kind {
+	case kwERROR, kwNULL, kwEMPTY:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseJSONQueryBehaviorClause parses one `(ERROR | NULL | EMPTY (ARRAY|OBJECT))
+// ON (EMPTY | ERROR)` clause (jsonQueryBehavior + its ON tail), returning the
+// behavior and which slot (kwEMPTY or kwERROR) it fills. As with JSON_VALUE the
+// slot is read from the trailing keyword so the two clauses disambiguate
+// regardless of order; ordering is enforced by the caller (J1).
+func (p *Parser) parseJSONQueryBehaviorClause() (*JSONQueryBehavior, TokenKind, error) {
+	startTok := p.cur
+	var b *JSONQueryBehavior
+	switch p.cur.Kind {
+	case kwERROR:
+		p.advance()
+		b = &JSONQueryBehavior{Kind: "ERROR", Loc: startTok.Loc}
+	case kwNULL:
+		p.advance()
+		b = &JSONQueryBehavior{Kind: "NULL", Loc: startTok.Loc}
+	case kwEMPTY:
+		p.advance() // EMPTY
+		var kind string
+		switch p.cur.Kind {
+		case kwARRAY:
+			p.advance()
+			kind = "EMPTY ARRAY"
+		case kwOBJECT:
+			p.advance()
+			kind = "EMPTY OBJECT"
+		default:
+			return nil, 0, p.exprErrorAt("expected ARRAY or OBJECT after EMPTY")
+		}
+		b = &JSONQueryBehavior{Kind: kind, Loc: ast.Loc{Start: startTok.Loc.Start, End: p.prev.Loc.End}}
+	default:
+		return nil, 0, p.exprErrorAt("expected ERROR, NULL, or EMPTY")
+	}
+	slot, err := p.expectOnSlot()
+	if err != nil {
+		return nil, 0, err
+	}
+	return b, slot, nil
+}
+
+// ---------------------------------------------------------------------------
+// JSON_OBJECT
+// ---------------------------------------------------------------------------
+
+// parseJSONObject parses `JSON_OBJECT( (member (, member)* null-handling?
+// uniqueness?)? (RETURNING type (FORMAT …)?)? )` (jsonObject). The leading
+// JSON_OBJECT keyword is the current token.
+func (p *Parser) parseJSONObject() (Expr, error) {
+	startTok := p.advance() // consume JSON_OBJECT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	jo := &JSONObjectExpr{Loc: ast.Loc{Start: startTok.Loc.Start}}
+
+	// Members are present unless the next token closes the call or begins the
+	// trailing RETURNING clause. (Both NULL ON NULL / ABSENT ON NULL and the
+	// uniqueness clause may only FOLLOW at least one member, so an empty member
+	// list cannot start with them — confirmed by the oracle: `JSON_OBJECT(NULL
+	// ON NULL)` and `JSON_OBJECT(ABSENT ON NULL)` are SYNTAX_ERRORs.)
+	if p.cur.Kind != int(')') && p.cur.Kind != kwRETURNING {
+		first, err := p.parseJSONObjectMember()
+		if err != nil {
+			return nil, err
+		}
+		jo.Members = append(jo.Members, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			member, err := p.parseJSONObjectMember()
+			if err != nil {
+				return nil, err
+			}
+			jo.Members = append(jo.Members, member)
+		}
+
+		// (NULL ON NULL | ABSENT ON NULL)?
+		if nh, ok, err := p.tryJSONNullHandling(); err != nil {
+			return nil, err
+		} else if ok {
+			jo.NullHandling = nh
+		}
+
+		// (WITH UNIQUE KEYS? | WITHOUT UNIQUE KEYS?)?
+		if p.cur.Kind == kwWITH || p.cur.Kind == kwWITHOUT {
+			if p.cur.Kind == kwWITH {
+				jo.Uniqueness = "WITH UNIQUE"
+			} else {
+				jo.Uniqueness = "WITHOUT UNIQUE"
+			}
+			p.advance() // WITH or WITHOUT
+			if _, err := p.expect(kwUNIQUE); err != nil {
+				return nil, err
+			}
+			if p.cur.Kind == kwKEYS {
+				p.advance()
+				jo.UniqueKeys = true
+			}
+		}
+	}
+
+	// (RETURNING type (FORMAT jsonRepresentation)?)?
+	if p.cur.Kind == kwRETURNING {
+		typ, format, err := p.parseJSONReturning()
+		if err != nil {
+			return nil, err
+		}
+		jo.Returning = typ
+		jo.ReturningFormat = format
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	jo.Loc.End = closeTok.Loc.End
+	return jo, nil
+}
+
+// parseJSONObjectMember parses one `KEY? expression VALUE jsonValueExpression`
+// or `expression COLON jsonValueExpression` member (jsonObjectMember).
+//
+// Per J4, a leading `KEY` keyword is ambiguous with `KEY` used as the key
+// expression (KEY is non-reserved). The reading is resolved by speculation: when
+// the current token is KEY, try consuming it as the keyword and parsing
+// `expression VALUE value`; if that does not fit (e.g. `KEY VALUE 1`, where KEY
+// is really the key column), rewind and parse the member with KEY as the
+// expression's first token.
+func (p *Parser) parseJSONObjectMember() (JSONObjectMember, error) {
+	// Speculative KEY-as-keyword reading.
+	if p.cur.Kind == kwKEY {
+		cp := p.checkpoint()
+		keyTok := p.advance() // tentatively consume KEY as the keyword
+		if member, ok := p.tryJSONObjectMemberBody(keyTok.Loc.Start, true); ok {
+			return member, nil
+		}
+		p.restore(cp)
+	}
+
+	// No leading KEY keyword: KEY (if present) is the key expression's first
+	// token. The member must use `: value` or `VALUE value`.
+	start := p.cur.Loc.Start
+	if member, ok := p.tryJSONObjectMemberBody(start, false); ok {
+		return member, nil
+	}
+	return JSONObjectMember{}, p.exprErrorAt("expected a JSON_OBJECT member (key VALUE value or key : value)")
+}
+
+// tryJSONObjectMemberBody parses `expression (VALUE | COLON) jsonValueExpression`
+// after any leading KEY keyword has been handled, returning ok=false (leaving
+// the cursor for the caller's restore) when the shape does not fit. keyKeyword
+// records whether the caller consumed a leading KEY; start is the member's span
+// start. A hard error inside the value (after the separator commits the reading)
+// is surfaced via ok=false so the outer parser reports a single member error;
+// the separators here are mandatory, so a missing separator simply means "not
+// this reading."
+func (p *Parser) tryJSONObjectMemberBody(start int, keyKeyword bool) (JSONObjectMember, bool) {
+	key, err := p.parseExpr()
+	if err != nil {
+		return JSONObjectMember{}, false
+	}
+	switch p.cur.Kind {
+	case kwVALUE:
+		p.advance() // consume VALUE
+		value, err := p.parseJSONValueExpr()
+		if err != nil {
+			return JSONObjectMember{}, false
+		}
+		return JSONObjectMember{
+			KeyKeyword: keyKeyword,
+			Key:        key,
+			Separator:  "VALUE",
+			Value:      value,
+			Loc:        ast.Loc{Start: start, End: value.Loc.End},
+		}, true
+	case int(':'):
+		// The colon form has no leading KEY keyword in the grammar; if the caller
+		// consumed KEY this reading is invalid (forces a rewind to the non-keyword
+		// path, which will re-parse KEY as part of the key expression).
+		if keyKeyword {
+			return JSONObjectMember{}, false
+		}
+		p.advance() // consume ':'
+		value, err := p.parseJSONValueExpr()
+		if err != nil {
+			return JSONObjectMember{}, false
+		}
+		return JSONObjectMember{
+			Key:       key,
+			Separator: ":",
+			Value:     value,
+			Loc:       ast.Loc{Start: start, End: value.Loc.End},
+		}, true
+	default:
+		return JSONObjectMember{}, false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON_ARRAY
+// ---------------------------------------------------------------------------
+
+// parseJSONArray parses `JSON_ARRAY( (jsonValueExpression (, jsonValueExpression)*
+// null-handling?)? (RETURNING type (FORMAT …)?)? )` (jsonArray). Per J5 the
+// element list is parsed first (a leading NULL is an element), then the
+// null-handling clause is recognized only after the list. The leading JSON_ARRAY
+// keyword is the current token.
+func (p *Parser) parseJSONArray() (Expr, error) {
+	startTok := p.advance() // consume JSON_ARRAY
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	ja := &JSONArrayExpr{Loc: ast.Loc{Start: startTok.Loc.Start}}
+
+	// Elements are present unless the next token closes the call or begins the
+	// trailing RETURNING clause.
+	if p.cur.Kind != int(')') && p.cur.Kind != kwRETURNING {
+		first, err := p.parseJSONValueExpr()
+		if err != nil {
+			return nil, err
+		}
+		ja.Elements = append(ja.Elements, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			elem, err := p.parseJSONValueExpr()
+			if err != nil {
+				return nil, err
+			}
+			ja.Elements = append(ja.Elements, elem)
+		}
+
+		// (NULL ON NULL | ABSENT ON NULL)?
+		if nh, ok, err := p.tryJSONNullHandling(); err != nil {
+			return nil, err
+		} else if ok {
+			ja.NullHandling = nh
+		}
+	}
+
+	// (RETURNING type (FORMAT jsonRepresentation)?)?
+	if p.cur.Kind == kwRETURNING {
+		typ, format, err := p.parseJSONReturning()
+		if err != nil {
+			return nil, err
+		}
+		ja.Returning = typ
+		ja.ReturningFormat = format
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ja.Loc.End = closeTok.Loc.End
+	return ja, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// parseJSONPathInvocation parses `jsonValueExpression , path = string_
+// (PASSING jsonArgument (, jsonArgument)*)?` (jsonPathInvocation): the JSON input
+// value expression, a mandatory comma, the path STRING LITERAL (J2), and an
+// optional PASSING argument list. The opening '(' has already been consumed.
+func (p *Parser) parseJSONPathInvocation() (*JSONPathInvocation, error) {
+	input, err := p.parseJSONValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+
+	// path = string_ — a string LITERAL, not an arbitrary expression (J2).
+	if p.cur.Kind != tokString && p.cur.Kind != tokUnicodeString {
+		return nil, p.exprErrorAt("expected a string literal JSON path")
+	}
+	pathTok := p.advance()
+
+	pi := &JSONPathInvocation{
+		Input: input,
+		Path:  pathTok.Str,
+		Loc:   ast.Loc{Start: input.Loc.Start, End: pathTok.Loc.End},
+	}
+
+	// (PASSING jsonArgument (, jsonArgument)*)?
+	if p.cur.Kind == kwPASSING {
+		p.advance() // consume PASSING
+		first, err := p.parseJSONArgument()
+		if err != nil {
+			return nil, err
+		}
+		pi.Passing = append(pi.Passing, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			arg, err := p.parseJSONArgument()
+			if err != nil {
+				return nil, err
+			}
+			pi.Passing = append(pi.Passing, arg)
+		}
+		pi.Loc.End = pi.Passing[len(pi.Passing)-1].Loc.End
+	}
+
+	return pi, nil
+}
+
+// parseJSONValueExpr parses `expression (FORMAT jsonRepresentation)?`
+// (jsonValueExpression): a full expression optionally tagged with a JSON FORMAT.
+func (p *Parser) parseJSONValueExpr() (*JSONValueExpr, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	jve := &JSONValueExpr{Expr: expr, Loc: ast.Loc{Start: expr.Span().Start, End: expr.Span().End}}
+	if p.cur.Kind == kwFORMAT {
+		format, err := p.parseJSONFormat()
+		if err != nil {
+			return nil, err
+		}
+		jve.Format = format
+		jve.Loc.End = format.Loc.End
+	}
+	return jve, nil
+}
+
+// parseJSONFormat parses `FORMAT JSON (ENCODING (UTF8|UTF16|UTF32))?`
+// (jsonRepresentation). Only the JSON representation keyword is accepted by
+// Trino 481 (e.g. `FORMAT XML` is a SYNTAX_ERROR). FORMAT is the current token.
+func (p *Parser) parseJSONFormat() (*JSONFormat, error) {
+	formatTok := p.advance() // consume FORMAT
+	// The representation keyword must be JSON (the non-reserved kwJSON token).
+	if p.cur.Kind != kwJSON {
+		return nil, p.exprErrorAt("expected JSON after FORMAT")
+	}
+	jsonTok := p.advance() // consume JSON
+	jf := &JSONFormat{Loc: ast.Loc{Start: formatTok.Loc.Start, End: jsonTok.Loc.End}}
+
+	if p.cur.Kind == kwENCODING {
+		p.advance() // consume ENCODING
+		switch p.cur.Kind {
+		case kwUTF8:
+			jf.Encoding = "UTF8"
+		case kwUTF16:
+			jf.Encoding = "UTF16"
+		case kwUTF32:
+			jf.Encoding = "UTF32"
+		default:
+			return nil, p.exprErrorAt("expected UTF8, UTF16, or UTF32 after ENCODING")
+		}
+		encTok := p.advance()
+		jf.Loc.End = encTok.Loc.End
+	}
+	return jf, nil
+}
+
+// parseJSONArgument parses one `jsonValueExpression AS identifier` PASSING
+// argument (jsonArgument).
+func (p *Parser) parseJSONArgument() (JSONArgument, error) {
+	value, err := p.parseJSONValueExpr()
+	if err != nil {
+		return JSONArgument{}, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return JSONArgument{}, err
+	}
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return JSONArgument{}, err
+	}
+	return JSONArgument{
+		Value: value,
+		Name:  name,
+		Loc:   ast.Loc{Start: value.Loc.Start, End: name.Loc.End},
+	}, nil
+}
+
+// parseJSONReturning parses `RETURNING type (FORMAT jsonRepresentation)?`, the
+// shared trailing clause of JSON_OBJECT and JSON_ARRAY. RETURNING is the current
+// token. Returns the type and the optional FORMAT (nil when absent).
+func (p *Parser) parseJSONReturning() (*DataType, *JSONFormat, error) {
+	p.advance() // consume RETURNING
+	typ, err := p.parseType()
+	if err != nil {
+		return nil, nil, err
+	}
+	var format *JSONFormat
+	if p.cur.Kind == kwFORMAT {
+		format, err = p.parseJSONFormat()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return typ, format, nil
+}
+
+// tryJSONNullHandling recognizes an optional `NULL ON NULL | ABSENT ON NULL`
+// clause shared by JSON_OBJECT and JSON_ARRAY, returning ok=false (consuming
+// nothing) when the current tokens do not begin such a clause. The clause is
+// detected by its two-token prefix (`NULL ON` / `ABSENT ON`); once that prefix
+// is consumed the trailing `NULL` is mandatory — Trino 481 rejects `… NULL ON
+// ERROR` / `… NULL ON` (oracle-confirmed), so a missing or wrong trailing token
+// is a hard error here rather than a rewind.
+func (p *Parser) tryJSONNullHandling() (string, bool, error) {
+	var canonical string
+	switch p.cur.Kind {
+	case kwNULL:
+		if p.peekNext().Kind != kwON {
+			return "", false, nil
+		}
+		canonical = "NULL ON NULL"
+	case kwABSENT:
+		if p.peekNext().Kind != kwON {
+			return "", false, nil
+		}
+		canonical = "ABSENT ON NULL"
+	default:
+		return "", false, nil
+	}
+	p.advance() // NULL or ABSENT
+	p.advance() // ON
+	if _, err := p.expect(kwNULL); err != nil {
+		return "", false, err
+	}
+	return canonical, true, nil
+}

--- a/trino/parser/json_test.go
+++ b/trino/parser/json_test.go
@@ -1,0 +1,449 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the expr-json node's correctness gate (correctness-protocol.md).
+// It proves the SQL/JSON function parser in json.go against three layers:
+//
+//  1. Accept/reject corpus — every documented Trino-481 SQL/JSON form (truth1:
+//     docs/migration/trino/truth1/types-expr-functions.md json-* sections) plus
+//     the legacy-grammar forms (truth2: TrinoParser.g4 jsonExists/jsonValue/
+//     jsonQuery/jsonObject/jsonArray and helper rules) and oracle-discovered
+//     edge cases, each tagged accept or reject.
+//  2. Oracle differential (TestJSON_OracleDifferential) — the authoritative
+//     gate: omni's ParseExpression accept/reject MUST equal Trino 481's
+//     accept/reject of `SELECT <expr>`. Skipped when no oracle is reachable.
+//  3. Structural assertions (TestJSON_Structure) — for representative forms, the
+//     produced AST has the expected shape (function kind, behavior spellings,
+//     member separators, null-handling, RETURNING type), catching wrong
+//     field-population that the accept/reject gate cannot see.
+//
+// Completeness checklist (every grammar rule + doc form → its test, 100%):
+//
+//	jsonExists                  → exists_* accept cases + missing-path/bare-ON reject
+//	jsonValue                   → value_* accept cases (RETURNING, ON EMPTY/ERROR, DEFAULT)
+//	jsonQuery                   → query_* accept cases (RETURNING+FORMAT, WRAPPER, QUOTES, ON EMPTY/ERROR)
+//	jsonObject                  → object_* accept cases (: and VALUE and KEY members, null/uniqueness/RETURNING)
+//	jsonArray                   → array_* accept cases (elements, null-handling, RETURNING+FORMAT)
+//	jsonPathInvocation          → every function's path arg; PASSING single/multi
+//	jsonValueExpression         → FORMAT-tagged input/value/element/arg/passing
+//	jsonRepresentation          → FORMAT JSON [ENCODING UTF8|UTF16|UTF32]; FORMAT XML / bad encoding reject
+//	jsonArgument                → PASSING <expr> [FORMAT] AS <ident>, single & multi
+//	jsonExistsErrorBehavior     → TRUE|FALSE|UNKNOWN|ERROR ON ERROR
+//	jsonValueBehavior           → ERROR|NULL|DEFAULT expr (ON EMPTY / ON ERROR)
+//	jsonQueryWrapperBehavior    → WITHOUT [ARRAY] | WITH [CONDITIONAL|UNCONDITIONAL] [ARRAY]
+//	jsonQueryBehavior           → ERROR|NULL|EMPTY (ARRAY|OBJECT)
+//	jsonObjectMember            → KEY? expr VALUE val | expr : val  (incl. KEY-as-expr J4)
+//	clause-ordering (J1)        → out-of-order clause reject cases
+//	path-literal (J2)           → non-literal path reject cases
+//	reserved-name (J3)          → bare JSON_* name reject (covered in expr node; re-asserted here)
+//	null-vs-element (J5)        → array_null_* cases + JSON_ARRAY(NULL ON NULL) reject
+
+// jsonAcceptCorpus is every SQL/JSON expression form omni must accept, drawn from
+// the truth1 docs (each json-* section's example_sql), the legacy grammar, and
+// the oracle probes. The oracle differential proves these actually parse in
+// Trino 481; here they are also smoke-tested oracle-free for parse success.
+var jsonAcceptCorpus = []string{
+	// --- JSON_EXISTS (jsonExists) ---
+	"JSON_EXISTS(description, 'lax $.children[*]?(@ > 10)')",
+	"JSON_EXISTS(doc, 'strict $.name' PASSING 'Alice' AS name_param)",
+	"JSON_EXISTS(col, '$.x' FALSE ON ERROR)",
+	"JSON_EXISTS(col, '$.x' TRUE ON ERROR)",
+	"JSON_EXISTS(col, '$.x' UNKNOWN ON ERROR)",
+	"JSON_EXISTS(col, '$.x' ERROR ON ERROR)",
+	"JSON_EXISTS(col FORMAT JSON, '$.x')",
+	"JSON_EXISTS(col FORMAT JSON ENCODING UTF8, '$.x')",
+	"JSON_EXISTS(col, '$.x' PASSING 1 AS a, 2 AS b)",
+	"JSON_EXISTS(c || d, '$.x')",
+	"JSON_EXISTS(CAST(c AS varchar) FORMAT JSON, '$.x')",
+	"JSON_EXISTS(c, '$.x' PASSING d FORMAT JSON AS doc)",
+	"JSON_EXISTS(c, '$.x' PASSING d FORMAT JSON ENCODING UTF16 AS doc, 5 AS num)",
+
+	// --- JSON_VALUE (jsonValue) ---
+	"JSON_VALUE(description, 'lax $.children[0]' RETURNING tinyint)",
+	"JSON_VALUE(doc, '$.name' DEFAULT 'unknown' ON EMPTY)",
+	"JSON_VALUE(col, 'strict $.id' ERROR ON ERROR)",
+	"JSON_VALUE(col, '$.x' NULL ON EMPTY NULL ON ERROR)",
+	"JSON_VALUE(col, '$.x' DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)",
+	"JSON_VALUE(col, '$.x' RETURNING varchar DEFAULT 'a' ON EMPTY)",
+	"JSON_VALUE(c, '$.x' DEFAULT 1 + 2 ON EMPTY)",
+	"JSON_VALUE(c, '$.x' DEFAULT 'a' || 'b' ON ERROR)",
+	"JSON_VALUE(c, '$.x' RETURNING DECIMAL(10,2))",
+	"JSON_VALUE(c, '$.x' RETURNING int ERROR ON EMPTY NULL ON ERROR)",
+	"JSON_VALUE(c, '$.x')", // bare (no RETURNING/behaviors)
+	"JSON_VALUE(c FORMAT JSON, '$.x')",
+	"JSON_VALUE(c, '$.x' PASSING a AS x, b FORMAT JSON AS y)",
+
+	// --- JSON_QUERY (jsonQuery) ---
+	"JSON_QUERY(description, 'lax $.children[last]' WITH ARRAY WRAPPER)",
+	"JSON_QUERY(doc, 'strict $.tags' RETURNING varchar)",
+	"JSON_QUERY(col, 'lax $.x' OMIT QUOTES ON SCALAR STRING NULL ON EMPTY)",
+	"JSON_QUERY(col, '$.x' WITHOUT WRAPPER)",
+	"JSON_QUERY(col, '$.x' WITHOUT ARRAY WRAPPER)",
+	"JSON_QUERY(col, '$.x' WITH CONDITIONAL ARRAY WRAPPER)",
+	"JSON_QUERY(col, '$.x' WITH UNCONDITIONAL WRAPPER)",
+	"JSON_QUERY(col, '$.x' KEEP QUOTES)",
+	"JSON_QUERY(col, '$.x' EMPTY ARRAY ON EMPTY EMPTY OBJECT ON ERROR)",
+	"JSON_QUERY(col, '$.x' RETURNING varchar FORMAT JSON WITH ARRAY WRAPPER)",
+	"JSON_QUERY(c, '$.x' KEEP QUOTES ON SCALAR STRING)",
+	"JSON_QUERY(c, '$.x' RETURNING ARRAY(int))",
+	"JSON_QUERY(c, '$.x' WITH ARRAY WRAPPER KEEP QUOTES ERROR ON EMPTY ERROR ON ERROR)",
+	"JSON_QUERY(c, '$.x')",              // bare (no optional clauses)
+	"JSON_QUERY(c, '$.x' WITH WRAPPER)", // WITH WRAPPER, no ARRAY/conditionality
+	"JSON_QUERY(c FORMAT JSON, '$.x' NULL ON EMPTY)",
+
+	// --- JSON_OBJECT (jsonObject) ---
+	"JSON_OBJECT('x' : true, 'y' : 1.2, 'z' : 'text')",
+	"JSON_OBJECT(KEY 'name' VALUE 'Alice', KEY 'age' VALUE 30)",
+	"JSON_OBJECT('x' : null, 'y' : 1 ABSENT ON NULL)",
+	"JSON_OBJECT('a' : 1 WITH UNIQUE KEYS)",
+	"JSON_OBJECT('a' VALUE 1)",
+	"JSON_OBJECT()",
+	"JSON_OBJECT('a' : 1 NULL ON NULL RETURNING varchar)",
+	"JSON_OBJECT('a' : 1 WITHOUT UNIQUE)",
+	"JSON_OBJECT('a' : 1 WITH UNIQUE)",
+	"JSON_OBJECT('k' VALUE 1 FORMAT JSON)",
+	"JSON_OBJECT(KEY 'a' VALUE 1, 'b' : 2)",
+	"JSON_OBJECT(KEY VALUE 1)",   // KEY as the key expression (J4)
+	"JSON_OBJECT(k VALUE 1)",     // bare column key
+	"JSON_OBJECT(KEY k VALUE 1)", // KEY keyword + column key
+	"JSON_OBJECT(KEY 'x' VALUE 1)",
+	"JSON_OBJECT(KEY KEY VALUE 1)", // KEY keyword + KEY-as-column key
+	"JSON_OBJECT(value VALUE 1)",   // VALUE as the key expression
+	"JSON_OBJECT('a' || 'b' VALUE 1)",
+	"JSON_OBJECT(concat('a','b') VALUE 1)",
+	"JSON_OBJECT('a' : 1 + 2)",
+	"JSON_OBJECT('a' VALUE 1 + 2)",
+	"JSON_OBJECT('k' VALUE col FORMAT JSON)",
+	"JSON_OBJECT('k' : col FORMAT JSON ENCODING UTF8)",
+	"JSON_OBJECT(RETURNING varchar)",
+	"JSON_OBJECT('a' : 1, KEY 'b' VALUE 2, 'c' VALUE 3)",
+	"JSON_OBJECT('a':1 WITHOUT UNIQUE KEYS)",
+	"JSON_OBJECT(KEY 'a' VALUE 1 NULL ON NULL)",        // KEY member then null-handling
+	"JSON_OBJECT('a':1 RETURNING varchar FORMAT JSON)", // RETURNING type + FORMAT (allowed here, unlike JSON_VALUE)
+
+	// --- JSON_ARRAY (jsonArray) ---
+	"JSON_ARRAY(true, 12e-1, 'text')",
+	"JSON_ARRAY(true, null, 1)",
+	"JSON_ARRAY(1, 2, 3 NULL ON NULL)",
+	"JSON_ARRAY(x, y RETURNING varbinary FORMAT JSON ENCODING UTF8)",
+	"JSON_ARRAY()",
+	"JSON_ARRAY(1 ABSENT ON NULL RETURNING varchar)",
+	"JSON_ARRAY(NULL)",           // single NULL element (J5)
+	"JSON_ARRAY(1, NULL)",        // NULL as a later element
+	"JSON_ARRAY(1 NULL ON NULL)", // element + NULL-ON-NULL (J5)
+	"JSON_ARRAY(RETURNING varchar)",
+	"JSON_ARRAY(absent)",           // ABSENT (non-reserved) as a column element
+	"JSON_ARRAY(x ABSENT ON NULL)", // element + ABSENT-ON-NULL handling (J5)
+	"JSON_ARRAY(1 RETURNING varchar FORMAT JSON)",
+
+	// --- nesting & composition ---
+	"JSON_VALUE(JSON_QUERY(c, '$.a'), '$.b')",
+	"JSON_OBJECT('k' : JSON_QUERY(c, '$.a'))",
+	"JSON_ARRAY(JSON_VALUE(c, '$.a'), JSON_VALUE(c, '$.b'))",
+}
+
+// jsonRejectCorpus is every SQL/JSON form omni must reject, mirroring Trino 481
+// (oracle-confirmed). Covers the missing-mandatory-part errors, the fixed
+// clause-ordering (J1), the path-must-be-literal rule (J2), the reserved bare
+// name (J3), the EMPTY-without-ARRAY/OBJECT error, the null-handling-without-a-
+// member error, and the bad-FORMAT / bad-ENCODING errors.
+var jsonRejectCorpus = []string{
+	// JSON_EXISTS: path is mandatory; ON ERROR needs a behavior keyword.
+	"JSON_EXISTS(col)",
+	"JSON_EXISTS(col, '$.x' ON ERROR)",
+	"JSON_EXISTS(c, somecol)",                          // path must be a string literal (J2)
+	"JSON_EXISTS(c, '$.x' PASSING)",                    // PASSING needs at least one arg
+	"JSON_EXISTS(c FORMAT XML, '$.x')",                 // FORMAT only allows JSON
+	"JSON_EXISTS(c FORMAT JSON ENCODING UTF99, '$.x')", // bad encoding
+
+	// JSON_VALUE: ordering is fixed (J1) — ON ERROR cannot precede ON EMPTY;
+	// neither ON EMPTY nor ON ERROR may repeat.
+	"JSON_VALUE(c, '$.x' NULL ON ERROR ERROR ON EMPTY)",
+	"JSON_VALUE(c, '$.x' NULL ON EMPTY NULL ON EMPTY)",
+	"JSON_VALUE(c, '$.x' NULL ON ERROR NULL ON ERROR)",
+	"JSON_VALUE(c, '$.x' NULL ON EMPTY NULL ON ERROR NULL ON ERROR)",
+	// JSON_VALUE's RETURNING takes a bare type — no FORMAT clause (unlike
+	// JSON_QUERY/JSON_OBJECT/JSON_ARRAY), so a trailing FORMAT is rejected.
+	"JSON_VALUE(c, '$.x' RETURNING varchar FORMAT JSON)",
+	"JSON_VALUE(c, '$.x' || 'y')", // path must be a literal (J2)
+
+	// JSON_QUERY: ordering is fixed (J1) — QUOTES cannot precede WRAPPER.
+	"JSON_QUERY(c, '$.x' KEEP QUOTES WITH ARRAY WRAPPER)",
+	"JSON_QUERY(col, '$.x' ON SCALAR STRING)",          // ON SCALAR STRING needs the QUOTES clause
+	"JSON_QUERY(c, '$.x' KEEP QUOTES ON SCALAR)",       // ON SCALAR requires the trailing STRING
+	"JSON_QUERY(c, '$.x' KEEP)",                        // KEEP requires QUOTES
+	"JSON_QUERY(c, '$.x' NULL ON EMPTY NULL ON EMPTY)", // duplicate ON EMPTY
+
+	// JSON_OBJECT: a member needs a separator; null-handling/uniqueness cannot
+	// appear without a member.
+	"JSON_OBJECT('k')",
+	"JSON_OBJECT('k' :)",
+	"JSON_OBJECT('k' VALUE)",
+	"JSON_OBJECT(NULL ON NULL)",
+	"JSON_OBJECT(ABSENT ON NULL)",
+	"JSON_OBJECT(KEY)",                                // KEY-as-column key, but no VALUE separator
+	"JSON_OBJECT('a':1, NULL ON NULL ABSENT ON NULL)", // double null-handling
+
+	// JSON_ARRAY: a leading null-handling clause (no element) is rejected (J5);
+	// the trailing token of the clause must be NULL.
+	"JSON_ARRAY(NULL ON NULL)",
+	"JSON_ARRAY(NULL ON NULL ABSENT ON NULL)",
+	"JSON_ARRAY(ABSENT ON NULL)",    // leading null-handling without an element (J5)
+	"JSON_ARRAY(1, ABSENT ON NULL)", // null-handling clause cannot follow a comma
+	"JSON_ARRAY(1 NULL ON ERROR)",
+	"JSON_ARRAY(1 NULL ON)",
+
+	// Reserved bare names (J3) — cannot be column references.
+	"JSON_EXISTS",
+	"JSON_VALUE",
+	"JSON_QUERY",
+	"JSON_OBJECT",
+	"JSON_ARRAY",
+}
+
+// TestJSON_AcceptCorpusParses verifies omni accepts every form in
+// jsonAcceptCorpus (oracle-free completeness smoke test). The oracle differential
+// proves the verdicts actually match Trino.
+func TestJSON_AcceptCorpusParses(t *testing.T) {
+	for _, expr := range jsonAcceptCorpus {
+		t.Run(truncateName(expr), func(t *testing.T) {
+			node, errs := ParseExpression(expr)
+			if len(errs) != 0 {
+				t.Errorf("ParseExpression(%q) should accept, got errors: %v", expr, errs)
+			}
+			if node == nil {
+				t.Errorf("ParseExpression(%q) returned nil node", expr)
+			}
+		})
+	}
+}
+
+// TestJSON_RejectCorpusRejected verifies omni rejects every form in
+// jsonRejectCorpus (required negative coverage per the correctness protocol).
+func TestJSON_RejectCorpusRejected(t *testing.T) {
+	for _, expr := range jsonRejectCorpus {
+		t.Run(truncateName(expr), func(t *testing.T) {
+			_, errs := ParseExpression(expr)
+			if len(errs) == 0 {
+				t.Errorf("ParseExpression(%q) should reject, but accepted", expr)
+			}
+		})
+	}
+}
+
+// TestJSON_OracleDifferential is the authoritative accept/reject gate: for every
+// form in both corpora, omni's ParseExpression accept/reject must equal Trino
+// 481's accept/reject of `SELECT <expr>`. Skipped when no oracle is reachable.
+func TestJSON_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+
+	check := func(t *testing.T, expr string) {
+		_, errs := ParseExpression(expr)
+		omniAccepts := len(errs) == 0
+
+		trinoAccepts, ok := oracleAccepts(t, o, wrapExpr(expr))
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH expr=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				expr, omniAccepts, errs, trinoAccepts)
+		}
+	}
+
+	t.Run("accept", func(t *testing.T) {
+		for _, expr := range jsonAcceptCorpus {
+			expr := expr
+			t.Run(truncateName(expr), func(t *testing.T) { check(t, expr) })
+		}
+	})
+	t.Run("reject", func(t *testing.T) {
+		for _, expr := range jsonRejectCorpus {
+			expr := expr
+			t.Run(truncateName(expr), func(t *testing.T) { check(t, expr) })
+		}
+	})
+}
+
+// TestJSON_Structure asserts the parsed AST shape for representative forms: the
+// accept/reject gate cannot see whether fields are populated correctly, so this
+// checks the function kind, behavior spellings, member separators, null-handling
+// and RETURNING type are set as expected. (Structural gate, correctness-protocol.md.)
+func TestJSON_Structure(t *testing.T) {
+	t.Run("exists_on_error", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_EXISTS(c, '$.x' FALSE ON ERROR)")
+		je, ok := e.(*JSONExistsExpr)
+		if !ok {
+			t.Fatalf("got %T, want *JSONExistsExpr", e)
+		}
+		if je.OnError != "FALSE" {
+			t.Errorf("OnError = %q, want FALSE", je.OnError)
+		}
+		if je.Path == nil || je.Path.Path != "$.x" {
+			t.Errorf("path = %+v, want path string %q", je.Path, "$.x")
+		}
+	})
+
+	t.Run("exists_passing", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_EXISTS(c, '$.x' PASSING 1 AS a, 2 AS b)")
+		je := e.(*JSONExistsExpr)
+		if got := len(je.Path.Passing); got != 2 {
+			t.Fatalf("PASSING count = %d, want 2", got)
+		}
+		if je.Path.Passing[0].Name.Value != "a" || je.Path.Passing[1].Name.Value != "b" {
+			t.Errorf("PASSING names = %q, %q, want a, b",
+				je.Path.Passing[0].Name.Value, je.Path.Passing[1].Name.Value)
+		}
+	})
+
+	t.Run("value_returning_default", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_VALUE(c, '$.x' RETURNING varchar DEFAULT 'a' ON EMPTY)")
+		jv, ok := e.(*JSONValueFunc)
+		if !ok {
+			t.Fatalf("got %T, want *JSONValueFunc", e)
+		}
+		if jv.Returning == nil {
+			t.Errorf("Returning is nil, want a varchar type")
+		}
+		if jv.OnEmpty == nil || jv.OnEmpty.Kind != "DEFAULT" || jv.OnEmpty.Default == nil {
+			t.Errorf("OnEmpty = %+v, want DEFAULT with expr", jv.OnEmpty)
+		}
+		if jv.OnError != nil {
+			t.Errorf("OnError = %+v, want nil", jv.OnError)
+		}
+	})
+
+	t.Run("query_wrapper_quotes", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_QUERY(c, '$.x' WITH CONDITIONAL ARRAY WRAPPER OMIT QUOTES ON SCALAR STRING NULL ON EMPTY)")
+		jq, ok := e.(*JSONQueryFunc)
+		if !ok {
+			t.Fatalf("got %T, want *JSONQueryFunc", e)
+		}
+		if jq.Wrapper != "WITH CONDITIONAL" || !jq.WrapperArray {
+			t.Errorf("wrapper = %q array=%v, want WITH CONDITIONAL array=true", jq.Wrapper, jq.WrapperArray)
+		}
+		if jq.Quotes != "OMIT" || !jq.QuotesOnScalar {
+			t.Errorf("quotes = %q onScalar=%v, want OMIT onScalar=true", jq.Quotes, jq.QuotesOnScalar)
+		}
+		if jq.OnEmpty == nil || jq.OnEmpty.Kind != "NULL" {
+			t.Errorf("OnEmpty = %+v, want NULL", jq.OnEmpty)
+		}
+	})
+
+	t.Run("query_empty_behavior", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_QUERY(c, '$.x' EMPTY ARRAY ON EMPTY EMPTY OBJECT ON ERROR)")
+		jq := e.(*JSONQueryFunc)
+		if jq.OnEmpty == nil || jq.OnEmpty.Kind != "EMPTY ARRAY" {
+			t.Errorf("OnEmpty = %+v, want EMPTY ARRAY", jq.OnEmpty)
+		}
+		if jq.OnError == nil || jq.OnError.Kind != "EMPTY OBJECT" {
+			t.Errorf("OnError = %+v, want EMPTY OBJECT", jq.OnError)
+		}
+	})
+
+	t.Run("object_members_mixed_separators", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_OBJECT('a' : 1, KEY 'b' VALUE 2, 'c' VALUE 3)")
+		jo, ok := e.(*JSONObjectExpr)
+		if !ok {
+			t.Fatalf("got %T, want *JSONObjectExpr", e)
+		}
+		if len(jo.Members) != 3 {
+			t.Fatalf("members = %d, want 3", len(jo.Members))
+		}
+		if jo.Members[0].Separator != ":" || jo.Members[0].KeyKeyword {
+			t.Errorf("member 0 = %+v, want ':' no-KEY", jo.Members[0])
+		}
+		if jo.Members[1].Separator != "VALUE" || !jo.Members[1].KeyKeyword {
+			t.Errorf("member 1 = %+v, want VALUE with KEY", jo.Members[1])
+		}
+		if jo.Members[2].Separator != "VALUE" || jo.Members[2].KeyKeyword {
+			t.Errorf("member 2 = %+v, want VALUE no-KEY", jo.Members[2])
+		}
+	})
+
+	t.Run("object_key_as_expression", func(t *testing.T) {
+		// JSON_OBJECT(KEY VALUE 1): KEY is the key column, not the keyword (J4).
+		e := mustParseJSON(t, "JSON_OBJECT(KEY VALUE 1)")
+		jo := e.(*JSONObjectExpr)
+		if len(jo.Members) != 1 {
+			t.Fatalf("members = %d, want 1", len(jo.Members))
+		}
+		m := jo.Members[0]
+		if m.KeyKeyword {
+			t.Errorf("KeyKeyword = true, want false (KEY is the key expression here)")
+		}
+		// KEY is parsed as a non-reserved-keyword identifier; its Value preserves
+		// the source case ("KEY") and Normalize folds it to "key".
+		if cr, ok := m.Key.(*ColumnRef); !ok || cr.Name.Normalize() != "key" {
+			t.Errorf("key = %+v, want ColumnRef normalizing to key", m.Key)
+		}
+	})
+
+	t.Run("object_null_handling_uniqueness", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_OBJECT('a' : 1 ABSENT ON NULL WITH UNIQUE KEYS RETURNING varchar)")
+		jo := e.(*JSONObjectExpr)
+		if jo.NullHandling != "ABSENT ON NULL" {
+			t.Errorf("NullHandling = %q, want ABSENT ON NULL", jo.NullHandling)
+		}
+		if jo.Uniqueness != "WITH UNIQUE" || !jo.UniqueKeys {
+			t.Errorf("uniqueness = %q keys=%v, want WITH UNIQUE keys=true", jo.Uniqueness, jo.UniqueKeys)
+		}
+		if jo.Returning == nil {
+			t.Errorf("Returning is nil, want varchar")
+		}
+	})
+
+	t.Run("array_elements_null_handling", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_ARRAY(1, 2, 3 NULL ON NULL)")
+		ja, ok := e.(*JSONArrayExpr)
+		if !ok {
+			t.Fatalf("got %T, want *JSONArrayExpr", e)
+		}
+		if len(ja.Elements) != 3 {
+			t.Fatalf("elements = %d, want 3", len(ja.Elements))
+		}
+		if ja.NullHandling != "NULL ON NULL" {
+			t.Errorf("NullHandling = %q, want NULL ON NULL", ja.NullHandling)
+		}
+	})
+
+	t.Run("array_single_null_element", func(t *testing.T) {
+		// JSON_ARRAY(NULL): one NULL element, NO null-handling clause (J5).
+		e := mustParseJSON(t, "JSON_ARRAY(NULL)")
+		ja := e.(*JSONArrayExpr)
+		if len(ja.Elements) != 1 {
+			t.Fatalf("elements = %d, want 1", len(ja.Elements))
+		}
+		if ja.NullHandling != "" {
+			t.Errorf("NullHandling = %q, want empty (NULL is the element)", ja.NullHandling)
+		}
+	})
+
+	t.Run("value_input_format", func(t *testing.T) {
+		e := mustParseJSON(t, "JSON_EXISTS(c FORMAT JSON ENCODING UTF16, '$.x')")
+		je := e.(*JSONExistsExpr)
+		if je.Path.Input.Format == nil || je.Path.Input.Format.Encoding != "UTF16" {
+			t.Errorf("input format = %+v, want JSON ENCODING UTF16", je.Path.Input.Format)
+		}
+	})
+}
+
+// mustParseJSON parses expr and fails the test if it does not parse cleanly to a
+// single Expr. Returns the parsed Expr.
+func mustParseJSON(t *testing.T, expr string) Expr {
+	t.Helper()
+	e, errs := ParseExpression(expr)
+	if len(errs) != 0 {
+		t.Fatalf("ParseExpression(%q): unexpected errors: %v", expr, errs)
+	}
+	if e == nil {
+		t.Fatalf("ParseExpression(%q): nil expr", expr)
+	}
+	return e
+}


### PR DESCRIPTION
## Node: `trino/expr-json` — SQL/JSON functions & path

v2 migration node implementing Trino 481's SQL/JSON function family as hand-written recursive descent, replacing the `expressions`-node stub. Spec: `docs/migration/trino/dag.md` (row `trino/expr-json`, writes `trino/parser/json.go`), grammar `docs/migration/trino/antlr_rules.md` + `truth1/types-expr-functions.md` (json-* sections).

### What landed
- **`trino/parser/json.go`** (new) — `JSON_EXISTS`, `JSON_VALUE`, `JSON_QUERY`, `JSON_OBJECT`, `JSON_ARRAY` and the shared json-path subsystem (`jsonPathInvocation`, `jsonValueExpression`, `jsonRepresentation`, `jsonArgument`, and every per-function behavior clause: `jsonExistsErrorBehavior`, `jsonValueBehavior`, `jsonQueryWrapperBehavior`, `jsonQueryBehavior`, `jsonObjectMember`). New `Expr` AST nodes: `JSONExistsExpr`, `JSONValueFunc`, `JSONQueryFunc`, `JSONObjectExpr`, `JSONArrayExpr` (+ `JSONPathInvocation`, `JSONValueExpr`, `JSONFormat`, `JSONArgument`, behavior/member structs).
- **`trino/parser/json_test.go`** (new) — the correctness gate: accept/reject corpus, the live-oracle differential, structural AST assertions, and a per-grammar-rule completeness checklist.

### Oracle-confirmed facts baked into the parser (json.go header J1–J5)
- **J1** clause ordering is FIXED (not free): `JSON_QUERY` = RETURNING → WRAPPER → QUOTES → ON EMPTY → ON ERROR; `JSON_VALUE` = RETURNING → ON EMPTY → ON ERROR. Out-of-order is a `SYNTAX_ERROR`.
- **J2** the json path is a string **literal**, not an expression (`JSON_EXISTS(c, somecol)` rejected).
- **J3** the five `JSON_*` names are **reserved** (bare `SELECT json_exists` rejected) ⇒ unambiguous dispatch.
- **J4** `jsonObjectMember`'s leading `KEY` is a backtracking-optional keyword: `JSON_OBJECT(KEY VALUE 1)` parses `KEY` as the key **column**, `JSON_OBJECT(KEY 'x' VALUE 1)` parses `KEY` as the keyword. Resolved by speculative checkpoint/restore.
- **J5** in `JSON_ARRAY` a leading `NULL`/`ABSENT` is consumed as an **element**; the null-handling clause is recognized only after the element list (`JSON_ARRAY(NULL)` = 1 element; `JSON_ARRAY(NULL ON NULL)` rejected; `JSON_ARRAY(1 NULL ON NULL)` accepted).
- Bonus asymmetry: `JSON_VALUE`'s `RETURNING` takes a **bare type** (no `FORMAT`), unlike `JSON_QUERY`/`JSON_OBJECT`/`JSON_ARRAY`.

### Correctness evidence
Differential gate against the **live Trino 481 oracle** (`trino/internal/trinooracle`, http://localhost:18080): **123 accept/reject cases, all pass** — omni's `ParseExpression` accept/reject equals Trino's accept/reject of `SELECT <expr>`. Corpus draws from truth1 docs (every json-* `example_sql`), the legacy ANTLR grammar (truth2), and oracle-probed edge cases; both positive and negative coverage. Plus `TestJSON_Structure` AST-shape assertions for representative forms (behavior spellings, member separators, KEY-as-expr, null-handling, RETURNING type, input FORMAT).

```
go test ./trino/parser/ -run TestJSON        # ok (oracle differential + structure + corpus)
```

The pre-existing `TestLexer_OracleDifferential` backtick failure is unrelated (in `lexer_oracle_test.go`, fails on clean `main` too; already tracked as a separate task).

### Divergences
**None.** omni matches Trino 481 exactly for every SQL/JSON form — truth1 docs, the legacy grammar, and the live oracle all agree here, so there is no behavior change to flag.

### Out-of-scope writes (designed stub→implementation handoff)
The `expressions` node explicitly staged these for `expr-json` (its own code comments call out both):
- `trino/parser/function.go` — removed the temporary `parseJSONFunction` "not yet supported" stub (Go forbids a duplicate name; the `expr.go` dispatch still calls `parseJSONFunction`, now in json.go).
- `trino/parser/expr_test.go` — removed `TestExpr_JSONDeferred` (which asserted JSON was rejected as "not yet supported"); that coverage now lives in `json_test.go`'s accept corpus.

### Review gate
Claude lens (`/code-review`, high) run on the diff — no blocking findings; the tricky paths (KEY backtracking, behavior-clause ordering loops, NULL/ABSENT element disambiguation, RETURNING-FORMAT asymmetry) are all oracle-confirmed. Codex lens could not run (workspace out of credits); the orchestrator may re-run it from the main session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
