### PR TITLE
feat(trino/parser): DML — INSERT/DELETE/UPDATE/MERGE/TRUNCATE (v2 node trino/parser-dml)

### DIFF
--- a/trino/parser/diagnose_test.go
+++ b/trino/parser/diagnose_test.go
@@ -9,10 +9,11 @@ import (
 // Parse and surfaces ParseErrors as Diagnostics. While a statement body is still
 // stubbed (no DAG node has implemented it), even valid SQL of that form yields a
 // "not yet supported" diagnostic — those vanish as later nodes implement real
-// parsing. INSERT (parser-dml's job) is still stubbed; SELECT is now implemented
-// by parser-select, so this test uses a still-stubbed form.
+// parsing. DML (INSERT/DELETE/UPDATE/MERGE/TRUNCATE) is now implemented by
+// parser-dml, so this test uses a DDL form (ALTER TABLE) that remains a
+// foundation stub until the parser-ddl node lands.
 func TestDiagnose_StubbedStatementProducesDiagnostic(t *testing.T) {
-	diags := Diagnose("INSERT INTO t VALUES (1)")
+	diags := Diagnose("ALTER TABLE t ADD COLUMN c integer")
 	if len(diags) != 1 {
 		t.Fatalf("got %d diagnostics, want 1: %+v", len(diags), diags)
 	}
@@ -50,12 +51,13 @@ func TestDiagnose_EmptyInput(t *testing.T) {
 }
 
 // TestDiagnose_MultipleStatements verifies diagnostics are collected across all
-// segments. A valid SELECT (now implemented by parser-select) yields none, while
-// the two still-stubbed DML statements (INSERT, DELETE) each yield one.
+// segments. A valid SELECT and a valid INSERT (both now implemented, by
+// parser-select and parser-dml) yield none, while the two still-stubbed DDL
+// statements (ALTER, COMMENT — parser-ddl's job) each yield one.
 func TestDiagnose_MultipleStatements(t *testing.T) {
-	diags := Diagnose("SELECT 1; INSERT INTO t VALUES (1); DELETE FROM t")
+	diags := Diagnose("SELECT 1; INSERT INTO t VALUES (1); ALTER TABLE t ADD COLUMN c integer; COMMENT ON TABLE t IS 'x'")
 	if len(diags) != 2 {
-		t.Fatalf("got %d diagnostics, want 2 (INSERT + DELETE stubs; SELECT now parses): %+v", len(diags), diags)
+		t.Fatalf("got %d diagnostics, want 2 (ALTER + COMMENT stubs; SELECT and INSERT now parse): %+v", len(diags), diags)
 	}
 }
 

--- a/trino/parser/dml_structure_test.go
+++ b/trino/parser/dml_structure_test.go
@@ -1,0 +1,380 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-dml node's correctness gate for the structural layer:
+// it asserts the AST shape produced for INSERT / DELETE / UPDATE / MERGE /
+// TRUNCATE. The authoritative accept/reject differential against the live
+// Trino 481 oracle lives in oracle_dml_test.go.
+
+// dmlParseOne parses exactly one statement via the public Parse entry point and
+// returns it, failing the test if parsing errored or did not yield exactly one
+// statement.
+func dmlParseOne(t *testing.T, sql string) interface{} {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q): unexpected errors: %v", sql, errs)
+	}
+	if file == nil || len(file.Stmts) != 1 {
+		got := 0
+		if file != nil {
+			got = len(file.Stmts)
+		}
+		t.Fatalf("Parse(%q): got %d statements, want 1", sql, got)
+	}
+	return file.Stmts[0]
+}
+
+// dmlParseErr asserts that Parse reports at least one error for sql (a
+// rejected-by-the-grammar input). The oracle differential confirms these
+// rejections match Trino 481.
+func dmlParseErr(t *testing.T, sql string) {
+	t.Helper()
+	_, errs := Parse(sql)
+	if len(errs) == 0 {
+		t.Errorf("Parse(%q): want at least one error, got none", sql)
+	}
+}
+
+func TestInsert_Structure(t *testing.T) {
+	t.Run("values", func(t *testing.T) {
+		stmt, ok := dmlParseOne(t, "INSERT INTO cities VALUES (1, 'San Francisco')").(*InsertStmt)
+		if !ok {
+			t.Fatalf("got %T, want *InsertStmt", stmt)
+		}
+		if got := stmt.Target.Normalize(); got != "cities" {
+			t.Errorf("target = %q, want cities", got)
+		}
+		if stmt.Columns != nil {
+			t.Errorf("columns = %v, want nil", stmt.Columns)
+		}
+		if stmt.Source == nil {
+			t.Fatalf("source = nil, want a query")
+		}
+		if _, ok := stmt.Source.Body.(*ValuesQuery); !ok {
+			t.Errorf("source body = %T, want *ValuesQuery", stmt.Source.Body)
+		}
+	})
+
+	t.Run("explicit_columns_select", func(t *testing.T) {
+		stmt := dmlParseOne(t, "INSERT INTO nation (nationkey, name, regionkey) SELECT 1, 'a', 2").(*InsertStmt)
+		if len(stmt.Columns) != 3 {
+			t.Fatalf("got %d columns, want 3", len(stmt.Columns))
+		}
+		want := []string{"nationkey", "name", "regionkey"}
+		for i, c := range stmt.Columns {
+			if c.Normalize() != want[i] {
+				t.Errorf("column[%d] = %q, want %q", i, c.Normalize(), want[i])
+			}
+		}
+		if _, ok := stmt.Source.Body.(*QuerySpec); !ok {
+			t.Errorf("source body = %T, want *QuerySpec", stmt.Source.Body)
+		}
+	})
+
+	t.Run("select_star", func(t *testing.T) {
+		stmt := dmlParseOne(t, "INSERT INTO orders SELECT * FROM new_orders").(*InsertStmt)
+		if stmt.Columns != nil {
+			t.Errorf("columns = %v, want nil", stmt.Columns)
+		}
+	})
+
+	t.Run("qualified_target_with_quoted_part", func(t *testing.T) {
+		stmt := dmlParseOne(t, `INSERT INTO a."b/c".d SELECT * FROM t`).(*InsertStmt)
+		if len(stmt.Target.Parts) != 3 {
+			t.Fatalf("got %d target parts, want 3", len(stmt.Target.Parts))
+		}
+		if stmt.Target.Parts[1].Value != "b/c" {
+			t.Errorf("middle part = %q, want b/c", stmt.Target.Parts[1].Value)
+		}
+	})
+
+	t.Run("parenthesized_source_query", func(t *testing.T) {
+		// `( SELECT … )` is a parenthesized source query, NOT a column list.
+		stmt := dmlParseOne(t, "INSERT INTO t (SELECT 1)").(*InsertStmt)
+		if stmt.Columns != nil {
+			t.Errorf("columns = %v, want nil (the parens are a subquery)", stmt.Columns)
+		}
+		if _, ok := stmt.Source.Body.(*ParenQuery); !ok {
+			t.Errorf("source body = %T, want *ParenQuery", stmt.Source.Body)
+		}
+	})
+
+	t.Run("table_query_source", func(t *testing.T) {
+		stmt := dmlParseOne(t, "INSERT INTO t TABLE other").(*InsertStmt)
+		if _, ok := stmt.Source.Body.(*TableQuery); !ok {
+			t.Errorf("source body = %T, want *TableQuery", stmt.Source.Body)
+		}
+	})
+
+	t.Run("with_cte_source", func(t *testing.T) {
+		stmt := dmlParseOne(t, "INSERT INTO t WITH cte AS (SELECT 1) SELECT * FROM cte").(*InsertStmt)
+		if stmt.Source.With == nil {
+			t.Errorf("source.With = nil, want a CTE clause")
+		}
+	})
+
+	// negatives (oracle confirms these are SYNTAX_ERROR in Trino 481)
+	t.Run("missing_source", func(t *testing.T) { dmlParseErr(t, "INSERT INTO t") })
+	t.Run("columns_no_source", func(t *testing.T) { dmlParseErr(t, "INSERT INTO t (a, b)") })
+	t.Run("four_part_target", func(t *testing.T) { dmlParseErr(t, "INSERT INTO a.b.c.d VALUES (1)") })
+	t.Run("missing_into", func(t *testing.T) { dmlParseErr(t, "INSERT t VALUES (1)") })
+}
+
+func TestTruncate_Structure(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		stmt, ok := dmlParseOne(t, "TRUNCATE TABLE orders").(*TruncateStmt)
+		if !ok {
+			t.Fatalf("got %T, want *TruncateStmt", stmt)
+		}
+		if got := stmt.Target.Normalize(); got != "orders" {
+			t.Errorf("target = %q, want orders", got)
+		}
+	})
+
+	t.Run("three_part", func(t *testing.T) {
+		stmt := dmlParseOne(t, "TRUNCATE TABLE a.b.c").(*TruncateStmt)
+		if len(stmt.Target.Parts) != 3 {
+			t.Errorf("got %d parts, want 3", len(stmt.Target.Parts))
+		}
+	})
+
+	// negatives
+	t.Run("missing_table_keyword", func(t *testing.T) { dmlParseErr(t, "TRUNCATE orders") })
+	t.Run("four_part_target", func(t *testing.T) { dmlParseErr(t, "TRUNCATE TABLE a.b.c.d") })
+	t.Run("trailing_token", func(t *testing.T) { dmlParseErr(t, "TRUNCATE TABLE orders extra") })
+}
+
+func TestDelete_Structure(t *testing.T) {
+	t.Run("no_where", func(t *testing.T) {
+		stmt, ok := dmlParseOne(t, "DELETE FROM orders").(*DeleteStmt)
+		if !ok {
+			t.Fatalf("got %T, want *DeleteStmt", stmt)
+		}
+		if got := stmt.Target.Normalize(); got != "orders" {
+			t.Errorf("target = %q, want orders", got)
+		}
+		if stmt.Where != nil {
+			t.Errorf("where = %v, want nil", stmt.Where)
+		}
+	})
+
+	t.Run("with_where", func(t *testing.T) {
+		stmt := dmlParseOne(t, "DELETE FROM lineitem WHERE shipmode = 'AIR'").(*DeleteStmt)
+		if stmt.Where == nil {
+			t.Errorf("where = nil, want a predicate")
+		}
+	})
+
+	t.Run("where_subquery", func(t *testing.T) {
+		stmt := dmlParseOne(t, "DELETE FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE x = 1)").(*DeleteStmt)
+		if stmt.Where == nil {
+			t.Errorf("where = nil, want an IN-subquery predicate")
+		}
+	})
+
+	t.Run("quoted_target", func(t *testing.T) {
+		stmt := dmlParseOne(t, `DELETE FROM "awesome table"`).(*DeleteStmt)
+		if stmt.Target.Parts[0].Value != "awesome table" {
+			t.Errorf("target = %q, want \"awesome table\"", stmt.Target.Parts[0].Value)
+		}
+	})
+
+	// negatives
+	t.Run("missing_from", func(t *testing.T) { dmlParseErr(t, "DELETE orders") })
+	t.Run("dangling_where", func(t *testing.T) { dmlParseErr(t, "DELETE FROM orders WHERE") })
+	t.Run("four_part_target", func(t *testing.T) { dmlParseErr(t, "DELETE FROM a.b.c.d") })
+	t.Run("trailing_token", func(t *testing.T) { dmlParseErr(t, "DELETE FROM orders garbage") })
+}
+
+func TestUpdate_Structure(t *testing.T) {
+	t.Run("single_assignment_with_where", func(t *testing.T) {
+		stmt, ok := dmlParseOne(t, "UPDATE purchases SET status = 'OVERDUE' WHERE ship_date IS NULL").(*UpdateStmt)
+		if !ok {
+			t.Fatalf("got %T, want *UpdateStmt", stmt)
+		}
+		if got := stmt.Target.Normalize(); got != "purchases" {
+			t.Errorf("target = %q, want purchases", got)
+		}
+		if len(stmt.Assignments) != 1 {
+			t.Fatalf("got %d assignments, want 1", len(stmt.Assignments))
+		}
+		if stmt.Assignments[0].Column.Normalize() != "status" {
+			t.Errorf("assignment column = %q, want status", stmt.Assignments[0].Column.Normalize())
+		}
+		if stmt.Where == nil {
+			t.Errorf("where = nil, want a predicate")
+		}
+	})
+
+	t.Run("multi_assignment_no_where", func(t *testing.T) {
+		stmt := dmlParseOne(t, "UPDATE customers SET account_manager = 'John Henry', assign_date = now()").(*UpdateStmt)
+		if len(stmt.Assignments) != 2 {
+			t.Fatalf("got %d assignments, want 2", len(stmt.Assignments))
+		}
+		if stmt.Where != nil {
+			t.Errorf("where = %v, want nil", stmt.Where)
+		}
+	})
+
+	t.Run("subquery_value", func(t *testing.T) {
+		stmt := dmlParseOne(t, "UPDATE new_hires SET manager = (SELECT e.name FROM employees e WHERE e.employee_id = new_hires.manager_id)").(*UpdateStmt)
+		if len(stmt.Assignments) != 1 {
+			t.Fatalf("got %d assignments, want 1", len(stmt.Assignments))
+		}
+		if stmt.Assignments[0].Value == nil {
+			t.Errorf("assignment value = nil, want a scalar subquery")
+		}
+	})
+
+	t.Run("quoted_target_column", func(t *testing.T) {
+		stmt := dmlParseOne(t, `UPDATE t SET "col one" = a + b * 2, x = CASE WHEN y THEN 1 ELSE 2 END`).(*UpdateStmt)
+		if stmt.Assignments[0].Column.Value != "col one" {
+			t.Errorf("first column = %q, want \"col one\"", stmt.Assignments[0].Column.Value)
+		}
+	})
+
+	// negatives
+	t.Run("missing_set", func(t *testing.T) { dmlParseErr(t, "UPDATE t a = 1") })
+	t.Run("dangling_set", func(t *testing.T) { dmlParseErr(t, "UPDATE t SET") })
+	t.Run("row_assignment", func(t *testing.T) { dmlParseErr(t, "UPDATE t SET (a, b) = (1, 2)") })
+	t.Run("four_part_target", func(t *testing.T) { dmlParseErr(t, "UPDATE a.b.c.d SET x = 1") })
+	t.Run("trailing_token", func(t *testing.T) { dmlParseErr(t, "UPDATE t SET a = 1 garbage") })
+}
+
+func TestMerge_Structure(t *testing.T) {
+	t.Run("matched_delete", func(t *testing.T) {
+		stmt, ok := dmlParseOne(t, "MERGE INTO accounts t USING monthly s ON t.customer = s.customer WHEN MATCHED THEN DELETE").(*MergeStmt)
+		if !ok {
+			t.Fatalf("got %T, want *MergeStmt", stmt)
+		}
+		if got := stmt.Target.Normalize(); got != "accounts" {
+			t.Errorf("target = %q, want accounts", got)
+		}
+		if stmt.Alias == nil || stmt.Alias.Normalize() != "t" {
+			t.Errorf("alias = %v, want t", stmt.Alias)
+		}
+		if stmt.Source == nil {
+			t.Fatalf("source = nil")
+		}
+		if stmt.On == nil {
+			t.Fatalf("on = nil")
+		}
+		if len(stmt.Whens) != 1 {
+			t.Fatalf("got %d WHEN clauses, want 1", len(stmt.Whens))
+		}
+		if stmt.Whens[0].Kind != MergeDelete {
+			t.Errorf("clause kind = %v, want MergeDelete", stmt.Whens[0].Kind)
+		}
+	})
+
+	t.Run("as_alias", func(t *testing.T) {
+		stmt := dmlParseOne(t, "MERGE INTO accounts AS t USING src s ON t.c = s.c WHEN MATCHED THEN DELETE").(*MergeStmt)
+		if stmt.Alias == nil || stmt.Alias.Normalize() != "t" {
+			t.Errorf("alias = %v, want t", stmt.Alias)
+		}
+	})
+
+	t.Run("no_alias", func(t *testing.T) {
+		stmt := dmlParseOne(t, "MERGE INTO accounts USING src s ON accounts.c = s.c WHEN MATCHED THEN DELETE").(*MergeStmt)
+		if stmt.Alias != nil {
+			t.Errorf("alias = %v, want nil", stmt.Alias)
+		}
+	})
+
+	t.Run("update_insert", func(t *testing.T) {
+		stmt := dmlParseOne(t, "MERGE INTO accounts t USING src s ON (t.customer = s.customer) "+
+			"WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases "+
+			"WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES (s.customer, s.purchases, s.address)").(*MergeStmt)
+		if len(stmt.Whens) != 2 {
+			t.Fatalf("got %d WHEN clauses, want 2", len(stmt.Whens))
+		}
+		upd := stmt.Whens[0]
+		if upd.Kind != MergeUpdate {
+			t.Errorf("clause[0] kind = %v, want MergeUpdate", upd.Kind)
+		}
+		if len(upd.Assignments) != 1 {
+			t.Errorf("update assignments = %d, want 1", len(upd.Assignments))
+		}
+		ins := stmt.Whens[1]
+		if ins.Kind != MergeInsert {
+			t.Errorf("clause[1] kind = %v, want MergeInsert", ins.Kind)
+		}
+		if len(ins.Columns) != 3 {
+			t.Errorf("insert columns = %d, want 3", len(ins.Columns))
+		}
+		if len(ins.Values) != 3 {
+			t.Errorf("insert values = %d, want 3", len(ins.Values))
+		}
+	})
+
+	t.Run("conditions_and_multi_assignment", func(t *testing.T) {
+		stmt := dmlParseOne(t, "MERGE INTO accounts t USING src s ON (t.customer = s.customer) "+
+			"WHEN MATCHED AND s.address = 'Centreville' THEN DELETE "+
+			"WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address "+
+			"WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES (s.customer, s.purchases, s.address)").(*MergeStmt)
+		if len(stmt.Whens) != 3 {
+			t.Fatalf("got %d WHEN clauses, want 3", len(stmt.Whens))
+		}
+		if stmt.Whens[0].Condition == nil {
+			t.Errorf("clause[0] (matched delete) condition = nil, want AND guard")
+		}
+		if stmt.Whens[0].Kind != MergeDelete {
+			t.Errorf("clause[0] kind = %v, want MergeDelete", stmt.Whens[0].Kind)
+		}
+		if len(stmt.Whens[1].Assignments) != 2 {
+			t.Errorf("clause[1] assignments = %d, want 2", len(stmt.Whens[1].Assignments))
+		}
+	})
+
+	t.Run("insert_no_column_list", func(t *testing.T) {
+		stmt := dmlParseOne(t, "MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN INSERT VALUES (s.c, s.p)").(*MergeStmt)
+		ins := stmt.Whens[0]
+		if ins.Columns != nil {
+			t.Errorf("insert columns = %v, want nil", ins.Columns)
+		}
+		if len(ins.Values) != 2 {
+			t.Errorf("insert values = %d, want 2", len(ins.Values))
+		}
+	})
+
+	t.Run("subquery_source", func(t *testing.T) {
+		stmt := dmlParseOne(t, "MERGE INTO acc t USING (SELECT * FROM src) s ON t.c = s.c WHEN MATCHED THEN DELETE").(*MergeStmt)
+		if stmt.Source == nil {
+			t.Errorf("source = nil, want a subquery relation")
+		}
+	})
+
+	t.Run("legacy_corpus_full", func(t *testing.T) {
+		// The full legacy examples/merge.sql case.
+		stmt := dmlParseOne(t, "MERGE INTO inventory AS i USING changes AS c ON i.part = c.part "+
+			"WHEN MATCHED AND c.action = 'mod' THEN UPDATE SET qty = qty + c.qty, ts = CURRENT_TIMESTAMP "+
+			"WHEN MATCHED AND c.action = 'del' THEN DELETE "+
+			"WHEN NOT MATCHED AND c.action = 'new' THEN INSERT (part, qty) VALUES (c.part, c.qty)").(*MergeStmt)
+		if len(stmt.Whens) != 3 {
+			t.Fatalf("got %d WHEN clauses, want 3", len(stmt.Whens))
+		}
+	})
+
+	// negatives
+	t.Run("no_when", func(t *testing.T) { dmlParseErr(t, "MERGE INTO accounts t USING src s ON t.c = s.c") })
+	t.Run("update_set_parenthesized", func(t *testing.T) {
+		dmlParseErr(t, "MERGE INTO accounts t USING src s ON t.c = s.c WHEN MATCHED THEN UPDATE SET (p = s.p)")
+	})
+	t.Run("insert_empty_values", func(t *testing.T) {
+		dmlParseErr(t, "MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN INSERT VALUES ()")
+	})
+	t.Run("four_part_target", func(t *testing.T) {
+		dmlParseErr(t, "MERGE INTO a.b.c.d t USING s ON t.c = s.c WHEN MATCHED THEN DELETE")
+	})
+	t.Run("not_matched_action_must_be_insert", func(t *testing.T) {
+		// A WHEN NOT MATCHED clause's only legal action is INSERT; DELETE/UPDATE/
+		// any other token before VALUES must NOT be silently accepted as INSERT.
+		dmlParseErr(t, "MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN DELETE VALUES (1)")
+		dmlParseErr(t, "MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN UPDATE VALUES (1)")
+		dmlParseErr(t, "MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN foo VALUES (1)")
+	})
+}

