### PR TITLE
feat(trino/parser): MATCH_RECOGNIZE row pattern (v2 node trino/parser-match-recognize)

### DIFF
--- a/trino/parser/function.go
+++ b/trino/parser/function.go
@@ -241,12 +241,16 @@ type WindowSpec struct {
 
 // WindowFrame is the common frame `frameType [BETWEEN start AND end] | frameType
 // start` (frameExtent). FrameType is ROWS/RANGE/GROUPS. End is nil for the
-// single-bound form. The pattern-recognition frame additions are deferred to
-// parser-match-recognize (B2).
+// single-bound form. Pattern carries the row-pattern-recognition additions a
+// windowFrame may wrap around the frameExtent (MEASURES / PATTERN / SUBSET /
+// DEFINE / AFTER MATCH / INITIAL|SEEK); it is nil for an ordinary frame and is
+// owned by parser-match-recognize (B2 — see MatchRecognizeFrame in
+// match_recognize.go).
 type WindowFrame struct {
 	FrameType string
 	Start     WindowBound
-	End       *WindowBound // nil for the single-bound form
+	End       *WindowBound         // nil for the single-bound form
+	Pattern   *MatchRecognizeFrame // row-pattern additions, nil for an ordinary frame
 	Loc       ast.Loc
 }
 
@@ -658,9 +662,12 @@ func (p *Parser) parseWindowSpecification(startOffset int) (*WindowSpec, error) 
 	spec := &WindowSpec{Loc: ast.Loc{Start: startOffset}}
 
 	// Optional existing window name: a leading identifier that is NOT the start
-	// of PARTITION/ORDER/a frame keyword or ')'.
+	// of PARTITION/ORDER/a frame keyword or ')'. MEASURES is excluded only when it
+	// begins a pattern-recognition MEASURES clause (parser-match-recognize); a
+	// leading MEASURES followed by a clause keyword is an ordinary window name
+	// (atMeasuresClause, B2).
 	if isIdentifierStart(p.cur.Kind) && p.cur.Kind != kwPARTITION && p.cur.Kind != kwORDER &&
-		!isFrameTypeKeyword(p.cur.Kind) {
+		!isFrameTypeKeyword(p.cur.Kind) && !p.atMeasuresClause() {
 		spec.ExistingName = identFromToken(p.advance())
 	}
 
@@ -692,7 +699,11 @@ func (p *Parser) parseWindowSpecification(startOffset int) (*WindowSpec, error) 
 		spec.OrderBy = items
 	}
 
-	if isFrameTypeKeyword(p.cur.Kind) {
+	// A window frame leads with its frameExtent keyword (ROWS/RANGE/GROUPS) or,
+	// for a pattern-recognition frame, with MEASURES (the windowFrame rule's
+	// leading MEASURES clause precedes the frameExtent — parser-match-recognize,
+	// B2).
+	if isFrameTypeKeyword(p.cur.Kind) || p.cur.Kind == kwMEASURES {
 		frame, err := p.parseWindowFrame()
 		if err != nil {
 			return nil, err
@@ -714,40 +725,83 @@ func isFrameTypeKeyword(kind TokenKind) bool {
 	return kind == kwROWS || kind == kwRANGE || kind == kwGROUPS
 }
 
-// parseWindowFrame parses the common frame `frameType (BETWEEN start AND end |
-// start)` (frameExtent + frameBound). The pattern-recognition frame additions
-// (MEASURES/PATTERN/DEFINE/…) are deferred to parser-match-recognize (B2); this
-// node implements only the standard frame.
+// parseWindowFrame parses a windowFrame: the common `frameType (BETWEEN start
+// AND end | start)` (frameExtent + frameBound), optionally surrounded by the
+// row-pattern-recognition additions `(MEASURES …)? frameExtent (AFTER MATCH …)?
+// (INITIAL|SEEK)? (PATTERN …)? (SUBSET …)? (DEFINE …)?`. The MEASURES clause
+// (when present) leads the frame, before the frameExtent; the remaining
+// additions follow it. The pattern additions are owned by parser-match-recognize
+// (B2): this function parses the standard frameExtent and delegates the
+// pattern parts to the match-recognize helpers, attaching the result to
+// frame.Pattern (nil for an ordinary frame).
 func (p *Parser) parseWindowFrame() (*WindowFrame, error) {
+	start := p.cur.Loc.Start
+
+	// Leading MEASURES (parser-match-recognize, B2). Precedes the frameExtent.
+	leadingMeasures, _, err := p.parseLeadingFrameMeasures()
+	if err != nil {
+		return nil, err
+	}
+
+	frame, err := p.parseFrameExtent(start)
+	if err != nil {
+		return nil, err
+	}
+
+	// Trailing pattern-recognition additions (AFTER MATCH / INITIAL|SEEK /
+	// PATTERN / SUBSET / DEFINE), plus the leading MEASURES if any.
+	mrf, err := p.parseTrailingFramePattern(leadingMeasures)
+	if err != nil {
+		return nil, err
+	}
+	frame.Pattern = mrf
+	// Extend the frame span over any trailing pattern clauses just consumed so the
+	// WindowFrame location covers the whole `[MEASURES] frameExtent [AFTER MATCH …]
+	// [PATTERN …] [SUBSET …] [DEFINE …]`, not just the frameExtent. p.prev is the
+	// last token consumed by parseTrailingFramePattern (or the frameExtent's last
+	// token when there were no trailing clauses).
+	if mrf != nil {
+		frame.Loc.End = p.prev.Loc.End
+	}
+	return frame, nil
+}
+
+// parseFrameExtent parses the `frameType (BETWEEN start AND end | start)`
+// frameExtent (the ROWS/RANGE/GROUPS keyword is current). start is the frame's
+// origin offset (the leading MEASURES start, or the frameType offset).
+func (p *Parser) parseFrameExtent(start int) (*WindowFrame, error) {
+	if !isFrameTypeKeyword(p.cur.Kind) {
+		return nil, p.exprErrorAt("expected ROWS, RANGE, or GROUPS frame type")
+	}
 	typeTok := p.advance() // ROWS / RANGE / GROUPS
 	frame := &WindowFrame{
 		FrameType: typeTok.Str,
-		Loc:       ast.Loc{Start: typeTok.Loc.Start},
+		Loc:       ast.Loc{Start: start},
 	}
 	if p.cur.Kind == kwBETWEEN {
 		p.advance() // consume BETWEEN
-		start, err := p.parseFrameBound()
+		lo, err := p.parseFrameBound()
 		if err != nil {
 			return nil, err
 		}
 		if _, err := p.expect(kwAND); err != nil {
 			return nil, err
 		}
-		end, err := p.parseFrameBound()
+		hi, err := p.parseFrameBound()
 		if err != nil {
 			return nil, err
 		}
-		frame.Start = start
-		frame.End = &end
-		frame.Loc.End = end.Loc.End
+		frame.Start = lo
+		frame.End = &hi
+		frame.Loc.End = hi.Loc.End
 		return frame, nil
 	}
-	start, err := p.parseFrameBound()
+	lo, err := p.parseFrameBound()
 	if err != nil {
 		return nil, err
 	}
-	frame.Start = start
-	frame.Loc.End = start.Loc.End
+	frame.Start = lo
+	frame.Loc.End = lo.Loc.End
 	return frame, nil
 }
 

--- a/trino/parser/match_recognize.go
+++ b/trino/parser/match_recognize.go
@@ -1,0 +1,867 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is the `parser-match-recognize` DAG node (with row_pattern.go): it
+// implements Trino's row-pattern-recognition subsystem — the `patternRecognition`
+// relation clause `MATCH_RECOGNIZE ( … )` and the window-frame row-pattern
+// additions (the windowFrame rule's MEASURES / PATTERN / SUBSET / DEFINE / AFTER
+// MATCH / INITIAL|SEEK extensions). row_pattern.go owns the rowPattern grammar
+// itself; this file owns the clause that surrounds it and the two integration
+// hooks into the parser-select / expressions nodes.
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	sampledRelation : patternRecognition (TABLESAMPLE …)? ;
+//	patternRecognition
+//	    : aliasedRelation (
+//	        MATCH_RECOGNIZE_ LPAREN_
+//	          (PARTITION_ BY_ expression (, expression)*)?
+//	          (ORDER_ BY_ sortItem (, sortItem)*)?
+//	          (MEASURES_ measureDefinition (, measureDefinition)*)?
+//	          rowsPerMatch?
+//	          (AFTER_ MATCH_ skipTo)?
+//	          (INITIAL_ | SEEK_)?
+//	          PATTERN_ LPAREN_ rowPattern RPAREN_
+//	          (SUBSET_ subsetDefinition (, subsetDefinition)*)?
+//	          DEFINE_ variableDefinition (, variableDefinition)*
+//	        RPAREN_ (AS_? identifier columnAliases?)?
+//	      )? ;
+//	measureDefinition : expression AS_ identifier ;
+//	rowsPerMatch      : ONE_ ROW_ PER_ MATCH_
+//	                  | ALL_ ROWS_ PER_ MATCH_ emptyMatchHandling? ;
+//	emptyMatchHandling: SHOW_ EMPTY_ MATCHES_ | OMIT_ EMPTY_ MATCHES_
+//	                  | WITH_ UNMATCHED_ ROWS_ ;
+//	skipTo            : SKIP_ (TO_ (NEXT_ ROW_ | (FIRST_|LAST_)? identifier)
+//	                          | PAST_ LAST_ ROW_) ;
+//	subsetDefinition  : identifier EQ_ LPAREN_ identifier (, identifier)* RPAREN_ ;
+//	variableDefinition: identifier AS_ expression ;
+//	windowFrame
+//	    : (MEASURES_ measureDefinition (, measureDefinition)*)? frameExtent
+//	      (AFTER_ MATCH_ skipTo)? (INITIAL_ | SEEK_)?
+//	      (PATTERN_ LPAREN_ rowPattern RPAREN_)?
+//	      (SUBSET_ subsetDefinition (, subsetDefinition)*)?
+//	      (DEFINE_ variableDefinition (, variableDefinition)*)? ;
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed structure
+// (probed; see oracle_match_recognize_test.go):
+//
+//	M1 (PATTERN and DEFINE are both mandatory in a relation MATCH_RECOGNIZE).
+//	   `MATCH_RECOGNIZE (PATTERN (A))`, `MATCH_RECOGNIZE (DEFINE A AS true)`, and
+//	   `MATCH_RECOGNIZE ()` are all SYNTAX_ERRORs. PATTERN's body parens are also
+//	   required (`PATTERN A …` is rejected).
+//	M2 (fixed clause order). The optional clauses appear in exactly the grammar
+//	   order — PARTITION BY, ORDER BY, MEASURES, rowsPerMatch, AFTER MATCH,
+//	   INITIAL|SEEK, then PATTERN. Reordering (e.g. ORDER BY before PARTITION BY)
+//	   is rejected, so each is parsed by a single positional check (no loop).
+//	M3 (double alias). The inner aliasedRelation may carry its own alias AND the
+//	   MATCH_RECOGNIZE may carry a trailing `AS? identifier columnAliases?`:
+//	   `t AS r MATCH_RECOGNIZE (…) AS m` is accepted. The trailing alias is on the
+//	   PatternRecognition node; the inner alias stays on the wrapped relation.
+//	M4 (MATCH_RECOGNIZE binds before TABLESAMPLE). Because sampledRelation is
+//	   `patternRecognition (TABLESAMPLE …)?`, MATCH_RECOGNIZE attaches to the
+//	   aliasedRelation and TABLESAMPLE wraps the result: `t MATCH_RECOGNIZE (…)
+//	   TABLESAMPLE …` is accepted, `t TABLESAMPLE … MATCH_RECOGNIZE (…)` rejected.
+//	   The relation-level hook therefore runs inside parseSampledRelation, between
+//	   aliasedRelation and TABLESAMPLE (the D4 boundary noted in relation.go).
+//	M5 (INITIAL|SEEK and AFTER MATCH SKIP forms parse). INITIAL / SEEK are
+//	   accepted at the grammar level (the planner may answer NOT_SUPPORTED, which
+//	   is a semantic outcome, not a syntax rejection); every skipTo form
+//	   (TO NEXT ROW, TO [FIRST|LAST] var, TO var, PAST LAST ROW) is accepted.
+//	M6 (window-frame pattern). The OVER-clause windowFrame may carry the same
+//	   MEASURES / PATTERN / SUBSET / DEFINE / AFTER MATCH / INITIAL|SEEK around a
+//	   frameExtent. There, every part is optional EXCEPT frameExtent — a window
+//	   frame may have MEASURES with no PATTERN, or PATTERN with no DEFINE
+//	   (unlike the mandatory relation form, M1). The expressions node's
+//	   parseWindowFrame delegates these additions here (the B2 boundary).
+
+// ---------------------------------------------------------------------------
+// patternRecognition node types (parser-package types; not ast.Node — matching
+// the Relation / Expr convention, see relation.go / expr.go headers)
+// ---------------------------------------------------------------------------
+
+// PatternRecognition is the relation produced by an aliasedRelation followed by
+// a `MATCH_RECOGNIZE ( … )` clause (the patternRecognition rule's
+// MATCH_RECOGNIZE alternative). It is a Relation, wrapping the underlying
+// aliasedRelation in Input. The body fields mirror the grammar; Pattern and
+// Definitions are always non-nil/non-empty (M1). Alias / ColumnAliases carry the
+// clause's own trailing `AS? identifier columnAliases?` (M3), nil when absent.
+//
+// When an aliasedRelation is NOT followed by MATCH_RECOGNIZE, no
+// PatternRecognition node is produced — the aliasedRelation is returned as-is
+// (the patternRecognition rule's empty alternative).
+type PatternRecognition struct {
+	Input          Relation             // the wrapped aliasedRelation
+	PartitionBy    []Expr               // PARTITION BY …, nil when absent
+	OrderBy        []SortItem           // ORDER BY …, nil when absent
+	Measures       []MeasureDefinition  // MEASURES …, nil when absent
+	RowsPerMatch   *RowsPerMatch        // ONE ROW / ALL ROWS PER MATCH, nil when absent
+	AfterMatchSkip *SkipTo              // AFTER MATCH SKIP …, nil when absent
+	SearchMode     string               // "", "INITIAL", or "SEEK"
+	Pattern        RowPattern           // PATTERN ( rowPattern ) — required (M1)
+	Subsets        []SubsetDefinition   // SUBSET …, nil when absent
+	Definitions    []VariableDefinition // DEFINE … — required, non-empty (M1)
+	Alias          *ast.Identifier      // trailing AS? identifier, nil when absent
+	ColumnAliases  []*ast.Identifier    // trailing columnAliases, nil when absent
+	Loc            ast.Loc
+}
+
+func (n *PatternRecognition) Span() ast.Loc { return n.Loc }
+func (*PatternRecognition) relationNode()   {}
+
+// MeasureDefinition is one `expression AS identifier` of a MEASURES clause (the
+// measureDefinition rule): a named row-pattern measure. The RUNNING/FINAL
+// semantics live inside Expr (the expression grammar's processingMode).
+type MeasureDefinition struct {
+	Expr Expr
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+// RowsPerMatchKind enumerates the rowsPerMatch shapes.
+type RowsPerMatchKind int
+
+const (
+	// OneRowPerMatch is `ONE ROW PER MATCH`.
+	OneRowPerMatch RowsPerMatchKind = iota
+	// AllRowsPerMatch is `ALL ROWS PER MATCH [emptyMatchHandling]`.
+	AllRowsPerMatch
+)
+
+// RowsPerMatch is the `ONE ROW PER MATCH` / `ALL ROWS PER MATCH
+// [emptyMatchHandling]` clause (the rowsPerMatch rule). EmptyHandling is "" for
+// ONE ROW PER MATCH and for ALL ROWS PER MATCH with no handling; otherwise it is
+// "SHOW EMPTY MATCHES", "OMIT EMPTY MATCHES", or "WITH UNMATCHED ROWS".
+type RowsPerMatch struct {
+	Kind          RowsPerMatchKind
+	EmptyHandling string
+	Loc           ast.Loc
+}
+
+// SkipToKind enumerates the AFTER MATCH SKIP target shapes (the skipTo rule).
+type SkipToKind int
+
+const (
+	// SkipPastLastRow is `SKIP PAST LAST ROW`.
+	SkipPastLastRow SkipToKind = iota
+	// SkipToNextRow is `SKIP TO NEXT ROW`.
+	SkipToNextRow
+	// SkipToFirst is `SKIP TO FIRST identifier`.
+	SkipToFirst
+	// SkipToLast is `SKIP TO LAST identifier`.
+	SkipToLast
+	// SkipToVariable is `SKIP TO identifier` (no FIRST/LAST).
+	SkipToVariable
+)
+
+// SkipTo is an `AFTER MATCH SKIP …` target (the skipTo rule). Kind is the target
+// shape; Variable is the pattern-variable name for the SkipToFirst / SkipToLast /
+// SkipToVariable forms (nil otherwise).
+type SkipTo struct {
+	Kind     SkipToKind
+	Variable *ast.Identifier // for SKIP TO [FIRST|LAST] variable, nil otherwise
+	Loc      ast.Loc
+}
+
+// SubsetDefinition is one `identifier = ( identifier (, identifier)* )` of a
+// SUBSET clause (the subsetDefinition rule): a union variable Name defined as the
+// union of the Of pattern variables.
+type SubsetDefinition struct {
+	Name *ast.Identifier
+	Of   []*ast.Identifier
+	Loc  ast.Loc
+}
+
+// VariableDefinition is one `identifier AS expression` of a DEFINE clause (the
+// variableDefinition rule): a row-pattern variable defined by a boolean
+// condition expression.
+type VariableDefinition struct {
+	Name      *ast.Identifier
+	Condition Expr
+	Loc       ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// Relation-level integration hook (D4 in relation.go's parseSampledRelation)
+// ---------------------------------------------------------------------------
+
+// parsePatternRecognitionSuffix is the patternRecognition rule applied to an
+// already-parsed aliasedRelation `input`. If the current token is MATCH_RECOGNIZE
+// it parses the full `MATCH_RECOGNIZE ( … ) (AS? identifier columnAliases?)?`
+// clause and returns a *PatternRecognition wrapping input; otherwise it returns
+// input unchanged (the rule's empty alternative). It is called by
+// parseSampledRelation between the aliasedRelation and the optional TABLESAMPLE
+// (M4), so MATCH_RECOGNIZE binds tighter than TABLESAMPLE.
+func (p *Parser) parsePatternRecognitionSuffix(input Relation) (Relation, error) {
+	if p.cur.Kind != kwMATCH_RECOGNIZE {
+		return input, nil
+	}
+	p.advance() // consume MATCH_RECOGNIZE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// The span starts at the wrapped relation (input), which already covers the
+	// table/subquery and its inner alias; the MATCH_RECOGNIZE keyword always
+	// follows it, so input.Span().Start is the node start.
+	pr := &PatternRecognition{
+		Input: input,
+		Loc:   ast.Loc{Start: input.Span().Start},
+	}
+	if err := p.parseMatchRecognizeBody(pr); err != nil {
+		return nil, err
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	pr.Loc.End = closeTok.Loc.End
+
+	// Optional trailing `AS? identifier columnAliases?` (M3).
+	if alias, cols, end, ok, err := p.parseTrailingMatchRecognizeAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		pr.Alias = alias
+		pr.ColumnAliases = cols
+		pr.Loc.End = end
+	}
+	return pr, nil
+}
+
+// parseTrailingMatchRecognizeAlias parses the optional `AS? identifier
+// columnAliases?` alias that may follow a `MATCH_RECOGNIZE ( … )` clause. It
+// mostly delegates to the shared relation alias helper (tryParseRelationAlias),
+// but first handles the one case that helper deliberately rejects: a no-AS alias
+// literally named MATCH_RECOGNIZE followed by '('. In the aliasedRelation
+// position tryParseRelationAlias's atRelationClauseStart guard reads
+// `MATCH_RECOGNIZE (` as the start of the MATCH_RECOGNIZE clause (so it is NOT
+// swallowed as an alias); but here the clause has already been parsed and a
+// second one cannot follow, so `… ) MATCH_RECOGNIZE (x)` is a valid bare alias
+// "match_recognize" with a column list — oracle-confirmed (it parses exactly as
+// `… ) AS MATCH_RECOGNIZE (x)`). This helper consumes that form directly; every
+// other alias (including a bare MATCH_RECOGNIZE not followed by '(') goes through
+// the shared helper unchanged.
+func (p *Parser) parseTrailingMatchRecognizeAlias() (alias *ast.Identifier, cols []*ast.Identifier, end int, ok bool, err error) {
+	if p.cur.Kind == kwMATCH_RECOGNIZE && p.peekNext().Kind == int('(') {
+		alias = identFromToken(p.advance()) // consume MATCH_RECOGNIZE as the alias
+		end = alias.Loc.End
+		c, e, cerr := p.parseColumnAliases()
+		if cerr != nil {
+			return nil, nil, 0, false, cerr
+		}
+		return alias, c, e, true, nil
+	}
+	return p.tryParseRelationAlias()
+}
+
+// parseMatchRecognizeBody parses the body of a relation `MATCH_RECOGNIZE ( … )`
+// between the opening '(' (already consumed) and the closing ')' (parsed by the
+// caller). The clauses appear in a fixed grammar order (M2); PATTERN and DEFINE
+// are mandatory (M1). It fills the body fields of pr.
+func (p *Parser) parseMatchRecognizeBody(pr *PatternRecognition) error {
+	// PARTITION BY expression (, expression)*
+	if p.cur.Kind == kwPARTITION {
+		exprs, err := p.parsePartitionByExprs()
+		if err != nil {
+			return err
+		}
+		pr.PartitionBy = exprs
+	}
+
+	// ORDER BY sortItem (, sortItem)*
+	if p.cur.Kind == kwORDER {
+		items, err := p.parseOrderByItems()
+		if err != nil {
+			return err
+		}
+		pr.OrderBy = items
+	}
+
+	// MEASURES measureDefinition (, measureDefinition)*
+	if p.cur.Kind == kwMEASURES {
+		measures, err := p.parseMeasures()
+		if err != nil {
+			return err
+		}
+		pr.Measures = measures
+	}
+
+	// rowsPerMatch (ONE ROW / ALL ROWS PER MATCH …)
+	if p.cur.Kind == kwONE || p.cur.Kind == kwALL {
+		rpm, err := p.parseRowsPerMatch()
+		if err != nil {
+			return err
+		}
+		pr.RowsPerMatch = rpm
+	}
+
+	// AFTER MATCH skipTo
+	if p.cur.Kind == kwAFTER {
+		skip, err := p.parseAfterMatchSkip()
+		if err != nil {
+			return err
+		}
+		pr.AfterMatchSkip = skip
+	}
+
+	// INITIAL | SEEK
+	if mode, ok := p.match(kwINITIAL, kwSEEK); ok {
+		pr.SearchMode = mode.Str
+	}
+
+	// PATTERN ( rowPattern ) — mandatory (M1)
+	pattern, err := p.parsePatternClause()
+	if err != nil {
+		return err
+	}
+	pr.Pattern = pattern
+
+	// SUBSET subsetDefinition (, subsetDefinition)*
+	if p.cur.Kind == kwSUBSET {
+		subsets, err := p.parseSubsets()
+		if err != nil {
+			return err
+		}
+		pr.Subsets = subsets
+	}
+
+	// DEFINE variableDefinition (, variableDefinition)* — mandatory (M1)
+	defs, err := p.parseDefine()
+	if err != nil {
+		return err
+	}
+	pr.Definitions = defs
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Window-frame integration hook (B2 in function.go's parseWindowFrame)
+// ---------------------------------------------------------------------------
+
+// MatchRecognizeFrame holds the row-pattern additions a windowFrame may carry
+// AROUND its frameExtent (the windowFrame rule's MEASURES / AFTER MATCH /
+// INITIAL|SEEK / PATTERN / SUBSET / DEFINE parts). Unlike the relation
+// MATCH_RECOGNIZE (M1), every part here is optional: a frame may carry MEASURES
+// with no PATTERN, or a PATTERN with no DEFINE (M6). Empty slices / nil pointers
+// / "" mark absent parts. It hangs off WindowFrame (function.go) via an optional
+// pointer set by parseWindowFramePattern.
+type MatchRecognizeFrame struct {
+	Measures       []MeasureDefinition
+	AfterMatchSkip *SkipTo
+	SearchMode     string     // "", "INITIAL", or "SEEK"
+	Pattern        RowPattern // nil when no PATTERN clause
+	Subsets        []SubsetDefinition
+	Definitions    []VariableDefinition
+}
+
+// atMeasuresClause reports whether a leading MEASURES in a windowSpecification
+// begins a pattern-recognition MEASURES clause rather than naming an existing
+// window. MEASURES is a non-reserved keyword, so `OVER (measures ORDER BY …)`
+// (a window named "measures") and `OVER (MEASURES x AS m …)` (the clause) both
+// start with MEASURES — and the two cannot be told apart by the next token
+// alone: `OVER (MEASURES ROWS CURRENT ROW)` (window named MEASURES + a ROWS
+// frame) and `OVER (MEASURES rows AS m ROWS CURRENT ROW)` (the clause whose
+// first measure is the column `rows`) both have a frame-type keyword after
+// MEASURES. Oracle-confirmed: Trino accepts both.
+//
+// The disambiguation therefore mirrors Trino — try to parse a measure
+// definition. MEASURES leads the CLAUSE iff, after consuming MEASURES, a single
+// `expression` parses and is immediately followed by AS (the `expression AS
+// identifier` shape of a measureDefinition). Otherwise MEASURES is an existing
+// window name. The probe is fully speculative (a checkpoint is restored before
+// returning), so the real parse happens later unaffected; a parse error during
+// the probe simply means "not a measure clause". Used by the expressions node's
+// parseWindowSpecification to keep MEASURES out of the existing-name slot (B2).
+func (p *Parser) atMeasuresClause() bool {
+	if p.cur.Kind != kwMEASURES {
+		return false
+	}
+	cp := p.checkpoint()
+	defer p.restore(cp)
+	p.advance() // consume MEASURES
+	if _, err := p.parseExpr(); err != nil {
+		return false
+	}
+	return p.cur.Kind == kwAS
+}
+
+// parseLeadingFrameMeasures parses the windowFrame's leading
+// `MEASURES measureDefinition (, …)*`, which precedes the frameExtent. It
+// returns (nil, false, nil) when the current token is not MEASURES. The
+// expressions node's parseWindowSpecification calls this before the frameExtent
+// so the frame parser is entered even when MEASURES leads (B2 / M6).
+func (p *Parser) parseLeadingFrameMeasures() ([]MeasureDefinition, bool, error) {
+	if p.cur.Kind != kwMEASURES {
+		return nil, false, nil
+	}
+	measures, err := p.parseMeasures()
+	if err != nil {
+		return nil, false, err
+	}
+	return measures, true, nil
+}
+
+// parseTrailingFramePattern parses the windowFrame's row-pattern additions that
+// FOLLOW the frameExtent: `(AFTER MATCH skipTo)? (INITIAL|SEEK)?
+// (PATTERN ( rowPattern ))? (SUBSET …)? (DEFINE …)?`. leadingMeasures carries the
+// MEASURES already parsed before the frameExtent (M6). It returns (nil, nil) when
+// none of these clauses are present and there were no leading measures — i.e. the
+// frame is an ordinary window frame with no pattern recognition. The expressions
+// node's parseWindowFrame calls this after the frameExtent (B2).
+func (p *Parser) parseTrailingFramePattern(leadingMeasures []MeasureDefinition) (*MatchRecognizeFrame, error) {
+	mrf := &MatchRecognizeFrame{Measures: leadingMeasures}
+	saw := len(leadingMeasures) > 0
+
+	if p.cur.Kind == kwAFTER {
+		skip, err := p.parseAfterMatchSkip()
+		if err != nil {
+			return nil, err
+		}
+		mrf.AfterMatchSkip = skip
+		saw = true
+	}
+	if mode, ok := p.match(kwINITIAL, kwSEEK); ok {
+		mrf.SearchMode = mode.Str
+		saw = true
+	}
+	if p.cur.Kind == kwPATTERN {
+		pattern, err := p.parsePatternClause()
+		if err != nil {
+			return nil, err
+		}
+		mrf.Pattern = pattern
+		saw = true
+	}
+	if p.cur.Kind == kwSUBSET {
+		subsets, err := p.parseSubsets()
+		if err != nil {
+			return nil, err
+		}
+		mrf.Subsets = subsets
+		saw = true
+	}
+	if p.cur.Kind == kwDEFINE {
+		defs, err := p.parseDefine()
+		if err != nil {
+			return nil, err
+		}
+		mrf.Definitions = defs
+		saw = true
+	}
+	if !saw {
+		return nil, nil
+	}
+	return mrf, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared clause parsers (used by both the relation and window-frame forms)
+// ---------------------------------------------------------------------------
+
+// parsePartitionByExprs parses `PARTITION BY expression (, expression)*`
+// (PARTITION is current) and returns the non-empty expression list.
+func (p *Parser) parsePartitionByExprs() ([]Expr, error) {
+	p.advance() // consume PARTITION
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	first, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	exprs := []Expr{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, next)
+	}
+	return exprs, nil
+}
+
+// parseMeasures parses `MEASURES measureDefinition (, measureDefinition)*`
+// (MEASURES is current); each measureDefinition is `expression AS identifier`.
+func (p *Parser) parseMeasures() ([]MeasureDefinition, error) {
+	p.advance() // consume MEASURES
+	first, err := p.parseMeasureDefinition()
+	if err != nil {
+		return nil, err
+	}
+	measures := []MeasureDefinition{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseMeasureDefinition()
+		if err != nil {
+			return nil, err
+		}
+		measures = append(measures, next)
+	}
+	return measures, nil
+}
+
+// parseMeasureDefinition parses one `expression AS identifier` (the
+// measureDefinition rule). The AS and the name are both mandatory.
+func (p *Parser) parseMeasureDefinition() (MeasureDefinition, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return MeasureDefinition{}, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return MeasureDefinition{}, err
+	}
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return MeasureDefinition{}, err
+	}
+	return MeasureDefinition{
+		Expr: expr,
+		Name: name,
+		Loc:  ast.Loc{Start: expr.Span().Start, End: name.Loc.End},
+	}, nil
+}
+
+// parseRowsPerMatch parses `ONE ROW PER MATCH` or `ALL ROWS PER MATCH
+// emptyMatchHandling?` (the leading ONE or ALL is current).
+func (p *Parser) parseRowsPerMatch() (*RowsPerMatch, error) {
+	lead := p.advance() // consume ONE or ALL
+	rpm := &RowsPerMatch{Loc: ast.Loc{Start: lead.Loc.Start}}
+
+	if lead.Kind == kwONE {
+		// ONE ROW PER MATCH
+		if _, err := p.expect(kwROW); err != nil {
+			return nil, err
+		}
+		rpm.Kind = OneRowPerMatch
+	} else {
+		// ALL ROWS PER MATCH
+		if _, err := p.expect(kwROWS); err != nil {
+			return nil, err
+		}
+		rpm.Kind = AllRowsPerMatch
+	}
+	if _, err := p.expect(kwPER); err != nil {
+		return nil, err
+	}
+	matchTok, err := p.expect(kwMATCH)
+	if err != nil {
+		return nil, err
+	}
+	rpm.Loc.End = matchTok.Loc.End
+
+	// ALL ROWS PER MATCH takes an optional emptyMatchHandling.
+	if rpm.Kind == AllRowsPerMatch {
+		handling, end, ok, err := p.tryParseEmptyMatchHandling()
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			rpm.EmptyHandling = handling
+			rpm.Loc.End = end
+		}
+	}
+	return rpm, nil
+}
+
+// tryParseEmptyMatchHandling parses the optional `emptyMatchHandling` of an
+// ALL ROWS PER MATCH clause: `SHOW EMPTY MATCHES` | `OMIT EMPTY MATCHES` |
+// `WITH UNMATCHED ROWS`. It returns ok=false when none of these leads. SHOW /
+// OMIT / WITH are the only valid lead-ins here; SHOW and WITH are non-reserved
+// but in this position can only begin the handling clause (a following PATTERN /
+// MEASURES would have ended the clause already).
+func (p *Parser) tryParseEmptyMatchHandling() (handling string, end int, ok bool, err error) {
+	switch p.cur.Kind {
+	case kwSHOW:
+		p.advance() // consume SHOW
+		if _, err := p.expect(kwEMPTY); err != nil {
+			return "", 0, false, err
+		}
+		t, err := p.expect(kwMATCHES)
+		if err != nil {
+			return "", 0, false, err
+		}
+		return "SHOW EMPTY MATCHES", t.Loc.End, true, nil
+	case kwOMIT:
+		p.advance() // consume OMIT
+		if _, err := p.expect(kwEMPTY); err != nil {
+			return "", 0, false, err
+		}
+		t, err := p.expect(kwMATCHES)
+		if err != nil {
+			return "", 0, false, err
+		}
+		return "OMIT EMPTY MATCHES", t.Loc.End, true, nil
+	case kwWITH:
+		p.advance() // consume WITH
+		if _, err := p.expect(kwUNMATCHED); err != nil {
+			return "", 0, false, err
+		}
+		t, err := p.expect(kwROWS)
+		if err != nil {
+			return "", 0, false, err
+		}
+		return "WITH UNMATCHED ROWS", t.Loc.End, true, nil
+	default:
+		return "", 0, false, nil
+	}
+}
+
+// parseAfterMatchSkip parses `AFTER MATCH skipTo` (AFTER is current). skipTo is
+// `SKIP (TO (NEXT ROW | (FIRST|LAST)? identifier) | PAST LAST ROW)`.
+func (p *Parser) parseAfterMatchSkip() (*SkipTo, error) {
+	afterTok := p.advance() // consume AFTER
+	if _, err := p.expect(kwMATCH); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwSKIP); err != nil {
+		return nil, err
+	}
+	skip := &SkipTo{Loc: ast.Loc{Start: afterTok.Loc.Start}}
+
+	switch p.cur.Kind {
+	case kwPAST:
+		// PAST LAST ROW
+		p.advance() // consume PAST
+		if _, err := p.expect(kwLAST); err != nil {
+			return nil, err
+		}
+		rowTok, err := p.expect(kwROW)
+		if err != nil {
+			return nil, err
+		}
+		skip.Kind = SkipPastLastRow
+		skip.Loc.End = rowTok.Loc.End
+		return skip, nil
+	case kwTO:
+		p.advance() // consume TO
+		return p.parseSkipToTarget(skip)
+	default:
+		return nil, p.exprErrorAt("expected TO or PAST after AFTER MATCH SKIP")
+	}
+}
+
+// parseSkipToTarget parses the part of skipTo after `SKIP TO`: `NEXT ROW |
+// (FIRST|LAST)? identifier`. skip already has its start offset; TO is consumed.
+//
+// NEXT, FIRST, and LAST are all NON-RESERVED keywords, so each may itself be a
+// pattern-variable name (oracle-confirmed: `SKIP TO NEXT`, `SKIP TO FIRST`,
+// `SKIP TO LAST`, `SKIP TO FIRST PATTERN (A)` all parse with NEXT / FIRST / LAST
+// as the variable). The disambiguation mirrors Trino's adaptive prediction:
+//
+//   - NEXT is the `NEXT ROW` form ONLY when immediately followed by ROW;
+//     otherwise NEXT is an ordinary variable identifier.
+//   - FIRST / LAST is the `(FIRST|LAST) identifier` keyword ONLY when an
+//     identifier follows it AND that identifier is in turn followed by a token
+//     that legitimately ends the skipTo — INITIAL, SEEK, or PATTERN (the only
+//     clauses that may follow `AFTER MATCH skipTo`). This is the discriminator
+//     because PATTERN is mandatory and always trails the skipTo. It is checked
+//     with a speculative checkpoint (peek beyond two tokens): e.g.
+//     `FIRST PATTERN (A)` has FIRST as the variable (the `(` after PATTERN is not
+//     a skipTo successor), whereas `FIRST zone PATTERN (A)` has FIRST as the
+//     keyword with variable zone. Otherwise FIRST / LAST is itself the variable.
+//
+// Anything else is a bare `TO identifier` variable target.
+func (p *Parser) parseSkipToTarget(skip *SkipTo) (*SkipTo, error) {
+	if p.cur.Kind == kwNEXT && p.peekNext().Kind == kwROW {
+		// TO NEXT ROW
+		p.advance()           // consume NEXT
+		rowTok := p.advance() // consume ROW
+		skip.Kind = SkipToNextRow
+		skip.Loc.End = rowTok.Loc.End
+		return skip, nil
+	}
+
+	if p.cur.Kind == kwFIRST || p.cur.Kind == kwLAST {
+		if kind, name, ok := p.tryParseSkipFirstLastKeyword(); ok {
+			skip.Kind = kind
+			skip.Variable = name
+			skip.Loc.End = name.Loc.End
+			return skip, nil
+		}
+	}
+
+	// TO identifier (no FIRST/LAST keyword, or NEXT/FIRST/LAST used as the
+	// variable name itself).
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	skip.Kind = SkipToVariable
+	skip.Variable = name
+	skip.Loc.End = name.Loc.End
+	return skip, nil
+}
+
+// tryParseSkipFirstLastKeyword speculatively parses the `(FIRST|LAST) identifier`
+// keyword form of a skipTo target. It returns the SkipToFirst/SkipToLast kind,
+// the variable identifier, and ok=true only when the leading FIRST/LAST is
+// genuinely the keyword — i.e. an identifier follows it AND that identifier is
+// itself followed by a skipTo successor (INITIAL / SEEK / PATTERN), which is how
+// Trino disambiguates FIRST/LAST as a keyword from FIRST/LAST used as the variable
+// name. On a non-match it restores the parser and returns ok=false (the caller
+// then reads FIRST/LAST as the variable).
+func (p *Parser) tryParseSkipFirstLastKeyword() (SkipToKind, *ast.Identifier, bool) {
+	cp := p.checkpoint()
+	kind := SkipToFirst
+	if p.cur.Kind == kwLAST {
+		kind = SkipToLast
+	}
+	p.advance() // consume FIRST / LAST
+	if !isIdentifierStart(p.cur.Kind) {
+		p.restore(cp)
+		return 0, nil, false
+	}
+	name := identFromToken(p.advance())
+	if !isSkipToSuccessor(p.cur.Kind) {
+		p.restore(cp)
+		return 0, nil, false
+	}
+	return kind, name, true
+}
+
+// isSkipToSuccessor reports whether kind is a token that may immediately follow a
+// MATCH_RECOGNIZE skipTo target. This is the complete set across both contexts:
+//
+//   - relation MATCH_RECOGNIZE: only `(INITIAL|SEEK)? PATTERN` may follow, so
+//     INITIAL / SEEK / PATTERN.
+//   - windowFrame: the skipTo is followed by the OPTIONAL `(INITIAL|SEEK)?
+//     (PATTERN …)? (SUBSET …)? (DEFINE …)?`, any of which may be absent — so the
+//     successor may also be SUBSET, DEFINE, or the frame-closing ')'.
+//
+// Using the union is safe: a FIRST/LAST mis-promoted to the keyword form in a
+// context where the trailing clause is then illegal (e.g. `SKIP TO FIRST A
+// SUBSET …` in a relation MATCH_RECOGNIZE, where PATTERN is mandatory before
+// SUBSET) still produces the same overall reject as Trino, because the body
+// parser rejects the missing PATTERN. It is used to decide whether a FIRST/LAST
+// is the skipTo keyword (followed by `variable <successor>`) or the variable.
+func isSkipToSuccessor(kind TokenKind) bool {
+	switch kind {
+	case kwINITIAL, kwSEEK, kwPATTERN, kwSUBSET, kwDEFINE, int(')'):
+		return true
+	default:
+		return false
+	}
+}
+
+// parsePatternClause parses `PATTERN ( rowPattern )` (PATTERN is current). The
+// body parens are mandatory (M1); the inner rowPattern is parsed by
+// row_pattern.go.
+func (p *Parser) parsePatternClause() (RowPattern, error) {
+	if _, err := p.expect(kwPATTERN); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	pattern, err := p.parseRowPattern()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return pattern, nil
+}
+
+// parseSubsets parses `SUBSET subsetDefinition (, subsetDefinition)*` (SUBSET is
+// current); each subsetDefinition is `identifier = ( identifier (, identifier)* )`.
+func (p *Parser) parseSubsets() ([]SubsetDefinition, error) {
+	p.advance() // consume SUBSET
+	first, err := p.parseSubsetDefinition()
+	if err != nil {
+		return nil, err
+	}
+	subsets := []SubsetDefinition{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseSubsetDefinition()
+		if err != nil {
+			return nil, err
+		}
+		subsets = append(subsets, next)
+	}
+	return subsets, nil
+}
+
+// parseSubsetDefinition parses one `identifier = ( identifier (, identifier)* )`
+// (the subsetDefinition rule): a union variable and its non-empty member list.
+func (p *Parser) parseSubsetDefinition() (SubsetDefinition, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return SubsetDefinition{}, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return SubsetDefinition{}, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return SubsetDefinition{}, err
+	}
+	firstOf, err := p.parseIdentifier()
+	if err != nil {
+		return SubsetDefinition{}, err
+	}
+	of := []*ast.Identifier{firstOf}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		nextOf, err := p.parseIdentifier()
+		if err != nil {
+			return SubsetDefinition{}, err
+		}
+		of = append(of, nextOf)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return SubsetDefinition{}, err
+	}
+	return SubsetDefinition{
+		Name: name,
+		Of:   of,
+		Loc:  ast.Loc{Start: name.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseDefine parses `DEFINE variableDefinition (, variableDefinition)*` (DEFINE
+// is current); each variableDefinition is `identifier AS expression`. At least
+// one definition is required (the rule has no `?`).
+func (p *Parser) parseDefine() ([]VariableDefinition, error) {
+	if _, err := p.expect(kwDEFINE); err != nil {
+		return nil, err
+	}
+	first, err := p.parseVariableDefinition()
+	if err != nil {
+		return nil, err
+	}
+	defs := []VariableDefinition{first}
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		next, err := p.parseVariableDefinition()
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, next)
+	}
+	return defs, nil
+}
+
+// parseVariableDefinition parses one `identifier AS expression` (the
+// variableDefinition rule): a pattern variable and its boolean condition.
+func (p *Parser) parseVariableDefinition() (VariableDefinition, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return VariableDefinition{}, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return VariableDefinition{}, err
+	}
+	cond, err := p.parseExpr()
+	if err != nil {
+		return VariableDefinition{}, err
+	}
+	return VariableDefinition{
+		Name:      name,
+		Condition: cond,
+		Loc:       ast.Loc{Start: name.Loc.Start, End: cond.Span().End},
+	}, nil
+}

--- a/trino/parser/match_recognize_test.go
+++ b/trino/parser/match_recognize_test.go
@@ -1,0 +1,472 @@
+package parser
+
+import (
+	"strconv"
+	"testing"
+)
+
+// This file is the parser-match-recognize node's structural slice: the oracle
+// differential (oracle_match_recognize_test.go) pins accept/reject, while these
+// tests pin the AST shapes accept/reject cannot see — row-pattern precedence and
+// associativity (R1), the at-most-one-quantifier model (R2), the quantifier
+// bounds, the double-alias split (M3), and the window-frame pattern attachment
+// (M6). Helpers parseOneQuery / querySpec live in select_test.go.
+
+// patternRecognitionFrom parses a single `SELECT * FROM <fromText>` and returns
+// the sole FROM relation as a *PatternRecognition, failing if the shape differs.
+func patternRecognitionFrom(t *testing.T, fromText string) *PatternRecognition {
+	t.Helper()
+	spec := querySpec(t, parseOneQuery(t, "SELECT * FROM "+fromText))
+	if len(spec.From) != 1 {
+		t.Fatalf("want 1 FROM relation, got %d", len(spec.From))
+	}
+	pr, ok := spec.From[0].(*PatternRecognition)
+	if !ok {
+		t.Fatalf("FROM relation is %T, want *PatternRecognition", spec.From[0])
+	}
+	return pr
+}
+
+// rowPatternOf parses a `MATCH_RECOGNIZE (PATTERN ( <patternText> ) DEFINE A AS
+// true)` and returns the parsed PATTERN tree.
+func rowPatternOf(t *testing.T, patternText string) RowPattern {
+	t.Helper()
+	pr := patternRecognitionFrom(t, "t MATCH_RECOGNIZE (PATTERN ("+patternText+") DEFINE A AS true)")
+	if pr.Pattern == nil {
+		t.Fatal("PATTERN tree is nil")
+	}
+	return pr.Pattern
+}
+
+func TestMatchRecognize_StructureMandatoryFields(t *testing.T) {
+	pr := patternRecognitionFrom(t, "t MATCH_RECOGNIZE (PATTERN (A B) DEFINE A AS true, B AS false)")
+	// Pattern must be present, Definitions must list both A and B.
+	if pr.Pattern == nil {
+		t.Fatal("Pattern is nil")
+	}
+	if len(pr.Definitions) != 2 {
+		t.Fatalf("want 2 DEFINE entries, got %d", len(pr.Definitions))
+	}
+	if pr.Definitions[0].Name.Value != "A" || pr.Definitions[1].Name.Value != "B" {
+		t.Errorf("DEFINE names = %q,%q, want A,B", pr.Definitions[0].Name.Value, pr.Definitions[1].Name.Value)
+	}
+	// The wrapped input relation is the table t.
+	ar, ok := pr.Input.(*AliasedRelation)
+	if !ok {
+		t.Fatalf("Input is %T, want *AliasedRelation", pr.Input)
+	}
+	if _, ok := ar.Inner.(*TableRelation); !ok {
+		t.Errorf("Input.Inner is %T, want *TableRelation", ar.Inner)
+	}
+}
+
+func TestMatchRecognize_StructureFullClauses(t *testing.T) {
+	pr := patternRecognitionFrom(t, "t MATCH_RECOGNIZE ("+
+		"PARTITION BY a, b ORDER BY c MEASURES x AS m, y AS n "+
+		"ALL ROWS PER MATCH WITH UNMATCHED ROWS "+
+		"AFTER MATCH SKIP TO FIRST B INITIAL "+
+		"PATTERN (A B) SUBSET U = (A, B) DEFINE A AS true, B AS false)")
+
+	if len(pr.PartitionBy) != 2 {
+		t.Errorf("PARTITION BY count = %d, want 2", len(pr.PartitionBy))
+	}
+	if len(pr.OrderBy) != 1 {
+		t.Errorf("ORDER BY count = %d, want 1", len(pr.OrderBy))
+	}
+	if len(pr.Measures) != 2 || pr.Measures[0].Name.Value != "m" || pr.Measures[1].Name.Value != "n" {
+		t.Errorf("MEASURES = %+v, want m,n", pr.Measures)
+	}
+	if pr.RowsPerMatch == nil || pr.RowsPerMatch.Kind != AllRowsPerMatch ||
+		pr.RowsPerMatch.EmptyHandling != "WITH UNMATCHED ROWS" {
+		t.Errorf("RowsPerMatch = %+v, want ALL ROWS / WITH UNMATCHED ROWS", pr.RowsPerMatch)
+	}
+	if pr.AfterMatchSkip == nil || pr.AfterMatchSkip.Kind != SkipToFirst ||
+		pr.AfterMatchSkip.Variable == nil || pr.AfterMatchSkip.Variable.Value != "B" {
+		t.Errorf("AfterMatchSkip = %+v, want SKIP TO FIRST B", pr.AfterMatchSkip)
+	}
+	if pr.SearchMode != "INITIAL" {
+		t.Errorf("SearchMode = %q, want INITIAL", pr.SearchMode)
+	}
+	if len(pr.Subsets) != 1 || pr.Subsets[0].Name.Value != "U" || len(pr.Subsets[0].Of) != 2 {
+		t.Errorf("Subsets = %+v, want U = (A, B)", pr.Subsets)
+	}
+}
+
+func TestMatchRecognize_StructureRowsPerMatchVariants(t *testing.T) {
+	cases := []struct {
+		text     string
+		wantKind RowsPerMatchKind
+		wantEmpt string
+	}{
+		{"ONE ROW PER MATCH", OneRowPerMatch, ""},
+		{"ALL ROWS PER MATCH", AllRowsPerMatch, ""},
+		{"ALL ROWS PER MATCH SHOW EMPTY MATCHES", AllRowsPerMatch, "SHOW EMPTY MATCHES"},
+		{"ALL ROWS PER MATCH OMIT EMPTY MATCHES", AllRowsPerMatch, "OMIT EMPTY MATCHES"},
+		{"ALL ROWS PER MATCH WITH UNMATCHED ROWS", AllRowsPerMatch, "WITH UNMATCHED ROWS"},
+	}
+	for _, c := range cases {
+		t.Run(c.text, func(t *testing.T) {
+			pr := patternRecognitionFrom(t, "t MATCH_RECOGNIZE ("+c.text+" PATTERN (A) DEFINE A AS true)")
+			if pr.RowsPerMatch == nil {
+				t.Fatal("RowsPerMatch is nil")
+			}
+			if pr.RowsPerMatch.Kind != c.wantKind || pr.RowsPerMatch.EmptyHandling != c.wantEmpt {
+				t.Errorf("got kind=%v empty=%q, want kind=%v empty=%q",
+					pr.RowsPerMatch.Kind, pr.RowsPerMatch.EmptyHandling, c.wantKind, c.wantEmpt)
+			}
+		})
+	}
+}
+
+func TestMatchRecognize_StructureSkipToVariants(t *testing.T) {
+	cases := []struct {
+		text     string
+		wantKind SkipToKind
+		wantVar  string
+	}{
+		{"AFTER MATCH SKIP PAST LAST ROW", SkipPastLastRow, ""},
+		{"AFTER MATCH SKIP TO NEXT ROW", SkipToNextRow, ""},
+		{"AFTER MATCH SKIP TO FIRST A", SkipToFirst, "A"},
+		{"AFTER MATCH SKIP TO LAST A", SkipToLast, "A"},
+		{"AFTER MATCH SKIP TO A", SkipToVariable, "A"},
+		// non-reserved NEXT/FIRST/LAST used as the variable name itself (the special
+		// form does not apply because the disambiguating token does not follow).
+		{"AFTER MATCH SKIP TO NEXT", SkipToVariable, "NEXT"},   // NEXT not followed by ROW
+		{"AFTER MATCH SKIP TO FIRST", SkipToVariable, "FIRST"}, // FIRST not followed by ident+successor
+		{"AFTER MATCH SKIP TO LAST", SkipToVariable, "LAST"},   // LAST not followed by ident+successor
+	}
+	for _, c := range cases {
+		t.Run(c.text, func(t *testing.T) {
+			pr := patternRecognitionFrom(t, "t MATCH_RECOGNIZE ("+c.text+" PATTERN (A) DEFINE A AS true)")
+			if pr.AfterMatchSkip == nil {
+				t.Fatal("AfterMatchSkip is nil")
+			}
+			if pr.AfterMatchSkip.Kind != c.wantKind {
+				t.Errorf("kind = %v, want %v", pr.AfterMatchSkip.Kind, c.wantKind)
+			}
+			gotVar := ""
+			if pr.AfterMatchSkip.Variable != nil {
+				gotVar = pr.AfterMatchSkip.Variable.Value
+			}
+			if gotVar != c.wantVar {
+				t.Errorf("var = %q, want %q", gotVar, c.wantVar)
+			}
+		})
+	}
+}
+
+func TestMatchRecognize_StructureDoubleAlias(t *testing.T) {
+	// `t AS r MATCH_RECOGNIZE (…) AS m`: the inner alias r is on the wrapped
+	// relation; the trailing alias m is on the PatternRecognition node (M3).
+	pr := patternRecognitionFrom(t, "t AS r MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) AS m (x, y)")
+	if pr.Alias == nil || pr.Alias.Value != "m" {
+		t.Errorf("trailing alias = %v, want m", pr.Alias)
+	}
+	if len(pr.ColumnAliases) != 2 || pr.ColumnAliases[0].Value != "x" || pr.ColumnAliases[1].Value != "y" {
+		t.Errorf("trailing column aliases = %+v, want x,y", pr.ColumnAliases)
+	}
+	ar, ok := pr.Input.(*AliasedRelation)
+	if !ok {
+		t.Fatalf("Input is %T, want *AliasedRelation", pr.Input)
+	}
+	if ar.Alias == nil || ar.Alias.Value != "r" {
+		t.Errorf("inner alias = %v, want r", ar.Alias)
+	}
+}
+
+// TestMatchRecognize_TrailingAliasNamedMatchRecognize pins the edge where the
+// trailing alias is itself the non-reserved keyword MATCH_RECOGNIZE with a column
+// list (no second clause can follow the MATCH_RECOGNIZE clause, so it is an alias).
+func TestMatchRecognize_TrailingAliasNamedMatchRecognize(t *testing.T) {
+	pr := patternRecognitionFrom(t, "t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) MATCH_RECOGNIZE (x)")
+	if pr.Alias == nil || pr.Alias.Value != "MATCH_RECOGNIZE" {
+		t.Errorf("trailing alias = %v, want MATCH_RECOGNIZE", pr.Alias)
+	}
+	if len(pr.ColumnAliases) != 1 || pr.ColumnAliases[0].Value != "x" {
+		t.Errorf("trailing column aliases = %+v, want [x]", pr.ColumnAliases)
+	}
+}
+
+// TestMatchRecognize_WindowFrameSpan verifies the WindowFrame source span covers
+// the whole frame including any trailing row-pattern clauses, not just the
+// frameExtent (so downstream span consumers see the full range).
+func TestMatchRecognize_WindowFrameSpan(t *testing.T) {
+	const src = "SELECT count(*) OVER (ROWS CURRENT ROW PATTERN (A) DEFINE A AS true) FROM t"
+	spec := querySpec(t, parseOneQuery(t, src))
+	frame := spec.Items[0].Expr.(*FuncCall).Over.Frame
+	if frame == nil {
+		t.Fatal("frame is nil")
+	}
+	covered := src[frame.Loc.Start:frame.Loc.End]
+	if covered != "ROWS CURRENT ROW PATTERN (A) DEFINE A AS true" {
+		t.Errorf("frame span = %q, want it to cover through the DEFINE clause", covered)
+	}
+}
+
+// TestMatchRecognize_RowPatternConcatLeftAssoc verifies `A B C` nests
+// left-associatively: PatternConcat{PatternConcat{A,B}, C} (R1).
+func TestMatchRecognize_RowPatternConcatLeftAssoc(t *testing.T) {
+	root, ok := rowPatternOf(t, "A B C").(*PatternConcat)
+	if !ok {
+		t.Fatalf("root is %T, want *PatternConcat", rowPatternOf(t, "A B C"))
+	}
+	if patternVarName(t, root.Right) != "C" {
+		t.Errorf("root.Right = %v, want variable C", root.Right)
+	}
+	left, ok := root.Left.(*PatternConcat)
+	if !ok {
+		t.Fatalf("root.Left is %T, want *PatternConcat", root.Left)
+	}
+	if patternVarName(t, left.Left) != "A" || patternVarName(t, left.Right) != "B" {
+		t.Errorf("left = (%v, %v), want (A, B)", left.Left, left.Right)
+	}
+}
+
+// TestMatchRecognize_RowPatternAltBindsLooser verifies concatenation binds
+// tighter than `|`: `A B | C D` is PatternAlternation{(A B), (C D)} (R1).
+func TestMatchRecognize_RowPatternAltBindsLooser(t *testing.T) {
+	root, ok := rowPatternOf(t, "A B | C D").(*PatternAlternation)
+	if !ok {
+		t.Fatalf("root is %T, want *PatternAlternation", rowPatternOf(t, "A B | C D"))
+	}
+	if _, ok := root.Left.(*PatternConcat); !ok {
+		t.Errorf("root.Left is %T, want *PatternConcat (A B)", root.Left)
+	}
+	if _, ok := root.Right.(*PatternConcat); !ok {
+		t.Errorf("root.Right is %T, want *PatternConcat (C D)", root.Right)
+	}
+}
+
+// TestMatchRecognize_RowPatternAltLeftAssoc verifies `A | B | C` nests
+// left-associatively: PatternAlternation{PatternAlternation{A,B}, C} (R1).
+func TestMatchRecognize_RowPatternAltLeftAssoc(t *testing.T) {
+	root, ok := rowPatternOf(t, "A | B | C").(*PatternAlternation)
+	if !ok {
+		t.Fatalf("root is %T, want *PatternAlternation", rowPatternOf(t, "A | B | C"))
+	}
+	if patternVarName(t, root.Right) != "C" {
+		t.Errorf("root.Right = %v, want C", root.Right)
+	}
+	if _, ok := root.Left.(*PatternAlternation); !ok {
+		t.Errorf("root.Left is %T, want *PatternAlternation (A | B)", root.Left)
+	}
+}
+
+func TestMatchRecognize_RowPatternQuantifiers(t *testing.T) {
+	mk := func(v int64) *int64 { return &v }
+	cases := []struct {
+		text      string
+		wantKind  PatternQuantifierKind
+		reluctant bool
+		exactly   *int64
+		atLeast   *int64
+		atMost    *int64
+	}{
+		{"A*", QuantZeroOrMore, false, nil, nil, nil},
+		{"A+", QuantOneOrMore, false, nil, nil, nil},
+		{"A?", QuantZeroOrOne, false, nil, nil, nil},
+		{"A*?", QuantZeroOrMore, true, nil, nil, nil},
+		{"A+?", QuantOneOrMore, true, nil, nil, nil},
+		{"A??", QuantZeroOrOne, true, nil, nil, nil},
+		{"A{3}", QuantRange, false, mk(3), nil, nil},
+		{"A{1,3}", QuantRange, false, nil, mk(1), mk(3)},
+		{"A{,3}", QuantRange, false, nil, nil, mk(3)},
+		{"A{2,}", QuantRange, false, nil, mk(2), nil},
+		{"A{2,}?", QuantRange, true, nil, mk(2), nil},
+		{"A{,}", QuantRange, false, nil, nil, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.text, func(t *testing.T) {
+			qp, ok := rowPatternOf(t, c.text).(*QuantifiedPattern)
+			if !ok {
+				t.Fatalf("root is %T, want *QuantifiedPattern", rowPatternOf(t, c.text))
+			}
+			q := qp.Quantifier
+			if q == nil {
+				t.Fatal("Quantifier is nil")
+			}
+			if q.Kind != c.wantKind || q.Reluctant != c.reluctant {
+				t.Errorf("kind=%v reluctant=%v, want kind=%v reluctant=%v", q.Kind, q.Reluctant, c.wantKind, c.reluctant)
+			}
+			if !eqIntPtr(q.Exactly, c.exactly) || !eqIntPtr(q.AtLeast, c.atLeast) || !eqIntPtr(q.AtMost, c.atMost) {
+				t.Errorf("bounds exactly=%v atLeast=%v atMost=%v, want exactly=%v atLeast=%v atMost=%v",
+					derefStr(q.Exactly), derefStr(q.AtLeast), derefStr(q.AtMost),
+					derefStr(c.exactly), derefStr(c.atLeast), derefStr(c.atMost))
+			}
+		})
+	}
+}
+
+func TestMatchRecognize_RowPatternPrimaries(t *testing.T) {
+	// Empty pattern ().
+	if _, ok := rowPatternOf(t, "()").(*EmptyPattern); !ok {
+		t.Errorf("() is %T, want *EmptyPattern", rowPatternOf(t, "()"))
+	}
+	// Grouped pattern (A B).
+	if g, ok := rowPatternOf(t, "(A B)").(*GroupedPattern); !ok {
+		t.Errorf("(A B) is %T, want *GroupedPattern", rowPatternOf(t, "(A B)"))
+	} else if _, ok := g.Inner.(*PatternConcat); !ok {
+		t.Errorf("grouped inner is %T, want *PatternConcat", g.Inner)
+	}
+	// Start / end anchors.
+	if a, ok := rowPatternOf(t, "^").(*AnchorPattern); !ok || !a.Start {
+		t.Errorf("^ is %T (start=%v), want *AnchorPattern start=true", rowPatternOf(t, "^"), ok && a.Start)
+	}
+	if a, ok := rowPatternOf(t, "$").(*AnchorPattern); !ok || a.Start {
+		t.Errorf("$ is %T, want *AnchorPattern start=false", rowPatternOf(t, "$"))
+	}
+	// Excluded pattern {- A -}.
+	if e, ok := rowPatternOf(t, "{- A -}").(*ExcludedPattern); !ok {
+		t.Errorf("{- A -} is %T, want *ExcludedPattern", rowPatternOf(t, "{- A -}"))
+	} else if patternVarName(t, e.Inner) != "A" {
+		t.Errorf("excluded inner = %v, want A", e.Inner)
+	}
+	// PERMUTE(A, B).
+	if perm, ok := rowPatternOf(t, "PERMUTE(A, B)").(*PatternPermutation); !ok {
+		t.Errorf("PERMUTE(A, B) is %T, want *PatternPermutation", rowPatternOf(t, "PERMUTE(A, B)"))
+	} else if len(perm.Patterns) != 2 {
+		t.Errorf("PERMUTE operand count = %d, want 2", len(perm.Patterns))
+	}
+	// Empty PERMUTE() — accepted (divergence #92), zero operands.
+	if perm, ok := rowPatternOf(t, "PERMUTE()").(*PatternPermutation); !ok {
+		t.Errorf("PERMUTE() is %T, want *PatternPermutation", rowPatternOf(t, "PERMUTE()"))
+	} else if len(perm.Patterns) != 0 {
+		t.Errorf("PERMUTE() operand count = %d, want 0", len(perm.Patterns))
+	}
+	// PERMUTE is non-reserved: a bare `permute` (no '(') is a pattern variable.
+	if pv, ok := rowPatternOf(t, "permute").(*PatternVariable); !ok || pv.Name.Value != "permute" {
+		t.Errorf("bare permute is %T, want *PatternVariable(permute)", rowPatternOf(t, "permute"))
+	}
+}
+
+// TestMatchRecognize_WindowMeasuresVsName pins the MEASURES-clause vs
+// existing-window-name disambiguation in an OVER frame (the >1-token lookahead
+// case Codex flagged): MEASURES followed by `expr AS id` is the clause; MEASURES
+// followed by a window-spec part (here a ROWS frame) is the window name.
+func TestMatchRecognize_WindowMeasuresVsName(t *testing.T) {
+	// MEASURES clause whose first measure column is the non-reserved keyword "rows".
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT count(*) OVER (MEASURES rows AS m ROWS CURRENT ROW PATTERN (A) DEFINE A AS true) FROM t"))
+	fc := spec.Items[0].Expr.(*FuncCall)
+	if fc.Over == nil || fc.Over.ExistingName != nil {
+		t.Errorf("MEASURES clause: ExistingName = %v, want nil", fc.Over.ExistingName)
+	}
+	if fc.Over.Frame == nil || fc.Over.Frame.Pattern == nil || len(fc.Over.Frame.Pattern.Measures) != 1 {
+		t.Fatalf("MEASURES clause: frame.Pattern.Measures wrong: %+v", fc.Over.Frame)
+	}
+	if fc.Over.Frame.Pattern.Measures[0].Name.Value != "m" {
+		t.Errorf("measure name = %v, want m", fc.Over.Frame.Pattern.Measures[0].Name.Value)
+	}
+
+	// A window literally named "MEASURES" + a ROWS frame: MEASURES is the existing
+	// window name, the frame is ordinary (no pattern additions).
+	spec2 := querySpec(t, parseOneQuery(t,
+		"SELECT count(*) OVER (MEASURES ROWS CURRENT ROW) FROM t WINDOW MEASURES AS (PARTITION BY a)"))
+	fc2 := spec2.Items[0].Expr.(*FuncCall)
+	if fc2.Over == nil || fc2.Over.ExistingName == nil || fc2.Over.ExistingName.Value != "MEASURES" {
+		t.Errorf("window named MEASURES: ExistingName = %v, want MEASURES", fc2.Over.ExistingName)
+	}
+	if fc2.Over.Frame == nil || fc2.Over.Frame.Pattern != nil {
+		t.Errorf("window named MEASURES: frame should be ordinary (Pattern nil), got %+v", fc2.Over.Frame)
+	}
+}
+
+// TestMatchRecognize_WindowFramePattern verifies the OVER-clause window frame
+// carries the row-pattern additions on WindowFrame.Pattern (M6).
+func TestMatchRecognize_WindowFramePattern(t *testing.T) {
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT count(*) OVER (MEASURES x AS m ROWS CURRENT ROW AFTER MATCH SKIP PAST LAST ROW "+
+			"PATTERN (A B) SUBSET U = (A, B) DEFINE A AS true) FROM t"))
+	fc, ok := spec.Items[0].Expr.(*FuncCall)
+	if !ok {
+		t.Fatalf("select item is %T, want *FuncCall", spec.Items[0].Expr)
+	}
+	if fc.Over == nil || fc.Over.Frame == nil {
+		t.Fatal("OVER frame is nil")
+	}
+	mrf := fc.Over.Frame.Pattern
+	if mrf == nil {
+		t.Fatal("frame.Pattern (MatchRecognizeFrame) is nil")
+	}
+	if len(mrf.Measures) != 1 || mrf.Measures[0].Name.Value != "m" {
+		t.Errorf("frame MEASURES = %+v, want m", mrf.Measures)
+	}
+	if mrf.AfterMatchSkip == nil || mrf.AfterMatchSkip.Kind != SkipPastLastRow {
+		t.Errorf("frame AFTER MATCH = %+v, want SKIP PAST LAST ROW", mrf.AfterMatchSkip)
+	}
+	if mrf.Pattern == nil {
+		t.Error("frame PATTERN is nil")
+	}
+	if len(mrf.Subsets) != 1 {
+		t.Errorf("frame SUBSET count = %d, want 1", len(mrf.Subsets))
+	}
+	if len(mrf.Definitions) != 1 {
+		t.Errorf("frame DEFINE count = %d, want 1", len(mrf.Definitions))
+	}
+}
+
+// TestMatchRecognize_WindowFrameSkipFollowers verifies the FIRST/LAST skip
+// keyword disambiguation in a window frame, where the skipTo target may be
+// followed only by the frame-closing ')' or by an optional SUBSET/DEFINE (no
+// PATTERN). FIRST/LAST is still the keyword (with the bare label as its variable).
+func TestMatchRecognize_WindowFrameSkipFollowers(t *testing.T) {
+	// skipTo target ends the frame (next token is ')').
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT count(*) OVER (ROWS CURRENT ROW AFTER MATCH SKIP TO FIRST A) FROM t"))
+	skip := spec.Items[0].Expr.(*FuncCall).Over.Frame.Pattern.AfterMatchSkip
+	if skip == nil || skip.Kind != SkipToFirst || skip.Variable == nil || skip.Variable.Value != "A" {
+		t.Errorf("window SKIP TO FIRST A): got %+v, want SkipToFirst(A)", skip)
+	}
+	// skipTo target followed by SUBSET/DEFINE (no PATTERN) in the frame.
+	spec2 := querySpec(t, parseOneQuery(t,
+		"SELECT count(*) OVER (ROWS CURRENT ROW AFTER MATCH SKIP TO LAST A SUBSET U = (A) DEFINE A AS true) FROM t"))
+	mrf := spec2.Items[0].Expr.(*FuncCall).Over.Frame.Pattern
+	if mrf.AfterMatchSkip == nil || mrf.AfterMatchSkip.Kind != SkipToLast || mrf.AfterMatchSkip.Variable.Value != "A" {
+		t.Errorf("window SKIP TO LAST A SUBSET: got %+v, want SkipToLast(A)", mrf.AfterMatchSkip)
+	}
+	if mrf.Pattern != nil {
+		t.Errorf("window frame with no PATTERN: mrf.Pattern = %+v, want nil", mrf.Pattern)
+	}
+	if len(mrf.Subsets) != 1 || len(mrf.Definitions) != 1 {
+		t.Errorf("frame SUBSET/DEFINE counts = %d/%d, want 1/1", len(mrf.Subsets), len(mrf.Definitions))
+	}
+}
+
+// TestMatchRecognize_OrdinaryFrameNoPattern verifies an ordinary window frame
+// (no pattern recognition) leaves WindowFrame.Pattern nil.
+func TestMatchRecognize_OrdinaryFrameNoPattern(t *testing.T) {
+	spec := querySpec(t, parseOneQuery(t,
+		"SELECT count(*) OVER (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM t"))
+	fc := spec.Items[0].Expr.(*FuncCall)
+	if fc.Over == nil || fc.Over.Frame == nil {
+		t.Fatal("OVER frame is nil")
+	}
+	if fc.Over.Frame.Pattern != nil {
+		t.Errorf("ordinary frame Pattern = %+v, want nil", fc.Over.Frame.Pattern)
+	}
+}
+
+// --- small helpers ---
+
+func patternVarName(t *testing.T, p RowPattern) string {
+	t.Helper()
+	pv, ok := p.(*PatternVariable)
+	if !ok {
+		t.Fatalf("pattern is %T, want *PatternVariable", p)
+	}
+	return pv.Name.Value
+}
+
+func eqIntPtr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func derefStr(p *int64) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return strconv.FormatInt(*p, 10)
+}

--- a/trino/parser/oracle_match_recognize_test.go
+++ b/trino/parser/oracle_match_recognize_test.go
@@ -1,0 +1,241 @@
+package parser
+
+import "testing"
+
+// This file is the parser-match-recognize node's differential-oracle gate
+// (correctness-protocol.md): for every statement in the corpus below, omni's
+// Parse accept/reject verdict must equal Trino 481's verdict as reported by the
+// live oracle (trinooracle.CheckSyntax, which classifies a SYNTAX_ERROR as
+// reject and every other outcome — success or a semantic error such as
+// TABLE_HAS_NO_COLUMNS / COLUMN_NOT_FOUND / INVALID_LABEL / NOT_SUPPORTED — as
+// accept).
+//
+// The corpus is NOT split into hardcoded accept/reject lists: the oracle is the
+// source of truth, so each case is run through both omni and Trino and the two
+// verdicts are compared. Every legacy ANTLR alternative of the patternRecognition
+// subsystem (truth2) and every documented MATCH_RECOGNIZE form (truth1) appears,
+// alongside the precedence/structure cases (R1–R5, M1–M6) and a set of negatives
+// the engine rejects. Skipped cleanly when no Trino oracle is reachable.
+//
+// Helpers (connectOracle / oracleAccepts / truncateName) live in
+// oracle_foundation_test.go.
+
+// matchRecognizeOracleCorpus is the full MATCH_RECOGNIZE / row-pattern corpus.
+// Each string is a complete statement (the differential needs a whole statement;
+// table/column references resolve to semantic errors, never syntax rejections).
+var matchRecognizeOracleCorpus = []string{
+	// --- minimal & mandatory clauses (M1) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B) DEFINE A AS true, B AS false)",
+	"SELECT * FROM t MATCH_RECOGNIZE ()",                                 // empty body — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A))",                      // no DEFINE — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (DEFINE A AS true)",                 // no PATTERN — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN A DEFINE A AS true)",       // PATTERN body parens required
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN () DEFINE A AS true)",      // empty PATTERN body — rejected (rowPattern required; cf. PATTERN(()) below)
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE)",               // DEFINE needs >=1 def
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) SUBSET DEFINE A AS x)", // SUBSET needs >=1 def
+
+	// --- full clause stack, in grammar order ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PARTITION BY a ORDER BY b MEASURES c AS m ONE ROW PER MATCH AFTER MATCH SKIP TO NEXT ROW PATTERN (A B+ C) DEFINE B AS B.x > 0)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PARTITION BY a, b ORDER BY c DESC, d ASC NULLS LAST PATTERN (A) DEFINE A AS true)",
+
+	// --- clause ordering is fixed (M2): reordering is rejected ---
+	"SELECT * FROM t MATCH_RECOGNIZE (ORDER BY b PARTITION BY a PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (MEASURES x AS m PARTITION BY a PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) MEASURES x AS m DEFINE A AS true)", // MEASURES after PATTERN — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (DEFINE A AS true PATTERN (A))",                 // DEFINE before PATTERN — rejected
+
+	// --- MEASURES (with RUNNING / FINAL semantics) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (MEASURES match_number() AS mn PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (MEASURES RUNNING last(A.x) AS m PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (MEASURES FINAL last(A.x) AS m PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (MEASURES x AS m, y AS n PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (MEASURES x m PATTERN (A) DEFINE A AS true)", // measure AS required — rejected
+
+	// --- rowsPerMatch + emptyMatchHandling ---
+	"SELECT * FROM t MATCH_RECOGNIZE (ONE ROW PER MATCH PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (ALL ROWS PER MATCH PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (ALL ROWS PER MATCH SHOW EMPTY MATCHES PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (ALL ROWS PER MATCH OMIT EMPTY MATCHES PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (ALL ROWS PER MATCH WITH UNMATCHED ROWS PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (ONE ROW PER MATCH WITH UNMATCHED ROWS PATTERN (A) DEFINE A AS true)", // handling only on ALL ROWS — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (ONE ROWS PER MATCH PATTERN (A) DEFINE A AS true)",                    // ONE ROWS — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (ALL ROW PER MATCH PATTERN (A) DEFINE A AS true)",                     // ALL ROW — rejected
+
+	// --- AFTER MATCH SKIP variants (M5) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP PAST LAST ROW PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO NEXT ROW PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO FIRST A PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO LAST A PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO A PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO PATTERN (A) DEFINE A AS true)", // SKIP TO needs a target — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP PATTERN (A) DEFINE A AS true)",    // SKIP needs TO/PAST — rejected
+	// NEXT/FIRST/LAST are non-reserved: each may itself be the skip variable name
+	// when not in its special form (NEXT not followed by ROW, FIRST/LAST not
+	// followed by an identifier).
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO next PATTERN (A) DEFINE A AS true, next AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO NEXT PATTERN (A) DEFINE A AS true)",            // NEXT as variable (no ROW)
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO FIRST PATTERN (A) DEFINE A AS true)",           // FIRST as variable (no ident)
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO LAST PATTERN (A) DEFINE A AS true)",            // LAST as variable (no ident)
+	"SELECT * FROM t MATCH_RECOGNIZE (AFTER MATCH SKIP TO FIRST first PATTERN (A) DEFINE first AS true)", // FIRST keyword + variable "first"
+
+	// --- INITIAL / SEEK (M5) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (INITIAL PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (SEEK PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (INITIAL SEEK PATTERN (A) DEFINE A AS true)", // only one of INITIAL/SEEK — rejected
+
+	// --- SUBSET ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B) SUBSET U = (A) DEFINE A AS true, B AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B) SUBSET U = (A, B) DEFINE A AS true, B AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B) SUBSET U = (A), V = (B) DEFINE A AS true, B AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) SUBSET U = () DEFINE A AS true)", // empty union — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) SUBSET U DEFINE A AS true)",      // SUBSET needs = (…) — rejected
+
+	// --- trailing alias + column aliases (M3) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) AS m",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) m",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) AS m (x, y)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) m (x, y)",
+	"SELECT * FROM t AS r MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) AS m", // double alias
+	"SELECT * FROM t r MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) m",       // double alias, no AS
+	// the trailing alias may itself be the non-reserved keyword MATCH_RECOGNIZE,
+	// even followed by a column list — no second clause can follow, so it is an alias.
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) MATCH_RECOGNIZE (x)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) AS MATCH_RECOGNIZE (x)",
+
+	// --- MATCH_RECOGNIZE binds before TABLESAMPLE (M4) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) TABLESAMPLE BERNOULLI (10)",
+	"SELECT * FROM t TABLESAMPLE BERNOULLI (10) MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true)", // wrong order — rejected
+
+	// --- input-relation shapes the clause attaches to ---
+	"SELECT * FROM (SELECT 1 x) t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true)",
+	"SELECT * FROM (t JOIN s ON true) MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true)",
+
+	// --- rowPattern: concatenation / alternation precedence (R1) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B C) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A | B) DEFINE A AS true, B AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A | B | C) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B | C D) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ((A B) | C) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ((A | B)+) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A |) DEFINE A AS true)", // dangling alternation — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (| A) DEFINE A AS true)", // leading alternation — rejected
+
+	// --- rowPattern: quantifiers (R2) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A*) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A+) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A?) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A*?) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A+?) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A??) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{3}) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{1,3}) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{,3}) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{2,}) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{2,}?) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{,}) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ((A)*) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ((A*)*) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A* B* C*) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A**) DEFINE A AS true)",     // adjacent quantifiers — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{2}{3}) DEFINE A AS true)", // adjacent quantifiers — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A{}) DEFINE A AS true)",     // empty braces — rejected
+
+	// --- rowPattern: anchors (R5) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (^ A+ $) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (^) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ($) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (^+) DEFINE A AS true)", // anchor + quantifier parses (semantic INVALID_LABEL)
+
+	// --- rowPattern: PERMUTE ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE(A, B)) DEFINE A AS true, B AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE(A)) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE(A B, C)) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE(A | B, C)) DEFINE A AS true)",
+	// empty PERMUTE() is ACCEPTED by the live Trino 481 server even though the
+	// published SqlBase.g4 requires >=1 operand (divergence #92, oracle decides).
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE()) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE(,)) DEFINE A AS true)",  // leading comma — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (PERMUTE(A,)) DEFINE A AS true)", // trailing comma — rejected
+	// PERMUTE is non-reserved: a bare `permute` not followed by '(' is a label.
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (permute) DEFINE permute AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (permute A) DEFINE permute AS true, A AS true)",
+
+	// --- rowPattern: excluded pattern ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ({- A -} B) DEFINE A AS true, B AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ({- A B -} C) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ({- A | B -}) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN ({- -}) DEFINE A AS true)", // empty exclusion — rejected
+
+	// --- rowPattern: empty pattern (R4) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (()) DEFINE A AS true)",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (() A) DEFINE A AS true)",
+
+	// --- quoted / non-reserved pattern variable labels ---
+	`SELECT * FROM t MATCH_RECOGNIZE (PATTERN ("quoted var") DEFINE "quoted var" AS true)`,
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (zone) DEFINE zone AS true)", // non-reserved keyword as a label
+
+	// --- DEFINE condition expressions (PREV / NEXT / CLASSIFIER / FIRST / LAST) ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS A.price > PREV(A.price))",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS CLASSIFIER() = 'X')",
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A B) DEFINE B AS B.value > LAST(A.value))",
+
+	// --- window-frame pattern recognition (M6) ---
+	"SELECT count(*) OVER (PARTITION BY a ORDER BY b MEASURES x AS m ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING PATTERN (A) DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (ORDER BY b ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING PATTERN (A) DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (MEASURES x AS m ROWS CURRENT ROW PATTERN (A) DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (ROWS CURRENT ROW AFTER MATCH SKIP PAST LAST ROW PATTERN (A) DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (ROWS CURRENT ROW INITIAL PATTERN (A) DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (ROWS CURRENT ROW PATTERN (A B) SUBSET U = (A, B) DEFINE A AS true) FROM t",
+	// In a window frame the skipTo target may be followed by NOTHING (frame end),
+	// or by SUBSET/DEFINE with no PATTERN — every clause after frameExtent is
+	// optional (M6). The FIRST/LAST skip-keyword disambiguation must allow these.
+	"SELECT count(*) OVER (ROWS CURRENT ROW AFTER MATCH SKIP TO FIRST A) FROM t",
+	"SELECT count(*) OVER (ROWS CURRENT ROW AFTER MATCH SKIP TO FIRST A DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (ROWS CURRENT ROW AFTER MATCH SKIP TO LAST A SUBSET U = (A) DEFINE A AS true) FROM t",
+	"SELECT count(*) OVER (MEASURES x AS m ROWS CURRENT ROW) FROM t",                                                                       // MEASURES, no PATTERN/DEFINE — accepted (M6)
+	"SELECT count(*) OVER (ROWS CURRENT ROW PATTERN (A)) FROM t",                                                                           // PATTERN, no DEFINE — accepted (M6)
+	"SELECT count(*) OVER w FROM t WINDOW w AS (ORDER BY b ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING PATTERN (A) DEFINE A AS true)", // named window
+	"SELECT count(*) OVER (PATTERN (A) DEFINE A AS true) FROM t",                                                                           // PATTERN with no frameExtent — rejected (frameExtent mandatory)
+	"SELECT count(*) OVER (MEASURES x AS m PATTERN (A) DEFINE A AS true) FROM t",                                                           // MEASURES + PATTERN, no frameExtent — rejected
+	"SELECT count(*) OVER (MEASURES x AS m) FROM t",                                                                                        // bare MEASURES, no frameExtent — rejected
+	"SELECT count(*) OVER (ORDER BY a PATTERN (A) DEFINE A AS true) FROM t",                                                                // PATTERN after ORDER BY, no frameExtent — rejected
+	// MEASURES vs existing-window-name disambiguation (the measure expr starts with
+	// a non-reserved keyword that also begins a frame type — needs >1-token lookahead).
+	"SELECT count(*) OVER (MEASURES rows AS m ROWS CURRENT ROW PATTERN (A) DEFINE A AS true) FROM t",  // MEASURES clause, measure col "rows"
+	"SELECT count(*) OVER (MEASURES range AS m ROWS CURRENT ROW PATTERN (A) DEFINE A AS true) FROM t", // measure col "range"
+	// a window named "measures" (MEASURES followed by a window-spec part, not a measure expr)
+	"SELECT count(*) OVER (measures ORDER BY b ROWS CURRENT ROW) FROM t WINDOW measures AS (PARTITION BY a)",
+	"SELECT count(*) OVER (MEASURES ROWS CURRENT ROW) FROM t WINDOW MEASURES AS (PARTITION BY a)", // MEASURES is the window name + ROWS frame
+
+	// --- negatives that look almost right ---
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true) FROM",     // trailing FROM is not an alias — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE PATTERN (A) DEFINE A AS true",            // missing outer parens — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PATTERN (A) DEFINE A AS true",           // unterminated — rejected
+	"SELECT * FROM t MATCH_RECOGNIZE (PARTITION a PATTERN (A) DEFINE A AS x)", // PARTITION without BY — rejected
+}
+
+// TestMatchRecognize_OracleDifferential is the authoritative accept/reject gate:
+// omni's Parse verdict must equal Trino 481's verdict for every corpus statement.
+func TestMatchRecognize_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, sql := range matchRecognizeOracleCorpus {
+		sql := sql
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			omniAccepts := len(errs) == 0
+
+			trinoAccepts, ok := oracleAccepts(t, o, sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if omniAccepts != trinoAccepts {
+				t.Errorf("MISMATCH %q: omni accepts=%v (errs=%v), Trino accepts=%v",
+					sql, omniAccepts, errs, trinoAccepts)
+			}
+		})
+	}
+}

