### PR TITLE
feat(trino/parser): DCL/TCL & prepared statements (v2 node trino/parser-dcl-tcl)

### DIFF
--- a/trino/ast/nodetags.go
+++ b/trino/ast/nodetags.go
@@ -26,6 +26,56 @@ const (
 	// T_QualifiedName is the tag for *QualifiedName, a dot-separated chain
 	// of identifiers (e.g., catalog.schema.table).
 	T_QualifiedName
+
+	// --- DCL / TCL / prepared statement nodes (parser-dcl-tcl node) ---
+	//
+	// These concrete statement types live in package parser (grant_revoke.go,
+	// transaction.go, prepared.go) — matching the Trino convention that
+	// parser-package node types (Expr, DataType) are defined where they are
+	// built — but they are returned from parseStmt as ast.Node, so they need a
+	// tag here. The ast-core comment notes the tag set is grown by the parser
+	// DAG nodes as they add statement types; these are the parser-dcl-tcl
+	// node's additions.
+
+	// T_GrantPrivStmt tags a GRANT <privileges> ON <target> TO <grantee>
+	// statement (privilege grant).
+	T_GrantPrivStmt
+	// T_RevokePrivStmt tags a REVOKE [GRANT OPTION FOR] <privileges> ON
+	// <target> FROM <grantee> statement (privilege revoke).
+	T_RevokePrivStmt
+	// T_DenyStmt tags a DENY <privileges> ON <target> TO <grantee> statement.
+	T_DenyStmt
+	// T_GrantRolesStmt tags a GRANT <roles> TO <principal> ... statement
+	// (role grant).
+	T_GrantRolesStmt
+	// T_RevokeRolesStmt tags a REVOKE [ADMIN OPTION FOR] <roles> FROM
+	// <principal> ... statement (role revoke).
+	T_RevokeRolesStmt
+	// T_CreateRoleStmt tags a CREATE ROLE statement.
+	T_CreateRoleStmt
+	// T_DropRoleStmt tags a DROP ROLE statement.
+	T_DropRoleStmt
+
+	// T_StartTransactionStmt tags a START TRANSACTION [mode, ...] statement.
+	T_StartTransactionStmt
+	// T_CommitStmt tags a COMMIT [WORK] statement.
+	T_CommitStmt
+	// T_RollbackStmt tags a ROLLBACK [WORK] statement.
+	T_RollbackStmt
+
+	// T_PrepareStmt tags a PREPARE <name> FROM <statement> statement.
+	T_PrepareStmt
+	// T_DeallocateStmt tags a DEALLOCATE PREPARE <name> statement.
+	T_DeallocateStmt
+	// T_ExecuteStmt tags an EXECUTE <name> [USING ...] statement.
+	T_ExecuteStmt
+	// T_ExecuteImmediateStmt tags an EXECUTE IMMEDIATE '<sql>' [USING ...]
+	// statement.
+	T_ExecuteImmediateStmt
+	// T_DescribeInputStmt tags a DESCRIBE INPUT <name> statement.
+	T_DescribeInputStmt
+	// T_DescribeOutputStmt tags a DESCRIBE OUTPUT <name> statement.
+	T_DescribeOutputStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -39,6 +89,38 @@ func (t NodeTag) String() string {
 		return "Identifier"
 	case T_QualifiedName:
 		return "QualifiedName"
+	case T_GrantPrivStmt:
+		return "GrantPrivStmt"
+	case T_RevokePrivStmt:
+		return "RevokePrivStmt"
+	case T_DenyStmt:
+		return "DenyStmt"
+	case T_GrantRolesStmt:
+		return "GrantRolesStmt"
+	case T_RevokeRolesStmt:
+		return "RevokeRolesStmt"
+	case T_CreateRoleStmt:
+		return "CreateRoleStmt"
+	case T_DropRoleStmt:
+		return "DropRoleStmt"
+	case T_StartTransactionStmt:
+		return "StartTransactionStmt"
+	case T_CommitStmt:
+		return "CommitStmt"
+	case T_RollbackStmt:
+		return "RollbackStmt"
+	case T_PrepareStmt:
+		return "PrepareStmt"
+	case T_DeallocateStmt:
+		return "DeallocateStmt"
+	case T_ExecuteStmt:
+		return "ExecuteStmt"
+	case T_ExecuteImmediateStmt:
+		return "ExecuteImmediateStmt"
+	case T_DescribeInputStmt:
+		return "DescribeInputStmt"
+	case T_DescribeOutputStmt:
+		return "DescribeOutputStmt"
 	default:
 		return "Unknown"
 	}

--- a/trino/parser/grant_revoke.go
+++ b/trino/parser/grant_revoke.go
@@ -1,0 +1,996 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the core of the parser-dcl-tcl DAG node: it implements Trino's
+// data-control-language (DCL) statements — CREATE/DROP ROLE, GRANT/REVOKE of
+// both roles and privileges, and DENY — as hand-written recursive-descent
+// parsers over the token stream.
+//
+// The statement nodes are returned from parseStmt as ast.Node and carry an
+// ast.NodeTag (trino/ast/nodetags.go); their concrete fields live here in
+// package parser (Trino convention for parser-built node types — see expr.go,
+// datatypes.go).
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : ...
+//	    | CREATE_ ROLE_ name=identifier (WITH_ ADMIN_ grantor)? (IN_ catalog=identifier)?  # createRole
+//	    | DROP_ ROLE_ name=identifier (IN_ catalog=identifier)?                            # dropRole
+//	    | GRANT_ roles TO_ principal (COMMA_ principal)* (WITH_ ADMIN_ OPTION_)?
+//	          (GRANTED_ BY_ grantor)? (IN_ catalog=identifier)?                            # grantRoles
+//	    | REVOKE_ (ADMIN_ OPTION_ FOR_)? roles FROM_ principal (COMMA_ principal)*
+//	          (GRANTED_ BY_ grantor)? (IN_ catalog=identifier)?                            # revokeRoles
+//	    | GRANT_ (privilege (COMMA_ privilege)* | ALL_ PRIVILEGES_)
+//	          ON_ (SCHEMA_ | TABLE_)? qualifiedName TO_ grantee=principal
+//	          (WITH_ GRANT_ OPTION_)?                                                      # grant
+//	    | DENY_ (privilege (COMMA_ privilege)* | ALL_ PRIVILEGES_)
+//	          ON_ (SCHEMA_ | TABLE_)? qualifiedName TO_ grantee=principal                  # deny
+//	    | REVOKE_ (GRANT_ OPTION_ FOR_)? (privilege (COMMA_ privilege)* | ALL_ PRIVILEGES_)
+//	          ON_ (SCHEMA_ | TABLE_)? qualifiedName FROM_ grantee=principal                # revoke
+//	    ;
+//	privilege : CREATE_ | SELECT_ | DELETE_ | INSERT_ | UPDATE_ ;
+//	principal : identifier | USER_ identifier | ROLE_ identifier ;
+//	grantor   : principal | CURRENT_USER_ | CURRENT_ROLE_ ;
+//	roles     : identifier (COMMA_ identifier)* ;
+//
+// Trino 481 (truth1 + the live oracle) diverges from this stale legacy grammar
+// in three oracle-confirmed ways (recorded in the divergence ledger):
+//
+//	D1 (privilege vocabulary is broadened). A privilege is the five legacy
+//	   reserved keywords CREATE/SELECT/DELETE/INSERT/UPDATE PLUS any non-reserved
+//	   identifier: 481 accepts `GRANT mypriv ON test TO alice`, `GRANT "My Priv"
+//	   ON ...`, and even `GRANT TO ON t ...` (TO is non-reserved). It is NOT "any
+//	   keyword" — other reserved keywords (FROM, WHERE, TABLE, ...) are rejected
+//	   as privileges. Validity beyond this is the access-control layer's concern.
+//	D2 (ON BRANCH … IN target). 481 accepts a branch-qualified target
+//	   `GRANT INSERT ON BRANCH audit IN orders TO alice` (and the REVOKE/DENY
+//	   forms), absent from the legacy grammar — the docs-ahead "@branch"
+//	   extension proven real by the oracle.
+//	D3 (bare ALL). 481 accepts `GRANT ALL ON test TO alice` (ALL without the
+//	   PRIVILEGES keyword) as an all-privileges grant; the legacy grammar
+//	   requires `ALL PRIVILEGES`.
+//	D5 (open entity-kind qualifier). The ON-target entity kind is an arbitrary
+//	   single identifier in 481, not the legacy grammar's fixed `(SCHEMA |
+//	   TABLE)?`: `ON VIEW v`, `ON a b` (qualifier "a", object "b") are accepted.
+//	   At most one leading qualifier word is allowed (`ON a b c` is a
+//	   SYNTAX_ERROR), and it must be a single non-dotted identifier (`ON a.b c`
+//	   is a SYNTAX_ERROR).
+//
+// Disambiguation (the central difficulty): GRANT/REVOKE/DENY each have a
+// role-grant and a privilege-grant alternative that share a leading
+// comma-separated name list. They are told apart purely structurally by the
+// keyword that terminates the list — `ON` ⇒ privilege grant; `TO` (GRANT/DENY)
+// or `FROM` (REVOKE) ⇒ role grant. scanGrantFormIsPrivilege performs a bounded
+// speculative scan to that terminator. The two forms then differ in their list
+// element rules (privileges allow reserved keywords; roles require valid
+// identifiers — `GRANT SELECT TO foo` is a SYNTAX_ERROR because reserved SELECT
+// is not a legal role) and in their trailing options (WITH GRANT OPTION vs
+// WITH ADMIN OPTION / GRANTED BY / IN catalog), all oracle-adjudicated.
+//
+// The implementation is adjudicated against the live Trino 481 oracle.
+
+// ---------------------------------------------------------------------------
+// Shared sub-grammar AST
+// ---------------------------------------------------------------------------
+
+// PrincipalKind classifies a principal: a bare name (defaults to a role/user
+// per Trino semantics), an explicit USER, or an explicit ROLE.
+type PrincipalKind int
+
+const (
+	// PrincipalUnspecified is a bare `identifier` principal (no USER/ROLE
+	// keyword).
+	PrincipalUnspecified PrincipalKind = iota
+	// PrincipalUser is `USER identifier`.
+	PrincipalUser
+	// PrincipalRole is `ROLE identifier`.
+	PrincipalRole
+)
+
+// Principal is a `principal` grammar node: an optionally USER/ROLE-qualified
+// name. Name is nil only for the keyword grantor forms handled by Grantor.
+type Principal struct {
+	Kind PrincipalKind
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+// GrantorKind classifies a GRANTED BY grantor: a specified principal, the
+// CURRENT_USER keyword, or the CURRENT_ROLE keyword.
+type GrantorKind int
+
+const (
+	// GrantorPrincipal is a grantor given as a principal.
+	GrantorPrincipal GrantorKind = iota
+	// GrantorCurrentUser is the CURRENT_USER keyword grantor.
+	GrantorCurrentUser
+	// GrantorCurrentRole is the CURRENT_ROLE keyword grantor.
+	GrantorCurrentRole
+)
+
+// Grantor is a `grantor` grammar node (the principal after GRANTED BY).
+// Principal is set only when Kind is GrantorPrincipal.
+type Grantor struct {
+	Kind      GrantorKind
+	Principal *Principal
+	Loc       ast.Loc
+}
+
+// GrantTarget is the ON clause of a privilege GRANT/REVOKE/DENY. Trino 481's
+// actual grammar (decoded from the live oracle — see the file-header D5 note) is
+//
+//	ON [ BRANCH branch_name IN ] [ entity_kind ] qualifiedName
+//
+// where:
+//   - branch_name (the D2 docs-ahead extension) is a single identifier; it is
+//     recognized only as `BRANCH <ident> IN …`, so a target literally named
+//     "branch" (`ON branch`) is an ordinary object name.
+//   - entity_kind is an OPTIONAL single leading qualifier word. The legacy
+//     grammar hard-coded it to `(SCHEMA | TABLE)?`, but 481 accepts ANY single
+//     non-reserved identifier here (`ON SCHEMA s`, `ON TABLE t`, `ON VIEW v`,
+//     `ON a b` are all accepted) — so it is captured as a generic Identifier,
+//     not a fixed enum (D5).
+//   - qualifiedName is the object name (may be dotted: catalog.schema.table).
+//
+// Field meanings: Branch is the branch identifier (nil unless the BRANCH form).
+// Qualifier is the optional entity-kind word (nil when the target is a bare
+// object name). Object is the object qualifiedName. For the BRANCH form,
+// Qualifier/Object describe the entity that follows IN.
+type GrantTarget struct {
+	Branch    *ast.Identifier    // nil unless ON BRANCH <branch> IN ...
+	Qualifier *ast.Identifier    // nil unless an entity-kind word precedes the name
+	Object    *ast.QualifiedName // the object name (may be dotted)
+	Loc       ast.Loc
+}
+
+// IsSchema reports whether the target's entity-kind qualifier is the SCHEMA
+// keyword (case-insensitive), the common "grant on a schema" form.
+func (t *GrantTarget) IsSchema() bool {
+	return t.Qualifier != nil && strings.EqualFold(t.Qualifier.Value, "SCHEMA")
+}
+
+// IsTable reports whether the target's entity-kind qualifier is the TABLE
+// keyword (case-insensitive).
+func (t *GrantTarget) IsTable() bool {
+	return t.Qualifier != nil && strings.EqualFold(t.Qualifier.Value, "TABLE")
+}
+
+// ---------------------------------------------------------------------------
+// Statement AST
+// ---------------------------------------------------------------------------
+
+// CreateRoleStmt is CREATE ROLE <name> [WITH ADMIN <grantor>] [IN <catalog>].
+type CreateRoleStmt struct {
+	Name    *ast.Identifier
+	Admin   *Grantor        // nil unless WITH ADMIN <grantor>
+	Catalog *ast.Identifier // nil unless IN <catalog>
+	Loc     ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *CreateRoleStmt) Tag() ast.NodeTag { return ast.T_CreateRoleStmt }
+
+// DropRoleStmt is DROP ROLE [IF EXISTS] <name> [IN <catalog>].
+//
+// IfExists is the D4 docs-ahead extension: 481 accepts DROP ROLE IF EXISTS,
+// absent from the legacy grammar.
+type DropRoleStmt struct {
+	IfExists bool
+	Name     *ast.Identifier
+	Catalog  *ast.Identifier // nil unless IN <catalog>
+	Loc      ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *DropRoleStmt) Tag() ast.NodeTag { return ast.T_DropRoleStmt }
+
+// GrantRolesStmt is
+//
+//	GRANT <roles> TO <principal> [, ...] [WITH ADMIN OPTION]
+//	    [GRANTED BY <grantor>] [IN <catalog>].
+type GrantRolesStmt struct {
+	Roles       []*ast.Identifier
+	Grantees    []*Principal
+	AdminOption bool
+	GrantedBy   *Grantor        // nil unless GRANTED BY <grantor>
+	Catalog     *ast.Identifier // nil unless IN <catalog>
+	Loc         ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *GrantRolesStmt) Tag() ast.NodeTag { return ast.T_GrantRolesStmt }
+
+// RevokeRolesStmt is
+//
+//	REVOKE [ADMIN OPTION FOR] <roles> FROM <principal> [, ...]
+//	    [GRANTED BY <grantor>] [IN <catalog>].
+type RevokeRolesStmt struct {
+	AdminOptionFor bool
+	Roles          []*ast.Identifier
+	Grantees       []*Principal
+	GrantedBy      *Grantor        // nil unless GRANTED BY <grantor>
+	Catalog        *ast.Identifier // nil unless IN <catalog>
+	Loc            ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *RevokeRolesStmt) Tag() ast.NodeTag { return ast.T_RevokeRolesStmt }
+
+// GrantPrivStmt is
+//
+//	GRANT ( <privileges> | ALL [PRIVILEGES] ) ON <target> TO <grantee>
+//	    [WITH GRANT OPTION].
+//
+// AllPrivileges is true for the ALL [PRIVILEGES] form (Privileges is then nil).
+type GrantPrivStmt struct {
+	AllPrivileges bool
+	Privileges    []*ast.Identifier
+	On            *GrantTarget
+	Grantee       *Principal
+	GrantOption   bool
+	Loc           ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *GrantPrivStmt) Tag() ast.NodeTag { return ast.T_GrantPrivStmt }
+
+// RevokePrivStmt is
+//
+//	REVOKE [GRANT OPTION FOR] ( <privileges> | ALL [PRIVILEGES] )
+//	    ON <target> FROM <grantee>.
+type RevokePrivStmt struct {
+	GrantOptionFor bool
+	AllPrivileges  bool
+	Privileges     []*ast.Identifier
+	On             *GrantTarget
+	Grantee        *Principal
+	Loc            ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *RevokePrivStmt) Tag() ast.NodeTag { return ast.T_RevokePrivStmt }
+
+// DenyStmt is
+//
+//	DENY ( <privileges> | ALL [PRIVILEGES] ) ON <target> TO <grantee>.
+type DenyStmt struct {
+	AllPrivileges bool
+	Privileges    []*ast.Identifier
+	On            *GrantTarget
+	Grantee       *Principal
+	Loc           ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *DenyStmt) Tag() ast.NodeTag { return ast.T_DenyStmt }
+
+// Compile-time assertions that the statement types satisfy ast.Node.
+var (
+	_ ast.Node = (*CreateRoleStmt)(nil)
+	_ ast.Node = (*DropRoleStmt)(nil)
+	_ ast.Node = (*GrantRolesStmt)(nil)
+	_ ast.Node = (*RevokeRolesStmt)(nil)
+	_ ast.Node = (*GrantPrivStmt)(nil)
+	_ ast.Node = (*RevokePrivStmt)(nil)
+	_ ast.Node = (*DenyStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// CREATE / DROP ROLE
+// ---------------------------------------------------------------------------
+
+// parseCreateRoleStmt parses
+// CREATE ROLE <name> [WITH ADMIN <grantor>] [IN <catalog>].
+//
+// On entry the CREATE and ROLE keywords have BOTH already been consumed by the
+// dispatcher (CREATE is a multi-object keyword); start is the CREATE keyword's
+// byte offset.
+func (p *Parser) parseCreateRoleStmt(start int) (ast.Node, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &CreateRoleStmt{Name: name, Loc: ast.Loc{Start: start, End: p.prev.Loc.End}}
+
+	// Optional WITH ADMIN <grantor>.
+	if p.cur.Kind == kwWITH && p.peekNext().Kind == kwADMIN {
+		p.advance() // consume WITH
+		p.advance() // consume ADMIN
+		grantor, err := p.parseGrantor()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Admin = grantor
+	}
+
+	// Optional IN <catalog>.
+	if catalog, err := p.parseOptionalInCatalog(); err != nil {
+		return nil, err
+	} else {
+		stmt.Catalog = catalog
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseDropRoleStmt parses DROP ROLE [IF EXISTS] <name> [IN <catalog>].
+//
+// On entry the DROP and ROLE keywords have both already been consumed; start is
+// the DROP keyword's byte offset.
+func (p *Parser) parseDropRoleStmt(start int) (ast.Node, error) {
+	stmt := &DropRoleStmt{Loc: ast.Loc{Start: start}}
+
+	// Optional IF EXISTS (D4 docs-ahead extension).
+	if p.cur.Kind == kwIF && p.peekNext().Kind == kwEXISTS {
+		p.advance() // consume IF
+		p.advance() // consume EXISTS
+		stmt.IfExists = true
+	}
+
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	if catalog, err := p.parseOptionalInCatalog(); err != nil {
+		return nil, err
+	} else {
+		stmt.Catalog = catalog
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// GRANT / REVOKE / DENY dispatch
+// ---------------------------------------------------------------------------
+
+// parseGrantStmt parses a GRANT statement, dispatching between the role-grant
+// and privilege-grant forms by the structural lookahead in
+// scanGrantFormIsPrivilege. On entry cur is the GRANT keyword.
+func (p *Parser) parseGrantStmt() (ast.Node, error) {
+	grantTok := p.advance() // consume GRANT
+	start := grantTok.Loc.Start
+	if p.scanGrantFormIsPrivilege(false) {
+		return p.parseGrantPrivileges(start)
+	}
+	return p.parseGrantRoles(start)
+}
+
+// parseRevokeStmt parses a REVOKE statement. A leading ADMIN OPTION FOR forces
+// the role form; a leading GRANT OPTION FOR forces the privilege form;
+// otherwise the ON-vs-FROM lookahead decides. On entry cur is the REVOKE
+// keyword.
+func (p *Parser) parseRevokeStmt() (ast.Node, error) {
+	revokeTok := p.advance() // consume REVOKE
+	start := revokeTok.Loc.Start
+
+	if p.cur.Kind == kwADMIN && p.peekNext().Kind == kwOPTION {
+		return p.parseRevokeRoles(start)
+	}
+	if p.cur.Kind == kwGRANT && p.peekNext().Kind == kwOPTION {
+		return p.parseRevokePrivileges(start)
+	}
+	if p.scanGrantFormIsPrivilege(true) {
+		return p.parseRevokePrivileges(start)
+	}
+	return p.parseRevokeRoles(start)
+}
+
+// parseDenyStmt parses a DENY statement. DENY has only the privilege form
+// (there is no role-deny), so it always parses as a privilege grant target.
+// On entry cur is the DENY keyword.
+func (p *Parser) parseDenyStmt() (ast.Node, error) {
+	denyTok := p.advance() // consume DENY
+	start := denyTok.Loc.Start
+
+	stmt := &DenyStmt{Loc: ast.Loc{Start: start}}
+	all, privs, err := p.parsePrivilegeSpec()
+	if err != nil {
+		return nil, err
+	}
+	stmt.AllPrivileges = all
+	stmt.Privileges = privs
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	target, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = target
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parsePrincipal()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// scanGrantFormIsPrivilege performs a bounded speculative scan from the current
+// token (the first token after GRANT/REVOKE, or after a GRANT/ADMIN OPTION FOR
+// prefix) to decide whether the statement is the privilege form (terminated by
+// ON) or the role form (terminated by TO for GRANT/DENY, FROM for REVOKE). It
+// rewinds via a checkpoint so the caller's cursor is unchanged.
+//
+// The scan is STRUCTURE-AWARE rather than a naive search for the first ON/TO/
+// FROM token: a privilege or role NAME may itself be the non-reserved word TO
+// or FROM (`GRANT TO ON t TO alice` grants a privilege literally named "TO").
+// So it walks the leading `item (',' item)*` list — each item one token, except
+// the two-token ALL PRIVILEGES — and only inspects the token that sits at a
+// list boundary (right after an item, where a comma or the terminator must
+// appear). ON at a boundary ⇒ privilege; TO/FROM at a boundary ⇒ role. A
+// boundary token that is neither (malformed, or EOF) defaults to the privilege
+// form so the concrete privilege parser emits a precise "expected ON" error.
+func (p *Parser) scanGrantFormIsPrivilege(isRevoke bool) bool {
+	cp := p.checkpoint()
+	defer p.restore(cp)
+
+	for {
+		// Consume one list item. The first token after the keyword is always an
+		// item (even if it is the non-reserved word TO/FROM/ON), never the
+		// terminator. ALL PRIVILEGES is a single two-token item.
+		if p.cur.Kind == tokEOF {
+			return true
+		}
+		if p.cur.Kind == kwALL && p.peekNext().Kind == kwPRIVILEGES {
+			p.advance() // ALL
+			p.advance() // PRIVILEGES
+		} else {
+			p.advance() // the single-token item
+		}
+
+		// Now at a list boundary: a comma continues the list; ON/TO/FROM
+		// terminates it; anything else is malformed (default to privilege).
+		switch p.cur.Kind {
+		case int(','):
+			p.advance() // consume comma, read the next item
+			continue
+		case kwON:
+			return true
+		case kwTO:
+			return false
+		case kwFROM:
+			if isRevoke {
+				return false
+			}
+			return true
+		default:
+			return true
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GRANT / REVOKE roles
+// ---------------------------------------------------------------------------
+
+// parseGrantRoles parses the role-grant form (the GRANT keyword consumed):
+//
+//	<roles> TO <principal> [, ...] [WITH ADMIN OPTION]
+//	    [GRANTED BY <grantor>] [IN <catalog>].
+func (p *Parser) parseGrantRoles(start int) (ast.Node, error) {
+	stmt := &GrantRolesStmt{Loc: ast.Loc{Start: start}}
+
+	roles, err := p.parseRoleList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Roles = roles
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	grantees, err := p.parsePrincipalList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantees = grantees
+
+	// Optional WITH ADMIN OPTION.
+	if p.cur.Kind == kwWITH && p.peekNext().Kind == kwADMIN {
+		p.advance() // consume WITH
+		p.advance() // consume ADMIN
+		if _, err := p.expect(kwOPTION); err != nil {
+			return nil, err
+		}
+		stmt.AdminOption = true
+	}
+
+	// Optional GRANTED BY <grantor>.
+	if grantedBy, err := p.parseOptionalGrantedBy(); err != nil {
+		return nil, err
+	} else {
+		stmt.GrantedBy = grantedBy
+	}
+
+	// Optional IN <catalog>.
+	if catalog, err := p.parseOptionalInCatalog(); err != nil {
+		return nil, err
+	} else {
+		stmt.Catalog = catalog
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRevokeRoles parses the role-revoke form (the REVOKE keyword consumed):
+//
+//	[ADMIN OPTION FOR] <roles> FROM <principal> [, ...]
+//	    [GRANTED BY <grantor>] [IN <catalog>].
+func (p *Parser) parseRevokeRoles(start int) (ast.Node, error) {
+	stmt := &RevokeRolesStmt{Loc: ast.Loc{Start: start}}
+
+	// Optional ADMIN OPTION FOR.
+	if p.cur.Kind == kwADMIN && p.peekNext().Kind == kwOPTION {
+		p.advance() // consume ADMIN
+		p.advance() // consume OPTION
+		if _, err := p.expect(kwFOR); err != nil {
+			return nil, err
+		}
+		stmt.AdminOptionFor = true
+	}
+
+	roles, err := p.parseRoleList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Roles = roles
+
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	grantees, err := p.parsePrincipalList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantees = grantees
+
+	if grantedBy, err := p.parseOptionalGrantedBy(); err != nil {
+		return nil, err
+	} else {
+		stmt.GrantedBy = grantedBy
+	}
+	if catalog, err := p.parseOptionalInCatalog(); err != nil {
+		return nil, err
+	} else {
+		stmt.Catalog = catalog
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRoleList parses `roles := identifier (COMMA identifier)*`. Each role is
+// a plain identifier; a reserved keyword is rejected here (so `GRANT SELECT TO
+// foo` fails, matching Trino).
+func (p *Parser) parseRoleList() ([]*ast.Identifier, error) {
+	first, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	roles := []*ast.Identifier{first}
+	for {
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+		next, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		roles = append(roles, next)
+	}
+	return roles, nil
+}
+
+// ---------------------------------------------------------------------------
+// GRANT / REVOKE privileges
+// ---------------------------------------------------------------------------
+
+// parseGrantPrivileges parses the privilege-grant form (the GRANT keyword
+// consumed):
+//
+//	( <privileges> | ALL [PRIVILEGES] ) ON <target> TO <grantee>
+//	    [WITH GRANT OPTION].
+func (p *Parser) parseGrantPrivileges(start int) (ast.Node, error) {
+	stmt := &GrantPrivStmt{Loc: ast.Loc{Start: start}}
+
+	all, privs, err := p.parsePrivilegeSpec()
+	if err != nil {
+		return nil, err
+	}
+	stmt.AllPrivileges = all
+	stmt.Privileges = privs
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	target, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = target
+
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parsePrincipal()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	// Optional WITH GRANT OPTION.
+	if p.cur.Kind == kwWITH && p.peekNext().Kind == kwGRANT {
+		p.advance() // consume WITH
+		p.advance() // consume GRANT
+		if _, err := p.expect(kwOPTION); err != nil {
+			return nil, err
+		}
+		stmt.GrantOption = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRevokePrivileges parses the privilege-revoke form (the REVOKE keyword
+// consumed):
+//
+//	[GRANT OPTION FOR] ( <privileges> | ALL [PRIVILEGES] )
+//	    ON <target> FROM <grantee>.
+func (p *Parser) parseRevokePrivileges(start int) (ast.Node, error) {
+	stmt := &RevokePrivStmt{Loc: ast.Loc{Start: start}}
+
+	// Optional GRANT OPTION FOR.
+	if p.cur.Kind == kwGRANT && p.peekNext().Kind == kwOPTION {
+		p.advance() // consume GRANT
+		p.advance() // consume OPTION
+		if _, err := p.expect(kwFOR); err != nil {
+			return nil, err
+		}
+		stmt.GrantOptionFor = true
+	}
+
+	all, privs, err := p.parsePrivilegeSpec()
+	if err != nil {
+		return nil, err
+	}
+	stmt.AllPrivileges = all
+	stmt.Privileges = privs
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	target, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = target
+
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	grantee, err := p.parsePrincipal()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Grantee = grantee
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parsePrivilegeSpec parses the privilege specification before ON:
+//
+//	ALL [PRIVILEGES]            -> (true, nil, nil)
+//	privilege [, privilege ...] -> (false, [...], nil)
+//
+// Per oracle divergence D3, a bare ALL immediately followed by ON is the
+// all-privileges form. A privilege is an arbitrary single identifier-or-keyword
+// (D1) — privilege validity is not a grammar concern — so reserved keywords
+// like SELECT/DELETE/UPDATE and ordinary identifiers both parse.
+func (p *Parser) parsePrivilegeSpec() (bool, []*ast.Identifier, error) {
+	// ALL [PRIVILEGES] — but only when ALL is the entire spec, i.e. it is
+	// followed by PRIVILEGES or directly by ON. (A privilege/role literally
+	// named ALL followed by a comma is not a documented Trino privilege form;
+	// in the role grant `GRANT ALL TO foo`, ALL is parsed as a role elsewhere.)
+	if p.cur.Kind == kwALL {
+		next := p.peekNext().Kind
+		if next == kwPRIVILEGES {
+			p.advance() // consume ALL
+			p.advance() // consume PRIVILEGES
+			return true, nil, nil
+		}
+		if next == kwON {
+			p.advance() // consume ALL
+			return true, nil, nil
+		}
+	}
+
+	var privs []*ast.Identifier
+	for {
+		priv, err := p.parsePrivilege()
+		if err != nil {
+			return false, nil, err
+		}
+		privs = append(privs, priv)
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	return false, privs, nil
+}
+
+// parsePrivilege parses a single privilege, captured as an ast.Identifier (a
+// quoted token keeps its quoting metadata). A privilege is one token; ON, a
+// comma, or a non-privilege token terminates the list.
+func (p *Parser) parsePrivilege() (*ast.Identifier, error) {
+	if !isPrivilegeWord(p.cur.Kind) {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return identFromToken(p.advance()), nil
+}
+
+// isPrivilegeWord reports whether a token kind can be a privilege name. Per the
+// oracle-pinned D1 vocabulary, a privilege is:
+//   - an unquoted/quoted identifier (incl. any NON-reserved keyword, since the
+//     lexer emits those as identifiers via isIdentifierStart) — e.g. mypriv,
+//     "My Priv", and the non-reserved word TO; OR
+//   - one of the five legacy reserved privilege keywords SELECT / INSERT /
+//     UPDATE / DELETE / CREATE.
+//
+// It is NOT "any keyword": other reserved keywords (FROM, WHERE, TABLE, DROP, …)
+// are rejected as privileges (`GRANT FROM ON t …` is a Trino SYNTAX_ERROR),
+// which is why this cannot simply test kind >= 700.
+func isPrivilegeWord(kind TokenKind) bool {
+	if isIdentifierStart(kind) {
+		return true
+	}
+	switch kind {
+	case kwSELECT, kwINSERT, kwUPDATE, kwDELETE, kwCREATE:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseGrantTarget parses the ON clause body (the ON keyword already consumed):
+//
+//	[ BRANCH branch_name IN ] [ entity_kind ] qualifiedName
+//
+// matching Trino 481 exactly (see the GrantTarget doc). The BRANCH prefix is the
+// D2 docs-ahead extension and the open entity_kind qualifier is D5; both are
+// oracle-confirmed. The clause ends at the grantee keyword (TO for GRANT/DENY,
+// FROM for REVOKE) or a '(' — those terminate the trailing entity.
+func (p *Parser) parseGrantTarget() (*GrantTarget, error) {
+	startLoc := p.cur.Loc
+	target := &GrantTarget{Loc: ast.Loc{Start: startLoc.Start}}
+
+	// Optional BRANCH <branch> IN — recognized only as the three-token shape
+	// `BRANCH <ident> IN`, so a target named "branch" (`ON branch`, or the
+	// entity-kind word in `ON branch x`) stays an ordinary name.
+	if p.branchClauseFollows() {
+		p.advance() // consume BRANCH (an unquoted identifier)
+		branch, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwIN); err != nil {
+			return nil, err
+		}
+		target.Branch = branch
+	}
+
+	// [ entity_kind ] qualifiedName.
+	qualifier, object, err := p.parseGrantEntity()
+	if err != nil {
+		return nil, err
+	}
+	target.Qualifier = qualifier
+	target.Object = object
+
+	target.Loc.End = p.prev.Loc.End
+	return target, nil
+}
+
+// parseGrantEntity parses an ON-target entity: an OPTIONAL single leading
+// entity-kind qualifier word followed by the object qualifiedName. It is used
+// both for the plain ON target and for the IN-target of the BRANCH form.
+//
+// The entity-kind qualifier (D5) is `TABLE | SCHEMA | <non-reserved identifier>`
+// — the two legacy reserved keywords plus any identifier; other reserved
+// keywords (SELECT, FROM, …) are rejected. It is present iff a SECOND name unit
+// follows the first before the terminator (TO/FROM/'('/EOF). A dotted qualifier
+// (`ON a.b c`) is rejected — the qualifier is a single identifier.
+func (p *Parser) parseGrantEntity() (*ast.Identifier, *ast.QualifiedName, error) {
+	// The reserved keywords TABLE/SCHEMA can only be the qualifier (they are not
+	// valid identifiers, so parseQualifiedName would reject them as an object).
+	if p.cur.Kind == kwTABLE || p.cur.Kind == kwSCHEMA {
+		qualifier := identFromToken(p.advance())
+		object, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, nil, err
+		}
+		return qualifier, object, nil
+	}
+
+	// Otherwise the leading unit is an identifier — either the object (one unit)
+	// or the qualifier (a second unit follows).
+	first, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, nil, err
+	}
+	if p.startsGrantEntityUnit() {
+		if len(first.Parts) != 1 {
+			return nil, nil, &ParseError{Loc: first.Loc, Msg: "entity kind in GRANT/REVOKE ON clause must be a single identifier"}
+		}
+		object, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, nil, err
+		}
+		return first.Parts[0], object, nil
+	}
+	return nil, first, nil
+}
+
+// branchClauseFollows reports whether the current position begins a
+// `BRANCH <ident> IN` clause: the current token is the unquoted identifier
+// "BRANCH" (case-insensitive), followed by a single identifier, followed by the
+// IN keyword. It uses a bounded speculative scan via a checkpoint so the
+// caller's cursor is unchanged. The three-token shape is required so that a
+// plain `ON branch <object>` (entity-kind word "branch") or `ON branch` (object
+// named branch) is NOT mistaken for the branch form.
+func (p *Parser) branchClauseFollows() bool {
+	if p.cur.Kind != tokIdent || !strings.EqualFold(p.cur.Str, "BRANCH") {
+		return false
+	}
+	cp := p.checkpoint()
+	defer p.restore(cp)
+	p.advance() // consume BRANCH
+	if !isIdentifierStart(p.cur.Kind) {
+		return false
+	}
+	p.advance() // consume the branch name
+	return p.cur.Kind == kwIN
+}
+
+// startsGrantEntityUnit reports whether the current token can begin another
+// space-separated name unit inside an ON target — used to decide whether the
+// already-parsed qualifiedName was the entity-kind qualifier (another unit
+// follows) or the object (the clause ends). The entity run ends at the grantee
+// keyword (TO/FROM), a '(' (a future signature), or EOF.
+func (p *Parser) startsGrantEntityUnit() bool {
+	switch p.cur.Kind {
+	case kwTO, kwFROM, int('('), tokEOF:
+		return false
+	}
+	return isIdentifierStart(p.cur.Kind)
+}
+
+// ---------------------------------------------------------------------------
+// principal / grantor
+// ---------------------------------------------------------------------------
+
+// parsePrincipalList parses `principal (COMMA principal)*` (the grantee list of
+// a role grant/revoke).
+func (p *Parser) parsePrincipalList() ([]*Principal, error) {
+	first, err := p.parsePrincipal()
+	if err != nil {
+		return nil, err
+	}
+	principals := []*Principal{first}
+	for {
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+		next, err := p.parsePrincipal()
+		if err != nil {
+			return nil, err
+		}
+		principals = append(principals, next)
+	}
+	return principals, nil
+}
+
+// parsePrincipal parses a `principal`:
+//
+//	identifier | USER identifier | ROLE identifier
+//
+// USER and ROLE are NON-RESERVED keywords, so they act as the USER/ROLE
+// qualifier ONLY when directly followed by an identifier (the principal name).
+// A bare `USER` / `ROLE` not followed by a name is itself the (unspecified)
+// principal name — Trino accepts `GRANT r TO USER` and `GRANT r TO ROLE, bar`.
+// A bare identifier principal is PrincipalUnspecified.
+func (p *Parser) parsePrincipal() (*Principal, error) {
+	startLoc := p.cur.Loc
+	switch p.cur.Kind {
+	case kwUSER:
+		if isIdentifierStart(p.peekNext().Kind) {
+			p.advance() // consume USER (qualifier)
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			return &Principal{Kind: PrincipalUser, Name: name, Loc: ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End}}, nil
+		}
+	case kwROLE:
+		if isIdentifierStart(p.peekNext().Kind) {
+			p.advance() // consume ROLE (qualifier)
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			return &Principal{Kind: PrincipalRole, Name: name, Loc: ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End}}, nil
+		}
+	}
+	// Bare name (includes a bare USER/ROLE not used as a qualifier).
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &Principal{Kind: PrincipalUnspecified, Name: name, Loc: ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End}}, nil
+}
+
+// parseGrantor parses a `grantor`:
+//
+//	principal | CURRENT_USER | CURRENT_ROLE
+//
+// USER/ROLE-qualified and bare-identifier grantors go through parsePrincipal.
+func (p *Parser) parseGrantor() (*Grantor, error) {
+	startLoc := p.cur.Loc
+	switch p.cur.Kind {
+	case kwCURRENT_USER:
+		p.advance()
+		return &Grantor{Kind: GrantorCurrentUser, Loc: ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End}}, nil
+	case kwCURRENT_ROLE:
+		p.advance()
+		return &Grantor{Kind: GrantorCurrentRole, Loc: ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End}}, nil
+	default:
+		principal, err := p.parsePrincipal()
+		if err != nil {
+			return nil, err
+		}
+		return &Grantor{Kind: GrantorPrincipal, Principal: principal, Loc: ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End}}, nil
+	}
+}
+
+// parseOptionalGrantedBy parses an optional `GRANTED BY <grantor>` clause,
+// returning nil when absent.
+func (p *Parser) parseOptionalGrantedBy() (*Grantor, error) {
+	if p.cur.Kind != kwGRANTED {
+		return nil, nil
+	}
+	p.advance() // consume GRANTED
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	return p.parseGrantor()
+}
+
+// parseOptionalInCatalog parses an optional `IN <catalog>` clause, returning nil
+// when absent. The catalog is a plain identifier.
+func (p *Parser) parseOptionalInCatalog() (*ast.Identifier, error) {
+	if p.cur.Kind != kwIN {
+		return nil, nil
+	}
+	p.advance() // consume IN
+	return p.parseIdentifier()
+}

--- a/trino/parser/grant_revoke_test.go
+++ b/trino/parser/grant_revoke_test.go
@@ -1,0 +1,410 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-dcl-tcl node's structural correctness gate for the
+// DCL statements (CREATE/DROP ROLE, GRANT/REVOKE roles & privileges, DENY). The
+// authoritative accept/reject differential against the live Trino 481 oracle
+// lives in oracle_dcl_tcl_test.go; here we pin the AST shape and the
+// role-vs-privilege disambiguation.
+
+func TestCreateDropRole_Structure(t *testing.T) {
+	t.Run("create_role", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "CREATE ROLE admin").(*CreateRoleStmt)
+		if !ok {
+			t.Fatalf("got %T, want *CreateRoleStmt", stmt)
+		}
+		if stmt.Name.Normalize() != "admin" {
+			t.Errorf("Name = %q", stmt.Name.Normalize())
+		}
+		if stmt.Admin != nil || stmt.Catalog != nil {
+			t.Errorf("unexpected Admin=%v Catalog=%v", stmt.Admin, stmt.Catalog)
+		}
+	})
+
+	t.Run("create_role_with_admin_user", func(t *testing.T) {
+		stmt := dclParseOne(t, "CREATE ROLE moderator WITH ADMIN USER bob").(*CreateRoleStmt)
+		if stmt.Admin == nil || stmt.Admin.Kind != GrantorPrincipal {
+			t.Fatalf("Admin = %+v, want a principal grantor", stmt.Admin)
+		}
+		if stmt.Admin.Principal.Kind != PrincipalUser || stmt.Admin.Principal.Name.Normalize() != "bob" {
+			t.Errorf("Admin principal = %+v, want USER bob", stmt.Admin.Principal)
+		}
+	})
+
+	t.Run("create_role_in_catalog", func(t *testing.T) {
+		stmt := dclParseOne(t, "CREATE ROLE admin IN hive").(*CreateRoleStmt)
+		if stmt.Catalog == nil || stmt.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v, want hive", stmt.Catalog)
+		}
+	})
+
+	t.Run("create_role_with_admin_current_role_in_catalog", func(t *testing.T) {
+		stmt := dclParseOne(t, "CREATE ROLE r WITH ADMIN CURRENT_ROLE IN hive").(*CreateRoleStmt)
+		if stmt.Admin == nil || stmt.Admin.Kind != GrantorCurrentRole {
+			t.Errorf("Admin = %+v, want CURRENT_ROLE", stmt.Admin)
+		}
+		if stmt.Catalog == nil || stmt.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v, want hive", stmt.Catalog)
+		}
+	})
+
+	t.Run("drop_role", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "DROP ROLE admin").(*DropRoleStmt)
+		if !ok {
+			t.Fatalf("got %T, want *DropRoleStmt", stmt)
+		}
+		if stmt.IfExists {
+			t.Errorf("IfExists = true, want false")
+		}
+		if stmt.Name.Normalize() != "admin" {
+			t.Errorf("Name = %q", stmt.Name.Normalize())
+		}
+	})
+
+	t.Run("drop_role_if_exists_in_catalog", func(t *testing.T) {
+		stmt := dclParseOne(t, "DROP ROLE IF EXISTS analyst IN hive").(*DropRoleStmt)
+		if !stmt.IfExists {
+			t.Errorf("IfExists = false, want true")
+		}
+		if stmt.Name.Normalize() != "analyst" {
+			t.Errorf("Name = %q", stmt.Name.Normalize())
+		}
+		if stmt.Catalog == nil || stmt.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v, want hive", stmt.Catalog)
+		}
+	})
+}
+
+func TestGrantRoles_Structure(t *testing.T) {
+	t.Run("grant_role_to_user", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "GRANT bar TO USER foo").(*GrantRolesStmt)
+		if !ok {
+			t.Fatalf("got %T, want *GrantRolesStmt", stmt)
+		}
+		if len(stmt.Roles) != 1 || stmt.Roles[0].Normalize() != "bar" {
+			t.Errorf("Roles = %v, want [bar]", stmt.Roles)
+		}
+		if len(stmt.Grantees) != 1 || stmt.Grantees[0].Kind != PrincipalUser || stmt.Grantees[0].Name.Normalize() != "foo" {
+			t.Errorf("Grantees = %+v, want [USER foo]", stmt.Grantees)
+		}
+		if stmt.AdminOption {
+			t.Errorf("AdminOption = true, want false")
+		}
+	})
+
+	t.Run("grant_roles_multi_with_admin_option", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT bar, foo TO USER baz, ROLE qux WITH ADMIN OPTION").(*GrantRolesStmt)
+		if len(stmt.Roles) != 2 {
+			t.Errorf("got %d roles, want 2", len(stmt.Roles))
+		}
+		if len(stmt.Grantees) != 2 {
+			t.Fatalf("got %d grantees, want 2", len(stmt.Grantees))
+		}
+		if stmt.Grantees[0].Kind != PrincipalUser || stmt.Grantees[1].Kind != PrincipalRole {
+			t.Errorf("grantee kinds = %v,%v want USER,ROLE", stmt.Grantees[0].Kind, stmt.Grantees[1].Kind)
+		}
+		if !stmt.AdminOption {
+			t.Errorf("AdminOption = false, want true")
+		}
+	})
+
+	t.Run("grant_role_granted_by_in", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT bar TO USER foo GRANTED BY CURRENT_USER IN hive").(*GrantRolesStmt)
+		if stmt.GrantedBy == nil || stmt.GrantedBy.Kind != GrantorCurrentUser {
+			t.Errorf("GrantedBy = %+v, want CURRENT_USER", stmt.GrantedBy)
+		}
+		if stmt.Catalog == nil || stmt.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v, want hive", stmt.Catalog)
+		}
+	})
+
+	t.Run("grant_role_bare_grantee", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT bar TO foo").(*GrantRolesStmt)
+		if stmt.Grantees[0].Kind != PrincipalUnspecified {
+			t.Errorf("grantee kind = %v, want Unspecified", stmt.Grantees[0].Kind)
+		}
+	})
+
+	t.Run("grant_role_all_as_rolename", func(t *testing.T) {
+		// `ALL` here is a role name (non-reserved), not all-privileges, because
+		// it is followed by TO (role form), not ON.
+		stmt := dclParseOne(t, "GRANT ALL TO foo").(*GrantRolesStmt)
+		if len(stmt.Roles) != 1 || stmt.Roles[0].Normalize() != "all" {
+			t.Errorf("Roles = %v, want [all]", stmt.Roles)
+		}
+	})
+}
+
+func TestRevokeRoles_Structure(t *testing.T) {
+	t.Run("revoke_role", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "REVOKE bar FROM USER foo").(*RevokeRolesStmt)
+		if !ok {
+			t.Fatalf("got %T, want *RevokeRolesStmt", stmt)
+		}
+		if stmt.AdminOptionFor {
+			t.Errorf("AdminOptionFor = true, want false")
+		}
+		if len(stmt.Roles) != 1 || stmt.Roles[0].Normalize() != "bar" {
+			t.Errorf("Roles = %v", stmt.Roles)
+		}
+	})
+
+	t.Run("revoke_admin_option_for_multi", func(t *testing.T) {
+		stmt := dclParseOne(t, "REVOKE ADMIN OPTION FOR bar, foo FROM USER baz, ROLE qux").(*RevokeRolesStmt)
+		if !stmt.AdminOptionFor {
+			t.Errorf("AdminOptionFor = false, want true")
+		}
+		if len(stmt.Roles) != 2 || len(stmt.Grantees) != 2 {
+			t.Errorf("got %d roles / %d grantees, want 2/2", len(stmt.Roles), len(stmt.Grantees))
+		}
+	})
+
+	t.Run("revoke_role_granted_by_role_in", func(t *testing.T) {
+		stmt := dclParseOne(t, "REVOKE bar FROM foo GRANTED BY CURRENT_ROLE IN hive").(*RevokeRolesStmt)
+		if stmt.GrantedBy == nil || stmt.GrantedBy.Kind != GrantorCurrentRole {
+			t.Errorf("GrantedBy = %+v, want CURRENT_ROLE", stmt.GrantedBy)
+		}
+		if stmt.Catalog == nil || stmt.Catalog.Normalize() != "hive" {
+			t.Errorf("Catalog = %v", stmt.Catalog)
+		}
+	})
+}
+
+func TestGrantPrivileges_Structure(t *testing.T) {
+	t.Run("grant_select_insert_on_table", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "GRANT INSERT, SELECT ON orders TO alice").(*GrantPrivStmt)
+		if !ok {
+			t.Fatalf("got %T, want *GrantPrivStmt", stmt)
+		}
+		if stmt.AllPrivileges {
+			t.Errorf("AllPrivileges = true, want false")
+		}
+		if len(stmt.Privileges) != 2 {
+			t.Fatalf("got %d privileges, want 2", len(stmt.Privileges))
+		}
+		if stmt.On.Qualifier != nil || stmt.On.Object.Normalize() != "orders" {
+			t.Errorf("On = %+v, want unqualified orders", stmt.On)
+		}
+		if stmt.On.Branch != nil {
+			t.Errorf("Branch = %v, want nil", stmt.On.Branch)
+		}
+		if stmt.Grantee.Kind != PrincipalUnspecified || stmt.Grantee.Name.Normalize() != "alice" {
+			t.Errorf("Grantee = %+v, want bare alice", stmt.Grantee)
+		}
+	})
+
+	t.Run("grant_delete_on_schema", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT DELETE ON SCHEMA finance TO bob").(*GrantPrivStmt)
+		if !stmt.On.IsSchema() || stmt.On.Object.Normalize() != "finance" {
+			t.Errorf("On = %+v, want SCHEMA finance", stmt.On)
+		}
+	})
+
+	t.Run("grant_select_on_table_kw_with_grant_option", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT SELECT ON TABLE orders TO alice WITH GRANT OPTION").(*GrantPrivStmt)
+		if !stmt.On.IsTable() {
+			t.Errorf("On.Qualifier = %v, want TABLE", stmt.On.Qualifier)
+		}
+		if !stmt.GrantOption {
+			t.Errorf("GrantOption = false, want true")
+		}
+	})
+
+	t.Run("grant_select_to_role_public", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT SELECT ON orders TO ROLE PUBLIC").(*GrantPrivStmt)
+		if stmt.Grantee.Kind != PrincipalRole || stmt.Grantee.Name.Normalize() != "public" {
+			t.Errorf("Grantee = %+v, want ROLE PUBLIC", stmt.Grantee)
+		}
+	})
+
+	t.Run("grant_all_privileges", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT ALL PRIVILEGES ON test TO alice").(*GrantPrivStmt)
+		if !stmt.AllPrivileges || len(stmt.Privileges) != 0 {
+			t.Errorf("got AllPrivileges=%v Privileges=%v, want true/empty", stmt.AllPrivileges, stmt.Privileges)
+		}
+	})
+
+	t.Run("grant_bare_all", func(t *testing.T) {
+		// `GRANT ALL ON test` — bare ALL followed by ON is all-privileges (D3).
+		stmt := dclParseOne(t, "GRANT ALL ON test TO alice").(*GrantPrivStmt)
+		if !stmt.AllPrivileges {
+			t.Errorf("AllPrivileges = false, want true")
+		}
+	})
+
+	t.Run("grant_on_branch", func(t *testing.T) {
+		// D2 docs-ahead extension: ON BRANCH <branch> IN <table>.
+		stmt := dclParseOne(t, "GRANT INSERT ON BRANCH audit IN orders TO alice").(*GrantPrivStmt)
+		if stmt.On.Branch == nil || stmt.On.Branch.Normalize() != "audit" {
+			t.Errorf("Branch = %v, want audit", stmt.On.Branch)
+		}
+		if stmt.On.Object.Normalize() != "orders" {
+			t.Errorf("Object = %v, want orders", stmt.On.Object)
+		}
+	})
+
+	t.Run("grant_open_privilege_vocab", func(t *testing.T) {
+		// D1: a non-reserved identifier is a valid privilege.
+		stmt := dclParseOne(t, "GRANT mypriv ON test TO alice").(*GrantPrivStmt)
+		if len(stmt.Privileges) != 1 || stmt.Privileges[0].Normalize() != "mypriv" {
+			t.Errorf("Privileges = %v, want [mypriv]", stmt.Privileges)
+		}
+	})
+
+	t.Run("grant_privilege_named_to", func(t *testing.T) {
+		// D1 edge: TO is non-reserved, so a privilege literally named "TO" is
+		// valid; the role-vs-privilege scan must not mistake this first TO for
+		// the role-form terminator.
+		stmt := dclParseOne(t, "GRANT TO ON t TO alice").(*GrantPrivStmt)
+		if len(stmt.Privileges) != 1 || stmt.Privileges[0].Normalize() != "to" {
+			t.Errorf("Privileges = %v, want [to]", stmt.Privileges)
+		}
+	})
+
+	t.Run("grant_bare_user_principal", func(t *testing.T) {
+		// USER is non-reserved: a bare USER not followed by a name is itself the
+		// (unspecified) grantee name.
+		stmt := dclParseOne(t, "GRANT SELECT ON t TO USER").(*GrantPrivStmt)
+		if stmt.Grantee.Kind != PrincipalUnspecified || stmt.Grantee.Name.Normalize() != "user" {
+			t.Errorf("Grantee = %+v, want bare name 'user'", stmt.Grantee)
+		}
+	})
+
+	t.Run("grant_qualified_target", func(t *testing.T) {
+		stmt := dclParseOne(t, "GRANT SELECT ON cat.sch.tbl TO alice").(*GrantPrivStmt)
+		if stmt.On.Object.Normalize() != "cat.sch.tbl" {
+			t.Errorf("Object = %v, want cat.sch.tbl", stmt.On.Object)
+		}
+	})
+
+	t.Run("grant_open_entity_kind", func(t *testing.T) {
+		// D5: an arbitrary single word is a valid entity-kind qualifier.
+		stmt := dclParseOne(t, "GRANT SELECT ON VIEW v TO alice").(*GrantPrivStmt)
+		if stmt.On.Qualifier == nil || stmt.On.Qualifier.Normalize() != "view" {
+			t.Errorf("Qualifier = %v, want view", stmt.On.Qualifier)
+		}
+		if stmt.On.Object.Normalize() != "v" {
+			t.Errorf("Object = %v, want v", stmt.On.Object)
+		}
+	})
+
+	t.Run("grant_object_named_branch", func(t *testing.T) {
+		// `ON branch` is an ordinary object named "branch", NOT the BRANCH
+		// clause (which requires `BRANCH <ident> IN`). The trailing TO is a
+		// non-reserved keyword, which previously fooled the branch heuristic.
+		stmt := dclParseOne(t, "GRANT SELECT ON branch TO alice").(*GrantPrivStmt)
+		if stmt.On.Branch != nil {
+			t.Errorf("Branch = %v, want nil (object named branch)", stmt.On.Branch)
+		}
+		if stmt.On.Object.Normalize() != "branch" {
+			t.Errorf("Object = %v, want branch", stmt.On.Object)
+		}
+	})
+
+	t.Run("grant_entity_qualifier_named_branch", func(t *testing.T) {
+		// `ON branch orders` — "branch" is the entity-kind qualifier (no IN
+		// follows), "orders" is the object.
+		stmt := dclParseOne(t, "GRANT SELECT ON branch orders TO alice").(*GrantPrivStmt)
+		if stmt.On.Branch != nil {
+			t.Errorf("Branch = %v, want nil", stmt.On.Branch)
+		}
+		if stmt.On.Qualifier == nil || stmt.On.Qualifier.Normalize() != "branch" {
+			t.Errorf("Qualifier = %v, want branch", stmt.On.Qualifier)
+		}
+		if stmt.On.Object.Normalize() != "orders" {
+			t.Errorf("Object = %v, want orders", stmt.On.Object)
+		}
+	})
+
+	t.Run("grant_branch_in_qualified", func(t *testing.T) {
+		// `ON BRANCH x IN orders` — real branch form; the IN target may itself
+		// carry an entity-kind qualifier.
+		stmt := dclParseOne(t, "GRANT INSERT ON BRANCH audit IN TABLE orders TO alice").(*GrantPrivStmt)
+		if stmt.On.Branch == nil || stmt.On.Branch.Normalize() != "audit" {
+			t.Errorf("Branch = %v, want audit", stmt.On.Branch)
+		}
+		if !stmt.On.IsTable() || stmt.On.Object.Normalize() != "orders" {
+			t.Errorf("IN target = qualifier %v object %v, want TABLE orders", stmt.On.Qualifier, stmt.On.Object)
+		}
+	})
+}
+
+func TestRevokePrivileges_Structure(t *testing.T) {
+	t.Run("revoke_grant_option_for", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "REVOKE GRANT OPTION FOR SELECT ON nation FROM alice").(*RevokePrivStmt)
+		if !ok {
+			t.Fatalf("got %T, want *RevokePrivStmt", stmt)
+		}
+		if !stmt.GrantOptionFor {
+			t.Errorf("GrantOptionFor = false, want true")
+		}
+		if len(stmt.Privileges) != 1 {
+			t.Errorf("got %d privileges, want 1", len(stmt.Privileges))
+		}
+	})
+
+	t.Run("revoke_all_privileges", func(t *testing.T) {
+		stmt := dclParseOne(t, "REVOKE ALL PRIVILEGES ON test FROM alice").(*RevokePrivStmt)
+		if !stmt.AllPrivileges {
+			t.Errorf("AllPrivileges = false, want true")
+		}
+	})
+
+	t.Run("revoke_on_branch", func(t *testing.T) {
+		stmt := dclParseOne(t, "REVOKE INSERT ON BRANCH audit IN orders FROM alice").(*RevokePrivStmt)
+		if stmt.On.Branch == nil || stmt.On.Branch.Normalize() != "audit" {
+			t.Errorf("Branch = %v, want audit", stmt.On.Branch)
+		}
+	})
+}
+
+func TestDeny_Structure(t *testing.T) {
+	t.Run("deny_privs_on_table", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "DENY INSERT, SELECT ON orders TO alice").(*DenyStmt)
+		if !ok {
+			t.Fatalf("got %T, want *DenyStmt", stmt)
+		}
+		if len(stmt.Privileges) != 2 {
+			t.Errorf("got %d privileges, want 2", len(stmt.Privileges))
+		}
+	})
+
+	t.Run("deny_on_schema_to_role_public", func(t *testing.T) {
+		stmt := dclParseOne(t, "DENY SELECT ON orders TO ROLE PUBLIC").(*DenyStmt)
+		if stmt.Grantee.Kind != PrincipalRole {
+			t.Errorf("Grantee kind = %v, want ROLE", stmt.Grantee.Kind)
+		}
+	})
+
+	t.Run("deny_on_branch", func(t *testing.T) {
+		stmt := dclParseOne(t, "DENY INSERT ON BRANCH audit IN orders TO alice").(*DenyStmt)
+		if stmt.On.Branch == nil || stmt.On.Branch.Normalize() != "audit" {
+			t.Errorf("Branch = %v, want audit", stmt.On.Branch)
+		}
+	})
+}
+
+func TestDCL_Negative(t *testing.T) {
+	// Oracle-confirmed (SYNTAX_ERROR in Trino 481) rejections:
+	negatives := []string{
+		"GRANT SELECT TO foo",                                   // privilege keyword with no ON, not a valid role
+		"GRANT select TO foo",                                   // reserved word can't be a role
+		"GRANT CREATE TO foo",                                   // reserved CREATE can't be a role
+		"GRANT SELECT, INSERT TO foo",                           // reserved privilege list with no ON
+		"GRANT ALL PRIVILEGES TO foo",                           // ALL PRIVILEGES is privilege-only (needs ON)
+		"GRANT SELECT TO alice IN hive",                         // IN catalog only valid for role grant
+		"GRANT bar TO foo WITH GRANT OPTION",                    // WITH GRANT OPTION is privilege-only
+		"GRANT SELECT ON test TO alice WITH ADMIN OPTION",       // WITH ADMIN OPTION is role-only
+		"GRANT SELECT ON test TO alice GRANTED BY CURRENT_USER", // GRANTED BY is role-only
+		"REVOKE SELECT ON test FROM alice CASCADE",              // Trino has no CASCADE/RESTRICT
+		"GRANT CREATE TABLE ON SCHEMA s TO alice",               // privileges are single tokens
+		"CREATE ROLE",                                           // missing name
+		"DROP ROLE",                                             // missing name
+	}
+	for _, sql := range negatives {
+		dclParseErr(t, sql)
+	}
+}

