### PR TITLE
fix(googlesql): genwalker value-struct traversal + identifierText keyword casing

### DIFF
--- a/googlesql/ast/ast_test.go
+++ b/googlesql/ast/ast_test.go
@@ -390,6 +390,92 @@ func TestWalkSliceOfPointerNodeFields(t *testing.T) {
 	}
 }
 
+// TestWalkValueStructNodeFields is the regression test for the genwalker
+// value-struct traversal gap. WindowFrame holds `Start WindowBound` and
+// `End WindowBound` — value (non-pointer, non-Node) struct fields — and
+// WindowBound carries an `Offset Node` (the `expr` in `5 PRECEDING` /
+// `@p FOLLOWING`). Before the fix genwalker's isChildType recognized only Node,
+// []Node, *<NodeStruct> and []*<NodeStruct>, so it emitted NO case for
+// WindowFrame at all and the bound offset expressions were unreachable by any
+// AST pass (query-span / lineage would miss frame-bound subexpressions). The
+// fix teaches the generator to descend into Node fields nested inside value
+// struct fields. This test asserts both bound offsets are now visited by Walk
+// (with the post-order Visit(nil)) and Inspect.
+func TestWalkValueStructNodeFields(t *testing.T) {
+	// A BETWEEN frame `ROWS BETWEEN <startOffset> PRECEDING AND <endOffset>
+	// FOLLOWING` with a distinct leaf Literal at each bound offset.
+	startOffset := &Literal{Kind: LitInt, Ival: 5, Loc: Loc{0, 1}}
+	endOffset := &Literal{Kind: LitInt, Ival: 10, Loc: Loc{2, 4}}
+	frame := &WindowFrame{
+		Kind:    FrameRows,
+		Between: true,
+		Start:   WindowBound{Kind: BoundPreceding, Offset: startOffset},
+		End:     WindowBound{Kind: BoundFollowing, Offset: endOffset},
+	}
+
+	// Walk must reach the frame, both bound offset literals, and the matching
+	// post-order Visit(nil) for each visited node.
+	var events []recordEvent
+	Walk(&recorder{events: &events}, frame)
+	want := []recordEvent{
+		{tag: T_WindowFrame}, // pre-order frame
+		{tag: T_Literal},     // pre-order Start.Offset
+		{post: true},         // post-order Start.Offset
+		{tag: T_Literal},     // pre-order End.Offset
+		{post: true},         // post-order End.Offset
+		{post: true},         // post-order frame
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Errorf("Walk over WindowFrame visit order mismatch:\n got: %+v\nwant: %+v", events, want)
+	}
+
+	// Inspect must reach the frame and both offset literals (no post-order).
+	var visited []Node
+	Inspect(frame, func(n Node) bool {
+		visited = append(visited, n)
+		return true
+	})
+	if len(visited) != 3 {
+		t.Fatalf("Inspect visited %d nodes, want 3 (frame + 2 bound offsets); value-struct field not walked", len(visited))
+	}
+	if visited[0] != Node(frame) {
+		t.Errorf("Inspect[0] = %v, want the WindowFrame", visited[0])
+	}
+	// Identity check: the exact offset Node pointers must be the ones reached,
+	// proving Walk descended into n.Start.Offset / n.End.Offset specifically.
+	if visited[1] != Node(startOffset) {
+		t.Errorf("Inspect[1] = %v, want Start.Offset literal %p", visited[1], startOffset)
+	}
+	if visited[2] != Node(endOffset) {
+		t.Errorf("Inspect[2] = %v, want End.Offset literal %p", visited[2], endOffset)
+	}
+}
+
+// TestWalkValueStructNilOffsets verifies the value-struct walk is nil-safe: a
+// frame whose bounds carry no offset (UNBOUNDED PRECEDING / CURRENT ROW leave
+// WindowBound.Offset nil) must not panic and must visit only the frame itself.
+func TestWalkValueStructNilOffsets(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Walk over WindowFrame with nil bound offsets panicked: %v", r)
+		}
+	}()
+	frame := &WindowFrame{
+		Kind:    FrameRows,
+		Between: true,
+		Start:   WindowBound{Kind: BoundUnboundedPreceding}, // Offset nil
+		End:     WindowBound{Kind: BoundCurrentRow},         // Offset nil
+	}
+	var visited []NodeTag
+	Inspect(frame, func(n Node) bool {
+		visited = append(visited, n.Tag())
+		return true
+	})
+	if len(visited) != 1 || visited[0] != T_WindowFrame {
+		t.Errorf("Inspect over nil-offset frame visited %v, want [T_WindowFrame] only", visited)
+	}
+}
+
 // -----------------------------------------------------------------------
 // NodeTag tests
 // -----------------------------------------------------------------------

