### PR TITLE
feat(googlesql/parser-ddl-spanner): CHANGE STREAM / SEQUENCE / ROLE / LOCALITY GROUP / PROTO BUNDLE + role GRANT

### DIFF
--- a/googlesql/analysis/classify.go
+++ b/googlesql/analysis/classify.go
@@ -148,7 +148,15 @@ func Classify(node ast.Node, dialect Dialect) QueryType {
 		*ast.CreateMaterializedViewStmt, *ast.CreateSnapshotStmt,
 		*ast.SearchVectorIndexStmt, *ast.CreateRowAccessPolicyStmt,
 		*ast.CreateEntityStmt, *ast.BQAlterStmt, *ast.BQDropStmt,
-		*ast.DropAllRowAccessPoliciesStmt:
+		*ast.DropAllRowAccessPoliciesStmt,
+		// Spanner-only object DDL (parser-ddl-spanner node): CHANGE STREAM,
+		// SEQUENCE, ROLE, LOCALITY GROUP, PROTO BUNDLE. Same DDL classification as
+		// every other CREATE/ALTER/DROP form.
+		*ast.CreateChangeStreamStmt, *ast.AlterChangeStreamStmt, *ast.DropChangeStreamStmt,
+		*ast.CreateSequenceStmt, *ast.AlterSequenceStmt, *ast.DropSequenceStmt,
+		*ast.CreateRoleStmt, *ast.DropRoleStmt,
+		*ast.CreateLocalityGroupStmt, *ast.AlterLocalityGroupStmt, *ast.DropLocalityGroupStmt,
+		*ast.CreateProtoBundleStmt, *ast.AlterProtoBundleStmt:
 		return DDL
 
 	// DCL — GRANT / REVOKE are DDL in the legacy listener (its rule list groups

--- a/googlesql/analysis/classify_test.go
+++ b/googlesql/analysis/classify_test.go
@@ -61,6 +61,25 @@ func TestClassifySQL(t *testing.T) {
 		{"drop all row access policies", "DROP ALL ROW ACCESS POLICIES ON ds.t", DDL},
 		{"drop capacity (generic entity)", "DROP CAPACITY `p.r.c`", DDL},
 
+		// --- DDL — Spanner-only objects (parser-ddl-spanner node). These now PARSE
+		// (previously over-rejected), so classification must report DDL, not Unknown. ---
+		{"create change stream", "CREATE CHANGE STREAM s FOR ALL", DDL},
+		{"alter change stream", "ALTER CHANGE STREAM s SET FOR ALL", DDL},
+		{"drop change stream", "DROP CHANGE STREAM s", DDL},
+		{"create sequence", "CREATE SEQUENCE q", DDL},
+		{"alter sequence", "ALTER SEQUENCE q SET OPTIONS (start_with_counter=1)", DDL},
+		{"drop sequence", "DROP SEQUENCE q", DDL},
+		{"create role", "CREATE ROLE analyst", DDL},
+		{"drop role", "DROP ROLE analyst", DDL},
+		{"create locality group", "CREATE LOCALITY GROUP g OPTIONS (storage='ssd')", DDL},
+		{"alter locality group", "ALTER LOCALITY GROUP g SET OPTIONS (storage='hdd')", DDL},
+		{"drop locality group", "DROP LOCALITY GROUP g", DDL},
+		{"create proto bundle", "CREATE PROTO BUNDLE (`a.b.C`)", DDL},
+		{"alter proto bundle", "ALTER PROTO BUNDLE INSERT (`a.b.C`)", DDL},
+		{"grant to role", "GRANT SELECT ON TABLE t TO ROLE r", DDL},
+		{"grant role to role", "GRANT ROLE a TO ROLE b", DDL},
+		{"revoke role from role", "REVOKE ROLE a FROM ROLE b", DDL},
+
 		// --- Unknown / empty ---
 		{"empty", "", Unknown},
 		{"whitespace only", "   \n  ", Unknown},

--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -142,6 +142,27 @@ const (
 	T_BQDropStmt
 	T_DropAllRowAccessPoliciesStmt
 
+	// Spanner-specific DDL (parser-ddl-spanner node): CHANGE STREAM, SEQUENCE,
+	// ROLE, LOCALITY GROUP, and PROTO BUNDLE CREATE/ALTER/DROP forms. These have
+	// no first-class rule in the legacy ANTLR grammar (it rides them on the
+	// generic-entity hook or rejects them); the omni parser models them directly,
+	// authoritatively verified against the live Cloud Spanner emulator. (Role-based
+	// GRANT/REVOKE reuses T_GrantStmt/T_RevokeStmt with the GranteeRole kind.)
+	T_ChangeStreamTrackedTable
+	T_CreateChangeStreamStmt
+	T_AlterChangeStreamStmt
+	T_DropChangeStreamStmt
+	T_CreateSequenceStmt
+	T_AlterSequenceStmt
+	T_DropSequenceStmt
+	T_CreateRoleStmt
+	T_DropRoleStmt
+	T_CreateLocalityGroupStmt
+	T_AlterLocalityGroupStmt
+	T_DropLocalityGroupStmt
+	T_CreateProtoBundleStmt
+	T_AlterProtoBundleStmt
+
 	// DML — INSERT / UPDATE / DELETE / MERGE / TRUNCATE (parser-dml node).
 	//
 	// The data-manipulation family for the BigQuery + Spanner union, plus their
@@ -361,6 +382,34 @@ func (t NodeTag) String() string {
 		return "BQDropStmt"
 	case T_DropAllRowAccessPoliciesStmt:
 		return "DropAllRowAccessPoliciesStmt"
+	case T_ChangeStreamTrackedTable:
+		return "ChangeStreamTrackedTable"
+	case T_CreateChangeStreamStmt:
+		return "CreateChangeStreamStmt"
+	case T_AlterChangeStreamStmt:
+		return "AlterChangeStreamStmt"
+	case T_DropChangeStreamStmt:
+		return "DropChangeStreamStmt"
+	case T_CreateSequenceStmt:
+		return "CreateSequenceStmt"
+	case T_AlterSequenceStmt:
+		return "AlterSequenceStmt"
+	case T_DropSequenceStmt:
+		return "DropSequenceStmt"
+	case T_CreateRoleStmt:
+		return "CreateRoleStmt"
+	case T_DropRoleStmt:
+		return "DropRoleStmt"
+	case T_CreateLocalityGroupStmt:
+		return "CreateLocalityGroupStmt"
+	case T_AlterLocalityGroupStmt:
+		return "AlterLocalityGroupStmt"
+	case T_DropLocalityGroupStmt:
+		return "DropLocalityGroupStmt"
+	case T_CreateProtoBundleStmt:
+		return "CreateProtoBundleStmt"
+	case T_AlterProtoBundleStmt:
+		return "AlterProtoBundleStmt"
 	case T_DefaultExpr:
 		return "DefaultExpr"
 	case T_InsertStmt:

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -100,6 +100,13 @@ const (
 	// system_variable_expression: '@@' path_expression). Value holds the
 	// dotted variable path without the leading '@@'.
 	GranteeSystemVariable
+	// GranteeRole is a Spanner role grantee, e.g. `TO ROLE analyst`. The legacy
+	// ZetaSQL grammar's grantee_list is string_literal_or_parameter only and has
+	// no role form; Spanner GRANT/REVOKE instead names roles via a single `ROLE`
+	// keyword followed by a comma-separated role-name list. Value holds the role
+	// name. (Authoritative oracle: the live Spanner emulator — `TO 'string'`
+	// REJECTS, `TO ROLE name [, name]` ACCEPTS.)
+	GranteeRole
 )
 
 // String returns a human-readable name for the grantee kind.
@@ -113,6 +120,8 @@ func (k GranteeKind) String() string {
 		return "POSITIONAL_PARAMETER"
 	case GranteeSystemVariable:
 		return "SYSTEM_VARIABLE"
+	case GranteeRole:
+		return "ROLE"
 	default:
 		return "UNKNOWN"
 	}
@@ -167,9 +176,19 @@ type GrantStmt struct {
 	AllPrivileges bool         // ALL [PRIVILEGES]
 	Privileges    []*Privilege // explicit privilege list; nil when AllPrivileges
 	ObjectType    []string     // 0, 1, or 2 object-type words
-	Path          NamePath     // the ON object name
-	Grantees      []*Grantee   // the TO recipients (>= 1)
-	Loc           Loc
+	Path          NamePath     // the ON object name (the FIRST object; == Paths[0])
+	// Paths is the full ON object list. The legacy ZetaSQL grant names a single
+	// object (len 1); the Spanner role grant allows a comma-separated list
+	// (`ON TABLE t1, t2 TO ROLE r`, emulator-verified). Path mirrors Paths[0] for
+	// the common single-object case.
+	Paths    []NamePath
+	Grantees []*Grantee // the TO recipients (>= 1)
+	// Roles is the Spanner role-to-role grant subject list: `GRANT ROLE r [, ...]
+	// TO ROLE …`. When non-nil this is the role-grant form (a Spanner extension,
+	// emulator-verified), and Privileges/AllPrivileges/ObjectType/Path are unset;
+	// Grantees holds the target roles. Nil for an ordinary privilege grant.
+	Roles []NamePath
+	Loc   Loc
 }
 
 // Tag implements Node.
@@ -185,9 +204,13 @@ type RevokeStmt struct {
 	AllPrivileges bool         // ALL [PRIVILEGES]
 	Privileges    []*Privilege // explicit privilege list; nil when AllPrivileges
 	ObjectType    []string     // 0, 1, or 2 object-type words
-	Path          NamePath     // the ON object name
+	Path          NamePath     // the ON object name (the FIRST object; == Paths[0])
+	Paths         []NamePath   // full ON object list (Spanner allows a comma list); Path == Paths[0]
 	Grantees      []*Grantee   // the FROM subjects (>= 1)
-	Loc           Loc
+	// Roles is the Spanner role-to-role revoke subject list: `REVOKE ROLE r [,
+	// ...] FROM ROLE …` (mirrors GrantStmt.Roles). Non-nil ⇒ role-revoke form.
+	Roles []NamePath
+	Loc   Loc
 }
 
 // Tag implements Node.
@@ -3077,4 +3100,259 @@ var (
 	_ Node = (*RenameStmt)(nil)
 	_ Node = (*CallArg)(nil)
 	_ Node = (*CallStmt)(nil)
+)
+
+// ===========================================================================
+// Spanner-specific DDL (googlesql/parser-ddl-spanner node)
+// ===========================================================================
+//
+// Cloud Spanner extends GoogleSQL with object kinds that the legacy ANTLR
+// GoogleSQLParser.g4 does NOT model as first-class rules — it rides them on the
+// generic-entity mechanism (or rejects them outright). The omni parser, whose
+// authoritative oracle for Spanner DDL is the live Cloud Spanner emulator
+// (oracle.md), parses these as dedicated statements so bytebase's Spanner
+// consumers (Diagnose / GetQuerySpan / SplitSQL) see a real tree instead of a
+// false "syntax error". The forms (all emulator-accept-verified) are:
+//
+//	CHANGE STREAM  — CREATE / ALTER / DROP CHANGE STREAM       (DDL-024/025/026)
+//	SEQUENCE       — CREATE / ALTER / DROP SEQUENCE            (DDL-027/028/029)
+//	ROLE           — CREATE / DROP ROLE                        (DDL-032/033)
+//	role GRANT     — GRANT/REVOKE … TO/FROM ROLE; GRANT/REVOKE ROLE … (DDL-034-037)
+//	LOCALITY GROUP — CREATE / ALTER / DROP LOCALITY GROUP      (DDL-041/042/043)
+//	PROTO BUNDLE   — CREATE / ALTER PROTO BUNDLE               (DDL-046/047)
+//
+// These DIVERGE from the legacy grammar (which over-rejects them); the divergence
+// is oracle-backed and recorded in the ledger. The role-based GRANT/REVOKE adds a
+// GranteeRole grantee kind to the shared Grantee node and role-list fields to the
+// shared GrantStmt/RevokeStmt (see those types), so the one union parser accepts
+// both the legacy ZetaSQL string-grantee dialect and the Spanner role dialect.
+
+// ChangeStreamTrackedTable is one entry of a CREATE/ALTER CHANGE STREAM's
+// `FOR table_and_column` list (grammar truth1 DDL-024):
+//
+//	table_name                       -> AllColumns=false, Columns=nil (whole table, all columns)
+//	table_name ( )                   -> ExplicitColumns=true, Columns=nil (track no non-key columns)
+//	table_name ( col [, col ...] )   -> ExplicitColumns=true, Columns=[…]
+//
+// The empty `()` form is distinct from omitting the parens entirely (the former
+// tracks only the primary key; the latter tracks the whole table), so a bare
+// ExplicitColumns flag disambiguates `t` from `t()`.
+type ChangeStreamTrackedTable struct {
+	Name            *PathExpr // the tracked table name
+	ExplicitColumns bool      // true when a `( … )` column list was given (even if empty)
+	Columns         []string  // the listed column names (nil for `t` or `t()`)
+	Loc             Loc
+}
+
+// Tag implements Node.
+func (n *ChangeStreamTrackedTable) Tag() NodeTag { return T_ChangeStreamTrackedTable }
+
+// CreateChangeStreamStmt is a CREATE CHANGE STREAM statement (Spanner; truth1
+// DDL-024):
+//
+//	CREATE CHANGE STREAM name { FOR ALL | FOR table_and_column [, ...] }?
+//	  [OPTIONS ( option [, ...] )]
+//
+// Exactly one of ForAll / ForTables describes the watched set when a FOR clause
+// is present; a CHANGE STREAM created with neither (just OPTIONS, or nothing)
+// watches nothing until ALTERed. HasFor records whether a FOR clause was present
+// at all (to distinguish `FOR ALL` from "no FOR").
+type CreateChangeStreamStmt struct {
+	Name      *PathExpr
+	HasFor    bool                        // a FOR clause was present
+	ForAll    bool                        // FOR ALL
+	ForTables []*ChangeStreamTrackedTable // FOR table_and_column [, ...]
+	Options   []*OptionsEntry
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *CreateChangeStreamStmt) Tag() NodeTag { return T_CreateChangeStreamStmt }
+
+// AlterChangeStreamStmt is an ALTER CHANGE STREAM statement (Spanner; truth1
+// DDL-025):
+//
+//	ALTER CHANGE STREAM name
+//	  { SET FOR { ALL | table_and_column [, ...] }
+//	  | DROP FOR ALL
+//	  | SET OPTIONS ( option [, ...] )
+//	  }
+//
+// Action selects which of the three forms this is.
+type AlterChangeStreamStmt struct {
+	Name      *PathExpr
+	Action    ChangeStreamAlterAction
+	ForAll    bool                        // for SetFor: SET FOR ALL
+	ForTables []*ChangeStreamTrackedTable // for SetFor: SET FOR table_and_column [, ...]
+	Options   []*OptionsEntry             // for SetOptions
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *AlterChangeStreamStmt) Tag() NodeTag { return T_AlterChangeStreamStmt }
+
+// ChangeStreamAlterAction discriminates the three ALTER CHANGE STREAM forms.
+type ChangeStreamAlterAction int
+
+const (
+	// ChangeStreamSetFor is `SET FOR { ALL | table_and_column [, ...] }`.
+	ChangeStreamSetFor ChangeStreamAlterAction = iota
+	// ChangeStreamDropForAll is `DROP FOR ALL`.
+	ChangeStreamDropForAll
+	// ChangeStreamSetOptions is `SET OPTIONS ( … )`.
+	ChangeStreamSetOptions
+)
+
+// DropChangeStreamStmt is a DROP CHANGE STREAM statement (Spanner; truth1
+// DDL-026): `DROP CHANGE STREAM name`.
+type DropChangeStreamStmt struct {
+	Name *PathExpr
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *DropChangeStreamStmt) Tag() NodeTag { return T_DropChangeStreamStmt }
+
+// CreateSequenceStmt is a CREATE SEQUENCE statement (Spanner; truth1 DDL-027):
+//
+//	CREATE SEQUENCE [IF NOT EXISTS] name [OPTIONS ( option [, ...] )]
+type CreateSequenceStmt struct {
+	Name        *PathExpr
+	IfNotExists bool
+	Options     []*OptionsEntry
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateSequenceStmt) Tag() NodeTag { return T_CreateSequenceStmt }
+
+// AlterSequenceStmt is an ALTER SEQUENCE statement (Spanner; truth1 DDL-028):
+//
+//	ALTER SEQUENCE [IF EXISTS] name SET OPTIONS ( option [, ...] )
+type AlterSequenceStmt struct {
+	Name       *PathExpr
+	IfExists   bool
+	SetOptions []*OptionsEntry
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterSequenceStmt) Tag() NodeTag { return T_AlterSequenceStmt }
+
+// DropSequenceStmt is a DROP SEQUENCE statement (Spanner; truth1 DDL-029):
+//
+//	DROP SEQUENCE [IF EXISTS] name
+type DropSequenceStmt struct {
+	Name     *PathExpr
+	IfExists bool
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *DropSequenceStmt) Tag() NodeTag { return T_DropSequenceStmt }
+
+// CreateRoleStmt is a CREATE ROLE statement (Spanner; truth1 DDL-032):
+// `CREATE ROLE role_name`. role_name is a single identifier in the grammar.
+type CreateRoleStmt struct {
+	Name *PathExpr
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *CreateRoleStmt) Tag() NodeTag { return T_CreateRoleStmt }
+
+// DropRoleStmt is a DROP ROLE statement (Spanner; truth1 DDL-033):
+// `DROP ROLE role_name`.
+type DropRoleStmt struct {
+	Name *PathExpr
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *DropRoleStmt) Tag() NodeTag { return T_DropRoleStmt }
+
+// CreateLocalityGroupStmt is a CREATE LOCALITY GROUP statement (Spanner; truth1
+// DDL-041):
+//
+//	CREATE LOCALITY GROUP name [OPTIONS ( storage_option [, ...] )]
+type CreateLocalityGroupStmt struct {
+	Name    *PathExpr
+	Options []*OptionsEntry
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *CreateLocalityGroupStmt) Tag() NodeTag { return T_CreateLocalityGroupStmt }
+
+// AlterLocalityGroupStmt is an ALTER LOCALITY GROUP statement (Spanner; truth1
+// DDL-042):
+//
+//	ALTER LOCALITY GROUP name SET OPTIONS ( storage_option [, ...] )
+type AlterLocalityGroupStmt struct {
+	Name       *PathExpr
+	SetOptions []*OptionsEntry
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterLocalityGroupStmt) Tag() NodeTag { return T_AlterLocalityGroupStmt }
+
+// DropLocalityGroupStmt is a DROP LOCALITY GROUP statement (Spanner; truth1
+// DDL-043): `DROP LOCALITY GROUP name`.
+type DropLocalityGroupStmt struct {
+	Name *PathExpr
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *DropLocalityGroupStmt) Tag() NodeTag { return T_DropLocalityGroupStmt }
+
+// CreateProtoBundleStmt is a CREATE PROTO BUNDLE statement (Spanner; truth1
+// DDL-046):
+//
+//	CREATE PROTO BUNDLE ( proto_type_name [, ...] )
+//
+// Each proto_type_name is a (usually backtick-quoted, dotted) fully-qualified
+// proto message name; captured as a NamePath so the dotted form survives.
+type CreateProtoBundleStmt struct {
+	Types []NamePath // the bundled proto type names (>= 1)
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *CreateProtoBundleStmt) Tag() NodeTag { return T_CreateProtoBundleStmt }
+
+// AlterProtoBundleStmt is an ALTER PROTO BUNDLE statement (Spanner; truth1
+// DDL-047):
+//
+//	ALTER PROTO BUNDLE { INSERT ( … ) | UPDATE ( … ) | DELETE ( … ) } [, ...]
+//
+// The grammar allows any combination of INSERT/UPDATE/DELETE groups in one
+// statement; each group's type list is collected here. An absent group is nil.
+type AlterProtoBundleStmt struct {
+	Insert []NamePath // INSERT ( proto_type_name [, ...] )
+	Update []NamePath // UPDATE ( proto_type_name [, ...] )
+	Delete []NamePath // DELETE ( proto_type_name [, ...] )
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *AlterProtoBundleStmt) Tag() NodeTag { return T_AlterProtoBundleStmt }
+
+// Compile-time assertions that the Spanner-DDL node types satisfy Node.
+var (
+	_ Node = (*ChangeStreamTrackedTable)(nil)
+	_ Node = (*CreateChangeStreamStmt)(nil)
+	_ Node = (*AlterChangeStreamStmt)(nil)
+	_ Node = (*DropChangeStreamStmt)(nil)
+	_ Node = (*CreateSequenceStmt)(nil)
+	_ Node = (*AlterSequenceStmt)(nil)
+	_ Node = (*DropSequenceStmt)(nil)
+	_ Node = (*CreateRoleStmt)(nil)
+	_ Node = (*DropRoleStmt)(nil)
+	_ Node = (*CreateLocalityGroupStmt)(nil)
+	_ Node = (*AlterLocalityGroupStmt)(nil)
+	_ Node = (*DropLocalityGroupStmt)(nil)
+	_ Node = (*CreateProtoBundleStmt)(nil)
+	_ Node = (*AlterProtoBundleStmt)(nil)
 )

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -26,6 +26,30 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
+	case *AlterChangeStreamStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.ForTables {
+			Walk(v, c)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+	case *AlterLocalityGroupStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.SetOptions {
+			Walk(v, c)
+		}
+	case *AlterSequenceStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.SetOptions {
+			Walk(v, c)
+		}
 	case *AlterStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -106,6 +130,10 @@ func walkChildren(v Visitor, node Node) {
 		}
 		Walk(v, n.Format)
 		Walk(v, n.TimeZone)
+	case *ChangeStreamTrackedTable:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *ClampedModifier:
 		Walk(v, n.Low)
 		Walk(v, n.High)
@@ -124,6 +152,16 @@ func walkChildren(v Visitor, node Node) {
 	case *CompareExpr:
 		Walk(v, n.Left)
 		Walk(v, n.Right)
+	case *CreateChangeStreamStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.ForTables {
+			Walk(v, c)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
 	case *CreateDatabaseStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -175,6 +213,13 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
+	case *CreateLocalityGroupStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
 	case *CreateMaterializedViewStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -201,6 +246,10 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
+	case *CreateRoleStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreateRowAccessPolicyStmt:
 		if n.Table != nil {
 			Walk(v, n.Table)
@@ -210,6 +259,13 @@ func walkChildren(v Visitor, node Node) {
 		}
 		Walk(v, n.Filter)
 	case *CreateSchemaStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+	case *CreateSequenceStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
@@ -290,6 +346,22 @@ func walkChildren(v Visitor, node Node) {
 	case *DropAllRowAccessPoliciesStmt:
 		if n.Table != nil {
 			Walk(v, n.Table)
+		}
+	case *DropChangeStreamStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *DropLocalityGroupStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *DropRoleStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *DropSequenceStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
 		}
 	case *DropStmt:
 		if n.Name != nil {

--- a/googlesql/parser/alter_table.go
+++ b/googlesql/parser/alter_table.go
@@ -64,7 +64,26 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	case kwVECTOR:
 		// ALTER VECTOR INDEX … ON … REBUILD (bq_search_vector_index.go).
 		return p.parseBQAlterVectorIndex(alter)
+	// --- Spanner-only ALTER objects (parser-ddl-spanner node) ---
+	case kwSEQUENCE:
+		// ALTER SEQUENCE [IF EXISTS] name SET OPTIONS … (spanner_sequence.go).
+		return p.parseAlterSequence(alter)
+	case kwPROTO:
+		// ALTER PROTO BUNDLE { INSERT|UPDATE|DELETE ( … ) } … (spanner_sequence.go).
+		if p.tokIsWord(p.peekNext(), "BUNDLE") {
+			return p.parseAlterProtoBundle(alter)
+		}
+		return p.unsupported("ALTER")
 	default:
+		// Spanner objects whose leading word lexes as a BARE IDENTIFIER (CHANGE
+		// STREAM, LOCALITY GROUP) — matched by spelling before the generic-entity
+		// fallback (parser-ddl-spanner node).
+		if p.tokIsWord(p.cur, "CHANGE") && p.tokIsWord(p.peekNext(), "STREAM") {
+			return p.parseAlterChangeStream(alter) // spanner_change_stream.go
+		}
+		if p.tokIsWord(p.cur, "LOCALITY") && p.tokIsWord(p.peekNext(), "GROUP") {
+			return p.parseAlterLocalityGroup(alter) // spanner_sequence.go
+		}
 		// ALTER <generic-entity> (CAPACITY / RESERVATION / ASSIGNMENT — the keyword
 		// lexes as an identifier) routes to the generic-entity alter
 		// (bq_capacity.go). ALTER FUNCTION / PROCEDURE / MODEL / PRIVILEGE

--- a/googlesql/parser/create_table.go
+++ b/googlesql/parser/create_table.go
@@ -133,7 +133,33 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 			return nil, p.syntaxErrorAtCur()
 		}
 		return p.parseCreateRowAccessPolicy(create, orReplace)
+	// --- Spanner-only object CREATEs (parser-ddl-spanner node) ---
+	case kwSEQUENCE:
+		// CREATE SEQUENCE [IF NOT EXISTS] name [OPTIONS …] (spanner_sequence.go).
+		return p.parseCreateSequence(create, orReplace, scope)
+	case kwPROTO:
+		// CREATE PROTO BUNDLE ( … ) (spanner_sequence.go). PROTO is a reserved
+		// keyword; BUNDLE follows as a bare identifier.
+		if p.tokIsWord(p.peekNext(), "BUNDLE") {
+			return p.parseCreateProtoBundle(create, orReplace, scope)
+		}
+		return p.unsupported("CREATE")
 	default:
+		// Spanner objects whose leading word lexes as a BARE IDENTIFIER (CHANGE
+		// STREAM, LOCALITY GROUP) and ROLE — matched by spelling before the
+		// generic-entity fallback below, since the entity path would otherwise
+		// misparse the two-word object type.
+		if p.tokIsWord(p.cur, "CHANGE") && p.tokIsWord(p.peekNext(), "STREAM") {
+			return p.parseCreateChangeStream(create, orReplace, scope) // spanner_change_stream.go
+		}
+		if p.tokIsWord(p.cur, "LOCALITY") && p.tokIsWord(p.peekNext(), "GROUP") {
+			return p.parseCreateLocalityGroup(create, orReplace, scope) // spanner_sequence.go
+		}
+		if p.curIsRoleKeyword() {
+			// CREATE ROLE name (spanner_schema_role.go). First-class — supersedes the
+			// generic-entity parse the bare `ROLE` identifier would otherwise get.
+			return p.parseCreateRole(create, orReplace, scope)
+		}
 		// A generic-entity object kind whose keyword lexes as a bare identifier
 		// (BigQuery CAPACITY / RESERVATION / ASSIGNMENT, or PROJECT) is handled by
 		// the create_entity_statement path (bq_capacity.go). MODEL / EXTERNAL /
@@ -1123,22 +1149,29 @@ func (p *Parser) parseInterleaveInParent() (*ast.InterleaveClause, error) {
 	if err != nil {
 		return nil, err
 	}
-	// foreign_key_on_delete: ON DELETE action (required by the grammar here).
-	if _, err := p.expect(kwON); err != nil {
-		return nil, err
+	il := &ast.InterleaveClause{Parent: parent}
+	// foreign_key_on_delete is OPTIONAL on a Spanner INTERLEAVE IN PARENT clause:
+	// `INTERLEAVE IN PARENT p` (no ON DELETE) defaults to ON DELETE NO ACTION. The
+	// live emulator ACCEPTS the bare form and the explicit ON DELETE CASCADE/NO
+	// ACTION forms, but REJECTS a dangling `ON DELETE` with no action — so ON
+	// must be followed by DELETE <action> when present. (Owned divergence #112:
+	// the original parser-ddl port wrongly REQUIRED ON DELETE, over-rejecting the
+	// documented default — DDL-007 "NO ACTION (default)" — and the emulator-accepted
+	// `INTERLEAVE IN PARENT p`. This closes that over-reject; verified in
+	// spanner_ddl_oracle_test.go.)
+	if p.cur.Type == kwON {
+		p.advance() // ON
+		if _, err := p.expect(kwDELETE); err != nil {
+			return nil, err
+		}
+		act, err := p.parseForeignKeyAction()
+		if err != nil {
+			return nil, err
+		}
+		il.OnDelete = act
 	}
-	if _, err := p.expect(kwDELETE); err != nil {
-		return nil, err
-	}
-	act, err := p.parseForeignKeyAction()
-	if err != nil {
-		return nil, err
-	}
-	return &ast.InterleaveClause{
-		Parent:   parent,
-		OnDelete: act,
-		Loc:      ast.Loc{Start: start.Start, End: p.prev.Loc.End},
-	}, nil
+	il.Loc = ast.Loc{Start: start.Start, End: p.prev.Loc.End}
+	return il, nil
 }
 
 // parseKeyPartList parses a parenthesized key-part list. When pkElement is true

--- a/googlesql/parser/drop.go
+++ b/googlesql/parser/drop.go
@@ -76,7 +76,25 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 		// DROP ALL ROW ACCESS POLICIES ON table
 		// (drop_all_row_access_policies_statement; bq_row_access_policy.go).
 		return p.parseDropRowAccessPolicy(drop)
+	// --- Spanner-only object DROPs (parser-ddl-spanner node) ---
+	case kwSEQUENCE:
+		// DROP SEQUENCE [IF EXISTS] name (spanner_sequence.go).
+		return p.parseDropSequence(drop)
 	default:
+		// Spanner objects whose leading word lexes as a BARE IDENTIFIER (CHANGE
+		// STREAM, LOCALITY GROUP) and ROLE — matched by spelling before the
+		// generic-entity fallback (parser-ddl-spanner node).
+		if p.tokIsWord(p.cur, "CHANGE") && p.tokIsWord(p.peekNext(), "STREAM") {
+			return p.parseDropChangeStream(drop) // spanner_change_stream.go
+		}
+		if p.tokIsWord(p.cur, "LOCALITY") && p.tokIsWord(p.peekNext(), "GROUP") {
+			return p.parseDropLocalityGroup(drop) // spanner_sequence.go
+		}
+		if p.curIsWord("ROLE") {
+			// DROP ROLE name (spanner_schema_role.go). First-class — supersedes the
+			// generic-entity drop the bare `ROLE` identifier would otherwise get.
+			return p.parseDropRole(drop)
+		}
 		// DROP <generic-entity> (CAPACITY / RESERVATION / ASSIGNMENT — DDL-053; the
 		// keyword lexes as an identifier) routes to the generic-entity drop
 		// (bq_capacity.go). DROP MODEL / CONNECTION / CONSTANT / PRIVILEGE

--- a/googlesql/parser/grant_revoke.go
+++ b/googlesql/parser/grant_revoke.go
@@ -38,10 +38,42 @@ import (
 
 // parseGrantStmt parses a GRANT statement. The GRANT keyword has NOT yet been
 // consumed when this is called (dispatch peeks it).
+//
+// It serves BOTH dialects (oracle.md, "one grammar for both"): the legacy ZetaSQL
+// privilege grant with string/parameter grantees AND the Spanner forms — a
+// privilege grant `… TO ROLE role [, ...]` and the role-to-role grant `GRANT ROLE
+// role [, ...] TO ROLE role [, ...]`. The Spanner role surface is added by the
+// parser-ddl-spanner node (spanner_schema_role.go) and is authoritative against
+// the live emulator; the grantee list (parseGranteeList) absorbs `ROLE …` as the
+// recipient.
 func (p *Parser) parseGrantStmt() (ast.Node, error) {
 	grant := p.advance() // consume GRANT
 
-	allPrivs, privs, objType, path, err := p.parseGrantRevokeHead()
+	// Spanner role-to-role grant: `GRANT ROLE role [, ...] TO ROLE role [, ...]`.
+	// Taken ONLY when the head is unambiguously a role list (`ROLE <name> …`), so a
+	// legacy privilege grant whose first privilege is named `ROLE` (`GRANT ROLE ON
+	// foo TO 'x'`) still falls through to the privilege path below. The target must
+	// itself be a `ROLE` list (the emulator REJECTS `GRANT ROLE a TO 'x'`).
+	if p.atRoleToRoleGrant() {
+		roles, err := p.parseRoleNameList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		grantees, err := p.parseRoleGranteeList()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.GrantStmt{
+			Roles:    roles,
+			Grantees: grantees,
+			Loc:      ast.Loc{Start: grant.Loc.Start, End: p.prev.Loc.End},
+		}, nil
+	}
+
+	allPrivs, privs, objType, paths, err := p.parseGrantRevokeHead()
 	if err != nil {
 		return nil, err
 	}
@@ -52,23 +84,50 @@ func (p *Parser) parseGrantStmt() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := p.checkObjectListGrantees(paths, grantees); err != nil {
+		return nil, err
+	}
 
 	return &ast.GrantStmt{
 		AllPrivileges: allPrivs,
 		Privileges:    privs,
 		ObjectType:    objType,
-		Path:          path,
+		Path:          paths[0],
+		Paths:         paths,
 		Grantees:      grantees,
 		Loc:           ast.Loc{Start: grant.Loc.Start, End: p.prev.Loc.End},
 	}, nil
 }
 
 // parseRevokeStmt parses a REVOKE statement. The REVOKE keyword has NOT yet been
-// consumed when this is called.
+// consumed when this is called. Like GRANT it serves both dialects, including the
+// Spanner role-from-role form `REVOKE ROLE role [, ...] FROM ROLE role [, ...]`
+// and `… FROM ROLE role [, ...]` grantees.
 func (p *Parser) parseRevokeStmt() (ast.Node, error) {
 	revoke := p.advance() // consume REVOKE
 
-	allPrivs, privs, objType, path, err := p.parseGrantRevokeHead()
+	// Spanner role-from-role revoke: `REVOKE ROLE role [, ...] FROM ROLE …` (same
+	// disambiguation + strict ROLE target as the GRANT branch above).
+	if p.atRoleToRoleGrant() {
+		roles, err := p.parseRoleNameList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwFROM); err != nil {
+			return nil, err
+		}
+		grantees, err := p.parseRoleGranteeList()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.RevokeStmt{
+			Roles:    roles,
+			Grantees: grantees,
+			Loc:      ast.Loc{Start: revoke.Loc.Start, End: p.prev.Loc.End},
+		}, nil
+	}
+
+	allPrivs, privs, objType, paths, err := p.parseGrantRevokeHead()
 	if err != nil {
 		return nil, err
 	}
@@ -79,38 +138,81 @@ func (p *Parser) parseRevokeStmt() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := p.checkObjectListGrantees(paths, grantees); err != nil {
+		return nil, err
+	}
 
 	return &ast.RevokeStmt{
 		AllPrivileges: allPrivs,
 		Privileges:    privs,
 		ObjectType:    objType,
-		Path:          path,
+		Path:          paths[0],
+		Paths:         paths,
 		Grantees:      grantees,
 		Loc:           ast.Loc{Start: revoke.Loc.Start, End: p.prev.Loc.End},
 	}, nil
 }
 
+// checkObjectListGrantees enforces the union constraint that a comma-separated
+// object list (>1 object) is a SPANNER-only form, which requires ROLE grantees.
+// The legacy ZetaSQL grant names exactly one object, so a multi-object grant with
+// a non-ROLE (string/parameter) grantee belongs to NEITHER dialect — the emulator
+// REJECTS `GRANT SELECT ON TABLE t1, t2 TO 'user'`. A single-object grant is
+// unconstrained (either dialect). Cross-model review surfaced the original
+// over-acceptance.
+func (p *Parser) checkObjectListGrantees(paths []ast.NamePath, grantees []*ast.Grantee) error {
+	if len(paths) <= 1 {
+		return nil
+	}
+	for _, g := range grantees {
+		if g.Kind != ast.GranteeRole {
+			return &ParseError{
+				Loc: g.Loc,
+				Msg: "syntax error: a GRANT/REVOKE over multiple objects requires ROLE grantees",
+			}
+		}
+	}
+	return nil
+}
+
+// parseRoleGranteeList parses the target of a role-to-role grant/revoke, which
+// MUST be a `ROLE role_name [, ...]` list (the emulator REJECTS a string/parameter
+// target there — `GRANT ROLE a TO 'x'` fails with "Expecting 'ROLE'"). cur is at
+// the target `ROLE` keyword.
+func (p *Parser) parseRoleGranteeList() ([]*ast.Grantee, error) {
+	if !p.curIsRoleKeyword() {
+		return nil, p.syntaxErrorAtCur()
+	}
+	roles, err := p.parseRoleNameList()
+	if err != nil {
+		return nil, err
+	}
+	return roleNamesToGrantees(roles), nil
+}
+
 // parseGrantRevokeHead parses the shared GRANT/REVOKE prefix up to (but not
 // including) the TO / FROM keyword:
 //
-//	privileges ON (identifier identifier?)? path_expression
+//	privileges ON (identifier identifier?)? path_expression (',' path_expression)*
 //
-// It returns (allPrivileges, privileges, objectType, path, err). The verb keyword
-// has already been consumed; on success cur is positioned at TO (GRANT) or FROM
-// (REVOKE).
-func (p *Parser) parseGrantRevokeHead() (bool, []*ast.Privilege, []string, ast.NamePath, error) {
+// It returns (allPrivileges, privileges, objectType, paths, err) where paths is
+// the (>= 1) ON object list. The legacy ZetaSQL grant names a single object; the
+// Spanner role grant allows a comma-separated object list (`ON TABLE t1, t2 TO
+// ROLE r`, emulator-verified). The verb keyword has already been consumed; on
+// success cur is positioned at TO (GRANT) or FROM (REVOKE).
+func (p *Parser) parseGrantRevokeHead() (bool, []*ast.Privilege, []string, []ast.NamePath, error) {
 	allPrivs, privs, err := p.parsePrivileges()
 	if err != nil {
-		return false, nil, nil, ast.NamePath{}, err
+		return false, nil, nil, nil, err
 	}
 	if _, err := p.expect(kwON); err != nil {
-		return false, nil, nil, ast.NamePath{}, err
+		return false, nil, nil, nil, err
 	}
-	objType, path, err := p.parseObjectTypeAndPath()
+	objType, paths, err := p.parseObjectTypeAndPathList()
 	if err != nil {
-		return false, nil, nil, ast.NamePath{}, err
+		return false, nil, nil, nil, err
 	}
-	return allPrivs, privs, objType, path, nil
+	return allPrivs, privs, objType, paths, nil
 }
 
 // parsePrivileges parses the grammar's `privileges`:
@@ -216,34 +318,69 @@ func (p *Parser) parsePathExpressionListWithParens() ([]ast.NamePath, error) {
 	return paths, nil
 }
 
-// parseObjectTypeAndPath parses the grammar's `(identifier identifier?)?
-// path_expression` — the optional 0/1/2-word object type followed by the
-// required object path. The verb keyword and ON have already been consumed; on
-// success cur is at TO/FROM.
+// parseObjectTypeAndPathList parses the grammar's object-type + object-path list.
+// The verb keyword and ON have already been consumed; on success cur is at
+// TO/FROM. Returns (objType, paths, err) with len(paths) >= 1.
 //
-// Disambiguation (matching ANTLR's longest-type-then-backtrack over this rule):
-// the object type words are SINGLE (non-dotted) identifiers and the path is one
-// dotted path_expression, then TO/FROM. So:
+// TWO dialect shapes share this position:
+//   - legacy ZetaSQL — `(identifier identifier?)? path_expression`: an OPTIONAL
+//     0/1/2-word object type and EXACTLY ONE object path. `GRANT SELECT ON foo TO
+//     'x'` (no type) is valid here.
+//   - Spanner — `target_type path (',' path)*`: a comma-separated object list,
+//     which REQUIRES a leading type keyword (TABLE/VIEW/CHANGE STREAM/TABLE
+//     FUNCTION). `GRANT SELECT ON TABLE t1, t2 TO ROLE r` is valid; `ON foo, bar`
+//     (no type) is NOT (the emulator: "Encountered 'foo' while parsing:
+//     target_type").
 //
-//   - Parse a path_expression P1 (greedy on dots).
-//   - If TO/FROM follows, there is NO object type and P1 is the path.
-//     (e.g. `ON datascape.foo TO`, `ON foo TO`)
-//   - Otherwise another identifier follows, so P1 was the FIRST type word and
-//     must be a single (non-dotted) identifier. Parse the next path_expression
-//     P2 and repeat once more for an optional SECOND type word.
-//     (e.g. `ON table foo TO` => type [table], path foo;
-//     `ON materialized view foo TO` => type [materialized, view], path foo)
+// Therefore a comma-separated list is accepted ONLY when an object type was
+// present. With no type keyword, exactly one path is allowed (the legacy form) and
+// a trailing comma is a syntax error. (The complementary "multi-object ⇒ ROLE
+// grantee" rule is enforced by checkObjectListGrantees after the grantee list.)
 //
-// A would-be type word that is actually dotted (e.g. `ON a.b c TO`) has no valid
-// parse in the grammar (type words are single identifiers) and is reported as a
-// syntax error.
-func (p *Parser) parseObjectTypeAndPath() ([]string, ast.NamePath, error) {
+// Object-type disambiguation (type words and the first path are all bare
+// identifiers): a leading word is a TYPE word only when followed by ANOTHER
+// path-expression-start — NOT by `,` and NOT by TO/FROM:
+//
+//   - `ON foo TO`                 => no type,  paths [foo]
+//   - `ON table foo TO`           => type [table], paths [foo]
+//   - `ON table t1, t2 TO`        => type [table], paths [t1, t2]
+//   - `ON materialized view v TO` => type [materialized, view], paths [v]
+func (p *Parser) parseObjectTypeAndPathList() ([]string, []ast.NamePath, error) {
+	objType, first, err := p.parseObjectTypeAndFirstPath()
+	if err != nil {
+		return nil, nil, err
+	}
+	paths := []ast.NamePath{first}
+
+	// A comma-separated object list is the Spanner form, which requires a leading
+	// object-type keyword. Without one, only the single legacy object is allowed,
+	// so a comma here is a syntax error (left for the caller's expect(TO/FROM), or
+	// reported directly so the diagnostic points at the comma).
+	if p.cur.Type == int(',') && len(objType) == 0 {
+		return nil, nil, p.syntaxErrorAtCur()
+	}
+	for p.cur.Type == int(',') {
+		p.advance() // ','
+		next, err := p.parsePathExpression()
+		if err != nil {
+			return nil, nil, err
+		}
+		paths = append(paths, next)
+	}
+	return objType, paths, nil
+}
+
+// parseObjectTypeAndFirstPath consumes the optional 0/1/2-word object type and the
+// FIRST object path. A word is a type word only when followed by another bare
+// identifier (not ',' and not TO/FROM); see parseObjectTypeAndPathList.
+func (p *Parser) parseObjectTypeAndFirstPath() ([]string, ast.NamePath, error) {
 	first, err := p.parsePathExpression()
 	if err != nil {
 		return nil, ast.NamePath{}, err
 	}
-	// No object type: the first path_expression is the object name.
-	if p.atGranteeIntro() {
+	// `first` is the object path when the run ends here — at TO/FROM (no more
+	// objects) or at ',' (more objects follow, so `first` is path #1, not a type).
+	if p.atPathRunBoundary() {
 		return nil, first, nil
 	}
 
@@ -259,7 +396,7 @@ func (p *Parser) parseObjectTypeAndPath() ([]string, ast.NamePath, error) {
 	if err != nil {
 		return nil, ast.NamePath{}, err
 	}
-	if p.atGranteeIntro() {
+	if p.atPathRunBoundary() {
 		return objType, path, nil
 	}
 
@@ -274,10 +411,17 @@ func (p *Parser) parseObjectTypeAndPath() ([]string, ast.NamePath, error) {
 	if err != nil {
 		return nil, ast.NamePath{}, err
 	}
-	// After at most two type words the grammar requires the grantee intro next;
+	// After at most two type words the grammar requires the path-run boundary next;
 	// anything else (e.g. a third bare word) is a syntax error, surfaced by the
-	// caller's expect(TO/FROM).
+	// caller's expect(TO/FROM) once the comma loop (if any) finishes.
 	return objType, path, nil
+}
+
+// atPathRunBoundary reports whether cur ends the object-type/path run: a comma
+// (the next comma-separated object path) or the TO/FROM grantee intro. A word
+// before one of these is an object PATH, not an object-type word.
+func (p *Parser) atPathRunBoundary() bool {
+	return p.cur.Type == int(',') || p.atGranteeIntro()
 }
 
 // singleIdentName returns the single component of a path that must be a lone
@@ -325,10 +469,29 @@ func (p *Parser) parsePathExpression() (ast.NamePath, error) {
 	return ast.NamePath{Parts: parts, Loc: ast.Loc{Start: start.Start, End: end.End}}, nil
 }
 
-// parseGranteeList parses the grammar's `grantee_list: string_literal_or_parameter
-// (',' string_literal_or_parameter)*`. Requires at least one grantee; a
-// trailing/leading comma is a syntax error.
+// parseGranteeList parses the recipients after TO (GRANT) / FROM (REVOKE). It
+// accepts the UNION of both dialects:
+//
+//   - legacy ZetaSQL `grantee_list: string_literal_or_parameter (',' …)*`
+//     (string / @param / '?' / @@sysvar grantees), and
+//   - the Spanner `ROLE role_name (',' role_name)*` form — a single `ROLE`
+//     keyword introduces a comma-separated role-name list (parser-ddl-spanner;
+//     emulator-authoritative). The two are NOT mixable: a list either starts with
+//     `ROLE` (all role grantees) or with a string/parameter (all legacy grantees),
+//     matching the emulator (`TO ROLE r1, ROLE r2` REJECTS — the `ROLE` keyword
+//     appears once).
+//
+// Requires at least one grantee; a trailing/leading comma is a syntax error.
 func (p *Parser) parseGranteeList() ([]*ast.Grantee, error) {
+	// Spanner role grantee list: `ROLE role_name [, role_name ...]`.
+	if p.curIsRoleKeyword() {
+		roles, err := p.parseRoleNameList()
+		if err != nil {
+			return nil, err
+		}
+		return roleNamesToGrantees(roles), nil
+	}
+
 	var grantees []*ast.Grantee
 	for {
 		g, err := p.parseGrantee()

--- a/googlesql/parser/grant_revoke_test.go
+++ b/googlesql/parser/grant_revoke_test.go
@@ -272,7 +272,11 @@ func TestGrantRevoke_Rejects(t *testing.T) {
 		"REVOKE ON table foo FROM 'x'",        // missing privileges
 		"REVOKE `select` ON table foo TO 'x'", // REVOKE uses FROM, not TO
 		"REVOKE `select` ON table foo",        // missing FROM
-		"GRANT ROLE analyst TO ROLE senior",   // Spanner role form: NOT in the ZetaSQL grammar
+		// NOTE: `GRANT ROLE analyst TO ROLE senior` is NO LONGER a reject — the
+		// parser-ddl-spanner node added the Spanner role-to-role grant to the union
+		// (emulator-authoritative: it ACCEPTS that form). See TestGrant_RoleToRole /
+		// spanner_ddl_test.go. The grantee must still not be a bare identifier
+		// (covered by `… TO foo` above), and `TO 'string'` is the legacy dialect.
 	}
 	for _, sql := range cases {
 		t.Run(sql, func(t *testing.T) {

--- a/googlesql/parser/spanner_change_stream.go
+++ b/googlesql/parser/spanner_change_stream.go
@@ -1,0 +1,250 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Spanner DDL — CHANGE STREAM (parser-ddl-spanner node)
+// ---------------------------------------------------------------------------
+//
+// Cloud Spanner change streams (truth1 DDL-024/025/026):
+//
+//	CREATE CHANGE STREAM name { FOR ALL | FOR table_and_column [, ...] }?
+//	  [OPTIONS ( option [, ...] )]
+//	ALTER  CHANGE STREAM name { SET FOR { ALL | table_and_column [, ...] }
+//	                          | DROP FOR ALL
+//	                          | SET OPTIONS ( option [, ...] ) }
+//	DROP   CHANGE STREAM name
+//
+//	table_and_column: table_name | table_name ( ) | table_name ( column [, ...] )
+//
+// DIALECT NOTE — these have NO first-class rule in the legacy ANTLR
+// GoogleSQLParser.g4 (it models CHANGE STREAM via the generic-entity hook, which
+// cannot express `CHANGE STREAM` as a two-word object-type with a FOR clause, so
+// the legacy parser effectively over-rejects them). The omni parser models them
+// directly. The authoritative oracle is the live Cloud Spanner emulator
+// (oracle.md), which ACCEPTS every form here; verified in
+// spanner_ddl_oracle_test.go. The `CHANGE` and `STREAM` words both lex as bare
+// identifiers (non-reserved), so dispatch matches them by spelling.
+
+// parseCreateChangeStream parses a CREATE CHANGE STREAM body. The shared CREATE
+// prefix has been consumed by parseCreateStmt; cur is at the `CHANGE` identifier
+// (peeked + confirmed `CHANGE STREAM` by the dispatcher). create_change_stream has
+// no opt_or_replace / opt_create_scope, so a leading OR REPLACE / scope rejects.
+func (p *Parser) parseCreateChangeStream(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if orReplace || scope != "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // CHANGE
+	p.advance() // STREAM
+
+	stmt := &ast.CreateChangeStreamStmt{}
+	stmt.Loc.Start = create.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional FOR clause: FOR ALL | FOR table_and_column [, ...].
+	if p.cur.Type == kwFOR {
+		p.advance() // FOR
+		stmt.HasFor = true
+		if p.cur.Type == kwALL {
+			p.advance() // ALL
+			stmt.ForAll = true
+		} else {
+			tables, err := p.parseChangeStreamForTables()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ForTables = tables
+		}
+	}
+
+	// opt_options_list?
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterChangeStream parses an ALTER CHANGE STREAM body. The ALTER keyword has
+// been consumed by parseAlterStmt; cur is at `CHANGE` (dispatcher confirmed
+// `CHANGE STREAM`).
+func (p *Parser) parseAlterChangeStream(alter Token) (ast.Node, error) {
+	p.advance() // CHANGE
+	p.advance() // STREAM
+
+	stmt := &ast.AlterChangeStreamStmt{}
+	stmt.Loc.Start = alter.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwSET:
+		p.advance() // SET
+		switch p.cur.Type {
+		case kwFOR:
+			p.advance() // FOR
+			stmt.Action = ast.ChangeStreamSetFor
+			if p.cur.Type == kwALL {
+				p.advance() // ALL
+				stmt.ForAll = true
+			} else {
+				tables, err := p.parseChangeStreamForTables()
+				if err != nil {
+					return nil, err
+				}
+				stmt.ForTables = tables
+			}
+		case kwOPTIONS:
+			stmt.Action = ast.ChangeStreamSetOptions
+			opts, err := p.parseOptionsList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = opts
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	case kwDROP:
+		p.advance() // DROP
+		if _, err := p.expect(kwFOR); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwALL); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.ChangeStreamDropForAll
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseDropChangeStream parses a DROP CHANGE STREAM body. The DROP keyword has
+// been consumed by parseDropStmt; cur is at `CHANGE` (dispatcher confirmed
+// `CHANGE STREAM`).
+func (p *Parser) parseDropChangeStream(drop Token) (ast.Node, error) {
+	p.advance() // CHANGE
+	p.advance() // STREAM
+
+	stmt := &ast.DropChangeStreamStmt{}
+	stmt.Loc.Start = drop.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseChangeStreamForTables parses a non-empty `table_and_column [, ...]` list.
+// cur is at the first table name. Each entry is:
+//
+//	table_name                     -> whole table (no parens)
+//	table_name ( )                 -> ExplicitColumns, no columns
+//	table_name ( column [, ...] )  -> ExplicitColumns + column list
+func (p *Parser) parseChangeStreamForTables() ([]*ast.ChangeStreamTrackedTable, error) {
+	var out []*ast.ChangeStreamTrackedTable
+	for {
+		entry, err := p.parseChangeStreamTrackedTable()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, entry)
+		if _, ok := p.match(int(',')); ok {
+			continue
+		}
+		break
+	}
+	return out, nil
+}
+
+// parseChangeStreamTrackedTable parses one table_and_column entry. cur is at the
+// table name.
+func (p *Parser) parseChangeStreamTrackedTable() (*ast.ChangeStreamTrackedTable, error) {
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	entry := &ast.ChangeStreamTrackedTable{Name: name, Loc: name.Loc}
+
+	// Optional `( )` or `( column [, ...] )`.
+	if p.cur.Type == int('(') {
+		p.advance() // '('
+		entry.ExplicitColumns = true
+		if p.cur.Type != int(')') {
+			cols, err := p.parseChangeStreamColumnList()
+			if err != nil {
+				return nil, err
+			}
+			entry.Columns = cols
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		entry.Loc.End = closeTok.Loc.End
+	} else {
+		entry.Loc.End = p.prev.Loc.End
+	}
+	return entry, nil
+}
+
+// parseChangeStreamColumnList parses a non-empty comma-separated column-name list
+// inside a tracked table's `( … )`. cur is at the first column name.
+func (p *Parser) parseChangeStreamColumnList() ([]string, error) {
+	var cols []string
+	for {
+		tok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, name)
+		if _, ok := p.match(int(',')); ok {
+			continue
+		}
+		break
+	}
+	return cols, nil
+}
+
+// tokIsWord reports whether tok is an identifier or keyword whose spelling equals
+// word (case-insensitive). It is the peek-friendly sibling of curIsWord, used by
+// the CREATE/ALTER/DROP dispatchers to recognize the bare-identifier object words
+// (CHANGE / STREAM / LOCALITY / GROUP) that the lexer does not tokenize as
+// dedicated keywords.
+func (p *Parser) tokIsWord(tok Token, word string) bool {
+	if tok.Type == tokIdentifier {
+		return strings.EqualFold(tok.Str, word)
+	}
+	if tok.Type >= keywordBase {
+		return strings.EqualFold(TokenName(tok.Type), word)
+	}
+	return false
+}

--- a/googlesql/parser/spanner_ddl_oracle_test.go
+++ b/googlesql/parser/spanner_ddl_oracle_test.go
@@ -1,0 +1,288 @@
+//go:build googlesql_oracle
+
+// Differential test for the parser-ddl-spanner node (Spanner DDL: CHANGE STREAM,
+// SEQUENCE, ROLE, LOCALITY GROUP, PROTO BUNDLE, and role-based GRANT/REVOKE)
+// against the live Cloud Spanner emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestSpannerDDLDifferential
+//
+// It is the PROVE gate for googlesql/parser-ddl-spanner (correctness-protocol.md):
+// for every fixture it feeds the full DDL statement to the emulator via the
+// harness/googlesql-spanner CLI (UpdateDatabaseDdl) and reads the accept/reject
+// verdict, then parses the same statement with omni's Parse and asserts the two
+// agree — BOTH polarities (the corpus has accept AND reject cases). A harness
+// `error` verdict (oracle could not decide) fails the fixture loudly.
+//
+// AUTHORITATIVE — every fixture below is a SPANNER-dialect form (oracle.md routes
+// "Spanner-only (… CHANGE STREAM, sequences, … role DDL)" to the emulator as
+// authoritative). EXCLUDED, because the emulator is NON-authoritative for them:
+//   - the legacy ZetaSQL string-grantee GRANT (`… TO 'user'`) — Spanner REJECTS
+//     it ("Expecting 'ROLE'") but the BigQuery+Spanner UNION parser must accept
+//     it; it is covered by grant_revoke_test.go.
+//   - empty `OPTIONS ()` — Spanner REJECTS it in every context (incl. CREATE
+//     TABLE) but the union/BigQuery grammar accepts it; the parser-ddl node
+//     already accepts empty OPTIONS, so a Spanner verdict there is a false
+//     divergence. Covered by the unit tests.
+package parser
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// spannerDDLFixture is a full DDL statement (no trailing ';') fed to BOTH the
+// oracle and omni's Parse. wantParse is the expected omni outcome and MUST equal
+// the emulator's grammar verdict.
+type spannerDDLFixture struct {
+	sql       string
+	wantParse bool
+}
+
+var spannerDDLFixtures = []spannerDDLFixture{
+	// ===================== CHANGE STREAM =====================
+	{"CREATE CHANGE STREAM MyStream FOR ALL", true},
+	{"CREATE CHANGE STREAM cs2 FOR ALL OPTIONS (retention_period = '7d')", true},
+	{"CREATE CHANGE STREAM cs3 OPTIONS (retention_period = '7d')", true}, // no FOR clause
+	{"CREATE CHANGE STREAM cs4 FOR ALL OPTIONS (retention_period = '2d', value_capture_type = 'NEW_ROW')", true},
+	{"ALTER CHANGE STREAM MyStream SET FOR ALL", true},
+	{"ALTER CHANGE STREAM MyStream DROP FOR ALL", true},
+	{"ALTER CHANGE STREAM MyStream SET OPTIONS (retention_period = '2d')", true},
+	{"DROP CHANGE STREAM MyStream", true},
+	{"CREATE CHANGE STREAM cs_sch FOR myschema.Singers", true},          // schema-qualified table
+	{"CREATE CHANGE STREAM cs_cols FOR Singers(`select`, key), Albums()", true}, // keyword/quoted cols, empty parens
+	// reject — ALL is not a table name; FOR ALL cannot be in a list; no trailing comma.
+	{"CREATE CHANGE STREAM cs FOR Singers, ALL", false},
+	{"CREATE CHANGE STREAM cs FOR ALL, Singers", false},
+	{"CREATE CHANGE STREAM cs FOR Singers(a,)", false}, // trailing comma in column list NOT allowed
+	{"CREATE CHANGE STREAM cs FOR Singers,", false},    // trailing comma in table list NOT allowed
+	// reject
+	{"CREATE CHANGE STREAM cs FOR", false},        // dangling FOR
+	{"ALTER CHANGE STREAM cs DROP FOR", false},    // DROP FOR without ALL
+	{"ALTER CHANGE STREAM cs SET", false},         // SET with nothing
+	{"ALTER CHANGE STREAM cs", false},             // no action
+
+	// ===================== SEQUENCE =====================
+	{"CREATE SEQUENCE Seq1 OPTIONS (sequence_kind = 'bit_reversed_positive')", true},
+	{"CREATE SEQUENCE IF NOT EXISTS Seq2 OPTIONS (sequence_kind = 'bit_reversed_positive')", true},
+	{"CREATE SEQUENCE BareSeq3", true}, // grammar-accept (semantic: missing kind)
+	{"ALTER SEQUENCE Seq1 SET OPTIONS (start_with_counter = 9000)", true},
+	{"ALTER SEQUENCE IF EXISTS SeqMissing SET OPTIONS (start_with_counter = 9000)", true},
+	{"DROP SEQUENCE Seq1", true},
+	{"DROP SEQUENCE IF EXISTS SeqX", true},
+	// reject
+	{"ALTER SEQUENCE s", false},     // missing SET OPTIONS (required for SEQUENCE)
+	{"ALTER SEQUENCE s SET", false}, // SET with no OPTIONS
+
+	// ===================== ROLE =====================
+	{"CREATE ROLE analyst_role", true},
+	{"DROP ROLE analyst_role", true},
+	{"CREATE ROLE `dotted.name`", true}, // backtick name is a single identifier
+	{"DROP ROLE a.b.c", true},           // DROP ROLE accepts a dotted path (CREATE does not)
+	// reject — a dotted CREATE ROLE name (role names are single identifiers).
+	{"CREATE ROLE a.b", false},
+
+	// ===================== LOCALITY GROUP =====================
+	{"CREATE LOCALITY GROUP lg_hot OPTIONS (storage = 'ssd')", true},
+	{"CREATE LOCALITY GROUP lg_cold OPTIONS (storage = 'hdd', ssd_to_hdd_spill_timespan = '30d')", true},
+	{"ALTER LOCALITY GROUP lg_cold SET OPTIONS (ssd_to_hdd_spill_timespan = '14d')", true},
+	{"ALTER LOCALITY GROUP lg_bare", true}, // SET OPTIONS is OPTIONAL for LOCALITY GROUP (unlike SEQUENCE)
+	{"DROP LOCALITY GROUP lg_cold", true},
+	// reject
+	{"ALTER LOCALITY GROUP g SET", false},          // SET with no OPTIONS
+	{"ALTER LOCALITY GROUP g RENAME TO h", false},  // not a valid action
+
+	// ===================== PROTO BUNDLE =====================
+	// CREATE PROTO BUNDLE with an empty descriptor file is a SEMANTIC failure
+	// (verdict accept — the grammar parsed). ALTER on a missing bundle likewise.
+	{"CREATE PROTO BUNDLE (`a.b.C`)", true},
+	{"CREATE PROTO BUNDLE (`a.b.C`, `a.b.D`)", true},
+	{"ALTER PROTO BUNDLE INSERT (`a.b.C`)", true},
+	{"ALTER PROTO BUNDLE INSERT (`a.b.C`) UPDATE (`a.b.D`) DELETE (`a.b.E`)", true},
+	{"ALTER PROTO BUNDLE DELETE (`a.b.C`, `a.b.D`)", true},
+	{"CREATE PROTO BUNDLE (`a.b.C`, `a.b.D`,)", true}, // trailing comma allowed (unlike change-stream cols)
+	{"ALTER PROTO BUNDLE INSERT (`a.b.C`,)", true},    // trailing comma allowed
+	// reject — empty bundle, comma between groups, repeat, out of order.
+	{"CREATE PROTO BUNDLE ()", false},
+	{"ALTER PROTO BUNDLE INSERT (`a.b.C`), UPDATE (`a.b.D`)", false}, // comma between groups
+	{"ALTER PROTO BUNDLE INSERT (`a.b.C`) INSERT (`a.b.D`)", false},  // repeated group
+	{"ALTER PROTO BUNDLE UPDATE (`a.b.C`) INSERT (`a.b.D`)", false},  // out of order
+	{"ALTER PROTO BUNDLE INSERT", false},                            // INSERT with no parens
+
+	// ===================== role-based GRANT / REVOKE =====================
+	{"GRANT SELECT ON TABLE T_grant TO ROLE r_g", true},
+	{"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE T_grant TO ROLE r_g2", true},
+	{"GRANT ROLE analyst_g TO ROLE senior_g", true},
+	{"GRANT ROLE a1, b1 TO ROLE c1, d1", true},
+	{"REVOKE SELECT ON TABLE T_grant FROM ROLE r_g", true},
+	{"REVOKE ROLE analyst_g FROM ROLE senior_g", true},
+	// Spanner comma-separated object list in a role grant/revoke.
+	{"GRANT SELECT ON TABLE t_cs1, t_cs2 TO ROLE r_g", true},
+	{"GRANT SELECT ON TABLE t_cs1, t_cs2 TO ROLE r_g1, r_g2", true},
+	{"REVOKE SELECT ON TABLE t_cs1, t_cs2 FROM ROLE r_g", true},
+	// reject — role-to-role target must be ROLE (not a string/parameter), and a
+	// multi-object grant cannot use a string grantee.
+	{"GRANT ROLE analyst_g TO 'user'", false},
+	{"GRANT SELECT ON TABLE t_cs1, t_cs2 TO 'user'", false},
+	// reject
+	{"GRANT SELECT ON TABLE t TO ROLE", false}, // TO ROLE with no role name
+	{"GRANT ROLE a TO ROLE", false},            // role-grant TO ROLE with no role
+	{"GRANT ROLE TO ROLE r", false},            // GRANT ROLE with no subject role
+	{"REVOKE ROLE a FROM ROLE", false},         // role-revoke FROM ROLE with no role
+	// reject — role names are single identifiers, not dotted paths.
+	{"GRANT SELECT ON TABLE t TO ROLE a.b", false},
+	{"GRANT ROLE a.b TO ROLE c", false},
+	{"GRANT SELECT ON TABLE t TO ROLE r1, r2.x", false},
+	{"REVOKE ROLE r1, r2.x FROM ROLE s", false},
+
+	// ===================== owned divergence #112 (INTERLEAVE) =====================
+	// INTERLEAVE IN PARENT with NO `ON DELETE` action now ACCEPTS (defaults to NO
+	// ACTION), matching the emulator; a dangling `ON DELETE` still REJECTS. This
+	// statement is parsed by create_table.go; the fix is part of this node.
+	{"CREATE TABLE cs_child (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT cs_parent", true},
+	{"CREATE TABLE cs_child2 (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT cs_parent ON DELETE CASCADE", true},
+	{"CREATE TABLE cs_child3 (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT cs_parent ON DELETE", false}, // dangling ON DELETE
+	// owned divergence #8 (inline column PRIMARY KEY) — emulator accepts; omni does too.
+	{"CREATE TABLE cs_inline (id INT64 PRIMARY KEY, name STRING(MAX))", true},
+
+	// ===================== OR REPLACE / scope / drop-mode rejects =====================
+	// None of these Spanner objects takes OR REPLACE or a create-scope; DROP takes
+	// no RESTRICT/CASCADE. All REJECT on the emulator.
+	{"CREATE OR REPLACE SEQUENCE s_or", false},
+	{"CREATE TEMP SEQUENCE s_temp", false},
+	{"CREATE OR REPLACE CHANGE STREAM s_or FOR ALL", false},
+	{"CREATE OR REPLACE LOCALITY GROUP g_or", false},
+	{"CREATE OR REPLACE PROTO BUNDLE (`a.b.C`)", false},
+	{"CREATE OR REPLACE ROLE r_or", false},
+	{"DROP SEQUENCE s_dm RESTRICT", false},
+}
+
+func TestSpannerDDLDifferential(t *testing.T) {
+	h := newSpannerDDLHarness(t)
+	defer h.close()
+
+	for _, fx := range spannerDDLFixtures {
+		fx := fx
+		t.Run(fx.sql, func(t *testing.T) {
+			v := h.verdict(t, fx.sql)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; fix the wrapper/emulator — do NOT treat as accept/reject",
+					fx.sql, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.sql)
+			}
+			oracleAccepts := v.Verdict == "accept"
+
+			// Sanity: the asserted wantParse must match the live oracle. If this
+			// trips, the fixture's hard-coded expectation drifted from reality (an
+			// emulator upgrade) — or it should not be in this Spanner differential.
+			if oracleAccepts != fx.wantParse {
+				t.Fatalf("fixture wantParse=%v but oracle says %q (%s: %s) for %q",
+					fx.wantParse, v.Verdict, v.Reason, v.Message, fx.sql)
+			}
+
+			_, errs := Parse(fx.sql)
+			omniAccepts := len(errs) == 0
+
+			if omniAccepts != oracleAccepts {
+				t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s); omni errs=%v",
+					fx.sql, omniAccepts, oracleAccepts, v.Reason, v.Message, errs)
+			}
+		})
+	}
+}
+
+// --- harness plumbing (one persistent batch process; names its own type to avoid
+// a duplicate-symbol collision under the shared googlesql_oracle build tag) ---
+
+type spannerDDLHarnessVerdict struct {
+	Verdict string `json:"verdict"`
+	Kind    string `json:"kind"`
+	Reason  string `json:"reason"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type spannerDDLHarness struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	mu     sync.Mutex
+}
+
+func newSpannerDDLHarness(t *testing.T) *spannerDDLHarness {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	projDir := filepath.Join(repoRoot, "harness", "googlesql-spanner")
+	if _, err := os.Stat(projDir); err != nil {
+		t.Skipf("harness project not found at %s", projDir)
+	}
+
+	bin := filepath.Join(projDir, "googlesql-spanner")
+	if _, err := os.Stat(bin); err != nil {
+		build := exec.Command("go", "build", "-o", bin, ".")
+		build.Dir = projDir
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("building harness failed: %v\n%s", err, out)
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(), "GOOGLESQL_HARNESS_LINE=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting harness: %v", err)
+	}
+	return &spannerDDLHarness{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdoutPipe)}
+}
+
+func (h *spannerDDLHarness) verdict(t *testing.T, stmt string) spannerDDLHarnessVerdict {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	enc := base64.StdEncoding.EncodeToString([]byte(stmt))
+	if _, err := fmt.Fprintln(h.stdin, enc); err != nil {
+		t.Fatalf("writing to harness: %v", err)
+	}
+	line, err := h.stdout.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading harness verdict: %v", err)
+	}
+	var v spannerDDLHarnessVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &v); err != nil {
+		t.Fatalf("decoding harness verdict %q: %v", line, err)
+	}
+	return v
+}
+
+func (h *spannerDDLHarness) close() {
+	if h.stdin != nil {
+		_ = h.stdin.Close()
+	}
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Wait()
+	}
+}

--- a/googlesql/parser/spanner_ddl_test.go
+++ b/googlesql/parser/spanner_ddl_test.go
@@ -1,0 +1,644 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit (structural-gate) tests for the parser-ddl-spanner node: CREATE/ALTER/DROP
+// of CHANGE STREAM, SEQUENCE, ROLE, LOCALITY GROUP, PROTO BUNDLE, plus the Spanner
+// role-based GRANT/REVOKE forms. Accept/reject parity with the live Spanner
+// emulator is in spanner_ddl_oracle_test.go.
+
+// --- CHANGE STREAM ---
+
+func changeStreamCreateOf(t *testing.T, sql string) *ast.CreateChangeStreamStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	s, ok := n.(*ast.CreateChangeStreamStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreateChangeStreamStmt", sql, n)
+	}
+	return s
+}
+
+func TestCreateChangeStream_ForAll(t *testing.T) {
+	s := changeStreamCreateOf(t, "CREATE CHANGE STREAM MyStream FOR ALL")
+	if s.Name.String() != "MyStream" {
+		t.Errorf("Name = %q, want MyStream", s.Name.String())
+	}
+	if !s.HasFor || !s.ForAll {
+		t.Errorf("HasFor=%v ForAll=%v, want both true", s.HasFor, s.ForAll)
+	}
+	if len(s.ForTables) != 0 {
+		t.Errorf("ForTables = %d, want 0", len(s.ForTables))
+	}
+}
+
+func TestCreateChangeStream_ForTables(t *testing.T) {
+	s := changeStreamCreateOf(t, "CREATE CHANGE STREAM s FOR Singers, Albums(Title, Budget), Tracks()")
+	if !s.HasFor || s.ForAll {
+		t.Fatalf("HasFor=%v ForAll=%v, want HasFor true / ForAll false", s.HasFor, s.ForAll)
+	}
+	if len(s.ForTables) != 3 {
+		t.Fatalf("ForTables = %d, want 3", len(s.ForTables))
+	}
+	// Singers: whole table, no parens.
+	if s.ForTables[0].Name.String() != "Singers" || s.ForTables[0].ExplicitColumns {
+		t.Errorf("ForTables[0] = %+v, want Singers w/o explicit cols", s.ForTables[0])
+	}
+	// Albums(Title, Budget): explicit columns.
+	if !s.ForTables[1].ExplicitColumns || len(s.ForTables[1].Columns) != 2 ||
+		s.ForTables[1].Columns[0] != "Title" || s.ForTables[1].Columns[1] != "Budget" {
+		t.Errorf("ForTables[1] = %+v, want Albums(Title, Budget)", s.ForTables[1])
+	}
+	// Tracks(): explicit, empty.
+	if !s.ForTables[2].ExplicitColumns || len(s.ForTables[2].Columns) != 0 {
+		t.Errorf("ForTables[2] = %+v, want Tracks() empty explicit", s.ForTables[2])
+	}
+}
+
+func TestCreateChangeStream_Options(t *testing.T) {
+	s := changeStreamCreateOf(t, "CREATE CHANGE STREAM s FOR ALL OPTIONS (retention_period = '7d', value_capture_type = 'NEW_ROW')")
+	if len(s.Options) != 2 {
+		t.Fatalf("Options = %d, want 2", len(s.Options))
+	}
+	if s.Options[0].Name != "retention_period" {
+		t.Errorf("Options[0].Name = %q, want retention_period", s.Options[0].Name)
+	}
+}
+
+func TestCreateChangeStream_OptionsOnly(t *testing.T) {
+	// FOR clause omitted: HasFor must be false. (Emulator-accepted.)
+	s := changeStreamCreateOf(t, "CREATE CHANGE STREAM s OPTIONS (retention_period = '7d')")
+	if s.HasFor {
+		t.Errorf("HasFor = true, want false (no FOR clause)")
+	}
+	if len(s.Options) != 1 {
+		t.Errorf("Options = %d, want 1", len(s.Options))
+	}
+}
+
+func TestAlterChangeStream_SetForAll(t *testing.T) {
+	n := parseDDL(t, "ALTER CHANGE STREAM s SET FOR ALL")
+	a, ok := n.(*ast.AlterChangeStreamStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.AlterChangeStreamStmt", n)
+	}
+	if a.Action != ast.ChangeStreamSetFor || !a.ForAll {
+		t.Errorf("Action=%v ForAll=%v, want SetFor/true", a.Action, a.ForAll)
+	}
+}
+
+func TestAlterChangeStream_SetForTables(t *testing.T) {
+	n := parseDDL(t, "ALTER CHANGE STREAM s SET FOR Singers, Albums")
+	a := n.(*ast.AlterChangeStreamStmt)
+	if a.Action != ast.ChangeStreamSetFor || a.ForAll || len(a.ForTables) != 2 {
+		t.Errorf("got Action=%v ForAll=%v tables=%d, want SetFor/false/2", a.Action, a.ForAll, len(a.ForTables))
+	}
+}
+
+func TestAlterChangeStream_DropForAll(t *testing.T) {
+	n := parseDDL(t, "ALTER CHANGE STREAM s DROP FOR ALL")
+	a := n.(*ast.AlterChangeStreamStmt)
+	if a.Action != ast.ChangeStreamDropForAll {
+		t.Errorf("Action = %v, want DropForAll", a.Action)
+	}
+}
+
+func TestAlterChangeStream_SetOptions(t *testing.T) {
+	n := parseDDL(t, "ALTER CHANGE STREAM s SET OPTIONS (retention_period = '14d')")
+	a := n.(*ast.AlterChangeStreamStmt)
+	if a.Action != ast.ChangeStreamSetOptions || len(a.Options) != 1 {
+		t.Errorf("got Action=%v opts=%d, want SetOptions/1", a.Action, len(a.Options))
+	}
+}
+
+func TestDropChangeStream(t *testing.T) {
+	n := parseDDL(t, "DROP CHANGE STREAM MyStream")
+	d, ok := n.(*ast.DropChangeStreamStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.DropChangeStreamStmt", n)
+	}
+	if d.Name.String() != "MyStream" {
+		t.Errorf("Name = %q, want MyStream", d.Name.String())
+	}
+}
+
+// --- SEQUENCE ---
+
+func TestCreateSequence(t *testing.T) {
+	n := parseDDL(t, "CREATE SEQUENCE MySeq OPTIONS (sequence_kind = 'bit_reversed_positive')")
+	s, ok := n.(*ast.CreateSequenceStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.CreateSequenceStmt", n)
+	}
+	if s.Name.String() != "MySeq" || s.IfNotExists || len(s.Options) != 1 {
+		t.Errorf("got Name=%q ifne=%v opts=%d, want MySeq/false/1", s.Name.String(), s.IfNotExists, len(s.Options))
+	}
+}
+
+func TestCreateSequence_IfNotExistsNoOptions(t *testing.T) {
+	n := parseDDL(t, "CREATE SEQUENCE IF NOT EXISTS s")
+	s := n.(*ast.CreateSequenceStmt)
+	if !s.IfNotExists || len(s.Options) != 0 {
+		t.Errorf("got ifne=%v opts=%d, want true/0", s.IfNotExists, len(s.Options))
+	}
+}
+
+func TestCreateSequence_Schema(t *testing.T) {
+	n := parseDDL(t, "CREATE SEQUENCE myschema.MySeq")
+	s := n.(*ast.CreateSequenceStmt)
+	if s.Name.String() != "myschema.MySeq" {
+		t.Errorf("Name = %q, want myschema.MySeq", s.Name.String())
+	}
+}
+
+func TestAlterSequence(t *testing.T) {
+	n := parseDDL(t, "ALTER SEQUENCE MySeq SET OPTIONS (start_with_counter = 9000)")
+	a, ok := n.(*ast.AlterSequenceStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.AlterSequenceStmt", n)
+	}
+	if a.IfExists || len(a.SetOptions) != 1 {
+		t.Errorf("got ife=%v opts=%d, want false/1", a.IfExists, len(a.SetOptions))
+	}
+}
+
+func TestAlterSequence_IfExists(t *testing.T) {
+	n := parseDDL(t, "ALTER SEQUENCE IF EXISTS s SET OPTIONS (x = 1)")
+	a := n.(*ast.AlterSequenceStmt)
+	if !a.IfExists {
+		t.Errorf("IfExists = false, want true")
+	}
+}
+
+func TestDropSequence(t *testing.T) {
+	n := parseDDL(t, "DROP SEQUENCE MySeq")
+	d, ok := n.(*ast.DropSequenceStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.DropSequenceStmt", n)
+	}
+	if d.IfExists {
+		t.Errorf("IfExists = true, want false")
+	}
+}
+
+func TestDropSequence_IfExists(t *testing.T) {
+	n := parseDDL(t, "DROP SEQUENCE IF EXISTS MySeq")
+	d := n.(*ast.DropSequenceStmt)
+	if !d.IfExists {
+		t.Errorf("IfExists = false, want true")
+	}
+}
+
+// --- ROLE ---
+
+func TestCreateRole(t *testing.T) {
+	n := parseDDL(t, "CREATE ROLE analyst")
+	r, ok := n.(*ast.CreateRoleStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.CreateRoleStmt", n)
+	}
+	if r.Name.String() != "analyst" {
+		t.Errorf("Name = %q, want analyst", r.Name.String())
+	}
+}
+
+func TestCreateRole_BacktickName(t *testing.T) {
+	// A backtick-quoted name is a SINGLE identifier token (its body may contain a
+	// dot); accepted, unlike an unquoted dotted name.
+	n := parseDDL(t, "CREATE ROLE `dotted.name`")
+	r := n.(*ast.CreateRoleStmt)
+	if r.Name.String() != "dotted.name" || len(r.Name.Parts) != 1 {
+		t.Errorf("Name = %+v, want single part 'dotted.name'", r.Name.Parts)
+	}
+}
+
+func TestDropRole(t *testing.T) {
+	n := parseDDL(t, "DROP ROLE analyst")
+	r, ok := n.(*ast.DropRoleStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.DropRoleStmt", n)
+	}
+	if r.Name.String() != "analyst" {
+		t.Errorf("Name = %q, want analyst", r.Name.String())
+	}
+}
+
+func TestDropRole_DottedPathAccepted(t *testing.T) {
+	// DROP ROLE accepts a dotted path (emulator-verified), unlike CREATE ROLE.
+	n := parseDDL(t, "DROP ROLE a.b.c")
+	r := n.(*ast.DropRoleStmt)
+	if r.Name.String() != "a.b.c" {
+		t.Errorf("Name = %q, want a.b.c", r.Name.String())
+	}
+}
+
+// --- LOCALITY GROUP ---
+
+func TestCreateLocalityGroup(t *testing.T) {
+	n := parseDDL(t, "CREATE LOCALITY GROUP hot_data OPTIONS (storage = 'ssd')")
+	lg, ok := n.(*ast.CreateLocalityGroupStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.CreateLocalityGroupStmt", n)
+	}
+	if lg.Name.String() != "hot_data" || len(lg.Options) != 1 {
+		t.Errorf("got Name=%q opts=%d, want hot_data/1", lg.Name.String(), len(lg.Options))
+	}
+}
+
+func TestCreateLocalityGroup_MultiOption(t *testing.T) {
+	n := parseDDL(t, "CREATE LOCALITY GROUP cold_data OPTIONS (storage = 'hdd', ssd_to_hdd_spill_timespan = '30d')")
+	lg := n.(*ast.CreateLocalityGroupStmt)
+	if len(lg.Options) != 2 {
+		t.Errorf("Options = %d, want 2", len(lg.Options))
+	}
+}
+
+func TestAlterLocalityGroup(t *testing.T) {
+	n := parseDDL(t, "ALTER LOCALITY GROUP cold_data SET OPTIONS (ssd_to_hdd_spill_timespan = '14d')")
+	a, ok := n.(*ast.AlterLocalityGroupStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.AlterLocalityGroupStmt", n)
+	}
+	if len(a.SetOptions) != 1 {
+		t.Errorf("SetOptions = %d, want 1", len(a.SetOptions))
+	}
+}
+
+func TestAlterLocalityGroup_NoSetOptions(t *testing.T) {
+	// The SET OPTIONS clause is optional for ALTER LOCALITY GROUP (emulator accepts
+	// a bare form — unlike ALTER SEQUENCE / ALTER CHANGE STREAM).
+	n := parseDDL(t, "ALTER LOCALITY GROUP g")
+	a := n.(*ast.AlterLocalityGroupStmt)
+	if len(a.SetOptions) != 0 {
+		t.Errorf("SetOptions = %d, want 0", len(a.SetOptions))
+	}
+}
+
+func TestDropLocalityGroup(t *testing.T) {
+	n := parseDDL(t, "DROP LOCALITY GROUP cold_data")
+	d, ok := n.(*ast.DropLocalityGroupStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.DropLocalityGroupStmt", n)
+	}
+	if d.Name.String() != "cold_data" {
+		t.Errorf("Name = %q, want cold_data", d.Name.String())
+	}
+}
+
+// --- PROTO BUNDLE ---
+
+func TestCreateProtoBundle(t *testing.T) {
+	n := parseDDL(t, "CREATE PROTO BUNDLE (`my.package.MyMessage`, `my.package.AnotherMessage`)")
+	b, ok := n.(*ast.CreateProtoBundleStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.CreateProtoBundleStmt", n)
+	}
+	if len(b.Types) != 2 {
+		t.Fatalf("Types = %d, want 2", len(b.Types))
+	}
+	if b.Types[0].String() != "my.package.MyMessage" {
+		t.Errorf("Types[0] = %q, want my.package.MyMessage", b.Types[0].String())
+	}
+}
+
+func TestAlterProtoBundle_Insert(t *testing.T) {
+	n := parseDDL(t, "ALTER PROTO BUNDLE INSERT (`my.package.NewMessage`)")
+	a, ok := n.(*ast.AlterProtoBundleStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.AlterProtoBundleStmt", n)
+	}
+	if len(a.Insert) != 1 || len(a.Update) != 0 || len(a.Delete) != 0 {
+		t.Errorf("got insert=%d update=%d delete=%d, want 1/0/0", len(a.Insert), len(a.Update), len(a.Delete))
+	}
+}
+
+func TestAlterProtoBundle_Combo(t *testing.T) {
+	// All three groups, fixed order INSERT→UPDATE→DELETE, space-separated.
+	n := parseDDL(t, "ALTER PROTO BUNDLE INSERT (`a.B`) UPDATE (`c.D`) DELETE (`e.F`)")
+	a := n.(*ast.AlterProtoBundleStmt)
+	if len(a.Insert) != 1 || len(a.Update) != 1 || len(a.Delete) != 1 {
+		t.Errorf("got insert=%d update=%d delete=%d, want 1/1/1", len(a.Insert), len(a.Update), len(a.Delete))
+	}
+}
+
+func TestAlterProtoBundle_DeleteMultiType(t *testing.T) {
+	n := parseDDL(t, "ALTER PROTO BUNDLE DELETE (`a.B`, `c.D`)")
+	a := n.(*ast.AlterProtoBundleStmt)
+	if len(a.Delete) != 2 || len(a.Insert) != 0 {
+		t.Errorf("got insert=%d delete=%d, want 0/2", len(a.Insert), len(a.Delete))
+	}
+}
+
+// TestProtoBundle_TrailingComma guards the emulator-verified leniency: a PROTO
+// BUNDLE type list ALLOWS a trailing comma (unlike a change-stream column list).
+func TestProtoBundle_TrailingComma(t *testing.T) {
+	b := parseDDL(t, "CREATE PROTO BUNDLE (`a.b.C`, `a.b.D`,)").(*ast.CreateProtoBundleStmt)
+	if len(b.Types) != 2 {
+		t.Errorf("CREATE Types = %d, want 2 (trailing comma allowed)", len(b.Types))
+	}
+	a := parseDDL(t, "ALTER PROTO BUNDLE INSERT (`a.b.C`,)").(*ast.AlterProtoBundleStmt)
+	if len(a.Insert) != 1 {
+		t.Errorf("ALTER Insert = %d, want 1 (trailing comma allowed)", len(a.Insert))
+	}
+	// An empty list (just `()`) still rejects (trailing comma needs a prior entry).
+	assertReject(t, "CREATE PROTO BUNDLE ()")
+	assertReject(t, "CREATE PROTO BUNDLE (,)")
+}
+
+// TestAlterProtoBundle_OrderingRejects guards the strict grammar: groups must be
+// space-separated (no commas), at most once each, in INSERT→UPDATE→DELETE order.
+func TestAlterProtoBundle_OrderingRejects(t *testing.T) {
+	for _, sql := range []string{
+		"ALTER PROTO BUNDLE INSERT (`a.B`), UPDATE (`c.D`)", // comma between groups
+		"ALTER PROTO BUNDLE INSERT (`a.B`) INSERT (`c.D`)",  // repeated group
+		"ALTER PROTO BUNDLE UPDATE (`a.B`) INSERT (`c.D`)",  // out of order
+	} {
+		assertReject(t, sql)
+	}
+}
+
+// --- role-based GRANT / REVOKE (Spanner) ---
+
+func TestGrant_ToRole(t *testing.T) {
+	n := parseDDL(t, "GRANT SELECT ON TABLE Singers TO ROLE analyst")
+	g, ok := n.(*ast.GrantStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.GrantStmt", n)
+	}
+	if len(g.Privileges) != 1 || g.Privileges[0].Name != "SELECT" {
+		t.Errorf("Privileges = %+v, want [SELECT]", g.Privileges)
+	}
+	if len(g.ObjectType) != 1 || g.ObjectType[0] != "TABLE" {
+		t.Errorf("ObjectType = %v, want [TABLE]", g.ObjectType)
+	}
+	if g.Path.String() != "Singers" {
+		t.Errorf("Path = %q, want Singers", g.Path.String())
+	}
+	if len(g.Grantees) != 1 || g.Grantees[0].Kind != ast.GranteeRole || g.Grantees[0].Value != "analyst" {
+		t.Errorf("Grantees = %+v, want [ROLE analyst]", g.Grantees)
+	}
+}
+
+func TestGrant_ToRoleList(t *testing.T) {
+	n := parseDDL(t, "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE Albums TO ROLE editor, admin")
+	g := n.(*ast.GrantStmt)
+	if len(g.Privileges) != 4 {
+		t.Errorf("Privileges = %d, want 4", len(g.Privileges))
+	}
+	if len(g.Grantees) != 2 || g.Grantees[0].Value != "editor" || g.Grantees[1].Value != "admin" {
+		t.Errorf("Grantees = %+v, want [editor admin]", g.Grantees)
+	}
+	for i, gr := range g.Grantees {
+		if gr.Kind != ast.GranteeRole {
+			t.Errorf("Grantees[%d].Kind = %v, want ROLE", i, gr.Kind)
+		}
+	}
+}
+
+func TestGrant_ColumnLevelToRole(t *testing.T) {
+	// Column-level privilege (DDL-034). The emulator rejects this ("does not yet
+	// support column level access controls"), but it is valid GoogleSQL/Spanner
+	// per the docs — the union parser accepts it (divergence #flagged).
+	n := parseDDL(t, "GRANT SELECT(SingerId, FirstName) ON TABLE Singers TO ROLE read_only")
+	g := n.(*ast.GrantStmt)
+	if len(g.Privileges) != 1 || len(g.Privileges[0].Columns) != 2 {
+		t.Errorf("Privileges = %+v, want SELECT with 2 columns", g.Privileges)
+	}
+	if g.Grantees[0].Kind != ast.GranteeRole {
+		t.Errorf("Grantee kind = %v, want ROLE", g.Grantees[0].Kind)
+	}
+}
+
+func TestGrant_ExecuteTableFunctionToRole(t *testing.T) {
+	n := parseDDL(t, "GRANT EXECUTE ON TABLE FUNCTION get_singers TO ROLE analyst")
+	g := n.(*ast.GrantStmt)
+	if len(g.ObjectType) != 2 || g.ObjectType[0] != "TABLE" || g.ObjectType[1] != "FUNCTION" {
+		t.Errorf("ObjectType = %v, want [TABLE FUNCTION]", g.ObjectType)
+	}
+}
+
+func TestGrant_RoleToRole(t *testing.T) {
+	n := parseDDL(t, "GRANT ROLE analyst TO ROLE senior_analyst")
+	g, ok := n.(*ast.GrantStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.GrantStmt", n)
+	}
+	if len(g.Roles) != 1 || g.Roles[0].String() != "analyst" {
+		t.Errorf("Roles = %+v, want [analyst]", g.Roles)
+	}
+	if len(g.Grantees) != 1 || g.Grantees[0].Kind != ast.GranteeRole || g.Grantees[0].Value != "senior_analyst" {
+		t.Errorf("Grantees = %+v, want [ROLE senior_analyst]", g.Grantees)
+	}
+	if g.Privileges != nil || g.AllPrivileges {
+		t.Errorf("role-grant must carry no privileges (privs=%v all=%v)", g.Privileges, g.AllPrivileges)
+	}
+}
+
+func TestGrant_RoleListToRoleList(t *testing.T) {
+	n := parseDDL(t, "GRANT ROLE a, b TO ROLE c, d")
+	g := n.(*ast.GrantStmt)
+	if len(g.Roles) != 2 || g.Roles[0].String() != "a" || g.Roles[1].String() != "b" {
+		t.Errorf("Roles = %+v, want [a b]", g.Roles)
+	}
+	if len(g.Grantees) != 2 {
+		t.Errorf("Grantees = %d, want 2", len(g.Grantees))
+	}
+}
+
+func TestRevoke_FromRole(t *testing.T) {
+	n := parseDDL(t, "REVOKE SELECT ON TABLE Singers FROM ROLE analyst")
+	r, ok := n.(*ast.RevokeStmt)
+	if !ok {
+		t.Fatalf("statement is %T, want *ast.RevokeStmt", n)
+	}
+	if len(r.Grantees) != 1 || r.Grantees[0].Kind != ast.GranteeRole || r.Grantees[0].Value != "analyst" {
+		t.Errorf("Grantees = %+v, want [ROLE analyst]", r.Grantees)
+	}
+}
+
+func TestRevoke_RoleFromRole(t *testing.T) {
+	n := parseDDL(t, "REVOKE ROLE analyst FROM ROLE senior_analyst")
+	r := n.(*ast.RevokeStmt)
+	if len(r.Roles) != 1 || r.Roles[0].String() != "analyst" {
+		t.Errorf("Roles = %+v, want [analyst]", r.Roles)
+	}
+	if len(r.Grantees) != 1 || r.Grantees[0].Kind != ast.GranteeRole {
+		t.Errorf("Grantees = %+v, want [ROLE senior_analyst]", r.Grantees)
+	}
+}
+
+// Regression: the legacy ZetaSQL string-grantee GRANT must STILL parse (the
+// union parser serves both dialects). This guards the parser-dcl behavior.
+func TestGrant_LegacyStringGranteeStillWorks(t *testing.T) {
+	n := parseDDL(t, "GRANT SELECT ON TABLE foo TO 'user@google.com'")
+	g := n.(*ast.GrantStmt)
+	if len(g.Grantees) != 1 || g.Grantees[0].Kind != ast.GranteeString || g.Grantees[0].Value != "user@google.com" {
+		t.Errorf("Grantees = %+v, want [STRING user@google.com]", g.Grantees)
+	}
+}
+
+// TestGrant_PrivilegeNamedRole guards the role-grant disambiguation: `GRANT ROLE
+// ON …` is a LEGACY privilege grant whose privilege is named "ROLE"
+// (privilege_name: identifier), NOT a Spanner role-to-role grant. The union must
+// accept it (the emulator rejects it as a Spanner form — non-authoritative there).
+// Discovered by the cross-model (Codex) review.
+func TestGrant_PrivilegeNamedRole(t *testing.T) {
+	n := parseDDL(t, "GRANT ROLE ON TABLE foo TO 'x'")
+	g := n.(*ast.GrantStmt)
+	if len(g.Roles) != 0 {
+		t.Errorf("Roles = %v, want empty (this is a privilege grant, not role-to-role)", g.Roles)
+	}
+	if len(g.Privileges) != 1 || g.Privileges[0].Name != "ROLE" {
+		t.Errorf("Privileges = %+v, want [ROLE]", g.Privileges)
+	}
+	if len(g.ObjectType) != 1 || g.ObjectType[0] != "TABLE" {
+		t.Errorf("ObjectType = %v, want [TABLE]", g.ObjectType)
+	}
+	// `GRANT ROLE, SELECT ON …` (ROLE as the first privilege in a list).
+	g2 := parseDDL(t, "GRANT ROLE, SELECT ON TABLE foo TO 'x'").(*ast.GrantStmt)
+	if len(g2.Privileges) != 2 || g2.Privileges[0].Name != "ROLE" {
+		t.Errorf("Privileges = %+v, want [ROLE SELECT]", g2.Privileges)
+	}
+}
+
+// TestGrant_CommaSeparatedObjects guards the Spanner comma-separated object list
+// (`ON TABLE t1, t2 TO ROLE r`). Discovered by the cross-model (Codex) review.
+func TestGrant_CommaSeparatedObjects(t *testing.T) {
+	g := parseDDL(t, "GRANT SELECT ON TABLE t1, t2, t3 TO ROLE r").(*ast.GrantStmt)
+	if len(g.Paths) != 3 {
+		t.Fatalf("Paths = %d, want 3", len(g.Paths))
+	}
+	if g.Paths[0].String() != "t1" || g.Paths[2].String() != "t3" {
+		t.Errorf("Paths = %v, want [t1 t2 t3]", g.Paths)
+	}
+	if g.Path.String() != "t1" {
+		t.Errorf("Path = %q, want t1 (== Paths[0])", g.Path.String())
+	}
+	if len(g.ObjectType) != 1 || g.ObjectType[0] != "TABLE" {
+		t.Errorf("ObjectType = %v, want [TABLE]", g.ObjectType)
+	}
+	// REVOKE comma objects.
+	r := parseDDL(t, "REVOKE SELECT ON TABLE t1, t2 FROM ROLE r").(*ast.RevokeStmt)
+	if len(r.Paths) != 2 {
+		t.Errorf("revoke Paths = %d, want 2", len(r.Paths))
+	}
+	// VIEW object type with a comma list.
+	g3 := parseDDL(t, "GRANT SELECT ON VIEW v1, v2 TO ROLE r").(*ast.GrantStmt)
+	if len(g3.ObjectType) != 1 || g3.ObjectType[0] != "VIEW" || len(g3.Paths) != 2 {
+		t.Errorf("ObjectType=%v Paths=%v, want [VIEW] + 2 paths", g3.ObjectType, g3.Paths)
+	}
+}
+
+// TestGrant_CommaObjectsRequireType guards that a comma-separated object list is
+// the Spanner form, which REQUIRES a leading object-type keyword: `ON foo, bar`
+// (no type) is invalid in BOTH dialects (Spanner needs target_type; legacy has no
+// multi-object). A single object with no type stays valid (legacy). Surfaced while
+// verifying the Codex comma-object finding against the oracle.
+func TestGrant_CommaObjectsRequireType(t *testing.T) {
+	// No type + comma list rejects.
+	assertReject(t, "GRANT SELECT ON foo, bar TO ROLE r")
+	assertReject(t, "REVOKE SELECT ON foo, bar FROM ROLE r")
+	// Single object with no type still parses (legacy form).
+	g := parseDDL(t, "GRANT SELECT ON foo TO 'x'").(*ast.GrantStmt)
+	if len(g.ObjectType) != 0 || len(g.Paths) != 1 || g.Paths[0].String() != "foo" {
+		t.Errorf("ObjectType=%v Paths=%v, want no type + [foo]", g.ObjectType, g.Paths)
+	}
+}
+
+// TestGrant_RoleTargetStrict guards that a role-to-role grant/revoke REQUIRES a
+// ROLE target (the emulator rejects a string/parameter target). Discovered by the
+// cross-model (Codex) review.
+func TestGrant_RoleTargetStrict(t *testing.T) {
+	for _, sql := range []string{
+		"GRANT ROLE analyst TO 'user'",       // string target
+		"GRANT ROLE analyst TO @p",           // parameter target
+		"REVOKE ROLE analyst FROM 'user'",    // string target (revoke)
+		"GRANT ROLE a, b TO ROLE c, 'x'",     // mixed role + string target
+	} {
+		assertReject(t, sql)
+	}
+}
+
+// --- owned divergence regressions ---
+
+// TestInterleave_OnDeleteOptional is the permanent regression for divergence
+// #112: a Spanner `INTERLEAVE IN PARENT p` with NO `ON DELETE` action must parse
+// (defaulting to NO ACTION), matching the live emulator. The original parser-ddl
+// port wrongly REQUIRED `ON DELETE`, over-rejecting the documented default form
+// (DDL-007). A dangling `ON DELETE` (keyword present, no action) still rejects.
+func TestInterleave_OnDeleteOptional(t *testing.T) {
+	ct := createTableOf(t, "CREATE TABLE child (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT parent")
+	if ct.Interleave == nil || ct.Interleave.Parent.String() != "parent" {
+		t.Fatalf("Interleave = %+v, want parent", ct.Interleave)
+	}
+	if ct.Interleave.OnDelete != ast.FKActionNone {
+		t.Errorf("OnDelete = %v, want FKActionNone (no action specified)", ct.Interleave.OnDelete)
+	}
+	// Explicit actions still parse.
+	ct2 := createTableOf(t, "CREATE TABLE c (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT p ON DELETE CASCADE")
+	if ct2.Interleave.OnDelete != ast.FKActionCascade {
+		t.Errorf("OnDelete = %v, want FKActionCascade", ct2.Interleave.OnDelete)
+	}
+	// A dangling `ON DELETE` with no action is still a syntax error.
+	assertReject(t, "CREATE TABLE c (id INT64) PRIMARY KEY (id), INTERLEAVE IN PARENT p ON DELETE")
+}
+
+// TestInlinePrimaryKey_Accepted is the regression for divergence #8: Spanner
+// accepts an inline column `PRIMARY KEY` (`id INT64 PRIMARY KEY`). The union
+// parser already accepts it (the BigQuery inline-PK production covers it); this
+// guards that the inline-PK form keeps parsing and matches the emulator.
+func TestInlinePrimaryKey_Accepted(t *testing.T) {
+	// Just assert it parses without error (shape covered by parser-ddl tests).
+	parseDDL(t, "CREATE TABLE tbl_inline (id INT64 PRIMARY KEY, name STRING(MAX))")
+}
+
+// --- negative tests (over-permissiveness guards) ---
+
+func TestSpannerDDL_Rejects(t *testing.T) {
+	for _, sql := range []string{
+		// CHANGE STREAM: a dangling FOR, a bad keyword, missing name.
+		"CREATE CHANGE STREAM",                  // missing name (+ at least nothing)
+		"CREATE CHANGE STREAM s FOR",            // FOR with nothing after
+		"CREATE CHANGE STREAM s FOR ALL ALL",    // trailing junk
+		"CREATE CHANGE STREAM s FOR Singers(a,)", // trailing comma in column list (NOT allowed, unlike proto)
+		"CREATE CHANGE STREAM s FOR Singers,",   // trailing comma in table list
+		"ALTER CHANGE STREAM s SET",             // SET with nothing
+		"ALTER CHANGE STREAM s DROP FOR",        // DROP FOR without ALL
+		"ALTER CHANGE STREAM s SET FOR",         // SET FOR with nothing
+		"DROP CHANGE STREAM",                    // missing name
+		// SEQUENCE
+		"ALTER SEQUENCE s",                      // missing SET OPTIONS
+		"ALTER SEQUENCE s SET",                  // SET with nothing
+		"CREATE SEQUENCE",                       // missing name
+		// ROLE
+		"CREATE ROLE",                           // missing name
+		"DROP ROLE",                             // missing name
+		// LOCALITY GROUP
+		"CREATE LOCALITY GROUP",                 // missing name
+		"ALTER LOCALITY GROUP g SET",            // SET with no OPTIONS
+		"ALTER LOCALITY GROUP g RENAME TO h",    // not a valid locality-group action
+		"DROP LOCALITY GROUP",                   // missing name
+		// PROTO BUNDLE
+		"CREATE PROTO BUNDLE",                   // missing ( )
+		"CREATE PROTO BUNDLE ()",                // empty bundle (grammar requires >=1)
+		"ALTER PROTO BUNDLE",                    // missing an action
+		"ALTER PROTO BUNDLE INSERT",             // INSERT with no ( )
+		// role GRANT/REVOKE
+		"GRANT ROLE a TO ROLE",                  // TO ROLE with no role
+		"GRANT SELECT ON TABLE t TO ROLE",       // TO ROLE with no role
+		"GRANT ROLE TO ROLE r",                  // GRANT ROLE with no role
+		"REVOKE ROLE a FROM ROLE",               // FROM ROLE with no role
+		// role names are SINGLE identifiers (emulator rejects dotted role names).
+		"CREATE ROLE a.b",                       // dotted CREATE ROLE name
+		"GRANT SELECT ON TABLE t TO ROLE a.b",   // dotted grantee role
+		"GRANT ROLE a.b TO ROLE c",              // dotted subject role
+		"GRANT SELECT ON TABLE t TO ROLE r1, r2.x", // dotted role in list
+		"REVOKE ROLE r1, r2.x FROM ROLE s",      // dotted role in revoke subject
+	} {
+		assertReject(t, sql)
+	}
+}

--- a/googlesql/parser/spanner_schema_role.go
+++ b/googlesql/parser/spanner_schema_role.go
@@ -1,0 +1,158 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Spanner DDL — ROLE + role-based GRANT/REVOKE (parser-ddl-spanner node)
+// ---------------------------------------------------------------------------
+//
+// Cloud Spanner fine-grained access control (truth1 DDL-032..037):
+//
+//	CREATE ROLE role_name
+//	DROP   ROLE role_name
+//	GRANT  privilege [, ...] ON { TABLE | VIEW | CHANGE STREAM | TABLE FUNCTION } name [, ...]
+//	         TO ROLE role_name [, ...]
+//	GRANT  ROLE role_name [, ...] TO ROLE role_name [, ...]
+//	REVOKE … FROM ROLE role_name [, ...]
+//	REVOKE ROLE role_name [, ...] FROM ROLE role_name [, ...]
+//
+// DIALECT NOTE — the legacy ANTLR grammar's grant_statement/revoke_statement
+// accept ONLY string-literal/parameter grantees (string_literal_or_parameter) and
+// have NO `ROLE` grantee, NO `GRANT ROLE` head, and NO CREATE/DROP ROLE rule, so
+// the legacy parser over-rejects the entire Spanner role surface. The omni parser
+// — whose authoritative oracle for Spanner DDL is the live emulator (oracle.md) —
+// accepts both dialects: the existing parser-dcl code (grant_revoke.go) still
+// handles the ZetaSQL string-grantee form, and the hooks here add the Spanner role
+// forms to that same union path. Verified ACCEPT/REJECT in
+// spanner_ddl_oracle_test.go; the emulator REJECTS a string grantee (`Expecting
+// 'ROLE'`) and ACCEPTS `TO ROLE name [, name]` / `GRANT ROLE …`.
+//
+// `ROLE` lexes as a bare (non-reserved) identifier, so it is matched by spelling.
+
+// parseCreateRole parses a CREATE ROLE body after the shared CREATE prefix. cur is
+// at `ROLE` (dispatcher confirmed). create_role takes no OR REPLACE / scope / IF
+// NOT EXISTS in the Spanner grammar.
+//
+// The role name is a SINGLE identifier, NOT a dotted path: the emulator REJECTS
+// `CREATE ROLE a.b` ("Expecting 'EOF' but found '.'"). A backtick-quoted name
+// (`\`dotted.name\``) is one identifier token and is accepted. (DROP ROLE, by
+// contrast, accepts a dotted path — see parseDropRole.)
+func (p *Parser) parseCreateRole(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if orReplace || scope != "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // ROLE
+
+	stmt := &ast.CreateRoleStmt{}
+	stmt.Loc.Start = create.Loc.Start
+
+	name, err := p.parseRoleName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseDropRole parses a DROP ROLE body. The DROP keyword has been consumed by
+// parseDropStmt; cur is at `ROLE` (dispatcher confirmed). No IF EXISTS in the
+// Spanner grammar.
+//
+// Unlike CREATE ROLE, the emulator ACCEPTS a dotted path here (`DROP ROLE a.b.c`
+// accepts), so parseTablePath (which folds dotted parts) is correct.
+func (p *Parser) parseDropRole(drop Token) (ast.Node, error) {
+	p.advance() // ROLE
+
+	stmt := &ast.DropRoleStmt{}
+	stmt.Loc.Start = drop.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseRoleName parses a single role-name identifier as a one-part *PathExpr. A
+// role name in CREATE ROLE / GRANT / REVOKE is a lone identifier (Spanner rejects
+// a dotted role name); a backtick-quoted name lands in a single part.
+func (p *Parser) parseRoleName() (*ast.PathExpr, error) {
+	tok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.PathExpr{Parts: []string{name}, Loc: tok.Loc}, nil
+}
+
+// curIsRoleKeyword reports whether cur is the bare-identifier `ROLE` word that
+// introduces a Spanner role grantee list / role-grant subject. (`ROLE` is not a
+// reserved token; the lexer emits it as tokIdentifier.)
+func (p *Parser) curIsRoleKeyword() bool {
+	return p.curIsWord("ROLE")
+}
+
+// atRoleToRoleGrant reports whether the head is a Spanner role-to-role
+// grant/revoke — `GRANT|REVOKE ROLE <role_name> …` — as opposed to a legacy
+// privilege grant whose first privilege happens to be named `ROLE`
+// (`GRANT ROLE ON …`, `GRANT ROLE, SELECT ON …`, `GRANT ROLE(cols) ON …`).
+//
+// The disambiguator: `ROLE` here lexes as a generic identifier, so it is BOTH a
+// valid privilege_name AND the role-list introducer. They are told apart by the
+// token AFTER `ROLE`: a role-to-role grant is `ROLE <role_name> …` where
+// role_name is an identifier; a privilege grant is `ROLE { ON | , | ( }`. So the
+// role-to-role form is exactly "ROLE followed by an identifier-start token". This
+// matches the live emulator, which REJECTS `GRANT ROLE ON …` (privilege ROLE is
+// not a Spanner privilege) yet the BigQuery/ZetaSQL UNION must still accept the
+// legacy `GRANT ROLE ON foo TO 'x'` (privilege_name: identifier), so the
+// role-to-role branch must NOT swallow it.
+func (p *Parser) atRoleToRoleGrant() bool {
+	return p.curIsRoleKeyword() && isIdentifierStart(p.peekNext().Type)
+}
+
+// parseRoleNameList parses `ROLE role_name (',' role_name)*` — a Spanner role list
+// introduced by a single `ROLE` keyword. cur must be at `ROLE`. Used for both the
+// GRANT/REVOKE grantee list (`TO ROLE r [, r]`) and the role-grant subject
+// (`GRANT ROLE r [, r] …`). Each role_name is a SINGLE identifier — the emulator
+// REJECTS a dotted role name (`TO ROLE r1, r2.x` and `GRANT ROLE r1, r2.x …` both
+// fail at the '.'). Returns the role names as one-part NamePaths.
+func (p *Parser) parseRoleNameList() ([]ast.NamePath, error) {
+	p.advance() // ROLE
+	var roles []ast.NamePath
+	for {
+		tok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		roles = append(roles, ast.NamePath{Parts: []string{name}, Loc: tok.Loc})
+		if _, ok := p.match(int(',')); ok {
+			continue
+		}
+		break
+	}
+	return roles, nil
+}
+
+// roleNamesToGrantees converts a Spanner role list into GranteeRole grantees (the
+// TO/FROM recipients of a GRANT/REVOKE).
+func roleNamesToGrantees(roles []ast.NamePath) []*ast.Grantee {
+	out := make([]*ast.Grantee, 0, len(roles))
+	for _, r := range roles {
+		out = append(out, &ast.Grantee{Kind: ast.GranteeRole, Value: r.String(), Loc: r.Loc})
+	}
+	return out
+}

--- a/googlesql/parser/spanner_sequence.go
+++ b/googlesql/parser/spanner_sequence.go
@@ -1,0 +1,374 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Spanner DDL — SEQUENCE + LOCALITY GROUP + PROTO BUNDLE (parser-ddl-spanner)
+// ---------------------------------------------------------------------------
+//
+// Cloud Spanner sequences / locality groups / proto bundles (truth1
+// DDL-027..029, 041..043, 046..047):
+//
+//	CREATE SEQUENCE [IF NOT EXISTS] name [OPTIONS ( … )]
+//	ALTER  SEQUENCE [IF EXISTS] name SET OPTIONS ( … )
+//	DROP   SEQUENCE [IF EXISTS] name
+//
+//	CREATE LOCALITY GROUP name [OPTIONS ( … )]
+//	ALTER  LOCALITY GROUP name SET OPTIONS ( … )
+//	DROP   LOCALITY GROUP name
+//
+//	CREATE PROTO BUNDLE ( proto_type_name [, ...] )
+//	ALTER  PROTO BUNDLE { INSERT ( … ) | UPDATE ( … ) | DELETE ( … ) } [, ...]
+//
+// DIALECT NOTE — like CHANGE STREAM, none of these is a first-class rule in the
+// legacy ANTLR grammar; the omni parser models them directly. The authoritative
+// oracle is the live Cloud Spanner emulator, which ACCEPTS each form
+// (spanner_ddl_oracle_test.go). `SEQUENCE` is a (non-reserved) keyword token;
+// `LOCALITY` lexes as a bare identifier and `GROUP` as a reserved keyword, so the
+// dispatcher recognizes LOCALITY by spelling; `PROTO` is a reserved keyword and
+// `BUNDLE` a bare identifier.
+
+// --- SEQUENCE ---
+
+// parseCreateSequence parses a CREATE SEQUENCE body after the shared CREATE prefix.
+// cur is at the SEQUENCE keyword. create_sequence has no opt_or_replace /
+// opt_create_scope, so a leading OR REPLACE / scope rejects.
+func (p *Parser) parseCreateSequence(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if orReplace || scope != "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // SEQUENCE
+
+	stmt := &ast.CreateSequenceStmt{}
+	stmt.Loc.Start = create.Loc.Start
+
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterSequence parses an ALTER SEQUENCE body. The ALTER keyword has been
+// consumed by parseAlterStmt; cur is at the SEQUENCE keyword.
+func (p *Parser) parseAlterSequence(alter Token) (ast.Node, error) {
+	p.advance() // SEQUENCE
+
+	stmt := &ast.AlterSequenceStmt{}
+	stmt.Loc.Start = alter.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// SET OPTIONS ( … ) is the only ALTER SEQUENCE action.
+	if _, err := p.expect(kwSET); err != nil {
+		return nil, err
+	}
+	if p.cur.Type != kwOPTIONS {
+		return nil, p.syntaxErrorAtCur()
+	}
+	opts, err := p.parseOptionsList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.SetOptions = opts
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseDropSequence parses a DROP SEQUENCE body. The DROP keyword has been
+// consumed by parseDropStmt; cur is at the SEQUENCE keyword.
+func (p *Parser) parseDropSequence(drop Token) (ast.Node, error) {
+	p.advance() // SEQUENCE
+
+	stmt := &ast.DropSequenceStmt{}
+	stmt.Loc.Start = drop.Loc.Start
+
+	ifExists, err := p.parseIfExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfExists = ifExists
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// --- LOCALITY GROUP ---
+
+// parseCreateLocalityGroup parses a CREATE LOCALITY GROUP body after the shared
+// CREATE prefix. cur is at `LOCALITY` (dispatcher confirmed `LOCALITY GROUP`).
+func (p *Parser) parseCreateLocalityGroup(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if orReplace || scope != "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // LOCALITY
+	p.advance() // GROUP
+
+	stmt := &ast.CreateLocalityGroupStmt{}
+	stmt.Loc.Start = create.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterLocalityGroup parses an ALTER LOCALITY GROUP body. The ALTER keyword
+// has been consumed; cur is at `LOCALITY` (dispatcher confirmed `LOCALITY GROUP`).
+//
+// The `SET OPTIONS ( … )` clause is OPTIONAL: the live emulator ACCEPTS a bare
+// `ALTER LOCALITY GROUP name` (verdict accept, semantic "Locality group not
+// found"), unlike ALTER SEQUENCE / ALTER CHANGE STREAM whose action is required
+// (those REJECT a bare form). When present, the clause must be `SET OPTIONS` (a
+// `SET` with no `OPTIONS`, or any other trailing token, REJECTS — emulator-
+// verified). See spanner_ddl_oracle_test.go.
+func (p *Parser) parseAlterLocalityGroup(alter Token) (ast.Node, error) {
+	p.advance() // LOCALITY
+	p.advance() // GROUP
+
+	stmt := &ast.AlterLocalityGroupStmt{}
+	stmt.Loc.Start = alter.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional SET OPTIONS ( … ).
+	if p.cur.Type == kwSET {
+		p.advance() // SET
+		if p.cur.Type != kwOPTIONS {
+			return nil, p.syntaxErrorAtCur()
+		}
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.SetOptions = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseDropLocalityGroup parses a DROP LOCALITY GROUP body. The DROP keyword has
+// been consumed; cur is at `LOCALITY` (dispatcher confirmed `LOCALITY GROUP`).
+func (p *Parser) parseDropLocalityGroup(drop Token) (ast.Node, error) {
+	p.advance() // LOCALITY
+	p.advance() // GROUP
+
+	stmt := &ast.DropLocalityGroupStmt{}
+	stmt.Loc.Start = drop.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// --- PROTO BUNDLE ---
+
+// parseCreateProtoBundle parses a CREATE PROTO BUNDLE body after the shared CREATE
+// prefix. cur is at the PROTO keyword (dispatcher confirmed `PROTO BUNDLE`).
+// create_proto_bundle has no opt_or_replace / opt_create_scope.
+func (p *Parser) parseCreateProtoBundle(create Token, orReplace bool, scope string) (ast.Node, error) {
+	if orReplace || scope != "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // PROTO
+	p.advance() // BUNDLE
+
+	stmt := &ast.CreateProtoBundleStmt{}
+	stmt.Loc.Start = create.Loc.Start
+
+	// `( proto_type_name [, ...] )` — at least one type (an empty bundle rejects).
+	types, err := p.parseProtoTypeNameListWithParens()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Types = types
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterProtoBundle parses an ALTER PROTO BUNDLE body. The ALTER keyword has
+// been consumed; cur is at the PROTO keyword (dispatcher confirmed `PROTO
+// BUNDLE`).
+//
+//	ALTER PROTO BUNDLE [INSERT ( … )] [UPDATE ( … )] [DELETE ( … )]
+//
+// The three groups are OPTIONAL, appear AT MOST ONCE EACH, in the FIXED order
+// INSERT → UPDATE → DELETE, SPACE-separated (NO commas between groups), and at
+// least one must be present. This is exactly the emulator's grammar (verified in
+// spanner_ddl_oracle_test.go): a repeated group (`INSERT (…) INSERT (…)`), an
+// out-of-order group (`UPDATE (…) INSERT (…)`), and a comma between groups
+// (`INSERT (…), UPDATE (…)`) all REJECT — so a naive "any order, any repeat,
+// optional comma" loop would be over-permissive.
+func (p *Parser) parseAlterProtoBundle(alter Token) (ast.Node, error) {
+	p.advance() // PROTO
+	p.advance() // BUNDLE
+
+	stmt := &ast.AlterProtoBundleStmt{}
+	stmt.Loc.Start = alter.Loc.Start
+
+	seen := false
+	// INSERT ( … )?
+	if p.cur.Type == kwINSERT {
+		p.advance()
+		types, err := p.parseProtoTypeNameListWithParens()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Insert = types
+		seen = true
+	}
+	// UPDATE ( … )?
+	if p.cur.Type == kwUPDATE {
+		p.advance()
+		types, err := p.parseProtoTypeNameListWithParens()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Update = types
+		seen = true
+	}
+	// DELETE ( … )?
+	if p.cur.Type == kwDELETE {
+		p.advance()
+		types, err := p.parseProtoTypeNameListWithParens()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Delete = types
+		seen = true
+	}
+	if !seen {
+		// No INSERT/UPDATE/DELETE group at all — the grammar requires at least one.
+		// (Also catches an out-of-order or comma-separated group: a leading UPDATE/
+		// DELETE is consumed above, but a later out-of-order INSERT / a stray comma
+		// is left for parseSingle's EOF check to reject.)
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseProtoTypeNameListWithParens parses `'(' proto_type_name (',' proto_type_name)* ','? ')'`
+// where each proto_type_name is a (typically backtick-quoted) dotted path. cur is
+// at '('. Requires at least one type name (an empty `()` rejects), but a TRAILING
+// comma is allowed: the emulator ACCEPTS `CREATE PROTO BUNDLE (\`a.B\`,)` and
+// `ALTER PROTO BUNDLE INSERT (\`a.B\`,)` (unlike a change-stream column list, which
+// rejects a trailing comma). Verified in spanner_ddl_oracle_test.go.
+func (p *Parser) parseProtoTypeNameListWithParens() ([]ast.NamePath, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	var types []ast.NamePath
+	for {
+		path, err := p.parseProtoTypeName()
+		if err != nil {
+			return nil, err
+		}
+		types = append(types, path)
+		if _, ok := p.match(int(',')); !ok {
+			break
+		}
+		// A comma was consumed; a closing ')' here is a permitted trailing comma.
+		if p.cur.Type == int(')') {
+			break
+		}
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return types, nil
+}
+
+// parseProtoTypeName parses one proto_type_name: a dotted name `identifier ('.'
+// identifier)*`. A backtick-quoted name (the common `\`my.package.Msg\`` form) is
+// a single identifier whose Str already holds the dotted body, so it lands in one
+// part; an unquoted dotted name spreads across parts.
+func (p *Parser) parseProtoTypeName() (ast.NamePath, error) {
+	if !isIdentifierStart(p.cur.Type) {
+		return ast.NamePath{}, p.syntaxErrorAtCur()
+	}
+	start := p.cur.Loc
+	first := p.advance()
+	firstText, err := p.identifierText(first)
+	if err != nil {
+		return ast.NamePath{}, err
+	}
+	parts := []string{firstText}
+	end := first.Loc
+
+	for p.cur.Type == int('.') {
+		if !isAnyKeywordIdentifier(p.peekNext().Type) {
+			break
+		}
+		p.advance() // '.'
+		next := p.advance()
+		text, err := p.identifierText(next)
+		if err != nil {
+			return ast.NamePath{}, err
+		}
+		parts = append(parts, text)
+		end = next.Loc
+	}
+
+	return ast.NamePath{Parts: parts, Loc: ast.Loc{Start: start.Start, End: end.End}}, nil
+}


### PR DESCRIPTION
## Node: `googlesql/parser-ddl-spanner`

Spanner-specific object DDL that the legacy ANTLR `GoogleSQLParser.g4` has **no first-class rule** for — it models CHANGE STREAM / ROLE / LOCALITY GROUP on the generic-entity hook (which can't express the two-word object type + clauses) and `grant_statement`/`revoke_statement` accept only string-literal grantees. The omni parser, whose authoritative oracle for Spanner DDL is the **live Cloud Spanner emulator** ([oracle.md](../blob/main/docs/migration/googlesql/oracle.md)), parses each as a dedicated statement so bytebase's Spanner consumers (Diagnose / GetQuerySpan / SplitSQL) see a real tree instead of a false syntax error.

### Forms implemented (all emulator-accept-verified)
| Object | Forms | truth1 |
|---|---|---|
| CHANGE STREAM | CREATE (`FOR ALL` / `FOR table_and_column [,…]` / OPTIONS), ALTER (`SET FOR`/`DROP FOR ALL`/`SET OPTIONS`), DROP | DDL-024/025/026 |
| SEQUENCE | CREATE `[IF NOT EXISTS]` `[OPTIONS]`, ALTER `[IF EXISTS] SET OPTIONS`, DROP `[IF EXISTS]` | DDL-027/028/029 |
| ROLE | CREATE ROLE, DROP ROLE | DDL-032/033 |
| role GRANT/REVOKE | `… TO/FROM ROLE r [,…]`, `GRANT/REVOKE ROLE r [,…] TO/FROM ROLE r [,…]`, comma-separated object lists `ON TABLE t1, t2 TO ROLE r` | DDL-034-037 |
| LOCALITY GROUP | CREATE `[OPTIONS]`, ALTER `[SET OPTIONS]` (optional), DROP | DDL-041/042/043 |
| PROTO BUNDLE | CREATE `( type [,…] )`, ALTER `INSERT?/UPDATE?/DELETE?` (fixed order) | DDL-046/047 |

### Design
- New AST nodes in `ast/parsenodes.go` (+ tags in `nodetags.go`, regenerated `walk_generated.go`). The role surface reuses the shared `GrantStmt`/`RevokeStmt` via a new `GranteeRole` grantee kind + `Roles`/`Paths` fields, so **one union parser** serves both the legacy ZetaSQL string-grantee dialect AND the Spanner role dialect.
- New parsers: `spanner_change_stream.go`, `spanner_sequence.go` (sequence + locality group + proto bundle), `spanner_schema_role.go` (role + role-grant helpers).
- Dispatch wired in `create_table.go` / `alter_table.go` / `drop.go` (`CHANGE`/`LOCALITY` are bare identifiers matched by spelling; `SEQUENCE`/`PROTO` are keywords) and `grant_revoke.go` (role-grant disambiguation + comma-object head). `analysis/classify.go` now classifies the new nodes as `DDL`.

### Proof — differential vs the live emulator (PROVE gate)
`spanner_ddl_oracle_test.go` runs **81 fixtures, both polarities** (accept AND reject) through the emulator via the `harness/googlesql-spanner` oracle and asserts omni's verdict matches. Run:
```
SPANNER_EMULATOR_HOST=localhost:9010 go test -tags googlesql_oracle ./googlesql/parser/ -run TestSpannerDDLDifferential
```
`go test ./googlesql/{parser,ast,analysis}/` green; `go vet` clean. Dialect-divergent forms (legacy ZetaSQL string-grantee GRANT, empty `OPTIONS ()`, object-named-keyword, no-type-keyword role grant) are EXCLUDED from the Spanner differential (emulator non-authoritative for the BigQuery/union dialect) and covered by unit tests instead.

### Owned divergences
- **#112 closed** — `INTERLEAVE IN PARENT … ON DELETE` made **optional** in `create_table.go` (defaults to NO ACTION per DDL-007); the original port over-rejected the documented default and the emulator-accepted `INTERLEAVE IN PARENT p`. A dangling `ON DELETE` still rejects.
- **#8 closed** — inline column `PRIMARY KEY` already accepted by the union parser (matches emulator); guarded by a regression test.
- **#128 flagged** — column-level GRANT (`GRANT SELECT(cols) … TO ROLE`): valid GoogleSQL (DDL-034) but the emulator rejects with "does not yet support column level access controls" (an emulator limitation, non-authoritative); the union parser accepts per docs.
- **flagged** — the central "Spanner object DDL is first-class, not generic-entity / role grantees not in legacy" dialect divergence (oracle + grammar-source evidence in the ledger).

### Review
Two-reviewer gate. The **Codex lens caught 3 real bugs** (all fixed + regression-tested): (1) legacy `GRANT ROLE ON …` misrouted to the role-grant path, (2) over-permissive non-ROLE target on a role grant, (3) over-rejected comma-separated object lists. Oracle-driven follow-ups while fixing: role names are single identifiers (CREATE ROLE rejects dotted; DROP ROLE accepts a path), a comma-object list requires both a type keyword and ROLE grantees, and PROTO BUNDLE lists allow a trailing comma (change-stream column lists do not). The Claude lens ran as an adversarial self-review across all angles.

### Scope note
The node's declared writes-globs centered on the new `spanner_*.go` files + the AST. The CREATE/ALTER/DROP/GRANT dispatch actually lives in `create_table.go`/`alter_table.go`/`drop.go`/`grant_revoke.go` (not `parser.go`), and the query-type classifier in `analysis/classify.go` — those out-of-scope edits were the minimal wiring + cross-node correctness needed to make the new forms parse and classify; recorded in the worker summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)