### PR TITLE
fix(tidb/catalog): WITH CTE visibility (siblings, recursive arms, nested WITH, subqueries)

### DIFF
--- a/tidb/catalog/analyze.go
+++ b/tidb/catalog/analyze.go
@@ -41,7 +41,11 @@ func (c *Catalog) analyzeSelectStmtWithCTEs(stmt *nodes.SelectStmt, parentScope 
 		return nil, err
 	}
 
-	// Merge inherited CTE map (for recursive CTE self-references).
+	// Carry inherited CTEs that analyzeCTEs did not return. analyzeCTEs seeds
+	// the inherited map when this level has its own WITH, but early-returns nil
+	// when there is no local WITH — so without this a query that inherits CTEs
+	// (a subquery, or a CTE body referencing an earlier sibling / itself) but
+	// declares none of its own would lose them. No-op when already seeded.
 	if inheritedCTEMap != nil {
 		if cteMap == nil {
 			cteMap = make(map[string]*CommonTableExprQ)

--- a/tidb/catalog/analyze.go
+++ b/tidb/catalog/analyze.go
@@ -752,7 +752,12 @@ func (c *Catalog) analyzeCTEs(ctes []*nodes.CommonTableExpr, q *Query, parentSco
 			// then register the CTE, then analyze the right arm.
 			innerQ, err = c.analyzeRecursiveCTE(cte, parentScope, cteMap)
 		} else {
-			innerQ, err = c.analyzeSelectStmtInternal(cte.Select, parentScope)
+			// Pass the CTEs built so far as inherited definitions so a later
+			// CTE body can reference an earlier sibling in the same WITH clause
+			// (WITH a AS (...), b AS (SELECT ... FROM a) ...). cteMap holds only
+			// CTEs 0..i-1 at this point, so forward and self references still
+			// correctly fall through to base-table resolution.
+			innerQ, err = c.analyzeSelectStmtWithCTEs(cte.Select, parentScope, cteMap)
 		}
 		if err != nil {
 			return nil, err

--- a/tidb/catalog/analyze.go
+++ b/tidb/catalog/analyze.go
@@ -53,6 +53,10 @@ func (c *Catalog) analyzeSelectStmtWithCTEs(stmt *nodes.SelectStmt, parentScope 
 		}
 	}
 
+	// Make the visible CTEs reachable from nested subqueries (derived tables,
+	// scalar/IN/EXISTS subqueries), which analyze through this scope.
+	scope.cteMap = cteMap
+
 	// Step 1: Analyze FROM clause → populate RangeTable and scope.
 	if err := analyzeFromClause(c, stmt.From, q, scope, cteMap); err != nil {
 		return nil, err
@@ -348,12 +352,13 @@ func markCoalescedInNode(node JoinNode, q *Query, scope *analyzerScope, usingSet
 // analyzeFromSubquery processes a subquery used as a derived table in FROM.
 func analyzeFromSubquery(c *Catalog, subq *nodes.SubqueryExpr, q *Query, scope *analyzerScope) (JoinNode, error) {
 	// Recursively analyze the inner SELECT. FROM subqueries are not correlated,
-	// so we pass nil as parent scope (unless LATERAL).
+	// so we pass nil as parent scope (unless LATERAL). CTEs from the enclosing
+	// WITH are visible regardless of correlation, so pass them down explicitly.
 	var parentScope *analyzerScope
 	if subq.Lateral {
 		parentScope = scope
 	}
-	innerQ, err := c.analyzeSelectStmtInternal(subq.Select, parentScope)
+	innerQ, err := c.analyzeSelectStmtWithCTEs(subq.Select, parentScope, scope.cteMap)
 	if err != nil {
 		return nil, err
 	}

--- a/tidb/catalog/analyze.go
+++ b/tidb/catalog/analyze.go
@@ -984,6 +984,9 @@ func (c *Catalog) analyzeSetOpWithCTEs(stmt *nodes.SelectStmt, parentScope *anal
 	// scope built from result columns.
 	if len(stmt.OrderBy) > 0 || stmt.Limit != nil {
 		setScope := newScope()
+		// CTEs visible to the set operation remain visible to subqueries in its
+		// ORDER BY / LIMIT (e.g. ORDER BY (SELECT ... FROM cte)).
+		setScope.cteMap = cteMap
 		// Build stub columns from target list for ORDER BY resolution.
 		cols := make([]*Column, len(targetList))
 		colNames := make([]string, len(targetList))

--- a/tidb/catalog/analyze.go
+++ b/tidb/catalog/analyze.go
@@ -36,7 +36,7 @@ func (c *Catalog) analyzeSelectStmtWithCTEs(stmt *nodes.SelectStmt, parentScope 
 	scope := newScopeWithParent(parentScope)
 
 	// Step 0: Process CTEs (WITH clause).
-	cteMap, err := c.analyzeCTEs(stmt.CTEs, q, parentScope)
+	cteMap, err := c.analyzeCTEs(stmt.CTEs, q, parentScope, inheritedCTEMap)
 	if err != nil {
 		return nil, err
 	}
@@ -733,12 +733,19 @@ func (c *Catalog) analyzeLimitOffset(limit *nodes.Limit, q *Query, scope *analyz
 }
 
 // analyzeCTEs processes WITH clause CTEs, returning a map for CTE name lookup.
-func (c *Catalog) analyzeCTEs(ctes []*nodes.CommonTableExpr, q *Query, parentScope *analyzerScope) (map[string]*CommonTableExprQ, error) {
+func (c *Catalog) analyzeCTEs(ctes []*nodes.CommonTableExpr, q *Query, parentScope *analyzerScope, inheritedCTEMap map[string]*CommonTableExprQ) (map[string]*CommonTableExprQ, error) {
 	if len(ctes) == 0 {
 		return nil, nil
 	}
 
 	cteMap := make(map[string]*CommonTableExprQ)
+	// Seed CTEs inherited from an enclosing WITH so a CTE body can reference them,
+	// and so a later CTE can chain off an earlier one in this same list. A local
+	// CTE of the same name shadows the inherited one (it overwrites the entry when
+	// registered below).
+	for k, v := range inheritedCTEMap {
+		cteMap[k] = v
+	}
 	for i, cte := range ctes {
 		if cte.Recursive {
 			q.IsRecursive = true
@@ -752,11 +759,8 @@ func (c *Catalog) analyzeCTEs(ctes []*nodes.CommonTableExpr, q *Query, parentSco
 			// then register the CTE, then analyze the right arm.
 			innerQ, err = c.analyzeRecursiveCTE(cte, parentScope, cteMap)
 		} else {
-			// Pass the CTEs built so far as inherited definitions so a later
-			// CTE body can reference an earlier sibling in the same WITH clause
-			// (WITH a AS (...), b AS (SELECT ... FROM a) ...). cteMap holds only
-			// CTEs 0..i-1 at this point, so forward and self references still
-			// correctly fall through to base-table resolution.
+			// Pass the running cteMap so this CTE body can reference inherited and
+			// earlier sibling CTEs (chained CTEs).
 			innerQ, err = c.analyzeSelectStmtWithCTEs(cte.Select, parentScope, cteMap)
 		}
 		if err != nil {
@@ -792,8 +796,10 @@ func (c *Catalog) analyzeCTEs(ctes []*nodes.CommonTableExpr, q *Query, parentSco
 func (c *Catalog) analyzeRecursiveCTE(cte *nodes.CommonTableExpr, parentScope *analyzerScope, cteMap map[string]*CommonTableExprQ) (*Query, error) {
 	stmt := cte.Select
 
-	// Analyze left arm to establish base columns.
-	larg, err := c.analyzeSelectStmtInternal(stmt.Left, parentScope)
+	// Analyze left arm to establish base columns. Pass cteMap so the base arm
+	// can reference earlier sibling CTEs in the same WITH clause; the recursive
+	// CTE itself is not yet registered, so the base case correctly cannot see it.
+	larg, err := c.analyzeSelectStmtWithCTEs(stmt.Left, parentScope, cteMap)
 	if err != nil {
 		return nil, err
 	}
@@ -865,7 +871,10 @@ func analyzeCTERef(ref *nodes.TableRef, cteQ *CommonTableExprQ, q *Query, scope 
 		eref = ref.Alias
 	}
 
-	// Find the CTE's index in the current query's CTEList.
+	// Find the CTE's index in the current query's CTEList. A CTE inherited from
+	// an enclosing WITH (or an earlier sibling, or a recursive self-reference
+	// being built) is not in this query's CTEList; CTEIndex stays -1 and the body
+	// is reachable only via Subquery (set below).
 	cteIndex := -1
 	for i, c := range q.CTEList {
 		if strings.EqualFold(c.Name, cteQ.Name) {
@@ -873,10 +882,6 @@ func analyzeCTERef(ref *nodes.TableRef, cteQ *CommonTableExprQ, q *Query, scope 
 			break
 		}
 	}
-	if cteIndex < 0 {
-		cteIndex = 0 // fallback for recursive self-ref during analysis
-	}
-
 	colNames := cteQ.ColumnNames
 
 	rte := &RangeTableEntryQ{
@@ -915,7 +920,7 @@ func (c *Catalog) analyzeSetOpWithCTEs(stmt *nodes.SelectStmt, parentScope *anal
 		JoinTree:    &JoinTreeQ{},
 	}
 
-	cteMap, err := c.analyzeCTEs(stmt.CTEs, q, parentScope)
+	cteMap, err := c.analyzeCTEs(stmt.CTEs, q, parentScope, inheritedCTEMap)
 	if err != nil {
 		return nil, err
 	}

--- a/tidb/catalog/analyze_expr.go
+++ b/tidb/catalog/analyze_expr.go
@@ -156,7 +156,7 @@ func analyzeInExpr(c *Catalog, expr *nodes.InExpr, scope *analyzerScope) (Analyz
 
 	if expr.Select != nil {
 		// IN (SELECT ...) / NOT IN (SELECT ...)
-		innerQ, err := c.analyzeSelectStmtInternal(expr.Select, scope)
+		innerQ, err := c.analyzeSelectStmtWithCTEs(expr.Select, scope, scope.cteMap)
 		if err != nil {
 			return nil, err
 		}
@@ -331,7 +331,7 @@ func dataTypeToResolvedType(dt *nodes.DataType) *ResolvedType {
 
 // analyzeScalarSubquery resolves a scalar subquery expression: (SELECT ...).
 func analyzeScalarSubquery(c *Catalog, subq *nodes.SubqueryExpr, scope *analyzerScope) (AnalyzedExpr, error) {
-	innerQ, err := c.analyzeSelectStmtInternal(subq.Select, scope)
+	innerQ, err := c.analyzeSelectStmtWithCTEs(subq.Select, scope, scope.cteMap)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func analyzeScalarSubquery(c *Catalog, subq *nodes.SubqueryExpr, scope *analyzer
 
 // analyzeExistsSubquery resolves an EXISTS (SELECT ...) expression.
 func analyzeExistsSubquery(c *Catalog, expr *nodes.ExistsExpr, scope *analyzerScope) (AnalyzedExpr, error) {
-	innerQ, err := c.analyzeSelectStmtInternal(expr.Select, scope)
+	innerQ, err := c.analyzeSelectStmtWithCTEs(expr.Select, scope, scope.cteMap)
 	if err != nil {
 		return nil, err
 	}

--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -3004,3 +3004,22 @@ func TestAnalyze_CTESiblingThroughSubquery(t *testing.T) {
 	_, err := c.AnalyzeSelectStmt(sel)
 	assertNoError(t, err)
 }
+
+// TestAnalyze_CTEInSetOpOrderBySubquery verifies a WITH CTE is visible inside a
+// scalar subquery in the ORDER BY of a set operation: the set-op's synthetic
+// ORDER BY/LIMIT scope must carry the CTE map.
+//
+//	WITH a AS (...) SELECT 1 AS r UNION SELECT 2 ORDER BY (SELECT x FROM a)
+func TestAnalyze_CTEInSetOpOrderBySubquery(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x) SELECT 1 AS r UNION SELECT 2 ORDER BY (SELECT x FROM a)")
+
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+	if q.SetOp != SetOpUnion {
+		t.Errorf("SetOp: want SetOpUnion, got %v", q.SetOp)
+	}
+	if len(q.SortClause) == 0 {
+		t.Errorf("SortClause: want non-empty (ORDER BY present), got empty")
+	}
+}

--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -2824,4 +2824,97 @@ func TestAnalyze_ChainedCTE(t *testing.T) {
 	if len(rte.ColNames) != 1 || rte.ColNames[0] != "x" {
 		t.Errorf("b body RTE.ColNames: want [x], got %v", rte.ColNames)
 	}
+	// `a` is inherited from the outer WITH, not declared in b's body, so it is
+	// not in bBody.CTEList. CTEIndex must be the -1 sentinel (use Subquery),
+	// never a fake 0 that would index out of an empty CTEList.
+	if len(bBody.CTEList) != 0 {
+		t.Errorf("b body CTEList: want 0 (a is inherited, not local), got %d", len(bBody.CTEList))
+	}
+	if rte.CTEIndex != -1 {
+		t.Errorf("b body RTE.CTEIndex: want -1 (inherited CTE sentinel), got %d", rte.CTEIndex)
+	}
+}
+
+// TestAnalyze_RecursiveCTEChainedSibling verifies that the base arm of a
+// recursive CTE can reference an earlier sibling CTE in the same WITH clause:
+//
+//	WITH RECURSIVE seed AS (...), r(n) AS (SELECT n FROM seed UNION ALL ...) ...
+//
+// TiDB v8.5.0 accepts this. The recursive CTE's base (left) arm must see the
+// sibling `seed`; the recursive arm references `r` itself.
+func TestAnalyze_RecursiveCTEChainedSibling(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH RECURSIVE seed AS (SELECT 1 AS n), r(n) AS (SELECT n FROM seed UNION ALL SELECT n + 1 FROM r WHERE n < 3) SELECT n FROM r")
+
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	if len(q.CTEList) != 2 {
+		t.Fatalf("CTEList: want 2 entries (seed, r), got %d", len(q.CTEList))
+	}
+	r := q.CTEList[1]
+	if !r.Recursive {
+		t.Errorf("r.Recursive: want true, got false")
+	}
+	if r.Query.SetOp != SetOpUnion {
+		t.Fatalf("r body SetOp: want SetOpUnion, got %d", r.Query.SetOp)
+	}
+
+	// The base (left) arm `SELECT n FROM seed` must resolve `seed` as the
+	// earlier sibling CTE, not a missing base table.
+	base := r.Query.LArg
+	if base == nil || len(base.RangeTable) != 1 {
+		t.Fatalf("r base arm RangeTable: want 1 entry, got %v", base)
+	}
+	brte := base.RangeTable[0]
+	if brte.Kind != RTECTE {
+		t.Fatalf("r base arm RTE.Kind: want RTECTE (sibling seed), got %v", brte.Kind)
+	}
+	if brte.CTEName != "seed" {
+		t.Errorf("r base arm RTE.CTEName: want %q, got %q", "seed", brte.CTEName)
+	}
+	if brte.Subquery != q.CTEList[0].Query {
+		t.Errorf("r base arm RTE.Subquery: want identity of CTE seed's Query, got a different node")
+	}
+}
+
+// TestAnalyze_NestedWithInLaterCTE verifies that a nested WITH inside a later
+// CTE body can reference an earlier sibling from the enclosing WITH:
+//
+//	WITH a AS (...), b AS (WITH c AS (SELECT x FROM a) SELECT x FROM c) ...
+//
+// TiDB accepts this. The inherited `a` must reach `c`'s body, which lives two
+// scopes in (inside b's WITH).
+func TestAnalyze_NestedWithInLaterCTE(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x), b AS (WITH c AS (SELECT x FROM a) SELECT x FROM c) SELECT x FROM b")
+
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	if len(q.CTEList) != 2 {
+		t.Fatalf("CTEList: want 2 entries (a, b), got %d", len(q.CTEList))
+	}
+
+	// b's body declares its own CTE c.
+	bBody := q.CTEList[1].Query
+	if len(bBody.CTEList) != 1 {
+		t.Fatalf("b body CTEList: want 1 entry (c), got %d", len(bBody.CTEList))
+	}
+
+	// c's body (SELECT x FROM a) must resolve the inherited sibling `a`.
+	cBody := bBody.CTEList[0].Query
+	if len(cBody.RangeTable) != 1 {
+		t.Fatalf("c body RangeTable: want 1 entry, got %d", len(cBody.RangeTable))
+	}
+	crte := cBody.RangeTable[0]
+	if crte.Kind != RTECTE {
+		t.Fatalf("c body RTE.Kind: want RTECTE (inherited a), got %v", crte.Kind)
+	}
+	if crte.CTEName != "a" {
+		t.Errorf("c body RTE.CTEName: want %q, got %q", "a", crte.CTEName)
+	}
+	if crte.Subquery != q.CTEList[0].Query {
+		t.Errorf("c body RTE.Subquery: want identity of outer CTE a's Query, got a different node")
+	}
 }

--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -2788,3 +2788,40 @@ func TestAnalyze_15_5_ViewFunctionTypeFlow(t *testing.T) {
 		t.Errorf("TargetList[2].ResName: want cnt, got %s", q.TargetList[2].ResName)
 	}
 }
+
+// TestAnalyze_ChainedCTE verifies that a CTE body can reference an earlier CTE
+// in the same WITH clause: WITH a AS (...), b AS (SELECT ... FROM a) ... .
+// TiDB accepts this; the analyzer must resolve `a` inside b's body as a CTE
+// reference (RTECTE pointing at a's body), not fail to find a base table.
+func TestAnalyze_ChainedCTE(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x), b AS (SELECT x FROM a) SELECT x FROM b")
+
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	// Two CTEs declared at the top level: a (index 0), b (index 1).
+	if len(q.CTEList) != 2 {
+		t.Fatalf("CTEList: want 2 entries, got %d", len(q.CTEList))
+	}
+
+	// b's body (SELECT x FROM a) must resolve `a` as a CTE reference.
+	bBody := q.CTEList[1].Query
+	if len(bBody.RangeTable) != 1 {
+		t.Fatalf("b body RangeTable: want 1 entry, got %d", len(bBody.RangeTable))
+	}
+	rte := bBody.RangeTable[0]
+	if rte.Kind != RTECTE {
+		t.Fatalf("b body RTE.Kind: want RTECTE (chained CTE ref), got %v", rte.Kind)
+	}
+	if rte.CTEName != "a" {
+		t.Errorf("b body RTE.CTEName: want %q, got %q", "a", rte.CTEName)
+	}
+	// Strongest check: the reference points at the actual `a` CTE body.
+	if rte.Subquery != q.CTEList[0].Query {
+		t.Errorf("b body RTE.Subquery: want identity of CTE a's Query, got a different node")
+	}
+	if len(rte.ColNames) != 1 || rte.ColNames[0] != "x" {
+		t.Errorf("b body RTE.ColNames: want [x], got %v", rte.ColNames)
+	}
+}

--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -3023,3 +3023,33 @@ func TestAnalyze_CTEInSetOpOrderBySubquery(t *testing.T) {
 		t.Errorf("SortClause: want non-empty (ORDER BY present), got empty")
 	}
 }
+
+// TestAnalyze_NonLateralDerivedTableNoCorrelation locks the correlation
+// invariant: the CTE map flows into nested subqueries, but it must NOT carry
+// column correlation. A non-LATERAL derived table cannot see a column from a
+// sibling FROM item — TiDB v8.5.0 rejects this (Unknown column 't1.a'). This is
+// the negative guard for the analyzerScope.cteMap channel: a future change that
+// passed `scope` (column visibility) instead of only `scope.cteMap` would
+// silently re-break it, and this test would catch it.
+func TestAnalyze_NonLateralDerivedTableNoCorrelation(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "SELECT a FROM (SELECT 1 AS a) t1, (SELECT t1.a AS b) s")
+
+	if _, err := c.AnalyzeSelectStmt(sel); err == nil {
+		t.Errorf("expected error: non-LATERAL derived table must not resolve sibling column t1.a")
+	}
+}
+
+// TestAnalyze_CTEVisibilityDoesNotLeakCorrelation is the sharper form of the
+// invariant: even when the derived table genuinely references a CTE (so the CTE
+// map is flowing into it), it still must not gain column correlation to a
+// sibling FROM item. TiDB v8.5.0 rejects this (Unknown column 't1.a') despite
+// `cte` resolving fine.
+func TestAnalyze_CTEVisibilityDoesNotLeakCorrelation(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH cte AS (SELECT 1 AS x) SELECT a FROM (SELECT 1 AS a) t1, (SELECT t1.a AS b FROM cte) s")
+
+	if _, err := c.AnalyzeSelectStmt(sel); err == nil {
+		t.Errorf("expected error: CTE visibility must not bring column correlation to sibling t1.a")
+	}
+}

--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -2918,3 +2918,89 @@ func TestAnalyze_NestedWithInLaterCTE(t *testing.T) {
 		t.Errorf("c body RTE.Subquery: want identity of outer CTE a's Query, got a different node")
 	}
 }
+
+// TestAnalyze_CTEInDerivedTable verifies a WITH CTE is visible inside a derived
+// table (FROM subquery): WITH a AS (...) SELECT x FROM (SELECT x FROM a) s.
+// TiDB v8.5.0 accepts this; the CTE map must reach the derived-table analysis.
+func TestAnalyze_CTEInDerivedTable(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x) SELECT x FROM (SELECT x FROM a) s")
+
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	// The FROM item is a derived table (RTESubquery) whose inner query
+	// references the CTE `a`.
+	if len(q.RangeTable) != 1 {
+		t.Fatalf("RangeTable: want 1 entry, got %d", len(q.RangeTable))
+	}
+	derived := q.RangeTable[0]
+	if derived.Kind != RTESubquery {
+		t.Fatalf("RTE.Kind: want RTESubquery, got %v", derived.Kind)
+	}
+	if derived.Subquery == nil || len(derived.Subquery.RangeTable) != 1 {
+		t.Fatalf("derived subquery RangeTable: want 1 entry, got %v", derived.Subquery)
+	}
+	inner := derived.Subquery.RangeTable[0]
+	if inner.Kind != RTECTE {
+		t.Fatalf("derived inner RTE.Kind: want RTECTE (CTE a), got %v", inner.Kind)
+	}
+	if inner.CTEName != "a" {
+		t.Errorf("derived inner RTE.CTEName: want %q, got %q", "a", inner.CTEName)
+	}
+}
+
+// TestAnalyze_CTEInScalarSubquery verifies a WITH CTE is visible inside a scalar
+// subquery: WITH a AS (...) SELECT (SELECT x FROM a) AS x.
+func TestAnalyze_CTEInScalarSubquery(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x) SELECT (SELECT x FROM a) AS x")
+
+	q, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+
+	if len(q.TargetList) != 1 {
+		t.Fatalf("TargetList: want 1 entry, got %d", len(q.TargetList))
+	}
+	sub, ok := q.TargetList[0].Expr.(*SubLinkExprQ)
+	if !ok {
+		t.Fatalf("target Expr: want *SubLinkExprQ, got %T", q.TargetList[0].Expr)
+	}
+	if sub.Subquery == nil || len(sub.Subquery.RangeTable) != 1 {
+		t.Fatalf("scalar subquery RangeTable: want 1 entry, got %v", sub.Subquery)
+	}
+	if sub.Subquery.RangeTable[0].Kind != RTECTE {
+		t.Errorf("scalar subquery inner RTE.Kind: want RTECTE (CTE a), got %v", sub.Subquery.RangeTable[0].Kind)
+	}
+}
+
+// TestAnalyze_CTEInInSubquery verifies a WITH CTE is visible inside an IN
+// subquery: WITH a AS (...) SELECT 1 WHERE 1 IN (SELECT x FROM a).
+func TestAnalyze_CTEInInSubquery(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x) SELECT 1 AS r WHERE 1 IN (SELECT x FROM a)")
+
+	_, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+}
+
+// TestAnalyze_CTEInExistsSubquery verifies a WITH CTE is visible inside an
+// EXISTS subquery: WITH a AS (...) SELECT 1 WHERE EXISTS (SELECT x FROM a).
+func TestAnalyze_CTEInExistsSubquery(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x) SELECT 1 AS r WHERE EXISTS (SELECT x FROM a)")
+
+	_, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+}
+
+// TestAnalyze_CTESiblingThroughSubquery verifies the two fixes compose: an
+// earlier sibling CTE is visible inside a derived table nested in a later CTE's
+// body: WITH a AS (...), b AS (SELECT x FROM (SELECT x FROM a) s) SELECT x FROM b.
+func TestAnalyze_CTESiblingThroughSubquery(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "WITH a AS (SELECT 1 AS x), b AS (SELECT x FROM (SELECT x FROM a) s) SELECT x FROM b")
+
+	_, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+}

--- a/tidb/catalog/query.go
+++ b/tidb/catalog/query.go
@@ -282,8 +282,10 @@ const (
 	RTEJoin
 
 	// RTECTE is a reference to a CTE declared in WITH. CTEIndex indexes into
-	// the enclosing Query.CTEList; the CTE body itself is
-	// `Query.CTEList[i].Query`.
+	// this Query's CTEList (the CTE body is `Query.CTEList[i].Query`), or is -1
+	// when the CTE is inherited from an enclosing WITH / an earlier sibling /
+	// a recursive self-reference and is therefore not in this Query's CTEList —
+	// in that case the body is reachable only via Subquery.
 	RTECTE
 
 	// RTEFunction is a function-in-FROM clause. In MySQL the only such

--- a/tidb/catalog/scope.go
+++ b/tidb/catalog/scope.go
@@ -14,6 +14,13 @@ type analyzerScope struct {
 	rteMap []int       // parallel to base entries: entry index -> RTE index in Query.RangeTable
 	cols   [][]*Column // parallel to base entries: entry index -> catalog Column pointers
 	parent *analyzerScope
+
+	// cteMap is the set of CTEs visible at this query level (local WITH plus any
+	// inherited from enclosing scopes). Unlike `parent`, which carries column
+	// visibility for correlated subqueries, this carries CTE-name visibility,
+	// which flows into ALL nested subqueries (derived tables, scalar/IN/EXISTS),
+	// correlated or not. Subquery analysis passes it down as inheritedCTEMap.
+	cteMap map[string]*CommonTableExprQ
 }
 
 func newScope() *analyzerScope {


### PR DESCRIPTION
Fixes a class of pre-existing bugs in the tidb catalog analyzer: **WITH CTEs were not made visible to every place that can reference them.** All cases below are valid on TiDB v8.5.0 (container-verified) but failed analysis with `Table '<cte>' doesn't exist`. None are introduced by this PR; they're surfaced incrementally and fixed at the root (thread the CTE map through every analysis path).

### Commits

1. **Chained sibling CTE** — `WITH a AS (...), b AS (SELECT ... FROM a) ...`. `analyzeCTEs` analyzed each non-recursive CTE body with a nil CTE map. Fix: thread the running map (entries `0..i-1`) into each body via the existing `inheritedCTEMap` path.

2. **Inherited / recursive / nested visibility + CTEIndex invariant**
   - Recursive base arm: `analyzeRecursiveCTE` analyzed the left arm with a nil map, so `WITH RECURSIVE seed AS (...), r(n) AS (SELECT n FROM seed UNION ALL ...)` couldn't see `seed`. Threaded `cteMap` into the base arm (the recursive CTE isn't registered yet, so the base case still correctly can't see itself).
   - Nested WITH in a later CTE: `analyzeCTEs` didn't take/seed `inheritedCTEMap`, so `WITH a AS (...), b AS (WITH c AS (SELECT x FROM a) SELECT x FROM c)` couldn't reach `a`. `analyzeCTEs` now takes and seeds it.
   - `RTECTE.CTEIndex` invariant: a reference to an inherited CTE (not in the local `CTEList`) fell back to `CTEIndex=0`, indexing out of an empty list. Dropped the fallback — `CTEIndex` stays `-1` for inherited / sibling / recursive-self refs; the body is reachable via `Subquery`. (`CTEIndex` is currently write-only in production — `DeparseQuery` resolves via `Subquery` — so this was latent, but the invariant is now honest and documented.)

3. **CTEs inside subqueries** — every subquery path (`FROM (...)`, `IN (...)`, scalar `(...)`, `EXISTS (...)`) reset the CTE map to nil, so `WITH a AS (...) SELECT x FROM (SELECT x FROM a) s` failed even at top level. Fix: carry the visible CTE map on `analyzerScope` (which already reaches every subquery) and pass it down as `inheritedCTEMap` at the four sites — separate from column correlation, so a non-LATERAL derived table still gets no correlated columns but does see enclosing CTEs. Chosen over threading a new param through `analyzeExpr`'s ~30 call sites, which would keep leaking new paths.

### Scope / relationship to #238

All pre-existing on `main`, independent of parenthesized-query support (#238). Carved out so the CTE-visibility fixes land with their own valid-SQL regression tests. Land this first; #238 rebases on top (the `analyzeCTEs` seeding hunk is byte-identical to #238's, so only the recursive-condition line — which #238 wraps in `nodes.UnwrapParenSource` — conflicts). The recursive-base-arm fix here also fixes #238, which had the same bug.

A2 (name- vs identity-based CTE index under same-`WITH` duplicate names) stays in #238: TiDB rejects duplicate CTE names (`ERROR 1066`), so it has no independent valid-SQL repro.

### Tests / gates
RED→GREEN tests for every case above (chained sibling; recursive sibling; nested WITH; `CTEIndex == -1`; CTE in derived-table / scalar / IN / EXISTS; sibling-through-subquery). `go test -short ./tidb/...` + `go vet ./tidb/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)