### PR TITLE
fix(partiql): recover FROM...MATCH source relation in analysis.extractTables

### DIFF
--- a/partiql/analysis/analysis.go
+++ b/partiql/analysis/analysis.go
@@ -114,6 +114,18 @@ func extractTables(te ast.TableExpr) []string {
 		left := extractTables(v.Left)
 		right := extractTables(v.Right)
 		return append(left, right...)
+	case *ast.MatchExpr:
+		// FROM-position graph match: `FROM <source> MATCH <pattern>`. The
+		// relation being matched is MatchExpr.Expr (the left-hand FROM source the
+		// MATCH is applied to), e.g. `g` in `SELECT * FROM g MATCH (n)`. The parser
+		// binds that source to the same node an ordinary FROM source would (a
+		// VarRef for `g`, a PathExpr for `s.g`), both of which satisfy TableExpr,
+		// so recurse to collect it exactly like a plain FROM source. The graph
+		// pattern itself binds no base relations, so only Expr is walked.
+		if src, ok := v.Expr.(ast.TableExpr); ok {
+			return extractTables(src)
+		}
+		return nil
 	case *ast.SubLink:
 		// subquery in FROM — no simple table name
 		return nil

--- a/partiql/analysis/analysis_test.go
+++ b/partiql/analysis/analysis_test.go
@@ -184,6 +184,69 @@ func TestAnalyze_JoinTables(t *testing.T) {
 	}
 }
 
