### PR TITLE
feat(googlesql/parser): expression grammar (expressions node)

### DIFF
--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -28,6 +28,58 @@ const (
 	T_RevokeStmt
 	T_Privilege
 	T_Grantee
+
+	// Expressions (googlesql/expressions node).
+	//
+	// The full GoogleSQL expression tree: the precedence chain
+	// (expression / expression_higher_prec_than_and / and_expression), every
+	// primary form, and the operator / predicate / constructor families. These
+	// mirror the legacy ANTLR expression rules (GoogleSQLParser.g4 §2.17-§2.18),
+	// a hand-port of ZetaSQL.
+	T_Identifier
+	T_PathExpr
+	T_TypeRef
+	T_StarExpr
+	T_Literal
+	T_TypedLiteral
+	T_IntervalExpr
+	T_Parameter
+	T_SystemVariable
+	T_ParenExpr
+	T_UnaryExpr
+	T_BinaryExpr
+	T_CompareExpr
+	T_IsExpr
+	T_InExpr
+	T_BetweenExpr
+	T_LikeExpr
+	T_CaseExpr
+	T_WhenClause
+	T_CastExpr
+	T_ExtractExpr
+	T_FuncCall
+	T_NamedArg
+	T_LambdaExpr
+	T_SequenceArg
+	T_StarModifiers
+	T_ArrayExpr
+	T_StructExpr
+	T_StructFieldExpr
+	T_FieldAccess
+	T_IndexAccess
+	T_ExtensionAccess
+	T_SubqueryExpr
+	T_ExistsExpr
+	T_ArraySubqueryExpr
+	T_NewConstructor
+	T_BracedConstructor
+	T_ReplaceFieldsExpr
+	T_WithExpr
+	T_WindowSpec
+	T_WindowFrame
+	T_OrderItem
+	T_HavingModifier
+	T_ClampedModifier
 )
 
 // String returns a human-readable representation of the tag.
@@ -45,6 +97,94 @@ func (t NodeTag) String() string {
 		return "Privilege"
 	case T_Grantee:
 		return "Grantee"
+	case T_Identifier:
+		return "Identifier"
+	case T_PathExpr:
+		return "PathExpr"
+	case T_TypeRef:
+		return "TypeRef"
+	case T_StarExpr:
+		return "StarExpr"
+	case T_Literal:
+		return "Literal"
+	case T_TypedLiteral:
+		return "TypedLiteral"
+	case T_IntervalExpr:
+		return "IntervalExpr"
+	case T_Parameter:
+		return "Parameter"
+	case T_SystemVariable:
+		return "SystemVariable"
+	case T_ParenExpr:
+		return "ParenExpr"
+	case T_UnaryExpr:
+		return "UnaryExpr"
+	case T_BinaryExpr:
+		return "BinaryExpr"
+	case T_CompareExpr:
+		return "CompareExpr"
+	case T_IsExpr:
+		return "IsExpr"
+	case T_InExpr:
+		return "InExpr"
+	case T_BetweenExpr:
+		return "BetweenExpr"
+	case T_LikeExpr:
+		return "LikeExpr"
+	case T_CaseExpr:
+		return "CaseExpr"
+	case T_WhenClause:
+		return "WhenClause"
+	case T_CastExpr:
+		return "CastExpr"
+	case T_ExtractExpr:
+		return "ExtractExpr"
+	case T_FuncCall:
+		return "FuncCall"
+	case T_NamedArg:
+		return "NamedArg"
+	case T_LambdaExpr:
+		return "LambdaExpr"
+	case T_SequenceArg:
+		return "SequenceArg"
+	case T_StarModifiers:
+		return "StarModifiers"
+	case T_ArrayExpr:
+		return "ArrayExpr"
+	case T_StructExpr:
+		return "StructExpr"
+	case T_StructFieldExpr:
+		return "StructFieldExpr"
+	case T_FieldAccess:
+		return "FieldAccess"
+	case T_IndexAccess:
+		return "IndexAccess"
+	case T_ExtensionAccess:
+		return "ExtensionAccess"
+	case T_SubqueryExpr:
+		return "SubqueryExpr"
+	case T_ExistsExpr:
+		return "ExistsExpr"
+	case T_ArraySubqueryExpr:
+		return "ArraySubqueryExpr"
+	case T_NewConstructor:
+		return "NewConstructor"
+	case T_BracedConstructor:
+		return "BracedConstructor"
+	case T_ReplaceFieldsExpr:
+		return "ReplaceFieldsExpr"
+	case T_WithExpr:
+		return "WithExpr"
+	case T_WindowSpec:
+		return "WindowSpec"
+	case T_WindowFrame:
+		return "WindowFrame"
+	case T_OrderItem:
+		return "OrderItem"
+	case T_HavingModifier:
+		return "HavingModifier"
+	case T_ClampedModifier:
+		return "ClampedModifier"
 	default:
 		return "Unknown"
 	}

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -200,3 +200,909 @@ var (
 	_ Node = (*Privilege)(nil)
 	_ Node = (*Grantee)(nil)
 )
