### PR TITLE
fix(tidb/parser): reject SELECT/TABLE INTO non-OUTFILE targets (TiDB parity)

### DIFF
--- a/tidb/parser/compare_test.go
+++ b/tidb/parser/compare_test.go
@@ -8523,6 +8523,31 @@ func TestParseSelectDistinctrow(t *testing.T) {
 
 // --- Batch 65: depth_fix_select_into_outfile ---
 
+// TestSelectIntoTiDBRejectsNonOutfile pins TiDB v8.5.0 parity (BYT-9650):
+// only SELECT/TABLE ... INTO OUTFILE is accepted. INTO DUMPFILE and INTO
+// into user/local variables are rejected (1064), unlike MySQL which accepts
+// all three. Verified on pingcap/tidb:v8.5.0.
+func TestSelectIntoTiDBRejectsNonOutfile(t *testing.T) {
+	cases := []string{
+		// INTO DUMPFILE (both statements, multiple clause positions)
+		"SELECT * INTO DUMPFILE '/tmp/d' FROM t",
+		"SELECT a FROM t GROUP BY a HAVING a > 0 INTO DUMPFILE '/tmp/d' ORDER BY a",
+		"TABLE t INTO DUMPFILE '/tmp/d'",
+		// INTO user variable
+		"SELECT a INTO @x FROM t",
+		"SELECT a, b INTO @x, @y FROM t",
+		"SELECT a, b FROM t GROUP BY a HAVING a > 0 INTO @x, @y ORDER BY a",
+		"TABLE t INTO @v1, @v2",
+		// INTO local variable (the SELECT clause backs routine-body INTO too)
+		"SELECT 1 INTO v",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			ParseExpectError(t, sql)
+		})
+	}
+}
+
 func TestParseSelectIntoOutfileFields(t *testing.T) {
 	tests := []string{
 		"SELECT * FROM t INTO OUTFILE '/tmp/data.csv' FIELDS TERMINATED BY ','",
@@ -8555,8 +8580,6 @@ func TestParseSelectIntoOutfileCharset(t *testing.T) {
 func TestParseSelectIntoBeforeFrom(t *testing.T) {
 	tests := []string{
 		"SELECT * INTO OUTFILE '/tmp/data.csv' FROM t",
-		"SELECT * INTO DUMPFILE '/tmp/data.bin' FROM t",
-		"SELECT a, b INTO @x, @y FROM t",
 	}
 	for _, sql := range tests {
 		t.Run(sql, func(t *testing.T) {
@@ -9368,13 +9391,9 @@ func TestParseSelectIntoAfterHaving(t *testing.T) {
 
 func TestParseSelectIntoAfterHavingBeforeOrderBy(t *testing.T) {
 	tests := []string{
-		// INTO with DUMPFILE at position 2
-		"SELECT a FROM t GROUP BY a HAVING a > 0 INTO DUMPFILE '/tmp/dump.dat' ORDER BY a",
-		// INTO with variable at position 2
-		"SELECT a, b FROM t GROUP BY a HAVING a > 0 INTO @x, @y ORDER BY a",
-		// Regression: INTO at position 1 still works
-		"SELECT a INTO @x FROM t",
-		// Regression: INTO at position 3 still works
+		// Regression: INTO OUTFILE at position 3 (after the locking clause)
+		// still works. The DUMPFILE / @var forms at positions 1-2 are rejected
+		// by TiDB v8.5.0 — see TestSelectIntoTiDBRejectsNonOutfile.
 		"SELECT a FROM t FOR UPDATE INTO OUTFILE '/tmp/result.txt'",
 	}
 	for _, sql := range tests {
@@ -10724,11 +10743,13 @@ func TestReviewBatch110_TableIntoOutfile(t *testing.T) {
 }
 
 func TestReviewBatch110_TableIntoDumpfile(t *testing.T) {
-	ParseAndCheck(t, "TABLE t1 INTO DUMPFILE '/tmp/out.dat'")
+	// TiDB v8.5.0 rejects INTO DUMPFILE (only INTO OUTFILE is supported).
+	ParseExpectError(t, "TABLE t1 INTO DUMPFILE '/tmp/out.dat'")
 }
 
 func TestReviewBatch110_TableIntoVar(t *testing.T) {
-	ParseAndCheck(t, "TABLE t1 INTO @v1, @v2")
+	// TiDB v8.5.0 rejects INTO @var (only INTO OUTFILE is supported).
+	ParseExpectError(t, "TABLE t1 INTO @v1, @v2")
 }
 
 func TestReviewBatch110_ValuesBasic(t *testing.T) {

--- a/tidb/parser/select.go
+++ b/tidb/parser/select.go
@@ -160,7 +160,7 @@ func (p *Parser) parseWithStmt() (nodes.Node, error) {
 //	    [ORDER BY {col_name | expr | position} [ASC | DESC], ...]
 //	    [LIMIT {[offset,] row_count | row_count OFFSET offset}]
 //	    [FOR {UPDATE | SHARE} [OF tbl_name [, tbl_name] ...] [NOWAIT | SKIP LOCKED]]
-//	    [INTO OUTFILE 'file_name' | INTO DUMPFILE 'file_name' | INTO var_name [, var_name]]
+//	    [INTO OUTFILE 'file_name']  (TiDB v8.5.0: only OUTFILE; no DUMPFILE / var targets)
 func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 	start := p.pos()
 
@@ -1610,7 +1610,8 @@ func (p *Parser) parseLockInShareMode() (*nodes.ForUpdate, error) {
 	}, nil
 }
 
-// parseIntoClause parses INTO OUTFILE / DUMPFILE / var_list.
+// parseIntoClause parses the SELECT/TABLE INTO clause. TiDB v8.5.0 supports
+// only INTO OUTFILE; INTO DUMPFILE and INTO var_list are rejected.
 //
 // Ref: https://dev.mysql.com/doc/refman/8.0/en/select.html
 //
@@ -1725,29 +1726,12 @@ func (p *Parser) parseIntoClause() (*nodes.IntoClause, error) {
 			}
 		}
 
-	case kwDUMPFILE:
-		p.advance()
-		if p.cur.Type == tokSCONST {
-			into.Dumpfile = p.cur.Str
-			p.advance()
-		}
 	default:
-		// INTO var_name [, var_name ...]
-		for {
-			if p.isVariableRef() {
-				v, err := p.parseVariableRef()
-				if err != nil {
-					return nil, err
-				}
-				into.Vars = append(into.Vars, v)
-			} else {
-				break
-			}
-			if p.cur.Type != ',' {
-				break
-			}
-			p.advance()
-		}
+		// TiDB v8.5.0 supports only SELECT ... INTO OUTFILE. Unlike MySQL it
+		// rejects INTO DUMPFILE and INTO @user_var / INTO local_var; the same
+		// applies to the TABLE statement's INTO clause (verified on
+		// pingcap/tidb:v8.5.0). Reject everything except OUTFILE.
+		return nil, p.syntaxErrorAtCur()
 	}
 
 	into.Loc.End = p.pos()


### PR DESCRIPTION
## What

`tidb/parser` now rejects `SELECT/TABLE ... INTO` targets other than `OUTFILE`, matching TiDB v8.5.0. Resolves the `SELECT ... INTO @uservar` over-acceptance tracked in **BYT-9650**.

## Why

TiDB v8.5.0 supports only `... INTO OUTFILE`. Unlike MySQL it **rejects** (1064):

| Form | MySQL | TiDB v8.5.0 | omni before | omni after |
|---|---|---|---|---|
| `INTO OUTFILE 'f'` | ✅ | ✅ | ✅ | ✅ |
| `INTO DUMPFILE 'f'` | ✅ | ❌ 1064 | ✅ over-accept | ❌ reject |
| `INTO @user_var` | ✅ | ❌ 1064 | ✅ over-accept | ❌ reject |
| `INTO local_var` (routine body) | ✅ | ❌ 1064 | ✅ over-accept | ❌ reject |

All container-verified on `pingcap/tidb:v8.5.0`. `parseIntoClause` now keeps only the `kwOUTFILE` branch; everything else returns `syntaxErrorAtCur()`. `FETCH ... INTO` (cursor, parsed in `compound.go`) is unaffected.

## Tests

- Removed the DUMPFILE/var acceptance cases (kept OUTFILE), converted the `TABLE INTO DUMPFILE/@var` tests to `ParseExpectError`.
- Added `TestSelectIntoTiDBRejectsNonOutfile` — 8 container-verified reject forms (DUMPFILE + `@var` + local var, across SELECT/TABLE and clause positions).
- `go build ./tidb/...` and `go test -short ./tidb/...` pass.

## Review

An adversarial pre-PR review with two container-backed verifiers confirmed **no false-rejection**: all 11 TiDB-accepted `INTO OUTFILE` forms still parse, and every DUMPFILE/var form (incl. routine-body) is now rejected with sensible error positions.

## Known follow-up (pre-existing, out of scope)

TiDB also rejects `INTO OUTFILE` in **non-terminal positions** — before `FROM`, before `ORDER BY`, and before the locking clause; it accepts OUTFILE only as the statement's final clause. omni still over-accepts those positions (pre-existing; `parseIntoClause` is invoked at three grammar positions). This is a distinct over-acceptance from the INTO-target bug fixed here and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
