### PR TITLE
feat(trino/parser): DDL — CREATE/ALTER/DROP table/schema/view/matview/catalog, COMMENT, ANALYZE (v2 node trino/parser-ddl)

### DIFF
--- a/trino/parser/alter_table.go
+++ b/trino/parser/alter_table.go
@@ -1,0 +1,457 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-ddl DAG node. It implements Trino's
+// ALTER TABLE statement family.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	| ALTER_ TABLE_ (IF_ EXISTS_)? from RENAME_ TO_ to                              # renameTable
+//	| ALTER_ TABLE_ (IF_ EXISTS_)? tableName ADD_ COLUMN_ (IF_ NOT_ EXISTS_)? columnDefinition # addColumn
+//	| ALTER_ TABLE_ (IF_ EXISTS_)? tableName RENAME_ COLUMN_ (IF_ EXISTS_)? from TO_ to # renameColumn
+//	| ALTER_ TABLE_ (IF_ EXISTS_)? tableName DROP_ COLUMN_ (IF_ EXISTS_)? column     # dropColumn
+//	| ALTER_ TABLE_ (IF_ EXISTS_)? tableName ALTER_ COLUMN_ columnName SET_ DATA_ TYPE_ type # setColumnType
+//	| ALTER_ TABLE_ tableName SET_ AUTHORIZATION_ principal                         # setTableAuthorization
+//	| ALTER_ TABLE_ tableName SET_ PROPERTIES_ propertyAssignments                  # setTableProperties
+//	| ALTER_ TABLE_ tableName EXECUTE_ procedureName (LPAREN_ (callArgument (COMMA_ callArgument)*)? RPAREN_)? (WHERE_ where)? # tableExecute
+//
+// Adjudicated against the live Trino 481 oracle (which is ahead of the legacy
+// grammar). Oracle-confirmed facts baked in:
+//
+//	D-AT1 (names ≤ 3 parts). The table name and the RENAME-TO target are bounded
+//	   to catalog.schema.table. A column name in DROP/RENAME/ALTER COLUMN may be
+//	   dotted (e.g. a nested-field path `c.field`), so column-position names are
+//	   parsed as an unbounded qualifiedName, matching the legacy grammar.
+//	D-AT2 (ADD COLUMN position). Trino 481 accepts a trailing
+//	   `FIRST | LAST | AFTER col` on ADD COLUMN (alter-table.html), absent from
+//	   the legacy grammar; it is accepted here. The full column constraint set
+//	   (DEFAULT / NOT NULL / COMMENT / WITH) of a plain column definition applies.
+//	D-AT3 (ALTER COLUMN docs forms). Beyond the legacy `SET DATA TYPE type`,
+//	   Trino 481 accepts `ALTER COLUMN col SET DEFAULT expr`,
+//	   `ALTER COLUMN col DROP DEFAULT`, and `ALTER COLUMN col DROP NOT NULL`
+//	   (alter-table.html). All four are accepted; the oracle pins them.
+//	D-AT4 (EXECUTE named args). ALTER TABLE … EXECUTE proc(name => v, …) uses the
+//	   same callArgument grammar as CALL; the arg list and the WHERE clause are
+//	   both optional.
+//	D-AT5 (RENAME TO target is UNBOUNDED). The renameTable `to` target is an
+//	   UNBOUNDED qualifiedName: Trino 481 accepts a 4+-part target (the over-bound
+//	   failure is the semantic TABLE_NOT_FOUND, not a SYNTAX_ERROR), in contrast
+//	   to the source name which is capped at 3. Same for ALTER VIEW / ALTER
+//	   MATERIALIZED VIEW RENAME TO. (Oracle-confirmed; divergence ledger DDL4.)
+//	D-AT6 (IF EXISTS only on the column/rename sub-forms). The legacy grammar
+//	   carries `(IF_ EXISTS_)?` ONLY on renameTable / addColumn / renameColumn /
+//	   dropColumn / setColumnType — NOT on setTableAuthorization /
+//	   setTableProperties / tableExecute. Trino 481 rejects
+//	   `ALTER TABLE IF EXISTS t SET …` and `ALTER TABLE IF EXISTS t EXECUTE …` as
+//	   SYNTAX_ERRORs. IF EXISTS is parsed up-front (shared with the column
+//	   sub-forms), then the SET/EXECUTE finishers reject it. (Oracle-confirmed.)
+
+// ---------------------------------------------------------------------------
+// AST nodes
+// ---------------------------------------------------------------------------
+
+// AlterTableKind classifies an ALTER TABLE sub-form.
+type AlterTableKind int
+
+const (
+	// AlterTableRename is ALTER TABLE [IF EXISTS] name RENAME TO new.
+	AlterTableRename AlterTableKind = iota
+	// AlterTableAddColumn is ALTER TABLE … ADD COLUMN [IF NOT EXISTS] coldef [pos].
+	AlterTableAddColumn
+	// AlterTableDropColumn is ALTER TABLE … DROP COLUMN [IF EXISTS] col.
+	AlterTableDropColumn
+	// AlterTableRenameColumn is ALTER TABLE … RENAME COLUMN [IF EXISTS] from TO to.
+	AlterTableRenameColumn
+	// AlterTableAlterColumn is ALTER TABLE … ALTER COLUMN col <action>.
+	AlterTableAlterColumn
+	// AlterTableSetAuthorization is ALTER TABLE name SET AUTHORIZATION principal.
+	AlterTableSetAuthorization
+	// AlterTableSetProperties is ALTER TABLE name SET PROPERTIES …
+	AlterTableSetProperties
+	// AlterTableExecute is ALTER TABLE name EXECUTE proc[(args)] [WHERE expr].
+	AlterTableExecute
+)
+
+// ColumnPosition is the optional ADD COLUMN placement (FIRST | LAST | AFTER c).
+type ColumnPosition int
+
+const (
+	// ColumnPositionNone means no placement clause.
+	ColumnPositionNone ColumnPosition = iota
+	// ColumnPositionFirst is FIRST.
+	ColumnPositionFirst
+	// ColumnPositionLast is LAST.
+	ColumnPositionLast
+	// ColumnPositionAfter is AFTER column (After holds the reference column).
+	ColumnPositionAfter
+)
+
+// AlterColumnAction classifies an ALTER COLUMN sub-action.
+type AlterColumnAction int
+
+const (
+	// AlterColumnSetDataType is SET DATA TYPE new_type.
+	AlterColumnSetDataType AlterColumnAction = iota
+	// AlterColumnSetDefault is SET DEFAULT expr (D-AT3).
+	AlterColumnSetDefault
+	// AlterColumnDropDefault is DROP DEFAULT (D-AT3).
+	AlterColumnDropDefault
+	// AlterColumnDropNotNull is DROP NOT NULL (D-AT3).
+	AlterColumnDropNotNull
+)
+
+// AlterTableStmt is one ALTER TABLE statement. Only the fields relevant to Kind
+// are populated.
+type AlterTableStmt struct {
+	Kind     AlterTableKind
+	IfExists bool // the table-level IF EXISTS (renameTable / addColumn / dropColumn / renameColumn / setColumnType)
+	Name     *ast.QualifiedName
+
+	// RENAME TO
+	NewName *ast.QualifiedName
+
+	// ADD COLUMN
+	ColumnIfNotExists bool
+	NewColumn         *ColumnDefinition
+	Position          ColumnPosition
+	PositionAfter     *ast.Identifier // AFTER reference column (ColumnPositionAfter)
+
+	// DROP / RENAME COLUMN
+	ColumnIfExists bool
+	Column         *ast.QualifiedName // DROP COLUMN target / RENAME COLUMN from
+	RenamedColumn  *ast.Identifier    // RENAME COLUMN … TO new
+
+	// ALTER COLUMN
+	ColumnAction  AlterColumnAction
+	AlterColumn   *ast.QualifiedName // the column being altered
+	NewColumnType *DataType          // SET DATA TYPE
+	NewDefault    Expr               // SET DEFAULT expr
+
+	// SET AUTHORIZATION
+	Authorization *Principal
+
+	// SET PROPERTIES
+	Properties []*Property
+
+	// EXECUTE
+	Procedure    *ast.Identifier
+	HasArgList   bool // an (arg, …) list was present (even if empty)
+	ExecuteArgs  []CallArgument
+	ExecuteWhere Expr // optional WHERE expression
+
+	Loc ast.Loc
+}
+
+func (n *AlterTableStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *AlterTableStmt) Span() ast.Loc    { return n.Loc }
+
+var _ ast.Node = (*AlterTableStmt)(nil)
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+// parseAlterTableStmt parses ALTER TABLE. On entry cur is ALTER (the dispatch
+// has peeked TABLE as the second keyword). startOffset is ALTER's byte offset.
+func (p *Parser) parseAlterTableStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume ALTER
+	p.advance() // consume TABLE
+
+	ifExists, err := p.parseOptionalIfExists()
+	if err != nil {
+		return nil, err
+	}
+	// D-AT1: table name ≤ catalog.schema.table.
+	name, err := p.parseBoundedQualifiedName(3, "table name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &AlterTableStmt{IfExists: ifExists, Name: name, Loc: ast.Loc{Start: startOffset}}
+
+	switch p.cur.Kind {
+	case kwRENAME:
+		return p.finishAlterTableRename(stmt)
+	case kwADD:
+		return p.finishAlterTableAddColumn(stmt)
+	case kwDROP:
+		return p.finishAlterTableDropColumn(stmt)
+	case kwALTER:
+		return p.finishAlterTableAlterColumn(stmt)
+	case kwSET:
+		return p.finishAlterTableSet(stmt)
+	case kwEXECUTE:
+		return p.finishAlterTableExecute(stmt)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// finishAlterTableRename handles `RENAME { TO new | COLUMN [IF EXISTS] from TO to }`.
+func (p *Parser) finishAlterTableRename(stmt *AlterTableStmt) (ast.Node, error) {
+	p.advance() // consume RENAME
+	if _, ok := p.match(kwTO); ok {
+		// renameTable. D-AT5: the RENAME TO target is UNBOUNDED — Trino 481
+		// accepts a 4+-part target (the over-bound failure is the semantic
+		// TABLE_NOT_FOUND, not a SYNTAX_ERROR), unlike the source name which is
+		// capped at 3. So the target uses the plain qualifiedName, not the
+		// bounded form.
+		newName, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterTableRename
+		stmt.NewName = newName
+		stmt.Loc.End = newName.Loc.End
+		return stmt, nil
+	}
+	// renameColumn: RENAME COLUMN [IF EXISTS] from TO to.
+	if _, err := p.expect(kwCOLUMN); err != nil {
+		return nil, err
+	}
+	colIfExists, err := p.parseOptionalIfExists()
+	if err != nil {
+		return nil, err
+	}
+	from, err := p.parseQualifiedName() // column path may be dotted (nested field)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	to, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Kind = AlterTableRenameColumn
+	stmt.ColumnIfExists = colIfExists
+	stmt.Column = from
+	stmt.RenamedColumn = to
+	stmt.Loc.End = to.Loc.End
+	return stmt, nil
+}
+
+// finishAlterTableAddColumn handles `ADD COLUMN [IF NOT EXISTS] columnDefinition
+// [FIRST | LAST | AFTER col]` (D-AT2).
+func (p *Parser) finishAlterTableAddColumn(stmt *AlterTableStmt) (ast.Node, error) {
+	p.advance() // consume ADD
+	if _, err := p.expect(kwCOLUMN); err != nil {
+		return nil, err
+	}
+	colIfNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	col, err := p.parseColumnDefinition()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Kind = AlterTableAddColumn
+	stmt.ColumnIfNotExists = colIfNotExists
+	stmt.NewColumn = col
+	stmt.Loc.End = col.Loc.End
+
+	// D-AT2: optional placement clause.
+	switch p.cur.Kind {
+	case kwFIRST:
+		tok := p.advance()
+		stmt.Position = ColumnPositionFirst
+		stmt.Loc.End = tok.Loc.End
+	case kwLAST:
+		tok := p.advance()
+		stmt.Position = ColumnPositionLast
+		stmt.Loc.End = tok.Loc.End
+	case kwAFTER:
+		p.advance() // consume AFTER
+		after, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Position = ColumnPositionAfter
+		stmt.PositionAfter = after
+		stmt.Loc.End = after.Loc.End
+	}
+	return stmt, nil
+}
+
+// finishAlterTableDropColumn handles `DROP COLUMN [IF EXISTS] column`.
+func (p *Parser) finishAlterTableDropColumn(stmt *AlterTableStmt) (ast.Node, error) {
+	p.advance() // consume DROP
+	if _, err := p.expect(kwCOLUMN); err != nil {
+		return nil, err
+	}
+	colIfExists, err := p.parseOptionalIfExists()
+	if err != nil {
+		return nil, err
+	}
+	col, err := p.parseQualifiedName() // dotted nested-field path allowed
+	if err != nil {
+		return nil, err
+	}
+	stmt.Kind = AlterTableDropColumn
+	stmt.ColumnIfExists = colIfExists
+	stmt.Column = col
+	stmt.Loc.End = col.Loc.End
+	return stmt, nil
+}
+
+// finishAlterTableAlterColumn handles `ALTER COLUMN col { SET DATA TYPE type |
+// SET DEFAULT expr | DROP DEFAULT | DROP NOT NULL }` (D-AT3).
+func (p *Parser) finishAlterTableAlterColumn(stmt *AlterTableStmt) (ast.Node, error) {
+	p.advance() // consume ALTER
+	if _, err := p.expect(kwCOLUMN); err != nil {
+		return nil, err
+	}
+	col, err := p.parseQualifiedName() // dotted nested-field path allowed
+	if err != nil {
+		return nil, err
+	}
+	stmt.Kind = AlterTableAlterColumn
+	stmt.AlterColumn = col
+
+	switch p.cur.Kind {
+	case kwSET:
+		p.advance() // consume SET
+		switch p.cur.Kind {
+		case kwDATA:
+			p.advance() // consume DATA
+			if _, err := p.expect(kwTYPE); err != nil {
+				return nil, err
+			}
+			newType, err := p.parseType()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ColumnAction = AlterColumnSetDataType
+			stmt.NewColumnType = newType
+			stmt.Loc.End = newType.Loc.End
+		case kwDEFAULT:
+			p.advance() // consume DEFAULT
+			def, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ColumnAction = AlterColumnSetDefault
+			stmt.NewDefault = def
+			stmt.Loc.End = def.Span().End
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	case kwDROP:
+		p.advance() // consume DROP
+		switch p.cur.Kind {
+		case kwDEFAULT:
+			tok := p.advance()
+			stmt.ColumnAction = AlterColumnDropDefault
+			stmt.Loc.End = tok.Loc.End
+		case kwNOT:
+			p.advance() // consume NOT
+			nullTok, err := p.expect(kwNULL)
+			if err != nil {
+				return nil, err
+			}
+			stmt.ColumnAction = AlterColumnDropNotNull
+			stmt.Loc.End = nullTok.Loc.End
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	return stmt, nil
+}
+
+// finishAlterTableSet handles `SET { AUTHORIZATION principal | PROPERTIES … }`.
+func (p *Parser) finishAlterTableSet(stmt *AlterTableStmt) (ast.Node, error) {
+	// D-AT6 (oracle-pinned): the setTableAuthorization / setTableProperties
+	// alternatives do NOT carry `IF EXISTS` (only rename/add/drop/rename/alter
+	// column do). Trino 481 rejects `ALTER TABLE IF EXISTS t SET …` as a
+	// SYNTAX_ERROR, so reject it here even though IF EXISTS was consumed
+	// up-front (it is shared with the column sub-forms).
+	if stmt.IfExists {
+		return nil, &ParseError{Loc: stmt.Name.Loc, Msg: "IF EXISTS is not allowed on ALTER TABLE … SET"}
+	}
+	p.advance() // consume SET
+	switch p.cur.Kind {
+	case kwAUTHORIZATION:
+		p.advance() // consume AUTHORIZATION
+		princ, err := p.parseAuthorizationPrincipal()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterTableSetAuthorization
+		stmt.Authorization = princ
+		stmt.Loc.End = princ.Loc.End
+	case kwPROPERTIES:
+		p.advance() // consume PROPERTIES
+		props, err := p.parsePropertyAssignments()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterTableSetProperties
+		stmt.Properties = props
+		stmt.Loc.End = p.prev.Loc.End
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	return stmt, nil
+}
+
+// finishAlterTableExecute handles `EXECUTE proc [(callArgument, …)] [WHERE expr]`
+// (D-AT4). The argument list reuses the CALL callArgument grammar (positional or
+// `name => expr`). Both the arg list and the WHERE clause are optional.
+func (p *Parser) finishAlterTableExecute(stmt *AlterTableStmt) (ast.Node, error) {
+	// D-AT6 (oracle-pinned): the tableExecute alternative does NOT carry
+	// `IF EXISTS`; Trino 481 rejects `ALTER TABLE IF EXISTS t EXECUTE …` as a
+	// SYNTAX_ERROR.
+	if stmt.IfExists {
+		return nil, &ParseError{Loc: stmt.Name.Loc, Msg: "IF EXISTS is not allowed on ALTER TABLE … EXECUTE"}
+	}
+	p.advance() // consume EXECUTE
+	proc, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Kind = AlterTableExecute
+	stmt.Procedure = proc
+	stmt.Loc.End = proc.Loc.End
+
+	if _, ok := p.match(int('(')); ok {
+		stmt.HasArgList = true
+		if p.cur.Kind != int(')') {
+			first, err := p.parseCallArgument()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ExecuteArgs = append(stmt.ExecuteArgs, first)
+			for {
+				if _, ok := p.match(int(',')); !ok {
+					break
+				}
+				next, err := p.parseCallArgument()
+				if err != nil {
+					return nil, err
+				}
+				stmt.ExecuteArgs = append(stmt.ExecuteArgs, next)
+			}
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		stmt.Loc.End = closeTok.Loc.End
+	}
+
+	if _, ok := p.match(kwWHERE); ok {
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.ExecuteWhere = where
+		stmt.Loc.End = where.Span().End
+	}
+	return stmt, nil
+}

--- a/trino/parser/catalog_ddl.go
+++ b/trino/parser/catalog_ddl.go
@@ -1,0 +1,151 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-ddl DAG node. It implements Trino's CREATE
+// CATALOG and DROP CATALOG statements.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	| CREATE_ CATALOG_ (IF_ NOT_ EXISTS_)? catalog = identifier USING_ connectorName = identifier
+//	    (COMMENT_ string_)? (AUTHORIZATION_ principal)? (WITH_ properties)? # createCatalog
+//	| DROP_ CATALOG_ (IF_ EXISTS_)? catalog = identifier (CASCADE_ | RESTRICT_)? # dropCatalog
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed facts:
+//
+//	D-CAT1 (catalog name is a SINGLE identifier). Unlike tables/views, a CREATE
+//	   CATALOG / DROP CATALOG target is one identifier, not a dotted name;
+//	   `CREATE CATALOG a.b USING …` is a SYNTAX_ERROR.
+//	D-CAT2 (USING is mandatory on CREATE). `CREATE CATALOG c` without
+//	   `USING connector` is a SYNTAX_ERROR.
+//	D-CAT3 (connector name is a SINGLE identifier).
+//
+// NOTE on the docs vs grammar: ddl.md (drop-catalog) says "No IF EXISTS clause
+// is documented" and shows no CASCADE/RESTRICT, but the legacy grammar (and
+// the oracle) accept `DROP CATALOG [IF EXISTS] c [CASCADE | RESTRICT]`. The
+// oracle is authoritative, so the optional clauses are accepted; the
+// differential corpus pins this.
+
+// ---------------------------------------------------------------------------
+// CREATE CATALOG
+// ---------------------------------------------------------------------------
+
+// CreateCatalogStmt is `CREATE CATALOG [IF NOT EXISTS] name USING connector
+// [COMMENT str] [AUTHORIZATION principal] [WITH (props)]`.
+type CreateCatalogStmt struct {
+	IfNotExists   bool
+	Name          *ast.Identifier
+	Connector     *ast.Identifier
+	Comment       *string
+	Authorization *Principal
+	Properties    []*Property
+	Loc           ast.Loc
+}
+
+func (n *CreateCatalogStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CreateCatalogStmt) Span() ast.Loc    { return n.Loc }
+
+// parseCreateCatalogStmt parses CREATE CATALOG. On entry cur is CREATE (dispatch
+// peeked CATALOG).
+func (p *Parser) parseCreateCatalogStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume CREATE
+	p.advance() // consume CATALOG
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	// D-CAT1: catalog name is a single identifier.
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	// D-CAT2: USING connector is mandatory.
+	if _, err := p.expect(kwUSING); err != nil {
+		return nil, err
+	}
+	// D-CAT3: connector name is a single identifier.
+	connector, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &CreateCatalogStmt{
+		IfNotExists: ifNotExists,
+		Name:        name,
+		Connector:   connector,
+		Loc:         ast.Loc{Start: startOffset, End: connector.Loc.End},
+	}
+
+	// Optional COMMENT, AUTHORIZATION, WITH — in the grammar's fixed order.
+	comment, err := p.parseOptionalComment()
+	if err != nil {
+		return nil, err
+	}
+	if comment != nil {
+		stmt.Comment = comment
+		stmt.Loc.End = p.prev.Loc.End
+	}
+	if _, ok := p.match(kwAUTHORIZATION); ok {
+		princ, err := p.parseAuthorizationPrincipal()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Authorization = princ
+		stmt.Loc.End = princ.Loc.End
+	}
+	props, err := p.parseOptionalWithProperties()
+	if err != nil {
+		return nil, err
+	}
+	if props != nil {
+		stmt.Properties = props
+		stmt.Loc.End = p.prev.Loc.End
+	}
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// DROP CATALOG
+// ---------------------------------------------------------------------------
+
+// DropCatalogStmt is `DROP CATALOG [IF EXISTS] name [CASCADE | RESTRICT]`.
+type DropCatalogStmt struct {
+	IfExists bool
+	Name     *ast.Identifier
+	Behavior DropBehavior
+	Loc      ast.Loc
+}
+
+func (n *DropCatalogStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *DropCatalogStmt) Span() ast.Loc    { return n.Loc }
+
+// parseDropCatalogStmt parses DROP CATALOG. On entry cur is DROP (dispatch
+// peeked CATALOG).
+func (p *Parser) parseDropCatalogStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume DROP
+	p.advance() // consume CATALOG
+	ifExists, err := p.parseOptionalIfExists()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &DropCatalogStmt{IfExists: ifExists, Name: name, Loc: ast.Loc{Start: startOffset, End: name.Loc.End}}
+	if tok, ok := p.match(kwCASCADE, kwRESTRICT); ok {
+		if tok.Kind == kwCASCADE {
+			stmt.Behavior = DropBehaviorCascade
+		} else {
+			stmt.Behavior = DropBehaviorRestrict
+		}
+		stmt.Loc.End = tok.Loc.End
+	}
+	return stmt, nil
+}
+
+var (
+	_ ast.Node = (*CreateCatalogStmt)(nil)
+	_ ast.Node = (*DropCatalogStmt)(nil)
+)

--- a/trino/parser/comment_analyze.go
+++ b/trino/parser/comment_analyze.go
@@ -1,0 +1,147 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-ddl DAG node. It implements Trino's
+// COMMENT ON and ANALYZE statements.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	| COMMENT_ ON_ TABLE_ qualifiedName IS_ (string_ | NULL_)  # commentTable
+//	| COMMENT_ ON_ VIEW_ qualifiedName IS_ (string_ | NULL_)   # commentView
+//	| COMMENT_ ON_ COLUMN_ qualifiedName IS_ (string_ | NULL_) # commentColumn
+//	| ANALYZE_ qualifiedName (WITH_ properties)?               # analyze
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed facts:
+//
+//	D-CM1 (COMMENT value is a string OR NULL). `COMMENT ON TABLE t IS 'x'` and
+//	   `COMMENT ON TABLE t IS NULL` (clear) are both accepted; anything else
+//	   after IS is a SYNTAX_ERROR.
+//	D-CM2 (object name part-count). TABLE/VIEW names are ≤ catalog.schema.object
+//	   (3 parts); a COLUMN name is catalog.schema.table.column (≤ 4 parts), since
+//	   it includes the column component (ddl.md comment-on-column).
+//	D-AN1 (ANALYZE target ≤ 3 parts). The ANALYZE table name is bounded to
+//	   catalog.schema.table.
+
+// ---------------------------------------------------------------------------
+// COMMENT ON
+// ---------------------------------------------------------------------------
+
+// CommentObjectKind classifies the COMMENT ON target.
+type CommentObjectKind int
+
+const (
+	// CommentOnTable is COMMENT ON TABLE.
+	CommentOnTable CommentObjectKind = iota
+	// CommentOnView is COMMENT ON VIEW.
+	CommentOnView
+	// CommentOnColumn is COMMENT ON COLUMN.
+	CommentOnColumn
+)
+
+// CommentStmt is `COMMENT ON {TABLE | VIEW | COLUMN} name IS (string | NULL)`.
+// IsNull is true for the `IS NULL` clear form; Comment holds the decoded string
+// otherwise.
+type CommentStmt struct {
+	Object  CommentObjectKind
+	Name    *ast.QualifiedName
+	IsNull  bool
+	Comment string // decoded string value (empty and meaningless when IsNull)
+	Loc     ast.Loc
+}
+
+func (n *CommentStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CommentStmt) Span() ast.Loc    { return n.Loc }
+
+// parseCommentStmt parses COMMENT ON {TABLE|VIEW|COLUMN} name IS (string|NULL).
+// On entry cur is COMMENT.
+func (p *Parser) parseCommentStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume COMMENT
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+
+	var (
+		object   CommentObjectKind
+		maxParts int
+	)
+	switch p.cur.Kind {
+	case kwTABLE:
+		p.advance()
+		object, maxParts = CommentOnTable, 3
+	case kwVIEW:
+		p.advance()
+		object, maxParts = CommentOnView, 3
+	case kwCOLUMN:
+		p.advance()
+		// D-CM2: a column reference carries its column component too.
+		object, maxParts = CommentOnColumn, 4
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	name, err := p.parseBoundedQualifiedName(maxParts, "comment target")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwIS); err != nil {
+		return nil, err
+	}
+
+	stmt := &CommentStmt{Object: object, Name: name, Loc: ast.Loc{Start: startOffset}}
+
+	// D-CM1: the comment value is a string literal or NULL.
+	if nullTok, ok := p.match(kwNULL); ok {
+		stmt.IsNull = true
+		stmt.Loc.End = nullTok.Loc.End
+		return stmt, nil
+	}
+	str, err := p.expectStringLiteral("COMMENT value")
+	if err != nil {
+		return nil, err
+	}
+	stmt.Comment = str.Str
+	stmt.Loc.End = str.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ANALYZE
+// ---------------------------------------------------------------------------
+
+// AnalyzeStmt is `ANALYZE table_name [WITH (props)]`.
+type AnalyzeStmt struct {
+	Name       *ast.QualifiedName
+	Properties []*Property
+	Loc        ast.Loc
+}
+
+func (n *AnalyzeStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *AnalyzeStmt) Span() ast.Loc    { return n.Loc }
+
+// parseAnalyzeStmt parses ANALYZE name [WITH (props)]. On entry cur is ANALYZE.
+func (p *Parser) parseAnalyzeStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume ANALYZE
+	// D-AN1: target is at most catalog.schema.table.
+	name, err := p.parseBoundedQualifiedName(3, "analyze target")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &AnalyzeStmt{Name: name, Loc: ast.Loc{Start: startOffset, End: name.Loc.End}}
+	props, err := p.parseOptionalWithProperties()
+	if err != nil {
+		return nil, err
+	}
+	if props != nil {
+		stmt.Properties = props
+		stmt.Loc.End = p.prev.Loc.End
+	}
+	return stmt, nil
+}
+
+var (
+	_ ast.Node = (*CommentStmt)(nil)
+	_ ast.Node = (*AnalyzeStmt)(nil)
+)

--- a/trino/parser/create_table.go
+++ b/trino/parser/create_table.go
@@ -1,0 +1,593 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-ddl DAG node. It implements Trino's CREATE
+// TABLE statements (the createTable and createTableAsSelect alternatives) plus
+// the shared property-list and column-definition helpers the rest of the DDL
+// node reuses (ALTER TABLE, CREATE SCHEMA/VIEW/MATERIALIZED VIEW, CREATE
+// CATALOG, ANALYZE all parse a `WITH ( property = value, … )` list).
+//
+// The statement / clause structs live here in package parser (matching the
+// Trino convention for parser-built node types — Expr in expr.go, DataType in
+// datatypes.go, the DML nodes in insert.go). They satisfy ast.Node via a Tag()
+// returning the placeholder ast.T_Invalid because the ast node-tag set is
+// closed to the ast-core node (File / Identifier / QualifiedName) plus the
+// utility/dcl-tcl statement tags; downstream consumers (analysis, completion,
+// deparse) reach the concrete statement type by a Go type switch, exactly as
+// they do for QueryStmt / InsertStmt.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : CREATE_ (OR_ REPLACE_)? TABLE_ (IF_ NOT_ EXISTS_)? qualifiedName
+//	        columnAliases? (COMMENT_ string_)? (WITH_ properties)?
+//	        AS_ (rootQuery | LPAREN_ rootQuery RPAREN_) (WITH_ (NO_)? DATA_)?  # createTableAsSelect
+//	    | CREATE_ (OR_ REPLACE_)? TABLE_ (IF_ NOT_ EXISTS_)? qualifiedName
+//	        LPAREN_ tableElement (COMMA_ tableElement)* RPAREN_
+//	        (COMMENT_ string_)? (WITH_ properties)?                           # createTable
+//	    ;
+//	tableElement     : columnDefinition | likeClause ;
+//	columnDefinition : identifier type (NOT_ NULL_)? (COMMENT_ string_)? (WITH_ properties)? ;
+//	likeClause       : LIKE_ qualifiedName ((INCLUDING_ | EXCLUDING_) PROPERTIES_)? ;
+//	properties           : LPAREN_ propertyAssignments RPAREN_ ;
+//	propertyAssignments  : property (COMMA_ property)* ;
+//	property             : identifier EQ_ propertyValue ;
+//	propertyValue        : DEFAULT_ | expression ;
+//
+// The implementation is adjudicated against the live Trino 481 oracle, not the
+// literal legacy grammar (which lags 481). Oracle-confirmed facts baked in:
+//
+//	D-CT1 (target ≤ catalog.schema.table). `CREATE TABLE a.b.c.d (…)` is a
+//	   SYNTAX_ERROR; the target qualifiedName is bounded to 3 parts.
+//	D-CT2 (column DEFAULT + FIXED clause order). Trino 481 accepts `col type
+//	   DEFAULT expr` in a column definition — the legacy grammar omits DEFAULT
+//	   (docs-ahead, ddl.md create-table). The optional column-constraint clauses
+//	   appear in a FIXED order: DEFAULT, then NOT NULL, then COMMENT, then WITH,
+//	   each at most once. 481 REJECTS out-of-order clauses (`NOT NULL DEFAULT 5`,
+//	   `COMMENT 'x' NOT NULL`, `WITH (...) NOT NULL` are all SYNTAX_ERRORs), so
+//	   parseColumnDefinition consumes them as a strict sequence, not a free set
+//	   — verified case-by-case against the oracle.
+//	D-CT6 (OR REPLACE ⊕ IF NOT EXISTS). CREATE TABLE rejects the two together at
+//	   PARSE time (SYNTAX_ERROR). This is TABLE-specific: the same combination on
+//	   CREATE MATERIALIZED VIEW is NOT_SUPPORTED (semantic, grammar-accepted).
+//	D-CT3 (empty body rejected). `CREATE TABLE t ()` is a SYNTAX_ERROR — the
+//	   parenthesized form requires at least one tableElement.
+//	D-CT4 (CTAS requires AS query). The createTable form (paren column list) and
+//	   the createTableAsSelect form (`AS query`) are distinct; a bare
+//	   `CREATE TABLE t` with neither is a SYNTAX_ERROR.
+//	D-CT5 (CTAS column aliases are bare identifiers). `CREATE TABLE t (a, b) AS …`
+//	   parses (a, b) as output-column aliases, NOT column definitions: the
+//	   trailing `AS query` disambiguates. A parenthesized list whose entries are
+//	   `ident type …` is the column-definition form and must NOT be followed by AS.
+
+// createObjectKeyword reports the object keyword of a CREATE statement — the
+// token kind directly after CREATE, or after an optional `OR REPLACE` prefix
+// (CREATE OR REPLACE { TABLE | VIEW | MATERIALIZED VIEW }). It does NOT consume
+// input (it uses checkpoint/restore for the OR-REPLACE lookahead, which the
+// parser's two-token window cannot reach). The CREATE dispatch uses it to route
+// to the right per-object DDL parser; ROLE / FUNCTION are handled before this
+// is reached. On entry cur is the CREATE keyword.
+func (p *Parser) createObjectKeyword() TokenKind {
+	if p.peekNext().Kind != kwOR {
+		return p.peekNext().Kind
+	}
+	cp := p.checkpoint()
+	defer p.restore(cp)
+	p.advance() // consume CREATE
+	p.advance() // consume OR (already confirmed)
+	if p.cur.Kind != kwREPLACE {
+		return tokInvalid
+	}
+	p.advance() // consume REPLACE
+	return p.cur.Kind
+}
+
+// ---------------------------------------------------------------------------
+// Property list (shared across the DDL node)
+// ---------------------------------------------------------------------------
+
+// Property is one `identifier = propertyValue` assignment inside a
+// `WITH ( … )` list (or an ALTER … SET PROPERTIES list). Value is nil when the
+// property uses the `= DEFAULT` reset form (IsDefault is then true).
+type Property struct {
+	Name      *ast.Identifier
+	Value     Expr // nil iff IsDefault
+	IsDefault bool // the `name = DEFAULT` reset form
+	Loc       ast.Loc
+}
+
+// parsePropertyList parses a `( property (, property)* )` list. On entry cur is
+// the opening '('. The list must be non-empty (Trino rejects `WITH ()`). Each
+// property is `identifier = ( DEFAULT | expression )`.
+func (p *Parser) parsePropertyList() ([]*Property, ast.Loc, error) {
+	openTok, err := p.expect(int('('))
+	if err != nil {
+		return nil, ast.Loc{}, err
+	}
+	first, err := p.parseProperty()
+	if err != nil {
+		return nil, ast.Loc{}, err
+	}
+	props := []*Property{first}
+	for {
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+		next, err := p.parseProperty()
+		if err != nil {
+			return nil, ast.Loc{}, err
+		}
+		props = append(props, next)
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, ast.Loc{}, err
+	}
+	return props, ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End}, nil
+}
+
+// parseProperty parses one `identifier = ( DEFAULT | expression )`.
+func (p *Parser) parseProperty() (*Property, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return nil, err
+	}
+	// propertyValue: DEFAULT keyword (reset) or an expression. DEFAULT is a
+	// reserved keyword, so a bare `= DEFAULT` cannot be a column reference.
+	if defTok, ok := p.match(kwDEFAULT); ok {
+		return &Property{
+			Name:      name,
+			IsDefault: true,
+			Loc:       ast.Loc{Start: name.Loc.Start, End: defTok.Loc.End},
+		}, nil
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &Property{
+		Name:  name,
+		Value: value,
+		Loc:   ast.Loc{Start: name.Loc.Start, End: value.Span().End},
+	}, nil
+}
+
+// parseOptionalWithProperties consumes a `WITH ( property, … )` clause when the
+// current token is WITH, returning the property list (nil when WITH is absent).
+func (p *Parser) parseOptionalWithProperties() ([]*Property, error) {
+	if _, ok := p.match(kwWITH); !ok {
+		return nil, nil
+	}
+	props, _, err := p.parsePropertyList()
+	return props, err
+}
+
+// ---------------------------------------------------------------------------
+// Column definitions / table elements
+// ---------------------------------------------------------------------------
+
+// ColumnDefinition is one `identifier type [DEFAULT expr] [NOT NULL]
+// [COMMENT str] [WITH (props)]` column of a CREATE TABLE body (columnDefinition
+// rule). Each constraint clause is optional and at most once.
+type ColumnDefinition struct {
+	Name       *ast.Identifier
+	Type       *DataType
+	Default    Expr // DEFAULT expr (D-CT2 docs-ahead extension); nil when absent
+	NotNull    bool
+	Comment    *string // COMMENT string literal value (decoded); nil when absent
+	Properties []*Property
+	Loc        ast.Loc
+}
+
+// LikeClause is a `LIKE qualifiedName [{INCLUDING | EXCLUDING} PROPERTIES]`
+// table element. Including is true for INCLUDING PROPERTIES, false for
+// EXCLUDING PROPERTIES or no option (EXCLUDING is the default).
+type LikeClause struct {
+	Source    *ast.QualifiedName
+	HasOption bool // an explicit INCLUDING/EXCLUDING PROPERTIES was given
+	Including bool // INCLUDING PROPERTIES (only meaningful when HasOption)
+	Loc       ast.Loc
+}
+
+// TableElement is one entry of a CREATE TABLE parenthesized body: either a
+// column definition or a LIKE clause. Exactly one of Column / Like is non-nil.
+type TableElement struct {
+	Column *ColumnDefinition
+	Like   *LikeClause
+}
+
+// parseTableElement parses one tableElement: a `LIKE …` clause or a column
+// definition. The LIKE keyword unambiguously selects the likeClause form;
+// anything else is a columnDefinition (which begins with an identifier).
+func (p *Parser) parseTableElement() (*TableElement, error) {
+	if p.cur.Kind == kwLIKE {
+		like, err := p.parseLikeClause()
+		if err != nil {
+			return nil, err
+		}
+		return &TableElement{Like: like}, nil
+	}
+	col, err := p.parseColumnDefinition()
+	if err != nil {
+		return nil, err
+	}
+	return &TableElement{Column: col}, nil
+}
+
+// parseLikeClause parses `LIKE qualifiedName [{INCLUDING | EXCLUDING}
+// PROPERTIES]`. On entry cur is the LIKE keyword.
+func (p *Parser) parseLikeClause() (*LikeClause, error) {
+	likeTok := p.advance() // consume LIKE
+	src, err := p.parseQualifiedName()
+	if err != nil {
+		return nil, err
+	}
+	lc := &LikeClause{Source: src, Loc: ast.Loc{Start: likeTok.Loc.Start, End: src.Loc.End}}
+	if opt, ok := p.match(kwINCLUDING, kwEXCLUDING); ok {
+		propsTok, err := p.expect(kwPROPERTIES)
+		if err != nil {
+			return nil, err
+		}
+		lc.HasOption = true
+		lc.Including = opt.Kind == kwINCLUDING
+		lc.Loc.End = propsTok.Loc.End
+	}
+	return lc, nil
+}
+
+// parseColumnDefinition parses `identifier type [DEFAULT expr] [NOT NULL]
+// [COMMENT str] [WITH (props)]`. The optional constraint clauses appear in a
+// FIXED order — DEFAULT, then NOT NULL, then COMMENT, then WITH — each at most
+// once. The order is oracle-pinned (D-CT2): Trino 481 rejects out-of-order
+// clauses (`NOT NULL DEFAULT 5`, `COMMENT 'x' NOT NULL`, `WITH (...) NOT NULL`
+// are all SYNTAX_ERRORs), so the parser consumes them as a strict sequence, not
+// an order-tolerant set. The legacy grammar omits DEFAULT entirely; 481 adds it
+// as the first clause (ddl.md create-table).
+func (p *Parser) parseColumnDefinition() (*ColumnDefinition, error) {
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	colType, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	col := &ColumnDefinition{
+		Name: name,
+		Type: colType,
+		Loc:  ast.Loc{Start: name.Loc.Start, End: colType.Loc.End},
+	}
+
+	// 1. DEFAULT expr (D-CT2 docs-ahead extension).
+	if _, ok := p.match(kwDEFAULT); ok {
+		def, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		col.Default = def
+		col.Loc.End = def.Span().End
+	}
+	// 2. NOT NULL.
+	if p.cur.Kind == kwNOT {
+		p.advance() // consume NOT
+		nullTok, err := p.expect(kwNULL)
+		if err != nil {
+			return nil, err
+		}
+		col.NotNull = true
+		col.Loc.End = nullTok.Loc.End
+	}
+	// 3. COMMENT str.
+	if _, ok := p.match(kwCOMMENT); ok {
+		str, err := p.expectStringLiteral("column COMMENT")
+		if err != nil {
+			return nil, err
+		}
+		s := str.Str
+		col.Comment = &s
+		col.Loc.End = str.Loc.End
+	}
+	// 4. WITH (props).
+	if _, ok := p.match(kwWITH); ok {
+		props, loc, err := p.parsePropertyList()
+		if err != nil {
+			return nil, err
+		}
+		col.Properties = props
+		col.Loc.End = loc.End
+	}
+	return col, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TABLE
+// ---------------------------------------------------------------------------
+
+// CreateTableStmt is a `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] name (…)
+// [COMMENT str] [WITH (props)]` statement (the createTable alternative — the
+// explicit-column-list form, NOT the AS-query form, which is CreateTableAsStmt).
+type CreateTableStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ast.QualifiedName
+	Elements    []*TableElement // at least one (D-CT3)
+	Comment     *string         // table COMMENT; nil when absent
+	Properties  []*Property
+	Loc         ast.Loc
+}
+
+func (n *CreateTableStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CreateTableStmt) Span() ast.Loc    { return n.Loc }
+
+// CreateTableAsStmt is a `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] name
+// [(col_alias, …)] [COMMENT str] [WITH (props)] AS query [WITH [NO] DATA]`
+// statement (the createTableAsSelect alternative). ColumnAliases renames the
+// query's output columns; WithData / NoData record the trailing data clause.
+type CreateTableAsStmt struct {
+	OrReplace     bool
+	IfNotExists   bool
+	Name          *ast.QualifiedName
+	ColumnAliases []*ast.Identifier // optional output-column aliases (nil when absent)
+	Comment       *string
+	Properties    []*Property
+	Query         *Query
+	HasDataClause bool // a trailing WITH [NO] DATA was given
+	NoData        bool // WITH NO DATA (only meaningful when HasDataClause)
+	Loc           ast.Loc
+}
+
+func (n *CreateTableAsStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CreateTableAsStmt) Span() ast.Loc    { return n.Loc }
+
+var (
+	_ ast.Node = (*CreateTableStmt)(nil)
+	_ ast.Node = (*CreateTableAsStmt)(nil)
+)
+
+// parseCreateTableStmt parses both CREATE TABLE forms. On entry cur is the
+// CREATE keyword (not yet consumed); startOffset is CREATE's byte offset.
+//
+// The createTable (paren column list) and createTableAsSelect (AS query) forms
+// share a prefix up to and past the target name; they diverge on whether a '('
+// here opens a column-definition list or an output-alias list. The
+// disambiguation cannot be made locally (`CREATE TABLE t (a` could be either a
+// column `a <type>` or an alias `a`), so the parenthesized list is parsed once
+// in a mode that accepts BOTH shapes, and the presence of a trailing AS decides
+// which statement form was meant (D-CT5).
+func (p *Parser) parseCreateTableStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume CREATE
+	orReplace := false
+	if _, ok := p.match(kwOR); ok {
+		if _, err := p.expect(kwREPLACE); err != nil {
+			return nil, err
+		}
+		orReplace = true
+	}
+	if _, err := p.expect(kwTABLE); err != nil {
+		return nil, err
+	}
+	ifNotExistsTok := p.cur
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	// D-CT6 (oracle-pinned): CREATE TABLE rejects OR REPLACE together with
+	// IF NOT EXISTS at PARSE time (SYNTAX_ERROR), matching the docs ("OR REPLACE
+	// and IF NOT EXISTS cannot be used together"). Note this is TABLE-specific:
+	// the same combination on CREATE MATERIALIZED VIEW is NOT_SUPPORTED
+	// (semantic, accepted by the grammar), so that parser does NOT reject it.
+	if orReplace && ifNotExists {
+		return nil, &ParseError{
+			Loc: ifNotExistsTok.Loc,
+			Msg: "CREATE TABLE cannot combine OR REPLACE with IF NOT EXISTS",
+		}
+	}
+
+	// D-CT1: target is at most catalog.schema.table.
+	name, err := p.parseBoundedQualifiedName(3, "table name")
+	if err != nil {
+		return nil, err
+	}
+
+	// A '(' here opens either a column-definition list (createTable) or an
+	// output-alias list (createTableAsSelect). Parse the contents once,
+	// recording enough to build either node, then let the trailing AS decide.
+	var (
+		elements      []*TableElement
+		columnAliases []*ast.Identifier
+		hadParen      bool
+		aliasOnly     bool // every paren entry was a bare identifier (alias-shaped)
+	)
+	if p.cur.Kind == int('(') {
+		hadParen = true
+		elements, columnAliases, aliasOnly, err = p.parseCreateTableParenBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Optional COMMENT then optional WITH (properties), in that grammar order.
+	comment, err := p.parseOptionalComment()
+	if err != nil {
+		return nil, err
+	}
+	properties, err := p.parseOptionalWithProperties()
+	if err != nil {
+		return nil, err
+	}
+
+	// The trailing AS decides the form. With AS → createTableAsSelect (the paren
+	// list, if any, is column aliases — must be alias-shaped). Without AS →
+	// createTable (the paren list is column definitions and is mandatory).
+	if p.cur.Kind == kwAS {
+		return p.finishCreateTableAs(startOffset, orReplace, ifNotExists, name, columnAliases, aliasOnly, hadParen, comment, properties)
+	}
+
+	// createTable: the parenthesized column-definition body is mandatory (D-CT4).
+	if !hadParen {
+		return nil, p.syntaxErrorAtCur()
+	}
+	// A list that was purely bare identifiers (no types) is only valid as CTAS
+	// aliases, which require AS — without AS it is an incomplete column
+	// definition (each column needs a type). Reject to match Trino.
+	if aliasOnly {
+		return nil, &ParseError{Loc: name.Loc, Msg: "expected column type in CREATE TABLE column definition"}
+	}
+	stmt := &CreateTableStmt{
+		OrReplace:   orReplace,
+		IfNotExists: ifNotExists,
+		Name:        name,
+		Elements:    elements,
+		Comment:     comment,
+		Properties:  properties,
+		Loc:         ast.Loc{Start: startOffset, End: p.prev.Loc.End},
+	}
+	return stmt, nil
+}
+
+// finishCreateTableAs completes a createTableAsSelect after the shared prefix.
+// On entry cur is the AS keyword. columnAliases holds the optional output-alias
+// list (already parsed); aliasOnly reports whether the paren body was purely
+// bare identifiers (the only legal CTAS alias shape); hadParen reports whether
+// any '(' was present.
+func (p *Parser) finishCreateTableAs(startOffset int, orReplace, ifNotExists bool, name *ast.QualifiedName, columnAliases []*ast.Identifier, aliasOnly, hadParen bool, comment *string, properties []*Property) (ast.Node, error) {
+	// If a paren list was present it must be alias-shaped (bare identifiers);
+	// a column-definition-shaped list (`a bigint`) before AS is a syntax error.
+	if hadParen && !aliasOnly {
+		return nil, &ParseError{Loc: name.Loc, Msg: "CREATE TABLE AS column list must be plain column aliases"}
+	}
+	p.advance() // consume AS
+
+	// The query may be parenthesized: `AS (query)`. parseQuery handles the
+	// SELECT / VALUES / TABLE / WITH … forms and a leading '(' subquery.
+	query, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &CreateTableAsStmt{
+		OrReplace:     orReplace,
+		IfNotExists:   ifNotExists,
+		Name:          name,
+		ColumnAliases: columnAliases,
+		Comment:       comment,
+		Properties:    properties,
+		Query:         query,
+		Loc:           ast.Loc{Start: startOffset, End: query.Loc.End},
+	}
+
+	// Optional trailing WITH [NO] DATA.
+	if _, ok := p.match(kwWITH); ok {
+		stmt.HasDataClause = true
+		if _, ok := p.match(kwNO); ok {
+			stmt.NoData = true
+		}
+		dataTok, err := p.expect(kwDATA)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Loc.End = dataTok.Loc.End
+	}
+	return stmt, nil
+}
+
+// parseCreateTableParenBody parses the `( … )` body shared by the createTable
+// and createTableAsSelect forms. It returns BOTH interpretations: elements is
+// the column-definition / LIKE list, columnAliases is the alias list (populated
+// only when every entry was a bare identifier), and aliasOnly reports the
+// alias-shaped case. On entry cur is the opening '('.
+//
+// Each entry is parsed as a full tableElement (column definition or LIKE). When
+// an entry is a column whose definition is exactly a bare identifier with no
+// type (only possible as a CTAS alias), it is recorded as an alias instead.
+// Because a column definition requires a type, the parser cannot know upfront
+// which form it is in; it parses optimistically and tracks whether the list
+// stayed alias-shaped throughout.
+func (p *Parser) parseCreateTableParenBody() (elements []*TableElement, columnAliases []*ast.Identifier, aliasOnly bool, err error) {
+	if _, err = p.expect(int('(')); err != nil {
+		return nil, nil, false, err
+	}
+	aliasOnly = true
+	for {
+		// Peek: a bare identifier immediately followed by ',' or ')' is an alias
+		// (no type), the only CTAS-alias shape. Anything else is a real
+		// tableElement (column definition with a type, or LIKE).
+		if isIdentifierStart(p.cur.Kind) && p.cur.Kind != kwLIKE &&
+			(p.peekNext().Kind == int(',') || p.peekNext().Kind == int(')')) {
+			alias := identFromToken(p.advance())
+			columnAliases = append(columnAliases, alias)
+			// Also record a column element so the createTable error path can
+			// report a missing type rather than losing the entry.
+			elements = append(elements, &TableElement{Column: &ColumnDefinition{Name: alias, Loc: alias.Loc}})
+		} else {
+			elem, perr := p.parseTableElement()
+			if perr != nil {
+				return nil, nil, false, perr
+			}
+			elements = append(elements, elem)
+			aliasOnly = false
+		}
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	if _, err = p.expect(int(')')); err != nil {
+		return nil, nil, false, err
+	}
+	if !aliasOnly {
+		columnAliases = nil
+	}
+	return elements, columnAliases, aliasOnly, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared small clause helpers (used across the DDL node)
+// ---------------------------------------------------------------------------
+
+// parseOptionalIfNotExists consumes an `IF NOT EXISTS` clause when present,
+// returning whether it was found. A bare `IF` not followed by `NOT EXISTS` is a
+// syntax error (IF is otherwise not a statement-position keyword here).
+func (p *Parser) parseOptionalIfNotExists() (bool, error) {
+	if _, ok := p.match(kwIF); !ok {
+		return false, nil
+	}
+	if _, err := p.expect(kwNOT); err != nil {
+		return false, err
+	}
+	if _, err := p.expect(kwEXISTS); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// parseOptionalIfExists consumes an `IF EXISTS` clause when present, returning
+// whether it was found.
+func (p *Parser) parseOptionalIfExists() (bool, error) {
+	if _, ok := p.match(kwIF); !ok {
+		return false, nil
+	}
+	if _, err := p.expect(kwEXISTS); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// parseOptionalComment consumes a `COMMENT string_` clause when present,
+// returning the decoded string value (nil when absent).
+func (p *Parser) parseOptionalComment() (*string, error) {
+	if _, ok := p.match(kwCOMMENT); !ok {
+		return nil, nil
+	}
+	str, err := p.expectStringLiteral("COMMENT")
+	if err != nil {
+		return nil, err
+	}
+	s := str.Str
+	return &s, nil
+}

--- a/trino/parser/ddl_structure_test.go
+++ b/trino/parser/ddl_structure_test.go
@@ -1,0 +1,438 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-ddl node's STRUCTURAL gate (correctness-protocol.md):
+// the differential oracle (oracle_ddl_test.go) proves accept/reject parity with
+// Trino 481, but cannot see the AST omni builds. These tests assert the parsed
+// node type and its field values for one representative of each DDL form, so a
+// regression that still parses but mis-assigns a clause (e.g. swapping RENAME
+// source/target, dropping a property, losing IF EXISTS) is caught.
+
+func TestDDLStructure_CreateTable(t *testing.T) {
+	file, errs := Parse("CREATE OR REPLACE TABLE cat.sch.orders (orderkey bigint NOT NULL, name varchar COMMENT 'n', LIKE base INCLUDING PROPERTIES) COMMENT 'tbl' WITH (format = 'ORC')")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	stmt, ok := file.Stmts[0].(*CreateTableStmt)
+	if !ok {
+		t.Fatalf("got %T, want *CreateTableStmt", file.Stmts[0])
+	}
+	if !stmt.OrReplace {
+		t.Error("OrReplace = false, want true")
+	}
+	if stmt.IfNotExists {
+		t.Error("IfNotExists = true, want false")
+	}
+	if got := stmt.Name.String(); got != "cat.sch.orders" {
+		t.Errorf("Name = %q, want cat.sch.orders", got)
+	}
+	if len(stmt.Elements) != 3 {
+		t.Fatalf("len(Elements) = %d, want 3", len(stmt.Elements))
+	}
+	// Element 0: orderkey bigint NOT NULL
+	c0 := stmt.Elements[0].Column
+	if c0 == nil || c0.Name.Value != "orderkey" || !c0.NotNull {
+		t.Errorf("element0 = %+v, want column orderkey NOT NULL", c0)
+	}
+	// Element 1: name varchar COMMENT 'n'
+	c1 := stmt.Elements[1].Column
+	if c1 == nil || c1.Comment == nil || *c1.Comment != "n" {
+		t.Errorf("element1 comment = %v, want 'n'", c1)
+	}
+	// Element 2: LIKE base INCLUDING PROPERTIES
+	l2 := stmt.Elements[2].Like
+	if l2 == nil || l2.Source.String() != "base" || !l2.HasOption || !l2.Including {
+		t.Errorf("element2 = %+v, want LIKE base INCLUDING PROPERTIES", l2)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "tbl" {
+		t.Errorf("table comment = %v, want 'tbl'", stmt.Comment)
+	}
+	if len(stmt.Properties) != 1 || stmt.Properties[0].Name.Value != "format" {
+		t.Errorf("properties = %+v, want [format=...]", stmt.Properties)
+	}
+}
+
+func TestDDLStructure_CreateTableAs(t *testing.T) {
+	file, errs := Parse("CREATE TABLE t (a, b) WITH (x = 1) AS SELECT 1, 2 WITH NO DATA")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	stmt, ok := file.Stmts[0].(*CreateTableAsStmt)
+	if !ok {
+		t.Fatalf("got %T, want *CreateTableAsStmt", file.Stmts[0])
+	}
+	if len(stmt.ColumnAliases) != 2 || stmt.ColumnAliases[0].Value != "a" || stmt.ColumnAliases[1].Value != "b" {
+		t.Errorf("ColumnAliases = %+v, want [a b]", stmt.ColumnAliases)
+	}
+	if stmt.Query == nil {
+		t.Error("Query is nil")
+	}
+	if !stmt.HasDataClause || !stmt.NoData {
+		t.Errorf("data clause: HasDataClause=%v NoData=%v, want true/true", stmt.HasDataClause, stmt.NoData)
+	}
+	if len(stmt.Properties) != 1 {
+		t.Errorf("properties = %+v, want 1", stmt.Properties)
+	}
+}
+
+func TestDDLStructure_ColumnDefault(t *testing.T) {
+	// DEFAULT then NOT NULL (the only legal order, D-CT2).
+	file, errs := Parse("CREATE TABLE t (status varchar DEFAULT 'created' NOT NULL)")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	stmt := file.Stmts[0].(*CreateTableStmt)
+	col := stmt.Elements[0].Column
+	if col.Default == nil {
+		t.Error("Default is nil, want 'created' expression")
+	}
+	if !col.NotNull {
+		t.Error("NotNull = false, want true")
+	}
+}
+
+func TestDDLStructure_DropVariants(t *testing.T) {
+	cases := []struct {
+		sql      string
+		object   DropObjectKind
+		ifExists bool
+		name     string
+		behavior DropBehavior
+	}{
+		{"DROP TABLE IF EXISTS a.b.c", DropTable, true, "a.b.c", DropBehaviorDefault},
+		{"DROP SCHEMA s CASCADE", DropSchema, false, "s", DropBehaviorCascade},
+		{"DROP SCHEMA IF EXISTS s RESTRICT", DropSchema, true, "s", DropBehaviorRestrict},
+		{"DROP VIEW v", DropView, false, "v", DropBehaviorDefault},
+		{"DROP MATERIALIZED VIEW mv", DropMaterializedView, false, "mv", DropBehaviorDefault},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			file, errs := Parse(tc.sql)
+			if len(errs) != 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			stmt, ok := file.Stmts[0].(*DropStmt)
+			if !ok {
+				t.Fatalf("got %T, want *DropStmt", file.Stmts[0])
+			}
+			if stmt.Object != tc.object {
+				t.Errorf("Object = %v, want %v", stmt.Object, tc.object)
+			}
+			if stmt.IfExists != tc.ifExists {
+				t.Errorf("IfExists = %v, want %v", stmt.IfExists, tc.ifExists)
+			}
+			if stmt.Name.String() != tc.name {
+				t.Errorf("Name = %q, want %q", stmt.Name.String(), tc.name)
+			}
+			if stmt.Behavior != tc.behavior {
+				t.Errorf("Behavior = %v, want %v", stmt.Behavior, tc.behavior)
+			}
+		})
+	}
+}
+
+func TestDDLStructure_AlterTableRename(t *testing.T) {
+	file, _ := Parse("ALTER TABLE IF EXISTS users RENAME TO people")
+	stmt := file.Stmts[0].(*AlterTableStmt)
+	if stmt.Kind != AlterTableRename {
+		t.Fatalf("Kind = %v, want AlterTableRename", stmt.Kind)
+	}
+	if !stmt.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+	if stmt.Name.String() != "users" || stmt.NewName.String() != "people" {
+		t.Errorf("rename %q -> %q, want users -> people", stmt.Name, stmt.NewName)
+	}
+}
+
+func TestDDLStructure_AlterTableAddColumn(t *testing.T) {
+	file, _ := Parse("ALTER TABLE users ADD COLUMN IF NOT EXISTS zip varchar AFTER country")
+	stmt := file.Stmts[0].(*AlterTableStmt)
+	if stmt.Kind != AlterTableAddColumn {
+		t.Fatalf("Kind = %v, want AlterTableAddColumn", stmt.Kind)
+	}
+	if !stmt.ColumnIfNotExists {
+		t.Error("ColumnIfNotExists = false, want true")
+	}
+	if stmt.NewColumn == nil || stmt.NewColumn.Name.Value != "zip" {
+		t.Errorf("NewColumn = %+v, want zip", stmt.NewColumn)
+	}
+	if stmt.Position != ColumnPositionAfter || stmt.PositionAfter.Value != "country" {
+		t.Errorf("position = %v after %v, want AFTER country", stmt.Position, stmt.PositionAfter)
+	}
+}
+
+func TestDDLStructure_AlterTableAlterColumn(t *testing.T) {
+	cases := []struct {
+		sql    string
+		action AlterColumnAction
+	}{
+		{"ALTER TABLE t ALTER COLUMN c SET DATA TYPE bigint", AlterColumnSetDataType},
+		{"ALTER TABLE t ALTER COLUMN c SET DEFAULT 1", AlterColumnSetDefault},
+		{"ALTER TABLE t ALTER COLUMN c DROP DEFAULT", AlterColumnDropDefault},
+		{"ALTER TABLE t ALTER COLUMN c DROP NOT NULL", AlterColumnDropNotNull},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			file, errs := Parse(tc.sql)
+			if len(errs) != 0 {
+				t.Fatalf("errors: %v", errs)
+			}
+			stmt := file.Stmts[0].(*AlterTableStmt)
+			if stmt.Kind != AlterTableAlterColumn {
+				t.Fatalf("Kind = %v, want AlterTableAlterColumn", stmt.Kind)
+			}
+			if stmt.ColumnAction != tc.action {
+				t.Errorf("ColumnAction = %v, want %v", stmt.ColumnAction, tc.action)
+			}
+			if stmt.AlterColumn.String() != "c" {
+				t.Errorf("AlterColumn = %q, want c", stmt.AlterColumn)
+			}
+		})
+	}
+}
+
+func TestDDLStructure_AlterTableExecute(t *testing.T) {
+	file, errs := Parse("ALTER TABLE t EXECUTE optimize(file_size_threshold => '16MB') WHERE p = 1")
+	if len(errs) != 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	stmt := file.Stmts[0].(*AlterTableStmt)
+	if stmt.Kind != AlterTableExecute {
+		t.Fatalf("Kind = %v, want AlterTableExecute", stmt.Kind)
+	}
+	if stmt.Procedure.Value != "optimize" {
+		t.Errorf("Procedure = %q, want optimize", stmt.Procedure.Value)
+	}
+	if !stmt.HasArgList || len(stmt.ExecuteArgs) != 1 {
+		t.Errorf("args: HasArgList=%v n=%d, want true/1", stmt.HasArgList, len(stmt.ExecuteArgs))
+	}
+	if stmt.ExecuteArgs[0].Name == nil || stmt.ExecuteArgs[0].Name.Value != "file_size_threshold" {
+		t.Errorf("arg name = %+v, want file_size_threshold", stmt.ExecuteArgs[0].Name)
+	}
+	if stmt.ExecuteWhere == nil {
+		t.Error("ExecuteWhere is nil")
+	}
+}
+
+func TestDDLStructure_AlterTableSetProperties(t *testing.T) {
+	file, _ := Parse("ALTER TABLE t SET PROPERTIES a = 1, b = DEFAULT")
+	stmt := file.Stmts[0].(*AlterTableStmt)
+	if stmt.Kind != AlterTableSetProperties {
+		t.Fatalf("Kind = %v, want AlterTableSetProperties", stmt.Kind)
+	}
+	if len(stmt.Properties) != 2 {
+		t.Fatalf("len(Properties) = %d, want 2", len(stmt.Properties))
+	}
+	if stmt.Properties[0].IsDefault {
+		t.Error("property[0] IsDefault = true, want false")
+	}
+	if !stmt.Properties[1].IsDefault {
+		t.Error("property[1] IsDefault = false, want true (= DEFAULT)")
+	}
+}
+
+func TestDDLStructure_CreateSchema(t *testing.T) {
+	file, _ := Parse("CREATE SCHEMA IF NOT EXISTS hive.web AUTHORIZATION ROLE PUBLIC WITH (location = '/x')")
+	stmt, ok := file.Stmts[0].(*CreateSchemaStmt)
+	if !ok {
+		t.Fatalf("got %T, want *CreateSchemaStmt", file.Stmts[0])
+	}
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists = false, want true")
+	}
+	if stmt.Name.String() != "hive.web" {
+		t.Errorf("Name = %q, want hive.web", stmt.Name)
+	}
+	if stmt.Authorization == nil || stmt.Authorization.Kind != PrincipalRole || stmt.Authorization.Name.Value != "PUBLIC" {
+		t.Errorf("Authorization = %+v, want ROLE PUBLIC", stmt.Authorization)
+	}
+	if len(stmt.Properties) != 1 {
+		t.Errorf("Properties = %+v, want 1", stmt.Properties)
+	}
+}
+
+func TestDDLStructure_AlterSchema(t *testing.T) {
+	rename, _ := Parse("ALTER SCHEMA foo.bar RENAME TO baz")
+	rs := rename.Stmts[0].(*AlterSchemaStmt)
+	if rs.Kind != AlterSchemaRename || rs.Name.String() != "foo.bar" || rs.NewName.Value != "baz" {
+		t.Errorf("rename = %+v, want foo.bar RENAME TO baz", rs)
+	}
+	auth, _ := Parse("ALTER SCHEMA web SET AUTHORIZATION USER alice")
+	as := auth.Stmts[0].(*AlterSchemaStmt)
+	if as.Kind != AlterSchemaSetAuthorization || as.Authorization.Kind != PrincipalUser {
+		t.Errorf("set auth = %+v, want SET AUTHORIZATION USER alice", as)
+	}
+}
+
+func TestDDLStructure_CreateView(t *testing.T) {
+	file, _ := Parse("CREATE OR REPLACE VIEW v COMMENT 'c' SECURITY INVOKER AS SELECT 1")
+	stmt, ok := file.Stmts[0].(*CreateViewStmt)
+	if !ok {
+		t.Fatalf("got %T, want *CreateViewStmt", file.Stmts[0])
+	}
+	if !stmt.OrReplace {
+		t.Error("OrReplace = false, want true")
+	}
+	if stmt.Comment == nil || *stmt.Comment != "c" {
+		t.Errorf("Comment = %v, want 'c'", stmt.Comment)
+	}
+	if stmt.Security != ViewSecurityInvoker {
+		t.Errorf("Security = %v, want ViewSecurityInvoker", stmt.Security)
+	}
+	if stmt.Query == nil {
+		t.Error("Query is nil")
+	}
+}
+
+func TestDDLStructure_AlterView(t *testing.T) {
+	cases := []struct {
+		sql  string
+		kind AlterViewKind
+	}{
+		{"ALTER VIEW v RENAME TO w", AlterViewRename},
+		{"ALTER VIEW v SET AUTHORIZATION alice", AlterViewSetAuthorization},
+		{"ALTER VIEW v REFRESH", AlterViewRefresh},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			file, errs := Parse(tc.sql)
+			if len(errs) != 0 {
+				t.Fatalf("errors: %v", errs)
+			}
+			stmt := file.Stmts[0].(*AlterViewStmt)
+			if stmt.Kind != tc.kind {
+				t.Errorf("Kind = %v, want %v", stmt.Kind, tc.kind)
+			}
+		})
+	}
+}
+
+func TestDDLStructure_CreateMaterializedView(t *testing.T) {
+	file, errs := Parse("CREATE MATERIALIZED VIEW mv GRACE PERIOD INTERVAL '1' HOUR WHEN STALE FAIL COMMENT 'c' WITH (p = 1) AS SELECT 1")
+	if len(errs) != 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	stmt, ok := file.Stmts[0].(*CreateMaterializedViewStmt)
+	if !ok {
+		t.Fatalf("got %T, want *CreateMaterializedViewStmt", file.Stmts[0])
+	}
+	if stmt.GracePeriod == nil {
+		t.Error("GracePeriod is nil, want INTERVAL '1' HOUR")
+	}
+	if stmt.StaleMode != MVStaleFail {
+		t.Errorf("StaleMode = %v, want MVStaleFail", stmt.StaleMode)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "c" {
+		t.Errorf("Comment = %v, want 'c'", stmt.Comment)
+	}
+	if len(stmt.Properties) != 1 {
+		t.Errorf("Properties = %+v, want 1", stmt.Properties)
+	}
+	if stmt.Query == nil {
+		t.Error("Query is nil")
+	}
+}
+
+func TestDDLStructure_CreateCatalog(t *testing.T) {
+	file, errs := Parse("CREATE CATALOG IF NOT EXISTS c USING postgresql COMMENT 'x' AUTHORIZATION alice WITH (\"connection-url\" = 'u')")
+	if len(errs) != 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	stmt, ok := file.Stmts[0].(*CreateCatalogStmt)
+	if !ok {
+		t.Fatalf("got %T, want *CreateCatalogStmt", file.Stmts[0])
+	}
+	if !stmt.IfNotExists {
+		t.Error("IfNotExists = false, want true")
+	}
+	if stmt.Name.Value != "c" {
+		t.Errorf("Name = %q, want c", stmt.Name.Value)
+	}
+	if stmt.Connector.Value != "postgresql" {
+		t.Errorf("Connector = %q, want postgresql", stmt.Connector.Value)
+	}
+	if stmt.Comment == nil || *stmt.Comment != "x" {
+		t.Errorf("Comment = %v, want 'x'", stmt.Comment)
+	}
+	if stmt.Authorization == nil || stmt.Authorization.Name.Value != "alice" {
+		t.Errorf("Authorization = %+v, want alice", stmt.Authorization)
+	}
+	if len(stmt.Properties) != 1 || stmt.Properties[0].Name.Value != "connection-url" {
+		t.Errorf("Properties = %+v, want connection-url", stmt.Properties)
+	}
+}
+
+func TestDDLStructure_DropCatalog(t *testing.T) {
+	file, _ := Parse("DROP CATALOG IF EXISTS c CASCADE")
+	stmt, ok := file.Stmts[0].(*DropCatalogStmt)
+	if !ok {
+		t.Fatalf("got %T, want *DropCatalogStmt", file.Stmts[0])
+	}
+	if !stmt.IfExists || stmt.Name.Value != "c" || stmt.Behavior != DropBehaviorCascade {
+		t.Errorf("got %+v, want IF EXISTS c CASCADE", stmt)
+	}
+}
+
+func TestDDLStructure_Comment(t *testing.T) {
+	cases := []struct {
+		sql     string
+		object  CommentObjectKind
+		isNull  bool
+		comment string
+		name    string
+	}{
+		{"COMMENT ON TABLE users IS 'master'", CommentOnTable, false, "master", "users"},
+		{"COMMENT ON TABLE users IS NULL", CommentOnTable, true, "", "users"},
+		{"COMMENT ON VIEW v IS 'x'", CommentOnView, false, "x", "v"},
+		{"COMMENT ON COLUMN a.b.c.d IS 'col'", CommentOnColumn, false, "col", "a.b.c.d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			file, errs := Parse(tc.sql)
+			if len(errs) != 0 {
+				t.Fatalf("errors: %v", errs)
+			}
+			stmt := file.Stmts[0].(*CommentStmt)
+			if stmt.Object != tc.object {
+				t.Errorf("Object = %v, want %v", stmt.Object, tc.object)
+			}
+			if stmt.IsNull != tc.isNull {
+				t.Errorf("IsNull = %v, want %v", stmt.IsNull, tc.isNull)
+			}
+			if !tc.isNull && stmt.Comment != tc.comment {
+				t.Errorf("Comment = %q, want %q", stmt.Comment, tc.comment)
+			}
+			if stmt.Name.String() != tc.name {
+				t.Errorf("Name = %q, want %q", stmt.Name.String(), tc.name)
+			}
+		})
+	}
+}
+
+func TestDDLStructure_Analyze(t *testing.T) {
+	bare, _ := Parse("ANALYZE hive.default.stores")
+	b := bare.Stmts[0].(*AnalyzeStmt)
+	if b.Name.String() != "hive.default.stores" || len(b.Properties) != 0 {
+		t.Errorf("bare ANALYZE = %+v, want hive.default.stores no props", b)
+	}
+	withProps, _ := Parse("ANALYZE t WITH (columns = ARRAY['a', 'b'])")
+	w := withProps.Stmts[0].(*AnalyzeStmt)
+	if len(w.Properties) != 1 || w.Properties[0].Name.Value != "columns" {
+		t.Errorf("ANALYZE WITH = %+v, want columns property", w.Properties)
+	}
+}
+
+func TestDDLStructure_RefreshMaterializedView(t *testing.T) {
+	file, _ := Parse("REFRESH MATERIALIZED VIEW cat.sch.mv")
+	stmt, ok := file.Stmts[0].(*RefreshMaterializedViewStmt)
+	if !ok {
+		t.Fatalf("got %T, want *RefreshMaterializedViewStmt", file.Stmts[0])
+	}
+	if stmt.Name.String() != "cat.sch.mv" {
+		t.Errorf("Name = %q, want cat.sch.mv", stmt.Name)
+	}
+}

--- a/trino/parser/diagnose_test.go
+++ b/trino/parser/diagnose_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 // TestDiagnose_CleanInputNoStubNoise verifies the wiring shape: Diagnose runs
-// Parse and surfaces ParseErrors as Diagnostics. While a statement body is still
-// stubbed (no DAG node has implemented it), even valid SQL of that form yields a
-// "not yet supported" diagnostic — those vanish as later nodes implement real
-// parsing. DML (INSERT/DELETE/UPDATE/MERGE/TRUNCATE) is now implemented by
-// parser-dml, so this test uses a DDL form (ALTER TABLE) that remains a
-// foundation stub until the parser-ddl node lands.
+// Parse and surfaces ParseErrors as Diagnostics. The CREATE/DROP/ALTER dispatch
+// recognizes the leading keyword but routes an UNRECOGNIZED object keyword to
+// the `unsupported` stub (e.g. `CREATE INDEX` / `ALTER INDEX`, which Trino has
+// no statement form for and also rejects). That stub path is what this test
+// exercises. (Every real Trino DDL/DML/query/admin form is now implemented by
+// the parser-* nodes, so a valid statement no longer hits the stub.)
 func TestDiagnose_StubbedStatementProducesDiagnostic(t *testing.T) {
-	diags := Diagnose("ALTER TABLE t ADD COLUMN c integer")
+	diags := Diagnose("ALTER INDEX i RENAME TO j")
 	if len(diags) != 1 {
 		t.Fatalf("got %d diagnostics, want 1: %+v", len(diags), diags)
 	}
@@ -51,13 +51,14 @@ func TestDiagnose_EmptyInput(t *testing.T) {
 }
 
 // TestDiagnose_MultipleStatements verifies diagnostics are collected across all
-// segments. A valid SELECT and a valid INSERT (both now implemented, by
-// parser-select and parser-dml) yield none, while the two still-stubbed DDL
-// statements (ALTER, COMMENT — parser-ddl's job) each yield one.
+// segments. A valid SELECT, a valid INSERT, a valid ALTER TABLE, and a valid
+// COMMENT (all now implemented by parser-select / parser-dml / parser-ddl)
+// yield none, while the two unrecognized-object stubs (CREATE INDEX, ALTER
+// INDEX — no Trino statement form) each yield one.
 func TestDiagnose_MultipleStatements(t *testing.T) {
-	diags := Diagnose("SELECT 1; INSERT INTO t VALUES (1); ALTER TABLE t ADD COLUMN c integer; COMMENT ON TABLE t IS 'x'")
+	diags := Diagnose("SELECT 1; INSERT INTO t VALUES (1); CREATE INDEX i ON t (a); ALTER INDEX i RENAME TO j")
 	if len(diags) != 2 {
-		t.Fatalf("got %d diagnostics, want 2 (ALTER + COMMENT stubs; SELECT and INSERT now parse): %+v", len(diags), diags)
+		t.Fatalf("got %d diagnostics, want 2 (CREATE INDEX + ALTER INDEX stubs; SELECT and INSERT parse): %+v", len(diags), diags)
 	}
 }
 

--- a/trino/parser/drop.go
+++ b/trino/parser/drop.go
@@ -1,0 +1,142 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-ddl DAG node. It implements Trino's DROP
+// statements for the schema-object family — TABLE, SCHEMA, VIEW, and
+// MATERIALIZED VIEW. DROP CATALOG lives in catalog_ddl.go (it is dispatched
+// from the CREATE/DROP CATALOG pair); DROP ROLE and DROP FUNCTION are owned by
+// other nodes (grant_revoke.go / function_def.go) and are dispatched before
+// this file is reached.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	statement
+//	    : DROP_ TABLE_ (IF_ EXISTS_)? qualifiedName                  # dropTable
+//	    | DROP_ SCHEMA_ (IF_ EXISTS_)? qualifiedName (CASCADE_ | RESTRICT_)? # dropSchema
+//	    | DROP_ VIEW_ (IF_ EXISTS_)? qualifiedName                   # dropView
+//	    | DROP_ MATERIALIZED_ VIEW_ (IF_ EXISTS_)? qualifiedName     # dropMaterializedView
+//	    ;
+//
+// Adjudicated against the live Trino 481 oracle. Oracle-confirmed facts:
+//
+//	D-DR1 (object name ≤ catalog.schema.object). `DROP TABLE a.b.c.d` is a
+//	   SYNTAX_ERROR for every object kind; the target is bounded to 3 parts.
+//	D-DR2 (DROP SCHEMA CASCADE/RESTRICT). Only DROP SCHEMA carries the optional
+//	   trailing CASCADE | RESTRICT; DROP TABLE/VIEW/MATERIALIZED VIEW do NOT
+//	   (`DROP TABLE t CASCADE` is a SYNTAX_ERROR).
+
+// DropObjectKind classifies which schema object a DROP targets.
+type DropObjectKind int
+
+const (
+	// DropTable is DROP TABLE.
+	DropTable DropObjectKind = iota
+	// DropSchema is DROP SCHEMA.
+	DropSchema
+	// DropView is DROP VIEW.
+	DropView
+	// DropMaterializedView is DROP MATERIALIZED VIEW.
+	DropMaterializedView
+)
+
+// DropBehavior is the trailing CASCADE / RESTRICT on DROP SCHEMA.
+type DropBehavior int
+
+const (
+	// DropBehaviorDefault is no explicit CASCADE/RESTRICT (RESTRICT semantics).
+	DropBehaviorDefault DropBehavior = iota
+	// DropBehaviorCascade is CASCADE.
+	DropBehaviorCascade
+	// DropBehaviorRestrict is RESTRICT.
+	DropBehaviorRestrict
+)
+
+// DropStmt is a `DROP { TABLE | SCHEMA | VIEW | MATERIALIZED VIEW }
+// [IF EXISTS] name [CASCADE | RESTRICT]` statement. Behavior is only ever
+// non-default for DROP SCHEMA (D-DR2).
+type DropStmt struct {
+	Object   DropObjectKind
+	IfExists bool
+	Name     *ast.QualifiedName
+	Behavior DropBehavior
+	Loc      ast.Loc
+}
+
+func (n *DropStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *DropStmt) Span() ast.Loc    { return n.Loc }
+
+var _ ast.Node = (*DropStmt)(nil)
+
+// parseDropStmt parses DROP TABLE/SCHEMA/VIEW/MATERIALIZED VIEW. On entry cur
+// is the DROP keyword; startOffset is DROP's byte offset. DROP CATALOG, DROP
+// ROLE and DROP FUNCTION are dispatched elsewhere before this is called, so the
+// object keyword here is exactly one of TABLE / SCHEMA / VIEW / MATERIALIZED.
+func (p *Parser) parseDropStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume DROP
+
+	var object DropObjectKind
+	switch p.cur.Kind {
+	case kwTABLE:
+		p.advance()
+		object = DropTable
+	case kwSCHEMA:
+		p.advance()
+		object = DropSchema
+	case kwVIEW:
+		p.advance()
+		object = DropView
+	case kwMATERIALIZED:
+		p.advance()
+		if _, err := p.expect(kwVIEW); err != nil {
+			return nil, err
+		}
+		object = DropMaterializedView
+	default:
+		// DROP with an object keyword this node does not own. The dispatch only
+		// routes the four kinds above here, so reaching this is a syntax error.
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	ifExists, err := p.parseOptionalIfExists()
+	if err != nil {
+		return nil, err
+	}
+
+	// D-DR1: object name part-count limit. A SCHEMA is catalog.schema (≤ 2);
+	// TABLE / VIEW / MATERIALIZED VIEW are catalog.schema.object (≤ 3). Trino
+	// 481 enforces the per-object cap at parse time even though the legacy
+	// grammar uses an unbounded qualifiedName everywhere.
+	maxParts := 3
+	context := "drop target"
+	if object == DropSchema {
+		maxParts = 2
+		context = "schema name"
+	}
+	name, err := p.parseBoundedQualifiedName(maxParts, context)
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &DropStmt{
+		Object:   object,
+		IfExists: ifExists,
+		Name:     name,
+		Loc:      ast.Loc{Start: startOffset, End: name.Loc.End},
+	}
+
+	// D-DR2: only DROP SCHEMA accepts a trailing CASCADE | RESTRICT.
+	if object == DropSchema {
+		if tok, ok := p.match(kwCASCADE, kwRESTRICT); ok {
+			if tok.Kind == kwCASCADE {
+				stmt.Behavior = DropBehaviorCascade
+			} else {
+				stmt.Behavior = DropBehaviorRestrict
+			}
+			stmt.Loc.End = tok.Loc.End
+		}
+	}
+	return stmt, nil
+}

--- a/trino/parser/oracle_ddl_test.go
+++ b/trino/parser/oracle_ddl_test.go
@@ -1,0 +1,449 @@
+package parser
+
+import (
+	"testing"
+)
+
+// This file is the parser-ddl node's differential-oracle gate
+// (correctness-protocol.md): for every statement in the corpus below, omni's
+// Parse accept/reject verdict must equal Trino 481's verdict as reported by the
+// live oracle (trinooracle.CheckSyntax, which classifies a SYNTAX_ERROR as
+// reject and every other outcome — success or a semantic error like
+// TABLE_NOT_FOUND / SCHEMA_NOT_FOUND / NOT_SUPPORTED / TYPE_NOT_FOUND — as
+// accept).
+//
+// The corpus is the oracle's to adjudicate: each case runs through both omni
+// and Trino and the two verdicts are compared. It covers the legacy grammar
+// examples (truth2, examples/{create_table,create_table_as_select,create_schema,
+// rename_schema,create_view,rename_view,alter_view_set_authorization,
+// create_materialized_view,rename_materialized_view,refresh_materialized_view,
+// drop_*,drop_column,alter_table_alter_column_set_data_type,
+// alter_table_set_authorization,comment_*,analyze}.sql with assertions
+// stripped), every documented form (truth1 ddl.md), the oracle-pinned grammar
+// facts (D-CT*/D-DR*/D-SC*/D-VW*/D-MV*/D-AT*/D-CAT*/D-CM*/D-AN*), and a set of
+// negative forms the engine must reject.
+//
+// Out of this node's scope (dispatched/owned elsewhere, NOT in this corpus):
+// CREATE/DROP FUNCTION (parser-routines), CREATE/DROP ROLE (parser-dcl-tcl),
+// TRUNCATE TABLE (parser-dml). Those have their own gates.
+//
+// Skipped cleanly when no Trino oracle is reachable.
+
+// ddlOracleCorpus is the full DDL statement corpus for the differential gate.
+var ddlOracleCorpus = []string{
+	// =====================================================================
+	// CREATE SCHEMA  (truth1 create-schema + truth2 create_schema.sql)
+	// =====================================================================
+	"CREATE SCHEMA web",
+	"CREATE SCHEMA hive.sales",
+	"CREATE SCHEMA IF NOT EXISTS traffic",
+	"CREATE SCHEMA web AUTHORIZATION alice",
+	"CREATE SCHEMA web AUTHORIZATION USER alice",
+	"CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC",
+	"CREATE SCHEMA web AUTHORIZATION alice WITH ( LOCATION = '/hive/data/web' )",
+	"CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC WITH ( LOCATION = '/hive/data/web' )",
+	"CREATE SCHEMA test",
+	"CREATE SCHEMA IF NOT EXISTS test",
+	"CREATE SCHEMA test WITH (a = 'apple', b = 123)",
+	`CREATE SCHEMA "some name that contains space"`,
+	// negatives
+	"CREATE SCHEMA",                                      // missing name
+	"CREATE SCHEMA a.b.c",                                // D-SC1: 3-part schema name
+	"CREATE SCHEMA web WITH ()",                          // empty property list
+	"CREATE SCHEMA web AUTHORIZATION",                    // dangling AUTHORIZATION
+	"CREATE SCHEMA s WITH (a = '1') AUTHORIZATION alice", // clause order: AUTHORIZATION before WITH
+
+	// =====================================================================
+	// DROP SCHEMA  (truth1 drop-schema + truth2 drop_schema.sql)
+	// =====================================================================
+	"DROP SCHEMA web",
+	"DROP SCHEMA IF EXISTS sales",
+	"DROP SCHEMA archive CASCADE",
+	"DROP SCHEMA archive RESTRICT",
+	"DROP SCHEMA test",
+	"DROP SCHEMA test CASCADE",
+	"DROP SCHEMA IF EXISTS test",
+	"DROP SCHEMA IF EXISTS test RESTRICT",
+	`DROP SCHEMA "some schema that contains space"`,
+	"DROP SCHEMA hive.sales", // 2-part
+	// negatives
+	"DROP SCHEMA",          // missing name
+	"DROP SCHEMA a.b.c",    // 3-part schema name
+	"DROP SCHEMA a FOObar", // trailing garbage
+
+	// =====================================================================
+	// ALTER SCHEMA  (truth1 alter-schema + truth2 rename_schema.sql)
+	// =====================================================================
+	"ALTER SCHEMA web RENAME TO traffic",
+	"ALTER SCHEMA web SET AUTHORIZATION alice",
+	"ALTER SCHEMA web SET AUTHORIZATION USER alice",
+	"ALTER SCHEMA web SET AUTHORIZATION ROLE PUBLIC",
+	"ALTER SCHEMA foo RENAME TO bar",
+	"ALTER SCHEMA foo.bar RENAME TO baz",
+	`ALTER SCHEMA "awesome schema"."awesome table" RENAME TO "even more awesome table"`,
+	// negatives
+	"ALTER SCHEMA web RENAME",               // dangling RENAME
+	"ALTER SCHEMA web RENAME TO a.b",        // rename target must be a single identifier
+	"ALTER SCHEMA web SET",                  // dangling SET
+	"ALTER SCHEMA web SET PROPERTIES x = 1", // schema has no SET PROPERTIES
+
+	// =====================================================================
+	// CREATE TABLE — column-definition form  (truth1 create-table + truth2)
+	// =====================================================================
+	"CREATE TABLE orders (orderkey bigint, orderstatus varchar, totalprice double, orderdate date) WITH (format = 'ORC')",
+	"CREATE TABLE IF NOT EXISTS orders (orderkey bigint, orderstatus varchar, totalprice double COMMENT 'Price in cents.', orderdate date, status varchar DEFAULT 'created') COMMENT 'A table to keep track of orders.'",
+	"CREATE TABLE bigger_orders (another_orderkey bigint, LIKE orders, another_orderdate date)",
+	"CREATE TABLE IF NOT EXISTS bar (LIKE like_table)",
+	"CREATE TABLE IF NOT EXISTS bar (LIKE like_table INCLUDING PROPERTIES)",
+	"CREATE TABLE t (a bigint, b varchar(10), c decimal(10, 2))",
+	"CREATE TABLE t (a bigint NOT NULL)",
+	"CREATE TABLE t (a bigint DEFAULT 5 NOT NULL)",             // D-CT2: DEFAULT then NOT NULL
+	"CREATE TABLE t (a bigint NOT NULL DEFAULT 5)",             // D-CT2: NOT NULL then DEFAULT
+	"CREATE TABLE t (a bigint COMMENT 'x' WITH (foo = 'bar'))", // column COMMENT + WITH
+	"CREATE TABLE t (a row(x bigint, y double))",
+	"CREATE TABLE t (a array(bigint))",
+	"CREATE TABLE cat.sch.t (a bigint)",
+	"CREATE TABLE t (LIKE a EXCLUDING PROPERTIES)",
+	"CREATE OR REPLACE TABLE t (a bigint)",
+	// negatives
+	"CREATE TABLE t ()",                                  // D-CT3: empty body
+	"CREATE TABLE t",                                     // D-CT4: neither body nor AS
+	"CREATE TABLE a.b.c.d (a bigint)",                    // D-CT1: 4-part name
+	"CREATE TABLE t (a)",                                 // bare ident, no type, no AS
+	"CREATE OR REPLACE TABLE IF NOT EXISTS t (a bigint)", // D-CT6: OR REPLACE + IF NOT EXISTS conflict (SYNTAX_ERROR)
+	"CREATE TABLE t (a bigint NOT NULL NOT NULL)",        // duplicate NOT NULL
+	"CREATE TABLE t (a bigint,)",                         // trailing comma
+	"CREATE TABLE t (a bigint COMMENT 'x' NOT NULL)",     // D-CT2 order: COMMENT before NOT NULL
+	"CREATE TABLE t (a bigint WITH (p = 1) NOT NULL)",    // D-CT2 order: WITH before NOT NULL
+
+	// =====================================================================
+	// CREATE TABLE AS SELECT  (truth1 create-table-as + truth2)
+	// =====================================================================
+	"CREATE TABLE orders_column_aliased (order_date, total_price) AS SELECT orderdate, totalprice FROM orders",
+	"CREATE TABLE orders_by_date COMMENT 'Summary of orders by date' WITH (format = 'ORC') AS SELECT orderdate, sum(totalprice) AS price FROM orders GROUP BY orderdate",
+	"CREATE TABLE IF NOT EXISTS orders_by_date AS SELECT orderdate, sum(totalprice) AS price FROM orders GROUP BY orderdate",
+	"CREATE TABLE empty_nation AS SELECT * FROM nation WITH NO DATA",
+	"CREATE TABLE foo AS SELECT * FROM t",
+	"CREATE TABLE foo(x) AS SELECT a FROM t",
+	"CREATE TABLE foo(x,y) AS SELECT a,b FROM t",
+	"CREATE TABLE IF NOT EXISTS foo AS SELECT * FROM t",
+	"CREATE TABLE foo AS SELECT * FROM t WITH NO DATA",
+	"CREATE TABLE foo(x) AS SELECT a FROM t WITH NO DATA",
+	"CREATE TABLE foo AS SELECT * FROM t WITH DATA",
+	"CREATE TABLE foo WITH ( string = 'bar', long = 42, computed = 'ban' || 'ana', a = ARRAY[ 'v1', 'v2' ] ) AS SELECT * FROM t",
+	"CREATE TABLE foo COMMENT 'test' WITH ( string = 'bar' ) AS SELECT * FROM t WITH NO DATA",
+	`CREATE TABLE foo(x,y) COMMENT 'test' WITH ( "string" = 'bar', "long" = 42, computed = 'ban' || 'ana', a = ARRAY[ 'v1', 'v2' ] ) AS SELECT a,b FROM t WITH NO DATA`,
+	"CREATE TABLE t AS (SELECT 1)",                           // parenthesized AS query
+	"CREATE TABLE t AS TABLE other",                          // TABLE query source
+	"CREATE TABLE t AS WITH c AS (SELECT 1) SELECT * FROM c", // WITH source
+	"CREATE OR REPLACE TABLE t AS SELECT * FROM x",
+	// negatives
+	"CREATE TABLE t (a bigint) AS SELECT * FROM x", // column defs + AS (alias list must be bare)
+	"CREATE TABLE t AS",                            // dangling AS
+	"CREATE TABLE t AS SELECT * FROM x WITH",       // dangling WITH after query
+
+	// =====================================================================
+	// DROP TABLE  (truth1 drop-table + truth2 drop_table.sql)
+	// =====================================================================
+	"DROP TABLE orders_by_date",
+	"DROP TABLE IF EXISTS orders_by_date",
+	"DROP TABLE a",
+	"DROP TABLE a.b",
+	"DROP TABLE a.b.c",
+	`DROP TABLE a."b/y".c`,
+	"DROP TABLE IF EXISTS a.b.c",
+	// negatives
+	"DROP TABLE",           // missing name
+	"DROP TABLE a.b.c.d",   // D-DR1: 4-part name
+	"DROP TABLE a CASCADE", // D-DR2: TABLE has no CASCADE
+
+	// =====================================================================
+	// ALTER TABLE — rename  (truth1 alter-table-rename)
+	// =====================================================================
+	"ALTER TABLE users RENAME TO people",
+	"ALTER TABLE IF EXISTS users RENAME TO people",
+	"ALTER TABLE a.b.c RENAME TO d.e.f",
+	"ALTER TABLE a RENAME TO b.c.d.e", // D-AT5: RENAME TO target is UNBOUNDED (4-part accepted; fails semantically)
+	// negatives
+	"ALTER TABLE users RENAME",        // dangling
+	"ALTER TABLE a.b.c.d RENAME TO x", // 4-part SOURCE is SYNTAX_ERROR (source capped at 3)
+
+	// =====================================================================
+	// ALTER TABLE — add column  (truth1 alter-table-add-column, D-AT2)
+	// =====================================================================
+	"ALTER TABLE users ADD COLUMN zip varchar",
+	"ALTER TABLE users ADD COLUMN zip varchar DEFAULT '90210'",
+	"ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS zip varchar",
+	"ALTER TABLE users ADD COLUMN id varchar FIRST",
+	"ALTER TABLE users ADD COLUMN zip varchar AFTER country",
+	"ALTER TABLE users ADD COLUMN zip varchar LAST",
+	"ALTER TABLE users ADD COLUMN c bigint NOT NULL COMMENT 'x' WITH (p = 1)",
+	// negatives
+	"ALTER TABLE users ADD COLUMN zip",               // missing type
+	"ALTER TABLE users ADD zip varchar",              // missing COLUMN keyword
+	"ALTER TABLE users ADD COLUMN zip varchar AFTER", // dangling AFTER
+
+	// =====================================================================
+	// ALTER TABLE — drop / rename column  (truth1 + truth2 drop_column.sql)
+	// =====================================================================
+	"ALTER TABLE users DROP COLUMN zip",
+	"ALTER TABLE IF EXISTS users DROP COLUMN IF EXISTS zip",
+	"ALTER TABLE foo.t DROP COLUMN c",
+	`ALTER TABLE "t x" DROP COLUMN "c d"`,
+	"ALTER TABLE foo.t DROP COLUMN IF EXISTS c",
+	"ALTER TABLE users RENAME COLUMN id TO user_id",
+	"ALTER TABLE IF EXISTS users RENAME COLUMN IF EXISTS id TO user_id",
+	"ALTER TABLE t DROP COLUMN a.b", // nested-field path
+	// negatives
+	"ALTER TABLE users DROP COLUMN",             // missing column
+	"ALTER TABLE users RENAME COLUMN id",        // missing TO
+	"ALTER TABLE users RENAME COLUMN id TO a.b", // new name must be single ident
+
+	// =====================================================================
+	// ALTER TABLE — alter column  (truth1 + truth2, D-AT3)
+	// =====================================================================
+	"ALTER TABLE users ALTER COLUMN id SET DATA TYPE bigint",
+	"ALTER TABLE foo.bar.baz ALTER COLUMN col1 SET DATA TYPE bigint",
+	"ALTER TABLE users ALTER COLUMN status SET DEFAULT 'active'",
+	"ALTER TABLE users ALTER COLUMN status DROP DEFAULT",
+	"ALTER TABLE users ALTER COLUMN id DROP NOT NULL",
+	"ALTER TABLE IF EXISTS users ALTER COLUMN id SET DATA TYPE bigint",
+	// negatives
+	"ALTER TABLE users ALTER COLUMN id SET DATA TYPE",   // missing type
+	"ALTER TABLE users ALTER COLUMN id SET",             // dangling SET
+	"ALTER TABLE users ALTER COLUMN id DROP",            // dangling DROP
+	"ALTER TABLE users ALTER COLUMN id SET TYPE bigint", // SET TYPE (missing DATA)
+
+	// =====================================================================
+	// ALTER TABLE — set authorization / properties  (truth1 + truth2)
+	// =====================================================================
+	"ALTER TABLE people SET AUTHORIZATION alice",
+	"ALTER TABLE people SET AUTHORIZATION ROLE PUBLIC",
+	"ALTER TABLE foo.bar.baz SET AUTHORIZATION qux",
+	"ALTER TABLE foo.bar.baz SET AUTHORIZATION USER qux",
+	"ALTER TABLE foo.bar.baz SET AUTHORIZATION ROLE qux",
+	"ALTER TABLE people SET PROPERTIES x = 'y'",
+	`ALTER TABLE people SET PROPERTIES foo = 123, "foo bar" = 456`,
+	"ALTER TABLE people SET PROPERTIES x = DEFAULT",
+	// negatives
+	"ALTER TABLE people SET PROPERTIES",               // empty
+	"ALTER TABLE people SET PROPERTIES x",             // missing = value
+	"ALTER TABLE people SET AUTHORIZATION",            // dangling
+	"ALTER TABLE IF EXISTS t SET PROPERTIES x = 1",    // D-AT6: IF EXISTS not allowed on SET PROPERTIES
+	"ALTER TABLE IF EXISTS t SET AUTHORIZATION alice", // D-AT6: IF EXISTS not allowed on SET AUTHORIZATION
+
+	// =====================================================================
+	// ALTER TABLE — execute  (truth1 alter-table-execute, D-AT4)
+	// =====================================================================
+	"ALTER TABLE example.test.test_table EXECUTE optimize(file_size_threshold => '16MB')",
+	"ALTER TABLE t EXECUTE optimize",
+	"ALTER TABLE t EXECUTE optimize()",
+	"ALTER TABLE t EXECUTE optimize(1, 2)",
+	"ALTER TABLE t EXECUTE optimize WHERE x > 1",
+	"ALTER TABLE t EXECUTE optimize(threshold => '1MB') WHERE part = 'a'",
+	// negatives
+	"ALTER TABLE t EXECUTE",                    // missing procedure
+	"ALTER TABLE t EXECUTE optimize WHERE",     // dangling WHERE
+	"ALTER TABLE IF EXISTS t EXECUTE optimize", // D-AT6: IF EXISTS not allowed on EXECUTE
+
+	// =====================================================================
+	// CREATE VIEW  (truth1 create-view + truth2 create_view.sql)
+	// =====================================================================
+	"CREATE VIEW test AS SELECT orderkey, orderstatus, totalprice / 2 AS half FROM orders",
+	"CREATE VIEW test_with_comment COMMENT 'A view to keep track of orders.' AS SELECT orderkey, orderstatus, totalprice FROM orders",
+	"CREATE OR REPLACE VIEW test AS SELECT orderkey, orderstatus, totalprice / 4 AS quarter FROM orders",
+	"CREATE VIEW a AS SELECT * FROM t",
+	"CREATE VIEW a SECURITY DEFINER AS SELECT * FROM t",
+	"CREATE VIEW a SECURITY INVOKER AS SELECT * FROM t",
+	"CREATE VIEW a COMMENT 'comment' SECURITY DEFINER AS SELECT * FROM t",
+	"CREATE VIEW a COMMENT '' AS SELECT * FROM t",
+	"CREATE VIEW bar.foo AS SELECT * FROM t",
+	`CREATE VIEW "awesome schema"."awesome view" AS SELECT * FROM t`,
+	// negatives
+	"CREATE VIEW a", // missing AS query
+	"CREATE VIEW IF NOT EXISTS a AS SELECT 1",                // D-VW1: no IF NOT EXISTS for plain view
+	"CREATE VIEW a SECURITY AS SELECT 1",                     // SECURITY without DEFINER/INVOKER
+	"CREATE VIEW a AS",                                       // dangling AS
+	"CREATE VIEW v SECURITY DEFINER COMMENT 'c' AS SELECT 1", // clause order: COMMENT before SECURITY
+
+	// =====================================================================
+	// DROP VIEW  (truth1 drop-view + truth2 drop_view.sql)
+	// =====================================================================
+	"DROP VIEW orders_by_date",
+	"DROP VIEW IF EXISTS orders_by_date",
+	"DROP VIEW a",
+	"DROP VIEW a.b.c",
+	// negatives
+	"DROP VIEW",           // missing name
+	"DROP VIEW a CASCADE", // VIEW has no CASCADE
+
+	// =====================================================================
+	// ALTER VIEW  (truth1 alter-view + truth2 rename_view / set_authorization)
+	// =====================================================================
+	"ALTER VIEW people RENAME TO users",
+	"ALTER VIEW a RENAME TO b.c.d.e", // D-AT5: RENAME TO target unbounded
+	"ALTER VIEW people REFRESH",
+	"ALTER VIEW people SET AUTHORIZATION alice",
+	"ALTER VIEW a RENAME TO b",
+	"ALTER VIEW foo.bar.baz SET AUTHORIZATION qux",
+	"ALTER VIEW foo.bar.baz SET AUTHORIZATION USER qux",
+	"ALTER VIEW foo.bar.baz SET AUTHORIZATION ROLE qux",
+	// negatives
+	"ALTER VIEW a RENAME", // dangling
+	"ALTER VIEW a SET",    // dangling SET
+
+	// =====================================================================
+	// CREATE MATERIALIZED VIEW  (truth1 + truth2, D-MV1)
+	// =====================================================================
+	"CREATE MATERIALIZED VIEW cancelled_orders AS SELECT orderkey, totalprice FROM orders WHERE orderstatus = 3",
+	"CREATE OR REPLACE MATERIALIZED VIEW order_totals_by_date AS SELECT orderdate, sum(totalprice) AS price FROM orders GROUP BY orderdate",
+	"CREATE MATERIALIZED VIEW orders_nation_mkgsegment COMMENT 'Orders with nation and market segment data' WITH ( partitioning = ARRAY['mktsegment', 'nationkey'] ) AS SELECT o.*, c.nationkey, c.mktsegment FROM orders AS o JOIN customer AS c ON o.custkey = c.custkey",
+	"CREATE MATERIALIZED VIEW orders_summary GRACE PERIOD INTERVAL '1' HOUR WHEN STALE FAIL AS SELECT orderdate, sum(totalprice) AS price FROM orders GROUP BY orderdate",
+	"CREATE MATERIALIZED VIEW orders_summary GRACE PERIOD INTERVAL '1' HOUR WHEN STALE INLINE AS SELECT orderdate, sum(totalprice) AS price FROM orders GROUP BY orderdate",
+	"CREATE MATERIALIZED VIEW a AS SELECT * FROM t",
+	"CREATE OR REPLACE MATERIALIZED VIEW catalog.schema.matview COMMENT 'A simple materialized view' AS SELECT * FROM catalog2.schema2.tab",
+	"CREATE OR REPLACE MATERIALIZED VIEW catalog.schema.matview COMMENT 'A simple materialized view' WITH (partitioned_by = ARRAY ['dateint']) AS SELECT * FROM catalog2.schema2.tab",
+	"CREATE OR REPLACE MATERIALIZED VIEW catalog.schema.matview COMMENT 'A partitioned materialized view' WITH (partitioned_by = ARRAY ['dateint']) AS WITH a (t, u) AS (SELECT * FROM x), b AS (SELECT * FROM a) TABLE b",
+	"CREATE MATERIALIZED VIEW a GRACE PERIOD INTERVAL '2' DAY AS SELECT * FROM t",
+	"CREATE MATERIALIZED VIEW IF NOT EXISTS a AS SELECT * FROM t",
+	"CREATE MATERIALIZED VIEW a WHEN STALE INLINE AS SELECT * FROM t", // D-MV1 WHEN STALE alone
+	// negatives
+	"CREATE MATERIALIZED VIEW a",                          // missing AS
+	"CREATE MATERIALIZED VIEW a GRACE PERIOD AS SELECT 1", // GRACE PERIOD without interval
+	"CREATE MATERIALIZED VIEW a WHEN STALE AS SELECT 1",   // WHEN STALE without mode
+	"CREATE MATERIALIZED VIEW a WHEN AS SELECT 1",         // WHEN without STALE
+	// fixed-clause-order negatives (D-MV1): clauses out of GRACE/WHEN/COMMENT/WITH order
+	"CREATE MATERIALIZED VIEW m COMMENT 'c' GRACE PERIOD INTERVAL '1' HOUR AS SELECT 1",       // COMMENT before GRACE PERIOD
+	"CREATE MATERIALIZED VIEW m WITH (p = 1) COMMENT 'c' AS SELECT 1",                         // WITH before COMMENT
+	"CREATE MATERIALIZED VIEW m WHEN STALE INLINE GRACE PERIOD INTERVAL '1' HOUR AS SELECT 1", // WHEN STALE before GRACE PERIOD
+
+	// =====================================================================
+	// DROP MATERIALIZED VIEW  (truth1 + truth2)
+	// =====================================================================
+	"DROP MATERIALIZED VIEW orders_by_date",
+	"DROP MATERIALIZED VIEW IF EXISTS orders_by_date",
+	"DROP MATERIALIZED VIEW a.b.c",
+	// negatives
+	"DROP MATERIALIZED VIEW", // missing name
+	"DROP MATERIALIZED a",    // missing VIEW
+
+	// =====================================================================
+	// ALTER MATERIALIZED VIEW  (truth1 + truth2 rename_materialized_view.sql)
+	// =====================================================================
+	"ALTER MATERIALIZED VIEW people RENAME TO users",
+	"ALTER MATERIALIZED VIEW a RENAME TO b.c.d.e", // D-AT5: RENAME TO target unbounded
+	"ALTER MATERIALIZED VIEW IF EXISTS people RENAME TO users",
+	"ALTER MATERIALIZED VIEW people SET PROPERTIES x = 'y'",
+	`ALTER MATERIALIZED VIEW people SET PROPERTIES foo = 123, "foo bar" = 456`,
+	"ALTER MATERIALIZED VIEW people SET PROPERTIES x = DEFAULT",
+	"ALTER MATERIALIZED VIEW a RENAME TO b",
+	"ALTER MATERIALIZED VIEW people SET AUTHORIZATION alice", // D-MV3: SET AUTHORIZATION (docs-ahead)
+	"ALTER MATERIALIZED VIEW people SET AUTHORIZATION ROLE PUBLIC",
+	"ALTER MATERIALIZED VIEW people SET AUTHORIZATION USER alice",
+	// negatives
+	"ALTER MATERIALIZED VIEW a RENAME",                                 // dangling
+	"ALTER MATERIALIZED VIEW IF EXISTS people SET PROPERTIES x = 'y'",  // D-MV3: IF EXISTS not allowed on SET
+	"ALTER MATERIALIZED VIEW IF EXISTS people SET AUTHORIZATION alice", // D-MV3: IF EXISTS not allowed on SET
+	"ALTER MATERIALIZED VIEW a SET PROPERTIES",                         // empty
+
+	// =====================================================================
+	// REFRESH MATERIALIZED VIEW  (truth1 + truth2)
+	// =====================================================================
+	"REFRESH MATERIALIZED VIEW orders_by_date",
+	"REFRESH MATERIALIZED VIEW test",
+	`REFRESH MATERIALIZED VIEW "some name that contains space"`,
+	// negatives
+	"REFRESH MATERIALIZED VIEW", // missing name
+	"REFRESH VIEW a",            // missing MATERIALIZED
+
+	// =====================================================================
+	// CREATE CATALOG  (truth1 create-catalog, D-CAT*)
+	// =====================================================================
+	"CREATE CATALOG tpch USING tpch",
+	`CREATE CATALOG brain USING memory WITH ("memory.max-data-per-node" = '128MB')`,
+	`CREATE CATALOG example USING postgresql WITH ("connection-url" = 'jdbc:pg:localhost:5432', "connection-user" = 'u', "connection-password" = 'p', "case-insensitive-name-matching" = 'true')`,
+	"CREATE CATALOG IF NOT EXISTS c USING tpch",
+	"CREATE CATALOG c USING tpch COMMENT 'my catalog'",
+	"CREATE CATALOG c USING tpch AUTHORIZATION alice",
+	"CREATE CATALOG c USING tpch COMMENT 'x' AUTHORIZATION alice WITH (a = '1')",
+	// negatives
+	"CREATE CATALOG c",           // D-CAT2: USING mandatory
+	"CREATE CATALOG a.b USING t", // D-CAT1: catalog name is single ident
+	"CREATE CATALOG c USING",     // dangling USING
+	"CREATE CATALOG",             // missing name
+	"CREATE CATALOG c USING tpch AUTHORIZATION alice COMMENT 'x'", // clause order: COMMENT before AUTHORIZATION
+	"CREATE CATALOG c USING tpch WITH (a = '1') COMMENT 'x'",      // clause order: COMMENT before WITH
+
+	// =====================================================================
+	// DROP CATALOG  (truth1 drop-catalog)
+	// =====================================================================
+	"DROP CATALOG example",
+	"DROP CATALOG IF EXISTS example",
+	"DROP CATALOG example CASCADE",
+	"DROP CATALOG example RESTRICT",
+	// negatives
+	"DROP CATALOG",     // missing name
+	"DROP CATALOG a.b", // catalog name is single ident
+
+	// =====================================================================
+	// COMMENT ON  (truth1 comment + truth2 comment_*.sql, D-CM*)
+	// =====================================================================
+	"COMMENT ON TABLE users IS 'master table'",
+	"COMMENT ON TABLE users IS NULL",
+	"COMMENT ON VIEW users IS 'master view'",
+	"COMMENT ON VIEW users IS NULL",
+	"COMMENT ON COLUMN users.name IS 'full name'",
+	"COMMENT ON COLUMN users.name IS NULL",
+	"COMMENT ON TABLE a IS ''",
+	"COMMENT ON COLUMN a.b IS 'test'",
+	"COMMENT ON COLUMN a IS 'test'",
+	"COMMENT ON COLUMN a.b.c IS 'test'",
+	"COMMENT ON COLUMN a.b.c.d IS 'test'", // D-CM2: 4-part column reference
+	"COMMENT ON TABLE cat.sch.t IS 'x'",
+	// negatives
+	"COMMENT ON TABLE a IS 5",         // D-CM1: value must be string or NULL
+	"COMMENT ON TABLE a",              // missing IS clause
+	"COMMENT ON SCHEMA a IS 'x'",      // COMMENT ON SCHEMA not supported in 481
+	"COMMENT TABLE a IS 'x'",          // missing ON
+	"COMMENT ON TABLE a.b.c.d IS 'x'", // D-CM2: TABLE name max 3 parts
+
+	// =====================================================================
+	// ANALYZE  (truth1 analyze + truth2 analyze.sql, D-AN1)
+	// =====================================================================
+	"ANALYZE web",
+	"ANALYZE hive.default.stores",
+	"ANALYZE hive.default.sales WITH (partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']])",
+	"ANALYZE hive.default.customers WITH (partitions = ARRAY[ARRAY['CA', 'San Francisco'], ARRAY['NY', 'NY']])",
+	"ANALYZE hive.default.sales WITH (partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']], columns = ARRAY['department', 'product_id'])",
+	"ANALYZE foo",
+	`ANALYZE foo WITH ( "string" = 'bar', "long" = 42, computed = concat('ban', 'ana'), a = ARRAY[ 'v1', 'v2' ] )`,
+	// negatives
+	"ANALYZE",             // missing name
+	"ANALYZE a.b.c.d",     // D-AN1: 4-part name
+	"ANALYZE foo WITH ()", // empty property list
+}
+
+// TestDDL_OracleDifferential is the authoritative accept/reject gate: omni's
+// Parse verdict must equal Trino 481's verdict for every corpus statement.
+func TestDDL_OracleDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("trino oracle: skipped in -short mode")
+	}
+	o := connectOracle(t)
+	for _, sql := range ddlOracleCorpus {
+		sql := sql
+		t.Run(truncateName(sql), func(t *testing.T) {
+			_, errs := Parse(sql)
+			omniAccepts := len(errs) == 0
+
+			trinoAccepts, ok := oracleAccepts(t, o, sql)
+			if !ok {
+				t.Skip("oracle unreachable for this case")
+			}
+			if omniAccepts != trinoAccepts {
+				t.Errorf("MISMATCH %q: omni accepts=%v (errs=%v), Trino accepts=%v",
+					sql, omniAccepts, errs, trinoAccepts)
+			}
+		})
+	}
+}

--- a/trino/parser/parser.go
+++ b/trino/parser/parser.go
@@ -238,6 +238,23 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			createTok := p.advance() // consume CREATE
 			return p.parseCreateFunctionStmt(createTok.Loc.Start)
 		}
