### PR TITLE
feat(googlesql/parser-ddl-bigquery): BigQuery-only object DDL

### DIFF
--- a/googlesql/analysis/classify.go
+++ b/googlesql/analysis/classify.go
@@ -136,10 +136,19 @@ func Classify(node ast.Node, dialect Dialect) QueryType {
 		*ast.MergeStmt, *ast.TruncateStmt:
 		return DML
 
-	// DDL — CREATE / ALTER / DROP over table-like objects.
+	// DDL — CREATE / ALTER / DROP over table-like objects, plus the BigQuery-only
+	// object DDL (FUNCTION / TABLE FUNCTION / PROCEDURE, MATERIALIZED|APPROX VIEW,
+	// SEARCH|VECTOR INDEX, SNAPSHOT TABLE, generic-entity CAPACITY/RESERVATION/
+	// ASSIGNMENT, ROW ACCESS POLICY). The legacy listener groups every CREATE/
+	// ALTER/DROP form under DDL, so these classify as DDL too.
 	case *ast.CreateTableStmt, *ast.CreateViewStmt, *ast.CreateIndexStmt,
 		*ast.CreateSchemaStmt, *ast.CreateDatabaseStmt,
-		*ast.AlterStmt, *ast.DropStmt:
+		*ast.AlterStmt, *ast.DropStmt,
+		*ast.CreateFunctionStmt, *ast.CreateProcedureStmt,
+		*ast.CreateMaterializedViewStmt, *ast.CreateSnapshotStmt,
+		*ast.SearchVectorIndexStmt, *ast.CreateRowAccessPolicyStmt,
+		*ast.CreateEntityStmt, *ast.BQAlterStmt, *ast.BQDropStmt,
+		*ast.DropAllRowAccessPoliciesStmt:
 		return DDL
 
 	// DCL — GRANT / REVOKE are DDL in the legacy listener (its rule list groups

--- a/googlesql/analysis/classify_test.go
+++ b/googlesql/analysis/classify_test.go
@@ -41,6 +41,26 @@ func TestClassifySQL(t *testing.T) {
 		{"grant", "GRANT SELECT ON t TO 'user@example.com'", DDL},
 		{"revoke", "REVOKE SELECT ON t FROM 'user@example.com'", DDL},
 
+		// --- DDL — BigQuery-only objects (parser-ddl-bigquery node) ---
+		{"create function", "CREATE FUNCTION ds.f(x INT64) RETURNS INT64 AS (x + 1)", DDL},
+		{"create table function", "CREATE TABLE FUNCTION ds.f(y INT64) AS SELECT 1 AS n", DDL},
+		{"create procedure", "CREATE PROCEDURE ds.p() BEGIN SELECT 1; END", DDL},
+		{"create materialized view", "CREATE MATERIALIZED VIEW ds.mv AS SELECT 1 AS n", DDL},
+		{"create search index", "CREATE SEARCH INDEX i ON ds.t(ALL COLUMNS)", DDL},
+		{"create vector index", "CREATE VECTOR INDEX i ON ds.t(c) OPTIONS(distance_type='COSINE')", DDL},
+		{"create snapshot table", "CREATE SNAPSHOT TABLE ds.s CLONE ds.t", DDL},
+		{"create row access policy", "CREATE ROW ACCESS POLICY p ON ds.t FILTER USING (TRUE)", DDL},
+		{"create capacity (generic entity)", "CREATE CAPACITY `p.r.c` OPTIONS(slot_count=100)", DDL},
+		{"alter materialized view", "ALTER MATERIALIZED VIEW ds.mv SET OPTIONS(x=1)", DDL},
+		{"alter vector index rebuild", "ALTER VECTOR INDEX i ON ds.t REBUILD", DDL},
+		{"drop function", "DROP FUNCTION ds.f", DDL},
+		{"drop materialized view", "DROP MATERIALIZED VIEW ds.mv", DDL},
+		{"drop snapshot table", "DROP SNAPSHOT TABLE ds.s", DDL},
+		{"drop search index", "DROP SEARCH INDEX i ON ds.t", DDL},
+		{"drop row access policy", "DROP ROW ACCESS POLICY p ON ds.t", DDL},
+		{"drop all row access policies", "DROP ALL ROW ACCESS POLICIES ON ds.t", DDL},
+		{"drop capacity (generic entity)", "DROP CAPACITY `p.r.c`", DDL},
+
 		// --- Unknown / empty ---
 		{"empty", "", Unknown},
 		{"whitespace only", "   \n  ", Unknown},

--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -125,6 +125,23 @@ const (
 	T_AlterAction
 	T_DropStmt
 
+	// BigQuery-specific DDL (parser-ddl-bigquery node): CREATE [AGGREGATE]
+	// FUNCTION / TABLE FUNCTION / PROCEDURE, CREATE MATERIALIZED|APPROX VIEW,
+	// CREATE [SEARCH|VECTOR] INDEX, CREATE SNAPSHOT TABLE, CREATE ROW ACCESS
+	// POLICY, the generic-entity CREATE/ALTER/DROP path
+	// (CAPACITY/RESERVATION/ASSIGNMENT), and their BigQuery-only ALTER/DROP forms.
+	T_FunctionParam
+	T_CreateFunctionStmt
+	T_CreateProcedureStmt
+	T_CreateMaterializedViewStmt
+	T_CreateSnapshotStmt
+	T_SearchVectorIndexStmt
+	T_CreateRowAccessPolicyStmt
+	T_CreateEntityStmt
+	T_BQAlterStmt
+	T_BQDropStmt
+	T_DropAllRowAccessPoliciesStmt
+
 	// DML — INSERT / UPDATE / DELETE / MERGE / TRUNCATE (parser-dml node).
 	//
 	// The data-manipulation family for the BigQuery + Spanner union, plus their
@@ -322,6 +339,28 @@ func (t NodeTag) String() string {
 		return "AlterAction"
 	case T_DropStmt:
 		return "DropStmt"
+	case T_FunctionParam:
+		return "FunctionParam"
+	case T_CreateFunctionStmt:
+		return "CreateFunctionStmt"
+	case T_CreateProcedureStmt:
+		return "CreateProcedureStmt"
+	case T_CreateMaterializedViewStmt:
+		return "CreateMaterializedViewStmt"
+	case T_CreateSnapshotStmt:
+		return "CreateSnapshotStmt"
+	case T_SearchVectorIndexStmt:
+		return "SearchVectorIndexStmt"
+	case T_CreateRowAccessPolicyStmt:
+		return "CreateRowAccessPolicyStmt"
+	case T_CreateEntityStmt:
+		return "CreateEntityStmt"
+	case T_BQAlterStmt:
+		return "BQAlterStmt"
+	case T_BQDropStmt:
+		return "BQDropStmt"
+	case T_DropAllRowAccessPoliciesStmt:
+		return "DropAllRowAccessPoliciesStmt"
 	case T_DefaultExpr:
 		return "DefaultExpr"
 	case T_InsertStmt:

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -2031,6 +2031,403 @@ var (
 	_ Node = (*DropStmt)(nil)
 )
 
+// ===========================================================================
+// BigQuery-specific DDL (parser-ddl-bigquery node)
+// ===========================================================================
+//
+// These node types model the BigQuery-only object DDL the core parser-ddl node
+// routes to a stub: CREATE [AGGREGATE] FUNCTION / CREATE TABLE FUNCTION (TVF) /
+// CREATE PROCEDURE, CREATE [MATERIALIZED|APPROX] VIEW, CREATE [SEARCH|VECTOR]
+// INDEX, CREATE SNAPSHOT TABLE, CREATE ROW ACCESS POLICY, and the generic-entity
+// CREATE/ALTER/DROP path (CAPACITY / RESERVATION / ASSIGNMENT and any other
+// extensible object), plus their ALTER (ALTER MATERIALIZED VIEW SET OPTIONS,
+// ALTER VECTOR INDEX … REBUILD) and DROP (DROP {SEARCH|VECTOR} INDEX … ON,
+// DROP SNAPSHOT TABLE, DROP TABLE FUNCTION, DROP ALL ROW ACCESS POLICIES) forms.
+//
+// They are a hand-port of the legacy ANTLR GoogleSQLParser.g4 rules
+// (create_function_statement, create_procedure_statement,
+// create_table_function_statement, create_view_statement materialized/approx
+// alternatives, create_index_statement SEARCH/VECTOR index_type,
+// create_snapshot_statement, create_row_access_policy_statement,
+// create_entity_statement, the generic-entity alter/drop alternatives), the same
+// ZetaSQL lineage the rest of the grammar follows.
+//
+// ORACLE NOTE — every form here is BigQuery-only at the GoogleSQL UNION level:
+// the Spanner emulator (the differential harness) either lacks the form entirely
+// (TABLE FUNCTION, PROCEDURE, MATERIALIZED VIEW, SEARCH index ALL COLUMNS,
+// SNAPSHOT, ROW ACCESS POLICY, CAPACITY/RESERVATION/ASSIGNMENT, ALTER VECTOR
+// INDEX REBUILD, DROP {SEARCH|VECTOR} INDEX … ON, DROP TABLE FUNCTION) or
+// supports only a NARROWER shape (a bare `CREATE FUNCTION … AS (expr)` and
+// `DROP FUNCTION` parse, but TEMP / AGGREGATE / LANGUAGE / DETERMINISTIC / REMOTE
+// reject). So the Spanner verdict is NON-authoritative for these and they are
+// triangulated against the legacy .g4 + the BigQuery truth1 corpus (oracle.md);
+// the unit tests in bq_*_test.go are the structural/accept-reject gate.
+
+// FunctionParamMode is the IN / OUT / INOUT mode prefix of a procedure parameter
+// (opt_procedure_parameter_mode). Function parameters carry no mode.
+type FunctionParamMode int
+
+const (
+	ParamModeNone  FunctionParamMode = iota // no mode (function parameter)
+	ParamModeIn                             // IN
+	ParamModeOut                            // OUT
+	ParamModeInout                          // INOUT
+)
+
+// String returns the mode keyword, or "" for ParamModeNone.
+func (m FunctionParamMode) String() string {
+	switch m {
+	case ParamModeIn:
+		return "IN"
+	case ParamModeOut:
+		return "OUT"
+	case ParamModeInout:
+		return "INOUT"
+	default:
+		return ""
+	}
+}
+
+// FunctionParam is one parameter of a CREATE FUNCTION / TABLE FUNCTION /
+// PROCEDURE parameter list (function_parameter / procedure_parameter). It models
+// the union of both grammars:
+//
+//   - function_parameter: identifier type_or_tvf_schema [AS alias]
+//     [DEFAULT expr] [NOT AGGREGATE]  — or a bare type_or_tvf_schema (no name).
+//   - procedure_parameter: [IN|OUT|INOUT] identifier type_or_tvf_schema.
+//
+// Type holds the rendered parameter type (a simple type, ANY TYPE templated
+// type, or a TVF `TABLE<…>` schema — all captured via Type.Text). For a bare
+// unnamed function parameter, Name is "" and Type still carries the type.
+type FunctionParam struct {
+	Mode         FunctionParamMode // procedure mode; ParamModeNone for functions / unset
+	Name         string            // parameter name; "" for a bare unnamed function parameter
+	Type         *TypeRef          // parameter type (type_or_tvf_schema); rendered text
+	Alias        string            // AS alias (function_parameter opt_as_alias_with_required_as); "" if absent
+	Default      Node              // DEFAULT expr (function_parameter); nil if absent
+	NotAggregate bool              // NOT AGGREGATE (function_parameter)
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *FunctionParam) Tag() NodeTag { return T_FunctionParam }
+
+// CreateFunctionStmt is a CREATE [AGGREGATE] FUNCTION or CREATE TABLE FUNCTION
+// statement (create_function_statement / create_table_function_statement). The
+// IsTableFunc flag selects the TVF shape (CREATE TABLE FUNCTION … RETURNS TABLE<…>
+// AS query) from the scalar/aggregate shape (CREATE [AGGREGATE] FUNCTION … RETURNS
+// type AS (expr)|string).
+type CreateFunctionStmt struct {
+	OrReplace   bool
+	Scope       string // opt_create_scope: "TEMP" | "TEMPORARY" | "" (PUBLIC/PRIVATE rare)
+	Aggregate   bool   // AGGREGATE (scalar aggregate function)
+	IsTableFunc bool   // CREATE TABLE FUNCTION (TVF)
+	IfNotExists bool
+	Name        *PathExpr
+	Params      []*FunctionParam // function_parameters / opt_function_parameters
+	Returns     *TypeRef         // RETURNS type (scalar) — rendered text; nil if absent
+	// RETURNS TABLE<col …> (TVF): the column declarations. ReturnsTable is true when
+	// a TVF declares an explicit RETURNS TABLE<…>; ReturnColumns holds the columns.
+	ReturnsTable   bool
+	ReturnColumns  []*ColumnDef
+	SQLSecurity    string // SQL SECURITY {INVOKER|DEFINER}; "" if absent
+	Determinism    string // DETERMINISTIC | NOT DETERMINISTIC | IMMUTABLE | STABLE | VOLATILE; "" if absent
+	Language       string // LANGUAGE <id> (js/python/…); "" if absent
+	Remote         bool   // REMOTE [WITH CONNECTION …]
+	HasConnection  bool   // a WITH CONNECTION clause was present (the connection path is captured as text only)
+	ConnectionName string // the connection path text, if any
+	Options        []*OptionsEntry
+	Body           Node   // scalar/aggregate AS (expr) body; nil if absent or string/TVF
+	BodyString     string // AS string body (JS/Python code or quoted SQL); "" if absent
+	HasBodyString  bool   // distinguishes an empty AS '' from an absent string body
+	AsQuery        Node   // TVF AS query body; nil if absent (*QueryStmt)
+	Loc            Loc
+}
+
+// Tag implements Node.
+func (n *CreateFunctionStmt) Tag() NodeTag { return T_CreateFunctionStmt }
+
+// CreateProcedureStmt is a CREATE PROCEDURE statement (create_procedure_statement):
+// a parameter list, optional EXTERNAL SECURITY / WITH CONNECTION / OPTIONS, then
+// either a BEGIN…END block body or a LANGUAGE <id> [AS code] body.
+type CreateProcedureStmt struct {
+	OrReplace        bool
+	Scope            string // opt_create_scope
+	IfNotExists      bool
+	Name             *PathExpr
+	Params           []*FunctionParam // procedure_parameters
+	ExternalSecurity string           // EXTERNAL SECURITY {INVOKER|DEFINER}; "" if absent
+	HasConnection    bool             // WITH CONNECTION present
+	ConnectionName   string           // connection path text, if any
+	Options          []*OptionsEntry
+	// Body: a BEGIN…END block is captured as raw text (the procedural script
+	// statement_list is owned by the parser-scripting node; this node records the
+	// block text so the procedure round-trips and the consumer sees a body). For a
+	// LANGUAGE body, Language is set and BodyString holds the AS code.
+	BodyText      string // BEGIN…END block text (verbatim, incl. the BEGIN/END keywords); "" for a LANGUAGE body
+	Language      string // LANGUAGE <id>; "" for a BEGIN…END body
+	BodyString    string // LANGUAGE … AS <code>; "" if absent
+	HasBodyString bool
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *CreateProcedureStmt) Tag() NodeTag { return T_CreateProcedureStmt }
+
+// ViewKind discriminates a CREATE VIEW variant: a plain view (owned by the core
+// parser-ddl node, not produced here) vs the BigQuery MATERIALIZED / APPROX
+// variants this node owns.
+type ViewKind int
+
+const (
+	ViewPlain        ViewKind = iota // plain VIEW (core node)
+	ViewMaterialized                 // MATERIALIZED VIEW
+	ViewApprox                       // APPROX VIEW
+)
+
+// String returns the view-kind keyword phrase.
+func (k ViewKind) String() string {
+	switch k {
+	case ViewMaterialized:
+		return "MATERIALIZED VIEW"
+	case ViewApprox:
+		return "APPROX VIEW"
+	default:
+		return "VIEW"
+	}
+}
+
+// CreateMaterializedViewStmt is a CREATE MATERIALIZED|APPROX VIEW statement (the
+// materialized / approx alternatives of create_view_statement). It adds, over a
+// plain view, PARTITION BY / CLUSTER BY (materialized only) and the
+// `AS REPLICA OF <source>` body alternative (query_or_replica_source).
+type CreateMaterializedViewStmt struct {
+	Kind        ViewKind // ViewMaterialized | ViewApprox
+	OrReplace   bool
+	Recursive   bool // RECURSIVE
+	IfNotExists bool
+	Name        *PathExpr
+	Columns     []*ViewColumn // column_with_options_list; nil if absent
+	SQLSecurity string        // SQL SECURITY {INVOKER|DEFINER}; "" if absent
+	PartitionBy []Node        // PARTITION BY exprs (materialized only); nil if absent
+	ClusterBy   []Node        // CLUSTER BY exprs (materialized only); nil if absent
+	Options     []*OptionsEntry
+	AsQuery     Node      // AS query body; nil when ReplicaOf is set (*QueryStmt)
+	ReplicaOf   *PathExpr // AS REPLICA OF <source> (materialized); nil if a query body
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateMaterializedViewStmt) Tag() NodeTag { return T_CreateMaterializedViewStmt }
+
+// CreateSnapshotStmt is a CREATE SNAPSHOT TABLE statement (create_snapshot_statement):
+//
+//	CREATE [OR REPLACE] SNAPSHOT TABLE [IF NOT EXISTS] <name>
+//	  CLONE <source> [FOR SYSTEM_TIME AS OF expr] [OPTIONS(…)]
+type CreateSnapshotStmt struct {
+	OrReplace     bool
+	IfNotExists   bool
+	Name          *PathExpr
+	CloneSource   *PathExpr // CLONE <source>
+	ForSystemTime Node      // FOR SYSTEM_TIME AS OF expr; nil if absent
+	Where         Node      // optional WHERE filter on the clone source; nil if absent
+	Options       []*OptionsEntry
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *CreateSnapshotStmt) Tag() NodeTag { return T_CreateSnapshotStmt }
+
+// SearchVectorIndexStmt is a CREATE [SEARCH|VECTOR] INDEX statement (the
+// SEARCH/VECTOR index_type variants of create_index_statement). It carries the
+// index name, target table, the column list or ALL COLUMNS, STORING list,
+// PARTITION BY (vector), and OPTIONS.
+type SearchVectorIndexStmt struct {
+	IsVector    bool // VECTOR (vs SEARCH)
+	OrReplace   bool // OR REPLACE (vector)
+	IfNotExists bool
+	Name        *PathExpr  // index name
+	Table       *PathExpr  // ON <table>
+	Keys        []*KeyPart // column list (index_order_by_and_options); nil for ALL COLUMNS
+	AllColumns  bool       // ( ALL COLUMNS [WITH COLUMN OPTIONS(…)] ) — SEARCH index
+	Storing     []Node     // STORING ( col, … ) — vector index; nil if absent
+	PartitionBy []Node     // PARTITION BY expr — vector index; nil if absent
+	Options     []*OptionsEntry
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *SearchVectorIndexStmt) Tag() NodeTag { return T_SearchVectorIndexStmt }
+
+// CreateRowAccessPolicyStmt is a CREATE ROW ACCESS POLICY statement
+// (create_row_access_policy_statement):
+//
+//	CREATE [OR REPLACE] ROW ACCESS POLICY [IF NOT EXISTS] [name]
+//	  ON <table> [GRANT TO (grantees) | TO grantees] [FILTER] USING (expr)
+type CreateRowAccessPolicyStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        string     // policy name (identifier?); "" if absent
+	Table       *PathExpr  // ON <table>
+	Grantees    []*Grantee // GRANT TO (…) / TO …; nil if absent
+	HasGrantTo  bool       // a grant-to clause was present (distinguishes empty list)
+	Filter      Node       // [FILTER] USING (expr) — required; the filter expression
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateRowAccessPolicyStmt) Tag() NodeTag { return T_CreateRowAccessPolicyStmt }
+
+// CreateEntityStmt is a CREATE <generic-entity> statement (create_entity_statement):
+//
+//	CREATE [OR REPLACE] <entity_type> [IF NOT EXISTS] <name> [OPTIONS(…)] [AS <body>]
+//
+// The generic-entity mechanism is how the legacy grammar parses extensible
+// object kinds whose keyword is a bare identifier — including BigQuery
+// CAPACITY / RESERVATION / ASSIGNMENT (DDL-024/025/026: `CREATE CAPACITY
+// \`p.l.c\` OPTIONS(…)`). EntityType holds the entity keyword spelling.
+type CreateEntityStmt struct {
+	OrReplace   bool
+	EntityType  string // the generic_entity_type identifier (e.g. "CAPACITY", "RESERVATION", "ASSIGNMENT", "PROJECT")
+	IfNotExists bool
+	Name        *PathExpr
+	Options     []*OptionsEntry
+	// BodyText: the AS <generic_entity_body> tail, captured as raw text (the body
+	// is a free-form JSON/string in the grammar). "" if absent.
+	BodyText string
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *CreateEntityStmt) Tag() NodeTag { return T_CreateEntityStmt }
+
+// BQAlterObjectKind discriminates the object kind of a BigQuery-only ALTER
+// statement this node owns (the kinds the core parser-ddl node routes away).
+type BQAlterObjectKind int
+
+const (
+	BQAlterMaterializedView BQAlterObjectKind = iota // ALTER MATERIALIZED VIEW
+	BQAlterApproxView                                // ALTER APPROX VIEW
+	BQAlterVectorIndex                               // ALTER VECTOR INDEX … REBUILD
+	BQAlterEntity                                    // ALTER <generic-entity> (CAPACITY/RESERVATION/…)
+)
+
+// String returns the object keyword phrase.
+func (k BQAlterObjectKind) String() string {
+	switch k {
+	case BQAlterMaterializedView:
+		return "MATERIALIZED VIEW"
+	case BQAlterApproxView:
+		return "APPROX VIEW"
+	case BQAlterVectorIndex:
+		return "VECTOR INDEX"
+	default:
+		return "ENTITY"
+	}
+}
+
+// BQAlterStmt is a BigQuery-only ALTER statement: ALTER MATERIALIZED|APPROX VIEW
+// SET OPTIONS, ALTER VECTOR INDEX … ON <table> REBUILD [OPTIONS(…)], or ALTER
+// <generic-entity> SET OPTIONS / SET AS <body>.
+type BQAlterStmt struct {
+	Object     BQAlterObjectKind
+	EntityType string // generic_entity_type spelling when Object==BQAlterEntity
+	IfExists   bool
+	Name       *PathExpr
+	OnTable    *PathExpr       // ON <table> for ALTER VECTOR INDEX; nil otherwise
+	Rebuild    bool            // REBUILD (vector index)
+	SetOptions []*OptionsEntry // SET OPTIONS(…); nil if absent
+	SetAsBody  string          // SET AS <generic_entity_body> text (entity); "" if absent
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *BQAlterStmt) Tag() NodeTag { return T_BQAlterStmt }
+
+// BQDropObjectKind discriminates the object kind of a BigQuery-only DROP
+// statement this node owns.
+type BQDropObjectKind int
+
+const (
+	BQDropFunction         BQDropObjectKind = iota // DROP FUNCTION
+	BQDropTableFunction                            // DROP TABLE FUNCTION
+	BQDropProcedure                                // DROP PROCEDURE
+	BQDropMaterializedView                         // DROP MATERIALIZED VIEW
+	BQDropApproxView                               // DROP APPROX VIEW
+	BQDropSnapshotTable                            // DROP SNAPSHOT TABLE
+	BQDropSearchIndex                              // DROP SEARCH INDEX … ON <table>
+	BQDropVectorIndex                              // DROP VECTOR INDEX … ON <table>
+	BQDropRowAccessPolicy                          // DROP ROW ACCESS POLICY … ON <table>
+	BQDropEntity                                   // DROP <generic-entity> (CAPACITY/RESERVATION/…)
+)
+
+// String returns the object keyword phrase.
+func (k BQDropObjectKind) String() string {
+	switch k {
+	case BQDropFunction:
+		return "FUNCTION"
+	case BQDropTableFunction:
+		return "TABLE FUNCTION"
+	case BQDropProcedure:
+		return "PROCEDURE"
+	case BQDropMaterializedView:
+		return "MATERIALIZED VIEW"
+	case BQDropApproxView:
+		return "APPROX VIEW"
+	case BQDropSnapshotTable:
+		return "SNAPSHOT TABLE"
+	case BQDropSearchIndex:
+		return "SEARCH INDEX"
+	case BQDropVectorIndex:
+		return "VECTOR INDEX"
+	case BQDropRowAccessPolicy:
+		return "ROW ACCESS POLICY"
+	default:
+		return "ENTITY"
+	}
+}
+
+// BQDropStmt is a BigQuery-only DROP statement: DROP FUNCTION / TABLE FUNCTION /
+// PROCEDURE / MATERIALIZED VIEW / APPROX VIEW / SNAPSHOT TABLE / {SEARCH|VECTOR}
+// INDEX … ON <table> / ROW ACCESS POLICY … ON <table> / generic-entity.
+type BQDropStmt struct {
+	Object     BQDropObjectKind
+	EntityType string // generic_entity_type spelling when Object==BQDropEntity
+	IfExists   bool
+	Name       *PathExpr // object path; for ROW ACCESS POLICY this is the policy name path
+	OnTable    *PathExpr // ON <table> for {SEARCH|VECTOR} INDEX / ROW ACCESS POLICY; nil otherwise
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *BQDropStmt) Tag() NodeTag { return T_BQDropStmt }
+
+// DropAllRowAccessPoliciesStmt is a DROP ALL ROW ACCESS POLICIES statement
+// (drop_all_row_access_policies_statement): `DROP ALL ROW ACCESS POLICIES ON
+// <table>`.
+type DropAllRowAccessPoliciesStmt struct {
+	Table *PathExpr // ON <table>
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *DropAllRowAccessPoliciesStmt) Tag() NodeTag { return T_DropAllRowAccessPoliciesStmt }
+
+// Compile-time assertions that the BigQuery DDL node types satisfy Node.
+var (
+	_ Node = (*FunctionParam)(nil)
+	_ Node = (*CreateFunctionStmt)(nil)
+	_ Node = (*CreateProcedureStmt)(nil)
+	_ Node = (*CreateMaterializedViewStmt)(nil)
+	_ Node = (*CreateSnapshotStmt)(nil)
+	_ Node = (*SearchVectorIndexStmt)(nil)
+	_ Node = (*CreateRowAccessPolicyStmt)(nil)
+	_ Node = (*CreateEntityStmt)(nil)
+	_ Node = (*BQAlterStmt)(nil)
+	_ Node = (*BQDropStmt)(nil)
+	_ Node = (*DropAllRowAccessPoliciesStmt)(nil)
+)
+
 // ---------------------------------------------------------------------------
 // DML — INSERT / UPDATE / DELETE / MERGE / TRUNCATE (parser-dml node)
 // ---------------------------------------------------------------------------

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -50,6 +50,23 @@ func walkChildren(v Visitor, node Node) {
 	case *AssertStmt:
 		Walk(v, n.Expr)
 		Walk(v, n.Description)
+	case *BQAlterStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.OnTable != nil {
+			Walk(v, n.OnTable)
+		}
+		for _, c := range n.SetOptions {
+			Walk(v, c)
+		}
+	case *BQDropStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.OnTable != nil {
+			Walk(v, n.OnTable)
+		}
 	case *BetweenExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.Low)
@@ -114,6 +131,31 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
+	case *CreateEntityStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+	case *CreateFunctionStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Params {
+			Walk(v, c)
+		}
+		if n.Returns != nil {
+			Walk(v, n.Returns)
+		}
+		for _, c := range n.ReturnColumns {
+			Walk(v, c)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+		Walk(v, n.Body)
+		Walk(v, n.AsQuery)
 	case *CreateIndexStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -133,10 +175,56 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
+	case *CreateMaterializedViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Columns {
+			Walk(v, c)
+		}
+		walkNodes(v, n.PartitionBy)
+		walkNodes(v, n.ClusterBy)
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+		Walk(v, n.AsQuery)
+		if n.ReplicaOf != nil {
+			Walk(v, n.ReplicaOf)
+		}
+	case *CreateProcedureStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Params {
+			Walk(v, c)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+	case *CreateRowAccessPolicyStmt:
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
+		for _, c := range n.Grantees {
+			Walk(v, c)
+		}
+		Walk(v, n.Filter)
 	case *CreateSchemaStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+	case *CreateSnapshotStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.CloneSource != nil {
+			Walk(v, n.CloneSource)
+		}
+		Walk(v, n.ForSystemTime)
+		Walk(v, n.Where)
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
@@ -199,6 +287,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.FromPath != nil {
 			Walk(v, n.FromPath)
 		}
+	case *DropAllRowAccessPoliciesStmt:
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
 	case *DropStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -244,6 +336,11 @@ func walkChildren(v Visitor, node Node) {
 		if n.Over != nil {
 			Walk(v, n.Over)
 		}
+	case *FunctionParam:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		Walk(v, n.Default)
 	case *GrantStmt:
 		for _, c := range n.Privileges {
 			Walk(v, c)
@@ -402,6 +499,21 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, c)
 		}
 		for _, c := range n.Grantees {
+			Walk(v, c)
+		}
+	case *SearchVectorIndexStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.Table != nil {
+			Walk(v, n.Table)
+		}
+		for _, c := range n.Keys {
+			Walk(v, c)
+		}
+		walkNodes(v, n.Storing)
+		walkNodes(v, n.PartitionBy)
+		for _, c := range n.Options {
 			Walk(v, c)
 		}
 	case *SelectItem:

--- a/googlesql/parser/alter_table.go
+++ b/googlesql/parser/alter_table.go
@@ -57,10 +57,22 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		kind = ast.AlterSchema
 	case kwDATABASE:
 		kind = ast.AlterDatabase
+	// --- BigQuery-only ALTER objects (parser-ddl-bigquery node) ---
+	case kwMATERIALIZED, kwAPPROX:
+		// ALTER MATERIALIZED|APPROX VIEW SET OPTIONS (bq_materialized_view.go).
+		return p.parseBQAlterMaterializedView(alter)
+	case kwVECTOR:
+		// ALTER VECTOR INDEX … ON … REBUILD (bq_search_vector_index.go).
+		return p.parseBQAlterVectorIndex(alter)
 	default:
-		// ALTER FUNCTION / PROCEDURE / MODEL / MATERIALIZED VIEW / generic entity /
-		// PRIVILEGE RESTRICTION / ROW ACCESS POLICY / ALL ROW ACCESS POLICIES — not
-		// owned here.
+		// ALTER <generic-entity> (CAPACITY / RESERVATION / ASSIGNMENT — the keyword
+		// lexes as an identifier) routes to the generic-entity alter
+		// (bq_capacity.go). ALTER FUNCTION / PROCEDURE / MODEL / PRIVILEGE
+		// RESTRICTION / ROW ACCESS POLICY / ALL ROW ACCESS POLICIES are not owned
+		// here.
+		if isGenericEntityType(p.cur.Type) {
+			return p.parseBQAlterEntity(alter)
+		}
 		return p.unsupported("ALTER")
 	}
 	p.advance() // consume the object keyword

--- a/googlesql/parser/bq_capacity.go
+++ b/googlesql/parser/bq_capacity.go
@@ -1,0 +1,212 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// BigQuery DDL — generic-entity CREATE / ALTER / DROP
+// (parser-ddl-bigquery node)
+// ---------------------------------------------------------------------------
+//
+// Ports the legacy ANTLR generic-entity mechanism (GoogleSQLParser.g4 §2.2/§2.3):
+// create_entity_statement plus the generic-entity alternatives of alter_statement
+// and drop_statement. This is how the legacy grammar parses extensible object
+// kinds whose KEYWORD is a bare identifier — which is exactly how BigQuery
+// CAPACITY / RESERVATION / ASSIGNMENT (DDL-024/025/026/053) are parsed: those
+// words are NOT reserved tokens in the grammar, so they match
+// `generic_entity_type: IDENTIFIER | PROJECT`. The node's display name calls out
+// CAPACITY/RESERVATION/ASSIGNMENT specifically; implementing the generic-entity
+// path covers them faithfully (the legacy grammar has no dedicated rule for any
+// of them) plus any other extensible entity.
+//
+//	create_entity_statement:
+//	  CREATE opt_or_replace? generic_entity_type opt_if_not_exists? path_expression
+//	    opt_options_list? opt_generic_entity_body?
+//	  opt_generic_entity_body: AS generic_entity_body
+//	  generic_entity_body: json_literal | string_literal
+//	  generic_entity_type: IDENTIFIER | PROJECT
+//	alter_statement (generic entity):
+//	  ALTER generic_entity_type opt_if_exists? path_expression alter_action_list
+//	  | ALTER generic_entity_type opt_if_exists? alter_action_list
+//	drop_statement (generic entity):
+//	  DROP generic_entity_type opt_if_exists? path_expression
+//
+// ORACLE NOTE — BigQuery-only at the union level (oracle.md). Probed 2026-06-05:
+// `CREATE CAPACITY \`p.l.c\` OPTIONS(…)` REJECTS on the Spanner emulator
+// ("Encountered 'CAPACITY' while parsing: create_statement" — Spanner has no
+// generic-entity mechanism). Triangulated against the legacy .g4 + BigQuery
+// truth1 (DDL-024/025/026/053); proven by the unit tests in bq_capacity_test.go.
+
+// isGenericEntityType reports whether tokenType can begin a generic_entity_type
+// (`IDENTIFIER | PROJECT`). CAPACITY / RESERVATION / ASSIGNMENT lex as
+// tokIdentifier (they are not reserved keywords), so they are admitted here.
+func isGenericEntityType(tokenType int) bool {
+	return tokenType == tokIdentifier || tokenType == kwPROJECT
+}
+
+// parseCreateEntity parses a CREATE <generic-entity> statement. The shared CREATE
+// prefix (OR REPLACE) has been consumed by parseCreateStmt; cur is at the entity
+// type token (a bare identifier or PROJECT). The grammar's create_entity_statement
+// has no opt_create_scope (so a TEMP/etc. before the entity type would already
+// have routed elsewhere).
+func (p *Parser) parseCreateEntity(create Token, orReplace bool) (ast.Node, error) {
+	entityTok := p.advance() // entity type
+	entityType := p.tokenSource(entityTok)
+
+	stmt := &ast.CreateEntityStmt{OrReplace: orReplace, EntityType: entityType}
+	stmt.Loc.Start = create.Loc.Start
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// opt_options_list?
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	// opt_generic_entity_body? — AS generic_entity_body (json_literal | string_literal).
+	if p.cur.Type == kwAS {
+		p.advance() // AS
+		body, err := p.parseGenericEntityBody()
+		if err != nil {
+			return nil, err
+		}
+		stmt.BodyText = body
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseGenericEntityBody parses a generic_entity_body (`json_literal |
+// string_literal`) and returns its source text. json_literal is `JSON 'string'`;
+// a bare string_literal is also accepted. Captured as text since the body is a
+// free-form literal the query-span consumer never inspects.
+func (p *Parser) parseGenericEntityBody() (string, error) {
+	start := p.cur.Loc
+	switch {
+	case p.cur.Type == kwJSON:
+		p.advance() // JSON
+		strTok, err := p.expect(tokString)
+		if err != nil {
+			return "", err
+		}
+		return p.sourceSpan(start, strTok.Loc), nil
+	case p.cur.Type == tokString:
+		strTok := p.advance()
+		return strTok.Str, nil
+	default:
+		return "", p.syntaxErrorAtCur()
+	}
+}
+
+// sourceSpan returns the verbatim source text spanning from start.Start through
+// end.End in the segment input, or "" if the span is out of range.
+func (p *Parser) sourceSpan(start, end ast.Loc) string {
+	s := absIndex(p, start.Start)
+	e := absIndex(p, end.End)
+	if s >= 0 && e <= len(p.input) && s < e {
+		return p.input[s:e]
+	}
+	return ""
+}
+
+// parseBQAlterEntity parses an ALTER <generic-entity> statement. The ALTER keyword
+// has been consumed by parseAlterStmt; cur is at the entity type token (a bare
+// identifier or PROJECT). The grammar admits two shapes:
+//
+//	ALTER generic_entity_type opt_if_exists? path_expression alter_action_list
+//	ALTER generic_entity_type opt_if_exists? alter_action_list           (no path)
+//
+// The alter_action of interest for these entities is SET OPTIONS(…) or
+// SET AS generic_entity_body. We accept those; other alter_actions are out of the
+// documented entity surface and reject as a syntax error.
+func (p *Parser) parseBQAlterEntity(alter Token) (ast.Node, error) {
+	entityTok := p.advance() // entity type
+	entityType := p.tokenSource(entityTok)
+
+	stmt := &ast.BQAlterStmt{Object: ast.BQAlterEntity, EntityType: entityType}
+	stmt.Loc.Start = alter.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	// Optional path_expression: present unless the next token starts the
+	// alter_action_list directly (SET). A leading SET means the no-path shape.
+	if p.cur.Type != kwSET {
+		name, err := p.parseTablePath()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Name = name
+	}
+
+	// alter_action_list — for entities, SET OPTIONS(…) | SET AS generic_entity_body.
+	if _, err := p.expect(kwSET); err != nil {
+		return nil, err
+	}
+	switch p.cur.Type {
+	case kwOPTIONS:
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SetOptions = opts
+	case kwAS:
+		p.advance() // AS
+		body, err := p.parseGenericEntityBody()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SetAsBody = body
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseBQDropEntity parses a DROP <generic-entity> statement. The DROP keyword has
+// been consumed by parseDropStmt; cur is at the entity type token (a bare
+// identifier or PROJECT). Grammar: `DROP generic_entity_type opt_if_exists?
+// path_expression` (DDL-053 DROP CAPACITY/RESERVATION/ASSIGNMENT).
+func (p *Parser) parseBQDropEntity(drop Token) (ast.Node, error) {
+	entityTok := p.advance() // entity type
+	entityType := p.tokenSource(entityTok)
+
+	stmt := &ast.BQDropStmt{Object: ast.BQDropEntity, EntityType: entityType}
+	stmt.Loc.Start = drop.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/googlesql/parser/bq_capacity_test.go
+++ b/googlesql/parser/bq_capacity_test.go
@@ -1,0 +1,126 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-ddl-bigquery node generic-entity path: CREATE / ALTER
+// / DROP CAPACITY / RESERVATION / ASSIGNMENT (DDL-024/025/026/053). The legacy
+// GoogleSQLParser.g4 has NO dedicated rule for these — they parse via the generic
+// entity mechanism (generic_entity_type: IDENTIFIER | PROJECT), so CAPACITY etc.
+// must lex as bare identifiers (they are not reserved keywords). BigQuery-only at
+// the union level (Spanner has no generic-entity mechanism; CREATE CAPACITY
+// rejects, probed 2026-06-05).
+
+func entityOf(t *testing.T, sql string) *ast.CreateEntityStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	e, ok := n.(*ast.CreateEntityStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateEntityStmt", sql, n)
+	}
+	return e
+}
+
+func TestCreateCapacity(t *testing.T) {
+	// DDL-024.
+	e := entityOf(t, "CREATE CAPACITY `admin_project.region-us.my-commitment` OPTIONS (slot_count = 100, plan = 'ANNUAL')")
+	if e.EntityType != "CAPACITY" {
+		t.Errorf("EntityType = %q, want CAPACITY", e.EntityType)
+	}
+	if e.Name.String() != "admin_project.region-us.my-commitment" {
+		t.Errorf("Name = %q", e.Name.String())
+	}
+	if len(e.Options) != 2 {
+		t.Errorf("Options = %d, want 2", len(e.Options))
+	}
+}
+
+func TestCreateReservation(t *testing.T) {
+	// DDL-025.
+	e := entityOf(t, "CREATE RESERVATION `admin_project.region-us.prod` OPTIONS (slot_capacity = 100)")
+	if e.EntityType != "RESERVATION" {
+		t.Errorf("EntityType = %q, want RESERVATION", e.EntityType)
+	}
+}
+
+func TestCreateAssignment(t *testing.T) {
+	// DDL-026.
+	e := entityOf(t, "CREATE ASSIGNMENT `admin_project.region-us.prod.my-assignment` OPTIONS (assignee = 'projects/my-project', job_type = 'QUERY')")
+	if e.EntityType != "ASSIGNMENT" {
+		t.Errorf("EntityType = %q, want ASSIGNMENT", e.EntityType)
+	}
+}
+
+func TestCreateEntity_OrReplaceIfNotExistsBody(t *testing.T) {
+	e := entityOf(t, "CREATE OR REPLACE RESERVATION IF NOT EXISTS `p.r` OPTIONS(x=1) AS JSON '{\"a\":1}'")
+	if !e.OrReplace || !e.IfNotExists {
+		t.Errorf("OrReplace=%v IfNotExists=%v, want both true", e.OrReplace, e.IfNotExists)
+	}
+	if e.BodyText == "" {
+		t.Error("BodyText = empty, want the AS JSON body text")
+	}
+}
+
+func TestCreateEntity_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE CAPACITY",                 // missing name
+		"CREATE RESERVATION OPTIONS(x=1)", // OPTIONS where a name is required (OPTIONS is a keyword, not a path)
+		// Regression (review finding): create_entity_statement has NO
+		// opt_create_scope; a leading TEMP must reject (TEMP is not the entity type).
+		"CREATE TEMP RESERVATION `p.r` OPTIONS(x=1)",
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- ALTER <generic-entity> ---
+
+func TestAlterReservation_SetOptions(t *testing.T) {
+	a := bqAlterOf(t, "ALTER RESERVATION `p.r` SET OPTIONS(slot_capacity=200)")
+	if a.Object != ast.BQAlterEntity || a.EntityType != "RESERVATION" {
+		t.Errorf("Object=%v EntityType=%q", a.Object, a.EntityType)
+	}
+	if len(a.SetOptions) != 1 {
+		t.Errorf("SetOptions = %d, want 1", len(a.SetOptions))
+	}
+}
+
+func TestAlterEntity_SetAs(t *testing.T) {
+	a := bqAlterOf(t, "ALTER CAPACITY `p.c` SET AS JSON '{\"x\":1}'")
+	if a.SetAsBody == "" {
+		t.Error("SetAsBody = empty, want the JSON body")
+	}
+}
+
+// --- DROP <generic-entity> ---
+
+func TestDropCapacity(t *testing.T) {
+	// DDL-053.
+	d := bqDropOf(t, "DROP CAPACITY IF EXISTS `admin_project.region-us.my-commitment`")
+	if d.Object != ast.BQDropEntity || d.EntityType != "CAPACITY" {
+		t.Errorf("Object=%v EntityType=%q", d.Object, d.EntityType)
+	}
+	if !d.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+}
+
+func TestDropReservationAssignment(t *testing.T) {
+	// DDL-053.
+	for _, tc := range []struct {
+		sql  string
+		want string
+	}{
+		{"DROP RESERVATION IF EXISTS `admin_project.region-us.prod`", "RESERVATION"},
+		{"DROP ASSIGNMENT IF EXISTS `admin_project.region-us.prod.my-assignment`", "ASSIGNMENT"},
+	} {
+		d := bqDropOf(t, tc.sql)
+		if d.EntityType != tc.want {
+			t.Errorf("Parse(%q): EntityType = %q, want %q", tc.sql, d.EntityType, tc.want)
+		}
+	}
+}

--- a/googlesql/parser/bq_ddl_oracle_test.go
+++ b/googlesql/parser/bq_ddl_oracle_test.go
@@ -1,0 +1,114 @@
+//go:build googlesql_oracle
+
+// Differential / triangulation gate for the parser-ddl-bigquery node against the
+// live Cloud Spanner emulator. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestBQDDL
+//
+// ⚠ Every form this node owns is BigQuery-ONLY at the GoogleSQL union level
+// (oracle.md): the Spanner emulator is NOT an authoritative oracle for them. So
+// this is NOT a plain accept/reject differential — it is a TRIANGULATION GUARD.
+// For each fixture we record:
+//   - omni's verdict (the union parser MUST accept these documented BigQuery
+//     forms — triangulated against the legacy GoogleSQLParser.g4 + truth1), and
+//   - the live emulator's verdict, asserted to equal the EMPIRICALLY-OBSERVED
+//     value (probed 2026-06-05). Most BigQuery-only forms hard-syntax-REJECT on
+//     Spanner (a non-authoritative reject the union parser correctly overrides);
+//     a NARROW few (bare CREATE FUNCTION … AS (expr), DROP FUNCTION, CREATE
+//     VECTOR INDEX) ACCEPT because Spanner happens to share that shape.
+//
+// The guard's value: if an emulator bump ever changes a recorded oracle verdict
+// (e.g. Spanner starts parsing a form it used to reject), this test fails and
+// forces a re-review of the triangulation for that form, rather than silently
+// trusting a now-stale assumption. omni's own accept/reject correctness is
+// proven by the hand-written unit tests (bq_*_test.go); this file ties those to
+// the live oracle so the BigQuery-vs-Spanner boundary stays honest.
+package parser
+
+import (
+	"os"
+	"testing"
+)
+
+// bqOracleExpectation is the empirically-observed live-emulator verdict for a
+// BigQuery-only form, plus omni's required verdict (always accept — the union
+// parser must parse the documented form).
+type bqOracleExpectation struct {
+	sql         string
+	oracle      string // "accept" | "reject" — the OBSERVED Spanner-emulator verdict (2026-06-05)
+	omniAccepts bool   // omni's required verdict (the union parser)
+	note        string
+}
+
+var bqOracleFixtures = []bqOracleExpectation{
+	// ---- hard BigQuery-only (Spanner has NO such grammar) → oracle REJECTs, omni accepts ----
+	{"CREATE OR REPLACE TABLE FUNCTION ds.f(y INT64) AS SELECT 1 AS n", "reject", true, "TABLE FUNCTION not in Spanner"},
+	{"CREATE PROCEDURE ds.p(IN tbl STRING) BEGIN SELECT 1; END", "reject", true, "PROCEDURE not in Spanner"},
+	{"CREATE MATERIALIZED VIEW ds.mv AS SELECT 1 AS n", "reject", true, "MATERIALIZED VIEW not in Spanner"},
+	{"CREATE APPROX VIEW ds.v AS SELECT 1 AS n", "reject", true, "APPROX VIEW not in Spanner"},
+	{"CREATE SEARCH INDEX my_index ON ds.t(ALL COLUMNS)", "reject", true, "SEARCH INDEX ALL COLUMNS not in Spanner"},
+	{"CREATE SNAPSHOT TABLE ds.s CLONE ds.t", "reject", true, "SNAPSHOT not in Spanner"},
+	{"CREATE ROW ACCESS POLICY p ON ds.t GRANT TO ('user:a@b.com') FILTER USING (TRUE)", "reject", true, "ROW ACCESS POLICY not in Spanner"},
+	{"CREATE CAPACITY `p.r.c` OPTIONS (slot_count = 100)", "reject", true, "generic-entity CAPACITY not in Spanner"},
+	{"CREATE RESERVATION `p.r` OPTIONS (slot_capacity = 100)", "reject", true, "generic-entity RESERVATION not in Spanner"},
+	{"CREATE TEMP FUNCTION f(x INT64) AS (x)", "reject", true, "TEMP function not in Spanner"},
+	{"CREATE AGGREGATE FUNCTION ds.f(x FLOAT64) AS (SUM(x))", "reject", true, "AGGREGATE function not in Spanner"},
+	{"CREATE FUNCTION ds.f(x FLOAT64) RETURNS FLOAT64 LANGUAGE js AS 'return x'", "reject", true, "LANGUAGE js not in Spanner"},
+	{"CREATE FUNCTION ds.f(x INT64) RETURNS INT64 DETERMINISTIC AS (x)", "reject", true, "DETERMINISTIC not in Spanner"},
+	{"DROP TABLE FUNCTION ds.f", "reject", true, "DROP TABLE FUNCTION not in Spanner"},
+	{"DROP VECTOR INDEX idx ON ds.t", "reject", true, "DROP VECTOR INDEX … ON not in Spanner"},
+	{"DROP SEARCH INDEX idx ON ds.t", "reject", true, "DROP SEARCH INDEX … ON not in Spanner"},
+	{"ALTER VECTOR INDEX idx ON ds.t REBUILD", "reject", true, "ALTER VECTOR INDEX REBUILD not in Spanner (nor in legacy .g4 — flagged divergence)"},
+
+	// ---- narrow shared shapes → oracle ACCEPTs (semantic), omni accepts ----
+	{"CREATE FUNCTION ds.f(x INT64) AS (x + 1)", "accept", true, "bare CREATE FUNCTION … AS (expr) is shared with Spanner"},
+	{"CREATE OR REPLACE FUNCTION ds.f(x INT64) RETURNS INT64 AS (x)", "accept", true, "shared scalar SQL function"},
+	{"CREATE VECTOR INDEX my_index ON ds.t(embedding) OPTIONS(distance_type='COSINE')", "accept", true, "Spanner has a vector-index grammar for this shape"},
+	{"DROP FUNCTION ds.f", "accept", true, "DROP FUNCTION is shared with Spanner"},
+	{"DROP FUNCTION IF EXISTS ds.f", "accept", true, "DROP FUNCTION IF EXISTS shared"},
+}
+
+func TestBQDDLTriangulation(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live triangulation guard")
+	}
+	h := newDDLHarness(t)
+	defer h.close()
+
+	for _, fx := range bqOracleFixtures {
+		fx := fx
+		t.Run(fx.sql, func(t *testing.T) {
+			// 1. Live oracle verdict.
+			v := h.verdict(t, fx.sql)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s",
+					fx.sql, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.sql)
+			}
+
+			// The recorded oracle expectation MUST still hold. If it drifts, the
+			// emulator changed (e.g. Spanner added the form) and the triangulation
+			// for this fixture needs a fresh look — do NOT silently update.
+			if v.Verdict != fx.oracle {
+				t.Fatalf("oracle verdict drift on %q: recorded=%q now=%q (%s: %s) [%s]\n"+
+					"the Spanner emulator changed; re-review the BigQuery-vs-Spanner triangulation for this form",
+					fx.sql, fx.oracle, v.Verdict, v.Reason, v.Message, fx.note)
+			}
+
+			// 2. omni's verdict — the union parser must match omniAccepts. For the
+			// BigQuery-only forms that is ALWAYS accept (the documented form is valid
+			// GoogleSQL); the Spanner reject above is non-authoritative.
+			_, errs := Parse(fx.sql)
+			omniAccepts := len(errs) == 0
+			if omniAccepts != fx.omniAccepts {
+				t.Errorf("omni verdict on %q: accepts=%v, want %v; errs=%v [%s]",
+					fx.sql, omniAccepts, fx.omniAccepts, errs, fx.note)
+			}
+		})
+	}
+}

--- a/googlesql/parser/bq_function_procedure.go
+++ b/googlesql/parser/bq_function_procedure.go
@@ -1,0 +1,945 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// BigQuery DDL — CREATE [AGGREGATE] FUNCTION / TABLE FUNCTION / PROCEDURE
+// (parser-ddl-bigquery node)
+// ---------------------------------------------------------------------------
+//
+// Ports the legacy ANTLR create_function_statement,
+// create_table_function_statement, and create_procedure_statement
+// (GoogleSQLParser.g4 §2.2) — a hand-port of Google's open-source ZetaSQL
+// reference. These object kinds are routed here from the core parseCreateStmt
+// fan-out (they were stubbed by the parser-ddl node).
+//
+//	create_function_statement:
+//	  CREATE opt_or_replace? opt_create_scope? opt_aggregate? FUNCTION opt_if_not_exists?
+//	    function_declaration opt_function_returns? opt_sql_security_clause?
+//	    opt_determinism_level? opt_language_or_remote_with_connection?
+//	    unordered_options_body?
+//	create_table_function_statement:
+//	  CREATE opt_or_replace? opt_create_scope? TABLE FUNCTION opt_if_not_exists?
+//	    path_expression opt_function_parameters? opt_returns? opt_sql_security_clause?
+//	    unordered_language_options? opt_as_query_or_string?
+//	create_procedure_statement:
+//	  CREATE opt_or_replace? opt_create_scope? PROCEDURE opt_if_not_exists?
+//	    path_expression procedure_parameters opt_external_security_clause?
+//	    with_connection_clause? opt_options_list? begin_end_block_or_language_as_code
+//
+// ORACLE NOTE — BigQuery-only at the union level (oracle.md). The Spanner
+// emulator parses a NARROWER CREATE FUNCTION (a bare `CREATE FUNCTION f(x T) AS
+// (expr)` accepts) but REJECTS TEMP / AGGREGATE / LANGUAGE / DETERMINISTIC /
+// REMOTE and the whole TABLE FUNCTION / PROCEDURE forms (probed 2026-06-05). So
+// the Spanner verdict is non-authoritative for these; they are triangulated
+// against the legacy .g4 + BigQuery truth1 (DDL-015..020) and proven by the unit
+// tests in bq_function_procedure_test.go.
+
+// parseCreateFunction parses a CREATE [AGGREGATE] FUNCTION or CREATE TABLE
+// FUNCTION statement. The shared CREATE prefix (OR REPLACE / scope) has been
+// consumed by parseCreateStmt; aggregate reports whether an AGGREGATE qualifier
+// preceded FUNCTION, and isTableFunc whether this is the TABLE FUNCTION form
+// (cur is at FUNCTION in both cases). create is the CREATE token (for Loc).
+func (p *Parser) parseCreateFunction(create Token, orReplace bool, scope string, aggregate, isTableFunc bool) (ast.Node, error) {
+	if isTableFunc {
+		// TABLE FUNCTION: cur is at TABLE (the dispatch matched kwTABLE and peeked
+		// FUNCTION). Consume both.
+		p.advance() // TABLE
+	}
+	p.advance() // consume FUNCTION
+
+	stmt := &ast.CreateFunctionStmt{
+		OrReplace:   orReplace,
+		Scope:       scope,
+		Aggregate:   aggregate,
+		IsTableFunc: isTableFunc,
+	}
+	stmt.Loc.Start = create.Loc.Start
+
+	// opt_if_not_exists? — note the legacy create_function_statement marks this as
+	// REQUIRED in the rule text (opt_if_not_exists without `?` on a rule that is
+	// itself optional), but it is genuinely optional in practice; parseIfNotExists
+	// returns false when absent.
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	// function_declaration: path_expression function_parameters.
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// function_parameters / opt_function_parameters — a parenthesized parameter
+	// list. For a scalar/aggregate FUNCTION the list is required (function_declaration
+	// requires it); for a TABLE FUNCTION it is opt_function_parameters? but the
+	// grammar's action emits "Expected (" when missing — so both effectively require
+	// the '('. We require it for both (a missing '(' is a syntax error either way).
+	if p.cur.Type != int('(') {
+		return nil, p.syntaxErrorAtCur()
+	}
+	params, err := p.parseFunctionParameters(false /*procedure*/)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Params = params
+
+	// opt_returns? — RETURNS type_or_tvf_schema. For a TVF this is RETURNS TABLE<…>.
+	if p.cur.Type == kwRETURNS {
+		if err := p.parseFunctionReturns(stmt); err != nil {
+			return nil, err
+		}
+	}
+
+	// opt_sql_security_clause? — SQL SECURITY {INVOKER|DEFINER}.
+	if p.cur.Type == kwSQL {
+		sec, err := p.parseSQLSecurityClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SQLSecurity = sec
+	}
+
+	if isTableFunc {
+		// TABLE FUNCTION tail: unordered_language_options? opt_as_query_or_string?
+		//   unordered_language_options: language opt_options_list? | opt_options_list language?
+		if err := p.parseUnorderedLanguageOptions(stmt); err != nil {
+			return nil, err
+		}
+		// opt_as_query_or_string?: AS query | AS string_literal.
+		if p.cur.Type == kwAS {
+			if err := p.parseAsQueryOrString(stmt); err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		// scalar / aggregate FUNCTION tail:
+		//   opt_determinism_level? opt_language_or_remote_with_connection?
+		//     unordered_options_body?
+		stmt.Determinism = p.matchDeterminismLevel()
+
+		// opt_language_or_remote_with_connection?:
+		//   LANGUAGE id remote_with_connection_clause?
+		//   | remote_with_connection_clause language?
+		if err := p.parseLanguageOrRemoteWithConnection(stmt); err != nil {
+			return nil, err
+		}
+
+		// unordered_options_body?:
+		//   opt_options_list as_sql_function_body_or_string?
+		//   | as_sql_function_body_or_string opt_options_list?
+		if err := p.parseUnorderedOptionsBody(stmt); err != nil {
+			return nil, err
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	// The function body / TVF query may embed subqueries captured as RawText by the
+	// frozen expressions node; fill them so the query-span consumer sees a complete
+	// tree (mirrors parseStmtWithSubqueries; idempotent).
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// parseFunctionReturns parses a RETURNS type_or_tvf_schema into stmt. cur is at
+// RETURNS. A TVF schema (TABLE < col, … >) sets ReturnsTable + ReturnColumns; a
+// plain type sets Returns.
+func (p *Parser) parseFunctionReturns(stmt *ast.CreateFunctionStmt) error {
+	p.advance() // RETURNS
+	if p.cur.Type == kwTABLE && p.peekNext().Type == int('<') {
+		cols, err := p.parseTVFSchema()
+		if err != nil {
+			return err
+		}
+		stmt.ReturnsTable = true
+		stmt.ReturnColumns = cols
+		return nil
+	}
+	dt, err := p.parseType()
+	if err != nil {
+		return err
+	}
+	stmt.Returns = &ast.TypeRef{Text: dt.String(), Loc: dt.Loc}
+	return nil
+}
+
+// parseTVFSchema parses a tvf_schema: `TABLE < tvf_schema_column (, …) >`, where
+// each tvf_schema_column is `identifier type | type`. cur is at TABLE; the next
+// token is the template-open '<'. Returns the columns as ColumnDefs (Name "" for
+// a bare-type column).
+func (p *Parser) parseTVFSchema() ([]*ast.ColumnDef, error) {
+	p.advance() // TABLE
+	if err := p.expectTemplateOpen(); err != nil {
+		return nil, err
+	}
+	var cols []*ast.ColumnDef
+	for {
+		col, err := p.parseTVFSchemaColumn()
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, col)
+		if _, ok := p.match(int(',')); ok {
+			continue
+		}
+		break
+	}
+	if _, err := p.expectTemplateClose(); err != nil {
+		return nil, err
+	}
+	return cols, nil
+}
+
+// beginsTypeOrTVFFollowingName reports whether tokenType can begin a
+// type_or_tvf_schema when it follows a candidate parameter/column NAME. It
+// extends beginsTypeFollowingName (the struct-field disambiguator) with the two
+// type-starts that only appear in the type_or_tvf_schema position: ANY (a
+// templated_parameter_type `ANY <kind>`) and TABLE (a tvf_schema `TABLE<…>`).
+// Both are needed so `p ANY TYPE` / `t TABLE<x INT64>` are read as named
+// parameters, not a bare type with trailing junk.
+func beginsTypeOrTVFFollowingName(tokenType int) bool {
+	if tokenType == kwANY || tokenType == kwTABLE {
+		return true
+	}
+	return beginsTypeFollowingName(tokenType)
+}
+
+// parseTVFSchemaColumn parses one tvf_schema_column: `identifier type | type`.
+// It is `identifier type` when the current token is an identifier-start AND the
+// following token begins a type (so a bare type name like `INT64` is not mistaken
+// for a column name with a missing type).
+func (p *Parser) parseTVFSchemaColumn() (*ast.ColumnDef, error) {
+	start := p.cur.Loc
+	if isIdentifierStart(p.cur.Type) && beginsTypeOrTVFFollowingName(p.peekNext().Type) {
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		dt, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.ColumnDef{
+			Name: name,
+			Type: &ast.TypeRef{Text: dt.String(), Loc: dt.Loc},
+			Loc:  ast.Loc{Start: start.Start, End: p.prev.Loc.End},
+		}, nil
+	}
+	// Bare type column (no name).
+	dt, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ColumnDef{
+		Type: &ast.TypeRef{Text: dt.String(), Loc: dt.Loc},
+		Loc:  ast.Loc{Start: start.Start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// parseFunctionParameters parses a parenthesized parameter list. cur is at the
+// opening '('. When isProcedure is true the procedure_parameter grammar applies
+// (an optional IN/OUT/INOUT mode then `identifier type_or_tvf_schema`); otherwise
+// the function_parameter grammar applies (`identifier type_or_tvf_schema [AS
+// alias] [DEFAULT expr] [NOT AGGREGATE]` or a bare `type_or_tvf_schema`). An empty
+// `()` list is legal.
+func (p *Parser) parseFunctionParameters(isProcedure bool) ([]*ast.FunctionParam, error) {
+	p.advance() // '('
+	var params []*ast.FunctionParam
+	if p.cur.Type == int(')') {
+		p.advance()
+		return params, nil
+	}
+	for {
+		var (
+			param *ast.FunctionParam
+			err   error
+		)
+		if isProcedure {
+			param, err = p.parseProcedureParameter()
+		} else {
+			param, err = p.parseFunctionParameter()
+		}
+		if err != nil {
+			return nil, err
+		}
+		params = append(params, param)
+		if _, ok := p.match(int(',')); ok {
+			continue
+		}
+		break
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+// parseFunctionParameter parses one function_parameter:
+//
+//	identifier type_or_tvf_schema [AS alias] [DEFAULT expr] [NOT AGGREGATE]
+//	| type_or_tvf_schema [AS alias] [NOT AGGREGATE]
+//
+// The named form applies when cur is an identifier-start AND the following token
+// begins a type; otherwise the bare-type form applies (so `INT64` is a bare type,
+// not a name with a missing type).
+func (p *Parser) parseFunctionParameter() (*ast.FunctionParam, error) {
+	start := p.cur.Loc
+	param := &ast.FunctionParam{}
+
+	if isIdentifierStart(p.cur.Type) && beginsTypeOrTVFFollowingName(p.peekNext().Type) {
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		param.Name = name
+	}
+
+	// type_or_tvf_schema: a TVF `TABLE<…>` schema, ANY TYPE/<kind>, or a plain type.
+	tref, err := p.parseTypeOrTVFSchema()
+	if err != nil {
+		return nil, err
+	}
+	param.Type = tref
+
+	// opt_as_alias_with_required_as? — AS identifier.
+	if p.cur.Type == kwAS {
+		p.advance() // AS
+		aliasTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(aliasTok)
+		if err != nil {
+			return nil, err
+		}
+		param.Alias = alias
+	}
+
+	// opt_default_expression? — DEFAULT expr (named form only in the grammar; the
+	// bare-type form has no DEFAULT, but parsing it here only affects an already-
+	// invalid bare-type-with-DEFAULT input, which is rare).
+	if param.Name != "" && p.cur.Type == kwDEFAULT {
+		p.advance() // DEFAULT
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		param.Default = expr
+	}
+
+	// opt_not_aggregate? — NOT AGGREGATE.
+	if p.cur.Type == kwNOT && p.peekNext().Type == kwAGGREGATE {
+		p.advance() // NOT
+		p.advance() // AGGREGATE
+		param.NotAggregate = true
+	}
+
+	param.Loc = ast.Loc{Start: start.Start, End: p.prev.Loc.End}
+	return param, nil
+}
+
+// parseProcedureParameter parses one procedure_parameter:
+//
+//	[IN|OUT|INOUT] identifier type_or_tvf_schema
+//
+// The error alternative (a parameter with no type) surfaces naturally as a
+// syntax error from parseTypeOrTVFSchema at the ')' or ',' terminator.
+func (p *Parser) parseProcedureParameter() (*ast.FunctionParam, error) {
+	start := p.cur.Loc
+	param := &ast.FunctionParam{}
+
+	// opt_procedure_parameter_mode?: IN | OUT | INOUT. These are non-reserved and
+	// may legitimately be a parameter NAME — disambiguate by lookahead: a mode is a
+	// mode only when an identifier (the real name) follows it; `IN INT64` means the
+	// parameter named `IN` of type `INT64`.
+	switch p.cur.Type {
+	case kwIN:
+		if isIdentifierStart(p.peekNext().Type) {
+			p.advance()
+			param.Mode = ast.ParamModeIn
+		}
+	case kwOUT:
+		if isIdentifierStart(p.peekNext().Type) {
+			p.advance()
+			param.Mode = ast.ParamModeOut
+		}
+	case kwINOUT:
+		if isIdentifierStart(p.peekNext().Type) {
+			p.advance()
+			param.Mode = ast.ParamModeInout
+		}
+	}
+
+	// identifier (the parameter name) — required.
+	nameTok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(nameTok)
+	if err != nil {
+		return nil, err
+	}
+	param.Name = name
+
+	// type_or_tvf_schema — required.
+	tref, err := p.parseTypeOrTVFSchema()
+	if err != nil {
+		return nil, err
+	}
+	param.Type = tref
+
+	param.Loc = ast.Loc{Start: start.Start, End: p.prev.Loc.End}
+	return param, nil
+}
+
+// parseTypeOrTVFSchema parses a type_or_tvf_schema (type | templated_parameter_type
+// | tvf_schema) and returns it as a rendered TypeRef. A `TABLE<…>` tvf_schema and
+// an `ANY <kind>` templated type are rendered to text via parseType (which handles
+// both — ANY is a type_name path and TABLE< is the function/array template path),
+// so this is a thin wrapper that records the source span. The bare ANY TYPE form
+// (templated_parameter_kind) is handled here because parseType treats ANY as a
+// plain type name.
+func (p *Parser) parseTypeOrTVFSchema() (*ast.TypeRef, error) {
+	start := p.cur.Loc
+
+	// tvf_schema: TABLE < … >. parseType does not model a multi-column TABLE<…>
+	// (its FUNCTION< / ARRAY< template paths are different), so handle it here and
+	// render to text.
+	if p.cur.Type == kwTABLE && p.peekNext().Type == int('<') {
+		cols, err := p.parseTVFSchema()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.TypeRef{Text: renderTVFSchema(cols), Loc: ast.Loc{Start: start.Start, End: p.prev.Loc.End}}, nil
+	}
+
+	// templated_parameter_type: ANY {PROTO|ENUM|STRUCT|ARRAY|identifier}.
+	if p.cur.Type == kwANY {
+		anyTok := p.advance() // ANY
+		kindTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		kind := p.tokenSource(kindTok)
+		return &ast.TypeRef{
+			Text: "ANY " + kind,
+			Loc:  ast.Loc{Start: anyTok.Loc.Start, End: kindTok.Loc.End},
+		}, nil
+	}
+
+	dt, err := p.parseType()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.TypeRef{Text: dt.String(), Loc: dt.Loc}, nil
+}
+
+// renderTVFSchema renders a TVF schema column list back to `TABLE<col TYPE, …>`
+// text for the TypeRef. (The structured columns are kept on the statement node;
+// this is only for the parameter-position TypeRef text.)
+func renderTVFSchema(cols []*ast.ColumnDef) string {
+	out := "TABLE<"
+	for i, c := range cols {
+		if i > 0 {
+			out += ", "
+		}
+		if c.Name != "" {
+			out += c.Name + " "
+		}
+		if c.Type != nil {
+			out += c.Type.Text
+		}
+	}
+	out += ">"
+	return out
+}
+
+// matchDeterminismLevel consumes an opt_determinism_level (DETERMINISTIC | NOT
+// DETERMINISTIC | IMMUTABLE | STABLE | VOLATILE) if present and returns its
+// spelling, or "" when absent.
+func (p *Parser) matchDeterminismLevel() string {
+	switch p.cur.Type {
+	case kwDETERMINISTIC:
+		p.advance()
+		return "DETERMINISTIC"
+	case kwNOT:
+		if p.peekNext().Type == kwDETERMINISTIC {
+			p.advance() // NOT
+			p.advance() // DETERMINISTIC
+			return "NOT DETERMINISTIC"
+		}
+	case kwIMMUTABLE:
+		p.advance()
+		return "IMMUTABLE"
+	case kwSTABLE:
+		p.advance()
+		return "STABLE"
+	case kwVOLATILE:
+		p.advance()
+		return "VOLATILE"
+	}
+	return ""
+}
+
+// parseLanguageOrRemoteWithConnection parses opt_language_or_remote_with_connection
+// into stmt:
+//
+//	LANGUAGE identifier remote_with_connection_clause?
+//	| remote_with_connection_clause language?
+//
+// where remote_with_connection_clause is `REMOTE [WITH CONNECTION conn]? | WITH
+// CONNECTION conn`.
+func (p *Parser) parseLanguageOrRemoteWithConnection(stmt *ast.CreateFunctionStmt) error {
+	switch {
+	case p.cur.Type == kwLANGUAGE:
+		p.advance() // LANGUAGE
+		langTok, err := p.expectIdentifier()
+		if err != nil {
+			return err
+		}
+		stmt.Language = p.tokenSource(langTok)
+		// remote_with_connection_clause?
+		return p.parseRemoteWithConnection(stmt)
+	case p.cur.Type == kwREMOTE || (p.cur.Type == kwWITH && p.peekNext().Type == kwCONNECTION):
+		if err := p.parseRemoteWithConnection(stmt); err != nil {
+			return err
+		}
+		// language?
+		if p.cur.Type == kwLANGUAGE {
+			p.advance() // LANGUAGE
+			langTok, err := p.expectIdentifier()
+			if err != nil {
+				return err
+			}
+			stmt.Language = p.tokenSource(langTok)
+		}
+		return nil
+	}
+	return nil
+}
+
+// parseRemoteWithConnection parses a remote_with_connection_clause into stmt:
+//
+//	REMOTE with_connection_clause?
+//	| with_connection_clause
+//
+// with_connection_clause is `WITH connection_clause`; connection_clause is
+// `CONNECTION <path>` (the path / DEFAULT keyword forms are captured as text). It
+// records the Remote flag and, when a connection path is present, HasConnection +
+// ConnectionName. Returns nil when neither REMOTE nor WITH CONNECTION is present.
+func (p *Parser) parseRemoteWithConnection(stmt *ast.CreateFunctionStmt) error {
+	if p.cur.Type == kwREMOTE {
+		p.advance() // REMOTE
+		stmt.Remote = true
+		// optional WITH CONNECTION conn.
+		if p.cur.Type == kwWITH && p.peekNext().Type == kwCONNECTION {
+			name, err := p.parseConnectionClause()
+			if err != nil {
+				return err
+			}
+			stmt.HasConnection = true
+			stmt.ConnectionName = name
+		}
+		return nil
+	}
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwCONNECTION {
+		name, err := p.parseConnectionClause()
+		if err != nil {
+			return err
+		}
+		stmt.HasConnection = true
+		stmt.ConnectionName = name
+		return nil
+	}
+	return nil
+}
+
+// parseConnectionClause parses a with_connection_clause `WITH CONNECTION
+// connection_clause` and returns the connection name text. connection_clause is a
+// path_expression or the DEFAULT keyword (BigQuery default connection). cur is at
+// WITH.
+func (p *Parser) parseConnectionClause() (string, error) {
+	p.advance() // WITH
+	if _, err := p.expect(kwCONNECTION); err != nil {
+		return "", err
+	}
+	// connection_clause: DEFAULT | path_expression.
+	if p.cur.Type == kwDEFAULT {
+		p.advance()
+		return "DEFAULT", nil
+	}
+	path, err := p.parseTablePath()
+	if err != nil {
+		return "", err
+	}
+	return path.String(), nil
+}
+
+// parseUnorderedOptionsBody parses unordered_options_body into stmt:
+//
+//	opt_options_list as_sql_function_body_or_string?
+//	| as_sql_function_body_or_string opt_options_list?
+//
+// where as_sql_function_body_or_string is `AS sql_function_body | AS
+// string_literal`, and sql_function_body is `( expression )` (the `( SELECT … )`
+// alternative is the legacy error path — a query body must be a scalar subquery,
+// so a leading SELECT inside the parens is rejected).
+func (p *Parser) parseUnorderedOptionsBody(stmt *ast.CreateFunctionStmt) error {
+	// Leading OPTIONS, then an optional AS body.
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return err
+		}
+		stmt.Options = opts
+		if p.cur.Type == kwAS {
+			return p.parseSQLFunctionBodyOrString(stmt)
+		}
+		return nil
+	}
+	// Leading AS body, then an optional OPTIONS.
+	if p.cur.Type == kwAS {
+		if err := p.parseSQLFunctionBodyOrString(stmt); err != nil {
+			return err
+		}
+		if p.cur.Type == kwOPTIONS {
+			opts, err := p.parseOptionsList()
+			if err != nil {
+				return err
+			}
+			stmt.Options = opts
+		}
+	}
+	return nil
+}
+
+// parseSQLFunctionBodyOrString parses an as_sql_function_body_or_string into stmt.
+// cur is at AS. It is `AS ( expression )` (sql_function_body) or `AS string`.
+func (p *Parser) parseSQLFunctionBodyOrString(stmt *ast.CreateFunctionStmt) error {
+	p.advance() // AS
+	if p.cur.Type == int('(') {
+		p.advance() // '('
+		// sql_function_body error alt: `( SELECT …` is rejected (must be a scalar
+		// subquery `( ( SELECT … ) )`). This reproduces the legacy ZetaSQL
+		// diagnostic.
+		if p.cur.Type == kwSELECT {
+			return &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "The body of each CREATE FUNCTION statement is an expression, not a query; to use a query as an expression, the query must be wrapped with additional parentheses to make it a scalar subquery expression",
+			}
+		}
+		expr, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return err
+		}
+		stmt.Body = expr
+		return nil
+	}
+	// AS string_literal.
+	if p.cur.Type == tokString {
+		strTok := p.advance()
+		stmt.BodyString = strTok.Str
+		stmt.HasBodyString = true
+		return nil
+	}
+	return p.syntaxErrorAtCur()
+}
+
+// parseUnorderedLanguageOptions parses unordered_language_options into stmt (TVF
+// form):
+//
+//	language opt_options_list?
+//	| opt_options_list language?
+//
+// where language is `LANGUAGE identifier`.
+func (p *Parser) parseUnorderedLanguageOptions(stmt *ast.CreateFunctionStmt) error {
+	if p.cur.Type == kwLANGUAGE {
+		p.advance() // LANGUAGE
+		langTok, err := p.expectIdentifier()
+		if err != nil {
+			return err
+		}
+		stmt.Language = p.tokenSource(langTok)
+		if p.cur.Type == kwOPTIONS {
+			opts, err := p.parseOptionsList()
+			if err != nil {
+				return err
+			}
+			stmt.Options = opts
+		}
+		return nil
+	}
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return err
+		}
+		stmt.Options = opts
+		if p.cur.Type == kwLANGUAGE {
+			p.advance() // LANGUAGE
+			langTok, err := p.expectIdentifier()
+			if err != nil {
+				return err
+			}
+			stmt.Language = p.tokenSource(langTok)
+		}
+	}
+	return nil
+}
+
+// parseAsQueryOrString parses an opt_as_query_or_string into stmt (TVF form):
+// `AS query | AS string_literal`. cur is at AS.
+func (p *Parser) parseAsQueryOrString(stmt *ast.CreateFunctionStmt) error {
+	p.advance() // AS
+	if p.cur.Type == tokString {
+		strTok := p.advance()
+		stmt.BodyString = strTok.Str
+		stmt.HasBodyString = true
+		return nil
+	}
+	q, err := p.parseQuery()
+	if err != nil {
+		return err
+	}
+	stmt.AsQuery = q
+	return nil
+}
+
+// parseCreateProcedure parses a CREATE PROCEDURE statement. The shared CREATE
+// prefix (OR REPLACE / scope) has been consumed; cur is at PROCEDURE.
+func (p *Parser) parseCreateProcedure(create Token, orReplace bool, scope string) (ast.Node, error) {
+	p.advance() // PROCEDURE
+
+	stmt := &ast.CreateProcedureStmt{OrReplace: orReplace, Scope: scope}
+	stmt.Loc.Start = create.Loc.Start
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// procedure_parameters — required parenthesized list.
+	if p.cur.Type != int('(') {
+		return nil, p.syntaxErrorAtCur()
+	}
+	params, err := p.parseFunctionParameters(true /*procedure*/)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Params = params
+
+	// opt_external_security_clause? — EXTERNAL SECURITY {INVOKER|DEFINER}.
+	if p.cur.Type == kwEXTERNAL && p.peekNext().Type == kwSECURITY {
+		p.advance() // EXTERNAL
+		p.advance() // SECURITY
+		switch p.cur.Type {
+		case kwINVOKER:
+			p.advance()
+			stmt.ExternalSecurity = "INVOKER"
+		case kwDEFINER:
+			p.advance()
+			stmt.ExternalSecurity = "DEFINER"
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+
+	// with_connection_clause? — WITH CONNECTION conn.
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwCONNECTION {
+		connName, err := p.parseConnectionClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.HasConnection = true
+		stmt.ConnectionName = connName
+	}
+
+	// opt_options_list?
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	// begin_end_block_or_language_as_code:
+	//   begin_end_block
+	//   | LANGUAGE identifier opt_as_code?
+	switch p.cur.Type {
+	case kwBEGIN:
+		text, err := p.captureBeginEndBlock()
+		if err != nil {
+			return nil, err
+		}
+		stmt.BodyText = text
+	case kwLANGUAGE:
+		p.advance() // LANGUAGE
+		langTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Language = p.tokenSource(langTok)
+		// opt_as_code?: AS string_literal.
+		if p.cur.Type == kwAS {
+			p.advance() // AS
+			strTok, err := p.expect(tokString)
+			if err != nil {
+				return nil, err
+			}
+			stmt.BodyString = strTok.Str
+			stmt.HasBodyString = true
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// captureBeginEndBlock consumes a begin_end_block (`BEGIN statement_list?
+// opt_exception_handler? END`) with balanced BEGIN/CASE … END nesting and returns
+// its verbatim source text (including the BEGIN and END keywords). cur is at
+// BEGIN.
+//
+// The procedural statement_list grammar is owned by the parser-scripting node;
+// this node captures the block as text so a CREATE PROCEDURE round-trips and the
+// query-span consumer sees a body, without parsing the script statements. Nesting
+// is tracked over the block-opening keywords that take a matching END in
+// GoogleSQL's procedural grammar: BEGIN, CASE, IF, WHILE, LOOP, REPEAT, FOR (each
+// closes with END / END CASE / END IF / …). A bare `END` at depth 1 closes the
+// outermost BEGIN.
+//
+// A block-opener keyword that is immediately followed by '(' is a FUNCTION call,
+// NOT a block — e.g. `SELECT IF(cond, a, b)` inside the body. Those have no
+// matching END, so counting them would make a valid body look unterminated; the
+// '(' lookahead excludes them. (A CASE *expression* `CASE WHEN … END` is still
+// counted as a block, which is harmless: its own END balances it.)
+func (p *Parser) captureBeginEndBlock() (string, error) {
+	beginTok := p.advance() // BEGIN
+	startOff := absIndex(p, beginTok.Loc.Start)
+	depth := 1
+	for p.cur.Type != tokEOF {
+		switch p.cur.Type {
+		case kwBEGIN, kwCASE, kwIF, kwWHILE, kwLOOP, kwREPEAT, kwFOR:
+			// A '(' immediately after makes this a function call (e.g. IF(...)),
+			// not a procedural block opener; do not count it.
+			if p.peekNext().Type == int('(') {
+				p.advance()
+				continue
+			}
+			depth++
+			p.advance()
+		case kwEND:
+			depth--
+			endTok := p.advance() // END
+			if depth == 0 {
+				// END may be followed by a closing keyword for an inner construct we
+				// over-counted? No — at depth 0 this END closes the outer BEGIN. The
+				// block text spans [BEGIN … END].
+				endOff := absIndex(p, endTok.Loc.End)
+				if startOff >= 0 && endOff <= len(p.input) && startOff < endOff {
+					return p.input[startOff:endOff], nil
+				}
+				return "", nil
+			}
+			// An inner END may carry a trailing closing keyword (END IF / END WHILE /
+			// END LOOP / END REPEAT / END FOR / END CASE); consume it so it is not
+			// re-counted as a new block opener.
+			switch p.cur.Type {
+			case kwIF, kwWHILE, kwLOOP, kwREPEAT, kwFOR, kwCASE:
+				p.advance()
+			}
+		default:
+			p.advance()
+		}
+	}
+	// Reached EOF without a matching END.
+	return "", &ParseError{Loc: beginTok.Loc, Msg: "syntax error: unterminated BEGIN...END block (expected END)"}
+}
+
+// ---------------------------------------------------------------------------
+// DROP FUNCTION / TABLE FUNCTION / PROCEDURE
+// ---------------------------------------------------------------------------
+
+// parseBQDropFunction parses a DROP FUNCTION or DROP TABLE FUNCTION statement. The
+// DROP keyword has been consumed by parseDropStmt; cur is at FUNCTION (DROP
+// FUNCTION) or TABLE (DROP TABLE FUNCTION). Grammar (drop_statement
+// table_or_table_function alt): `DROP table_or_table_function opt_if_exists?
+// maybe_dashed_path opt_function_parameters?`, where table_or_table_function is
+// `TABLE FUNCTION?`. The plain `DROP TABLE` is owned by the core node; this is
+// reached only for FUNCTION / TABLE FUNCTION.
+func (p *Parser) parseBQDropFunction(drop Token) (ast.Node, error) {
+	kind := ast.BQDropFunction
+	if p.cur.Type == kwTABLE {
+		p.advance() // TABLE
+		kind = ast.BQDropTableFunction
+	}
+	if _, err := p.expect(kwFUNCTION); err != nil {
+		return nil, err
+	}
+	return p.finishBQDropObject(drop, kind, true /*allowFunctionParams*/)
+}
+
+// parseBQDropProcedure parses a DROP PROCEDURE statement. cur is at PROCEDURE (the
+// DROP token is consumed). schema_object_kind PROCEDURE carries an
+// opt_function_parameters? and opt_drop_mode? in the grammar; the parameters are
+// accepted (rare) and the trailing RESTRICT/CASCADE is consumed by the core
+// schema-object drop, but PROCEDURE has no documented drop-mode so we keep it
+// minimal: `DROP PROCEDURE [IF EXISTS] path [opt_function_parameters]`.
+func (p *Parser) parseBQDropProcedure(drop Token) (ast.Node, error) {
+	p.advance() // PROCEDURE
+	return p.finishBQDropObject(drop, ast.BQDropProcedure, true /*allowFunctionParams*/)
+}
+
+// finishBQDropObject parses the shared tail `opt_if_exists? maybe_dashed_path
+// [opt_function_parameters]` for a simple BigQuery DROP of an object whose kind is
+// already determined and whose object keyword has been consumed. When
+// allowFunctionParams is true, a trailing `( … )` parameter list (used by the
+// FUNCTION / TABLE FUNCTION / PROCEDURE drop alternatives to disambiguate
+// overloads) is consumed structurally and discarded.
+func (p *Parser) finishBQDropObject(drop Token, kind ast.BQDropObjectKind, allowFunctionParams bool) (ast.Node, error) {
+	stmt := &ast.BQDropStmt{Object: kind}
+	stmt.Loc.Start = drop.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// opt_function_parameters? — a parenthesized parameter list disambiguating an
+	// overloaded function/procedure. Consumed structurally and discarded.
+	if allowFunctionParams && p.cur.Type == int('(') {
+		if err := p.skipBalancedParens(); err != nil {
+			return nil, err
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/googlesql/parser/bq_function_procedure_test.go
+++ b/googlesql/parser/bq_function_procedure_test.go
@@ -1,0 +1,360 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-ddl-bigquery node: CREATE [AGGREGATE] FUNCTION /
+// TABLE FUNCTION / PROCEDURE and their DROP forms. These are BigQuery-only at the
+// GoogleSQL union level (the Spanner emulator rejects most of them), so the
+// accept/reject verdicts here are triangulated against the legacy
+// GoogleSQLParser.g4 + the BigQuery truth1 corpus (DDL-015..020/049/050/051), not
+// the Spanner differential. Structural-gate assertions on the produced AST.
+
+func cfOf(t *testing.T, sql string) *ast.CreateFunctionStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	cf, ok := n.(*ast.CreateFunctionStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateFunctionStmt", sql, n)
+	}
+	return cf
+}
+
+func TestCreateFunction_SQLBody(t *testing.T) {
+	// DDL-015: CREATE FUNCTION mydataset.square(x FLOAT64) RETURNS FLOAT64 AS (x * x)
+	cf := cfOf(t, "CREATE FUNCTION mydataset.square(x FLOAT64) RETURNS FLOAT64 AS (x * x)")
+	if cf.Name.String() != "mydataset.square" {
+		t.Errorf("Name = %q, want mydataset.square", cf.Name.String())
+	}
+	if len(cf.Params) != 1 || cf.Params[0].Name != "x" || cf.Params[0].Type.Text != "FLOAT64" {
+		t.Fatalf("Params = %+v, want [x FLOAT64]", cf.Params)
+	}
+	if cf.Returns == nil || cf.Returns.Text != "FLOAT64" {
+		t.Errorf("Returns = %v, want FLOAT64", cf.Returns)
+	}
+	if cf.Body == nil {
+		t.Error("Body = nil, want the (x * x) expression")
+	}
+	if cf.Aggregate || cf.IsTableFunc {
+		t.Errorf("Aggregate=%v IsTableFunc=%v, want both false", cf.Aggregate, cf.IsTableFunc)
+	}
+}
+
+func TestCreateFunction_OrReplaceTempNoReturns(t *testing.T) {
+	// DDL-015: CREATE OR REPLACE TEMP FUNCTION add_n(x INT64, n INT64) AS (x + n)
+	cf := cfOf(t, "CREATE OR REPLACE TEMP FUNCTION add_n(x INT64, n INT64) AS (x + n)")
+	if !cf.OrReplace {
+		t.Error("OrReplace = false, want true")
+	}
+	if cf.Scope != "TEMP" {
+		t.Errorf("Scope = %q, want TEMP", cf.Scope)
+	}
+	if len(cf.Params) != 2 {
+		t.Fatalf("Params = %d, want 2", len(cf.Params))
+	}
+	if cf.Returns != nil {
+		t.Errorf("Returns = %v, want nil (no RETURNS)", cf.Returns)
+	}
+}
+
+func TestCreateFunction_JavaScript(t *testing.T) {
+	// DDL-016: LANGUAGE js with a raw-string body and DETERMINISTIC.
+	cf := cfOf(t, `CREATE OR REPLACE FUNCTION mydataset.multiplyInputs(x FLOAT64, y FLOAT64) RETURNS FLOAT64 LANGUAGE js AS "return x*y;"`)
+	if cf.Language != "js" {
+		t.Errorf("Language = %q, want js", cf.Language)
+	}
+	if !cf.HasBodyString || cf.BodyString != "return x*y;" {
+		t.Errorf("BodyString = %q (has=%v), want \"return x*y;\"", cf.BodyString, cf.HasBodyString)
+	}
+}
+
+func TestCreateFunction_Determinism(t *testing.T) {
+	cf := cfOf(t, `CREATE FUNCTION ds.f(x INT64) RETURNS INT64 DETERMINISTIC LANGUAGE js AS "return x"`)
+	if cf.Determinism != "DETERMINISTIC" {
+		t.Errorf("Determinism = %q, want DETERMINISTIC", cf.Determinism)
+	}
+	cf2 := cfOf(t, `CREATE FUNCTION ds.f(x INT64) RETURNS INT64 NOT DETERMINISTIC LANGUAGE js AS "return x"`)
+	if cf2.Determinism != "NOT DETERMINISTIC" {
+		t.Errorf("Determinism = %q, want NOT DETERMINISTIC", cf2.Determinism)
+	}
+}
+
+func TestCreateFunction_PythonRemote(t *testing.T) {
+	// DDL-017: Python UDF with LANGUAGE python WITH CONNECTION and OPTIONS.
+	cf := cfOf(t, "CREATE FUNCTION mydataset.py_square(x FLOAT64) RETURNS FLOAT64 LANGUAGE python WITH CONNECTION `my-project.us.my-connection` OPTIONS (entry_point='square') AS \"def square(x):\\n  return x*x\"")
+	if cf.Language != "python" {
+		t.Errorf("Language = %q, want python", cf.Language)
+	}
+	if !cf.HasConnection || cf.ConnectionName == "" {
+		t.Errorf("Connection: has=%v name=%q, want present", cf.HasConnection, cf.ConnectionName)
+	}
+	if len(cf.Options) != 1 {
+		t.Errorf("Options = %d, want 1", len(cf.Options))
+	}
+}
+
+func TestCreateFunction_RemoteWithConnection(t *testing.T) {
+	// DDL-017: remote function form REMOTE WITH CONNECTION conn.
+	cf := cfOf(t, "CREATE FUNCTION ds.f(x INT64) RETURNS INT64 REMOTE WITH CONNECTION `p.us.c` OPTIONS(endpoint='https://x')")
+	if !cf.Remote {
+		t.Error("Remote = false, want true")
+	}
+	if !cf.HasConnection {
+		t.Error("HasConnection = false, want true")
+	}
+}
+
+func TestCreateFunction_Aggregate(t *testing.T) {
+	// DDL-018: CREATE AGGREGATE FUNCTION … AS (SUM(x * x)).
+	cf := cfOf(t, "CREATE AGGREGATE FUNCTION mydataset.sum_of_squares(x FLOAT64) RETURNS FLOAT64 AS (SUM(x * x))")
+	if !cf.Aggregate {
+		t.Error("Aggregate = false, want true")
+	}
+	if cf.Body == nil {
+		t.Error("Body = nil")
+	}
+}
+
+func TestCreateFunction_NotAggregateParam(t *testing.T) {
+	// A NOT AGGREGATE parameter on an aggregate function.
+	cf := cfOf(t, "CREATE AGGREGATE FUNCTION ds.f(x FLOAT64, y FLOAT64 NOT AGGREGATE) AS (SUM(x) + y)")
+	if len(cf.Params) != 2 {
+		t.Fatalf("Params = %d, want 2", len(cf.Params))
+	}
+	if !cf.Params[1].NotAggregate {
+		t.Error("Params[1].NotAggregate = false, want true")
+	}
+}
+
+func TestCreateTableFunction(t *testing.T) {
+	// DDL-019: CREATE TABLE FUNCTION … AS query (no RETURNS TABLE).
+	cf := cfOf(t, "CREATE OR REPLACE TABLE FUNCTION mydataset.names_by_year(y INT64) AS SELECT year, name FROM t WHERE year = y")
+	if !cf.IsTableFunc {
+		t.Error("IsTableFunc = false, want true")
+	}
+	if cf.AsQuery == nil {
+		t.Error("AsQuery = nil, want the SELECT body")
+	}
+	if cf.ReturnsTable {
+		t.Error("ReturnsTable = true, want false (no RETURNS TABLE)")
+	}
+}
+
+func TestCreateTableFunction_ReturnsTable(t *testing.T) {
+	// DDL-019: CREATE TABLE FUNCTION … RETURNS TABLE<name STRING, year INT64> AS query.
+	cf := cfOf(t, "CREATE OR REPLACE TABLE FUNCTION mydataset.names_by_year(y INT64) RETURNS TABLE<name STRING, year INT64, total INT64> AS SELECT name, year, 1 AS total FROM t WHERE year = y")
+	if !cf.IsTableFunc || !cf.ReturnsTable {
+		t.Fatalf("IsTableFunc=%v ReturnsTable=%v, want both true", cf.IsTableFunc, cf.ReturnsTable)
+	}
+	if len(cf.ReturnColumns) != 3 {
+		t.Fatalf("ReturnColumns = %d, want 3", len(cf.ReturnColumns))
+	}
+	if cf.ReturnColumns[0].Name != "name" || cf.ReturnColumns[0].Type.Text != "STRING" {
+		t.Errorf("ReturnColumns[0] = %+v, want name STRING", cf.ReturnColumns[0])
+	}
+}
+
+func TestCreateTableFunction_AnyTypeParam(t *testing.T) {
+	// function_parameter with ANY TYPE / a TABLE<…> param.
+	cf := cfOf(t, "CREATE TABLE FUNCTION ds.f(t TABLE<x INT64>, p ANY TYPE) AS SELECT 1 AS n")
+	if len(cf.Params) != 2 {
+		t.Fatalf("Params = %d, want 2", len(cf.Params))
+	}
+	if cf.Params[0].Type.Text != "TABLE<x INT64>" {
+		t.Errorf("Params[0].Type = %q, want TABLE<x INT64>", cf.Params[0].Type.Text)
+	}
+	if cf.Params[1].Type.Text != "ANY TYPE" {
+		t.Errorf("Params[1].Type = %q, want ANY TYPE", cf.Params[1].Type.Text)
+	}
+}
+
+func TestCreateTableFunction_NoBodyAcceptedPerGrammar(t *testing.T) {
+	// DEFEND (review finding): the legacy create_table_function_statement makes the
+	// AS body OPTIONAL (`opt_as_query_or_string?`). BigQuery docs require AS query,
+	// but the migration target is legacy-grammar parity and there is no Spanner
+	// oracle for TVFs — so we FOLLOW THE GRAMMAR and accept a body-less TVF (the
+	// "needs a body" rule is a ZetaSQL semantic check, not a parse rule).
+	cf := cfOf(t, "CREATE TABLE FUNCTION ds.f(y INT64)")
+	if !cf.IsTableFunc {
+		t.Error("IsTableFunc = false, want true")
+	}
+	if cf.AsQuery != nil || cf.HasBodyString {
+		t.Error("expected no body for a body-less TVF")
+	}
+}
+
+func TestCreateFunction_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE FUNCTION ds.f",                        // missing parameter list
+		"CREATE FUNCTION ds.f(x INT64) RETURNS",       // RETURNS with no type
+		"CREATE FUNCTION ds.f(x INT64) AS (SELECT 1)", // sql_function_body error: query body must be a scalar subquery
+		"CREATE FUNCTION ds.f(x INT64) AS",            // AS with no body
+		"CREATE AGGREGATE ds.f(x INT64) AS (x)",       // AGGREGATE without FUNCTION
+		"CREATE FUNCTION (x INT64) AS (x)",            // missing name
+		"CREATE TABLE FUNCTION ds.f AS SELECT 1",      // TABLE FUNCTION missing parameter list
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- CREATE PROCEDURE ---
+
+func cpOf(t *testing.T, sql string) *ast.CreateProcedureStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	cp, ok := n.(*ast.CreateProcedureStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateProcedureStmt", sql, n)
+	}
+	return cp
+}
+
+func TestCreateProcedure_BeginEnd(t *testing.T) {
+	// DDL-020: CREATE OR REPLACE PROCEDURE … (IN tbl STRING, OUT result INT64) BEGIN … END;
+	cp := cpOf(t, "CREATE OR REPLACE PROCEDURE mydataset.SelectFromTable(IN tbl STRING, OUT result INT64) BEGIN SELECT COUNT(*) FROM t; END")
+	if cp.Name.String() != "mydataset.SelectFromTable" {
+		t.Errorf("Name = %q", cp.Name.String())
+	}
+	if len(cp.Params) != 2 {
+		t.Fatalf("Params = %d, want 2", len(cp.Params))
+	}
+	if cp.Params[0].Mode != ast.ParamModeIn || cp.Params[0].Name != "tbl" {
+		t.Errorf("Params[0] = mode %v name %q, want IN tbl", cp.Params[0].Mode, cp.Params[0].Name)
+	}
+	if cp.Params[1].Mode != ast.ParamModeOut || cp.Params[1].Name != "result" {
+		t.Errorf("Params[1] = mode %v name %q, want OUT result", cp.Params[1].Mode, cp.Params[1].Name)
+	}
+	if cp.BodyText == "" {
+		t.Error("BodyText = empty, want the BEGIN…END block text")
+	}
+}
+
+func TestCreateProcedure_NoParams(t *testing.T) {
+	cp := cpOf(t, "CREATE PROCEDURE ds.p() BEGIN SELECT 1; END")
+	if len(cp.Params) != 0 {
+		t.Errorf("Params = %d, want 0", len(cp.Params))
+	}
+}
+
+func TestCreateProcedure_BodyWithIfFunction(t *testing.T) {
+	// Regression (review finding): the IF / CASE / WHILE / FOR keywords appear as
+	// FUNCTION calls inside a body — `IF(cond, a, b)`, `SELECT CASE WHEN … END` —
+	// and must NOT be counted as procedural block openers (else the body looks
+	// unterminated). The '(' lookahead excludes the IF() function call.
+	cp := cpOf(t, "CREATE PROCEDURE ds.p() BEGIN SELECT IF(TRUE, 1, 0); SELECT IFNULL(x, 0) FROM t; END")
+	if cp.BodyText == "" {
+		t.Fatal("BodyText empty; IF(...) function miscounted as a block opener")
+	}
+	// A CASE expression inside the body is balanced by its own END and must not
+	// leak the outer block.
+	cp2 := cpOf(t, "CREATE PROCEDURE ds.p() BEGIN SELECT CASE WHEN x THEN 1 ELSE 2 END FROM t; END")
+	if cp2.BodyText == "" {
+		t.Fatal("BodyText empty; CASE expression mishandled")
+	}
+}
+
+func TestCreateProcedure_NestedBeginEnd(t *testing.T) {
+	// A nested BEGIN…END and an IF…END IF must not close the outer block early.
+	cp := cpOf(t, "CREATE PROCEDURE ds.p() BEGIN IF TRUE THEN SELECT 1; END IF; BEGIN SELECT 2; END; END")
+	if cp.BodyText == "" {
+		t.Fatal("BodyText empty")
+	}
+	// The captured block must include the final END (the body must extend past the
+	// inner blocks).
+	if got := cp.BodyText; got[len(got)-3:] != "END" {
+		t.Errorf("BodyText does not end at the outer END: %q", got)
+	}
+}
+
+func TestCreateProcedure_LanguageBody(t *testing.T) {
+	cp := cpOf(t, "CREATE PROCEDURE ds.p(x INT64) OPTIONS(strict_mode=true) LANGUAGE python AS \"pass\"")
+	if cp.Language != "python" {
+		t.Errorf("Language = %q, want python", cp.Language)
+	}
+	if !cp.HasBodyString || cp.BodyString != "pass" {
+		t.Errorf("BodyString = %q (has=%v), want pass", cp.BodyString, cp.HasBodyString)
+	}
+	if len(cp.Options) != 1 {
+		t.Errorf("Options = %d, want 1", len(cp.Options))
+	}
+}
+
+func TestCreateProcedure_ExternalSecurity(t *testing.T) {
+	cp := cpOf(t, "CREATE PROCEDURE ds.p() EXTERNAL SECURITY INVOKER BEGIN SELECT 1; END")
+	if cp.ExternalSecurity != "INVOKER" {
+		t.Errorf("ExternalSecurity = %q, want INVOKER", cp.ExternalSecurity)
+	}
+}
+
+func TestCreateProcedure_INOUTParamMode(t *testing.T) {
+	cp := cpOf(t, "CREATE PROCEDURE ds.p(INOUT x INT64) BEGIN SELECT x; END")
+	if cp.Params[0].Mode != ast.ParamModeInout {
+		t.Errorf("Params[0].Mode = %v, want INOUT", cp.Params[0].Mode)
+	}
+}
+
+func TestCreateProcedure_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE PROCEDURE ds.p",                        // missing parameter list
+		"CREATE PROCEDURE ds.p()",                      // missing body
+		"CREATE PROCEDURE ds.p() BEGIN SELECT 1;",      // unterminated BEGIN…END (no END)
+		"CREATE PROCEDURE ds.p(x) BEGIN SELECT 1; END", // procedure parameter without a type
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- DROP FUNCTION / TABLE FUNCTION / PROCEDURE ---
+
+func bqDropOf(t *testing.T, sql string) *ast.BQDropStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	d, ok := n.(*ast.BQDropStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.BQDropStmt", sql, n)
+	}
+	return d
+}
+
+func TestDropFunction(t *testing.T) {
+	// DDL-049.
+	d := bqDropOf(t, "DROP FUNCTION IF EXISTS mydataset.my_function")
+	if d.Object != ast.BQDropFunction {
+		t.Errorf("Object = %v, want FUNCTION", d.Object)
+	}
+	if !d.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+	if d.Name.String() != "mydataset.my_function" {
+		t.Errorf("Name = %q", d.Name.String())
+	}
+}
+
+func TestDropTableFunction(t *testing.T) {
+	// DDL-050.
+	d := bqDropOf(t, "DROP TABLE FUNCTION IF EXISTS mydataset.my_tvf")
+	if d.Object != ast.BQDropTableFunction {
+		t.Errorf("Object = %v, want TABLE FUNCTION", d.Object)
+	}
+}
+
+func TestDropProcedure(t *testing.T) {
+	// DDL-051.
+	d := bqDropOf(t, "DROP PROCEDURE IF EXISTS mydataset.my_procedure")
+	if d.Object != ast.BQDropProcedure {
+		t.Errorf("Object = %v, want PROCEDURE", d.Object)
+	}
+}
+
+func TestDropFunction_WithOverloadParams(t *testing.T) {
+	// opt_function_parameters disambiguating an overload — consumed structurally.
+	d := bqDropOf(t, "DROP FUNCTION ds.f(INT64, STRING)")
+	if d.Object != ast.BQDropFunction || d.Name.String() != "ds.f" {
+		t.Errorf("got Object=%v Name=%q", d.Object, d.Name.String())
+	}
+}

--- a/googlesql/parser/bq_materialized_view.go
+++ b/googlesql/parser/bq_materialized_view.go
@@ -1,0 +1,240 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// BigQuery DDL — CREATE MATERIALIZED|APPROX VIEW + ALTER MATERIALIZED|APPROX VIEW
+// (parser-ddl-bigquery node)
+// ---------------------------------------------------------------------------
+//
+// Ports the MATERIALIZED and APPROX alternatives of the legacy ANTLR
+// create_view_statement (GoogleSQLParser.g4 §2.2) and the BigQuery
+// ALTER MATERIALIZED VIEW SET OPTIONS form (the schema_object_kind
+// MATERIALIZED VIEW alternative of alter_statement). The plain VIEW alternative
+// is owned by the core parser-ddl node (view.go).
+//
+//	create_view_statement (materialized):
+//	  CREATE opt_or_replace? MATERIALIZED RECURSIVE? VIEW opt_if_not_exists?
+//	    maybe_dashed_path column_with_options_list? opt_sql_security_clause?
+//	    partition_by_clause_prefix_no_hint? cluster_by_clause_prefix_no_hint?
+//	    opt_options_list? AS query_or_replica_source
+//	create_view_statement (approx):
+//	  CREATE opt_or_replace? APPROX RECURSIVE? VIEW opt_if_not_exists?
+//	    maybe_dashed_path column_with_options_list? opt_sql_security_clause?
+//	    opt_options_list? as_query
+//	query_or_replica_source: query | REPLICA OF maybe_dashed_path
+//
+// ORACLE NOTE — BigQuery-only at the union level (oracle.md): the Spanner
+// emulator rejects `CREATE MATERIALIZED VIEW` outright (probed 2026-06-05:
+// "Encountered 'MATERIALIZED' while parsing: create_statement"). Triangulated
+// against the legacy .g4 + BigQuery truth1 (DDL-011/012/040); proven by the unit
+// tests in bq_materialized_view_test.go.
+
+// parseCreateMaterializedView parses a CREATE MATERIALIZED|APPROX [RECURSIVE]
+// VIEW statement. The shared CREATE prefix (OR REPLACE) has been consumed by
+// parseCreateStmt; cur is at MATERIALIZED or APPROX. scope is unused for these
+// forms (the grammar has no opt_create_scope before MATERIALIZED/APPROX), so a
+// non-empty scope is a syntax error.
+func (p *Parser) parseCreateMaterializedView(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if scope != "" {
+		// MATERIALIZED/APPROX VIEW take no TEMP/TEMPORARY/PUBLIC/PRIVATE scope.
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	var kind ast.ViewKind
+	switch p.cur.Type {
+	case kwMATERIALIZED:
+		kind = ast.ViewMaterialized
+	case kwAPPROX:
+		kind = ast.ViewApprox
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // MATERIALIZED | APPROX
+
+	stmt := &ast.CreateMaterializedViewStmt{Kind: kind, OrReplace: orReplace}
+	stmt.Loc.Start = create.Loc.Start
+
+	// RECURSIVE?
+	if p.cur.Type == kwRECURSIVE {
+		p.advance()
+		stmt.Recursive = true
+	}
+
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// column_with_options_list? — `( identifier opt_options_list? (, …)* )`.
+	if p.cur.Type == int('(') {
+		cols, err := p.parseViewColumnList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Columns = cols
+	}
+
+	// opt_sql_security_clause? — SQL SECURITY {INVOKER|DEFINER}.
+	if p.cur.Type == kwSQL {
+		sec, err := p.parseSQLSecurityClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SQLSecurity = sec
+	}
+
+	// partition_by_clause_prefix_no_hint? / cluster_by_clause_prefix_no_hint? —
+	// MATERIALIZED only in the grammar. APPROX has neither; a PARTITION/CLUSTER after
+	// an APPROX view falls through to the AS check and is reported there.
+	if kind == ast.ViewMaterialized {
+		if p.cur.Type == kwPARTITION {
+			exprs, err := p.parsePartitionByNoHint()
+			if err != nil {
+				return nil, err
+			}
+			stmt.PartitionBy = exprs
+		}
+		if p.cur.Type == kwCLUSTER {
+			exprs, err := p.parseClusterByNoHint()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ClusterBy = exprs
+		}
+	}
+
+	// opt_options_list?
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	// AS query_or_replica_source (materialized) | as_query (approx). Required.
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	// query_or_replica_source: query | REPLICA OF maybe_dashed_path. The REPLICA OF
+	// alternative is materialized-only; for APPROX a leading REPLICA would be a bad
+	// query head and reject in parseQuery.
+	if kind == ast.ViewMaterialized && p.cur.Type == kwREPLICA {
+		p.advance() // REPLICA
+		if _, err := p.expect(kwOF); err != nil {
+			return nil, err
+		}
+		src, err := p.parseTablePath()
+		if err != nil {
+			return nil, err
+		}
+		stmt.ReplicaOf = src
+		// Trailing OPTIONS(materialized_view_replica_option_list) after AS REPLICA OF
+		// (BigQuery DDL-012). The legacy GoogleSQLParser.g4 puts opt_options_list only
+		// BEFORE `AS`, so it rejects this trailing form; the BigQuery docs document it,
+		// and accepting it is additive (Spanner rejects the whole REPLICA-OF view
+		// regardless). Recognized here so a documented replica-OF view with options
+		// does not draw a false Diagnose error.
+		if p.cur.Type == kwOPTIONS {
+			opts, err := p.parseOptionsList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = opts
+		}
+	} else {
+		q, err := p.parseQuery()
+		if err != nil {
+			return nil, err
+		}
+		stmt.AsQuery = q
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// parseBQAlterMaterializedView parses an ALTER MATERIALIZED|APPROX VIEW statement.
+// The ALTER keyword has been consumed by parseAlterStmt; cur is at MATERIALIZED or
+// APPROX. The only documented action is SET OPTIONS (DDL-040), but the legacy
+// schema_object_kind alter path admits any alter_action; we accept SET OPTIONS
+// (the BigQuery-documented form) and reject others as a syntax error.
+func (p *Parser) parseBQAlterMaterializedView(alter Token) (ast.Node, error) {
+	var kind ast.BQAlterObjectKind
+	switch p.cur.Type {
+	case kwMATERIALIZED:
+		kind = ast.BQAlterMaterializedView
+	case kwAPPROX:
+		kind = ast.BQAlterApproxView
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // MATERIALIZED | APPROX
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.BQAlterStmt{Object: kind}
+	stmt.Loc.Start = alter.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// SET OPTIONS options_list.
+	if _, err := p.expect(kwSET); err != nil {
+		return nil, err
+	}
+	if p.cur.Type != kwOPTIONS {
+		return nil, p.syntaxErrorAtCur()
+	}
+	opts, err := p.parseOptionsList() // consumes OPTIONS and the parenthesized body
+	if err != nil {
+		return nil, err
+	}
+	stmt.SetOptions = opts
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseBQDropMaterializedView parses a DROP MATERIALIZED|APPROX VIEW statement.
+// The DROP keyword has been consumed by parseDropStmt; cur is at MATERIALIZED or
+// APPROX. Grammar: `DROP schema_object_kind opt_if_exists? path opt_drop_mode?`
+// where schema_object_kind ⊇ {MATERIALIZED VIEW, APPROX VIEW}. A documented DROP
+// MATERIALIZED VIEW (DDL-048) takes no RESTRICT/CASCADE, so the trailing
+// opt_drop_mode is left for the EOF check to reject if present.
+func (p *Parser) parseBQDropMaterializedView(drop Token) (ast.Node, error) {
+	kind := ast.BQDropMaterializedView
+	if p.cur.Type == kwAPPROX {
+		kind = ast.BQDropApproxView
+	}
+	p.advance() // MATERIALIZED | APPROX
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	return p.finishBQDropObject(drop, kind, false /*allowFunctionParams*/)
+}

--- a/googlesql/parser/bq_materialized_view_test.go
+++ b/googlesql/parser/bq_materialized_view_test.go
@@ -1,0 +1,161 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-ddl-bigquery node: CREATE MATERIALIZED|APPROX VIEW,
+// ALTER MATERIALIZED VIEW SET OPTIONS, DROP MATERIALIZED VIEW. BigQuery-only at
+// the union level (Spanner rejects MATERIALIZED VIEW outright, probed
+// 2026-06-05); accept/reject verdicts triangulated against the legacy
+// GoogleSQLParser.g4 + BigQuery truth1 (DDL-011/012/040/048).
+
+func mvOf(t *testing.T, sql string) *ast.CreateMaterializedViewStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	mv, ok := n.(*ast.CreateMaterializedViewStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateMaterializedViewStmt", sql, n)
+	}
+	return mv
+}
+
+func TestCreateMaterializedView_Basic(t *testing.T) {
+	// DDL-011.
+	mv := mvOf(t, "CREATE MATERIALIZED VIEW myProject.myDataset.myView AS SELECT product, SUM(sales) AS total FROM mydataset.sales GROUP BY product")
+	if mv.Kind != ast.ViewMaterialized {
+		t.Errorf("Kind = %v, want MATERIALIZED VIEW", mv.Kind)
+	}
+	if mv.Name.String() != "myProject.myDataset.myView" {
+		t.Errorf("Name = %q", mv.Name.String())
+	}
+	if mv.AsQuery == nil {
+		t.Error("AsQuery = nil")
+	}
+}
+
+func TestCreateMaterializedView_PartitionCluster(t *testing.T) {
+	// DDL-011: PARTITION BY DATE(ts) CLUSTER BY product.
+	mv := mvOf(t, "CREATE MATERIALIZED VIEW p.d.v PARTITION BY DATE(ts) CLUSTER BY product OPTIONS(enable_refresh=true) AS SELECT product, ts, SUM(sales) AS total FROM mydataset.sales GROUP BY product, ts")
+	if len(mv.PartitionBy) != 1 {
+		t.Errorf("PartitionBy = %d, want 1", len(mv.PartitionBy))
+	}
+	if len(mv.ClusterBy) != 1 {
+		t.Errorf("ClusterBy = %d, want 1", len(mv.ClusterBy))
+	}
+	if len(mv.Options) != 1 {
+		t.Errorf("Options = %d, want 1", len(mv.Options))
+	}
+}
+
+func TestCreateMaterializedView_ReplicaOf(t *testing.T) {
+	// DDL-012: CREATE MATERIALIZED VIEW … AS REPLICA OF source.
+	mv := mvOf(t, "CREATE MATERIALIZED VIEW mydataset.my_replica AS REPLICA OF other_project.other_dataset.my_mv")
+	if mv.ReplicaOf == nil || mv.ReplicaOf.String() != "other_project.other_dataset.my_mv" {
+		t.Errorf("ReplicaOf = %v, want other_project.other_dataset.my_mv", mv.ReplicaOf)
+	}
+	if mv.AsQuery != nil {
+		t.Error("AsQuery != nil, want nil for a REPLICA OF view")
+	}
+}
+
+func TestCreateMaterializedView_ReplicaOfOptions(t *testing.T) {
+	// Review finding / DDL-012: trailing OPTIONS(...) after AS REPLICA OF source.
+	// The legacy .g4 omits this (OPTIONS only before AS), but BigQuery documents it
+	// and accepting it is additive (Spanner rejects the whole REPLICA-OF view).
+	mv := mvOf(t, "CREATE MATERIALIZED VIEW ds.r AS REPLICA OF ds.src OPTIONS(replication_interval_seconds=300)")
+	if mv.ReplicaOf == nil || mv.ReplicaOf.String() != "ds.src" {
+		t.Errorf("ReplicaOf = %v, want ds.src", mv.ReplicaOf)
+	}
+	if len(mv.Options) != 1 {
+		t.Errorf("Options = %d, want 1 (trailing OPTIONS after REPLICA OF)", len(mv.Options))
+	}
+}
+
+func TestCreateApproxView(t *testing.T) {
+	mv := mvOf(t, "CREATE APPROX VIEW ds.v OPTIONS(description='d') AS SELECT 1 AS n")
+	if mv.Kind != ast.ViewApprox {
+		t.Errorf("Kind = %v, want APPROX VIEW", mv.Kind)
+	}
+}
+
+func TestCreateMaterializedView_OrReplaceColumnsSecurity(t *testing.T) {
+	mv := mvOf(t, "CREATE OR REPLACE MATERIALIZED VIEW IF NOT EXISTS ds.v(a, b) SQL SECURITY INVOKER AS SELECT 1 AS a, 2 AS b")
+	if !mv.OrReplace || !mv.IfNotExists {
+		t.Errorf("OrReplace=%v IfNotExists=%v, want both true", mv.OrReplace, mv.IfNotExists)
+	}
+	if len(mv.Columns) != 2 {
+		t.Errorf("Columns = %d, want 2", len(mv.Columns))
+	}
+	if mv.SQLSecurity != "INVOKER" {
+		t.Errorf("SQLSecurity = %q, want INVOKER", mv.SQLSecurity)
+	}
+}
+
+func TestCreateMaterializedView_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE MATERIALIZED VIEW v",                      // missing AS body
+		"CREATE MATERIALIZED v AS SELECT 1",               // missing VIEW keyword
+		"CREATE TEMP MATERIALIZED VIEW v AS SELECT 1",     // MATERIALIZED takes no scope
+		"CREATE APPROX VIEW v PARTITION BY x AS SELECT 1", // PARTITION BY is materialized-only; rejects on APPROX
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- ALTER MATERIALIZED VIEW ---
+
+func bqAlterOf(t *testing.T, sql string) *ast.BQAlterStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	a, ok := n.(*ast.BQAlterStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.BQAlterStmt", sql, n)
+	}
+	return a
+}
+
+func TestAlterMaterializedView_SetOptions(t *testing.T) {
+	// DDL-040.
+	a := bqAlterOf(t, "ALTER MATERIALIZED VIEW mydataset.myview SET OPTIONS(enable_refresh=false)")
+	if a.Object != ast.BQAlterMaterializedView {
+		t.Errorf("Object = %v, want MATERIALIZED VIEW", a.Object)
+	}
+	if len(a.SetOptions) != 1 {
+		t.Errorf("SetOptions = %d, want 1", len(a.SetOptions))
+	}
+}
+
+func TestAlterMaterializedView_IfExists(t *testing.T) {
+	a := bqAlterOf(t, "ALTER MATERIALIZED VIEW IF EXISTS ds.v SET OPTIONS(x=1)")
+	if !a.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+}
+
+func TestAlterMaterializedView_Rejects(t *testing.T) {
+	cases := []string{
+		"ALTER MATERIALIZED VIEW v",                    // missing SET OPTIONS
+		"ALTER MATERIALIZED VIEW v ADD COLUMN c INT64", // unsupported action on an MV
+		"ALTER MATERIALIZED v SET OPTIONS(x=1)",        // missing VIEW
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- DROP MATERIALIZED VIEW ---
+
+func TestDropMaterializedView(t *testing.T) {
+	// DDL-048.
+	d := bqDropOf(t, "DROP MATERIALIZED VIEW IF EXISTS mydataset.my_mv")
+	if d.Object != ast.BQDropMaterializedView {
+		t.Errorf("Object = %v, want MATERIALIZED VIEW", d.Object)
+	}
+	if !d.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+}

--- a/googlesql/parser/bq_row_access_policy.go
+++ b/googlesql/parser/bq_row_access_policy.go
@@ -1,0 +1,208 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// BigQuery DDL — CREATE ROW ACCESS POLICY + DROP [ALL] ROW ACCESS POLICY/POLICIES
+// (parser-ddl-bigquery node)
+// ---------------------------------------------------------------------------
+//
+// Ports the legacy ANTLR create_row_access_policy_statement (GoogleSQLParser.g4
+// §2.2), the `DROP ROW ACCESS POLICY … ON …` alternative of drop_statement, and
+// drop_all_row_access_policies_statement.
+//
+//	create_row_access_policy_statement:
+//	  CREATE opt_or_replace? ROW ACCESS? POLICY opt_if_not_exists? identifier?
+//	    ON path_expression create_row_access_policy_grant_to_clause? filter_using_clause
+//	  create_row_access_policy_grant_to_clause: grant_to_clause | TO grantee_list
+//	  grant_to_clause: GRANT TO ( grantee_list )
+//	  filter_using_clause: FILTER? USING ( expression )
+//	drop_statement: DROP ROW ACCESS POLICY opt_if_exists? identifier on_path_expression
+//	drop_all_row_access_policies_statement:
+//	  DROP ALL ROW ACCESS? POLICIES ON path_expression
+//
+// ORACLE NOTE — BigQuery-only at the union level (oracle.md). Probed 2026-06-05:
+// `CREATE ROW ACCESS POLICY …` REJECTS on the Spanner emulator ("Encountered
+// 'ROW' while parsing: create_statement"). Triangulated against the legacy .g4 +
+// BigQuery truth1 (DDL-021/052); proven by the unit tests in
+// bq_row_access_policy_test.go.
+
+// parseCreateRowAccessPolicy parses a CREATE ROW ACCESS POLICY statement. The
+// shared CREATE prefix (OR REPLACE) has been consumed by parseCreateStmt; cur is
+// at ROW.
+func (p *Parser) parseCreateRowAccessPolicy(create Token, orReplace bool) (ast.Node, error) {
+	p.advance() // ROW
+	// ACCESS? — the grammar marks ACCESS optional (ROW [ACCESS] POLICY); accept both.
+	if p.cur.Type == kwACCESS {
+		p.advance()
+	}
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateRowAccessPolicyStmt{OrReplace: orReplace}
+	stmt.Loc.Start = create.Loc.Start
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	// identifier? — the policy name, optional in the grammar. It is present unless
+	// the next token is ON (the required clause that follows). An identifier-start
+	// that is not ON is the policy name.
+	if p.cur.Type != kwON && isIdentifierStart(p.cur.Type) {
+		nameTok := p.advance()
+		name, err := p.identifierText(nameTok)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Name = name
+	}
+
+	// ON path_expression — required.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	table, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Table = table
+
+	// create_row_access_policy_grant_to_clause?:
+	//   grant_to_clause          = GRANT TO ( grantee_list )
+	//   | TO grantee_list
+	switch p.cur.Type {
+	case kwGRANT:
+		p.advance() // GRANT
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		grantees, err := p.parseGranteeList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		stmt.Grantees = grantees
+		stmt.HasGrantTo = true
+	case kwTO:
+		p.advance() // TO
+		grantees, err := p.parseGranteeList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Grantees = grantees
+		stmt.HasGrantTo = true
+	}
+
+	// filter_using_clause: FILTER? USING ( expression ) — required.
+	if p.cur.Type == kwFILTER {
+		p.advance() // FILTER
+	}
+	if _, err := p.expect(kwUSING); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	filter, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	stmt.Filter = filter
+
+	stmt.Loc.End = p.prev.Loc.End
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// parseDropRowAccessPolicy parses either `DROP ROW ACCESS POLICY [IF EXISTS]
+// identifier ON path` or `DROP ALL ROW ACCESS POLICIES ON path`. The DROP keyword
+// has been consumed by parseDropStmt; cur is at ROW or ALL.
+func (p *Parser) parseDropRowAccessPolicy(drop Token) (ast.Node, error) {
+	if p.cur.Type == kwALL {
+		return p.parseDropAllRowAccessPolicies(drop)
+	}
+
+	// DROP ROW ACCESS POLICY [IF EXISTS] identifier ON path.
+	p.advance() // ROW
+	if _, err := p.expect(kwACCESS); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.BQDropStmt{Object: ast.BQDropRowAccessPolicy}
+	stmt.Loc.Start = drop.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	// identifier — the policy name (required for the single-policy drop).
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// on_path_expression: ON path_expression — required.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	onTable, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.OnTable = onTable
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseDropAllRowAccessPolicies parses `DROP ALL ROW ACCESS? POLICIES ON
+// path_expression`. cur is at ALL (the DROP token is consumed).
+func (p *Parser) parseDropAllRowAccessPolicies(drop Token) (ast.Node, error) {
+	p.advance() // ALL
+	if _, err := p.expect(kwROW); err != nil {
+		return nil, err
+	}
+	// ACCESS? — optional in drop_all_row_access_policies_statement (ROW ACCESS?
+	// POLICIES).
+	if p.cur.Type == kwACCESS {
+		p.advance()
+	}
+	if _, err := p.expect(kwPOLICIES); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.DropAllRowAccessPoliciesStmt{}
+	stmt.Loc.Start = drop.Loc.Start
+
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	table, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Table = table
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/googlesql/parser/bq_row_access_policy_test.go
+++ b/googlesql/parser/bq_row_access_policy_test.go
@@ -1,0 +1,122 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-ddl-bigquery node: CREATE ROW ACCESS POLICY, DROP ROW
+// ACCESS POLICY, DROP ALL ROW ACCESS POLICIES (DDL-021/052). BigQuery-only at the
+// union level (Spanner rejects ROW ACCESS POLICY outright, probed 2026-06-05);
+// verdicts triangulated against the legacy GoogleSQLParser.g4 + BigQuery truth1.
+
+func rapOf(t *testing.T, sql string) *ast.CreateRowAccessPolicyStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	r, ok := n.(*ast.CreateRowAccessPolicyStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateRowAccessPolicyStmt", sql, n)
+	}
+	return r
+}
+
+func TestCreateRowAccessPolicy_Full(t *testing.T) {
+	// DDL-021.
+	r := rapOf(t, "CREATE ROW ACCESS POLICY my_policy ON mydataset.mytable GRANT TO (\"user:alice@example.com\") FILTER USING (department = SESSION_USER())")
+	if r.Name != "my_policy" {
+		t.Errorf("Name = %q, want my_policy", r.Name)
+	}
+	if r.Table.String() != "mydataset.mytable" {
+		t.Errorf("Table = %q", r.Table.String())
+	}
+	if !r.HasGrantTo || len(r.Grantees) != 1 {
+		t.Errorf("HasGrantTo=%v Grantees=%d, want true/1", r.HasGrantTo, len(r.Grantees))
+	}
+	if r.Filter == nil {
+		t.Error("Filter = nil, want the USING expression")
+	}
+}
+
+func TestCreateRowAccessPolicy_NoName_NoGrant(t *testing.T) {
+	// identifier? is optional; the grant-to clause is optional; FILTER is optional
+	// (USING required).
+	r := rapOf(t, "CREATE ROW ACCESS POLICY ON ds.t USING (TRUE)")
+	if r.Name != "" {
+		t.Errorf("Name = %q, want empty", r.Name)
+	}
+	if r.HasGrantTo {
+		t.Error("HasGrantTo = true, want false")
+	}
+	if r.Filter == nil {
+		t.Error("Filter = nil")
+	}
+}
+
+func TestCreateRowAccessPolicy_OrReplaceToGrantees(t *testing.T) {
+	// `TO grantee_list` (without the GRANT keyword) is the alternate grant-to form.
+	r := rapOf(t, "CREATE OR REPLACE ROW ACCESS POLICY p ON ds.t GRANT TO ('user:a@b.com', 'group:g@b.com') FILTER USING (x > 0)")
+	if !r.OrReplace {
+		t.Error("OrReplace = false, want true")
+	}
+	if len(r.Grantees) != 2 {
+		t.Errorf("Grantees = %d, want 2", len(r.Grantees))
+	}
+}
+
+func TestCreateRowAccessPolicy_IfNotExists(t *testing.T) {
+	r := rapOf(t, "CREATE ROW ACCESS POLICY IF NOT EXISTS p ON ds.t FILTER USING (TRUE)")
+	if !r.IfNotExists {
+		t.Error("IfNotExists = false, want true")
+	}
+}
+
+func TestCreateRowAccessPolicy_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE ROW ACCESS POLICY p ON ds.t",             // missing FILTER USING
+		"CREATE ROW ACCESS POLICY p FILTER USING (TRUE)", // missing ON table
+		"CREATE ROW ACCESS POLICY p ON ds.t USING TRUE",  // USING without parens
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- DROP ROW ACCESS POLICY / DROP ALL ROW ACCESS POLICIES ---
+
+func TestDropRowAccessPolicy(t *testing.T) {
+	// DDL-052.
+	d := bqDropOf(t, "DROP ROW ACCESS POLICY IF EXISTS my_policy ON mydataset.mytable")
+	if d.Object != ast.BQDropRowAccessPolicy {
+		t.Errorf("Object = %v, want ROW ACCESS POLICY", d.Object)
+	}
+	if !d.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+	if d.Name.String() != "my_policy" || d.OnTable.String() != "mydataset.mytable" {
+		t.Errorf("Name=%q OnTable=%q", d.Name.String(), d.OnTable.String())
+	}
+}
+
+func TestDropAllRowAccessPolicies(t *testing.T) {
+	// DDL-052.
+	n := parseDDL(t, "DROP ALL ROW ACCESS POLICIES ON mydataset.mytable")
+	d, ok := n.(*ast.DropAllRowAccessPoliciesStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.DropAllRowAccessPoliciesStmt", n)
+	}
+	if d.Table.String() != "mydataset.mytable" {
+		t.Errorf("Table = %q", d.Table.String())
+	}
+}
+
+func TestDropRowAccessPolicy_Rejects(t *testing.T) {
+	cases := []string{
+		"DROP ROW ACCESS POLICY p",     // missing ON table
+		"DROP ROW POLICY p ON t",       // missing ACCESS
+		"DROP ALL ROW ACCESS POLICIES", // missing ON table
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}

--- a/googlesql/parser/bq_search_vector_index.go
+++ b/googlesql/parser/bq_search_vector_index.go
@@ -1,0 +1,294 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// BigQuery DDL — CREATE [SEARCH|VECTOR] INDEX / ALTER VECTOR INDEX REBUILD /
+// DROP [SEARCH|VECTOR] INDEX (parser-ddl-bigquery node)
+// ---------------------------------------------------------------------------
+//
+// Ports the SEARCH / VECTOR index_type variants of the legacy ANTLR
+// create_index_statement (GoogleSQLParser.g4 §2.2/§2.6), the BigQuery
+// `DROP index_type INDEX … ON …` alternative of drop_statement, and the
+// BigQuery-documented `ALTER VECTOR INDEX … REBUILD`. The plain / UNIQUE /
+// NULL_FILTERED CREATE INDEX is owned by the core parser-ddl node
+// (create_index.go).
+//
+//	create_index_statement (search/vector):
+//	  CREATE opt_or_replace? UNIQUE? opt_spanner_null_filtered? index_type INDEX
+//	    opt_if_not_exists? path_expression on_path_expression as_alias?
+//	    index_unnest_expression_list? index_order_by_and_options index_storing_list?
+//	    opt_create_index_statement_suffix?
+//	  index_type: SEARCH | VECTOR
+//	  index_order_by_and_options: ( column_ordering_and_options_expr, … ) | index_all_columns
+//	  index_all_columns: ( ALL COLUMNS opt_with_column_options? )
+//	drop_statement (search/vector):
+//	  DROP index_type INDEX opt_if_exists? path_expression on_path_expression?
+//
+// ORACLE NOTE — BigQuery-only at the union level (oracle.md). Probed 2026-06-05:
+// a bare `CREATE VECTOR INDEX i ON t(c) OPTIONS(…)` ACCEPTS on the Spanner
+// emulator (Spanner has a vector-index grammar), but `CREATE SEARCH INDEX i ON
+// t(ALL COLUMNS)` REJECTS ("Expecting ')' but found 'ALL'") and `DROP {SEARCH|
+// VECTOR} INDEX … ON …` / `ALTER VECTOR INDEX … REBUILD` all REJECT (Spanner's
+// shapes differ). So the Spanner verdict is non-authoritative here; triangulated
+// against the legacy .g4 + BigQuery truth1 (DDL-022/023/041/054); proven by the
+// unit tests in bq_search_vector_index_test.go.
+//
+// DIVERGENCE (flagged) — `ALTER VECTOR INDEX … REBUILD` (DDL-041) is a documented
+// BigQuery form that the legacy GoogleSQLParser.g4 does NOT parse (no REBUILD
+// token anywhere; ALTER VECTOR INDEX rejects in the .g4 because VECTOR is neither
+// a table_or_table_function nor a schema_object_kind nor a generic_entity_type).
+// We implement the documented behavior (accept it) since the omni parser targets
+// the BigQuery+Spanner union and this is strictly additive over one of the
+// legacy grammar's known gaps. See the divergence ledger entry for this node.
+
+// parseCreateSearchVectorIndex parses a CREATE SEARCH|VECTOR INDEX statement. The
+// shared CREATE prefix (OR REPLACE / scope) has been consumed by parseCreateStmt;
+// cur is at SEARCH or VECTOR. scope is not part of create_index_statement, so a
+// non-empty scope is a syntax error.
+func (p *Parser) parseCreateSearchVectorIndex(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if scope != "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	isVector := p.cur.Type == kwVECTOR
+	p.advance() // SEARCH | VECTOR
+
+	stmt := &ast.SearchVectorIndexStmt{IsVector: isVector, OrReplace: orReplace}
+	stmt.Loc.Start = create.Loc.Start
+
+	if _, err := p.expect(kwINDEX); err != nil {
+		return nil, err
+	}
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	// index name (path_expression).
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// on_path_expression: ON path_expression.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	table, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Table = table
+
+	// index_order_by_and_options: `( column_ordering_and_options_expr, … )` or
+	// index_all_columns `( ALL COLUMNS opt_with_column_options? )`.
+	if p.cur.Type != int('(') {
+		return nil, p.syntaxErrorAtCur()
+	}
+	if p.peekNext().Type == kwALL {
+		// index_all_columns: `( ALL COLUMNS opt_with_column_options? )`. The grammar
+		// REQUIRES COLUMNS after ALL, so validate the `( ALL COLUMNS` prefix rather
+		// than blindly skipping balanced parens (a bare `( ALL )` must reject). The
+		// remaining body (the optional WITH COLUMN OPTIONS(...) and the closing ')')
+		// is captured structurally — the per-column options are not load-bearing for
+		// the query-span consumer.
+		if err := p.parseIndexAllColumns(stmt); err != nil {
+			return nil, err
+		}
+	} else {
+		keys, err := p.parseKeyPartList(false /*index element*/)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Keys = keys
+	}
+
+	// index_storing_list? — STORING ( expr, … ).
+	if p.cur.Type == kwSTORING {
+		p.advance() // STORING
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		exprs, _, err := p.parseExprListThroughParen()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Storing = exprs
+	}
+
+	// opt_create_index_statement_suffix?:
+	//   partition_by_clause_prefix_no_hint opt_options_list?
+	//   | opt_options_list? spanner_index_interleave_clause   (not valid for search/vector — left unhandled)
+	//   | opt_options_list
+	if p.cur.Type == kwPARTITION {
+		exprs, err := p.parsePartitionByNoHint()
+		if err != nil {
+			return nil, err
+		}
+		stmt.PartitionBy = exprs
+	}
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseIndexAllColumns parses an index_all_columns body:
+//
+//	'(' ALL COLUMNS opt_with_column_options? ')'
+//	opt_with_column_options: WITH COLUMN OPTIONS '(' column_ordering_and_options_expr (, …) ')'
+//
+// cur is at the opening '(' (the next token is ALL). It sets stmt.AllColumns and
+// validates that COLUMNS follows ALL (a bare `( ALL )` rejects). The optional
+// WITH COLUMN OPTIONS(...) parenthesized run is consumed structurally.
+func (p *Parser) parseIndexAllColumns(stmt *ast.SearchVectorIndexStmt) error {
+	p.advance() // '('
+	if _, err := p.expect(kwALL); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwCOLUMNS); err != nil {
+		return err
+	}
+	stmt.AllColumns = true
+
+	// opt_with_column_options?: WITH COLUMN OPTIONS ( … ).
+	if p.cur.Type == kwWITH {
+		p.advance() // WITH
+		if _, err := p.expect(kwCOLUMN); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwOPTIONS); err != nil {
+			return err
+		}
+		// all_column_column_options is a parenthesized column_ordering_and_options_expr
+		// list; consume it structurally (its per-column options are not load-bearing).
+		if p.cur.Type != int('(') {
+			return p.syntaxErrorAtCur()
+		}
+		if err := p.skipBalancedParens(); err != nil {
+			return err
+		}
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseBQAlterVectorIndex parses an `ALTER VECTOR INDEX [IF EXISTS] index_name ON
+// table_name REBUILD [OPTIONS(…)]` statement (DDL-041). The ALTER keyword has been
+// consumed by parseAlterStmt; cur is at VECTOR.
+//
+// This form is NOT in the legacy GoogleSQLParser.g4 (see the file header
+// divergence note); it is implemented from the BigQuery docs as an additive union
+// form.
+func (p *Parser) parseBQAlterVectorIndex(alter Token) (ast.Node, error) {
+	p.advance() // VECTOR
+	if _, err := p.expect(kwINDEX); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.BQAlterStmt{Object: ast.BQAlterVectorIndex}
+	stmt.Loc.Start = alter.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// ON table_name.
+	if _, err := p.expect(kwON); err != nil {
+		return nil, err
+	}
+	table, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.OnTable = table
+
+	// REBUILD (the keyword lexes as an identifier; match it case-insensitively by
+	// source spelling via curIsWord).
+	if !p.curIsWord("REBUILD") {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // REBUILD
+	stmt.Rebuild = true
+
+	// opt OPTIONS(…) (index_rebuild_option_list).
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SetOptions = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseBQDropSearchVectorIndex parses a `DROP {SEARCH|VECTOR} INDEX [IF EXISTS]
+// path ON table` statement. The DROP keyword has been consumed by parseDropStmt;
+// cur is at SEARCH or VECTOR. Grammar (drop_statement index_type alt):
+// `DROP index_type INDEX opt_if_exists? path_expression on_path_expression?`
+// (DDL-054). The on_path_expression is documented as required for BigQuery
+// SEARCH/VECTOR index drops, but the grammar marks it optional; we accept both
+// (an absent ON yields OnTable nil).
+func (p *Parser) parseBQDropSearchVectorIndex(drop Token) (ast.Node, error) {
+	kind := ast.BQDropSearchIndex
+	if p.cur.Type == kwVECTOR {
+		kind = ast.BQDropVectorIndex
+	}
+	p.advance() // SEARCH | VECTOR
+	if _, err := p.expect(kwINDEX); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.BQDropStmt{Object: kind}
+	stmt.Loc.Start = drop.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// on_path_expression? — ON path.
+	if p.cur.Type == kwON {
+		p.advance() // ON
+		onTable, err := p.parseTablePath()
+		if err != nil {
+			return nil, err
+		}
+		stmt.OnTable = onTable
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/googlesql/parser/bq_search_vector_index_test.go
+++ b/googlesql/parser/bq_search_vector_index_test.go
@@ -1,0 +1,182 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-ddl-bigquery node: CREATE [SEARCH|VECTOR] INDEX,
+// ALTER VECTOR INDEX … REBUILD, DROP [SEARCH|VECTOR] INDEX. BigQuery-only at the
+// union level (the SEARCH-index ALL COLUMNS form, the DROP … ON form, and the
+// REBUILD form all reject on the Spanner emulator, probed 2026-06-05); verdicts
+// triangulated against the legacy GoogleSQLParser.g4 + BigQuery truth1
+// (DDL-022/023/041/054). NB: ALTER VECTOR INDEX … REBUILD is NOT in the legacy
+// .g4 — it is implemented from the BigQuery docs as an additive union form
+// (flagged divergence; see bq_search_vector_index.go header).
+
+func sviOf(t *testing.T, sql string) *ast.SearchVectorIndexStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	svi, ok := n.(*ast.SearchVectorIndexStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.SearchVectorIndexStmt", sql, n)
+	}
+	return svi
+}
+
+func TestCreateSearchIndex_AllColumns(t *testing.T) {
+	// DDL-022.
+	svi := sviOf(t, "CREATE SEARCH INDEX my_index ON mydataset.mytable(ALL COLUMNS)")
+	if svi.IsVector {
+		t.Error("IsVector = true, want false (SEARCH)")
+	}
+	if !svi.AllColumns {
+		t.Error("AllColumns = false, want true")
+	}
+	if svi.Name.String() != "my_index" || svi.Table.String() != "mydataset.mytable" {
+		t.Errorf("Name=%q Table=%q", svi.Name.String(), svi.Table.String())
+	}
+}
+
+func TestCreateSearchIndex_ColumnList(t *testing.T) {
+	// DDL-022.
+	svi := sviOf(t, "CREATE SEARCH INDEX my_index ON mydataset.mytable(name, description)")
+	if svi.AllColumns {
+		t.Error("AllColumns = true, want false")
+	}
+	if len(svi.Keys) != 2 {
+		t.Errorf("Keys = %d, want 2", len(svi.Keys))
+	}
+}
+
+func TestCreateSearchIndex_AllColumnsWithOptions(t *testing.T) {
+	svi := sviOf(t, "CREATE SEARCH INDEX i ON t(ALL COLUMNS WITH COLUMN OPTIONS(a))")
+	if !svi.AllColumns {
+		t.Error("AllColumns = false, want true")
+	}
+}
+
+func TestCreateVectorIndex(t *testing.T) {
+	// DDL-023.
+	svi := sviOf(t, "CREATE VECTOR INDEX my_index ON mydataset.mytable(embedding_column) OPTIONS(index_type='TREE_AH', distance_type='COSINE')")
+	if !svi.IsVector {
+		t.Error("IsVector = false, want true")
+	}
+	if len(svi.Keys) != 1 {
+		t.Errorf("Keys = %d, want 1", len(svi.Keys))
+	}
+	if len(svi.Options) != 2 {
+		t.Errorf("Options = %d, want 2", len(svi.Options))
+	}
+}
+
+func TestCreateVectorIndex_StoringPartition(t *testing.T) {
+	// DDL-023: STORING + PARTITION BY.
+	svi := sviOf(t, "CREATE OR REPLACE VECTOR INDEX i ON t(emb) STORING(a, b) PARTITION BY DATE(d) OPTIONS(distance_type='COSINE')")
+	if !svi.OrReplace {
+		t.Error("OrReplace = false, want true")
+	}
+	if len(svi.Storing) != 2 {
+		t.Errorf("Storing = %d, want 2", len(svi.Storing))
+	}
+	if len(svi.PartitionBy) != 1 {
+		t.Errorf("PartitionBy = %d, want 1", len(svi.PartitionBy))
+	}
+}
+
+func TestCreateVectorIndex_NoOptionsAcceptedPerGrammar(t *testing.T) {
+	// DEFEND (review finding): the legacy create_index_statement makes the
+	// option/suffix tail OPTIONAL (`opt_create_index_statement_suffix?`). BigQuery
+	// docs show OPTIONS on a VECTOR index, but with no Spanner oracle for this exact
+	// shape and the migration target being legacy-grammar parity, we FOLLOW THE
+	// GRAMMAR and accept a VECTOR index with no OPTIONS.
+	svi := sviOf(t, "CREATE VECTOR INDEX i ON ds.t(embedding)")
+	if !svi.IsVector || len(svi.Options) != 0 {
+		t.Errorf("IsVector=%v Options=%d, want vector index with no options", svi.IsVector, len(svi.Options))
+	}
+}
+
+func TestDropSearchVectorIndex_NoOnAcceptedPerGrammar(t *testing.T) {
+	// DEFEND (review finding): drop_statement's `DROP index_type INDEX … path
+	// on_path_expression?` makes the ON clause OPTIONAL. BigQuery docs show ON, but
+	// the grammar permits its absence; we follow the grammar (accept, OnTable nil).
+	d := bqDropOf(t, "DROP SEARCH INDEX i")
+	if d.Object != ast.BQDropSearchIndex || d.OnTable != nil {
+		t.Errorf("got Object=%v OnTable=%v, want SEARCH INDEX with nil OnTable", d.Object, d.OnTable)
+	}
+}
+
+func TestCreateSearchVectorIndex_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE SEARCH INDEX i",              // missing ON
+		"CREATE SEARCH INDEX i ON t",         // missing column list
+		"CREATE VECTOR i ON t(c)",            // missing INDEX keyword
+		"CREATE TEMP SEARCH INDEX i ON t(c)", // index takes no scope
+		// Regression (review finding): index_all_columns requires COLUMNS after ALL;
+		// a bare `( ALL )` must reject (not be skipped as balanced parens).
+		"CREATE SEARCH INDEX i ON t(ALL)",
+		"CREATE SEARCH INDEX i ON t(ALL COLUMNS WITH COLUMN)", // WITH COLUMN OPTIONS malformed (missing OPTIONS + list)
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- ALTER VECTOR INDEX REBUILD ---
+
+func TestAlterVectorIndex_Rebuild(t *testing.T) {
+	// DDL-041 (NOT in the legacy .g4; additive union form).
+	a := bqAlterOf(t, "ALTER VECTOR INDEX my_index ON mydataset.mytable REBUILD")
+	if a.Object != ast.BQAlterVectorIndex {
+		t.Errorf("Object = %v, want VECTOR INDEX", a.Object)
+	}
+	if !a.Rebuild {
+		t.Error("Rebuild = false, want true")
+	}
+	if a.OnTable == nil || a.OnTable.String() != "mydataset.mytable" {
+		t.Errorf("OnTable = %v", a.OnTable)
+	}
+}
+
+func TestAlterVectorIndex_RebuildOptions(t *testing.T) {
+	a := bqAlterOf(t, "ALTER VECTOR INDEX IF EXISTS i ON t REBUILD OPTIONS(x=1)")
+	if !a.IfExists || !a.Rebuild {
+		t.Errorf("IfExists=%v Rebuild=%v", a.IfExists, a.Rebuild)
+	}
+	if len(a.SetOptions) != 1 {
+		t.Errorf("SetOptions = %d, want 1", len(a.SetOptions))
+	}
+}
+
+func TestAlterVectorIndex_Rejects(t *testing.T) {
+	cases := []string{
+		"ALTER VECTOR INDEX i ON t",    // missing REBUILD
+		"ALTER VECTOR INDEX i REBUILD", // missing ON table
+		"ALTER VECTOR i ON t REBUILD",  // missing INDEX
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// --- DROP SEARCH/VECTOR INDEX ---
+
+func TestDropSearchIndex(t *testing.T) {
+	// DDL-054.
+	d := bqDropOf(t, "DROP SEARCH INDEX IF EXISTS my_index ON mydataset.mytable")
+	if d.Object != ast.BQDropSearchIndex {
+		t.Errorf("Object = %v, want SEARCH INDEX", d.Object)
+	}
+	if d.OnTable == nil || d.OnTable.String() != "mydataset.mytable" {
+		t.Errorf("OnTable = %v", d.OnTable)
+	}
+}
+
+func TestDropVectorIndex(t *testing.T) {
+	// DDL-054.
+	d := bqDropOf(t, "DROP VECTOR INDEX IF EXISTS my_index ON mydataset.mytable")
+	if d.Object != ast.BQDropVectorIndex {
+		t.Errorf("Object = %v, want VECTOR INDEX", d.Object)
+	}
+}

--- a/googlesql/parser/bq_snapshot_clone.go
+++ b/googlesql/parser/bq_snapshot_clone.go
@@ -1,0 +1,140 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// BigQuery DDL — CREATE SNAPSHOT TABLE + DROP SNAPSHOT TABLE
+// (parser-ddl-bigquery node)
+// ---------------------------------------------------------------------------
+//
+// Ports the legacy ANTLR create_snapshot_statement (GoogleSQLParser.g4 §2.2) and
+// the `DROP SNAPSHOT TABLE` alternative of drop_statement. (CREATE TABLE … CLONE
+// / COPY / LIKE — DDL-006/007/009 — are part of the core CREATE TABLE grammar and
+// are owned by the parser-ddl node in create_table.go; this file is only the
+// SNAPSHOT object.)
+//
+//	create_snapshot_statement:
+//	  CREATE opt_or_replace? SNAPSHOT (TABLE | schema_object_kind) opt_if_not_exists?
+//	    maybe_dashed_path CLONE clone_data_source opt_options_list?
+//	  clone_data_source: maybe_dashed_path opt_at_system_time? where_clause?
+//	  opt_at_system_time: FOR SYSTEM_TIME AS OF expr   (also `FOR SYSTEM TIME AS OF`)
+//	drop_statement: DROP SNAPSHOT TABLE opt_if_exists? maybe_dashed_path
+//
+// ORACLE NOTE — BigQuery-only at the union level (oracle.md). Probed 2026-06-05:
+// `CREATE SNAPSHOT TABLE … CLONE …` REJECTS on the Spanner emulator
+// ("Encountered 'SNAPSHOT' while parsing: create_statement"). Triangulated
+// against the legacy .g4 + BigQuery truth1 (DDL-008/045); proven by the unit
+// tests in bq_snapshot_clone_test.go.
+
+// parseCreateSnapshot parses a CREATE SNAPSHOT TABLE statement. The shared CREATE
+// prefix (OR REPLACE) has been consumed by parseCreateStmt; cur is at SNAPSHOT.
+func (p *Parser) parseCreateSnapshot(create Token, orReplace bool) (ast.Node, error) {
+	p.advance() // SNAPSHOT
+
+	stmt := &ast.CreateSnapshotStmt{OrReplace: orReplace}
+	stmt.Loc.Start = create.Loc.Start
+
+	// SNAPSHOT (TABLE | schema_object_kind) — the documented form is SNAPSHOT TABLE;
+	// the grammar also admits a schema_object_kind, but TABLE is the BigQuery form.
+	if _, err := p.expect(kwTABLE); err != nil {
+		return nil, err
+	}
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// CLONE clone_data_source.
+	if _, err := p.expect(kwCLONE); err != nil {
+		return nil, err
+	}
+	src, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.CloneSource = src
+
+	// opt_at_system_time? — FOR SYSTEM_TIME AS OF expr.
+	if p.cur.Type == kwFOR {
+		ts, err := p.parseForSystemTimeExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.ForSystemTime = ts
+	}
+
+	// where_clause? — WHERE expr (part of clone_data_source).
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = expr
+	}
+
+	// opt_options_list?
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// parseForSystemTimeExpr parses an opt_at_system_time clause and RETURNS its time
+// expression (as opposed to from_join.go's parseForSystemTime, which attaches it
+// to a TableExpr):
+//
+//	FOR SYSTEM_TIME AS OF expr
+//	| FOR SYSTEM TIME AS OF expr
+//
+// cur is at FOR. The lexer emits SYSTEM_TIME as one token (kwSYSTEM_TIME) or
+// SYSTEM + TIME as two; both spellings are accepted.
+func (p *Parser) parseForSystemTimeExpr() (ast.Node, error) {
+	p.advance() // FOR
+	switch p.cur.Type {
+	case kwSYSTEM_TIME:
+		p.advance() // SYSTEM_TIME
+	case kwSYSTEM:
+		p.advance() // SYSTEM
+		if _, err := p.expect(kwTIME); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwOF); err != nil {
+		return nil, err
+	}
+	return p.parseExpr()
+}
+
+// parseBQDropSnapshot parses a DROP SNAPSHOT TABLE statement. The DROP keyword has
+// been consumed by parseDropStmt; cur is at SNAPSHOT. Grammar:
+// `DROP SNAPSHOT TABLE opt_if_exists? maybe_dashed_path` (DDL-045).
+func (p *Parser) parseBQDropSnapshot(drop Token) (ast.Node, error) {
+	p.advance() // SNAPSHOT
+	if _, err := p.expect(kwTABLE); err != nil {
+		return nil, err
+	}
+	return p.finishBQDropObject(drop, ast.BQDropSnapshotTable, false /*allowFunctionParams*/)
+}

--- a/googlesql/parser/bq_snapshot_clone_test.go
+++ b/googlesql/parser/bq_snapshot_clone_test.go
@@ -1,0 +1,86 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-ddl-bigquery node: CREATE SNAPSHOT TABLE … CLONE …
+// and DROP SNAPSHOT TABLE. BigQuery-only at the union level (Spanner rejects
+// SNAPSHOT outright, probed 2026-06-05); verdicts triangulated against the legacy
+// GoogleSQLParser.g4 + BigQuery truth1 (DDL-008/045). (CREATE TABLE … CLONE/COPY/
+// LIKE is core CREATE TABLE, covered by the parser-ddl node — not here.)
+
+func snapOf(t *testing.T, sql string) *ast.CreateSnapshotStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	s, ok := n.(*ast.CreateSnapshotStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateSnapshotStmt", sql, n)
+	}
+	return s
+}
+
+func TestCreateSnapshotTable_Basic(t *testing.T) {
+	s := snapOf(t, "CREATE SNAPSHOT TABLE mydataset.my_snapshot CLONE mydataset.mytable")
+	if s.Name.String() != "mydataset.my_snapshot" {
+		t.Errorf("Name = %q", s.Name.String())
+	}
+	if s.CloneSource == nil || s.CloneSource.String() != "mydataset.mytable" {
+		t.Errorf("CloneSource = %v", s.CloneSource)
+	}
+}
+
+func TestCreateSnapshotTable_ForSystemTime(t *testing.T) {
+	// DDL-008.
+	s := snapOf(t, "CREATE SNAPSHOT TABLE mydataset.my_snapshot CLONE mydataset.mytable FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)")
+	if s.ForSystemTime == nil {
+		t.Error("ForSystemTime = nil, want the time expression")
+	}
+}
+
+func TestCreateSnapshotTable_IfNotExistsOptions(t *testing.T) {
+	s := snapOf(t, "CREATE SNAPSHOT TABLE IF NOT EXISTS ds.s CLONE ds.t OPTIONS(expiration_timestamp=TIMESTAMP '2025-01-01 00:00:00 UTC')")
+	if !s.IfNotExists {
+		t.Error("IfNotExists = false, want true")
+	}
+	if len(s.Options) != 1 {
+		t.Errorf("Options = %d, want 1", len(s.Options))
+	}
+}
+
+func TestCreateSnapshotTable_SpaceSystemTime(t *testing.T) {
+	// `FOR SYSTEM TIME AS OF` (two-word spelling) is accepted as well as SYSTEM_TIME.
+	s := snapOf(t, "CREATE SNAPSHOT TABLE ds.s CLONE ds.t FOR SYSTEM TIME AS OF CURRENT_TIMESTAMP()")
+	if s.ForSystemTime == nil {
+		t.Error("ForSystemTime = nil")
+	}
+}
+
+func TestCreateSnapshotTable_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE SNAPSHOT TABLE s",                              // missing CLONE source
+		"CREATE SNAPSHOT s CLONE t",                            // missing TABLE keyword
+		"CREATE SNAPSHOT TABLE s CLONE t FOR SYSTEM_TIME AS x", // bad FOR SYSTEM_TIME (missing OF)
+		// Regression (review finding): create_snapshot_statement has NO
+		// opt_create_scope; a leading TEMP/TEMPORARY must reject (not be silently
+		// dropped).
+		"CREATE TEMP SNAPSHOT TABLE s CLONE t",
+		"CREATE TEMPORARY SNAPSHOT TABLE s CLONE t",
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+func TestDropSnapshotTable(t *testing.T) {
+	// DDL-045.
+	d := bqDropOf(t, "DROP SNAPSHOT TABLE IF EXISTS mydataset.mytablesnapshot")
+	if d.Object != ast.BQDropSnapshotTable {
+		t.Errorf("Object = %v, want SNAPSHOT TABLE", d.Object)
+	}
+	if !d.IfExists {
+		t.Error("IfExists = false, want true")
+	}
+}

--- a/googlesql/parser/create_table.go
+++ b/googlesql/parser/create_table.go
@@ -64,40 +64,90 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	switch p.cur.Type {
 	case kwTABLE:
 		// CREATE TABLE — but CREATE TABLE FUNCTION (TVF) is a BigQuery-only object
-		// owned by parser-ddl-bigquery; route it to the stub.
+		// owned by parser-ddl-bigquery (bq_function_procedure.go).
 		if p.peekNext().Type == kwFUNCTION {
-			return p.unsupported("CREATE TABLE FUNCTION")
+			return p.parseCreateFunction(create, orReplace, scope, false /*aggregate*/, true /*isTableFunc*/)
 		}
 		return p.parseCreateTable(create, orReplace, scope)
 	case kwVIEW:
 		return p.parseCreateView(create, orReplace, scope, false /*recursive*/)
 	case kwRECURSIVE:
 		// RECURSIVE VIEW (the plain-view alt with RECURSIVE). MATERIALIZED/APPROX
-		// RECURSIVE views are dialect-node territory; a bare RECURSIVE followed by
-		// VIEW is the plain recursive view this node owns.
+		// RECURSIVE views are owned by parser-ddl-bigquery (bq_materialized_view.go);
+		// a bare RECURSIVE followed by VIEW is the plain recursive view this node
+		// owns.
 		if p.peekNext().Type == kwVIEW {
 			p.advance() // RECURSIVE
 			return p.parseCreateView(create, orReplace, scope, true /*recursive*/)
 		}
+		if p.peekNext().Type == kwMATERIALIZED || p.peekNext().Type == kwAPPROX {
+			// CREATE RECURSIVE MATERIALIZED|APPROX VIEW is not a grammar form (the
+			// RECURSIVE keyword follows MATERIALIZED/APPROX, not precedes it); leave
+			// it as an unknown CREATE.
+			return p.unsupported("CREATE")
+		}
 		return p.unsupported("CREATE")
+	case kwMATERIALIZED, kwAPPROX:
+		// CREATE MATERIALIZED|APPROX [RECURSIVE] VIEW — BigQuery-only
+		// (bq_materialized_view.go).
+		return p.parseCreateMaterializedView(create, orReplace, scope)
 	case kwUNIQUE, kwNULL_FILTERED, kwINDEX:
 		// CREATE [UNIQUE] [NULL_FILTERED] INDEX. The SEARCH/VECTOR index_type
 		// variants are dialect-node territory; parseCreateIndex rejects a
 		// SEARCH/VECTOR token after the qualifiers by routing to the stub.
 		return p.parseCreateIndex(create, orReplace, scope)
 	case kwSEARCH, kwVECTOR:
-		// CREATE SEARCH|VECTOR INDEX — dialect-specific (parser-ddl-{bigquery,
-		// spanner}).
-		return p.unsupported("CREATE " + p.cur.Str)
+		// CREATE SEARCH|VECTOR INDEX — BigQuery-only (bq_search_vector_index.go).
+		return p.parseCreateSearchVectorIndex(create, orReplace, scope)
 	case kwSCHEMA:
 		return p.parseCreateSchema(create, orReplace)
 	case kwDATABASE:
 		return p.parseCreateDatabase(create, orReplace, scope)
+	case kwAGGREGATE:
+		// CREATE [OR REPLACE] [scope] AGGREGATE FUNCTION — BigQuery-only
+		// (bq_function_procedure.go). opt_aggregate precedes FUNCTION.
+		if p.peekNext().Type == kwFUNCTION {
+			p.advance() // AGGREGATE
+			return p.parseCreateFunction(create, orReplace, scope, true /*aggregate*/, false /*isTableFunc*/)
+		}
+		return p.unsupported("CREATE")
+	case kwFUNCTION:
+		// CREATE [OR REPLACE] [scope] FUNCTION — BigQuery-only (bq_function_procedure.go).
+		return p.parseCreateFunction(create, orReplace, scope, false /*aggregate*/, false /*isTableFunc*/)
+	case kwPROCEDURE:
+		// CREATE [OR REPLACE] [scope] PROCEDURE — BigQuery-only (bq_function_procedure.go).
+		return p.parseCreateProcedure(create, orReplace, scope)
+	case kwSNAPSHOT:
+		// CREATE [OR REPLACE] SNAPSHOT TABLE … CLONE — BigQuery-only
+		// (bq_snapshot_clone.go). create_snapshot_statement has NO opt_create_scope,
+		// so a leading TEMP/TEMPORARY/PUBLIC/PRIVATE is a syntax error.
+		if scope != "" {
+			return nil, p.syntaxErrorAtCur()
+		}
+		return p.parseCreateSnapshot(create, orReplace)
+	case kwROW:
+		// CREATE [OR REPLACE] ROW ACCESS POLICY — BigQuery-only
+		// (bq_row_access_policy.go). create_row_access_policy_statement has NO
+		// opt_create_scope, so a leading scope is a syntax error.
+		if scope != "" {
+			return nil, p.syntaxErrorAtCur()
+		}
+		return p.parseCreateRowAccessPolicy(create, orReplace)
 	default:
-		// Any other object kind (FUNCTION / PROCEDURE / MODEL / EXTERNAL /
-		// MATERIALIZED|APPROX VIEW / SNAPSHOT / generic entity / a bare identifier
-		// such as the dispatch-coverage `CREATE x` probe) is not owned here; emit
-		// a "CREATE …" not-yet-supported diagnostic.
+		// A generic-entity object kind whose keyword lexes as a bare identifier
+		// (BigQuery CAPACITY / RESERVATION / ASSIGNMENT, or PROJECT) is handled by
+		// the create_entity_statement path (bq_capacity.go). MODEL / EXTERNAL /
+		// CONNECTION / CONSTANT / PROPERTY GRAPH and the dispatch-coverage `CREATE x`
+		// probe are not owned here; the entity parser rejects a leading reserved
+		// keyword (it requires an identifier entity-type) and otherwise emits the
+		// not-yet-supported diagnostic.
+		if isGenericEntityType(p.cur.Type) {
+			// create_entity_statement has NO opt_create_scope; a leading scope rejects.
+			if scope != "" {
+				return nil, p.syntaxErrorAtCur()
+			}
+			return p.parseCreateEntity(create, orReplace)
+		}
 		return p.unsupported("CREATE")
 	}
 }

--- a/googlesql/parser/drop.go
+++ b/googlesql/parser/drop.go
@@ -34,9 +34,10 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 
 	switch p.cur.Type {
 	case kwTABLE:
-		// DROP TABLE — but DROP TABLE FUNCTION is dialect-node territory.
+		// DROP TABLE — but DROP TABLE FUNCTION is BigQuery-only
+		// (bq_function_procedure.go).
 		if p.peekNext().Type == kwFUNCTION {
-			return p.unsupported("DROP TABLE FUNCTION")
+			return p.parseBQDropFunction(drop)
 		}
 		return p.parseDropObject(drop, ast.DropTable, false /*external*/)
 	case kwVIEW:
@@ -44,8 +45,9 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 	case kwINDEX:
 		return p.parseDropIndex(drop)
 	case kwSEARCH, kwVECTOR:
-		// DROP {SEARCH|VECTOR} INDEX … ON table — dialect-specific.
-		return p.unsupported("DROP " + p.cur.Str + " INDEX")
+		// DROP {SEARCH|VECTOR} INDEX … ON table — BigQuery-only
+		// (bq_search_vector_index.go).
+		return p.parseBQDropSearchVectorIndex(drop)
 	case kwSCHEMA:
 		return p.parseDropObject(drop, ast.DropSchema, false)
 	case kwDATABASE:
@@ -58,10 +60,31 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 			return p.parseDropObject(drop, ast.DropSchema, true /*external*/)
 		}
 		return p.unsupported("DROP EXTERNAL")
+	// --- BigQuery-only object drops (parser-ddl-bigquery node) ---
+	case kwFUNCTION:
+		return p.parseBQDropFunction(drop)
+	case kwPROCEDURE:
+		return p.parseBQDropProcedure(drop)
+	case kwMATERIALIZED, kwAPPROX:
+		return p.parseBQDropMaterializedView(drop)
+	case kwSNAPSHOT:
+		return p.parseBQDropSnapshot(drop)
+	case kwROW:
+		// DROP ROW ACCESS POLICY … ON table (bq_row_access_policy.go).
+		return p.parseDropRowAccessPolicy(drop)
+	case kwALL:
+		// DROP ALL ROW ACCESS POLICIES ON table
+		// (drop_all_row_access_policies_statement; bq_row_access_policy.go).
+		return p.parseDropRowAccessPolicy(drop)
 	default:
-		// DROP FUNCTION / PROCEDURE / MODEL / SNAPSHOT TABLE / ROW ACCESS POLICY /
-		// PRIVILEGE RESTRICTION / generic entity / a bare-identifier object — not
-		// owned here.
+		// DROP <generic-entity> (CAPACITY / RESERVATION / ASSIGNMENT — DDL-053; the
+		// keyword lexes as an identifier) routes to the generic-entity drop
+		// (bq_capacity.go). DROP MODEL / CONNECTION / CONSTANT / PRIVILEGE
+		// RESTRICTION and the bare-identifier dispatch-coverage probe otherwise emit
+		// the not-yet-supported diagnostic.
+		if isGenericEntityType(p.cur.Type) {
+			return p.parseBQDropEntity(drop)
+		}
 		return p.unsupported("DROP")
 	}
 }

--- a/googlesql/parser/parser_test.go
+++ b/googlesql/parser/parser_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"strings"
 	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
 )
 
 // TestParse_EmptyInput verifies that parsing empty or whitespace/comment-only
@@ -329,15 +331,22 @@ func TestParse_QueryStatementsParse(t *testing.T) {
 }
 
 // TestParse_ProceduralBodyParsedAsOneSegment verifies the parse driver feeds a
-// procedural BEGIN/END body to a single parseSingle call (block-aware Split),
-// so a stored procedure yields exactly one "not yet supported" error, not one
-// per inner statement.
+// procedural BEGIN/END body to a single parseSingle call (block-aware Split): a
+// stored procedure whose body has an inner ';' must be ONE segment, not split at
+// the inner statement boundary. Now that the parser-ddl-bigquery node parses
+// CREATE PROCEDURE, the whole block parses to exactly ONE statement with no
+// errors — had Split cut at the inner ';', the trailing fragments
+// (`SELECT 2`, `END`) would have failed to parse, so a clean single-statement
+// parse is the proof the block stayed whole.
 func TestParse_ProceduralBodyParsedAsOneSegment(t *testing.T) {
 	res := ParseBestEffort("CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 2; END")
-	if len(res.Errors) != 1 {
-		t.Fatalf("got %d errors, want 1 (block is one segment): %v", len(res.Errors), res.Errors)
+	if len(res.Errors) != 0 {
+		t.Fatalf("got %d errors, want 0 (block is one segment, CREATE PROCEDURE parses): %v", len(res.Errors), res.Errors)
 	}
-	if !strings.HasPrefix(res.Errors[0].Msg, "CREATE ") {
-		t.Errorf("error = %q, want it to dispatch on CREATE", res.Errors[0].Msg)
+	if len(res.File.Stmts) != 1 {
+		t.Fatalf("got %d statements, want 1 (the whole procedure)", len(res.File.Stmts))
+	}
+	if _, ok := res.File.Stmts[0].(*ast.CreateProcedureStmt); !ok {
+		t.Errorf("statement is %T, want *ast.CreateProcedureStmt", res.File.Stmts[0])
 	}
 }


### PR DESCRIPTION
## googlesql/parser-ddl-bigquery — BigQuery-only object DDL

Implements the BigQuery-specific DDL the core `parser-ddl` node (#220) stubbed. One omni parser serves the BigQuery+Spanner union; every form here is **BigQuery-only at the union level**.

Spec: `docs/migration/googlesql/truth1/bigquery/ddl.md` (DDL-008/011/012/015–026/040/041/045/048–054) + legacy `GoogleSQLParser.g4` (create_function_statement, create_table_function_statement, create_procedure_statement, create_view_statement materialized/approx, create_index_statement SEARCH/VECTOR, create_snapshot_statement, create_row_access_policy_statement, create_entity_statement, generic-entity alter/drop).

### Coverage (forms → file)
- **bq_function_procedure.go** — CREATE [AGGREGATE] FUNCTION (SQL/JS/Python/remote bodies, RETURNS, determinism, SQL SECURITY, LANGUAGE, REMOTE WITH CONNECTION, OPTIONS), CREATE TABLE FUNCTION (params incl. `ANY TYPE` / `TABLE<…>`, RETURNS TABLE<…>, AS query/string), CREATE PROCEDURE (IN/OUT/INOUT params, EXTERNAL SECURITY, BEGIN…END block captured as text, LANGUAGE…AS code); DROP FUNCTION/TABLE FUNCTION/PROCEDURE.
- **bq_materialized_view.go** — CREATE MATERIALIZED|APPROX VIEW (columns, SQL SECURITY, PARTITION/CLUSTER, OPTIONS, AS query / AS REPLICA OF); ALTER MATERIALIZED VIEW SET OPTIONS; DROP MATERIALIZED|APPROX VIEW.
- **bq_search_vector_index.go** — CREATE SEARCH|VECTOR INDEX (column list / ALL COLUMNS, STORING, PARTITION BY, OPTIONS); ALTER VECTOR INDEX … REBUILD; DROP SEARCH|VECTOR INDEX … ON.
- **bq_snapshot_clone.go** — CREATE SNAPSHOT TABLE … CLONE … [FOR SYSTEM_TIME AS OF] [OPTIONS]; DROP SNAPSHOT TABLE. (CREATE TABLE … CLONE/COPY/LIKE stays core.)
- **bq_capacity.go** — generic-entity CREATE/ALTER/DROP (CAPACITY/RESERVATION/ASSIGNMENT and any extensible entity, via `generic_entity_type: IDENTIFIER | PROJECT`).
- **bq_row_access_policy.go** — CREATE ROW ACCESS POLICY (GRANT TO / TO grantees, [FILTER] USING); DROP ROW ACCESS POLICY … ON; DROP ALL ROW ACCESS POLICIES ON.

New AST nodes in `ast/parsenodes.go` (+ `nodetags.go`, `walk_generated.go` regenerated via genwalker); `analysis/classify.go` classifies them as DDL.

### Proof (correctness-protocol.md)
- **Triangulation** (BigQuery-only ⇒ Spanner emulator non-authoritative): hand-written unit tests assert AST shape + accept/reject against the legacy `.g4` + truth1 (both polarities, per-form reject cases).
- **Live oracle guard** (`bq_ddl_oracle_test.go`, `-tags googlesql_oracle`): records each form's empirically-observed Spanner-emulator verdict (probed 2026-06-05) and asserts it holds — fails if an emulator bump shifts the BigQuery-vs-Spanner boundary, forcing a re-review rather than silently trusting a stale assumption. The union parser's required `accept` is asserted alongside.
- `go test ./googlesql/{parser,ast,analysis,diagnostics}/...` green; `SPANNER_EMULATOR_HOST=localhost:9010 go test -tags googlesql_oracle ./googlesql/parser/...` green (core DDL + all existing differentials unregressed).

### Review (review-gate.md, two-model)
Claude lens + Codex lens. Codex surfaced 7; **4 real bugs fixed** (IF()/CASE function calls in a procedure body miscounted as block openers → false reject; TEMP scope silently accepted on scope-less SNAPSHOT/ROW ACCESS POLICY/entity; `( ALL )` accepted without the required COLUMNS), each with a permanent regression test. **3 docs-require-more-than-grammar findings defended** as legacy-grammar-faithful (body-less TVF, OPTIONS-less VECTOR INDEX, ON-less DROP INDEX — all `?` in the `.g4`) with pinning tests.

### Divergences (flagged in the ledger)
1. **ALTER VECTOR INDEX … REBUILD** (DDL-041) — documented by BigQuery but **absent from the legacy `.g4`** (no REBUILD token; one of the grammar's known gaps). Implemented as an additive union form; Spanner rejects it regardless. `high`.
2. **AS REPLICA OF … OPTIONS(…)** (DDL-012) — BigQuery documents trailing replica options; the legacy `query_or_replica_source` omits them. Additive; zero Spanner risk. `medium`.

### Scope
In-scope writes: the 6 `bq_*.go` + `ast/{parsenodes,nodetags,walk_generated}.go`. `parser/parser.go` unchanged (dispatch hooks live in the fan-out). Out-of-scope (recorded): dispatch hooks in `parser/{create_table,alter_table,drop}.go` (the seam #220 created; same pattern as parser-dml #237 / parser-utility #241); `parser/parser_test.go` (stale CREATE PROCEDURE expectation now parses); `analysis/classify.go`(+test) (classify new DDL nodes as DDL — parity); `bq_*_test.go` + `bq_ddl_oracle_test.go` (node test deliverables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