+
+// ===========================================================================
+// Expressions (googlesql/expressions node)
+// ===========================================================================
+//
+// The GoogleSQL expression tree. These node types model the legacy ANTLR
+// expression grammar (GoogleSQLParser.g4 §2.17 precedence chain, §2.18
+// constructors/CASE/CAST/EXTRACT/function calls), itself a hand-port of
+// Google's open-source ZetaSQL reference and the grammar bytebase consumes
+// today. The parser (parser/expr.go) builds these via precedence climbing.
+//
+// Adjudication: the LIVE Cloud Spanner emulator oracle (oracle.md) decides
+// accept/reject for every shared GoogleSQL-core expression form; the ZetaSQL
+// .g4 is the structural hint. Two oracle-confirmed precedence facts are baked
+// into the parser and reflected in these shapes:
+//
+//	P1 (comparison non-associativity). The whole comparison family —
+//	   comparative operators (= != <> < <= > >=), [NOT] LIKE, [NOT] IN,
+//	   [NOT] BETWEEN, IS [NOT] {NULL|TRUE|FALSE|UNKNOWN}, and IS [NOT] DISTINCT
+//	   FROM — is NON-ASSOCIATIVE: `a = b = c`, `1 < 2 < 3`, `x IN (1) IN (2)`,
+//	   `1 IS NULL IS NULL`, `x LIKE 'a' LIKE 'b'`, `1 BETWEEN 0 AND 2 BETWEEN ..`
+//	   all REJECT (oracle: "Syntax error: ..." / "Expression to the left of IS
+//	   must be parenthesized"). The operands of these nodes are therefore the
+//	   next-higher precedence level, never another comparison.
+//
+//	P2 (NOT binds looser than comparison). `NOT a = b` parses as `NOT (a = b)`
+//	   and `NOT a IS NULL` as `NOT (a IS NULL)` (oracle: both accept). Prefix
+//	   NOT's operand spans the whole comparison level (it sits between the
+//	   comparison family and AND in precedence).
+//
+// Subquery seam: GoogleSQL subquery-bearing expressions — `(SELECT …)`,
+// `EXISTS(…)`, `ARRAY(…)`, and IN/comparison RHS subqueries — are recognized
+// here so the expression grammar accepts every oracle-accepted form, but the
+// INNER query is NOT parsed by this node: the query/SELECT grammar belongs to
+// the downstream parser-select node (which depends on this one). The subquery
+// nodes (SubqueryExpr / ExistsExpr / ArraySubqueryExpr) capture the balanced
+// parenthesized source span in RawText and leave Query nil; parser-select fills
+// Query when it lands. See parser/expr.go parseParenOrSubquery.
+
+// BinaryOp enumerates GoogleSQL binary operators that build a left-associative
+// BinaryExpr (arithmetic, bitwise, shift, logical, concat). The comparison
+// family is modeled separately (CompareExpr / IsExpr / InExpr / BetweenExpr /
+// LikeExpr) because it is non-associative (P1).
+type BinaryOp int
+
+const (
+	BinAdd        BinaryOp = iota // +
+	BinSub                        // -
+	BinMul                        // *
+	BinDiv                        // /
+	BinConcat                     // || (BOOL_OR_SYMBOL — string concat / logical-or-style)
+	BinBitOr                      // |  (STROKE_SYMBOL)
+	BinBitXor                     // ^  (CIRCUMFLEX_SYMBOL)
+	BinBitAnd                     // &  (BIT_AND_SYMBOL)
+	BinShiftLeft                  // <<
+	BinShiftRight                 // >>
+	BinAnd                        // AND
+	BinOr                         // OR
+)
+
+// String returns the operator symbol/keyword.
+func (op BinaryOp) String() string {
+	switch op {
+	case BinAdd:
+		return "+"
+	case BinSub:
+		return "-"
+	case BinMul:
+		return "*"
+	case BinDiv:
+		return "/"
+	case BinConcat:
+		return "||"
+	case BinBitOr:
+		return "|"
+	case BinBitXor:
+		return "^"
+	case BinBitAnd:
+		return "&"
+	case BinShiftLeft:
+		return "<<"
+	case BinShiftRight:
+		return ">>"
+	case BinAnd:
+		return "AND"
+	case BinOr:
+		return "OR"
+	default:
+		return "?"
+	}
+}
+
+// UnaryOp enumerates GoogleSQL prefix unary operators (unary_operator + NOT).
+type UnaryOp int
+
+const (
+	UnaryPlus   UnaryOp = iota // +
+	UnaryMinus                 // -
+	UnaryBitNot                // ~ (BITWISE_NOT_OPERATOR)
+	UnaryNot                   // NOT
+)
+
+// String returns the operator symbol/keyword.
+func (op UnaryOp) String() string {
+	switch op {
+	case UnaryPlus:
+		return "+"
+	case UnaryMinus:
+		return "-"
+	case UnaryBitNot:
+		return "~"
+	case UnaryNot:
+		return "NOT"
+	default:
+		return "?"
+	}
+}
+
+// CompareOp enumerates the comparative operators (comparative_operator). These
+// build a non-associative CompareExpr.
+type CompareOp int
+
+const (
+	CmpEq CompareOp = iota // =
+	CmpNe                  // != or <>
+	CmpLt                  // <
+	CmpLe                  // <=
+	CmpGt                  // >
+	CmpGe                  // >=
+)
+
+// String returns the operator symbol.
+func (op CompareOp) String() string {
+	switch op {
+	case CmpEq:
+		return "="
+	case CmpNe:
+		return "!="
+	case CmpLt:
+		return "<"
+	case CmpLe:
+		return "<="
+	case CmpGt:
+		return ">"
+	case CmpGe:
+		return ">="
+	default:
+		return "?"
+	}
+}
+
+// LiteralKind classifies a Literal's value type, mirroring the grammar's
+// literal alternatives (§2.21) that carry no type keyword. Typed-prefix
+// literals (NUMERIC '…', DATE '…', JSON '…', RANGE<…> '…') are modeled by
+// TypedLiteral, not Literal.
+type LiteralKind int
+
+const (
+	// LitNull is the NULL literal (null_literal).
+	LitNull LiteralKind = iota
+	// LitBool is TRUE / FALSE (boolean_literal). Value is the source spelling.
+	LitBool
+	// LitInt is an INTEGER_LITERAL (decimal or 0x-hex). Ival holds the value
+	// (0 on int64 overflow — Value preserves the exact spelling).
+	LitInt
+	// LitFloat is a FLOATING_POINT_LITERAL. Value holds the source spelling.
+	LitFloat
+	// LitString is a STRING_LITERAL (one or more adjacent components, already
+	// concatenated by the parser). Value holds the unquoted content.
+	LitString
+	// LitBytes is a BYTES_LITERAL. Value holds the unquoted, un-prefixed bytes.
+	LitBytes
+)
+
+// String returns a human-readable name for the kind.
+func (k LiteralKind) String() string {
+	switch k {
+	case LitNull:
+		return "NULL"
+	case LitBool:
+		return "BOOL"
+	case LitInt:
+		return "INT"
+	case LitFloat:
+		return "FLOAT"
+	case LitString:
+		return "STRING"
+	case LitBytes:
+		return "BYTES"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primary / leaf expression nodes
+// ---------------------------------------------------------------------------
+
+// Identifier is a single GoogleSQL identifier used as an expression (the
+// grammar's identifier as a primary expression — a column / variable / name
+// reference). Name is the normalized text: a backtick-quoted identifier has its
+// backticks stripped by the lexer; an unquoted identifier or keyword-as-
+// identifier is its source word.
+//
+// A multi-part dotted name (`a.b.c`) is a PathExpr, not an Identifier — but a
+// dotted continuation in an expression is built as repeated FieldAccess over a
+// leading Identifier (matching the grammar's `EHP . identifier` left-recursion),
+// so a bare Identifier is always a single component here.
+type Identifier struct {
+	Name string
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *Identifier) Tag() NodeTag { return T_Identifier }
+
+// PathExpr is a dotted identifier path used where the grammar requires a
+// path_expression as a whole (function names, sequence args, generalized-
+// extension `(path)`, system-variable paths). Parts holds each normalized
+// component (>= 1). General dotted field access on an arbitrary expression is
+// FieldAccess, not PathExpr; PathExpr is used only in the grammar positions that
+// take a path_expression token-sequence directly.
+type PathExpr struct {
+	Parts []string
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *PathExpr) Tag() NodeTag { return T_PathExpr }
+
+// String renders the path by joining its normalized parts with '.'. It does NOT
+// re-quote; it is a debug/representation helper, not a deparser.
+func (n *PathExpr) String() string {
+	out := ""
+	for i, part := range n.Parts {
+		if i > 0 {
+			out += "."
+		}
+		out += part
+	}
+	return out
+}
+
+// TypeRef is a reference to a parsed GoogleSQL data type in an expression
+// position (CAST target, ARRAY<T>[…] element type, STRUCT<…>(…) / NEW type /
+// braced-struct type). The `type` grammar itself is owned by the parser's
+// `types` node (parser.DataType), which is a parser-package value type and not
+// an ast.Node — so to keep the ast package free of a parser dependency, TypeRef
+// stores only the rendered type text (parser.DataType.String(), which
+// round-trips) plus its source span. Downstream consumers that need the
+// structured type re-parse Text via parser.ParseDataType; bytebase's query-span
+// path does not inspect types, so the rendered text is sufficient here.
+type TypeRef struct {
+	Text string // rendered type (e.g. "INT64", "ARRAY<STRUCT<x INT64>>")
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *TypeRef) Tag() NodeTag { return T_TypeRef }
+
+// StarExpr is a `*` used as an expression — only valid as a bare function
+// argument (the grammar's MULTIPLY_OPERATOR alternative in
+// function_call_expression_with_clauses_suffix, e.g. COUNT(*)). It is NOT a
+// general expression primary; the parser admits it only in argument position.
+// Modifiers carries an optional EXCEPT/REPLACE star_modifiers (rare in
+// argument position; nil normally).
+type StarExpr struct {
+	Modifiers *StarModifiers // optional; nil for a bare *
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *StarExpr) Tag() NodeTag { return T_StarExpr }
+
+// StarModifiers carries the EXCEPT(...) / REPLACE(...) suffixes that can follow
+// a star (star_modifiers). Except holds the EXCEPT column names; Replace holds
+// the REPLACE items (each `expr AS name`). This node is defined here for the
+// argument-position StarExpr; the SELECT-list star reuses it.
+type StarModifiers struct {
+	Except  []string           // EXCEPT (a, b, ...) column names
+	Replace []*StructFieldExpr // REPLACE (expr AS name, ...) — reuses the aliased-expr shape
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *StarModifiers) Tag() NodeTag { return T_StarModifiers }
+
+// Literal is a NULL / boolean / integer / float / string / bytes literal that
+// carries no type-name prefix (§2.21). Value is the source spelling (unquoted
+// for string/bytes); Ival is the integer value for LitInt.
+type Literal struct {
+	Kind  LiteralKind
+	Value string
+	Ival  int64 // for LitInt
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *Literal) Tag() NodeTag { return T_Literal }
+
+// TypedLiteral is a type-prefixed literal: NUMERIC/DECIMAL/BIGNUMERIC/BIGDECIMAL
+// '…', JSON '…', DATE/TIME/DATETIME/TIMESTAMP '…', or RANGE<type> '…'
+// (numeric_literal / bignumeric_literal / json_literal / date_or_time_literal /
+// range_literal). TypeKeyword is the leading type word (e.g. "NUMERIC", "DATE",
+// "RANGE"); RangeType is the parsed element type for a RANGE literal (nil
+// otherwise); Value is the unquoted string body.
+type TypedLiteral struct {
+	TypeKeyword string
+	Value       string // the unquoted string-literal body
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *TypedLiteral) Tag() NodeTag { return T_TypedLiteral }
+
+// IntervalExpr is an interval value expression:
+// `INTERVAL expr datepart [TO datepart]` (interval_expression). Value is the
+// magnitude expression; From / To are the date-part identifier spellings (To is
+// "" for the single-part form).
+type IntervalExpr struct {
+	Value Node
+	From  string // leading datepart (e.g. "DAY", "YEAR")
+	To    string // trailing datepart for `… TO …`; "" if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *IntervalExpr) Tag() NodeTag { return T_IntervalExpr }
+
+// Parameter is a query parameter: a named parameter `@name`
+// (named_parameter_expression) or a positional `?` (QUESTION_SYMBOL). Name holds
+// the parameter name for the named form, "" for positional.
+type Parameter struct {
+	Name       string // "" for positional '?'
+	Positional bool   // true for '?'
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *Parameter) Tag() NodeTag { return T_Parameter }
+
+// SystemVariable is a system-variable reference `@@path`
+// (system_variable_expression: ATAT path_expression). Parts holds the dotted
+// path components after the `@@` (>= 1).
+type SystemVariable struct {
+	Parts []string
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *SystemVariable) Tag() NodeTag { return T_SystemVariable }
+
+// ParenExpr is a parenthesized expression `( expr )`
+// (parenthesized_expression_not_a_query). A parenthesized QUERY is a
+// SubqueryExpr instead; the parser disambiguates by the token after '('.
+type ParenExpr struct {
+	Expr Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ParenExpr) Tag() NodeTag { return T_ParenExpr }
+
+// ---------------------------------------------------------------------------
+// Operator nodes
+// ---------------------------------------------------------------------------
+
+// UnaryExpr is a prefix unary operation `op expr` (unary_operator EHP, or
+// NOT EHP). For NOT, Expr spans the whole comparison level (P2).
+type UnaryExpr struct {
+	Op   UnaryOp
+	Expr Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *UnaryExpr) Tag() NodeTag { return T_UnaryExpr }
+
+// BinaryExpr is a left-associative binary operation `left op right` for the
+// arithmetic / bitwise / shift / logical / concat operators. (The comparison
+// family is non-associative and uses CompareExpr/IsExpr/etc., not BinaryExpr.)
+type BinaryExpr struct {
+	Op    BinaryOp
+	Left  Node
+	Right Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *BinaryExpr) Tag() NodeTag { return T_BinaryExpr }
+
+// CompareExpr is a single comparative operation `left op right` for
+// = != <> < <= > >= (comparative_operator). NON-ASSOCIATIVE (P1): Left and
+// Right are both the next-higher precedence level, never another comparison.
+type CompareExpr struct {
+	Op    CompareOp
+	Left  Node
+	Right Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *CompareExpr) Tag() NodeTag { return T_CompareExpr }
+
+// IsExpr is `expr IS [NOT] {NULL | TRUE | FALSE | UNKNOWN}` or
+// `expr IS [NOT] DISTINCT FROM expr` (is_operator / distinct_operator). Not
+// flags the NOT. For the IS-predicate form, Pred holds the predicate keyword
+// ("NULL", "TRUE", "FALSE", "UNKNOWN") and DistinctFrom is nil. For the DISTINCT
+// FROM form, DistinctFrom is the right operand and Pred is "".
+type IsExpr struct {
+	Expr         Node
+	Not          bool
+	Pred         string // "NULL" | "TRUE" | "FALSE" | "UNKNOWN"; "" for DISTINCT FROM
+	DistinctFrom Node   // non-nil for IS [NOT] DISTINCT FROM expr
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *IsExpr) Tag() NodeTag { return T_IsExpr }
+
+// InExpr is `expr [NOT] IN <rhs>` (in_operator). Exactly one RHS form is set:
+// Values (a parenthesized expression list — one or more), Unnest (an
+// UNNEST(...) call), or Subquery (a parenthesized query). Hint carries an
+// optional `@{...}` between IN and a non-UNNEST RHS (the grammar rejects a hint
+// before UNNEST).
+type InExpr struct {
+	Expr     Node
+	Not      bool
+	Values   []Node // parenthesized expression list (>= 1); nil for the other forms
+	Unnest   Node   // UNNEST(...) RHS; nil otherwise
+	Subquery Node   // parenthesized-query RHS (SubqueryExpr); nil otherwise
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *InExpr) Tag() NodeTag { return T_InExpr }
+
+// BetweenExpr is `expr [NOT] BETWEEN low AND high` (between_operator). low and
+// high are at the EHP (higher-than-AND) level, so a bare OR inside is rejected
+// (the grammar's "Expression in BETWEEN must be parenthesized" alt).
+type BetweenExpr struct {
+	Expr Node
+	Low  Node
+	High Node
+	Not  bool
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *BetweenExpr) Tag() NodeTag { return T_BetweenExpr }
+
+// LikeExpr is `expr [NOT] LIKE <rhs>` (like_operator). The plain form sets
+// Pattern. The quantified form (`LIKE ANY|SOME|ALL ...`) sets Quantifier and one
+// of QuantValues (parenthesized list), QuantUnnest (UNNEST), or QuantSubquery.
+type LikeExpr struct {
+	Expr          Node
+	Not           bool
+	Pattern       Node   // plain `LIKE pattern`; nil for the quantified form
+	Quantifier    string // "ANY" | "SOME" | "ALL"; "" for the plain form
+	QuantValues   []Node // quantified list RHS
+	QuantUnnest   Node   // quantified UNNEST RHS
+	QuantSubquery Node   // quantified parenthesized-query RHS
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *LikeExpr) Tag() NodeTag { return T_LikeExpr }
+
+// ---------------------------------------------------------------------------
+// CASE / CAST / EXTRACT
+// ---------------------------------------------------------------------------
+
+// CaseExpr is a CASE expression (case_expression). Operand is non-nil for the
+// simple form (`CASE x WHEN …`) and nil for the searched form (`CASE WHEN …`).
+// Whens has one or more branches; Else is the optional ELSE result (nil if
+// absent).
+type CaseExpr struct {
+	Operand Node          // nil for searched CASE
+	Whens   []*WhenClause // >= 1
+	Else    Node          // nil if no ELSE
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *CaseExpr) Tag() NodeTag { return T_CaseExpr }
+
+// WhenClause is one `WHEN cond THEN result` branch of a CaseExpr. For a simple
+// CASE, Cond is the value compared against the operand.
+type WhenClause struct {
+	Cond   Node
+	Result Node
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *WhenClause) Tag() NodeTag { return T_WhenClause }
+
+// CastExpr is `CAST(expr AS type [FORMAT fmt [AT TIME ZONE tz]])` or the
+// `SAFE_CAST(...)` variant (cast_expression). Safe flags SAFE_CAST. Type is the
+// target type. Format / TimeZone are the optional FORMAT and AT TIME ZONE
+// expressions (nil if absent). Type is carried as a Node wrapper produced by the
+// parser (the parser embeds its *DataType in a typeNode); downstream consumers
+// read the rendered type via the parser, so Type is opaque here.
+type CastExpr struct {
+	Expr     Node
+	Type     *TypeRef // the target type (rendered); nil only on a malformed parse
+	Safe     bool     // SAFE_CAST
+	Format   Node     // optional FORMAT expr; nil if absent
+	TimeZone Node     // optional AT TIME ZONE expr (only with FORMAT); nil if absent
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *CastExpr) Tag() NodeTag { return T_CastExpr }
+
+// ExtractExpr is `EXTRACT(part FROM expr [AT TIME ZONE tz])`
+// (extract_expression). Part is the part expression (e.g. YEAR, or
+// DATE(...)); From is the source; TimeZone is the optional AT TIME ZONE expr.
+type ExtractExpr struct {
+	Part     Node
+	From     Node
+	TimeZone Node // optional; nil if absent
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *ExtractExpr) Tag() NodeTag { return T_ExtractExpr }
+
+// ---------------------------------------------------------------------------
+// Function calls, arguments, window
+// ---------------------------------------------------------------------------
+
+// FuncCall is a function-call expression with all its clauses
+// (function_call_expression_with_clauses + suffix). Name is the function name
+// (a path, or a keyword-as-function-name like IF/GROUPING/LEFT/RIGHT/COLLATE/
+// RANGE rendered into Name.Parts). The modifier fields mirror the suffix grammar.
+type FuncCall struct {
+	Name          *PathExpr        // function name path
+	Args          []Node           // positional / named / lambda / sequence args; a bare '*' is a StarExpr
+	Distinct      bool             // DISTINCT before the args
+	NullHandling  string           // "IGNORE NULLS" | "RESPECT NULLS"; "" if absent
+	Having        *HavingModifier  // HAVING MAX/MIN expr [group-by]; nil if absent
+	Clamped       *ClampedModifier // CLAMPED BETWEEN low AND high; nil if absent
+	WithReport    bool             // WITH REPORT (...) present
+	OrderBy       []*OrderItem     // trailing ORDER BY inside the call (aggregate ordering)
+	Limit         Node             // trailing LIMIT expr; nil if absent
+	LimitOffset   Node             // trailing OFFSET expr (only with Limit); nil if absent
+	WithGroupRows bool             // WITH GROUP ROWS present
+	Over          *WindowSpec      // OVER window; nil if not a window call
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *FuncCall) Tag() NodeTag { return T_FuncCall }
+
+// HavingModifier is the aggregate `HAVING MAX expr` / `HAVING MIN expr <group>`
+// modifier (opt_having_or_group_by_modifier). IsMax selects MAX vs MIN; Expr is
+// the having expression. (The MIN form's trailing group-by is rare and its items
+// are not retained beyond Expr in this node — the modifier's presence is the
+// load-bearing fact for parse parity.)
+type HavingModifier struct {
+	IsMax bool
+	Expr  Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *HavingModifier) Tag() NodeTag { return T_HavingModifier }
+
+// ClampedModifier is the differential-privacy `CLAMPED BETWEEN low AND high`
+// modifier (clamped_between_modifier).
+type ClampedModifier struct {
+	Low  Node
+	High Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ClampedModifier) Tag() NodeTag { return T_ClampedModifier }
+
+// NamedArg is a named function argument `name => value` (named_argument). Value
+// is the argument expression (which may itself be a LambdaExpr).
+type NamedArg struct {
+	Name  string
+	Value Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *NamedArg) Tag() NodeTag { return T_NamedArg }
+
+// LambdaExpr is a lambda function argument `params -> body` (lambda_argument).
+// Params holds the parameter identifier spellings (empty for the `() -> body`
+// form). Body is the lambda body expression.
+type LambdaExpr struct {
+	Params []string
+	Body   Node
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *LambdaExpr) Tag() NodeTag { return T_LambdaExpr }
+
+// SequenceArg is the `SEQUENCE path` function argument (sequence_arg). Path is
+// the sequence name path.
+type SequenceArg struct {
+	Path *PathExpr
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *SequenceArg) Tag() NodeTag { return T_SequenceArg }
+
+// WindowSpec is an OVER window specification (over_clause + window_specification):
+// either a named window reference (Name set, all else empty) or an inline spec
+// `( [name] [PARTITION BY …] [ORDER BY …] [frame] )`.
+type WindowSpec struct {
+	Name        string       // named window reference, or the leading name of an inline spec; "" if none
+	PartitionBy []Node       // PARTITION BY expressions
+	OrderBy     []*OrderItem // ORDER BY items
+	Frame       *WindowFrame // window frame; nil if absent
+	Inline      bool         // true if the spec was a parenthesized inline spec (vs a bare name reference)
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *WindowSpec) Tag() NodeTag { return T_WindowSpec }
+
+// OrderItem is one `expr [COLLATE c] [ASC|DESC] [NULLS FIRST|LAST]` ordering
+// element (ordering_expression), used in window ORDER BY and aggregate ORDER BY.
+type OrderItem struct {
+	Expr       Node
+	Collate    Node  // optional COLLATE expr; nil if absent
+	Desc       bool  // true for DESC
+	HasDir     bool  // true if ASC or DESC was given explicitly
+	NullsFirst *bool // nil = unspecified, true = NULLS FIRST, false = NULLS LAST
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *OrderItem) Tag() NodeTag { return T_OrderItem }
+
+// WindowFrameKind enumerates the frame unit (frame_unit).
+type WindowFrameKind int
+
+const (
+	FrameRows  WindowFrameKind = iota // ROWS
+	FrameRange                        // RANGE
+)
+
+// WindowBoundKind enumerates a frame bound shape (window_frame_bound).
+type WindowBoundKind int
+
+const (
+	BoundUnboundedPreceding WindowBoundKind = iota // UNBOUNDED PRECEDING
+	BoundUnboundedFollowing                        // UNBOUNDED FOLLOWING
+	BoundCurrentRow                                // CURRENT ROW
+	BoundPreceding                                 // expr PRECEDING
+	BoundFollowing                                 // expr FOLLOWING
+)
+
+// WindowFrame is a `ROWS|RANGE { <bound> | BETWEEN <bound> AND <bound> }` clause
+// (opt_window_frame_clause). Between is true for the BETWEEN form (Start + End);
+// for the single-bound form only Start is meaningful.
+type WindowFrame struct {
+	Kind    WindowFrameKind
+	Between bool
+	Start   WindowBound
+	End     WindowBound // meaningful only when Between
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *WindowFrame) Tag() NodeTag { return T_WindowFrame }
+
+// WindowBound is one end of a frame (window_frame_bound). Offset is the `expr`
+// for BoundPreceding/BoundFollowing (nil otherwise). Not a Node.
+type WindowBound struct {
+	Kind   WindowBoundKind
+	Offset Node // for BoundPreceding/BoundFollowing
+}
+
+// ---------------------------------------------------------------------------
+// Constructors: array / struct / new / braced / replace-fields / with
+// ---------------------------------------------------------------------------
+
+// ArrayExpr is an array constructor: `[…]`, `ARRAY[…]`, or `ARRAY<T>[…]`
+// (array_constructor). Elements holds zero or more element expressions; ElemType
+// is the optional explicit element type (the T in ARRAY<T>[…]), wrapped as a
+// Node by the parser (nil if absent). HasArrayKeyword records whether the ARRAY
+// keyword was present (vs the bare `[…]` form).
+type ArrayExpr struct {
+	Elements        []Node
+	ElemType        *TypeRef // explicit element type (ARRAY<T>[…]); nil otherwise
+	HasArrayKeyword bool
+	Loc             Loc
+}
+
+// Tag implements Node.
+func (n *ArrayExpr) Tag() NodeTag { return T_ArrayExpr }
+
+// StructExpr is a struct constructor (struct_constructor). Three source forms map
+// here: the keyword form `STRUCT(args)` / `STRUCT<…>(args)` (HasStruct true,
+// Type optionally set), and the bare tuple form `(e1, e2, …)` with two or more
+// elements (HasStruct false, Type nil). Fields holds each `expr [AS alias]` arg.
+type StructExpr struct {
+	HasStruct bool               // STRUCT keyword present
+	Type      *TypeRef           // explicit STRUCT<…> type; nil otherwise
+	Fields    []*StructFieldExpr // the constructor args (>= 0 for STRUCT(), >= 2 for the bare tuple)
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *StructExpr) Tag() NodeTag { return T_StructExpr }
+
+// StructFieldExpr is one `expr [AS alias]` constructor argument
+// (struct_constructor_arg) — reused for array/struct REPLACE items. Alias is ""
+// when no `AS name` was given.
+type StructFieldExpr struct {
+	Value Node
+	Alias string // "" if no AS alias
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *StructFieldExpr) Tag() NodeTag { return T_StructFieldExpr }
+
+// NewConstructor is a proto constructor `NEW type ( args )` (new_constructor) or
+// the braced form `NEW type { … }` (braced_new_constructor). Type is the proto
+// type name (wraps a parsed type_name as a Node). Args holds the parenthesized
+// args; Braced holds the braced constructor (one of Args/Braced is set).
+type NewConstructor struct {
+	Type   *TypeRef           // the proto type_name (rendered)
+	Args   []*StructFieldExpr // parenthesized form args (each `expr [AS id | AS (path)]`)
+	Braced *BracedConstructor // braced form; nil for the parenthesized form
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *NewConstructor) Tag() NodeTag { return T_NewConstructor }
+
+// BracedConstructor is a proto braced constructor `{ field… }` (braced_constructor
+// / struct_braced_constructor). Type is the optional leading STRUCT<…> / struct
+// type for struct_braced_constructor (nil for the proto braced_constructor and
+// the bare `STRUCT {…}` no-type form). The field internals are retained as raw
+// field expressions in Fields (each a `path : value` or `path {…}`); the exact
+// proto-field shape is not consumed by bytebase, so fields capture the value
+// expressions for walk/coverage without a bespoke per-field node.
+type BracedConstructor struct {
+	Type   *TypeRef // optional struct type (struct_braced_constructor); nil otherwise
+	Fields []Node   // field value expressions (best-effort capture for walking)
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *BracedConstructor) Tag() NodeTag { return T_BracedConstructor }
+
+// ReplaceFieldsExpr is `REPLACE_FIELDS(expr, value AS path, …)`
+// (replace_fields_expression). Expr is the base; Items holds each replacement
+// (`expr AS generalized-path`).
+type ReplaceFieldsExpr struct {
+	Expr  Node
+	Items []*StructFieldExpr // each `value AS path` (Alias holds the rendered path)
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ReplaceFieldsExpr) Tag() NodeTag { return T_ReplaceFieldsExpr }
+
+// WithExpr is the inline `WITH(name AS expr, …, body)` expression
+// (with_expression). Vars holds the `name AS expr` bindings; Body is the final
+// result expression.
+type WithExpr struct {
+	Vars []*StructFieldExpr // each `name AS expr` (Alias holds the var name, Value the bound expr)
+	Body Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *WithExpr) Tag() NodeTag { return T_WithExpr }
+
+// ---------------------------------------------------------------------------
+// Access (field / index / extension) and subqueries
+// ---------------------------------------------------------------------------
+
+// FieldAccess is dotted field access on an expression `expr . field`
+// (EHP DOT identifier). Field is the accessed field name (normalized).
+type FieldAccess struct {
+	Expr  Node
+	Field string
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *FieldAccess) Tag() NodeTag { return T_FieldAccess }
+
+// IndexAccess is array/struct subscript access `expr [ index ]`
+// (EHP LS_BRACKET expression RS_BRACKET). Index is the subscript expression
+// (which may itself be an OFFSET(...)/ORDINAL(...)/SAFE_OFFSET/SAFE_ORDINAL
+// function call — those are ordinary FuncCall nodes, not special syntax).
+type IndexAccess struct {
+	Expr  Node
+	Index Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *IndexAccess) Tag() NodeTag { return T_IndexAccess }
+
+// ExtensionAccess is proto-extension field access `expr . ( path )`
+// (EHP DOT '(' path_expression ')'). Path is the parenthesized extension path.
+type ExtensionAccess struct {
+	Expr Node
+	Path *PathExpr
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ExtensionAccess) Tag() NodeTag { return T_ExtensionAccess }
+
+// SubqueryExpr is a parenthesized query used as a scalar expression
+// `( SELECT … )` (parenthesized_query in expression position). Query is the
+// parsed inner query — left nil by the expressions node (the query grammar is
+// owned by parser-select); RawText holds the inner query source (without the
+// outer parens) so parser-select can fill Query later and so deparse/round-trip
+// works in the interim.
+type SubqueryExpr struct {
+	Query   Node   // nil until parser-select wires the query grammar
+	RawText string // inner query source (between the parens)
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *SubqueryExpr) Tag() NodeTag { return T_SubqueryExpr }
+
+// ExistsExpr is `EXISTS [hint] ( query )` (expression_subquery_with_keyword).
+// Query is the parsed inner query (nil until parser-select); RawText holds the
+// inner source.
+type ExistsExpr struct {
+	Query   Node
+	RawText string
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *ExistsExpr) Tag() NodeTag { return T_ExistsExpr }
+
+// ArraySubqueryExpr is `ARRAY ( query )` (expression_subquery_with_keyword).
+// Query is the parsed inner query (nil until parser-select); RawText holds the
+// inner source.
+type ArraySubqueryExpr struct {
+	Query   Node
+	RawText string
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *ArraySubqueryExpr) Tag() NodeTag { return T_ArraySubqueryExpr }
+
+// Compile-time assertions that the expression node types satisfy Node.
+var (
+	_ Node = (*Identifier)(nil)
+	_ Node = (*PathExpr)(nil)
+	_ Node = (*TypeRef)(nil)
+	_ Node = (*StarExpr)(nil)
+	_ Node = (*StarModifiers)(nil)
+	_ Node = (*Literal)(nil)
+	_ Node = (*TypedLiteral)(nil)
+	_ Node = (*IntervalExpr)(nil)
+	_ Node = (*Parameter)(nil)
+	_ Node = (*SystemVariable)(nil)
+	_ Node = (*ParenExpr)(nil)
+	_ Node = (*UnaryExpr)(nil)
+	_ Node = (*BinaryExpr)(nil)
+	_ Node = (*CompareExpr)(nil)
+	_ Node = (*IsExpr)(nil)
+	_ Node = (*InExpr)(nil)
+	_ Node = (*BetweenExpr)(nil)
+	_ Node = (*LikeExpr)(nil)
+	_ Node = (*CaseExpr)(nil)
+	_ Node = (*WhenClause)(nil)
+	_ Node = (*CastExpr)(nil)
+	_ Node = (*ExtractExpr)(nil)
+	_ Node = (*FuncCall)(nil)
+	_ Node = (*NamedArg)(nil)
+	_ Node = (*LambdaExpr)(nil)
+	_ Node = (*SequenceArg)(nil)
+	_ Node = (*WindowSpec)(nil)
+	_ Node = (*WindowFrame)(nil)
+	_ Node = (*OrderItem)(nil)
+	_ Node = (*HavingModifier)(nil)
+	_ Node = (*ClampedModifier)(nil)
+	_ Node = (*ArrayExpr)(nil)
+	_ Node = (*StructExpr)(nil)
+	_ Node = (*StructFieldExpr)(nil)
+	_ Node = (*NewConstructor)(nil)
+	_ Node = (*BracedConstructor)(nil)
+	_ Node = (*ReplaceFieldsExpr)(nil)
+	_ Node = (*WithExpr)(nil)
+	_ Node = (*FieldAccess)(nil)
+	_ Node = (*IndexAccess)(nil)
+	_ Node = (*ExtensionAccess)(nil)
+	_ Node = (*SubqueryExpr)(nil)
+	_ Node = (*ExistsExpr)(nil)
+	_ Node = (*ArraySubqueryExpr)(nil)
+)

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -6,13 +6,128 @@ package ast
 // for each child. This function is generated from parsenodes.go and node.go.
 func walkChildren(v Visitor, node Node) {
 	switch n := node.(type) {
+	case *ArrayExpr:
+		walkNodes(v, n.Elements)
+		if n.ElemType != nil {
+			Walk(v, n.ElemType)
+		}
+	case *ArraySubqueryExpr:
+		Walk(v, n.Query)
+	case *BetweenExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Low)
+		Walk(v, n.High)
+	case *BinaryExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *BracedConstructor:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		walkNodes(v, n.Fields)
+	case *CaseExpr:
+		Walk(v, n.Operand)
+		for _, c := range n.Whens {
+			Walk(v, c)
+		}
+		Walk(v, n.Else)
+	case *CastExpr:
+		Walk(v, n.Expr)
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		Walk(v, n.Format)
+		Walk(v, n.TimeZone)
+	case *ClampedModifier:
+		Walk(v, n.Low)
+		Walk(v, n.High)
+	case *CompareExpr:
+		Walk(v, n.Left)
+		Walk(v, n.Right)
+	case *ExistsExpr:
+		Walk(v, n.Query)
+	case *ExtensionAccess:
+		Walk(v, n.Expr)
+		if n.Path != nil {
+			Walk(v, n.Path)
+		}
+	case *ExtractExpr:
+		Walk(v, n.Part)
+		Walk(v, n.From)
+		Walk(v, n.TimeZone)
+	case *FieldAccess:
+		Walk(v, n.Expr)
 	case *File:
 		walkNodes(v, n.Stmts)
+	case *FuncCall:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		walkNodes(v, n.Args)
+		if n.Having != nil {
+			Walk(v, n.Having)
+		}
+		if n.Clamped != nil {
+			Walk(v, n.Clamped)
+		}
+		for _, c := range n.OrderBy {
+			Walk(v, c)
+		}
+		Walk(v, n.Limit)
+		Walk(v, n.LimitOffset)
+		if n.Over != nil {
+			Walk(v, n.Over)
+		}
 	case *GrantStmt:
 		for _, c := range n.Privileges {
 			Walk(v, c)
 		}
 		for _, c := range n.Grantees {
+			Walk(v, c)
+		}
+	case *HavingModifier:
+		Walk(v, n.Expr)
+	case *InExpr:
+		Walk(v, n.Expr)
+		walkNodes(v, n.Values)
+		Walk(v, n.Unnest)
+		Walk(v, n.Subquery)
+	case *IndexAccess:
+		Walk(v, n.Expr)
+		Walk(v, n.Index)
+	case *IntervalExpr:
+		Walk(v, n.Value)
+	case *IsExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.DistinctFrom)
+	case *LambdaExpr:
+		Walk(v, n.Body)
+	case *LikeExpr:
+		Walk(v, n.Expr)
+		Walk(v, n.Pattern)
+		walkNodes(v, n.QuantValues)
+		Walk(v, n.QuantUnnest)
+		Walk(v, n.QuantSubquery)
+	case *NamedArg:
+		Walk(v, n.Value)
+	case *NewConstructor:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		for _, c := range n.Args {
+			Walk(v, c)
+		}
+		if n.Braced != nil {
+			Walk(v, n.Braced)
+		}
+	case *OrderItem:
+		Walk(v, n.Expr)
+		Walk(v, n.Collate)
+	case *ParenExpr:
+		Walk(v, n.Expr)
+	case *ReplaceFieldsExpr:
+		Walk(v, n.Expr)
+		for _, c := range n.Items {
 			Walk(v, c)
 		}
 	case *RevokeStmt:
@@ -22,5 +137,46 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Grantees {
 			Walk(v, c)
 		}
+	case *SequenceArg:
+		if n.Path != nil {
+			Walk(v, n.Path)
+		}
+	case *StarExpr:
+		if n.Modifiers != nil {
+			Walk(v, n.Modifiers)
+		}
+	case *StarModifiers:
+		for _, c := range n.Replace {
+			Walk(v, c)
+		}
+	case *StructExpr:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		for _, c := range n.Fields {
+			Walk(v, c)
+		}
+	case *StructFieldExpr:
+		Walk(v, n.Value)
+	case *SubqueryExpr:
+		Walk(v, n.Query)
+	case *UnaryExpr:
+		Walk(v, n.Expr)
+	case *WhenClause:
+		Walk(v, n.Cond)
+		Walk(v, n.Result)
+	case *WindowSpec:
+		walkNodes(v, n.PartitionBy)
+		for _, c := range n.OrderBy {
+			Walk(v, c)
+		}
+		if n.Frame != nil {
+			Walk(v, n.Frame)
+		}
+	case *WithExpr:
+		for _, c := range n.Vars {
+			Walk(v, c)
+		}
+		Walk(v, n.Body)
 	}
 }

--- a/googlesql/parser/expr.go
+++ b/googlesql/parser/expr.go
@@ -1,0 +1,2664 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is the `expressions` DAG node. It implements GoogleSQL's full
+// expression grammar — the precedence chain (expression /
+// expression_higher_prec_than_and / and_expression), every primary form, the
+// operator / predicate / constructor families, function calls with all their
+// clauses, CASE / CAST / EXTRACT, array / struct constructors, field & array
+// access, INTERVAL, AT TIME ZONE, named arguments, lambdas, and the subquery
+// keywords (ARRAY(…), EXISTS(…), parenthesized query) — as a hand-written
+// recursive-descent + precedence-climbing parser over the token stream,
+// producing ast.Node expression trees.
+//
+// Legacy ZetaSQL ANTLR rules (GoogleSQLParser.g4 §2.17 / §2.18), a hand-port of
+// Google's open-source GoogleSQL reference. The implementation is adjudicated
+// against the LIVE Cloud Spanner emulator oracle (oracle.md), not the literal
+// ANTLR alternative ordering — ANTLR's left-recursive alternative order for the
+// one big `expression_higher_prec_than_and` rule does NOT reflect operator
+// precedence (it is a bison-port artifact; the real precedence lives in the
+// referenced bison %left/%nonassoc declarations and the official GoogleSQL
+// operator-precedence table). This parser uses standard precedence climbing,
+// verified against the emulator. Two oracle-confirmed precedence facts:
+//
+//	P1 — the comparison family is NON-ASSOCIATIVE. After one comparison-family
+//	     operator (comparative / [NOT] LIKE / [NOT] IN / [NOT] BETWEEN /
+//	     IS [NOT] {NULL|TRUE|FALSE|UNKNOWN} / IS [NOT] DISTINCT FROM) you may not
+//	     chain another at the same level: `a = b = c`, `1 < 2 < 3`,
+//	     `x IN (1) IN (2)`, `1 IS NULL IS NULL`, `'a' LIKE 'b' LIKE 'c'`,
+//	     `1 BETWEEN 0 AND 2 BETWEEN 0 AND 1` all REJECT. (Oracle: "Syntax error"
+//	     / "Expression to the left of IS must be parenthesized".)
+//	P2 — prefix NOT binds LOOSER than comparison. `NOT a = b` is `NOT (a = b)`,
+//	     `NOT a IS NULL` is `NOT (a IS NULL)` (oracle: both accept). NOT sits
+//	     between the comparison level and AND in precedence.
+
+// Binding powers for precedence climbing (lowest → highest). bpCompare is the
+// non-associative comparison-family level; it is handled specially in the loop
+// (it never recurses back into another comparison). bpNot is the prefix-NOT
+// level, between comparison and AND (P2).
+const (
+	bpNone    = iota
+	bpOr      // OR
+	bpAnd     // AND
+	bpNot     // NOT (prefix) — P2
+	bpCompare // = != <> < <= > >=, LIKE, IN, BETWEEN, IS, DISTINCT (non-assoc, P1)
+	bpBitOr   // |
+	bpBitXor  // ^
+	bpBitAnd  // &
+	bpConcat  // ||  (BOOL_OR_SYMBOL)
+	bpShift   // << >>
+	bpAdd     // + -
+	bpMul     // * /
+	bpUnary   // unary + - ~
+	bpAccess  // postfix . [] .(path)
+)
+
+// ParseExpression parses a complete GoogleSQL expression from a standalone
+// string, returning the ast.Node and any ParseErrors. Trailing tokens after the
+// expression are reported as an error (the expression is still returned). It is
+// the string-input counterpart of parseExpr, for tests and callers (and the
+// differential oracle harness) that hold an expression string rather than a
+// token stream. Mirrors ParseDataType / snowflake's parser entry points.
+func ParseExpression(input string) (ast.Node, []ParseError) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+
+	node, err := p.parseExpr()
+	if err != nil {
+		return nil, errToSlice(err)
+	}
+	if p.cur.Type != tokEOF {
+		text := p.cur.Str
+		if text == "" {
+			text = TokenName(p.cur.Type)
+		}
+		return node, []ParseError{{Loc: p.cur.Loc, Msg: "unexpected token after expression: " + text}}
+	}
+	// Surface any best-effort errors collected during the parse (e.g. the
+	// grammar's notify-style "SELECT as a query argument" alternatives, which
+	// parse a tree but flag a diagnostic).
+	return node, p.errors
+}
+
+// errToSlice converts a parse error into the []ParseError result shape.
+func errToSlice(err error) []ParseError {
+	if pe, ok := err.(*ParseError); ok {
+		return []ParseError{*pe}
+	}
+	return []ParseError{{Msg: err.Error()}}
+}
+
+// ---------------------------------------------------------------------------
+// Precedence-climbing core
+// ---------------------------------------------------------------------------
+
+// parseExpr is the expression entry point. It parses a full `expression`,
+// lowest precedence first: OR. The precedence is layered as explicit recursive
+// descents for the bands where associativity matters distinctly —
+//
+//	parseExpr → OR (left-assoc loop)
+//	          → AND (left-assoc loop)
+//	          → NOT (prefix, P2)
+//	          → comparison family (NON-associative single step, P1)
+//	          → bitwise/shift/arithmetic (left-assoc precedence-climbing loop)
+//	          → unary prefix → primary → postfix access
+//
+// — so the comparison family is parsed by exactly ONE step (parseComparison),
+// never folded twice at the same level. That is what makes `a = b = c`,
+// `1 < 2 < 3`, `x IN (1) IN (2)`, `1 IS NULL IS NULL`, etc. reject (P1): after
+// one comparison operator, no second comparison operator is accepted; the
+// trailing operator is left as an unexpected token.
+func (p *Parser) parseExpr() (ast.Node, error) {
+	return p.parseOr()
+}
+
+// parseOr parses the OR level: `and_expr (OR and_expr)*` (left-associative).
+func (p *Parser) parseOr() (ast.Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == kwOR {
+		p.advance()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{Op: ast.BinOr, Left: left, Right: right, Loc: spanNodes(left, right)}
+	}
+	return left, nil
+}
+
+// parseAnd parses the AND level: `not_expr (AND not_expr)*` (left-associative,
+// matching the grammar's and_expression).
+func (p *Parser) parseAnd() (ast.Node, error) {
+	left, err := p.parseNotExpr()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == kwAND {
+		p.advance()
+		right, err := p.parseNotExpr()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{Op: ast.BinAnd, Left: left, Right: right, Loc: spanNodes(left, right)}
+	}
+	return left, nil
+}
+
+// parseNotExpr parses prefix NOT (P2: NOT binds looser than comparison, so its
+// operand is a full comparison-level expression). `NOT NOT x` chains. A
+// non-NOT token falls through to the comparison level.
+func (p *Parser) parseNotExpr() (ast.Node, error) {
+	if p.cur.Type == kwNOT {
+		tok := p.advance()
+		operand, err := p.parseNotExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{Op: ast.UnaryNot, Expr: operand, Loc: locFromTo2(tok.Loc, operand)}, nil
+	}
+	return p.parseComparison()
+}
+
+// parseComparison parses the NON-ASSOCIATIVE comparison family (P1): a single
+// higher-precedence operand, then AT MOST ONE comparison-family operator
+// (comparative / [NOT] LIKE / [NOT] IN / [NOT] BETWEEN / IS […] /
+// IS […] DISTINCT FROM) whose RHS is again a higher-precedence operand. After
+// one operator it returns — a second comparison operator at the same level is
+// NOT consumed, so the caller (and ultimately parseSingle/ParseExpression)
+// reports it as an unexpected token. The higher band (bitwise/shift/arith) is
+// parsed by parseBinaryExpr.
+func (p *Parser) parseComparison() (ast.Node, error) {
+	left, err := p.parseBinaryExpr(bpBitOr)
+	if err != nil {
+		return nil, err
+	}
+	switch p.cur.Type {
+	case int('='):
+		return p.parseCompareRHS(left, ast.CmpEq)
+	case tokNotEqual, tokNotEqual2:
+		return p.parseCompareRHS(left, ast.CmpNe)
+	case int('<'):
+		return p.parseCompareRHS(left, ast.CmpLt)
+	case tokLessEqual:
+		return p.parseCompareRHS(left, ast.CmpLe)
+	case int('>'):
+		return p.parseCompareRHS(left, ast.CmpGt)
+	case tokGreaterEqual:
+		return p.parseCompareRHS(left, ast.CmpGe)
+	case kwIS:
+		return p.parseIs(left)
+	case kwBETWEEN:
+		return p.parseBetween(left, false)
+	case kwIN:
+		return p.parseIn(left, false)
+	case kwLIKE:
+		return p.parseLike(left, false)
+	case kwNOT:
+		// NOT { LIKE | IN | BETWEEN } — a comparison-family lead-in.
+		switch p.peekNext().Type {
+		case kwLIKE, kwIN, kwBETWEEN:
+			p.advance() // consume NOT
+			switch p.cur.Type {
+			case kwLIKE:
+				return p.parseLike(left, true)
+			case kwIN:
+				return p.parseIn(left, true)
+			case kwBETWEEN:
+				return p.parseBetween(left, true)
+			}
+		}
+		// A bare NOT not followed by a comparison-family keyword is not an infix
+		// operator here; leave it (the caller surfaces it).
+		return left, nil
+	}
+	return left, nil
+}
+
+// parseCompareRHS consumes a comparative operator and its RHS (a higher-prec
+// operand). The RHS is parseBinaryExpr(bpBitOr) — NOT another comparison — so
+// the family stays non-associative (P1).
+func (p *Parser) parseCompareRHS(left ast.Node, op ast.CompareOp) (ast.Node, error) {
+	p.advance() // consume the operator
+	right, err := p.parseBinaryExpr(bpBitOr)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CompareExpr{Op: op, Left: left, Right: right, Loc: spanNodes(left, right)}, nil
+}
+
+// parseBinaryExpr parses the left-associative arithmetic / bitwise / shift /
+// concat band by precedence climbing with the given minimum binding power
+// (lowest in this band is bpBitOr). Below this band lives the comparison family
+// (handled by the caller); above it live unary and postfix (handled by
+// parsePrefixExpr).
+func (p *Parser) parseBinaryExpr(minBP int) (ast.Node, error) {
+	left, err := p.parsePrefixExpr()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		op, bp, ok := p.binaryOpAt()
+		if !ok || bp < minBP {
+			break
+		}
+		p.advance() // consume the operator
+		right, err := p.parseBinaryExpr(bp + 1)
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.BinaryExpr{Op: op, Left: left, Right: right, Loc: spanNodes(left, right)}
+	}
+	return left, nil
+}
+
+// binaryOpAt returns the BinaryOp, binding power, and ok for the current token
+// as a left-associative binary operator in the bitwise/shift/arithmetic band.
+// (OR / AND / comparison are handled by their dedicated layers, not here.)
+func (p *Parser) binaryOpAt() (ast.BinaryOp, int, bool) {
+	switch p.cur.Type {
+	case int('|'):
+		return ast.BinBitOr, bpBitOr, true
+	case int('^'):
+		return ast.BinBitXor, bpBitXor, true
+	case int('&'):
+		return ast.BinBitAnd, bpBitAnd, true
+	case tokBoolOr:
+		return ast.BinConcat, bpConcat, true
+	case tokShiftLeft:
+		return ast.BinShiftLeft, bpShift, true
+	case tokShiftRight:
+		return ast.BinShiftRight, bpShift, true
+	case int('+'):
+		return ast.BinAdd, bpAdd, true
+	case int('-'):
+		return ast.BinSub, bpAdd, true
+	case int('*'):
+		return ast.BinMul, bpMul, true
+	case int('/'):
+		return ast.BinDiv, bpMul, true
+	}
+	return 0, 0, false
+}
+
+// parseIs parses `IS [NOT] { NULL | TRUE | FALSE | UNKNOWN }` or
+// `IS [NOT] DISTINCT FROM expr` (is_operator / distinct_operator). The IS
+// keyword is the current token. Non-associative (P1): a DISTINCT FROM RHS is
+// parsed at bpCompare+1.
+func (p *Parser) parseIs(left ast.Node) (ast.Node, error) {
+	p.advance() // consume IS
+	not := false
+	if p.cur.Type == kwNOT {
+		p.advance()
+		not = true
+	}
+	// DISTINCT FROM form.
+	if p.cur.Type == kwDISTINCT {
+		p.advance() // DISTINCT
+		if _, err := p.expect(kwFROM); err != nil {
+			return nil, err
+		}
+		right, err := p.parseBinaryExpr(bpBitOr)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.IsExpr{Expr: left, Not: not, DistinctFrom: right, Loc: spanNodes(left, right)}, nil
+	}
+	// Predicate form: NULL / TRUE / FALSE / UNKNOWN.
+	var pred string
+	switch p.cur.Type {
+	case kwNULL:
+		pred = "NULL"
+	case kwTRUE:
+		pred = "TRUE"
+	case kwFALSE:
+		pred = "FALSE"
+	case kwUNKNOWN:
+		pred = "UNKNOWN"
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	tok := p.advance()
+	return &ast.IsExpr{Expr: left, Not: not, Pred: pred, Loc: locFromTo(left, tok)}, nil
+}
+
+// parseBetween parses `[NOT] BETWEEN low AND high` (between_operator). The
+// BETWEEN keyword is the current token; not records a preceding NOT. low and
+// high are parsed at the EHP (higher-than-AND) level so a bare OR/AND inside is
+// not consumed (the grammar's "Expression in BETWEEN must be parenthesized"
+// alternative — verified: `a BETWEEN 1 OR 2` rejects). Concretely, low and high
+// parse at bpCompare+1: above AND/OR/NOT and above the comparison family, so the
+// AND separator is the BETWEEN's own AND, not a logical conjunction.
+func (p *Parser) parseBetween(left ast.Node, not bool) (ast.Node, error) {
+	p.advance() // consume BETWEEN
+	low, err := p.parseBinaryExpr(bpBitOr)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAND); err != nil {
+		return nil, err
+	}
+	high, err := p.parseBinaryExpr(bpBitOr)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.BetweenExpr{Expr: left, Low: low, High: high, Not: not, Loc: spanNodes(left, high)}, nil
+}
+
+// parseIn parses `[NOT] IN <rhs>` (in_operator). The IN keyword is the current
+// token. RHS forms: `UNNEST(...)`, a parenthesized query, or a parenthesized
+// expression list (>= 1). A leading `@{...}` hint is allowed before a
+// non-UNNEST RHS (the grammar errors on a hint before UNNEST — we record the
+// diagnostic but still parse, matching the notify-style oracle behavior).
+func (p *Parser) parseIn(left ast.Node, not bool) (ast.Node, error) {
+	inTok := p.advance() // consume IN
+
+	// Optional hint @{...} / @N before the RHS.
+	hadHint := false
+	if p.cur.Type == int('@') {
+		hadHint = true
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+
+	out := &ast.InExpr{Expr: left, Not: not}
+
+	// UNNEST(...) RHS.
+	if p.cur.Type == kwUNNEST {
+		if hadHint {
+			p.errors = append(p.errors, ParseError{
+				Loc: inTok.Loc,
+				Msg: "Syntax error: HINTs cannot be specified on IN clause with UNNEST",
+			})
+		}
+		unnest, err := p.parseUnnestExpression()
+		if err != nil {
+			return nil, err
+		}
+		out.Unnest = unnest
+		out.Loc = spanNodes(left, unnest)
+		return out, nil
+	}
+
+	// Parenthesized RHS: a query, or a (one-or-more) expression list.
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	if p.atQueryStart() {
+		sub, end, err := p.parseSubqueryBody(inTok.Loc.Start)
+		if err != nil {
+			return nil, err
+		}
+		out.Subquery = sub
+		out.Loc = ast.Loc{Start: nodeLoc(left).Start, End: end}
+		return out, nil
+	}
+	// Expression list.
+	values, endLoc, err := p.parseExprListThroughParen()
+	if err != nil {
+		return nil, err
+	}
+	out.Values = values
+	out.Loc = ast.Loc{Start: nodeLoc(left).Start, End: endLoc.End}
+	return out, nil
+}
+
+// parseLike parses `[NOT] LIKE <rhs>` (like_operator). The LIKE keyword is the
+// current token. Plain form: `LIKE pattern`. Quantified form: `LIKE
+// {ANY|SOME|ALL} [hint] <list|UNNEST|query>`.
+func (p *Parser) parseLike(left ast.Node, not bool) (ast.Node, error) {
+	p.advance() // consume LIKE
+	out := &ast.LikeExpr{Expr: left, Not: not}
+
+	// Quantified form: ANY / SOME / ALL.
+	switch p.cur.Type {
+	case kwANY, kwSOME, kwALL:
+		out.Quantifier = strings.ToUpper(TokenName(p.cur.Type))
+		p.advance()
+		if p.cur.Type == int('@') {
+			if herr := p.skipHint(); herr != nil {
+				return nil, herr
+			}
+		}
+		if p.cur.Type == kwUNNEST {
+			unnest, err := p.parseUnnestExpression()
+			if err != nil {
+				return nil, err
+			}
+			out.QuantUnnest = unnest
+			out.Loc = spanNodes(left, unnest)
+			return out, nil
+		}
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		if p.atQueryStart() {
+			sub, end, err := p.parseSubqueryBody(nodeLoc(left).Start)
+			if err != nil {
+				return nil, err
+			}
+			out.QuantSubquery = sub
+			out.Loc = ast.Loc{Start: nodeLoc(left).Start, End: end}
+			return out, nil
+		}
+		values, endLoc, err := p.parseExprListThroughParen()
+		if err != nil {
+			return nil, err
+		}
+		out.QuantValues = values
+		out.Loc = ast.Loc{Start: nodeLoc(left).Start, End: endLoc.End}
+		return out, nil
+	}
+
+	// Plain form: a single pattern at the comparison-RHS level (non-assoc).
+	pattern, err := p.parseBinaryExpr(bpBitOr)
+	if err != nil {
+		return nil, err
+	}
+	out.Pattern = pattern
+	out.Loc = spanNodes(left, pattern)
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Prefix / primary dispatch
+// ---------------------------------------------------------------------------
+
+// parsePrefixExpr handles the prefix unary operators (+ - ~) and otherwise
+// delegates to parsePrimaryExpr followed by postfix-access folding. (Prefix NOT
+// is handled higher up by parseNotExpr — P2 — because it binds looser than the
+// comparison family, while + - ~ bind tighter than multiplication.) Unary + - ~
+// take the official GoogleSQL precedence: above multiplicative (level 2), so
+// `-a*b` groups as `(-a)*b` — semantically identical to `-(a*b)`, so this choice
+// is unobservable through the oracle and follows the documented precedence
+// table (truth1).
+func (p *Parser) parsePrefixExpr() (ast.Node, error) {
+	switch p.cur.Type {
+	case int('+'):
+		return p.parseUnary(ast.UnaryPlus)
+	case int('-'):
+		return p.parseUnary(ast.UnaryMinus)
+	case int('~'):
+		return p.parseUnary(ast.UnaryBitNot)
+	}
+
+	prim, err := p.parsePrimaryExpr()
+	if err != nil {
+		return nil, err
+	}
+	return p.parsePostfix(prim)
+}
+
+// parseUnary consumes a prefix unary operator and its operand at bpUnary, so a
+// following higher-or-equal-precedence operator (another unary, or postfix
+// access) binds to the operand and `- - 1` / `2 - - 1` / `-a[0]` parse.
+func (p *Parser) parseUnary(op ast.UnaryOp) (ast.Node, error) {
+	tok := p.advance()
+	operand, err := p.parseBinaryExpr(bpUnary)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.UnaryExpr{Op: op, Expr: operand, Loc: locFromTo2(tok.Loc, operand)}, nil
+}
+
+// parsePostfix folds postfix-access operators (`. field`, `. (path)`,
+// `[ index ]`) onto base. Access is left-associative and the highest precedence,
+// so it always binds before returning to the caller.
+func (p *Parser) parsePostfix(base ast.Node) (ast.Node, error) {
+	for {
+		switch p.cur.Type {
+		case int('.'):
+			next, err := p.parseDotAccess(base)
+			if err != nil {
+				return nil, err
+			}
+			base = next
+		case int('['):
+			next, err := p.parseIndexAccess(base)
+			if err != nil {
+				return nil, err
+			}
+			base = next
+		default:
+			return base, nil
+		}
+	}
+}
+
+// parseDotAccess parses a `. field` or `. (path)` postfix on base
+// (EHP DOT identifier | EHP DOT '(' path ')'). The '.' is the current token.
+func (p *Parser) parseDotAccess(base ast.Node) (ast.Node, error) {
+	p.advance() // consume '.'
+	// Extension access: . ( path ).
+	if p.cur.Type == int('(') {
+		p.advance() // consume '('
+		path, err := p.parsePathExpr()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ExtensionAccess{Expr: base, Path: path, Loc: ast.Loc{Start: nodeLoc(base).Start, End: closeTok.Loc.End}}, nil
+	}
+	// Field access: . identifier (any keyword permitted as a field name part).
+	if !isAnyKeywordIdentifier(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	tok := p.advance()
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.FieldAccess{Expr: base, Field: name, Loc: locFromTo(base, tok)}, nil
+}
+
+// parseIndexAccess parses a `[ index ]` subscript on base
+// (EHP LS_BRACKET expression RS_BRACKET). The '[' is the current token. The
+// index expression may be an OFFSET/ORDINAL/SAFE_OFFSET/SAFE_ORDINAL function
+// call — those are ordinary function calls, not special syntax.
+func (p *Parser) parseIndexAccess(base ast.Node) (ast.Node, error) {
+	p.advance() // consume '['
+	idx, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(']'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.IndexAccess{Expr: base, Index: idx, Loc: ast.Loc{Start: nodeLoc(base).Start, End: closeTok.Loc.End}}, nil
+}
+
+// parsePrimaryExpr parses a primary (atomic) expression — everything in the
+// `expression_higher_prec_than_and` rule that is not an operator application:
+// literals, parameters, constructors, CASE/CAST/EXTRACT, function calls,
+// identifiers/paths, parenthesized expressions, and subquery keywords.
+func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
+	switch p.cur.Type {
+	// --- literals ---
+	case kwNULL:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitNull, Value: "NULL", Loc: tok.Loc}, nil
+	case kwTRUE, kwFALSE:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitBool, Value: TokenName(tok.Type), Loc: tok.Loc}, nil
+	case tokInteger:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitInt, Value: tok.Str, Ival: tok.Ival, Loc: tok.Loc}, nil
+	case tokFloat:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitFloat, Value: tok.Str, Loc: tok.Loc}, nil
+	case tokString:
+		return p.parseStringLiteral()
+	case tokBytes:
+		return p.parseBytesLiteral()
+
+	// --- typed-prefix literals (NUMERIC '…', DATE '…', JSON '…', RANGE<…> '…') ---
+	case kwNUMERIC, kwDECIMAL, kwBIGNUMERIC, kwBIGDECIMAL, kwJSON,
+		kwDATE, kwTIME, kwDATETIME, kwTIMESTAMP:
+		// These are also valid bare type names / identifiers; here they are typed
+		// literals ONLY when immediately followed by a string literal. Otherwise
+		// fall through to identifier/function-call handling.
+		if p.peekNext().Type == tokString {
+			return p.parseTypedLiteral()
+		}
+		return p.parseNameOrCall()
+
+	// --- parameters / system variables ---
+	case int('@'):
+		return p.parseNamedParameter()
+	case tokAtAt:
+		return p.parseSystemVariable()
+	case int('?'):
+		tok := p.advance()
+		return &ast.Parameter{Positional: true, Loc: tok.Loc}, nil
+
+	// --- CASE / CAST / EXTRACT / INTERVAL ---
+	case kwCASE:
+		return p.parseCaseExpr()
+	case kwCAST:
+		return p.parseCastExpr(false)
+	case kwSAFE_CAST:
+		return p.parseCastExpr(true)
+	case kwEXTRACT:
+		return p.parseExtractExpr()
+	case kwINTERVAL:
+		return p.parseIntervalExpr()
+
+	// --- constructors ---
+	case int('['):
+		// Bare array constructor [ … ].
+		return p.parseArrayConstructor(false, nil)
+	case kwARRAY:
+		return p.parseArrayOrArraySubquery()
+	case kwSTRUCT:
+		return p.parseStructOrTyped()
+	case kwNEW:
+		return p.parseNewConstructor()
+	case kwREPLACE_FIELDS:
+		return p.parseReplaceFields()
+	case kwWITH:
+		return p.parseWithExpr()
+	case int('{'):
+		return p.parseBracedConstructor(nil)
+
+	// --- EXISTS subquery ---
+	case kwEXISTS:
+		return p.parseExistsExpr()
+
+	// --- parenthesized expression or subquery ---
+	case int('('):
+		return p.parseParenOrSubquery()
+
+	// --- keyword function names (IF/GROUPING/LEFT/RIGHT/COLLATE/RANGE) ---
+	case kwIF, kwGROUPING, kwLEFT, kwRIGHT, kwCOLLATE:
+		return p.parseKeywordFuncCall()
+	case kwRANGE:
+		// RANGE is a keyword function name AND a type prefix (RANGE<T> '…'). A
+		// following '<' is the typed RANGE literal; a following '(' is the
+		// keyword function call.
+		if p.peekNext().Type == int('<') {
+			return p.parseRangeLiteral()
+		}
+		return p.parseKeywordFuncCall()
+
+	// --- identifier / path / function call ---
+	default:
+		if isIdentifierStart(p.cur.Type) {
+			return p.parseNameOrCall()
+		}
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Identifiers, paths, and function calls
+// ---------------------------------------------------------------------------
+
+// parseNameOrCall parses an identifier-led primary: either a path expression
+// (`a`, `a.b.c`) used as a column/name reference, or a function call when a
+// path is immediately followed by `(`. The grammar resolves this exactly as
+// ZetaSQL's LALR action does: `path_expression '(' …` is a call; otherwise the
+// path is a name reference (further `.field` / `[idx]` access is folded by
+// parsePostfix). The current token begins an identifier.
+func (p *Parser) parseNameOrCall() (ast.Node, error) {
+	path, err := p.parsePathExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type == int('(') {
+		return p.parseFuncCallSuffix(path)
+	}
+	if len(path.Parts) == 1 {
+		return &ast.Identifier{Name: path.Parts[0], Loc: path.Loc}, nil
+	}
+	return path, nil
+}
+
+// parsePathExpr parses `path_expression: identifier (DOT identifier)*`. The
+// first component must be an identifier-start (token identifier or non-reserved
+// keyword); dotted continuations accept any keyword as a name part (matching the
+// foundation's permissive path-component rule, also used by parseType). The
+// current token begins the path.
+func (p *Parser) parsePathExpr() (*ast.PathExpr, error) {
+	if !isIdentifierStart(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	first := p.advance()
+	part0, err := p.identifierText(first)
+	if err != nil {
+		return nil, err
+	}
+	path := &ast.PathExpr{Parts: []string{part0}, Loc: first.Loc}
+	for p.cur.Type == int('.') {
+		// Only treat '.' as a path continuation when followed by a name part. A
+		// '.(' is extension access (handled by parsePostfix), and a '.' followed
+		// by a non-name is a syntax error surfaced by the caller — but here we
+		// stop so the caller/postfix layer handles those uniformly.
+		if !isAnyKeywordIdentifier(p.peekNext().Type) {
+			break
+		}
+		p.advance() // consume '.'
+		partTok := p.advance()
+		part, err := p.identifierText(partTok)
+		if err != nil {
+			return nil, err
+		}
+		path.Parts = append(path.Parts, part)
+		path.Loc.End = partTok.Loc.End
+	}
+	return path, nil
+}
+
+// parseFuncCallSuffix parses a function call given its already-parsed name path.
+// The current token is the opening '('. Implements
+// function_call_expression_with_clauses_suffix: optional DISTINCT, the argument
+// list (or empty / bare '*'), the null-handling / having / clamped / with-report
+// modifiers, trailing ORDER BY / LIMIT, then the closing ')', and the
+// post-paren hint / WITH GROUP ROWS / OVER clauses.
+func (p *Parser) parseFuncCallSuffix(name *ast.PathExpr) (ast.Node, error) {
+	p.advance() // consume '('
+	fc := &ast.FuncCall{Name: name, Loc: name.Loc}
+
+	if p.cur.Type == kwDISTINCT {
+		p.advance()
+		fc.Distinct = true
+	}
+
+	// Argument list (possibly empty, or a bare '*').
+	if p.cur.Type != int(')') {
+		if err := p.parseFuncArgs(fc); err != nil {
+			return nil, err
+		}
+		// Aggregate / DP modifiers, in grammar order.
+		if err := p.parseFuncModifiers(fc); err != nil {
+			return nil, err
+		}
+	} else {
+		// Empty-arg list still allows opt_having / ORDER BY / LIMIT before ')'.
+		if err := p.parseEmptyArgModifiers(fc); err != nil {
+			return nil, err
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	fc.Loc.End = closeTok.Loc.End
+
+	// Post-paren: hint? with_group_rows? over_clause?
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+		fc.Loc.End = p.prev.Loc.End
+	}
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwGROUP {
+		// WITH GROUP ROWS.
+		p.advance() // WITH
+		p.advance() // GROUP
+		rowsTok, err := p.expect(kwROWS)
+		if err != nil {
+			return nil, err
+		}
+		fc.WithGroupRows = true
+		fc.Loc.End = rowsTok.Loc.End
+	}
+	if p.cur.Type == kwOVER {
+		win, err := p.parseOverClause()
+		if err != nil {
+			return nil, err
+		}
+		fc.Over = win
+		fc.Loc.End = win.Loc.End
+	}
+	return fc, nil
+}
+
+// parseKeywordFuncCall parses a function call whose name is one of the keyword
+// function names (function_name_from_keyword: IF / GROUPING / LEFT / RIGHT /
+// COLLATE / RANGE). The current token is the keyword; it must be followed by
+// '('. The keyword spelling becomes the function name.
+func (p *Parser) parseKeywordFuncCall() (ast.Node, error) {
+	kw := p.advance()
+	name := &ast.PathExpr{Parts: []string{TokenName(kw.Type)}, Loc: kw.Loc}
+	if p.cur.Type != int('(') {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return p.parseFuncCallSuffix(name)
+}
+
+// parseFuncArgs parses a non-empty function argument list into fc.Args. The
+// first token is the first argument (not ')'). Each argument is a positional
+// expression (optionally `AS alias` for a TVF arg), a named argument
+// (`id => expr`), a lambda, a sequence arg, or a bare '*' (only as the sole
+// leading token). A bare SELECT argument is the grammar's notify-style error
+// alternative: it parses (as a flagged subquery) so the call is still accepted.
+func (p *Parser) parseFuncArgs(fc *ast.FuncCall) error {
+	// Bare '*' argument (COUNT(*)).
+	if p.cur.Type == int('*') {
+		star := p.advance()
+		fc.Args = append(fc.Args, &ast.StarExpr{Loc: star.Loc})
+		for p.cur.Type == int(',') {
+			p.advance()
+			arg, err := p.parseFuncArg()
+			if err != nil {
+				return err
+			}
+			fc.Args = append(fc.Args, arg)
+		}
+		return nil
+	}
+	arg, err := p.parseFuncArg()
+	if err != nil {
+		return err
+	}
+	fc.Args = append(fc.Args, arg)
+	for p.cur.Type == int(',') {
+		p.advance()
+		a, err := p.parseFuncArg()
+		if err != nil {
+			return err
+		}
+		fc.Args = append(fc.Args, a)
+	}
+	return nil
+}
+
+// parseFuncArg parses one function_call_argument: a named arg (`id => …`), a
+// lambda (`params -> body` / `() -> body`), a sequence arg (`SEQUENCE path`), a
+// bare SELECT (notify-style accept), or a positional expression with an optional
+// `AS alias`.
+func (p *Parser) parseFuncArg() (ast.Node, error) {
+	// SEQUENCE path arg.
+	if p.cur.Type == kwSEQUENCE {
+		seqTok := p.advance()
+		path, err := p.parsePathExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.SequenceArg{Path: path, Loc: ast.Loc{Start: seqTok.Loc.Start, End: path.Loc.End}}, nil
+	}
+	// Bare SELECT as an argument: the grammar's error alternative. It flags a
+	// diagnostic but the call parses (oracle: `func(SELECT 1)` is ACCEPT with a
+	// semantic-style message). We consume the subquery body and record the
+	// notify-style message so accept/reject parity holds.
+	if p.cur.Type == kwSELECT {
+		startLoc := p.cur.Loc
+		p.errors = append(p.errors, ParseError{
+			Loc: startLoc,
+			Msg: "Each function argument is an expression, not a query; to use a query as an expression, the query must be wrapped with additional parentheses to make it a scalar subquery expression",
+		})
+		// Consume the bare SELECT body up to the call's closing ')'/',' at depth 0.
+		sub := p.captureBareSelectArg(startLoc)
+		return sub, nil
+	}
+
+	// Named argument: identifier '=>' …  (lookahead: ident then '=>').
+	if isIdentifierStart(p.cur.Type) && p.peekNext().Type == tokFatArrow {
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		p.advance() // consume '=>'
+		// The value may itself be a lambda.
+		val, err := p.parseArgValueMaybeLambda()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.NamedArg{Name: name, Value: val, Loc: ast.Loc{Start: nameTok.Loc.Start, End: nodeLoc(val).End}}, nil
+	}
+
+	// Lambda with a parenthesized parameter list: '(' id (',' id)* ')' '->' …
+	// or the empty '() -> …'. Disambiguated from a parenthesized expression by a
+	// trailing '->'.
+	if p.cur.Type == int('(') {
+		if lam, ok, err := p.tryParseParenLambda(); ok || err != nil {
+			return lam, err
+		}
+	}
+
+	// Positional expression, possibly a single-identifier lambda `id -> body`.
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type == tokArrow {
+		// `id -> body` lambda: the parsed expr must be a single identifier.
+		if id, ok := expr.(*ast.Identifier); ok {
+			p.advance() // consume '->'
+			body, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			return &ast.LambdaExpr{Params: []string{id.Name}, Body: body, Loc: ast.Loc{Start: id.Loc.Start, End: nodeLoc(body).End}}, nil
+		}
+	}
+	// Optional `AS alias` (TVF / struct-style aliased argument).
+	if p.cur.Type == kwAS {
+		p.advance()
+		aliasTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(aliasTok)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.StructFieldExpr{Value: expr, Alias: alias, Loc: ast.Loc{Start: nodeLoc(expr).Start, End: aliasTok.Loc.End}}, nil
+	}
+	return expr, nil
+}
+
+// parseArgValueMaybeLambda parses a named-argument value, which may be a lambda
+// (`id => lambda` is allowed by named_argument). It tries a parenthesized lambda
+// first, then a single-identifier lambda, then a plain expression.
+func (p *Parser) parseArgValueMaybeLambda() (ast.Node, error) {
+	if p.cur.Type == int('(') {
+		if lam, ok, err := p.tryParseParenLambda(); ok || err != nil {
+			return lam, err
+		}
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type == tokArrow {
+		if id, ok := expr.(*ast.Identifier); ok {
+			p.advance()
+			body, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			return &ast.LambdaExpr{Params: []string{id.Name}, Body: body, Loc: ast.Loc{Start: id.Loc.Start, End: nodeLoc(body).End}}, nil
+		}
+	}
+	return expr, nil
+}
+
+// parseFuncModifiers parses the post-argument aggregate / DP modifiers in
+// grammar order: opt_null_handling_modifier? opt_having_or_group_by_modifier?
+// clamped_between_modifier? with_report_modifier? order_by_clause?
+// limit_offset_clause?. The current token is just past the argument list.
+func (p *Parser) parseFuncModifiers(fc *ast.FuncCall) error {
+	// IGNORE NULLS | RESPECT NULLS.
+	if p.cur.Type == kwIGNORE || p.cur.Type == kwRESPECT {
+		kw := p.advance()
+		if _, err := p.expect(kwNULLS); err != nil {
+			return err
+		}
+		fc.NullHandling = strings.ToUpper(TokenName(kw.Type)) + " NULLS"
+	}
+	// HAVING MAX expr | HAVING MIN expr group-by.
+	if p.cur.Type == kwHAVING {
+		havTok := p.advance()
+		isMax := false
+		switch p.cur.Type {
+		case kwMAX:
+			isMax = true
+		case kwMIN:
+			isMax = false
+		default:
+			return p.syntaxErrorAtCur()
+		}
+		p.advance() // MAX/MIN
+		hexpr, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		fc.Having = &ast.HavingModifier{IsMax: isMax, Expr: hexpr, Loc: ast.Loc{Start: havTok.Loc.Start, End: nodeLoc(hexpr).End}}
+		// The MIN form carries a trailing group-by; consume it best-effort
+		// (GROUP [hint] [AND ORDER] BY grouping_item, …). Only relevant for
+		// parse parity; the items are not retained.
+		if !isMax && p.cur.Type == kwGROUP {
+			if err := p.skipGroupByTail(); err != nil {
+				return err
+			}
+		}
+	}
+	// CLAMPED BETWEEN low AND high.
+	if p.cur.Type == kwCLAMPED {
+		clTok := p.advance()
+		low, err := p.parseBinaryExpr(bpBitOr)
+		if err != nil {
+			return err
+		}
+		if _, err := p.expect(kwAND); err != nil {
+			return err
+		}
+		high, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		fc.Clamped = &ast.ClampedModifier{Low: low, High: high, Loc: ast.Loc{Start: clTok.Loc.Start, End: nodeLoc(high).End}}
+	}
+	// WITH REPORT options_list.
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwREPORT {
+		p.advance() // WITH
+		p.advance() // REPORT
+		if err := p.skipOptionsList(); err != nil {
+			return err
+		}
+		fc.WithReport = true
+	}
+	// ORDER BY.
+	if p.cur.Type == kwORDER {
+		items, err := p.parseOrderByClause()
+		if err != nil {
+			return err
+		}
+		fc.OrderBy = items
+	}
+	// LIMIT expr [OFFSET expr].
+	if p.cur.Type == kwLIMIT {
+		if err := p.parseLimitOffset(fc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseEmptyArgModifiers parses the empty-argument-list tail: opt_having? ORDER
+// BY? LIMIT?. Only ORDER BY / LIMIT and the having modifier are valid here
+// (the empty-list alternative in the grammar). The current token is just after
+// '(' with no arguments.
+func (p *Parser) parseEmptyArgModifiers(fc *ast.FuncCall) error {
+	if p.cur.Type == kwHAVING {
+		// Reuse the full modifier parser, which handles HAVING and the trailing
+		// ORDER BY / LIMIT.
+		return p.parseFuncModifiers(fc)
+	}
+	if p.cur.Type == kwORDER {
+		items, err := p.parseOrderByClause()
+		if err != nil {
+			return err
+		}
+		fc.OrderBy = items
+	}
+	if p.cur.Type == kwLIMIT {
+		if err := p.parseLimitOffset(fc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseLimitOffset parses `LIMIT expr [OFFSET expr]` into fc.
+func (p *Parser) parseLimitOffset(fc *ast.FuncCall) error {
+	p.advance() // LIMIT
+	lim, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	fc.Limit = lim
+	if p.cur.Type == kwOFFSET {
+		p.advance()
+		off, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		fc.LimitOffset = off
+	}
+	return nil
+}
+
+// parseOverClause parses `OVER window_specification` (over_clause). OVER is the
+// current token. The window spec is either a bare name or a parenthesized inline
+// spec.
+func (p *Parser) parseOverClause() (*ast.WindowSpec, error) {
+	overTok := p.advance() // OVER
+	if p.cur.Type == int('(') {
+		return p.parseInlineWindowSpec(overTok.Loc.Start)
+	}
+	// Named window reference.
+	if !isIdentifierStart(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	nameTok := p.advance()
+	name, err := p.identifierText(nameTok)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.WindowSpec{Name: name, Loc: ast.Loc{Start: overTok.Loc.Start, End: nameTok.Loc.End}}, nil
+}
+
+// parseInlineWindowSpec parses `( [name] [PARTITION BY …] [ORDER BY …]
+// [frame] )` (window_specification). The current token is '('. startOff anchors
+// the Loc start (the OVER keyword).
+func (p *Parser) parseInlineWindowSpec(startOff int) (*ast.WindowSpec, error) {
+	p.advance() // '('
+	ws := &ast.WindowSpec{Inline: true, Loc: ast.Loc{Start: startOff, End: startOff}}
+	// Optional leading base-window name.
+	if isIdentifierStart(p.cur.Type) && p.cur.Type != kwPARTITION {
+		// Only an identifier that is NOT the start of PARTITION/ORDER/frame is a
+		// base name. PARTITION is non-reserved (isIdentifierStart true) but here
+		// always introduces the partition clause, so exclude it.
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		ws.Name = name
+	}
+	if p.cur.Type == kwPARTITION {
+		parts, err := p.parsePartitionBy()
+		if err != nil {
+			return nil, err
+		}
+		ws.PartitionBy = parts
+	}
+	if p.cur.Type == kwORDER {
+		items, err := p.parseOrderByClause()
+		if err != nil {
+			return nil, err
+		}
+		ws.OrderBy = items
+	}
+	if p.cur.Type == kwROWS || p.cur.Type == kwRANGE {
+		frame, err := p.parseWindowFrame()
+		if err != nil {
+			return nil, err
+		}
+		ws.Frame = frame
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ws.Loc.End = closeTok.Loc.End
+	return ws, nil
+}
+
+// parsePartitionBy parses `PARTITION [hint] BY expr (, expr)*`
+// (partition_by_clause). PARTITION is the current token.
+func (p *Parser) parsePartitionBy() ([]ast.Node, error) {
+	p.advance() // PARTITION
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	return p.parseExprCommaList()
+}
+
+// parseOrderByClause parses `ORDER [hint] BY ordering_expression (, …)*`
+// (order_by_clause). ORDER is the current token. Each item is
+// `expr [COLLATE c] [ASC|DESC] [NULLS FIRST|LAST]`.
+func (p *Parser) parseOrderByClause() ([]*ast.OrderItem, error) {
+	p.advance() // ORDER
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	var items []*ast.OrderItem
+	for {
+		item, err := p.parseOrderItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance()
+	}
+	return items, nil
+}
+
+// parseOrderItem parses one `expr [COLLATE c] [ASC|DESC] [NULLS FIRST|LAST]`.
+func (p *Parser) parseOrderItem() (*ast.OrderItem, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	item := &ast.OrderItem{Expr: expr, Loc: nodeLoc(expr)}
+	if p.cur.Type == kwCOLLATE {
+		p.advance()
+		coll, err := p.parseBinaryExpr(bpBitOr)
+		if err != nil {
+			return nil, err
+		}
+		item.Collate = coll
+		item.Loc.End = nodeLoc(coll).End
+	}
+	if p.cur.Type == kwASC || p.cur.Type == kwDESC {
+		item.HasDir = true
+		item.Desc = p.cur.Type == kwDESC
+		item.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+	if p.cur.Type == kwNULLS {
+		p.advance()
+		switch p.cur.Type {
+		case kwFIRST:
+			v := true
+			item.NullsFirst = &v
+		case kwLAST:
+			v := false
+			item.NullsFirst = &v
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+		item.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+	return item, nil
+}
+
+// parseWindowFrame parses `{ROWS|RANGE} { bound | BETWEEN bound AND bound }`
+// (opt_window_frame_clause). The current token is ROWS or RANGE.
+func (p *Parser) parseWindowFrame() (*ast.WindowFrame, error) {
+	unitTok := p.advance() // ROWS / RANGE
+	frame := &ast.WindowFrame{Loc: unitTok.Loc}
+	if unitTok.Type == kwRANGE {
+		frame.Kind = ast.FrameRange
+	} else {
+		frame.Kind = ast.FrameRows
+	}
+	if p.cur.Type == kwBETWEEN {
+		p.advance()
+		start, err := p.parseWindowBound()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwAND); err != nil {
+			return nil, err
+		}
+		end, err := p.parseWindowBound()
+		if err != nil {
+			return nil, err
+		}
+		frame.Between = true
+		frame.Start = start
+		frame.End = end
+		frame.Loc.End = p.prev.Loc.End
+		return frame, nil
+	}
+	start, err := p.parseWindowBound()
+	if err != nil {
+		return nil, err
+	}
+	frame.Start = start
+	frame.Loc.End = p.prev.Loc.End
+	return frame, nil
+}
+
+// parseWindowBound parses one window_frame_bound: `UNBOUNDED {PRECEDING|
+// FOLLOWING}`, `CURRENT ROW`, or `expr {PRECEDING|FOLLOWING}`.
+func (p *Parser) parseWindowBound() (ast.WindowBound, error) {
+	switch p.cur.Type {
+	case kwUNBOUNDED:
+		p.advance()
+		switch p.cur.Type {
+		case kwPRECEDING:
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundUnboundedPreceding}, nil
+		case kwFOLLOWING:
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundUnboundedFollowing}, nil
+		default:
+			return ast.WindowBound{}, p.syntaxErrorAtCur()
+		}
+	case kwCURRENT:
+		p.advance()
+		if _, err := p.expect(kwROW); err != nil {
+			return ast.WindowBound{}, err
+		}
+		return ast.WindowBound{Kind: ast.BoundCurrentRow}, nil
+	default:
+		expr, err := p.parseExpr()
+		if err != nil {
+			return ast.WindowBound{}, err
+		}
+		switch p.cur.Type {
+		case kwPRECEDING:
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundPreceding, Offset: expr}, nil
+		case kwFOLLOWING:
+			p.advance()
+			return ast.WindowBound{Kind: ast.BoundFollowing, Offset: expr}, nil
+		default:
+			return ast.WindowBound{}, p.syntaxErrorAtCur()
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Literals
+// ---------------------------------------------------------------------------
+
+// parseStringLiteral parses one or more adjacent STRING_LITERAL components
+// (string_literal: adjacent concatenation). GoogleSQL concatenates adjacent
+// string literals into one value; the lexer emits one token per component.
+// Adjacent bytes/string mixing is not handled here (the lexer typed each token);
+// a bytes token after a string simply stops the string and is left for the
+// caller, which is a syntax error in expression position if unexpected.
+func (p *Parser) parseStringLiteral() (ast.Node, error) {
+	first := p.advance()
+	value := first.Str
+	loc := first.Loc
+	for p.cur.Type == tokString {
+		comp := p.advance()
+		value += comp.Str
+		loc.End = comp.Loc.End
+	}
+	return &ast.Literal{Kind: ast.LitString, Value: value, Loc: loc}, nil
+}
+
+// parseBytesLiteral parses one or more adjacent BYTES_LITERAL components
+// (bytes_literal: adjacent concatenation).
+func (p *Parser) parseBytesLiteral() (ast.Node, error) {
+	first := p.advance()
+	value := first.Str
+	loc := first.Loc
+	for p.cur.Type == tokBytes {
+		comp := p.advance()
+		value += comp.Str
+		loc.End = comp.Loc.End
+	}
+	return &ast.Literal{Kind: ast.LitBytes, Value: value, Loc: loc}, nil
+}
+
+// parseTypedLiteral parses a type-prefixed literal `<kw> '…'` for
+// NUMERIC/DECIMAL/BIGNUMERIC/BIGDECIMAL/JSON/DATE/TIME/DATETIME/TIMESTAMP. The
+// keyword is the current token and is known to be followed by a string literal.
+func (p *Parser) parseTypedLiteral() (ast.Node, error) {
+	kw := p.advance()
+	strTok := p.advance() // the string literal (peekNext-confirmed by caller)
+	return &ast.TypedLiteral{
+		TypeKeyword: TokenName(kw.Type),
+		Value:       strTok.Str,
+		Loc:         ast.Loc{Start: kw.Loc.Start, End: strTok.Loc.End},
+	}, nil
+}
+
+// parseRangeLiteral parses `RANGE<type> '…'` (range_literal: range_type
+// string_literal). RANGE is the current token, followed by '<'. The element
+// type is parsed by the `types` node; the trailing string literal is required.
+func (p *Parser) parseRangeLiteral() (ast.Node, error) {
+	startLoc := p.cur.Loc
+	// Reuse the type parser for `RANGE<type>` (parseRangeType lives in the types
+	// node). It consumes RANGE and the template.
+	rt, err := p.parseRangeType()
+	if err != nil {
+		return nil, err
+	}
+	strTok, err := p.expect(tokString)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.TypedLiteral{
+		TypeKeyword: rt.String(),
+		Value:       strTok.Str,
+		Loc:         ast.Loc{Start: startLoc.Start, End: strTok.Loc.End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Parameters / system variables
+// ---------------------------------------------------------------------------
+
+// parseNamedParameter parses `@identifier` (named_parameter_expression). The
+// current token is '@'. (Statement-level hints `@{`/`@N`/`@[` are handled by the
+// foundation before dispatch and never reach expression parsing; an '@' here is
+// always a named parameter.)
+func (p *Parser) parseNamedParameter() (ast.Node, error) {
+	atTok := p.advance() // '@'
+	if !isAnyKeywordIdentifier(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	nameTok := p.advance()
+	name, err := p.identifierText(nameTok)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.Parameter{Name: name, Loc: ast.Loc{Start: atTok.Loc.Start, End: nameTok.Loc.End}}, nil
+}
+
+// parseSystemVariable parses `@@path` (system_variable_expression: ATAT
+// path_expression). The current token is '@@'.
+func (p *Parser) parseSystemVariable() (ast.Node, error) {
+	atatTok := p.advance() // '@@'
+	if !isAnyKeywordIdentifier(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	sv := &ast.SystemVariable{Loc: atatTok.Loc}
+	nameTok := p.advance()
+	name, err := p.identifierText(nameTok)
+	if err != nil {
+		return nil, err
+	}
+	sv.Parts = append(sv.Parts, name)
+	sv.Loc.End = nameTok.Loc.End
+	for p.cur.Type == int('.') {
+		if !isAnyKeywordIdentifier(p.peekNext().Type) {
+			break
+		}
+		p.advance() // '.'
+		partTok := p.advance()
+		part, err := p.identifierText(partTok)
+		if err != nil {
+			return nil, err
+		}
+		sv.Parts = append(sv.Parts, part)
+		sv.Loc.End = partTok.Loc.End
+	}
+	return sv, nil
+}
+
+// ---------------------------------------------------------------------------
+// CASE / CAST / EXTRACT / INTERVAL
+// ---------------------------------------------------------------------------
+
+// parseCaseExpr parses a CASE expression (case_expression). The current token
+// is CASE. Simple form has an operand before the first WHEN; searched form goes
+// straight to WHEN. At least one WHEN…THEN is required; ELSE is optional; END
+// terminates.
+func (p *Parser) parseCaseExpr() (ast.Node, error) {
+	caseTok := p.advance() // CASE
+	ce := &ast.CaseExpr{Loc: caseTok.Loc}
+
+	// Simple CASE: an operand expression before WHEN.
+	if p.cur.Type != kwWHEN {
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Operand = operand
+	}
+
+	// One or more WHEN cond THEN result.
+	for p.cur.Type == kwWHEN {
+		whenTok := p.advance()
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		result, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Whens = append(ce.Whens, &ast.WhenClause{
+			Cond: cond, Result: result,
+			Loc: ast.Loc{Start: whenTok.Loc.Start, End: nodeLoc(result).End},
+		})
+	}
+	if len(ce.Whens) == 0 {
+		// `CASE END` / `CASE x END` with no WHEN is a syntax error (oracle:
+		// `CASE END` rejects "Unexpected keyword END").
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	// Optional ELSE.
+	if p.cur.Type == kwELSE {
+		p.advance()
+		elseExpr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Else = elseExpr
+	}
+
+	endTok, err := p.expect(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	ce.Loc.End = endTok.Loc.End
+	return ce, nil
+}
+
+// parseCastExpr parses `CAST(expr AS type [FORMAT fmt [AT TIME ZONE tz]])` or
+// the SAFE_CAST variant (cast_expression). The CAST/SAFE_CAST keyword is the
+// current token. The `CAST(CAST …` / `CAST(SAFE_CAST …` error alternatives are
+// surfaced as the grammar's notify-style reject: the inner reserved-keyword
+// argument is not a valid expression, so it falls out as a syntax error
+// (oracle: `CAST(CAST AS INT64)` rejects).
+func (p *Parser) parseCastExpr(safe bool) (ast.Node, error) {
+	castTok := p.advance() // CAST / SAFE_CAST
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	dt, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	ce := &ast.CastExpr{
+		Expr: expr,
+		Type: &ast.TypeRef{Text: dt.String(), Loc: dt.Loc},
+		Safe: safe,
+		Loc:  castTok.Loc,
+	}
+	// Optional FORMAT fmt [AT TIME ZONE tz].
+	if p.cur.Type == kwFORMAT {
+		p.advance()
+		fmtExpr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		ce.Format = fmtExpr
+		if p.cur.Type == int('@') && p.peekNext().Type == kwTIME {
+			// AT TIME ZONE — '@' here is the AT keyword? No: AT is the '@' symbol?
+			// GoogleSQL AT TIME ZONE uses the keyword AT, lexed as a word. Handled
+			// below via the AT-token path.
+		}
+		if tz, ok, err := p.tryParseAtTimeZone(); err != nil {
+			return nil, err
+		} else if ok {
+			ce.TimeZone = tz
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ce.Loc.End = closeTok.Loc.End
+	return ce, nil
+}
+
+// parseExtractExpr parses `EXTRACT(part FROM expr [AT TIME ZONE tz])`
+// (extract_expression). EXTRACT is the current token.
+func (p *Parser) parseExtractExpr() (ast.Node, error) {
+	extractTok := p.advance() // EXTRACT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	part, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	from, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	ee := &ast.ExtractExpr{Part: part, From: from, Loc: extractTok.Loc}
+	if tz, ok, err := p.tryParseAtTimeZone(); err != nil {
+		return nil, err
+	} else if ok {
+		ee.TimeZone = tz
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	ee.Loc.End = closeTok.Loc.End
+	return ee, nil
+}
+
+// parseIntervalExpr parses `INTERVAL expr datepart [TO datepart]`
+// (interval_expression). INTERVAL is the current token. The date-part(s) are
+// identifier spellings (e.g. DAY, YEAR, SECOND).
+func (p *Parser) parseIntervalExpr() (ast.Node, error) {
+	intervalTok := p.advance() // INTERVAL
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if !isAnyKeywordIdentifier(p.cur.Type) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	fromTok := p.advance()
+	fromPart, err := p.identifierText(fromTok)
+	if err != nil {
+		return nil, err
+	}
+	ie := &ast.IntervalExpr{Value: val, From: fromPart, Loc: ast.Loc{Start: intervalTok.Loc.Start, End: fromTok.Loc.End}}
+	if p.cur.Type == kwTO {
+		p.advance()
+		if !isAnyKeywordIdentifier(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		toTok := p.advance()
+		toPart, err := p.identifierText(toTok)
+		if err != nil {
+			return nil, err
+		}
+		ie.To = toPart
+		ie.Loc.End = toTok.Loc.End
+	}
+	return ie, nil
+}
+
+// tryParseAtTimeZone parses an optional `AT TIME ZONE expr` suffix
+// (opt_at_time_zone). It returns (tz, true, nil) when present, (nil, false, nil)
+// when the current token is not the AT keyword. GoogleSQL's AT is a word-keyword
+// — but the lexer has no dedicated AT token; the foundation's keyword set omits
+// a standalone "at" keyword (the '@' AT_SYMBOL is punctuation). AT TIME ZONE is
+// recognized by matching a bare identifier "AT" followed by TIME ZONE.
+func (p *Parser) tryParseAtTimeZone() (ast.Node, bool, error) {
+	if !p.curIsWord("AT") {
+		return nil, false, nil
+	}
+	// Look ahead: AT TIME ZONE. TIME is a keyword; ZONE is a keyword.
+	if p.peekNext().Type != kwTIME {
+		return nil, false, nil
+	}
+	p.advance() // AT
+	p.advance() // TIME
+	if _, err := p.expect(kwZONE); err != nil {
+		return nil, false, err
+	}
+	tz, err := p.parseExpr()
+	if err != nil {
+		return nil, false, err
+	}
+	return tz, true, nil
+}
+
+// curIsWord reports whether the current token is an identifier (or keyword)
+// whose spelling equals word (case-insensitive). Used for context keywords that
+// the lexer does not tokenize as dedicated keywords (e.g. AT in AT TIME ZONE).
+func (p *Parser) curIsWord(word string) bool {
+	if p.cur.Type == tokIdentifier {
+		return strings.EqualFold(p.cur.Str, word)
+	}
+	if p.cur.Type >= keywordBase {
+		return strings.EqualFold(TokenName(p.cur.Type), word)
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Constructors: array / struct / new / braced / replace-fields / with
+// ---------------------------------------------------------------------------
+
+// parseArrayOrArraySubquery parses an ARRAY-led primary: `ARRAY(query)`
+// (expression_subquery_with_keyword), `ARRAY[…]` (array_constructor with the
+// ARRAY keyword), or `ARRAY<T>[…]` (typed array constructor). ARRAY is the
+// current token.
+func (p *Parser) parseArrayOrArraySubquery() (ast.Node, error) {
+	arrayTok := p.advance() // ARRAY
+	switch p.cur.Type {
+	case int('('):
+		// ARRAY ( query ).
+		p.advance() // '('
+		sub, end, err := p.parseSubqueryBodyRaw(arrayTok.Loc.Start)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ArraySubqueryExpr{RawText: sub, Loc: ast.Loc{Start: arrayTok.Loc.Start, End: end}}, nil
+	case int('['):
+		// ARRAY [ … ].
+		return p.parseArrayConstructor(true, nil)
+	case int('<'):
+		// ARRAY < T > [ … ] — typed array constructor. Re-parse the full type
+		// starting from ARRAY using the types node.
+		dt, err := p.parseArrayTypeFromKeyword(arrayTok)
+		if err != nil {
+			return nil, err
+		}
+		tr := &ast.TypeRef{Text: dt.String(), Loc: dt.Loc}
+		return p.parseArrayConstructor(true, tr)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseArrayConstructor parses `[ … ]` element list (array_constructor). The
+// current token is '['. hasArrayKeyword/elemType carry context from a leading
+// ARRAY / ARRAY<T>.
+func (p *Parser) parseArrayConstructor(hasArrayKeyword bool, elemType *ast.TypeRef) (ast.Node, error) {
+	openTok := p.advance() // '['
+	ae := &ast.ArrayExpr{HasArrayKeyword: hasArrayKeyword, ElemType: elemType}
+	start := openTok.Loc.Start
+	if elemType != nil {
+		start = elemType.Loc.Start
+	} else if hasArrayKeyword {
+		start = p.prev.Loc.Start // ARRAY keyword captured by caller; approximate
+	}
+	if p.cur.Type != int(']') {
+		elems, err := p.parseExprCommaList()
+		if err != nil {
+			return nil, err
+		}
+		ae.Elements = elems
+	}
+	closeTok, err := p.expect(int(']'))
+	if err != nil {
+		return nil, err
+	}
+	ae.Loc = ast.Loc{Start: start, End: closeTok.Loc.End}
+	return ae, nil
+}
+
+// parseStructOrTyped parses a STRUCT-led primary: `STRUCT(args)`,
+// `STRUCT<…>(args)`, or `STRUCT { … }` / `STRUCT<…> { … }` braced. STRUCT is the
+// current token.
+func (p *Parser) parseStructOrTyped() (ast.Node, error) {
+	switch p.peekNext().Type {
+	case int('('):
+		// STRUCT ( args ).
+		structTok := p.advance() // STRUCT
+		p.advance()              // '('
+		return p.parseStructBody(structTok.Loc.Start, true, nil)
+	case int('{'):
+		// STRUCT { … } braced (no type).
+		p.advance() // STRUCT
+		return p.parseBracedConstructor(nil)
+	case int('<'):
+		// STRUCT < … > followed by '(' (typed constructor) or '{' (braced). Use
+		// parseRawType (NOT parseType): the `(args)` that follows is the
+		// constructor's argument list, NOT an opt_type_parameters list — parseType
+		// would greedily consume `(1)` as type parameters. parseRawType stops after
+		// `STRUCT<…>`. (A field's own type params, e.g. STRUCT<x STRING(10)>, are
+		// parsed inside the template by the field's parseType and are unaffected.)
+		dt, err := p.parseRawType() // consumes STRUCT<…> only
+		if err != nil {
+			return nil, err
+		}
+		tr := &ast.TypeRef{Text: dt.String(), Loc: dt.Loc}
+		switch p.cur.Type {
+		case int('('):
+			p.advance() // '('
+			return p.parseStructBody(dt.Loc.Start, true, tr)
+		case int('{'):
+			return p.parseBracedConstructor(tr)
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseStructBody parses the parenthesized struct-constructor argument list
+// (struct_constructor_prefix*). The current token is just after '('. start
+// anchors Loc; hasStruct/typeRef carry context.
+func (p *Parser) parseStructBody(start int, hasStruct bool, typeRef *ast.TypeRef) (ast.Node, error) {
+	se := &ast.StructExpr{HasStruct: hasStruct, Type: typeRef, Loc: ast.Loc{Start: start}}
+	if p.cur.Type != int(')') {
+		for {
+			field, err := p.parseStructArg()
+			if err != nil {
+				return nil, err
+			}
+			se.Fields = append(se.Fields, field)
+			if p.cur.Type != int(',') {
+				break
+			}
+			p.advance()
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	se.Loc.End = closeTok.Loc.End
+	return se, nil
+}
+
+// parseStructArg parses one `expr [AS alias]` struct constructor argument
+// (struct_constructor_arg).
+func (p *Parser) parseStructArg() (*ast.StructFieldExpr, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	field := &ast.StructFieldExpr{Value: expr, Loc: nodeLoc(expr)}
+	if p.cur.Type == kwAS {
+		p.advance()
+		aliasTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(aliasTok)
+		if err != nil {
+			return nil, err
+		}
+		field.Alias = alias
+		field.Loc.End = aliasTok.Loc.End
+	}
+	return field, nil
+}
+
+// parseNewConstructor parses `NEW type ( args )` (new_constructor) or
+// `NEW type { … }` (braced_new_constructor). NEW is the current token. The type
+// is a type_name (parsed via the types node, which yields a path/INTERVAL form).
+func (p *Parser) parseNewConstructor() (ast.Node, error) {
+	newTok := p.advance() // NEW
+	dt, err := p.parseTypeName()
+	if err != nil {
+		return nil, err
+	}
+	tr := &ast.TypeRef{Text: dt.String(), Loc: dt.Loc}
+	nc := &ast.NewConstructor{Type: tr, Loc: newTok.Loc}
+	switch p.cur.Type {
+	case int('('):
+		p.advance() // '('
+		if p.cur.Type != int(')') {
+			for {
+				arg, err := p.parseNewArg()
+				if err != nil {
+					return nil, err
+				}
+				nc.Args = append(nc.Args, arg)
+				if p.cur.Type != int(',') {
+					break
+				}
+				p.advance()
+			}
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		nc.Loc.End = closeTok.Loc.End
+		return nc, nil
+	case int('{'):
+		braced, err := p.parseBracedConstructor(nil)
+		if err != nil {
+			return nil, err
+		}
+		nc.Braced = braced.(*ast.BracedConstructor)
+		nc.Loc.End = nc.Braced.Loc.End
+		return nc, nil
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseNewArg parses one new_constructor_arg: `expr`, `expr AS id`, or
+// `expr AS ( path )`.
+func (p *Parser) parseNewArg() (*ast.StructFieldExpr, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	field := &ast.StructFieldExpr{Value: expr, Loc: nodeLoc(expr)}
+	if p.cur.Type == kwAS {
+		p.advance()
+		if p.cur.Type == int('(') {
+			p.advance()
+			path, err := p.parsePathExpr()
+			if err != nil {
+				return nil, err
+			}
+			closeTok, err := p.expect(int(')'))
+			if err != nil {
+				return nil, err
+			}
+			field.Alias = "(" + path.String() + ")"
+			field.Loc.End = closeTok.Loc.End
+			return field, nil
+		}
+		aliasTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(aliasTok)
+		if err != nil {
+			return nil, err
+		}
+		field.Alias = alias
+		field.Loc.End = aliasTok.Loc.End
+	}
+	return field, nil
+}
+
+// parseBracedConstructor parses a proto braced constructor `{ field… }`
+// (braced_constructor). The current token is '{'. typeRef carries an optional
+// leading struct type (struct_braced_constructor). Field internals are captured
+// best-effort: each field is `path { value | : expr }` or an extension
+// `( path )`; the value expressions are retained for walking. A trailing comma
+// is permitted.
+func (p *Parser) parseBracedConstructor(typeRef *ast.TypeRef) (ast.Node, error) {
+	openTok := p.advance() // '{'
+	bc := &ast.BracedConstructor{Type: typeRef, Loc: openTok.Loc}
+	if typeRef != nil {
+		bc.Loc.Start = typeRef.Loc.Start
+	}
+	for p.cur.Type != int('}') && p.cur.Type != tokEOF {
+		// Extension field: ( path ).
+		if p.cur.Type == int('(') {
+			p.advance()
+			path, err := p.parsePathExpr()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(int(')')); err != nil {
+				return nil, err
+			}
+			bc.Fields = append(bc.Fields, path)
+		} else {
+			// path { … } | path : expr.
+			lhs, err := p.parsePathExpr()
+			if err != nil {
+				return nil, err
+			}
+			bc.Fields = append(bc.Fields, lhs)
+			switch p.cur.Type {
+			case int(':'):
+				p.advance()
+				val, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				bc.Fields = append(bc.Fields, val)
+			case int('{'):
+				nested, err := p.parseBracedConstructor(nil)
+				if err != nil {
+					return nil, err
+				}
+				bc.Fields = append(bc.Fields, nested)
+			default:
+				return nil, p.syntaxErrorAtCur()
+			}
+		}
+		// Optional comma between fields (also a trailing comma before '}').
+		if p.cur.Type == int(',') {
+			p.advance()
+		}
+	}
+	closeTok, err := p.expect(int('}'))
+	if err != nil {
+		return nil, err
+	}
+	bc.Loc.End = closeTok.Loc.End
+	return bc, nil
+}
+
+// parseReplaceFields parses `REPLACE_FIELDS(expr, value AS path, …)`
+// (replace_fields_expression). REPLACE_FIELDS is the current token.
+func (p *Parser) parseReplaceFields() (ast.Node, error) {
+	rfTok := p.advance() // REPLACE_FIELDS
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	base, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	rf := &ast.ReplaceFieldsExpr{Expr: base, Loc: rfTok.Loc}
+	for p.cur.Type == int(',') {
+		p.advance()
+		val, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwAS); err != nil {
+			return nil, err
+		}
+		path, err := p.parseGeneralizedPath()
+		if err != nil {
+			return nil, err
+		}
+		rf.Items = append(rf.Items, &ast.StructFieldExpr{Value: val, Alias: path, Loc: nodeLoc(val)})
+	}
+	if len(rf.Items) == 0 {
+		// REPLACE_FIELDS requires at least one replacement arg.
+		return nil, p.syntaxErrorAtCur()
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	rf.Loc.End = closeTok.Loc.End
+	return rf, nil
+}
+
+// parseWithExpr parses the inline `WITH(name AS expr, …, body)` expression
+// (with_expression). WITH is the current token, known (by the caller) to be
+// followed by '('. Each leading entry is `name AS expr`; the final entry is the
+// body expression.
+func (p *Parser) parseWithExpr() (ast.Node, error) {
+	// Distinguish the inline WITH(...) expression from a WITH-CTE query head: an
+	// inline WITH expression requires `WITH (` and a first entry `id AS expr`.
+	// (A query `WITH cte AS (...)` is not an expression and never reaches here in
+	// expression position; the expression node only owns WITH(...) here.)
+	if p.peekNext().Type != int('(') {
+		return nil, p.syntaxErrorAtCur()
+	}
+	withTok := p.advance() // WITH
+	p.advance()            // '('
+	we := &ast.WithExpr{Loc: withTok.Loc}
+	for {
+		nameTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwAS); err != nil {
+			return nil, err
+		}
+		bound, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		we.Vars = append(we.Vars, &ast.StructFieldExpr{Alias: name, Value: bound, Loc: ast.Loc{Start: nameTok.Loc.Start, End: nodeLoc(bound).End}})
+		if _, err := p.expect(int(',')); err != nil {
+			return nil, err
+		}
+		// After a variable, the next token decides: another `id AS …` binding, or
+		// the body expression. A binding is `identifier AS`; anything else is the
+		// body.
+		if isIdentifierStart(p.cur.Type) && p.peekNext().Type == kwAS {
+			continue
+		}
+		break
+	}
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	we.Body = body
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	we.Loc.End = closeTok.Loc.End
+	return we, nil
+}
+
+// ---------------------------------------------------------------------------
+// Parenthesized expression / subquery / EXISTS / UNNEST
+// ---------------------------------------------------------------------------
+
+// parseParenOrSubquery parses a parenthesized primary: a parenthesized query
+// `( SELECT … )` → SubqueryExpr (parenthesized_query), a bare struct-tuple
+// `( e1, e2, … )` with two or more elements → StructExpr (the
+// struct_constructor_prefix_without_keyword form), or a plain parenthesized
+// expression `( expr )` → ParenExpr. The current token is '('.
+func (p *Parser) parseParenOrSubquery() (ast.Node, error) {
+	openTok := p.advance() // '('
+
+	// Parenthesized query.
+	if p.atQueryStart() {
+		sub, _, err := p.parseSubqueryBody(openTok.Loc.Start)
+		if err != nil {
+			return nil, err
+		}
+		return sub, nil
+	}
+
+	// First element expression.
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	// Bare struct tuple: two or more comma-separated elements.
+	if p.cur.Type == int(',') {
+		se := &ast.StructExpr{HasStruct: false, Loc: openTok.Loc}
+		se.Fields = append(se.Fields, &ast.StructFieldExpr{Value: first, Loc: nodeLoc(first)})
+		for p.cur.Type == int(',') {
+			p.advance()
+			field, err := p.parseStructArg()
+			if err != nil {
+				return nil, err
+			}
+			se.Fields = append(se.Fields, field)
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		se.Loc.End = closeTok.Loc.End
+		return se, nil
+	}
+	// Plain parenthesized expression.
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ParenExpr{Expr: first, Loc: ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End}}, nil
+}
+
+// parseExistsExpr parses `EXISTS [hint] ( query )`
+// (expression_subquery_with_keyword). EXISTS is the current token.
+func (p *Parser) parseExistsExpr() (ast.Node, error) {
+	existsTok := p.advance() // EXISTS
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	raw, end, err := p.parseSubqueryBodyRaw(existsTok.Loc.Start)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ExistsExpr{RawText: raw, Loc: ast.Loc{Start: existsTok.Loc.Start, End: end}}, nil
+}
+
+// parseUnnestExpression parses `UNNEST ( expr [AS alias] [, zip-mode] )`
+// (unnest_expression) as an expression. UNNEST is the current token. It is
+// represented as a FuncCall named UNNEST so downstream consumers treat it
+// uniformly; the inner args carry the array expression(s).
+func (p *Parser) parseUnnestExpression() (ast.Node, error) {
+	unnestTok := p.advance() // UNNEST
+	name := &ast.PathExpr{Parts: []string{"UNNEST"}, Loc: unnestTok.Loc}
+	if p.cur.Type != int('(') {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return p.parseFuncCallSuffix(name)
+}
+
+// atQueryStart reports whether the current token begins a query (so a following
+// '(' opens a parenthesized_query rather than a parenthesized expression). A
+// query head is SELECT, WITH, FROM (the FROM-query form), GRAPH (GQL), or a
+// nested '(' that itself opens a query. This is the disambiguator the grammar's
+// LALR(1) lookahead applies.
+func (p *Parser) atQueryStart() bool {
+	switch p.cur.Type {
+	case kwSELECT, kwWITH, kwFROM, kwGRAPH:
+		return true
+	case int('('):
+		// A nested '(' could open a parenthesized query — but it could also open a
+		// parenthesized expression or a struct tuple. Peek one token: a SELECT/WITH
+		// after the nested '(' indicates a query.
+		switch p.peekNext().Type {
+		case kwSELECT, kwWITH, kwFROM:
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// parseSubqueryBody parses a parenthesized query body after the opening '(' has
+// been consumed (the current token is the query's first token, e.g. SELECT). It
+// captures the inner query as a SubqueryExpr with RawText set (the query grammar
+// belongs to parser-select, which fills Query later). Returns the node and the
+// end offset (past the matching ')').
+func (p *Parser) parseSubqueryBody(start int) (ast.Node, int, error) {
+	raw, end, err := p.parseSubqueryBodyRaw(start)
+	if err != nil {
+		return nil, 0, err
+	}
+	return &ast.SubqueryExpr{RawText: raw, Loc: ast.Loc{Start: start, End: end}}, end, nil
+}
+
+// parseSubqueryBodyRaw consumes a balanced parenthesized query body — the
+// current token is the first token inside the already-consumed '(' — up to and
+// including the matching ')'. It returns the inner source text (between the
+// parens, trimmed) and the end offset past the ')'. The inner query is NOT
+// parsed: the query/SELECT grammar is owned by the downstream parser-select
+// node (which depends on this one), so the expression node only records the
+// span so it accepts every subquery-bearing form the oracle accepts and so
+// parser-select can re-parse RawText when it lands.
+//
+// Balance tracks ( ) [ ] { } so a nested subquery, array, or struct inside the
+// query does not prematurely close it. An unterminated body (EOF before the
+// matching ')') is a syntax error.
+func (p *Parser) parseSubqueryBodyRaw(start int) (string, int, error) {
+	innerStart := p.cur.Loc.Start
+	depth := 1
+	innerEnd := innerStart
+	for {
+		if p.cur.Type == tokEOF {
+			return "", 0, &ParseError{Loc: p.cur.Loc, Msg: "syntax error: unterminated subquery (expected ')')"}
+		}
+		switch p.cur.Type {
+		case int('('), int('['), int('{'):
+			depth++
+		case int(')'), int(']'), int('}'):
+			depth--
+			if depth == 0 {
+				closeTok := p.advance() // consume the matching ')'
+				inner := strings.TrimSpace(p.input[absIndex(p, innerStart):absIndex(p, innerEnd)])
+				return inner, closeTok.Loc.End, nil
+			}
+		}
+		innerEnd = p.cur.Loc.End
+		p.advance()
+	}
+}
+
+// absIndex converts an absolute source offset to an index into p.input, which
+// is the current segment text. The lexer was created with NewLexerWithOffset, so
+// token offsets are absolute (baseOffset + segment index); subtract baseOffset
+// to index p.input. For the standalone ParseExpression path baseOffset is 0.
+func absIndex(p *Parser, absOffset int) int {
+	idx := absOffset - p.baseOffset
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(p.input) {
+		idx = len(p.input)
+	}
+	return idx
+}
+
+// ---------------------------------------------------------------------------
+// Lambdas, generalized paths, list helpers, hint/options skips
+// ---------------------------------------------------------------------------
+
+// tryParseParenLambda attempts to parse a parenthesized-parameter lambda
+// `( id (, id)* ) -> body` or the empty `() -> body` (lambda_argument with a
+// parenthesized list). The current token is '('. It returns (node, true, nil) on
+// success. If the parenthesized run is NOT a lambda (no trailing '->'), it does
+// NOT consume anything and returns (nil, false, nil) so the caller falls back to
+// parsing a parenthesized expression. Detection scans the balanced '(' … ')'
+// span and checks the token immediately after it for '->'.
+func (p *Parser) tryParseParenLambda() (ast.Node, bool, error) {
+	if !p.parenRunFollowedByArrow() {
+		return nil, false, nil
+	}
+	openTok := p.advance() // '('
+	var params []string
+	if p.cur.Type != int(')') {
+		for {
+			idTok, err := p.expectIdentifier()
+			if err != nil {
+				return nil, false, err
+			}
+			name, err := p.identifierText(idTok)
+			if err != nil {
+				return nil, false, err
+			}
+			params = append(params, name)
+			if p.cur.Type != int(',') {
+				break
+			}
+			p.advance()
+		}
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, false, err
+	}
+	if _, err := p.expect(tokArrow); err != nil {
+		return nil, false, err
+	}
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.LambdaExpr{Params: params, Body: body, Loc: ast.Loc{Start: openTok.Loc.Start, End: nodeLoc(body).End}}, true, nil
+}
+
+// parenRunFollowedByArrow reports whether the balanced parenthesized run
+// starting at the current '(' is immediately followed by a '->' token (the
+// signature of a parenthesized-list lambda). It uses a temporary lexer scan from
+// the saved cursor WITHOUT mutating the parser state. The parser's two-token
+// lookahead is insufficient (the param list is arbitrary-length), so this peeks
+// via a throwaway lexer cloned at the current position.
+func (p *Parser) parenRunFollowedByArrow() bool {
+	// Scan the remaining input from the current token's start with a fresh lexer.
+	startIdx := absIndex(p, p.cur.Loc.Start)
+	lx := NewLexerWithOffset(p.input[startIdx:], 0)
+	depth := 0
+	for {
+		t := lx.NextToken()
+		if t.Type == tokEOF {
+			return false
+		}
+		switch t.Type {
+		case int('('), int('['), int('{'):
+			depth++
+		case int(')'), int(']'), int('}'):
+			depth--
+			if depth == 0 {
+				// The run closed; the next token decides.
+				return lx.NextToken().Type == tokArrow
+			}
+		}
+	}
+}
+
+// captureBareSelectArg consumes a bare SELECT used as a function argument (the
+// grammar's notify-style error alternative) up to — but not including — the
+// argument list's closing ')' or a top-level ',' at bracket depth 0. It returns
+// a SubqueryExpr capturing the consumed source so the call still parses (the
+// diagnostic is recorded by the caller). The current token is SELECT.
+func (p *Parser) captureBareSelectArg(start ast.Loc) ast.Node {
+	innerStart := p.cur.Loc.Start
+	innerEnd := innerStart
+	depth := 0
+	for p.cur.Type != tokEOF {
+		if depth == 0 && (p.cur.Type == int(')') || p.cur.Type == int(',')) {
+			break
+		}
+		switch p.cur.Type {
+		case int('('), int('['), int('{'):
+			depth++
+		case int(')'), int(']'), int('}'):
+			depth--
+		}
+		innerEnd = p.cur.Loc.End
+		p.advance()
+	}
+	raw := strings.TrimSpace(p.input[absIndex(p, innerStart):absIndex(p, innerEnd)])
+	return &ast.SubqueryExpr{RawText: raw, Loc: ast.Loc{Start: start.Start, End: innerEnd}}
+}
+
+// parseGeneralizedPath parses a generalized_path_expression and renders it to a
+// string (used for REPLACE_FIELDS replacement targets, which carry a path, not a
+// general expression). It accepts `identifier`, `. identifier`, `. ( path )`,
+// and `[ expr ]` continuations. The rendering is for the StructFieldExpr.Alias
+// slot; the exact path structure is not consumed by bytebase.
+func (p *Parser) parseGeneralizedPath() (string, error) {
+	if !isIdentifierStart(p.cur.Type) {
+		return "", p.syntaxErrorAtCur()
+	}
+	tok := p.advance()
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	for {
+		switch p.cur.Type {
+		case int('.'):
+			p.advance()
+			if p.cur.Type == int('(') {
+				p.advance()
+				path, err := p.parsePathExpr()
+				if err != nil {
+					return "", err
+				}
+				if _, err := p.expect(int(')')); err != nil {
+					return "", err
+				}
+				b.WriteString(".(")
+				b.WriteString(path.String())
+				b.WriteString(")")
+				continue
+			}
+			if !isAnyKeywordIdentifier(p.cur.Type) {
+				return "", p.syntaxErrorAtCur()
+			}
+			part := p.advance()
+			pn, err := p.identifierText(part)
+			if err != nil {
+				return "", err
+			}
+			b.WriteString(".")
+			b.WriteString(pn)
+		case int('['):
+			p.advance()
+			if _, err := p.parseExpr(); err != nil {
+				return "", err
+			}
+			if _, err := p.expect(int(']')); err != nil {
+				return "", err
+			}
+			b.WriteString("[...]")
+		default:
+			return b.String(), nil
+		}
+	}
+}
+
+// parseExprCommaList parses one or more comma-separated expressions (no
+// surrounding delimiters consumed). The current token begins the first
+// expression; parsing stops at the first non-comma boundary.
+func (p *Parser) parseExprCommaList() ([]ast.Node, error) {
+	var out []ast.Node
+	for {
+		e, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+		if p.cur.Type != int(',') {
+			return out, nil
+		}
+		p.advance()
+	}
+}
+
+// parseExprListThroughParen parses a parenthesized expression list when the
+// opening '(' has already been consumed: `expr (, expr)* )`. At least one
+// expression is required (the IN / quantified-list RHS, which the grammar
+// rejects when empty — oracle: `a IN ()` rejects). Returns the elements and the
+// Loc through the closing ')'.
+func (p *Parser) parseExprListThroughParen() ([]ast.Node, ast.Loc, error) {
+	values, err := p.parseExprCommaList()
+	if err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, ast.NoLoc(), err
+	}
+	return values, closeTok.Loc, nil
+}
+
+// parseArrayTypeFromKeyword parses `ARRAY < type >` given the already-consumed
+// ARRAY keyword token (arrTok). It is a thin wrapper that reconstructs the
+// element-type parse so parseArrayType (which itself consumes ARRAY) is not
+// re-entered with the keyword already gone. The current token is '<'.
+func (p *Parser) parseArrayTypeFromKeyword(arrTok Token) (*DataType, error) {
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+	elem, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	endLoc, err := p.expectTemplateClose()
+	if err != nil {
+		return nil, err
+	}
+	return &DataType{
+		Kind:        TypeArray,
+		ElementType: elem,
+		Loc:         ast.Loc{Start: arrTok.Loc.Start, End: endLoc.End},
+	}, nil
+}
+
+// expectIdentifier consumes the current token if it can be an identifier
+// (token identifier or non-reserved keyword), else returns a syntax error.
+func (p *Parser) expectIdentifier() (Token, error) {
+	if isIdentifierStart(p.cur.Type) {
+		return p.advance(), nil
+	}
+	return Token{}, p.syntaxErrorAtCur()
+}
+
+// skipHint consumes a hint `@<int>` or `@{ … }` / `@[ <int> @] { … }` that may
+// appear before an IN/LIKE RHS or after a function call (hint). The current
+// token is '@'. It reuses the foundation's brace-balanced hint skipper. Returns
+// a *ParseError for a malformed (unterminated / empty) hint body.
+func (p *Parser) skipHint() *ParseError {
+	if p.cur.Type != int('@') {
+		return nil
+	}
+	hintStart := p.cur.Loc
+	next := p.peekNext()
+	switch {
+	case next.Type == int('{'):
+		p.advance() // '@'
+		return p.skipBalancedBraces(hintStart)
+	case next.Type == int('['):
+		p.advance() // '@'
+		p.advance() // '['
+		for p.cur.Type != tokEOF && p.cur.Type != int(']') {
+			p.advance()
+		}
+		if p.cur.Type != int(']') {
+			return &ParseError{Loc: hintStart, Msg: "unterminated hint"}
+		}
+		p.advance() // ']'
+		if p.cur.Type == int('{') {
+			return p.skipBalancedBraces(hintStart)
+		}
+		return &ParseError{Loc: hintStart, Msg: "unterminated hint"}
+	case next.Type == tokInteger:
+		p.advance() // '@'
+		p.advance() // int
+	}
+	return nil
+}
+
+// skipOptionsList consumes an options_list `( [entry (, entry)*] )` (used by
+// WITH REPORT). The current token is '('. Entry internals are not retained;
+// balance is tracked so nested parens do not close early.
+func (p *Parser) skipOptionsList() error {
+	if _, err := p.expect(int('(')); err != nil {
+		return err
+	}
+	depth := 1
+	for depth > 0 {
+		if p.cur.Type == tokEOF {
+			return &ParseError{Loc: p.cur.Loc, Msg: "syntax error: unterminated OPTIONS list"}
+		}
+		switch p.cur.Type {
+		case int('('):
+			depth++
+		case int(')'):
+			depth--
+		}
+		p.advance()
+	}
+	return nil
+}
+
+// skipGroupByTail consumes the trailing group-by of the HAVING MIN aggregate
+// modifier (group_by_clause_prefix): `GROUP [hint] [AND ORDER] BY grouping_item
+// (, grouping_item)*`. The current token is GROUP. Items are not retained;
+// each grouping_item is parsed as an expression (the common case) up to the
+// boundary. Used only for parse parity of the DP HAVING MIN form.
+func (p *Parser) skipGroupByTail() error {
+	p.advance() // GROUP
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return herr
+		}
+	}
+	if p.cur.Type == kwAND {
+		p.advance()
+		if _, err := p.expect(kwORDER); err != nil {
+			return err
+		}
+	}
+	if _, err := p.expect(kwBY); err != nil {
+		return err
+	}
+	for {
+		if _, err := p.parseExpr(); err != nil {
+			return err
+		}
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance()
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Loc helpers (local to the expressions node)
+// ---------------------------------------------------------------------------
+//
+// These compute spans directly from already-built nodes / tokens, without
+// relying on ast.NodeLoc (which is owned by ast-core and does not yet enumerate
+// the expression node types). nodeLoc reads the Loc field off any expression
+// node this package builds.
+
+// spanNodes returns the Loc spanning from a's start to b's end (both expression
+// nodes built by this package).
+func spanNodes(a, b ast.Node) ast.Loc {
+	return ast.Loc{Start: nodeLoc(a).Start, End: nodeLoc(b).End}
+}
+
+// locFromTo returns the Loc spanning from node a's start to token b's end.
+func locFromTo(a ast.Node, b Token) ast.Loc {
+	return ast.Loc{Start: nodeLoc(a).Start, End: b.Loc.End}
+}
+
+// locFromTo2 returns the Loc spanning from loc a's start to node b's end.
+func locFromTo2(a ast.Loc, b ast.Node) ast.Loc {
+	return ast.Loc{Start: a.Start, End: nodeLoc(b).End}
+}
+
+// nodeLoc reads the Loc off any expression node this package constructs. It is a
+// local type switch (not ast.NodeLoc) so the expressions node owns its own span
+// extraction independent of ast-core's NodeLoc enumeration. An unknown node
+// yields NoLoc (defensive; every node this package builds is enumerated).
+func nodeLoc(n ast.Node) ast.Loc {
+	switch v := n.(type) {
+	case *ast.Identifier:
+		return v.Loc
+	case *ast.PathExpr:
+		return v.Loc
+	case *ast.TypeRef:
+		return v.Loc
+	case *ast.StarExpr:
+		return v.Loc
+	case *ast.Literal:
+		return v.Loc
+	case *ast.TypedLiteral:
+		return v.Loc
+	case *ast.IntervalExpr:
+		return v.Loc
+	case *ast.Parameter:
+		return v.Loc
+	case *ast.SystemVariable:
+		return v.Loc
+	case *ast.ParenExpr:
+		return v.Loc
+	case *ast.UnaryExpr:
+		return v.Loc
+	case *ast.BinaryExpr:
+		return v.Loc
+	case *ast.CompareExpr:
+		return v.Loc
+	case *ast.IsExpr:
+		return v.Loc
+	case *ast.InExpr:
+		return v.Loc
+	case *ast.BetweenExpr:
+		return v.Loc
+	case *ast.LikeExpr:
+		return v.Loc
+	case *ast.CaseExpr:
+		return v.Loc
+	case *ast.CastExpr:
+		return v.Loc
+	case *ast.ExtractExpr:
+		return v.Loc
+	case *ast.FuncCall:
+		return v.Loc
+	case *ast.NamedArg:
+		return v.Loc
+	case *ast.LambdaExpr:
+		return v.Loc
+	case *ast.SequenceArg:
+		return v.Loc
+	case *ast.ArrayExpr:
+		return v.Loc
+	case *ast.StructExpr:
+		return v.Loc
+	case *ast.StructFieldExpr:
+		return v.Loc
+	case *ast.NewConstructor:
+		return v.Loc
+	case *ast.BracedConstructor:
+		return v.Loc
+	case *ast.ReplaceFieldsExpr:
+		return v.Loc
+	case *ast.WithExpr:
+		return v.Loc
+	case *ast.FieldAccess:
+		return v.Loc
+	case *ast.IndexAccess:
+		return v.Loc
+	case *ast.ExtensionAccess:
+		return v.Loc
+	case *ast.SubqueryExpr:
+		return v.Loc
+	case *ast.ExistsExpr:
+		return v.Loc
+	case *ast.ArraySubqueryExpr:
+		return v.Loc
+	default:
+		return ast.NoLoc()
+	}
+}

--- a/googlesql/parser/expr_oracle_test.go
+++ b/googlesql/parser/expr_oracle_test.go
@@ -1,0 +1,337 @@
+//go:build googlesql_oracle
+
+// Differential test for the `expressions` node against the live Cloud Spanner
+// emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestExprDifferential
+//
+// It is the PROVE gate for googlesql/expressions (correctness-protocol.md): for
+// every fixture it (1) feeds a full statement embedding the expression to the
+// emulator via the harness/googlesql-spanner CLI and reads the accept/reject
+// verdict, then (2) parses the bare expression text with omni's ParseExpression,
+// and asserts the two agree — BOTH polarities (the corpus has accept AND reject
+// cases). A harness `error` verdict (oracle could not decide) fails the fixture
+// loudly; it is never folded into accept or reject.
+//
+// The emulator speaks Spanner's dialect, a SUBSET of the BigQuery+Spanner union
+// the parser must accept (oracle.md). Every expression form covered here is in
+// the SHARED GoogleSQL core (the full precedence chain, function calls, CASE/
+// CAST/EXTRACT, array/struct constructors, access, INTERVAL, AT TIME ZONE,
+// parameters, subqueries), so the Spanner verdict is authoritative. A few
+// fixtures parse on the grammar but are semantically rejected by Spanner
+// ("X is not supported", "Table not found", "Unrecognized name", "IS DISTINCT
+// FROM is not supported", "No matching signature") — those are classified ACCEPT
+// (the grammar accepted) and asserted as accept. BigQuery-only expression forms
+// (e.g. WITH(...) inline expression, REPLACE_FIELDS, NEW proto, braced proto
+// constructors) are NOT authoritative against this emulator; they are covered by
+// the hand-written unit tests (expr_test.go) and triangulated against the legacy
+// .g4 + docs, and are deliberately excluded from this differential.
+package parser
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// exprFixture pairs a bare expression (fed to omni's ParseExpression) with a
+// full statement embedding that expression in a position where the emulator
+// yields a clean accept/reject verdict. wantParse is the expected omni outcome
+// and MUST equal the emulator's grammar verdict.
+type exprFixture struct {
+	expr      string // bare expression for ParseExpression
+	stmt      string // full statement for the oracle (one stmt, no trailing ';')
+	wantParse bool   // expected: omni parses (and oracle accepts)
+}
+
+// exprFixtures are oracle-probed expression forms. Each stmt is chosen so the
+// emulator returns a deterministic accept/reject (NOT an Unimplemented "error"):
+// most use `SELECT <expr> FROM t` (Table-not-found ⇒ accept) or `SELECT <expr>`;
+// struct/tuple-returning expressions use a field extraction (`.x` / `.field1`)
+// to dodge the emulator's "struct value cannot be returned" Unimplemented path.
+var exprFixtures = []exprFixture{
+	// --- literals (accept) ---
+	{"1", "SELECT 1", true},
+	{"1.5", "SELECT 1.5", true},
+	{"NULL", "SELECT NULL", true},
+	{"TRUE", "SELECT TRUE", true},
+	{"FALSE", "SELECT FALSE", true},
+	{"'hello'", "SELECT 'hello'", true},
+	{"'a' 'b'", "SELECT 'a' 'b'", true}, // adjacent string concatenation
+	{"b'bytes'", "SELECT b'bytes'", true},
+	{"0x1F", "SELECT 0x1F", true},
+
+	// --- typed-prefix literals (accept) ---
+	{"DATE '2020-01-01'", "SELECT DATE '2020-01-01'", true},
+	{"TIMESTAMP '2020-01-01 00:00:00'", "SELECT TIMESTAMP '2020-01-01 00:00:00'", true},
+	{"NUMERIC '1.5'", "SELECT NUMERIC '1.5'", true},
+	{"JSON '{}'", "SELECT JSON '{}'", true},
+
+	// --- parameters (accept; semantic) ---
+	{"@p", "SELECT @p", true},
+	{"@@sysvar", "SELECT @@sysvar", true},
+
+	// --- identifiers / paths (accept; semantic Table-not-found / Unrecognized) ---
+	{"a", "SELECT a FROM t", true},
+	{"t.a.b", "SELECT t.a.b FROM t", true},
+
+	// --- arithmetic / precedence (accept) ---
+	{"1 + 2 * 3", "SELECT 1 + 2 * 3", true},
+	{"(1 + 2) * 3", "SELECT (1 + 2) * 3", true},
+	{"1 - 2 - 3", "SELECT 1 - 2 - 3", true},
+	{"- - 1", "SELECT - - 1", true},
+	{"~ 5", "SELECT ~ 5", true},
+	{"5 & 3 | 1", "SELECT 5 & 3 | 1", true},
+	{"1 << 2 + 3", "SELECT 1 << 2 + 3", true},
+	{"'a' || 'b' || 'c'", "SELECT 'a' || 'b' || 'c'", true},
+
+	// --- logical (accept) ---
+	{"TRUE AND FALSE OR TRUE", "SELECT TRUE AND FALSE OR TRUE", true},
+	{"NOT TRUE", "SELECT NOT TRUE", true},
+	{"NOT NOT TRUE", "SELECT NOT NOT TRUE", true},
+	{"NOT 1 = 1", "SELECT NOT 1 = 1", true},
+
+	// --- comparison family (accept) ---
+	{"1 = 2", "SELECT 1 = 2", true},
+	{"1 != 2", "SELECT 1 != 2", true},
+	{"1 <> 2", "SELECT 1 <> 2", true},
+	{"1 < 2", "SELECT 1 < 2", true},
+	{"1 >= 2", "SELECT 1 >= 2", true},
+	{"1 + 2 = 3", "SELECT 1 + 2 = 3", true},
+	{"a IS NULL", "SELECT a IS NULL FROM t", true},
+	{"a IS NOT NULL", "SELECT a IS NOT NULL FROM t", true},
+	{"1 IS TRUE", "SELECT 1 IS TRUE", true},
+	{"1 IS NOT FALSE", "SELECT 1 IS NOT FALSE", true},
+	{"1 IS UNKNOWN", "SELECT 1 IS UNKNOWN", true},
+	{"a IS NOT DISTINCT FROM b", "SELECT a IS NOT DISTINCT FROM b FROM t", true},
+	{"a BETWEEN 1 AND 2", "SELECT a BETWEEN 1 AND 2 FROM t", true},
+	{"a NOT BETWEEN 1 AND 2", "SELECT a NOT BETWEEN 1 AND 2 FROM t", true},
+	{"a IN (1, 2, 3)", "SELECT a IN (1, 2, 3) FROM t", true},
+	{"a IN (1)", "SELECT a IN (1) FROM t", true},
+	{"a NOT IN (1, 2)", "SELECT a NOT IN (1, 2) FROM t", true},
+	{"a IN UNNEST([1, 2])", "SELECT a IN UNNEST([1, 2]) FROM t", true},
+	{"a IN (SELECT x FROM t2)", "SELECT a IN (SELECT x FROM t2) FROM t", true},
+	{"x LIKE '%a%'", "SELECT x LIKE '%a%' FROM t", true},
+	{"x NOT LIKE '%a%'", "SELECT x NOT LIKE '%a%' FROM t", true},
+	{"x LIKE ANY ('a', 'b')", "SELECT x LIKE ANY ('a', 'b') FROM t", true},
+
+	// --- CASE (accept) ---
+	{"CASE WHEN a THEN 1 ELSE 2 END", "SELECT CASE WHEN a THEN 1 ELSE 2 END FROM t", true},
+	{"CASE a WHEN 1 THEN 2 END", "SELECT CASE a WHEN 1 THEN 2 END FROM t", true},
+	{"CASE WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE 5 END", "SELECT CASE WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE 5 END", true},
+
+	// --- CAST / EXTRACT (accept) ---
+	{"CAST(x AS INT64)", "SELECT CAST(x AS INT64) FROM t", true},
+	{"SAFE_CAST(x AS STRING)", "SELECT SAFE_CAST(x AS STRING) FROM t", true},
+	{"CAST(x AS STRING FORMAT 'fmt')", "SELECT CAST(x AS STRING FORMAT 'fmt') FROM t", true},
+	{"CAST(x AS STRING FORMAT 'f' AT TIME ZONE 'UTC')", "SELECT CAST(x AS STRING FORMAT 'f' AT TIME ZONE 'UTC') FROM t", true},
+	{"EXTRACT(YEAR FROM d)", "SELECT EXTRACT(YEAR FROM d) FROM t", true},
+	{"EXTRACT(HOUR FROM ts AT TIME ZONE 'UTC')", "SELECT EXTRACT(HOUR FROM ts AT TIME ZONE 'UTC') FROM t", true},
+
+	// --- function calls (accept) ---
+	{"f(x, y)", "SELECT f(x, y) FROM t", true},
+	{"mypkg.myfunc(x)", "SELECT mypkg.myfunc(x) FROM t", true},
+	{"COUNT(*)", "SELECT COUNT(*) FROM t", true},
+	{"COUNT(DISTINCT x)", "SELECT COUNT(DISTINCT x) FROM t", true},
+	{"IF(a, 1, 2)", "SELECT IF(a, 1, 2) FROM t", true},
+	{"GROUPING(x)", "SELECT GROUPING(x) FROM t", true},
+	{"ARRAY_AGG(x IGNORE NULLS)", "SELECT ARRAY_AGG(x IGNORE NULLS) FROM t", true},
+	{"ARRAY_AGG(x ORDER BY y)", "SELECT ARRAY_AGG(x ORDER BY y) FROM t", true},
+	{"ARRAY_AGG(x LIMIT 10)", "SELECT ARRAY_AGG(x LIMIT 10) FROM t", true},
+	{"func(a => 1, b => 2)", "SELECT func(a => 1, b => 2)", true},
+	{"ARRAY_TRANSFORM([1], e -> e + 1)", "SELECT ARRAY_TRANSFORM([1], e -> e + 1)", true},
+	{"REDUCE([1], (a, b) -> a + b)", "SELECT REDUCE([1], (a, b) -> a + b)", true},
+
+	// --- window (accept) ---
+	{"SUM(x) OVER (PARTITION BY a ORDER BY b)", "SELECT SUM(x) OVER (PARTITION BY a ORDER BY b) FROM t", true},
+	{"SUM(x) OVER w", "SELECT SUM(x) OVER w FROM t", true},
+	{"ROW_NUMBER() OVER (ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+		"SELECT ROW_NUMBER() OVER (ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t", true},
+	{"COUNT(*) OVER ()", "SELECT COUNT(*) OVER () FROM t", true},
+
+	// --- array constructors (accept) ---
+	{"[1, 2, 3]", "SELECT [1, 2, 3]", true},
+	{"ARRAY[1, 2]", "SELECT ARRAY[1, 2]", true},
+	{"ARRAY<INT64>[1, 2]", "SELECT ARRAY<INT64>[1, 2]", true},
+	{"[]", "SELECT []", true}, // empty array literal (oracle: accept)
+	{"ARRAY<INT64>[]", "SELECT ARRAY<INT64>[]", true},
+
+	// --- struct constructors (accept; field-extracted to dodge struct-return) ---
+	{"STRUCT(1 AS x, 2 AS y)", "SELECT STRUCT(1 AS x, 2 AS y).x", true},
+	{"STRUCT<x INT64, y STRING>(1, 'a')", "SELECT STRUCT<x INT64, y STRING>(1, 'a').x", true},
+	{"STRUCT()", "SELECT STRUCT().field1", true}, // empty struct constructor
+	{"(1, 2, 3)", "SELECT (1, 2, 3).field1", true},
+
+	// --- access (accept) ---
+	{"a[0]", "SELECT a[0] FROM t", true},
+	{"a[OFFSET(0)]", "SELECT a[OFFSET(0)] FROM t", true},
+	{"a[ORDINAL(1)]", "SELECT a[ORDINAL(1)] FROM t", true},
+	{"a[SAFE_OFFSET(0)]", "SELECT a[SAFE_OFFSET(0)] FROM t", true},
+	{"f(x).y", "SELECT f(x).y FROM t", true},
+	{"a[0].b", "SELECT a[0].b FROM t", true},
+
+	// --- INTERVAL (accept) ---
+	{"INTERVAL 5 DAY", "SELECT INTERVAL 5 DAY", true},
+	{"INTERVAL x YEAR TO MONTH", "SELECT INTERVAL x YEAR TO MONTH FROM t", true},
+
+	// --- subqueries (accept) ---
+	{"EXISTS(SELECT 1)", "SELECT EXISTS(SELECT 1)", true},
+	{"ARRAY(SELECT 1)", "SELECT ARRAY(SELECT 1)", true},
+	{"(SELECT 1) + 2", "SELECT (SELECT 1) + 2", true},
+
+	// =====================================================================
+	// NEGATIVES — all reject (syntax)
+	// =====================================================================
+	{"1 +", "SELECT 1 +", false},
+	{"1 2", "SELECT 1 2", false},
+	{"a BETWEEN 1", "SELECT a BETWEEN 1 FROM t", false},
+	{"a BETWEEN 1 OR 2", "SELECT a BETWEEN 1 OR 2 FROM t", false},
+	{"a = b = c", "SELECT a = b = c FROM t", false},
+	{"1 < 2 < 3", "SELECT 1 < 2 < 3", false},
+	{"a = b IS NULL", "SELECT a = b IS NULL FROM t", false},
+	{"a IN (1) IN (2)", "SELECT a IN (1) IN (2) FROM t", false},
+	{"1 IS NULL IS NULL", "SELECT 1 IS NULL IS NULL", false},
+	{"1 LIKE 'a' LIKE 'b'", "SELECT 1 LIKE 'a' LIKE 'b'", false},
+	{"1 BETWEEN 0 AND 2 BETWEEN 0 AND 1", "SELECT 1 BETWEEN 0 AND 2 BETWEEN 0 AND 1", false},
+	{"CASE END", "SELECT CASE END", false},
+	{"CAST(x INT64)", "SELECT CAST(x INT64) FROM t", false},
+	{"CAST(x AS)", "SELECT CAST(x AS) FROM t", false},
+	{"CAST(CAST AS INT64)", "SELECT CAST(CAST AS INT64)", false},
+	{"EXTRACT(x y)", "SELECT EXTRACT(x y) FROM t", false},
+	{"a IN ()", "SELECT a IN () FROM t", false},
+	{"a..b", "SELECT a..b FROM t", false},
+	{"* 5", "SELECT * 5", false},
+	{"EXTRACT(HOUR FROM ts @ TIME ZONE 'UTC')", "SELECT EXTRACT(HOUR FROM ts @ TIME ZONE 'UTC') FROM t", false},
+}
+
+func TestExprDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live differential")
+	}
+	h := newExprHarness(t)
+	defer h.close()
+
+	for _, fx := range exprFixtures {
+		fx := fx
+		t.Run(fx.expr, func(t *testing.T) {
+			// 1. Oracle verdict for the embedded statement.
+			v := h.verdict(t, fx.stmt)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; fix the wrapper/emulator — do NOT treat as accept/reject",
+					fx.stmt, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.stmt)
+			}
+			oracleAccepts := v.Verdict == "accept"
+
+			// Sanity: the asserted wantParse must match the live oracle.
+			if oracleAccepts != fx.wantParse {
+				t.Fatalf("fixture wantParse=%v but oracle says %q (%s) for %q",
+					fx.wantParse, v.Verdict, v.Message, fx.stmt)
+			}
+
+			// 2. omni ParseExpression verdict on the bare expression.
+			_, errs := ParseExpression(fx.expr)
+			omniAccepts := len(errs) == 0
+
+			if omniAccepts != oracleAccepts {
+				t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s)",
+					fx.expr, omniAccepts, oracleAccepts, v.Reason, v.Message)
+			}
+		})
+	}
+}
+
+// --- harness plumbing (one persistent batch process, mirrors datatypes_oracle_test) ---
+
+type exprHarnessVerdict struct {
+	Verdict string `json:"verdict"`
+	Kind    string `json:"kind"`
+	Reason  string `json:"reason"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type exprHarness struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	mu     sync.Mutex
+}
+
+func newExprHarness(t *testing.T) *exprHarness {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	projDir := filepath.Join(repoRoot, "harness", "googlesql-spanner")
+	if _, err := os.Stat(projDir); err != nil {
+		t.Skipf("harness project not found at %s", projDir)
+	}
+
+	bin := filepath.Join(projDir, "googlesql-spanner")
+	if _, err := os.Stat(bin); err != nil {
+		build := exec.Command("go", "build", "-o", bin, ".")
+		build.Dir = projDir
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("building harness failed: %v\n%s", err, out)
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(), "GOOGLESQL_HARNESS_LINE=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting harness: %v", err)
+	}
+	return &exprHarness{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdoutPipe)}
+}
+
+func (h *exprHarness) verdict(t *testing.T, stmt string) exprHarnessVerdict {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	enc := base64.StdEncoding.EncodeToString([]byte(stmt))
+	if _, err := fmt.Fprintln(h.stdin, enc); err != nil {
+		t.Fatalf("writing to harness: %v", err)
+	}
+	line, err := h.stdout.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading harness verdict: %v", err)
+	}
+	var v exprHarnessVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &v); err != nil {
+		t.Fatalf("decoding harness verdict %q: %v", line, err)
+	}
+	return v
+}
+
+func (h *exprHarness) close() {
+	if h.stdin != nil {
+		_ = h.stdin.Close()
+	}
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Wait()
+	}
+}

--- a/googlesql/parser/expr_test.go
+++ b/googlesql/parser/expr_test.go
@@ -1,0 +1,756 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// expr_test.go is the hand-written unit suite for the `expressions` node. It
+// complements expr_oracle_test.go (the live Spanner-emulator differential):
+//
+//   - the differential proves accept/reject parity for SHARED GoogleSQL-core
+//     forms against the live oracle (both polarities);
+//   - this file proves (a) STRUCTURAL correctness — precedence/associativity
+//     grouping, which accept/reject cannot catch (1+2*3 "accepts" however it
+//     groups), via a deparse-style sexpr round-trip; (b) coverage of the
+//     BigQuery-only forms the Spanner emulator cannot authoritatively verdict
+//     (inline WITH(...), REPLACE_FIELDS, NEW proto / braced constructors); and
+//     (c) the node-internal invariants (Loc spans, walker traversal, the
+//     notify-style accept alternatives).
+
+// ---------------------------------------------------------------------------
+// Structural precedence / associativity (the structural gate)
+// ---------------------------------------------------------------------------
+
+// sexpr renders an expression tree to a compact prefix form so precedence and
+// associativity are asserted exactly, not just "it parsed".
+func sexpr(n ast.Node) string {
+	switch v := n.(type) {
+	case *ast.BinaryExpr:
+		return fmt.Sprintf("(%s %s %s)", v.Op, sexpr(v.Left), sexpr(v.Right))
+	case *ast.CompareExpr:
+		return fmt.Sprintf("(%s %s %s)", v.Op, sexpr(v.Left), sexpr(v.Right))
+	case *ast.UnaryExpr:
+		return fmt.Sprintf("(%s %s)", v.Op, sexpr(v.Expr))
+	case *ast.IsExpr:
+		if v.DistinctFrom != nil {
+			pfx := "ISDISTINCT"
+			if v.Not {
+				pfx = "ISNOTDISTINCT"
+			}
+			return fmt.Sprintf("(%s %s %s)", pfx, sexpr(v.Expr), sexpr(v.DistinctFrom))
+		}
+		pfx := "IS"
+		if v.Not {
+			pfx = "ISNOT"
+		}
+		return fmt.Sprintf("(%s %s %s)", pfx, sexpr(v.Expr), v.Pred)
+	case *ast.BetweenExpr:
+		pfx := "BETWEEN"
+		if v.Not {
+			pfx = "NOTBETWEEN"
+		}
+		return fmt.Sprintf("(%s %s %s %s)", pfx, sexpr(v.Expr), sexpr(v.Low), sexpr(v.High))
+	case *ast.InExpr:
+		pfx := "IN"
+		if v.Not {
+			pfx = "NOTIN"
+		}
+		var rhs string
+		switch {
+		case v.Unnest != nil:
+			rhs = "unnest"
+		case v.Subquery != nil:
+			rhs = "subq"
+		default:
+			rhs = fmt.Sprintf("%d-vals", len(v.Values))
+		}
+		return fmt.Sprintf("(%s %s %s)", pfx, sexpr(v.Expr), rhs)
+	case *ast.LikeExpr:
+		pfx := "LIKE"
+		if v.Not {
+			pfx = "NOTLIKE"
+		}
+		if v.Quantifier != "" {
+			return fmt.Sprintf("(%s-%s %s)", pfx, v.Quantifier, sexpr(v.Expr))
+		}
+		return fmt.Sprintf("(%s %s %s)", pfx, sexpr(v.Expr), sexpr(v.Pattern))
+	case *ast.Identifier:
+		return v.Name
+	case *ast.PathExpr:
+		return "path:" + v.String()
+	case *ast.Literal:
+		return v.Value
+	case *ast.TypedLiteral:
+		return v.TypeKeyword + ":" + v.Value
+	case *ast.Parameter:
+		if v.Positional {
+			return "?"
+		}
+		return "@" + v.Name
+	case *ast.SystemVariable:
+		return "@@" + strings.Join(v.Parts, ".")
+	case *ast.ParenExpr:
+		return "(paren " + sexpr(v.Expr) + ")"
+	case *ast.FieldAccess:
+		return fmt.Sprintf("(. %s %s)", sexpr(v.Expr), v.Field)
+	case *ast.IndexAccess:
+		return fmt.Sprintf("([] %s %s)", sexpr(v.Expr), sexpr(v.Index))
+	case *ast.ExtensionAccess:
+		return fmt.Sprintf("(.ext %s %s)", sexpr(v.Expr), v.Path.String())
+	case *ast.FuncCall:
+		parts := []string{"call:" + v.Name.String()}
+		if v.Distinct {
+			parts = append(parts, "DISTINCT")
+		}
+		for _, a := range v.Args {
+			parts = append(parts, sexpr(a))
+		}
+		if v.NullHandling != "" {
+			parts = append(parts, v.NullHandling)
+		}
+		if v.Over != nil {
+			parts = append(parts, "OVER")
+		}
+		return "(" + strings.Join(parts, " ") + ")"
+	case *ast.StarExpr:
+		return "*"
+	case *ast.CaseExpr:
+		pfx := "case"
+		if v.Operand != nil {
+			pfx = "case:" + sexpr(v.Operand)
+		}
+		s := pfx
+		for _, w := range v.Whens {
+			s += fmt.Sprintf(" (when %s %s)", sexpr(w.Cond), sexpr(w.Result))
+		}
+		if v.Else != nil {
+			s += " (else " + sexpr(v.Else) + ")"
+		}
+		return "(" + s + ")"
+	case *ast.CastExpr:
+		k := "cast"
+		if v.Safe {
+			k = "safecast"
+		}
+		return fmt.Sprintf("(%s %s %s)", k, sexpr(v.Expr), v.Type.Text)
+	case *ast.ExtractExpr:
+		return fmt.Sprintf("(extract %s %s)", sexpr(v.Part), sexpr(v.From))
+	case *ast.ArrayExpr:
+		return fmt.Sprintf("(array %d)", len(v.Elements))
+	case *ast.StructExpr:
+		return fmt.Sprintf("(struct %d)", len(v.Fields))
+	case *ast.IntervalExpr:
+		return fmt.Sprintf("(interval %s %s)", sexpr(v.Value), v.From)
+	case *ast.LambdaExpr:
+		return fmt.Sprintf("(lambda %s %s)", strings.Join(v.Params, ","), sexpr(v.Body))
+	case *ast.NamedArg:
+		return fmt.Sprintf("(=> %s %s)", v.Name, sexpr(v.Value))
+	case *ast.SubqueryExpr:
+		return "(subquery " + v.RawText + ")"
+	case *ast.ExistsExpr:
+		return "(exists " + v.RawText + ")"
+	case *ast.ArraySubqueryExpr:
+		return "(arraysubq " + v.RawText + ")"
+	case *ast.NewConstructor:
+		return fmt.Sprintf("(new %s %d)", v.Type.Text, len(v.Args))
+	case *ast.WithExpr:
+		return fmt.Sprintf("(with %d %s)", len(v.Vars), sexpr(v.Body))
+	case *ast.ReplaceFieldsExpr:
+		return fmt.Sprintf("(replacefields %s %d)", sexpr(v.Expr), len(v.Items))
+	case *ast.BracedConstructor:
+		return fmt.Sprintf("(braced %d)", len(v.Fields))
+	case nil:
+		return "<nil>"
+	default:
+		return "<" + n.Tag().String() + ">"
+	}
+}
+
+func mustParse(t *testing.T, in string) ast.Node {
+	t.Helper()
+	n, errs := ParseExpression(in)
+	if len(errs) != 0 {
+		t.Fatalf("ParseExpression(%q) unexpected errors: %v", in, errs)
+	}
+	if n == nil {
+		t.Fatalf("ParseExpression(%q) returned nil node", in)
+	}
+	return n
+}
+
+// TestExpr_Precedence asserts the grouping of mixed-operator expressions — the
+// structural gate accept/reject cannot cover. Each grouping was cross-checked
+// against the GoogleSQL precedence table and the live oracle's accept of the
+// equivalent semantically-revealing form (see expr_oracle_test.go probes).
+func TestExpr_Precedence(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// arithmetic
+		{"1 + 2 * 3", "(+ 1 (* 2 3))"},
+		{"1 * 2 + 3", "(+ (* 1 2) 3)"},
+		{"1 - 2 - 3", "(- (- 1 2) 3)"}, // left-assoc
+		{"1 / 2 / 3", "(/ (/ 1 2) 3)"},
+		{"-a * b", "(* (- a) b)"}, // unary tighter than *
+		{"- - 1", "(- (- 1))"},
+		{"~ 1 + 2", "(+ (~ 1) 2)"}, // unary tighter than +
+		// bitwise / shift precedence ladder: | < ^ < & < shift < +
+		{"1 | 2 ^ 3", "(| 1 (^ 2 3))"},
+		{"1 ^ 2 & 3", "(^ 1 (& 2 3))"},
+		{"1 & 2 << 3", "(& 1 (<< 2 3))"},
+		{"1 << 2 + 3", "(<< 1 (+ 2 3))"},
+		{"1 & 2 | 3 ^ 4", "(| (& 1 2) (^ 3 4))"},
+		// concat precedence (|| below shift, above comparison). The sexpr renderer
+		// shows the UNQUOTED literal body (Literal.Value), so 'a' renders as a.
+		{"'a' || 'b' || 'c'", "(|| (|| a b) c)"},
+		// comparison below bitwise
+		{"5 & 3 = 1", "(= (& 5 3) 1)"},
+		{"1 = 5 & 3", "(= 1 (& 5 3))"},
+		// logical: AND tighter than OR, both left-assoc
+		{"a OR b AND c", "(OR a (AND b c))"},
+		{"a AND b OR c", "(OR (AND a b) c)"},
+		{"a AND b AND c", "(AND (AND a b) c)"},
+		{"a OR b OR c", "(OR (OR a b) c)"},
+		{"TRUE AND FALSE OR TRUE", "(OR (AND TRUE FALSE) TRUE)"},
+		// NOT below comparison (P2), above AND
+		{"NOT a = b", "(NOT (= a b))"},
+		{"NOT a IS NULL", "(NOT (IS a NULL))"},
+		{"NOT a AND b", "(AND (NOT a) b)"},
+		{"NOT NOT a", "(NOT (NOT a))"},
+		// access tighter than everything
+		{"a.b.c", "path:a.b.c"},
+		{"f(x).y", "(. (call:f x) y)"},
+		{"a[0].b", "(. ([] a 0) b)"},
+		{"a.b[0]", "([] path:a.b 0)"},
+		// `a.b` as a primary is a single dotted PathExpr (path_expression), so
+		// `-a.b` is `-(a.b)`; the unary still binds looser than the path.
+		{"-a.b", "(- path:a.b)"},
+	}
+	for _, c := range cases {
+		got := sexpr(mustParse(t, c.in))
+		if got != c.want {
+			t.Errorf("%q: got %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+// TestExpr_NonAssociative asserts the comparison family is non-associative (P1):
+// chaining two comparison-family operators at the same level is a syntax error.
+// (Cross-checked against the live oracle, which rejects each of these.)
+func TestExpr_NonAssociative(t *testing.T) {
+	rejects := []string{
+		"a = b = c",
+		"1 < 2 < 3",
+		"a = b IS NULL",
+		"a IN (1) IN (2)",
+		"1 IS NULL IS NULL",
+		"1 LIKE 'a' LIKE 'b'",
+		"1 BETWEEN 0 AND 2 BETWEEN 0 AND 1",
+		"a < b > c",
+		"1 = 2 != 3",
+	}
+	for _, in := range rejects {
+		if _, errs := ParseExpression(in); len(errs) == 0 {
+			t.Errorf("ParseExpression(%q): expected a syntax error (non-associative), got none", in)
+		}
+	}
+	// But a comparison nested in parens or under AND/OR is fine.
+	accepts := []string{
+		"(a = b) = c",
+		"a = b AND c = d",
+		"a < b OR c > d",
+		"1 BETWEEN 0 AND 2 AND TRUE",
+	}
+	for _, in := range accepts {
+		if _, errs := ParseExpression(in); len(errs) != 0 {
+			t.Errorf("ParseExpression(%q): expected accept, got %v", in, errs)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primary forms — structural shape assertions
+// ---------------------------------------------------------------------------
+
+func TestExpr_Literals(t *testing.T) {
+	cases := []struct {
+		in   string
+		kind ast.LiteralKind
+		val  string
+	}{
+		{"42", ast.LitInt, "42"},
+		{"0x10", ast.LitInt, "0x10"},
+		{"3.14", ast.LitFloat, "3.14"},
+		{"NULL", ast.LitNull, "NULL"},
+		{"TRUE", ast.LitBool, "TRUE"},
+		{"FALSE", ast.LitBool, "FALSE"},
+		{"'str'", ast.LitString, "str"},
+		{"b'by'", ast.LitBytes, "by"},
+	}
+	for _, c := range cases {
+		n := mustParse(t, c.in)
+		lit, ok := n.(*ast.Literal)
+		if !ok {
+			t.Errorf("%q: got %T, want *ast.Literal", c.in, n)
+			continue
+		}
+		if lit.Kind != c.kind || lit.Value != c.val {
+			t.Errorf("%q: got {%s %q}, want {%s %q}", c.in, lit.Kind, lit.Value, c.kind, c.val)
+		}
+	}
+	// Integer value is captured.
+	if lit := mustParse(t, "42").(*ast.Literal); lit.Ival != 42 {
+		t.Errorf("integer Ival: got %d, want 42", lit.Ival)
+	}
+	// Adjacent string concatenation merges into one value.
+	if lit := mustParse(t, "'ab' 'cd'").(*ast.Literal); lit.Value != "abcd" {
+		t.Errorf("string concat: got %q, want %q", lit.Value, "abcd")
+	}
+}
+
+func TestExpr_TypedLiterals(t *testing.T) {
+	cases := []struct{ in, kw, val string }{
+		{"DATE '2020-01-01'", "DATE", "2020-01-01"},
+		{"TIMESTAMP '2020-01-01'", "TIMESTAMP", "2020-01-01"},
+		{"NUMERIC '1.5'", "NUMERIC", "1.5"},
+		{"BIGNUMERIC '9'", "BIGNUMERIC", "9"},
+		{"JSON '{}'", "JSON", "{}"},
+		{"DATETIME '2020-01-01'", "DATETIME", "2020-01-01"},
+		{"TIME '00:00'", "TIME", "00:00"},
+	}
+	for _, c := range cases {
+		n := mustParse(t, c.in)
+		tl, ok := n.(*ast.TypedLiteral)
+		if !ok {
+			t.Errorf("%q: got %T, want *ast.TypedLiteral", c.in, n)
+			continue
+		}
+		if tl.TypeKeyword != c.kw || tl.Value != c.val {
+			t.Errorf("%q: got {%s %q}, want {%s %q}", c.in, tl.TypeKeyword, tl.Value, c.kw, c.val)
+		}
+	}
+	// RANGE<T> '…' renders the element type into the keyword.
+	rl := mustParse(t, "RANGE<DATE> '[2020-01-01, 2020-12-31)'").(*ast.TypedLiteral)
+	if !strings.HasPrefix(rl.TypeKeyword, "RANGE<") {
+		t.Errorf("range literal keyword = %q, want RANGE<…>", rl.TypeKeyword)
+	}
+	// A bare type keyword NOT followed by a string is NOT a typed literal.
+	if _, ok := mustParse(t, "DATE").(*ast.Identifier); !ok {
+		t.Errorf("bare DATE: want *ast.Identifier")
+	}
+	if fc, ok := mustParse(t, "DATE(x)").(*ast.FuncCall); !ok || fc.Name.String() != "DATE" {
+		t.Errorf("DATE(x): want a FuncCall named DATE")
+	}
+}
+
+func TestExpr_Parameters(t *testing.T) {
+	if p := mustParse(t, "@foo").(*ast.Parameter); p.Name != "foo" || p.Positional {
+		t.Errorf("@foo = %+v", p)
+	}
+	if p := mustParse(t, "?").(*ast.Parameter); !p.Positional {
+		t.Errorf("? should be positional")
+	}
+	if sv := mustParse(t, "@@a.b.c").(*ast.SystemVariable); strings.Join(sv.Parts, ".") != "a.b.c" {
+		t.Errorf("@@a.b.c parts = %v", sv.Parts)
+	}
+}
+
+func TestExpr_Paths(t *testing.T) {
+	// Single identifier → Identifier; dotted → PathExpr.
+	if id, ok := mustParse(t, "col").(*ast.Identifier); !ok || id.Name != "col" {
+		t.Errorf("col: want Identifier{col}")
+	}
+	if pe, ok := mustParse(t, "a.b.c").(*ast.PathExpr); !ok || pe.String() != "a.b.c" {
+		t.Errorf("a.b.c: want PathExpr a.b.c")
+	}
+	// Backtick identifiers are unquoted by the lexer.
+	if id, ok := mustParse(t, "`weird name`").(*ast.Identifier); !ok || id.Name != "weird name" {
+		t.Errorf("backtick ident: got %#v", mustParse(t, "`weird name`"))
+	}
+	// Non-reserved keyword as a bare identifier.
+	if _, ok := mustParse(t, "data").(*ast.Identifier); !ok {
+		t.Errorf("non-reserved keyword `data` should parse as identifier")
+	}
+}
+
+// TestExpr_FunctionCalls covers the function-call suffix grammar: positional /
+// named / lambda / sequence args, DISTINCT, *, null-handling, ORDER BY, LIMIT,
+// and keyword function names.
+func TestExpr_FunctionCalls(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"f()", "(call:f)"},
+		{"f(1, 2)", "(call:f 1 2)"},
+		{"COUNT(*)", "(call:COUNT *)"},
+		{"COUNT(DISTINCT x)", "(call:COUNT DISTINCT x)"},
+		{"f(a => 1, b => 2)", "(call:f (=> a 1) (=> b 2))"},
+		{"ARRAY_AGG(x IGNORE NULLS)", "(call:ARRAY_AGG x IGNORE NULLS)"},
+		{"ARRAY_AGG(x RESPECT NULLS)", "(call:ARRAY_AGG x RESPECT NULLS)"},
+		{"f(x -> x + 1)", "(call:f (lambda x (+ x 1)))"},
+		{"f((a, b) -> a)", "(call:f (lambda a,b a))"},
+		{"f(() -> 1)", "(call:f (lambda  1))"},
+		{"pkg.sub.fn(x)", "(call:pkg.sub.fn x)"},
+		{"IF(a, b, c)", "(call:IF a b c)"},
+		{"GROUPING(x)", "(call:GROUPING x)"},
+		{"LEFT(s, 3)", "(call:LEFT s 3)"},
+	}
+	for _, c := range cases {
+		got := sexpr(mustParse(t, c.in))
+		if got != c.want {
+			t.Errorf("%q: got %s, want %s", c.in, got, c.want)
+		}
+	}
+	// ORDER BY / LIMIT inside an aggregate.
+	fc := mustParse(t, "ARRAY_AGG(x ORDER BY y DESC LIMIT 5)").(*ast.FuncCall)
+	if len(fc.OrderBy) != 1 || !fc.OrderBy[0].Desc || fc.Limit == nil {
+		t.Errorf("ARRAY_AGG order/limit: orderBy=%v limit=%v", fc.OrderBy, fc.Limit)
+	}
+}
+
+// TestExpr_Window covers OVER clauses: named window, inline partition/order/frame.
+func TestExpr_Window(t *testing.T) {
+	// Named window.
+	fc := mustParse(t, "SUM(x) OVER w").(*ast.FuncCall)
+	if fc.Over == nil || fc.Over.Name != "w" || fc.Over.Inline {
+		t.Fatalf("OVER w: %+v", fc.Over)
+	}
+	// Inline with partition + order + frame.
+	fc = mustParse(t, "SUM(x) OVER (PARTITION BY a, b ORDER BY c DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)").(*ast.FuncCall)
+	w := fc.Over
+	if w == nil || !w.Inline {
+		t.Fatalf("inline window not parsed: %+v", w)
+	}
+	if len(w.PartitionBy) != 2 {
+		t.Errorf("PARTITION BY count = %d, want 2", len(w.PartitionBy))
+	}
+	if len(w.OrderBy) != 1 || !w.OrderBy[0].Desc {
+		t.Errorf("ORDER BY = %v", w.OrderBy)
+	}
+	if w.Frame == nil || w.Frame.Kind != ast.FrameRows || !w.Frame.Between {
+		t.Fatalf("frame = %+v", w.Frame)
+	}
+	if w.Frame.Start.Kind != ast.BoundUnboundedPreceding || w.Frame.End.Kind != ast.BoundCurrentRow {
+		t.Errorf("frame bounds = %+v / %+v", w.Frame.Start, w.Frame.End)
+	}
+	// Single-bound frame with an offset expr.
+	fc = mustParse(t, "AVG(x) OVER (ORDER BY t RANGE 5 PRECEDING)").(*ast.FuncCall)
+	if fc.Over.Frame == nil || fc.Over.Frame.Between || fc.Over.Frame.Start.Kind != ast.BoundPreceding || fc.Over.Frame.Start.Offset == nil {
+		t.Errorf("single-bound frame = %+v", fc.Over.Frame)
+	}
+}
+
+func TestExpr_CaseCastExtract(t *testing.T) {
+	// Searched CASE.
+	ce := mustParse(t, "CASE WHEN a THEN 1 WHEN b THEN 2 ELSE 3 END").(*ast.CaseExpr)
+	if ce.Operand != nil || len(ce.Whens) != 2 || ce.Else == nil {
+		t.Errorf("searched CASE: operand=%v whens=%d else=%v", ce.Operand, len(ce.Whens), ce.Else)
+	}
+	// Simple CASE.
+	ce = mustParse(t, "CASE x WHEN 1 THEN 'a' END").(*ast.CaseExpr)
+	if ce.Operand == nil || len(ce.Whens) != 1 || ce.Else != nil {
+		t.Errorf("simple CASE: operand=%v whens=%d else=%v", ce.Operand, len(ce.Whens), ce.Else)
+	}
+	// CAST / SAFE_CAST with the rendered type.
+	cast := mustParse(t, "CAST(x AS ARRAY<INT64>)").(*ast.CastExpr)
+	if cast.Safe || cast.Type.Text != "ARRAY<INT64>" {
+		t.Errorf("CAST type = %q safe=%v", cast.Type.Text, cast.Safe)
+	}
+	if !mustParse(t, "SAFE_CAST(x AS STRING)").(*ast.CastExpr).Safe {
+		t.Errorf("SAFE_CAST: Safe should be true")
+	}
+	// CAST with FORMAT + AT TIME ZONE.
+	cast = mustParse(t, "CAST(x AS STRING FORMAT 'f' AT TIME ZONE 'UTC')").(*ast.CastExpr)
+	if cast.Format == nil || cast.TimeZone == nil {
+		t.Errorf("CAST format/tz: format=%v tz=%v", cast.Format, cast.TimeZone)
+	}
+	// EXTRACT with AT TIME ZONE.
+	ee := mustParse(t, "EXTRACT(HOUR FROM ts AT TIME ZONE 'UTC')").(*ast.ExtractExpr)
+	if ee.Part == nil || ee.From == nil || ee.TimeZone == nil {
+		t.Errorf("EXTRACT: %+v", ee)
+	}
+}
+
+func TestExpr_ArrayStruct(t *testing.T) {
+	// Bare / ARRAY / typed array.
+	ae := mustParse(t, "[1, 2, 3]").(*ast.ArrayExpr)
+	if ae.HasArrayKeyword || ae.ElemType != nil || len(ae.Elements) != 3 {
+		t.Errorf("[1,2,3]: %+v", ae)
+	}
+	ae = mustParse(t, "ARRAY[1, 2]").(*ast.ArrayExpr)
+	if !ae.HasArrayKeyword || len(ae.Elements) != 2 {
+		t.Errorf("ARRAY[1,2]: %+v", ae)
+	}
+	ae = mustParse(t, "ARRAY<INT64>[1]").(*ast.ArrayExpr)
+	if !ae.HasArrayKeyword || ae.ElemType == nil || ae.ElemType.Text != "ARRAY<INT64>" {
+		t.Errorf("ARRAY<INT64>[1]: elemType=%v", ae.ElemType)
+	}
+	if len(mustParse(t, "[]").(*ast.ArrayExpr).Elements) != 0 {
+		t.Errorf("empty array should have 0 elements")
+	}
+	// STRUCT forms.
+	se := mustParse(t, "STRUCT(1 AS x, 2 AS y)").(*ast.StructExpr)
+	if !se.HasStruct || se.Type != nil || len(se.Fields) != 2 || se.Fields[0].Alias != "x" {
+		t.Errorf("STRUCT(...): %+v", se)
+	}
+	se = mustParse(t, "STRUCT<x INT64>(1)").(*ast.StructExpr)
+	if !se.HasStruct || se.Type == nil || se.Type.Text != "STRUCT<x INT64>" || len(se.Fields) != 1 {
+		t.Errorf("STRUCT<x INT64>(1): type=%v fields=%d", se.Type, len(se.Fields))
+	}
+	// Bare tuple (>= 2 elements) is a struct.
+	se = mustParse(t, "(1, 2, 3)").(*ast.StructExpr)
+	if se.HasStruct || len(se.Fields) != 3 {
+		t.Errorf("(1,2,3): hasStruct=%v fields=%d", se.HasStruct, len(se.Fields))
+	}
+	// A single parenthesized expr is NOT a struct.
+	if _, ok := mustParse(t, "(1)").(*ast.ParenExpr); !ok {
+		t.Errorf("(1): want ParenExpr, got %T", mustParse(t, "(1)"))
+	}
+}
+
+func TestExpr_Access(t *testing.T) {
+	// OFFSET/ORDINAL inside a subscript are ordinary function calls.
+	ia := mustParse(t, "a[OFFSET(0)]").(*ast.IndexAccess)
+	fc, ok := ia.Index.(*ast.FuncCall)
+	if !ok || fc.Name.String() != "OFFSET" {
+		t.Errorf("a[OFFSET(0)] index = %T", ia.Index)
+	}
+	// Extension access `. ( path )`.
+	ext := mustParse(t, "a.(pkg.field)").(*ast.ExtensionAccess)
+	if ext.Path.String() != "pkg.field" {
+		t.Errorf("extension path = %q", ext.Path.String())
+	}
+	// Chained access folds left.
+	if got := sexpr(mustParse(t, "a.b[0].c")); got != "(. ([] path:a.b 0) c)" {
+		t.Errorf("a.b[0].c = %s", got)
+	}
+}
+
+func TestExpr_Interval(t *testing.T) {
+	ie := mustParse(t, "INTERVAL 5 DAY").(*ast.IntervalExpr)
+	if ie.From != "DAY" || ie.To != "" {
+		t.Errorf("INTERVAL 5 DAY: from=%q to=%q", ie.From, ie.To)
+	}
+	ie = mustParse(t, "INTERVAL x YEAR TO MONTH").(*ast.IntervalExpr)
+	if ie.From != "YEAR" || ie.To != "MONTH" {
+		t.Errorf("INTERVAL TO: from=%q to=%q", ie.From, ie.To)
+	}
+}
+
+func TestExpr_Subqueries(t *testing.T) {
+	// Subquery RawText captures the inner query (Query stays nil for parser-select).
+	sq := mustParse(t, "(SELECT 1)").(*ast.SubqueryExpr)
+	if sq.Query != nil || sq.RawText != "SELECT 1" {
+		t.Errorf("subquery: query=%v raw=%q", sq.Query, sq.RawText)
+	}
+	ex := mustParse(t, "EXISTS(SELECT x FROM t)").(*ast.ExistsExpr)
+	if ex.RawText != "SELECT x FROM t" {
+		t.Errorf("exists raw = %q", ex.RawText)
+	}
+	as := mustParse(t, "ARRAY(SELECT 1)").(*ast.ArraySubqueryExpr)
+	if as.RawText != "SELECT 1" {
+		t.Errorf("array subquery raw = %q", as.RawText)
+	}
+	// Balanced nesting inside the subquery body.
+	sq = mustParse(t, "(SELECT f(1, (2 + 3)) FROM t WHERE x IN (1, 2))").(*ast.SubqueryExpr)
+	if !strings.Contains(sq.RawText, "WHERE x IN (1, 2)") {
+		t.Errorf("nested subquery raw = %q", sq.RawText)
+	}
+	// A subquery participates in an outer expression.
+	if got := sexpr(mustParse(t, "(SELECT 1) + 2")); got != "(+ (subquery SELECT 1) 2)" {
+		t.Errorf("(SELECT 1)+2 = %s", got)
+	}
+}
+
+// TestExpr_BigQueryOnly covers forms the Spanner emulator cannot authoritatively
+// verdict (BigQuery-only). They are validated structurally here and triangulated
+// against the legacy GoogleSQLParser.g4 (which parses each) + the BigQuery docs.
+// (oracle.md routing: BigQuery-only ⇒ triangulation, emulator verdict ignored.)
+func TestExpr_BigQueryOnly(t *testing.T) {
+	// Inline WITH(...) expression (with_expression).
+	we := mustParse(t, "WITH(a AS 1, b AS a + 1, a + b)").(*ast.WithExpr)
+	if len(we.Vars) != 2 || we.Vars[0].Alias != "a" || we.Body == nil {
+		t.Errorf("WITH expr: vars=%d body=%v", len(we.Vars), we.Body)
+	}
+	// NEW proto constructor (new_constructor). Use a non-keyword type name so
+	// source case is preserved (keyword-named path parts fold to upper case — a
+	// pre-existing identifierText behavior; see TestExpr_KeywordPathCaseFolding).
+	nc := mustParse(t, "NEW pkg.MyMessage(1 AS x, 2 AS y)").(*ast.NewConstructor)
+	if nc.Type.Text != "pkg.MyMessage" || len(nc.Args) != 2 {
+		t.Errorf("NEW: type=%q args=%d", nc.Type.Text, len(nc.Args))
+	}
+	// NEW with an extension-path alias.
+	nc = mustParse(t, "NEW pkg.MyMessage(v AS (ext.field))").(*ast.NewConstructor)
+	if len(nc.Args) != 1 || nc.Args[0].Alias != "(ext.field)" {
+		t.Errorf("NEW ext: %+v", nc.Args)
+	}
+	// Braced proto constructor (braced_constructor / braced_new_constructor).
+	if _, ok := mustParse(t, "NEW pkg.Type {a: 1, b: 2}").(*ast.NewConstructor); !ok {
+		t.Errorf("NEW braced: want NewConstructor")
+	}
+	bc := mustParse(t, "STRUCT<x INT64> {x: 1}").(*ast.BracedConstructor)
+	if bc.Type == nil || bc.Type.Text != "STRUCT<x INT64>" {
+		t.Errorf("struct braced: type=%v", bc.Type)
+	}
+	// REPLACE_FIELDS (replace_fields_expression).
+	rf := mustParse(t, "REPLACE_FIELDS(s, 1 AS a, 2 AS b.c)").(*ast.ReplaceFieldsExpr)
+	if len(rf.Items) != 2 || rf.Items[1].Alias != "b.c" {
+		t.Errorf("REPLACE_FIELDS: items=%d", len(rf.Items))
+	}
+}
+
+// TestExpr_KeywordPathCaseFolding documents a pre-existing, KNOWN behavior of
+// the shared identifierText helper (datatypes.go / the types+foundation nodes,
+// out of this node's writes-scope): a dotted path/type component that happens to
+// be a GoogleSQL word-keyword (e.g. TYPE, PATH, VALUE) renders in UPPER case,
+// because keyword tokens carry no source spelling and identifierText substitutes
+// the canonical keyword name. Non-keyword components preserve source case.
+//
+// This does NOT affect accept/reject parity (the live oracle accepts the form
+// regardless of case — see expr_oracle_test.go `foo.bar.Baz`), but it loses case
+// for keyword-named proto/enum path parts, which ARE case-sensitive in GoogleSQL
+// for resolution. It is flagged to the divergence ledger as an
+// identifierText/foundation issue (googlesql/expressions: "keyword-as-identifier
+// path-part case folding") for a follow-up at the lexer/foundation layer; this
+// test pins the current behavior so the fix is observed when it lands.
+func TestExpr_KeywordPathCaseFolding(t *testing.T) {
+	// Non-keyword parts keep their source case.
+	if pe := mustParse(t, "Foo.Bar.Baz").(*ast.PathExpr); pe.String() != "Foo.Bar.Baz" {
+		t.Errorf("non-keyword path case: got %q, want Foo.Bar.Baz", pe.String())
+	}
+	// A keyword-named part folds to upper case (KNOWN; documents the behavior).
+	if pe := mustParse(t, "pkg.Type").(*ast.PathExpr); pe.String() != "pkg.TYPE" {
+		t.Errorf("keyword path-part folding changed: got %q (was pkg.TYPE) — "+
+			"if identifierText now preserves case, update this test and resolve the divergence", pe.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node-internal invariants: Loc spans, walker, notify-style accepts
+// ---------------------------------------------------------------------------
+
+// TestExpr_Loc spot-checks that node Loc spans cover the full source extent of
+// the parsed construct.
+func TestExpr_Loc(t *testing.T) {
+	cases := []string{
+		"1 + 2", "f(a, b, c)", "CASE WHEN a THEN 1 END", "CAST(x AS INT64)",
+		"a[0]", "STRUCT(1 AS x)", "[1, 2, 3]", "a BETWEEN 1 AND 2",
+		"SUM(x) OVER (PARTITION BY a)",
+	}
+	for _, in := range cases {
+		n := mustParse(t, in)
+		loc := nodeLoc(n)
+		if loc.Start != 0 || loc.End != len(in) {
+			t.Errorf("%q: Loc = {%d,%d}, want {0,%d}", in, loc.Start, loc.End, len(in))
+		}
+	}
+}
+
+// TestExpr_Walk verifies the generated walker descends into expression children:
+// walking `f(a + b, c)` visits both operands of the inner BinaryExpr.
+func TestExpr_Walk(t *testing.T) {
+	n := mustParse(t, "f(a + b, c)")
+	var idents []string
+	ast.Inspect(n, func(node ast.Node) bool {
+		if id, ok := node.(*ast.Identifier); ok {
+			idents = append(idents, id.Name)
+		}
+		return true
+	})
+	// f is a PathExpr (name), so the identifiers reached are a, b, c.
+	want := map[string]bool{"a": true, "b": true, "c": true}
+	if len(idents) != 3 {
+		t.Fatalf("walk reached identifiers %v, want a,b,c", idents)
+	}
+	for _, id := range idents {
+		if !want[id] {
+			t.Errorf("unexpected identifier %q reached", id)
+		}
+	}
+}
+
+// TestExpr_NotifyStyleAccept verifies the grammar's notify-style alternatives
+// that parse a tree while flagging a diagnostic still PARSE (the oracle
+// classifies them ACCEPT). A bare SELECT as a function argument is the canonical
+// case (`func(SELECT 1)`): a diagnostic is recorded but the call is accepted.
+func TestExpr_NotifyStyleAccept(t *testing.T) {
+	node, errs := ParseExpression("func(SELECT 1)")
+	if node == nil {
+		t.Fatal("func(SELECT 1): expected a parsed node (notify-style accept)")
+	}
+	if _, ok := node.(*ast.FuncCall); !ok {
+		t.Errorf("func(SELECT 1): want FuncCall, got %T", node)
+	}
+	// A diagnostic is recorded (the "argument is not a query" notify).
+	if len(errs) == 0 {
+		t.Errorf("func(SELECT 1): expected a recorded diagnostic")
+	} else if !strings.Contains(errs[0].Msg, "expression, not a query") {
+		t.Errorf("func(SELECT 1): diagnostic = %q", errs[0].Msg)
+	}
+}
+
+// TestExpr_TrailingTokens verifies ParseExpression reports trailing tokens after
+// a complete expression (a standalone-entry-point concern).
+func TestExpr_TrailingTokens(t *testing.T) {
+	node, errs := ParseExpression("1 + 2 garbage")
+	if node == nil {
+		t.Fatal("expected the leading expression to parse")
+	}
+	if len(errs) == 0 || !strings.Contains(errs[0].Msg, "unexpected token after expression") {
+		t.Errorf("trailing tokens: errs = %v", errs)
+	}
+}
+
+// TestExpr_NoPanic feeds pathological / truncated / degenerate input and
+// asserts ParseExpression never panics or hangs — it must always return cleanly
+// (with an error). Covers unbalanced brackets, dangling operators, deep nesting,
+// and truncated keyword forms. Bounded by the test timeout to catch any
+// no-forward-progress loop.
+func TestExpr_NoPanic(t *testing.T) {
+	inputs := []string{
+		"", "(", ")", "((((", "))))", "[[[[", "@@@@", "...", "a.", ".a",
+		"f(", "f(((", "CASE", "CAST(", "EXTRACT(", "NOT NOT NOT",
+		"- - - - -", "a[", "a[[", "STRUCT<", "ARRAY<", "NEW",
+		"1 + + + +", "a => => b", "() -> () -> x", "WITH(", "REPLACE_FIELDS(",
+		"a IN UNNEST", "OVER", "f() OVER (", strings.Repeat("(", 200),
+		strings.Repeat("a.", 200) + "b", strings.Repeat("NOT ", 100) + "x",
+		strings.Repeat("-", 100) + "1", "f(" + strings.Repeat("x,", 100) + "y)",
+		"@", "@@", "?", "0x", "''", "``", "INTERVAL", "LIKE", "BETWEEN",
+		strings.Repeat("[", 100) + "1" + strings.Repeat("]", 100),
+		"(SELECT (SELECT (SELECT 1)))", "EXISTS(", "ARRAY(",
+	}
+	for _, in := range inputs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("PANIC on %q: %v", in, r)
+				}
+			}()
+			_, _ = ParseExpression(in) // must not panic or hang
+		}()
+	}
+}
+
+// TestExpr_Rejects covers syntax rejects beyond the non-associative set (these
+// are also confirmed by the live oracle in expr_oracle_test.go).
+func TestExpr_Rejects(t *testing.T) {
+	rejects := []string{
+		"1 +",
+		"CASE END",
+		"CAST(x INT64)",
+		"CAST(x AS)",
+		"EXTRACT(x y)",
+		"a IN ()",
+		"a..b",
+		"INTERVAL 5",        // missing datepart
+		"NEW",               // missing type
+		"REPLACE_FIELDS(x)", // needs >= 1 replacement
+		"@",                 // bare @ with no name
+		"f(,)",              // empty arg before comma
+	}
+	for _, in := range rejects {
+		if _, errs := ParseExpression(in); len(errs) == 0 {
+			t.Errorf("ParseExpression(%q): expected a syntax error, got none", in)
+		}
+	}
+}


### PR DESCRIPTION
## Node: `googlesql/expressions` (omni-engine-v2 migration, engine=googlesql)

Implements GoogleSQL's full **expression grammar** as a hand-written recursive-descent + precedence-climbing parser, serving both bytebase consumers (`BIGQUERY` + `SPANNER`) via one grammar. Ports the legacy ZetaSQL ANTLR expression rules (`GoogleSQLParser.g4` §2.17/§2.18), **adjudicated against the live Cloud Spanner emulator oracle** — not the literal ANTLR alternative ordering (which is a bison-port artifact that does not reflect operator precedence).

Spec/artifacts: `docs/migration/googlesql/` (analysis.md, antlr_rules.md, contract.md, oracle.md). Depends on the merged `types` node (`parser.parseType`/`ParseDataType`) and the lexer/foundation.

### Coverage
- **Precedence chain** OR / AND / NOT / comparison / bitwise(`| ^ &`) / shift / additive / multiplicative / unary(`+ - ~`) / postfix-access — with two **oracle-verified** facts baked in:
  - **P1** the comparison family (`= != <> < <= > >=`, `[NOT] LIKE/IN/BETWEEN`, `IS […]`, `IS […] DISTINCT FROM`) is **non-associative** — `a = b = c`, `1 < 2 < 3`, `x IN (1) IN (2)` all reject.
  - **P2** prefix `NOT` binds **looser** than comparison — `NOT a = b` = `NOT (a = b)`.
- **Primaries**: literals (incl. adjacent string concat, `0x` hex, bytes), typed-prefix literals (`DATE/NUMERIC/JSON/RANGE<T> '…'`), parameters (`@p`, `?`), system variables (`@@p`), identifiers/paths.
- **Function calls**: `DISTINCT`, `*`, named args (`=>`), lambdas (`x -> …`, `(a,b) -> …`, `() -> …`), sequence args, `IGNORE/RESPECT NULLS`, `HAVING MAX/MIN`, `CLAMPED BETWEEN`, `WITH REPORT`, aggregate `ORDER BY`/`LIMIT`, `WITH GROUP ROWS`, `OVER` windows (named + inline, `PARTITION BY`/`ORDER BY`/frames).
- **CASE** (simple + searched), **CAST/SAFE_CAST** (+ `FORMAT`, `AT TIME ZONE`), **EXTRACT** (+ `AT TIME ZONE`), **INTERVAL** (`… TO …`).
- **Constructors**: array (`[…]`, `ARRAY[…]`, `ARRAY<T>[…]`), struct (`STRUCT(…)`, `STRUCT<…>(…)`, bare tuple `(a,b,…)`), `NEW` proto (paren + braced), braced / struct-braced, `REPLACE_FIELDS`, inline `WITH(…)`.
- **Access**: field `. id`, index `[expr]` (incl. `OFFSET`/`ORDINAL`/`SAFE_OFFSET`/`SAFE_ORDINAL` as ordinary calls), proto extension `.(path)`.
- **Subqueries**: `(SELECT…)`, `EXISTS(…)`, `ARRAY(…)`, IN/quantified RHS — recognized so every oracle-accepted form parses, but the inner query is captured as **raw text** (`Query` nil); the query/SELECT grammar belongs to the downstream `parser-select` node (which depends on this one). `parser-select` fills `Query` later.

### AST
~45 new expression node types in `googlesql/ast` (`parsenodes.go` + `nodetags.go`); walker regenerated (`walk_generated.go`, 39 cases / 81 child fields).

### Proof (PROVE gate — correctness-protocol.md)
- **Differential vs the live Spanner emulator** (`expr_oracle_test.go`): **116 fixtures, both polarities (accept + reject), zero divergences.** Run: `SPANNER_EMULATOR_HOST=localhost:9010 go test -tags googlesql_oracle ./googlesql/parser/ -run TestExprDifferential`.
- **Structural gate** (`expr_test.go`): precedence/associativity grouping via sexpr round-trip (accept/reject can't catch grouping), non-associativity rejects, BigQuery-only forms (triangulated against `.g4` + docs since the Spanner oracle can't verdict them), Loc spans, walker traversal, notify-style accepts, no-panic fuzz.
- Extra adversarial differential (~60 exprs) run during review: zero real divergences.
- `go test ./googlesql/parser/ ./googlesql/ast/ ./googlesql/diagnostics/` green; `go vet` clean.

### Divergences (recorded in the ledger)
| case | disposition | evidence |
|---|---|---|
| `AT TIME ZONE` uses the keyword **AT**, not the legacy `.g4`'s `@` (`AT_SYMBOL`) | **confirmed** | oracle rejects `… ts @ TIME ZONE …` with `Expected ")" or keyword AT but got "@"`; accepts `… ts AT TIME ZONE …` |
| keyword-as-identifier path-part case folding (`pkg.Type` → `pkg.TYPE`) in the shared `identifierText` helper | **flagged** (pre-existing, foundation follow-up; out of this node's scope) | does not affect accept/reject parity (oracle accepts `foo.bar.Baz` regardless); pinned by `TestExpr_KeywordPathCaseFolding` |

### Review gate
Claude lens (`/code-review` high) + a rigorous adversarial self-review substituting for the **Codex lens** (Codex CLI was returning persistent HTTP 401 Unauthorized and could not run after one retry, per the work-order's non-blocking fallback). Audits: walker completeness, offset math under non-zero base offsets, forward-progress/no-hang, false-accept/false-reject paths. No blocking findings.

### Scope
Touches only this node's files: `googlesql/parser/expr.go` (+ its co-located tests `expr_test.go`, `expr_oracle_test.go`), `googlesql/ast/parsenodes.go`, `googlesql/ast/nodetags.go`, `googlesql/ast/walk_generated.go`. `googlesql/parser/parser.go` was in the writes-globs but needed no change (SELECT-family dispatch stays stubbed for `parser-select`). No `docs/migration` or `harness/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)