### PR TITLE
feat(trino/parser): SHOW / session / EXPLAIN / CALL utility statements (v2 node trino/parser-utility)

### DIFF
--- a/trino/ast/nodetags.go
+++ b/trino/ast/nodetags.go
@@ -26,6 +26,59 @@ const (
 	// T_QualifiedName is the tag for *QualifiedName, a dot-separated chain
 	// of identifiers (e.g., catalog.schema.table).
 	T_QualifiedName
+
+	// --- statement nodes (parser-utility DAG node) ---
+	//
+	// These tags are returned by statement structs that live in package
+	// parser, not here: a statement embeds parser-local Expr / DataType
+	// children (which the ast package cannot import without a cycle), so the
+	// structs stay in parser and satisfy ast.Node by returning the tag
+	// constant declared below. Mirrors how expr.go / datatypes.go keep their
+	// node types in package parser; only the closed tag set lives here.
+
+	// T_ShowStmt is the tag for the SHOW family and DESCRIBE / DESC
+	// (parser.ShowStmt): SHOW {TABLES|SCHEMAS|CATALOGS|COLUMNS|FUNCTIONS|
+	// SESSION|STATS|GRANTS|ROLES|ROLE GRANTS|CREATE …} and DESCRIBE/DESC name.
+	T_ShowStmt
+
+	// T_UseStmt is the tag for parser.UseStmt: USE [catalog.]schema.
+	T_UseStmt
+
+	// T_SetSessionStmt is the tag for parser.SetSessionStmt:
+	// SET SESSION name = expression.
+	T_SetSessionStmt
+
+	// T_ResetSessionStmt is the tag for parser.ResetSessionStmt:
+	// RESET SESSION name.
+	T_ResetSessionStmt
+
+	// T_SetSessionAuthorizationStmt is the tag for
+	// parser.SetSessionAuthorizationStmt: SET SESSION AUTHORIZATION user.
+	T_SetSessionAuthorizationStmt
+
+	// T_ResetSessionAuthorizationStmt is the tag for
+	// parser.ResetSessionAuthorizationStmt: RESET SESSION AUTHORIZATION.
+	T_ResetSessionAuthorizationStmt
+
+	// T_SetRoleStmt is the tag for parser.SetRoleStmt:
+	// SET ROLE (role | ALL | NONE) [IN catalog].
+	T_SetRoleStmt
+
+	// T_SetPathStmt is the tag for parser.SetPathStmt:
+	// SET PATH pathElement (, pathElement)*.
+	T_SetPathStmt
+
+	// T_SetTimeZoneStmt is the tag for parser.SetTimeZoneStmt:
+	// SET TIME ZONE (LOCAL | expression).
+	T_SetTimeZoneStmt
+
+	// T_ExplainStmt is the tag for parser.ExplainStmt:
+	// EXPLAIN [ (option, …) ] statement and EXPLAIN ANALYZE [VERBOSE] statement.
+	T_ExplainStmt
+
+	// T_CallStmt is the tag for parser.CallStmt:
+	// CALL name ( [name =>] expression, … ).
+	T_CallStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -39,6 +92,28 @@ func (t NodeTag) String() string {
 		return "Identifier"
 	case T_QualifiedName:
 		return "QualifiedName"
+	case T_ShowStmt:
+		return "ShowStmt"
+	case T_UseStmt:
+		return "UseStmt"
+	case T_SetSessionStmt:
+		return "SetSessionStmt"
+	case T_ResetSessionStmt:
+		return "ResetSessionStmt"
+	case T_SetSessionAuthorizationStmt:
+		return "SetSessionAuthorizationStmt"
+	case T_ResetSessionAuthorizationStmt:
+		return "ResetSessionAuthorizationStmt"
+	case T_SetRoleStmt:
+		return "SetRoleStmt"
+	case T_SetPathStmt:
+		return "SetPathStmt"
+	case T_SetTimeZoneStmt:
+		return "SetTimeZoneStmt"
+	case T_ExplainStmt:
+		return "ExplainStmt"
+	case T_CallStmt:
+		return "CallStmt"
 	default:
 		return "Unknown"
 	}

--- a/trino/parser/explain_call.go
+++ b/trino/parser/explain_call.go
@@ -1,0 +1,300 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the `parser-utility` DAG node (with show.go and
+// session.go): it implements Trino's EXPLAIN / EXPLAIN ANALYZE and CALL
+// statements — the legacy TrinoParser.g4 `statement` alternatives labelled
+// explain, explainAnalyze, and call.
+//
+// As in show.go / session.go, the statement nodes are PARSER-PACKAGE types
+// satisfying ast.Node via tags declared in trino/ast/nodetags.go.
+//
+// The legacy alternatives implemented here:
+//
+//	EXPLAIN (LPAREN explainOption (, explainOption)* RPAREN)? statement  # explain
+//	EXPLAIN ANALYZE VERBOSE? statement                                   # explainAnalyze
+//	CALL qualifiedName LPAREN (callArgument (, callArgument)*)? RPAREN    # call
+//
+//	explainOption : FORMAT (TEXT|GRAPHVIZ|JSON) | TYPE (LOGICAL|DISTRIBUTED|VALIDATE|IO) ;
+//	callArgument  : expression | identifier RDOUBLEARROW expression ;
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed facts baked
+// in:
+//
+//	E1 (EXPLAIN wraps the full statement grammar). EXPLAIN / EXPLAIN ANALYZE may
+//	   prefix ANY statement (SELECT, INSERT, CREATE TABLE AS, even SHOW TABLES);
+//	   all are oracle-ACCEPTED. The inner statement is parsed by recursing into
+//	   the top-level dispatch (parseStmt), so EXPLAIN gains every statement form
+//	   automatically as the other DAG nodes land. A stubbed inner statement
+//	   (e.g. SELECT before parser-select merges) surfaces the inner node's
+//	   "not yet supported" error, which is correct foundation behaviour.
+//	E2 (explainOption values are a closed enum). `EXPLAIN (TYPE FOO) …` and
+//	   `EXPLAIN (FORMAT BAR) …` are SYNTAX_ERRORs; the FORMAT/TYPE values are the
+//	   fixed keyword sets below, not arbitrary identifiers. An empty option list
+//	   `EXPLAIN () …` is also rejected (at least one option required inside the
+//	   parens).
+//	E3 (CALL name is at most 3 parts). `CALL c.s.p()` is accepted but
+//	   `CALL c.s.p.x()` is a SYNTAX_ERROR — a procedure name is
+//	   [catalog.[schema.]]procedure. parseCallStmt enforces the ≤3-part limit.
+//	   The parens are mandatory (`CALL f` rejects); arguments may be empty,
+//	   positional, named (`name => expr`), or mixed in any order (Trino 481
+//	   accepts `CALL f(name => 1, 2)`).
+
+// ---------------------------------------------------------------------------
+// EXPLAIN
+// ---------------------------------------------------------------------------
+
+// ExplainFormat is the FORMAT value of an EXPLAIN option.
+type ExplainFormat int
+
+const (
+	// ExplainFormatUnset means no FORMAT option was given.
+	ExplainFormatUnset ExplainFormat = iota
+	// ExplainFormatText is FORMAT TEXT.
+	ExplainFormatText
+	// ExplainFormatGraphviz is FORMAT GRAPHVIZ.
+	ExplainFormatGraphviz
+	// ExplainFormatJSON is FORMAT JSON.
+	ExplainFormatJSON
+)
+
+// ExplainType is the TYPE value of an EXPLAIN option.
+type ExplainType int
+
+const (
+	// ExplainTypeUnset means no TYPE option was given.
+	ExplainTypeUnset ExplainType = iota
+	// ExplainTypeLogical is TYPE LOGICAL.
+	ExplainTypeLogical
+	// ExplainTypeDistributed is TYPE DISTRIBUTED.
+	ExplainTypeDistributed
+	// ExplainTypeValidate is TYPE VALIDATE.
+	ExplainTypeValidate
+	// ExplainTypeIO is TYPE IO.
+	ExplainTypeIO
+)
+
+// ExplainStmt is EXPLAIN [ (option, …) ] statement or
+// EXPLAIN ANALYZE [VERBOSE] statement. Analyze and the option fields are
+// mutually exclusive in valid Trino (ANALYZE has no parenthesised options), but
+// the node represents whichever the source used.
+type ExplainStmt struct {
+	// Analyze is true for EXPLAIN ANALYZE.
+	Analyze bool
+	// Verbose is true for EXPLAIN ANALYZE VERBOSE.
+	Verbose bool
+	// Format / Type are the parenthesised options (non-analyze form); Unset
+	// when the corresponding option was absent.
+	Format ExplainFormat
+	Type   ExplainType
+	// Statement is the explained inner statement, parsed by recursing into the
+	// top-level dispatch. Nil only if the inner statement failed to parse.
+	Statement ast.Node
+	Loc       ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *ExplainStmt) Tag() ast.NodeTag { return ast.T_ExplainStmt }
+
+// Span returns the source byte range.
+func (s *ExplainStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*ExplainStmt)(nil)
+
+// parseExplainStmt parses EXPLAIN / EXPLAIN ANALYZE. EXPLAIN is the current
+// token.
+func (p *Parser) parseExplainStmt() (ast.Node, error) {
+	explainTok := p.advance() // consume EXPLAIN
+	s := &ExplainStmt{Loc: ast.Loc{Start: explainTok.Loc.Start, End: explainTok.Loc.End}}
+
+	if _, ok := p.match(kwANALYZE); ok {
+		s.Analyze = true
+		if _, ok := p.match(kwVERBOSE); ok {
+			s.Verbose = true
+		}
+	} else if p.cur.Kind == int('(') {
+		// EXPLAIN ( option (, option)* ) — at least one option required.
+		if err := p.parseExplainOptions(s); err != nil {
+			return nil, err
+		}
+	}
+
+	stmt, err := p.parseStmt()
+	// Even when the inner statement errors — most importantly when it is a
+	// still-stubbed "not yet supported" form (SELECT/INSERT/CREATE before
+	// parser-select / dml / ddl land) — return the ExplainStmt node alongside
+	// the error. parseSingle records the error AND keeps the node, so Diagnose
+	// reports the inner gap while downstream consumers still see an EXPLAIN node
+	// (and the result is classifiable as pending-inner rather than a hard
+	// rejection of EXPLAIN's own grammar). Once the inner node lands the error
+	// disappears and the same EXPLAIN parse becomes clean.
+	s.Statement = stmt
+	if sp, ok := stmt.(interface{ Span() ast.Loc }); ok && stmt != nil {
+		s.Loc.End = sp.Span().End
+	} else if end := p.prev.Loc.End; end > s.Loc.End {
+		// Inner statement produced no measurable node (e.g. a still-stubbed form
+		// whose unsupported() helper consumed to the segment boundary). Extend
+		// the EXPLAIN span to the last token the inner parser consumed so the
+		// node still covers the explained statement text rather than ending at
+		// the EXPLAIN keyword.
+		s.Loc.End = end
+	}
+	return s, err
+}
+
+// parseExplainOptions parses `( explainOption (, explainOption)* )` into s. The
+// opening '(' is the current token. At least one option is required (an empty
+// list is a syntax error, matching Trino 481).
+func (p *Parser) parseExplainOptions(s *ExplainStmt) error {
+	p.advance() // consume '('
+	if err := p.parseExplainOption(s); err != nil {
+		return err
+	}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		if err := p.parseExplainOption(s); err != nil {
+			return err
+		}
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseExplainOption parses one `FORMAT (TEXT|GRAPHVIZ|JSON)` or
+// `TYPE (LOGICAL|DISTRIBUTED|VALIDATE|IO)` option into s. The value keyword set
+// is closed (E2).
+func (p *Parser) parseExplainOption(s *ExplainStmt) error {
+	switch p.cur.Kind {
+	case kwFORMAT:
+		p.advance() // consume FORMAT
+		switch p.cur.Kind {
+		case kwTEXT:
+			s.Format = ExplainFormatText
+		case kwGRAPHVIZ:
+			s.Format = ExplainFormatGraphviz
+		case kwJSON:
+			s.Format = ExplainFormatJSON
+		default:
+			return p.syntaxErrorAtCur()
+		}
+		p.advance() // consume the value keyword
+		return nil
+	case kwTYPE:
+		p.advance() // consume TYPE
+		switch p.cur.Kind {
+		case kwLOGICAL:
+			s.Type = ExplainTypeLogical
+		case kwDISTRIBUTED:
+			s.Type = ExplainTypeDistributed
+		case kwVALIDATE:
+			s.Type = ExplainTypeValidate
+		case kwIO:
+			s.Type = ExplainTypeIO
+		default:
+			return p.syntaxErrorAtCur()
+		}
+		p.advance() // consume the value keyword
+		return nil
+	default:
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CALL
+// ---------------------------------------------------------------------------
+
+// CallArgument is one argument of a CALL: positional (`expression`) or named
+// (`name => expression`). Name is nil for the positional form.
+type CallArgument struct {
+	Name  *ast.Identifier
+	Value Expr
+	Loc   ast.Loc
+}
+
+// CallStmt is CALL name ( [name =>] expression, … ). Name has 1-3 parts
+// ([catalog.[schema.]]procedure).
+type CallStmt struct {
+	Name      *ast.QualifiedName
+	Arguments []CallArgument
+	Loc       ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *CallStmt) Tag() ast.NodeTag { return ast.T_CallStmt }
+
+// Span returns the source byte range.
+func (s *CallStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*CallStmt)(nil)
+
+// parseCallStmt parses CALL qualifiedName ( (callArgument (, callArgument)*)? ).
+// CALL is the current token.
+func (p *Parser) parseCallStmt() (ast.Node, error) {
+	callTok := p.advance() // consume CALL
+	// E3: a procedure name is at most catalog.schema.procedure (3 parts);
+	// `CALL c.s.p.x()` is a SYNTAX_ERROR in Trino 481. parseBoundedQualifiedName
+	// (show.go) enforces the limit, matching the other name positions.
+	name, err := p.parseBoundedQualifiedName(3, "procedure name")
+	if err != nil {
+		return nil, err
+	}
+	s := &CallStmt{Name: name, Loc: ast.Loc{Start: callTok.Loc.Start, End: name.Loc.End}}
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int(')') {
+		first, err := p.parseCallArgument()
+		if err != nil {
+			return nil, err
+		}
+		s.Arguments = append(s.Arguments, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseCallArgument()
+			if err != nil {
+				return nil, err
+			}
+			s.Arguments = append(s.Arguments, next)
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	s.Loc.End = closeTok.Loc.End
+	return s, nil
+}
+
+// parseCallArgument parses one callArgument: a named `identifier => expression`
+// or a positional `expression`. The named form is detected by an identifier
+// followed by the => (tokDoubleArrow) token; otherwise the whole thing is a
+// positional expression (which may itself begin with an identifier, e.g. a
+// column or function call).
+func (p *Parser) parseCallArgument() (CallArgument, error) {
+	if isIdentifierStart(p.cur.Kind) && p.peekNext().Kind == tokDoubleArrow {
+		nameTok := p.advance() // consume the name
+		name := identFromToken(nameTok)
+		p.advance() // consume =>
+		value, err := p.parseExpr()
+		if err != nil {
+			return CallArgument{}, err
+		}
+		return CallArgument{
+			Name:  name,
+			Value: value,
+			Loc:   ast.Loc{Start: name.Loc.Start, End: value.Span().End},
+		}, nil
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return CallArgument{}, err
+	}
+	return CallArgument{Value: value, Loc: value.Span()}, nil
+}

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -212,7 +212,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// --- Session / catalog context ---
 	case kwUSE:
-		return p.unsupported("USE")
+		return p.parseUseStmt()
 
 	// --- DDL ---
 	case kwCREATE:
@@ -242,7 +242,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// --- Procedures ---
 	case kwCALL:
-		return p.unsupported("CALL")
+		return p.parseCallStmt()
 
 	// --- DCL (roles / privileges) ---
 	case kwGRANT:
@@ -254,19 +254,25 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// --- Session / path / time zone ---
 	case kwSET:
-		return p.unsupported("SET")
+		// SET fans out on the second keyword: SESSION (setSession /
+		// setSessionAuthorization), ROLE (setRole), PATH (setPath), TIME
+		// (setTimeZone). See session.go.
+		return p.parseSetStmt()
 	case kwRESET:
-		return p.unsupported("RESET")
+		// RESET SESSION { AUTHORIZATION | name }. See session.go.
+		return p.parseResetStmt()
 
 	// --- Inspection ---
 	case kwSHOW:
-		return p.unsupported("SHOW")
+		// SHOW family + DESCRIBE/DESC aliases. See show.go.
+		return p.parseShowStmt()
 	case kwEXPLAIN:
-		return p.unsupported("EXPLAIN")
-	case kwDESCRIBE:
-		return p.unsupported("DESCRIBE")
-	case kwDESC:
-		return p.unsupported("DESC")
+		// EXPLAIN / EXPLAIN ANALYZE. See explain_call.go.
+		return p.parseExplainStmt()
+	case kwDESCRIBE, kwDESC:
+		// DESCRIBE/DESC name == SHOW COLUMNS; DESCRIBE INPUT/OUTPUT route to the
+		// prepared-statement node (parser-dcl-tcl). See show.go.
+		return p.parseDescribeStmt()
 
 	// --- Transactions ---
 	case kwSTART:
@@ -358,6 +364,16 @@ func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
 					Msg: err.Error(),
 				})
 			}
+		} else if p.cur.Kind != tokEOF {
+			// A statement parsed without error but did not consume the whole
+			// segment: tokens remain after a complete statement. Because Split
+			// already cut the input on statement boundaries (';'), leftover
+			// tokens here mean the statement grammar rejected the tail — e.g.
+			// `SHOW SCHEMAS FROM c.x` (the scope is a single identifier, so `.x`
+			// is extra) or `DESC INPUT a` (DESCRIBE-table takes one name, so `a`
+			// is extra). Trino reports these as SYNTAX_ERRORs, so the parser must
+			// too. Reported as trailing-token rather than swallowed.
+			p.errors = append(p.errors, *p.syntaxErrorAtCur())
 		}
 		result = node
 	}

--- a/trino/parser/parser_test.go
+++ b/trino/parser/parser_test.go
@@ -114,7 +114,15 @@ func TestParse_DispatchKeywordsRecognized(t *testing.T) {
 	}
 	for _, p := range prefixes {
 		// Use a minimal-but-plausible tail so the leading token is the keyword.
+		// EXPLAIN is special: it is now a real parser (parser-utility node) that
+		// recurses into the inner statement, so `EXPLAIN x` would route the inner
+		// bare `x` to the default branch (correctly — Trino also rejects
+		// `EXPLAIN x`). Probe it with an inner keyword that is itself dispatched
+		// so the assertion checks EXPLAIN's own dispatch, not the inner token.
 		sql := p + " x"
+		if p == "EXPLAIN" {
+			sql = "EXPLAIN SELECT 1"
+		}
 		_, errs := Parse(sql)
 		for _, e := range errs {
 			if strings.Contains(e.Msg, "unknown or unsupported statement") {

--- a/trino/parser/session.go
+++ b/trino/parser/session.go
@@ -1,0 +1,436 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the `parser-utility` DAG node (with show.go and
+// explain_call.go): it implements Trino's session / catalog-context statements —
+// the legacy TrinoParser.g4 `statement` alternatives labelled use, setSession,
+// resetSession, setSessionAuthorization, resetSessionAuthorization, setRole,
+// setPath, and setTimeZone.
+//
+// As in show.go, the statement nodes are PARSER-PACKAGE types satisfying
+// ast.Node via tags declared in trino/ast/nodetags.go.
+//
+// The legacy alternatives implemented here:
+//
+//	USE schema                                # use
+//	USE catalog.schema                        # use
+//	SET SESSION qualifiedName EQ expression   # setSession
+//	RESET SESSION qualifiedName               # resetSession
+//	SET SESSION AUTHORIZATION authorizationUser   # setSessionAuthorization
+//	RESET SESSION AUTHORIZATION               # resetSessionAuthorization
+//	SET ROLE (ALL | NONE | identifier) (IN catalog)?  # setRole
+//	SET PATH pathSpecification                # setPath
+//	SET TIME ZONE (LOCAL | expression)        # setTimeZone
+//
+//	authorizationUser : identifier | string_ ;
+//	pathSpecification : pathElement (COMMA pathElement)* ;
+//	pathElement       : identifier DOT identifier | identifier ;
+//
+// Adjudicated against the live Trino 481 oracle. The `SET` leading keyword
+// fans out on the second keyword (SESSION / ROLE / PATH / TIME), and `SET
+// SESSION` further splits on AUTHORIZATION vs a property name; `RESET SESSION`
+// splits on AUTHORIZATION vs a property name. All of these forms are this
+// node's: SET ROLE is the session-role activation (not a DCL grant — that is
+// the parser-dcl-tcl node's grant_revoke.go), and SET PATH / SET TIME ZONE have
+// no other home.
+
+// ---------------------------------------------------------------------------
+// USE
+// ---------------------------------------------------------------------------
+
+// UseStmt is USE [catalog.]schema. Catalog is nil for the schema-only form.
+type UseStmt struct {
+	// Catalog is the catalog identifier in `USE catalog.schema`; nil for the
+	// `USE schema` form.
+	Catalog *ast.Identifier
+	// Schema is the schema identifier (always present).
+	Schema *ast.Identifier
+	Loc    ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *UseStmt) Tag() ast.NodeTag { return ast.T_UseStmt }
+
+// Span returns the source byte range.
+func (s *UseStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*UseStmt)(nil)
+
+// parseUseStmt parses USE schema | USE catalog.schema. USE is the current token.
+func (p *Parser) parseUseStmt() (ast.Node, error) {
+	useTok := p.advance() // consume USE
+	first, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	s := &UseStmt{Schema: first, Loc: ast.Loc{Start: useTok.Loc.Start, End: first.Loc.End}}
+	if _, ok := p.match(int('.')); ok {
+		schema, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		s.Catalog = first
+		s.Schema = schema
+		s.Loc.End = schema.Loc.End
+	}
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// SET dispatch
+// ---------------------------------------------------------------------------
+
+// parseSetStmt parses a statement whose leading keyword is SET, dispatching on
+// the second keyword: SESSION (setSession / setSessionAuthorization), ROLE
+// (setRole), PATH (setPath), TIME (setTimeZone). SET is the current token.
+func (p *Parser) parseSetStmt() (ast.Node, error) {
+	setTok := p.advance() // consume SET
+	start := setTok.Loc.Start
+	switch p.cur.Kind {
+	case kwSESSION:
+		return p.parseSetSession(start)
+	case kwROLE:
+		return p.parseSetRole(start)
+	case kwPATH:
+		return p.parseSetPath(start)
+	case kwTIME:
+		return p.parseSetTimeZone(start)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SET / RESET SESSION
+// ---------------------------------------------------------------------------
+
+// SetSessionStmt is SET SESSION name = expression. Name is a qualifiedName
+// (system property `name` or catalog property `catalog.name`).
+type SetSessionStmt struct {
+	Name  *ast.QualifiedName
+	Value Expr
+	Loc   ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *SetSessionStmt) Tag() ast.NodeTag { return ast.T_SetSessionStmt }
+
+// Span returns the source byte range.
+func (s *SetSessionStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*SetSessionStmt)(nil)
+
+// ResetSessionStmt is RESET SESSION name.
+type ResetSessionStmt struct {
+	Name *ast.QualifiedName
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *ResetSessionStmt) Tag() ast.NodeTag { return ast.T_ResetSessionStmt }
+
+// Span returns the source byte range.
+func (s *ResetSessionStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*ResetSessionStmt)(nil)
+
+// SetSessionAuthorizationStmt is SET SESSION AUTHORIZATION user, where user is
+// an identifier or a string literal (authorizationUser).
+type SetSessionAuthorizationStmt struct {
+	// User is the identifier form (`SET SESSION AUTHORIZATION alice`); nil when
+	// the string form was used.
+	User *ast.Identifier
+	// UserString is the string-literal form (`SET SESSION AUTHORIZATION 'alice'`)
+	// decoded value; HasUserString marks its presence.
+	UserString    string
+	HasUserString bool
+	Loc           ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *SetSessionAuthorizationStmt) Tag() ast.NodeTag { return ast.T_SetSessionAuthorizationStmt }
+
+// Span returns the source byte range.
+func (s *SetSessionAuthorizationStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*SetSessionAuthorizationStmt)(nil)
+
+// ResetSessionAuthorizationStmt is RESET SESSION AUTHORIZATION.
+type ResetSessionAuthorizationStmt struct {
+	Loc ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *ResetSessionAuthorizationStmt) Tag() ast.NodeTag {
+	return ast.T_ResetSessionAuthorizationStmt
+}
+
+// Span returns the source byte range.
+func (s *ResetSessionAuthorizationStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*ResetSessionAuthorizationStmt)(nil)
+
+// parseSetSession parses SET SESSION { AUTHORIZATION user | name = expression }.
+// SESSION is the current token; start is the SET keyword's start offset.
+//
+// AUTHORIZATION is a non-reserved keyword, so it can ALSO be the first part of a
+// session-property name. Trino 481 accepts `SET SESSION AUTHORIZATION = 1` and
+// `SET SESSION AUTHORIZATION.foo = 1` as property assignments (the property is
+// named `authorization` / `authorization.foo`). So the AUTHORIZATION-user form
+// fires only when AUTHORIZATION is NOT immediately followed by '.' or '=' — i.e.
+// when it is genuinely the SET SESSION AUTHORIZATION keyword rather than a
+// property name. Otherwise we fall through to the qualifiedName property path.
+func (p *Parser) parseSetSession(start int) (ast.Node, error) {
+	p.advance() // consume SESSION
+	if p.cur.Kind == kwAUTHORIZATION && p.peekNext().Kind != int('.') && p.peekNext().Kind != int('=') {
+		p.advance() // consume AUTHORIZATION
+		return p.parseSetSessionAuthorization(start)
+	}
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return nil, err
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &SetSessionStmt{
+		Name:  name,
+		Value: value,
+		Loc:   ast.Loc{Start: start, End: value.Span().End},
+	}, nil
+}
+
+// parseSetSessionAuthorization parses the tail of SET SESSION AUTHORIZATION:
+// an identifier or a string literal. AUTHORIZATION has been consumed.
+func (p *Parser) parseSetSessionAuthorization(start int) (ast.Node, error) {
+	if p.cur.Kind == tokString || p.cur.Kind == tokUnicodeString {
+		strTok := p.advance()
+		return &SetSessionAuthorizationStmt{
+			UserString:    strTok.Str,
+			HasUserString: true,
+			Loc:           ast.Loc{Start: start, End: strTok.Loc.End},
+		}, nil
+	}
+	ident, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &SetSessionAuthorizationStmt{
+		User: ident,
+		Loc:  ast.Loc{Start: start, End: ident.Loc.End},
+	}, nil
+}
+
+// parseResetStmt parses RESET SESSION { AUTHORIZATION | name }. RESET is the
+// current token.
+func (p *Parser) parseResetStmt() (ast.Node, error) {
+	resetTok := p.advance() // consume RESET
+	start := resetTok.Loc.Start
+	if _, err := p.expect(kwSESSION); err != nil {
+		return nil, err
+	}
+	// As in parseSetSession, AUTHORIZATION is the RESET SESSION AUTHORIZATION
+	// keyword only when not followed by '.' (a dotted property name like
+	// `authorization.foo`); Trino 481 accepts `RESET SESSION AUTHORIZATION.foo`
+	// as a property reset. (RESET takes no '=', so only '.' disambiguates.)
+	if p.cur.Kind == kwAUTHORIZATION && p.peekNext().Kind != int('.') {
+		authTok := p.advance() // consume AUTHORIZATION
+		return &ResetSessionAuthorizationStmt{
+			Loc: ast.Loc{Start: start, End: authTok.Loc.End},
+		}, nil
+	}
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	return &ResetSessionStmt{
+		Name: name,
+		Loc:  ast.Loc{Start: start, End: name.Loc.End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// SET ROLE
+// ---------------------------------------------------------------------------
+
+// RoleSpec classifies the role argument of SET ROLE.
+type RoleSpec int
+
+const (
+	// RoleNamed is SET ROLE <identifier>.
+	RoleNamed RoleSpec = iota
+	// RoleAll is SET ROLE ALL.
+	RoleAll
+	// RoleNone is SET ROLE NONE.
+	RoleNone
+)
+
+// SetRoleStmt is SET ROLE (role | ALL | NONE) [IN catalog].
+type SetRoleStmt struct {
+	Spec RoleSpec
+	// Role is the role identifier when Spec == RoleNamed; nil otherwise.
+	Role *ast.Identifier
+	// Catalog is the `IN catalog` scope identifier; nil when absent.
+	Catalog *ast.Identifier
+	Loc     ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *SetRoleStmt) Tag() ast.NodeTag { return ast.T_SetRoleStmt }
+
+// Span returns the source byte range.
+func (s *SetRoleStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*SetRoleStmt)(nil)
+
+// parseSetRole parses the tail of SET ROLE: (ALL | NONE | identifier)
+// (IN catalog)?. ROLE is the current token; start is the SET start offset.
+func (p *Parser) parseSetRole(start int) (ast.Node, error) {
+	roleTok := p.advance() // consume ROLE
+	s := &SetRoleStmt{Loc: ast.Loc{Start: start, End: roleTok.Loc.End}}
+	switch p.cur.Kind {
+	case kwALL:
+		end := p.advance()
+		s.Spec = RoleAll
+		s.Loc.End = end.Loc.End
+	case kwNONE:
+		end := p.advance()
+		s.Spec = RoleNone
+		s.Loc.End = end.Loc.End
+	default:
+		ident, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		s.Spec = RoleNamed
+		s.Role = ident
+		s.Loc.End = ident.Loc.End
+	}
+	if _, ok := p.match(kwIN); ok {
+		catalog, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		s.Catalog = catalog
+		s.Loc.End = catalog.Loc.End
+	}
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// SET PATH
+// ---------------------------------------------------------------------------
+
+// PathElement is one element of a SET PATH specification: a bare schema
+// (`schema`) or a qualified `catalog.schema`. Catalog is nil for the bare form.
+type PathElement struct {
+	Catalog *ast.Identifier
+	Schema  *ast.Identifier
+	Loc     ast.Loc
+}
+
+// SetPathStmt is SET PATH pathElement (, pathElement)*.
+type SetPathStmt struct {
+	Elements []PathElement
+	Loc      ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *SetPathStmt) Tag() ast.NodeTag { return ast.T_SetPathStmt }
+
+// Span returns the source byte range.
+func (s *SetPathStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*SetPathStmt)(nil)
+
+// parsePathElement parses `identifier (DOT identifier)?` (pathElement).
+func (p *Parser) parsePathElement() (PathElement, error) {
+	first, err := p.parseIdentifier()
+	if err != nil {
+		return PathElement{}, err
+	}
+	el := PathElement{Schema: first, Loc: first.Loc}
+	if _, ok := p.match(int('.')); ok {
+		schema, err := p.parseIdentifier()
+		if err != nil {
+			return PathElement{}, err
+		}
+		el.Catalog = first
+		el.Schema = schema
+		el.Loc.End = schema.Loc.End
+	}
+	return el, nil
+}
+
+// parseSetPath parses the tail of SET PATH: pathElement (, pathElement)*. PATH
+// is the current token; start is the SET start offset.
+func (p *Parser) parseSetPath(start int) (ast.Node, error) {
+	p.advance() // consume PATH
+	first, err := p.parsePathElement()
+	if err != nil {
+		return nil, err
+	}
+	s := &SetPathStmt{Elements: []PathElement{first}, Loc: ast.Loc{Start: start, End: first.Loc.End}}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parsePathElement()
+		if err != nil {
+			return nil, err
+		}
+		s.Elements = append(s.Elements, next)
+		s.Loc.End = next.Loc.End
+	}
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// SET TIME ZONE
+// ---------------------------------------------------------------------------
+
+// SetTimeZoneStmt is SET TIME ZONE (LOCAL | expression). Local is true for the
+// LOCAL form; Value holds the expression otherwise.
+type SetTimeZoneStmt struct {
+	Local bool
+	// Value is the time-zone expression (string / interval / function call);
+	// nil when Local is true.
+	Value Expr
+	Loc   ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *SetTimeZoneStmt) Tag() ast.NodeTag { return ast.T_SetTimeZoneStmt }
+
+// Span returns the source byte range.
+func (s *SetTimeZoneStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*SetTimeZoneStmt)(nil)
+
+// parseSetTimeZone parses the tail of SET TIME ZONE: LOCAL | expression. TIME is
+// the current token; start is the SET start offset.
+func (p *Parser) parseSetTimeZone(start int) (ast.Node, error) {
+	p.advance() // consume TIME
+	if _, err := p.expect(kwZONE); err != nil {
+		return nil, err
+	}
+	if localTok, ok := p.match(kwLOCAL); ok {
+		return &SetTimeZoneStmt{
+			Local: true,
+			Loc:   ast.Loc{Start: start, End: localTok.Loc.End},
+		}, nil
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &SetTimeZoneStmt{
+		Value: value,
+		Loc:   ast.Loc{Start: start, End: value.Span().End},
+	}, nil
+}

--- a/trino/parser/show.go
+++ b/trino/parser/show.go
@@ -1,0 +1,574 @@
+package parser
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the `parser-utility` DAG node (with session.go and
+// explain_call.go): it implements Trino's SHOW family and the DESCRIBE / DESC
+// aliases — the legacy TrinoParser.g4 `statement` alternatives labelled
+// showCreateTable / showCreateSchema / showCreateView /
+// showCreateMaterializedView / showTables / showSchemas / showCatalogs /
+// showColumns / showStats / showStatsForQuery / showRoles / showRoleGrants /
+// showFunctions / showSession / showGrants, plus DESCRIBE/DESC (which the
+// legacy grammar folds into the showColumns label).
+//
+// Like expr.go's Expr and datatypes.go's DataType, the statement nodes are
+// PARSER-PACKAGE types carrying their own ast.Loc; they satisfy ast.Node by
+// returning a NodeTag declared in trino/ast/nodetags.go (the ast tag set is
+// closed to the ast-core node — File/Identifier/QualifiedName — so a statement
+// that embeds a parser-local child cannot itself live in package ast without
+// an import cycle). parseStmt (parser.go) dispatches SHOW / DESCRIBE / DESC
+// here.
+//
+// The legacy SHOW/DESCRIBE alternatives (TrinoParser.g4), folded into ShowStmt:
+//
+//	SHOW GRANTS (ON TABLE? qualifiedName)?                                  # showGrants
+//	SHOW CREATE TABLE qualifiedName                                         # showCreateTable
+//	SHOW CREATE SCHEMA qualifiedName                                        # showCreateSchema
+//	SHOW CREATE VIEW qualifiedName                                          # showCreateView
+//	SHOW CREATE MATERIALIZED VIEW qualifiedName                            # showCreateMaterializedView
+//	SHOW TABLES ((FROM|IN) qualifiedName)? (LIKE pattern (ESCAPE escape)?)? # showTables
+//	SHOW SCHEMAS ((FROM|IN) identifier)? (LIKE pattern (ESCAPE escape)?)?   # showSchemas
+//	SHOW CATALOGS (LIKE pattern (ESCAPE escape)?)?                          # showCatalogs
+//	SHOW COLUMNS (FROM|IN) qualifiedName? (LIKE pattern (ESCAPE escape)?)?  # showColumns
+//	SHOW STATS FOR qualifiedName                                            # showStats
+//	SHOW STATS FOR ( query )                                                # showStatsForQuery
+//	SHOW CURRENT? ROLES ((FROM|IN) identifier)?                            # showRoles
+//	SHOW ROLE GRANTS ((FROM|IN) identifier)?                              # showRoleGrants
+//	DESCRIBE qualifiedName | DESC qualifiedName                            # showColumns
+//	SHOW FUNCTIONS ((FROM|IN) qualifiedName)? (LIKE pattern (ESCAPE escape)?)? # showFunctions
+//	SHOW SESSION (LIKE pattern (ESCAPE escape)?)?                          # showSession
+//
+// Adjudicated against the live Trino 481 oracle, not the literal legacy
+// grammar. Oracle-confirmed divergences from a naive reading of the legacy
+// rule, recorded in the migration divergence ledger:
+//
+//	U1 (SHOW CREATE FUNCTION). The legacy grammar has no SHOW CREATE FUNCTION
+//	   alternative, but Trino 481 accepts `SHOW CREATE FUNCTION name` (oracle:
+//	   NOT_SUPPORTED, a semantic verdict — so syntactically ACCEPTED). It is a
+//	   documented form (trino.io/docs/current/sql/show-create-function). Added
+//	   as a ShowCreateFunction kind; flagged docs-ahead-of-legacy.
+//
+//	U2 (SHOW COLUMNS requires a name). The legacy `SHOW COLUMNS (FROM|IN)
+//	   qualifiedName?` marks the name optional, but Trino 481 rejects
+//	   `SHOW COLUMNS FROM` (SYNTAX_ERROR): the name is mandatory after FROM/IN.
+//	   parseShowColumns therefore requires it; flagged (legacy grammar wrong).
+//
+//	U3 (DESCRIBE INPUT/OUTPUT belong to the prepared-statement node). DESCRIBE
+//	   INPUT name and DESCRIBE OUTPUT name (describeInput/describeOutput) are
+//	   prepared-statement introspection, implemented by the parser-dcl-tcl node
+//	   (prepared.go). parseShowOrDescribe dispatches them to that node's
+//	   parseDescribeInputOutput when present, else routes to the unsupported
+//	   stub, so this node never mis-claims them as DESCRIBE-table.
+
+// ---------------------------------------------------------------------------
+// ShowStmt
+// ---------------------------------------------------------------------------
+
+// ShowKind classifies a ShowStmt — one per legacy SHOW/DESCRIBE alternative.
+type ShowKind int
+
+const (
+	// ShowInvalid is the zero value; never produced by the parser.
+	ShowInvalid ShowKind = iota
+	// ShowGrants is SHOW GRANTS [ON [TABLE] name].
+	ShowGrants
+	// ShowCreateTable is SHOW CREATE TABLE name.
+	ShowCreateTable
+	// ShowCreateSchema is SHOW CREATE SCHEMA name.
+	ShowCreateSchema
+	// ShowCreateView is SHOW CREATE VIEW name.
+	ShowCreateView
+	// ShowCreateMaterializedView is SHOW CREATE MATERIALIZED VIEW name.
+	ShowCreateMaterializedView
+	// ShowCreateFunction is SHOW CREATE FUNCTION name (U1: docs-ahead-of-legacy).
+	ShowCreateFunction
+	// ShowTables is SHOW TABLES [(FROM|IN) name] [LIKE pattern [ESCAPE esc]].
+	ShowTables
+	// ShowSchemas is SHOW SCHEMAS [(FROM|IN) catalog] [LIKE pattern [ESCAPE esc]].
+	ShowSchemas
+	// ShowCatalogs is SHOW CATALOGS [LIKE pattern [ESCAPE esc]].
+	ShowCatalogs
+	// ShowColumns is SHOW COLUMNS (FROM|IN) name [LIKE pattern [ESCAPE esc]]
+	// — also the target of DESCRIBE/DESC name.
+	ShowColumns
+	// ShowStats is SHOW STATS FOR name.
+	ShowStats
+	// ShowStatsForQuery is SHOW STATS FOR ( query ).
+	ShowStatsForQuery
+	// ShowRoles is SHOW [CURRENT] ROLES [(FROM|IN) catalog].
+	ShowRoles
+	// ShowRoleGrants is SHOW ROLE GRANTS [(FROM|IN) catalog].
+	ShowRoleGrants
+	// ShowFunctions is SHOW FUNCTIONS [(FROM|IN) name] [LIKE pattern [ESCAPE esc]].
+	ShowFunctions
+	// ShowSession is SHOW SESSION [LIKE pattern [ESCAPE esc]].
+	ShowSession
+)
+
+// ShowStmt is the parse node for the SHOW family and DESCRIBE/DESC. The fields
+// populated depend on Kind; unused fields are zero. It carries enough structure
+// for downstream consumers (query-type classification treats SHOW … as a
+// read / SelectInfoSchema-style statement; completion offers object names) while
+// keeping a single node type for the whole family (mirroring snowflake's
+// open-ended SHOW node).
+type ShowStmt struct {
+	Kind ShowKind
+
+	// Name is the object/target qualifiedName, where the form has one
+	// (SHOW CREATE …, SHOW STATS FOR name, SHOW COLUMNS (FROM|IN) name,
+	// DESCRIBE/DESC name). Nil otherwise.
+	Name *ast.QualifiedName
+	// In is the (FROM|IN) scope. For SHOW SCHEMAS / SHOW ROLES /
+	// SHOW ROLE GRANTS it is a single-identifier catalog (legacy: identifier);
+	// for SHOW TABLES / SHOW FUNCTIONS it is a qualifiedName. Stored as a
+	// QualifiedName in both cases (single-part for the identifier forms). Nil
+	// when absent.
+	In *ast.QualifiedName
+	// InKeyword records whether the scope was introduced by IN (true) or FROM
+	// (false); meaningless when In is nil.
+	InKeyword bool
+
+	// Current is true for SHOW CURRENT ROLES.
+	Current bool
+	// OnTable is true for SHOW GRANTS ON TABLE name (vs. SHOW GRANTS ON name).
+	OnTable bool
+
+	// Like is the LIKE pattern string literal text (decoded, quotes stripped),
+	// with HasLike marking its presence (the pattern may legitimately be "").
+	Like    string
+	HasLike bool
+	// Escape is the ESCAPE string literal text; HasEscape marks its presence.
+	Escape    string
+	HasEscape bool
+
+	// QueryText is the raw inner SQL of SHOW STATS FOR ( query ), trimmed.
+	// Only set for ShowStatsForQuery. The query is captured as raw text (a
+	// placeholder) rather than a parsed tree — the `query` rule belongs to the
+	// parser-select node — mirroring expr.go's SubqueryExpr (B1).
+	QueryText string
+
+	Loc ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *ShowStmt) Tag() ast.NodeTag { return ast.T_ShowStmt }
+
+// Span returns the source byte range covered by the statement.
+func (s *ShowStmt) Span() ast.Loc { return s.Loc }
+
+// Compile-time assertion that *ShowStmt satisfies ast.Node.
+var _ ast.Node = (*ShowStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// parsing
+// ---------------------------------------------------------------------------
+
+// parseShowStmt parses a statement whose leading keyword is SHOW, dispatching
+// on the second keyword. The SHOW token has NOT been consumed yet.
+func (p *Parser) parseShowStmt() (ast.Node, error) {
+	showTok := p.advance() // consume SHOW
+	start := showTok.Loc.Start
+
+	switch p.cur.Kind {
+	case kwGRANTS:
+		return p.parseShowGrants(start)
+	case kwCREATE:
+		return p.parseShowCreate(start)
+	case kwTABLES:
+		return p.parseShowTablesLike(start, ShowTables)
+	case kwSCHEMAS:
+		return p.parseShowSchemas(start)
+	case kwCATALOGS:
+		return p.parseShowCatalogs(start)
+	case kwCOLUMNS:
+		return p.parseShowColumns(start)
+	case kwSTATS:
+		return p.parseShowStats(start)
+	case kwCURRENT, kwROLES:
+		return p.parseShowRoles(start)
+	case kwROLE:
+		return p.parseShowRoleGrants(start)
+	case kwFUNCTIONS:
+		return p.parseShowTablesLike(start, ShowFunctions)
+	case kwSESSION:
+		return p.parseShowSession(start)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseShowGrants parses SHOW GRANTS (ON TABLE? qualifiedName)?. GRANTS is the
+// current token.
+func (p *Parser) parseShowGrants(start int) (ast.Node, error) {
+	grantsTok := p.advance() // consume GRANTS
+	s := &ShowStmt{Kind: ShowGrants, Loc: ast.Loc{Start: start, End: grantsTok.Loc.End}}
+	if _, ok := p.match(kwON); ok {
+		if _, ok := p.match(kwTABLE); ok {
+			s.OnTable = true
+		}
+		name, err := p.parseBoundedQualifiedName(3, "table name")
+		if err != nil {
+			return nil, err
+		}
+		s.Name = name
+		s.Loc.End = name.Loc.End
+	}
+	return s, nil
+}
+
+// parseShowCreate parses SHOW CREATE (TABLE|SCHEMA|VIEW|MATERIALIZED VIEW|
+// FUNCTION) qualifiedName. CREATE is the current token.
+func (p *Parser) parseShowCreate(start int) (ast.Node, error) {
+	p.advance() // consume CREATE
+	var kind ShowKind
+	switch p.cur.Kind {
+	case kwTABLE:
+		p.advance()
+		kind = ShowCreateTable
+	case kwSCHEMA:
+		p.advance()
+		kind = ShowCreateSchema
+	case kwVIEW:
+		p.advance()
+		kind = ShowCreateView
+	case kwMATERIALIZED:
+		p.advance()
+		if _, err := p.expect(kwVIEW); err != nil {
+			return nil, err
+		}
+		kind = ShowCreateMaterializedView
+	case kwFUNCTION:
+		// U1: docs-ahead-of-legacy; Trino 481 accepts SHOW CREATE FUNCTION.
+		p.advance()
+		kind = ShowCreateFunction
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	name, err := p.parseBoundedQualifiedName(3, "object name")
+	if err != nil {
+		return nil, err
+	}
+	return &ShowStmt{Kind: kind, Name: name, Loc: ast.Loc{Start: start, End: name.Loc.End}}, nil
+}
+
+// parseShowTablesLike parses the shape shared by SHOW TABLES and SHOW FUNCTIONS:
+// `((FROM|IN) qualifiedName)? (LIKE pattern (ESCAPE escape)?)?`. The
+// TABLES/FUNCTIONS keyword is the current token.
+func (p *Parser) parseShowTablesLike(start int, kind ShowKind) (ast.Node, error) {
+	kwTok := p.advance() // consume TABLES / FUNCTIONS
+	s := &ShowStmt{Kind: kind, Loc: ast.Loc{Start: start, End: kwTok.Loc.End}}
+	if scopeTok, ok := p.match(kwFROM, kwIN); ok {
+		s.InKeyword = scopeTok.Kind == kwIN
+		// The FROM/IN scope is a schema (catalog.schema), capped at 2 parts;
+		// `SHOW TABLES FROM a.b.c` is a SYNTAX_ERROR in Trino 481.
+		name, err := p.parseBoundedQualifiedName(2, "schema name")
+		if err != nil {
+			return nil, err
+		}
+		s.In = name
+		s.Loc.End = name.Loc.End
+	}
+	if err := p.parseLikeEscape(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// parseShowSchemas parses SHOW SCHEMAS ((FROM|IN) identifier)?
+// (LIKE pattern (ESCAPE escape)?)?. The legacy grammar takes a single
+// identifier (catalog) after FROM/IN — NOT a qualifiedName — and Trino 481
+// rejects a dotted scope (`SHOW SCHEMAS FROM c.x` is a SYNTAX_ERROR).
+// SCHEMAS is the current token.
+func (p *Parser) parseShowSchemas(start int) (ast.Node, error) {
+	schemasTok := p.advance() // consume SCHEMAS
+	s := &ShowStmt{Kind: ShowSchemas, Loc: ast.Loc{Start: start, End: schemasTok.Loc.End}}
+	if scopeTok, ok := p.match(kwFROM, kwIN); ok {
+		s.InKeyword = scopeTok.Kind == kwIN
+		ident, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		s.In = &ast.QualifiedName{Parts: []*ast.Identifier{ident}, Loc: ident.Loc}
+		s.Loc.End = ident.Loc.End
+	}
+	if err := p.parseLikeEscape(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// parseShowCatalogs parses SHOW CATALOGS (LIKE pattern (ESCAPE escape)?)?.
+// CATALOGS is the current token.
+func (p *Parser) parseShowCatalogs(start int) (ast.Node, error) {
+	catalogsTok := p.advance() // consume CATALOGS
+	s := &ShowStmt{Kind: ShowCatalogs, Loc: ast.Loc{Start: start, End: catalogsTok.Loc.End}}
+	if err := p.parseLikeEscape(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// parseShowColumns parses SHOW COLUMNS (FROM|IN) qualifiedName
+// (LIKE pattern (ESCAPE escape)?)?. COLUMNS is the current token.
+//
+// U2: the (FROM|IN) keyword AND the name are both mandatory — Trino 481 rejects
+// both `SHOW COLUMNS` and `SHOW COLUMNS FROM` despite the legacy grammar marking
+// the name optional.
+func (p *Parser) parseShowColumns(start int) (ast.Node, error) {
+	p.advance() // consume COLUMNS
+	scopeTok, ok := p.match(kwFROM, kwIN)
+	if !ok {
+		return nil, p.syntaxErrorAtCur()
+	}
+	name, err := p.parseBoundedQualifiedName(3, "table name")
+	if err != nil {
+		return nil, err
+	}
+	s := &ShowStmt{
+		Kind:      ShowColumns,
+		Name:      name,
+		InKeyword: scopeTok.Kind == kwIN,
+		Loc:       ast.Loc{Start: start, End: name.Loc.End},
+	}
+	if err := p.parseLikeEscape(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// parseShowStats parses SHOW STATS FOR (qualifiedName | ( query )). STATS is the
+// current token.
+func (p *Parser) parseShowStats(start int) (ast.Node, error) {
+	p.advance() // consume STATS
+	if _, err := p.expect(kwFOR); err != nil {
+		return nil, err
+	}
+	// SHOW STATS FOR ( query ) — a parenthesised query. The inner must START a
+	// query (SELECT/WITH/TABLE/VALUES); Trino 481 rejects `SHOW STATS FOR
+	// (nation)`, `SHOW STATS FOR ()`, and other non-query parens with a
+	// SYNTAX_ERROR. We gate on startsQuery() (the same check parser-select's
+	// query rule begins with) and then capture the inner query as raw text — the
+	// `query` grammar belongs to the parser-select node, so the inner is a
+	// placeholder here, mirroring expr.go's SubqueryExpr (B1). Full inner-query
+	// validation arrives with parser-select; the gate already rejects the common
+	// non-query cases.
+	if p.cur.Kind == int('(') {
+		openTok := p.advance() // consume '('
+		if !p.startsQuery() {
+			return nil, p.syntaxErrorAtCur()
+		}
+		raw, closeTok, err := p.captureBalancedParen(openTok)
+		if err != nil {
+			return nil, err
+		}
+		return &ShowStmt{
+			Kind:      ShowStatsForQuery,
+			QueryText: raw,
+			Loc:       ast.Loc{Start: start, End: closeTok.Loc.End},
+		}, nil
+	}
+	name, err := p.parseBoundedQualifiedName(3, "table name")
+	if err != nil {
+		return nil, err
+	}
+	return &ShowStmt{Kind: ShowStats, Name: name, Loc: ast.Loc{Start: start, End: name.Loc.End}}, nil
+}
+
+// parseShowRoles parses SHOW CURRENT? ROLES ((FROM|IN) identifier)?. The current
+// token is CURRENT or ROLES.
+func (p *Parser) parseShowRoles(start int) (ast.Node, error) {
+	s := &ShowStmt{Kind: ShowRoles}
+	if _, ok := p.match(kwCURRENT); ok {
+		s.Current = true
+	}
+	rolesTok, err := p.expect(kwROLES)
+	if err != nil {
+		return nil, err
+	}
+	s.Loc = ast.Loc{Start: start, End: rolesTok.Loc.End}
+	if scopeTok, ok := p.match(kwFROM, kwIN); ok {
+		s.InKeyword = scopeTok.Kind == kwIN
+		ident, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		s.In = &ast.QualifiedName{Parts: []*ast.Identifier{ident}, Loc: ident.Loc}
+		s.Loc.End = ident.Loc.End
+	}
+	return s, nil
+}
+
+// parseShowRoleGrants parses SHOW ROLE GRANTS ((FROM|IN) identifier)?. ROLE is
+// the current token.
+func (p *Parser) parseShowRoleGrants(start int) (ast.Node, error) {
+	p.advance() // consume ROLE
+	grantsTok, err := p.expect(kwGRANTS)
+	if err != nil {
+		return nil, err
+	}
+	s := &ShowStmt{Kind: ShowRoleGrants, Loc: ast.Loc{Start: start, End: grantsTok.Loc.End}}
+	if scopeTok, ok := p.match(kwFROM, kwIN); ok {
+		s.InKeyword = scopeTok.Kind == kwIN
+		ident, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		s.In = &ast.QualifiedName{Parts: []*ast.Identifier{ident}, Loc: ident.Loc}
+		s.Loc.End = ident.Loc.End
+	}
+	return s, nil
+}
+
+// parseShowSession parses SHOW SESSION (LIKE pattern (ESCAPE escape)?)?. SESSION
+// is the current token.
+func (p *Parser) parseShowSession(start int) (ast.Node, error) {
+	sessionTok := p.advance() // consume SESSION
+	s := &ShowStmt{Kind: ShowSession, Loc: ast.Loc{Start: start, End: sessionTok.Loc.End}}
+	if err := p.parseLikeEscape(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// parseShowOrDescribe is the entry point for DESCRIBE / DESC. The DESCRIBE/DESC
+// token is the current token. DESCRIBE qualifiedName and DESC qualifiedName are
+// aliases for SHOW COLUMNS (ShowColumns kind). DESCRIBE INPUT name and
+// DESCRIBE OUTPUT name are prepared-statement introspection owned by the
+// parser-dcl-tcl node (prepared.go); they are routed there when present, else
+// to the unsupported stub (U3).
+func (p *Parser) parseDescribeStmt() (ast.Node, error) {
+	descTok := p.advance() // consume DESCRIBE / DESC
+
+	// DESCRIBE INPUT name / DESCRIBE OUTPUT name / DESCRIBE OUTPUT (query):
+	// prepared-statement introspection (legacy describeInput/describeOutput),
+	// owned by the parser-dcl-tcl node (prepared.go). The disambiguation is
+	// exactly Trino 481's (oracle-confirmed):
+	//
+	//   - only the DESCRIBE spelling has the prepared form; `DESC INPUT a` is a
+	//     SYNTAX_ERROR (DESC takes a single qualifiedName, so two bare names is
+	//     invalid).
+	//   - INPUT/OUTPUT followed by an identifier-start token is the prepared
+	//     `DESCRIBE (INPUT|OUTPUT) statement_name` form. `DESCRIBE INPUT` (INPUT
+	//     then EOF) and `DESCRIBE input.t` (INPUT then '.') are instead
+	//     DESCRIBE-of-table-named-INPUT (ShowColumns), since INPUT/OUTPUT are
+	//     non-reserved keywords usable as identifiers.
+	//   - OUTPUT (but NOT INPUT) also has the direct `DESCRIBE OUTPUT (query)`
+	//     form; `DESCRIBE INPUT (SELECT 1)` and `DESC OUTPUT (SELECT 1)` are
+	//     SYNTAX_ERRORs, so only `DESCRIBE OUTPUT (` routes here on the '('.
+	//
+	// The prepared forms route to the "not yet supported" stub until
+	// parser-dcl-tcl lands (U3); Diagnose then distinguishes valid-Trino-not-
+	// yet-implemented from invalid syntax. They are out of this node's scope and
+	// excluded from its oracle differential.
+	if descTok.Kind == kwDESCRIBE {
+		switch {
+		case (p.cur.Kind == kwINPUT || p.cur.Kind == kwOUTPUT) && isIdentifierStart(p.peekNext().Kind):
+			return p.unsupported("DESCRIBE INPUT/OUTPUT")
+		case p.cur.Kind == kwOUTPUT && p.peekNext().Kind == int('('):
+			return p.unsupported("DESCRIBE OUTPUT (query)")
+		}
+	}
+
+	start := descTok.Loc.Start
+	name, err := p.parseBoundedQualifiedName(3, "table name")
+	if err != nil {
+		return nil, err
+	}
+	return &ShowStmt{Kind: ShowColumns, Name: name, Loc: ast.Loc{Start: start, End: name.Loc.End}}, nil
+}
+
+// parseLikeEscape parses an optional `LIKE pattern (ESCAPE escape)?` tail into s.
+// Both pattern and escape are string literals. Sets HasLike / HasEscape so an
+// empty pattern is distinguishable from no LIKE clause.
+func (p *Parser) parseLikeEscape(s *ShowStmt) error {
+	if _, ok := p.match(kwLIKE); !ok {
+		return nil
+	}
+	pat, err := p.expectStringLiteral("LIKE pattern")
+	if err != nil {
+		return err
+	}
+	s.Like = pat.Str
+	s.HasLike = true
+	s.Loc.End = pat.Loc.End
+	if _, ok := p.match(kwESCAPE); ok {
+		esc, err := p.expectStringLiteral("ESCAPE")
+		if err != nil {
+			return err
+		}
+		s.Escape = esc.Str
+		s.HasEscape = true
+		s.Loc.End = esc.Loc.End
+	}
+	return nil
+}
+
+// expectStringLiteral consumes the current token if it is a string literal
+// ('...' or U&'...'), returning it. Otherwise returns a *ParseError naming the
+// context (e.g. "LIKE pattern").
+func (p *Parser) expectStringLiteral(context string) (Token, error) {
+	if p.cur.Kind != tokString && p.cur.Kind != tokUnicodeString {
+		return Token{}, &ParseError{Loc: p.cur.Loc, Msg: "expected string literal for " + context}
+	}
+	return p.advance(), nil
+}
+
+// parseBoundedQualifiedName parses a qualifiedName and rejects it with a
+// *ParseError when it has more than maxParts dotted components. Trino's legacy
+// ANTLR grammar uses the unbounded `qualifiedName` for every name position, but
+// Trino 481 enforces a part-count limit per position at PARSE time (the verdict
+// is SYNTAX_ERROR), so the omni parser must too — otherwise it over-accepts
+// names the oracle rejects. Object names (table/view/schema/function/procedure
+// targets) cap at 3 (catalog.schema.object); a schema scope (SHOW TABLES/
+// FUNCTIONS FROM) caps at 2 (catalog.schema). This is a confirmed
+// docs/oracle-vs-legacy divergence (legacy grammar too permissive).
+func (p *Parser) parseBoundedQualifiedName(maxParts int, context string) (*ast.QualifiedName, error) {
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	if len(name.Parts) > maxParts {
+		return nil, &ParseError{
+			Loc: name.Loc,
+			Msg: "too many dotted parts in " + context + " (expected at most " + strconv.Itoa(maxParts) + ")",
+		}
+	}
+	return name, nil
+}
+
+// captureBalancedParen consumes tokens up to and including the ')' matching an
+// already-consumed '(' (openTok), returning the inner text (trimmed) and the
+// closing token. Nested parentheses are balanced. Mirrors
+// expr.go's parseSubqueryPlaceholder — used to capture a SHOW STATS FOR ( query )
+// inner query as raw text without parsing the query grammar (a parser-select
+// concern).
+func (p *Parser) captureBalancedParen(openTok Token) (string, Token, error) {
+	depth := 1
+	innerStart := p.cur.Loc.Start
+	innerEnd := p.cur.Loc.Start
+	for depth > 0 && p.cur.Kind != tokEOF {
+		switch p.cur.Kind {
+		case int('('):
+			depth++
+		case int(')'):
+			depth--
+			if depth == 0 {
+				innerEnd = p.cur.Loc.Start
+			}
+		}
+		if depth > 0 {
+			p.advance()
+		}
+	}
+	if depth != 0 {
+		return "", Token{}, &ParseError{Loc: p.cur.Loc, Msg: "unterminated parenthesised query"}
+	}
+	raw := p.sourceSlice(innerStart, innerEnd)
+	closeTok := p.advance() // consume ')'
+	return strings.TrimSpace(raw), closeTok, nil
+}

--- a/trino/parser/utility_structure_test.go
+++ b/trino/parser/utility_structure_test.go
@@ -1,0 +1,420 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the structural (Layer 2) gate for the `parser-utility` node.
+// Accept/reject alone does not catch a form that "accepts" but is parsed into
+// the wrong node shape (e.g. SHOW TABLES vs SHOW SCHEMAS both accept; the IN/FROM
+// scope must land in the right field; SET TIME ZONE LOCAL vs an expression).
+// These tests pin the parse-node fields of one representative per alternative.
+
+// parseOneStmt parses sql, requiring exactly one statement and no errors, and
+// returns it. Fails the test otherwise.
+func parseOneStmt(t *testing.T, sql string) ast.Node {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q): unexpected errors: %v", sql, errs)
+	}
+	if file == nil || len(file.Stmts) != 1 {
+		got := 0
+		if file != nil {
+			got = len(file.Stmts)
+		}
+		t.Fatalf("Parse(%q): got %d statements, want 1", sql, got)
+	}
+	return file.Stmts[0]
+}
+
+func TestUtility_StructureShow(t *testing.T) {
+	t.Run("show_tables_from_like_escape", func(t *testing.T) {
+		s, ok := parseOneStmt(t, "SHOW TABLES FROM tpch.tiny LIKE 'p%' ESCAPE '#'").(*ShowStmt)
+		if !ok {
+			t.Fatal("not a *ShowStmt")
+		}
+		if s.Kind != ShowTables {
+			t.Errorf("Kind = %v, want ShowTables", s.Kind)
+		}
+		if s.In == nil || s.In.Normalize() != "tpch.tiny" {
+			t.Errorf("In = %v, want tpch.tiny", s.In)
+		}
+		if s.InKeyword {
+			t.Error("InKeyword = true, want false (FROM)")
+		}
+		if !s.HasLike || s.Like != "p%" {
+			t.Errorf("Like = %q (has=%v), want p%%", s.Like, s.HasLike)
+		}
+		if !s.HasEscape || s.Escape != "#" {
+			t.Errorf("Escape = %q (has=%v), want #", s.Escape, s.HasEscape)
+		}
+	})
+
+	t.Run("show_tables_in_keyword", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW TABLES IN s").(*ShowStmt)
+		if !s.InKeyword {
+			t.Error("InKeyword = false, want true (IN)")
+		}
+	})
+
+	t.Run("show_schemas_single_identifier_scope", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW SCHEMAS FROM tpch").(*ShowStmt)
+		if s.Kind != ShowSchemas {
+			t.Errorf("Kind = %v, want ShowSchemas", s.Kind)
+		}
+		if s.In == nil || len(s.In.Parts) != 1 || s.In.Normalize() != "tpch" {
+			t.Errorf("In = %v, want single-part tpch", s.In)
+		}
+	})
+
+	t.Run("show_columns_name_required", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW COLUMNS FROM tpch.sf1.nation").(*ShowStmt)
+		if s.Kind != ShowColumns {
+			t.Errorf("Kind = %v, want ShowColumns", s.Kind)
+		}
+		if s.Name == nil || s.Name.Normalize() != "tpch.sf1.nation" {
+			t.Errorf("Name = %v, want tpch.sf1.nation", s.Name)
+		}
+	})
+
+	t.Run("show_create_table", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW CREATE TABLE sf1.orders").(*ShowStmt)
+		if s.Kind != ShowCreateTable {
+			t.Errorf("Kind = %v, want ShowCreateTable", s.Kind)
+		}
+		if s.Name == nil || s.Name.Normalize() != "sf1.orders" {
+			t.Errorf("Name = %v, want sf1.orders", s.Name)
+		}
+	})
+
+	t.Run("show_create_materialized_view", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW CREATE MATERIALIZED VIEW mv").(*ShowStmt)
+		if s.Kind != ShowCreateMaterializedView {
+			t.Errorf("Kind = %v, want ShowCreateMaterializedView", s.Kind)
+		}
+	})
+
+	t.Run("show_create_function_U1", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW CREATE FUNCTION a.b.c").(*ShowStmt)
+		if s.Kind != ShowCreateFunction {
+			t.Errorf("Kind = %v, want ShowCreateFunction", s.Kind)
+		}
+	})
+
+	t.Run("show_grants_on_table", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW GRANTS ON TABLE orders").(*ShowStmt)
+		if s.Kind != ShowGrants {
+			t.Errorf("Kind = %v, want ShowGrants", s.Kind)
+		}
+		if !s.OnTable {
+			t.Error("OnTable = false, want true")
+		}
+		if s.Name == nil || s.Name.Normalize() != "orders" {
+			t.Errorf("Name = %v, want orders", s.Name)
+		}
+	})
+
+	t.Run("show_grants_bare", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW GRANTS").(*ShowStmt)
+		if s.OnTable || s.Name != nil {
+			t.Errorf("bare SHOW GRANTS: OnTable=%v Name=%v, want false/nil", s.OnTable, s.Name)
+		}
+	})
+
+	t.Run("show_current_roles", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW CURRENT ROLES FROM hive").(*ShowStmt)
+		if s.Kind != ShowRoles || !s.Current {
+			t.Errorf("Kind=%v Current=%v, want ShowRoles/true", s.Kind, s.Current)
+		}
+		if s.In == nil || s.In.Normalize() != "hive" {
+			t.Errorf("In = %v, want hive", s.In)
+		}
+	})
+
+	t.Run("show_role_grants", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW ROLE GRANTS").(*ShowStmt)
+		if s.Kind != ShowRoleGrants {
+			t.Errorf("Kind = %v, want ShowRoleGrants", s.Kind)
+		}
+	})
+
+	t.Run("show_stats_for_query_raw", func(t *testing.T) {
+		s := parseOneStmt(t, "SHOW STATS FOR (SELECT * FROM nation WHERE regionkey = 1)").(*ShowStmt)
+		if s.Kind != ShowStatsForQuery {
+			t.Errorf("Kind = %v, want ShowStatsForQuery", s.Kind)
+		}
+		if s.QueryText != "SELECT * FROM nation WHERE regionkey = 1" {
+			t.Errorf("QueryText = %q, want the inner query text", s.QueryText)
+		}
+	})
+
+	t.Run("describe_is_show_columns", func(t *testing.T) {
+		s := parseOneStmt(t, "DESCRIBE nation").(*ShowStmt)
+		if s.Kind != ShowColumns {
+			t.Errorf("Kind = %v, want ShowColumns (DESCRIBE alias)", s.Kind)
+		}
+		if s.Name == nil || s.Name.Normalize() != "nation" {
+			t.Errorf("Name = %v, want nation", s.Name)
+		}
+	})
+
+	t.Run("describe_input_as_table_name", func(t *testing.T) {
+		// `DESCRIBE input` with no trailing name is DESCRIBE-of-table-"input".
+		s := parseOneStmt(t, "DESCRIBE input").(*ShowStmt)
+		if s.Kind != ShowColumns {
+			t.Errorf("Kind = %v, want ShowColumns", s.Kind)
+		}
+		if s.Name == nil || s.Name.Normalize() != "input" {
+			t.Errorf("Name = %v, want input", s.Name)
+		}
+	})
+}
+
+func TestUtility_StructureSession(t *testing.T) {
+	t.Run("use_schema_only", func(t *testing.T) {
+		s := parseOneStmt(t, "USE information_schema").(*UseStmt)
+		if s.Catalog != nil {
+			t.Errorf("Catalog = %v, want nil", s.Catalog)
+		}
+		if s.Schema == nil || s.Schema.Normalize() != "information_schema" {
+			t.Errorf("Schema = %v, want information_schema", s.Schema)
+		}
+	})
+
+	t.Run("use_catalog_schema", func(t *testing.T) {
+		s := parseOneStmt(t, "USE hive.finance").(*UseStmt)
+		if s.Catalog == nil || s.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v, want hive", s.Catalog)
+		}
+		if s.Schema == nil || s.Schema.Normalize() != "finance" {
+			t.Errorf("Schema = %v, want finance", s.Schema)
+		}
+	})
+
+	t.Run("set_session_property", func(t *testing.T) {
+		s := parseOneStmt(t, "SET SESSION cat.prop = 'v'").(*SetSessionStmt)
+		if s.Name == nil || s.Name.Normalize() != "cat.prop" {
+			t.Errorf("Name = %v, want cat.prop", s.Name)
+		}
+		if s.Value == nil {
+			t.Error("Value = nil, want an expression")
+		}
+	})
+
+	t.Run("reset_session_property", func(t *testing.T) {
+		s := parseOneStmt(t, "RESET SESSION cat.prop").(*ResetSessionStmt)
+		if s.Name == nil || s.Name.Normalize() != "cat.prop" {
+			t.Errorf("Name = %v, want cat.prop", s.Name)
+		}
+	})
+
+	t.Run("set_session_authorization_identifier", func(t *testing.T) {
+		s := parseOneStmt(t, "SET SESSION AUTHORIZATION alice").(*SetSessionAuthorizationStmt)
+		if s.HasUserString {
+			t.Error("HasUserString = true, want false (identifier form)")
+		}
+		if s.User == nil || s.User.Normalize() != "alice" {
+			t.Errorf("User = %v, want alice", s.User)
+		}
+	})
+
+	t.Run("set_session_authorization_string", func(t *testing.T) {
+		s := parseOneStmt(t, "SET SESSION AUTHORIZATION 'alice'").(*SetSessionAuthorizationStmt)
+		if !s.HasUserString || s.UserString != "alice" {
+			t.Errorf("UserString = %q (has=%v), want alice", s.UserString, s.HasUserString)
+		}
+	})
+
+	t.Run("reset_session_authorization", func(t *testing.T) {
+		if _, ok := parseOneStmt(t, "RESET SESSION AUTHORIZATION").(*ResetSessionAuthorizationStmt); !ok {
+			t.Error("not a *ResetSessionAuthorizationStmt")
+		}
+	})
+
+	t.Run("set_role_named_in_catalog", func(t *testing.T) {
+		s := parseOneStmt(t, "SET ROLE analyst IN hive").(*SetRoleStmt)
+		if s.Spec != RoleNamed {
+			t.Errorf("Spec = %v, want RoleNamed", s.Spec)
+		}
+		if s.Role == nil || s.Role.Normalize() != "analyst" {
+			t.Errorf("Role = %v, want analyst", s.Role)
+		}
+		if s.Catalog == nil || s.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v, want hive", s.Catalog)
+		}
+	})
+
+	t.Run("set_role_all", func(t *testing.T) {
+		s := parseOneStmt(t, "SET ROLE ALL").(*SetRoleStmt)
+		if s.Spec != RoleAll {
+			t.Errorf("Spec = %v, want RoleAll", s.Spec)
+		}
+	})
+
+	t.Run("set_role_none", func(t *testing.T) {
+		s := parseOneStmt(t, "SET ROLE NONE").(*SetRoleStmt)
+		if s.Spec != RoleNone {
+			t.Errorf("Spec = %v, want RoleNone", s.Spec)
+		}
+	})
+
+	t.Run("set_path_multi", func(t *testing.T) {
+		s := parseOneStmt(t, "SET PATH a, b.c, d").(*SetPathStmt)
+		if len(s.Elements) != 3 {
+			t.Fatalf("Elements = %d, want 3", len(s.Elements))
+		}
+		if s.Elements[0].Catalog != nil || s.Elements[0].Schema.Normalize() != "a" {
+			t.Errorf("element 0 = %+v, want bare schema a", s.Elements[0])
+		}
+		if s.Elements[1].Catalog == nil || s.Elements[1].Catalog.Normalize() != "b" ||
+			s.Elements[1].Schema.Normalize() != "c" {
+			t.Errorf("element 1 = %+v, want b.c", s.Elements[1])
+		}
+	})
+
+	t.Run("set_time_zone_local", func(t *testing.T) {
+		s := parseOneStmt(t, "SET TIME ZONE LOCAL").(*SetTimeZoneStmt)
+		if !s.Local {
+			t.Error("Local = false, want true")
+		}
+		if s.Value != nil {
+			t.Errorf("Value = %v, want nil for LOCAL", s.Value)
+		}
+	})
+
+	t.Run("set_time_zone_expr", func(t *testing.T) {
+		s := parseOneStmt(t, "SET TIME ZONE INTERVAL '10' HOUR").(*SetTimeZoneStmt)
+		if s.Local {
+			t.Error("Local = true, want false")
+		}
+		if s.Value == nil {
+			t.Error("Value = nil, want the interval expression")
+		}
+	})
+}
+
+func TestUtility_StructureExplainCall(t *testing.T) {
+	t.Run("explain_options", func(t *testing.T) {
+		// Inner SHOW TABLES is implemented, so this parses cleanly.
+		s := parseOneStmt(t, "EXPLAIN (TYPE LOGICAL, FORMAT JSON) SHOW TABLES").(*ExplainStmt)
+		if s.Analyze {
+			t.Error("Analyze = true, want false")
+		}
+		if s.Type != ExplainTypeLogical {
+			t.Errorf("Type = %v, want ExplainTypeLogical", s.Type)
+		}
+		if s.Format != ExplainFormatJSON {
+			t.Errorf("Format = %v, want ExplainFormatJSON", s.Format)
+		}
+		if s.Statement == nil {
+			t.Error("Statement = nil, want the inner SHOW node")
+		}
+	})
+
+	t.Run("explain_analyze_verbose", func(t *testing.T) {
+		s := parseOneStmt(t, "EXPLAIN ANALYZE VERBOSE SHOW TABLES").(*ExplainStmt)
+		if !s.Analyze || !s.Verbose {
+			t.Errorf("Analyze=%v Verbose=%v, want both true", s.Analyze, s.Verbose)
+		}
+	})
+
+	t.Run("explain_io_validate", func(t *testing.T) {
+		s := parseOneStmt(t, "EXPLAIN (TYPE IO) SHOW TABLES").(*ExplainStmt)
+		if s.Type != ExplainTypeIO {
+			t.Errorf("Type = %v, want ExplainTypeIO", s.Type)
+		}
+	})
+
+	t.Run("call_positional", func(t *testing.T) {
+		s := parseOneStmt(t, "CALL test(123, 'apple')").(*CallStmt)
+		if s.Name == nil || s.Name.Normalize() != "test" {
+			t.Errorf("Name = %v, want test", s.Name)
+		}
+		if len(s.Arguments) != 2 {
+			t.Fatalf("Arguments = %d, want 2", len(s.Arguments))
+		}
+		for i, a := range s.Arguments {
+			if a.Name != nil {
+				t.Errorf("argument %d Name = %v, want nil (positional)", i, a.Name)
+			}
+		}
+	})
+
+	t.Run("call_named", func(t *testing.T) {
+		s := parseOneStmt(t, "CALL c.s.test(name => 'apple', id => 123)").(*CallStmt)
+		if s.Name == nil || s.Name.Normalize() != "c.s.test" {
+			t.Errorf("Name = %v, want c.s.test", s.Name)
+		}
+		if len(s.Arguments) != 2 {
+			t.Fatalf("Arguments = %d, want 2", len(s.Arguments))
+		}
+		if s.Arguments[0].Name == nil || s.Arguments[0].Name.Normalize() != "name" {
+			t.Errorf("argument 0 Name = %v, want name", s.Arguments[0].Name)
+		}
+		if s.Arguments[1].Name == nil || s.Arguments[1].Name.Normalize() != "id" {
+			t.Errorf("argument 1 Name = %v, want id", s.Arguments[1].Name)
+		}
+	})
+
+	t.Run("call_empty_args", func(t *testing.T) {
+		s := parseOneStmt(t, "CALL p()").(*CallStmt)
+		if len(s.Arguments) != 0 {
+			t.Errorf("Arguments = %d, want 0", len(s.Arguments))
+		}
+	})
+
+	t.Run("call_mixed_named_positional", func(t *testing.T) {
+		// Trino 481 accepts named-then-positional order.
+		s := parseOneStmt(t, "CALL f(name => 1, 2)").(*CallStmt)
+		if len(s.Arguments) != 2 {
+			t.Fatalf("Arguments = %d, want 2", len(s.Arguments))
+		}
+		if s.Arguments[0].Name == nil {
+			t.Error("argument 0 should be named")
+		}
+		if s.Arguments[1].Name != nil {
+			t.Error("argument 1 should be positional")
+		}
+	})
+}
+
+// TestUtility_NodeTagsAndLoc verifies every node type returns its declared
+// NodeTag and a valid Loc spanning the statement.
+func TestUtility_NodeTagsAndLoc(t *testing.T) {
+	cases := []struct {
+		sql string
+		tag ast.NodeTag
+	}{
+		{"SHOW TABLES", ast.T_ShowStmt},
+		{"DESCRIBE t", ast.T_ShowStmt},
+		{"USE s", ast.T_UseStmt},
+		{"SET SESSION a = 1", ast.T_SetSessionStmt},
+		{"RESET SESSION a", ast.T_ResetSessionStmt},
+		{"SET SESSION AUTHORIZATION u", ast.T_SetSessionAuthorizationStmt},
+		{"RESET SESSION AUTHORIZATION", ast.T_ResetSessionAuthorizationStmt},
+		{"SET ROLE ALL", ast.T_SetRoleStmt},
+		{"SET PATH a", ast.T_SetPathStmt},
+		{"SET TIME ZONE LOCAL", ast.T_SetTimeZoneStmt},
+		{"EXPLAIN SHOW TABLES", ast.T_ExplainStmt},
+		{"CALL p()", ast.T_CallStmt},
+	}
+	for _, tc := range cases {
+		t.Run(truncateName(tc.sql), func(t *testing.T) {
+			stmt := parseOneStmt(t, tc.sql)
+			if stmt.Tag() != tc.tag {
+				t.Errorf("Tag() = %v, want %v", stmt.Tag(), tc.tag)
+			}
+			sp, ok := stmt.(interface{ Span() ast.Loc })
+			if !ok {
+				t.Fatal("statement does not expose Span()")
+			}
+			loc := sp.Span()
+			if !loc.IsValid() || loc.Start != 0 || loc.End != len(tc.sql) {
+				t.Errorf("Span() = %+v, want [0,%d)", loc, len(tc.sql))
+			}
+		})
+	}
+}

--- a/trino/parser/utility_test.go
+++ b/trino/parser/utility_test.go
@@ -1,0 +1,451 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the correctness gate for the `parser-utility` DAG node
+// (show.go + session.go + explain_call.go). Following correctness-protocol.md:
+//
+//   - Layer 1 (accept/reject differential): utilityAcceptCorpus and
+//     utilityRejectCorpus span every SHOW / DESCRIBE / USE / SET* / RESET* /
+//     EXPLAIN / CALL alternative of TrinoParser.g4, plus the oracle-discovered
+//     docs-ahead forms (SHOW CREATE FUNCTION) and oracle-discovered negatives.
+//     TestUtility_OracleDifferential is the authoritative gate: this node's
+//     accept/reject (via parseUtility) must equal Trino 481's accept/reject of
+//     the same statement.
+//   - Layer 2 (structural): TestUtility_Structure pins the parse-node shape of
+//     representative forms (Kind, Name, scope, options) so a form that "accepts"
+//     is also parsed into the right node.
+//   - Completeness: every legacy alternative appears in the corpus with its
+//     oracle-derived verdict; the per-alternative checklist is the corpus
+//     comment blocks below.
+//
+// The oracle helpers (connectOracle / oracleAccepts / truncateName) live in
+// oracle_foundation_test.go and lexer_oracle_test.go.
+//
+// Scope boundary: DESCRIBE INPUT / DESCRIBE OUTPUT (prepared-statement
+// introspection) and START TRANSACTION / COMMIT / ROLLBACK / PREPARE / EXECUTE /
+// DEALLOCATE / GRANT / REVOKE / DENY belong to the parser-dcl-tcl node and are
+// NOT exercised here — they are still stubbed (unsupported) until that node
+// lands. parseUtility asserts the statement it parsed is one of this node's
+// kinds, so an accidentally-claimed out-of-scope form would surface.
+
+// utilityVerdict is this node's tri-state classification of a parse result,
+// needed because EXPLAIN recurses into the inner statement (E1) whose parser may
+// not have landed yet:
+//
+//   - verdictAccept: parsed into one of this node's node types with no error.
+//   - verdictReject: a real syntax rejection (or a nil/empty/foreign result).
+//   - verdictPendingInner: the statement IS one of this node's nodes, but its
+//     only error is a downstream "not yet supported" stub — exclusively the
+//     EXPLAIN-wraps-an-unimplemented-inner-statement case. Trino accepts these;
+//     omni will too once the inner DAG node (parser-select / dml / ddl) lands.
+//     The differential treats these as pending, not failures, so this node does
+//     not falsely depend on a sibling/later node.
+type utilityVerdict int
+
+const (
+	verdictReject utilityVerdict = iota
+	verdictAccept
+	verdictPendingInner
+)
+
+// isUtilityNode reports whether n is one of the node types this node produces.
+func isUtilityNode(n ast.Node) bool {
+	switch n.(type) {
+	case *ShowStmt, *UseStmt, *SetSessionStmt, *ResetSessionStmt,
+		*SetSessionAuthorizationStmt, *ResetSessionAuthorizationStmt,
+		*SetRoleStmt, *SetPathStmt, *SetTimeZoneStmt, *ExplainStmt, *CallStmt:
+		return true
+	default:
+		return false
+	}
+}
+
+// classifyUtility parses a single utility statement and returns its verdict plus
+// the parse errors (for diagnostics). See utilityVerdict.
+func classifyUtility(sql string) (utilityVerdict, ast.Node, []ParseError) {
+	file, errs := Parse(sql)
+	var stmt ast.Node
+	if file != nil && len(file.Stmts) == 1 {
+		stmt = file.Stmts[0]
+	}
+	if len(errs) == 0 {
+		if stmt != nil && isUtilityNode(stmt) {
+			return verdictAccept, stmt, nil
+		}
+		return verdictReject, nil, nil
+	}
+	// Errors present. The single pending case: an EXPLAIN node was produced and
+	// every error is a "not yet supported" inner-statement stub.
+	if _, ok := stmt.(*ExplainStmt); ok && allNotYetSupported(errs) {
+		return verdictPendingInner, stmt, errs
+	}
+	return verdictReject, nil, errs
+}
+
+// allNotYetSupported reports whether every error is a downstream "not yet
+// supported" stub (the foundation's unsupported() sentinel), as opposed to a
+// real syntax error.
+func allNotYetSupported(errs []ParseError) bool {
+	if len(errs) == 0 {
+		return false
+	}
+	for _, e := range errs {
+		if !strings.Contains(e.Msg, "not yet supported") {
+			return false
+		}
+	}
+	return true
+}
+
+// parseUtility reports whether this node cleanly accepts sql (verdictAccept).
+// Pending-inner and reject both count as "not a clean accept" for the oracle-
+// free smoke tests; the oracle differential uses classifyUtility directly to
+// treat pending-inner specially.
+func parseUtility(sql string) (ast.Node, bool) {
+	v, node, _ := classifyUtility(sql)
+	return node, v == verdictAccept
+}
+
+// utilityAcceptCorpus is every utility statement this node must ACCEPT,
+// organised by the legacy alternative it exercises. Every entry has been
+// confirmed ACCEPTED by the live Trino 481 oracle (a non-SYNTAX_ERROR verdict).
+var utilityAcceptCorpus = []string{
+	// --- use ---
+	"USE information_schema",
+	"USE hive.finance",
+	"USE \"My Catalog\".\"My Schema\"",
+
+	// --- setSession / resetSession ---
+	"SET SESSION query_max_run_time = '10m'",
+	"SET SESSION example.incremental_refresh_enabled = false",
+	"SET SESSION foo = 42",
+	"SET SESSION cat.prop = ARRAY[1, 2]",
+	// SET/RESET SESSION names are NOT part-limited at parse time (semantic
+	// INVALID_SESSION_PROPERTY, not SYNTAX_ERROR) — must not over-restrict.
+	"SET SESSION a.b.c.d = 1",
+	// AUTHORIZATION as a property NAME (not the auth keyword) when followed by
+	// '.' or '=' — Trino 481 accepts these as property assignments/resets.
+	"SET SESSION AUTHORIZATION = 1",
+	"SET SESSION AUTHORIZATION.foo = 1",
+	"RESET SESSION query_max_run_time",
+	"RESET SESSION hive.optimized_reader_enabled",
+	"RESET SESSION a.b.c.d",
+	"RESET SESSION AUTHORIZATION.foo",
+
+	// --- setSessionAuthorization / resetSessionAuthorization ---
+	"SET SESSION AUTHORIZATION 'John'",
+	"SET SESSION AUTHORIZATION \"John\"",
+	"SET SESSION AUTHORIZATION John",
+	"RESET SESSION AUTHORIZATION",
+
+	// --- setRole ---
+	"SET ROLE admin",
+	"SET ROLE ALL",
+	"SET ROLE NONE",
+	"SET ROLE analyst IN hive",
+
+	// --- setPath ---
+	"SET PATH example.system",
+	"SET PATH a, b.c, d",
+
+	// --- setTimeZone ---
+	"SET TIME ZONE LOCAL",
+	"SET TIME ZONE '-08:00'",
+	"SET TIME ZONE INTERVAL '10' HOUR",
+	"SET TIME ZONE INTERVAL -'08:00' HOUR TO MINUTE",
+	"SET TIME ZONE 'America/Los_Angeles'",
+	"SET TIME ZONE concat_ws('/', 'America', 'Los_Angeles')",
+
+	// --- showGrants ---
+	"SHOW GRANTS",
+	"SHOW GRANTS ON TABLE orders",
+	"SHOW GRANTS ON orders",
+
+	// --- showCreateTable / Schema / View / MaterializedView / Function ---
+	"SHOW CREATE TABLE sf1.orders",
+	"SHOW CREATE SCHEMA hive.web",
+	"SHOW CREATE VIEW my_view",
+	"SHOW CREATE MATERIALIZED VIEW my_mv",
+	// U1: docs-ahead-of-legacy — accepted by Trino 481 (NOT_SUPPORTED, semantic).
+	"SHOW CREATE FUNCTION example.default.meaning_of_life",
+	"SHOW CREATE FUNCTION f",
+
+	// --- showTables ---
+	"SHOW TABLES",
+	"SHOW TABLES FROM tpch.tiny",
+	"SHOW TABLES IN tpch.tiny",
+	"SHOW TABLES FROM tpch.tiny LIKE 'p%'",
+	"SHOW TABLES LIKE 'p%' ESCAPE '#'",
+
+	// --- showSchemas (FROM/IN takes a single-identifier catalog) ---
+	"SHOW SCHEMAS",
+	"SHOW SCHEMAS FROM tpch",
+	"SHOW SCHEMAS IN tpch",
+	"SHOW SCHEMAS FROM tpch LIKE '__3%'",
+
+	// --- showCatalogs ---
+	"SHOW CATALOGS",
+	"SHOW CATALOGS LIKE 't%'",
+
+	// --- showColumns (FROM/IN + name both mandatory — U2) ---
+	"SHOW COLUMNS FROM nation",
+	"SHOW COLUMNS IN nation",
+	"SHOW COLUMNS FROM tpch.sf1.nation",
+	"SHOW COLUMNS FROM nation LIKE '%key'",
+
+	// --- showStats / showStatsForQuery ---
+	"SHOW STATS FOR nation",
+	"SHOW STATS FOR (SELECT * FROM nation WHERE regionkey = 1)",
+
+	// --- showRoles (CURRENT?, FROM/IN single identifier) ---
+	"SHOW ROLES",
+	"SHOW ROLES FROM hive",
+	"SHOW CURRENT ROLES",
+	"SHOW CURRENT ROLES FROM hive",
+
+	// --- showRoleGrants ---
+	"SHOW ROLE GRANTS",
+	"SHOW ROLE GRANTS FROM hive",
+
+	// --- showFunctions ---
+	"SHOW FUNCTIONS",
+	"SHOW FUNCTIONS FROM example.default",
+	"SHOW FUNCTIONS LIKE 'array%'",
+
+	// --- showSession ---
+	"SHOW SESSION",
+	"SHOW SESSION LIKE 'query%'",
+
+	// --- describe / desc (== showColumns) ---
+	"DESCRIBE nation",
+	"DESC nation",
+	"DESCRIBE tpch.sf1.nation",
+	// INPUT/OUTPUT as a TABLE name (not the prepared form): no trailing name.
+	"DESCRIBE input",
+	"DESCRIBE output",
+	"DESC input",
+
+	// --- call (E3: 1-3 part name, empty/positional/named/mixed args) ---
+	"CALL test(123, 'apple')",
+	"CALL test(name => 'apple', id => 123)",
+	"CALL p()",
+	"CALL s.p()",
+	"CALL c.s.p()",
+	"CALL system.runtime.kill_query(query_id => '20210101_000000_00000_abcde')",
+	"CALL f(name => 1, 2)",
+}
+
+// utilityRejectCorpus is every malformed utility statement this node must
+// REJECT. Every entry has been confirmed a SYNTAX_ERROR by the live Trino 481
+// oracle. These are the required negative coverage.
+var utilityRejectCorpus = []string{
+	// truncated heads
+	"SHOW",
+	"SHOW TABLES FROM",
+	"SHOW COLUMNS",      // U2: name required
+	"SHOW COLUMNS FROM", // U2: name required after FROM
+	"SHOW STATS FOR",
+	"SHOW STATS FOR (nation)",              // parens must hold a query, not a name
+	"SHOW STATS FOR (garbage tokens here)", // not a query
+	"SHOW STATS FOR ()",                    // empty parens
+	"SHOW SESSION LIKE",                    // LIKE needs a pattern
+	"SHOW CREATE TABLE",                    // name required
+	"SHOW CREATE",                          // object kind required
+	"DESCRIBE",
+	"USE",
+	"SET",
+	"SET SESSION = 'x'", // name required
+	"SET SESSION foo",   // '=' value required
+	"SET TIME ZONE",
+	"SET ROLE",
+	"SET PATH",
+	"RESET",
+	"RESET SESSION", // name or AUTHORIZATION required
+	"CALL",
+	"CALL f", // parens mandatory
+	// SHOW ROLE/ROLES disambiguation edge cases
+	"SHOW ROLE",                // ROLE needs GRANTS
+	"SHOW CURRENT ROLE GRANTS", // CURRENT only precedes ROLES, not ROLE GRANTS
+	// dotted-scope where a single identifier is required
+	"SHOW SCHEMAS FROM c.x",
+	// procedure name too long (E3)
+	"CALL c.s.p.x()",
+	// qualifiedName part limits (oracle enforces at parse time; legacy grammar
+	// is unbounded — confirmed divergence). Object names cap at 3, schema scopes
+	// at 2, path elements at 2.
+	"SHOW CREATE TABLE a.b.c.d",
+	"SHOW CREATE FUNCTION a.b.c.d",
+	"SHOW COLUMNS FROM a.b.c.d",
+	"SHOW STATS FOR a.b.c.d",
+	"SHOW GRANTS ON TABLE a.b.c.d",
+	"DESCRIBE a.b.c.d",
+	"SHOW TABLES FROM a.b.c",
+	"SHOW FUNCTIONS FROM a.b.c",
+	"SET PATH a.b.c",
+	// DESC has no INPUT/OUTPUT prepared form, and two bare names is invalid
+	"DESC INPUT a",
+	// trailing tokens after a complete statement (parseSingle trailing-token
+	// check — Trino rejects all of these too)
+	"SHOW TABLES extra",
+	"USE a b",
+	"SET ROLE ALL x",
+	"SHOW STATS FOR (SELECT 1) x",
+	"DESCRIBE a b",
+	"SET TIME ZONE LOCAL x",
+	"CALL p() x",
+	// EXPLAIN structure errors (E1/E2): the inner statement is reached only
+	// after EXPLAIN's own prefix parses, so these test EXPLAIN itself.
+	"EXPLAIN ()",              // empty option list
+	"EXPLAIN (TYPE) SELECT 1", // option value required
+	"EXPLAIN (TYPE FOO) SELECT 1",
+	"EXPLAIN (FORMAT BAR) SELECT 1",
+	"EXPLAIN x",       // inner `x` is not a statement — Trino rejects too
+	"EXPLAIN ANALYZE", // inner statement required
+}
+
+// explainCleanAcceptCorpus is EXPLAIN forms whose inner statement is already
+// implemented (a SHOW / SET / USE / CALL — this node's own statements), so the
+// whole thing parses cleanly (verdictAccept). Trino accepts all of these.
+var explainCleanAcceptCorpus = []string{
+	"EXPLAIN SHOW TABLES",
+	"EXPLAIN SHOW SCHEMAS FROM tpch",
+	"EXPLAIN ANALYZE SHOW TABLES",
+	"EXPLAIN (TYPE LOGICAL) SHOW TABLES",
+}
+
+// explainPendingAcceptCorpus is EXPLAIN forms whose inner statement is NOT yet
+// implemented (SELECT / INSERT / CREATE … — parser-select / dml / ddl DAG
+// nodes). Trino accepts them; this node parses EXPLAIN's own structure and
+// recurses, so it currently yields verdictPendingInner (the only error is the
+// inner "not yet supported" stub). They become verdictAccept once the inner
+// node lands. The differential asserts: Trino accepts AND omni is pending-or-
+// accept (never a real syntax reject) — proving EXPLAIN's own grammar is right
+// without depending on a sibling/later node.
+var explainPendingAcceptCorpus = []string{
+	"EXPLAIN SELECT 1",
+	"EXPLAIN (TYPE LOGICAL) SELECT regionkey FROM nation",
+	"EXPLAIN (TYPE LOGICAL, FORMAT JSON) SELECT 1",
+	"EXPLAIN (TYPE DISTRIBUTED) SELECT 1",
+	"EXPLAIN (TYPE VALIDATE) SELECT 1",
+	"EXPLAIN (TYPE IO, FORMAT JSON) SELECT 1",
+	"EXPLAIN (FORMAT TEXT) SELECT 1",
+	"EXPLAIN (FORMAT GRAPHVIZ) SELECT 1",
+	"EXPLAIN ANALYZE SELECT 1",
+	"EXPLAIN ANALYZE VERBOSE SELECT 1",
+	"EXPLAIN INSERT INTO t VALUES (1)",
+	"EXPLAIN CREATE TABLE t AS SELECT 1 AS x",
+}
+
+// TestUtility_AcceptCorpusParses verifies this node parses every form in
+// utilityAcceptCorpus into one of its node types with no error (oracle-free
+// completeness smoke test). The oracle differential proves the verdicts match
+// Trino.
+func TestUtility_AcceptCorpusParses(t *testing.T) {
+	accept := append(append([]string{}, utilityAcceptCorpus...), explainCleanAcceptCorpus...)
+	for _, sql := range accept {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			node, ok := parseUtility(sql)
+			if !ok {
+				_, errs := Parse(sql)
+				t.Errorf("parseUtility(%q) should accept, got errors: %v", sql, errs)
+			}
+			if ok && node == nil {
+				t.Errorf("parseUtility(%q) accepted but returned nil node", sql)
+			}
+		})
+	}
+}
+
+// TestUtility_ExplainPendingInner verifies the EXPLAIN-wraps-an-unimplemented-
+// inner-statement cases (E1): EXPLAIN's own grammar parses, and the result is
+// pending-inner (the only error is the inner "not yet supported" stub) — never
+// a real syntax rejection. This proves EXPLAIN's structure is correct without
+// depending on the inner DAG node (parser-select / dml / ddl). Once those land,
+// these become verdictAccept (the differential below tolerates both).
+func TestUtility_ExplainPendingInner(t *testing.T) {
+	for _, sql := range explainPendingAcceptCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			v, _, errs := classifyUtility(sql)
+			if v == verdictReject {
+				t.Errorf("classifyUtility(%q) = reject, want accept or pending-inner (errs=%v)", sql, errs)
+			}
+		})
+	}
+}
+
+// TestUtility_RejectCorpusRejected verifies this node rejects every form in
+// utilityRejectCorpus (required negative coverage).
+func TestUtility_RejectCorpusRejected(t *testing.T) {
+	for _, sql := range utilityRejectCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, ok := parseUtility(sql); ok {
+				t.Errorf("parseUtility(%q) should reject, but accepted", sql)
+			}
+		})
+	}
+}
+
+// TestUtility_OracleDifferential is the authoritative accept/reject gate: for
+// every form in both corpora, this node's accept/reject must equal Trino 481's
+// accept/reject of the same statement. Skipped when no oracle is reachable.
+func TestUtility_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+
+	check := func(t *testing.T, sql string) {
+		_, omniAccepts := parseUtility(sql)
+
+		trinoAccepts, ok := oracleAccepts(t, o, sql)
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			_, errs := Parse(sql)
+			t.Errorf("MISMATCH sql=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				sql, omniAccepts, errs, trinoAccepts)
+		}
+	}
+
+	t.Run("accept", func(t *testing.T) {
+		accept := append(append([]string{}, utilityAcceptCorpus...), explainCleanAcceptCorpus...)
+		for _, sql := range accept {
+			sql := sql
+			t.Run(truncateName(sql), func(t *testing.T) { check(t, sql) })
+		}
+	})
+	t.Run("reject", func(t *testing.T) {
+		for _, sql := range utilityRejectCorpus {
+			sql := sql
+			t.Run(truncateName(sql), func(t *testing.T) { check(t, sql) })
+		}
+	})
+	// EXPLAIN of an unimplemented inner statement: Trino accepts; omni must be
+	// pending-or-accept (never a real syntax reject). This is the dependency-
+	// aware slice of the differential.
+	t.Run("explain_pending", func(t *testing.T) {
+		for _, sql := range explainPendingAcceptCorpus {
+			sql := sql
+			t.Run(truncateName(sql), func(t *testing.T) {
+				v, _, errs := classifyUtility(sql)
+				trinoAccepts, ok := oracleAccepts(t, o, sql)
+				if !ok {
+					t.Skip("oracle unreachable for this case")
+				}
+				if !trinoAccepts {
+					t.Errorf("expected Trino to accept %q (pending-inner corpus), but it rejected", sql)
+				}
+				if v == verdictReject {
+					t.Errorf("MISMATCH sql=%q: omni real-rejects (errs=%v), Trino accepts; EXPLAIN's own grammar is wrong", sql, errs)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Node

`trino/parser-utility` (v2 migration DAG, migration id 3) — the grammar rule-group for Trino's SHOW family + DESCRIBE/DESC, session/catalog-context statements, and EXPLAIN / EXPLAIN ANALYZE / CALL. Spec: `docs/migration/trino/analysis.md` §6 Tier 6 + `docs/migration/trino/dag.md` (row `trino/parser-utility`). Deps: `parser-foundation`, `expressions` (both merged).

## What this implements

Legacy `TrinoParser.g4` `statement` alternatives, by file:

- **show.go** — `showGrants`, `showCreate{Table,Schema,View,MaterializedView}` (+ `ShowCreateFunction`, see U1), `showTables`, `showSchemas`, `showCatalogs`, `showColumns`, `showStats`/`showStatsForQuery`, `showRoles`, `showRoleGrants`, `showFunctions`, `showSession`, and `DESCRIBE`/`DESC` (the legacy `showColumns` aliases).
- **session.go** — `use`, `setSession`, `resetSession`, `setSessionAuthorization`, `resetSessionAuthorization`, `setRole`, `setPath`, `setTimeZone`.
- **explain_call.go** — `explain`, `explainAnalyze`, `call`.

Statement nodes are **parser-package types** (like `expr.go`'s `Expr` and `datatypes.go`'s `DataType`) that satisfy `ast.Node` via `T_*Stmt` tags added to `trino/ast/nodetags.go`. The trino `ast` tag set is closed to ast-core (`File`/`Identifier`/`QualifiedName`), and a statement embeds parser-local `Expr` children, so the structs live in `package parser` and only the tag constants live in `ast` — exactly the snowflake T6.3 (#189) precedent.

## Correctness — proven against the live Trino 481 oracle

`TestUtility_OracleDifferential` is the authoritative accept/reject gate: this node's verdict must equal Trino 481's for every corpus case (semantic errors like `NOT_SUPPORTED` count as *accepted* — the oracle keys only on `SYNTAX_ERROR`). **146 differential subtests pass, 0 mismatches.** Plus oracle-free completeness (`TestUtility_AcceptCorpusParses` / `RejectCorpusRejected`) and a structural gate (`utility_structure_test.go`, `TestUtility_Structure*` + `TestUtility_NodeTagsAndLoc`) pinning the parsed node shape (Kind / Name / scope / options / Loc) so a form that "accepts" is also parsed correctly.

Every legacy alternative in scope has a corpus case with its oracle-derived verdict; per-alternative checklist is in the corpus comment blocks.

## Divergences (oracle-adjudicated, recorded in the v2 store)

- **U1 confirmed — `SHOW CREATE FUNCTION`**: absent from the legacy grammar but documented and ACCEPTED by Trino 481 (`NOT_SUPPORTED`, semantic). Added as `ShowCreateFunction`.
- **U2 confirmed — `SHOW COLUMNS` requires `(FROM|IN) name`**: Trino rejects both `SHOW COLUMNS` and `SHOW COLUMNS FROM` despite the legacy `qualifiedName?` marking the name optional.
- **confirmed — qualifiedName part-count limits**: the legacy grammar uses the unbounded `qualifiedName` everywhere, but Trino enforces per-position caps at parse time (`SYNTAX_ERROR`): object names (`SHOW CREATE *`, `SHOW COLUMNS FROM`, `SHOW STATS FOR`, `SHOW GRANTS ON`, `DESCRIBE`) ≤ 3; schema scopes (`SHOW TABLES|FUNCTIONS FROM`) ≤ 2; `CALL` procedure name ≤ 3; `SET PATH` element ≤ 2. (Verified that `SET`/`RESET SESSION` names are NOT limited — semantic `INVALID_SESSION_PROPERTY`, so left unbounded.)
- **E2 confirmed — EXPLAIN option enum**: `FORMAT {TEXT|GRAPHVIZ|JSON}` / `TYPE {LOGICAL|DISTRIBUTED|VALIDATE|IO}` only; `EXPLAIN (TYPE FOO)` / `EXPLAIN ()` reject.
- **confirmed — `SHOW STATS FOR (...)` inner must start a query**: gated on `startsQuery()` (then captured as raw text, B1 placeholder — the `query` rule belongs to parser-select); `SHOW STATS FOR (nation)`, `()` reject.
- **confirmed — `parseSingle` trailing-token check**: a foundation gap these first real statement parsers exposed — a statement that parses but leaves tokens in its segment (`SHOW TABLES extra`, `USE a b`, `DESC INPUT a`, `SHOW SCHEMAS FROM c.x`) must error, which Trino does too.

### Scope boundaries (oracle-confirmed, deferred to siblings)

- **E1 — EXPLAIN recurses into the inner statement** (the full statement grammar). EXPLAIN of an implemented inner (SHOW/SET/USE/CALL) parses cleanly today; EXPLAIN of a not-yet-implemented inner (SELECT/INSERT/CREATE) is *pending-inner* — the `ExplainStmt` is built and the only error is the inner "not yet supported" stub — and becomes a clean accept once parser-select / dml / ddl land. `EXPLAIN x` correctly rejects. The differential is dependency-aware: it asserts EXPLAIN's own grammar is right (never a real syntax reject) without depending on a sibling/later node.
- **U3 — `DESCRIBE INPUT`/`OUTPUT`** (prepared-statement introspection) belong to `parser-dcl-tcl` (`prepared.go`); they route to the unsupported stub until that node lands. The `DESCRIBE`-vs-`DESC` and `INPUT`/`OUTPUT`-as-table-name disambiguation is the oracle's (`DESCRIBE input` is a table; `DESCRIBE INPUT a` is the prepared form; `DESC INPUT a` rejects).

## Out-of-scope writes (recorded, necessary — snowflake T6.3 precedent)

This node's declared `writes_globs` are `trino/parser/{show,session,explain_call}.go`. Also touched (a statement-group node must wire the shared dispatch + AST, exactly as snowflake #189 did):

- `trino/ast/nodetags.go` — `T_*Stmt` tag constants + `String()`.
- `trino/parser/parser.go` — wire the `USE`/`SET`/`RESET`/`SHOW`/`EXPLAIN`/`DESCRIBE`/`DESC`/`CALL` dispatch cases, and the `parseSingle` trailing-token check (the confirmed foundation-gap fix above).
- `trino/parser/parser_test.go` — `TestParse_DispatchKeywordsRecognized` now probes EXPLAIN with `EXPLAIN SELECT 1` (EXPLAIN recurses, so the old `EXPLAIN x` routed the inner bare `x` to the default branch — which Trino also rejects).
- `trino/parser/utility_test.go`, `trino/parser/utility_structure_test.go` — the node's test files.

## Tests

`go test ./trino/parser/` is green for all parser-utility tests and every other parser test. The one remaining failure — `TestLexer_OracleDifferential` on a backtick-quoted identifier — is **pre-existing and unrelated** (already spun off as a separate task; backticks aren't valid Trino 481 identifiers and the lexer corpus includes one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)