### PR TITLE
feat(trino/parser): SELECT core — relations, joins, group/window, set-ops, CTEs (v2 node trino/parser-select)

### DIFF
--- a/trino/parser/ctes.go
+++ b/trino/parser/ctes.go
@@ -1,0 +1,108 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `parser-select` DAG node (with select.go, setops.go,
+// relation.go and window.go): it implements Trino's common-table-expression
+// grammar — the `with` and `namedQuery` rules.
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	with      : WITH RECURSIVE? namedQuery (, namedQuery)* ;
+//	namedQuery: name=identifier columnAliases? AS ( query ) ;
+//
+// The WITH FUNCTION inline-routine prefix (`WITH functionSpecification …`,
+// the withFunction rule) is the parser-routines DAG node, NOT a CTE; parseQuery
+// (select.go) routes a `WITH FUNCTION …` away from this file. Here a leading
+// WITH always introduces a CTE list.
+//
+// Divergence #4 (D2 in select.go): the `WITH SESSION prop = v <query>` prefix
+// valid in Trino 481 is ABSENT from the legacy grammar (where WITH is CTE-only).
+// It is a deferred P1 extension; not parsed here. A `WITH SESSION …` therefore
+// fails as a malformed CTE (SESSION is not a valid namedQuery name followed by
+// AS), which is the legacy-scope behavior. Recorded in the migration divergence
+// ledger.
+
+// WithClause is a `WITH [RECURSIVE] namedQuery (, namedQuery)*` clause (the with
+// rule). Recursive marks the RECURSIVE keyword; CTEs is the non-empty list of
+// named queries.
+type WithClause struct {
+	Recursive bool
+	CTEs      []NamedQuery
+	Loc       ast.Loc
+}
+
+// NamedQuery is one `name [columnAliases] AS ( query )` common table expression
+// (the namedQuery rule). Name is the CTE name; ColumnAliases is the optional
+// explicit column list; Query is the parsed CTE body.
+type NamedQuery struct {
+	Name          *ast.Identifier
+	ColumnAliases []*ast.Identifier
+	Query         *Query
+	Loc           ast.Loc
+}
+
+// parseWithClause parses a `WITH [RECURSIVE] namedQuery (, namedQuery)*` clause
+// (WITH is current; the caller has already confirmed it is not WITH FUNCTION).
+func (p *Parser) parseWithClause() (*WithClause, error) {
+	withTok := p.advance() // consume WITH
+	wc := &WithClause{Loc: ast.Loc{Start: withTok.Loc.Start}}
+
+	if _, ok := p.match(kwRECURSIVE); ok {
+		wc.Recursive = true
+	}
+
+	first, err := p.parseNamedQuery()
+	if err != nil {
+		return nil, err
+	}
+	wc.CTEs = []NamedQuery{first}
+	wc.Loc.End = first.Loc.End
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseNamedQuery()
+		if err != nil {
+			return nil, err
+		}
+		wc.CTEs = append(wc.CTEs, next)
+		wc.Loc.End = next.Loc.End
+	}
+	return wc, nil
+}
+
+// parseNamedQuery parses one `name=identifier columnAliases? AS ( query )`
+// (the namedQuery rule). The body is wrapped in mandatory parentheses and is a
+// full `query` (so a CTE may itself have a WITH, set-operation, ORDER BY, etc.).
+func (p *Parser) parseNamedQuery() (NamedQuery, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return NamedQuery{}, err
+	}
+	nq := NamedQuery{Name: name, Loc: name.Loc}
+
+	if p.cur.Kind == int('(') {
+		cols, _, err := p.parseColumnAliases()
+		if err != nil {
+			return NamedQuery{}, err
+		}
+		nq.ColumnAliases = cols
+	}
+
+	if _, err := p.expect(kwAS); err != nil {
+		return NamedQuery{}, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return NamedQuery{}, err
+	}
+	q, err := p.parseQuery()
+	if err != nil {
+		return NamedQuery{}, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return NamedQuery{}, err
+	}
+	nq.Query = q
+	nq.Loc.End = closeTok.Loc.End
+	return nq, nil
+}