+		// Every other CREATE object is a parser-ddl concern. The object keyword
+		// follows CREATE directly, except after the optional OR REPLACE prefix
+		// (CREATE OR REPLACE { TABLE | VIEW | MATERIALIZED VIEW }), which the
+		// per-object parsers handle. createObjectKeyword peeks past an
+		// OR REPLACE without consuming so dispatch can route on the object word.
+		switch p.createObjectKeyword() {
+		case kwTABLE:
+			return p.parseCreateTableStmt(p.cur.Loc.Start)
+		case kwSCHEMA:
+			return p.parseCreateSchemaStmt(p.cur.Loc.Start)
+		case kwVIEW:
+			return p.parseCreateViewStmt(p.cur.Loc.Start)
+		case kwMATERIALIZED:
+			return p.parseCreateMaterializedViewStmt(p.cur.Loc.Start)
+		case kwCATALOG:
+			return p.parseCreateCatalogStmt(p.cur.Loc.Start)
+		}
 		return p.unsupported("CREATE")
 	case kwDROP:
 		// DROP ROLE belongs to the parser-dcl-tcl node (grant_revoke.go);
@@ -253,15 +270,35 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 			p.advance()            // consume FUNCTION
 			return p.parseDropFunctionStmt(dropTok.Loc.Start)
 		}
