### PR TITLE
fix(partiql): IS <type> predicate + reject IS TRUE/FALSE + empty IN

### DIFF
--- a/partiql/ast/ast_test.go
+++ b/partiql/ast/ast_test.go
@@ -251,10 +251,10 @@ func TestNodeToString(t *testing.T) {
 			name: "is_missing_predicate",
 			node: &IsExpr{
 				Expr: &VarRef{Name: "y"},
-				Type: IsTypeMissing,
+				Type: &TypeRef{Name: "MISSING"},
 				Not:  false,
 			},
-			want: `IsExpr{Expr:VarRef{Name:y} Type:MISSING Not:false}`,
+			want: `IsExpr{Expr:VarRef{Name:y} Type:TypeRef{Name:MISSING} Not:false}`,
 		},
 		{
 			name: "func_call_count_distinct",

--- a/partiql/ast/exprs.go
+++ b/partiql/ast/exprs.go
@@ -120,32 +120,6 @@ func (op UnOp) String() string {
 	}
 }
 
-// IsType identifies the right-hand side of an `IS [NOT] X` predicate.
-type IsType int
-
-const (
-	IsTypeInvalid IsType = iota
-	IsTypeNull
-	IsTypeMissing
-	IsTypeTrue
-	IsTypeFalse
-)
-
-func (t IsType) String() string {
-	switch t {
-	case IsTypeNull:
-		return "NULL"
-	case IsTypeMissing:
-		return "MISSING"
-	case IsTypeTrue:
-		return "TRUE"
-	case IsTypeFalse:
-		return "FALSE"
-	default:
-		return "INVALID"
-	}
-}
-
 // ===========================================================================
 // Operator nodes
 // ===========================================================================
@@ -229,12 +203,20 @@ func (*LikeExpr) nodeTag()      {}
 func (n *LikeExpr) GetLoc() Loc { return n.Loc }
 func (*LikeExpr) exprNode()     {}
 
-// IsExpr represents `expr IS [NOT] (NULL|MISSING|TRUE|FALSE)`.
+// IsExpr represents `expr IS [NOT] <type>`.
 //
-// Grammar: exprPredicate#PredicateIs
+// Type is the full PartiQL `type` production (PartiQLParser.g4:674-686),
+// the same one CAST uses. The grammar's `type` rule includes NULL and
+// MISSING as atomic types, so `x IS NULL` / `x IS MISSING` are modeled
+// here as `IS <type>` with Type = TypeRef{Name:"NULL"} / {Name:"MISSING"}
+// — there is no separate keyword form. `x IS TRUE` / `x IS FALSE` are NOT
+// valid: TRUE/FALSE are not types, and the legacy grammar marks them "Not
+// yet implemented" (PartiQLParser.g4:437-438); the parser rejects them.
+//
+// Grammar: exprPredicate#PredicateIs (g4:486 — `lhs IS NOT? type`).
 type IsExpr struct {
 	Expr ExprNode
-	Type IsType
+	Type TypeName
 	Not  bool
 	Loc  Loc
 }

