### PR TITLE
feat(snowflake): T4.6 CREATE / ALTER ROLE / USER / MASKING / ROW ACCESS / SESSION-PASSWORD-NETWORK-AUTHENTICATION POLICY

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -147,6 +147,15 @@ const (
 	T_CreateEventTableStmt
 	T_CreateSequenceStmt
 	T_AlterSequenceStmt
+
+	// Access-control DDL tags (T4.6)
+	T_PolicyArg
+	T_CreateRoleStmt
+	T_CreateUserStmt
+	T_CreatePolicyStmt
+	T_AlterRoleStmt
+	T_AlterUserStmt
+	T_AlterPolicyStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -352,6 +361,20 @@ func (t NodeTag) String() string {
 		return "CreateSequenceStmt"
 	case T_AlterSequenceStmt:
 		return "AlterSequenceStmt"
+	case T_PolicyArg:
+		return "PolicyArg"
+	case T_CreateRoleStmt:
+		return "CreateRoleStmt"
+	case T_CreateUserStmt:
+		return "CreateUserStmt"
+	case T_CreatePolicyStmt:
+		return "CreatePolicyStmt"
+	case T_AlterRoleStmt:
+		return "AlterRoleStmt"
+	case T_AlterUserStmt:
+		return "AlterUserStmt"
+	case T_AlterPolicyStmt:
+		return "AlterPolicyStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -3352,6 +3352,276 @@ var (
 )
 
 // ---------------------------------------------------------------------------
+// Access-control DDL — CREATE / ALTER ROLE / USER / { MASKING | ROW ACCESS |
+// SESSION | PASSWORD | NETWORK | AUTHENTICATION } POLICY (T4.6)
+// ---------------------------------------------------------------------------
+//
+// Roles, users, and the six policy objects share the open-ended `KEY = <value>`
+// option-bag approach already merged for STAGE (T4.1) / FILE FORMAT (T4.2) /
+// COPY (T5.2) / pipeline (T4.3): every option a CREATE/ALTER USER or
+// SESSION/PASSWORD/NETWORK/AUTHENTICATION POLICY carries is a version-growing
+// vocabulary the catalog/semantic layer — not the parser — validates, so each
+// option is captured as a CopyOption rather than enumerated against the
+// already-stale legacy ANTLR rules (which lack, e.g., the network policy's
+// ALLOWED_NETWORK_RULE_LIST, the user's TYPE / RSA_PUBLIC_KEY_2, and the whole
+// AUTHENTICATION POLICY object). The two structurally distinct objects —
+// MASKING POLICY and ROW ACCESS POLICY — carry a typed argument list, a RETURNS
+// type, and an expression body after `->`; those are modeled as dedicated fields
+// (Args / Returns / Body), with the body reusing the expression parser so it
+// participates in walks / query-span / analysis. COMMENT and other trailing
+// `KEY = value` options after the body are captured open-ended in Options.
+
+// PolicyKind discriminates the six access-control policy object types.
+type PolicyKind int
+
+const (
+	PolicyMasking        PolicyKind = iota // MASKING POLICY
+	PolicyRowAccess                        // ROW ACCESS POLICY
+	PolicySession                          // SESSION POLICY
+	PolicyPassword                         // PASSWORD POLICY
+	PolicyNetwork                          // NETWORK POLICY
+	PolicyAuthentication                   // AUTHENTICATION POLICY
+)
+
+// String returns the SQL spelling of a PolicyKind (without the trailing POLICY).
+func (k PolicyKind) String() string {
+	switch k {
+	case PolicyMasking:
+		return "MASKING"
+	case PolicyRowAccess:
+		return "ROW ACCESS"
+	case PolicySession:
+		return "SESSION"
+	case PolicyPassword:
+		return "PASSWORD"
+	case PolicyNetwork:
+		return "NETWORK"
+	case PolicyAuthentication:
+		return "AUTHENTICATION"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// PolicyArg is one `<arg_name> <arg_type>` entry in a MASKING / ROW ACCESS
+// policy's signature: AS ( <arg_name> <arg_type> [ , ... ] ).
+type PolicyArg struct {
+	Name     Ident
+	DataType *TypeName
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *PolicyArg) Tag() NodeTag { return T_PolicyArg }
+
+// CreateRoleStmt represents
+//
+//	CREATE [ OR REPLACE ] [ DATABASE ] ROLE [ IF NOT EXISTS ] <name>
+//	  [ COMMENT = '<string_literal>' ]
+//	  [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , ... ] ) ]
+//
+// Database is true for the CREATE DATABASE ROLE form (its <name> may be
+// db-qualified, db_name.role_name). Account roles take an unqualified name.
+type CreateRoleStmt struct {
+	OrReplace   bool
+	Database    bool // CREATE DATABASE ROLE
+	IfNotExists bool
+	Name        *ObjectName
+	Comment     *string          // COMMENT = '...'; nil if absent
+	Tags        []*TagAssignment // [WITH] TAG (...); nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateRoleStmt) Tag() NodeTag { return T_CreateRoleStmt }
+
+// CreateUserStmt represents
+//
+//	CREATE [ OR REPLACE ] USER [ IF NOT EXISTS ] <name>
+//	  [ objectProperties ] [ objectParams ] [ sessionParams ]
+//	  [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , ... ] ) ]
+//
+// Every property/parameter (PASSWORD / LOGIN_NAME / DISPLAY_NAME / DEFAULT_ROLE
+// / DEFAULT_WAREHOUSE / RSA_PUBLIC_KEY / DEFAULT_SECONDARY_ROLES / TYPE /
+// MUST_CHANGE_PASSWORD / network-policy / session params / ...) is captured
+// open-ended as a CopyOption, preserving source order.
+type CreateUserStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Options     []*CopyOption    // open-ended objectProperties / objectParams / sessionParams
+	Tags        []*TagAssignment // [WITH] TAG (...); nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateUserStmt) Tag() NodeTag { return T_CreateUserStmt }
+
+// CreatePolicyStmt represents the CREATE form of the six access-control policy
+// objects (one node, discriminated by Kind):
+//
+//	CREATE [ OR REPLACE ] MASKING POLICY [ IF NOT EXISTS ] <name>
+//	  AS ( <arg> <type> [ , ... ] ) RETURNS <type> -> <body>
+//	  [ COMMENT = '...' ] [ EXEMPT_OTHER_POLICIES = { TRUE | FALSE } ]
+//
+//	CREATE [ OR REPLACE ] ROW ACCESS POLICY [ IF NOT EXISTS ] <name>
+//	  AS ( <arg> <type> [ , ... ] ) RETURNS BOOLEAN -> <body> [ COMMENT = '...' ]
+//
+//	CREATE [ OR REPLACE ] { SESSION | PASSWORD | NETWORK | AUTHENTICATION } POLICY
+//	  [ IF NOT EXISTS ] <name> [ <option> ... ]
+//
+// For MASKING / ROW ACCESS policies Args holds the typed signature, Returns the
+// RETURNS type, and Body the `-> <expr>` body (an expression node). For the
+// SESSION / PASSWORD / NETWORK / AUTHENTICATION policies Args/Returns/Body are
+// nil and Options holds the open-ended option bag. Trailing options after a
+// MASKING / ROW ACCESS body (COMMENT / EXEMPT_OTHER_POLICIES) are also captured
+// in Options.
+type CreatePolicyStmt struct {
+	Kind        PolicyKind
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Args        []*PolicyArg  // MASKING / ROW ACCESS signature; nil for option-bag policies
+	Returns     *TypeName     // RETURNS <type>; nil for option-bag policies
+	Body        Node          // `-> <expr>` body; nil for option-bag policies
+	Options     []*CopyOption // option bag + trailing COMMENT / EXEMPT_OTHER_POLICIES
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreatePolicyStmt) Tag() NodeTag { return T_CreatePolicyStmt }
+
+// AlterRoleAction discriminates the action variants of ALTER ROLE.
+type AlterRoleAction int
+
+const (
+	AlterRoleRename     AlterRoleAction = iota // RENAME TO <new_name>
+	AlterRoleSetComment                        // SET COMMENT = '...'
+	AlterRoleUnset                             // UNSET COMMENT
+	AlterRoleSetTag                            // SET TAG <tag> = '<value>' [ , ... ]
+	AlterRoleUnsetTag                          // UNSET TAG <tag> [ , ... ]
+)
+
+// AlterRoleStmt represents ALTER [ DATABASE ] ROLE [ IF EXISTS ] <name> <action>.
+//
+//	RENAME TO <new_name>
+//	SET COMMENT = '<string>'
+//	UNSET COMMENT
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//
+// Database is true for ALTER DATABASE ROLE.
+type AlterRoleStmt struct {
+	Database  bool
+	IfExists  bool
+	Name      *ObjectName
+	Action    AlterRoleAction
+	NewName   *ObjectName      // RENAME TO target; for AlterRoleRename
+	Comment   *string          // SET COMMENT = '...'; for AlterRoleSetComment
+	Tags      []*TagAssignment // SET TAG (...) assignments; for AlterRoleSetTag
+	UnsetTags []*ObjectName    // UNSET TAG names; for AlterRoleUnsetTag
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *AlterRoleStmt) Tag() NodeTag { return T_AlterRoleStmt }
+
+// AlterUserAction discriminates the action variants of ALTER USER.
+type AlterUserAction int
+
+const (
+	AlterUserRename          AlterUserAction = iota // RENAME TO <new_name>
+	AlterUserResetPassword                          // RESET PASSWORD
+	AlterUserAbortQueries                           // ABORT ALL QUERIES
+	AlterUserSet                                    // SET <options>
+	AlterUserUnset                                  // UNSET <property> [ , ... ]
+	AlterUserSetTag                                 // SET TAG <tag> = '<value>' [ , ... ]
+	AlterUserUnsetTag                               // UNSET TAG <tag> [ , ... ]
+	AlterUserAddDelegated                           // ADD DELEGATED AUTHORIZATION ...
+	AlterUserRemoveDelegated                        // REMOVE DELEGATED ... FROM SECURITY INTEGRATION ...
+)
+
+// AlterUserStmt represents ALTER USER [ IF EXISTS ] <name> <action>.
+//
+//	RENAME TO <new_name>
+//	RESET PASSWORD
+//	ABORT ALL QUERIES
+//	SET <options>                                  -- open-ended KEY = value
+//	UNSET <property> [ , ... ]
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	ADD DELEGATED AUTHORIZATION OF ROLE <r> TO SECURITY INTEGRATION <i>
+//	REMOVE DELEGATED { AUTHORIZATION OF ROLE <r> | AUTHORIZATIONS } FROM SECURITY INTEGRATION <i>
+//
+// The ADD / REMOVE DELEGATED forms are captured structurally only by Action
+// (their body identifiers are consumed but not modeled), matching the
+// open-ended philosophy; Raw holds their verbatim source for round-tripping.
+type AlterUserStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterUserAction
+	NewName    *ObjectName      // RENAME TO target; for AlterUserRename
+	Options    []*CopyOption    // SET <options>; for AlterUserSet
+	UnsetProps []string         // UNSET <property> names; for AlterUserUnset
+	Tags       []*TagAssignment // SET TAG (...) assignments; for AlterUserSetTag
+	UnsetTags  []*ObjectName    // UNSET TAG names; for AlterUserUnsetTag
+	Raw        string           // verbatim tail for ADD / REMOVE DELEGATED forms
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterUserStmt) Tag() NodeTag { return T_AlterUserStmt }
+
+// AlterPolicyAction discriminates the action variants of ALTER <...> POLICY.
+type AlterPolicyAction int
+
+const (
+	AlterPolicyRename   AlterPolicyAction = iota // RENAME TO <new_name>
+	AlterPolicySetBody                           // SET BODY -> <expr> (MASKING / ROW ACCESS)
+	AlterPolicySet                               // SET <options> (COMMENT / option bag)
+	AlterPolicyUnset                             // UNSET <property> [ , ... ]
+	AlterPolicySetTag                            // SET TAG <tag> = '<value>' [ , ... ]
+	AlterPolicyUnsetTag                          // UNSET TAG <tag> [ , ... ]
+)
+
+// AlterPolicyStmt represents the ALTER form of the six access-control policy
+// objects (one node, discriminated by Kind):
+//
+//	RENAME TO <new_name>
+//	SET BODY -> <expr>                  -- MASKING / ROW ACCESS only
+//	SET { COMMENT = '...' | <options> }
+//	UNSET { COMMENT | <property> } [ , ... ]
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+type AlterPolicyStmt struct {
+	Kind       PolicyKind
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterPolicyAction
+	NewName    *ObjectName      // RENAME TO target; for AlterPolicyRename
+	Body       Node             // SET BODY -> <expr>; for AlterPolicySetBody
+	Options    []*CopyOption    // SET <options>; for AlterPolicySet
+	UnsetProps []string         // UNSET <property> names; for AlterPolicyUnset
+	Tags       []*TagAssignment // SET TAG (...) assignments; for AlterPolicySetTag
+	UnsetTags  []*ObjectName    // UNSET TAG names; for AlterPolicyUnsetTag
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterPolicyStmt) Tag() NodeTag { return T_AlterPolicyStmt }
+
+// Compile-time assertions for access-control DDL nodes.
+var (
+	_ Node = (*PolicyArg)(nil)
+	_ Node = (*CreateRoleStmt)(nil)
+	_ Node = (*CreateUserStmt)(nil)
+	_ Node = (*CreatePolicyStmt)(nil)
+	_ Node = (*AlterRoleStmt)(nil)
+	_ Node = (*AlterUserStmt)(nil)
+	_ Node = (*AlterPolicyStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
 // Routine DDL — CREATE / ALTER FUNCTION & PROCEDURE (T4.5)
 // ---------------------------------------------------------------------------
 //

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -57,6 +57,21 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *AlterPolicyStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
+		Walk(v, n.Body)
+	case *AlterRoleStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterRoutineStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -99,6 +114,13 @@ func walkChildren(v Visitor, node Node) {
 		}
 		Walk(v, n.When)
 		Walk(v, n.Body)
+	case *AlterUserStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterViewStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -228,6 +250,18 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Name)
 		}
 		Walk(v, n.Copy)
+	case *CreatePolicyStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.Returns != nil {
+			Walk(v, n.Returns)
+		}
+		Walk(v, n.Body)
+	case *CreateRoleStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreateRoutineStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -274,6 +308,10 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Body)
 		if n.Clone != nil {
 			Walk(v, n.Clone)
+		}
+	case *CreateUserStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
 		}
 	case *CreateViewStmt:
 		if n.Name != nil {
@@ -388,6 +426,10 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.On)
 	case *ParenExpr:
 		Walk(v, n.Expr)
+	case *PolicyArg:
+		if n.DataType != nil {
+			Walk(v, n.DataType)
+		}
 	case *PutStmt:
 		if n.File != nil {
 			Walk(v, n.File)

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -103,6 +103,12 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	case kwTABLE:
 		return p.parseCreateTableStmt(start, orReplace, transient, temporary, volatile)
 	case kwDATABASE:
+		// CREATE [OR REPLACE] DATABASE ROLE ... (T4.6) vs CREATE DATABASE ... (T2.1).
+		// DATABASE ROLE is disambiguated by the ROLE keyword following DATABASE.
+		if p.peekNext().Type == kwROLE {
+			p.advance() // consume DATABASE
+			return p.parseCreateRoleStmt(start, orReplace, true)
+		}
 		return p.parseCreateDatabaseStmt(start, orReplace, transient)
 	case kwSCHEMA:
 		return p.parseCreateSchemaStmt(start, orReplace, transient)
@@ -172,9 +178,46 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// SECRET, CONNECTION, GIT REPOSITORY. parseCreateIntegrationStmt consumes the
 		// object-type keyword(s).
 		return p.parseCreateIntegrationStmt(start, orReplace)
+	case kwROLE:
+		// CREATE [OR REPLACE] ROLE ... (T4.6). DATABASE ROLE is dispatched by the
+		// kwDATABASE case above.
+		return p.parseCreateRoleStmt(start, orReplace, false)
+	case kwUSER:
+		// CREATE [OR REPLACE] USER ... (T4.6).
+		return p.parseCreateUserStmt(start, orReplace)
+	case kwMASKING, kwSESSION, kwPASSWORD, kwNETWORK, kwROW:
+		// CREATE [OR REPLACE] { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK }
+		// POLICY ... (T4.6). parseCreatePolicyDispatch consumes the kind keyword(s)
+		// and the POLICY keyword, then delegates. A leading keyword not followed by
+		// the expected POLICY (or ACCESS POLICY, for ROW) is not a policy statement.
+		return p.parseCreatePolicyDispatch(start, orReplace)
 	default:
+		// AUTHENTICATION is not a reserved keyword, so CREATE AUTHENTICATION POLICY
+		// lexes as an "AUTHENTICATION" identifier followed by the POLICY keyword;
+		// that form is dispatched here (T4.6).
+		if p.curIsWord("AUTHENTICATION") && p.peekNext().Type == kwPOLICY {
+			return p.parseCreatePolicyDispatch(start, orReplace)
+		}
 		return p.unsupported("CREATE")
 	}
+}
+
+// parseCreatePolicyDispatch identifies which policy object follows and consumes
+// the policy-kind keyword(s) and the POLICY keyword, then delegates to
+// parseCreatePolicyStmt. On entry cur is the first policy-kind word:
+//
+//	MASKING POLICY            -> PolicyMasking
+//	ROW ACCESS POLICY         -> PolicyRowAccess
+//	SESSION POLICY            -> PolicySession
+//	PASSWORD POLICY           -> PolicyPassword
+//	NETWORK POLICY            -> PolicyNetwork
+//	AUTHENTICATION POLICY     -> PolicyAuthentication  (AUTHENTICATION is an identifier)
+func (p *Parser) parseCreatePolicyDispatch(start ast.Loc, orReplace bool) (ast.Node, error) {
+	kind, err := p.consumePolicyKeywords()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseCreatePolicyStmt(start, orReplace, kind)
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -164,6 +164,12 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	case kwTABLE:
 		return p.parseAlterTableStmt()
 	case kwDATABASE:
+		// ALTER DATABASE ROLE ... (T4.6) vs ALTER DATABASE ... (T2.1). DATABASE ROLE
+		// is disambiguated by the ROLE keyword following DATABASE.
+		if p.peekNext().Type == kwROLE {
+			p.advance() // consume DATABASE
+			return p.parseAlterRoleStmt(true)
+		}
 		return p.parseAlterDatabaseStmt()
 	case kwSCHEMA:
 		return p.parseAlterSchemaStmt()
@@ -222,9 +228,41 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// CONNECTION, GIT REPOSITORY. A bare ALTER INTEGRATION (qualifier omitted)
 		// dispatches here too. parseAlterIntegrationStmt consumes the keyword(s).
 		return p.parseAlterIntegrationStmt()
+	case kwROLE:
+		// ALTER ROLE ... (T4.6). DATABASE ROLE is dispatched by the kwDATABASE case.
+		return p.parseAlterRoleStmt(false)
+	case kwUSER:
+		// ALTER USER ... (T4.6).
+		return p.parseAlterUserStmt()
+	case kwMASKING, kwSESSION, kwPASSWORD, kwNETWORK, kwROW:
+		// ALTER { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK } POLICY ...
+		// (T4.6). Only routed to the policy parser when the kind keyword is actually
+		// followed by POLICY (and, for ROW, ACCESS POLICY); otherwise a same-prefix
+		// non-policy statement (e.g. ALTER SESSION SET ...) is left unsupported here.
+		if p.startsPolicyKeyword() {
+			return p.parseAlterPolicyDispatch()
+		}
+		return p.unsupported("ALTER")
 	default:
+		// AUTHENTICATION is not a reserved keyword, so ALTER AUTHENTICATION POLICY
+		// lexes as an "AUTHENTICATION" identifier followed by POLICY (T4.6).
+		if p.startsPolicyKeyword() {
+			return p.parseAlterPolicyDispatch()
+		}
 		return p.unsupported("ALTER")
 	}
