### PR TITLE
chore: harden oracle parser against real corpus gaps

### DIFF
--- a/oracle/ast/loc.go
+++ b/oracle/ast/loc.go
@@ -221,6 +221,12 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *FuncCallExpr:
 		return v.Loc
+	case *NamedArgExpr:
+		return v.Loc
+	case *FieldAccessExpr:
+		return v.Loc
+	case *CursorAttributeExpr:
+		return v.Loc
 	case *ExtractExpr:
 		return v.Loc
 	case *CaseExpr:

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -94,6 +94,12 @@ func writeNode(sb *strings.Builder, node Node) {
 		writeBoolExpr(sb, n)
 	case *FuncCallExpr:
 		writeFuncCallExpr(sb, n)
+	case *NamedArgExpr:
+		writeNamedArgExpr(sb, n)
+	case *FieldAccessExpr:
+		writeFieldAccessExpr(sb, n)
+	case *CursorAttributeExpr:
+		writeCursorAttributeExpr(sb, n)
 	case *ExtractExpr:
 		writeExtractExpr(sb, n)
 	case *CaseExpr:
@@ -732,6 +738,39 @@ func writeFuncCallExpr(sb *strings.Builder, n *FuncCallExpr) {
 		sb.WriteString(" :over ")
 		writeNode(sb, n.Over)
 	}
+	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
+	sb.WriteString("}")
+}
+
+func writeNamedArgExpr(sb *strings.Builder, n *NamedArgExpr) {
+	sb.WriteString("{NAMEDARG")
+	sb.WriteString(fmt.Sprintf(" :name %q", n.Name))
+	if n.Expr != nil {
+		sb.WriteString(" :expr ")
+		writeNode(sb, n.Expr)
+	}
+	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
+	sb.WriteString("}")
+}
+
+func writeFieldAccessExpr(sb *strings.Builder, n *FieldAccessExpr) {
+	sb.WriteString("{FIELDACCESS")
+	if n.Expr != nil {
+		sb.WriteString(" :expr ")
+		writeNode(sb, n.Expr)
+	}
+	sb.WriteString(fmt.Sprintf(" :field %q", n.Field))
+	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
+	sb.WriteString("}")
+}
+
+func writeCursorAttributeExpr(sb *strings.Builder, n *CursorAttributeExpr) {
+	sb.WriteString("{CURSORATTRIBUTE")
+	if n.Cursor != nil {
+		sb.WriteString(" :cursor ")
+		writeNode(sb, n.Cursor)
+	}
+	sb.WriteString(fmt.Sprintf(" :attribute %q", n.Attribute))
 	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
 	sb.WriteString("}")
 }