--- a/googlesql/ast/cmd/genwalker/main.go
+++ b/googlesql/ast/cmd/genwalker/main.go
@@ -56,6 +56,14 @@ func main() {
 
 	var structs []structInfo
 
+	// allFields records EVERY field of EVERY struct (name+type), keyed by struct
+	// name. Unlike `structs` below (which keeps only walkable child fields), this
+	// is the raw view used to look INSIDE value-typed struct fields: when a field
+	// is a value struct (e.g. WindowFrame.Start of type WindowBound), the walker
+	// must reach the Node fields nested inside that value (WindowBound.Offset).
+	// We need the full field list of the referenced struct to find those.
+	allFields := map[string][]rawField{}
+
 	// nodeStructs tracks which structs implement the Node interface (have a Tag() method).
 	// Only these structs get their own case in the walkChildren switch, and only
 	// pointer-to-Node-struct fields generate Walk calls.
@@ -120,18 +128,23 @@ func main() {
 				}
 
 				var fields []field
+				var raw []rawField
 				for _, fld := range st.Fields.List {
 					if len(fld.Names) == 0 {
 						continue // embedded
 					}
 					typStr := typeString(fld.Type)
-					if isChildType(typStr, nodeStructs) {
+					for _, name := range fld.Names {
+						raw = append(raw, rawField{Name: name.Name, Type: typStr})
+					}
+					if isChildType(typStr, structNames, nodeStructs) {
 						for _, name := range fld.Names {
 							fields = append(fields, field{Name: name.Name, Type: typStr})
 						}
 					}
 				}
 				structs = append(structs, structInfo{Name: ts.Name.Name, Fields: fields})
+				allFields[ts.Name.Name] = raw
 			}
 		}
 	}
