### PR TITLE
feat(googlesql/parser-dml): INSERT/UPDATE/DELETE/MERGE/TRUNCATE

### DIFF
--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -124,6 +124,26 @@ const (
 	T_AlterStmt
 	T_AlterAction
 	T_DropStmt
+
+	// DML — INSERT / UPDATE / DELETE / MERGE / TRUNCATE (parser-dml node).
+	//
+	// The data-manipulation family for the BigQuery + Spanner union, plus their
+	// structural sub-nodes (VALUES row, SET item, ON CONFLICT, MERGE WHEN/action,
+	// THEN RETURN). These mirror the legacy ANTLR DML grammar
+	// (GoogleSQLParser.g4 §2.7), a hand-port of ZetaSQL.
+	T_DefaultExpr
+	T_InsertStmt
+	T_InsertRow
+	T_InsertTable
+	T_OnConflict
+	T_UpdateStmt
+	T_UpdateItem
+	T_DeleteStmt
+	T_MergeStmt
+	T_MergeWhen
+	T_MergeAction
+	T_TruncateStmt
+	T_Returning
 )
 
 // String returns a human-readable representation of the tag.
@@ -285,6 +305,32 @@ func (t NodeTag) String() string {
 		return "AlterAction"
 	case T_DropStmt:
 		return "DropStmt"
+	case T_DefaultExpr:
+		return "DefaultExpr"
+	case T_InsertStmt:
+		return "InsertStmt"
+	case T_InsertRow:
+		return "InsertRow"
+	case T_InsertTable:
+		return "InsertTable"
+	case T_OnConflict:
+		return "OnConflict"
+	case T_UpdateStmt:
+		return "UpdateStmt"
+	case T_UpdateItem:
+		return "UpdateItem"
+	case T_DeleteStmt:
+		return "DeleteStmt"
+	case T_MergeStmt:
+		return "MergeStmt"
+	case T_MergeWhen:
+		return "MergeWhen"
+	case T_MergeAction:
+		return "MergeAction"
+	case T_TruncateStmt:
+		return "TruncateStmt"
+	case T_Returning:
+		return "Returning"
 	default:
 		return "Unknown"
 	}

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -2030,3 +2030,334 @@ var (
 	_ Node = (*AlterAction)(nil)
 	_ Node = (*DropStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// DML — INSERT / UPDATE / DELETE / MERGE / TRUNCATE (parser-dml node)
+// ---------------------------------------------------------------------------
+//
+// These node types model the legacy ANTLR DML family (GoogleSQLParser.g4 §2.7),
+// a hand-port of Google's open-source ZetaSQL reference and the grammar bytebase
+// consumes today. One omni parser serves the BigQuery + Spanner union; the
+// dialect deltas are FEATURE rejections layered on top of a shared grammar (the
+// grammar parses MERGE, ON CONFLICT, THEN RETURN, INSERT OR UPDATE/IGNORE for
+// both, and the engine rejects the unsupported ones at execution). The
+// authoritative accept/reject oracle is the canonical ZetaSQL corpus
+// (parser/googlesql/examples/.../dml_*.sql) plus the live Spanner emulator for
+// the shared + Spanner-only forms (BigQuery-only forms — MERGE, TRUNCATE,
+// dashed paths — are triangulated against the docs + the .g4; the emulator's
+// verdict on them is NON-authoritative; see the divergence ledger).
+//
+// The grammar is (abbreviated):
+//
+//	insert_statement: insert_statement_prefix column_list? insert_values_or_query           opt_assert? opt_returning?
+//	                | insert_statement_prefix column_list? insert_values_list_or_table_clause on_conflict opt_assert? opt_returning?
+//	                | insert_statement_prefix column_list? '(' query ')'                       on_conflict opt_assert? opt_returning?
+//	insert_statement_prefix: INSERT opt_or_ignore_replace_update? INTO? <target> hint?
+//	opt_or_ignore_replace_update: [OR] IGNORE | [OR] REPLACE | [OR] UPDATE
+//	update_statement: UPDATE <target> hint? as_alias? with_offset? SET update_item_list from_clause? where? assert? returning?
+//	delete_statement: DELETE FROM? <target> hint? as_alias? with_offset? where? assert? returning?
+//	merge_statement:  MERGE INTO? <target> as_alias? USING merge_source ON expr (merge_when_clause)+
+//	truncate_statement: TRUNCATE TABLE <path> where?
+//
+// <target> is maybe_dashed_generalized_path_expression — a dotted/dashed path
+// optionally extended by generalized accessors (`.field`, `.(extension)`,
+// `[index]`) for nested/array DML targets (oracle: `UPDATE t.a[0].b SET …`
+// parses; the nested-target rejection is semantic, not syntactic).
+
+// DefaultExpr is the `DEFAULT` keyword used where an expression is expected
+// (expression_or_default's DEFAULT alternative): a VALUES row element, an
+// update_set_value RHS, or a merge INSERT value. It carries no payload beyond
+// its source position — the engine fills the column default at execution.
+type DefaultExpr struct {
+	Loc Loc
+}
+
+// Tag implements Node.
+func (n *DefaultExpr) Tag() NodeTag { return T_DefaultExpr }
+
+// InsertStmt is an INSERT statement (insert_statement). Exactly one of
+// {Rows, Query, TableClause} carries the inserted data:
+//   - Rows:        a VALUES list — one InsertRow per parenthesized row.
+//   - Query:       an `INSERT … <query>` or `INSERT … ( query )` source (a
+//     *QueryStmt). The parenthesized form is recorded with Query set and
+//     QueryParens true (it is the on-conflict-eligible alternative).
+//   - TableClause: an `INSERT … TABLE <path-or-tvf> [WHERE …]` source
+//     (insert_values_list_or_table_clause's table_clause alt; on-conflict only).
+//
+// OrAction is the upsert modifier (opt_or_ignore_replace_update) — one of "",
+// "OR IGNORE", "IGNORE", "OR REPLACE", "REPLACE", "OR UPDATE", "UPDATE" (Spanner
+// upserts; the bare IGNORE/REPLACE/UPDATE forms drop the OR and the emulator
+// accepts them). Into records whether the optional INTO keyword was present.
+// Target is the table path (maybe_dashed_generalized_path_expression). Columns
+// is the optional explicit column_list (nil if absent). OnConflict is the
+// ON CONFLICT clause (only valid with the VALUES / TABLE / `( query )` forms;
+// nil otherwise). AssertRows is the ASSERT_ROWS_MODIFIED count expression (nil
+// if absent). Returning is the THEN RETURN clause (nil if absent).
+type InsertStmt struct {
+	OrAction    string       // "" | "OR IGNORE" | "IGNORE" | "OR REPLACE" | "REPLACE" | "OR UPDATE" | "UPDATE"
+	Into        bool         // INTO keyword present
+	Target      *PathExpr    // table path
+	Columns     []string     // explicit column list; nil if absent
+	Rows        []*InsertRow // VALUES rows; nil unless the VALUES form
+	Query       Node         // INSERT … SELECT / ( query ) source (*QueryStmt); nil unless the query form
+	QueryParens bool         // the query source was written as `( query )` (on-conflict-eligible)
+	TableClause *InsertTable // INSERT … TABLE source; nil unless the table-clause form
+	OnConflict  *OnConflict  // ON CONFLICT clause; nil if absent
+	AssertRows  Node         // ASSERT_ROWS_MODIFIED count; nil if absent
+	Returning   *Returning   // THEN RETURN clause; nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *InsertStmt) Tag() NodeTag { return T_InsertStmt }
+
+// InsertRow is one parenthesized row of an INSERT … VALUES list
+// (insert_values_row): a list of expression_or_default values (a DEFAULT value
+// is a *DefaultExpr element).
+type InsertRow struct {
+	Values []Node // expression_or_default elements (>= 1)
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *InsertRow) Tag() NodeTag { return T_InsertRow }
+
+// InsertTable is the `TABLE <path-or-tvf> [WHERE expr]` insert source
+// (table_clause_unreversed → table_clause_no_keyword). Path is the source table
+// path or TVF name; Func, when set, makes it a TVF call. Where is the optional
+// trailing WHERE filter. This form is on-conflict-only in the grammar.
+type InsertTable struct {
+	Path  *PathExpr // source table path / TVF name
+	Func  *FuncCall // table-valued function call; nil for a plain table
+	Where Node      // trailing WHERE expr; nil if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *InsertTable) Tag() NodeTag { return T_InsertTable }
+
+// OnConflict is an ON CONFLICT clause on an INSERT (on_conflict_clause):
+//
+//	ON CONFLICT [conflict_target] DO NOTHING
+//	ON CONFLICT [conflict_target] DO UPDATE SET update_item_list [WHERE expr]
+//
+// Target is the optional conflict target: either an explicit Columns list
+// (`( col, … )`) or a named unique constraint (ConstraintName, from
+// `ON UNIQUE CONSTRAINT id`). DoNothing selects the DO NOTHING action; when
+// false the action is DO UPDATE with SetItems (and optional Where). At most one
+// of Columns / ConstraintName is set; both empty means no conflict target.
+type OnConflict struct {
+	Columns        []string      // ON CONFLICT ( col, … ); nil if none / constraint form
+	ConstraintName string        // ON CONFLICT ON UNIQUE CONSTRAINT <id>; "" if none / columns form
+	DoNothing      bool          // DO NOTHING (true) vs DO UPDATE (false)
+	SetItems       []*UpdateItem // DO UPDATE SET items; nil for DO NOTHING
+	Where          Node          // DO UPDATE … WHERE expr; nil if absent
+	Loc            Loc
+}
+
+// Tag implements Node.
+func (n *OnConflict) Tag() NodeTag { return T_OnConflict }
+
+// UpdateStmt is an UPDATE statement (update_statement):
+//
+//	UPDATE <target> [hint] [[AS] alias] [WITH OFFSET [[AS] name]]
+//	  SET <update_item_list> [FROM <from>] [WHERE expr]
+//	  [ASSERT_ROWS_MODIFIED count] [THEN RETURN …]
+//
+// Target is the table path. Alias is the optional `[AS] alias` ("" if absent).
+// WithOffset / WithOffsetAlias record the Spanner `WITH OFFSET [[AS] name]`
+// companion column. Items is the non-empty SET list. From is the optional
+// join-update FROM source list (nil if absent). Where / AssertRows / Returning
+// mirror the other DML nodes. A leading statement `@{…}` hint and a per-target
+// `@{…}` hint are skipped (not retained) like elsewhere in the parser.
+type UpdateStmt struct {
+	Target          *PathExpr     // table path
+	Alias           string        // [AS] alias; "" if absent
+	WithOffset      bool          // WITH OFFSET
+	WithOffsetAlias string        // alias for WITH OFFSET; "" if absent / unaliased
+	Items           []*UpdateItem // SET items (>= 1)
+	From            []Node        // FROM sources (*TableExpr / *JoinExpr / *UnnestExpr); nil if absent
+	Where           Node          // WHERE expr; nil if absent
+	AssertRows      Node          // ASSERT_ROWS_MODIFIED count; nil if absent
+	Returning       *Returning    // THEN RETURN clause; nil if absent
+	Loc             Loc
+}
+
+// Tag implements Node.
+func (n *UpdateStmt) Tag() NodeTag { return T_UpdateStmt }
+
+// UpdateItem is one entry of a SET clause (update_item). Two shapes:
+//   - assignment:  `generalized_path = expression_or_default`. Path holds the
+//     LHS generalized path spelling (`a`, `a.b.c`, `id.(pkg.ext)`, `id[0]`);
+//     Value is the RHS (an expression or a *DefaultExpr). Nested is nil.
+//   - nested DML:  `( insert | update | delete )` — a nested statement run
+//     against an array-valued column (Spanner). Nested holds the inner DML
+//     node (*InsertStmt / *UpdateStmt / *DeleteStmt); Path is "" and Value nil.
+type UpdateItem struct {
+	Path   string // LHS generalized path; "" for the nested-DML form
+	Value  Node   // RHS expression or *DefaultExpr; nil for the nested-DML form
+	Nested Node   // nested ( dml ) statement; nil for the assignment form
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *UpdateItem) Tag() NodeTag { return T_UpdateItem }
+
+// DeleteStmt is a DELETE statement (delete_statement):
+//
+//	DELETE [FROM] <target> [hint] [[AS] alias] [WITH OFFSET [[AS] name]]
+//	  [WHERE expr] [ASSERT_ROWS_MODIFIED count] [THEN RETURN …]
+//
+// The FROM keyword is optional (ZetaSQL: `DELETE T WHERE …` parses). Target /
+// Alias / WithOffset / WithOffsetAlias / Where / AssertRows / Returning mirror
+// UpdateStmt. From records whether the optional FROM keyword was present (it has
+// no structural effect, but is retained for faithful round-trip).
+type DeleteStmt struct {
+	From            bool       // FROM keyword present
+	Target          *PathExpr  // table path
+	Alias           string     // [AS] alias; "" if absent
+	WithOffset      bool       // WITH OFFSET
+	WithOffsetAlias string     // alias for WITH OFFSET; "" if absent / unaliased
+	Where           Node       // WHERE expr; nil if absent
+	AssertRows      Node       // ASSERT_ROWS_MODIFIED count; nil if absent
+	Returning       *Returning // THEN RETURN clause; nil if absent
+	Loc             Loc
+}
+
+// Tag implements Node.
+func (n *DeleteStmt) Tag() NodeTag { return T_DeleteStmt }
+
+// MergeStmt is a MERGE statement (merge_statement):
+//
+//	MERGE [INTO] <target> [[AS] alias] USING <source> ON <expr> <when_clause>+
+//
+// Target is the merge target path; Alias the optional `[AS] alias`. Source is
+// the USING source (a *TableExpr — a table path or a `( query )` subquery, per
+// merge_source). On is the merge condition expression. Whens is the non-empty
+// list of WHEN clauses. MERGE is BigQuery-only among the bytebase consumers
+// (Spanner feature-rejects it after parse); the grammar — and therefore omni —
+// parses it for both. The emulator gives NO authoritative syntax verdict on
+// MERGE bodies (it rejects at statement dispatch), so MERGE forms are oracled
+// against the ZetaSQL corpus + the docs, not the emulator.
+type MergeStmt struct {
+	Target *PathExpr    // merge target path
+	Alias  string       // [AS] alias; "" if absent
+	Source Node         // USING source (*TableExpr: path or ( query ))
+	On     Node         // ON merge condition
+	Whens  []*MergeWhen // WHEN clauses (>= 1)
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *MergeStmt) Tag() NodeTag { return T_MergeStmt }
+
+// MergeWhen is one WHEN clause of a MERGE (merge_when_clause):
+//
+//	WHEN MATCHED [AND expr] THEN <action>
+//	WHEN NOT MATCHED [BY TARGET] [AND expr] THEN <action>
+//	WHEN NOT MATCHED BY SOURCE [AND expr] THEN <action>
+//
+// Matched is true for `WHEN MATCHED`; NotMatched true for `WHEN NOT MATCHED`
+// (exactly one holds). For the NOT MATCHED forms, BySource distinguishes
+// `BY SOURCE` from the default/`BY TARGET`; ByTarget records whether the
+// explicit `BY TARGET` words were present (default when neither). And is the
+// optional `AND search_condition` (nil if absent). Action is the THEN action.
+type MergeWhen struct {
+	Matched    bool         // WHEN MATCHED
+	NotMatched bool         // WHEN NOT MATCHED
+	ByTarget   bool         // explicit BY TARGET (NOT MATCHED only)
+	BySource   bool         // BY SOURCE (NOT MATCHED only)
+	And        Node         // AND search_condition; nil if absent
+	Action     *MergeAction // THEN action
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *MergeWhen) Tag() NodeTag { return T_MergeWhen }
+
+// MergeActionKind enumerates the THEN action of a MERGE WHEN clause.
+type MergeActionKind int
+
+const (
+	// MergeInsert is `INSERT [(cols)] (VALUES (row) | ROW)`.
+	MergeInsert MergeActionKind = iota
+	// MergeUpdate is `UPDATE SET update_item_list`.
+	MergeUpdate
+	// MergeDelete is `DELETE`.
+	MergeDelete
+)
+
+// MergeAction is the THEN action of a MERGE WHEN clause (merge_action):
+//
+//	INSERT [column_list] (VALUES insert_values_row | ROW)
+//	UPDATE SET update_item_list
+//	DELETE
+//
+// Kind selects the action. For MergeInsert: Columns is the optional column list;
+// InsertRow holds the VALUES row (nil when the bare `ROW` form was used), and
+// SourceRow is true for `ROW`. For MergeUpdate: SetItems is the SET list.
+// DELETE carries no payload.
+type MergeAction struct {
+	Kind      MergeActionKind
+	Columns   []string      // INSERT column list; nil if absent
+	InsertRow *InsertRow    // INSERT VALUES row; nil for `ROW` / non-insert
+	SourceRow bool          // INSERT ... ROW (source-row insert)
+	SetItems  []*UpdateItem // UPDATE SET items; nil for non-update
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *MergeAction) Tag() NodeTag { return T_MergeAction }
+
+// TruncateStmt is a TRUNCATE TABLE statement (truncate_statement):
+//
+//	TRUNCATE TABLE <path> [WHERE expr]
+//
+// Target is the table path (maybe_dashed_path_expression). Where is the optional
+// filter (ZetaSQL accepts `TRUNCATE TABLE foo WHERE bar > 3`). TRUNCATE is a
+// BigQuery DML statement; Spanner has no TRUNCATE (its DDL path syntax-rejects
+// it — non-authoritative), so TRUNCATE forms are oracled against the ZetaSQL
+// corpus + the BigQuery docs.
+type TruncateStmt struct {
+	Target *PathExpr // table path
+	Where  Node      // WHERE expr; nil if absent
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *TruncateStmt) Tag() NodeTag { return T_TruncateStmt }
+
+// Returning is a THEN RETURN clause on a DML statement (opt_returning_clause):
+//
+//	THEN RETURN [WITH ACTION [AS action_alias]] <select_list>
+//
+// WithAction records the `WITH ACTION` modifier (the returned action column);
+// ActionAlias is its optional `AS alias` ("" if absent / no WITH ACTION). Items
+// is the returned select_list (the same SelectItem shape as a SELECT list, so
+// `*`, `* EXCEPT (…)`, `expr AS x` are all supported).
+type Returning struct {
+	WithAction  bool          // WITH ACTION
+	ActionAlias string        // AS action_alias; "" if absent
+	Items       []*SelectItem // returned select list
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *Returning) Tag() NodeTag { return T_Returning }
+
+// Compile-time assertions that the DML node types satisfy Node.
+var (
+	_ Node = (*DefaultExpr)(nil)
+	_ Node = (*InsertStmt)(nil)
+	_ Node = (*InsertRow)(nil)
+	_ Node = (*InsertTable)(nil)
+	_ Node = (*OnConflict)(nil)
+	_ Node = (*UpdateStmt)(nil)
+	_ Node = (*UpdateItem)(nil)
+	_ Node = (*DeleteStmt)(nil)
+	_ Node = (*MergeStmt)(nil)
+	_ Node = (*MergeWhen)(nil)
+	_ Node = (*MergeAction)(nil)
+	_ Node = (*TruncateStmt)(nil)
+	_ Node = (*Returning)(nil)
+)

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -164,6 +164,15 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, c)
 		}
 		Walk(v, n.AsQuery)
+	case *DeleteStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		Walk(v, n.Where)
+		Walk(v, n.AssertRows)
+		if n.Returning != nil {
+			Walk(v, n.Returning)
+		}
 	case *DropStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -233,6 +242,34 @@ func walkChildren(v Visitor, node Node) {
 	case *IndexAccess:
 		Walk(v, n.Expr)
 		Walk(v, n.Index)
+	case *InsertRow:
+		walkNodes(v, n.Values)
+	case *InsertStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		for _, c := range n.Rows {
+			Walk(v, c)
+		}
+		Walk(v, n.Query)
+		if n.TableClause != nil {
+			Walk(v, n.TableClause)
+		}
+		if n.OnConflict != nil {
+			Walk(v, n.OnConflict)
+		}
+		Walk(v, n.AssertRows)
+		if n.Returning != nil {
+			Walk(v, n.Returning)
+		}
+	case *InsertTable:
+		if n.Path != nil {
+			Walk(v, n.Path)
+		}
+		if n.Func != nil {
+			Walk(v, n.Func)
+		}
+		Walk(v, n.Where)
 	case *InterleaveClause:
 		if n.Parent != nil {
 			Walk(v, n.Parent)
@@ -259,6 +296,27 @@ func walkChildren(v Visitor, node Node) {
 		walkNodes(v, n.QuantValues)
 		Walk(v, n.QuantUnnest)
 		Walk(v, n.QuantSubquery)
+	case *MergeAction:
+		if n.InsertRow != nil {
+			Walk(v, n.InsertRow)
+		}
+		for _, c := range n.SetItems {
+			Walk(v, c)
+		}
+	case *MergeStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		Walk(v, n.Source)
+		Walk(v, n.On)
+		for _, c := range n.Whens {
+			Walk(v, c)
+		}
+	case *MergeWhen:
+		Walk(v, n.And)
+		if n.Action != nil {
+			Walk(v, n.Action)
+		}
 	case *NamedArg:
 		Walk(v, n.Value)
 	case *NewConstructor:
@@ -271,6 +329,11 @@ func walkChildren(v Visitor, node Node) {
 		if n.Braced != nil {
 			Walk(v, n.Braced)
 		}
+	case *OnConflict:
+		for _, c := range n.SetItems {
+			Walk(v, c)
+		}
+		Walk(v, n.Where)
 	case *OptionsEntry:
 		Walk(v, n.Value)
 	case *OrderItem:
@@ -294,6 +357,10 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Max)
 	case *ReplaceFieldsExpr:
 		Walk(v, n.Expr)
+		for _, c := range n.Items {
+			Walk(v, c)
+		}
+	case *Returning:
 		for _, c := range n.Items {
 			Walk(v, c)
 		}
@@ -372,10 +439,31 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Func)
 		}
 		Walk(v, n.SystemTime)
+	case *TruncateStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		Walk(v, n.Where)
 	case *UnaryExpr:
 		Walk(v, n.Expr)
 	case *UnnestExpr:
 		Walk(v, n.Array)
+	case *UpdateItem:
+		Walk(v, n.Value)
+		Walk(v, n.Nested)
+	case *UpdateStmt:
+		if n.Target != nil {
+			Walk(v, n.Target)
+		}
+		for _, c := range n.Items {
+			Walk(v, c)
+		}
+		walkNodes(v, n.From)
+		Walk(v, n.Where)
+		Walk(v, n.AssertRows)
+		if n.Returning != nil {
+			Walk(v, n.Returning)
+		}
 	case *ViewColumn:
 		for _, c := range n.Options {
 			Walk(v, c)

--- a/googlesql/diagnostics/diagnostics_test.go
+++ b/googlesql/diagnostics/diagnostics_test.go
@@ -54,12 +54,13 @@ func TestSeverity_String(t *testing.T) {
 }
 
 func TestAnalyze_StubbedStatementShape(t *testing.T) {
-	// A statement whose body is still stubbed (INSERT — the DML node has not
+	// A statement whose body is still stubbed (CALL — its parser node has not
 	// landed) produces a "not yet supported" diagnostic. Assert the diagnostic
-	// shape. (The query family — SELECT/WITH — is now implemented by
-	// parser-select and produces zero diagnostics for valid input; see
+	// shape. (The query family — SELECT/WITH — is implemented by parser-select
+	// and the DML family — INSERT/UPDATE/DELETE/MERGE/TRUNCATE — by parser-dml;
+	// both produce zero diagnostics for valid input. See
 	// TestAnalyze_ValidQueryNoDiagnostics.)
-	diags := Analyze("INSERT INTO t VALUES (1)")
+	diags := Analyze("CALL my_proc()")
 	if len(diags) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
 	}
@@ -73,7 +74,7 @@ func TestAnalyze_StubbedStatementShape(t *testing.T) {
 	if !strings.Contains(d.Message, "not yet supported") {
 		t.Errorf("message = %q, want it to mention 'not yet supported'", d.Message)
 	}
-	// INSERT starts at byte 0 => line 1, col 1.
+	// CALL starts at byte 0 => line 1, col 1.
 	if d.Range.Start.Line != 1 || d.Range.Start.Column != 1 {
 		t.Errorf("start = (%d, %d), want (1, 1)", d.Range.Start.Line, d.Range.Start.Column)
 	}

--- a/googlesql/parser/delete.go
+++ b/googlesql/parser/delete.go
@@ -1,0 +1,88 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-dml` DAG node. It implements GoogleSQL's
+// DELETE statement (GoogleSQLParser.g4 §2.7 delete_statement), a hand-port of
+// Google's open-source ZetaSQL reference. Shared DML helpers (target path,
+// ASSERT_ROWS_MODIFIED, THEN RETURN, WITH OFFSET) live in insert.go / update.go.
+//
+// Grammar (delete_statement):
+//
+//	DELETE FROM? <target> hint? as_alias? opt_with_offset_and_alias?
+//	  opt_where_expression? opt_assert? opt_returning?
+//
+// The FROM keyword is OPTIONAL (ZetaSQL: `DELETE T WHERE …` parses, as does
+// `DELETE FROM T …`). <target> is maybe_dashed_generalized_path_expression.
+
+// parseDeleteStmt parses a DELETE statement. DELETE is the current token.
+func (p *Parser) parseDeleteStmt() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	p.advance() // DELETE
+
+	stmt := &ast.DeleteStmt{Loc: ast.Loc{Start: start}}
+
+	// Optional FROM.
+	if _, ok := p.match(kwFROM); ok {
+		stmt.From = true
+	}
+
+	// Target.
+	target, err := p.parseDMLTargetPath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Target = target
+
+	// Optional per-target `@{…}` hint.
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+
+	// Optional `[AS] alias`.
+	if alias, ok, err := p.tryParseTableAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		stmt.Alias = alias
+	}
+
+	// Optional `WITH OFFSET [[AS] name]`.
+	if err := p.parseWithOffsetAndAlias(&stmt.WithOffset, &stmt.WithOffsetAlias); err != nil {
+		return nil, err
+	}
+
+	// Optional WHERE.
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	// opt_assert_rows_modified.
+	if p.cur.Type == kwASSERT_ROWS_MODIFIED {
+		ar, err := p.parseAssertRowsModified()
+		if err != nil {
+			return nil, err
+		}
+		stmt.AssertRows = ar
+	}
+
+	// opt_returning_clause.
+	if p.cur.Type == kwTHEN {
+		ret, err := p.parseReturning()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Returning = ret
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/googlesql/parser/dml_oracle_test.go
+++ b/googlesql/parser/dml_oracle_test.go
@@ -1,0 +1,186 @@
+//go:build googlesql_oracle
+
+// Differential test for the `parser-dml` node against the live Cloud Spanner
+// emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestDMLDifferential
+//
+// It is a PROVE gate for googlesql/parser-dml (correctness-protocol.md): for
+// every fixture it (1) feeds the statement to the emulator via the
+// harness/googlesql-spanner CLI and reads the accept/reject verdict, then (2)
+// parses the same statement with omni's Parse, and asserts the two agree — BOTH
+// polarities (the corpus has accept AND reject cases). A harness `error` verdict
+// (oracle could not decide) fails the fixture loudly; it is never folded into
+// accept or reject. The harness plumbing (newSelectHarness / verdict / close) is
+// shared with select_oracle_test.go (same package).
+//
+// SCOPE OF THIS DIFFERENTIAL — Spanner is authoritative ONLY for forms its
+// grammar actually adjudicates. Every fixture below is one of:
+//   - SHARED GoogleSQL DML (INSERT/UPDATE/DELETE incl. VALUES/SELECT/DEFAULT/
+//     FROM-update/WITH OFFSET/THEN RETURN/ASSERT_ROWS_MODIFIED/ON CONFLICT) —
+//     the Spanner verdict is authoritative (the emulator parses then
+//     feature-rejects with "Table not found", which the harness classifies
+//     ACCEPT per its message-prefix rule).
+//   - Spanner-only upserts (INSERT OR IGNORE/UPDATE/REPLACE, bare IGNORE/REPLACE/
+//     UPDATE) — authoritative ACCEPT.
+//   - genuine SYNTAX rejects (truncated statements, trailing-comma SET list,
+//     ON CONFLICT after a bare query) — authoritative REJECT.
+//
+// EXCLUDED (NON-authoritative on Spanner — covered in dml_test.go + the
+// divergence ledger, NOT here, because the emulator's verdict would manufacture
+// a false divergence):
+//   - MERGE — the emulator rejects it at statement dispatch ("Statement not
+//     supported: MergeStmt") BEFORE parsing the body, so it accepts even a MERGE
+//     with zero/garbage WHEN clauses. No authoritative MERGE-syntax signal.
+//   - TRUNCATE TABLE — routed to Spanner's DDL path, which has no TRUNCATE and
+//     syntax-rejects it; BigQuery-only DML (truth1 BigQuery DML-003).
+//   - dashed table paths (`my-project.ds.tbl`) — Spanner syntax-rejects '-' in a
+//     table name (divergence #85); BigQuery-valid, omni accepts.
+//   - INSERT … TABLE <clause> … ON CONFLICT — the emulator rejects the
+//     on-conflict after a TABLE source; the .g4 (union) allows it.
+
+package parser
+
+import (
+	"os"
+	"testing"
+)
+
+// dmlFixture is one DML statement fed to BOTH the oracle and omni's Parse.
+// wantParse is the expected omni outcome and MUST equal the emulator's grammar
+// verdict.
+type dmlFixture struct {
+	sql       string
+	wantParse bool
+}
+
+var dmlFixtures = []dmlFixture{
+	// ===================== INSERT — accept (shared) =====================
+	{"INSERT INTO Singers (SingerId, FirstName) VALUES (1, 'Marc')", true},
+	{"INSERT Singers (SingerId, FirstName) VALUES (1, 'Marc')", true}, // no INTO
+	{"INSERT INTO Singers VALUES (1, 'Marc')", true},                  // no column list
+	{"INSERT INTO t (a) VALUES (1), (2), (3)", true},                  // multi-row
+	{"INSERT INTO t (a, b) VALUES (1, DEFAULT)", true},                // DEFAULT value
+	{"INSERT INTO t (a) SELECT x FROM s", true},                       // insert select
+	{"INSERT INTO s.t (a) VALUES (1)", true},                          // schema-qualified target
+	{"INSERT INTO t (a) (SELECT 1)", true},                            // ( query ) source
+	{"INSERT INTO t (a, b) (SELECT 5, 7) UNION ALL SELECT 8, 9", true},
+	{"INSERT INTO t (a) ((SELECT 1) UNION ALL (SELECT 2))", true},
+	{"INSERT INTO t VALUES ((1, 2), (SELECT 1))", true}, // struct + scalar subquery values
+	// A parenthesized query with a query-level trailing ORDER BY / LIMIT is a
+	// BARE query (alt-1), accepted WITHOUT ON CONFLICT.
+	{"INSERT INTO t (a) (SELECT 1) LIMIT 5", true},
+	{"INSERT INTO t (a) (SELECT 1) ORDER BY x", true},
+	{"INSERT INTO t (a) (SELECT 1) ORDER BY x LIMIT 5", true},
+
+	// ===================== INSERT — Spanner upserts (accept) ============
+	{"INSERT OR IGNORE INTO t (a) VALUES (1)", true},
+	{"INSERT OR UPDATE INTO t (a) VALUES (1)", true},
+	{"INSERT OR REPLACE INTO t (a) VALUES (1)", true},
+	{"INSERT IGNORE INTO t (a) VALUES (1)", true},  // bare IGNORE (no OR)
+	{"INSERT REPLACE INTO t (a) VALUES (1)", true}, // bare REPLACE
+	{"INSERT UPDATE INTO t (a) VALUES (1)", true},  // bare UPDATE
+
+	// ===================== INSERT — trailers (accept) ===================
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN a", true},
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN WITH ACTION a", true},
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN WITH ACTION AS act *", true},
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN a AS x, b", true},
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN * EXCEPT (a)", true},
+	{"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED 1", true},
+	{"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED @p", true},
+	{"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED CAST(1 AS INT64)", true},
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN WITH(x AS 1, x)", true}, // inline WITH expr item, NOT WITH ACTION
+	{"INSERT INTO t (graph) VALUES (1)", true},                         // non-reserved keyword column name
+
+	// ===================== INSERT — ON CONFLICT (accept) ================
+	{"INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING", true},
+	{"INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a = 2", true},
+	{"INSERT INTO t (a) VALUES (1) ON CONFLICT (a, b) DO NOTHING", true},
+	{"INSERT INTO t (a) VALUES (1) ON CONFLICT ON UNIQUE CONSTRAINT uc DO NOTHING", true},
+	{"INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a = 2 WHERE a > 1", true},
+	{"INSERT INTO t (a) (SELECT 1) ON CONFLICT DO NOTHING", true},
+
+	// ===================== UPDATE — accept (shared) =====================
+	{"UPDATE Singers SET FirstName = 'A' WHERE SingerId = 1", true},
+	{"UPDATE t a SET a.x = 1 WHERE a.id = 2", true},
+	{"UPDATE t AS a SET x = 1, y = 2 WHERE id = 3", true},
+	{"UPDATE t SET x = DEFAULT WHERE id = 1", true},
+	{"UPDATE t a SET x = b.y FROM s b WHERE a.id = b.id", true}, // join-update
+	{"UPDATE t SET x = 1", true},                                // no WHERE
+	{"UPDATE t SET x = 1 THEN RETURN x", true},
+	{"UPDATE t SET x = 1 WHERE id = 1 ASSERT_ROWS_MODIFIED 1", true},
+	{"UPDATE t SET arr[OFFSET(0)] = 5 WHERE id = 1", true},              // generalized LHS
+	{"UPDATE t SET (DELETE FROM t.arr WHERE x = 1) WHERE id = 1", true}, // nested DML item
+	{"UPDATE t SET x = (SELECT c FROM s) WHERE id = 1", true},           // embedded subquery (valid)
+
+	// ===================== DELETE — accept (shared) =====================
+	{"DELETE FROM Singers WHERE SingerId = 1", true},
+	{"DELETE Singers WHERE SingerId = 1", true}, // no FROM
+	{"DELETE FROM t", true},                     // no WHERE
+	{"DELETE Singers AS s WHERE s.SingerId = 1 THEN RETURN s.FirstName", true},
+	{"DELETE FROM t WHERE id = 1 THEN RETURN *", true},
+	{"DELETE FROM t WHERE id = 1 THEN RETURN * EXCEPT (a)", true},
+
+	// ===================== negatives — reject (authoritative) ===========
+	{"INSERT INTO", false},
+	{"INSERT t", false},
+	{"INSERT INTO t (a) VALUES", false},
+	{"INSERT INTO t (a) VALUES (1) THEN RETURN", false},
+	{"INSERT INTO t (a) SELECT 1 ON CONFLICT DO NOTHING", false},           // ON CONFLICT after bare query
+	{"INSERT INTO t (a) (SELECT 1) LIMIT 5 ON CONFLICT DO NOTHING", false}, // ON CONFLICT after a bare (parenthesized + LIMIT) query
+	{"UPDATE", false},
+	{"UPDATE t SET", false},
+	{"UPDATE t SET x = 1, WHERE id = 1", false}, // trailing comma in SET list
+	{"UPDATE t SET x = 1 FROM", false},
+	{"UPDATE t SET x = (SELECT 1 FROM s a b) WHERE id = 1", false}, // malformed embedded subquery (stray alias)
+	{"DELETE", false},
+	{"DELETE FROM t ASSERT_ROWS_MODIFIED 1 + 1", false},      // ASSERT operand is not an expression
+	{"DELETE FROM t ASSERT_ROWS_MODIFIED 'x'", false},        // ASSERT operand is not a string
+	{"DELETE FROM t ASSERT_ROWS_MODIFIED (SELECT 1)", false}, // ASSERT operand is not a subquery
+}
+
+func TestDMLDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live differential")
+	}
+	h := newSelectHarness(t)
+	defer h.close()
+
+	for _, fx := range dmlFixtures {
+		fx := fx
+		t.Run(fx.sql, func(t *testing.T) {
+			// 1. Oracle verdict.
+			v := h.verdict(t, fx.sql)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; fix the wrapper/emulator — do NOT treat as accept/reject",
+					fx.sql, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.sql)
+			}
+			oracleAccepts := v.Verdict == "accept"
+
+			// Sanity: the asserted wantParse must match the live oracle. A mismatch
+			// here means the fixture is mis-tagged (or the form is actually
+			// non-authoritative on Spanner and should be moved out of this set).
+			if oracleAccepts != fx.wantParse {
+				t.Fatalf("fixture wantParse=%v but oracle says %q (%s) for %q",
+					fx.wantParse, v.Verdict, v.Message, fx.sql)
+			}
+
+			// 2. omni Parse verdict.
+			_, errs := Parse(fx.sql)
+			omniAccepts := len(errs) == 0
+
+			if omniAccepts != oracleAccepts {
+				t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s)",
+					fx.sql, omniAccepts, oracleAccepts, v.Reason, v.Message)
+			}
+		})
+	}
+}

--- a/googlesql/parser/dml_test.go
+++ b/googlesql/parser/dml_test.go
@@ -1,0 +1,718 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Tests for the `parser-dml` node: INSERT / UPDATE / DELETE / MERGE / TRUNCATE.
+//
+// CORRECTNESS BASIS (correctness-protocol.md). The accept/reject verdicts are
+// proven two ways, both authoritative for the forms they cover:
+//   - the canonical ZetaSQL corpus (parser/googlesql/examples/.../dml_*.sql) —
+//     the legacy ANTLR grammar bytebase consumes is a hand-port of that ZetaSQL
+//     reference, so the corpus is the breadth oracle (TestDML_LegacyCorpusAccepts);
+//   - the live Cloud Spanner emulator — the differential is in dml_oracle_test.go
+//     (build tag `googlesql_oracle`), covering the SHARED + Spanner-only forms.
+//
+// BigQuery-only forms (MERGE, TRUNCATE, dashed table paths, the bare `INSERT …
+// SELECT … ON CONFLICT` reject) are NON-authoritative on the Spanner emulator
+// (MERGE: rejected at statement dispatch before body parse; TRUNCATE: Spanner
+// DDL has none; dashed paths: Spanner syntax-rejects '-'). They are covered here
+// against the ZetaSQL corpus + the BigQuery docs and recorded in the divergence
+// ledger — NOT diffed against the emulator (a Spanner reject there would be a
+// false divergence).
+
+// ---------------------------------------------------------------------------
+// INSERT — AST structure
+// ---------------------------------------------------------------------------
+
+func TestDML_Insert(t *testing.T) {
+	t.Run("values with columns", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO Singers (SingerId, FirstName) VALUES (1, 'Marc')")
+		if !ins.Into {
+			t.Error("Into = false, want true")
+		}
+		if got := pathString(ins.Target); got != "Singers" {
+			t.Errorf("Target = %q, want Singers", got)
+		}
+		if got := strings.Join(ins.Columns, ","); got != "SingerId,FirstName" {
+			t.Errorf("Columns = %q", got)
+		}
+		if len(ins.Rows) != 1 || len(ins.Rows[0].Values) != 2 {
+			t.Fatalf("Rows = %#v", ins.Rows)
+		}
+		if ins.OrAction != "" {
+			t.Errorf("OrAction = %q, want empty", ins.OrAction)
+		}
+	})
+
+	t.Run("no INTO, no columns", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT Singers VALUES (1, 'Marc')")
+		if ins.Into {
+			t.Error("Into = true, want false")
+		}
+		if ins.Columns != nil {
+			t.Errorf("Columns = %v, want nil", ins.Columns)
+		}
+	})
+
+	t.Run("multi-row values", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1), (2), (3)")
+		if len(ins.Rows) != 3 {
+			t.Fatalf("Rows = %d, want 3", len(ins.Rows))
+		}
+	})
+
+	t.Run("DEFAULT value", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a, b) VALUES (1, DEFAULT)")
+		row := ins.Rows[0]
+		if _, ok := row.Values[1].(*ast.DefaultExpr); !ok {
+			t.Errorf("Values[1] = %T, want *ast.DefaultExpr", row.Values[1])
+		}
+	})
+
+	t.Run("insert select", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) SELECT x FROM s")
+		if ins.Query == nil {
+			t.Fatal("Query = nil")
+		}
+		if _, ok := ins.Query.(*ast.QueryStmt); !ok {
+			t.Errorf("Query = %T, want *ast.QueryStmt", ins.Query)
+		}
+		if ins.Rows != nil {
+			t.Error("Rows should be nil for a query source")
+		}
+		if ins.QueryParens {
+			t.Error("QueryParens = true for a bare SELECT source")
+		}
+	})
+
+	t.Run("insert with leading WITH cte", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO T (c1) WITH q1 AS (SELECT 1) SELECT * FROM q1")
+		q := ins.Query.(*ast.QueryStmt)
+		if q.With == nil || len(q.With.CTEs) != 1 {
+			t.Errorf("expected one CTE, got %#v", q.With)
+		}
+	})
+
+	t.Run("parenthesized query source", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) (SELECT 1)")
+		if !ins.QueryParens {
+			t.Error("QueryParens = false, want true for ( query )")
+		}
+		if ins.OnConflict != nil {
+			t.Error("OnConflict should be nil")
+		}
+	})
+
+	t.Run("set-op bare query source", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a, b) (SELECT 5, 7) UNION ALL SELECT 8, 9")
+		if ins.QueryParens {
+			t.Error("QueryParens = true; a set-op bare query is NOT the ( query ) form")
+		}
+		q := ins.Query.(*ast.QueryStmt)
+		if _, ok := q.Body.(*ast.SetOperation); !ok {
+			t.Errorf("Query.Body = %T, want *ast.SetOperation", q.Body)
+		}
+	})
+
+	t.Run("parenthesized query with query-level tail is a bare query", func(t *testing.T) {
+		// `( query ) LIMIT n` is alt-1 (a bare query), NOT the ON-CONFLICT-eligible
+		// `( query )` form — so QueryParens stays false and the trailing LIMIT must
+		// be consumed (oracle: accepts; with a trailing ON CONFLICT it rejects).
+		for _, sql := range []string{
+			"INSERT INTO t (a) (SELECT 1) LIMIT 5",
+			"INSERT INTO t (a) (SELECT 1) ORDER BY x",
+			"INSERT INTO t (a) (SELECT 1) ORDER BY x LIMIT 5",
+		} {
+			ins := parseInsert(t, sql)
+			if ins.QueryParens {
+				t.Errorf("%q: QueryParens = true; a query with a trailing ORDER BY/LIMIT is a bare query", sql)
+			}
+		}
+	})
+}
+
+func TestDML_InsertOrAction(t *testing.T) {
+	cases := map[string]string{
+		"INSERT OR IGNORE INTO t (a) VALUES (1)":  "OR IGNORE",
+		"INSERT OR UPDATE INTO t (a) VALUES (1)":  "OR UPDATE",
+		"INSERT OR REPLACE INTO t (a) VALUES (1)": "OR REPLACE",
+		"INSERT IGNORE INTO t (a) VALUES (1)":     "IGNORE",
+		"INSERT REPLACE INTO t (a) VALUES (1)":    "REPLACE",
+		"INSERT UPDATE INTO t (a) VALUES (1)":     "UPDATE",
+	}
+	for sql, want := range cases {
+		t.Run(want, func(t *testing.T) {
+			ins := parseInsert(t, sql)
+			if ins.OrAction != want {
+				t.Errorf("OrAction = %q, want %q", ins.OrAction, want)
+			}
+		})
+	}
+}
+
+func TestDML_InsertOnConflict(t *testing.T) {
+	t.Run("do nothing", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING")
+		if ins.OnConflict == nil || !ins.OnConflict.DoNothing {
+			t.Fatalf("OnConflict = %#v", ins.OnConflict)
+		}
+	})
+	t.Run("target columns + do update set where", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a = a + excluded.a WHERE a > 1")
+		oc := ins.OnConflict
+		if oc == nil || oc.DoNothing {
+			t.Fatalf("OnConflict = %#v", oc)
+		}
+		if strings.Join(oc.Columns, ",") != "a" {
+			t.Errorf("Columns = %v", oc.Columns)
+		}
+		if len(oc.SetItems) != 1 {
+			t.Errorf("SetItems = %#v", oc.SetItems)
+		}
+		if oc.Where == nil {
+			t.Error("Where = nil")
+		}
+	})
+	t.Run("on unique constraint", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) ON CONFLICT ON UNIQUE CONSTRAINT uc DO NOTHING")
+		if ins.OnConflict.ConstraintName != "uc" {
+			t.Errorf("ConstraintName = %q, want uc", ins.OnConflict.ConstraintName)
+		}
+	})
+	t.Run("parenthesized query + on conflict", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) (SELECT 1) ON CONFLICT DO NOTHING")
+		if !ins.QueryParens || ins.OnConflict == nil {
+			t.Fatalf("QueryParens=%v OnConflict=%#v", ins.QueryParens, ins.OnConflict)
+		}
+	})
+}
+
+func TestDML_InsertTrailers(t *testing.T) {
+	t.Run("assert rows modified", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED 5")
+		if ins.AssertRows == nil {
+			t.Error("AssertRows = nil")
+		}
+	})
+	t.Run("then return", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) THEN RETURN a, b")
+		if ins.Returning == nil || len(ins.Returning.Items) != 2 {
+			t.Fatalf("Returning = %#v", ins.Returning)
+		}
+		if ins.Returning.WithAction {
+			t.Error("WithAction = true, want false")
+		}
+	})
+	t.Run("then return with action", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) THEN RETURN WITH ACTION AS act *")
+		r := ins.Returning
+		if r == nil || !r.WithAction || r.ActionAlias != "act" {
+			t.Fatalf("Returning = %#v", r)
+		}
+		if len(r.Items) != 1 || !r.Items[0].Star {
+			t.Errorf("Items = %#v, want a single star", r.Items)
+		}
+	})
+	t.Run("then return with inline WITH expr item", func(t *testing.T) {
+		// `THEN RETURN WITH(x AS 1, x)` is a select-list item that is an inline
+		// WITH(...) expression — NOT the WITH ACTION modifier. Regression for the
+		// over-eager WITH-ACTION branch (oracle: accepts).
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) THEN RETURN WITH(x AS 1, x)")
+		if ins.Returning == nil || ins.Returning.WithAction {
+			t.Fatalf("Returning = %#v; WITH(...) must NOT be read as WITH ACTION", ins.Returning)
+		}
+		if len(ins.Returning.Items) != 1 {
+			t.Errorf("Items = %d, want 1 (the WITH expression)", len(ins.Returning.Items))
+		}
+	})
+	t.Run("assert rows restricted operand", func(t *testing.T) {
+		// ASSERT_ROWS_MODIFIED takes only an int literal / parameter / @@var / CAST
+		// of one — NOT an arbitrary expression. Regression: these must reject
+		// (oracle-confirmed syntax rejects).
+		for _, sql := range []string{
+			"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED 1 + 1",
+			"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED 'x'",
+			"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED (SELECT 1)",
+		} {
+			if _, errs := Parse(sql); len(errs) == 0 {
+				t.Errorf("Parse(%q): expected a syntax error (operand is not int/param/CAST)", sql)
+			}
+		}
+		// The accepted operand forms.
+		for _, sql := range []string{
+			"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED 5",
+			"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED @p",
+			"INSERT INTO t (a) VALUES (1) ASSERT_ROWS_MODIFIED CAST(@p AS INT64)",
+		} {
+			parseInsert(t, sql)
+		}
+	})
+	t.Run("keyword column name", func(t *testing.T) {
+		// `graph` is a non-reserved keyword and a valid column name; the column-list
+		// vs query-source discriminator must not treat it as a query head.
+		ins := parseInsert(t, "INSERT INTO t (graph) VALUES (1)")
+		if len(ins.Columns) != 1 {
+			t.Errorf("Columns = %v, want one (graph)", ins.Columns)
+		}
+	})
+	t.Run("malformed embedded subquery rejected", func(t *testing.T) {
+		// A DML expression-embedded subquery is re-parsed (fillSubqueries), so a
+		// malformed one surfaces a diagnostic. Regression (oracle: rejects on `b`).
+		if _, errs := Parse("UPDATE t SET x = (SELECT 1 FROM s a b) WHERE id = 1"); len(errs) == 0 {
+			t.Error("expected a syntax error for the malformed embedded subquery")
+		}
+	})
+	t.Run("assert + returning together", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING ASSERT_ROWS_MODIFIED 1 THEN RETURN WITH ACTION AS ACTION a, b")
+		if ins.OnConflict == nil || ins.AssertRows == nil || ins.Returning == nil {
+			t.Fatalf("ins = %#v", ins)
+		}
+		if ins.Returning.ActionAlias != "ACTION" {
+			t.Errorf("ActionAlias = %q (ACTION is a valid non-reserved alias)", ins.Returning.ActionAlias)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// UPDATE — AST structure
+// ---------------------------------------------------------------------------
+
+func TestDML_Update(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		u := parseUpdate(t, "UPDATE Singers SET FirstName = 'A' WHERE SingerId = 1")
+		if pathString(u.Target) != "Singers" {
+			t.Errorf("Target = %q", pathString(u.Target))
+		}
+		if len(u.Items) != 1 {
+			t.Fatalf("Items = %d", len(u.Items))
+		}
+		if u.Items[0].Path != "FirstName" {
+			t.Errorf("Items[0].Path = %q", u.Items[0].Path)
+		}
+		if u.Where == nil {
+			t.Error("Where = nil")
+		}
+	})
+	t.Run("alias forms", func(t *testing.T) {
+		for _, sql := range []string{
+			"UPDATE t a SET a.x = 1 WHERE a.id = 2",
+			"UPDATE t AS a SET x = 1 WHERE id = 2",
+		} {
+			u := parseUpdate(t, sql)
+			if u.Alias != "a" {
+				t.Errorf("%q: Alias = %q, want a", sql, u.Alias)
+			}
+		}
+	})
+	t.Run("multiple set items + DEFAULT rhs", func(t *testing.T) {
+		u := parseUpdate(t, "UPDATE t SET x = 1, y = DEFAULT WHERE id = 1")
+		if len(u.Items) != 2 {
+			t.Fatalf("Items = %d", len(u.Items))
+		}
+		if _, ok := u.Items[1].Value.(*ast.DefaultExpr); !ok {
+			t.Errorf("Items[1].Value = %T, want *ast.DefaultExpr", u.Items[1].Value)
+		}
+	})
+	t.Run("from clause join-update", func(t *testing.T) {
+		u := parseUpdate(t, "UPDATE t a SET x = b.y FROM s b WHERE a.id = b.id")
+		if len(u.From) != 1 {
+			t.Fatalf("From = %#v", u.From)
+		}
+	})
+	t.Run("with offset alias", func(t *testing.T) {
+		// Non-keyword alias `o` — see the DELETE with-offset note (divergence #84).
+		u := parseUpdate(t, "UPDATE T WITH OFFSET AS o SET x = y")
+		if !u.WithOffset || u.WithOffsetAlias != "o" {
+			t.Errorf("WithOffset=%v alias=%q", u.WithOffset, u.WithOffsetAlias)
+		}
+	})
+	t.Run("nested DML set item", func(t *testing.T) {
+		u := parseUpdate(t, "UPDATE T SET (DELETE x), z = DEFAULT")
+		if len(u.Items) != 2 {
+			t.Fatalf("Items = %d", len(u.Items))
+		}
+		if _, ok := u.Items[0].Nested.(*ast.DeleteStmt); !ok {
+			t.Errorf("Items[0].Nested = %T, want *ast.DeleteStmt", u.Items[0].Nested)
+		}
+	})
+	t.Run("generalized lhs paths", func(t *testing.T) {
+		// These are the ZetaSQL update_set_value LHS forms.
+		for _, sql := range []string{
+			"UPDATE T SET id.(path.x.extension) = 5",
+			"UPDATE T SET id[0] = DEFAULT",
+			"UPDATE T SET id1.id2.(path.x.extension) = 5",
+			"UPDATE T SET id1[0].(a.b.c).id1.(d.e.f)[1].id3 = 5",
+			"UPDATE T SET id1[0][1] = 5",
+		} {
+			parseUpdate(t, sql)
+		}
+	})
+	t.Run("assert rows + then return", func(t *testing.T) {
+		u := parseUpdate(t, "UPDATE t SET x = 1 WHERE id = 1 ASSERT_ROWS_MODIFIED 1 THEN RETURN x")
+		if u.AssertRows == nil || u.Returning == nil {
+			t.Fatalf("u = %#v", u)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// DELETE — AST structure
+// ---------------------------------------------------------------------------
+
+func TestDML_Delete(t *testing.T) {
+	t.Run("with FROM", func(t *testing.T) {
+		d := parseDelete(t, "DELETE FROM Singers WHERE SingerId = 1")
+		if !d.From {
+			t.Error("From = false, want true")
+		}
+		if d.Where == nil {
+			t.Error("Where = nil")
+		}
+	})
+	t.Run("without FROM", func(t *testing.T) {
+		d := parseDelete(t, "DELETE Singers WHERE SingerId = 1")
+		if d.From {
+			t.Error("From = true, want false")
+		}
+	})
+	t.Run("bare delete, no where", func(t *testing.T) {
+		d := parseDelete(t, "DELETE T")
+		if d.From || d.Where != nil {
+			t.Errorf("d = %#v", d)
+		}
+	})
+	t.Run("alias + then return", func(t *testing.T) {
+		d := parseDelete(t, "DELETE Singers AS s WHERE s.SingerId = 1 THEN RETURN s.FirstName")
+		if d.Alias != "s" || d.Returning == nil {
+			t.Fatalf("d = %#v", d)
+		}
+	})
+	t.Run("with offset", func(t *testing.T) {
+		// Use a non-keyword alias `o`: the keyword-spelled `offset` alias is
+		// affected by the known identifierText case-folding gap (divergence #84,
+		// out of this node's scope), which would mask the WITH OFFSET assertion.
+		d := parseDelete(t, "DELETE T WITH OFFSET AS o WHERE true")
+		if !d.WithOffset || d.WithOffsetAlias != "o" {
+			t.Errorf("WithOffset=%v alias=%q", d.WithOffset, d.WithOffsetAlias)
+		}
+	})
+	t.Run("assert rows cast forms", func(t *testing.T) {
+		for _, sql := range []string{
+			"DELETE T ASSERT_ROWS_MODIFIED 10",
+			"DELETE T ASSERT_ROWS_MODIFIED CAST(@param1 AS int64)",
+			"DELETE T ASSERT_ROWS_MODIFIED CAST(@@sysvar AS int64)",
+			"DELETE T ASSERT_ROWS_MODIFIED @row_count",
+		} {
+			d := parseDelete(t, sql)
+			if d.AssertRows == nil {
+				t.Errorf("%q: AssertRows = nil", sql)
+			}
+		}
+	})
+	t.Run("generalized target", func(t *testing.T) {
+		parseDelete(t, "DELETE T.(a.b).c WHERE true")
+		parseDelete(t, "DELETE T.a[0].b WHERE true")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// MERGE — AST structure (BigQuery; ZetaSQL-corpus oracle)
+// ---------------------------------------------------------------------------
+
+func TestDML_Merge(t *testing.T) {
+	t.Run("matched update", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T USING S ON t1 = s1 WHEN MATCHED AND T.T1 = 5 THEN UPDATE SET T1 = T1 + 10, T2 = T.T1")
+		if pathString(m.Target) != "T" {
+			t.Errorf("Target = %q", pathString(m.Target))
+		}
+		if len(m.Whens) != 1 {
+			t.Fatalf("Whens = %d", len(m.Whens))
+		}
+		w := m.Whens[0]
+		if !w.Matched || w.And == nil {
+			t.Errorf("when = %#v", w)
+		}
+		if w.Action.Kind != ast.MergeUpdate || len(w.Action.SetItems) != 2 {
+			t.Errorf("action = %#v", w.Action)
+		}
+	})
+	t.Run("not matched by target insert", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T USING S ON t1 = s1 WHEN NOT MATCHED BY TARGET THEN INSERT (t1, t2) VALUES (10, S.C3)")
+		w := m.Whens[0]
+		if !w.NotMatched || !w.ByTarget {
+			t.Errorf("when = %#v", w)
+		}
+		if w.Action.Kind != ast.MergeInsert || len(w.Action.Columns) != 2 {
+			t.Errorf("action = %#v", w.Action)
+		}
+	})
+	t.Run("not matched by source delete", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T USING S ON t1 = s1 WHEN NOT MATCHED BY SOURCE THEN DELETE")
+		w := m.Whens[0]
+		if !w.NotMatched || !w.BySource || w.Action.Kind != ast.MergeDelete {
+			t.Errorf("when = %#v", w)
+		}
+	})
+	t.Run("not matched default (no BY)", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T USING S ON t1 = s1 WHEN NOT MATCHED THEN INSERT (t1) VALUES (1)")
+		w := m.Whens[0]
+		if !w.NotMatched || w.ByTarget || w.BySource {
+			t.Errorf("when = %#v (default NOT MATCHED is neither BY TARGET nor BY SOURCE)", w)
+		}
+	})
+	t.Run("insert ROW source", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T USING S ON t1 = s1 WHEN NOT MATCHED BY SOURCE THEN INSERT ROW")
+		a := m.Whens[0].Action
+		if a.Kind != ast.MergeInsert || !a.SourceRow || a.InsertRow != nil {
+			t.Errorf("action = %#v", a)
+		}
+	})
+	t.Run("subquery source + alias", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T AS X USING (SELECT * FROM Y JOIN Z ON Y.C1 = Z.C1) AS S ON X.t1 = S.s1 WHEN MATCHED THEN DELETE")
+		if m.Alias != "X" {
+			t.Errorf("Alias = %q, want X", m.Alias)
+		}
+		src, ok := m.Source.(*ast.TableExpr)
+		if !ok || src.Subquery == nil || src.Alias != "S" {
+			t.Errorf("Source = %#v", m.Source)
+		}
+	})
+	t.Run("multiple when clauses", func(t *testing.T) {
+		m := parseMerge(t, "MERGE INTO T USING S ON t1 = s1 "+
+			"WHEN MATCHED AND T.T1 = 5 THEN UPDATE SET T1 = T1 + 10 "+
+			"WHEN NOT MATCHED BY TARGET THEN INSERT (t1) VALUES (10) "+
+			"WHEN NOT MATCHED BY SOURCE THEN DELETE")
+		if len(m.Whens) != 3 {
+			t.Fatalf("Whens = %d, want 3", len(m.Whens))
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TRUNCATE — AST structure (BigQuery; ZetaSQL-corpus oracle)
+// ---------------------------------------------------------------------------
+
+func TestDML_Truncate(t *testing.T) {
+	t.Run("plain", func(t *testing.T) {
+		tr := parseTruncate(t, "TRUNCATE TABLE foo")
+		if pathString(tr.Target) != "foo" || tr.Where != nil {
+			t.Errorf("tr = %#v", tr)
+		}
+	})
+	t.Run("with where", func(t *testing.T) {
+		tr := parseTruncate(t, "TRUNCATE TABLE foo WHERE bar > 3")
+		if tr.Where == nil {
+			t.Error("Where = nil")
+		}
+	})
+	t.Run("qualified path", func(t *testing.T) {
+		// Use non-keyword path parts: `project`/`dataset` are non-reserved keywords
+		// affected by the identifierText case-folding gap (divergence #84).
+		tr := parseTruncate(t, "TRUNCATE TABLE myproj.ds.foo")
+		if pathString(tr.Target) != "myproj.ds.foo" {
+			t.Errorf("Target = %q", pathString(tr.Target))
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Dashed BigQuery paths (BigQuery-only; non-authoritative on Spanner — see ledger)
+// ---------------------------------------------------------------------------
+
+func TestDML_DashedPaths(t *testing.T) {
+	// Dashed table paths are BigQuery-valid (dashed_path_expression) and omni
+	// accepts them. The Spanner emulator syntax-rejects '-' in a table name, so
+	// these are covered here, not in the differential (divergence ledger #85).
+	t.Run("insert", func(t *testing.T) {
+		ins := parseInsert(t, "INSERT INTO my-project.ds.tbl (a) VALUES (1)")
+		if pathString(ins.Target) != "my-project.ds.tbl" {
+			t.Errorf("Target = %q", pathString(ins.Target))
+		}
+	})
+	t.Run("update", func(t *testing.T) {
+		u := parseUpdate(t, "UPDATE my-project.ds.tbl SET x = 1 WHERE id = 1")
+		if pathString(u.Target) != "my-project.ds.tbl" {
+			t.Errorf("Target = %q", pathString(u.Target))
+		}
+	})
+	t.Run("truncate", func(t *testing.T) {
+		parseTruncate(t, "TRUNCATE TABLE my-project.ds.tbl")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases — omni must reject (oracle-confirmed syntax rejects)
+// ---------------------------------------------------------------------------
+
+func TestDML_Rejects(t *testing.T) {
+	cases := []string{
+		// Truncated / incomplete.
+		"INSERT INTO",
+		"INSERT t",
+		"INSERT INTO t (a) VALUES",
+		"UPDATE",
+		"UPDATE t SET",
+		"DELETE",
+		"UPDATE t SET x = 1 FROM",
+		"INSERT INTO t (a) VALUES (1) THEN RETURN",
+		// Trailing comma in SET list (oracle: Expected "(" but got keyword WHERE).
+		"UPDATE t SET x = 1, WHERE id = 1",
+		// ON CONFLICT after a BARE query source is rejected (oracle: Expected end
+		// of input but got keyword ON) — only VALUES / TABLE / ( query ) allow it.
+		"INSERT INTO t (a) SELECT 1 ON CONFLICT DO NOTHING",
+		// A parenthesized query WITH a query-level tail (LIMIT) is a bare query, so
+		// a trailing ON CONFLICT is also rejected.
+		"INSERT INTO t (a) (SELECT 1) LIMIT 5 ON CONFLICT DO NOTHING",
+		// MERGE requires >= 1 WHEN clause (the .g4's (merge_when_clause)+).
+		"MERGE INTO t USING s ON t.a = s.a",
+		// MERGE missing USING / ON.
+		"MERGE INTO t",
+		"MERGE INTO t USING s ON",
+		// Slashed target is not a DML target.
+		"UPDATE /a/b SET x = 1 WHERE id = 1",
+		// TRUNCATE without TABLE keyword.
+		"TRUNCATE foo",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) == 0 {
+				t.Errorf("Parse(%q): expected a syntax error, got none", sql)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Breadth: the entire canonical ZetaSQL DML corpus must parse cleanly
+// ---------------------------------------------------------------------------
+
+// TestDML_LegacyCorpusAccepts parses every statement of the canonical ZetaSQL
+// DML corpus files and asserts each parses to a single DML node with no errors.
+// This is the breadth oracle for the node (correctness-protocol completeness
+// gate): the legacy grammar bytebase consumes is a hand-port of this ZetaSQL
+// reference, so full corpus parity is the bar. Skips if the legacy checkout is
+// absent (CI without it).
+func TestDML_LegacyCorpusAccepts(t *testing.T) {
+	dir := filepath.Join(legacyCorpusRoot, "zetasql", "parser", "testdata")
+	files := []string{
+		"dml_insert.sql",
+		"dml_update.sql",
+		"dml_delete.sql",
+		"dml_merge.sql",
+		"truncate.sql",
+		"dml_insert_on_conflict_clause.sql",
+	}
+	for _, name := range files {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Skipf("legacy corpus file %s not available: %v", path, err)
+		}
+		// The truncate.sql corpus mixes in SELECTs that USE `truncate` as an
+		// identifier; those are valid query statements, not DML. We only assert a
+		// clean parse to a single statement (no error), not the node kind, for
+		// that file.
+		assertDMLNode := name != "truncate.sql"
+		for i, raw := range splitStatements(string(data)) {
+			stmt := strings.TrimSpace(raw)
+			if stmt == "" {
+				continue
+			}
+			file, errs := Parse(stmt)
+			if len(errs) != 0 {
+				t.Errorf("%s[%d] parse failed:\n%s\nerrs=%v", name, i, stmt, errs)
+				continue
+			}
+			if len(file.Stmts) != 1 {
+				t.Errorf("%s[%d]: got %d stmts:\n%s", name, i, len(file.Stmts), stmt)
+				continue
+			}
+			if assertDMLNode && !isDMLNode(file.Stmts[0]) {
+				t.Errorf("%s[%d]: got %T, want a DML node:\n%s", name, i, file.Stmts[0], stmt)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func parseInsert(t *testing.T, sql string) *ast.InsertStmt {
+	t.Helper()
+	n := parseOneStmt(t, sql)
+	ins, ok := n.(*ast.InsertStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): got %T, want *ast.InsertStmt", sql, n)
+	}
+	return ins
+}
+
+func parseUpdate(t *testing.T, sql string) *ast.UpdateStmt {
+	t.Helper()
+	n := parseOneStmt(t, sql)
+	u, ok := n.(*ast.UpdateStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): got %T, want *ast.UpdateStmt", sql, n)
+	}
+	return u
+}
+
+func parseDelete(t *testing.T, sql string) *ast.DeleteStmt {
+	t.Helper()
+	n := parseOneStmt(t, sql)
+	d, ok := n.(*ast.DeleteStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): got %T, want *ast.DeleteStmt", sql, n)
+	}
+	return d
+}
+
+func parseMerge(t *testing.T, sql string) *ast.MergeStmt {
+	t.Helper()
+	n := parseOneStmt(t, sql)
+	m, ok := n.(*ast.MergeStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): got %T, want *ast.MergeStmt", sql, n)
+	}
+	return m
+}
+
+func parseTruncate(t *testing.T, sql string) *ast.TruncateStmt {
+	t.Helper()
+	n := parseOneStmt(t, sql)
+	tr, ok := n.(*ast.TruncateStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): got %T, want *ast.TruncateStmt", sql, n)
+	}
+	return tr
+}
+
+func pathString(p *ast.PathExpr) string {
+	if p == nil {
+		return ""
+	}
+	return strings.Join(p.Parts, ".")
+}
+
+func isDMLNode(n ast.Node) bool {
+	switch n.(type) {
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt, *ast.TruncateStmt:
+		return true
+	}
+	return false
+}
+
+// splitStatements splits a corpus file on top-level ';' (the corpus is
+// formatted so no ';' appears inside a statement except as a terminator).
+func splitStatements(src string) []string {
+	return strings.Split(src, ";")
+}

--- a/googlesql/parser/insert.go
+++ b/googlesql/parser/insert.go
@@ -1,0 +1,691 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-dml` DAG node. It implements GoogleSQL's
+// INSERT statement plus the DML helpers shared across INSERT / UPDATE / DELETE /
+// MERGE (target-path parsing, ASSERT_ROWS_MODIFIED, THEN RETURN, the SET
+// update_item_list, and expression_or_default). The grammar is a hand-port of
+// Google's open-source ZetaSQL reference (GoogleSQLParser.g4 §2.7); one omni
+// parser serves the BigQuery + Spanner union.
+//
+// INSERT grammar (insert_statement):
+//
+//	insert_statement_prefix column_list? insert_values_or_query            opt_assert? opt_returning?
+//	insert_statement_prefix column_list? insert_values_list_or_table_clause on_conflict opt_assert? opt_returning?
+//	insert_statement_prefix column_list? '(' query ')'                       on_conflict opt_assert? opt_returning?
+//	insert_statement_prefix: INSERT opt_or_ignore_replace_update? INTO? <target> hint?
+//	opt_or_ignore_replace_update: [OR] IGNORE | [OR] REPLACE | [OR] UPDATE
+//	insert_values_or_query: insert_values_list | query
+//	insert_values_list_or_table_clause: insert_values_list | TABLE table_clause_no_keyword
+//
+// The three alternatives collapse to a single unified parse here: after the
+// prefix + optional column list we read the data source (VALUES list, a query,
+// a `( query )`, or a TABLE clause), then the optional ON CONFLICT, then the
+// trailing opt_assert / opt_returning. ON CONFLICT is grammatically restricted
+// to the VALUES / TABLE / `( query )` sources (NOT a bare top-level query); we
+// enforce that mapping by where ON CONFLICT is allowed.
+
+// parseInsertStmt parses an INSERT statement. INSERT is the current token.
+func (p *Parser) parseInsertStmt() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	p.advance() // INSERT
+
+	stmt := &ast.InsertStmt{Loc: ast.Loc{Start: start}}
+
+	// opt_or_ignore_replace_update: [OR] IGNORE | [OR] REPLACE | [OR] UPDATE.
+	// The bare forms (no OR) are accepted by the grammar and the emulator.
+	stmt.OrAction = p.parseInsertOrAction()
+
+	// opt_into.
+	if _, ok := p.match(kwINTO); ok {
+		stmt.Into = true
+	}
+
+	// Target: maybe_dashed_generalized_path_expression.
+	target, err := p.parseDMLTargetPath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Target = target
+
+	// Per-target `@{…}` hint (insert_statement_prefix's trailing hint).
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+
+	// Optional explicit column_list. A '(' here opens either a column_list
+	// (`( col, … )`) or the parenthesized-query source (`( query )` / a nested
+	// `(( … ) UNION …)`). They are distinguished by the token after '(': a query
+	// source opens with SELECT / WITH / FROM / GRAPH or a further '(' (a
+	// parenthesized query primary), whereas a column list opens with a column
+	// name (an identifier). atQueryStart only peeks one token, so it misses the
+	// nested `((SELECT …))` case — handle the leading '(' explicitly here.
+	if p.cur.Type == int('(') && !p.insertSourceParenFollows() {
+		cols, err := p.parseColumnList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Columns = cols
+	}
+
+	// The data source: VALUES list | query | ( query ) | TABLE clause.
+	// onConflictAllowed tracks whether the source admits a trailing ON CONFLICT
+	// (the grammar's alternatives 2 and 3); a bare top-level query (alt 1's
+	// `query` that is NOT parenthesized) does NOT.
+	onConflictAllowed, err := p.parseInsertSource(stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	// on_conflict_clause (only after the VALUES / TABLE / ( query ) sources).
+	if p.cur.Type == kwON {
+		if !onConflictAllowed {
+			return nil, p.syntaxErrorAtCur()
+		}
+		oc, err := p.parseOnConflict()
+		if err != nil {
+			return nil, err
+		}
+		stmt.OnConflict = oc
+	}
+
+	// opt_assert_rows_modified.
+	if p.cur.Type == kwASSERT_ROWS_MODIFIED {
+		ar, err := p.parseAssertRowsModified()
+		if err != nil {
+			return nil, err
+		}
+		stmt.AssertRows = ar
+	}
+
+	// opt_returning_clause.
+	if p.cur.Type == kwTHEN {
+		ret, err := p.parseReturning()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Returning = ret
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseInsertOrAction parses opt_or_ignore_replace_update and returns the
+// canonical action spelling ("" when absent). All six forms are valid:
+//
+//	OR IGNORE | IGNORE | OR REPLACE | REPLACE | OR UPDATE | UPDATE
+func (p *Parser) parseInsertOrAction() string {
+	if p.cur.Type == kwOR {
+		// OR (IGNORE | REPLACE | UPDATE)
+		switch p.peekNext().Type {
+		case kwIGNORE:
+			p.advance()
+			p.advance()
+			return "OR IGNORE"
+		case kwREPLACE:
+			p.advance()
+			p.advance()
+			return "OR REPLACE"
+		case kwUPDATE:
+			p.advance()
+			p.advance()
+			return "OR UPDATE"
+		}
+		// `OR` not followed by IGNORE/REPLACE/UPDATE is not an or-action; leave it
+		// for the (failing) target parse to report.
+		return ""
+	}
+	// Bare IGNORE | REPLACE | UPDATE (no OR).
+	switch p.cur.Type {
+	case kwIGNORE:
+		p.advance()
+		return "IGNORE"
+	case kwREPLACE:
+		p.advance()
+		return "REPLACE"
+	case kwUPDATE:
+		p.advance()
+		return "UPDATE"
+	}
+	return ""
+}
+
+// insertSourceParenFollows reports whether the current '(' opens a parenthesized
+// query SOURCE rather than a column_list. The discriminator is the token right
+// after '(': a query source begins with the RESERVED query heads SELECT / WITH /
+// FROM, or a nested '(' (a parenthesized query primary, e.g.
+// `((SELECT 1) UNION ALL (SELECT 2))`); a column_list begins with a column-name
+// identifier. Only RESERVED keywords are query-source signals — a NON-reserved
+// keyword such as GRAPH is a valid column name (`INSERT INTO t (graph) …`), so it
+// must fall through to the column-list path. The current token must be '('.
+func (p *Parser) insertSourceParenFollows() bool {
+	switch p.peekNext().Type {
+	case kwSELECT, kwWITH, kwFROM, int('('):
+		return true
+	}
+	return false
+}
+
+// parseInsertSource reads the INSERT data source into stmt and reports whether a
+// trailing ON CONFLICT is grammatically allowed after it. The source is one of:
+//
+//	VALUES (row) [, (row)]…              -> stmt.Rows           (on-conflict OK)
+//	TABLE <path/tvf> [WHERE …]           -> stmt.TableClause    (on-conflict OK)
+//	( query )                            -> stmt.Query+Parens   (on-conflict OK)
+//	query                                -> stmt.Query          (on-conflict NOT allowed)
+func (p *Parser) parseInsertSource(stmt *ast.InsertStmt) (onConflictAllowed bool, err error) {
+	switch {
+	case p.cur.Type == kwVALUES:
+		rows, err := p.parseInsertValuesList()
+		if err != nil {
+			return false, err
+		}
+		stmt.Rows = rows
+		return true, nil
+
+	case p.cur.Type == kwTABLE:
+		tc, err := p.parseInsertTableClause()
+		if err != nil {
+			return false, err
+		}
+		stmt.TableClause = tc
+		return true, nil
+
+	case p.cur.Type == int('('):
+		// A '('-led source is grammatically ambiguous between:
+		//   alt-3  `( query )`                       — ON CONFLICT eligible
+		//   alt-1  query = ( primary ) <continuation> — a bare query, NOT eligible
+		// Both accept without ON CONFLICT (oracle); they differ only in whether a
+		// trailing ON CONFLICT is legal. The discriminator is whether ANY
+		// query-level continuation follows the closing ')': a set operation
+		// (UNION/INTERSECT/EXCEPT) OR a trailing ORDER BY / LIMIT / FOR UPDATE. If
+		// one does, the parens were a query_primary of a larger BARE query (alt-1,
+		// no ON CONFLICT); if nothing query-continuing follows, the parens wrap
+		// the whole source (alt-3, ON CONFLICT OK). This is exactly what the
+		// emulator enforces:
+		//   `(SELECT 1) ON CONFLICT …`            accepts (alt-3)
+		//   `(SELECT 1) LIMIT 5`                  accepts (alt-1, bare query)
+		//   `(SELECT 1) LIMIT 5 ON CONFLICT …`    REJECTS (alt-1 + ON CONFLICT)
+		//   `SELECT 1 ON CONFLICT …`              REJECTS (alt-1, unparenthesized)
+		openTok := p.advance() // '('
+		inner, err := p.parseQuery()
+		if err != nil {
+			return false, err
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return false, err
+		}
+		inner.Parens = true
+		inner.Loc = ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End}
+
+		// Continue a set-op chain, if any, treating the parenthesized query as the
+		// left primary. parseSetOpChain returns inner unchanged when no set op
+		// follows.
+		body, err := p.parseSetOpChain(inner)
+		if err != nil {
+			return false, err
+		}
+		setOpFollowed := body != ast.Node(inner)
+
+		// A query-level trailing ORDER BY / LIMIT / FOR UPDATE also marks the
+		// source as a bare query (alt-1), not a `( query )`. wrapSetOpQueryTail
+		// consumes them and reports whether any were present.
+		q, tailFollowed, err := p.wrapSetOpQueryTail(body)
+		if err != nil {
+			return false, err
+		}
+
+		if !setOpFollowed && !tailFollowed {
+			// Nothing query-continuing followed the ')': a true `( query )` source
+			// — ON CONFLICT eligible.
+			stmt.Query = inner
+			stmt.QueryParens = true
+			return true, nil
+		}
+		// A set op and/or a query-level tail followed: a bare query (alt-1). NOT
+		// ON CONFLICT eligible.
+		stmt.Query = q
+		return false, nil
+
+	default:
+		// A bare top-level query (SELECT / WITH). NOT on-conflict-eligible.
+		q, err := p.parseQuery()
+		if err != nil {
+			return false, err
+		}
+		stmt.Query = q
+		return false, nil
+	}
+}
+
+// wrapSetOpQueryTail wraps an already-parsed query body in a *QueryStmt and
+// consumes the query-level trailing ORDER BY / LIMIT[/OFFSET] / FOR UPDATE that
+// bind to the whole query (query_without_pipe_operators). It reports whether any
+// such tail was present (tailFollowed). Used for the INSERT alt-1
+// `( primary ) [UNION …] [ORDER BY …] [LIMIT …]` source, where the parenthesized
+// primary (and any set-op chain) was already pulled off before this call.
+//
+// body is always wrapped in a FRESH outer *QueryStmt — a parenthesized inner
+// query (`( SELECT 1 )`) becomes the Body of the outer query so an outer-level
+// ORDER BY / LIMIT stays distinct from any the inner query carried inside its
+// own parens (`( SELECT 1 ORDER BY x ) ORDER BY y` keeps both). The caller only
+// uses the returned QueryStmt on the bare-query (alt-1) path; on the alt-3
+// `( query )` path it returns the inner QueryStmt directly and ignores this.
+func (p *Parser) wrapSetOpQueryTail(body ast.Node) (q *ast.QueryStmt, tailFollowed bool, err error) {
+	q = &ast.QueryStmt{Body: body, Loc: ast.Loc{Start: qLoc(body).Start, End: qLoc(body).End}}
+	if p.cur.Type == kwORDER {
+		items, err := p.parseOrderByClause()
+		if err != nil {
+			return nil, false, err
+		}
+		q.OrderBy = items
+		q.Loc.End = p.prev.Loc.End
+		tailFollowed = true
+	}
+	if p.cur.Type == kwLIMIT {
+		if err := p.parseQueryLimitOffset(q); err != nil {
+			return nil, false, err
+		}
+		tailFollowed = true
+	}
+	if p.cur.Type == kwFOR && p.peekNext().Type == kwUPDATE {
+		p.advance()           // FOR
+		updTok := p.advance() // UPDATE
+		q.ForUpdate = true
+		q.Loc.End = updTok.Loc.End
+		tailFollowed = true
+	}
+	return q, tailFollowed, nil
+}
+
+// parseInsertValuesList parses insert_values_list:
+// `VALUES insert_values_row (, insert_values_row)*`. VALUES is the current token.
+func (p *Parser) parseInsertValuesList() ([]*ast.InsertRow, error) {
+	p.advance() // VALUES
+	var rows []*ast.InsertRow
+	for {
+		row, err := p.parseInsertValuesRow()
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	return rows, nil
+}
+
+// parseInsertValuesRow parses insert_values_row: a parenthesized
+// expression_or_default list `( e_or_d (, e_or_d)* )`. The current token is '('.
+func (p *Parser) parseInsertValuesRow() (*ast.InsertRow, error) {
+	openTok, err := p.expect(int('('))
+	if err != nil {
+		return nil, err
+	}
+	row := &ast.InsertRow{Loc: openTok.Loc}
+	for {
+		val, err := p.parseExprOrDefault()
+		if err != nil {
+			return nil, err
+		}
+		row.Values = append(row.Values, val)
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	row.Loc.End = closeTok.Loc.End
+	return row, nil
+}
+
+// parseInsertTableClause parses table_clause_unreversed → table_clause_no_keyword:
+// `TABLE (path | tvf) [WHERE expr]`. TABLE is the current token.
+func (p *Parser) parseInsertTableClause() (*ast.InsertTable, error) {
+	tableTok := p.advance() // TABLE
+	tc := &ast.InsertTable{Loc: tableTok.Loc}
+
+	path, err := p.parsePathExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type == int('(') {
+		// path ( args ) — a tvf_with_suffixes table source.
+		fc, err := p.parseFuncCallSuffix(path)
+		if err != nil {
+			return nil, err
+		}
+		tc.Func = fc.(*ast.FuncCall)
+	} else {
+		tc.Path = path
+	}
+	tc.Loc.End = p.prev.Loc.End
+
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		tc.Where = where
+		tc.Loc.End = nodeLoc(where).End
+	}
+	return tc, nil
+}
+
+// parseOnConflict parses on_conflict_clause:
+//
+//	ON CONFLICT [conflict_target] DO NOTHING
+//	ON CONFLICT [conflict_target] DO UPDATE SET update_item_list [WHERE expr]
+//
+// conflict_target: column_list | ON UNIQUE CONSTRAINT identifier
+//
+// ON is the current token.
+func (p *Parser) parseOnConflict() (*ast.OnConflict, error) {
+	onTok := p.advance() // ON
+	if _, err := p.expect(kwCONFLICT); err != nil {
+		return nil, err
+	}
+	oc := &ast.OnConflict{Loc: onTok.Loc}
+
+	// opt_conflict_target: column_list | ON UNIQUE CONSTRAINT identifier.
+	switch {
+	case p.cur.Type == int('('):
+		cols, err := p.parseColumnList()
+		if err != nil {
+			return nil, err
+		}
+		oc.Columns = cols
+	case p.cur.Type == kwON:
+		p.advance() // ON
+		if _, err := p.expect(kwUNIQUE); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwCONSTRAINT); err != nil {
+			return nil, err
+		}
+		nameTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		oc.ConstraintName = name
+	}
+
+	if _, err := p.expect(kwDO); err != nil {
+		return nil, err
+	}
+	switch p.cur.Type {
+	case kwNOTHING:
+		p.advance()
+		oc.DoNothing = true
+	case kwUPDATE:
+		p.advance() // UPDATE
+		if _, err := p.expect(kwSET); err != nil {
+			return nil, err
+		}
+		items, err := p.parseUpdateItemList()
+		if err != nil {
+			return nil, err
+		}
+		oc.SetItems = items
+		if p.cur.Type == kwWHERE {
+			p.advance() // WHERE
+			where, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			oc.Where = where
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	oc.Loc.End = p.prev.Loc.End
+	return oc, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared DML helpers
+// ---------------------------------------------------------------------------
+
+// parseDMLTargetPath parses maybe_dashed_generalized_path_expression — the
+// DML target path used by INSERT / UPDATE / DELETE. It is a dotted, optionally
+// dashed (BigQuery `my-project.ds.tbl`) path, optionally extended by generalized
+// accessors: `.field`, `.(extension)`, `[index]` (for nested / array DML
+// targets, e.g. `UPDATE t.a[0].b SET …`). The base dotted/dashed path is held in
+// the returned PathExpr.Parts; trailing generalized accessors are consumed (they
+// fold into the path's source span) so the target round-trips and its base table
+// name is recoverable for query-span resolution.
+func (p *Parser) parseDMLTargetPath() (*ast.PathExpr, error) {
+	// Base dotted/dashed path (reuses the FROM-source path parser, which folds
+	// dashed `a-b-c` and dotted `a.b.c` components — the dashed BigQuery form is
+	// a target-valid path per the .g4's dashed_path_expression alternative).
+	path, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	// Trailing generalized accessors (generalized_path_expression's recursive
+	// `.field` / `.(ext)` / `[index]`). These extend a nested/array target; the
+	// base table name stays in path.Parts[0..]. parseTablePath already folded the
+	// leading dotted/dashed run, so this loop only runs once a generalized
+	// accessor (`[…]` or `.(…)`) has interrupted that run — after which a further
+	// `.field` must be consumed here too (the run does not resume in
+	// parseTablePath). We fold each accessor into path.Parts so the full target
+	// span and base name round-trip for query-span resolution.
+	for {
+		switch {
+		case p.cur.Type == int('.') && p.peekNext().Type == int('('):
+			// `.(extension)` — generalized_extension_path.
+			p.advance() // '.'
+			p.advance() // '('
+			ext, err := p.parsePathExpr()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(int(')')); err != nil {
+				return nil, err
+			}
+			path.Parts = append(path.Parts, "("+ext.String()+")")
+			path.Loc.End = p.prev.Loc.End
+		case p.cur.Type == int('.') && isAnyKeywordIdentifier(p.peekNext().Type):
+			// `.field` — a plain name part following a generalized accessor.
+			p.advance() // '.'
+			partTok := p.advance()
+			part, err := p.identifierText(partTok)
+			if err != nil {
+				return nil, err
+			}
+			path.Parts = append(path.Parts, part)
+			path.Loc.End = partTok.Loc.End
+		case p.cur.Type == int('['):
+			// `[index]` — array-element access on the target.
+			p.advance() // '['
+			if _, err := p.parseExpr(); err != nil {
+				return nil, err
+			}
+			closeTok, err := p.expect(int(']'))
+			if err != nil {
+				return nil, err
+			}
+			path.Parts = append(path.Parts, "[...]")
+			path.Loc.End = closeTok.Loc.End
+		default:
+			return path, nil
+		}
+	}
+}
+
+// parseExprOrDefault parses expression_or_default: an expression or the bare
+// DEFAULT keyword. DEFAULT yields a *DefaultExpr marker.
+func (p *Parser) parseExprOrDefault() (ast.Node, error) {
+	if p.cur.Type == kwDEFAULT {
+		tok := p.advance()
+		return &ast.DefaultExpr{Loc: tok.Loc}, nil
+	}
+	return p.parseExpr()
+}
+
+// parseAssertRowsModified parses opt_assert_rows_modified:
+// `ASSERT_ROWS_MODIFIED possibly_cast_int_literal_or_parameter`. The operand is
+// NARROW — an integer literal, a query parameter (`@p` / `?`), a system variable
+// (`@@v`), or a `CAST(... AS type)` of one — NOT an arbitrary expression. Using
+// the full expression grammar here would wrongly accept `ASSERT_ROWS_MODIFIED
+// 1 + 1`, a string, or a subquery (oracle: all three syntax-reject).
+// ASSERT_ROWS_MODIFIED is the current token.
+func (p *Parser) parseAssertRowsModified() (ast.Node, error) {
+	p.advance() // ASSERT_ROWS_MODIFIED
+	return p.parseIntLiteralOrParameterOrCast()
+}
+
+// parseIntLiteralOrParameterOrCast parses possibly_cast_int_literal_or_parameter:
+//
+//	integer_literal | parameter_expression | system_variable_expression
+//	| CAST ( int_literal_or_parameter AS type [FORMAT …] )
+//
+// It accepts the restricted operand set the grammar allows for
+// ASSERT_ROWS_MODIFIED / TABLESAMPLE counts, rejecting general expressions. The
+// CAST arm reuses parseCastExpr (whose inner is a full expression — a CAST of a
+// non-literal like `CAST(1+1 AS INT64)` is a rare over-accept relative to the
+// grammar's int_literal_or_parameter inner, but every documented/corpus form
+// casts a literal or parameter; the load-bearing fix is rejecting a bare
+// non-literal operand, which this does).
+func (p *Parser) parseIntLiteralOrParameterOrCast() (ast.Node, error) {
+	switch p.cur.Type {
+	case tokInteger:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitInt, Value: tok.Str, Loc: tok.Loc}, nil
+	case int('@'):
+		return p.parseNamedParameter()
+	case tokAtAt:
+		return p.parseSystemVariable()
+	case int('?'):
+		tok := p.advance()
+		return &ast.Parameter{Positional: true, Loc: tok.Loc}, nil
+	case kwCAST:
+		return p.parseCastExpr(false)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseReturning parses opt_returning_clause:
+//
+//	THEN RETURN [WITH ACTION [AS action_alias]] select_list
+//
+// THEN is the current token.
+func (p *Parser) parseReturning() (*ast.Returning, error) {
+	thenTok := p.advance() // THEN
+	if _, err := p.expect(kwRETURN); err != nil {
+		return nil, err
+	}
+	ret := &ast.Returning{Loc: thenTok.Loc}
+
+	// `WITH ACTION [AS id]` is the action modifier. It must be distinguished from
+	// a select_list item that is an inline WITH(...) expression (`THEN RETURN
+	// WITH(x AS 1, x)`): only `WITH ACTION` (WITH followed by the ACTION keyword)
+	// is the modifier; `WITH (` is a select-list expression, left for
+	// parseSelectList (oracle: `THEN RETURN WITH(x AS 1, x)` accepts).
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwACTION {
+		p.advance() // WITH
+		p.advance() // ACTION
+		ret.WithAction = true
+		if p.cur.Type == kwAS {
+			p.advance() // AS
+			aliasTok, err := p.expectIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			alias, err := p.identifierText(aliasTok)
+			if err != nil {
+				return nil, err
+			}
+			ret.ActionAlias = alias
+		}
+	}
+
+	items, err := p.parseSelectList()
+	if err != nil {
+		return nil, err
+	}
+	ret.Items = items
+	ret.Loc.End = p.prev.Loc.End
+	return ret, nil
+}
+
+// parseUpdateItemList parses update_item_list: `update_item (, update_item)*`.
+// The current token begins the first item.
+func (p *Parser) parseUpdateItemList() ([]*ast.UpdateItem, error) {
+	var items []*ast.UpdateItem
+	for {
+		item, err := p.parseUpdateItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+	}
+	return items, nil
+}
+
+// parseUpdateItem parses update_item: a `generalized_path = expression_or_default`
+// assignment OR a nested_dml_statement `( insert | update | delete )`.
+func (p *Parser) parseUpdateItem() (*ast.UpdateItem, error) {
+	start := p.cur.Loc
+	// nested_dml_statement: ( dml_statement ).
+	if p.cur.Type == int('(') {
+		p.advance() // '('
+		nested, err := p.parseNestedDML()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		return &ast.UpdateItem{Nested: nested, Loc: ast.Loc{Start: start.Start, End: p.prev.Loc.End}}, nil
+	}
+
+	// update_set_value: generalized_path_expression = expression_or_default.
+	lhs, err := p.parseGeneralizedPath()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return nil, err
+	}
+	rhs, err := p.parseExprOrDefault()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.UpdateItem{Path: lhs, Value: rhs, Loc: ast.Loc{Start: start.Start, End: p.prev.Loc.End}}, nil
+}
+
+// parseNestedDML parses the body of a nested_dml_statement (the inner
+// insert/update/delete of an `( dml )` update item). The current token is the
+// inner statement's leading keyword.
+func (p *Parser) parseNestedDML() (ast.Node, error) {
+	switch p.cur.Type {
+	case kwINSERT:
+		return p.parseInsertStmt()
+	case kwUPDATE:
+		return p.parseUpdateStmt()
+	case kwDELETE:
+		return p.parseDeleteStmt()
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}

--- a/googlesql/parser/merge.go
+++ b/googlesql/parser/merge.go
@@ -1,0 +1,242 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-dml` DAG node. It implements GoogleSQL's
+// MERGE statement (GoogleSQLParser.g4 §2.7 merge_statement), a hand-port of
+// Google's open-source ZetaSQL reference. Shared DML helpers (column list,
+// update_item_list, insert_values_row) live in insert.go.
+//
+// Grammar (merge_statement):
+//
+//	MERGE INTO? <target> as_alias? USING merge_source ON expression (merge_when_clause)+
+//	merge_source: table_path_expression | table_subquery
+//	merge_when_clause:
+//	    WHEN MATCHED [AND expr] THEN merge_action
+//	  | WHEN NOT MATCHED [BY TARGET] [AND expr] THEN merge_action
+//	  | WHEN NOT MATCHED BY SOURCE [AND expr] THEN merge_action
+//	merge_action:
+//	    INSERT column_list? (VALUES insert_values_row | ROW)
+//	  | UPDATE SET update_item_list
+//	  | DELETE
+//
+// MERGE is BigQuery-only among the bytebase consumers: Spanner feature-rejects
+// it AFTER parse (the emulator answers "Statement not supported: MergeStmt" at
+// statement dispatch, BEFORE validating the body — so the emulator gives NO
+// authoritative syntax verdict on MERGE bodies). MERGE forms are therefore
+// oracled against the canonical ZetaSQL corpus (dml_merge.sql) + the BigQuery
+// docs, NOT the emulator (divergence ledger: MERGE non-authoritative on Spanner;
+// the grammar requires (merge_when_clause)+ but the emulator accepts a MERGE
+// with zero WHEN clauses — we follow the .g4 and require >= 1).
+
+// parseMergeStmt parses a MERGE statement. MERGE is the current token.
+func (p *Parser) parseMergeStmt() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	p.advance() // MERGE
+
+	stmt := &ast.MergeStmt{Loc: ast.Loc{Start: start}}
+
+	// opt_into.
+	p.match(kwINTO)
+
+	// Target (maybe_dashed_path_expression — a table name).
+	target, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Target = target
+
+	// Optional `[AS] alias`. USING (a reserved keyword) terminates the target, so
+	// a bare identifier before USING is the implicit alias.
+	if alias, ok, err := p.tryParseTableAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		stmt.Alias = alias
+	}
+
+	// USING merge_source.
+	if _, err := p.expect(kwUSING); err != nil {
+		return nil, err
+	}
+	source, err := p.parseMergeSource()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Source = source
+
+	// ON expression.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	on, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.On = on
+
+	// (merge_when_clause)+ — at least one is required.
+	for p.cur.Type == kwWHEN {
+		when, err := p.parseMergeWhen()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Whens = append(stmt.Whens, when)
+	}
+	if len(stmt.Whens) == 0 {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseMergeSource parses merge_source: `table_path_expression | table_subquery`.
+// A leading '(' is a parenthesized subquery; otherwise it is a table path
+// (optionally aliased). The result is a *TableExpr (Path or Subquery set).
+func (p *Parser) parseMergeSource() (ast.Node, error) {
+	if p.cur.Type == int('(') {
+		openTok := p.advance() // '('
+		query, err := p.parseQuery()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		te := &ast.TableExpr{Subquery: query, Loc: ast.Loc{Start: openTok.Loc.Start, End: closeTok.Loc.End}}
+		// table_subquery takes an optional `[AS] alias`.
+		if err := p.parseTableAliasOnly(te); err != nil {
+			return nil, err
+		}
+		return te, nil
+	}
+
+	// table_path_expression: a table path with an optional `[AS] alias`.
+	path, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	te := &ast.TableExpr{Path: path, Loc: path.Loc}
+	if alias, ok, err := p.tryParseTableAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		te.Alias = alias
+		te.Loc.End = p.prev.Loc.End
+	}
+	return te, nil
+}
+
+// parseMergeWhen parses one merge_when_clause. WHEN is the current token.
+func (p *Parser) parseMergeWhen() (*ast.MergeWhen, error) {
+	whenTok := p.advance() // WHEN
+	when := &ast.MergeWhen{Loc: whenTok.Loc}
+
+	if _, ok := p.match(kwNOT); ok {
+		// WHEN NOT MATCHED [BY TARGET | BY SOURCE] [AND expr] THEN …
+		if _, err := p.expect(kwMATCHED); err != nil {
+			return nil, err
+		}
+		when.NotMatched = true
+		if p.cur.Type == kwBY {
+			p.advance() // BY
+			switch p.cur.Type {
+			case kwTARGET:
+				p.advance()
+				when.ByTarget = true
+			case kwSOURCE:
+				p.advance()
+				when.BySource = true
+			default:
+				return nil, p.syntaxErrorAtCur()
+			}
+		}
+	} else {
+		// WHEN MATCHED [AND expr] THEN …
+		if _, err := p.expect(kwMATCHED); err != nil {
+			return nil, err
+		}
+		when.Matched = true
+	}
+
+	// opt_and_expression: AND expr.
+	if _, ok := p.match(kwAND); ok {
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		when.And = cond
+	}
+
+	if _, err := p.expect(kwTHEN); err != nil {
+		return nil, err
+	}
+	action, err := p.parseMergeAction()
+	if err != nil {
+		return nil, err
+	}
+	when.Action = action
+	when.Loc.End = p.prev.Loc.End
+	return when, nil
+}
+
+// parseMergeAction parses merge_action:
+//
+//	INSERT column_list? (VALUES insert_values_row | ROW)
+//	UPDATE SET update_item_list
+//	DELETE
+//
+// The current token is the action keyword (INSERT / UPDATE / DELETE).
+func (p *Parser) parseMergeAction() (*ast.MergeAction, error) {
+	start := p.cur.Loc
+	switch p.cur.Type {
+	case kwINSERT:
+		p.advance() // INSERT
+		act := &ast.MergeAction{Kind: ast.MergeInsert, Loc: start}
+		// Optional column_list.
+		if p.cur.Type == int('(') {
+			cols, err := p.parseColumnList()
+			if err != nil {
+				return nil, err
+			}
+			act.Columns = cols
+		}
+		// merge_insert_value_list_or_source_row: VALUES insert_values_row | ROW.
+		switch p.cur.Type {
+		case kwVALUES:
+			p.advance() // VALUES
+			row, err := p.parseInsertValuesRow()
+			if err != nil {
+				return nil, err
+			}
+			act.InsertRow = row
+		case kwROW:
+			p.advance() // ROW
+			act.SourceRow = true
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+		act.Loc.End = p.prev.Loc.End
+		return act, nil
+
+	case kwUPDATE:
+		p.advance() // UPDATE
+		if _, err := p.expect(kwSET); err != nil {
+			return nil, err
+		}
+		items, err := p.parseUpdateItemList()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.MergeAction{Kind: ast.MergeUpdate, SetItems: items, Loc: ast.Loc{Start: start.Start, End: p.prev.Loc.End}}, nil
+
+	case kwDELETE:
+		delTok := p.advance() // DELETE
+		return &ast.MergeAction{Kind: ast.MergeDelete, Loc: delTok.Loc}, nil
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}

--- a/googlesql/parser/parser.go
+++ b/googlesql/parser/parser.go
@@ -358,7 +358,8 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwUNDROP:
 		return p.unsupported("UNDROP")
 	case kwTRUNCATE:
-		return p.unsupported("TRUNCATE")
+		// TRUNCATE TABLE (a BigQuery DML statement; the .g4 groups it under DDL).
+		return p.parseDMLStatement(p.parseTruncateStmt)
 	case kwDEFINE:
 		// DEFINE TABLE (DEFINE MACRO is intentionally unimplemented — a
 		// reserved error alt in the legacy grammar).
@@ -366,13 +367,13 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// --- DML ---
 	case kwINSERT:
-		return p.unsupported("INSERT")
+		return p.parseDMLStatement(p.parseInsertStmt)
 	case kwUPDATE:
-		return p.unsupported("UPDATE")
+		return p.parseDMLStatement(p.parseUpdateStmt)
 	case kwDELETE:
-		return p.unsupported("DELETE")
+		return p.parseDMLStatement(p.parseDeleteStmt)
 	case kwMERGE:
-		return p.unsupported("MERGE")
+		return p.parseDMLStatement(p.parseMergeStmt)
 
 	// --- DCL ---
 	case kwGRANT:
@@ -489,6 +490,25 @@ func (p *Parser) parseQueryStatement() (ast.Node, error) {
 	}
 	p.fillSubqueries(q)
 	return q, nil
+}
+
+// parseDMLStatement runs a DML parse function and then fills every
+// expression-embedded subquery the way parseQueryStatement does. DML statements
+// carry expressions (VALUES rows, SET / merge-action values, WHERE / ON / merge
+// conditions, ASSERT_ROWS_MODIFIED, THEN RETURN items) that may contain
+// SubqueryExpr / ExistsExpr / ArraySubqueryExpr captured as RawText with
+// Query==nil by the frozen expressions node. fillSubqueries re-parses each into
+// a real *QueryStmt — which both (a) completes the tree for the downstream
+// query-span / lineage extractor and (b) surfaces a malformed embedded subquery
+// (e.g. `UPDATE t SET x = (SELECT 1 FROM s a b)`, which the oracle rejects on
+// the stray `b`) as a diagnostic, matching the query-statement path.
+func (p *Parser) parseDMLStatement(parse func() (ast.Node, error)) (ast.Node, error) {
+	n, err := parse()
+	if err != nil {
+		return nil, err
+	}
+	p.fillSubqueries(n)
+	return n, nil
 }
 
 // fillSubqueries walks node and re-parses the RawText of every SubqueryExpr /

--- a/googlesql/parser/parser_test.go
+++ b/googlesql/parser/parser_test.go
@@ -46,28 +46,29 @@ func TestParse_UnknownStatement(t *testing.T) {
 
 // TestParse_KnownStatementUnsupported verifies a statement whose leading
 // keyword IS in the dispatch switch but whose body is still stubbed yields a
-// "not yet supported" diagnostic rather than an "unknown statement" one. INSERT
-// is used because the DML node has not landed yet; the query family (SELECT /
-// WITH) is now implemented by the parser-select node and no longer stubbed.
+// "not yet supported" diagnostic rather than an "unknown statement" one. CALL is
+// used because it is still stubbed; the query family (SELECT / WITH,
+// parser-select) and the DML family (INSERT/UPDATE/DELETE/MERGE/TRUNCATE,
+// parser-dml) are now implemented and no longer stubbed.
 func TestParse_KnownStatementUnsupported(t *testing.T) {
-	_, errs := Parse("INSERT INTO t VALUES (1)")
+	_, errs := Parse("CALL my_proc()")
 	if len(errs) != 1 {
-		t.Fatalf("Parse(\"INSERT ...\"): got %d errors, want 1: %v", len(errs), errs)
+		t.Fatalf("Parse(\"CALL ...\"): got %d errors, want 1: %v", len(errs), errs)
 	}
 	if !strings.Contains(errs[0].Msg, "not yet supported") {
 		t.Errorf("error = %q, want 'not yet supported'", errs[0].Msg)
 	}
-	if !strings.HasPrefix(errs[0].Msg, "INSERT ") {
-		t.Errorf("error = %q, want it to name the INSERT statement", errs[0].Msg)
+	if !strings.HasPrefix(errs[0].Msg, "CALL ") {
+		t.Errorf("error = %q, want it to name the CALL statement", errs[0].Msg)
 	}
 }
 
 // TestParse_MultiStatementErrorsCollected verifies ParseBestEffort collects
 // errors from every segment, not just the first. The leading `SELECT 1` now
-// parses cleanly (parser-select), so only the two stubbed DML segments
-// contribute errors.
+// parses cleanly (parser-select) and the INSERT now parses cleanly
+// (parser-dml), so only the two still-stubbed CALL segments contribute errors.
 func TestParse_MultiStatementErrorsCollected(t *testing.T) {
-	res := ParseBestEffort("SELECT 1; INSERT INTO t VALUES (1); UPDATE t SET x=1")
+	res := ParseBestEffort("SELECT 1; INSERT INTO t VALUES (1); CALL a(); CALL b()")
 	if got := len(res.Errors); got != 2 {
 		t.Fatalf("ParseBestEffort: got %d errors, want 2: %v", got, res.Errors)
 	}
@@ -311,18 +312,18 @@ func TestParse_StatementLevelHintSkipped(t *testing.T) {
 	}
 }
 
-// TestParse_QueryStatementsParse documents that the parser-select node flips the
-// foundation's "all bodies stubbed" invariant for the query family: a valid
-// SELECT now parses to a real AST node, while a still-stubbed DML segment
-// (INSERT) yields its "not yet supported" diagnostic. (Pre-parser-select this
-// test asserted File.Stmts stayed empty for SELECT.)
+// TestParse_QueryStatementsParse documents that the parser-select and parser-dml
+// nodes flip the foundation's "all bodies stubbed" invariant: a valid SELECT and
+// a valid INSERT both now parse to real AST nodes, while a still-stubbed segment
+// (CALL) yields its "not yet supported" diagnostic. (Pre-parser-select this test
+// asserted File.Stmts stayed empty for SELECT.)
 func TestParse_QueryStatementsParse(t *testing.T) {
-	file, errs := Parse("SELECT 1; INSERT INTO t VALUES (1)")
-	if len(file.Stmts) != 1 {
-		t.Errorf("File.Stmts = %d, want 1 (the SELECT parses; INSERT is still stubbed)", len(file.Stmts))
+	file, errs := Parse("SELECT 1; INSERT INTO t VALUES (1); CALL p()")
+	if len(file.Stmts) != 2 {
+		t.Errorf("File.Stmts = %d, want 2 (SELECT + INSERT parse; CALL is still stubbed)", len(file.Stmts))
 	}
 	if len(errs) != 1 {
-		t.Errorf("errors = %d, want 1 (the stubbed INSERT): %v", len(errs), errs)
+		t.Errorf("errors = %d, want 1 (the stubbed CALL): %v", len(errs), errs)
 	}
 }
 

--- a/googlesql/parser/truncate.go
+++ b/googlesql/parser/truncate.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-dml` DAG node. It implements GoogleSQL's
+// TRUNCATE TABLE statement (GoogleSQLParser.g4 §2.3 truncate_statement), a
+// hand-port of Google's open-source ZetaSQL reference.
+//
+// Grammar (truncate_statement):
+//
+//	TRUNCATE TABLE maybe_dashed_path_expression opt_where_expression?
+//
+// TRUNCATE is a BigQuery DML statement (truth1 BigQuery DML-003). Spanner has no
+// TRUNCATE — its DDL path syntax-rejects it (oracle: "Error parsing Spanner DDL
+// statement: … Encountered 'TRUNCATE'"), which is NON-authoritative for the
+// BigQuery + Spanner union. TRUNCATE forms are therefore oracled against the
+// canonical ZetaSQL corpus (truncate.sql) + the BigQuery docs (divergence
+// ledger: TRUNCATE non-authoritative on Spanner). The grammar accepts an
+// optional trailing WHERE (`TRUNCATE TABLE foo WHERE bar > 3`).
+
+// parseTruncateStmt parses a TRUNCATE TABLE statement. TRUNCATE is the current
+// token.
+func (p *Parser) parseTruncateStmt() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	p.advance() // TRUNCATE
+
+	if _, err := p.expect(kwTABLE); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.TruncateStmt{Loc: ast.Loc{Start: start}}
+
+	// maybe_dashed_path_expression — a (possibly dashed) table path.
+	target, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Target = target
+	stmt.Loc.End = target.Loc.End
+
+	// opt_where_expression.
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+		stmt.Loc.End = nodeLoc(where).End
+	}
+
+	return stmt, nil
+}

--- a/googlesql/parser/update.go
+++ b/googlesql/parser/update.go
@@ -1,0 +1,122 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-dml` DAG node. It implements GoogleSQL's
+// UPDATE statement (GoogleSQLParser.g4 §2.7 update_statement), a hand-port of
+// Google's open-source ZetaSQL reference. Shared DML helpers (target path,
+// update_item_list, ASSERT_ROWS_MODIFIED, THEN RETURN) live in insert.go.
+//
+// Grammar (update_statement):
+//
+//	UPDATE <target> hint? as_alias? opt_with_offset_and_alias?
+//	  SET update_item_list from_clause? opt_where_expression? opt_assert? opt_returning?
+//
+// <target> is maybe_dashed_generalized_path_expression; opt_with_offset_and_alias
+// is `WITH OFFSET [[AS] name]`; the SET list is non-empty. The FROM clause is the
+// join-update source list (`UPDATE T SET x = S.y FROM S WHERE …`).
+
+// parseUpdateStmt parses an UPDATE statement. UPDATE is the current token.
+func (p *Parser) parseUpdateStmt() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	p.advance() // UPDATE
+
+	stmt := &ast.UpdateStmt{Loc: ast.Loc{Start: start}}
+
+	// Target.
+	target, err := p.parseDMLTargetPath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Target = target
+
+	// Optional per-target `@{…}` hint.
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+
+	// Optional `[AS] alias`. SET (a reserved keyword) terminates the target, so a
+	// bare identifier before SET is the implicit alias.
+	if alias, ok, err := p.tryParseTableAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		stmt.Alias = alias
+	}
+
+	// Optional `WITH OFFSET [[AS] name]`.
+	if err := p.parseWithOffsetAndAlias(&stmt.WithOffset, &stmt.WithOffsetAlias); err != nil {
+		return nil, err
+	}
+
+	// SET update_item_list.
+	if _, err := p.expect(kwSET); err != nil {
+		return nil, err
+	}
+	items, err := p.parseUpdateItemList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Items = items
+
+	// Optional FROM clause (join-update source list).
+	if p.cur.Type == kwFROM {
+		from, err := p.parseFromClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = from
+	}
+
+	// Optional WHERE.
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = where
+	}
+
+	// opt_assert_rows_modified.
+	if p.cur.Type == kwASSERT_ROWS_MODIFIED {
+		ar, err := p.parseAssertRowsModified()
+		if err != nil {
+			return nil, err
+		}
+		stmt.AssertRows = ar
+	}
+
+	// opt_returning_clause.
+	if p.cur.Type == kwTHEN {
+		ret, err := p.parseReturning()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Returning = ret
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseWithOffsetAndAlias parses opt_with_offset_and_alias:
+// `WITH OFFSET [[AS] name]`. It sets *have to true and fills *alias when the
+// clause is present, and is a no-op otherwise. Used by UPDATE and DELETE.
+func (p *Parser) parseWithOffsetAndAlias(have *bool, alias *string) error {
+	if !(p.cur.Type == kwWITH && p.peekNext().Type == kwOFFSET) {
+		return nil
+	}
+	p.advance() // WITH
+	p.advance() // OFFSET
+	*have = true
+	if a, ok, err := p.tryParseTableAlias(); err != nil {
+		return err
+	} else if ok {
+		*alias = a
+	}
+	return nil
+}


### PR DESCRIPTION
## googlesql/parser-dml — INSERT / UPDATE / DELETE / MERGE / TRUNCATE

Implements the DML statement family for the omni `googlesql` engine. One omni parser serves the **BigQuery + Spanner union**; the grammar is a hand-port of Google's open-source ZetaSQL reference (`GoogleSQLParser.g4` §2.7), the same lineage as the legacy ANTLR grammar bytebase consumes.

Spec: `docs/migration/googlesql/` (analysis.md, antlr_rules.md §2.7/§4.3, truth1/{bigquery,spanner}/dml.md, oracle.md). DAG node `googlesql/parser-dml` (P0).

### What landed

- **INSERT** — VALUES rows / `SELECT` / `( query )` / `TABLE` sources; all six `opt_or_ignore_replace_update` upsert prefixes (`OR IGNORE/REPLACE/UPDATE` + the bare `IGNORE/REPLACE/UPDATE`); explicit column lists; `ON CONFLICT` (DO NOTHING / DO UPDATE SET … [WHERE]; column-list target or `ON UNIQUE CONSTRAINT id`); `DEFAULT` values; `ASSERT_ROWS_MODIFIED`; `THEN RETURN [WITH ACTION [AS alias]] select_list`.
- **UPDATE** — target alias, `WITH OFFSET`, generalized SET-item LHS paths (`.field` / `.(extension)` / `[idx]`), nested-DML SET items (`SET (DELETE …)`), join-update `FROM`, `WHERE`, `ASSERT_ROWS_MODIFIED`, `THEN RETURN`.
- **DELETE** — optional `FROM`, alias, `WITH OFFSET`, `WHERE`, `ASSERT_ROWS_MODIFIED`, `THEN RETURN`.
- **MERGE** — `INTO?` / alias / `USING` (table or `( query )` subquery) / `ON` / `(WHEN …)+` with `MATCHED` / `NOT MATCHED [BY TARGET | BY SOURCE]` and `INSERT` / `UPDATE SET` / `DELETE` actions (`INSERT [(cols)] (VALUES row | ROW)`). Requires ≥1 WHEN per the `.g4`.
- **TRUNCATE TABLE [WHERE]**.
- **AST**: 13 new node types (`InsertStmt`, `InsertRow`, `InsertTable`, `OnConflict`, `UpdateStmt`, `UpdateItem`, `DeleteStmt`, `MergeStmt`, `MergeWhen`, `MergeAction`, `TruncateStmt`, `Returning`, `DefaultExpr`) + tags + regenerated walker (all children traversed for the downstream query-span/lineage walk).

A grammar-exact subtlety: **`ON CONFLICT` is eligible only after a VALUES / TABLE / bare `( query )` source** — not after a bare or set-op/ORDER-BY/LIMIT-tailed query. (`(SELECT 1) ON CONFLICT` accepts; `(SELECT 1) LIMIT 5 ON CONFLICT` and `SELECT 1 ON CONFLICT` reject — oracle-confirmed.)

### PROVE (correctness-protocol.md)

- **Live Spanner-emulator differential** (`dml_oracle_test.go`, build tag `googlesql_oracle`, **68 fixtures, both polarities**) — omni's accept/reject matches the emulator for every shared + Spanner-only form. Run: `SPANNER_EMULATOR_HOST=localhost:9010 go test -tags googlesql_oracle ./googlesql/parser/ -run TestDMLDifferential`.
- **Full canonical ZetaSQL DML corpus parses** (`dml_insert.sql`, `dml_update.sql`, `dml_delete.sql`, `dml_merge.sql`, `truncate.sql`, `dml_insert_on_conflict_clause.sql`) — the breadth/completeness gate.
- Hand-written AST-shape unit tests + negatives (`dml_test.go`).
- Neighboring differentials (Select/Expr/Type/DDL) re-run green — no regression.

### Divergences (Spanner oracle NON-authoritative; followed `.g4` + BigQuery docs + ZetaSQL corpus)

| Form | Spanner emulator | Disposition |
|---|---|---|
| MERGE | rejects at statement dispatch (`Statement not supported: MergeStmt`) **before** body parse — accepts even a 0-WHEN MERGE | no authoritative MERGE-syntax signal; followed ZetaSQL `.g4` (require ≥1 WHEN) + corpus |
| TRUNCATE TABLE | routed to Spanner DDL, syntax-rejects (no TRUNCATE there) | BigQuery-only DML (truth1 BQ DML-003); corpus-oracled |
| dashed table paths (`my-project.ds.tbl`) | syntax-rejects `'-'` (divergence #85) | BigQuery-valid; omni accepts |
| `INSERT … TABLE <clause> … ON CONFLICT` | rejects the on-conflict after a TABLE source | `.g4` (union) allows it; followed `.g4` |

These forms are excluded from the differential (a Spanner reject would fabricate a false divergence) and covered against the ZetaSQL corpus + docs instead.

### Review gate (review-gate.md)

Two-reviewer cross-family gate, both lenses run:
- **Claude lens** — caught a false-reject: `(SELECT 1) LIMIT 5` (a parenthesized query with a query-level trailing ORDER BY/LIMIT is a bare query, not the on-conflict-eligible `( query )`). Fixed + regression.
- **Codex lens** — caught **4 real bugs**, all oracle-verified and fixed with per-finding regression tests:
  1. DML expression-embedded subqueries were never re-parsed (`fillSubqueries`) → false-accept of malformed `(SELECT 1 FROM s a b)` + missing lineage. Now DML routes through `parseDMLStatement` (mirrors `parseQueryStatement`).
  2. `ASSERT_ROWS_MODIFIED` accepted arbitrary expressions → false-accept of `1 + 1` / `'x'` / `(SELECT 1)`. Now restricted to `possibly_cast_int_literal_or_parameter`.
  3. `THEN RETURN WITH(x AS 1, x)` (inline WITH-expr select item) was mis-parsed as `WITH ACTION` → false-reject. Now only `WITH ACTION` takes the modifier branch.
  4. `INSERT INTO t (graph) VALUES (1)` (non-reserved keyword column name) → false-reject. The column-list discriminator now treats only reserved query heads as query-source signals.

No blockers remain.

### Scope

Touches only this node's declared files plus its own tests. Out-of-scope test touch-ups (test-only, mandated by DML no longer being stubbed): `parser_test.go` + `diagnostics_test.go` switch their "still-stubbed" example statement from INSERT/UPDATE to CALL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