--- a/partiql/ast/outfuncs.go
+++ b/partiql/ast/outfuncs.go
@@ -134,7 +134,9 @@ func writeNode(sb *strings.Builder, n Node) {
 	case *IsExpr:
 		sb.WriteString("IsExpr{Expr:")
 		writeNode(sb, v.Expr)
-		fmt.Fprintf(sb, " Type:%s Not:%t}", v.Type, v.Not)
+		sb.WriteString(" Type:")
+		writeNode(sb, v.Type)
+		fmt.Fprintf(sb, " Not:%t}", v.Not)
 
 	// -----------------------------------------------------------------------
 	// exprs.go — special-form expressions

--- a/partiql/parser/expr.go
+++ b/partiql/parser/expr.go
@@ -162,17 +162,19 @@ func tokToComparisonOp(t int) ast.BinOp {
 // alternatives plus the NOT-prefix form for IN/LIKE/BETWEEN:
 //
 //	comparison (=, <>, <, <=, >, >=)
-//	IS [NOT] {NULL|MISSING|TRUE|FALSE}
+//	IS [NOT] <type>
 //	[NOT] IN (expr, expr, ...)
 //	[NOT] LIKE mathOp00 [ESCAPE expr]
 //	[NOT] BETWEEN mathOp00 AND mathOp00
 //
 // Grammar: exprPredicate (lines 484-492).
 //
-// IS type support is RESTRICTED to the 4 values the AST supports
-// (NULL/MISSING/TRUE/FALSE). The grammar allows `IS <any type>` but
-// ast.IsExpr.Type is a 4-value enum. Any other IS form returns a
-// syntax error.
+// The IS predicate's RHS is the full `type` production (g4:486 —
+// `lhs IS NOT? type`), which includes NULL and MISSING as atomic types.
+// `x IS NULL`, `x IS MISSING`, `x IS INT`, `x IS DECIMAL(10,2)`, and
+// `a IS NOT STRUCT` are therefore all valid. `x IS TRUE` / `x IS FALSE`
+// are rejected — TRUE/FALSE are not types (the legacy grammar marks the
+// SQL-92 `IS TRUE/FALSE` form "Not yet implemented", g4:437-438).
 func (p *Parser) parsePredicate() (ast.ExprNode, error) {
 	left, err := p.parseMathOp00()
 	if err != nil {
@@ -247,32 +249,26 @@ func (p *Parser) parsePredicate() (ast.ExprNode, error) {
 	}
 }
 
-// parseIsBody parses the RHS of `expr IS [NOT] {NULL|MISSING|TRUE|FALSE}`.
-// The caller has already consumed the IS token and optionally NOT.
+// parseIsBody parses the RHS of `expr IS [NOT] <type>`. The caller has
+// already consumed the IS token and optionally NOT.
+//
+// The RHS is the full `type` production (PartiQLParser.g4:674-686) — the
+// same one CAST consumes via parseType. NULL and MISSING are atomic types
+// in that production, so `IS NULL` / `IS MISSING` flow through here as
+// types; there is no separate keyword branch. TRUE / FALSE / UNKNOWN are
+// not types, so parseType rejects them with "expected type" — matching the
+// generated ANTLR parser, which yields `mismatched input 'TRUE' expecting
+// { <type first-set> }`.
 func (p *Parser) parseIsBody(left ast.ExprNode, not bool, startLoc int) (*ast.IsExpr, error) {
-	var isType ast.IsType
-	switch p.cur.Type {
-	case tokNULL:
-		isType = ast.IsTypeNull
-	case tokMISSING:
-		isType = ast.IsTypeMissing
-	case tokTRUE:
-		isType = ast.IsTypeTrue
-	case tokFALSE:
-		isType = ast.IsTypeFalse
-	default:
-		return nil, &ParseError{
-			Message: "IS predicate requires NULL, MISSING, TRUE, or FALSE",
-			Loc:     p.cur.Loc,
-		}
+	typeRef, err := p.parseType()
+	if err != nil {
+		return nil, err
 	}
-	end := p.cur.Loc.End
-	p.advance()
 	return &ast.IsExpr{
 		Expr: left,
-		Type: isType,
+		Type: typeRef,
 		Not:  not,
-		Loc:  ast.Loc{Start: startLoc, End: end},
+		Loc:  ast.Loc{Start: startLoc, End: typeRef.GetLoc().End},
 	}, nil
 }
 
@@ -291,19 +287,27 @@ func (p *Parser) parseInBody(left ast.ExprNode, not bool, startLoc int) (*ast.In
 	// Parenthesized form: IN (expr, expr, ...)
 	if p.cur.Type == tokPAREN_LEFT {
 		p.advance() // consume (
-		var list []ast.ExprNode
-		if p.cur.Type != tokPAREN_RIGHT {
-			for {
-				item, err := p.parseMathOp00()
-				if err != nil {
-					return nil, err
-				}
-				list = append(list, item)
-				if p.cur.Type != tokCOMMA {
-					break
-				}
-				p.advance() // consume ,
+		// The grammar requires at least one expr inside the parens
+		// (g4:487 — `NOT? IN PAREN_LEFT expr PAREN_RIGHT`). An empty list
+		// `IN ()` is rejected: the generated ANTLR parser reports
+		// "no viable alternative at input 'IN ()'".
+		if p.cur.Type == tokPAREN_RIGHT {
+			return nil, &ParseError{
+				Message: "IN list requires at least one expression",
+				Loc:     p.cur.Loc,
 			}
+		}
+		var list []ast.ExprNode
+		for {
+			item, err := p.parseMathOp00()
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, item)
+			if p.cur.Type != tokCOMMA {
+				break
+			}
+			p.advance() // consume ,
 		}
 		rp, err := p.expect(tokPAREN_RIGHT)
 		if err != nil {

--- a/partiql/parser/is_in_predicate_test.go
+++ b/partiql/parser/is_in_predicate_test.go
@@ -1,0 +1,230 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/partiql/ast"
+)
+
+// TestIsPredicate_Accept covers the `expr IS [NOT] <type>` predicate
+// (PartiQLParser.g4:486 — `lhs=exprPredicate IS NOT? type`). The RHS is the
+// full `type` production (g4:674-686), which crucially includes NULL and
+// MISSING as atomic types — so `x IS NULL` / `x IS MISSING` are parsed as
+// `IS <type>`, not as a separate keyword form.
+//
+// Oracle (antlr_fallback): the executable generated ANTLR parser at
+// github.com/bytebase/parser/partiql ACCEPTS every one of these via the
+// top-level Script() rule (verified differentially as `SELECT <expr> FROM t;`,
+// parsed to EOF with zero lexer/parser syntax errors). omni previously
+// REJECTED all of them with "IS predicate requires NULL, MISSING, TRUE, or
+// FALSE" — that was a migration bug.
+func TestIsPredicate_Accept(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		// want is the ast.NodeToString rendering of the parsed expression.
+		want string
+	}{
+		{
+			name:  "is_null",
+			input: "x IS NULL",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:NULL} Not:false}",
+		},
+		{
+			name:  "is_missing",
+			input: "x IS MISSING",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:MISSING} Not:false}",
+		},
+		{
+			name:  "is_not_null",
+			input: "x IS NOT NULL",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:NULL} Not:true}",
+		},
+		{
+			name:  "is_not_missing",
+			input: "x IS NOT MISSING",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:MISSING} Not:true}",
+		},
+		{
+			name:  "is_int",
+			input: "x IS INT",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:INT} Not:false}",
+		},
+		{
+			name:  "is_struct",
+			input: "x IS STRUCT",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:STRUCT} Not:false}",
+		},
+		{
+			name:  "is_decimal_args",
+			input: "x IS DECIMAL(10, 2)",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:DECIMAL Args:[10,2]} Not:false}",
+		},
+		{
+			name:  "is_not_int",
+			input: "a IS NOT INT",
+			want:  "IsExpr{Expr:VarRef{Name:a} Type:TypeRef{Name:INT} Not:true}",
+		},
+		{
+			name:  "is_varchar_arg",
+			input: "x IS VARCHAR(255)",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:VARCHAR Args:[255]} Not:false}",
+		},
+		{
+			name:  "is_double_precision",
+			input: "x IS DOUBLE PRECISION",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:DOUBLE PRECISION} Not:false}",
+		},
+		{
+			name:  "is_character_varying",
+			input: "x IS CHARACTER VARYING",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:CHARACTER VARYING} Not:false}",
+		},
+		{
+			name:  "is_time_with_time_zone",
+			input: "x IS TIME WITH TIME ZONE",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:TIME WithTimeZone:true} Not:false}",
+		},
+		{
+			name:  "is_bag",
+			input: "x IS BAG",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:BAG} Not:false}",
+		},
+		{
+			name:  "is_custom_type_ident",
+			input: "x IS foobar",
+			want:  "IsExpr{Expr:VarRef{Name:x} Type:TypeRef{Name:foobar} Not:false}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			expr, err := p.ParseExpr()
+			if err != nil {
+				t.Fatalf("ParseExpr(%q) unexpected error: %v", tc.input, err)
+			}
+			got := ast.NodeToString(expr)
+			if got != tc.want {
+				t.Errorf("ParseExpr(%q)\n got: %s\nwant: %s", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsPredicate_Reject covers the IS forms the executable ANTLR parser
+// REJECTS. TRUE / FALSE are NOT in the `type` production, and the legacy
+// PartiQLParser.g4 precedence comment (line 437-438) marks `IS TRUE/FALSE`
+// as "Not yet implemented in PartiQL". UNKNOWN is likewise not a type.
+//
+// Oracle: via Script(), each yields a syntax error of the form
+// `mismatched input 'TRUE' expecting { <type first-set> }` — an unambiguous
+// reject. omni previously ACCEPTED `IS TRUE`/`IS FALSE` (the removed
+// IsTypeTrue/IsTypeFalse enum values); this test pins the corrected reject.
+func TestIsPredicate_Reject(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErrIn string
+	}{
+		{name: "is_true", input: "x IS TRUE", wantErrIn: "expected type"},
+		{name: "is_false", input: "x IS FALSE", wantErrIn: "expected type"},
+		{name: "is_not_true", input: "x IS NOT TRUE", wantErrIn: "expected type"},
+		{name: "is_not_false", input: "x IS NOT FALSE", wantErrIn: "expected type"},
+		{name: "is_unknown", input: "x IS UNKNOWN", wantErrIn: "expected type"},
+		{name: "is_missing_type", input: "x IS", wantErrIn: "expected type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			_, err := p.ParseExpr()
+			if err == nil {
+				t.Fatalf("ParseExpr(%q) = nil error, want error containing %q", tc.input, tc.wantErrIn)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrIn) {
+				t.Errorf("ParseExpr(%q) error = %q, want to contain %q", tc.input, err.Error(), tc.wantErrIn)
+			}
+		})
+	}
+}
+
+// TestInPredicate_Accept covers the non-empty `expr [NOT] IN (...)` list form
+// and the bare-expression `IN <mathOp00>` form (e.g. an array literal), both
+// confirmed ACCEPT by the ANTLR oracle.
+//
+// Grammar (g4:487-488):
+//
+//	lhs NOT? IN PAREN_LEFT expr PAREN_RIGHT   # PredicateIn  (>=1 expr)
+//	lhs NOT? IN rhs=mathOp00                   # PredicateIn  (array/subquery)
+func TestInPredicate_Accept(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "in_single",
+			input: "a IN (1)",
+			want:  "InExpr{Expr:VarRef{Name:a} List:[NumberLit{Val:1}] Not:false}",
+		},
+		{
+			name:  "in_multi",
+			input: "a IN (1, 2, 3)",
+			want:  "InExpr{Expr:VarRef{Name:a} List:[NumberLit{Val:1} NumberLit{Val:2} NumberLit{Val:3}] Not:false}",
+		},
+		{
+			name:  "not_in_multi",
+			input: "a NOT IN (1, 2)",
+			want:  "InExpr{Expr:VarRef{Name:a} List:[NumberLit{Val:1} NumberLit{Val:2}] Not:true}",
+		},
+		{
+			name:  "in_array_form",
+			input: "a IN [1, 2]",
+			want:  "InExpr{Expr:VarRef{Name:a} List:[ListLit{Items:[NumberLit{Val:1} NumberLit{Val:2}]}] Not:false}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			expr, err := p.ParseExpr()
+			if err != nil {
+				t.Fatalf("ParseExpr(%q) unexpected error: %v", tc.input, err)
+			}
+			got := ast.NodeToString(expr)
+			if got != tc.want {
+				t.Errorf("ParseExpr(%q)\n got: %s\nwant: %s", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInPredicate_Reject covers the empty parenthesized IN list, which the
+// ANTLR oracle REJECTS (g4:487 requires `PAREN_LEFT expr PAREN_RIGHT`, i.e.
+// at least one expr — `a IN ()` yields `no viable alternative at input
+// 'IN ()'`). omni previously ACCEPTED the empty list (the `if p.cur.Type !=
+// tokPAREN_RIGHT` guard let it slip through with a nil List); this pins the
+// corrected reject. The trailing-comma case is also confirmed reject.
+func TestInPredicate_Reject(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErrIn string
+	}{
+		{name: "in_empty", input: "a IN ()", wantErrIn: "IN list requires at least one expression"},
+		{name: "not_in_empty", input: "a NOT IN ()", wantErrIn: "IN list requires at least one expression"},
+		{name: "in_trailing_comma", input: "a IN (1,)", wantErrIn: "unexpected token"},
+		{name: "in_unclosed", input: "a IN (1, 2", wantErrIn: "expected PAREN_RIGHT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			_, err := p.ParseExpr()
+			if err == nil {
+				t.Fatalf("ParseExpr(%q) = nil error, want error containing %q", tc.input, tc.wantErrIn)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrIn) {
+				t.Errorf("ParseExpr(%q) error = %q, want to contain %q", tc.input, err.Error(), tc.wantErrIn)
+			}
+		})
+	}
+}

--- a/partiql/parser/parser_test.go
+++ b/partiql/parser/parser_test.go
@@ -688,11 +688,12 @@ func TestParser_Errors(t *testing.T) {
 			input:     "a BETWEEN 1 10",
 			wantErrIn: "expected AND",
 		},
-		{
-			name:      "is_invalid_type",
-			input:     "a IS INT",
-			wantErrIn: "IS predicate requires NULL, MISSING, TRUE, or FALSE",
-		},
+		// Note: the former "is_invalid_type" case asserted `a IS INT` must
+		// error ("IS predicate requires NULL, MISSING, TRUE, or FALSE"). That
+		// was wrong — g4:486 is `lhs IS NOT? type` and the generated ANTLR
+		// parser ACCEPTS `a IS INT` (INT is a type). The corrected accept/reject
+		// coverage for the IS <type> predicate now lives in
+		// is_in_predicate_test.go (TestIsPredicate_Accept / _Reject).
 		{
 			name:      "bare_comma",
 			input:     ",",

--- a/partiql/parser/testdata/parser-foundation/pred_is_not_null.golden
+++ b/partiql/parser/testdata/parser-foundation/pred_is_not_null.golden
@@ -1,1 +1,1 @@
-IsExpr{Expr:VarRef{Name:a} Type:NULL Not:true}
+IsExpr{Expr:VarRef{Name:a} Type:TypeRef{Name:NULL} Not:true}

--- a/partiql/parser/testdata/parser-foundation/pred_is_null.golden
+++ b/partiql/parser/testdata/parser-foundation/pred_is_null.golden
@@ -1,1 +1,1 @@
-IsExpr{Expr:VarRef{Name:a} Type:NULL Not:false}
+IsExpr{Expr:VarRef{Name:a} Type:TypeRef{Name:NULL} Not:false}


### PR DESCRIPTION
## The bug

Three spec-correctness defects in the PartiQL predicate parser (`partiql/parser/expr.go`), flagged during PartiQL v2 re-validation. The oracle is `antlr_fallback` — the executable generated ANTLR parser/lexer at `github.com/bytebase/parser/partiql`.

**B1 / U1 — `IS <type>` was over-restrictive.** `parseIsBody` modeled the RHS as a 4-value `ast.IsType` enum (NULL/MISSING/TRUE/FALSE) and rejected every other type:

```
x IS INT            -> "IS predicate requires NULL, MISSING, TRUE, or FALSE"
x IS STRUCT         -> (same)
x IS DECIMAL(10,2)  -> (same)
a IS NOT INT        -> (same)
```

But grammar `PartiQLParser.g4:486` is `lhs=exprPredicate IS NOT? type`, and the `type` production (`g4:674-686`) is the full CAST-style type — and it already includes `NULL` and `MISSING` as atomic types. The generated ANTLR parser accepts all of the above.

**Human ruling — reject `IS TRUE` / `IS FALSE`.** `TRUE`/`FALSE` are not in the `type` production. The legacy grammar's precedence comment (`g4:437-438`) marks the SQL-92 `IS TRUE/FALSE` form **"Not yet implemented in PartiQL"**, and the ANTLR parser rejects it. omni previously *accepted* it (via the `IsTypeTrue`/`IsTypeFalse` enum values).

**B2 — wrong reject test.** `parser_test.go` had an `is_invalid_type` case asserting `a IS INT` must error. That assertion encoded the bug.

**B10 — empty `IN ()` was over-permissive.** `parseInBody`'s `if p.cur.Type != tokPAREN_RIGHT` guard let an empty list through (nil `List`). `g4:487` (`NOT? IN PAREN_LEFT expr PAREN_RIGHT`) requires >= 1 expr; ANTLR rejects `a IN ()`.

## Oracle evidence (differential)

Every input below was run through the **generated ANTLR parser** via the top-level `Script()` rule (`SELECT <expr> FROM t;`, parsed to EOF, error-classified — a syntax error means reject), then through the **omni** parser. A throwaway probe module under `/tmp` imported both; both source repos left pristine afterward.

| input | ANTLR verdict | reason (ANTLR) | omni (after fix) |
|---|---|---|---|
| `x IS NULL` / `x IS MISSING` | ACCEPT | NULL/MISSING are atomic types | ACCEPT |
| `x IS INT` / `IS STRUCT` / `IS DECIMAL(10,2)` | ACCEPT | type production | ACCEPT |
| `a IS NOT INT` | ACCEPT | `IS NOT? type` | ACCEPT |
| `x IS VARCHAR(255)` / `DOUBLE PRECISION` / `CHARACTER VARYING` / `TIME WITH TIME ZONE` / `BAG` / `foobar` | ACCEPT | parameterized / 2-token / custom types | ACCEPT |
| `x IS TRUE` / `IS FALSE` / `IS NOT TRUE` / `IS NOT FALSE` / `IS UNKNOWN` | REJECT | `mismatched input 'TRUE' expecting { <type first-set> }` | REJECT |
| `a IN ()` / `a NOT IN ()` | REJECT | `no viable alternative at input 'IN ()'` | REJECT |
| `a IN (1,)` (trailing comma) | REJECT | `mismatched input ')'` | REJECT |
| `a IN (1)` / `IN (1,2,3)` / `NOT IN (1,2)` / `IN [1,2]` | ACCEPT | non-empty list / array form | ACCEPT |

**Result: 26/26 verdicts agree, 0 mismatches.** `truth1` (PartiQL docs) corroborates: `type` covers the scalar/collection types; `IS TRUE/FALSE` is not a documented PartiQL predicate.

## The fix

- **`partiql/ast/exprs.go`** — `IsExpr.Type` changed from the `IsType` enum to `ast.TypeName`; the `IsType` enum (incl. the now-invalid `IsTypeTrue`/`IsTypeFalse`) removed.
- **`partiql/parser/expr.go`** — `parseIsBody` now delegates to `parseType()` (the exact helper `CAST` uses), so `IS NULL`/`IS MISSING`/`IS INT`/`IS DECIMAL(10,2)`/`IS NOT STRUCT` parse as `IS <type>`, and `IS TRUE`/`FALSE`/`UNKNOWN` reject with "expected type". `parseInBody` rejects an empty parenthesized IN list ("IN list requires at least one expression").
- **`partiql/parser/parser_test.go`** — the wrong `is_invalid_type` reject case removed (replaced by accept/reject coverage in the new test file).

## Coverage

New `partiql/parser/is_in_predicate_test.go` (28 sub-tests, all oracle-derived):
- `TestIsPredicate_Accept` — 14 cases: NULL, MISSING, NOT NULL, NOT MISSING, INT, STRUCT, DECIMAL(10,2), NOT INT, VARCHAR(255), DOUBLE PRECISION, CHARACTER VARYING, TIME WITH TIME ZONE, BAG, custom ident — asserted via `ast.NodeToString` (AST-shape, not just accept).
- `TestIsPredicate_Reject` — IS TRUE / FALSE / NOT TRUE / NOT FALSE / UNKNOWN / bare `IS`.
- `TestInPredicate_Accept` — single, multi, NOT-IN, array form.
- `TestInPredicate_Reject` — empty `IN ()`, empty `NOT IN ()`, trailing comma, unclosed.

Verification:
- `go build ./partiql/...` — clean
- `go test -race ./partiql/parser/ ./partiql/completion/ ./partiql/ast/` — pass
- `go test ./partiql/...` — pass
- `go vet ./partiql/ast/ ./partiql/parser/` — clean

## Review

`/code-review` (Claude lens, high effort) across 9 angles — **zero correctness findings**. The fix correctly reuses `parseType()` (right altitude — no re-implemented type parsing) and modeling `IsExpr.Type` as the full `TypeName` generalizes to the grammar's actual shape rather than special-casing NULL/MISSING. One nit (non-blocking): omni's empty-IN error text ("IN list requires at least one expression") differs from ANTLR's wording, consistent with house error-message style; the differential asserts accept/reject parity, not message strings.

## Out-of-scope writes (recorded)

The `IsExpr.Type` field-type change forces these minimal mechanical updates outside the declared scope:
- `partiql/ast/outfuncs.go` — print the `IsExpr.Type` via `writeNode` (was `%s` on the enum).
- `partiql/ast/ast_test.go` — `is_missing_predicate` case updated to `&TypeRef{Name:"MISSING"}` / `Type:TypeRef{Name:MISSING}`.
- `partiql/parser/testdata/parser-foundation/pred_is_null.golden`, `pred_is_not_null.golden` — regenerated (`Type:NULL` -> `Type:TypeRef{Name:NULL}`); diff is print-format only, both inputs still accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
