### PR TITLE
feat(snowflake): T4.3 CREATE / ALTER PIPE / STREAM / TASK / ALERT

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -112,6 +112,16 @@ const (
 	// File-format DDL tags (T4.2)
 	T_CreateFileFormatStmt
 	T_AlterFileFormatStmt
+
+	// Data-pipeline DDL tags (T4.3)
+	T_CreatePipeStmt
+	T_AlterPipeStmt
+	T_CreateStreamStmt
+	T_AlterStreamStmt
+	T_CreateTaskStmt
+	T_AlterTaskStmt
+	T_CreateAlertStmt
+	T_AlterAlertStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -267,6 +277,22 @@ func (t NodeTag) String() string {
 		return "CreateFileFormatStmt"
 	case T_AlterFileFormatStmt:
 		return "AlterFileFormatStmt"
+	case T_CreatePipeStmt:
+		return "CreatePipeStmt"
+	case T_AlterPipeStmt:
+		return "AlterPipeStmt"
+	case T_CreateStreamStmt:
+		return "CreateStreamStmt"
+	case T_AlterStreamStmt:
+		return "AlterStreamStmt"
+	case T_CreateTaskStmt:
+		return "CreateTaskStmt"
+	case T_AlterTaskStmt:
+		return "AlterTaskStmt"
+	case T_CreateAlertStmt:
+		return "CreateAlertStmt"
+	case T_AlterAlertStmt:
+		return "AlterAlertStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -2719,3 +2719,359 @@ var (
 	_ Node = (*CreateFileFormatStmt)(nil)
 	_ Node = (*AlterFileFormatStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// Data-pipeline DDL — CREATE / ALTER PIPE / STREAM / TASK / ALERT (T4.3)
+// ---------------------------------------------------------------------------
+//
+// These four objects are Snowflake's data-pipeline primitives. Like STAGE /
+// FILE FORMAT / COPY before them, each carries a large, version-growing
+// configuration vocabulary (PIPE: AUTO_INGEST / INTEGRATION / ERROR_INTEGRATION
+// / AWS_SNS_TOPIC / ...; TASK: WAREHOUSE / SCHEDULE / CONFIG / OVERLAP_POLICY /
+// ERROR_INTEGRATION / SUCCESS_INTEGRATION / LOG_LEVEL / TARGET_COMPLETION_INTERVAL
+// / SERVERLESS_TASK_* / arbitrary session parameters / ...; ALERT: WAREHOUSE /
+// SCHEDULE / COMMENT / CONFIG / RUNBOOK / SUSPEND_ALERT_AFTER_NUM_FAILURES /
+// ...). The legacy ANTLR grammar enumerates a stale subset of each (its
+// create_task lists only task_overlap?/task_timeout?/task_suspend_after_failure;
+// its create_pipe lacks SUCCESS-side options; etc.), so — matching the merged
+// STAGE (T4.1) / FILE FORMAT (T4.2) / COPY (T5.2) approach — every such config
+// parameter is captured as an open-ended `KEY = <value>` pair (CopyOption). Only
+// the structural anchors are modeled as dedicated fields: the embedded statement
+// bodies (PIPE's AS COPY, TASK's AS <sql>, ALERT's IF(EXISTS(...)) THEN <action>),
+// STREAM's ON <source> + AT/BEFORE time-travel, TASK's AFTER predecessor list and
+// WHEN predicate, and the [WITH] TAG / COPY GRANTS clauses.
+//
+// Embedded bodies are handled by REUSING the existing statement parsers rather
+// than reinventing them: PIPE's body is parsed by parseCopyStmt, ALERT's
+// condition by parseQueryExpr, and TASK's body / ALERT's action by the top-level
+// parseStmt. Because a TASK body may be a Snowflake Scripting block
+// (BEGIN…END / DECLARE…BEGIN…END) or any statement parseStmt does not yet
+// support (e.g. CALL), those bodies additionally retain the verbatim source text
+// (BodyRaw / ActionRaw) and tolerate a nil parsed node — the statement is never
+// rejected on account of an unsupported body. (F3's Split already keeps a
+// `... AS BEGIN … END;` body as one segment, so the body text runs to the
+// segment end.)
+
+// PipeOption / StreamOption / TaskOption / AlertOption are all CopyOption — the
+// shared open-ended `KEY = <value>` option type. The aliases below exist only to
+// document intent at the field declarations; no separate type is introduced.
+
+// CreatePipeStmt represents
+//
+//	CREATE [ OR REPLACE ] PIPE [ IF NOT EXISTS ] <name>
+//	  [ AUTO_INGEST = { TRUE | FALSE } ]
+//	  [ ERROR_INTEGRATION = <integration_name> ]
+//	  [ AWS_SNS_TOPIC = '<string>' ]
+//	  [ INTEGRATION = '<string>' ]
+//	  [ COMMENT = '<string_literal>' ]
+//	  AS <copy_statement>
+//
+// Options holds every config parameter that precedes AS (AUTO_INGEST /
+// ERROR_INTEGRATION / AWS_SNS_TOPIC / INTEGRATION / COMMENT / ...), each a
+// CopyOption, preserving source order. Copy holds the parsed `AS COPY INTO`
+// body (a *CopyIntoTableStmt); the AS body is always a COPY INTO, which the
+// parser fully supports, so Copy is non-nil for a well-formed statement. The
+// body may be wrapped in parentheses in the source (`AS (COPY INTO …)`); the
+// parens are not retained.
+type CreatePipeStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Options     []*CopyOption // AUTO_INGEST / ERROR_INTEGRATION / AWS_SNS_TOPIC / INTEGRATION / COMMENT / ...
+	Copy        Node          // the AS <copy_into_table> body (parseCopyStmt result)
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreatePipeStmt) Tag() NodeTag { return T_CreatePipeStmt }
+
+// AlterPipeAction discriminates the action variants of ALTER PIPE.
+type AlterPipeAction int
+
+const (
+	AlterPipeSet      AlterPipeAction = iota // SET <options>
+	AlterPipeUnset                           // UNSET <property> [, ...]
+	AlterPipeSetTag                          // SET TAG <tag> = '<value>' [, ...]
+	AlterPipeUnsetTag                        // UNSET TAG <tag> [, ...]
+	AlterPipeRefresh                         // REFRESH [ PREFIX = '<p>' ] [ MODIFIED_AFTER = '<ts>' ]
+)
+
+// AlterPipeStmt represents ALTER PIPE [ IF EXISTS ] <name> <action>.
+//
+//	SET <options>                                        -- open-ended KEY = value
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]                            -- e.g. PIPE_EXECUTION_PAUSED, COMMENT
+//	REFRESH [ PREFIX = '<path>' ] [ MODIFIED_AFTER = '<timestamp>' ]
+type AlterPipeStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterPipeAction
+	Options    []*CopyOption    // SET <options> / REFRESH PREFIX|MODIFIED_AFTER params
+	Tags       []*TagAssignment // SET TAG assignments; for AlterPipeSetTag
+	UnsetTags  []*ObjectName    // UNSET TAG names; for AlterPipeUnsetTag
+	UnsetProps []string         // UNSET <property> names; for AlterPipeUnset
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterPipeStmt) Tag() NodeTag { return T_AlterPipeStmt }
+
+// StreamSourceKind classifies the object a stream is created ON.
+type StreamSourceKind int
+
+const (
+	StreamOnTable         StreamSourceKind = iota // ON TABLE <name>
+	StreamOnView                                  // ON VIEW <name>
+	StreamOnStage                                 // ON STAGE <name>
+	StreamOnExternalTable                         // ON EXTERNAL TABLE <name>
+)
+
+// StreamTimeTravel holds a stream's { AT | BEFORE } ( <key> => <value> ) clause.
+// Per the docs the key is one of TIMESTAMP / OFFSET / STATEMENT / STREAM and the
+// value is a general expression (the corpus shows function calls like
+// TO_TIMESTAMP(...), arithmetic like -60*5, and string literals). Both the AT/
+// BEFORE selector and the key are captured verbatim (uppercased); Value holds the
+// parsed value expression.
+type StreamTimeTravel struct {
+	AtBefore string // "AT" or "BEFORE"
+	Key      string // "TIMESTAMP" / "OFFSET" / "STATEMENT" / "STREAM" (uppercased)
+	Value    Node   // the => value expression
+	Loc      Loc
+}
+
+// CreateStreamStmt represents
+//
+//	CREATE [ OR REPLACE ] STREAM [ IF NOT EXISTS ] <name>
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//	  [ COPY GRANTS ]
+//	  ON { TABLE | VIEW | STAGE | EXTERNAL TABLE } <object_name>
+//	  [ { AT | BEFORE } ( { TIMESTAMP => … | OFFSET => … | STATEMENT => … | STREAM => … } ) ]
+//	  [ APPEND_ONLY = { TRUE | FALSE } ]      -- TABLE/VIEW
+//	  [ INSERT_ONLY = TRUE ]                  -- EXTERNAL TABLE
+//	  [ SHOW_INITIAL_ROWS = { TRUE | FALSE } ]
+//	  [ COMMENT = '<string_literal>' ]
+//
+// (plus a CLONE variant: CREATE [OR REPLACE] STREAM <name> CLONE <source> [COPY GRANTS].)
+//
+// SourceKind + Source model the mandatory ON clause. TimeTravel holds the
+// optional AT/BEFORE clause. Options holds every trailing config parameter
+// (APPEND_ONLY / INSERT_ONLY / SHOW_INITIAL_ROWS / COMMENT / ...) open-ended,
+// preserving source order — they are not type-validated against SourceKind here
+// (the catalog/semantic layer does that). Tags holds the [WITH] TAG assignments;
+// CopyGrants records the COPY GRANTS flag. For the CLONE form, Clone is set and
+// SourceKind/Source/Options are zero.
+type CreateStreamStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Tags        []*TagAssignment  // [WITH] TAG (...); nil if absent
+	CopyGrants  bool              // COPY GRANTS
+	SourceKind  StreamSourceKind  // ON { TABLE | VIEW | STAGE | EXTERNAL TABLE }
+	Source      *ObjectName       // the ON <object_name>
+	TimeTravel  *StreamTimeTravel // { AT | BEFORE } (...); nil if absent
+	Options     []*CopyOption     // APPEND_ONLY / INSERT_ONLY / SHOW_INITIAL_ROWS / COMMENT / ...
+	Clone       *ObjectName       // CLONE <source>; non-nil only for the CLONE form
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateStreamStmt) Tag() NodeTag { return T_CreateStreamStmt }
+
+// AlterStreamAction discriminates the action variants of ALTER STREAM.
+type AlterStreamAction int
+
+const (
+	AlterStreamSet      AlterStreamAction = iota // SET <options>
+	AlterStreamUnset                             // UNSET <property> [, ...] (e.g. COMMENT)
+	AlterStreamSetTag                            // SET TAG <tag> = '<value>' [, ...]
+	AlterStreamUnsetTag                          // UNSET TAG <tag> [, ...]
+)
+
+// AlterStreamStmt represents ALTER STREAM [ IF EXISTS ] <name> <action>.
+//
+//	SET <options>                              -- open-ended KEY = value (COMMENT = '…')
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]                  -- e.g. COMMENT
+type AlterStreamStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterStreamAction
+	Options    []*CopyOption    // SET <options>; for AlterStreamSet
+	Tags       []*TagAssignment // SET TAG assignments; for AlterStreamSetTag
+	UnsetTags  []*ObjectName    // UNSET TAG names; for AlterStreamUnsetTag
+	UnsetProps []string         // UNSET <property> names; for AlterStreamUnset
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterStreamStmt) Tag() NodeTag { return T_AlterStreamStmt }
+
+// CreateTaskStmt represents
+//
+//	CREATE [ OR REPLACE ] TASK [ IF NOT EXISTS ] <name>
+//	  [ [ WITH ] TAG ( … ) ]
+//	  [ config parameters: WAREHOUSE | USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE |
+//	    SCHEDULE | CONFIG | OVERLAP_POLICY | <session_parameter> | USER_TASK_TIMEOUT_MS |
+//	    SUSPEND_TASK_AFTER_NUM_FAILURES | ERROR_INTEGRATION | SUCCESS_INTEGRATION |
+//	    LOG_LEVEL | COMMENT | FINALIZE | TASK_AUTO_RETRY_ATTEMPTS | … ]
+//	  [ AFTER <predecessor> [ , <predecessor> , ... ] ]
+//	  [ WHEN <boolean_expr> ]
+//	  AS <sql>
+//
+// Options holds every config parameter that precedes AFTER/WHEN/AS, open-ended,
+// preserving source order. After holds the AFTER predecessor list (object names;
+// the corpus uses bare identifiers while the docs spell them as strings — object
+// names cover both). When holds the optional WHEN predicate expression. Body /
+// BodyRaw hold the AS body: Body is the parsed statement (a SELECT / INSERT /
+// etc.) when parseStmt supports it, and nil for a Snowflake Scripting block
+// (BEGIN…END / DECLARE…BEGIN…END) or any other unsupported body; BodyRaw always
+// holds the verbatim body source text so consumers retain it regardless. Tags
+// holds the [WITH] TAG assignments.
+//
+// CREATE TASK also has a CLONE form (CREATE [OR REPLACE] TASK <name> CLONE
+// <source_task>), recorded via Clone with Options/After/When/Body all zero.
+type CreateTaskStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Tags        []*TagAssignment // [WITH] TAG (...); nil if absent
+	Options     []*CopyOption    // WAREHOUSE / SCHEDULE / CONFIG / session params / ...
+	After       []*ObjectName    // AFTER <predecessor> [, ...]; nil if absent
+	When        Node             // WHEN <boolean_expr>; nil if absent
+	Body        Node             // AS <sql> parsed statement; nil for an unsupported/scripting body
+	BodyRaw     string           // verbatim AS body source text (always set)
+	Clone       *ObjectName      // CLONE <source_task>; non-nil only for the CLONE form
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateTaskStmt) Tag() NodeTag { return T_CreateTaskStmt }
+
+// AlterTaskAction discriminates the action variants of ALTER TASK.
+type AlterTaskAction int
+
+const (
+	AlterTaskResume      AlterTaskAction = iota // RESUME
+	AlterTaskSuspend                            // SUSPEND
+	AlterTaskAddAfter                           // ADD AFTER <task> [, ...]
+	AlterTaskRemoveAfter                        // REMOVE AFTER <task> [, ...]
+	AlterTaskSet                                // SET <options>
+	AlterTaskUnset                              // UNSET <property> [, ...]
+	AlterTaskSetTag                             // SET TAG <tag> = '<value>' [, ...]
+	AlterTaskUnsetTag                           // UNSET TAG <tag> [, ...]
+	AlterTaskModifyAs                           // MODIFY AS <sql>
+	AlterTaskModifyWhen                         // MODIFY WHEN <boolean_expr>
+)
+
+// AlterTaskStmt represents ALTER TASK [ IF EXISTS ] <name> <action>.
+//
+//	RESUME | SUSPEND
+//	{ ADD | REMOVE } AFTER <task> [ , ... ]
+//	SET <options>                              -- open-ended KEY = value
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]
+//	MODIFY AS <sql>
+//	MODIFY WHEN <boolean_expr>
+type AlterTaskStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterTaskAction
+	After      []*ObjectName    // {ADD|REMOVE} AFTER list; for AlterTaskAddAfter/RemoveAfter
+	Options    []*CopyOption    // SET <options>; for AlterTaskSet
+	Tags       []*TagAssignment // SET TAG assignments; for AlterTaskSetTag
+	UnsetTags  []*ObjectName    // UNSET TAG names; for AlterTaskUnsetTag
+	UnsetProps []string         // UNSET <property> names; for AlterTaskUnset
+	When       Node             // MODIFY WHEN <expr>; for AlterTaskModifyWhen
+	Body       Node             // MODIFY AS <sql> parsed statement; nil for an unsupported/scripting body
+	BodyRaw    string           // verbatim MODIFY AS body source text; set for AlterTaskModifyAs
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterTaskStmt) Tag() NodeTag { return T_AlterTaskStmt }
+
+// CreateAlertStmt represents
+//
+//	CREATE [ OR REPLACE ] ALERT [ IF NOT EXISTS ] <name>
+//	  [ [ WITH ] TAG ( … ) ]
+//	  [ WAREHOUSE = <warehouse_name> ]        -- optional for serverless alerts
+//	  SCHEDULE = '<schedule>'
+//	  [ COMMENT = '…' ] [ CONFIG = '…' ] [ RUNBOOK = '…' ]
+//	  [ SUSPEND_ALERT_AFTER_NUM_FAILURES = <n> ]
+//	  IF ( EXISTS ( <condition> ) )
+//	  THEN <action>
+//
+// Options holds every config parameter that precedes IF (WAREHOUSE / SCHEDULE /
+// COMMENT / CONFIG / RUNBOOK / SUSPEND_ALERT_AFTER_NUM_FAILURES / ...),
+// open-ended, preserving source order — WAREHOUSE and SCHEDULE are NOT lifted out
+// (WAREHOUSE is optional for serverless alerts and SCHEDULE's value vocabulary
+// grows), matching the open-ended philosophy. Condition holds the query inside
+// IF(EXISTS(<condition>)) (a SELECT / SHOW / CALL; parsed via parseQueryExpr for
+// the SELECT case). Action / ActionRaw hold the THEN body: Action is the parsed
+// statement when parseStmt supports it, nil otherwise; ActionRaw always holds the
+// verbatim action source text.
+type CreateAlertStmt struct {
+	OrReplace    bool
+	IfNotExists  bool
+	Name         *ObjectName
+	Tags         []*TagAssignment // [WITH] TAG (...); nil if absent
+	Options      []*CopyOption    // WAREHOUSE / SCHEDULE / COMMENT / CONFIG / RUNBOOK / ...
+	Condition    Node             // IF(EXISTS(<condition>)) query; nil only if unparsed
+	ConditionRaw string           // verbatim condition source text (always set)
+	Action       Node             // THEN <action> parsed statement; nil for an unsupported body
+	ActionRaw    string           // verbatim THEN action source text (always set)
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *CreateAlertStmt) Tag() NodeTag { return T_CreateAlertStmt }
+
+// AlterAlertAction discriminates the action variants of ALTER ALERT.
+type AlterAlertAction int
+
+const (
+	AlterAlertResume          AlterAlertAction = iota // RESUME
+	AlterAlertSuspend                                 // SUSPEND
+	AlterAlertSet                                     // SET <options>
+	AlterAlertUnset                                   // UNSET <property> [, ...]
+	AlterAlertModifyCondition                         // MODIFY CONDITION EXISTS (<query>)
+	AlterAlertModifyAction                            // MODIFY ACTION <action>
+)
+
+// AlterAlertStmt represents ALTER ALERT [ IF EXISTS ] <name> <action>.
+//
+//	RESUME | SUSPEND
+//	SET <options>                              -- WAREHOUSE = … | SCHEDULE = … | COMMENT = …
+//	UNSET <property> [ , ... ]                  -- WAREHOUSE | SCHEDULE | COMMENT
+//	MODIFY CONDITION EXISTS ( <query> )
+//	MODIFY ACTION <action>
+type AlterAlertStmt struct {
+	IfExists     bool
+	Name         *ObjectName
+	Action       AlterAlertAction
+	Options      []*CopyOption // SET <options>; for AlterAlertSet
+	UnsetProps   []string      // UNSET <property> names; for AlterAlertUnset
+	Condition    Node          // MODIFY CONDITION EXISTS (<query>); for AlterAlertModifyCondition
+	ConditionRaw string        // verbatim condition source text; set for AlterAlertModifyCondition
+	ActionBody   Node          // MODIFY ACTION <action> parsed statement; nil for an unsupported body
+	ActionRaw    string        // verbatim MODIFY ACTION source text; set for AlterAlertModifyAction
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *AlterAlertStmt) Tag() NodeTag { return T_AlterAlertStmt }
+
+// Compile-time assertions for data-pipeline DDL nodes.
+var (
+	_ Node = (*CreatePipeStmt)(nil)
+	_ Node = (*AlterPipeStmt)(nil)
+	_ Node = (*CreateStreamStmt)(nil)
+	_ Node = (*AlterStreamStmt)(nil)
+	_ Node = (*CreateTaskStmt)(nil)
+	_ Node = (*AlterTaskStmt)(nil)
+	_ Node = (*CreateAlertStmt)(nil)
+	_ Node = (*AlterAlertStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -9,6 +9,12 @@ func walkChildren(v Visitor, node Node) {
 	case *AccessExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.Index)
+	case *AlterAlertStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.Condition)
+		Walk(v, n.ActionBody)
 	case *AlterDatabaseStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -31,6 +37,10 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.NewName)
 		}
 		walkNodes(v, n.ClusterBy)
