### PR TITLE
feat(trino/analysis): query span + statement classification (v2 node trino/analysis)

### DIFF
--- a/trino/analysis/classify.go
+++ b/trino/analysis/classify.go
@@ -1,0 +1,292 @@
+// Package analysis provides Bytebase-facing query analysis for Trino SQL:
+// statement classification (the query_type / validateQuery contract) and query
+// span extraction (table/column lineage for masking and access tracking).
+//
+// It is the omni counterpart of bytebase's legacy plugin/parser/trino
+// getQueryType + GetQuerySpan, built on the hand-written trino/parser AST.
+package analysis
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/parser"
+)
+
+// QueryType classifies a Trino SQL statement. The values mirror bytebase's
+// base.QueryType so the import switch (bytebase-switch node) can map them 1:1.
+type QueryType int
+
+const (
+	// Unknown is returned for empty input or an unrecognised leading token.
+	Unknown QueryType = iota
+	// Select is a read-only user SELECT query (SELECT/WITH/TABLE/VALUES) that
+	// does not touch a system/information schema.
+	Select
+	// Explain is an EXPLAIN / EXPLAIN ANALYZE statement.
+	Explain
+	// SelectInfoSchema is a read-only query against system/information_schema
+	// objects, or a SHOW / DESCRIBE statement.
+	SelectInfoSchema
+	// DDL changes schema: CREATE/ALTER/DROP/RENAME, GRANT/REVOKE/DENY, roles,
+	// COMMENT, ANALYZE, REFRESH MATERIALIZED VIEW.
+	DDL
+	// DML changes table data: INSERT/UPDATE/DELETE/MERGE/TRUNCATE/CALL.
+	DML
+)
+
+// String returns a human-readable name for the QueryType. The spellings match
+// bytebase's base.QueryType.String() so logs/tests read identically across the
+// legacy and omni stacks.
+func (q QueryType) String() string {
+	switch q {
+	case Select:
+		return "SELECT"
+	case Explain:
+		return "EXPLAIN"
+	case SelectInfoSchema:
+		return "SELECT_INFO_SCHEMA"
+	case DDL:
+		return "DDL"
+	case DML:
+		return "DML"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// firstKeywordType maps a leading-keyword TokenKind to its QueryType. It is
+// populated in init() via parser.KeywordToken so we never depend on the numeric
+// values of the parser's unexported kw* constants.
+//
+// SELECT-family leads (SELECT/WITH/TABLE/VALUES) map to Select and may be
+// refined to SelectInfoSchema by Classify when the statement text references a
+// system schema (matching the legacy containsSystemSchema check). EXPLAIN maps
+// to Explain. SHOW/DESCRIBE map to SelectInfoSchema directly.
+var firstKeywordType map[parser.TokenKind]QueryType
+
+func init() {
+	firstKeywordType = make(map[parser.TokenKind]QueryType)
+
+	register := func(qt QueryType, names ...string) {
+		for _, name := range names {
+			kind, ok := parser.KeywordToken(name)
+			if !ok {
+				panic("trino/analysis: unknown keyword: " + name)
+			}
+			firstKeywordType[kind] = qt
+		}
+	}
+
+	// SELECT-family (refined to SelectInfoSchema by Classify on system schemas).
+	register(Select,
+		"SELECT",
+		"WITH",
+		"TABLE",
+		"VALUES",
+		// SET/RESET SESSION are read-only session statements; the legacy
+		// queryTypeListener classifies them as Select (read-only, no data).
+		"SET",
+		"RESET",
+	)
+
+	// EXPLAIN / EXPLAIN ANALYZE.
+	register(Explain, "EXPLAIN")
+
+	// Information-schema reads: SHOW family and DESCRIBE/DESC.
+	register(SelectInfoSchema,
+		"SHOW",
+		"DESCRIBE",
+		"DESC",
+	)
+
+	// Data manipulation language.
+	register(DML,
+		"INSERT",
+		"UPDATE",
+		"DELETE",
+		"MERGE",
+		"TRUNCATE",
+		"CALL",
+	)
+
+	// Data definition language and access control.
+	register(DDL,
+		"CREATE",
+		"ALTER",
+		"DROP",
+		"COMMENT",
+		"ANALYZE",
+		"GRANT",
+		"REVOKE",
+		"DENY",
+		"REFRESH",
+		"USE",
+	)
+}
+
+// tokEOF is the zero value the lexer returns at end-of-input (matches the
+// unexported parser.tokEOF = 0).
+const tokEOF parser.TokenKind = 0
+
+// kwANALYZE / kwVERBOSE are the token kinds of the EXPLAIN ANALYZE [VERBOSE]
+// prefix keywords, resolved once via parser.KeywordToken (init-checked).
+var (
+	kwANALYZE = mustKeyword("ANALYZE")
+	kwVERBOSE = mustKeyword("VERBOSE")
+)
+
+// mustKeyword resolves a keyword name to its token kind, panicking if the
+// parser does not know it (a build-time invariant, like the register helper).
+func mustKeyword(name string) parser.TokenKind {
+	kind, ok := parser.KeywordToken(name)
+	if !ok {
+		panic("trino/analysis: unknown keyword: " + name)
+	}
+	return kind
+}
+
+// systemSchemaPrefixes are the Trino system/metadata schema qualifiers that
+// promote a SELECT to SelectInfoSchema. Lifted from the legacy
+// containsSystemSchema check (plugin/parser/trino/query_type.go) so the omni
+// classifier reports the same read-only-but-system verdict.
+var systemSchemaPrefixes = []string{
+	"system.",
+	"information_schema.",
+	"$system.",
+	"catalog.",
+	"metadata.",
+}
+
+// Classify determines the QueryType for a single Trino statement by lexing its
+// first meaningful token. It does NOT fully parse the statement, so it is robust
+// even for statement kinds whose parser bodies are not yet implemented.
+//
+// Whitespace and comments are skipped by the lexer. A leading '(' (a
+// parenthesized query) is treated as the SELECT family. SELECT-family results
+// are promoted to SelectInfoSchema when the statement text references a Trino
+// system/information schema, matching the legacy classifier. Empty input or an
+// unrecognised leading token yields Unknown.
+func Classify(statement string) QueryType {
+	l := parser.NewLexer(statement)
+	tok := l.NextToken()
+	if tok.Kind == tokEOF {
+		return Unknown
+	}
+
+	// A parenthesized query — `( SELECT ... )` / `( TABLE ... )` — leads with
+	// '(' rather than a keyword; treat it as the SELECT family.
+	if tok.Kind == int('(') {
+		return refineSelect(statement, Select)
+	}
+
+	qt, ok := firstKeywordType[tok.Kind]
+	if !ok {
+		return Unknown
+	}
+	if qt == Select {
+		return refineSelect(statement, qt)
+	}
+	if qt == Explain {
+		return classifyExplain(statement, l)
+	}
+	return qt
+}
+
+// classifyExplain refines the classification of an EXPLAIN statement. The
+// leading EXPLAIN keyword has already been consumed; l is positioned just after
+// it.
+//
+// Plain EXPLAIN does not execute its inner statement, so it is read-only
+// regardless of the inner kind. EXPLAIN ANALYZE, however, RUNS the inner
+// statement (oracle-confirmed against Trino 481: EXPLAIN ANALYZE INSERT
+// performs the insert), so an EXPLAIN ANALYZE of a mutating statement is NOT
+// read-only and is classified by the inner statement's kind (DML/DDL). This is
+// a deliberate, oracle-backed improvement over the legacy classifier, which
+// reports EXPLAIN ANALYZE as read-only Select irrespective of the inner kind —
+// see the migration divergence ledger.
+//
+// For a read-only or non-mutating inner statement the classification stays
+// Explain, except that a reference to a system/information schema promotes it to
+// SelectInfoSchema (matching the legacy containsSystemSchema rule).
+func classifyExplain(statement string, l *parser.Lexer) QueryType {
+	analyze := false
+	// Skip the optional `ANALYZE [VERBOSE]` and `( option, … )` prefix, then read
+	// the inner statement's first keyword.
+	for {
+		tok := l.NextToken()
+		if tok.Kind == tokEOF {
+			break
+		}
+		if tok.Kind == kwANALYZE {
+			analyze = true
+			continue
+		}
+		if tok.Kind == kwVERBOSE {
+			continue
+		}
+		if tok.Kind == int('(') {
+			// Skip a balanced `( … )` option list.
+			skipParenGroup(l)
+			continue
+		}
+		// First non-prefix token is the inner statement's leading keyword.
+		if analyze {
+			if inner, ok := firstKeywordType[tok.Kind]; ok && (inner == DML || inner == DDL) {
+				return inner
+			}
+		}
+		break
+	}
+	// Non-mutating (or plain) EXPLAIN: read-only. Promote to SelectInfoSchema on
+	// a system-schema reference, else Explain.
+	if hasSystemSchema(statement) {
+		return SelectInfoSchema
+	}
+	return Explain
+}
+
+// skipParenGroup consumes tokens through the ')' that balances an already-read
+// '(' (used to skip an EXPLAIN option list).
+func skipParenGroup(l *parser.Lexer) {
+	depth := 1
+	for depth > 0 {
+		tok := l.NextToken()
+		if tok.Kind == tokEOF {
+			return
+		}
+		switch tok.Kind {
+		case int('('):
+			depth++
+		case int(')'):
+			depth--
+		}
+	}
+}
+
+// refineSelect promotes a Select classification to SelectInfoSchema when the
+// statement text references a system/information schema. SET/RESET SESSION are
+// left as Select (they have no table reference). The check is a case-insensitive
+// substring scan over the whole statement, exactly as the legacy
+// containsSystemSchema does.
+func refineSelect(statement string, base QueryType) QueryType {
+	if base != Select {
+		return base
+	}
+	if hasSystemSchema(statement) {
+		return SelectInfoSchema
+	}
+	return base
+}
+
+// hasSystemSchema reports whether the statement text references a Trino
+// system/information schema, via the same case-insensitive substring scan the
+// legacy containsSystemSchema uses.
+func hasSystemSchema(statement string) bool {
+	lower := strings.ToLower(statement)
+	for _, prefix := range systemSchemaPrefixes {
+		if strings.Contains(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/trino/analysis/classify_test.go
+++ b/trino/analysis/classify_test.go
@@ -1,0 +1,103 @@
+package analysis
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want QueryType
+	}{
+		// ---- SELECT family ----
+		{"plain select", "SELECT 1", Select},
+		{"select from table", "SELECT a FROM t", Select},
+		{"with cte select", "WITH c AS (SELECT 1) SELECT * FROM c", Select},
+		{"table query", "TABLE orders", Select},
+		{"values query", "VALUES (1), (2)", Select},
+		{"parenthesized select", "(SELECT 1)", Select},
+		{"lowercase select", "select 1", Select},
+		{"leading whitespace and comment", "  -- hi\n SELECT 1", Select},
+
+		// ---- SelectInfoSchema: SELECT touching a system/info schema ----
+		{"select information_schema", "SELECT * FROM information_schema.tables", SelectInfoSchema},
+		{"select system schema", "SELECT * FROM system.runtime.nodes", SelectInfoSchema},
+		{"select metadata schema", "SELECT * FROM metadata.foo", SelectInfoSchema},
+		{"with cte over information_schema", "WITH c AS (SELECT * FROM information_schema.columns) SELECT * FROM c", SelectInfoSchema},
+
+		// ---- SHOW / DESCRIBE family → SelectInfoSchema ----
+		{"show tables", "SHOW TABLES", SelectInfoSchema},
+		{"show schemas", "SHOW SCHEMAS", SelectInfoSchema},
+		{"show columns", "SHOW COLUMNS FROM t", SelectInfoSchema},
+		{"show catalogs", "SHOW CATALOGS", SelectInfoSchema},
+		{"describe", "DESCRIBE t", SelectInfoSchema},
+		{"desc", "DESC t", SelectInfoSchema},
+
+		// ---- EXPLAIN family ----
+		{"explain select", "EXPLAIN SELECT 1", Explain},
+		{"explain analyze select", "EXPLAIN ANALYZE SELECT a FROM t", Explain},
+
+		// ---- DML ----
+		{"insert", "INSERT INTO t VALUES (1)", DML},
+		{"insert select", "INSERT INTO t SELECT * FROM s", DML},
+		{"update", "UPDATE t SET a = 1", DML},
+		{"delete", "DELETE FROM t WHERE a = 1", DML},
+		{"merge", "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE", DML},
+		{"truncate", "TRUNCATE TABLE t", DML},
+		{"call", "CALL system.runtime.kill_query('x')", DML},
+
+		// ---- DDL ----
+		{"create table", "CREATE TABLE t (id INT)", DDL},
+		{"create table as", "CREATE TABLE t AS SELECT 1", DDL},
+		{"create view", "CREATE VIEW v AS SELECT 1", DDL},
+		{"create schema", "CREATE SCHEMA s", DDL},
+		{"alter table", "ALTER TABLE t ADD COLUMN c INT", DDL},
+		{"drop table", "DROP TABLE t", DDL},
+		{"drop view", "DROP VIEW v", DDL},
+		{"drop schema", "DROP SCHEMA s", DDL},
+		{"comment on", "COMMENT ON TABLE t IS 'x'", DDL},
+		{"analyze", "ANALYZE t", DDL},
+		{"grant", "GRANT SELECT ON t TO u", DDL},
+		{"revoke", "REVOKE SELECT ON t FROM u", DDL},
+		{"deny", "DENY SELECT ON t TO u", DDL},
+		{"create role", "CREATE ROLE r", DDL},
+		{"drop role", "DROP ROLE r", DDL},
+		{"refresh materialized view", "REFRESH MATERIALIZED VIEW mv", DDL},
+
+		// ---- Session / admin: read-only-ish, classified Select per legacy ----
+		{"set session", "SET SESSION x = 1", Select},
+		{"reset session", "RESET SESSION x", Select},
+
+		// ---- Unknown / empty ----
+		{"empty", "", Unknown},
+		{"whitespace only", "   \n  ", Unknown},
+		{"comment only", "-- just a comment", Unknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Classify(tt.sql)
+			if got != tt.want {
+				t.Errorf("Classify(%q) = %v, want %v", tt.sql, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryType_String(t *testing.T) {
+	tests := []struct {
+		qt   QueryType
+		want string
+	}{
+		{Select, "SELECT"},
+		{SelectInfoSchema, "SELECT_INFO_SCHEMA"},
+		{Explain, "EXPLAIN"},
+		{DML, "DML"},
+		{DDL, "DDL"},
+		{Unknown, "UNKNOWN"},
+	}
+	for _, tt := range tests {
+		if got := tt.qt.String(); got != tt.want {
+			t.Errorf("QueryType(%d).String() = %q, want %q", tt.qt, got, tt.want)
+		}
+	}
+}

--- a/trino/analysis/oracle_test.go
+++ b/trino/analysis/oracle_test.go
@@ -1,0 +1,144 @@
+package analysis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bytebase/omni/trino/internal/trinooracle"
+)
+
+// This file is the analysis node's slice of the differential-oracle gate
+// (correctness-protocol.md). analysis is a feature node, so the oracle is not
+// used to adjudicate a grammar accept/reject — that is the parser nodes' job.
+// What the oracle pins here is that the SQL the span/classify tests assert over
+// is REAL Trino 481 syntax: if a corpus statement the tests treat as a valid
+// SELECT were actually rejected by Trino, the lineage/classification assertions
+// built on it would be meaningless. The oracle therefore confirms accept/reject
+// for the whole corpus and cross-checks the read-only classification against
+// Trino's own verdict.
+//
+// All subtests skip cleanly when no Trino is reachable, matching the harness
+// convention (oracle_foundation_test.go).
+
+// connectOracle dials the live Trino oracle, skipping the test when unreachable.
+func connectOracle(t *testing.T) *trinooracle.Oracle {
+	t.Helper()
+	o := trinooracle.Connect("")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ver, err := o.Ping(ctx)
+	if err != nil {
+		t.Skipf("trino oracle not reachable (start: docker run -d -p 18080:8080 %s): %v",
+			trinooracle.DefaultImage, err)
+	}
+	t.Logf("connected to Trino %s", ver)
+	return o
+}
+
+func oracleAccepts(t *testing.T, o *trinooracle.Oracle, sql string) (accepted, ok bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := o.CheckSyntax(ctx, sql)
+	if err != nil {
+		return false, false
+	}
+	return res.Accepted, true
+}
+
+// readOnlyCorpus pairs each statement with whether Trino should accept it AND
+// whether the analysis classifier deems it read-only (Select/SelectInfoSchema/
+// Explain). The corpus is intentionally schema-light (every table is created in
+// the oracle's memory catalog below) so the only verdict that varies is
+// accept/reject of the SYNTAX, which is what we cross-check.
+var readOnlyCorpus = []struct {
+	sql        string
+	wantType   QueryType
+	isReadOnly bool
+}{
+	{"SELECT a FROM t", Select, true},
+	{"SELECT * FROM t1 JOIN t2 ON t1.id = t2.id", Select, true},
+	{"WITH c AS (SELECT a FROM t) SELECT a FROM c", Select, true},
+	{"SELECT a FROM t WHERE b IN (SELECT b FROM t2)", Select, true},
+	{"SELECT a FROM t UNION SELECT a2 FROM t2", Select, true},
+	{"SELECT * FROM information_schema.tables", SelectInfoSchema, true},
+	{"SHOW TABLES", SelectInfoSchema, true},
+	{"SHOW SCHEMAS", SelectInfoSchema, true},
+	{"DESCRIBE t", SelectInfoSchema, true},
+	{"EXPLAIN SELECT a FROM t", Explain, true},
+	{"EXPLAIN ANALYZE SELECT a FROM t", Explain, true},
+	// EXPLAIN ANALYZE executes its inner statement: a mutating inner statement
+	// is NOT read-only (oracle confirms Trino runs it).
+	{"EXPLAIN ANALYZE INSERT INTO t VALUES (1)", DML, false},
+	// Plain EXPLAIN never executes, so EXPLAIN of a DML stays read-only.
+	{"EXPLAIN INSERT INTO t VALUES (1)", Explain, true},
+	{"INSERT INTO t VALUES (1)", DML, false},
+	{"DELETE FROM t WHERE a = 1", DML, false},
+	{"UPDATE t SET a = 2 WHERE a = 1", DML, false},
+	{"CREATE TABLE t3 (a integer)", DDL, false},
+	{"DROP TABLE t3", DDL, false},
+}
+
+// TestAnalysis_ClassificationDifferential confirms each corpus statement is
+// syntactically accepted by Trino 481, and that the analysis classifier's
+// read-only verdict agrees with Trino's read-only/data-changing nature.
+// Read-only-ness is checked structurally (a SELECT/SHOW/EXPLAIN is read-only; an
+// INSERT/DELETE/UPDATE/CREATE/DROP is not) — the classifier must put each
+// statement on the correct side of that line.
+func TestAnalysis_ClassificationDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+
+	// Seed the schema objects so the corpus statements reach Trino's PARSER
+	// without being rejected for missing tables (a missing-table error is a
+	// SEMANTIC, not SYNTAX, rejection — CheckSyntax already treats it as
+	// "accepted" — but seeding keeps the corpus runnable end to end).
+	setup := []string{
+		"DROP TABLE IF EXISTS t",
+		"DROP TABLE IF EXISTS t2",
+		"DROP TABLE IF EXISTS t3",
+		"CREATE TABLE t (a integer, b integer, id integer)",
+		"CREATE TABLE t2 (a2 integer, b integer, id integer)",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	for _, s := range setup {
+		if _, err := o.CheckSyntax(ctx, s); err != nil {
+			t.Skipf("oracle setup failed (%q): %v", s, err)
+		}
+	}
+
+	for _, tc := range readOnlyCorpus {
+		tc := tc
+		t.Run(tc.sql, func(t *testing.T) {
+			accepted, ok := oracleAccepts(t, o, tc.sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if !accepted {
+				t.Errorf("Trino 481 REJECTED corpus statement %q — the analysis assertions on it are built on invalid syntax", tc.sql)
+				return
+			}
+
+			gotType := Classify(tc.sql)
+			if gotType != tc.wantType {
+				t.Errorf("Classify(%q) = %v, want %v", tc.sql, gotType, tc.wantType)
+			}
+
+			gotReadOnly := isReadOnly(gotType)
+			if gotReadOnly != tc.isReadOnly {
+				t.Errorf("isReadOnly(%q) = %v (type %v), want %v",
+					tc.sql, gotReadOnly, gotType, tc.isReadOnly)
+			}
+		})
+	}
+}
+
+// isReadOnly mirrors the bytebase validateQuery read-only guard: a statement is
+// read-only iff it is a Select, Explain, or SelectInfoSchema.
+func isReadOnly(qt QueryType) bool {
+	return qt == Select || qt == Explain || qt == SelectInfoSchema
+}

--- a/trino/analysis/query_span.go
+++ b/trino/analysis/query_span.go
@@ -1,0 +1,949 @@
+package analysis
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+	"github.com/bytebase/omni/trino/parser"
+)
+
+// QuerySpan captures the tables and columns a query references. It is the data
+// structure Bytebase consumes for field-level lineage (masking) and for SQL
+// editor access tracking (read/write permission checks). It is the omni
+// counterpart of the legacy plugin/parser/trino GetQuerySpan result.
+//
+// The extraction is best-effort and parser-driven: it walks the SELECT / set-op
+// / CTE / FROM / expression tree the trino/parser produces. Known best-effort
+// boundaries (each a deliberate scope decision, matching the doris/analysis
+// precedent — full resolution belongs to a later metadata-aware layer):
+//   - `SELECT *` is not expanded against catalog metadata (needs a
+//     DatabaseMetadata the completion/bytebase layer supplies); a star item is
+//     recorded by name only ("*").
+//   - A column reference is recorded by its written (catalog/schema/)table/
+//     column parts; it is not resolved to which FROM relation actually owns it.
+//   - A named-window reference (`OVER w`) is not resolved to window w's
+//     definition, so its partition/order columns are captured as predicate
+//     columns (via the WINDOW clause walk) but not attributed to the specific
+//     OVER-w result column.
+type QuerySpan struct {
+	// Type is the statement classification (Select, DML, DDL, ...).
+	Type QueryType
+
+	// AccessTables is the set of base tables the query reads from: every
+	// physical table reference in FROM clauses, JOINs, and subqueries. Entries
+	// are deduplicated on (catalog, schema, table, alias); CTE references and
+	// derived-table aliases are excluded.
+	AccessTables []TableAccess
+
+	// Results is the list of output columns produced by the outermost query. For
+	// a set operation (UNION/INTERSECT/EXCEPT) the left arm wins, matching SQL's
+	// "column names come from the first select" rule.
+	Results []ColumnInfo
+
+	// PredicateColumns is the set of columns referenced in filter/join positions
+	// (WHERE, JOIN ON, HAVING, QUALIFY). Bytebase uses these for row-level
+	// masking policy evaluation. Deduplicated.
+	PredicateColumns []ColumnRef
+
+	// CTEs lists the names defined by WITH clauses at any scope, in declaration
+	// order — useful for consumers and for debugging the CTE structure.
+	CTEs []string
+}
+
+// TableAccess represents one physical table referenced in a query. In Trino a
+// fully-qualified name is catalog.schema.table; the optional qualifiers are
+// empty when the source name omitted them (resolution against the session's
+// current catalog/schema is the engine's job, not the parser's).
+type TableAccess struct {
+	Catalog string  // optional catalog qualifier (empty when none)
+	Schema  string  // optional schema qualifier (empty when none)
+	Table   string  // table (or view) name
+	Alias   string  // alias at the reference site (empty when none)
+	Loc     ast.Loc // source location of the table reference
+}
+
+// ColumnInfo represents one output column of a query result.
+type ColumnInfo struct {
+	// Name is the output column name: the explicit alias if present, otherwise a
+	// best-effort rendering of the expression (the column name for a bare
+	// column reference, "*" for a star item, or "" when none can be derived).
+	Name string
+
+	// SourceColumns is the best-effort list of column references that directly
+	// feed this output column (the column refs in the select-item expression,
+	// excluding those inside nested subqueries).
+	SourceColumns []ColumnRef
+}
+
+// ColumnRef identifies a column by its optional catalog/schema/table qualifier
+// and its name. Trino column references are at most table.column inside a query
+// (catalog/schema qualification on a column is rare but legal via a longer
+// dotted chain); the rightmost component is always the column.
+type ColumnRef struct {
+	Catalog string
+	Schema  string
+	Table   string
+	Column  string
+}
+
+// GetQuerySpan analyzes a single Trino SQL statement and returns its query
+// span: the statement classification, the base tables it reads, the CTE names
+// it defines, its output columns with their source columns, and the columns
+// used in predicate positions.
+//
+// It is tolerant of parse errors — if the parser produces a partial AST,
+// whatever parsed is still analyzed. On empty input it returns a zero-valued
+// span with Type=Unknown.
+func GetQuerySpan(statement string) (*QuerySpan, error) {
+	file, _ := parser.Parse(statement)
+	span := &QuerySpan{Type: Classify(statement)}
+	if file == nil || len(file.Stmts) == 0 {
+		return span, nil
+	}
+
+	w := newSpanWalker(span)
+	for _, stmt := range file.Stmts {
+		w.analyzeStmt(stmt)
+	}
+	return span, nil
+}
+
+// ---------------------------------------------------------------------------
+// CTE scope
+// ---------------------------------------------------------------------------
+
+// cteScope is a linked stack of CTE name sets. Resolving a bare table reference
+// walks outwards; an inner CTE shadows an outer one of the same name.
+type cteScope struct {
+	names  map[string]bool
+	parent *cteScope
+}
+
+func (s *cteScope) isCTE(name string) bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.names[strings.ToLower(name)] {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Walker
+// ---------------------------------------------------------------------------
+
+// spanWalker walks the query tree the trino/parser produces (parser-package
+// node types — Query / QueryNode / Relation / Expr — not ast.Node, so it cannot
+// reuse ast.Walk). It maintains:
+//   - a CTE scope stack so bare table references that name a CTE are filtered
+//     out of AccessTables;
+//   - a dedup map of (catalog, schema, table, alias) for AccessTables;
+//   - a dedup map for PredicateColumns;
+//   - a flag tracking whether the outermost query has populated Results yet.
+type spanWalker struct {
+	span     *QuerySpan
+	scope    *cteScope
+	accessed map[tableKey]bool
+	predSeen map[ColumnRef]bool
+	resolved bool // Results captured for the outermost query
+}
+
+type tableKey struct {
+	Catalog string
+	Schema  string
+	Table   string
+	Alias   string
+}
+
+func newSpanWalker(span *QuerySpan) *spanWalker {
+	return &spanWalker{
+		span:     span,
+		accessed: make(map[tableKey]bool),
+		predSeen: make(map[ColumnRef]bool),
+	}
+}
+
+// analyzeStmt dispatches on the top-level statement node. Only the query
+// statement (QueryStmt) yields query-span data; other statement kinds are
+// recorded via their Type classification only.
+func (w *spanWalker) analyzeStmt(node ast.Node) {
+	if qs, ok := node.(*parser.QueryStmt); ok && qs.Query != nil {
+		w.visitQuery(qs.Query, true /* outermost */)
+	}
+}
+
+// visitQuery walks a `Query` (optional WITH + a queryNoWith body with its own
+// ORDER BY/OFFSET/LIMIT/FETCH). The WITH clause defines a new CTE scope visible
+// to the body and to sibling CTE bodies.
+func (w *spanWalker) visitQuery(q *parser.Query, outermost bool) {
+	if q == nil {
+		return
+	}
+
+	scope := &cteScope{names: make(map[string]bool), parent: w.scope}
+	if q.With != nil {
+		for _, cte := range q.With.CTEs {
+			name := identName(cte.Name)
+			if name == "" {
+				continue
+			}
+			scope.names[strings.ToLower(name)] = true
+			w.span.CTEs = append(w.span.CTEs, name)
+		}
+	}
+	w.scope = scope
+
+	// Walk CTE bodies first so their base tables land in AccessTables. They run
+	// in the scope that already includes the sibling CTE names (matching the
+	// legacy extractor's permissive visibility).
+	if q.With != nil {
+		for _, cte := range q.With.CTEs {
+			w.visitQuery(cte.Query, false)
+		}
+	}
+
+	// The query body (a queryNoWith) carries the result columns when outermost.
+	w.visitQueryNode(q.Body, outermost)
+
+	// queryNoWith-level ORDER BY keys may reference columns; walk them as
+	// predicate-ish expressions (collecting column refs, recursing subqueries).
+	for _, item := range q.OrderBy {
+		w.walkExprPredicate(item.Expr)
+	}
+	if q.Offset != nil {
+		w.walkExprPredicate(q.Offset.Count)
+	}
+	if q.Limit != nil {
+		w.walkExprPredicate(q.Limit.Count)
+	}
+	if q.Fetch != nil {
+		w.walkExprPredicate(q.Fetch.Count)
+	}
+
+	w.scope = scope.parent
+}
+
+// visitQueryNode dispatches on a query body / set-op operand / query primary.
+func (w *spanWalker) visitQueryNode(node parser.QueryNode, outermost bool) {
+	switch n := node.(type) {
+	case *parser.QuerySpec:
+		w.visitQuerySpec(n, outermost)
+	case *parser.SetOperation:
+		w.visitSetOp(n, outermost)
+	case *parser.ParenQuery:
+		if n.Inner != nil {
+			w.visitQuery(n.Inner, outermost)
+		}
+	case *parser.TableQuery:
+		// TABLE name == SELECT * FROM name: record the table and a single star
+		// result column when this is the outermost query.
+		w.recordTable(n.Name, "")
+		if outermost && !w.resolved {
+			w.span.Results = append(w.span.Results, ColumnInfo{Name: "*"})
+			w.resolved = true
+		}
+	case *parser.ValuesQuery:
+		for _, row := range n.Rows {
+			w.walkExprPredicate(row)
+		}
+	}
+}
+
+// visitSetOp walks a UNION/INTERSECT/EXCEPT tree. The left arm surfaces its
+// Results when this is the outermost statement (SQL's first-select rule); the
+// right arm never does.
+func (w *spanWalker) visitSetOp(n *parser.SetOperation, outermost bool) {
+	if n == nil {
+		return
+	}
+	w.visitQueryNode(n.Left, outermost)
+	w.visitQueryNode(n.Right, false)
+}
+
+// visitQuerySpec processes one querySpecification (a SELECT block): its FROM
+// relations, predicate clauses, and select list.
+func (w *spanWalker) visitQuerySpec(spec *parser.QuerySpec, outermost bool) {
+	if spec == nil {
+		return
+	}
+
+	for _, rel := range spec.From {
+		w.visitRelation(rel)
+	}
+
+	if spec.Where != nil {
+		w.walkExprPredicate(spec.Where)
+	}
+	if spec.GroupBy != nil {
+		for _, el := range spec.GroupBy.Elements {
+			for _, e := range el.Exprs {
+				w.walkExprPredicate(e)
+			}
+			for _, set := range el.Sets {
+				for _, e := range set {
+					w.walkExprPredicate(e)
+				}
+			}
+		}
+	}
+	if spec.Having != nil {
+		w.walkExprPredicate(spec.Having)
+	}
+	for _, win := range spec.Windows {
+		ew := exprWalk{w: w, followSub: true, onColumn: w.addPredicateColumn}
+		ew.walkWindowSpec(win.Spec)
+	}
+
+	// SELECT list last so Results reflects final column order.
+	for _, item := range spec.Items {
+		if outermost && !w.resolved {
+			w.span.Results = append(w.span.Results, w.makeColumnInfo(item))
+		}
+		// Walk the item expression to pick up subquery tables (the direct
+		// column refs are captured in makeColumnInfo; here we only need the
+		// subqueries and any deeper table references).
+		w.walkExprSubqueries(item.Expr)
+	}
+	if outermost {
+		w.resolved = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Relations (FROM)
+// ---------------------------------------------------------------------------
+
+// visitRelation walks one FROM relation, threading an optional alias down only
+// to a direct base-table primary.
+func (w *spanWalker) visitRelation(rel parser.Relation) {
+	switch n := rel.(type) {
+	case *parser.AliasedRelation:
+		w.visitAliasedRelation(n)
+	case *parser.Join:
+		w.visitRelation(n.Left)
+		w.visitRelation(n.Right)
+		w.walkExprPredicate(n.On)
+		// USING (col, …) names join-key columns — record them as predicate
+		// columns (they are unqualified; resolution to a side is the engine's).
+		for _, id := range n.Using {
+			if name := identName(id); name != "" {
+				w.addPredicateColumn(ColumnRef{Column: name})
+			}
+		}
+	case *parser.ParenRelation:
+		w.visitRelation(n.Inner)
+	case *parser.TableRelation:
+		w.recordTable(n.Name, "")
+	case *parser.SubqueryRelation:
+		w.visitQuery(n.Query, false)
+	case *parser.LateralRelation:
+		w.visitQuery(n.Query, false)
+	case *parser.UnnestRelation:
+		for _, e := range n.Exprs {
+			w.walkExprPredicate(e)
+		}
+	case *parser.TableFunctionRelation:
+		w.visitTableFunctionCall(n.Call)
+	}
+}
+
+// visitAliasedRelation handles a relationPrimary wrapped in its (optional)
+// alias. The alias attaches to a direct base table only; for a derived table
+// (subquery / lateral / unnest / table function) the alias names the derived
+// relation, not its underlying base tables, so it is not propagated.
+func (w *spanWalker) visitAliasedRelation(n *parser.AliasedRelation) {
+	if n == nil {
+		return
+	}
+	alias := identName(n.Alias)
+	switch inner := n.Inner.(type) {
+	case *parser.TableRelation:
+		w.recordTable(inner.Name, alias)
+	default:
+		w.visitRelation(n.Inner)
+	}
+}
+
+// visitTableFunctionCall walks a table-function invocation's table arguments,
+// which may themselves name base tables or wrap subqueries.
+func (w *spanWalker) visitTableFunctionCall(call *parser.TableFunctionCall) {
+	if call == nil {
+		return
+	}
+	for _, arg := range call.Args {
+		switch arg.Kind {
+		case parser.TFArgExpr:
+			w.walkExprPredicate(arg.Expr)
+		case parser.TFArgTable:
+			if arg.Table != nil {
+				if arg.Table.Query != nil {
+					w.visitQuery(arg.Table.Query, false)
+				} else if arg.Table.Name != nil {
+					w.recordTable(arg.Table.Name, "")
+				}
+				for _, e := range arg.Table.PartitionBy {
+					w.walkExprPredicate(e)
+				}
+				for _, item := range arg.Table.OrderBy {
+					w.walkExprPredicate(item.Expr)
+				}
+			}
+		}
+	}
+}
+
+// recordTable adds a base-table reference to AccessTables unless it names an
+// in-scope CTE or is a duplicate. The qualified name's components map to
+// (catalog, schema, table): a 1-part name is the table; 2-part is schema.table;
+// 3-part (or longer) is catalog.schema.table on the rightmost three parts.
+func (w *spanWalker) recordTable(name *ast.QualifiedName, alias string) {
+	parts := normalizedParts(name)
+	if len(parts) == 0 {
+		return
+	}
+
+	var catalog, schema, table string
+	switch len(parts) {
+	case 1:
+		table = parts[0]
+		// A bare (single-part) name that matches an in-scope CTE is a CTE
+		// reference, not a base table — exclude it regardless of any alias
+		// (`FROM c` and `FROM c AS x` both reference the CTE c).
+		if w.scope.isCTE(table) {
+			return
+		}
+	case 2:
+		schema = parts[0]
+		table = parts[1]
+	default:
+		catalog = parts[len(parts)-3]
+		schema = parts[len(parts)-2]
+		table = parts[len(parts)-1]
+	}
+
+	key := tableKey{Catalog: catalog, Schema: schema, Table: table, Alias: alias}
+	if w.accessed[key] {
+		return
+	}
+	w.accessed[key] = true
+
+	loc := ast.Loc{}
+	if name != nil {
+		loc = name.Loc
+	}
+	w.span.AccessTables = append(w.span.AccessTables, TableAccess{
+		Catalog: catalog,
+		Schema:  schema,
+		Table:   table,
+		Alias:   alias,
+		Loc:     loc,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Expression walking
+// ---------------------------------------------------------------------------
+
+// exprWalk parameterizes a single expression traversal so the walker code is
+// written once and reused for the two concerns it serves:
+//   - onColumn is invoked for each column reference encountered (nil to ignore
+//     columns — used when a pass only needs to discover subquery tables).
+//   - followSub controls whether subquery placeholders are recursed into by
+//     re-parsing their raw text (true for predicate/table discovery; false when
+//     collecting a select item's DIRECT columns, which must not cross a
+//     subquery boundary).
+//
+// Threading these through one walker (rather than two near-identical type
+// switches) keeps the ~40-arm expr dispatch in a single place, so a new
+// expression node type cannot be handled in one pass but silently dropped in
+// the other.
+type exprWalk struct {
+	w         *spanWalker
+	onColumn  func(ColumnRef)
+	followSub bool
+}
+
+// addPredicateColumn appends a column reference to PredicateColumns,
+// deduplicating against earlier predicate columns.
+func (w *spanWalker) addPredicateColumn(ref ColumnRef) {
+	if w.predSeen[ref] {
+		return
+	}
+	w.predSeen[ref] = true
+	w.span.PredicateColumns = append(w.span.PredicateColumns, ref)
+}
+
+// walkExprPredicate walks a predicate-position expression (WHERE / ON / HAVING /
+// GROUP BY / ORDER BY / VALUES), collecting its column references into
+// PredicateColumns and recursing into any subqueries (which may reference more
+// base tables).
+func (w *spanWalker) walkExprPredicate(expr parser.Expr) {
+	ew := exprWalk{
+		w:         w,
+		followSub: true,
+		onColumn:  w.addPredicateColumn,
+	}
+	ew.walk(expr)
+}
+
+// walkExprSubqueries walks a select-item expression purely to discover the base
+// tables inside nested subqueries; the item's direct column refs are captured
+// separately by makeColumnInfo, so column refs are ignored here.
+func (w *spanWalker) walkExprSubqueries(expr parser.Expr) {
+	ew := exprWalk{w: w, followSub: true}
+	ew.walk(expr)
+}
+
+// walk is the shared expression traversal. It descends every expression child
+// of the trino expr model, invoking onColumn for each column reference (a
+// ColumnRef or a Dereference chain), and — when followSub is set — recursing
+// into subquery placeholders by re-parsing their raw text. Expression node
+// types that cannot contain a column or subquery are leaves.
+func (ew exprWalk) walk(expr parser.Expr) {
+	onColumn := ew.onColumn
+	switch e := expr.(type) {
+	case nil:
+		return
+
+	// Column references.
+	case *parser.ColumnRef:
+		if onColumn != nil {
+			if ref, ok := columnRefFrom(e); ok {
+				onColumn(ref)
+			}
+		}
+	case *parser.Dereference:
+		// A dotted name (t.a / cat.sch.t.col) is a Dereference chain over a
+		// ColumnRef. Flatten it into a single qualified ColumnRef; if the base
+		// is not a plain name chain (e.g. field access on a function result),
+		// fall back to walking the base expression.
+		if ref, ok := dereferenceRef(e); ok {
+			if onColumn != nil {
+				onColumn(ref)
+			}
+		} else {
+			ew.walk(e.Base)
+		}
+
+	// Subquery placeholders — re-parse the raw inner text and recurse, but only
+	// when this pass follows subqueries (a select item's direct-column pass does
+	// not cross the subquery boundary).
+	case *parser.SubqueryExpr:
+		ew.followSubquery(e)
+
+	// Composite expressions — recurse into children.
+	case *parser.Subscript:
+		ew.walk(e.Value)
+		ew.walk(e.Index)
+	case *parser.UnaryExpr:
+		ew.walk(e.Operand)
+	case *parser.BinaryExpr:
+		ew.walk(e.Left)
+		ew.walk(e.Right)
+	case *parser.LogicalExpr:
+		ew.walk(e.Left)
+		ew.walk(e.Right)
+	case *parser.NotExpr:
+		ew.walk(e.Operand)
+	case *parser.AtTimeZoneExpr:
+		ew.walk(e.Value)
+		ew.walk(e.Zone)
+	case *parser.ParenExpr:
+		ew.walk(e.Expr)
+	case *parser.RowConstructor:
+		ew.walkList(e.Elements)
+	case *parser.ArrayConstructor:
+		ew.walkList(e.Elements)
+	case *parser.ComparisonExpr:
+		ew.walk(e.Left)
+		ew.walk(e.Right)
+	case *parser.QuantifiedComparisonExpr:
+		ew.walk(e.Left)
+		ew.followSubquery(e.Subquery)
+	case *parser.BetweenExpr:
+		ew.walk(e.Value)
+		ew.walk(e.Lower)
+		ew.walk(e.Upper)
+	case *parser.InListExpr:
+		ew.walk(e.Value)
+		ew.walkList(e.List)
+	case *parser.InSubqueryExpr:
+		ew.walk(e.Value)
+		ew.followSubquery(e.Subquery)
+	case *parser.LikeExpr:
+		ew.walk(e.Value)
+		ew.walk(e.Pattern)
+		ew.walk(e.Escape)
+	case *parser.IsNullExpr:
+		ew.walk(e.Value)
+	case *parser.IsDistinctFromExpr:
+		ew.walk(e.Value)
+		ew.walk(e.Right)
+	case *parser.FuncCall:
+		ew.walkList(e.Args)
+		for _, item := range e.OrderBy {
+			ew.walk(item.Expr)
+		}
+		ew.walk(e.Filter)
+		ew.walkWindowSpec(e.Over)
+	case *parser.LambdaExpr:
+		// Lambda parameters (the `x` in `x -> …`) are bound variables, not table
+		// columns. Walk the body with an onColumn that drops any reference whose
+		// unqualified name matches a parameter, so free (outer) columns still
+		// surface but the bound params do not pollute lineage.
+		ew.walkLambdaBody(e)
+	case *parser.CaseExpr:
+		ew.walk(e.Operand)
+		for _, when := range e.Whens {
+			ew.walk(when.Cond)
+			ew.walk(when.Result)
+		}
+		ew.walk(e.Else)
+	case *parser.CastExpr:
+		ew.walk(e.Expr)
+	case *parser.ExtractExpr:
+		ew.walk(e.Source)
+	case *parser.SubstringExpr:
+		ew.walk(e.Source)
+		ew.walk(e.From)
+		ew.walk(e.For)
+	case *parser.TrimExpr:
+		ew.walk(e.Char)
+		ew.walk(e.Source)
+	case *parser.NormalizeExpr:
+		ew.walk(e.Source)
+	case *parser.PositionExpr:
+		ew.walk(e.Needle)
+		ew.walk(e.Haystack)
+	case *parser.ListaggExpr:
+		ew.walk(e.Arg)
+		ew.walk(e.Separator)
+		for _, item := range e.WithinGroupBy {
+			ew.walk(item.Expr)
+		}
+		ew.walk(e.Filter)
+	case *parser.GroupingExpr:
+		// GROUPING(col, …) references each named column.
+		if onColumn != nil {
+			for _, qn := range e.Args {
+				if parts := normalizedParts(qn); len(parts) > 0 {
+					onColumn(columnRefFromParts(parts))
+				}
+			}
+		}
+
+	// SQL/JSON functions — the path input and arguments are column positions.
+	case *parser.JSONExistsExpr:
+		ew.walkJSONPath(e.Path)
+	case *parser.JSONValueFunc:
+		ew.walkJSONPath(e.Path)
+		if e.OnEmpty != nil {
+			ew.walk(e.OnEmpty.Default)
+		}
+		if e.OnError != nil {
+			ew.walk(e.OnError.Default)
+		}
+	case *parser.JSONQueryFunc:
+		ew.walkJSONPath(e.Path)
+	case *parser.JSONObjectExpr:
+		for _, m := range e.Members {
+			ew.walk(m.Key)
+			ew.walkJSONValueExpr(m.Value)
+		}
+	case *parser.JSONArrayExpr:
+		for _, el := range e.Elements {
+			ew.walkJSONValueExpr(el)
+		}
+
+	// Leaves (literals, parameters, special date/time funcs, interval, typed
+	// literals) carry no column or subquery and need no recursion.
+	default:
+		return
+	}
+}
+
+// followSubquery recurses into a subquery placeholder by re-parsing its raw
+// text, but only when this pass follows subqueries. A nil placeholder is a
+// no-op.
+func (ew exprWalk) followSubquery(sub *parser.SubqueryExpr) {
+	if !ew.followSub || sub == nil {
+		return
+	}
+	ew.w.analyzeSubqueryText(sub.RawText)
+}
+
+// walkLambdaBody walks a lambda's body with the bound parameter names excluded
+// from column collection. A lambda parameter is an unqualified single
+// identifier; a body reference to that bare name is the bound variable, not a
+// table column, so it is dropped — while qualified references and free
+// (outer-scope) column names still pass through to onColumn.
+func (ew exprWalk) walkLambdaBody(lambda *parser.LambdaExpr) {
+	if lambda == nil {
+		return
+	}
+	if ew.onColumn == nil {
+		ew.walk(lambda.Body)
+		return
+	}
+	params := make(map[string]bool, len(lambda.Params))
+	for _, p := range lambda.Params {
+		if name := identName(p); name != "" {
+			params[name] = true
+		}
+	}
+	inner := ew
+	outer := ew.onColumn
+	inner.onColumn = func(ref ColumnRef) {
+		// Drop a reference whose ROOT name is a bound parameter: either a bare
+		// `x` (param used as a value) or a field access `x.field` (which flattens
+		// to a ColumnRef whose leftmost qualifier is the param). Both are uses of
+		// the bound variable, not table columns.
+		if params[rootName(ref)] {
+			return
+		}
+		outer(ref)
+	}
+	inner.walk(lambda.Body)
+}
+
+// rootName returns the leftmost (most-qualifying) name of a column reference:
+// the catalog if present, else the schema, else the table, else the column. For
+// a flattened dereference like x.price (ColumnRef{Table:"x", Column:"price"})
+// the root is "x"; for a bare column it is the column name itself.
+func rootName(ref ColumnRef) string {
+	switch {
+	case ref.Catalog != "":
+		return ref.Catalog
+	case ref.Schema != "":
+		return ref.Schema
+	case ref.Table != "":
+		return ref.Table
+	default:
+		return ref.Column
+	}
+}
+
+// walkJSONPath walks a SQL/JSON path invocation's input expression and PASSING
+// arguments for column references (the path string itself is opaque).
+func (ew exprWalk) walkJSONPath(path *parser.JSONPathInvocation) {
+	if path == nil {
+		return
+	}
+	ew.walkJSONValueExpr(path.Input)
+	for _, arg := range path.Passing {
+		ew.walkJSONValueExpr(arg.Value)
+	}
+}
+
+// walkJSONValueExpr walks a `expression [FORMAT …]` JSON value expression.
+func (ew exprWalk) walkJSONValueExpr(v *parser.JSONValueExpr) {
+	if v == nil {
+		return
+	}
+	ew.walk(v.Expr)
+}
+
+// walkList walks each expression in a slice.
+func (ew exprWalk) walkList(exprs []parser.Expr) {
+	for _, e := range exprs {
+		ew.walk(e)
+	}
+}
+
+// walkWindowSpec walks an inline/named window specification's PARTITION BY and
+// ORDER BY expressions and frame bounds for column/subquery references, reusing
+// this pass's onColumn/followSub settings.
+func (ew exprWalk) walkWindowSpec(spec *parser.WindowSpec) {
+	if spec == nil {
+		return
+	}
+	ew.walkList(spec.PartitionBy)
+	for _, item := range spec.OrderBy {
+		ew.walk(item.Expr)
+	}
+	if spec.Frame != nil {
+		ew.walk(spec.Frame.Start.Value)
+		if spec.Frame.End != nil {
+			ew.walk(spec.Frame.End.Value)
+		}
+	}
+}
+
+// analyzeSubqueryText re-parses an expression-embedded subquery's raw inner text
+// and recurses into the resulting query. Errors are swallowed — an unparseable
+// subquery leaves the already-discovered tables intact (best-effort).
+func (w *spanWalker) analyzeSubqueryText(text string) {
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	file, _ := parser.Parse(text)
+	if file == nil {
+		return
+	}
+	for _, stmt := range file.Stmts {
+		if qs, ok := stmt.(*parser.QueryStmt); ok {
+			w.visitQuery(qs.Query, false)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Select-item rendering
+// ---------------------------------------------------------------------------
+
+// makeColumnInfo derives a ColumnInfo from a select-item. Name is the alias if
+// present, else a simple rendering ("*"/"t.*" for a star, the column name for a
+// bare column reference, "" otherwise). SourceColumns is the set of column refs
+// the item's expression directly references (excluding nested subqueries).
+func (w *spanWalker) makeColumnInfo(item parser.SelectItem) ColumnInfo {
+	info := ColumnInfo{}
+	switch item.Kind {
+	case parser.SelectAll:
+		info.Name = "*"
+		return info
+	case parser.SelectAllFrom:
+		// expr.* — name it "<expr>.*" best-effort; the underlying columns are
+		// the column refs in the row expression.
+		if name := renderExprName(item.Expr); name != "" {
+			info.Name = name + ".*"
+		} else {
+			info.Name = "*"
+		}
+		info.SourceColumns = w.collectDirectColumns(item.Expr)
+		return info
+	}
+
+	if name := identName(item.Alias); name != "" {
+		info.Name = name
+	} else {
+		info.Name = renderExprName(item.Expr)
+	}
+	info.SourceColumns = w.collectDirectColumns(item.Expr)
+	return info
+}
+
+// collectDirectColumns returns the column references directly mentioned in expr,
+// in source order, excluding any inside nested subqueries (which are followed
+// for table discovery elsewhere, not for this item's source columns). It is the
+// same traversal as the predicate pass with followSub disabled.
+func (w *spanWalker) collectDirectColumns(expr parser.Expr) []ColumnRef {
+	var refs []ColumnRef
+	ew := exprWalk{
+		w:         w,
+		followSub: false,
+		onColumn:  func(ref ColumnRef) { refs = append(refs, ref) },
+	}
+	ew.walk(expr)
+	return refs
+}
+
+// renderExprName returns a short human-readable name for a select-item
+// expression: the column name for a bare column reference (or the trailing
+// field of a dotted reference), unwrapping a single layer of parentheses. Other
+// expressions have no derivable name ("").
+func renderExprName(expr parser.Expr) string {
+	switch e := expr.(type) {
+	case *parser.ColumnRef:
+		return identName(e.Name)
+	case *parser.Dereference:
+		return identName(e.FieldName)
+	case *parser.ParenExpr:
+		return renderExprName(e.Expr)
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Name helpers
+// ---------------------------------------------------------------------------
+
+// identName returns the normalized (Trino case-folded) name of an identifier,
+// or "" for a nil identifier.
+func identName(id *ast.Identifier) string {
+	if id == nil {
+		return ""
+	}
+	return id.Normalize()
+}
+
+// normalizedParts returns the normalized component names of a qualified name,
+// skipping nil components.
+func normalizedParts(name *ast.QualifiedName) []string {
+	if name == nil {
+		return nil
+	}
+	return name.NormalizedParts()
+}
+
+// columnRefFrom builds a ColumnRef from a bare ColumnRef node (a single
+// identifier). Returns ok=false for a nil node or nil/empty name.
+func columnRefFrom(c *parser.ColumnRef) (ColumnRef, bool) {
+	if c == nil {
+		return ColumnRef{}, false
+	}
+	name := identName(c.Name)
+	if name == "" {
+		return ColumnRef{}, false
+	}
+	return ColumnRef{Column: name}, true
+}
+
+// dereferenceRef flattens a Dereference chain that bottoms out at a ColumnRef
+// into a single qualified ColumnRef (the rightmost component is the column; the
+// preceding ones map to table / schema / catalog). It returns ok=false when the
+// base is not a plain name chain (e.g. a subscript or function result), so the
+// caller can fall back to walking the base expression.
+func dereferenceRef(d *parser.Dereference) (ColumnRef, bool) {
+	parts := flattenDereference(d)
+	if parts == nil {
+		return ColumnRef{}, false
+	}
+	return columnRefFromParts(parts), true
+}
+
+// flattenDereference returns the dotted-name components of a Dereference chain
+// rooted at a ColumnRef (e.g. ["t", "a"] for t.a), or nil when the chain's base
+// is not a ColumnRef.
+func flattenDereference(d *parser.Dereference) []string {
+	if d == nil {
+		return nil
+	}
+	field := identName(d.FieldName)
+	if field == "" {
+		return nil
+	}
+	switch base := d.Base.(type) {
+	case *parser.ColumnRef:
+		root := identName(base.Name)
+		if root == "" {
+			return nil
+		}
+		return []string{root, field}
+	case *parser.Dereference:
+		prefix := flattenDereference(base)
+		if prefix == nil {
+			return nil
+		}
+		return append(prefix, field)
+	default:
+		return nil
+	}
+}
+
+// columnRefFromParts maps the components of a dotted column reference to a
+// ColumnRef. The rightmost part is always the column; the (up to three)
+// preceding parts are table, schema, catalog from right to left.
+func columnRefFromParts(parts []string) ColumnRef {
+	n := len(parts)
+	ref := ColumnRef{Column: parts[n-1]}
+	if n >= 2 {
+		ref.Table = parts[n-2]
+	}
+	if n >= 3 {
+		ref.Schema = parts[n-3]
+	}
+	if n >= 4 {
+		ref.Catalog = parts[n-4]
+	}
+	return ref
+}

--- a/trino/analysis/query_span_test.go
+++ b/trino/analysis/query_span_test.go
@@ -1,0 +1,789 @@
+package analysis
+
+import "testing"
+
+// tableSig is a compact, order-insensitive form of TableAccess used in tests.
+type tableSig struct {
+	Catalog string
+	Schema  string
+	Table   string
+	Alias   string
+}
+
+func toSigs(tables []TableAccess) []tableSig {
+	out := make([]tableSig, len(tables))
+	for i, tbl := range tables {
+		out[i] = tableSig{Catalog: tbl.Catalog, Schema: tbl.Schema, Table: tbl.Table, Alias: tbl.Alias}
+	}
+	return out
+}
+
+func containsSig(haystack []tableSig, needle tableSig) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGetQuerySpan_Basics(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		wantType    QueryType
+		wantTables  []tableSig
+		wantResults []string // output column names, in order
+		wantCTEs    []string
+	}{
+		{
+			name:        "simple select",
+			sql:         "SELECT a FROM t",
+			wantType:    Select,
+			wantTables:  []tableSig{{Table: "t"}},
+			wantResults: []string{"a"},
+		},
+		{
+			name:        "qualified schema.table",
+			sql:         "SELECT * FROM s.t",
+			wantType:    Select,
+			wantTables:  []tableSig{{Schema: "s", Table: "t"}},
+			wantResults: []string{"*"},
+		},
+		{
+			name:        "three-part catalog.schema.table",
+			sql:         "SELECT * FROM cat.sch.tbl",
+			wantType:    Select,
+			wantTables:  []tableSig{{Catalog: "cat", Schema: "sch", Table: "tbl"}},
+			wantResults: []string{"*"},
+		},
+		{
+			name:        "table alias",
+			sql:         "SELECT a FROM t AS x",
+			wantType:    Select,
+			wantTables:  []tableSig{{Table: "t", Alias: "x"}},
+			wantResults: []string{"a"},
+		},
+		{
+			name:        "table alias without AS",
+			sql:         "SELECT a FROM t x",
+			wantType:    Select,
+			wantTables:  []tableSig{{Table: "t", Alias: "x"}},
+			wantResults: []string{"a"},
+		},
+		{
+			name:        "select item alias",
+			sql:         "SELECT a AS col_a, b FROM t",
+			wantType:    Select,
+			wantTables:  []tableSig{{Table: "t"}},
+			wantResults: []string{"col_a", "b"},
+		},
+		{
+			name:     "join of two tables",
+			sql:      "SELECT a, b FROM t1 JOIN t2 ON t1.id = t2.id",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"a", "b"},
+		},
+		{
+			name:     "inner and left join with qualified table",
+			sql:      "SELECT a FROM t1 INNER JOIN t2 ON t1.id = t2.id LEFT JOIN s.t3 ON t1.x = t3.x",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+				{Schema: "s", Table: "t3"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "cross join",
+			sql:      "SELECT * FROM t1 CROSS JOIN t2",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"*"},
+		},
+		{
+			name:     "comma join (implicit cross)",
+			sql:      "SELECT * FROM t1, t2",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"*"},
+		},
+		{
+			name:        "cte exclusion",
+			sql:         "WITH c AS (SELECT * FROM real_t) SELECT * FROM c",
+			wantType:    Select,
+			wantTables:  []tableSig{{Table: "real_t"}},
+			wantResults: []string{"*"},
+			wantCTEs:    []string{"c"},
+		},
+		{
+			name: "multiple ctes chained",
+			sql: `WITH a AS (SELECT id FROM t1),
+			      b AS (SELECT id FROM a JOIN t2 ON a.id = t2.id)
+			      SELECT id FROM b`,
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"id"},
+			wantCTEs:    []string{"a", "b"},
+		},
+		{
+			name:     "subquery in where IN",
+			sql:      "SELECT a FROM t WHERE b IN (SELECT b FROM other)",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "other"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "scalar subquery in select",
+			sql:      "SELECT a, (SELECT max(x) FROM agg) FROM t",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "agg"},
+			},
+		},
+		{
+			name:     "exists subquery",
+			sql:      "SELECT a FROM t WHERE EXISTS (SELECT 1 FROM other WHERE other.id = t.id)",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "other"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "from subquery (parsed into real Query)",
+			sql:      "SELECT x.a FROM (SELECT a FROM inner_t) AS x",
+			wantType: Select,
+			// The derived-table alias `x` applies to the derived table, not to
+			// its underlying base table — so inner_t is recorded unaliased.
+			wantTables: []tableSig{
+				{Table: "inner_t"},
+			},
+		},
+		{
+			name:     "union two tables (left wins for results)",
+			sql:      "SELECT a FROM t1 UNION SELECT a FROM t2",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:     "union all three tables",
+			sql:      "SELECT a FROM t1 UNION ALL SELECT a FROM t2 UNION ALL SELECT a FROM s.t3",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t1"},
+				{Table: "t2"},
+				{Schema: "s", Table: "t3"},
+			},
+			wantResults: []string{"a"},
+		},
+		{
+			name:        "table query shorthand",
+			sql:         "TABLE orders",
+			wantType:    Select,
+			wantTables:  []tableSig{{Table: "orders"}},
+			wantResults: nil,
+		},
+		{
+			name:        "unnest in from",
+			sql:         "SELECT v FROM UNNEST(ARRAY[1,2,3]) AS u(v)",
+			wantType:    Select,
+			wantTables:  nil, // UNNEST is not a base table
+			wantResults: []string{"v"},
+		},
+		{
+			name:     "lateral subquery",
+			sql:      "SELECT t.a, l.b FROM t, LATERAL (SELECT b FROM u WHERE u.id = t.id) AS l",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t"},
+				{Table: "u"},
+			},
+		},
+		{
+			name:     "order by limit do not add tables",
+			sql:      "SELECT a FROM t ORDER BY a LIMIT 10",
+			wantType: Select,
+			wantTables: []tableSig{
+				{Table: "t"},
+			},
+			wantResults: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tt.sql)
+			if err != nil {
+				t.Fatalf("GetQuerySpan returned error: %v", err)
+			}
+			if span.Type != tt.wantType {
+				t.Errorf("Type = %v, want %v", span.Type, tt.wantType)
+			}
+
+			gotSigs := toSigs(span.AccessTables)
+			if len(gotSigs) != len(tt.wantTables) {
+				t.Errorf("AccessTables len = %d (%v), want %d (%v)",
+					len(gotSigs), gotSigs, len(tt.wantTables), tt.wantTables)
+			}
+			for _, want := range tt.wantTables {
+				if !containsSig(gotSigs, want) {
+					t.Errorf("AccessTables missing %+v (got %+v)", want, gotSigs)
+				}
+			}
+
+			if tt.wantResults != nil {
+				if len(span.Results) != len(tt.wantResults) {
+					t.Fatalf("Results len = %d, want %d (got %+v)",
+						len(span.Results), len(tt.wantResults), span.Results)
+				}
+				for i, want := range tt.wantResults {
+					if span.Results[i].Name != want {
+						t.Errorf("Results[%d].Name = %q, want %q", i, span.Results[i].Name, want)
+					}
+				}
+			}
+
+			if tt.wantCTEs != nil {
+				if len(span.CTEs) != len(tt.wantCTEs) {
+					t.Fatalf("CTEs = %v, want %v", span.CTEs, tt.wantCTEs)
+				}
+				for i, want := range tt.wantCTEs {
+					if span.CTEs[i] != want {
+						t.Errorf("CTEs[%d] = %q, want %q", i, span.CTEs[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetQuerySpan_NonQuery(t *testing.T) {
+	tests := []struct {
+		sql      string
+		wantType QueryType
+	}{
+		{"CREATE TABLE t (id INT)", DDL},
+		{"SHOW TABLES", SelectInfoSchema},
+		{"INSERT INTO t VALUES (1)", DML},
+		{"EXPLAIN SELECT 1", Explain},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			span, err := GetQuerySpan(tt.sql)
+			if err != nil {
+				t.Fatalf("GetQuerySpan returned error: %v", err)
+			}
+			if span.Type != tt.wantType {
+				t.Errorf("Type = %v, want %v", span.Type, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestGetQuerySpan_Empty(t *testing.T) {
+	span, err := GetQuerySpan("")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if span.Type != Unknown {
+		t.Errorf("Type = %v, want Unknown", span.Type)
+	}
+	if len(span.AccessTables) != 0 {
+		t.Errorf("AccessTables = %v, want empty", span.AccessTables)
+	}
+	if len(span.Results) != 0 {
+		t.Errorf("Results = %v, want empty", span.Results)
+	}
+}
+
+func TestGetQuerySpan_DedupTables(t *testing.T) {
+	// Same unaliased table referenced twice — should appear once.
+	span, err := GetQuerySpan("SELECT a FROM t WHERE b IN (SELECT b FROM t)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 1 {
+		t.Errorf("AccessTables = %v, want one entry for t", span.AccessTables)
+	}
+}
+
+func TestGetQuerySpan_SameTableDifferentAliases(t *testing.T) {
+	// Self-join — two aliases of the same physical table should each appear.
+	span, err := GetQuerySpan("SELECT * FROM t AS a JOIN t AS b ON a.id = b.id")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 2 {
+		t.Errorf("AccessTables = %+v, want two (a, b)", span.AccessTables)
+	}
+	sigs := toSigs(span.AccessTables)
+	if !containsSig(sigs, tableSig{Table: "t", Alias: "a"}) {
+		t.Errorf("missing alias a: %+v", sigs)
+	}
+	if !containsSig(sigs, tableSig{Table: "t", Alias: "b"}) {
+		t.Errorf("missing alias b: %+v", sigs)
+	}
+}
+
+func TestGetQuerySpan_SourceColumns(t *testing.T) {
+	span, err := GetQuerySpan("SELECT a + b AS total FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	r := span.Results[0]
+	if r.Name != "total" {
+		t.Errorf("Results[0].Name = %q, want total", r.Name)
+	}
+	if len(r.SourceColumns) != 2 {
+		t.Fatalf("SourceColumns len = %d, want 2 (%+v)", len(r.SourceColumns), r.SourceColumns)
+	}
+	want := []ColumnRef{{Column: "a"}, {Column: "b"}}
+	for i, w := range want {
+		if r.SourceColumns[i] != w {
+			t.Errorf("SourceColumns[%d] = %+v, want %+v", i, r.SourceColumns[i], w)
+		}
+	}
+}
+
+func TestGetQuerySpan_DirectColumnBesideSubquery(t *testing.T) {
+	// A select item whose expression has a direct column reference alongside a
+	// subquery (`a IN (SELECT ...)`) must surface the direct column `a` as a
+	// source column, and the subquery's table must still be discovered.
+	span, err := GetQuerySpan("SELECT (a IN (SELECT x FROM u)) AS flag FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 || span.Results[0].Name != "flag" {
+		t.Fatalf("Results = %+v, want one named flag", span.Results)
+	}
+	found := false
+	for _, c := range span.Results[0].SourceColumns {
+		if c == (ColumnRef{Column: "a"}) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("SourceColumns = %+v, want to contain {Column:a}", span.Results[0].SourceColumns)
+	}
+	sigs := toSigs(span.AccessTables)
+	if !containsSig(sigs, tableSig{Table: "t"}) || !containsSig(sigs, tableSig{Table: "u"}) {
+		t.Errorf("AccessTables = %+v, want [t, u]", sigs)
+	}
+}
+
+func TestGetQuerySpan_QualifiedSourceColumn(t *testing.T) {
+	// A dotted column reference t.a is a Dereference over a ColumnRef in the
+	// trino AST; the extractor must flatten it back into a qualified ColumnRef.
+	span, err := GetQuerySpan("SELECT t.a FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1", len(span.Results))
+	}
+	r := span.Results[0]
+	if r.Name != "a" {
+		t.Errorf("Results[0].Name = %q, want a", r.Name)
+	}
+	if len(r.SourceColumns) != 1 {
+		t.Fatalf("SourceColumns = %+v, want 1", r.SourceColumns)
+	}
+	if got := r.SourceColumns[0]; got != (ColumnRef{Table: "t", Column: "a"}) {
+		t.Errorf("SourceColumns[0] = %+v, want {Table:t Column:a}", got)
+	}
+}
+
+func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
+	// A CTE named real_t shadows any physical table of the same name; the outer
+	// reference resolves to the CTE, so AccessTables holds only the CTE body's
+	// tables.
+	span, err := GetQuerySpan(`
+		WITH real_t AS (SELECT id FROM underlying)
+		SELECT id FROM real_t
+	`)
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "underlying" {
+		t.Errorf("AccessTables = %+v, want [underlying]", sigs)
+	}
+}
+
+func TestGetQuerySpan_JSONFunctionSourceColumns(t *testing.T) {
+	// A SQL/JSON function input is a real column-reference position; the
+	// extractor must surface it as a source column.
+	span, err := GetQuerySpan("SELECT JSON_VALUE(t.data, 'lax $.x') AS v FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	r := span.Results[0]
+	if r.Name != "v" {
+		t.Errorf("Results[0].Name = %q, want v", r.Name)
+	}
+	want := ColumnRef{Table: "t", Column: "data"}
+	found := false
+	for _, got := range r.SourceColumns {
+		if got == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("SourceColumns = %+v, want to contain %+v", r.SourceColumns, want)
+	}
+}
+
+func TestGetQuerySpan_SubqueryInheritsOuterCTEScope(t *testing.T) {
+	// A subquery embedded in WHERE references an outer-scope CTE (c); because the
+	// re-parsed subquery is walked with the current CTE scope as parent, c is
+	// recognized as a CTE and excluded — only the CTE body's base table and the
+	// outer FROM table appear.
+	span, err := GetQuerySpan("WITH c AS (SELECT y FROM base) SELECT a FROM t WHERE x IN (SELECT y FROM c)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 2 {
+		t.Fatalf("AccessTables = %+v, want [base, t]", sigs)
+	}
+	if !containsSig(sigs, tableSig{Table: "base"}) || !containsSig(sigs, tableSig{Table: "t"}) {
+		t.Errorf("AccessTables = %+v, want [base, t] (CTE c excluded)", sigs)
+	}
+}
+
+func TestGetQuerySpan_DeeplyNestedFromSubquery(t *testing.T) {
+	span, err := GetQuerySpan("SELECT a FROM (SELECT b FROM (SELECT c FROM deep) AS i1) AS i2")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "deep" {
+		t.Errorf("AccessTables = %+v, want [deep]", sigs)
+	}
+}
+
+func TestGetQuerySpan_AliasedCTEReferenceExcluded(t *testing.T) {
+	// A CTE referenced WITH an alias (`FROM c AS x`) is still a CTE and must be
+	// excluded from AccessTables — only the CTE body's base table appears.
+	span, err := GetQuerySpan("WITH c AS (SELECT a FROM real_t) SELECT x.a FROM c AS x")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "real_t" {
+		t.Errorf("AccessTables = %+v, want only [real_t] (CTE c excluded)", sigs)
+	}
+}
+
+func TestGetQuerySpan_TableQueryResultStar(t *testing.T) {
+	// `TABLE orders` is shorthand for `SELECT * FROM orders`; its result is a
+	// single star column.
+	span, err := GetQuerySpan("TABLE orders")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 || span.Results[0].Name != "*" {
+		t.Errorf("Results = %+v, want [*]", span.Results)
+	}
+}
+
+func TestGetQuerySpan_JoinUsingPredicateColumns(t *testing.T) {
+	// JOIN ... USING (col) columns are join keys and must appear in
+	// PredicateColumns for row-level masking parity.
+	span, err := GetQuerySpan("SELECT * FROM orders JOIN lineitem USING (orderkey)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	found := false
+	for _, c := range span.PredicateColumns {
+		if c == (ColumnRef{Column: "orderkey"}) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("PredicateColumns = %+v, want to contain {Column:orderkey}", span.PredicateColumns)
+	}
+}
+
+func TestGetQuerySpan_LambdaParamNotALineageColumn(t *testing.T) {
+	// A lambda-bound parameter (x in `x -> x + 1`) is NOT a table column and
+	// must not appear as a source column; an outer column referenced inside the
+	// lambda body still should.
+	span, err := GetQuerySpan("SELECT transform(xs, x -> x + outer_col) AS ys FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results = %+v, want 1", span.Results)
+	}
+	for _, c := range span.Results[0].SourceColumns {
+		if c == (ColumnRef{Column: "x"}) {
+			t.Errorf("SourceColumns = %+v, must NOT contain lambda param {Column:x}", span.Results[0].SourceColumns)
+		}
+	}
+	// The free column `xs` (and ideally `outer_col`) should still be present.
+	foundXS := false
+	for _, c := range span.Results[0].SourceColumns {
+		if c == (ColumnRef{Column: "xs"}) {
+			foundXS = true
+		}
+	}
+	if !foundXS {
+		t.Errorf("SourceColumns = %+v, want to contain free column {Column:xs}", span.Results[0].SourceColumns)
+	}
+}
+
+func TestGetQuerySpan_LambdaParamDereferenceNotALineageColumn(t *testing.T) {
+	// A field access rooted at a lambda-bound parameter (`x.price` in
+	// `x -> x.price + …`) is access on the bound variable, not a table column,
+	// and must not appear as a source column; the free column `outer_col` still
+	// should.
+	span, err := GetQuerySpan("SELECT transform(items, x -> x.price + outer_col) AS prices FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results = %+v, want 1", span.Results)
+	}
+	for _, c := range span.Results[0].SourceColumns {
+		if c.Table == "x" {
+			t.Errorf("SourceColumns = %+v, must NOT contain a ref rooted at lambda param x", span.Results[0].SourceColumns)
+		}
+	}
+	foundFree := false
+	foundItems := false
+	for _, c := range span.Results[0].SourceColumns {
+		if c == (ColumnRef{Column: "outer_col"}) {
+			foundFree = true
+		}
+		if c == (ColumnRef{Column: "items"}) {
+			foundItems = true
+		}
+	}
+	if !foundFree {
+		t.Errorf("SourceColumns = %+v, want free column {Column:outer_col}", span.Results[0].SourceColumns)
+	}
+	if !foundItems {
+		t.Errorf("SourceColumns = %+v, want collection arg {Column:items}", span.Results[0].SourceColumns)
+	}
+}
+
+func TestGetQuerySpan_GroupingArgsAreColumns(t *testing.T) {
+	// GROUPING(a) references column a; it must be surfaced as a source column.
+	span, err := GetQuerySpan("SELECT GROUPING(a) AS g FROM t GROUP BY ROLLUP(a)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results = %+v, want 1", span.Results)
+	}
+	found := false
+	for _, c := range span.Results[0].SourceColumns {
+		if c == (ColumnRef{Column: "a"}) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("SourceColumns = %+v, want to contain {Column:a}", span.Results[0].SourceColumns)
+	}
+}
+
+func TestGetQuerySpan_TableFunctionArgColumns(t *testing.T) {
+	// A table-function table argument's PARTITION BY and ORDER BY columns are
+	// real column references and must both be captured.
+	span, err := GetQuerySpan("SELECT * FROM TABLE(my_function(input => TABLE(orders) PARTITION BY orderstatus ORDER BY orderdate))")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if !containsSig(toSigs(span.AccessTables), tableSig{Table: "orders"}) {
+		t.Errorf("AccessTables = %+v, want to contain orders", toSigs(span.AccessTables))
+	}
+	for _, want := range []ColumnRef{{Column: "orderstatus"}, {Column: "orderdate"}} {
+		found := false
+		for _, c := range span.PredicateColumns {
+			if c == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("PredicateColumns = %+v, want to contain %+v", span.PredicateColumns, want)
+		}
+	}
+}
+
+func TestGetQuerySpan_NamedWindowColumnsCaptured(t *testing.T) {
+	// The PARTITION BY / ORDER BY columns of a named WINDOW definition are real
+	// column references and must be captured (as predicate columns) so masking
+	// sees them — even though attributing them to the specific OVER-w result
+	// column is out of best-effort scope.
+	span, err := GetQuerySpan("SELECT row_number() OVER w AS rn FROM t WINDOW w AS (PARTITION BY y ORDER BY z)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	for _, want := range []ColumnRef{{Column: "y"}, {Column: "z"}} {
+		found := false
+		for _, c := range span.PredicateColumns {
+			if c == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("PredicateColumns = %+v, want to contain %+v", span.PredicateColumns, want)
+		}
+	}
+}
+
+func TestClassify_ExplainAnalyzeMutating(t *testing.T) {
+	// EXPLAIN ANALYZE executes its inner statement, so EXPLAIN ANALYZE of a
+	// mutating statement is NOT read-only — it must classify by the inner
+	// statement's nature (oracle-confirmed: Trino 481 runs the INSERT).
+	tests := []struct {
+		sql  string
+		want QueryType
+	}{
+		{"EXPLAIN ANALYZE SELECT a FROM t", Explain},
+		{"EXPLAIN ANALYZE VERBOSE SELECT a FROM t", Explain},
+		{"EXPLAIN SELECT a FROM t", Explain},
+		{"EXPLAIN ANALYZE INSERT INTO t VALUES (1)", DML},
+		{"EXPLAIN ANALYZE DELETE FROM t WHERE a = 1", DML},
+		{"EXPLAIN ANALYZE UPDATE t SET a = 1", DML},
+		// Plain EXPLAIN (no ANALYZE) never executes, so it stays read-only even
+		// for a DML inner statement.
+		{"EXPLAIN INSERT INTO t VALUES (1)", Explain},
+		// EXPLAIN ANALYZE of an info-schema read stays read-only/info-schema.
+		{"EXPLAIN ANALYZE SELECT * FROM information_schema.tables", SelectInfoSchema},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			if got := Classify(tt.sql); got != tt.want {
+				t.Errorf("Classify(%q) = %v, want %v", tt.sql, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetQuerySpan_PredicateColumns(t *testing.T) {
+	// WHERE / JOIN-ON columns are collected into PredicateColumns (used for
+	// row-level masking parity with the legacy extractor).
+	span, err := GetQuerySpan("SELECT a FROM t1 JOIN t2 ON t1.id = t2.id WHERE t1.region = 'x'")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	want := []ColumnRef{
+		{Table: "t1", Column: "id"},
+		{Table: "t2", Column: "id"},
+		{Table: "t1", Column: "region"},
+	}
+	for _, w := range want {
+		found := false
+		for _, got := range span.PredicateColumns {
+			if got == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("PredicateColumns missing %+v (got %+v)", w, span.PredicateColumns)
+		}
+	}
+}
+
+func TestGetQuerySpan_NoPanicOnVariedInput(t *testing.T) {
+	// Robustness sweep (correctness-protocol.md item 3): GetQuerySpan must
+	// terminate without panicking on a broad range of expression-heavy,
+	// nested, exotic, and malformed inputs.
+	corpus := []string{
+		"",
+		";",
+		"SELECT",
+		"SELECT 1",
+		"SELECT CASE WHEN a > 1 THEN b ELSE c END FROM t",
+		"SELECT CAST(a AS varchar), TRY_CAST(b AS bigint) FROM t",
+		"SELECT EXTRACT(YEAR FROM ts), SUBSTRING(s FROM 1 FOR 3) FROM t",
+		"SELECT ARRAY[a, b, c], ROW(x, y) FROM t",
+		"SELECT f(x) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM t",
+		"SELECT a[1], m['k'] FROM t",
+		"SELECT JSON_QUERY(payload, 'lax $.items') FROM t",
+		"SELECT JSON_OBJECT(KEY k VALUE v) FROM t",
+		"SELECT * FROM t1 NATURAL JOIN t2",
+		"SELECT * FROM UNNEST(ARRAY[1,2]) WITH ORDINALITY AS u(v, ord)",
+		"SELECT * FROM t1, LATERAL (SELECT * FROM t2 WHERE t2.id = t1.id) l",
+		"SELECT * FROM TABLE(my_func(input => TABLE(orders) PARTITION BY region))",
+		"WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM r WHERE n < 5) SELECT * FROM r",
+		"SELECT a FROM t WHERE x = ANY (SELECT y FROM u)",
+		"SELECT a FROM t GROUP BY ROLLUP (a, b), CUBE (c) HAVING count(*) > 1",
+		"SELECT a FROM t WHERE a BETWEEN 1 AND 10 AND b LIKE '%x%' ESCAPE '\\'",
+		"VALUES (1, 'a'), (2, 'b')",
+		"TABLE orders",
+		"((SELECT 1))",
+		"SELECT a FROM (SELECT b FROM (SELECT c FROM deep) AS inner1) AS inner2",
+		"garbage tokens that do not parse @@@ %%%",
+		"INSERT INTO t SELECT * FROM s",
+		"MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a",
+	}
+	for _, sql := range corpus {
+		sql := sql
+		t.Run(truncate(sql), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("GetQuerySpan(%q) panicked: %v", sql, r)
+				}
+			}()
+			if _, err := GetQuerySpan(sql); err != nil {
+				t.Fatalf("GetQuerySpan(%q) returned error: %v", sql, err)
+			}
+		})
+	}
+}
+
+func truncate(s string) string {
+	if len(s) > 48 {
+		return s[:48]
+	}
+	if s == "" {
+		return "(empty)"
+	}
+	return s
+}
+
+func TestGetQuerySpan_ToleratesParseError(t *testing.T) {
+	// A statement whose body fails to parse must not panic; GetQuerySpan returns
+	// whatever was classified/extracted.
+	span, err := GetQuerySpan("SELECT a FROM")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if span.Type != Select {
+		t.Errorf("Type = %v, want Select", span.Type)
+	}
+}


### PR DESCRIPTION
## Node: `trino/analysis` (feature, P0)

Implements the Trino omni migration's `trino/analysis` node — the P0 query-analysis surface bytebase consumes: **`GetQuerySpan`** (table/column lineage for masking + SQL-editor access tracking) and **statement classification** (`query_type` / the `validateQuery` read-only guard). Depends on the merged `parser-foundation` + `parser-select` nodes. Writes only `trino/analysis/*.go`.

Spec: `docs/migration/trino/analysis.md` (Tier 3 — query-span, §"Bytebase Contract"). DAG: `docs/migration/trino/dag.md` (row `trino/analysis`).

### What it does
- **`classify.go`** — `QueryType` (`Select`/`SelectInfoSchema`/`Explain`/`DML`/`DDL`, 1:1 with bytebase `base.QueryType`) and `Classify(sql)`. Classification is first-keyword-lexing-based (robust even where DDL/DML parser bodies aren't merged yet) plus the legacy system-schema text rule (`system.`/`information_schema.`/… → `SelectInfoSchema`).
- **`query_span.go`** — `QuerySpan{Type, AccessTables, Results, PredicateColumns, CTEs}` + `GetQuerySpan(sql)`. A hand-written type-switch walker over the trino `Query`/`QueryNode`/`Relation`/`Expr` node model (these are **parser-package** types, not `ast.Node`, so `ast.Walk` is unusable — unlike doris). Best-effort, parser-driven lineage:
  - base tables (FROM/JOIN/subquery), CTE-excluded + deduped, self-join aliases preserved;
  - output columns with per-result `SourceColumns`;
  - `PredicateColumns` (WHERE/ON/USING/HAVING/GROUP BY/WINDOW/table-function args);
  - subquery recursion by re-parsing `SubqueryExpr.RawText` with outer CTE-scope inheritance;
  - set-op left-arm result rule; `TABLE name` → `*` result.
  - A single parameterized walker (`exprWalk{onColumn, followSub}`) serves both the predicate pass and the direct-column pass — no duplicated ~40-arm dispatch.

Mirrors the `doris/analysis` precedent, adapted to the trino AST.

### Correctness evidence
- **Differential oracle (live Trino 481, http://localhost:18080)** — `TestAnalysis_ClassificationDifferential` confirms every classify-corpus statement is real Trino syntax AND that the read-only verdict matches Trino's read-only/data-changing nature (incl. `EXPLAIN ANALYZE INSERT` → executes → not read-only). Skips cleanly when the oracle is unreachable.
- **Robustness sweep** — `TestGetQuerySpan_NoPanicOnVariedInput`: no panic across 28 exotic/nested/malformed inputs.
- **Unit coverage** — 154 passing cases over classification, lineage, CTE shadow/scope, dedup, self-join, subquery recursion (incl. nested + outer-CTE-scope), JSON functions, lambda, set-ops, UNNEST/LATERAL/table-function.
- `go test ./trino/analysis/...`, `go vet`, `gofmt` all clean; whole `trino/...` tree builds.

### Completeness (walker accounted-for)
All 5 `QueryNode` types, all 8 `Relation` types, and all ~40 `Expr` types (incl. the 5 SQL/JSON functions) are handled or are intentional leaves. Documented best-effort boundaries (matching the doris precedent): no `SELECT *` metadata expansion, no column→relation ownership resolution, no `OVER w` named-window resolution (its columns are still captured as predicate columns).

### Review (cross-family gate)
- **Claude lens** — found + fixed: CTE-**aliased**-reference exclusion bug (`FROM c AS x`), nil-deref hardening, and the two-walker → one-walker unification (−115 LOC, prevents dispatch drift).
- **Codex lens** (3 rounds, converged) — found + fixed: `EXPLAIN ANALYZE <mutating>` classification, JOIN `USING` columns, lambda-bound-param false lineage (incl. dereferences rooted at a param, `x.price`), `GROUPING(...)` args, `TABLE name` result star, named-window + table-function `ORDER BY` predicate columns.

### Divergences
One oracle-backed behavior change vs legacy: **`EXPLAIN ANALYZE` of a mutating inner statement classifies as `DML`/`DDL` (not read-only)** — the legacy classifier reports it read-only `Select` irrespective of inner kind, but Trino 481 *executes* the inner statement (oracle-confirmed), so this is a safety fix. Plain `EXPLAIN` stays read-only. No other divergences (best-effort lineage follows the doris precedent + legacy text contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)