--- a/trino/parser/oracle_dcl_tcl_test.go
+++ b/trino/parser/oracle_dcl_tcl_test.go
@@ -1,0 +1,216 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-dcl-tcl node's differential-oracle gate
+// (correctness-protocol.md): for every statement in the corpus below, omni's
+// Parse accept/reject verdict must equal Trino 481's verdict as reported by the
+// live oracle (trinooracle.CheckSyntax, which classifies a SYNTAX_ERROR as
+// reject and every other outcome — success or a semantic error like
+// ROLE_NOT_FOUND / NOT_FOUND / CATALOG_NOT_FOUND — as accept).
+//
+// The corpus is NOT split into "accept" and "reject" lists with hardcoded
+// expectations: the oracle is the source of truth, so each case is run through
+// both omni and Trino and the two verdicts are compared. This both proves
+// correctness and documents (via the captured verdict) which docs/legacy forms
+// Trino 481 actually accepts. Every documented form (truth1), every legacy
+// grammar alternative (truth2), the oracle-confirmed docs-ahead extensions
+// (ON BRANCH, bare ALL, open privilege vocab, DROP ROLE IF EXISTS), and a set
+// of negative forms are present.
+//
+// Skipped cleanly when no Trino oracle is reachable.
+
+// dclTclOracleCorpus is the full DCL/TCL/prepared statement corpus for the
+// differential gate. Each string is fed to both omni and the oracle; the
+// verdicts must match.
+var dclTclOracleCorpus = []string{
+	// --- CREATE / DROP ROLE (truth1 + truth2) ---
+	"CREATE ROLE admin",
+	"CREATE ROLE moderator WITH ADMIN USER bob",
+	"CREATE ROLE admin IN hive",
+	"CREATE ROLE r WITH ADMIN ROLE other",
+	"CREATE ROLE r WITH ADMIN CURRENT_USER",
+	"CREATE ROLE r WITH ADMIN CURRENT_ROLE IN hive",
+	"DROP ROLE admin",
+	"DROP ROLE IF EXISTS analyst", // D4 docs-ahead
+	"DROP ROLE IF EXISTS analyst IN hive",
+	"DROP ROLE analyst IN hive",
+	// negatives
+	"CREATE ROLE",                     // missing name
+	"DROP ROLE",                       // missing name
+	"CREATE ROLE WITH ADMIN USER bob", // missing name before WITH
+	"DROP ROLE IF analyst",            // malformed IF (no EXISTS)
+
+	// --- GRANT roles (truth1 + truth2) ---
+	"GRANT bar TO USER foo",
+	"GRANT bar, foo TO USER baz, ROLE qux WITH ADMIN OPTION",
+	"GRANT bar TO foo",
+	"GRANT bar TO ROLE qux",
+	"GRANT bar TO USER foo GRANTED BY CURRENT_USER",
+	"GRANT bar TO USER foo GRANTED BY ROLE admin",
+	"GRANT bar TO USER foo GRANTED BY USER carol",
+	"GRANT bar TO USER foo IN hive",
+	"GRANT bar TO USER foo WITH ADMIN OPTION GRANTED BY CURRENT_USER IN hive",
+	"GRANT zone TO USER foo", // non-reserved keyword as role name
+	"GRANT ALL TO foo",       // ALL as a role name (followed by TO)
+	`GRANT "my role" TO USER foo`,
+	// USER / ROLE are non-reserved: a bare USER/ROLE not followed by a name is
+	// itself the principal name.
+	"GRANT r TO USER",
+	"GRANT r TO ROLE",
+	"GRANT r TO ROLE, bar",
+	"GRANT r TO USER WITH ADMIN OPTION",
+	"GRANT r TO foo GRANTED BY USER", // bare USER grantor
+	// negatives
+	"GRANT SELECT TO foo",                // reserved privilege keyword, no ON
+	"GRANT select TO foo",                // reserved word can't be a role
+	"GRANT CREATE TO foo",                // reserved CREATE can't be a role
+	"GRANT SELECT, INSERT TO foo",        // reserved list, no ON
+	"GRANT bar TO foo WITH GRANT OPTION", // WITH GRANT OPTION is privilege-only
+	"GRANT bar TO",                       // missing principal
+
+	// --- GRANT privileges (truth1 + truth2 + docs-ahead) ---
+	"GRANT INSERT, SELECT ON orders TO alice",
+	"GRANT DELETE ON SCHEMA finance TO bob",
+	"GRANT SELECT ON nation TO alice WITH GRANT OPTION",
+	"GRANT SELECT ON orders TO ROLE PUBLIC",
+	"GRANT SELECT ON TABLE orders TO alice",
+	"GRANT ALL PRIVILEGES ON test TO alice",
+	"GRANT ALL ON test TO alice", // D3 bare ALL
+	"GRANT UPDATE ON orders TO USER alice",
+	"GRANT SELECT ON cat.sch.tbl TO alice",
+	"GRANT INSERT ON BRANCH audit IN orders TO alice",       // D2 docs-ahead
+	"GRANT INSERT ON BRANCH audit IN TABLE orders TO alice", // branch + IN entity-kind
+	"GRANT INSERT ON BRANCH audit IN cat.s.t TO alice",      // branch + dotted IN target
+	"GRANT mypriv ON test TO alice",                         // D1 open vocab
+	`GRANT "My Priv" ON test TO alice`,
+	"GRANT TO ON t TO alice",   // privilege literally named "TO" (non-reserved)
+	"GRANT FROM ON t TO alice", // privilege literally named "FROM"
+	// D5 open entity-kind qualifier + branch-vs-name disambiguation
+	"GRANT SELECT ON VIEW v TO alice",        // arbitrary entity kind
+	"GRANT SELECT ON a b TO alice",           // arbitrary qualifier "a", object "b"
+	"GRANT SELECT ON branch TO alice",        // object literally named "branch"
+	"GRANT SELECT ON branch orders TO alice", // qualifier "branch", object "orders"
+	"GRANT SELECT ON BRANCH orders TO alice", // qualifier "BRANCH", object "orders" (no IN)
+	"GRANT SELECT ON x a.b.c TO alice",       // qualifier + dotted object
+	// negatives
+	"GRANT ALL PRIVILEGES TO foo",                           // privilege spec needs ON
+	"GRANT SELECT ON test TO alice IN hive",                 // IN catalog is role-only
+	"GRANT SELECT ON test TO alice WITH ADMIN OPTION",       // WITH ADMIN OPTION is role-only
+	"GRANT SELECT ON test TO alice GRANTED BY CURRENT_USER", // GRANTED BY is role-only
+	"GRANT CREATE TABLE ON SCHEMA s TO alice",               // privileges are single tokens
+	"GRANT SELECT ON TO alice",                              // missing object name
+	"GRANT SELECT orders TO alice",                          // missing ON
+	"GRANT SELECT ON a b c TO alice",                        // at most one entity-kind word
+	"GRANT SELECT ON a.b c TO alice",                        // entity-kind qualifier must be single ident
+	"GRANT SELECT ON SELECT orders TO alice",                // reserved word can't be entity kind
+	"GRANT SELECT ON BRANCH a.b IN orders TO alice",         // branch name must be single ident
+	"GRANT SELECT ON BRANCH IN orders TO alice",             // branch name required before IN
+
+	// --- REVOKE roles ---
+	"REVOKE bar FROM USER foo",
+	"REVOKE ADMIN OPTION FOR bar, foo FROM USER baz, ROLE qux",
+	"REVOKE bar FROM foo GRANTED BY CURRENT_ROLE IN hive",
+	"REVOKE bar, foo FROM USER baz",
+	// negatives
+	"REVOKE select FROM foo", // reserved word can't be a role
+	"REVOKE bar FROM",        // missing principal
+
+	// --- REVOKE privileges ---
+	"REVOKE INSERT, SELECT ON orders FROM alice",
+	"REVOKE DELETE ON SCHEMA finance FROM bob",
+	"REVOKE GRANT OPTION FOR SELECT ON nation FROM ROLE PUBLIC",
+	"REVOKE ALL PRIVILEGES ON test FROM alice",
+	"REVOKE INSERT ON BRANCH audit IN orders FROM alice", // D2
+	"REVOKE ALL ON test FROM alice",                      // D3 bare ALL
+	// negatives
+	"REVOKE SELECT ON test FROM alice CASCADE",  // Trino has no CASCADE
+	"REVOKE SELECT ON test FROM alice RESTRICT", // nor RESTRICT
+	"REVOKE GRANT OPTION FOR bar FROM foo",      // GRANT OPTION FOR with no ON (role-ish)
+
+	// --- DENY ---
+	"DENY INSERT, SELECT ON orders TO alice",
+	"DENY DELETE ON SCHEMA finance TO bob",
+	"DENY SELECT ON orders TO ROLE PUBLIC",
+	"DENY ALL PRIVILEGES ON test TO alice",
+	"DENY INSERT ON BRANCH audit IN orders TO alice", // D2
+	// negatives
+	"DENY bar TO foo",                  // DENY has no role form (no ON)
+	"DENY SELECT ON orders FROM alice", // DENY uses TO, not FROM
+
+	// --- START TRANSACTION / COMMIT / ROLLBACK ---
+	"START TRANSACTION",
+	"START TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+	"START TRANSACTION READ WRITE",
+	"START TRANSACTION READ ONLY",
+	"START TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY",
+	"START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE",
+	"START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED",
+	"COMMIT",
+	"COMMIT WORK",
+	"ROLLBACK",
+	"ROLLBACK WORK",
+	// negatives
+	"START TRANSACTION ISOLATION LEVEL BOGUS",
+	"START TRANSACTION READ",
+	"START TRANSACTION ISOLATION REPEATABLE READ", // missing LEVEL
+	"START TRANSACTION ISOLATION LEVEL READ COMMITTED,",
+	"COMMIT TRANSACTION", // Trino COMMIT has no TRANSACTION keyword
+	"ROLLBACK TO sp",     // Trino ROLLBACK has no savepoint form
+
+	// --- PREPARE / DEALLOCATE / EXECUTE / DESCRIBE INPUT|OUTPUT ---
+	"PREPARE my_select1 FROM SELECT * FROM nation",
+	"PREPARE my_select2 FROM SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?",
+	"PREPARE my_insert FROM INSERT INTO cities VALUES (1, 'San Francisco')",
+	"PREPARE my_create FROM CREATE TABLE foo AS SELECT * FROM nation",
+	"DEALLOCATE PREPARE my_query",
+	"EXECUTE my_select1",
+	"EXECUTE my_select2 USING 1, 3",
+	"EXECUTE IMMEDIATE 'SELECT name FROM nation'",
+	"EXECUTE IMMEDIATE 'SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?' USING 1, 3",
+	"EXECUTE IMMEDIATE",         // IMMEDIATE is non-reserved: named-execute of "immediate"
+	"EXECUTE IMMEDIATE USING 1", // named-execute "immediate" with USING
+	"DESCRIBE INPUT my_select1",
+	"DESCRIBE OUTPUT my_select1",
+	"DESCRIBE INPUT foo.bar",  // describeInput takes a single identifier...
+	"DESCRIBE OUTPUT foo.bar", // ...so a dotted name is a SYNTAX_ERROR
+	// negatives
+	"PREPARE p FROM",               // missing inner statement
+	"PREPARE FROM SELECT 1",        // missing name
+	"PREPARE p FROM 1",             // inner is not a statement
+	"PREPARE p FROM NOTASTATEMENT", // inner is not a statement
+	"DEALLOCATE my_query",          // missing PREPARE keyword
+	"EXECUTE IMMEDIATE my_name",    // "immediate" name + trailing token (rejected)
+	"EXECUTE my_select USING",      // dangling USING
+	// NOTE: bare `DESCRIBE INPUT` / `DESCRIBE INPUT.col` are the SHOW COLUMNS
+	// alias `DESCRIBE qualifiedName` (INPUT/OUTPUT are non-reserved table
+	// names there), owned by the parser-utility node — out of this node's
+	// scope, so they are not in this corpus.
+}
+
+// TestDCLTCL_OracleDifferential is the authoritative accept/reject gate: omni's
+// Parse verdict must equal Trino 481's verdict for every corpus statement.
+func TestDCLTCL_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, sql := range dclTclOracleCorpus {
+		sql := sql
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			omniAccepts := len(errs) == 0
+
+			trinoAccepts, ok := oracleAccepts(t, o, sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if omniAccepts != trinoAccepts {
+				t.Errorf("MISMATCH %q: omni accepts=%v (errs=%v), Trino accepts=%v",
+					sql, omniAccepts, errs, trinoAccepts)
+			}
+		})
+	}
+}

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -216,8 +216,22 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// --- DDL ---
 	case kwCREATE:
