### PR TITLE
fix(partiql): accept modifier-prefixed CROSS JOIN (B12) + completion path-step FROM false-positive (B13)

### DIFF
--- a/partiql/completion/completion.go
+++ b/partiql/completion/completion.go
@@ -87,11 +87,35 @@ func isIdentChar(ch byte) bool {
 }
 
 func isInFromContext(upper string) bool {
-	// Simple heuristic: last SQL keyword before cursor is FROM
+	// The cursor is in a table-name position when the last completed clause
+	// keyword is FROM / JOIN / INTO. Each must match as a STANDALONE keyword:
+	// a dotted path step such as "x.from" (member access) also ends in "FROM",
+	// but `from` after a '.' is a path key, not a FROM clause, so it must NOT
+	// trigger table suggestions.
 	upper = strings.TrimRight(upper, " \t\n\r")
-	return strings.HasSuffix(upper, "FROM") ||
-		strings.HasSuffix(upper, "JOIN") ||
-		strings.HasSuffix(upper, "INTO")
+	return endsWithKeyword(upper, "FROM") ||
+		endsWithKeyword(upper, "JOIN") ||
+		endsWithKeyword(upper, "INTO")
+}
+
+// endsWithKeyword reports whether s ends with kw as a standalone keyword: kw is
+// a suffix of s, and either kw is the whole string or the character immediately
+// before it is whitespace (a real clause boundary). This rejects a keyword that
+// is merely the tail of a larger token — most importantly a '.'-prefixed path
+// step like "X.FROM" (member access x.from), which is not a FROM clause.
+func endsWithKeyword(s, kw string) bool {
+	if !strings.HasSuffix(s, kw) {
+		return false
+	}
+	if len(s) == len(kw) {
+		return true
+	}
+	switch s[len(s)-len(kw)-1] {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
 }
 
 func matchesPrefix(text, prefix string) bool {

--- a/partiql/completion/completion_negtests_test.go
+++ b/partiql/completion/completion_negtests_test.go
@@ -313,14 +313,11 @@ func TestCompletePathStepNotFromKeyword(t *testing.T) {
 	got := Complete(input, len(input), cat)
 	tabs := negTables(got)
 
-	// CORRECT contract (oracle): no table suggestions — `from` is a path key.
-	// If omni currently violates it (suggests tables), skip with a divergence
-	// note rather than failing or encoding the wrong expectation.
+	// CORRECT contract (oracle): no table suggestions — `from` after `.` is a
+	// path key (member access x.from), not a FROM clause.
 	if len(tabs) != 0 {
-		t.Skip("DIVERGENCE: omni suggests tables after path step `x.from ` (isInFromContext " +
-			"HasSuffix match in completion.go ignores the '.' path separator); ANTLR/grammar " +
-			"parses `from` as a pathStep key (member access x.from), so it is NOT a FROM clause " +
-			"and tables must not be suggested")
+		t.Errorf("Complete(%q): `from` after `.` is a path step, not a FROM clause; "+
+			"expected no table suggestions, got %v", input, tabs)
 	}
 	// Reached only if/when the divergence is fixed: the contract holds.
 }

--- a/partiql/parser/from.go
+++ b/partiql/parser/from.go
@@ -436,11 +436,14 @@ func (p *Parser) parseTableUnpivot() (*ast.UnpivotExpr, error) {
 //
 // Plus the CROSS JOIN form (line 390).
 func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
-	// Snapshot so a modifier not followed by JOIN can be fully rewound.
+	// Snapshot so a modifier not followed by JOIN / CROSS JOIN can be fully
+	// rewound (a dangling modifier must reject, not be silently consumed).
 	start := p.save()
 
+	// Bare forms carrying no joinType modifier.
 	switch p.cur.Type {
 	case tokCROSS:
+		// CROSS JOIN with no modifier.
 		p.advance() // consume CROSS
 		if p.cur.Type != tokJOIN {
 			// CROSS must be followed by JOIN.
@@ -450,60 +453,58 @@ func (p *Parser) tryParseJoinType() (ast.JoinKind, bool) {
 		p.advance() // consume JOIN
 		return ast.JoinKindCross, true
 
-	case tokINNER:
-		p.advance() // consume INNER
-		if p.cur.Type != tokJOIN {
-			p.restore(start)
-			return ast.JoinKindInvalid, false
-		}
-		p.advance() // consume JOIN
-		return ast.JoinKindInner, true
-
-	case tokLEFT:
-		p.advance() // consume LEFT
-		p.match(tokOUTER)
-		if p.cur.Type != tokJOIN {
-			p.restore(start)
-			return ast.JoinKindInvalid, false
-		}
-		p.advance() // consume JOIN
-		return ast.JoinKindLeft, true
-
-	case tokRIGHT:
-		p.advance() // consume RIGHT
-		p.match(tokOUTER)
-		if p.cur.Type != tokJOIN {
-			p.restore(start)
-			return ast.JoinKindInvalid, false
-		}
-		p.advance() // consume JOIN
-		return ast.JoinKindRight, true
-
-	case tokFULL:
-		p.advance() // consume FULL
-		p.match(tokOUTER)
-		if p.cur.Type != tokJOIN {
-			p.restore(start)
-			return ast.JoinKindInvalid, false
-		}
-		p.advance() // consume JOIN
-		return ast.JoinKindFull, true
-
-	case tokOUTER:
-		p.advance() // consume OUTER
-		if p.cur.Type != tokJOIN {
-			p.restore(start)
-			return ast.JoinKindInvalid, false
-		}
-		p.advance() // consume JOIN
-		return ast.JoinKindOuter, true
-
 	case tokJOIN:
 		// Bare JOIN => defaults to INNER.
 		p.advance() // consume JOIN
 		return ast.JoinKindInner, true
+	}
 
+	// joinType modifier (PartiQLParser.g4:419-425):
+	//   INNER | LEFT OUTER? | RIGHT OUTER? | FULL OUTER? | OUTER
+	var kind ast.JoinKind
+	switch p.cur.Type {
+	case tokINNER:
+		p.advance() // consume INNER
+		kind = ast.JoinKindInner
+	case tokLEFT:
+		p.advance() // consume LEFT
+		p.match(tokOUTER)
+		kind = ast.JoinKindLeft
+	case tokRIGHT:
+		p.advance() // consume RIGHT
+		p.match(tokOUTER)
+		kind = ast.JoinKindRight
+	case tokFULL:
+		p.advance() // consume FULL
+		p.match(tokOUTER)
+		kind = ast.JoinKindFull
+	case tokOUTER:
+		p.advance() // consume OUTER
+		kind = ast.JoinKindOuter
 	default:
+		return ast.JoinKindInvalid, false
+	}
+
+	// After a joinType modifier the grammar permits either form:
+	//   joinType JOIN  rhs joinSpec   (#TableQualifiedJoin)        -> kind
+	//   joinType CROSS JOIN rhs       (#TableCrossJoin, g4:390)    -> CROSS
+	// A modifier preceding CROSS JOIN is grammar-legal; the result is a cross
+	// join (the modifier is discarded — a cross join carries no ON). Anything
+	// else is a dangling modifier and must rewind so the caller rejects it.
+	switch p.cur.Type {
+	case tokJOIN:
+		p.advance() // consume JOIN
+		return kind, true
+	case tokCROSS:
+		p.advance() // consume CROSS
+		if p.cur.Type != tokJOIN {
+			p.restore(start)
+			return ast.JoinKindInvalid, false
+		}
+		p.advance() // consume JOIN
+		return ast.JoinKindCross, true
+	default:
+		p.restore(start)
 		return ast.JoinKindInvalid, false
 	}
 }

--- a/partiql/parser/select_coverage_test.go
+++ b/partiql/parser/select_coverage_test.go
@@ -164,12 +164,31 @@ func TestSelectCoverage_ModifierCrossJoin(t *testing.T) {
 		{"right_outer_cross", "SELECT a FROM t RIGHT OUTER CROSS JOIN t2"},
 		{"full_outer_cross", "SELECT a FROM t FULL OUTER CROSS JOIN t2"},
 	}
+	// A joinType modifier before CROSS JOIN is grammar-legal and yields a cross
+	// join (the modifier is discarded — a cross join has no ON), so every input
+	// parses to the SAME AST as the bare `CROSS JOIN` form (see
+	// TestSelectCoverage_CrossJoinSpec for the bare golden).
+	const wantCross = "SelectStmt{Targets:[TargetEntry{Expr:VarRef{Name:a}}] From:JoinExpr{Kind:CROSS Left:VarRef{Name:t} Right:VarRef{Name:t2}}}"
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Skip("DIVERGENCE: omni rejects `<joinType> CROSS JOIN` " +
-				"(tryParseJoinType in from.go handles only bare CROSS JOIN); " +
-				"ANTLR/PartiQLParser.g4:390 TableCrossJoin `lhs joinType? CROSS JOIN rhs` accepts it. " +
-				"Residual omni bug; input: " + tc.input)
+			runAcceptGolden(t, tc.input, wantCross)
+		})
+	}
+}
+
+// TestSelectCoverage_ModifierCrossJoinReject locks the reject branch of the
+// `joinType? CROSS JOIN` form: even with a modifier, CROSS must be followed by
+// JOIN. Oracle (ANTLR/PartiQLParser.g4:390): `<mod> CROSS` not followed by JOIN
+// is a syntax error (the modifier rewinds and the leftover token fails at EOF).
+func TestSelectCoverage_ModifierCrossJoinReject(t *testing.T) {
+	cases := []struct{ name, input string }{
+		{"full_cross_no_join", "SELECT a FROM t FULL CROSS t2"},
+		{"left_cross_eof", "SELECT a FROM t LEFT CROSS"},
+		{"inner_cross_no_join", "SELECT a FROM t INNER CROSS t2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runReject(t, tc.input)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Fixes the two residual divergences the PartiQL negative-test backfill surfaced (oracle = executable ANTLR parser). Both in-tree `t.Skip` divergence tests are **un-skipped** to assert the corrected behavior.

### B12 — `parser-select`: accept modifier-prefixed `CROSS JOIN`
`tryParseJoinType` (from.go) only recognized a bare `CROSS JOIN`; a join-type modifier before it (`FULL CROSS JOIN`, `LEFT OUTER CROSS JOIN`, `INNER CROSS JOIN`, …) was rewound by the dangling-modifier guard → rejected. Grammar `PartiQLParser.g4:390` `tableReference joinType? CROSS JOIN joinRhs` makes the modifier legal; the result is a cross join (modifier discarded, no `ON`). Restructured so a parsed modifier may be followed by **either** `JOIN` (qualified join) **or** `CROSS JOIN` (cross join); a dangling modifier still rewinds + rejects.

- Un-skipped `TestSelectCoverage_ModifierCrossJoin` (8 inputs → all assert the exact bare-`CROSS JOIN` AST).
- Added `TestSelectCoverage_ModifierCrossJoinReject` (locks the `<mod> CROSS` not-followed-by-`JOIN` reject branch).

### B13 — `completion`: dotted path-step `x.from` is not a FROM clause
`isInFromContext` did `strings.HasSuffix(upper, "FROM")`, matching `"SELECT X.FROM"` and wrongly suggesting all tables. Now `FROM`/`JOIN`/`INTO` match only as **standalone keywords** (preceded by whitespace or start-of-string), so a `.`-prefixed path step is not a clause keyword. Un-skipped `TestCompletePathStepNotFromKeyword`.

## Verification
- Oracle: executable ANTLR parser (truth2) + `PartiQLParser.g4`.
- `go build ./partiql/...`, `go vet`, `go test -race ./partiql/parser/ ./partiql/completion/`, `go test ./partiql/...` — all green (incl. both un-skipped tests now passing, not skipping).
- All existing join + completion tests unchanged/green (dangling-modifier rejection preserved; real `FROM`/`JOIN`/`INTO` contexts still detected).

## Review note
Codex auth is expired (account-wide) and the `/code-review` agent fan-out is being rate-limited, so this was authored + traced manually against the oracle-derived test suite. Scope: 4 files (2 source, 2 test).