### PR TITLE
feat(snowflake): T4.7 CREATE / ALTER integration objects (STORAGE/API/NOTIFICATION INTEGRATION, RESOURCE MONITOR, SECRET, CONNECTION, EXTERNAL VOLUME, GIT REPOSITORY)

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -113,6 +113,12 @@ const (
 	T_CreateFileFormatStmt
 	T_AlterFileFormatStmt
 
+	// Integration-object DDL tags (T4.7)
+	T_ResourceMonitorTrigger
+	T_ConnectionReplica
+	T_CreateIntegrationStmt
+	T_AlterIntegrationStmt
+
 	// Data-pipeline DDL tags (T4.3)
 	T_CreatePipeStmt
 	T_AlterPipeStmt
@@ -312,6 +318,14 @@ func (t NodeTag) String() string {
 		return "CreateAlertStmt"
 	case T_AlterAlertStmt:
 		return "AlterAlertStmt"
+	case T_ResourceMonitorTrigger:
+		return "ResourceMonitorTrigger"
+	case T_ConnectionReplica:
+		return "ConnectionReplica"
+	case T_CreateIntegrationStmt:
+		return "CreateIntegrationStmt"
+	case T_AlterIntegrationStmt:
+		return "AlterIntegrationStmt"
 	case T_CreateRoutineStmt:
 		return "CreateRoutineStmt"
 	case T_AlterRoutineStmt:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -2806,6 +2806,196 @@ var (
 )
 
 // ---------------------------------------------------------------------------
+// Account-level integration-object DDL — CREATE / ALTER for STORAGE / API /
+// NOTIFICATION / SECURITY INTEGRATION, RESOURCE MONITOR, SECRET, CONNECTION,
+// EXTERNAL VOLUME, GIT REPOSITORY (T4.7)
+// ---------------------------------------------------------------------------
+//
+// These account/schema-level objects all configure an external resource through
+// a large, version-growing vocabulary of `KEY = <value>` parameters: a STORAGE
+// INTEGRATION carries STORAGE_PROVIDER / STORAGE_AWS_ROLE_ARN /
+// STORAGE_ALLOWED_LOCATIONS / ...; an API INTEGRATION API_PROVIDER /
+// API_ALLOWED_PREFIXES / ...; a SECRET TYPE / OAUTH_SCOPES / SECRET_STRING / ...;
+// a GIT REPOSITORY ORIGIN / API_INTEGRATION / GIT_CREDENTIALS; an EXTERNAL VOLUME
+// STORAGE_LOCATIONS / ALLOW_WRITES; and so on. Rather than mirror the legacy
+// ANTLR grammar's finite, already-stale per-type enumerations (its
+// create_*_integration rules pin a fixed option order and lack newer params, and
+// it has no rule for CREATE EXTERNAL VOLUME at all), every parameter that follows
+// the object name is captured as an open-ended `KEY = <value>` pair (CopyOption),
+// reusing the merged COPY (T5.2) / STAGE (T4.1) / FILE FORMAT (T4.2) machinery.
+// Only the structural anchors are modeled as dedicated fields: the object Kind,
+// the RESOURCE MONITOR WITH keyword + its TRIGGERS clause, the GIT REPOSITORY
+// [WITH] TAG clause, and (on ALTER) the action keyword and EXTERNAL VOLUME's
+// ADD/REMOVE/UPDATE STORAGE_LOCATION actions. The catalog/semantic layer, not the
+// parser, validates that an option is real and legal for the chosen Kind.
+
+// IntegrationObjectKind discriminates the account-level object types handled by
+// the T4.7 CREATE / ALTER parsers.
+type IntegrationObjectKind int
+
+const (
+	StorageIntegration      IntegrationObjectKind = iota // [STORAGE] INTEGRATION
+	APIIntegration                                       // API INTEGRATION
+	NotificationIntegration                              // NOTIFICATION INTEGRATION
+	SecurityIntegration                                  // SECURITY INTEGRATION
+	ResourceMonitor                                      // RESOURCE MONITOR
+	Secret                                               // SECRET
+	Connection                                           // CONNECTION
+	ExternalVolume                                       // EXTERNAL VOLUME
+	GitRepository                                        // GIT REPOSITORY
+)
+
+// String returns the SQL object keyword(s) for the kind (uppercased), used for
+// diagnostics and deparse.
+func (k IntegrationObjectKind) String() string {
+	switch k {
+	case StorageIntegration:
+		return "STORAGE INTEGRATION"
+	case APIIntegration:
+		return "API INTEGRATION"
+	case NotificationIntegration:
+		return "NOTIFICATION INTEGRATION"
+	case SecurityIntegration:
+		return "SECURITY INTEGRATION"
+	case ResourceMonitor:
+		return "RESOURCE MONITOR"
+	case Secret:
+		return "SECRET"
+	case Connection:
+		return "CONNECTION"
+	case ExternalVolume:
+		return "EXTERNAL VOLUME"
+	case GitRepository:
+		return "GIT REPOSITORY"
+	default:
+		return "INTEGRATION OBJECT"
+	}
+}
+
+// ResourceMonitorTrigger is one RESOURCE MONITOR trigger definition:
+//
+//	ON <threshold> PERCENT DO { SUSPEND | SUSPEND_IMMEDIATE | NOTIFY }
+//
+// Triggers are space-separated in the source (no comma). Action is the uppercased
+// action keyword.
+type ResourceMonitorTrigger struct {
+	Threshold int64  // the ON <threshold> PERCENT value
+	Action    string // "SUSPEND" | "SUSPEND_IMMEDIATE" | "NOTIFY"
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *ResourceMonitorTrigger) Tag() NodeTag { return T_ResourceMonitorTrigger }
+
+// ConnectionReplica holds a CREATE CONNECTION ... AS REPLICA OF
+// <organization>.<account>.<connection> clause. The three parts are captured as
+// an ObjectName (so quoting / dotted-name handling is shared with every other
+// name in the AST).
+type ConnectionReplica struct {
+	Source *ObjectName // organization_name.account_name.connection_name
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ConnectionReplica) Tag() NodeTag { return T_ConnectionReplica }
+
+// CreateIntegrationStmt represents the CREATE form of every T4.7 object:
+//
+//	CREATE [ OR REPLACE ] { STORAGE | API | NOTIFICATION | SECURITY } INTEGRATION [ IF NOT EXISTS ] <name> <options...>
+//	CREATE [ OR REPLACE ] RESOURCE MONITOR [ IF NOT EXISTS ] <name> WITH <options...> [ TRIGGERS <trigger>... ]
+//	CREATE [ OR REPLACE ] SECRET [ IF NOT EXISTS ] <name> <options...>
+//	CREATE CONNECTION [ IF NOT EXISTS ] <name> [ AS REPLICA OF <a.b.c> ] [ COMMENT = '...' ]
+//	CREATE [ OR REPLACE ] EXTERNAL VOLUME [ IF NOT EXISTS ] <name> STORAGE_LOCATIONS = (...) [ ALLOW_WRITES = ... ] [ COMMENT = '...' ]
+//	CREATE [ OR REPLACE ] GIT REPOSITORY [ IF NOT EXISTS ] <name> <options...> [ [ WITH ] TAG (...) ]
+//
+// All configuration parameters are captured open-ended in Options, preserving
+// source order. The structural anchors are modeled separately: With records the
+// RESOURCE MONITOR WITH keyword; Triggers holds its TRIGGERS clause; Tags holds a
+// GIT REPOSITORY [WITH] TAG clause; Replica holds a CONNECTION AS REPLICA OF
+// clause. Per the docs OR REPLACE and IF NOT EXISTS are mutually exclusive for
+// every kind, and CONNECTION supports neither OR REPLACE nor SECURE — the parser
+// accepts the open-ended combination and the semantic layer enforces the
+// exclusions (matching the rest of this engine's parse-permissively philosophy).
+type CreateIntegrationStmt struct {
+	Kind        IntegrationObjectKind
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	With        bool                      // RESOURCE MONITOR's mandatory WITH keyword was present
+	Options     []*CopyOption             // open-ended KEY = value parameters, source order
+	Tags        []*TagAssignment          // GIT REPOSITORY [WITH] TAG (...); nil if absent
+	Triggers    []*ResourceMonitorTrigger // RESOURCE MONITOR TRIGGERS ...; nil if absent
+	Replica     *ConnectionReplica        // CONNECTION AS REPLICA OF a.b.c; nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateIntegrationStmt) Tag() NodeTag { return T_CreateIntegrationStmt }
+
+// AlterIntegrationAction discriminates the action variants of the T4.7 ALTER
+// parsers. Most objects share the SET / UNSET / SET TAG / UNSET TAG quartet;
+// EXTERNAL VOLUME instead uses the storage-location actions, GIT REPOSITORY adds
+// FETCH, RESOURCE MONITOR's SET carries NOTIFY_USERS + TRIGGERS, and CONNECTION
+// adds the failover/primary actions.
+type AlterIntegrationAction int
+
+const (
+	AlterIntegrationSet             AlterIntegrationAction = iota // SET <options> [ NOTIFY_USERS / TRIGGERS for RESOURCE MONITOR ]
+	AlterIntegrationUnset                                         // UNSET <property> [ , ... ]
+	AlterIntegrationSetTag                                        // SET TAG <tag> = '<value>' [ , ... ]
+	AlterIntegrationUnsetTag                                      // UNSET TAG <tag> [ , ... ]
+	AlterIntegrationFetch                                         // GIT REPOSITORY FETCH
+	AlterIntegrationAddLocation                                   // EXTERNAL VOLUME ADD STORAGE_LOCATION = (...)
+	AlterIntegrationRemoveLocation                                // EXTERNAL VOLUME REMOVE STORAGE_LOCATION '<name>'
+	AlterIntegrationUpdateLocation                                // EXTERNAL VOLUME UPDATE STORAGE_LOCATION = '<name>' CREDENTIALS = (...)
+	AlterIntegrationEnableFailover                                // CONNECTION ENABLE FAILOVER TO ACCOUNTS ...
+	AlterIntegrationDisableFailover                               // CONNECTION DISABLE FAILOVER [ TO ACCOUNTS ... ]
+	AlterIntegrationPrimary                                       // CONNECTION PRIMARY
+)
+
+// AlterIntegrationStmt represents the ALTER form of every T4.7 object. The set of
+// legal actions depends on Kind (validated by the semantic layer, not here):
+//
+//	ALTER [STORAGE] INTEGRATION [ IF EXISTS ] <name> SET <options>
+//	ALTER {API|NOTIFICATION|SECURITY} INTEGRATION [ IF EXISTS ] <name> SET <options>
+//	ALTER ... INTEGRATION [ IF EXISTS ] <name> UNSET <property> [ , ... ]
+//	ALTER ... INTEGRATION <name> { SET | UNSET } TAG ...
+//	ALTER RESOURCE MONITOR [ IF EXISTS ] <name> SET <options> [ NOTIFY_USERS = (...) ] [ TRIGGERS <trigger>... ]
+//	ALTER SECRET [ IF EXISTS ] <name> { SET <options> | UNSET COMMENT }
+//	ALTER CONNECTION [ IF EXISTS ] <name> { SET <options> | UNSET COMMENT }
+//	ALTER CONNECTION <name> { ENABLE FAILOVER TO ACCOUNTS a.b [,...] | DISABLE FAILOVER [ TO ACCOUNTS a.b [,...] ] | PRIMARY }
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> ADD STORAGE_LOCATION = (...)
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> REMOVE STORAGE_LOCATION '<name>'
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> UPDATE STORAGE_LOCATION = '<name>' CREDENTIALS = (...)
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> SET { ALLOW_WRITES | COMMENT } = ...
+//	ALTER GIT REPOSITORY <name> { SET <options> | UNSET <property> [ , ... ] | FETCH }
+type AlterIntegrationStmt struct {
+	Kind       IntegrationObjectKind
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterIntegrationAction
+	Options    []*CopyOption             // SET <options>; for AlterIntegrationSet / Add / Update (the STORAGE_LOCATION + CREDENTIALS params)
+	Tags       []*TagAssignment          // SET TAG assignments; for AlterIntegrationSetTag
+	UnsetTags  []*ObjectName             // UNSET TAG names; for AlterIntegrationUnsetTag
+	UnsetProps []string                  // UNSET <property> names; for AlterIntegrationUnset
+	Triggers   []*ResourceMonitorTrigger // RESOURCE MONITOR SET ... TRIGGERS ...; nil if absent
+	Location   string                    // EXTERNAL VOLUME REMOVE/UPDATE STORAGE_LOCATION '<name>'; "" otherwise
+	Accounts   []*ObjectName             // CONNECTION {ENABLE|DISABLE} FAILOVER TO ACCOUNTS <a.b> [,...]; nil if absent
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterIntegrationStmt) Tag() NodeTag { return T_AlterIntegrationStmt }
+
+// Compile-time assertions for integration-object DDL nodes.
+var (
+	_ Node = (*ResourceMonitorTrigger)(nil)
+	_ Node = (*ConnectionReplica)(nil)
+	_ Node = (*CreateIntegrationStmt)(nil)
+	_ Node = (*AlterIntegrationStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
 // Data-pipeline DDL — CREATE / ALTER PIPE / STREAM / TASK / ALERT (T4.3)
 // ---------------------------------------------------------------------------
 //

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -41,6 +41,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterIntegrationStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *AlterMaterializedViewStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -143,6 +147,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.Column != nil {
 			Walk(v, n.Column)
 		}
+	case *ConnectionReplica:
+		if n.Source != nil {
+			Walk(v, n.Source)
+		}
 	case *CopyIntoLocationStmt:
 		if n.Into != nil {
 			Walk(v, n.Into)
@@ -201,6 +209,13 @@ func walkChildren(v Visitor, node Node) {
 	case *CreateFileFormatStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+	case *CreateIntegrationStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.Replica != nil {
+			Walk(v, n.Replica)
 		}
 	case *CreateMaterializedViewStmt:
 		if n.Name != nil {

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -148,18 +148,30 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// CREATE [OR REPLACE] SEQUENCE ... (T4.4).
 		return p.parseCreateSequenceStmt(start, orReplace)
 	case kwEXTERNAL:
-		// CREATE [OR REPLACE] EXTERNAL { FUNCTION (T4.5) | TABLE (T4.4) }. The
-		// object is disambiguated by the keyword that follows EXTERNAL. EXTERNAL
-		// TABLE keeps cur on the EXTERNAL keyword (its sub-parser consumes both
-		// EXTERNAL and TABLE), matching the DYNAMIC/EVENT two-keyword handling.
+		// CREATE [OR REPLACE] EXTERNAL { FUNCTION (T4.5) | TABLE (T4.4) | VOLUME (T4.7) }.
+		// The object is disambiguated by what follows EXTERNAL. EXTERNAL TABLE keeps
+		// cur on the EXTERNAL keyword (its sub-parser consumes both EXTERNAL and
+		// TABLE), matching the DYNAMIC/EVENT two-keyword handling. VOLUME is not a
+		// reserved keyword, so EXTERNAL VOLUME lexes as kwEXTERNAL followed by a
+		// "VOLUME" identifier; that branch is taken here.
 		if p.peekNext().Type == kwTABLE {
 			return p.parseCreateExternalTableStmt(start, orReplace)
 		}
 		p.advance() // consume EXTERNAL
+		if p.curIsWord("VOLUME") {
+			p.advance() // consume VOLUME (a plain identifier; not a reserved keyword)
+			return p.parseCreateExternalVolumeStmt(start, orReplace)
+		}
 		if p.cur.Type != kwFUNCTION {
 			return p.unsupported("CREATE")
 		}
 		return p.parseCreateExternalFunctionStmt(start, orReplace, false)
+	case kwSTORAGE, kwAPI, kwNOTIFICATION, kwSECURITY, kwRESOURCE, kwSECRET, kwCONNECTION, kwGIT:
+		// CREATE [OR REPLACE] account-level integration objects (T4.7):
+		// { STORAGE | API | NOTIFICATION | SECURITY } INTEGRATION, RESOURCE MONITOR,
+		// SECRET, CONNECTION, GIT REPOSITORY. parseCreateIntegrationStmt consumes the
+		// object-type keyword(s).
+		return p.parseCreateIntegrationStmt(start, orReplace)
 	default:
 		return p.unsupported("CREATE")
 	}

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -201,15 +201,27 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// ALTER DYNAMIC TABLE ... (T4.4). The sub-parser consumes DYNAMIC + TABLE.
 		return p.parseAlterDynamicTableStmt()
 	case kwEXTERNAL:
-		// ALTER EXTERNAL TABLE ... (T4.4). The sub-parser consumes EXTERNAL +
-		// TABLE; any other EXTERNAL object is unsupported here.
+		// ALTER EXTERNAL { TABLE (T4.4) | VOLUME (T4.7) }. The TABLE sub-parser
+		// consumes EXTERNAL + TABLE. VOLUME is not a reserved keyword, so EXTERNAL
+		// VOLUME lexes as kwEXTERNAL followed by a "VOLUME" identifier.
 		if p.peekNext().Type == kwTABLE {
 			return p.parseAlterExternalTableStmt()
+		}
+		extTok := p.advance() // consume EXTERNAL (anchors Loc.Start)
+		if p.curIsWord("VOLUME") {
+			p.advance() // consume VOLUME
+			return p.parseAlterExternalVolumeStmt(extTok.Loc)
 		}
 		return p.unsupported("ALTER")
 	case kwSEQUENCE:
 		// ALTER SEQUENCE ... (T4.4). (ALTER EVENT TABLE goes through ALTER TABLE.)
 		return p.parseAlterSequenceStmt()
+	case kwSTORAGE, kwAPI, kwNOTIFICATION, kwSECURITY, kwINTEGRATION, kwRESOURCE, kwSECRET, kwCONNECTION, kwGIT:
+		// ALTER account-level integration objects (T4.7): { [STORAGE] | API |
+		// NOTIFICATION | SECURITY } INTEGRATION, RESOURCE MONITOR, SECRET,
+		// CONNECTION, GIT REPOSITORY. A bare ALTER INTEGRATION (qualifier omitted)
+		// dispatches here too. parseAlterIntegrationStmt consumes the keyword(s).
+		return p.parseAlterIntegrationStmt()
 	default:
 		return p.unsupported("ALTER")
 	}

--- a/snowflake/parser/integration.go
+++ b/snowflake/parser/integration.go
@@ -1,0 +1,820 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Account-level integration-object DDL — CREATE / ALTER (T4.7)
+// ---------------------------------------------------------------------------
+//
+// CREATE / ALTER for the account/schema-level objects:
+//
+//	{ STORAGE | API | NOTIFICATION | SECURITY } INTEGRATION
+//	RESOURCE MONITOR
+//	SECRET
+//	CONNECTION
+//	EXTERNAL VOLUME
+//	GIT REPOSITORY
+//
+// Every one carries a large, version-growing vocabulary of `KEY = <value>`
+// configuration parameters. Rather than mirror the legacy ANTLR grammar's
+// finite, already-stale per-type enumerations (its create_*_integration rules
+// pin a fixed option order and lack newer params; it has no CREATE EXTERNAL
+// VOLUME rule at all), every parameter that follows the object name is parsed as
+// an open-ended `KEY = <value>` pair (ast.CopyOption), reusing the merged COPY
+// (T5.2) machinery (parseCopyOption / startsCopyOption). Only the structural
+// anchors are modeled: the object Kind, RESOURCE MONITOR's WITH keyword + its
+// TRIGGERS clause, the GIT REPOSITORY [WITH] TAG clause, CONNECTION's AS REPLICA
+// OF clause, and (on ALTER) the action keyword and EXTERNAL VOLUME's
+// ADD/REMOVE/UPDATE STORAGE_LOCATION actions. The catalog/semantic layer, not the
+// parser, validates that an option is real and legal for the chosen Kind. This
+// mirrors the merged STAGE (T4.1) / FILE FORMAT (T4.2) / pipeline (T4.3)
+// open-ended approach.
+//
+// Two structural notes that distinguish these from STAGE/FILE FORMAT:
+//   - EXTERNAL VOLUME's STORAGE_LOCATIONS = ( ( NAME=... ... ), ( ... ) ) is a
+//     comma-separated *list of parenthesized groups*, a shape the shared
+//     parseCopyOptionParen does not handle (it expects either a key/value group
+//     or a flat literal list). parseStorageLocationsOption captures it as a
+//     CopyOption whose Group holds one unnamed sub-CopyOption per inner group.
+//   - VOLUME is not a reserved keyword, so EXTERNAL VOLUME lexes as the kwEXTERNAL
+//     keyword followed by a plain "VOLUME" identifier; the CREATE/ALTER dispatch
+//     in create_table.go / database_schema.go branches EXTERNAL TABLE vs EXTERNAL
+//     VOLUME on that identifier.
+
+// ---------------------------------------------------------------------------
+// CREATE
+// ---------------------------------------------------------------------------
+
+// parseCreateIntegrationStmt parses the body of a CREATE statement for one of the
+// T4.7 objects. The CREATE keyword and the optional OR REPLACE modifier have
+// already been consumed by parseCreateStmt; start is the Loc of the CREATE token,
+// and cur is the object-type keyword (STORAGE / API / NOTIFICATION / SECURITY /
+// RESOURCE / SECRET / CONNECTION / GIT). EXTERNAL VOLUME enters through
+// parseCreateExternalVolumeStmt instead (its dispatch already consumed EXTERNAL +
+// VOLUME).
+func (p *Parser) parseCreateIntegrationStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	kind, err := p.consumeIntegrationObjectKeyword()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateIntegrationStmt{
+		Kind:      kind,
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch kind {
+	case ast.ResourceMonitor:
+		// CREATE RESOURCE MONITOR <name> WITH <options...> [ TRIGGERS <trigger>... ]
+		// The WITH keyword is mandatory per the docs; the option list after it is
+		// all-optional. TRIGGERS is a distinct trailing clause.
+		if _, err := p.expect(kwWITH); err != nil {
+			return nil, err
+		}
+		stmt.With = true
+		opts, err := p.parseIntegrationOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+		if p.cur.Type == kwTRIGGERS {
+			triggers, err := p.parseResourceMonitorTriggers()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Triggers = triggers
+		}
+
+	case ast.Connection:
+		// CREATE CONNECTION <name> [ AS REPLICA OF a.b.c ] [ COMMENT = '...' ]
+		if p.cur.Type == kwAS {
+			replica, err := p.parseConnectionReplica()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Replica = replica
+		}
+		opts, err := p.parseIntegrationOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+
+	default:
+		// STORAGE/API/NOTIFICATION/SECURITY INTEGRATION, SECRET, GIT REPOSITORY:
+		// an open-ended option bag, optionally followed (GIT REPOSITORY) by a
+		// [WITH] TAG clause. The loop accepts options and tag clauses in any order
+		// so a COMMENT that trails the TAG clause is not dropped (mirrors STAGE).
+		for {
+			if p.startsIntegrationTags() {
+				tags, err := p.parseStageWithTags()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Tags = append(stmt.Tags, tags...)
+				continue
+			}
+			if p.startsIntegrationOption() {
+				opt, err := p.parseCopyOption()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Options = append(stmt.Options, opt)
+				continue
+			}
+			break
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseCreateExternalVolumeStmt parses
+//
+//	CREATE [ OR REPLACE ] EXTERNAL VOLUME [ IF NOT EXISTS ] <name>
+//	  STORAGE_LOCATIONS = ( ( NAME=... <provider params> ) [, ( ... ) ] )
+//	  [ ALLOW_WRITES = { TRUE | FALSE } ]
+//	  [ COMMENT = '<string_literal>' ]
+//
+// The CREATE / OR REPLACE / EXTERNAL / VOLUME tokens have already been consumed by
+// the dispatch in create_table.go; start is the Loc of the CREATE token. Every
+// parameter is open-ended; only STORAGE_LOCATIONS needs the list-of-groups reader.
+func (p *Parser) parseCreateExternalVolumeStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	stmt := &ast.CreateIntegrationStmt{
+		Kind:      ast.ExternalVolume,
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	opts, err := p.parseIntegrationOptions()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Options = opts
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER
+// ---------------------------------------------------------------------------
+
+// parseAlterIntegrationStmt parses the body of an ALTER statement for one of the
+// T4.7 integration-style objects (STORAGE/API/NOTIFICATION/SECURITY INTEGRATION,
+// RESOURCE MONITOR, SECRET, CONNECTION, GIT REPOSITORY). The ALTER keyword has
+// already been consumed; cur is the object-type keyword. EXTERNAL VOLUME enters
+// through parseAlterExternalVolumeStmt instead.
+//
+// The shared action grammar is:
+//
+//	[ IF EXISTS ] <name> SET <options>
+//	[ IF EXISTS ] <name> UNSET <property> [ , ... ]
+//	<name> SET TAG <tag> = '<value>' [ , ... ]
+//	<name> UNSET TAG <tag> [ , ... ]
+//
+// with per-kind extras: RESOURCE MONITOR's SET carries NOTIFY_USERS + TRIGGERS;
+// GIT REPOSITORY adds FETCH; CONNECTION adds ENABLE/DISABLE FAILOVER and PRIMARY.
+func (p *Parser) parseAlterIntegrationStmt() (ast.Node, error) {
+	startLoc := p.cur.Loc // object keyword anchors Loc.Start (ALTER convention)
+	kind, err := p.consumeIntegrationObjectKeyword()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.AlterIntegrationStmt{Kind: kind, Loc: ast.Loc{Start: startLoc.Start}}
+
+	p.parseOptionalIfExists(&stmt.IfExists)
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwSET:
+		if err := p.parseAlterIntegrationSet(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwUNSET:
+		if err := p.parseAlterIntegrationUnset(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwFETCH:
+		// GIT REPOSITORY FETCH.
+		p.advance() // consume FETCH
+		stmt.Action = ast.AlterIntegrationFetch
+
+	case kwENABLE, kwDISABLE:
+		// CONNECTION ENABLE/DISABLE FAILOVER [ TO ACCOUNTS a.b [, ...] ].
+		if err := p.parseAlterConnectionFailover(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwPRIMARY:
+		// CONNECTION PRIMARY.
+		p.advance() // consume PRIMARY
+		stmt.Action = ast.AlterIntegrationPrimary
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterExternalVolumeStmt parses
+//
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> ADD STORAGE_LOCATION = (...)
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> REMOVE STORAGE_LOCATION '<name>'
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> UPDATE STORAGE_LOCATION = '<name>' CREDENTIALS = (...)
+//	ALTER EXTERNAL VOLUME [ IF EXISTS ] <name> SET { ALLOW_WRITES | COMMENT } = ...
+//
+// EXTERNAL + VOLUME have already been consumed by the dispatch in
+// database_schema.go; startLoc is the EXTERNAL keyword Loc.
+func (p *Parser) parseAlterExternalVolumeStmt(startLoc ast.Loc) (ast.Node, error) {
+	stmt := &ast.AlterIntegrationStmt{Kind: ast.ExternalVolume, Loc: ast.Loc{Start: startLoc.Start}}
+
+	p.parseOptionalIfExists(&stmt.IfExists)
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwADD:
+		// ADD STORAGE_LOCATION = ( NAME=... <provider params> )
+		p.advance() // consume ADD
+		opt, err := p.parseStorageLocationSingleOption()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterIntegrationAddLocation
+		stmt.Options = []*ast.CopyOption{opt}
+
+	case kwREMOVE:
+		// REMOVE STORAGE_LOCATION '<name>'
+		p.advance() // consume REMOVE
+		if err := p.expectStorageLocationKeyword(); err != nil {
+			return nil, err
+		}
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterIntegrationRemoveLocation
+		stmt.Location = tok.Str
+
+	case kwUPDATE:
+		// UPDATE STORAGE_LOCATION = '<name>' <params...>
+		p.advance() // consume UPDATE
+		if err := p.expectStorageLocationKeyword(); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('='); err != nil {
+			return nil, err
+		}
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Location = tok.Str
+		opts, err := p.parseIntegrationOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterIntegrationUpdateLocation
+		stmt.Options = opts
+
+	case kwSET:
+		// SET <options> — open-ended (ALLOW_WRITES / COMMENT).
+		p.advance() // consume SET
+		opts, err := p.parseIntegrationOptions()
+		if err != nil {
+			return nil, err
+		}
+		if len(opts) == 0 {
+			return nil, p.syntaxErrorAtCur()
+		}
+		stmt.Action = ast.AlterIntegrationSet
+		stmt.Options = opts
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER action helpers
+// ---------------------------------------------------------------------------
+
+// parseAlterIntegrationSet parses the SET branch shared by the integration-style
+// objects. cur is the SET keyword. The branches are:
+//
+//	SET TAG <tag> = '<value>' [ , ... ]            -> AlterIntegrationSetTag
+//	SET <options> [ NOTIFY_USERS=(...) ] [ TRIGGERS ... ]  -> AlterIntegrationSet
+//
+// NOTIFY_USERS is captured as an ordinary open-ended option; only TRIGGERS needs
+// the dedicated reader (it is the one non-`KEY = value` clause). RESOURCE MONITOR
+// is the only kind that carries TRIGGERS, but accepting it for any kind here is
+// harmless — a non-RESOURCE-MONITOR statement simply never contains it.
+func (p *Parser) parseAlterIntegrationSet(stmt *ast.AlterIntegrationStmt) error {
+	p.advance() // consume SET
+
+	if p.cur.Type == kwTAG {
+		tags, err := p.parseTagSetList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterIntegrationSetTag
+		stmt.Tags = tags
+		return nil
+	}
+
+	opts, err := p.parseIntegrationOptions()
+	if err != nil {
+		return err
+	}
+	if p.cur.Type == kwTRIGGERS {
+		triggers, err := p.parseResourceMonitorTriggers()
+		if err != nil {
+			return err
+		}
+		stmt.Triggers = triggers
+	}
+	if len(opts) == 0 && len(stmt.Triggers) == 0 {
+		// SET with nothing settable is a syntax error.
+		return p.syntaxErrorAtCur()
+	}
+	stmt.Action = ast.AlterIntegrationSet
+	stmt.Options = opts
+	return nil
+}
+
+// parseAlterIntegrationUnset parses the UNSET branch shared by the
+// integration-style objects. cur is the UNSET keyword.
+//
+//	UNSET TAG <tag> [ , ... ]            -> AlterIntegrationUnsetTag
+//	UNSET <property> [ , ... ]           -> AlterIntegrationUnset (e.g. ENABLED, COMMENT)
+func (p *Parser) parseAlterIntegrationUnset(stmt *ast.AlterIntegrationStmt) error {
+	p.advance() // consume UNSET
+
+	if p.cur.Type == kwTAG {
+		names, err := p.parseUnsetTagNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterIntegrationUnsetTag
+		stmt.UnsetTags = names
+		return nil
+	}
+
+	// UNSET <property> [, ...]. Each property is an open-ended run of name words
+	// (reusing the STAGE UNSET-property reader, which captures multi-word
+	// properties whole and uppercases them). A comma separates properties.
+	props, err := p.parseStageUnsetProps()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterIntegrationUnset
+	stmt.UnsetProps = props
+	return nil
+}
+
+// parseAlterConnectionFailover parses CONNECTION's ENABLE / DISABLE FAILOVER
+// action. cur is the ENABLE or DISABLE keyword.
+//
+//	ENABLE FAILOVER TO ACCOUNTS <org>.<account> [ , ... ] [ IGNORE EDITION CHECK ]
+//	DISABLE FAILOVER [ TO ACCOUNTS <org>.<account> [ , ... ] ]
+func (p *Parser) parseAlterConnectionFailover(stmt *ast.AlterIntegrationStmt) error {
+	enable := p.cur.Type == kwENABLE
+	p.advance() // consume ENABLE / DISABLE
+	if _, err := p.expect(kwFAILOVER); err != nil {
+		return err
+	}
+
+	if enable {
+		stmt.Action = ast.AlterIntegrationEnableFailover
+		// ENABLE FAILOVER requires TO ACCOUNTS.
+		if _, err := p.expect(kwTO); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwACCOUNTS); err != nil {
+			return err
+		}
+		accounts, err := p.parseAccountNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Accounts = accounts
+		// Optional IGNORE EDITION CHECK.
+		if p.cur.Type == kwIGNORE {
+			p.advance() // consume IGNORE
+			if _, err := p.expect(kwEDITION); err != nil {
+				return err
+			}
+			if _, err := p.expect(kwCHECK); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	stmt.Action = ast.AlterIntegrationDisableFailover
+	// DISABLE FAILOVER [ TO ACCOUNTS ... ].
+	if p.cur.Type == kwTO {
+		p.advance() // consume TO
+		if _, err := p.expect(kwACCOUNTS); err != nil {
+			return err
+		}
+		accounts, err := p.parseAccountNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Accounts = accounts
+	}
+	return nil
+}
+
+// parseAccountNameList parses a comma-separated list of <org>.<account> names
+// (each a dotted ObjectName). Consumes at least one.
+func (p *Parser) parseAccountNameList() ([]*ast.ObjectName, error) {
+	var names []*ast.ObjectName
+	for {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return names, nil
+}
+
+// ---------------------------------------------------------------------------
+// CONNECTION AS REPLICA OF
+// ---------------------------------------------------------------------------
+
+// parseConnectionReplica parses an AS REPLICA OF <org>.<account>.<connection>
+// clause. cur is the AS keyword.
+func (p *Parser) parseConnectionReplica() (*ast.ConnectionReplica, error) {
+	asTok := p.advance() // consume AS
+	if _, err := p.expect(kwREPLICA); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwOF); err != nil {
+		return nil, err
+	}
+	src, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ConnectionReplica{
+		Source: src,
+		Loc:    ast.Loc{Start: asTok.Loc.Start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// RESOURCE MONITOR triggers
+// ---------------------------------------------------------------------------
+
+// parseResourceMonitorTriggers parses a TRIGGERS clause: the TRIGGERS keyword
+// followed by one or more space-separated trigger definitions. cur is the
+// TRIGGERS keyword. Per the docs the trigger definitions are NOT comma-separated.
+//
+//	TRIGGERS ( ON <num> PERCENT DO { SUSPEND | SUSPEND_IMMEDIATE | NOTIFY } )+
+func (p *Parser) parseResourceMonitorTriggers() ([]*ast.ResourceMonitorTrigger, error) {
+	if _, err := p.expect(kwTRIGGERS); err != nil {
+		return nil, err
+	}
+
+	var triggers []*ast.ResourceMonitorTrigger
+	for p.cur.Type == kwON {
+		trig, err := p.parseResourceMonitorTrigger()
+		if err != nil {
+			return nil, err
+		}
+		triggers = append(triggers, trig)
+	}
+	if len(triggers) == 0 {
+		// TRIGGERS with no trigger definition is a syntax error.
+		return nil, p.syntaxErrorAtCur()
+	}
+	return triggers, nil
+}
+
+// parseResourceMonitorTrigger parses one trigger definition:
+//
+//	ON <num> PERCENT DO { SUSPEND | SUSPEND_IMMEDIATE | NOTIFY }
+//
+// cur is the ON keyword.
+func (p *Parser) parseResourceMonitorTrigger() (*ast.ResourceMonitorTrigger, error) {
+	onTok := p.advance() // consume ON
+	trig := &ast.ResourceMonitorTrigger{Loc: ast.Loc{Start: onTok.Loc.Start}}
+
+	thresholdTok, err := p.expect(tokInt)
+	if err != nil {
+		return nil, err
+	}
+	trig.Threshold = thresholdTok.Ival
+
+	if _, err := p.expect(kwPERCENT); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwDO); err != nil {
+		return nil, err
+	}
+
+	switch p.cur.Type {
+	case kwSUSPEND:
+		p.advance()
+		trig.Action = "SUSPEND"
+	case kwSUSPEND_IMMEDIATE:
+		p.advance()
+		trig.Action = "SUSPEND_IMMEDIATE"
+	case kwNOTIFY:
+		p.advance()
+		trig.Action = "NOTIFY"
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	trig.Loc.End = p.prev.Loc.End
+	return trig, nil
+}
+
+// ---------------------------------------------------------------------------
+// EXTERNAL VOLUME STORAGE_LOCATIONS list-of-groups
+// ---------------------------------------------------------------------------
+
+// parseStorageLocationsOption parses the EXTERNAL VOLUME
+//
+//	STORAGE_LOCATIONS = ( ( NAME=... <params> ) [, ( ... ) ] )
+//
+// option, whose value is a comma-separated list of parenthesized key/value
+// groups. cur is the STORAGE_LOCATIONS option name. The result is a CopyOption
+// named STORAGE_LOCATIONS whose Group holds one unnamed sub-CopyOption per inner
+// group (each carrying that inner group's own Group of NAME/STORAGE_PROVIDER/...
+// entries). This shape is not handled by the shared parseCopyOptionParen (which
+// expects a key/value group or a flat literal list, never a list of groups), so
+// it is read here.
+func (p *Parser) parseStorageLocationsOption() (*ast.CopyOption, error) {
+	nameTok := p.advance() // consume STORAGE_LOCATIONS
+	opt := &ast.CopyOption{
+		Name: strings.ToUpper(nameTok.Str),
+		Loc:  ast.Loc{Start: nameTok.Loc.Start, End: nameTok.Loc.End},
+	}
+	if _, err := p.expect('='); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var groups []*ast.CopyOption
+	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		inner, err := p.parseStorageLocationGroup()
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, inner)
+		if p.cur.Type == ',' {
+			p.advance() // consume optional ',' separator between groups
+		}
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	opt.Group = groups
+	opt.Loc.End = p.prev.Loc.End
+	return opt, nil
+}
+
+// parseStorageLocationGroup parses one parenthesized inner group of a
+// STORAGE_LOCATIONS list, e.g. ( NAME = 'x' STORAGE_PROVIDER = 'S3' ENCRYPTION =
+// (...) ). cur is the inner '('. The group is returned as an unnamed CopyOption
+// (Name == "") whose Group holds the inner key/value entries, parsed by the
+// shared parseCopyOptionParen.
+func (p *Parser) parseStorageLocationGroup() (*ast.CopyOption, error) {
+	if p.cur.Type != '(' {
+		return nil, p.syntaxErrorAtCur()
+	}
+	start := p.cur.Loc.Start
+	group := &ast.CopyOption{Loc: ast.Loc{Start: start}}
+	if err := p.parseCopyOptionParen(group); err != nil {
+		return nil, err
+	}
+	group.Loc.End = p.prev.Loc.End
+	return group, nil
+}
+
+// parseStorageLocationSingleOption parses an ALTER EXTERNAL VOLUME ADD
+// STORAGE_LOCATION = ( NAME=... <params> ) option (a single parenthesized group,
+// not the bracketed list form). cur is the STORAGE_LOCATION option name.
+func (p *Parser) parseStorageLocationSingleOption() (*ast.CopyOption, error) {
+	if !p.curIsStorageLocationWord() {
+		return nil, p.syntaxErrorAtCur()
+	}
+	// STORAGE_LOCATION = ( ... ) is exactly the COPY option shape, so the shared
+	// parseCopyOption reader handles it directly.
+	return p.parseCopyOption()
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// consumeIntegrationObjectKeyword consumes the object-type keyword(s) at the
+// current position and returns the corresponding IntegrationObjectKind. On entry
+// cur is the leading keyword. It handles the optional INTEGRATION word for the
+// {STORAGE|API|NOTIFICATION|SECURITY} INTEGRATION forms, the two-word RESOURCE
+// MONITOR and GIT REPOSITORY forms, and the single-word SECRET / CONNECTION.
+//
+// Per the docs and the legacy grammar, ALTER accepts a bare INTEGRATION keyword
+// with the leading qualifier word omitted (ALTER [STORAGE] INTEGRATION ...). On
+// CREATE the qualifier is required and INTEGRATION follows it; this helper maps
+// both spellings since a bare ALTER INTEGRATION cannot recover the original
+// subtype anyway (the semantic layer resolves it from the catalog).
+func (p *Parser) consumeIntegrationObjectKeyword() (ast.IntegrationObjectKind, error) {
+	switch p.cur.Type {
+	case kwSTORAGE:
+		p.advance() // consume STORAGE
+		if _, err := p.expect(kwINTEGRATION); err != nil {
+			return 0, err
+		}
+		return ast.StorageIntegration, nil
+	case kwAPI:
+		p.advance() // consume API
+		if _, err := p.expect(kwINTEGRATION); err != nil {
+			return 0, err
+		}
+		return ast.APIIntegration, nil
+	case kwNOTIFICATION:
+		p.advance() // consume NOTIFICATION
+		if _, err := p.expect(kwINTEGRATION); err != nil {
+			return 0, err
+		}
+		return ast.NotificationIntegration, nil
+	case kwSECURITY:
+		p.advance() // consume SECURITY
+		if _, err := p.expect(kwINTEGRATION); err != nil {
+			return 0, err
+		}
+		return ast.SecurityIntegration, nil
+	case kwINTEGRATION:
+		// Bare ALTER INTEGRATION <name> ... — subtype qualifier omitted.
+		p.advance() // consume INTEGRATION
+		return ast.StorageIntegration, nil
+	case kwRESOURCE:
+		p.advance() // consume RESOURCE
+		if _, err := p.expect(kwMONITOR); err != nil {
+			return 0, err
+		}
+		return ast.ResourceMonitor, nil
+	case kwSECRET:
+		p.advance() // consume SECRET
+		return ast.Secret, nil
+	case kwCONNECTION:
+		p.advance() // consume CONNECTION
+		return ast.Connection, nil
+	case kwGIT:
+		p.advance() // consume GIT
+		if _, err := p.expect(kwREPOSITORY); err != nil {
+			return 0, err
+		}
+		return ast.GitRepository, nil
+	default:
+		return 0, p.syntaxErrorAtCur()
+	}
+}
+
+// parseIntegrationOptions parses a run of zero or more open-ended `KEY = value`
+// options. STORAGE_LOCATIONS is special-cased to the list-of-groups reader; every
+// other option uses the shared parseCopyOption. The run terminates at a statement
+// boundary, at a structural keyword that anchors a trailing clause (TRIGGERS /
+// WITH / TAG), or at any token that does not begin an option.
+func (p *Parser) parseIntegrationOptions() ([]*ast.CopyOption, error) {
+	var opts []*ast.CopyOption
+	for p.startsIntegrationOption() {
+		var (
+			opt *ast.CopyOption
+			err error
+		)
+		if p.curIsWord("STORAGE_LOCATIONS") {
+			opt, err = p.parseStorageLocationsOption()
+		} else {
+			opt, err = p.parseCopyOption()
+		}
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+	}
+	return opts, nil
+}
+
+// startsIntegrationOption reports whether the current token can begin an option.
+// It is the COPY option predicate minus the structural keywords that anchor a
+// trailing clause: TRIGGERS (RESOURCE MONITOR), and WITH / TAG (GIT REPOSITORY's
+// [WITH] TAG). Those must not be swallowed as an option name.
+func (p *Parser) startsIntegrationOption() bool {
+	switch p.cur.Type {
+	case kwTRIGGERS, kwWITH, kwTAG:
+		return false
+	}
+	return p.startsCopyOption()
+}
+
+// startsIntegrationTags reports whether the current position begins a GIT
+// REPOSITORY [WITH] TAG clause (TAG directly, or WITH immediately followed by
+// TAG). Reuses the STAGE predicate semantics.
+func (p *Parser) startsIntegrationTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// curIsStorageLocationWord reports whether cur is the STORAGE_LOCATION option name
+// (used by ALTER EXTERNAL VOLUME ADD / UPDATE).
+func (p *Parser) curIsStorageLocationWord() bool {
+	return p.curIsWord("STORAGE_LOCATION")
+}
+
+// expectStorageLocationKeyword consumes the STORAGE_LOCATION option name, erroring
+// if the current token is not it.
+func (p *Parser) expectStorageLocationKeyword() error {
+	if !p.curIsStorageLocationWord() {
+		return p.syntaxErrorAtCur()
+	}
+	p.advance() // consume STORAGE_LOCATION
+	return nil
+}
+
+// parseOptionalIfNotExists consumes an optional IF NOT EXISTS clause, setting
+// *flag when present. Shared by the T4.7 CREATE parsers.
+func (p *Parser) parseOptionalIfNotExists(flag *bool) error {
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwNOT {
+			p.advance() // consume IF
+			p.advance() // consume NOT
+			if _, err := p.expect(kwEXISTS); err != nil {
+				return err
+			}
+			*flag = true
+		}
+	}
+	return nil
+}
+
+// parseOptionalIfExists consumes an optional IF EXISTS clause, setting *flag when
+// present. Shared by the T4.7 ALTER parsers.
+func (p *Parser) parseOptionalIfExists(flag *bool) {
+	if p.cur.Type == kwIF {
+		if p.peekNext().Type == kwEXISTS {
+			p.advance() // consume IF
+			p.advance() // consume EXISTS
+			*flag = true
+		}
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-integrations` (v1 DAG **T4.7**) — `CREATE`/`ALTER` for account-level integration objects. `DROP` for these was already merged (drop.go), untouched.

## Forms (all 9 objects wired into the CREATE/ALTER dispatch)
- `CREATE [OR REPLACE] { STORAGE | API | NOTIFICATION | SECURITY } INTEGRATION [IF NOT EXISTS] <name> …`
- `CREATE [OR REPLACE] RESOURCE MONITOR <name> WITH …`
- `CREATE [OR REPLACE] SECRET <name> …`
- `CREATE [OR REPLACE] [SECURE] CONNECTION <name> …`
- `CREATE [OR REPLACE] EXTERNAL VOLUME <name> …` (shares the `kwEXTERNAL` dispatch case with EXTERNAL TABLE, branching TABLE-vs-VOLUME)
- `CREATE [OR REPLACE] GIT REPOSITORY <name> …`
- `ALTER` for each.

## Design
Config parsed as open-ended `KEY = <value>` options (`ast.CopyOption`), mirroring the merged STAGE/FILE-FORMAT machinery rather than the legacy ANTLR enums. New AST nodes + tags; `walk_generated.go` regenerated via `genwalker`; CREATE dispatch in `parseCreateStmt`, ALTER in `parseAlterStmt`.

## Oracle / tests
Triangulation — official docs (authoritative) + legacy ANTLR `create_*_integration`/`create_resource_monitor`/`create_secret`/etc. + the `create-storage-integration` corpus. `go build`/`go vet`/`gofmt` clean; `go test ./snowflake/parser/... ./snowflake/ast/... -timeout 120s` green.

## Divergences (flagged)
- Open-ended `KEY=value` options vs the stale legacy enumerations (docs win) — consistent with the merged STAGE/FILE-FORMAT/integration siblings.

## Review / provenance
The implementing worker completed the code (build + tests green, scope = the 6 declared files, gofmt clean) but **froze at its finish step before committing or returning its summary** (a genuine infra stall, confirmed via the transcript mtime). The orchestrator verified the work independently (build / `-timeout` tests / scope / gofmt), committed it (`487d375b`), and opened this PR. The worker's full divergence write-up was lost to the freeze; `corpus-closure` (M2) will re-verify all parsing at the end. Codex lens unavailable (out of credits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)