--- a/trino/parser/insert.go
+++ b/trino/parser/insert.go
@@ -1,0 +1,200 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-dml DAG node (with update_delete.go and
+// merge.go): it implements Trino's INSERT and TRUNCATE data-manipulation
+// statements as hand-written recursive-descent parsers over the token stream.
+//
+// The statement structs live here in package parser (matching the Trino
+// convention for parser-built node types — Expr in expr.go, DataType in
+// datatypes.go, the SELECT layer in select.go). They satisfy ast.Node so
+// parseStmt can return them in the File statement list; like select.go's
+// QueryStmt they carry the placeholder tag ast.T_Invalid because the ast
+// node-tag set is closed to the ast-core node (File / Identifier /
+// QualifiedName) and is extended only by the utility/dcl-tcl statement nodes —
+// adding DML tags would collide with the concurrently-developed DDL node that
+// also extends trino/ast/nodetags.go. Downstream consumers (analysis,
+// completion) reach the concrete statement type by a Go type switch, not by
+// the tag, exactly as they do for QueryStmt.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : ...
+//	    | INSERT_ INTO_ qualifiedName columnAliases? rootQuery # insertInto
+//	    | TRUNCATE_ TABLE_ qualifiedName                       # truncateTable
+//	    ;
+//	rootQuery   : withFunction? query ;
+//	columnAliases : LPAREN_ identifier (COMMA_ identifier)* RPAREN_ ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar. Oracle-confirmed facts (Trino 481) baked in:
+//
+//	D-INS1 (INSERT requires a source query). `INSERT INTO t` and
+//	   `INSERT INTO t (a, b)` are SYNTAX_ERRORs: the rootQuery is mandatory.
+//	   The query may be SELECT / VALUES / TABLE / WITH … / a parenthesized
+//	   query — exactly the queryStmt entry the SELECT node already parses.
+//	D-INS2 (target is at most catalog.schema.table). `INSERT INTO a.b.c.d …`
+//	   is a SYNTAX_ERROR; the target qualifiedName is bounded to 3 parts.
+//	D-TR1  (TRUNCATE requires the TABLE keyword). `TRUNCATE orders` is a
+//	   SYNTAX_ERROR; only `TRUNCATE TABLE qualifiedName` is accepted, and the
+//	   target is likewise bounded to 3 parts.
+//
+// FLAGGED divergence (ledger #5, "DML branch @branch"): Trino 481 accepts an
+// optional `@ branch_name` after the target table in INSERT/DELETE/UPDATE/MERGE
+// (e.g. `INSERT INTO cities @ audit VALUES (1, 'x')`). omni REJECTS it because
+// the merged lexer node emits no token for '@' (it records an "unrecognized
+// character" lex error), so the form cannot reach this parser intact. Adding
+// '@' to the token model is a lexer-node concern outside this node's writes
+// scope; until that lands, `@branch` stays a flagged, omni-rejects/Trino-accepts
+// divergence and is excluded from this node's differential corpus. See the
+// migration divergence ledger.
+
+// ---------------------------------------------------------------------------
+// INSERT
+// ---------------------------------------------------------------------------
+
+// InsertStmt is an `INSERT INTO qualifiedName [(col, …)] rootQuery` statement
+// (the insertInto alternative). Target is the destination table (1-3 parts).
+// Columns is the optional explicit column list (nil when absent). Source is the
+// query supplying the rows — a SELECT, VALUES, TABLE, or WITH query (never nil;
+// the source is mandatory, D-INS1).
+type InsertStmt struct {
+	Target  *ast.QualifiedName
+	Columns []*ast.Identifier // explicit column list, nil when absent
+	Source  *Query
+	Loc     ast.Loc
+}
+
+// Tag implements ast.Node. See the file header for why DML statements use the
+// placeholder T_Invalid rather than a dedicated tag.
+func (n *InsertStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+
+// Span returns the source byte range.
+func (n *InsertStmt) Span() ast.Loc { return n.Loc }
+
+// ---------------------------------------------------------------------------
+// TRUNCATE
+// ---------------------------------------------------------------------------
+
+// TruncateStmt is a `TRUNCATE TABLE qualifiedName` statement (the truncateTable
+// alternative). Target is the table to truncate (1-3 parts). Trino's TRUNCATE
+// has no column / partition / options clause — it is exactly these three
+// keywords plus a name.
+type TruncateStmt struct {
+	Target *ast.QualifiedName
+	Loc    ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *TruncateStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+
+// Span returns the source byte range.
+func (n *TruncateStmt) Span() ast.Loc { return n.Loc }
+
+// Compile-time assertions that the statement types satisfy ast.Node.
+var (
+	_ ast.Node = (*InsertStmt)(nil)
+	_ ast.Node = (*TruncateStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+// parseInsertStmt parses `INSERT INTO qualifiedName [(col, …)] rootQuery`. On
+// entry cur is the INSERT keyword (not yet consumed).
+//
+// The optional `( identifier, … )` column list is disambiguated from a
+// parenthesized source query (`INSERT INTO t (SELECT …)`): a '(' begins the
+// column list only when it is followed by an identifier and then a ',' or ')'
+// (i.e. `(a)` or `(a, b)`). A '(' followed by SELECT/WITH/TABLE/VALUES — or by
+// an identifier that is NOT immediately closed/continued, which only a query
+// can be — is the parenthesized source query, parsed by parseQuery.
+func (p *Parser) parseInsertStmt() (ast.Node, error) {
+	insertTok := p.advance() // consume INSERT
+	if _, err := p.expect(kwINTO); err != nil {
+		return nil, err
+	}
+
+	// D-INS2: target is at most catalog.schema.table.
+	target, err := p.parseBoundedQualifiedName(3, "insert target")
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &InsertStmt{Target: target, Loc: ast.Loc{Start: insertTok.Loc.Start, End: target.Loc.End}}
+
+	// Optional explicit column list. Only treat a leading '(' as the column
+	// list when it is unambiguously `( ident [, …] )`; otherwise it opens a
+	// parenthesized source query.
+	if p.cur.Kind == int('(') && p.columnListFollows() {
+		cols, _, err := p.parseColumnAliases()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Columns = cols
+	}
+
+	// D-INS1: the source query is mandatory. parseQuery handles SELECT / VALUES
+	// / TABLE / WITH … / a parenthesized query (and reports a leading
+	// WITH FUNCTION inline routine as unsupported, deferred to parser-routines).
+	src, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Source = src
+	stmt.Loc.End = src.Loc.End
+	return stmt, nil
+}
+
+// columnListFollows reports whether the current '(' opens an INSERT column
+// list (`( ident [, ident]* )`) rather than a parenthesized source query.
+// It must NOT consume input. The decision uses two-token lookahead plus the
+// fact that a column list's second token is always a non-keyword identifier:
+//
+//   - `(` then SELECT/WITH/TABLE/VALUES/'(' → a query, not a column list.
+//   - `(` then an identifier → a column list ONLY if a one-element `(a)` or a
+//     multi-element `(a, …)` list is syntactically possible. We can see only
+//     the token after '(', so we accept the identifier case here and let the
+//     subsequent parseColumnAliases enforce the `, ident` / `)` shape. A query
+//     whose first token is an identifier necessarily continues with something
+//     other than an immediate ')'/',' (e.g. `(a + b)` — a VALUES-less query is
+//     not legal anyway), so this never misclassifies a real Trino query: the
+//     only `( identifier …` query primaries are a subquery (which starts with
+//     SELECT/WITH/TABLE/VALUES, handled above) — a bare `( expr )` is not a
+//     valid INSERT source on its own.
+//
+// The leading '(' is the current token; we look at the token after it.
+func (p *Parser) columnListFollows() bool {
+	switch p.peekNext().Kind {
+	case kwSELECT, kwWITH, kwTABLE, kwVALUES, int('('):
+		// A parenthesized source query, never a column list.
+		return false
+	default:
+		// `( identifier …` — treat as a column list. isIdentifierStart covers
+		// unquoted, quoted, back-quoted and non-reserved-keyword identifiers.
+		return isIdentifierStart(p.peekNext().Kind)
+	}
+}
+
+// parseTruncateStmt parses `TRUNCATE TABLE qualifiedName`. On entry cur is the
+// TRUNCATE keyword. D-TR1: the TABLE keyword is mandatory; the target is at
+// most catalog.schema.table.
+func (p *Parser) parseTruncateStmt() (ast.Node, error) {
+	truncTok := p.advance() // consume TRUNCATE
+	if _, err := p.expect(kwTABLE); err != nil {
+		return nil, err
+	}
+	target, err := p.parseBoundedQualifiedName(3, "truncate target")
+	if err != nil {
+		return nil, err
+	}
+	return &TruncateStmt{
+		Target: target,
+		Loc:    ast.Loc{Start: truncTok.Loc.Start, End: target.Loc.End},
+	}, nil
+}

--- a/trino/parser/merge.go
+++ b/trino/parser/merge.go
@@ -1,0 +1,334 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-dml DAG node (with insert.go and
+// update_delete.go): it implements Trino's MERGE statement and its WHEN clauses
+// as hand-written recursive-descent parsers over the token stream.
+//
+// The statement structs live here in package parser and satisfy ast.Node with
+// the placeholder tag ast.T_Invalid; see the insert.go file header for why DML
+// statement nodes use T_Invalid rather than a dedicated trino/ast/nodetags.go
+// tag.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : ...
+//	    | MERGE_ INTO_ qualifiedName (AS_? identifier)? USING_ relation
+//	          ON_ expression mergeCase+                                            # merge
+//	    ;
+//	mergeCase
+//	    : WHEN_ MATCHED_ (AND_ condition = expression)? THEN_ UPDATE_ SET_
+//	          targets += identifier EQ_ values += expression
+//	          (COMMA_ targets += identifier EQ_ values += expression)*             # mergeUpdate
+//	    | WHEN_ MATCHED_ (AND_ condition = expression)? THEN_ DELETE_              # mergeDelete
+//	    | WHEN_ NOT_ MATCHED_ (AND_ condition = expression)? THEN_ INSERT_
+//	          (LPAREN_ targets += identifier (COMMA_ targets += identifier)* RPAREN_)?
+//	          VALUES_ LPAREN_ values += expression (COMMA_ values += expression)* RPAREN_ # mergeInsert
+//	    ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar. Oracle-confirmed facts (Trino 481) baked in:
+//
+//	D-MRG1 (at least one WHEN clause is required). `MERGE INTO t u USING s ON
+//	   t.c = s.c` with no WHEN clause is a SYNTAX_ERROR (mergeCase+).
+//	D-MRG2 (UPDATE SET is unparenthesized `col = expr` pairs). The Trino 481
+//	   docs render the syntax as `THEN UPDATE SET ( column = expr [, …] )` but
+//	   the oracle REJECTS the parenthesized form: `WHEN MATCHED THEN UPDATE SET
+//	   (p = s.p)` is a SYNTAX_ERROR, while `WHEN MATCHED THEN UPDATE SET p = s.p`
+//	   is accepted. The legacy grammar and the docs' own examples agree with the
+//	   oracle (no parens), so the parenthesized doc syntax is treated as a doc
+//	   error and NOT implemented (recorded as a flagged docs-vs-oracle item).
+//	D-MRG3 (INSERT VALUES requires at least one expression). `THEN INSERT VALUES
+//	   ()` is a SYNTAX_ERROR; the optional column list `( col, … )` may precede
+//	   VALUES but the VALUES list itself is non-empty.
+//	D-MRG4 (the target is at most catalog.schema.table; the USING source is a
+//	   full `relation`). A 4-part MERGE target (`a.b.c.d`) is a SYNTAX_ERROR, but
+//	   a 4-part USING-source table is accepted (the source goes through the
+//	   relation rule, which does not bound the name) — so the target is parsed
+//	   with the 3-part bound and the source with parseRelation, matching the FROM
+//	   clause. A join source (`USING a JOIN b ON …`) is accepted; a top-level
+//	   alias appended to a join (`USING a JOIN b ON … s`) is a SYNTAX_ERROR,
+//	   which falls out naturally because parseRelation binds the alias to the
+//	   inner sampledRelation, not the whole join.
+//
+// FLAGGED divergence (ledger #5): `@ branch_name` after the target table
+// (`MERGE INTO accounts @ audit t USING …`) is accepted by Trino 481 but
+// rejected by omni because the lexer emits no '@' token. See the insert.go
+// file header.
+
+// ---------------------------------------------------------------------------
+// MERGE WHEN-clause AST
+// ---------------------------------------------------------------------------
+
+// MergeCaseKind classifies a MergeWhenClause (the three mergeCase
+// alternatives).
+type MergeCaseKind int
+
+const (
+	// MergeUpdate is `WHEN MATCHED [AND cond] THEN UPDATE SET col = expr, …`.
+	MergeUpdate MergeCaseKind = iota
+	// MergeDelete is `WHEN MATCHED [AND cond] THEN DELETE`.
+	MergeDelete
+	// MergeInsert is `WHEN NOT MATCHED [AND cond] THEN INSERT [(col, …)]
+	// VALUES (expr, …)`.
+	MergeInsert
+)
+
+// MergeWhenClause is one WHEN clause of a MERGE (the mergeCase rule). Kind
+// selects the alternative. Condition is the optional `AND <expression>` guard
+// (nil when absent). The remaining fields are populated per Kind:
+//
+//   - MergeUpdate: Assignments holds the `col = expr` SET pairs (non-empty).
+//   - MergeDelete: no further fields.
+//   - MergeInsert: Columns is the optional explicit column list (nil when the
+//     `(col, …)` is absent); Values holds the VALUES expressions (non-empty).
+type MergeWhenClause struct {
+	Kind        MergeCaseKind
+	Condition   Expr               // optional AND <condition>, nil when absent
+	Assignments []UpdateAssignment // MergeUpdate: the SET col = expr pairs
+	Columns     []*ast.Identifier  // MergeInsert: optional INSERT column list, nil when absent
+	Values      []Expr             // MergeInsert: the VALUES expressions
+	Loc         ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// MERGE statement AST
+// ---------------------------------------------------------------------------
+
+// MergeStmt is a
+//
+//	MERGE INTO qualifiedName [[AS] alias] USING relation ON expression
+//	    whenClause+
+//
+// statement (the merge alternative). Target is the destination table (1-3
+// parts). Alias is the optional target alias (nil when absent). Source is the
+// USING relation (a table, subquery, join, …). On is the merge-condition
+// expression. Whens is the non-empty list of WHEN clauses.
+type MergeStmt struct {
+	Target *ast.QualifiedName
+	Alias  *ast.Identifier // optional [AS] target alias, nil when absent
+	Source Relation
+	On     Expr
+	Whens  []MergeWhenClause
+	Loc    ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *MergeStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+
+// Span returns the source byte range.
+func (n *MergeStmt) Span() ast.Loc { return n.Loc }
+
+// Compile-time assertion that *MergeStmt satisfies ast.Node.
+var _ ast.Node = (*MergeStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+// parseMergeStmt parses
+//
+//	MERGE INTO qualifiedName [[AS] alias] USING relation ON expression
+//	    mergeCase+
+//
+// On entry cur is the MERGE keyword.
+func (p *Parser) parseMergeStmt() (ast.Node, error) {
+	mergeTok := p.advance() // consume MERGE
+	if _, err := p.expect(kwINTO); err != nil {
+		return nil, err
+	}
+
+	// D-MRG4: target is at most catalog.schema.table.
+	target, err := p.parseBoundedQualifiedName(3, "merge target")
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &MergeStmt{Target: target, Loc: ast.Loc{Start: mergeTok.Loc.Start, End: target.Loc.End}}
+
+	// Optional target alias: `AS identifier` or a bare identifier. USING is a
+	// reserved keyword (so isIdentifierStart(USING) is false): a bare identifier
+	// here is therefore unambiguously the alias, never the USING clause.
+	if p.cur.Kind == kwAS {
+		p.advance() // consume AS — an identifier must follow
+		alias, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Alias = alias
+		stmt.Loc.End = alias.Loc.End
+	} else if isIdentifierStart(p.cur.Kind) {
+		alias := identFromToken(p.advance())
+		stmt.Alias = alias
+		stmt.Loc.End = alias.Loc.End
+	}
+
+	if _, err := p.expect(kwUSING); err != nil {
+		return nil, err
+	}
+
+	// D-MRG4: the USING source is a full relation (table / subquery / join,
+	// with optional alias and TABLESAMPLE), parsed exactly like a FROM item.
+	source, err := p.parseRelation()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Source = source
+	stmt.Loc.End = source.Span().End
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	on, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = on
+	stmt.Loc.End = on.Span().End
+
+	// D-MRG1: at least one WHEN clause (mergeCase+).
+	for p.cur.Kind == kwWHEN {
+		clause, err := p.parseMergeWhenClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Whens = append(stmt.Whens, clause)
+		stmt.Loc.End = clause.Loc.End
+	}
+	if len(stmt.Whens) == 0 {
+		// No WHEN clause at all: report the missing clause at the current token.
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	return stmt, nil
+}
+
+// parseMergeWhenClause parses one mergeCase. On entry cur is the WHEN keyword.
+// The clause shape is decided by MATCHED vs NOT MATCHED and then by the THEN
+// action keyword (UPDATE / DELETE for MATCHED; INSERT for NOT MATCHED).
+func (p *Parser) parseMergeWhenClause() (MergeWhenClause, error) {
+	whenTok := p.advance() // consume WHEN
+
+	notMatched := false
+	if p.cur.Kind == kwNOT {
+		p.advance() // consume NOT
+		notMatched = true
+	}
+	if _, err := p.expect(kwMATCHED); err != nil {
+		return MergeWhenClause{}, err
+	}
+
+	clause := MergeWhenClause{Loc: ast.Loc{Start: whenTok.Loc.Start, End: p.prev.Loc.End}}
+
+	// Optional `AND <condition>` guard.
+	if p.cur.Kind == kwAND {
+		p.advance() // consume AND
+		cond, err := p.parseExpr()
+		if err != nil {
+			return MergeWhenClause{}, err
+		}
+		clause.Condition = cond
+		clause.Loc.End = cond.Span().End
+	}
+
+	if _, err := p.expect(kwTHEN); err != nil {
+		return MergeWhenClause{}, err
+	}
+
+	if notMatched {
+		// WHEN NOT MATCHED … THEN INSERT … VALUES (…)
+		if err := p.parseMergeInsertAction(&clause); err != nil {
+			return MergeWhenClause{}, err
+		}
+		return clause, nil
+	}
+
+	// WHEN MATCHED … THEN (UPDATE SET … | DELETE)
+	switch p.cur.Kind {
+	case kwUPDATE:
+		if err := p.parseMergeUpdateAction(&clause); err != nil {
+			return MergeWhenClause{}, err
+		}
+	case kwDELETE:
+		clause.Kind = MergeDelete
+		delTok := p.advance() // consume DELETE
+		clause.Loc.End = delTok.Loc.End
+	default:
+		// MATCHED clauses allow only UPDATE or DELETE.
+		return MergeWhenClause{}, p.syntaxErrorAtCur()
+	}
+	return clause, nil
+}
+
+// parseMergeUpdateAction parses `UPDATE SET col = expr (, col = expr)*` into
+// clause (a WHEN MATCHED … THEN UPDATE). On entry cur is the UPDATE keyword.
+// D-MRG2: the SET list is unparenthesized `identifier = expression` pairs,
+// reusing parseUpdateAssignment so MERGE and UPDATE share one assignment shape.
+func (p *Parser) parseMergeUpdateAction(clause *MergeWhenClause) error {
+	clause.Kind = MergeUpdate
+	p.advance() // consume UPDATE
+	if _, err := p.expect(kwSET); err != nil {
+		return err
+	}
+	for {
+		asgn, err := p.parseUpdateAssignment()
+		if err != nil {
+			return err
+		}
+		clause.Assignments = append(clause.Assignments, asgn)
+		clause.Loc.End = asgn.Loc.End
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	return nil
+}
+
+// parseMergeInsertAction parses `INSERT [(col, …)] VALUES (expr, …)` into clause
+// (a WHEN NOT MATCHED … THEN INSERT). On entry cur is the action keyword: it
+// MUST be INSERT — a WHEN NOT MATCHED clause's only legal action is INSERT, so
+// `THEN DELETE`/`THEN UPDATE`/`THEN <other>` is a SYNTAX_ERROR (Trino 481
+// rejects `WHEN NOT MATCHED THEN DELETE VALUES (1)`). D-MRG3: the VALUES list
+// is non-empty; the column list is optional.
+func (p *Parser) parseMergeInsertAction(clause *MergeWhenClause) error {
+	clause.Kind = MergeInsert
+	if _, err := p.expect(kwINSERT); err != nil {
+		return err
+	}
+
+	// Optional explicit column list `( identifier (, identifier)* )`.
+	if p.cur.Kind == int('(') {
+		cols, _, err := p.parseColumnAliases()
+		if err != nil {
+			return err
+		}
+		clause.Columns = cols
+	}
+
+	if _, err := p.expect(kwVALUES); err != nil {
+		return err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return err
+	}
+	for {
+		val, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		clause.Values = append(clause.Values, val)
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return err
+	}
+	clause.Loc.End = closeTok.Loc.End
+	return nil
+}

--- a/trino/parser/oracle_dml_test.go
+++ b/trino/parser/oracle_dml_test.go
@@ -1,0 +1,221 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-dml node's differential-oracle gate
+// (correctness-protocol.md): for every statement in the corpus below, omni's
+// Parse accept/reject verdict must equal Trino 481's verdict as reported by the
+// live oracle (trinooracle.CheckSyntax, which classifies a SYNTAX_ERROR as
+// reject and every other outcome — success or a semantic error like
+// TABLE_NOT_FOUND / COLUMN_NOT_FOUND / NOT_SUPPORTED — as accept).
+//
+// The corpus is NOT split into hardcoded accept/reject lists: the oracle is the
+// source of truth, so each case is run through both omni and Trino and the two
+// verdicts compared. It covers every legacy grammar example (truth2,
+// examples/{insert_into,delete,update,truncate_table,whereless_update,merge}.sql
+// with their assertions stripped), every documented form (truth1
+// query-dml.md), the oracle-pinned grammar facts (D-INS*/D-DEL*/D-UPD*/D-MRG*),
+// and a set of negative forms.
+//
+// EXCLUDED — the `@ branch_name` form (divergence ledger #5). Trino 481 accepts
+// `INSERT/DELETE/UPDATE/MERGE INTO tbl @ branch …`, but omni REJECTS it because
+// the merged lexer emits no '@' token (an "unrecognized character" lex error),
+// a lexer-node concern outside this node's writes scope. Those cases are listed
+// in dmlBranchDivergenceCorpus below and asserted as a KNOWN, flagged divergence
+// (omni rejects, Trino accepts) rather than mixed into the parity gate, so the
+// gate stays a true equality check.
+//
+// Skipped cleanly when no Trino oracle is reachable.
+
+// dmlOracleCorpus is the full DML statement corpus for the differential gate.
+// Each string is fed to both omni and the oracle; the verdicts must match.
+var dmlOracleCorpus = []string{
+	// ---------------------------------------------------------------------
+	// INSERT (truth1 insert.html + truth2 insert_into.sql)
+	// ---------------------------------------------------------------------
+	"INSERT INTO orders SELECT * FROM new_orders",
+	"INSERT INTO cities VALUES (1, 'San Francisco')",
+	"INSERT INTO cities VALUES (2, 'San Jose'), (3, 'Oakland')",
+	"INSERT INTO nation (nationkey, name, regionkey, comment) SELECT 1, 'a', 2, 'c'",
+	"INSERT INTO nation (nationkey, name, regionkey) VALUES (1, 'a', 2)",
+	`INSERT INTO a."b/c".d SELECT * FROM t`,
+	`INSERT INTO a."b/c".d (c1, c2) SELECT * FROM t`,
+	"INSERT INTO t (SELECT 1)", // parenthesized source query
+	"INSERT INTO t VALUES (1), (2), (3)",
+	"INSERT INTO t SELECT a FROM b UNION SELECT c FROM d",    // set-op source
+	"INSERT INTO t SELECT * FROM a ORDER BY 1 LIMIT 5",       // query tail
+	"INSERT INTO t TABLE other",                              // TABLE query source
+	"INSERT INTO t WITH cte AS (SELECT 1) SELECT * FROM cte", // WITH source
+	"INSERT INTO cat.sch.t VALUES (1)",                       // 3-part target
+	// INSERT negatives
+	"INSERT INTO t",                  // D-INS1: source query mandatory
+	"INSERT INTO t (a, b)",           // D-INS1: column list without source
+	"INSERT INTO a.b.c.d VALUES (1)", // D-INS2: 4-part target
+	"INSERT t VALUES (1)",            // missing INTO
+	"INSERT INTO",                    // missing target
+	"INSERT INTO t VALUES",           // VALUES with no rows
+
+	// ---------------------------------------------------------------------
+	// TRUNCATE (truth2 truncate_table.sql)
+	// ---------------------------------------------------------------------
+	"TRUNCATE TABLE orders",
+	"TRUNCATE TABLE a",
+	"TRUNCATE TABLE a.b",
+	"TRUNCATE TABLE a.b.c",
+	`TRUNCATE TABLE "My Table"`,
+	// TRUNCATE negatives
+	"TRUNCATE orders",             // D-TR1: TABLE keyword mandatory
+	"TRUNCATE TABLE a.b.c.d",      // 4-part target
+	"TRUNCATE TABLE orders extra", // trailing token
+	"TRUNCATE TABLE",              // missing target
+
+	// ---------------------------------------------------------------------
+	// DELETE (truth1 delete.html + truth2 delete.sql)
+	// ---------------------------------------------------------------------
+	"DELETE FROM orders",
+	"DELETE FROM lineitem WHERE shipmode = 'AIR'",
+	"DELETE FROM lineitem WHERE orderkey IN (SELECT orderkey FROM orders WHERE totalprice > 100)",
+	"DELETE FROM t",
+	`DELETE FROM "awesome table"`,
+	"DELETE FROM t WHERE a = b",
+	"DELETE FROM cat.sch.orders WHERE x = 1",
+	"DELETE FROM orders WHERE a = 1 AND b > 2 OR c IS NULL",
+	// DELETE negatives
+	"DELETE orders",              // D-DEL1: FROM mandatory
+	"DELETE FROM orders WHERE",   // dangling WHERE
+	"DELETE FROM a.b.c.d",        // 4-part target
+	"DELETE FROM orders garbage", // trailing token
+	"DELETE FROM",                // missing target
+
+	// ---------------------------------------------------------------------
+	// UPDATE (truth1 update.html + truth2 update.sql / whereless_update.sql)
+	// ---------------------------------------------------------------------
+	"UPDATE purchases SET status = 'OVERDUE' WHERE ship_date IS NULL",
+	"UPDATE customers SET account_manager = 'John Henry', assign_date = now()",
+	"UPDATE new_hires SET manager = (SELECT e.name FROM employees e WHERE e.employee_id = new_hires.manager_id)",
+	"UPDATE foo_tablen SET bar = 23, baz = 3.1415E0, bletch = 'barf' WHERE (nothing = 'fun')",
+	"UPDATE foo_tablen SET bar = 23",
+	`UPDATE t SET "col one" = a + b * 2, x = CASE WHEN y THEN 1 ELSE 2 END`,
+	"UPDATE cat.sch.t SET a = 1",
+	// UPDATE negatives
+	"UPDATE t a = 1",               // D-UPD2: SET mandatory
+	"UPDATE t SET",                 // D-UPD2: at least one assignment
+	"UPDATE t SET (a, b) = (1, 2)", // D-UPD1: no row assignment
+	"UPDATE t SET a = 1 garbage",   // trailing token
+	"UPDATE SET a = 1",             // missing target
+	"UPDATE t SET a",               // assignment missing = expr
+
+	// ---------------------------------------------------------------------
+	// MERGE (truth1 merge.html + truth2 merge.sql)
+	// ---------------------------------------------------------------------
+	"MERGE INTO accounts t USING monthly_accounts_update s ON t.customer = s.customer WHEN MATCHED THEN DELETE",
+	"MERGE INTO accounts t USING monthly_accounts_update s ON (t.customer = s.customer) " +
+		"WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases " +
+		"WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES (s.customer, s.purchases, s.address)",
+	"MERGE INTO accounts t USING monthly_accounts_update s ON (t.customer = s.customer) " +
+		"WHEN MATCHED AND s.address = 'Centreville' THEN DELETE " +
+		"WHEN MATCHED THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address " +
+		"WHEN NOT MATCHED THEN INSERT (customer, purchases, address) VALUES (s.customer, s.purchases, s.address)",
+	"MERGE INTO inventory AS i USING changes AS c ON i.part = c.part " +
+		"WHEN MATCHED AND c.action = 'mod' THEN UPDATE SET qty = qty + c.qty, ts = CURRENT_TIMESTAMP " +
+		"WHEN MATCHED AND c.action = 'del' THEN DELETE " +
+		"WHEN NOT MATCHED AND c.action = 'new' THEN INSERT (part, qty) VALUES (c.part, c.qty)",
+	"MERGE INTO accounts USING src s ON accounts.c = s.c WHEN MATCHED THEN DELETE",                               // no target alias
+	"MERGE INTO accounts AS t USING src s ON t.c = s.c WHEN MATCHED THEN DELETE",                                 // AS alias
+	"MERGE INTO acc data USING src s ON data.c = s.c WHEN MATCHED THEN DELETE",                                   // non-reserved kw alias
+	"MERGE INTO acc t USING (SELECT * FROM src) s ON t.c = s.c WHEN MATCHED THEN DELETE",                         // subquery source
+	"MERGE INTO acc t USING (SELECT * FROM src) AS s ON t.c = s.c WHEN MATCHED THEN DELETE",                      // subquery AS source
+	"MERGE INTO cat.sch.acc t USING src s ON t.c = s.c WHEN MATCHED THEN DELETE",                                 // qualified target
+	"MERGE INTO acc t USING cat.sch.src s ON t.c = s.c WHEN MATCHED THEN DELETE",                                 // qualified source
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN INSERT VALUES (s.c, s.p)",                   // INSERT no column list
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN MATCHED AND s.x > 0 THEN DELETE",                             // matched AND guard
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED AND s.x > 0 THEN INSERT VALUES (1)",              // not-matched AND guard
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN MATCHED THEN DELETE WHEN NOT MATCHED THEN INSERT VALUES (1)", // multi-clause
+	"MERGE INTO acc t USING src CROSS JOIN other ON t.c = 1 WHEN MATCHED THEN DELETE",                            // D-MRG4: join source
+	// MERGE negatives
+	"MERGE INTO accounts t USING src s ON t.c = s.c",                                                 // D-MRG1: no WHEN
+	"MERGE INTO accounts t USING src s ON t.c = s.c WHEN MATCHED THEN UPDATE SET (p = s.p)",          // D-MRG2: parenthesized SET
+	"MERGE INTO accounts t USING src s ON t.c = s.c WHEN MATCHED THEN UPDATE SET (p = s.p, a = s.a)", // D-MRG2
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN INSERT VALUES ()",               // D-MRG3: empty VALUES
+	"MERGE INTO a.b.c.d t USING s ON t.c = s.c WHEN MATCHED THEN DELETE",                             // D-MRG4: 4-part target
+	"MERGE INTO acc t USING a JOIN b ON a.k = b.k s ON t.c = a.c WHEN MATCHED THEN DELETE",           // alias after join
+	"MERGE INTO acc t USING src s WHEN MATCHED THEN DELETE",                                          // missing ON
+	"MERGE acc t USING src s ON t.c = s.c WHEN MATCHED THEN DELETE",                                  // missing INTO
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN MATCHED THEN INSERT VALUES (1)",                  // INSERT under MATCHED
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN DELETE",                         // DELETE under NOT MATCHED
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN UPDATE SET p = 1",               // UPDATE under NOT MATCHED
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN DELETE VALUES (1)",              // NOT MATCHED action must be INSERT (not DELETE)
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN UPDATE VALUES (1)",              // NOT MATCHED action must be INSERT (not UPDATE)
+	"MERGE INTO acc t USING src s ON t.c = s.c WHEN NOT MATCHED THEN foo VALUES (1)",                 // NOT MATCHED action must be the INSERT keyword
+}
+
+// TestDML_OracleDifferential is the authoritative accept/reject gate: omni's
+// Parse verdict must equal Trino 481's verdict for every corpus statement.
+func TestDML_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, sql := range dmlOracleCorpus {
+		sql := sql
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			omniAccepts := len(errs) == 0
+
+			trinoAccepts, ok := oracleAccepts(t, o, sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if omniAccepts != trinoAccepts {
+				t.Errorf("MISMATCH %q: omni accepts=%v (errs=%v), Trino accepts=%v",
+					sql, omniAccepts, errs, trinoAccepts)
+			}
+		})
+	}
+}
+
+// dmlBranchDivergenceCorpus holds the `@ branch_name` DML forms (divergence
+// ledger #5). Trino 481 ACCEPTS each; omni REJECTS each because the lexer emits
+// no '@' token. This documents and pins the known divergence so a future lexer
+// change that adds the '@' token (and the corresponding DML support) is detected
+// here as a behavior change.
+var dmlBranchDivergenceCorpus = []string{
+	"INSERT INTO cities @ audit VALUES (1, 'San Francisco')",
+	"DELETE FROM orders @ audit",
+	"DELETE FROM orders @ audit WHERE x = 1",
+	"UPDATE purchases @ audit SET status = 'OVERDUE' WHERE ship_date IS NULL",
+	"MERGE INTO accounts @ audit t USING src s ON t.c = s.c WHEN MATCHED THEN DELETE",
+}
+
+// TestDML_BranchDivergence asserts the flagged divergence #5 is still in effect:
+// Trino accepts `@ branch`, omni rejects it. If omni ever starts accepting these
+// (e.g. after the lexer learns '@'), this test FAILS loudly so the divergence
+// ledger and this corpus are revisited and the cases promoted into the parity
+// gate.
+func TestDML_BranchDivergence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, sql := range dmlBranchDivergenceCorpus {
+		sql := sql
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			omniAccepts := len(errs) == 0
+			if omniAccepts {
+				t.Errorf("DIVERGENCE RESOLVED: omni now ACCEPTS %q — Trino 481 accepts it too; "+
+					"promote this case into dmlOracleCorpus and update divergence ledger #5", sql)
+			}
+
+			trinoAccepts, ok := oracleAccepts(t, o, sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if !trinoAccepts {
+				t.Errorf("ORACLE CHANGED: Trino 481 now REJECTS %q — revisit divergence ledger #5", sql)
+			}
+		})
+	}
+}

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -235,17 +235,17 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwREFRESH:
 		return p.unsupported("REFRESH")
 
-	// --- DML ---
+	// --- DML --- [parser-dml node: insert.go, update_delete.go, merge.go]
 	case kwINSERT:
-		return p.unsupported("INSERT")
+		return p.parseInsertStmt()
 	case kwDELETE:
-		return p.unsupported("DELETE")
+		return p.parseDeleteStmt()
 	case kwUPDATE:
-		return p.unsupported("UPDATE")
+		return p.parseUpdateStmt()
 	case kwMERGE:
-		return p.unsupported("MERGE")
+		return p.parseMergeStmt()
 	case kwTRUNCATE:
-		return p.unsupported("TRUNCATE")
+		return p.parseTruncateStmt()
 
 	// --- Procedures ---
 	case kwCALL:

--- a/trino/parser/parser_test.go
+++ b/trino/parser/parser_test.go
@@ -41,16 +41,16 @@ func TestParse_UnknownStatement(t *testing.T) {
 // TestParse_KnownStatementUnsupported verifies that a statement whose leading
 // keyword IS in the dispatch switch but whose body is STILL stubbed (no DAG node
 // has implemented it yet) yields a "not yet supported" diagnostic rather than an
-// "unknown statement" one. INSERT (parser-dml's job) is still stubbed; SELECT and
-// the rest of the query layer are now implemented by parser-select, so this test
-// uses a statement that remains a foundation stub.
+// "unknown statement" one. DML (parser-dml) and the query layer (parser-select)
+// are now implemented; ALTER (parser-ddl's job) remains a foundation stub, so
+// this test uses it.
 func TestParse_KnownStatementUnsupported(t *testing.T) {
-	file, errs := Parse("INSERT INTO t VALUES (1)")
+	file, errs := Parse("ALTER TABLE t ADD COLUMN c integer")
 	if file == nil {
 		t.Fatal("Parse: File is nil")
 	}
 	if len(errs) != 1 {
-		t.Fatalf("Parse(\"INSERT ...\"): got %d errors, want 1: %v", len(errs), errs)
+		t.Fatalf("Parse(\"ALTER ...\"): got %d errors, want 1: %v", len(errs), errs)
 	}
 	if !strings.Contains(errs[0].Msg, "not yet supported") {
 		t.Errorf("error = %q, want it to mention 'not yet supported'", errs[0].Msg)
@@ -59,10 +59,10 @@ func TestParse_KnownStatementUnsupported(t *testing.T) {
 
 // TestParse_MultiStatementErrorsCollected verifies that ParseBestEffort
 // collects errors from every segment, not just the first. Two still-stubbed
-// statements (INSERT and DELETE, parser-dml's job) separated by ';' must yield
+// statements (ALTER and COMMENT, parser-ddl's job) separated by ';' must yield
 // two errors.
 func TestParse_MultiStatementErrorsCollected(t *testing.T) {
-	res := ParseBestEffort("INSERT INTO t VALUES (1); DELETE FROM u")
+	res := ParseBestEffort("ALTER TABLE t ADD COLUMN c integer; COMMENT ON TABLE u IS 'x'")
 	if got := len(res.Errors); got != 2 {
 		t.Fatalf("ParseBestEffort: got %d errors, want 2: %v", got, res.Errors)
 	}

--- a/trino/parser/update_delete.go
+++ b/trino/parser/update_delete.go
@@ -1,0 +1,210 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-dml DAG node (with insert.go and merge.go):
+// it implements Trino's DELETE and UPDATE data-manipulation statements as
+// hand-written recursive-descent parsers over the token stream.
+//
+// The statement structs live here in package parser and satisfy ast.Node with
+// the placeholder tag ast.T_Invalid; see the insert.go file header for why DML
+// statement nodes use T_Invalid rather than a dedicated trino/ast/nodetags.go
+// tag.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : ...
+//	    | DELETE_ FROM_ qualifiedName (WHERE_ booleanExpression)?                   # delete
+//	    | UPDATE_ qualifiedName SET_ updateAssignment (COMMA_ updateAssignment)*
+//	          (WHERE_ where = booleanExpression)?                                   # update
+//	    ;
+//	updateAssignment : identifier EQ_ expression ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar. Oracle-confirmed facts (Trino 481) baked in:
+//
+//	D-DEL1 (DELETE requires FROM). `DELETE orders` is a SYNTAX_ERROR; the FROM
+//	   keyword is mandatory. The WHERE clause is optional (`DELETE FROM orders`
+//	   deletes all rows). A dangling `DELETE FROM orders WHERE` is rejected.
+//	D-UPD1 (UPDATE assignment target is a single identifier, value is an
+//	   expression). `UPDATE t SET (a, b) = (1, 2)` — a row assignment — is a
+//	   SYNTAX_ERROR in Trino 481: each assignment is exactly `identifier = expr`.
+//	D-UPD2 (UPDATE requires at least one assignment after SET). `UPDATE t SET`
+//	   and `UPDATE t a = 1` (missing SET) are SYNTAX_ERRORs.
+//	D-DML-NAME (target is at most catalog.schema.table). A 4-part target name
+//	   (`a.b.c.d`) is a SYNTAX_ERROR for both DELETE and UPDATE.
+//
+// The WHERE / value / assignment expressions use the shared expression entry
+// point parseExpr (== the grammar's `expression` / `booleanExpression`), so a
+// subquery predicate (`DELETE … WHERE k IN (SELECT …)`) and a scalar-subquery
+// assignment value (`UPDATE … SET m = (SELECT …)`) parse via the expression
+// node's SubqueryExpr placeholder, exactly as in SELECT predicates.
+//
+// FLAGGED divergence (ledger #5): `@ branch_name` after the target table —
+// `DELETE FROM orders @ audit`, `UPDATE purchases @ audit SET …` — is accepted
+// by Trino 481 but rejected by omni because the lexer emits no '@' token. See
+// the insert.go file header.
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+// DeleteStmt is a `DELETE FROM qualifiedName [WHERE booleanExpression]`
+// statement (the delete alternative). Target is the table to delete from (1-3
+// parts). Where is the optional row filter (nil when absent — meaning delete
+// all rows).
+type DeleteStmt struct {
+	Target *ast.QualifiedName
+	Where  Expr // nil when there is no WHERE clause
+	Loc    ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *DeleteStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+
+// Span returns the source byte range.
+func (n *DeleteStmt) Span() ast.Loc { return n.Loc }
+
+// ---------------------------------------------------------------------------
+// UPDATE
+// ---------------------------------------------------------------------------
+
+// UpdateAssignment is one `identifier = expression` SET assignment (the
+// updateAssignment rule). Column is the single target column name; Value is the
+// new-value expression (which may be a scalar subquery placeholder).
+type UpdateAssignment struct {
+	Column *ast.Identifier
+	Value  Expr
+	Loc    ast.Loc
+}
+
+// UpdateStmt is an `UPDATE qualifiedName SET assignment (, assignment)*
+// [WHERE booleanExpression]` statement (the update alternative). Target is the
+// table to update (1-3 parts). Assignments is the non-empty SET list. Where is
+// the optional row filter (nil when absent).
+type UpdateStmt struct {
+	Target      *ast.QualifiedName
+	Assignments []UpdateAssignment
+	Where       Expr // nil when there is no WHERE clause
+	Loc         ast.Loc
+}
+
+// Tag implements ast.Node.
+func (n *UpdateStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+
+// Span returns the source byte range.
+func (n *UpdateStmt) Span() ast.Loc { return n.Loc }
+
+// Compile-time assertions that the statement types satisfy ast.Node.
+var (
+	_ ast.Node = (*DeleteStmt)(nil)
+	_ ast.Node = (*UpdateStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+// parseDeleteStmt parses `DELETE FROM qualifiedName [WHERE booleanExpression]`.
+// On entry cur is the DELETE keyword. D-DEL1: FROM is mandatory; the WHERE
+// clause is optional.
+func (p *Parser) parseDeleteStmt() (ast.Node, error) {
+	deleteTok := p.advance() // consume DELETE
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+
+	// D-DML-NAME: target is at most catalog.schema.table.
+	target, err := p.parseBoundedQualifiedName(3, "delete target")
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &DeleteStmt{Target: target, Loc: ast.Loc{Start: deleteTok.Loc.Start, End: target.Loc.End}}
+
+	if p.cur.Kind == kwWHERE {
+		p.advance() // consume WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+		stmt.Loc.End = where.Span().End
+	}
+
+	return stmt, nil
+}
+
+// parseUpdateStmt parses
+//
+//	UPDATE qualifiedName SET updateAssignment (, updateAssignment)*
+//	    [WHERE booleanExpression]
+//
+// On entry cur is the UPDATE keyword. D-UPD2: SET and at least one assignment
+// are mandatory; the WHERE clause is optional.
+func (p *Parser) parseUpdateStmt() (ast.Node, error) {
+	updateTok := p.advance() // consume UPDATE
+
+	// D-DML-NAME: target is at most catalog.schema.table.
+	target, err := p.parseBoundedQualifiedName(3, "update target")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwSET); err != nil {
+		return nil, err
+	}
+
+	stmt := &UpdateStmt{Target: target, Loc: ast.Loc{Start: updateTok.Loc.Start, End: target.Loc.End}}
+
+	// One or more comma-separated assignments (the list is non-empty: D-UPD2).
+	for {
+		asgn, err := p.parseUpdateAssignment()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Assignments = append(stmt.Assignments, asgn)
+		stmt.Loc.End = asgn.Loc.End
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+
+	if p.cur.Kind == kwWHERE {
+		p.advance() // consume WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+		stmt.Loc.End = where.Span().End
+	}
+
+	return stmt, nil
+}
+
+// parseUpdateAssignment parses one `identifier = expression` (the
+// updateAssignment rule). D-UPD1: the target is a single bare identifier — a
+// parenthesized row target like `(a, b) = (1, 2)` is rejected because '(' is
+// not an identifier start, surfacing as a syntax error at the '('.
+func (p *Parser) parseUpdateAssignment() (UpdateAssignment, error) {
+	col, err := p.parseIdentifier()
+	if err != nil {
+		return UpdateAssignment{}, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return UpdateAssignment{}, err
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return UpdateAssignment{}, err
+	}
+	return UpdateAssignment{
+		Column: col,
+		Value:  value,
+		Loc:    ast.Loc{Start: col.Loc.Start, End: value.Span().End},
+	}, nil
+}


### PR DESCRIPTION
## v2 migration node: `trino/parser-dml` (DAG migration id 3, layer 6)

Hand-written recursive-descent parsers for Trino 481's data-manipulation statements, completing the `trino/parser-dml` grammar node. Spec: [`docs/migration/trino/analysis.md`](docs/migration/trino/analysis.md) §6 Tier 4 + [`docs/migration/trino/dag.md`](docs/migration/trino/dag.md). Depends on (merged): `trino/parser-select`.

### Statements implemented

| Form | File | Grammar |
|---|---|---|
| `INSERT INTO qn [(cols)] rootQuery` | `insert.go` | `insertInto` |
| `TRUNCATE TABLE qn` | `insert.go` | `truncateTable` |
| `DELETE FROM qn [WHERE booleanExpression]` | `update_delete.go` | `delete` |
| `UPDATE qn SET col=expr,… [WHERE …]` | `update_delete.go` | `update` + `updateAssignment` |
| `MERGE INTO qn [[AS] alias] USING relation ON expr whenClause+` | `merge.go` | `merge` + `mergeCase` |

Statement nodes live in `package parser` (mirroring `select.go`'s `QueryStmt`, `expr.go`, `datatypes.go`) and satisfy `ast.Node` via `Tag()==ast.T_Invalid`. The ast nodetags set stays closed — dedicated DML tags would collide with the concurrently-developed `parser-ddl` node that also extends `trino/ast/nodetags.go`. Downstream consumers reach the concrete type by Go type switch, as they already do for `QueryStmt`.

### Correctness — proven against the live Trino 481 oracle

Per `correctness-protocol.md`, the verdict comes from the executable oracle, not judgment. `oracle_dml_test.go` (`TestDML_OracleDifferential`) runs **90 accept/reject cases** through both omni's `Parse` and the live Trino 481 oracle (`trinooracle.CheckSyntax`); **0 mismatches**. The corpus is the union of:

- **Legacy examples** (truth2), assertions stripped: `examples/{insert_into,delete,update,truncate_table,whereless_update,merge}.sql`.
- **Every documented form** (truth1 `query-dml.md`): INSERT/DELETE/UPDATE/MERGE syntax + example blocks.
- **Oracle-pinned grammar facts** (below).
- **A full negative set** (missing keywords, dangling clauses, 4-part names, trailing tokens, wrong WHEN→action pairings).

`dml_structure_test.go` asserts the produced AST shape. Total node test surface: 139 passing tests/subtests, 0 failures.

Oracle-adjudicated facts baked into the parsers (vs the legacy grammar / docs):

- **INSERT** requires a source query (`INSERT INTO t` / `INSERT INTO t (a,b)` → SYNTAX_ERROR); target bounded to 3 dotted parts.
- **DELETE** requires `FROM`; **TRUNCATE** requires `TABLE`; both targets bounded to 3 parts.
- **UPDATE** assignment is a single `identifier = expr` — the row form `SET (a,b)=(1,2)` is rejected; `SET` + ≥1 assignment mandatory.
- **MERGE** needs ≥1 WHEN clause; `WHEN MATCHED`→{UPDATE,DELETE}, `WHEN NOT MATCHED`→INSERT (cross pairings rejected); `USING` is a full `relation` (joins/subqueries) parsed exactly like a FROM item; INSERT `VALUES` is non-empty with an optional column list.

### Divergences (oracle-adjudicated)

| # | Case | Disposition | Status |
|---|---|---|---|
| 5 | DML `@ branch` (`INSERT/DELETE/UPDATE/MERGE INTO tbl @ b`) | Trino 481 **accepts**; omni **rejects** — the merged lexer emits no `'@'` token (records an "unrecognized character" lex error). Supporting it needs a coordinated lexer change (emit `@`) outside `parser-dml`'s writes scope. **Pinned** by `TestDML_BranchDivergence` so it surfaces when the lexer learns `@`. | flagged |
| 91 (new) | MERGE UPDATE SET parenthesization | Trino 481 docs render `THEN UPDATE SET ( col = expr [, …] )` with parens, but the oracle **rejects** the parens and accepts the unparenthesized form; the docs' own examples + legacy grammar agree with the oracle. Docs error → omni follows oracle/legacy (no parens). Both forms in the differential corpus. | confirmed |

### Scope (`writes` globs: `insert.go`, `update_delete.go`, `merge.go`)

In-scope source + their tests (`dml_structure_test.go`, `oracle_dml_test.go`). **Out-of-scope writes (recorded, not silent):**

- `trino/parser/parser.go` — the 5 DML dispatch arms (`INSERT/DELETE/UPDATE/MERGE/TRUNCATE`) re-pointed from the `unsupported(…)` stubs to the new parsers. This is the established statement-node convention (every merged statement node — select, utility, dcl-tcl — wired its own dispatch); the edit is disjoint from the DDL arms the concurrent `parser-ddl` node will touch.
- `trino/parser/parser_test.go` + `trino/parser/diagnose_test.go` — foundation stub tests re-pointed from the now-implemented DML examples (INSERT/DELETE) to still-stubbed DDL examples (ALTER/COMMENT). Same handoff `parser-select` made when it implemented SELECT.

### Review

- **Claude lens** (`/code-review` high): line-by-line + removed-behavior + cross-file + reuse/simplification/efficiency/altitude angles; adversarial oracle edge-probes (column-list vs paren-query, CASE-WHEN inside MERGE ON, empty column/VALUES, non-reserved-keyword aliases, subquery-in-VALUES). Also simplified a redundant `kwUSING` guard in the MERGE alias path.
- **Codex lens** (`codex exec`, different model family): **caught a real bug** — `parseMergeInsertAction` consumed any action keyword before `VALUES` as INSERT, so `WHEN NOT MATCHED THEN DELETE VALUES (1)` was wrongly **accepted** (Trino 481 rejects it). Fixed by requiring the `INSERT` keyword; oracle-verified, with structural + 3 differential regression cases added.

Review gate terminated after the Codex finding was triaged (oracle-confirmed), fixed, and re-verified — no blockers remain. The cross-family gate worked as intended: Codex found a bug the Claude lens and the author's own probes missed. (No CodeRabbit/Copilot comments arrived in the in-wave poll window.)

### Known pre-existing failure (NOT introduced here)

`TestLexer_OracleDifferential` has one failing case (`SELECT "quoted col", \`backtick col\` …`) that fails on `origin/main` independent of this PR — already spun off as a separate task. Every other `trino/...` test is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
