### PR TITLE
feat(googlesql/parser-gql): GQL graph query + CREATE PROPERTY GRAPH

### DIFF
--- a/googlesql/analysis/classify.go
+++ b/googlesql/analysis/classify.go
@@ -156,13 +156,31 @@ func Classify(node ast.Node, dialect Dialect) QueryType {
 		*ast.CreateSequenceStmt, *ast.AlterSequenceStmt, *ast.DropSequenceStmt,
 		*ast.CreateRoleStmt, *ast.DropRoleStmt,
 		*ast.CreateLocalityGroupStmt, *ast.AlterLocalityGroupStmt, *ast.DropLocalityGroupStmt,
-		*ast.CreateProtoBundleStmt, *ast.AlterProtoBundleStmt:
+		*ast.CreateProtoBundleStmt, *ast.AlterProtoBundleStmt,
+		// CREATE PROPERTY GRAPH (parser-gql node) is DDL — the legacy
+		// queryTypeListener lists create_property_graph_statement directly among the
+		// DDL forms (plugin/parser/{bigquery,spanner}/query_type.go), same as every
+		// other CREATE.
+		*ast.CreatePropertyGraphStmt:
 		return DDL
 
 	// DCL — GRANT / REVOKE are DDL in the legacy listener (its rule list groups
 	// privilege statements under DDL alongside CREATE/ALTER/DROP).
 	case *ast.GrantStmt, *ast.RevokeStmt:
 		return DDL
+
+	// GQL graph query (parser-gql node: `GRAPH <name> <ops>`). The legacy
+	// queryTypeListener has NO case for gql_statement, so it falls through its
+	// switch to `default: base.QueryTypeUnknown` — a bare GQL graph read is
+	// classified Unknown, NOT Select, in BOTH dialects
+	// (plugin/parser/{bigquery,spanner}/query_type.go). We mirror that exactly:
+	// query-type parity with bytebase means Unknown here (the legacy GetQuerySpan
+	// then short-circuits a non-Select to an empty span — see query_span.go's
+	// GQLStmt handling, divergence-ledger note). An explicit case (rather than
+	// relying on the default) documents this is a deliberate, evidence-backed
+	// parity choice, not an oversight.
+	case *ast.GQLStmt:
+		return Unknown
 
 	default:
 		return Unknown

--- a/googlesql/analysis/classify_test.go
+++ b/googlesql/analysis/classify_test.go
@@ -80,11 +80,25 @@ func TestClassifySQL(t *testing.T) {
 		{"grant role to role", "GRANT ROLE a TO ROLE b", DDL},
 		{"revoke role from role", "REVOKE ROLE a FROM ROLE b", DDL},
 
+		// --- DDL — CREATE PROPERTY GRAPH (parser-gql node). Every CREATE form is
+		// DDL; the legacy queryTypeListener lists create_property_graph_statement
+		// directly among the DDL alternatives. ---
+		{"create property graph", "CREATE PROPERTY GRAPH g NODE TABLES (Person)", DDL},
+		{"create or replace property graph", "CREATE OR REPLACE PROPERTY GRAPH g NODE TABLES (Person) EDGE TABLES (Knows SOURCE KEY (a) REFERENCES Person DESTINATION KEY (b) REFERENCES Person)", DDL},
+
 		// --- Unknown / empty ---
 		{"empty", "", Unknown},
 		{"whitespace only", "   \n  ", Unknown},
 		{"comment only", "-- just a comment\n", Unknown},
 		{"garbage", "this is not sql", Unknown},
+
+		// --- GQL graph query (parser-gql node). A bare `GRAPH … MATCH … RETURN …`
+		// read classifies UNKNOWN, NOT Select: the legacy queryTypeListener has no
+		// gql_statement case and falls through to `default: QueryTypeUnknown` in both
+		// dialects. This is deliberate parity (see Classify's GQLStmt case + the
+		// divergence ledger), so it lives with the Unknown group. ---
+		{"gql graph query", "GRAPH g MATCH (n) RETURN n", Unknown},
+		{"gql graph query with ops", "GRAPH g MATCH (a)-[e]->(b) WHERE a.id = 1 RETURN a, b", Unknown},
 	}
 
 	for _, tc := range tests {

--- a/googlesql/analysis/query_span_test.go
+++ b/googlesql/analysis/query_span_test.go
@@ -430,3 +430,41 @@ func TestGetQuerySpan_LambdaParamsExcluded(t *testing.T) {
 		t.Errorf("source columns = %v, want [arr threshold] (lambda param e excluded)", cols)
 	}
 }
+
+// TestGetQuerySpan_GQLEmptySpan pins the parser-gql query-span DISPOSITION
+// (finding F9): a GQL graph query (`GRAPH … MATCH … RETURN …`) yields an EMPTY
+// span — Type=Unknown, no AccessTables, no Results, no PredicateColumns. This is
+// faithful parity with the legacy bytebase GetQuerySpan, which short-circuits any
+// non-Select statement to `{Type: <unknown>, SourceColumns: {}, Results: []}`
+// (plugin/parser/{bigquery,spanner}/query_span_extractor.go getQuerySpan) and
+// whose accessTableListener walks only table_path_expression nodes — graph
+// element patterns reference labels, not table paths, so legacy records nothing
+// for a graph read either. Deferred-parity: a future source-table-discovery pass
+// over graph patterns is tracked as a divergence/follow-up, not implemented here.
+func TestGetQuerySpan_GQLEmptySpan(t *testing.T) {
+	cases := []string{
+		"GRAPH g MATCH (n) RETURN n",
+		"GRAPH g MATCH (a)-[e]->(b) WHERE a.id = b.id RETURN a, b",
+		"GRAPH myproject.mydataset.g MATCH (p:Person) RETURN p.name",
+	}
+	for _, sql := range cases {
+		for _, dialect := range []Dialect{DialectBigQuery, DialectSpanner} {
+			span, err := GetQuerySpan(sql, dialect)
+			if err != nil {
+				t.Fatalf("GetQuerySpan(%q, %v) error: %v", sql, dialect, err)
+			}
+			if span.Type != Unknown {
+				t.Errorf("GetQuerySpan(%q, %v) Type = %v, want Unknown (legacy non-Select parity)", sql, dialect, span.Type)
+			}
+			if len(span.AccessTables) != 0 {
+				t.Errorf("GetQuerySpan(%q, %v) AccessTables = %v, want empty", sql, dialect, tableNames(span))
+			}
+			if len(span.Results) != 0 {
+				t.Errorf("GetQuerySpan(%q, %v) Results = %v, want empty", sql, dialect, resultNames(span))
+			}
+			if len(span.PredicateColumns) != 0 {
+				t.Errorf("GetQuerySpan(%q, %v) PredicateColumns = %v, want empty", sql, dialect, predicateColumnNames(span))
+			}
+		}
+	}
+}

--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -213,6 +213,43 @@ const (
 	T_LoadDataStmt
 	T_CloneDataStmt
 	T_CloneDataSource
+
+	// GQL / property-graph (parser-gql node).
+	//
+	// The §2.12 graph query language and the create_property_graph_statement
+	// DDL from the legacy ANTLR grammar (GoogleSQLParser.g4) — a hand-port of
+	// ZetaSQL's GoogleSQL graph extension (BigQuery / Spanner Graph). The
+	// top-level GQL statement (`GRAPH <path> <ops>`), its linear/composite query
+	// blocks, the GQL operators (MATCH / LET / FILTER / ORDER BY / PAGE / WITH /
+	// FOR / RETURN / TABLESAMPLE), the graph-pattern tree (path / node / edge
+	// patterns, the element-pattern filler, label algebra, property specs), and
+	// the CREATE PROPERTY GRAPH element-table definitions.
+	T_GQLStmt
+	T_GraphSetOp
+	T_GraphLinearQuery
+	T_GraphMatchOp
+	T_GraphLetOp
+	T_GraphLetVar
+	T_GraphFilterOp
+	T_GraphOrderByOp
+	T_GraphPageOp
+	T_GraphWithOp
+	T_GraphForOp
+	T_GraphSampleOp
+	T_GraphReturnOp
+	T_GraphReturnItem
+	T_GraphPattern
+	T_GraphPathPattern
+	T_GraphNodePattern
+	T_GraphEdgePattern
+	T_GraphPatternFiller
+	T_GraphPropertySpec
+	T_GraphPropertyNameValue
+	T_GraphLabelExpr
+	T_CreatePropertyGraphStmt
+	T_ElementTableDef
+	T_LabelAndProperties
+	T_DerivedProperty
 )
 
 // String returns a human-readable representation of the tag.
@@ -480,6 +517,58 @@ func (t NodeTag) String() string {
 		return "CloneDataStmt"
 	case T_CloneDataSource:
 		return "CloneDataSource"
+	case T_GQLStmt:
+		return "GQLStmt"
+	case T_GraphSetOp:
+		return "GraphSetOp"
+	case T_GraphLinearQuery:
+		return "GraphLinearQuery"
+	case T_GraphMatchOp:
+		return "GraphMatchOp"
+	case T_GraphLetOp:
+		return "GraphLetOp"
+	case T_GraphLetVar:
+		return "GraphLetVar"
+	case T_GraphFilterOp:
+		return "GraphFilterOp"
+	case T_GraphOrderByOp:
+		return "GraphOrderByOp"
+	case T_GraphPageOp:
+		return "GraphPageOp"
+	case T_GraphWithOp:
+		return "GraphWithOp"
+	case T_GraphForOp:
+		return "GraphForOp"
+	case T_GraphSampleOp:
+		return "GraphSampleOp"
+	case T_GraphReturnOp:
+		return "GraphReturnOp"
+	case T_GraphReturnItem:
+		return "GraphReturnItem"
+	case T_GraphPattern:
+		return "GraphPattern"
+	case T_GraphPathPattern:
+		return "GraphPathPattern"
+	case T_GraphNodePattern:
+		return "GraphNodePattern"
+	case T_GraphEdgePattern:
+		return "GraphEdgePattern"
+	case T_GraphPatternFiller:
+		return "GraphPatternFiller"
+	case T_GraphPropertySpec:
+		return "GraphPropertySpec"
+	case T_GraphPropertyNameValue:
+		return "GraphPropertyNameValue"
+	case T_GraphLabelExpr:
+		return "GraphLabelExpr"
+	case T_CreatePropertyGraphStmt:
+		return "CreatePropertyGraphStmt"
+	case T_ElementTableDef:
+		return "ElementTableDef"
+	case T_LabelAndProperties:
+		return "LabelAndProperties"
+	case T_DerivedProperty:
+		return "DerivedProperty"
 	default:
 		return "Unknown"
 	}

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -3471,3 +3471,550 @@ var (
 	_ Node = (*CreateProtoBundleStmt)(nil)
 	_ Node = (*AlterProtoBundleStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// GQL — graph query language + CREATE PROPERTY GRAPH (parser-gql node)
+// ---------------------------------------------------------------------------
+//
+// The §2.12 GQL sub-language and create_property_graph_statement from the
+// legacy ANTLR grammar (GoogleSQLParser.g4) — a hand-port of ZetaSQL's
+// GoogleSQL graph extension (BigQuery / Spanner Graph). One omni AST serves
+// both dialects: the production accepts the BigQuery+Spanner union.
+//
+// ORACLE NOTE — GQL is BigQuery/Spanner-Graph syntax. The Spanner emulator's
+// accept/reject is recorded by the differential harness and used where it does
+// not disagree with the legacy .g4; the authoritative reference for the GQL
+// grammar shape is the pinned legacy GoogleSQLParser.g4 itself (the truth1
+// BigQuery corpus explicitly scopes GQL out — INDEX.md). See
+// graph_query_oracle_test.go.
+
+// GQLStmt is a top-level GQL graph query (gql_statement):
+//
+//	GRAPH <path> <graph_operation_block>
+//
+// Name is the graph name (path_expression). Blocks is the NEXT-separated list
+// of composite query blocks (graph_operation_block: block (NEXT block)*); it has
+// >= 1 entry. Each block is a *GraphLinearQuery or a *GraphSetOp.
+type GQLStmt struct {
+	Name   *PathExpr
+	Blocks []Node // *GraphLinearQuery | *GraphSetOp; >= 1
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *GQLStmt) Tag() NodeTag { return T_GQLStmt }
+
+// GraphSetOp is a set-operation-joined chain of linear query operations
+// (graph_composite_query_prefix): a sequence of >= 2 linear queries separated by
+// set-operation metadata. Ops holds the linear queries (each a
+// *GraphLinearQuery), and Metas holds the set-operation metadata BETWEEN them
+// (len(Metas) == len(Ops)-1): Metas[i] joins Ops[i] and Ops[i+1].
+type GraphSetOp struct {
+	Ops   []Node            // *GraphLinearQuery; >= 2
+	Metas []*GraphSetOpMeta // set-op between consecutive Ops; len == len(Ops)-1
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *GraphSetOp) Tag() NodeTag { return T_GraphSetOp }
+
+// GraphSetOpMeta is one set-operation metadata token pair
+// (graph_set_operation_metadata: query_set_operation_type all_or_distinct).
+// Op is "UNION" | "EXCEPT" | "INTERSECT"; Quantifier is "ALL" | "DISTINCT"
+// (both are REQUIRED by the grammar). It is a plain value type, not a Node.
+type GraphSetOpMeta struct {
+	Op         string // "UNION" | "EXCEPT" | "INTERSECT"
+	Quantifier string // "ALL" | "DISTINCT"
+	Loc        Loc
+}
+
+// GraphLinearQuery is a graph_linear_query_operation:
+//
+//	[graph_linear_operator …] <graph_return_operator>
+//
+// Operators is the leading sequence of linear operators (MATCH / OPTIONAL MATCH
+// / LET / FILTER / ORDER BY / PAGE / WITH / FOR / TABLESAMPLE), each a Node of
+// the corresponding Graph*Op type; nil if there were none. Return is the
+// trailing RETURN operator (required by the grammar) — a *GraphReturnOp.
+type GraphLinearQuery struct {
+	Operators []Node // Graph*Op operators; may be empty
+	Return    *GraphReturnOp
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *GraphLinearQuery) Tag() NodeTag { return T_GraphLinearQuery }
+
+// GraphMatchOp is a (graph_match_operator / graph_optional_match_operator):
+//
+//	[OPTIONAL] MATCH [hint] <graph_pattern>
+//
+// Optional flags the OPTIONAL prefix. Pattern is the graph pattern matched.
+type GraphMatchOp struct {
+	Optional bool
+	Pattern  *GraphPattern
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *GraphMatchOp) Tag() NodeTag { return T_GraphMatchOp }
+
+// GraphLetOp is a graph_let_operator (`LET <var defs>`). Vars has >= 1 entry.
+type GraphLetOp struct {
+	Vars []*GraphLetVar // >= 1
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *GraphLetOp) Tag() NodeTag { return T_GraphLetOp }
+
+// GraphLetVar is one variable definition of a LET operator
+// (graph_let_variable_definition: identifier = expression).
+type GraphLetVar struct {
+	Name string
+	Expr Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *GraphLetVar) Tag() NodeTag { return T_GraphLetVar }
+
+// GraphFilterOp is a graph_filter_operator:
+//
+//	FILTER WHERE <expr>   |   FILTER <expr>
+//
+// HasWhere records whether the WHERE keyword was present (`FILTER WHERE expr`)
+// vs the bare `FILTER expr` form. Expr is the filter predicate.
+type GraphFilterOp struct {
+	HasWhere bool
+	Expr     Node
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *GraphFilterOp) Tag() NodeTag { return T_GraphFilterOp }
+
+// GraphOrderByOp is a graph_order_by_operator (graph_order_by_clause):
+//
+//	ORDER [hint] BY <ordering_expression> (, …)
+//
+// Items reuses OrderItem (the shared `expr [COLLATE] [ASC|DESC|ASCENDING|
+// DESCENDING] [NULLS …]` ordering element); >= 1 entry.
+type GraphOrderByOp struct {
+	Items []*OrderItem // >= 1
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *GraphOrderByOp) Tag() NodeTag { return T_GraphOrderByOp }
+
+// GraphPageOp is a graph_page_operator (graph_page_clause):
+//
+//	(OFFSET|SKIP) <n> [LIMIT <n>]   |   LIMIT <n>
+//
+// Skip records `OFFSET <n>` / `SKIP <n>` (nil if the bare-LIMIT form was used).
+// SkipIsSkip distinguishes the SKIP spelling from OFFSET. Limit is the LIMIT
+// count (nil if a bare OFFSET/SKIP with no LIMIT).
+type GraphPageOp struct {
+	Skip       Node // OFFSET/SKIP count; nil if bare LIMIT
+	SkipIsSkip bool // true if the SKIP keyword was used (vs OFFSET)
+	Limit      Node // LIMIT count; nil if bare OFFSET/SKIP
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *GraphPageOp) Tag() NodeTag { return T_GraphPageOp }
+
+// GraphWithOp is a graph_with_operator:
+//
+//	WITH [ALL|DISTINCT] [hint] <return_item_list> [GROUP BY …]
+//
+// Quantifier is "ALL" | "DISTINCT" | "" (absent). Items is the projected return
+// items (>= 1). GroupBy is the optional trailing GROUP BY clause (nil if absent)
+// — it reuses the shared GroupByClause.
+type GraphWithOp struct {
+	Quantifier string             // "ALL" | "DISTINCT" | ""
+	Items      []*GraphReturnItem // >= 1
+	GroupBy    *GroupByClause     // nil if absent
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *GraphWithOp) Tag() NodeTag { return T_GraphWithOp }
+
+// GraphForOp is a graph_for_operator:
+//
+//	FOR <id> IN <expr> [WITH OFFSET [AS alias]]
+//
+// Name is the loop variable. Expr is the iterated expression. WithOffset records
+// the `WITH OFFSET` suffix; OffsetAlias is its optional `AS alias` ("" if absent
+// or no WITH OFFSET).
+type GraphForOp struct {
+	Name        string
+	Expr        Node
+	WithOffset  bool
+	OffsetAlias string
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *GraphForOp) Tag() NodeTag { return T_GraphForOp }
+
+// GraphSampleOp is a graph_sample_clause:
+//
+//	TABLESAMPLE <method> ( <size> (ROWS|PERCENT) ) [WITH WEIGHT [AS id]] [REPEATABLE(n)]
+//
+// Method is the sampling method identifier (e.g. RESERVOIR / BERNOULLI). Size is
+// the sample size expression; Unit is "ROWS" | "PERCENT". WithWeight records the
+// `WITH WEIGHT` suffix; WeightAlias its optional `AS id` ("" if absent).
+// Repeatable holds the REPEATABLE(n) seed expression (nil if absent).
+type GraphSampleOp struct {
+	Method      string
+	Size        Node
+	Unit        string // "ROWS" | "PERCENT"
+	WithWeight  bool
+	WeightAlias string
+	Repeatable  Node // REPEATABLE(n); nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *GraphSampleOp) Tag() NodeTag { return T_GraphSampleOp }
+
+// GraphReturnOp is a graph_return_operator:
+//
+//	RETURN [hint] [ALL|DISTINCT] <return_item_list> [GROUP BY] [ORDER BY] [PAGE]
+//
+// Quantifier is "ALL" | "DISTINCT" | "". Items is the return list (>= 1). GroupBy
+// / OrderBy / Page are the optional trailing clauses (nil/absent if not present).
+type GraphReturnOp struct {
+	Quantifier string             // "ALL" | "DISTINCT" | ""
+	Items      []*GraphReturnItem // >= 1
+	GroupBy    *GroupByClause     // nil if absent
+	OrderBy    []*OrderItem       // nil if absent
+	Page       *GraphPageOp       // nil if absent
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *GraphReturnOp) Tag() NodeTag { return T_GraphReturnOp }
+
+// GraphReturnItem is one entry of a graph_return_item_list (graph_return_item):
+//
+//	<expr> [AS alias]   |   *
+//
+// Star is true for the bare `*` form (Expr nil). Otherwise Expr is the projected
+// expression and Alias the optional `AS name` ("" if absent).
+type GraphReturnItem struct {
+	Expr  Node   // nil for `*`
+	Star  bool   // true for `*`
+	Alias string // `AS alias`; "" if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *GraphReturnItem) Tag() NodeTag { return T_GraphReturnItem }
+
+// GraphPattern is a graph_pattern (`<path_pattern_list> [WHERE]`). Paths has
+// >= 1 path pattern; Where is the optional trailing WHERE predicate (nil if
+// absent).
+type GraphPattern struct {
+	Paths []*GraphPathPattern // >= 1
+	Where Node                // nil if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *GraphPattern) Tag() NodeTag { return T_GraphPattern }
+
+// GraphPathPattern is a graph_path_pattern:
+//
+//	[<var> =] [(ANY|ALL) [SHORTEST]] [<mode> [PATH|PATHS]] <path_pattern_expr>
+//
+// PathVar is the optional `<id> =` path-variable assignment ("" if absent).
+// Search is the optional search prefix ("ANY" | "ALL" | "ANY SHORTEST" |
+// "ALL SHORTEST" | ""). Mode is the optional path-mode prefix ("WALK" | "TRAIL"
+// | "SIMPLE" | "ACYCLIC", optionally suffixed " PATH"/" PATHS"; "" if absent).
+// Factors is the sequence of path factors (node/edge/parenthesized patterns,
+// each a Node) that make up the path expression (>= 1).
+type GraphPathPattern struct {
+	PathVar string // path-variable assignment id; "" if absent
+	Search  string // "ANY" | "ALL" | "ANY SHORTEST" | "ALL SHORTEST" | ""
+	Mode    string // "WALK"/"TRAIL"/"SIMPLE"/"ACYCLIC" [PATH|PATHS]; "" if absent
+	Factors []Node // *GraphNodePattern | *GraphEdgePattern | *GraphPathPattern (parenthesized); >= 1
+	// Where is the trailing `WHERE <expr>` of a parenthesized path pattern
+	// (graph_parenthesized_path_pattern: '(' … graph_path_pattern where_clause? ')').
+	// It is nil for a top-level (non-parenthesized) path pattern, whose WHERE
+	// belongs to the enclosing graph_pattern instead.
+	Where Node // parenthesized-path trailing WHERE; nil if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *GraphPathPattern) Tag() NodeTag { return T_GraphPathPattern }
+
+// GraphNodePattern is a graph_node_pattern (`( <filler> )`). Filler carries the
+// optional variable / label expression / property spec / inline WHERE.
+type GraphNodePattern struct {
+	Filler *GraphPatternFiller
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *GraphNodePattern) Tag() NodeTag { return T_GraphNodePattern }
+
+// GraphEdgeDirection enumerates the six graph_edge_pattern shapes (three
+// abbreviated — EdgeAny / EdgeLeft / EdgeRight — and three full forms —
+// EdgeLeftFull / EdgeRightFull / EdgeUndirectedFull).
+type GraphEdgeDirection int
+
+const (
+	// EdgeAny is the undirected abbreviated edge `-` (MINUS_OPERATOR).
+	EdgeAny GraphEdgeDirection = iota
+	// EdgeLeft is the left-directed abbreviated edge `<-` (LT MINUS).
+	EdgeLeft
+	// EdgeRight is the right-directed abbreviated edge `->` (SUB_GT_BRACKET).
+	EdgeRight
+	// EdgeLeftFull is the left-directed full edge `<-[ filler ]-`.
+	EdgeLeftFull
+	// EdgeRightFull is the right-directed full edge `-[ filler ]->`.
+	EdgeRightFull
+	// EdgeUndirectedFull is the undirected full edge `-[ filler ]-` (the legacy
+	// graph_edge_pattern's first alternative `LT_OPERATOR? MINUS … MINUS` with the
+	// leading `<` ABSENT — distinct from EdgeLeftFull, which has it present).
+	EdgeUndirectedFull
+)
+
+// GraphEdgePattern is a graph_edge_pattern. Direction selects the arrow shape;
+// Filler is the bracketed `[ … ]` filler for the three full forms (EdgeLeftFull
+// / EdgeRightFull / EdgeUndirectedFull) and nil for the three abbreviated forms
+// (EdgeAny / EdgeLeft / EdgeRight).
+type GraphEdgePattern struct {
+	Direction GraphEdgeDirection
+	Filler    *GraphPatternFiller // nil for abbreviated edges
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *GraphEdgePattern) Tag() NodeTag { return T_GraphEdgePattern }
+
+// GraphPatternFiller is a graph_element_pattern_filler — the shared interior of
+// a node `( … )` or full-edge `[ … ]` pattern:
+//
+//	[hint] [<var>] [(IS|:) <label_expr>] [{ prop : expr, … }] [WHERE]
+//
+// Var is the optional element variable ("" if absent). Label is the optional
+// label expression (nil if absent); LabelColon records whether the `:` spelling
+// (vs `IS`) introduced it. Properties is the optional `{ … }` property
+// specification (nil if absent). Where is the optional inline WHERE predicate
+// (nil if absent).
+type GraphPatternFiller struct {
+	Var        string
+	Label      *GraphLabelExpr // nil if absent
+	LabelColon bool            // true if `:` spelling, false if `IS`
+	Properties *GraphPropertySpec
+	Where      Node // inline WHERE; nil if absent
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *GraphPatternFiller) Tag() NodeTag { return T_GraphPatternFiller }
+
+// GraphLabelKind enumerates a label_expression / label_primary shape.
+type GraphLabelKind int
+
+const (
+	// LabelName is a bare label identifier (label_primary: identifier).
+	LabelName GraphLabelKind = iota
+	// LabelWildcard is the `%` any-label primary (MODULO_OPERATOR).
+	LabelWildcard
+	// LabelNot is `! <label>` (EXCLAMATION_OPERATOR label_expression).
+	LabelNot
+	// LabelAnd is `<label> & <label>` (BIT_AND_SYMBOL).
+	LabelAnd
+	// LabelOr is `<label> | <label>` (STROKE_SYMBOL).
+	LabelOr
+)
+
+// GraphLabelExpr is a node of the label algebra (label_expression /
+// label_primary): a bare label, the `%` wildcard, negation `!`, or the binary
+// `&` / `|` combinators. Parens are dropped (parenthesized_label_expression is
+// transparent — associativity is captured by the tree shape).
+//
+// For LabelName, Name holds the label identifier. For LabelNot, Operand is the
+// negated sub-expression. For LabelAnd / LabelOr, Left and Right are the
+// operands. LabelWildcard carries no children.
+type GraphLabelExpr struct {
+	Kind    GraphLabelKind
+	Name    string          // for LabelName
+	Operand *GraphLabelExpr // for LabelNot
+	Left    *GraphLabelExpr // for LabelAnd / LabelOr
+	Right   *GraphLabelExpr // for LabelAnd / LabelOr
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *GraphLabelExpr) Tag() NodeTag { return T_GraphLabelExpr }
+
+// GraphPropertySpec is a graph_property_specification (`{ id : expr, … }`).
+// Properties has >= 1 entry.
+type GraphPropertySpec struct {
+	Properties []*GraphPropertyNameValue // >= 1
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *GraphPropertySpec) Tag() NodeTag { return T_GraphPropertySpec }
+
+// GraphPropertyNameValue is one entry of a property specification
+// (graph_property_name_and_value: identifier : expression).
+type GraphPropertyNameValue struct {
+	Name string
+	Expr Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *GraphPropertyNameValue) Tag() NodeTag { return T_GraphPropertyNameValue }
+
+// CreatePropertyGraphStmt is a CREATE PROPERTY GRAPH statement
+// (create_property_graph_statement):
+//
+//	CREATE [OR REPLACE] PROPERTY GRAPH [IF NOT EXISTS] <path>
+//	  [OPTIONS(…)] NODE TABLES ( <element_table>, … ) [EDGE TABLES ( … )]
+//
+// OrReplace / IfNotExists flag the prefixes. Name is the graph name. Options is
+// the optional OPTIONS list. NodeTables is the required NODE TABLES element
+// list (>= 1). EdgeTables is the optional EDGE TABLES element list (nil if
+// absent).
+type CreatePropertyGraphStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *PathExpr
+	Options     []*OptionsEntry
+	NodeTables  []*ElementTableDef // >= 1
+	EdgeTables  []*ElementTableDef // nil if no EDGE TABLES clause
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreatePropertyGraphStmt) Tag() NodeTag { return T_CreatePropertyGraphStmt }
+
+// ElementTableDef is one entry of a NODE/EDGE TABLES list
+// (element_table_definition):
+//
+//	<path> [AS alias] [KEY ( cols )]
+//	  [SOURCE KEY ( cols ) REFERENCES <node> [( cols )]]
+//	  [DESTINATION KEY ( cols ) REFERENCES <node> [( cols )]]
+//	  [<label-and-properties> | <properties-clause>]
+//
+// Name is the underlying table path. Alias is the optional `AS alias` ("" if
+// absent). Key is the optional `KEY ( … )` column list (nil if absent). Source /
+// Dest are the optional SOURCE / DESTINATION node-table references (edge tables;
+// nil if absent). Labels is the label-and-properties list (the
+// opt_label_and_properties_clause); nil if absent.
+type ElementTableDef struct {
+	Name   *PathExpr
+	Alias  string
+	Key    []string         // KEY ( cols ); nil if absent
+	Source *ElementTableRef // SOURCE KEY … REFERENCES …; nil if absent
+	Dest   *ElementTableRef // DESTINATION KEY … REFERENCES …; nil if absent
+	Labels []*LabelAndProperties
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ElementTableDef) Tag() NodeTag { return T_ElementTableDef }
+
+// ElementTableRef is a SOURCE / DESTINATION node-table reference of an edge
+// table (opt_source_node_table_clause / opt_dest_node_table_clause):
+//
+//	(SOURCE|DESTINATION) KEY ( cols ) REFERENCES <node> [( cols )]
+//
+// Columns is the local edge-table key column list. Node is the referenced node
+// table name. RefColumns is the optional referenced-column list (nil if absent).
+// It is a plain value type, not a Node.
+type ElementTableRef struct {
+	Columns    []string // KEY ( cols )
+	Node       string   // REFERENCES <node>
+	RefColumns []string // optional ( cols ) after the node; nil if absent
+	Loc        Loc
+}
+
+// LabelKind discriminates a properties_clause shape inside a label-and-properties
+// or a bare element-table properties clause.
+type LabelKind int
+
+const (
+	// LabelPropsAllColumns is `PROPERTIES [ARE] ALL COLUMNS [EXCEPT ( cols )]`.
+	LabelPropsAllColumns LabelKind = iota
+	// LabelPropsNone is `NO PROPERTIES`.
+	LabelPropsNone
+	// LabelPropsList is `PROPERTIES ( <derived_property>, … )`.
+	LabelPropsList
+	// LabelPropsDefault is no properties clause on this label entry.
+	LabelPropsDefault
+)
+
+// LabelAndProperties is one entry of a label_and_properties_list, OR the bare
+// properties_clause form of opt_label_and_properties_clause (in which case
+// LabelName is "" and Default is false):
+//
+//	[DEFAULT] LABEL <id> [<properties_clause>]
+//
+// Default flags the `DEFAULT LABEL` form. LabelName is the label identifier (""
+// for the bare-properties form). Kind selects the properties_clause shape;
+// PropsList holds the derived properties for LabelPropsList; ExceptColumns holds
+// the `EXCEPT ( cols )` list for LabelPropsAllColumns (nil if none).
+type LabelAndProperties struct {
+	Default       bool
+	LabelName     string // "" for the bare opt_label_and_properties_clause properties form
+	Kind          LabelKind
+	PropsList     []*DerivedProperty // for LabelPropsList
+	ExceptColumns []string           // EXCEPT ( cols ) for LabelPropsAllColumns; nil if none
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *LabelAndProperties) Tag() NodeTag { return T_LabelAndProperties }
+
+// DerivedProperty is one entry of a derived_property_list
+// (derived_property: expression [AS alias]).
+type DerivedProperty struct {
+	Expr  Node
+	Alias string // `AS alias`; "" if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *DerivedProperty) Tag() NodeTag { return T_DerivedProperty }
+
+// Compile-time assertions that the GQL / property-graph node types satisfy Node.
+var (
+	_ Node = (*GQLStmt)(nil)
+	_ Node = (*GraphSetOp)(nil)
+	_ Node = (*GraphLinearQuery)(nil)
+	_ Node = (*GraphMatchOp)(nil)
+	_ Node = (*GraphLetOp)(nil)
+	_ Node = (*GraphLetVar)(nil)
+	_ Node = (*GraphFilterOp)(nil)
+	_ Node = (*GraphOrderByOp)(nil)
+	_ Node = (*GraphPageOp)(nil)
+	_ Node = (*GraphWithOp)(nil)
+	_ Node = (*GraphForOp)(nil)
+	_ Node = (*GraphSampleOp)(nil)
+	_ Node = (*GraphReturnOp)(nil)
+	_ Node = (*GraphReturnItem)(nil)
+	_ Node = (*GraphPattern)(nil)
+	_ Node = (*GraphPathPattern)(nil)
+	_ Node = (*GraphNodePattern)(nil)
+	_ Node = (*GraphEdgePattern)(nil)
+	_ Node = (*GraphPatternFiller)(nil)
+	_ Node = (*GraphPropertySpec)(nil)
+	_ Node = (*GraphPropertyNameValue)(nil)
+	_ Node = (*GraphLabelExpr)(nil)
+	_ Node = (*CreatePropertyGraphStmt)(nil)
+	_ Node = (*ElementTableDef)(nil)
+	_ Node = (*LabelAndProperties)(nil)
+	_ Node = (*DerivedProperty)(nil)
+)

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -259,6 +259,19 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Options {
 			Walk(v, c)
 		}
+	case *CreatePropertyGraphStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Options {
+			Walk(v, c)
+		}
+		for _, c := range n.NodeTables {
+			Walk(v, c)
+		}
+		for _, c := range n.EdgeTables {
+			Walk(v, c)
+		}
 	case *CreateRoleStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -349,6 +362,8 @@ func walkChildren(v Visitor, node Node) {
 		if n.Returning != nil {
 			Walk(v, n.Returning)
 		}
+	case *DerivedProperty:
+		Walk(v, n.Expr)
 	case *DescribeStmt:
 		if n.Path != nil {
 			Walk(v, n.Path)
@@ -382,6 +397,13 @@ func walkChildren(v Visitor, node Node) {
 		}
 		if n.OnTable != nil {
 			Walk(v, n.OnTable)
+		}
+	case *ElementTableDef:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		for _, c := range n.Labels {
+			Walk(v, c)
 		}
 	case *ExistsExpr:
 		Walk(v, n.Query)
@@ -438,12 +460,110 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Type)
 		}
 		Walk(v, n.Default)
+	case *GQLStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		walkNodes(v, n.Blocks)
 	case *GrantStmt:
 		for _, c := range n.Privileges {
 			Walk(v, c)
 		}
 		for _, c := range n.Grantees {
 			Walk(v, c)
+		}
+	case *GraphEdgePattern:
+		if n.Filler != nil {
+			Walk(v, n.Filler)
+		}
+	case *GraphFilterOp:
+		Walk(v, n.Expr)
+	case *GraphForOp:
+		Walk(v, n.Expr)
+	case *GraphLabelExpr:
+		if n.Operand != nil {
+			Walk(v, n.Operand)
+		}
+		if n.Left != nil {
+			Walk(v, n.Left)
+		}
+		if n.Right != nil {
+			Walk(v, n.Right)
+		}
+	case *GraphLetOp:
+		for _, c := range n.Vars {
+			Walk(v, c)
+		}
+	case *GraphLetVar:
+		Walk(v, n.Expr)
+	case *GraphLinearQuery:
+		walkNodes(v, n.Operators)
+		if n.Return != nil {
+			Walk(v, n.Return)
+		}
+	case *GraphMatchOp:
+		if n.Pattern != nil {
+			Walk(v, n.Pattern)
+		}
+	case *GraphNodePattern:
+		if n.Filler != nil {
+			Walk(v, n.Filler)
+		}
+	case *GraphOrderByOp:
+		for _, c := range n.Items {
+			Walk(v, c)
+		}
+	case *GraphPageOp:
+		Walk(v, n.Skip)
+		Walk(v, n.Limit)
+	case *GraphPathPattern:
+		walkNodes(v, n.Factors)
+		Walk(v, n.Where)
+	case *GraphPattern:
+		for _, c := range n.Paths {
+			Walk(v, c)
+		}
+		Walk(v, n.Where)
+	case *GraphPatternFiller:
+		if n.Label != nil {
+			Walk(v, n.Label)
+		}
+		if n.Properties != nil {
+			Walk(v, n.Properties)
+		}
+		Walk(v, n.Where)
+	case *GraphPropertyNameValue:
+		Walk(v, n.Expr)
+	case *GraphPropertySpec:
+		for _, c := range n.Properties {
+			Walk(v, c)
+		}
+	case *GraphReturnItem:
+		Walk(v, n.Expr)
+	case *GraphReturnOp:
+		for _, c := range n.Items {
+			Walk(v, c)
+		}
+		if n.GroupBy != nil {
+			Walk(v, n.GroupBy)
+		}
+		for _, c := range n.OrderBy {
+			Walk(v, c)
+		}
+		if n.Page != nil {
+			Walk(v, n.Page)
+		}
+	case *GraphSampleOp:
+		Walk(v, n.Size)
+		Walk(v, n.Repeatable)
+	case *GraphSetOp:
+		walkNodes(v, n.Ops)
+	case *GraphWithOp:
+		for _, c := range n.Items {
+			Walk(v, c)
+		}
+		if n.GroupBy != nil {
+			Walk(v, n.GroupBy)
 		}
 	case *GroupByClause:
 		for _, c := range n.Items {
@@ -506,6 +626,10 @@ func walkChildren(v Visitor, node Node) {
 	case *KeyPart:
 		Walk(v, n.Expr)
 		for _, c := range n.Options {
+			Walk(v, c)
+		}
+	case *LabelAndProperties:
+		for _, c := range n.PropsList {
 			Walk(v, c)
 		}
 	case *LambdaExpr:

--- a/googlesql/parser/create_property_graph.go
+++ b/googlesql/parser/create_property_graph.go
@@ -1,0 +1,425 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// CREATE PROPERTY GRAPH (parser-gql node)
+// ---------------------------------------------------------------------------
+//
+// This file ports the legacy ANTLR create_property_graph_statement and its
+// element-table grammar (GoogleSQLParser.g4 §2.4 — element_table_list /
+// element_table_definition / label_and_properties / properties_clause /
+// derived_property_list / source+dest node-table clauses) — a hand-port of
+// ZetaSQL's GoogleSQL graph DDL (BigQuery / Spanner Graph):
+//
+//	CREATE [OR REPLACE] PROPERTY GRAPH [IF NOT EXISTS] <path>
+//	  [OPTIONS(…)]
+//	  NODE TABLES ( <element_table>, … )
+//	  [EDGE TABLES ( <element_table>, … )]
+//
+// One omni parser serves both dialects; it accepts the BigQuery+Spanner union.
+// ORACLE NOTE — the truth1 BigQuery corpus scopes the full graph syntax out
+// (INDEX.md), so the authoritative reference is the pinned legacy .g4; the
+// Spanner emulator verdict is recorded by the differential where it agrees.
+
+// parseCreatePropertyGraph parses the body of a CREATE PROPERTY GRAPH statement
+// after the shared CREATE prefix (OR REPLACE) has been consumed and cur is at
+// the PROPERTY keyword. create_property_graph_statement has NO opt_create_scope,
+// so the caller rejects a leading TEMP/TEMPORARY/PUBLIC/PRIVATE before reaching
+// here.
+//
+//	PROPERTY GRAPH opt_if_not_exists path_expression opt_options_list?
+//	  NODE TABLES element_table_list opt_edge_table_clause?
+func (p *Parser) parseCreatePropertyGraph(create Token, orReplace bool) (ast.Node, error) {
+	p.advance() // PROPERTY
+	if _, err := p.expect(kwGRAPH); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreatePropertyGraphStmt{OrReplace: orReplace}
+	stmt.Loc.Start = create.Loc.Start
+
+	ifTok := p.cur // anchor for the OR-REPLACE/IF-NOT-EXISTS conflict diagnostic
+	ifNotExists, err := p.parseIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	stmt.IfNotExists = ifNotExists
+
+	// OR REPLACE and IF NOT EXISTS are mutually exclusive (a GoogleSQL-wide
+	// invariant — you cannot both replace an object and skip-if-it-exists).
+	// DIVERGENCE from the legacy .g4, which (a) requires IF NOT EXISTS on every
+	// CREATE PROPERTY GRAPH — `opt_or_replace? PROPERTY GRAPH opt_if_not_exists
+	// path_expression`, where opt_if_not_exists carries NO `?` (a hand-port slip:
+	// every other CREATE makes it optional) — and (b) permits OR REPLACE
+	// alongside it. The live Spanner emulator is authoritative for this Spanner-
+	// Graph form: it makes IF NOT EXISTS OPTIONAL and REJECTS the OR REPLACE + IF
+	// NOT EXISTS combination with a true DDL parse error ("CREATE PROPERTY GRAPH
+	// IF NOT EXISTS cannot be used with other existence modifiers such as
+	// `OR REPLACE`"). We follow the oracle: IF NOT EXISTS optional, the pair
+	// rejected. See divergence ledger + graph_query_oracle_test.go.
+	if orReplace && ifNotExists {
+		return nil, &ParseError{
+			Loc: ifTok.Loc,
+			Msg: "syntax error: CREATE PROPERTY GRAPH IF NOT EXISTS cannot be used with OR REPLACE",
+		}
+	}
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc.End = name.Loc.End
+
+	// opt_options_list?  — OPTIONS ( … ).
+	if p.cur.Type == kwOPTIONS {
+		opts, err := p.parseOptionsList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = opts
+	}
+
+	// NODE TABLES <element_table_list>  (required).
+	if _, err := p.expect(kwNODE); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwTABLES); err != nil {
+		return nil, err
+	}
+	nodeTables, end, err := p.parseElementTableList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.NodeTables = nodeTables
+	stmt.Loc.End = end
+
+	// opt_edge_table_clause?  — EDGE TABLES <element_table_list>.
+	if p.cur.Type == kwEDGE {
+		p.advance() // EDGE
+		if _, err := p.expect(kwTABLES); err != nil {
+			return nil, err
+		}
+		edgeTables, eend, err := p.parseElementTableList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.EdgeTables = edgeTables
+		stmt.Loc.End = eend
+	}
+
+	return stmt, nil
+}
+
+// parseElementTableList parses an element_table_list:
+//
+//	( <element_table_definition> (, <element_table_definition>)* [,] )
+//
+// A trailing comma before the close paren is permitted by the grammar. Returns
+// the definitions (>= 1) and the end offset of the close paren.
+func (p *Parser) parseElementTableList() ([]*ast.ElementTableDef, int, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, 0, err
+	}
+	var defs []*ast.ElementTableDef
+	for {
+		def, err := p.parseElementTableDef()
+		if err != nil {
+			return nil, 0, err
+		}
+		defs = append(defs, def)
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ,
+		// Trailing comma: `, )` closes the list.
+		if p.cur.Type == int(')') {
+			break
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, 0, err
+	}
+	return defs, closeTok.Loc.End, nil
+}
+
+// parseElementTableDef parses an element_table_definition:
+//
+//	<path> [AS alias] [KEY ( cols )]
+//	  [SOURCE KEY ( cols ) REFERENCES <node> [( cols )]]
+//	  [DESTINATION KEY ( cols ) REFERENCES <node> [( cols )]]
+//	  [<opt_label_and_properties_clause>]
+func (p *Parser) parseElementTableDef() (*ast.ElementTableDef, error) {
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	def := &ast.ElementTableDef{Name: name, Loc: name.Loc}
+	def.Loc.End = name.Loc.End
+
+	// opt_as_alias_with_required_as?: AS identifier.
+	if p.cur.Type == kwAS {
+		p.advance() // AS
+		tok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		def.Alias = alias
+		def.Loc.End = tok.Loc.End
+	}
+
+	// opt_key_clause?: KEY ( cols ).
+	if p.cur.Type == kwKEY {
+		p.advance() // KEY
+		cols, err := p.parseColumnList()
+		if err != nil {
+			return nil, err
+		}
+		def.Key = cols
+		def.Loc.End = p.prev.Loc.End
+	}
+
+	// opt_source_node_table_clause?: SOURCE KEY ( cols ) REFERENCES node [( cols )].
+	if p.cur.Type == kwSOURCE {
+		ref, err := p.parseNodeTableRef(kwSOURCE)
+		if err != nil {
+			return nil, err
+		}
+		def.Source = ref
+		def.Loc.End = ref.Loc.End
+	}
+
+	// opt_dest_node_table_clause?: DESTINATION KEY ( cols ) REFERENCES node [( cols )].
+	if p.cur.Type == kwDESTINATION {
+		ref, err := p.parseNodeTableRef(kwDESTINATION)
+		if err != nil {
+			return nil, err
+		}
+		def.Dest = ref
+		def.Loc.End = ref.Loc.End
+	}
+
+	// opt_label_and_properties_clause?: properties_clause | label_and_properties+.
+	labels, err := p.parseLabelAndPropertiesClause()
+	if err != nil {
+		return nil, err
+	}
+	if labels != nil {
+		def.Labels = labels
+		def.Loc.End = labels[len(labels)-1].Loc.End
+	}
+
+	return def, nil
+}
+
+// parseNodeTableRef parses a SOURCE / DESTINATION node-table reference
+// (opt_source_node_table_clause / opt_dest_node_table_clause):
+//
+//	(SOURCE|DESTINATION) KEY ( cols ) REFERENCES <identifier> [( cols )]
+//
+// kw is the leading keyword (kwSOURCE or kwDESTINATION), at the current token.
+func (p *Parser) parseNodeTableRef(kw int) (*ast.ElementTableRef, error) {
+	lead := p.advance() // SOURCE | DESTINATION
+	ref := &ast.ElementTableRef{Loc: lead.Loc}
+	if _, err := p.expect(kwKEY); err != nil {
+		return nil, err
+	}
+	cols, err := p.parseColumnList()
+	if err != nil {
+		return nil, err
+	}
+	ref.Columns = cols
+	if _, err := p.expect(kwREFERENCES); err != nil {
+		return nil, err
+	}
+	tok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	node, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	ref.Node = node
+	ref.Loc.End = tok.Loc.End
+	// Optional referenced-column list: `( cols )`.
+	if p.cur.Type == int('(') {
+		refCols, err := p.parseColumnList()
+		if err != nil {
+			return nil, err
+		}
+		ref.RefColumns = refCols
+		ref.Loc.End = p.prev.Loc.End
+	}
+	return ref, nil
+}
+
+// parseLabelAndPropertiesClause parses an opt_label_and_properties_clause:
+//
+//	properties_clause              (the bare form)
+//	| label_and_properties+        (one or more `[DEFAULT] LABEL id [props]`)
+//
+// It returns nil when neither form is present (the clause is optional). The bare
+// properties_clause form is normalized into a single LabelAndProperties entry
+// with an empty LabelName.
+func (p *Parser) parseLabelAndPropertiesClause() ([]*ast.LabelAndProperties, error) {
+	// Bare properties_clause: starts with NO PROPERTIES | PROPERTIES … .
+	if p.cur.Type == kwNO || p.cur.Type == kwPROPERTIES {
+		lp := &ast.LabelAndProperties{Loc: p.cur.Loc}
+		if err := p.parsePropertiesClause(lp); err != nil {
+			return nil, err
+		}
+		return []*ast.LabelAndProperties{lp}, nil
+	}
+	// label_and_properties+: [DEFAULT] LABEL id [properties_clause].
+	if p.cur.Type != kwDEFAULT && p.cur.Type != kwLABEL {
+		return nil, nil
+	}
+	var labels []*ast.LabelAndProperties
+	for p.cur.Type == kwDEFAULT || p.cur.Type == kwLABEL {
+		lp, err := p.parseLabelAndProperties()
+		if err != nil {
+			return nil, err
+		}
+		labels = append(labels, lp)
+	}
+	return labels, nil
+}
+
+// parseLabelAndProperties parses one label_and_properties:
+//
+//	[DEFAULT] LABEL <identifier> [properties_clause]
+func (p *Parser) parseLabelAndProperties() (*ast.LabelAndProperties, error) {
+	lp := &ast.LabelAndProperties{Kind: ast.LabelPropsDefault, Loc: p.cur.Loc}
+	start := p.cur.Loc.Start
+	if p.cur.Type == kwDEFAULT {
+		p.advance() // DEFAULT
+		lp.Default = true
+	}
+	if _, err := p.expect(kwLABEL); err != nil {
+		return nil, err
+	}
+	tok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	lp.LabelName = name
+	lp.Loc = ast.Loc{Start: start, End: tok.Loc.End}
+	// Optional properties_clause.
+	if p.cur.Type == kwNO || p.cur.Type == kwPROPERTIES {
+		if err := p.parsePropertiesClause(lp); err != nil {
+			return nil, err
+		}
+	}
+	return lp, nil
+}
+
+// parsePropertiesClause parses a properties_clause into lp:
+//
+//	NO PROPERTIES
+//	| PROPERTIES ARE? ALL COLUMNS [EXCEPT ( cols )]
+//	| PROPERTIES ( <derived_property>, … )
+//
+// The cursor is at NO or PROPERTIES.
+func (p *Parser) parsePropertiesClause(lp *ast.LabelAndProperties) error {
+	if p.cur.Type == kwNO {
+		p.advance() // NO
+		end, err := p.expect(kwPROPERTIES)
+		if err != nil {
+			return err
+		}
+		lp.Kind = ast.LabelPropsNone
+		lp.Loc.End = end.Loc.End
+		return nil
+	}
+	// PROPERTIES …
+	p.advance() // PROPERTIES
+	// properties_all_columns: PROPERTIES ARE? ALL COLUMNS  — but the leading
+	// PROPERTIES is already consumed. Distinguish ALL-COLUMNS from the
+	// parenthesized derived-property list by the next token.
+	switch {
+	case p.cur.Type == kwARE || p.cur.Type == kwALL:
+		// PROPERTIES [ARE] ALL COLUMNS [EXCEPT ( cols )].
+		if p.cur.Type == kwARE {
+			p.advance() // ARE
+		}
+		if _, err := p.expect(kwALL); err != nil {
+			return err
+		}
+		end, err := p.expect(kwCOLUMNS)
+		if err != nil {
+			return err
+		}
+		lp.Kind = ast.LabelPropsAllColumns
+		lp.Loc.End = end.Loc.End
+		// opt_except_column_list: EXCEPT ( cols ).
+		if p.cur.Type == kwEXCEPT {
+			p.advance() // EXCEPT
+			cols, err := p.parseColumnList()
+			if err != nil {
+				return err
+			}
+			lp.ExceptColumns = cols
+			lp.Loc.End = p.prev.Loc.End
+		}
+		return nil
+	case p.cur.Type == int('('):
+		// PROPERTIES ( <derived_property>, … ).
+		p.advance() // (
+		lp.Kind = ast.LabelPropsList
+		for {
+			dp, err := p.parseDerivedProperty()
+			if err != nil {
+				return err
+			}
+			lp.PropsList = append(lp.PropsList, dp)
+			if p.cur.Type != int(',') {
+				break
+			}
+			p.advance() // ,
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return err
+		}
+		lp.Loc.End = closeTok.Loc.End
+		return nil
+	default:
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// parseDerivedProperty parses one derived_property: expression [AS alias].
+func (p *Parser) parseDerivedProperty() (*ast.DerivedProperty, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	dp := &ast.DerivedProperty{Expr: expr, Loc: ast.Loc{Start: nodeLoc(expr).Start, End: nodeLoc(expr).End}}
+	if p.cur.Type == kwAS {
+		p.advance() // AS
+		tok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		dp.Alias = alias
+		dp.Loc.End = tok.Loc.End
+	}
+	return dp, nil
+}

--- a/googlesql/parser/create_table.go
+++ b/googlesql/parser/create_table.go
@@ -99,6 +99,15 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	case kwSEARCH, kwVECTOR:
 		// CREATE SEARCH|VECTOR INDEX — BigQuery-only (bq_search_vector_index.go).
 		return p.parseCreateSearchVectorIndex(create, orReplace, scope)
+	case kwPROPERTY:
+		// CREATE [OR REPLACE] PROPERTY GRAPH [IF NOT EXISTS] … NODE TABLES (…)
+		// (create_property_graph_statement, parser-gql node →
+		// create_property_graph.go). PROPERTY GRAPH has NO opt_create_scope, so a
+		// leading TEMP/TEMPORARY/PUBLIC/PRIVATE is a syntax error.
+		if scope != "" {
+			return nil, p.syntaxErrorAtCur()
+		}
+		return p.parseCreatePropertyGraph(create, orReplace)
 	case kwSCHEMA:
 		return p.parseCreateSchema(create, orReplace)
 	case kwDATABASE:

--- a/googlesql/parser/graph_query.go
+++ b/googlesql/parser/graph_query.go
@@ -1,0 +1,1424 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// GQL — graph query language (parser-gql node)
+// ---------------------------------------------------------------------------
+//
+// This file ports the legacy ANTLR §2.12 GQL sub-language
+// (GoogleSQLParser.g4 gql_statement and its graph_* / label_expression rules) —
+// a hand-port of ZetaSQL's GoogleSQL graph extension (BigQuery / Spanner Graph).
+// The top-level GQL statement is `GRAPH <path> <graph_operation_block>`, a
+// NEXT-separated list of composite query blocks; each composite block is either
+// a single linear query operation or a set-operation-joined chain. A linear
+// query operation is a sequence of linear operators (MATCH / OPTIONAL MATCH /
+// LET / FILTER / ORDER BY / PAGE / WITH / FOR / TABLESAMPLE) terminated by a
+// required RETURN operator. The graph pattern is a path-pattern list of
+// node `( … )` and edge `-[ … ]->` patterns over a shared element-pattern
+// filler (variable + label algebra + property spec + inline WHERE).
+//
+// ORACLE NOTE — GQL is BigQuery/Spanner-Graph syntax. The Spanner emulator's
+// accept/reject is recorded by the differential (graph_query_oracle_test.go) and
+// used where it does not disagree with the legacy .g4; the truth1 BigQuery corpus
+// explicitly scopes the full GQL syntax OUT (INDEX.md), so the authoritative
+// reference for the grammar shape is the pinned legacy GoogleSQLParser.g4 itself.
+// One omni parser serves both dialects — it accepts the BigQuery+Spanner union.
+
+// parseGQLStmt parses a gql_statement:
+//
+//	GRAPH <path_expression> <graph_operation_block>
+//
+// The GRAPH keyword has NOT been consumed (parseStmt peeks it). The graph
+// operation block is a NEXT-separated list of composite query blocks.
+func (p *Parser) parseGQLStmt() (ast.Node, error) {
+	graph := p.advance() // consume GRAPH
+
+	stmt := &ast.GQLStmt{}
+	stmt.Loc.Start = graph.Loc.Start
+
+	name, err := p.parseTablePath()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// graph_operation_block: composite_query_block (NEXT composite_query_block)*.
+	for {
+		block, err := p.parseGraphCompositeQueryBlock()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Blocks = append(stmt.Blocks, block)
+		stmt.Loc.End = nodeLoc(block).End
+		if p.cur.Type != kwNEXT {
+			break
+		}
+		p.advance() // NEXT
+	}
+	return stmt, nil
+}
+
+// parseGraphCompositeQueryBlock parses a graph_composite_query_block: a single
+// linear query operation, or a graph_composite_query_prefix (a set-operation-
+// joined chain of >= 2 linear query operations). Because both alternatives begin
+// with a linear query operation, we parse one and then check for a trailing
+// set-operation metadata token to decide which alternative we are in.
+func (p *Parser) parseGraphCompositeQueryBlock() (ast.Node, error) {
+	first, err := p.parseGraphLinearQuery()
+	if err != nil {
+		return nil, err
+	}
+	if !p.atGraphSetOpMeta() {
+		return first, nil
+	}
+	// graph_composite_query_prefix: linear (meta linear)+ — at least one more.
+	setOp := &ast.GraphSetOp{Ops: []ast.Node{first}, Loc: first.Loc}
+	for p.atGraphSetOpMeta() {
+		meta, err := p.parseGraphSetOpMeta()
+		if err != nil {
+			return nil, err
+		}
+		next, err := p.parseGraphLinearQuery()
+		if err != nil {
+			return nil, err
+		}
+		setOp.Metas = append(setOp.Metas, meta)
+		setOp.Ops = append(setOp.Ops, next)
+		setOp.Loc.End = next.Loc.End
+	}
+	return setOp, nil
+}
+
+// atGraphSetOpMeta reports whether the cursor is at the start of a
+// graph_set_operation_metadata (query_set_operation_type all_or_distinct): one
+// of UNION / EXCEPT / INTERSECT.
+func (p *Parser) atGraphSetOpMeta() bool {
+	switch p.cur.Type {
+	case kwUNION, kwEXCEPT, kwINTERSECT:
+		return true
+	}
+	return false
+}
+
+// parseGraphSetOpMeta parses a graph_set_operation_metadata:
+// query_set_operation_type all_or_distinct. Both the operation type
+// (UNION|EXCEPT|INTERSECT) and the quantifier (ALL|DISTINCT) are REQUIRED.
+func (p *Parser) parseGraphSetOpMeta() (*ast.GraphSetOpMeta, error) {
+	opTok := p.advance() // UNION | EXCEPT | INTERSECT (atGraphSetOpMeta gated)
+	meta := &ast.GraphSetOpMeta{Op: TokenName(opTok.Type), Loc: opTok.Loc}
+	switch p.cur.Type {
+	case kwALL:
+		meta.Quantifier = "ALL"
+	case kwDISTINCT:
+		meta.Quantifier = "DISTINCT"
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	q := p.advance()
+	meta.Loc.End = q.Loc.End
+	return meta, nil
+}
+
+// parseGraphLinearQuery parses a graph_linear_query_operation:
+//
+//	graph_linear_operator_list? graph_return_operator
+//
+// The operator list is a sequence of linear operators; the RETURN operator is
+// required at the end.
+func (p *Parser) parseGraphLinearQuery() (*ast.GraphLinearQuery, error) {
+	lq := &ast.GraphLinearQuery{Loc: p.cur.Loc}
+	for p.atGraphLinearOperator() {
+		op, err := p.parseGraphLinearOperator()
+		if err != nil {
+			return nil, err
+		}
+		lq.Operators = append(lq.Operators, op)
+	}
+	ret, err := p.parseGraphReturnOp()
+	if err != nil {
+		return nil, err
+	}
+	lq.Return = ret
+	lq.Loc.End = ret.Loc.End
+	if len(lq.Operators) > 0 {
+		lq.Loc.Start = nodeLoc(lq.Operators[0]).Start
+	} else {
+		lq.Loc.Start = ret.Loc.Start
+	}
+	return lq, nil
+}
+
+// atGraphLinearOperator reports whether the cursor is at the start of a
+// graph_linear_operator (one of MATCH / OPTIONAL MATCH / LET / FILTER /
+// ORDER BY / PAGE(OFFSET|SKIP|LIMIT) / WITH / FOR / TABLESAMPLE). RETURN is NOT
+// a linear operator (it terminates the linear query), so it is excluded.
+func (p *Parser) atGraphLinearOperator() bool {
+	switch p.cur.Type {
+	case kwMATCH, kwOPTIONAL, kwLET, kwFILTER, kwORDER, kwWITH, kwFOR,
+		kwTABLESAMPLE, kwOFFSET, kwSKIP, kwLIMIT:
+		return true
+	}
+	return false
+}
+
+// parseGraphLinearOperator parses one graph_linear_operator by dispatching on
+// the leading keyword.
+func (p *Parser) parseGraphLinearOperator() (ast.Node, error) {
+	switch p.cur.Type {
+	case kwMATCH:
+		return p.parseGraphMatchOp(false)
+	case kwOPTIONAL:
+		return p.parseGraphMatchOp(true)
+	case kwLET:
+		return p.parseGraphLetOp()
+	case kwFILTER:
+		return p.parseGraphFilterOp()
+	case kwORDER:
+		return p.parseGraphOrderByOp()
+	case kwOFFSET, kwSKIP, kwLIMIT:
+		return p.parseGraphPageOp()
+	case kwWITH:
+		return p.parseGraphWithOp()
+	case kwFOR:
+		return p.parseGraphForOp()
+	case kwTABLESAMPLE:
+		return p.parseGraphSampleOp()
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseGraphMatchOp parses a graph_match_operator / graph_optional_match_operator:
+//
+//	[OPTIONAL] MATCH [hint] <graph_pattern>
+//
+// When optional is true the cursor is at OPTIONAL; otherwise it is at MATCH.
+func (p *Parser) parseGraphMatchOp(optional bool) (ast.Node, error) {
+	start := p.cur.Loc
+	if optional {
+		p.advance() // OPTIONAL
+		if _, err := p.expect(kwMATCH); err != nil {
+			return nil, err
+		}
+	} else {
+		p.advance() // MATCH
+	}
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	pattern, err := p.parseGraphPattern()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.GraphMatchOp{
+		Optional: optional,
+		Pattern:  pattern,
+		Loc:      ast.Loc{Start: start.Start, End: pattern.Loc.End},
+	}, nil
+}
+
+// parseGraphLetOp parses a graph_let_operator: `LET <var defs>`. Each definition
+// is `identifier = expression`; >= 1.
+func (p *Parser) parseGraphLetOp() (ast.Node, error) {
+	let := p.advance() // LET
+	op := &ast.GraphLetOp{Loc: let.Loc}
+	for {
+		v, err := p.parseGraphLetVar()
+		if err != nil {
+			return nil, err
+		}
+		op.Vars = append(op.Vars, v)
+		op.Loc.End = v.Loc.End
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ,
+	}
+	return op, nil
+}
+
+// parseGraphLetVar parses one graph_let_variable_definition:
+// identifier = expression.
+func (p *Parser) parseGraphLetVar() (*ast.GraphLetVar, error) {
+	tok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('=')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.GraphLetVar{
+		Name: name,
+		Expr: expr,
+		Loc:  ast.Loc{Start: tok.Loc.Start, End: nodeLoc(expr).End},
+	}, nil
+}
+
+// parseGraphFilterOp parses a graph_filter_operator:
+//
+//	FILTER WHERE <expr>   |   FILTER <expr>
+func (p *Parser) parseGraphFilterOp() (ast.Node, error) {
+	filter := p.advance() // FILTER
+	op := &ast.GraphFilterOp{Loc: filter.Loc}
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		op.HasWhere = true
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	op.Expr = expr
+	op.Loc.End = nodeLoc(expr).End
+	return op, nil
+}
+
+// parseGraphOrderByOp parses a graph_order_by_operator (graph_order_by_clause):
+//
+//	ORDER [hint] BY <ordering_expression> (, …)
+//
+// Each ordering expression is `expr [COLLATE c] [ASC|DESC|ASCENDING|DESCENDING]
+// [NULLS FIRST|LAST]`, reusing the shared OrderItem.
+func (p *Parser) parseGraphOrderByOp() (ast.Node, error) {
+	order := p.advance() // ORDER
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	if _, err := p.expect(kwBY); err != nil {
+		return nil, err
+	}
+	items, end, err := p.parseGraphOrderingList()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.GraphOrderByOp{Items: items, Loc: ast.Loc{Start: order.Loc.Start, End: end}}, nil
+}
+
+// parseGraphOrderingList parses a comma-separated list of graph_ordering_expression
+// into OrderItems and returns the end offset of the last item. Used by both the
+// ORDER BY operator and the trailing ORDER BY of RETURN.
+func (p *Parser) parseGraphOrderingList() ([]*ast.OrderItem, int, error) {
+	var items []*ast.OrderItem
+	end := p.cur.Loc.End
+	for {
+		item, err := p.parseGraphOrderingExpr()
+		if err != nil {
+			return nil, 0, err
+		}
+		items = append(items, item)
+		end = item.Loc.End
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ,
+	}
+	return items, end, nil
+}
+
+// parseGraphOrderingExpr parses a graph_ordering_expression:
+//
+//	expression [COLLATE c] [ASC|DESC|ASCENDING|DESCENDING] [NULLS FIRST|LAST]
+//
+// It returns an OrderItem (the shared ordering element). GQL additionally allows
+// the long ASCENDING/DESCENDING spellings (opt_graph_asc_or_desc) on top of the
+// usual ASC/DESC.
+func (p *Parser) parseGraphOrderingExpr() (*ast.OrderItem, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	item := &ast.OrderItem{Expr: expr, Loc: ast.Loc{Start: nodeLoc(expr).Start, End: nodeLoc(expr).End}}
+	if p.cur.Type == kwCOLLATE {
+		p.advance() // COLLATE
+		// collate_clause: COLLATE string_literal_or_parameter. Parse it as a Node
+		// (bit-or precedence, matching the shared parseOrderItem) so the collation
+		// operand is retained on the OrderItem for AST consumers, not just dropped.
+		coll, err := p.parseBinaryExpr(bpBitOr)
+		if err != nil {
+			return nil, err
+		}
+		item.Collate = coll
+		item.Loc.End = nodeLoc(coll).End
+	}
+	if dir, ok := p.matchGraphAscDesc(); ok {
+		item.HasDir = true
+		item.Desc = dir
+		item.Loc.End = p.prev.Loc.End
+	}
+	if no := p.matchNullOrder(); no != "" {
+		nf := no == "FIRST"
+		item.NullsFirst = &nf
+		item.Loc.End = p.prev.Loc.End
+	}
+	return item, nil
+}
+
+// matchGraphAscDesc consumes an opt_graph_asc_or_desc (ASC | DESC | ASCENDING |
+// DESCENDING) if present and returns (isDesc, true), or (false, false) when
+// absent.
+func (p *Parser) matchGraphAscDesc() (bool, bool) {
+	switch p.cur.Type {
+	case kwASC, kwASCENDING:
+		p.advance()
+		return false, true
+	case kwDESC, kwDESCENDING:
+		p.advance()
+		return true, true
+	}
+	return false, false
+}
+
+// parseGraphPageOp parses a graph_page_operator (graph_page_clause) appearing as
+// a standalone linear operator:
+//
+//	(OFFSET|SKIP) <n> [LIMIT <n>]   |   LIMIT <n>
+func (p *Parser) parseGraphPageOp() (ast.Node, error) {
+	return p.parseGraphPageClause()
+}
+
+// parseGraphPageClause parses a graph_page_clause and returns it as a
+// *GraphPageOp. Shared by the standalone PAGE operator and the trailing PAGE of
+// a RETURN operator.
+func (p *Parser) parseGraphPageClause() (*ast.GraphPageOp, error) {
+	// The OFFSET/SKIP/LIMIT counts are possibly_cast_int_literal_or_parameter
+	// (integer / @param / ? / @@sysvar / CAST(… AS …)) — NOT a full expression. A
+	// bare identifier or an arithmetic expression is a syntax error (oracle: the
+	// Spanner emulator rejects `LIMIT x` / `LIMIT 1+1`).
+	op := &ast.GraphPageOp{Loc: p.cur.Loc}
+	switch p.cur.Type {
+	case kwOFFSET, kwSKIP:
+		op.SkipIsSkip = p.cur.Type == kwSKIP
+		p.advance() // OFFSET | SKIP
+		skip, err := p.parseIntLiteralOrParameterOrCast()
+		if err != nil {
+			return nil, err
+		}
+		op.Skip = skip
+		op.Loc.End = nodeLoc(skip).End
+		if p.cur.Type == kwLIMIT {
+			p.advance() // LIMIT
+			lim, err := p.parseIntLiteralOrParameterOrCast()
+			if err != nil {
+				return nil, err
+			}
+			op.Limit = lim
+			op.Loc.End = nodeLoc(lim).End
+		}
+	case kwLIMIT:
+		p.advance() // LIMIT
+		lim, err := p.parseIntLiteralOrParameterOrCast()
+		if err != nil {
+			return nil, err
+		}
+		op.Limit = lim
+		op.Loc.End = nodeLoc(lim).End
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	return op, nil
+}
+
+// parseGraphWithOp parses a graph_with_operator:
+//
+//	WITH [ALL|DISTINCT] [hint] <return_item_list> [GROUP BY …]
+func (p *Parser) parseGraphWithOp() (ast.Node, error) {
+	with := p.advance() // WITH
+	op := &ast.GraphWithOp{Loc: with.Loc}
+	op.Quantifier = p.matchAllOrDistinct()
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	items, end, err := p.parseGraphReturnItemList()
+	if err != nil {
+		return nil, err
+	}
+	op.Items = items
+	op.Loc.End = end
+	if p.cur.Type == kwGROUP {
+		gb, err := p.parseGroupByClause()
+		if err != nil {
+			return nil, err
+		}
+		op.GroupBy = gb
+		op.Loc.End = gb.Loc.End
+	}
+	return op, nil
+}
+
+// parseGraphForOp parses a graph_for_operator:
+//
+//	FOR <id> IN <expr> [WITH OFFSET [AS alias]]
+func (p *Parser) parseGraphForOp() (ast.Node, error) {
+	forTok := p.advance() // FOR
+	op := &ast.GraphForOp{Loc: forTok.Loc}
+	tok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	op.Name = name
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	op.Expr = expr
+	op.Loc.End = nodeLoc(expr).End
+	// opt_with_offset_and_alias_with_required_as: WITH OFFSET [AS alias].
+	if p.cur.Type == kwWITH && p.peekNext().Type == kwOFFSET {
+		p.advance()           // WITH
+		offTok := p.advance() // OFFSET
+		op.WithOffset = true
+		op.Loc.End = offTok.Loc.End
+		if p.cur.Type == kwAS {
+			p.advance() // AS
+			aliasTok, err := p.expectIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			alias, err := p.identifierText(aliasTok)
+			if err != nil {
+				return nil, err
+			}
+			op.OffsetAlias = alias
+			op.Loc.End = aliasTok.Loc.End
+		}
+	}
+	return op, nil
+}
+
+// parseGraphSampleOp parses a graph_sample_clause:
+//
+//	TABLESAMPLE <method> ( <sample_size> ) [opt_graph_sample_clause_suffix]
+//
+// where sample_size is `<value> (ROWS|PERCENT) [PARTITION BY …]` and the suffix
+// is one of `REPEATABLE(n)` / `WITH WEIGHT [REPEATABLE(n)]` /
+// `WITH WEIGHT AS id [REPEATABLE(n)]`.
+func (p *Parser) parseGraphSampleOp() (ast.Node, error) {
+	ts := p.advance() // TABLESAMPLE
+	op := &ast.GraphSampleOp{Loc: ts.Loc}
+	methodTok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	method, err := p.identifierText(methodTok)
+	if err != nil {
+		return nil, err
+	}
+	op.Method = method
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	// sample_size: sample_size_value sample_size_unit partition_by?
+	// sample_size_value is possibly_cast_int_literal_or_parameter OR a
+	// floating_point_literal — NOT a full expression. A bare identifier or an
+	// arithmetic expression is a syntax error (oracle: the Spanner emulator
+	// rejects `(foo ROWS)` / `(1+1 ROWS)`).
+	size, err := p.parseGraphSampleSizeValue()
+	if err != nil {
+		return nil, err
+	}
+	op.Size = size
+	switch p.cur.Type {
+	case kwROWS:
+		op.Unit = "ROWS"
+	case kwPERCENT:
+		op.Unit = "PERCENT"
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // ROWS | PERCENT
+	// partition_by_clause_prefix_no_hint?  — PARTITION BY expr (, expr)* inside
+	// the sample size. The expressions are parse-only here (the sample-size
+	// partition is a rarely-used tail); consume them for parity.
+	if p.cur.Type == kwPARTITION {
+		p.advance() // PARTITION
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		for {
+			if _, err := p.parseExpr(); err != nil {
+				return nil, err
+			}
+			if p.cur.Type != int(',') {
+				break
+			}
+			p.advance() // ,
+		}
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	op.Loc.End = closeTok.Loc.End
+	// opt_graph_sample_clause_suffix.
+	if err := p.parseGraphSampleSuffix(op); err != nil {
+		return nil, err
+	}
+	return op, nil
+}
+
+// parseGraphSampleSuffix consumes an opt_graph_sample_clause_suffix into op:
+//
+//	repeatable_clause
+//	| WITH WEIGHT repeatable_clause?
+//	| WITH WEIGHT AS identifier repeatable_clause?
+func (p *Parser) parseGraphSampleSuffix(op *ast.GraphSampleOp) error {
+	switch p.cur.Type {
+	case kwREPEATABLE:
+		return p.parseRepeatableInto(op)
+	case kwWITH:
+		p.advance() // WITH
+		if _, err := p.expect(kwWEIGHT); err != nil {
+			return err
+		}
+		op.WithWeight = true
+		op.Loc.End = p.prev.Loc.End
+		if p.cur.Type == kwAS {
+			p.advance() // AS
+			aliasTok, err := p.expectIdentifier()
+			if err != nil {
+				return err
+			}
+			alias, err := p.identifierText(aliasTok)
+			if err != nil {
+				return err
+			}
+			op.WeightAlias = alias
+			op.Loc.End = aliasTok.Loc.End
+		}
+		if p.cur.Type == kwREPEATABLE {
+			return p.parseRepeatableInto(op)
+		}
+	}
+	return nil
+}
+
+// parseRepeatableInto parses a repeatable_clause `REPEATABLE ( <n> )` into
+// op.Repeatable. The cursor is at REPEATABLE.
+func (p *Parser) parseRepeatableInto(op *ast.GraphSampleOp) error {
+	p.advance() // REPEATABLE
+	if _, err := p.expect(int('(')); err != nil {
+		return err
+	}
+	n, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	op.Repeatable = n
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return err
+	}
+	op.Loc.End = closeTok.Loc.End
+	return nil
+}
+
+// parseGraphIntLiteralOrParameter parses an int_literal_or_parameter:
+//
+//	integer_literal | parameter_expression | system_variable_expression
+//
+// This is the STRICT form (no CAST, no float) used for graph quantifier bounds
+// (`{ [n,] m }`). It deliberately rejects a bare identifier, a float, a CAST, or
+// any arithmetic expression — the legacy grammar's int_literal_or_parameter does
+// not admit them, and the live Spanner emulator syntax-rejects e.g. `{a,b}` /
+// `{1+1,3}`. (Distinct from parseIntLiteralOrParameterOrCast, the
+// possibly_cast_int_literal_or_parameter superset used for page counts.)
+func (p *Parser) parseGraphIntLiteralOrParameter() (ast.Node, error) {
+	switch p.cur.Type {
+	case tokInteger:
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitInt, Value: tok.Str, Loc: tok.Loc}, nil
+	case int('@'):
+		return p.parseNamedParameter()
+	case tokAtAt:
+		return p.parseSystemVariable()
+	case int('?'):
+		tok := p.advance()
+		return &ast.Parameter{Positional: true, Loc: tok.Loc}, nil
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseGraphSampleSizeValue parses a sample_size_value:
+//
+//	possibly_cast_int_literal_or_parameter | floating_point_literal
+//
+// i.e. the page-count operand set (integer / @param / ? / @@sysvar / CAST)
+// PLUS a floating-point literal (TABLESAMPLE BERNOULLI (10.5 PERCENT)). It
+// rejects a bare identifier or an arithmetic expression as the size (oracle: the
+// Spanner emulator syntax-rejects `(foo ROWS)` / `(1+1 ROWS)`).
+func (p *Parser) parseGraphSampleSizeValue() (ast.Node, error) {
+	if p.cur.Type == tokFloat {
+		tok := p.advance()
+		return &ast.Literal{Kind: ast.LitFloat, Value: tok.Str, Loc: tok.Loc}, nil
+	}
+	return p.parseIntLiteralOrParameterOrCast()
+}
+
+// parseGraphReturnOp parses a graph_return_operator:
+//
+//	RETURN [hint] [ALL|DISTINCT] <return_item_list> [GROUP BY] [ORDER BY] [PAGE]
+func (p *Parser) parseGraphReturnOp() (*ast.GraphReturnOp, error) {
+	ret, err := p.expect(kwRETURN)
+	if err != nil {
+		return nil, err
+	}
+	op := &ast.GraphReturnOp{Loc: ret.Loc}
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	op.Quantifier = p.matchAllOrDistinct()
+	items, end, err := p.parseGraphReturnItemList()
+	if err != nil {
+		return nil, err
+	}
+	op.Items = items
+	op.Loc.End = end
+	if p.cur.Type == kwGROUP {
+		gb, err := p.parseGroupByClause()
+		if err != nil {
+			return nil, err
+		}
+		op.GroupBy = gb
+		op.Loc.End = gb.Loc.End
+	}
+	if p.cur.Type == kwORDER {
+		p.advance() // ORDER
+		if p.cur.Type == int('@') {
+			if herr := p.skipHint(); herr != nil {
+				return nil, herr
+			}
+		}
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		obItems, obEnd, err := p.parseGraphOrderingList()
+		if err != nil {
+			return nil, err
+		}
+		op.OrderBy = obItems
+		op.Loc.End = obEnd
+	}
+	if p.atGraphPageClause() {
+		page, err := p.parseGraphPageClause()
+		if err != nil {
+			return nil, err
+		}
+		op.Page = page
+		op.Loc.End = page.Loc.End
+	}
+	return op, nil
+}
+
+// atGraphPageClause reports whether the cursor is at the start of a
+// graph_page_clause (OFFSET | SKIP | LIMIT) — the trailing PAGE of a RETURN.
+func (p *Parser) atGraphPageClause() bool {
+	switch p.cur.Type {
+	case kwOFFSET, kwSKIP, kwLIMIT:
+		return true
+	}
+	return false
+}
+
+// matchAllOrDistinct consumes an all_or_distinct (ALL | DISTINCT) if present and
+// returns "ALL"/"DISTINCT", or "" when absent. (In GQL the quantifier is
+// optional on WITH/RETURN, distinct from a set-operation metadata where it is
+// required.)
+func (p *Parser) matchAllOrDistinct() string {
+	switch p.cur.Type {
+	case kwALL:
+		p.advance()
+		return "ALL"
+	case kwDISTINCT:
+		p.advance()
+		return "DISTINCT"
+	}
+	return ""
+}
+
+// parseGraphReturnItemList parses a graph_return_item_list and returns the items
+// plus the end offset of the last item. Each item is `expr [AS id]` or `*`.
+func (p *Parser) parseGraphReturnItemList() ([]*ast.GraphReturnItem, int, error) {
+	var items []*ast.GraphReturnItem
+	end := p.cur.Loc.End
+	for {
+		item, err := p.parseGraphReturnItem()
+		if err != nil {
+			return nil, 0, err
+		}
+		items = append(items, item)
+		end = item.Loc.End
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ,
+	}
+	return items, end, nil
+}
+
+// parseGraphReturnItem parses one graph_return_item:
+//
+//	<expr> [AS identifier]   |   *
+func (p *Parser) parseGraphReturnItem() (*ast.GraphReturnItem, error) {
+	if p.cur.Type == int('*') {
+		star := p.advance()
+		return &ast.GraphReturnItem{Star: true, Loc: star.Loc}, nil
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	item := &ast.GraphReturnItem{Expr: expr, Loc: ast.Loc{Start: nodeLoc(expr).Start, End: nodeLoc(expr).End}}
+	if p.cur.Type == kwAS {
+		p.advance() // AS
+		tok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		alias, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		item.Alias = alias
+		item.Loc.End = tok.Loc.End
+	}
+	return item, nil
+}
+
+// ---------------------------------------------------------------------------
+// Graph patterns
+// ---------------------------------------------------------------------------
+
+// parseGraphPattern parses a graph_pattern:
+//
+//	<path_pattern_list> [WHERE <expr>]
+func (p *Parser) parseGraphPattern() (*ast.GraphPattern, error) {
+	gp := &ast.GraphPattern{Loc: p.cur.Loc}
+	// graph_path_pattern_list: path (COMMA hint? path)*.
+	for {
+		path, err := p.parseGraphPathPattern()
+		if err != nil {
+			return nil, err
+		}
+		gp.Paths = append(gp.Paths, path)
+		gp.Loc.End = path.Loc.End
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ,
+		if p.cur.Type == int('@') {
+			if herr := p.skipHint(); herr != nil {
+				return nil, herr
+			}
+		}
+	}
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		gp.Where = where
+		gp.Loc.End = nodeLoc(where).End
+	}
+	gp.Loc.Start = gp.Paths[0].Loc.Start
+	return gp, nil
+}
+
+// parseGraphPathPattern parses a graph_path_pattern:
+//
+//	[<var> =] [(ANY|ALL) [SHORTEST]] [<mode> [PATH|PATHS]] <path_pattern_expr>
+func (p *Parser) parseGraphPathPattern() (*ast.GraphPathPattern, error) {
+	pp := &ast.GraphPathPattern{Loc: p.cur.Loc}
+	start := p.cur.Loc.Start
+
+	// opt_path_variable_assignment: graph_identifier '='. Only when the '=' is
+	// the next token (an element-pattern variable is NOT followed by '=').
+	if isIdentifierStart(p.cur.Type) && p.peekNext().Type == int('=') {
+		tok := p.advance()
+		name, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		pp.PathVar = name
+		p.advance() // =
+	}
+
+	// opt_graph_search_prefix: (ANY|ALL) SHORTEST?.
+	switch p.cur.Type {
+	case kwANY:
+		p.advance()
+		pp.Search = "ANY"
+		if p.cur.Type == kwSHORTEST {
+			p.advance()
+			pp.Search = "ANY SHORTEST"
+		}
+	case kwALL:
+		// ALL is also a set-quantifier; in a path-pattern prefix position it is the
+		// search prefix. It is only consumed as a search prefix here when followed
+		// by SHORTEST or by a path-factor start — but since a path-pattern always
+		// begins with a path factor, a bare leading ALL here is the search prefix.
+		p.advance()
+		pp.Search = "ALL"
+		if p.cur.Type == kwSHORTEST {
+			p.advance()
+			pp.Search = "ALL SHORTEST"
+		}
+	}
+
+	// opt_graph_path_mode_prefix: opt_graph_path_mode path_or_paths?.
+	switch p.cur.Type {
+	case kwWALK, kwTRAIL, kwSIMPLE, kwACYCLIC:
+		mode := TokenName(p.cur.Type)
+		p.advance()
+		switch p.cur.Type {
+		case kwPATH:
+			p.advance()
+			mode += " PATH"
+		case kwPATHS:
+			p.advance()
+			mode += " PATHS"
+		}
+		pp.Mode = mode
+	}
+
+	// graph_path_pattern_expr: graph_path_factor (hint? graph_path_factor)*.
+	for {
+		factor, err := p.parseGraphPathFactor()
+		if err != nil {
+			return nil, err
+		}
+		pp.Factors = append(pp.Factors, factor)
+		pp.Loc.End = nodeLoc(factor).End
+		if p.cur.Type == int('@') {
+			if herr := p.skipHint(); herr != nil {
+				return nil, herr
+			}
+		}
+		if !p.atGraphPathFactor() {
+			break
+		}
+	}
+	pp.Loc.Start = start
+	return pp, nil
+}
+
+// atGraphPathFactor reports whether the cursor is at the start of a
+// graph_path_factor: a node pattern `(`, an edge pattern (`-`, `<-`, `->`), or a
+// parenthesized path pattern `(`. (Both node patterns and parenthesized paths
+// start with '(', disambiguated inside parseGraphPathPrimary.)
+func (p *Parser) atGraphPathFactor() bool {
+	switch p.cur.Type {
+	case int('('), int('-'), int('<'), tokArrow:
+		return true
+	}
+	return false
+}
+
+// parseGraphPathFactor parses a graph_path_factor:
+//
+//	graph_path_primary [ { [n,] m } ]   (a quantified path primary)
+func (p *Parser) parseGraphPathFactor() (ast.Node, error) {
+	primary, err := p.parseGraphPathPrimary()
+	if err != nil {
+		return nil, err
+	}
+	// graph_quantified_path_primary: primary '{' int? ',' int '}' | primary '{' int '}'.
+	if p.cur.Type == int('{') {
+		return p.parseGraphQuantifier(primary)
+	}
+	return primary, nil
+}
+
+// parseGraphQuantifier consumes a `{ [n,] m }` quantifier following a path
+// primary. The quantifier bounds are parse-only (the consumer needs the inner
+// pattern's tables, not the repetition count); the primary node is returned with
+// its Loc extended over the quantifier. The cursor is at '{'.
+func (p *Parser) parseGraphQuantifier(primary ast.Node) (ast.Node, error) {
+	p.advance() // {
+	// int_literal_or_parameter? ',' int_literal_or_parameter  |  int_literal_or_parameter
+	//
+	// The bounds are int_literal_or_parameter (integer / @param / ? / @@sysvar) —
+	// NOT a full expression. A bare identifier or an arithmetic expression here is
+	// a syntax error (oracle: the Spanner emulator rejects `{a,b}` / `{1+1,3}`).
+	if p.cur.Type != int(',') {
+		if _, err := p.parseGraphIntLiteralOrParameter(); err != nil {
+			return nil, err
+		}
+	}
+	if p.cur.Type == int(',') {
+		p.advance() // ,
+		if _, err := p.parseGraphIntLiteralOrParameter(); err != nil {
+			return nil, err
+		}
+	}
+	closeTok, err := p.expect(int('}'))
+	if err != nil {
+		return nil, err
+	}
+	// Extend the primary's Loc to include the quantifier so the factor spans it.
+	switch n := primary.(type) {
+	case *ast.GraphNodePattern:
+		n.Loc.End = closeTok.Loc.End
+	case *ast.GraphEdgePattern:
+		n.Loc.End = closeTok.Loc.End
+	case *ast.GraphPathPattern:
+		n.Loc.End = closeTok.Loc.End
+	}
+	return primary, nil
+}
+
+// parseGraphPathPrimary parses a graph_path_primary:
+//
+//	graph_element_pattern   |   graph_parenthesized_path_pattern
+//
+// A '(' begins either a node pattern `( <filler> )` or a parenthesized path
+// `( [hint] <path> [WHERE] )`. We disambiguate by looking past the '(': a node
+// pattern's filler is an element filler (identifier / label colon `:` / `IS` /
+// `{` / WHERE / empty `)`), whereas a parenthesized path's content begins with a
+// path-factor start (another '(' or an edge `-`/`<`/`->`) or a path-variable /
+// search / mode prefix.
+func (p *Parser) parseGraphPathPrimary() (ast.Node, error) {
+	switch p.cur.Type {
+	case int('-'), int('<'), tokArrow:
+		return p.parseGraphEdgePattern()
+	case int('('):
+		if p.parenStartsParenthesizedPath() {
+			return p.parseGraphParenthesizedPath()
+		}
+		return p.parseGraphNodePattern()
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parenStartsParenthesizedPath decides, with cur at '(', whether the parenthesis
+// opens a graph_parenthesized_path_pattern (vs a graph_node_pattern). A
+// parenthesized path's interior begins with a nested path factor or a path
+// prefix; a node pattern's interior is an element filler. The discriminating
+// token right after '(' is:
+//   - another '(' or an edge start ('-', '<', '->')  => parenthesized path
+//     (a node filler never starts with one of these).
+//   - '@' (a leading hint)                           => parenthesized path.
+//
+// Everything else (identifier, ':', IS, '{', WHERE, ')') is a node filler.
+func (p *Parser) parenStartsParenthesizedPath() bool {
+	switch p.peekNext().Type {
+	case int('('), int('-'), int('<'), tokArrow, int('@'):
+		return true
+	}
+	return false
+}
+
+// parseGraphParenthesizedPath parses a graph_parenthesized_path_pattern:
+//
+//	( [hint] <graph_path_pattern> [WHERE <expr>] )
+func (p *Parser) parseGraphParenthesizedPath() (ast.Node, error) {
+	open := p.advance() // (
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+	path, err := p.parseGraphPathPattern()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		path.Where = where
+		path.Loc.End = nodeLoc(where).End
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	path.Loc.Start = open.Loc.Start
+	path.Loc.End = closeTok.Loc.End
+	return path, nil
+}
+
+// parseGraphNodePattern parses a graph_node_pattern: `( <filler> )`.
+func (p *Parser) parseGraphNodePattern() (ast.Node, error) {
+	open, err := p.expect(int('('))
+	if err != nil {
+		return nil, err
+	}
+	filler, err := p.parseGraphPatternFiller()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.GraphNodePattern{
+		Filler: filler,
+		Loc:    ast.Loc{Start: open.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseGraphEdgePattern parses a graph_edge_pattern — one of the six shapes the
+// legacy grammar admits (graph_edge_pattern):
+//
+//	<-[ filler ]-      (EdgeLeftFull)        LT? MINUS LS filler RS MINUS, < present
+//	 -[ filler ]-      (EdgeUndirectedFull)  LT? MINUS LS filler RS MINUS, < absent
+//	 -[ filler ]->     (EdgeRightFull)       MINUS LS filler RS SUB_GT
+//	-                  (EdgeAny)             MINUS
+//	<-                 (EdgeLeft)            LT MINUS
+//	->                 (EdgeRight)           SUB_GT
+//
+// The leading `<` of the first alternative is OPTIONAL, so a full edge with a
+// trailing `-` (MINUS) is left-directed when `<` is present and UNDIRECTED when
+// it is absent — both are valid. A full edge with a trailing `->` (tokArrow) is
+// right-directed and must NOT carry a leading `<` (the oracle rejects `<-[..]->`
+// with "Expected '-' but got '->'"). The lexer emits `->` as a single token
+// (tokArrow); `<-`, `-[`, `]-` are sequences of single-char tokens.
+func (p *Parser) parseGraphEdgePattern() (ast.Node, error) {
+	start := p.cur.Loc
+	switch p.cur.Type {
+	case tokArrow:
+		// `->`  (EdgeRight, abbreviated).
+		arrow := p.advance()
+		return &ast.GraphEdgePattern{Direction: ast.EdgeRight, Loc: ast.Loc{Start: start.Start, End: arrow.Loc.End}}, nil
+	case int('<'):
+		// `<-` then optionally `[ filler ]-` (left-directed).
+		p.advance() // <
+		if _, err := p.expect(int('-')); err != nil {
+			return nil, err
+		}
+		if p.cur.Type == int('[') {
+			// `<-[ filler ]-`  (EdgeLeftFull): a leading `<` forces the trailing close
+			// to be a bare MINUS (`->` is rejected — see the doc note above).
+			filler, end, err := p.parseBracketedEdgeFiller(false /*allowArrowClose*/)
+			if err != nil {
+				return nil, err
+			}
+			return &ast.GraphEdgePattern{Direction: ast.EdgeLeftFull, Filler: filler, Loc: ast.Loc{Start: start.Start, End: end}}, nil
+		}
+		// `<-`  (EdgeLeft, abbreviated).
+		return &ast.GraphEdgePattern{Direction: ast.EdgeLeft, Loc: ast.Loc{Start: start.Start, End: p.prev.Loc.End}}, nil
+	case int('-'):
+		p.advance() // -
+		if p.cur.Type == int('[') {
+			// `-[ filler ]-`  (EdgeUndirectedFull) or `-[ filler ]->` (EdgeRightFull):
+			// no leading `<`, so the trailing close may be either MINUS or `->`.
+			filler, closeArrow, end, err := p.parseBracketedEdge(true /*allowArrowClose*/)
+			if err != nil {
+				return nil, err
+			}
+			dir := ast.EdgeUndirectedFull
+			if closeArrow {
+				dir = ast.EdgeRightFull
+			}
+			return &ast.GraphEdgePattern{Direction: dir, Filler: filler, Loc: ast.Loc{Start: start.Start, End: end}}, nil
+		}
+		// `-`  (EdgeAny, abbreviated undirected).
+		return &ast.GraphEdgePattern{Direction: ast.EdgeAny, Loc: ast.Loc{Start: start.Start, End: p.prev.Loc.End}}, nil
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseBracketedEdgeFiller parses the `[ <filler> ]` and trailing close of a full
+// edge whose direction is already fixed by a leading `<` (the EdgeLeftFull case),
+// so the close MUST be a bare MINUS. allowArrowClose is false here; it returns
+// only the filler and end offset.
+func (p *Parser) parseBracketedEdgeFiller(allowArrowClose bool) (*ast.GraphPatternFiller, int, error) {
+	filler, _, end, err := p.parseBracketedEdge(allowArrowClose)
+	return filler, end, err
+}
+
+// parseBracketedEdge parses the `[ <filler> ]` of a full edge pattern and its
+// trailing close. The current token is '['. The close is always `]` followed by
+// either a bare MINUS (`]-`, an undirected/left edge) or, when allowArrowClose is
+// true, `->` (`]->`, a right-directed edge). It returns the filler, whether the
+// close was the `->` arrow (closeArrow), and the end offset.
+func (p *Parser) parseBracketedEdge(allowArrowClose bool) (filler *ast.GraphPatternFiller, closeArrow bool, end int, err error) {
+	p.advance() // [
+	filler, err = p.parseGraphPatternFiller()
+	if err != nil {
+		return nil, false, 0, err
+	}
+	if _, err = p.expect(int(']')); err != nil {
+		return nil, false, 0, err
+	}
+	if allowArrowClose && p.cur.Type == tokArrow {
+		// `]->` : a right-directed full edge closes with `->` (tokArrow).
+		arrow := p.advance()
+		return filler, true, arrow.Loc.End, nil
+	}
+	// `]-` : an undirected or left-directed full edge closes with a bare MINUS.
+	minus, merr := p.expect(int('-'))
+	if merr != nil {
+		return nil, false, 0, merr
+	}
+	return filler, false, minus.Loc.End, nil
+}
+
+// parseGraphPatternFiller parses a graph_element_pattern_filler — the interior
+// of a node `( … )` or full-edge `[ … ]` pattern:
+//
+//	[hint] [<var>] [(IS|:) <label_expr>] [{ prop : expr, … }] [WHERE <expr>]
+//
+// Every part is optional (an empty filler `()` is valid, per the grammar's empty
+// production). The grammar's three alternatives differ only in how WHERE relates
+// to the property spec; this parser accepts the superset (var?, label?, props?,
+// where?) which covers all three.
+func (p *Parser) parseGraphPatternFiller() (*ast.GraphPatternFiller, error) {
+	filler := &ast.GraphPatternFiller{Loc: p.cur.Loc}
+	start := p.cur.Loc.Start
+	end := p.prev.Loc.End // empty filler: zero-width at the prior token's end
+
+	if p.cur.Type == int('@') {
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
+		}
+	}
+
+	// opt_graph_element_identifier: a bare graph_identifier (NOT followed by '=' —
+	// that is a path-variable assignment handled at the path level, which never
+	// reaches here). An identifier directly before ':'/'IS'/'{'/WHERE/')'/']' is
+	// the element variable.
+	if isIdentifierStart(p.cur.Type) {
+		tok := p.advance()
+		name, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		filler.Var = name
+		end = tok.Loc.End
+	}
+
+	// opt_is_label_expression: IS <label_expr> | ':' <label_expr>.
+	if p.cur.Type == kwIS || p.cur.Type == int(':') {
+		filler.LabelColon = p.cur.Type == int(':')
+		p.advance() // IS | ':'
+		label, err := p.parseLabelExpression()
+		if err != nil {
+			return nil, err
+		}
+		filler.Label = label
+		end = label.Loc.End
+	}
+
+	// graph_property_specification?: `{ id : expr , … }`.
+	if p.cur.Type == int('{') {
+		props, err := p.parseGraphPropertySpec()
+		if err != nil {
+			return nil, err
+		}
+		filler.Properties = props
+		end = props.Loc.End
+	}
+
+	// where_clause?: WHERE <expr>.
+	if p.cur.Type == kwWHERE {
+		p.advance() // WHERE
+		where, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		filler.Where = where
+		end = nodeLoc(where).End
+	}
+
+	filler.Loc = ast.Loc{Start: start, End: end}
+	return filler, nil
+}
+
+// parseGraphPropertySpec parses a graph_property_specification:
+//
+//	{ <id> : <expr> (, <id> : <expr>)* }
+func (p *Parser) parseGraphPropertySpec() (*ast.GraphPropertySpec, error) {
+	open := p.advance() // {
+	spec := &ast.GraphPropertySpec{Loc: open.Loc}
+	for {
+		nv, err := p.parseGraphPropertyNameValue()
+		if err != nil {
+			return nil, err
+		}
+		spec.Properties = append(spec.Properties, nv)
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ,
+	}
+	closeTok, err := p.expect(int('}'))
+	if err != nil {
+		return nil, err
+	}
+	spec.Loc.End = closeTok.Loc.End
+	return spec, nil
+}
+
+// parseGraphPropertyNameValue parses one graph_property_name_and_value:
+// identifier ':' expression.
+func (p *Parser) parseGraphPropertyNameValue() (*ast.GraphPropertyNameValue, error) {
+	tok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(tok)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(':')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.GraphPropertyNameValue{
+		Name: name,
+		Expr: expr,
+		Loc:  ast.Loc{Start: tok.Loc.Start, End: nodeLoc(expr).End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Label algebra
+// ---------------------------------------------------------------------------
+
+// parseLabelExpression parses a label_expression with the precedence the
+// legacy grammar's left-recursive rule encodes: `!` (unary, tightest) binds
+// before `&`, which binds before `|`. The grammar is:
+//
+//	label_expression:
+//	    label_primary
+//	  | label_expression '&' label_expression
+//	  | label_expression '|' label_expression
+//	  | '!' label_expression
+//
+// ANTLR resolves the ambiguous binary alternatives by listed order (& before |)
+// and left-associativity. We implement that explicitly: parse an OR-chain whose
+// operands are AND-chains whose operands are (possibly negated) primaries.
+func (p *Parser) parseLabelExpression() (*ast.GraphLabelExpr, error) {
+	return p.parseLabelOr()
+}
+
+// parseLabelOr parses an `|`-separated chain of AND-expressions (left-assoc).
+func (p *Parser) parseLabelOr() (*ast.GraphLabelExpr, error) {
+	left, err := p.parseLabelAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == int('|') {
+		p.advance() // |
+		right, err := p.parseLabelAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.GraphLabelExpr{
+			Kind:  ast.LabelOr,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Loc.Start, End: right.Loc.End},
+		}
+	}
+	return left, nil
+}
+
+// parseLabelAnd parses an `&`-separated chain of unary label expressions
+// (left-assoc).
+func (p *Parser) parseLabelAnd() (*ast.GraphLabelExpr, error) {
+	left, err := p.parseLabelUnary()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == int('&') {
+		p.advance() // &
+		right, err := p.parseLabelUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = &ast.GraphLabelExpr{
+			Kind:  ast.LabelAnd,
+			Left:  left,
+			Right: right,
+			Loc:   ast.Loc{Start: left.Loc.Start, End: right.Loc.End},
+		}
+	}
+	return left, nil
+}
+
+// parseLabelUnary parses a `!`-prefixed label expression (right-recursive) or a
+// label primary.
+func (p *Parser) parseLabelUnary() (*ast.GraphLabelExpr, error) {
+	if p.cur.Type == int('!') {
+		bang := p.advance() // !
+		operand, err := p.parseLabelUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.GraphLabelExpr{
+			Kind:    ast.LabelNot,
+			Operand: operand,
+			Loc:     ast.Loc{Start: bang.Loc.Start, End: operand.Loc.End},
+		}, nil
+	}
+	return p.parseLabelPrimary()
+}
+
+// parseLabelPrimary parses a label_primary:
+//
+//	identifier   |   '%'   |   '(' label_expression ')'
+func (p *Parser) parseLabelPrimary() (*ast.GraphLabelExpr, error) {
+	switch {
+	case p.cur.Type == int('%'):
+		mod := p.advance()
+		return &ast.GraphLabelExpr{Kind: ast.LabelWildcard, Loc: mod.Loc}, nil
+	case p.cur.Type == int('('):
+		p.advance() // (
+		inner, err := p.parseLabelExpression()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		// parenthesized_label_expression is transparent: the tree shape already
+		// captures the grouping, so we return the inner expression directly.
+		return inner, nil
+	case isIdentifierStart(p.cur.Type):
+		tok := p.advance()
+		name, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.GraphLabelExpr{Kind: ast.LabelName, Name: name, Loc: tok.Loc}, nil
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}

--- a/googlesql/parser/graph_query.go
+++ b/googlesql/parser/graph_query.go
@@ -870,45 +870,66 @@ func (p *Parser) parseGraphPathPattern() (*ast.GraphPathPattern, error) {
 		p.advance() // =
 	}
 
-	// opt_graph_search_prefix: (ANY|ALL) SHORTEST?.
+	// opt_graph_search_prefix: (ANY|ALL) SHORTEST?. ANY/ALL are also usable as
+	// bare graph_identifiers, so they are consumed as a search prefix only when
+	// graphPrefixKeywordContinues confirms a prefix follows (SHORTEST / a further
+	// prefix / a path-factor start) — NOT when the keyword is the first node's own
+	// identifier (e.g. the parenthesized path `( ANY )` is a single node named
+	// ANY). This is the same guard the disambiguator (atGraphPathPrefix) uses, so
+	// the two never disagree about whether a leading keyword is a prefix.
 	switch p.cur.Type {
 	case kwANY:
-		p.advance()
-		pp.Search = "ANY"
-		if p.cur.Type == kwSHORTEST {
+		if p.graphPrefixKeywordContinues(p.peekNext().Type) {
 			p.advance()
-			pp.Search = "ANY SHORTEST"
+			pp.Search = "ANY"
+			if p.cur.Type == kwSHORTEST {
+				p.advance()
+				pp.Search = "ANY SHORTEST"
+			}
 		}
 	case kwALL:
-		// ALL is also a set-quantifier; in a path-pattern prefix position it is the
-		// search prefix. It is only consumed as a search prefix here when followed
-		// by SHORTEST or by a path-factor start — but since a path-pattern always
-		// begins with a path factor, a bare leading ALL here is the search prefix.
-		p.advance()
-		pp.Search = "ALL"
-		if p.cur.Type == kwSHORTEST {
+		if p.graphPrefixKeywordContinues(p.peekNext().Type) {
 			p.advance()
-			pp.Search = "ALL SHORTEST"
+			pp.Search = "ALL"
+			if p.cur.Type == kwSHORTEST {
+				p.advance()
+				pp.Search = "ALL SHORTEST"
+			}
 		}
 	}
 
-	// opt_graph_path_mode_prefix: opt_graph_path_mode path_or_paths?.
+	// opt_graph_path_mode_prefix: opt_graph_path_mode path_or_paths?. The mode
+	// keywords are likewise usable as bare identifiers, so they are consumed as a
+	// mode prefix only when graphPrefixKeywordContinues confirms a prefix follows
+	// (PATH/PATHS / a further prefix / a path-factor start).
 	switch p.cur.Type {
 	case kwWALK, kwTRAIL, kwSIMPLE, kwACYCLIC:
-		mode := TokenName(p.cur.Type)
-		p.advance()
-		switch p.cur.Type {
-		case kwPATH:
+		if p.graphPrefixKeywordContinues(p.peekNext().Type) {
+			mode := TokenName(p.cur.Type)
 			p.advance()
-			mode += " PATH"
-		case kwPATHS:
-			p.advance()
-			mode += " PATHS"
+			switch p.cur.Type {
+			case kwPATH:
+				p.advance()
+				mode += " PATH"
+			case kwPATHS:
+				p.advance()
+				mode += " PATHS"
+			}
+			pp.Mode = mode
 		}
-		pp.Mode = mode
 	}
 
 	// graph_path_pattern_expr: graph_path_factor (hint? graph_path_factor)*.
+	//
+	// A hint between factors is part of a `(hint? graph_path_factor)` group, so a
+	// hint MUST be followed by another factor — a trailing hint with no factor
+	// after it is a syntax error (oracle F5: the live emulator rejects
+	// `(a) @{h} RETURN *` with `Expected "(" or "-" or "<" or -> but got …`). We
+	// therefore only consume a hint once we know a factor follows: if the next
+	// token is '@' we require either a factor right after the hint, or we leave the
+	// '@' for the caller (which would have its own hint position). Because the only
+	// position a trailing '@' could be consumed is here, we detect it and demand a
+	// factor.
 	for {
 		factor, err := p.parseGraphPathFactor()
 		if err != nil {
@@ -916,13 +937,19 @@ func (p *Parser) parseGraphPathPattern() (*ast.GraphPathPattern, error) {
 		}
 		pp.Factors = append(pp.Factors, factor)
 		pp.Loc.End = nodeLoc(factor).End
-		if p.cur.Type == int('@') {
-			if herr := p.skipHint(); herr != nil {
-				return nil, herr
+		if p.cur.Type != int('@') {
+			if !p.atGraphPathFactor() {
+				break
 			}
+			continue
+		}
+		// A '@' here opens a `hint? graph_path_factor` continuation. Consume the
+		// hint, then REQUIRE a following factor (F5).
+		if herr := p.skipHint(); herr != nil {
+			return nil, herr
 		}
 		if !p.atGraphPathFactor() {
-			break
+			return nil, p.syntaxErrorAtCur()
 		}
 	}
 	pp.Loc.Start = start
@@ -999,53 +1026,106 @@ func (p *Parser) parseGraphQuantifier(primary ast.Node) (ast.Node, error) {
 //	graph_element_pattern   |   graph_parenthesized_path_pattern
 //
 // A '(' begins either a node pattern `( <filler> )` or a parenthesized path
-// `( [hint] <path> [WHERE] )`. We disambiguate by looking past the '(': a node
-// pattern's filler is an element filler (identifier / label colon `:` / `IS` /
-// `{` / WHERE / empty `)`), whereas a parenthesized path's content begins with a
-// path-factor start (another '(' or an edge `-`/`<`/`->`) or a path-variable /
-// search / mode prefix.
+// `( [hint] <graph_path_pattern> [WHERE] )`. Both can carry a leading hint
+// (the node hint lives INSIDE the filler — graph_element_pattern_filler:
+// `hint? …`; the parenthesized-path hint sits between '(' and the path — and the
+// hint is discarded either way), so we consume '(' and any leading hint FIRST,
+// then disambiguate on the post-hint interior token. The parser has only
+// one-token lookahead, so peeking PAST a multi-token `@{…}` hint is impossible;
+// consuming it up front is what lets a hinted node `(@{h} v:L)` be recognized
+// (the disambiguation bug F2). The interior is a parenthesized PATH when it
+// begins with a nested path factor (another '(' or an edge `-`/`<`/`->`) or a
+// path-pattern prefix (path-variable assignment `id =`, search prefix ANY/ALL,
+// or path-mode prefix WALK/TRAIL/SIMPLE/ACYCLIC — bug F1); otherwise it is a
+// node-pattern filler (identifier / ':' / IS / '{' / WHERE / empty ')').
 func (p *Parser) parseGraphPathPrimary() (ast.Node, error) {
 	switch p.cur.Type {
 	case int('-'), int('<'), tokArrow:
 		return p.parseGraphEdgePattern()
 	case int('('):
-		if p.parenStartsParenthesizedPath() {
-			return p.parseGraphParenthesizedPath()
+		open := p.advance() // (
+		if p.cur.Type == int('@') {
+			if herr := p.skipHint(); herr != nil {
+				return nil, herr
+			}
 		}
-		return p.parseGraphNodePattern()
+		if p.interiorStartsParenthesizedPath() {
+			return p.parseGraphParenthesizedPathBody(open)
+		}
+		return p.parseGraphNodePatternBody(open)
 	default:
 		return nil, p.syntaxErrorAtCur()
 	}
 }
 
-// parenStartsParenthesizedPath decides, with cur at '(', whether the parenthesis
-// opens a graph_parenthesized_path_pattern (vs a graph_node_pattern). A
-// parenthesized path's interior begins with a nested path factor or a path
-// prefix; a node pattern's interior is an element filler. The discriminating
-// token right after '(' is:
-//   - another '(' or an edge start ('-', '<', '->')  => parenthesized path
-//     (a node filler never starts with one of these).
-//   - '@' (a leading hint)                           => parenthesized path.
+// interiorStartsParenthesizedPath decides, with cur positioned at the FIRST
+// interior token of a '(' group (after the '(' and any leading hint have already
+// been consumed), whether the group is a graph_parenthesized_path_pattern (vs a
+// graph_node_pattern). It is a parenthesized path when the interior begins with:
+//   - a path factor: another '(' or an edge start ('-', '<', '->') — a node
+//     filler never starts with one of these; or
+//   - a path-pattern prefix: a path-variable assignment (`id =`), a search
+//     prefix (ANY/ALL …), or a path-mode prefix (WALK/TRAIL/SIMPLE/ACYCLIC …) —
+//     see atGraphPathPrefix.
 //
-// Everything else (identifier, ':', IS, '{', WHERE, ')') is a node filler.
-func (p *Parser) parenStartsParenthesizedPath() bool {
-	switch p.peekNext().Type {
-	case int('('), int('-'), int('<'), tokArrow, int('@'):
+// Everything else (a bare identifier not followed by '=', ':', IS, '{', WHERE,
+// or an immediate ')') is a node-pattern filler.
+func (p *Parser) interiorStartsParenthesizedPath() bool {
+	switch p.cur.Type {
+	case int('('), int('-'), int('<'), tokArrow:
+		return true
+	}
+	return p.atGraphPathPrefix()
+}
+
+// atGraphPathPrefix reports whether cur is at the start of a graph_path_pattern
+// prefix — opt_path_variable_assignment? opt_graph_search_prefix?
+// opt_graph_path_mode_prefix? — using the SAME detection parseGraphPathPattern
+// applies when it consumes those prefixes (kept in lockstep so the disambiguator
+// and the consumer never disagree):
+//   - path-variable assignment: an identifier IMMEDIATELY followed by '='.
+//   - search prefix: ANY or ALL. These are also usable as bare graph_identifiers,
+//     so they are a prefix only when followed by SHORTEST or by something that
+//     starts a path factor / further prefix — NOT when followed by a filler
+//     continuation (':', IS, '{', WHERE) or a closing ')'.
+//   - path-mode prefix: WALK/TRAIL/SIMPLE/ACYCLIC, with the same
+//     identifier-vs-prefix disambiguation (a prefix only when followed by
+//     PATH/PATHS or a path-factor / further-prefix start).
+func (p *Parser) atGraphPathPrefix() bool {
+	switch p.cur.Type {
+	case kwANY, kwALL, kwWALK, kwTRAIL, kwSIMPLE, kwACYCLIC:
+		return p.graphPrefixKeywordContinues(p.peekNext().Type)
+	}
+	// opt_path_variable_assignment: graph_identifier '='.
+	return isIdentifierStart(p.cur.Type) && p.peekNext().Type == int('=')
+}
+
+// graphPrefixKeywordContinues reports whether a token following a search/mode
+// prefix keyword (ANY/ALL/WALK/TRAIL/SIMPLE/ACYCLIC) confirms that the keyword
+// introduces a path-pattern prefix rather than standing in as a node-filler
+// identifier. A prefix continues into another prefix word (SHORTEST after
+// ANY/ALL; PATH/PATHS after a mode; or a further mode/search keyword) or
+// directly into a path factor ('(' or an edge). A following filler-continuation
+// (':', IS, '{', WHERE) or a closing ')' means the keyword was the node's own
+// identifier, so it does NOT continue.
+func (p *Parser) graphPrefixKeywordContinues(next int) bool {
+	switch next {
+	case kwSHORTEST, kwPATH, kwPATHS,
+		kwANY, kwALL, kwWALK, kwTRAIL, kwSIMPLE, kwACYCLIC,
+		int('('), int('-'), int('<'), tokArrow:
 		return true
 	}
 	return false
 }
 
-// parseGraphParenthesizedPath parses a graph_parenthesized_path_pattern:
+// parseGraphParenthesizedPathBody parses the body of a
+// graph_parenthesized_path_pattern after its '(' (and any leading hint) have
+// already been consumed by parseGraphPathPrimary:
 //
-//	( [hint] <graph_path_pattern> [WHERE <expr>] )
-func (p *Parser) parseGraphParenthesizedPath() (ast.Node, error) {
-	open := p.advance() // (
-	if p.cur.Type == int('@') {
-		if herr := p.skipHint(); herr != nil {
-			return nil, herr
-		}
-	}
+//	<graph_path_pattern> [WHERE <expr>] )
+//
+// open is the already-consumed '(' token (for the Loc start).
+func (p *Parser) parseGraphParenthesizedPathBody(open Token) (ast.Node, error) {
 	path, err := p.parseGraphPathPattern()
 	if err != nil {
 		return nil, err
@@ -1068,12 +1148,17 @@ func (p *Parser) parseGraphParenthesizedPath() (ast.Node, error) {
 	return path, nil
 }
 
-// parseGraphNodePattern parses a graph_node_pattern: `( <filler> )`.
-func (p *Parser) parseGraphNodePattern() (ast.Node, error) {
-	open, err := p.expect(int('('))
-	if err != nil {
-		return nil, err
-	}
+// parseGraphNodePatternBody parses the body of a graph_node_pattern after its
+// '(' (and any leading hint) have already been consumed by
+// parseGraphPathPrimary:
+//
+//	<filler> )
+//
+// open is the already-consumed '(' token (for the Loc start). The filler's own
+// optional leading hint has already been skipped at the '(' level, so any '@'
+// the filler parser sees here would be a SECOND hint (the grammar admits at most
+// one — a stray one is a syntax error from parseGraphPatternFiller's tail).
+func (p *Parser) parseGraphNodePatternBody(open Token) (ast.Node, error) {
 	filler, err := p.parseGraphPatternFiller()
 	if err != nil {
 		return nil, err

--- a/googlesql/parser/graph_query.go
+++ b/googlesql/parser/graph_query.go
@@ -1044,15 +1044,17 @@ func (p *Parser) parseGraphPathPrimary() (ast.Node, error) {
 		return p.parseGraphEdgePattern()
 	case int('('):
 		open := p.advance() // (
+		hintConsumed := false
 		if p.cur.Type == int('@') {
 			if herr := p.skipHint(); herr != nil {
 				return nil, herr
 			}
+			hintConsumed = true
 		}
 		if p.interiorStartsParenthesizedPath() {
 			return p.parseGraphParenthesizedPathBody(open)
 		}
-		return p.parseGraphNodePatternBody(open)
+		return p.parseGraphNodePatternBody(open, hintConsumed)
 	default:
 		return nil, p.syntaxErrorAtCur()
 	}
@@ -1158,8 +1160,8 @@ func (p *Parser) parseGraphParenthesizedPathBody(open Token) (ast.Node, error) {
 // optional leading hint has already been skipped at the '(' level, so any '@'
 // the filler parser sees here would be a SECOND hint (the grammar admits at most
 // one — a stray one is a syntax error from parseGraphPatternFiller's tail).
-func (p *Parser) parseGraphNodePatternBody(open Token) (ast.Node, error) {
-	filler, err := p.parseGraphPatternFiller()
+func (p *Parser) parseGraphNodePatternBody(open Token, hintAlreadyConsumed bool) (ast.Node, error) {
+	filler, err := p.parseGraphPatternFiller(hintAlreadyConsumed)
 	if err != nil {
 		return nil, err
 	}
@@ -1251,7 +1253,7 @@ func (p *Parser) parseBracketedEdgeFiller(allowArrowClose bool) (*ast.GraphPatte
 // close was the `->` arrow (closeArrow), and the end offset.
 func (p *Parser) parseBracketedEdge(allowArrowClose bool) (filler *ast.GraphPatternFiller, closeArrow bool, end int, err error) {
 	p.advance() // [
-	filler, err = p.parseGraphPatternFiller()
+	filler, err = p.parseGraphPatternFiller(false)
 	if err != nil {
 		return nil, false, 0, err
 	}
@@ -1280,12 +1282,16 @@ func (p *Parser) parseBracketedEdge(allowArrowClose bool) (filler *ast.GraphPatt
 // production). The grammar's three alternatives differ only in how WHERE relates
 // to the property spec; this parser accepts the superset (var?, label?, props?,
 // where?) which covers all three.
-func (p *Parser) parseGraphPatternFiller() (*ast.GraphPatternFiller, error) {
+func (p *Parser) parseGraphPatternFiller(hintAlreadyConsumed bool) (*ast.GraphPatternFiller, error) {
 	filler := &ast.GraphPatternFiller{Loc: p.cur.Loc}
 	start := p.cur.Loc.Start
 	end := p.prev.Loc.End // empty filler: zero-width at the prior token's end
 
-	if p.cur.Type == int('@') {
+	// graph_element_pattern_filler admits at most one leading hint. When the caller
+	// (a node pattern via parseGraphPathPrimary) already consumed the single hint at
+	// the '(' level, do NOT consume another here — a second '@' is a syntax error
+	// (oracle: `(@{h1} @{h2} v)` -> live emulator `Expected ")" but got "@"`).
+	if !hintAlreadyConsumed && p.cur.Type == int('@') {
 		if herr := p.skipHint(); herr != nil {
 			return nil, herr
 		}

--- a/googlesql/parser/graph_query_oracle_test.go
+++ b/googlesql/parser/graph_query_oracle_test.go
@@ -1,0 +1,212 @@
+//go:build googlesql_oracle
+
+// Differential gate for the parser-gql node (GQL graph queries +
+// CREATE PROPERTY GRAPH) against the live Cloud Spanner emulator. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestGQLOracle
+//
+// EMPIRICAL FINDING (probed 2026-06-05, this node) — GQL is NOT a "BigQuery-only
+// blind spot" on this emulator. The analysis corpus (oracle.md) listed GQL among
+// the BigQuery-only forms to triangulate; the live emulator says otherwise: it
+// PARSES the GQL sub-language (Spanner natively supports Spanner Graph). A
+// `GRAPH <name> MATCH … RETURN …` query parses and fails only at the resolver
+// with InvalidArgument "Property graph not found: <name>" (no "Syntax error:"
+// prefix), which the harness classifies ACCEPT(semantic) — exactly like
+// "QUALIFY is not supported". So the positive differential is a true accept/accept
+// match, and the negative differential is a true reject/reject match (the emulator
+// emits a real "Syntax error:" for missing RETURN, set-op without ALL/DISTINCT,
+// bad arrows, empty labels, etc.). This is a far stronger PROVE result than the
+// triangulation the corpus presumed.
+//
+// THE ONE CLASSIFICATION CAVEAT — CREATE PROPERTY GRAPH's INNER grammar. The
+// emulator runs CREATE PROPERTY GRAPH through two layers: the OUTER Spanner DDL
+// grammar (its rejects carry the canonical "Error parsing Spanner DDL statement:"
+// prefix → harness REJECT) and a SEPARATE ZetaSQL property-graph subparser for
+// everything after the graph name, whose syntax errors come back as a plain
+// "Syntax error:" WITHOUT that prefix → harness ACCEPT(semantic). So a malformed
+// NODE TABLES list (missing parens / empty / no NODE TABLES at all) is a real
+// inner-parser syntax error that the harness MISCLASSIFIES as accept. Those cases
+// live in gqlDivergentFixtures: omni REJECTS them per the authoritative .g4 (and
+// per the emulator's actual inner-parser message), the harness mislabels them
+// accept, and we DEFEND omni. Divergence ledger ids 136 (IF NOT EXISTS optional +
+// mutually exclusive with OR REPLACE — a TRUE outer-grammar reject the harness
+// catches) and 137 (the inner-grammar misclassification). Reuses the ddlHarness
+// plumbing from ddl_oracle_test.go under the shared googlesql_oracle tag.
+
+package parser
+
+import (
+	"os"
+	"testing"
+)
+
+// gqlOracleExpectation is one fixture: the SQL, the expected live-emulator
+// verdict ("accept"/"reject" after harness classification), the expected omni
+// accept, and a note. (Same shape as bqOracleExpectation but named distinctly to
+// avoid a duplicate-symbol clash under the shared build tag.)
+type gqlOracleExpectation struct {
+	sql          string
+	oracleAccept string // "accept" | "reject"
+	omniAccept   bool
+	note         string
+}
+
+// gqlAcceptFixtures — GQL forms BOTH the live emulator and omni ACCEPT. The
+// emulator parses each and fails only at the resolver ("Property graph not
+// found" / "Table not found"), classified ACCEPT(semantic). A true accept/accept
+// differential across the whole §2.12 grammar surface.
+var gqlAcceptFixtures = []gqlOracleExpectation{
+	// ---- gql_statement: GRAPH <path> <ops> ----
+	{"GRAPH my_graph MATCH (n) RETURN n", "accept", true, "basic MATCH node + RETURN"},
+	{"GRAPH myproject.mydataset.my_graph MATCH (n) RETURN n", "accept", true, "dotted graph name path"},
+	{"GRAPH g MATCH (a)-[e]->(b) RETURN a, b", "accept", true, "right-directed full edge"},
+	{"GRAPH g MATCH (a)<-[e]-(b) RETURN a", "accept", true, "left-directed full edge"},
+	{"GRAPH g MATCH (a)-[e]-(b) RETURN a", "accept", true, "undirected full edge (leading < absent)"},
+	{"GRAPH g MATCH (a)-(b) RETURN a", "accept", true, "abbreviated undirected edge"},
+	{"GRAPH g MATCH (a)<-(b) RETURN a", "accept", true, "abbreviated left edge"},
+	{"GRAPH g MATCH (a)->(b) RETURN a", "accept", true, "abbreviated right edge"},
+	{"GRAPH g OPTIONAL MATCH (a)-[e]->(b) RETURN a, b", "accept", true, "OPTIONAL MATCH"},
+	// ---- label algebra ----
+	{"GRAPH g MATCH (n:Person) RETURN n", "accept", true, "label via ':'"},
+	{"GRAPH g MATCH (n IS Person) RETURN n", "accept", true, "label via IS"},
+	{"GRAPH g MATCH (n:%) RETURN n", "accept", true, "wildcard label %"},
+	{"GRAPH g MATCH (n:!Temp) RETURN n", "accept", true, "negated label"},
+	{"GRAPH g MATCH (n:A|B&C) RETURN n", "accept", true, "label OR/AND precedence"},
+	{"GRAPH g MATCH (n:(A|B)&C) RETURN n", "accept", true, "parenthesized label expr"},
+	// ---- filler: properties, inline WHERE, empty ----
+	{"GRAPH g MATCH (n:Person {name: 'Alice', age: 30}) RETURN n", "accept", true, "property specification"},
+	{"GRAPH g MATCH (n:Person WHERE n.age > 18) RETURN n", "accept", true, "inline WHERE in filler"},
+	{"GRAPH g MATCH () RETURN 1", "accept", true, "empty node pattern"},
+	{"GRAPH g MATCH (a)-[e]->(b) WHERE a.id = b.id RETURN a", "accept", true, "pattern-level WHERE"},
+	{"GRAPH g MATCH (a)-[]->(b), (b)-[]->(c) RETURN a, c", "accept", true, "multiple path patterns"},
+	// ---- path prefixes / quantifier / parenthesized ----
+	{"GRAPH g MATCH p = ANY SHORTEST TRAIL (a)-[e]->(b) RETURN p", "accept", true, "path var + search + mode prefix"},
+	{"GRAPH g MATCH ANY (a)-[e]->(b) RETURN a", "accept", true, "bare ANY search prefix (no SHORTEST)"},
+	{"GRAPH g MATCH ALL (a)-[e]->(b) RETURN a", "accept", true, "bare ALL search prefix"},
+	{"GRAPH g MATCH (a)-[:KNOWS]->(b) RETURN a", "accept", true, "anonymous edge with label"},
+	{"GRAPH g MATCH (a)-[e:KNOWS|LIKES]->(b) RETURN a", "accept", true, "edge with label disjunction in filler"},
+	{"GRAPH g MATCH WALK PATHS (a)-[e]->(b) RETURN a", "accept", true, "path mode WALK PATHS"},
+	{"GRAPH g MATCH (a) (-[e]->){1,3} (b) RETURN a", "accept", true, "quantified parenthesized path"},
+	{"GRAPH g MATCH ((a)-[e]->(b) WHERE a.x > 0) RETURN a", "accept", true, "parenthesized path with WHERE"},
+	// ---- linear operators ----
+	{"GRAPH g MATCH (n) LET x = n.age FILTER x > 18 RETURN x", "accept", true, "LET + bare FILTER"},
+	{"GRAPH g MATCH (n) FILTER WHERE n.age > 18 RETURN n", "accept", true, "FILTER WHERE form"},
+	{"GRAPH g MATCH (n) ORDER BY n.age DESC, n.name ASCENDING RETURN n", "accept", true, "ORDER BY operator w/ ASCENDING"},
+	{"GRAPH g MATCH (n) ORDER BY n.name COLLATE 'und:ci' DESC RETURN n", "accept", true, "ORDER BY with COLLATE"},
+	{"GRAPH g MATCH (n) WITH DISTINCT n.age AS age GROUP BY age RETURN age", "accept", true, "WITH + GROUP BY"},
+	{"GRAPH g MATCH (n) FOR x IN n.items WITH OFFSET AS pos RETURN x, pos", "accept", true, "FOR ... WITH OFFSET"},
+	{"GRAPH g MATCH (n) LIMIT 10 RETURN n", "accept", true, "standalone PAGE (LIMIT) operator"},
+	{"GRAPH g MATCH (n) OFFSET 5 LIMIT 10 RETURN n", "accept", true, "standalone PAGE (OFFSET..LIMIT)"},
+	{"GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (100 ROWS) RETURN n", "accept", true, "TABLESAMPLE rows"},
+	{"GRAPH g MATCH (n) TABLESAMPLE BERNOULLI (10 PERCENT) WITH WEIGHT AS w REPEATABLE (42) RETURN n", "accept", true, "TABLESAMPLE percent + WITH WEIGHT + REPEATABLE"},
+	// ---- restricted numeric operands — the VALID forms (int/param/cast/float) ----
+	{"GRAPH g MATCH (n) RETURN n LIMIT @p", "accept", true, "page LIMIT parameter (possibly_cast_int_literal_or_parameter)"},
+	{"GRAPH g MATCH (n) RETURN n LIMIT CAST(@p AS INT64)", "accept", true, "page LIMIT cast"},
+	{"GRAPH g MATCH (a) (-[e]->){@p,3} (b) RETURN a", "accept", true, "quantifier bound parameter (int_literal_or_parameter)"},
+	{"GRAPH g MATCH (n) TABLESAMPLE BERNOULLI (10.5 PERCENT) RETURN n", "accept", true, "sample size float (sample_size_value)"},
+	// ---- RETURN tails / composite ----
+	{"GRAPH g MATCH (n) RETURN *", "accept", true, "RETURN star"},
+	{"GRAPH g MATCH (n) RETURN n ORDER BY n.id OFFSET 5 LIMIT 3", "accept", true, "RETURN with ORDER BY + PAGE"},
+	{"GRAPH g MATCH (a) RETURN a NEXT MATCH (b) RETURN b", "accept", true, "NEXT-separated composite blocks"},
+	{"GRAPH g MATCH (a) RETURN a UNION ALL MATCH (b) RETURN b", "accept", true, "set-op UNION ALL"},
+	{"GRAPH g MATCH (a) RETURN a INTERSECT DISTINCT MATCH (b) RETURN b", "accept", true, "set-op INTERSECT DISTINCT"},
+
+	// ---- create_property_graph_statement (DDL) — OUTER grammar accepts ----
+	{"CREATE PROPERTY GRAPH g NODE TABLES (Person, Account)", "accept", true, "basic NODE TABLES"},
+	{"CREATE OR REPLACE PROPERTY GRAPH g NODE TABLES (T)", "accept", true, "OR REPLACE alone"},
+	{"CREATE PROPERTY GRAPH IF NOT EXISTS g NODE TABLES (T)", "accept", true, "IF NOT EXISTS alone"},
+	{"CREATE PROPERTY GRAPH g OPTIONS(x=true) NODE TABLES (T)", "accept", true, "OPTIONS"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES (Person KEY (id), Account KEY (id)) EDGE TABLES (Owns KEY (person_id, account_id) SOURCE KEY (person_id) REFERENCES Person (id) DESTINATION KEY (account_id) REFERENCES Account (id))", "accept", true, "EDGE TABLES with SOURCE/DESTINATION"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES (T PROPERTIES ARE ALL COLUMNS EXCEPT (secret))", "accept", true, "PROPERTIES ARE ALL COLUMNS EXCEPT"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES (T LABEL L NO PROPERTIES)", "accept", true, "LABEL ... NO PROPERTIES"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES (A, B,)", "accept", true, "trailing comma in element list"},
+}
+
+// gqlRejectFixtures — forms BOTH the live emulator and omni REJECT with a true
+// syntax error. For queries the emulator emits "Syntax error:" (harness REJECT);
+// for the CREATE PROPERTY GRAPH OR-REPLACE/IF-NOT-EXISTS conflict it emits the
+// canonical "Error parsing Spanner DDL statement:" prefix (harness REJECT,
+// ledger 136).
+var gqlRejectFixtures = []gqlOracleExpectation{
+	{"GRAPH g MATCH (n)", "reject", false, "missing RETURN (emulator: Expected keyword RETURN)"},
+	{"GRAPH g RETURN", "reject", false, "RETURN with no items"},
+	{"GRAPH g MATCH n RETURN n", "reject", false, "bare node needs parens (emulator: Expected '=' / path-var)"},
+	{"GRAPH g MATCH (a)=>(b) RETURN a", "reject", false, "'=>' is not a valid edge arrow"},
+	{"GRAPH g MATCH (a)<-[e]->(b) RETURN a", "reject", false, "a full edge cannot be both <- and -> (emulator: Expected '-' but got '->')"},
+	{"GRAPH g MATCH (n:) RETURN n", "reject", false, "empty label after ':'"},
+	{"GRAPH g MATCH (a) RETURN a UNION MATCH (b) RETURN b", "reject", false, "set-op metadata requires ALL|DISTINCT"},
+	// Restricted numeric operands: a page count / quantifier bound / sample size is
+	// int_literal_or_parameter (+cast/float where the grammar allows), NOT a full
+	// expression — a bare identifier or arithmetic there is a true syntax error.
+	{"GRAPH g MATCH (n) RETURN n LIMIT x", "reject", false, "page LIMIT must be int/param/cast, not an identifier"},
+	{"GRAPH g MATCH (n) RETURN n LIMIT 1+1", "reject", false, "page LIMIT cannot be an arithmetic expression"},
+	{"GRAPH g MATCH (n) LIMIT z RETURN n", "reject", false, "standalone-page LIMIT identifier"},
+	{"GRAPH g MATCH (a) (-[e]->){1+1,3} (b) RETURN a", "reject", false, "quantifier bound cannot be arithmetic"},
+	{"GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (foo ROWS) RETURN n", "reject", false, "sample size must be numeric/param, not an identifier"},
+	// CREATE PROPERTY GRAPH — OUTER-grammar true rejects (ledger 136).
+	{"CREATE OR REPLACE PROPERTY GRAPH IF NOT EXISTS g NODE TABLES (T)", "reject", false, "OR REPLACE + IF NOT EXISTS mutually exclusive (emulator: Error parsing Spanner DDL statement: ... cannot be used with other existence modifiers)"},
+	{"CREATE PROPERTY g NODE TABLES (T)", "reject", false, "PROPERTY without GRAPH (emulator outer DDL: Encountered 'PROPERTY')"},
+	{"CREATE TEMP PROPERTY GRAPH g NODE TABLES (T)", "reject", false, "no create-scope before PROPERTY GRAPH (emulator outer DDL: Encountered 'TEMP')"},
+}
+
+// gqlDivergentFixtures — DEFENDED divergences (ledger 137). omni REJECTS these
+// per the authoritative .g4 (NODE TABLES requires a parenthesized non-empty
+// element_table_list; LABEL needs a name; KEY needs parens). The live emulator's
+// INNER property-graph subparser ALSO rejects them (its messages are real
+// "Syntax error: Expected ( …" / "Unexpected )" complaints) — but those errors
+// lack the "Error parsing Spanner DDL statement:" prefix, so the harness
+// MISCLASSIFIES them as accept(semantic). The oracle therefore did NOT truly
+// decide; omni follows the .g4 and the emulator's actual inner-parser behavior.
+// Recorded so any future flip (e.g. the emulator starting to emit the DDL prefix
+// for these) is caught.
+var gqlDivergentFixtures = []gqlOracleExpectation{
+	{"CREATE PROPERTY GRAPH g", "accept", false, "no NODE TABLES — .g4 requires it; emulator inner-parser rejects but harness misclassifies accept"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES ()", "accept", false, "empty element list — .g4 requires >=1; misclassified accept"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES T", "accept", false, "element list needs parens; misclassified accept"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES (T LABEL)", "accept", false, "LABEL needs a name; misclassified accept"},
+	{"CREATE PROPERTY GRAPH g NODE TABLES (T KEY id)", "accept", false, "KEY needs parens; misclassified accept"},
+	{"CREATE PROPERTY GRAPH g EDGE TABLES (E)", "accept", false, "NODE TABLES is required first; misclassified accept"},
+}
+
+func TestGQLOracleDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live GQL oracle differential")
+	}
+	h := newDDLHarness(t)
+	defer h.close()
+
+	// Positive + negative: omni's accept/reject MUST equal the (correctly
+	// classified) emulator verdict.
+	run := func(name string, fixtures []gqlOracleExpectation, enforce bool) {
+		t.Run(name, func(t *testing.T) {
+			for _, fx := range fixtures {
+				v := h.verdict(t, fx.sql)
+				if v.Verdict == "error" {
+					t.Fatalf("oracle returned ERROR (no verdict) for %q: %s %s — fix the emulator/fixture, do not proceed", fx.sql, v.Reason, v.Message)
+				}
+				oracleAccepts := v.Verdict == "accept"
+				if oracleAccepts != (fx.oracleAccept == "accept") {
+					t.Errorf("oracle verdict drift on %q: got %s (%s: %s), fixture expected %s", fx.sql, v.Verdict, v.Reason, v.Message, fx.oracleAccept)
+				}
+				_, errs := Parse(fx.sql)
+				omniAccepts := len(errs) == 0
+				if omniAccepts != fx.omniAccept {
+					t.Errorf("omni accept drift on %q: omni accepts=%v, fixture expected %v; errs=%v", fx.sql, omniAccepts, fx.omniAccept, errs)
+				}
+				if enforce && omniAccepts != oracleAccepts {
+					t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s)", fx.sql, omniAccepts, oracleAccepts, v.Reason, v.Message)
+				}
+			}
+		})
+	}
+
+	run("Accept", gqlAcceptFixtures, true)
+	run("Reject", gqlRejectFixtures, true)
+	// Divergent: assert omni REJECTS and the emulator MISCLASSIFIES as accept (the
+	// documented inner-grammar classification gap). enforce=false: the
+	// accept/reject mismatch is EXPECTED and DEFENDED (ledger 137); we still pin
+	// both sides so a future emulator change (it starting to surface the DDL
+	// prefix for these → harness reject → match) trips the per-side checks.
+	run("DivergentDefended", gqlDivergentFixtures, false)
+}

--- a/googlesql/parser/graph_query_oracle_test.go
+++ b/googlesql/parser/graph_query_oracle_test.go
@@ -89,6 +89,20 @@ var gqlAcceptFixtures = []gqlOracleExpectation{
 	{"GRAPH g MATCH WALK PATHS (a)-[e]->(b) RETURN a", "accept", true, "path mode WALK PATHS"},
 	{"GRAPH g MATCH (a) (-[e]->){1,3} (b) RETURN a", "accept", true, "quantified parenthesized path"},
 	{"GRAPH g MATCH ((a)-[e]->(b) WHERE a.x > 0) RETURN a", "accept", true, "parenthesized path with WHERE"},
+	// ---- F1: parenthesized path whose interior begins with a path-pattern prefix
+	//      (path-var assignment / search / mode). graph_parenthesized_path_pattern
+	//      wraps the FULL graph_path_pattern (prefixes included). ----
+	{"GRAPH g MATCH (p = (a)-[e]->(b)) RETURN p", "accept", true, "F1: parenthesized path with path-variable assignment"},
+	{"GRAPH g MATCH (ANY (a)-[e]->(b)) RETURN a", "accept", true, "F1: parenthesized path with ANY search prefix"},
+	{"GRAPH g MATCH (ALL SHORTEST (a)-[e]->(b)) RETURN a", "accept", true, "F1: parenthesized path with ALL SHORTEST search prefix"},
+	{"GRAPH g MATCH (WALK (a)-[e]->(b)) RETURN a", "accept", true, "F1: parenthesized path with WALK path-mode prefix"},
+	// ---- F2: a node pattern whose filler starts with a hint. ----
+	{"GRAPH g MATCH (@{force_index=idx} v:Person) RETURN v", "accept", true, "F2: hinted node pattern filler"},
+	// ---- F6: inline WHERE in a filler with NO element identifier (opt_graph_element_identifier absent). ----
+	{"GRAPH g MATCH (:Person WHERE TRUE) RETURN 1", "accept", true, "F6: labeled filler with WHERE, no identifier"},
+	{"GRAPH g MATCH (WHERE foo) RETURN 1", "accept", true, "F6: bare WHERE filler, no identifier"},
+	// ---- F5: an inter-factor hint FOLLOWED by a factor is valid. ----
+	{"GRAPH g MATCH (a) @{h=1} (b) RETURN *", "accept", true, "F5: inter-factor hint followed by a node factor"},
 	// ---- linear operators ----
 	{"GRAPH g MATCH (n) LET x = n.age FILTER x > 18 RETURN x", "accept", true, "LET + bare FILTER"},
 	{"GRAPH g MATCH (n) FILTER WHERE n.age > 18 RETURN n", "accept", true, "FILTER WHERE form"},
@@ -144,6 +158,11 @@ var gqlRejectFixtures = []gqlOracleExpectation{
 	{"GRAPH g MATCH (n) LIMIT z RETURN n", "reject", false, "standalone-page LIMIT identifier"},
 	{"GRAPH g MATCH (a) (-[e]->){1+1,3} (b) RETURN a", "reject", false, "quantifier bound cannot be arithmetic"},
 	{"GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (foo ROWS) RETURN n", "reject", false, "sample size must be numeric/param, not an identifier"},
+	// F5: a hint between factors belongs to a `(hint? graph_path_factor)` group, so a
+	// TRAILING hint with no factor after it is a syntax error (emulator: Expected "("
+	// or "-" or "<" or -> but got the next keyword).
+	{"GRAPH g MATCH (a) @{h=1} RETURN *", "reject", false, "F5: trailing path-factor hint with no following factor"},
+	{"GRAPH g MATCH (a)-[e]->(b) @{h=1} RETURN *", "reject", false, "F5: trailing path-factor hint after a full path"},
 	// CREATE PROPERTY GRAPH — OUTER-grammar true rejects (ledger 136).
 	{"CREATE OR REPLACE PROPERTY GRAPH IF NOT EXISTS g NODE TABLES (T)", "reject", false, "OR REPLACE + IF NOT EXISTS mutually exclusive (emulator: Error parsing Spanner DDL statement: ... cannot be used with other existence modifiers)"},
 	{"CREATE PROPERTY g NODE TABLES (T)", "reject", false, "PROPERTY without GRAPH (emulator outer DDL: Encountered 'PROPERTY')"},

--- a/googlesql/parser/graph_query_test.go
+++ b/googlesql/parser/graph_query_test.go
@@ -450,6 +450,36 @@ func TestGQL_HintedNodePattern(t *testing.T) {
 	}
 }
 
+// TestGQL_DoubleHintRejected pins the post-review fix: a node pattern admits at
+// most one leading hint (graph_element_pattern_filler: `hint? ...`). The single
+// hint is consumed at the '(' level; the filler must NOT consume a second, so a
+// second '@' is a syntax error. Oracle: the live Spanner emulator rejects
+// `(@{h1} @{h2} v)` with `Expected ")" but got "@"`.
+func TestGQL_DoubleHintRejected(t *testing.T) {
+	assertReject(t, "GRAPH g MATCH (@{h1=1} @{h2=2} v) RETURN v")
+	assertReject(t, "GRAPH g MATCH (@{h1=1} @{h2=2} :Person) RETURN 1")
+}
+
+// TestGQL_KeywordPathVarRejected pins the resolution of a review finding: a
+// path-variable assignment whose name is a graph path-mode keyword
+// (WALK/TRAIL/SIMPLE/...) is REJECTED. The legacy .g4 lists WALK/TRAIL/ACYCLIC
+// in common_keyword_as_identifier (which would permit them as graph
+// identifiers), but the live ZetaSQL/Spanner emulator REJECTS them as path-var
+// names (`Syntax error: Unexpected "="`). The oracle wins over the .g4, so omni
+// correctly rejects; this guards against a future change that loosens it to the
+// .g4.
+func TestGQL_KeywordPathVarRejected(t *testing.T) {
+	for _, sql := range []string{
+		"GRAPH g MATCH (walk = (a)) RETURN walk",
+		"GRAPH g MATCH (trail = (a)) RETURN trail",
+		"GRAPH g MATCH (simple = (a)) RETURN simple",
+	} {
+		assertReject(t, sql)
+	}
+	// A plain (non-keyword) identifier path-variable name is still accepted.
+	gqlStmtOf(t, "GRAPH g MATCH (x = (a)) RETURN x")
+}
+
 // TestGQL_TrailingPathFactorHintRejected covers finding F5: a hint between path
 // factors is part of a `(hint? graph_path_factor)` group, so it MUST be followed
 // by another factor. A TRAILING hint with no factor after it is a syntax error —

--- a/googlesql/parser/graph_query_test.go
+++ b/googlesql/parser/graph_query_test.go
@@ -1,0 +1,744 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-gql node — the §2.12 GQL graph query language
+// (gql_statement: `GRAPH <path> <ops>`) and the create_property_graph_statement
+// DDL. These assert the AST STRUCTURE (the structural gate: accept/reject alone
+// does not catch wrong nesting / direction / label-precedence) and cover the
+// edge-direction set, the label algebra precedence, the linear operators, and
+// the property-graph element-table grammar.
+//
+// GQL is BigQuery/Spanner-Graph syntax; the truth1 BigQuery corpus scopes the
+// full GQL syntax OUT (INDEX.md), so the authoritative reference for the grammar
+// shape is the pinned legacy GoogleSQLParser.g4. The accept/reject of these forms
+// against the live Spanner emulator is recorded in graph_query_oracle_test.go
+// (build tag googlesql_oracle).
+
+// gqlStmtOf parses sql and asserts the single statement is a *GQLStmt.
+func gqlStmtOf(t *testing.T, sql string) *ast.GQLStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	g, ok := n.(*ast.GQLStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.GQLStmt", sql, n)
+	}
+	return g
+}
+
+// linearOf asserts the GQL statement is a single linear query (one block, not a
+// set operation) and returns it.
+func linearOf(t *testing.T, g *ast.GQLStmt) *ast.GraphLinearQuery {
+	t.Helper()
+	if len(g.Blocks) != 1 {
+		t.Fatalf("Blocks = %d, want 1", len(g.Blocks))
+	}
+	lq, ok := g.Blocks[0].(*ast.GraphLinearQuery)
+	if !ok {
+		t.Fatalf("Blocks[0] is %T, want *ast.GraphLinearQuery", g.Blocks[0])
+	}
+	return lq
+}
+
+func TestGQL_BasicMatchReturn(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH my_graph MATCH (n) RETURN n")
+	if g.Name.String() != "my_graph" {
+		t.Errorf("Name = %q, want my_graph", g.Name.String())
+	}
+	lq := linearOf(t, g)
+	if len(lq.Operators) != 1 {
+		t.Fatalf("Operators = %d, want 1 (MATCH)", len(lq.Operators))
+	}
+	m, ok := lq.Operators[0].(*ast.GraphMatchOp)
+	if !ok {
+		t.Fatalf("operator is %T, want *ast.GraphMatchOp", lq.Operators[0])
+	}
+	if m.Optional {
+		t.Error("MATCH should not be Optional")
+	}
+	if len(m.Pattern.Paths) != 1 {
+		t.Fatalf("pattern paths = %d, want 1", len(m.Pattern.Paths))
+	}
+	node, ok := m.Pattern.Paths[0].Factors[0].(*ast.GraphNodePattern)
+	if !ok {
+		t.Fatalf("factor is %T, want *ast.GraphNodePattern", m.Pattern.Paths[0].Factors[0])
+	}
+	if node.Filler.Var != "n" {
+		t.Errorf("node var = %q, want n", node.Filler.Var)
+	}
+	if lq.Return == nil || len(lq.Return.Items) != 1 {
+		t.Fatalf("RETURN items = %v, want 1", lq.Return)
+	}
+}
+
+func TestGQL_OptionalMatch(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g OPTIONAL MATCH (a)-[e]->(b) RETURN a, b")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	if !m.Optional {
+		t.Error("OPTIONAL MATCH should be Optional")
+	}
+	// (a)-[e]->(b): node, right-full edge, node.
+	factors := m.Pattern.Paths[0].Factors
+	if len(factors) != 3 {
+		t.Fatalf("factors = %d, want 3 (node, edge, node)", len(factors))
+	}
+	edge, ok := factors[1].(*ast.GraphEdgePattern)
+	if !ok {
+		t.Fatalf("factors[1] is %T, want *ast.GraphEdgePattern", factors[1])
+	}
+	if edge.Direction != ast.EdgeRightFull {
+		t.Errorf("edge direction = %v, want EdgeRightFull", edge.Direction)
+	}
+	if edge.Filler == nil || edge.Filler.Var != "e" {
+		t.Errorf("edge filler var = %v, want e", edge.Filler)
+	}
+}
+
+// TestGQL_EdgeDirections covers all six graph_edge_pattern shapes, including the
+// undirected full edge `-[e]-` (the legacy first alternative `LT? MINUS … MINUS`
+// with the leading `<` ABSENT — a real over-reject the oracle differential caught
+// when it was modeled as left-only).
+func TestGQL_EdgeDirections(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want ast.GraphEdgeDirection
+		full bool
+	}{
+		{"GRAPH g MATCH (a)-(b) RETURN a", ast.EdgeAny, false},
+		{"GRAPH g MATCH (a)<-(b) RETURN a", ast.EdgeLeft, false},
+		{"GRAPH g MATCH (a)->(b) RETURN a", ast.EdgeRight, false},
+		{"GRAPH g MATCH (a)<-[e]-(b) RETURN a", ast.EdgeLeftFull, true},
+		{"GRAPH g MATCH (a)-[e]->(b) RETURN a", ast.EdgeRightFull, true},
+		{"GRAPH g MATCH (a)-[e]-(b) RETURN a", ast.EdgeUndirectedFull, true},
+	}
+	for _, c := range cases {
+		g := gqlStmtOf(t, c.sql)
+		lq := linearOf(t, g)
+		m := lq.Operators[0].(*ast.GraphMatchOp)
+		factors := m.Pattern.Paths[0].Factors
+		edge, ok := factors[1].(*ast.GraphEdgePattern)
+		if !ok {
+			t.Fatalf("%q: factors[1] is %T, want edge", c.sql, factors[1])
+		}
+		if edge.Direction != c.want {
+			t.Errorf("%q: direction = %v, want %v", c.sql, edge.Direction, c.want)
+		}
+		if c.full && edge.Filler == nil {
+			t.Errorf("%q: full edge should carry a filler", c.sql)
+		}
+		if !c.full && edge.Filler != nil {
+			t.Errorf("%q: abbreviated edge should not carry a filler", c.sql)
+		}
+	}
+}
+
+// TestGQL_LabelExpression covers the label algebra: bare label via `:` and `IS`,
+// the `%` wildcard, `&`/`|` combinators with precedence, `!` negation, and
+// parentheses.
+func TestGQL_LabelExpression(t *testing.T) {
+	// Bare label via ':'.
+	g := gqlStmtOf(t, "GRAPH g MATCH (n:Person) RETURN n")
+	filler := nodeFiller(t, g)
+	if filler.Label == nil || filler.Label.Kind != ast.LabelName || filler.Label.Name != "Person" {
+		t.Fatalf("label = %+v, want LabelName Person", filler.Label)
+	}
+	if !filler.LabelColon {
+		t.Error("expected LabelColon true for ':' spelling")
+	}
+
+	// Label via IS.
+	g = gqlStmtOf(t, "GRAPH g MATCH (n IS Person) RETURN n")
+	filler = nodeFiller(t, g)
+	if filler.LabelColon {
+		t.Error("expected LabelColon false for IS spelling")
+	}
+	if filler.Label.Name != "Person" {
+		t.Errorf("label = %q, want Person", filler.Label.Name)
+	}
+
+	// Wildcard %.
+	g = gqlStmtOf(t, "GRAPH g MATCH (n:%) RETURN n")
+	filler = nodeFiller(t, g)
+	if filler.Label.Kind != ast.LabelWildcard {
+		t.Errorf("label kind = %v, want LabelWildcard", filler.Label.Kind)
+	}
+
+	// Negation !A.
+	g = gqlStmtOf(t, "GRAPH g MATCH (n:!Temp) RETURN n")
+	filler = nodeFiller(t, g)
+	if filler.Label.Kind != ast.LabelNot || filler.Label.Operand.Name != "Temp" {
+		t.Errorf("label = %+v, want !Temp", filler.Label)
+	}
+
+	// Precedence: A | B & C parses as A | (B & C) (& binds tighter than |).
+	g = gqlStmtOf(t, "GRAPH g MATCH (n:A|B&C) RETURN n")
+	filler = nodeFiller(t, g)
+	if filler.Label.Kind != ast.LabelOr {
+		t.Fatalf("top label kind = %v, want LabelOr", filler.Label.Kind)
+	}
+	if filler.Label.Left.Kind != ast.LabelName || filler.Label.Left.Name != "A" {
+		t.Errorf("OR left = %+v, want A", filler.Label.Left)
+	}
+	if filler.Label.Right.Kind != ast.LabelAnd {
+		t.Errorf("OR right kind = %v, want LabelAnd (B & C)", filler.Label.Right.Kind)
+	}
+	if filler.Label.Right.Left.Name != "B" || filler.Label.Right.Right.Name != "C" {
+		t.Errorf("AND operands = %+v / %+v, want B / C", filler.Label.Right.Left, filler.Label.Right.Right)
+	}
+
+	// Parentheses override: (A | B) & C parses as (A | B) & C.
+	g = gqlStmtOf(t, "GRAPH g MATCH (n:(A|B)&C) RETURN n")
+	filler = nodeFiller(t, g)
+	if filler.Label.Kind != ast.LabelAnd {
+		t.Fatalf("top label kind = %v, want LabelAnd", filler.Label.Kind)
+	}
+	if filler.Label.Left.Kind != ast.LabelOr {
+		t.Errorf("AND left kind = %v, want LabelOr ((A|B))", filler.Label.Left.Kind)
+	}
+	if filler.Label.Right.Name != "C" {
+		t.Errorf("AND right = %+v, want C", filler.Label.Right)
+	}
+}
+
+// nodeFiller extracts the filler of the first node pattern of a single
+// MATCH-RETURN GQL statement.
+func nodeFiller(t *testing.T, g *ast.GQLStmt) *ast.GraphPatternFiller {
+	t.Helper()
+	lq := linearOf(t, g)
+	m, ok := lq.Operators[0].(*ast.GraphMatchOp)
+	if !ok {
+		t.Fatalf("operator is %T, want match", lq.Operators[0])
+	}
+	node, ok := m.Pattern.Paths[0].Factors[0].(*ast.GraphNodePattern)
+	if !ok {
+		t.Fatalf("factor is %T, want node", m.Pattern.Paths[0].Factors[0])
+	}
+	return node.Filler
+}
+
+func TestGQL_PropertySpecification(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n:Person {name: 'Alice', age: 30}) RETURN n")
+	filler := nodeFiller(t, g)
+	if filler.Properties == nil || len(filler.Properties.Properties) != 2 {
+		t.Fatalf("properties = %+v, want 2", filler.Properties)
+	}
+	if filler.Properties.Properties[0].Name != "name" {
+		t.Errorf("prop[0] name = %q, want name", filler.Properties.Properties[0].Name)
+	}
+	if filler.Properties.Properties[1].Name != "age" {
+		t.Errorf("prop[1] name = %q, want age", filler.Properties.Properties[1].Name)
+	}
+}
+
+func TestGQL_EmptyNodePattern(t *testing.T) {
+	// An empty filler `()` is valid (the grammar's empty production).
+	g := gqlStmtOf(t, "GRAPH g MATCH () RETURN 1")
+	filler := nodeFiller(t, g)
+	if filler.Var != "" || filler.Label != nil || filler.Properties != nil {
+		t.Errorf("empty filler should be all-zero, got %+v", filler)
+	}
+}
+
+func TestGQL_InlineWhereInFiller(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n:Person WHERE n.age > 18) RETURN n")
+	filler := nodeFiller(t, g)
+	if filler.Where == nil {
+		t.Error("expected inline WHERE in filler")
+	}
+	if filler.Label == nil || filler.Label.Name != "Person" {
+		t.Errorf("label = %+v, want Person", filler.Label)
+	}
+}
+
+func TestGQL_PatternWhere(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (a)-[e]->(b) WHERE a.id = b.id RETURN a")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	if m.Pattern.Where == nil {
+		t.Error("expected pattern-level WHERE")
+	}
+}
+
+func TestGQL_MultiplePathPatterns(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (a)-[]->(b), (b)-[]->(c) RETURN a, c")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	if len(m.Pattern.Paths) != 2 {
+		t.Fatalf("paths = %d, want 2", len(m.Pattern.Paths))
+	}
+}
+
+func TestGQL_PathVariableAndSearchAndMode(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH p = ANY SHORTEST TRAIL (a)-[e]->(b) RETURN p")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	path := m.Pattern.Paths[0]
+	if path.PathVar != "p" {
+		t.Errorf("PathVar = %q, want p", path.PathVar)
+	}
+	if path.Search != "ANY SHORTEST" {
+		t.Errorf("Search = %q, want 'ANY SHORTEST'", path.Search)
+	}
+	if path.Mode != "TRAIL" {
+		t.Errorf("Mode = %q, want TRAIL", path.Mode)
+	}
+}
+
+func TestGQL_PathModeWithPaths(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH WALK PATHS (a)-[e]->(b) RETURN a")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	if m.Pattern.Paths[0].Mode != "WALK PATHS" {
+		t.Errorf("Mode = %q, want 'WALK PATHS'", m.Pattern.Paths[0].Mode)
+	}
+}
+
+func TestGQL_QuantifiedPath(t *testing.T) {
+	// (a)-[e]->{1,3}(b): a quantified edge factor.
+	g := gqlStmtOf(t, "GRAPH g MATCH (a) (-[e]->){1,3} (b) RETURN a")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	// The middle factor is a parenthesized path with a {1,3} quantifier; just
+	// assert the path parsed with >= 3 factors (a, (quantified path), b).
+	if len(m.Pattern.Paths[0].Factors) < 3 {
+		t.Errorf("factors = %d, want >= 3", len(m.Pattern.Paths[0].Factors))
+	}
+}
+
+func TestGQL_ParenthesizedPath(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH ((a)-[e]->(b) WHERE a.x > 0) RETURN a")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	// The single factor is a parenthesized sub-path.
+	sub, ok := m.Pattern.Paths[0].Factors[0].(*ast.GraphPathPattern)
+	if !ok {
+		t.Fatalf("factor is %T, want *ast.GraphPathPattern (parenthesized)", m.Pattern.Paths[0].Factors[0])
+	}
+	if sub.Where == nil {
+		t.Error("expected WHERE inside parenthesized path")
+	}
+}
+
+// TestGQL_LinearOperators covers LET / FILTER / ORDER BY / WITH / FOR / PAGE.
+func TestGQL_LinearOperators(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) LET x = n.age FILTER x > 18 RETURN x")
+	lq := linearOf(t, g)
+	if len(lq.Operators) != 3 {
+		t.Fatalf("operators = %d, want 3 (MATCH, LET, FILTER)", len(lq.Operators))
+	}
+	let, ok := lq.Operators[1].(*ast.GraphLetOp)
+	if !ok || len(let.Vars) != 1 || let.Vars[0].Name != "x" {
+		t.Fatalf("LET = %+v, want one var x", lq.Operators[1])
+	}
+	filter, ok := lq.Operators[2].(*ast.GraphFilterOp)
+	if !ok || filter.HasWhere {
+		t.Fatalf("FILTER = %+v, want bare filter (no WHERE)", lq.Operators[2])
+	}
+}
+
+func TestGQL_FilterWhere(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) FILTER WHERE n.age > 18 RETURN n")
+	lq := linearOf(t, g)
+	filter := lq.Operators[1].(*ast.GraphFilterOp)
+	if !filter.HasWhere {
+		t.Error("expected FILTER WHERE form")
+	}
+}
+
+func TestGQL_OrderByOperator(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) ORDER BY n.age DESC, n.name ASCENDING RETURN n")
+	lq := linearOf(t, g)
+	ob, ok := lq.Operators[1].(*ast.GraphOrderByOp)
+	if !ok {
+		t.Fatalf("operator is %T, want order-by", lq.Operators[1])
+	}
+	if len(ob.Items) != 2 {
+		t.Fatalf("order items = %d, want 2", len(ob.Items))
+	}
+	if !ob.Items[0].HasDir || !ob.Items[0].Desc {
+		t.Errorf("item[0] = %+v, want DESC", ob.Items[0])
+	}
+	if !ob.Items[1].HasDir || ob.Items[1].Desc {
+		t.Errorf("item[1] = %+v, want ASCENDING (asc)", ob.Items[1])
+	}
+}
+
+func TestGQL_OrderByCollate(t *testing.T) {
+	// graph_ordering_expression: expression collate_clause? asc/desc? null_order?.
+	// The COLLATE operand must be retained as a Node on the OrderItem (not dropped),
+	// so an AST/lineage pass can reach it.
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) ORDER BY n.name COLLATE 'und:ci' DESC RETURN n")
+	lq := linearOf(t, g)
+	ob := lq.Operators[1].(*ast.GraphOrderByOp)
+	if len(ob.Items) != 1 {
+		t.Fatalf("order items = %d, want 1", len(ob.Items))
+	}
+	if ob.Items[0].Collate == nil {
+		t.Error("expected COLLATE operand retained on the OrderItem")
+	}
+	if !ob.Items[0].Desc {
+		t.Error("expected DESC after COLLATE")
+	}
+}
+
+func TestGQL_WithOperator(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) WITH DISTINCT n.age AS age GROUP BY age RETURN age")
+	lq := linearOf(t, g)
+	with, ok := lq.Operators[1].(*ast.GraphWithOp)
+	if !ok {
+		t.Fatalf("operator is %T, want with", lq.Operators[1])
+	}
+	if with.Quantifier != "DISTINCT" {
+		t.Errorf("quantifier = %q, want DISTINCT", with.Quantifier)
+	}
+	if len(with.Items) != 1 || with.Items[0].Alias != "age" {
+		t.Fatalf("with items = %+v, want one aliased 'age'", with.Items)
+	}
+	if with.GroupBy == nil {
+		t.Error("expected GROUP BY in WITH")
+	}
+}
+
+func TestGQL_ForOperator(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) FOR x IN n.items WITH OFFSET AS pos RETURN x, pos")
+	lq := linearOf(t, g)
+	forOp, ok := lq.Operators[1].(*ast.GraphForOp)
+	if !ok {
+		t.Fatalf("operator is %T, want for", lq.Operators[1])
+	}
+	if forOp.Name != "x" {
+		t.Errorf("FOR var = %q, want x", forOp.Name)
+	}
+	if !forOp.WithOffset || forOp.OffsetAlias != "pos" {
+		t.Errorf("WITH OFFSET = %v/%q, want true/pos", forOp.WithOffset, forOp.OffsetAlias)
+	}
+}
+
+func TestGQL_PageOperatorAndReturn(t *testing.T) {
+	// Standalone PAGE operator (LIMIT) then a RETURN with its own trailing PAGE.
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) LIMIT 10 RETURN n ORDER BY n.id OFFSET 5 LIMIT 3")
+	lq := linearOf(t, g)
+	page, ok := lq.Operators[1].(*ast.GraphPageOp)
+	if !ok {
+		t.Fatalf("operator is %T, want page", lq.Operators[1])
+	}
+	if page.Limit == nil || page.Skip != nil {
+		t.Errorf("standalone page = %+v, want bare LIMIT", page)
+	}
+	if lq.Return.OrderBy == nil {
+		t.Error("expected RETURN ORDER BY")
+	}
+	if lq.Return.Page == nil || lq.Return.Page.Skip == nil || lq.Return.Page.Limit == nil {
+		t.Errorf("RETURN page = %+v, want OFFSET..LIMIT", lq.Return.Page)
+	}
+}
+
+func TestGQL_SampleOperator(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (100 ROWS) WITH WEIGHT AS w REPEATABLE (42) RETURN n")
+	lq := linearOf(t, g)
+	s, ok := lq.Operators[1].(*ast.GraphSampleOp)
+	if !ok {
+		t.Fatalf("operator is %T, want sample", lq.Operators[1])
+	}
+	if s.Method != "RESERVOIR" {
+		t.Errorf("method = %q, want RESERVOIR", s.Method)
+	}
+	if s.Unit != "ROWS" {
+		t.Errorf("unit = %q, want ROWS", s.Unit)
+	}
+	if !s.WithWeight || s.WeightAlias != "w" {
+		t.Errorf("WITH WEIGHT = %v/%q, want true/w", s.WithWeight, s.WeightAlias)
+	}
+	if s.Repeatable == nil {
+		t.Error("expected REPEATABLE seed")
+	}
+}
+
+func TestGQL_ReturnStar(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n) RETURN *")
+	lq := linearOf(t, g)
+	if len(lq.Return.Items) != 1 || !lq.Return.Items[0].Star {
+		t.Fatalf("RETURN items = %+v, want a single star", lq.Return.Items)
+	}
+}
+
+func TestGQL_NextChain(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (a) RETURN a NEXT MATCH (b) RETURN b")
+	if len(g.Blocks) != 2 {
+		t.Fatalf("blocks = %d, want 2 (NEXT-separated)", len(g.Blocks))
+	}
+}
+
+func TestGQL_SetOperation(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (a) RETURN a UNION ALL MATCH (b) RETURN b")
+	if len(g.Blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1 (a single composite set-op block)", len(g.Blocks))
+	}
+	setOp, ok := g.Blocks[0].(*ast.GraphSetOp)
+	if !ok {
+		t.Fatalf("block is %T, want *ast.GraphSetOp", g.Blocks[0])
+	}
+	if len(setOp.Ops) != 2 || len(setOp.Metas) != 1 {
+		t.Fatalf("set op = %d ops / %d metas, want 2/1", len(setOp.Ops), len(setOp.Metas))
+	}
+	if setOp.Metas[0].Op != "UNION" || setOp.Metas[0].Quantifier != "ALL" {
+		t.Errorf("meta = %+v, want UNION ALL", setOp.Metas[0])
+	}
+}
+
+func TestGQL_DottedGraphName(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH myproject.mydataset.my_graph MATCH (n) RETURN n")
+	if g.Name.String() != "myproject.mydataset.my_graph" {
+		t.Errorf("Name = %q, want the 3-part path", g.Name.String())
+	}
+}
+
+// ---- Negative tests (the grammar must REJECT these) ----
+
+func TestGQL_Rejects(t *testing.T) {
+	cases := []string{
+		"GRAPH",                                               // no graph name, no ops
+		"GRAPH g",                                             // no operation block (RETURN required)
+		"GRAPH g MATCH (n)",                                   // missing RETURN
+		"GRAPH g RETURN",                                      // RETURN with no items
+		"GRAPH g MATCH n RETURN n",                            // node pattern needs parens
+		"GRAPH g MATCH (n LET x = 1 RETURN n",                 // unbalanced node paren
+		"GRAPH g MATCH (a)=>(b) RETURN a",                     // not a valid edge arrow
+		"GRAPH g MATCH (n) LET = 1 RETURN n",                  // LET needs an identifier
+		"GRAPH g MATCH (n) FOR x n.items RETURN x",            // FOR needs IN
+		"GRAPH g MATCH (a) RETURN a UNION MATCH (b) RETURN b", // set-op needs ALL|DISTINCT
+		"GRAPH g MATCH (n:) RETURN n",                         // empty label after ':'
+		"GRAPH g MATCH (n {x}) RETURN n",                      // property spec needs ': value'
+		// Numeric operands are restricted to int_literal_or_parameter /
+		// possibly_cast_int_literal_or_parameter / sample_size_value — NOT a full
+		// expression. A bare identifier or an arithmetic expression in a page count,
+		// a quantifier bound, or a sample size is a syntax error (oracle-confirmed —
+		// the live Spanner emulator rejects each with "Syntax error:").
+		"GRAPH g MATCH (n) RETURN n LIMIT x",                    // page LIMIT must be int/param/cast, not an ident
+		"GRAPH g MATCH (n) RETURN n OFFSET y LIMIT 3",           // page OFFSET ident
+		"GRAPH g MATCH (n) LIMIT z RETURN n",                    // standalone-page LIMIT ident
+		"GRAPH g MATCH (n) RETURN n LIMIT 1+1",                  // page LIMIT arithmetic
+		"GRAPH g MATCH (a) (-[e]->){1+1,3} (b) RETURN a",        // quantifier bound must be int/param, not arithmetic
+		"GRAPH g MATCH (a) (-[e]->){x} (b) RETURN a",            // quantifier bound ident
+		"GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (foo ROWS) RETURN n",  // sample size ident
+		"GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (1+1 ROWS) RETURN n",  // sample size arithmetic
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// TestGQL_NumericOperandForms asserts the RESTRICTED-but-valid operand forms the
+// grammar admits for page counts (possibly_cast_int_literal_or_parameter),
+// quantifier bounds (int_literal_or_parameter), and sample sizes
+// (sample_size_value = possibly_cast_int_literal_or_parameter | float): an
+// integer, a query parameter, a system variable, a CAST of one, and — for the
+// sample size only — a floating-point literal. (The reject side lives in
+// TestGQL_Rejects; both sides are pinned against the live oracle in
+// graph_query_oracle_test.go.)
+func TestGQL_NumericOperandForms(t *testing.T) {
+	accepts := []string{
+		"GRAPH g MATCH (n) RETURN n LIMIT @p",                  // page LIMIT parameter
+		"GRAPH g MATCH (n) RETURN n LIMIT CAST(@p AS INT64)",   // page LIMIT cast
+		"GRAPH g MATCH (n) RETURN n OFFSET @o LIMIT @l",        // page OFFSET..LIMIT params
+		"GRAPH g MATCH (n) LIMIT @@max RETURN n",               // standalone-page LIMIT system var
+		"GRAPH g MATCH (a) (-[e]->){@p,3} (b) RETURN a",        // quantifier bound parameter
+		"GRAPH g MATCH (a) (-[e]->){2} (b) RETURN a",           // quantifier single int bound
+		"GRAPH g MATCH (n) TABLESAMPLE BERNOULLI (10.5 PERCENT) RETURN n", // sample size float
+		"GRAPH g MATCH (n) TABLESAMPLE RESERVOIR (@n ROWS) RETURN n",      // sample size parameter
+	}
+	for _, sql := range accepts {
+		if _, errs := Parse(sql); len(errs) != 0 {
+			t.Errorf("Parse(%q) should accept, got errs=%v", sql, errs)
+		}
+	}
+}
+
+// ---- CREATE PROPERTY GRAPH ----
+
+// createPropertyGraphOf parses sql and asserts it is a *CreatePropertyGraphStmt.
+func createPropertyGraphOf(t *testing.T, sql string) *ast.CreatePropertyGraphStmt {
+	t.Helper()
+	n := parseDDL(t, sql)
+	pg, ok := n.(*ast.CreatePropertyGraphStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): statement is %T, want *ast.CreatePropertyGraphStmt", sql, n)
+	}
+	return pg
+}
+
+func TestCreatePropertyGraph_Basic(t *testing.T) {
+	pg := createPropertyGraphOf(t, "CREATE PROPERTY GRAPH my_graph NODE TABLES (Person, Account)")
+	if pg.Name.String() != "my_graph" {
+		t.Errorf("Name = %q, want my_graph", pg.Name.String())
+	}
+	if len(pg.NodeTables) != 2 {
+		t.Fatalf("node tables = %d, want 2", len(pg.NodeTables))
+	}
+	if pg.NodeTables[0].Name.String() != "Person" || pg.NodeTables[1].Name.String() != "Account" {
+		t.Errorf("node tables = %q/%q, want Person/Account", pg.NodeTables[0].Name, pg.NodeTables[1].Name)
+	}
+	if pg.EdgeTables != nil {
+		t.Errorf("EdgeTables = %+v, want nil", pg.EdgeTables)
+	}
+}
+
+func TestCreatePropertyGraph_OrReplaceOptions(t *testing.T) {
+	pg := createPropertyGraphOf(t, "CREATE OR REPLACE PROPERTY GRAPH g OPTIONS(x='y') NODE TABLES (T)")
+	if !pg.OrReplace {
+		t.Error("expected OrReplace")
+	}
+	if pg.IfNotExists {
+		t.Error("did not expect IfNotExists")
+	}
+	if len(pg.Options) != 1 || pg.Options[0].Name != "x" {
+		t.Fatalf("options = %+v, want one option x", pg.Options)
+	}
+}
+
+func TestCreatePropertyGraph_IfNotExists(t *testing.T) {
+	pg := createPropertyGraphOf(t, "CREATE PROPERTY GRAPH IF NOT EXISTS g NODE TABLES (T)")
+	if pg.OrReplace {
+		t.Error("did not expect OrReplace")
+	}
+	if !pg.IfNotExists {
+		t.Error("expected IfNotExists")
+	}
+}
+
+// TestCreatePropertyGraph_OrReplaceIfNotExistsConflict asserts the oracle-backed
+// divergence: OR REPLACE and IF NOT EXISTS are mutually exclusive (the live
+// Spanner emulator rejects the combination with a true DDL parse error; the
+// legacy .g4 would accept it). See the divergence note in
+// create_property_graph.go + graph_query_oracle_test.go.
+func TestCreatePropertyGraph_OrReplaceIfNotExistsConflict(t *testing.T) {
+	assertReject(t, "CREATE OR REPLACE PROPERTY GRAPH IF NOT EXISTS g NODE TABLES (T)")
+}
+
+func TestCreatePropertyGraph_EdgeTablesWithSourceDest(t *testing.T) {
+	sql := "CREATE PROPERTY GRAPH g " +
+		"NODE TABLES (Person KEY (id), Account KEY (id)) " +
+		"EDGE TABLES (Owns KEY (person_id, account_id) " +
+		"SOURCE KEY (person_id) REFERENCES Person (id) " +
+		"DESTINATION KEY (account_id) REFERENCES Account (id))"
+	pg := createPropertyGraphOf(t, sql)
+	if len(pg.NodeTables) != 2 {
+		t.Fatalf("node tables = %d, want 2", len(pg.NodeTables))
+	}
+	if len(pg.NodeTables[0].Key) != 1 || pg.NodeTables[0].Key[0] != "id" {
+		t.Errorf("Person KEY = %+v, want [id]", pg.NodeTables[0].Key)
+	}
+	if len(pg.EdgeTables) != 1 {
+		t.Fatalf("edge tables = %d, want 1", len(pg.EdgeTables))
+	}
+	edge := pg.EdgeTables[0]
+	if edge.Source == nil || edge.Source.Node != "Person" {
+		t.Fatalf("edge SOURCE = %+v, want REFERENCES Person", edge.Source)
+	}
+	if len(edge.Source.Columns) != 1 || edge.Source.Columns[0] != "person_id" {
+		t.Errorf("source columns = %+v, want [person_id]", edge.Source.Columns)
+	}
+	if len(edge.Source.RefColumns) != 1 || edge.Source.RefColumns[0] != "id" {
+		t.Errorf("source ref columns = %+v, want [id]", edge.Source.RefColumns)
+	}
+	if edge.Dest == nil || edge.Dest.Node != "Account" {
+		t.Fatalf("edge DESTINATION = %+v, want REFERENCES Account", edge.Dest)
+	}
+}
+
+func TestCreatePropertyGraph_Labels(t *testing.T) {
+	sql := "CREATE PROPERTY GRAPH g NODE TABLES (" +
+		"Person AS P LABEL Human PROPERTIES (name, age AS years) " +
+		"DEFAULT LABEL Entity)"
+	pg := createPropertyGraphOf(t, sql)
+	def := pg.NodeTables[0]
+	if def.Alias != "P" {
+		t.Errorf("alias = %q, want P", def.Alias)
+	}
+	if len(def.Labels) != 2 {
+		t.Fatalf("labels = %d, want 2", len(def.Labels))
+	}
+	if def.Labels[0].LabelName != "Human" || def.Labels[0].Kind != ast.LabelPropsList {
+		t.Errorf("label[0] = %+v, want Human with a props list", def.Labels[0])
+	}
+	if len(def.Labels[0].PropsList) != 2 || def.Labels[0].PropsList[1].Alias != "years" {
+		t.Errorf("label[0] props = %+v, want name, age AS years", def.Labels[0].PropsList)
+	}
+	if !def.Labels[1].Default || def.Labels[1].LabelName != "Entity" {
+		t.Errorf("label[1] = %+v, want DEFAULT LABEL Entity", def.Labels[1])
+	}
+}
+
+func TestCreatePropertyGraph_PropertiesAllColumns(t *testing.T) {
+	pg := createPropertyGraphOf(t, "CREATE PROPERTY GRAPH g NODE TABLES (T PROPERTIES ARE ALL COLUMNS EXCEPT (secret))")
+	def := pg.NodeTables[0]
+	if len(def.Labels) != 1 {
+		t.Fatalf("labels = %d, want 1 (bare properties clause)", len(def.Labels))
+	}
+	if def.Labels[0].Kind != ast.LabelPropsAllColumns {
+		t.Errorf("kind = %v, want LabelPropsAllColumns", def.Labels[0].Kind)
+	}
+	if def.Labels[0].LabelName != "" {
+		t.Errorf("bare properties clause should have empty LabelName, got %q", def.Labels[0].LabelName)
+	}
+	if len(def.Labels[0].ExceptColumns) != 1 || def.Labels[0].ExceptColumns[0] != "secret" {
+		t.Errorf("except = %+v, want [secret]", def.Labels[0].ExceptColumns)
+	}
+}
+
+func TestCreatePropertyGraph_NoProperties(t *testing.T) {
+	pg := createPropertyGraphOf(t, "CREATE PROPERTY GRAPH g NODE TABLES (T LABEL L NO PROPERTIES)")
+	if pg.NodeTables[0].Labels[0].Kind != ast.LabelPropsNone {
+		t.Errorf("kind = %v, want LabelPropsNone", pg.NodeTables[0].Labels[0].Kind)
+	}
+}
+
+func TestCreatePropertyGraph_TrailingComma(t *testing.T) {
+	// A trailing comma before the close paren is permitted by element_table_list.
+	pg := createPropertyGraphOf(t, "CREATE PROPERTY GRAPH g NODE TABLES (A, B,)")
+	if len(pg.NodeTables) != 2 {
+		t.Errorf("node tables = %d, want 2", len(pg.NodeTables))
+	}
+}
+
+func TestCreatePropertyGraph_Rejects(t *testing.T) {
+	cases := []string{
+		"CREATE PROPERTY GRAPH g",                        // no NODE TABLES
+		"CREATE PROPERTY g NODE TABLES (T)",              // PROPERTY without GRAPH
+		"CREATE PROPERTY GRAPH g NODE TABLES ()",         // empty element list
+		"CREATE PROPERTY GRAPH g NODE TABLES T",          // element list needs parens
+		"CREATE TEMP PROPERTY GRAPH g NODE TABLES (T)",   // no create-scope allowed
+		"CREATE PROPERTY GRAPH g NODE TABLES (T LABEL)",  // LABEL needs a name
+		"CREATE PROPERTY GRAPH g NODE TABLES (T KEY id)", // KEY needs parens
+		"CREATE PROPERTY GRAPH g EDGE TABLES (E)",        // NODE TABLES is required first
+	}
+	for _, sql := range cases {
+		assertReject(t, sql)
+	}
+}
+
+// TestGQL_WalkReachesSubnodes verifies the generated walker descends into GQL
+// nodes — a query-span / lineage pass must be able to reach the expressions
+// embedded in a graph query (LET/FILTER/property values/return items). We count
+// the path-expression nodes reachable from a GQL statement.
+func TestGQL_WalkReachesSubnodes(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (n:Person {x: a.b}) FILTER n.age > c.d RETURN n.name AS nm")
+	var pathExprs int
+	ast.Inspect(g, func(n ast.Node) bool {
+		if _, ok := n.(*ast.PathExpr); ok {
+			pathExprs++
+		}
+		return true
+	})
+	// Expect at least: a.b (property value), c.d (filter rhs), n.age, n.name,
+	// plus the graph name path. The exact count depends on how the expressions
+	// node shapes column refs; assert a healthy lower bound proves traversal.
+	if pathExprs < 3 {
+		t.Errorf("walker reached %d PathExpr nodes, want >= 3 (subnodes unreachable?)", pathExprs)
+	}
+}

--- a/googlesql/parser/graph_query_test.go
+++ b/googlesql/parser/graph_query_test.go
@@ -205,6 +205,48 @@ func TestGQL_LabelExpression(t *testing.T) {
 	}
 }
 
+// TestGQL_LabelNotBindsTightest pins the label-expression precedence the legacy
+// .g4 gets WRONG and the oracle/official docs get right (finding F4). The .g4
+// lists the unary `EXCLAMATION_OPERATOR label_expression` alternative LAST, which
+// — read as ANTLR left-recursion precedence — would bind `!` LOOSEST, parsing
+// `!A & B` as `!(A & B)`. That is a hand-port slip. Standard GQL/ZetaSQL label-
+// expression precedence (ISO/IEC 39075 GQL: NOT binds tighter than AND tighter
+// than OR; ZetaSQL graph-patterns.md's own example `(p:(!Singer&!Writer))` only
+// parses as `(!Singer)&(!Writer)`) makes `!` bind TIGHTEST, so `!A & B` is
+// `(!A) & B`. omni builds `(!A) & B`; we DEFEND that and lock the AST shape here.
+// (See the divergence ledger: the .g4 operator order is backwards.)
+func TestGQL_LabelNotBindsTightest(t *testing.T) {
+	// !A & B  must be  (!A) & B  — top is AND, left is NOT(A), right is B.
+	g := gqlStmtOf(t, "GRAPH g MATCH (n:!A&B) RETURN n")
+	lbl := nodeFiller(t, g).Label
+	if lbl.Kind != ast.LabelAnd {
+		t.Fatalf("top kind = %v, want LabelAnd ((!A)&B, i.e. ! binds tighter than &)", lbl.Kind)
+	}
+	if lbl.Left.Kind != ast.LabelNot || lbl.Left.Operand.Name != "A" {
+		t.Errorf("AND left = %+v, want LabelNot(A)", lbl.Left)
+	}
+	if lbl.Right.Kind != ast.LabelName || lbl.Right.Name != "B" {
+		t.Errorf("AND right = %+v, want LabelName B", lbl.Right)
+	}
+
+	// !A | B  must be  (!A) | B  — top is OR, left is NOT(A), right is B.
+	g = gqlStmtOf(t, "GRAPH g MATCH (n:!A|B) RETURN n")
+	lbl = nodeFiller(t, g).Label
+	if lbl.Kind != ast.LabelOr {
+		t.Fatalf("top kind = %v, want LabelOr ((!A)|B)", lbl.Kind)
+	}
+	if lbl.Left.Kind != ast.LabelNot || lbl.Left.Operand.Name != "A" {
+		t.Errorf("OR left = %+v, want LabelNot(A)", lbl.Left)
+	}
+
+	// The ZetaSQL canonical example: !A & !B  ==  (!A) & (!B).
+	g = gqlStmtOf(t, "GRAPH g MATCH (n:!A&!B) RETURN n")
+	lbl = nodeFiller(t, g).Label
+	if lbl.Kind != ast.LabelAnd || lbl.Left.Kind != ast.LabelNot || lbl.Right.Kind != ast.LabelNot {
+		t.Errorf("!A & !B = %+v, want LabelAnd(LabelNot, LabelNot)", lbl)
+	}
+}
+
 // nodeFiller extracts the filler of the first node pattern of a single
 // MATCH-RETURN GQL statement.
 func nodeFiller(t *testing.T, g *ast.GQLStmt) *ast.GraphPatternFiller {
@@ -321,6 +363,144 @@ func TestGQL_ParenthesizedPath(t *testing.T) {
 	}
 	if sub.Where == nil {
 		t.Error("expected WHERE inside parenthesized path")
+	}
+}
+
+// parenSubPathOf extracts the first path factor of a single MATCH-RETURN GQL
+// statement and asserts it is a parenthesized sub-path (*ast.GraphPathPattern).
+func parenSubPathOf(t *testing.T, sql string) *ast.GraphPathPattern {
+	t.Helper()
+	g := gqlStmtOf(t, sql)
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	sub, ok := m.Pattern.Paths[0].Factors[0].(*ast.GraphPathPattern)
+	if !ok {
+		t.Fatalf("%q: factor[0] is %T, want *ast.GraphPathPattern (parenthesized path)", sql, m.Pattern.Paths[0].Factors[0])
+	}
+	return sub
+}
+
+// TestGQL_ParenthesizedPathWithPrefix covers finding F1: a parenthesized path
+// whose interior begins with a path-pattern PREFIX — a path-variable assignment
+// (`p = …`), a search prefix (ANY / ALL [SHORTEST]), or a path-mode prefix
+// (WALK / TRAIL / SIMPLE / ACYCLIC). The .g4
+// `graph_parenthesized_path_pattern: '(' hint? graph_path_pattern …` admits the
+// full graph_path_pattern (prefixes included) inside the parens; the live Spanner
+// emulator accepts all of these. The disambiguator previously misrouted them to a
+// node pattern (and errored). These must parse as parenthesized sub-paths with
+// the prefix recorded on the inner path.
+func TestGQL_ParenthesizedPathWithPrefix(t *testing.T) {
+	// Path-variable assignment inside parens.
+	sub := parenSubPathOf(t, "GRAPH g MATCH (p = (a)-[e]->(b)) RETURN p")
+	if sub.PathVar != "p" {
+		t.Errorf("PathVar = %q, want p", sub.PathVar)
+	}
+	if len(sub.Factors) != 3 {
+		t.Errorf("inner factors = %d, want 3 (node, edge, node)", len(sub.Factors))
+	}
+
+	// Search prefix ANY.
+	if sub := parenSubPathOf(t, "GRAPH g MATCH (ANY (a)-[e]->(b)) RETURN a"); sub.Search != "ANY" {
+		t.Errorf("Search = %q, want ANY", sub.Search)
+	}
+
+	// Search prefix ALL SHORTEST.
+	if sub := parenSubPathOf(t, "GRAPH g MATCH (ALL SHORTEST (a)-[e]->(b)) RETURN a"); sub.Search != "ALL SHORTEST" {
+		t.Errorf("Search = %q, want 'ALL SHORTEST'", sub.Search)
+	}
+
+	// Path-mode prefix WALK.
+	if sub := parenSubPathOf(t, "GRAPH g MATCH (WALK (a)-[e]->(b)) RETURN a"); sub.Mode != "WALK" {
+		t.Errorf("Mode = %q, want WALK", sub.Mode)
+	}
+
+	// Combined prefix inside parens: var + search + mode.
+	sub = parenSubPathOf(t, "GRAPH g MATCH (q = ANY SHORTEST TRAIL (a)-[e]->(b)) RETURN q")
+	if sub.PathVar != "q" || sub.Search != "ANY SHORTEST" || sub.Mode != "TRAIL" {
+		t.Errorf("combined prefix = {var %q, search %q, mode %q}, want {q, 'ANY SHORTEST', TRAIL}", sub.PathVar, sub.Search, sub.Mode)
+	}
+}
+
+// TestGQL_HintedNodePattern covers finding F2: a node pattern whose filler starts
+// with a hint — `graph_element_pattern_filler: hint? opt_graph_element_identifier?
+// …`. The disambiguator previously treated the leading '@' as a parenthesized-
+// path opener and misparsed `(@{h} v:L)`. After consuming the optional leading
+// hint, the next token (`v`) reveals a node filler; the live emulator accepts it.
+func TestGQL_HintedNodePattern(t *testing.T) {
+	g := gqlStmtOf(t, "GRAPH g MATCH (@{force_index=idx} v:Person) RETURN v")
+	lq := linearOf(t, g)
+	m := lq.Operators[0].(*ast.GraphMatchOp)
+	node, ok := m.Pattern.Paths[0].Factors[0].(*ast.GraphNodePattern)
+	if !ok {
+		t.Fatalf("factor[0] is %T, want *ast.GraphNodePattern (hinted node)", m.Pattern.Paths[0].Factors[0])
+	}
+	if node.Filler.Var != "v" {
+		t.Errorf("node var = %q, want v", node.Filler.Var)
+	}
+	if node.Filler.Label == nil || node.Filler.Label.Name != "Person" {
+		t.Errorf("node label = %+v, want Person", node.Filler.Label)
+	}
+
+	// A hinted node with label only, no var (the hint is consumed at the '(' level,
+	// then the filler is `:Person`).
+	g = gqlStmtOf(t, "GRAPH g MATCH (@{h=1} :Person) RETURN 1")
+	f := nodeFiller(t, g)
+	if f.Var != "" || f.Label == nil || f.Label.Name != "Person" {
+		t.Errorf("hinted (:Person) filler = %+v, want var='' label=Person", f)
+	}
+}
+
+// TestGQL_TrailingPathFactorHintRejected covers finding F5: a hint between path
+// factors is part of a `(hint? graph_path_factor)` group, so it MUST be followed
+// by another factor. A TRAILING hint with no factor after it is a syntax error —
+// the live Spanner emulator rejects `(a) @{h} RETURN *` with
+// `Expected "(" or "-" or "<" or -> but got …`. The inter-factor form
+// `(a) @{h} (b)` stays valid (the emulator accepts it).
+func TestGQL_TrailingPathFactorHintRejected(t *testing.T) {
+	// Reject: trailing hint with no following factor.
+	assertReject(t, "GRAPH g MATCH (a) @{h=1} RETURN *")
+	assertReject(t, "GRAPH g MATCH (a)-[e]->(b) @{h=1} RETURN *")
+
+	// Accept: inter-factor hint followed by a factor.
+	for _, sql := range []string{
+		"GRAPH g MATCH (a) @{h=1} (b) RETURN *",
+		"GRAPH g MATCH (a)-[e]-> @{h=1} (b) RETURN *",
+	} {
+		if _, errs := Parse(sql); len(errs) != 0 {
+			t.Errorf("Parse(%q) should accept (inter-factor hint), got errs=%v", sql, errs)
+		}
+	}
+}
+
+// TestGQL_FillerWhereWithoutIdentifier covers finding F6: the where-bearing
+// graph_element_pattern_filler alternatives are written with
+// `opt_graph_element_identifier` (no trailing '?'), but opt_graph_element_identifier
+// is itself optional in practice — the live Spanner emulator ACCEPTS an inline
+// WHERE with NO element identifier, both with a label (`(:Person WHERE TRUE)`) and
+// bare (`(WHERE foo)`). omni accepts these (the filler treats the identifier as
+// optional); we DEFEND that with an accept test.
+func TestGQL_FillerWhereWithoutIdentifier(t *testing.T) {
+	// (:Person WHERE …): label + WHERE, no element identifier.
+	g := gqlStmtOf(t, "GRAPH g MATCH (:Person WHERE TRUE) RETURN 1")
+	f := nodeFiller(t, g)
+	if f.Var != "" {
+		t.Errorf("var = %q, want '' (no element identifier)", f.Var)
+	}
+	if f.Label == nil || f.Label.Name != "Person" {
+		t.Errorf("label = %+v, want Person", f.Label)
+	}
+	if f.Where == nil {
+		t.Error("expected inline WHERE")
+	}
+
+	// (WHERE …): bare WHERE, no identifier and no label.
+	g = gqlStmtOf(t, "GRAPH g MATCH (WHERE foo) RETURN 1")
+	f = nodeFiller(t, g)
+	if f.Var != "" || f.Label != nil {
+		t.Errorf("filler = %+v, want empty var + nil label", f)
+	}
+	if f.Where == nil {
+		t.Error("expected bare inline WHERE")
 	}
 }
 

--- a/googlesql/parser/parser.go
+++ b/googlesql/parser/parser.go
@@ -328,8 +328,9 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		// (owned by the expressions node in expression position).
 		return p.parseQueryStatement()
 	case kwGRAPH:
-		// GQL graph query: GRAPH <name> <gql ops>. Owned by the parser-gql node.
-		return p.unsupported("GRAPH")
+		// GQL graph query: GRAPH <name> <gql ops> (gql_statement). Owned by the
+		// parser-gql node (graph_query.go).
+		return p.parseGQLStmt()
 	case int('('):
 		// Parenthesized query at top level, e.g. (SELECT 1) UNION ALL (SELECT 2).
 		return p.parseQueryStatement()


### PR DESCRIPTION
## googlesql/parser-gql — GQL graph query + CREATE PROPERTY GRAPH

Hand-written parser for GoogleSQL graph queries (`GRAPH_TABLE` / `MATCH` patterns) and `CREATE PROPERTY GRAPH` DDL. New AST nodes + regenerated walker + parser dispatch.

**Salvaged from an orphaned worker** — the implementing worker completed IMPLEMENT + PROVE but was killed before commit/push/review. State independently verified before push:
- `go build ./googlesql/...` — clean
- `go vet ./googlesql/{parser,ast}/...` — clean
- `go test ./googlesql/{parser,ast,analysis,diagnostics}/...` — green (incl. `graph_query_test.go`, 744 lines)
- `TestGQLOracleDifferential` (live Spanner emulator) — green

**REVIEW gate pending** — the two-model (Claude + Codex) cross-review has NOT yet run on this code. A follow-up review pass will run it, fix any findings with regression tests, and re-prove before merge.

Files: `graph_query.go` (1424), `create_property_graph.go` (425), `ast/parsenodes.go`/`nodetags.go`/`walk_generated.go`, `parser.go` dispatch, `create_table.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
