### PR TITLE
feat(snowflake): T4.1 CREATE / ALTER STAGE

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -104,6 +104,10 @@ const (
 	T_GetStmt
 	T_ListStmt
 	T_RemoveStmt
+
+	// Stage DDL tags (T4.1)
+	T_CreateStageStmt
+	T_AlterStageStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -251,6 +255,10 @@ func (t NodeTag) String() string {
 		return "ListStmt"
 	case T_RemoveStmt:
 		return "RemoveStmt"
+	case T_CreateStageStmt:
+		return "CreateStageStmt"
+	case T_AlterStageStmt:
+		return "AlterStageStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -2550,3 +2550,91 @@ var (
 	_ Node = (*ListStmt)(nil)
 	_ Node = (*RemoveStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// Stage DDL — CREATE / ALTER STAGE (T4.1)
+// ---------------------------------------------------------------------------
+//
+// Like COPY, the stage grammar carries large, version-growing option
+// vocabularies: the external-stage cloud params (URL, STORAGE_INTEGRATION,
+// CREDENTIALS, ENCRYPTION, ENDPOINT, AWS_ACCESS_POINT_ARN,
+// USE_PRIVATELINK_ENDPOINT, ...), the directory-table params (DIRECTORY = (...)),
+// the file-format params (FILE_FORMAT = (FORMAT_NAME = ... | TYPE = ... ...)) and
+// the copy options (COPY_OPTIONS = (...)). Rather than enumerate them — the
+// legacy ANTLR grammar's finite lists are already stale relative to the docs
+// (they lack AWS_ACCESS_POINT_ARN, USE_PRIVATELINK_ENDPOINT, ENDPOINT, the
+// s3compat:// form, ...) — every such param is captured as an open-ended
+// `KEY = <value>` pair (CopyOption), reusing the merged COPY (T5.2) machinery.
+// Only the structurally-distinct WITH TAG and COMMENT clauses, and the ALTER
+// action keywords (RENAME / SET / UNSET / REFRESH), anchor the grammar. The
+// catalog/semantic layer, not the parser, validates that an option is legal.
+
+// CreateStageStmt represents
+//
+//	CREATE [ OR REPLACE ] [ TEMP | TEMPORARY ] STAGE [ IF NOT EXISTS ] <name>
+//	  <stageParams>            -- internal: ENCRYPTION=(...); external: URL=...,
+//	                              STORAGE_INTEGRATION=..., CREDENTIALS=(...),
+//	                              ENCRYPTION=(...), ...
+//	  [ DIRECTORY = ( ... ) ]
+//	  [ FILE_FORMAT = ( ... ) ]
+//	  [ COPY_OPTIONS = ( ... ) ]
+//	  [ COMMENT = '<string>' ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//
+// All cloud/format/copy/comment params are captured open-ended in Options,
+// preserving source order (an internal stage simply has no URL option). Tags
+// holds the WITH TAG assignments. There is no dedicated External flag: an
+// external stage is exactly one that carries a URL option, which downstream
+// consumers can detect.
+type CreateStageStmt struct {
+	OrReplace   bool
+	Temporary   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Options     []*CopyOption    // URL / STORAGE_INTEGRATION / CREDENTIALS / ENCRYPTION / DIRECTORY / FILE_FORMAT / COPY_OPTIONS / COMMENT / ...
+	Tags        []*TagAssignment // [WITH] TAG (...); nil if absent
+	Loc         Loc
+}
+
+func (n *CreateStageStmt) Tag() NodeTag { return T_CreateStageStmt }
+
+// AlterStageAction discriminates the action variants of ALTER STAGE.
+type AlterStageAction int
+
+const (
+	AlterStageRename   AlterStageAction = iota // RENAME TO <new_name>
+	AlterStageSet                              // SET <stageParams|FILE_FORMAT|COPY_OPTIONS|COMMENT|DIRECTORY>
+	AlterStageUnset                            // UNSET <property names> (e.g. DCM PROJECT)
+	AlterStageSetTag                           // SET TAG (...)
+	AlterStageUnsetTag                         // UNSET TAG (...)
+	AlterStageRefresh                          // REFRESH [ SUBPATH = '<relative-path>' ]
+)
+
+// AlterStageStmt represents ALTER STAGE [IF EXISTS] <name> <action>.
+//
+//	RENAME TO <new_name>
+//	SET <options>                       -- open-ended KEY = value params
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]          -- e.g. UNSET DCM PROJECT
+//	REFRESH [ SUBPATH = '<relative-path>' ]
+type AlterStageStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterStageAction
+	NewName    *ObjectName      // RENAME TO target; non-nil for AlterStageRename
+	Options    []*CopyOption    // SET <options>; for AlterStageSet
+	Tags       []*TagAssignment // SET TAG (...) assignments; for AlterStageSetTag
+	UnsetTags  []*ObjectName    // UNSET TAG (...) names; for AlterStageUnsetTag
+	UnsetProps []string         // UNSET <property> names; for AlterStageUnset
+	Subpath    *string          // REFRESH SUBPATH = '...'; nil when absent
+	Loc        Loc
+}
+
+func (n *AlterStageStmt) Tag() NodeTag { return T_AlterStageStmt }
+
+// Compile-time assertions for stage DDL nodes.
+var (
+	_ Node = (*CreateStageStmt)(nil)
+	_ Node = (*AlterStageStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -31,6 +31,13 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterStageStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterTableStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -117,6 +124,10 @@ func walkChildren(v Visitor, node Node) {
 		walkNodes(v, n.ClusterBy)
 		Walk(v, n.Query)
 	case *CreateSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *CreateStageStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -86,6 +86,9 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	case kwMATERIALIZED:
 		p.advance() // consume MATERIALIZED
 		return p.parseCreateMaterializedViewStmt(start, orReplace, false)
+	case kwSTAGE:
+		// CREATE [OR REPLACE] [TEMP|TEMPORARY] STAGE ... (T4.1).
+		return p.parseCreateStageStmt(start, orReplace, temporary)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -172,6 +172,9 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	case kwMATERIALIZED:
 		p.advance() // consume MATERIALIZED
 		return p.parseAlterMaterializedViewStmt()
+	case kwSTAGE:
+		// ALTER STAGE ... (T4.1).
+		return p.parseAlterStageStmt()
 	default:
 		return p.unsupported("ALTER")
 	}

--- a/snowflake/parser/stage.go
+++ b/snowflake/parser/stage.go
@@ -1,0 +1,374 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Stage DDL — CREATE / ALTER STAGE (T4.1)
+// ---------------------------------------------------------------------------
+//
+// Snowflake's stage grammar carries large, version-growing option vocabularies
+// for both internal and external stages: the external cloud params (URL,
+// STORAGE_INTEGRATION, CREDENTIALS, ENCRYPTION, ENDPOINT, AWS_ACCESS_POINT_ARN,
+// USE_PRIVATELINK_ENDPOINT, ...), the directory-table params (DIRECTORY = (...)),
+// the file-format params (FILE_FORMAT = (FORMAT_NAME = ... | TYPE = ... ...)) and
+// the copy options (COPY_OPTIONS = (...)). Rather than mirror the legacy ANTLR
+// grammar's finite, already-stale enumerations (its external_stage_params and
+// stage_encryption_opts_* rules lack AWS_ACCESS_POINT_ARN, USE_PRIVATELINK_ENDPOINT,
+// ENDPOINT, the s3compat:// form, ... all of which appear in the docs corpus),
+// every param that follows the stage name is parsed as an open-ended
+// `KEY = <value>` pair (ast.CopyOption), reusing the merged COPY (T5.2)
+// machinery (parseCopyOption / parseCopyOptionParen). Only the structurally
+// distinct WITH TAG and COMMENT clauses, and the ALTER action keywords
+// (RENAME / SET / UNSET / REFRESH), anchor the grammar. The catalog/semantic
+// layer, not the parser, validates that an option is real and legal. This
+// mirrors the open-ended COPY / GRANT / SHOW approaches already merged.
+
+// ---------------------------------------------------------------------------
+// CREATE STAGE
+// ---------------------------------------------------------------------------
+
+// parseCreateStageStmt parses the body of a
+//
+//	CREATE [OR REPLACE] [TEMP|TEMPORARY] STAGE [IF NOT EXISTS] <name>
+//	  <stageParams> [DIRECTORY=(...)] [FILE_FORMAT=(...)] [COPY_OPTIONS=(...)]
+//	  [COMMENT='<string>'] [[WITH] TAG (<tag>='<value>' [,...])]
+//
+// statement. The CREATE keyword and the optional OR REPLACE / TEMPORARY
+// modifiers have already been consumed by parseCreateStmt; start is the Loc of
+// the CREATE token, and cur is the STAGE keyword.
+func (p *Parser) parseCreateStageStmt(start ast.Loc, orReplace, temporary bool) (ast.Node, error) {
+	p.advance() // consume STAGE
+
+	stmt := &ast.CreateStageStmt{
+		OrReplace: orReplace,
+		Temporary: temporary,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// Stage name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Trailing clauses: open-ended cloud / directory / file-format / copy /
+	// comment params (each a KEY = value pair) interleaved with the [WITH] TAG
+	// clause. The docs place COMMENT before [WITH] TAG, while the legacy ANTLR
+	// grammar lists `with_tags? comment_clause?` (TAG before COMMENT); accepting
+	// either order (a) follows the docs, (b) regresses neither, and (c) avoids
+	// silently dropping a COMMENT that trails the TAG clause. The loop ends at a
+	// statement boundary or any token that begins neither an option nor a tag
+	// clause.
+	for {
+		if p.startsStageTags() {
+			tags, err := p.parseStageWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+			continue
+		}
+		if p.startsStageOption() {
+			opt, err := p.parseCopyOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+			continue
+		}
+		break
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER STAGE
+// ---------------------------------------------------------------------------
+
+// parseAlterStageStmt parses ALTER STAGE [IF EXISTS] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the STAGE keyword.
+//
+//	RENAME TO <new_name>
+//	SET <options>
+//	SET TAG <tag> = '<value>' [, ...]
+//	UNSET TAG <tag> [, ...]
+//	UNSET <property> [, ...]            (e.g. UNSET DCM PROJECT)
+//	REFRESH [ SUBPATH = '<relative-path>' ]
+func (p *Parser) parseAlterStageStmt() (ast.Node, error) {
+	altTok := p.advance() // consume STAGE
+	stmt := &ast.AlterStageStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// Stage name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch.
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO <new_name>
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterStageRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			// SET TAG <tag> = '<value>' [, ...]
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStageSetTag
+			stmt.Tags = tags
+		} else {
+			// SET <options> — open-ended KEY = value params.
+			opts, err := p.parseStageOptions()
+			if err != nil {
+				return nil, err
+			}
+			if len(opts) == 0 {
+				// SET with nothing settable is a syntax error.
+				return nil, p.syntaxErrorAtCur()
+			}
+			stmt.Action = ast.AlterStageSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			// UNSET TAG <tag> [, ...]
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStageUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET <property> [, ...] (e.g. DCM PROJECT). Each property is an
+			// open-ended run of name words (DCM PROJECT is two words); names are
+			// not enumerated.
+			props, err := p.parseStageUnsetProps()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStageUnset
+			stmt.UnsetProps = props
+		}
+
+	case kwREFRESH:
+		// REFRESH [ SUBPATH = '<relative-path>' ]
+		p.advance() // consume REFRESH
+		stmt.Action = ast.AlterStageRefresh
+		if p.curIsWord("SUBPATH") {
+			p.advance() // consume SUBPATH
+			if _, err := p.expect('='); err != nil {
+				return nil, err
+			}
+			tok, err := p.expect(tokString)
+			if err != nil {
+				return nil, err
+			}
+			s := tok.Str
+			stmt.Subpath = &s
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared stage helpers
+// ---------------------------------------------------------------------------
+
+// parseStageOptions parses a run of zero or more stage params, each an
+// open-ended `KEY = <value>` pair (reusing parseCopyOption). The run continues
+// while the current token begins another option and terminates at a statement
+// boundary (';' / EOF), at the WITH / TAG clause, or at any token that does not
+// begin an option. WITH and TAG are explicitly excluded as option starters
+// because they introduce the trailing WITH TAG clause, not a stage param.
+func (p *Parser) parseStageOptions() ([]*ast.CopyOption, error) {
+	var opts []*ast.CopyOption
+	for p.startsStageOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+	}
+	return opts, nil
+}
+
+// startsStageOption reports whether the current token can begin a stage param.
+// It is the COPY option predicate minus WITH and TAG, which anchor the trailing
+// [WITH] TAG clause and must not be swallowed as an option name.
+func (p *Parser) startsStageOption() bool {
+	switch p.cur.Type {
+	case kwWITH, kwTAG:
+		return false
+	}
+	return p.startsCopyOption()
+}
+
+// startsStageTags reports whether the current position begins a [WITH] TAG
+// clause: either the TAG keyword directly, or WITH immediately followed by TAG
+// (a WITH not followed by TAG is not a tag clause and is left for the caller).
+func (p *Parser) startsStageTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// parseStageWithTags parses a [WITH] TAG (...) clause and returns the tag
+// assignments. It accepts both the WITH TAG and the bare TAG spellings
+// (matching the docs' "[ WITH ] TAG (...)"). The caller must have confirmed
+// startsStageTags; calling it otherwise yields a syntax error from
+// parseTagAssignments.
+func (p *Parser) parseStageWithTags() ([]*ast.TagAssignment, error) {
+	if p.cur.Type == kwWITH {
+		p.advance() // consume WITH (peekNext == TAG guaranteed by startsStageTags)
+	}
+	return p.parseTagAssignments()
+}
+
+// parseTagSetList parses a SET TAG <tag> = '<value>' [, ...] list. Unlike the
+// parenthesized WITH TAG (...) form, the SET TAG form is an unparenthesized
+// comma-separated assignment list (per CREATE/ALTER ... SET TAG). The TAG
+// keyword is consumed here.
+func (p *Parser) parseTagSetList() ([]*ast.TagAssignment, error) {
+	if _, err := p.expect(kwTAG); err != nil {
+		return nil, err
+	}
+
+	var tags []*ast.TagAssignment
+	for {
+		tagName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('='); err != nil {
+			return nil, err
+		}
+		valueTok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		tags = append(tags, &ast.TagAssignment{Name: tagName, Value: valueTok.Str})
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return tags, nil
+}
+
+// parseUnsetTagNameList parses an UNSET TAG <tag> [, ...] name list. Unlike the
+// DATABASE/SCHEMA UNSET TAG (...) form, ALTER STAGE's UNSET TAG list is
+// unparenthesized (per the docs). The TAG keyword is consumed here.
+func (p *Parser) parseUnsetTagNameList() ([]*ast.ObjectName, error) {
+	if _, err := p.expect(kwTAG); err != nil {
+		return nil, err
+	}
+
+	var names []*ast.ObjectName
+	for {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return names, nil
+}
+
+// parseStageUnsetProps parses an UNSET <property> [, ...] list, where each
+// property is an open-ended run of one or more name words (e.g. the two-word
+// DCM PROJECT, or a single COMMENT / URL / CREDENTIALS / ENCRYPTION /
+// STORAGE_INTEGRATION). Property names are not enumerated; consecutive
+// space-separated name words within one property are joined with a single
+// space, and a comma separates properties. Consumes at least one property.
+func (p *Parser) parseStageUnsetProps() ([]string, error) {
+	var props []string
+	for {
+		prop, err := p.parseStageUnsetProp()
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, prop)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return props, nil
+}
+
+// parseStageUnsetProp parses a single UNSET property: one or more consecutive
+// name words (identifier or keyword), joined with single spaces and uppercased.
+// Multi-word properties such as DCM PROJECT are captured whole. The run stops at
+// a comma, a statement boundary, or any non-word token.
+func (p *Parser) parseStageUnsetProp() (string, error) {
+	if !p.isOptionWord(p.cur.Type) {
+		return "", p.syntaxErrorAtCur()
+	}
+	var b strings.Builder
+	b.WriteString(strings.ToUpper(p.advance().Str))
+	for p.isOptionWord(p.cur.Type) {
+		b.WriteByte(' ')
+		b.WriteString(strings.ToUpper(p.advance().Str))
+	}
+	return b.String(), nil
+}

--- a/snowflake/parser/stage_test.go
+++ b/snowflake/parser/stage_test.go
@@ -1,0 +1,647 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateStage(t *testing.T, input string) *ast.CreateStageStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateStageStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateStageStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterStage(t *testing.T, input string) *ast.AlterStageStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterStageStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterStageStmt", input, node)
+	}
+	return stmt
+}
+
+// groupEntry returns the named entry of a parenthesized option group, or nil.
+func groupEntry(opt *ast.CopyOption, name string) *ast.CopyOption {
+	if opt == nil {
+		return nil
+	}
+	return findOption(opt.Group, name)
+}
+
+// ---------------------------------------------------------------------------
+// CREATE STAGE — modifiers, name, IF NOT EXISTS
+// ---------------------------------------------------------------------------
+
+func TestParseCreateStage_Modifiers(t *testing.T) {
+	t.Run("minimal internal", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE my_stage")
+		if stmt.Name.String() != "my_stage" {
+			t.Errorf("Name = %q, want my_stage", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.Temporary || stmt.IfNotExists {
+			t.Errorf("unexpected modifier set: %+v", stmt)
+		}
+		if len(stmt.Options) != 0 || len(stmt.Tags) != 0 {
+			t.Errorf("expected no options/tags, got %+v / %+v", stmt.Options, stmt.Tags)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE OR REPLACE STAGE s")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("temporary", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE TEMPORARY STAGE s")
+		if !stmt.Temporary {
+			t.Error("Temporary not set")
+		}
+	})
+
+	t.Run("temp", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE TEMP STAGE s")
+		if !stmt.Temporary {
+			t.Error("Temporary not set for TEMP")
+		}
+	})
+
+	t.Run("or replace temporary", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE OR REPLACE TEMPORARY STAGE s")
+		if !stmt.OrReplace || !stmt.Temporary {
+			t.Errorf("OrReplace=%v Temporary=%v, want both true", stmt.OrReplace, stmt.Temporary)
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE IF NOT EXISTS s")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE db.sch.s")
+		if stmt.Name.String() != "db.sch.s" {
+			t.Errorf("Name = %q, want db.sch.s", stmt.Name.String())
+		}
+	})
+
+	t.Run("quoted name", func(t *testing.T) {
+		stmt := mustCreateStage(t, `CREATE STAGE "My Stage"`)
+		if stmt.Name.String() != `"My Stage"` {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE STAGE — internal stage params (ENCRYPTION / DIRECTORY / FILE_FORMAT /
+// COPY_OPTIONS / COMMENT / WITH TAG)
+// ---------------------------------------------------------------------------
+
+func TestParseCreateStage_InternalParams(t *testing.T) {
+	t.Run("encryption snowflake_sse", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE')")
+		enc := findOption(stmt.Options, "ENCRYPTION")
+		if enc == nil {
+			t.Fatalf("missing ENCRYPTION; options=%+v", stmt.Options)
+		}
+		typ := groupEntry(enc, "TYPE")
+		if typ == nil || typ.Lit == nil || typ.Lit.Value != "SNOWFLAKE_SSE" {
+			t.Errorf("ENCRYPTION TYPE = %+v, want 'SNOWFLAKE_SSE'", typ)
+		}
+	})
+
+	t.Run("encryption snowflake_full", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s ENCRYPTION = (TYPE = 'SNOWFLAKE_FULL')")
+		if groupEntry(findOption(stmt.Options, "ENCRYPTION"), "TYPE") == nil {
+			t.Error("missing ENCRYPTION TYPE")
+		}
+	})
+
+	t.Run("directory enable", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s DIRECTORY = (ENABLE = TRUE)")
+		dir := findOption(stmt.Options, "DIRECTORY")
+		en := groupEntry(dir, "ENABLE")
+		if en == nil || en.Words != "TRUE" {
+			t.Errorf("DIRECTORY ENABLE = %+v, want Words=TRUE", en)
+		}
+	})
+
+	t.Run("directory enable auto_refresh (internal)", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s DIRECTORY = (ENABLE = TRUE AUTO_REFRESH = FALSE)")
+		dir := findOption(stmt.Options, "DIRECTORY")
+		if groupEntry(dir, "ENABLE") == nil || groupEntry(dir, "AUTO_REFRESH") == nil {
+			t.Errorf("DIRECTORY group = %+v", dir)
+		}
+	})
+
+	t.Run("file_format format_name", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s FILE_FORMAT = (FORMAT_NAME = 'my_csv')")
+		ff := findOption(stmt.Options, "FILE_FORMAT")
+		fn := groupEntry(ff, "FORMAT_NAME")
+		if fn == nil || fn.Lit == nil || fn.Lit.Value != "my_csv" {
+			t.Errorf("FORMAT_NAME = %+v, want 'my_csv'", fn)
+		}
+	})
+
+	t.Run("file_format type with options", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s FILE_FORMAT = (TYPE = CSV SKIP_HEADER = 1 FIELD_DELIMITER = ',')")
+		ff := findOption(stmt.Options, "FILE_FORMAT")
+		if ff == nil || len(ff.Group) != 3 {
+			t.Fatalf("FILE_FORMAT group = %+v", ff)
+		}
+		typ := groupEntry(ff, "TYPE")
+		if typ == nil || typ.Words != "CSV" {
+			t.Errorf("TYPE = %+v, want Words=CSV", typ)
+		}
+		if groupEntry(ff, "SKIP_HEADER") == nil || groupEntry(ff, "FIELD_DELIMITER") == nil {
+			t.Errorf("missing SKIP_HEADER/FIELD_DELIMITER in %+v", ff)
+		}
+	})
+
+	t.Run("copy_options", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s COPY_OPTIONS = (ON_ERROR = 'SKIP_FILE' PURGE = TRUE)")
+		co := findOption(stmt.Options, "COPY_OPTIONS")
+		if co == nil || len(co.Group) != 2 {
+			t.Fatalf("COPY_OPTIONS group = %+v", co)
+		}
+		if groupEntry(co, "ON_ERROR") == nil || groupEntry(co, "PURGE") == nil {
+			t.Errorf("COPY_OPTIONS entries = %+v", co.Group)
+		}
+	})
+
+	t.Run("comment", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s COMMENT = 'a stage'")
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "a stage" {
+			t.Errorf("COMMENT = %+v, want 'a stage'", c)
+		}
+	})
+
+	t.Run("with tag", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s WITH TAG (cost_center = 'sales')")
+		if len(stmt.Tags) != 1 {
+			t.Fatalf("Tags = %+v, want 1", stmt.Tags)
+		}
+		if stmt.Tags[0].Name.String() != "cost_center" || stmt.Tags[0].Value != "sales" {
+			t.Errorf("tag = %+v", stmt.Tags[0])
+		}
+	})
+
+	t.Run("bare tag", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s TAG (a = '1', b = '2')")
+		if len(stmt.Tags) != 2 {
+			t.Fatalf("Tags = %+v, want 2", stmt.Tags)
+		}
+	})
+
+	t.Run("comment then with tag (docs order)", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s COMMENT = 'c' WITH TAG (t = 'v')")
+		if findOption(stmt.Options, "COMMENT") == nil {
+			t.Error("missing COMMENT")
+		}
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v, want 1", stmt.Tags)
+		}
+	})
+
+	// The legacy ANTLR grammar lists `with_tags? comment_clause?` (TAG before
+	// COMMENT); accepting that order too avoids silently dropping a trailing
+	// COMMENT and regresses neither order. Both spellings must keep the COMMENT.
+	t.Run("with tag then comment (antlr order)", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s WITH TAG (t = 'v') COMMENT = 'c'")
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "c" {
+			t.Errorf("COMMENT not captured after TAG: %+v", c)
+		}
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v, want 1", stmt.Tags)
+		}
+	})
+
+	t.Run("bare tag then comment (antlr order)", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s TAG (t = 'v') COMMENT = 'c'")
+		if findOption(stmt.Options, "COMMENT") == nil {
+			t.Error("COMMENT dropped after bare TAG")
+		}
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v, want 1", stmt.Tags)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE STAGE — external stage params (S3 / GCS / Azure)
+// ---------------------------------------------------------------------------
+
+func TestParseCreateStage_ExternalS3(t *testing.T) {
+	t.Run("url + storage_integration", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://mybucket/path/' STORAGE_INTEGRATION = my_int")
+		url := findOption(stmt.Options, "URL")
+		if url == nil || url.Lit == nil || url.Lit.Value != "s3://mybucket/path/" {
+			t.Errorf("URL = %+v", url)
+		}
+		si := findOption(stmt.Options, "STORAGE_INTEGRATION")
+		if si == nil || si.Words != "MY_INT" {
+			t.Errorf("STORAGE_INTEGRATION = %+v, want Words=MY_INT", si)
+		}
+	})
+
+	t.Run("credentials aws key/secret/token", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' CREDENTIALS = (AWS_KEY_ID = 'k' AWS_SECRET_KEY = 's' AWS_TOKEN = 't')")
+		cr := findOption(stmt.Options, "CREDENTIALS")
+		if cr == nil || len(cr.Group) != 3 {
+			t.Fatalf("CREDENTIALS = %+v", cr)
+		}
+		for _, k := range []string{"AWS_KEY_ID", "AWS_SECRET_KEY", "AWS_TOKEN"} {
+			if groupEntry(cr, k) == nil {
+				t.Errorf("missing %s in %+v", k, cr.Group)
+			}
+		}
+	})
+
+	t.Run("credentials aws_role", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' CREDENTIALS = (AWS_ROLE = 'arn:aws:iam::123:role/r')")
+		cr := findOption(stmt.Options, "CREDENTIALS")
+		if groupEntry(cr, "AWS_ROLE") == nil {
+			t.Errorf("missing AWS_ROLE in %+v", cr)
+		}
+	})
+
+	t.Run("encryption aws_sse_kms with kms_key_id", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' ENCRYPTION = (TYPE = 'AWS_SSE_KMS' KMS_KEY_ID = 'aws-key')")
+		enc := findOption(stmt.Options, "ENCRYPTION")
+		if groupEntry(enc, "TYPE") == nil || groupEntry(enc, "KMS_KEY_ID") == nil {
+			t.Errorf("ENCRYPTION = %+v", enc)
+		}
+	})
+
+	t.Run("encryption aws_cse with master_key", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' ENCRYPTION = (TYPE = 'AWS_CSE' MASTER_KEY = 'm')")
+		enc := findOption(stmt.Options, "ENCRYPTION")
+		if groupEntry(enc, "MASTER_KEY") == nil {
+			t.Errorf("missing MASTER_KEY in %+v", enc)
+		}
+	})
+
+	t.Run("storage_integration and encryption combined", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' STORAGE_INTEGRATION = i ENCRYPTION = (TYPE = 'AWS_SSE_S3')")
+		if findOption(stmt.Options, "URL") == nil ||
+			findOption(stmt.Options, "STORAGE_INTEGRATION") == nil ||
+			findOption(stmt.Options, "ENCRYPTION") == nil {
+			t.Errorf("options = %+v", stmt.Options)
+		}
+	})
+}
+
+func TestParseCreateStage_ExternalGCS(t *testing.T) {
+	t.Run("url + storage_integration + encryption gcs_sse_kms", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 'gcs://mybucket/path/' STORAGE_INTEGRATION = gcs_int ENCRYPTION = (TYPE = 'GCS_SSE_KMS' KMS_KEY_ID = 'k')")
+		url := findOption(stmt.Options, "URL")
+		if url == nil || url.Lit.Value != "gcs://mybucket/path/" {
+			t.Errorf("URL = %+v", url)
+		}
+		enc := findOption(stmt.Options, "ENCRYPTION")
+		if groupEntry(enc, "TYPE") == nil || groupEntry(enc, "KMS_KEY_ID") == nil {
+			t.Errorf("ENCRYPTION = %+v", enc)
+		}
+	})
+}
+
+func TestParseCreateStage_ExternalAzure(t *testing.T) {
+	t.Run("url + credentials azure_sas_token + encryption azure_cse", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 'azure://acct.blob.core.windows.net/cont/path/' CREDENTIALS = (AZURE_SAS_TOKEN = 'sas') ENCRYPTION = (TYPE = 'AZURE_CSE' MASTER_KEY = 'm')")
+		if findOption(stmt.Options, "URL") == nil {
+			t.Error("missing URL")
+		}
+		cr := findOption(stmt.Options, "CREDENTIALS")
+		if groupEntry(cr, "AZURE_SAS_TOKEN") == nil {
+			t.Errorf("missing AZURE_SAS_TOKEN in %+v", cr)
+		}
+		enc := findOption(stmt.Options, "ENCRYPTION")
+		if groupEntry(enc, "MASTER_KEY") == nil {
+			t.Errorf("missing MASTER_KEY in %+v", enc)
+		}
+	})
+}
+
+func TestParseCreateStage_ExternalDirectory(t *testing.T) {
+	// External DIRECTORY supports REFRESH_ON_CREATE / AUTO_REFRESH /
+	// NOTIFICATION_INTEGRATION beyond the internal ENABLE/AUTO_REFRESH.
+	t.Run("directory full external", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' STORAGE_INTEGRATION = i DIRECTORY = (ENABLE = TRUE REFRESH_ON_CREATE = TRUE AUTO_REFRESH = TRUE NOTIFICATION_INTEGRATION = 'ni')")
+		dir := findOption(stmt.Options, "DIRECTORY")
+		if dir == nil || len(dir.Group) != 4 {
+			t.Fatalf("DIRECTORY group = %+v", dir)
+		}
+		for _, k := range []string{"ENABLE", "REFRESH_ON_CREATE", "AUTO_REFRESH", "NOTIFICATION_INTEGRATION"} {
+			if groupEntry(dir, k) == nil {
+				t.Errorf("missing %s in %+v", k, dir.Group)
+			}
+		}
+	})
+}
+
+func TestParseCreateStage_ExternalFull(t *testing.T) {
+	// A full external S3 stage exercising every option block + COMMENT + WITH TAG
+	// in one statement, in the documented order.
+	input := "CREATE OR REPLACE STAGE db.sch.my_ext_stage " +
+		"URL = 's3://load/files/' " +
+		"STORAGE_INTEGRATION = s3_int " +
+		"ENCRYPTION = (TYPE = 'AWS_SSE_KMS' KMS_KEY_ID = 'aws-key') " +
+		"DIRECTORY = (ENABLE = TRUE AUTO_REFRESH = TRUE) " +
+		"FILE_FORMAT = (TYPE = JSON STRIP_OUTER_ARRAY = TRUE) " +
+		"COPY_OPTIONS = (ON_ERROR = 'CONTINUE') " +
+		"COMMENT = 'prod load stage' " +
+		"WITH TAG (env = 'prod', team = 'data')"
+	stmt := mustCreateStage(t, input)
+	if !stmt.OrReplace {
+		t.Error("OrReplace not set")
+	}
+	if stmt.Name.String() != "db.sch.my_ext_stage" {
+		t.Errorf("Name = %q", stmt.Name.String())
+	}
+	for _, k := range []string{"URL", "STORAGE_INTEGRATION", "ENCRYPTION", "DIRECTORY", "FILE_FORMAT", "COPY_OPTIONS", "COMMENT"} {
+		if findOption(stmt.Options, k) == nil {
+			t.Errorf("missing option %s", k)
+		}
+	}
+	if len(stmt.Tags) != 2 {
+		t.Errorf("Tags = %+v, want 2", stmt.Tags)
+	}
+}
+
+func TestParseCreateStage_DocsNewOptions(t *testing.T) {
+	// Options present in the official docs but absent from the legacy ANTLR
+	// grammar. The open-ended option parser must accept them with no special
+	// casing. (Divergence: docs add these; antlr lacks them — docs win.)
+	t.Run("aws_access_point_arn", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' AWS_ACCESS_POINT_ARN = 'arn:aws:s3:::ap'")
+		if findOption(stmt.Options, "AWS_ACCESS_POINT_ARN") == nil {
+			t.Errorf("missing AWS_ACCESS_POINT_ARN; options=%+v", stmt.Options)
+		}
+	})
+
+	t.Run("use_privatelink_endpoint", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3://b/p' USE_PRIVATELINK_ENDPOINT = TRUE")
+		opt := findOption(stmt.Options, "USE_PRIVATELINK_ENDPOINT")
+		if opt == nil || opt.Words != "TRUE" {
+			t.Errorf("USE_PRIVATELINK_ENDPOINT = %+v", opt)
+		}
+	})
+
+	t.Run("s3compat endpoint", func(t *testing.T) {
+		stmt := mustCreateStage(t, "CREATE STAGE s URL = 's3compat://bucket/path/' ENDPOINT = 'my.endpoint.com' CREDENTIALS = (AWS_KEY_ID = 'k' AWS_SECRET_KEY = 's')")
+		if findOption(stmt.Options, "ENDPOINT") == nil {
+			t.Errorf("missing ENDPOINT; options=%+v", stmt.Options)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER STAGE
+// ---------------------------------------------------------------------------
+
+func TestParseAlterStage_Rename(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s RENAME TO s2")
+		if stmt.Action != ast.AlterStageRename {
+			t.Fatalf("Action = %v, want Rename", stmt.Action)
+		}
+		if stmt.Name.String() != "s" || stmt.NewName.String() != "s2" {
+			t.Errorf("Name=%q NewName=%q", stmt.Name.String(), stmt.NewName.String())
+		}
+	})
+
+	t.Run("if exists rename qualified", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE IF EXISTS db.sch.s RENAME TO db.sch.s2")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+		if stmt.NewName.String() != "db.sch.s2" {
+			t.Errorf("NewName = %q", stmt.NewName.String())
+		}
+	})
+}
+
+func TestParseAlterStage_Set(t *testing.T) {
+	t.Run("set file_format", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET FILE_FORMAT = (TYPE = CSV SKIP_HEADER = 1)")
+		if stmt.Action != ast.AlterStageSet {
+			t.Fatalf("Action = %v, want Set", stmt.Action)
+		}
+		if findOption(stmt.Options, "FILE_FORMAT") == nil {
+			t.Errorf("missing FILE_FORMAT; options=%+v", stmt.Options)
+		}
+	})
+
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET COMMENT = 'updated'")
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "updated" {
+			t.Errorf("COMMENT = %+v", c)
+		}
+	})
+
+	t.Run("set external params", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET URL = 's3://b/p2' CREDENTIALS = (AWS_KEY_ID = 'k' AWS_SECRET_KEY = 's') ENCRYPTION = (TYPE = 'AWS_SSE_S3')")
+		for _, k := range []string{"URL", "CREDENTIALS", "ENCRYPTION"} {
+			if findOption(stmt.Options, k) == nil {
+				t.Errorf("missing %s; options=%+v", k, stmt.Options)
+			}
+		}
+	})
+
+	t.Run("set copy_options", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET COPY_OPTIONS = (ON_ERROR = 'SKIP_FILE')")
+		if findOption(stmt.Options, "COPY_OPTIONS") == nil {
+			t.Errorf("missing COPY_OPTIONS; options=%+v", stmt.Options)
+		}
+	})
+
+	t.Run("set directory", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET DIRECTORY = (ENABLE = TRUE)")
+		if groupEntry(findOption(stmt.Options, "DIRECTORY"), "ENABLE") == nil {
+			t.Errorf("missing DIRECTORY ENABLE; options=%+v", stmt.Options)
+		}
+	})
+}
+
+func TestParseAlterStage_Tags(t *testing.T) {
+	t.Run("set tag single", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET TAG cost = '42'")
+		if stmt.Action != ast.AlterStageSetTag {
+			t.Fatalf("Action = %v, want SetTag", stmt.Action)
+		}
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Name.String() != "cost" || stmt.Tags[0].Value != "42" {
+			t.Errorf("Tags = %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("set tag multiple", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET TAG a = '1', b = '2'")
+		if len(stmt.Tags) != 2 {
+			t.Fatalf("Tags = %+v, want 2", stmt.Tags)
+		}
+	})
+
+	t.Run("set tag qualified name", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s SET TAG db.sch.t = 'v'")
+		if stmt.Tags[0].Name.String() != "db.sch.t" {
+			t.Errorf("tag name = %q", stmt.Tags[0].Name.String())
+		}
+	})
+
+	t.Run("unset tag single", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s UNSET TAG cost")
+		if stmt.Action != ast.AlterStageUnsetTag {
+			t.Fatalf("Action = %v, want UnsetTag", stmt.Action)
+		}
+		if len(stmt.UnsetTags) != 1 || stmt.UnsetTags[0].String() != "cost" {
+			t.Errorf("UnsetTags = %+v", stmt.UnsetTags)
+		}
+	})
+
+	t.Run("unset tag multiple", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s UNSET TAG a, b, c")
+		if len(stmt.UnsetTags) != 3 {
+			t.Errorf("UnsetTags = %+v, want 3", stmt.UnsetTags)
+		}
+	})
+}
+
+func TestParseAlterStage_Unset(t *testing.T) {
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s UNSET COMMENT")
+		if stmt.Action != ast.AlterStageUnset {
+			t.Fatalf("Action = %v, want Unset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("UnsetProps = %+v, want [COMMENT]", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("unset dcm project (multi-word, docs)", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s UNSET DCM PROJECT")
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "DCM PROJECT" {
+			t.Errorf("UnsetProps = %+v, want [\"DCM PROJECT\"]", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("unset multiple properties", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s UNSET URL, CREDENTIALS")
+		if len(stmt.UnsetProps) != 2 {
+			t.Errorf("UnsetProps = %+v, want 2", stmt.UnsetProps)
+		}
+	})
+}
+
+func TestParseAlterStage_Refresh(t *testing.T) {
+	t.Run("refresh no subpath", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s REFRESH")
+		if stmt.Action != ast.AlterStageRefresh {
+			t.Fatalf("Action = %v, want Refresh", stmt.Action)
+		}
+		if stmt.Subpath != nil {
+			t.Errorf("Subpath = %v, want nil", *stmt.Subpath)
+		}
+	})
+
+	t.Run("refresh subpath", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE s REFRESH SUBPATH = '/sub/dir'")
+		if stmt.Subpath == nil || *stmt.Subpath != "/sub/dir" {
+			t.Errorf("Subpath = %v, want /sub/dir", stmt.Subpath)
+		}
+	})
+
+	t.Run("if exists refresh subpath", func(t *testing.T) {
+		stmt := mustAlterStage(t, "ALTER STAGE IF EXISTS s REFRESH SUBPATH = 'p'")
+		if !stmt.IfExists || stmt.Subpath == nil {
+			t.Errorf("IfExists=%v Subpath=%v", stmt.IfExists, stmt.Subpath)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — malformed CREATE / ALTER STAGE must be rejected
+// ---------------------------------------------------------------------------
+
+func TestParseStage_Negative(t *testing.T) {
+	bad := []string{
+		"CREATE STAGE",                             // missing name
+		"CREATE STAGE s URL =",                     // option missing value
+		"CREATE STAGE s FILE_FORMAT = (TYPE = CSV", // unterminated group
+		"CREATE STAGE s ENCRYPTION = (TYPE = )",    // group entry missing value
+		"CREATE STAGE IF NOT s",                    // malformed IF NOT EXISTS
+		"ALTER STAGE",                              // missing name
+		"ALTER STAGE s",                            // missing action
+		"ALTER STAGE s RENAME",                     // missing TO
+		"ALTER STAGE s RENAME TO",                  // missing new name
+		"ALTER STAGE s SET",                        // nothing to set
+		"ALTER STAGE s SET TAG t =",                // tag missing value
+		"ALTER STAGE s SET TAG",                    // missing tag assignment
+		"ALTER STAGE s UNSET",                      // missing property
+		"ALTER STAGE s UNSET TAG",                  // missing tag name
+		"ALTER STAGE s REFRESH SUBPATH =",          // subpath missing value
+		"ALTER STAGE s REFRESH SUBPATH = bad",      // subpath not a string
+		"ALTER STAGE s FROBNICATE",                 // unknown action
+	}
+	for _, in := range bad {
+		t.Run(in, func(t *testing.T) {
+			result := ParseBestEffort(in)
+			if len(result.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got none (stmts=%d)", in, len(result.File.Stmts))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc accuracy
+// ---------------------------------------------------------------------------
+
+func TestParseStage_Loc(t *testing.T) {
+	input := "CREATE STAGE my_stage"
+	stmt := mustCreateStage(t, input)
+	if stmt.Loc.Start != 0 || stmt.Loc.End != len(input) {
+		t.Errorf("CREATE Loc = %+v, want {0, %d}", stmt.Loc, len(input))
+	}
+
+	// ALTER sub-parsers set Loc.Start at the object-type keyword (STAGE), not the
+	// ALTER keyword, matching the established ALTER TABLE/DATABASE/SCHEMA
+	// convention (the dispatcher consumes ALTER before the sub-parser runs).
+	ainput := "ALTER STAGE s RENAME TO s2"
+	const stageKwOff = len("ALTER ")
+	astmt := mustAlterStage(t, ainput)
+	if astmt.Loc.Start != stageKwOff || astmt.Loc.End != len(ainput) {
+		t.Errorf("ALTER Loc = %+v, want {%d, %d}", astmt.Loc, stageKwOff, len(ainput))
+	}
+
+	// Second statement in a multi-statement input gets a non-zero base offset;
+	// the option literal must still be correct (exercises base handling).
+	multi := "SELECT 1;\nCREATE STAGE s URL = 's3://b/p'"
+	res := ParseBestEffort(multi)
+	if len(res.Errors) != 0 {
+		t.Fatalf("multi parse errors: %v", res.Errors)
+	}
+	cs, ok := res.File.Stmts[1].(*ast.CreateStageStmt)
+	if !ok {
+		t.Fatalf("stmt[1] = %T", res.File.Stmts[1])
+	}
+	if findOption(cs.Options, "URL").Lit.Value != "s3://b/p" {
+		t.Errorf("URL value wrong in multi-statement input")
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-stage` (v1 DAG **T4.1**) — `CREATE STAGE` / `ALTER STAGE` for the hand-written omni Snowflake parser. `kwSTAGE` wired into the shared `parseCreateStmt` (create_table.go) and `parseAlterStmt` (database_schema.go). `DROP STAGE` was already done (drop.go), untouched.

## Forms
- **`CREATE [OR REPLACE] [TEMP|TEMPORARY] STAGE [IF NOT EXISTS] <name>`** — internal (`ENCRYPTION`, `DIRECTORY`, `FILE_FORMAT`, `COPY_OPTIONS`, `COMMENT`, `[WITH] TAG`) and external S3/GCS/Azure (`URL`, `STORAGE_INTEGRATION`, `CREDENTIALS`, `ENCRYPTION`, …).
- **`ALTER STAGE [IF EXISTS] <name>`** — `RENAME TO`, `SET <options>`, `SET TAG`, `UNSET TAG`, `UNSET <property>`, `REFRESH [SUBPATH=]`.

## Design
Reuses COPY's (T5.2) open-ended `KEY = <value>` option parsing (`ast.CopyOption`) for the version-growing cloud/directory/file-format/copy option blocks rather than enumerating them; only `[WITH] TAG` and the ALTER action keywords anchor the grammar. New AST: `CreateStageStmt`, `AlterStageStmt` (+ `AlterStageAction`); `walk_generated.go` regenerated via `genwalker`.

## Oracle / tests
Triangulation — no live Snowflake, **no stage corpus file**, so cases built from official docs (`create-stage`/`alter-stage`, authoritative) + legacy ANTLR `create_stage`/`alter_stage`/`external_stage_params` (regression baseline). **77 stage subtests** incl. 17 negatives + Loc/base-offset. `go test ./snowflake/parser/... ./snowflake/ast/...` green; full `./snowflake/...` no regression; `go vet`/`gofmt` clean.

## Divergences (flagged — docs win over stale ANTLR)
1. Docs-only external options absent from the `.g4` (`AWS_ACCESS_POINT_ARN`, `USE_PRIVATELINK_ENDPOINT`, `ENDPOINT`, `s3compat://`) — accepted via open-ended parsing.
2. `ALTER STAGE REFRESH [SUBPATH]`, `SET DIRECTORY=`, `UNSET <property>` — in docs, absent from the legacy `alter_stage` rule.
3. `CREATE STAGE` accepts `COMMENT` in either order vs `[WITH] TAG` — closes a silent-drop path (`parseSingle` doesn't assert all-tokens-consumed, so a strictly-docs-ordered parser dropped a post-TAG COMMENT with no error). Bug caught + fixed mid-implementation, regression test added.
4. Over-permissiveness backstopped by the semantic layer: `CREATE TRANSIENT/VOLATILE STAGE` (modifier ignored — pre-existing shared-dispatcher property across all CREATE types); comma-less `UNSET a b` captured as one multi-word property (supports `DCM PROJECT`).

## Review
Claude lens (`/code-review` high) — no blockers. Codex lens unavailable this wave (out of credits); orchestrator did an independent build/test/scope + dispatch-diff verification before merge.

## Note
Opened by the orchestrator from the worker's pushed, verified commit `74ac197e` (worker contract: implement→prove→review→commit→push→return; orchestrator opens the PR). No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)