--- a/trino/parser/relation.go
+++ b/trino/parser/relation.go
@@ -499,12 +499,21 @@ func (p *Parser) parseJoinCriteria(join *Join) error {
 // sampledRelation / aliasedRelation
 // ---------------------------------------------------------------------------
 
-// parseSampledRelation parses a `sampledRelation`: an aliasedRelation with an
-// optional trailing `TABLESAMPLE (BERNOULLI|SYSTEM) ( percentage )`. (The
-// MATCH_RECOGNIZE patternRecognition layer between them is the
-// parser-match-recognize node, D4.)
+// parseSampledRelation parses a `sampledRelation`: a patternRecognition with an
+// optional trailing `TABLESAMPLE (BERNOULLI|SYSTEM) ( percentage )`. The
+// patternRecognition rule is an aliasedRelation followed by an optional
+// MATCH_RECOGNIZE clause; the MATCH_RECOGNIZE layer is the parser-match-recognize
+// node (D4 / match_recognize.go's parsePatternRecognitionSuffix). Because
+// sampledRelation wraps patternRecognition (not the other way round),
+// MATCH_RECOGNIZE binds tighter than TABLESAMPLE.
 func (p *Parser) parseSampledRelation() (Relation, error) {
 	rel, err := p.parseAliasedRelation()
+	if err != nil {
+		return nil, err
+	}
+	// patternRecognition: an optional MATCH_RECOGNIZE clause on the aliasedRelation
+	// (parser-match-recognize node). A no-op when MATCH_RECOGNIZE is absent.
+	rel, err = p.parsePatternRecognitionSuffix(rel)
 	if err != nil {
 		return nil, err
 	}
@@ -626,15 +635,24 @@ func (p *Parser) tryParseRelationAlias() (alias *ast.Identifier, cols []*ast.Ide
 // keyword that, here, introduces a clause rather than naming a relation alias —
 // disambiguated by the token that follows it (matching Trino 481, probed):
 //
-//	WINDOW      + identifier      → the querySpecification WINDOW clause
-//	LIMIT       + (ALL|int|?)     → the queryNoWith LIMIT clause
-//	OFFSET      + (int|?)         → the queryNoWith OFFSET clause
-//	FETCH       + (FIRST|NEXT)    → the queryNoWith FETCH clause
-//	TABLESAMPLE + (BERNOULLI|SYSTEM) → the sampledRelation TABLESAMPLE clause
+//	WINDOW           + identifier         → the querySpecification WINDOW clause
+//	LIMIT            + (ALL|int|?)        → the queryNoWith LIMIT clause
+//	OFFSET           + (int|?)            → the queryNoWith OFFSET clause
+//	FETCH            + (FIRST|NEXT)       → the queryNoWith FETCH clause
+//	TABLESAMPLE      + (BERNOULLI|SYSTEM) → the sampledRelation TABLESAMPLE clause
+//	MATCH_RECOGNIZE  + (                  → the patternRecognition MATCH_RECOGNIZE clause
 //
-// A bare occurrence (e.g. `FROM t window`, `FROM t limit`) does NOT match and is
-// taken as an alias by the caller. The reserved clause/join keywords need no
-// guard (isIdentifierStart already rejects them).
+// A bare occurrence (e.g. `FROM t window`, `FROM t limit`, `FROM t match_recognize`)
+// does NOT match and is taken as an alias by the caller — oracle-confirmed for
+// MATCH_RECOGNIZE (`FROM t MATCH_RECOGNIZE` resolves to a table aliased
+// "match_recognize"). The reserved clause/join keywords need no guard
+// (isIdentifierStart already rejects them).
+//
+// MATCH_RECOGNIZE belongs to the parser-match-recognize node
+// (match_recognize.go's parsePatternRecognitionSuffix); the guard lives here
+// because the alias decision (tryParseRelationAlias) is made before that hook
+// runs — without it, a non-reserved MATCH_RECOGNIZE keyword would be swallowed
+// as the aliasedRelation's alias and the clause never reached.
 func (p *Parser) atRelationClauseStart() bool {
 	switch p.cur.Kind {
 	case kwWINDOW:
@@ -651,6 +669,8 @@ func (p *Parser) atRelationClauseStart() bool {
 	case kwTABLESAMPLE:
 		nk := p.peekNext().Kind
 		return nk == kwBERNOULLI || nk == kwSYSTEM
+	case kwMATCH_RECOGNIZE:
+		return p.peekNext().Kind == int('(')
 	default:
 		return false
 	}

--- a/trino/parser/row_pattern.go
+++ b/trino/parser/row_pattern.go
@@ -1,0 +1,502 @@
+package parser
+
+import "github.com/bytebase/omni/trino/ast"
+
+// This file is part of the `parser-match-recognize` DAG node (with
+// match_recognize.go): it implements Trino's row-pattern grammar — the
+// `rowPattern`, `patternPrimary`, and `patternQuantifier` rules that appear
+// inside a `MATCH_RECOGNIZE ( … PATTERN ( rowPattern ) … )` clause (and inside
+// the windowFrame's PATTERN). match_recognize.go owns the surrounding
+// patternRecognition clause and the two integration hooks; this file owns the
+// pattern expression itself.
+//
+// Legacy ANTLR grammar (TrinoParser.g4):
+//
+//	rowPattern
+//	    : patternPrimary patternQuantifier?   # quantifiedPrimary
+//	    | rowPattern rowPattern               # patternConcatenation
+//	    | rowPattern VBAR_ rowPattern         # patternAlternation ;
+//	patternPrimary
+//	    : identifier                                          # patternVariable
+//	    | LPAREN_ RPAREN_                                     # emptyPattern
+//	    | PERMUTE_ LPAREN_ rowPattern (COMMA_ rowPattern)* RPAREN_ # patternPermutation
+//	    | LPAREN_ rowPattern RPAREN_                          # groupedPattern
+//	    | CARET_                                              # partitionStartAnchor
+//	    | DOLLAR_                                             # partitionEndAnchor
+//	    | LCURLYHYPHEN_ rowPattern RCURLYHYPHEN_              # excludedPattern ;
+//	patternQuantifier
+//	    : ASTERISK_ QUESTION_MARK_?                                       # zeroOrMore
+//	    | PLUS_ QUESTION_MARK_?                                           # oneOrMore
+//	    | QUESTION_MARK_ QUESTION_MARK_?                                  # zeroOrOne
+//	    | LCURLY_ exactly=INTEGER_VALUE_ RCURLY_ QUESTION_MARK_?          # range
+//	    | LCURLY_ atLeast=INTEGER_VALUE_? COMMA_ atMost=INTEGER_VALUE_? RCURLY_ QUESTION_MARK_? # range ;
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed structure
+// (probed; see oracle_match_recognize_test.go for the differential corpus):
+//
+//	R1 (precedence & associativity). The ANTLR rule is ambiguous; Trino resolves
+//	   it as a classic regex: a quantifier binds to its immediately-preceding
+//	   patternPrimary, concatenation binds tighter than `|` alternation, and both
+//	   concatenation and alternation are left-associative. So `A B | C D` is
+//	   `(A B) | (C D)`, `A | B | C` is `((A | B) | C)`, and `A B C` is
+//	   `((A B) C)`. parseRowPattern is a two-level precedence climber:
+//	   parseRowPattern (alternation) → parsePatternConcat (concatenation) →
+//	   parsePatternFactor (primary + optional single quantifier).
+//	R2 (at most one quantifier per primary). `A**` / `A{2}{3}` are REJECTED — a
+//	   patternQuantifier may not directly follow another. A quantified group
+//	   `(A*)*` is the legal way to stack. parsePatternFactor consumes at most one
+//	   quantifier and does not loop.
+//	R3 (concatenation boundary). Concatenation continues while the next token can
+//	   begin a patternPrimary (identifier-start, '(', PERMUTE, '^', '$', '{-').
+//	   It stops at ')', '|', '-}', ',' (PERMUTE arg separator) and the trailing
+//	   MATCH_RECOGNIZE keywords — none of which begin a primary.
+//	R4 (empty pattern vs grouped pattern). A leading '(' is the emptyPattern `()`
+//	   when immediately followed by ')', else a groupedPattern `( rowPattern )`.
+//	R5 (anchors and the empty pattern are full primaries). `^`, `$`, and `()` may
+//	   themselves carry a quantifier (`^+`, `()*`) and participate in
+//	   concatenation/alternation — grammatically; later semantic analysis may
+//	   reject (INVALID_LABEL), which is NOT a syntax error.
+
+// ---------------------------------------------------------------------------
+// Row-pattern node hierarchy (parser-package types; not ast.Node — matching the
+// Relation / Expr / DataType convention, see relation.go / expr.go headers)
+// ---------------------------------------------------------------------------
+
+// RowPattern is the interface implemented by every node of a MATCH_RECOGNIZE
+// row pattern (the rowPattern / patternPrimary rules). Span returns the source
+// byte range; concrete fields are reached by a Go type switch.
+type RowPattern interface {
+	// Span returns the source byte range covered by the pattern.
+	Span() ast.Loc
+	// rowPatternNode is a marker preventing unrelated types from satisfying it.
+	rowPatternNode()
+}
+
+// PatternConcat is a concatenation `left right` of two adjacent patterns (the
+// patternConcatenation alternative). Built left-associatively, so a longer run
+// `A B C` nests as PatternConcat{PatternConcat{A,B}, C}.
+type PatternConcat struct {
+	Left  RowPattern
+	Right RowPattern
+	Loc   ast.Loc
+}
+
+func (n *PatternConcat) Span() ast.Loc { return n.Loc }
+func (*PatternConcat) rowPatternNode() {}
+
+// PatternAlternation is an alternation `left | right` (the patternAlternation
+// alternative). Built left-associatively (`A | B | C` nests as
+// PatternAlternation{PatternAlternation{A,B}, C}); alternation binds looser than
+// concatenation.
+type PatternAlternation struct {
+	Left  RowPattern
+	Right RowPattern
+	Loc   ast.Loc
+}
+
+func (n *PatternAlternation) Span() ast.Loc { return n.Loc }
+func (*PatternAlternation) rowPatternNode() {}
+
+// QuantifiedPattern is a patternPrimary with an optional trailing quantifier
+// (the quantifiedPrimary alternative). Quantifier is nil for a bare primary.
+type QuantifiedPattern struct {
+	Primary    RowPattern
+	Quantifier *PatternQuantifier // nil when the primary is unquantified
+	Loc        ast.Loc
+}
+
+func (n *QuantifiedPattern) Span() ast.Loc { return n.Loc }
+func (*QuantifiedPattern) rowPatternNode() {}
+
+// PatternVariable is a primary pattern variable `identifier` (the patternVariable
+// alternative): a reference to a row-pattern variable that is given meaning by a
+// DEFINE (or the implicit always-true variable).
+type PatternVariable struct {
+	Name *ast.Identifier
+	Loc  ast.Loc
+}
+
+func (n *PatternVariable) Span() ast.Loc { return n.Loc }
+func (*PatternVariable) rowPatternNode() {}
+
+// EmptyPattern is the empty pattern `()` (the emptyPattern alternative): matches
+// an empty sequence of rows.
+type EmptyPattern struct {
+	Loc ast.Loc
+}
+
+func (n *EmptyPattern) Span() ast.Loc { return n.Loc }
+func (*EmptyPattern) rowPatternNode() {}
+
+// PatternPermutation is `PERMUTE ( rowPattern (, rowPattern)* )` (the
+// patternPermutation alternative): matches any permutation of its operand
+// patterns. Patterns holds the operands (at least one).
+type PatternPermutation struct {
+	Patterns []RowPattern
+	Loc      ast.Loc
+}
+
+func (n *PatternPermutation) Span() ast.Loc { return n.Loc }
+func (*PatternPermutation) rowPatternNode() {}
+
+// GroupedPattern is a parenthesized pattern `( rowPattern )` (the groupedPattern
+// alternative): groups a sub-pattern, e.g. so a quantifier applies to the whole.
+type GroupedPattern struct {
+	Inner RowPattern
+	Loc   ast.Loc
+}
+
+func (n *GroupedPattern) Span() ast.Loc { return n.Loc }
+func (*GroupedPattern) rowPatternNode() {}
+
+// AnchorPattern is a partition-boundary anchor — `^` (start) or `$` (end) (the
+// partitionStartAnchor / partitionEndAnchor alternatives). Start marks `^`;
+// otherwise it is `$`.
+type AnchorPattern struct {
+	Start bool // true for `^` (partition start), false for `$` (partition end)
+	Loc   ast.Loc
+}
+
+func (n *AnchorPattern) Span() ast.Loc { return n.Loc }
+func (*AnchorPattern) rowPatternNode() {}
+
+// ExcludedPattern is an exclusion `{- rowPattern -}` (the excludedPattern
+// alternative): the matched rows of Inner are excluded from the output.
+type ExcludedPattern struct {
+	Inner RowPattern
+	Loc   ast.Loc
+}
+
+func (n *ExcludedPattern) Span() ast.Loc { return n.Loc }
+func (*ExcludedPattern) rowPatternNode() {}
+
+// PatternQuantifierKind enumerates the patternQuantifier shapes.
+type PatternQuantifierKind int
+
+const (
+	// QuantZeroOrMore is `*` (zeroOrMoreQuantifier).
+	QuantZeroOrMore PatternQuantifierKind = iota
+	// QuantOneOrMore is `+` (oneOrMoreQuantifier).
+	QuantOneOrMore
+	// QuantZeroOrOne is `?` (zeroOrOneQuantifier).
+	QuantZeroOrOne
+	// QuantRange is a `{ … }` range (rangeQuantifier), with the bounds in the
+	// PatternQuantifier's AtLeast/AtMost/Exactly fields.
+	QuantRange
+)
+
+// PatternQuantifier is a row-pattern quantifier (the patternQuantifier rule).
+// Kind is the quantifier shape. Reluctant marks the trailing `?` (reluctant /
+// non-greedy) marker. For QuantRange, Exactly is set for the `{n}` form (and
+// AtLeast/AtMost are nil), otherwise AtLeast/AtMost hold the `{m,n}` bounds (each
+// nil when its side is omitted: `{,n}` / `{m,}` / `{,}`).
+type PatternQuantifier struct {
+	Kind      PatternQuantifierKind
+	Reluctant bool
+	Exactly   *int64 // {n} exact count, nil unless the exact form
+	AtLeast   *int64 // {m,…} lower bound, nil when omitted
+	AtMost    *int64 // {…,n} upper bound, nil when omitted
+	Loc       ast.Loc
+}
+
+// ---------------------------------------------------------------------------
+// rowPattern parsing (precedence climbing: alternation → concat → factor)
+// ---------------------------------------------------------------------------
+
+// parseRowPattern parses a full `rowPattern`: the loosest-binding alternation
+// level. It parses a concatenation, then folds a left-associative chain of
+// `| concatenation` alternatives (R1). It is the entry point used by
+// match_recognize.go's PATTERN ( … ) and PERMUTE / grouped / excluded
+// sub-patterns.
+func (p *Parser) parseRowPattern() (RowPattern, error) {
+	left, err := p.parsePatternConcat()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Kind == int('|') {
+		p.advance() // consume '|'
+		right, err := p.parsePatternConcat()
+		if err != nil {
+			return nil, err
+		}
+		left = &PatternAlternation{
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// parsePatternConcat parses a `patternConcatenation`: one or more pattern
+// factors juxtaposed. It parses a first factor, then folds a left-associative
+// chain of additional factors while the next token begins a patternPrimary (R3).
+func (p *Parser) parsePatternConcat() (RowPattern, error) {
+	left, err := p.parsePatternFactor()
+	if err != nil {
+		return nil, err
+	}
+	for p.startsPatternPrimary() {
+		right, err := p.parsePatternFactor()
+		if err != nil {
+			return nil, err
+		}
+		left = &PatternConcat{
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
+		}
+	}
+	return left, nil
+}
+
+// startsPatternPrimary reports whether the current token can begin a
+// patternPrimary — i.e. whether concatenation should continue (R3). A primary
+// starts with an identifier (a pattern variable, including non-reserved keywords
+// usable as identifiers), '(' (empty or grouped), PERMUTE, '^', '$', or '{-'
+// (an excluded pattern). Everything else — ')', '|', '-}', ',', and the
+// MATCH_RECOGNIZE trailing keywords (SUBSET / DEFINE) — does not, ending the
+// concatenation.
+func (p *Parser) startsPatternPrimary() bool {
+	switch p.cur.Kind {
+	case int('('), kwPERMUTE, int('^'), int('$'), tokLCurlyHyphen:
+		return true
+	default:
+		return isIdentifierStart(p.cur.Kind)
+	}
+}
+
+// parsePatternFactor parses a `patternPrimary patternQuantifier?` (the
+// quantifiedPrimary alternative): a single primary with at most one trailing
+// quantifier (R2 — a second quantifier is not consumed, so `A**` fails when the
+// stray `*` is later rejected as not beginning a primary/clause).
+func (p *Parser) parsePatternFactor() (RowPattern, error) {
+	primary, err := p.parsePatternPrimary()
+	if err != nil {
+		return nil, err
+	}
+	q, ok, err := p.tryParsePatternQuantifier()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return primary, nil
+	}
+	return &QuantifiedPattern{
+		Primary:    primary,
+		Quantifier: q,
+		Loc:        ast.Loc{Start: primary.Span().Start, End: q.Loc.End},
+	}, nil
+}
+
+// parsePatternPrimary parses one `patternPrimary`:
+//
+//   - identifier                  → PatternVariable
+//   - ( )                         → EmptyPattern        (R4: '(' then ')')
+//   - ( rowPattern )              → GroupedPattern      (R4: '(' then a pattern)
+//   - PERMUTE ( rowPattern, … )   → PatternPermutation  (only when followed by '(')
+//   - ^ | $                       → AnchorPattern
+//   - {- rowPattern -}            → ExcludedPattern
+//
+// PERMUTE is a NON-RESERVED keyword, so a bare `permute` (not followed by '(') is
+// an ordinary pattern variable, not the permutation form — oracle-confirmed:
+// Trino 481 accepts `PATTERN (permute) DEFINE permute AS true`. Only `PERMUTE (`
+// enters parsePatternPermutation; otherwise PERMUTE falls through to the
+// identifier (PatternVariable) branch.
+func (p *Parser) parsePatternPrimary() (RowPattern, error) {
+	switch {
+	case p.cur.Kind == int('('):
+		return p.parseParenPattern()
+	case p.cur.Kind == kwPERMUTE && p.peekNext().Kind == int('('):
+		return p.parsePatternPermutation()
+	case p.cur.Kind == int('^'):
+		tok := p.advance()
+		return &AnchorPattern{Start: true, Loc: tok.Loc}, nil
+	case p.cur.Kind == int('$'):
+		tok := p.advance()
+		return &AnchorPattern{Start: false, Loc: tok.Loc}, nil
+	case p.cur.Kind == tokLCurlyHyphen:
+		return p.parseExcludedPattern()
+	default:
+		if !isIdentifierStart(p.cur.Kind) {
+			return nil, p.exprErrorAt("expected a row-pattern variable, '(', PERMUTE, '^', '$', or '{-'")
+		}
+		id, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		return &PatternVariable{Name: id, Loc: id.Loc}, nil
+	}
+}
+
+// parseParenPattern parses `( )` (emptyPattern) or `( rowPattern )`
+// (groupedPattern); the '(' is the current token. The token after '(' decides
+// (R4): an immediate ')' is the empty pattern; otherwise a grouped sub-pattern.
+func (p *Parser) parseParenPattern() (RowPattern, error) {
+	openTok := p.advance() // consume '('
+	if p.cur.Kind == int(')') {
+		closeTok := p.advance() // consume ')'
+		return &EmptyPattern{Loc: ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End}}, nil
+	}
+	inner, err := p.parseRowPattern()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &GroupedPattern{
+		Inner: inner,
+		Loc:   ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parsePatternPermutation parses `PERMUTE ( ( rowPattern (, rowPattern)* )? )`
+// (the patternPermutation alternative; PERMUTE is current). The operand list may
+// be EMPTY — Trino 481 accepts `PERMUTE()` (divergence "match-recognize empty
+// PERMUTE": the live oracle is more permissive than the legacy ANTLR grammar,
+// which required `rowPattern (, rowPattern)*`; oracle decides). A leading or
+// trailing comma is still rejected (`PERMUTE(,)` / `PERMUTE(A,)`), so the list,
+// when present, is the standard comma-separated form.
+func (p *Parser) parsePatternPermutation() (RowPattern, error) {
+	permuteTok := p.advance() // consume PERMUTE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	var patterns []RowPattern
+	if p.cur.Kind != int(')') {
+		first, err := p.parseRowPattern()
+		if err != nil {
+			return nil, err
+		}
+		patterns = append(patterns, first)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			next, err := p.parseRowPattern()
+			if err != nil {
+				return nil, err
+			}
+			patterns = append(patterns, next)
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &PatternPermutation{
+		Patterns: patterns,
+		Loc:      ast.Loc{Start: permuteTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseExcludedPattern parses `{- rowPattern -}` (the excludedPattern
+// alternative; the '{-' token is current). The body is a full rowPattern (an
+// empty `{- -}` is a syntax error — there is no inner emptyPattern shortcut).
+func (p *Parser) parseExcludedPattern() (RowPattern, error) {
+	openTok := p.advance() // consume '{-'
+	inner, err := p.parseRowPattern()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(tokRCurlyHyphen)
+	if err != nil {
+		return nil, err
+	}
+	return &ExcludedPattern{
+		Inner: inner,
+		Loc:   ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// tryParsePatternQuantifier parses an optional `patternQuantifier` after a
+// primary. It returns ok=false when the current token does not begin a
+// quantifier (`*`, `+`, `?`, or `{`). It consumes exactly one quantifier; a
+// second adjacent quantifier is left for the caller, which does not accept it
+// (R2).
+func (p *Parser) tryParsePatternQuantifier() (*PatternQuantifier, bool, error) {
+	switch p.cur.Kind {
+	case int('*'):
+		tok := p.advance()
+		q := &PatternQuantifier{Kind: QuantZeroOrMore, Loc: tok.Loc}
+		p.consumeReluctant(q)
+		return q, true, nil
+	case int('+'):
+		tok := p.advance()
+		q := &PatternQuantifier{Kind: QuantOneOrMore, Loc: tok.Loc}
+		p.consumeReluctant(q)
+		return q, true, nil
+	case tokQuestion, int('?'):
+		tok := p.advance()
+		q := &PatternQuantifier{Kind: QuantZeroOrOne, Loc: tok.Loc}
+		p.consumeReluctant(q)
+		return q, true, nil
+	case int('{'):
+		q, err := p.parseRangeQuantifier()
+		if err != nil {
+			return nil, false, err
+		}
+		return q, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+// consumeReluctant consumes an optional trailing reluctant `?` marker on a
+// quantifier and records it (extending the quantifier's span).
+func (p *Parser) consumeReluctant(q *PatternQuantifier) {
+	if p.cur.Kind == tokQuestion || p.cur.Kind == int('?') {
+		tok := p.advance()
+		q.Reluctant = true
+		q.Loc.End = tok.Loc.End
+	}
+}
+
+// parseRangeQuantifier parses a `{ … }` range quantifier (the rangeQuantifier
+// alternatives; '{' is current):
+//
+//	{ n }          → Exactly = n
+//	{ m , n }      → AtLeast = m, AtMost = n
+//	{ m , }        → AtLeast = m
+//	{ , n }        → AtMost = n
+//	{ , }          → both nil (unbounded both sides)
+//
+// followed by an optional reluctant `?`. The two grammar alternatives are
+// distinguished by whether a ',' appears: `{ n }` has none; every comma form is
+// the bounded-range alternative. (Trino's lexer tokenizes `{-` specially, so a
+// lone '{' here is unambiguously the range-quantifier brace.)
+func (p *Parser) parseRangeQuantifier() (*PatternQuantifier, error) {
+	openTok := p.advance() // consume '{'
+	q := &PatternQuantifier{Kind: QuantRange, Loc: ast.Loc{Start: openTok.Loc.Start}}
+
+	// Optional leading integer (the `{n}` count or the `{m,…}` lower bound).
+	var leading *int64
+	if p.cur.Kind == tokInteger {
+		v := p.advance().Ival
+		leading = &v
+	}
+
+	if p.cur.Kind == int(',') {
+		// Bounded-range form `{ m? , n? }`.
+		p.advance() // consume ','
+		q.AtLeast = leading
+		if p.cur.Kind == tokInteger {
+			v := p.advance().Ival
+			q.AtMost = &v
+		}
+	} else {
+		// Exact form `{ n }` — the leading integer is mandatory here.
+		if leading == nil {
+			return nil, p.exprErrorAt("expected an integer or ',' in row-pattern range quantifier")
+		}
+		q.Exactly = leading
+	}
+
+	closeTok, err := p.expect(int('}'))
+	if err != nil {
+		return nil, err
+	}
+	q.Loc.End = closeTok.Loc.End
+	p.consumeReluctant(q)
+	return q, nil
+}


### PR DESCRIPTION
## Summary

Implements Trino 481's **MATCH_RECOGNIZE row-pattern-recognition** subsystem (v2 migration node `trino/parser-match-recognize`) as hand-written recursive-descent parsers, adjudicated against the live Trino 481 oracle (`trino/internal/trinooracle`).

- **`trino/parser/match_recognize.go`** — the `patternRecognition` relation clause and the `windowFrame` row-pattern additions:
  - relation form: `MATCH_RECOGNIZE ( [PARTITION BY] [ORDER BY] [MEASURES] [rowsPerMatch] [AFTER MATCH SKIP] [INITIAL|SEEK] PATTERN (rowPattern) [SUBSET] DEFINE ) [AS? alias cols]` — `PATTERN` and `DEFINE` mandatory, fixed clause order (M1, M2).
  - window form (the `windowFrame` rule): `[MEASURES] frameExtent [AFTER MATCH SKIP] [INITIAL|SEEK] [PATTERN] [SUBSET] [DEFINE]` — every part optional except the `frameExtent` (M6).
- **`trino/parser/row_pattern.go`** — the `rowPattern` grammar: a two-level precedence climber (alternation `|` binds looser than concatenation; both left-associative; at most one quantifier per primary, R1/R2), the seven `patternPrimary` alternatives (variable, empty `()`, `PERMUTE`, grouped, `^`/`$` anchors, `{- -}` exclusion), and the `patternQuantifier` forms (`*` `+` `?`, `{n}`, `{m,n}`, reluctant `?`).

## Correctness — differential oracle gate

`oracle_match_recognize_test.go` runs ~132 statements through **both** omni and the live Trino 481 server and asserts the accept/reject verdicts match (SYNTAX_ERROR ⇒ reject; any other outcome ⇒ accept). Covers all documented forms, all legacy ANTLR alternatives, precedence/structure cases, and negatives. **176 subtests green.** Structural tests (`match_recognize_test.go`) pin the AST shapes the accept/reject gate cannot see (pattern precedence/associativity, quantifier bounds, double alias, the non-reserved disambiguations, window-frame attachment + span).

## Non-reserved-keyword disambiguation

`MATCH_RECOGNIZE`, `MEASURES`, `PERMUTE`, `NEXT`, `FIRST`, `LAST` are all usable as ordinary identifiers, so each is its special form **only in its disambiguating context** — oracle-confirmed, and most were surfaced by the cross-family Codex review:

- `MATCH_RECOGNIZE` is the clause only before `(` (else a relation alias, incl. a trailing alias literally named `MATCH_RECOGNIZE`);
- `PERMUTE` is the permutation only before `(` (else a pattern variable);
- `NEXT` is `NEXT ROW` only before `ROW` (else a skip variable);
- `FIRST`/`LAST` is the skip keyword only before `ident <skipTo-successor>` (else the variable);
- `MEASURES` is the window MEASURES clause only when an `expr AS id` measure follows (else an existing window name).

## Divergence (oracle-adjudicated, logged #92)

Empty `PERMUTE()` is **accepted**: the live Trino 481 server accepts it at the parser stage (fails later with `INVALID_LABEL`, a semantic error) even though the published `SqlBase.g4` requires ≥1 operand. The oracle is authoritative, so omni must not emit a false syntax error here. A leading/trailing comma (`PERMUTE(,)`, `PERMUTE(A,)`) is still rejected.

## Review

Two-reviewer cross-family gate (Claude `/code-review` + Codex `codex review`). Codex caught five genuine non-reserved-keyword disambiguation bugs and one span-accuracy issue across three rounds; all fixed and re-verified against the oracle, converging to a clean final pass. The PERMUTE divergence was defended against the reviewer (which lacked oracle access) with the oracle evidence packet.

## Scope

In-scope writes: `trino/parser/match_recognize.go`, `trino/parser/row_pattern.go` (+ the node's test files). Out-of-scope writes (recorded; both anticipated by the existing node headers): `relation.go` wires the `patternRecognition` hook in `parseSampledRelation` and the MATCH_RECOGNIZE alias-start guard (boundary **D4**); `function.go` wires the window-frame pattern hook and extends the frame span (boundary **B2**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
