### PR TITLE
fix(partiql): ddl: literal bracket-key path step in CREATE INDEX

### DIFF
--- a/partiql/parser/ddl.go
+++ b/partiql/parser/ddl.go
@@ -193,9 +193,18 @@ loop:
 		case tokBRACKET_LEFT:
 			stepStart := p.cur.Loc.Start
 			p.advance() // consume [
-			// Try literal first, then symbolPrimitive.
+			// pathSimpleSteps has two bracket alternatives (g4 lines
+			// 114-115): `[ key=literal ]` and `[ key=symbolPrimitive ]`.
+			// A `literal` is the full set NULL | MISSING | TRUE | FALSE |
+			// string | number | Ion | DATE/TIME (g4 lines 661-672), so we
+			// route every literal-start token through parseLiteral —
+			// matching parsePrimaryBase's literal dispatch — and fall back
+			// to symbolPrimitive only for a bare identifier. (TIMESTAMP is
+			// dispatched here but is not a literal; parseLiteral rejects it
+			// precisely, matching the ANTLR oracle which also rejects
+			// `a[TIMESTAMP '...']`.)
 			var idx ast.ExprNode
-			if p.cur.Type == tokSCONST || p.cur.Type == tokICONST || p.cur.Type == tokFCONST {
+			if isLiteralStart(p.cur.Type) {
 				lit, err := p.parseLiteral()
 				if err != nil {
 					return nil, err
@@ -233,4 +242,26 @@ loop:
 		Steps: steps,
 		Loc:   ast.Loc{Start: nameLoc.Start, End: end},
 	}, nil
+}
+
+// isLiteralStart reports whether tok can begin a `literal` (PartiQLParser.g4
+// lines 661-672): NULL, MISSING, TRUE, FALSE, string, integer, decimal, Ion,
+// or a DATE/TIME literal. It mirrors the literal cases of parsePrimaryBase's
+// dispatch (exprprimary.go) so the bracket-key path step in parsePathSimple
+// admits exactly the grammar's `literal` set.
+//
+// tokTIMESTAMP is included so it is routed to parseLiteral, which rejects it
+// with a precise "TIMESTAMP literal is not supported" error rather than the
+// generic "expected identifier" symbolPrimitive failure — TIMESTAMP is a
+// type-name keyword, not a member of the `literal` rule, and the ANTLR oracle
+// likewise rejects `a[TIMESTAMP '...']`.
+func isLiteralStart(tok int) bool {
+	switch tok {
+	case tokNULL, tokMISSING, tokTRUE, tokFALSE,
+		tokSCONST, tokICONST, tokFCONST, tokION_LITERAL,
+		tokDATE, tokTIME, tokTIMESTAMP:
+		return true
+	default:
+		return false
+	}
 }

--- a/partiql/parser/ddl_test.go
+++ b/partiql/parser/ddl_test.go
@@ -1,0 +1,182 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/partiql/ast"
+)
+
+// TestParser_CreateIndexBracketKeyLiteral verifies that every literal form
+// permitted by the grammar's bracket-key path step is accepted in a
+// CREATE INDEX path list.
+//
+// Grammar (PartiQLParser.g4 line 114):
+//
+//	pathSimpleSteps : BRACKET_LEFT key=literal BRACKET_RIGHT  # PathSimpleLiteral
+//
+// where `literal` (g4 lines 661-672) is NULL | MISSING | TRUE | FALSE |
+// LITERAL_STRING | LITERAL_INTEGER | LITERAL_DECIMAL | ION_CLOSURE |
+// DATE LITERAL_STRING | TIME (...) LITERAL_STRING — i.e. far more than the
+// string/integer/decimal subset the parser previously routed to
+// parseLiteral.
+//
+// Oracle: the executable generated ANTLR parser (bytebase/parser/partiql)
+// ACCEPTS every accept-case below and REJECTS every reject-case (verified
+// differentially via the full Script() entrypoint). These were the exact
+// forms the omni parser wrongly rejected with "expected identifier, got
+// null" because the bracket-key gate only admitted SCONST/ICONST/FCONST.
+func TestParser_CreateIndexBracketKeyLiteral(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// --- newly-accepted non-numeric/non-string literal keys ---
+		{
+			name:  "null_key",
+			input: "CREATE INDEX ON t (a[null])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:NullLit{}}]}]}",
+		},
+		{
+			name:  "true_key",
+			input: "CREATE INDEX ON t (a[true])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:BoolLit{Val:true}}]}]}",
+		},
+		{
+			name:  "false_key",
+			input: "CREATE INDEX ON t (a[false])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:BoolLit{Val:false}}]}]}",
+		},
+		{
+			name:  "missing_key",
+			input: "CREATE INDEX ON t (a[missing])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:MissingLit{}}]}]}",
+		},
+		{
+			name:  "ion_int_key",
+			input: "CREATE INDEX ON t (a[`42`])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:IonLit{Text:\"42\"}}]}]}",
+		},
+		{
+			name:  "ion_struct_key",
+			input: "CREATE INDEX ON t (a[`{x:1}`])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:IonLit{Text:\"{x:1}\"}}]}]}",
+		},
+		{
+			name:  "null_key_then_dot",
+			input: "CREATE INDEX ON t (a[null].b)",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:NullLit{}} DotStep{Field:b}]}]}",
+		},
+		{
+			name:  "dot_then_null_key",
+			input: "CREATE INDEX ON t (a.b[null])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[DotStep{Field:b} IndexStep{Index:NullLit{}}]}]}",
+		},
+		// --- DATE / TIME literal keys (grammar permits; oracle accepts) ---
+		{
+			name:  "date_key",
+			input: "CREATE INDEX ON t (a[DATE '2020-01-01'])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:DateLit{Val:2020-01-01}}]}]}",
+		},
+		{
+			name:  "time_key",
+			input: "CREATE INDEX ON t (a[TIME '12:00:00'])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:TimeLit{Val:12:00:00}}]}]}",
+		},
+		// --- regression guards: forms already accepted pre-fix ---
+		{
+			name:  "string_key",
+			input: "CREATE INDEX ON t (a['k'])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:StringLit{Val:\"k\"}}]}]}",
+		},
+		{
+			name:  "int_key",
+			input: "CREATE INDEX ON t (a[42])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:NumberLit{Val:42}}]}]}",
+		},
+		{
+			name:  "decimal_key",
+			input: "CREATE INDEX ON t (a[3.14])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:NumberLit{Val:3.14}}]}]}",
+		},
+		{
+			name:  "symbol_key",
+			input: "CREATE INDEX ON t (a[b])",
+			want:  "CreateIndexStmt{Table:VarRef{Name:t} Paths:[PathExpr{Root:VarRef{Name:a} Steps:[IndexStep{Index:VarRef{Name:b}}]}]}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			got := ast.NodeToString(stmt)
+			if got != tc.want {
+				t.Errorf("AST mismatch\ngot:  %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParser_CreateIndexBracketKeyReject verifies that the bracket-key path
+// step still rejects everything the grammar forbids: a non-literal/
+// non-symbol bracket key is not a valid `pathSimpleSteps`. Oracle (the
+// generated ANTLR parser) rejects every input below.
+//
+// Negative coverage is required: routing the full literal set through
+// parseLiteral must NOT loosen the gate into accepting general expressions
+// (e.g. `a[1+1]`, `a[(null)]`), an empty bracket, or a TIMESTAMP literal
+// (which is not a member of the `literal` rule).
+func TestParser_CreateIndexBracketKeyReject(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErrIn string
+	}{
+		{
+			name:      "empty_bracket",
+			input:     "CREATE INDEX ON t (a[])",
+			wantErrIn: "expected",
+		},
+		{
+			name:      "missing_rbracket",
+			input:     "CREATE INDEX ON t (a[null)",
+			wantErrIn: "BRACKET_RIGHT",
+		},
+		{
+			name:      "expr_not_literal",
+			input:     "CREATE INDEX ON t (a[1+1])",
+			wantErrIn: "BRACKET_RIGHT",
+		},
+		{
+			name:      "paren_literal",
+			input:     "CREATE INDEX ON t (a[(null)])",
+			wantErrIn: "expected",
+		},
+		{
+			// TIMESTAMP is intentionally NOT a member of the literal rule;
+			// parseLiteral rejects it with a precise message. Oracle also
+			// rejects `a[TIMESTAMP '...']` (no viable alternative).
+			name:      "timestamp_key",
+			input:     "CREATE INDEX ON t (a[TIMESTAMP '2020-01-01 00:00:00'])",
+			wantErrIn: "TIMESTAMP literal is not supported",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			_, err := p.ParseStatement()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrIn) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.wantErrIn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug (B9, low)

`partiql/parser/ddl.go` `parsePathSimple` (bracket-key branch) routed only `tokSCONST | tokICONST | tokFCONST` to `parseLiteral`. Every other bracket-key path step in `CREATE INDEX` fell through to the `symbolPrimitive` branch and was rejected with `expected identifier, got "null"`:

- `CREATE INDEX ON t (a[null])`
- `CREATE INDEX ON t (a[true])`, `a[false]`
- `CREATE INDEX ON t (a[missing])`
- `` CREATE INDEX ON t (a[`42`]) `` (Ion literal)
- `CREATE INDEX ON t (a[null].b)`

The grammar permits these. `pathSimpleSteps` (PartiQLParser.g4:114) is:

```
BRACKET_LEFT key=literal BRACKET_RIGHT             # PathSimpleLiteral
```

and `literal` (g4:661-672) is the full set `NULL | MISSING | TRUE | FALSE | LITERAL_STRING | LITERAL_INTEGER | LITERAL_DECIMAL | ION_CLOSURE | DATE LITERAL_STRING | TIME (...) LITERAL_STRING` — not just the string/number subset.

(Low severity: DynamoDB PartiQL has no `CREATE INDEX`. But it is a real grammar divergence from the canonical PartiQL grammar.)

## Oracle evidence (truth2 = executable generated ANTLR parser)

Verified **differentially** against the generated ANTLR parser/lexer at `bytebase/parser/partiql` (truth2), driven through the full `Script()` entrypoint, on the exact inputs — **0 mismatches** across 14 accept + 5 reject cases. Throwaway probe built under `/tmp` and deleted; both repos left pristine.

ACCEPT (oracle): `a[null]`, `a[true]`, `a[false]`, `a[missing]`, `` a[`42`] ``, `` a[`{x:1}`] ``, `a[null].b`, `a.b[null]`, `a['k']`, `a[42]`, `a[3.14]`, `a[b]` (symbol), `a[DATE '2020-01-01']`, `a[TIME '12:00:00']`.

REJECT (oracle): `a[]` (`no viable alternative at input '[]'`), `a[null` (`missing ']'`), `a[1+1]` (`mismatched input '+' expecting ']'`), `a[(null)]` (`no viable alternative at '[('`), `a[TIMESTAMP '...']` (`no viable alternative at input '[TIMESTAMP'`).

truth1 (docs): the canonical PartiQL grammar's `literal` rule corroborates; `TIMESTAMP` is a type-name keyword, not a `literal` alternative.

## The fix

`partiql/parser/ddl.go`: replace the narrow token check with `isLiteralStart(p.cur.Type)`, a new helper that admits the full literal-start token set, mirroring `parsePrimaryBase`'s literal dispatch (`exprprimary.go`). The `symbolPrimitive` fallback is preserved for bare-identifier keys (`a[b]`).

`tokTIMESTAMP` is included in `isLiteralStart` so it routes to `parseLiteral`, which rejects it with the precise `TIMESTAMP literal is not supported` error instead of the generic `expected identifier` — matching the oracle, which also rejects `a[TIMESTAMP '...']`.

## Coverage (`partiql/parser/ddl_test.go`, new)

100% of the `literal` rule + the `symbolPrimitive` alternative, all verdicts oracle-derived:

- **Accept** (`TestParser_CreateIndexBracketKeyLiteral`, 14): NULL, TRUE, FALSE, MISSING, Ion (int + struct), `null].b` chain, `.b[null` chain, DATE, TIME, plus regression guards string/int/decimal/symbol.
- **Reject** (`TestParser_CreateIndexBracketKeyReject`, 5): empty bracket, missing `]`, `a[1+1]` (expr not literal), `a[(null)]` (parenthesized), `a[TIMESTAMP '...']` (not a literal).

## Verification

- `go build ./partiql/...` — clean
- `go test -race ./partiql/parser/ ./partiql/completion/ ./partiql/ast/` — pass
- `go test ./partiql/...` — pass (existing `create_index` / `create_index_multi` goldens unaffected)
- `go vet ./partiql/parser/` — clean

## Divergence ledger

One **confirmed** behavior change: bracket-key path steps in `CREATE INDEX` now accept the full `literal` set (previously string/number only). Confirmed by the executable ANTLR oracle (0 mismatches) + the g4 grammar. No flagged/unresolved divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)