### PR TITLE
feat(googlesql/analysis): query-span + classification feature node

### DIFF
--- a/googlesql/analysis/classify.go
+++ b/googlesql/analysis/classify.go
@@ -1,0 +1,223 @@
+// Package analysis provides Bytebase-facing query analysis for GoogleSQL — the
+// SQL dialect shared by Google BigQuery and Google Cloud Spanner. It ships two
+// concerns the legacy plugin/parser/{bigquery,spanner} packages provide today:
+//
+//   - statement classification (the legacy queryTypeListener: Select / DML /
+//     DDL / Explain / SelectInfoSchema), and
+//   - query-span extraction (table/column lineage for masking and SQL-editor
+//     access tracking — the legacy querySpanExtractor + accessTableListener).
+//
+// It is built on the hand-written googlesql/parser AST (one parser serves both
+// engines) and is parameterized by Dialect for the three genuine bigquery vs
+// spanner seams the contract identifies (contract.md §4): the metadata model
+// (BigQuery project.dataset.table vs Spanner db.schema.table), the system-schema
+// set (BigQuery INFORMATION_SCHEMA vs Spanner INFORMATION_SCHEMA + SPANNER_SYS),
+// and the default unqualified-join semantics. Everything else is shared.
+//
+// Scope (matching the merged omni peers trino/analysis, doris/analysis,
+// snowflake/analysis): the extraction is parser-driven and best-effort. It does
+// NOT resolve names against live catalog metadata (the legacy
+// GetDatabaseMetadataFunc path) nor expand `SELECT *` against a schema — that
+// metadata-aware resolution belongs to the bytebase-switch layer, which maps
+// these local types onto base.QuerySpan. This package produces the structural
+// lineage the parser alone can determine.
+package analysis
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/googlesql/ast"
+	"github.com/bytebase/omni/googlesql/parser"
+)
+
+// Dialect selects the bigquery vs spanner behavior for the three contract
+// divergences. One GoogleSQL parser+AST serves both; this enum carries the
+// per-dialect deltas (system schemas, name-part bucketing, default join type)
+// down into the shared analysis code.
+type Dialect int
+
+const (
+	// DialectBigQuery is Google BigQuery. Metadata model: project.dataset.table
+	// (no schema layer; a dataset is the database). System schema:
+	// INFORMATION_SCHEMA only. Default unqualified join: CROSS.
+	DialectBigQuery Dialect = iota
+	// DialectSpanner is Google Cloud Spanner. Metadata model: db.schema.table
+	// (named schemas under one database). System schemas: INFORMATION_SCHEMA and
+	// SPANNER_SYS. Default unqualified join: INNER.
+	DialectSpanner
+)
+
+// String returns a human-readable dialect name.
+func (d Dialect) String() string {
+	switch d {
+	case DialectBigQuery:
+		return "BIGQUERY"
+	case DialectSpanner:
+		return "SPANNER"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// QueryType classifies a GoogleSQL statement. The values mirror bytebase's
+// base.QueryType so the bytebase-switch node can map them 1:1 (the legacy
+// queryTypeListener emits exactly this set: Select, DDL, DML, Explain,
+// SelectInfoSchema, plus QueryTypeUnknown).
+type QueryType int
+
+const (
+	// Unknown is returned for empty input, a parse failure, or an unrecognized
+	// statement node (the legacy base.QueryTypeUnknown).
+	Unknown QueryType = iota
+	// Select is a read-only user query (query_statement) that does not read
+	// exclusively from a system/information schema.
+	Select
+	// Explain is an EXPLAIN statement (explain_statement). Reserved for
+	// forward-compatibility: the merged parser foundation does not yet build an
+	// EXPLAIN node (its dispatch case is stubbed), so ClassifySQL does not emit
+	// Explain today — but Classify maps the node type when parser-utility lands.
+	Explain
+	// SelectInfoSchema is a read-only query that reads EXCLUSIVELY from a
+	// system/information schema (the legacy allSystems case of a Select).
+	SelectInfoSchema
+	// DDL changes schema: CREATE/ALTER/DROP over TABLE/VIEW/INDEX/SCHEMA/DATABASE,
+	// plus GRANT/REVOKE (the legacy DDL rule list).
+	DDL
+	// DML changes table data: INSERT/UPDATE/DELETE/MERGE/TRUNCATE (the legacy DML
+	// rule list; CALL is DML in the legacy listener but is not yet a merged node).
+	DML
+)
+
+// String returns a human-readable name for the QueryType. The spellings match
+// bytebase's base.QueryType.String() so logs/tests read identically across the
+// legacy and omni stacks.
+func (q QueryType) String() string {
+	switch q {
+	case Select:
+		return "SELECT"
+	case Explain:
+		return "EXPLAIN"
+	case SelectInfoSchema:
+		return "SELECT_INFO_SCHEMA"
+	case DDL:
+		return "DDL"
+	case DML:
+		return "DML"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Classify returns the QueryType for a single parsed statement node, in the
+// given dialect.
+//
+// It type-switches over the concrete googlesql/ast statement nodes the merged
+// parser builds (query / DML / DDL / DCL). A query statement is reported as
+// Select, then promoted to SelectInfoSchema when the statement reads exclusively
+// from a system/information schema — exactly the legacy queryTypeListener's
+// `allSystems` rule, evaluated here by walking the parsed AST's table paths
+// (the legacy accessTableListener) rather than re-scanning the source text.
+//
+// A nil or unrecognized node yields Unknown.
+func Classify(node ast.Node, dialect Dialect) QueryType {
+	if node == nil {
+		return Unknown
+	}
+	switch node.(type) {
+	// Query (query_statement) — Select, possibly promoted to SelectInfoSchema.
+	case *ast.QueryStmt, *ast.SelectStmt, *ast.SetOperation:
+		if isAllSystemQuery(node, dialect) {
+			return SelectInfoSchema
+		}
+		return Select
+
+	// DML (dml_statement / merge_statement / truncate_statement).
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt,
+		*ast.MergeStmt, *ast.TruncateStmt:
+		return DML
+
+	// DDL — CREATE / ALTER / DROP over table-like objects.
+	case *ast.CreateTableStmt, *ast.CreateViewStmt, *ast.CreateIndexStmt,
+		*ast.CreateSchemaStmt, *ast.CreateDatabaseStmt,
+		*ast.AlterStmt, *ast.DropStmt:
+		return DDL
+
+	// DCL — GRANT / REVOKE are DDL in the legacy listener (its rule list groups
+	// privilege statements under DDL alongside CREATE/ALTER/DROP).
+	case *ast.GrantStmt, *ast.RevokeStmt:
+		return DDL
+
+	default:
+		return Unknown
+	}
+}
+
+// ClassifySQL parses the first statement in sql (best-effort) and returns its
+// QueryType in the given dialect. Parse errors are tolerated — the first
+// successfully-parsed statement node is classified; empty/whitespace/comment-only
+// input or a total parse failure yields Unknown.
+func ClassifySQL(sql string, dialect Dialect) QueryType {
+	return ClassifyFromFile(parseFile(sql), dialect)
+}
+
+// ClassifyFromFile classifies the first statement of an already-parsed file.
+// Returns Unknown for a nil/empty file.
+func ClassifyFromFile(file *ast.File, dialect Dialect) QueryType {
+	if file == nil || len(file.Stmts) == 0 {
+		return Unknown
+	}
+	return Classify(file.Stmts[0], dialect)
+}
+
+// parseFile runs the best-effort GoogleSQL parser and returns the parsed file
+// (which always reflects whatever statements parsed, even on error). It is the
+// single parse entry point both classification and query-span share, so they
+// never disagree about which statement is "first".
+func parseFile(sql string) *ast.File {
+	file, _ := parser.Parse(sql)
+	return file
+}
+
+// isAllSystemQuery reports whether a query node reads EXCLUSIVELY from system
+// (INFORMATION_SCHEMA / — Spanner — SPANNER_SYS) tables. It is the AST analogue
+// of the legacy isMixedQuery()'s allSystems result, evaluated over the access
+// tables the query references. A query with no table references at all (e.g.
+// `SELECT 1`) is NOT all-system (it has no user tables, but the legacy code only
+// returns allSystems when at least one system table is present:
+// `!hasUser && hasSystem`).
+func isAllSystemQuery(node ast.Node, dialect Dialect) bool {
+	tables := collectAccessTables(node, dialect)
+	hasSystem, hasUser := false, false
+	for _, ta := range tables {
+		if ta.IsSystem {
+			hasSystem = true
+		} else {
+			hasUser = true
+		}
+	}
+	return hasSystem && !hasUser
+}
+
+// systemSchemas returns the schema names that mark a system/information-schema
+// reference for the given dialect. BigQuery: INFORMATION_SCHEMA only. Spanner:
+// INFORMATION_SCHEMA and SPANNER_SYS (contract.md §4; oracle.md).
+func systemSchemas(dialect Dialect) []string {
+	switch dialect {
+	case DialectSpanner:
+		return []string{"INFORMATION_SCHEMA", "SPANNER_SYS"}
+	default:
+		return []string{"INFORMATION_SCHEMA"}
+	}
+}
+
+// isSystemSchemaName reports whether name equals (case-insensitively) one of the
+// dialect's system schema names. Matches the legacy isSystemResource (BigQuery:
+// EqualFold INFORMATION_SCHEMA; Spanner: INFORMATION_SCHEMA OR SPANNER_SYS).
+func isSystemSchemaName(name string, dialect Dialect) bool {
+	for _, s := range systemSchemas(dialect) {
+		if strings.EqualFold(name, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/googlesql/analysis/classify_test.go
+++ b/googlesql/analysis/classify_test.go
@@ -1,0 +1,144 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+func TestClassifySQL(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want QueryType
+	}{
+		// --- SELECT family ---
+		{"plain select", "SELECT 1", Select},
+		{"select from", "SELECT a, b FROM t", Select},
+		{"select star", "SELECT * FROM t", Select},
+		{"with cte", "WITH c AS (SELECT 1 AS n) SELECT n FROM c", Select},
+		{"set op union", "SELECT a FROM t UNION ALL SELECT a FROM u", Select},
+		{"parenthesized query", "(SELECT 1) UNION ALL (SELECT 2)", Select},
+
+		// --- DML ---
+		{"insert", "INSERT INTO t (a) VALUES (1)", DML},
+		{"insert select", "INSERT INTO t SELECT a FROM u", DML},
+		{"insert or update (spanner upsert)", "INSERT OR UPDATE INTO t (a) VALUES (1)", DML},
+		{"update", "UPDATE t SET a = 1 WHERE b = 2", DML},
+		{"delete", "DELETE FROM t WHERE a = 1", DML},
+		{"merge", "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE", DML},
+		{"truncate", "TRUNCATE TABLE t", DML},
+
+		// --- DDL ---
+		{"create table", "CREATE TABLE t (a INT64) PRIMARY KEY (a)", DDL},
+		{"create view", "CREATE VIEW v AS SELECT 1", DDL},
+		{"create index", "CREATE INDEX idx ON t (a)", DDL},
+		{"create schema", "CREATE SCHEMA s", DDL},
+		{"create database", "CREATE DATABASE d", DDL},
+		{"alter table", "ALTER TABLE t ADD COLUMN b INT64", DDL},
+		{"drop table", "DROP TABLE t", DDL},
+		{"drop view", "DROP VIEW v", DDL},
+		{"grant", "GRANT SELECT ON t TO 'user@example.com'", DDL},
+		{"revoke", "REVOKE SELECT ON t FROM 'user@example.com'", DDL},
+
+		// --- Unknown / empty ---
+		{"empty", "", Unknown},
+		{"whitespace only", "   \n  ", Unknown},
+		{"comment only", "-- just a comment\n", Unknown},
+		{"garbage", "this is not sql", Unknown},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifySQL(tc.sql, DialectBigQuery)
+			if got != tc.want {
+				t.Errorf("ClassifySQL(%q) = %v, want %v", tc.sql, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassify_InfoSchema covers the SelectInfoSchema promotion, which is
+// dialect-specific: BigQuery promotes only on INFORMATION_SCHEMA; Spanner
+// promotes on INFORMATION_SCHEMA or SPANNER_SYS. The promotion fires only for
+// SELECT-family statements that read EXCLUSIVELY system tables.
+func TestClassify_InfoSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		wantBQ      QueryType
+		wantSpanner QueryType
+	}{
+		{
+			name:        "information_schema both",
+			sql:         "SELECT * FROM INFORMATION_SCHEMA.TABLES",
+			wantBQ:      SelectInfoSchema,
+			wantSpanner: SelectInfoSchema,
+		},
+		{
+			name:        "dataset qualified information_schema",
+			sql:         "SELECT * FROM mydataset.INFORMATION_SCHEMA.COLUMNS",
+			wantBQ:      SelectInfoSchema,
+			wantSpanner: SelectInfoSchema,
+		},
+		{
+			name:        "spanner_sys only spanner",
+			sql:         "SELECT * FROM SPANNER_SYS.QUERY_STATS_TOP_MINUTE",
+			wantBQ:      Select, // BigQuery has no SPANNER_SYS notion
+			wantSpanner: SelectInfoSchema,
+		},
+		{
+			name:        "user table stays select",
+			sql:         "SELECT * FROM mydataset.users",
+			wantBQ:      Select,
+			wantSpanner: Select,
+		},
+		{
+			name:        "non-select referencing info schema is not promoted",
+			sql:         "CREATE VIEW v AS SELECT * FROM INFORMATION_SCHEMA.TABLES",
+			wantBQ:      DDL,
+			wantSpanner: DDL,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifySQL(tc.sql, DialectBigQuery); got != tc.wantBQ {
+				t.Errorf("BigQuery ClassifySQL(%q) = %v, want %v", tc.sql, got, tc.wantBQ)
+			}
+			if got := ClassifySQL(tc.sql, DialectSpanner); got != tc.wantSpanner {
+				t.Errorf("Spanner ClassifySQL(%q) = %v, want %v", tc.sql, got, tc.wantSpanner)
+			}
+		})
+	}
+}
+
+func TestClassify_Node(t *testing.T) {
+	// nil node is Unknown.
+	if got := Classify(nil, DialectBigQuery); got != Unknown {
+		t.Errorf("Classify(nil) = %v, want Unknown", got)
+	}
+	// An unrecognized node type is Unknown.
+	if got := Classify(&ast.File{}, DialectBigQuery); got != Unknown {
+		t.Errorf("Classify(*ast.File) = %v, want Unknown", got)
+	}
+}
+
+func TestQueryType_String(t *testing.T) {
+	tests := []struct {
+		qt   QueryType
+		want string
+	}{
+		{Unknown, "UNKNOWN"},
+		{Select, "SELECT"},
+		{Explain, "EXPLAIN"},
+		{SelectInfoSchema, "SELECT_INFO_SCHEMA"},
+		{DDL, "DDL"},
+		{DML, "DML"},
+	}
+	for _, tc := range tests {
+		if got := tc.qt.String(); got != tc.want {
+			t.Errorf("QueryType(%d).String() = %q, want %q", tc.qt, got, tc.want)
+		}
+	}
+}

--- a/googlesql/analysis/oracle_test.go
+++ b/googlesql/analysis/oracle_test.go
@@ -1,0 +1,215 @@
+//go:build googlesql_oracle
+
+// Differential test for the googlesql/analysis node against the live Cloud
+// Spanner emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/analysis/ -run TestAnalysisDifferential
+//
+// analysis is a FEATURE node, so the oracle is NOT used to adjudicate a grammar
+// accept/reject — that is the parser nodes' job (parser/*_oracle_test.go). What
+// the oracle pins HERE is that the SQL the classify/span tests assert over is
+// REAL GoogleSQL syntax the grammar accepts: if a corpus statement the tests
+// treat as a valid query were actually rejected by the emulator, the
+// classification/lineage assertions built on it would be meaningless. The oracle
+// therefore confirms the grammar verdict for the whole classify corpus and
+// cross-checks the read-only classification against the statement's true nature.
+//
+// The emulator speaks Spanner's dialect, a SUBSET of the BigQuery+Spanner union
+// (oracle.md). The corpus below is restricted to forms whose Spanner GRAMMAR
+// verdict is authoritative: shared GoogleSQL core (SELECT/FROM/JOIN/CTE/set-op),
+// DML (INSERT/UPDATE/DELETE), and DDL (CREATE/DROP/ALTER) — all of which the
+// emulator parses. BigQuery-only forms whose Spanner verdict is non-authoritative
+// (dashed paths, MERGE, TRUNCATE) are covered by the hand-written unit tests +
+// the divergence ledger instead, NOT here.
+//
+// The harness classifies a statement that PARSES but is then feature-rejected
+// ("X is not supported") as ACCEPT (message-prefix rule, oracle.md), so a
+// union-grammar form that Spanner feature-rejects is still a valid accept fixture.
+package analysis
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+	"github.com/bytebase/omni/googlesql/parser"
+)
+
+// parseFirstStmt parses sql and returns its first statement node, failing the
+// test if nothing parsed (the corpus is curated to parse cleanly).
+func parseFirstStmt(t *testing.T, sql string) ast.Node {
+	t.Helper()
+	file, _ := parser.Parse(sql)
+	if file == nil || len(file.Stmts) == 0 {
+		t.Fatalf("no statement parsed from %q", sql)
+	}
+	return file.Stmts[0]
+}
+
+// classifyCorpus pairs each statement with the QueryType the analysis classifier
+// must report (in the dialect noted) and whether it is read-only. Every entry is
+// expected to be ACCEPTED by the emulator's grammar (wantAccept implicitly true);
+// the differential fails loudly if the oracle rejects one, because that would
+// mean the classification assertion rests on invalid syntax.
+var classifyCorpus = []struct {
+	sql        string
+	dialect    Dialect
+	wantType   QueryType
+	isReadOnly bool
+}{
+	// --- read-only queries ---
+	{"SELECT a FROM t", DialectSpanner, Select, true},
+	{"SELECT * FROM t1 JOIN t2 ON t1.id = t2.id", DialectSpanner, Select, true},
+	{"WITH c AS (SELECT a FROM t) SELECT a FROM c", DialectSpanner, Select, true},
+	{"SELECT a FROM t WHERE b IN (SELECT b FROM t2)", DialectSpanner, Select, true},
+	{"SELECT a FROM t UNION ALL SELECT a2 FROM t2", DialectSpanner, Select, true},
+	{"SELECT * FROM INFORMATION_SCHEMA.TABLES", DialectSpanner, SelectInfoSchema, true},
+	{"SELECT * FROM SPANNER_SYS.QUERY_STATS_TOP_MINUTE", DialectSpanner, SelectInfoSchema, true},
+	// --- data-changing (DML) ---
+	{"INSERT INTO t (a) VALUES (1)", DialectSpanner, DML, false},
+	{"DELETE FROM t WHERE a = 1", DialectSpanner, DML, false},
+	{"UPDATE t SET a = 2 WHERE a = 1", DialectSpanner, DML, false},
+	// --- schema-changing (DDL) ---
+	{"CREATE TABLE t3 (a INT64) PRIMARY KEY (a)", DialectSpanner, DDL, false},
+	{"DROP TABLE t3", DialectSpanner, DDL, false},
+	{"ALTER TABLE t ADD COLUMN c INT64", DialectSpanner, DDL, false},
+}
+
+// TestAnalysisDifferential confirms each corpus statement's grammar verdict
+// against the live emulator and that the analysis classifier's read-only verdict
+// agrees with the statement's true (read-only vs data/schema-changing) nature.
+func TestAnalysisDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live differential")
+	}
+	h := newAnalysisHarness(t)
+	defer h.close()
+
+	for _, tc := range classifyCorpus {
+		tc := tc
+		t.Run(tc.sql, func(t *testing.T) {
+			v := h.verdict(t, tc.sql)
+			switch v.Verdict {
+			case "accept", "reject":
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; fix the wrapper/emulator — do NOT treat as accept/reject",
+					tc.sql, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, tc.sql)
+			}
+			if v.Verdict != "accept" {
+				t.Fatalf("emulator REJECTED corpus statement %q (%s: %s) — the analysis assertions on it rest on invalid syntax",
+					tc.sql, v.Reason, v.Message)
+			}
+
+			// Cross-check: the classifier puts the statement on the correct side of
+			// the read-only line, and reports the expected type.
+			gotType := Classify(parseFirstStmt(t, tc.sql), tc.dialect)
+			if gotType != tc.wantType {
+				t.Errorf("Classify(%q) = %v, want %v", tc.sql, gotType, tc.wantType)
+			}
+			if got := isReadOnly(gotType); got != tc.isReadOnly {
+				t.Errorf("isReadOnly(%q) = %v (type %v), want %v", tc.sql, got, gotType, tc.isReadOnly)
+			}
+		})
+	}
+}
+
+// isReadOnly mirrors the bytebase read-only guard: a statement is read-only iff
+// it is a Select, Explain, or SelectInfoSchema.
+func isReadOnly(qt QueryType) bool {
+	return qt == Select || qt == Explain || qt == SelectInfoSchema
+}
+
+// --- harness plumbing (one persistent batch process; mirrors the parser
+// package's *_oracle_test.go harness) ---
+
+type analysisHarnessVerdict struct {
+	Verdict string `json:"verdict"`
+	Kind    string `json:"kind"`
+	Reason  string `json:"reason"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type analysisHarness struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	mu     sync.Mutex
+}
+
+func newAnalysisHarness(t *testing.T) *analysisHarness {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	projDir := filepath.Join(repoRoot, "harness", "googlesql-spanner")
+	if _, err := os.Stat(projDir); err != nil {
+		t.Skipf("harness project not found at %s", projDir)
+	}
+
+	bin := filepath.Join(projDir, "googlesql-spanner")
+	if _, err := os.Stat(bin); err != nil {
+		build := exec.Command("go", "build", "-o", bin, ".")
+		build.Dir = projDir
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("building harness failed: %v\n%s", err, out)
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(), "GOOGLESQL_HARNESS_LINE=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting harness: %v", err)
+	}
+	return &analysisHarness{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdoutPipe)}
+}
+
+func (h *analysisHarness) verdict(t *testing.T, stmt string) analysisHarnessVerdict {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	enc := base64.StdEncoding.EncodeToString([]byte(stmt))
+	if _, err := fmt.Fprintln(h.stdin, enc); err != nil {
+		t.Fatalf("writing to harness: %v", err)
+	}
+	line, err := h.stdout.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading harness verdict: %v", err)
+	}
+	var v analysisHarnessVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &v); err != nil {
+		t.Fatalf("decoding harness verdict %q: %v", line, err)
+	}
+	return v
+}
+
+func (h *analysisHarness) close() {
+	if h.stdin != nil {
+		_ = h.stdin.Close()
+	}
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Wait()
+	}
+}

--- a/googlesql/analysis/query_span.go
+++ b/googlesql/analysis/query_span.go
@@ -1,0 +1,1289 @@
+package analysis
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// QuerySpan captures the tables and columns a GoogleSQL statement references. It
+// is the data structure Bytebase consumes for field-level lineage (masking) and
+// for SQL-editor access tracking (read/write permission checks); it is the omni
+// counterpart of the legacy plugin/parser/{bigquery,spanner} GetQuerySpan result
+// (which the bytebase-switch node maps onto base.QuerySpan).
+//
+// The extraction is best-effort and parser-driven: it walks the fully-connected
+// AST the googlesql/parser produces (subqueries are already parsed into real
+// QueryStmt nodes by the parser, so the walk reaches them directly — no
+// re-parsing of raw text). Known best-effort boundaries (each a deliberate scope
+// decision matching the merged trino/doris/snowflake analysis peers — full
+// catalog-aware resolution belongs to the bytebase-switch layer):
+//   - `SELECT *` is not expanded against catalog metadata; a star item is
+//     recorded by name only ("*", or "t.*" for a qualified star).
+//   - A column reference is recorded by its written qualifier parts; it is not
+//     resolved to which FROM relation actually owns it.
+//   - Table-valued-function and UNNEST sources contribute their argument column
+//     references (as predicates) but no resolved output columns.
+type QuerySpan struct {
+	// Type is the statement classification (Select / SelectInfoSchema / DML / DDL
+	// / Explain / Unknown).
+	Type QueryType
+
+	// AccessTables is the set of base tables the statement reads from or writes
+	// to: every physical table path in FROM clauses, JOINs, subqueries, and DML/
+	// DDL targets. Entries are deduplicated on (catalog, schema, table, alias);
+	// CTE references and derived-table aliases are excluded.
+	AccessTables []TableAccess
+
+	// Results is the list of output columns produced by the outermost query (for
+	// a query statement). For a set operation the left arm wins, matching SQL's
+	// "column names come from the first select" rule. Empty for non-query
+	// statements.
+	Results []ColumnInfo
+
+	// PredicateColumns is the set of columns referenced in filter/join positions
+	// (WHERE, JOIN ON / USING, HAVING, QUALIFY, GROUP BY). Deduplicated.
+	PredicateColumns []ColumnRef
+
+	// CTEs lists the names defined by WITH clauses at any scope, in declaration
+	// order.
+	CTEs []string
+}
+
+// TableAccess represents one physical table referenced in a statement. The
+// qualifier fields are dialect-bucketed (contract.md §4): for BigQuery a
+// 2-part name is dataset.table (Database.Table, no Schema) unless the qualifier
+// is INFORMATION_SCHEMA; for Spanner a 2-part name is schema.table. The
+// rightmost component is always the table.
+type TableAccess struct {
+	Catalog  string  // optional catalog/project qualifier (empty when none)
+	Database string  // optional database/dataset qualifier (empty when none)
+	Schema   string  // optional schema qualifier (empty when none)
+	Table    string  // table (or view) name
+	Alias    string  // alias at the reference site (empty when none)
+	IsSystem bool     // true when the reference is to a system/information schema
+	Loc      ast.Loc // source location of the table reference
+}
+
+// ColumnInfo represents one output column of a query result.
+type ColumnInfo struct {
+	// Name is the output column name: the explicit alias if present, otherwise a
+	// best-effort rendering (the column name for a bare column reference, "*"/
+	// "t.*" for a star item, or "" when none can be derived).
+	Name string
+
+	// SourceColumns is the best-effort list of column references that directly
+	// feed this output column (the column refs in the select-item expression,
+	// excluding those inside nested subqueries).
+	SourceColumns []ColumnRef
+}
+
+// ColumnRef identifies a column by its optional qualifier parts and its name.
+// The rightmost component is always the column.
+type ColumnRef struct {
+	Catalog  string
+	Database string
+	Schema   string
+	Table    string
+	Column   string
+}
+
+// GetQuerySpan analyzes a single GoogleSQL statement in the given dialect and
+// returns its query span: the statement classification, the base tables it
+// touches, the CTE names it defines, its output columns with their source
+// columns, and the columns used in predicate positions.
+//
+// It is tolerant of parse errors — if the parser produces a partial AST, whatever
+// parsed is still analyzed. On empty input it returns a zero-valued span with
+// Type=Unknown.
+func GetQuerySpan(statement string, dialect Dialect) (*QuerySpan, error) {
+	file := parseFile(statement)
+	span := &QuerySpan{Type: ClassifyFromFile(file, dialect)}
+	if file == nil || len(file.Stmts) == 0 {
+		return span, nil
+	}
+
+	w := newSpanWalker(span, dialect)
+	w.analyzeStmt(file.Stmts[0])
+	return span, nil
+}
+
+// ---------------------------------------------------------------------------
+// CTE scope
+// ---------------------------------------------------------------------------
+
+// cteScope is a linked stack of CTE name sets. Resolving a bare table reference
+// walks outwards; an inner CTE shadows an outer one of the same name. GoogleSQL
+// unquoted identifiers are case-insensitive for resolution, so CTE names are
+// compared case-folded (matching the legacy findTableSchema's EqualFold CTE
+// lookup).
+type cteScope struct {
+	names  map[string]bool
+	parent *cteScope
+}
+
+func (s *cteScope) isCTE(name string) bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.names[strings.ToLower(name)] {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Walker
+// ---------------------------------------------------------------------------
+
+// spanWalker walks the connected googlesql AST to populate a QuerySpan. It
+// maintains a CTE scope stack (so bare references that name a CTE are filtered
+// out of AccessTables), dedup maps for AccessTables and PredicateColumns, the
+// current SELECT block's FROM aliases (so a correlated array/field path off an
+// earlier FROM source is not mistaken for a base table), and a flag tracking
+// whether the outermost query has populated Results.
+type spanWalker struct {
+	span        *QuerySpan
+	dialect     Dialect
+	scope       *cteScope
+	fromAliases map[string]bool // alias + bare table name of the current SELECT's FROM sources
+	accessed    map[tableKey]bool
+	predSeen    map[ColumnRef]bool
+	resolved    bool // Results captured for the outermost query
+}
+
+type tableKey struct {
+	Catalog  string
+	Database string
+	Schema   string
+	Table    string
+	Alias    string
+}
+
+func newSpanWalker(span *QuerySpan, dialect Dialect) *spanWalker {
+	return &spanWalker{
+		span:     span,
+		dialect:  dialect,
+		accessed: make(map[tableKey]bool),
+		predSeen: make(map[ColumnRef]bool),
+	}
+}
+
+// analyzeStmt dispatches on the top-level statement node. A query statement
+// yields full query-span data (results + predicates + tables); DML/DDL
+// statements have their bodies walked for the tables they touch (masking and
+// access tracking care about INSERT/UPDATE/DELETE/CTAS targets and sources).
+func (w *spanWalker) analyzeStmt(node ast.Node) {
+	switch n := node.(type) {
+	case *ast.QueryStmt:
+		w.visitQueryStmt(n, true /* outermost */)
+	case *ast.SelectStmt:
+		w.visitSelect(n, true)
+	case *ast.SetOperation:
+		w.visitSetOp(n, true)
+	case *ast.InsertStmt:
+		w.visitInsert(n)
+	case *ast.UpdateStmt:
+		w.visitUpdate(n)
+	case *ast.DeleteStmt:
+		w.visitDelete(n)
+	case *ast.MergeStmt:
+		w.visitMerge(n)
+	case *ast.TruncateStmt:
+		w.recordTable(n.Target, "")
+		w.walkPredicate(n.Where)
+	default:
+		// DDL and everything else: walk for table references generically. The
+		// generic table-discovery pass records every PathExpr that sits in a
+		// table position (CTAS source, VIEW body, the target name).
+		w.discoverTables(node)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Query / SELECT / set-op
+// ---------------------------------------------------------------------------
+
+// visitQueryStmt walks a QueryStmt (optional WITH + body + trailing ORDER BY/
+// LIMIT/OFFSET). CTE names enter scope PROGRESSIVELY: a non-recursive CTE body
+// sees only the siblings declared BEFORE it (GoogleSQL non-recursive WITH
+// visibility, matching the legacy extractor's sequential recordCTE — a forward
+// reference to a later sibling resolves to a base table, not the CTE). A
+// RECURSIVE WITH additionally makes a CTE's OWN name visible inside its body (so
+// the recursive self-reference is filtered out, not recorded as a base table).
+func (w *spanWalker) visitQueryStmt(q *ast.QueryStmt, outermost bool) {
+	if q == nil {
+		return
+	}
+
+	scope := &cteScope{names: make(map[string]bool), parent: w.scope}
+	w.scope = scope
+
+	if q.With != nil {
+		recursive := q.With.Recursive
+		// Walk CTE bodies in declaration order, adding each name to scope at the
+		// right moment so earlier-sibling (and, when RECURSIVE, self) references are
+		// filtered while later-sibling names still resolve to base tables.
+		for _, cte := range q.With.CTEs {
+			if cte == nil || cte.Name == "" {
+				continue
+			}
+			w.span.CTEs = append(w.span.CTEs, cte.Name)
+			lower := strings.ToLower(cte.Name)
+			// RECURSIVE: the name is visible inside its own body.
+			if recursive {
+				scope.names[lower] = true
+			}
+			if cte.Query != nil {
+				w.visitBody(cte.Query, false)
+			}
+			// Non-recursive: the name becomes visible only AFTER its body (to the
+			// following siblings and the main body).
+			scope.names[lower] = true
+		}
+	}
+
+	w.visitBody(q.Body, outermost)
+
+	// Query-level ORDER BY / LIMIT / OFFSET keys may reference columns.
+	for _, item := range q.OrderBy {
+		if item != nil {
+			w.walkPredicate(item.Expr)
+		}
+	}
+	w.walkPredicate(q.Limit)
+	w.walkPredicate(q.Offset)
+
+	w.scope = scope.parent
+}
+
+// visitBody dispatches a query body / set-op operand / query primary.
+func (w *spanWalker) visitBody(node ast.Node, outermost bool) {
+	switch n := node.(type) {
+	case *ast.QueryStmt:
+		// A parenthesized ( query ) query_primary.
+		w.visitQueryStmt(n, outermost)
+	case *ast.SelectStmt:
+		w.visitSelect(n, outermost)
+	case *ast.SetOperation:
+		w.visitSetOp(n, outermost)
+	}
+}
+
+// visitSetOp walks a UNION/INTERSECT/EXCEPT tree. The left arm surfaces its
+// Results when this is the outermost statement (SQL's first-select rule); the
+// right arm never does.
+func (w *spanWalker) visitSetOp(n *ast.SetOperation, outermost bool) {
+	if n == nil {
+		return
+	}
+	w.visitBody(n.Left, outermost)
+	w.visitBody(n.Right, false)
+}
+
+// visitSelect processes one SelectStmt: its FROM relations, predicate clauses,
+// and select list.
+func (w *spanWalker) visitSelect(stmt *ast.SelectStmt, outermost bool) {
+	if stmt == nil {
+		return
+	}
+
+	// A new FROM-alias scope for this SELECT block. Populated as FROM sources are
+	// visited so a later comma-source that is a correlated array/field path off an
+	// earlier alias (e.g. `FROM T t, t.arr`) is recognized as a field path, not a
+	// base table. Saved/restored so nested SELECTs do not leak aliases.
+	prevFrom := w.fromAliases
+	w.fromAliases = map[string]bool{}
+	defer func() { w.fromAliases = prevFrom }()
+
+	for _, src := range stmt.From {
+		w.visitFromItem(src)
+	}
+
+	w.walkPredicate(stmt.Where)
+	if stmt.GroupBy != nil {
+		for _, item := range stmt.GroupBy.Items {
+			if item == nil {
+				continue
+			}
+			w.walkPredicate(item.Expr)
+			for _, e := range item.Items {
+				w.walkPredicate(e)
+			}
+		}
+	}
+	w.walkPredicate(stmt.Having)
+	w.walkPredicate(stmt.Qualify)
+	for _, win := range stmt.Window {
+		if win != nil {
+			w.walkWindowSpec(win.Spec)
+		}
+	}
+
+	// SELECT list last so Results reflects final column order.
+	for _, item := range stmt.Items {
+		if item == nil {
+			continue
+		}
+		if outermost && !w.resolved {
+			w.span.Results = append(w.span.Results, w.makeColumnInfo(item))
+		}
+		// Walk the item expression for nested-subquery tables (the direct column
+		// refs are captured in makeColumnInfo).
+		w.walkSubqueriesOnly(item.Expr)
+		if item.Modifiers != nil {
+			for _, r := range item.Modifiers.Replace {
+				if r != nil {
+					w.walkSubqueriesOnly(r.Value)
+				}
+			}
+		}
+	}
+	if outermost {
+		w.resolved = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FROM relations
+// ---------------------------------------------------------------------------
+
+// visitFromItem walks one FROM source (TableExpr / JoinExpr / UnnestExpr).
+func (w *spanWalker) visitFromItem(node ast.Node) {
+	switch n := node.(type) {
+	case *ast.TableExpr:
+		w.visitTableExpr(n)
+	case *ast.JoinExpr:
+		w.visitFromItem(n.Left)
+		w.visitFromItem(n.Right)
+		w.walkPredicate(n.On)
+		for _, col := range n.Using {
+			if col != "" {
+				w.addPredicateColumn(ColumnRef{Column: col})
+			}
+		}
+	case *ast.UnnestExpr:
+		// UNNEST(array_expr) — the array argument's columns are predicate-ish
+		// references; UNNEST produces no base-table access.
+		w.walkPredicate(n.Array)
+	}
+}
+
+// visitTableExpr handles a non-join FROM source: a base table path, a
+// parenthesized subquery, or a table-valued function call. A subquery/TVF/array-
+// path alias names a derived relation, not a base table, so it is not propagated
+// into AccessTables — but the alias IS registered in the FROM scope so a later
+// correlated path off it (`FROM (…) s, s.arr` or `FROM T t, t.arr a, a.child`)
+// is also recognized as a correlated path rather than a base table.
+func (w *spanWalker) visitTableExpr(n *ast.TableExpr) {
+	if n == nil {
+		return
+	}
+	switch {
+	case n.Subquery != nil:
+		w.visitBody(n.Subquery, false)
+		w.registerFromAlias(n.Alias)
+	case n.Func != nil:
+		// Table-valued function: its arguments may reference columns and
+		// subqueries. The argument columns are predicate-position references
+		// (they parameterize the TVF), so collect them as predicates AND recurse
+		// any subquery tables. The TVF's OUTPUT columns are unknown without a
+		// function signature, so it contributes no resolved Results — matching the
+		// legacy extractor, which rejected TVFs outright for lack of return-column
+		// info.
+		w.walkPredicate(n.Func)
+		w.registerFromAlias(n.Alias)
+	case n.Path != nil:
+		// A multi-part path whose ROOT matches an earlier FROM alias/table in this
+		// SELECT is a correlated array/field unnest (`FROM T t, t.arr`), NOT a base
+		// table — the legacy extractor treats the array-path source as a non-table
+		// (it rejected UNNEST/array sources). Record its root as a predicate column
+		// instead so the lineage still reflects the array column it walks, and
+		// register this source's own alias so a chained correlated path off it
+		// (`t.arr a, a.child`) is likewise recognized.
+		if len(n.Path.Parts) >= 2 && w.fromAliases[strings.ToLower(n.Path.Parts[0])] {
+			w.addPredicateColumn(columnRefFromParts(n.Path.Parts, w.dialect))
+			w.registerFromAlias(n.Alias)
+		} else {
+			w.recordPath(n.Path, n.Alias)
+		}
+	}
+	w.walkPredicate(n.SystemTime)
+}
+
+// registerFromAlias records a derived-relation alias (subquery / TVF / correlated
+// array-path source) in the current SELECT's FROM scope, so a later correlated
+// path off it is recognized as a field path rather than a base table. A no-op
+// when the alias is empty or there is no active FROM scope.
+func (w *spanWalker) registerFromAlias(alias string) {
+	if w.fromAliases == nil || alias == "" {
+		return
+	}
+	w.fromAliases[strings.ToLower(alias)] = true
+}
+
+// ---------------------------------------------------------------------------
+// DML
+// ---------------------------------------------------------------------------
+
+func (w *spanWalker) visitInsert(n *ast.InsertStmt) {
+	if n == nil {
+		return
+	}
+	w.recordTable(n.Target, "")
+	for _, row := range n.Rows {
+		if row == nil {
+			continue
+		}
+		for _, v := range row.Values {
+			w.walkPredicate(v)
+		}
+	}
+	if n.Query != nil {
+		w.visitBody(n.Query, false)
+	}
+	if n.TableClause != nil {
+		if n.TableClause.Path != nil {
+			w.recordPath(n.TableClause.Path, "")
+		}
+		if n.TableClause.Func != nil {
+			w.walkPredicate(n.TableClause.Func)
+		}
+		w.walkPredicate(n.TableClause.Where)
+	}
+	if n.OnConflict != nil {
+		for _, it := range n.OnConflict.SetItems {
+			if it != nil {
+				w.walkPredicate(it.Value)
+			}
+		}
+		w.walkPredicate(n.OnConflict.Where)
+	}
+	if n.Returning != nil {
+		for _, item := range n.Returning.Items {
+			if item != nil {
+				w.walkSubqueriesOnly(item.Expr)
+			}
+		}
+	}
+}
+
+func (w *spanWalker) visitUpdate(n *ast.UpdateStmt) {
+	if n == nil {
+		return
+	}
+	w.recordTable(n.Target, n.Alias)
+	for _, it := range n.Items {
+		if it == nil {
+			continue
+		}
+		w.walkPredicate(it.Value)
+		if it.Nested != nil {
+			w.analyzeStmt(it.Nested)
+		}
+	}
+	for _, src := range n.From {
+		w.visitFromItem(src)
+	}
+	w.walkPredicate(n.Where)
+	if n.Returning != nil {
+		for _, item := range n.Returning.Items {
+			if item != nil {
+				w.walkSubqueriesOnly(item.Expr)
+			}
+		}
+	}
+}
+
+func (w *spanWalker) visitDelete(n *ast.DeleteStmt) {
+	if n == nil {
+		return
+	}
+	w.recordTable(n.Target, n.Alias)
+	w.walkPredicate(n.Where)
+	if n.Returning != nil {
+		for _, item := range n.Returning.Items {
+			if item != nil {
+				w.walkSubqueriesOnly(item.Expr)
+			}
+		}
+	}
+}
+
+func (w *spanWalker) visitMerge(n *ast.MergeStmt) {
+	if n == nil {
+		return
+	}
+	w.recordTable(n.Target, n.Alias)
+	// The USING source is a TableExpr (a table path or a ( query ) subquery).
+	if src, ok := n.Source.(*ast.TableExpr); ok {
+		w.visitTableExpr(src)
+	} else {
+		w.discoverTables(n.Source)
+	}
+	w.walkPredicate(n.On)
+	for _, when := range n.Whens {
+		if when == nil {
+			continue
+		}
+		w.walkPredicate(when.And)
+		if when.Action != nil {
+			if when.Action.InsertRow != nil {
+				for _, v := range when.Action.InsertRow.Values {
+					w.walkPredicate(v)
+				}
+			}
+			for _, it := range when.Action.SetItems {
+				if it != nil {
+					w.walkPredicate(it.Value)
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Generic table discovery (DDL bodies, CTAS, VIEW bodies, merge non-TableExpr)
+// ---------------------------------------------------------------------------
+
+// discoverTables records the tables a DDL statement touches: its (table-like)
+// target name, any source tables it references (CTAS query, LIKE/CLONE/COPY
+// source, INTERLEAVE parent, FOREIGN KEY references), and embedded query bodies.
+// A full per-clause walk is unnecessary — the masking/access concern is purely
+// which tables the statement reads or writes. Embedded queries are routed through
+// the normal CTE-aware path (a raw ast.Inspect would double-count CTE names as
+// base tables).
+//
+// Only TABLE/VIEW objects contribute a target table access; SCHEMA / DATABASE /
+// INDEX names are NOT table references (recording them would pollute AccessTables
+// with non-table objects — Codex finding #3). An index's ON <table> target IS
+// recorded, and its INTERLEAVE parent too.
+func (w *spanWalker) discoverTables(node ast.Node) {
+	if node == nil {
+		return
+	}
+	switch n := node.(type) {
+	case *ast.CreateTableStmt:
+		w.recordTable(n.Name, "")
+		w.visitBody(n.AsQuery, false)
+		// Source tables a CREATE TABLE references (Codex finding #4).
+		w.recordTable(n.Like, "")
+		w.recordTable(n.Clone, "")
+		w.recordTable(n.Copy, "")
+		if n.Interleave != nil {
+			w.recordTable(n.Interleave.Parent, "")
+		}
+		w.recordConstraintRefs(n.Constraints)
+		for _, col := range n.Columns {
+			if col != nil && col.ForeignKey != nil {
+				w.recordTable(col.ForeignKey.Table, "")
+			}
+		}
+	case *ast.CreateViewStmt:
+		w.recordTable(n.Name, "")
+		w.visitBody(n.AsQuery, false)
+	case *ast.CreateIndexStmt:
+		// An index references its target table (ON <table>) and, on Spanner, its
+		// INTERLEAVE parent. The index NAME itself is not a table.
+		w.recordTable(n.Table, "")
+		w.recordTable(n.Interleave, "")
+	case *ast.AlterStmt:
+		// Only ALTER TABLE / ALTER VIEW name a table-like object; ALTER INDEX /
+		// SCHEMA / DATABASE do not (their name is not a table). An ADD CONSTRAINT
+		// FK references another table, recorded regardless of object kind guard
+		// below (the guard only gates the TARGET name).
+		if n.Object == ast.AlterTable || n.Object == ast.AlterView {
+			w.recordTable(n.Name, "")
+		}
+		for _, act := range n.Actions {
+			if act == nil {
+				continue
+			}
+			if act.Constraint != nil && act.Constraint.ForeignKey != nil {
+				w.recordTable(act.Constraint.ForeignKey.Table, "")
+			}
+			if act.Column != nil && act.Column.ForeignKey != nil {
+				w.recordTable(act.Column.ForeignKey.Table, "")
+			}
+		}
+	case *ast.DropStmt:
+		// Only DROP TABLE / DROP VIEW name a table-like object (Codex finding #3:
+		// DROP SCHEMA/DATABASE/INDEX names are not tables).
+		if n.Object == ast.DropTable || n.Object == ast.DropView {
+			w.recordTable(n.Name, "")
+		}
+	case *ast.CreateSchemaStmt, *ast.CreateDatabaseStmt:
+		// Schema/Database creates have no table reference of lineage interest.
+	default:
+		// Fallback: re-dispatch known query/DML nodes; otherwise nothing.
+		w.redispatch(node)
+	}
+}
+
+// recordConstraintRefs records the referenced table of every FOREIGN KEY
+// table-constraint in the list.
+func (w *spanWalker) recordConstraintRefs(constraints []*ast.TableConstraint) {
+	for _, c := range constraints {
+		if c != nil && c.ForeignKey != nil {
+			w.recordTable(c.ForeignKey.Table, "")
+		}
+	}
+}
+
+// redispatch routes a node back through analyzeStmt for the node kinds that
+// carry query-span data (used when discoverTables encounters an embedded
+// statement it does not special-case).
+func (w *spanWalker) redispatch(node ast.Node) {
+	switch node.(type) {
+	case *ast.QueryStmt, *ast.SelectStmt, *ast.SetOperation,
+		*ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt:
+		w.analyzeStmt(node)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Table recording
+// ---------------------------------------------------------------------------
+
+// recordPath records a base-table reference from a *PathExpr FROM source with an
+// optional alias, AND registers the source's alias + bare table name in the
+// current SELECT's FROM scope so a later correlated array/field path off this
+// source (e.g. `FROM T t, t.arr`) is recognized as a field path rather than a
+// base table (see visitTableExpr).
+func (w *spanWalker) recordPath(path *ast.PathExpr, alias string) {
+	if path == nil {
+		return
+	}
+	w.recordParts(path.Parts, alias, path.Loc)
+	if w.fromAliases != nil {
+		if alias != "" {
+			w.fromAliases[strings.ToLower(alias)] = true
+		}
+		if n := len(path.Parts); n > 0 {
+			// The bare (rightmost) table name is also a valid correlation root.
+			w.fromAliases[strings.ToLower(path.Parts[n-1])] = true
+		}
+	}
+}
+
+// recordTable records a base-table reference from a *PathExpr target (DDL/DML
+// targets are *PathExpr too).
+func (w *spanWalker) recordTable(path *ast.PathExpr, alias string) {
+	if path == nil {
+		return
+	}
+	w.recordParts(path.Parts, alias, path.Loc)
+}
+
+// recordParts buckets the dotted name components per the dialect's metadata
+// model, applies the CTE-shadowing rule for a bare name, dedups, and appends a
+// TableAccess. The qualifier bucketing is shared with column references (see
+// bucketNameParts) so a column's qualifier fields line up with the table's.
+func (w *spanWalker) recordParts(parts []string, alias string, loc ast.Loc) {
+	if len(parts) == 0 {
+		return
+	}
+
+	cat, db, schema, table := bucketNameParts(parts, w.dialect)
+
+	// Bare name: a match to an in-scope CTE is a CTE reference, not a base table.
+	if cat == "" && db == "" && schema == "" && w.scope.isCTE(table) {
+		return
+	}
+
+	ta := TableAccess{
+		Catalog:  cat,
+		Database: db,
+		Schema:   schema,
+		Table:    table,
+		Alias:    alias,
+		Loc:      loc,
+	}
+	ta.IsSystem = w.tableIsSystem(ta)
+
+	key := tableKey{
+		Catalog:  ta.Catalog,
+		Database: ta.Database,
+		Schema:   ta.Schema,
+		Table:    ta.Table,
+		Alias:    ta.Alias,
+	}
+	if w.accessed[key] {
+		return
+	}
+	w.accessed[key] = true
+	w.span.AccessTables = append(w.span.AccessTables, ta)
+}
+
+// bucketNameParts maps a dotted name's components to (catalog, database, schema,
+// table) per the dialect's metadata model. It is the single bucketing rule used
+// for BOTH table paths and column references, so a column's qualifier fields are
+// directly comparable to the accessed table's (the consistency Codex finding #1
+// flagged).
+//
+// Dialect bucketing (contract.md §4, mirroring the legacy accessTableListener):
+//   - 1 part: bare table (no qualifier).
+//   - 2 parts (X.table):
+//     - BigQuery: X is Schema iff X==INFORMATION_SCHEMA, else X is Database
+//       (dataset) — the legacy listener's INFORMATION_SCHEMA-only schema rule.
+//     - Spanner: X is always Schema (named schema under one DB).
+//   - 3 parts (X.Y.table):
+//     - BigQuery: Y is Schema iff Y==INFORMATION_SCHEMA (then X is Database),
+//       else Y is Database (dataset) and X is Catalog (project) — the
+//       project.dataset.table shape.
+//     - Spanner: Y is Schema, X is Database (db.schema.table — Spanner has no
+//       catalog/project layer, so X is Database, not Catalog).
+//   - >3 parts: the rightmost three follow the 3-part rule; the one extra
+//     leading part is captured as Catalog for the BigQuery info-schema shape
+//     (project.dataset.INFORMATION_SCHEMA.VIEW), otherwise dropped (no
+//     meaningful deeper qualifier exists in either model).
+func bucketNameParts(parts []string, dialect Dialect) (catalog, database, schema, table string) {
+	n := len(parts)
+	if n == 0 {
+		return "", "", "", ""
+	}
+	table = parts[n-1]
+	if n == 1 {
+		return "", "", "", table
+	}
+
+	mid := parts[n-2] // 2nd-to-last
+	if n == 2 {
+		if dialect == DialectBigQuery {
+			if isSystemSchemaName(mid, dialect) {
+				schema = mid
+			} else {
+				database = mid
+			}
+		} else {
+			schema = mid
+		}
+		return catalog, database, schema, table
+	}
+
+	// n >= 3.
+	outer := parts[n-3] // 3rd-to-last
+	if dialect == DialectBigQuery {
+		if isSystemSchemaName(mid, dialect) {
+			// [project.](dataset|region.)INFORMATION_SCHEMA.VIEW — INFORMATION_SCHEMA
+			// is the Schema, the part before it is the dataset/region (Database), and
+			// (when present, n>=4) the part before THAT is the project (Catalog). The
+			// project must be captured so two projects' INFORMATION_SCHEMA do not
+			// collapse to one access identity (re-review finding #2).
+			schema = mid
+			database = outer
+			if n >= 4 {
+				catalog = parts[n-4]
+			}
+		} else {
+			// project.dataset.table: dataset is Database, project is Catalog.
+			database = mid
+			catalog = outer
+		}
+	} else {
+		// Spanner db.schema.table: schema is Schema, db is Database (no
+		// catalog/project layer).
+		schema = mid
+		database = outer
+	}
+	return catalog, database, schema, table
+}
+
+// tableIsSystem reports whether a recorded TableAccess is a system/information
+// schema reference for the walker's dialect, matching the legacy isSystemResource
+// (BigQuery: Schema EqualFold INFORMATION_SCHEMA; Spanner: INFORMATION_SCHEMA OR
+// SPANNER_SYS). For Spanner, SPANNER_SYS appears as the table's Schema (e.g.
+// SPANNER_SYS.X → Schema=SPANNER_SYS); for both, INFORMATION_SCHEMA does too.
+func (w *spanWalker) tableIsSystem(ta TableAccess) bool {
+	return isSystemSchemaName(ta.Schema, w.dialect)
+}
+
+// ---------------------------------------------------------------------------
+// Expression walking
+// ---------------------------------------------------------------------------
+
+// addPredicateColumn appends a column reference to PredicateColumns,
+// deduplicating against earlier predicate columns.
+func (w *spanWalker) addPredicateColumn(ref ColumnRef) {
+	if w.predSeen[ref] {
+		return
+	}
+	w.predSeen[ref] = true
+	w.span.PredicateColumns = append(w.span.PredicateColumns, ref)
+}
+
+// walkPredicate walks a predicate-position expression (WHERE / ON / HAVING /
+// QUALIFY / GROUP BY / ORDER BY / VALUES), collecting its column references into
+// PredicateColumns and recursing into nested subqueries (which may reference more
+// base tables).
+func (w *spanWalker) walkPredicate(expr ast.Node) {
+	if expr == nil {
+		return
+	}
+	ew := &exprWalk{w: w, followSub: true, onColumn: w.addPredicateColumn}
+	ew.walk(expr)
+}
+
+// walkSubqueriesOnly walks an expression purely to discover the base tables
+// inside nested subqueries; column refs are ignored (the direct refs of a select
+// item are captured separately by makeColumnInfo).
+func (w *spanWalker) walkSubqueriesOnly(expr ast.Node) {
+	if expr == nil {
+		return
+	}
+	ew := &exprWalk{w: w, followSub: true}
+	ew.walk(expr)
+}
+
+// walkWindowSpec walks a window specification's PARTITION BY / ORDER BY / frame
+// bounds as predicate-ish expressions.
+func (w *spanWalker) walkWindowSpec(spec *ast.WindowSpec) {
+	if spec == nil {
+		return
+	}
+	for _, e := range spec.PartitionBy {
+		w.walkPredicate(e)
+	}
+	for _, item := range spec.OrderBy {
+		if item != nil {
+			w.walkPredicate(item.Expr)
+		}
+	}
+	if spec.Frame != nil {
+		w.walkPredicate(spec.Frame.Start.Offset)
+		if spec.Frame.Between {
+			w.walkPredicate(spec.Frame.End.Offset)
+		}
+	}
+}
+
+// exprWalk parameterizes one expression traversal. onColumn is invoked for each
+// column reference (nil to ignore columns). followSub controls whether subquery
+// bodies are recursed into (true for predicate/table discovery; false when
+// collecting a select item's DIRECT columns, which must not cross a subquery
+// boundary).
+type exprWalk struct {
+	w         *spanWalker
+	onColumn  func(ColumnRef)
+	followSub bool
+}
+
+// walk is the shared expression traversal over the googlesql expression AST. It
+// recognizes the two column-reference shapes — a leading Identifier and a
+// FieldAccess/PathExpr dotted chain — invoking onColumn for each, and descends
+// every expression child. Subquery bodies (already parsed into QueryStmt nodes)
+// are recursed when followSub is set.
+func (ew *exprWalk) walk(node ast.Node) {
+	if node == nil {
+		return
+	}
+	switch e := node.(type) {
+
+	// --- Column references ---
+	case *ast.Identifier:
+		ew.emit(ColumnRef{Column: e.Name})
+	case *ast.PathExpr:
+		ew.emit(columnRefFromParts(e.Parts, ew.w.dialect))
+	case *ast.FieldAccess:
+		// A dotted name (t.a / a.b.c) is a FieldAccess chain over a leading
+		// Identifier. Flatten it into a single qualified ColumnRef; if the base is
+		// not a plain name chain (field access on a function result, etc.), fall
+		// back to walking the base expression.
+		if parts := flattenFieldAccess(e); parts != nil {
+			ew.emit(columnRefFromParts(parts, ew.w.dialect))
+		} else {
+			ew.walk(e.Expr)
+		}
+
+	// --- Subquery bodies (parsed into real QueryStmt by the parser) ---
+	case *ast.SubqueryExpr:
+		ew.followSubquery(e.Query)
+	case *ast.ExistsExpr:
+		ew.followSubquery(e.Query)
+	case *ast.ArraySubqueryExpr:
+		ew.followSubquery(e.Query)
+
+	// --- Composite expressions: recurse into children ---
+	case *ast.ParenExpr:
+		ew.walk(e.Expr)
+	case *ast.UnaryExpr:
+		ew.walk(e.Expr)
+	case *ast.BinaryExpr:
+		ew.walk(e.Left)
+		ew.walk(e.Right)
+	case *ast.CompareExpr:
+		ew.walk(e.Left)
+		ew.walk(e.Right)
+	case *ast.IsExpr:
+		ew.walk(e.Expr)
+		ew.walk(e.DistinctFrom)
+	case *ast.InExpr:
+		ew.walk(e.Expr)
+		ew.walkList(e.Values)
+		ew.walk(e.Unnest)
+		ew.walk(e.Subquery)
+	case *ast.BetweenExpr:
+		ew.walk(e.Expr)
+		ew.walk(e.Low)
+		ew.walk(e.High)
+	case *ast.LikeExpr:
+		ew.walk(e.Expr)
+		ew.walk(e.Pattern)
+		ew.walkList(e.QuantValues)
+		ew.walk(e.QuantUnnest)
+		ew.walk(e.QuantSubquery)
+	case *ast.CaseExpr:
+		ew.walk(e.Operand)
+		for _, when := range e.Whens {
+			if when != nil {
+				ew.walk(when.Cond)
+				ew.walk(when.Result)
+			}
+		}
+		ew.walk(e.Else)
+	case *ast.CastExpr:
+		ew.walk(e.Expr)
+		ew.walk(e.Format)
+		ew.walk(e.TimeZone)
+	case *ast.ExtractExpr:
+		ew.walk(e.Part)
+		ew.walk(e.From)
+		ew.walk(e.TimeZone)
+	case *ast.IntervalExpr:
+		ew.walk(e.Value)
+	case *ast.FuncCall:
+		ew.walkFuncCall(e)
+	case *ast.NamedArg:
+		ew.walk(e.Value)
+	case *ast.LambdaExpr:
+		ew.walkLambda(e)
+	case *ast.ArrayExpr:
+		ew.walkList(e.Elements)
+	case *ast.StructExpr:
+		for _, f := range e.Fields {
+			if f != nil {
+				ew.walk(f.Value)
+			}
+		}
+	case *ast.NewConstructor:
+		for _, f := range e.Args {
+			if f != nil {
+				ew.walk(f.Value)
+			}
+		}
+		if e.Braced != nil {
+			ew.walkList(e.Braced.Fields)
+		}
+	case *ast.BracedConstructor:
+		ew.walkList(e.Fields)
+	case *ast.ReplaceFieldsExpr:
+		ew.walk(e.Expr)
+		for _, f := range e.Items {
+			if f != nil {
+				ew.walk(f.Value)
+			}
+		}
+	case *ast.WithExpr:
+		ew.walkWithExpr(e)
+	case *ast.IndexAccess:
+		ew.walk(e.Expr)
+		ew.walk(e.Index)
+	case *ast.ExtensionAccess:
+		ew.walk(e.Expr)
+	case *ast.StarExpr:
+		// A bare '*' (COUNT(*)) carries no column reference.
+
+	// --- Leaves: literals, parameters, system vars, typed literals ---
+	default:
+		// Literal / TypedLiteral / Parameter / SystemVariable / TypeRef / etc.
+		// carry no column or subquery.
+	}
+}
+
+// emit invokes onColumn for a resolved column reference, when collecting columns
+// and the reference has a non-empty column name.
+func (ew *exprWalk) emit(ref ColumnRef) {
+	if ew.onColumn == nil || ref.Column == "" {
+		return
+	}
+	ew.onColumn(ref)
+}
+
+// followSubquery recurses into a parsed subquery body when this pass follows
+// subqueries. The body is a *QueryStmt (or set-op / select) the parser already
+// filled, so the walk reaches it directly.
+func (ew *exprWalk) followSubquery(query ast.Node) {
+	if !ew.followSub || query == nil {
+		return
+	}
+	ew.w.visitBody(query, false)
+}
+
+// walkFuncCall walks a function call's arguments, ORDER BY, FILTER, and OVER
+// window for column/subquery references.
+func (ew *exprWalk) walkFuncCall(e *ast.FuncCall) {
+	if e == nil {
+		return
+	}
+	ew.walkList(e.Args)
+	for _, item := range e.OrderBy {
+		if item != nil {
+			ew.walk(item.Expr)
+		}
+	}
+	if e.Having != nil {
+		ew.walk(e.Having.Expr)
+	}
+	if e.Clamped != nil {
+		ew.walk(e.Clamped.Low)
+		ew.walk(e.Clamped.High)
+	}
+	ew.walk(e.Limit)
+	ew.walk(e.LimitOffset)
+	if e.Over != nil {
+		// Reuse the walker's window-spec pass with this pass's settings.
+		ew.walkWindowSpec(e.Over)
+	}
+}
+
+// walkWindowSpec (on exprWalk) walks an OVER window spec with this pass's
+// onColumn/followSub settings (so a window inside a select-item subquery pass
+// only discovers subqueries, while a predicate pass also collects columns).
+func (ew *exprWalk) walkWindowSpec(spec *ast.WindowSpec) {
+	if spec == nil {
+		return
+	}
+	ew.walkList(spec.PartitionBy)
+	for _, item := range spec.OrderBy {
+		if item != nil {
+			ew.walk(item.Expr)
+		}
+	}
+	if spec.Frame != nil {
+		ew.walk(spec.Frame.Start.Offset)
+		if spec.Frame.Between {
+			ew.walk(spec.Frame.End.Offset)
+		}
+	}
+}
+
+// walkLambda walks a lambda body with the bound parameter names excluded from
+// column collection: a body reference to a bare parameter name is the bound
+// variable, not a table column, so it is dropped — while qualified references
+// and free (outer-scope) names still pass through.
+func (ew *exprWalk) walkLambda(lambda *ast.LambdaExpr) {
+	if lambda == nil {
+		return
+	}
+	ew.walkBoundBody(lambda.Params, lambda.Body)
+}
+
+// walkWithExpr walks an inline `WITH(name AS expr, …, body)` expression. A
+// WITH-expr binding may reference EARLIER bindings (they are in scope left to
+// right), and the body sees all of them — so each binding value is walked with
+// the previously-bound names excluded, and the body with every bound name
+// excluded. A reference to a bound variable is the local binding, not a table
+// column (Codex findings #7 and re-review #1), exactly like a lambda parameter.
+func (ew *exprWalk) walkWithExpr(e *ast.WithExpr) {
+	if e == nil {
+		return
+	}
+	var bound []string
+	for _, v := range e.Vars {
+		if v == nil {
+			continue
+		}
+		// The binding value sees the names bound BEFORE it (not its own name).
+		ew.walkBoundBody(bound, v.Value)
+		if v.Alias != "" {
+			bound = append(bound, v.Alias)
+		}
+	}
+	ew.walkBoundBody(bound, e.Body)
+}
+
+// walkBoundBody walks body with the given bound names excluded from column
+// collection: a column reference whose root name is one of the bound names is a
+// local binding (lambda param / WITH-expr var), not a table column, so it is
+// dropped; qualified and free names still pass through. When this pass does not
+// collect columns (onColumn nil), it walks the body unchanged.
+func (ew *exprWalk) walkBoundBody(bound []string, body ast.Node) {
+	if ew.onColumn == nil || len(bound) == 0 {
+		ew.walk(body)
+		return
+	}
+	names := make(map[string]bool, len(bound))
+	for _, b := range bound {
+		if b != "" {
+			names[strings.ToLower(b)] = true
+		}
+	}
+	outer := ew.onColumn
+	inner := &exprWalk{
+		w:         ew.w,
+		followSub: ew.followSub,
+		onColumn: func(ref ColumnRef) {
+			if names[strings.ToLower(rootName(ref))] {
+				return
+			}
+			outer(ref)
+		},
+	}
+	inner.walk(body)
+}
+
+// walkList walks each node in a slice.
+func (ew *exprWalk) walkList(nodes []ast.Node) {
+	for _, n := range nodes {
+		ew.walk(n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Select-item rendering
+// ---------------------------------------------------------------------------
+
+// makeColumnInfo derives a ColumnInfo from a select-item. Name is the alias if
+// present, else a best-effort rendering ("*"/"t.*" for a star, the column name
+// for a bare column reference, "" otherwise). SourceColumns is the set of column
+// refs the item's expression directly references (excluding nested subqueries).
+func (w *spanWalker) makeColumnInfo(item *ast.SelectItem) ColumnInfo {
+	info := ColumnInfo{}
+	if item.Star {
+		if item.Expr != nil {
+			// expr.* — name it "<expr>.*"; the underlying columns are the item's
+			// direct column refs.
+			if name := renderExprName(item.Expr); name != "" {
+				info.Name = name + ".*"
+			} else {
+				info.Name = "*"
+			}
+			info.SourceColumns = w.collectDirectColumns(item.Expr)
+		} else {
+			info.Name = "*"
+		}
+		return info
+	}
+
+	if item.Alias != "" {
+		info.Name = item.Alias
+	} else {
+		info.Name = renderExprName(item.Expr)
+	}
+	info.SourceColumns = w.collectDirectColumns(item.Expr)
+	return info
+}
+
+// collectDirectColumns returns the column references directly mentioned in expr,
+// in source order, excluding any inside nested subqueries (followSub disabled).
+func (w *spanWalker) collectDirectColumns(expr ast.Node) []ColumnRef {
+	if expr == nil {
+		return nil
+	}
+	var refs []ColumnRef
+	ew := &exprWalk{
+		w:         w,
+		followSub: false,
+		onColumn:  func(ref ColumnRef) { refs = append(refs, ref) },
+	}
+	ew.walk(expr)
+	return refs
+}
+
+// renderExprName returns a short human-readable name for a select-item
+// expression: the column name for a bare Identifier, the trailing field of a
+// FieldAccess, the last part of a PathExpr, unwrapping a single layer of
+// parentheses. Other expressions have no derivable name ("").
+func renderExprName(expr ast.Node) string {
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		return e.Name
+	case *ast.FieldAccess:
+		return e.Field
+	case *ast.PathExpr:
+		if len(e.Parts) > 0 {
+			return e.Parts[len(e.Parts)-1]
+		}
+	case *ast.ParenExpr:
+		return renderExprName(e.Expr)
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Name helpers
+// ---------------------------------------------------------------------------
+
+// flattenFieldAccess returns the dotted-name components of a FieldAccess chain
+// rooted at an Identifier (e.g. ["t", "a"] for t.a), or nil when the chain's
+// base is not a plain name chain (so the caller can fall back to walking it).
+func flattenFieldAccess(f *ast.FieldAccess) []string {
+	if f == nil || f.Field == "" {
+		return nil
+	}
+	switch base := f.Expr.(type) {
+	case *ast.Identifier:
+		if base.Name == "" {
+			return nil
+		}
+		return []string{base.Name, f.Field}
+	case *ast.PathExpr:
+		if len(base.Parts) == 0 {
+			return nil
+		}
+		return append(append([]string{}, base.Parts...), f.Field)
+	case *ast.FieldAccess:
+		prefix := flattenFieldAccess(base)
+		if prefix == nil {
+			return nil
+		}
+		return append(prefix, f.Field)
+	default:
+		return nil
+	}
+}
+
+// columnRefFromParts maps the components of a dotted column reference to a
+// ColumnRef, in the given dialect. The rightmost part is the column; the
+// preceding parts name its qualifying table and are bucketed by the SAME
+// dialect rule as a table path (bucketNameParts), so a ColumnRef's
+// Catalog/Database/Schema/Table fields line up exactly with the corresponding
+// TableAccess (the consistency Codex finding #1 flagged). E.g. BigQuery
+// `proj.ds.t.c` → {Catalog:proj, Database:ds, Table:t, Column:c}, matching the
+// TableAccess for `proj.ds.t`.
+func columnRefFromParts(parts []string, dialect Dialect) ColumnRef {
+	n := len(parts)
+	if n == 0 {
+		return ColumnRef{}
+	}
+	ref := ColumnRef{Column: parts[n-1]}
+	if n >= 2 {
+		ref.Catalog, ref.Database, ref.Schema, ref.Table = bucketNameParts(parts[:n-1], dialect)
+	}
+	return ref
+}
+
+// rootName returns the leftmost (most-qualifying) name of a column reference.
+func rootName(ref ColumnRef) string {
+	switch {
+	case ref.Catalog != "":
+		return ref.Catalog
+	case ref.Database != "":
+		return ref.Database
+	case ref.Schema != "":
+		return ref.Schema
+	case ref.Table != "":
+		return ref.Table
+	default:
+		return ref.Column
+	}
+}
+
+// collectAccessTables runs a lightweight access-table-only pass over a statement
+// node and returns its TableAccess set. Used by Classify's isAllSystemQuery to
+// decide SelectInfoSchema without building a full span.
+func collectAccessTables(node ast.Node, dialect Dialect) []TableAccess {
+	span := &QuerySpan{}
+	w := newSpanWalker(span, dialect)
+	w.analyzeStmt(node)
+	return span.AccessTables
+}

--- a/googlesql/analysis/query_span_test.go
+++ b/googlesql/analysis/query_span_test.go
@@ -1,0 +1,432 @@
+package analysis
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- helpers --------------------------------------------------------------
+
+// tableNames renders AccessTables as sorted "schema.table" (or
+// "catalog.schema.table") strings for stable comparison.
+func tableNames(span *QuerySpan) []string {
+	var out []string
+	for _, ta := range span.AccessTables {
+		out = append(out, ta.qualifiedString())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (ta TableAccess) qualifiedString() string {
+	var parts []string
+	if ta.Catalog != "" {
+		parts = append(parts, ta.Catalog)
+	}
+	if ta.Database != "" {
+		parts = append(parts, ta.Database)
+	}
+	if ta.Schema != "" {
+		parts = append(parts, ta.Schema)
+	}
+	parts = append(parts, ta.Table)
+	return strings.Join(parts, ".")
+}
+
+func resultNames(span *QuerySpan) []string {
+	var out []string
+	for _, r := range span.Results {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func predicateColumnNames(span *QuerySpan) []string {
+	var out []string
+	for _, c := range span.PredicateColumns {
+		out = append(out, c.Column)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// --- AccessTables ---------------------------------------------------------
+
+func TestGetQuerySpan_AccessTables(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		dialect    Dialect
+		wantTables []string
+	}{
+		{"single table", "SELECT a FROM t", DialectBigQuery, []string{"t"}},
+		{"qualified table bq", "SELECT a FROM ds.t", DialectBigQuery, []string{"ds.t"}},
+		{"three-part bq", "SELECT a FROM proj.ds.t", DialectBigQuery, []string{"proj.ds.t"}},
+		{"join", "SELECT * FROM a JOIN b ON a.x = b.x", DialectBigQuery, []string{"a", "b"}},
+		{"comma join", "SELECT * FROM a, b", DialectBigQuery, []string{"a", "b"}},
+		{"chained join", "SELECT * FROM a JOIN b ON a.x=b.x JOIN c ON b.y=c.y", DialectBigQuery, []string{"a", "b", "c"}},
+		{"aliased table excluded-from-name", "SELECT * FROM t AS x", DialectBigQuery, []string{"t"}},
+		{"subquery in from", "SELECT * FROM (SELECT a FROM inner_t) AS s", DialectBigQuery, []string{"inner_t"}},
+		{"scalar subquery", "SELECT (SELECT MAX(x) FROM u) AS m FROM t", DialectBigQuery, []string{"t", "u"}},
+		{"exists subquery", "SELECT * FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.id = t.id)", DialectBigQuery, []string{"t", "u"}},
+		{"in subquery", "SELECT * FROM t WHERE id IN (SELECT id FROM u)", DialectBigQuery, []string{"t", "u"}},
+		{"set op", "SELECT a FROM t UNION ALL SELECT a FROM u", DialectBigQuery, []string{"t", "u"}},
+		{"dedup same table", "SELECT * FROM t WHERE a IN (SELECT a FROM t)", DialectBigQuery, []string{"t"}},
+		// Spanner schema.table bucketing (named schema under one DB).
+		{"qualified table spanner", "SELECT a FROM myschema.t", DialectSpanner, []string{"myschema.t"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, tc.dialect)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			got := tableNames(span)
+			if !eqStrings(got, tc.wantTables) {
+				t.Errorf("GetQuerySpan(%q) tables = %v, want %v", tc.sql, got, tc.wantTables)
+			}
+		})
+	}
+}
+
+// TestGetQuerySpan_CTEsExcluded confirms CTE names are recorded in span.CTEs and
+// excluded from AccessTables, while the CTE BODY's base tables are kept.
+func TestGetQuerySpan_CTEsExcluded(t *testing.T) {
+	sql := "WITH c AS (SELECT a FROM base) SELECT a FROM c"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if got := tableNames(span); !eqStrings(got, []string{"base"}) {
+		t.Errorf("tables = %v, want [base] (CTE c must be excluded, its body's base kept)", got)
+	}
+	if len(span.CTEs) != 1 || !strings.EqualFold(span.CTEs[0], "c") {
+		t.Errorf("CTEs = %v, want [c]", span.CTEs)
+	}
+}
+
+// TestGetQuerySpan_CTEShadowsTable confirms a bare reference to a CTE name is not
+// recorded as a base table even when a real table of the same name could exist.
+func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
+	sql := "WITH t AS (SELECT 1 AS n) SELECT n FROM t"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.AccessTables) != 0 {
+		t.Errorf("tables = %v, want [] (FROM t references the CTE, not a base table)", tableNames(span))
+	}
+}
+
+// --- System-schema classification (dialect divergence) --------------------
+
+func TestGetQuerySpan_SystemTables(t *testing.T) {
+	// wantSchema / wantDatabase reflect WHERE the 2nd-to-last qualifier lands per
+	// the dialect bucketing: in BigQuery a non-INFORMATION_SCHEMA qualifier is the
+	// Database (dataset); in Spanner it is always the Schema.
+	tests := []struct {
+		name         string
+		sql          string
+		dialect      Dialect
+		wantSystem   bool
+		wantSchema   string
+		wantDatabase string
+	}{
+		{"bq info schema", "SELECT * FROM INFORMATION_SCHEMA.TABLES", DialectBigQuery, true, "INFORMATION_SCHEMA", ""},
+		{"bq dataset.info_schema.view", "SELECT * FROM ds.INFORMATION_SCHEMA.COLUMNS", DialectBigQuery, true, "INFORMATION_SCHEMA", "ds"},
+		{"bq spanner_sys not system", "SELECT * FROM SPANNER_SYS.X", DialectBigQuery, false, "", "SPANNER_SYS"},
+		{"spanner info schema", "SELECT * FROM INFORMATION_SCHEMA.TABLES", DialectSpanner, true, "INFORMATION_SCHEMA", ""},
+		{"spanner spanner_sys", "SELECT * FROM SPANNER_SYS.QUERY_STATS_TOP_MINUTE", DialectSpanner, true, "SPANNER_SYS", ""},
+		{"user table bq", "SELECT * FROM ds.users", DialectBigQuery, false, "", "ds"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, tc.dialect)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			if len(span.AccessTables) != 1 {
+				t.Fatalf("expected exactly 1 table, got %d (%v)", len(span.AccessTables), tableNames(span))
+			}
+			ta := span.AccessTables[0]
+			if ta.IsSystem != tc.wantSystem {
+				t.Errorf("IsSystem = %v, want %v (sql %q dialect %v)", ta.IsSystem, tc.wantSystem, tc.sql, tc.dialect)
+			}
+			if ta.Schema != tc.wantSchema {
+				t.Errorf("Schema = %q, want %q", ta.Schema, tc.wantSchema)
+			}
+			if ta.Database != tc.wantDatabase {
+				t.Errorf("Database = %q, want %q", ta.Database, tc.wantDatabase)
+			}
+		})
+	}
+}
+
+// TestGetQuerySpan_BigQuerySchemaBucketing confirms the BigQuery accessTableListener
+// rule: the 2nd-to-last identifier is treated as Schema ONLY when it is
+// INFORMATION_SCHEMA; otherwise it is the Database (dataset). Spanner always
+// treats the 2nd-to-last identifier as Schema.
+func TestGetQuerySpan_SchemaBucketing(t *testing.T) {
+	// BigQuery: ds.t => ds is Database, Schema empty.
+	span, _ := GetQuerySpan("SELECT a FROM ds.t", DialectBigQuery)
+	ta := span.AccessTables[0]
+	if ta.Database != "ds" || ta.Schema != "" {
+		t.Errorf("BigQuery ds.t: Database=%q Schema=%q, want Database=ds Schema=\"\"", ta.Database, ta.Schema)
+	}
+
+	// Spanner: sch.t => sch is Schema.
+	span, _ = GetQuerySpan("SELECT a FROM sch.t", DialectSpanner)
+	ta = span.AccessTables[0]
+	if ta.Schema != "sch" {
+		t.Errorf("Spanner sch.t: Schema=%q, want sch", ta.Schema)
+	}
+}
+
+// --- Results --------------------------------------------------------------
+
+func TestGetQuerySpan_Results(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		wantResults []string
+	}{
+		{"columns", "SELECT a, b FROM t", []string{"a", "b"}},
+		{"alias", "SELECT a AS x, b y FROM t", []string{"x", "y"}},
+		{"star", "SELECT * FROM t", []string{"*"}},
+		{"qualified col", "SELECT t.a FROM t", []string{"a"}},
+		{"expr no name", "SELECT a + b FROM t", []string{""}},
+		{"set op left wins", "SELECT a AS x FROM t UNION ALL SELECT b AS y FROM u", []string{"x"}},
+		{"dot star", "SELECT t.* FROM t", []string{"t.*"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, DialectBigQuery)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			got := resultNames(span)
+			if !eqStrings(got, tc.wantResults) {
+				t.Errorf("GetQuerySpan(%q) results = %v, want %v", tc.sql, got, tc.wantResults)
+			}
+		})
+	}
+}
+
+// --- PredicateColumns -----------------------------------------------------
+
+func TestGetQuerySpan_PredicateColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		wantPred []string
+	}{
+		{"where", "SELECT a FROM t WHERE b > 1", []string{"b"}},
+		{"where and", "SELECT a FROM t WHERE b > 1 AND c < 2", []string{"b", "c"}},
+		{"join on", "SELECT * FROM a JOIN b ON a.x = b.y", []string{"x", "y"}},
+		{"having", "SELECT a, COUNT(*) c FROM t GROUP BY a HAVING c > 1", []string{"a", "c"}},
+		{"qualify", "SELECT a FROM t QUALIFY ROW_NUMBER() OVER (ORDER BY b) = 1", []string{"b"}},
+		{"using", "SELECT * FROM a JOIN b USING (k)", []string{"k"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, DialectBigQuery)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			got := predicateColumnNames(span)
+			if !eqStrings(got, tc.wantPred) {
+				t.Errorf("GetQuerySpan(%q) predicate columns = %v, want %v", tc.sql, got, tc.wantPred)
+			}
+		})
+	}
+}
+
+// --- DML / DDL / empty ----------------------------------------------------
+
+func TestGetQuerySpan_NonQuery(t *testing.T) {
+	// DML / DDL statements get a Type but the access-table walk still runs over
+	// their bodies (an UPDATE/INSERT touches tables, which masking/access cares
+	// about).
+	tests := []struct {
+		name       string
+		sql        string
+		wantType   QueryType
+		wantTables []string
+	}{
+		{"insert select", "INSERT INTO dst SELECT a FROM src", DML, []string{"dst", "src"}},
+		{"update", "UPDATE t SET a = 1 WHERE b = 2", DML, []string{"t"}},
+		{"delete", "DELETE FROM t WHERE a = 1", DML, []string{"t"}},
+		{"create table", "CREATE TABLE t (a INT64) PRIMARY KEY (a)", DDL, []string{"t"}},
+		{"ctas", "CREATE TABLE t AS SELECT a FROM src", DDL, []string{"src", "t"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, DialectBigQuery)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			if span.Type != tc.wantType {
+				t.Errorf("Type = %v, want %v", span.Type, tc.wantType)
+			}
+			got := tableNames(span)
+			if !eqStrings(got, tc.wantTables) {
+				t.Errorf("tables = %v, want %v", got, tc.wantTables)
+			}
+		})
+	}
+}
+
+func TestGetQuerySpan_Empty(t *testing.T) {
+	span, err := GetQuerySpan("", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan(\"\") error: %v", err)
+	}
+	if span.Type != Unknown {
+		t.Errorf("Type = %v, want Unknown", span.Type)
+	}
+	if len(span.AccessTables) != 0 || len(span.Results) != 0 {
+		t.Errorf("expected empty span, got %+v", span)
+	}
+}
+
+// TestGetQuerySpan_PartialParse confirms tolerance of a partial/invalid parse:
+// a malformed statement yields whatever was discoverable without panicking.
+func TestGetQuerySpan_PartialParse(t *testing.T) {
+	// Missing FROM target — invalid, but must not panic.
+	span, err := GetQuerySpan("SELECT * FROM", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	_ = span // no panic / nil-deref is the assertion
+}
+
+// TestGetQuerySpan_CorrelatedSubquery confirms a correlated scalar subquery
+// contributes its own base table AND its correlation predicate columns.
+func TestGetQuerySpan_CorrelatedSubquery(t *testing.T) {
+	sql := "SELECT (SELECT x FROM u WHERE u.id = t.id) AS m FROM t"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if got := tableNames(span); !eqStrings(got, []string{"t", "u"}) {
+		t.Errorf("tables = %v, want [t u]", got)
+	}
+	// The correlation predicate `u.id = t.id` columns are collected from the inner
+	// WHERE (a predicate position).
+	if got := predicateColumnNames(span); !eqStrings(got, []string{"id", "id"}) {
+		t.Errorf("predicate columns = %v, want [id id]", got)
+	}
+}
+
+// TestGetQuerySpan_NestedCTEShadowing confirms an inner WITH scope shadows an
+// outer CTE of the same name, and both scopes' bodies' base tables are recorded.
+func TestGetQuerySpan_NestedCTEShadowing(t *testing.T) {
+	sql := "WITH c AS (SELECT a FROM outer_base) " +
+		"SELECT a FROM (WITH c AS (SELECT a FROM inner_base) SELECT a FROM c)"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	// Both CTE bodies' base tables are recorded; neither `c` reference is a base
+	// table. outer_base is from the outer CTE body (walked even though the outer
+	// query does not reference the outer c — matching the legacy permissive walk).
+	if got := tableNames(span); !eqStrings(got, []string{"inner_base", "outer_base"}) {
+		t.Errorf("tables = %v, want [inner_base outer_base]", got)
+	}
+}
+
+// TestGetQuerySpan_SetOpThreeArms confirms the leftmost arm's result names win
+// across a chained set operation.
+func TestGetQuerySpan_SetOpThreeArms(t *testing.T) {
+	sql := "SELECT a AS first FROM t UNION ALL SELECT b FROM u UNION ALL SELECT c FROM v"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if got := resultNames(span); !eqStrings(got, []string{"first"}) {
+		t.Errorf("results = %v, want [first] (leftmost arm wins)", got)
+	}
+	if got := tableNames(span); !eqStrings(got, []string{"t", "u", "v"}) {
+		t.Errorf("tables = %v, want [t u v]", got)
+	}
+}
+
+// TestGetQuerySpan_DMLSubquery confirms a subquery inside a DML WHERE clause
+// contributes its table.
+func TestGetQuerySpan_DMLSubquery(t *testing.T) {
+	sql := "DELETE FROM t WHERE id IN (SELECT id FROM staging)"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if span.Type != DML {
+		t.Errorf("Type = %v, want DML", span.Type)
+	}
+	if got := tableNames(span); !eqStrings(got, []string{"staging", "t"}) {
+		t.Errorf("tables = %v, want [staging t]", got)
+	}
+}
+
+// TestGetQuerySpan_SourceColumns confirms a select-item's direct source columns
+// are captured (the lineage seed the masking layer consumes).
+func TestGetQuerySpan_SourceColumns(t *testing.T) {
+	span, err := GetQuerySpan("SELECT a + b AS s, t.c FROM t", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(span.Results))
+	}
+	// s = a + b → two source columns a, b.
+	var srcCols []string
+	for _, sc := range span.Results[0].SourceColumns {
+		srcCols = append(srcCols, sc.Column)
+	}
+	sort.Strings(srcCols)
+	if !eqStrings(srcCols, []string{"a", "b"}) {
+		t.Errorf("result[0] source columns = %v, want [a b]", srcCols)
+	}
+	// t.c → one source column c with table t.
+	if len(span.Results[1].SourceColumns) != 1 ||
+		span.Results[1].SourceColumns[0].Column != "c" ||
+		span.Results[1].SourceColumns[0].Table != "t" {
+		t.Errorf("result[1] source columns = %+v, want [{Table:t Column:c}]", span.Results[1].SourceColumns)
+	}
+}
+
+// TestGetQuerySpan_LambdaParamsExcluded confirms a lambda's bound parameter is
+// not recorded as a column reference, while a free column inside the lambda is.
+func TestGetQuerySpan_LambdaParamsExcluded(t *testing.T) {
+	// ARRAY_FILTER-style: the lambda param `e` is bound; `threshold` is a free
+	// column reference.
+	sql := "SELECT ARRAY_TRANSFORM(arr, e -> e + threshold) AS r FROM t"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	var cols []string
+	for _, sc := range span.Results[0].SourceColumns {
+		cols = append(cols, sc.Column)
+	}
+	sort.Strings(cols)
+	// `arr` (the array arg) and `threshold` (free) are columns; `e` (bound param)
+	// is excluded.
+	if !eqStrings(cols, []string{"arr", "threshold"}) {
+		t.Errorf("source columns = %v, want [arr threshold] (lambda param e excluded)", cols)
+	}
+}

--- a/googlesql/analysis/regression_test.go
+++ b/googlesql/analysis/regression_test.go
@@ -1,0 +1,313 @@
+package analysis
+
+import (
+	"sort"
+	"testing"
+)
+
+// This file holds one permanent regression test per review finding (the Codex
+// lens, review-gate.md), so a future change that reintroduces the defect fails
+// loudly. Each test names the finding it pins.
+
+// Finding #1: column-ref qualifiers must bucket by the SAME dialect rule as
+// table paths, so a ColumnRef's Catalog/Database/Schema/Table line up with the
+// matching TableAccess.
+func TestRegression_ColumnRefDialectBucketing(t *testing.T) {
+	// BigQuery proj.ds.t.c → column c of table proj.ds.t.
+	span, err := GetQuerySpan("SELECT proj.ds.t.c FROM proj.ds.t", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.AccessTables) != 1 {
+		t.Fatalf("want 1 table, got %d (%v)", len(span.AccessTables), tableNames(span))
+	}
+	ta := span.AccessTables[0]
+	if ta.Catalog != "proj" || ta.Database != "ds" || ta.Table != "t" {
+		t.Fatalf("table buckets = {Catalog:%q Database:%q Schema:%q Table:%q}, want {proj ds \"\" t}",
+			ta.Catalog, ta.Database, ta.Schema, ta.Table)
+	}
+	if len(span.Results) != 1 || len(span.Results[0].SourceColumns) != 1 {
+		t.Fatalf("want 1 result with 1 source column, got %+v", span.Results)
+	}
+	col := span.Results[0].SourceColumns[0]
+	// The column's qualifier fields must match the table's, NOT the old
+	// table/schema/database/catalog-right-to-left bucketing.
+	if col.Catalog != ta.Catalog || col.Database != ta.Database ||
+		col.Schema != ta.Schema || col.Table != ta.Table || col.Column != "c" {
+		t.Errorf("column ref = {Catalog:%q Database:%q Schema:%q Table:%q Column:%q}, "+
+			"want it to match table {%q %q %q %q} with Column=c",
+			col.Catalog, col.Database, col.Schema, col.Table, col.Column,
+			ta.Catalog, ta.Database, ta.Schema, ta.Table)
+	}
+}
+
+// Finding #2: Spanner 3-part db.schema.table puts db in Database, not Catalog
+// (Spanner has no project/catalog layer).
+func TestRegression_Spanner3PartDatabase(t *testing.T) {
+	span, err := GetQuerySpan("SELECT * FROM db.sch.t", DialectSpanner)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	ta := span.AccessTables[0]
+	if ta.Database != "db" || ta.Schema != "sch" || ta.Table != "t" || ta.Catalog != "" {
+		t.Errorf("Spanner db.sch.t = {Catalog:%q Database:%q Schema:%q Table:%q}, want {\"\" db sch t}",
+			ta.Catalog, ta.Database, ta.Schema, ta.Table)
+	}
+}
+
+// Finding #3: DROP/ALTER of non-table objects (SCHEMA/DATABASE/INDEX) must NOT
+// produce fake AccessTables entries.
+func TestRegression_DDLNonTableObjects(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want int // expected AccessTables count
+	}{
+		{"DROP SCHEMA s", 0},
+		{"DROP DATABASE d", 0},
+		{"DROP INDEX idx", 0},
+		{"ALTER SCHEMA s SET OPTIONS ()", 0},
+		{"DROP TABLE realtbl", 1},  // a real table IS recorded
+		{"DROP VIEW realview", 1},  // a view IS recorded
+	}
+	for _, tc := range tests {
+		t.Run(tc.sql, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, DialectSpanner)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			if len(span.AccessTables) != tc.want {
+				t.Errorf("AccessTables = %v (%d), want %d", tableNames(span), len(span.AccessTables), tc.want)
+			}
+		})
+	}
+}
+
+// Finding #4: CREATE TABLE source-table references (LIKE / CLONE / COPY /
+// INTERLEAVE parent / FOREIGN KEY references) must appear in AccessTables.
+func TestRegression_CreateTableSourceRefs(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		dialect    Dialect
+		wantTables []string
+	}{
+		{
+			name:       "like",
+			sql:        "CREATE TABLE dst LIKE src",
+			dialect:    DialectBigQuery,
+			wantTables: []string{"dst", "src"},
+		},
+		{
+			name:       "clone",
+			sql:        "CREATE TABLE dst CLONE src",
+			dialect:    DialectBigQuery,
+			wantTables: []string{"dst", "src"},
+		},
+		{
+			// The merged parser requires the ON DELETE action on INTERLEAVE (it
+			// rejects the bare `INTERLEAVE IN PARENT parent`, which the Spanner
+			// emulator actually ACCEPTS — a parser-grammar over-reject flagged to the
+			// ledger, owned by parser-ddl-spanner, NOT this node). Use the parseable
+			// form here; the analysis records the parent either way.
+			name:       "interleave parent",
+			sql:        "CREATE TABLE child (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT parent ON DELETE CASCADE",
+			dialect:    DialectSpanner,
+			wantTables: []string{"child", "parent"},
+		},
+		{
+			name:       "foreign key reference",
+			sql:        "CREATE TABLE child (id INT64, pid INT64, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES parent (id)) PRIMARY KEY (id)",
+			dialect:    DialectSpanner,
+			wantTables: []string{"child", "parent"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tc.sql, tc.dialect)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q) error: %v", tc.sql, err)
+			}
+			got := tableNames(span)
+			if !eqStrings(got, tc.wantTables) {
+				t.Errorf("tables = %v, want %v", got, tc.wantTables)
+			}
+		})
+	}
+}
+
+// Finding #5: TRUNCATE TABLE ... WHERE must walk the WHERE clause (predicate
+// columns + any subquery source tables).
+func TestRegression_TruncateWhere(t *testing.T) {
+	span, err := GetQuerySpan("TRUNCATE TABLE t WHERE id IN (SELECT id FROM s)", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if got := tableNames(span); !eqStrings(got, []string{"s", "t"}) {
+		t.Errorf("tables = %v, want [s t]", got)
+	}
+	// Only the outer `id` is a predicate column; the subquery's SELECT-list `id`
+	// is a result item of the subquery, not a predicate.
+	if got := predicateColumnNames(span); !eqStrings(got, []string{"id"}) {
+		t.Errorf("predicate columns = %v, want [id]", got)
+	}
+}
+
+// Finding #6: TVF arguments contribute predicate columns (the doc-promised
+// behavior), not just subquery discovery.
+func TestRegression_TVFArgsPredicateColumns(t *testing.T) {
+	span, err := GetQuerySpan("SELECT * FROM my_tvf(t.id) AS x", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	got := predicateColumnNames(span)
+	if !eqStrings(got, []string{"id"}) {
+		t.Errorf("predicate columns = %v, want [id] (TVF arg t.id)", got)
+	}
+}
+
+// Finding #7: WITH-expression local variables are excluded from the body's
+// column refs, like lambda parameters.
+func TestRegression_WithExprVarScoping(t *testing.T) {
+	// `x` is a WITH-expr local binding; `y` is a table column. The body `x + y`
+	// must contribute only `y`. The binding `x AS y_plus_1`'s value `y + 1` also
+	// references `y` (a real column).
+	span, err := GetQuerySpan("SELECT WITH(x AS y + 1, x + z) AS v FROM t", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(span.Results))
+	}
+	var cols []string
+	for _, sc := range span.Results[0].SourceColumns {
+		cols = append(cols, sc.Column)
+	}
+	sort.Strings(cols)
+	// y (from the binding value), z (free in the body) — but NOT x (bound name).
+	if !eqStrings(cols, []string{"y", "z"}) {
+		t.Errorf("source columns = %v, want [y z] (WITH-expr var x excluded)", cols)
+	}
+}
+
+// Re-review finding #1: a later WITH-expr binding may reference an earlier
+// binding, which must also be treated as a local variable (not a table column).
+func TestRegression_WithExprProgressiveScoping(t *testing.T) {
+	// a AS c1; b AS a + c2 (a is the earlier local binding, c2 a table column);
+	// body b + c3 (b is local, c3 a table column). Source columns: c1, c2, c3.
+	span, err := GetQuerySpan("SELECT WITH(a AS c1, b AS a + c2, b + c3) AS v FROM t", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(span.Results))
+	}
+	var cols []string
+	for _, sc := range span.Results[0].SourceColumns {
+		cols = append(cols, sc.Column)
+	}
+	sort.Strings(cols)
+	if !eqStrings(cols, []string{"c1", "c2", "c3"}) {
+		t.Errorf("source columns = %v, want [c1 c2 c3] (locals a, b excluded)", cols)
+	}
+}
+
+// Round-3 finding #1: non-recursive CTE visibility is sequential — a forward
+// reference to a LATER sibling resolves to a base table, not the CTE.
+func TestRegression_NonRecursiveCTEForwardRef(t *testing.T) {
+	// CTE `a`'s body references `b`, which is a LATER sibling CTE. In
+	// non-recursive GoogleSQL `b` is not yet visible inside `a`, so it is the base
+	// table `b`. Tables: b (the real base table referenced from a) + src (from b's
+	// body). Neither `a` nor the CTE-`b` reference is a base table.
+	sql := "WITH a AS (SELECT * FROM b), b AS (SELECT * FROM src) SELECT * FROM a"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if got := tableNames(span); !eqStrings(got, []string{"b", "src"}) {
+		t.Errorf("tables = %v, want [b src] (forward ref to later sibling b is a base table)", got)
+	}
+}
+
+// TestRegression_RecursiveCTESelfRef confirms a RECURSIVE CTE's self-reference
+// is filtered (the name is visible inside its own body).
+func TestRegression_RecursiveCTESelfRef(t *testing.T) {
+	sql := "WITH RECURSIVE c AS ((SELECT 1 AS n) UNION ALL (SELECT n + 1 FROM c WHERE n < 3)) SELECT * FROM c"
+	span, err := GetQuerySpan(sql, DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	// `c` references only itself; no base tables.
+	if len(span.AccessTables) != 0 {
+		t.Errorf("tables = %v, want [] (recursive self-ref c is not a base table)", tableNames(span))
+	}
+}
+
+// Round-3 finding #2: a correlated array/field path off an earlier FROM alias
+// (`FROM T t, t.arr`) is NOT a base table.
+func TestRegression_CorrelatedArrayPath(t *testing.T) {
+	span, err := GetQuerySpan("SELECT * FROM T1 t1, t1.array_column", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	// Only T1 is a base table; t1.array_column is a correlated unnest of its alias.
+	if got := tableNames(span); !eqStrings(got, []string{"T1"}) {
+		t.Errorf("tables = %v, want [T1] (t1.array_column is a correlated path, not a table)", got)
+	}
+	// A genuine 2-part table (dataset.table, root not a FROM alias) is still a
+	// base table — the alias check must not over-suppress real qualified tables.
+	span2, _ := GetQuerySpan("SELECT * FROM ds.users", DialectBigQuery)
+	if got := tableNames(span2); !eqStrings(got, []string{"ds.users"}) {
+		t.Errorf("tables = %v, want [ds.users] (real qualified table)", got)
+	}
+}
+
+// Round-4 finding: a correlated array path off a DERIVED (subquery) alias or a
+// CHAINED correlated alias is also not a base table.
+func TestRegression_CorrelatedPathDerivedAndChained(t *testing.T) {
+	// Off a subquery alias: `s.arr` correlates the derived relation `s`.
+	span, err := GetQuerySpan("SELECT * FROM (SELECT [1, 2] AS arr) s, s.arr", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.AccessTables) != 0 {
+		t.Errorf("derived-alias correlated path: tables = %v, want [] (subquery has no base table; s.arr is correlated)", tableNames(span))
+	}
+
+	// Chained: `t.arr a` registers alias `a`, so `a.child` correlates off it.
+	span2, err := GetQuerySpan("SELECT * FROM T t, t.arr a, a.child", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if got := tableNames(span2); !eqStrings(got, []string{"T"}) {
+		t.Errorf("chained correlated path: tables = %v, want [T] (t.arr and a.child are correlated)", got)
+	}
+}
+
+// Re-review finding #2: a project-qualified BigQuery INFORMATION_SCHEMA path
+// keeps the project as Catalog, so two projects' info-schema do not collapse.
+func TestRegression_ProjectQualifiedInfoSchema(t *testing.T) {
+	span, err := GetQuerySpan("SELECT * FROM proj.ds.INFORMATION_SCHEMA.COLUMNS", DialectBigQuery)
+	if err != nil {
+		t.Fatalf("GetQuerySpan error: %v", err)
+	}
+	if len(span.AccessTables) != 1 {
+		t.Fatalf("want 1 table, got %d", len(span.AccessTables))
+	}
+	ta := span.AccessTables[0]
+	if ta.Catalog != "proj" || ta.Database != "ds" || ta.Schema != "INFORMATION_SCHEMA" || ta.Table != "COLUMNS" {
+		t.Errorf("buckets = {Catalog:%q Database:%q Schema:%q Table:%q}, want {proj ds INFORMATION_SCHEMA COLUMNS}",
+			ta.Catalog, ta.Database, ta.Schema, ta.Table)
+	}
+	if !ta.IsSystem {
+		t.Errorf("IsSystem = false, want true")
+	}
+
+	// Two different projects must NOT collapse to one access identity.
+	span2, _ := GetQuerySpan(
+		"SELECT * FROM proj1.ds.INFORMATION_SCHEMA.COLUMNS, proj2.ds.INFORMATION_SCHEMA.COLUMNS",
+		DialectBigQuery)
+	if len(span2.AccessTables) != 2 {
+		t.Errorf("two projects collapsed: got %d tables (%v), want 2",
+			len(span2.AccessTables), tableNames(span2))
+	}
+}


### PR DESCRIPTION
## Node

`googlesql/analysis` (migration id=5) — the **query-span + statement-classification** feature node for the omni GoogleSQL engine (serves bytebase BigQuery + Spanner via one grammar). Spec: `docs/migration/googlesql/{analysis,contract}.md`.

It is the omni counterpart of bytebase's legacy `plugin/parser/{bigquery,spanner}` `GetQuerySpan` + `queryTypeListener` + `accessTableListener`. Following the merged omni analysis peers (`trino/`, `doris/`, `snowflake/`), it is **parser-driven and best-effort**: it produces self-contained local types that the later `bytebase-switch` node maps onto `base.QuerySpan`, and does **not** resolve names against live catalog metadata (that metadata-aware layer is the cutover's job).

## What it ships

- **`classify.go`** — dialect-aware `QueryType` classification (`Select` / `DML` / `DDL` / `SelectInfoSchema` / `Unknown`) over the merged googlesql AST. `Classify(node, dialect)` / `ClassifySQL(sql, dialect)`. `SelectInfoSchema` promotion follows the legacy `allSystems` rule (a query reading **exclusively** system tables), evaluated over the AST's access tables.
- **`query_span.go`** — `GetQuerySpan(sql, dialect)` walks the **fully-connected** AST (the parser fills subqueries into real `QueryStmt` nodes, so no re-parse of raw text is needed, unlike trino/doris) to produce `AccessTables`, `Results`, `PredicateColumns`, and `CTEs`.

### Per-dialect divergences (contract.md §4), parameterized by a `Dialect` enum

| Seam | BigQuery | Spanner |
|---|---|---|
| Metadata model | `project.dataset.table` (2nd-to-last is Database unless `INFORMATION_SCHEMA`) | `db.schema.table` (2nd-to-last always Schema) |
| System schemas | `INFORMATION_SCHEMA` only | `INFORMATION_SCHEMA` **+ `SPANNER_SYS`** |

A single shared `bucketNameParts` rule buckets BOTH table paths and column references, so a `ColumnRef`'s qualifier fields line up exactly with the matching `TableAccess`.

## PROVE (correctness-protocol.md — feature node)

- `go test ./googlesql/analysis/...` — **113 cases green**, race-clean.
- **Differential vs the live Cloud Spanner emulator** (`oracle_test.go`, tag `googlesql_oracle`, `SPANNER_EMULATOR_HOST=localhost:9010`): confirms every classify-corpus statement is **real GoogleSQL the grammar accepts** (so the classification/lineage assertions rest on valid syntax) and cross-checks the read-only verdict against each statement's true nature. The `INFORMATION_SCHEMA` and `SPANNER_SYS` info-schema promotions are oracle-confirmed.

## REVIEW (review-gate.md — two-reviewer gate)

Claude lens + **Codex lens** (in-worker, shared runtime), **4 rounds**, findings narrowing 7 → 2 → 2 → 1, all real and fixed with a **permanent regression test each** (`regression_test.go`):

1. dialect-aware column-ref bucketing (lines up with TableAccess)
2. Spanner 3-part name → `Database` (not `Catalog`)
3. DDL object-kind gating (DROP/ALTER SCHEMA/DATABASE/INDEX names are not tables)
4. CREATE TABLE source refs: `LIKE` / `CLONE` / `COPY` / `INTERLEAVE` parent / FK `REFERENCES`
5. `TRUNCATE ... WHERE` walked
6. TVF arguments contribute predicate columns
7. `WITH(...)` expression progressive var scoping (each binding sees earlier bindings; body sees all)
8. project-qualified `INFORMATION_SCHEMA` keeps the project as `Catalog` (no cross-project collapse)
9. **sequential** non-recursive CTE visibility (forward ref to a later sibling = base table); RECURSIVE self-ref filtered
10. correlated array/field FROM paths (`FROM T t, t.arr`), including **derived** (`(…) s, s.arr`) and **chained** (`t.arr a, a.child`)

## Divergence flagged (NOT this node)

**#112** (`parser-ddl-spanner`): the merged parser over-rejects bare `INTERLEAVE IN PARENT parent` without `ON DELETE`, which the Spanner emulator **accepts** (verdict=accept, semantic "Table not found"). Recorded in the ledger; owned by the Spanner DDL node.

## Scope

Touches only `googlesql/analysis/*.go` (the node's writes-glob). No `docs/migration` or `harness/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)