### PR TITLE
fix(tidb/parser): balance inner END in routine compound bodies

### DIFF
--- a/tidb/parser/alter_misc.go
+++ b/tidb/parser/alter_misc.go
@@ -240,32 +240,7 @@ func (p *Parser) parseAlterEventStmt() (*nodes.AlterEventStmt, error) {
 	// Optional: DO event_body
 	if p.cur.Type == kwDO {
 		p.advance()
-		bodyStart := p.pos()
-		depth := 0
-		for p.cur.Type != tokEOF {
-			if p.cur.Type == ';' && depth == 0 {
-				break
-			}
-			if p.cur.Type == kwBEGIN {
-				depth++
-			}
-			if p.cur.Type == kwEND {
-				if depth > 0 {
-					depth--
-					if depth == 0 {
-						p.advance()
-						break
-					}
-				} else {
-					break
-				}
-			}
-			p.advance()
-		}
-		bodyEnd := p.pos()
-		if bodyEnd > bodyStart {
-			stmt.Body = p.inputText(bodyStart, bodyEnd)
-		}
+		stmt.Body = p.consumeRoutineBody()
 	}
 
 	stmt.Loc.End = p.pos()

--- a/tidb/parser/create_function.go
+++ b/tidb/parser/create_function.go
@@ -191,33 +191,9 @@ func (p *Parser) parseCreateFunctionStmt(isProcedure bool) (*nodes.CreateFunctio
 		stmt.Characteristics = append(stmt.Characteristics, ch)
 	}
 
-	// Routine body — consume everything until we hit a semicolon or EOF
-	bodyStart := p.pos()
-	depth := 0
-	for p.cur.Type != tokEOF {
-		if p.cur.Type == ';' && depth == 0 {
-			break
-		}
-		if p.cur.Type == kwBEGIN {
-			depth++
-		}
-		if p.cur.Type == kwEND {
-			if depth > 0 {
-				depth--
-				if depth == 0 {
-					p.advance()
-					break
-				}
-			} else {
-				break
-			}
-		}
-		p.advance()
-	}
-	bodyEnd := p.pos()
-	if bodyEnd > bodyStart {
-		stmt.Body = p.inputText(bodyStart, bodyEnd)
-	}
+	// Routine body — balances inner block terminators (END IF / END CASE / ...)
+	// so they don't truncate the body at the inner END.
+	stmt.Body = p.consumeRoutineBody()
 
 	stmt.Loc.End = p.pos()
 	return stmt, nil

--- a/tidb/parser/parser.go
+++ b/tidb/parser/parser.go
@@ -178,6 +178,30 @@ func (p *Parser) inputText(start, end int) string {
 	return p.lexer.input[start:end]
 }
 
+// consumeRoutineBody captures a routine/trigger/event compound body as raw text,
+// advancing the token stream past it. It balances all compound openers against
+// END (via findCompoundBodyEnd) so an inner END IF / END CASE / END WHILE /
+// END LOOP / END REPEAT does not truncate the body at the inner block's END.
+// Returns the body text from the current position up to (but excluding) the
+// first top-level ';' or end of input.
+func (p *Parser) consumeRoutineBody() string {
+	bodyStartAbs := p.pos()
+	bodyStartLocal := bodyStartAbs - p.lexer.baseOffset
+	if bodyStartLocal < 0 {
+		bodyStartLocal = 0
+	}
+	bodyEndAbs := findCompoundBodyEnd(p.lexer.input, bodyStartLocal) + p.lexer.baseOffset
+	for p.cur.Type != tokEOF && p.cur.Loc < bodyEndAbs {
+		p.advance()
+	}
+	// Capture via inputText, not a direct lexer.input slice: tokenizing the body
+	// above can rewrite lexer.input in place (conditional comments /*! ... */),
+	// so the body offset computed before the loop would be stale against the
+	// shrunken buffer. inputText reads the post-advance buffer with the current
+	// p.pos() and clamps to its length, matching the original scanner's slice.
+	return p.inputText(bodyStartAbs, p.pos())
+}
+
 // ParseError represents a parse error with position information.
 type ParseError struct {
 	Message     string

--- a/tidb/parser/routine_body_test.go
+++ b/tidb/parser/routine_body_test.go
@@ -108,6 +108,10 @@ func TestFindCompoundBodyEnd(t *testing.T) {
 		// still a function call, so the scan stops at the body's top-level ';'.
 		{"if_function_conditional_comment", `BEGIN SELECT IF /*!50000*/ (1,2,3); END; SELECT 4`, `BEGIN SELECT IF /*!50000*/ (1,2,3); END`},
 		{"repeat_function_conditional_comment", `BEGIN SELECT REPEAT /*!50000*/ ('a',2); END; SELECT 4`, `BEGIN SELECT REPEAT /*!50000*/ ('a',2); END`},
+		// Non-empty conditional comment = executable SQL: IF /*!... EXISTS */ (...)
+		// is a compound IF (counted), so its END IF balances and the scan stops
+		// at the body's top-level ';'.
+		{"if_compound_conditional_comment", `BEGIN IF /*!50000 EXISTS */ (SELECT 1 FROM t) THEN SELECT 1; END IF; END; SELECT 2`, `BEGIN IF /*!50000 EXISTS */ (SELECT 1 FROM t) THEN SELECT 1; END IF; END`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -211,6 +215,10 @@ func TestRoutineBodyDoesNotSwallowTrailingStatement(t *testing.T) {
 		// function paren — still a function call, not a compound opener.
 		{"if_function_conditional_comment", `CREATE PROCEDURE p() BEGIN SELECT IF /*!50000*/ (1,2,3); END; SELECT 4`},
 		{"repeat_function_conditional_comment", `CREATE PROCEDURE p() BEGIN SELECT REPEAT /*!50000*/ ('a',2); END; SELECT 4`},
+		// A NON-empty conditional comment holds executable SQL: `IF /*!50000 EXISTS */ (...)`
+		// expands to `IF EXISTS (...)`, a compound IF, so the IF must be counted
+		// and its END IF balances (it is not the IF(...) function).
+		{"if_compound_conditional_comment", `CREATE PROCEDURE p() BEGIN IF /*!50000 EXISTS */ (SELECT 1 FROM t) THEN SELECT 1; END IF; END; SELECT 2`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/tidb/parser/routine_body_test.go
+++ b/tidb/parser/routine_body_test.go
@@ -100,6 +100,10 @@ func TestFindCompoundBodyEnd(t *testing.T) {
 		// scan stops at the body's top-level ';' instead of over-counting and
 		// swallowing the following statement.
 		{"if_exists_ddl_stops_at_semicolon", `BEGIN DROP TABLE IF EXISTS t; END; SELECT 2`, `BEGIN DROP TABLE IF EXISTS t; END`},
+		// IF(...) / REPEAT(...) functions with a comment before '(' are not
+		// compound openers, so the scan stops at the body's top-level ';'.
+		{"if_function_comment_before_paren", `BEGIN SELECT IF /*c*/ (1,2,3); END; SELECT 4`, `BEGIN SELECT IF /*c*/ (1,2,3); END`},
+		{"repeat_function_comment_before_paren", `BEGIN SELECT REPEAT /*c*/ ('a',2); END; SELECT 4`, `BEGIN SELECT REPEAT /*c*/ ('a',2); END`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -194,6 +198,11 @@ func TestRoutineBodyDoesNotSwallowTrailingStatement(t *testing.T) {
 		// rejects DDL inside a procedure body, so this pins omni's split
 		// correctness, not TiDB parity.
 		{"ddl_if_exists_custom_delimiter", "DELIMITER //\nCREATE PROCEDURE p() BEGIN DROP TABLE IF EXISTS t; END; SELECT 2//"},
+		// IF(...) / REPEAT(...) are built-in functions, not compound openers,
+		// even with a comment between the keyword and '('. TiDB v8.5.0 accepts
+		// SELECT IF /*c*/ (1,2,3) and SELECT REPEAT /*c*/ ('a',2).
+		{"if_function_comment_before_paren", `CREATE PROCEDURE p() BEGIN SELECT IF /*c*/ (1,2,3); END; SELECT 4`},
+		{"repeat_function_comment_before_paren", `CREATE PROCEDURE p() BEGIN SELECT REPEAT /*c*/ ('a',2); END; SELECT 4`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/tidb/parser/routine_body_test.go
+++ b/tidb/parser/routine_body_test.go
@@ -1,0 +1,167 @@
+package parser
+
+import (
+	"testing"
+
+	nodes "github.com/bytebase/omni/tidb/ast"
+)
+
+// Compound routine bodies whose blocks close with a two-word terminator —
+// END IF / END CASE / END WHILE / END REPEAT — must not truncate the body at
+// the inner END. The body is captured as raw text by balancing every compound
+// opener (BEGIN/IF/CASE/WHILE/LOOP/REPEAT) against END, mirroring Split.
+//
+// CREATE PROCEDURE is the TiDB-grounded case: TiDB v8.5.0 parses these bodies
+// (it reports ERROR 8108 = parse-OK, plan-unsupported), while a garbage body is
+// rejected (1064), so TiDB validates the body grammar. Verified on TiDB v8.5.0.
+// (TiDB rejects CREATE FUNCTION/TRIGGER/EVENT and LOOP-in-procedure outright;
+// omni's acceptance of those is a pre-existing over-acceptance, tracked
+// separately — not exercised as TiDB-parity here.)
+
+func TestRoutineCompoundBodyAccepted(t *testing.T) {
+	cases := []string{
+		`CREATE PROCEDURE p() BEGIN IF 1>0 THEN SELECT 1; END IF; END`,
+		`CREATE PROCEDURE p() BEGIN CASE 1 WHEN 1 THEN SELECT 1; END CASE; END`,
+		`CREATE PROCEDURE p() BEGIN DECLARE x INT DEFAULT 3; WHILE x>0 DO SET x=x-1; END WHILE; END`,
+		`CREATE PROCEDURE p() BEGIN DECLARE x INT DEFAULT 0; REPEAT SET x=x+1; UNTIL x>5 END REPEAT; END`,
+		`CREATE PROCEDURE p() BEGIN IF 1>0 THEN BEGIN DECLARE y INT DEFAULT 3; WHILE y>0 DO SET y=y-1; END WHILE; END; END IF; END`,
+		`CREATE PROCEDURE p() lbl: BEGIN SELECT 1; END lbl`,
+		`CREATE PROCEDURE p() BEGIN END`,
+		`CREATE PROCEDURE p() BEGIN SELECT 1; END`,
+		// EXISTS (subquery) is a search condition, not a DDL IF EXISTS modifier;
+		// the IF must be counted so its END IF balances.
+		`CREATE PROCEDURE p() BEGIN IF EXISTS (SELECT 1 FROM t) THEN DELETE FROM t; END IF; END`,
+		`CREATE PROCEDURE p() BEGIN IF NOT EXISTS (SELECT 1 FROM t) THEN INSERT INTO t VALUES (1); END IF; END`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Fatalf("Parse(%q) error: %v", sql, err)
+			}
+		})
+	}
+}
+
+// The captured body must span exactly the routine body — the inner END IF must
+// not truncate it, and the outer END must not over-consume into a following
+// statement. Parsing a routine followed by another statement pins both ends.
+func TestRoutineCompoundBodyFullCapture(t *testing.T) {
+	const sql = `CREATE PROCEDURE p() BEGIN IF 1>0 THEN SELECT 1; END IF; END; SELECT 999`
+	const wantBody = `BEGIN IF 1>0 THEN SELECT 1; END IF; END`
+
+	list, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse(%q) error: %v", sql, err)
+	}
+	if len(list.Items) != 2 {
+		t.Fatalf("Parse(%q) produced %d statements, want 2 (routine + trailing SELECT)", sql, len(list.Items))
+	}
+	proc, ok := list.Items[0].(*nodes.CreateFunctionStmt)
+	if !ok {
+		t.Fatalf("first statement is %T, want *nodes.CreateFunctionStmt", list.Items[0])
+	}
+	if !proc.IsProcedure {
+		t.Errorf("IsProcedure = false, want true")
+	}
+	if proc.Body != wantBody {
+		t.Errorf("captured body = %q, want %q", proc.Body, wantBody)
+	}
+}
+
+// findCompoundBodyEnd is the body-capture balancer. These cases exercise it
+// directly (decoupled from which statements TiDB accepts): every compound
+// opener nets against its END, openers inside string literals or comments are
+// ignored, and a top-level ';' terminates the body. The LOOP case verifies the
+// balancer counts LOOP/END LOOP even though TiDB rejects LOOP-in-procedure
+// (statement-level rejection is a separate concern); here we only assert the
+// body end is found correctly.
+func TestFindCompoundBodyEnd(t *testing.T) {
+	cases := []struct {
+		name     string
+		sql      string
+		wantBody string // sql[:findCompoundBodyEnd(sql,0)]
+	}{
+		{"end_if", `BEGIN IF 1>0 THEN SELECT 1; END IF; END`, `BEGIN IF 1>0 THEN SELECT 1; END IF; END`},
+		{"end_case", `BEGIN CASE 1 WHEN 1 THEN SELECT 1; END CASE; END`, `BEGIN CASE 1 WHEN 1 THEN SELECT 1; END CASE; END`},
+		{"end_while", `BEGIN WHILE x>0 DO SET x=x-1; END WHILE; END`, `BEGIN WHILE x>0 DO SET x=x-1; END WHILE; END`},
+		{"end_repeat", `BEGIN REPEAT SET x=x+1; UNTIL x>5 END REPEAT; END`, `BEGIN REPEAT SET x=x+1; UNTIL x>5 END REPEAT; END`},
+		{"end_loop_balancing_only", `BEGIN l: LOOP LEAVE l; END LOOP; END`, `BEGIN l: LOOP LEAVE l; END LOOP; END`},
+		{"nested", `BEGIN IF 1>0 THEN BEGIN WHILE y>0 DO SET y=y-1; END WHILE; END; END IF; END`, `BEGIN IF 1>0 THEN BEGIN WHILE y>0 DO SET y=y-1; END WHILE; END; END IF; END`},
+		{"string_literal_with_end_if", `BEGIN SELECT 'END IF'; END`, `BEGIN SELECT 'END IF'; END`},
+		{"comment_with_end_while", `BEGIN SELECT 1; /* END WHILE */ END`, `BEGIN SELECT 1; /* END WHILE */ END`},
+		{"empty", `BEGIN END`, `BEGIN END`},
+		{"top_level_semicolon_terminates", `BEGIN SELECT 1; END; SELECT 2`, `BEGIN SELECT 1; END`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := findCompoundBodyEnd(c.sql, 0)
+			if c.sql[:got] != c.wantBody {
+				t.Errorf("findCompoundBodyEnd(%q) ended at %d (%q), want %q", c.sql, got, c.sql[:got], c.wantBody)
+			}
+		})
+	}
+}
+
+// A routine body containing a MySQL conditional comment (/*! ... */ or
+// /*T! ... */) must parse without panicking. The lexer rewrites its input
+// buffer in place when it expands a conditional comment, so the body text must
+// be captured against the post-tokenization buffer (clamped), not a stale
+// pre-tokenization offset. TiDB v8.5.0 parses these bodies (ERROR 8108).
+func TestRoutineCompoundBodyConditionalComment(t *testing.T) {
+	cases := []string{
+		`CREATE PROCEDURE p() BEGIN /*!50003 SET @x = 1 */; END`,
+		`CREATE PROCEDURE p() BEGIN /*T!90000 SET @x = 1 */; END`,
+		`CREATE PROCEDURE p() BEGIN IF 1>0 THEN /*!50003 SET @x = 1 */; END IF; END`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			list, err := Parse(sql)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", sql, err)
+			}
+			if len(list.Items) != 1 {
+				t.Fatalf("Parse(%q) produced %d statements, want 1", sql, len(list.Items))
+			}
+			proc, ok := list.Items[0].(*nodes.CreateFunctionStmt)
+			if !ok {
+				t.Fatalf("statement is %T, want *nodes.CreateFunctionStmt", list.Items[0])
+			}
+			if proc.Body == "" {
+				t.Errorf("captured body is empty, want the compound body text")
+			}
+		})
+	}
+}
+
+// A routine defined with a custom DELIMITER (mysqldump style) followed by
+// another statement must parse as two statements — the compound body must not
+// swallow the following statement.
+func TestRoutineBodyWithDelimiter(t *testing.T) {
+	const sql = "DELIMITER //\nCREATE PROCEDURE p() BEGIN IF 1>0 THEN SELECT 1; END IF; END//\nSELECT 2//"
+	list, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse(%q) error: %v", sql, err)
+	}
+	if len(list.Items) != 2 {
+		t.Fatalf("Parse produced %d statements, want 2 (procedure + SELECT)", len(list.Items))
+	}
+	if _, ok := list.Items[0].(*nodes.CreateFunctionStmt); !ok {
+		t.Errorf("first statement is %T, want *nodes.CreateFunctionStmt", list.Items[0])
+	}
+}
+
+// The IF [NOT] EXISTS tightening must not change how Split delimits ordinary
+// DDL: IF EXISTS / IF NOT EXISTS followed by an identifier is a DDL modifier
+// (not a compound opener), so these statements stay at top level and split on
+// their own ';'.
+func TestSplitPreservesIfExistsDDL(t *testing.T) {
+	const sql = `DROP TABLE IF EXISTS t; CREATE TABLE IF NOT EXISTS u (a INT); SELECT 1`
+	segs := Split(sql)
+	if len(segs) != 3 {
+		var texts []string
+		for _, s := range segs {
+			texts = append(texts, s.Text)
+		}
+		t.Fatalf("Split(%q) = %d segments %q, want 3", sql, len(segs), texts)
+	}
+}

--- a/tidb/parser/routine_body_test.go
+++ b/tidb/parser/routine_body_test.go
@@ -32,6 +32,8 @@ func TestRoutineCompoundBodyAccepted(t *testing.T) {
 		// the IF must be counted so its END IF balances.
 		`CREATE PROCEDURE p() BEGIN IF EXISTS (SELECT 1 FROM t) THEN DELETE FROM t; END IF; END`,
 		`CREATE PROCEDURE p() BEGIN IF NOT EXISTS (SELECT 1 FROM t) THEN INSERT INTO t VALUES (1); END IF; END`,
+		// A comment between EXISTS and '(' must not flip the IF to a DDL modifier.
+		`CREATE PROCEDURE p() BEGIN IF EXISTS /*c*/ (SELECT 1 FROM t) THEN DELETE FROM t; END IF; END`,
 	}
 	for _, sql := range cases {
 		t.Run(sql, func(t *testing.T) {
@@ -91,6 +93,13 @@ func TestFindCompoundBodyEnd(t *testing.T) {
 		{"comment_with_end_while", `BEGIN SELECT 1; /* END WHILE */ END`, `BEGIN SELECT 1; /* END WHILE */ END`},
 		{"empty", `BEGIN END`, `BEGIN END`},
 		{"top_level_semicolon_terminates", `BEGIN SELECT 1; END; SELECT 2`, `BEGIN SELECT 1; END`},
+		// IF EXISTS (subquery) is a compound IF — counted — even with a comment
+		// between EXISTS and '(', so its END IF balances and the body spans whole.
+		{"if_exists_comment_subquery", `BEGIN IF EXISTS /*c*/ (SELECT 1) THEN SELECT 1; END IF; END`, `BEGIN IF EXISTS /*c*/ (SELECT 1) THEN SELECT 1; END IF; END`},
+		// A body-internal DDL IF EXISTS <ident> is NOT a compound opener, so the
+		// scan stops at the body's top-level ';' instead of over-counting and
+		// swallowing the following statement.
+		{"if_exists_ddl_stops_at_semicolon", `BEGIN DROP TABLE IF EXISTS t; END; SELECT 2`, `BEGIN DROP TABLE IF EXISTS t; END`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -163,5 +172,41 @@ func TestSplitPreservesIfExistsDDL(t *testing.T) {
 			texts = append(texts, s.Text)
 		}
 		t.Fatalf("Split(%q) = %d segments %q, want 3", sql, len(segs), texts)
+	}
+}
+
+// The body capture must not swallow a statement following the routine — the
+// split-first guarantee the over-count analysis relies on. Covers the two body
+// shapes whose scan could mis-balance: a conditional comment, and a
+// body-internal DDL IF EXISTS, each followed by another statement.
+func TestRoutineBodyDoesNotSwallowTrailingStatement(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		// Conditional-comment body + trailing SELECT (default ';' delimiter).
+		// TiDB parses both (procedure 8108, SELECT executes).
+		{"conditional_comment", `CREATE PROCEDURE p() BEGIN /*!50003 SET @x = 1 */; END; SELECT 2`},
+		// DDL IF EXISTS in the body + trailing SELECT, custom delimiter so the
+		// routine and SELECT share ONE segment (this is what exercises
+		// findCompoundBodyEnd's top-level ';' detection). omni text-captures the
+		// body; the point is that the trailing SELECT is not swallowed. TiDB
+		// rejects DDL inside a procedure body, so this pins omni's split
+		// correctness, not TiDB parity.
+		{"ddl_if_exists_custom_delimiter", "DELIMITER //\nCREATE PROCEDURE p() BEGIN DROP TABLE IF EXISTS t; END; SELECT 2//"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			list, err := Parse(c.sql)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", c.sql, err)
+			}
+			if len(list.Items) != 2 {
+				t.Fatalf("Parse(%q) produced %d statements, want 2 (routine + trailing)", c.sql, len(list.Items))
+			}
+			if _, ok := list.Items[0].(*nodes.CreateFunctionStmt); !ok {
+				t.Errorf("first statement is %T, want *nodes.CreateFunctionStmt", list.Items[0])
+			}
+		})
 	}
 }

--- a/tidb/parser/routine_body_test.go
+++ b/tidb/parser/routine_body_test.go
@@ -104,6 +104,10 @@ func TestFindCompoundBodyEnd(t *testing.T) {
 		// compound openers, so the scan stops at the body's top-level ';'.
 		{"if_function_comment_before_paren", `BEGIN SELECT IF /*c*/ (1,2,3); END; SELECT 4`, `BEGIN SELECT IF /*c*/ (1,2,3); END`},
 		{"repeat_function_comment_before_paren", `BEGIN SELECT REPEAT /*c*/ ('a',2); END; SELECT 4`, `BEGIN SELECT REPEAT /*c*/ ('a',2); END`},
+		// Conditional comment before the function paren — a no-op version gate,
+		// still a function call, so the scan stops at the body's top-level ';'.
+		{"if_function_conditional_comment", `BEGIN SELECT IF /*!50000*/ (1,2,3); END; SELECT 4`, `BEGIN SELECT IF /*!50000*/ (1,2,3); END`},
+		{"repeat_function_conditional_comment", `BEGIN SELECT REPEAT /*!50000*/ ('a',2); END; SELECT 4`, `BEGIN SELECT REPEAT /*!50000*/ ('a',2); END`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -203,6 +207,10 @@ func TestRoutineBodyDoesNotSwallowTrailingStatement(t *testing.T) {
 		// SELECT IF /*c*/ (1,2,3) and SELECT REPEAT /*c*/ ('a',2).
 		{"if_function_comment_before_paren", `CREATE PROCEDURE p() BEGIN SELECT IF /*c*/ (1,2,3); END; SELECT 4`},
 		{"repeat_function_comment_before_paren", `CREATE PROCEDURE p() BEGIN SELECT REPEAT /*c*/ ('a',2); END; SELECT 4`},
+		// A conditional comment (/*!...*/) is a no-op version gate before the
+		// function paren — still a function call, not a compound opener.
+		{"if_function_conditional_comment", `CREATE PROCEDURE p() BEGIN SELECT IF /*!50000*/ (1,2,3); END; SELECT 4`},
+		{"repeat_function_conditional_comment", `CREATE PROCEDURE p() BEGIN SELECT REPEAT /*!50000*/ ('a',2); END; SELECT 4`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -169,10 +169,13 @@ func matchDelimiter(sql string, i int, delim string) bool {
 
 // nextSignificantChar returns the next character after pos, skipping whitespace
 // and comments, or 0 if none. Used for keyword lookahead (e.g. distinguishing
-// the IF(...) / REPEAT(...) functions from the compound IF / REPEAT statements),
-// where a comment may sit between the keyword and the following token.
-func nextSignificantChar(sql string, pos int) byte {
-	j := skipSpaceAndComments(sql, pos)
+// the IF(...) / REPEAT(...) functions from the compound IF / REPEAT statements).
+// skipConditional controls handling of conditional comments — see
+// skipSpaceAndComments: pass true for "is the next token '(' ?" (a version-gate
+// comment does not change a function call), false where conditional-comment SQL
+// is significant content (the BEGIN transaction check).
+func nextSignificantChar(sql string, pos int, skipConditional bool) byte {
+	j := skipSpaceAndComments(sql, pos, skipConditional)
 	if j >= len(sql) {
 		return 0
 	}
@@ -181,19 +184,22 @@ func nextSignificantChar(sql string, pos int) byte {
 
 // skipSpaceAndComments advances past whitespace and comments (block /* */,
 // line -- and #) starting at position i. Conditional comments (/*!...*/ and
-// /*T!...*/) are NOT skipped: they contain executable SQL and are significant
-// (same treatment as Segment.Empty).
-func skipSpaceAndComments(sql string, i int) int {
+// /*T!...*/) hold executable SQL: skipConditional=true skips them like any
+// comment, false treats them as significant and stops the scan (matching
+// Segment.Empty).
+func skipSpaceAndComments(sql string, i int, skipConditional bool) int {
 	for i < len(sql) {
 		switch {
 		case sql[i] == ' ' || sql[i] == '\t' || sql[i] == '\n' || sql[i] == '\r':
 			i++
 		case sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*':
-			if i+2 < len(sql) && sql[i+2] == '!' {
-				return i // /*!...*/ conditional comment — executable SQL.
-			}
-			if i+3 < len(sql) && sql[i+2] == 'T' && sql[i+3] == '!' {
-				return i // /*T!...*/ TiDB-specific comment — executable SQL.
+			if !skipConditional {
+				if i+2 < len(sql) && sql[i+2] == '!' {
+					return i // /*!...*/ conditional comment — executable SQL.
+				}
+				if i+3 < len(sql) && sql[i+2] == 'T' && sql[i+3] == '!' {
+					return i // /*T!...*/ TiDB-specific comment — executable SQL.
+				}
 			}
 			i = skipBlockCommentMySQL(sql, i)
 		case isDashComment(sql, i):
@@ -214,14 +220,14 @@ func skipSpaceAndComments(sql string, i int) int {
 // because EXISTS is followed by '('. Shared by Split and findCompoundBodyEnd so
 // they classify IF the same way.
 func isIfExistsModifier(sql string, ifEnd int) bool {
-	p := skipSpaceAndComments(sql, ifEnd)
+	p := skipSpaceAndComments(sql, ifEnd, true)
 	if matchWord(sql, p, "NOT") {
-		p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p))
+		p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p), true)
 	}
 	if !matchWord(sql, p, "EXISTS") {
 		return false
 	}
-	p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p))
+	p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p), true)
 	return p >= len(sql) || sql[p] != '('
 }
 
@@ -305,7 +311,7 @@ func Split(sql string) []Segment {
 			// BEGIN WORK => transaction, not compound.
 			// BEGIN at EOF or followed by ; => transaction.
 			// XA BEGIN => transaction.
-			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord) != ';' && nextSignificantChar(sql, endOfWord) != 0 {
+			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord, false) != ';' && nextSignificantChar(sql, endOfWord, false) != 0 {
 				depth++
 			}
 			i = endOfWord
@@ -314,7 +320,7 @@ func Split(sql string) []Segment {
 		// modifier, or an IF(...) function call.
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord, true) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -347,7 +353,7 @@ func Split(sql string) []Segment {
 		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
-			if prev != "END" && nextSignificantChar(sql, endOfWord) != '(' {
+			if prev != "END" && nextSignificantChar(sql, endOfWord, true) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -441,7 +447,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 			endOfWord := skipToEndOfWord(sql, i)
 			next := nextWordAfter(sql, endOfWord)
 			prev := prevWord(sql, i)
-			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord) != ';' && nextSignificantChar(sql, endOfWord) != 0 {
+			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord, false) != ';' && nextSignificantChar(sql, endOfWord, false) != 0 {
 				depth++
 			}
 			i = endOfWord
@@ -454,7 +460,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 		// and swallow a following statement in a custom-delimiter segment).
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord, true) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -487,7 +493,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
-			if prev != "END" && nextSignificantChar(sql, endOfWord) != '(' {
+			if prev != "END" && nextSignificantChar(sql, endOfWord, true) != '(' {
 				depth++
 			}
 			i = endOfWord

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -167,9 +167,12 @@ func matchDelimiter(sql string, i int, delim string) bool {
 	return sql[i:i+len(delim)] == delim
 }
 
-// nextNonSpaceChar returns the next non-whitespace character after pos, or 0 if none.
-func nextNonSpaceChar(sql string, pos int) byte {
-	j := skipWhitespace(sql, pos)
+// nextSignificantChar returns the next character after pos, skipping whitespace
+// and comments, or 0 if none. Used for keyword lookahead (e.g. distinguishing
+// the IF(...) / REPEAT(...) functions from the compound IF / REPEAT statements),
+// where a comment may sit between the keyword and the following token.
+func nextSignificantChar(sql string, pos int) byte {
+	j := skipSpaceAndComments(sql, pos)
 	if j >= len(sql) {
 		return 0
 	}
@@ -177,13 +180,21 @@ func nextNonSpaceChar(sql string, pos int) byte {
 }
 
 // skipSpaceAndComments advances past whitespace and comments (block /* */,
-// line -- and #) starting at position i.
+// line -- and #) starting at position i. Conditional comments (/*!...*/ and
+// /*T!...*/) are NOT skipped: they contain executable SQL and are significant
+// (same treatment as Segment.Empty).
 func skipSpaceAndComments(sql string, i int) int {
 	for i < len(sql) {
 		switch {
 		case sql[i] == ' ' || sql[i] == '\t' || sql[i] == '\n' || sql[i] == '\r':
 			i++
 		case sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			if i+2 < len(sql) && sql[i+2] == '!' {
+				return i // /*!...*/ conditional comment — executable SQL.
+			}
+			if i+3 < len(sql) && sql[i+2] == 'T' && sql[i+3] == '!' {
+				return i // /*T!...*/ TiDB-specific comment — executable SQL.
+			}
 			i = skipBlockCommentMySQL(sql, i)
 		case isDashComment(sql, i):
 			i = skipDashComment(sql, i)
@@ -294,7 +305,7 @@ func Split(sql string) []Segment {
 			// BEGIN WORK => transaction, not compound.
 			// BEGIN at EOF or followed by ; => transaction.
 			// XA BEGIN => transaction.
-			if next != "WORK" && prev != "XA" && nextNonSpaceChar(sql, endOfWord) != ';' && nextNonSpaceChar(sql, endOfWord) != 0 {
+			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord) != ';' && nextSignificantChar(sql, endOfWord) != 0 {
 				depth++
 			}
 			i = endOfWord
@@ -303,7 +314,7 @@ func Split(sql string) []Segment {
 		// modifier, or an IF(...) function call.
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextNonSpaceChar(sql, endOfWord) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -336,7 +347,7 @@ func Split(sql string) []Segment {
 		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
-			if prev != "END" && nextNonSpaceChar(sql, endOfWord) != '(' {
+			if prev != "END" && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -430,7 +441,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 			endOfWord := skipToEndOfWord(sql, i)
 			next := nextWordAfter(sql, endOfWord)
 			prev := prevWord(sql, i)
-			if next != "WORK" && prev != "XA" && nextNonSpaceChar(sql, endOfWord) != ';' && nextNonSpaceChar(sql, endOfWord) != 0 {
+			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord) != ';' && nextSignificantChar(sql, endOfWord) != 0 {
 				depth++
 			}
 			i = endOfWord
@@ -443,7 +454,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 		// and swallow a following statement in a custom-delimiter segment).
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextNonSpaceChar(sql, endOfWord) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -476,7 +487,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
-			if prev != "END" && nextNonSpaceChar(sql, endOfWord) != '(' {
+			if prev != "END" && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -261,12 +261,31 @@ func Split(sql string) []Segment {
 			}
 			i = endOfWord
 
-		// IF — increment depth unless preceded by END, followed by EXISTS, or followed by '('.
+		// IF — increment depth unless preceded by END, an IF [NOT] EXISTS DDL
+		// modifier, or an IF(...) function call.
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
 			next := nextWordAfter(sql, endOfWord)
-			isExistsClause := next == "EXISTS" || (next == "NOT" && nextWordAfter(sql, skipToEndOfWord(sql, skipWhitespace(sql, endOfWord))) == "EXISTS")
+			// Treat "IF [NOT] EXISTS" as a DDL modifier only when EXISTS is
+			// followed by a bare identifier (e.g. DROP TABLE IF EXISTS t).
+			// When EXISTS is followed by '(' (e.g. IF EXISTS (subquery) THEN),
+			// it is the EXISTS subquery predicate inside a compound IF.
+			isExistsClause := false
+			if next == "EXISTS" {
+				existsEnd := skipToEndOfWord(sql, skipWhitespace(sql, endOfWord))
+				if nextNonSpaceChar(sql, existsEnd) != '(' {
+					isExistsClause = true
+				}
+			} else if next == "NOT" {
+				notEnd := skipToEndOfWord(sql, skipWhitespace(sql, endOfWord))
+				if nextWordAfter(sql, notEnd) == "EXISTS" {
+					existsEnd := skipToEndOfWord(sql, skipWhitespace(sql, notEnd))
+					if nextNonSpaceChar(sql, existsEnd) != '(' {
+						isExistsClause = true
+					}
+				}
+			}
 			if prev != "END" && !isExistsClause && nextNonSpaceChar(sql, endOfWord) != '(' {
 				depth++
 			}
@@ -348,6 +367,122 @@ func Split(sql string) []Segment {
 		return nil
 	}
 	return segments
+}
+
+// findCompoundBodyEnd scans a routine/trigger/event body starting at byte offset
+// start and returns the offset of the first top-level (depth 0) ';', or len(sql)
+// if none is found. It balances every compound opener (BEGIN/IF/CASE/WHILE/LOOP/
+// REPEAT) against END using the same heuristics as Split, so an inner block
+// terminator like END IF / END CASE / END WHILE / END LOOP / END REPEAT does not
+// prematurely close the enclosing BEGIN block. This is the body-capture analogue
+// of Split's depth tracking; a naive BEGIN/END-only counter mis-reads the END of
+// an inner block as closing the routine and truncates the body.
+func findCompoundBodyEnd(sql string, start int) int {
+	i := start
+	depth := 0
+	for i < len(sql) {
+		b := sql[i]
+		switch {
+		// Single-quoted string.
+		case b == '\'':
+			i = skipSingleQuoteMySQL(sql, i)
+
+		// Double-quoted string (MySQL treats as string literal).
+		case b == '"':
+			i = skipDoubleQuoteMySQL(sql, i)
+
+		// Backtick-quoted identifier.
+		case b == '`':
+			i = skipBacktick(sql, i)
+
+		// Block comment.
+		case b == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			i = skipBlockCommentMySQL(sql, i)
+
+		// Dash line comment.
+		case isDashComment(sql, i):
+			i = skipDashComment(sql, i)
+
+		// Hash line comment.
+		case b == '#':
+			i = skipHashComment(sql, i)
+
+		// BEGIN — increment depth unless it's a transaction (BEGIN WORK, lone
+		// BEGIN at ';'/EOF, XA BEGIN).
+		case (b == 'b' || b == 'B') && matchWord(sql, i, "BEGIN"):
+			endOfWord := skipToEndOfWord(sql, i)
+			next := nextWordAfter(sql, endOfWord)
+			prev := prevWord(sql, i)
+			if next != "WORK" && prev != "XA" && nextNonSpaceChar(sql, endOfWord) != ';' && nextNonSpaceChar(sql, endOfWord) != 0 {
+				depth++
+			}
+			i = endOfWord
+
+		// IF — increment depth unless preceded by END or used as the IF(...)
+		// function (next char '('). "IF EXISTS (subquery) THEN ... END IF" flow
+		// control is counted (EXISTS is followed by '(', matching Split's
+		// tightened IF arm). We do not replicate Split's IF [NOT] EXISTS <ident>
+		// DDL skip: a routine body is a single Split-delimited segment, so this
+		// scan only needs the body's terminating top-level ';' (or EOF), and
+		// over-counting a body-internal DDL IF EXISTS is harmless — depth simply
+		// stays > 0 through the (single-segment) body to its end.
+		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
+			endOfWord := skipToEndOfWord(sql, i)
+			prev := prevWord(sql, i)
+			if prev != "END" && nextNonSpaceChar(sql, endOfWord) != '(' {
+				depth++
+			}
+			i = endOfWord
+
+		// CASE — increment depth unless preceded by END.
+		case (b == 'c' || b == 'C') && matchWord(sql, i, "CASE"):
+			endOfWord := skipToEndOfWord(sql, i)
+			if prevWord(sql, i) != "END" {
+				depth++
+			}
+			i = endOfWord
+
+		// WHILE — increment depth unless preceded by END.
+		case (b == 'w' || b == 'W') && matchWord(sql, i, "WHILE"):
+			endOfWord := skipToEndOfWord(sql, i)
+			if prevWord(sql, i) != "END" {
+				depth++
+			}
+			i = endOfWord
+
+		// LOOP — increment depth unless preceded by END.
+		case (b == 'l' || b == 'L') && matchWord(sql, i, "LOOP"):
+			endOfWord := skipToEndOfWord(sql, i)
+			if prevWord(sql, i) != "END" {
+				depth++
+			}
+			i = endOfWord
+
+		// REPEAT — increment depth unless preceded by END or followed by '('.
+		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
+			endOfWord := skipToEndOfWord(sql, i)
+			prev := prevWord(sql, i)
+			if prev != "END" && nextNonSpaceChar(sql, endOfWord) != '(' {
+				depth++
+			}
+			i = endOfWord
+
+		// END — decrement depth (if > 0), skip if preceded by XA.
+		case (b == 'e' || b == 'E') && matchWord(sql, i, "END"):
+			endOfWord := skipToEndOfWord(sql, i)
+			if depth > 0 && prevWord(sql, i) != "XA" {
+				depth--
+			}
+			i = endOfWord
+
+		default:
+			if depth == 0 && b == ';' {
+				return i
+			}
+			i++
+		}
+	}
+	return i
 }
 
 // skipSingleQuoteMySQL skips a single-quoted string starting at position i.

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -176,6 +176,44 @@ func nextNonSpaceChar(sql string, pos int) byte {
 	return sql[j]
 }
 
+// skipSpaceAndComments advances past whitespace and comments (block /* */,
+// line -- and #) starting at position i.
+func skipSpaceAndComments(sql string, i int) int {
+	for i < len(sql) {
+		switch {
+		case sql[i] == ' ' || sql[i] == '\t' || sql[i] == '\n' || sql[i] == '\r':
+			i++
+		case sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*':
+			i = skipBlockCommentMySQL(sql, i)
+		case isDashComment(sql, i):
+			i = skipDashComment(sql, i)
+		case sql[i] == '#':
+			i = skipHashComment(sql, i)
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+// isIfExistsModifier reports whether the IF whose word ends at ifEnd is the DDL
+// modifier "IF [NOT] EXISTS <identifier>" (e.g. DROP TABLE IF EXISTS t) rather
+// than a compound IF statement. It is comment-aware: "IF EXISTS /*c*/ (subquery)
+// THEN" is a compound IF (the EXISTS subquery predicate), not a DDL modifier,
+// because EXISTS is followed by '('. Shared by Split and findCompoundBodyEnd so
+// they classify IF the same way.
+func isIfExistsModifier(sql string, ifEnd int) bool {
+	p := skipSpaceAndComments(sql, ifEnd)
+	if matchWord(sql, p, "NOT") {
+		p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p))
+	}
+	if !matchWord(sql, p, "EXISTS") {
+		return false
+	}
+	p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p))
+	return p >= len(sql) || sql[p] != '('
+}
+
 // Split splits SQL text into segments at top-level semicolons.
 // It is a pure lexical scanner that does not parse SQL, so it works
 // on both valid and invalid SQL. Segments do NOT include the trailing
@@ -265,28 +303,7 @@ func Split(sql string) []Segment {
 		// modifier, or an IF(...) function call.
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			prev := prevWord(sql, i)
-			next := nextWordAfter(sql, endOfWord)
-			// Treat "IF [NOT] EXISTS" as a DDL modifier only when EXISTS is
-			// followed by a bare identifier (e.g. DROP TABLE IF EXISTS t).
-			// When EXISTS is followed by '(' (e.g. IF EXISTS (subquery) THEN),
-			// it is the EXISTS subquery predicate inside a compound IF.
-			isExistsClause := false
-			if next == "EXISTS" {
-				existsEnd := skipToEndOfWord(sql, skipWhitespace(sql, endOfWord))
-				if nextNonSpaceChar(sql, existsEnd) != '(' {
-					isExistsClause = true
-				}
-			} else if next == "NOT" {
-				notEnd := skipToEndOfWord(sql, skipWhitespace(sql, endOfWord))
-				if nextWordAfter(sql, notEnd) == "EXISTS" {
-					existsEnd := skipToEndOfWord(sql, skipWhitespace(sql, notEnd))
-					if nextNonSpaceChar(sql, existsEnd) != '(' {
-						isExistsClause = true
-					}
-				}
-			}
-			if prev != "END" && !isExistsClause && nextNonSpaceChar(sql, endOfWord) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextNonSpaceChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -418,18 +435,15 @@ func findCompoundBodyEnd(sql string, start int) int {
 			}
 			i = endOfWord
 
-		// IF — increment depth unless preceded by END or used as the IF(...)
-		// function (next char '('). "IF EXISTS (subquery) THEN ... END IF" flow
-		// control is counted (EXISTS is followed by '(', matching Split's
-		// tightened IF arm). We do not replicate Split's IF [NOT] EXISTS <ident>
-		// DDL skip: a routine body is a single Split-delimited segment, so this
-		// scan only needs the body's terminating top-level ';' (or EOF), and
-		// over-counting a body-internal DDL IF EXISTS is harmless — depth simply
-		// stays > 0 through the (single-segment) body to its end.
+		// IF — same classification as Split: count it as a compound opener
+		// unless preceded by END, used as the IF(...) function (next char '('),
+		// or a DDL "IF [NOT] EXISTS <ident>" modifier. "IF EXISTS (subquery)
+		// THEN ... END IF" flow control is counted (EXISTS followed by '('); a
+		// body-internal "DROP ... IF EXISTS t" is not (so it does not push depth
+		// and swallow a following statement in a custom-delimiter segment).
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			prev := prevWord(sql, i)
-			if prev != "END" && nextNonSpaceChar(sql, endOfWord) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextNonSpaceChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -170,38 +170,36 @@ func matchDelimiter(sql string, i int, delim string) bool {
 // nextSignificantChar returns the next character after pos, skipping whitespace
 // and comments, or 0 if none. Used for keyword lookahead (e.g. distinguishing
 // the IF(...) / REPEAT(...) functions from the compound IF / REPEAT statements).
-// skipConditional controls handling of conditional comments — see
-// skipSpaceAndComments: pass true for "is the next token '(' ?" (a version-gate
-// comment does not change a function call), false where conditional-comment SQL
-// is significant content (the BEGIN transaction check).
-func nextSignificantChar(sql string, pos int, skipConditional bool) byte {
-	j := skipSpaceAndComments(sql, pos, skipConditional)
+func nextSignificantChar(sql string, pos int) byte {
+	j := skipSpaceAndComments(sql, pos)
 	if j >= len(sql) {
 		return 0
 	}
 	return sql[j]
 }
 
-// skipSpaceAndComments advances past whitespace and comments (block /* */,
-// line -- and #) starting at position i. Conditional comments (/*!...*/ and
-// /*T!...*/) hold executable SQL: skipConditional=true skips them like any
-// comment, false treats them as significant and stops the scan (matching
-// Segment.Empty).
-func skipSpaceAndComments(sql string, i int, skipConditional bool) int {
+// skipSpaceAndComments advances past whitespace and comments (block /* */, line
+// -- and #) starting at position i. A non-empty conditional comment
+// (/*!NNNNN sql */, /*T! sql */) holds executable SQL and is significant — the
+// scan stops at it (matching Segment.Empty). An EMPTY conditional comment
+// (/*!50000*/, a bare version gate) is a no-op and is skipped like whitespace,
+// so e.g. `IF /*!50000*/ (...)` is still recognised as the IF(...) function.
+// Conditional comments remain opaque to Split's main scan; this only affects
+// keyword lookahead.
+func skipSpaceAndComments(sql string, i int) int {
 	for i < len(sql) {
 		switch {
 		case sql[i] == ' ' || sql[i] == '\t' || sql[i] == '\n' || sql[i] == '\r':
 			i++
 		case sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*':
-			if !skipConditional {
-				if i+2 < len(sql) && sql[i+2] == '!' {
-					return i // /*!...*/ conditional comment — executable SQL.
+			if end, empty, ok := conditionalCommentEnd(sql, i); ok {
+				if !empty {
+					return i // executable SQL — significant.
 				}
-				if i+3 < len(sql) && sql[i+2] == 'T' && sql[i+3] == '!' {
-					return i // /*T!...*/ TiDB-specific comment — executable SQL.
-				}
+				i = end // bare version gate — skip like whitespace.
+			} else {
+				i = skipBlockCommentMySQL(sql, i)
 			}
-			i = skipBlockCommentMySQL(sql, i)
 		case isDashComment(sql, i):
 			i = skipDashComment(sql, i)
 		case sql[i] == '#':
@@ -213,6 +211,39 @@ func skipSpaceAndComments(sql string, i int, skipConditional bool) int {
 	return i
 }
 
+// conditionalCommentEnd reports whether a conditional comment (/*!NNNNN...*/ or
+// /*T!...*/) begins at i. If so it returns end = the index just past the closing
+// */ and empty = whether the inner content (after the /*!NNNNN or /*T! marker)
+// is only whitespace. ok is false for a regular block comment.
+func conditionalCommentEnd(sql string, i int) (end int, empty bool, ok bool) {
+	if i+2 >= len(sql) || sql[i] != '/' || sql[i+1] != '*' {
+		return 0, false, false
+	}
+	var innerStart int
+	switch {
+	case sql[i+2] == '!':
+		innerStart = i + 3
+		for innerStart < len(sql) && sql[innerStart] >= '0' && sql[innerStart] <= '9' {
+			innerStart++
+		}
+	case i+3 < len(sql) && sql[i+2] == 'T' && sql[i+3] == '!':
+		innerStart = i + 4
+	default:
+		return 0, false, false
+	}
+	end = skipBlockCommentMySQL(sql, i)
+	innerEnd := end
+	if innerEnd-2 >= innerStart && sql[innerEnd-2] == '*' && sql[innerEnd-1] == '/' {
+		innerEnd -= 2
+	}
+	for j := innerStart; j < innerEnd; j++ {
+		if sql[j] != ' ' && sql[j] != '\t' && sql[j] != '\n' && sql[j] != '\r' {
+			return end, false, true
+		}
+	}
+	return end, true, true
+}
+
 // isIfExistsModifier reports whether the IF whose word ends at ifEnd is the DDL
 // modifier "IF [NOT] EXISTS <identifier>" (e.g. DROP TABLE IF EXISTS t) rather
 // than a compound IF statement. It is comment-aware: "IF EXISTS /*c*/ (subquery)
@@ -220,14 +251,14 @@ func skipSpaceAndComments(sql string, i int, skipConditional bool) int {
 // because EXISTS is followed by '('. Shared by Split and findCompoundBodyEnd so
 // they classify IF the same way.
 func isIfExistsModifier(sql string, ifEnd int) bool {
-	p := skipSpaceAndComments(sql, ifEnd, true)
+	p := skipSpaceAndComments(sql, ifEnd)
 	if matchWord(sql, p, "NOT") {
-		p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p), true)
+		p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p))
 	}
 	if !matchWord(sql, p, "EXISTS") {
 		return false
 	}
-	p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p), true)
+	p = skipSpaceAndComments(sql, skipToEndOfWord(sql, p))
 	return p >= len(sql) || sql[p] != '('
 }
 
@@ -311,7 +342,7 @@ func Split(sql string) []Segment {
 			// BEGIN WORK => transaction, not compound.
 			// BEGIN at EOF or followed by ; => transaction.
 			// XA BEGIN => transaction.
-			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord, false) != ';' && nextSignificantChar(sql, endOfWord, false) != 0 {
+			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord) != ';' && nextSignificantChar(sql, endOfWord) != 0 {
 				depth++
 			}
 			i = endOfWord
@@ -320,7 +351,7 @@ func Split(sql string) []Segment {
 		// modifier, or an IF(...) function call.
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord, true) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -353,7 +384,7 @@ func Split(sql string) []Segment {
 		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
-			if prev != "END" && nextSignificantChar(sql, endOfWord, true) != '(' {
+			if prev != "END" && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -447,7 +478,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 			endOfWord := skipToEndOfWord(sql, i)
 			next := nextWordAfter(sql, endOfWord)
 			prev := prevWord(sql, i)
-			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord, false) != ';' && nextSignificantChar(sql, endOfWord, false) != 0 {
+			if next != "WORK" && prev != "XA" && nextSignificantChar(sql, endOfWord) != ';' && nextSignificantChar(sql, endOfWord) != 0 {
 				depth++
 			}
 			i = endOfWord
@@ -460,7 +491,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 		// and swallow a following statement in a custom-delimiter segment).
 		case (b == 'i' || b == 'I') && matchWord(sql, i, "IF"):
 			endOfWord := skipToEndOfWord(sql, i)
-			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord, true) != '(' {
+			if prevWord(sql, i) != "END" && !isIfExistsModifier(sql, endOfWord) && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord
@@ -493,7 +524,7 @@ func findCompoundBodyEnd(sql string, start int) int {
 		case (b == 'r' || b == 'R') && matchWord(sql, i, "REPEAT"):
 			endOfWord := skipToEndOfWord(sql, i)
 			prev := prevWord(sql, i)
-			if prev != "END" && nextSignificantChar(sql, endOfWord, true) != '(' {
+			if prev != "END" && nextSignificantChar(sql, endOfWord) != '(' {
 				depth++
 			}
 			i = endOfWord

--- a/tidb/parser/trigger.go
+++ b/tidb/parser/trigger.go
@@ -124,33 +124,9 @@ func (p *Parser) parseCreateTriggerStmt() (*nodes.CreateTriggerStmt, error) {
 		}
 	}
 
-	// Trigger body — consume everything until EOF or ;
-	bodyStart := p.pos()
-	depth := 0
-	for p.cur.Type != tokEOF {
-		if p.cur.Type == ';' && depth == 0 {
-			break
-		}
-		if p.cur.Type == kwBEGIN {
-			depth++
-		}
-		if p.cur.Type == kwEND {
-			if depth > 0 {
-				depth--
-				if depth == 0 {
-					p.advance()
-					break
-				}
-			} else {
-				break
-			}
-		}
-		p.advance()
-	}
-	bodyEnd := p.pos()
-	if bodyEnd > bodyStart {
-		stmt.Body = p.inputText(bodyStart, bodyEnd)
-	}
+	// Trigger body — balances inner block terminators (END IF / END CASE / ...)
+	// so they don't truncate the body at the inner END.
+	stmt.Body = p.consumeRoutineBody()
 
 	stmt.Loc.End = p.pos()
 	return stmt, nil
@@ -263,32 +239,7 @@ func (p *Parser) parseCreateEventStmt() (*nodes.CreateEventStmt, error) {
 		p.advance()
 	}
 
-	bodyStart := p.pos()
-	depth := 0
-	for p.cur.Type != tokEOF {
-		if p.cur.Type == ';' && depth == 0 {
-			break
-		}
-		if p.cur.Type == kwBEGIN {
-			depth++
-		}
-		if p.cur.Type == kwEND {
-			if depth > 0 {
-				depth--
-				if depth == 0 {
-					p.advance()
-					break
-				}
-			} else {
-				break
-			}
-		}
-		p.advance()
-	}
-	bodyEnd := p.pos()
-	if bodyEnd > bodyStart {
-		stmt.Body = p.inputText(bodyStart, bodyEnd)
-	}
+	stmt.Body = p.consumeRoutineBody()
 
 	stmt.Loc.End = p.pos()
 	return stmt, nil


### PR DESCRIPTION
## What

Make the TiDB parser accept compound **`CREATE PROCEDURE`** bodies whose blocks close with a two-word terminator — `END IF` / `END CASE` / `END WHILE` / `END REPEAT`. The body scanners counted only `BEGIN`/`END`, so an inner `END IF` decremented the `BEGIN` depth to zero and truncated the body early:

```sql
CREATE PROCEDURE p() BEGIN IF 1>0 THEN SELECT 1; END IF; END
-- before: syntax error at or near "IF"   (omni truncated at the inner END)
-- TiDB v8.5.0: parses (ERROR 8108 = parse-OK, plan-unsupported)
```

So omni was rejecting valid SQL. Verified the full accept set on a real **TiDB v8.5.0** container: `END IF`/`END CASE`/`END WHILE`/`END REPEAT…UNTIL`, nested, labeled (`lbl: BEGIN … END lbl`), and empty bodies all parse; a garbage body is rejected (1064), so TiDB genuinely validates the body grammar.

## How

Port of mysql commit `381542ed`:
- Extract **`findCompoundBodyEnd()`** in `split.go` — balances every compound opener (`BEGIN`/`IF`/`CASE`/`WHILE`/`LOOP`/`REPEAT`) against `END` using the same primitives as `Split`, returning the body's terminating top-level `;` (or EOF).
- Companion **Split `IF [NOT] EXISTS (` tightening** so `IF EXISTS (subquery) THEN … END IF` flow control is counted (EXISTS followed by `(`), while DDL `IF EXISTS <ident>` stays a modifier. Verified on v8.5.0: TiDB parses `IF EXISTS (subquery) THEN`.
- **Consolidate the four duplicated body scanners** (`parseCreateFunctionStmt`, `parseCreateTriggerStmt`, `parseCreateEventStmt`, `parseAlterEventStmt`) onto a single `consumeRoutineBody()` — net −108 lines of copy-pasted scan loops.

The catalog is unaffected: `triggercmds`/`routinecmds`/`eventcmds` store/re-emit `stmt.Body` as text, so this is a parser-only change. C4 scenario failure set is unchanged (the 5 pre-existing: 4_3/4_5/4_8/4_9/4_11).

## Scope / known limitations (not regressions)

`CREATE PROCEDURE` is the **TiDB-grounded** case. TiDB v8.5.0 **rejects** `CREATE FUNCTION`, `CREATE TRIGGER`, `CREATE EVENT`, and `LOOP…END LOOP`-in-procedure outright (1064). omni already **accepts** all of these (pre-existing over-acceptance at the *statement* level) — this PR does **not** change that; it only fixes **where the body ends** for statements omni already parsed. The over-acceptance + the `IF (expr) THEN` parenthesized-condition gap (shared with `Split`, not addressed by the reference commit) are tracked in [BYT-9650](https://linear.app/bytebase/issue/BYT-9650).

## Verification

- TDD: failing test first (`END IF` → syntax error), then the fix.
- `go test ./tidb/... -short` green; `go vet` clean; full parser corpus (`TestVerifyCorpus`) green.
- Adversarial pre-PR review caught + fixed two issues before this PR: (1) a **panic** on conditional-comment bodies (`/*! … */`) — the lexer rewrites its buffer in place during tokenization, so the body is now captured via `inputText` post-advance (clamped) rather than a stale raw slice; (2) the half-ported `IF EXISTS (subquery)` case (the companion Split tightening was missing) — now ported.
- Tests in `routine_body_test.go`: acceptance matrix, full-body-capture boundary, `findCompoundBodyEnd` unit cases (string/comment/LOOP balancing, `;` termination), conditional-comment regression, DELIMITER multi-statement, `IF EXISTS` subquery, and a Split DDL-`IF EXISTS` guard.