+		// CREATE ROLE belongs to the parser-dcl-tcl node (grant_revoke.go);
+		// every other CREATE object is a parser-ddl concern (still stubbed).
+		if p.peekNext().Kind == kwROLE {
+			createTok := p.advance() // consume CREATE
+			p.advance()              // consume ROLE
+			return p.parseCreateRoleStmt(createTok.Loc.Start)
+		}
 		return p.unsupported("CREATE")
 	case kwDROP:
+		// DROP ROLE belongs to the parser-dcl-tcl node (grant_revoke.go);
+		// every other DROP object is a parser-ddl concern (still stubbed).
+		if p.peekNext().Kind == kwROLE {
+			dropTok := p.advance() // consume DROP
+			p.advance()            // consume ROLE
+			return p.parseDropRoleStmt(dropTok.Loc.Start)
+		}
 		return p.unsupported("DROP")
 	case kwALTER:
 		return p.unsupported("ALTER")
@@ -244,13 +258,13 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwCALL:
 		return p.unsupported("CALL")
 
-	// --- DCL (roles / privileges) ---
+	// --- DCL (roles / privileges) --- [parser-dcl-tcl node: grant_revoke.go]
 	case kwGRANT:
-		return p.unsupported("GRANT")
+		return p.parseGrantStmt()
 	case kwREVOKE:
