### PR TITLE
fix(partiql): completion: panic on pos>len + duplicate NOT

### DIFF
--- a/partiql/completion/completion.go
+++ b/partiql/completion/completion.go
@@ -23,6 +23,18 @@ type Candidate struct {
 // after SELECT/WHERE/etc → suggest columns and keywords, default →
 // suggest keywords).
 func Complete(input string, pos int, cat *catalog.Catalog) []Candidate {
+	// Clamp the cursor position into [0, len(input)] before any slicing.
+	// Complete is exported, so a caller may pass a position past the end of
+	// the input (e.g. a stale cursor). extractPrefix clamps internally, but
+	// the input[:pos-len(prefix)] slice below uses pos directly, so without
+	// this clamp an out-of-range pos panics with "slice bounds out of range".
+	if pos > len(input) {
+		pos = len(input)
+	}
+	if pos < 0 {
+		pos = 0
+	}
+
 	// Get the partial word at cursor position
 	prefix := extractPrefix(input, pos)
 
@@ -101,5 +113,5 @@ var keywords = []string{
 	"UNION", "INTERSECT", "EXCEPT", "DISTINCT", "ALL",
 	"NULL", "MISSING", "TRUE", "FALSE",
 	"CAST", "CASE", "WHEN", "THEN", "ELSE", "END",
-	"EXISTS", "NOT", "ASC", "DESC",
+	"EXISTS", "ASC", "DESC",
 }

--- a/partiql/completion/completion_test.go
+++ b/partiql/completion/completion_test.go
@@ -84,3 +84,113 @@ func TestComplete(t *testing.T) {
 		})
 	}
 }