@@ -3122,6 +3161,9 @@ func writeCreateProcedureStmt(sb *strings.Builder, n *CreateProcedureStmt) {
 	if n.Sharing != "" {
 		sb.WriteString(fmt.Sprintf(" :sharing %q", n.Sharing))
 	}
+	if n.AuthID != "" {
+		sb.WriteString(fmt.Sprintf(" :authID %q", n.AuthID))
+	}
 	if n.Name != nil {
 		sb.WriteString(" :name ")
 		writeNode(sb, n.Name)
@@ -3184,6 +3226,9 @@ func writeCreateFunctionStmt(sb *strings.Builder, n *CreateFunctionStmt) {
 	}
 	if n.SqlMacro {
 		sb.WriteString(" :sqlMacro true")
+	}
+	if n.AuthID != "" {
+		sb.WriteString(fmt.Sprintf(" :authID %q", n.AuthID))
 	}
 	if n.Body != nil {
 		sb.WriteString(" :body ")
@@ -4833,6 +4878,10 @@ func writePLSQLLoop(sb *strings.Builder, n *PLSQLLoop) {
 		sb.WriteString(" :cursorArgs ")
 		writeNode(sb, n.CursorArgs)
 	}
+	if n.CursorQuery != nil {
+		sb.WriteString(" :cursorQuery ")
+		writeNode(sb, n.CursorQuery)
+	}
 	if n.Statements != nil {
 		sb.WriteString(" :statements ")
 		writeNode(sb, n.Statements)
@@ -4951,6 +5000,14 @@ func writePLSQLOpen(sb *strings.Builder, n *PLSQLOpen) {
 	if n.ForQuery != nil {
 		sb.WriteString(" :forQuery ")
 		writeNode(sb, n.ForQuery)
+	}
+	if n.ForExpr != nil {
+		sb.WriteString(" :forExpr ")
+		writeNode(sb, n.ForExpr)
+	}
+	if n.UsingArgs != nil {
+		sb.WriteString(" :usingArgs ")
+		writeNode(sb, n.UsingArgs)
 	}
 	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
 	sb.WriteString("}")

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -429,6 +429,36 @@ type FuncCallExpr struct {
 func (n *FuncCallExpr) nodeTag()  {}
 func (n *FuncCallExpr) exprNode() {}
 
+// NamedArgExpr represents a named argument association in a function call.
+type NamedArgExpr struct {
+	Name string
+	Expr ExprNode
+	Loc  Loc
+}
+
+func (n *NamedArgExpr) nodeTag()  {}
+func (n *NamedArgExpr) exprNode() {}
+
+// FieldAccessExpr represents field access on an expression (e.g., collection(i).field).
+type FieldAccessExpr struct {
+	Expr  ExprNode
+	Field string
+	Loc   Loc
+}
+
+func (n *FieldAccessExpr) nodeTag()  {}
+func (n *FieldAccessExpr) exprNode() {}
+
+// CursorAttributeExpr represents PL/SQL cursor attributes (e.g., c%ROWCOUNT).
+type CursorAttributeExpr struct {
+	Cursor    ExprNode
+	Attribute string
+	Loc       Loc
+}
+
+func (n *CursorAttributeExpr) nodeTag()  {}
+func (n *CursorAttributeExpr) exprNode() {}
+
 // ExtractExpr represents EXTRACT(datetime_field FROM expr).
 type ExtractExpr struct {
 	Field string   // YEAR, MONTH, DAY, HOUR, MINUTE, SECOND
@@ -1958,6 +1988,7 @@ type CreateProcedureStmt struct {
 	Editionable    bool        // EDITIONABLE
 	NonEditionable bool        // NONEDITIONABLE
 	Sharing        string      // SHARING = METADATA | NONE
+	AuthID         string      // AUTHID CURRENT_USER | DEFINER
 	Name           *ObjectName // procedure name
 	Parameters     *List       // parameter list (list of *Parameter)
 	Body           StmtNode    // procedure body (PL/SQL block)
@@ -1983,6 +2014,7 @@ type CreateFunctionStmt struct {
 	ResultCache    bool        // RESULT_CACHE
 	Aggregate      bool        // AGGREGATE USING
 	SqlMacro       bool        // SQL_MACRO
+	AuthID         string      // AUTHID CURRENT_USER | DEFINER
 	Body           StmtNode    // function body (PL/SQL block)
 	Loc            Loc         // start location
 }
@@ -2276,17 +2308,18 @@ func (n *PLSQLElsIf) nodeTag() {}
 
 // PLSQLLoop represents a LOOP/WHILE/FOR statement.
 type PLSQLLoop struct {
-	Type       PLSQLLoopType // loop type
-	Label      string        // loop label
-	Condition  ExprNode      // WHILE condition
-	Iterator   string        // FOR iterator variable
-	LowerBound ExprNode      // FOR lower bound
-	UpperBound ExprNode      // FOR upper bound
-	Reverse    bool          // REVERSE
-	CursorName string        // cursor name (for cursor FOR loop)
-	CursorArgs *List         // cursor arguments
-	Statements *List         // loop body
-	Loc        Loc           // start location
+	Type        PLSQLLoopType // loop type
+	Label       string        // loop label
+	Condition   ExprNode      // WHILE condition
+	Iterator    string        // FOR iterator variable
+	LowerBound  ExprNode      // FOR lower bound
+	UpperBound  ExprNode      // FOR upper bound
+	Reverse     bool          // REVERSE
+	CursorName  string        // cursor name (for cursor FOR loop)
+	CursorArgs  *List         // cursor arguments
+	CursorQuery StmtNode      // query source for cursor FOR loop
+	Statements  *List         // loop body
+	Loc         Loc           // start location
 }
 
 func (n *PLSQLLoop) nodeTag()  {}
@@ -2372,10 +2405,12 @@ func (n *PLSQLExecImmediate) stmtNode() {}
 
 // PLSQLOpen represents an OPEN cursor statement.
 type PLSQLOpen struct {
-	Cursor   string   // cursor name
-	Args     *List    // cursor arguments
-	ForQuery StmtNode // FOR select statement (ref cursor)
-	Loc      Loc
+	Cursor    string   // cursor name
+	Args      *List    // cursor arguments
+	ForQuery  StmtNode // FOR select statement (ref cursor)
+	ForExpr   ExprNode // FOR dynamic SQL expression (ref cursor)
+	UsingArgs *List    // USING bind argument list
+	Loc       Loc
 }
 
 func (n *PLSQLOpen) nodeTag()  {}

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -731,6 +731,8 @@ func walkChildren(v Visitor, node Node) {
 		walkList(v, n.Args)
 	case *CursorExpr:
 		Walk(v, n.Subquery)
+	case *CursorAttributeExpr:
+		Walk(v, n.Cursor)
 	case *DDLOption:
 		walkList(v, n.Items)
 	case *DatafileClause:
@@ -858,6 +860,8 @@ func walkChildren(v Visitor, node Node) {
 	case *ForUpdateClause:
 		walkList(v, n.Tables)
 		Walk(v, n.Wait)
+	case *FieldAccessExpr:
+		Walk(v, n.Expr)
 	case *FuncCallExpr:
 		if n.FuncName != nil {
 			Walk(v, n.FuncName)
@@ -870,6 +874,8 @@ func walkChildren(v Visitor, node Node) {
 		if n.Over != nil {
 			Walk(v, n.Over)
 		}
+	case *NamedArgExpr:
+		Walk(v, n.Expr)
 	case *GrantStmt:
 		walkList(v, n.Privileges)
 		if n.OnObject != nil {
@@ -1158,10 +1164,13 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.LowerBound)
 		Walk(v, n.UpperBound)
 		walkList(v, n.CursorArgs)
+		Walk(v, n.CursorQuery)
 		walkList(v, n.Statements)
 	case *PLSQLOpen:
 		walkList(v, n.Args)
 		Walk(v, n.ForQuery)
+		Walk(v, n.ForExpr)
+		walkList(v, n.UsingArgs)
 	case *PLSQLPipeRow:
 		Walk(v, n.Row)
 	case *PLSQLPragma:

--- a/oracle/parser/create_proc.go
+++ b/oracle/parser/create_proc.go
@@ -60,11 +60,16 @@ func (p *Parser) parseCreateProcedureStmt(start int, orReplace, ifNotExists, edi
 		}
 	}
 
+	var parseErr456 error
+	stmt.AuthID, parseErr456 = p.parseOptionalAuthID()
+	if parseErr456 != nil {
+		return nil, parseErr456
+	}
+
 	if p.cur.Type != kwIS && p.cur.Type != kwAS {
 		return nil, p.syntaxErrorAtCur()
 	}
 	p.advance()
-	var parseErr456 error
 
 	// PL/SQL block body (BEGIN ... END)
 	stmt.Body, parseErr456 = p.parsePLSQLBlock()
@@ -237,11 +242,11 @@ func (p *Parser) parseFunctionProperties(stmt *nodes.CreateFunctionStmt) error {
 				}
 			}
 		case p.isIdentLikeStr("AUTHID"):
-			// invoker_rights_clause: AUTHID { CURRENT_USER | DEFINER }
-			p.advance() // consume AUTHID
-			if p.isIdentLike() {
-				p.advance() // consume CURRENT_USER or DEFINER
+			authID, parseErr464 := p.parseOptionalAuthID()
+			if parseErr464 != nil {
+				return parseErr464
 			}
+			stmt.AuthID = authID
 		case p.isIdentLikeStr("ACCESSIBLE"):
 			// accessible_by_clause: ACCESSIBLE BY ( accessor [, ...] )
 			p.advance() // consume ACCESSIBLE
@@ -277,6 +282,29 @@ func (p *Parser) parseFunctionProperties(stmt *nodes.CreateFunctionStmt) error {
 		}
 	}
 	return nil
+}
+
+func (p *Parser) parseOptionalAuthID() (string, error) {
+	if !p.isIdentLikeStr("AUTHID") {
+		return "", nil
+	}
+	p.advance()
+	if p.isIdentLikeStr("CURRENT_USER") {
+		p.advance()
+		return "CURRENT_USER", nil
+	}
+	if p.cur.Type == kwCURRENT {
+		p.advance()
+		if p.isIdentLikeStr("USER") {
+			p.advance()
+		}
+		return "CURRENT_USER", nil
+	}
+	if p.isIdentLikeStr("DEFINER") {
+		p.advance()
+		return "DEFINER", nil
+	}
+	return "", p.syntaxErrorAtCur()
 }
 
 // parseCreatePackageStmt parses a CREATE [OR REPLACE] PACKAGE [BODY] statement.

--- a/oracle/parser/create_proc_test.go
+++ b/oracle/parser/create_proc_test.go
@@ -64,6 +64,19 @@ func TestParseCreateOrReplaceProcedure(t *testing.T) {
 	}
 }
 
+func TestParseCreateProcedureAuthID(t *testing.T) {
+	sql := `CREATE PROCEDURE my_proc AUTHID CURRENT_USER IS BEGIN NULL; END;`
+	result, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.CreateProcedureStmt)
+	if stmt.AuthID != "CURRENT_USER" {
+		t.Fatalf("expected AUTHID CURRENT_USER, got %q", stmt.AuthID)
+	}
+}
+
 func TestParseCreateFunctionSimple(t *testing.T) {
 	sql := `CREATE FUNCTION get_total (p_id IN NUMBER) RETURN NUMBER IS BEGIN RETURN 0; END;`
 	result, err := Parse(sql)
@@ -119,6 +132,19 @@ func TestParseCreateFunctionPipelined(t *testing.T) {
 	stmt := raw.Stmt.(*ast.CreateFunctionStmt)
 	if !stmt.Pipelined {
 		t.Error("expected Pipelined to be true")
+	}
+}
+
+func TestParseCreateFunctionAuthID(t *testing.T) {
+	sql := `CREATE FUNCTION get_total RETURN NUMBER AUTHID DEFINER IS BEGIN RETURN 0; END;`
+	result, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.CreateFunctionStmt)
+	if stmt.AuthID != "DEFINER" {
+		t.Fatalf("expected AUTHID DEFINER, got %q", stmt.AuthID)
 	}
 }
 

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -30,6 +30,22 @@ func TestParseCreateView(t *testing.T) {
 	}
 }
 
+func TestParseCreateViewWithSoftKeywordAliases(t *testing.T) {
+	result := ParseAndCheck(t, "CREATE VIEW v AS SELECT wait.name wait FROM jobs wait")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.CreateViewStmt)
+	sel := stmt.Query.(*ast.SelectStmt)
+
+	target := sel.TargetList.Items[0].(*ast.ResTarget)
+	if target.Name != "WAIT" {
+		t.Fatalf("expected select alias WAIT, got %q", target.Name)
+	}
+	from := sel.FromClause.Items[0].(*ast.TableRef)
+	if from.Alias == nil || from.Alias.Name != "WAIT" {
+		t.Fatalf("expected table alias WAIT, got %#v", from.Alias)
+	}
+}
+
 func TestParseCreateOrReplaceView(t *testing.T) {
 	p := newTestParser("VIEW emp_view AS SELECT 1 FROM dual")
 	stmt, parseErr2 := p.parseCreateViewStmt(0, true)

--- a/oracle/parser/expr.go
+++ b/oracle/parser/expr.go
@@ -70,6 +70,33 @@ func (p *Parser) parseExprPrec(minPrec int) (nodes.ExprNode, error) {
 	}
 
 	for {
+		if p.startsDotPostfix() {
+			var err error
+			left, err = p.parseDotPostfix(left)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if p.startsCursorAttributePostfix() {
+			var err error
+			left, err = p.parseCursorAttributePostfix(left)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if p.startsAtTimeZoneExpr() {
+			var err error
+			left, err = p.parseAtTimeZoneExpr(left)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
 		if prec, ok := p.postfixInfo(); ok && prec >= minPrec {
 			var err error
 			left, err = p.parsePostfix(left)
@@ -114,6 +141,135 @@ func (p *Parser) parseExprPrec(minPrec int) (nodes.ExprNode, error) {
 	}
 
 	return left, nil
+}
+
+func (p *Parser) startsDotPostfix() bool {
+	if p.cur.Type != '.' {
+		return false
+	}
+	next := p.peekNext()
+	return next.Type == tokIDENT || next.Type == tokQIDENT || next.Type >= 2000
+}
+
+func (p *Parser) parseDotPostfix(left nodes.ExprNode) (nodes.ExprNode, error) {
+	start := exprLocStart(left, p.pos())
+	p.advance() // consume '.'
+	memberStart := p.pos()
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	if p.cur.Type != '(' {
+		return &nodes.FieldAccessExpr{
+			Expr:  left,
+			Field: name,
+			Loc:   nodes.Loc{Start: start, End: p.prev.End},
+		}, nil
+	}
+
+	fc := &nodes.FuncCallExpr{
+		FuncName: &nodes.ObjectName{Name: name, Loc: nodes.Loc{Start: memberStart, End: p.prev.End}},
+		Args:     &nodes.List{Items: []nodes.Node{left}},
+		Loc:      nodes.Loc{Start: start},
+	}
+	p.advance() // consume '('
+	if p.cur.Type != ')' {
+		args, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		if args != nil {
+			fc.Args.Items = append(fc.Args.Items, args.Items...)
+		}
+	}
+	if p.cur.Type != ')' {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance()
+	fc.Loc.End = p.prev.End
+	return p.parseFuncCallPostfix(fc)
+}
+
+func (p *Parser) startsCursorAttributePostfix() bool {
+	if p.cur.Type != '%' {
+		return false
+	}
+	next := p.peekNext()
+	return p.isCursorAttributeToken(next)
+}
+
+func (p *Parser) isCursorAttributeToken(tok Token) bool {
+	switch tok.Str {
+	case "FOUND", "ISOPEN", "NOTFOUND", "ROWCOUNT":
+		return tok.Type == tokIDENT || tok.Type == tokQIDENT || tok.Type >= 2000
+	default:
+		return false
+	}
+}
+
+func (p *Parser) parseCursorAttributePostfix(left nodes.ExprNode) (nodes.ExprNode, error) {
+	start := exprLocStart(left, p.pos())
+	p.advance() // consume '%'
+	attr, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	if attr == "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return &nodes.CursorAttributeExpr{
+		Cursor:    left,
+		Attribute: attr,
+		Loc:       nodes.Loc{Start: start, End: p.prev.End},
+	}, nil
+}
+
+func (p *Parser) startsAtTimeZoneExpr() bool {
+	if !p.isIdentLikeStr("AT") {
+		return false
+	}
+	next := p.peekNext()
+	return p.isIdentLikeStrAt(next, "LOCAL") || p.isIdentLikeStrAt(next, "TIME")
+}
+
+func (p *Parser) parseAtTimeZoneExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
+	start := exprLocStart(left, p.pos())
+	p.advance() // consume AT
+
+	if p.cur.Type == kwLOCAL {
+		p.advance()
+		return &nodes.FuncCallExpr{
+			FuncName: &nodes.ObjectName{Name: "AT_LOCAL", Loc: nodes.Loc{Start: start, End: p.prev.End}},
+			Args:     &nodes.List{Items: []nodes.Node{left}},
+			Loc:      nodes.Loc{Start: start, End: p.prev.End},
+		}, nil
+	}
+
+	if !p.isIdentLikeStr("TIME") {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance()
+	if p.cur.Type != kwZONE {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance()
+
+	zone, err := p.parseExprPrec(precPrimary)
+	if err != nil {
+		return nil, err
+	}
+	if zone == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	return &nodes.FuncCallExpr{
+		FuncName: &nodes.ObjectName{Name: "AT_TIME_ZONE", Loc: nodes.Loc{Start: start, End: p.prev.End}},
+		Args:     &nodes.List{Items: []nodes.Node{left, zone}},
+		Loc:      nodes.Loc{Start: start, End: p.prev.End},
+	}, nil
 }
 
 func (p *Parser) infixInfo() (int, string, bool) {
@@ -683,6 +839,9 @@ func (p *Parser) parseIdentExpr() (nodes.ExprNode, error) {
 					Loc:    nodes.Loc{Start: start, End: p.prev.End},
 				})
 			}
+			if p.cur.Type == '(' {
+				return p.parseFuncCall(name3, name1+"."+name2, start)
+			}
 			return &nodes.ColumnRef{
 				Schema: name1,
 				Table:  name2,
@@ -713,6 +872,36 @@ func (p *Parser) parseIdentExpr() (nodes.ExprNode, error) {
 //	EXTRACT({ YEAR | MONTH | DAY | HOUR | MINUTE | SECOND } FROM expr)
 func (p *Parser) parseExtractExpr(start int) (nodes.ExprNode, error) {
 	p.advance() // consume '('
+
+	if !(p.isIntervalField() && p.peekNext().Type == kwFROM) {
+		fc := &nodes.FuncCallExpr{
+			FuncName: &nodes.ObjectName{Name: "EXTRACT", Loc: nodes.Loc{Start: start, End: p.prev.End}},
+			Args:     &nodes.List{},
+			Loc:      nodes.Loc{Start: start},
+		}
+		if p.cur.Type != ')' {
+			for {
+				arg, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				if arg == nil {
+					return nil, p.syntaxErrorAtCur()
+				}
+				fc.Args.Items = append(fc.Args.Items, arg)
+				if p.cur.Type != ',' {
+					break
+				}
+				p.advance()
+			}
+		}
+		if p.cur.Type != ')' {
+			return nil, p.syntaxErrorAtCur()
+		}
+		p.advance()
+		fc.Loc.End = p.prev.End
+		return p.parseFuncCallPostfix(fc)
+	}
 
 	field, parseErr713 := p.parseIdentifier()
 	if parseErr713 != nil {
@@ -897,12 +1086,44 @@ func (p *Parser) parseFuncCall(name, schema string, start int) (nodes.ExprNode, 
 		p.advance()
 	}
 
+	if schema == "" && name == "TRIM" {
+		if err := p.parseTrimFuncArgs(fc); err != nil {
+			return nil, err
+		}
+		if p.cur.Type == ')' {
+			p.advance()
+		}
+		return p.parseFuncCallPostfix(fc)
+	}
+
 	// Arguments
 	if p.cur.Type != ')' {
 		for {
 			arg, parseErr714 := p.parseExpr()
 			if parseErr714 != nil {
 				return nil, parseErr714
+			}
+			if p.cur.Type == tokASSOC {
+				named, err := p.parseNamedArgExpr(arg)
+				if err != nil {
+					return nil, err
+				}
+				arg = named
+			}
+			if schema == "" && name == "TRIM" && p.cur.Type == kwFROM {
+				if arg != nil {
+					fc.Args.Items = append(fc.Args.Items, arg)
+				}
+				p.advance()
+				source, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				if source == nil {
+					return nil, p.syntaxErrorAtCur()
+				}
+				fc.Args.Items = append(fc.Args.Items, source)
+				break
 			}
 			if arg != nil {
 				fc.Args.Items = append(fc.Args.Items, arg)
@@ -919,6 +1140,94 @@ func (p *Parser) parseFuncCall(name, schema string, start int) (nodes.ExprNode, 
 	}
 
 	return p.parseFuncCallPostfix(fc)
+}
+
+func (p *Parser) parseTrimFuncArgs(fc *nodes.FuncCallExpr) error {
+	if p.cur.Type == ')' {
+		return nil
+	}
+
+	arg, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	if arg == nil {
+		return p.syntaxErrorAtCur()
+	}
+	fc.Args.Items = append(fc.Args.Items, arg)
+
+	if p.isTrimModeArg(arg) && p.cur.Type != kwFROM && p.cur.Type != ',' && p.cur.Type != ')' {
+		charArg, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		if charArg == nil {
+			return p.syntaxErrorAtCur()
+		}
+		fc.Args.Items = append(fc.Args.Items, charArg)
+	}
+
+	if p.cur.Type == kwFROM {
+		p.advance()
+		source, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		if source == nil {
+			return p.syntaxErrorAtCur()
+		}
+		fc.Args.Items = append(fc.Args.Items, source)
+		return nil
+	}
+
+	for p.cur.Type == ',' {
+		p.advance()
+		arg, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		if arg == nil {
+			return p.syntaxErrorAtCur()
+		}
+		fc.Args.Items = append(fc.Args.Items, arg)
+	}
+
+	return nil
+}
+
+func (p *Parser) isTrimModeArg(arg nodes.ExprNode) bool {
+	ref, ok := arg.(*nodes.ColumnRef)
+	if !ok || ref.Schema != "" || ref.Table != "" {
+		return false
+	}
+	switch ref.Column {
+	case "LEADING", "TRAILING", "BOTH":
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Parser) parseNamedArgExpr(arg nodes.ExprNode) (nodes.ExprNode, error) {
+	ref, ok := arg.(*nodes.ColumnRef)
+	if !ok || ref.Schema != "" || ref.Table != "" || ref.Column == "" {
+		return nil, p.syntaxErrorAtCur()
+	}
+	start := ref.Loc.Start
+	name := ref.Column
+	p.advance() // consume =>
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if value == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return &nodes.NamedArgExpr{
+		Name: name,
+		Expr: value,
+		Loc:  nodes.Loc{Start: start, End: p.prev.End},
+	}, nil
 }
 
 // parseFuncCallPostfix checks for WITHIN GROUP, KEEP, and OVER clauses
@@ -1245,6 +1554,39 @@ func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
 	inner, parseErr729 := p.parseExpr()
 	if parseErr729 != nil {
 		return nil, parseErr729
+	}
+	if inner == nil {
+		if p.cur.Type == ')' {
+			p.advance()
+		}
+		return &nodes.ParenExpr{
+			Loc: nodes.Loc{Start: start, End: p.prev.End},
+		}, nil
+	}
+
+	if p.cur.Type == ',' {
+		items := &nodes.List{Items: []nodes.Node{inner}}
+		for p.cur.Type == ',' {
+			p.advance()
+			item, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			if item == nil {
+				return nil, p.syntaxErrorAtCur()
+			}
+			items.Items = append(items.Items, item)
+		}
+		if p.cur.Type == ')' {
+			p.advance()
+		} else {
+			return nil, p.syntaxErrorAtCur()
+		}
+		return &nodes.FuncCallExpr{
+			FuncName: &nodes.ObjectName{Name: "", Loc: nodes.Loc{Start: start, End: p.prev.End}},
+			Args:     items,
+			Loc:      nodes.Loc{Start: start, End: p.prev.End},
+		}, nil
 	}
 
 	if p.cur.Type == ')' {
@@ -2082,15 +2424,21 @@ func (p *Parser) parseJsonObjectOrArray(name string) (nodes.ExprNode, error) {
 	p.advance() // consume '('
 
 	for p.cur.Type != ')' && p.cur.Type != tokEOF {
-		arg, parseErr757 := p.parseExpr()
+		var arg nodes.ExprNode
+		var parseErr757 error
+		if name == "JSON_OBJECT" {
+			arg, parseErr757 = p.parseExprPrec(precComp)
+		} else {
+			arg, parseErr757 = p.parseExpr()
+		}
 		if parseErr757 != nil {
 			return nil, parseErr757
 		}
 		if arg != nil {
 			fc.Args.Items = append(fc.Args.Items, arg)
 		}
-		// Skip VALUE keyword (JSON_OBJECT key VALUE val syntax)
-		if p.isIdentLikeStr("VALUE") {
+		// Skip VALUE/IS keyword (JSON_OBJECT key VALUE val or key IS val syntax)
+		if p.isIdentLikeStr("VALUE") || (name == "JSON_OBJECT" && p.cur.Type == kwIS) {
 			p.advance()
 			val, parseErr758 := p.parseExpr()
 			if parseErr758 != nil {

--- a/oracle/parser/expr_test.go
+++ b/oracle/parser/expr_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/oracle/ast"
@@ -95,6 +96,54 @@ func TestParseExprBinary(t *testing.T) {
 				t.Errorf("expected op %q, got %q", tc.op, be.Op)
 			}
 		})
+	}
+}
+
+func TestParseExprAtTimeZone(t *testing.T) {
+	result := ParseAndCheck(t, `SELECT FROM_TZ(CAST(ts AS TIMESTAMP), 'UTC') AT TIME ZONE 'Asia/Tokyo' AS local_ts FROM dual`)
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	target := sel.TargetList.Items[0].(*ast.ResTarget)
+	expr, ok := target.Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected AT TIME ZONE function expression, got %T", target.Expr)
+	}
+	if expr.FuncName == nil || expr.FuncName.Name != "AT_TIME_ZONE" {
+		t.Fatalf("expected AT_TIME_ZONE function, got %#v", expr.FuncName)
+	}
+	if expr.Args == nil || expr.Args.Len() != 2 {
+		t.Fatalf("expected two AT_TIME_ZONE args, got %#v", expr.Args)
+	}
+}
+
+func TestParseExprThreePartFunctionName(t *testing.T) {
+	result := ParseAndCheck(t, `SELECT sys.dbms_lob.substr(payload, 10) AS chunk_text FROM docs`)
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	target := sel.TargetList.Items[0].(*ast.ResTarget)
+	expr, ok := target.Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected function expression, got %T", target.Expr)
+	}
+	if expr.FuncName == nil || expr.FuncName.Schema != "SYS.DBMS_LOB" || expr.FuncName.Name != "SUBSTR" {
+		t.Fatalf("unexpected function name: %#v", expr.FuncName)
+	}
+}
+
+func TestParseExprMethodCallPostfix(t *testing.T) {
+	result := ParseAndCheck(t, `SELECT xmltype(payload).extract('/r').getStringVal() AS value FROM docs`)
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	target := sel.TargetList.Items[0].(*ast.ResTarget)
+	expr, ok := target.Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected method call expression, got %T", target.Expr)
+	}
+	if expr.FuncName == nil || expr.FuncName.Name != "GETSTRINGVAL" {
+		t.Fatalf("unexpected method name: %#v", expr.FuncName)
+	}
+	if expr.Args == nil || expr.Args.Len() != 1 {
+		t.Fatalf("expected receiver arg, got %#v", expr.Args)
 	}
 }
 
@@ -352,6 +401,24 @@ func TestParseExprLikeLocCoversLeftOperand(t *testing.T) {
 	}
 }
 
+func TestParseExprExtractXmlFunction(t *testing.T) {
+	p := newTestParser("EXTRACT(payload, '/root/value')")
+	e, err := p.parseExpr()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fc, ok := e.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected FuncCallExpr, got %T", e)
+	}
+	if fc.FuncName.Name != "EXTRACT" {
+		t.Fatalf("expected EXTRACT function, got %q", fc.FuncName.Name)
+	}
+	if fc.Args.Len() != 2 {
+		t.Fatalf("expected XML expression and XPath args, got %d", fc.Args.Len())
+	}
+}
+
 // TestParseExprIsNull tests IS NULL and IS NOT NULL.
 func TestParseExprIsNull(t *testing.T) {
 	tests := []struct {
@@ -418,6 +485,75 @@ func TestParseExprFuncCall(t *testing.T) {
 	}
 	if fc.Args.Len() != 2 {
 		t.Errorf("expected 2 args, got %d", fc.Args.Len())
+	}
+}
+
+func TestParseExprTrimFrom(t *testing.T) {
+	p := newTestParser("TRIM(',' FROM status)")
+	e, err := p.parseExpr()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fc, ok := e.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected FuncCallExpr, got %T", e)
+	}
+	if fc.FuncName.Name != "TRIM" {
+		t.Fatalf("expected TRIM function, got %q", fc.FuncName.Name)
+	}
+	if fc.Args.Len() != 2 {
+		t.Fatalf("expected trim character and source args, got %d", fc.Args.Len())
+	}
+}
+
+func TestParseExprTrimModeCharacterFrom(t *testing.T) {
+	p := newTestParser("TRIM(LEADING pad_char FROM payload)")
+	e, err := p.parseExpr()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fc, ok := e.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected FuncCallExpr, got %T", e)
+	}
+	if fc.FuncName.Name != "TRIM" {
+		t.Fatalf("expected TRIM function, got %q", fc.FuncName.Name)
+	}
+	if fc.Args.Len() != 3 {
+		t.Fatalf("expected trim mode, character, and source args, got %d", fc.Args.Len())
+	}
+}
+
+func TestParseExprNamedArgument(t *testing.T) {
+	p := newTestParser("pkg.call_job('run', retry_count => 3)")
+	e, err := p.parseExpr()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out := ast.NodeToString(e)
+	if !strings.Contains(out, `:name "RETRY_COUNT"`) {
+		t.Fatalf("expected named argument in AST, got %s", out)
+	}
+	if !strings.Contains(out, `:expr {NUMLIT :val "3"`) {
+		t.Fatalf("expected named argument value in AST, got %s", out)
+	}
+}
+
+func TestParseExprJsonObjectIsPairs(t *testing.T) {
+	p := newTestParser("JSON_OBJECT('items' IS JSON_ARRAY(JSON_OBJECT('id' IS id, 'name' IS name)))")
+	e, err := p.parseExpr()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fc, ok := e.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected FuncCallExpr, got %T", e)
+	}
+	if fc.FuncName.Name != "JSON_OBJECT" {
+		t.Fatalf("expected JSON_OBJECT, got %q", fc.FuncName.Name)
+	}
+	if fc.Args.Len() != 2 {
+		t.Fatalf("expected top-level key and value args, got %d", fc.Args.Len())
 	}
 }
 

--- a/oracle/parser/plsql_block.go
+++ b/oracle/parser/plsql_block.go
@@ -244,7 +244,17 @@ func (p *Parser) parsePLSQLCursorDecl() (*nodes.PLSQLCursorDecl, error) {
 	}
 
 	// SELECT statement
-	if p.cur.Type == kwSELECT {
+	if p.cur.Type == '(' && (p.peekNext().Type == kwSELECT || p.peekNext().Type == kwWITH) {
+		p.advance()
+		var parseErr840 error
+		decl.Query, parseErr840 = p.parseSelectStmt()
+		if parseErr840 != nil {
+			return nil, parseErr840
+		}
+		if p.cur.Type == ')' {
+			p.advance()
+		}
+	} else if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
 		var parseErr840 error
 		decl.Query, parseErr840 = p.parseSelectStmt()
 		if parseErr840 !=
@@ -743,6 +753,8 @@ func (p *Parser) parsePLSQLForLoop() (*nodes.PLSQLLoop, error) {
 		// Extract cursor name from expr1
 		if colRef, ok := expr1.(*nodes.ColumnRef); ok {
 			loop.CursorName = colRef.Column
+		} else if subquery, ok := expr1.(*nodes.SubqueryExpr); ok {
+			loop.CursorQuery = subquery.Subquery
 		}
 		// Optional cursor arguments
 		if p.cur.Type == '(' {
@@ -939,7 +951,7 @@ func (p *Parser) parsePLSQLExecImmediate() (*nodes.PLSQLExecImmediate, error) {
 	return stmt, nil
 }
 
-// parsePLSQLOpen parses OPEN cursor [(args)] [FOR query] ;
+// parsePLSQLOpen parses OPEN cursor [(args)] [FOR query|dynamic_sql [USING args]] ;
 func (p *Parser) parsePLSQLOpen() (*nodes.PLSQLOpen, error) {
 	start := p.pos()
 	p.advance() // consume OPEN
@@ -978,6 +990,23 @@ func (p *Parser) parsePLSQLOpen() (*nodes.PLSQLOpen, error) {
 			o.ForQuery, parseErr873 = p.parseSelectStmt()
 			if parseErr873 != nil {
 				return nil, parseErr873
+			}
+		} else {
+			var parseErr873 error
+			o.ForExpr, parseErr873 = p.parseExpr()
+			if parseErr873 != nil {
+				return nil, parseErr873
+			}
+			if o.ForExpr == nil {
+				return nil, p.syntaxErrorAtCur()
+			}
+		}
+		if p.cur.Type == kwUSING {
+			p.advance()
+			var parseErr874 error
+			o.UsingArgs, parseErr874 = p.parseExprList()
+			if parseErr874 != nil {
+				return nil, parseErr874
 			}
 		}
 	}
@@ -1095,7 +1124,7 @@ func (p *Parser) parsePLSQLExceptionHandlers() (*nodes.List, error) {
 		if p.cur.Type == kwTHEN {
 			return nil, p.syntaxErrorAtCur()
 		}
-		name, parseErr877 := p.parseIdentifier()
+		name, parseErr877 := p.parsePLSQLExceptionName()
 		if parseErr877 != nil {
 			return nil, parseErr877
 		}
@@ -1108,7 +1137,7 @@ func (p *Parser) parsePLSQLExceptionHandlers() (*nodes.List, error) {
 			p.advance()
 			var // consume OR
 			parseErr878 error
-			name, parseErr878 = p.parseIdentifier()
+			name, parseErr878 = p.parsePLSQLExceptionName()
 			if parseErr878 != nil {
 				return nil, parseErr878
 			}
@@ -1134,6 +1163,20 @@ func (p *Parser) parsePLSQLExceptionHandlers() (*nodes.List, error) {
 	}
 
 	return handlers, nil
+}
+
+func (p *Parser) parsePLSQLExceptionName() (string, error) {
+	obj, err := p.parseObjectName()
+	if err != nil {
+		return "", err
+	}
+	if obj == nil || obj.Name == "" {
+		return "", nil
+	}
+	if obj.Schema != "" {
+		return obj.Schema + "." + obj.Name, nil
+	}
+	return obj.Name, nil
 }
 
 // parsePLSQLVarList parses a comma-separated list of variable references.

--- a/oracle/parser/plsql_block_test.go
+++ b/oracle/parser/plsql_block_test.go
@@ -67,6 +67,45 @@ func TestPLSQLDeclareBlock(t *testing.T) {
 	}
 }
 
+// TestPLSQLCollectionElementFieldAssignment tests collection(index).field assignment.
+func TestPLSQLCollectionElementFieldAssignment(t *testing.T) {
+	sql := `BEGIN
+		rows(i).status := 'READY';
+	END;`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	block := raw.Stmt.(*ast.PLSQLBlock)
+
+	assign := block.Statements.Items[0].(*ast.PLSQLAssign)
+	field, ok := assign.Target.(*ast.FieldAccessExpr)
+	if !ok {
+		t.Fatalf("expected FieldAccessExpr target, got %T", assign.Target)
+	}
+	if field.Field != "STATUS" {
+		t.Errorf("expected STATUS field, got %q", field.Field)
+	}
+}
+
+// TestPLSQLCursorAttributes tests cursor%ROWCOUNT and cursor%NOTFOUND expressions.
+func TestPLSQLCursorAttributes(t *testing.T) {
+	sql := `BEGIN
+		count_rows := c%ROWCOUNT;
+		EXIT WHEN c%NOTFOUND;
+	END;`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	block := raw.Stmt.(*ast.PLSQLBlock)
+
+	assign := block.Statements.Items[0].(*ast.PLSQLAssign)
+	attr, ok := assign.Value.(*ast.CursorAttributeExpr)
+	if !ok {
+		t.Fatalf("expected CursorAttributeExpr value, got %T", assign.Value)
+	}
+	if attr.Attribute != "ROWCOUNT" {
+		t.Errorf("expected ROWCOUNT, got %q", attr.Attribute)
+	}
+}
+
 // TestPLSQLIfElsifElse tests IF/ELSIF/ELSE/END IF.
 func TestPLSQLIfElsifElse(t *testing.T) {
 	sql := `BEGIN
@@ -191,6 +230,28 @@ func TestPLSQLForLoopReverse(t *testing.T) {
 	loop := block.Statements.Items[0].(*ast.PLSQLLoop)
 	if !loop.Reverse {
 		t.Error("expected REVERSE to be true")
+	}
+}
+
+func TestPLSQLCursorForLoopSubquery(t *testing.T) {
+	sql := `BEGIN
+		FOR rec IN (SELECT id, name FROM employees WHERE active = 1) LOOP
+			NULL;
+		END LOOP;
+	END;`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	block := raw.Stmt.(*ast.PLSQLBlock)
+
+	loop, ok := block.Statements.Items[0].(*ast.PLSQLLoop)
+	if !ok {
+		t.Fatalf("expected PLSQLLoop, got %T", block.Statements.Items[0])
+	}
+	if loop.Type != ast.LOOP_CURSOR_FOR {
+		t.Fatalf("expected LOOP_CURSOR_FOR, got %d", loop.Type)
+	}
+	if loop.CursorQuery == nil {
+		t.Fatal("expected cursor query")
 	}
 }
 
@@ -479,6 +540,22 @@ func TestPLSQLCursorDecl(t *testing.T) {
 	}
 }
 
+func TestPLSQLCursorDeclParenthesizedQuery(t *testing.T) {
+	sql := `DECLARE
+		CURSOR emp_cur IS (SELECT id, name FROM employees);
+	BEGIN
+		NULL;
+	END;`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	block := raw.Stmt.(*ast.PLSQLBlock)
+
+	cursor := block.Declarations.Items[0].(*ast.PLSQLCursorDecl)
+	if cursor.Query == nil {
+		t.Fatal("expected cursor query")
+	}
+}
+
 // TestPLSQLLabeledBlock tests a labeled block.
 func TestPLSQLLabeledBlock(t *testing.T) {
 	sql := `<<my_block>> BEGIN NULL; END my_block;`
@@ -529,6 +606,27 @@ func TestPLSQLExceptionOrHandler(t *testing.T) {
 	}
 }
 
+func TestPLSQLQualifiedExceptionOrHandler(t *testing.T) {
+	sql := `BEGIN
+		NULL;
+	EXCEPTION
+		WHEN err_pkg.e_transient OR other_pkg.e_retry THEN
+			NULL;
+	END;`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	block := raw.Stmt.(*ast.PLSQLBlock)
+
+	handler := block.Exceptions.Items[0].(*ast.ExceptionHandler)
+	if handler.Exceptions.Len() != 2 {
+		t.Fatalf("expected 2 exception names, got %d", handler.Exceptions.Len())
+	}
+	first := handler.Exceptions.Items[0].(*ast.String)
+	if first.Str != "ERR_PKG.E_TRANSIENT" {
+		t.Fatalf("expected qualified exception ERR_PKG.E_TRANSIENT, got %q", first.Str)
+	}
+}
+
 // TestPLSQLDeclareDefault tests DEFAULT keyword in declarations.
 func TestPLSQLDeclareDefault(t *testing.T) {
 	sql := `DECLARE
@@ -561,6 +659,27 @@ func TestPLSQLOpenFor(t *testing.T) {
 	}
 	if openStmt.ForQuery == nil {
 		t.Error("expected FOR query")
+	}
+}
+
+// TestPLSQLOpenForDynamicSQLUsing tests OPEN cursor FOR dynamic SQL USING binds.
+func TestPLSQLOpenForDynamicSQLUsing(t *testing.T) {
+	sql := `BEGIN
+		OPEN rc FOR stmt USING emp_id, NVL(emp_name, 'unknown'), salary + 1;
+	END;`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	block := raw.Stmt.(*ast.PLSQLBlock)
+
+	openStmt := block.Statements.Items[0].(*ast.PLSQLOpen)
+	if openStmt.Cursor != "RC" {
+		t.Errorf("expected RC, got %q", openStmt.Cursor)
+	}
+	if openStmt.ForExpr == nil {
+		t.Error("expected dynamic SQL expression")
+	}
+	if openStmt.UsingArgs == nil || openStmt.UsingArgs.Len() != 3 {
+		t.Fatalf("expected 3 USING args, got %#v", openStmt.UsingArgs)
 	}
 }
 

--- a/oracle/parser/select.go
+++ b/oracle/parser/select.go
@@ -227,6 +227,21 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 		}
 	}
 
+	if p.cur.Type == kwGROUP && (sel.GroupClause == nil || sel.GroupClause.Len() == 0) {
+		p.advance()
+		if p.cur.Type == kwBY {
+			p.advance()
+		}
+		var parseErr951 error
+		sel.GroupClause, parseErr951 = p.parseGroupByList()
+		if parseErr951 != nil {
+			return nil, parseErr951
+		}
+		if sel.GroupClause.Len() == 0 {
+			return sel, p.syntaxErrorAtCur()
+		}
+	}
+
 	if p.cur.Type == kwMODEL {
 		var parseErr951 error
 		sel.ModelClause, parseErr951 = p.parseModelClause()
@@ -441,10 +456,12 @@ func (p *Parser) isAliasCandidate() bool {
 		kwJOIN, kwWHEN, kwTHEN, kwELSE, kwEND, kwAND, kwOR, kwNOT,
 		kwIS, kwIN, kwBETWEEN, kwLIKE, kwLIKEC, kwLIKE2, kwLIKE4,
 		kwINTO, kwVALUES, kwSET, kwRETURNING, kwPIVOT, kwUNPIVOT,
-		kwMODEL, kwWITH, kwKEEP, kwOVER:
+		kwMODEL, kwWITH, kwKEEP, kwOVER, kwUSING:
 		return false
 	}
-	return false
+	return p.cur.Type >= 2000 &&
+		!isOracleSQLReservedKeyword(p.cur) &&
+		!isOracleClauseStarterKeyword(p.cur.Type)
 }
 
 // parseExprList parses a comma-separated list of expressions.
@@ -670,7 +687,11 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 
 	// Subquery: ( SELECT ... )
 	if p.cur.Type == '(' {
-		return p.parseSubqueryRef(start)
+		next := p.peekNext()
+		if next.Type == kwSELECT || next.Type == kwWITH {
+			return p.parseSubqueryRef(start)
+		}
+		return p.parseParenthesizedTableRef(start)
 	}
 
 	// MATCH_RECOGNIZE as standalone (rare, usually post-table)
@@ -791,7 +812,20 @@ func (p *Parser) isTableAliasCandidate() bool {
 		}
 		return true
 	}
-	return false
+	switch p.cur.Type {
+	case kwFROM, kwWHERE, kwGROUP, kwHAVING, kwORDER, kwUNION, kwINTERSECT,
+		kwMINUS, kwFOR, kwCONNECT, kwSTART, kwFETCH, kwOFFSET, kwON,
+		kwLEFT, kwRIGHT, kwINNER, kwOUTER, kwCROSS, kwFULL, kwNATURAL,
+		kwJOIN, kwWHEN, kwTHEN, kwELSE, kwEND, kwAND, kwOR, kwNOT,
+		kwIS, kwIN, kwBETWEEN, kwLIKE, kwLIKEC, kwLIKE2, kwLIKE4,
+		kwINTO, kwVALUES, kwSET, kwRETURNING, kwPIVOT, kwUNPIVOT,
+		kwMODEL, kwWITH, kwKEEP, kwOVER, kwUSING,
+		kwPARTITION, kwSUBPARTITION, kwSAMPLE, kwVERSIONS:
+		return false
+	}
+	return p.cur.Type >= 2000 &&
+		!isOracleSQLReservedKeyword(p.cur) &&
+		!isOracleClauseStarterKeyword(p.cur.Type)
 }
 
 // parseSubqueryRef parses a subquery in FROM: ( SELECT ... ) alias.
@@ -830,6 +864,56 @@ func (p *Parser) parseSubqueryRef(start int) (nodes.TableExpr, error) {
 
 	ref.Loc.End = p.prev.End
 	return ref, nil
+}
+
+func (p *Parser) parseParenthesizedTableRef(start int) (nodes.TableExpr, error) {
+	p.advance() // consume '('
+
+	tref, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	if tref == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+	tref, err = p.parseJoinContinuation(tref)
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type != ')' {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance()
+
+	if aliasable, ok := tref.(*nodes.TableRef); ok {
+		if p.cur.Type == kwAS {
+			p.advance()
+			alias, err := p.parseAlias()
+			if err != nil {
+				return nil, err
+			}
+			aliasable.Alias = alias
+		} else if p.isTableAliasCandidate() {
+			alias, err := p.parseAlias()
+			if err != nil {
+				return nil, err
+			}
+			aliasable.Alias = alias
+		}
+	}
+
+	switch n := tref.(type) {
+	case *nodes.JoinClause:
+		n.Loc.Start = start
+		n.Loc.End = p.prev.End
+	case *nodes.TableRef:
+		n.Loc.Start = start
+		n.Loc.End = p.prev.End
+	case *nodes.SubqueryRef:
+		n.Loc.Start = start
+		n.Loc.End = p.prev.End
+	}
+	return tref, nil
 }
 
 // parseInlineExternalTable parses Oracle's inline external table source.
@@ -1268,16 +1352,19 @@ func (p *Parser) parseJsonTableRef(start int) (nodes.TableExpr, error) {
 
 	if p.cur.Type == ',' {
 		p.advance()
-	}
-	var parseErr996 error
+		var parseErr996 error
 
-	// Path expression (string literal)
-	ref.Path, parseErr996 = p.parseExpr()
-	if parseErr996 !=
-
-		// COLUMNS ( column_def [, ...] )
-		nil {
-		return nil, parseErr996
+		// Path expression (string literal)
+		ref.Path, parseErr996 = p.parseExpr()
+		if parseErr996 != nil {
+			return nil, parseErr996
+		}
+	} else if p.cur.Type != kwCOLUMNS {
+		var parseErr996 error
+		ref.Path, parseErr996 = p.parseExpr()
+		if parseErr996 != nil {
+			return nil, parseErr996
+		}
 	}
 
 	if p.cur.Type == kwCOLUMNS {
@@ -1410,6 +1497,10 @@ func (p *Parser) parseJsonTableColumn() (*nodes.JsonTableColumn, error) {
 		return nil, parseErr1004
 	}
 
+	if parseErr1004 = p.parseJsonTableValueColumnModifiers(); parseErr1004 != nil {
+		return nil, parseErr1004
+	}
+
 	if p.cur.Type == kwEXISTS {
 		col.Exists = true
 		p.advance()
@@ -1427,6 +1518,40 @@ func (p *Parser) parseJsonTableColumn() (*nodes.JsonTableColumn, error) {
 
 	col.Loc.End = p.prev.End
 	return col, nil
+}
+
+func (p *Parser) parseJsonTableValueColumnModifiers() error {
+	if p.cur.Type == kwFORMAT {
+		p.advance()
+		if p.cur.Type == kwJSON {
+			p.advance()
+		} else {
+			return p.syntaxErrorAtCur()
+		}
+	}
+
+	switch {
+	case p.cur.Type == kwWITH:
+		p.advance()
+		if p.isIdentLikeStr("CONDITIONAL") || p.isIdentLikeStr("UNCONDITIONAL") {
+			p.advance()
+		}
+		if p.isIdentLikeStr("ARRAY") {
+			p.advance()
+		}
+		if p.isIdentLikeStr("WRAPPER") {
+			p.advance()
+		}
+	case p.isIdentLikeStr("WITHOUT"):
+		p.advance()
+		if p.isIdentLikeStr("ARRAY") {
+			p.advance()
+		}
+		if p.isIdentLikeStr("WRAPPER") {
+			p.advance()
+		}
+	}
+	return nil
 }
 
 // parseJoinContinuation parses any JOIN clauses that follow a table reference.

--- a/oracle/parser/select_test.go
+++ b/oracle/parser/select_test.go
@@ -78,6 +78,26 @@ func TestParseSelectWhere(t *testing.T) {
 	}
 }
 
+func TestParseSelectWhereRowValueNotInSubquery(t *testing.T) {
+	result := ParseAndCheck(t, "SELECT * FROM t WHERE (a, b, typ) NOT IN (SELECT x, y, typ FROM u)")
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	in, ok := sel.WhereClause.(*ast.InExpr)
+	if !ok {
+		t.Fatalf("expected InExpr, got %T", sel.WhereClause)
+	}
+	if !in.Not {
+		t.Fatal("expected NOT IN")
+	}
+	tuple, ok := in.Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected row-value tuple, got %T", in.Expr)
+	}
+	if tuple.Args.Len() != 3 {
+		t.Fatalf("expected 3 tuple args, got %d", tuple.Args.Len())
+	}
+}
+
 // TestParseSelectOrderBy tests SELECT with ORDER BY.
 func TestParseSelectOrderBy(t *testing.T) {
 	result := ParseAndCheck(t, "SELECT * FROM employees ORDER BY salary DESC, name ASC")
@@ -105,6 +125,18 @@ func TestParseSelectGroupBy(t *testing.T) {
 	}
 }
 
+func TestParseSelectHavingBeforeGroupBy(t *testing.T) {
+	result := ParseAndCheck(t, "SELECT department_id, COUNT(*) FROM employees HAVING COUNT(*) > 5 GROUP BY department_id")
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	if sel.HavingClause == nil {
+		t.Fatal("expected non-nil HavingClause")
+	}
+	if sel.GroupClause.Len() != 1 {
+		t.Fatalf("expected 1 GROUP BY item, got %d", sel.GroupClause.Len())
+	}
+}
+
 // TestParseSelectJoin tests SELECT with JOIN.
 func TestParseSelectJoin(t *testing.T) {
 	result := ParseAndCheck(t, "SELECT e.name, d.name FROM employees e INNER JOIN departments d ON e.dept_id = d.id")
@@ -119,6 +151,56 @@ func TestParseSelectJoin(t *testing.T) {
 	}
 	if jc.Type != ast.JOIN_INNER {
 		t.Errorf("expected JOIN_INNER, got %d", jc.Type)
+	}
+}
+
+func TestParseSelectParenthesizedJoin(t *testing.T) {
+	result := ParseAndCheck(t, "SELECT o.id FROM (orders o INNER JOIN customers c ON o.customer_id = c.id)")
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	if sel.FromClause.Len() != 1 {
+		t.Fatalf("expected 1 FROM item, got %d", sel.FromClause.Len())
+	}
+	if _, ok := sel.FromClause.Items[0].(*ast.JoinClause); !ok {
+		t.Fatalf("expected JoinClause, got %T", sel.FromClause.Items[0])
+	}
+}
+
+func TestParseJsonTableColumnFormatJson(t *testing.T) {
+	result := ParseAndCheck(t, "SELECT jt.payload FROM src s, JSON_TABLE(s.doc, '$' COLUMNS (payload VARCHAR2(4000) FORMAT JSON WITHOUT WRAPPER PATH '$.payload')) jt")
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	if sel.FromClause.Len() != 2 {
+		t.Fatalf("expected 2 FROM items, got %d", sel.FromClause.Len())
+	}
+	jt := sel.FromClause.Items[1].(*ast.JsonTableRef)
+	if jt.Alias == nil || jt.Alias.Name != "JT" {
+		t.Fatalf("expected JSON_TABLE alias JT, got %#v", jt.Alias)
+	}
+	if jt.Columns == nil || jt.Columns.Len() != 1 {
+		t.Fatalf("expected 1 JSON_TABLE column, got %#v", jt.Columns)
+	}
+	col := jt.Columns.Items[0].(*ast.JsonTableColumn)
+	if col.Name != "PAYLOAD" {
+		t.Fatalf("expected PAYLOAD column, got %q", col.Name)
+	}
+}
+
+func TestParseJsonTableSimplifiedPathColumns(t *testing.T) {
+	result := ParseAndCheck(t, "SELECT jt.id FROM src s CROSS JOIN JSON_TABLE(s.doc.rows[*] COLUMNS (id NUMBER PATH id)) jt")
+	raw := result.Items[0].(*ast.RawStmt)
+	sel := raw.Stmt.(*ast.SelectStmt)
+	if sel.FromClause.Len() != 1 {
+		t.Fatalf("expected 1 FROM item, got %d", sel.FromClause.Len())
+	}
+	join := sel.FromClause.Items[0].(*ast.JoinClause)
+	jt := join.Right.(*ast.JsonTableRef)
+	if jt.Columns == nil || jt.Columns.Len() != 1 {
+		t.Fatalf("expected 1 JSON_TABLE column, got %#v", jt.Columns)
+	}
+	col := jt.Columns.Items[0].(*ast.JsonTableColumn)
+	if col.Name != "ID" {
+		t.Fatalf("expected ID column, got %q", col.Name)
 	}
 }
 

--- a/oracle/parser/split.go
+++ b/oracle/parser/split.go
@@ -459,6 +459,12 @@ func sqlPlusCommandAtLineStart(sql string, tok Token) (sqlPlusCommand, bool) {
 	if word == "" {
 		return sqlPlusCommand{}, false
 	}
+	if sqlPlusCommandWordIsQualifiedIdentifier(sql, tok.End) {
+		return sqlPlusCommand{}, false
+	}
+	if (word == "R" || word == "RUN") && !onlyHorizontalSpaceUntilLineEnd(sql, tok.End) {
+		return sqlPlusCommand{}, false
+	}
 	if isOracleSetStatement(word, sql, tok.End) {
 		return sqlPlusCommand{}, false
 	}
@@ -476,6 +482,24 @@ func splitTokenWord(tok Token) string {
 		return tok.Str
 	}
 	return ""
+}
+
+func sqlPlusCommandWordIsQualifiedIdentifier(sql string, pos int) bool {
+	return pos < len(sql) && sql[pos] == '.'
+}
+
+func onlyHorizontalSpaceUntilLineEnd(sql string, pos int) bool {
+	for pos < len(sql) {
+		switch sql[pos] {
+		case ' ', '\t', '\f':
+			pos++
+		case '\r', '\n':
+			return true
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func isOracleSetStatement(word, sql string, pos int) bool {

--- a/oracle/parser/split_test.go
+++ b/oracle/parser/split_test.go
@@ -680,6 +680,29 @@ func TestSplitDoesNotClassifySQLContinuationLinesAsSQLPlus(t *testing.T) {
 	}
 }
 
+func TestSplitDoesNotTreatQualifiedRAtLineStartAsRun(t *testing.T) {
+	sql := "CREATE VIEW v AS SELECT\n" +
+		"  r.id,\n" +
+		"  r rows,\n" +
+		"  r.name\n" +
+		"FROM records r;"
+	got := Split(sql)
+	wantTexts := []string{
+		"CREATE VIEW v AS SELECT\n  r.id,\n  r rows,\n  r.name\nFROM records r",
+	}
+	if len(got) != len(wantTexts) {
+		t.Fatalf("got %d segments %q, want %d", len(got), splitTexts(got), len(wantTexts))
+	}
+	for i := range wantTexts {
+		if got[i].Text != wantTexts[i] {
+			t.Fatalf("segment[%d] Text = %q, want %q", i, got[i].Text, wantTexts[i])
+		}
+		if got[i].Kind != SegmentSQL {
+			t.Fatalf("segment[%d] Kind = %v for %q, want %v", i, got[i].Kind, got[i].Text, SegmentSQL)
+		}
+	}
+}
+
 func TestSplitClassifiesUnambiguousSQLPlusCommandsAfterBufferedSQL(t *testing.T) {
 	sql := "SELECT 1 FROM dual\n" +
 		"PROMPT running next query\n" +

--- a/oracle/parser/testdata/coverage/loc_node_coverage.tsv
+++ b/oracle/parser/testdata/coverage/loc_node_coverage.tsv
@@ -105,6 +105,9 @@ node_type	family	status	fixture	notes	debt_class	approval	next_action
 *nodes.BoolExpr	expression	covered	SELECT 1 FROM dual WHERE NOT (a = 1 AND b = 2)	boolean expression span	none	covered	keep_regression_guard
 *nodes.ColumnRef	expression	covered	SELECT a FROM t	column reference span	none	covered	keep_regression_guard
 *nodes.FuncCallExpr	expression	covered	SELECT f(1) FROM dual	function call span	none	covered	keep_regression_guard
+*nodes.NamedArgExpr	expression	covered	SELECT f(p => 1) FROM dual	named function argument span	none	covered	keep_regression_guard
+*nodes.FieldAccessExpr	expression	covered	BEGIN rows(i).status := 'READY'; END;	field access expression span	none	covered	keep_regression_guard
+*nodes.CursorAttributeExpr	expression	covered	BEGIN count_rows := c%ROWCOUNT; END;	cursor attribute expression span	none	covered	keep_regression_guard
 *nodes.ExtractExpr	expression	covered	SELECT EXTRACT(YEAR FROM d) FROM t	EXTRACT datetime expression span	none	covered	keep_regression_guard
 *nodes.CaseExpr	expression	covered	SELECT CASE WHEN a = 1 THEN 2 ELSE 3 END FROM dual	case expression span	none	covered	keep_regression_guard
 *nodes.CaseWhen	ast	covered	SELECT CASE WHEN a = 1 THEN 2 ELSE 3 END FROM dual	case expression span	none	covered	keep_regression_guard

--- a/oracle/parser/type.go
+++ b/oracle/parser/type.go
@@ -118,11 +118,20 @@ func (p *Parser) parseTypeName() (*nodes.TypeName, error) {
 		p.advance()
 
 	default:
-		parseErr1121 :=
-			// User-defined type or %TYPE/%ROWTYPE reference
-			p.parseUserDefinedType(tn)
-		if parseErr1121 != nil {
-			return nil, parseErr1121
+		if p.isIdentLikeStr("NUMERIC") {
+			tn.Names.Items = append(tn.Names.Items, &nodes.String{Str: p.cur.Str})
+			p.advance()
+			parseErr1121 := p.parseOptionalPrecisionScale(tn)
+			if parseErr1121 != nil {
+				return nil, parseErr1121
+			}
+		} else {
+			parseErr1121 :=
+				// User-defined type or %TYPE/%ROWTYPE reference
+				p.parseUserDefinedType(tn)
+			if parseErr1121 != nil {
+				return nil, parseErr1121
+			}
 		}
 	}
 

--- a/oracle/parser/type_test.go
+++ b/oracle/parser/type_test.go
@@ -21,6 +21,7 @@ func TestParseTypeNumber(t *testing.T) {
 		{"FLOAT", []string{"FLOAT"}, 0},
 		{"FLOAT(53)", []string{"FLOAT"}, 1},
 		{"DECIMAL(10,2)", []string{"DECIMAL"}, 2},
+		{"NUMERIC(10,2)", []string{"NUMERIC"}, 2},
 	}
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Harden Oracle parser support for real-corpus SELECT, expression, PL/SQL routine, type, and splitter patterns.
- Add synthetic regression coverage for the supported Oracle syntax shapes without committing real export data.
- Extend AST serialization/walker support for new parser nodes and fields.

## Validation
- git diff --check
- go test ./oracle/parser -count=1
- go test ./oracle/... -count=1
- go run /tmp/oracle_corpus_probe.go | sed -n '1,18p'\n- Verified remaining 3 local corpus residuals against Oracle Free testcontainer; Oracle rejected all 3, so they are not parser compatibility gaps.\n\n## Data handling\n- Real Oracle export data stayed local under ~/Github/bb_export_2.\n- No raw real SQL or temporary corpus validation test file is included in this PR.