-		return p.unsupported("REVOKE")
+		return p.parseRevokeStmt()
 	case kwDENY:
-		return p.unsupported("DENY")
+		return p.parseDenyStmt()
 
 	// --- Session / path / time zone ---
 	case kwSET:
@@ -264,25 +278,41 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwEXPLAIN:
 		return p.unsupported("EXPLAIN")
 	case kwDESCRIBE:
+		// DESCRIBE INPUT <name> / DESCRIBE OUTPUT <name> are prepared-statement
+		// introspection (parser-dcl-tcl node: prepared.go). They are claimed
+		// ONLY when INPUT/OUTPUT is followed by a statement-name identifier:
+		// INPUT and OUTPUT are NON-RESERVED keywords, so a bare `DESCRIBE INPUT`
+		// or `DESCRIBE INPUT.col` is the SHOW COLUMNS alias `DESCRIBE
+		// qualifiedName` (INPUT/OUTPUT being the table name), owned by
+		// parser-utility (still stubbed). Trino's own grammar disambiguates the
+		// same way via adaptive prediction.
+		if (p.peekNext().Kind == kwINPUT || p.peekNext().Kind == kwOUTPUT) && p.describeIntrospectionFollows() {
+			descTok := p.advance() // consume DESCRIBE
+			kind := p.advance()    // consume INPUT / OUTPUT
+			if kind.Kind == kwINPUT {
+				return p.parseDescribeInputStmt(descTok.Loc.Start)
+			}
+			return p.parseDescribeOutputStmt(descTok.Loc.Start)
+		}
 		return p.unsupported("DESCRIBE")
 	case kwDESC:
 		return p.unsupported("DESC")
 