--- a/trino/parser/ctes_test.go
+++ b/trino/parser/ctes_test.go
@@ -1,0 +1,140 @@
+package parser
+
+import "testing"
+
+// This file is the parser-select node's correctness slice for the CTE grammar
+// (ctes.go): WITH / WITH RECURSIVE / namedQuery, including the WITH SESSION
+// divergence (D2). The oracle differential is authoritative; structural tests
+// pin the CTE list / column-alias / recursive shapes. Helpers live in
+// oracle_foundation_test.go and select_test.go.
+
+// cteAcceptCorpus is the WITH / CTE surface Trino 481 accepts.
+var cteAcceptCorpus = []string{
+	"WITH t AS (SELECT 1) SELECT * FROM t",
+	"WITH t AS (SELECT 1) TABLE t",
+	"WITH t (a, b) AS (SELECT 1, 2) SELECT * FROM t",
+	"WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a, b",
+	"WITH a AS (SELECT 1), b AS (SELECT 2), c AS (SELECT 3) SELECT * FROM a, b, c",
+	"WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n<5) SELECT * FROM t",
+	"WITH RECURSIVE a AS (SELECT * FROM x) TABLE y",
+	"WITH a (t, u) AS (SELECT * FROM x), b AS (SELECT * FROM y) TABLE z",
+	// a CTE whose body is itself a set operation / has ORDER BY / its own WITH
+	"WITH t AS (SELECT 1 UNION SELECT 2) SELECT * FROM t",
+	"WITH t AS (SELECT 1 ORDER BY 1 LIMIT 1) SELECT * FROM t",
+	"WITH outer_cte AS (WITH inner_cte AS (SELECT 1) SELECT * FROM inner_cte) SELECT * FROM outer_cte",
+	// WITH feeding a set operation / VALUES body
+	"WITH t AS (SELECT 1) SELECT * FROM t UNION SELECT 2",
+	"WITH t AS (VALUES 1, 2) SELECT * FROM t",
+}
+
+// cteRejectCorpus is malformed WITH input Trino 481 rejects with a SYNTAX_ERROR.
+// Includes the WITH SESSION divergence (D2): omni rejects it (legacy grammar
+// scope) and Trino 481 ALSO rejects `WITH SESSION` as a *CTE* — the 481 SESSION
+// prefix is `WITH SESSION prop = v <query>` which is exercised in the divergence
+// test, not here.
+var cteRejectCorpus = []string{
+	"WITH SELECT 1",                           // WITH with no CTE before the query
+	"WITH t SELECT 1",                         // CTE name with no AS (…)
+	"WITH t AS SELECT 1",                      // CTE body without parentheses
+	"WITH t AS () SELECT 1",                   // empty CTE body
+	"WITH t AS (SELECT 1)",                    // CTE with no trailing query
+	"WITH t AS (SELECT 1),",                   // trailing comma, no second CTE
+	"WITH RECURSIVE SELECT 1",                 // RECURSIVE with no CTE
+	"WITH t () AS (SELECT 1) SELECT * FROM t", // empty column-alias list
+}
+
+func TestCTE_AcceptCorpusParses(t *testing.T) {
+	for _, sql := range cteAcceptCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) != 0 {
+				t.Errorf("Parse(%q) should accept, got: %v", sql, errs)
+			}
+		})
+	}
+}
+
+func TestCTE_RejectCorpusRejected(t *testing.T) {
+	for _, sql := range cteRejectCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) == 0 {
+				t.Errorf("Parse(%q) should reject, but accepted", sql)
+			}
+		})
+	}
+}
+
+func TestCTE_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	check := func(t *testing.T, sql string) {
+		_, errs := Parse(sql)
+		omniAccepts := len(errs) == 0
+		trinoAccepts, ok := oracleAccepts(t, o, sql)
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH sql=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				sql, omniAccepts, errs, trinoAccepts)
+		}
+	}
+	for _, sql := range cteAcceptCorpus {
+		t.Run("accept/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+	for _, sql := range cteRejectCorpus {
+		t.Run("reject/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+}
+
+// ---------------------------------------------------------------------------
+// structural tests
+// ---------------------------------------------------------------------------
+
+func TestCTE_StructureWithList(t *testing.T) {
+	q := parseOneQuery(t, "WITH a AS (SELECT 1), b (x, y) AS (SELECT 1, 2) SELECT * FROM a, b")
+	if q.With == nil {
+		t.Fatal("With is nil, want a CTE list")
+	}
+	if q.With.Recursive {
+		t.Error("Recursive=true, want false")
+	}
+	if len(q.With.CTEs) != 2 {
+		t.Fatalf("CTEs=%d, want 2", len(q.With.CTEs))
+	}
+	if q.With.CTEs[0].Name.Value != "a" || len(q.With.CTEs[0].ColumnAliases) != 0 {
+		t.Errorf("CTE 0 = %+v, want name a no aliases", q.With.CTEs[0])
+	}
+	if q.With.CTEs[1].Name.Value != "b" || len(q.With.CTEs[1].ColumnAliases) != 2 {
+		t.Errorf("CTE 1 = %+v, want name b with 2 aliases", q.With.CTEs[1])
+	}
+	if q.With.CTEs[0].Query == nil {
+		t.Error("CTE 0 body is nil")
+	}
+}
+
+func TestCTE_StructureRecursive(t *testing.T) {
+	q := parseOneQuery(t, "WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n<5) SELECT * FROM t")
+	if q.With == nil || !q.With.Recursive {
+		t.Fatalf("With=%+v, want Recursive", q.With)
+	}
+	if len(q.With.CTEs) != 1 {
+		t.Fatalf("CTEs=%d, want 1", len(q.With.CTEs))
+	}
+	// The recursive CTE body is a set operation.
+	if _, ok := q.With.CTEs[0].Query.Body.(*SetOperation); !ok {
+		t.Errorf("CTE body is %T, want *SetOperation", q.With.CTEs[0].Query.Body)
+	}
+}
+
+func TestCTE_StructureNestedWith(t *testing.T) {
+	// A CTE whose body itself has a WITH.
+	q := parseOneQuery(t, "WITH a AS (WITH b AS (SELECT 1) SELECT * FROM b) SELECT * FROM a")
+	if q.With == nil || len(q.With.CTEs) != 1 {
+		t.Fatalf("With=%+v, want one outer CTE", q.With)
+	}
+	if q.With.CTEs[0].Query.With == nil {
+		t.Error("inner CTE query has no WITH, want a nested WITH")
+	}
+}

--- a/trino/parser/diagnose_test.go
+++ b/trino/parser/diagnose_test.go
@@ -6,12 +6,13 @@ import (
 )
 
 // TestDiagnose_CleanInputNoStubNoise verifies the wiring shape: Diagnose runs
-// Parse and surfaces ParseErrors as Diagnostics. While statement bodies are
-// stubbed, even valid SQL yields a "not yet supported" diagnostic — those
-// vanish as later DAG nodes implement real parsing. This test asserts the
-// count/shape relationship, not zero diagnostics.
+// Parse and surfaces ParseErrors as Diagnostics. While a statement body is still
+// stubbed (no DAG node has implemented it), even valid SQL of that form yields a
+// "not yet supported" diagnostic — those vanish as later nodes implement real
+// parsing. INSERT (parser-dml's job) is still stubbed; SELECT is now implemented
+// by parser-select, so this test uses a still-stubbed form.
 func TestDiagnose_StubbedStatementProducesDiagnostic(t *testing.T) {
-	diags := Diagnose("SELECT 1")
+	diags := Diagnose("INSERT INTO t VALUES (1)")
 	if len(diags) != 1 {
 		t.Fatalf("got %d diagnostics, want 1: %+v", len(diags), diags)
 	}
@@ -49,11 +50,12 @@ func TestDiagnose_EmptyInput(t *testing.T) {
 }
 
 // TestDiagnose_MultipleStatements verifies diagnostics are collected across all
-// segments (each stubbed statement yields its own).
+// segments. A valid SELECT (now implemented by parser-select) yields none, while
+// the two still-stubbed DML statements (INSERT, DELETE) each yield one.
 func TestDiagnose_MultipleStatements(t *testing.T) {
 	diags := Diagnose("SELECT 1; INSERT INTO t VALUES (1); DELETE FROM t")
-	if len(diags) != 3 {
-		t.Fatalf("got %d diagnostics, want 3: %+v", len(diags), diags)
+	if len(diags) != 2 {
+		t.Fatalf("got %d diagnostics, want 2 (INSERT + DELETE stubs; SELECT now parses): %+v", len(diags), diags)
 	}
 }
 

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -196,19 +196,12 @@ func (p *Parser) unknownStatementError() *ParseError {
 func (p *Parser) parseStmt() (ast.Node, error) {
 	switch p.cur.Kind {
 	// --- Query (rootQuery / queryPrimary leading tokens) ---
-	case kwSELECT:
-		return p.unsupported("SELECT")
-	case kwWITH:
-		// WITH cte... query  OR  WITH FUNCTION ... query (inline routine).
-		return p.unsupported("WITH")
-	case kwTABLE:
-		// TABLE qualifiedName — a query primary, e.g. `TABLE t`.
-		return p.unsupported("TABLE")
-	case kwVALUES:
-		return p.unsupported("VALUES")
-	case int('('):
-		// Parenthesized query expression at top level, e.g. (SELECT 1) UNION (SELECT 2).
-		return p.unsupported("query")
+	// SELECT / WITH / TABLE / VALUES / '(' all begin a query; parser-select's
+	// parseQueryStmt parses the whole query layer. (A leading `WITH FUNCTION`
+	// inline routine is the parser-routines node; parseQuery reports it as
+	// unsupported until that node lands.)
+	case kwSELECT, kwWITH, kwTABLE, kwVALUES, int('('):
+		return p.parseQueryStmt()
 
 	// --- Session / catalog context ---
 	case kwUSE:
@@ -358,6 +351,12 @@ func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
 					Msg: err.Error(),
 				})
 			}
+		} else if p.cur.Kind != tokEOF {
+			// A statement parsed cleanly but did not consume the whole segment:
+			// the leftover tokens are a syntax error (e.g. `SELECT a a a`,
+			// `SELECT 1 garbage`). Each segment holds exactly one top-level
+			// statement (Split cut on ';'), so any trailing token is invalid here.
+			p.errors = append(p.errors, *p.syntaxErrorAtCur())
 		}
 		result = node
 	}

--- a/trino/parser/parser_test.go
+++ b/trino/parser/parser_test.go
@@ -39,17 +39,18 @@ func TestParse_UnknownStatement(t *testing.T) {
 }
 
 // TestParse_KnownStatementUnsupported verifies that a statement whose leading
-// keyword IS in the dispatch switch but whose body is stubbed yields a
-// "not yet supported" diagnostic rather than an "unknown statement" one. The
-// foundation node ships dispatch only; concrete statement parsers arrive in
-// later DAG nodes.
+// keyword IS in the dispatch switch but whose body is STILL stubbed (no DAG node
+// has implemented it yet) yields a "not yet supported" diagnostic rather than an
+// "unknown statement" one. INSERT (parser-dml's job) is still stubbed; SELECT and
+// the rest of the query layer are now implemented by parser-select, so this test
+// uses a statement that remains a foundation stub.
 func TestParse_KnownStatementUnsupported(t *testing.T) {
-	file, errs := Parse("SELECT 1")
+	file, errs := Parse("INSERT INTO t VALUES (1)")
 	if file == nil {
 		t.Fatal("Parse: File is nil")
 	}
 	if len(errs) != 1 {
-		t.Fatalf("Parse(\"SELECT 1\"): got %d errors, want 1: %v", len(errs), errs)
+		t.Fatalf("Parse(\"INSERT ...\"): got %d errors, want 1: %v", len(errs), errs)
 	}
 	if !strings.Contains(errs[0].Msg, "not yet supported") {
 		t.Errorf("error = %q, want it to mention 'not yet supported'", errs[0].Msg)
@@ -57,10 +58,11 @@ func TestParse_KnownStatementUnsupported(t *testing.T) {
 }
 
 // TestParse_MultiStatementErrorsCollected verifies that ParseBestEffort
-// collects errors from every segment, not just the first. Two stubbed
-// statements separated by ';' must yield two errors.
+// collects errors from every segment, not just the first. Two still-stubbed
+// statements (INSERT and DELETE, parser-dml's job) separated by ';' must yield
+// two errors.
 func TestParse_MultiStatementErrorsCollected(t *testing.T) {
-	res := ParseBestEffort("SELECT 1; INSERT INTO t VALUES (1)")
+	res := ParseBestEffort("INSERT INTO t VALUES (1); DELETE FROM u")
 	if got := len(res.Errors); got != 2 {
 		t.Fatalf("ParseBestEffort: got %d errors, want 2: %v", got, res.Errors)
 	}

--- a/trino/parser/relation.go
+++ b/trino/parser/relation.go
@@ -1,0 +1,1330 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `parser-select` DAG node (with select.go, setops.go,
+// ctes.go and window.go): it implements Trino's FROM-clause relation grammar —
+// the `relation`, `joinType`, `joinCriteria`, `sampledRelation`,
+// `aliasedRelation`, `relationPrimary`, and `tableFunctionCall` rules.
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	relation
+//	    : left (CROSS JOIN right
+//	           | joinType JOIN rightRelation joinCriteria
+//	           | NATURAL joinType JOIN right)        # joinRelation
+//	    | sampledRelation                            # relationDefault ;
+//	joinType        : INNER? | (LEFT|RIGHT|FULL) OUTER? ;
+//	joinCriteria    : ON booleanExpression | USING ( identifier (, …)* ) ;
+//	sampledRelation : patternRecognition (TABLESAMPLE sampleType ( percentage ))? ;
+//	aliasedRelation : relationPrimary (AS? identifier columnAliases?)? ;
+//	relationPrimary
+//	    : qualifiedName queryPeriod?                 # tableName
+//	    | ( query )                                  # subqueryRelation
+//	    | UNNEST ( expression (, …)* ) (WITH ORDINALITY)?  # unnest
+//	    | LATERAL ( query )                          # lateral
+//	    | TABLE ( tableFunctionCall )                # tableFunctionInvocation
+//	    | ( relation )                               # parenthesizedRelation ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle.
+//
+// JOIN associativity & the CROSS/NATURAL operand asymmetry (oracle-confirmed via
+// the grammar shape): a JOIN chain is LEFT-associative. The qualified-join
+// alternative's right operand is `relation` (recursively), but CROSS JOIN and
+// NATURAL JOIN take a `sampledRelation` right operand — so `a JOIN b JOIN c` and
+// `a CROSS JOIN b CROSS JOIN c` both group left as `((a J b) J c)`. parseRelation
+// parses a sampledRelation then folds a left-associative loop of join suffixes.
+//
+// Node-scope boundary D4 (select.go): sampledRelation's patternRecognition adds
+// the MATCH_RECOGNIZE row-pattern subsystem, which is the parser-match-recognize
+// DAG node (row_pattern.go). Here a relation primary is its aliasedRelation with
+// the optional TABLESAMPLE only; a MATCH_RECOGNIZE following an aliasedRelation
+// is left for that node (its absence here means omni rejects MATCH_RECOGNIZE
+// until that node lands — tracked separately, not a parser-select divergence).
+//
+// Node-scope boundary B1 (expr.go): a LATERAL / subquery / TABLE(query) inner
+// `query` IS parsed into a real Query tree here (this node owns the query rule),
+// unlike expression-embedded subqueries which stay raw-text placeholders.
+
+// ---------------------------------------------------------------------------
+// Relation node hierarchy (parser-package; not ast.Node — see select.go header)
+// ---------------------------------------------------------------------------
+
+// Relation is the interface implemented by every FROM-clause relation node.
+// Span returns the source byte range; concrete fields are reached by a Go type
+// switch. It is the result type of the `relation` / `sampledRelation` /
+// `relationPrimary` rules.
+type Relation interface {
+	// Span returns the source byte range covered by the relation.
+	Span() ast.Loc
+	// relationNode is a marker preventing unrelated types from satisfying Relation.
+	relationNode()
+}
+
+// JoinType enumerates the join flavors (joinType + the CROSS/NATURAL forms).
+type JoinType int
+
+const (
+	// JoinInner is `[INNER] JOIN` (the default qualified join).
+	JoinInner JoinType = iota
+	// JoinLeft is `LEFT [OUTER] JOIN`.
+	JoinLeft
+	// JoinRight is `RIGHT [OUTER] JOIN`.
+	JoinRight
+	// JoinFull is `FULL [OUTER] JOIN`.
+	JoinFull
+	// JoinCross is `CROSS JOIN` (no criteria).
+	JoinCross
+)
+
+// String returns the canonical spelling of the join type (without OUTER).
+func (j JoinType) String() string {
+	switch j {
+	case JoinLeft:
+		return "LEFT"
+	case JoinRight:
+		return "RIGHT"
+	case JoinFull:
+		return "FULL"
+	case JoinCross:
+		return "CROSS"
+	default:
+		return "INNER"
+	}
+}
+
+// Join is a binary join (the joinRelation rule): `left <jointype> JOIN right
+// [criteria]`. Type is the join flavor; Natural marks a NATURAL join; Outer
+// records the explicit OUTER keyword. On is the `ON booleanExpression` criteria
+// (nil otherwise); Using is the `USING ( col, … )` criteria (nil otherwise).
+// CROSS and NATURAL joins carry no criteria.
+type Join struct {
+	Type    JoinType
+	Natural bool
+	Outer   bool
+	Left    Relation
+	Right   Relation
+	On      Expr              // ON condition, nil when absent
+	Using   []*ast.Identifier // USING column list, nil when absent
+	Loc     ast.Loc
+}
+
+func (n *Join) Span() ast.Loc { return n.Loc }
+func (*Join) relationNode()   {}
+
+// AliasedRelation is a relation primary with an optional alias and column-alias
+// list (the aliasedRelation rule applied to a relationPrimary). It also carries
+// the optional TABLESAMPLE (sampledRelation) wrapping the primary. Inner is the
+// underlying relationPrimary node. Alias / ColumnAliases are nil when absent.
+// Sample is nil when there is no TABLESAMPLE.
+type AliasedRelation struct {
+	Inner         Relation
+	Alias         *ast.Identifier
+	ColumnAliases []*ast.Identifier
+	Sample        *TableSample // TABLESAMPLE, nil when absent
+	Loc           ast.Loc
+}
+
+func (n *AliasedRelation) Span() ast.Loc { return n.Loc }
+func (*AliasedRelation) relationNode()   {}
+
+// TableSample is the `TABLESAMPLE (BERNOULLI|SYSTEM) ( percentage )` modifier
+// (the sampledRelation TABLESAMPLE clause). Method is "BERNOULLI" or "SYSTEM";
+// Percentage is the sample-rate expression.
+type TableSample struct {
+	Method     string
+	Percentage Expr
+	Loc        ast.Loc
+}
+
+// TableRelation is the `qualifiedName queryPeriod?` relation primary (the
+// tableName rule): a base table or view reference, optionally with a time-travel
+// queryPeriod. Period is nil when absent.
+type TableRelation struct {
+	Name   *ast.QualifiedName
+	Period *QueryPeriod // FOR (TIMESTAMP|VERSION) AS OF …, nil when absent
+	Loc    ast.Loc
+}
+
+func (n *TableRelation) Span() ast.Loc { return n.Loc }
+func (*TableRelation) relationNode()   {}
+
+// QueryPeriod is the `FOR (TIMESTAMP|VERSION) AS OF valueExpression` time-travel
+// clause (the queryPeriod rule). RangeType is "TIMESTAMP" or "VERSION"; End is
+// the as-of value expression.
+type QueryPeriod struct {
+	RangeType string // "TIMESTAMP" or "VERSION"
+	End       Expr
+	Loc       ast.Loc
+}
+
+// SubqueryRelation is the `( query )` relation primary (the subqueryRelation
+// rule): a derived table. Query is the parsed inner query (B1 boundary does not
+// apply — this node owns the query rule).
+type SubqueryRelation struct {
+	Query *Query
+	Loc   ast.Loc
+}
+
+func (n *SubqueryRelation) Span() ast.Loc { return n.Loc }
+func (*SubqueryRelation) relationNode()   {}
+
+// UnnestRelation is the `UNNEST ( expression (, …)* ) (WITH ORDINALITY)?`
+// relation primary (the unnest rule): expands array/map expressions into rows.
+// WithOrdinality marks the trailing WITH ORDINALITY.
+type UnnestRelation struct {
+	Exprs          []Expr
+	WithOrdinality bool
+	Loc            ast.Loc
+}
+
+func (n *UnnestRelation) Span() ast.Loc { return n.Loc }
+func (*UnnestRelation) relationNode()   {}
+
+// LateralRelation is the `LATERAL ( query )` relation primary (the lateral
+// rule): a correlated subquery that may reference earlier FROM items. Query is
+// the parsed inner query.
+type LateralRelation struct {
+	Query *Query
+	Loc   ast.Loc
+}
+
+func (n *LateralRelation) Span() ast.Loc { return n.Loc }
+func (*LateralRelation) relationNode()   {}
+
+// ParenRelation is the `( relation )` relation primary (the parenthesizedRelation
+// rule): a parenthesized relation, used to group joins explicitly. Inner is the
+// wrapped relation.
+type ParenRelation struct {
+	Inner Relation
+	Loc   ast.Loc
+}
+
+func (n *ParenRelation) Span() ast.Loc { return n.Loc }
+func (*ParenRelation) relationNode()   {}
+
+// TableFunctionRelation is the `TABLE ( tableFunctionCall )` relation primary
+// (the tableFunctionInvocation rule): a polymorphic table function invocation.
+// Call is the parsed table-function call.
+type TableFunctionRelation struct {
+	Call *TableFunctionCall
+	Loc  ast.Loc
+}
+
+func (n *TableFunctionRelation) Span() ast.Loc { return n.Loc }
+func (*TableFunctionRelation) relationNode()   {}
+
+// TableFunctionCall is `qualifiedName ( tableFunctionArgument (, …)* )
+// (COPARTITION …)?` (the tableFunctionCall rule). Name is the function name;
+// Args is the argument list; Copartition holds each COPARTITION group's tables.
+type TableFunctionCall struct {
+	Name        *ast.QualifiedName
+	Args        []TableFunctionArgument
+	Copartition [][]*ast.QualifiedName // each inner slice is one COPARTITION group
+	Loc         ast.Loc
+}
+
+// TableFunctionArgKind classifies a TableFunctionArgument's value.
+type TableFunctionArgKind int
+
+const (
+	// TFArgExpr is a scalar `expression` argument.
+	TFArgExpr TableFunctionArgKind = iota
+	// TFArgTable is a `TABLE ( … )` table argument (tableArgument).
+	TFArgTable
+	// TFArgDescriptor is a `DESCRIPTOR ( field, … )` or `CAST(NULL AS DESCRIPTOR)`
+	// argument (descriptorArgument).
+	TFArgDescriptor
+)
+
+// TableFunctionArgument is one argument of a table-function call (the
+// tableFunctionArgument rule): an optional `name =>` followed by a scalar
+// expression, a table argument, or a descriptor argument. Name is the optional
+// named-argument identifier (nil for a positional argument).
+type TableFunctionArgument struct {
+	Name       *ast.Identifier // name => …, nil for positional
+	Kind       TableFunctionArgKind
+	Expr       Expr           // for TFArgExpr
+	Table      *TableArgument // for TFArgTable
+	Descriptor *DescriptorArg // for TFArgDescriptor
+	Loc        ast.Loc
+}
+
+// TableArgument is a table-function `TABLE ( name | query )` argument with the
+// optional PARTITION BY / PRUNE|KEEP WHEN EMPTY / ORDER BY modifiers (the
+// tableArgument + tableArgumentRelation rules). Exactly one of Name / Query is
+// non-nil. Alias / ColumnAliases carry the optional `AS? identifier (cols)?`.
+type TableArgument struct {
+	Name          *ast.QualifiedName // TABLE ( qualifiedName )
+	Query         *Query             // TABLE ( query )
+	Alias         *ast.Identifier
+	ColumnAliases []*ast.Identifier
+	PartitionBy   []Expr     // PARTITION BY …, nil when absent
+	Pruning       string     // "", "PRUNE WHEN EMPTY", or "KEEP WHEN EMPTY"
+	OrderBy       []SortItem // ORDER BY …, nil when absent
+	Loc           ast.Loc
+}
+
+// DescriptorArg is a `DESCRIPTOR ( field, … )` or `CAST(NULL AS DESCRIPTOR)`
+// table-function argument (the descriptorArgument rule). NullCast marks the
+// CAST(NULL AS DESCRIPTOR) form (Fields is nil then). Otherwise Fields lists the
+// descriptor fields.
+type DescriptorArg struct {
+	NullCast bool
+	Fields   []DescriptorField
+	Loc      ast.Loc
+}
+
+// DescriptorField is one `identifier type?` of a DESCRIPTOR argument (the
+// descriptorField rule). Type is nil when the field has no declared type.
+type DescriptorField struct {
+	Name *ast.Identifier
+	Type *DataType // nil when absent
+	Loc  ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// relation list / relation (joins)
+// ---------------------------------------------------------------------------
+
+// parseRelationList parses `relation (, relation)*` — the comma-separated FROM
+// item list. A comma between relations is an implicit cross join; each item is a
+// full `relation` (so `FROM a JOIN b, c` is `(a JOIN b)` and `c`).
+func (p *Parser) parseRelationList() ([]Relation, error) {
+	first, err := p.parseRelation()
+	if err != nil {
+		return nil, err
+	}
+	rels := []Relation{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseRelation()
+		if err != nil {
+			return nil, err
+		}
+		rels = append(rels, next)
+	}
+	return rels, nil
+}
+
+// parseRelation parses one `relation`: a sampledRelation followed by a
+// left-associative chain of join suffixes (CROSS JOIN, qualified JOIN with
+// criteria, or NATURAL JOIN). The left-associative loop mirrors ANTLR's
+// left-recursive `relation` rule.
+func (p *Parser) parseRelation() (Relation, error) {
+	left, err := p.parseSampledRelation()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		joined, ok, err := p.tryParseJoinSuffix(left)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return left, nil
+		}
+		left = joined
+	}
+}
+
+// tryParseJoinSuffix parses one join suffix on `left` if the current token
+// begins a join (CROSS / NATURAL / a joinType keyword / JOIN). It returns
+// ok=false (no join) when no join keyword leads. The three join shapes:
+//
+//   - CROSS JOIN sampledRelation         (no criteria)
+//   - joinType JOIN relation joinCriteria
+//   - NATURAL joinType JOIN sampledRelation (no criteria)
+func (p *Parser) tryParseJoinSuffix(left Relation) (Relation, bool, error) {
+	switch p.cur.Kind {
+	case kwCROSS:
+		return p.parseCrossJoin(left)
+	case kwNATURAL:
+		return p.parseNaturalJoin(left)
+	case kwJOIN, kwINNER, kwLEFT, kwRIGHT, kwFULL:
+		j, err := p.parseQualifiedJoin(left)
+		if err != nil {
+			return nil, false, err
+		}
+		return j, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+// parseCrossJoin parses `CROSS JOIN sampledRelation` on `left` (CROSS is
+// current). A cross join carries no criteria and takes a sampledRelation (not a
+// full relation) right operand, keeping a chain left-associative.
+func (p *Parser) parseCrossJoin(left Relation) (Relation, bool, error) {
+	p.advance() // consume CROSS
+	if _, err := p.expect(kwJOIN); err != nil {
+		return nil, false, err
+	}
+	right, err := p.parseSampledRelation()
+	if err != nil {
+		return nil, false, err
+	}
+	return &Join{
+		Type:  JoinCross,
+		Left:  left,
+		Right: right,
+		Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+	}, true, nil
+}
+
+// parseNaturalJoin parses `NATURAL joinType JOIN sampledRelation` on `left`
+// (NATURAL is current). A natural join carries no explicit criteria and takes a
+// sampledRelation right operand.
+func (p *Parser) parseNaturalJoin(left Relation) (Relation, bool, error) {
+	p.advance() // consume NATURAL
+	jt, outer := p.parseJoinType()
+	if _, err := p.expect(kwJOIN); err != nil {
+		return nil, false, err
+	}
+	right, err := p.parseSampledRelation()
+	if err != nil {
+		return nil, false, err
+	}
+	return &Join{
+		Type:    jt,
+		Natural: true,
+		Outer:   outer,
+		Left:    left,
+		Right:   right,
+		Loc:     ast.Loc{Start: left.Span().Start, End: right.Span().End},
+	}, true, nil
+}
+
+// parseQualifiedJoin parses `joinType JOIN relation joinCriteria` on `left`
+// (the leading joinType keyword or JOIN is current). The right operand is a full
+// relation; the criteria (ON / USING) is mandatory for a qualified join.
+func (p *Parser) parseQualifiedJoin(left Relation) (Relation, error) {
+	jt, outer := p.parseJoinType()
+	if _, err := p.expect(kwJOIN); err != nil {
+		return nil, err
+	}
+	right, err := p.parseRelation()
+	if err != nil {
+		return nil, err
+	}
+	join := &Join{
+		Type:  jt,
+		Outer: outer,
+		Left:  left,
+		Right: right,
+		Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+	}
+	if err := p.parseJoinCriteria(join); err != nil {
+		return nil, err
+	}
+	return join, nil
+}
+
+// parseJoinType parses the optional `joinType` keyword sequence (INNER? |
+// (LEFT|RIGHT|FULL) OUTER?) and returns the flavor plus whether an explicit
+// OUTER was present. A bare JOIN (no leading keyword) is INNER. INNER never
+// takes OUTER.
+func (p *Parser) parseJoinType() (JoinType, bool) {
+	switch p.cur.Kind {
+	case kwINNER:
+		p.advance() // consume INNER
+		return JoinInner, false
+	case kwLEFT:
+		p.advance()
+		return JoinLeft, p.matchOptionalOuter()
+	case kwRIGHT:
+		p.advance()
+		return JoinRight, p.matchOptionalOuter()
+	case kwFULL:
+		p.advance()
+		return JoinFull, p.matchOptionalOuter()
+	default:
+		// Bare JOIN — INNER.
+		return JoinInner, false
+	}
+}
+
+// matchOptionalOuter consumes an optional OUTER keyword, returning whether it
+// was present.
+func (p *Parser) matchOptionalOuter() bool {
+	_, ok := p.match(kwOUTER)
+	return ok
+}
+
+// parseJoinCriteria parses the mandatory `joinCriteria` of a qualified join
+// (ON booleanExpression | USING ( identifier (, …)* )) and stores it on the
+// join. ON / USING is the current token.
+func (p *Parser) parseJoinCriteria(join *Join) error {
+	switch p.cur.Kind {
+	case kwON:
+		p.advance() // consume ON
+		cond, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		join.On = cond
+		join.Loc.End = cond.Span().End
+		return nil
+	case kwUSING:
+		p.advance() // consume USING
+		if _, err := p.expect(int('(')); err != nil {
+			return err
+		}
+		first, err := p.parseIdentifier()
+		if err != nil {
+			return err
+		}
+		cols := []*ast.Identifier{first}
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseIdentifier()
+			if err != nil {
+				return err
+			}
+			cols = append(cols, next)
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return err
+		}
+		join.Using = cols
+		join.Loc.End = closeTok.Loc.End
+		return nil
+	default:
+		return p.exprErrorAt("expected ON or USING join criteria")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sampledRelation / aliasedRelation
+// ---------------------------------------------------------------------------
+
+// parseSampledRelation parses a `sampledRelation`: an aliasedRelation with an
+// optional trailing `TABLESAMPLE (BERNOULLI|SYSTEM) ( percentage )`. (The
+// MATCH_RECOGNIZE patternRecognition layer between them is the
+// parser-match-recognize node, D4.)
+func (p *Parser) parseSampledRelation() (Relation, error) {
+	rel, err := p.parseAliasedRelation()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != kwTABLESAMPLE {
+		return rel, nil
+	}
+	sample, err := p.parseTableSample()
+	if err != nil {
+		return nil, err
+	}
+	// Attach the sample to the aliased relation; if rel is not an AliasedRelation
+	// (it always is, parseAliasedRelation wraps every primary) fall back to a
+	// fresh wrapper so the sample is never dropped.
+	if ar, ok := rel.(*AliasedRelation); ok {
+		ar.Sample = sample
+		ar.Loc.End = sample.Loc.End
+		return ar, nil
+	}
+	return &AliasedRelation{
+		Inner:  rel,
+		Sample: sample,
+		Loc:    ast.Loc{Start: rel.Span().Start, End: sample.Loc.End},
+	}, nil
+}
+
+// parseTableSample parses `TABLESAMPLE (BERNOULLI|SYSTEM) ( percentage )`
+// (TABLESAMPLE is current).
+func (p *Parser) parseTableSample() (*TableSample, error) {
+	sampleTok := p.advance() // consume TABLESAMPLE
+	methodTok, ok := p.match(kwBERNOULLI, kwSYSTEM)
+	if !ok {
+		return nil, p.exprErrorAt("expected BERNOULLI or SYSTEM after TABLESAMPLE")
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	pct, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &TableSample{
+		Method:     methodTok.Str,
+		Percentage: pct,
+		Loc:        ast.Loc{Start: sampleTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseAliasedRelation parses an `aliasedRelation`: a relationPrimary with an
+// optional `AS? identifier columnAliases?` alias. The alias identifier is
+// optional and (per the grammar) follows an optional AS; a column-alias list may
+// follow the alias name.
+func (p *Parser) parseAliasedRelation() (Relation, error) {
+	primary, err := p.parseRelationPrimary()
+	if err != nil {
+		return nil, err
+	}
+
+	alias, cols, end, ok, err := p.tryParseRelationAlias()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		// No alias: still wrap in AliasedRelation so a later TABLESAMPLE can attach
+		// uniformly, and so consumers see a single relation-primary node shape.
+		return &AliasedRelation{Inner: primary, Loc: primary.Span()}, nil
+	}
+	return &AliasedRelation{
+		Inner:         primary,
+		Alias:         alias,
+		ColumnAliases: cols,
+		Loc:           ast.Loc{Start: primary.Span().Start, End: end},
+	}, nil
+}
+
+// tryParseRelationAlias parses the optional `AS? identifier columnAliases?` after
+// a relation primary. It returns ok=false when no alias is present. An explicit
+// AS makes the identifier mandatory; without AS, an identifier-start token is
+// taken as the alias UNLESS it is a non-reserved clause keyword sitting in
+// clause-introducing position (see atRelationClauseStart) — those introduce the
+// surrounding querySpecification's WINDOW / LIMIT / OFFSET / FETCH clause or the
+// sampledRelation's TABLESAMPLE, not an alias. (Most clause/join keywords —
+// WHERE/GROUP/HAVING/ORDER/JOIN/ON/… — are reserved, so isIdentifierStart already
+// excludes them; only WINDOW/LIMIT/OFFSET/FETCH/TABLESAMPLE are non-reserved and
+// need the extra guard. A bare non-reserved keyword — `FROM t window`,
+// `FROM t limit` — is still a valid alias and is taken here.)
+func (p *Parser) tryParseRelationAlias() (alias *ast.Identifier, cols []*ast.Identifier, end int, ok bool, err error) {
+	if p.cur.Kind == kwAS {
+		p.advance() // consume AS — an identifier MUST follow (even a clause keyword)
+		id, e := p.parseIdentifier()
+		if e != nil {
+			return nil, nil, 0, false, e
+		}
+		alias = id
+		end = id.Loc.End
+	} else if isIdentifierStart(p.cur.Kind) && !p.atRelationClauseStart() {
+		alias = identFromToken(p.advance())
+		end = alias.Loc.End
+	} else {
+		return nil, nil, 0, false, nil
+	}
+
+	// Optional column-alias list `( col, … )`.
+	if p.cur.Kind == int('(') {
+		c, e, cerr := p.parseColumnAliases()
+		if cerr != nil {
+			return nil, nil, 0, false, cerr
+		}
+		cols = c
+		end = e
+	}
+	return alias, cols, end, true, nil
+}
+
+// atRelationClauseStart reports whether the cursor sits at a NON-RESERVED clause
+// keyword that, here, introduces a clause rather than naming a relation alias —
+// disambiguated by the token that follows it (matching Trino 481, probed):
+//
+//	WINDOW      + identifier      → the querySpecification WINDOW clause
+//	LIMIT       + (ALL|int|?)     → the queryNoWith LIMIT clause
+//	OFFSET      + (int|?)         → the queryNoWith OFFSET clause
+//	FETCH       + (FIRST|NEXT)    → the queryNoWith FETCH clause
+//	TABLESAMPLE + (BERNOULLI|SYSTEM) → the sampledRelation TABLESAMPLE clause
+//
+// A bare occurrence (e.g. `FROM t window`, `FROM t limit`) does NOT match and is
+// taken as an alias by the caller. The reserved clause/join keywords need no
+// guard (isIdentifierStart already rejects them).
+func (p *Parser) atRelationClauseStart() bool {
+	switch p.cur.Kind {
+	case kwWINDOW:
+		return isIdentifierStart(p.peekNext().Kind)
+	case kwLIMIT:
+		nk := p.peekNext().Kind
+		return nk == kwALL || nk == tokInteger || nk == tokQuestion || nk == int('?')
+	case kwOFFSET:
+		nk := p.peekNext().Kind
+		return nk == tokInteger || nk == tokQuestion || nk == int('?')
+	case kwFETCH:
+		nk := p.peekNext().Kind
+		return nk == kwFIRST || nk == kwNEXT
+	case kwTABLESAMPLE:
+		nk := p.peekNext().Kind
+		return nk == kwBERNOULLI || nk == kwSYSTEM
+	default:
+		return false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// relationPrimary
+// ---------------------------------------------------------------------------
+
+// parseRelationPrimary parses one `relationPrimary`:
+//
+//   - UNNEST ( … ) [WITH ORDINALITY]      (unnest)
+//   - LATERAL ( query )                   (lateral)
+//   - TABLE ( tableFunctionCall )         (tableFunctionInvocation)
+//   - ( query ) | ( relation )            (subqueryRelation / parenthesizedRelation)
+//   - qualifiedName [queryPeriod]         (tableName)
+//
+// UNNEST and TABLE are reserved keywords, so they unambiguously begin their forms
+// (and require the following '('). LATERAL is NON-RESERVED, so it begins the
+// lateral form only when directly followed by '('; a bare LATERAL (or LATERAL not
+// followed by '(') is an ordinary table-name reference (`FROM lateral`,
+// `FROM lateral x`), oracle-confirmed in Trino 481.
+//
+// JSON_TABLE (a 481 relationPrimary absent from the legacy grammar) is the
+// deferred P1 extension D1 (select.go); it is not handled here.
+func (p *Parser) parseRelationPrimary() (Relation, error) {
+	switch p.cur.Kind {
+	case kwUNNEST:
+		return p.parseUnnest()
+	case kwLATERAL:
+		// LATERAL is non-reserved: `LATERAL ( query )` is the lateral form, but a
+		// LATERAL not followed by '(' is a table named "lateral".
+		if p.peekNext().Kind == int('(') {
+			return p.parseLateral()
+		}
+		return p.parseTableRelation()
+	case kwTABLE:
+		return p.parseTableFunctionInvocation()
+	case int('('):
+		return p.parseParenRelationOrSubquery()
+	default:
+		return p.parseTableRelation()
+	}
+}
+
+// parseTableRelation parses `qualifiedName queryPeriod?` (the tableName rule):
+// a base table/view reference with an optional time-travel period.
+func (p *Parser) parseTableRelation() (Relation, error) {
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	rel := &TableRelation{Name: name, Loc: name.Loc}
+	if p.cur.Kind == kwFOR {
+		period, err := p.parseQueryPeriod()
+		if err != nil {
+			return nil, err
+		}
+		rel.Period = period
+		rel.Loc.End = period.Loc.End
+	}
+	return rel, nil
+}
+
+// parseQueryPeriod parses `FOR (TIMESTAMP|VERSION) AS OF valueExpression`
+// (the queryPeriod rule; FOR is current). The as-of value is a valueExpression
+// (not a full booleanExpression).
+func (p *Parser) parseQueryPeriod() (*QueryPeriod, error) {
+	forTok := p.advance() // consume FOR
+	rangeTok, ok := p.match(kwTIMESTAMP, kwVERSION)
+	if !ok {
+		return nil, p.exprErrorAt("expected TIMESTAMP or VERSION after FOR")
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwOF); err != nil {
+		return nil, err
+	}
+	end, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &QueryPeriod{
+		RangeType: rangeTok.Str,
+		End:       end,
+		Loc:       ast.Loc{Start: forTok.Loc.Start, End: end.Span().End},
+	}, nil
+}
+
+// parseUnnest parses `UNNEST ( expression (, …)* ) (WITH ORDINALITY)?` (UNNEST
+// is current).
+func (p *Parser) parseUnnest() (Relation, error) {
+	unnestTok := p.advance() // consume UNNEST
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	exprs := []Expr{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	rel := &UnnestRelation{
+		Exprs: exprs,
+		Loc:   ast.Loc{Start: unnestTok.Loc.Start, End: closeTok.Loc.End},
+	}
+	if p.cur.Kind == kwWITH {
+		p.advance() // consume WITH
+		ordTok, err := p.expect(kwORDINALITY)
+		if err != nil {
+			return nil, err
+		}
+		rel.WithOrdinality = true
+		rel.Loc.End = ordTok.Loc.End
+	}
+	return rel, nil
+}
+
+// parseLateral parses `LATERAL ( query )` (LATERAL is current). The inner query
+// is parsed into a real Query tree (this node owns the query rule).
+func (p *Parser) parseLateral() (Relation, error) {
+	lateralTok := p.advance() // consume LATERAL
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	q, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &LateralRelation{
+		Query: q,
+		Loc:   ast.Loc{Start: lateralTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseParenRelationOrSubquery disambiguates a leading '(' between a
+// parenthesized query `( query )` (subqueryRelation) and a parenthesized
+// relation `( relation )` (parenthesizedRelation; e.g. an explicitly grouped
+// join). The token after '(' decides:
+//
+//   - SELECT / WITH / VALUES / TABLE-name → unambiguously a query; parse one.
+//   - a nested '(' → AMBIGUOUS: `((SELECT 1))` is a nested subquery, while
+//     `((a JOIN b ON …) JOIN c ON …)` is a nested parenthesized relation. Both
+//     start `((`, and the deciding token lies arbitrarily deep, so a checkpoint
+//     speculates: try a query first; if that fails (or does not land on the
+//     matching ')'), rewind and parse a relation.
+//   - anything else (an identifier table name, UNNEST, LATERAL, TABLE(func)) →
+//     a relation.
+func (p *Parser) parseParenRelationOrSubquery() (Relation, error) {
+	openTok := p.advance() // consume '('
+
+	switch {
+	case p.startsQueryRelation():
+		return p.finishSubqueryRelation(openTok.Loc.Start)
+	case p.cur.Kind == int('('):
+		// Ambiguous `((…`. Speculatively read a query; fall back to a relation.
+		cp := p.checkpoint()
+		if q, err := p.parseQuery(); err == nil && p.cur.Kind == int(')') {
+			closeTok := p.advance() // consume ')'
+			return &SubqueryRelation{
+				Query: q,
+				Loc:   ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+			}, nil
+		}
+		p.restore(cp)
+		return p.finishParenRelation(openTok.Loc.Start)
+	default:
+		return p.finishParenRelation(openTok.Loc.Start)
+	}
+}
+
+// finishSubqueryRelation parses `query )` after the opening '(' of a relation
+// subquery (the '(' already consumed; startOffset is its byte offset).
+func (p *Parser) finishSubqueryRelation(startOffset int) (Relation, error) {
+	q, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &SubqueryRelation{
+		Query: q,
+		Loc:   ast.Loc{Start: startOffset, End: closeTok.Loc.End},
+	}, nil
+}
+
+// finishParenRelation parses `relation )` after the opening '(' of a
+// parenthesized relation (the '(' already consumed; startOffset is its byte
+// offset).
+func (p *Parser) finishParenRelation(startOffset int) (Relation, error) {
+	inner, err := p.parseRelation()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ParenRelation{
+		Inner: inner,
+		Loc:   ast.Loc{Start: startOffset, End: closeTok.Loc.End},
+	}, nil
+}
+
+// startsQueryRelation reports whether the current token UNAMBIGUOUSLY begins a
+// `query` in a relation-subquery position: SELECT / WITH / VALUES, or TABLE not
+// followed by '(' (the `TABLE qualifiedName` query primary). A nested '(' is
+// deliberately EXCLUDED — it is ambiguous between a nested subquery and a nested
+// parenthesized relation, and is resolved by speculation in the caller. A
+// relation, by contrast, starts with an identifier (table name), UNNEST,
+// LATERAL, or TABLE ( … ) (the table-function relation primary).
+func (p *Parser) startsQueryRelation() bool {
+	switch p.cur.Kind {
+	case kwSELECT, kwWITH, kwVALUES:
+		return true
+	case kwTABLE:
+		// TABLE qualifiedName is a query primary; TABLE ( … ) is the table-function
+		// relation primary. Decide by the token after TABLE.
+		return p.peekNext().Kind != int('(')
+	default:
+		return false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// table function invocation
+// ---------------------------------------------------------------------------
+
+// parseTableFunctionInvocation parses `TABLE ( tableFunctionCall )`
+// (the tableFunctionInvocation relation primary; TABLE is current). Note this is
+// distinct from the `TABLE qualifiedName` query primary — here TABLE is
+// immediately followed by '(' and wraps a tableFunctionCall.
+func (p *Parser) parseTableFunctionInvocation() (Relation, error) {
+	tableTok := p.advance() // consume TABLE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	call, err := p.parseTableFunctionCall()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &TableFunctionRelation{
+		Call: call,
+		Loc:  ast.Loc{Start: tableTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// atCopartitionClause reports whether the cursor sits at the COPARTITION clause
+// of a tableFunctionCall, as opposed to a `copartition => …` named argument.
+// COPARTITION is a non-reserved keyword, so a leading COPARTITION followed by
+// `=>` is an argument name, not the clause. Oracle-confirmed: Trino 481 accepts
+// `TABLE(f(copartition => 1))` as a named-argument call.
+func (p *Parser) atCopartitionClause() bool {
+	return p.cur.Kind == kwCOPARTITION && p.peekNext().Kind != tokDoubleArrow
+}
+
+// parseTableFunctionCall parses `qualifiedName ( tableFunctionArgument (, …)* )
+// (COPARTITION copartitionTables (, …)*)?` (the tableFunctionCall rule).
+func (p *Parser) parseTableFunctionCall() (*TableFunctionCall, error) {
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	call := &TableFunctionCall{Name: name, Loc: ast.Loc{Start: name.Loc.Start}}
+
+	// Argument list (possibly empty). COPARTITION is non-reserved, so a leading
+	// COPARTITION is the COPARTITION clause only when it is NOT a `copartition =>`
+	// named argument (atCopartitionClause); otherwise it begins an argument.
+	if p.cur.Kind != int(')') && !p.atCopartitionClause() {
+		first, err := p.parseTableFunctionArgument()
+		if err != nil {
+			return nil, err
+		}
+		call.Args = []TableFunctionArgument{first}
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseTableFunctionArgument()
+			if err != nil {
+				return nil, err
+			}
+			call.Args = append(call.Args, next)
+		}
+	}
+
+	// Optional COPARTITION groups (the clause, not a `copartition =>` argument).
+	for p.atCopartitionClause() {
+		p.advance() // consume COPARTITION
+		group, err := p.parseCopartitionTables()
+		if err != nil {
+			return nil, err
+		}
+		call.Copartition = append(call.Copartition, group)
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	call.Loc.End = closeTok.Loc.End
+	return call, nil
+}
+
+// parseTableFunctionArgument parses one `tableFunctionArgument`: an optional
+// `name =>` followed by a table argument, a descriptor argument, or a scalar
+// expression. The descriptor alternative is tried before expression (its DESCRIPTOR
+// keyword leads), and TABLE leads the table argument.
+func (p *Parser) parseTableFunctionArgument() (TableFunctionArgument, error) {
+	arg := TableFunctionArgument{}
+	start := p.cur.Loc.Start
+
+	// Optional `name =>` prefix.
+	if isIdentifierStart(p.cur.Kind) && p.peekNext().Kind == tokDoubleArrow {
+		arg.Name = identFromToken(p.advance())
+		p.advance() // consume =>
+	}
+
+	switch {
+	case p.cur.Kind == kwTABLE:
+		ta, err := p.parseTableArgument()
+		if err != nil {
+			return TableFunctionArgument{}, err
+		}
+		arg.Kind = TFArgTable
+		arg.Table = ta
+		arg.Loc = ast.Loc{Start: start, End: ta.Loc.End}
+	case (p.cur.Kind == kwDESCRIPTOR && p.peekNext().Kind == int('(')) || (p.cur.Kind == kwCAST && p.peekNext().Kind == int('(')):
+		// DESCRIPTOR(...) or CAST(NULL AS DESCRIPTOR). DESCRIPTOR is non-reserved,
+		// so a bare `descriptor` (not followed by '(') is an ordinary column
+		// reference handled by the default expression branch — only DESCRIPTOR '('
+		// enters here. For CAST, only the CAST(NULL AS DESCRIPTOR) shape is a
+		// descriptor argument; an ordinary CAST is a scalar expression. Try the
+		// descriptor form, fall back to a scalar expression.
+		da, ok, err := p.tryParseDescriptorArg(start)
+		if err != nil {
+			return TableFunctionArgument{}, err
+		}
+		if ok {
+			arg.Kind = TFArgDescriptor
+			arg.Descriptor = da
+			arg.Loc = ast.Loc{Start: start, End: da.Loc.End}
+		} else {
+			e, err := p.parseExpr()
+			if err != nil {
+				return TableFunctionArgument{}, err
+			}
+			arg.Kind = TFArgExpr
+			arg.Expr = e
+			arg.Loc = ast.Loc{Start: start, End: e.Span().End}
+		}
+	default:
+		e, err := p.parseExpr()
+		if err != nil {
+			return TableFunctionArgument{}, err
+		}
+		arg.Kind = TFArgExpr
+		arg.Expr = e
+		arg.Loc = ast.Loc{Start: start, End: e.Span().End}
+	}
+	return arg, nil
+}
+
+// atTableArgModifier reports whether the cursor sits at a table-argument
+// modifier in position — PARTITION/ORDER followed by BY, or PRUNE/KEEP followed
+// by WHEN. These four words are non-reserved keywords (usable as relation
+// aliases), so the table-argument parser must not consume them as an alias when
+// they actually introduce a modifier clause.
+func (p *Parser) atTableArgModifier() bool {
+	switch p.cur.Kind {
+	case kwPARTITION, kwORDER:
+		return p.peekNext().Kind == kwBY
+	case kwPRUNE, kwKEEP:
+		return p.peekNext().Kind == kwWHEN
+	default:
+		return false
+	}
+}
+
+// parseTableArgument parses a `tableArgument`: a `TABLE ( name | query )`
+// relation with the optional PARTITION BY / PRUNE|KEEP WHEN EMPTY / ORDER BY
+// modifiers (TABLE is current).
+func (p *Parser) parseTableArgument() (*TableArgument, error) {
+	tableTok := p.advance() // consume TABLE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	ta := &TableArgument{Loc: ast.Loc{Start: tableTok.Loc.Start}}
+
+	// TABLE ( query ) vs TABLE ( qualifiedName ). A query starts with
+	// SELECT/WITH/VALUES/TABLE-name; a bare table name is a qualifiedName. A
+	// leading '(' here is unambiguously a (parenthesized) query — a qualifiedName
+	// cannot start with '(' — so it is parsed as a query, not via the relation
+	// speculation parseParenRelationOrSubquery uses (a tableArgument's content is
+	// `query | qualifiedName`, never a parenthesized relation).
+	if p.startsQueryRelation() || p.cur.Kind == int('(') {
+		q, err := p.parseQuery()
+		if err != nil {
+			return nil, err
+		}
+		ta.Query = q
+	} else {
+		name, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, err
+		}
+		ta.Name = name
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ta.Loc.End = closeTok.Loc.End
+
+	// Optional `AS? identifier columnAliases?`. The alias is NOT taken when the
+	// current token is a table-argument MODIFIER in position — PARTITION/ORDER
+	// followed by BY, or PRUNE/KEEP followed by WHEN — because those non-reserved
+	// keywords would otherwise be mis-consumed as the alias (e.g. the alias parser
+	// would grab PARTITION, leaving a dangling BY). An explicit AS still forces an
+	// alias. Probed against Trino 481 (`TABLE(orders) PARTITION BY …`).
+	if !p.atTableArgModifier() {
+		if alias, cols, end, ok, err := p.tryParseRelationAlias(); err != nil {
+			return nil, err
+		} else if ok {
+			ta.Alias = alias
+			ta.ColumnAliases = cols
+			ta.Loc.End = end
+		}
+	}
+
+	// Optional PARTITION BY ( … ) | expression.
+	if p.cur.Kind == kwPARTITION {
+		p.advance() // consume PARTITION
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		exprs, end, err := p.parseParenOrBareExprList()
+		if err != nil {
+			return nil, err
+		}
+		ta.PartitionBy = exprs
+		ta.Loc.End = end
+	}
+
+	// Optional PRUNE WHEN EMPTY | KEEP WHEN EMPTY.
+	if p.cur.Kind == kwPRUNE || p.cur.Kind == kwKEEP {
+		kwTok := p.advance() // consume PRUNE / KEEP
+		if _, err := p.expect(kwWHEN); err != nil {
+			return nil, err
+		}
+		emptyTok, err := p.expect(kwEMPTY)
+		if err != nil {
+			return nil, err
+		}
+		ta.Pruning = kwTok.Str + " WHEN EMPTY"
+		ta.Loc.End = emptyTok.Loc.End
+	}
+
+	// Optional ORDER BY ( sortItem, … ) | sortItem.
+	if p.cur.Kind == kwORDER {
+		items, end, err := p.parseParenOrBareSortItems()
+		if err != nil {
+			return nil, err
+		}
+		ta.OrderBy = items
+		ta.Loc.End = end
+	}
+
+	return ta, nil
+}
+
+// parseParenOrBareExprList parses `( expression (, …)* )` (possibly empty) or a
+// single bare expression, returning the expressions and the end offset. Used by
+// a table argument's PARTITION BY, which allows either spelling.
+func (p *Parser) parseParenOrBareExprList() ([]Expr, int, error) {
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		exprs, closeTok, err := p.parseBracketedExprList(int(')'))
+		if err != nil {
+			return nil, 0, err
+		}
+		return exprs, closeTok.Loc.End, nil
+	}
+	e, err := p.parseExpr()
+	if err != nil {
+		return nil, 0, err
+	}
+	return []Expr{e}, e.Span().End, nil
+}
+
+// parseParenOrBareSortItems parses `ORDER BY ( sortItem (, …)* )` or `ORDER BY
+// sortItem` (ORDER is current), returning the sort items and the end offset.
+// Used by a table argument's ORDER BY, which allows either spelling.
+func (p *Parser) parseParenOrBareSortItems() ([]SortItem, int, error) {
+	p.advance() // consume ORDER
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, 0, err
+	}
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		first, err := p.parseSortItem()
+		if err != nil {
+			return nil, 0, err
+		}
+		items := []SortItem{first}
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseSortItem()
+			if err != nil {
+				return nil, 0, err
+			}
+			items = append(items, next)
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, 0, err
+		}
+		return items, closeTok.Loc.End, nil
+	}
+	first, err := p.parseSortItem()
+	if err != nil {
+		return nil, 0, err
+	}
+	items := []SortItem{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseSortItem()
+		if err != nil {
+			return nil, 0, err
+		}
+		items = append(items, next)
+	}
+	return items, items[len(items)-1].Loc.End, nil
+}
+
+// tryParseDescriptorArg parses a `descriptorArgument`:
+// `DESCRIPTOR ( field, … )` or `CAST ( NULL AS DESCRIPTOR )`. start is the
+// argument's first-token offset. It returns ok=false (parser rewound) when a
+// leading CAST is an ordinary CAST expression rather than the
+// CAST(NULL AS DESCRIPTOR) form.
+func (p *Parser) tryParseDescriptorArg(start int) (*DescriptorArg, bool, error) {
+	if p.cur.Kind == kwDESCRIPTOR {
+		p.advance() // consume DESCRIPTOR
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, false, err
+		}
+		first, err := p.parseDescriptorField()
+		if err != nil {
+			return nil, false, err
+		}
+		fields := []DescriptorField{first}
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseDescriptorField()
+			if err != nil {
+				return nil, false, err
+			}
+			fields = append(fields, next)
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, false, err
+		}
+		return &DescriptorArg{Fields: fields, Loc: ast.Loc{Start: start, End: closeTok.Loc.End}}, true, nil
+	}
+
+	// CAST ( NULL AS DESCRIPTOR ) — speculatively match the exact shape; on any
+	// mismatch rewind so the caller parses an ordinary CAST expression.
+	cp := p.checkpoint()
+	p.advance() // consume CAST
+	if p.cur.Kind != int('(') {
+		p.restore(cp)
+		return nil, false, nil
+	}
+	p.advance() // consume '('
+	if p.cur.Kind != kwNULL {
+		p.restore(cp)
+		return nil, false, nil
+	}
+	p.advance() // consume NULL
+	if p.cur.Kind != kwAS {
+		p.restore(cp)
+		return nil, false, nil
+	}
+	p.advance() // consume AS
+	if p.cur.Kind != kwDESCRIPTOR {
+		p.restore(cp)
+		return nil, false, nil
+	}
+	p.advance() // consume DESCRIPTOR
+	if p.cur.Kind != int(')') {
+		p.restore(cp)
+		return nil, false, nil
+	}
+	closeTok := p.advance() // consume ')'
+	return &DescriptorArg{NullCast: true, Loc: ast.Loc{Start: start, End: closeTok.Loc.End}}, true, nil
+}
+
+// parseDescriptorField parses one `descriptorField`: `identifier type?`. The
+// type is parsed only when a type-start token follows the name; a bare
+// identifier (followed by ',' or ')') is a type-less field.
+func (p *Parser) parseDescriptorField() (DescriptorField, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return DescriptorField{}, err
+	}
+	field := DescriptorField{Name: name, Loc: name.Loc}
+	// A type follows unless the field ends here (at ',' or ')').
+	if p.cur.Kind != int(',') && p.cur.Kind != int(')') {
+		ty, err := p.parseType()
+		if err != nil {
+			return DescriptorField{}, err
+		}
+		field.Type = ty
+		field.Loc.End = ty.Loc.End
+	}
+	return field, nil
+}
+
+// parseCopartitionTables parses one `copartitionTables` group:
+// `( qualifiedName , qualifiedName (, …)* )` (the COPARTITION keyword already
+// consumed). Per the grammar a group has AT LEAST TWO tables — the first comma
+// is mandatory — so a single-table group `COPARTITION (a)` is a syntax error
+// (oracle-confirmed: Trino 481 rejects it).
+func (p *Parser) parseCopartitionTables() ([]*ast.QualifiedName, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	first, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	// The second table (and its comma) is required.
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+	second, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	tables := []*ast.QualifiedName{first, second}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, next)
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return tables, nil
+}

--- a/trino/parser/relation_test.go
+++ b/trino/parser/relation_test.go
@@ -1,0 +1,359 @@
+package parser
+
+import "testing"
+
+// This file is the parser-select node's correctness slice for the FROM-clause
+// relation grammar (relation.go): joins, sampledRelation/TABLESAMPLE,
+// aliasedRelation, relationPrimary (table / subquery / UNNEST / LATERAL /
+// TABLE(func) / parenthesized / queryPeriod), and tableFunctionCall. The oracle
+// differential is authoritative; structural tests pin join associativity and
+// relation shapes. Helpers (connectOracle / oracleAccepts / truncateName) live
+// in oracle_foundation_test.go; parseOneQuery / querySpec live in select_test.go.
+
+// relationAcceptCorpus is the FROM-clause relation surface Trino 481 accepts.
+// Each is a complete statement (the differential needs a whole statement);
+// table/column references resolve to semantic errors, not syntax rejections.
+var relationAcceptCorpus = []string{
+	// --- comma (implicit cross) joins ---
+	"SELECT * FROM a, b",
+	"SELECT * FROM a, b, c",
+
+	// --- qualified joins + criteria ---
+	"SELECT * FROM a JOIN b ON a.x = b.x",
+	"SELECT * FROM a INNER JOIN b ON a.x = b.x",
+	"SELECT * FROM a LEFT JOIN b ON a.x = b.x",
+	"SELECT * FROM a LEFT OUTER JOIN b ON a.x = b.x",
+	"SELECT * FROM a RIGHT JOIN b ON true",
+	"SELECT * FROM a RIGHT OUTER JOIN b ON true",
+	"SELECT * FROM a FULL JOIN b ON true",
+	"SELECT * FROM a FULL OUTER JOIN b ON true",
+	"SELECT * FROM a JOIN b USING (x)",
+	"SELECT * FROM a JOIN b USING (x, y)",
+
+	// --- cross / natural joins ---
+	"SELECT * FROM a CROSS JOIN b",
+	"SELECT * FROM a NATURAL JOIN b",
+	"SELECT * FROM a NATURAL LEFT JOIN b",
+	"SELECT * FROM a NATURAL FULL OUTER JOIN b",
+
+	// --- join chains (left-associative) + the legacy join_precedence examples ---
+	"SELECT * FROM a JOIN b ON a.x=b.x JOIN c ON b.y=c.y",
+	"SELECT * FROM a CROSS JOIN b LEFT JOIN c ON true",
+	"SELECT * FROM a CROSS JOIN b NATURAL JOIN c CROSS JOIN d NATURAL JOIN e",
+	"SELECT * FROM t1 a JOIN t2 b ON a.id=b.id JOIN t3 c ON b.id=c.id",
+
+	// --- parenthesized relation (explicit grouping) ---
+	"SELECT * FROM (a JOIN b ON a.x=b.x)",
+	"SELECT * FROM (a CROSS JOIN b) JOIN c ON true",
+	// nested parens: `((join))` is a parenthesized relation, NOT a subquery — the
+	// deciding token lies arbitrarily deep, so it is resolved by speculation.
+	"SELECT * FROM ((a JOIN b ON true) JOIN c ON true)",
+	"SELECT * FROM (((a)))",
+	"SELECT * FROM ((SELECT 1))", // nested parens that ARE a subquery
+
+	// --- aliased relations ---
+	"SELECT * FROM t a",
+	"SELECT * FROM t AS a",
+	"SELECT * FROM t AS a (x, y)",
+	"SELECT * FROM t a (x, y)",
+	"SELECT * FROM nation AS n CROSS JOIN region AS r",
+
+	// --- subquery relations ---
+	"SELECT * FROM (SELECT 1)",
+	"SELECT * FROM (SELECT 1) t",
+	"SELECT * FROM (SELECT 1) AS t (x)",
+	"SELECT * FROM (SELECT a FROM u WHERE a > 1) t",
+	"SELECT * FROM (VALUES (1, '1'), (2, '2'))",
+	"SELECT * FROM (TABLE foo)",
+	"SELECT * FROM (SELECT 1 UNION SELECT 2) t",
+	// a relation subquery is `( query )` — WITH is allowed inside it (unlike the
+	// parenthesized query PRIMARY `( queryNoWith )`, which rejects WITH; see
+	// setopRejectCorpus). Oracle-confirmed.
+	"SELECT * FROM (WITH c AS (SELECT 1) SELECT * FROM c)",
+
+	// --- UNNEST ---
+	"SELECT * FROM UNNEST(ARRAY[1,2])",
+	"SELECT * FROM UNNEST(ARRAY[1,2]) WITH ORDINALITY",
+	"SELECT * FROM UNNEST(ARRAY[1,2]) AS t(number)",
+	"SELECT * FROM UNNEST(a, b) WITH ORDINALITY AS t(x, y, ord)",
+	"SELECT * FROM t CROSS JOIN UNNEST(a)",
+	"SELECT * FROM t CROSS JOIN UNNEST(a, b) WITH ORDINALITY",
+	"SELECT * FROM t FULL JOIN UNNEST(a) AS tmp (c) ON true",
+
+	// --- LATERAL ---
+	"SELECT * FROM LATERAL (SELECT 1)",
+	"SELECT * FROM t, LATERAL (VALUES 1) a(x)",
+	"SELECT * FROM t CROSS JOIN LATERAL (VALUES 1)",
+	"SELECT * FROM t FULL JOIN LATERAL (VALUES 1) ON true",
+	// LATERAL is non-reserved: not followed by '(' it is an ordinary table name.
+	"SELECT * FROM LATERAL",
+	"SELECT * FROM LATERAL x",
+
+	// --- TABLESAMPLE ---
+	"SELECT * FROM t TABLESAMPLE BERNOULLI (10)",
+	"SELECT * FROM t TABLESAMPLE SYSTEM (50)",
+	"SELECT * FROM t a TABLESAMPLE BERNOULLI (10)",
+
+	// --- queryPeriod (time travel) ---
+	"SELECT * FROM t FOR TIMESTAMP AS OF TIMESTAMP '2020-01-01 00:00:00'",
+	"SELECT * FROM t FOR VERSION AS OF 3",
+	"SELECT * FROM cat.sch.t FOR VERSION AS OF 'snap-1'",
+
+	// --- table function invocation ---
+	"SELECT * FROM TABLE(my_function(1, 100))",
+	"SELECT * FROM TABLE(my_function(row_count => 100, column_count => 1))",
+	"SELECT * FROM TABLE(schema_name.my_function(1, 100))",
+	"SELECT * FROM TABLE(catalog_name.schema_name.my_function(1, 100))",
+	"SELECT * FROM TABLE(sequence(start => 1000000, stop => -2000000, step => -3))",
+	"SELECT * FROM TABLE(exclude_columns(input => TABLE(orders), columns => DESCRIPTOR(clerk, comment)))",
+	"SELECT * FROM TABLE(my_function(input => TABLE(orders) PARTITION BY orderstatus ORDER BY orderdate))",
+	"SELECT * FROM TABLE(my_function(input => TABLE(SELECT * FROM orders) PARTITION BY (a, b) PRUNE WHEN EMPTY))",
+	"SELECT * FROM TABLE(f(TABLE(orders) KEEP WHEN EMPTY))",
+	"SELECT * FROM TABLE(f(d => DESCRIPTOR(a integer, b varchar)))",
+	"SELECT * FROM TABLE(f(d => CAST(NULL AS DESCRIPTOR)))",
+	"SELECT * FROM TABLE(f(TABLE(a) PARTITION BY x, TABLE(b) PARTITION BY y COPARTITION (a, b)))",
+	// COPARTITION and DESCRIPTOR are NON-RESERVED, so they are also ordinary
+	// argument names / column references (not only the clause / descriptor forms).
+	// Oracle-confirmed; these were cross-review (Codex) catches.
+	"SELECT * FROM TABLE(f(copartition => 1))",
+	"SELECT * FROM TABLE(f(descriptor))",
+	"SELECT * FROM TABLE(f(descriptor => 1))",
+}
+
+// relationRejectCorpus is malformed FROM-clause input Trino 481 rejects with a
+// SYNTAX_ERROR (required negative coverage).
+var relationRejectCorpus = []string{
+	"SELECT * FROM a JOIN b",                // qualified join needs ON/USING
+	"SELECT * FROM a INNER JOIN b",          // ditto
+	"SELECT * FROM a JOIN b ON",             // ON with no predicate
+	"SELECT * FROM a JOIN b USING",          // USING with no column list
+	"SELECT * FROM a JOIN b USING ()",       // empty USING list
+	"SELECT * FROM a CROSS b",               // CROSS without JOIN
+	"SELECT * FROM ,",                       // empty relation list
+	"SELECT * FROM a,",                      // trailing comma
+	"SELECT * FROM UNNEST",                  // UNNEST (reserved) without parens
+	"SELECT * FROM UNNEST()",                // UNNEST with no expression
+	"SELECT * FROM LATERAL (a)",             // LATERAL ( … ) must wrap a query, not a name
+	"SELECT * FROM t TABLESAMPLE (10)",      // TABLESAMPLE without method
+	"SELECT * FROM t TABLESAMPLE BERNOULLI", // TABLESAMPLE without percentage
+	"SELECT * FROM t FOR AS OF 3",           // queryPeriod without range type
+	"SELECT * FROM t FOR VERSION 3",         // queryPeriod without AS OF
+	"SELECT * FROM t AS",                    // AS with no alias
+	// a COPARTITION group requires at least two tables (the first comma is
+	// mandatory); a single-table group is a syntax error. Oracle-confirmed.
+	"SELECT * FROM TABLE(f(TABLE(a) PARTITION BY x COPARTITION (a)))",
+}
+
+func TestRelation_AcceptCorpusParses(t *testing.T) {
+	for _, sql := range relationAcceptCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) != 0 {
+				t.Errorf("Parse(%q) should accept, got: %v", sql, errs)
+			}
+		})
+	}
+}
+
+func TestRelation_RejectCorpusRejected(t *testing.T) {
+	for _, sql := range relationRejectCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) == 0 {
+				t.Errorf("Parse(%q) should reject, but accepted", sql)
+			}
+		})
+	}
+}
+
+func TestRelation_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	check := func(t *testing.T, sql string) {
+		_, errs := Parse(sql)
+		omniAccepts := len(errs) == 0
+		trinoAccepts, ok := oracleAccepts(t, o, sql)
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH sql=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				sql, omniAccepts, errs, trinoAccepts)
+		}
+	}
+	for _, sql := range relationAcceptCorpus {
+		t.Run("accept/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+	for _, sql := range relationRejectCorpus {
+		t.Run("reject/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+}
+
+// ---------------------------------------------------------------------------
+// structural tests
+// ---------------------------------------------------------------------------
+
+// fromRel extracts the single FROM relation of a plain query specification.
+func fromRel(t *testing.T, sql string) Relation {
+	t.Helper()
+	spec := querySpec(t, parseOneQuery(t, sql))
+	if len(spec.From) != 1 {
+		t.Fatalf("Parse(%q): want 1 FROM relation, got %d", sql, len(spec.From))
+	}
+	return spec.From[0]
+}
+
+// unwrapAlias returns the inner relation primary of an AliasedRelation (the
+// shape parseAliasedRelation always produces), or the relation itself otherwise.
+func unwrapAlias(r Relation) Relation {
+	if ar, ok := r.(*AliasedRelation); ok {
+		return ar.Inner
+	}
+	return r
+}
+
+func TestRelation_StructureJoinLeftAssoc(t *testing.T) {
+	// `a JOIN b ... JOIN c ...` groups left: the top Join's Left is itself a Join.
+	rel := fromRel(t, "SELECT * FROM a JOIN b ON a.x=b.x JOIN c ON b.y=c.y")
+	top, ok := rel.(*Join)
+	if !ok {
+		t.Fatalf("top relation is %T, want *Join", rel)
+	}
+	if _, ok := top.Left.(*Join); !ok {
+		t.Errorf("join not left-associative: Left is %T, want *Join", top.Left)
+	}
+}
+
+func TestRelation_StructureJoinTypes(t *testing.T) {
+	cases := []struct {
+		sql   string
+		jt    JoinType
+		outer bool
+	}{
+		{"SELECT * FROM a JOIN b ON true", JoinInner, false},
+		{"SELECT * FROM a INNER JOIN b ON true", JoinInner, false},
+		{"SELECT * FROM a LEFT JOIN b ON true", JoinLeft, false},
+		{"SELECT * FROM a LEFT OUTER JOIN b ON true", JoinLeft, true},
+		{"SELECT * FROM a RIGHT JOIN b ON true", JoinRight, false},
+		{"SELECT * FROM a FULL OUTER JOIN b ON true", JoinFull, true},
+		{"SELECT * FROM a CROSS JOIN b", JoinCross, false},
+	}
+	for _, c := range cases {
+		t.Run(truncateName(c.sql), func(t *testing.T) {
+			j, ok := fromRel(t, c.sql).(*Join)
+			if !ok {
+				t.Fatalf("relation is %T, want *Join", fromRel(t, c.sql))
+			}
+			if j.Type != c.jt {
+				t.Errorf("Type=%v, want %v", j.Type, c.jt)
+			}
+			if j.Outer != c.outer {
+				t.Errorf("Outer=%v, want %v", j.Outer, c.outer)
+			}
+		})
+	}
+}
+
+func TestRelation_StructureJoinCriteria(t *testing.T) {
+	j := fromRel(t, "SELECT * FROM a JOIN b ON a.x = b.x").(*Join)
+	if j.On == nil || j.Using != nil {
+		t.Errorf("ON join: On=%v Using=%v, want On set", j.On, j.Using)
+	}
+	j = fromRel(t, "SELECT * FROM a JOIN b USING (x, y)").(*Join)
+	if j.On != nil || len(j.Using) != 2 {
+		t.Errorf("USING join: On=%v Using=%v, want 2-col Using", j.On, j.Using)
+	}
+	j = fromRel(t, "SELECT * FROM a NATURAL LEFT JOIN b").(*Join)
+	if !j.Natural || j.Type != JoinLeft {
+		t.Errorf("natural left join: Natural=%v Type=%v", j.Natural, j.Type)
+	}
+}
+
+func TestRelation_StructurePrimaries(t *testing.T) {
+	if _, ok := unwrapAlias(fromRel(t, "SELECT * FROM t")).(*TableRelation); !ok {
+		t.Errorf("`FROM t`: want *TableRelation")
+	}
+	if _, ok := unwrapAlias(fromRel(t, "SELECT * FROM (SELECT 1) x")).(*SubqueryRelation); !ok {
+		t.Errorf("`FROM (SELECT 1) x`: want *SubqueryRelation")
+	}
+	if _, ok := unwrapAlias(fromRel(t, "SELECT * FROM UNNEST(a) WITH ORDINALITY")).(*UnnestRelation); !ok {
+		t.Errorf("`FROM UNNEST(a)`: want *UnnestRelation")
+	}
+	if _, ok := unwrapAlias(fromRel(t, "SELECT * FROM LATERAL (SELECT 1)")).(*LateralRelation); !ok {
+		t.Errorf("`FROM LATERAL (...)`: want *LateralRelation")
+	}
+	if _, ok := unwrapAlias(fromRel(t, "SELECT * FROM TABLE(f(1))")).(*TableFunctionRelation); !ok {
+		t.Errorf("`FROM TABLE(f(1))`: want *TableFunctionRelation")
+	}
+	if _, ok := unwrapAlias(fromRel(t, "SELECT * FROM (a JOIN b ON true)")).(*ParenRelation); !ok {
+		t.Errorf("`FROM (a JOIN b)`: want *ParenRelation")
+	}
+}
+
+func TestRelation_StructureAliasAndSample(t *testing.T) {
+	ar, ok := fromRel(t, "SELECT * FROM t AS a (x, y) TABLESAMPLE BERNOULLI (10)").(*AliasedRelation)
+	if !ok {
+		t.Fatalf("want *AliasedRelation")
+	}
+	if ar.Alias == nil || ar.Alias.Value != "a" {
+		t.Errorf("Alias=%v, want a", ar.Alias)
+	}
+	if len(ar.ColumnAliases) != 2 {
+		t.Errorf("ColumnAliases=%d, want 2", len(ar.ColumnAliases))
+	}
+	if ar.Sample == nil || ar.Sample.Method != "BERNOULLI" {
+		t.Errorf("Sample=%v, want BERNOULLI", ar.Sample)
+	}
+}
+
+func TestRelation_StructureUnnest(t *testing.T) {
+	ur := unwrapAlias(fromRel(t, "SELECT * FROM UNNEST(a, b) WITH ORDINALITY AS t(x,y,o)")).(*UnnestRelation)
+	if len(ur.Exprs) != 2 {
+		t.Errorf("UNNEST exprs=%d, want 2", len(ur.Exprs))
+	}
+	if !ur.WithOrdinality {
+		t.Error("WithOrdinality=false, want true")
+	}
+}
+
+func TestRelation_StructureQueryPeriod(t *testing.T) {
+	tr := unwrapAlias(fromRel(t, "SELECT * FROM t FOR VERSION AS OF 3")).(*TableRelation)
+	if tr.Period == nil || tr.Period.RangeType != "VERSION" {
+		t.Errorf("Period=%v, want VERSION", tr.Period)
+	}
+	tr = unwrapAlias(fromRel(t, "SELECT * FROM t FOR TIMESTAMP AS OF TIMESTAMP '2020-01-01 00:00:00'")).(*TableRelation)
+	if tr.Period == nil || tr.Period.RangeType != "TIMESTAMP" {
+		t.Errorf("Period=%v, want TIMESTAMP", tr.Period)
+	}
+}
+
+func TestRelation_StructureTableFunction(t *testing.T) {
+	tf := unwrapAlias(fromRel(t,
+		"SELECT * FROM TABLE(exclude_columns(input => TABLE(orders), columns => DESCRIPTOR(clerk, comment)))")).(*TableFunctionRelation)
+	if tf.Call.Name.Normalize() != "exclude_columns" {
+		t.Errorf("func name=%q, want exclude_columns", tf.Call.Name.Normalize())
+	}
+	if len(tf.Call.Args) != 2 {
+		t.Fatalf("args=%d, want 2", len(tf.Call.Args))
+	}
+	if tf.Call.Args[0].Name == nil || tf.Call.Args[0].Name.Value != "input" || tf.Call.Args[0].Kind != TFArgTable {
+		t.Errorf("arg0 = %+v, want named 'input' table arg", tf.Call.Args[0])
+	}
+	if tf.Call.Args[1].Kind != TFArgDescriptor {
+		t.Errorf("arg1 kind=%v, want TFArgDescriptor", tf.Call.Args[1].Kind)
+	}
+	if tf.Call.Args[1].Descriptor == nil || len(tf.Call.Args[1].Descriptor.Fields) != 2 {
+		t.Errorf("descriptor fields = %+v, want 2", tf.Call.Args[1].Descriptor)
+	}
+}
+
+func TestRelation_StructureCopartition(t *testing.T) {
+	tf := unwrapAlias(fromRel(t,
+		"SELECT * FROM TABLE(f(TABLE(a) PARTITION BY x, TABLE(b) PARTITION BY y COPARTITION (a, b)))")).(*TableFunctionRelation)
+	if len(tf.Call.Copartition) != 1 {
+		t.Fatalf("copartition groups=%d, want 1", len(tf.Call.Copartition))
+	}
+	if len(tf.Call.Copartition[0]) != 2 {
+		t.Errorf("copartition group tables=%d, want 2", len(tf.Call.Copartition[0]))
+	}
+}

--- a/trino/parser/select.go
+++ b/trino/parser/select.go
@@ -1,0 +1,1005 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is the `parser-select` DAG node (with relation.go, ctes.go,
+// window.go and setops.go): it implements Trino's query layer — the `query`,
+// `queryNoWith`, `queryTerm`, `queryPrimary`, and `querySpecification` grammar
+// rules and their clause helpers (SELECT list, FROM, WHERE, GROUP BY, HAVING,
+// the named-WINDOW clause, ORDER BY / OFFSET / LIMIT / FETCH, and set
+// operations) — as a hand-written recursive-descent parser over the token
+// stream, producing a Query node tree.
+//
+// Like datatypes.go's DataType and expr.go's Expr, the query nodes are
+// PARSER-PACKAGE types (not ast.Node): the Trino ast tag set is closed to the
+// ast-core nodes (File/Identifier/QualifiedName), so — matching the
+// types/expressions precedent — query nodes live in package parser and carry
+// their own Loc. They embed the Expr values produced by the expressions node;
+// later DAG nodes (parser-ddl's CREATE-TABLE-AS / CREATE-VIEW, parser-dml's
+// INSERT-from-query, analysis, deparse) embed these Query values.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	query             : with? queryNoWith ;
+//	queryNoWith       : queryTerm (ORDER BY sortItem (, sortItem)*)?
+//	                      (OFFSET rowCount (ROW|ROWS)?)?
+//	                      (LIMIT limitRowCount | FETCH (FIRST|NEXT) rowCount? (ROW|ROWS) (ONLY|WITH TIES))? ;
+//	queryTerm         : queryPrimary                                  # queryTermDefault
+//	                  | left INTERSECT setQuantifier? right           # setOperation
+//	                  | left (UNION|EXCEPT) setQuantifier? right      # setOperation ;
+//	queryPrimary      : querySpecification          # queryPrimaryDefault
+//	                  | TABLE qualifiedName         # table
+//	                  | VALUES expression (, expression)*  # inlineTable
+//	                  | ( queryNoWith )             # subquery ;
+//	querySpecification: SELECT setQuantifier? selectItem (, selectItem)*
+//	                      (FROM relation (, relation)*)?
+//	                      (WHERE booleanExpression)?
+//	                      (GROUP BY groupBy)?
+//	                      (HAVING booleanExpression)?
+//	                      (WINDOW windowDefinition (, windowDefinition)*)? ;
+//	selectItem        : expression as_column_alias?            # selectSingle
+//	                  | primaryExpression . *  (AS columnAliases)?  # selectAll
+//	                  | *                                      # selectAll ;
+//	groupBy           : setQuantifier? groupingElement (, groupingElement)* ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar. Oracle-confirmed facts baked in:
+//
+//	S1 (set-op precedence & associativity). INTERSECT binds tighter than
+//	   UNION/EXCEPT; within a precedence level operators are left-associative
+//	   (`a UNION b EXCEPT c` == `(a UNION b) EXCEPT c`, `a INTERSECT b UNION c`
+//	   == `(a INTERSECT b) UNION c`). See setops.go.
+//	S2 (ORDER BY / OFFSET / LIMIT / FETCH attach to the WHOLE queryTerm). They
+//	   are part of queryNoWith, OUTSIDE queryTerm, so in `SELECT 1 UNION SELECT 2
+//	   ORDER BY 1` the ORDER BY orders the union, not the right SELECT.
+//	S3 (GROUP BY setQuantifier disambiguation). `ALL`/`DISTINCT` is the
+//	   leading setQuantifier ONLY when a grouping element follows it; `GROUP BY
+//	   ALL` (nothing after) and `GROUP BY ALL, x` (a comma after) read `ALL` as
+//	   an ordinary grouping expression — ALL is a non-reserved keyword usable as
+//	   a column reference. `GROUP BY ALL x` reads ALL as the quantifier. Probed
+//	   against Trino 481. See parseGroupBy.
+//
+// Node-scope boundaries (recorded in the migration divergence ledger), all
+// following the analysis §5 target policy "implement the legacy grammar scope
+// correctly; treat docs-ahead-of-legacy items as explicit deferred P1
+// extensions":
+//
+//	D1 (JSON_TABLE relation — divergence #3). JSON_TABLE is a relationPrimary
+//	   valid in Trino 481 but ABSENT from the legacy grammar. It is a separate
+//	   P1 extension; this node does not parse it (omni rejects, 481 accepts).
+//	D2 (WITH SESSION — divergence #4). `WITH SESSION prop = v <query>` is a 481
+//	   query prefix absent from the legacy grammar (where WITH is CTE-only). P1
+//	   extension; not parsed here.
+//	D3 (set-op CORRESPONDING — divergence #6). `UNION/INTERSECT/EXCEPT
+//	   CORRESPONDING` is a 481 set-op modifier absent from the legacy grammar
+//	   (where the modifier is setQuantifier = DISTINCT/ALL only). P1 extension;
+//	   not parsed here. See setops.go.
+//	D4 (MATCH_RECOGNIZE — parser-match-recognize node). sampledRelation's
+//	   patternRecognition MATCH_RECOGNIZE subsystem is its own DAG node; here a
+//	   relation is its aliasedRelation with the optional TABLESAMPLE only. See
+//	   relation.go.
+
+// ---------------------------------------------------------------------------
+// Query node hierarchy (parser-package; not ast.Node — see file header)
+// ---------------------------------------------------------------------------
+
+// QueryNode is the interface implemented by every Trino query-layer node
+// produced by this node's parsers. Span returns the source byte range; concrete
+// fields are reached by a Go type switch (mirroring Expr / DataType). It is the
+// `query` / `queryTerm` / `queryPrimary` result type.
+type QueryNode interface {
+	// Span returns the source byte range covered by the query node.
+	Span() ast.Loc
+	// queryNode is a marker preventing unrelated types from satisfying QueryNode.
+	queryNode()
+}
+
+// Query is the top-level `query` (with? queryNoWith): an optional WITH clause
+// wrapping a body. It is what parseStmt returns for a query statement and what
+// a subquery / CTE / set-op operand reduces to.
+//
+// With is nil when there is no leading WITH. Body is the queryNoWith — a
+// QuerySpec, TableQuery, ValuesQuery, set-operation, or a parenthesized query —
+// already decorated with this query's ORDER BY / OFFSET / LIMIT / FETCH (which
+// belong to queryNoWith, outside the queryTerm; see S2). OrderBy/Offset/Limit/
+// Fetch on this node carry the queryNoWith-level modifiers.
+type Query struct {
+	With    *WithClause // nil when no WITH
+	Body    QueryNode   // the queryTerm (QuerySpec / set-op / parenthesized / TABLE / VALUES)
+	OrderBy []SortItem  // queryNoWith ORDER BY, nil when absent
+	Offset  *OffsetClause
+	Limit   *LimitClause
+	Fetch   *FetchClause
+	Loc     ast.Loc
+}
+
+func (n *Query) Span() ast.Loc { return n.Loc }
+func (*Query) queryNode()      {}
+
+// OffsetClause is `OFFSET count [ROW|ROWS]` (the OFFSET part of queryNoWith).
+// Count is an INTEGER_VALUE_ or a `?` parameter (the rowCount rule). RowKeyword
+// records the optional ROW/ROWS spelling for deparse fidelity.
+type OffsetClause struct {
+	Count      Expr   // integer literal or parameter
+	RowKeyword string // "", "ROW", or "ROWS"
+	Loc        ast.Loc
+}
+
+// LimitClause is `LIMIT (ALL | count)` (the LIMIT part of queryNoWith). All
+// marks `LIMIT ALL`; Count is the rowCount otherwise (nil when All is true).
+type LimitClause struct {
+	All   bool
+	Count Expr // integer literal or parameter; nil for LIMIT ALL
+	Loc   ast.Loc
+}
+
+// FetchClause is `FETCH (FIRST|NEXT) [count] (ROW|ROWS) (ONLY | WITH TIES)`
+// (the FETCH part of queryNoWith). Count is nil for the count-less form
+// (`FETCH FIRST ROW ONLY`). WithTies marks the WITH TIES spelling (vs ONLY).
+type FetchClause struct {
+	Keyword    string // "FIRST" or "NEXT"
+	Count      Expr   // rowCount, nil when absent
+	RowKeyword string // "ROW" or "ROWS"
+	WithTies   bool   // true for WITH TIES, false for ONLY
+	Loc        ast.Loc
+}
+
+// QuerySpec is a `querySpecification` (queryPrimaryDefault): a SELECT block.
+// SetQuantifier is "", "DISTINCT", or "ALL". Items is the non-empty select
+// list. From is the comma-separated relation list (nil when no FROM). Where /
+// Having carry the optional predicates. GroupBy is nil when absent. Windows is
+// the named-WINDOW clause (nil when absent).
+type QuerySpec struct {
+	SetQuantifier string // "", "DISTINCT", or "ALL"
+	Items         []SelectItem
+	From          []Relation // nil when no FROM clause
+	Where         Expr       // nil when absent
+	GroupBy       *GroupBy   // nil when absent
+	Having        Expr       // nil when absent
+	Windows       []WindowDefinition
+	Loc           ast.Loc
+}
+
+func (n *QuerySpec) Span() ast.Loc { return n.Loc }
+func (*QuerySpec) queryNode()      {}
+
+// TableQuery is the `TABLE qualifiedName` query primary (the `table` rule): a
+// shorthand for `SELECT * FROM qualifiedName`.
+type TableQuery struct {
+	Name *ast.QualifiedName
+	Loc  ast.Loc
+}
+
+func (n *TableQuery) Span() ast.Loc { return n.Loc }
+func (*TableQuery) queryNode()      {}
+
+// ValuesQuery is the `VALUES expression (, expression)*` query primary (the
+// `inlineTable` rule): an inline row set. Each row is an expression (commonly a
+// rowConstructor for multi-column rows, e.g. `VALUES (1, 'a'), (2, 'b')`).
+type ValuesQuery struct {
+	Rows []Expr
+	Loc  ast.Loc
+}
+
+func (n *ValuesQuery) Span() ast.Loc { return n.Loc }
+func (*ValuesQuery) queryNode()      {}
+
+// ParenQuery is the `( queryNoWith )` query primary (the `subquery` rule): a
+// parenthesized query expression. Inner is the wrapped queryNoWith (a Query
+// without a WITH clause but possibly with its own ORDER BY / LIMIT etc.).
+type ParenQuery struct {
+	Inner *Query
+	Loc   ast.Loc
+}
+
+func (n *ParenQuery) Span() ast.Loc { return n.Loc }
+func (*ParenQuery) queryNode()      {}
+
+// SelectItem is one entry of a SELECT list. Kind distinguishes the three
+// selectItem alternatives. For SelectSingle, Expr is the projected expression
+// and Alias the optional `[AS] column_alias`. For SelectAllFrom (`expr.*`),
+// Expr is the row-valued primary and Aliases the optional `AS (a, b, …)`. For
+// SelectAll (bare `*`), all fields are zero.
+type SelectItem struct {
+	Kind    SelectItemKind
+	Expr    Expr              // the projected/row expression (nil for bare SelectAll)
+	Alias   *ast.Identifier   // SelectSingle [AS] alias, nil when absent
+	Aliases []*ast.Identifier // SelectAllFrom AS (a, b, …), nil when absent
+	Loc     ast.Loc
+}
+
+// SelectItemKind classifies a SelectItem.
+type SelectItemKind int
+
+const (
+	// SelectSingle is `expression [[AS] column_alias]` (selectSingle).
+	SelectSingle SelectItemKind = iota
+	// SelectAllFrom is `primaryExpression . * [AS columnAliases]` — all columns
+	// of a row-valued expression (the first selectAll alternative).
+	SelectAllFrom
+	// SelectAll is the bare `*` — all columns (the second selectAll alternative).
+	SelectAll
+)
+
+// GroupBy is the `GROUP BY groupBy` clause body (the groupBy rule):
+// `setQuantifier? groupingElement (, groupingElement)*`. SetQuantifier is "",
+// "DISTINCT", or "ALL" (the leading quantifier, disambiguated per S3). Elements
+// is the non-empty list of grouping elements.
+type GroupBy struct {
+	SetQuantifier string // "", "DISTINCT", or "ALL"
+	Elements      []GroupingElement
+	Loc           ast.Loc
+}
+
+// GroupingElementKind classifies a GroupingElement.
+type GroupingElementKind int
+
+const (
+	// GroupingExpr is a single grouping set `( e, … )` or a bare expression
+	// (the singleGroupingSet rule via groupingSet). Exprs holds the expressions;
+	// for the bare-expression form it is a single element.
+	GroupingExprKind GroupingElementKind = iota
+	// GroupingRollup is `ROLLUP ( e, … )` (the rollup rule); the list may be empty.
+	GroupingRollup
+	// GroupingCube is `CUBE ( e, … )` (the cube rule); the list may be empty.
+	GroupingCube
+	// GroupingSets is `GROUPING SETS ( groupingSet, … )` (the multipleGroupingSets
+	// rule). Sets holds each grouping set's expression list.
+	GroupingSets
+)
+
+// GroupingElement is one element of a GROUP BY (the groupingElement rule):
+// a single grouping set / bare expression, a ROLLUP, a CUBE, or a GROUPING SETS.
+type GroupingElement struct {
+	Kind  GroupingElementKind
+	Exprs []Expr   // for GroupingExprKind / GroupingRollup / GroupingCube
+	Sets  [][]Expr // for GroupingSets — each inner slice is one grouping set
+	Loc   ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// Statement-dispatch wiring
+// ---------------------------------------------------------------------------
+
+// parseQueryStmt parses a top-level query statement and returns it as an
+// ast.Node (the dispatch contract of parseStmt). The leading token is SELECT,
+// WITH, TABLE, VALUES, or '('. The WITH-FUNCTION inline-routine prefix
+// (`WITH FUNCTION …`) is the parser-routines node; here a leading WITH is a CTE
+// list only. parseQueryStmt wraps the parsed *Query in a QueryStmt so the File
+// statement list holds an ast.Node.
+func (p *Parser) parseQueryStmt() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	q, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	return &QueryStmt{Query: q, Loc: ast.Loc{Start: start, End: q.Loc.End}}, nil
+}
+
+// QueryStmt is the ast.Node wrapper for a top-level query statement (the
+// statementDefault / rootQuery alternative). It adapts a parser-package *Query
+// to the ast.Node interface parseStmt returns, mirroring how the foundation's
+// File holds ast.Node statements. Query is the parsed query body.
+type QueryStmt struct {
+	Query *Query
+	Loc   ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *QueryStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+
+// Compile-time assertion that *QueryStmt satisfies ast.Node.
+var _ ast.Node = (*QueryStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// query / queryNoWith
+// ---------------------------------------------------------------------------
+
+// parseQuery parses the `query` rule (`with? queryNoWith`). A leading WITH (not
+// WITH FUNCTION) introduces a CTE list parsed by parseWithClause (ctes.go); the
+// body is then a queryNoWith.
+func (p *Parser) parseQuery() (*Query, error) {
+	var with *WithClause
+	start := p.cur.Loc.Start
+	if p.cur.Kind == kwWITH {
+		// WITH FUNCTION (inline routine) is the parser-routines node; a CTE WITH
+		// is `WITH [RECURSIVE] namedQuery …`. If FUNCTION follows WITH, this is not
+		// a CTE list — report it as unsupported here rather than mis-parsing.
+		if p.peekNext().Kind == kwFUNCTION {
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "WITH FUNCTION (inline SQL routine) is not yet supported",
+			}
+		}
+		w, err := p.parseWithClause()
+		if err != nil {
+			return nil, err
+		}
+		with = w
+	}
+	return p.parseQueryNoWith(with, start)
+}
+
+// parseQueryNoWith parses `queryNoWith` (a queryTerm followed by the optional
+// ORDER BY / OFFSET / LIMIT / FETCH tail) and attaches the already-parsed
+// optional WITH clause. start is the byte offset of the whole query (the WITH
+// keyword or the queryTerm's first token).
+//
+// The ORDER BY / OFFSET / LIMIT / FETCH attach to the WHOLE queryTerm (S2), so
+// they are parsed here, after the (possibly set-operation) term — not inside a
+// querySpecification.
+func (p *Parser) parseQueryNoWith(with *WithClause, start int) (*Query, error) {
+	body, err := p.parseQueryTerm()
+	if err != nil {
+		return nil, err
+	}
+
+	q := &Query{
+		With: with,
+		Body: body,
+		Loc:  ast.Loc{Start: start, End: body.Span().End},
+	}
+
+	if p.cur.Kind == kwORDER {
+		items, err := p.parseOrderByItems()
+		if err != nil {
+			return nil, err
+		}
+		q.OrderBy = items
+		if len(items) > 0 {
+			q.Loc.End = items[len(items)-1].Loc.End
+		}
+	}
+
+	if p.cur.Kind == kwOFFSET {
+		off, err := p.parseOffset()
+		if err != nil {
+			return nil, err
+		}
+		q.Offset = off
+		q.Loc.End = off.Loc.End
+	}
+
+	switch p.cur.Kind {
+	case kwLIMIT:
+		lim, err := p.parseLimit()
+		if err != nil {
+			return nil, err
+		}
+		q.Limit = lim
+		q.Loc.End = lim.Loc.End
+	case kwFETCH:
+		fetch, err := p.parseFetch()
+		if err != nil {
+			return nil, err
+		}
+		q.Fetch = fetch
+		q.Loc.End = fetch.Loc.End
+	}
+
+	return q, nil
+}
+
+// parseOffset parses `OFFSET rowCount (ROW|ROWS)?` (OFFSET is current). The
+// count is an INTEGER_VALUE_ or a `?` parameter (the rowCount rule).
+func (p *Parser) parseOffset() (*OffsetClause, error) {
+	offTok := p.advance() // consume OFFSET
+	count, err := p.parseRowCount()
+	if err != nil {
+		return nil, err
+	}
+	oc := &OffsetClause{Count: count, Loc: ast.Loc{Start: offTok.Loc.Start, End: count.Span().End}}
+	if tok, ok := p.match(kwROW, kwROWS); ok {
+		oc.RowKeyword = tok.Str
+		oc.Loc.End = tok.Loc.End
+	}
+	return oc, nil
+}
+
+// parseLimit parses `LIMIT (ALL | rowCount)` (LIMIT is current).
+func (p *Parser) parseLimit() (*LimitClause, error) {
+	limTok := p.advance() // consume LIMIT
+	if p.cur.Kind == kwALL {
+		allTok := p.advance()
+		return &LimitClause{All: true, Loc: ast.Loc{Start: limTok.Loc.Start, End: allTok.Loc.End}}, nil
+	}
+	count, err := p.parseRowCount()
+	if err != nil {
+		return nil, err
+	}
+	return &LimitClause{Count: count, Loc: ast.Loc{Start: limTok.Loc.Start, End: count.Span().End}}, nil
+}
+
+// parseFetch parses `FETCH (FIRST|NEXT) rowCount? (ROW|ROWS) (ONLY | WITH TIES)`
+// (FETCH is current).
+func (p *Parser) parseFetch() (*FetchClause, error) {
+	fetchTok := p.advance() // consume FETCH
+	kwTok, ok := p.match(kwFIRST, kwNEXT)
+	if !ok {
+		return nil, p.exprErrorAt("expected FIRST or NEXT after FETCH")
+	}
+	fc := &FetchClause{Keyword: kwTok.Str, Loc: ast.Loc{Start: fetchTok.Loc.Start}}
+
+	// Optional row count before ROW/ROWS. Present only when the next token starts
+	// a rowCount (an integer or '?'); ROW/ROWS follows directly otherwise.
+	if p.cur.Kind == tokInteger || p.cur.Kind == tokQuestion || p.cur.Kind == int('?') {
+		count, err := p.parseRowCount()
+		if err != nil {
+			return nil, err
+		}
+		fc.Count = count
+	}
+
+	rowTok, ok := p.match(kwROW, kwROWS)
+	if !ok {
+		return nil, p.exprErrorAt("expected ROW or ROWS in FETCH clause")
+	}
+	fc.RowKeyword = rowTok.Str
+
+	switch p.cur.Kind {
+	case kwONLY:
+		onlyTok := p.advance()
+		fc.Loc.End = onlyTok.Loc.End
+	case kwWITH:
+		p.advance() // consume WITH
+		tiesTok, err := p.expect(kwTIES)
+		if err != nil {
+			return nil, err
+		}
+		fc.WithTies = true
+		fc.Loc.End = tiesTok.Loc.End
+	default:
+		return nil, p.exprErrorAt("expected ONLY or WITH TIES in FETCH clause")
+	}
+	return fc, nil
+}
+
+// parseRowCount parses the `rowCount` rule: an INTEGER_VALUE_ or a `?`
+// parameter. Used by OFFSET / LIMIT / FETCH.
+func (p *Parser) parseRowCount() (Expr, error) {
+	switch p.cur.Kind {
+	case tokInteger:
+		tok := p.advance()
+		return &Literal{Kind: LiteralInteger, Value: tok.Str, Loc: tok.Loc}, nil
+	case tokQuestion, int('?'):
+		tok := p.advance()
+		return &Parameter{Loc: tok.Loc}, nil
+	default:
+		return nil, p.exprErrorAt("expected an integer or '?' row count")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// querySpecification
+// ---------------------------------------------------------------------------
+
+// parseQuerySpecification parses a `querySpecification` (SELECT block). SELECT is
+// the current token. The clause order is fixed: SELECT [quantifier] items
+// [FROM …] [WHERE …] [GROUP BY …] [HAVING …] [WINDOW …].
+func (p *Parser) parseQuerySpecification() (*QuerySpec, error) {
+	selTok := p.advance() // consume SELECT
+	spec := &QuerySpec{Loc: ast.Loc{Start: selTok.Loc.Start}}
+
+	// Optional setQuantifier (DISTINCT | ALL). Here ALL/DISTINCT before the select
+	// list is unambiguously the quantifier (a select item must follow either way),
+	// matching the grammar `SELECT setQuantifier? selectItem …`.
+	if tok, ok := p.match(kwDISTINCT, kwALL); ok {
+		spec.SetQuantifier = tok.Str
+	}
+
+	items, err := p.parseSelectItems()
+	if err != nil {
+		return nil, err
+	}
+	spec.Items = items
+	spec.Loc.End = items[len(items)-1].Loc.End
+
+	if p.cur.Kind == kwFROM {
+		p.advance() // consume FROM
+		rels, err := p.parseRelationList()
+		if err != nil {
+			return nil, err
+		}
+		spec.From = rels
+		spec.Loc.End = rels[len(rels)-1].Span().End
+	}
+
+	if p.cur.Kind == kwWHERE {
+		p.advance() // consume WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		spec.Where = where
+		spec.Loc.End = where.Span().End
+	}
+
+	if p.cur.Kind == kwGROUP {
+		gb, err := p.parseGroupBy()
+		if err != nil {
+			return nil, err
+		}
+		spec.GroupBy = gb
+		spec.Loc.End = gb.Loc.End
+	}
+
+	if p.cur.Kind == kwHAVING {
+		p.advance() // consume HAVING
+		having, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		spec.Having = having
+		spec.Loc.End = having.Span().End
+	}
+
+	if p.cur.Kind == kwWINDOW {
+		defs, err := p.parseWindowClause()
+		if err != nil {
+			return nil, err
+		}
+		spec.Windows = defs
+		if len(defs) > 0 {
+			spec.Loc.End = defs[len(defs)-1].Loc.End
+		}
+	}
+
+	return spec, nil
+}
+
+// parseSelectItems parses `selectItem (, selectItem)*` — the non-empty SELECT
+// list.
+func (p *Parser) parseSelectItems() ([]SelectItem, error) {
+	first, err := p.parseSelectItem()
+	if err != nil {
+		return nil, err
+	}
+	items := []SelectItem{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseSelectItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, next)
+	}
+	return items, nil
+}
+
+// parseSelectItem parses one `selectItem`, disambiguating the three alternatives:
+//
+//   - bare `*` → SelectAll.
+//   - `primaryExpression . *` → SelectAllFrom (`t.*`, `a.b.*`, `(row).*`), with
+//     an optional `AS (col, …)`.
+//   - `expression [[AS] column_alias]` → SelectSingle.
+//
+// The `expr.*` form is the selectAll alternative `primaryExpression DOT_
+// ASTERISK_`. Two readings reach it:
+//   - a dotted NAME ending in `.*` (`t.*`, `cat.sch.tbl.*`). The expression
+//     parser's qualifiedName reader (parseIdentifierOrFunction → parseQualifiedName)
+//     greedily commits to `.identifier` and so would fail on the trailing `.*`;
+//     parseSelectAllName therefore speculatively reads the dotted name and, when
+//     it ends in `.*`, builds the row reference itself.
+//   - a non-name primary followed by `.*` (`(row).*`), where the expression
+//     parser stops the dotted chain before `.*` (parsePostfix leaves the `.`),
+//     so the trailing `. *` is consumed after parseExpr returns.
+func (p *Parser) parseSelectItem() (SelectItem, error) {
+	// Bare `*` — all columns.
+	if p.cur.Kind == int('*') {
+		starTok := p.advance()
+		return SelectItem{Kind: SelectAll, Loc: starTok.Loc}, nil
+	}
+
+	// `name . *` — a dotted name whose final step is `.*`. Detected speculatively
+	// because the expression parser's qualifiedName reader cannot stop before a
+	// trailing `.*`.
+	if isIdentifierStart(p.cur.Kind) {
+		if item, ok, err := p.tryParseSelectAllName(); err != nil {
+			return SelectItem{}, err
+		} else if ok {
+			return item, nil
+		}
+	}
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		return SelectItem{}, err
+	}
+
+	// `(row) . *` — a non-name primary followed by `.*`.
+	if p.cur.Kind == int('.') && p.peekNext().Kind == int('*') {
+		p.advance()            // consume '.'
+		starTok := p.advance() // consume '*'
+		item := SelectItem{
+			Kind: SelectAllFrom,
+			Expr: expr,
+			Loc:  ast.Loc{Start: expr.Span().Start, End: starTok.Loc.End},
+		}
+		if err := p.parseSelectAllAliases(&item); err != nil {
+			return SelectItem{}, err
+		}
+		return item, nil
+	}
+
+	// `expression [[AS] column_alias]` — a projected expression with an optional
+	// alias.
+	item := SelectItem{Kind: SelectSingle, Expr: expr, Loc: expr.Span()}
+	if alias, ok, err := p.parseOptionalColumnAlias(); err != nil {
+		return SelectItem{}, err
+	} else if ok {
+		item.Alias = alias
+		item.Loc.End = alias.Loc.End
+	}
+	return item, nil
+}
+
+// tryParseSelectAllName speculatively parses a dotted name that ends in `.*`
+// (the `primaryExpression DOT_ ASTERISK_` selectAll form, name reading). The
+// current token is an identifier-start. It reads `identifier (. identifier)*`
+// and, only when the very next step is `. *`, builds a SelectAllFrom whose Expr
+// is the column-reference chain for the leading parts. When the name is not
+// followed by `. *` (it is an ordinary column reference, function call, etc.) it
+// rewinds and returns ok=false so the caller parses the item as an expression.
+func (p *Parser) tryParseSelectAllName() (SelectItem, bool, error) {
+	cp := p.checkpoint()
+
+	first := identFromToken(p.advance())
+	parts := []*ast.Identifier{first}
+	for p.cur.Kind == int('.') {
+		// A `. *` ends the name as a row reference; stop and build SelectAllFrom.
+		if p.peekNext().Kind == int('*') {
+			p.advance()            // consume '.'
+			starTok := p.advance() // consume '*'
+			name := &ast.QualifiedName{Parts: parts, Loc: ast.Loc{Start: parts[0].Loc.Start, End: parts[len(parts)-1].Loc.End}}
+			item := SelectItem{
+				Kind: SelectAllFrom,
+				Expr: p.columnRefFromName(name),
+				Loc:  ast.Loc{Start: parts[0].Loc.Start, End: starTok.Loc.End},
+			}
+			if err := p.parseSelectAllAliases(&item); err != nil {
+				return SelectItem{}, false, err
+			}
+			return item, true, nil
+		}
+		// A `. identifier` continues the dotted name. If a non-identifier follows
+		// the dot (and it is not the `*` handled above), this is not a clean dotted
+		// name (it may be `m['k']`, a call, etc.) — rewind to the expression path.
+		if !isIdentifierStart(p.peekNext().Kind) {
+			p.restore(cp)
+			return SelectItem{}, false, nil
+		}
+		p.advance() // consume '.'
+		parts = append(parts, identFromToken(p.advance()))
+	}
+
+	// The name did not end in `. *` (no trailing `.*`); it is an ordinary
+	// expression (column reference, function call, typeConstructor, …). Rewind.
+	p.restore(cp)
+	return SelectItem{}, false, nil
+}
+
+// parseSelectAllAliases parses the optional `AS ( col, … )` column-alias list of
+// a `primaryExpression . *` select item and stores it on item.
+func (p *Parser) parseSelectAllAliases(item *SelectItem) error {
+	if p.cur.Kind != kwAS {
+		return nil
+	}
+	p.advance() // consume AS
+	aliases, end, err := p.parseColumnAliases()
+	if err != nil {
+		return err
+	}
+	item.Aliases = aliases
+	item.Loc.End = end
+	return nil
+}
+
+// parseOptionalColumnAlias parses an optional `[AS] column_alias` after a select
+// expression (the as_column_alias rule). It returns ok=false (no alias) when the
+// next token is neither AS nor an identifier-start. A bare identifier following
+// an expression is an alias; an explicit AS makes the following identifier
+// mandatory.
+//
+// As in a relation alias, a bare non-reserved keyword that introduces a
+// following clause (WINDOW/LIMIT/OFFSET/FETCH in clause-introducing position —
+// atRelationClauseStart) is NOT consumed as a column alias, so `SELECT 2 LIMIT 3`
+// reads `2` then the LIMIT clause (not `2 AS limit` with a dangling `3`), while
+// the bare `SELECT 2 limit` still aliases `2` as "limit". Oracle-probed against
+// Trino 481. An explicit AS still forces even a clause keyword to be the alias.
+func (p *Parser) parseOptionalColumnAlias() (*ast.Identifier, bool, error) {
+	if p.cur.Kind == kwAS {
+		p.advance() // consume AS — an identifier MUST follow (even a clause keyword)
+		alias, err := p.parseIdentifier()
+		if err != nil {
+			return nil, false, err
+		}
+		return alias, true, nil
+	}
+	if isIdentifierStart(p.cur.Kind) && !p.atRelationClauseStart() {
+		return identFromToken(p.advance()), true, nil
+	}
+	return nil, false, nil
+}
+
+// parseColumnAliases parses `( identifier (, identifier)* )` (the columnAliases
+// rule), the opening '(' the current token. Returns the identifiers and the
+// closing ')' end offset. Used by the `expr.* AS (…)` select item, relation
+// aliases, and CTE column lists.
+func (p *Parser) parseColumnAliases() ([]*ast.Identifier, int, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+	first, err := p.parseIdentifier()
+	if err != nil {
+		return nil, 0, err
+	}
+	cols := []*ast.Identifier{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseIdentifier()
+		if err != nil {
+			return nil, 0, err
+		}
+		cols = append(cols, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+	return cols, closeTok.Loc.End, nil
+}
+
+// ---------------------------------------------------------------------------
+// GROUP BY
+// ---------------------------------------------------------------------------
+
+// parseGroupBy parses `GROUP BY groupBy` (GROUP is current). The body is
+// `setQuantifier? groupingElement (, groupingElement)*`.
+//
+// setQuantifier disambiguation (S3): `ALL`/`DISTINCT` is the leading quantifier
+// ONLY when a grouping element follows it on the same level. Because ALL is a
+// non-reserved keyword usable as a column reference (and DISTINCT, though
+// reserved, only appears here as the quantifier), the quantifier is taken only
+// when the token after ALL/DISTINCT begins another grouping element (i.e. is not
+// ',' and not a clause/segment terminator). Probed against Trino 481:
+// `GROUP BY ALL x` → ALL is the quantifier; `GROUP BY ALL` and `GROUP BY ALL, x`
+// → ALL is a grouping expression.
+func (p *Parser) parseGroupBy() (*GroupBy, error) {
+	groupTok := p.advance() // consume GROUP
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	gb := &GroupBy{Loc: ast.Loc{Start: groupTok.Loc.Start}}
+
+	if (p.cur.Kind == kwALL || p.cur.Kind == kwDISTINCT) && startsGroupingElement(p.peekNext().Kind) {
+		gb.SetQuantifier = p.advance().Str
+	}
+
+	first, err := p.parseGroupingElement()
+	if err != nil {
+		return nil, err
+	}
+	gb.Elements = []GroupingElement{first}
+	gb.Loc.End = first.Loc.End
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseGroupingElement()
+		if err != nil {
+			return nil, err
+		}
+		gb.Elements = append(gb.Elements, next)
+		gb.Loc.End = next.Loc.End
+	}
+	return gb, nil
+}
+
+// startsGroupingElement reports whether kind can begin a groupingElement: an
+// expression-start, a '(' (parenthesized grouping set), or one of ROLLUP / CUBE
+// / GROUPING (the keyword grouping forms). Used to disambiguate the GROUP BY
+// setQuantifier (S3) — ALL/DISTINCT is the quantifier only when a grouping
+// element follows.
+func startsGroupingElement(kind TokenKind) bool {
+	switch kind {
+	case kwROLLUP, kwCUBE, kwGROUPING, int('('):
+		return true
+	default:
+		return startsExpression(kind)
+	}
+}
+
+// startsExpression reports whether kind can begin an `expression`
+// (booleanExpression → … → primaryExpression). It enumerates the leading-token
+// vocabulary of parsePrimaryAtom (expr.go) plus the prefix operators NOT / + / -
+// that begin a boolean/value expression. Used where a token must be classified
+// as "starts an expression" without committing to a parse (e.g. the GROUP BY
+// setQuantifier disambiguation, S3).
+//
+// It is deliberately permissive on the keyword-led atoms (CASE, CAST, EXISTS,
+// the special built-ins, the JSON functions, ARRAY/ROW constructors) and on any
+// identifier-start (an unquoted/quoted name or a non-reserved keyword usable as
+// a column reference). A token it returns true for may still fail to parse as a
+// complete expression — the caller commits and surfaces any error normally.
+func startsExpression(kind TokenKind) bool {
+	switch kind {
+	case kwNOT, // logicalNot prefix
+		int('+'), int('-'), // arithmeticUnary prefix
+		kwNULL, kwTRUE, kwFALSE,
+		tokString, tokUnicodeString, tokInteger, tokDecimal, tokDouble, tokBinaryLiteral,
+		tokQuestion, int('?'),
+		kwINTERVAL, int('('),
+		kwARRAY, kwROW, kwCASE, kwCAST, kwTRY_CAST, kwEXISTS,
+		kwEXTRACT, kwTRIM, kwNORMALIZE, kwLISTAGG, kwGROUPING,
+		kwJSON_EXISTS, kwJSON_VALUE, kwJSON_QUERY, kwJSON_OBJECT, kwJSON_ARRAY,
+		kwRUNNING, kwFINAL,
+		kwCURRENT_DATE, kwCURRENT_USER, kwCURRENT_CATALOG, kwCURRENT_SCHEMA, kwCURRENT_PATH,
+		kwCURRENT_TIME, kwCURRENT_TIMESTAMP, kwLOCALTIME, kwLOCALTIMESTAMP,
+		kwDOUBLE:
+		return true
+	default:
+		return isIdentifierStart(kind)
+	}
+}
+
+// parseGroupingElement parses one `groupingElement`: ROLLUP(…), CUBE(…),
+// GROUPING SETS(…), a parenthesized grouping set `( e, … )`, or a bare
+// expression.
+func (p *Parser) parseGroupingElement() (GroupingElement, error) {
+	switch p.cur.Kind {
+	case kwROLLUP:
+		return p.parseRollupCube(GroupingRollup)
+	case kwCUBE:
+		return p.parseRollupCube(GroupingCube)
+	case kwGROUPING:
+		// GROUPING SETS ( … ). A bare GROUPING(...) is the groupingOperation
+		// expression (function.go); GROUPING SETS is the grouping-element form,
+		// recognised by the SETS keyword following GROUPING.
+		if p.peekNext().Kind == kwSETS {
+			return p.parseGroupingSets()
+		}
+		// GROUPING not followed by SETS is a groupingOperation expression used as
+		// a single grouping expression (e.g. GROUP BY GROUPING(x)).
+		return p.parseGroupingSetOrExpr()
+	default:
+		return p.parseGroupingSetOrExpr()
+	}
+}
+
+// parseRollupCube parses `ROLLUP ( e, … )` or `CUBE ( e, … )` (kind selects
+// which; the keyword is current). The expression list may be empty.
+func (p *Parser) parseRollupCube(kind GroupingElementKind) (GroupingElement, error) {
+	kwTok := p.advance() // consume ROLLUP / CUBE
+	if _, err := p.expect(int('(')); err != nil {
+		return GroupingElement{}, err
+	}
+	exprs, closeTok, err := p.parseBracketedExprList(int(')'))
+	if err != nil {
+		return GroupingElement{}, err
+	}
+	return GroupingElement{
+		Kind:  kind,
+		Exprs: exprs,
+		Loc:   ast.Loc{Start: kwTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseGroupingSets parses `GROUPING SETS ( groupingSet (, groupingSet)* )`
+// (GROUPING is current, SETS confirmed by the caller). Each grouping set is a
+// parenthesized expression list `( e, … )` or a bare expression.
+func (p *Parser) parseGroupingSets() (GroupingElement, error) {
+	groupingTok := p.advance() // consume GROUPING
+	if _, err := p.expect(kwSETS); err != nil {
+		return GroupingElement{}, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return GroupingElement{}, err
+	}
+	first, err := p.parseGroupingSetExprs()
+	if err != nil {
+		return GroupingElement{}, err
+	}
+	sets := [][]Expr{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseGroupingSetExprs()
+		if err != nil {
+			return GroupingElement{}, err
+		}
+		sets = append(sets, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return GroupingElement{}, err
+	}
+	return GroupingElement{
+		Kind: GroupingSets,
+		Sets: sets,
+		Loc:  ast.Loc{Start: groupingTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseGroupingSetExprs parses one grouping set inside GROUPING SETS: either a
+// parenthesized expression list `( e, … )` (possibly empty, the `()` empty set)
+// or a single bare expression. Returns the expression list (nil/empty for `()`).
+func (p *Parser) parseGroupingSetExprs() ([]Expr, error) {
+	if p.cur.Kind == int('(') {
+		p.advance() // consume '('
+		exprs, _, err := p.parseBracketedExprList(int(')'))
+		return exprs, err
+	}
+	e, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return []Expr{e}, nil
+}
+
+// parseGroupingSetOrExpr parses a single groupingSet (the singleGroupingSet
+// alternative): a parenthesized grouping set `( (expression (, …)*)? )` — which
+// may be empty (the `()` empty grouping set) or multi-column — or a single bare
+// expression.
+//
+// A leading '(' is genuinely ambiguous (oracle-confirmed in Trino 481): it can
+// open a grouping set (`GROUP BY (a, b)`, `GROUP BY ()`) OR a parenthesized
+// sub-expression of a larger grouping expression (`GROUP BY (a + b) * 2`,
+// `GROUP BY (a) IS NULL`, `GROUP BY (a, b)[1]` — all parse, the latter as a row
+// subscript). ANTLR resolves this by adaptive prediction; here a checkpoint does
+// it: read `( expr-list? )`, then decide by what follows the `)`:
+//   - empty `()` → the empty grouping set (nothing else can start with `()`).
+//   - the `)` followed by an expression-continuation token (an operator,
+//     subscript, dereference, predicate, …) → the parentheses were a
+//     sub-expression; rewind and parse the whole grouping element as one
+//     expression.
+//   - otherwise (the `)` is followed by ',' or a clause terminator) → a
+//     parenthesized grouping set; keep its column list.
+//
+// A leading non-'(' token is always a single grouping expression.
+func (p *Parser) parseGroupingSetOrExpr() (GroupingElement, error) {
+	if p.cur.Kind == int('(') {
+		cp := p.checkpoint()
+		openTok := p.advance() // consume '('
+		exprs, closeTok, err := p.parseBracketedExprList(int(')'))
+		if err == nil && (len(exprs) == 0 || !continuesExpression(p.cur.Kind)) {
+			return GroupingElement{
+				Kind:  GroupingExprKind,
+				Exprs: exprs,
+				Loc:   ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+			}, nil
+		}
+		// The parentheses opened a larger expression (or the bracketed list failed
+		// to parse, e.g. a single expression with internal structure). Rewind and
+		// parse the whole grouping element as one expression.
+		p.restore(cp)
+	}
+	e, err := p.parseExpr()
+	if err != nil {
+		return GroupingElement{}, err
+	}
+	return GroupingElement{
+		Kind:  GroupingExprKind,
+		Exprs: []Expr{e},
+		Loc:   e.Span(),
+	}, nil
+}
+
+// continuesExpression reports whether kind, appearing right after a closing ')',
+// continues the surrounding expression — i.e. it is an infix/postfix operator,
+// subscript, dereference, AT-TIME-ZONE, comparison, or boolean/predicate keyword.
+// Used by parseGroupingSetOrExpr to tell a parenthesized grouping set from a
+// parenthesized sub-expression. The conservative default (false) treats the ')'
+// as ending a grouping set, which is correct at a grouping-element boundary
+// (',' or a clause keyword).
+func continuesExpression(kind TokenKind) bool {
+	switch kind {
+	case int('+'), int('-'), int('*'), int('/'), int('%'), // arithmetic
+		tokConcat,                                                       // ||
+		int('['),                                                        // subscript
+		int('.'),                                                        // dereference
+		kwAT,                                                            // AT TIME ZONE
+		int('='), tokNotEq, int('<'), tokLessEq, int('>'), tokGreaterEq, // comparison
+		kwAND, kwOR, // boolean
+		kwNOT, kwBETWEEN, kwIN, kwLIKE, kwIS: // predicate
+		return true
+	default:
+		return false
+	}
+}

--- a/trino/parser/select_test.go
+++ b/trino/parser/select_test.go
@@ -1,0 +1,426 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the parser-select node's slice of the correctness gate
+// (correctness-protocol.md) for the querySpecification / queryNoWith / GROUP BY
+// surface. The differential gate (TestSelect_OracleDifferential) is the
+// authoritative accept/reject check: omni's Parse accept/reject must equal Trino
+// 481's, error-classified (a SYNTAX_ERROR is a reject; any other error —
+// TABLE_NOT_FOUND, COLUMN_NOT_FOUND, TYPE_MISMATCH, NOT_SUPPORTED,
+// MISSING_ORDER_BY — means Trino's parser ACCEPTED the statement). The oracle
+// helpers (connectOracle / oracleAccepts / truncateName) live in
+// oracle_foundation_test.go; the relation / CTE / set-op / window corpora live in
+// their sibling *_test.go files. The structural tests pin precedence and clause
+// shapes the accept/reject gate cannot see.
+//
+// Corpus sources (correctness-protocol §completeness): every query form of the
+// legacy ANTLR grammar (truth2) + every documented Trino 481 form (truth1,
+// docs/migration/trino/truth1/query-dml.md) + the legacy examples
+// (/Users/h3n4l/OpenSource/parser/trino/examples/*.sql) + oracle-probed edge
+// cases. Negative (reject) inputs are required and present.
+
+// selectAcceptCorpus is the querySpecification / queryNoWith / GROUP BY surface
+// Trino 481 accepts (its parser does not raise SYNTAX_ERROR). The relation /
+// join, CTE, set-op, and window forms have their own accept corpora in the
+// sibling files.
+var selectAcceptCorpus = []string{
+	// --- minimal SELECT ---
+	"SELECT 1",
+	"SELECT 1, 2, 3",
+	"SELECT 1 + 2 * 3",
+	"SELECT 'a', TRUE, NULL",
+	"SELECT a, b, c FROM t",
+	"SELECT * FROM t",
+
+	// --- setQuantifier ---
+	"SELECT DISTINCT a FROM t",
+	"SELECT ALL a FROM t",
+	"SELECT DISTINCT a, b FROM t",
+
+	// --- select items: alias forms ---
+	"SELECT a AS x FROM t",
+	"SELECT a x FROM t", // bare alias
+	"SELECT a + b AS s FROM t",
+	"SELECT a x, b AS y, c FROM t",
+	"SELECT count(*) AS n FROM t",
+	`SELECT a AS "Quoted Alias" FROM t`,
+
+	// --- selectAll variants (the three selectItem alternatives) ---
+	"SELECT *",
+	"SELECT * FROM t",
+	"SELECT t.* FROM t",
+	"SELECT a.b.* FROM cat.sch.tbl a",
+	"SELECT r.* FROM t",
+	"SELECT ROW (1, 'a', true).*",
+	"SELECT ROW (1, 'a', true).* AS (f1, f2, f3)",
+	"SELECT (CAST(ROW(1, true) AS ROW(field1 bigint, field2 boolean))).* AS (alias1, alias2)",
+	"SELECT a.id AS hello FROM t",
+	"SELECT col1.f1, col2, col3.f1.f2.f3 FROM table1",
+	"SELECT col1.f1[0], col2, col3[2].f2.f3, col4[4] FROM table1",
+
+	// --- WHERE / HAVING ---
+	"SELECT a FROM t WHERE a > 1",
+	"SELECT a FROM t WHERE a > 1 AND b < 2 OR c = 3",
+	"SELECT a FROM t WHERE a IN (1, 2, 3)",
+	"SELECT a FROM t WHERE a BETWEEN 1 AND 10",
+	"SELECT a, count(*) FROM t GROUP BY a HAVING count(*) > 5",
+
+	// --- GROUP BY: plain, sets, rollup, cube, grouping sets ---
+	"SELECT a FROM t GROUP BY a",
+	"SELECT a, b FROM t GROUP BY a, b",
+	"SELECT a FROM t GROUP BY ()",
+	"SELECT a FROM t GROUP BY (a, b)",
+	"SELECT a FROM t GROUP BY a, b, (c, d)",
+	"SELECT a FROM t GROUP BY ROLLUP (a, b)",
+	"SELECT a FROM t GROUP BY ROLLUP ()",
+	"SELECT a FROM t GROUP BY CUBE (a, b)",
+	"SELECT a FROM t GROUP BY GROUPING SETS (a)",
+	"SELECT a, b, GROUPING(a, b) FROM t GROUP BY GROUPING SETS ((a), (b))",
+	"SELECT a FROM t GROUP BY GROUPING SETS ((a), (b), ())",
+	"SELECT a FROM t GROUP BY ALL GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
+	"SELECT a FROM t GROUP BY DISTINCT GROUPING SETS ((a, b), (a), ()), CUBE (c), ROLLUP (d)",
+	// GROUP BY setQuantifier disambiguation (S3, oracle-probed)
+	"SELECT a FROM t GROUP BY ALL x",         // ALL is the quantifier
+	"SELECT count(*) FROM t GROUP BY ALL",    // ALL is a grouping expr (column "all")
+	"SELECT count(*) FROM t GROUP BY ALL, x", // ALL is a grouping expr (comma after)
+	"SELECT a FROM t GROUP BY DISTINCT x",
+	"SELECT count(*) FROM t GROUP BY AUTO", // AUTO keyword form (parses)
+	// parenthesized-expr vs grouping-set ambiguity (oracle-probed)
+	"SELECT a FROM t GROUP BY (a + b) * 2",
+	"SELECT a FROM t GROUP BY (a) + 1",
+	"SELECT a FROM t GROUP BY (a) IS NULL",
+
+	// --- ORDER BY / OFFSET / LIMIT / FETCH ---
+	"SELECT a FROM t ORDER BY a",
+	"SELECT a FROM t ORDER BY a DESC",
+	"SELECT a FROM t ORDER BY a ASC NULLS FIRST, b DESC NULLS LAST",
+	"SELECT a FROM t ORDER BY 1, 2",
+	"SELECT a FROM t LIMIT 10",
+	"SELECT a FROM t LIMIT ALL",
+	"SELECT a FROM t ORDER BY a LIMIT 5",
+	"SELECT a FROM t OFFSET 5",
+	"SELECT a FROM t OFFSET 5 ROWS",
+	"SELECT a FROM t OFFSET 5 ROW",
+	"SELECT a FROM t OFFSET ? ROWS LIMIT ?",
+	"SELECT a FROM t FETCH FIRST 3 ROWS ONLY",
+	"SELECT a FROM t FETCH NEXT ROW ONLY",
+	"SELECT a FROM t FETCH FIRST ROW WITH TIES", // ORDER BY (required semantically) goes BEFORE FETCH; see reject corpus
+	"SELECT a FROM t ORDER BY a OFFSET 2 ROWS FETCH FIRST 3 ROWS WITH TIES",
+	"SELECT a FROM t ORDER BY a OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY",
+
+	// --- queryPrimary: TABLE / VALUES ---
+	"TABLE foo",
+	"TABLE cat.sch.tbl",
+	"VALUES 1, 2, 3",
+	"VALUES (1, 'a'), (2, 'b')",
+	"VALUES 1",
+	"SELECT * FROM (VALUES 42, 13)",
+
+	// --- whole-query decorations on TABLE/VALUES ---
+	"TABLE foo ORDER BY 1 LIMIT 5",
+	"VALUES (1), (2), (3) ORDER BY 1 DESC",
+
+	// --- nested subqueries in expression position (B1 placeholders) ---
+	"SELECT (SELECT 1)",
+	"SELECT a FROM t WHERE a IN (SELECT b FROM u)",
+	"SELECT a FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.x = t.x)",
+	"SELECT a FROM t WHERE a > ALL (SELECT b FROM u)",
+}
+
+// selectRejectCorpus is malformed querySpecification / queryNoWith input Trino
+// 481 rejects with a SYNTAX_ERROR (required negative coverage).
+var selectRejectCorpus = []string{
+	"SELECT",                             // no select list
+	"SELECT FROM t",                      // empty select list before FROM
+	"SELECT 1 FROM",                      // FROM with no relation
+	"SELECT 1,",                          // trailing comma in select list
+	"SELECT * FROM",                      // FROM with no relation
+	"SELECT 1 WHERE",                     // WHERE with no predicate
+	"SELECT 1 WHERE FROM t",              // WHERE with no predicate before FROM
+	"SELECT 1 GROUP BY",                  // GROUP BY with no element
+	"SELECT 1 GROUP",                     // GROUP without BY
+	"SELECT 1 ORDER BY",                  // ORDER BY with no key
+	"SELECT 1 ORDER",                     // ORDER without BY
+	"SELECT 1 HAVING",                    // HAVING with no predicate
+	"SELECT a FROM t LIMIT x",            // LIMIT with a non-count token
+	"SELECT a FROM t FETCH FIRST 3 ROWS", // FETCH without ONLY/WITH TIES
+	"SELECT a FROM t FETCH FIRST ROW WITH TIES ORDER BY a", // ORDER BY must precede FETCH
+	"SELECT DISTINCT FROM t",                               // DISTINCT (reserved) with no select item
+	"SELECT a FROM t GROUP BY ROLLUP",                      // ROLLUP without parens
+	"SELECT a FROM t GROUP BY GROUPING SETS",               // GROUPING SETS without parens
+	"VALUES",                                               // VALUES with no rows
+	"TABLE",                                                // TABLE with no name
+	"SELECT a a a FROM t",                                  // two aliases (trailing-token error)
+	"SELECT 1 garbage extra",                               // trailing junk after the statement
+}
+
+// TestSelect_AcceptCorpusParses verifies omni accepts every form in
+// selectAcceptCorpus (oracle-free completeness smoke test). The oracle
+// differential proves the verdicts actually match Trino.
+func TestSelect_AcceptCorpusParses(t *testing.T) {
+	for _, sql := range selectAcceptCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) != 0 {
+				t.Errorf("Parse(%q) should accept, got errors: %v", sql, errs)
+			}
+		})
+	}
+}
+
+// TestSelect_RejectCorpusRejected verifies omni rejects every form in
+// selectRejectCorpus (required negative coverage).
+func TestSelect_RejectCorpusRejected(t *testing.T) {
+	for _, sql := range selectRejectCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) == 0 {
+				t.Errorf("Parse(%q) should reject, but accepted", sql)
+			}
+		})
+	}
+}
+
+// TestSelect_OracleDifferential is the authoritative accept/reject gate: for
+// every form in both corpora, omni's Parse accept/reject must equal Trino 481's
+// accept/reject. Skipped when no oracle is reachable.
+func TestSelect_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	check := func(t *testing.T, sql string) {
+		_, errs := Parse(sql)
+		omniAccepts := len(errs) == 0
+		trinoAccepts, ok := oracleAccepts(t, o, sql)
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH sql=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				sql, omniAccepts, errs, trinoAccepts)
+		}
+	}
+	for _, sql := range selectAcceptCorpus {
+		t.Run("accept/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+	for _, sql := range selectRejectCorpus {
+		t.Run("reject/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+}
+
+// ---------------------------------------------------------------------------
+// structural tests (precedence / clause shapes the accept/reject gate can't see)
+// ---------------------------------------------------------------------------
+
+// parseOneQuery parses a single-statement query input and returns the *Query,
+// failing the test on any parse error or a non-query statement.
+func parseOneQuery(t *testing.T, sql string) *Query {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) errors: %v", sql, errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Parse(%q): want 1 statement, got %d", sql, len(file.Stmts))
+	}
+	stmt, ok := file.Stmts[0].(*QueryStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): want *QueryStmt, got %T", sql, file.Stmts[0])
+	}
+	return stmt.Query
+}
+
+// querySpec extracts the *QuerySpec body of a query (failing if the body is not
+// a plain query specification).
+func querySpec(t *testing.T, q *Query) *QuerySpec {
+	t.Helper()
+	spec, ok := q.Body.(*QuerySpec)
+	if !ok {
+		t.Fatalf("query body is %T, want *QuerySpec", q.Body)
+	}
+	return spec
+}
+
+func TestSelect_StructureSelectList(t *testing.T) {
+	spec := querySpec(t, parseOneQuery(t, "SELECT a, b AS y, * FROM t"))
+	if len(spec.Items) != 3 {
+		t.Fatalf("want 3 select items, got %d", len(spec.Items))
+	}
+	if spec.Items[0].Kind != SelectSingle || spec.Items[0].Alias != nil {
+		t.Errorf("item 0: want SelectSingle no alias, got kind=%v alias=%v", spec.Items[0].Kind, spec.Items[0].Alias)
+	}
+	if spec.Items[1].Kind != SelectSingle || spec.Items[1].Alias == nil || spec.Items[1].Alias.Value != "y" {
+		t.Errorf("item 1: want SelectSingle alias=y, got kind=%v alias=%v", spec.Items[1].Kind, spec.Items[1].Alias)
+	}
+	if spec.Items[2].Kind != SelectAll {
+		t.Errorf("item 2: want SelectAll, got %v", spec.Items[2].Kind)
+	}
+}
+
+func TestSelect_StructureSelectAllFrom(t *testing.T) {
+	spec := querySpec(t, parseOneQuery(t, "SELECT t.* FROM t"))
+	if len(spec.Items) != 1 || spec.Items[0].Kind != SelectAllFrom {
+		t.Fatalf("want one SelectAllFrom item, got %+v", spec.Items)
+	}
+	// The row expression of `t.*` is a ColumnRef to t.
+	if _, ok := spec.Items[0].Expr.(*ColumnRef); !ok {
+		t.Errorf("SelectAllFrom expr is %T, want *ColumnRef", spec.Items[0].Expr)
+	}
+
+	spec = querySpec(t, parseOneQuery(t, "SELECT a.b.* AS (x, y) FROM cat a"))
+	if spec.Items[0].Kind != SelectAllFrom {
+		t.Fatalf("want SelectAllFrom, got %v", spec.Items[0].Kind)
+	}
+	if len(spec.Items[0].Aliases) != 2 {
+		t.Errorf("want 2 column aliases, got %d", len(spec.Items[0].Aliases))
+	}
+	// The row expression of `a.b.*` is a Dereference(ColumnRef a, b).
+	if _, ok := spec.Items[0].Expr.(*Dereference); !ok {
+		t.Errorf("SelectAllFrom expr is %T, want *Dereference", spec.Items[0].Expr)
+	}
+}
+
+func TestSelect_StructureClauses(t *testing.T) {
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT DISTINCT a FROM t WHERE a > 1 GROUP BY a HAVING count(*) > 2 WINDOW w AS (ORDER BY a)"))
+	if spec.SetQuantifier != "DISTINCT" {
+		t.Errorf("SetQuantifier=%q, want DISTINCT", spec.SetQuantifier)
+	}
+	if len(spec.From) != 1 {
+		t.Errorf("want 1 FROM relation, got %d", len(spec.From))
+	}
+	if spec.Where == nil {
+		t.Error("Where is nil, want a predicate")
+	}
+	if spec.GroupBy == nil || len(spec.GroupBy.Elements) != 1 {
+		t.Errorf("GroupBy = %+v, want one element", spec.GroupBy)
+	}
+	if spec.Having == nil {
+		t.Error("Having is nil, want a predicate")
+	}
+	if len(spec.Windows) != 1 || spec.Windows[0].Name.Value != "w" {
+		t.Errorf("Windows = %+v, want one named 'w'", spec.Windows)
+	}
+}
+
+func TestSelect_StructureGroupByQuantifier(t *testing.T) {
+	// `GROUP BY ALL x` — ALL is the setQuantifier, x the grouping element.
+	gb := querySpec(t, parseOneQuery(t, "SELECT a FROM t GROUP BY ALL x")).GroupBy
+	if gb.SetQuantifier != "ALL" {
+		t.Errorf("`GROUP BY ALL x`: SetQuantifier=%q, want ALL", gb.SetQuantifier)
+	}
+	if len(gb.Elements) != 1 {
+		t.Errorf("`GROUP BY ALL x`: want 1 element, got %d", len(gb.Elements))
+	}
+
+	// `GROUP BY ALL` — ALL is a grouping expression (no quantifier).
+	gb = querySpec(t, parseOneQuery(t, "SELECT count(*) FROM t GROUP BY ALL")).GroupBy
+	if gb.SetQuantifier != "" {
+		t.Errorf("`GROUP BY ALL`: SetQuantifier=%q, want empty", gb.SetQuantifier)
+	}
+	if len(gb.Elements) != 1 || gb.Elements[0].Kind != GroupingExprKind {
+		t.Errorf("`GROUP BY ALL`: want 1 expr element, got %+v", gb.Elements)
+	}
+
+	// `GROUP BY ALL, x` — ALL is a grouping expression; two elements.
+	gb = querySpec(t, parseOneQuery(t, "SELECT count(*) FROM t GROUP BY ALL, x")).GroupBy
+	if gb.SetQuantifier != "" {
+		t.Errorf("`GROUP BY ALL, x`: SetQuantifier=%q, want empty", gb.SetQuantifier)
+	}
+	if len(gb.Elements) != 2 {
+		t.Errorf("`GROUP BY ALL, x`: want 2 elements, got %d", len(gb.Elements))
+	}
+}
+
+func TestSelect_StructureGroupingElements(t *testing.T) {
+	gb := querySpec(t, parseOneQuery(t,
+		"SELECT a FROM t GROUP BY a, ROLLUP (b, c), CUBE (d), GROUPING SETS ((e), ())")).GroupBy
+	if len(gb.Elements) != 4 {
+		t.Fatalf("want 4 grouping elements, got %d", len(gb.Elements))
+	}
+	wantKinds := []GroupingElementKind{GroupingExprKind, GroupingRollup, GroupingCube, GroupingSets}
+	for i, want := range wantKinds {
+		if gb.Elements[i].Kind != want {
+			t.Errorf("element %d kind=%v, want %v", i, gb.Elements[i].Kind, want)
+		}
+	}
+	// ROLLUP (b, c) → two expressions.
+	if len(gb.Elements[1].Exprs) != 2 {
+		t.Errorf("ROLLUP element: want 2 exprs, got %d", len(gb.Elements[1].Exprs))
+	}
+	// GROUPING SETS ((e), ()) → two sets, second empty.
+	if len(gb.Elements[3].Sets) != 2 {
+		t.Errorf("GROUPING SETS: want 2 sets, got %d", len(gb.Elements[3].Sets))
+	}
+	if len(gb.Elements[3].Sets[1]) != 0 {
+		t.Errorf("GROUPING SETS second set: want empty, got %d", len(gb.Elements[3].Sets[1]))
+	}
+}
+
+func TestSelect_StructureLimitFetchOffset(t *testing.T) {
+	q := parseOneQuery(t, "SELECT a FROM t ORDER BY a OFFSET 2 ROWS FETCH FIRST 3 ROWS WITH TIES")
+	if len(q.OrderBy) != 1 {
+		t.Errorf("want 1 ORDER BY item, got %d", len(q.OrderBy))
+	}
+	if q.Offset == nil || q.Offset.RowKeyword != "ROWS" {
+		t.Errorf("Offset = %+v, want ROWS", q.Offset)
+	}
+	if q.Fetch == nil || q.Fetch.Keyword != "FIRST" || !q.Fetch.WithTies {
+		t.Errorf("Fetch = %+v, want FIRST WITH TIES", q.Fetch)
+	}
+
+	q = parseOneQuery(t, "SELECT a FROM t LIMIT ALL")
+	if q.Limit == nil || !q.Limit.All {
+		t.Errorf("Limit = %+v, want LIMIT ALL", q.Limit)
+	}
+
+	q = parseOneQuery(t, "SELECT a FROM t LIMIT 10")
+	if q.Limit == nil || q.Limit.All || q.Limit.Count == nil {
+		t.Errorf("Limit = %+v, want LIMIT 10", q.Limit)
+	}
+}
+
+func TestSelect_StructureTableAndValues(t *testing.T) {
+	q := parseOneQuery(t, "TABLE cat.sch.tbl")
+	tq, ok := q.Body.(*TableQuery)
+	if !ok {
+		t.Fatalf("body is %T, want *TableQuery", q.Body)
+	}
+	if got := tq.Name.Normalize(); got != "cat.sch.tbl" {
+		t.Errorf("TABLE name = %q, want cat.sch.tbl", got)
+	}
+
+	q = parseOneQuery(t, "VALUES (1, 'a'), (2, 'b')")
+	vq, ok := q.Body.(*ValuesQuery)
+	if !ok {
+		t.Fatalf("body is %T, want *ValuesQuery", q.Body)
+	}
+	if len(vq.Rows) != 2 {
+		t.Errorf("VALUES rows = %d, want 2", len(vq.Rows))
+	}
+}
+
+// TestSelect_LocSpans checks the parsed query's Loc covers the whole statement.
+func TestSelect_LocSpans(t *testing.T) {
+	sql := "SELECT a, b FROM t WHERE a > 1"
+	q := parseOneQuery(t, sql)
+	if q.Loc.Start != 0 {
+		t.Errorf("query Loc.Start = %d, want 0", q.Loc.Start)
+	}
+	if q.Loc.End != len(sql) {
+		t.Errorf("query Loc.End = %d, want %d", q.Loc.End, len(sql))
+	}
+	// every select item carries a valid span.
+	for i, it := range querySpec(t, q).Items {
+		if !it.Loc.IsValid() {
+			t.Errorf("select item %d has invalid Loc %+v", i, it.Loc)
+		}
+		_ = ast.Loc(it.Loc)
+	}
+}

--- a/trino/parser/setops.go
+++ b/trino/parser/setops.go
@@ -1,0 +1,206 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `parser-select` DAG node (with select.go,
+// relation.go, ctes.go and window.go): it implements Trino's `queryTerm` and
+// `queryPrimary` grammar rules — the set-operation layer (UNION / INTERSECT /
+// EXCEPT) and the four query primaries (a SELECT block, `TABLE name`,
+// `VALUES …`, and a parenthesized `( queryNoWith )`).
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	queryTerm
+//	    : queryPrimary                                              # queryTermDefault
+//	    | left INTERSECT setQuantifier? right                       # setOperation
+//	    | left (UNION|EXCEPT) setQuantifier? right                  # setOperation ;
+//	queryPrimary
+//	    : querySpecification          # queryPrimaryDefault
+//	    | TABLE qualifiedName         # table
+//	    | VALUES expression (, …)*    # inlineTable
+//	    | ( queryNoWith )             # subquery ;
+//
+// Oracle-confirmed precedence & associativity (S1 in select.go), reflected in
+// the two-level parse: INTERSECT binds TIGHTER than UNION/EXCEPT (ANTLR lists
+// the INTERSECT alternative first), and within each level operators are
+// LEFT-associative. So `a UNION b EXCEPT c` == `(a UNION b) EXCEPT c` and
+// `a INTERSECT b UNION c` == `(a INTERSECT b) UNION c`. parseQueryTerm parses a
+// UNION/EXCEPT chain whose operands are INTERSECT chains.
+//
+// Divergence #6 (D3 in select.go): the `CORRESPONDING` set-op modifier valid in
+// Trino 481 is ABSENT from the legacy grammar (where the only modifier is
+// setQuantifier = DISTINCT/ALL). It is a deferred P1 extension; not parsed here
+// (omni rejects `UNION CORRESPONDING`, Trino 481 accepts it). Recorded in the
+// migration divergence ledger.
+
+// SetOperation is a binary set operation `left <op> [quantifier] right`
+// (the setOperation queryTerm alternative). Op is "UNION", "INTERSECT", or
+// "EXCEPT". Quantifier is "" (no modifier), "DISTINCT", or "ALL". Left and Right
+// are the operand query terms.
+type SetOperation struct {
+	Op         string // "UNION", "INTERSECT", or "EXCEPT"
+	Quantifier string // "", "DISTINCT", or "ALL"
+	Left       QueryNode
+	Right      QueryNode
+	Loc        ast.Loc
+}
+
+func (n *SetOperation) Span() ast.Loc { return n.Loc }
+func (*SetOperation) queryNode()      {}
+
+// parseQueryTerm parses a `queryTerm`: a left-associative UNION/EXCEPT chain
+// whose operands are INTERSECT chains (S1). This is the entry point for a query
+// body, a parenthesized query, a CTE body, and a relation subquery.
+func (p *Parser) parseQueryTerm() (QueryNode, error) {
+	left, err := p.parseIntersectTerm()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == kwUNION || p.cur.Kind == kwEXCEPT {
+		opTok := p.advance() // consume UNION / EXCEPT
+		quant := p.parseSetQuantifier()
+		right, err := p.parseIntersectTerm()
+		if err != nil {
+			return nil, err
+		}
+		left = &SetOperation{
+			Op:         opTok.Str,
+			Quantifier: quant,
+			Left:       left,
+			Right:      right,
+			Loc:        ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseIntersectTerm parses the INTERSECT precedence level: a left-associative
+// INTERSECT chain whose operands are query primaries. INTERSECT binds tighter
+// than UNION/EXCEPT (S1).
+func (p *Parser) parseIntersectTerm() (QueryNode, error) {
+	left, err := p.parseQueryPrimary()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == kwINTERSECT {
+		opTok := p.advance() // consume INTERSECT
+		quant := p.parseSetQuantifier()
+		right, err := p.parseQueryPrimary()
+		if err != nil {
+			return nil, err
+		}
+		left = &SetOperation{
+			Op:         opTok.Str,
+			Quantifier: quant,
+			Left:       left,
+			Right:      right,
+			Loc:        ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parseSetQuantifier consumes an optional `DISTINCT | ALL` set-operation
+// modifier and returns its spelling ("" when absent). The CORRESPONDING modifier
+// (Trino 481) is a deferred P1 extension and is intentionally NOT consumed here
+// (D3) — leaving it surfaces as the syntax error a legacy-scope parser reports.
+func (p *Parser) parseSetQuantifier() string {
+	if tok, ok := p.match(kwDISTINCT, kwALL); ok {
+		return tok.Str
+	}
+	return ""
+}
+
+// parseQueryPrimary parses a `queryPrimary`: a SELECT block, `TABLE
+// qualifiedName`, `VALUES …`, or a parenthesized `( queryNoWith )`.
+func (p *Parser) parseQueryPrimary() (QueryNode, error) {
+	switch p.cur.Kind {
+	case kwSELECT:
+		return p.parseQuerySpecification()
+	case kwTABLE:
+		return p.parseTableQuery()
+	case kwVALUES:
+		return p.parseValuesQuery()
+	case int('('):
+		return p.parseParenQuery()
+	default:
+		return nil, p.queryPrimaryError()
+	}
+}
+
+// parseTableQuery parses the `TABLE qualifiedName` query primary (TABLE is
+// current): shorthand for `SELECT * FROM qualifiedName`.
+func (p *Parser) parseTableQuery() (*TableQuery, error) {
+	tableTok := p.advance() // consume TABLE
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	return &TableQuery{
+		Name: name,
+		Loc:  ast.Loc{Start: tableTok.Loc.Start, End: name.Loc.End},
+	}, nil
+}
+
+// parseValuesQuery parses the `VALUES expression (, expression)*` query primary
+// (VALUES is current): an inline row set. Each row is an expression — commonly a
+// rowConstructor for a multi-column row (`VALUES (1, 'a'), (2, 'b')`), parsed by
+// the expression layer.
+func (p *Parser) parseValuesQuery() (*ValuesQuery, error) {
+	valuesTok := p.advance() // consume VALUES
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	rows := []Expr{first}
+	end := first.Span().End
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, next)
+		end = next.Span().End
+	}
+	return &ValuesQuery{
+		Rows: rows,
+		Loc:  ast.Loc{Start: valuesTok.Loc.Start, End: end},
+	}, nil
+}
+
+// parseParenQuery parses the `( queryNoWith )` query primary (the `subquery`
+// rule; '(' is current). The inner content is a queryNoWith — a query without
+// its own WITH but possibly carrying its own ORDER BY / LIMIT / set-operation.
+// A WITH inside the parentheses is NOT a queryNoWith, so it is reported as a
+// syntax error (Trino rejects `(WITH … SELECT …)` in this position; a CTE there
+// must be a relation subquery `( query )`, handled in relation.go).
+func (p *Parser) parseParenQuery() (*ParenQuery, error) {
+	openTok := p.advance() // consume '('
+	inner, err := p.parseQueryNoWith(nil, p.cur.Loc.Start)
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	inner.Loc.End = closeTok.Loc.Start
+	return &ParenQuery{
+		Inner: inner,
+		Loc:   ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// queryPrimaryError reports a token that cannot begin a queryPrimary (SELECT /
+// TABLE / VALUES / '(') where one is required.
+func (p *Parser) queryPrimaryError() *ParseError {
+	if p.cur.Kind == tokEOF {
+		return &ParseError{Loc: p.cur.Loc, Msg: "expected a query (SELECT/TABLE/VALUES), found end of input"}
+	}
+	text := p.cur.Str
+	if text == "" {
+		text = TokenName(p.cur.Kind)
+	}
+	return &ParseError{Loc: p.cur.Loc, Msg: "expected a query (SELECT/TABLE/VALUES), found " + text}
+}

--- a/trino/parser/setops_test.go
+++ b/trino/parser/setops_test.go
@@ -1,0 +1,193 @@
+package parser
+
+import "testing"
+
+// This file is the parser-select node's correctness slice for the set-operation
+// layer (setops.go): UNION / INTERSECT / EXCEPT precedence & associativity (S1)
+// and the four query primaries. The oracle differential is authoritative;
+// structural tests pin the INTERSECT-binds-tighter and left-associative shapes.
+// Helpers live in oracle_foundation_test.go and select_test.go.
+
+// setopAcceptCorpus is the set-operation surface Trino 481 accepts.
+var setopAcceptCorpus = []string{
+	"SELECT 1 UNION SELECT 2",
+	"SELECT 1 UNION ALL SELECT 2",
+	"SELECT 1 UNION DISTINCT SELECT 2",
+	"SELECT 1 INTERSECT SELECT 2",
+	"SELECT 1 INTERSECT ALL SELECT 2",
+	"SELECT 1 INTERSECT DISTINCT SELECT 2",
+	"SELECT 1 EXCEPT SELECT 2",
+	"SELECT 1 EXCEPT ALL SELECT 2",
+	"SELECT 1 EXCEPT DISTINCT SELECT 2",
+	// chains & precedence
+	"SELECT 1 UNION SELECT 2 UNION SELECT 3",
+	"SELECT 1 UNION SELECT 2 UNION ALL SELECT 3",
+	"SELECT 1 INTERSECT SELECT 2 UNION SELECT 3",
+	"SELECT 1 UNION SELECT 2 INTERSECT SELECT 3",
+	"SELECT 1 EXCEPT SELECT 2 EXCEPT SELECT 3",
+	// legacy examples
+	"SELECT 123 UNION DISTINCT SELECT 123 UNION ALL SELECT 123",
+	"SELECT 123 INTERSECT DISTINCT SELECT 123 INTERSECT ALL SELECT 123",
+	// primaries as operands
+	"TABLE foo UNION TABLE bar",
+	"VALUES 1, 2 UNION VALUES 3",
+	"VALUES (1) UNION ALL SELECT 2",
+	// parenthesized operands & whole-query ORDER BY (S2)
+	"(SELECT 1) UNION (SELECT 2)",
+	"SELECT 1 UNION (SELECT 2 INTERSECT SELECT 3)",
+	"(SELECT 1 UNION SELECT 2) INTERSECT SELECT 3",
+	"SELECT 1 UNION SELECT 2 ORDER BY 1",
+	"SELECT 1 UNION SELECT 2 ORDER BY 1 LIMIT 5",
+	"(SELECT 1 ORDER BY 1) UNION (SELECT 2 LIMIT 3)",
+}
+
+// setopRejectCorpus is malformed set-operation input Trino 481 rejects.
+var setopRejectCorpus = []string{
+	"SELECT 1 UNION",                // no right operand
+	"SELECT 1 INTERSECT",            // no right operand
+	"SELECT 1 EXCEPT",               // no right operand
+	"UNION SELECT 1",                // no left operand
+	"SELECT 1 UNION ALL",            // quantifier but no operand
+	"SELECT 1 UNION UNION SELECT 2", // doubled operator
+	// a parenthesized query PRIMARY is `( queryNoWith )` — WITH is NOT allowed
+	// there (a WITH must be a relation subquery `( query )`). Oracle-confirmed.
+	"(WITH c AS (SELECT 1) SELECT * FROM c)",
+	"(WITH c AS (SELECT 1) SELECT * FROM c) UNION SELECT 2",
+}
+
+func TestSetop_AcceptCorpusParses(t *testing.T) {
+	for _, sql := range setopAcceptCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) != 0 {
+				t.Errorf("Parse(%q) should accept, got: %v", sql, errs)
+			}
+		})
+	}
+}
+
+func TestSetop_RejectCorpusRejected(t *testing.T) {
+	for _, sql := range setopRejectCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) == 0 {
+				t.Errorf("Parse(%q) should reject, but accepted", sql)
+			}
+		})
+	}
+}
+
+func TestSetop_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	check := func(t *testing.T, sql string) {
+		_, errs := Parse(sql)
+		omniAccepts := len(errs) == 0
+		trinoAccepts, ok := oracleAccepts(t, o, sql)
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH sql=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				sql, omniAccepts, errs, trinoAccepts)
+		}
+	}
+	for _, sql := range setopAcceptCorpus {
+		t.Run("accept/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+	for _, sql := range setopRejectCorpus {
+		t.Run("reject/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+}
+
+// ---------------------------------------------------------------------------
+// structural tests (precedence & associativity, S1)
+// ---------------------------------------------------------------------------
+
+func TestSetop_StructureUnionLeftAssoc(t *testing.T) {
+	// `a UNION b UNION c` groups left: top.Left is itself a SetOperation.
+	q := parseOneQuery(t, "SELECT 1 UNION SELECT 2 UNION SELECT 3")
+	top, ok := q.Body.(*SetOperation)
+	if !ok {
+		t.Fatalf("body is %T, want *SetOperation", q.Body)
+	}
+	if top.Op != "UNION" {
+		t.Errorf("top op=%q, want UNION", top.Op)
+	}
+	if _, ok := top.Left.(*SetOperation); !ok {
+		t.Errorf("UNION not left-associative: Left is %T, want *SetOperation", top.Left)
+	}
+	if _, ok := top.Right.(*QuerySpec); !ok {
+		t.Errorf("top.Right is %T, want *QuerySpec", top.Right)
+	}
+}
+
+func TestSetop_StructureIntersectBindsTighter(t *testing.T) {
+	// `a INTERSECT b UNION c` == `(a INTERSECT b) UNION c`: the top op is UNION,
+	// its Left is the INTERSECT.
+	q := parseOneQuery(t, "SELECT 1 INTERSECT SELECT 2 UNION SELECT 3")
+	top := q.Body.(*SetOperation)
+	if top.Op != "UNION" {
+		t.Fatalf("top op=%q, want UNION", top.Op)
+	}
+	left, ok := top.Left.(*SetOperation)
+	if !ok || left.Op != "INTERSECT" {
+		t.Errorf("top.Left = %T (op?), want INTERSECT SetOperation", top.Left)
+	}
+
+	// `a UNION b INTERSECT c` == `a UNION (b INTERSECT c)`: top is UNION, Right is
+	// the INTERSECT.
+	q = parseOneQuery(t, "SELECT 1 UNION SELECT 2 INTERSECT SELECT 3")
+	top = q.Body.(*SetOperation)
+	if top.Op != "UNION" {
+		t.Fatalf("top op=%q, want UNION", top.Op)
+	}
+	right, ok := top.Right.(*SetOperation)
+	if !ok || right.Op != "INTERSECT" {
+		t.Errorf("top.Right = %T, want INTERSECT SetOperation", top.Right)
+	}
+}
+
+func TestSetop_StructureQuantifier(t *testing.T) {
+	q := parseOneQuery(t, "SELECT 1 UNION ALL SELECT 2")
+	if op := q.Body.(*SetOperation); op.Quantifier != "ALL" {
+		t.Errorf("Quantifier=%q, want ALL", op.Quantifier)
+	}
+	q = parseOneQuery(t, "SELECT 1 INTERSECT DISTINCT SELECT 2")
+	if op := q.Body.(*SetOperation); op.Quantifier != "DISTINCT" {
+		t.Errorf("Quantifier=%q, want DISTINCT", op.Quantifier)
+	}
+	q = parseOneQuery(t, "SELECT 1 UNION SELECT 2")
+	if op := q.Body.(*SetOperation); op.Quantifier != "" {
+		t.Errorf("Quantifier=%q, want empty", op.Quantifier)
+	}
+}
+
+func TestSetop_StructureOrderByAttachesToWhole(t *testing.T) {
+	// S2: `SELECT 1 UNION SELECT 2 ORDER BY 1` — the ORDER BY is on the queryNoWith
+	// (the whole union), NOT on the right SELECT.
+	q := parseOneQuery(t, "SELECT 1 UNION SELECT 2 ORDER BY 1")
+	if _, ok := q.Body.(*SetOperation); !ok {
+		t.Fatalf("body is %T, want *SetOperation", q.Body)
+	}
+	if len(q.OrderBy) != 1 {
+		t.Errorf("query ORDER BY items=%d, want 1 (attached to the whole union)", len(q.OrderBy))
+	}
+}
+
+func TestSetop_StructurePrimaries(t *testing.T) {
+	q := parseOneQuery(t, "TABLE foo UNION TABLE bar")
+	top := q.Body.(*SetOperation)
+	if _, ok := top.Left.(*TableQuery); !ok {
+		t.Errorf("Left is %T, want *TableQuery", top.Left)
+	}
+	if _, ok := top.Right.(*TableQuery); !ok {
+		t.Errorf("Right is %T, want *TableQuery", top.Right)
+	}
+
+	q = parseOneQuery(t, "(SELECT 1) UNION (SELECT 2)")
+	top = q.Body.(*SetOperation)
+	if _, ok := top.Left.(*ParenQuery); !ok {
+		t.Errorf("Left is %T, want *ParenQuery", top.Left)
+	}
+}

--- a/trino/parser/window.go
+++ b/trino/parser/window.go
@@ -1,0 +1,79 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `parser-select` DAG node (with select.go, setops.go,
+// relation.go and ctes.go): it implements Trino's named-window grammar — the
+// `WINDOW` clause of a querySpecification and its `windowDefinition` rule.
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	querySpecification: SELECT … (WINDOW windowDefinition (, windowDefinition)*)? ;
+//	windowDefinition  : name=identifier AS ( windowSpecification ) ;
+//	windowSpecification: (existingWindowName)? (PARTITION BY …)?
+//	                       (ORDER BY sortItem (, …)*)? windowFrame? ;
+//
+// The windowSpecification itself — PARTITION BY / ORDER BY / the window frame
+// (ROWS|RANGE|GROUPS …) — was implemented by the expressions DAG node for the
+// inline OVER clause (function.go: WindowSpec / WindowFrame / WindowBound and
+// parseWindowSpecification). This file reuses that parser for the named-window
+// definitions, so a name defined in the WINDOW clause and a name referenced by
+// `OVER w` share one WindowSpec model. The pattern-recognition frame additions
+// remain deferred to parser-match-recognize (B2 in expr.go).
+
+// WindowDefinition is one `name AS ( windowSpecification )` of a querySpecification
+// WINDOW clause (the windowDefinition rule). Name is the window's name; Spec is
+// the (reused) inline-OVER window specification.
+type WindowDefinition struct {
+	Name *ast.Identifier
+	Spec *WindowSpec
+	Loc  ast.Loc
+}
+
+// parseWindowClause parses `WINDOW windowDefinition (, windowDefinition)*`
+// (WINDOW is current) and returns the non-empty list of named window definitions.
+func (p *Parser) parseWindowClause() ([]WindowDefinition, error) {
+	p.advance() // consume WINDOW
+	first, err := p.parseWindowDefinition()
+	if err != nil {
+		return nil, err
+	}
+	defs := []WindowDefinition{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseWindowDefinition()
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, next)
+	}
+	return defs, nil
+}
+
+// parseWindowDefinition parses one `name=identifier AS ( windowSpecification )`
+// (the windowDefinition rule). The window specification body is parsed by the
+// shared parseWindowSpecification (function.go), which consumes the opening '('
+// and the closing ')'.
+func (p *Parser) parseWindowDefinition() (WindowDefinition, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return WindowDefinition{}, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return WindowDefinition{}, err
+	}
+	if p.cur.Kind != int('(') {
+		return WindowDefinition{}, p.exprErrorAt("expected ( after AS in window definition")
+	}
+	// parseWindowSpecification consumes the '(' … ')'. Pass the name's start as
+	// the span origin so the definition's WindowSpec.Loc covers `name AS ( … )`.
+	spec, err := p.parseWindowSpecification(name.Loc.Start)
+	if err != nil {
+		return WindowDefinition{}, err
+	}
+	return WindowDefinition{
+		Name: name,
+		Spec: spec,
+		Loc:  ast.Loc{Start: name.Loc.Start, End: spec.Loc.End},
+	}, nil
+}

--- a/trino/parser/window_test.go
+++ b/trino/parser/window_test.go
@@ -1,0 +1,205 @@
+package parser
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// This file is the parser-select node's correctness slice for the named-WINDOW
+// clause (window.go) plus the node's divergence audit (the docs-ahead-of-legacy
+// P1 extensions D1–D3 that omni rejects and Trino 481 accepts, and the one
+// over-permissive table-function corner). The oracle differential is
+// authoritative; structural tests pin the windowDefinition shape. Helpers live
+// in oracle_foundation_test.go and select_test.go.
+
+// windowAcceptCorpus is the querySpecification WINDOW-clause surface Trino 481
+// accepts. (The inline OVER window specification is the expressions node's
+// concern; here the named WINDOW clause defines names an OVER may reference.)
+var windowAcceptCorpus = []string{
+	"SELECT count(*) OVER w FROM t WINDOW w AS (PARTITION BY a ORDER BY b)",
+	"SELECT 1 FROM t WINDOW w AS ()",
+	"SELECT 1 FROM t WINDOW w AS (PARTITION BY a)",
+	"SELECT 1 FROM t WINDOW w AS (ORDER BY a)",
+	"SELECT 1 FROM t WINDOW w AS (PARTITION BY a ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+	"SELECT 1 FROM t WINDOW w AS (RANGE UNBOUNDED PRECEDING)",
+	"SELECT 1 FROM t WINDOW w1 AS (PARTITION BY a), w2 AS (ORDER BY b)",
+	// the legacy window_clause example: a window that references a prior window name
+	"SELECT * FROM T WINDOW someWindow AS (PARTITION BY a), otherWindow AS (someWindow ORDER BY b)",
+	// a bare WINDOW (non-reserved) with nothing after is the table alias `t AS window`
+	"SELECT 1 FROM t WINDOW",
+}
+
+// windowRejectCorpus is malformed WINDOW-clause input Trino 481 rejects.
+// (Note `SELECT 1 FROM t WINDOW` — a bare WINDOW with nothing after — is NOT a
+// reject: WINDOW is non-reserved, so it reads as the table alias `t AS window`.
+// It is in windowAcceptCorpus.)
+var windowRejectCorpus = []string{
+	"SELECT 1 FROM t WINDOW w",                   // WINDOW clause name with no AS (…)
+	"SELECT 1 FROM t WINDOW w AS",                // AS with no (…)
+	"SELECT 1 FROM t WINDOW w AS PARTITION BY a", // window spec without parens
+	"SELECT 1 FROM t WINDOW w AS (PARTITION a)",  // PARTITION without BY
+}
+
+func TestWindow_AcceptCorpusParses(t *testing.T) {
+	for _, sql := range windowAcceptCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) != 0 {
+				t.Errorf("Parse(%q) should accept, got: %v", sql, errs)
+			}
+		})
+	}
+}
+
+func TestWindow_RejectCorpusRejected(t *testing.T) {
+	for _, sql := range windowRejectCorpus {
+		t.Run(truncateName(sql), func(t *testing.T) {
+			if _, errs := Parse(sql); len(errs) == 0 {
+				t.Errorf("Parse(%q) should reject, but accepted", sql)
+			}
+		})
+	}
+}
+
+func TestWindow_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	check := func(t *testing.T, sql string) {
+		_, errs := Parse(sql)
+		omniAccepts := len(errs) == 0
+		trinoAccepts, ok := oracleAccepts(t, o, sql)
+		if !ok {
+			t.Skip("oracle unreachable for this case")
+		}
+		if omniAccepts != trinoAccepts {
+			t.Errorf("MISMATCH sql=%q: omni accepts=%v (errs=%v), Trino accepts=%v",
+				sql, omniAccepts, errs, trinoAccepts)
+		}
+	}
+	for _, sql := range windowAcceptCorpus {
+		t.Run("accept/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+	for _, sql := range windowRejectCorpus {
+		t.Run("reject/"+truncateName(sql), func(t *testing.T) { check(t, sql) })
+	}
+}
+
+func TestWindow_StructureDefinitions(t *testing.T) {
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT 1 FROM t WINDOW w1 AS (PARTITION BY a), w2 AS (ORDER BY b ROWS UNBOUNDED PRECEDING)"))
+	if len(spec.Windows) != 2 {
+		t.Fatalf("window defs=%d, want 2", len(spec.Windows))
+	}
+	if spec.Windows[0].Name.Value != "w1" {
+		t.Errorf("window 0 name=%q, want w1", spec.Windows[0].Name.Value)
+	}
+	if spec.Windows[0].Spec == nil || len(spec.Windows[0].Spec.PartitionBy) != 1 {
+		t.Errorf("window 0 spec = %+v, want one PARTITION BY", spec.Windows[0].Spec)
+	}
+	if spec.Windows[1].Name.Value != "w2" {
+		t.Errorf("window 1 name=%q, want w2", spec.Windows[1].Name.Value)
+	}
+	if spec.Windows[1].Spec == nil || len(spec.Windows[1].Spec.OrderBy) != 1 || spec.Windows[1].Spec.Frame == nil {
+		t.Errorf("window 1 spec = %+v, want ORDER BY + frame", spec.Windows[1].Spec)
+	}
+}
+
+func TestWindow_StructureExistingNameReference(t *testing.T) {
+	// `otherWindow AS (someWindow ORDER BY b)` references the base window someWindow.
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT * FROM T WINDOW someWindow AS (PARTITION BY a), otherWindow AS (someWindow ORDER BY b)"))
+	if len(spec.Windows) != 2 {
+		t.Fatalf("window defs=%d, want 2", len(spec.Windows))
+	}
+	other := spec.Windows[1].Spec
+	if other == nil || other.ExistingName == nil || other.ExistingName.Value != "someWindow" {
+		t.Errorf("otherWindow ExistingName = %+v, want someWindow", other)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Divergence audit (review-gate.md concern 2): the node implements the LEGACY
+// grammar scope and FLAGS the docs-ahead-of-legacy P1 forms it deliberately does
+// not parse. These tests pin those decisions: omni REJECTS the form while the
+// Trino 481 oracle ACCEPTS it. If a future node implements the extension, the
+// corresponding subtest will start failing — a signal to move the form into the
+// accept corpus and clear the divergence.
+// ---------------------------------------------------------------------------
+
+// divergenceFlaggedForms are the oracle-accepted forms omni intentionally
+// rejects per the migration divergence ledger (analysis §5 target policy:
+// implement the legacy grammar; defer docs-ahead-of-legacy items as P1).
+var divergenceFlaggedForms = []struct {
+	name string
+	sql  string
+	note string
+}{
+	{
+		name: "JSON_TABLE_relation",
+		sql:  "SELECT * FROM JSON_TABLE('[1]', 'lax $' COLUMNS (a integer))",
+		note: "divergence #3 (D1): JSON_TABLE relationPrimary is 481 but absent from the legacy grammar; deferred P1",
+	},
+	{
+		name: "WITH_SESSION_prefix",
+		sql:  "WITH SESSION foo = 1 SELECT 1",
+		note: "divergence #4 (D2): WITH SESSION query prefix is 481 but absent from the legacy grammar; deferred P1",
+	},
+	{
+		name: "set_op_CORRESPONDING",
+		sql:  "SELECT 1 UNION CORRESPONDING SELECT 1",
+		note: "divergence #6 (D3): set-op CORRESPONDING is 481 but absent from the legacy grammar; deferred P1",
+	},
+}
+
+// TestSelect_DivergenceFlaggedRejected verifies omni rejects each flagged
+// docs-ahead-of-legacy form (the legacy-grammar-scope behavior). Oracle-free.
+func TestSelect_DivergenceFlaggedRejected(t *testing.T) {
+	for _, d := range divergenceFlaggedForms {
+		t.Run(d.name, func(t *testing.T) {
+			if _, errs := Parse(d.sql); len(errs) == 0 {
+				t.Errorf("Parse(%q) accepted, but this is a deferred P1 form omni should reject (%s)", d.sql, d.note)
+			}
+		})
+	}
+}
+
+// TestSelect_DivergenceFlaggedOracleAccepts documents that Trino 481 ACCEPTS each
+// flagged form — confirming the divergence is real (omni rejects, 481 accepts).
+// This is the evidence half of the divergence packet; skipped without an oracle.
+func TestSelect_DivergenceFlaggedOracleAccepts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, d := range divergenceFlaggedForms {
+		t.Run(d.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			res, err := o.CheckSyntax(ctx, d.sql)
+			if err != nil {
+				t.Skip("oracle unreachable for this case")
+			}
+			if !res.Accepted {
+				t.Errorf("Trino 481 REJECTED %q (errorName=%s); the divergence assumes 481 accepts it — re-check the ledger",
+					d.sql, res.ErrorName)
+			}
+		})
+	}
+}
+
+// TestSelect_CopartitionOverPermissive documents the one over-permissive corner
+// (a flagged divergence): omni ACCEPTS a table-function table argument that is
+// directly followed by COPARTITION with no intervening PARTITION BY, which Trino
+// 481 rejects with a SYNTAX_ERROR. The legacy ANTLR grammar
+// (tableFunctionCall: arg* (COPARTITION …)?) accepts it for any argument kind;
+// matching 481's narrow rejection would require tracking per-argument partition
+// state for a semantically-degenerate form, so the node follows the legacy
+// grammar and flags it. Oracle-free assertion of omni's (intentional) accept.
+func TestSelect_CopartitionOverPermissive(t *testing.T) {
+	const sql = "SELECT * FROM TABLE(f(TABLE(a), TABLE(b) COPARTITION (a, b)))"
+	if _, errs := Parse(sql); len(errs) != 0 {
+		t.Errorf("Parse(%q): expected the flagged over-permissive ACCEPT, got errors: %v", sql, errs)
+	}
+}


### PR DESCRIPTION
## v2 node `trino/parser-select` — SELECT core (relations, joins, group/window, set-ops, CTEs)

Implements Trino's query layer as a hand-written recursive-descent parser, adjudicated against the **live Trino 481 oracle** (`trino/internal/trinooracle`). Spec: [`docs/migration/trino/dag.md`](docs/migration/trino/dag.md) row `trino/parser-select` + [`analysis.md`](docs/migration/trino/analysis.md) §6 Tier 2. Depends on the merged `trino/expressions` node.

### What it adds (within the node's `writes` globs)

- **`select.go`** — `query` / `queryNoWith` / `querySpecification`: SELECT list (the three `selectItem` forms incl. `expr.*` with column aliases), FROM, WHERE, GROUP BY (single sets / `ROLLUP` / `CUBE` / `GROUPING SETS` / empty `()` / `setQuantifier`), HAVING, named `WINDOW`, `ORDER BY` / `OFFSET` / `LIMIT [ALL]` / `FETCH … ONLY|WITH TIES`; statement-dispatch entry.
- **`relation.go`** — `relation` / joins (`INNER`/`LEFT`/`RIGHT`/`FULL`/`CROSS`/`NATURAL`, `ON`/`USING`), `sampledRelation` (`TABLESAMPLE`), `aliasedRelation`, `relationPrimary` (table, subquery, `UNNEST [WITH ORDINALITY]`, `LATERAL`, `TABLE(tableFunctionCall)` with table/descriptor args + `PARTITION BY`/`ORDER BY`/`PRUNE`|`KEEP WHEN EMPTY`/`COPARTITION`, parenthesized relation, `queryPeriod` time travel).
- **`ctes.go`** — `WITH` / `WITH RECURSIVE` / `namedQuery`.
- **`setops.go`** — `UNION` / `INTERSECT` / `EXCEPT` (`INTERSECT` binds tighter; left-associative) + the four query primaries.
- **`window.go`** — the `querySpecification` `WINDOW` clause (reuses the OVER `WindowSpec` from the expressions node).

Query nodes are parser-package types (like `Expr` / `DataType`) because the `ast` tag set is closed to ast-core — matching the established types/expressions precedent.

### Correctness — oracle differential (the authoritative gate)

**254 oracle-differential subtests** (omni `Parse` accept/reject == Trino 481, error-classified: only `SYNTAX_ERROR` is a reject) + structural precedence/shape tests, **all green against live Trino 481**. Coverage = legacy ANTLR grammar (truth2) + documented 481 forms (truth1) + the 94 legacy example files + oracle-probed edge cases; negative corpus included.

Oracle-confirmed disambiguations baked in (each probed, not guessed):
- set-op precedence/associativity (S1); `ORDER BY`/`OFFSET`/`LIMIT`/`FETCH` attach to the whole `queryTerm` (S2);
- `GROUP BY ALL`/`DISTINCT` is the `setQuantifier` only when a grouping element follows (else a grouping expr) (S3); parenthesized grouping-set vs sub-expression (`(a+b)*2`, `(a) IS NULL`);
- the **non-reserved** clause keywords `WINDOW`/`LIMIT`/`OFFSET`/`FETCH`/`TABLESAMPLE` vs relation/select aliases; `LATERAL`/`COPARTITION`/`DESCRIPTOR` as ordinary names; nested `((join))` parenthesized relations resolved by speculation; the parenthesized-query-primary `( queryNoWith )` rejecting `WITH` while the relation subquery `( query )` allows it.

### Divergences (legacy-grammar scope per analysis §5; oracle-confirmed)

| # | Case | Disposition |
|---|---|---|
| 3 | `JSON_TABLE` relation | deferred P1 — omni rejects, 481 accepts (absent from legacy grammar) |
| 4 | `WITH SESSION` prefix | deferred P1 — omni rejects, 481 accepts |
| 6 | set-op `CORRESPONDING` | deferred P1 — omni rejects, 481 accepts |
| 7 | `GROUP BY ALL`/`AUTO` | implemented to the legacy grammar; accept/reject-matches 481 |
| — | `COPARTITION` after a bare table arg (no `PARTITION BY`) | **flagged** over-permissive corner — omni accepts, 481 rejects; legacy grammar accepts, matching 481 needs per-arg partition-state tracking for a degenerate form |

The deferred-P1 rejections are pinned by `TestSelect_DivergenceFlaggedRejected`/`…OracleAccepts`; the flagged corner by `TestSelect_CopartitionOverPermissive`.

### Review gate

Two-reviewer cross-family gate before opening:
- **Claude lens** — found and fixed the `t.*` qualifiedName greediness, the alias-vs-clause-keyword greediness, a missing trailing-token check, and the nested `((join))` case.
- **Codex lens** — found 3 more real table-function bugs (all oracle-confirmed, now fixed + regression-tested): `copartition =>` / `descriptor` as non-reserved arg names, and the `COPARTITION (single)` group that should require ≥2 tables.

All fixes are oracle-validated. No blockers remain.

### Out-of-scope edits (recorded, not silent)

- `parser.go` — wired the SELECT/WITH/TABLE/VALUES/`(` dispatch to the new query parser (the foundation stubbed these and documented "later nodes replace the bodies"); added a **trailing-token check** to `parseSingle` (statements that parse cleanly but leave leftover tokens — e.g. `SELECT a a a` — are now a syntax error, matching Trino).
- `parser_test.go` / `diagnose_test.go` — updated the now-stale "SELECT is stubbed" assertions to use a still-stubbed statement (INSERT, parser-dml's job).

Pre-existing `TestLexer_OracleDifferential` backtick failure is unrelated (lexer files untouched; confirmed failing on clean `main`; tracked as a separate task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