+	case *AlterPipeStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *AlterSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -45,10 +55,20 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterStreamStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *AlterTableStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *AlterTaskStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.When)
+		Walk(v, n.Body)
 	case *AlterViewStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -120,6 +140,12 @@ func walkChildren(v Visitor, node Node) {
 		if n.Lit != nil {
 			Walk(v, n.Lit)
 		}
+	case *CreateAlertStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.Condition)
+		Walk(v, n.Action)
 	case *CreateDatabaseStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -134,6 +160,11 @@ func walkChildren(v Visitor, node Node) {
 		}
 		walkNodes(v, n.ClusterBy)
 		Walk(v, n.Query)
+	case *CreatePipeStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.Copy)
 	case *CreateSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -141,6 +172,16 @@ func walkChildren(v Visitor, node Node) {
 	case *CreateStageStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+	case *CreateStreamStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.Source != nil {
+			Walk(v, n.Source)
+		}
+		if n.Clone != nil {
+			Walk(v, n.Clone)
 		}
 	case *CreateTableStmt:
 		if n.Name != nil {
@@ -150,6 +191,15 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.AsSelect)
 		if n.Like != nil {
 			Walk(v, n.Like)
+		}
+	case *CreateTaskStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		Walk(v, n.When)
+		Walk(v, n.Body)
+		if n.Clone != nil {
+			Walk(v, n.Clone)
 		}
 	case *CreateViewStmt:
 		if n.Name != nil {

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -95,6 +95,18 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// both dispatch here. Per the docs VOLATILE is a synonym of TEMPORARY for
 		// a file format, so either modifier sets the statement's Temporary flag.
 		return p.parseCreateFileFormatStmt(start, orReplace, temporary || volatile)
+	case kwPIPE:
+		// CREATE [OR REPLACE] PIPE ... (T4.3).
+		return p.parseCreatePipeStmt(start, orReplace)
+	case kwSTREAM:
+		// CREATE [OR REPLACE] STREAM ... (T4.3).
+		return p.parseCreateStreamStmt(start, orReplace)
+	case kwTASK:
+		// CREATE [OR REPLACE] TASK ... (T4.3).
+		return p.parseCreateTaskStmt(start, orReplace)
+	case kwALERT:
+		// CREATE [OR REPLACE] ALERT ... (T4.3).
+		return p.parseCreateAlertStmt(start, orReplace)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -179,6 +179,18 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// ALTER FILE FORMAT ... (T4.2). FILE FORMAT lexes as one FILE_FORMAT token
 		// or two FILE+FORMAT tokens; both dispatch here.
 		return p.parseAlterFileFormatStmt()
+	case kwPIPE:
+		// ALTER PIPE ... (T4.3).
+		return p.parseAlterPipeStmt()
+	case kwSTREAM:
+		// ALTER STREAM ... (T4.3).
+		return p.parseAlterStreamStmt()
+	case kwTASK:
+		// ALTER TASK ... (T4.3).
+		return p.parseAlterTaskStmt()
+	case kwALERT:
+		// ALTER ALERT ... (T4.3).
+		return p.parseAlterAlertStmt()
 	default:
 		return p.unsupported("ALTER")
 	}

--- a/snowflake/parser/pipe_stream_task.go
+++ b/snowflake/parser/pipe_stream_task.go
@@ -1,0 +1,1112 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Data-pipeline DDL — CREATE / ALTER PIPE / STREAM / TASK / ALERT (T4.3)
+// ---------------------------------------------------------------------------
+//
+// PIPE / STREAM / TASK / ALERT are Snowflake's data-pipeline objects. Several
+// embed other statements:
+//
+//   - PIPE   AS <copy_into_table>          — reuses parseCopyStmt (T5.2).
+//   - TASK   AS <sql>                       — reuses parseStmt (any statement);
+//                                             falls back to verbatim capture for a
+//                                             Snowflake Scripting BEGIN…END /
+//                                             DECLARE…BEGIN…END body or any
+//                                             statement parseStmt cannot yet parse.
+//   - ALERT  IF(EXISTS(<query>)) THEN <act> — condition reuses parseQueryExpr; the
+//                                             THEN action reuses parseStmt with the
+//                                             same verbatim fallback.
+//
+// Each object's growable config vocabulary (PIPE's AUTO_INGEST / INTEGRATION /
+// AWS_SNS_TOPIC / ERROR_INTEGRATION; TASK's WAREHOUSE / SCHEDULE / CONFIG /
+// OVERLAP_POLICY / SUCCESS_INTEGRATION / LOG_LEVEL / session params / …; ALERT's
+// WAREHOUSE / SCHEDULE / CONFIG / RUNBOOK / …) is parsed as open-ended
+// `KEY = <value>` pairs (ast.CopyOption), reusing the merged STAGE (T4.1) /
+// FILE FORMAT (T4.2) / COPY (T5.2) machinery rather than mirroring the legacy
+// ANTLR grammar's stale enumerations. Only the structural anchors are modeled
+// explicitly: the embedded bodies, STREAM's ON <source> + AT/BEFORE clause,
+// TASK's AFTER list and WHEN predicate, and the [WITH] TAG / COPY GRANTS clauses.
+
+// ---------------------------------------------------------------------------
+// CREATE PIPE
+// ---------------------------------------------------------------------------
+
+// parseCreatePipeStmt parses
+//
+//	CREATE [ OR REPLACE ] PIPE [ IF NOT EXISTS ] <name>
+//	  [ <config options> ] AS <copy_into_table>
+//
+// The CREATE keyword and the optional OR REPLACE modifier have already been
+// consumed by parseCreateStmt; start is the Loc of the CREATE token and cur is
+// the PIPE keyword. Every option before AS (AUTO_INGEST / ERROR_INTEGRATION /
+// AWS_SNS_TOPIC / INTEGRATION / COMMENT / …) is captured open-ended. AS is the
+// structural anchor; its body is a COPY INTO, optionally wrapped in parens.
+func (p *Parser) parseCreatePipeStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume PIPE
+
+	stmt := &ast.CreatePipeStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExistsInto(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Config options precede AS. AS is a keyword that startsCopyOption would
+	// otherwise treat as an option name, so the loop stops explicitly at AS.
+	for p.cur.Type != kwAS && p.startsCopyOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = append(stmt.Options, opt)
+	}
+
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+
+	// AS <copy_into_table>, optionally parenthesized: AS (COPY INTO …). The
+	// parens are consumed and not retained. parseCopyStmt expects cur at COPY.
+	copyNode, err := p.parseParenthesizedCopy()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Copy = copyNode
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseParenthesizedCopy parses a COPY statement that may be wrapped in a single
+// layer of parentheses (the pipe `AS (COPY INTO …)` form seen in the docs
+// corpus). A leading '(' is consumed and its matching ')' is required after the
+// COPY body; otherwise the COPY is parsed bare. cur must be '(' or COPY.
+func (p *Parser) parseParenthesizedCopy() (ast.Node, error) {
+	if p.cur.Type == '(' {
+		p.advance() // consume '('
+		copyNode, err := p.parseCopyStmt()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		return copyNode, nil
+	}
+	return p.parseCopyStmt()
+}
+
+// ---------------------------------------------------------------------------
+// ALTER PIPE
+// ---------------------------------------------------------------------------
+
+// parseAlterPipeStmt parses ALTER PIPE [ IF EXISTS ] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the PIPE keyword.
+//
+//	SET <options>
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]                 (e.g. PIPE_EXECUTION_PAUSED, COMMENT)
+//	REFRESH [ PREFIX = '<path>' ] [ MODIFIED_AFTER = '<timestamp>' ]
+func (p *Parser) parseAlterPipeStmt() (ast.Node, error) {
+	altTok := p.advance() // consume PIPE
+	stmt := &ast.AlterPipeStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	if err := p.parseIfExistsInto(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPipeSetTag
+			stmt.Tags = tags
+		} else {
+			opts, err := p.parseRequiredOptions()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPipeSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPipeUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			props, err := p.parseUnsetPropertyList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPipeUnset
+			stmt.UnsetProps = props
+		}
+
+	case kwREFRESH:
+		// REFRESH [ PREFIX = '<path>' ] [ MODIFIED_AFTER = '<timestamp>' ] — both
+		// optional, captured open-ended.
+		p.advance() // consume REFRESH
+		stmt.Action = ast.AlterPipeRefresh
+		for p.startsCopyOption() {
+			opt, err := p.parseCopyOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE STREAM
+// ---------------------------------------------------------------------------
+
+// parseCreateStreamStmt parses
+//
+//	CREATE [ OR REPLACE ] STREAM [ IF NOT EXISTS ] <name>
+//	  [ [ WITH ] TAG ( … ) ] [ COPY GRANTS ]
+//	  ON { TABLE | VIEW | STAGE | EXTERNAL TABLE } <object_name>
+//	  [ { AT | BEFORE } ( <key> => <value> ) ]
+//	  [ <config options> ]
+//
+//	CREATE [ OR REPLACE ] STREAM <name> CLONE <source> [ COPY GRANTS ]
+//
+// The CREATE keyword and OR REPLACE have been consumed; cur is the STREAM
+// keyword. Per the docs the [WITH] TAG clause precedes COPY GRANTS, which
+// precedes ON. The trailing config options (APPEND_ONLY / INSERT_ONLY /
+// SHOW_INITIAL_ROWS / COMMENT / …) are captured open-ended.
+func (p *Parser) parseCreateStreamStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume STREAM
+
+	stmt := &ast.CreateStreamStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExistsInto(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// CLONE form: CREATE STREAM <name> CLONE <source> [COPY GRANTS].
+	if p.cur.Type == kwCLONE {
+		p.advance() // consume CLONE
+		src, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Clone = src
+		if p.startsCopyGrants() {
+			p.advance() // consume COPY
+			p.advance() // consume GRANTS
+			stmt.CopyGrants = true
+		}
+		stmt.Loc.End = p.prev.Loc.End
+		return stmt, nil
+	}
+
+	// [WITH] TAG (...) and COPY GRANTS both precede ON, in either order
+	// defensively (docs list TAG then COPY GRANTS; the legacy grammar agrees).
+	for {
+		if p.startsStreamWithTags() {
+			tags, err := p.parseStreamWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+			continue
+		}
+		if p.startsCopyGrants() {
+			p.advance() // consume COPY
+			p.advance() // consume GRANTS
+			stmt.CopyGrants = true
+			continue
+		}
+		break
+	}
+
+	// ON { TABLE | VIEW | STAGE | EXTERNAL TABLE } <object_name> — mandatory.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	switch p.cur.Type {
+	case kwTABLE:
+		p.advance() // consume TABLE
+		stmt.SourceKind = ast.StreamOnTable
+	case kwVIEW:
+		p.advance() // consume VIEW
+		stmt.SourceKind = ast.StreamOnView
+	case kwSTAGE:
+		p.advance() // consume STAGE
+		stmt.SourceKind = ast.StreamOnStage
+	case kwEXTERNAL:
+		p.advance() // consume EXTERNAL
+		if _, err := p.expect(kwTABLE); err != nil {
+			return nil, err
+		}
+		stmt.SourceKind = ast.StreamOnExternalTable
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	src, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Source = src
+
+	// Optional { AT | BEFORE } ( <key> => <value> ) time-travel clause. Parsed
+	// inline/open-ended (not via the T5.3 query-clauses node).
+	if p.cur.Type == kwAT || p.cur.Type == kwBEFORE {
+		tt, err := p.parseStreamTimeTravel()
+		if err != nil {
+			return nil, err
+		}
+		stmt.TimeTravel = tt
+	}
+
+	// Trailing config options: APPEND_ONLY / INSERT_ONLY / SHOW_INITIAL_ROWS /
+	// COMMENT / … — open-ended KEY = value pairs.
+	for p.startsCopyOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = append(stmt.Options, opt)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseStreamTimeTravel parses a stream's { AT | BEFORE } ( <key> => <value> )
+// clause. cur is AT or BEFORE. key ∈ { TIMESTAMP | OFFSET | STATEMENT | STREAM }
+// (captured verbatim/uppercased, not enumerated, to tolerate doc growth); the
+// value after => is a general expression (the corpus shows TO_TIMESTAMP(...),
+// arithmetic like -60*5, and string literals), parsed by the shared expression
+// parser.
+func (p *Parser) parseStreamTimeTravel() (*ast.StreamTimeTravel, error) {
+	atTok := p.advance() // consume AT or BEFORE
+	tt := &ast.StreamTimeTravel{
+		AtBefore: strings.ToUpper(atTok.Str),
+		Loc:      ast.Loc{Start: atTok.Loc.Start},
+	}
+
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	if !p.isOptionWord(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	tt.Key = strings.ToUpper(p.advance().Str)
+
+	if _, err := p.expect(tokAssoc); err != nil {
+		return nil, err
+	}
+
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	tt.Value = val
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	tt.Loc.End = p.prev.Loc.End
+	return tt, nil
+}
+
+// startsStreamWithTags reports whether cur begins a [WITH] TAG clause: the TAG
+// keyword directly, or WITH immediately followed by TAG.
+func (p *Parser) startsStreamWithTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// parseStreamWithTags parses a [WITH] TAG (...) clause, accepting both the WITH
+// TAG and bare TAG spellings. The caller must have confirmed startsStreamWithTags.
+func (p *Parser) parseStreamWithTags() ([]*ast.TagAssignment, error) {
+	if p.cur.Type == kwWITH {
+		p.advance() // consume WITH (peekNext == TAG guaranteed by caller)
+	}
+	return p.parseTagAssignments()
+}
+
+// startsCopyGrants reports whether cur begins a COPY GRANTS clause (COPY
+// immediately followed by GRANTS).
+func (p *Parser) startsCopyGrants() bool {
+	return p.cur.Type == kwCOPY && p.peekNext().Type == kwGRANTS
+}
+
+// ---------------------------------------------------------------------------
+// ALTER STREAM
+// ---------------------------------------------------------------------------
+
+// parseAlterStreamStmt parses ALTER STREAM [ IF EXISTS ] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the STREAM keyword.
+//
+//	SET <options>                              (COMMENT = '…', …)
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]                  (e.g. COMMENT)
+func (p *Parser) parseAlterStreamStmt() (ast.Node, error) {
+	altTok := p.advance() // consume STREAM
+	stmt := &ast.AlterStreamStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	if err := p.parseIfExistsInto(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStreamSetTag
+			stmt.Tags = tags
+		} else {
+			opts, err := p.parseRequiredOptions()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStreamSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStreamUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			props, err := p.parseUnsetPropertyList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterStreamUnset
+			stmt.UnsetProps = props
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TASK
+// ---------------------------------------------------------------------------
+
+// parseCreateTaskStmt parses
+//
+//	CREATE [ OR REPLACE ] TASK [ IF NOT EXISTS ] <name>
+//	  [ [ WITH ] TAG ( … ) ]
+//	  [ <config options> ]
+//	  [ AFTER <predecessor> [ , ... ] ]
+//	  [ WHEN <boolean_expr> ]
+//	  AS <sql>
+//
+// The CREATE keyword and OR REPLACE have been consumed; cur is the TASK keyword.
+// The config options (WAREHOUSE / SCHEDULE / CONFIG / OVERLAP_POLICY /
+// session params / …) are captured open-ended, with AFTER / WHEN / AS as the
+// structural anchors. AS's body is captured by parseEmbeddedBody (reuses
+// parseStmt, with verbatim fallback for scripting / unsupported bodies).
+func (p *Parser) parseCreateTaskStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume TASK
+
+	stmt := &ast.CreateTaskStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExistsInto(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// CLONE form: CREATE [OR REPLACE] TASK <name> CLONE <source_task>.
+	if p.cur.Type == kwCLONE {
+		p.advance() // consume CLONE
+		src, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Clone = src
+		stmt.Loc.End = p.prev.Loc.End
+		return stmt, nil
+	}
+
+	// [WITH] TAG (...) precedes the config options.
+	for p.startsStreamWithTags() {
+		tags, err := p.parseStreamWithTags()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Tags = append(stmt.Tags, tags...)
+	}
+
+	// Config options, AFTER, and WHEN may appear before AS. WHEN and AFTER are
+	// the structural anchors; AS terminates the option run. AFTER and WHEN are
+	// keywords startsCopyOption would treat as option names, so they are matched
+	// before the option branch.
+	for {
+		switch p.cur.Type {
+		case kwAFTER:
+			after, err := p.parseTaskAfterList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.After = after
+			continue
+		case kwWHEN:
+			p.advance() // consume WHEN
+			when, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			stmt.When = when
+			continue
+		case kwAS:
+			// fallthrough out of the loop below
+		default:
+			if p.startsCopyOption() {
+				opt, err := p.parseCopyOption()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Options = append(stmt.Options, opt)
+				continue
+			}
+		}
+		break
+	}
+
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+
+	body, raw, err := p.parseEmbeddedBody()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+	stmt.BodyRaw = raw
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseTaskAfterList parses AFTER <predecessor> [ , <predecessor> , ... ]. The
+// docs spell predecessors as strings while the corpus uses bare identifiers;
+// parseObjectName covers both (a bare/quoted name). The AFTER keyword is
+// consumed here.
+func (p *Parser) parseTaskAfterList() ([]*ast.ObjectName, error) {
+	if _, err := p.expect(kwAFTER); err != nil {
+		return nil, err
+	}
+	var names []*ast.ObjectName
+	for {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return names, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TASK
+// ---------------------------------------------------------------------------
+
+// parseAlterTaskStmt parses ALTER TASK [ IF EXISTS ] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the TASK keyword.
+//
+//	RESUME | SUSPEND
+//	{ ADD | REMOVE } AFTER <task> [ , ... ]
+//	SET <options>
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	UNSET <property> [ , ... ]
+//	MODIFY AS <sql>
+//	MODIFY WHEN <boolean_expr>
+func (p *Parser) parseAlterTaskStmt() (ast.Node, error) {
+	altTok := p.advance() // consume TASK
+	stmt := &ast.AlterTaskStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	if err := p.parseIfExistsInto(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRESUME:
+		p.advance()
+		stmt.Action = ast.AlterTaskResume
+
+	case kwSUSPEND:
+		p.advance()
+		stmt.Action = ast.AlterTaskSuspend
+
+	case kwADD:
+		p.advance() // consume ADD
+		after, err := p.parseTaskAfterList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterTaskAddAfter
+		stmt.After = after
+
+	case kwREMOVE:
+		p.advance() // consume REMOVE
+		after, err := p.parseTaskAfterList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterTaskRemoveAfter
+		stmt.After = after
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTaskSetTag
+			stmt.Tags = tags
+		} else {
+			opts, err := p.parseRequiredOptions()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTaskSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTaskUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			props, err := p.parseUnsetPropertyList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTaskUnset
+			stmt.UnsetProps = props
+		}
+
+	case kwMODIFY:
+		p.advance() // consume MODIFY
+		switch p.cur.Type {
+		case kwAS:
+			p.advance() // consume AS
+			body, raw, err := p.parseEmbeddedBody()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTaskModifyAs
+			stmt.Body = body
+			stmt.BodyRaw = raw
+		case kwWHEN:
+			p.advance() // consume WHEN
+			when, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTaskModifyWhen
+			stmt.When = when
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE ALERT
+// ---------------------------------------------------------------------------
+
+// parseCreateAlertStmt parses
+//
+//	CREATE [ OR REPLACE ] ALERT [ IF NOT EXISTS ] <name>
+//	  [ [ WITH ] TAG ( … ) ]
+//	  [ <config options> ]                     (WAREHOUSE / SCHEDULE / COMMENT / …)
+//	  IF ( EXISTS ( <condition> ) )
+//	  THEN <action>
+//
+// The CREATE keyword and OR REPLACE have been consumed; cur is the ALERT
+// keyword. WAREHOUSE and SCHEDULE are NOT lifted out — WAREHOUSE is optional for
+// serverless alerts and SCHEDULE's value grows — so all config is open-ended.
+// IF / THEN are the structural anchors. The condition reuses parseQueryExpr; the
+// action reuses parseEmbeddedBody (parseStmt + verbatim fallback).
+func (p *Parser) parseCreateAlertStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume ALERT
+
+	stmt := &ast.CreateAlertStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExistsInto(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// [WITH] TAG (...) precedes the config options.
+	for p.startsStreamWithTags() {
+		tags, err := p.parseStreamWithTags()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Tags = append(stmt.Tags, tags...)
+	}
+
+	// Config options precede IF. IF is a keyword startsCopyOption would treat as
+	// an option name, so the loop stops explicitly at IF.
+	for p.cur.Type != kwIF && p.startsCopyOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = append(stmt.Options, opt)
+	}
+
+	// IF ( EXISTS ( <condition> ) ) THEN <action>.
+	if _, err := p.expect(kwIF); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwEXISTS); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	cond, condRaw, err := p.parseAlertCondition()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Condition = cond
+	stmt.ConditionRaw = condRaw
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwTHEN); err != nil {
+		return nil, err
+	}
+
+	action, actionRaw, err := p.parseEmbeddedBody()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Action = action
+	stmt.ActionRaw = actionRaw
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlertCondition parses the query inside IF(EXISTS(<condition>)). Per the
+// docs the condition is a SELECT, SHOW, or CALL. SELECT/WITH reuse the shared
+// query-expression parser; SHOW reuses parseShowStmt; any other condition
+// (e.g. CALL, unsupported by parseStmt) is captured verbatim by consuming
+// balanced tokens up to the closing ')' so the alert still parses. Returns the
+// parsed node (nil for the verbatim case) and the verbatim condition text.
+func (p *Parser) parseAlertCondition() (ast.Node, string, error) {
+	condStartAbs := p.cur.Loc.Start
+
+	switch p.cur.Type {
+	case kwSELECT, '(':
+		node, err := p.parseQueryExpr()
+		if err != nil {
+			return nil, "", err
+		}
+		return node, p.srcSlice(condStartAbs, p.prev.Loc.End), nil
+	case kwWITH:
+		node, err := p.parseWithQueryExpr()
+		if err != nil {
+			return nil, "", err
+		}
+		return node, p.srcSlice(condStartAbs, p.prev.Loc.End), nil
+	case kwSHOW:
+		node, err := p.parseShowStmt()
+		if err != nil {
+			return nil, "", err
+		}
+		return node, p.srcSlice(condStartAbs, p.prev.Loc.End), nil
+	default:
+		// CALL or any other condition: capture verbatim up to the matching ')'
+		// that closes EXISTS( … ), tracking nested parens.
+		raw := p.captureBalancedRaw(condStartAbs)
+		return nil, raw, nil
+	}
+}
+
+// captureBalancedRaw consumes tokens from the current position until the parser
+// reaches the ')' that closes the paren level the caller is already inside (i.e.
+// until nesting depth would go negative), without consuming that ')'. It returns
+// the verbatim source text from startAbs to the end of the last consumed token.
+// Used to capture an embedded condition (e.g. a CALL) that no available
+// sub-parser handles, so the enclosing statement still parses cleanly.
+func (p *Parser) captureBalancedRaw(startAbs int) string {
+	depth := 0
+	endAbs := startAbs
+	for p.cur.Type != tokEOF {
+		if p.cur.Type == ')' && depth == 0 {
+			break
+		}
+		switch p.cur.Type {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		endAbs = p.cur.Loc.End
+		p.advance()
+	}
+	return p.srcSlice(startAbs, endAbs)
+}
+
+// ---------------------------------------------------------------------------
+// ALTER ALERT
+// ---------------------------------------------------------------------------
+
+// parseAlterAlertStmt parses ALTER ALERT [ IF EXISTS ] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the ALERT keyword.
+//
+//	RESUME | SUSPEND
+//	SET <options>                              (WAREHOUSE = … | SCHEDULE = … | COMMENT = …)
+//	UNSET <property> [ , ... ]                  (WAREHOUSE | SCHEDULE | COMMENT)
+//	MODIFY CONDITION EXISTS ( <query> )
+//	MODIFY ACTION <action>
+func (p *Parser) parseAlterAlertStmt() (ast.Node, error) {
+	altTok := p.advance() // consume ALERT
+	stmt := &ast.AlterAlertStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	if err := p.parseIfExistsInto(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRESUME:
+		p.advance()
+		stmt.Action = ast.AlterAlertResume
+
+	case kwSUSPEND:
+		p.advance()
+		stmt.Action = ast.AlterAlertSuspend
+
+	case kwSET:
+		p.advance() // consume SET
+		opts, err := p.parseRequiredOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterAlertSet
+		stmt.Options = opts
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		props, err := p.parseUnsetPropertyList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterAlertUnset
+		stmt.UnsetProps = props
+
+	case kwMODIFY:
+		p.advance() // consume MODIFY
+		switch p.cur.Type {
+		case kwCONDITION:
+			// MODIFY CONDITION EXISTS ( <query> )
+			p.advance() // consume CONDITION
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect('('); err != nil {
+				return nil, err
+			}
+			cond, condRaw, err := p.parseAlertCondition()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(')'); err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterAlertModifyCondition
+			stmt.Condition = cond
+			stmt.ConditionRaw = condRaw
+		case kwACTION:
+			// MODIFY ACTION <action>
+			p.advance() // consume ACTION
+			action, raw, err := p.parseEmbeddedBody()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterAlertModifyAction
+			stmt.ActionBody = action
+			stmt.ActionRaw = raw
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// parseEmbeddedBody parses an embedded statement body (TASK's AS <sql>, ALERT's
+// THEN <action>), reusing the top-level parseStmt where it can and falling back
+// to a verbatim capture otherwise. It returns the parsed node (nil on fallback)
+// and the verbatim body source text (always non-empty for a well-formed body).
+//
+// A Snowflake Scripting block (BEGIN…END / DECLARE…BEGIN…END) and any statement
+// parseStmt does not yet support (e.g. CALL) cannot be parsed structurally; for
+// those the parser snapshot is restored and the remaining tokens of the segment
+// are consumed verbatim, so the enclosing statement is never rejected on account
+// of its body. (F3's Split keeps a `… AS BEGIN … END;` body as one segment, so
+// the remaining tokens are exactly the body.)
+func (p *Parser) parseEmbeddedBody() (ast.Node, string, error) {
+	if p.cur.Type == tokEOF {
+		// AS / THEN with no body is a syntax error.
+		return nil, "", p.syntaxErrorAtCur()
+	}
+	bodyStartAbs := p.cur.Loc.Start
+
+	// A BEGIN / DECLARE opener is a scripting block parseStmt cannot parse; go
+	// straight to verbatim capture without attempting (and erroring) parseStmt.
+	if p.cur.Type != kwBEGIN && p.cur.Type != kwDECLARE {
+		snap := p.snapshot()
+		node, err := p.parseStmt()
+		if err == nil && node != nil {
+			return node, p.srcSlice(bodyStartAbs, p.prev.Loc.End), nil
+		}
+		// Unsupported / unparsable body: restore and fall through to verbatim.
+		p.restore(snap)
+	}
+
+	raw := p.captureRawToEOF(bodyStartAbs)
+	return nil, raw, nil
+}
+
+// captureRawToEOF consumes every remaining token of the current segment and
+// returns the verbatim source text from startAbs to the end of the last token.
+func (p *Parser) captureRawToEOF(startAbs int) string {
+	endAbs := startAbs
+	for p.cur.Type != tokEOF {
+		endAbs = p.cur.Loc.End
+		p.advance()
+	}
+	return p.srcSlice(startAbs, endAbs)
+}
+
+// parserSnapshot captures enough Parser state to roll back a speculative parse
+// (used by parseEmbeddedBody before attempting parseStmt on a body that may turn
+// out to be unsupported). The Lexer is a value-copyable struct (string + int
+// cursors + an error slice), so a shallow copy plus the buffered-token and
+// error-length fields fully restores the position.
+type parserSnapshot struct {
+	lexer     Lexer
+	cur       Token
+	prev      Token
+	nextBuf   Token
+	hasNext   bool
+	numErrors int
+}
+
+// snapshot records the current Parser state for a later restore.
+func (p *Parser) snapshot() parserSnapshot {
+	return parserSnapshot{
+		lexer:     *p.lexer,
+		cur:       p.cur,
+		prev:      p.prev,
+		nextBuf:   p.nextBuf,
+		hasNext:   p.hasNext,
+		numErrors: len(p.errors),
+	}
+}
+
+// restore rolls the Parser back to a previously captured snapshot, discarding
+// any tokens consumed and any errors appended since.
+func (p *Parser) restore(s parserSnapshot) {
+	*p.lexer = s.lexer
+	p.cur = s.cur
+	p.prev = s.prev
+	p.nextBuf = s.nextBuf
+	p.hasNext = s.hasNext
+	p.errors = p.errors[:s.numErrors]
+}
+
+// parseRequiredOptions parses a run of one or more open-ended KEY = value
+// options (reusing parseCopyOption). An empty run — a SET with nothing settable
+// — is a syntax error. Shared by the ALTER … SET branches.
+func (p *Parser) parseRequiredOptions() ([]*ast.CopyOption, error) {
+	var opts []*ast.CopyOption
+	for p.startsCopyOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+	}
+	if len(opts) == 0 {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return opts, nil
+}
+
+// parseUnsetPropertyList parses an UNSET <property> [ , ... ] list, where each
+// property is a single name word (identifier or keyword), uppercased. Property
+// names are not enumerated. Consumes at least one property.
+func (p *Parser) parseUnsetPropertyList() ([]string, error) {
+	var props []string
+	for {
+		if !p.isOptionWord(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		props = append(props, strings.ToUpper(p.advance().Str))
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return props, nil
+}
+
+// parseIfNotExistsInto consumes an optional IF NOT EXISTS prefix, setting *dst
+// when present. cur should be just past the object-type keyword.
+func (p *Parser) parseIfNotExistsInto(dst *bool) error {
+	if p.cur.Type == kwIF && p.peekNext().Type == kwNOT {
+		p.advance() // consume IF
+		p.advance() // consume NOT
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return err
+		}
+		*dst = true
+	}
+	return nil
+}
+
+// parseIfExistsInto consumes an optional IF EXISTS prefix, setting *dst when
+// present. cur should be just past the object-type keyword.
+func (p *Parser) parseIfExistsInto(dst *bool) error {
+	if p.cur.Type == kwIF && p.peekNext().Type == kwEXISTS {
+		p.advance() // consume IF
+		p.advance() // consume EXISTS
+		*dst = true
+	}
+	return nil
+}

--- a/snowflake/parser/pipe_stream_task_test.go
+++ b/snowflake/parser/pipe_stream_task_test.go
@@ -1,0 +1,1161 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreatePipe(t *testing.T, input string) *ast.CreatePipeStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreatePipeStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreatePipeStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterPipe(t *testing.T, input string) *ast.AlterPipeStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterPipeStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterPipeStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateStream(t *testing.T, input string) *ast.CreateStreamStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateStreamStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateStreamStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterStream(t *testing.T, input string) *ast.AlterStreamStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterStreamStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterStreamStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateTask(t *testing.T, input string) *ast.CreateTaskStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateTaskStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateTaskStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterTask(t *testing.T, input string) *ast.AlterTaskStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterTaskStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterTaskStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateAlert(t *testing.T, input string) *ast.CreateAlertStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateAlertStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateAlertStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterAlert(t *testing.T, input string) *ast.AlterAlertStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterAlertStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterAlertStmt", input, node)
+	}
+	return stmt
+}
+
+// mustNotParse asserts that input fails to parse (a syntax error is produced).
+// Negative test gate (correctness-protocol.md): an over-permissive parser passes
+// every accept-test, so each object covers its reject forms here.
+func mustNotParse(t *testing.T, input string) {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) == 0 {
+		t.Fatalf("parse %q: expected a syntax error, got none (stmts=%d)", input, len(result.File.Stmts))
+	}
+}
+
+// optByName returns the first option whose Name (uppercased) equals name, or nil.
+func optByName(opts []*ast.CopyOption, name string) *ast.CopyOption {
+	for _, o := range opts {
+		if o.Name == name {
+			return o
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE PIPE
+//
+// Docs (truth1, authoritative):
+//
+//	CREATE [ OR REPLACE ] PIPE [ IF NOT EXISTS ] <name>
+//	  [ AUTO_INGEST = {TRUE|FALSE} ] [ ERROR_INTEGRATION = <id> ]
+//	  [ AWS_SNS_TOPIC = '<s>' ] [ INTEGRATION = '<s>' ] [ COMMENT = '<s>' ]
+//	  AS <copy_into_table>
+// ---------------------------------------------------------------------------
+
+func TestParseCreatePipe(t *testing.T) {
+	t.Run("minimal AS COPY", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE PIPE mypipe AS COPY INTO mytable FROM @mystage FILE_FORMAT = (TYPE = 'JSON')")
+		if stmt.Name.String() != "mypipe" {
+			t.Errorf("Name = %q, want mypipe", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.IfNotExists {
+			t.Errorf("unexpected modifier: %+v", stmt)
+		}
+		if len(stmt.Options) != 0 {
+			t.Errorf("expected no options, got %+v", stmt.Options)
+		}
+		if _, ok := stmt.Copy.(*ast.CopyIntoTableStmt); !ok {
+			t.Fatalf("Copy = %T, want *ast.CopyIntoTableStmt", stmt.Copy)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE OR REPLACE PIPE p AS COPY INTO t FROM @s")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE PIPE IF NOT EXISTS p AS COPY INTO t FROM @s")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("config options before AS", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE PIPE p AUTO_INGEST = TRUE INTEGRATION = 'MYINT' AS COPY INTO t FROM @s")
+		if optByName(stmt.Options, "AUTO_INGEST") == nil {
+			t.Errorf("AUTO_INGEST option missing: %+v", stmt.Options)
+		}
+		if o := optByName(stmt.Options, "INTEGRATION"); o == nil || o.Lit == nil || o.Lit.Value != "MYINT" {
+			t.Errorf("INTEGRATION option wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("parenthesized COPY body", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE PIPE p AS (COPY INTO t FROM @s FILE_FORMAT = (TYPE = 'JSON'))")
+		if _, ok := stmt.Copy.(*ast.CopyIntoTableStmt); !ok {
+			t.Fatalf("Copy = %T, want *ast.CopyIntoTableStmt", stmt.Copy)
+		}
+	})
+
+	t.Run("AWS_SNS_TOPIC option", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE PIPE p AUTO_INGEST = TRUE AWS_SNS_TOPIC = 'arn:aws:sns:x' AS COPY INTO t FROM @s")
+		if o := optByName(stmt.Options, "AWS_SNS_TOPIC"); o == nil || o.Lit == nil {
+			t.Errorf("AWS_SNS_TOPIC option wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("qualified name and target", func(t *testing.T) {
+		stmt := mustCreatePipe(t, "CREATE PIPE db.sch.p AS COPY INTO db.sch.t FROM @db.sch.s")
+		if stmt.Name.String() != "db.sch.p" {
+			t.Errorf("Name = %q, want db.sch.p", stmt.Name.String())
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: missing AS body", func(t *testing.T) {
+		mustNotParse(t, "CREATE PIPE p AUTO_INGEST = TRUE")
+	})
+	t.Run("reject: AS without COPY", func(t *testing.T) {
+		mustNotParse(t, "CREATE PIPE p AS SELECT 1")
+	})
+	t.Run("reject: missing name", func(t *testing.T) {
+		mustNotParse(t, "CREATE PIPE AS COPY INTO t FROM @s")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER PIPE
+//
+// Legacy ANTLR (truth2):
+//
+//	ALTER PIPE if_exists? id_ SET (object_properties? comment_clause?)
+//	ALTER PIPE id_ set_tags | unset_tags
+//	ALTER PIPE if_exists? id_ UNSET PIPE_EXECUTION_PAUSED EQ true_false
+//	ALTER PIPE if_exists? id_ UNSET COMMENT
+//	ALTER PIPE if_exists? id_ REFRESH (PREFIX EQ string)? (MODIFIED_AFTER EQ string)?
+// ---------------------------------------------------------------------------
+
+func TestParseAlterPipe(t *testing.T) {
+	t.Run("set options", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p SET PIPE_EXECUTION_PAUSED = TRUE")
+		if stmt.Action != ast.AlterPipeSet {
+			t.Errorf("Action = %v, want AlterPipeSet", stmt.Action)
+		}
+		if optByName(stmt.Options, "PIPE_EXECUTION_PAUSED") == nil {
+			t.Errorf("PIPE_EXECUTION_PAUSED missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p SET COMMENT = 'hi'")
+		if stmt.Action != ast.AlterPipeSet {
+			t.Errorf("Action = %v, want AlterPipeSet", stmt.Action)
+		}
+	})
+
+	t.Run("if exists", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE IF EXISTS p SET COMMENT = 'hi'")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p SET TAG cost_center = 'eng'")
+		if stmt.Action != ast.AlterPipeSetTag {
+			t.Errorf("Action = %v, want AlterPipeSetTag", stmt.Action)
+		}
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Value != "eng" {
+			t.Errorf("Tags wrong: %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p UNSET TAG cost_center")
+		if stmt.Action != ast.AlterPipeUnsetTag {
+			t.Errorf("Action = %v, want AlterPipeUnsetTag", stmt.Action)
+		}
+		if len(stmt.UnsetTags) != 1 {
+			t.Errorf("UnsetTags wrong: %+v", stmt.UnsetTags)
+		}
+	})
+
+	t.Run("unset property", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p UNSET COMMENT")
+		if stmt.Action != ast.AlterPipeUnset {
+			t.Errorf("Action = %v, want AlterPipeUnset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("UnsetProps = %v, want [COMMENT]", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("refresh bare", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p REFRESH")
+		if stmt.Action != ast.AlterPipeRefresh {
+			t.Errorf("Action = %v, want AlterPipeRefresh", stmt.Action)
+		}
+		if len(stmt.Options) != 0 {
+			t.Errorf("expected no refresh options, got %+v", stmt.Options)
+		}
+	})
+
+	t.Run("refresh with prefix and modified_after", func(t *testing.T) {
+		stmt := mustAlterPipe(t, "ALTER PIPE p REFRESH PREFIX = 'data/' MODIFIED_AFTER = '2020-01-01'")
+		if stmt.Action != ast.AlterPipeRefresh {
+			t.Errorf("Action = %v, want AlterPipeRefresh", stmt.Action)
+		}
+		if optByName(stmt.Options, "PREFIX") == nil || optByName(stmt.Options, "MODIFIED_AFTER") == nil {
+			t.Errorf("refresh options wrong: %+v", stmt.Options)
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: SET nothing", func(t *testing.T) {
+		mustNotParse(t, "ALTER PIPE p SET")
+	})
+	t.Run("reject: bad action", func(t *testing.T) {
+		mustNotParse(t, "ALTER PIPE p FROBNICATE")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE STREAM
+//
+// Docs (truth1, authoritative):
+//
+//	CREATE [OR REPLACE] STREAM [IF NOT EXISTS] <name>
+//	  [[WITH] TAG (...)] [COPY GRANTS]
+//	  ON {TABLE|VIEW|STAGE|EXTERNAL TABLE} <object_name>
+//	  [{AT|BEFORE} ({TIMESTAMP=>..|OFFSET=>..|STATEMENT=>..|STREAM=>..})]
+//	  [APPEND_ONLY=..] [INSERT_ONLY=..] [SHOW_INITIAL_ROWS=..] [COMMENT=..]
+// ---------------------------------------------------------------------------
+
+func TestParseCreateStream(t *testing.T) {
+	t.Run("on table minimal", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM mystream ON TABLE mytable")
+		if stmt.Name.String() != "mystream" {
+			t.Errorf("Name = %q, want mystream", stmt.Name.String())
+		}
+		if stmt.SourceKind != ast.StreamOnTable {
+			t.Errorf("SourceKind = %v, want StreamOnTable", stmt.SourceKind)
+		}
+		if stmt.Source.String() != "mytable" {
+			t.Errorf("Source = %q, want mytable", stmt.Source.String())
+		}
+		if stmt.TimeTravel != nil {
+			t.Errorf("TimeTravel = %+v, want nil", stmt.TimeTravel)
+		}
+	})
+
+	t.Run("on view", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON VIEW myview")
+		if stmt.SourceKind != ast.StreamOnView {
+			t.Errorf("SourceKind = %v, want StreamOnView", stmt.SourceKind)
+		}
+	})
+
+	t.Run("on stage", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON STAGE mystage")
+		if stmt.SourceKind != ast.StreamOnStage {
+			t.Errorf("SourceKind = %v, want StreamOnStage", stmt.SourceKind)
+		}
+	})
+
+	t.Run("on external table", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON EXTERNAL TABLE my_ext_table INSERT_ONLY = TRUE")
+		if stmt.SourceKind != ast.StreamOnExternalTable {
+			t.Errorf("SourceKind = %v, want StreamOnExternalTable", stmt.SourceKind)
+		}
+		if optByName(stmt.Options, "INSERT_ONLY") == nil {
+			t.Errorf("INSERT_ONLY option missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE OR REPLACE STREAM s ON TABLE t")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM IF NOT EXISTS s ON TABLE t")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("copy grants", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s COPY GRANTS ON TABLE t")
+		if !stmt.CopyGrants {
+			t.Error("CopyGrants not set")
+		}
+	})
+
+	t.Run("with tag", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s WITH TAG (cost = 'x') ON TABLE t")
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Value != "x" {
+			t.Errorf("Tags wrong: %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("with tag and copy grants", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s WITH TAG (cost = 'x') COPY GRANTS ON TABLE t")
+		if len(stmt.Tags) != 1 || !stmt.CopyGrants {
+			t.Errorf("Tags=%+v CopyGrants=%v", stmt.Tags, stmt.CopyGrants)
+		}
+	})
+
+	t.Run("at timestamp function value", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t AT (TIMESTAMP => TO_TIMESTAMP(40*365*86400))")
+		if stmt.TimeTravel == nil {
+			t.Fatalf("TimeTravel nil")
+		}
+		if stmt.TimeTravel.AtBefore != "AT" || stmt.TimeTravel.Key != "TIMESTAMP" {
+			t.Errorf("TimeTravel = %+v, want AT/TIMESTAMP", stmt.TimeTravel)
+		}
+		if _, ok := stmt.TimeTravel.Value.(*ast.FuncCallExpr); !ok {
+			t.Errorf("TimeTravel.Value = %T, want *ast.FuncCallExpr", stmt.TimeTravel.Value)
+		}
+	})
+
+	t.Run("before timestamp", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t BEFORE (TIMESTAMP => TO_TIMESTAMP(40))")
+		if stmt.TimeTravel == nil || stmt.TimeTravel.AtBefore != "BEFORE" {
+			t.Errorf("TimeTravel = %+v, want BEFORE", stmt.TimeTravel)
+		}
+	})
+
+	t.Run("at offset negative arithmetic", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t AT(OFFSET => -60*5)")
+		if stmt.TimeTravel == nil || stmt.TimeTravel.Key != "OFFSET" {
+			t.Errorf("TimeTravel = %+v, want OFFSET", stmt.TimeTravel)
+		}
+	})
+
+	t.Run("at stream string", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t AT(STREAM => 'oldstream')")
+		if stmt.TimeTravel == nil || stmt.TimeTravel.Key != "STREAM" {
+			t.Errorf("TimeTravel = %+v, want STREAM", stmt.TimeTravel)
+		}
+	})
+
+	t.Run("before statement string", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t BEFORE(STATEMENT => '8e5d0ca9')")
+		if stmt.TimeTravel == nil || stmt.TimeTravel.Key != "STATEMENT" {
+			t.Errorf("TimeTravel = %+v, want STATEMENT", stmt.TimeTravel)
+		}
+	})
+
+	t.Run("append_only and comment", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t APPEND_ONLY = TRUE COMMENT = 'c'")
+		if optByName(stmt.Options, "APPEND_ONLY") == nil || optByName(stmt.Options, "COMMENT") == nil {
+			t.Errorf("options wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("show_initial_rows", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t SHOW_INITIAL_ROWS = TRUE")
+		if optByName(stmt.Options, "SHOW_INITIAL_ROWS") == nil {
+			t.Errorf("SHOW_INITIAL_ROWS missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("at then append_only and time travel order", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s ON TABLE t AT (OFFSET => -5) APPEND_ONLY = TRUE")
+		if stmt.TimeTravel == nil {
+			t.Error("TimeTravel nil")
+		}
+		if optByName(stmt.Options, "APPEND_ONLY") == nil {
+			t.Errorf("APPEND_ONLY missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("clone", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE STREAM s CLONE src_stream")
+		if stmt.Clone == nil || stmt.Clone.String() != "src_stream" {
+			t.Errorf("Clone = %+v, want src_stream", stmt.Clone)
+		}
+	})
+
+	t.Run("clone with copy grants", func(t *testing.T) {
+		stmt := mustCreateStream(t, "CREATE OR REPLACE STREAM s CLONE src COPY GRANTS")
+		if stmt.Clone == nil || !stmt.CopyGrants {
+			t.Errorf("Clone=%+v CopyGrants=%v", stmt.Clone, stmt.CopyGrants)
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: missing ON", func(t *testing.T) {
+		mustNotParse(t, "CREATE STREAM s mytable")
+	})
+	t.Run("reject: ON bad object kind", func(t *testing.T) {
+		mustNotParse(t, "CREATE STREAM s ON DATABASE d")
+	})
+	t.Run("reject: time travel missing =>", func(t *testing.T) {
+		mustNotParse(t, "CREATE STREAM s ON TABLE t AT (TIMESTAMP 5)")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER STREAM
+//
+// Legacy ANTLR (truth2):
+//
+//	ALTER STREAM if_exists? id_ SET tag_decl_list? comment_clause?
+//	ALTER STREAM if_exists? id_ set_tags | unset_tags
+//	ALTER STREAM if_exists? id_ UNSET COMMENT
+// ---------------------------------------------------------------------------
+
+func TestParseAlterStream(t *testing.T) {
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterStream(t, "ALTER STREAM s SET COMMENT = 'hi'")
+		if stmt.Action != ast.AlterStreamSet {
+			t.Errorf("Action = %v, want AlterStreamSet", stmt.Action)
+		}
+		if optByName(stmt.Options, "COMMENT") == nil {
+			t.Errorf("COMMENT missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("if exists", func(t *testing.T) {
+		stmt := mustAlterStream(t, "ALTER STREAM IF EXISTS s SET COMMENT = 'hi'")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterStream(t, "ALTER STREAM s SET TAG cost = 'eng'")
+		if stmt.Action != ast.AlterStreamSetTag {
+			t.Errorf("Action = %v, want AlterStreamSetTag", stmt.Action)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterStream(t, "ALTER STREAM s UNSET TAG cost")
+		if stmt.Action != ast.AlterStreamUnsetTag {
+			t.Errorf("Action = %v, want AlterStreamUnsetTag", stmt.Action)
+		}
+	})
+
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterStream(t, "ALTER STREAM s UNSET COMMENT")
+		if stmt.Action != ast.AlterStreamUnset {
+			t.Errorf("Action = %v, want AlterStreamUnset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("UnsetProps = %v", stmt.UnsetProps)
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: SET nothing", func(t *testing.T) {
+		mustNotParse(t, "ALTER STREAM s SET")
+	})
+	t.Run("reject: bad action", func(t *testing.T) {
+		mustNotParse(t, "ALTER STREAM s RESUME")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TASK
+//
+// Docs (truth1, authoritative):
+//
+//	CREATE [OR REPLACE] TASK [IF NOT EXISTS] <name>
+//	  [config: WAREHOUSE|USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE|SCHEDULE|CONFIG|...]
+//	  [AFTER <pred> [,...]] [WHEN <bool>] AS <sql>
+// ---------------------------------------------------------------------------
+
+func TestParseCreateTask(t *testing.T) {
+	t.Run("schedule and select body", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t1 SCHEDULE = '5 MINUTES' AS SELECT CURRENT_TIMESTAMP")
+		if stmt.Name.String() != "t1" {
+			t.Errorf("Name = %q, want t1", stmt.Name.String())
+		}
+		if optByName(stmt.Options, "SCHEDULE") == nil {
+			t.Errorf("SCHEDULE missing: %+v", stmt.Options)
+		}
+		if _, ok := stmt.Body.(*ast.SelectStmt); !ok {
+			t.Errorf("Body = %T, want *ast.SelectStmt", stmt.Body)
+		}
+		if !strings.Contains(strings.ToUpper(stmt.BodyRaw), "SELECT") {
+			t.Errorf("BodyRaw = %q, want it to contain SELECT", stmt.BodyRaw)
+		}
+	})
+
+	t.Run("warehouse and schedule", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t WAREHOUSE = mywh SCHEDULE = '5 MINUTES' AS SELECT 1")
+		if optByName(stmt.Options, "WAREHOUSE") == nil || optByName(stmt.Options, "SCHEDULE") == nil {
+			t.Errorf("options wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("insert body", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t SCHEDULE = '5 MINUTES' AS INSERT INTO mytable(ts) VALUES(CURRENT_TIMESTAMP)")
+		if _, ok := stmt.Body.(*ast.InsertStmt); !ok {
+			t.Errorf("Body = %T, want *ast.InsertStmt", stmt.Body)
+		}
+	})
+
+	t.Run("when predicate", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t WAREHOUSE = wh SCHEDULE = '5 MINUTES' WHEN SYSTEM$STREAM_HAS_DATA('S') AS INSERT INTO t1(id) SELECT id FROM s")
+		if stmt.When == nil {
+			t.Error("When nil")
+		}
+		if _, ok := stmt.Body.(*ast.InsertStmt); !ok {
+			t.Errorf("Body = %T, want *ast.InsertStmt", stmt.Body)
+		}
+	})
+
+	t.Run("after single", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t AFTER root AS INSERT INTO t1(ts) VALUES(CURRENT_TIMESTAMP)")
+		if len(stmt.After) != 1 || stmt.After[0].String() != "root" {
+			t.Errorf("After = %+v, want [root]", stmt.After)
+		}
+	})
+
+	t.Run("after list", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t5 AFTER task2, task3, task4 AS INSERT INTO t1(ts) VALUES(1)")
+		if len(stmt.After) != 3 {
+			t.Errorf("After len = %d, want 3: %+v", len(stmt.After), stmt.After)
+		}
+	})
+
+	t.Run("call body (parseStmt unsupported, raw fallback)", func(t *testing.T) {
+		// CALL is not yet supported by parseStmt; the body must still be captured
+		// verbatim so the task parses. Body is nil, BodyRaw holds the text.
+		stmt := mustCreateTask(t, "CREATE TASK t WAREHOUSE = wh SCHEDULE = '60 MINUTES' AS CALL my_sp()")
+		if stmt.Body != nil {
+			t.Errorf("Body = %T, want nil (CALL unsupported)", stmt.Body)
+		}
+		if !strings.Contains(strings.ToUpper(stmt.BodyRaw), "CALL MY_SP()") {
+			t.Errorf("BodyRaw = %q, want it to contain CALL MY_SP()", stmt.BodyRaw)
+		}
+	})
+
+	t.Run("scripting BEGIN END body (raw fallback)", func(t *testing.T) {
+		input := "CREATE OR REPLACE TASK t USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = 'XSMALL' SCHEDULE = '1 m' AS BEGIN SELECT 1; SELECT 2; END"
+		stmt := mustCreateTask(t, input)
+		if stmt.Body != nil {
+			t.Errorf("Body = %T, want nil (scripting block)", stmt.Body)
+		}
+		if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(stmt.BodyRaw)), "BEGIN") {
+			t.Errorf("BodyRaw = %q, want it to start with BEGIN", stmt.BodyRaw)
+		}
+		if !strings.Contains(strings.ToUpper(stmt.BodyRaw), "END") {
+			t.Errorf("BodyRaw = %q, want it to contain END", stmt.BodyRaw)
+		}
+	})
+
+	t.Run("scripting DECLARE body (raw fallback)", func(t *testing.T) {
+		input := "CREATE TASK t SCHEDULE = '15 SECONDS' AS DECLARE x float; BEGIN x := 3; RETURN x; END"
+		stmt := mustCreateTask(t, input)
+		if stmt.Body != nil {
+			t.Errorf("Body = %T, want nil (DECLARE block)", stmt.Body)
+		}
+		if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(stmt.BodyRaw)), "DECLARE") {
+			t.Errorf("BodyRaw = %q, want it to start with DECLARE", stmt.BodyRaw)
+		}
+	})
+
+	t.Run("config dollar-string and finalize", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t WAREHOUSE = wh FINALIZE = my_root AS SELECT 1")
+		if optByName(stmt.Options, "FINALIZE") == nil {
+			t.Errorf("FINALIZE missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("with tag then options", func(t *testing.T) {
+		stmt := mustCreateTask(t, "CREATE TASK t WITH TAG (cost = 'x') WAREHOUSE = wh SCHEDULE = '5 m' AS SELECT 1")
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v, want 1", stmt.Tags)
+		}
+		if optByName(stmt.Options, "WAREHOUSE") == nil {
+			t.Errorf("WAREHOUSE missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("clone", func(t *testing.T) {
+		// CREATE TASK <name> CLONE <source> (docs + legacy create_object_clone).
+		stmt := mustCreateTask(t, "CREATE OR REPLACE TASK t CLONE src_task")
+		if stmt.Clone == nil || stmt.Clone.String() != "src_task" {
+			t.Errorf("Clone = %+v, want src_task", stmt.Clone)
+		}
+		if stmt.Body != nil || stmt.BodyRaw != "" {
+			t.Errorf("CLONE form should have no body: Body=%v BodyRaw=%q", stmt.Body, stmt.BodyRaw)
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: missing AS body", func(t *testing.T) {
+		mustNotParse(t, "CREATE TASK t SCHEDULE = '5 MINUTES'")
+	})
+	t.Run("reject: AS with nothing", func(t *testing.T) {
+		mustNotParse(t, "CREATE TASK t SCHEDULE = '5 MINUTES' AS")
+	})
+	t.Run("reject: missing name", func(t *testing.T) {
+		mustNotParse(t, "CREATE TASK AS SELECT 1")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TASK
+//
+// Legacy ANTLR (truth2):
+//
+//	ALTER TASK if_exists? object_name resume_suspend
+//	ALTER TASK if_exists? object_name (REMOVE|ADD) AFTER string_list
+//	ALTER TASK if_exists? object_name SET ... | UNSET ... | set_tags | unset_tags
+//	ALTER TASK if_exists? object_name MODIFY AS task_sql
+//	ALTER TASK if_exists? object_name MODIFY WHEN expr
+// ---------------------------------------------------------------------------
+
+func TestParseAlterTask(t *testing.T) {
+	t.Run("resume", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t RESUME")
+		if stmt.Action != ast.AlterTaskResume {
+			t.Errorf("Action = %v, want AlterTaskResume", stmt.Action)
+		}
+	})
+
+	t.Run("suspend", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t SUSPEND")
+		if stmt.Action != ast.AlterTaskSuspend {
+			t.Errorf("Action = %v, want AlterTaskSuspend", stmt.Action)
+		}
+	})
+
+	t.Run("if exists resume", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK IF EXISTS t RESUME")
+		if !stmt.IfExists || stmt.Action != ast.AlterTaskResume {
+			t.Errorf("IfExists=%v Action=%v", stmt.IfExists, stmt.Action)
+		}
+	})
+
+	t.Run("add after", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t ADD AFTER p1, p2")
+		if stmt.Action != ast.AlterTaskAddAfter {
+			t.Errorf("Action = %v, want AlterTaskAddAfter", stmt.Action)
+		}
+		if len(stmt.After) != 2 {
+			t.Errorf("After len = %d, want 2", len(stmt.After))
+		}
+	})
+
+	t.Run("remove after", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t REMOVE AFTER p1")
+		if stmt.Action != ast.AlterTaskRemoveAfter {
+			t.Errorf("Action = %v, want AlterTaskRemoveAfter", stmt.Action)
+		}
+	})
+
+	t.Run("set options", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t SET WAREHOUSE = wh SCHEDULE = '5 m'")
+		if stmt.Action != ast.AlterTaskSet {
+			t.Errorf("Action = %v, want AlterTaskSet", stmt.Action)
+		}
+		if optByName(stmt.Options, "WAREHOUSE") == nil {
+			t.Errorf("WAREHOUSE missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t SET TAG cost = 'eng'")
+		if stmt.Action != ast.AlterTaskSetTag {
+			t.Errorf("Action = %v, want AlterTaskSetTag", stmt.Action)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t UNSET TAG cost")
+		if stmt.Action != ast.AlterTaskUnsetTag {
+			t.Errorf("Action = %v, want AlterTaskUnsetTag", stmt.Action)
+		}
+	})
+
+	t.Run("unset properties", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t UNSET WAREHOUSE, SCHEDULE, COMMENT")
+		if stmt.Action != ast.AlterTaskUnset {
+			t.Errorf("Action = %v, want AlterTaskUnset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 3 {
+			t.Errorf("UnsetProps = %v, want 3", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("modify as", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t MODIFY AS SELECT 2")
+		if stmt.Action != ast.AlterTaskModifyAs {
+			t.Errorf("Action = %v, want AlterTaskModifyAs", stmt.Action)
+		}
+		if _, ok := stmt.Body.(*ast.SelectStmt); !ok {
+			t.Errorf("Body = %T, want *ast.SelectStmt", stmt.Body)
+		}
+	})
+
+	t.Run("modify as scripting (raw fallback)", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t MODIFY AS BEGIN SELECT 1; END")
+		if stmt.Action != ast.AlterTaskModifyAs {
+			t.Errorf("Action = %v, want AlterTaskModifyAs", stmt.Action)
+		}
+		if stmt.Body != nil {
+			t.Errorf("Body = %T, want nil", stmt.Body)
+		}
+		if !strings.Contains(strings.ToUpper(stmt.BodyRaw), "BEGIN") {
+			t.Errorf("BodyRaw = %q", stmt.BodyRaw)
+		}
+	})
+
+	t.Run("modify when", func(t *testing.T) {
+		stmt := mustAlterTask(t, "ALTER TASK t MODIFY WHEN SYSTEM$STREAM_HAS_DATA('S')")
+		if stmt.Action != ast.AlterTaskModifyWhen {
+			t.Errorf("Action = %v, want AlterTaskModifyWhen", stmt.Action)
+		}
+		if stmt.When == nil {
+			t.Error("When nil")
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: SET nothing", func(t *testing.T) {
+		mustNotParse(t, "ALTER TASK t SET")
+	})
+	t.Run("reject: MODIFY without AS/WHEN", func(t *testing.T) {
+		mustNotParse(t, "ALTER TASK t MODIFY COMMENT")
+	})
+	t.Run("reject: bad action", func(t *testing.T) {
+		mustNotParse(t, "ALTER TASK t FROBNICATE")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE ALERT
+//
+// Docs (truth1, authoritative):
+//
+//	CREATE [OR REPLACE] ALERT [IF NOT EXISTS] <name>
+//	  [[WITH] TAG (...)] [WAREHOUSE=..] SCHEDULE=.. [COMMENT=..] [CONFIG=..] ...
+//	  IF(EXISTS(<condition>)) THEN <action>
+// (No official create-alert corpus; covered from docs + .g4.)
+// ---------------------------------------------------------------------------
+
+func TestParseCreateAlert(t *testing.T) {
+	t.Run("warehouse schedule if exists then", func(t *testing.T) {
+		stmt := mustCreateAlert(t, "CREATE ALERT myalert WAREHOUSE = wh SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1 FROM t WHERE x > 0)) THEN INSERT INTO log VALUES (1)")
+		if stmt.Name.String() != "myalert" {
+			t.Errorf("Name = %q, want myalert", stmt.Name.String())
+		}
+		if optByName(stmt.Options, "WAREHOUSE") == nil || optByName(stmt.Options, "SCHEDULE") == nil {
+			t.Errorf("options wrong: %+v", stmt.Options)
+		}
+		if _, ok := stmt.Condition.(*ast.SelectStmt); !ok {
+			t.Errorf("Condition = %T, want *ast.SelectStmt", stmt.Condition)
+		}
+		if _, ok := stmt.Action.(*ast.InsertStmt); !ok {
+			t.Errorf("Action = %T, want *ast.InsertStmt", stmt.Action)
+		}
+	})
+
+	t.Run("serverless (no warehouse)", func(t *testing.T) {
+		// WAREHOUSE is optional for serverless alerts (docs).
+		stmt := mustCreateAlert(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN INSERT INTO log VALUES (1)")
+		if optByName(stmt.Options, "WAREHOUSE") != nil {
+			t.Errorf("unexpected WAREHOUSE: %+v", stmt.Options)
+		}
+		if optByName(stmt.Options, "SCHEDULE") == nil {
+			t.Errorf("SCHEDULE missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateAlert(t, "CREATE OR REPLACE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN INSERT INTO l VALUES (1)")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateAlert(t, "CREATE ALERT IF NOT EXISTS a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN INSERT INTO l VALUES (1)")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("with tag and comment", func(t *testing.T) {
+		stmt := mustCreateAlert(t, "CREATE ALERT a WITH TAG (cost = 'x') WAREHOUSE = wh SCHEDULE = '1 MINUTE' COMMENT = 'c' IF (EXISTS (SELECT 1)) THEN INSERT INTO l VALUES (1)")
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v, want 1", stmt.Tags)
+		}
+		if optByName(stmt.Options, "COMMENT") == nil {
+			t.Errorf("COMMENT missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("condition raw captured", func(t *testing.T) {
+		stmt := mustCreateAlert(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT col FROM tbl)) THEN INSERT INTO l VALUES (1)")
+		if !strings.Contains(strings.ToUpper(stmt.ConditionRaw), "SELECT COL FROM TBL") {
+			t.Errorf("ConditionRaw = %q", stmt.ConditionRaw)
+		}
+	})
+
+	t.Run("call action (raw fallback)", func(t *testing.T) {
+		stmt := mustCreateAlert(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN CALL SYSTEM$SEND_EMAIL('i', 'a@b.c', 's', 'm')")
+		if stmt.Action != nil {
+			t.Errorf("Action = %T, want nil (CALL unsupported)", stmt.Action)
+		}
+		if !strings.Contains(strings.ToUpper(stmt.ActionRaw), "CALL SYSTEM$SEND_EMAIL") {
+			t.Errorf("ActionRaw = %q", stmt.ActionRaw)
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: missing IF", func(t *testing.T) {
+		mustNotParse(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' THEN INSERT INTO l VALUES (1)")
+	})
+	t.Run("reject: missing EXISTS", func(t *testing.T) {
+		mustNotParse(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (SELECT 1) THEN INSERT INTO l VALUES (1)")
+	})
+	t.Run("reject: missing THEN", func(t *testing.T) {
+		mustNotParse(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) INSERT INTO l VALUES (1)")
+	})
+	t.Run("reject: missing THEN action", func(t *testing.T) {
+		mustNotParse(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER ALERT
+//
+// Legacy ANTLR (truth2):
+//
+//	ALTER ALERT if_exists? id_ (resume_suspend | SET alert_set_clause+
+//	  | UNSET alert_unset_clause+ | MODIFY CONDITION EXISTS '(' alert_condition ')'
+//	  | MODIFY ACTION alert_action)
+// ---------------------------------------------------------------------------
+
+func TestParseAlterAlert(t *testing.T) {
+	t.Run("resume", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a RESUME")
+		if stmt.Action != ast.AlterAlertResume {
+			t.Errorf("Action = %v, want AlterAlertResume", stmt.Action)
+		}
+	})
+
+	t.Run("suspend", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a SUSPEND")
+		if stmt.Action != ast.AlterAlertSuspend {
+			t.Errorf("Action = %v, want AlterAlertSuspend", stmt.Action)
+		}
+	})
+
+	t.Run("if exists", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT IF EXISTS a RESUME")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+	})
+
+	t.Run("set options", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a SET WAREHOUSE = wh SCHEDULE = '5 MINUTE'")
+		if stmt.Action != ast.AlterAlertSet {
+			t.Errorf("Action = %v, want AlterAlertSet", stmt.Action)
+		}
+		if optByName(stmt.Options, "WAREHOUSE") == nil {
+			t.Errorf("WAREHOUSE missing: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("unset properties", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a UNSET WAREHOUSE, COMMENT")
+		if stmt.Action != ast.AlterAlertUnset {
+			t.Errorf("Action = %v, want AlterAlertUnset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 2 {
+			t.Errorf("UnsetProps = %v, want 2", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("modify condition", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a MODIFY CONDITION EXISTS (SELECT 1 FROM t)")
+		if stmt.Action != ast.AlterAlertModifyCondition {
+			t.Errorf("Action = %v, want AlterAlertModifyCondition", stmt.Action)
+		}
+		if _, ok := stmt.Condition.(*ast.SelectStmt); !ok {
+			t.Errorf("Condition = %T, want *ast.SelectStmt", stmt.Condition)
+		}
+	})
+
+	t.Run("modify action", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a MODIFY ACTION INSERT INTO log VALUES (2)")
+		if stmt.Action != ast.AlterAlertModifyAction {
+			t.Errorf("Action = %v, want AlterAlertModifyAction", stmt.Action)
+		}
+		if _, ok := stmt.ActionBody.(*ast.InsertStmt); !ok {
+			t.Errorf("ActionBody = %T, want *ast.InsertStmt", stmt.ActionBody)
+		}
+	})
+
+	t.Run("modify action call (raw fallback)", func(t *testing.T) {
+		stmt := mustAlterAlert(t, "ALTER ALERT a MODIFY ACTION CALL my_sp()")
+		if stmt.Action != ast.AlterAlertModifyAction {
+			t.Errorf("Action = %v, want AlterAlertModifyAction", stmt.Action)
+		}
+		if stmt.ActionBody != nil {
+			t.Errorf("ActionBody = %T, want nil", stmt.ActionBody)
+		}
+		if !strings.Contains(strings.ToUpper(stmt.ActionRaw), "CALL MY_SP()") {
+			t.Errorf("ActionRaw = %q", stmt.ActionRaw)
+		}
+	})
+
+	// Negatives.
+	t.Run("reject: SET nothing", func(t *testing.T) {
+		mustNotParse(t, "ALTER ALERT a SET")
+	})
+	t.Run("reject: MODIFY CONDITION missing EXISTS", func(t *testing.T) {
+		mustNotParse(t, "ALTER ALERT a MODIFY CONDITION (SELECT 1)")
+	})
+	t.Run("reject: bad action", func(t *testing.T) {
+		mustNotParse(t, "ALTER ALERT a FROBNICATE")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Walker integration — the new nodes must be reachable by ast.Inspect, and
+// their embedded children (names, COPY body, condition, action, expr) visited.
+// ---------------------------------------------------------------------------
+
+func TestPipeStreamTask_WalkerVisitsChildren(t *testing.T) {
+	cases := []string{
+		"CREATE PIPE p AS COPY INTO t FROM @s",
+		"CREATE STREAM s ON TABLE t AT (OFFSET => -5)",
+		"CREATE TASK t SCHEDULE = '5 m' WHEN SYSTEM$STREAM_HAS_DATA('x') AS SELECT 1",
+		"CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN INSERT INTO l VALUES (1)",
+		"ALTER TASK t MODIFY AS SELECT 2",
+		"ALTER ALERT a MODIFY CONDITION EXISTS (SELECT 1)",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			node := mustParseOne(t, input)
+			// Inspect must not panic and must visit at least the root + one child.
+			count := 0
+			ast.Inspect(node, func(n ast.Node) bool {
+				if n != nil {
+					count++
+				}
+				return true
+			})
+			if count < 2 {
+				t.Errorf("Inspect visited %d nodes, want >= 2 (root + children)", count)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official docs corpus — every CREATE PIPE / STREAM / TASK statement in the
+// corresponding corpus directory must parse with zero errors to its expected
+// AST type. The official docs are the authoritative oracle (truth1).
+//
+// Three known cross-cutting dependency gaps are filtered (and logged if they
+// close), mirroring the file_format corpus test:
+//   - CREATE OR ALTER (preview): parseCreateStmt's OR-prefix parser recognizes
+//     only OR REPLACE, not OR ALTER (owned by create_table.go / parseCreateStmt,
+//     out of this node's writes-scope). create-task examples 13/14 use it.
+//   - $N positional column references inside a COPY transform query
+//     (`AS COPY INTO t FROM (SELECT $1, $2 FROM @s)`): the shared expression
+//     parser does not yet parse a `$<int>` positional column (a pre-existing gap
+//     owned by expr.go/select.go — `SELECT $1 FROM t` fails identically at the
+//     bare level, with or without the PIPE wrapper). create-pipe examples 02/08/
+//     09/10 use it. The PIPE parser correctly delegates the body to parseCopyStmt;
+//     the failure lives entirely in the COPY/expression layer.
+//   - Context statements owned by other DAG nodes (SHOW, SELECT, CREATE
+//     PROCEDURE, CREATE EXTERNAL TABLE) appear interleaved in some corpus files;
+//     only the PIPE/STREAM/TASK statements are asserted here.
+// ---------------------------------------------------------------------------
+
+func TestPipeStreamTask_OfficialCorpus(t *testing.T) {
+	dirs := []struct {
+		dir    string
+		create string // the object keyword after CREATE that this dir owns
+		wantFn func(ast.Node) bool
+	}{
+		{"testdata/official/create-pipe", "PIPE", func(n ast.Node) bool { _, ok := n.(*ast.CreatePipeStmt); return ok }},
+		{"testdata/official/create-stream", "STREAM", func(n ast.Node) bool { _, ok := n.(*ast.CreateStreamStmt); return ok }},
+		{"testdata/official/create-task", "TASK", func(n ast.Node) bool { _, ok := n.(*ast.CreateTaskStmt); return ok }},
+	}
+	for _, d := range dirs {
+		entries, err := os.ReadDir(d.dir)
+		if err != nil {
+			t.Fatalf("read corpus dir %s: %v", d.dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+				continue
+			}
+			path := filepath.Join(d.dir, entry.Name())
+			t.Run(path, func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				assertOwnedCreateParses(t, string(data), d.create, d.wantFn)
+			})
+		}
+	}
+}
+
+// assertOwnedCreateParses parses every statement in sql and, for each `CREATE
+// <obj>` statement matching obj, asserts it parses with no errors to the
+// expected type. Statements owned by other DAG nodes are skipped. OR ALTER
+// preview statements are skipped (and logged if they begin to parse).
+func assertOwnedCreateParses(t *testing.T, sql, obj string, wantFn func(ast.Node) bool) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+
+		// Only assert the CREATE <obj> statements this corpus directory owns.
+		if !strings.HasPrefix(upper, "CREATE") || !createTargetsObject(upper, obj) {
+			continue
+		}
+
+		if orAlterLimited(upper) {
+			// Known dependency limitation (OR ALTER preview): must currently fail
+			// to parse. If it starts parsing, surface that so the filter can drop.
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: OR ALTER statement now parses, drop it from orAlterLimited: %q", text)
+			}
+			continue
+		}
+
+		if dollarPositionalLimited(text) {
+			// Known dependency limitation ($N positional column in a COPY transform
+			// query): must currently fail to parse. If it starts parsing, the
+			// expression-parser gap was closed — surface that so the filter drops.
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: $N positional column now parses, drop it from dollarPositionalLimited: %q", text)
+			}
+			continue
+		}
+
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+			continue
+		}
+		if !wantFn(node) {
+			t.Errorf("statement %q parsed to unexpected type %T", text, node)
+		}
+	}
+}
+
+// dollarPositionalLimited reports whether sql contains a `$<digit>` positional
+// column reference, which the shared expression parser does not yet support (a
+// pre-existing gap inherited by the COPY transform-query parser). Distinguished
+// from `$$...$$` dollar-strings and `$<name>` variables by requiring a digit
+// immediately after the '$'.
+func dollarPositionalLimited(sql string) bool {
+	for i := 0; i+1 < len(sql); i++ {
+		if sql[i] == '$' && sql[i+1] >= '0' && sql[i+1] <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+// createTargetsObject reports whether a CREATE statement (uppercased) targets the
+// given object keyword, accounting for the OR REPLACE / OR ALTER / TEMPORARY-style
+// modifiers that may sit between CREATE and the object keyword. It checks that the
+// object keyword appears as a whole word before the first statement body keyword.
+func createTargetsObject(upper, obj string) bool {
+	// The object keyword must appear, surrounded by spaces, before AS/ON/IF.
+	idx := strings.Index(upper, " "+obj+" ")
+	if idx < 0 {
+		// EXTERNAL TABLE etc. — obj won't be a standalone word; treat as not-owned.
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-pipeline` (v1 DAG **T4.3**) — `CREATE`/`ALTER` for the four data-pipeline objects **PIPE / STREAM / TASK / ALERT**. DROP for these was already merged (drop.go), untouched.

## Embedded bodies — reuse existing parsers (the interesting part)
| Object | Body | Reused parser |
|---|---|---|
| `PIPE` | `AS <copy_into_table>` | `parseCopyStmt` |
| `TASK` | `AS <sql>` | `parseStmt` (+ verbatim `BodyRaw` fallback for scripting/CALL bodies) |
| `ALERT` | `IF (EXISTS (<query>)) THEN <action>` | `parseQueryExpr`/`parseShowStmt` + `parseStmt` (+ `ActionRaw` fallback) |
| `STREAM` | `ON {TABLE\|VIEW\|STAGE\|EXTERNAL TABLE} <name>` + inline `{AT\|BEFORE} (k => <expr>)` | expression parser (no dependency on T5.3) |

Because `parseStmt` doesn't yet parse Snowflake Scripting or `CALL`, TASK/ALERT bodies that can't parse are **captured verbatim** (parsed node nil) via parser snapshot/restore — a pipeline DDL is never rejected on account of its body. Config vocabularies (SCHEDULE/WAREHOUSE/AUTO_INGEST/CONFIG/…) are open-ended `KEY = <value>` pairs (`ast.CopyOption`), mirroring merged STAGE/FILE FORMAT/COPY. ALTER covers every legacy action for all four objects (RESUME/SUSPEND, ADD/REMOVE AFTER, MODIFY AS/WHEN/CONDITION/ACTION, SET/UNSET/TAG, REFRESH).

## Oracle / tests
Triangulation — official docs (authoritative) + legacy ANTLR `create_pipe`/`create_stream`/`create_task`/`create_alert`/`alter_*` + the `create-pipe`/`create-stream`/`create-task` corpora. **103 subtests** (all CREATE/ALTER × embedded bodies × time-travel × negatives + walker integration). `go test ./snowflake/parser/... ./snowflake/ast/...` green; `go vet` clean.

## Divergences (ledger ids 78–82)
- **confirmed** — config options open-ended vs stale legacy enums.
- **confirmed** — embedded TASK/ALERT bodies retain verbatim raw + tolerate nil parsed node (never reject the DDL).
- **flagged** — STREAM options accepted regardless of ON-source kind (semantic layer enforces).
- **flagged (cross-cutting)** — `$N`-in-COPY-transform gap (`expr.go`/`select.go`); affects create-pipe ex 02/08/09/10.
- **flagged (cross-cutting)** — `CREATE OR ALTER` gap (`parseCreateStmt`); affects create-task ex 13/14.

The two cross-cutting gaps are being formalized as dedicated follow-up nodes that block `corpus-closure`.

## Review
Claude lens (`/code-review`) — no blockers. Codex unavailable (out of credits); orchestrator did independent build/test/scope verification.

## Note
Opened by orchestrator from worker's verified commit `d05fd417`. No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)