### PR TITLE
feat(snowflake): T6.2 BEGIN / COMMIT / ROLLBACK transaction control

### DIFF
--- a/snowflake/ast/ast_test.go
+++ b/snowflake/ast/ast_test.go
@@ -313,11 +313,85 @@ func TestNodeTagString(t *testing.T) {
 	}{
 		{T_Invalid, "Invalid"},
 		{T_File, "File"},
+		{T_BeginStmt, "BeginStmt"},
+		{T_CommitStmt, "CommitStmt"},
+		{T_RollbackStmt, "RollbackStmt"},
 		{NodeTag(9999), "Unknown"},
 	}
 	for _, c := range cases {
 		if got := c.tag.String(); got != c.want {
 			t.Errorf("NodeTag(%d).String() = %q, want %q", c.tag, got, c.want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------
+// TCL (transaction control) node tests (T6.2)
+// -----------------------------------------------------------------------
+
+func TestTCLNodeTags(t *testing.T) {
+	cases := []struct {
+		node Node
+		want NodeTag
+	}{
+		{&BeginStmt{}, T_BeginStmt},
+		{&CommitStmt{}, T_CommitStmt},
+		{&RollbackStmt{}, T_RollbackStmt},
+	}
+	for _, c := range cases {
+		if got := c.node.Tag(); got != c.want {
+			t.Errorf("%T.Tag() = %v, want %v", c.node, got, c.want)
+		}
+	}
+}
+
+func TestBeginKindString(t *testing.T) {
+	cases := []struct {
+		kind BeginKind
+		want string
+	}{
+		{BeginBare, "BEGIN"},
+		{BeginWork, "BEGIN WORK"},
+		{BeginTransaction, "BEGIN TRANSACTION"},
+		{BeginStartTransaction, "START TRANSACTION"},
+		{BeginKind(9999), "UNKNOWN"},
+	}
+	for _, c := range cases {
+		if got := c.kind.String(); got != c.want {
+			t.Errorf("BeginKind(%d).String() = %q, want %q", c.kind, got, c.want)
+		}
+	}
+}
+
+// TestTCLNodesWalkNoChildren verifies the generated walker visits each TCL node
+// itself but descends into no children (their only "name" field is an Ident
+// value, not a Node — matching ObjectName's embedded Idents).
+func TestTCLNodesWalkNoChildren(t *testing.T) {
+	cases := []struct {
+		node Node
+		tag  NodeTag
+	}{
+		{&BeginStmt{Name: Ident{Name: "t1"}}, T_BeginStmt},
+		{&CommitStmt{Work: true}, T_CommitStmt},
+		{&RollbackStmt{Work: true}, T_RollbackStmt},
+	}
+	for _, c := range cases {
+		var events []recordEvent
+		Walk(&recorder{events: &events}, c.node)
+		// A leaf node yields exactly two events: the pre-order visit (tag set)
+		// and the post-order Visit(nil). No child pre-visits.
+		var preVisits []NodeTag
+		for _, e := range events {
+			if !e.post {
+				preVisits = append(preVisits, e.tag)
+			}
+		}
+		if len(preVisits) != 1 {
+			t.Errorf("%T: walk pre-visited %d nodes, want 1 (self only): %+v", c.node, len(preVisits), preVisits)
+			continue
+		}
+		if preVisits[0] != c.tag {
+			t.Errorf("%T: pre-visit tag = %v, want %v", c.node, preVisits[0], c.tag)
 		}
 	}
 }

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -126,6 +126,11 @@ const (
 	// Routine DDL tags (T4.5)
 	T_CreateRoutineStmt
 	T_AlterRoutineStmt
+
+	// TCL (transaction control) tags (T6.2)
+	T_BeginStmt
+	T_CommitStmt
+	T_RollbackStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -301,6 +306,12 @@ func (t NodeTag) String() string {
 		return "CreateRoutineStmt"
 	case T_AlterRoutineStmt:
 		return "AlterRoutineStmt"
+	case T_BeginStmt:
+		return "BeginStmt"
+	case T_CommitStmt:
+		return "CommitStmt"
+	case T_RollbackStmt:
+		return "RollbackStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1296,6 +1296,91 @@ var (
 )
 
 // ---------------------------------------------------------------------------
+// TCL (transaction control) statement nodes (T6.2)
+// ---------------------------------------------------------------------------
+
+// BeginKind distinguishes the surface form that opened a transaction.
+//
+// Snowflake treats START TRANSACTION as a synonym for BEGIN, and the optional
+// WORK / TRANSACTION modifier after BEGIN is purely for cross-database
+// compatibility. The kind preserves the original keyword(s) so deparse and
+// tooling can round-trip the exact form the user wrote.
+type BeginKind int
+
+const (
+	// BeginBare is `BEGIN` with no WORK/TRANSACTION modifier.
+	BeginBare BeginKind = iota
+	// BeginWork is `BEGIN WORK`.
+	BeginWork
+	// BeginTransaction is `BEGIN TRANSACTION`.
+	BeginTransaction
+	// BeginStartTransaction is `START TRANSACTION`.
+	BeginStartTransaction
+)
+
+// String returns the keyword(s) that introduced the transaction.
+func (k BeginKind) String() string {
+	switch k {
+	case BeginBare:
+		return "BEGIN"
+	case BeginWork:
+		return "BEGIN WORK"
+	case BeginTransaction:
+		return "BEGIN TRANSACTION"
+	case BeginStartTransaction:
+		return "START TRANSACTION"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// BeginStmt represents the transaction-opening statement, covering both
+// surface forms documented by Snowflake:
+//
+//	BEGIN [ { WORK | TRANSACTION } ] [ NAME <name> ]
+//	START TRANSACTION [ NAME <name> ]
+//
+// Kind records which form/modifier was used. Name is the optional transaction
+// name following the NAME keyword; it is the zero Ident (IsEmpty) when absent.
+// Name is an Ident value (not a Node) and is therefore not visited by the
+// walker, matching how ObjectName embeds its Ident parts.
+type BeginStmt struct {
+	Kind BeginKind
+	Name Ident // optional; zero Ident (IsEmpty) when no NAME clause
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *BeginStmt) Tag() NodeTag { return T_BeginStmt }
+
+// CommitStmt represents `COMMIT [ WORK ]`. Work records whether the optional
+// WORK keyword (a cross-database-compatibility no-op) was present.
+type CommitStmt struct {
+	Work bool
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *CommitStmt) Tag() NodeTag { return T_CommitStmt }
+
+// RollbackStmt represents `ROLLBACK [ WORK ]`. Work records whether the
+// optional WORK keyword (a cross-database-compatibility no-op) was present.
+type RollbackStmt struct {
+	Work bool
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *RollbackStmt) Tag() NodeTag { return T_RollbackStmt }
+
+// Compile-time assertions.
+var (
+	_ Node = (*BeginStmt)(nil)
+	_ Node = (*CommitStmt)(nil)
+	_ Node = (*RollbackStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
 // DML statement nodes
 // ---------------------------------------------------------------------------
 

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -237,13 +237,13 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// TCL (4 cases)
 	case kwBEGIN:
-		return p.unsupported("BEGIN")
+		return p.parseBeginStmt()
 	case kwSTART:
-		return p.unsupported("START")
+		return p.parseStartTransactionStmt()
 	case kwCOMMIT:
-		return p.unsupported("COMMIT")
+		return p.parseCommitStmt()
 	case kwROLLBACK:
-		return p.unsupported("ROLLBACK")
+		return p.parseRollbackStmt()
 
 	// Info / inspection (5 cases)
 	case kwSHOW:

--- a/snowflake/parser/parser_test.go
+++ b/snowflake/parser/parser_test.go
@@ -131,24 +131,39 @@ func TestParse_LexErrorPropagated(t *testing.T) {
 	}
 }
 
-func TestParse_BeginEndBlockOneError(t *testing.T) {
-	// F3's Split treats "BEGIN SELECT 1; END;" as ONE segment, so parseSingle
-	// sees the whole block as one statement starting with BEGIN. The BEGIN
-	// stub emits ONE ParseError for the whole block.
-	runParseBestEffortCase(t, parseCase{
-		name:        "BEGIN..END block",
-		input:       "BEGIN SELECT 1; END;",
-		wantStmtCnt: 0,
-		wantErrCnt:  1,
-		wantErrMsgs: []string{"BEGIN statement parsing is not yet supported"},
-		wantErrLocs: []int{0},
-	})
+func TestParse_BeginEndBlockOneSegment(t *testing.T) {
+	// F3's Split treats "BEGIN SELECT 1; END;" as ONE segment (it recognizes
+	// BEGIN..END scripting blocks and does not split on the inner ';'), so
+	// parseSingle sees the whole block as one statement starting with BEGIN.
+	//
+	// As of T6.2, BEGIN is a real transaction-control statement: parseBeginStmt
+	// consumes the leading BEGIN and produces a *ast.BeginStmt. The remaining
+	// "SELECT 1; END" tail is left unconsumed without error (the engine-wide
+	// trailing-token convention shared with DROP/TRUNCATE/USE). Full Snowflake
+	// Scripting BEGIN..END block parsing is a separate Tier 7 feature; until it
+	// lands, a script block opener is captured as a bare BeginStmt.
+	result := ParseBestEffort("BEGIN SELECT 1; END;")
+	if len(result.Errors) != 0 {
+		t.Fatalf("error count = %d, want 0: %+v", len(result.Errors), result.Errors)
+	}
+	if len(result.File.Stmts) != 1 {
+		t.Fatalf("stmt count = %d, want 1", len(result.File.Stmts))
+	}
+	begin, ok := result.File.Stmts[0].(*ast.BeginStmt)
+	if !ok {
+		t.Fatalf("stmt[0] = %T, want *ast.BeginStmt", result.File.Stmts[0])
+	}
+	if begin.Kind != ast.BeginBare {
+		t.Errorf("kind = %v, want BeginBare", begin.Kind)
+	}
 }
 
 func TestParse_StrictVsBestEffort(t *testing.T) {
-	// INSERT now parses successfully — both statements in the input succeed.
-	// Use a BEGIN statement (still unsupported) to produce an error.
-	input := "SELECT 1; BEGIN TRANSACTION;"
+	// SELECT now parses successfully; BEGIN is now a real TCL statement too.
+	// Use a CALL statement (still unsupported) to produce the error that
+	// distinguishes strict Parse (returns first error) from ParseBestEffort
+	// (collects all errors).
+	input := "SELECT 1; CALL p();"
 
 	file, err := Parse(input)
 	if err == nil {
@@ -157,8 +172,8 @@ func TestParse_StrictVsBestEffort(t *testing.T) {
 		pe, ok := err.(*ParseError)
 		if !ok {
 			t.Errorf("Parse: expected *ParseError, got %T", err)
-		} else if !strings.Contains(pe.Msg, "BEGIN") {
-			t.Errorf("Parse: first error Msg = %q, want to contain BEGIN", pe.Msg)
+		} else if !strings.Contains(pe.Msg, "CALL") {
+			t.Errorf("Parse: first error Msg = %q, want to contain CALL", pe.Msg)
 		}
 	}
 	if file == nil {

--- a/snowflake/parser/transaction.go
+++ b/snowflake/parser/transaction.go
@@ -1,0 +1,135 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// TCL (transaction control) statements — T6.2
+//
+// Grammar (docs.snowflake.com + legacy SnowflakeParser.g4, which agree):
+//
+//	BEGIN [ { WORK | TRANSACTION } ] [ NAME <name> ]
+//	START TRANSACTION [ NAME <name> ]
+//	COMMIT [ WORK ]
+//	ROLLBACK [ WORK ]
+//
+// START TRANSACTION is a documented synonym for BEGIN. WORK after COMMIT /
+// ROLLBACK (and the WORK / TRANSACTION modifier after BEGIN) is a no-op kept
+// for cross-database compatibility. Snowflake has no SAVEPOINT, RELEASE
+// SAVEPOINT, or ROLLBACK TO — those keywords are absent from both the docs and
+// the legacy grammar, so they are not accepted here.
+//
+// Note on trailing tokens: like the rest of omni's snowflake parser (e.g.
+// parseDropStmt, parseTruncateStmt), these functions consume exactly the
+// grammar they own and do not reject extra tokens that follow a complete
+// statement — the F3 splitter is trusted to segment input, and trailing-token
+// strictness is an engine-wide concern, not enforced per node.
+// ---------------------------------------------------------------------------
+
+// parseBeginStmt parses the transaction-opening statement in its BEGIN form:
+//
+//	BEGIN [ { WORK | TRANSACTION } ] [ NAME <name> ]
+//
+// The BEGIN keyword has NOT yet been consumed when this function is called.
+func (p *Parser) parseBeginStmt() (ast.Node, error) {
+	beginTok := p.advance() // consume BEGIN
+	stmt := &ast.BeginStmt{
+		Kind: ast.BeginBare,
+		Loc:  ast.Loc{Start: beginTok.Loc.Start, End: beginTok.Loc.End},
+	}
+
+	// Optional { WORK | TRANSACTION } modifier (at most one).
+	switch p.cur.Type {
+	case kwWORK:
+		p.advance()
+		stmt.Kind = ast.BeginWork
+	case kwTRANSACTION:
+		p.advance()
+		stmt.Kind = ast.BeginTransaction
+	}
+
+	// Optional NAME <name>.
+	if err := p.parseOptionalTxnName(stmt); err != nil {
+		return nil, err
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseStartTransactionStmt parses the transaction-opening statement in its
+// START TRANSACTION form:
+//
+//	START TRANSACTION [ NAME <name> ]
+//
+// The START keyword has NOT yet been consumed when this function is called.
+// TRANSACTION is required after START (START WORK and a bare START are not
+// valid transaction openers).
+func (p *Parser) parseStartTransactionStmt() (ast.Node, error) {
+	startTok := p.advance() // consume START
+	stmt := &ast.BeginStmt{
+		Kind: ast.BeginStartTransaction,
+		Loc:  ast.Loc{Start: startTok.Loc.Start, End: startTok.Loc.End},
+	}
+
+	if _, err := p.expect(kwTRANSACTION); err != nil {
+		return nil, err
+	}
+
+	// Optional NAME <name>.
+	if err := p.parseOptionalTxnName(stmt); err != nil {
+		return nil, err
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseOptionalTxnName consumes an optional `NAME <name>` clause and stores the
+// identifier on stmt. NAME is a non-reserved keyword (kwNAME); when present it
+// MUST be followed by an identifier (a missing identifier is a parse error).
+func (p *Parser) parseOptionalTxnName(stmt *ast.BeginStmt) error {
+	if p.cur.Type != kwNAME {
+		return nil
+	}
+	p.advance() // consume NAME
+	name, err := p.parseIdent()
+	if err != nil {
+		return err
+	}
+	stmt.Name = name
+	return nil
+}
+
+// parseCommitStmt parses `COMMIT [ WORK ]`. The COMMIT keyword has NOT yet been
+// consumed when this function is called.
+func (p *Parser) parseCommitStmt() (ast.Node, error) {
+	commitTok := p.advance() // consume COMMIT
+	stmt := &ast.CommitStmt{
+		Loc: ast.Loc{Start: commitTok.Loc.Start, End: commitTok.Loc.End},
+	}
+
+	if p.cur.Type == kwWORK {
+		p.advance()
+		stmt.Work = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRollbackStmt parses `ROLLBACK [ WORK ]`. The ROLLBACK keyword has NOT
+// yet been consumed when this function is called.
+func (p *Parser) parseRollbackStmt() (ast.Node, error) {
+	rollbackTok := p.advance() // consume ROLLBACK
+	stmt := &ast.RollbackStmt{
+		Loc: ast.Loc{Start: rollbackTok.Loc.Start, End: rollbackTok.Loc.End},
+	}
+
+	if p.cur.Type == kwWORK {
+		p.advance()
+		stmt.Work = true
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/snowflake/parser/transaction_test.go
+++ b/snowflake/parser/transaction_test.go
@@ -1,0 +1,534 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func testParseBeginStmt(input string) (*ast.BeginStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.BeginStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a BeginStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseCommitStmt(input string) (*ast.CommitStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CommitStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a CommitStmt"})
+	}
+	return stmt, result.Errors
+}
+
+func testParseRollbackStmt(input string) (*ast.RollbackStmt, []ParseError) {
+	result := ParseBestEffort(input)
+	if len(result.File.Stmts) == 0 {
+		return nil, result.Errors
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.RollbackStmt)
+	if !ok {
+		return nil, append(result.Errors, ParseError{Msg: "not a RollbackStmt"})
+	}
+	return stmt, result.Errors
+}
+
+// ---------------------------------------------------------------------------
+// BEGIN tests
+//   Syntax (docs + legacy .g4):
+//     BEGIN [ { WORK | TRANSACTION } ] [ NAME <name> ]
+//     START TRANSACTION [ NAME <name> ]
+// ---------------------------------------------------------------------------
+
+func TestBegin_Bare(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginBare {
+		t.Errorf("kind = %v, want BeginBare", stmt.Kind)
+	}
+	if !stmt.Name.IsEmpty() {
+		t.Errorf("expected no NAME, got %q", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_Work(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN WORK")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginWork {
+		t.Errorf("kind = %v, want BeginWork", stmt.Kind)
+	}
+	if !stmt.Name.IsEmpty() {
+		t.Errorf("expected no NAME, got %q", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_Transaction(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN TRANSACTION")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginTransaction {
+		t.Errorf("kind = %v, want BeginTransaction", stmt.Kind)
+	}
+}
+
+func TestBegin_Name(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN NAME T1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginBare {
+		t.Errorf("kind = %v, want BeginBare", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "T1" {
+		t.Errorf("name = %q, want T1", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_WorkName(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN WORK NAME txn1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginWork {
+		t.Errorf("kind = %v, want BeginWork", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "TXN1" {
+		t.Errorf("name = %q, want TXN1", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_TransactionName(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN TRANSACTION NAME my_txn")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginTransaction {
+		t.Errorf("kind = %v, want BeginTransaction", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "MY_TXN" {
+		t.Errorf("name = %q, want MY_TXN", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_QuotedName(t *testing.T) {
+	stmt, errs := testParseBeginStmt(`BEGIN NAME "My Txn"`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Name.Quoted {
+		t.Error("expected quoted name")
+	}
+	// Quoted identifiers preserve case.
+	if stmt.Name.Normalize() != "My Txn" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "My Txn")
+	}
+}
+
+func TestBegin_StartTransaction(t *testing.T) {
+	stmt, errs := testParseBeginStmt("START TRANSACTION")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginStartTransaction {
+		t.Errorf("kind = %v, want BeginStartTransaction", stmt.Kind)
+	}
+	if !stmt.Name.IsEmpty() {
+		t.Errorf("expected no NAME, got %q", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_StartTransactionName(t *testing.T) {
+	stmt, errs := testParseBeginStmt("START TRANSACTION NAME T2")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginStartTransaction {
+		t.Errorf("kind = %v, want BeginStartTransaction", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "T2" {
+		t.Errorf("name = %q, want T2", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_Lowercase(t *testing.T) {
+	stmt, errs := testParseBeginStmt("begin transaction name t1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginTransaction {
+		t.Errorf("kind = %v, want BeginTransaction", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "T1" {
+		t.Errorf("name = %q, want T1", stmt.Name.Normalize())
+	}
+}
+
+func TestBegin_Loc(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN TRANSACTION NAME t1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	// End is the exclusive byte offset just past the final token ("t1").
+	if stmt.Loc.End != len("BEGIN TRANSACTION NAME t1") {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len("BEGIN TRANSACTION NAME t1"))
+	}
+}
+
+// Trailing-junk leniency: like every other omni snowflake statement parser
+// (verified against parseDropStmt / parseTruncateStmt / parseUseStmt, which all
+// accept "<stmt> junk" with zero errors), parseBeginStmt consumes exactly the
+// grammar it owns and leaves any trailing tokens unconsumed without raising an
+// error. Real Snowflake rejects "BEGIN FOO" as a syntax error; omni's
+// engine-wide convention is to trust the F3 splitter and not enforce
+// trailing-token strictness per node. This is a pre-existing engine-wide
+// divergence (recorded in the divergence ledger), not specific to TCL. The
+// statement still parses to the correct BeginStmt with the right Kind.
+func TestBegin_TrailingJunkLenient(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN FOO")
+	if len(errs) != 0 {
+		t.Fatalf("BEGIN FOO: expected lenient parse (engine-wide convention), got errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginBare {
+		t.Errorf("kind = %v, want BeginBare", stmt.Kind)
+	}
+	if !stmt.Name.IsEmpty() {
+		t.Errorf("expected no NAME (FOO is trailing junk, not consumed), got %q", stmt.Name.Normalize())
+	}
+}
+
+// Trailing junk after a complete BEGIN WORK: TRANSACTION is left unconsumed
+// (WORK and TRANSACTION are mutually exclusive; at most one modifier is part of
+// the grammar). Lenient parse per engine-wide convention.
+func TestBegin_WorkTransactionLenient(t *testing.T) {
+	stmt, errs := testParseBeginStmt("BEGIN WORK TRANSACTION")
+	if len(errs) != 0 {
+		t.Fatalf("BEGIN WORK TRANSACTION: expected lenient parse, got errors: %v", errs)
+	}
+	if stmt.Kind != ast.BeginWork {
+		t.Errorf("kind = %v, want BeginWork (TRANSACTION is trailing junk)", stmt.Kind)
+	}
+}
+
+// Negative (real grammar error this node owns): NAME keyword with no following
+// identifier. parseIdent fails, so the whole statement fails.
+func TestBegin_NegativeNameMissingIdent(t *testing.T) {
+	_, errs := testParseBeginStmt("BEGIN NAME")
+	if len(errs) == 0 {
+		t.Fatal("expected error for BEGIN NAME (missing identifier), got none")
+	}
+}
+
+// Negative (real grammar error): START without TRANSACTION is not a valid
+// transaction opener — expect(kwTRANSACTION) fails.
+func TestBegin_NegativeStartWithoutTransaction(t *testing.T) {
+	_, errs := testParseBeginStmt("START")
+	if len(errs) == 0 {
+		t.Fatal("expected error for bare START, got none")
+	}
+}
+
+// Negative (real grammar error): START WORK is invalid — only START TRANSACTION
+// is documented; expect(kwTRANSACTION) fails on WORK.
+func TestBegin_NegativeStartWork(t *testing.T) {
+	_, errs := testParseBeginStmt("START WORK")
+	if len(errs) == 0 {
+		t.Fatal("expected error for START WORK, got none")
+	}
+}
+
+// Negative (real grammar error): START TRANSACTION NAME with no following
+// identifier — the NAME clause inside the START-form requires an identifier.
+func TestBegin_NegativeStartTransactionNameMissingIdent(t *testing.T) {
+	_, errs := testParseBeginStmt("START TRANSACTION NAME")
+	if len(errs) == 0 {
+		t.Fatal("expected error for START TRANSACTION NAME (missing identifier), got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// COMMIT tests
+//   Syntax: COMMIT [ WORK ]
+// ---------------------------------------------------------------------------
+
+func TestCommit_Bare(t *testing.T) {
+	stmt, errs := testParseCommitStmt("COMMIT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Work {
+		t.Error("expected Work=false")
+	}
+}
+
+func TestCommit_Work(t *testing.T) {
+	stmt, errs := testParseCommitStmt("COMMIT WORK")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Work {
+		t.Error("expected Work=true")
+	}
+}
+
+func TestCommit_Lowercase(t *testing.T) {
+	stmt, errs := testParseCommitStmt("commit work")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Work {
+		t.Error("expected Work=true")
+	}
+}
+
+func TestCommit_Loc(t *testing.T) {
+	stmt, errs := testParseCommitStmt("COMMIT WORK")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len("COMMIT WORK") {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len("COMMIT WORK"))
+	}
+}
+
+func TestCommit_BareLoc(t *testing.T) {
+	stmt, errs := testParseCommitStmt("COMMIT")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.End != len("COMMIT") {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len("COMMIT"))
+	}
+}
+
+// Trailing-junk leniency (engine-wide convention): a junk token after
+// COMMIT [WORK] is left unconsumed without error. Real Snowflake rejects
+// "COMMIT FOO"; omni does not enforce trailing-token strictness per node.
+func TestCommit_TrailingJunkLenient(t *testing.T) {
+	stmt, errs := testParseCommitStmt("COMMIT FOO")
+	if len(errs) != 0 {
+		t.Fatalf("COMMIT FOO: expected lenient parse, got errors: %v", errs)
+	}
+	if stmt.Work {
+		t.Error("expected Work=false (FOO is trailing junk, not WORK)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ROLLBACK tests
+//   Syntax: ROLLBACK [ WORK ]
+// ---------------------------------------------------------------------------
+
+func TestRollback_Bare(t *testing.T) {
+	stmt, errs := testParseRollbackStmt("ROLLBACK")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Work {
+		t.Error("expected Work=false")
+	}
+}
+
+func TestRollback_Work(t *testing.T) {
+	stmt, errs := testParseRollbackStmt("ROLLBACK WORK")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Work {
+		t.Error("expected Work=true")
+	}
+}
+
+func TestRollback_Lowercase(t *testing.T) {
+	stmt, errs := testParseRollbackStmt("rollback")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Work {
+		t.Error("expected Work=false")
+	}
+}
+
+func TestRollback_Loc(t *testing.T) {
+	stmt, errs := testParseRollbackStmt("ROLLBACK WORK")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len("ROLLBACK WORK") {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len("ROLLBACK WORK"))
+	}
+}
+
+// ROLLBACK TO [SAVEPOINT] is NOT supported by Snowflake — SAVEPOINT appears in
+// neither the docs nor the legacy .g4, and WORK is the only modifier ROLLBACK
+// accepts. The grammar therefore does NOT consume "TO SAVEPOINT sp1"; per the
+// engine-wide trailing-token convention those tokens are left unconsumed
+// without error, and only the leading ROLLBACK is captured. The important
+// spec property — Snowflake has no savepoints, so omni must not grow a
+// ROLLBACK-TO-SAVEPOINT form — holds: Work stays false and no SAVEPOINT branch
+// exists.
+func TestRollback_ToSavepointNotConsumed(t *testing.T) {
+	stmt, errs := testParseRollbackStmt("ROLLBACK TO SAVEPOINT sp1")
+	if len(errs) != 0 {
+		t.Fatalf("ROLLBACK TO SAVEPOINT sp1: expected lenient parse, got errors: %v", errs)
+	}
+	if stmt.Work {
+		t.Error("expected Work=false (TO is not WORK; no savepoint support)")
+	}
+	// Loc must end right after ROLLBACK, proving TO SAVEPOINT sp1 was not part
+	// of the statement.
+	if stmt.Loc.End != len("ROLLBACK") {
+		t.Errorf("Loc.End = %d, want %d (only ROLLBACK consumed)", stmt.Loc.End, len("ROLLBACK"))
+	}
+}
+
+// Trailing-junk leniency (engine-wide convention): ROLLBACK FOO.
+func TestRollback_TrailingJunkLenient(t *testing.T) {
+	stmt, errs := testParseRollbackStmt("ROLLBACK FOO")
+	if len(errs) != 0 {
+		t.Fatalf("ROLLBACK FOO: expected lenient parse, got errors: %v", errs)
+	}
+	if stmt.Work {
+		t.Error("expected Work=false (FOO is trailing junk, not WORK)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-statement: a transaction-bracketed block parses every statement.
+// ---------------------------------------------------------------------------
+
+func TestTransaction_MultiStatement(t *testing.T) {
+	sql := "BEGIN; COMMIT;"
+	result := ParseBestEffort(sql)
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.File.Stmts) != 2 {
+		t.Fatalf("got %d statements, want 2", len(result.File.Stmts))
+	}
+	if _, ok := result.File.Stmts[0].(*ast.BeginStmt); !ok {
+		t.Errorf("stmt[0] = %T, want *ast.BeginStmt", result.File.Stmts[0])
+	}
+	if _, ok := result.File.Stmts[1].(*ast.CommitStmt); !ok {
+		t.Errorf("stmt[1] = %T, want *ast.CommitStmt", result.File.Stmts[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Corpus — official docs (truth1, authoritative) + legacy (truth2, regression)
+//
+// Oracle agreement: docs.snowflake.com BEGIN/COMMIT/ROLLBACK pages and the
+// legacy SnowflakeParser.g4 begin_txn/commit/rollback rules agree exactly on
+// the grammar, so the corpus is a pure accept-test. Statements owned by other
+// nodes (SHOW TRANSACTIONS, SELECT CURRENT_TRANSACTION(), etc.) are skipped.
+// ---------------------------------------------------------------------------
+
+// txnCorpusDirs are official-docs corpora whose transaction-control statements
+// are owned by this node. Other statements in these files (SHOW TRANSACTIONS,
+// SELECT ...) are skipped as context.
+var txnCorpusDirs = []string{
+	"testdata/official/begin",
+}
+
+func TestTransaction_OfficialCorpus(t *testing.T) {
+	for _, dir := range txnCorpusDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read corpus dir %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			t.Run(path, func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				assertTxnStatementsParse(t, string(data))
+			})
+		}
+	}
+}
+
+// TestTransaction_LegacyCorpus exercises the COMMIT / ROLLBACK examples in the
+// legacy other.sql file (the only legacy corpus file with standalone TCL
+// statements). Statements owned by other nodes are skipped.
+func TestTransaction_LegacyCorpus(t *testing.T) {
+	path := "testdata/legacy/other.sql"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	assertTxnStatementsParse(t, string(data))
+}
+
+// assertTxnStatementsParse parses sql and asserts that every transaction-control
+// statement (BEGIN / START TRANSACTION / COMMIT / ROLLBACK) parses with no
+// errors and to the expected AST type. Statements owned by other DAG nodes are
+// skipped.
+func assertTxnStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+
+		// Identify the statements this node owns.
+		owned := strings.HasPrefix(upper, "BEGIN") ||
+			strings.HasPrefix(upper, "START TRANSACTION") ||
+			strings.HasPrefix(upper, "COMMIT") ||
+			strings.HasPrefix(upper, "ROLLBACK")
+		if !owned {
+			continue
+		}
+
+		result := ParseBestEffort(text)
+		if len(result.Errors) > 0 {
+			t.Errorf("statement %q: unexpected errors: %v", text, result.Errors)
+			continue
+		}
+		if len(result.File.Stmts) == 0 {
+			t.Errorf("statement %q: produced no AST node", text)
+			continue
+		}
+		switch result.File.Stmts[0].(type) {
+		case *ast.BeginStmt, *ast.CommitStmt, *ast.RollbackStmt:
+			// expected
+		default:
+			t.Errorf("statement %q: got %T, want a TCL statement node", text, result.File.Stmts[0])
+		}
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/tcl` (v1 DAG **T6.2**) — transaction control. Replaces the four `p.unsupported(...)` TCL stubs in `parseStmt` with real parsers.

## Forms
- `BEGIN [ { WORK | TRANSACTION } ] [ NAME <name> ]`
- `START TRANSACTION [ NAME <name> ]` (documented synonym of BEGIN)
- `COMMIT [ WORK ]`
- `ROLLBACK [ WORK ]`

New AST: `BeginStmt` (unifies BEGIN + START TRANSACTION via a `BeginKind` enum), `CommitStmt{Work}`, `RollbackStmt{Work}` — matching the legacy `begin_txn`/`commit`/`rollback` grain. `Name` is an `Ident` value (no Node child) so `walk_generated.go` needs no change. **Scope confirmed against the oracle:** Snowflake has **no** SAVEPOINT / RELEASE SAVEPOINT / ROLLBACK TO (absent from docs, the legacy `.g4`, and the keyword table) — not accepted.

## Oracle / tests
Triangulation — official docs (authoritative; begin/commit/rollback) + legacy ANTLR `begin_txn`/`commit`/`rollback` (agree exactly) + corpus (`testdata/official/begin/*`, legacy `commit;`/`rollback;`). **100% coverage** on `transaction.go` (every form × WORK/TRANSACTION/NAME optionals, quoted/lowercase names, Loc spans, multi-statement, + grammar negatives). `go build`/`go vet`/`go test ./snowflake/parser/... ./snowflake/ast/...` green.

## Divergences (flagged)
1. **Trailing-token leniency** — `COMMIT FOO` / `BEGIN FOO` parse the leading statement and leave junk unconsumed with 0 errors. **Pre-existing, engine-wide** (`parseSingle` trusts the F3 splitter, never asserts EOF — identical for DROP/TRUNCATE/USE); not introduced here.
2. **`BEGIN..END` scripting opener** — F3 keeps `BEGIN … END;` as one segment; TCL `BEGIN` consumes the opener → a bare `BeginStmt`, body unconsumed, 0 errors. Snowflake Scripting `BEGIN..END` is the separate Tier 7 (`scripting`) node; this is the documented intermediate state until it lands.

## Out-of-scope writes (recorded, necessary)
- `snowflake/parser/parser_test.go` — 2 pre-existing tests asserted `BEGIN` was *unsupported*; updated since it now parses (`…OneError`→`…OneSegment`; strict-vs-besteffort error trigger switched to `CALL p()`).
- `snowflake/ast/ast_test.go` — added TCL node tag/String/walk tests.

## Review
Claude lens (`/code-review` high) — no blockers (one candidate re: `ast.NodeLoc` reviewed + dismissed: no statement node is registered there, only expression/query nodes). Codex lens unavailable (out of credits); orchestrator did independent build/test/scope verification + confirmed the out-of-scope test changes are exactly the BEGIN-now-supported updates.

## Note
Opened by orchestrator from the worker's verified commit `125a00bd`. No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)