### PR TITLE
fix(partiql): dml: FROM-led DML (P0) + UPDATE multi-command

### DIFF
--- a/partiql/ast/outfuncs.go
+++ b/partiql/ast/outfuncs.go
@@ -418,7 +418,11 @@ func writeNode(sb *strings.Builder, n Node) {
 	case *InsertStmt:
 		writeDmlStmt(sb, "InsertStmt", v.Target, v.AsAlias, v.Value, v.Pos, v.OnConflict, v.Returning)
 	case *UpdateStmt:
-		sb.WriteString("UpdateStmt{Source:")
+		sb.WriteString("UpdateStmt{")
+		if v.From {
+			sb.WriteString("From:true ")
+		}
+		sb.WriteString("Source:")
 		writeNode(sb, v.Source)
 		sb.WriteString(" Sets:[")
 		for i, s := range v.Sets {
@@ -428,6 +432,16 @@ func writeNode(sb *strings.Builder, n Node) {
 			writeNode(sb, s)
 		}
 		sb.WriteString("]")
+		if len(v.Commands) > 0 {
+			sb.WriteString(" Commands:[")
+			for i, c := range v.Commands {
+				if i > 0 {
+					sb.WriteString(" ")
+				}
+				writeNode(sb, c)
+			}
+			sb.WriteString("]")
+		}
 		if v.Where != nil {
 			sb.WriteString(" Where:")
 			writeNode(sb, v.Where)

--- a/partiql/ast/stmts.go
+++ b/partiql/ast/stmts.go
@@ -231,13 +231,43 @@ func (*InsertStmt) nodeTag()      {}
 func (n *InsertStmt) GetLoc() Loc { return n.Loc }
 func (*InsertStmt) stmtNode()     {}
 
-// UpdateStmt represents `UPDATE source SET ... [WHERE ...] [RETURNING ...]`
-// and the equivalent `FROM source SET ...` form.
+// UpdateStmt represents the two surface forms of the dml#DmlBaseWrapper
+// grammar rule:
 //
-// Grammar: updateClause, dml#DmlBaseWrapper (with dmlBaseCommand containing setCommand)
+//	UPDATE source dmlBaseCommand+ [WHERE ...] [RETURNING ...]   (From == false)
+//	FROM   source [WHERE ...] dmlBaseCommand+ [RETURNING ...]   (From == true)
+//
+// where `source` is a tableBaseReference (UPDATE form) or a full
+// tableReference / join (FROM form), and each `dmlBaseCommand` is one of
+// setCommand, insertCommand, replaceCommand, removeCommand, upsertCommand.
+//
+// Field semantics:
+//   - From distinguishes the two surface forms (they share the
+//     DmlBaseWrapper label in the grammar but differ in clause order: the
+//     FROM form's WHERE precedes the commands; the UPDATE form's WHERE
+//     follows them).
+//   - Sets holds every assignment from every setCommand, flattened in
+//     order (so `SET a=1, b=2` and `SET a=1 SET b=2` are represented
+//     identically — the grammar accepts both equivalently). This is the
+//     dominant case and matches the original single-SET shape.
+//   - Commands holds the non-SET dmlBaseCommands
+//     (*InsertStmt/*ReplaceStmt/*RemoveStmt/*UpsertStmt) in order. It is nil
+//     for the common SET-only statement, so plain UPDATE…SET parses to the
+//     same shape as before this multi-command support was added.
+//
+// The relative interleaving of SET vs non-SET commands is not retained
+// (e.g. `UPDATE t REMOVE a SET b=1` and `UPDATE t SET b=1 REMOVE a` produce
+// equal ASTs). The executable oracle decides only parse accept/reject, and
+// no consumer in this repo executes these multi-command DMLs, so the split
+// representation is spec-correct for parsing; this modeling simplification
+// is recorded in the migration divergence ledger.
+//
+// Grammar: updateClause, dml#DmlBaseWrapper, dmlBaseCommand
 type UpdateStmt struct {
 	Source    TableExpr
+	From      bool
 	Sets      []*SetAssignment
+	Commands  []Node
 	Where     ExprNode
 	Returning *ReturningClause
 	Loc       Loc

--- a/partiql/parser/dml.go
+++ b/partiql/parser/dml.go
@@ -171,19 +171,22 @@ func (p *Parser) parseDeleteStmt() (*ast.DeleteStmt, error) {
 	}, nil
 }
 
-// parseUpdateStmt parses:
+// parseUpdateStmt parses the UPDATE form of dml#DmlBaseWrapper (1st alt):
 //
-//	UPDATE tableBaseReference SET assignment, ... [WHERE expr] [RETURNING ...]
+//	updateClause dmlBaseCommand+ whereClause? returningClause?
 //
-// For the `UPDATE ... SET ...` form, the grammar specifies
-// `updateClause dmlBaseCommand+ whereClause? returningClause?` where
-// updateClause is `UPDATE tableBaseReference` and dmlBaseCommand includes
-// setCommand. We simplify to the common pattern:
+// where updateClause is `UPDATE tableBaseReference` and dmlBaseCommand is
+// one of setCommand / insertCommand / replaceCommand / removeCommand /
+// upsertCommand. All of `UPDATE t SET a=1`, `UPDATE t REMOVE a.b`,
+// `UPDATE t SET a=1 REMOVE b`, `UPDATE t INSERT INTO a VALUE 1`, … are
+// accepted by the grammar (confirmed against the generated ANTLR parser).
 //
-//	UPDATE source (SET assignment, ... | REMOVE pathSimple)+ [WHERE ...] [RETURNING ...]
+// Note the clause order: in this alt the optional whereClause follows the
+// commands (`UPDATE t SET a=1 WHERE x=1`), unlike the FROM-led alt where
+// WHERE precedes them.
 //
-// The source is parsed as a pathSimple with optional aliases since we
-// do not yet have the full FROM parser (node 5 adds it). For cases like
+// The source is parsed as a pathSimple with optional aliases since this
+// branch does not use the full FROM parser. For cases like
 // `UPDATE "Music" SET ...`, pathSimple + aliases is sufficient.
 //
 // Grammar: updateClause + dml#DmlBaseWrapper (PartiQLParser.g4 lines 94-96, 182-183).
@@ -200,39 +203,13 @@ func (p *Parser) parseUpdateStmt() (*ast.UpdateStmt, error) {
 		return nil, err
 	}
 
-	// Parse one or more DML base commands (SET, REMOVE, INSERT, etc.)
-	// In practice the common form is one or more SET commands.
-	var sets []*ast.SetAssignment
-	for {
-		switch p.cur.Type {
-		case tokSET:
-			s, err := p.parseSetCommand()
-			if err != nil {
-				return nil, err
-			}
-			sets = append(sets, s...)
-		case tokREMOVE:
-			// UPDATE ... REMOVE path is a DML base command (removeCommand).
-			// We model it as a SET assignment with nil value. Actually,
-			// the grammar treats REMOVE as a separate dmlBaseCommand.
-			// For now we return an error since UpdateStmt only has Sets.
-			return nil, &ParseError{
-				Message: "REMOVE inside UPDATE is not yet supported; use a standalone REMOVE statement",
-				Loc:     p.cur.Loc,
-			}
-		default:
-			goto doneCommands
-		}
-	}
-doneCommands:
-
-	if len(sets) == 0 {
-		return nil, &ParseError{
-			Message: "expected SET after UPDATE source",
-			Loc:     p.cur.Loc,
-		}
+	// dmlBaseCommand+ : at least one command is required.
+	sets, commands, err := p.parseDmlBaseCommands()
+	if err != nil {
+		return nil, err
 	}
 
+	// whereClause? — AFTER the commands in this alternative.
 	var where ast.ExprNode
 	if p.cur.Type == tokWHERE {
 		p.advance() // consume WHERE
@@ -242,6 +219,7 @@ doneCommands:
 		}
 	}
 
+	// returningClause?
 	var ret *ast.ReturningClause
 	if p.cur.Type == tokRETURNING {
 		ret, err = p.parseReturningClause()
@@ -254,10 +232,139 @@ doneCommands:
 	return &ast.UpdateStmt{
 		Source:    source,
 		Sets:      sets,
+		Commands:  commands,
 		Where:     where,
 		Returning: ret,
 		Loc:       ast.Loc{Start: start, End: end},
 	}, nil
+}
+
+// parseFromLedDml parses the FROM-led form of dml#DmlBaseWrapper (2nd alt):
+//
+//	fromClause whereClause? dmlBaseCommand+ returningClause?
+//
+// e.g. `FROM t SET a=1`, `FROM t WHERE x=1 SET a=1`, `FROM t REMOVE a.b`,
+// `FROM a, b SET x=1` (joins). The source is a full tableReference (handled
+// by parseFromClause), so joins / paths / parenthesised sources all work.
+//
+// Note the clause order differs from the UPDATE alt: here the optional
+// whereClause PRECEDES the commands, and there is no trailing whereClause
+// (a trailing WHERE is a syntax error, matching the ANTLR oracle).
+//
+// The result is represented as an UpdateStmt with From=true.
+//
+// Grammar: fromClause + dml#DmlBaseWrapper (PartiQLParser.g4 lines 94-97, 297-298).
+func (p *Parser) parseFromLedDml() (*ast.UpdateStmt, error) {
+	start := p.cur.Loc.Start
+
+	// fromClause : FROM tableReference (parseFromClause consumes FROM).
+	source, err := p.parseFromClause()
+	if err != nil {
+		return nil, err
+	}
+
+	// whereClause? — BEFORE the commands in this alternative.
+	var where ast.ExprNode
+	if p.cur.Type == tokWHERE {
+		p.advance() // consume WHERE
+		where, err = p.parseExprTop()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// dmlBaseCommand+ : at least one command is required.
+	sets, commands, err := p.parseDmlBaseCommands()
+	if err != nil {
+		return nil, err
+	}
+
+	// returningClause?
+	var ret *ast.ReturningClause
+	if p.cur.Type == tokRETURNING {
+		ret, err = p.parseReturningClause()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	end := p.prev.Loc.End
+	return &ast.UpdateStmt{
+		Source:    source,
+		From:      true,
+		Sets:      sets,
+		Commands:  commands,
+		Where:     where,
+		Returning: ret,
+		Loc:       ast.Loc{Start: start, End: end},
+	}, nil
+}
+
+// parseDmlBaseCommands parses the shared `dmlBaseCommand+` sequence used by
+// both alternatives of dml#DmlBaseWrapper. It requires at least one command
+// and stops at the first token that does not start a dmlBaseCommand.
+//
+// It returns:
+//   - sets: every SET assignment, flattened in order (the dominant case);
+//   - commands: the non-SET commands (*InsertStmt/*ReplaceStmt/*RemoveStmt/
+//     *UpsertStmt) in order, nil when the statement only has SET assignments.
+//
+// At least one command (SET or otherwise) must be present, so a statement
+// that has neither is a syntax error — the ANTLR oracle rejects such input.
+//
+// Grammar: dmlBaseCommand (g4 lines 102-108) =
+// insertCommand | setCommand | replaceCommand | removeCommand | upsertCommand.
+func (p *Parser) parseDmlBaseCommands() (sets []*ast.SetAssignment, commands []ast.Node, err error) {
+	seen := false
+	for {
+		switch p.cur.Type {
+		case tokSET:
+			s, serr := p.parseSetCommand()
+			if serr != nil {
+				return nil, nil, serr
+			}
+			sets = append(sets, s...)
+			seen = true
+		case tokINSERT:
+			ins, ierr := p.parseInsertStmt()
+			if ierr != nil {
+				return nil, nil, ierr
+			}
+			commands = append(commands, ins)
+			seen = true
+		case tokREPLACE:
+			rep, rerr := p.parseReplaceStmt()
+			if rerr != nil {
+				return nil, nil, rerr
+			}
+			commands = append(commands, rep)
+			seen = true
+		case tokREMOVE:
+			rem, rerr := p.parseRemoveStmt()
+			if rerr != nil {
+				return nil, nil, rerr
+			}
+			commands = append(commands, rem)
+			seen = true
+		case tokUPSERT:
+			ups, uerr := p.parseUpsertStmt()
+			if uerr != nil {
+				return nil, nil, uerr
+			}
+			commands = append(commands, ups)
+			seen = true
+		default:
+			if !seen {
+				return nil, nil, &ParseError{
+					// "expected SET" leads the message because SET is the
+					// dominant DML command; the parenthetical lists the rest.
+					Message: fmt.Sprintf("expected SET or another DML command (INSERT, REPLACE, REMOVE, UPSERT), got %q", p.cur.Str),
+					Loc:     p.cur.Loc,
+				}
+			}
+			return sets, commands, nil
+		}
+	}
 }
 
 // parseUpdateSource parses the table reference after UPDATE. This is

--- a/partiql/parser/dml_extra_test.go
+++ b/partiql/parser/dml_extra_test.go
@@ -1,0 +1,391 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/partiql/ast"
+)
+
+// TestParser_FromLedDML covers the FROM-led DML form (the 2nd alternative
+// of dml#DmlBaseWrapper in PartiQLParser.g4):
+//
+//	FROM fromClause whereClause? dmlBaseCommand+ returningClause?
+//
+// Every accept-case below was confirmed ACCEPTED by the generated ANTLR
+// PartiQL parser (Script() entry rule) via a differential probe; every
+// reject-case was confirmed REJECTED (syntax error) by the same parser.
+// The ANTLR grammar is the executable oracle (antlr_fallback) for this node.
+func TestParser_FromLedDML(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantStr string // substring NodeToString must contain
+	}{
+		{
+			name:    "from_set",
+			input:   "FROM t SET a = 1",
+			wantStr: "UpdateStmt{From:true Source:VarRef{Name:t",
+		},
+		{
+			name:    "from_where_set",
+			input:   "FROM t WHERE x = 1 SET a = 1",
+			wantStr: "Where:",
+		},
+		{
+			name:    "from_set_multi",
+			input:   "FROM t SET a = 1, b = 2",
+			wantStr: "Sets:[SetAssignment{Target:PathExpr{Root:VarRef{Name:a",
+		},
+		{
+			name:    "from_set_remove",
+			input:   "FROM t SET a = 1 REMOVE b",
+			wantStr: "RemoveStmt{Path:",
+		},
+		{
+			name:    "from_remove",
+			input:   "FROM t REMOVE a.b",
+			wantStr: "UpdateStmt{From:true Source:VarRef{Name:t",
+		},
+		{
+			name:    "from_insert",
+			input:   "FROM t INSERT INTO a VALUE 1",
+			wantStr: "InsertStmt{",
+		},
+		{
+			name:    "from_replace_bare_expr",
+			input:   "FROM t REPLACE INTO a 1",
+			wantStr: "ReplaceStmt{",
+		},
+		{
+			name:    "from_upsert_bare_expr",
+			input:   "FROM t UPSERT INTO a 1",
+			wantStr: "UpsertStmt{",
+		},
+		{
+			name:    "from_where_set_returning",
+			input:   "FROM t WHERE x = 1 SET a = 1 RETURNING MODIFIED NEW *",
+			wantStr: "Returning:ReturningClause{",
+		},
+		{
+			name:    "from_set_returning",
+			input:   "FROM t SET a = 1 RETURNING ALL OLD *",
+			wantStr: "Returning:ReturningClause{",
+		},
+		{
+			name:    "from_join_set",
+			input:   "FROM a, b SET x = 1",
+			wantStr: "JoinExpr{",
+		},
+		{
+			name:    "from_path_set",
+			input:   "FROM t.x.y SET a = 1",
+			wantStr: "UpdateStmt{From:true",
+		},
+		{
+			name:    "from_alias_set",
+			input:   "FROM t AS x SET a = 1",
+			wantStr: "AliasedSource{",
+		},
+		// FROM source is a full tableReference, so joins / paren / unpivot
+		// all flow through (all ACCEPTed by the ANTLR oracle).
+		{
+			name:    "from_join_on_set",
+			input:   "FROM a JOIN b ON a.id = b.id SET x = 1",
+			wantStr: "JoinExpr{Kind:INNER",
+		},
+		{
+			name:    "from_paren_set",
+			input:   "FROM (t) SET a = 1",
+			wantStr: "UpdateStmt{From:true Source:VarRef{Name:t",
+		},
+		{
+			name:    "from_unpivot_set",
+			input:   "FROM UNPIVOT x SET a = 1",
+			wantStr: "Source:UnpivotExpr{",
+		},
+		// Multiple non-SET commands of the same kind, captured in order.
+		{
+			name:    "from_multi_insert",
+			input:   "FROM t INSERT INTO a VALUE 1 INSERT INTO b VALUE 2",
+			wantStr: "Commands:[InsertStmt{Target:PathExpr{Root:VarRef{Name:a} Steps:[]} Value:NumberLit{Val:1}} InsertStmt{Target:PathExpr{Root:VarRef{Name:b}",
+		},
+		{
+			name:    "from_set_insert_remove",
+			input:   "FROM t SET a = 1 INSERT INTO b VALUE 2 REMOVE c",
+			wantStr: "Commands:[InsertStmt{Target:PathExpr{Root:VarRef{Name:b} Steps:[]} Value:NumberLit{Val:2}} RemoveStmt{Path:",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err != nil {
+				t.Fatalf("ParseStatement(%q) unexpected error: %v", tc.input, err)
+			}
+			us, ok := stmt.(*ast.UpdateStmt)
+			if !ok {
+				t.Fatalf("ParseStatement(%q) = %T, want *ast.UpdateStmt", tc.input, stmt)
+			}
+			if !us.From {
+				t.Errorf("FROM-led form should have From=true, got false")
+			}
+			got := ast.NodeToString(stmt)
+			if !strings.Contains(got, tc.wantStr) {
+				t.Errorf("NodeToString = %q, want to contain %q", got, tc.wantStr)
+			}
+		})
+	}
+}
+
+// TestParser_FromLedDML_Script verifies FROM-led DML also dispatches through
+// the script-level entry point (Parse), which uses parseRootStatement rather
+// than ParseStatement.
+func TestParser_FromLedDML_Script(t *testing.T) {
+	list, err := Parse("FROM t SET a = 1; FROM u WHERE x = 1 REMOVE p.q")
+	if err != nil {
+		t.Fatalf("Parse unexpected error: %v", err)
+	}
+	if list.Len() != 2 {
+		t.Fatalf("Parse len = %d, want 2", list.Len())
+	}
+	for i, item := range list.Items {
+		if _, ok := item.(*ast.UpdateStmt); !ok {
+			t.Errorf("item[%d] = %T, want *ast.UpdateStmt", i, item)
+		}
+	}
+}
+
+// TestParser_FromLedDML_Explain verifies the EXPLAIN prefix composes with
+// FROM-led DML through the script entry (the EXPLAIN prefix is handled by
+// parseRoot, then the inner statement dispatches to FROM-led DML). ANTLR
+// accepts `EXPLAIN FROM t SET a = 1`.
+func TestParser_FromLedDML_Explain(t *testing.T) {
+	list, err := Parse("EXPLAIN FROM t SET a = 1")
+	if err != nil {
+		t.Fatalf("Parse unexpected error: %v", err)
+	}
+	if list.Len() != 1 {
+		t.Fatalf("Parse len = %d, want 1", list.Len())
+	}
+	ex, ok := list.Items[0].(*ast.ExplainStmt)
+	if !ok {
+		t.Fatalf("item[0] = %T, want *ast.ExplainStmt", list.Items[0])
+	}
+	us, ok := ex.Inner.(*ast.UpdateStmt)
+	if !ok {
+		t.Fatalf("EXPLAIN inner = %T, want *ast.UpdateStmt", ex.Inner)
+	}
+	if !us.From {
+		t.Errorf("inner UpdateStmt From = false, want true")
+	}
+}
+
+// TestParser_UpdateParenSource_KnownGap documents a PRE-EXISTING limitation
+// unrelated to this fix: the UPDATE source parser (parseUpdateSource) only
+// accepts a bare/quoted identifier, not a full tableBaseReference, so a
+// parenthesised source `UPDATE (t) SET ...` is rejected even though the
+// ANTLR oracle accepts it. This is out of scope for the multi-command fix
+// (B7/B8 concern the dmlBaseCommand+ loop, not the source production) and is
+// flagged in the migration divergence ledger. The test pins the current
+// behavior so a future source-parser node can flip it deliberately.
+func TestParser_UpdateParenSource_KnownGap(t *testing.T) {
+	p := NewParser("UPDATE (t) SET a = 1")
+	if _, err := p.ParseStatement(); err == nil {
+		t.Fatal("expected error for parenthesised UPDATE source (known gap), got nil")
+	}
+}
+
+// TestParser_UpdateMultiCommand covers the UPDATE multi-command form (the
+// 1st alternative of dml#DmlBaseWrapper):
+//
+//	UPDATE updateClause dmlBaseCommand+ whereClause? returningClause?
+//
+// All accept/reject verdicts confirmed against the generated ANTLR parser.
+func TestParser_UpdateMultiCommand(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantStr string
+	}{
+		{
+			name:    "update_set",
+			input:   "UPDATE t SET a = 1",
+			wantStr: "UpdateStmt{Source:VarRef{Name:t",
+		},
+		{
+			name:    "update_remove",
+			input:   "UPDATE t REMOVE a.b",
+			wantStr: "Commands:[RemoveStmt{Path:",
+		},
+		{
+			name:    "update_set_remove",
+			input:   "UPDATE t SET a = 1 REMOVE b",
+			wantStr: "RemoveStmt{Path:",
+		},
+		{
+			name:    "update_insert",
+			input:   "UPDATE t INSERT INTO a VALUE 1",
+			wantStr: "Commands:[InsertStmt{",
+		},
+		{
+			name:    "update_set_insert",
+			input:   "UPDATE t SET a = 1 INSERT INTO a VALUE 2",
+			wantStr: "InsertStmt{",
+		},
+		{
+			name:    "update_replace_bare_expr",
+			input:   "UPDATE t REPLACE INTO a 1",
+			wantStr: "ReplaceStmt{",
+		},
+		{
+			name:    "update_upsert_bare_expr",
+			input:   "UPDATE t UPSERT INTO a 1",
+			wantStr: "UpsertStmt{",
+		},
+		{
+			name:    "update_remove_set",
+			input:   "UPDATE t REMOVE a.b SET c = 1",
+			wantStr: "Commands:[RemoveStmt{Path:",
+		},
+		{
+			name:    "update_set_where",
+			input:   "UPDATE t SET a = 1 WHERE x = 1",
+			wantStr: "Where:",
+		},
+		{
+			name:    "update_remove_where",
+			input:   "UPDATE t REMOVE a.b WHERE x = 1",
+			wantStr: "Where:",
+		},
+		{
+			name:    "update_set_remove_where_returning",
+			input:   "UPDATE t SET a = 1 REMOVE b WHERE x = 1 RETURNING MODIFIED NEW *",
+			wantStr: "Returning:ReturningClause{",
+		},
+		{
+			name:    "update_multi_set",
+			input:   "UPDATE t SET a = 1 SET b = 2",
+			wantStr: "Sets:[SetAssignment{Target:PathExpr{Root:VarRef{Name:a} Steps:[]} Value:NumberLit{Val:1}} SetAssignment{Target:PathExpr{Root:VarRef{Name:b}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err != nil {
+				t.Fatalf("ParseStatement(%q) unexpected error: %v", tc.input, err)
+			}
+			us, ok := stmt.(*ast.UpdateStmt)
+			if !ok {
+				t.Fatalf("ParseStatement(%q) = %T, want *ast.UpdateStmt", tc.input, stmt)
+			}
+			if us.From {
+				t.Errorf("UPDATE form should have From=false, got true")
+			}
+			got := ast.NodeToString(stmt)
+			if !strings.Contains(got, tc.wantStr) {
+				t.Errorf("NodeToString = %q, want to contain %q", got, tc.wantStr)
+			}
+		})
+	}
+}
+
+// TestParser_DMLWrapperRejects covers inputs the ANTLR oracle REJECTS for
+// both the FROM-led and UPDATE multi-command forms. omni must reject them
+// too (a syntax error). Without these negative cases the dispatch could be
+// over-permissive.
+func TestParser_DMLWrapperRejects(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErrIn string
+	}{
+		// FROM-led: at least one dmlBaseCommand is required.
+		{
+			name:      "from_only",
+			input:     "FROM t",
+			wantErrIn: "expected SET or another DML command",
+		},
+		{
+			name:      "from_where_only",
+			input:     "FROM t WHERE x = 1",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// FROM-led: DELETE is not a dmlBaseCommand (analysis.md:375's
+		// "FROM..DELETE" claim is inaccurate — ANTLR rejects it).
+		{
+			name:      "from_delete",
+			input:     "FROM t DELETE",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// FROM-led: SELECT is not a dmlBaseCommand.
+		{
+			name:      "from_select",
+			input:     "FROM t SELECT a",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// FROM-led: WHERE must precede the commands; a trailing WHERE is
+		// rejected (the alt has no whereClause after the commands).
+		{
+			name:      "from_set_then_where",
+			input:     "FROM t SET a = 1 WHERE x = 1",
+			wantErrIn: "after statement",
+		},
+		// UPDATE: at least one dmlBaseCommand is required.
+		{
+			name:      "update_only",
+			input:     "UPDATE t",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// UPDATE: WHERE only follows the commands; a leading WHERE is rejected.
+		{
+			name:      "update_where_before_set",
+			input:     "UPDATE t WHERE x = 1 SET a = 1",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// UPDATE: bare WHERE with no command is rejected.
+		{
+			name:      "update_where_only",
+			input:     "UPDATE t WHERE x = 1",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// UPDATE: DELETE / SELECT are not dmlBaseCommands.
+		{
+			name:      "update_delete",
+			input:     "UPDATE t DELETE",
+			wantErrIn: "expected SET or another DML command",
+		},
+		{
+			name:      "update_select",
+			input:     "UPDATE t SELECT a",
+			wantErrIn: "expected SET or another DML command",
+		},
+		// REPLACE/UPSERT as a command does NOT take a VALUE keyword (the
+		// grammar is `REPLACE INTO sym asIdent? expr`); VALUE there is a
+		// syntax error. omni rejects it while parsing the replace value
+		// expression (the ANTLR oracle reports "extraneous input 'VALUE'");
+		// both are syntax rejections — the verdict, not the wording, is the
+		// contract.
+		{
+			name:      "from_replace_value_kw",
+			input:     "FROM t REPLACE INTO a VALUE 1",
+			wantErrIn: "unexpected token \"VALUE\" in expression",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			_, err := p.ParseStatement()
+			if err == nil {
+				t.Fatalf("ParseStatement(%q): expected error, got nil", tc.input)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrIn) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tc.wantErrIn)
+			}
+		})
+	}
+}

--- a/partiql/parser/parse.go
+++ b/partiql/parser/parse.go
@@ -141,6 +141,11 @@ func (p *Parser) parseRootStatement() (ast.StmtNode, error) {
 		return p.parseUpsertStmt()
 	case tokREMOVE:
 		return p.parseRemoveStmt()
+	case tokFROM:
+		// FROM-led DML: `FROM fromClause whereClause? dmlBaseCommand+
+		// returningClause?` (dml#DmlBaseWrapper 2nd alt). A leading FROM at
+		// statement position is always DML.
+		return p.parseFromLedDml()
 	case tokEXEC, tokEXECUTE:
 		p.advance() // consume EXEC/EXECUTE
 		return p.parseExecCommand()

--- a/partiql/parser/parser.go
+++ b/partiql/parser/parser.go
@@ -701,6 +701,12 @@ func (p *Parser) ParseStatement() (ast.StmtNode, error) {
 		stmt, err = p.parseUpsertStmt()
 	case tokREMOVE:
 		stmt, err = p.parseRemoveStmt()
+	case tokFROM:
+		// FROM-led DML: `FROM fromClause whereClause? dmlBaseCommand+
+		// returningClause?` (dml#DmlBaseWrapper 2nd alt). A leading FROM at
+		// statement position is always DML — SELECT begins with SELECT, and
+		// a bare expression cannot start with FROM.
+		stmt, err = p.parseFromLedDml()
 	case tokEXEC, tokEXECUTE:
 		p.advance() // consume EXEC/EXECUTE
 		stmt, err = p.parseExecCommand()


### PR DESCRIPTION
## The bug

Two DML forms that the legacy/generated ANTLR PartiQL parser **accepts** were unparseable in omni:

**B7 — FROM-led DML (P0).** The grammar's `dml#DmlBaseWrapper` 2nd alternative is `fromClause whereClause? dmlBaseCommand+ returningClause?` — e.g. `FROM t SET a=1`, `FROM t WHERE x=1 SET a=1`. omni had **no leading-`FROM` DML dispatch** (statement dispatch in `partiql/parser/parser.go` and `partiql/parser/parse.go`), so such input fell through to expression parsing and failed with `unexpected token FROM in expression`. `analysis.md:374` lists FROM-led DML as P0.

**B8 — UPDATE multi-command.** `partiql/parser/dml.go`'s UPDATE handling required a single `SET` and hard-rejected `REMOVE` (`"REMOVE inside UPDATE is not yet supported"`), so `UPDATE t REMOVE a.b`, `UPDATE t SET a=1 REMOVE b`, `UPDATE t INSERT INTO a VALUE 1` were rejected even though the grammar is `updateClause dmlBaseCommand+ whereClause? returningClause?` and ANTLR accepts all.

## Oracle evidence (antlr_fallback — differential)

Every accept/reject verdict below was confirmed **differentially against the executable generated ANTLR parser** at `/Users/h3n4l/OpenSource/parser/partiql` (`Script()` entry rule) via a throwaway `/tmp` Go module (since deleted; both repos left `git status` clean). The ANTLR grammar is the oracle for this node; truth1 = official PartiQL / AWS DynamoDB docs.

Findings folded into the fix:
- **Clause order differs between the two alts.** FROM alt: WHERE **precedes** the commands; a **trailing** WHERE is rejected (`FROM t SET a=1 WHERE x=1` → reject). UPDATE alt: WHERE **follows** the commands (`UPDATE t SET a=1 WHERE x=1` → accept; `UPDATE t WHERE x=1 SET a=1` → reject).
- **REPLACE/UPSERT as a command take a bare expr, not a `VALUE` keyword** (`REPLACE INTO a 1` accept; `REPLACE INTO a VALUE 1` reject). The existing `parseReplaceStmt`/`parseUpsertStmt` already match this.
- **`FROM..DELETE..` and `FROM/UPDATE .. SELECT` are rejected** by ANTLR (DELETE/SELECT are not `dmlBaseCommand`s). So `analysis.md:375`'s `FROM..DELETE..` claim is **inaccurate** — not added.
- At least one `dmlBaseCommand` is required: `FROM t`, `FROM t WHERE x=1`, `UPDATE t` all reject.

## The fix

- Added `case tokFROM:` → `parseFromLedDml()` to both statement-dispatch points (`ParseStatement` in parser.go, `parseRootStatement` in parse.go). A leading `FROM` at statement position is unambiguously DML.
- `parseFromLedDml`: `parseFromClause` (full `tableReference`, so joins / paths / paren / UNPIVOT sources all flow through) → optional WHERE → `dmlBaseCommand+` → optional RETURNING.
- Rewrote `parseUpdateStmt`'s SET-only loop and removed the REMOVE rejection; both alts now share a new `parseDmlBaseCommands` helper covering SET / INSERT / REPLACE / REMOVE / UPSERT, requiring ≥1 command.

### AST (out-of-scope, recorded)

`UpdateStmt` gains `From bool` (distinguishes the two surface forms) and `Commands []Node` (the non-SET commands — `*InsertStmt`/`*ReplaceStmt`/`*RemoveStmt`/`*UpsertStmt`; `nil` for plain `UPDATE…SET`, so the common case and its golden dumps are **byte-identical**). SET assignments stay in `Sets`. `outfuncs.go` dumps the new fields only when set. These two `partiql/ast/` files are write-disjoint from the other in-flight partiql fix PRs (lexer / ddl).

**Documented divergences (flagged, not bugs):**
1. SET vs non-SET command **interleave order is not retained** (`UPDATE t REMOVE a SET b=1` ≡ `UPDATE t SET b=1 REMOVE a`). Spec-correct for parsing — the oracle decides only accept/reject and no consumer executes these multi-command DMLs.
2. **Parenthesised UPDATE source** `UPDATE (t) SET …` is still rejected (ANTLR accepts it). This is a **pre-existing** limitation of `parseUpdateSource` (bare/quoted identifier only), unrelated to the command-loop fix — flagged and pinned with a known-gap test for a future source-parser node.

## Coverage

New file `partiql/parser/dml_extra_test.go`:
- **FROM-led accept (13):** set, where+set, multi-assignment, set+remove, remove, insert, replace/upsert (bare expr), returning ×2, comma-join, path source, alias, JOIN…ON, paren, UNPIVOT, multi-insert, set+insert+remove.
- **UPDATE accept (12):** set, remove, set+remove, insert, set+insert, replace/upsert, remove+set, set+where, remove+where, set+remove+where+returning, multi-set.
- **Rejects (11):** no-command (FROM/UPDATE), WHERE-without-command, WHERE wrong-side, FROM/UPDATE-then-DELETE/SELECT, trailing-WHERE, REPLACE-VALUE-keyword.
- EXPLAIN composition (via `Parse`) + the parenthesised-UPDATE-source known-gap.

`go build ./partiql/...`, `go test -race ./partiql/parser/ ./partiql/completion/ ./partiql/ast/`, and `go test ./partiql/...` all pass; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)