+// TestAnalyze_MatchSource asserts that a FROM-position graph MATCH collects its
+// underlying source relation just like an ordinary FROM source. In
+// `SELECT * FROM g MATCH (n)` the relation being matched is `g`; the parser
+// models this as a *ast.MatchExpr whose Expr is the source (here VarRef{g}).
+// Before the fix extractTables had no *ast.MatchExpr case and silently dropped
+// the source, yielding an empty Tables slice.
+//
+// Oracle: official PartiQL graph-match docs define `FROM <graph> MATCH <pattern>`
+// where <graph> is the source relation; the parser already binds `g` as a VarRef
+// (the same node an ordinary `FROM g` produces), so collecting it is spec-correct.
+func TestAnalyze_MatchSource(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Unparenthesised FROM...MATCH (exprGraphMatchOne):
+		// parser.From is *ast.MatchExpr{Expr: VarRef{g}}.
+		{"unparenthesised", "SELECT * FROM g MATCH (n)", "g"},
+		// Parenthesised single-pattern form (exprGraphMatchMany via
+		// parseParenExpr): also lands as *ast.MatchExpr{Expr: VarRef{g}}.
+		{"parenthesised", "SELECT * FROM (g MATCH (n))", "g"},
+		// A richer pattern (node-edge-node) does not change the source relation.
+		{"with edge pattern", "SELECT * FROM g MATCH (a)-[e]->(b)", "g"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			sel := parseSelect(t, tc.input)
+			qa := Analyze(sel)
+			if len(qa.Tables) != 1 || qa.Tables[0] != tc.want {
+				t.Errorf("Analyze(%q).Tables = %v, want [%s]", tc.input, qa.Tables, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnalyze_MatchSourcePath asserts that a schema-qualified graph source
+// (`s.g MATCH ...`) collects the path root `s`, matching how extractTables
+// already treats an ordinary `FROM s.g` (a PathExpr rooted at VarRef{s}).
+func TestAnalyze_MatchSourcePath(t *testing.T) {
+	sel := parseSelect(t, "SELECT * FROM s.g MATCH (n)")
+	qa := Analyze(sel)
+	if len(qa.Tables) != 1 || qa.Tables[0] != "s" {
+		t.Errorf("Analyze(%q).Tables = %v, want [s]", "SELECT * FROM s.g MATCH (n)", qa.Tables)
+	}
+}
+
+// TestAnalyze_MatchSourceInJoin asserts a FROM...MATCH source on one side of a
+// join is collected alongside the ordinary join source. The parenthesised MATCH
+// keeps it a distinct join arm: `(g MATCH (n))` is *ast.MatchExpr, joined with t.
+func TestAnalyze_MatchSourceInJoin(t *testing.T) {
+	sel := parseSelect(t, "SELECT * FROM (g MATCH (n)), t")
+	qa := Analyze(sel)
+	tableSet := map[string]bool{}
+	for _, tbl := range qa.Tables {
+		tableSet[tbl] = true
+	}
+	if len(qa.Tables) != 2 || !tableSet["g"] || !tableSet["t"] {
+		t.Errorf("Analyze(...).Tables = %v, want [g t]", qa.Tables)
+	}
+}
+
 func TestAnalyze_LiteralProjection(t *testing.T) {
 	sel := parseSelect(t, "SELECT 1 FROM t")
 	qa := Analyze(sel)


### PR DESCRIPTION
## Node

PartiQL migration follow-up fix (surfaced during the graph `#183` node): `partiql/analysis` `extractTables` had no case for `*ast.MatchExpr`, so a FROM-position graph match silently dropped its source relation.

## Problem

A FROM-position graph match such as `SELECT * FROM g MATCH (n)` parses with `SelectStmt.From` set to `*ast.MatchExpr{Expr: VarRef{g}, ...}` — `MatchExpr` is a `TableExpr` so it flows into the FROM position directly (see `partiql/ast/patterns.go` and `parseGraphMatchOne`/`parseGraphMatch` in `partiql/parser/graph.go`). `extractTables` switched over `TableExpr` but had no `*ast.MatchExpr` arm, so it fell through to `default: return nil`. Result: the source relation `g` was never collected (no crash, just a missing table). In a join like `SELECT * FROM (g MATCH (n)), t`, only `t` was collected while `g` was dropped.

## Fix

`partiql/analysis/analysis.go` — add an `*ast.MatchExpr` case to `extractTables` that recurses into `MatchExpr.Expr` (the left-hand FROM source the MATCH is applied to). The graph source is bound to the same AST node an ordinary FROM source would be, so recursion reuses the existing handling:

| Graph source | `MatchExpr.Expr` type | Collected |
|---|---|---|
| `FROM g MATCH ...` | `*ast.VarRef` | `g` (via existing VarRef case) |
| `FROM s.g MATCH ...` | `*ast.PathExpr` | `s` (via existing PathExpr case) |
| `FROM g[0] MATCH ...` | `*ast.PathExpr` | `g` |
| `FROM (SELECT ...) MATCH ...` | `*ast.SubLink` (is a TableExpr) | nil (subquery, no base relation) |
| `FROM foo() MATCH ...` | `*ast.FuncCall` (NOT a TableExpr) | nil (guarded by the type-assert `ok`) |

The `v.Expr.(ast.TableExpr)` guard is load-bearing: a non-relation source (FuncCall) is not a `TableExpr`, so it yields no table — matching the existing `SubLink`/`UnpivotExpr` fallthrough. A nil-interface assertion is safe, and `MatchExpr.Expr` is never nil in practice (it is the already-parsed `lhs`).

This is the right altitude: the source is collected identically to a plain FROM source rather than via a bespoke name grab. `extractTables` is the only FROM-source walker in the engine (no sibling walker to update).

## Oracle

`antlr_fallback`. truth1 = official PartiQL graph-match docs, which define `FROM <graph> MATCH <pattern>` where `<graph>` is the source relation; truth2 = `PartiQL{Parser,Lexer}.g4` (`exprGraphMatchOne` g4:628-629, `tableBaseReference#TableBaseRefMatch` g4:405). The parser already binds the graph source to the same node an ordinary `FROM g` produces, so collecting it is spec-correct. This is a coverage-gap recovery (a dropped relation), not a behavior change with a competing interpretation — **no divergence packet**.

## Tests (`partiql/analysis/analysis_test.go`)

Each input's AST shape was confirmed empirically against the parser before asserting:

- `TestAnalyze_MatchSource` — `FROM g MATCH (n)` (unparenthesised `exprGraphMatchOne`), `FROM (g MATCH (n))` (parenthesised `exprGraphMatchMany`), and `FROM g MATCH (a)-[e]->(b)` all collect `[g]`.
- `TestAnalyze_MatchSourcePath` — `FROM s.g MATCH (n)` collects `[s]` (path root), matching plain `FROM s.g`.
- `TestAnalyze_MatchSourceInJoin` — `FROM (g MATCH (n)), t` collects both `g` and `t` (exercises `JoinExpr → MatchExpr → VarRef` recursion; this is the case that previously dropped `g`).

All five new sub-cases failed before the fix (RED) and pass after (GREEN). No negative/reject case applies — this node neither accepts nor rejects syntax; it walks an already-parsed AST.

## Verify

- `go build ./partiql/...` — OK
- `go test -race ./partiql/parser/ ./partiql/analysis/` — ok
- `go test ./partiql/...` — all packages ok (partiql, analysis, ast, catalog, completion, parser)
- `go vet ./partiql/analysis/` + `gofmt` — clean

## Review

Claude lens (`/code-review`, max effort): no blocking findings. Verified no nil/panic hazard (nil-interface assertion is safe; `Expr` always non-nil), no caller breakage (`extractTables` return shape unchanged, only called from `Analyze` + recursively), no removed behavior. Codex lens re-run by the orchestrator.

## Scope

Touched only `partiql/analysis/analysis.go` + `analysis_test.go` (declared writes). No out-of-scope writes. SQLite store untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)