### PR TITLE
fix(pg/catalog): honor IF NOT EXISTS on ADD COLUMN

### DIFF
--- a/pg/catalog/alter.go
+++ b/pg/catalog/alter.go
@@ -336,7 +336,7 @@ func (c *Catalog) execAlterTableCmd(schema *Schema, rel *Relation, relName strin
 			return &Error{Code: CodeInvalidTableDefinition,
 				Message: "cannot recursively add identity column to table that has child tables"}
 		}
-		if err := c.atAddColumn(schema, rel, relName, colDef, recursing); err != nil {
+		if err := c.atAddColumn(schema, rel, relName, colDef, atc.Missing_ok, recursing); err != nil {
 			return err
 		}
 		// Analyze column default after column is added to the relation.
@@ -1100,13 +1100,17 @@ func (c *Catalog) renameAttribute(stmt *nodes.RenameStmt) error {
 	return c.atRenameColumn(rel, stmt.Subname, stmt.Newname)
 }
 
-func (c *Catalog) atAddColumn(schema *Schema, rel *Relation, relName string, colDef ColumnDef, recursing bool) error {
+func (c *Catalog) atAddColumn(schema *Schema, rel *Relation, relName string, colDef ColumnDef, missingOk, recursing bool) error {
 	// pg: src/backend/commands/tablecmds.c — ATExecAddColumn (MaxHeapAttributeNumber check)
 	if len(rel.Columns) >= MaxHeapAttributeNumber {
 		return &Error{Code: CodeTooManyColumns, Message: fmt.Sprintf("tables can have at most %d columns", MaxHeapAttributeNumber)}
 	}
 
 	if _, exists := rel.colByName[colDef.Name]; exists {
+		// ALTER TABLE ... ADD COLUMN IF NOT EXISTS: an already-present column is a no-op, not an error.
+		if missingOk {
+			return nil
+		}
 		return errDuplicateColumn(colDef.Name)
 	}
 

--- a/pg/catalog/alter_test.go
+++ b/pg/catalog/alter_test.go
@@ -19,10 +19,11 @@ func makeAlterTableStmt(schema, name string, cmds ...*nodes.AlterTableCmd) *node
 	}
 }
 
-func makeATAddColumn(cd ColumnDef) *nodes.AlterTableCmd {
+func makeATAddColumn(cd ColumnDef, ifNotExists bool) *nodes.AlterTableCmd {
 	return &nodes.AlterTableCmd{
-		Subtype: int(nodes.AT_AddColumn),
-		Def:     makeColumnDefNode(cd),
+		Subtype:    int(nodes.AT_AddColumn),
+		Def:        makeColumnDefNode(cd),
+		Missing_ok: ifNotExists,
 	}
 }
 
@@ -115,7 +116,7 @@ func TestAlterTableAddColumn(t *testing.T) {
 	c.DefineRelation(makeCreateTableStmt("", "t", []ColumnDef{{Name: "id", Type: TypeName{Name: "int4", TypeMod: -1}}}, nil, false), 'r')
 
 	err := c.AlterTableStmt(makeAlterTableStmt("", "t",
-		makeATAddColumn(ColumnDef{Name: "name", Type: TypeName{Name: "text", TypeMod: -1}}),
+		makeATAddColumn(ColumnDef{Name: "name", Type: TypeName{Name: "text", TypeMod: -1}}, false),
 	))
 	if err != nil {
 		t.Fatal(err)
@@ -141,9 +142,51 @@ func TestAlterTableAddColumnDuplicate(t *testing.T) {
 	c.DefineRelation(makeCreateTableStmt("", "t", []ColumnDef{{Name: "id", Type: TypeName{Name: "int4", TypeMod: -1}}}, nil, false), 'r')
 
 	err := c.AlterTableStmt(makeAlterTableStmt("", "t",
-		makeATAddColumn(ColumnDef{Name: "id", Type: TypeName{Name: "text", TypeMod: -1}}),
+		makeATAddColumn(ColumnDef{Name: "id", Type: TypeName{Name: "text", TypeMod: -1}}, false),
 	))
 	assertErrorCode(t, err, CodeDuplicateColumn)
+}
+
+func TestAlterTableAddColumnIfNotExistsOnExisting(t *testing.T) {
+	c := New()
+	c.DefineRelation(makeCreateTableStmt("", "t", []ColumnDef{{Name: "id", Type: TypeName{Name: "int4", TypeMod: -1}}}, nil, false), 'r')
+
+	// ADD COLUMN IF NOT EXISTS on a column that already exists must be a no-op, not an error.
+	err := c.AlterTableStmt(makeAlterTableStmt("", "t",
+		makeATAddColumn(ColumnDef{Name: "id", Type: TypeName{Name: "text", TypeMod: -1}}, true),
+	))
+	if err != nil {
+		t.Fatalf("ADD COLUMN IF NOT EXISTS on existing column should be a no-op, got: %v", err)
+	}
+
+	r := c.GetRelation("", "t")
+	if len(r.Columns) != 1 {
+		t.Fatalf("columns: got %d, want 1 (no-op must not add a duplicate)", len(r.Columns))
+	}
+	if r.Columns[0].TypeOID != INT4OID {
+		t.Errorf("existing column type: got %d, want INT4OID (original column must be unchanged)", r.Columns[0].TypeOID)
+	}
+}
+
+func TestAlterTableAddColumnIfNotExistsOnNew(t *testing.T) {
+	c := New()
+	c.DefineRelation(makeCreateTableStmt("", "t", []ColumnDef{{Name: "id", Type: TypeName{Name: "int4", TypeMod: -1}}}, nil, false), 'r')
+
+	// ADD COLUMN IF NOT EXISTS on a column that does not exist still adds it.
+	err := c.AlterTableStmt(makeAlterTableStmt("", "t",
+		makeATAddColumn(ColumnDef{Name: "name", Type: TypeName{Name: "text", TypeMod: -1}}, true),
+	))
+	if err != nil {
+		t.Fatalf("ADD COLUMN IF NOT EXISTS on new column should add it, got: %v", err)
+	}
+
+	r := c.GetRelation("", "t")
+	if len(r.Columns) != 2 {
+		t.Fatalf("columns: got %d, want 2 (new column should be added)", len(r.Columns))
+	}
+	if r.Columns[1].Name != "name" || r.Columns[1].TypeOID != TEXTOID {
+		t.Errorf("added column: got (%q, %d), want (name, TEXTOID)", r.Columns[1].Name, r.Columns[1].TypeOID)
+	}
 }
 
 func TestAlterTableDropColumn(t *testing.T) {
@@ -474,7 +517,7 @@ func TestAlterTablePassOrdering(t *testing.T) {
 	// Issue DROP COLUMN b and ADD COLUMN c in statement order.
 	// Pass ordering should execute DROP first (pass 0), then ADD (pass 2).
 	err := c.AlterTableStmt(makeAlterTableStmt("", "t",
-		makeATAddColumn(ColumnDef{Name: "c", Type: TypeName{Name: "int8", TypeMod: -1}}),
+		makeATAddColumn(ColumnDef{Name: "c", Type: TypeName{Name: "int8", TypeMod: -1}}, false),
 		makeATDropColumn("b", false, false),
 	))
 	if err != nil {

--- a/pg/catalog/round3_test.go
+++ b/pg/catalog/round3_test.go
@@ -1010,6 +1010,6 @@ func TestATAddColumnOverLimit(t *testing.T) {
 
 	// Try to add one more column — should fail.
 	err := c.AlterTableStmt(makeAlterTableStmt("", "big_t",
-		makeATAddColumn(ColumnDef{Name: "extra", Type: TypeName{Name: "int4", TypeMod: -1}})))
+		makeATAddColumn(ColumnDef{Name: "extra", Type: TypeName{Name: "int4", TypeMod: -1}}, false)))
 	assertErrorCode(t, err, CodeTooManyColumns)
 }

--- a/pg/catalog/round8_phase7_test.go
+++ b/pg/catalog/round8_phase7_test.go
@@ -201,7 +201,7 @@ func TestRecursiveAddColumn(t *testing.T) {
 
 	// ADD COLUMN on parent should propagate to child.
 	err := c.AlterTableStmt(makeAlterTableStmt("", "parent",
-		makeATAddColumn(ColumnDef{Name: "b", Type: TypeName{Name: "text", TypeMod: -1}}),
+		makeATAddColumn(ColumnDef{Name: "b", Type: TypeName{Name: "text", TypeMod: -1}}, false),
 	))
 	if err != nil {
 		t.Fatal(err)
@@ -318,7 +318,7 @@ func TestPassOrderDropBeforeAdd(t *testing.T) {
 	// ADD COLUMN 'c', then DROP COLUMN 'b' in statement order.
 	// Pass ordering: DROP (pass 0) before ADD (pass 3).
 	stmt := makeAlterTableStmt("", "t",
-		makeATAddColumn(ColumnDef{Name: "c", Type: TypeName{Name: "int8", TypeMod: -1}}),
+		makeATAddColumn(ColumnDef{Name: "c", Type: TypeName{Name: "int8", TypeMod: -1}}, false),
 		makeATDropColumn("b", false, false),
 	)
 	err := c.AlterTableStmt(stmt)


### PR DESCRIPTION
## What

`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` now no-ops when the target column already exists, instead of returning `errDuplicateColumn` (SQLSTATE 42701). The PG parser already populates `AlterTableCmd.Missing_ok` for the `IF NOT EXISTS` form; this threads that flag through `atAddColumn` and short-circuits the duplicate-column check. The `MaxHeapAttributeNumber` hard-limit check is unchanged.

## Why

Bytebase SQL review (the `BUILTIN_WALK_THROUGH_CHECK` rule) runs submitted DDL through this catalog as a simulation. Idempotent DDL such as `ADD COLUMN IF NOT EXISTS` was wrongly flagged as an error when the column already existed, even though the database treats it as a no-op. Linear BYT-9352 (parent SUP-185).

## Tests

- `TestAlterTableAddColumnIfNotExistsOnExisting` — IF NOT EXISTS on an existing column is a no-op (no error, no duplicate, original column unchanged).
- `TestAlterTableAddColumnIfNotExistsOnNew` — IF NOT EXISTS on a new column still adds it.
- `TestAlterTableAddColumnDuplicate` (existing) — without IF NOT EXISTS, a duplicate column still errors (regression guard).
- `go build/vet ./pg/...` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)