### PR TITLE
fix(partiql): surface trailing lexer errors at parse entry points

### DIFF
--- a/partiql/parser/parse.go
+++ b/partiql/parser/parse.go
@@ -56,6 +56,17 @@ func (p *Parser) parseScript() (*ast.List, error) {
 		stmts = append(stmts, stmt)
 	}
 
+	// Surface trailing garbage that lexed to a LEXER error before the EOF
+	// check below (see Parser.ParseExpr for the first-error-and-stop
+	// rationale): a trailing '#' or unterminated '/*' after the final
+	// statement sets p.lexer.Err and makes advance() yield tokEOF, so the
+	// cur==tokEOF check would otherwise pass and drop the pending lexer
+	// error. This entry point backs the public Parse function consumed by
+	// partiql/analysis, so the gap is reachable from bytebase.
+	if err := p.checkLexerErr(); err != nil {
+		return nil, err
+	}
+
 	if p.cur.Type != tokEOF {
 		return nil, &ParseError{
 			Message: "unexpected token after statement",

--- a/partiql/parser/parse_test.go
+++ b/partiql/parser/parse_test.go
@@ -217,3 +217,93 @@ func TestParseStatement_Exec(t *testing.T) {
 		})
 	}
 }
+
+// TestParse_TrailingLexerError verifies that the script-level entry point
+// (Parse -> parseScript) surfaces trailing garbage that lexes to a LEXER error
+// rather than silently dropping it. parseScript calls checkLexerErr() at entry
+// but, before the fix, never after: once the trailing '#' / unterminated '/*'
+// set p.lexer.Err, advance() yields tokEOF, the post-parse `cur==tokEOF` check
+// passes, and the pending lexer error was lost. Oracle (antlr_fallback,
+// PartiQLLexer.g4): '#' matches only UNRECOGNIZED (default channel) and an
+// unterminated '/*' cannot match COMMENT_BLOCK, so ANTLR rejects both; closed
+// comments and whitespace are HIDDEN-channel and must still be accepted.
+func TestParse_TrailingLexerError(t *testing.T) {
+	bases := []string{
+		"SELECT a FROM t",
+		"CREATE TABLE t",
+		"DROP TABLE t",
+		"INSERT INTO t VALUE 1",
+		"UPDATE t SET x = 1",
+		"DELETE FROM t",
+	}
+	for _, base := range bases {
+		t.Run(base+" #", func(t *testing.T) {
+			input := base + " #"
+			_, err := Parse(input)
+			if err == nil {
+				t.Fatalf("Parse(%q) = nil error, want trailing-lexer-error rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unexpected character") {
+				t.Errorf("Parse(%q) error = %q, want to contain %q", input, err.Error(), "unexpected character")
+			}
+		})
+		t.Run(base+" /*", func(t *testing.T) {
+			input := base + " /*"
+			_, err := Parse(input)
+			if err == nil {
+				t.Fatalf("Parse(%q) = nil error, want trailing-lexer-error rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unterminated block comment") {
+				t.Errorf("Parse(%q) error = %q, want to contain %q", input, err.Error(), "unterminated block comment")
+			}
+		})
+	}
+
+	// A lexer error on a trailing statement AFTER a semicolon must also surface
+	// (the multi-root loop path), not just on the first statement.
+	t.Run("trailing_stmt_after_semicolon", func(t *testing.T) {
+		input := "SELECT a FROM t; SELECT b FROM u #"
+		_, err := Parse(input)
+		if err == nil {
+			t.Fatalf("Parse(%q) = nil error, want trailing-lexer-error rejection", input)
+		}
+		if !strings.Contains(err.Error(), "unexpected character") {
+			t.Errorf("Parse(%q) error = %q, want to contain %q", input, err.Error(), "unexpected character")
+		}
+	})
+
+	// Garbage IMMEDIATELY after a semicolon exercises the loop's
+	// trailing-semicolon `break` path (the lexer error is set while scanning
+	// for the next root, which yields tokEOF and breaks the loop): the
+	// post-loop checkLexerErr must still surface it.
+	t.Run("garbage_immediately_after_semicolon", func(t *testing.T) {
+		for _, tc := range []struct{ input, want string }{
+			{"SELECT a FROM t ; #", "unexpected character"},
+			{"SELECT a FROM t ; /*", "unterminated block comment"},
+		} {
+			_, err := Parse(tc.input)
+			if err == nil {
+				t.Fatalf("Parse(%q) = nil error, want trailing-lexer-error rejection", tc.input)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Parse(%q) error = %q, want to contain %q", tc.input, err.Error(), tc.want)
+			}
+		}
+	})
+
+	// Valid trailing whitespace / closed comments and a trailing semicolon must
+	// STILL parse cleanly (HIDDEN-channel content must not regress).
+	t.Run("valid_trailing_accepted", func(t *testing.T) {
+		for _, input := range []string{
+			"SELECT a FROM t -- ok",
+			"SELECT a FROM t /* closed */",
+			"SELECT a FROM t;",
+			"SELECT a FROM t; -- ok",
+			"SELECT a FROM t   ",
+		} {
+			if _, err := Parse(input); err != nil {
+				t.Errorf("Parse(%q) unexpected error: %v", input, err)
+			}
+		}
+	})
+}

--- a/partiql/parser/parser.go
+++ b/partiql/parser/parser.go
@@ -247,6 +247,16 @@ func (p *Parser) ParseExpr() (ast.ExprNode, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Surface trailing garbage that lexed to a LEXER error before the EOF
+	// check below. The lexer is first-error-and-stop: trailing garbage such
+	// as a stray UNRECOGNIZED character ('#') or an unterminated block
+	// comment ('/*') sets p.lexer.Err and makes advance() yield tokEOF, so
+	// the cur==tokEOF check would otherwise pass and silently drop the
+	// pending lexer error. checkLexerErr() must run first so the lexer
+	// diagnostic wins over the generic "unexpected token" message.
+	if err := p.checkLexerErr(); err != nil {
+		return nil, err
+	}
 	if p.cur.Type != tokEOF {
 		return nil, &ParseError{
 			Message: fmt.Sprintf("unexpected token %q after expression", p.cur.Str),
@@ -722,6 +732,14 @@ func (p *Parser) ParseStatement() (ast.StmtNode, error) {
 		}
 	}
 	if err != nil {
+		return nil, err
+	}
+	// Surface trailing garbage that lexed to a LEXER error before the EOF
+	// check below (see ParseExpr for the first-error-and-stop rationale): a
+	// trailing '#' or unterminated '/*' sets p.lexer.Err and makes advance()
+	// yield tokEOF, so the cur==tokEOF check would otherwise pass and drop
+	// the pending lexer error.
+	if err := p.checkLexerErr(); err != nil {
 		return nil, err
 	}
 	if p.cur.Type != tokEOF {

--- a/partiql/parser/parser_test.go
+++ b/partiql/parser/parser_test.go
@@ -985,3 +985,147 @@ func TestParser_FuncCall(t *testing.T) {
 		})
 	}
 }
+
+// TestParseExpr_TrailingLexerError verifies that trailing garbage which lexes
+// to a LEXER error (an UNRECOGNIZED character like '#', or an unterminated
+// block comment '/*') after an otherwise-complete expression is surfaced as a
+// parse error rather than silently swallowed. The lexer uses first-error-and-
+// stop: once the trailing garbage sets p.lexer.Err, advance() yields tokEOF,
+// so the post-parse `cur==tokEOF` check passes and the pending lexer error
+// would be dropped without an explicit post-parse checkLexerErr().
+//
+// Oracle (antlr_fallback, PartiQLLexer.g4): '#' matches only UNRECOGNIZED
+// (line 372-373, default channel — a real token the parser sees, never hidden),
+// and an unterminated '/*' cannot match COMMENT_BLOCK (line 369-370, which
+// requires a closing '*/'). ANTLR therefore rejects both trailing forms; the
+// valid HIDDEN-channel forms (closed block comment, line comment, whitespace)
+// are invisible to the parser and must still be accepted.
+func TestParseExpr_TrailingLexerError(t *testing.T) {
+	// Each base expression is paired with trailing garbage that produces a
+	// lexer error. Both the '#' (UNRECOGNIZED) and the unterminated '/*'
+	// (unterminated block comment) forms must be rejected.
+	bases := []struct {
+		name string
+		expr string
+	}{
+		{"int_literal", "42"},
+		{"string_literal", "'str'"},
+		{"identifier", "foo"},
+		{"select", "SELECT a FROM t"},
+		{"funccall", "f(x)"},
+		{"path", "a.b.c"},
+	}
+	for _, b := range bases {
+		t.Run(b.name+"_trailing_hash", func(t *testing.T) {
+			input := b.expr + " #"
+			p := NewParser(input)
+			_, err := p.ParseExpr()
+			if err == nil {
+				t.Fatalf("ParseExpr(%q) = nil error, want trailing-lexer-error rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unexpected character") {
+				t.Errorf("ParseExpr(%q) error = %q, want to contain %q", input, err.Error(), "unexpected character")
+			}
+		})
+		t.Run(b.name+"_trailing_unterminated_block", func(t *testing.T) {
+			input := b.expr + " /*"
+			p := NewParser(input)
+			_, err := p.ParseExpr()
+			if err == nil {
+				t.Fatalf("ParseExpr(%q) = nil error, want trailing-lexer-error rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unterminated block comment") {
+				t.Errorf("ParseExpr(%q) error = %q, want to contain %q", input, err.Error(), "unterminated block comment")
+			}
+		})
+	}
+
+	// Trailing VALID tokens are already rejected by the existing EOF
+	// "unexpected token after expression" check — verify the fix does not
+	// disturb that path.
+	t.Run("trailing_valid_token_still_rejected", func(t *testing.T) {
+		for _, input := range []string{"42 99", "foo bar"} {
+			p := NewParser(input)
+			_, err := p.ParseExpr()
+			if err == nil {
+				t.Fatalf("ParseExpr(%q) = nil error, want rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unexpected token") {
+				t.Errorf("ParseExpr(%q) error = %q, want to contain %q", input, err.Error(), "unexpected token")
+			}
+		}
+	})
+
+	// Valid trailing whitespace and CLOSED comments must STILL be accepted —
+	// they are HIDDEN-channel in the grammar and must not regress.
+	t.Run("valid_trailing_accepted", func(t *testing.T) {
+		for _, input := range []string{
+			"42 -- ok",
+			"42 /* closed */",
+			"42   ",
+			"42\t\n",
+			"foo /* a */",
+		} {
+			p := NewParser(input)
+			if _, err := p.ParseExpr(); err != nil {
+				t.Errorf("ParseExpr(%q) unexpected error: %v", input, err)
+			}
+		}
+	})
+}
+
+// TestParseStatement_TrailingLexerError mirrors TestParseExpr_TrailingLexerError
+// for the statement entry point. Every fully-parsed statement form (DQL/DDL/DML)
+// followed by lexer-error trailing garbage must be rejected, while valid hidden
+// trailing content (closed comments, whitespace) is still accepted.
+func TestParseStatement_TrailingLexerError(t *testing.T) {
+	bases := []struct {
+		name string
+		stmt string
+	}{
+		{"select", "SELECT a FROM t"},
+		{"create_table", "CREATE TABLE t"},
+		{"drop_table", "DROP TABLE t"},
+		{"insert", "INSERT INTO t VALUE 1"},
+		{"update", "UPDATE t SET x = 1"},
+		{"delete", "DELETE FROM t"},
+	}
+	for _, b := range bases {
+		t.Run(b.name+"_trailing_hash", func(t *testing.T) {
+			input := b.stmt + " #"
+			p := NewParser(input)
+			_, err := p.ParseStatement()
+			if err == nil {
+				t.Fatalf("ParseStatement(%q) = nil error, want trailing-lexer-error rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unexpected character") {
+				t.Errorf("ParseStatement(%q) error = %q, want to contain %q", input, err.Error(), "unexpected character")
+			}
+		})
+		t.Run(b.name+"_trailing_unterminated_block", func(t *testing.T) {
+			input := b.stmt + " /*"
+			p := NewParser(input)
+			_, err := p.ParseStatement()
+			if err == nil {
+				t.Fatalf("ParseStatement(%q) = nil error, want trailing-lexer-error rejection", input)
+			}
+			if !strings.Contains(err.Error(), "unterminated block comment") {
+				t.Errorf("ParseStatement(%q) error = %q, want to contain %q", input, err.Error(), "unterminated block comment")
+			}
+		})
+	}
+
+	t.Run("valid_trailing_accepted", func(t *testing.T) {
+		for _, input := range []string{
+			"SELECT a FROM t -- ok",
+			"SELECT a FROM t /* closed */",
+			"CREATE TABLE t   ",
+			"INSERT INTO t VALUE 1 /* c */",
+		} {
+			p := NewParser(input)
+			if _, err := p.ParseStatement(); err != nil {
+				t.Errorf("ParseStatement(%q) unexpected error: %v", input, err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Problem

The PartiQL parser silently swallowed trailing garbage that lexes to a **LEXER error**. These inputs parsed as **SUCCESS** but must be rejected:

- `42 #`, `'str' /*`, `foo #`
- `SELECT a FROM t #`
- `INSERT INTO t VALUE 1 #`

A trailing `#` (an `UNRECOGNIZED` character) or an unterminated `/*` (unterminated block comment) sets `p.lexer.Err`, yet the parse returned success.

This is reachable from bytebase: `analysis.ValidateQuery` parses via `parser.Parse` (→ `parseScript`), so it would previously **accept a DQL query with trailing garbage**.

## Root cause

The lexer is **first-error-and-stop**: once trailing garbage sets `p.lexer.Err`, `advance()` yields `tokEOF`. The three public/internal entry points — `ParseExpr` (`partiql/parser/parser.go`), `ParseStatement` (`partiql/parser/parser.go`), and `parseScript` (`partiql/parser/parse.go`) — call `p.checkLexerErr()` at **entry** (before parsing) but never **after**. When trailing garbage lexes to a lexer error, the post-parse `cur == tokEOF` check is satisfied, so the pending lexer error is dropped.

Trailing **valid** tokens (e.g. `42 99`) were already correctly rejected by the existing EOF `"unexpected token after expression"` check — only lexer-error-producing trailing garbage was swallowed.

## Fix

Minimal and additive: add a post-parse `p.checkLexerErr()` in `ParseExpr`, `ParseStatement`, and `parseScript`, placed **before** the trailing-EOF check so the lexer diagnostic wins over the generic "unexpected token" message. Reuses the existing `checkLexerErr()` helper.

## Oracle (antlr_fallback)

Verified **differentially** against the generated ANTLR PartiQL parser (`github.com/bytebase/parser/partiql`) driving its top-level `Script()` rule, plus `PartiQLLexer.g4` (truth2):

- `#` matches only `UNRECOGNIZED : . ;` (default channel → a real token the parser sees, never hidden); an unterminated `/*` cannot match `COMMENT_BLOCK : '/*' .*? '*/'`.
- ANTLR **rejects** every `<form> #` and `<form> /*` case tested (literal, identifier, path, func-call, SELECT, CREATE/DROP TABLE, INSERT, UPDATE, DELETE, post-semicolon), and **accepts** closed block comments, line comments, whitespace, and trailing semicolons — byte-for-byte matching this fix's accept/reject verdicts.

Benign message-only difference (not a behavior divergence): ANTLR classifies these as *parser* errors on the UNRECOGNIZED token, while omni reports them as *lexer* errors (`"unexpected character"` / `"unterminated block comment"`). The accept/reject **verdict is identical** — which is what the oracle gate decides on.

## Tests added

Broad accept/reject matrix (`partiql/parser/parser_test.go`, `partiql/parser/parse_test.go`):

- **Reject** `<form> #` and `<form> /*` for: int literal, string literal, identifier, path, func-call (`ParseExpr`); SELECT / CREATE TABLE / DROP TABLE / INSERT / UPDATE / DELETE (`ParseStatement` and `Parse`/script).
- Script-level: lexer error on a statement **after** a semicolon, and garbage **immediately after** a semicolon (exercises the trailing-semicolon `break` path).
- **Keep accepting**: trailing whitespace, line comments (`-- ok`), closed block comments (`/* closed */`), trailing semicolons.
- Guard: trailing **valid** tokens (`42 99`, `foo bar`) still rejected with the existing message.

## Verification

- `go build ./partiql/...` — OK
- `go test -race ./partiql/parser/ ./partiql/analysis/` — pass
- `go test ./partiql/...` — pass (all 6 packages)
- `gofmt` clean

## Review

Claude lens (`/code-review`, high effort): zero blocking findings. Codex lens re-run by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)