-	// --- Transactions ---
+	// --- Transactions --- [parser-dcl-tcl node: transaction.go]
 	case kwSTART:
-		return p.unsupported("START TRANSACTION")
+		return p.parseStartTransactionStmt()
 	case kwCOMMIT:
-		return p.unsupported("COMMIT")
+		return p.parseCommitStmt()
 	case kwROLLBACK:
-		return p.unsupported("ROLLBACK")
+		return p.parseRollbackStmt()
 
-	// --- Prepared statements ---
+	// --- Prepared statements --- [parser-dcl-tcl node: prepared.go]
 	case kwPREPARE:
-		return p.unsupported("PREPARE")
+		return p.parsePrepareStmt()
 	case kwDEALLOCATE:
-		return p.unsupported("DEALLOCATE")
+		return p.parseDeallocateStmt()
 	case kwEXECUTE:
-		return p.unsupported("EXECUTE")
+		return p.parseExecuteStmt()
 
 	default:
 		return nil, p.unknownStatementError()
@@ -358,6 +388,15 @@ func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
 					Msg: err.Error(),
 				})
 			}
+		} else if p.cur.Kind != tokEOF {
+			// A successful parse must consume the entire segment. Trailing
+			// tokens mean the statement parser stopped early on input the
+			// grammar does not accept (e.g. a misplaced clause like
+			// `GRANT bar TO foo WITH GRANT OPTION`, or `... CASCADE` where
+			// Trino has no such option). Report it so Diagnose flags it and
+			// the oracle differential agrees. (Stubbed statements always
+			// return a non-nil error, so they never reach this branch.)
+			p.errors = append(p.errors, *p.syntaxErrorAtCur())
 		}
 		result = node
 	}