@@ -150,6 +163,11 @@ func main() {
 	buf.WriteString("func walkChildren(v Visitor, node Node) {\n")
 	buf.WriteString("\tswitch n := node.(type) {\n")
 
+	// cases / fields count what is ACTUALLY emitted (a retained field can emit
+	// nothing — a value struct with no Node descendants like NamePath — so these
+	// are tallied from real output, not from len(s.Fields)).
+	cases := 0
+	fields := 0
 	for _, s := range structs {
 		if len(s.Fields) == 0 {
 			continue
@@ -158,27 +176,26 @@ func main() {
 		if !nodeStructs[s.Name] {
 			continue
 		}
-		fmt.Fprintf(&buf, "\tcase *%s:\n", s.Name)
+		// Build the case body into a scratch buffer first: a field may turn out
+		// to contribute nothing (a value-struct field whose target has no Node
+		// descendants, e.g. NamePath). If the whole body is empty we skip the
+		// `case` header entirely so the generated switch stays clean.
+		var body bytes.Buffer
+		emittedFields := 0
 		for _, f := range s.Fields {
-			switch {
-			case f.Type == "Node":
-				fmt.Fprintf(&buf, "\t\tWalk(v, n.%s)\n", f.Name)
-			case f.Type == "[]Node":
-				fmt.Fprintf(&buf, "\t\twalkNodes(v, n.%s)\n", f.Name)
-			case strings.HasPrefix(f.Type, "[]*"):
-				// Slice of pointer-to-Node-struct (e.g. []*Privilege): walk each
-				// element. Mirrors the []Node walkNodes loop; the parser never
-				// stores nil pointers in these slices.
-				fmt.Fprintf(&buf, "\t\tfor _, c := range n.%s {\n", f.Name)
-				fmt.Fprintf(&buf, "\t\t\tWalk(v, c)\n")
-				fmt.Fprintf(&buf, "\t\t}\n")
-			default:
-				// Pointer to a known struct type (e.g. *SelectStmt).
-				fmt.Fprintf(&buf, "\t\tif n.%s != nil {\n", f.Name)
-				fmt.Fprintf(&buf, "\t\t\tWalk(v, n.%s)\n", f.Name)
-				fmt.Fprintf(&buf, "\t\t}\n")
+			before := body.Len()
+			emitFieldWalk(&body, "n."+f.Name, f.Type, "\t\t", structNames, nodeStructs, allFields, nil)
+			if body.Len() > before {
+				emittedFields++
 			}
 		}
+		if body.Len() == 0 {
+			continue
+		}
+		cases++
+		fields += emittedFields
+		fmt.Fprintf(&buf, "\tcase *%s:\n", s.Name)
+		buf.Write(body.Bytes())
 	}
 
 	buf.WriteString("\t}\n")
@@ -198,16 +215,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Stats.
-	cases := 0
-	fields := 0
-	for _, s := range structs {
-		if len(s.Fields) > 0 && nodeStructs[s.Name] {
-			cases++
-			fields += len(s.Fields)
-		}
-	}
 	fmt.Printf("Generated walk_generated.go: %d cases, %d child fields\n", cases, fields)
+}
+
+// rawField is one struct field (name + textual type). The package keeps the
+// raw field list of every struct so the emitter can look inside value-typed
+// struct fields and reach the Node fields nested within them.
+type rawField struct {
+	Name string
+	Type string
 }
 
 // typeString returns the string representation of a Go type expression.
@@ -227,6 +243,148 @@ func typeString(expr ast.Expr) string {
 	}
 }
 
+// emitFieldWalk writes the walk statements for one field of type typStr,
+// reachable via the Go expression accessor (e.g. "n.Start" or "n.Start.Offset"),
+// indented by indent. It handles every shape isChildType accepts:
+//
+//   - Node / []Node                 → Walk / walkNodes
+//   - *<NodeStruct> / []*<NodeStruct> → nil-checked Walk / range-Walk
+//   - <ValueStruct> / *<ValueStruct> / []<ValueStruct> → recurse into the
+//     value's own Node-bearing fields (nil-checked for the pointer form,
+//     range-iterated for the slice form), so e.g. WindowBound.Offset is reached.
+//
+// A value struct with no Node descendants emits nothing. seen guards against
+// type cycles among value structs.
+func emitFieldWalk(buf *bytes.Buffer, accessor, typStr, indent string, structNames, nodeStructs map[string]bool, allFields map[string][]rawField, seen map[string]bool) {
+	switch {
+	case typStr == "Node":
+		fmt.Fprintf(buf, "%sWalk(v, %s)\n", indent, accessor)
+		return
+	case typStr == "[]Node":
+		fmt.Fprintf(buf, "%swalkNodes(v, %s)\n", indent, accessor)
+		return
+	case strings.HasPrefix(typStr, "[]*"):
+		// Slice of pointer-to-Node-struct (e.g. []*Privilege): walk each element.
+		// Mirrors the []Node walkNodes loop; the parser never stores nil pointers
+		// in these slices.
+		name := typStr[len("[]*"):]
+		if nodeStructs[name] {
+			fmt.Fprintf(buf, "%sfor _, c := range %s {\n", indent, accessor)
+			fmt.Fprintf(buf, "%s\tWalk(v, c)\n", indent)
+			fmt.Fprintf(buf, "%s}\n", indent)
+			return
+		}
+		// []*<ValueStruct>: range, nil-check each element, then recurse into it.
+		emitValueStructSlice(buf, accessor, name, indent, structNames, nodeStructs, allFields, seen, true)
+		return
+	case strings.HasPrefix(typStr, "[]"):
+		name := typStr[len("[]"):]
+		if nodeStructs[name] {
+			// []<NodeStruct>: a slice of Node structs held BY VALUE. Walk the
+			// address of each element so the Node itself is visited. (No such
+			// field exists today — Nodes are pointer-held — but handle it so the
+			// generator is correct if one is ever added.)
+			fmt.Fprintf(buf, "%sfor i := range %s {\n", indent, accessor)
+			fmt.Fprintf(buf, "%s\tWalk(v, &%s[i])\n", indent, accessor)
+			fmt.Fprintf(buf, "%s}\n", indent)
+			return
+		}
+		// []<ValueStruct>: range and recurse into each element value.
+		emitValueStructSlice(buf, accessor, name, indent, structNames, nodeStructs, allFields, seen, false)
+		return
+	case strings.HasPrefix(typStr, "*"):
+		name := typStr[1:]
+		if nodeStructs[name] {
+			// Pointer to a Node struct (e.g. *SelectStmt).
+			fmt.Fprintf(buf, "%sif %s != nil {\n", indent, accessor)
+			fmt.Fprintf(buf, "%s\tWalk(v, %s)\n", indent, accessor)
+			fmt.Fprintf(buf, "%s}\n", indent)
+			return
+		}
+		// Pointer to a non-Node value struct: nil-check, then recurse into the
+		// pointee's Node-bearing fields.
+		if !valueStructHasNodes(name, structNames, nodeStructs, allFields, map[string]bool{}) {
+			return
+		}
+		var inner bytes.Buffer
+		emitValueStructBody(&inner, accessor, name, indent+"\t", structNames, nodeStructs, allFields, seen)
+		if inner.Len() == 0 {
+			return
+		}
+		fmt.Fprintf(buf, "%sif %s != nil {\n", indent, accessor)
+		buf.Write(inner.Bytes())
+		fmt.Fprintf(buf, "%s}\n", indent)
+		return
+	default:
+		if nodeStructs[typStr] {
+			// A Node struct held BY VALUE (e.g. `Foo Bar` where Bar has Tag()).
+			// Walk its address so the Node itself is visited rather than only its
+			// children. (No such field exists today — Nodes are pointer-held — but
+			// handle it for generality.)
+			fmt.Fprintf(buf, "%sWalk(v, &%s)\n", indent, accessor)
+			return
+		}
+		// Bare value struct (e.g. WindowFrame.Start of type WindowBound): recurse
+		// directly into its Node-bearing fields.
+		emitValueStructBody(buf, accessor, typStr, indent, structNames, nodeStructs, allFields, seen)
+		return
+	}
+}
+
+// emitValueStructBody emits walks for every Node-bearing field of the value
+// struct named structType, reached via accessor (e.g. "n.Start" →
+// "n.Start.Offset"). Cycles among value structs are broken via seen.
+func emitValueStructBody(buf *bytes.Buffer, accessor, structType, indent string, structNames, nodeStructs map[string]bool, allFields map[string][]rawField, seen map[string]bool) {
+	if seen[structType] {
+		return // type cycle guard
+	}
+	next := map[string]bool{structType: true}
+	for k := range seen {
+		next[k] = true
+	}
+	for _, f := range allFields[structType] {
+		if !isChildType(f.Type, structNames, nodeStructs) {
+			continue
+		}
+		emitFieldWalk(buf, accessor+"."+f.Name, f.Type, indent, structNames, nodeStructs, allFields, next)
+	}
+}
+
+// emitValueStructSlice emits a range loop over a slice of value structs (or
+// pointers to them) named elem, recursing into each element. In both forms the
+// loop variable c ends up as *elem (an addressable pointer into the slice for
+// the value form; the slice element itself for the pointer form), so the body
+// accesses c.Field uniformly. ptr selects the []*Elem form, whose elements are
+// nil-checked. (No []*ValueStruct field exists today; this path is defensive.)
+func emitValueStructSlice(buf *bytes.Buffer, accessor, elem, indent string, structNames, nodeStructs map[string]bool, allFields map[string][]rawField, seen map[string]bool, ptr bool) {
+	if !valueStructHasNodes(elem, structNames, nodeStructs, allFields, map[string]bool{}) {
+		return
+	}
+	bodyIndent := indent + "\t"
+	if ptr {
+		bodyIndent = indent + "\t\t"
+	}
+	var inner bytes.Buffer
+	emitValueStructBody(&inner, "c", elem, bodyIndent, structNames, nodeStructs, allFields, seen)
+	if inner.Len() == 0 {
+		return
+	}
+	if ptr {
+		// []*Elem: each element is already a *Elem; range by value and nil-check.
+		fmt.Fprintf(buf, "%sfor _, c := range %s {\n", indent, accessor)
+		fmt.Fprintf(buf, "%s\tif c != nil {\n", indent)
+		buf.Write(inner.Bytes())
+		fmt.Fprintf(buf, "%s\t}\n", indent)
+		fmt.Fprintf(buf, "%s}\n", indent)
+		return
+	}
+	// []Elem: take the address of each element so c is an addressable *Elem.
+	fmt.Fprintf(buf, "%sfor i := range %s {\n", indent, accessor)
+	fmt.Fprintf(buf, "%s\tc := &%s[i]\n", indent, accessor)
+	buf.Write(inner.Bytes())
+	fmt.Fprintf(buf, "%s}\n", indent)
+}
+
 // isChildType reports whether typStr represents a field that walkChildren
 // should descend into.
 //
@@ -237,11 +395,18 @@ func typeString(expr ast.Expr) string {
 //   - "[]*<NodeStruct>"  — slice of pointer-to-Node-struct (e.g. []*Privilege,
 //     []*Grantee); each element is walked. Future nodes define []*Expr /
 //     []*SelectItem fields and query-span walks the AST, so these must traverse.
+//   - "<ValueStruct>", "*<ValueStruct>", "[]<ValueStruct>" — a value-typed struct
+//     field whose struct is NOT itself a Node (no Tag() method) but transitively
+//     carries Node fields. The canonical case is WindowFrame.Start/End of type
+//     WindowBound, which holds `Offset Node`: without descending into the value,
+//     frame-bound expressions (`5 PRECEDING`, `@p FOLLOWING`) are unreachable by
+//     any AST pass. Whether such a field actually contributes a walk is decided
+//     at emission time (emitFieldWalk) against the referenced struct's fields, so
+//     a value struct with no Node descendants (e.g. NamePath) yields nothing.
 //
-// Excluded: pointer to "Loc" (Loc is not a node), pointer to non-Node structs
-// (helper types like WindowSpec, etc.), slice of pointer-to-non-Node-struct, and
-// any other shape.
-func isChildType(typStr string, nodeStructs map[string]bool) bool {
+// Excluded: pointer to "Loc" (Loc is not a node), pointer/slice of plain helper
+// structs that carry no Node fields, and any other shape.
+func isChildType(typStr string, structNames, nodeStructs map[string]bool) bool {
 	if typStr == "Node" {
 		return true
 	}
@@ -255,14 +420,63 @@ func isChildType(typStr string, nodeStructs map[string]bool) bool {
 		if name == "Loc" {
 			return false
 		}
-		return nodeStructs[name]
-	}
-	if strings.HasPrefix(typStr, "*") {
-		name := typStr[1:]
-		if name == "Loc" {
-			return false
+		if nodeStructs[name] {
+			return true
 		}
-		return nodeStructs[name]
+		// []*<ValueStruct>: slice of pointer-to-non-Node-struct. Retain it so
+		// emitFieldWalk can look inside; it emits nothing if the element has no
+		// Node descendants.
+		return structNames[name]
+	}
+	// Strip a single leading "[]" (slice of value structs) before the pointer
+	// check so "[]WindowBound" is classified by its element type.
+	bare := strings.TrimPrefix(typStr, "[]")
+	name := strings.TrimPrefix(bare, "*")
+	if name == "Loc" {
+		return false
+	}
+	if !structNames[name] {
+		return false
+	}
+	// Pointer-to-Node-struct (e.g. *SelectStmt) is the common case.
+	if strings.HasPrefix(bare, "*") && nodeStructs[name] {
+		return true
+	}
+	// Otherwise it is a value-struct shape (bare, *, or [] of a non-Node helper
+	// struct). Retain it; emitFieldWalk decides whether it carries Node fields.
+	return structNames[name]
+}
+
+// valueStructHasNodes reports whether the named struct transitively contains a
+// field that walkChildren would descend into (a Node / []Node / pointer- or
+// slice-of-Node-struct field, or a nested value-struct that itself qualifies).
+// It guards against type cycles via seen. Used to decide whether a value-struct
+// field is worth emitting at all.
+func valueStructHasNodes(name string, structNames, nodeStructs map[string]bool, allFields map[string][]rawField, seen map[string]bool) bool {
+	if seen[name] {
+		return false
+	}
+	seen[name] = true
+	for _, f := range allFields[name] {
+		t := f.Type
+		if t == "Node" || t == "[]Node" {
+			return true
+		}
+		elem := strings.TrimPrefix(strings.TrimPrefix(t, "[]"), "*")
+		if elem == "Loc" || !structNames[elem] {
+			continue
+		}
+		if nodeStructs[elem] {
+			// A pointer/slice-of-pointer to a Node struct is walkable; a *bare*
+			// value field whose type is itself a Node is malformed (Nodes are
+			// pointer-held) and never occurs, but treating it as walkable here is
+			// harmless since emitFieldWalk only descends value structs.
+			return true
+		}
+		// Nested non-Node value struct: recurse.
+		if valueStructHasNodes(elem, structNames, nodeStructs, allFields, seen) {
+			return true
+		}
 	}
 	return false
 }

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -475,6 +475,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.Spec != nil {
 			Walk(v, n.Spec)
 		}
+	case *WindowFrame:
+		Walk(v, n.Start.Offset)
+		Walk(v, n.End.Offset)
 	case *WindowSpec:
 		walkNodes(v, n.PartitionBy)
 		for _, c := range n.OrderBy {

--- a/googlesql/parser/datatypes.go
+++ b/googlesql/parser/datatypes.go
@@ -429,16 +429,27 @@ func (p *Parser) parseTypeName() (*DataType, error) {
 	return dt, nil
 }
 
-// identifierText returns the source text of an identifier-or-keyword token: the
-// raw Str for a token identifier (the lexer already stripped backticks), or the
-// keyword spelling for a keyword-as-identifier (whose Str is empty).
+// identifierText returns the SOURCE text of an identifier-or-keyword token: the
+// raw Str for a token identifier (the lexer already stripped any backticks), and
+// likewise the raw Str for a keyword-as-identifier — preserving the source
+// casing the user wrote.
+//
+// Source casing matters because GoogleSQL identifiers are case-insensitive for
+// *resolution* but the parser preserves the spelling (folding is a downstream
+// metadata concern); collapsing a keyword-spelled name part to its canonical
+// upper-case keyword spelling would corrupt the name. Concretely, when a
+// non-reserved keyword stands in as a name part — `pkg.Type`, `x.value`,
+// `p.Key.Value` — the lexer emits the kw* token but still populates Token.Str
+// with the verbatim source text (lexer.go scanIdentOrKeyword: `Str: text`). So
+// every keyword-as-identifier carries its real spelling and we return it as-is;
+// returning TokenName(tok.Type) here would yield `pkg.TYPE` / `x.VALUE`.
 //
 // An empty `tokIdentifier` (the body of an empty backtick pair “) is rejected
 // as an "invalid empty identifier" — the lexer admits empty backticks without a
 // lex error, but the GoogleSQL grammar rejects them (oracle: `CAST(NULL AS “)`
-// → "Syntax error: Invalid empty identifier"). Keyword tokens legitimately
-// carry an empty Str, so the substitution is keyed on the token TYPE, not on
-// emptiness, to avoid turning an empty identifier into the literal "IDENTIFIER".
+// → "Syntax error: Invalid empty identifier"). The emptiness check stays keyed
+// on tokIdentifier so a (hypothetical) zero-width keyword token can still fall
+// back to its canonical spelling rather than being rejected as empty.
 func (p *Parser) identifierText(tok Token) (string, error) {
 	if tok.Type == tokIdentifier {
 		if tok.Str == "" {
@@ -446,8 +457,21 @@ func (p *Parser) identifierText(tok Token) (string, error) {
 		}
 		return tok.Str, nil
 	}
-	// A keyword-as-identifier: its Str is empty; use the keyword spelling.
-	return TokenName(tok.Type), nil
+	// A keyword-as-identifier: the lexer recorded the source spelling in Str
+	// (case preserved). Use it so casing survives; fall back to the canonical
+	// keyword name only in the defensive case of a missing Str (never produced
+	// by the current lexer for a scanned keyword).
+	if tok.Str != "" {
+		return tok.Str, nil
+	}
+	// Empty Str with a non-identifier token. For a keyword token use its
+	// canonical spelling. Any other token here means a caller fed a non-name
+	// token (an operator/literal) — fail closed rather than fabricate a name
+	// from TokenName (which would yield e.g. "." or "INTEGER").
+	if tok.Type >= keywordBase {
+		return TokenName(tok.Type), nil
+	}
+	return "", &ParseError{Loc: tok.Loc, Msg: "expected an identifier"}
 }
 
 // parseArrayType parses `ARRAY < type >` (caller confirmed the leading ARRAY).

--- a/googlesql/parser/datatypes_test.go
+++ b/googlesql/parser/datatypes_test.go
@@ -134,6 +134,49 @@ func TestParseType_DottedPathName(t *testing.T) {
 	}
 }
 
+func TestParseType_KeywordPartCasePreserved(t *testing.T) {
+	// Regression for identifierText folding keyword-spelled path parts to their
+	// canonical UPPER-case keyword name. `Type`, `value`, `Key`, `Value` are all
+	// NON-reserved keywords, so the lexer emits a kw* token for them — but it
+	// also records the verbatim source spelling in Token.Str. identifierText must
+	// return that spelling, not TokenName(tok.Type): otherwise `pkg.Type` parses
+	// as `pkg.TYPE`, `x.value` as `x.VALUE`, silently corrupting proto/enum type
+	// names (and, since identifierText backs every name part in the grammar,
+	// every keyword-spelled identifier elsewhere too).
+	cases := []struct {
+		input string
+		parts []string
+	}{
+		{"pkg.Type", []string{"pkg", "Type"}},
+		{"x.value", []string{"x", "value"}},
+		{"p.Key.Value", []string{"p", "Key", "Value"}},
+		// Mixed case on the part itself must survive byte-for-byte.
+		{"a.TyPe", []string{"a", "TyPe"}},
+		// A keyword as the FIRST part (parseTypeName accepts a non-reserved
+		// keyword there via isIdentifierStart) must also keep its casing.
+		{"Value.x", []string{"Value", "x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dt, err := testParseType(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dt.Kind != TypeName {
+				t.Fatalf("Kind = %v, want TypeName", dt.Kind)
+			}
+			if len(dt.NameParts) != len(tc.parts) {
+				t.Fatalf("NameParts = %v, want %v", dt.NameParts, tc.parts)
+			}
+			for i := range tc.parts {
+				if dt.NameParts[i] != tc.parts[i] {
+					t.Errorf("NameParts[%d] = %q, want %q (source casing must be preserved for keyword-spelled parts)", i, dt.NameParts[i], tc.parts[i])
+				}
+			}
+		})
+	}
+}
+
 func TestParseType_EmptyBacktickRejected(t *testing.T) {
 	// Oracle: `CAST(NULL AS ``)` REJECTS ("Syntax error: Invalid empty
 	// identifier"). The lexer admits the empty backtick pair `` as a

--- a/googlesql/parser/expr_test.go
+++ b/googlesql/parser/expr_test.go
@@ -599,29 +599,25 @@ func TestExpr_BigQueryOnly(t *testing.T) {
 	}
 }
 
-// TestExpr_KeywordPathCaseFolding documents a pre-existing, KNOWN behavior of
-// the shared identifierText helper (datatypes.go / the types+foundation nodes,
-// out of this node's writes-scope): a dotted path/type component that happens to
-// be a GoogleSQL word-keyword (e.g. TYPE, PATH, VALUE) renders in UPPER case,
-// because keyword tokens carry no source spelling and identifierText substitutes
-// the canonical keyword name. Non-keyword components preserve source case.
-//
-// This does NOT affect accept/reject parity (the live oracle accepts the form
-// regardless of case — see expr_oracle_test.go `foo.bar.Baz`), but it loses case
-// for keyword-named proto/enum path parts, which ARE case-sensitive in GoogleSQL
-// for resolution. It is flagged to the divergence ledger as an
-// identifierText/foundation issue (googlesql/expressions: "keyword-as-identifier
-// path-part case folding") for a follow-up at the lexer/foundation layer; this
-// test pins the current behavior so the fix is observed when it lands.
+// TestExpr_KeywordPathCaseFolding locks in that the shared identifierText helper
+// (datatypes.go) PRESERVES the source casing of a dotted path/type component
+// that happens to be a GoogleSQL word-keyword (e.g. Type, Path, Value). It used
+// to fold such a part to the canonical UPPER-case keyword name (`pkg.Type` →
+// `pkg.TYPE`) on the false premise that keyword tokens carry no source spelling;
+// in fact the lexer records the verbatim text in Token.Str (lexer.go
+// scanIdentOrKeyword), so identifierText now returns it. This matters because
+// keyword-named proto/enum path parts ARE case-sensitive for GoogleSQL
+// resolution — folding them silently corrupted the name (and PathExpr shares the
+// same helper, so the fix lands here too). Accept/reject parity is unaffected
+// (the oracle accepts the form regardless of case — see expr_oracle_test.go).
 func TestExpr_KeywordPathCaseFolding(t *testing.T) {
-	// Non-keyword parts keep their source case.
+	// Non-keyword parts keep their source case (unchanged).
 	if pe := mustParse(t, "Foo.Bar.Baz").(*ast.PathExpr); pe.String() != "Foo.Bar.Baz" {
 		t.Errorf("non-keyword path case: got %q, want Foo.Bar.Baz", pe.String())
 	}
-	// A keyword-named part folds to upper case (KNOWN; documents the behavior).
-	if pe := mustParse(t, "pkg.Type").(*ast.PathExpr); pe.String() != "pkg.TYPE" {
-		t.Errorf("keyword path-part folding changed: got %q (was pkg.TYPE) — "+
-			"if identifierText now preserves case, update this test and resolve the divergence", pe.String())
+	// A keyword-named part now ALSO keeps its source case (the fix).
+	if pe := mustParse(t, "pkg.Type").(*ast.PathExpr); pe.String() != "pkg.Type" {
+		t.Errorf("keyword path-part case: got %q, want pkg.Type (source casing must be preserved)", pe.String())
 	}
 }
 


### PR DESCRIPTION
Two foundation fixes in the omni `googlesql` engine. Both sit **below** the accept/reject layer (AST walker + identifier casing) and gate the upcoming `analysis` / query-span node, so correctness matters. Unit tests are the primary proof; the live Spanner emulator confirms no accept/reject regression.

## BUG 1 — genwalker does not recurse into VALUE-struct fields

`googlesql/ast/cmd/genwalker/main.go` → regenerated `googlesql/ast/walk_generated.go`

`WindowBound` is a value struct with an `Offset Node` field; `WindowFrame` holds `Start WindowBound` / `End WindowBound`. The generator's `isChildType` recognized `Node`, `[]Node`, `*<NodeStruct>`, `[]*<NodeStruct>` — but **not** a `Node` field nested inside a value-typed struct field. So **no `case *WindowFrame`** was emitted at all, and `Walk`/`Inspect` over a `WindowFrame` never visited `n.Start.Offset` / `n.End.Offset`. Frame-bound expressions (`ROWS BETWEEN 5 PRECEDING AND 10 FOLLOWING`, `@p PRECEDING`) were unreachable by any AST pass — query-span / lineage would silently miss frame-bound subexpressions.

**Fix:** teach genwalker to descend into Node fields nested inside value-typed struct fields, as the **general case** and nil-safe:
- bare value-struct (`Start WindowBound` → `Walk(v, n.Start.Offset)`),
- pointer-to-value-struct (nil-checked, then recurse),
- slice-of-value-struct (`for i := range … { c := &s[i]; … }`, addressable),
- slice-of-pointer-to-value-struct (range + per-element nil-check),
- arbitrarily **nested** value-structs (cycle-guarded via a `seen` set).

A value struct with no Node descendants (e.g. `NamePath`) emits nothing, so empty cases are skipped (`Privilege`'s case correctly disappears). By-value Node-struct fields (none exist today — Nodes are pointer-held — but handled for generality) `Walk` their address.

Regenerated `walk_generated.go` adds exactly:

```go
case *WindowFrame:
	Walk(v, n.Start.Offset)
	Walk(v, n.End.Offset)
```

`Walk(v, node)` is already nil-safe, so a nil `Offset` (UNBOUNDED / CURRENT ROW bounds) is a safe no-op. `go generate ./googlesql/ast/...` is **idempotent** (re-run → zero diff).

## BUG 2 — identifierText case-folds keyword-spelled path parts

`googlesql/parser/datatypes.go`, func `identifierText`

For a keyword token it returned the canonical UPPER-cased `TokenName(tok.Type)`, discarding source casing: `pkg.Type` → `pkg.TYPE`, `x.value` → `x.VALUE`. The justifying comment claimed `tok.Str` is empty for keyword tokens — **false**: the lexer (`googlesql/parser/lexer.go` `scanIdentOrKeyword`) emits keyword tokens with `Str: text` (source-cased; the doc there even says "case preserved"). `identifierText` is the **single shared helper** backing every name part across the whole grammar (path expressions, types, aliases, DDL/DML object names), so this silently corrupted the casing of every keyword-spelled identifier — and keyword-named proto/enum path parts ARE case-sensitive for GoogleSQL resolution.

**Fix:** return `tok.Str` for keyword tokens too (preserve source casing). The empty-backtick rejection stays keyed on `tokIdentifier`; the empty-`Str` fallback now uses `TokenName` only for an actual keyword token and otherwise **fails closed** (a non-name token reaching here is a caller bug → parse error, not a fabricated name like `"."`).

## Verification

- **Walk test (BUG 1):** new `TestWalkValueStructNodeFields` asserts `Walk` (full visit order incl. post-order) and `Inspect` reach **both** bound offset literals, with pointer-identity checks that the exact `Start.Offset` / `End.Offset` nodes are visited; `TestWalkValueStructNilOffsets` asserts nil-offset bounds don't panic and visit only the frame. Both **fail** against the pre-fix walker (only the frame is reached).
- **`go generate` idempotency:** re-running produces zero diff; honest generator stats (80 cases / 211 child fields).
- **Casing test (BUG 2):** new `TestParseType_KeywordPartCasePreserved` (`pkg.Type`, `x.value`, `p.Key.Value`, mixed-case `a.TyPe`, keyword-first `Value.x`) — **fails** against pre-fix code (`pkg.TYPE`, `x.VALUE`, …). Existing `TestExpr_KeywordPathCaseFolding` (which had pinned the buggy upper-case behavior with a "update when fixed" note) updated to assert preserved casing on `PathExpr`.
- **`go test ./googlesql/ast/... ./googlesql/parser/...`** green; full `./googlesql/...` tree green; **`go vet ./googlesql/...`** clean; **gofmt** clean.
- **Live Spanner emulator differential oracle** (`-tags googlesql_oracle`, Type/DDL/DML/Expr/Select) green **before and after** — zero accept/reject regression from the casing change (the fix only changes the stored spelling, not parseability).
- Adversarial self-review (incl. a synthetic-AST probe proving all five value-struct shapes emit valid compiling Go) + an external **Codex** review lens: **NO BLOCKING ISSUES**. Two minor nits applied — honest generator stats, and the fail-closed `identifierText` fallback.

## Scope

Touches only: `googlesql/ast/cmd/genwalker/main.go`, `googlesql/ast/walk_generated.go`, `googlesql/parser/datatypes.go`, and test files (`googlesql/ast/ast_test.go`, `googlesql/parser/datatypes_test.go`, `googlesql/parser/expr_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)