+}
+
+// parseAlterPolicyDispatch consumes the policy-kind keyword(s) + the POLICY
+// keyword and delegates to parseAlterPolicyStmt (T4.6). On entry cur is the
+// first policy-kind word; the caller has confirmed startsPolicyKeyword.
+func (p *Parser) parseAlterPolicyDispatch() (ast.Node, error) {
+	startLoc := p.cur.Loc // policy-kind keyword anchors Loc.Start (ALTER convention)
+	kind, err := p.consumePolicyKeywords()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseAlterPolicyStmt(startLoc, kind)
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/role_user_policy.go
+++ b/snowflake/parser/role_user_policy.go
@@ -1,0 +1,853 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Access-control DDL — CREATE / ALTER ROLE / USER / { MASKING | ROW ACCESS |
+// SESSION | PASSWORD | NETWORK | AUTHENTICATION } POLICY (T4.6)
+// ---------------------------------------------------------------------------
+//
+// Roles, users, and the six policy objects reuse the open-ended `KEY = <value>`
+// option-bag machinery already merged for STAGE (T4.1) / FILE FORMAT (T4.2) /
+// COPY (T5.2) / pipeline (T4.3) (parseCopyOption / startsCopyOption): every
+// option that CREATE/ALTER USER and the SESSION / PASSWORD / NETWORK /
+// AUTHENTICATION policies carry is a version-growing vocabulary the catalog /
+// semantic layer — not the parser — validates, so each is captured as a
+// CopyOption rather than enumerated against the already-stale legacy ANTLR rules
+// (whose create_network_policy lists only ALLOWED_IP_LIST / BLOCKED_IP_LIST, not
+// the docs' ALLOWED_NETWORK_RULE_LIST, and which has no AUTHENTICATION POLICY
+// rule at all). The two structurally distinct objects — MASKING POLICY and ROW
+// ACCESS POLICY — carry a typed argument list, a RETURNS type, and an expression
+// body after `->`; those anchor the grammar (Args / Returns / Body), and the
+// body reuses the expression parser so it participates in walks / query-span /
+// analysis. Trailing `KEY = value` options after a MASKING / ROW ACCESS body
+// (COMMENT / EXEMPT_OTHER_POLICIES) are captured open-ended in Options.
+//
+// Oracle (no live Snowflake instance): triangulation of the legacy
+// SnowflakeParser.g4 rules (create_role / create_user / create_masking_policy /
+// create_row_access_policy / create_{session,password,network}_policy +
+// alter_*) against the official docs (docs win on conflict) and the
+// testdata/official/{create-role,create-user,create-masking-policy,
+// create-row-access-policy,create-network-policy} corpus.
+
+// ---------------------------------------------------------------------------
+// CREATE ROLE
+// ---------------------------------------------------------------------------
+
+// parseCreateRoleStmt parses
+//
+//	CREATE [ OR REPLACE ] [ DATABASE ] ROLE [ IF NOT EXISTS ] <name>
+//	  [ COMMENT = '<string_literal>' ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//
+// The CREATE keyword and the optional OR REPLACE modifier have already been
+// consumed by parseCreateStmt; start is the Loc of the CREATE token. database is
+// true when the DATABASE keyword preceded ROLE (CREATE DATABASE ROLE), whose
+// <name> may be db-qualified. On entry cur is the ROLE keyword.
+//
+// The docs list COMMENT before [WITH] TAG; the legacy ANTLR create_role lists
+// `with_tags? comment_clause?` (TAG before COMMENT). Accepting either order (a)
+// follows the docs, (b) regresses neither, and (c) avoids silently dropping a
+// COMMENT that trails the TAG clause — matching the merged STAGE (T4.1) handling.
+func (p *Parser) parseCreateRoleStmt(start ast.Loc, orReplace, database bool) (ast.Node, error) {
+	p.advance() // consume ROLE
+
+	stmt := &ast.CreateRoleStmt{
+		OrReplace: orReplace,
+		Database:  database,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Trailing COMMENT / [WITH] TAG, in either order.
+	for {
+		if p.cur.Type == kwCOMMENT {
+			if err := p.parseEqComment(&stmt.Comment); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if p.startsWithTags() {
+			tags, err := p.parseWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+			continue
+		}
+		break
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE USER
+// ---------------------------------------------------------------------------
+
+// parseCreateUserStmt parses
+//
+//	CREATE [ OR REPLACE ] USER [ IF NOT EXISTS ] <name>
+//	  [ objectProperties ] [ objectParams ] [ sessionParams ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//
+// Every property/parameter is an open-ended `KEY = value` pair (CopyOption).
+// The CREATE keyword and OR REPLACE have already been consumed; cur is USER.
+func (p *Parser) parseCreateUserStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume USER
+
+	stmt := &ast.CreateUserStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Open-ended option bag interleaved with the trailing [WITH] TAG clause.
+	// WITH/TAG are excluded as option starters (startsUserOption) so the tag
+	// clause is not swallowed as an option named WITH or TAG.
+	for {
+		if p.startsWithTags() {
+			tags, err := p.parseWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+			continue
+		}
+		if p.startsUserOption() {
+			opt, err := p.parseCopyOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+			continue
+		}
+		break
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK | AUTHENTICATION }
+// POLICY
+// ---------------------------------------------------------------------------
+
+// parseCreatePolicyStmt parses the CREATE form of one of the six policy objects.
+// The CREATE keyword and OR REPLACE have already been consumed by
+// parseCreateStmt; the policy-kind keyword(s) (MASKING / ROW ACCESS / SESSION /
+// PASSWORD / NETWORK / AUTHENTICATION) and the trailing POLICY keyword have ALSO
+// already been consumed by the dispatcher. start is the Loc of the CREATE token
+// and kind identifies which policy.
+//
+// MASKING / ROW ACCESS:
+//
+//	... [ IF NOT EXISTS ] <name> AS ( <arg> <type> [ , ... ] )
+//	      RETURNS <type> -> <body> [ <trailing options> ]
+//
+// SESSION / PASSWORD / NETWORK / AUTHENTICATION:
+//
+//	... [ IF NOT EXISTS ] <name> [ <option> ... ]
+func (p *Parser) parseCreatePolicyStmt(start ast.Loc, orReplace bool, kind ast.PolicyKind) (ast.Node, error) {
+	stmt := &ast.CreatePolicyStmt{
+		Kind:      kind,
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch kind {
+	case ast.PolicyMasking, ast.PolicyRowAccess:
+		// AS ( <arg> <type> [ , ... ] ) RETURNS <type> -> <body>
+		if _, err := p.expect(kwAS); err != nil {
+			return nil, err
+		}
+		args, err := p.parsePolicyArgs()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Args = args
+
+		if _, err := p.expect(kwRETURNS); err != nil {
+			return nil, err
+		}
+		ret, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Returns = ret
+
+		if _, err := p.expect(tokArrow); err != nil {
+			return nil, err
+		}
+		body, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Body = body
+
+		// Trailing open-ended options (COMMENT / EXEMPT_OTHER_POLICIES). The
+		// expression parser stops at the first non-expression token, which is the
+		// first trailing option name (or the statement boundary).
+		opts, err := p.parseCopyOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+
+	default:
+		// SESSION / PASSWORD / NETWORK / AUTHENTICATION: open-ended option bag.
+		opts, err := p.parseCopyOptions()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parsePolicyArgs parses the parenthesized typed signature of a MASKING / ROW
+// ACCESS policy: ( <arg_name> <arg_type> [ , <arg_name> <arg_type> ... ] ).
+// At least one argument is required (per the docs and the legacy grammar).
+func (p *Parser) parsePolicyArgs() ([]*ast.PolicyArg, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	var args []*ast.PolicyArg
+	for {
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		dt, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, &ast.PolicyArg{
+			Name:     name,
+			DataType: dt,
+			Loc:      ast.Loc{Start: name.Loc.Start, End: dt.Loc.End},
+		})
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return args, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER ROLE
+// ---------------------------------------------------------------------------
+
+// parseAlterRoleStmt parses
+//
+//	ALTER [ DATABASE ] ROLE [ IF EXISTS ] <name>
+//	  { RENAME TO <new_name>
+//	  | SET COMMENT = '<string>'
+//	  | UNSET COMMENT
+//	  | SET TAG <tag> = '<value>' [ , ... ]
+//	  | UNSET TAG <tag> [ , ... ] }
+//
+// The ALTER keyword has already been consumed by parseAlterStmt; database is
+// true when DATABASE preceded ROLE. On entry cur is the ROLE keyword.
+func (p *Parser) parseAlterRoleStmt(database bool) (ast.Node, error) {
+	altTok := p.advance() // consume ROLE
+	stmt := &ast.AlterRoleStmt{Database: database, Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	if err := p.parseIfExists(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRENAME:
+		newName, err := p.parseRenameTo()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterRoleRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterRoleSetTag
+			stmt.Tags = tags
+		} else {
+			// SET COMMENT = '...'
+			if p.cur.Type != kwCOMMENT {
+				return nil, p.syntaxErrorAtCur()
+			}
+			if err := p.parseEqComment(&stmt.Comment); err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterRoleSetComment
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterRoleUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET COMMENT (the only unsettable role property).
+			if p.cur.Type != kwCOMMENT {
+				return nil, p.syntaxErrorAtCur()
+			}
+			p.advance() // consume COMMENT
+			stmt.Action = ast.AlterRoleUnset
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER USER
+// ---------------------------------------------------------------------------
+
+// parseAlterUserStmt parses
+//
+//	ALTER USER [ IF EXISTS ] <name>
+//	  { RENAME TO <new_name>
+//	  | RESET PASSWORD
+//	  | ABORT ALL QUERIES
+//	  | SET <options>
+//	  | UNSET <property> [ , ... ]
+//	  | SET TAG <tag> = '<value>' [ , ... ]
+//	  | UNSET TAG <tag> [ , ... ]
+//	  | ADD DELEGATED AUTHORIZATION OF ROLE <r> TO SECURITY INTEGRATION <i>
+//	  | REMOVE DELEGATED { AUTHORIZATION OF ROLE <r> | AUTHORIZATIONS }
+//	      FROM SECURITY INTEGRATION <i> }
+//
+// The ALTER keyword has already been consumed; cur is the USER keyword.
+func (p *Parser) parseAlterUserStmt() (ast.Node, error) {
+	altTok := p.advance() // consume USER
+	stmt := &ast.AlterUserStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	if err := p.parseIfExists(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRENAME:
+		newName, err := p.parseRenameTo()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterUserRename
+		stmt.NewName = newName
+
+	case kwRESET:
+		// RESET PASSWORD
+		p.advance() // consume RESET
+		if _, err := p.expect(kwPASSWORD); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterUserResetPassword
+
+	case kwABORT:
+		// ABORT ALL QUERIES
+		p.advance() // consume ABORT
+		if _, err := p.expect(kwALL); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwQUERIES); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterUserAbortQueries
+
+	case kwADD:
+		// ADD DELEGATED AUTHORIZATION OF ROLE <r> TO SECURITY INTEGRATION <i>
+		rawStart := p.cur.Loc.Start
+		if err := p.parseAddDelegatedAuthorization(); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterUserAddDelegated
+		stmt.Raw = p.srcSlice(rawStart, p.prev.Loc.End)
+
+	case kwREMOVE:
+		// REMOVE DELEGATED { AUTHORIZATION OF ROLE <r> | AUTHORIZATIONS }
+		//   FROM SECURITY INTEGRATION <i>
+		rawStart := p.cur.Loc.Start
+		if err := p.parseRemoveDelegatedAuthorization(); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterUserRemoveDelegated
+		stmt.Raw = p.srcSlice(rawStart, p.prev.Loc.End)
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterUserSetTag
+			stmt.Tags = tags
+		} else {
+			// SET <options> — open-ended KEY = value params (including the policy
+			// forms SET <kind> POLICY <name>, captured as bare/word options).
+			opts, err := p.parseCopyOptions()
+			if err != nil {
+				return nil, err
+			}
+			if len(opts) == 0 {
+				return nil, p.syntaxErrorAtCur()
+			}
+			stmt.Action = ast.AlterUserSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterUserUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET <property> [ , ... ] — open-ended name list.
+			props, err := p.parseUnsetPropertyNames()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterUserUnset
+			stmt.UnsetProps = props
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAddDelegatedAuthorization parses the body following ADD:
+//
+//	ADD DELEGATED AUTHORIZATION OF ROLE <r> TO SECURITY INTEGRATION <i>
+//
+// On entry cur is the ADD keyword. The identifiers are consumed but not modeled
+// (the caller captures the verbatim tail via Raw).
+func (p *Parser) parseAddDelegatedAuthorization() error {
+	p.advance() // consume ADD
+	if _, err := p.expect(kwDELEGATED); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwAUTHORIZATION); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwOF); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwROLE); err != nil {
+		return err
+	}
+	if _, err := p.parseObjectName(); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwTO); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwSECURITY); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwINTEGRATION); err != nil {
+		return err
+	}
+	if _, err := p.parseObjectName(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseRemoveDelegatedAuthorization parses the body following REMOVE:
+//
+//	REMOVE DELEGATED { AUTHORIZATION OF ROLE <r> | AUTHORIZATIONS }
+//	  FROM SECURITY INTEGRATION <i>
+//
+// On entry cur is the REMOVE keyword.
+func (p *Parser) parseRemoveDelegatedAuthorization() error {
+	p.advance() // consume REMOVE
+	if _, err := p.expect(kwDELEGATED); err != nil {
+		return err
+	}
+	switch p.cur.Type {
+	case kwAUTHORIZATION:
+		p.advance() // consume AUTHORIZATION
+		if _, err := p.expect(kwOF); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwROLE); err != nil {
+			return err
+		}
+		if _, err := p.parseObjectName(); err != nil {
+			return err
+		}
+	case kwAUTHORIZATIONS:
+		p.advance() // consume AUTHORIZATIONS
+	default:
+		return p.syntaxErrorAtCur()
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwSECURITY); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwINTEGRATION); err != nil {
+		return err
+	}
+	if _, err := p.parseObjectName(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK | AUTHENTICATION }
+// POLICY
+// ---------------------------------------------------------------------------
+
+// parseAlterPolicyStmt parses the ALTER form of one of the six policy objects.
+// The ALTER keyword and the policy-kind keyword(s) + the POLICY keyword have
+// already been consumed by the dispatcher; startLoc anchors Loc.Start and kind
+// identifies which policy.
+//
+//	... [ IF EXISTS ] <name>
+//	  { RENAME TO <new_name>
+//	  | SET BODY -> <expr>                     -- MASKING / ROW ACCESS only
+//	  | SET { COMMENT = '...' | <options> }
+//	  | UNSET { COMMENT | <property> } [ , ... ]
+//	  | SET TAG <tag> = '<value>' [ , ... ]
+//	  | UNSET TAG <tag> [ , ... ] }
+func (p *Parser) parseAlterPolicyStmt(startLoc ast.Loc, kind ast.PolicyKind) (ast.Node, error) {
+	stmt := &ast.AlterPolicyStmt{Kind: kind, Loc: ast.Loc{Start: startLoc.Start}}
+
+	if err := p.parseIfExists(&stmt.IfExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRENAME:
+		newName, err := p.parseRenameTo()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterPolicyRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		switch {
+		case p.cur.Type == kwBODY:
+			// SET BODY -> <expr> (MASKING / ROW ACCESS).
+			p.advance() // consume BODY
+			if _, err := p.expect(tokArrow); err != nil {
+				return nil, err
+			}
+			body, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPolicySetBody
+			stmt.Body = body
+		case p.cur.Type == kwTAG:
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPolicySetTag
+			stmt.Tags = tags
+		default:
+			// SET { COMMENT = '...' | <option> ... } — open-ended option bag.
+			opts, err := p.parseCopyOptions()
+			if err != nil {
+				return nil, err
+			}
+			if len(opts) == 0 {
+				return nil, p.syntaxErrorAtCur()
+			}
+			stmt.Action = ast.AlterPolicySet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPolicyUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET { COMMENT | <param_name> } [ , ... ] — open-ended name list.
+			props, err := p.parseUnsetPropertyNames()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterPolicyUnset
+			stmt.UnsetProps = props
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// startsPolicyKeyword reports whether the current token begins a policy-kind
+// prefix ({ MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK |
+// AUTHENTICATION } POLICY) such that consumePolicyKeywords would succeed. It is
+// used by the ALTER dispatcher, whose switch must first decide whether ALTER is
+// followed by a policy object. AUTHENTICATION is matched as a non-reserved
+// identifier; the others are keywords. The trailing POLICY (and, for ROW, the
+// intervening ACCESS) is confirmed so non-policy statements (e.g. ALTER NETWORK
+// RULE, ALTER SESSION) are not misrouted.
+func (p *Parser) startsPolicyKeyword() bool {
+	switch p.cur.Type {
+	case kwMASKING, kwSESSION, kwPASSWORD, kwNETWORK:
+		return p.peekNext().Type == kwPOLICY
+	case kwROW:
+		// ROW ACCESS POLICY — only the ROW + ACCESS prefix is checkable with one
+		// token of lookahead; consumePolicyKeywords validates the POLICY keyword.
+		return p.peekNext().Type == kwACCESS
+	}
+	return p.curIsWord("AUTHENTICATION") && p.peekNext().Type == kwPOLICY
+}
+
+// consumePolicyKeywords consumes the policy-kind keyword(s) and the trailing
+// POLICY keyword, returning the identified PolicyKind. On entry cur is the first
+// policy-kind word. Returns a syntax error if the token sequence is not a valid
+// policy prefix.
+func (p *Parser) consumePolicyKeywords() (ast.PolicyKind, error) {
+	switch p.cur.Type {
+	case kwMASKING:
+		p.advance() // consume MASKING
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return 0, err
+		}
+		return ast.PolicyMasking, nil
+	case kwROW:
+		p.advance() // consume ROW
+		if _, err := p.expect(kwACCESS); err != nil {
+			return 0, err
+		}
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return 0, err
+		}
+		return ast.PolicyRowAccess, nil
+	case kwSESSION:
+		p.advance() // consume SESSION
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return 0, err
+		}
+		return ast.PolicySession, nil
+	case kwPASSWORD:
+		p.advance() // consume PASSWORD
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return 0, err
+		}
+		return ast.PolicyPassword, nil
+	case kwNETWORK:
+		p.advance() // consume NETWORK
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return 0, err
+		}
+		return ast.PolicyNetwork, nil
+	}
+	// AUTHENTICATION (non-reserved identifier) POLICY.
+	if p.curIsWord("AUTHENTICATION") {
+		p.advance() // consume AUTHENTICATION
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return 0, err
+		}
+		return ast.PolicyAuthentication, nil
+	}
+	return 0, p.syntaxErrorAtCur()
+}
+
+// startsUserOption reports whether the current token can begin a CREATE USER
+// option. It is the COPY option predicate minus WITH and TAG, which anchor the
+// trailing [WITH] TAG clause and must not be swallowed as an option name.
+func (p *Parser) startsUserOption() bool {
+	switch p.cur.Type {
+	case kwWITH, kwTAG:
+		return false
+	}
+	return p.startsCopyOption()
+}
+
+// startsWithTags reports whether the current position begins a [WITH] TAG
+// clause: either the TAG keyword directly, or WITH immediately followed by TAG.
+func (p *Parser) startsWithTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// parseWithTags parses a [WITH] TAG ( <tag> = '<value>' [ , ... ] ) clause and
+// returns the tag assignments. The caller must have confirmed startsWithTags.
+func (p *Parser) parseWithTags() ([]*ast.TagAssignment, error) {
+	if p.cur.Type == kwWITH {
+		p.advance() // consume WITH (peekNext == TAG guaranteed by startsWithTags)
+	}
+	return p.parseTagAssignments()
+}
+
+// parseUnsetPropertyNames parses a comma-separated UNSET property-name list for
+// USER / POLICY objects, where each name is a single open-ended name word
+// (identifier or keyword) — the settable property/parameter vocabulary is large
+// and version-growing (DEFAULT_ROLE / DISPLAY_NAME / DEFAULT_WAREHOUSE /
+// SESSION_IDLE_TIMEOUT_MINS / PASSWORD_MIN_LENGTH / COMMENT / ...), much of it
+// lexed as keywords, so it is NOT enumerated (unlike the DB/SCHEMA-specific
+// parsePropertyNameList). Returns the uppercased names; consumes at least one.
+func (p *Parser) parseUnsetPropertyNames() ([]string, error) {
+	var names []string
+	for {
+		if !p.isOptionWord(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		names = append(names, strings.ToUpper(p.advance().Str))
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return names, nil
+}
+
+// parseIfNotExists consumes an optional IF NOT EXISTS clause, setting *flag.
+func (p *Parser) parseIfNotExists(flag *bool) error {
+	if p.cur.Type == kwIF && p.peekNext().Type == kwNOT {
+		p.advance() // consume IF
+		p.advance() // consume NOT
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return err
+		}
+		*flag = true
+	}
+	return nil
+}
+
+// parseIfExists consumes an optional IF EXISTS clause, setting *flag.
+func (p *Parser) parseIfExists(flag *bool) error {
+	if p.cur.Type == kwIF && p.peekNext().Type == kwEXISTS {
+		p.advance() // consume IF
+		p.advance() // consume EXISTS
+		*flag = true
+	}
+	return nil
+}
+
+// parseRenameTo consumes RENAME TO <new_name> and returns the new name. On entry
+// cur is the RENAME keyword.
+func (p *Parser) parseRenameTo() (*ast.ObjectName, error) {
+	p.advance() // consume RENAME
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	return p.parseObjectName()
+}
+
+// parseEqComment parses a `COMMENT [=] '<string>'` clause, storing the string
+// into *dst. On entry cur is the COMMENT keyword. The '=' is required by the
+// docs (COMMENT = '...') but tolerated-optional defensively, matching other
+// merged DDL.
+func (p *Parser) parseEqComment(dst **string) error {
+	p.advance() // consume COMMENT
+	if p.cur.Type == '=' {
+		p.advance() // consume '='
+	}
+	tok, err := p.expect(tokString)
+	if err != nil {
+		return err
+	}
+	s := tok.Str
+	*dst = &s
+	return nil
+}

--- a/snowflake/parser/role_user_policy_test.go
+++ b/snowflake/parser/role_user_policy_test.go
@@ -1,0 +1,937 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// T4.6 — CREATE / ALTER ROLE / USER / { MASKING | ROW ACCESS | SESSION |
+// PASSWORD | NETWORK | AUTHENTICATION } POLICY.
+//
+// Oracle: triangulation of the legacy SnowflakeParser.g4 rules (create_role /
+// create_user / create_masking_policy / create_row_access_policy /
+// create_{session,password,network}_policy + alter_*) against the official docs
+// (docs win on conflict) and the testdata/official corpus. No live Snowflake
+// instance is available, so divergences where the docs are followed over the
+// (stale) ANTLR grammar are flagged in the migration ledger.
+// ---------------------------------------------------------------------------
+
+func mustCreateRole(t *testing.T, input string) *ast.CreateRoleStmt {
+	t.Helper()
+	stmt, ok := mustParseOne(t, input).(*ast.CreateRoleStmt)
+	if !ok {
+		t.Fatalf("parse %q: want *ast.CreateRoleStmt", input)
+	}
+	return stmt
+}
+
+func mustCreateUser(t *testing.T, input string) *ast.CreateUserStmt {
+	t.Helper()
+	stmt, ok := mustParseOne(t, input).(*ast.CreateUserStmt)
+	if !ok {
+		t.Fatalf("parse %q: want *ast.CreateUserStmt", input)
+	}
+	return stmt
+}
+
+func mustCreatePolicy(t *testing.T, input string) *ast.CreatePolicyStmt {
+	t.Helper()
+	stmt, ok := mustParseOne(t, input).(*ast.CreatePolicyStmt)
+	if !ok {
+		t.Fatalf("parse %q: want *ast.CreatePolicyStmt", input)
+	}
+	return stmt
+}
+
+func mustAlterRole(t *testing.T, input string) *ast.AlterRoleStmt {
+	t.Helper()
+	stmt, ok := mustParseOne(t, input).(*ast.AlterRoleStmt)
+	if !ok {
+		t.Fatalf("parse %q: want *ast.AlterRoleStmt", input)
+	}
+	return stmt
+}
+
+func mustAlterUser(t *testing.T, input string) *ast.AlterUserStmt {
+	t.Helper()
+	stmt, ok := mustParseOne(t, input).(*ast.AlterUserStmt)
+	if !ok {
+		t.Fatalf("parse %q: want *ast.AlterUserStmt", input)
+	}
+	return stmt
+}
+
+func mustAlterPolicy(t *testing.T, input string) *ast.AlterPolicyStmt {
+	t.Helper()
+	stmt, ok := mustParseOne(t, input).(*ast.AlterPolicyStmt)
+	if !ok {
+		t.Fatalf("parse %q: want *ast.AlterPolicyStmt", input)
+	}
+	return stmt
+}
+
+// assertSecurityLoc asserts an AST node's Loc has non-negative, ordered bounds.
+// Every new T4.6 node must carry a valid Loc (Start/End >= 0, Start <= End).
+func assertSecurityLoc(t *testing.T, loc ast.Loc, what string) {
+	t.Helper()
+	if loc.Start < 0 || loc.End < 0 {
+		t.Errorf("%s: negative Loc %+v", what, loc)
+	}
+	if loc.Start > loc.End {
+		t.Errorf("%s: Loc.Start %d > Loc.End %d", what, loc.Start, loc.End)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE ROLE
+//
+// Docs grammar (truth1, authoritative):
+//
+//	CREATE [ OR REPLACE ] ROLE [ IF NOT EXISTS ] <name>
+//	  [ COMMENT = '<string_literal>' ]
+//	  [ [ WITH ] TAG ( <tag_name> = '<tag_value>' [ , ... ] ) ]
+//
+//	CREATE [ OR REPLACE ] DATABASE ROLE [ IF NOT EXISTS ] [<db>.]<name>
+//	  [ COMMENT = '<string_literal>' ]
+// ---------------------------------------------------------------------------
+
+func TestParseCreateRole(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE ROLE myrole")
+		if stmt.Name.String() != "myrole" {
+			t.Errorf("Name = %q, want myrole", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.Database || stmt.IfNotExists {
+			t.Errorf("unexpected modifier: %+v", stmt)
+		}
+		if stmt.Comment != nil || stmt.Tags != nil {
+			t.Errorf("unexpected comment/tags: %+v", stmt)
+		}
+		assertSecurityLoc(t, stmt.Loc, "CreateRoleStmt")
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE OR REPLACE ROLE r")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE ROLE IF NOT EXISTS r")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("comment", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE ROLE r COMMENT = 'desc'")
+		if stmt.Comment == nil || *stmt.Comment != "desc" {
+			t.Errorf("Comment = %v, want desc", stmt.Comment)
+		}
+	})
+
+	t.Run("with tag", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE ROLE r WITH TAG (cost_center = 'finance')")
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Name.String() != "cost_center" || stmt.Tags[0].Value != "finance" {
+			t.Errorf("Tags = %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("bare tag (no WITH)", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE ROLE r TAG (t = 'v')")
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("comment then tag", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE OR REPLACE ROLE IF NOT EXISTS r COMMENT = 'c' WITH TAG (a = 'b')")
+		if stmt.Comment == nil || *stmt.Comment != "c" || len(stmt.Tags) != 1 {
+			t.Errorf("Comment=%v Tags=%+v", stmt.Comment, stmt.Tags)
+		}
+	})
+
+	t.Run("tag then comment (docs/antlr order divergence)", func(t *testing.T) {
+		// The legacy ANTLR create_role lists `with_tags? comment_clause?` (TAG before
+		// COMMENT); the docs list COMMENT first. Both orders are accepted so neither
+		// is regressed and a trailing COMMENT after TAG is not dropped.
+		stmt := mustCreateRole(t, "CREATE ROLE r TAG (a = 'b') COMMENT = 'c'")
+		if stmt.Comment == nil || *stmt.Comment != "c" || len(stmt.Tags) != 1 {
+			t.Errorf("Comment=%v Tags=%+v", stmt.Comment, stmt.Tags)
+		}
+	})
+
+	t.Run("quoted name", func(t *testing.T) {
+		stmt := mustCreateRole(t, `CREATE ROLE "My Role"`)
+		if stmt.Name.String() != `"My Role"` {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+
+	t.Run("database role", func(t *testing.T) {
+		stmt := mustCreateRole(t, "CREATE DATABASE ROLE dr")
+		if !stmt.Database {
+			t.Error("Database not set")
+		}
+		if stmt.Name.String() != "dr" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+
+	t.Run("database role qualified name", func(t *testing.T) {
+		// DATABASE ROLE names may be db-qualified (db_name.role_name) per the docs.
+		stmt := mustCreateRole(t, "CREATE OR REPLACE DATABASE ROLE IF NOT EXISTS mydb.dr COMMENT = 'c'")
+		if !stmt.Database || stmt.Name.String() != "mydb.dr" {
+			t.Errorf("Database=%v Name=%q", stmt.Database, stmt.Name.String())
+		}
+		if stmt.Comment == nil || *stmt.Comment != "c" {
+			t.Errorf("Comment = %v", stmt.Comment)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE USER
+//
+// Docs grammar (truth1):
+//
+//	CREATE [ OR REPLACE ] USER [ IF NOT EXISTS ] <name>
+//	  [ objectProperties ] [ objectParams ] [ sessionParams ]
+//	  [ [ WITH ] TAG ( ... ) ]
+//
+// Every property/parameter is an open-ended KEY = value pair (CopyOption).
+// ---------------------------------------------------------------------------
+
+func TestParseCreateUser(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		stmt := mustCreateUser(t, "CREATE USER u")
+		if stmt.Name.String() != "u" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+		if len(stmt.Options) != 0 {
+			t.Errorf("unexpected options: %+v", stmt.Options)
+		}
+		assertSecurityLoc(t, stmt.Loc, "CreateUserStmt")
+	})
+
+	t.Run("or replace if not exists", func(t *testing.T) {
+		stmt := mustCreateUser(t, "CREATE OR REPLACE USER IF NOT EXISTS u")
+		if !stmt.OrReplace || !stmt.IfNotExists {
+			t.Errorf("OrReplace=%v IfNotExists=%v", stmt.OrReplace, stmt.IfNotExists)
+		}
+	})
+
+	t.Run("properties", func(t *testing.T) {
+		stmt := mustCreateUser(t, "CREATE USER u PASSWORD = 'abc' LOGIN_NAME = 'ln' DISPLAY_NAME = 'dn' DEFAULT_ROLE = r DEFAULT_WAREHOUSE = wh")
+		if findOption(stmt.Options, "PASSWORD").Lit.Value != "abc" {
+			t.Errorf("PASSWORD = %+v", findOption(stmt.Options, "PASSWORD"))
+		}
+		if findOption(stmt.Options, "DEFAULT_ROLE").Words != "R" {
+			t.Errorf("DEFAULT_ROLE = %+v", findOption(stmt.Options, "DEFAULT_ROLE"))
+		}
+		for _, n := range []string{"LOGIN_NAME", "DISPLAY_NAME", "DEFAULT_WAREHOUSE"} {
+			if findOption(stmt.Options, n) == nil {
+				t.Errorf("missing option %s", n)
+			}
+		}
+	})
+
+	t.Run("rsa key + bool param", func(t *testing.T) {
+		stmt := mustCreateUser(t, "CREATE USER u RSA_PUBLIC_KEY = 'MIIB...' MUST_CHANGE_PASSWORD = TRUE")
+		if findOption(stmt.Options, "RSA_PUBLIC_KEY") == nil {
+			t.Error("missing RSA_PUBLIC_KEY")
+		}
+		mcp := findOption(stmt.Options, "MUST_CHANGE_PASSWORD")
+		if mcp == nil || mcp.Words != "TRUE" {
+			t.Errorf("MUST_CHANGE_PASSWORD = %+v", mcp)
+		}
+	})
+
+	t.Run("default_secondary_roles parenthesized list", func(t *testing.T) {
+		stmt := mustCreateUser(t, "CREATE USER u DEFAULT_SECONDARY_ROLES = ('ALL')")
+		dsr := findOption(stmt.Options, "DEFAULT_SECONDARY_ROLES")
+		if dsr == nil || len(dsr.List) != 1 || dsr.List[0].Value != "ALL" {
+			t.Errorf("DEFAULT_SECONDARY_ROLES = %+v", dsr)
+		}
+	})
+
+	t.Run("default_secondary_roles empty list", func(t *testing.T) {
+		// DEFAULT_SECONDARY_ROLES = () activates no roles (a documented form).
+		stmt := mustCreateUser(t, "CREATE USER u DEFAULT_SECONDARY_ROLES = ()")
+		dsr := findOption(stmt.Options, "DEFAULT_SECONDARY_ROLES")
+		if dsr == nil || dsr.Group == nil {
+			t.Errorf("DEFAULT_SECONDARY_ROLES = %+v (want non-nil empty group)", dsr)
+		}
+	})
+
+	t.Run("with tag", func(t *testing.T) {
+		stmt := mustCreateUser(t, "CREATE USER u LOGIN_NAME = 'ln' WITH TAG (dept = 'eng')")
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Value != "eng" {
+			t.Errorf("Tags = %+v", stmt.Tags)
+		}
+		if findOption(stmt.Options, "LOGIN_NAME") == nil {
+			t.Error("LOGIN_NAME dropped")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE MASKING POLICY / ROW ACCESS POLICY
+//
+// Docs grammar (truth1):
+//
+//	CREATE [ OR REPLACE ] MASKING POLICY [ IF NOT EXISTS ] <name>
+//	  AS ( <arg> <type> [ , ... ] ) RETURNS <type> -> <body>
+//	  [ COMMENT = '...' ] [ EXEMPT_OTHER_POLICIES = { TRUE | FALSE } ]
+//
+//	CREATE [ OR REPLACE ] ROW ACCESS POLICY [ IF NOT EXISTS ] <name>
+//	  AS ( <arg> <type> [ , ... ] ) RETURNS BOOLEAN -> <body> [ COMMENT = '...' ]
+// ---------------------------------------------------------------------------
+
+func TestParseCreateMaskingPolicy(t *testing.T) {
+	t.Run("single arg", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE MASKING POLICY mp AS (val string) RETURNS string -> val")
+		if stmt.Kind != ast.PolicyMasking {
+			t.Errorf("Kind = %v, want Masking", stmt.Kind)
+		}
+		if stmt.Name.String() != "mp" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+		if len(stmt.Args) != 1 || stmt.Args[0].Name.String() != "val" {
+			t.Fatalf("Args = %+v", stmt.Args)
+		}
+		if strings.ToUpper(stmt.Args[0].DataType.Name) != "STRING" {
+			t.Errorf("arg type = %q", stmt.Args[0].DataType.Name)
+		}
+		if stmt.Returns == nil || strings.ToUpper(stmt.Returns.Name) != "STRING" {
+			t.Errorf("Returns = %+v", stmt.Returns)
+		}
+		if stmt.Body == nil {
+			t.Error("Body is nil")
+		}
+		assertSecurityLoc(t, stmt.Loc, "CreatePolicyStmt(masking)")
+		assertSecurityLoc(t, stmt.Args[0].Loc, "PolicyArg")
+	})
+
+	t.Run("multiple args", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE MASKING POLICY mp AS (email varchar, visibility string) RETURNS varchar -> case when visibility = 'Public' then email else '***' end")
+		if len(stmt.Args) != 2 {
+			t.Fatalf("Args = %+v", stmt.Args)
+		}
+		if stmt.Args[1].Name.String() != "visibility" {
+			t.Errorf("arg[1] = %q", stmt.Args[1].Name.String())
+		}
+		if _, ok := stmt.Body.(*ast.CaseExpr); !ok {
+			t.Errorf("Body = %T, want *ast.CaseExpr", stmt.Body)
+		}
+	})
+
+	t.Run("case body", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE OR REPLACE MASKING POLICY email_mask AS (val string) RETURNS string -> CASE WHEN current_role() IN ('ANALYST') THEN VAL ELSE '********' END")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+		if _, ok := stmt.Body.(*ast.CaseExpr); !ok {
+			t.Errorf("Body = %T", stmt.Body)
+		}
+		if len(stmt.Options) != 0 {
+			t.Errorf("unexpected options: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("trailing comment and exempt_other_policies", func(t *testing.T) {
+		// Trailing options follow the body. The expression parser must stop at
+		// 'comment' rather than swallowing it.
+		stmt := mustCreatePolicy(t, "CREATE MASKING POLICY mp AS (val string) RETURNS string -> case when 1=1 then val else '*' end COMMENT = 'c' EXEMPT_OTHER_POLICIES = true")
+		if findOption(stmt.Options, "COMMENT") == nil || findOption(stmt.Options, "COMMENT").Lit.Value != "c" {
+			t.Errorf("COMMENT option = %+v", findOption(stmt.Options, "COMMENT"))
+		}
+		eop := findOption(stmt.Options, "EXEMPT_OTHER_POLICIES")
+		if eop == nil || eop.Words != "TRUE" {
+			t.Errorf("EXEMPT_OTHER_POLICIES = %+v", eop)
+		}
+	})
+
+	t.Run("if not exists + qualified name", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE MASKING POLICY IF NOT EXISTS governance.policies.email_mask AS (val string) RETURNS string -> val")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+		if stmt.Name.String() != "governance.policies.email_mask" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+}
+
+func TestParseCreateRowAccessPolicy(t *testing.T) {
+	t.Run("case body returns boolean", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE OR REPLACE ROW ACCESS POLICY rap_it AS (empl_id varchar) RETURNS BOOLEAN -> case when 'it_admin' = current_role() then true else false end")
+		if stmt.Kind != ast.PolicyRowAccess {
+			t.Errorf("Kind = %v, want RowAccess", stmt.Kind)
+		}
+		if stmt.Returns == nil || strings.ToUpper(stmt.Returns.Name) != "BOOLEAN" {
+			t.Errorf("Returns = %+v", stmt.Returns)
+		}
+		if _, ok := stmt.Body.(*ast.CaseExpr); !ok {
+			t.Errorf("Body = %T", stmt.Body)
+		}
+	})
+
+	t.Run("boolean expression body with subquery", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE OR REPLACE ROW ACCESS POLICY rap AS (sales_region varchar) RETURNS BOOLEAN -> 'exec' = current_role() or exists (select 1 from t where region = sales_region)")
+		if stmt.Body == nil {
+			t.Fatal("Body is nil")
+		}
+		if _, ok := stmt.Body.(*ast.BinaryExpr); !ok {
+			t.Errorf("Body = %T, want *ast.BinaryExpr (OR)", stmt.Body)
+		}
+	})
+
+	t.Run("trivial true body, two args", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE OR REPLACE ROW ACCESS POLICY rap_test2 AS (n number, v varchar) RETURNS BOOLEAN -> true")
+		if len(stmt.Args) != 2 {
+			t.Errorf("Args = %+v", stmt.Args)
+		}
+		if lit, ok := stmt.Body.(*ast.Literal); !ok || lit.Kind != ast.LitBool {
+			t.Errorf("Body = %T", stmt.Body)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE { SESSION | PASSWORD | NETWORK | AUTHENTICATION } POLICY (option bags)
+// ---------------------------------------------------------------------------
+
+func TestParseCreateOptionBagPolicies(t *testing.T) {
+	t.Run("session policy", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE SESSION POLICY sp SESSION_IDLE_TIMEOUT_MINS = 30 SESSION_UI_IDLE_TIMEOUT_MINS = 10 COMMENT = 'c'")
+		if stmt.Kind != ast.PolicySession {
+			t.Errorf("Kind = %v", stmt.Kind)
+		}
+		if stmt.Args != nil || stmt.Returns != nil || stmt.Body != nil {
+			t.Errorf("option-bag policy should have nil Args/Returns/Body: %+v", stmt)
+		}
+		if findOption(stmt.Options, "SESSION_IDLE_TIMEOUT_MINS").Lit.Ival != 30 {
+			t.Errorf("SESSION_IDLE_TIMEOUT_MINS = %+v", findOption(stmt.Options, "SESSION_IDLE_TIMEOUT_MINS"))
+		}
+		if findOption(stmt.Options, "COMMENT").Lit.Value != "c" {
+			t.Errorf("COMMENT = %+v", findOption(stmt.Options, "COMMENT"))
+		}
+		assertSecurityLoc(t, stmt.Loc, "CreatePolicyStmt(session)")
+	})
+
+	t.Run("password policy", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE OR REPLACE PASSWORD POLICY IF NOT EXISTS pp PASSWORD_MIN_LENGTH = 10 PASSWORD_MAX_RETRIES = 3")
+		if stmt.Kind != ast.PolicyPassword || !stmt.OrReplace || !stmt.IfNotExists {
+			t.Errorf("flags: %+v", stmt)
+		}
+		if findOption(stmt.Options, "PASSWORD_MIN_LENGTH").Lit.Ival != 10 {
+			t.Errorf("PASSWORD_MIN_LENGTH = %+v", findOption(stmt.Options, "PASSWORD_MIN_LENGTH"))
+		}
+	})
+
+	t.Run("network policy (docs ALLOWED_NETWORK_RULE_LIST)", func(t *testing.T) {
+		// The docs' current network policy options (ALLOWED_NETWORK_RULE_LIST /
+		// BLOCKED_NETWORK_RULE_LIST) supersede the legacy ANTLR grammar's
+		// ALLOWED_IP_LIST / BLOCKED_IP_LIST; the open-ended bag accepts both.
+		stmt := mustCreatePolicy(t, "CREATE NETWORK POLICY np ALLOWED_NETWORK_RULE_LIST = ('a') BLOCKED_NETWORK_RULE_LIST = ('b')")
+		if stmt.Kind != ast.PolicyNetwork {
+			t.Errorf("Kind = %v", stmt.Kind)
+		}
+		anrl := findOption(stmt.Options, "ALLOWED_NETWORK_RULE_LIST")
+		if anrl == nil || len(anrl.List) != 1 || anrl.List[0].Value != "a" {
+			t.Errorf("ALLOWED_NETWORK_RULE_LIST = %+v", anrl)
+		}
+	})
+
+	t.Run("network policy (legacy ALLOWED_IP_LIST)", func(t *testing.T) {
+		stmt := mustCreatePolicy(t, "CREATE NETWORK POLICY np ALLOWED_IP_LIST = ('192.168.1.0/24') BLOCKED_IP_LIST = ('192.168.1.99')")
+		if findOption(stmt.Options, "ALLOWED_IP_LIST") == nil {
+			t.Error("ALLOWED_IP_LIST dropped")
+		}
+	})
+
+	t.Run("authentication policy (no legacy ANTLR rule; docs only)", func(t *testing.T) {
+		// AUTHENTICATION POLICY has no rule in the legacy grammar at all — it is a
+		// docs-only object. AUTHENTICATION is a non-reserved identifier, so the
+		// dispatcher keys on the AUTHENTICATION+POLICY token pair.
+		stmt := mustCreatePolicy(t, "CREATE AUTHENTICATION POLICY ap AUTHENTICATION_METHODS = ('SAML', 'PASSWORD') CLIENT_TYPES = ('SNOWFLAKE_UI', 'DRIVERS') MFA_ENROLLMENT = 'REQUIRED' COMMENT = 'c'")
+		if stmt.Kind != ast.PolicyAuthentication {
+			t.Errorf("Kind = %v", stmt.Kind)
+		}
+		am := findOption(stmt.Options, "AUTHENTICATION_METHODS")
+		if am == nil || len(am.List) != 2 {
+			t.Errorf("AUTHENTICATION_METHODS = %+v", am)
+		}
+		mfa := findOption(stmt.Options, "MFA_ENROLLMENT")
+		if mfa == nil || mfa.Lit == nil || mfa.Lit.Value != "REQUIRED" {
+			t.Errorf("MFA_ENROLLMENT = %+v", mfa)
+		}
+	})
+
+	t.Run("authentication policy nested group option", func(t *testing.T) {
+		// MFA_POLICY = ( <sub-properties> ) is a nested key/value group.
+		stmt := mustCreatePolicy(t, "CREATE AUTHENTICATION POLICY ap CLIENT_POLICY = (SNOWFLAKE_UI = (MINIMUM_VERSION = '1.0'))")
+		cp := findOption(stmt.Options, "CLIENT_POLICY")
+		if cp == nil || len(cp.Group) == 0 {
+			t.Errorf("CLIENT_POLICY = %+v (want nested group)", cp)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER ROLE
+//
+// Docs/legacy alter_role:
+//
+//	ALTER [ DATABASE ] ROLE [ IF EXISTS ] <name>
+//	  { RENAME TO <n> | SET COMMENT = '...' | UNSET COMMENT
+//	  | SET TAG ... | UNSET TAG ... }
+// ---------------------------------------------------------------------------
+
+func TestParseAlterRole(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterRole(t, "ALTER ROLE r RENAME TO r2")
+		if stmt.Action != ast.AlterRoleRename || stmt.NewName.String() != "r2" {
+			t.Errorf("Action=%v NewName=%v", stmt.Action, stmt.NewName)
+		}
+		assertSecurityLoc(t, stmt.Loc, "AlterRoleStmt")
+	})
+
+	t.Run("if exists set comment", func(t *testing.T) {
+		stmt := mustAlterRole(t, "ALTER ROLE IF EXISTS r SET COMMENT = 'c'")
+		if !stmt.IfExists || stmt.Action != ast.AlterRoleSetComment {
+			t.Errorf("IfExists=%v Action=%v", stmt.IfExists, stmt.Action)
+		}
+		if stmt.Comment == nil || *stmt.Comment != "c" {
+			t.Errorf("Comment = %v", stmt.Comment)
+		}
+	})
+
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterRole(t, "ALTER ROLE r UNSET COMMENT")
+		if stmt.Action != ast.AlterRoleUnset {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterRole(t, "ALTER ROLE r SET TAG a = 'b', c = 'd'")
+		if stmt.Action != ast.AlterRoleSetTag || len(stmt.Tags) != 2 {
+			t.Errorf("Action=%v Tags=%+v", stmt.Action, stmt.Tags)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterRole(t, "ALTER ROLE r UNSET TAG a, b")
+		if stmt.Action != ast.AlterRoleUnsetTag || len(stmt.UnsetTags) != 2 {
+			t.Errorf("Action=%v UnsetTags=%+v", stmt.Action, stmt.UnsetTags)
+		}
+	})
+
+	t.Run("database role rename", func(t *testing.T) {
+		stmt := mustAlterRole(t, "ALTER DATABASE ROLE mydb.dr RENAME TO mydb.dr2")
+		if !stmt.Database || stmt.Action != ast.AlterRoleRename {
+			t.Errorf("Database=%v Action=%v", stmt.Database, stmt.Action)
+		}
+		if stmt.Name.String() != "mydb.dr" || stmt.NewName.String() != "mydb.dr2" {
+			t.Errorf("Name=%q NewName=%q", stmt.Name.String(), stmt.NewName.String())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER USER
+// ---------------------------------------------------------------------------
+
+func TestParseAlterUser(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER u RENAME TO u2")
+		if stmt.Action != ast.AlterUserRename || stmt.NewName.String() != "u2" {
+			t.Errorf("Action=%v NewName=%v", stmt.Action, stmt.NewName)
+		}
+		assertSecurityLoc(t, stmt.Loc, "AlterUserStmt")
+	})
+
+	t.Run("reset password", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER u RESET PASSWORD")
+		if stmt.Action != ast.AlterUserResetPassword {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+	})
+
+	t.Run("abort all queries", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER IF EXISTS u ABORT ALL QUERIES")
+		if !stmt.IfExists || stmt.Action != ast.AlterUserAbortQueries {
+			t.Errorf("IfExists=%v Action=%v", stmt.IfExists, stmt.Action)
+		}
+	})
+
+	t.Run("set options", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER u SET DEFAULT_ROLE = r DISABLED = TRUE DEFAULT_WAREHOUSE = wh")
+		if stmt.Action != ast.AlterUserSet {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+		if findOption(stmt.Options, "DEFAULT_ROLE") == nil || findOption(stmt.Options, "DISABLED") == nil {
+			t.Errorf("options = %+v", stmt.Options)
+		}
+	})
+
+	t.Run("unset properties (keyword names)", func(t *testing.T) {
+		// DEFAULT_ROLE / DISPLAY_NAME lex as keywords; the open-ended UNSET name
+		// list must accept any name word, not just the DB/SCHEMA vocabulary.
+		stmt := mustAlterUser(t, "ALTER USER u UNSET DEFAULT_ROLE, DISPLAY_NAME, COMMENT")
+		if stmt.Action != ast.AlterUserUnset {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+		want := []string{"DEFAULT_ROLE", "DISPLAY_NAME", "COMMENT"}
+		if len(stmt.UnsetProps) != 3 {
+			t.Fatalf("UnsetProps = %+v", stmt.UnsetProps)
+		}
+		for i, w := range want {
+			if stmt.UnsetProps[i] != w {
+				t.Errorf("UnsetProps[%d] = %q, want %q", i, stmt.UnsetProps[i], w)
+			}
+		}
+	})
+
+	t.Run("set tag / unset tag", func(t *testing.T) {
+		s1 := mustAlterUser(t, "ALTER USER u SET TAG dept = 'eng'")
+		if s1.Action != ast.AlterUserSetTag || len(s1.Tags) != 1 {
+			t.Errorf("set tag: %+v", s1)
+		}
+		s2 := mustAlterUser(t, "ALTER USER u UNSET TAG dept")
+		if s2.Action != ast.AlterUserUnsetTag || len(s2.UnsetTags) != 1 {
+			t.Errorf("unset tag: %+v", s2)
+		}
+	})
+
+	t.Run("add delegated authorization", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER u ADD DELEGATED AUTHORIZATION OF ROLE r TO SECURITY INTEGRATION i")
+		if stmt.Action != ast.AlterUserAddDelegated {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+		if !strings.Contains(stmt.Raw, "DELEGATED") {
+			t.Errorf("Raw = %q", stmt.Raw)
+		}
+	})
+
+	t.Run("remove delegated authorization of role", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER u REMOVE DELEGATED AUTHORIZATION OF ROLE r FROM SECURITY INTEGRATION i")
+		if stmt.Action != ast.AlterUserRemoveDelegated {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+	})
+
+	t.Run("remove delegated authorizations", func(t *testing.T) {
+		stmt := mustAlterUser(t, "ALTER USER u REMOVE DELEGATED AUTHORIZATIONS FROM SECURITY INTEGRATION i")
+		if stmt.Action != ast.AlterUserRemoveDelegated {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK | AUTHENTICATION }
+// POLICY
+// ---------------------------------------------------------------------------
+
+func TestParseAlterPolicy(t *testing.T) {
+	t.Run("masking set body", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER MASKING POLICY mp SET BODY -> case when 1=1 then a else '*' end")
+		if stmt.Kind != ast.PolicyMasking || stmt.Action != ast.AlterPolicySetBody {
+			t.Errorf("Kind=%v Action=%v", stmt.Kind, stmt.Action)
+		}
+		if _, ok := stmt.Body.(*ast.CaseExpr); !ok {
+			t.Errorf("Body = %T", stmt.Body)
+		}
+		assertSecurityLoc(t, stmt.Loc, "AlterPolicyStmt")
+	})
+
+	t.Run("masking rename", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER MASKING POLICY IF EXISTS mp RENAME TO mp2")
+		if !stmt.IfExists || stmt.Action != ast.AlterPolicyRename || stmt.NewName.String() != "mp2" {
+			t.Errorf("%+v", stmt)
+		}
+	})
+
+	t.Run("masking set comment", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER MASKING POLICY mp SET COMMENT = 'c'")
+		if stmt.Action != ast.AlterPolicySet {
+			t.Errorf("Action = %v", stmt.Action)
+		}
+		if findOption(stmt.Options, "COMMENT").Lit.Value != "c" {
+			t.Errorf("COMMENT = %+v", findOption(stmt.Options, "COMMENT"))
+		}
+	})
+
+	t.Run("row access set body", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER ROW ACCESS POLICY rap SET BODY -> true")
+		if stmt.Kind != ast.PolicyRowAccess || stmt.Action != ast.AlterPolicySetBody {
+			t.Errorf("Kind=%v Action=%v", stmt.Kind, stmt.Action)
+		}
+	})
+
+	t.Run("session set / unset", func(t *testing.T) {
+		s1 := mustAlterPolicy(t, "ALTER SESSION POLICY sp SET SESSION_IDLE_TIMEOUT_MINS = 5")
+		if s1.Kind != ast.PolicySession || s1.Action != ast.AlterPolicySet {
+			t.Errorf("set: %+v", s1)
+		}
+		s2 := mustAlterPolicy(t, "ALTER SESSION POLICY sp UNSET SESSION_IDLE_TIMEOUT_MINS, COMMENT")
+		if s2.Action != ast.AlterPolicyUnset || len(s2.UnsetProps) != 2 {
+			t.Errorf("unset: %+v", s2)
+		}
+	})
+
+	t.Run("password unset", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER PASSWORD POLICY pp UNSET PASSWORD_MIN_LENGTH")
+		if stmt.Kind != ast.PolicyPassword || stmt.Action != ast.AlterPolicyUnset {
+			t.Errorf("%+v", stmt)
+		}
+	})
+
+	t.Run("network set", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER NETWORK POLICY np SET ALLOWED_IP_LIST = ('1.2.3.4')")
+		if stmt.Kind != ast.PolicyNetwork || stmt.Action != ast.AlterPolicySet {
+			t.Errorf("%+v", stmt)
+		}
+	})
+
+	t.Run("policy set tag / unset tag", func(t *testing.T) {
+		s1 := mustAlterPolicy(t, "ALTER MASKING POLICY mp SET TAG t = 'v'")
+		if s1.Action != ast.AlterPolicySetTag || len(s1.Tags) != 1 {
+			t.Errorf("set tag: %+v", s1)
+		}
+		s2 := mustAlterPolicy(t, "ALTER MASKING POLICY mp UNSET TAG t")
+		if s2.Action != ast.AlterPolicyUnsetTag || len(s2.UnsetTags) != 1 {
+			t.Errorf("unset tag: %+v", s2)
+		}
+	})
+
+	t.Run("authentication set", func(t *testing.T) {
+		stmt := mustAlterPolicy(t, "ALTER AUTHENTICATION POLICY ap SET COMMENT = 'c'")
+		if stmt.Kind != ast.PolicyAuthentication || stmt.Action != ast.AlterPolicySet {
+			t.Errorf("%+v", stmt)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — the parser must reject these (it must not be over-permissive)
+// ---------------------------------------------------------------------------
+
+func TestParseSecurityNegatives(t *testing.T) {
+	bad := []string{
+		"CREATE ROLE",          // missing name
+		"CREATE DATABASE ROLE", // missing name
+		"CREATE USER",          // missing name
+		"CREATE MASKING POLICY mp RETURNS string -> val",              // missing AS (args)
+		"CREATE MASKING POLICY mp AS (val string) -> val",             // missing RETURNS
+		"CREATE MASKING POLICY mp AS (val string) RETURNS string",     // missing -> body
+		"CREATE MASKING POLICY mp AS (val string) RETURNS string -> ", // missing body expr
+		"CREATE MASKING POLICY mp AS () RETURNS string -> val",        // empty arg list
+		"CREATE MASKING POLICY mp AS (val) RETURNS string -> val",     // arg missing type
+		"CREATE ROW ACCESS POLICY rap AS (a int) RETURNS BOOLEAN val", // missing arrow
+		"CREATE MASKING mp AS (a int) RETURNS int -> a",               // MASKING not followed by POLICY
+		"CREATE ROW POLICY rap AS (a int) RETURNS BOOLEAN -> true",    // ROW not followed by ACCESS
+		"CREATE SESSION sp COMMENT = 'c'",                             // SESSION not followed by POLICY
+		"CREATE AUTHENTICATION ap COMMENT = 'c'",                      // AUTHENTICATION not followed by POLICY
+		"ALTER ROLE r SET",                                            // SET nothing
+		"ALTER ROLE r SET DEFAULT_ROLE = x",                           // ROLE has no settable options other than COMMENT/TAG
+		"ALTER ROLE r FOO",                                            // unknown action
+		"ALTER USER u SET",                                            // SET nothing
+		"ALTER USER u UNSET",                                          // UNSET nothing
+		"ALTER USER u ADD DELEGATED AUTHORIZATION OF ROLE r",          // truncated (missing TO SECURITY INTEGRATION)
+		"ALTER USER u REMOVE DELEGATED FROM SECURITY INTEGRATION i",   // REMOVE DELEGATED missing AUTHORIZATION(S)
+		"ALTER MASKING POLICY mp SET BODY val",                        // missing arrow
+		"ALTER MASKING POLICY mp SET",                                 // SET nothing
+		"ALTER MASKING POLICY mp FROBNICATE",                          // unknown action
+	}
+	for _, sql := range bad {
+		t.Run(sql, func(t *testing.T) {
+			res := ParseBestEffort(sql)
+			if len(res.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got AST %T", sql, firstStmt(res))
+			}
+		})
+	}
+}
+
+func firstStmt(r *ParseResult) ast.Node {
+	if len(r.File.Stmts) > 0 {
+		return r.File.Stmts[0]
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// DATABASE ROLE vs DATABASE disambiguation. `CREATE DATABASE ROLE x` is a
+// database role; a database literally named ROLE must be quoted
+// (CREATE DATABASE "ROLE"). The dispatcher keys on the ROLE keyword after
+// DATABASE, matching Snowflake's grammar precedence.
+// ---------------------------------------------------------------------------
+
+func TestSecurityDatabaseRoleDisambiguation(t *testing.T) {
+	cases := []struct {
+		sql      string
+		wantRole bool // true => Create/AlterRoleStmt; false => Create/AlterDatabaseStmt
+	}{
+		{`CREATE DATABASE "ROLE"`, false},
+		{"CREATE DATABASE mydb", false},
+		{"CREATE DATABASE ROLE dr", true},
+		{"CREATE OR REPLACE DATABASE ROLE IF NOT EXISTS db.dr", true},
+		{"ALTER DATABASE ROLE db.dr RENAME TO db.dr2", true},
+		{`ALTER DATABASE "ROLE" RENAME TO d2`, false},
+		{"ALTER DATABASE mydb RENAME TO d2", false},
+	}
+	for _, c := range cases {
+		t.Run(c.sql, func(t *testing.T) {
+			node := mustParseOne(t, c.sql)
+			_, isCreateRole := node.(*ast.CreateRoleStmt)
+			_, isAlterRole := node.(*ast.AlterRoleStmt)
+			gotRole := isCreateRole || isAlterRole
+			if gotRole != c.wantRole {
+				t.Errorf("%q: role-node=%v want=%v (got %T)", c.sql, gotRole, c.wantRole, node)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch isolation — same-prefix statements owned by other nodes must NOT be
+// mis-parsed as a T4.6 node. (They may be unsupported or syntax errors, but they
+// must never become a Create/AlterPolicyStmt.)
+// ---------------------------------------------------------------------------
+
+func TestSecurityDispatchIsolation(t *testing.T) {
+	// ALTER SESSION SET ... is the session statement (a different node); it must
+	// not be routed to ALTER SESSION POLICY.
+	res := ParseBestEffort("ALTER SESSION SET TIMEZONE = 'UTC'")
+	for _, s := range res.File.Stmts {
+		if _, ok := s.(*ast.AlterPolicyStmt); ok {
+			t.Errorf("ALTER SESSION SET misrouted to AlterPolicyStmt")
+		}
+	}
+	// CREATE NETWORK RULE is a different object; it must not become a NETWORK
+	// POLICY. (It is currently unsupported; the assertion is that it is not a
+	// CreatePolicyStmt.)
+	res = ParseBestEffort("CREATE NETWORK RULE nr TYPE = IPV4 VALUE_LIST = ('1.2.3.4')")
+	for _, s := range res.File.Stmts {
+		if _, ok := s.(*ast.CreatePolicyStmt); ok {
+			t.Errorf("CREATE NETWORK RULE misrouted to CreatePolicyStmt")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk coverage — the policy body expression must be reachable via Walk (so
+// query-span / analysis can descend into it). A round-trip Walk must visit a
+// node inside the body.
+// ---------------------------------------------------------------------------
+
+func TestSecurityWalkBody(t *testing.T) {
+	stmt := mustCreatePolicy(t, "CREATE MASKING POLICY mp AS (val string) RETURNS string -> current_role()")
+	found := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if _, ok := n.(*ast.FuncCallExpr); ok {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Error("policy body FuncCallExpr not reachable via Walk/Inspect")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official-docs corpus — every CREATE statement in the security corpus dirs
+// must parse to the expected AST type. Context statements (USE ...) and the
+// DESC NETWORK POLICY statement are owned by other nodes and skipped.
+// ---------------------------------------------------------------------------
+
+func TestSecurityOfficialCorpus(t *testing.T) {
+	dirs := []string{
+		"testdata/official/create-role",
+		"testdata/official/create-user",
+		"testdata/official/create-masking-policy",
+		"testdata/official/create-row-access-policy",
+		"testdata/official/create-network-policy",
+	}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read corpus dir %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			t.Run(path, func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				assertSecurityStatementsParse(t, string(data))
+			})
+		}
+	}
+}
+
+// assertSecurityStatementsParse parses sql and asserts that every CREATE ROLE /
+// USER / POLICY and ALTER ... statement parses with no errors and to a T4.6 AST
+// type. Statements owned by other nodes (USE, DESC/DESCRIBE, GRANT, and the
+// CREATE OR ALTER preview form) are skipped with a note.
+func assertSecurityStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+
+		// CREATE OR ALTER preview form is owned by parser-or-alter; skip (and
+		// surface if it unexpectedly starts parsing here).
+		if strings.Contains(upper, "CREATE OR ALTER") {
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: CREATE OR ALTER now parses, revisit skip: %q", text)
+			}
+			continue
+		}
+
+		var want func(ast.Node) bool
+		switch {
+		case strings.HasPrefix(upper, "CREATE ROLE"),
+			strings.HasPrefix(upper, "CREATE OR REPLACE ROLE"),
+			strings.HasPrefix(upper, "CREATE DATABASE ROLE"),
+			strings.HasPrefix(upper, "CREATE OR REPLACE DATABASE ROLE"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.CreateRoleStmt); return ok }
+		case strings.HasPrefix(upper, "CREATE USER"),
+			strings.HasPrefix(upper, "CREATE OR REPLACE USER"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.CreateUserStmt); return ok }
+		case strings.Contains(upper, "POLICY") && strings.HasPrefix(upper, "CREATE"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.CreatePolicyStmt); return ok }
+		case strings.HasPrefix(upper, "ALTER") && strings.Contains(upper, "POLICY"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.AlterPolicyStmt); return ok }
+		default:
+			// USE / DESC / DESCRIBE / GRANT context statements owned by other nodes.
+			continue
+		}
+
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+			continue
+		}
+		if !want(node) {
+			t.Errorf("statement %q parsed to unexpected type %T", text, node)
+		}
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-security` (v1 DAG **T4.6**) — `CREATE`/`ALTER` access-control objects: `ROLE` (incl. `DATABASE ROLE`), `USER`, and the six policy objects (`MASKING` / `ROW ACCESS` / `SESSION` / `PASSWORD` / `NETWORK` / `AUTHENTICATION POLICY`). `DROP` for these stays in drop.go (untouched).

## Design
- New AST: `CreateRoleStmt`, `CreateUserStmt`, `CreatePolicyStmt` (Kind-discriminated over the 6 policy kinds), `PolicyArg`, `AlterRoleStmt`, `AlterUserStmt`, `AlterPolicyStmt` — all with valid `Loc`; the policy `-> <expr>` body is a walked `Node`. `walk_generated.go` regenerated via `genwalker`.
- USER + SESSION/PASSWORD/NETWORK/AUTHENTICATION policies parse options as open-ended `KEY = value` (`ast.CopyOption`), mirroring merged STAGE/FILE-FORMAT/COPY.
- MASKING / ROW ACCESS: typed arg list `AS (<arg> <type>, …)` via `parseDataType`, `RETURNS <type>`, `-> <expr>` body via the expression parser (verified it stops exactly at trailing options, doesn't swallow `COMMENT=`).
- Dispatch in `parseCreateStmt`/`parseAlterStmt`: `kwROLE`/`kwUSER` + multi-keyword policy forms; `DATABASE ROLE` disambiguated from `CREATE DATABASE` by the `ROLE` keyword; same-prefix non-policy statements (`ALTER SESSION SET`, `CREATE NETWORK RULE`) guarded out.

## Oracle / tests
Triangulation — legacy ANTLR (`create_role`/`create_user`/`create_masking_policy`/`create_row_access_policy`/`create_*_policy`/`alter_*`) + official docs (docs win) + corpus `testdata/official/{create-role,create-user,create-masking-policy,create-row-access-policy,create-network-policy}`. **~104 subtests** (all 12 corpus files, exhaustive forms, negatives, dispatch-isolation, DATABASE-ROLE disambiguation, Walk-reachability). `go test ./snowflake/... -timeout 180s` green; `go vet`/`gofmt` clean.

## Divergences (flagged — ledger 130-134; docs win)
1. NETWORK POLICY gains `OR REPLACE`/`IF NOT EXISTS` + rule-list options (`ALLOWED_NETWORK_RULE_LIST` etc.) absent from the legacy rule.
2. AUTHENTICATION POLICY — docs-only object, no legacy rule.
3. DATABASE ROLE with db-qualified name — absent from legacy.
4. ALTER USER `SET`/`UNSET <props>` — legacy comments these out.
5. `SET TAG`/`UNSET TAG` for MASKING & ROW ACCESS policies — legacy omits them.
Plus the standard `CREATE OR ALTER`/`$N` corpus filters (owned by `parser-or-alter`/`expr-dollar-refs`).

## Review
Claude `/code-review` (inline — no nested agent in worker context) across line-by-line/removed-behavior/cross-file/reuse/efficiency angles — no blockers. Orchestrator independently verified build/`-timeout` tests/scope/gofmt. Codex lens unavailable (out of credits).

## Note
Opened by orchestrator from the worker's verified, pushed commit `5ea4ba86`. No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)