--- a/trino/parser/prepared.go
+++ b/trino/parser/prepared.go
@@ -1,0 +1,351 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-dcl-tcl DAG node: it implements Trino's
+// prepared-statement family — PREPARE, DEALLOCATE PREPARE, EXECUTE, EXECUTE
+// IMMEDIATE, DESCRIBE INPUT, and DESCRIBE OUTPUT — as hand-written
+// recursive-descent parsers over the token stream.
+//
+// The statement nodes are returned from parseStmt as ast.Node and carry an
+// ast.NodeTag (trino/ast/nodetags.go); their concrete fields live here in
+// package parser (Trino convention for parser-built node types).
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : ...
+//	    | PREPARE_ identifier FROM_ statement                                   # prepare
+//	    | DEALLOCATE_ PREPARE_ identifier                                       # deallocate
+//	    | EXECUTE_ identifier (USING_ expression (COMMA_ expression)*)?         # execute
+//	    | EXECUTE_ IMMEDIATE_ string_ (USING_ expression (COMMA_ expression)*)? # executeImmediate
+//	    | DESCRIBE_ INPUT_ identifier                                           # describeInput
+//	    | DESCRIBE_ OUTPUT_ identifier                                          # describeOutput
+//	    ;
+//
+// Trino 481 docs (truth1) confirm the same surface.
+//
+// Boundary decision (recorded as flagged-by-design in the migration divergence
+// ledger, following the doris/snowflake/expressions B1 precedent): the inner
+// `statement` of PREPARE is captured as RAW TEXT, not a parsed AST sub-tree.
+// The omni statement-layer parsers (parser-select/ddl/dml) are not all merged
+// when this node lands, and even once they are, an embedded statement stays a
+// placeholder analogous to a SubqueryExpr — a later consumer (analysis,
+// deparse) re-parses the RawText if it needs structure. We still require the
+// inner statement to be non-empty so `PREPARE x FROM` (which Trino rejects as a
+// syntax error) is rejected here too.
+//
+// The implementation is adjudicated against the live Trino 481 oracle.
+
+// ---------------------------------------------------------------------------
+// Statement AST
+// ---------------------------------------------------------------------------
+
+// PrepareStmt is a PREPARE <name> FROM <statement>. Name is the prepared
+// statement name; Body is the raw source text of the prepared statement (see
+// the file-header boundary decision).
+type PrepareStmt struct {
+	Name *ast.Identifier
+	Body string
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *PrepareStmt) Tag() ast.NodeTag { return ast.T_PrepareStmt }
+
+// DeallocateStmt is a DEALLOCATE PREPARE <name>.
+type DeallocateStmt struct {
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *DeallocateStmt) Tag() ast.NodeTag { return ast.T_DeallocateStmt }
+
+// ExecuteStmt is an EXECUTE <name> [USING <expr> [, <expr> ...]]. Using holds
+// the positional parameter expressions (nil/empty when the USING clause is
+// absent).
+type ExecuteStmt struct {
+	Name  *ast.Identifier
+	Using []Expr
+	Loc   ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *ExecuteStmt) Tag() ast.NodeTag { return ast.T_ExecuteStmt }
+
+// ExecuteImmediateStmt is an EXECUTE IMMEDIATE '<sql>' [USING <expr> [, ...]].
+// SQL is the decoded statement-string literal; Using holds the positional
+// parameter expressions.
+type ExecuteImmediateStmt struct {
+	SQL   string
+	Using []Expr
+	Loc   ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *ExecuteImmediateStmt) Tag() ast.NodeTag { return ast.T_ExecuteImmediateStmt }
+
+// DescribeInputStmt is a DESCRIBE INPUT <name>.
+type DescribeInputStmt struct {
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *DescribeInputStmt) Tag() ast.NodeTag { return ast.T_DescribeInputStmt }
+
+// DescribeOutputStmt is a DESCRIBE OUTPUT <name>.
+type DescribeOutputStmt struct {
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *DescribeOutputStmt) Tag() ast.NodeTag { return ast.T_DescribeOutputStmt }
+
+// Compile-time assertions that the statement types satisfy ast.Node.
+var (
+	_ ast.Node = (*PrepareStmt)(nil)
+	_ ast.Node = (*DeallocateStmt)(nil)
+	_ ast.Node = (*ExecuteStmt)(nil)
+	_ ast.Node = (*ExecuteImmediateStmt)(nil)
+	_ ast.Node = (*DescribeInputStmt)(nil)
+	_ ast.Node = (*DescribeOutputStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+// parsePrepareStmt parses PREPARE <name> FROM <statement>. On entry cur is the
+// PREPARE keyword. The inner statement is captured as raw text (see the
+// file-header boundary decision) but is also validated as a real Trino
+// statement so that PREPARE rejects an invalid inner statement the way Trino
+// does (`PREPARE p FROM 1` is a SYNTAX_ERROR).
+func (p *Parser) parsePrepareStmt() (ast.Node, error) {
+	prepareTok := p.advance() // consume PREPARE
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+
+	// The inner statement is required and runs to the end of this segment (the
+	// statement splitter has already isolated one statement per segment). Slice
+	// the remaining source as raw text.
+	if p.cur.Kind == tokEOF {
+		// PREPARE x FROM <nothing> — Trino rejects this as a syntax error.
+		return nil, p.syntaxErrorAtCur()
+	}
+	bodyStart := p.cur.Loc.Start
+	bodyLoc := p.cur.Loc
+	bodyEnd := p.cur.Loc.Start
+	for p.cur.Kind != tokEOF {
+		bodyEnd = p.cur.Loc.End
+		p.advance()
+	}
+	body := strings.TrimSpace(p.sourceSlice(bodyStart, bodyEnd))
+	if body == "" {
+		return nil, &ParseError{Loc: ast.Loc{Start: bodyStart, End: bodyEnd}, Msg: "expected a statement after PREPARE ... FROM"}
+	}
+
+	// Validate the inner statement. Re-parsing the body through the full parser
+	// reports a real error for non-statements (`PREPARE p FROM 1`,
+	// `... FROM NOTASTATEMENT`). A "not yet supported" stub error means the
+	// inner statement FORM is recognized (its concrete parser is a later DAG
+	// node) — that counts as syntactically valid here, and the check tightens
+	// automatically as those parsers land. See bodyHasHardError.
+	if err := bodyHasHardError(body); err != nil {
+		return nil, &ParseError{Loc: bodyLoc, Msg: "invalid statement after PREPARE ... FROM: " + err.Error()}
+	}
+
+	return &PrepareStmt{
+		Name: name,
+		Body: body,
+		Loc:  ast.Loc{Start: prepareTok.Loc.Start, End: bodyEnd},
+	}, nil
+}
+
+// bodyHasHardError re-parses a PREPARE inner-statement body and reports the
+// first NON-STUB error, or nil if the body is a syntactically valid statement
+// (possibly one whose concrete parser is not yet implemented). A "not yet
+// supported" stub error is treated as success: it means the statement form was
+// recognized by the dispatch but its body parser is a later DAG node. Any other
+// error — an unknown leading keyword, a lex error, or (once the statement
+// parsers land) a genuine inner syntax error — is a hard error.
+func bodyHasHardError(body string) error {
+	_, errs := Parse(body)
+	for i := range errs {
+		if !strings.Contains(errs[i].Msg, "not yet supported") {
+			return &errs[i]
+		}
+	}
+	return nil
+}
+
+// parseDeallocateStmt parses DEALLOCATE PREPARE <name>. On entry cur is the
+// DEALLOCATE keyword.
+func (p *Parser) parseDeallocateStmt() (ast.Node, error) {
+	deallocTok := p.advance() // consume DEALLOCATE
+	if _, err := p.expect(kwPREPARE); err != nil {
+		return nil, err
+	}
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &DeallocateStmt{
+		Name: name,
+		Loc:  ast.Loc{Start: deallocTok.Loc.Start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// parseExecuteStmt parses both EXECUTE forms, dispatching on a leading
+// IMMEDIATE:
+//
+//	EXECUTE <name> [USING <expr> [, ...]]
+//	EXECUTE IMMEDIATE '<sql>' [USING <expr> [, ...]]
+//
+// On entry cur is the EXECUTE keyword.
+func (p *Parser) parseExecuteStmt() (ast.Node, error) {
+	executeTok := p.advance() // consume EXECUTE
+	start := executeTok.Loc.Start
+
+	// EXECUTE IMMEDIATE '<sql>' is the immediate form ONLY when IMMEDIATE is
+	// directly followed by a string literal. IMMEDIATE is a NON-RESERVED
+	// keyword, so a bare `EXECUTE IMMEDIATE` (or `EXECUTE IMMEDIATE USING 1`)
+	// is the named-execute form of a prepared statement named "immediate" —
+	// Trino dispatches the same way (it reports a semantic
+	// "Prepared statement not found: IMMEDIATE", i.e. accepts the syntax).
+	if p.cur.Kind == kwIMMEDIATE {
+		next := p.peekNext().Kind
+		if next == tokString || next == tokUnicodeString {
+			return p.parseExecuteImmediateTail(start)
+		}
+	}
+
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &ExecuteStmt{
+		Name: name,
+		Loc:  ast.Loc{Start: start, End: p.prev.Loc.End},
+	}
+	using, err := p.parseOptionalUsing()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Using = using
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseExecuteImmediateTail parses the tail of EXECUTE IMMEDIATE:
+//
+//	IMMEDIATE '<sql>' [USING <expr> [, ...]]
+//
+// On entry cur is IMMEDIATE. start is the byte offset of the EXECUTE keyword.
+func (p *Parser) parseExecuteImmediateTail(start int) (ast.Node, error) {
+	p.advance() // consume IMMEDIATE
+
+	// The grammar requires a string_ literal here (the SQL text). A non-string
+	// token is a syntax error; in particular EXECUTE IMMEDIATE <ident> is
+	// invalid (that is the named-EXECUTE form, which has no IMMEDIATE).
+	if p.cur.Kind != tokString && p.cur.Kind != tokUnicodeString {
+		return nil, p.syntaxErrorAtCur()
+	}
+	strTok := p.advance()
+
+	stmt := &ExecuteImmediateStmt{
+		SQL: strTok.Str,
+		Loc: ast.Loc{Start: start, End: strTok.Loc.End},
+	}
+	using, err := p.parseOptionalUsing()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Using = using
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseOptionalUsing parses an optional `USING <expr> (, <expr>)*` clause. It
+// returns nil when no USING is present. A USING keyword with no following
+// expression is a syntax error.
+func (p *Parser) parseOptionalUsing() ([]Expr, error) {
+	if _, ok := p.match(kwUSING); !ok {
+		return nil, nil
+	}
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	using := []Expr{first}
+	for {
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		using = append(using, next)
+	}
+	return using, nil
+}
+
+// describeIntrospectionFollows reports whether the token two positions ahead of
+// the current DESCRIBE keyword (i.e. the token after INPUT/OUTPUT) starts an
+// identifier — the statement name of a DESCRIBE INPUT/OUTPUT introspection
+// statement. It performs a bounded 3-token speculative scan via a checkpoint so
+// the caller's cursor is unchanged; on entry cur is DESCRIBE and peekNext is
+// INPUT/OUTPUT.
+//
+// When this returns false (INPUT/OUTPUT is the last token, or is followed by a
+// '.' or any non-identifier), the statement is the SHOW COLUMNS alias
+// `DESCRIBE qualifiedName` with INPUT/OUTPUT as the (non-reserved) table name,
+// which the dispatcher leaves to parser-utility.
+func (p *Parser) describeIntrospectionFollows() bool {
+	cp := p.checkpoint()
+	defer p.restore(cp)
+	p.advance() // consume DESCRIBE
+	p.advance() // consume INPUT / OUTPUT
+	return isIdentifierStart(p.cur.Kind)
+}
+
+// parseDescribeInputStmt parses DESCRIBE INPUT <name>. On entry the DESCRIBE
+// keyword and the INPUT keyword have BOTH already been consumed by the
+// dispatcher (DESCRIBE is shared with the showColumns form, so the dispatcher
+// peeks the second keyword); start is the DESCRIBE keyword's byte offset.
+func (p *Parser) parseDescribeInputStmt(start int) (ast.Node, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &DescribeInputStmt{
+		Name: name,
+		Loc:  ast.Loc{Start: start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// parseDescribeOutputStmt parses DESCRIBE OUTPUT <name>. On entry the DESCRIBE
+// and OUTPUT keywords have both already been consumed; start is the DESCRIBE
+// keyword's byte offset.
+func (p *Parser) parseDescribeOutputStmt(start int) (ast.Node, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &DescribeOutputStmt{
+		Name: name,
+		Loc:  ast.Loc{Start: start, End: p.prev.Loc.End},
+	}, nil
+}

--- a/trino/parser/prepared_test.go
+++ b/trino/parser/prepared_test.go
@@ -1,0 +1,146 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-dcl-tcl node's structural correctness gate for the
+// prepared-statement family (PREPARE / DEALLOCATE / EXECUTE / EXECUTE IMMEDIATE
+// / DESCRIBE INPUT / DESCRIBE OUTPUT). The authoritative accept/reject
+// differential against the live Trino 481 oracle lives in
+// oracle_dcl_tcl_test.go.
+
+func TestPrepared_Structure(t *testing.T) {
+	t.Run("prepare_select", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "PREPARE my_select FROM SELECT * FROM nation").(*PrepareStmt)
+		if !ok {
+			t.Fatalf("got %T, want *PrepareStmt", stmt)
+		}
+		if stmt.Name.Normalize() != "my_select" {
+			t.Errorf("Name = %q, want my_select", stmt.Name.Normalize())
+		}
+		if stmt.Body != "SELECT * FROM nation" {
+			t.Errorf("Body = %q, want %q", stmt.Body, "SELECT * FROM nation")
+		}
+	})
+
+	t.Run("prepare_insert", func(t *testing.T) {
+		stmt := dclParseOne(t, "PREPARE my_insert FROM INSERT INTO cities VALUES (1, 'San Francisco')").(*PrepareStmt)
+		if stmt.Body != "INSERT INTO cities VALUES (1, 'San Francisco')" {
+			t.Errorf("Body = %q", stmt.Body)
+		}
+	})
+
+	t.Run("prepare_with_params", func(t *testing.T) {
+		// The placeholder '?' and the rest of the inner statement are captured
+		// verbatim; the ';' inside a string would have been handled by Split,
+		// but here the whole tail is one statement.
+		stmt := dclParseOne(t, "PREPARE p FROM SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?").(*PrepareStmt)
+		want := "SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?"
+		if stmt.Body != want {
+			t.Errorf("Body = %q, want %q", stmt.Body, want)
+		}
+	})
+
+	t.Run("deallocate", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "DEALLOCATE PREPARE my_query").(*DeallocateStmt)
+		if !ok {
+			t.Fatalf("got %T, want *DeallocateStmt", stmt)
+		}
+		if stmt.Name.Normalize() != "my_query" {
+			t.Errorf("Name = %q, want my_query", stmt.Name.Normalize())
+		}
+	})
+
+	t.Run("execute_no_using", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "EXECUTE my_select1").(*ExecuteStmt)
+		if !ok {
+			t.Fatalf("got %T, want *ExecuteStmt", stmt)
+		}
+		if stmt.Name.Normalize() != "my_select1" {
+			t.Errorf("Name = %q", stmt.Name.Normalize())
+		}
+		if len(stmt.Using) != 0 {
+			t.Errorf("got %d USING args, want 0", len(stmt.Using))
+		}
+	})
+
+	t.Run("execute_using", func(t *testing.T) {
+		stmt := dclParseOne(t, "EXECUTE my_select2 USING 1, 3").(*ExecuteStmt)
+		if len(stmt.Using) != 2 {
+			t.Fatalf("got %d USING args, want 2", len(stmt.Using))
+		}
+	})
+
+	t.Run("execute_immediate", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "EXECUTE IMMEDIATE 'SELECT name FROM nation'").(*ExecuteImmediateStmt)
+		if !ok {
+			t.Fatalf("got %T, want *ExecuteImmediateStmt", stmt)
+		}
+		if stmt.SQL != "SELECT name FROM nation" {
+			t.Errorf("SQL = %q", stmt.SQL)
+		}
+		if len(stmt.Using) != 0 {
+			t.Errorf("got %d USING args, want 0", len(stmt.Using))
+		}
+	})
+
+	t.Run("execute_immediate_using", func(t *testing.T) {
+		stmt := dclParseOne(t, "EXECUTE IMMEDIATE 'SELECT name FROM nation WHERE regionkey = ? AND nationkey < ?' USING 1, 3").(*ExecuteImmediateStmt)
+		if len(stmt.Using) != 2 {
+			t.Fatalf("got %d USING args, want 2", len(stmt.Using))
+		}
+	})
+
+	t.Run("execute_named_immediate", func(t *testing.T) {
+		// IMMEDIATE not followed by a string is a prepared-statement NAME
+		// (IMMEDIATE is non-reserved), so this is the named-execute form.
+		stmt, ok := dclParseOne(t, "EXECUTE IMMEDIATE").(*ExecuteStmt)
+		if !ok {
+			t.Fatalf("got %T, want *ExecuteStmt (named execute of 'immediate')", stmt)
+		}
+		if stmt.Name.Normalize() != "immediate" {
+			t.Errorf("Name = %q, want immediate", stmt.Name.Normalize())
+		}
+	})
+
+	t.Run("execute_named_immediate_using", func(t *testing.T) {
+		stmt := dclParseOne(t, "EXECUTE IMMEDIATE USING 1").(*ExecuteStmt)
+		if stmt.Name.Normalize() != "immediate" || len(stmt.Using) != 1 {
+			t.Errorf("got Name=%q Using=%d, want immediate / 1", stmt.Name.Normalize(), len(stmt.Using))
+		}
+	})
+
+	t.Run("describe_input", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "DESCRIBE INPUT my_select1").(*DescribeInputStmt)
+		if !ok {
+			t.Fatalf("got %T, want *DescribeInputStmt", stmt)
+		}
+		if stmt.Name.Normalize() != "my_select1" {
+			t.Errorf("Name = %q", stmt.Name.Normalize())
+		}
+	})
+
+	t.Run("describe_output", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "DESCRIBE OUTPUT my_select1").(*DescribeOutputStmt)
+		if !ok {
+			t.Fatalf("got %T, want *DescribeOutputStmt", stmt)
+		}
+		if stmt.Name.Normalize() != "my_select1" {
+			t.Errorf("Name = %q", stmt.Name.Normalize())
+		}
+	})
+}
+
+func TestPrepared_Negative(t *testing.T) {
+	// PREPARE with no/invalid inner statement; DEALLOCATE missing PREPARE
+	// keyword; EXECUTE IMMEDIATE <ident> (parsed as named-execute "immediate"
+	// with a trailing token); EXECUTE with a dangling USING. The oracle
+	// differential confirms each matches Trino 481.
+	dclParseErr(t, "PREPARE p FROM")
+	dclParseErr(t, "PREPARE p FROM 1")             // inner is not a statement
+	dclParseErr(t, "PREPARE p FROM NOTASTATEMENT") // inner is not a statement
+	dclParseErr(t, "DEALLOCATE my_query")
+	dclParseErr(t, "EXECUTE IMMEDIATE my_select") // "immediate" name + trailing token
+	dclParseErr(t, "EXECUTE my_select USING")
+}

