### PR TITLE
feat(snowflake): T4.2 CREATE / ALTER FILE FORMAT

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -108,6 +108,10 @@ const (
 	// Stage DDL tags (T4.1)
 	T_CreateStageStmt
 	T_AlterStageStmt
+
+	// File-format DDL tags (T4.2)
+	T_CreateFileFormatStmt
+	T_AlterFileFormatStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -259,6 +263,10 @@ func (t NodeTag) String() string {
 		return "CreateStageStmt"
 	case T_AlterStageStmt:
 		return "AlterStageStmt"
+	case T_CreateFileFormatStmt:
+		return "CreateFileFormatStmt"
+	case T_AlterFileFormatStmt:
+		return "AlterFileFormatStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -2638,3 +2638,84 @@ var (
 	_ Node = (*CreateStageStmt)(nil)
 	_ Node = (*AlterStageStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// File-format DDL — CREATE / ALTER FILE FORMAT (T4.2)
+// ---------------------------------------------------------------------------
+//
+// A named file format carries a TYPE ({ CSV | JSON | AVRO | ORC | PARQUET |
+// XML }) plus a large, type-dependent and version-growing vocabulary of
+// formatTypeOptions (CSV: FIELD_DELIMITER / SKIP_HEADER /
+// FIELD_OPTIONALLY_ENCLOSED_BY / NULL_IF / ...; JSON: STRIP_OUTER_ARRAY / ...;
+// PARQUET: BINARY_AS_TEXT / USE_VECTORIZED_SCANNER / ...; etc.). Rather than
+// enumerate those options — the legacy ANTLR grammar's format_type_options list
+// is already stale relative to the docs (it lacks USE_VECTORIZED_SCANNER,
+// USE_LOGICAL_TYPE, the per-type COMPRESSION variants, ...) — every option that
+// follows the TYPE clause is captured as an open-ended `KEY = <value>` pair
+// (CopyOption), reusing the merged COPY (T5.2) machinery. The TYPE keyword is
+// the one structural anchor (it selects which options are legal); COMMENT is
+// captured open-ended in Options. The catalog/semantic layer, not the parser,
+// validates that an option is real and legal for the chosen TYPE. This mirrors
+// the merged STAGE (T4.1) / COPY (T5.2) open-ended approach.
+
+// CreateFileFormatStmt represents
+//
+//	CREATE [ OR REPLACE ] [ { TEMP | TEMPORARY | VOLATILE } ]
+//	  FILE FORMAT [ IF NOT EXISTS ] <name>
+//	  [ TYPE = { CSV | JSON | AVRO | ORC | PARQUET | XML } ]
+//	  [ formatTypeOptions ]
+//	  [ COMMENT = '<string_literal>' ]
+//
+// Type holds the uppercased format type word (e.g. "CSV"); it is "" when the
+// TYPE clause is omitted (TYPE is optional per the docs, defaulting to CSV).
+// Options holds the formatTypeOptions and the COMMENT clause, each a CopyOption,
+// preserving source order. There is no dedicated External/Volatile distinction
+// beyond the Temporary flag: VOLATILE is a synonym of TEMPORARY here and sets
+// Temporary.
+type CreateFileFormatStmt struct {
+	OrReplace   bool
+	Temporary   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Type        string        // uppercased TYPE word (CSV/JSON/AVRO/ORC/PARQUET/XML); "" if omitted
+	TypeLoc     Loc           // Loc of the TYPE value word; zero when Type is ""
+	Options     []*CopyOption // formatTypeOptions + COMMENT, preserving source order
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateFileFormatStmt) Tag() NodeTag { return T_CreateFileFormatStmt }
+
+// AlterFileFormatAction discriminates the action variants of ALTER FILE FORMAT.
+type AlterFileFormatAction int
+
+const (
+	AlterFileFormatRename AlterFileFormatAction = iota // RENAME TO <new_name>
+	AlterFileFormatSet                                 // SET <formatTypeOptions> [COMMENT=...]
+)
+
+// AlterFileFormatStmt represents
+//
+//	ALTER FILE FORMAT [ IF EXISTS ] <name> RENAME TO <new_name>
+//	ALTER FILE FORMAT [ IF EXISTS ] <name> SET { [ formatTypeOptions ] [ COMMENT = '<string_literal>' ] }
+//
+// The SET form is unparenthesized (per the docs and the legacy ANTLR grammar):
+// the formatTypeOptions and COMMENT follow SET directly. ALTER FILE FORMAT
+// supports no UNSET, no SET TAG, and no RENAME-plus-SET combination.
+type AlterFileFormatStmt struct {
+	IfExists bool
+	Name     *ObjectName
+	Action   AlterFileFormatAction
+	NewName  *ObjectName   // RENAME TO target; non-nil for AlterFileFormatRename
+	Options  []*CopyOption // SET <formatTypeOptions> [COMMENT=...]; for AlterFileFormatSet
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *AlterFileFormatStmt) Tag() NodeTag { return T_AlterFileFormatStmt }
+
+// Compile-time assertions for file-format DDL nodes.
+var (
+	_ Node = (*CreateFileFormatStmt)(nil)
+	_ Node = (*AlterFileFormatStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -16,6 +16,13 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterFileFormatStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterMaterializedViewStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -114,6 +121,10 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Lit)
 		}
 	case *CreateDatabaseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *CreateFileFormatStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -89,6 +89,12 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	case kwSTAGE:
 		// CREATE [OR REPLACE] [TEMP|TEMPORARY] STAGE ... (T4.1).
 		return p.parseCreateStageStmt(start, orReplace, temporary)
+	case kwFILE_FORMAT, kwFILE:
+		// CREATE [OR REPLACE] [TEMP|TEMPORARY|VOLATILE] FILE FORMAT ... (T4.2).
+		// FILE FORMAT lexes as one FILE_FORMAT token or two FILE+FORMAT tokens;
+		// both dispatch here. Per the docs VOLATILE is a synonym of TEMPORARY for
+		// a file format, so either modifier sets the statement's Temporary flag.
+		return p.parseCreateFileFormatStmt(start, orReplace, temporary || volatile)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -175,6 +175,10 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	case kwSTAGE:
 		// ALTER STAGE ... (T4.1).
 		return p.parseAlterStageStmt()
+	case kwFILE_FORMAT, kwFILE:
+		// ALTER FILE FORMAT ... (T4.2). FILE FORMAT lexes as one FILE_FORMAT token
+		// or two FILE+FORMAT tokens; both dispatch here.
+		return p.parseAlterFileFormatStmt()
 	default:
 		return p.unsupported("ALTER")
 	}

--- a/snowflake/parser/file_format.go
+++ b/snowflake/parser/file_format.go
@@ -1,0 +1,239 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// File-format DDL — CREATE / ALTER FILE FORMAT (T4.2)
+// ---------------------------------------------------------------------------
+//
+// A named file format carries a TYPE ({ CSV | JSON | AVRO | ORC | PARQUET |
+// XML }) plus a large, type-dependent and version-growing vocabulary of
+// formatTypeOptions. Rather than mirror the legacy ANTLR grammar's
+// format_type_options rule — already stale relative to the docs (it lacks
+// USE_VECTORIZED_SCANNER, USE_LOGICAL_TYPE, MULTI_LINE, the per-type COMPRESSION
+// variants, ...) — every option that follows the TYPE clause is parsed as an
+// open-ended `KEY = <value>` pair (ast.CopyOption), reusing the merged COPY
+// (T5.2) machinery (parseCopyOption / startsCopyOption). The `TYPE = <fmt>`
+// clause is the one structural anchor: it selects which options are legal, so it
+// is lifted out into a dedicated field. COMMENT is captured open-ended in
+// Options. The catalog/semantic layer, not the parser, validates that an option
+// is real and legal for the chosen TYPE. This mirrors the merged STAGE (T4.1) /
+// COPY (T5.2) open-ended approach.
+//
+// FILE FORMAT lexes either as one FILE_FORMAT keyword token or as two separate
+// FILE and FORMAT tokens (depending on intervening whitespace); both spellings
+// are accepted, mirroring the DROP FILE FORMAT path (drop.go).
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT
+// ---------------------------------------------------------------------------
+
+// parseCreateFileFormatStmt parses the body of a
+//
+//	CREATE [ OR REPLACE ] [ { TEMP | TEMPORARY | VOLATILE } ]
+//	  FILE FORMAT [ IF NOT EXISTS ] <name>
+//	  [ TYPE = { CSV | JSON | AVRO | ORC | PARQUET | XML } ]
+//	  [ formatTypeOptions ]
+//	  [ COMMENT = '<string_literal>' ]
+//
+// statement. The CREATE keyword and the optional OR REPLACE / TEMPORARY
+// modifiers have already been consumed by parseCreateStmt; start is the Loc of
+// the CREATE token, and cur is the FILE_FORMAT keyword (or the FILE keyword of
+// the two-token spelling). temporary is set when any of TEMP / TEMPORARY /
+// VOLATILE preceded FILE FORMAT.
+func (p *Parser) parseCreateFileFormatStmt(start ast.Loc, orReplace, temporary bool) (ast.Node, error) {
+	if err := p.consumeFileFormatKeyword(); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateFileFormatStmt{
+		OrReplace: orReplace,
+		Temporary: temporary,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			stmt.IfNotExists = true
+		}
+	}
+
+	// File-format name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Trailing clauses: the optional TYPE anchor, the open-ended formatTypeOptions,
+	// and the COMMENT clause, in any order. The docs list TYPE first, but the loop
+	// accepts TYPE anywhere and routes it to the dedicated Type field; every other
+	// clause is an open-ended option. The loop ends at a statement boundary or any
+	// token that does not begin an option.
+	for p.startsCopyOption() {
+		// TYPE = <fmt> is the structural anchor; capture it into Type, not Options.
+		if p.cur.Type == kwTYPE {
+			if err := p.parseFileFormatType(&stmt.Type, &stmt.TypeLoc); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = append(stmt.Options, opt)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER FILE FORMAT
+// ---------------------------------------------------------------------------
+
+// parseAlterFileFormatStmt parses
+//
+//	ALTER FILE FORMAT [ IF EXISTS ] <name> RENAME TO <new_name>
+//	ALTER FILE FORMAT [ IF EXISTS ] <name> SET { [ formatTypeOptions ] [ COMMENT = '...' ] }
+//
+// The ALTER keyword has already been consumed; cur is the FILE_FORMAT keyword
+// (or the FILE keyword of the two-token spelling). The SET form is
+// unparenthesized (per the docs and the legacy ANTLR grammar). ALTER FILE FORMAT
+// supports no UNSET and no SET TAG.
+func (p *Parser) parseAlterFileFormatStmt() (ast.Node, error) {
+	startLoc := p.cur.Loc // FILE_FORMAT / FILE keyword anchors Loc.Start (ALTER convention)
+	if err := p.consumeFileFormatKeyword(); err != nil {
+		return nil, err
+	}
+	stmt := &ast.AlterFileFormatStmt{Loc: ast.Loc{Start: startLoc.Start}}
+
+	// Optional IF EXISTS
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			stmt.IfExists = true
+		}
+	}
+
+	// File-format name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch.
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO <new_name>
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterFileFormatRename
+		stmt.NewName = newName
+
+	case kwSET:
+		// SET <formatTypeOptions> [ COMMENT = '...' ] — unparenthesized, open-ended
+		// KEY = value params. A TYPE clause is not settable post-creation, so it is
+		// captured (open-ended) like any other option rather than lifted out.
+		p.advance() // consume SET
+		var opts []*ast.CopyOption
+		for p.startsCopyOption() {
+			opt, err := p.parseCopyOption()
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, opt)
+		}
+		if len(opts) == 0 {
+			// SET with nothing settable is a syntax error.
+			return nil, p.syntaxErrorAtCur()
+		}
+		stmt.Action = ast.AlterFileFormatSet
+		stmt.Options = opts
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared file-format helpers
+// ---------------------------------------------------------------------------
+
+// consumeFileFormatKeyword consumes the FILE FORMAT object keyword in either of
+// its two lexings: the single FILE_FORMAT keyword token, or the two separate
+// FILE and FORMAT tokens. On entry cur is the FILE_FORMAT or FILE keyword
+// (callers dispatch on exactly those). Mirrors the DROP FILE FORMAT handling.
+func (p *Parser) consumeFileFormatKeyword() error {
+	switch p.cur.Type {
+	case kwFILE_FORMAT:
+		p.advance() // consume FILE_FORMAT (single keyword token)
+		return nil
+	case kwFILE:
+		p.advance() // consume FILE
+		if _, err := p.expect(kwFORMAT); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// parseFileFormatType parses the structural `TYPE = { CSV | JSON | AVRO | ORC |
+// PARQUET | XML }` clause, storing the uppercased format word into *typ and the
+// value's source span into *loc. The format value is accepted as either a bare
+// keyword (the documented form, TYPE = CSV) or a quoted string (TYPE = 'CSV'),
+// which some real-world DDL uses; both normalize to the uppercased word. On
+// entry cur is the TYPE keyword. The parser does not validate that the value is
+// one of the six documented types — an unknown TYPE is left to the
+// catalog/semantic layer, matching the open-ended option philosophy.
+func (p *Parser) parseFileFormatType(typ *string, loc *ast.Loc) error {
+	p.advance() // consume TYPE
+	if _, err := p.expect('='); err != nil {
+		return err
+	}
+
+	// Quoted form: TYPE = 'CSV'.
+	if p.cur.Type == tokString {
+		tok := p.advance()
+		*typ = strings.ToUpper(tok.Str)
+		*loc = tok.Loc
+		return nil
+	}
+
+	// Bare-word form: TYPE = CSV (and any other keyword/identifier). Reuses the
+	// single-token word-value reader so a value is always required. The value's
+	// start is captured before reading, since parseValueWord may consume dotted
+	// continuations.
+	start := p.cur.Loc.Start
+	words, end, err := p.parseValueWord()
+	if err != nil {
+		return err
+	}
+	*typ = words
+	*loc = ast.Loc{Start: start, End: end}
+	return nil
+}

--- a/snowflake/parser/file_format_test.go
+++ b/snowflake/parser/file_format_test.go
@@ -1,0 +1,683 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateFileFormat(t *testing.T, input string) *ast.CreateFileFormatStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateFileFormatStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateFileFormatStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterFileFormat(t *testing.T, input string) *ast.AlterFileFormatStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterFileFormatStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterFileFormatStmt", input, node)
+	}
+	return stmt
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — modifiers, name, IF NOT EXISTS
+//
+// Docs grammar (truth1, authoritative):
+//
+//	CREATE [ OR REPLACE ] [ { TEMP | TEMPORARY | VOLATILE } ]
+//	  FILE FORMAT [ IF NOT EXISTS ] <name>
+//	  [ TYPE = { CSV | JSON | AVRO | ORC | PARQUET | XML } ]
+//	  [ formatTypeOptions ] [ COMMENT = '<string_literal>' ]
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_Modifiers(t *testing.T) {
+	t.Run("minimal (no type)", func(t *testing.T) {
+		// TYPE is optional per the docs (defaults to CSV); the legacy ANTLR
+		// grammar also makes it optional. A bare CREATE FILE FORMAT <name> is
+		// therefore valid.
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT my_format")
+		if stmt.Name.String() != "my_format" {
+			t.Errorf("Name = %q, want my_format", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.Temporary || stmt.IfNotExists {
+			t.Errorf("unexpected modifier set: %+v", stmt)
+		}
+		if stmt.Type != "" {
+			t.Errorf("Type = %q, want empty", stmt.Type)
+		}
+		if len(stmt.Options) != 0 {
+			t.Errorf("expected no options, got %+v", stmt.Options)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE OR REPLACE FILE FORMAT f TYPE = CSV")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("temporary", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE TEMPORARY FILE FORMAT f TYPE = CSV")
+		if !stmt.Temporary {
+			t.Error("Temporary not set")
+		}
+	})
+
+	t.Run("temp", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE TEMP FILE FORMAT f TYPE = CSV")
+		if !stmt.Temporary {
+			t.Error("Temporary not set for TEMP")
+		}
+	})
+
+	t.Run("volatile (docs synonym of temporary)", func(t *testing.T) {
+		// VOLATILE is listed in the docs alongside TEMP/TEMPORARY and is treated
+		// as a synonym setting Temporary. (Divergence: the legacy ANTLR grammar's
+		// create_file_format rule lacks any TEMP/TEMPORARY/VOLATILE modifier; docs
+		// win.)
+		stmt := mustCreateFileFormat(t, "CREATE VOLATILE FILE FORMAT f TYPE = CSV")
+		if !stmt.Temporary {
+			t.Error("Temporary not set for VOLATILE")
+		}
+	})
+
+	t.Run("or replace temporary", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE OR REPLACE TEMPORARY FILE FORMAT f TYPE = CSV")
+		if !stmt.OrReplace || !stmt.Temporary {
+			t.Errorf("OrReplace=%v Temporary=%v, want both true", stmt.OrReplace, stmt.Temporary)
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT IF NOT EXISTS f TYPE = CSV")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT db.sch.f TYPE = CSV")
+		if stmt.Name.String() != "db.sch.f" {
+			t.Errorf("Name = %q, want db.sch.f", stmt.Name.String())
+		}
+	})
+
+	t.Run("quoted name", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, `CREATE FILE FORMAT "My Format" TYPE = CSV`)
+		if stmt.Name.String() != `"My Format"` {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — every TYPE value
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_Types(t *testing.T) {
+	for _, typ := range []string{"CSV", "JSON", "AVRO", "ORC", "PARQUET", "XML"} {
+		t.Run(typ, func(t *testing.T) {
+			stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = "+typ)
+			if stmt.Type != typ {
+				t.Errorf("Type = %q, want %q", stmt.Type, typ)
+			}
+			if len(stmt.Options) != 0 {
+				t.Errorf("expected no options, got %+v", stmt.Options)
+			}
+		})
+	}
+
+	t.Run("lowercase type uppercased", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = csv")
+		if stmt.Type != "CSV" {
+			t.Errorf("Type = %q, want CSV", stmt.Type)
+		}
+	})
+
+	t.Run("quoted type string", func(t *testing.T) {
+		// The docs show the bare-keyword form (TYPE = CSV); some legacy corpora and
+		// real-world DDL quote it (TYPE = 'CSV'). Accept both, normalizing to the
+		// uppercased value.
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = 'JSON'")
+		if stmt.Type != "JSON" {
+			t.Errorf("Type = %q, want JSON", stmt.Type)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — per-type formatTypeOptions (open-ended)
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_CSVOptions(t *testing.T) {
+	input := "CREATE FILE FORMAT f TYPE = CSV " +
+		"COMPRESSION = GZIP " +
+		"RECORD_DELIMITER = '\\n' " +
+		"FIELD_DELIMITER = '|' " +
+		"SKIP_HEADER = 1 " +
+		"SKIP_BLANK_LINES = TRUE " +
+		"DATE_FORMAT = AUTO " +
+		"TIME_FORMAT = 'HH24:MI:SS' " +
+		"BINARY_FORMAT = HEX " +
+		"ESCAPE = NONE " +
+		"ESCAPE_UNENCLOSED_FIELD = '\\\\' " +
+		"TRIM_SPACE = FALSE " +
+		"FIELD_OPTIONALLY_ENCLOSED_BY = '\"' " +
+		"NULL_IF = ('NULL', 'null', '') " +
+		"ERROR_ON_COLUMN_COUNT_MISMATCH = TRUE " +
+		"REPLACE_INVALID_CHARACTERS = FALSE " +
+		"EMPTY_FIELD_AS_NULL = TRUE " +
+		"SKIP_BYTE_ORDER_MARK = TRUE " +
+		"ENCODING = 'UTF8'"
+	stmt := mustCreateFileFormat(t, input)
+	if stmt.Type != "CSV" {
+		t.Fatalf("Type = %q, want CSV", stmt.Type)
+	}
+	for _, k := range []string{
+		"COMPRESSION", "RECORD_DELIMITER", "FIELD_DELIMITER", "SKIP_HEADER",
+		"SKIP_BLANK_LINES", "DATE_FORMAT", "TIME_FORMAT", "BINARY_FORMAT",
+		"ESCAPE", "ESCAPE_UNENCLOSED_FIELD", "TRIM_SPACE",
+		"FIELD_OPTIONALLY_ENCLOSED_BY", "NULL_IF",
+		"ERROR_ON_COLUMN_COUNT_MISMATCH", "REPLACE_INVALID_CHARACTERS",
+		"EMPTY_FIELD_AS_NULL", "SKIP_BYTE_ORDER_MARK", "ENCODING",
+	} {
+		if findOption(stmt.Options, k) == nil {
+			t.Errorf("missing CSV option %s; options=%+v", k, stmt.Options)
+		}
+	}
+
+	// NULL_IF is a string list ( 'a', 'b', ... ), captured in List.
+	nullIf := findOption(stmt.Options, "NULL_IF")
+	if nullIf == nil || len(nullIf.List) != 3 {
+		t.Errorf("NULL_IF list = %+v, want 3 entries", nullIf)
+	}
+
+	// SKIP_HEADER is a numeric literal.
+	sh := findOption(stmt.Options, "SKIP_HEADER")
+	if sh == nil || sh.Lit == nil || sh.Lit.Kind != ast.LitInt || sh.Lit.Ival != 1 {
+		t.Errorf("SKIP_HEADER = %+v, want int 1", sh)
+	}
+
+	// COMPRESSION = GZIP is a bare word value.
+	comp := findOption(stmt.Options, "COMPRESSION")
+	if comp == nil || comp.Words != "GZIP" {
+		t.Errorf("COMPRESSION = %+v, want Words=GZIP", comp)
+	}
+}
+
+func TestParseCreateFileFormat_JSONOptions(t *testing.T) {
+	input := "CREATE FILE FORMAT f TYPE = JSON " +
+		"COMPRESSION = AUTO " +
+		"DATE_FORMAT = AUTO " +
+		"TRIM_SPACE = TRUE " +
+		"NULL_IF = ('\\\\N') " +
+		"ENABLE_OCTAL = FALSE " +
+		"ALLOW_DUPLICATE = FALSE " +
+		"STRIP_OUTER_ARRAY = TRUE " +
+		"STRIP_NULL_VALUES = FALSE " +
+		"IGNORE_UTF8_ERRORS = FALSE " +
+		"SKIP_BYTE_ORDER_MARK = TRUE"
+	stmt := mustCreateFileFormat(t, input)
+	if stmt.Type != "JSON" {
+		t.Fatalf("Type = %q, want JSON", stmt.Type)
+	}
+	for _, k := range []string{
+		"COMPRESSION", "DATE_FORMAT", "TRIM_SPACE", "NULL_IF", "ENABLE_OCTAL",
+		"ALLOW_DUPLICATE", "STRIP_OUTER_ARRAY", "STRIP_NULL_VALUES",
+		"IGNORE_UTF8_ERRORS", "SKIP_BYTE_ORDER_MARK",
+	} {
+		if findOption(stmt.Options, k) == nil {
+			t.Errorf("missing JSON option %s; options=%+v", k, stmt.Options)
+		}
+	}
+}
+
+func TestParseCreateFileFormat_AvroOrcOptions(t *testing.T) {
+	t.Run("avro", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = AVRO COMPRESSION = AUTO TRIM_SPACE = TRUE NULL_IF = ('\\\\N')")
+		if stmt.Type != "AVRO" {
+			t.Fatalf("Type = %q, want AVRO", stmt.Type)
+		}
+		for _, k := range []string{"COMPRESSION", "TRIM_SPACE", "NULL_IF"} {
+			if findOption(stmt.Options, k) == nil {
+				t.Errorf("missing AVRO option %s; options=%+v", k, stmt.Options)
+			}
+		}
+	})
+
+	t.Run("orc", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = ORC TRIM_SPACE = TRUE NULL_IF = ('\\\\N')")
+		if stmt.Type != "ORC" {
+			t.Fatalf("Type = %q, want ORC", stmt.Type)
+		}
+		for _, k := range []string{"TRIM_SPACE", "NULL_IF"} {
+			if findOption(stmt.Options, k) == nil {
+				t.Errorf("missing ORC option %s; options=%+v", k, stmt.Options)
+			}
+		}
+	})
+}
+
+func TestParseCreateFileFormat_ParquetOptions(t *testing.T) {
+	input := "CREATE FILE FORMAT f TYPE = PARQUET " +
+		"COMPRESSION = SNAPPY " +
+		"SNAPPY_COMPRESSION = TRUE " +
+		"BINARY_AS_TEXT = FALSE " +
+		"USE_VECTORIZED_SCANNER = TRUE " +
+		"USE_LOGICAL_TYPE = TRUE " +
+		"TRIM_SPACE = FALSE " +
+		"NULL_IF = ('\\\\N')"
+	stmt := mustCreateFileFormat(t, input)
+	if stmt.Type != "PARQUET" {
+		t.Fatalf("Type = %q, want PARQUET", stmt.Type)
+	}
+	for _, k := range []string{
+		"COMPRESSION", "SNAPPY_COMPRESSION", "BINARY_AS_TEXT",
+		"USE_VECTORIZED_SCANNER", "USE_LOGICAL_TYPE", "TRIM_SPACE", "NULL_IF",
+	} {
+		if findOption(stmt.Options, k) == nil {
+			t.Errorf("missing PARQUET option %s; options=%+v", k, stmt.Options)
+		}
+	}
+}
+
+func TestParseCreateFileFormat_XMLOptions(t *testing.T) {
+	input := "CREATE FILE FORMAT f TYPE = XML " +
+		"COMPRESSION = AUTO " +
+		"IGNORE_UTF8_ERRORS = FALSE " +
+		"PRESERVE_SPACE = FALSE " +
+		"STRIP_OUTER_ELEMENT = TRUE " +
+		"DISABLE_SNOWFLAKE_DATA = FALSE " +
+		"DISABLE_AUTO_CONVERT = FALSE " +
+		"SKIP_BYTE_ORDER_MARK = TRUE"
+	stmt := mustCreateFileFormat(t, input)
+	if stmt.Type != "XML" {
+		t.Fatalf("Type = %q, want XML", stmt.Type)
+	}
+	for _, k := range []string{
+		"COMPRESSION", "IGNORE_UTF8_ERRORS", "PRESERVE_SPACE",
+		"STRIP_OUTER_ELEMENT", "DISABLE_SNOWFLAKE_DATA", "DISABLE_AUTO_CONVERT",
+		"SKIP_BYTE_ORDER_MARK",
+	} {
+		if findOption(stmt.Options, k) == nil {
+			t.Errorf("missing XML option %s; options=%+v", k, stmt.Options)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — COMMENT + ordering
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_Comment(t *testing.T) {
+	t.Run("type then comment", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE OR REPLACE FILE FORMAT f TYPE = CSV COMMENT = 'my file format'")
+		if stmt.Type != "CSV" {
+			t.Errorf("Type = %q, want CSV", stmt.Type)
+		}
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "my file format" {
+			t.Errorf("COMMENT = %+v, want 'my file format'", c)
+		}
+	})
+
+	t.Run("comment without type", func(t *testing.T) {
+		// TYPE omitted; COMMENT alone follows the name.
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f COMMENT = 'no type'")
+		if stmt.Type != "" {
+			t.Errorf("Type = %q, want empty", stmt.Type)
+		}
+		if findOption(stmt.Options, "COMMENT") == nil {
+			t.Errorf("missing COMMENT; options=%+v", stmt.Options)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — docs options absent from the legacy ANTLR grammar
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_DocsNewOptions(t *testing.T) {
+	// Options present in the official docs but absent from the legacy ANTLR
+	// format_type_options rule. The open-ended option parser must accept them
+	// with no special casing. (Divergence: docs add these; antlr lacks them —
+	// docs win.)
+	t.Run("parquet use_vectorized_scanner / use_logical_type", func(t *testing.T) {
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = PARQUET USE_VECTORIZED_SCANNER = TRUE USE_LOGICAL_TYPE = TRUE")
+		if findOption(stmt.Options, "USE_VECTORIZED_SCANNER") == nil ||
+			findOption(stmt.Options, "USE_LOGICAL_TYPE") == nil {
+			t.Errorf("missing PARQUET docs options; options=%+v", stmt.Options)
+		}
+	})
+
+	t.Run("multi_line for json", func(t *testing.T) {
+		// MULTI_LINE is a newer JSON option not in the legacy grammar.
+		stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = JSON MULTI_LINE = TRUE")
+		opt := findOption(stmt.Options, "MULTI_LINE")
+		if opt == nil || opt.Words != "TRUE" {
+			t.Errorf("MULTI_LINE = %+v", opt)
+		}
+	})
+}
+
+// TestParseCreateFileFormat_BareOption documents the open-ended option parser's
+// tolerance of a value-less trailing option (Bare=true), the same contract the
+// merged COPY (bare HEADER/FORCE) and STAGE nodes follow. Snowflake would reject
+// an arity-violating option such as a value-less SKIP_HEADER, but enforcing
+// per-option arity is deliberately deferred to the catalog/semantic layer, not
+// the parser — so the parser accepts it. Asserting the behavior here keeps it
+// from being relied on silently.
+func TestParseCreateFileFormat_BareOption(t *testing.T) {
+	stmt := mustCreateFileFormat(t, "CREATE FILE FORMAT f TYPE = CSV SOMEFLAG")
+	opt := findOption(stmt.Options, "SOMEFLAG")
+	if opt == nil || !opt.Bare {
+		t.Errorf("SOMEFLAG = %+v, want a bare option", opt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — full statement
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_Full(t *testing.T) {
+	input := "CREATE OR REPLACE FILE FORMAT db.sch.my_csv " +
+		"TYPE = CSV " +
+		"FIELD_DELIMITER = '|' " +
+		"SKIP_HEADER = 1 " +
+		"NULL_IF = ('NULL', 'null') " +
+		"EMPTY_FIELD_AS_NULL = TRUE " +
+		"COMPRESSION = GZIP " +
+		"COMMENT = 'prod csv format'"
+	stmt := mustCreateFileFormat(t, input)
+	if !stmt.OrReplace {
+		t.Error("OrReplace not set")
+	}
+	if stmt.Name.String() != "db.sch.my_csv" {
+		t.Errorf("Name = %q", stmt.Name.String())
+	}
+	if stmt.Type != "CSV" {
+		t.Errorf("Type = %q, want CSV", stmt.Type)
+	}
+	for _, k := range []string{
+		"FIELD_DELIMITER", "SKIP_HEADER", "NULL_IF", "EMPTY_FIELD_AS_NULL",
+		"COMPRESSION", "COMMENT",
+	} {
+		if findOption(stmt.Options, k) == nil {
+			t.Errorf("missing option %s", k)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FILE FORMAT — two-word vs single-token FILE FORMAT
+// ---------------------------------------------------------------------------
+
+func TestParseCreateFileFormat_KeywordForms(t *testing.T) {
+	// Snowflake's lexer may emit FILE FORMAT either as one FILE_FORMAT keyword
+	// token or as two separate FILE and FORMAT tokens (the DROP path handles both
+	// — see drop.go). CREATE must accept both spellings identically.
+	want := "f"
+	for _, in := range []string{
+		"CREATE FILE FORMAT f TYPE = CSV",
+		"CREATE FILE  FORMAT f TYPE = CSV", // extra whitespace keeps two tokens
+	} {
+		t.Run(in, func(t *testing.T) {
+			stmt := mustCreateFileFormat(t, in)
+			if stmt.Name.String() != want {
+				t.Errorf("Name = %q, want %q", stmt.Name.String(), want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER FILE FORMAT
+//
+// Docs grammar (truth1):
+//
+//	ALTER FILE FORMAT [ IF EXISTS ] <name> RENAME TO <new_name>
+//	ALTER FILE FORMAT [ IF EXISTS ] <name> SET { [ formatTypeOptions ] [ COMMENT = '...' ] }
+// ---------------------------------------------------------------------------
+
+func TestParseAlterFileFormat_Rename(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterFileFormat(t, "ALTER FILE FORMAT f RENAME TO f2")
+		if stmt.Action != ast.AlterFileFormatRename {
+			t.Fatalf("Action = %v, want Rename", stmt.Action)
+		}
+		if stmt.Name.String() != "f" || stmt.NewName.String() != "f2" {
+			t.Errorf("Name=%q NewName=%q", stmt.Name.String(), stmt.NewName.String())
+		}
+	})
+
+	t.Run("if exists rename qualified", func(t *testing.T) {
+		stmt := mustAlterFileFormat(t, "ALTER FILE FORMAT IF EXISTS db.sch.f RENAME TO db.sch.f2")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+		if stmt.NewName.String() != "db.sch.f2" {
+			t.Errorf("NewName = %q", stmt.NewName.String())
+		}
+	})
+}
+
+func TestParseAlterFileFormat_Set(t *testing.T) {
+	t.Run("set format options", func(t *testing.T) {
+		// SET is unparenthesized (docs + legacy): the options follow SET directly.
+		stmt := mustAlterFileFormat(t, "ALTER FILE FORMAT f SET FIELD_DELIMITER = '|' SKIP_HEADER = 2")
+		if stmt.Action != ast.AlterFileFormatSet {
+			t.Fatalf("Action = %v, want Set", stmt.Action)
+		}
+		if findOption(stmt.Options, "FIELD_DELIMITER") == nil ||
+			findOption(stmt.Options, "SKIP_HEADER") == nil {
+			t.Errorf("missing options; options=%+v", stmt.Options)
+		}
+	})
+
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterFileFormat(t, "ALTER FILE FORMAT f SET COMMENT = 'updated'")
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "updated" {
+			t.Errorf("COMMENT = %+v", c)
+		}
+	})
+
+	t.Run("set options then comment", func(t *testing.T) {
+		stmt := mustAlterFileFormat(t, "ALTER FILE FORMAT f SET COMPRESSION = GZIP NULL_IF = ('NULL') COMMENT = 'c'")
+		for _, k := range []string{"COMPRESSION", "NULL_IF", "COMMENT"} {
+			if findOption(stmt.Options, k) == nil {
+				t.Errorf("missing %s; options=%+v", k, stmt.Options)
+			}
+		}
+	})
+
+	t.Run("if exists set", func(t *testing.T) {
+		stmt := mustAlterFileFormat(t, "ALTER FILE FORMAT IF EXISTS f SET SKIP_HEADER = 1")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+		if findOption(stmt.Options, "SKIP_HEADER") == nil {
+			t.Errorf("missing SKIP_HEADER; options=%+v", stmt.Options)
+		}
+	})
+}
+
+func TestParseAlterFileFormat_KeywordForms(t *testing.T) {
+	// Both the single FILE_FORMAT token and the two-token FILE FORMAT spelling
+	// must be accepted by ALTER, mirroring DROP and CREATE.
+	for _, in := range []string{
+		"ALTER FILE FORMAT f RENAME TO f2",
+		"ALTER FILE  FORMAT f RENAME TO f2",
+	} {
+		t.Run(in, func(t *testing.T) {
+			stmt := mustAlterFileFormat(t, in)
+			if stmt.Action != ast.AlterFileFormatRename || stmt.NewName.String() != "f2" {
+				t.Errorf("got Action=%v NewName=%q", stmt.Action, stmt.NewName.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — malformed CREATE / ALTER FILE FORMAT must be rejected
+// ---------------------------------------------------------------------------
+
+func TestParseFileFormat_Negative(t *testing.T) {
+	bad := []string{
+		"CREATE FILE FORMAT",                  // missing name
+		"CREATE FILE",                         // missing FORMAT keyword
+		"CREATE FILE FORMAT f TYPE =",         // TYPE missing value
+		"CREATE FILE FORMAT f NULL_IF = ('a'", // unterminated list
+		"CREATE FILE FORMAT IF NOT f",         // malformed IF NOT EXISTS
+		"ALTER FILE FORMAT",                   // missing name
+		"ALTER FILE FORMAT f",                 // missing action
+		"ALTER FILE FORMAT f RENAME",          // missing TO
+		"ALTER FILE FORMAT f RENAME TO",       // missing new name
+		"ALTER FILE FORMAT f SET",             // nothing to set
+		"ALTER FILE FORMAT f FROBNICATE",      // unknown action
+		"ALTER FILE FORMAT f UNSET COMMENT",   // UNSET unsupported for file format
+	}
+	for _, in := range bad {
+		t.Run(in, func(t *testing.T) {
+			result := ParseBestEffort(in)
+			if len(result.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got none (stmts=%d)", in, len(result.File.Stmts))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc accuracy
+// ---------------------------------------------------------------------------
+
+func TestParseFileFormat_Loc(t *testing.T) {
+	input := "CREATE FILE FORMAT my_format TYPE = CSV"
+	stmt := mustCreateFileFormat(t, input)
+	if stmt.Loc.Start != 0 || stmt.Loc.End != len(input) {
+		t.Errorf("CREATE Loc = %+v, want {0, %d}", stmt.Loc, len(input))
+	}
+	// The TYPE value Loc points at the "CSV" word.
+	if got := input[stmt.TypeLoc.Start:stmt.TypeLoc.End]; got != "CSV" {
+		t.Errorf("TypeLoc spans %q, want CSV", got)
+	}
+
+	// ALTER sub-parsers set Loc.Start at the object-type keyword (FILE), not the
+	// ALTER keyword, matching the established ALTER STAGE/TABLE convention.
+	ainput := "ALTER FILE FORMAT f RENAME TO f2"
+	const fileKwOff = len("ALTER ")
+	astmt := mustAlterFileFormat(t, ainput)
+	if astmt.Loc.Start != fileKwOff || astmt.Loc.End != len(ainput) {
+		t.Errorf("ALTER Loc = %+v, want {%d, %d}", astmt.Loc, fileKwOff, len(ainput))
+	}
+
+	// Second statement in a multi-statement input gets a non-zero base offset; the
+	// option literal must still be correct (exercises base handling).
+	multi := "SELECT 1;\nCREATE FILE FORMAT f TYPE = CSV COMMENT = 'x'"
+	res := ParseBestEffort(multi)
+	if len(res.Errors) != 0 {
+		t.Fatalf("multi parse errors: %v", res.Errors)
+	}
+	cf, ok := res.File.Stmts[1].(*ast.CreateFileFormatStmt)
+	if !ok {
+		t.Fatalf("stmt[1] = %T", res.File.Stmts[1])
+	}
+	if findOption(cf.Options, "COMMENT").Lit.Value != "x" {
+		t.Errorf("COMMENT value wrong in multi-statement input")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official docs corpus — every CREATE FILE FORMAT statement in the
+// create-file-format corpus must parse with zero errors. The official docs are
+// the authoritative oracle (truth1).
+//
+// example_02.sql uses `CREATE OR ALTER FILE FORMAT`, a preview feature. The
+// shared parseCreateStmt OR-prefix parser currently recognizes only OR REPLACE,
+// not OR ALTER (a cross-cutting gap affecting create-table, create-dynamic-table,
+// create-tag, ... corpora alike, owned by parser.go / parseCreateStmt — out of
+// this node's writes-scope). Such statements are skipped here and tracked as a
+// flagged divergence; when OR ALTER lands they will parse unchanged.
+// ---------------------------------------------------------------------------
+
+func TestFileFormat_OfficialCorpus(t *testing.T) {
+	const dir = "testdata/official/create-file-format"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read corpus dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			assertFileFormatStatementsParse(t, string(data))
+		})
+	}
+}
+
+// orAlterLimited reports whether a CREATE statement uses the OR ALTER preview
+// form, which the shared parseCreateStmt prefix parser does not yet recognize.
+func orAlterLimited(upper string) bool {
+	return strings.Contains(upper, "CREATE OR ALTER")
+}
+
+// assertFileFormatStatementsParse parses sql and asserts that every CREATE /
+// ALTER FILE FORMAT statement parses with no errors and to the expected AST
+// type. OR ALTER preview statements are skipped (see orAlterLimited).
+func assertFileFormatStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+		var want func(ast.Node) bool
+		switch {
+		case strings.HasPrefix(upper, "CREATE"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.CreateFileFormatStmt); return ok }
+		case strings.HasPrefix(upper, "ALTER"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.AlterFileFormatStmt); return ok }
+		default:
+			continue // context statement owned by another DAG node
+		}
+		if orAlterLimited(upper) {
+			// Known dependency limitation: must currently fail to parse. If it
+			// starts parsing, the OR ALTER gap was closed — surface that so the
+			// filter can be removed.
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: OR ALTER statement now parses, drop it from orAlterLimited: %q", text)
+			}
+			continue
+		}
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+			continue
+		}
+		if !want(node) {
+			t.Errorf("statement %q parsed to unexpected type %T", text, node)
+		}
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-file-format` (v1 DAG **T4.2**) — `CREATE` / `ALTER FILE FORMAT`. `DROP FILE FORMAT` was already merged, untouched.

## Forms
- `CREATE [OR REPLACE] [{TEMP|TEMPORARY|VOLATILE}] FILE FORMAT [IF NOT EXISTS] <name> [TYPE = {CSV|JSON|AVRO|ORC|PARQUET|XML}] [formatTypeOptions] [COMMENT = '<s>']`
- `ALTER FILE FORMAT [IF EXISTS] <name> RENAME TO <new_name>`
- `ALTER FILE FORMAT [IF EXISTS] <name> SET { [formatTypeOptions] [COMMENT = '<s>'] }`

## Design
Mirrors the merged STAGE (T4.1) / COPY (T5.2) machinery: `TYPE = <fmt>` is the one structural anchor (dedicated `Type` field, bare or quoted); the large, type-dependent, version-growing `formatTypeOptions` + `COMMENT` are open-ended `KEY = <value>` pairs (`ast.CopyOption`), deferring option validity to the catalog/semantic layer. `FILE FORMAT` accepted in both single-token and two-token (`FILE`+`FORMAT`) lexings, mirroring DROP. New AST `CreateFileFormatStmt`/`AlterFileFormatStmt`; walker regenerated via `genwalker`; dispatch added to `parseCreateStmt`/`parseAlterStmt`.

## Oracle / tests
Triangulation — official docs (authoritative) + legacy ANTLR `create_file_format`/`alter_file_format`/`format_type_options`. The official `create-file-format` corpus is wired in. `go test ./snowflake/parser/... ./snowflake/ast/...` green; `go vet`/`gofmt` clean. 100% form parity (all 6 TYPEs + option sets + ALTER actions + 12 negatives).

## Divergences (flagged — docs win over stale `.g4`)
1. `TEMP|TEMPORARY|VOLATILE` modifiers — docs add, `.g4` lacks.
2. **`CREATE OR ALTER` preview form** — in docs/corpus, `.g4` lacks. **Cross-cutting**: the shared `parseCreateStmt` OR-prefix parser (in `parser.go`, out of this node's scope) only knows `OR REPLACE`, so `CREATE OR ALTER` is currently unparsable across create-table/dynamic-table/tag/file-format. Corpus `example_02` skipped; will parse once a shared `OR ALTER` change lands (good follow-up node).
3. Newer `formatTypeOptions` (`USE_VECTORIZED_SCANNER`, `USE_LOGICAL_TYPE`, `MULTI_LINE`, per-type `COMPRESSION`) accepted open-ended.

## Review
Claude lens (`/code-review` high) — 0 blockers. Codex lens unavailable (out of credits); orchestrator did independent build/test/scope + dispatch-diff verification.

## Note
Opened by orchestrator from worker's verified commit `6db9135d`. No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)