### PR TITLE
feat(trino/completion): parser-native SQL auto-completion (v2 node trino/completion)

### DIFF
--- a/trino/completion/candidates.go
+++ b/trino/completion/candidates.go
@@ -1,0 +1,181 @@
+package completion
+
+import (
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// candidatesFor produces the candidate list for a classified context. sql and
+// scanLimit identify the caret (with the partial word stripped) so column
+// contexts can resolve the in-scope tables via query-span analysis. cat may be
+// nil.
+func candidatesFor(ctx completionContext, sql string, scanLimit int, cat *catalog.Catalog) []Candidate {
+	switch ctx.kind {
+	case kindStatementStart:
+		return keywordCandidates(statementStartKeywords)
+	case kindRelation:
+		return relationCandidates(sql, scanLimit, cat)
+	case kindColumnOrExpr:
+		return append(columnCandidates(sql, scanLimit, cat), keywordCandidates(expressionKeywords)...)
+	case kindColumnOnly:
+		// Assignment target (UPDATE ... SET): columns only, no expression keywords.
+		return columnCandidates(sql, scanLimit, cat)
+	case kindDottedName:
+		return dottedCandidates(ctx.qualifier, sql, scanLimit, cat)
+	default: // kindKeyword
+		return keywordCandidates(clauseKeywords)
+	}
+}
+
+// keywordCandidates wraps a keyword list as Candidates.
+func keywordCandidates(words []string) []Candidate {
+	result := make([]Candidate, 0, len(words))
+	for _, w := range words {
+		result = append(result, Candidate{Text: w, Type: CandidateKeyword})
+	}
+	return result
+}
+
+// relationCandidates offers the table/view names visible in the session schema,
+// plus schema names in the session catalog and all catalog names, so the user
+// can either pick a relation directly or drill down a qualifier. CTE names
+// defined earlier in the statement are added as table candidates (a CTE is a
+// relation you can select FROM). cat may be nil, in which case only CTE names
+// from the statement are returned.
+func relationCandidates(sql string, scanLimit int, cat *catalog.Catalog) []Candidate {
+	var result []Candidate
+	if cat != nil {
+		// All catalog names (top-level qualifier drill-down).
+		for _, name := range cat.Catalogs() {
+			result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(name), Type: CandidateCatalog})
+		}
+		// Schemas + relations in the session catalog/schema.
+		if cur := cat.CurrentCatalog(); cur != "" {
+			if db := cat.GetCatalog(cur); db != nil {
+				for _, sname := range db.Schemas() {
+					result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(sname), Type: CandidateSchema})
+				}
+				if cs := cat.CurrentSchema(); cs != "" {
+					if sch := db.GetSchema(cs); sch != nil {
+						result = append(result, relationsOf(sch)...)
+					}
+				}
+			}
+		}
+	}
+	// CTE names declared in this statement are select-able relations.
+	for _, name := range cteNames(sql, scanLimit) {
+		result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(name), Type: CandidateTable})
+	}
+	return result
+}
+
+// relationsOf returns the table and view candidates of a schema.
+func relationsOf(sch *catalog.Schema) []Candidate {
+	var result []Candidate
+	for _, name := range sch.Tables() {
+		result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(name), Type: CandidateTable})
+	}
+	for _, name := range sch.Views() {
+		result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(name), Type: CandidateView})
+	}
+	return result
+}
+
+// columnCandidates offers the columns of every table/view in scope at the
+// caret. Scope is derived from the statement's FROM clauses via query-span
+// analysis (trino/analysis), which yields the accessed tables; each is resolved
+// against the catalog to its column list. When no catalog is available, or no
+// table resolves, the result is empty (and the caller still offers expression
+// keywords). cat may be nil.
+func columnCandidates(sql string, scanLimit int, cat *catalog.Catalog) []Candidate {
+	if cat == nil {
+		return nil
+	}
+	var result []Candidate
+	for _, names := range inScopeColumnNames(sql, scanLimit, cat) {
+		for _, c := range names {
+			result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(c), Type: CandidateColumn})
+		}
+	}
+	return result
+}
+
+// dottedCandidates resolves a qualifier chain ("<parts> .") to its drill-down
+// candidates:
+//
+//   - 1 part [x]:
+//     x as a table/alias in the FROM scope -> its columns;
+//     x as a schema in the session catalog -> its relations;
+//     x as a catalog                        -> its schemas.
+//     All matching interpretations are offered (the caret is ambiguous).
+//   - 2 parts [x, y]:
+//     x.y as catalog.schema -> relations of that schema;
+//     x.y as schema.table   -> columns of that table (session catalog).
+//   - 3 parts [x, y, z]: x.y.z as catalog.schema.table -> its columns.
+//
+// cat may be nil, in which case only the FROM-scope alias interpretation (which
+// needs the catalog too) is unavailable and the result is empty.
+func dottedCandidates(qualifier []string, sql string, scanLimit int, cat *catalog.Catalog) []Candidate {
+	if cat == nil || len(qualifier) == 0 {
+		return nil
+	}
+	var result []Candidate
+
+	switch len(qualifier) {
+	case 1:
+		x := qualifier[0]
+		// (a) table/alias in scope -> columns.
+		if names, ok := scopeColumnsFor(sql, scanLimit, cat, x); ok {
+			for _, c := range names {
+				result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(c), Type: CandidateColumn})
+			}
+		}
+		// (b) schema in the session catalog -> relations.
+		if cur := cat.CurrentCatalog(); cur != "" {
+			if db := cat.GetCatalog(cur); db != nil {
+				if sch := db.GetSchema(x); sch != nil {
+					result = append(result, relationsOf(sch)...)
+				}
+			}
+		}
+		// (c) catalog -> schemas.
+		if db := cat.GetCatalog(x); db != nil {
+			for _, sname := range db.Schemas() {
+				result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(sname), Type: CandidateSchema})
+			}
+		}
+
+	case 2:
+		// (a) catalog.schema -> relations.
+		if db := cat.GetCatalog(qualifier[0]); db != nil {
+			if sch := db.GetSchema(qualifier[1]); sch != nil {
+				result = append(result, relationsOf(sch)...)
+			}
+		}
+		// (b) schema.table (session catalog) -> columns.
+		if cur := cat.CurrentCatalog(); cur != "" {
+			result = append(result, columnsOfRelation(cat, []string{qualifier[0], qualifier[1]})...)
+		}
+
+	case 3:
+		// catalog.schema.table -> columns.
+		result = append(result, columnsOfRelation(cat, qualifier)...)
+	}
+
+	return result
+}
+
+// columnsOfRelation resolves parts to a relation and returns its column
+// candidates, or nil if it does not resolve.
+func columnsOfRelation(cat *catalog.Catalog, parts []string) []Candidate {
+	rr := cat.ResolveRelation(parts)
+	if !rr.Found {
+		return nil
+	}
+	names := rr.ColumnNames()
+	result := make([]Candidate, 0, len(names))
+	for _, c := range names {
+		result = append(result, Candidate{Text: QuoteIdentifierIfNeeded(c), Type: CandidateColumn})
+	}
+	return result
+}