--- a/trino/parser/transaction.go
+++ b/trino/parser/transaction.go
@@ -1,0 +1,278 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-dcl-tcl DAG node: it implements Trino's
+// transaction-control (TCL) statements — START TRANSACTION, COMMIT, and
+// ROLLBACK — as hand-written recursive-descent parsers over the token stream.
+//
+// The statement nodes are returned from parseStmt as ast.Node and so carry an
+// ast.NodeTag (declared in trino/ast/nodetags.go); their concrete fields live
+// here in package parser, matching the Trino convention for parser-built node
+// types (Expr in expr.go, DataType in datatypes.go).
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : ...
+//	    | START_ TRANSACTION_ (transactionMode (COMMA_ transactionMode)*)? # startTransaction
+//	    | COMMIT_ WORK_?                                                   # commit
+//	    | ROLLBACK_ WORK_?                                                 # rollback
+//	    ;
+//	transactionMode
+//	    : ISOLATION_ LEVEL_ levelOfIsolation  # isolationLevel
+//	    | READ_ accessMode = (ONLY_ | WRITE_) # transactionAccessMode
+//	    ;
+//	levelOfIsolation
+//	    : READ_ UNCOMMITTED_ # readUncommitted
+//	    | READ_ COMMITTED_   # readCommitted
+//	    | REPEATABLE_ READ_  # repeatableRead
+//	    | SERIALIZABLE_      # serializable
+//	    ;
+//
+// Trino 481 docs (truth1) confirm the same surface, including combining
+// multiple comma-separated modes in one statement, e.g.
+//
+//	START TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY;
+//	START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE;
+//
+// The implementation is adjudicated against the live Trino 481 oracle.
+
+// ---------------------------------------------------------------------------
+// Transaction-mode AST
+// ---------------------------------------------------------------------------
+
+// TxnIsolationLevel enumerates the four SQL isolation levels Trino accepts in
+// an ISOLATION LEVEL transaction mode.
+type TxnIsolationLevel int
+
+const (
+	// IsolationReadUncommitted is READ UNCOMMITTED.
+	IsolationReadUncommitted TxnIsolationLevel = iota
+	// IsolationReadCommitted is READ COMMITTED.
+	IsolationReadCommitted
+	// IsolationRepeatableRead is REPEATABLE READ.
+	IsolationRepeatableRead
+	// IsolationSerializable is SERIALIZABLE.
+	IsolationSerializable
+)
+
+// String renders the isolation level in its canonical SQL spelling.
+func (l TxnIsolationLevel) String() string {
+	switch l {
+	case IsolationReadUncommitted:
+		return "READ UNCOMMITTED"
+	case IsolationReadCommitted:
+		return "READ COMMITTED"
+	case IsolationRepeatableRead:
+		return "REPEATABLE READ"
+	case IsolationSerializable:
+		return "SERIALIZABLE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// TransactionMode is one mode of a START TRANSACTION statement: either an
+// ISOLATION LEVEL clause or a READ ONLY / READ WRITE access mode. Exactly one
+// of the two flavors is active, selected by IsAccessMode.
+type TransactionMode struct {
+	// IsAccessMode distinguishes the two transactionMode alternatives: false
+	// for ISOLATION LEVEL (Isolation is meaningful), true for READ ONLY /
+	// READ WRITE (ReadOnly is meaningful).
+	IsAccessMode bool
+	// Isolation is the isolation level when IsAccessMode is false.
+	Isolation TxnIsolationLevel
+	// ReadOnly is true for READ ONLY, false for READ WRITE, when
+	// IsAccessMode is true.
+	ReadOnly bool
+	Loc      ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// Statement AST
+// ---------------------------------------------------------------------------
+
+// StartTransactionStmt is a START TRANSACTION statement with zero or more
+// comma-separated transaction modes.
+type StartTransactionStmt struct {
+	Modes []*TransactionMode
+	Loc   ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *StartTransactionStmt) Tag() ast.NodeTag { return ast.T_StartTransactionStmt }
+
+// CommitStmt is a COMMIT [WORK] statement. Work records whether the optional,
+// no-op WORK keyword was present (preserved for source-faithful deparse).
+type CommitStmt struct {
+	Work bool
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *CommitStmt) Tag() ast.NodeTag { return ast.T_CommitStmt }
+
+// RollbackStmt is a ROLLBACK [WORK] statement. Work records whether the
+// optional, no-op WORK keyword was present.
+type RollbackStmt struct {
+	Work bool
+	Loc  ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *RollbackStmt) Tag() ast.NodeTag { return ast.T_RollbackStmt }
+
+// Compile-time assertions that the statement types satisfy ast.Node.
+var (
+	_ ast.Node = (*StartTransactionStmt)(nil)
+	_ ast.Node = (*CommitStmt)(nil)
+	_ ast.Node = (*RollbackStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+// parseStartTransactionStmt parses START TRANSACTION [mode [, ...]].
+// On entry cur is the START keyword (not yet consumed).
+func (p *Parser) parseStartTransactionStmt() (ast.Node, error) {
+	startTok := p.advance() // consume START
+	if _, err := p.expect(kwTRANSACTION); err != nil {
+		return nil, err
+	}
+
+	stmt := &StartTransactionStmt{Loc: ast.Loc{Start: startTok.Loc.Start, End: p.prev.Loc.End}}
+
+	// Optional mode list. A mode begins with ISOLATION or READ; anything else
+	// terminates the statement (EOF / ';'). The grammar makes the whole list
+	// optional, so a bare START TRANSACTION is valid.
+	if p.cur.Kind == kwISOLATION || p.cur.Kind == kwREAD {
+		for {
+			mode, err := p.parseTransactionMode()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Modes = append(stmt.Modes, mode)
+			if _, ok := p.match(int(',')); !ok {
+				break
+			}
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseTransactionMode parses one transactionMode:
+//
+//	ISOLATION LEVEL <levelOfIsolation>
+//	READ ( ONLY | WRITE )
+//
+// On entry cur is ISOLATION or READ.
+func (p *Parser) parseTransactionMode() (*TransactionMode, error) {
+	startLoc := p.cur.Loc
+	switch p.cur.Kind {
+	case kwISOLATION:
+		p.advance() // consume ISOLATION
+		if _, err := p.expect(kwLEVEL); err != nil {
+			return nil, err
+		}
+		level, err := p.parseIsolationLevel()
+		if err != nil {
+			return nil, err
+		}
+		return &TransactionMode{
+			IsAccessMode: false,
+			Isolation:    level,
+			Loc:          ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+		}, nil
+
+	case kwREAD:
+		p.advance() // consume READ
+		switch p.cur.Kind {
+		case kwONLY:
+			p.advance() // consume ONLY
+			return &TransactionMode{
+				IsAccessMode: true,
+				ReadOnly:     true,
+				Loc:          ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+			}, nil
+		case kwWRITE:
+			p.advance() // consume WRITE
+			return &TransactionMode{
+				IsAccessMode: true,
+				ReadOnly:     false,
+				Loc:          ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+			}, nil
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseIsolationLevel parses a levelOfIsolation:
+//
+//	READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE
+//
+// On entry cur is READ, REPEATABLE, or SERIALIZABLE (the LEVEL keyword has
+// already been consumed).
+func (p *Parser) parseIsolationLevel() (TxnIsolationLevel, error) {
+	switch p.cur.Kind {
+	case kwREAD:
+		p.advance() // consume READ
+		switch p.cur.Kind {
+		case kwUNCOMMITTED:
+			p.advance()
+			return IsolationReadUncommitted, nil
+		case kwCOMMITTED:
+			p.advance()
+			return IsolationReadCommitted, nil
+		default:
+			return 0, p.syntaxErrorAtCur()
+		}
+	case kwREPEATABLE:
+		p.advance() // consume REPEATABLE
+		if _, err := p.expect(kwREAD); err != nil {
+			return 0, err
+		}
+		return IsolationRepeatableRead, nil
+	case kwSERIALIZABLE:
+		p.advance() // consume SERIALIZABLE
+		return IsolationSerializable, nil
+	default:
+		return 0, p.syntaxErrorAtCur()
+	}
+}
+
+// parseCommitStmt parses COMMIT [WORK]. On entry cur is the COMMIT keyword.
+func (p *Parser) parseCommitStmt() (ast.Node, error) {
+	commitTok := p.advance() // consume COMMIT
+	stmt := &CommitStmt{Loc: ast.Loc{Start: commitTok.Loc.Start, End: commitTok.Loc.End}}
+	if _, ok := p.match(kwWORK); ok {
+		stmt.Work = true
+		stmt.Loc.End = p.prev.Loc.End
+	}
+	return stmt, nil
+}
+
+// parseRollbackStmt parses ROLLBACK [WORK]. On entry cur is the ROLLBACK
+// keyword.
+//
+// Note Trino's ROLLBACK statement is transaction rollback only; it has no
+// SAVEPOINT / TO form (the grammar's rollback alternative is just
+// `ROLLBACK_ WORK_?`).
+func (p *Parser) parseRollbackStmt() (ast.Node, error) {
+	rollbackTok := p.advance() // consume ROLLBACK
+	stmt := &RollbackStmt{Loc: ast.Loc{Start: rollbackTok.Loc.Start, End: rollbackTok.Loc.End}}
+	if _, ok := p.match(kwWORK); ok {
+		stmt.Work = true
+		stmt.Loc.End = p.prev.Loc.End
+	}
+	return stmt, nil
+}

--- a/trino/parser/transaction_test.go
+++ b/trino/parser/transaction_test.go
@@ -1,0 +1,149 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-dcl-tcl node's correctness gate for the TCL
+// statements (START TRANSACTION / COMMIT / ROLLBACK), structural layer. The
+// authoritative accept/reject differential against the live Trino 481 oracle
+// lives in oracle_dcl_tcl_test.go alongside the DCL/prepared corpora.
+
+// dclParseOne parses exactly one statement via the public Parse entry point and
+// returns it, failing the test if parsing errored or did not yield exactly one
+// statement. It is the shared structural-test helper for the parser-dcl-tcl
+// node (used by the transaction / grant-revoke / prepared structural tests).
+func dclParseOne(t *testing.T, sql string) interface{} {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q): unexpected errors: %v", sql, errs)
+	}
+	if file == nil || len(file.Stmts) != 1 {
+		got := 0
+		if file != nil {
+			got = len(file.Stmts)
+		}
+		t.Fatalf("Parse(%q): got %d statements, want 1", sql, got)
+	}
+	return file.Stmts[0]
+}
+
+// dclParseErr asserts that Parse reports at least one error for sql (a
+// rejected-by-the-grammar input). It is the structural-layer negative-case
+// helper; the oracle differential confirms these rejections match Trino.
+func dclParseErr(t *testing.T, sql string) {
+	t.Helper()
+	_, errs := Parse(sql)
+	if len(errs) == 0 {
+		t.Errorf("Parse(%q): want at least one error, got none", sql)
+	}
+}
+
+func TestTransaction_Structure(t *testing.T) {
+	t.Run("start_bare", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "START TRANSACTION").(*StartTransactionStmt)
+		if !ok {
+			t.Fatalf("got %T, want *StartTransactionStmt", stmt)
+		}
+		if len(stmt.Modes) != 0 {
+			t.Errorf("got %d modes, want 0", len(stmt.Modes))
+		}
+	})
+
+	t.Run("start_isolation_repeatable_read", func(t *testing.T) {
+		stmt := dclParseOne(t, "START TRANSACTION ISOLATION LEVEL REPEATABLE READ").(*StartTransactionStmt)
+		if len(stmt.Modes) != 1 {
+			t.Fatalf("got %d modes, want 1", len(stmt.Modes))
+		}
+		m := stmt.Modes[0]
+		if m.IsAccessMode {
+			t.Errorf("mode IsAccessMode = true, want false (isolation)")
+		}
+		if m.Isolation != IsolationRepeatableRead {
+			t.Errorf("isolation = %v, want RepeatableRead", m.Isolation)
+		}
+	})
+
+	t.Run("start_read_write", func(t *testing.T) {
+		stmt := dclParseOne(t, "START TRANSACTION READ WRITE").(*StartTransactionStmt)
+		if len(stmt.Modes) != 1 {
+			t.Fatalf("got %d modes, want 1", len(stmt.Modes))
+		}
+		m := stmt.Modes[0]
+		if !m.IsAccessMode || m.ReadOnly {
+			t.Errorf("got IsAccessMode=%v ReadOnly=%v, want access-mode READ WRITE", m.IsAccessMode, m.ReadOnly)
+		}
+	})
+
+	t.Run("start_two_modes", func(t *testing.T) {
+		stmt := dclParseOne(t, "START TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY").(*StartTransactionStmt)
+		if len(stmt.Modes) != 2 {
+			t.Fatalf("got %d modes, want 2", len(stmt.Modes))
+		}
+		if stmt.Modes[0].IsAccessMode || stmt.Modes[0].Isolation != IsolationReadCommitted {
+			t.Errorf("mode[0] = %+v, want isolation READ COMMITTED", stmt.Modes[0])
+		}
+		if !stmt.Modes[1].IsAccessMode || !stmt.Modes[1].ReadOnly {
+			t.Errorf("mode[1] = %+v, want access READ ONLY", stmt.Modes[1])
+		}
+	})
+
+	t.Run("start_serializable", func(t *testing.T) {
+		stmt := dclParseOne(t, "START TRANSACTION ISOLATION LEVEL SERIALIZABLE").(*StartTransactionStmt)
+		if stmt.Modes[0].Isolation != IsolationSerializable {
+			t.Errorf("isolation = %v, want Serializable", stmt.Modes[0].Isolation)
+		}
+	})
+
+	t.Run("start_read_uncommitted", func(t *testing.T) {
+		stmt := dclParseOne(t, "START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED").(*StartTransactionStmt)
+		if stmt.Modes[0].Isolation != IsolationReadUncommitted {
+			t.Errorf("isolation = %v, want ReadUncommitted", stmt.Modes[0].Isolation)
+		}
+	})
+
+	t.Run("commit_bare", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "COMMIT").(*CommitStmt)
+		if !ok {
+			t.Fatalf("got %T, want *CommitStmt", stmt)
+		}
+		if stmt.Work {
+			t.Errorf("Work = true, want false")
+		}
+	})
+
+	t.Run("commit_work", func(t *testing.T) {
+		stmt := dclParseOne(t, "COMMIT WORK").(*CommitStmt)
+		if !stmt.Work {
+			t.Errorf("Work = false, want true")
+		}
+	})
+
+	t.Run("rollback_bare", func(t *testing.T) {
+		stmt, ok := dclParseOne(t, "ROLLBACK").(*RollbackStmt)
+		if !ok {
+			t.Fatalf("got %T, want *RollbackStmt", stmt)
+		}
+		if stmt.Work {
+			t.Errorf("Work = true, want false")
+		}
+	})
+
+	t.Run("rollback_work", func(t *testing.T) {
+		stmt := dclParseOne(t, "ROLLBACK WORK").(*RollbackStmt)
+		if !stmt.Work {
+			t.Errorf("Work = false, want true")
+		}
+	})
+}
+
+func TestTransaction_Negative(t *testing.T) {
+	// Forms Trino rejects: a bogus isolation level, READ with no access mode,
+	// a trailing comma, and ISOLATION without LEVEL. The oracle differential
+	// confirms these match Trino 481.
+	dclParseErr(t, "START TRANSACTION ISOLATION LEVEL BOGUS")
+	dclParseErr(t, "START TRANSACTION READ")
+	dclParseErr(t, "START TRANSACTION ISOLATION REPEATABLE READ")
+	dclParseErr(t, "START TRANSACTION ISOLATION LEVEL READ COMMITTED,")
+}


### PR DESCRIPTION
## Summary

Implements the **parser-dcl-tcl** v2 migration node for the Trino engine: Trino 481's data-control (DCL), transaction-control (TCL), and prepared-statement grammar, as hand-written recursive-descent parsers adjudicated against the **live Trino 481 oracle** (`trino/internal/trinooracle`).

Spec: `docs/migration/trino/analysis.md` Tier 6 + `docs/migration/trino/dag.md` (node `trino/parser-dcl-tcl`).

### Statements implemented
- **`grant_revoke.go`** — `CREATE ROLE`, `DROP ROLE`, `GRANT`/`REVOKE` roles, `GRANT`/`REVOKE`/`DENY` privileges. The role-vs-privilege ambiguity is resolved structurally (a leading `ON` ⇒ privilege grant; `TO`/`FROM` ⇒ role grant) via a bounded, item-aware speculative scan.
- **`transaction.go`** — `START TRANSACTION` (ISOLATION LEVEL + READ ONLY/WRITE modes), `COMMIT [WORK]`, `ROLLBACK [WORK]`.
- **`prepared.go`** — `PREPARE … FROM <stmt>`, `DEALLOCATE PREPARE`, `EXECUTE [USING …]`, `EXECUTE IMMEDIATE '…' [USING …]`, `DESCRIBE INPUT`, `DESCRIBE OUTPUT`.

### Correctness — differential oracle gate
`oracle_dcl_tcl_test.go` runs ~135 statements (every documented 481 form, every legacy ANTLR alternative, the docs-ahead extensions, and negatives) through both omni `Parse` and the live Trino 481 oracle; **omni's accept/reject matches Trino on every case**. Structural unit tests pin the AST shape. The node's full suite is green; the only failing test in `trino/parser` is the pre-existing `TestLexer_OracleDifferential` backtick case (a separate spun-off task, untouched here).

### Divergences (oracle-confirmed, logged in the ledger)
Trino 481 is ahead of the stale legacy ANTLR grammar in 5 ways, all proven real via the oracle and implemented:
- **D1** privilege vocabulary = the five legacy keywords (SELECT/INSERT/UPDATE/DELETE/CREATE) **plus any non-reserved identifier** (e.g. `GRANT TO ON t …`), but not other reserved keywords (`GRANT FROM …` is rejected).
- **D2** `ON BRANCH <branch> IN <target>` branch-qualified targets.
- **D3** bare `ALL` (without `PRIVILEGES`) before `ON`.
- **D4** `DROP ROLE IF EXISTS`.
- **D5** the ON-target entity-kind qualifier is open — `TABLE | SCHEMA | <non-reserved identifier>` (`ON VIEW v`, `ON a b`), not the legacy fixed `(SCHEMA|TABLE)?`.

### Review
Two-reviewer cross-family gate (Claude `/code-review` + Codex). The Claude lens caught a BRANCH-vs-object-name disambiguation bug; the Codex lens caught four more non-reserved-keyword edge cases (EXECUTE IMMEDIATE as a statement name, bare USER/ROLE principals, a privilege named `TO`, and unvalidated PREPARE inner statements). All were verified against the oracle, fixed, and locked into the corpus.

### Out-of-scope writes (recorded, not silent)
The node's declared `writes` globs are the three parser files above. These additional touches were required and are minimal:
- `trino/ast/nodetags.go` — new `NodeTag` constants for the statement nodes (the ast-core tag set is intentionally grown by the parser DAG nodes; statement nodes returned from `parseStmt` must implement `ast.Node`).
- `trino/parser/parser.go` — dispatch wiring for the new statements (incl. second-keyword dispatch for `CREATE/DROP ROLE` and `DESCRIBE INPUT/OUTPUT`), **plus a `parseSingle` trailing-token EOF check** so a statement parser that stops early on input the grammar does not accept (e.g. a misplaced clause, or `… CASCADE` which Trino has no form for) is reported — a foundation-level correctness fix that benefits every statement node.
- Test files (`*_test.go`) alongside the three source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
