### PR TITLE
feat(trino/parser): SQL routines — CREATE/DROP/WITH FUNCTION + control flow (v2 node trino/parser-routines)

### DIFF
--- a/trino/ast/nodetags.go
+++ b/trino/ast/nodetags.go
@@ -128,6 +128,24 @@ const (
 	T_DescribeInputStmt
 	// T_DescribeOutputStmt tags a DESCRIBE OUTPUT <name> statement.
 	T_DescribeOutputStmt
+
+	// --- SQL routine statement nodes (parser-routines node) ---
+	//
+	// These concrete statement types live in package parser (function_def.go) —
+	// matching the Trino convention that parser-package node types (Expr,
+	// DataType, the other statement shells) are defined where they are built —
+	// but they are returned from parseStmt / parseQuery as ast.Node, so they need
+	// a tag here. The routine-body control statements (RoutineStatement in
+	// routine_body.go) are a parser-local interface like Expr and get NO tag.
+
+	// T_CreateFunctionStmt tags a CREATE [OR REPLACE] FUNCTION statement (an
+	// inline SQL routine definition).
+	T_CreateFunctionStmt
+	// T_DropFunctionStmt tags a DROP FUNCTION [IF EXISTS] statement.
+	T_DropFunctionStmt
+	// T_WithFunctionStmt tags a WITH FUNCTION ... <query> statement (inline SQL
+	// routines preceding a query — the rootQuery withFunction form).
+	T_WithFunctionStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -195,6 +213,12 @@ func (t NodeTag) String() string {
 		return "DescribeInputStmt"
 	case T_DescribeOutputStmt:
 		return "DescribeOutputStmt"
+	case T_CreateFunctionStmt:
+		return "CreateFunctionStmt"
+	case T_DropFunctionStmt:
+		return "DropFunctionStmt"
+	case T_WithFunctionStmt:
+		return "WithFunctionStmt"
 	default:
 		return "Unknown"
 	}

--- a/trino/parser/function_def.go
+++ b/trino/parser/function_def.go
@@ -1,0 +1,634 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is the `parser-routines` DAG node's statement shell (with
+// routine_body.go, which holds the control-flow body language): it implements
+// Trino's SQL-routine definition statements — the legacy TrinoParser.g4
+// `statement` alternatives labelled createFunction and dropFunction, plus the
+// `withFunction` inline-routine prefix on a top-level query (the rootQuery rule).
+//
+// Legacy grammar (truth2):
+//
+//	createFunction      : CREATE (OR REPLACE)? functionSpecification
+//	dropFunction        : DROP FUNCTION (IF EXISTS)? functionDeclaration
+//	withFunction        : WITH functionSpecification (, functionSpecification)*   (precedes a query)
+//	functionSpecification : FUNCTION functionDeclaration returnsClause routineCharacteristic* controlStatement
+//	functionDeclaration   : qualifiedName ( (parameterDeclaration (, parameterDeclaration)*)? )
+//	parameterDeclaration  : identifier? type
+//	returnsClause         : RETURNS type
+//	routineCharacteristic :
+//	      LANGUAGE identifier              # languageCharacteristic
+//	    | NOT? DETERMINISTIC               # deterministicCharacteristic
+//	    | RETURNS NULL ON NULL INPUT       # returnsNullOnNullInputCharacteristic
+//	    | CALLED ON NULL INPUT             # calledOnNullInputCharacteristic
+//	    | SECURITY (DEFINER | INVOKER)     # securityCharacteristic
+//	    | COMMENT string                   # commentCharacteristic
+//
+// As with the other statement nodes (show.go / session.go / grant_revoke.go),
+// the three top-level statement structs are PARSER-PACKAGE types that satisfy
+// ast.Node via tags declared in trino/ast/nodetags.go (T_CreateFunctionStmt,
+// T_DropFunctionStmt, T_WithFunctionStmt). The functionSpecification and its
+// child clauses are parser-local helper structs (no ast.NodeTag) because they
+// are only ever embedded inside one of those three shells. The control-flow body
+// (RoutineStatement) lives in routine_body.go.
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed facts baked in
+// (see oracle_routines_test.go for the differential corpus):
+//
+//	F1 (the whole functionSpecification parses, even though the memory connector
+//	   cannot STORE a UDF). `CREATE FUNCTION f() RETURNS bigint RETURN 42` and the
+//	   full-characteristic / compound-body variants are oracle-ACCEPTED: Trino's
+//	   parser+analyzer succeed and only the connector rejects with NOT_SUPPORTED
+//	   (a non-SYNTAX_ERROR ⇒ accepted by the differential oracle). So this node
+//	   must ACCEPT every well-formed functionSpecification.
+//	F2 (parameter name is optional). `CREATE FUNCTION f(bigint) …` (type only),
+//	   `f(x bigint, varchar, z double)` (mixed), and named forms are all accepted
+//	   — parameterDeclaration is `identifier? type`.
+//	F3 (characteristics are an unordered, repeatable list). `routineCharacteristic*`
+//	   accepts any order and even repeats: `… DETERMINISTIC DETERMINISTIC …` and
+//	   `… COMMENT 'x' LANGUAGE SQL DETERMINISTIC …` are accepted. parseFunctionSpec
+//	   loops, appending each characteristic, with no ordering/uniqueness check.
+//	F4 (WITH ( property = expr, … ) is a real but legacy-absent characteristic).
+//	   The Trino 481 docs list a `WITH ( property_name = expression, … )` clause
+//	   in CREATE FUNCTION (used e.g. for LANGUAGE PYTHON handler properties); the
+//	   oracle ACCEPTS it (`CREATE FUNCTION f() RETURNS int WITH (handler = 'x')
+//	   RETURN 1`). It is ABSENT from the legacy ANTLR routineCharacteristic rule.
+//	   Because Diagnose must not false-reject valid Trino 481, this node
+//	   IMPLEMENTS it as a propertiesCharacteristic and FLAGS it as a confirmed
+//	   docs-ahead-of-legacy divergence (see the divergence ledger / PR body). An
+//	   empty `WITH ()` is rejected (at least one property required).
+//	F5 (DROP FUNCTION reuses functionDeclaration). `DROP FUNCTION f(bigint)`,
+//	   `DROP FUNCTION IF EXISTS my.func(integer, varchar)`, and `DROP FUNCTION f()`
+//	   are accepted; the parenthesised parameter list (types, optionally named) is
+//	   mandatory even when empty (it disambiguates overloads).
+//	F6 (WITH FUNCTION … query is the inline-routine prefix). `WITH FUNCTION
+//	   f(x bigint) RETURNS bigint RETURN x + 1 SELECT f(10)` is accepted; several
+//	   comma-separated specifications may precede the query, and a CTE `WITH` may
+//	   still follow (`WITH FUNCTION … WITH t AS (…) SELECT …`). This is the
+//	   rootQuery rule; parseQuery (select.go) routes a leading `WITH FUNCTION` here.
+
+// ---------------------------------------------------------------------------
+// functionSpecification and its child clauses (parser-local helpers)
+// ---------------------------------------------------------------------------
+
+// ParameterDeclaration is one `identifier? type` parameter of a function
+// signature (parameterDeclaration). Name is nil for the type-only form (F2).
+type ParameterDeclaration struct {
+	Name *ast.Identifier // nil when only a type was given
+	Type *DataType
+	Loc  ast.Loc
+}
+
+// FunctionDeclaration is `qualifiedName ( (parameterDeclaration, …)? )` — the
+// function signature shared by CREATE FUNCTION (via functionSpecification) and
+// DROP FUNCTION (F5). The parameter parens are always present (possibly empty).
+type FunctionDeclaration struct {
+	Name       *ast.QualifiedName
+	Parameters []ParameterDeclaration
+	Loc        ast.Loc
+}
+
+// RoutineCharacteristicKind identifies which routineCharacteristic alternative a
+// RoutineCharacteristic represents.
+type RoutineCharacteristicKind int
+
+const (
+	// CharacteristicLanguage is `LANGUAGE identifier`.
+	CharacteristicLanguage RoutineCharacteristicKind = iota
+	// CharacteristicDeterministic is `DETERMINISTIC`.
+	CharacteristicDeterministic
+	// CharacteristicNotDeterministic is `NOT DETERMINISTIC`.
+	CharacteristicNotDeterministic
+	// CharacteristicReturnsNullOnNullInput is `RETURNS NULL ON NULL INPUT`.
+	CharacteristicReturnsNullOnNullInput
+	// CharacteristicCalledOnNullInput is `CALLED ON NULL INPUT`.
+	CharacteristicCalledOnNullInput
+	// CharacteristicSecurityDefiner is `SECURITY DEFINER`.
+	CharacteristicSecurityDefiner
+	// CharacteristicSecurityInvoker is `SECURITY INVOKER`.
+	CharacteristicSecurityInvoker
+	// CharacteristicComment is `COMMENT string`.
+	CharacteristicComment
+	// CharacteristicProperties is `WITH ( property = expr, … )` (F4 — a
+	// docs-ahead-of-legacy extension flagged in the divergence ledger).
+	CharacteristicProperties
+)
+
+// RoutineProperty is one `name = expression` entry of a WITH (...) properties
+// characteristic (F4). Name is a single identifier (quoted allowed); Value is a
+// full expression.
+type RoutineProperty struct {
+	Name  *ast.Identifier
+	Value Expr
+	Loc   ast.Loc
+}
+
+// RoutineCharacteristic is one routineCharacteristic. Only the fields relevant
+// to Kind are populated: Language (CharacteristicLanguage), Comment
+// (CharacteristicComment), or Properties (CharacteristicProperties). The
+// remaining kinds are keyword-only and carry no payload.
+type RoutineCharacteristic struct {
+	Kind       RoutineCharacteristicKind
+	Language   *ast.Identifier   // CharacteristicLanguage
+	Comment    Expr              // CharacteristicComment (a string literal expression)
+	Properties []RoutineProperty // CharacteristicProperties
+	Loc        ast.Loc
+}
+
+// FunctionSpecification is
+// `FUNCTION functionDeclaration returnsClause routineCharacteristic* controlStatement`
+// — the function body shared by CREATE FUNCTION and WITH FUNCTION.
+type FunctionSpecification struct {
+	Declaration     FunctionDeclaration
+	ReturnType      *DataType               // the RETURNS type
+	Characteristics []RoutineCharacteristic // nil when none
+	Body            RoutineStatement        // the trailing controlStatement (RETURN / BEGIN / …)
+	Loc             ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FUNCTION
+// ---------------------------------------------------------------------------
+
+// CreateFunctionStmt is `CREATE [OR REPLACE] functionSpecification`
+// (createFunction). OrReplace is true for the OR REPLACE form.
+type CreateFunctionStmt struct {
+	OrReplace bool
+	Spec      FunctionSpecification
+	Loc       ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *CreateFunctionStmt) Tag() ast.NodeTag { return ast.T_CreateFunctionStmt }
+
+// Span returns the source byte range.
+func (s *CreateFunctionStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*CreateFunctionStmt)(nil)
+
+// createOrReplaceFunctionFollows reports whether a `CREATE OR REPLACE …` is the
+// FUNCTION variant (`CREATE OR REPLACE FUNCTION …`) rather than a parser-ddl
+// OR-REPLACE object (TABLE / VIEW / MATERIALIZED VIEW). On entry cur is CREATE
+// and peekNext is OR. It speculatively consumes CREATE OR REPLACE via a
+// checkpoint — the parser's two-token window cannot otherwise see the keyword
+// after OR REPLACE — and rewinds, leaving the cursor unchanged. A malformed
+// `CREATE OR <not-REPLACE>` returns false so the dispatcher falls through (the
+// real error surfaces later from whatever claims it).
+func (p *Parser) createOrReplaceFunctionFollows() bool {
+	cp := p.checkpoint()
+	defer p.restore(cp)
+	p.advance() // consume CREATE
+	if p.cur.Kind != kwOR {
+		return false
+	}
+	p.advance() // consume OR
+	if p.cur.Kind != kwREPLACE {
+		return false
+	}
+	p.advance() // consume REPLACE
+	return p.cur.Kind == kwFUNCTION
+}
+
+// parseCreateFunctionStmt parses `CREATE [OR REPLACE] functionSpecification`.
+// The CREATE keyword has already been consumed by the dispatcher; createStart is
+// its start offset, and the current token is either OR or FUNCTION.
+func (p *Parser) parseCreateFunctionStmt(createStart int) (ast.Node, error) {
+	s := &CreateFunctionStmt{Loc: ast.Loc{Start: createStart}}
+	if p.cur.Kind == kwOR {
+		p.advance() // consume OR
+		if _, err := p.expect(kwREPLACE); err != nil {
+			return nil, err
+		}
+		s.OrReplace = true
+	}
+	spec, err := p.parseFunctionSpecification()
+	if err != nil {
+		return nil, err
+	}
+	s.Spec = spec
+	s.Loc.End = spec.Loc.End
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// DROP FUNCTION
+// ---------------------------------------------------------------------------
+
+// DropFunctionStmt is `DROP FUNCTION [IF EXISTS] functionDeclaration`
+// (dropFunction, F5). IfExists is true for the IF EXISTS form.
+type DropFunctionStmt struct {
+	IfExists    bool
+	Declaration FunctionDeclaration
+	Loc         ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *DropFunctionStmt) Tag() ast.NodeTag { return ast.T_DropFunctionStmt }
+
+// Span returns the source byte range.
+func (s *DropFunctionStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*DropFunctionStmt)(nil)
+
+// parseDropFunctionStmt parses `DROP FUNCTION [IF EXISTS] functionDeclaration`.
+// The DROP and FUNCTION keywords have already been consumed by the dispatcher;
+// dropStart is DROP's start offset and the current token is IF or the
+// declaration's qualified name.
+func (p *Parser) parseDropFunctionStmt(dropStart int) (ast.Node, error) {
+	s := &DropFunctionStmt{Loc: ast.Loc{Start: dropStart}}
+	if p.cur.Kind == kwIF {
+		p.advance() // consume IF
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		s.IfExists = true
+	}
+	decl, err := p.parseFunctionDeclaration()
+	if err != nil {
+		return nil, err
+	}
+	s.Declaration = decl
+	s.Loc.End = decl.Loc.End
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// WITH FUNCTION (inline routine prefix on a query)
+// ---------------------------------------------------------------------------
+
+// WithFunctionStmt is `WITH functionSpecification (, functionSpecification)* query`
+// (the withFunction rule on rootQuery, F6). Functions is the non-empty list of
+// inline routine definitions; Query is the trailing query that may call them.
+type WithFunctionStmt struct {
+	Functions []FunctionSpecification
+	Query     *Query
+	Loc       ast.Loc
+}
+
+// Tag implements ast.Node.
+func (s *WithFunctionStmt) Tag() ast.NodeTag { return ast.T_WithFunctionStmt }
+
+// Span returns the source byte range.
+func (s *WithFunctionStmt) Span() ast.Loc { return s.Loc }
+
+var _ ast.Node = (*WithFunctionStmt)(nil)
+
+// parseWithFunctionQuery parses `WITH functionSpecification (, functionSpecification)* query`
+// (withFunction). WITH is the current token and the caller (parseQuery in
+// select.go) has already confirmed FUNCTION follows it. Returns a
+// *WithFunctionStmt wrapping the inline routines and the trailing query.
+func (p *Parser) parseWithFunctionQuery() (ast.Node, error) {
+	withTok := p.advance() // consume WITH
+	s := &WithFunctionStmt{Loc: ast.Loc{Start: withTok.Loc.Start}}
+
+	first, err := p.parseFunctionSpecification()
+	if err != nil {
+		return nil, err
+	}
+	s.Functions = append(s.Functions, first)
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseFunctionSpecification()
+		if err != nil {
+			return nil, err
+		}
+		s.Functions = append(s.Functions, next)
+	}
+
+	// The trailing query (which may itself begin with a CTE `WITH`, F6).
+	q, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	s.Query = q
+	s.Loc.End = q.Loc.End
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// functionSpecification / functionDeclaration / characteristics
+// ---------------------------------------------------------------------------
+
+// parseFunctionSpecification parses
+// `FUNCTION functionDeclaration returnsClause routineCharacteristic* controlStatement`.
+// FUNCTION is the current token.
+func (p *Parser) parseFunctionSpecification() (FunctionSpecification, error) {
+	funcTok, err := p.expect(kwFUNCTION)
+	if err != nil {
+		return FunctionSpecification{}, err
+	}
+	spec := FunctionSpecification{Loc: ast.Loc{Start: funcTok.Loc.Start, End: funcTok.Loc.End}}
+
+	decl, err := p.parseFunctionDeclaration()
+	if err != nil {
+		return FunctionSpecification{}, err
+	}
+	spec.Declaration = decl
+
+	// returnsClause: RETURNS type.
+	if _, err := p.expect(kwRETURNS); err != nil {
+		return FunctionSpecification{}, err
+	}
+	retType, err := p.parseType()
+	if err != nil {
+		return FunctionSpecification{}, err
+	}
+	spec.ReturnType = retType
+
+	// routineCharacteristic* (F3 — unordered, repeatable).
+	for {
+		ch, ok, err := p.tryParseRoutineCharacteristic()
+		if err != nil {
+			return FunctionSpecification{}, err
+		}
+		if !ok {
+			break
+		}
+		spec.Characteristics = append(spec.Characteristics, ch)
+	}
+
+	// controlStatement (the trailing body — RETURN / BEGIN / IF / …).
+	body, err := p.parseRoutineStatement()
+	if err != nil {
+		return FunctionSpecification{}, err
+	}
+	spec.Body = body
+	spec.Loc.End = body.Span().End
+	return spec, nil
+}
+
+// parseFunctionDeclaration parses
+// `qualifiedName ( (parameterDeclaration (, parameterDeclaration)*)? )` (F2, F5).
+// The qualified name is the current token; the parameter parens are mandatory
+// (possibly empty).
+func (p *Parser) parseFunctionDeclaration() (FunctionDeclaration, error) {
+	name, err := p.parseQualifiedName()
+	if err != nil {
+		return FunctionDeclaration{}, err
+	}
+	decl := FunctionDeclaration{Name: name, Loc: ast.Loc{Start: name.Loc.Start, End: name.Loc.End}}
+
+	if _, err := p.expect(int('(')); err != nil {
+		return FunctionDeclaration{}, err
+	}
+	if p.cur.Kind != int(')') {
+		first, err := p.parseParameterDeclaration()
+		if err != nil {
+			return FunctionDeclaration{}, err
+		}
+		decl.Parameters = append(decl.Parameters, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseParameterDeclaration()
+			if err != nil {
+				return FunctionDeclaration{}, err
+			}
+			decl.Parameters = append(decl.Parameters, next)
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return FunctionDeclaration{}, err
+	}
+	decl.Loc.End = closeTok.Loc.End
+	return decl, nil
+}
+
+// parseParameterDeclaration parses one `identifier? type` parameter (F2). The
+// grammar is ambiguous between an unnamed `type` and a named `identifier type`:
+// a parameter name is itself an identifier (and may be a non-reserved type
+// keyword — `f(comment bigint)` names a parameter `comment`), while a type can
+// be multi-token (DOUBLE PRECISION, TIME WITHOUT TIME ZONE, INTERVAL DAY TO
+// SECOND, t ARRAY[5], ARRAY(int)). Two tokens of lookahead cannot resolve every
+// case (`f(double precision)` is one unnamed DOUBLE PRECISION type, but
+// `f(x double)` names a parameter `x` of type DOUBLE — the deciding token comes
+// after the second), so this mirrors parseRowField's speculative resolution.
+//
+// Resolution follows ANTLR's alternative order. The `identifier?` is optional,
+// so the no-name reading is tried first: parse a single type and keep it if it
+// lands exactly on a parameter boundary (',' or ')'). Only if that does not fit
+// is the named form `identifier type` tried (consume a one-token name, then a
+// full type, again requiring a clean boundary). Each attempt rewinds on failure
+// via a parser/lexer checkpoint. This accepts every Trino-481 form — type-only
+// (`bigint`, `double precision`, `interval day to second`, `ROW(a int)`),
+// named (`x bigint`, `comment bigint`, `x double precision`), and quoted-name
+// (`"my x" bigint`) — matching the oracle.
+func (p *Parser) parseParameterDeclaration() (ParameterDeclaration, error) {
+	start := p.cur.Loc.Start
+
+	// Attempt 1 — unnamed `type` (the `identifier?` is absent).
+	cp := p.checkpoint()
+	if typ, err := p.parseType(); err == nil && p.atParameterBoundary() {
+		return ParameterDeclaration{Type: typ, Loc: ast.Loc{Start: start, End: typ.Loc.End}}, nil
+	}
+	p.restore(cp)
+
+	// Attempt 2 — named `identifier type`. The name is a single identifier
+	// token; the type follows and must reach a parameter boundary.
+	if isIdentifierStart(p.cur.Kind) {
+		name := identFromToken(p.advance())
+		if typ, err := p.parseType(); err == nil && p.atParameterBoundary() {
+			return ParameterDeclaration{
+				Name: name,
+				Type: typ,
+				Loc:  ast.Loc{Start: start, End: typ.Loc.End},
+			}, nil
+		}
+		p.restore(cp)
+	}
+
+	// Neither reading fits: report the error at the parameter's first token.
+	return ParameterDeclaration{}, p.syntaxErrorAtCur()
+}
+
+// atParameterBoundary reports whether the cursor sits at the end of a
+// parameterDeclaration (a ',' before the next parameter or the closing ')').
+func (p *Parser) atParameterBoundary() bool {
+	return p.cur.Kind == int(',') || p.cur.Kind == int(')')
+}
+
+// tryParseRoutineCharacteristic parses one routineCharacteristic if the current
+// token begins one, returning ok == false (and consuming nothing) otherwise so
+// the caller's loop can stop and fall through to the controlStatement body.
+func (p *Parser) tryParseRoutineCharacteristic() (RoutineCharacteristic, bool, error) {
+	start := p.cur.Loc.Start
+	switch p.cur.Kind {
+	case kwLANGUAGE:
+		p.advance() // consume LANGUAGE
+		lang, err := p.parseIdentifier()
+		if err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		return RoutineCharacteristic{
+			Kind:     CharacteristicLanguage,
+			Language: lang,
+			Loc:      ast.Loc{Start: start, End: lang.Loc.End},
+		}, true, nil
+
+	case kwNOT:
+		p.advance() // consume NOT
+		detTok, err := p.expect(kwDETERMINISTIC)
+		if err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		return RoutineCharacteristic{
+			Kind: CharacteristicNotDeterministic,
+			Loc:  ast.Loc{Start: start, End: detTok.Loc.End},
+		}, true, nil
+
+	case kwDETERMINISTIC:
+		detTok := p.advance() // consume DETERMINISTIC
+		return RoutineCharacteristic{
+			Kind: CharacteristicDeterministic,
+			Loc:  ast.Loc{Start: start, End: detTok.Loc.End},
+		}, true, nil
+
+	case kwRETURNS:
+		// RETURNS NULL ON NULL INPUT. (The functionSpecification's own RETURNS
+		// type clause has already been consumed before the characteristic loop,
+		// so a RETURNS here is unambiguously the null-input characteristic.)
+		p.advance() // consume RETURNS
+		if _, err := p.expect(kwNULL); err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		if _, err := p.expect(kwON); err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		if _, err := p.expect(kwNULL); err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		inputTok, err := p.expect(kwINPUT)
+		if err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		return RoutineCharacteristic{
+			Kind: CharacteristicReturnsNullOnNullInput,
+			Loc:  ast.Loc{Start: start, End: inputTok.Loc.End},
+		}, true, nil
+
+	case kwCALLED:
+		p.advance() // consume CALLED
+		if _, err := p.expect(kwON); err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		if _, err := p.expect(kwNULL); err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		inputTok, err := p.expect(kwINPUT)
+		if err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		return RoutineCharacteristic{
+			Kind: CharacteristicCalledOnNullInput,
+			Loc:  ast.Loc{Start: start, End: inputTok.Loc.End},
+		}, true, nil
+
+	case kwSECURITY:
+		p.advance() // consume SECURITY
+		switch p.cur.Kind {
+		case kwDEFINER:
+			defTok := p.advance()
+			return RoutineCharacteristic{
+				Kind: CharacteristicSecurityDefiner,
+				Loc:  ast.Loc{Start: start, End: defTok.Loc.End},
+			}, true, nil
+		case kwINVOKER:
+			invTok := p.advance()
+			return RoutineCharacteristic{
+				Kind: CharacteristicSecurityInvoker,
+				Loc:  ast.Loc{Start: start, End: invTok.Loc.End},
+			}, true, nil
+		default:
+			return RoutineCharacteristic{}, false, p.syntaxErrorAtCur()
+		}
+
+	case kwCOMMENT:
+		p.advance() // consume COMMENT
+		// The grammar's commentCharacteristic is `COMMENT string_` — a STRING
+		// literal specifically, NOT an arbitrary expression. Trino 481 rejects a
+		// non-string COMMENT (`COMMENT 42`, `COMMENT foo`) with a SYNTAX_ERROR, so
+		// only a basic or unicode string token is accepted here.
+		if p.cur.Kind != tokString && p.cur.Kind != tokUnicodeString {
+			return RoutineCharacteristic{}, false, p.syntaxErrorAtCur()
+		}
+		comment, err := p.parseStringLiteral()
+		if err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		return RoutineCharacteristic{
+			Kind:    CharacteristicComment,
+			Comment: comment,
+			Loc:     ast.Loc{Start: start, End: comment.Span().End},
+		}, true, nil
+
+	case kwWITH:
+		// F4: WITH ( property = expr, … ) — a docs-ahead-of-legacy properties
+		// characteristic (flagged divergence). At least one property is required
+		// (`WITH ()` is rejected by Trino 481).
+		props, end, err := p.parseRoutineProperties()
+		if err != nil {
+			return RoutineCharacteristic{}, false, err
+		}
+		return RoutineCharacteristic{
+			Kind:       CharacteristicProperties,
+			Properties: props,
+			Loc:        ast.Loc{Start: start, End: end},
+		}, true, nil
+
+	default:
+		return RoutineCharacteristic{}, false, nil
+	}
+}
+
+// parseRoutineProperties parses `WITH ( property (, property)* )` where each
+// property is `name = expression` (F4). WITH is the current token. Returns the
+// property list and the end offset (the closing ')'). An empty list is a syntax
+// error (Trino 481 rejects `WITH ()`).
+func (p *Parser) parseRoutineProperties() ([]RoutineProperty, int, error) {
+	p.advance() // consume WITH
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+	first, err := p.parseRoutineProperty()
+	if err != nil {
+		return nil, 0, err
+	}
+	props := []RoutineProperty{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseRoutineProperty()
+		if err != nil {
+			return nil, 0, err
+		}
+		props = append(props, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+	return props, closeTok.Loc.End, nil
+}
+
+// parseRoutineProperty parses one `name = expression` property entry (F4). Name
+// is a single identifier (quoted allowed); value is a full expression.
+func (p *Parser) parseRoutineProperty() (RoutineProperty, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return RoutineProperty{}, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return RoutineProperty{}, err
+	}
+	val, err := p.parseExpr()
+	if err != nil {
+		return RoutineProperty{}, err
+	}
+	return RoutineProperty{
+		Name:  name,
+		Value: val,
+		Loc:   ast.Loc{Start: name.Loc.Start, End: val.Span().End},
+	}, nil
+}

--- a/trino/parser/function_def_test.go
+++ b/trino/parser/function_def_test.go
@@ -1,0 +1,283 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the structural (Layer 2) gate for the parser-routines node's
+// statement shells — CREATE FUNCTION, DROP FUNCTION, and the WITH FUNCTION
+// inline-routine prefix (function_def.go). Accept/reject alone does not catch a
+// form that "accepts" but parses into the wrong node shape (OR REPLACE flag, the
+// parameter name/type split, the characteristic list, IF EXISTS, the inline
+// function count). These tests pin the parse-node fields of one representative
+// per alternative. The authoritative accept/reject differential against the live
+// Trino 481 oracle lives in oracle_routines_test.go.
+
+func TestRoutines_StructureCreateFunction(t *testing.T) {
+	t.Run("minimal_return", func(t *testing.T) {
+		s, ok := parseOneStmt(t, "CREATE FUNCTION meaning_of_life() RETURNS bigint RETURN 42").(*CreateFunctionStmt)
+		if !ok {
+			t.Fatalf("not a *CreateFunctionStmt")
+		}
+		if s.OrReplace {
+			t.Errorf("OrReplace = true, want false")
+		}
+		if got := s.Spec.Declaration.Name.Normalize(); got != "meaning_of_life" {
+			t.Errorf("name = %q, want meaning_of_life", got)
+		}
+		if n := len(s.Spec.Declaration.Parameters); n != 0 {
+			t.Errorf("params = %d, want 0", n)
+		}
+		if s.Spec.ReturnType == nil || s.Spec.ReturnType.Name != "bigint" {
+			t.Errorf("return type = %v, want bigint", s.Spec.ReturnType)
+		}
+		if _, ok := s.Spec.Body.(*ReturnStatement); !ok {
+			t.Errorf("body = %T, want *ReturnStatement", s.Spec.Body)
+		}
+	})
+
+	t.Run("or_replace_qualified_name", func(t *testing.T) {
+		s := parseOneStmt(t, "CREATE OR REPLACE FUNCTION example.default.f(x bigint) RETURNS bigint RETURN x * x").(*CreateFunctionStmt)
+		if !s.OrReplace {
+			t.Errorf("OrReplace = false, want true")
+		}
+		if got := s.Spec.Declaration.Name.Normalize(); got != "example.default.f" {
+			t.Errorf("name = %q, want example.default.f", got)
+		}
+		if n := len(s.Spec.Declaration.Parameters); n != 1 {
+			t.Fatalf("params = %d, want 1", n)
+		}
+		p := s.Spec.Declaration.Parameters[0]
+		if p.Name == nil || p.Name.Normalize() != "x" {
+			t.Errorf("param[0] name = %v, want x", p.Name)
+		}
+		if p.Type == nil || p.Type.Name != "bigint" {
+			t.Errorf("param[0] type = %v, want bigint", p.Type)
+		}
+	})
+
+	t.Run("unnamed_and_mixed_parameters", func(t *testing.T) {
+		// F2: parameterDeclaration is `identifier? type`. A type-only parameter
+		// has a nil Name; a named one carries it.
+		s := parseOneStmt(t, "CREATE FUNCTION f(x bigint, varchar, z double) RETURNS bigint RETURN 1").(*CreateFunctionStmt)
+		params := s.Spec.Declaration.Parameters
+		if len(params) != 3 {
+			t.Fatalf("params = %d, want 3", len(params))
+		}
+		if params[0].Name == nil || params[0].Name.Normalize() != "x" {
+			t.Errorf("param[0] name = %v, want x", params[0].Name)
+		}
+		if params[1].Name != nil {
+			t.Errorf("param[1] name = %v, want nil (type-only)", params[1].Name)
+		}
+		if params[1].Type == nil || params[1].Type.Name != "varchar" {
+			t.Errorf("param[1] type = %v, want varchar", params[1].Type)
+		}
+		if params[2].Name == nil || params[2].Name.Normalize() != "z" {
+			t.Errorf("param[2] name = %v, want z", params[2].Name)
+		}
+	})
+
+	t.Run("multitoken_typeonly_parameters", func(t *testing.T) {
+		// Two tokens of lookahead cannot distinguish a type-only multi-token type
+		// (DOUBLE PRECISION, INTERVAL DAY TO SECOND) from a named parameter; the
+		// speculative resolution must read them as a single unnamed type (nil
+		// Name), not as name + truncated type.
+		for _, tc := range []struct {
+			sql      string
+			wantType string
+		}{
+			{"CREATE FUNCTION f(double precision) RETURNS int RETURN 1", "DOUBLE PRECISION"},
+			{"CREATE FUNCTION f(interval day to second) RETURNS int RETURN 1", "INTERVAL"},
+		} {
+			s := parseOneStmt(t, tc.sql).(*CreateFunctionStmt)
+			ps := s.Spec.Declaration.Parameters
+			if len(ps) != 1 {
+				t.Fatalf("%q: params = %d, want 1", tc.sql, len(ps))
+			}
+			if ps[0].Name != nil {
+				t.Errorf("%q: param name = %v, want nil (type-only)", tc.sql, ps[0].Name)
+			}
+			if ps[0].Type == nil || ps[0].Type.Name != tc.wantType {
+				t.Errorf("%q: param type = %v, want %s", tc.sql, ps[0].Type, tc.wantType)
+			}
+		}
+	})
+
+	t.Run("nonreserved_keyword_parameter_name", func(t *testing.T) {
+		// A non-reserved keyword (COMMENT) is a valid parameter NAME when a type
+		// follows it.
+		s := parseOneStmt(t, "CREATE FUNCTION f(comment bigint) RETURNS int RETURN 1").(*CreateFunctionStmt)
+		ps := s.Spec.Declaration.Parameters
+		if len(ps) != 1 || ps[0].Name == nil || ps[0].Name.Normalize() != "comment" {
+			t.Errorf("param name = %v, want comment", ps[0].Name)
+		}
+		if ps[0].Type == nil || ps[0].Type.Name != "bigint" {
+			t.Errorf("param type = %v, want bigint", ps[0].Type)
+		}
+	})
+
+	t.Run("all_keyword_characteristics", func(t *testing.T) {
+		// F3: a representative full characteristic list (each keyword-only form
+		// plus LANGUAGE and COMMENT) parses into the kinds in source order.
+		s := parseOneStmt(t, "CREATE FUNCTION f(x bigint) RETURNS bigint LANGUAGE SQL DETERMINISTIC RETURNS NULL ON NULL INPUT SECURITY DEFINER COMMENT 'doc' RETURN x").(*CreateFunctionStmt)
+		chs := s.Spec.Characteristics
+		wantKinds := []RoutineCharacteristicKind{
+			CharacteristicLanguage,
+			CharacteristicDeterministic,
+			CharacteristicReturnsNullOnNullInput,
+			CharacteristicSecurityDefiner,
+			CharacteristicComment,
+		}
+		if len(chs) != len(wantKinds) {
+			t.Fatalf("characteristics = %d, want %d", len(chs), len(wantKinds))
+		}
+		for i, want := range wantKinds {
+			if chs[i].Kind != want {
+				t.Errorf("characteristic[%d] kind = %v, want %v", i, chs[i].Kind, want)
+			}
+		}
+		if chs[0].Language == nil || chs[0].Language.Normalize() != "sql" {
+			t.Errorf("LANGUAGE id = %v, want sql", chs[0].Language)
+		}
+	})
+
+	t.Run("not_deterministic_called_invoker", func(t *testing.T) {
+		s := parseOneStmt(t, "CREATE FUNCTION f(x bigint) RETURNS bigint NOT DETERMINISTIC CALLED ON NULL INPUT SECURITY INVOKER RETURN x").(*CreateFunctionStmt)
+		wantKinds := []RoutineCharacteristicKind{
+			CharacteristicNotDeterministic,
+			CharacteristicCalledOnNullInput,
+			CharacteristicSecurityInvoker,
+		}
+		chs := s.Spec.Characteristics
+		if len(chs) != len(wantKinds) {
+			t.Fatalf("characteristics = %d, want %d", len(chs), len(wantKinds))
+		}
+		for i, want := range wantKinds {
+			if chs[i].Kind != want {
+				t.Errorf("characteristic[%d] kind = %v, want %v", i, chs[i].Kind, want)
+			}
+		}
+	})
+
+	t.Run("properties_characteristic_docs_ahead", func(t *testing.T) {
+		// F4: WITH ( name = expr, ... ) — a docs-ahead-of-legacy characteristic
+		// (flagged divergence). Confirm it parses into a properties characteristic
+		// with the named entries.
+		s := parseOneStmt(t, "CREATE FUNCTION f() RETURNS int LANGUAGE PYTHON WITH (handler = 'x', other_prop = 1) RETURN 1").(*CreateFunctionStmt)
+		chs := s.Spec.Characteristics
+		if len(chs) != 2 {
+			t.Fatalf("characteristics = %d, want 2", len(chs))
+		}
+		if chs[1].Kind != CharacteristicProperties {
+			t.Fatalf("characteristic[1] kind = %v, want Properties", chs[1].Kind)
+		}
+		props := chs[1].Properties
+		if len(props) != 2 {
+			t.Fatalf("properties = %d, want 2", len(props))
+		}
+		if props[0].Name.Normalize() != "handler" {
+			t.Errorf("property[0] name = %q, want handler", props[0].Name.Normalize())
+		}
+		if props[1].Name.Normalize() != "other_prop" {
+			t.Errorf("property[1] name = %q, want other_prop", props[1].Name.Normalize())
+		}
+	})
+
+	t.Run("compound_body", func(t *testing.T) {
+		s := parseOneStmt(t, "CREATE FUNCTION f(x bigint) RETURNS bigint BEGIN DECLARE y bigint DEFAULT 0; SET y = x + 1; RETURN y; END").(*CreateFunctionStmt)
+		body, ok := s.Spec.Body.(*CompoundStatement)
+		if !ok {
+			t.Fatalf("body = %T, want *CompoundStatement", s.Spec.Body)
+		}
+		if len(body.Declarations) != 1 {
+			t.Errorf("declarations = %d, want 1", len(body.Declarations))
+		}
+		if len(body.Body) != 2 {
+			t.Errorf("body statements = %d, want 2", len(body.Body))
+		}
+	})
+}
+
+func TestRoutines_StructureDropFunction(t *testing.T) {
+	t.Run("with_param_types", func(t *testing.T) {
+		s, ok := parseOneStmt(t, "DROP FUNCTION multiply_by_two(bigint)").(*DropFunctionStmt)
+		if !ok {
+			t.Fatalf("not a *DropFunctionStmt")
+		}
+		if s.IfExists {
+			t.Errorf("IfExists = true, want false")
+		}
+		if got := s.Declaration.Name.Normalize(); got != "multiply_by_two" {
+			t.Errorf("name = %q, want multiply_by_two", got)
+		}
+		if len(s.Declaration.Parameters) != 1 {
+			t.Fatalf("params = %d, want 1", len(s.Declaration.Parameters))
+		}
+		if s.Declaration.Parameters[0].Type.Name != "bigint" {
+			t.Errorf("param[0] type = %v, want bigint", s.Declaration.Parameters[0].Type)
+		}
+	})
+
+	t.Run("if_exists_qualified", func(t *testing.T) {
+		s := parseOneStmt(t, "DROP FUNCTION IF EXISTS example.default.f(integer, varchar)").(*DropFunctionStmt)
+		if !s.IfExists {
+			t.Errorf("IfExists = false, want true")
+		}
+		if got := s.Declaration.Name.Normalize(); got != "example.default.f" {
+			t.Errorf("name = %q, want example.default.f", got)
+		}
+		if len(s.Declaration.Parameters) != 2 {
+			t.Errorf("params = %d, want 2", len(s.Declaration.Parameters))
+		}
+	})
+
+	t.Run("no_params", func(t *testing.T) {
+		s := parseOneStmt(t, "DROP FUNCTION meaning_of_life()").(*DropFunctionStmt)
+		if len(s.Declaration.Parameters) != 0 {
+			t.Errorf("params = %d, want 0", len(s.Declaration.Parameters))
+		}
+	})
+}
+
+func TestRoutines_StructureWithFunction(t *testing.T) {
+	t.Run("single_inline_function", func(t *testing.T) {
+		s, ok := parseOneStmt(t, "WITH FUNCTION f(x bigint) RETURNS bigint RETURN x + 1 SELECT f(10)").(*WithFunctionStmt)
+		if !ok {
+			t.Fatalf("not a *WithFunctionStmt")
+		}
+		if len(s.Functions) != 1 {
+			t.Fatalf("functions = %d, want 1", len(s.Functions))
+		}
+		if got := s.Functions[0].Declaration.Name.Normalize(); got != "f" {
+			t.Errorf("function name = %q, want f", got)
+		}
+		if s.Query == nil {
+			t.Errorf("Query = nil, want a parsed query")
+		}
+	})
+
+	t.Run("multiple_inline_functions", func(t *testing.T) {
+		s := parseOneStmt(t, "WITH FUNCTION a(x int) RETURNS int RETURN x, FUNCTION b(y int) RETURNS int RETURN y SELECT a(1), b(2)").(*WithFunctionStmt)
+		if len(s.Functions) != 2 {
+			t.Fatalf("functions = %d, want 2", len(s.Functions))
+		}
+		if s.Functions[0].Declaration.Name.Normalize() != "a" {
+			t.Errorf("function[0] = %q, want a", s.Functions[0].Declaration.Name.Normalize())
+		}
+		if s.Functions[1].Declaration.Name.Normalize() != "b" {
+			t.Errorf("function[1] = %q, want b", s.Functions[1].Declaration.Name.Normalize())
+		}
+	})
+
+	t.Run("inline_function_then_cte", func(t *testing.T) {
+		// F6: a CTE WITH may still follow the inline routines.
+		s := parseOneStmt(t, "WITH FUNCTION f(x int) RETURNS int RETURN x WITH t AS (SELECT 1 AS c) SELECT f(c) FROM t").(*WithFunctionStmt)
+		if len(s.Functions) != 1 {
+			t.Fatalf("functions = %d, want 1", len(s.Functions))
+		}
+		if s.Query == nil || s.Query.With == nil {
+			t.Errorf("trailing query CTE = nil, want a WITH clause")
+		}
+	})
+}

--- a/trino/parser/oracle_routines_test.go
+++ b/trino/parser/oracle_routines_test.go
@@ -1,0 +1,228 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-routines node's differential-oracle gate
+// (correctness-protocol.md): for every statement in the corpus below, omni's
+// Parse accept/reject verdict must equal Trino 481's verdict as reported by the
+// live oracle (trinooracle.CheckSyntax, which classifies a SYNTAX_ERROR as
+// reject and every other outcome — success or a semantic error like
+// NOT_SUPPORTED / FUNCTION_NOT_FOUND / TYPE_MISMATCH — as accept). Most
+// CREATE/DROP FUNCTION forms fail at execution with NOT_SUPPORTED (the disposable
+// `memory` connector cannot store a UDF), which the oracle correctly classifies
+// as ACCEPTED — the parser+analyzer succeeded.
+//
+// The corpus is NOT split into hardcoded accept/reject lists: the oracle is the
+// source of truth, so each case is run through both omni and Trino and the two
+// verdicts are compared. This both proves correctness and documents which
+// docs/legacy forms Trino 481 actually accepts. It covers every documented form
+// (truth1 create-function / drop-function), every legacy controlStatement and
+// routineCharacteristic alternative (truth2), the oracle-confirmed docs-ahead
+// WITH (properties) characteristic (the flagged divergence), and a set of
+// negative forms that pin the grammar distinctions (RETURN takes a
+// valueExpression not a boolean; ITERATE/LEAVE require a label; DECLARE precede
+// statements; labels only on LOOP/WHILE/REPEAT; sqlStatementList ';'-termination).
+//
+// Skipped cleanly when no Trino oracle is reachable.
+
+// routinesOracleCorpus is the full SQL-routine corpus for the differential gate.
+// Each string is fed to both omni and the oracle; the verdicts must match.
+//
+// NOTE: statements carry NO trailing ';'. omni's Parse runs Split first (which
+// strips a trailing ';'), while the oracle receives the raw string over the REST
+// API and rejects an embedded extra ';'; omitting it keeps the two comparable
+// (it is how the real pipeline compares, and matches the merged dcl-tcl / utility
+// corpora).
+var routinesOracleCorpus = []string{
+	// ---------------------------------------------------------------------
+	// CREATE FUNCTION — minimal & docs (truth1 create-function)
+	// ---------------------------------------------------------------------
+	"CREATE FUNCTION meaning_of_life() RETURNS bigint RETURN 42",
+	"CREATE FUNCTION example.default.meaning_of_life() RETURNS bigint BEGIN RETURN 42; END",
+	"CREATE FUNCTION my.func(x integer) RETURNS integer RETURN x + 1",
+	"CREATE OR REPLACE FUNCTION f(x bigint) RETURNS bigint RETURN x * x",
+
+	// ---------------------------------------------------------------------
+	// parameterDeclaration (F2): named / type-only / mixed / complex types
+	// ---------------------------------------------------------------------
+	"CREATE FUNCTION f(bigint) RETURNS bigint RETURN 1",
+	"CREATE FUNCTION f(x bigint, varchar, z double) RETURNS bigint RETURN 1",
+	"CREATE FUNCTION f(x ROW(a int, b int)) RETURNS int RETURN 1",
+	"CREATE FUNCTION f(x ARRAY(int)) RETURNS int RETURN 1",
+	"CREATE FUNCTION f(x DECIMAL(10, 2)) RETURNS int RETURN 1",
+	"CREATE FUNCTION f(x timestamp(3) with time zone) RETURNS int RETURN 1",
+	// Multi-token type-only params: two tokens of lookahead cannot tell these
+	// apart from a named param, so they exercise the speculative resolution
+	// (parseParameterDeclaration tries unnamed-type-first, then named).
+	"CREATE FUNCTION f(double precision) RETURNS int RETURN 1",       // type-only DOUBLE PRECISION
+	"CREATE FUNCTION f(x double precision) RETURNS int RETURN 1",     // named, DOUBLE PRECISION type
+	"CREATE FUNCTION f(interval day to second) RETURNS int RETURN 1", // type-only INTERVAL DAY TO SECOND
+	"CREATE FUNCTION f(comment bigint) RETURNS int RETURN 1",         // non-reserved keyword as a param name
+	`CREATE FUNCTION f("my x" bigint) RETURNS int RETURN 1`,          // quoted param name
+	"CREATE FUNCTION f() RETURNS varchar(10) RETURN 'x'",             // parameterized RETURNS type
+	"CREATE FUNCTION f() RETURNS array(int) RETURN ARRAY[1]",         // complex RETURNS type
+
+	// ---------------------------------------------------------------------
+	// routineCharacteristic (truth2): every alternative, order & repetition (F3)
+	// ---------------------------------------------------------------------
+	"CREATE FUNCTION f(x bigint) RETURNS bigint LANGUAGE SQL DETERMINISTIC RETURNS NULL ON NULL INPUT RETURN x",
+	"CREATE FUNCTION f(x bigint) RETURNS bigint NOT DETERMINISTIC CALLED ON NULL INPUT SECURITY DEFINER COMMENT 'doc' RETURN x",
+	"CREATE FUNCTION f(x bigint) RETURNS bigint SECURITY INVOKER RETURN x",
+	"CREATE FUNCTION f() RETURNS bigint COMMENT 'a' LANGUAGE SQL DETERMINISTIC RETURN 1",
+	"CREATE FUNCTION f() RETURNS bigint DETERMINISTIC DETERMINISTIC RETURN 1", // repeated (routineCharacteristic*)
+	"CREATE FUNCTION f() RETURNS bigint LANGUAGE PYTHON RETURN 1",
+	"CREATE FUNCTION f() RETURNS bigint COMMENT U&'doc' RETURN 1", // unicode string COMMENT (string_ covers U&'…')
+
+	// ---------------------------------------------------------------------
+	// WITH (properties) characteristic — docs-ahead-of-legacy (F4, flagged)
+	// ---------------------------------------------------------------------
+	"CREATE FUNCTION f() RETURNS int LANGUAGE PYTHON WITH (handler = 'myfunc') RETURN 1",
+	"CREATE FUNCTION f() RETURNS int WITH (handler = 'x') RETURN 1",
+	"CREATE FUNCTION f() RETURNS int WITH (a = 'str', b = 2.5, c = true) RETURN 1",
+	"CREATE FUNCTION f() RETURNS int WITH (a = ARRAY[1, 2]) RETURN 1",
+	`CREATE FUNCTION f() RETURNS int WITH ("quoted name" = 1) RETURN 1`,
+	"CREATE FUNCTION f() RETURNS int COMMENT 'x' WITH (a = 1) RETURN 1",
+	"CREATE FUNCTION f() RETURNS int DETERMINISTIC WITH (a = 1) WITH (b = 2) RETURN 1",
+
+	// ---------------------------------------------------------------------
+	// controlStatement bodies (truth2) — compound, declarations, assignment
+	// ---------------------------------------------------------------------
+	"CREATE FUNCTION f(x bigint) RETURNS bigint BEGIN DECLARE y bigint DEFAULT 0; SET y = x + 1; RETURN y; END",
+	"CREATE FUNCTION f() RETURNS bigint BEGIN RETURN 1; END",
+	"CREATE FUNCTION f() RETURNS bigint BEGIN DECLARE a, b int; SET a = 1; SET b = 2; RETURN a + b; END",
+	"CREATE FUNCTION f() RETURNS bigint BEGIN END",                      // empty compound (R6)
+	"CREATE FUNCTION f() RETURNS bigint BEGIN BEGIN RETURN 1; END; END", // nested
+	"CREATE FUNCTION f() RETURNS bigint BEGIN DECLARE x int; END",       // declares only (R6)
+	"CREATE FUNCTION f() RETURNS int BEGIN DECLARE x int DEFAULT 1 + 2 * 3; RETURN x; END",
+	"CREATE FUNCTION f() RETURNS int BEGIN DECLARE x int DEFAULT (SELECT 1); RETURN x; END",
+	"CREATE FUNCTION f(x int) RETURNS int BEGIN DECLARE y int; SET y = x IN (1, 2); RETURN y; END", // SET takes full expression (R2)
+
+	// IF / ELSEIF / ELSE
+	"CREATE FUNCTION f(x bigint) RETURNS bigint BEGIN IF x > 0 THEN RETURN 1; ELSEIF x < 0 THEN RETURN -1; ELSE RETURN 0; END IF; END",
+	"CREATE FUNCTION f(x bigint) RETURNS bigint BEGIN IF x > 0 THEN RETURN 1; END IF; RETURN 0; END",
+	"CREATE FUNCTION f(x int) RETURNS int BEGIN IF x IN (1, 2, 3) THEN RETURN 1; END IF; RETURN 0; END", // IF cond is full expression (R2)
+
+	// CASE (simple + searched)
+	"CREATE FUNCTION f(x bigint) RETURNS varchar BEGIN CASE x WHEN 1 THEN RETURN 'one'; WHEN 2 THEN RETURN 'two'; ELSE RETURN 'other'; END CASE; END",
+	"CREATE FUNCTION f(x bigint) RETURNS varchar BEGIN CASE WHEN x > 0 THEN RETURN 'pos'; ELSE RETURN 'neg'; END CASE; END",
+	"CREATE FUNCTION f(x int) RETURNS int BEGIN CASE x + 1 WHEN 2 THEN RETURN 1; END CASE; END",     // simple-case subject is an expression
+	"CREATE FUNCTION f(x int) RETURNS int BEGIN CASE WHEN x IN (1, 2) THEN RETURN 1; END CASE; END", // searched WHEN is full expression (R2)
+
+	// LOOP / WHILE / REPEAT with labels + ITERATE / LEAVE
+	"CREATE FUNCTION f(x bigint) RETURNS bigint BEGIN DECLARE i bigint DEFAULT 0; top: LOOP SET i = i + 1; IF i > 10 THEN LEAVE top; END IF; END LOOP; RETURN i; END",
+	"CREATE FUNCTION f(n bigint) RETURNS bigint BEGIN DECLARE i bigint DEFAULT 0; WHILE i < n DO SET i = i + 1; END WHILE; RETURN i; END",
+	"CREATE FUNCTION f(n bigint) RETURNS bigint BEGIN DECLARE i bigint DEFAULT 0; REPEAT SET i = i + 1; UNTIL i >= n END REPEAT; RETURN i; END",
+	"CREATE FUNCTION f() RETURNS bigint BEGIN DECLARE i bigint DEFAULT 0; abc: WHILE i < 10 DO SET i = i + 1; ITERATE abc; END WHILE; RETURN i; END",
+	"CREATE FUNCTION f() RETURNS bigint BEGIN LOOP RETURN 1; END LOOP; END", // unlabeled LOOP
+	"CREATE FUNCTION f() RETURNS bigint BEGIN WHILE true DO RETURN 1; END WHILE; RETURN 0; END",
+	"CREATE FUNCTION f(n int) RETURNS int BEGIN DECLARE i int DEFAULT 0; REPEAT SET i = i + 1; UNTIL i >= n AND i > 0 END REPEAT; RETURN i; END", // UNTIL is full expression (R2)
+	"CREATE FUNCTION f() RETURNS int BEGIN DECLARE i int DEFAULT 0; lbl: REPEAT SET i = i + 1; UNTIL i > 3 END REPEAT; RETURN i; END",            // labeled REPEAT
+	// Label names that ARE non-reserved control keywords: the label check must
+	// precede the keyword dispatch (Trino accepts `loop:` / `while:` / `set:`).
+	"CREATE FUNCTION f() RETURNS int BEGIN loop: LOOP LEAVE loop; END LOOP; RETURN 1; END",
+	"CREATE FUNCTION f() RETURNS int BEGIN while: LOOP LEAVE while; END LOOP; RETURN 1; END",
+	"CREATE FUNCTION f() RETURNS int BEGIN set: WHILE true DO LEAVE set; END WHILE; RETURN 1; END",
+
+	// ---------------------------------------------------------------------
+	// DROP FUNCTION (truth1 drop-function, F5)
+	// ---------------------------------------------------------------------
+	"DROP FUNCTION f(bigint)",
+	"DROP FUNCTION IF EXISTS my.func(integer, varchar)",
+	"DROP FUNCTION meaning_of_life()",
+	"DROP FUNCTION example.default.f(bigint)",
+	"DROP FUNCTION f(x bigint)", // named parameter in drop (allowed)
+
+	// ---------------------------------------------------------------------
+	// WITH FUNCTION inline routines (rootQuery, F6)
+	// ---------------------------------------------------------------------
+	"WITH FUNCTION f(x bigint) RETURNS bigint RETURN x + 1 SELECT f(10)",
+	"WITH FUNCTION a(x int) RETURNS int RETURN x, FUNCTION b(y int) RETURNS int RETURN y SELECT a(1), b(2)",
+	"WITH FUNCTION f(x int) RETURNS int RETURN x WITH t AS (SELECT 1 AS c) SELECT f(c) FROM t",
+	"WITH FUNCTION f(x int) RETURNS int BEGIN RETURN x; END SELECT f(1)",
+	// EXPLAIN wraps any statement (it recurses into parseStmt), so it gains
+	// CREATE FUNCTION and WITH FUNCTION automatically.
+	"EXPLAIN CREATE FUNCTION f() RETURNS int RETURN 1",
+	"EXPLAIN WITH FUNCTION f(x int) RETURNS int RETURN x SELECT f(1)",
+	// deeply nested control flow (IF within IF within a compound)
+	"CREATE FUNCTION f(x int) RETURNS int BEGIN IF x > 0 THEN IF x > 5 THEN RETURN 2; END IF; RETURN 1; END IF; RETURN 0; END",
+
+	// ---------------------------------------------------------------------
+	// NEGATIVES — grammar distinctions the parser MUST reject
+	// ---------------------------------------------------------------------
+	// R1: RETURN / DECLARE DEFAULT take a valueExpression, not a boolean/predicate.
+	"CREATE FUNCTION f(x int) RETURNS boolean RETURN x IN (1, 2, 3)",
+	"CREATE FUNCTION f(x int) RETURNS boolean RETURN x > 0 AND x < 10",
+	"CREATE FUNCTION f(x int) RETURNS boolean RETURN x BETWEEN 1 AND 10",
+	"CREATE FUNCTION f() RETURNS int BEGIN DECLARE x boolean DEFAULT 1 IN (1, 2); RETURN 1; END",
+	"CREATE FUNCTION f() RETURNS boolean BEGIN DECLARE x boolean DEFAULT true AND false; RETURN x; END",
+	// missing pieces
+	"CREATE FUNCTION f() RETURNS bigint RETURN",                                     // RETURN needs an expression
+	"CREATE FUNCTION f() RETURN 1",                                                  // missing RETURNS type
+	"CREATE FUNCTION f() RETURNS bigint",                                            // missing controlStatement body
+	"CREATE FUNCTION RETURNS bigint RETURN 1",                                       // missing function name
+	"CREATE FUNCTION f() RETURNS bigint BEGIN RETURN 1 END",                         // R7: missing ';' after RETURN
+	"CREATE FUNCTION f() RETURNS bigint BEGIN IF true THEN RETURN 1; END; END",      // END IF required, not END
+	"CREATE FUNCTION f() RETURNS int BEGIN SET x = 1; DECLARE y int; RETURN y; END", // R6: DECLARE must precede
+	// R3: assignment target is a single identifier
+	"CREATE FUNCTION f() RETURNS int BEGIN DECLARE x int; SET x.y = 1; RETURN x; END",
+	// R5: labels only on LOOP / WHILE / REPEAT, not compound
+	"CREATE FUNCTION f() RETURNS int BEGIN lbl: BEGIN RETURN 1; END; END",
+	// R4: ITERATE / LEAVE require a label
+	"CREATE FUNCTION f() RETURNS bigint BEGIN LOOP LEAVE; END LOOP; RETURN 1; END",
+	"CREATE FUNCTION f() RETURNS bigint BEGIN LOOP ITERATE; END LOOP; RETURN 1; END",
+	// commentCharacteristic is `COMMENT string_` — a non-string is rejected.
+	"CREATE FUNCTION f() RETURNS int COMMENT 42 RETURN 1",
+	"CREATE FUNCTION f() RETURNS int COMMENT foo RETURN 1",
+	// languageCharacteristic is `LANGUAGE identifier` — a string is rejected.
+	"CREATE FUNCTION f() RETURNS int LANGUAGE 'sql' RETURN 1",
+	// securityCharacteristic value is the closed set { DEFINER, INVOKER }.
+	"CREATE FUNCTION f() RETURNS int SECURITY PUBLIC RETURN 1",
+	// no standalone functionSpecification at statement level
+	"FUNCTION f() RETURNS int RETURN 1",
+	// DROP FUNCTION needs the (possibly empty) parameter parens / a complete IF EXISTS.
+	"DROP FUNCTION f",
+	"DROP FUNCTION IF f(int)",
+	// WITH FUNCTION must be followed by a query; a dangling comma is invalid.
+	"WITH FUNCTION f(x int) RETURNS int RETURN x",
+	"WITH FUNCTION f(x int) RETURNS int RETURN x, SELECT 1",
+	// F4 negative: empty WITH () rejected
+	"CREATE FUNCTION f() RETURNS int WITH () RETURN 1",
+	// WITH FUNCTION is rootQuery-only. A relation/FROM subquery is parsed via
+	// parseQuery (relation.go), which rejects a leading WITH FUNCTION — matching
+	// Trino. (A scalar subquery in the SELECT list, e.g.
+	// `SELECT (WITH FUNCTION … SELECT …)`, is NOT in this corpus: the expressions
+	// node captures expression-embedded subqueries as raw-text placeholders that
+	// it does not re-validate (expr.go B1), so omni accepts ANY content there
+	// — including syntactically invalid queries like
+	// `SELECT (SELECT a FROM t WHERE)`. That over-acceptance is a pre-existing
+	// limitation of the expression layer, not of this node, so adjudicating it
+	// here would be testing the wrong node.)
+	"SELECT * FROM (WITH FUNCTION f(x int) RETURNS int RETURN x SELECT f(1) AS c) t",
+}
+
+// TestRoutines_OracleDifferential is the authoritative accept/reject gate: omni's
+// Parse verdict must equal Trino 481's verdict for every corpus statement.
+func TestRoutines_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, sql := range routinesOracleCorpus {
+		sql := sql
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			omniAccepts := len(errs) == 0
+
+			trinoAccepts, ok := oracleAccepts(t, o, sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if omniAccepts != trinoAccepts {
+				t.Errorf("MISMATCH %q: omni accepts=%v (errs=%v), Trino accepts=%v",
+					sql, omniAccepts, errs, trinoAccepts)
+			}
+		})
+	}
+}

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -197,10 +197,20 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	switch p.cur.Kind {
 	// --- Query (rootQuery / queryPrimary leading tokens) ---
 	// SELECT / WITH / TABLE / VALUES / '(' all begin a query; parser-select's
-	// parseQueryStmt parses the whole query layer. (A leading `WITH FUNCTION`
-	// inline routine is the parser-routines node; parseQuery reports it as
-	// unsupported until that node lands.)
-	case kwSELECT, kwWITH, kwTABLE, kwVALUES, int('('):
+	// parseQueryStmt parses the whole query layer.
+	//
+	// A leading `WITH FUNCTION` is the rootQuery inline-routine prefix
+	// (parser-routines node, function_def.go), NOT a CTE. It is valid only at
+	// the statement level (and after EXPLAIN, which recurses into parseStmt) —
+	// Trino 481 REJECTS `WITH FUNCTION …` inside a subquery — so it is detected
+	// HERE and routed to parseWithFunctionQuery, while the subquery parseQuery
+	// path keeps rejecting it.
+	case kwWITH:
+		if p.peekNext().Kind == kwFUNCTION {
+			return p.parseWithFunctionQuery()
+		}
+		return p.parseQueryStmt()
+	case kwSELECT, kwTABLE, kwVALUES, int('('):
 		return p.parseQueryStmt()
 
 	// --- Session / catalog context ---
@@ -210,20 +220,38 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	// --- DDL ---
 	case kwCREATE:
 		// CREATE ROLE belongs to the parser-dcl-tcl node (grant_revoke.go);
-		// every other CREATE object is a parser-ddl concern (still stubbed).
+		// CREATE [OR REPLACE] FUNCTION is the parser-routines node
+		// (function_def.go); every other CREATE object is a parser-ddl concern
+		// (still stubbed).
 		if p.peekNext().Kind == kwROLE {
 			createTok := p.advance() // consume CREATE
 			p.advance()              // consume ROLE
 			return p.parseCreateRoleStmt(createTok.Loc.Start)
 		}
+		// CREATE FUNCTION (peekNext == FUNCTION) is this node's. CREATE OR
+		// REPLACE FUNCTION needs three-token lookahead (past OR REPLACE) to
+		// distinguish from CREATE OR REPLACE TABLE/VIEW/MATERIALIZED VIEW
+		// (parser-ddl), which exceeds the parser's two-token window; it is
+		// detected by createOrReplaceFunctionFollows, which peeks the raw input
+		// for the keyword after OR REPLACE without consuming.
+		if p.peekNext().Kind == kwFUNCTION || (p.peekNext().Kind == kwOR && p.createOrReplaceFunctionFollows()) {
+			createTok := p.advance() // consume CREATE
+			return p.parseCreateFunctionStmt(createTok.Loc.Start)
+		}
 		return p.unsupported("CREATE")
 	case kwDROP:
 		// DROP ROLE belongs to the parser-dcl-tcl node (grant_revoke.go);
-		// every other DROP object is a parser-ddl concern (still stubbed).
+		// DROP FUNCTION is the parser-routines node (function_def.go); every
+		// other DROP object is a parser-ddl concern (still stubbed).
 		if p.peekNext().Kind == kwROLE {
 			dropTok := p.advance() // consume DROP
 			p.advance()            // consume ROLE
 			return p.parseDropRoleStmt(dropTok.Loc.Start)
+		}
+		if p.peekNext().Kind == kwFUNCTION {
+			dropTok := p.advance() // consume DROP
+			p.advance()            // consume FUNCTION
+			return p.parseDropFunctionStmt(dropTok.Loc.Start)
 		}
 		return p.unsupported("DROP")
 	case kwALTER:

--- a/trino/parser/routine_body.go
+++ b/trino/parser/routine_body.go
@@ -1,0 +1,750 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the `parser-routines` DAG node (with function_def.go):
+// it implements the SQL-routine control-flow body language — the legacy
+// TrinoParser.g4 `controlStatement`, `caseStatementWhenClause`, `elseIfClause`,
+// `elseClause`, `variableDeclaration`, and `sqlStatementList` rules. The
+// CREATE/DROP/WITH FUNCTION statement shells live in function_def.go.
+//
+// A routine body is the `controlStatement` that follows the function signature
+// (functionSpecification = FUNCTION declaration returnsClause characteristic*
+// controlStatement). Its alternatives are:
+//
+//	RETURN valueExpression                                                   # returnStatement
+//	SET identifier = expression                                             # assignmentStatement
+//	CASE expression caseWhen+ elseClause? END CASE                          # simpleCaseStatement
+//	CASE caseWhen+ elseClause? END CASE                                     # searchedCaseStatement
+//	IF expression THEN sqlStatementList elseIfClause* elseClause? END IF    # ifStatement
+//	ITERATE identifier                                                      # iterateStatement
+//	LEAVE identifier                                                        # leaveStatement
+//	BEGIN (variableDeclaration ;)* sqlStatementList? END                    # compoundStatement
+//	(label:)? LOOP sqlStatementList END LOOP                                # loopStatement
+//	(label:)? WHILE expression DO sqlStatementList END WHILE                # whileStatement
+//	(label:)? REPEAT sqlStatementList UNTIL expression END REPEAT           # repeatStatement
+//
+//	caseStatementWhenClause : WHEN expression THEN sqlStatementList
+//	elseIfClause            : ELSEIF expression THEN sqlStatementList
+//	elseClause              : ELSE sqlStatementList
+//	variableDeclaration     : DECLARE identifier (, identifier)* type (DEFAULT valueExpression)?
+//	sqlStatementList        : (controlStatement ;)+
+//
+// As with expr.go / datatypes.go, the body-statement node types are
+// PARSER-PACKAGE types. They satisfy a parser-local RoutineStatement interface
+// (Span() marker) rather than ast.Node — exactly how Expr is a parser-local
+// interface — so no ast.NodeTag is minted for the inner control statements;
+// only the three top-level FUNCTION statement shells (function_def.go) get tags.
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed facts baked
+// in (see oracle_routines_test.go for the differential corpus):
+//
+//	R1 (RETURN takes a valueExpression, NOT a full expression). Trino 481
+//	   REJECTS `RETURN x IN (1,2,3)`, `RETURN x > 0 AND x < 10`, and
+//	   `RETURN x BETWEEN 1 AND 10` with SYNTAX_ERROR — a bare predicate / boolean
+//	   is not a valueExpression. parseRoutineStatement therefore calls
+//	   parseValueExpr (not parseExpr) for RETURN. Likewise DEFAULT in a DECLARE
+//	   is a valueExpression (`DECLARE x int DEFAULT 1 IN (1,2)` is rejected).
+//	R2 (SET / IF / WHILE / CASE / UNTIL take a full expression). The condition
+//	   positions DO accept predicates/booleans: `SET y = x IN (1,2)`,
+//	   `IF x IN (1,2,3) THEN …`, `WHILE x > 0 AND x < 10 DO …`,
+//	   `CASE WHEN x IN (1,2) THEN …`, `REPEAT … UNTIL i >= n AND i > 0 …` are all
+//	   accepted. Those positions call parseExpr.
+//	R3 (assignment target is a single identifier). `SET x = 1` is accepted but
+//	   `SET x.y = 1` is a SYNTAX_ERROR — the grammar is `SET identifier = …`, not
+//	   a qualifiedName. parseAssignmentStatement reads exactly one identifier.
+//	R4 (ITERATE / LEAVE require a label). `LEAVE;` and `ITERATE;` with no label
+//	   are SYNTAX_ERRORs in 481; the label identifier is mandatory.
+//	R5 (labels attach only to LOOP / WHILE / REPEAT). `BEGIN lbl: BEGIN … END; END`
+//	   is rejected — a `label:` prefix is NOT allowed on a compound statement.
+//	R6 (DECLARE precede statements; both optional). In a compound, every
+//	   variableDeclaration must come before the first sqlStatementList statement
+//	   (`BEGIN SET x=1; DECLARE y int; …` is rejected). Both the declaration block
+//	   and the statement list are optional: `BEGIN END` and `BEGIN DECLARE x int; END`
+//	   are both accepted.
+//	R7 (each statement in a sqlStatementList is terminated by ';'). Inside
+//	   BEGIN/IF/LOOP/WHILE/REPEAT bodies every controlStatement ends with ';'
+//	   (`BEGIN RETURN 1 END` — missing ';' — is rejected). The trailing
+//	   controlStatement of the whole functionSpecification (the RETURN/BEGIN form)
+//	   is NOT semicolon-terminated; that ';' belongs to the statement splitter.
+
+// RoutineStatement is one statement of a SQL-routine body — a `controlStatement`
+// grammar alternative. Like Expr it is a parser-local interface (no ast.NodeTag)
+// because routine statements are only ever embedded inside a FUNCTION shell.
+type RoutineStatement interface {
+	// Span returns the source byte range covered by the statement.
+	Span() ast.Loc
+	// routineStmtNode is a marker preventing unrelated types from satisfying
+	// the interface.
+	routineStmtNode()
+}
+
+// ---------------------------------------------------------------------------
+// RETURN
+// ---------------------------------------------------------------------------
+
+// ReturnStatement is `RETURN valueExpression` (R1). Value is the returned
+// value-expression (predicates/booleans are NOT permitted bare — they would be
+// a SYNTAX_ERROR; see R1).
+type ReturnStatement struct {
+	Value Expr
+	Loc   ast.Loc
+}
+
+func (s *ReturnStatement) Span() ast.Loc    { return s.Loc }
+func (s *ReturnStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*ReturnStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// SET (assignment)
+// ---------------------------------------------------------------------------
+
+// AssignmentStatement is `SET identifier = expression` (R2, R3). Target is the
+// single assigned variable name (a qualified `x.y` target is rejected, R3);
+// Value is a full expression (predicates allowed, R2).
+type AssignmentStatement struct {
+	Target *ast.Identifier
+	Value  Expr
+	Loc    ast.Loc
+}
+
+func (s *AssignmentStatement) Span() ast.Loc    { return s.Loc }
+func (s *AssignmentStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*AssignmentStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// CASE (simple + searched)
+// ---------------------------------------------------------------------------
+
+// CaseWhenClause is `WHEN expression THEN sqlStatementList` (caseStatementWhenClause).
+type CaseWhenClause struct {
+	// Condition is the WHEN expression (a value to match in a simple CASE, a
+	// boolean in a searched CASE — both are full expressions).
+	Condition Expr
+	// Body is the THEN statement list.
+	Body []RoutineStatement
+	Loc  ast.Loc
+}
+
+// CaseStatement is `CASE [operand] when+ [else] END CASE`. Operand is non-nil
+// for the simple form (`CASE expr WHEN v THEN …`) and nil for the searched form
+// (`CASE WHEN cond THEN …`).
+type CaseStatement struct {
+	Operand Expr // nil for the searched form
+	Whens   []CaseWhenClause
+	Else    []RoutineStatement // nil when no ELSE clause
+	Loc     ast.Loc
+}
+
+func (s *CaseStatement) Span() ast.Loc    { return s.Loc }
+func (s *CaseStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*CaseStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// IF / ELSEIF / ELSE
+// ---------------------------------------------------------------------------
+
+// ElseIfClause is `ELSEIF expression THEN sqlStatementList`.
+type ElseIfClause struct {
+	Condition Expr
+	Body      []RoutineStatement
+	Loc       ast.Loc
+}
+
+// IfStatement is `IF expression THEN body elseIf* [else] END IF`.
+type IfStatement struct {
+	Condition Expr
+	Then      []RoutineStatement
+	ElseIfs   []ElseIfClause
+	Else      []RoutineStatement // nil when no ELSE clause
+	Loc       ast.Loc
+}
+
+func (s *IfStatement) Span() ast.Loc    { return s.Loc }
+func (s *IfStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*IfStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// ITERATE / LEAVE
+// ---------------------------------------------------------------------------
+
+// IterateStatement is `ITERATE identifier` (R4 — the label is mandatory).
+type IterateStatement struct {
+	Label *ast.Identifier
+	Loc   ast.Loc
+}
+
+func (s *IterateStatement) Span() ast.Loc    { return s.Loc }
+func (s *IterateStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*IterateStatement)(nil)
+
+// LeaveStatement is `LEAVE identifier` (R4 — the label is mandatory).
+type LeaveStatement struct {
+	Label *ast.Identifier
+	Loc   ast.Loc
+}
+
+func (s *LeaveStatement) Span() ast.Loc    { return s.Loc }
+func (s *LeaveStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*LeaveStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// BEGIN … END (compound)
+// ---------------------------------------------------------------------------
+
+// VariableDeclaration is `DECLARE identifier (, identifier)* type [DEFAULT valueExpression]`
+// (variableDeclaration). One DECLARE may introduce several names of the same
+// type. Default, when present, is a valueExpression (R1).
+type VariableDeclaration struct {
+	Names   []*ast.Identifier
+	Type    *DataType
+	Default Expr // nil when no DEFAULT
+	Loc     ast.Loc
+}
+
+// CompoundStatement is `BEGIN (variableDeclaration ;)* sqlStatementList? END`
+// (R5 — no label is permitted; R6 — declarations precede statements, both
+// optional).
+type CompoundStatement struct {
+	Declarations []VariableDeclaration // nil when none
+	Body         []RoutineStatement    // nil when the body is empty
+	Loc          ast.Loc
+}
+
+func (s *CompoundStatement) Span() ast.Loc    { return s.Loc }
+func (s *CompoundStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*CompoundStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// LOOP / WHILE / REPEAT (labeled iteration)
+// ---------------------------------------------------------------------------
+
+// LoopStatement is `(label:)? LOOP sqlStatementList END LOOP`. Label is non-nil
+// when a `label:` prefix was present.
+type LoopStatement struct {
+	Label *ast.Identifier // nil when unlabeled
+	Body  []RoutineStatement
+	Loc   ast.Loc
+}
+
+func (s *LoopStatement) Span() ast.Loc    { return s.Loc }
+func (s *LoopStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*LoopStatement)(nil)
+
+// WhileStatement is `(label:)? WHILE expression DO sqlStatementList END WHILE`.
+type WhileStatement struct {
+	Label     *ast.Identifier // nil when unlabeled
+	Condition Expr
+	Body      []RoutineStatement
+	Loc       ast.Loc
+}
+
+func (s *WhileStatement) Span() ast.Loc    { return s.Loc }
+func (s *WhileStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*WhileStatement)(nil)
+
+// RepeatStatement is `(label:)? REPEAT sqlStatementList UNTIL expression END REPEAT`.
+// Condition is the UNTIL expression (a full expression, R2).
+type RepeatStatement struct {
+	Label     *ast.Identifier // nil when unlabeled
+	Body      []RoutineStatement
+	Condition Expr
+	Loc       ast.Loc
+}
+
+func (s *RepeatStatement) Span() ast.Loc    { return s.Loc }
+func (s *RepeatStatement) routineStmtNode() {}
+
+var _ RoutineStatement = (*RepeatStatement)(nil)
+
+// ---------------------------------------------------------------------------
+// controlStatement dispatch
+// ---------------------------------------------------------------------------
+
+// parseRoutineStatement parses one `controlStatement` and returns it as a
+// RoutineStatement. A `label:` prefix (any identifier — including a non-reserved
+// keyword — followed by ':') selects one of the labeled iteration forms
+// (LOOP / WHILE / REPEAT — R5); otherwise the leading keyword selects the
+// alternative.
+//
+// The label check MUST precede the keyword switch: a label name may itself be a
+// non-reserved control keyword (Trino 481 accepts `loop: LOOP …`,
+// `while: LOOP …`, `set: LOOP …`, etc. — every dispatch keyword except the
+// reserved CASE is a valid label). Dispatching on the keyword first would
+// mis-read `loop: LOOP …` as an unlabeled LOOP starting at the label token.
+func (p *Parser) parseRoutineStatement() (RoutineStatement, error) {
+	// A `label:` prefix: an identifier (or non-reserved keyword) immediately
+	// followed by ':' begins a labeled LOOP / WHILE / REPEAT.
+	if isIdentifierStart(p.cur.Kind) && p.peekNext().Kind == int(':') {
+		labelTok := p.advance() // consume the label identifier
+		label := identFromToken(labelTok)
+		p.advance() // consume ':'
+		switch p.cur.Kind {
+		case kwLOOP:
+			return p.parseLoopStatement(label, label.Loc.Start)
+		case kwWHILE:
+			return p.parseWhileStatement(label, label.Loc.Start)
+		case kwREPEAT:
+			return p.parseRepeatStatement(label, label.Loc.Start)
+		default:
+			// Only LOOP / WHILE / REPEAT take a label (R5); a label on anything
+			// else (e.g. `lbl: BEGIN`) is a syntax error.
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+
+	switch p.cur.Kind {
+	case kwRETURN:
+		return p.parseReturnStatement()
+	case kwSET:
+		return p.parseAssignmentStatement()
+	case kwCASE:
+		return p.parseCaseStatement()
+	case kwIF:
+		return p.parseIfStatement()
+	case kwITERATE:
+		return p.parseIterateStatement()
+	case kwLEAVE:
+		return p.parseLeaveStatement()
+	case kwBEGIN:
+		return p.parseCompoundStatement()
+	case kwLOOP:
+		return p.parseLoopStatement(nil, p.cur.Loc.Start)
+	case kwWHILE:
+		return p.parseWhileStatement(nil, p.cur.Loc.Start)
+	case kwREPEAT:
+		return p.parseRepeatStatement(nil, p.cur.Loc.Start)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseReturnStatement parses `RETURN valueExpression` (R1). RETURN is current.
+func (p *Parser) parseReturnStatement() (RoutineStatement, error) {
+	retTok := p.advance() // consume RETURN
+	// R1: RETURN takes a valueExpression, not a full expression. A bare
+	// predicate/boolean (`RETURN x IN (1,2)`) is a SYNTAX_ERROR in Trino 481.
+	val, err := p.parseValueExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ReturnStatement{
+		Value: val,
+		Loc:   ast.Loc{Start: retTok.Loc.Start, End: val.Span().End},
+	}, nil
+}
+
+// parseAssignmentStatement parses `SET identifier = expression` (R2, R3). SET is
+// current.
+func (p *Parser) parseAssignmentStatement() (RoutineStatement, error) {
+	setTok := p.advance() // consume SET
+	// R3: the assignment target is a single identifier; `SET x.y = …` is a
+	// SYNTAX_ERROR (the grammar is SET identifier EQ expression, not a
+	// qualifiedName).
+	target, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return nil, err
+	}
+	// R2: the assigned value is a full expression (predicates allowed).
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &AssignmentStatement{
+		Target: target,
+		Value:  val,
+		Loc:    ast.Loc{Start: setTok.Loc.Start, End: val.Span().End},
+	}, nil
+}
+
+// parseCaseStatement parses the simple (`CASE expr WHEN …`) and searched
+// (`CASE WHEN …`) case statements; the two share the `when+ else? END CASE`
+// tail. CASE is current.
+func (p *Parser) parseCaseStatement() (RoutineStatement, error) {
+	caseTok := p.advance() // consume CASE
+	s := &CaseStatement{Loc: ast.Loc{Start: caseTok.Loc.Start, End: caseTok.Loc.End}}
+
+	// Simple form: a subject expression precedes the first WHEN. Searched form:
+	// WHEN comes immediately after CASE.
+	if p.cur.Kind != kwWHEN {
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		s.Operand = operand
+	}
+
+	// At least one WHEN clause is required (when+).
+	if p.cur.Kind != kwWHEN {
+		return nil, p.syntaxErrorAtCur()
+	}
+	for p.cur.Kind == kwWHEN {
+		w, err := p.parseCaseWhenClause()
+		if err != nil {
+			return nil, err
+		}
+		s.Whens = append(s.Whens, w)
+	}
+
+	if p.cur.Kind == kwELSE {
+		body, err := p.parseElseClause()
+		if err != nil {
+			return nil, err
+		}
+		s.Else = body
+	}
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endCaseTok, err := p.expect(kwCASE)
+	if err != nil {
+		return nil, err
+	}
+	s.Loc.End = endCaseTok.Loc.End
+	return s, nil
+}
+
+// parseCaseWhenClause parses `WHEN expression THEN sqlStatementList`. WHEN is
+// current.
+func (p *Parser) parseCaseWhenClause() (CaseWhenClause, error) {
+	whenTok := p.advance() // consume WHEN
+	cond, err := p.parseExpr()
+	if err != nil {
+		return CaseWhenClause{}, err
+	}
+	if _, err := p.expect(kwTHEN); err != nil {
+		return CaseWhenClause{}, err
+	}
+	body, err := p.parseSQLStatementList()
+	if err != nil {
+		return CaseWhenClause{}, err
+	}
+	end := whenTok.Loc.End
+	if n := len(body); n > 0 {
+		end = body[n-1].Span().End
+	}
+	return CaseWhenClause{
+		Condition: cond,
+		Body:      body,
+		Loc:       ast.Loc{Start: whenTok.Loc.Start, End: end},
+	}, nil
+}
+
+// parseElseClause parses `ELSE sqlStatementList` and returns the statement list.
+// ELSE is current.
+func (p *Parser) parseElseClause() ([]RoutineStatement, error) {
+	p.advance() // consume ELSE
+	return p.parseSQLStatementList()
+}
+
+// parseIfStatement parses
+// `IF expression THEN sqlStatementList elseIfClause* elseClause? END IF`. IF is
+// current.
+func (p *Parser) parseIfStatement() (RoutineStatement, error) {
+	ifTok := p.advance() // consume IF
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwTHEN); err != nil {
+		return nil, err
+	}
+	thenBody, err := p.parseSQLStatementList()
+	if err != nil {
+		return nil, err
+	}
+	s := &IfStatement{
+		Condition: cond,
+		Then:      thenBody,
+		Loc:       ast.Loc{Start: ifTok.Loc.Start, End: ifTok.Loc.End},
+	}
+
+	for p.cur.Kind == kwELSEIF {
+		elseIfTok := p.advance() // consume ELSEIF
+		eiCond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		eiBody, err := p.parseSQLStatementList()
+		if err != nil {
+			return nil, err
+		}
+		end := elseIfTok.Loc.End
+		if n := len(eiBody); n > 0 {
+			end = eiBody[n-1].Span().End
+		}
+		s.ElseIfs = append(s.ElseIfs, ElseIfClause{
+			Condition: eiCond,
+			Body:      eiBody,
+			Loc:       ast.Loc{Start: elseIfTok.Loc.Start, End: end},
+		})
+	}
+
+	if p.cur.Kind == kwELSE {
+		elseBody, err := p.parseElseClause()
+		if err != nil {
+			return nil, err
+		}
+		s.Else = elseBody
+	}
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endIfTok, err := p.expect(kwIF)
+	if err != nil {
+		return nil, err
+	}
+	s.Loc.End = endIfTok.Loc.End
+	return s, nil
+}
+
+// parseIterateStatement parses `ITERATE identifier` (R4). ITERATE is current.
+func (p *Parser) parseIterateStatement() (RoutineStatement, error) {
+	iterTok := p.advance() // consume ITERATE
+	// R4: the label is mandatory; `ITERATE` with no label is a SYNTAX_ERROR.
+	label, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &IterateStatement{
+		Label: label,
+		Loc:   ast.Loc{Start: iterTok.Loc.Start, End: label.Loc.End},
+	}, nil
+}
+
+// parseLeaveStatement parses `LEAVE identifier` (R4). LEAVE is current.
+func (p *Parser) parseLeaveStatement() (RoutineStatement, error) {
+	leaveTok := p.advance() // consume LEAVE
+	// R4: the label is mandatory; `LEAVE` with no label is a SYNTAX_ERROR.
+	label, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &LeaveStatement{
+		Label: label,
+		Loc:   ast.Loc{Start: leaveTok.Loc.Start, End: label.Loc.End},
+	}, nil
+}
+
+// parseCompoundStatement parses
+// `BEGIN (variableDeclaration ;)* sqlStatementList? END` (R5, R6). BEGIN is
+// current. No label is permitted (R5 — the caller never reaches here via the
+// `label:` path).
+func (p *Parser) parseCompoundStatement() (RoutineStatement, error) {
+	beginTok := p.advance() // consume BEGIN
+	s := &CompoundStatement{Loc: ast.Loc{Start: beginTok.Loc.Start, End: beginTok.Loc.End}}
+
+	// R6: zero or more `DECLARE … ;` declarations, all before any statement.
+	for p.cur.Kind == kwDECLARE {
+		decl, err := p.parseVariableDeclaration()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(';')); err != nil {
+			return nil, err
+		}
+		s.Declarations = append(s.Declarations, decl)
+	}
+
+	// R6: an optional sqlStatementList. It is absent when END follows the
+	// declarations directly (`BEGIN END`, `BEGIN DECLARE x int; END`).
+	if p.cur.Kind != kwEND {
+		body, err := p.parseSQLStatementList()
+		if err != nil {
+			return nil, err
+		}
+		s.Body = body
+	}
+
+	endTok, err := p.expect(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	s.Loc.End = endTok.Loc.End
+	return s, nil
+}
+
+// parseVariableDeclaration parses
+// `DECLARE identifier (, identifier)* type [DEFAULT valueExpression]`. DECLARE is
+// current. The terminating ';' is consumed by the caller (compound statement).
+func (p *Parser) parseVariableDeclaration() (VariableDeclaration, error) {
+	declTok := p.advance() // consume DECLARE
+	first, err := p.parseIdentifier()
+	if err != nil {
+		return VariableDeclaration{}, err
+	}
+	names := []*ast.Identifier{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseIdentifier()
+		if err != nil {
+			return VariableDeclaration{}, err
+		}
+		names = append(names, next)
+	}
+
+	typ, err := p.parseType()
+	if err != nil {
+		return VariableDeclaration{}, err
+	}
+
+	decl := VariableDeclaration{
+		Names: names,
+		Type:  typ,
+		Loc:   ast.Loc{Start: declTok.Loc.Start, End: typ.Loc.End},
+	}
+
+	if p.cur.Kind == kwDEFAULT {
+		p.advance() // consume DEFAULT
+		// R1: DEFAULT is a valueExpression, not a full expression.
+		def, err := p.parseValueExpr()
+		if err != nil {
+			return VariableDeclaration{}, err
+		}
+		decl.Default = def
+		decl.Loc.End = def.Span().End
+	}
+
+	return decl, nil
+}
+
+// parseLoopStatement parses `LOOP sqlStatementList END LOOP`. LOOP is current;
+// label (may be nil) and start are supplied by the dispatcher (so the node span
+// covers a leading `label:`).
+func (p *Parser) parseLoopStatement(label *ast.Identifier, start int) (RoutineStatement, error) {
+	p.advance() // consume LOOP
+	body, err := p.parseSQLStatementList()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endLoopTok, err := p.expect(kwLOOP)
+	if err != nil {
+		return nil, err
+	}
+	return &LoopStatement{
+		Label: label,
+		Body:  body,
+		Loc:   ast.Loc{Start: start, End: endLoopTok.Loc.End},
+	}, nil
+}
+
+// parseWhileStatement parses `WHILE expression DO sqlStatementList END WHILE`.
+// WHILE is current; label (may be nil) and start come from the dispatcher.
+func (p *Parser) parseWhileStatement(label *ast.Identifier, start int) (RoutineStatement, error) {
+	p.advance() // consume WHILE
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwDO); err != nil {
+		return nil, err
+	}
+	body, err := p.parseSQLStatementList()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endWhileTok, err := p.expect(kwWHILE)
+	if err != nil {
+		return nil, err
+	}
+	return &WhileStatement{
+		Label:     label,
+		Condition: cond,
+		Body:      body,
+		Loc:       ast.Loc{Start: start, End: endWhileTok.Loc.End},
+	}, nil
+}
+
+// parseRepeatStatement parses
+// `REPEAT sqlStatementList UNTIL expression END REPEAT`. REPEAT is current;
+// label (may be nil) and start come from the dispatcher.
+func (p *Parser) parseRepeatStatement(label *ast.Identifier, start int) (RoutineStatement, error) {
+	p.advance() // consume REPEAT
+	body, err := p.parseSQLStatementList()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwUNTIL); err != nil {
+		return nil, err
+	}
+	// R2: the UNTIL condition is a full expression.
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endRepeatTok, err := p.expect(kwREPEAT)
+	if err != nil {
+		return nil, err
+	}
+	return &RepeatStatement{
+		Label:     label,
+		Body:      body,
+		Condition: cond,
+		Loc:       ast.Loc{Start: start, End: endRepeatTok.Loc.End},
+	}, nil
+}
+
+// parseSQLStatementList parses `(controlStatement ;)+` (sqlStatementList). At
+// least one statement is required, and EACH statement is terminated by ';' (R7).
+// The list ends when the next token is not a controlStatement start (e.g. END,
+// ELSE, ELSEIF, UNTIL).
+func (p *Parser) parseSQLStatementList() ([]RoutineStatement, error) {
+	var stmts []RoutineStatement
+	for {
+		stmt, err := p.parseRoutineStatement()
+		if err != nil {
+			return nil, err
+		}
+		// R7: every statement in a sqlStatementList is ';'-terminated.
+		if _, err := p.expect(int(';')); err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, stmt)
+		if !p.routineStatementStarts() {
+			break
+		}
+	}
+	return stmts, nil
+}
+
+// routineStatementStarts reports whether the current token can begin another
+// controlStatement, so parseSQLStatementList knows when to stop. It mirrors the
+// dispatch in parseRoutineStatement: the fixed leading keywords plus a `label:`
+// prefix (identifier followed by ':'). Terminators (END, ELSE, ELSEIF, UNTIL)
+// return false.
+func (p *Parser) routineStatementStarts() bool {
+	switch p.cur.Kind {
+	case kwRETURN, kwSET, kwCASE, kwIF, kwITERATE, kwLEAVE, kwBEGIN, kwLOOP, kwWHILE, kwREPEAT:
+		return true
+	default:
+		return isIdentifierStart(p.cur.Kind) && p.peekNext().Kind == int(':')
+	}
+}

--- a/trino/parser/routine_body_test.go
+++ b/trino/parser/routine_body_test.go
@@ -1,0 +1,237 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the structural (Layer 2) gate for the parser-routines node's
+// control-flow body language (routine_body.go): RETURN, SET (assignment),
+// IF/ELSEIF/ELSE, CASE (simple + searched), LOOP/WHILE/REPEAT (labeled),
+// ITERATE/LEAVE, BEGIN/END (compound) with DECLARE. It pins the parse-node shape
+// of each controlStatement alternative. The authoritative accept/reject
+// differential against the live Trino 481 oracle is in oracle_routines_test.go.
+
+// bodyOf parses `CREATE FUNCTION f() RETURNS int <body>` and returns the
+// function's single control-statement body, failing the test if the wrapper or
+// parse is wrong. It lets each test focus on one routine statement shape.
+func bodyOf(t *testing.T, body string) RoutineStatement {
+	t.Helper()
+	sql := "CREATE FUNCTION f() RETURNS int " + body
+	s, ok := parseOneStmt(t, sql).(*CreateFunctionStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): not a *CreateFunctionStmt", sql)
+	}
+	return s.Spec.Body
+}
+
+func TestRoutineBody_Return(t *testing.T) {
+	s, ok := bodyOf(t, "RETURN 1 + 2").(*ReturnStatement)
+	if !ok {
+		t.Fatalf("body = %T, want *ReturnStatement", s)
+	}
+	if s.Value == nil {
+		t.Errorf("Value = nil")
+	}
+}
+
+func TestRoutineBody_Compound(t *testing.T) {
+	t.Run("declares_and_statements", func(t *testing.T) {
+		s := bodyOf(t, "BEGIN DECLARE a, b int; DECLARE c varchar DEFAULT 'x'; SET a = 1; RETURN a; END").(*CompoundStatement)
+		if len(s.Declarations) != 2 {
+			t.Fatalf("declarations = %d, want 2", len(s.Declarations))
+		}
+		if len(s.Declarations[0].Names) != 2 {
+			t.Errorf("decl[0] names = %d, want 2", len(s.Declarations[0].Names))
+		}
+		if s.Declarations[1].Default == nil {
+			t.Errorf("decl[1] DEFAULT = nil, want a value")
+		}
+		if len(s.Body) != 2 {
+			t.Errorf("body statements = %d, want 2", len(s.Body))
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		// R6: an empty BEGIN END is valid (both blocks optional).
+		s := bodyOf(t, "BEGIN END").(*CompoundStatement)
+		if len(s.Declarations) != 0 || len(s.Body) != 0 {
+			t.Errorf("empty compound: decls=%d body=%d, want 0/0", len(s.Declarations), len(s.Body))
+		}
+	})
+
+	t.Run("declares_only", func(t *testing.T) {
+		s := bodyOf(t, "BEGIN DECLARE x int; END").(*CompoundStatement)
+		if len(s.Declarations) != 1 {
+			t.Errorf("declarations = %d, want 1", len(s.Declarations))
+		}
+		if len(s.Body) != 0 {
+			t.Errorf("body statements = %d, want 0", len(s.Body))
+		}
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		s := bodyOf(t, "BEGIN BEGIN RETURN 1; END; END").(*CompoundStatement)
+		if len(s.Body) != 1 {
+			t.Fatalf("outer body statements = %d, want 1", len(s.Body))
+		}
+		if _, ok := s.Body[0].(*CompoundStatement); !ok {
+			t.Errorf("inner = %T, want *CompoundStatement", s.Body[0])
+		}
+	})
+}
+
+func TestRoutineBody_Assignment(t *testing.T) {
+	s := bodyOf(t, "BEGIN DECLARE x int; SET x = 1 + 2; RETURN x; END").(*CompoundStatement)
+	assign, ok := s.Body[0].(*AssignmentStatement)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *AssignmentStatement", s.Body[0])
+	}
+	if assign.Target.Normalize() != "x" {
+		t.Errorf("target = %q, want x", assign.Target.Normalize())
+	}
+	if assign.Value == nil {
+		t.Errorf("value = nil")
+	}
+}
+
+func TestRoutineBody_If(t *testing.T) {
+	s := bodyOf(t, "BEGIN IF 1 > 0 THEN RETURN 1; ELSEIF 1 < 0 THEN RETURN -1; ELSE RETURN 0; END IF; END").(*CompoundStatement)
+	ifs, ok := s.Body[0].(*IfStatement)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *IfStatement", s.Body[0])
+	}
+	if ifs.Condition == nil {
+		t.Errorf("condition = nil")
+	}
+	if len(ifs.Then) != 1 {
+		t.Errorf("then = %d, want 1", len(ifs.Then))
+	}
+	if len(ifs.ElseIfs) != 1 {
+		t.Errorf("elseifs = %d, want 1", len(ifs.ElseIfs))
+	}
+	if len(ifs.Else) != 1 {
+		t.Errorf("else = %d, want 1", len(ifs.Else))
+	}
+}
+
+func TestRoutineBody_If_NoElse(t *testing.T) {
+	s := bodyOf(t, "BEGIN IF 1 > 0 THEN RETURN 1; END IF; RETURN 0; END").(*CompoundStatement)
+	ifs := s.Body[0].(*IfStatement)
+	if len(ifs.ElseIfs) != 0 {
+		t.Errorf("elseifs = %d, want 0", len(ifs.ElseIfs))
+	}
+	if ifs.Else != nil {
+		t.Errorf("else = %v, want nil", ifs.Else)
+	}
+}
+
+func TestRoutineBody_CaseSimple(t *testing.T) {
+	s := bodyOf(t, "BEGIN CASE 1 WHEN 1 THEN RETURN 1; WHEN 2 THEN RETURN 2; ELSE RETURN 0; END CASE; END").(*CompoundStatement)
+	cs, ok := s.Body[0].(*CaseStatement)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *CaseStatement", s.Body[0])
+	}
+	if cs.Operand == nil {
+		t.Errorf("operand = nil, want a subject expression (simple CASE)")
+	}
+	if len(cs.Whens) != 2 {
+		t.Errorf("whens = %d, want 2", len(cs.Whens))
+	}
+	if len(cs.Else) != 1 {
+		t.Errorf("else = %d, want 1", len(cs.Else))
+	}
+}
+
+func TestRoutineBody_CaseSearched(t *testing.T) {
+	s := bodyOf(t, "BEGIN CASE WHEN 1 > 0 THEN RETURN 1; ELSE RETURN 0; END CASE; END").(*CompoundStatement)
+	cs := s.Body[0].(*CaseStatement)
+	if cs.Operand != nil {
+		t.Errorf("operand = %v, want nil (searched CASE)", cs.Operand)
+	}
+	if len(cs.Whens) != 1 {
+		t.Errorf("whens = %d, want 1", len(cs.Whens))
+	}
+}
+
+func TestRoutineBody_Loop(t *testing.T) {
+	t.Run("labeled_with_leave", func(t *testing.T) {
+		s := bodyOf(t, "BEGIN DECLARE i int DEFAULT 0; top: LOOP SET i = i + 1; IF i > 10 THEN LEAVE top; END IF; END LOOP; RETURN i; END").(*CompoundStatement)
+		loop, ok := s.Body[0].(*LoopStatement)
+		if !ok {
+			t.Fatalf("body[0] = %T, want *LoopStatement", s.Body[0])
+		}
+		if loop.Label == nil || loop.Label.Normalize() != "top" {
+			t.Errorf("label = %v, want top", loop.Label)
+		}
+		// inner: SET, then IF (containing LEAVE)
+		if len(loop.Body) != 2 {
+			t.Fatalf("loop body = %d, want 2", len(loop.Body))
+		}
+		innerIf := loop.Body[1].(*IfStatement)
+		if _, ok := innerIf.Then[0].(*LeaveStatement); !ok {
+			t.Errorf("LEAVE = %T, want *LeaveStatement", innerIf.Then[0])
+		}
+	})
+
+	t.Run("unlabeled", func(t *testing.T) {
+		s := bodyOf(t, "BEGIN LOOP RETURN 1; END LOOP; END").(*CompoundStatement)
+		loop := s.Body[0].(*LoopStatement)
+		if loop.Label != nil {
+			t.Errorf("label = %v, want nil", loop.Label)
+		}
+	})
+
+	t.Run("label_named_as_control_keyword", func(t *testing.T) {
+		// A label may be a non-reserved control keyword (`loop`, `set`, …): the
+		// label check must win over the keyword dispatch.
+		s := bodyOf(t, "BEGIN loop: LOOP LEAVE loop; END LOOP; RETURN 1; END").(*CompoundStatement)
+		loop, ok := s.Body[0].(*LoopStatement)
+		if !ok {
+			t.Fatalf("body[0] = %T, want *LoopStatement", s.Body[0])
+		}
+		if loop.Label == nil || loop.Label.Normalize() != "loop" {
+			t.Errorf("label = %v, want loop", loop.Label)
+		}
+		leave := loop.Body[0].(*LeaveStatement)
+		if leave.Label.Normalize() != "loop" {
+			t.Errorf("LEAVE label = %q, want loop", leave.Label.Normalize())
+		}
+	})
+}
+
+func TestRoutineBody_While(t *testing.T) {
+	t.Run("labeled_with_iterate", func(t *testing.T) {
+		s := bodyOf(t, "BEGIN DECLARE i int DEFAULT 0; abc: WHILE i < 10 DO SET i = i + 1; ITERATE abc; END WHILE; RETURN i; END").(*CompoundStatement)
+		w, ok := s.Body[0].(*WhileStatement)
+		if !ok {
+			t.Fatalf("body[0] = %T, want *WhileStatement", s.Body[0])
+		}
+		if w.Label == nil || w.Label.Normalize() != "abc" {
+			t.Errorf("label = %v, want abc", w.Label)
+		}
+		if w.Condition == nil {
+			t.Errorf("condition = nil")
+		}
+		iter, ok := w.Body[1].(*IterateStatement)
+		if !ok {
+			t.Fatalf("body[1] = %T, want *IterateStatement", w.Body[1])
+		}
+		if iter.Label.Normalize() != "abc" {
+			t.Errorf("ITERATE label = %q, want abc", iter.Label.Normalize())
+		}
+	})
+}
+
+func TestRoutineBody_Repeat(t *testing.T) {
+	s := bodyOf(t, "BEGIN DECLARE i int DEFAULT 0; REPEAT SET i = i + 1; UNTIL i >= 10 END REPEAT; RETURN i; END").(*CompoundStatement)
+	r, ok := s.Body[0].(*RepeatStatement)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *RepeatStatement", s.Body[0])
+	}
+	if len(r.Body) != 1 {
+		t.Errorf("repeat body = %d, want 1", len(r.Body))
+	}
+	if r.Condition == nil {
+		t.Errorf("UNTIL condition = nil")
+	}
+}

--- a/trino/parser/select.go
+++ b/trino/parser/select.go
@@ -302,14 +302,15 @@ func (p *Parser) parseQuery() (*Query, error) {
 	var with *WithClause
 	start := p.cur.Loc.Start
 	if p.cur.Kind == kwWITH {
-		// WITH FUNCTION (inline routine) is the parser-routines node; a CTE WITH
-		// is `WITH [RECURSIVE] namedQuery …`. If FUNCTION follows WITH, this is not
-		// a CTE list — report it as unsupported here rather than mis-parsing.
+		// WITH FUNCTION (the rootQuery inline-routine prefix, parser-routines
+		// node) is valid ONLY at the statement level — parseStmt routes it to
+		// parseWithFunctionQuery there. Reaching parseQuery with a leading
+		// WITH FUNCTION means it appeared in a subquery / nested-query position,
+		// which Trino 481 rejects with a SYNTAX_ERROR; a CTE WITH is
+		// `WITH [RECURSIVE] namedQuery …`. Report the syntax error rather than
+		// mis-parsing it as a CTE.
 		if p.peekNext().Kind == kwFUNCTION {
-			return nil, &ParseError{
-				Loc: p.cur.Loc,
-				Msg: "WITH FUNCTION (inline SQL routine) is not yet supported",
-			}
+			return nil, p.syntaxErrorAtCur()
 		}
 		w, err := p.parseWithClause()
 		if err != nil {


### PR DESCRIPTION
## Node: `trino/parser-routines` (v2 migration, migration id 3)

Hand-written recursive-descent parser for Trino's **SQL routines** — the legacy `TrinoParser.g4` `createFunction` / `dropFunction` statement alternatives, the `withFunction` rootQuery inline-routine prefix, and the full control-flow body language. Spec: [`docs/migration/trino/analysis.md`](docs/migration/trino/analysis.md) §6 Tier 5 item 18 + [`dag.md`](docs/migration/trino/dag.md) (`writes`: `function_def.go`, `routine_body.go`). Dependencies merged: `trino/expressions` (#190), `trino/parser-select` (#203).

### Grammar implemented (truth2 `TrinoParser.g4` + truth1 Trino 481 docs)
- `CREATE [OR REPLACE] functionSpecification` and `DROP FUNCTION [IF EXISTS] functionDeclaration`.
- `withFunction`: `WITH functionSpecification (, functionSpecification)* query` (rootQuery-only).
- `functionSpecification` = `FUNCTION functionDeclaration returnsClause routineCharacteristic* controlStatement`; `parameterDeclaration` (`identifier? type`); all `routineCharacteristic` alternatives (LANGUAGE / `[NOT] DETERMINISTIC` / `RETURNS NULL ON NULL INPUT` / `CALLED ON NULL INPUT` / `SECURITY DEFINER|INVOKER` / `COMMENT string_`).
- `controlStatement`: `RETURN`, `SET` assignment, simple + searched `CASE`, `IF/ELSEIF/ELSE`, `ITERATE`, `LEAVE`, `BEGIN…END` compound (with `DECLARE`), labeled `LOOP` / `WHILE` / `REPEAT`; `sqlStatementList`, `variableDeclaration`, the WHEN/ELSEIF/ELSE clauses.

### Evidence — differential oracle gate (correctness-protocol.md)
`TestRoutines_OracleDifferential` runs **97 statements** through both omni `Parse` and the live **Trino 481** oracle (`trino/internal/trinooracle`, `SYNTAX_ERROR` = reject, everything else incl. `NOT_SUPPORTED` = accept). **omni's verdict == Trino 481's verdict for every case.** Corpus = truth1 docs (`create-function`, `drop-function`) + every truth2 controlStatement/routineCharacteristic alternative + the docs-ahead `WITH(properties)` + **19 negatives**. Plus structural gates (`TestRoutines_Structure*`, `TestRoutineBody_*`) pinning AST shape per alternative.

Oracle-confirmed semantics baked in (with negatives proving each):
- `RETURN` and `DECLARE … DEFAULT` take a **valueExpression** (a bare boolean/predicate like `RETURN x IN (1,2)` is `SYNTAX_ERROR`); `SET` / `IF` / `WHILE` / `UNTIL` / `CASE WHEN` take a **full expression**.
- `SET` target is a **single identifier** (`SET x.y = 1` rejected).
- `ITERATE` / `LEAVE` **require a label**; labels attach only to `LOOP/WHILE/REPEAT` (`lbl: BEGIN` rejected) — and a label may itself be a non-reserved control keyword (`loop:`, `set:`).
- `DECLARE`s **precede** statements; both compound blocks optional (`BEGIN END` valid); `sqlStatementList` is `;`-terminated.
- Parameter name is optional; multi-token type-only params (`DOUBLE PRECISION`, `INTERVAL DAY TO SECOND`) resolved via a speculative `type | identifier type` parse (mirrors `parseRowField`).
- `COMMENT` requires a **string literal** (`COMMENT 42` / `COMMENT foo` rejected).

### Divergence (ledger id=93, status=confirmed)
**`WITH ( property = expression, … )` routine characteristic** — present in the Trino 481 `CREATE FUNCTION` docs and **accepted by the oracle**, but **absent from the legacy ANTLR `routineCharacteristic` rule**. Implemented (any order, repeatable; empty `WITH ()` rejected) so bytebase `Diagnose` does not false-reject valid Trino 481, and **flagged docs-ahead-of-legacy**. Evidence: doc (`create-function.html`, v481) + oracle accept of `… WITH (handler = 'x') …` + oracle reject of `WITH ()`.

### Review gate (review-gate.md)
Claude-lens multi-angle review run pre-PR; it surfaced **3 real bugs**, all fixed and locked with regression cases:
1. Multi-token type-only params (`DOUBLE PRECISION`, `INTERVAL DAY TO SECOND`) were mis-parsed / wrongly rejected → replaced the lookahead heuristic with the codebase's speculative `parseRowField`-style resolution.
2. A label named as a non-reserved control keyword (`loop:`, `set:`) was mis-dispatched → label check now precedes the keyword switch.
3. `COMMENT` accepted any expression → now requires a `string_` literal.

The Codex lens is run by the orchestrator at the cross-review gate.

### Scope
- **In-scope (`writes_globs`):** `trino/parser/function_def.go`, `trino/parser/routine_body.go`.
- **Out-of-scope writes (standard wiring every grammar node performs, recorded):** `function_def_test.go`, `routine_body_test.go`, `oracle_routines_test.go` (the proof); `trino/ast/nodetags.go` (+3 tags); `trino/parser/parser.go` (CREATE/DROP/WITH FUNCTION dispatch); `trino/parser/select.go` (replaced the WITH FUNCTION stub parser-select left for this node).

### Verification
- `go test ./trino/parser/ ./trino/ast/` green (skipping the pre-existing `TestLexer_OracleDifferential` backtick failure — unrelated to this node, already spun off as a task; verified to fail identically on clean `origin/main`).
- `go build ./trino/...`, `go vet ./trino/parser/... ./trino/ast/...`, `gofmt` all clean.

### Out-of-scope finding (spun off as a separate task)
The expression layer captures expression-embedded subqueries as **unvalidated raw text** (`expr.go` B1), so omni accepts syntactically-invalid scalar/IN/EXISTS subqueries that Trino rejects (e.g. `SELECT (SELECT a FROM t WHERE)`, and a scalar `SELECT (WITH FUNCTION …)`). Pre-existing in the expressions/parser-select nodes, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
