### PR TITLE
feat(googlesql/types): hand-written GoogleSQL data-type parser (v2 node googlesql/types)

### DIFF
--- a/googlesql/parser/datatypes.go
+++ b/googlesql/parser/datatypes.go
@@ -1,0 +1,964 @@
+package parser
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is the `types` DAG node: it implements GoogleSQL's `type` grammar
+// rule and its sub-rules (raw_type, type_name, array_type, struct_type,
+// struct_field, range_type, map_type, function_type, opt_type_parameters,
+// type_parameter, collate_clause) as a hand-written recursive-descent parser
+// over the token stream, producing a *DataType value tree.
+//
+// Legacy ZetaSQL ANTLR `type` rule (GoogleSQLParser.g4):
+//
+//	type:        raw_type opt_type_parameters? collate_clause? ;
+//	raw_type:    array_type | struct_type | type_name | range_type
+//	             | function_type | map_type ;
+//	type_name:   path_expression | INTERVAL ;
+//	array_type:  ARRAY '<' type '>' ;
+//	struct_type: STRUCT '<' '>' | STRUCT '<' struct_field (',' struct_field)* '>' ;
+//	struct_field: identifier type | type ;
+//	range_type:  RANGE '<' type '>' ;
+//	map_type:    MAP '<' type ',' type '>' ;
+//	function_type: FUNCTION '<' '(' ')' '->' type '>'
+//	             | FUNCTION '<' type '->' type '>'
+//	             | FUNCTION '<' '(' type (',' type)* ')' '->' type '>' ;
+//	opt_type_parameters: '(' type_parameter (',' type_parameter)* ')'  (trailing comma -> error) ;
+//	type_parameter: integer | boolean | string | bytes | float | MAX ;
+//	collate_clause: COLLATE string_literal_or_parameter ;
+//
+// DataType is a PARSER-PACKAGE node, NOT an ast.Node — the googlesql ast tag
+// set is closed to the ast-core File container (ast/parsenodes.go ships only
+// *File; adding type tags belongs to ast-core, not this node's writes-glob).
+// This follows the trino/parser.DataType precedent exactly: later DAG nodes
+// (expressions: CAST/typed literals/struct constructors; parser-ddl: column
+// schemas, function params/returns; parser-dml) embed *DataType in their ast
+// results and render it via String. The node carries its own ast.Loc span.
+//
+// The implementation is adjudicated against the LIVE Cloud Spanner emulator
+// oracle (oracle.md), not the literal legacy grammar. Two oracle-confirmed
+// divergences from a naive reading of the ANTLR rule are baked in (see the
+// migration divergence ledger):
+//
+//	D1 (template-close token splitting). The omni lexer greedily emits `>>`
+//	   (tokShiftRight) and `>=` (tokGreaterEqual); the legacy grammar's
+//	   `template_type_close: GT_OPERATOR` matches only a single `>`, so a
+//	   literal reading would REJECT nested types like ARRAY<ARRAY<INT64>> and
+//	   STRUCT<x ARRAY<STRUCT<y INT64>>>. The live oracle ACCEPTS them (semantic
+//	   "Arrays of arrays are not supported" — it PARSED). So a `>>` (or `>=`)
+//	   token at a template-close position is SPLIT: the first `>` closes the
+//	   current template and the remaining `>`/`=` is pushed back as a fresh
+//	   token. A leftover `>` where no template is open is left in place and
+//	   surfaces as a syntax error (oracle: ARRAY<INT64>> rejects).
+//
+//	D2 (empty STRUCT<>). Written adjacently, `<>` lexes as one token
+//	   (tokNotEqual2). The oracle ACCEPTS the empty struct STRUCT<> (and the
+//	   spaced STRUCT< >) but REJECTS ARRAY<>/RANGE<> (those need content). So
+//	   STRUCT treats a leading `<>` (or `< >`) as an empty template; ARRAY/RANGE/
+//	   MAP/FUNCTION require a real `<` followed by content.
+//
+// Dispatch on the leading keyword (raw_type alternatives):
+//   - ARRAY / STRUCT / RANGE are RESERVED keywords (keywords.go) and can ONLY
+//     introduce their template form — they are NOT valid bare type_names
+//     (oracle: bare ARRAY / STRUCT / RANGE all reject "Expected < ...").
+//   - MAP / FUNCTION are NON-reserved: they take the template form when
+//     followed by `<`, else fall through to a bare type_name (oracle: bare MAP /
+//     FUNCTION accept as type names "Type not found: MAP").
+//   - INTERVAL is the dedicated type_name alternative (no template, no path
+//     continuation — oracle: INTERVAL<...> and INTERVAL.foo both reject).
+//   - anything else (tokIdentifier, or a non-reserved keyword like
+//     NUMERIC/JSON/DATE/TIMESTAMP) is a type_name path_expression.
+
+// TypeKind classifies the top-level shape of a parsed DataType, mirroring the
+// raw_type alternatives so downstream consumers (expressions, DDL, deparse) can
+// switch on the form without re-inspecting tokens.
+type TypeKind int
+
+const (
+	// TypeName is a type_name: a path_expression (INT64, STRING, NUMERIC,
+	// foo.bar.Baz, `proto.Type`) or the bare INTERVAL keyword (IsInterval set).
+	// Covers all scalars, parameterized scalars (STRING(N), NUMERIC(p,s)), and
+	// proto/enum type names — GoogleSQL scalar type names are identifiers, not
+	// reserved keywords.
+	TypeName TypeKind = iota
+	// TypeArray is ARRAY < type >. The element is in ElementType.
+	TypeArray
+	// TypeStruct is STRUCT < [field (, field)*] >. Fields holds the (possibly
+	// empty) field list.
+	TypeStruct
+	// TypeRange is RANGE < type >. The element is in ElementType.
+	TypeRange
+	// TypeMap is MAP < keyType , valueType >. KeyType / ValueType hold the
+	// components (a ZetaSQL/legacy raw_type alt; Spanner rejects it semantically).
+	TypeMap
+	// TypeFunction is FUNCTION < (args) -> returnType >. ArgTypes / ReturnType
+	// hold the signature (a ZetaSQL/legacy raw_type alt; semantically
+	// unsupported on Spanner but grammatically valid).
+	TypeFunction
+)
+
+// String returns a human-readable tag for the kind (diagnostics only).
+func (k TypeKind) String() string {
+	switch k {
+	case TypeName:
+		return "Name"
+	case TypeArray:
+		return "Array"
+	case TypeStruct:
+		return "Struct"
+	case TypeRange:
+		return "Range"
+	case TypeMap:
+		return "Map"
+	case TypeFunction:
+		return "Function"
+	default:
+		return "Unknown"
+	}
+}
+
+// TypeParam is one entry of an opt_type_parameters list. Exactly one of
+// IsInt / IsMax / Text-bearing literal kinds is meaningful:
+//
+//	type_parameter: integer | boolean | string | bytes | float | MAX
+//
+// IsInt + IntVal capture an integer parameter (the 100 in STRING(100), the 38
+// in NUMERIC(38,9)); IsMax marks the MAX keyword (STRING(MAX)); Text holds the
+// source spelling for the remaining literal kinds (boolean / string / bytes /
+// float) so a faithful round-trip is possible without re-classifying them.
+// IntText preserves an integer's exact source spelling (faithful even on int64
+// overflow, where the lexer leaves IntVal at 0 but keeps the text).
+type TypeParam struct {
+	IsInt   bool
+	IsMax   bool
+	IntVal  int64
+	IntText string // exact source spelling of an integer parameter
+	Text    string // source spelling of a non-integer literal parameter
+	Loc     ast.Loc
+}
+
+func (p TypeParam) writeTo(b *strings.Builder) {
+	switch {
+	case p.IsMax:
+		b.WriteString("MAX")
+	case p.IsInt:
+		if p.IntText != "" {
+			b.WriteString(p.IntText)
+		} else {
+			b.WriteString(strconv.FormatInt(p.IntVal, 10))
+		}
+	default:
+		b.WriteString(p.Text)
+	}
+}
+
+// StructField is one field of a STRUCT type. Name is the optional field-name
+// identifier ("" for an anonymous field); Type is the field type (which may
+// itself carry a trailing COLLATE captured on Type.Collate).
+//
+//	struct_field: identifier type | type
+type StructField struct {
+	Name string // "" for an anonymous field
+	Type *DataType
+	Loc  ast.Loc
+}
+
+func (f StructField) writeTo(b *strings.Builder) {
+	if f.Name != "" {
+		b.WriteString(f.Name)
+		b.WriteByte(' ')
+	}
+	if f.Type != nil {
+		f.Type.writeTo(b)
+	}
+}
+
+// DataType is a parsed GoogleSQL data type (the `type` rule). The active fields
+// depend on Kind:
+//
+//	TypeName     — NameParts (path), or IsInterval for the INTERVAL alt
+//	TypeArray    — ElementType
+//	TypeStruct   — Fields (possibly empty)
+//	TypeRange    — ElementType
+//	TypeMap      — KeyType, ValueType
+//	TypeFunction — ArgTypes, ReturnType
+//
+// Params (opt_type_parameters) and Collate (collate_clause) may decorate ANY
+// kind (the grammar appends both to `type` after raw_type), though in practice
+// they appear on scalar type_names (STRING(100), NUMERIC(p,s) COLLATE '…').
+type DataType struct {
+	Kind TypeKind
+
+	// NameParts is the dotted path of a TypeName (e.g. ["INT64"],
+	// ["foo","bar","Baz"]). Source case is preserved (GoogleSQL type names are
+	// case-insensitive for resolution, but the parser keeps the spelling).
+	NameParts []string
+	// IsInterval marks the type_name INTERVAL alternative (Kind==TypeName,
+	// NameParts nil). INTERVAL is a reserved keyword and a type_name in its own
+	// right, distinct from a path_expression.
+	IsInterval bool
+
+	// ElementType is the element of an ARRAY (TypeArray) or RANGE (TypeRange).
+	ElementType *DataType
+
+	// Fields holds the STRUCT field list (TypeStruct); empty for STRUCT<>.
+	Fields []StructField
+
+	// KeyType / ValueType are the components of MAP<k,v> (TypeMap).
+	KeyType   *DataType
+	ValueType *DataType
+
+	// ArgTypes / ReturnType describe a FUNCTION<(args) -> ret> (TypeFunction);
+	// ArgTypes is empty for the no-argument form FUNCTION<() -> ret>.
+	ArgTypes   []*DataType
+	ReturnType *DataType
+
+	// Params holds an opt_type_parameters list (nil when absent).
+	Params []TypeParam
+
+	// Collate is the collation name/spelling from a trailing collate_clause
+	// ("" when absent). For a string literal it is the unquoted body; for a
+	// parameter (@name / ? / @@sysvar) it is the source spelling.
+	Collate string
+
+	Loc ast.Loc
+}
+
+// String renders the DataType back to GoogleSQL source syntax. It is the
+// round-trip rendering downstream deparse relies on: it is not byte-identical
+// to the input (unquoted-name case is preserved, inter-token spacing is
+// normalized), but re-parsing String() yields an equal DataType.
+func (t *DataType) String() string {
+	if t == nil {
+		return ""
+	}
+	var b strings.Builder
+	t.writeTo(&b)
+	return b.String()
+}
+
+func (t *DataType) writeTo(b *strings.Builder) {
+	switch t.Kind {
+	case TypeName:
+		if t.IsInterval {
+			b.WriteString("INTERVAL")
+		} else {
+			b.WriteString(strings.Join(t.NameParts, "."))
+		}
+	case TypeArray:
+		b.WriteString("ARRAY<")
+		t.ElementType.writeTo(b)
+		b.WriteByte('>')
+	case TypeStruct:
+		b.WriteString("STRUCT<")
+		for i, f := range t.Fields {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			f.writeTo(b)
+		}
+		b.WriteByte('>')
+	case TypeRange:
+		b.WriteString("RANGE<")
+		t.ElementType.writeTo(b)
+		b.WriteByte('>')
+	case TypeMap:
+		b.WriteString("MAP<")
+		t.KeyType.writeTo(b)
+		b.WriteString(", ")
+		t.ValueType.writeTo(b)
+		b.WriteByte('>')
+	case TypeFunction:
+		b.WriteString("FUNCTION<(")
+		for i, a := range t.ArgTypes {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			a.writeTo(b)
+		}
+		b.WriteString(") -> ")
+		t.ReturnType.writeTo(b)
+		b.WriteByte('>')
+	}
+	if len(t.Params) > 0 {
+		b.WriteByte('(')
+		for i, p := range t.Params {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			p.writeTo(b)
+		}
+		b.WriteByte(')')
+	}
+	if t.Collate != "" {
+		b.WriteString(" COLLATE ")
+		// Render string collations quoted (the common case); a parameter
+		// spelling (@p / ? / @@v) is written verbatim.
+		if isParameterSpelling(t.Collate) {
+			b.WriteString(t.Collate)
+		} else {
+			b.WriteByte('\'')
+			b.WriteString(t.Collate)
+			b.WriteByte('\'')
+		}
+	}
+}
+
+// isParameterSpelling reports whether s looks like a collate parameter (a query
+// parameter @name, positional ?, or system variable @@var) rather than a
+// string-literal collation name. Used only by String for round-trip rendering.
+func isParameterSpelling(s string) bool {
+	return s == "?" || strings.HasPrefix(s, "@")
+}
+
+// ---------------------------------------------------------------------------
+// parseType — the `type` rule entry point.
+// ---------------------------------------------------------------------------
+
+// parseType parses a GoogleSQL type (`type: raw_type opt_type_parameters?
+// collate_clause?`) and returns it as a *DataType. It is the single entry point
+// for every type position — CAST / SAFE_CAST targets, typed literals
+// (ARRAY<T>[…], STRUCT<…>(…)), RANGE<T> literals, function parameter/return
+// types, variable declarations, and (via the DDL nodes) column schemas.
+// Returns a *ParseError if the current token does not begin a valid type.
+func (p *Parser) parseType() (*DataType, error) {
+	dt, err := p.parseRawType()
+	if err != nil {
+		return nil, err
+	}
+
+	// opt_type_parameters — `( type_parameter (, type_parameter)* )`.
+	if p.cur.Type == int('(') {
+		params, endLoc, err := p.parseTypeParameters()
+		if err != nil {
+			return nil, err
+		}
+		dt.Params = params
+		dt.Loc.End = endLoc.End
+	}
+
+	// collate_clause — `COLLATE string_literal_or_parameter`.
+	if p.cur.Type == kwCOLLATE {
+		collate, endLoc, err := p.parseCollateClause()
+		if err != nil {
+			return nil, err
+		}
+		dt.Collate = collate
+		dt.Loc.End = endLoc.End
+	}
+
+	return dt, nil
+}
+
+// parseRawType parses one raw_type alternative (without the trailing
+// opt_type_parameters / collate_clause, which parseType appends).
+func (p *Parser) parseRawType() (*DataType, error) {
+	switch p.cur.Type {
+	case kwARRAY:
+		return p.parseArrayType()
+	case kwSTRUCT:
+		return p.parseStructType()
+	case kwRANGE:
+		return p.parseRangeType()
+	case kwMAP:
+		// MAP is non-reserved: template form only when the NEXT token opens a
+		// template `<`. Otherwise it is a bare type_name (oracle: bare MAP
+		// accepts as "Type not found: MAP").
+		if p.peekNext().Type == int('<') {
+			return p.parseMapType()
+		}
+		return p.parseTypeName()
+	case kwFUNCTION:
+		if p.peekNext().Type == int('<') {
+			return p.parseFunctionType()
+		}
+		return p.parseTypeName()
+	default:
+		return p.parseTypeName()
+	}
+}
+
+// parseTypeName parses a type_name: `path_expression | INTERVAL`.
+//
+//	path_expression: identifier (DOT identifier)*
+//	identifier:      token_identifier | keyword_as_identifier
+//
+// The first component accepts a token identifier OR a non-reserved word-keyword
+// (NUMERIC, JSON, DATE, MAP, FUNCTION, …); reserved keywords are rejected as a
+// bare type name. Dotted continuations accept any keyword as a part (matching
+// the foundation's permissive name-part rule). INTERVAL is its own alternative
+// with no continuation.
+func (p *Parser) parseTypeName() (*DataType, error) {
+	if p.cur.Type == kwINTERVAL {
+		tok := p.advance()
+		return &DataType{Kind: TypeName, IsInterval: true, Loc: tok.Loc}, nil
+	}
+
+	if !isIdentifierStart(p.cur.Type) {
+		return nil, p.typeError()
+	}
+	first := p.advance()
+	part0, err := p.identifierText(first)
+	if err != nil {
+		return nil, err
+	}
+	dt := &DataType{
+		Kind:      TypeName,
+		NameParts: []string{part0},
+		Loc:       first.Loc,
+	}
+	for p.cur.Type == int('.') {
+		p.advance() // consume '.'
+		// A dotted name part may be any keyword or identifier (path components
+		// after the first are permissive — common for proto/enum type names).
+		if !isAnyKeywordIdentifier(p.cur.Type) {
+			return nil, p.typeErrorAt("expected name after '.' in type")
+		}
+		partTok := p.advance()
+		part, err := p.identifierText(partTok)
+		if err != nil {
+			return nil, err
+		}
+		dt.NameParts = append(dt.NameParts, part)
+		dt.Loc.End = partTok.Loc.End
+	}
+	return dt, nil
+}
+
+// identifierText returns the source text of an identifier-or-keyword token: the
+// raw Str for a token identifier (the lexer already stripped backticks), or the
+// keyword spelling for a keyword-as-identifier (whose Str is empty).
+//
+// An empty `tokIdentifier` (the body of an empty backtick pair “) is rejected
+// as an "invalid empty identifier" — the lexer admits empty backticks without a
+// lex error, but the GoogleSQL grammar rejects them (oracle: `CAST(NULL AS “)`
+// → "Syntax error: Invalid empty identifier"). Keyword tokens legitimately
+// carry an empty Str, so the substitution is keyed on the token TYPE, not on
+// emptiness, to avoid turning an empty identifier into the literal "IDENTIFIER".
+func (p *Parser) identifierText(tok Token) (string, error) {
+	if tok.Type == tokIdentifier {
+		if tok.Str == "" {
+			return "", &ParseError{Loc: tok.Loc, Msg: "invalid empty identifier"}
+		}
+		return tok.Str, nil
+	}
+	// A keyword-as-identifier: its Str is empty; use the keyword spelling.
+	return TokenName(tok.Type), nil
+}
+
+// parseArrayType parses `ARRAY < type >` (caller confirmed the leading ARRAY).
+func (p *Parser) parseArrayType() (*DataType, error) {
+	arrTok := p.advance() // ARRAY
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+	elem, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	endLoc, err := p.expectTemplateClose()
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:        TypeArray,
+		ElementType: elem,
+		Loc:         ast.Loc{Start: arrTok.Loc.Start, End: endLoc.End},
+	}, nil
+}
+
+// parseRangeType parses `RANGE < type >` (caller confirmed RANGE). The grammar
+// admits ANY `type` inside RANGE (oracle: RANGE<INT64> parses, then fails
+// semantically) — the DATE/DATETIME/TIMESTAMP restriction is a resolution
+// concern, not syntax.
+func (p *Parser) parseRangeType() (*DataType, error) {
+	rangeTok := p.advance() // RANGE
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+	elem, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	endLoc, err := p.expectTemplateClose()
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:        TypeRange,
+		ElementType: elem,
+		Loc:         ast.Loc{Start: rangeTok.Loc.Start, End: endLoc.End},
+	}, nil
+}
+
+// parseStructType parses a STRUCT type (caller confirmed STRUCT):
+//
+//	STRUCT '<' '>'                                  (empty)
+//	STRUCT '<' struct_field (',' struct_field)* '>'
+//
+// D2: the empty form may arrive as the adjacent `<>` token (tokNotEqual2) or as
+// a `< >` pair; both are accepted (oracle: STRUCT<> and STRUCT< > both parse).
+func (p *Parser) parseStructType() (*DataType, error) {
+	structTok := p.advance() // STRUCT
+
+	// Empty struct via the adjacent `<>` token.
+	if p.cur.Type == tokNotEqual2 {
+		closeTok := p.advance()
+		return &DataType{
+			Kind: TypeStruct,
+			Loc:  ast.Loc{Start: structTok.Loc.Start, End: closeTok.Loc.End},
+		}, nil
+	}
+
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+
+	dt := &DataType{Kind: TypeStruct, Loc: structTok.Loc}
+
+	// Empty struct via a `< >` pair: a template-close immediately after `<`.
+	if p.atTemplateClose() {
+		endLoc, err := p.expectTemplateClose()
+		if err != nil {
+			return nil, err
+		}
+		dt.Loc.End = endLoc.End
+		return dt, nil
+	}
+
+	first, err := p.parseStructField()
+	if err != nil {
+		return nil, err
+	}
+	dt.Fields = append(dt.Fields, first)
+	for p.cur.Type == int(',') {
+		p.advance() // consume ','
+		f, err := p.parseStructField()
+		if err != nil {
+			return nil, err
+		}
+		dt.Fields = append(dt.Fields, f)
+	}
+	endLoc, err := p.expectTemplateClose()
+	if err != nil {
+		return nil, err
+	}
+	dt.Loc.End = endLoc.End
+	return dt, nil
+}
+
+// parseStructField parses one `struct_field: identifier type | type`.
+//
+// The two alternatives are ambiguous: a field name is itself an identifier, and
+// a type begins with an identifier (a path_expression). Resolution follows the
+// foundation's lookahead rule used elsewhere: a NAMED field is `name type`
+// where `name` is a plain identifier-start token AND the token after it also
+// begins a type (so the name is not itself the whole type). Concretely, the
+// named form is taken when the current token is an identifier-start and the
+// NEXT token begins a type and is not a field separator (',' / template-close)
+// — otherwise the current token is the (single-component) type itself.
+//
+// This matches the oracle: STRUCT<x INT64> is named {x INT64}; STRUCT<INT64,
+// STRING> is two anonymous types; STRUCT<x STRUCT<…>> names x; STRUCT<a
+// ARRAY<…>> names a. A bare keyword type name (NUMERIC, DATE) in a field is the
+// anonymous type, since the following token is a separator.
+func (p *Parser) parseStructField() (StructField, error) {
+	// Try the named form first: `identifier type`. The name must be a plain
+	// identifier-start token, and what follows it must itself begin a type and
+	// not be a field boundary.
+	if isIdentifierStart(p.cur.Type) && beginsTypeFollowingName(p.peekNext().Type) {
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return StructField{}, err
+		}
+		fieldType, err := p.parseType()
+		if err != nil {
+			return StructField{}, err
+		}
+		return StructField{
+			Name: name,
+			Type: fieldType,
+			Loc:  ast.Loc{Start: nameTok.Loc.Start, End: fieldType.Loc.End},
+		}, nil
+	}
+
+	// Anonymous form: a bare `type`.
+	fieldType, err := p.parseType()
+	if err != nil {
+		return StructField{}, err
+	}
+	return StructField{Type: fieldType, Loc: fieldType.Loc}, nil
+}
+
+// beginsTypeFollowingName reports whether tokenType can begin a struct field's
+// TYPE when it follows a candidate field-name token. It is the disambiguator
+// for `identifier type` vs a bare single-component `type`: the named form is
+// only taken when the token after the name actually starts a type.
+//
+// A type begins with: ARRAY / STRUCT / RANGE / MAP / FUNCTION / INTERVAL
+// keywords, a template-bearing name, a token identifier, or any non-reserved
+// word-keyword (a scalar type_name). It does NOT begin with a field separator
+// (',') or a template-close ('>', or the split '>>'/'>='), nor with '.' (which
+// would be a path continuation of the name, handled inside parseTypeName).
+func beginsTypeFollowingName(tokenType int) bool {
+	switch tokenType {
+	case kwARRAY, kwSTRUCT, kwRANGE, kwMAP, kwFUNCTION, kwINTERVAL:
+		return true
+	}
+	return isIdentifierStart(tokenType)
+}
+
+// parseMapType parses `MAP < keyType , valueType >` (caller confirmed MAP '<').
+func (p *Parser) parseMapType() (*DataType, error) {
+	mapTok := p.advance() // MAP
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+	keyType, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+	valueType, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	endLoc, err := p.expectTemplateClose()
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:      TypeMap,
+		KeyType:   keyType,
+		ValueType: valueType,
+		Loc:       ast.Loc{Start: mapTok.Loc.Start, End: endLoc.End},
+	}, nil
+}
+
+// parseFunctionType parses a FUNCTION type (caller confirmed FUNCTION '<'):
+//
+//	FUNCTION '<' '(' ')' '->' return '>'                 (no args)
+//	FUNCTION '<' arg '->' return '>'                     (single bare arg)
+//	FUNCTION '<' '(' type (',' type)* ')' '->' return '>'  (paren arg list)
+func (p *Parser) parseFunctionType() (*DataType, error) {
+	funcTok := p.advance() // FUNCTION
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+
+	dt := &DataType{Kind: TypeFunction, Loc: funcTok.Loc}
+
+	if p.cur.Type == int('(') {
+		// Parenthesized argument list (possibly empty).
+		p.advance() // consume '('
+		if p.cur.Type != int(')') {
+			arg, err := p.parseType()
+			if err != nil {
+				return nil, err
+			}
+			dt.ArgTypes = append(dt.ArgTypes, arg)
+			for p.cur.Type == int(',') {
+				p.advance() // consume ','
+				a, err := p.parseType()
+				if err != nil {
+					return nil, err
+				}
+				dt.ArgTypes = append(dt.ArgTypes, a)
+			}
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+	} else {
+		// Single bare argument type.
+		arg, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		dt.ArgTypes = append(dt.ArgTypes, arg)
+	}
+
+	if _, err := p.expect(tokArrow); err != nil {
+		return nil, err
+	}
+	ret, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	dt.ReturnType = ret
+
+	endLoc, err := p.expectTemplateClose()
+	if err != nil {
+		return nil, err
+	}
+	dt.Loc.End = endLoc.End
+	return dt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Template brackets — open `<`, close `>` (with the D1 `>>`/`>=` split).
+// ---------------------------------------------------------------------------
+
+// expectTemplateOpen consumes a template-open `<` (int('<')), returning a
+// *ParseError otherwise. A `<>` (tokNotEqual2) at an ARRAY/RANGE/MAP/FUNCTION
+// open is NOT a valid open (those require content) and is reported as a syntax
+// error — matching the oracle reject of ARRAY<> / RANGE<>.
+func (p *Parser) expectTemplateOpen() error {
+	if p.cur.Type == int('<') {
+		p.advance()
+		return nil
+	}
+	return p.typeErrorAt("expected '<'")
+}
+
+// atTemplateClose reports whether the current token closes a template: a bare
+// `>` (int('>')), or a `>>` / `>=` whose FIRST `>` closes this template (the
+// D1 split). It does not consume anything.
+func (p *Parser) atTemplateClose() bool {
+	switch p.cur.Type {
+	case int('>'), tokShiftRight, tokGreaterEqual:
+		return true
+	default:
+		return false
+	}
+}
+
+// expectTemplateClose consumes a single template-close `>` and returns its Loc.
+//
+// D1 split: the omni lexer greedily lexes `>>` (tokShiftRight) and `>=`
+// (tokGreaterEqual). When the close is one of those compound tokens, only the
+// leading `>` belongs to THIS template; the remainder is pushed back into the
+// parser's lookahead as a fresh token (`>` for the second char of `>>`, `=` for
+// `>=`) at the adjusted offset, so the enclosing template (or the trailing
+// context) sees it next. The returned Loc covers just the consumed `>`.
+//
+// If the current token is not a close at all, a syntax error is returned. A
+// leftover bare `>` with no enclosing template is left for the caller and
+// surfaces downstream (oracle: ARRAY<INT64>> rejects with the stray `>`).
+func (p *Parser) expectTemplateClose() (ast.Loc, error) {
+	tok := p.cur
+	switch tok.Type {
+	case int('>'):
+		p.advance()
+		return tok.Loc, nil
+	case tokShiftRight:
+		// `>>` — consume one `>`, push back the second as a bare `>`.
+		gtLoc := ast.Loc{Start: tok.Loc.Start, End: tok.Loc.Start + 1}
+		p.replaceCurrent(Token{
+			Type: int('>'),
+			Loc:  ast.Loc{Start: tok.Loc.Start + 1, End: tok.Loc.End},
+		})
+		return gtLoc, nil
+	case tokGreaterEqual:
+		// `>=` — consume the `>`, push back the `=`.
+		gtLoc := ast.Loc{Start: tok.Loc.Start, End: tok.Loc.Start + 1}
+		p.replaceCurrent(Token{
+			Type: int('='),
+			Loc:  ast.Loc{Start: tok.Loc.Start + 1, End: tok.Loc.End},
+		})
+		return gtLoc, nil
+	default:
+		return ast.NoLoc(), p.typeErrorAt("expected '>'")
+	}
+}
+
+// replaceCurrent overwrites the current token with tok WITHOUT touching the
+// lexer or the lookahead buffer, used by the D1 template-close split to push
+// back the second half of a compound `>>` / `>=` token. The lexer position is
+// already past the original compound token, and any buffered lookahead
+// (nextBuf/hasNext, set by a prior peekNext) is preserved unchanged — so the
+// next advance() correctly yields the buffered token (or the next lexed one)
+// after tok is consumed.
+func (p *Parser) replaceCurrent(tok Token) {
+	p.cur = tok
+}
+
+// ---------------------------------------------------------------------------
+// opt_type_parameters — `( type_parameter (, type_parameter)* )`.
+// ---------------------------------------------------------------------------
+
+// parseTypeParameters parses an opt_type_parameters list. The opening '(' is
+// the current token. At least one type_parameter is required (oracle: STRING()
+// rejects "Unexpected )"). Returns the params and the Loc spanning through ')'.
+//
+//	type_parameter: integer | boolean | string | bytes | float | MAX
+//
+// A trailing comma is a syntax error (legacy grammar emits a dedicated message;
+// oracle rejects equivalently).
+func (p *Parser) parseTypeParameters() ([]TypeParam, ast.Loc, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	first, err := p.parseTypeParameter()
+	if err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	params := []TypeParam{first}
+	for p.cur.Type == int(',') {
+		p.advance() // consume ','
+		// A `)` right after the comma is a trailing comma — reject.
+		if p.cur.Type == int(')') {
+			return nil, ast.NoLoc(), p.typeErrorAt("trailing comma in type parameters list is not allowed")
+		}
+		next, err := p.parseTypeParameter()
+		if err != nil {
+			return nil, ast.NoLoc(), err
+		}
+		params = append(params, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	return params, closeTok.Loc, nil
+}
+
+// parseTypeParameter parses one type_parameter. Accepts an integer literal, the
+// MAX keyword, a boolean literal (TRUE/FALSE), a string literal, a bytes
+// literal, or a floating-point literal. A leading sign is NOT part of an
+// integer type_parameter (oracle: NUMERIC(-5) rejects "Unexpected -").
+func (p *Parser) parseTypeParameter() (TypeParam, error) {
+	tok := p.cur
+	switch tok.Type {
+	case tokInteger:
+		p.advance()
+		return TypeParam{IsInt: true, IntVal: tok.Ival, IntText: tok.Str, Loc: tok.Loc}, nil
+	case kwMAX:
+		p.advance()
+		return TypeParam{IsMax: true, Loc: tok.Loc}, nil
+	case kwTRUE, kwFALSE:
+		p.advance()
+		return TypeParam{Text: TokenName(tok.Type), Loc: tok.Loc}, nil
+	case tokString:
+		p.advance()
+		return TypeParam{Text: tok.Str, Loc: tok.Loc}, nil
+	case tokBytes:
+		p.advance()
+		return TypeParam{Text: tok.Str, Loc: tok.Loc}, nil
+	case tokFloat:
+		p.advance()
+		return TypeParam{Text: tok.Str, Loc: tok.Loc}, nil
+	default:
+		return TypeParam{}, p.typeErrorAt("expected a type parameter (integer, boolean, string, bytes, float, or MAX)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collate_clause — `COLLATE string_literal_or_parameter`.
+// ---------------------------------------------------------------------------
+
+// parseCollateClause parses `COLLATE string_literal_or_parameter`, where the
+// argument is a string literal, a query parameter (@name | ?), or a system
+// variable (@@path). The current token is COLLATE. Returns the collation
+// spelling and the Loc through the argument.
+func (p *Parser) parseCollateClause() (string, ast.Loc, error) {
+	collateTok := p.advance() // COLLATE
+	tok := p.cur
+	switch tok.Type {
+	case tokString:
+		p.advance()
+		return tok.Str, ast.Loc{Start: collateTok.Loc.Start, End: tok.Loc.End}, nil
+	case int('?'):
+		p.advance()
+		return "?", ast.Loc{Start: collateTok.Loc.Start, End: tok.Loc.End}, nil
+	case int('@'):
+		// Named parameter `@identifier`.
+		p.advance() // consume '@'
+		if !isAnyKeywordIdentifier(p.cur.Type) {
+			return "", ast.NoLoc(), p.typeErrorAt("expected parameter name after '@' in COLLATE")
+		}
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return "", ast.NoLoc(), err
+		}
+		return "@" + name, ast.Loc{Start: collateTok.Loc.Start, End: nameTok.Loc.End}, nil
+	case tokAtAt:
+		// System variable `@@path`.
+		p.advance() // consume '@@'
+		if !isAnyKeywordIdentifier(p.cur.Type) {
+			return "", ast.NoLoc(), p.typeErrorAt("expected system variable name after '@@' in COLLATE")
+		}
+		var parts []string
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return "", ast.NoLoc(), err
+		}
+		parts = append(parts, name)
+		end := nameTok.Loc.End
+		for p.cur.Type == int('.') {
+			p.advance()
+			if !isAnyKeywordIdentifier(p.cur.Type) {
+				return "", ast.NoLoc(), p.typeErrorAt("expected name after '.' in system variable")
+			}
+			partTok := p.advance()
+			part, err := p.identifierText(partTok)
+			if err != nil {
+				return "", ast.NoLoc(), err
+			}
+			parts = append(parts, part)
+			end = partTok.Loc.End
+		}
+		return "@@" + strings.Join(parts, "."), ast.Loc{Start: collateTok.Loc.Start, End: end}, nil
+	default:
+		return "", ast.NoLoc(), p.typeErrorAt("expected a string or parameter after COLLATE")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Errors & standalone entry point.
+// ---------------------------------------------------------------------------
+
+// typeError returns a *ParseError describing a missing type at the current
+// token, distinct from a generic error so a type position reports "expected
+// type".
+func (p *Parser) typeError() *ParseError {
+	if p.cur.Type == tokEOF {
+		return &ParseError{Loc: p.cur.Loc, Msg: "expected type, found end of input"}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Type)
+	}
+	return &ParseError{Loc: p.cur.Loc, Msg: "expected type, found " + text}
+}
+
+// typeErrorAt returns a *ParseError with a custom message at the current token.
+func (p *Parser) typeErrorAt(msg string) *ParseError {
+	return &ParseError{Loc: p.cur.Loc, Msg: msg}
+}
+
+// ParseDataType parses a complete GoogleSQL type from a standalone string,
+// returning the *DataType and any ParseErrors. Trailing tokens after the type
+// are reported as an error (the type is still returned). It is the string-input
+// counterpart of parseType, for tests and callers (catalog, deparse) that hold
+// a type string rather than a token stream. Mirrors snowflake/parser and
+// trino/parser ParseDataType.
+func ParseDataType(input string) (*DataType, []ParseError) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+
+	dt, err := p.parseType()
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			return nil, []ParseError{*pe}
+		}
+		return nil, []ParseError{{Msg: err.Error()}}
+	}
+	if p.cur.Type != tokEOF {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Type)
+		}
+		return dt, []ParseError{{Loc: p.cur.Loc, Msg: "unexpected token after type: " + text}}
+	}
+	return dt, nil
+}

--- a/googlesql/parser/datatypes_oracle_test.go
+++ b/googlesql/parser/datatypes_oracle_test.go
@@ -1,0 +1,270 @@
+//go:build googlesql_oracle
+
+// Differential test for the `types` node against the live Cloud Spanner
+// emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestTypeDifferential
+//
+// It is the PROVE gate for googlesql/types (correctness-protocol.md): for every
+// fixture it (1) feeds a full statement embedding the type to the emulator via
+// the harness/googlesql-spanner CLI and reads the accept/reject verdict, then
+// (2) parses the bare type text with omni's parseType, and asserts the two
+// agree — BOTH polarities (the corpus has accept AND reject cases). A harness
+// `error` verdict (oracle could not decide) fails the fixture loudly; it is
+// never folded into accept or reject.
+//
+// The emulator speaks Spanner's dialect, a SUBSET of the BigQuery+Spanner union
+// the parser must accept (oracle.md). Every type form covered here is in the
+// SHARED GoogleSQL core (scalars, ARRAY/STRUCT/RANGE/MAP/FUNCTION, parameterized
+// scalars, collate), so the Spanner verdict is authoritative — there are no
+// BigQuery-only type forms to triangulate. (RANGE / MAP / FUNCTION are parsed by
+// the grammar and reported by the emulator as ACCEPT with a semantic "not
+// supported", which is the grammar verdict we assert.)
+package parser
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// typeFixture pairs a bare type (fed to omni's parseType) with a full statement
+// embedding that type in a position where the emulator yields a clean
+// accept/reject verdict (NOT an "error"/Unimplemented one). wantParse is the
+// expected omni outcome and MUST equal the emulator's grammar verdict; it is
+// stated here so a divergence between the asserted truth and the live oracle is
+// caught explicitly.
+type typeFixture struct {
+	typeText  string // bare type for parseType
+	stmt      string // full statement for the oracle (one stmt, no trailing ';')
+	wantParse bool   // expected: omni parses (and oracle accepts)
+}
+
+// typeFixtures are oracle-probed type forms. Each `stmt` was chosen to produce a
+// deterministic emulator verdict: scalars/arrays/range/map/function via
+// CAST(NULL AS …); structs via field extraction so the emulator does not hit
+// its "struct value cannot be returned" Unimplemented path.
+var typeFixtures = []typeFixture{
+	// --- scalars (type_name path_expression) — all accept ---
+	{"INT64", "SELECT CAST(NULL AS INT64)", true},
+	{"STRING", "SELECT CAST(NULL AS STRING)", true},
+	{"BYTES", "SELECT CAST(NULL AS BYTES)", true},
+	{"BOOL", "SELECT CAST(NULL AS BOOL)", true},
+	{"FLOAT64", "SELECT CAST(NULL AS FLOAT64)", true},
+	{"FLOAT32", "SELECT CAST(NULL AS FLOAT32)", true},
+	{"NUMERIC", "SELECT CAST(NULL AS NUMERIC)", true},
+	{"BIGNUMERIC", "SELECT CAST(NULL AS BIGNUMERIC)", true},
+	{"JSON", "SELECT CAST(NULL AS JSON)", true},
+	{"DATE", "SELECT CAST(NULL AS DATE)", true},
+	{"TIMESTAMP", "SELECT CAST(NULL AS TIMESTAMP)", true},
+	{"GEOGRAPHY", "SELECT CAST(NULL AS GEOGRAPHY)", true},
+	{"TOKENLIST", "SELECT CAST(NULL AS TOKENLIST)", true},
+	{"INT", "SELECT CAST(NULL AS INT)", true},
+	{"INTERVAL", "SELECT CAST(NULL AS INTERVAL)", true},
+	{"foo.bar.Baz", "SELECT CAST(NULL AS foo.bar.Baz)", true},
+	{"`my.proto.Type`", "SELECT CAST(NULL AS `my.proto.Type`)", true},
+	{"NUMERIC.foo", "SELECT CAST(NULL AS NUMERIC.foo)", true},
+
+	// --- parameterized scalars — all accept ---
+	{"STRING(100)", "SELECT CAST(NULL AS STRING(100))", true},
+	{"BYTES(256)", "SELECT CAST(NULL AS BYTES(256))", true},
+	{"NUMERIC(10, 2)", "SELECT CAST(NULL AS NUMERIC(10, 2))", true},
+	{"STRING(MAX)", "SELECT CAST(NULL AS STRING(MAX))", true},
+	{"NUMERIC(10, 2, 3)", "SELECT CAST(NULL AS NUMERIC(10, 2, 3))", true},
+	{"NUMERIC(true)", "SELECT CAST(NULL AS NUMERIC(true))", true},
+	{"NUMERIC('foo')", "SELECT CAST(NULL AS NUMERIC('foo'))", true},
+
+	// --- collate — accept ---
+	{"INT64 COLLATE 'und:ci'", "SELECT CAST(NULL AS INT64 COLLATE 'und:ci')", true},
+	{"DATE COLLATE 'und:ci'", "SELECT CAST(NULL AS DATE COLLATE 'und:ci')", true},
+
+	// --- ARRAY — accept (incl. nested >> split) ---
+	{"ARRAY<INT64>", "SELECT CAST(NULL AS ARRAY<INT64>)", true},
+	{"ARRAY<ARRAY<INT64>>", "SELECT CAST(NULL AS ARRAY<ARRAY<INT64>>)", true},
+	{"ARRAY<INT64 COLLATE 'und:ci'>", "SELECT 1 FROM UNNEST(CAST(NULL AS ARRAY<INT64 COLLATE 'und:ci'>))", true},
+
+	// --- RANGE / MAP / FUNCTION — accept (grammar parses; semantic-unsupported) ---
+	{"RANGE<DATE>", "SELECT CAST(NULL AS RANGE<DATE>)", true},
+	{"RANGE<INT64>", "SELECT CAST(NULL AS RANGE<INT64>)", true},
+	{"MAP<INT64, STRING>", "SELECT CAST(NULL AS MAP<INT64, STRING>)", true},
+	{"FUNCTION<INT64 -> STRING>", "SELECT CAST(NULL AS FUNCTION<INT64 -> STRING>)", true},
+	{"FUNCTION<(INT64, STRING) -> BOOL>", "SELECT CAST(NULL AS FUNCTION<(INT64, STRING) -> BOOL>)", true},
+	{"FUNCTION<() -> INT64>", "SELECT CAST(NULL AS FUNCTION<() -> INT64>)", true},
+
+	// --- STRUCT (field-extraction wrappers to dodge the struct-return limit) ---
+	{"STRUCT<x INT64, y STRING>", "SELECT STRUCT<x INT64, y STRING>(1, 'a').x", true},
+	{"STRUCT<INT64, STRING>", "SELECT STRUCT<INT64, STRING>(1, 'a').field1", true},
+	{"STRUCT<a ARRAY<INT64>>", "SELECT STRUCT<a ARRAY<INT64>>([1,2]).a", true},
+	{"STRUCT<ARRAY<INT64>>", "SELECT STRUCT<ARRAY<INT64>>([1,2]).field1", true},
+	{"STRUCT<x ARRAY<STRUCT<y INT64>>>", "SELECT STRUCT<x ARRAY<STRUCT<y INT64>>>([STRUCT<y INT64>(1)]).x", true},
+	{"STRUCT<x INT64 COLLATE 'und:ci'>", "SELECT STRUCT<x INT64 COLLATE 'und:ci'>('a').x", true},
+
+	// --- negatives — all reject ---
+	{"ARRAY<>", "SELECT CAST(NULL AS ARRAY<>)", false},
+	{"ARRAY< >", "SELECT CAST(NULL AS ARRAY< >)", false},
+	{"ARRAY<INT64, STRING>", "SELECT CAST(NULL AS ARRAY<INT64, STRING>)", false},
+	{"ARRAY<INT64>>", "SELECT CAST(NULL AS ARRAY<INT64>>)", false},
+	{"ARRAY", "SELECT CAST(NULL AS ARRAY)", false},
+	{"ARRAY.foo", "SELECT CAST(NULL AS ARRAY.foo)", false},
+	{"STRUCT", "SELECT CAST(NULL AS STRUCT)", false},
+	{"STRUCT<x INT64,>", "SELECT STRUCT<x INT64,>(1).x", false},
+	{"RANGE", "SELECT CAST(NULL AS RANGE)", false},
+	{"RANGE<>", "SELECT CAST(NULL AS RANGE<>)", false},
+	{"INTERVAL.foo", "SELECT CAST(NULL AS INTERVAL.foo)", false},
+	{"INTERVAL<INT64>", "SELECT CAST(NULL AS INTERVAL<INT64>)", false},
+	{"STRING()", "SELECT CAST(NULL AS STRING())", false},
+	{"STRING(,)", "SELECT CAST(NULL AS STRING(,))", false},
+	{"NUMERIC(-5)", "SELECT CAST(NULL AS NUMERIC(-5))", false},
+	{"NUMERIC(10,)", "SELECT CAST(NULL AS NUMERIC(10,))", false},
+	{"ARRAY<INT64>(vector_length=>128)", "SELECT CAST(NULL AS ARRAY<INT64>(vector_length=>128))", false},
+	{"MAP<>", "SELECT CAST(NULL AS MAP<>)", false},
+	{"FUNCTION<>", "SELECT CAST(NULL AS FUNCTION<>)", false},
+	{"MAP<INT64>", "SELECT CAST(NULL AS MAP<INT64>)", false},
+	{"FUNCTION<INT64>", "SELECT CAST(NULL AS FUNCTION<INT64>)", false},
+	{"``", "SELECT CAST(NULL AS ``)", false},
+
+	// --- additional nested forms (>> / >>> split with named fields) — accept ---
+	{"STRUCT<STRUCT<x INT64>>", "SELECT STRUCT<STRUCT<x INT64>>(STRUCT<x INT64>(1)).field1", true},
+	{"STRUCT<x ARRAY<ARRAY<INT64>>>", "SELECT STRUCT<x ARRAY<ARRAY<INT64>>>([[1]]).x", true},
+	{"ARRAY<STRUCT<a INT64 COLLATE 'x'>>", "SELECT CAST(NULL AS ARRAY<STRUCT<a INT64 COLLATE 'x'>>)", true},
+	{"ARRAY<NUMERIC(10, 2)>", "SELECT CAST(NULL AS ARRAY<NUMERIC(10, 2)>)", true},
+	{"STRING(0)", "SELECT CAST(NULL AS STRING(0))", true},
+	{"STRING(0x10)", "SELECT CAST(NULL AS STRING(0x10))", true},
+	{"STRUCT<key INT64>", "SELECT STRUCT<key INT64>(1).key", true},
+	{"STRUCT<row INT64>", "SELECT STRUCT<row INT64>(1).row", true},
+}
+
+func TestTypeDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live differential")
+	}
+	h := newTypeHarness(t)
+	defer h.close()
+
+	for _, fx := range typeFixtures {
+		fx := fx
+		t.Run(fx.typeText, func(t *testing.T) {
+			// 1. Oracle verdict for the embedded statement.
+			v := h.verdict(t, fx.stmt)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; fix the wrapper/emulator — do NOT treat as accept/reject",
+					fx.stmt, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.stmt)
+			}
+			oracleAccepts := v.Verdict == "accept"
+
+			// Sanity: the asserted wantParse must match the live oracle. If this
+			// trips, the fixture's hard-coded expectation drifted from reality.
+			if oracleAccepts != fx.wantParse {
+				t.Fatalf("fixture wantParse=%v but oracle says %q (%s) for %q",
+					fx.wantParse, v.Verdict, v.Message, fx.stmt)
+			}
+
+			// 2. omni parseType verdict on the bare type.
+			_, errs := ParseDataType(fx.typeText)
+			omniAccepts := len(errs) == 0
+
+			if omniAccepts != oracleAccepts {
+				t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s)",
+					fx.typeText, omniAccepts, oracleAccepts, v.Reason, v.Message)
+			}
+		})
+	}
+}
+
+// --- harness plumbing (one persistent batch process, mirrors mssql's) ---
+
+type harnessVerdict struct {
+	Verdict string `json:"verdict"`
+	Kind    string `json:"kind"`
+	Reason  string `json:"reason"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type typeHarness struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	mu     sync.Mutex
+}
+
+func newTypeHarness(t *testing.T) *typeHarness {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	// googlesql/parser/datatypes_oracle_test.go → repo root is ../..
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	projDir := filepath.Join(repoRoot, "harness", "googlesql-spanner")
+	if _, err := os.Stat(projDir); err != nil {
+		t.Skipf("harness project not found at %s", projDir)
+	}
+
+	bin := filepath.Join(projDir, "googlesql-spanner")
+	// Prefer a prebuilt binary; build it if missing.
+	if _, err := os.Stat(bin); err != nil {
+		build := exec.Command("go", "build", "-o", bin, ".")
+		build.Dir = projDir
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("building harness failed: %v\n%s", err, out)
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(), "GOOGLESQL_HARNESS_LINE=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting harness: %v", err)
+	}
+	return &typeHarness{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdoutPipe)}
+}
+
+func (h *typeHarness) verdict(t *testing.T, stmt string) harnessVerdict {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	enc := base64.StdEncoding.EncodeToString([]byte(stmt))
+	if _, err := fmt.Fprintln(h.stdin, enc); err != nil {
+		t.Fatalf("writing to harness: %v", err)
+	}
+	line, err := h.stdout.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading harness verdict: %v", err)
+	}
+	var v harnessVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &v); err != nil {
+		t.Fatalf("decoding harness verdict %q: %v", line, err)
+	}
+	return v
+}
+
+func (h *typeHarness) close() {
+	if h.stdin != nil {
+		_ = h.stdin.Close()
+	}
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Wait()
+	}
+}

--- a/googlesql/parser/datatypes_test.go
+++ b/googlesql/parser/datatypes_test.go
@@ -1,0 +1,895 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// testParseType constructs a Parser over input and calls parseType, asserting
+// the whole input is consumed (cur at EOF). It mirrors snowflake's
+// testParseDataType helper. Returns the parsed *DataType and any error.
+func testParseType(input string) (*DataType, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	dt, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type != tokEOF {
+		return dt, &ParseError{Loc: p.cur.Loc, Msg: "trailing tokens after type: " + TokenName(p.cur.Type)}
+	}
+	return dt, nil
+}
+
+// ---------------------------------------------------------------------------
+// type_name (path_expression | INTERVAL) — scalars are plain identifiers.
+// ---------------------------------------------------------------------------
+
+func TestParseType_ScalarIdentifierNames(t *testing.T) {
+	// Oracle (Spanner emulator): every one of these parses (accept) as a
+	// type_name path_expression — INT64/STRING/BOOL/FLOAT64/FLOAT32/BYTES/
+	// GEOGRAPHY/TOKENLIST are NOT keyword tokens, they are identifiers; the
+	// "Type not found" cases (INT, BIGNUMERIC, GEOGRAPHY) are semantic, the
+	// grammar still parsed them.
+	names := []string{
+		"INT64", "INT", "SMALLINT", "INTEGER", "BIGINT", "TINYINT", "BYTEINT",
+		"FLOAT64", "FLOAT32", "BOOL", "BOOLEAN", "STRING", "BYTES",
+		"GEOGRAPHY", "TOKENLIST", "BIGNUMERIC", "BIGDECIMAL",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			dt, err := testParseType(name)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", name, err)
+			}
+			if dt.Kind != TypeName {
+				t.Errorf("Kind = %v, want TypeName", dt.Kind)
+			}
+			if got := strings.ToUpper(dt.String()); got != name {
+				t.Errorf("String() = %q, want %q", got, name)
+			}
+			if len(dt.NameParts) != 1 || strings.ToUpper(dt.NameParts[0]) != name {
+				t.Errorf("NameParts = %v, want [%q]", dt.NameParts, name)
+			}
+		})
+	}
+}
+
+func TestParseType_KeywordScalarNames(t *testing.T) {
+	// These type names ARE keyword tokens but are non-reserved, so they parse
+	// as the first component of a type_name path_expression (oracle: all accept,
+	// some "Type not found" semantically on Spanner — still parsed).
+	names := []string{"NUMERIC", "DECIMAL", "JSON", "DATE", "DATETIME", "TIMESTAMP", "TIME", "MAP", "FUNCTION"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			dt, err := testParseType(name)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", name, err)
+			}
+			if dt.Kind != TypeName {
+				t.Errorf("Kind = %v, want TypeName", dt.Kind)
+			}
+			if got := strings.ToUpper(dt.String()); got != name {
+				t.Errorf("String() = %q, want %q", got, name)
+			}
+		})
+	}
+}
+
+func TestParseType_Interval(t *testing.T) {
+	// type_name's INTERVAL alternative. Oracle: `CAST(NULL AS INTERVAL)` accepts.
+	dt, err := testParseType("INTERVAL")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeName {
+		t.Fatalf("Kind = %v, want TypeName", dt.Kind)
+	}
+	if !dt.IsInterval {
+		t.Errorf("IsInterval = false, want true")
+	}
+	if dt.String() != "INTERVAL" {
+		t.Errorf("String() = %q, want INTERVAL", dt.String())
+	}
+}
+
+func TestParseType_IntervalNoPathContinuation(t *testing.T) {
+	// Oracle: `INTERVAL.foo` REJECTS ("Expected ... but got ."). INTERVAL is
+	// its own type_name alt with no path continuation. testParseType requires
+	// EOF, so the trailing `.foo` must surface as an error.
+	if _, err := testParseType("INTERVAL.foo"); err == nil {
+		t.Fatal("parseType(\"INTERVAL.foo\"): want error, got nil")
+	}
+}
+
+func TestParseType_DottedPathName(t *testing.T) {
+	// Oracle: `CAST(NULL AS foo.bar.Baz)` and `NUMERIC.foo` both accept — a
+	// type_name path_expression may be multi-component (proto/enum type names).
+	cases := []struct {
+		input string
+		parts []string
+	}{
+		{"foo.bar.Baz", []string{"foo", "bar", "Baz"}},
+		{"NUMERIC.foo", []string{"NUMERIC", "foo"}},
+		{"a.b", []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dt, err := testParseType(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dt.Kind != TypeName {
+				t.Fatalf("Kind = %v, want TypeName", dt.Kind)
+			}
+			if len(dt.NameParts) != len(tc.parts) {
+				t.Fatalf("NameParts = %v, want %v", dt.NameParts, tc.parts)
+			}
+			for i := range tc.parts {
+				if dt.NameParts[i] != tc.parts[i] {
+					t.Errorf("NameParts[%d] = %q, want %q", i, dt.NameParts[i], tc.parts[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseType_EmptyBacktickRejected(t *testing.T) {
+	// Oracle: `CAST(NULL AS ``)` REJECTS ("Syntax error: Invalid empty
+	// identifier"). The lexer admits the empty backtick pair `` as a
+	// tokIdentifier with empty Str and NO lex error (a lexer gap, out of this
+	// node's scope), so the type parser must reject the empty identifier rather
+	// than fabricate a name from the token kind.
+	if _, errs := ParseDataType("``"); len(errs) == 0 {
+		t.Error("ParseDataType(\"``\"): want an error, got none")
+	} else if !strings.Contains(errs[0].Msg, "empty identifier") {
+		t.Errorf("error = %q, want it to mention 'empty identifier'", errs[0].Msg)
+	}
+	// Also as a dotted continuation and a struct field name.
+	if _, errs := ParseDataType("foo.``"); len(errs) == 0 {
+		t.Error("ParseDataType(\"foo.``\"): want an error, got none")
+	}
+}
+
+func TestParseType_BacktickQuotedName(t *testing.T) {
+	// Oracle: `CAST(NULL AS `my.proto.Type`)` accepts. The lexer strips the
+	// backticks and emits a single tokIdentifier whose Str contains the dots;
+	// it is ONE path component, not three.
+	dt, err := testParseType("`my.proto.Type`")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeName {
+		t.Fatalf("Kind = %v, want TypeName", dt.Kind)
+	}
+	if len(dt.NameParts) != 1 || dt.NameParts[0] != "my.proto.Type" {
+		t.Errorf("NameParts = %v, want [my.proto.Type]", dt.NameParts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ARRAY<type>
+// ---------------------------------------------------------------------------
+
+func TestParseType_Array(t *testing.T) {
+	dt, err := testParseType("ARRAY<INT64>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeArray {
+		t.Fatalf("Kind = %v, want TypeArray", dt.Kind)
+	}
+	if dt.ElementType == nil || dt.ElementType.Kind != TypeName {
+		t.Fatalf("ElementType = %+v, want a TypeName INT64", dt.ElementType)
+	}
+	if got := strings.ToUpper(dt.ElementType.String()); got != "INT64" {
+		t.Errorf("element = %q, want INT64", got)
+	}
+}
+
+func TestParseType_ArrayWhitespaceInsensitive(t *testing.T) {
+	// Oracle: `ARRAY< INT64 >`, `ARRAY<INT64 >`, `ARRAY< INT64>` all accept.
+	for _, in := range []string{"ARRAY< INT64 >", "ARRAY<INT64 >", "ARRAY< INT64>"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := testParseType(in); err != nil {
+				t.Errorf("parseType(%q): unexpected error: %v", in, err)
+			}
+		})
+	}
+}
+
+func TestParseType_ArrayRequiresElement(t *testing.T) {
+	// Oracle: `ARRAY<>` REJECTS ("Expected < but got <>") — the adjacent `<>`
+	// lexes as one token (tokNotEqual2); an array needs an element type.
+	if _, err := testParseType("ARRAY<>"); err == nil {
+		t.Error("parseType(\"ARRAY<>\"): want error, got nil")
+	}
+	// `ARRAY< >` (spaced, two tokens) is also empty and rejects.
+	if _, err := testParseType("ARRAY< >"); err == nil {
+		t.Error("parseType(\"ARRAY< >\"): want error, got nil")
+	}
+}
+
+func TestParseType_ArrayRejectsMultipleElements(t *testing.T) {
+	// Oracle: `ARRAY<INT64, STRING>` REJECTS ("Expected > but got ,").
+	if _, err := testParseType("ARRAY<INT64, STRING>"); err == nil {
+		t.Error("parseType(\"ARRAY<INT64, STRING>\"): want error, got nil")
+	}
+}
+
+func TestParseType_BareArrayRejected(t *testing.T) {
+	// Oracle: bare `ARRAY` (no `<`) REJECTS ("Expected < but got )"). ARRAY is a
+	// reserved keyword and can ONLY introduce array_type; it is not a valid
+	// bare type_name. Same for ARRAY.foo (oracle reject "Expected < but got .").
+	for _, in := range []string{"ARRAY", "ARRAY.foo"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := testParseType(in); err == nil {
+				t.Errorf("parseType(%q): want error, got nil", in)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nested types — the >> / >>> split (D1 divergence).
+// ---------------------------------------------------------------------------
+
+func TestParseType_NestedArray(t *testing.T) {
+	// Oracle: `ARRAY<ARRAY<INT64>>` ACCEPTS (semantic "Arrays of arrays are not
+	// supported" — the grammar parsed it). The adjacent `>>` lexes as
+	// tokShiftRight and MUST be split into two template closers.
+	dt, err := testParseType("ARRAY<ARRAY<INT64>>")
+	if err != nil {
+		t.Fatalf("parseType(\"ARRAY<ARRAY<INT64>>\"): unexpected error: %v", err)
+	}
+	if dt.Kind != TypeArray {
+		t.Fatalf("outer Kind = %v, want TypeArray", dt.Kind)
+	}
+	if dt.ElementType == nil || dt.ElementType.Kind != TypeArray {
+		t.Fatalf("inner = %+v, want a TypeArray", dt.ElementType)
+	}
+	inner := dt.ElementType.ElementType
+	if inner == nil || strings.ToUpper(inner.String()) != "INT64" {
+		t.Errorf("innermost = %+v, want INT64", inner)
+	}
+}
+
+func TestParseType_TripleNestedClose(t *testing.T) {
+	// Oracle: `STRUCT<x ARRAY<STRUCT<y INT64>>>` ACCEPTS — the `>>>` (lexed as
+	// tokShiftRight then '>') must split into THREE template closers.
+	dt, err := testParseType("STRUCT<x ARRAY<STRUCT<y INT64>>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeStruct {
+		t.Fatalf("Kind = %v, want TypeStruct", dt.Kind)
+	}
+	if len(dt.Fields) != 1 {
+		t.Fatalf("got %d fields, want 1", len(dt.Fields))
+	}
+	if dt.Fields[0].Type == nil || dt.Fields[0].Type.Kind != TypeArray {
+		t.Errorf("field type = %+v, want TypeArray", dt.Fields[0].Type)
+	}
+}
+
+func TestParseType_StructWithArrayDoubleClose(t *testing.T) {
+	// Oracle: `STRUCT<ARRAY<INT64>>` ACCEPTS — anonymous struct field of array
+	// type, closing `>>`.
+	dt, err := testParseType("STRUCT<ARRAY<INT64>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeStruct || len(dt.Fields) != 1 {
+		t.Fatalf("got %+v, want a 1-field struct", dt)
+	}
+	if dt.Fields[0].Name != "" {
+		t.Errorf("field name = %q, want anonymous", dt.Fields[0].Name)
+	}
+	if dt.Fields[0].Type.Kind != TypeArray {
+		t.Errorf("field type kind = %v, want TypeArray", dt.Fields[0].Type.Kind)
+	}
+}
+
+func TestParseType_ExtraCloseRejected(t *testing.T) {
+	// Oracle: `ARRAY<INT64>>` REJECTS ("Expected ) ... but got >"). After the
+	// type is complete, a leftover `>` is a syntax error — the >>-split must NOT
+	// borrow a closer when no template is open. testParseType requires EOF.
+	if _, err := testParseType("ARRAY<INT64>>"); err == nil {
+		t.Error("parseType(\"ARRAY<INT64>>\"): want error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// STRUCT<...>
+// ---------------------------------------------------------------------------
+
+func TestParseType_StructNamedFields(t *testing.T) {
+	dt, err := testParseType("STRUCT<x INT64, y STRING>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeStruct {
+		t.Fatalf("Kind = %v, want TypeStruct", dt.Kind)
+	}
+	if len(dt.Fields) != 2 {
+		t.Fatalf("got %d fields, want 2", len(dt.Fields))
+	}
+	if dt.Fields[0].Name != "x" || strings.ToUpper(dt.Fields[0].Type.String()) != "INT64" {
+		t.Errorf("field0 = %+v, want {x INT64}", dt.Fields[0])
+	}
+	if dt.Fields[1].Name != "y" || strings.ToUpper(dt.Fields[1].Type.String()) != "STRING" {
+		t.Errorf("field1 = %+v, want {y STRING}", dt.Fields[1])
+	}
+}
+
+func TestParseType_StructAnonymousFields(t *testing.T) {
+	// Oracle: `STRUCT<INT64, STRING>` accepts (anonymous fields).
+	dt, err := testParseType("STRUCT<INT64, STRING>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dt.Fields) != 2 {
+		t.Fatalf("got %d fields, want 2", len(dt.Fields))
+	}
+	for i, f := range dt.Fields {
+		if f.Name != "" {
+			t.Errorf("field%d name = %q, want anonymous", i, f.Name)
+		}
+	}
+}
+
+func TestParseType_StructEmpty(t *testing.T) {
+	// Oracle: `STRUCT<>` and `STRUCT< >` both ACCEPT (empty struct). The
+	// adjacent `<>` lexes as tokNotEqual2; STRUCT treats it as an empty template.
+	for _, in := range []string{"STRUCT<>", "STRUCT< >"} {
+		t.Run(in, func(t *testing.T) {
+			dt, err := testParseType(in)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", in, err)
+			}
+			if dt.Kind != TypeStruct {
+				t.Fatalf("Kind = %v, want TypeStruct", dt.Kind)
+			}
+			if len(dt.Fields) != 0 {
+				t.Errorf("got %d fields, want 0", len(dt.Fields))
+			}
+		})
+	}
+}
+
+func TestParseType_StructNested(t *testing.T) {
+	dt, err := testParseType("STRUCT<x STRUCT<y INT64, z INT64>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeStruct || len(dt.Fields) != 1 {
+		t.Fatalf("got %+v, want 1-field struct", dt)
+	}
+	inner := dt.Fields[0].Type
+	if inner == nil || inner.Kind != TypeStruct || len(inner.Fields) != 2 {
+		t.Errorf("inner = %+v, want a 2-field struct", inner)
+	}
+}
+
+func TestParseType_NamedFieldOfNestedType(t *testing.T) {
+	// Regression for the named-field disambiguation + >>-split interaction: a
+	// named field whose type is itself a template type closing with `>>` or
+	// `>>>`. The named-form lookahead buffers the field type's leading keyword
+	// via peekNext, then the inner template-close split pushes a `>` back —
+	// these must compose. All oracle-accept.
+	cases := []string{
+		"STRUCT<a STRUCT<b INT64>>",          // named struct field of struct type, >> close
+		"STRUCT<STRUCT<x INT64>>",            // anonymous struct field of struct type, >> close
+		"STRUCT<x ARRAY<ARRAY<INT64>>>",      // named field, array-of-array, >>> close
+		"ARRAY<STRUCT<a INT64 COLLATE 'x'>>", // collate inside a nested struct field, >> close
+		"ARRAY<NUMERIC(10, 2)>",              // parameterized element type, then `)>` close
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, errs := ParseDataType(in); len(errs) != 0 {
+				t.Errorf("ParseDataType(%q): unexpected errors: %v", in, errs)
+			}
+		})
+	}
+}
+
+func TestParseType_HexAndZeroTypeParam(t *testing.T) {
+	// Oracle: STRING(0) and STRING(0x10) both accept (an integer_literal
+	// type_parameter may be 0 or hex; the lexer parses 0x-hex into tokInteger).
+	for _, in := range []string{"STRING(0)", "STRING(0x10)"} {
+		t.Run(in, func(t *testing.T) {
+			dt, err := testParseType(in)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", in, err)
+			}
+			if len(dt.Params) != 1 || !dt.Params[0].IsInt {
+				t.Errorf("Params = %+v, want one int param", dt.Params)
+			}
+		})
+	}
+}
+
+func TestParseType_StructFieldArray(t *testing.T) {
+	// Oracle: `STRUCT<a ARRAY<INT64>>` accepts.
+	dt, err := testParseType("STRUCT<a ARRAY<INT64>>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeStruct || len(dt.Fields) != 1 {
+		t.Fatalf("got %+v, want 1-field struct", dt)
+	}
+	if dt.Fields[0].Name != "a" || dt.Fields[0].Type.Kind != TypeArray {
+		t.Errorf("field0 = %+v, want {a ARRAY<...>}", dt.Fields[0])
+	}
+}
+
+func TestParseType_StructFieldCollate(t *testing.T) {
+	// Oracle: `STRUCT<x INT64 COLLATE 'und:ci'>` and
+	// `STRUCT<INT64 COLLATE 'x', y STRING>` both accept (collate on a struct
+	// field type, named and anonymous).
+	for _, in := range []string{"STRUCT<x INT64 COLLATE 'und:ci'>", "STRUCT<INT64 COLLATE 'x', y STRING>"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := testParseType(in); err != nil {
+				t.Errorf("parseType(%q): unexpected error: %v", in, err)
+			}
+		})
+	}
+}
+
+func TestParseType_StructKeywordFieldName(t *testing.T) {
+	// Oracle: STRUCT<key INT64> and STRUCT<row INT64> accept — a NON-reserved
+	// word-keyword (KEY, ROW, VALUE, DATA) is a valid struct field name
+	// (struct_field: identifier type; identifier admits keyword_as_identifier).
+	cases := []struct {
+		input string
+		name  string
+	}{
+		{"STRUCT<key INT64>", "KEY"},
+		{"STRUCT<row INT64>", "ROW"},
+		{"STRUCT<value STRING, data INT64>", "VALUE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dt, err := testParseType(tc.input)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", tc.input, err)
+			}
+			if len(dt.Fields) == 0 || strings.ToUpper(dt.Fields[0].Name) != tc.name {
+				t.Errorf("first field name = %q, want %q", dt.Fields[0].Name, tc.name)
+			}
+		})
+	}
+}
+
+func TestParseType_FieldNameEqualsTypeKeyword(t *testing.T) {
+	// The hardest named/anonymous disambiguation: a field whose NAME is a
+	// type-name keyword AND whose TYPE is the same keyword. Oracle accepts
+	// STRUCT<date DATE> (field `date` : DATE), STRUCT<json JSON>. The lookahead
+	// `name type` must win because the token after the name still begins a type.
+	cases := []struct {
+		input    string
+		wantName string
+		wantType string
+	}{
+		{"STRUCT<date DATE>", "DATE", "DATE"},
+		{"STRUCT<json JSON>", "JSON", "JSON"},
+		{"STRUCT<timestamp TIMESTAMP>", "TIMESTAMP", "TIMESTAMP"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dt, err := testParseType(tc.input)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", tc.input, err)
+			}
+			if len(dt.Fields) != 1 {
+				t.Fatalf("got %d fields, want 1", len(dt.Fields))
+			}
+			if strings.ToUpper(dt.Fields[0].Name) != tc.wantName {
+				t.Errorf("field name = %q, want %q", dt.Fields[0].Name, tc.wantName)
+			}
+			if strings.ToUpper(dt.Fields[0].Type.String()) != tc.wantType {
+				t.Errorf("field type = %q, want %q", dt.Fields[0].Type.String(), tc.wantType)
+			}
+		})
+	}
+}
+
+func TestParseType_GreaterEqualSplitLeavesEquals(t *testing.T) {
+	// The D1 split must also handle `>=` (tokGreaterEqual) as a template close:
+	// the `>` closes the template and the `=` is pushed back. ParseDataType over
+	// "ARRAY<INT64>=" must yield a TypeArray plus a trailing-token error for the
+	// leftover `=`.
+	dt, errs := ParseDataType("ARRAY<INT64>=")
+	if dt == nil || dt.Kind != TypeArray {
+		t.Fatalf("got %+v, want a TypeArray", dt)
+	}
+	if len(errs) == 0 {
+		t.Error("want a trailing-token error for the leftover '='")
+	}
+}
+
+func TestParseType_StructTrailingCommaRejected(t *testing.T) {
+	// Oracle: `STRUCT<x INT64,>` REJECTS ("Unexpected >") — no trailing comma.
+	if _, err := testParseType("STRUCT<x INT64,>"); err == nil {
+		t.Error("parseType(\"STRUCT<x INT64,>\"): want error, got nil")
+	}
+}
+
+func TestParseType_BareStructRejected(t *testing.T) {
+	// Oracle: bare `STRUCT` (no `<`) REJECTS ("Expected < but got )").
+	if _, err := testParseType("STRUCT"); err == nil {
+		t.Error("parseType(\"STRUCT\"): want error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RANGE<type>
+// ---------------------------------------------------------------------------
+
+func TestParseType_Range(t *testing.T) {
+	// Oracle: `RANGE<DATE>` accepts (semantic "Type not found: RANGE<DATE>" on
+	// Spanner, which lacks RANGE, but the grammar parsed it). `RANGE<INT64>`
+	// also accepts at parse time (semantic "Unsupported type") — the grammar
+	// puts ANY `type` inside RANGE, not just DATE/DATETIME/TIMESTAMP.
+	for _, in := range []string{"RANGE<DATE>", "RANGE<DATETIME>", "RANGE<TIMESTAMP>", "RANGE<INT64>"} {
+		t.Run(in, func(t *testing.T) {
+			dt, err := testParseType(in)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", in, err)
+			}
+			if dt.Kind != TypeRange {
+				t.Fatalf("Kind = %v, want TypeRange", dt.Kind)
+			}
+			if dt.ElementType == nil {
+				t.Fatal("ElementType is nil")
+			}
+		})
+	}
+}
+
+func TestParseType_RangeRejections(t *testing.T) {
+	// Oracle: `RANGE<>` REJECTS ("Expected < but got <>"); bare `RANGE` REJECTS.
+	for _, in := range []string{"RANGE<>", "RANGE"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := testParseType(in); err == nil {
+				t.Errorf("parseType(%q): want error, got nil", in)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MAP<key, value> and FUNCTION<...> (legacy raw_type alts).
+// ---------------------------------------------------------------------------
+
+func TestParseType_Map(t *testing.T) {
+	// Oracle: `MAP<INT64, STRING>` accepts (semantic "MAP datatype is not
+	// supported" — grammar parsed it). Bare `MAP` is a type_name (accept,
+	// "Type not found: MAP") since MAP is non-reserved.
+	dt, err := testParseType("MAP<INT64, STRING>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeMap {
+		t.Fatalf("Kind = %v, want TypeMap", dt.Kind)
+	}
+	if dt.KeyType == nil || dt.ValueType == nil {
+		t.Fatalf("KeyType/ValueType = %v/%v, want both set", dt.KeyType, dt.ValueType)
+	}
+	if strings.ToUpper(dt.KeyType.String()) != "INT64" || strings.ToUpper(dt.ValueType.String()) != "STRING" {
+		t.Errorf("MAP<%s, %s>, want MAP<INT64, STRING>", dt.KeyType, dt.ValueType)
+	}
+}
+
+func TestParseType_BareMapIsTypeName(t *testing.T) {
+	// Oracle: bare `MAP` accepts as a type_name (MAP is non-reserved).
+	dt, err := testParseType("MAP")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeName {
+		t.Errorf("Kind = %v, want TypeName (bare MAP is a type_name)", dt.Kind)
+	}
+}
+
+func TestParseType_Function(t *testing.T) {
+	// Oracle: all three accept (semantic "FUNCTION type not supported"):
+	//   FUNCTION<INT64 -> STRING>          single arg
+	//   FUNCTION<() -> INT64>              no args
+	//   FUNCTION<(INT64, STRING) -> BOOL>  multi args
+	cases := []struct {
+		input   string
+		nArgs   int
+		wantRet string
+	}{
+		{"FUNCTION<INT64 -> STRING>", 1, "STRING"},
+		{"FUNCTION<() -> INT64>", 0, "INT64"},
+		{"FUNCTION<(INT64, STRING) -> BOOL>", 2, "BOOL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dt, err := testParseType(tc.input)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", tc.input, err)
+			}
+			if dt.Kind != TypeFunction {
+				t.Fatalf("Kind = %v, want TypeFunction", dt.Kind)
+			}
+			if len(dt.ArgTypes) != tc.nArgs {
+				t.Errorf("got %d arg types, want %d", len(dt.ArgTypes), tc.nArgs)
+			}
+			if dt.ReturnType == nil || strings.ToUpper(dt.ReturnType.String()) != tc.wantRet {
+				t.Errorf("return = %v, want %s", dt.ReturnType, tc.wantRet)
+			}
+		})
+	}
+}
+
+func TestParseType_BareFunctionIsTypeName(t *testing.T) {
+	// Oracle: bare `FUNCTION` accepts as a type_name (FUNCTION is non-reserved).
+	dt, err := testParseType("FUNCTION")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeName {
+		t.Errorf("Kind = %v, want TypeName (bare FUNCTION is a type_name)", dt.Kind)
+	}
+}
+
+func TestParseType_MapFunctionMalformed(t *testing.T) {
+	// Oracle rejects (the bare MAP/FUNCTION type_name is parsed, then the
+	// template tokens are unexpected, OR the template body is incomplete):
+	//   MAP<>          reject ("Expected ) ... but got <>")  -> MAP type_name + stray <>
+	//   FUNCTION<>     reject (same shape)
+	//   MAP<INT64>     reject ("Expected , but got >")        -> map needs 2 types
+	//   FUNCTION<INT64> reject ("Expected -> but got >")      -> function needs -> ret
+	// (`<>` adjacent lexes as one token, so MAP</FUNCTION< fall through to a
+	// bare type_name and the `<>` becomes a trailing token — exactly the oracle
+	// shape.)
+	for _, in := range []string{"MAP<>", "FUNCTION<>", "MAP<INT64>", "FUNCTION<INT64>"} {
+		t.Run(in, func(t *testing.T) {
+			if _, errs := ParseDataType(in); len(errs) == 0 {
+				t.Errorf("ParseDataType(%q): want error, got none", in)
+			}
+		})
+	}
+	// Spaced MAP< … > is a real template and accepts.
+	if _, errs := ParseDataType("MAP< INT64, STRING >"); len(errs) != 0 {
+		t.Errorf("ParseDataType(\"MAP< INT64, STRING >\"): unexpected errors: %v", errs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// opt_type_parameters — (n), (n, m), (MAX), bool/string/bytes/float params.
+// ---------------------------------------------------------------------------
+
+func TestParseType_TypeParameters(t *testing.T) {
+	// Oracle: all accept (semantic "Parameterized types are not supported" on
+	// Spanner — the grammar parsed the parameter list). type_parameter is
+	// int | bool | string | bytes | float | MAX; multiple are allowed.
+	cases := []struct {
+		input  string
+		nParam int
+	}{
+		{"STRING(100)", 1},
+		{"BYTES(256)", 1},
+		{"NUMERIC(10, 2)", 2},
+		{"STRING(MAX)", 1},
+		{"STRING(MAX, 2)", 2},
+		{"NUMERIC(10, 2, 3)", 3},
+		{"NUMERIC(true)", 1},
+		{"NUMERIC('foo')", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dt, err := testParseType(tc.input)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", tc.input, err)
+			}
+			if len(dt.Params) != tc.nParam {
+				t.Errorf("got %d params, want %d: %+v", len(dt.Params), tc.nParam, dt.Params)
+			}
+		})
+	}
+}
+
+func TestParseType_TypeParametersOnNameKind(t *testing.T) {
+	// STRING(100) keeps Kind=TypeName (the params hang off the type_name).
+	dt, err := testParseType("STRING(100)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeName {
+		t.Errorf("Kind = %v, want TypeName", dt.Kind)
+	}
+	if len(dt.Params) != 1 || !dt.Params[0].IsInt || dt.Params[0].IntVal != 100 {
+		t.Errorf("Params = %+v, want one int 100", dt.Params)
+	}
+}
+
+func TestParseType_TypeParametersMax(t *testing.T) {
+	dt, err := testParseType("STRING(MAX)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dt.Params) != 1 || !dt.Params[0].IsMax {
+		t.Errorf("Params = %+v, want one MAX param", dt.Params)
+	}
+}
+
+func TestParseType_TypeParameterRejections(t *testing.T) {
+	// Oracle rejects (syntax):
+	//   STRING()       empty list             ("Unexpected )")
+	//   STRING(,)      leading comma          ("Unexpected ,")
+	//   NUMERIC(-5)    signed (not an int lit)("Unexpected -")
+	for _, in := range []string{"STRING()", "STRING(,)", "NUMERIC(-5)"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := testParseType(in); err == nil {
+				t.Errorf("parseType(%q): want error, got nil", in)
+			}
+		})
+	}
+}
+
+func TestParseType_TrailingCommaInTypeParameters(t *testing.T) {
+	// Legacy grammar emits a dedicated "Trailing comma in type parameters list
+	// is not allowed" error for `(n,)`. The oracle rejects equivalently
+	// ("Unexpected )"). Either way it must be an error.
+	if _, err := testParseType("NUMERIC(10,)"); err == nil {
+		t.Error("parseType(\"NUMERIC(10,)\"): want error, got nil")
+	}
+}
+
+func TestParseType_ArrayTypeParametersRejectNamedArg(t *testing.T) {
+	// Oracle: `ARRAY<INT64>(vector_length=>128)` REJECTS ("Unexpected
+	// identifier vector_length") in a bare `type` position — vector_length is a
+	// DDL column-schema attribute, NOT a type_parameter. The general `type`
+	// rule's opt_type_parameters only accepts int/bool/string/bytes/float/MAX.
+	if _, err := testParseType("ARRAY<INT64>(vector_length=>128)"); err == nil {
+		t.Error("parseType(\"ARRAY<INT64>(vector_length=>128)\"): want error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collate_clause — type COLLATE 'string-or-parameter'
+// ---------------------------------------------------------------------------
+
+func TestParseType_Collate(t *testing.T) {
+	// Oracle: `INT64 COLLATE 'und:ci'` and `DATE COLLATE 'und:ci'` accept
+	// (semantic "Type with collation name is not supported in cast" — parsed).
+	for _, in := range []string{"INT64 COLLATE 'und:ci'", "DATE COLLATE 'und:ci'", "STRING COLLATE 'und'"} {
+		t.Run(in, func(t *testing.T) {
+			dt, err := testParseType(in)
+			if err != nil {
+				t.Fatalf("parseType(%q): unexpected error: %v", in, err)
+			}
+			if dt.Collate == "" {
+				t.Errorf("Collate = empty, want the collation string")
+			}
+		})
+	}
+}
+
+func TestParseType_CollateOnArrayElement(t *testing.T) {
+	// Oracle: `ARRAY<INT64 COLLATE 'und:ci'>` accepts — collate binds to the
+	// element type inside the array, not the array.
+	dt, err := testParseType("ARRAY<INT64 COLLATE 'und:ci'>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dt.Kind != TypeArray {
+		t.Fatalf("Kind = %v, want TypeArray", dt.Kind)
+	}
+	if dt.ElementType == nil || dt.ElementType.Collate == "" {
+		t.Errorf("element collate not captured: %+v", dt.ElementType)
+	}
+	if dt.Collate != "" {
+		t.Errorf("array Collate = %q, want empty (collate is on the element)", dt.Collate)
+	}
+}
+
+func TestParseType_CollateParameter(t *testing.T) {
+	// collate_clause: COLLATE string_literal_or_parameter, where parameter is
+	// @name | ? | @@sysvar. The grammar accepts a parameter; capture it.
+	for _, in := range []string{"STRING COLLATE @p", "STRING COLLATE ?"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := testParseType(in); err != nil {
+				t.Errorf("parseType(%q): unexpected error: %v", in, err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: String() re-renders to syntax the parser re-accepts.
+// ---------------------------------------------------------------------------
+
+func TestParseType_StringRoundTrip(t *testing.T) {
+	inputs := []string{
+		"INT64",
+		"STRING(100)",
+		"NUMERIC(10, 2)",
+		"STRING(MAX)",
+		"ARRAY<INT64>",
+		"ARRAY<ARRAY<INT64>>",
+		"STRUCT<x INT64, y STRING>",
+		"STRUCT<INT64, STRING>",
+		"STRUCT<>",
+		"STRUCT<a ARRAY<INT64>>",
+		"RANGE<DATE>",
+		"MAP<INT64, STRING>",
+		"FUNCTION<(INT64, STRING) -> BOOL>",
+		"INTERVAL",
+		"foo.bar.Baz",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			dt1, err := testParseType(in)
+			if err != nil {
+				t.Fatalf("parseType(%q): %v", in, err)
+			}
+			rendered := dt1.String()
+			dt2, err := testParseType(rendered)
+			if err != nil {
+				t.Fatalf("re-parse of String()=%q failed: %v", rendered, err)
+			}
+			if dt1.String() != dt2.String() {
+				t.Errorf("round-trip unstable: %q -> %q -> %q", in, rendered, dt2.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseDataType — standalone string entry point.
+// ---------------------------------------------------------------------------
+
+func TestParseDataType_Standalone(t *testing.T) {
+	dt, errs := ParseDataType("ARRAY<STRUCT<x INT64>>")
+	if len(errs) != 0 {
+		t.Fatalf("ParseDataType: unexpected errors: %v", errs)
+	}
+	if dt == nil || dt.Kind != TypeArray {
+		t.Fatalf("got %+v, want a TypeArray", dt)
+	}
+}
+
+func TestParseDataType_TrailingTokens(t *testing.T) {
+	// A complete type followed by junk reports an error but still returns the
+	// type (mirrors snowflake/trino ParseDataType).
+	dt, errs := ParseDataType("INT64 garbage")
+	if dt == nil {
+		t.Fatal("ParseDataType returned nil type")
+	}
+	if len(errs) == 0 {
+		t.Error("want a trailing-token error, got none")
+	}
+}
+
+func TestParseDataType_Invalid(t *testing.T) {
+	_, errs := ParseDataType("SELECT")
+	if len(errs) == 0 {
+		t.Error("ParseDataType(\"SELECT\"): want an error, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc — every node carries a valid byte span.
+// ---------------------------------------------------------------------------
+
+func TestParseType_Loc(t *testing.T) {
+	in := "ARRAY<INT64>"
+	dt, err := testParseType(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !dt.Loc.IsValid() {
+		t.Fatalf("Loc invalid: %+v", dt.Loc)
+	}
+	if dt.Loc.Start != 0 || dt.Loc.End != len(in) {
+		t.Errorf("Loc = %+v, want {0, %d}", dt.Loc, len(in))
+	}
+	if dt.ElementType == nil || !dt.ElementType.Loc.IsValid() {
+		t.Errorf("element Loc invalid: %+v", dt.ElementType)
+	}
+}


### PR DESCRIPTION
## Node: `googlesql/types` (v2 migration, P0 grammar)

Spec: `Data types: scalars, parameterized (STRING(N), NUMERIC(p,s)), ARRAY<>, STRUCT<>, RANGE<>, INTERVAL`. Implements the GoogleSQL `type` grammar rule (§2.20 of `docs/migration/googlesql/antlr_rules.md`) and all its sub-rules.

Depends on `googlesql/parser-foundation` (merged) + `googlesql/ast-core` (merged); feeds `googlesql/expressions` and the DDL/DML nodes.

### What ships
A single hand-written recursive-descent parser in `googlesql/parser/datatypes.go`:
- `parseType` = `raw_type opt_type_parameters? collate_clause?`, plus `parseRawType`, `parseTypeName`, `parseArrayType`, `parseStructType`, `parseStructField`, `parseRangeType`, `parseMapType`, `parseFunctionType`, `parseTypeParameters`, `parseTypeParameter`, `parseCollateClause`, and the `expectTemplateClose` splitter.
- A `DataType` **parser-package value type** (NOT an `ast.Node`) with `String()` round-trip rendering — following the `trino/parser.DataType` precedent, since the googlesql `ast` tag set is closed to the `ast-core` `File` container. Later nodes (expressions, ddl, dml) embed `*DataType`.
- Public `ParseDataType(string)` entry point (mirrors snowflake/trino).

### Coverage (completeness gate — 100%)
All 14 §2.20 ANTLR rules and all `truth1/{bigquery,spanner}` documented type forms (DT-001..006, TYPE-001..018) → tested with an oracle-derived verdict. Scalars (INT64/STRING/BOOL/FLOAT64/FLOAT32/BYTES/GEOGRAPHY/TOKENLIST as identifiers; NUMERIC/JSON/DATE/TIME/etc. as non-reserved keywords; proto/enum dotted + backtick paths), parameterized scalars (`STRING(N)`, `STRING(MAX)`, `NUMERIC(p,s)`, multi/bool/string/float params), `ARRAY<T>`, `STRUCT<…>` (named/anonymous/empty/nested), `RANGE<T>`, `MAP<k,v>`, `FUNCTION<(args)->ret>` (3 forms), `INTERVAL`, `COLLATE`.

### Correctness — proven against the live oracle (both polarities)
PROVE gate = build-tagged differential `go test -tags googlesql_oracle ./googlesql/parser/ -run TestTypeDifferential` shelling out to `harness/googlesql-spanner` (live Cloud Spanner emulator, gRPC :9010). **72 fixtures — 50 accept-polarity + 22 reject-polarity — omni's `parseType` verdict matches the emulator on every one.** An `error` verdict (oracle can't decide) fails the fixture loudly; none are folded into accept/reject. Plus deparse round-trip stability and AST structural assertions, and 145 unit subtests (`go test ./googlesql/parser/`).

### Divergences from the literal ANTLR grammar (oracle-confirmed)
Both are rooted in the lexer's greedy longest-match (which the hand-port of ZetaSQL's grammar does not special-case), and both are decided by the live oracle:

- **D1 — template-close `>>`/`>=` split.** The lexer emits `>>` (`tokShiftRight`) and `>=` (`tokGreaterEqual`); `template_type_close` is a single `>`. A literal reading rejects nested types, but the oracle **accepts** `ARRAY<ARRAY<INT64>>`, `STRUCT<x ARRAY<STRUCT<y INT64>>>` (semantic "Arrays of arrays are not supported" = it parsed). So a `>>`/`>=` at a template close is split (first `>` closes; remainder pushed back). A leftover `>` with no open template still errors (oracle: `ARRAY<INT64>>` rejects).
- **D2 — empty `STRUCT<>`.** Adjacent `<>` lexes as one `tokNotEqual2`. The oracle **accepts** `STRUCT<>` / `STRUCT< >` (empty struct) but **rejects** `ARRAY<>` / `RANGE<>` (need content). STRUCT treats a leading `<>` as an empty template; the others require a real `<` then content.

Self-review (Codex unavailable this run — substituted a second adversarial pass) also caught and fixed an over-permissive edge: an empty backtick `` `` `` lexes cleanly (a lexer gap, out of this node's scope) and was being turned into the literal name "IDENTIFIER"; now rejected as "invalid empty identifier", matching the oracle. Regression-covered in both the unit suite and the differential.

### Reference
Pattern copied from `snowflake/parser/datatypes.go` (datatype parsing) and `trino/parser/datatypes.go` (parser-package `DataType`, not an ast node). Differential harness pattern from `mssql/parser/scriptdom_harness_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)