### PR TITLE
feat(snowflake): T4.5 CREATE / ALTER FUNCTION / PROCEDURE

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -122,6 +122,10 @@ const (
 	T_AlterTaskStmt
 	T_CreateAlertStmt
 	T_AlterAlertStmt
+
+	// Routine DDL tags (T4.5)
+	T_CreateRoutineStmt
+	T_AlterRoutineStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -293,6 +297,10 @@ func (t NodeTag) String() string {
 		return "CreateAlertStmt"
 	case T_AlterAlertStmt:
 		return "AlterAlertStmt"
+	case T_CreateRoutineStmt:
+		return "CreateRoutineStmt"
+	case T_AlterRoutineStmt:
+		return "AlterRoutineStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -3075,3 +3075,163 @@ var (
 	_ Node = (*CreateAlertStmt)(nil)
 	_ Node = (*AlterAlertStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// Routine DDL — CREATE / ALTER FUNCTION & PROCEDURE (T4.5)
+// ---------------------------------------------------------------------------
+//
+// A UDF / UDTF / stored procedure / external function carries a large,
+// version-growing vocabulary of property clauses: LANGUAGE, RUNTIME_VERSION,
+// HANDLER, PACKAGES, IMPORTS, TARGET_PATH, EXTERNAL_ACCESS_INTEGRATIONS,
+// SECRETS, COMMENT, the volatility / null-handling modifiers (VOLATILE,
+// IMMUTABLE, STRICT, MEMOIZABLE, CALLED ON NULL INPUT, RETURNS NULL ON NULL
+// INPUT), and the external-function cloud params (API_INTEGRATION, HEADERS,
+// CONTEXT_HEADERS, MAX_BATCH_ROWS, COMPRESSION, REQUEST_TRANSLATOR,
+// RESPONSE_TRANSLATOR). Rather than mirror the legacy ANTLR grammar's finite,
+// already-stale enumerations (its create_function rule lacks TARGET_PATH,
+// EXTERNAL_ACCESS_INTEGRATIONS, SECRETS, the SCALA / JAVA-scala runtimes, ...
+// all of which appear in the official docs corpus), every property is captured
+// as an open-ended `KEY = <value>` pair or a bare modifier word (CopyOption),
+// reusing the merged STAGE (T4.1) / FILE FORMAT (T4.2) / PIPE (T4.3) / COPY
+// (T5.2) machinery. Only the structural anchors are modeled explicitly: the
+// argument list, the RETURNS clause (a scalar data type or a TABLE (...) column
+// list), the EXECUTE AS {CALLER|OWNER} clause, and the AS <body> clause. The
+// body is OPAQUE — its language is SQL-scripting / JavaScript / Python / Java /
+// Scala, never parsed here — and is captured verbatim including its delimiters,
+// whether single-quoted ('...') or dollar-quoted ($$...$$). The catalog /
+// semantic layer, not the parser, validates that a property is real and legal.
+
+// RoutineArg is one argument of a function / procedure signature:
+//
+//	<arg_name> <data_type> [ DEFAULT <expr> ]
+//
+// It is a helper struct (not a Node); the walker does not descend into it,
+// mirroring TagAssignment / CloneSource / ForeignKeyRef.
+type RoutineArg struct {
+	Name    Ident
+	Type    *TypeName
+	Default Node // DEFAULT <expr>; nil if absent
+	Loc     Loc
+}
+
+// RoutineTableColumn is one column of a RETURNS TABLE ( ... ) result spec:
+//
+//	<column_name> <data_type>
+//
+// It is a helper struct (not a Node).
+type RoutineTableColumn struct {
+	Name Ident
+	Type *TypeName
+	Loc  Loc
+}
+
+// RoutineKind discriminates the object a routine statement targets.
+type RoutineKind int
+
+const (
+	RoutineFunction         RoutineKind = iota // FUNCTION (UDF / UDTF)
+	RoutineExternalFunction                    // EXTERNAL FUNCTION
+	RoutineProcedure                           // PROCEDURE
+)
+
+// ExecuteAs discriminates the EXECUTE AS clause of a procedure.
+type ExecuteAs int
+
+const (
+	ExecuteAsUnset  ExecuteAs = iota // no EXECUTE AS clause
+	ExecuteAsCaller                  // EXECUTE AS CALLER
+	ExecuteAsOwner                   // EXECUTE AS OWNER
+)
+
+// CreateRoutineStmt represents CREATE [OR REPLACE] [SECURE] [TEMP|TEMPORARY]
+// FUNCTION / EXTERNAL FUNCTION / PROCEDURE.
+//
+//	CREATE [ OR REPLACE ] [ SECURE ] [ TEMP | TEMPORARY ]
+//	  FUNCTION [ IF NOT EXISTS ] <name> ( [ <arg> [, ...] ] )
+//	  RETURNS { <data_type> | TABLE ( <col> <type> [, ...] ) } [ [ NOT ] NULL ]
+//	  [ <property clauses> ]                     -- open-ended KEY = value / bare words
+//	  AS { '<body>' | $$<body>$$ }
+//
+//	CREATE [ OR REPLACE ] [ SECURE ] EXTERNAL FUNCTION <name> ( [ <arg> [, ...] ] )
+//	  RETURNS <data_type> [ [ NOT ] NULL ]
+//	  [ <property clauses> ] API_INTEGRATION = <id> [ <property clauses> ]
+//	  AS '<url>'
+//
+//	CREATE [ OR REPLACE ] [ SECURE ] PROCEDURE <name> ( [ <arg> [, ...] ] )
+//	  RETURNS <data_type> [ [ NOT ] NULL ]
+//	  [ <property clauses> ] [ EXECUTE AS { CALLER | OWNER } ] [ <property clauses> ]
+//	  AS { '<body>' | $$<body>$$ }
+//
+// ReturnTable is non-nil for the RETURNS TABLE ( ... ) form, in which case
+// ReturnType is nil; otherwise ReturnType holds the scalar return type. Options
+// holds every property clause (LANGUAGE / RUNTIME_VERSION / HANDLER / PACKAGES /
+// IMPORTS / API_INTEGRATION / the volatility & null-handling modifiers / ...),
+// open-ended, preserving source order. Body holds the verbatim body text WITH
+// its delimiters ('...' or $$...$$); BodyDollar reports whether the
+// dollar-quoted form was used. Body is "" only for the no-body external/SQL UDF
+// forms the docs permit (e.g. a function defined entirely by its handler).
+type CreateRoutineStmt struct {
+	Kind          RoutineKind
+	OrReplace     bool
+	Secure        bool
+	Temporary     bool
+	IfNotExists   bool
+	Name          *ObjectName
+	Args          []*RoutineArg         // ( <arg> [, ...] ); nil for an empty arg list
+	ReturnType    *TypeName             // scalar RETURNS type; nil for the TABLE form
+	ReturnTable   []*RoutineTableColumn // RETURNS TABLE ( ... ) columns; non-nil for the TABLE form
+	ReturnNotNull bool                  // RETURNS ... NOT NULL
+	ReturnNull    bool                  // RETURNS ... NULL (explicit nullable)
+	Options       []*CopyOption         // property clauses (LANGUAGE / HANDLER / volatility / ...)
+	ExecuteAs     ExecuteAs             // procedure EXECUTE AS {CALLER|OWNER}; ExecuteAsUnset otherwise
+	Body          string                // verbatim body incl. delimiters ('...' or $$...$$); "" if no body
+	BodyDollar    bool                  // true when the $$...$$ form was used
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *CreateRoutineStmt) Tag() NodeTag { return T_CreateRoutineStmt }
+
+// AlterRoutineAction discriminates the action variants of ALTER FUNCTION /
+// PROCEDURE.
+type AlterRoutineAction int
+
+const (
+	AlterRoutineRename    AlterRoutineAction = iota // RENAME TO <new_name>
+	AlterRoutineSet                                 // SET <options> (SECURE / COMMENT / LOG_LEVEL / ...)
+	AlterRoutineUnset                               // UNSET <property> [, ...] (SECURE / COMMENT / ...)
+	AlterRoutineExecuteAs                           // EXECUTE AS {CALLER|OWNER} (procedure only)
+)
+
+// AlterRoutineStmt represents
+//
+//	ALTER { FUNCTION | PROCEDURE } [ IF EXISTS ] <name> ( [ <argtype> [, ...] ] ) <action>
+//
+//	RENAME TO <new_name>
+//	SET <options>                              -- open-ended (SECURE / COMMENT / LOG_LEVEL / ...)
+//	UNSET <property> [ , ... ]                  -- SECURE / COMMENT / ...
+//	EXECUTE AS { CALLER | OWNER }               -- procedure only
+//
+// The ALTER signature carries argument TYPES only (no names), captured in
+// ArgTypes. Procedure is true for ALTER PROCEDURE, false for ALTER FUNCTION.
+type AlterRoutineStmt struct {
+	Procedure  bool // true for ALTER PROCEDURE, false for ALTER FUNCTION
+	IfExists   bool
+	Name       *ObjectName
+	ArgTypes   []*TypeName // ( <argtype> [, ...] ) signature; nil for an empty list
+	Action     AlterRoutineAction
+	NewName    *ObjectName   // RENAME TO target; non-nil for AlterRoutineRename
+	Options    []*CopyOption // SET <options>; for AlterRoutineSet
+	UnsetProps []string      // UNSET <property> names; for AlterRoutineUnset
+	ExecuteAs  ExecuteAs     // EXECUTE AS {CALLER|OWNER}; for AlterRoutineExecuteAs
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterRoutineStmt) Tag() NodeTag { return T_AlterRoutineStmt }
+
+// Compile-time assertions for routine DDL nodes.
+var (
+	_ Node = (*CreateRoutineStmt)(nil)
+	_ Node = (*AlterRoutineStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -41,6 +41,13 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *AlterRoutineStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -165,6 +172,13 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Name)
 		}
 		Walk(v, n.Copy)
+	case *CreateRoutineStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.ReturnType != nil {
+			Walk(v, n.ReturnType)
+		}
 	case *CreateSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -23,8 +23,9 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		}
 	}
 
-	// Optional SECURE modifier (VIEW-only — must be checked before temporary modifiers
-	// since SECURE can appear before MATERIALIZED VIEW too).
+	// Optional SECURE modifier. SECURE applies to VIEW / MATERIALIZED VIEW
+	// (T2.4) and to FUNCTION / EXTERNAL FUNCTION / PROCEDURE (T4.5). It is
+	// checked before the temporary modifiers since it precedes the object type.
 	secure := false
 	if p.cur.Type == kwSECURE {
 		p.advance()
@@ -38,8 +39,9 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		recursive = true
 	}
 
-	// If SECURE or RECURSIVE were consumed, the next token must be VIEW or MATERIALIZED VIEW.
-	// Dispatch early before checking temporary modifiers.
+	// If SECURE or RECURSIVE were consumed, dispatch early on the object type.
+	// RECURSIVE pairs only with VIEW; SECURE additionally precedes
+	// FUNCTION / EXTERNAL FUNCTION / PROCEDURE.
 	if secure || recursive {
 		switch p.cur.Type {
 		case kwVIEW:
@@ -47,6 +49,29 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		case kwMATERIALIZED:
 			p.advance() // consume MATERIALIZED
 			return p.parseCreateMaterializedViewStmt(start, orReplace, secure)
+		case kwFUNCTION:
+			if recursive {
+				return p.unsupported("CREATE")
+			}
+			// CREATE [OR REPLACE] SECURE FUNCTION ... (T4.5).
+			return p.parseCreateFunctionStmt(start, orReplace, true, false)
+		case kwPROCEDURE:
+			if recursive {
+				return p.unsupported("CREATE")
+			}
+			// CREATE [OR REPLACE] SECURE PROCEDURE ... (T4.5).
+			return p.parseCreateProcedureStmt(start, orReplace, true)
+		case kwEXTERNAL:
+			if recursive {
+				return p.unsupported("CREATE")
+			}
+			// CREATE [OR REPLACE] SECURE EXTERNAL FUNCTION ... (T4.5).
+			p.advance() // consume EXTERNAL
+			if p.cur.Type != kwFUNCTION {
+				// EXTERNAL TABLE (and any other EXTERNAL object) is owned by another node.
+				return p.unsupported("CREATE")
+			}
+			return p.parseCreateExternalFunctionStmt(start, orReplace, true)
 		default:
 			return p.unsupported("CREATE")
 		}
@@ -107,6 +132,20 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	case kwALERT:
 		// CREATE [OR REPLACE] ALERT ... (T4.3).
 		return p.parseCreateAlertStmt(start, orReplace)
+	case kwFUNCTION:
+		// CREATE [OR REPLACE] [TEMP|TEMPORARY] FUNCTION ... (T4.5).
+		return p.parseCreateFunctionStmt(start, orReplace, false, temporary)
+	case kwPROCEDURE:
+		// CREATE [OR REPLACE] PROCEDURE ... (T4.5).
+		return p.parseCreateProcedureStmt(start, orReplace, false)
+	case kwEXTERNAL:
+		// CREATE [OR REPLACE] EXTERNAL FUNCTION ... (T4.5). EXTERNAL TABLE (and
+		// any other EXTERNAL object) is owned by another node.
+		p.advance() // consume EXTERNAL
+		if p.cur.Type != kwFUNCTION {
+			return p.unsupported("CREATE")
+		}
+		return p.parseCreateExternalFunctionStmt(start, orReplace, false)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -191,6 +191,12 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	case kwALERT:
 		// ALTER ALERT ... (T4.3).
 		return p.parseAlterAlertStmt()
+	case kwFUNCTION:
+		// ALTER FUNCTION ... (T4.5).
+		return p.parseAlterFunctionStmt()
+	case kwPROCEDURE:
+		// ALTER PROCEDURE ... (T4.5).
+		return p.parseAlterProcedureStmt()
 	default:
 		return p.unsupported("ALTER")
 	}

--- a/snowflake/parser/function_procedure.go
+++ b/snowflake/parser/function_procedure.go
@@ -1,0 +1,597 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// Routine DDL — CREATE / ALTER FUNCTION & PROCEDURE (T4.5)
+// ---------------------------------------------------------------------------
+//
+// A UDF / UDTF / stored procedure / external function carries a large,
+// version-growing vocabulary of property clauses (LANGUAGE, RUNTIME_VERSION,
+// HANDLER, PACKAGES, IMPORTS, TARGET_PATH, EXTERNAL_ACCESS_INTEGRATIONS,
+// SECRETS, COMMENT, the volatility / null-handling modifiers, and the
+// external-function cloud params API_INTEGRATION / HEADERS / CONTEXT_HEADERS /
+// MAX_BATCH_ROWS / COMPRESSION / REQUEST_TRANSLATOR / RESPONSE_TRANSLATOR).
+// Rather than mirror the legacy ANTLR grammar's finite, already-stale
+// enumerations (its create_function rule lacks TARGET_PATH,
+// EXTERNAL_ACCESS_INTEGRATIONS, SECRETS, the SCALA runtime, ... all in the docs
+// corpus), every property is captured as an open-ended `KEY = <value>` pair or a
+// bare modifier word (ast.CopyOption), reusing the merged STAGE (T4.1) / FILE
+// FORMAT (T4.2) / PIPE (T4.3) / COPY (T5.2) machinery. Only the structural
+// anchors are modeled explicitly: the argument list, the RETURNS clause (a
+// scalar data type or a TABLE (...) column list), the EXECUTE AS {CALLER|OWNER}
+// clause, and the AS <body> clause.
+//
+// Body handling is the delicate part. The body after AS is either single-quoted
+// ('...') or dollar-quoted ($$...$$). A multi-line single-quoted body — very
+// common for SQL / JavaScript / Python handlers — cannot be taken from the lexer
+// token stream: omni's scanString does NOT span newlines (it emits an
+// "unterminated string literal" on the first embedded '\n'). parseRoutineBody
+// therefore RAW-SCANS the body directly from the source text, mirroring the
+// p.base / p.input raw-source-slice + lexer re-sync pattern copy.go established
+// for unquoted file:// paths, and returns the verbatim body (delimiters
+// included). The body is OPAQUE — its contents (SQL-scripting / JS / Python /
+// Java / Scala) are never parsed.
+
+// ---------------------------------------------------------------------------
+// CREATE FUNCTION / EXTERNAL FUNCTION / PROCEDURE
+// ---------------------------------------------------------------------------
+
+// parseCreateFunctionStmt parses CREATE [OR REPLACE] [SECURE] [TEMP|TEMPORARY]
+// FUNCTION ... . The CREATE keyword and the OR REPLACE / SECURE / TEMPORARY
+// modifiers have already been consumed by parseCreateStmt; start is the Loc of
+// the CREATE token and cur is the FUNCTION keyword.
+func (p *Parser) parseCreateFunctionStmt(start ast.Loc, orReplace, secure, temporary bool) (ast.Node, error) {
+	p.advance() // consume FUNCTION
+	return p.parseCreateRoutineBody(start, ast.RoutineFunction, orReplace, secure, temporary)
+}
+
+// parseCreateExternalFunctionStmt parses CREATE [OR REPLACE] [SECURE] EXTERNAL
+// FUNCTION ... . The CREATE / OR REPLACE / SECURE modifiers and the EXTERNAL
+// keyword have already been consumed by parseCreateStmt; start is the Loc of the
+// CREATE token and cur is the FUNCTION keyword. An external function is exactly
+// a function whose API_INTEGRATION property and quoted-URL body the
+// catalog/semantic layer can detect; structurally it parses through the same
+// path (its API_INTEGRATION / HEADERS / CONTEXT_HEADERS / ... clauses are
+// captured open-ended like any other property, and its `AS '<url>'` body is the
+// single-quoted form).
+func (p *Parser) parseCreateExternalFunctionStmt(start ast.Loc, orReplace, secure bool) (ast.Node, error) {
+	p.advance() // consume FUNCTION
+	return p.parseCreateRoutineBody(start, ast.RoutineExternalFunction, orReplace, secure, false)
+}
+
+// parseCreateProcedureStmt parses CREATE [OR REPLACE] [SECURE] PROCEDURE ... .
+// The CREATE / OR REPLACE / SECURE modifiers have already been consumed by
+// parseCreateStmt; start is the Loc of the CREATE token and cur is the PROCEDURE
+// keyword.
+func (p *Parser) parseCreateProcedureStmt(start ast.Loc, orReplace, secure bool) (ast.Node, error) {
+	p.advance() // consume PROCEDURE
+	return p.parseCreateRoutineBody(start, ast.RoutineProcedure, orReplace, secure, false)
+}
+
+// parseCreateRoutineBody parses the shared tail common to CREATE FUNCTION /
+// EXTERNAL FUNCTION / PROCEDURE, after the object-type keyword has been consumed:
+//
+//	[ IF NOT EXISTS ] <name> ( [ <arg> [, ...] ] )
+//	  RETURNS { <data_type> | TABLE ( <col> <type> [, ...] ) } [ [ NOT ] NULL ]
+//	  [ <property clauses> ] [ EXECUTE AS { CALLER | OWNER } ] [ <property clauses> ]
+//	  AS { '<body>' | $$<body>$$ }
+//
+// IF NOT EXISTS is documented for FUNCTION only; it is accepted uniformly and
+// harmlessly for all three (an unsupported IF NOT EXISTS on a procedure is a
+// semantic, not syntactic, concern). The body is optional: the docs permit a
+// function defined entirely by its handler (no AS clause), in which case Body
+// stays "".
+func (p *Parser) parseCreateRoutineBody(start ast.Loc, kind ast.RoutineKind, orReplace, secure, temporary bool) (ast.Node, error) {
+	stmt := &ast.CreateRoutineStmt{
+		Kind:      kind,
+		OrReplace: orReplace,
+		Secure:    secure,
+		Temporary: temporary,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExistsInto(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Argument list: ( [ <arg_name> <data_type> [ DEFAULT <expr> ] [, ...] ] ).
+	args, err := p.parseRoutineArgList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Args = args
+
+	// RETURNS { <data_type> | TABLE ( ... ) } [ [ NOT ] NULL ].
+	if _, err := p.expect(kwRETURNS); err != nil {
+		return nil, err
+	}
+	if err := p.parseRoutineReturns(stmt); err != nil {
+		return nil, err
+	}
+
+	// Property clauses, the optional EXECUTE AS clause, and the AS body may
+	// appear in any documented order; AS is the terminal anchor. The loop reads
+	// open-ended property clauses (KEY = value pairs and bare modifier words such
+	// as VOLATILE / IMMUTABLE / STRICT / MEMOIZABLE / SECURE and the
+	// CALLED ON NULL INPUT / RETURNS NULL ON NULL INPUT phrases), stopping at AS
+	// or at EXECUTE (which introduces EXECUTE AS, not a property).
+	for {
+		if p.cur.Type == kwAS {
+			break
+		}
+		if p.curIsWord("EXECUTE") {
+			if err := p.parseRoutineExecuteAs(&stmt.ExecuteAs); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if p.startsCopyOption() {
+			opt, err := p.parseCopyOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+			continue
+		}
+		break
+	}
+
+	// Optional AS <body>. A function may have no body (handler-only); when AS is
+	// present the body is mandatory.
+	if p.cur.Type == kwAS {
+		body, dollar, end, err := p.parseRoutineBody()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Body = body
+		stmt.BodyDollar = dollar
+		stmt.Loc.End = end
+		return stmt, nil
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRoutineArgList parses the parenthesized argument list:
+//
+//	( [ <arg_name> <data_type> [ DEFAULT <expr> ] [ , ... ] ] )
+//
+// An empty list — () — yields nil args. cur must be '('.
+func (p *Parser) parseRoutineArgList() ([]*ast.RoutineArg, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	// Empty arg list.
+	if p.cur.Type == ')' {
+		p.advance() // consume ')'
+		return nil, nil
+	}
+
+	var args []*ast.RoutineArg
+	for {
+		arg, err := p.parseRoutineArg()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return args, nil
+}
+
+// parseRoutineArg parses one argument: <arg_name> <data_type> [ DEFAULT <expr> ].
+func (p *Parser) parseRoutineArg() (*ast.RoutineArg, error) {
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+
+	typ, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+
+	arg := &ast.RoutineArg{
+		Name: name,
+		Type: typ,
+		Loc:  ast.Loc{Start: name.Loc.Start, End: typ.Loc.End},
+	}
+
+	// Optional DEFAULT <expr>.
+	if p.cur.Type == kwDEFAULT {
+		p.advance() // consume DEFAULT
+		def, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		arg.Default = def
+		arg.Loc.End = p.prev.Loc.End
+	}
+
+	return arg, nil
+}
+
+// parseRoutineReturns parses the RETURNS clause body (RETURNS already consumed):
+//
+//	<data_type> [ [ NOT ] NULL ]
+//	TABLE ( <column_name> <data_type> [ , ... ] )
+//
+// The TABLE form (a UDTF / table stored procedure) records its columns in
+// ReturnTable; the scalar form records its type in ReturnType. A trailing
+// [ NOT ] NULL nullability modifier is accepted on the scalar form (the docs and
+// the corpus show `RETURNS FLOAT NOT NULL`).
+func (p *Parser) parseRoutineReturns(stmt *ast.CreateRoutineStmt) error {
+	if p.cur.Type == kwTABLE {
+		p.advance() // consume TABLE
+		cols, err := p.parseRoutineTableColumns()
+		if err != nil {
+			return err
+		}
+		// Non-nil (possibly empty) slice records the TABLE form explicitly.
+		if cols == nil {
+			cols = []*ast.RoutineTableColumn{}
+		}
+		stmt.ReturnTable = cols
+		return nil
+	}
+
+	typ, err := p.parseDataType()
+	if err != nil {
+		return err
+	}
+	stmt.ReturnType = typ
+
+	// Optional [ NOT ] NULL nullability modifier.
+	switch p.cur.Type {
+	case kwNOT:
+		if p.peekNext().Type == kwNULL {
+			p.advance() // consume NOT
+			p.advance() // consume NULL
+			stmt.ReturnNotNull = true
+		}
+	case kwNULL:
+		p.advance() // consume NULL
+		stmt.ReturnNull = true
+	}
+	return nil
+}
+
+// parseRoutineTableColumns parses the RETURNS TABLE ( ... ) column list:
+//
+//	( [ <column_name> <data_type> [ , ... ] ] )
+//
+// An empty TABLE () yields a non-nil empty slice (recorded by the caller). cur
+// must be '('.
+func (p *Parser) parseRoutineTableColumns() ([]*ast.RoutineTableColumn, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type == ')' {
+		p.advance() // consume ')'
+		return []*ast.RoutineTableColumn{}, nil
+	}
+
+	var cols []*ast.RoutineTableColumn
+	for {
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		typ, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, &ast.RoutineTableColumn{
+			Name: name,
+			Type: typ,
+			Loc:  ast.Loc{Start: name.Loc.Start, End: typ.Loc.End},
+		})
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return cols, nil
+}
+
+// parseRoutineExecuteAs parses an EXECUTE AS { CALLER | OWNER } clause. cur is
+// the EXECUTE word (an identifier — EXECUTE is not an omni keyword). EXECUTE AS
+// is documented for procedures; it is parsed uniformly so the option loop never
+// mistakes the EXECUTE word for a bare property and then swallows the body AS.
+func (p *Parser) parseRoutineExecuteAs(dst *ast.ExecuteAs) error {
+	p.advance() // consume EXECUTE
+	if _, err := p.expect(kwAS); err != nil {
+		return err
+	}
+	switch p.cur.Type {
+	case kwCALLER:
+		p.advance()
+		*dst = ast.ExecuteAsCaller
+	case kwOWNER:
+		p.advance()
+		*dst = ast.ExecuteAsOwner
+	default:
+		return p.syntaxErrorAtCur()
+	}
+	return nil
+}
+
+// parseRoutineBody parses the AS <body> clause. On entry cur is the AS keyword
+// (NOT yet consumed). The body is one of:
+//
+//	'<...>'            single-quoted (may span newlines; '' is an escaped quote)
+//	$$<...>$$          dollar-quoted (always spans newlines)
+//
+// and is returned VERBATIM, delimiters included, together with whether the
+// dollar-quoted form was used and the absolute end offset of the body.
+//
+// The body is read by RAW-SCANNING the source text rather than from the lexer
+// token stream. This is mandatory for the single-quoted form: omni's scanString
+// rejects an embedded newline ("unterminated string literal"), so a multi-line
+// single-quoted body (a SQL / JS / Python handler) never lexes to a usable
+// token. To stay uniform — and to never depend on the lexer for an opaque body —
+// the dollar-quoted form is raw-scanned too. After the body, the lexer is
+// re-synced past it (pos set to the byte after the closing delimiter, the
+// buffered lookahead cleared) and cur is re-primed; any spurious lex error the
+// (now-discarded) token scan recorded for a multi-line single-quoted body is
+// truncated away.
+func (p *Parser) parseRoutineBody() (body string, dollar bool, end int, err error) {
+	// Snapshot the lexer's error count BEFORE consuming AS's following token, so
+	// a spurious "unterminated string literal" from a multi-line single-quoted
+	// body (which the about-to-run scan triggers) can be dropped.
+	errLenBefore := len(p.lexer.errors)
+
+	asTok := p.advance() // consume AS; cur is now the body's first token
+	_ = asTok
+
+	if p.cur.Type == tokEOF {
+		// AS with no body is a syntax error.
+		return "", false, 0, p.syntaxErrorAtCur()
+	}
+
+	// Local (input-relative) scan cursor at the body's first byte. Token Locs are
+	// absolute (input-relative + base); p.input is the input-relative segment.
+	startLocal := p.cur.Loc.Start - p.base
+	if startLocal < 0 || startLocal >= len(p.input) {
+		return "", false, 0, p.syntaxErrorAtCur()
+	}
+
+	var endLocal int
+	switch p.input[startLocal] {
+	case '$':
+		// Dollar-quoted body: $$ ... $$. Snowflake's dollar-quoted body is a
+		// single $$-delimited run (no nesting, no escapes).
+		if startLocal+1 >= len(p.input) || p.input[startLocal+1] != '$' {
+			// A single '$' is not a body opener.
+			return "", false, 0, p.syntaxErrorAtCur()
+		}
+		j := startLocal + 2
+		for j+1 < len(p.input) && !(p.input[j] == '$' && p.input[j+1] == '$') {
+			j++
+		}
+		if j+1 >= len(p.input) {
+			// Unterminated $$ body.
+			return "", false, 0, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "unterminated dollar-quoted routine body",
+			}
+		}
+		endLocal = j + 2 // include the closing $$
+		dollar = true
+
+	case '\'':
+		// Single-quoted body: ' ... ' where '' is an escaped quote and the body
+		// may span newlines (unlike a lexer string literal). Scan to the matching
+		// unescaped closing quote.
+		j := startLocal + 1
+		closed := false
+		for j < len(p.input) {
+			if p.input[j] == '\'' {
+				if j+1 < len(p.input) && p.input[j+1] == '\'' {
+					j += 2 // '' escaped quote
+					continue
+				}
+				j++ // consume closing quote
+				closed = true
+				break
+			}
+			j++
+		}
+		if !closed {
+			return "", false, 0, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "unterminated routine body string literal",
+			}
+		}
+		endLocal = j
+		dollar = false
+
+	default:
+		return "", false, 0, p.syntaxErrorAtCur()
+	}
+
+	body = p.input[startLocal:endLocal]
+	end = endLocal + p.base
+
+	// Drop any spurious lex error the discarded body token produced (a multi-line
+	// single-quoted body makes scanString append an unterminated-string error).
+	if len(p.lexer.errors) > errLenBefore {
+		p.lexer.errors = p.lexer.errors[:errLenBefore]
+	}
+
+	// Re-sync the lexer past the body and re-prime cur. Because the body bypassed
+	// the token stream, the buffered lookahead and current token must be
+	// discarded and re-read from endLocal.
+	p.lexer.pos = endLocal
+	p.hasNext = false
+	p.advance()
+
+	return body, dollar, end, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER FUNCTION / PROCEDURE
+// ---------------------------------------------------------------------------
+
+// parseAlterFunctionStmt parses ALTER FUNCTION [IF EXISTS] <name> ( [argtypes] )
+// <action>. The ALTER keyword has already been consumed; cur is the FUNCTION
+// keyword.
+func (p *Parser) parseAlterFunctionStmt() (ast.Node, error) {
+	p.advance() // consume FUNCTION
+	return p.parseAlterRoutineBody(false)
+}
+
+// parseAlterProcedureStmt parses ALTER PROCEDURE [IF EXISTS] <name>
+// ( [argtypes] ) <action>. The ALTER keyword has already been consumed; cur is
+// the PROCEDURE keyword.
+func (p *Parser) parseAlterProcedureStmt() (ast.Node, error) {
+	p.advance() // consume PROCEDURE
+	return p.parseAlterRoutineBody(true)
+}
+
+// parseAlterRoutineBody parses the shared ALTER FUNCTION / PROCEDURE tail after
+// the object-type keyword has been consumed:
+//
+//	[ IF EXISTS ] <name> ( [ <argtype> [ , ... ] ] ) <action>
+//
+//	RENAME TO <new_name>
+//	SET <options>                              -- open-ended (SECURE / COMMENT / LOG_LEVEL / ...)
+//	UNSET <property> [ , ... ]                  -- SECURE / COMMENT / ...
+//	EXECUTE AS { CALLER | OWNER }               -- procedure only
+//
+// The ALTER signature carries argument TYPES only (no names). SET SECURE /
+// UNSET SECURE fall out of the open-ended SET options / UNSET property list (a
+// bare SECURE word), so they need no special case.
+func (p *Parser) parseAlterRoutineBody(procedure bool) (ast.Node, error) {
+	stmt := &ast.AlterRoutineStmt{
+		Procedure: procedure,
+		Loc:       ast.Loc{Start: p.prev.Loc.Start},
+	}
+
+	if err := p.parseIfExistsInto(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// ( [ <argtype> [ , ... ] ] ) signature.
+	argTypes, err := p.parseRoutineArgTypeList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.ArgTypes = argTypes
+
+	// Action.
+	switch p.cur.Type {
+	case kwRENAME:
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterRoutineRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		opts, err := p.parseRequiredOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterRoutineSet
+		stmt.Options = opts
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		props, err := p.parseUnsetPropertyList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterRoutineUnset
+		stmt.UnsetProps = props
+
+	default:
+		// EXECUTE AS { CALLER | OWNER } (procedure only). EXECUTE is an identifier,
+		// not a keyword, so it is matched by text.
+		if p.curIsWord("EXECUTE") {
+			if err := p.parseRoutineExecuteAs(&stmt.ExecuteAs); err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterRoutineExecuteAs
+			break
+		}
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRoutineArgTypeList parses the ALTER signature's argument-type list:
+//
+//	( [ <data_type> [ , ... ] ] )
+//
+// Unlike the CREATE arg list this carries types only (no names). An empty
+// list — () — yields nil. cur must be '('.
+func (p *Parser) parseRoutineArgTypeList() ([]*ast.TypeName, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	if p.cur.Type == ')' {
+		p.advance() // consume ')'
+		return nil, nil
+	}
+
+	var types []*ast.TypeName
+	for {
+		typ, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		types = append(types, typ)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return types, nil
+}

--- a/snowflake/parser/function_procedure_test.go
+++ b/snowflake/parser/function_procedure_test.go
@@ -1,0 +1,787 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateRoutine(t *testing.T, input string) *ast.CreateRoutineStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateRoutineStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateRoutineStmt", input, node)
+	}
+	return stmt
+}
+
+// mustCreateRoutineDirect parses ONE statement via parseSingle, bypassing F3's
+// Split. It is used for the multi-line single-quoted body canaries: those bodies
+// contain an embedded ';' that F3's lexer-driven Split mis-segments (the omni
+// lexer's scanString cannot span a newline, so a ';' that follows the newline
+// inside the body is mistaken for a statement terminator — a Split-layer
+// limitation tracked as a flagged divergence). parseSingle receives the whole
+// statement text, so it exercises THIS node's body raw-scan in isolation, which
+// is the layer this node owns. Forms that survive Split (single-line '…',
+// multi-line '…' with no embedded ';', and every $$…$$ body) are still asserted
+// end-to-end via mustCreateRoutine / the corpus harness.
+func mustCreateRoutineDirect(t *testing.T, input string) *ast.CreateRoutineStmt {
+	t.Helper()
+	node, errs := parseSingle(input, 0)
+	if len(errs) > 0 {
+		t.Fatalf("parseSingle %q: %d error(s): %v", input, len(errs), errs)
+	}
+	stmt, ok := node.(*ast.CreateRoutineStmt)
+	if !ok {
+		t.Fatalf("parseSingle %q: got %T, want *ast.CreateRoutineStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterRoutine(t *testing.T, input string) *ast.AlterRoutineStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterRoutineStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterRoutineStmt", input, node)
+	}
+	return stmt
+}
+
+// assertParseError parses input and asserts at least one error is produced (a
+// negative test). It does not require a specific message — only that omni
+// rejects the statement.
+func assertParseError(t *testing.T, input string) {
+	t.Helper()
+	result := ParseBestEffort(input)
+	if len(result.Errors) == 0 {
+		t.Fatalf("parse %q: expected an error, got none (stmts=%d)", input, len(result.File.Stmts))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ⭐ CANARY — body handling: single-line '…', MULTI-LINE '…', and $$…$$
+// ---------------------------------------------------------------------------
+
+func TestRoutineBody_SingleLineSingleQuote(t *testing.T) {
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION multiply1 (a number, b number) RETURNS number AS 'a * b'")
+	if stmt.Body != "'a * b'" {
+		t.Errorf("Body = %q, want %q", stmt.Body, "'a * b'")
+	}
+	if stmt.BodyDollar {
+		t.Errorf("BodyDollar = true, want false")
+	}
+}
+
+// The defining canary: a MULTI-LINE single-quoted body. The omni lexer cannot
+// tokenize this (scanString rejects the embedded newline); the parser must
+// raw-scan it from source, verbatim, with the embedded newline and quotes
+// preserved, and the statement must parse with ZERO errors. The body also
+// contains a ';', which F3's Split mis-segments (a Split-layer limitation; see
+// mustCreateRoutineDirect), so this canary is asserted directly against the
+// parser via parseSingle — the layer this node owns.
+func TestRoutineBody_MultiLineSingleQuote(t *testing.T) {
+	input := "CREATE FUNCTION f() RETURNS VARCHAR AS 'var r = 1;\n  return r;'"
+	stmt := mustCreateRoutineDirect(t, input)
+	want := "'var r = 1;\n  return r;'"
+	if stmt.Body != want {
+		t.Errorf("Body = %q, want %q", stmt.Body, want)
+	}
+	if stmt.BodyDollar {
+		t.Errorf("BodyDollar = true, want false")
+	}
+}
+
+// A multi-line single-quoted SQL body with NO embedded ';' survives F3's Split
+// (one segment), so it is asserted end-to-end through ParseBestEffort — proving
+// the body raw-scan works across the full pipeline when Split cooperates. This
+// is the create-function example_14 shape.
+func TestRoutineBody_MultiLineSingleQuoteSQL(t *testing.T) {
+	input := "CREATE OR REPLACE FUNCTION get_x ( id NUMBER )\n" +
+		"  RETURNS TABLE (country_code CHAR, country_name VARCHAR)\n" +
+		"  AS 'SELECT DISTINCT c.country_code, c.country_name\n" +
+		"      FROM user_addresses a, countries c\n" +
+		"      WHERE a.user_id = id\n" +
+		"      AND c.country_code = a.country_code'"
+	stmt := mustCreateRoutine(t, input)
+	if !strings.HasPrefix(stmt.Body, "'SELECT DISTINCT") || !strings.HasSuffix(stmt.Body, "a.country_code'") {
+		t.Errorf("Body = %q, want the verbatim multi-line single-quoted SELECT", stmt.Body)
+	}
+	if strings.Count(stmt.Body, "\n") != 3 {
+		t.Errorf("Body newline count = %d, want 3 (verbatim preserved)", strings.Count(stmt.Body, "\n"))
+	}
+	if stmt.ReturnTable == nil {
+		t.Errorf("ReturnTable = nil, want the RETURNS TABLE columns")
+	}
+}
+
+func TestRoutineBody_DollarQuoted(t *testing.T) {
+	input := "CREATE OR REPLACE FUNCTION f() RETURNS VARIANT LANGUAGE PYTHON HANDLER = 'udf' AS $$\nimport numpy\ndef udf():\n    return 1\n$$"
+	stmt := mustCreateRoutine(t, input)
+	if !strings.HasPrefix(stmt.Body, "$$") || !strings.HasSuffix(stmt.Body, "$$") {
+		t.Errorf("Body = %q, want a $$-delimited body", stmt.Body)
+	}
+	if !stmt.BodyDollar {
+		t.Errorf("BodyDollar = false, want true")
+	}
+	if !strings.Contains(stmt.Body, "import numpy") {
+		t.Errorf("Body = %q, want to contain the verbatim Python source", stmt.Body)
+	}
+}
+
+func TestRoutineBody_DollarQuotedEmpty(t *testing.T) {
+	// $$ $$ (empty body) — the legacy regression corpus uses this.
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS BOOLEAN AS $$ $$")
+	if stmt.Body != "$$ $$" {
+		t.Errorf("Body = %q, want %q", stmt.Body, "$$ $$")
+	}
+	if !stmt.BodyDollar {
+		t.Errorf("BodyDollar = false, want true")
+	}
+}
+
+func TestRoutineBody_SingleQuoteEscapedQuote(t *testing.T) {
+	// A doubled single-quote inside the body is an escaped quote and must not
+	// terminate the body early.
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS VARCHAR AS 'a ''quoted'' b'")
+	if stmt.Body != "'a ''quoted'' b'" {
+		t.Errorf("Body = %q, want %q", stmt.Body, "'a ''quoted'' b'")
+	}
+}
+
+func TestRoutineBody_TrailingSemicolonNotInBody(t *testing.T) {
+	// The trailing ';' is the statement delimiter (stripped by Split) and must
+	// not be absorbed into the body.
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS FLOAT AS '3.14::FLOAT';")
+	if stmt.Body != "'3.14::FLOAT'" {
+		t.Errorf("Body = %q, want %q", stmt.Body, "'3.14::FLOAT'")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FUNCTION — language × body matrix
+//
+// Asserted via parseSingle (mustCreateRoutineDirect): the multi-line
+// single-quoted handler bodies embed ';' / '{' that F3's Split mis-segments, so
+// this matrix isolates the node's own language × body handling. Split-safe forms
+// (single-line, no-';' multi-line, $$) are additionally covered end-to-end by the
+// dedicated tests and the official corpus harness.
+// ---------------------------------------------------------------------------
+
+func TestCreateFunction_LanguageBodyMatrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantDollar bool
+	}{
+		{
+			"java single-line",
+			"CREATE FUNCTION f(x VARCHAR) RETURNS VARCHAR LANGUAGE JAVA HANDLER = 'T.e' AS 'class T {}'",
+			false,
+		},
+		{
+			"java multi-line single-quote",
+			"CREATE FUNCTION f(x VARCHAR) RETURNS VARCHAR LANGUAGE JAVA HANDLER = 'T.e' AS\n'class T {\n  static String e(String x){ return x; }\n}'",
+			false,
+		},
+		{
+			"javascript multi-line single-quote",
+			"CREATE FUNCTION f(d DOUBLE) RETURNS DOUBLE LANGUAGE JAVASCRIPT STRICT AS '\nif (D <= 0) { return 1; }\nreturn D;\n'",
+			false,
+		},
+		{
+			"python dollar",
+			"CREATE FUNCTION f() RETURNS VARIANT LANGUAGE PYTHON RUNTIME_VERSION = '3.10' HANDLER = 'udf' AS $$\ndef udf(): return 1\n$$",
+			true,
+		},
+		{
+			"scala dollar runtime float",
+			"CREATE FUNCTION f(x VARCHAR) RETURNS VARCHAR LANGUAGE SCALA RUNTIME_VERSION = 2.12 HANDLER='E.e' AS\n$$\nclass E { def e(x:String):String = x }\n$$",
+			true,
+		},
+		{
+			"sql single-line",
+			"CREATE FUNCTION f(a NUMBER, b NUMBER) RETURNS NUMBER AS 'a * b'",
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := mustCreateRoutineDirect(t, tc.input)
+			if stmt.Kind != ast.RoutineFunction {
+				t.Errorf("Kind = %v, want RoutineFunction", stmt.Kind)
+			}
+			if stmt.BodyDollar != tc.wantDollar {
+				t.Errorf("BodyDollar = %v, want %v (body=%q)", stmt.BodyDollar, tc.wantDollar, stmt.Body)
+			}
+			if stmt.Body == "" {
+				t.Errorf("Body is empty, want a non-empty verbatim body")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FUNCTION — structure (args, RETURNS scalar/TABLE, modifiers, no-body)
+// ---------------------------------------------------------------------------
+
+func TestCreateFunction_Args(t *testing.T) {
+	t.Run("empty args", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS INT AS '1'")
+		if stmt.Args != nil {
+			t.Errorf("Args = %+v, want nil for ()", stmt.Args)
+		}
+	})
+	t.Run("typed args with params", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE FUNCTION f(i NUMERIC(9, 0), s VARCHAR(100)) RETURNS NUMERIC AS '1'")
+		if len(stmt.Args) != 2 {
+			t.Fatalf("len(Args) = %d, want 2", len(stmt.Args))
+		}
+		if stmt.Args[0].Name.Normalize() != "I" || stmt.Args[0].Type.Kind != ast.TypeNumber {
+			t.Errorf("Args[0] = %+v / %+v, want I NUMERIC", stmt.Args[0].Name, stmt.Args[0].Type)
+		}
+		if stmt.Args[1].Name.Normalize() != "S" || stmt.Args[1].Type.Kind != ast.TypeVarchar {
+			t.Errorf("Args[1] = %+v / %+v, want S VARCHAR", stmt.Args[1].Name, stmt.Args[1].Type)
+		}
+	})
+	t.Run("arg default expr", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE FUNCTION f(x INT DEFAULT 42) RETURNS INT AS '1'")
+		if len(stmt.Args) != 1 || stmt.Args[0].Default == nil {
+			t.Fatalf("Args = %+v, want one arg with a DEFAULT", stmt.Args)
+		}
+	})
+}
+
+func TestCreateFunction_ReturnsScalar(t *testing.T) {
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS FLOAT AS '1.0'")
+	if stmt.ReturnType == nil || stmt.ReturnType.Kind != ast.TypeFloat {
+		t.Fatalf("ReturnType = %+v, want FLOAT", stmt.ReturnType)
+	}
+	if stmt.ReturnTable != nil {
+		t.Errorf("ReturnTable = %+v, want nil for scalar return", stmt.ReturnTable)
+	}
+}
+
+func TestCreateFunction_ReturnsTable(t *testing.T) {
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS TABLE (x INTEGER, y VARCHAR) AS $$ SELECT 1, 'a' $$")
+	if stmt.ReturnTable == nil {
+		t.Fatalf("ReturnTable = nil, want columns")
+	}
+	if len(stmt.ReturnTable) != 2 {
+		t.Fatalf("len(ReturnTable) = %d, want 2", len(stmt.ReturnTable))
+	}
+	if stmt.ReturnTable[0].Name.Normalize() != "X" || stmt.ReturnTable[0].Type.Kind != ast.TypeInt {
+		t.Errorf("ReturnTable[0] = %+v, want X INTEGER", stmt.ReturnTable[0])
+	}
+	if stmt.ReturnType != nil {
+		t.Errorf("ReturnType = %+v, want nil for TABLE return", stmt.ReturnType)
+	}
+}
+
+func TestCreateFunction_ReturnsEmptyTable(t *testing.T) {
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS TABLE () AS $$ SELECT 1 $$")
+	if stmt.ReturnTable == nil {
+		t.Errorf("ReturnTable = nil, want a non-nil empty slice for RETURNS TABLE ()")
+	}
+	if len(stmt.ReturnTable) != 0 {
+		t.Errorf("len(ReturnTable) = %d, want 0", len(stmt.ReturnTable))
+	}
+}
+
+func TestCreateFunction_ReturnsNotNull(t *testing.T) {
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS FLOAT NOT NULL AS '1.0'")
+	if !stmt.ReturnNotNull {
+		t.Errorf("ReturnNotNull = false, want true")
+	}
+}
+
+func TestCreateFunction_Modifiers(t *testing.T) {
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE OR REPLACE FUNCTION f() RETURNS INT AS '1'")
+		if !stmt.OrReplace {
+			t.Errorf("OrReplace = false, want true")
+		}
+	})
+	t.Run("secure", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE SECURE FUNCTION f() RETURNS INT AS '1'")
+		if !stmt.Secure {
+			t.Errorf("Secure = false, want true")
+		}
+	})
+	t.Run("or replace secure", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE OR REPLACE SECURE FUNCTION f() RETURNS INT AS '1'")
+		if !stmt.OrReplace || !stmt.Secure {
+			t.Errorf("OrReplace/Secure = %v/%v, want true/true", stmt.OrReplace, stmt.Secure)
+		}
+	})
+	t.Run("temp", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE TEMP FUNCTION f() RETURNS INT AS '1'")
+		if !stmt.Temporary {
+			t.Errorf("Temporary = false, want true")
+		}
+	})
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE FUNCTION IF NOT EXISTS f() RETURNS INT AS '1'")
+		if !stmt.IfNotExists {
+			t.Errorf("IfNotExists = false, want true")
+		}
+	})
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE FUNCTION db.sch.f() RETURNS INT AS '1'")
+		if stmt.Name.String() != "db.sch.f" {
+			t.Errorf("Name = %q, want db.sch.f", stmt.Name.String())
+		}
+	})
+}
+
+func TestCreateFunction_VolatilityModifierWords(t *testing.T) {
+	// VOLATILE / IMMUTABLE / MEMOIZABLE / STRICT and the CALLED ON NULL INPUT /
+	// RETURNS NULL ON NULL INPUT phrases are captured as open-ended options.
+	cases := []string{
+		"CREATE FUNCTION f(x FLOAT) RETURNS FLOAT VOLATILE MEMOIZABLE AS '1'",
+		"CREATE FUNCTION f(x FLOAT) RETURNS FLOAT IMMUTABLE AS '1'",
+		"CREATE FUNCTION f(x VARCHAR) RETURNS VARCHAR LANGUAGE JAVA CALLED ON NULL INPUT HANDLER = 'T.e' AS 'x'",
+		"CREATE FUNCTION f(x VARCHAR) RETURNS VARCHAR RETURNS NULL ON NULL INPUT AS 'x'",
+		"CREATE FUNCTION f(d DOUBLE) RETURNS DOUBLE LANGUAGE JAVASCRIPT STRICT AS 'D'",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			stmt := mustCreateRoutine(t, in)
+			if len(stmt.Options) == 0 {
+				t.Errorf("Options is empty, want the modifier words captured")
+			}
+			if stmt.Body == "" {
+				t.Errorf("Body is empty, want the body still parsed after the modifiers")
+			}
+		})
+	}
+}
+
+func TestCreateFunction_NoBody(t *testing.T) {
+	// A function may be defined entirely by its handler (no AS body) — docs
+	// example_05 (IMPORTS-only, no AS).
+	stmt := mustCreateRoutine(t, "CREATE OR REPLACE FUNCTION f(i INT) RETURNS VARIANT LANGUAGE PYTHON RUNTIME_VERSION = '3.10' HANDLER = 's.snore' IMPORTS = ('@my_stage/sleepy.py')")
+	if stmt.Body != "" {
+		t.Errorf("Body = %q, want empty for a handler-only function", stmt.Body)
+	}
+	if stmt.BodyDollar {
+		t.Errorf("BodyDollar = true, want false")
+	}
+}
+
+func TestCreateFunction_OptionsCaptured(t *testing.T) {
+	stmt := mustCreateRoutine(t, "CREATE FUNCTION f() RETURNS VARIANT LANGUAGE PYTHON RUNTIME_VERSION = '3.10' PACKAGES = ('numpy','pandas') HANDLER = 'udf' AS $$ x $$")
+	names := map[string]bool{}
+	for _, o := range stmt.Options {
+		names[o.Name] = true
+	}
+	for _, want := range []string{"LANGUAGE", "RUNTIME_VERSION", "PACKAGES", "HANDLER"} {
+		if !names[want] {
+			t.Errorf("missing option %q; got %v", want, names)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE EXTERNAL FUNCTION
+// ---------------------------------------------------------------------------
+
+func TestCreateExternalFunction(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE EXTERNAL FUNCTION e() RETURNS INT API_INTEGRATION = i1 AS 'https://host/path'")
+		if stmt.Kind != ast.RoutineExternalFunction {
+			t.Errorf("Kind = %v, want RoutineExternalFunction", stmt.Kind)
+		}
+		if stmt.Body != "'https://host/path'" {
+			t.Errorf("Body = %q, want the quoted URL", stmt.Body)
+		}
+	})
+	t.Run("secure external", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE OR REPLACE SECURE EXTERNAL FUNCTION e(x INT) RETURNS VARIANT API_INTEGRATION = i1 MAX_BATCH_ROWS = 100 AS 'https://host/path'")
+		if stmt.Kind != ast.RoutineExternalFunction || !stmt.Secure || !stmt.OrReplace {
+			t.Errorf("Kind/Secure/OrReplace = %v/%v/%v", stmt.Kind, stmt.Secure, stmt.OrReplace)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE PROCEDURE
+// ---------------------------------------------------------------------------
+
+func TestCreateProcedure(t *testing.T) {
+	t.Run("javascript dollar", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE OR REPLACE PROCEDURE p() RETURNS FLOAT NOT NULL LANGUAGE JAVASCRIPT AS $$ return 1; $$")
+		if stmt.Kind != ast.RoutineProcedure {
+			t.Errorf("Kind = %v, want RoutineProcedure", stmt.Kind)
+		}
+		if !stmt.ReturnNotNull {
+			t.Errorf("ReturnNotNull = false, want true")
+		}
+	})
+	t.Run("execute as owner", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE OR REPLACE PROCEDURE p(x FLOAT) RETURNS STRING LANGUAGE JAVASCRIPT STRICT EXECUTE AS OWNER AS $$ return 'x'; $$")
+		if stmt.ExecuteAs != ast.ExecuteAsOwner {
+			t.Errorf("ExecuteAs = %v, want ExecuteAsOwner", stmt.ExecuteAs)
+		}
+	})
+	t.Run("execute as caller after options", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE OR REPLACE PROCEDURE p(a NUMBER) RETURNS NUMBER LANGUAGE PYTHON HANDLER='main' RUNTIME_VERSION=3.10 PACKAGES = ('snowflake-snowpark-python') EXECUTE AS CALLER AS $$ x $$")
+		if stmt.ExecuteAs != ast.ExecuteAsCaller {
+			t.Errorf("ExecuteAs = %v, want ExecuteAsCaller", stmt.ExecuteAs)
+		}
+	})
+	t.Run("secure procedure single-quote body", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE SECURE PROCEDURE p() RETURNS STRING LANGUAGE JAVASCRIPT AS ' '")
+		if !stmt.Secure {
+			t.Errorf("Secure = false, want true")
+		}
+		if stmt.Body != "' '" {
+			t.Errorf("Body = %q, want %q", stmt.Body, "' '")
+		}
+	})
+	t.Run("sql language single-quote", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "create procedure p() returns int language sql as ' '")
+		if stmt.Kind != ast.RoutineProcedure || stmt.Body != "' '" {
+			t.Errorf("Kind/Body = %v/%q", stmt.Kind, stmt.Body)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER FUNCTION / PROCEDURE
+// ---------------------------------------------------------------------------
+
+func TestAlterFunction(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f() RENAME TO f2")
+		if stmt.Procedure {
+			t.Errorf("Procedure = true, want false")
+		}
+		if stmt.Action != ast.AlterRoutineRename || stmt.NewName.String() != "f2" {
+			t.Errorf("Action/NewName = %v/%v", stmt.Action, stmt.NewName)
+		}
+	})
+	t.Run("rename with argtypes", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f(NUMBER, VARCHAR) RENAME TO f2")
+		if len(stmt.ArgTypes) != 2 {
+			t.Fatalf("len(ArgTypes) = %d, want 2", len(stmt.ArgTypes))
+		}
+		if stmt.ArgTypes[0].Kind != ast.TypeNumber || stmt.ArgTypes[1].Kind != ast.TypeVarchar {
+			t.Errorf("ArgTypes = %+v, want NUMBER, VARCHAR", stmt.ArgTypes)
+		}
+	})
+	t.Run("if exists", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION IF EXISTS f() RENAME TO f2")
+		if !stmt.IfExists {
+			t.Errorf("IfExists = false, want true")
+		}
+	})
+	t.Run("set secure", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f() SET SECURE")
+		if stmt.Action != ast.AlterRoutineSet || len(stmt.Options) != 1 || stmt.Options[0].Name != "SECURE" {
+			t.Errorf("Action/Options = %v/%+v, want SET [SECURE]", stmt.Action, stmt.Options)
+		}
+	})
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f() SET COMMENT = 'hi'")
+		if stmt.Action != ast.AlterRoutineSet || stmt.Options[0].Name != "COMMENT" {
+			t.Errorf("Options = %+v, want [COMMENT='hi']", stmt.Options)
+		}
+	})
+	t.Run("set log_level", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f(INT) SET LOG_LEVEL = 'DEBUG'")
+		if stmt.Options[0].Name != "LOG_LEVEL" {
+			t.Errorf("Options = %+v, want LOG_LEVEL", stmt.Options)
+		}
+	})
+	t.Run("unset secure", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f() UNSET SECURE")
+		if stmt.Action != ast.AlterRoutineUnset || len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "SECURE" {
+			t.Errorf("Action/UnsetProps = %v/%v", stmt.Action, stmt.UnsetProps)
+		}
+	})
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f() UNSET COMMENT")
+		if stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("UnsetProps = %v, want [COMMENT]", stmt.UnsetProps)
+		}
+	})
+	t.Run("set api_integration external", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER FUNCTION f(INT) SET API_INTEGRATION = i2")
+		if stmt.Options[0].Name != "API_INTEGRATION" {
+			t.Errorf("Options = %+v, want API_INTEGRATION", stmt.Options)
+		}
+	})
+}
+
+func TestAlterProcedure(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER PROCEDURE pr() RENAME TO p2")
+		if !stmt.Procedure {
+			t.Errorf("Procedure = false, want true")
+		}
+		if stmt.Action != ast.AlterRoutineRename || stmt.NewName.String() != "p2" {
+			t.Errorf("Action/NewName = %v/%v", stmt.Action, stmt.NewName)
+		}
+	})
+	t.Run("execute as caller", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER PROCEDURE p(VARCHAR) EXECUTE AS CALLER")
+		if stmt.Action != ast.AlterRoutineExecuteAs || stmt.ExecuteAs != ast.ExecuteAsCaller {
+			t.Errorf("Action/ExecuteAs = %v/%v", stmt.Action, stmt.ExecuteAs)
+		}
+	})
+	t.Run("execute as owner", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER PROCEDURE p() EXECUTE AS OWNER")
+		if stmt.ExecuteAs != ast.ExecuteAsOwner {
+			t.Errorf("ExecuteAs = %v, want ExecuteAsOwner", stmt.ExecuteAs)
+		}
+	})
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER PROCEDURE p(INT, INT) SET COMMENT = 'x'")
+		if stmt.Action != ast.AlterRoutineSet || stmt.Options[0].Name != "COMMENT" {
+			t.Errorf("Options = %+v", stmt.Options)
+		}
+	})
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterRoutine(t, "ALTER PROCEDURE IF EXISTS p() UNSET COMMENT")
+		if !stmt.IfExists || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("IfExists/UnsetProps = %v/%v", stmt.IfExists, stmt.UnsetProps)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — omni must reject malformed routine DDL
+// ---------------------------------------------------------------------------
+
+func TestRoutine_Negatives(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"function missing parens", "CREATE FUNCTION f RETURNS INT AS '1'"},
+		{"function missing returns", "CREATE FUNCTION f() AS '1'"},
+		{"function returns missing type", "CREATE FUNCTION f() RETURNS AS '1'"},
+		{"function as with no body", "CREATE FUNCTION f() RETURNS INT AS"},
+		{"function unterminated single-quote body", "CREATE FUNCTION f() RETURNS INT AS 'abc"},
+		{"function unterminated dollar body", "CREATE FUNCTION f() RETURNS INT AS $$abc"},
+		{"function arg missing type", "CREATE FUNCTION f(x) RETURNS INT AS '1'"},
+		{"alter function missing signature parens", "ALTER FUNCTION f RENAME TO g"},
+		{"alter function bad action", "ALTER FUNCTION f() FROBNICATE"},
+		{"alter procedure set nothing", "ALTER PROCEDURE p() SET"},
+		{"external function not function", "CREATE EXTERNAL TABLE e() RETURNS INT AS 'x'"},
+		{"procedure execute as bad", "CREATE PROCEDURE p() RETURNS INT LANGUAGE SQL EXECUTE AS NOBODY AS '1'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertParseError(t, tc.input)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc spans
+// ---------------------------------------------------------------------------
+
+func TestRoutine_LocSpansBody(t *testing.T) {
+	input := "CREATE FUNCTION f() RETURNS INT AS '1 + 1'"
+	stmt := mustCreateRoutine(t, input)
+	// Loc.End must reach the closing quote of the body (the last byte of input).
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d (end of body)", stmt.Loc.End, len(input))
+	}
+	if input[stmt.Loc.Start:stmt.Loc.End] != input {
+		t.Errorf("Loc span = %q, want the full statement", input[stmt.Loc.Start:stmt.Loc.End])
+	}
+}
+
+func TestRoutine_LocMultiLineBody(t *testing.T) {
+	input := "CREATE FUNCTION f() RETURNS VARCHAR AS 'line1\nline2'"
+	stmt := mustCreateRoutine(t, input)
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d (end of multi-line body)", stmt.Loc.End, len(input))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official docs corpus — every CREATE FUNCTION / PROCEDURE example in the
+// create-function and create-procedure corpora must parse with zero errors. The
+// official docs are the authoritative oracle (truth1); the legacy .g4 corpus is
+// the regression baseline (truth2).
+//
+// Each corpus file is exactly ONE statement, so it is driven through parseSingle
+// on the whole file text (trailing ';' stripped) rather than ParseBestEffort.
+// This is deliberate: the multi-line single-quoted handler bodies (example_01 /
+// _03, etc.) embed a ';' that F3's lexer-driven Split mis-segments — a Split-layer
+// limitation (the omni lexer's scanString cannot span a newline) tracked as a
+// flagged divergence, NOT this node's concern. parseSingle exercises THIS node's
+// body raw-scan against the real documented forms, including those multi-line
+// single-quoted bodies, which all parse. The only skips are CREATE OR ALTER …
+// (create-function example_15/16, create-procedure example_05/06), owned by the
+// separate parser-or-alter DAG node, and the SELECT FROM TABLE(...) line
+// (create-function example_12), owned by the select-core node.
+// ---------------------------------------------------------------------------
+
+var routineCorpusDirs = []string{
+	"testdata/official/create-function",
+	"testdata/official/create-procedure",
+}
+
+func TestRoutine_OfficialCorpus(t *testing.T) {
+	for _, dir := range routineCorpusDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read corpus dir %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			t.Run(path, func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				assertRoutineFileParses(t, string(data))
+			})
+		}
+	}
+}
+
+func TestRoutine_LegacyCorpus(t *testing.T) {
+	// The legacy create_function.sql / create_procedure.sql carry the regression
+	// cases; each line is a single, ';'-terminated statement with a Split-safe
+	// $$ or short single-quoted body, so they are driven statement-by-statement
+	// via Split + parseSingle.
+	for _, path := range []string{"testdata/legacy/create_function.sql", "testdata/legacy/create_procedure.sql"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		t.Run(path, func(t *testing.T) {
+			assertRoutineStatementsParse(t, string(data))
+		})
+	}
+}
+
+// assertRoutineFileParses treats a single-statement corpus file as ONE
+// statement: it strips a trailing ';' and parses the whole text via parseSingle
+// (bypassing F3's Split, which mis-segments multi-line single-quoted bodies). It
+// asserts the statement parses with no errors and to a routine node, unless it is
+// owned by another DAG node (CREATE OR ALTER → parser-or-alter; SELECT →
+// select-core), which is skipped with a logged note.
+func assertRoutineFileParses(t *testing.T, sql string) {
+	t.Helper()
+	text := strings.TrimRight(strings.TrimSpace(sql), ";")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	upper := strings.ToUpper(text)
+
+	if routineOrAlterLimited(upper) {
+		// CREATE OR ALTER is owned by the parser-or-alter node. If it starts
+		// parsing here, surface that so the filter can be removed.
+		if _, errs := parseSingle(text, 0); len(errs) == 0 {
+			t.Logf("note: CREATE OR ALTER now parses, drop it from routineOrAlterLimited: %q", text)
+		}
+		return
+	}
+
+	kind, want := routineStmtKind(upper)
+	if kind == "" {
+		return // context statement owned by another DAG node (e.g. SELECT)
+	}
+
+	node, errs := parseSingle(text, 0)
+	if len(errs) > 0 {
+		t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+		return
+	}
+	if !want(node) {
+		t.Errorf("statement %q (%s) parsed to unexpected type %T", text, kind, node)
+	}
+}
+
+// routineOrAlterLimited reports whether a statement uses the CREATE OR ALTER form
+// (owned by the separate parser-or-alter DAG node). Those are skipped with a
+// logged note + a flagged divergence, mirroring the copy / file-format / pipeline
+// corpus harnesses' skip-with-note pattern.
+func routineOrAlterLimited(upper string) bool {
+	return strings.HasPrefix(upper, "CREATE OR ALTER ")
+}
+
+// assertRoutineStatementsParse parses sql via Split + parseSingle and asserts
+// that every CREATE FUNCTION / EXTERNAL FUNCTION / PROCEDURE and ALTER FUNCTION /
+// PROCEDURE statement parses with no errors and to the expected AST type.
+// Statements owned by other DAG nodes (a SELECT, a CREATE OR ALTER) are skipped.
+// Used for the legacy corpus, whose bodies are Split-safe.
+func assertRoutineStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+
+		if routineOrAlterLimited(upper) {
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: CREATE OR ALTER now parses, drop it from routineOrAlterLimited: %q", text)
+			}
+			continue
+		}
+
+		kind, want := routineStmtKind(upper)
+		if kind == "" {
+			continue // context statement owned by another DAG node (e.g. SELECT)
+		}
+
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+			continue
+		}
+		if !want(node) {
+			t.Errorf("statement %q (%s) parsed to unexpected type %T", text, kind, node)
+		}
+	}
+}
+
+// routineStmtKind classifies an uppercased statement by its leading keywords,
+// returning a kind label and a predicate checking the parsed node type. Returns
+// ("", nil) for statements this node does not own.
+func routineStmtKind(upper string) (string, func(ast.Node) bool) {
+	isCreate := routineHasCreatePrefix(upper)
+	switch {
+	case isCreate:
+		return "CREATE-ROUTINE", func(n ast.Node) bool { _, ok := n.(*ast.CreateRoutineStmt); return ok }
+	case strings.HasPrefix(upper, "ALTER FUNCTION "), strings.HasPrefix(upper, "ALTER PROCEDURE "):
+		return "ALTER-ROUTINE", func(n ast.Node) bool { _, ok := n.(*ast.AlterRoutineStmt); return ok }
+	}
+	return "", nil
+}
+
+// routineHasCreatePrefix reports whether an uppercased statement is a CREATE
+// FUNCTION / EXTERNAL FUNCTION / PROCEDURE, allowing for the OR REPLACE / SECURE
+// / TEMP / TEMPORARY modifiers between CREATE and the object keyword.
+func routineHasCreatePrefix(upper string) bool {
+	if !strings.HasPrefix(upper, "CREATE ") {
+		return false
+	}
+	rest := strings.TrimPrefix(upper, "CREATE ")
+	for _, mod := range []string{"OR REPLACE ", "SECURE ", "TEMPORARY ", "TEMP ", "EXTERNAL "} {
+		rest = strings.TrimPrefix(rest, mod)
+	}
+	return strings.HasPrefix(rest, "FUNCTION ") || strings.HasPrefix(rest, "FUNCTION(") ||
+		strings.HasPrefix(rest, "PROCEDURE ") || strings.HasPrefix(rest, "PROCEDURE(")
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-routines` (v1 DAG **T4.5**) — `CREATE`/`ALTER FUNCTION` & `PROCEDURE`. `DROP` for these was already merged (drop.go), untouched.

## Forms
- `CREATE [OR REPLACE] [SECURE] [TEMP|TEMPORARY] FUNCTION [IF NOT EXISTS] <name> ( [args] ) RETURNS {<type> | TABLE (…)} [lang/runtime/handler/packages/imports/volatility…] {AS <body> | AS $$…$$}` — handlers SQL/JAVASCRIPT/PYTHON/JAVA/SCALA
- `CREATE [SECURE] EXTERNAL FUNCTION … API_INTEGRATION= … AS '<url>'`
- `CREATE [OR REPLACE] PROCEDURE <name> ( [args] ) RETURNS <type> [lang/…] [EXECUTE AS {CALLER|OWNER}] AS <body>`
- `ALTER FUNCTION/PROCEDURE [IF EXISTS] <name> ( [argtypes] )` SET/UNSET / RENAME TO

## Body handling — raw-scan from source (the notable part)
The `AS` body is captured **verbatim and opaque** (handler languages aren't parsed here). It is **raw-scanned from source via the `Parser.base` offset rather than the lexer token**, because the lexer's `scanString` does not span newlines and **multi-line single-quoted bodies** (`AS 'SELECT a,\n b\n FROM t'`) are common — they would otherwise lex as "unterminated string." The scan handles `''` escapes, spans newlines, errors on an unterminated body, and re-syncs the lexer past the scanned span (mirroring copy.go's `file://` raw-scan). `$$…$$` bodies use the lexer token directly. Language/runtime options are open-ended `KEY=<value>` pairs (`ast.CopyOption`).

## Oracle / tests
Triangulation — official docs (authoritative) + legacy ANTLR `create_function`/`create_procedure`/`alter_*` + the `create-function`/`create-procedure` corpora. `go test ./snowflake/parser/... ./snowflake/ast/...` green (incl. single-line / **multi-line** `'…'` / `$$…$$` bodies × all handlers × external/procedure × ALTER × **negatives** for unterminated `'` and `$$` bodies). `gofmt`/`go vet` clean.

## Divergences (flagged — docs win)
1. **Multi-line single-quoted body** worked around in-node via raw-scan (the lexer's `scanString` newline limitation is a `lexer`-node concern; flagged, not fixed here).
2. **`CREATE OR ALTER`** corpus examples filtered — owned by the tracked `parser-or-alter` node.

## Review
Claude lens + orchestrator independent verification: build clean, full scoped tests green (incl. negatives + multi-line), scope = the 7 declared files, and a line-by-line review of the raw-scan `parseRoutineBody` (bounds-checked, both scan loops strictly advance and are bounded — no infinite-loop risk). Codex lens unavailable (out of credits).

## Note
The implementing worker completed + verified the code but stalled at its finish step before committing; the orchestrator committed its verified work (`3d689232`) and opened this PR. No code modified beyond the worker's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)