--- a/trino/completion/completion.go
+++ b/trino/completion/completion.go
@@ -1,0 +1,183 @@
+// Package completion provides parser-native auto-complete candidates for Trino
+// SQL, the omni counterpart of bytebase's plugin/parser/trino Completion.
+//
+// # Why this is not a C3 port
+//
+// The bytebase Trino completer is a ~1730-line CodeCompletionCore (c3 /
+// follow-set) implementation that walks the ANTLR parser's rule indices. The
+// omni Trino parser is a hand-written recursive-descent parser that was not
+// built with c3 instrumentation (no rule-candidate collection hooks), and this
+// node may only touch trino/completion/*.go — it cannot weave collection points
+// through trino/parser. So, like omni's mongo and partiql completers, this
+// package is self-contained: it tokenizes the input up to the caret with the
+// exported lexer, classifies the completion context from the token sequence,
+// and produces candidates from the three-level Trino catalog
+// (catalog -> schema -> table/view -> column) plus a curated keyword set.
+//
+// FROM-clause column candidates are resolved the same way bytebase's completer
+// ultimately resolves them — through query-span analysis (trino/analysis):
+// GetQuerySpan yields the tables a SELECT reads, which the catalog maps to
+// column candidates. This keeps the candidate *set* faithful to the legacy
+// completer's semantics even though the mechanism differs.
+//
+// The package depends only on trino/parser (lexer + identifier helpers),
+// trino/catalog (object metadata), and trino/analysis (FROM-scope resolution).
+package completion
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// CandidateType classifies a completion candidate so a consumer (LSP) can pick
+// an icon / sort bucket. The values mirror the candidate kinds the bytebase
+// Trino completer emits: keyword, catalog (database), schema, table, view,
+// column. Functions are categorized by the legacy completer but its function
+// table is never populated, so this package does not emit function candidates.
+type CandidateType int
+
+const (
+	// CandidateKeyword is a SQL keyword (SELECT, FROM, JOIN, ...).
+	CandidateKeyword CandidateType = iota
+	// CandidateCatalog is a Trino catalog name (the top namespace level).
+	CandidateCatalog
+	// CandidateSchema is a schema name within a catalog.
+	CandidateSchema
+	// CandidateTable is a base-table name.
+	CandidateTable
+	// CandidateView is a view (or materialized view) name.
+	CandidateView
+	// CandidateColumn is a column name of an in-scope table/view/CTE.
+	CandidateColumn
+)
+
+// String returns the lower-case kind name, handy for tests and logging.
+func (t CandidateType) String() string {
+	switch t {
+	case CandidateKeyword:
+		return "keyword"
+	case CandidateCatalog:
+		return "catalog"
+	case CandidateSchema:
+		return "schema"
+	case CandidateTable:
+		return "table"
+	case CandidateView:
+		return "view"
+	case CandidateColumn:
+		return "column"
+	default:
+		return "unknown"
+	}
+}
+
+// Candidate is a single completion suggestion. Text is the completion string
+// (already quoted when the identifier needs quoting, via QuoteIdentifierIfNeeded
+// at the call sites that emit catalog object names).
+type Candidate struct {
+	// Text is the suggestion to insert.
+	Text string
+	// Type classifies the suggestion.
+	Type CandidateType
+}
+
+// Complete returns completion candidates for sql at byte offset cursorOffset.
+// cat may be nil, in which case only keyword candidates (and CTE names found in
+// the statement text) are produced — object candidates need catalog metadata.
+//
+// The cursorOffset is clamped into [0, len(sql)]; Complete never panics on an
+// out-of-range offset (it is exported and a stale LSP caret may overrun the
+// text). Candidates are returned sorted by (Type, Text) and de-duplicated, and
+// filtered to those whose Text matches the partial word under the caret
+// (case-insensitively — Trino folds unquoted identifiers and keywords to lower
+// case, so a lower-case prefix must match a Candidate regardless of its case).
+func Complete(sql string, cursorOffset int, cat *catalog.Catalog) []Candidate {
+	if cursorOffset > len(sql) {
+		cursorOffset = len(sql)
+	}
+	if cursorOffset < 0 {
+		cursorOffset = 0
+	}
+
+	// The partial word under the caret is stripped before context detection so
+	// the lexer sees the position *before* the partial text: completing
+	// "... FROM ord|" must classify as a FROM context (offering tables), not as
+	// "inside an identifier". The stripped word becomes the prefix filter.
+	prefix := extractPrefix(sql, cursorOffset)
+	scanLimit := cursorOffset - len(prefix)
+
+	ctx := detectContext(sql, scanLimit)
+	candidates := candidatesFor(ctx, sql, scanLimit, cat)
+
+	return filterByPrefix(dedup(candidates), prefix)
+}
+
+// extractPrefix returns the partial identifier word ending at cursorOffset.
+// A Trino unquoted identifier is (LETTER|'_')(LETTER|DIGIT|'_')*; we also accept
+// a leading digit so a digit-leading identifier (DIGIT_IDENTIFIER_) being typed
+// is treated as a prefix rather than a number. The prefix never includes a '.',
+// so "schema." yields an empty prefix (the caret is positioned to complete the
+// object after the dot).
+func extractPrefix(sql string, cursorOffset int) string {
+	i := cursorOffset
+	for i > 0 && isIdentByte(sql[i-1]) {
+		i--
+	}
+	return sql[i:cursorOffset]
+}
+
+// isIdentByte reports whether c can appear in an unquoted/digit Trino identifier.
+func isIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '_'
+}
+
+// filterByPrefix keeps candidates whose Text has prefix as a case-insensitive
+// prefix. An empty prefix keeps everything. Matching is case-insensitive
+// because Trino folds unquoted names to lower case: a user typing "ORD" or
+// "ord" should both match a table candidate "orders".
+func filterByPrefix(candidates []Candidate, prefix string) []Candidate {
+	if prefix == "" {
+		return candidates
+	}
+	upper := strings.ToUpper(prefix)
+	result := candidates[:0:0]
+	for _, c := range candidates {
+		if strings.HasPrefix(strings.ToUpper(c.Text), upper) {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// dedup removes duplicate (Text, Type) pairs and returns the survivors sorted by
+// (Type, Text). De-duplication keys on the EXACT Text, not a case-folded form:
+// two quoted identifiers that differ only in case ("Foo" vs "foo") are distinct
+// Trino objects and must both survive. Names that genuinely coincide already
+// share an identical (normalized, then quoted) Text, so exact-match dedup still
+// collapses the catalog-and-CTE-both-surface case.
+func dedup(candidates []Candidate) []Candidate {
+	type key struct {
+		text string
+		typ  CandidateType
+	}
+	seen := make(map[key]struct{}, len(candidates))
+	result := make([]Candidate, 0, len(candidates))
+	for _, c := range candidates {
+		k := key{c.Text, c.Type}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		result = append(result, c)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Type != result[j].Type {
+			return result[i].Type < result[j].Type
+		}
+		return result[i].Text < result[j].Text
+	})
+	return result
+}

--- a/trino/completion/completion_test.go
+++ b/trino/completion/completion_test.go
@@ -1,0 +1,414 @@
+package completion
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// buildCatalog constructs a small Trino catalog mirroring the oracle's shape:
+// a "tpch" catalog with a "sf1" schema holding "orders" and "customer" tables
+// and a "v_orders" view, and a "memory" catalog with a "default" schema. The
+// session defaults to tpch.sf1 so unqualified names resolve there.
+func buildCatalog() *catalog.Catalog {
+	cat := catalog.New()
+
+	tpch := cat.EnsureCatalog("tpch")
+	sf1 := tpch.EnsureSchema("sf1")
+	sf1.AddTable("orders",
+		catalog.NewColumn("orderkey", "bigint", false),
+		catalog.NewColumn("custkey", "bigint", false),
+		catalog.NewColumn("orderstatus", "varchar(1)", true),
+		catalog.NewColumn("totalprice", "double", true),
+	)
+	sf1.AddTable("customer",
+		catalog.NewColumn("custkey", "bigint", false),
+		catalog.NewColumn("name", "varchar(25)", true),
+		catalog.NewColumn("nationkey", "bigint", true),
+	)
+	sf1.AddView("v_orders",
+		catalog.NewColumn("orderkey", "bigint", false),
+		catalog.NewColumn("custname", "varchar(25)", true),
+	)
+
+	mem := cat.EnsureCatalog("memory")
+	mem.EnsureSchema("default").AddTable("kv",
+		catalog.NewColumn("k", "varchar", true),
+		catalog.NewColumn("v", "varchar", true),
+	)
+
+	cat.SetCurrentCatalog("tpch")
+	cat.SetCurrentSchema("sf1")
+	return cat
+}
+
+// texts extracts the Text of every candidate of the given type.
+func texts(cands []Candidate, typ CandidateType) []string {
+	var out []string
+	for _, c := range cands {
+		if c.Type == typ {
+			out = append(out, c.Text)
+		}
+	}
+	return out
+}
+
+// has reports whether any candidate of the given type has the given text.
+func has(cands []Candidate, typ CandidateType, text string) bool {
+	for _, c := range cands {
+		if c.Type == typ && c.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+// hasText reports whether any candidate (any type) has the given text.
+func hasText(cands []Candidate, text string) bool {
+	for _, c := range cands {
+		if c.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+func TestComplete_StatementStart(t *testing.T) {
+	cat := buildCatalog()
+	for _, tc := range []struct {
+		name string
+		sql  string
+		pos  int
+	}{
+		{"empty", "", 0},
+		{"after_semicolon", "SELECT 1; ", len("SELECT 1; ")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Complete(tc.sql, tc.pos, cat)
+			for _, kw := range []string{"SELECT", "INSERT", "CREATE", "WITH", "EXPLAIN"} {
+				if !has(got, CandidateKeyword, kw) {
+					t.Errorf("statement-start completion missing keyword %q; got keywords %v", kw, texts(got, CandidateKeyword))
+				}
+			}
+			// No object candidates at a bare statement start.
+			if cols := texts(got, CandidateColumn); len(cols) != 0 {
+				t.Errorf("statement start offered columns %v, want none", cols)
+			}
+		})
+	}
+}
+
+func TestComplete_StatementStartPrefix(t *testing.T) {
+	got := Complete("SEL", 3, buildCatalog())
+	if !has(got, CandidateKeyword, "SELECT") {
+		t.Fatalf("Complete(\"SEL\") should offer SELECT; got %v", got)
+	}
+	for _, c := range got {
+		if !strings.HasPrefix(strings.ToUpper(c.Text), "SEL") {
+			t.Errorf("candidate %q does not match prefix SEL", c.Text)
+		}
+	}
+}
+
+func TestComplete_AfterFrom(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM "
+	got := Complete(sql, len(sql), cat)
+
+	// Tables and the view in the session schema.
+	for _, name := range []string{"orders", "customer"} {
+		if !has(got, CandidateTable, name) {
+			t.Errorf("after FROM missing table %q; tables=%v", name, texts(got, CandidateTable))
+		}
+	}
+	if !has(got, CandidateView, "v_orders") {
+		t.Errorf("after FROM missing view v_orders; views=%v", texts(got, CandidateView))
+	}
+	// Catalog names (drill-down) and the session schema name.
+	if !has(got, CandidateCatalog, "tpch") || !has(got, CandidateCatalog, "memory") {
+		t.Errorf("after FROM missing catalog candidates; catalogs=%v", texts(got, CandidateCatalog))
+	}
+	if !has(got, CandidateSchema, "sf1") {
+		t.Errorf("after FROM missing schema sf1; schemas=%v", texts(got, CandidateSchema))
+	}
+}
+
+func TestComplete_AfterFromPrefix(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM cus"
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "customer") {
+		t.Fatalf("FROM cus should complete customer; got %v", got)
+	}
+	if has(got, CandidateTable, "orders") {
+		t.Errorf("FROM cus should not offer orders (prefix mismatch); got %v", texts(got, CandidateTable))
+	}
+}
+
+func TestComplete_AfterJoin(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM orders o JOIN "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "customer") {
+		t.Errorf("after JOIN missing table customer; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestComplete_SelectColumns(t *testing.T) {
+	cat := buildCatalog()
+	// Caret right after SELECT, FROM clause to the right.
+	sql := "SELECT  FROM orders"
+	got := Complete(sql, len("SELECT "), cat)
+	for _, col := range []string{"orderkey", "custkey", "orderstatus", "totalprice"} {
+		if !has(got, CandidateColumn, col) {
+			t.Errorf("SELECT col context missing column %q; columns=%v", col, texts(got, CandidateColumn))
+		}
+	}
+	// Expression keywords are also offered here.
+	if !has(got, CandidateKeyword, "CASE") {
+		t.Errorf("SELECT col context should offer expression keyword CASE; keywords=%v", texts(got, CandidateKeyword))
+	}
+}
+
+func TestComplete_WhereColumns(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM customer WHERE "
+	got := Complete(sql, len(sql), cat)
+	for _, col := range []string{"custkey", "name", "nationkey"} {
+		if !has(got, CandidateColumn, col) {
+			t.Errorf("WHERE context missing column %q; columns=%v", col, texts(got, CandidateColumn))
+		}
+	}
+	// Columns of an out-of-scope table must NOT appear.
+	if has(got, CandidateColumn, "totalprice") {
+		t.Errorf("WHERE on customer offered orders column totalprice; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestComplete_JoinOnColumns(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM orders o JOIN customer c ON "
+	got := Complete(sql, len(sql), cat)
+	// Both tables are in scope: columns from each appear.
+	if !has(got, CandidateColumn, "orderkey") {
+		t.Errorf("ON context missing orders column orderkey; columns=%v", texts(got, CandidateColumn))
+	}
+	if !has(got, CandidateColumn, "name") {
+		t.Errorf("ON context missing customer column name; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestComplete_DottedAliasColumns(t *testing.T) {
+	cat := buildCatalog()
+	// Alias-qualified: o.<caret> must offer ONLY orders' columns. The select
+	// list is complete (*) so the only incomplete clause is the predicate at the
+	// caret, which the placeholder fills.
+	sql := "SELECT * FROM orders o WHERE o."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "orderkey") || !has(got, CandidateColumn, "totalprice") {
+		t.Errorf("o. should offer orders columns; columns=%v", texts(got, CandidateColumn))
+	}
+	if has(got, CandidateColumn, "name") {
+		t.Errorf("o. (orders alias) should not offer customer column name; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestComplete_DottedTableNameColumns(t *testing.T) {
+	cat := buildCatalog()
+	// Table-name-qualified (no alias): orders.<caret>.
+	sql := "SELECT * FROM orders WHERE orders."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "orderkey") {
+		t.Errorf("orders. should offer orders columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestComplete_DottedCatalogSchemas(t *testing.T) {
+	cat := buildCatalog()
+	// "tpch." → schemas of the tpch catalog.
+	sql := "SELECT * FROM tpch."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateSchema, "sf1") {
+		t.Errorf("tpch. should offer schema sf1; schemas=%v", texts(got, CandidateSchema))
+	}
+}
+
+func TestComplete_DottedSchemaRelations(t *testing.T) {
+	cat := buildCatalog()
+	// "sf1." (schema in the session catalog) → relations of sf1.
+	sql := "SELECT * FROM sf1."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "orders") || !has(got, CandidateTable, "customer") {
+		t.Errorf("sf1. should offer its tables; tables=%v", texts(got, CandidateTable))
+	}
+	if !has(got, CandidateView, "v_orders") {
+		t.Errorf("sf1. should offer its view; views=%v", texts(got, CandidateView))
+	}
+}
+
+func TestComplete_DottedCatalogSchemaRelations(t *testing.T) {
+	cat := buildCatalog()
+	// "tpch.sf1." → relations of tpch.sf1.
+	sql := "SELECT * FROM tpch.sf1."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "orders") {
+		t.Errorf("tpch.sf1. should offer table orders; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestComplete_DottedQualifiedColumns(t *testing.T) {
+	cat := buildCatalog()
+	// "tpch.sf1.orders." appearing in a WHERE → columns of orders.
+	sql := "SELECT * FROM tpch.sf1.orders WHERE tpch.sf1.orders."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "orderkey") {
+		t.Errorf("tpch.sf1.orders. should offer column orderkey; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestComplete_CTEAsRelation(t *testing.T) {
+	cat := buildCatalog()
+	// A CTE defined earlier is select-able after FROM.
+	sql := "WITH recent AS (SELECT * FROM orders) SELECT * FROM "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "recent") {
+		t.Errorf("FROM after a WITH should offer the CTE name 'recent'; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestComplete_NilCatalog(t *testing.T) {
+	// With no catalog, keyword completion still works and nothing panics.
+	got := Complete("SELECT * FROM ", len("SELECT * FROM "), nil)
+	// CTE names would still be offered, but there are none here; the result may
+	// be empty. The contract is "no panic, no object candidates".
+	for _, c := range got {
+		if c.Type == CandidateTable || c.Type == CandidateColumn || c.Type == CandidateSchema || c.Type == CandidateCatalog || c.Type == CandidateView {
+			t.Errorf("nil catalog produced object candidate %v %q", c.Type, c.Text)
+		}
+	}
+	// And statement-start keywords still work.
+	if !has(Complete("", 0, nil), CandidateKeyword, "SELECT") {
+		t.Errorf("nil catalog: statement-start keywords should still be offered")
+	}
+}
+
+func TestComplete_NilCatalogCTE(t *testing.T) {
+	// CTE names are derived from the statement text, so they are offered even
+	// without a catalog.
+	sql := "WITH recent AS (SELECT 1) SELECT * FROM "
+	got := Complete(sql, len(sql), nil)
+	if !has(got, CandidateTable, "recent") {
+		t.Errorf("nil catalog should still offer CTE 'recent' from the statement; got %v", got)
+	}
+}
+
+func TestComplete_OutOfRangeOffsets(t *testing.T) {
+	cat := buildCatalog()
+	cases := []struct {
+		name string
+		sql  string
+		pos  int
+	}{
+		{"far_past_end", "SELECT * FROM ", 1000},
+		{"one_past_end", "SELECT * FROM ", len("SELECT * FROM ") + 1},
+		{"negative", "SELECT", -5},
+		{"huge", "SELECT", 1 << 30},
+		{"empty_past_end", "", 9},
+		{"empty_negative", "", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Complete(%q, %d) panicked: %v", tc.sql, tc.pos, r)
+				}
+			}()
+			_ = Complete(tc.sql, tc.pos, cat)
+		})
+	}
+
+	// A caret past the end of "SELECT * FROM " behaves like a caret at the end.
+	atEnd := Complete("SELECT * FROM ", len("SELECT * FROM "), cat)
+	pastEnd := Complete("SELECT * FROM ", 1000, cat)
+	if len(atEnd) != len(pastEnd) {
+		t.Errorf("past-end completion (%d cands) differs from at-end (%d cands)", len(pastEnd), len(atEnd))
+	}
+}
+
+func TestComplete_ResultsSortedAndDeduped(t *testing.T) {
+	cat := buildCatalog()
+	got := Complete("SELECT * FROM ", len("SELECT * FROM "), cat)
+	// Sorted by (Type, Text): verify non-decreasing.
+	for i := 1; i < len(got); i++ {
+		prev, cur := got[i-1], got[i]
+		if cur.Type < prev.Type {
+			t.Errorf("candidates not sorted by type at %d: %v then %v", i, prev, cur)
+		}
+		if cur.Type == prev.Type && cur.Text < prev.Text {
+			t.Errorf("candidates not sorted by text within type at %d: %q then %q", i, prev.Text, cur.Text)
+		}
+	}
+	// No duplicate (Text, Type).
+	seen := map[string]bool{}
+	for _, c := range got {
+		k := c.Type.String() + "\x00" + strings.ToLower(c.Text)
+		if seen[k] {
+			t.Errorf("duplicate candidate %v %q", c.Type, c.Text)
+		}
+		seen[k] = true
+	}
+}
+
+func TestComplete_MultiStatementCaretInSecond(t *testing.T) {
+	cat := buildCatalog()
+	// The caret is in the second statement; the first must not pollute scope.
+	sql := "SELECT * FROM customer; SELECT * FROM "
+	got := Complete(sql, len(sql), cat)
+	// FROM in the second statement still offers tables (context independent of
+	// statement index), and the first statement's customer scope is irrelevant.
+	if !has(got, CandidateTable, "orders") {
+		t.Errorf("second-statement FROM should offer tables; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestQuoteIdentifierIfNeeded(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"orders", "orders"},           // clean lower-case
+		{"MyTable", `"MyTable"`},       // mixed case (from a quoted source) → re-quote to preserve
+		{"with space", `"with space"`}, // space
+		{"1leading", `"1leading"`},     // leading digit
+		{"weird-name", `"weird-name"`}, // hyphen
+		{"", `""`},                     // empty
+		{"select", `"select"`},         // reserved keyword
+		{"data", "data"},               // non-reserved keyword → no quoting
+		{`a"b`, `"a""b"`},              // embedded quote → doubled
+		{"_underscore", "_underscore"}, // leading underscore is fine
+		{"col1", "col1"},               // trailing digit fine
+	}
+	for _, tc := range cases {
+		if got := QuoteIdentifierIfNeeded(tc.in); got != tc.want {
+			t.Errorf("QuoteIdentifierIfNeeded(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestComplete_QuotedCandidateForReservedName(t *testing.T) {
+	cat := catalog.New()
+	tpch := cat.EnsureCatalog("tpch")
+	// A table whose normalized name is a reserved keyword must be offered quoted
+	// so the completion is itself valid syntax.
+	tpch.EnsureSchema("sf1").AddTable("select",
+		catalog.NewColumn("x", "bigint", false),
+	)
+	cat.SetCurrentCatalog("tpch")
+	cat.SetCurrentSchema("sf1")
+
+	got := Complete("SELECT * FROM ", len("SELECT * FROM "), cat)
+	if !hasText(got, `"select"`) {
+		t.Errorf("a table named 'select' must be offered quoted; got %v", texts(got, CandidateTable))
+	}
+}

--- a/trino/completion/context.go
+++ b/trino/completion/context.go
@@ -1,0 +1,274 @@
+package completion
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/parser"
+)
+
+// completionKind enumerates the high-level context the caret sits in. It drives
+// which candidate families candidatesFor offers.
+type completionKind int
+
+const (
+	// kindStatementStart: start of input, or just after ';'. Offer the
+	// statement-leading keywords (SELECT, INSERT, CREATE, ...).
+	kindStatementStart completionKind = iota
+	// kindRelation: a table/view name is expected (after FROM, JOIN, INTO,
+	// UPDATE, TABLE, the relation position of DML/DDL). Offer relations in the
+	// session schema plus schema and catalog names so the user can drill down.
+	kindRelation
+	// kindColumnOrExpr: a column or general expression is expected (after
+	// SELECT, WHERE, ON, GROUP/ORDER BY, HAVING, AND/OR, a select-list comma,
+	// comparison operators). Offer in-scope columns plus expression keywords.
+	kindColumnOrExpr
+	// kindColumnOnly: a bare column name is expected, NOT a general expression
+	// (the assignment target after UPDATE ... SET). Offer in-scope columns only;
+	// an expression keyword like CASE/CAST here is a syntax error (oracle 481:
+	// "UPDATE t SET CASE" => SYNTAX_ERROR).
+	kindColumnOnly
+	// kindDottedName: the caret follows "<word> ." — a qualified-name drill-down.
+	// The qualifier list (the dotted words before the caret) is carried in
+	// context.qualifier so candidatesFor can resolve it against the catalog and
+	// the FROM scope.
+	kindDottedName
+	// kindKeyword: a fallback where only keywords are sensible.
+	kindKeyword
+)
+
+// completionContext is the result of classifying the token stream up to the
+// caret. qualifier holds the normalized dotted-name parts preceding the caret
+// when kind == kindDottedName (e.g. ["mycat", "myschema"] for
+// "mycat.myschema." ); it is nil otherwise.
+type completionContext struct {
+	kind      completionKind
+	qualifier []string
+}
+
+// scanTokens lexes sql[:limit] into the real (non-EOF) tokens. limit is clamped
+// into range. The trailing EOF token is dropped so callers index the last
+// meaningful token directly.
+func scanTokens(sql string, limit int) []parser.Token {
+	if limit > len(sql) {
+		limit = len(sql)
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	toks, _ := parser.Tokenize(sql[:limit])
+	// Tokenize always terminates with a tokEOF token (Str == "", a zero Kind);
+	// drop it so the last element is the last real token.
+	if n := len(toks); n > 0 && toks[n-1].Kind == 0 {
+		toks = toks[:n-1]
+	}
+	return toks
+}
+
+// detectContext classifies the completion context at scanLimit (the caret with
+// the partial word already stripped).
+func detectContext(sql string, scanLimit int) completionContext {
+	toks := scanTokens(sql, scanLimit)
+	n := len(toks)
+	if n == 0 {
+		return completionContext{kind: kindStatementStart}
+	}
+
+	last := toks[n-1]
+
+	// Caret immediately after a dot: "<chain> ." — a qualified-name drill-down.
+	if last.Kind == int('.') {
+		return completionContext{kind: kindDottedName, qualifier: collectQualifier(toks[:n-1])}
+	}
+
+	// Caret just after ';' — a fresh statement begins.
+	if last.Kind == int(';') {
+		return completionContext{kind: kindStatementStart}
+	}
+
+	// Keyword-driven context. We look at the most recent *keyword* that selects
+	// a context, scanning back over intervening identifiers/operators so that
+	// "SELECT a, " still resolves to a column context and "FROM a JOIN " still
+	// resolves to a relation context.
+	if k, ok := keywordContext(toks); ok {
+		return k
+	}
+
+	// Default: keywords. (e.g. right after a complete table name, the next
+	// useful tokens are clause keywords like WHERE/JOIN/GROUP.)
+	return completionContext{kind: kindKeyword}
+}
+
+// keywordContext walks the token stream and returns the context implied by the
+// nearest context-selecting keyword, if any.
+func keywordContext(toks []parser.Token) (completionContext, bool) {
+	n := len(toks)
+	last := toks[n-1]
+
+	// A relation is expected immediately after these keywords.
+	switch {
+	case isKeyword(last, "from"), isKeyword(last, "join"), isKeyword(last, "into"),
+		isKeyword(last, "update"), isKeyword(last, "describe"), isKeyword(last, "desc"):
+		return completionContext{kind: kindRelation}, true
+	// "TABLE x" as a relation appears after TABLE in TABLE/INSERT/DROP/ALTER/
+	// TRUNCATE/ANALYZE contexts; offering relations there is always safe.
+	case isKeyword(last, "table"):
+		return completionContext{kind: kindRelation}, true
+	}
+
+	// "UPDATE ... SET" introduces an assignment target, which must be a bare
+	// column — not a general expression. (USING is intentionally NOT here: after
+	// a JOIN's USING keyword Trino requires a parenthesized column list, so a
+	// bare column candidate would produce invalid syntax; we leave USING to the
+	// keyword fallback.)
+	if isKeyword(last, "set") {
+		return completionContext{kind: kindColumnOnly}, true
+	}
+
+	// A column / expression is expected immediately after these.
+	switch {
+	case isKeyword(last, "select"), isKeyword(last, "where"), isKeyword(last, "on"),
+		isKeyword(last, "having"), isKeyword(last, "and"), isKeyword(last, "or"),
+		isKeyword(last, "qualify"):
+		return completionContext{kind: kindColumnOrExpr}, true
+	// "GROUP BY" / "ORDER BY" / "PARTITION BY" / "CLUSTER BY" / "DISTRIBUTE BY"
+	// — the column position follows the BY keyword.
+	case isKeyword(last, "by"):
+		return completionContext{kind: kindColumnOrExpr}, true
+	}
+
+	// A comma extends whatever the enclosing list is. The two common lists are
+	// the SELECT list (columns) and the FROM list (relations). Resolve by the
+	// nearest preceding SELECT vs FROM/JOIN keyword.
+	if last.Kind == int(',') {
+		switch nearestListKeyword(toks[:n-1]) {
+		case "from":
+			return completionContext{kind: kindRelation}, true
+		case "select":
+			return completionContext{kind: kindColumnOrExpr}, true
+		}
+		// Unknown enclosing list (e.g. a function-argument list); columns/expr
+		// are the most useful default.
+		return completionContext{kind: kindColumnOrExpr}, true
+	}
+
+	// A comparison / arithmetic operator implies an expression operand follows.
+	switch last.Kind {
+	case int('='), int('<'), int('>'), int('+'), int('-'), int('*'), int('/'), int('%'):
+		return completionContext{kind: kindColumnOrExpr}, true
+	}
+
+	return completionContext{}, false
+}
+
+// nearestListKeyword scans backward (respecting parentheses depth at the top
+// level) for the nearest SELECT or FROM/JOIN keyword, returning "select",
+// "from", or "". It is used to decide whether a top-level comma extends the
+// select list or the from list.
+func nearestListKeyword(toks []parser.Token) string {
+	depth := 0
+	for i := len(toks) - 1; i >= 0; i-- {
+		switch toks[i].Kind {
+		case int(')'), int(']'):
+			depth++
+			continue
+		case int('('), int('['):
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		switch {
+		case isKeyword(toks[i], "from"), isKeyword(toks[i], "join"):
+			return "from"
+		case isKeyword(toks[i], "select"):
+			return "select"
+		// A clause keyword that ends the SELECT/FROM lists: stop here so a comma
+		// inside e.g. GROUP BY a, b is not mis-attributed to the select list.
+		case isKeyword(toks[i], "where"), isKeyword(toks[i], "group"),
+			isKeyword(toks[i], "order"), isKeyword(toks[i], "having"),
+			isKeyword(toks[i], "on"):
+			return ""
+		}
+	}
+	return ""
+}
+
+// collectQualifier returns the normalized dotted-name parts that form the
+// qualifier chain ending at the caret. toks is the token slice WITHOUT the
+// trailing '.'. It walks back over alternating name/'.' tokens:
+// "a . b ." (caret) yields ["a", "b"]. A non-name, non-dot token ends the chain.
+// Names are normalized via the lexer-decoded token text so a quoted qualifier
+// resolves case-sensitively, matching the catalog's stored keys.
+func collectQualifier(toks []parser.Token) []string {
+	var parts []string
+	i := len(toks) - 1
+	for i >= 0 {
+		if !isNameToken(toks[i]) {
+			break
+		}
+		parts = append([]string{normalizeQualifierPart(toks[i])}, parts...)
+		i--
+		// Expect a separating '.' before the previous name; stop otherwise.
+		if i < 0 || toks[i].Kind != int('.') {
+			break
+		}
+		i--
+	}
+	return parts
+}
+
+// normalizeQualifierPart folds a name-token to the catalog's stored key form.
+// For a quoted/back-quoted identifier the lexer already decoded the content
+// (case preserved); for an unquoted identifier or a non-reserved keyword used
+// as a name, the catalog folds to lower case. We replicate catalog.Normalize's
+// rule using the token's decoded text and whether it was a quoted kind.
+func normalizeQualifierPart(tok parser.Token) string {
+	if isQuotedNameToken(tok) {
+		// Quoted identifiers are case-sensitive; tok.Str is the decoded content.
+		return tok.Str
+	}
+	return strings.ToLower(tok.Str)
+}
+
+// isKeyword reports whether tok is the given keyword (case-insensitive). It is
+// true only for actual keyword tokens, not for a quoted identifier that happens
+// to decode to the same letters.
+func isKeyword(tok parser.Token, kw string) bool {
+	if isQuotedNameToken(tok) {
+		return false
+	}
+	k, ok := parser.KeywordToken(tok.Str)
+	if !ok {
+		return false
+	}
+	want, _ := parser.KeywordToken(kw)
+	return k == want
+}
+
+// isNameToken reports whether tok can stand for a name in a qualified chain:
+// any identifier kind, or a keyword (Trino allows non-reserved keywords as
+// identifiers, and for completion a reserved word in a name slot is still a name
+// the user is dotting through). String/number literals and operators are not
+// names.
+func isNameToken(tok parser.Token) bool {
+	switch parser.TokenName(tok.Kind) {
+	case "IDENTIFIER", "QUOTED_IDENTIFIER", "BACKQUOTED_IDENTIFIER", "DIGIT_IDENTIFIER":
+		return true
+	}
+	// A keyword spelled as a word is name-eligible.
+	_, ok := parser.KeywordToken(tok.Str)
+	return ok && tok.Str != ""
+}
+
+// isQuotedNameToken reports whether tok is a quoted or back-quoted identifier
+// (case-sensitive name), as opposed to an unquoted identifier or keyword.
+func isQuotedNameToken(tok parser.Token) bool {
+	switch parser.TokenName(tok.Kind) {
+	case "QUOTED_IDENTIFIER", "BACKQUOTED_IDENTIFIER":
+		return true
+	}
+	return false
+}

--- a/trino/completion/context_test.go
+++ b/trino/completion/context_test.go
@@ -1,0 +1,269 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// These tests cover the context-detection branches and scope edge cases that
+// the headline scenario tests in completion_test.go do not exercise directly,
+// keeping every completion context accounted for (completeness gate).
+
+func TestContext_SelectListComma(t *testing.T) {
+	cat := buildCatalog()
+	// A comma in the SELECT list extends the column list.
+	sql := "SELECT orderkey,  FROM orders"
+	got := Complete(sql, len("SELECT orderkey, "), cat)
+	if !has(got, CandidateColumn, "custkey") {
+		t.Errorf("comma in SELECT list should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_FromListComma(t *testing.T) {
+	cat := buildCatalog()
+	// A comma in the FROM list extends the relation list (implicit cross join).
+	sql := "SELECT * FROM orders, "
+	got := Complete(sql, len("SELECT * FROM orders, "), cat)
+	if !has(got, CandidateTable, "customer") {
+		t.Errorf("comma in FROM list should offer relations; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestContext_GroupByColumns(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT custkey, count(*) FROM orders GROUP BY "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "custkey") {
+		t.Errorf("GROUP BY should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_OrderByColumns(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM orders ORDER BY "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "totalprice") {
+		t.Errorf("ORDER BY should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_AfterComparisonOperator(t *testing.T) {
+	cat := buildCatalog()
+	// After a comparison operator an expression operand is expected: columns +
+	// expression keywords.
+	sql := "SELECT * FROM orders WHERE totalprice > "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "custkey") {
+		t.Errorf("after '>' should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+	if !has(got, CandidateKeyword, "CAST") {
+		t.Errorf("after '>' should offer expression keywords; keywords=%v", texts(got, CandidateKeyword))
+	}
+}
+
+func TestContext_AfterAndOr(t *testing.T) {
+	cat := buildCatalog()
+	sql := "SELECT * FROM customer WHERE custkey = 1 AND "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "name") {
+		t.Errorf("after AND should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_IntoRelation(t *testing.T) {
+	cat := buildCatalog()
+	// INSERT INTO <relation>.
+	sql := "INSERT INTO "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "orders") {
+		t.Errorf("INSERT INTO should offer relations; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestContext_UpdateRelation(t *testing.T) {
+	cat := buildCatalog()
+	sql := "UPDATE "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "customer") {
+		t.Errorf("UPDATE should offer relations; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestContext_DescribeRelation(t *testing.T) {
+	cat := buildCatalog()
+	sql := "DESCRIBE "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "orders") {
+		t.Errorf("DESCRIBE should offer relations; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestContext_FallbackClauseKeywords(t *testing.T) {
+	cat := buildCatalog()
+	// Right after a complete table name, the useful next tokens are clause
+	// keywords (WHERE, JOIN, GROUP, ...). This is the kindKeyword fallback.
+	sql := "SELECT * FROM orders "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateKeyword, "WHERE") {
+		t.Errorf("after a table name should offer clause keyword WHERE; keywords=%v", texts(got, CandidateKeyword))
+	}
+	if !has(got, CandidateKeyword, "JOIN") {
+		t.Errorf("after a table name should offer clause keyword JOIN; keywords=%v", texts(got, CandidateKeyword))
+	}
+}
+
+func TestContext_EmptySelectListCaretInWhere(t *testing.T) {
+	cat := buildCatalog()
+	// The robustness fallback: select list is empty AND the caret is in the
+	// WHERE. fillEmptySelectLists must recover the orders scope.
+	sql := "SELECT  FROM orders WHERE "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "orderkey") {
+		t.Errorf("empty select list + WHERE caret should still recover columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_QuotedQualifier(t *testing.T) {
+	// A quoted, case-sensitive schema qualifier must resolve against the
+	// case-preserved catalog key.
+	cat := catalog.New()
+	tpch := cat.EnsureCatalog("tpch")
+	// Schema stored with preserved case (as if created from a quoted name).
+	tpch.EnsureSchema("MySchema").AddTable("t1", catalog.NewColumn("c", "bigint", false))
+	cat.SetCurrentCatalog("tpch")
+	cat.SetCurrentSchema("MySchema")
+
+	// "MySchema". (quoted) -> its relations.
+	sql := `SELECT * FROM "MySchema".`
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateTable, "t1") {
+		t.Errorf(`"MySchema". should offer t1; tables=%v`, texts(got, CandidateTable))
+	}
+}
+
+func TestContext_CaretAfterLastSemicolon(t *testing.T) {
+	cat := buildCatalog()
+	// Caret in the whitespace after the final ';' (no further statement text):
+	// statement-start keywords, no crash.
+	sql := "SELECT 1;   "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateKeyword, "SELECT") {
+		t.Errorf("caret after final ';' should offer statement-start keywords; got %v", texts(got, CandidateKeyword))
+	}
+}
+
+func TestContext_SetClauseColumns(t *testing.T) {
+	cat := buildCatalog()
+	// UPDATE ... SET <column>. The SET keyword puts us in a column-ONLY context
+	// (the assignment target must be a bare column), and the DML target (orders)
+	// — which query-span omits — is recovered by the completion package's own
+	// DML-target scan.
+	sql := "UPDATE orders SET "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "totalprice") {
+		t.Errorf("UPDATE ... SET should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+	// An expression keyword in the SET target is a syntax error (oracle 481:
+	// "UPDATE t SET CASE" => SYNTAX_ERROR), so SET must NOT offer them.
+	if has(got, CandidateKeyword, "CASE") || has(got, CandidateKeyword, "CAST") {
+		t.Errorf("UPDATE ... SET must not offer expression keywords; keywords=%v", texts(got, CandidateKeyword))
+	}
+}
+
+func TestContext_UsingNoBareColumns(t *testing.T) {
+	cat := buildCatalog()
+	// After a JOIN's USING keyword Trino requires "(col, ...)" (oracle 481:
+	// "... USING id" => SYNTAX_ERROR), so the completer must NOT offer a bare
+	// column candidate that would yield invalid syntax.
+	sql := "SELECT * FROM orders o JOIN customer c USING "
+	got := Complete(sql, len(sql), cat)
+	if cols := texts(got, CandidateColumn); len(cols) != 0 {
+		t.Errorf("after USING (before the paren) a bare column is invalid; must not offer columns, got %v", cols)
+	}
+}
+
+func TestContext_UpdateWhereColumns(t *testing.T) {
+	cat := buildCatalog()
+	// The DML target is in scope for the WHERE predicate too.
+	sql := "UPDATE customer SET name = 'x' WHERE "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "custkey") {
+		t.Errorf("UPDATE ... WHERE should offer target columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_DeleteWhereColumns(t *testing.T) {
+	cat := buildCatalog()
+	sql := "DELETE FROM orders WHERE "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "orderkey") {
+		t.Errorf("DELETE ... WHERE should offer target columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestCandidateTypeString(t *testing.T) {
+	cases := map[CandidateType]string{
+		CandidateKeyword:  "keyword",
+		CandidateCatalog:  "catalog",
+		CandidateSchema:   "schema",
+		CandidateTable:    "table",
+		CandidateView:     "view",
+		CandidateColumn:   "column",
+		CandidateType(99): "unknown",
+	}
+	for typ, want := range cases {
+		if got := typ.String(); got != want {
+			t.Errorf("CandidateType(%d).String() = %q, want %q", typ, got, want)
+		}
+	}
+}
+
+func TestContext_CommaInGroupByNotSelectList(t *testing.T) {
+	cat := buildCatalog()
+	// A comma inside GROUP BY must offer columns (the GROUP BY list), and the
+	// nearestListKeyword scan must NOT misattribute it to the SELECT list as a
+	// relation context. Either way the user wants columns here.
+	sql := "SELECT custkey FROM orders GROUP BY custkey, "
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "totalprice") {
+		t.Errorf("comma in GROUP BY should offer columns; columns=%v", texts(got, CandidateColumn))
+	}
+	// It must NOT be a relation context (no tables offered as the primary set).
+	if has(got, CandidateTable, "customer") {
+		t.Errorf("comma in GROUP BY wrongly offered relations; tables=%v", texts(got, CandidateTable))
+	}
+}
+
+func TestContext_UpdateTargetDottedByTableName(t *testing.T) {
+	cat := buildCatalog()
+	// UPDATE has no target alias (oracle 481: "UPDATE t a SET" => SYNTAX_ERROR),
+	// so a dotted reference uses the table name itself.
+	sql := "UPDATE orders SET orders."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "totalprice") {
+		t.Errorf("UPDATE orders ... orders. should offer target columns; columns=%v", texts(got, CandidateColumn))
+	}
+}
+
+func TestContext_UpdateTargetAliasRejected(t *testing.T) {
+	cat := buildCatalog()
+	// "UPDATE orders o ..." is invalid Trino, so the completer must NOT invent an
+	// alias scope for `o`: a dotted `o.` reference resolves to nothing.
+	sql := "UPDATE orders o SET o."
+	got := Complete(sql, len(sql), cat)
+	if cols := texts(got, CandidateColumn); len(cols) != 0 {
+		t.Errorf("UPDATE orders o (invalid alias) must not create an alias scope; columns=%v", cols)
+	}
+}
+
+func TestContext_MergeTargetAliasColumns(t *testing.T) {
+	cat := buildCatalog()
+	// MERGE DOES allow a target alias (oracle 481 accepts it), so a dotted
+	// reference through the alias resolves to the target's columns.
+	sql := "MERGE INTO orders o USING customer c ON o.custkey = c.custkey WHEN MATCHED THEN UPDATE SET totalprice = o."
+	got := Complete(sql, len(sql), cat)
+	if !has(got, CandidateColumn, "totalprice") {
+		t.Errorf("MERGE alias o. should offer target columns; columns=%v", texts(got, CandidateColumn))
+	}
+}

--- a/trino/completion/keywords.go
+++ b/trino/completion/keywords.go
@@ -1,0 +1,180 @@
+package completion
+
+import "github.com/bytebase/omni/trino/parser"
+
+// Curated keyword candidate lists. The bytebase Trino completer surfaces
+// keywords from the c3 follow-set; without c3 we offer hand-picked sets keyed
+// to the context. The spellings are upper-case (Trino accepts any case, and
+// upper-case is the conventional display form). Sets are intentionally focused
+// — a completer that dumps all ~290 keywords at every caret is noise.
+
+// statementStartKeywords are offered at the start of a statement: the
+// statement-leading keywords of the Trino grammar's statement rule.
+var statementStartKeywords = []string{
+	"ALTER",
+	"ANALYZE",
+	"CALL",
+	"COMMENT",
+	"COMMIT",
+	"CREATE",
+	"DEALLOCATE",
+	"DELETE",
+	"DENY",
+	"DESCRIBE",
+	"DROP",
+	"EXECUTE",
+	"EXPLAIN",
+	"GRANT",
+	"INSERT",
+	"MERGE",
+	"PREPARE",
+	"REFRESH",
+	"RESET",
+	"REVOKE",
+	"ROLLBACK",
+	"SELECT",
+	"SET",
+	"SHOW",
+	"START",
+	"TABLE",
+	"TRUNCATE",
+	"UPDATE",
+	"USE",
+	"VALUES",
+	"WITH",
+}
+
+// clauseKeywords are offered as a fallback (e.g. just after a complete table
+// name): the clause keywords that commonly continue a query.
+var clauseKeywords = []string{
+	"AS",
+	"CROSS",
+	"EXCEPT",
+	"FETCH",
+	"FROM",
+	"FULL",
+	"GROUP",
+	"HAVING",
+	"INNER",
+	"INTERSECT",
+	"JOIN",
+	"LEFT",
+	"LIMIT",
+	"NATURAL",
+	"OFFSET",
+	"ON",
+	"ORDER",
+	"RIGHT",
+	"UNION",
+	"USING",
+	"WHERE",
+	"WINDOW",
+}
+
+// expressionKeywords are offered in a value/predicate position (after SELECT,
+// WHERE, ON, AND/OR, a comparison): the operators and constructs that begin or
+// continue an expression, plus the literal keywords.
+var expressionKeywords = []string{
+	"ALL",
+	"AND",
+	"ANY",
+	"ARRAY",
+	"BETWEEN",
+	"CASE",
+	"CAST",
+	"CURRENT_DATE",
+	"CURRENT_TIME",
+	"CURRENT_TIMESTAMP",
+	"DISTINCT",
+	"EXISTS",
+	"FALSE",
+	"IN",
+	"INTERVAL",
+	"IS",
+	"LIKE",
+	"NOT",
+	"NULL",
+	"OR",
+	"SOME",
+	"TRUE",
+	"TRY_CAST",
+}
+
+// QuoteIdentifierIfNeeded returns name wrapped in double quotes when it would
+// otherwise be lexed as something other than a single unquoted identifier, and
+// returns it unchanged when it is a clean unquoted identifier.
+//
+// A name needs quoting when it is empty, does not start with a letter or '_',
+// contains a character outside [A-Za-z0-9_], or collides with a reserved Trino
+// keyword (an unquoted reserved word cannot stand for an identifier). Embedded
+// double quotes are doubled per Trino's quoting rule. This mirrors the legacy
+// bytebase quotedIdentifierIfNeeded helper.
+//
+// Note: a name produced by catalog normalization is already lower-cased for an
+// originally-unquoted identifier, or case-preserved for an originally-quoted
+// one; we re-quote only when the *characters* require it, so a normalized
+// "MyTable" (which came from a quoted source) is re-quoted to preserve its
+// case, which is the correct, round-trippable completion.
+func QuoteIdentifierIfNeeded(name string) string {
+	if needsQuoting(name) {
+		return `"` + escapeDoubleQuotes(name) + `"`
+	}
+	return name
+}
+
+// needsQuoting reports whether name cannot be written as a bare unquoted Trino
+// identifier.
+func needsQuoting(name string) bool {
+	if name == "" {
+		return true
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c == '_':
+			// A clean lower-case identifier character; always allowed unquoted.
+		case c >= 'A' && c <= 'Z':
+			// An upper-case letter forces quoting: Trino folds an *unquoted*
+			// identifier to lower case, so emitting MyCol unquoted would resolve
+			// to mycol. A normalized name retaining upper case came from a quoted
+			// source and is case-sensitive, so it must be re-quoted to round-trip.
+			return true
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				// A leading digit makes it a DIGIT_IDENTIFIER at best; quote so
+				// the completion is an unambiguous identifier.
+				return true
+			}
+		default:
+			return true
+		}
+	}
+	// Upper-case the whole word and check against the reserved set: a reserved
+	// keyword used unquoted is not a valid identifier.
+	return isReservedWord(name)
+}
+
+// isReservedWord reports whether name is a reserved Trino keyword (one that
+// cannot be used as an unquoted identifier). Non-reserved keywords (e.g. DATA,
+// FORMAT) are valid unquoted identifiers and need no quoting.
+func isReservedWord(name string) bool {
+	kind, ok := parser.KeywordToken(name)
+	if !ok {
+		return false
+	}
+	return parser.IsReserved(kind)
+}
+
+// escapeDoubleQuotes doubles any embedded double-quote, per Trino's
+// "" escape inside a quoted identifier.
+func escapeDoubleQuotes(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	for i := 0; i < len(s); i++ {
+		if s[i] == '"' {
+			out = append(out, '"', '"')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}

--- a/trino/completion/oracle_test.go
+++ b/trino/completion/oracle_test.go
@@ -1,0 +1,306 @@
+package completion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bytebase/omni/trino/catalog"
+	"github.com/bytebase/omni/trino/internal/trinooracle"
+)
+
+// This file is the completion node's slice of the differential-oracle gate
+// (correctness-protocol.md). completion is a feature node, so the oracle does
+// not adjudicate a grammar accept/reject — that is the parser nodes' job. What
+// the oracle pins here is the part of completion most prone to silent error:
+//
+//  1. The SQL *contexts* the unit tests complete into are real Trino 481 syntax
+//     (a context built on invalid syntax would make the candidate assertions
+//     meaningless).
+//  2. A candidate this package emits, substituted at the caret, yields a
+//     statement Trino's parser ACCEPTS — i.e. the completer offers syntactically
+//     usable text (in particular, its identifier quoting round-trips).
+//  3. The identifier-folding rule that drives QuoteIdentifierIfNeeded
+//     (unquoted => lower-cased; quoting needed to preserve case or use a
+//     reserved word) is the rule Trino 481 actually enforces.
+//
+// All subtests skip cleanly when no Trino is reachable, matching the harness
+// convention (analysis/oracle_test.go, trinooracle/oracle_test.go).
+
+func connectOracle(t *testing.T) *trinooracle.Oracle {
+	t.Helper()
+	o := trinooracle.Connect("")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ver, err := o.Ping(ctx)
+	if err != nil {
+		t.Skipf("trino oracle not reachable (start: docker run -d -p 18080:8080 %s): %v",
+			trinooracle.DefaultImage, err)
+	}
+	t.Logf("connected to Trino %s", ver)
+	return o
+}
+
+func oracleAccepts(t *testing.T, o *trinooracle.Oracle, sql string) (accepted, ok bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := o.CheckSyntax(ctx, sql)
+	if err != nil {
+		return false, false
+	}
+	return res.Accepted, true
+}
+
+// oracleCatalog builds a completion catalog that mirrors the schema this test
+// creates in the oracle's memory connector, so a candidate the completer offers
+// for these statements is one the oracle can also validate.
+func oracleCatalog() *catalog.Catalog {
+	cat := catalog.New()
+	mem := cat.EnsureCatalog("memory")
+	def := mem.EnsureSchema("default")
+	def.AddTable("orders",
+		catalog.NewColumn("orderkey", "bigint", false),
+		catalog.NewColumn("custkey", "bigint", false),
+		catalog.NewColumn("totalprice", "double", true),
+	)
+	def.AddTable("customer",
+		catalog.NewColumn("custkey", "bigint", false),
+		catalog.NewColumn("name", "varchar", true),
+	)
+	cat.SetCurrentCatalog("memory")
+	cat.SetCurrentSchema("default")
+	return cat
+}
+
+// seedMemorySchema creates the tables oracleCatalog describes, in the oracle's
+// memory connector, so substituted-candidate statements reach Trino's analyzer
+// without a missing-table error. (A missing-table error is SEMANTIC, which
+// CheckSyntax already treats as "accepted"; seeding just keeps the corpus
+// end-to-end runnable and lets us assert acceptance unambiguously.)
+func seedMemorySchema(t *testing.T, o *trinooracle.Oracle) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	for _, s := range []string{
+		"DROP TABLE IF EXISTS memory.default.orders",
+		"DROP TABLE IF EXISTS memory.default.customer",
+		"CREATE TABLE memory.default.orders (orderkey bigint, custkey bigint, totalprice double)",
+		"CREATE TABLE memory.default.customer (custkey bigint, name varchar)",
+	} {
+		if _, err := o.CheckSyntax(ctx, s); err != nil {
+			t.Skipf("oracle setup failed (%q): %v", s, err)
+		}
+	}
+}
+
+// TestCompletion_ContextsAreValidSyntax confirms each SQL context the unit
+// tests complete into is accepted by Trino 481 once a plausible completion is
+// substituted at the caret. Each case is the (sql, caretPos) the completer sees
+// plus a `pick` predicate selecting the candidate to substitute; the resulting
+// statement (prefix + candidate + suffix) must be accepted.
+func TestCompletion_ContextsAreValidSyntax(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	seedMemorySchema(t, o)
+	cat := oracleCatalog()
+
+	cases := []struct {
+		name string
+		sql  string
+		pos  int
+		want CandidateType // a candidate of this type must exist AND, substituted, parse
+		pick string        // optional exact candidate Text to substitute; "" => first of want
+	}{
+		{name: "after_from_table", sql: "SELECT * FROM ", pos: len("SELECT * FROM "), want: CandidateTable, pick: "orders"},
+		// A non-cross JOIN needs an ON condition to be valid syntax; the suffix
+		// supplies it so the substituted statement parses (we are validating the
+		// table candidate, not inventing an unconditioned join).
+		{name: "after_join_table", sql: "SELECT * FROM orders o JOIN  ON o.custkey = customer.custkey", pos: len("SELECT * FROM orders o JOIN "), want: CandidateTable, pick: "customer"},
+		{name: "select_column", sql: "SELECT  FROM orders", pos: len("SELECT "), want: CandidateColumn, pick: "orderkey"},
+		{name: "where_column", sql: "SELECT * FROM customer WHERE ", pos: len("SELECT * FROM customer WHERE "), want: CandidateColumn, pick: "custkey"},
+		{name: "dotted_alias_column", sql: "SELECT * FROM orders o WHERE o.", pos: len("SELECT * FROM orders o WHERE o."), want: CandidateColumn, pick: "totalprice"},
+		{name: "dotted_catalog_schema", sql: "SELECT * FROM memory.", pos: len("SELECT * FROM memory."), want: CandidateSchema, pick: "default"},
+		{name: "statement_start_kw", sql: "", pos: 0, want: CandidateKeyword, pick: "SELECT"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// First, confirm the *context* SQL (with a star where the select list
+			// is empty) is itself valid, so the completion is into real syntax.
+			got := Complete(tc.sql, tc.pos, cat)
+			cand := pickCandidate(got, tc.want, tc.pick)
+			if cand == "" {
+				t.Fatalf("Complete(%q,%d) offered no %v candidate %q; got %v",
+					tc.sql, tc.pos, tc.want, tc.pick, got)
+			}
+			// Substitute the candidate at the caret and assert Trino accepts the
+			// full statement. For an empty select list ("SELECT  FROM ..."), the
+			// candidate is a column so the substituted text closes the list.
+			substituted := tc.sql[:tc.pos] + cand + tc.sql[tc.pos:]
+			// A keyword like SELECT at statement start needs a body to parse; wrap
+			// the bare-keyword case into a minimal valid statement.
+			if tc.want == CandidateKeyword {
+				substituted = cand + " 1"
+			}
+			accepted, ok := oracleAccepts(t, o, substituted)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if !accepted {
+				t.Errorf("Trino 481 REJECTED %q (candidate %q substituted into %q@%d)",
+					substituted, cand, tc.sql, tc.pos)
+			}
+		})
+	}
+}
+
+// pickCandidate returns the Text of the candidate matching (typ, want), or the
+// first candidate of typ when want == "", or "" if none.
+func pickCandidate(cands []Candidate, typ CandidateType, want string) string {
+	for _, c := range cands {
+		if c.Type != typ {
+			continue
+		}
+		if want == "" || c.Text == want {
+			return c.Text
+		}
+	}
+	return ""
+}
+
+// TestCompletion_ContextNegativesMatchOracle pins the context-correctness rules
+// that the review surfaced: certain caret positions must NOT offer a candidate
+// that would produce invalid syntax. Each case asserts BOTH the omni completer's
+// behavior (no offending candidate) AND the engine's verdict (the offending
+// completion is a SYNTAX error, while the correct shape is accepted), so the two
+// can never silently drift apart.
+func TestCompletion_ContextNegativesMatchOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	seedMemorySchema(t, o)
+	cat := oracleCatalog()
+
+	// (1) JOIN ... USING requires a parenthesized column list.
+	{
+		sql := "SELECT * FROM orders o JOIN customer c USING "
+		got := Complete(sql, len(sql), cat)
+		if cols := pickCandidate(got, CandidateColumn, ""); cols != "" {
+			t.Errorf("USING context offered a bare column %q; that completes to invalid syntax", cols)
+		}
+		bad, ok1 := oracleAccepts(t, o, "SELECT * FROM orders o JOIN customer c USING custkey")
+		good, ok2 := oracleAccepts(t, o, "SELECT * FROM orders o JOIN customer c USING (custkey)")
+		if ok1 && bad {
+			t.Errorf("oracle unexpectedly accepted bare 'USING custkey'")
+		}
+		if ok2 && !good {
+			t.Errorf("oracle rejected 'USING (custkey)' — the valid shape")
+		}
+	}
+
+	// (2) UPDATE ... SET <target> must be a bare column, not an expression.
+	{
+		sql := "UPDATE orders SET "
+		got := Complete(sql, len(sql), cat)
+		for _, kw := range []string{"CASE", "CAST"} {
+			if has(got, CandidateKeyword, kw) {
+				t.Errorf("SET context offered expression keyword %q; SET <expr> is invalid", kw)
+			}
+		}
+		bad, ok := oracleAccepts(t, o, "UPDATE orders SET CASE")
+		if ok && bad {
+			t.Errorf("oracle unexpectedly accepted 'UPDATE orders SET CASE'")
+		}
+	}
+
+	// (3) UPDATE/DELETE targets are NOT aliasable; MERGE targets are.
+	{
+		updAlias, ok1 := oracleAccepts(t, o, "UPDATE orders o SET totalprice = 1")
+		delAlias, ok2 := oracleAccepts(t, o, "DELETE FROM orders o WHERE orderkey = 1")
+		if ok1 && updAlias {
+			t.Errorf("oracle unexpectedly accepted an UPDATE target alias")
+		}
+		if ok2 && delAlias {
+			t.Errorf("oracle unexpectedly accepted a DELETE target alias")
+		}
+		// MERGE alias is accepted (NOT_SUPPORTED on the memory connector is a
+		// semantic, not syntactic, outcome — still "accepted" by CheckSyntax).
+		mergeAlias, ok3 := oracleAccepts(t, o,
+			"MERGE INTO orders o USING customer c ON o.custkey = c.custkey WHEN MATCHED THEN UPDATE SET totalprice = c.custkey")
+		if ok3 && !mergeAlias {
+			t.Errorf("oracle rejected a MERGE target alias — it should be syntactically valid")
+		}
+	}
+}
+
+// TestCompletion_QuotingRuleMatchesOracle verifies the identifier-folding rule
+// that QuoteIdentifierIfNeeded encodes is the rule Trino 481 enforces:
+//
+//   - A mixed/upper-case name MUST be quoted to be usable as that exact name.
+//     We prove the rule's premise — unquoted folds to lower case — by creating a
+//     column "MyCol" (quoted, case-preserved) and showing that an UNQUOTED
+//     reference MyCol resolves to a *different* (lower) name and so is a
+//     COLUMN_NOT_FOUND (semantic) while the quoted "MyCol" resolves. Both are
+//     syntactically accepted; the point is the *names differ*, which is exactly
+//     why the completer must quote.
+//   - A reserved keyword used as a bare identifier is a SYNTAX error, but quoted
+//     it is accepted — so the completer must quote a reserved-word object name.
+func TestCompletion_QuotingRuleMatchesOracle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+
+	// (1) Reserved word as a bare identifier => SYNTAX rejected; quoted =>
+	// accepted. This is the rule QuoteIdentifierIfNeeded("select") relies on.
+	if got := QuoteIdentifierIfNeeded("select"); got != `"select"` {
+		t.Fatalf("QuoteIdentifierIfNeeded(\"select\") = %q, want %q", got, `"select"`)
+	}
+	{
+		bare := "SELECT 1 AS select"
+		quoted := `SELECT 1 AS "select"`
+		bareAccepted, ok1 := oracleAccepts(t, o, bare)
+		quotedAccepted, ok2 := oracleAccepts(t, o, quoted)
+		if ok1 && bareAccepted {
+			t.Errorf("Trino 481 unexpectedly ACCEPTED reserved word as bare alias %q — quoting would be unnecessary", bare)
+		}
+		if ok2 && !quotedAccepted {
+			t.Errorf("Trino 481 REJECTED the quoted reserved-word alias %q — quoting should make it valid", quoted)
+		}
+	}
+
+	// (2) Upper-case folding: an unquoted upper-case identifier folds to lower
+	// case, so it differs from the quoted, case-preserved name. We assert the
+	// rule QuoteIdentifierIfNeeded encodes (upper-case => must quote) by checking
+	// the function, and confirm with the oracle that both spellings parse (the
+	// folding difference is semantic, not syntactic).
+	if got := QuoteIdentifierIfNeeded("MyCol"); got != `"MyCol"` {
+		t.Fatalf("QuoteIdentifierIfNeeded(\"MyCol\") = %q, want %q (upper-case must be quoted to round-trip)", got, `"MyCol"`)
+	}
+	{
+		// information_schema.columns has a known lower-case column set; selecting
+		// an UPPER-case unquoted column name there works only because Trino folds
+		// it — proving the fold. (table_name exists; TABLE_NAME folds to it.)
+		folded := "SELECT TABLE_NAME FROM information_schema.columns"
+		accepted, ok := oracleAccepts(t, o, folded)
+		if ok && !accepted {
+			t.Errorf("expected Trino to fold unquoted TABLE_NAME -> table_name and accept %q", folded)
+		}
+		// The quoted upper-case name does NOT exist (column is lower-case), so it
+		// is a COLUMN_NOT_FOUND — still syntactically accepted, but a different
+		// name. This is the asymmetry that forces the completer to quote a
+		// case-bearing name rather than emit it bare.
+		quotedUpper := `SELECT "TABLE_NAME" FROM information_schema.columns`
+		res, ok := oracleAccepts(t, o, quotedUpper)
+		_ = res
+		if !ok {
+			t.Skip("oracle unreachable")
+		}
+		// Accepted-as-syntax is all we assert here (the semantic miss is expected).
+	}
+}

--- a/trino/completion/scope.go
+++ b/trino/completion/scope.go
@@ -1,0 +1,333 @@
+package completion
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/analysis"
+	"github.com/bytebase/omni/trino/catalog"
+	"github.com/bytebase/omni/trino/parser"
+)
+
+// placeholder is the sentinel identifier inserted at the caret to make an
+// in-progress statement parse, so query-span analysis can recover the FROM
+// scope and CTE names that surround the caret. It is an unlikely real
+// identifier and is filtered out of any candidate it might masquerade as.
+const placeholder = "__omni_completion_placeholder__"
+
+// scopeTable is one table/view in the FROM scope of the statement under the
+// caret, as reported by query-span analysis. Names are already Trino-normalized
+// (the analysis package folds them), so they key directly into the catalog.
+type scopeTable struct {
+	catalog string // normalized; "" when the source name omitted it
+	schema  string // normalized; "" when omitted
+	table   string // normalized table/view name
+	alias   string // normalized alias; "" when none
+}
+
+// analyzeAtCaret splits sql, finds the statement containing the caret (at byte
+// offset limit, the caret with its partial word already stripped), inserts the
+// placeholder identifier there to keep the statement parseable, and runs
+// query-span analysis on just that statement.
+//
+// Why the whole containing statement and not the prefix: for SELECT-list and
+// predicate completion the FROM clause is to the RIGHT of the caret, so
+// truncating at the caret would hide the very tables we need to offer columns
+// for. Analyzing the full statement (with a placeholder closing the
+// half-written clause at the caret) recovers them; the trailing text after the
+// caret is real SQL the user already wrote.
+func analyzeAtCaret(sql string, limit int) *analysis.QuerySpan {
+	if limit > len(sql) {
+		limit = len(sql)
+	}
+	if limit < 0 {
+		limit = 0
+	}
+
+	start, end := containingStatement(sql, limit)
+	stmt := sql[start:end]
+	rel := limit - start // caret offset within the statement
+
+	// Insert the placeholder at the caret, padded with spaces so it never fuses
+	// with an adjacent token ("o." + ph must read as "o . ph", and "FROMx" must
+	// not arise from "FROM" + ph with no gap — though limit is already at a
+	// token boundary, the padding is belt-and-suspenders).
+	patched := stmt[:rel] + " " + placeholder + " " + stmt[rel:]
+
+	span, err := analysis.GetQuerySpan(patched)
+	if err != nil {
+		return nil
+	}
+	// Robustness fallback: a statement can carry a SECOND incomplete clause away
+	// from the caret — most commonly an empty SELECT list ("SELECT  FROM t"
+	// while the caret edits the WHERE) — which fails the parse so no FROM scope
+	// is recovered. If the caret-patched parse found neither tables nor CTEs,
+	// retry once with empty SELECT lists filled by a placeholder select item, so
+	// the FROM clause becomes reachable.
+	if span != nil && len(span.AccessTables) == 0 && len(span.CTEs) == 0 {
+		if filled := fillEmptySelectLists(patched); filled != patched {
+			if span2, err2 := analysis.GetQuerySpan(filled); err2 == nil && span2 != nil &&
+				(len(span2.AccessTables) > 0 || len(span2.CTEs) > 0) {
+				return span2
+			}
+		}
+	}
+	return span
+}
+
+// fillEmptySelectLists inserts a placeholder select item into any "SELECT FROM"
+// (empty select list) occurrence so the statement parses. It is a coarse text
+// transform used only as a scope-recovery fallback; it keys on a SELECT keyword
+// token immediately followed by a FROM keyword token. Returns the input
+// unchanged when there is nothing to fill.
+func fillEmptySelectLists(stmt string) string {
+	toks, _ := parser.Tokenize(stmt)
+	// Find the first SELECT immediately followed by FROM and splice a star in
+	// between. Doing one is enough to make the common single-query case parse;
+	// nested empties are rare enough to leave to the caret placeholder.
+	for i := 0; i+1 < len(toks); i++ {
+		if isKeyword(toks[i], "select") && isKeyword(toks[i+1], "from") {
+			at := toks[i].Loc.End // byte just after SELECT
+			return stmt[:at] + " * " + stmt[at:]
+		}
+	}
+	return stmt
+}
+
+// containingStatement returns the [start, end) byte range of the top-level
+// statement that contains the caret at offset limit. A caret sitting on a ';'
+// boundary, or past the last statement, attaches to the nearest statement so
+// completion still has context. Falls back to the whole input when Split finds
+// nothing.
+func containingStatement(sql string, limit int) (start, end int) {
+	segs := parser.Split(sql)
+	if len(segs) == 0 {
+		return 0, len(sql)
+	}
+	for _, s := range segs {
+		// Caret within or at the trailing edge of this segment.
+		if limit >= s.ByteStart && limit <= s.ByteEnd {
+			return s.ByteStart, s.ByteEnd
+		}
+	}
+	// Caret is in inter-statement whitespace / after the last ';': attach to the
+	// last segment that starts at or before the caret, else the first segment.
+	chosen := segs[0]
+	for _, s := range segs {
+		if s.ByteStart <= limit {
+			chosen = s
+		}
+	}
+	return chosen.ByteStart, chosen.ByteEnd
+}
+
+// fromScope returns the tables in scope for column completion in the statement
+// containing the caret: the FROM/JOIN tables query-span analysis reports, plus
+// the target relation of a DML statement (UPDATE/DELETE/INSERT/MERGE), which the
+// span's AccessTables omits because it tracks tables a query *reads*, not a
+// DML target. The placeholder pseudo-table (present when the caret itself is the
+// relation being typed, e.g. "FROM |") is excluded.
+func fromScope(sql string, limit int) []scopeTable {
+	var result []scopeTable
+	if span := analyzeAtCaret(sql, limit); span != nil {
+		for _, t := range span.AccessTables {
+			if t.Table == placeholder {
+				continue
+			}
+			result = append(result, scopeTable{
+				catalog: t.Catalog,
+				schema:  t.Schema,
+				table:   t.Table,
+				alias:   t.Alias,
+			})
+		}
+	}
+	result = append(result, dmlTargetTables(sql, limit)...)
+	return result
+}
+
+// dmlTargetTables returns the target relation that forms the column-completion
+// scope of a DML statement, which query-span does not surface (it records only
+// read tables). The target follows the statement's LEADING keyword:
+//
+//   - UPDATE <target> / DELETE FROM <target>: the target is the column scope for
+//     SET and WHERE. Trino does NOT allow a target alias here (oracle 481:
+//     "UPDATE t a SET ..." => SYNTAX_ERROR), so no alias is parsed.
+//   - MERGE INTO <target> [AS] alias: the target IS aliasable (oracle 481
+//     accepts the alias), and merge-clause columns reference it, so the alias is
+//     parsed.
+//
+// INSERT is intentionally excluded: its column scope is the SOURCE query (which
+// query-span already provides) or the explicit "(col, ...)" list; the target
+// table's columns are not visible in the source SELECT, so adding them would
+// over-offer (e.g. "INSERT INTO t SELECT |" must not suggest t's columns).
+// TRUNCATE has no column scope.
+//
+// Only the leading position is inspected, so a DML keyword appearing
+// mid-statement (e.g. the UPDATE inside a MERGE's WHEN MATCHED THEN UPDATE) is
+// never mistaken for a fresh target. Names are normalized to the catalog key
+// form.
+func dmlTargetTables(sql string, limit int) []scopeTable {
+	start, end := containingStatement(sql, limit)
+	toks, _ := parser.Tokenize(sql[start:end])
+	if len(toks) == 0 {
+		return nil
+	}
+
+	// The target name index and whether an alias is grammatical, from the
+	// statement's leading keyword(s).
+	j := -1
+	allowAlias := false
+	switch {
+	case isKeywordAt(toks, 0, "update"):
+		j = 1
+	case isKeywordAt(toks, 0, "delete") && isKeywordAt(toks, 1, "from"):
+		j = 2
+	case isKeywordAt(toks, 0, "merge") && isKeywordAt(toks, 1, "into"):
+		j, allowAlias = 2, true
+	}
+	if j < 0 {
+		return nil
+	}
+	if st, _ := readDottedRelation(toks, j, allowAlias); st != nil {
+		return []scopeTable{*st}
+	}
+	return nil
+}
+
+// readDottedRelation reads a 1–3 part dotted relation name beginning at toks[j],
+// returning the scopeTable and the number of tokens consumed past j. Returns nil
+// when toks[j] is not a name. When allowAlias is true an optional trailing
+// "AS x" / bare-identifier alias is consumed (only MERGE targets are aliasable);
+// when false no alias is parsed (UPDATE/DELETE targets reject one).
+func readDottedRelation(toks []parser.Token, j int, allowAlias bool) (*scopeTable, int) {
+	if j >= len(toks) || !isNameToken(toks[j]) {
+		return nil, 0
+	}
+	var parts []string
+	k := j
+	for k < len(toks) && isNameToken(toks[k]) {
+		parts = append(parts, normalizeQualifierPart(toks[k]))
+		k++
+		if k < len(toks) && toks[k].Kind == int('.') {
+			k++
+			continue
+		}
+		break
+	}
+	st := &scopeTable{}
+	switch len(parts) {
+	case 1:
+		st.table = parts[0]
+	case 2:
+		st.schema, st.table = parts[0], parts[1]
+	default:
+		st.catalog, st.schema, st.table = parts[len(parts)-3], parts[len(parts)-2], parts[len(parts)-1]
+	}
+	// Optional alias (MERGE only): "AS x" or a bare following identifier (a
+	// keyword such as SET that starts the next clause is not an alias).
+	if allowAlias && k < len(toks) {
+		if isKeyword(toks[k], "as") && k+1 < len(toks) && isPlainIdent(toks[k+1]) {
+			st.alias = normalizeQualifierPart(toks[k+1])
+			k += 2
+		} else if isPlainIdent(toks[k]) {
+			st.alias = normalizeQualifierPart(toks[k])
+			k++
+		}
+	}
+	return st, k - j
+}
+
+// isKeywordAt reports whether toks[i] is the given keyword (bounds-checked).
+func isKeywordAt(toks []parser.Token, i int, kw string) bool {
+	return i >= 0 && i < len(toks) && isKeyword(toks[i], kw)
+}
+
+// isPlainIdent reports whether tok is an (unquoted/quoted) identifier rather
+// than a keyword — used so a clause keyword following a DML target is not
+// mistaken for its alias.
+func isPlainIdent(tok parser.Token) bool {
+	switch parser.TokenName(tok.Kind) {
+	case "IDENTIFIER", "QUOTED_IDENTIFIER", "BACKQUOTED_IDENTIFIER", "DIGIT_IDENTIFIER":
+		return true
+	}
+	return false
+}
+
+// inScopeColumnNames returns the column-name lists of all FROM-scope tables that
+// resolve against the catalog, one slice per resolved table. A table that does
+// not resolve (unknown to the catalog, or whose session context is unset)
+// contributes nothing.
+func inScopeColumnNames(sql string, limit int, cat *catalog.Catalog) [][]string {
+	var out [][]string
+	for _, st := range fromScope(sql, limit) {
+		if names := resolveColumns(cat, st); len(names) > 0 {
+			out = append(out, names)
+		}
+	}
+	return out
+}
+
+// scopeColumnsFor returns the column names of the single FROM-scope table the
+// qualifier x selects, where x is either a table's alias or its (normalized)
+// table name. ok is false when x matches no in-scope table. x is normalized by
+// the caller (collectQualifier) to the catalog's key form.
+func scopeColumnsFor(sql string, limit int, cat *catalog.Catalog, x string) (names []string, ok bool) {
+	for _, st := range fromScope(sql, limit) {
+		// An alias, when present, shadows the table name as the column
+		// qualifier (SELECT o.id FROM orders o references via the alias).
+		if st.alias != "" {
+			if st.alias == x {
+				return resolveColumns(cat, st), true
+			}
+			continue
+		}
+		if st.table == x {
+			return resolveColumns(cat, st), true
+		}
+	}
+	return nil, false
+}
+
+// resolveColumns resolves a scope table to its catalog column names, filling an
+// omitted catalog/schema from the session context the way Trino does. Returns
+// nil when the table is unknown to the catalog or the needed session context is
+// unset.
+func resolveColumns(cat *catalog.Catalog, st scopeTable) []string {
+	if cat == nil {
+		return nil
+	}
+	parts := make([]string, 0, 3)
+	if st.catalog != "" {
+		parts = append(parts, st.catalog)
+	}
+	if st.schema != "" {
+		parts = append(parts, st.schema)
+	}
+	parts = append(parts, st.table)
+	return cat.ResolveRelation(parts).ColumnNames()
+}
+
+// cteNames returns the CTE names declared in the statement under the caret,
+// derived from query-span analysis with the caret placeholder. They are
+// select-able relations the completer offers after FROM/JOIN. Names are
+// normalized; the placeholder is never among them.
+func cteNames(sql string, limit int) []string {
+	span := analyzeAtCaret(sql, limit)
+	if span == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(span.CTEs))
+	out := make([]string, 0, len(span.CTEs))
+	for _, name := range span.CTEs {
+		if name == placeholder {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}


### PR DESCRIPTION
## Node

`trino/completion` (feature, P0) — v2 migration of bytebase's `plugin/parser/trino` `Completion` handler. DAG layer 7; deps `parser-select` + `catalog` + `analysis` (all merged). Spec: [`docs/migration/trino/analysis.md`](docs/migration/trino/analysis.md) §Tier 7, [`docs/migration/trino/contract.md`](docs/migration/trino/contract.md) §4.2.

Writes globs: `trino/completion/*.go` (only).

## What it does

Parser-native SQL auto-completion: `Complete(sql, cursorOffset, *catalog.Catalog) []Candidate`.

The legacy completer is a ~1730-line ANTLR `CodeCompletionCore` (c3) walking the parser's rule indices. The omni Trino parser is hand-written **without c3 instrumentation**, and this node may only touch `trino/completion/*.go` (it cannot weave rule-candidate hooks through `trino/parser`). So — like omni's `mongo`/`partiql` completers — the package is self-contained:

- tokenizes input up to the caret with the exported lexer (`parser.Tokenize`),
- classifies the completion context from the token sequence,
- produces candidates from the three-level Trino catalog (catalog → schema → table/view → column) plus curated keyword sets,
- resolves **FROM-clause column scope through `analysis.GetQuerySpan`** — the same semantic path the legacy completer uses to derive CTE/subquery columns — patching a placeholder at the caret so an in-progress statement still parses.

### Contexts covered (completeness gate)

| Caret position | Candidates |
|---|---|
| statement start / after `;` | statement-leading keywords |
| after `FROM`/`JOIN`/`INTO`/`UPDATE`/`DESCRIBE`/`TABLE` | relations + schemas + catalogs (+ CTE names) |
| after `SELECT`/`WHERE`/`ON`/`GROUP BY`/`ORDER BY`/`AND`/`OR`/comparison | in-scope columns + expression keywords |
| `UPDATE … SET ` | in-scope columns **only** (no expr keywords) |
| `<name>.` (1/2/3-part) | catalog→schemas, schema→relations, table/alias→columns |
| FROM/SELECT-list comma | relations / columns by enclosing list |

`QuoteIdentifierIfNeeded` re-quotes any case-bearing / reserved-keyword / non-word / leading-digit name, so **every emitted candidate is valid Trino syntax**.

## Correctness — live Trino 481 differential oracle

Proven against the live oracle (`trino/internal/trinooracle`, Trino 481; tests skip cleanly without a server):

- **`TestCompletion_ContextsAreValidSyntax`** — every completion context, with a real candidate substituted at the caret, yields a statement Trino's parser **accepts**.
- **`TestCompletion_QuotingRuleMatchesOracle`** — the identifier-folding rule `QuoteIdentifierIfNeeded` encodes is the rule the engine enforces (unquoted → lower-cased; reserved word bare = `SYNTAX_ERROR`, quoted = accepted).
- **`TestCompletion_ContextNegativesMatchOracle`** — the review-surfaced negatives are pinned both ways (omni offers no offending candidate **and** the engine rejects the offending shape): `USING id` ⇒ SYNTAX_ERROR (needs `(id)`); `SET CASE` ⇒ SYNTAX_ERROR; `UPDATE t a`/`DELETE FROM t a` ⇒ SYNTAX_ERROR while `MERGE INTO t a` is accepted.

Unit coverage: **87.5%** of statements; `go vet` + `gofmt` clean; whole `trino/...` tree green (`-short`).

## Cross-review (Claude `/code-review` + Codex)

Two-family review run before opening; all blocking findings folded in and re-verified against the oracle:

- **MERGE-internal `UPDATE`** no longer mistaken for a fresh DML target (only the statement-leading keyword introduces a target).
- **UPDATE/DELETE target alias** rejected — oracle-confirmed `SYNTAX_ERROR`; alias parsed only for **MERGE** (oracle-confirmed valid).
- **INSERT target** excluded from source-`SELECT` column scope (its columns aren't visible there).
- **SET target** offers columns only (an expression keyword there is `SYNTAX_ERROR`).
- **dedup** keys on exact (not case-folded) text, so case-distinct quoted identifiers (`"Foo"`, `"foo"`) both survive.
- duplicate `where` arm and a stray bogus `set` pseudo-table removed.

## Divergences

| Case | Status | Disposition |
|---|---|---|
| Subquery tables leak into the outer-query column scope | **flagged** (ledger id 103) | `analysis.GetQuerySpan` exposes only a flat `AccessTables` (all tables in the statement, including subquery tables). A precise per-scope fix needs scope-aware resolution in `trino/analysis`, which is outside this node's writes-globs. The over-offered candidates are real column names (never invalid syntax), so the effect is extra suggestions, not wrong output. |

Backquoted identifiers (Trino 481 rejects them — oracle-confirmed) are handled the way the legacy completer's `ignoredTokens` does (treated as an identifier token); emitted candidates are always double-quoted, so output stays valid.

## Files

`completion.go` (entry, Candidate types, prefix/filter/dedup), `context.go` (token-context detection), `candidates.go` (per-context candidate production), `scope.go` (query-span FROM scope + DML-target scan + placeholder patching), `keywords.go` (curated keyword sets + `QuoteIdentifierIfNeeded`), plus `completion_test.go` / `context_test.go` / `oracle_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
