### PR TITLE
fix(pg/catalog): make ADD COLUMN IF NOT EXISTS a full no-op on existing column

### DIFF
--- a/pg/catalog/alter.go
+++ b/pg/catalog/alter.go
@@ -332,11 +332,19 @@ func (c *Catalog) execAlterTableCmd(schema *Schema, rel *Relation, relName strin
 		if err != nil {
 			return err
 		}
+		// ALTER TABLE ... ADD COLUMN IF NOT EXISTS on an already-present column is a
+		// complete no-op: skip identity validation, the column add, and all of the
+		// default/generated/inline-constraint processing below.
+		if atc.Missing_ok {
+			if _, exists := rel.colByName[colDef.Name]; exists {
+				return nil
+			}
+		}
 		if colDef.Identity != 0 && recurse && !recursing && rel.RelKind != 'p' && len(c.findChildRelations(rel.OID)) > 0 {
 			return &Error{Code: CodeInvalidTableDefinition,
 				Message: "cannot recursively add identity column to table that has child tables"}
 		}
-		if err := c.atAddColumn(schema, rel, relName, colDef, atc.Missing_ok, recursing); err != nil {
+		if err := c.atAddColumn(schema, rel, relName, colDef, recursing); err != nil {
 			return err
 		}
 		// Analyze column default after column is added to the relation.
@@ -1100,17 +1108,13 @@ func (c *Catalog) renameAttribute(stmt *nodes.RenameStmt) error {
 	return c.atRenameColumn(rel, stmt.Subname, stmt.Newname)
 }
 
-func (c *Catalog) atAddColumn(schema *Schema, rel *Relation, relName string, colDef ColumnDef, missingOk, recursing bool) error {
+func (c *Catalog) atAddColumn(schema *Schema, rel *Relation, relName string, colDef ColumnDef, recursing bool) error {
 	// pg: src/backend/commands/tablecmds.c — ATExecAddColumn (MaxHeapAttributeNumber check)
 	if len(rel.Columns) >= MaxHeapAttributeNumber {
 		return &Error{Code: CodeTooManyColumns, Message: fmt.Sprintf("tables can have at most %d columns", MaxHeapAttributeNumber)}
 	}
 
 	if _, exists := rel.colByName[colDef.Name]; exists {
-		// ALTER TABLE ... ADD COLUMN IF NOT EXISTS: an already-present column is a no-op, not an error.
-		if missingOk {
-			return nil
-		}
 		return errDuplicateColumn(colDef.Name)
 	}
 

--- a/pg/catalog/alter_test.go
+++ b/pg/catalog/alter_test.go
@@ -189,6 +189,31 @@ func TestAlterTableAddColumnIfNotExistsOnNew(t *testing.T) {
 	}
 }
 
+func TestAddColumnIfNotExistsExistingDoesNotCorruptLastColumn(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE TABLE t (id int, counter int)", nil); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// 'id' already exists, so ADD COLUMN IF NOT EXISTS is a no-op. The DEFAULT meant
+	// for the not-added column must not leak onto the table's last column ('counter').
+	results, err := c.Exec("ALTER TABLE t ADD COLUMN IF NOT EXISTS id int DEFAULT 99", nil)
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if len(results) != 1 || results[0].Error != nil {
+		t.Fatalf("ADD COLUMN IF NOT EXISTS on existing column should be a no-op, got %+v", results)
+	}
+
+	r := c.GetRelation("", "t")
+	if r == nil || len(r.Columns) != 2 {
+		t.Fatalf("want 2 columns intact, got %+v", r)
+	}
+	if last := r.Columns[1]; last.Name != "counter" || last.HasDefault || last.Default != "" {
+		t.Errorf("no-op must not mutate last column: name=%q HasDefault=%v Default=%q", last.Name, last.HasDefault, last.Default)
+	}
+}
+
 func TestAlterTableDropColumn(t *testing.T) {
 	c := New()
 	c.DefineRelation(makeCreateTableStmt("", "t", []ColumnDef{


### PR DESCRIPTION
## What

Makes `ALTER TABLE ... ADD COLUMN IF NOT EXISTS <existing_col> ...` a complete no-op. Previously (after #227) `atAddColumn` returned `nil` when the column already existed, but `execAlterTableCmd` kept going and ran the default / generated-expression / inline-constraint handling against `rel.Columns[len-1]` — the last column of the table, not the one named in the statement.

Effect: a valid no-op like `ADD COLUMN IF NOT EXISTS id int DEFAULT 0` on a table that already has `id` would push the default onto a different column, and if default analysis failed it would delete that column from the in-memory catalog, corrupting SQL-review metadata.

## Fix

Move the existence short-circuit to the call site, before identity validation, the column add, and all post-add processing. Revert `atAddColumn` to its prior signature so the caller owns the no-op decision.

## Tests

- `TestAddColumnIfNotExistsExistingDoesNotCorruptLastColumn` (new) — `ADD COLUMN IF NOT EXISTS id int DEFAULT 99` on a table that already has `id` leaves the last column untouched (no leaked default, not deleted).
- `TestAlterTableAddColumnIfNotExistsOnExisting` / `OnNew` (from #227) still pass.
- `TestAlterTableAddColumnDuplicate` — without `IF NOT EXISTS`, a duplicate column still errors.
- `go build/vet ./pg/...`, `gofmt` clean.

Addresses the Codex P1 raised on bytebase/bytebase#20520. Follow-up to #227. Linear BYT-9352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)