+
+// TestCompletePositionOutOfRange is a negative test guarding against a slice
+// panic when the caller passes a cursor position past the end of the input.
+// Complete() is exported, so it must clamp internally rather than rely on a
+// caller-side clamp. extractPrefix() already clamps pos, but Complete() used
+// the original unclamped pos when slicing input[:pos-len(prefix)], which
+// panicked with "slice bounds out of range" for any pos > len(input).
+//
+// Spec note (oracle = generated ANTLR PartiQL lexer, truth2): tokenizing
+// "SELECT * FROM " yields "... FROM WS EOF" — no partial identifier follows
+// FROM — so a cursor at/after the end is equivalent to a cursor at the end:
+// prefix is empty and the context is FROM, so tables are suggested.
+func TestCompletePositionOutOfRange(t *testing.T) {
+	cat := catalog.New()
+	cat.AddTable("Music")
+	cat.AddTable("Albums")
+	cat.AddTable("Artists")
+
+	cases := []struct {
+		name  string
+		input string
+		pos   int
+	}{
+		{name: "from_context_far_past_end", input: "SELECT * FROM ", pos: 100},
+		{name: "from_context_one_past_end", input: "SELECT * FROM ", pos: len("SELECT * FROM ") + 1},
+		{name: "with_prefix_past_end", input: "SELECT * FROM M", pos: 100},
+		{name: "empty_input_past_end", input: "", pos: 5},
+		{name: "huge_positive_offset", input: "SELECT", pos: 1 << 30},
+		{name: "negative_offset", input: "SELECT", pos: -3},
+		{name: "negative_offset_empty_input", input: "", pos: -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Complete(%q, %d) panicked: %v", tc.input, tc.pos, r)
+				}
+			}()
+			_ = Complete(tc.input, tc.pos, cat)
+		})
+	}
+
+	// Beyond "does not panic": a cursor past the end of "SELECT * FROM "
+	// must behave exactly like a cursor at the end — FROM context, all tables
+	// suggested, empty prefix.
+	atEnd := Complete("SELECT * FROM ", len("SELECT * FROM "), cat)
+	pastEnd := Complete("SELECT * FROM ", 100, cat)
+	if !equalCandidates(atEnd, pastEnd) {
+		t.Fatalf("past-end completion differs from at-end completion:\n at-end = %v\n past-end = %v", atEnd, pastEnd)
+	}
+	if countKind(pastEnd, "table") != 3 {
+		t.Errorf("past-end FROM context: table candidates = %d, want 3", countKind(pastEnd, "table"))
+	}
+}
+
+// TestKeywordsNoDuplicates guards against duplicate entries in the keyword
+// candidate list. "NOT" was listed twice; it is a single PartiQL keyword
+// (oracle: PartiQLLexer.g4 -> `NOT: 'NOT';`, truth2), so it must appear in
+// completion output exactly once.
+func TestKeywordsNoDuplicates(t *testing.T) {
+	seen := map[string]int{}
+	for _, kw := range keywords {
+		seen[kw]++
+	}
+	for kw, n := range seen {
+		if n > 1 {
+			t.Errorf("keyword %q appears %d times in keywords list, want exactly 1", kw, n)
+		}
+	}
+	if seen["NOT"] != 1 {
+		t.Errorf("keyword %q appears %d times, want 1", "NOT", seen["NOT"])
+	}
+
+	// And the dedup must surface through Complete(): "NOT" must be emitted
+	// once for an input where it matches as a prefix.
+	cat := catalog.New()
+	got := Complete("NO", len("NO"), cat)
+	notCount := 0
+	for _, c := range got {
+		if c.Kind == "keyword" && c.Text == "NOT" {
+			notCount++
+		}
+	}
+	if notCount != 1 {
+		t.Errorf("Complete(\"NO\") emitted NOT %d times, want 1", notCount)
+	}
+}
+
+func equalCandidates(a, b []Candidate) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func countKind(cs []Candidate, kind string) int {
+	n := 0
+	for _, c := range cs {
+		if c.Kind == kind {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## The bugs

`partiql/completion/completion.go` has two defects in the exported `Complete()` API:

**B11 (PANIC — slice bounds out of range).** `Complete()` slices `input[:pos-len(prefix)]` (line 45) using the **original, unclamped** `pos`. `extractPrefix()` clamps `pos` internally (so `prefix` is computed correctly), but `Complete()` does not clamp before its own slice. Any `pos > len(input)` (or `pos < 0`) panics.

- Probe: `Complete("SELECT * FROM ", 100, cat)` → `panic: runtime error: slice bounds out of range [:100] with length 14`.
- This is masked in production by the bytebase wrapper's caller-side clamp, but `Complete()` is **exported** and must be robust on its own.

**Duplicate keyword.** `"NOT"` appeared **twice** in the `keywords` slice (the logical-operator group and again near `EXISTS`), so `Complete()` emitted `NOT` as a candidate twice.

## Oracle evidence (differential)

Oracle = `antlr_fallback`; verified differentially against the **executable generated ANTLR PartiQL lexer** (truth2, `github.com/bytebase/parser/partiql`) using a throwaway `/tmp` Go module (deleted afterward; both repos left pristine).

- Tokenizing `"SELECT * FROM "` → `SELECT WS ASTERISK WS FROM WS EOF`. The last meaningful token is `FROM` and there is **no partial identifier** after it (trailing whitespace, then EOF). So a cursor **at or past** the end is spec-equivalent to a cursor **at** the end: empty prefix, FROM context, suggest all tables. The fix makes past-end completion byte-for-byte identical to at-end completion.
- Tokenizing `"NOT"` → single token `NOT` (type 138); `"a NOT IN b"` → `IDENTIFIER NOT IN IDENTIFIER`. Confirms `NOT` is a real, single PartiQL keyword (`PartiQLLexer.g4`: `NOT: 'NOT';`) that belongs in the candidate list **exactly once** — so the fix is dedup, not removal.

## The fix

- Clamp `pos` into `[0, len(input)]` at the top of `Complete()`, before any slicing.
- Remove the duplicate `"NOT"` from the `keywords` slice (kept once, in the `AND, OR, NOT` group).

Diff is 2 files; `Complete()`'s logic is otherwise unchanged.

## Coverage

- `TestCompletePositionOutOfRange` (negative / no-panic): far-past-end (`pos=100`), one-past-end, with-prefix-past-end, empty-input-past-end, huge-positive-offset (`1<<30`), negative-offset, negative-offset-on-empty-input. Plus an **at-end == past-end** equality assertion and a table-count assertion (FROM context still yields all 3 tables).
- `TestKeywordsNoDuplicates`: asserts no keyword appears more than once and that `NOT` surfaces through `Complete("NO", …)` exactly once.
- Both clamp branches were verified to have teeth: reverting the `pos > len` clamp panics the past-end tests; reverting the `pos < 0` clamp panics the negative tests (`slice bounds out of range [:-3]`).

## Verification

- `go build ./partiql/...` — OK
- `go test -race ./partiql/parser/ ./partiql/completion/ ./partiql/ast/` — all pass
- `go test ./partiql/...` — all 6 packages pass
- `go vet ./partiql/completion/` — clean

## Review

Claude lens (`/code-review`) run pre-PR: no correctness findings on the fix. Two self-caught test-quality gaps fixed during review (misleading case name; missing coverage of the `pos < 0` branch). No flagged divergences — both fixes are oracle-confirmed spec-correct. Codex lens re-run by the orchestrator.

## Scope

Touches only `partiql/completion/completion.go` and `partiql/completion/completion_test.go`. No out-of-scope writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)