### PR TITLE
fix(partiql): select: dangling join keyword + wrapped join

### DIFF
--- a/partiql/parser/from.go
+++ b/partiql/parser/from.go
@@ -106,15 +106,53 @@ func (p *Parser) parseTableReference() (ast.TableExpr, error) {
 }
 
 // parseTablePrimary parses a non-join table reference: a base table
-// reference, UNPIVOT, or parenthesized table reference.
+// reference, UNPIVOT, or a parenthesized table reference.
+//
+// A leading '(' is grammatically ambiguous between two productions:
+//
+//	tableReference#TableRefBase  whose source is a parenthesized
+//	    value expression / subquery — e.g. (t1), (SELECT ...), ((t1)).
+//	    This reading DOES accept a trailing AS/AT/BY alias chain, so it
+//	    is what the bare-/aliased cases resolve to.
+//	tableReference#TableWrapped  — `( tableReference )` (PartiQLParser.g4
+//	    line 394), where the parenthesized content is a join, comma
+//	    cross-join, or inner-aliased table that the value-expression
+//	    grammar cannot consume up to the matching ')'. The parentheses
+//	    are purely structural (the inner table expression is returned
+//	    directly), and this reading does NOT accept a trailing (outer)
+//	    alias.
+//
+// The generated ANTLR parser resolves this with unbounded lookahead,
+// preferring TableRefBase whenever the value-expression reading reaches
+// the closing ')'. We reproduce that faithfully by trying the base
+// reference first and, only if it fails, rewinding and parsing the
+// TableWrapped form. Bug B6: an earlier version always routed '(' through
+// the base/value-expression path, so a wrapped join such as
+// "(t1 CROSS JOIN t2)" was rejected at the first join keyword.
 func (p *Parser) parseTablePrimary() (ast.TableExpr, error) {
-	// Parenthesized table reference: (tableReference) or (SELECT ...)
-	// followed by optional aliases.
 	if p.cur.Type == tokPAREN_LEFT {
-		// Use parseSelectExpr which handles (SELECT...) as SubLink.
-		// This means the expression-level parseParenExpr will be called,
-		// which properly handles both (expr) and (SELECT...).
-		return p.parseTableBaseReference()
+		// First attempt: '(' begins a value expression / subquery used as
+		// a base table reference (handles (expr), (SELECT...), and a
+		// trailing AS/AT/BY alias). parseTableBaseReference -> parseSelectExpr
+		// -> the expression-level parseParenExpr.
+		start := p.save()
+		base, err := p.parseTableBaseReference()
+		if err == nil {
+			return base, nil
+		}
+		// The value-expression reading failed (e.g. the content is a join
+		// or carries an inner alias). Rewind and try the wrapped
+		// table-reference form `( tableReference )`.
+		p.restore(start)
+		wrapped, werr := p.parseWrappedTableReference()
+		if werr != nil {
+			// Neither reading applies. Surface the wrapped-form error: at
+			// this point we know the content was not a plain value
+			// expression, so the table-reference-oriented diagnostic is the
+			// more relevant one.
+			return nil, werr
+		}
+		return wrapped, nil
 	}
 
 	// UNPIVOT.
@@ -124,6 +162,28 @@ func (p *Parser) parseTablePrimary() (ast.TableExpr, error) {
 
 	// Base table reference: source expression + optional aliases.
 	return p.parseTableBaseReference()
+}
+
+// parseWrappedTableReference parses the TableWrapped form
+// `( tableReference )` (PartiQLParser.g4 line 394). The parentheses are
+// purely structural: the inner table expression is returned directly with
+// no wrapper node and no outer alias (matching how parseJoinRhs unwraps the
+// JoinRhsTableJoined form). A trailing alias is deliberately left
+// unconsumed so the caller rejects it at the next-token / EOF check, which
+// is what the generated ANTLR grammar does ("(t1 CROSS JOIN t2) AS x" is a
+// syntax error).
+func (p *Parser) parseWrappedTableReference() (ast.TableExpr, error) {
+	if _, err := p.expect(tokPAREN_LEFT); err != nil {
+		return nil, err
+	}
+	inner, err := p.parseTableReference()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(tokPAREN_RIGHT); err != nil {
+		return nil, err
+	}
+	return inner, nil
 }
 
 // parseJoinRhs parses the right-hand side of a JOIN: either a
@@ -351,8 +411,20 @@ func (p *Parser) parseTableUnpivot() (*ast.UnpivotExpr, error) {
 }
 
 // tryParseJoinType attempts to parse a join type. Returns the JoinKind
-// and true if a join keyword sequence was found, or (Invalid, false)
-// if the current token does not start a join.
+// and true if a complete join keyword sequence (a modifier and/or CROSS
+// followed by JOIN, or a bare JOIN) was found, or (Invalid, false) if the
+// current token does not start a join.
+//
+// IMPORTANT: when a join *modifier* (LEFT/RIGHT/FULL/INNER/OUTER, with an
+// optional trailing OUTER, or CROSS) is present but is NOT followed by the
+// required JOIN keyword, this is NOT a join — and the consumed modifier
+// token(s) are rewound (save/restore) so they remain in the token stream.
+// The caller then breaks out of the join loop with the modifier still
+// pending, which makes a dangling modifier ("FROM t1 LEFT") fail at the
+// next-token / EOF check rather than being silently swallowed. Bug B5: an
+// earlier version returned (Invalid, false) here WITHOUT restoring, which
+// dropped the keyword and wrongly accepted dangling-modifier inputs that
+// the generated ANTLR grammar rejects.
 //
 // Grammar: joinType (lines 419-425):
 //
@@ -364,11 +436,15 @@ func (p *Parser) parseTableUnpivot() (*ast.UnpivotExpr, error) {
 //
 // Plus the CROSS JOIN form (line 390).
 func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
+	// Snapshot so a modifier not followed by JOIN can be fully rewound.
+	start := p.save()
+
 	switch p.cur.Type {
 	case tokCROSS:
 		p.advance() // consume CROSS
 		if p.cur.Type != tokJOIN {
 			// CROSS must be followed by JOIN.
+			p.restore(start)
 			return ast.JoinKindInvalid, false
 		}
 		p.advance() // consume JOIN
@@ -377,6 +453,7 @@ func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
 	case tokINNER:
 		p.advance() // consume INNER
 		if p.cur.Type != tokJOIN {
+			p.restore(start)
 			return ast.JoinKindInvalid, false
 		}
 		p.advance() // consume JOIN
@@ -386,6 +463,7 @@ func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
 		p.advance() // consume LEFT
 		p.match(tokOUTER)
 		if p.cur.Type != tokJOIN {
+			p.restore(start)
 			return ast.JoinKindInvalid, false
 		}
 		p.advance() // consume JOIN
@@ -395,6 +473,7 @@ func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
 		p.advance() // consume RIGHT
 		p.match(tokOUTER)
 		if p.cur.Type != tokJOIN {
+			p.restore(start)
 			return ast.JoinKindInvalid, false
 		}
 		p.advance() // consume JOIN
@@ -404,6 +483,7 @@ func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
 		p.advance() // consume FULL
 		p.match(tokOUTER)
 		if p.cur.Type != tokJOIN {
+			p.restore(start)
 			return ast.JoinKindInvalid, false
 		}
 		p.advance() // consume JOIN
@@ -412,6 +492,7 @@ func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
 	case tokOUTER:
 		p.advance() // consume OUTER
 		if p.cur.Type != tokJOIN {
+			p.restore(start)
 			return ast.JoinKindInvalid, false
 		}
 		p.advance() // consume JOIN

--- a/partiql/parser/from_join_test.go
+++ b/partiql/parser/from_join_test.go
@@ -1,0 +1,305 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/partiql/ast"
+)
+
+// TestParser_DanglingJoinKeyword covers bug B5: a join-type modifier
+// (LEFT/RIGHT/FULL/INNER/OUTER, with optional trailing OUTER, plus CROSS)
+// that is NOT followed by JOIN must be rejected, not silently dropped.
+//
+// Oracle: the generated ANTLR PartiQL parser (bytebase/parser/partiql)
+// REJECTS every one of these inputs ("no viable alternative" / "mismatched
+// input ... expecting JOIN" / "extraneous input"). Before the fix,
+// tryParseJoinType consumed the modifier token(s) and returned (Invalid,
+// false) without restoring the lexer position, so the keyword vanished and
+// the statement wrongly parsed (e.g. "FROM t1 LEFT" parsed as "FROM t1").
+//
+// We assert via ParseStatement (which requires EOF after the statement):
+// because the swallowed keyword now stays in the token stream, parsing
+// fails — either inside the FROM-clause join loop or at the trailing-token
+// (EOF) check. We only assert rejection (the oracle decides accept/reject);
+// the exact message is implementation-defined.
+func TestParser_DanglingJoinKeyword(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"left", "SELECT * FROM t1 LEFT"},
+		{"right", "SELECT * FROM t1 RIGHT"},
+		{"inner", "SELECT * FROM t1 INNER"},
+		{"outer", "SELECT * FROM t1 OUTER"},
+		{"full", "SELECT * FROM t1 FULL"},
+		{"cross", "SELECT * FROM t1 CROSS"},
+		{"left_outer", "SELECT * FROM t1 LEFT OUTER"},
+		{"right_outer", "SELECT * FROM t1 RIGHT OUTER"},
+		{"full_outer", "SELECT * FROM t1 FULL OUTER"},
+		// The modifier is followed by a *different* clause keyword, not
+		// JOIN: the keyword must not be swallowed into the preceding table
+		// reference (pre-fix this parsed as "FROM t1 WHERE a = 1").
+		{"left_then_where", "SELECT * FROM t1 LEFT WHERE a = 1"},
+		{"right_then_where", "SELECT * FROM t1 RIGHT WHERE a = 1"},
+		{"left_outer_then_where", "SELECT * FROM t1 LEFT OUTER WHERE a = 1"},
+		// Dangling modifier before ORDER BY (another trailing clause).
+		{"inner_then_order", "SELECT * FROM t1 INNER ORDER BY a"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err == nil {
+				t.Fatalf("expected rejection, but parsed OK: %s", ast.NodeToString(stmt))
+			}
+		})
+	}
+}
+
+// TestParser_WrappedTableReference covers bug B6: the parenthesized
+// table-reference form `( tableReference )` (grammar tableReference#
+// TableWrapped, PartiQLParser.g4:394) must be accepted when the wrapped
+// content is a join (or comma cross-join, or an inner-aliased table) that
+// the value-expression grammar cannot consume.
+//
+// Oracle: the generated ANTLR PartiQL parser ACCEPTS each input. Before the
+// fix, parseTablePrimary routed every leading '(' through the
+// value-expression paren path, which failed at the first join keyword
+// ("expected PAREN_RIGHT, got CROSS/INNER/...").
+//
+// The parentheses around a table reference are purely structural, so the
+// resulting AST is the inner table expression itself (no wrapper node) —
+// matching how parseJoinRhs already unwraps `( tableReference )`.
+func TestParser_WrappedTableReference(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "cross_join",
+			input: "SELECT * FROM (t1 CROSS JOIN t2)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}",
+		},
+		{
+			name:  "inner_join_on",
+			input: "SELECT * FROM (t1 INNER JOIN t2 ON a = b)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:INNER Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			name:  "bare_join_on",
+			input: "SELECT * FROM (t1 JOIN t2 ON a = b)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:INNER Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			name:  "left_join_on",
+			input: "SELECT * FROM (t1 LEFT JOIN t2 ON a = b)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:LEFT Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			name:  "left_outer_join_on",
+			input: "SELECT * FROM (t1 LEFT OUTER JOIN t2 ON a = b)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:LEFT Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			// Double-wrapped join: the outer parens wrap a wrapped join.
+			name:  "double_wrapped_join",
+			input: "SELECT * FROM ((t1 CROSS JOIN t2))",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}",
+		},
+		{
+			// Left-associative chain inside the parens.
+			name:  "three_way_cross_join",
+			input: "SELECT * FROM (t1 CROSS JOIN t2 CROSS JOIN t3)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}} Right:VarRef{Name:t3}}}",
+		},
+		{
+			// Comma cross-join inside the parens (grammar: COMMA rhs).
+			name:  "comma_cross_join",
+			input: "SELECT * FROM (t1, t2)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}",
+		},
+		{
+			// Wrapped join as the LEFT operand of an outer join.
+			name:  "wrapped_left_then_cross",
+			input: "SELECT * FROM (t1 CROSS JOIN t2) CROSS JOIN t3",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}} Right:VarRef{Name:t3}}}",
+		},
+		{
+			// Wrapped table reference with an inner alias `t1 AS a`. The
+			// value-expression grammar cannot consume "t1 AS a", so this is
+			// the TableWrapped reading.
+			name:  "wrapped_inner_alias",
+			input: "SELECT * FROM (t1 AS a)",
+			want:  "SelectStmt{Star:true From:AliasedSource{Source:VarRef{Name:t1} As:a}}",
+		},
+		{
+			// Nested: inner `(t1)` is a value-expr paren base reference,
+			// the outer parens wrap the cross join.
+			name:  "nested_paren_left_cross",
+			input: "SELECT * FROM ((t1) CROSS JOIN t2)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err != nil {
+				t.Fatalf("expected accept, got error: %v", err)
+			}
+			got := ast.NodeToString(stmt)
+			if got != tc.want {
+				t.Errorf("AST mismatch\ninput: %s\ngot:  %s\nwant: %s", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParser_WrappedTableReferencePreserved pins the cases the B6 fix must
+// NOT regress: a leading '(' whose content is a plain value expression or a
+// subquery is read as a base table reference (grammar tableReference#
+// TableRefBase whose source is `(expr)`), and that reading DOES accept a
+// trailing AS/AT/BY alias chain. Oracle: ANTLR accepts all of these.
+func TestParser_WrappedTableReferencePreserved(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "paren_single_table",
+			input: "SELECT * FROM (t1)",
+			want:  "SelectStmt{Star:true From:VarRef{Name:t1}}",
+		},
+		{
+			name:  "paren_single_table_alias",
+			input: "SELECT * FROM (t1) AS x",
+			want:  "SelectStmt{Star:true From:AliasedSource{Source:VarRef{Name:t1} As:x}}",
+		},
+		{
+			name:  "paren_single_table_bare_alias",
+			input: "SELECT * FROM (t1) t2",
+			want:  "SelectStmt{Star:true From:AliasedSource{Source:VarRef{Name:t1} As:t2}}",
+		},
+		{
+			name:  "double_paren_single_table",
+			input: "SELECT * FROM ((t1))",
+			want:  "SelectStmt{Star:true From:VarRef{Name:t1}}",
+		},
+		{
+			name:  "subquery_alias",
+			input: "SELECT * FROM (SELECT * FROM t1) AS s",
+			want:  "SelectStmt{Star:true From:AliasedSource{Source:SubLink{Stmt:SelectStmt{Star:true From:VarRef{Name:t1}}} As:s}}",
+		},
+		{
+			name:  "subquery_no_alias",
+			input: "SELECT * FROM (SELECT * FROM t1)",
+			want:  "SelectStmt{Star:true From:SubLink{Stmt:SelectStmt{Star:true From:VarRef{Name:t1}}}}",
+		},
+		{
+			// Wrapped join on the JOIN right-hand side (parseJoinRhs path).
+			// (A *subquery* with a trailing alias on the JOIN RHS, e.g.
+			// "... CROSS JOIN (SELECT ...) AS s", is a separate pre-existing
+			// parseJoinRhs divergence and is intentionally out of scope for
+			// this B5/B6 fix, which only touches tryParseJoinType and
+			// parseTablePrimary.)
+			name:  "join_rhs_wrapped_join",
+			input: "SELECT * FROM t3 CROSS JOIN (t1 CROSS JOIN t2)",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t3} Right:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err != nil {
+				t.Fatalf("expected accept, got error: %v", err)
+			}
+			got := ast.NodeToString(stmt)
+			if got != tc.want {
+				t.Errorf("AST mismatch\ninput: %s\ngot:  %s\nwant: %s", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParser_WrappedTableReferenceNoOuterAlias covers the negative half of
+// B6: the TableWrapped form `( tableReference )` does NOT accept a trailing
+// (outer) alias. Oracle: ANTLR REJECTS each of these ("mismatched input
+// 'AS'", "extraneous input 't3'"). The wrapped reading must therefore leave
+// the trailing alias token unconsumed so the statement fails at EOF.
+func TestParser_WrappedTableReferenceNoOuterAlias(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"join_as_alias", "SELECT * FROM (t1 CROSS JOIN t2) AS x"},
+		{"join_bare_alias", "SELECT * FROM (t1 CROSS JOIN t2) t3"},
+		{"inner_join_as_then_join", "SELECT * FROM (t1 INNER JOIN t2 ON a=b) AS j CROSS JOIN t3"},
+		{"inner_alias_then_outer_alias", "SELECT * FROM (t1 AS a) AS b"},
+		// Empty parens are never a valid table reference.
+		{"empty_parens", "SELECT * FROM ()"},
+		// UNPIVOT is a primary, not a postfix table operator: `t1 UNPIVOT t2`
+		// is not a valid wrapped tableReference.
+		{"wrapped_unpivot_postfix", "SELECT * FROM (t1 UNPIVOT t2)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err == nil {
+				t.Fatalf("expected rejection, but parsed OK: %s", ast.NodeToString(stmt))
+			}
+		})
+	}
+}
+
+// TestParser_ValidJoinsStillParse is a positive control: the fixes must not
+// regress ordinary (unwrapped) joins. Oracle: ANTLR accepts all.
+func TestParser_ValidJoinsStillParse(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "left_join",
+			input: "SELECT * FROM t1 LEFT JOIN t2 ON a = b",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:LEFT Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			name:  "left_outer_join",
+			input: "SELECT * FROM t1 LEFT OUTER JOIN t2 ON a = b",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:LEFT Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			name:  "cross_join",
+			input: "SELECT * FROM t1 CROSS JOIN t2",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}",
+		},
+		{
+			name:  "bare_join",
+			input: "SELECT * FROM t1 JOIN t2 ON a = b",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:INNER Left:VarRef{Name:t1} Right:VarRef{Name:t2} On:BinaryExpr{Op:= Left:VarRef{Name:a} Right:VarRef{Name:b}}}}",
+		},
+		{
+			name:  "comma_cross_join_unwrapped",
+			input: "SELECT * FROM t1, t2",
+			want:  "SelectStmt{Star:true From:JoinExpr{Kind:CROSS Left:VarRef{Name:t1} Right:VarRef{Name:t2}}}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParser(tc.input)
+			stmt, err := p.ParseStatement()
+			if err != nil {
+				t.Fatalf("expected accept, got error: %v", err)
+			}
+			got := ast.NodeToString(stmt)
+			if got != tc.want {
+				t.Errorf("AST mismatch\ninput: %s\ngot:  %s\nwant: %s", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two FROM-clause parser bugs in `partiql/parser/from.go`, both verified differentially against the executable generated ANTLR PartiQL parser (`bytebase/parser/partiql`, the `antlr_fallback` oracle).

### B5 — dangling join keyword wrongly accepted

`tryParseJoinType` consumed a join *modifier* (`LEFT`/`RIGHT`/`FULL`/`INNER`/`OUTER`, optional trailing `OUTER`, or `CROSS`) and, when the required `JOIN` did not follow, returned `(Invalid, false)` **without restoring** the lexer position. The modifier token was silently dropped, so dangling-modifier inputs wrongly parsed:

| input | before (omni) | ANTLR oracle |
|---|---|---|
| `SELECT * FROM t1 LEFT` | ACCEPT → `From:VarRef{t1}` (LEFT vanished) | **REJECT** |
| `SELECT * FROM t1 LEFT WHERE a = 1` | ACCEPT → `From:t1 Where:a=1` (LEFT vanished) | **REJECT** |
| `RIGHT`/`INNER`/`OUTER`/`FULL`/`CROSS`/`LEFT OUTER`/… | ACCEPT (dropped) | **REJECT** |

**Fix:** snapshot the parse position with the existing `save()` on entry and `restore()` on every "modifier present but `JOIN` absent" path, so the dangling modifier stays in the token stream and is rejected at the next-token / EOF check.

### B6 — wrapped table reference wrongly rejected

`parseTablePrimary` routed every leading `(` through the value-expression paren path, so the grammar's `tableReference#TableWrapped` form (`( tableReference )`, `PartiQLParser.g4:394`) failed at the first join keyword:

| input | before (omni) | ANTLR oracle |
|---|---|---|
| `SELECT * FROM (t1 CROSS JOIN t2)` | REJECT `expected PAREN_RIGHT, got "CROSS"` | **ACCEPT** |
| `SELECT * FROM (t1 INNER JOIN t2 ON a=b)` | REJECT `... got "INNER"` | **ACCEPT** |
| `(t1 JOIN t2 ON a=b)`, `(t1 LEFT JOIN …)`, `((t1 CROSS JOIN t2))`, `(t1, t2)`, `(t1 AS a)` | REJECT | **ACCEPT** |

**Fix:** reproduce ANTLR's unbounded-lookahead prediction faithfully — try the value-expression/base reading first (preserving `(t1)`, `(SELECT …)`, and a trailing `AS/AT/BY` alias), and only on failure rewind and parse the wrapped form via a new `parseWrappedTableReference` helper. The parens are structural, so the inner table expression is returned directly (mirroring `parseJoinRhs`) with **no outer alias** — so `(t1 CROSS JOIN t2) AS x` correctly remains a syntax error (oracle-confirmed REJECT), while `(t1) AS x` (a value-expr base reference) keeps its alias.

## Oracle evidence

Differential accept/reject parity vs the generated ANTLR parser on **47 cases**, error-classified (a syntax rejection is the only "reject"):
- B5 dangling-modifier rejects (incl. modifier-then-`WHERE`/`ORDER BY`).
- B6 wrapped accepts: cross/inner/left/left-outer/bare joins, comma cross-join, 3-way comma, double/triple nesting, wrapped-as-join-operand.
- Negatives (oracle REJECT, must stay rejected): `(… JOIN …) AS x` / bare alias, `(t1 AS a) AS b`, `()`, `(t1 UNPIVOT t2)`.
- Preserved (oracle ACCEPT, must stay accepted): `(t1)`, `(t1) AS x [AT y]`, `((t1))`, `(SELECT … ) [AS s]`, JOIN-RHS wrapped join, plain unwrapped joins, and graph-`MATCH`-in-paren.

Result: **omni == ANTLR on all 47 cases.** No divergences from the oracle in the changed domain.

## Coverage (new file `partiql/parser/from_join_test.go`)

- `TestParser_DanglingJoinKeyword` — B5 negatives (13 cases).
- `TestParser_WrappedTableReference` — B6 positives with full AST-shape assertions (11 cases).
- `TestParser_WrappedTableReferencePreserved` — non-regression accepts (7 cases).
- `TestParser_WrappedTableReferenceNoOuterAlias` — B6 negatives, the no-outer-alias rule (6 cases).
- `TestParser_ValidJoinsStillParse` — unwrapped-join positive control (5 cases).

## Verification

- `go build ./partiql/...` — OK
- `go test -race ./partiql/parser/ ./partiql/completion/ ./partiql/ast/` — PASS
- `go test ./partiql/...` — PASS
- `gofmt -l` clean, `go vet ./partiql/parser/` clean

## Scope

Touches only `partiql/parser/from.go` and the new `partiql/parser/from_join_test.go`. `parser_test.go` untouched.

## Out of scope (noted, not fixed here)

A trailing alias on a **subquery** placed on a JOIN right-hand side — `… CROSS JOIN (SELECT …) AS s` — is a separate pre-existing `parseJoinRhs` divergence (ANTLR accepts; omni rejects). It is in a different code path and not part of B5/B6; left for a dedicated fix to keep these parallel fix PRs write-disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)