+		// DROP CATALOG has its own parser (catalog_ddl.go); every other DROP
+		// object (TABLE / SCHEMA / VIEW / MATERIALIZED VIEW) is parseDropStmt.
+		if p.peekNext().Kind == kwCATALOG {
+			return p.parseDropCatalogStmt(p.cur.Loc.Start)
+		}
+		switch p.peekNext().Kind {
+		case kwTABLE, kwSCHEMA, kwVIEW, kwMATERIALIZED:
+			return p.parseDropStmt(p.cur.Loc.Start)
+		}
 		return p.unsupported("DROP")
 	case kwALTER:
+		// ALTER fans out on the object keyword (second token).
+		switch p.peekNext().Kind {
+		case kwTABLE:
+			return p.parseAlterTableStmt(p.cur.Loc.Start)
+		case kwSCHEMA:
+			return p.parseAlterSchemaStmt(p.cur.Loc.Start)
+		case kwVIEW:
+			return p.parseAlterViewStmt(p.cur.Loc.Start)
+		case kwMATERIALIZED:
+			return p.parseAlterMaterializedViewStmt(p.cur.Loc.Start)
+		}
 		return p.unsupported("ALTER")
 	case kwCOMMENT:
-		return p.unsupported("COMMENT")
+		return p.parseCommentStmt(p.cur.Loc.Start)
 	case kwANALYZE:
-		return p.unsupported("ANALYZE")
+		return p.parseAnalyzeStmt(p.cur.Loc.Start)
 	case kwREFRESH:
-		return p.unsupported("REFRESH")
+		return p.parseRefreshMaterializedViewStmt(p.cur.Loc.Start)
 
 	// --- DML --- [parser-dml node: insert.go, update_delete.go, merge.go]
 	case kwINSERT:

--- a/trino/parser/parser_test.go
+++ b/trino/parser/parser_test.go
@@ -39,18 +39,18 @@ func TestParse_UnknownStatement(t *testing.T) {
 }
 
 // TestParse_KnownStatementUnsupported verifies that a statement whose leading
-// keyword IS in the dispatch switch but whose body is STILL stubbed (no DAG node
-// has implemented it yet) yields a "not yet supported" diagnostic rather than an
-// "unknown statement" one. DML (parser-dml) and the query layer (parser-select)
-// are now implemented; ALTER (parser-ddl's job) remains a foundation stub, so
-// this test uses it.
+// keyword IS in the dispatch switch but whose object keyword is unrecognized
+// (no Trino statement form) routes to the `unsupported` stub — a "not yet
+// supported" error rather than an "unknown statement" one. Every real Trino
+// DDL/DML/query/admin form is now implemented, so the stub is reached only by
+// such non-forms; `CREATE INDEX` (Trino has no CREATE INDEX) exercises it.
 func TestParse_KnownStatementUnsupported(t *testing.T) {
-	file, errs := Parse("ALTER TABLE t ADD COLUMN c integer")
+	file, errs := Parse("CREATE INDEX idx ON t (a)")
 	if file == nil {
 		t.Fatal("Parse: File is nil")
 	}
 	if len(errs) != 1 {
-		t.Fatalf("Parse(\"ALTER ...\"): got %d errors, want 1: %v", len(errs), errs)
+		t.Fatalf("Parse(\"CREATE INDEX ...\"): got %d errors, want 1: %v", len(errs), errs)
 	}
 	if !strings.Contains(errs[0].Msg, "not yet supported") {
 		t.Errorf("error = %q, want it to mention 'not yet supported'", errs[0].Msg)
@@ -58,11 +58,11 @@ func TestParse_KnownStatementUnsupported(t *testing.T) {
 }
 
 // TestParse_MultiStatementErrorsCollected verifies that ParseBestEffort
-// collects errors from every segment, not just the first. Two still-stubbed
-// statements (ALTER and COMMENT, parser-ddl's job) separated by ';' must yield
+// collects errors from every segment, not just the first. Two unrecognized
+// object-keyword stubs (CREATE INDEX, ALTER INDEX) separated by ';' must yield
 // two errors.
 func TestParse_MultiStatementErrorsCollected(t *testing.T) {
-	res := ParseBestEffort("ALTER TABLE t ADD COLUMN c integer; COMMENT ON TABLE u IS 'x'")
+	res := ParseBestEffort("CREATE INDEX i ON t (a); ALTER INDEX i RENAME TO j")
 	if got := len(res.Errors); got != 2 {
 		t.Fatalf("ParseBestEffort: got %d errors, want 2: %v", got, res.Errors)
 	}

--- a/trino/parser/schema_view.go
+++ b/trino/parser/schema_view.go
@@ -1,0 +1,656 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
+
+// This file is part of the parser-ddl DAG node. It implements Trino's CREATE /
+// ALTER statements for schemas, views, and materialized views, plus REFRESH
+// MATERIALIZED VIEW:
+//
+//	CREATE SCHEMA / ALTER SCHEMA (RENAME TO | SET AUTHORIZATION)
+//	CREATE [OR REPLACE] VIEW … AS query / ALTER VIEW (RENAME | REFRESH | SET AUTHORIZATION)
+//	CREATE [OR REPLACE] MATERIALIZED VIEW … AS query
+//	ALTER MATERIALIZED VIEW (RENAME | SET PROPERTIES) / REFRESH MATERIALIZED VIEW
+//
+// DROP {SCHEMA,VIEW,MATERIALIZED VIEW} live in drop.go.
+//
+// Legacy ANTLR grammar (TrinoParser.g4) the implementation tracks:
+//
+//	| CREATE_ SCHEMA_ (IF_ NOT_ EXISTS_)? qualifiedName (AUTHORIZATION_ principal)? (WITH_ properties)? # createSchema
+//	| ALTER_ SCHEMA_ qualifiedName RENAME_ TO_ identifier              # renameSchema
+//	| ALTER_ SCHEMA_ qualifiedName SET_ AUTHORIZATION_ principal       # setSchemaAuthorization
+//	| CREATE_ (OR_ REPLACE_)? MATERIALIZED_ VIEW_ (IF_ NOT_ EXISTS_)? qualifiedName
+//	    (GRACE_ PERIOD_ interval)? (COMMENT_ string_)? (WITH_ properties)? AS_ rootQuery # createMaterializedView
+//	| CREATE_ (OR_ REPLACE_)? VIEW_ qualifiedName (COMMENT_ string_)? (SECURITY_ (DEFINER_ | INVOKER_))? AS_ rootQuery # createView
+//	| REFRESH_ MATERIALIZED_ VIEW_ qualifiedName                       # refreshMaterializedView
+//	| ALTER_ MATERIALIZED_ VIEW_ (IF_ EXISTS_)? from RENAME_ TO_ to    # renameMaterializedView
+//	| ALTER_ MATERIALIZED_ VIEW_ qualifiedName SET_ PROPERTIES_ propertyAssignments # setMaterializedViewProperties
+//	| ALTER_ VIEW_ from RENAME_ TO_ to                                 # renameView
+//	| ALTER_ VIEW_ from SET_ AUTHORIZATION_ principal                  # setViewAuthorization
+//
+// Adjudicated against the live Trino 481 oracle (which is ahead of the legacy
+// grammar). Oracle-confirmed facts baked in:
+//
+//	D-MV1 (WHEN STALE + FIXED clause order). Trino 481 accepts `CREATE
+//	   MATERIALIZED VIEW … WHEN STALE (INLINE | FAIL) …` (ddl.md
+//	   create-materialized-view), absent from the legacy grammar.
+//	   WHEN/STALE/INLINE/FAIL are NON-reserved (STALE/INLINE/FAIL are not even
+//	   keyword tokens; they lex as plain identifiers), so STALE is matched by
+//	   identifier text. The optional clauses appear in a FIXED order — GRACE
+//	   PERIOD, then WHEN STALE, then COMMENT, then WITH, each at most once: 481
+//	   REJECTS out-of-order clauses (`COMMENT 'c' GRACE PERIOD …`,
+//	   `WITH (…) COMMENT …` are SYNTAX_ERRORs), so they are parsed as a strict
+//	   sequence (verified against the oracle), not an order-tolerant set.
+//	D-MV2 (object name ≤ 3 parts). Names are bounded to catalog.schema.object;
+//	   the RENAME TO target is UNBOUNDED (over-bound failure is semantic — see
+//	   D-AT5 in alter_table.go).
+//	D-MV3 (SET AUTHORIZATION + IF EXISTS scoping). 481 accepts `ALTER MATERIALIZED
+//	   VIEW name SET AUTHORIZATION principal` (ddl.md
+//	   alter-materialized-view-set-authorization), absent from the legacy grammar
+//	   — a docs-ahead extension. IF EXISTS is valid ONLY on the RENAME form (the
+//	   legacy grammar's `(IF_ EXISTS_)?` is only on renameMaterializedView); 481
+//	   rejects `ALTER MATERIALIZED VIEW IF EXISTS … SET …` as a SYNTAX_ERROR. Both
+//	   facts are oracle-confirmed.
+//	D-SC1 (CREATE SCHEMA name ≤ 2 parts). A schema is catalog.schema; `CREATE
+//	   SCHEMA a.b.c` is a SYNTAX_ERROR. ALTER SCHEMA targets are likewise ≤ 2.
+//	D-VW1 (CREATE VIEW has no IF NOT EXISTS). The grammar offers only `CREATE
+//	   [OR REPLACE] VIEW` — there is no IF NOT EXISTS for a plain view, matching
+//	   the docs (only OR REPLACE). MATERIALIZED VIEW does carry IF NOT EXISTS.
+
+// ---------------------------------------------------------------------------
+// Authorization target (shared: SCHEMA / VIEW / TABLE / MATERIALIZED VIEW)
+// ---------------------------------------------------------------------------
+
+// parseAuthorizationPrincipal parses the principal after AUTHORIZATION /
+// SET AUTHORIZATION (`identifier | USER identifier | ROLE identifier`). It is a
+// thin wrapper over the shared parsePrincipal (grant_revoke.go) so every DDL
+// authorization clause resolves the principal identically.
+func (p *Parser) parseAuthorizationPrincipal() (*Principal, error) {
+	return p.parsePrincipal()
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SCHEMA
+// ---------------------------------------------------------------------------
+
+// CreateSchemaStmt is `CREATE SCHEMA [IF NOT EXISTS] name
+// [AUTHORIZATION principal] [WITH (props)]`.
+type CreateSchemaStmt struct {
+	IfNotExists   bool
+	Name          *ast.QualifiedName // ≤ 2 parts (catalog.schema)
+	Authorization *Principal         // nil when no AUTHORIZATION clause
+	Properties    []*Property
+	Loc           ast.Loc
+}
+
+func (n *CreateSchemaStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CreateSchemaStmt) Span() ast.Loc    { return n.Loc }
+
+// parseCreateSchemaStmt parses CREATE SCHEMA. On entry cur is CREATE.
+func (p *Parser) parseCreateSchemaStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume CREATE
+	if _, err := p.expect(kwSCHEMA); err != nil {
+		return nil, err
+	}
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	// D-SC1: a schema name is catalog.schema (≤ 2 parts).
+	name, err := p.parseBoundedQualifiedName(2, "schema name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &CreateSchemaStmt{IfNotExists: ifNotExists, Name: name, Loc: ast.Loc{Start: startOffset, End: name.Loc.End}}
+
+	if _, ok := p.match(kwAUTHORIZATION); ok {
+		princ, err := p.parseAuthorizationPrincipal()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Authorization = princ
+		stmt.Loc.End = princ.Loc.End
+	}
+	props, err := p.parseOptionalWithProperties()
+	if err != nil {
+		return nil, err
+	}
+	if props != nil {
+		stmt.Properties = props
+		stmt.Loc.End = p.prev.Loc.End
+	}
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SCHEMA
+// ---------------------------------------------------------------------------
+
+// AlterSchemaKind classifies an ALTER SCHEMA sub-form.
+type AlterSchemaKind int
+
+const (
+	// AlterSchemaRename is ALTER SCHEMA name RENAME TO new_name.
+	AlterSchemaRename AlterSchemaKind = iota
+	// AlterSchemaSetAuthorization is ALTER SCHEMA name SET AUTHORIZATION principal.
+	AlterSchemaSetAuthorization
+)
+
+// AlterSchemaStmt is an ALTER SCHEMA statement. NewName is set for the rename
+// form; Authorization for the set-authorization form.
+type AlterSchemaStmt struct {
+	Kind          AlterSchemaKind
+	Name          *ast.QualifiedName
+	NewName       *ast.Identifier // rename target (RENAME form)
+	Authorization *Principal      // SET AUTHORIZATION form
+	Loc           ast.Loc
+}
+
+func (n *AlterSchemaStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *AlterSchemaStmt) Span() ast.Loc    { return n.Loc }
+
+// parseAlterSchemaStmt parses ALTER SCHEMA. On entry cur is ALTER (the dispatch
+// has peeked SCHEMA as the second keyword).
+func (p *Parser) parseAlterSchemaStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume ALTER
+	p.advance() // consume SCHEMA
+	name, err := p.parseBoundedQualifiedName(2, "schema name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &AlterSchemaStmt{Name: name, Loc: ast.Loc{Start: startOffset}}
+
+	switch p.cur.Kind {
+	case kwRENAME:
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterSchemaRename
+		stmt.NewName = newName
+		stmt.Loc.End = newName.Loc.End
+	case kwSET:
+		p.advance() // consume SET
+		if _, err := p.expect(kwAUTHORIZATION); err != nil {
+			return nil, err
+		}
+		princ, err := p.parseAuthorizationPrincipal()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterSchemaSetAuthorization
+		stmt.Authorization = princ
+		stmt.Loc.End = princ.Loc.End
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE VIEW
+// ---------------------------------------------------------------------------
+
+// ViewSecurity is the SECURITY mode of a CREATE VIEW.
+type ViewSecurity int
+
+const (
+	// ViewSecurityNone means no SECURITY clause was given.
+	ViewSecurityNone ViewSecurity = iota
+	// ViewSecurityDefiner is SECURITY DEFINER.
+	ViewSecurityDefiner
+	// ViewSecurityInvoker is SECURITY INVOKER.
+	ViewSecurityInvoker
+)
+
+// CreateViewStmt is `CREATE [OR REPLACE] VIEW name [COMMENT str]
+// [SECURITY {DEFINER | INVOKER}] AS query`.
+type CreateViewStmt struct {
+	OrReplace bool
+	Name      *ast.QualifiedName
+	Comment   *string
+	Security  ViewSecurity
+	Query     *Query
+	Loc       ast.Loc
+}
+
+func (n *CreateViewStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CreateViewStmt) Span() ast.Loc    { return n.Loc }
+
+// parseCreateViewStmt parses CREATE [OR REPLACE] VIEW. On entry cur is CREATE.
+func (p *Parser) parseCreateViewStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume CREATE
+	orReplace, err := p.parseOptionalOrReplace()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	// D-VW1: no IF NOT EXISTS for a plain view; the name follows directly.
+	name, err := p.parseBoundedQualifiedName(3, "view name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &CreateViewStmt{OrReplace: orReplace, Name: name, Loc: ast.Loc{Start: startOffset}}
+
+	comment, err := p.parseOptionalComment()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Comment = comment
+
+	if _, ok := p.match(kwSECURITY); ok {
+		secTok, ok := p.match(kwDEFINER, kwINVOKER)
+		if !ok {
+			return nil, p.syntaxErrorAtCur()
+		}
+		if secTok.Kind == kwDEFINER {
+			stmt.Security = ViewSecurityDefiner
+		} else {
+			stmt.Security = ViewSecurityInvoker
+		}
+	}
+
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	query, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Query = query
+	stmt.Loc.End = query.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER VIEW
+// ---------------------------------------------------------------------------
+
+// AlterViewKind classifies an ALTER VIEW sub-form.
+type AlterViewKind int
+
+const (
+	// AlterViewRename is ALTER VIEW name RENAME TO new_name.
+	AlterViewRename AlterViewKind = iota
+	// AlterViewSetAuthorization is ALTER VIEW name SET AUTHORIZATION principal.
+	AlterViewSetAuthorization
+	// AlterViewRefresh is ALTER VIEW name REFRESH (docs-ahead extension, D-AV1).
+	AlterViewRefresh
+)
+
+// AlterViewStmt is an ALTER VIEW statement.
+type AlterViewStmt struct {
+	Kind          AlterViewKind
+	Name          *ast.QualifiedName
+	NewName       *ast.QualifiedName // RENAME target
+	Authorization *Principal         // SET AUTHORIZATION form
+	Loc           ast.Loc
+}
+
+func (n *AlterViewStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *AlterViewStmt) Span() ast.Loc    { return n.Loc }
+
+// parseAlterViewStmt parses ALTER VIEW. On entry cur is ALTER (dispatch peeked
+// VIEW). The docs (alter-view.html) add `ALTER VIEW name REFRESH` over the
+// legacy grammar (D-AV1); the oracle adjudicates whether 481 accepts it.
+func (p *Parser) parseAlterViewStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume ALTER
+	p.advance() // consume VIEW
+	name, err := p.parseBoundedQualifiedName(3, "view name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &AlterViewStmt{Name: name, Loc: ast.Loc{Start: startOffset}}
+
+	switch p.cur.Kind {
+	case kwRENAME:
+		p.advance()
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		// The RENAME TO target is UNBOUNDED (oracle-confirmed, ledger DDL4): a
+		// 4+-part target fails semantically (TABLE_NOT_FOUND), not at parse.
+		newName, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterViewRename
+		stmt.NewName = newName
+		stmt.Loc.End = newName.Loc.End
+	case kwSET:
+		p.advance()
+		if _, err := p.expect(kwAUTHORIZATION); err != nil {
+			return nil, err
+		}
+		princ, err := p.parseAuthorizationPrincipal()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterViewSetAuthorization
+		stmt.Authorization = princ
+		stmt.Loc.End = princ.Loc.End
+	case kwREFRESH:
+		refreshTok := p.advance()
+		stmt.Kind = AlterViewRefresh
+		stmt.Loc.End = refreshTok.Loc.End
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// MaterializedViewStaleMode is the WHEN STALE mode (D-MV1 docs-ahead extension).
+type MaterializedViewStaleMode int
+
+const (
+	// MVStaleNone means no WHEN STALE clause was given.
+	MVStaleNone MaterializedViewStaleMode = iota
+	// MVStaleInline is WHEN STALE INLINE.
+	MVStaleInline
+	// MVStaleFail is WHEN STALE FAIL.
+	MVStaleFail
+)
+
+// CreateMaterializedViewStmt is `CREATE [OR REPLACE] MATERIALIZED VIEW
+// [IF NOT EXISTS] name [GRACE PERIOD interval] [WHEN STALE (INLINE|FAIL)]
+// [COMMENT str] [WITH (props)] AS query`.
+type CreateMaterializedViewStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ast.QualifiedName
+	GracePeriod Expr // INTERVAL literal; nil when absent
+	StaleMode   MaterializedViewStaleMode
+	Comment     *string
+	Properties  []*Property
+	Query       *Query
+	Loc         ast.Loc
+}
+
+func (n *CreateMaterializedViewStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *CreateMaterializedViewStmt) Span() ast.Loc    { return n.Loc }
+
+// parseCreateMaterializedViewStmt parses CREATE [OR REPLACE] MATERIALIZED VIEW.
+// On entry cur is CREATE. The optional clauses (GRACE PERIOD, WHEN STALE,
+// COMMENT, WITH) are parsed in an order-tolerant loop, each at most once, then
+// the mandatory `AS query` (D-MV1).
+func (p *Parser) parseCreateMaterializedViewStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume CREATE
+	orReplace, err := p.parseOptionalOrReplace()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.parseBoundedQualifiedName(3, "materialized view name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &CreateMaterializedViewStmt{
+		OrReplace:   orReplace,
+		IfNotExists: ifNotExists,
+		Name:        name,
+		Loc:         ast.Loc{Start: startOffset},
+	}
+
+	// D-MV1: the optional clauses appear in a FIXED order — GRACE PERIOD, then
+	// WHEN STALE, then COMMENT, then WITH — each at most once. Trino 481 REJECTS
+	// out-of-order clauses (`COMMENT 'c' GRACE PERIOD …`, `WITH (…) COMMENT …`,
+	// `WHEN STALE … GRACE PERIOD …` are SYNTAX_ERRORs), so they are consumed as a
+	// strict sequence, not an order-tolerant set — verified against the oracle.
+	if p.cur.Kind == kwGRACE {
+		p.advance() // consume GRACE
+		if _, err := p.expect(kwPERIOD); err != nil {
+			return nil, err
+		}
+		if p.cur.Kind != kwINTERVAL {
+			return nil, p.exprErrorAt("expected INTERVAL after GRACE PERIOD")
+		}
+		gp, err := p.parseIntervalLiteral()
+		if err != nil {
+			return nil, err
+		}
+		stmt.GracePeriod = gp
+	}
+	if p.cur.Kind == kwWHEN {
+		// WHEN STALE (INLINE | FAIL). STALE/INLINE/FAIL are not keyword tokens;
+		// match them by identifier text.
+		p.advance() // consume WHEN
+		if p.cur.Kind != tokIdent || !strings.EqualFold(p.cur.Str, "STALE") {
+			return nil, &ParseError{Loc: p.cur.Loc, Msg: "expected STALE after WHEN"}
+		}
+		p.advance() // consume STALE
+		switch {
+		case p.cur.Kind == tokIdent && strings.EqualFold(p.cur.Str, "INLINE"):
+			stmt.StaleMode = MVStaleInline
+		case p.cur.Kind == tokIdent && strings.EqualFold(p.cur.Str, "FAIL"):
+			stmt.StaleMode = MVStaleFail
+		default:
+			return nil, &ParseError{Loc: p.cur.Loc, Msg: "expected INLINE or FAIL after WHEN STALE"}
+		}
+		p.advance() // consume INLINE / FAIL
+	}
+	comment, err := p.parseOptionalComment()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Comment = comment
+	props, err := p.parseOptionalWithProperties()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Properties = props
+
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	query, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Query = query
+	stmt.Loc.End = query.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// AlterMaterializedViewKind classifies an ALTER MATERIALIZED VIEW sub-form.
+type AlterMaterializedViewKind int
+
+const (
+	// AlterMVRename is ALTER MATERIALIZED VIEW [IF EXISTS] name RENAME TO new.
+	AlterMVRename AlterMaterializedViewKind = iota
+	// AlterMVSetProperties is ALTER MATERIALIZED VIEW name SET PROPERTIES …
+	AlterMVSetProperties
+	// AlterMVSetAuthorization is ALTER MATERIALIZED VIEW name SET AUTHORIZATION
+	// principal (D-MV3 docs-ahead extension — absent from the legacy grammar but
+	// documented and oracle-accepted in 481).
+	AlterMVSetAuthorization
+)
+
+// AlterMaterializedViewStmt is an ALTER MATERIALIZED VIEW statement.
+type AlterMaterializedViewStmt struct {
+	Kind          AlterMaterializedViewKind
+	IfExists      bool // only valid on the RENAME form (D-MV3)
+	Name          *ast.QualifiedName
+	NewName       *ast.QualifiedName // RENAME target
+	Properties    []*Property        // SET PROPERTIES form
+	Authorization *Principal         // SET AUTHORIZATION form
+	Loc           ast.Loc
+}
+
+func (n *AlterMaterializedViewStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *AlterMaterializedViewStmt) Span() ast.Loc    { return n.Loc }
+
+// parseAlterMaterializedViewStmt parses ALTER MATERIALIZED VIEW. On entry cur
+// is ALTER (dispatch peeked MATERIALIZED).
+func (p *Parser) parseAlterMaterializedViewStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume ALTER
+	p.advance() // consume MATERIALIZED
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	// D-MV3: IF EXISTS is valid ONLY on the RENAME form (legacy grammar carries
+	// `(IF_ EXISTS_)?` only on renameMaterializedView, not on the SET forms). It
+	// appears before the name, so it is parsed here and the SET branch rejects
+	// it. Trino 481 rejects `ALTER MATERIALIZED VIEW IF EXISTS … SET …` as a
+	// SYNTAX_ERROR.
+	ifExists, err := p.parseOptionalIfExists()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.parseBoundedQualifiedName(3, "materialized view name")
+	if err != nil {
+		return nil, err
+	}
+	stmt := &AlterMaterializedViewStmt{IfExists: ifExists, Name: name, Loc: ast.Loc{Start: startOffset}}
+
+	switch p.cur.Kind {
+	case kwRENAME:
+		p.advance()
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		// The RENAME TO target is UNBOUNDED (oracle-confirmed, ledger DDL4): a
+		// 4+-part target fails semantically (TABLE_NOT_FOUND), not at parse.
+		newName, err := p.parseQualifiedName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = AlterMVRename
+		stmt.NewName = newName
+		stmt.Loc.End = newName.Loc.End
+	case kwSET:
+		// D-MV3: IF EXISTS is not allowed on the SET forms.
+		if ifExists {
+			return nil, &ParseError{Loc: name.Loc, Msg: "IF EXISTS is not allowed on ALTER MATERIALIZED VIEW … SET"}
+		}
+		p.advance() // consume SET
+		switch p.cur.Kind {
+		case kwPROPERTIES:
+			p.advance() // consume PROPERTIES
+			props, err := p.parsePropertyAssignments()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Kind = AlterMVSetProperties
+			stmt.Properties = props
+			stmt.Loc.End = p.prev.Loc.End
+		case kwAUTHORIZATION:
+			// D-MV3: SET AUTHORIZATION (docs-ahead; absent from legacy grammar,
+			// accepted by 481).
+			p.advance() // consume AUTHORIZATION
+			princ, err := p.parseAuthorizationPrincipal()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Kind = AlterMVSetAuthorization
+			stmt.Authorization = princ
+			stmt.Loc.End = princ.Loc.End
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// REFRESH MATERIALIZED VIEW
+// ---------------------------------------------------------------------------
+
+// RefreshMaterializedViewStmt is `REFRESH MATERIALIZED VIEW name`.
+type RefreshMaterializedViewStmt struct {
+	Name *ast.QualifiedName
+	Loc  ast.Loc
+}
+
+func (n *RefreshMaterializedViewStmt) Tag() ast.NodeTag { return ast.T_Invalid }
+func (n *RefreshMaterializedViewStmt) Span() ast.Loc    { return n.Loc }
+
+// parseRefreshMaterializedViewStmt parses REFRESH MATERIALIZED VIEW name. On
+// entry cur is REFRESH.
+func (p *Parser) parseRefreshMaterializedViewStmt(startOffset int) (ast.Node, error) {
+	p.advance() // consume REFRESH
+	if _, err := p.expect(kwMATERIALIZED); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	name, err := p.parseBoundedQualifiedName(3, "materialized view name")
+	if err != nil {
+		return nil, err
+	}
+	return &RefreshMaterializedViewStmt{Name: name, Loc: ast.Loc{Start: startOffset, End: name.Loc.End}}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// parseOptionalOrReplace consumes an `OR REPLACE` clause when present.
+func (p *Parser) parseOptionalOrReplace() (bool, error) {
+	if _, ok := p.match(kwOR); !ok {
+		return false, nil
+	}
+	if _, err := p.expect(kwREPLACE); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// parsePropertyAssignments parses a bare `property (, property)*` list (no
+// surrounding parentheses) — the SET PROPERTIES form's propertyAssignments rule.
+func (p *Parser) parsePropertyAssignments() ([]*Property, error) {
+	first, err := p.parseProperty()
+	if err != nil {
+		return nil, err
+	}
+	props := []*Property{first}
+	for {
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+		next, err := p.parseProperty()
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, next)
+	}
+	return props, nil
+}
+
+var (
+	_ ast.Node = (*CreateSchemaStmt)(nil)
+	_ ast.Node = (*AlterSchemaStmt)(nil)
+	_ ast.Node = (*CreateViewStmt)(nil)
+	_ ast.Node = (*AlterViewStmt)(nil)
+	_ ast.Node = (*CreateMaterializedViewStmt)(nil)
+	_ ast.Node = (*AlterMaterializedViewStmt)(nil)
+	_ ast.Node = (*RefreshMaterializedViewStmt)(nil)
+)


### PR DESCRIPTION
## Node

`trino/parser-ddl` (v2 migration, engine=trino, grammar). DAG node spec: `docs/migration/trino/dag.md` + `analysis.md`. Depends on (merged) `trino/parser-select` + `trino/types`.

Implements Trino 481's schema-object DDL, replacing the foundation's stubbed `CREATE`/`DROP`/`ALTER`/`COMMENT`/`ANALYZE`/`REFRESH` dispatch arms with real recursive-descent parsers.

## What's implemented

| File | Statements |
|---|---|
| `create_table.go` | `CREATE [OR REPLACE] TABLE [IF NOT EXISTS]` — column-definition form (cols / `LIKE` / constraints) and CTAS form (`AS query`, column aliases, `WITH [NO] DATA`); shared property-list + column-definition + `IF [NOT] EXISTS` / `COMMENT` helpers |
| `alter_table.go` | `ALTER TABLE` rename · add/drop/rename/alter column (`SET DATA TYPE` / `SET`·`DROP DEFAULT` / `DROP NOT NULL`) · `SET AUTHORIZATION` · `SET PROPERTIES` · `EXECUTE` |
| `drop.go` | `DROP {TABLE\|SCHEMA\|VIEW\|MATERIALIZED VIEW} [IF EXISTS] [CASCADE\|RESTRICT]` |
| `schema_view.go` | `CREATE`/`ALTER SCHEMA`; `CREATE`/`ALTER VIEW`; `CREATE`/`ALTER`/`REFRESH MATERIALIZED VIEW` |
| `catalog_ddl.go` | `CREATE`/`DROP CATALOG` |
| `comment_analyze.go` | `COMMENT ON {TABLE\|VIEW\|COLUMN}`; `ANALYZE` |

Statement structs live in package `parser` and return `ast.T_Invalid` from `Tag()` — the established convention (see `insert.go`); downstream consumers reach the concrete type by a Go type switch.

CREATE/DROP `FUNCTION` (parser-routines), CREATE/DROP `ROLE` (parser-dcl-tcl), and `TRUNCATE TABLE` (parser-dml) are owned by other nodes and out of scope.

## Correctness — proven against the live Trino 481 oracle

`oracle_ddl_test.go` is the **differential gate** (correctness-protocol.md): ~260 statements — every legacy `examples/*.sql` form (assertions stripped), every `truth1/ddl.md` documented form, the oracle-pinned grammar facts, and negatives — run through both omni `Parse` and Trino 481 (`trinooracle.CheckSyntax`); the accept/reject verdicts must match. **All pass.** `ddl_structure_test.go` is the **structural gate**, asserting the parsed AST shape for each form. Skips cleanly when no oracle is reachable.

### Oracle-confirmed divergences (legacy grammar vs 481), verified case-by-case

- **Per-position name caps**: table/view/matview/ANALYZE ≤ 3, schema ≤ 2, `COMMENT ON COLUMN` ≤ 4, catalog = 1 (legacy uses unbounded `qualifiedName`; 481 enforces at parse).
- **RENAME TO target is UNBOUNDED** (4+-part accepted → fails semantically) while the source stays capped at 3 — for TABLE/VIEW/MATERIALIZED VIEW.
- **Column constraints are FIXED-ORDER** (`DEFAULT`, `NOT NULL`, `COMMENT`, `WITH`); column `DEFAULT` is a docs-ahead 481 addition; out-of-order ⇒ SYNTAX_ERROR.
- **CREATE MATERIALIZED VIEW clauses are FIXED-ORDER** (`GRACE PERIOD`, `WHEN STALE`, `COMMENT`, `WITH`); `WHEN STALE (INLINE|FAIL)` is a docs-ahead 481 addition.
- **CREATE TABLE rejects `OR REPLACE` + `IF NOT EXISTS`** at parse time (TABLE-only; same combo on MATERIALIZED VIEW is `NOT_SUPPORTED` = grammar-accepted).
- **`IF EXISTS` on ALTER TABLE / ALTER MATERIALIZED VIEW** is valid ONLY on rename/column sub-forms, NOT on `SET AUTHORIZATION` / `SET PROPERTIES` / `EXECUTE`.
- **`ALTER MATERIALIZED VIEW SET AUTHORIZATION`** and **`ALTER VIEW REFRESH`** are docs-ahead 481 additions absent from the legacy grammar.

These reconcile with / confirm the pre-seeded divergence ledger rows (DDL part-count, CTAS disambiguation, OR REPLACE on column-def form, unbounded rename target, OR REPLACE ⊕ IF NOT EXISTS).

## Review gate

Cross-reviewed with **Claude** (`/code-review`) and **Codex** lenses. Codex caught two real over-/under-accepts my initial corpus missed — the `ALTER MATERIALIZED VIEW SET AUTHORIZATION` miss and the `IF EXISTS`-scoping over-accepts — both now fixed and locked in with corpus negatives. No blocking findings remain.

## Out-of-scope edits (recorded)

- **`parser.go`**: wired the `CREATE`/`DROP`/`ALTER`/`COMMENT`/`ANALYZE`/`REFRESH` dispatch arms to the new parsers (ROLE/FUNCTION stay routed elsewhere). Same pattern as the parser-dml node.
- **`diagnose_test.go` / `parser_test.go`**: repointed two foundation stub-assertion tests (which used ALTER/COMMENT as "still-stubbed" placeholders) at the remaining unrecognized-object stub path (`CREATE INDEX` / `ALTER INDEX`), since every real Trino DDL form is now implemented.

## Note

Pre-existing, unrelated: `TestLexer_OracleDifferential`'s backtick case still fails (lexer node; already spun off as a separate task). No lexer files touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)