### PR TITLE
feat(mysql/parser): support parenthesized query expressions

### DIFF
--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -594,6 +594,18 @@ func writeSelectStmt(sb *strings.Builder, n *SelectStmt) {
 			writeNode(sb, n.Right)
 		}
 	}
+	if n.TableSource != nil {
+		sb.WriteString(" :table_source ")
+		writeNode(sb, n.TableSource)
+	}
+	if n.ValuesSource != nil {
+		sb.WriteString(" :values_source ")
+		writeNode(sb, n.ValuesSource)
+	}
+	if n.ParenSource != nil {
+		sb.WriteString(" :paren_source ")
+		writeNode(sb, n.ParenSource)
+	}
 	sb.WriteString("}")
 }
 

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -32,6 +32,14 @@ type SelectStmt struct {
 	SetAll            bool               // ALL modifier for set operations
 	Left              *SelectStmt        // left side of set operation
 	Right             *SelectStmt        // right side of set operation
+	TableSource       *TableStmt         // TABLE query primary
+	ValuesSource      *ValuesStmt        // VALUES query primary
+	// ParenSource is the inner query of a parenthesized query expression
+	// ( SELECT ... ). When non-nil this node is a parentheses wrapper: its own
+	// OrderBy/Limit hold the OUTER trailing clauses, while ParenSource carries
+	// the inner query (which may have its own OrderBy/Limit). This keeps the two
+	// scopes of "(SELECT 1 LIMIT 5) LIMIT 2" distinct.
+	ParenSource *SelectStmt
 }
 
 // CommonTableExpr represents a single CTE in a WITH clause.
@@ -47,6 +55,38 @@ func (c *CommonTableExpr) nodeTag() {}
 
 func (s *SelectStmt) nodeTag()  {}
 func (s *SelectStmt) stmtNode() {}
+
+// UnwrapParenSource unwraps parenthesized-query wrappers (ParenSource) and
+// returns the underlying query node — a SELECT leaf or a set-operation node.
+// Unlike walking to the leftmost leaf, it stops at a set-op so callers can
+// inspect SetOp / Left / Right (e.g. recursive-CTE detection). Returns the
+// input unchanged when it is not a wrapper.
+func UnwrapParenSource(s *SelectStmt) *SelectStmt {
+	for s != nil && s.ParenSource != nil {
+		s = s.ParenSource
+	}
+	return s
+}
+
+// LeftmostQueryLeaf returns the leftmost output SELECT of a query expression: it
+// unwraps ParenSource wrappers and walks set-operation left arms until it
+// reaches the SELECT whose target list defines the result columns. For a bare
+// SELECT it returns the input unchanged. Use this wherever a leftmost-leaf walk
+// reads a target list (view columns, CTE / derived virtual tables, ORDER BY
+// ordinals); UnwrapParenSource is the variant that stops at a set-op.
+func LeftmostQueryLeaf(s *SelectStmt) *SelectStmt {
+	for s != nil {
+		switch {
+		case s.ParenSource != nil:
+			s = s.ParenSource
+		case s.SetOp != SetOpNone && s.Left != nil:
+			s = s.Left
+		default:
+			return s
+		}
+	}
+	return s
+}
 
 // DistinctKind enumerates DISTINCT modes.
 type DistinctKind int

--- a/mysql/ast/walk_generated.go
+++ b/mysql/ast/walk_generated.go
@@ -751,6 +751,15 @@ func walkChildren(v Visitor, node Node) {
 		if n.Right != nil {
 			Walk(v, n.Right)
 		}
+		if n.TableSource != nil {
+			Walk(v, n.TableSource)
+		}
+		if n.ValuesSource != nil {
+			Walk(v, n.ValuesSource)
+		}
+		if n.ParenSource != nil {
+			Walk(v, n.ParenSource)
+		}
 	case *SetPasswordStmt:
 		if n.User != nil {
 			Walk(v, n.User)

--- a/mysql/catalog/define_test.go
+++ b/mysql/catalog/define_test.go
@@ -154,6 +154,25 @@ func TestDefineView_HappyPath(t *testing.T) {
 	}
 }
 
+func TestDefineView_ParenthesizedSetOpColumns(t *testing.T) {
+	c := newCatalogWithDB(t, "mydb")
+	if err := c.DefineTable(mustParseTable(t, "CREATE TABLE t (a INT)")); err != nil {
+		t.Fatal(err)
+	}
+	stmt := mustParseView(t, "CREATE VIEW v AS (SELECT a FROM t) UNION (SELECT a FROM t)")
+	if err := c.DefineView(stmt); err != nil {
+		t.Fatalf("DefineView: %v", err)
+	}
+	db := c.GetDatabase("mydb")
+	view := db.Views["v"]
+	if view == nil {
+		t.Fatal("view not registered")
+	}
+	if len(view.Columns) != 1 || view.Columns[0] != "a" {
+		t.Fatalf("view columns = %v, want [a]", view.Columns)
+	}
+}
+
 func TestDefineIndex_HappyPath(t *testing.T) {
 	c := newCatalogWithDB(t, "mydb")
 	if err := c.DefineTable(mustParseTable(t, "CREATE TABLE t (id INT, name VARCHAR(50))")); err != nil {

--- a/mysql/catalog/viewcmds.go
+++ b/mysql/catalog/viewcmds.go
@@ -840,18 +840,25 @@ func extractViewColumns(sel *nodes.SelectStmt) []string {
 	if sel == nil {
 		return nil
 	}
+	// The result columns live on the leftmost output SELECT. Unwrap any
+	// parenthesized-query wrappers and walk set-operation left arms to reach it,
+	// so a parenthesized or set-op view body (CREATE VIEW v AS (SELECT a, b) or
+	// (SELECT 1 AS a) UNION (SELECT 2 AS a)) derives columns from that SELECT.
+	sel = nodes.LeftmostQueryLeaf(sel)
 	var cols []string
 	for _, target := range sel.TargetList {
-		rt, ok := target.(*nodes.ResTarget)
-		if !ok {
-			continue
-		}
-		if rt.Name != "" {
-			cols = append(cols, canonicalViewDerivedColumnName(rt.Name))
-		} else if cr, ok := rt.Val.(*nodes.ColumnRef); ok {
+		if rt, ok := target.(*nodes.ResTarget); ok {
+			if rt.Name != "" {
+				cols = append(cols, canonicalViewDerivedColumnName(rt.Name))
+			} else if cr, ok := rt.Val.(*nodes.ColumnRef); ok {
+				cols = append(cols, cr.Column)
+			} else {
+				cols = append(cols, canonicalViewDerivedColumnName(nodeToSQL(rt.Val)))
+			}
+		} else if cr, ok := target.(*nodes.ColumnRef); ok {
 			cols = append(cols, cr.Column)
 		} else {
-			cols = append(cols, canonicalViewDerivedColumnName(nodeToSQL(rt.Val)))
+			cols = append(cols, canonicalViewDerivedColumnName(nodeToSQL(target)))
 		}
 	}
 	return cols

--- a/mysql/completion/refs.go
+++ b/mysql/completion/refs.go
@@ -83,6 +83,11 @@ func extractRefsFromSelect(s *ast.SelectStmt) []TableRef {
 		return refs
 	}
 
+	// Parenthesized query: walk the inner query.
+	if s.ParenSource != nil {
+		return append(refs, extractRefsFromSelect(s.ParenSource)...)
+	}
+
 	// CTEs.
 	for _, cte := range s.CTEs {
 		if cte != nil && cte.Name != "" {

--- a/mysql/deparse/deparse.go
+++ b/mysql/deparse/deparse.go
@@ -39,6 +39,21 @@ func deparseSelectStmtNoAlias(stmt *ast.SelectStmt) string {
 }
 
 func deparseSelectStmtCtx(stmt *ast.SelectStmt, suppressAlias bool) string {
+	// Parenthesized query expression: ( inner ) with optional OUTER ORDER BY /
+	// LIMIT held on the wrapper. Materialize the parens — a dropped ParenSource
+	// silently loses the inner query.
+	if stmt.ParenSource != nil {
+		return deparseParenSource(stmt)
+	}
+
+	if stmt.TableSource != nil {
+		return deparseTableQueryPrimary(stmt)
+	}
+
+	if stmt.ValuesSource != nil {
+		return deparseValuesQueryPrimary(stmt)
+	}
+
 	// Handle set operations: UNION / UNION ALL / INTERSECT / EXCEPT
 	if stmt.SetOp != ast.SetOpNone {
 		return deparseSetOperation(stmt)
@@ -206,6 +221,114 @@ func deparseForUpdate(fu *ast.ForUpdate) string {
 // deparseSetOperation formats a set operation (UNION, INTERSECT, EXCEPT).
 // MySQL 8.0 format: select ... union [all] select ... (flat, no parens around sub-selects)
 // CTEs from the leftmost child are hoisted and emitted before the entire set operation.
+// deparseParenSource formats a parenthesized query expression: an optional WITH,
+// '(' inner ')', and the OUTER trailing ORDER BY / LIMIT held on the wrapper.
+// The inner query keeps its own clauses, so both scopes round-trip (e.g.
+// "(select 1 limit 5) limit 2").
+func deparseParenSource(stmt *ast.SelectStmt) string {
+	var b strings.Builder
+
+	if len(stmt.CTEs) > 0 {
+		b.WriteString(deparseCTEs(stmt.CTEs))
+		b.WriteString(" ")
+	}
+
+	b.WriteString("(")
+	b.WriteString(deparseSelectStmt(stmt.ParenSource))
+	b.WriteString(")")
+
+	// Outer ORDER BY (applies to the parenthesized result).
+	if len(stmt.OrderBy) > 0 {
+		b.WriteString(" order by ")
+		for i, item := range stmt.OrderBy {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(deparseExpr(item.Expr))
+			if item.Desc {
+				b.WriteString(" desc")
+			}
+		}
+	}
+
+	// Outer LIMIT (applies to the parenthesized result).
+	if stmt.Limit != nil {
+		b.WriteString(" limit ")
+		if stmt.Limit.Offset != nil {
+			b.WriteString(deparseExpr(stmt.Limit.Offset))
+			b.WriteString(",")
+		}
+		b.WriteString(deparseExpr(stmt.Limit.Count))
+	}
+
+	return b.String()
+}
+
+func deparseTableQueryPrimary(stmt *ast.SelectStmt) string {
+	var b strings.Builder
+
+	if len(stmt.CTEs) > 0 {
+		b.WriteString(deparseCTEs(stmt.CTEs))
+		b.WriteString(" ")
+	}
+
+	b.WriteString("table ")
+	if stmt.TableSource.Table != nil {
+		b.WriteString(deparseTableRef(stmt.TableSource.Table))
+	}
+	appendOrderByLimit(&b, stmt.OrderBy, stmt.Limit)
+	return b.String()
+}
+
+func deparseValuesQueryPrimary(stmt *ast.SelectStmt) string {
+	var b strings.Builder
+
+	if len(stmt.CTEs) > 0 {
+		b.WriteString(deparseCTEs(stmt.CTEs))
+		b.WriteString(" ")
+	}
+
+	b.WriteString("values ")
+	for i, row := range stmt.ValuesSource.Rows {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("row(")
+		for j, expr := range row {
+			if j > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(deparseExpr(expr))
+		}
+		b.WriteString(")")
+	}
+	appendOrderByLimit(&b, stmt.OrderBy, stmt.Limit)
+	return b.String()
+}
+
+func appendOrderByLimit(b *strings.Builder, orderBy []*ast.OrderByItem, limit *ast.Limit) {
+	if len(orderBy) > 0 {
+		b.WriteString(" order by ")
+		for i, item := range orderBy {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(deparseExpr(item.Expr))
+			if item.Desc {
+				b.WriteString(" desc")
+			}
+		}
+	}
+	if limit != nil {
+		b.WriteString(" limit ")
+		if limit.Offset != nil {
+			b.WriteString(deparseExpr(limit.Offset))
+			b.WriteString(",")
+		}
+		b.WriteString(deparseExpr(limit.Count))
+	}
+}
+
 func deparseSetOperation(stmt *ast.SelectStmt) string {
 	// Hoist CTEs from the leftmost descendant
 	var ctePrefix string
@@ -273,18 +396,15 @@ func deparseSetOperation(stmt *ast.SelectStmt) string {
 	return b.String()
 }
 
-// extractCTEs walks down the left spine of a set operation tree and extracts
-// CTEs from the leftmost leaf SelectStmt, clearing them so they aren't emitted
-// again by deparseSelectStmt.
+// extractCTEs returns the WITH clause of a set-operation query expression. The
+// parser attaches a query-expression-level WITH to the set-op ROOT node (the
+// WITH applies to the whole UNION, not just the leftmost operand — a
+// parenthesized operand's own WITH stays inside its parens). The CTEs are
+// cleared so deparseSelectStmt doesn't emit them again.
 func extractCTEs(stmt *ast.SelectStmt) []*ast.CommonTableExpr {
-	// Walk to the leftmost leaf
-	cur := stmt
-	for cur.SetOp != ast.SetOpNone && cur.Left != nil {
-		cur = cur.Left
-	}
-	if len(cur.CTEs) > 0 {
-		ctes := cur.CTEs
-		cur.CTEs = nil // prevent double emission
+	if len(stmt.CTEs) > 0 {
+		ctes := stmt.CTEs
+		stmt.CTEs = nil // prevent double emission
 		return ctes
 	}
 	return nil

--- a/mysql/deparse/deparse_test.go
+++ b/mysql/deparse/deparse_test.go
@@ -1236,6 +1236,45 @@ func TestDeparseSelect_Section_5_5_SetOperations(t *testing.T) {
 	}
 }
 
+func TestDeparseSelect_ParenthesizedQueryExpressions(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "inner_and_outer_limit",
+			input:    "(SELECT 1 LIMIT 5) LIMIT 2",
+			expected: "(select 1 AS `1` limit 5) limit 2",
+		},
+		{
+			name:     "nested_parenthesized_set_op",
+			input:    "((SELECT 1) UNION (SELECT 2)) ORDER BY 1",
+			expected: "((select 1 AS `1`) union (select 2 AS `2`)) order by 1",
+		},
+		{
+			name:     "table_query_primary_operand",
+			input:    "(SELECT 1) UNION (TABLE t)",
+			expected: "(select 1 AS `1`) union (table `t`)",
+		},
+		{
+			name:     "values_query_primary_operand",
+			input:    "(SELECT 1) UNION (VALUES ROW(2))",
+			expected: "(select 1 AS `1`) union (values row(2))",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := parseSelect(t, tc.input)
+			got := DeparseSelect(sel)
+			if got != tc.expected {
+				t.Errorf("DeparseSelect(%q) =\n  %q\nwant:\n  %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestDeparseSelect_Section_5_7_CTE(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/mysql/deparse/resolver.go
+++ b/mysql/deparse/resolver.go
@@ -40,17 +40,81 @@ func (r *Resolver) Resolve(stmt *ast.SelectStmt) *ast.SelectStmt {
 // resolveWithCTEs resolves a SelectStmt with optional CTE virtual tables
 // available in scope. cteTables maps CTE names to virtual ResolverTables
 // built from their SELECT target lists.
+// resolveOrderByOrdinals rewrites positional ORDER BY items (ORDER BY 1) to the
+// matching column alias from the leftmost SELECT's target list, matching MySQL
+// 8.0 behavior.
+func resolveOrderByOrdinals(orderBy []*ast.OrderByItem, leftmost *ast.SelectStmt) {
+	if leftmost == nil {
+		return
+	}
+	for _, item := range orderBy {
+		lit, ok := item.Expr.(*ast.IntLit)
+		if !ok {
+			continue
+		}
+		idx := int(lit.Value) - 1 // 1-based to 0-based
+		if idx < 0 || idx >= len(leftmost.TargetList) {
+			continue
+		}
+		rt, ok := leftmost.TargetList[idx].(*ast.ResTarget)
+		if !ok {
+			continue
+		}
+		alias := rt.Name
+		if alias == "" {
+			// Derive alias from a bare column ref.
+			if cr, ok := rt.Val.(*ast.ColumnRef); ok {
+				alias = cr.Column
+			}
+		}
+		if alias != "" {
+			item.Expr = &ast.ColumnRef{Column: alias}
+		}
+	}
+}
+
+// resolveParenSource resolves a parenthesized query expression: the inner query
+// (with the wrapper's CTEs visible), then any OUTER ORDER BY ordinals against
+// the inner's leftmost SELECT target list.
+func (r *Resolver) resolveParenSource(stmt *ast.SelectStmt, cteTables map[string]*ResolverTable) {
+	mergedCTETables := cteTables
+	if len(stmt.CTEs) > 0 {
+		mergedCTETables = make(map[string]*ResolverTable)
+		for k, v := range cteTables {
+			mergedCTETables[k] = v
+		}
+		for _, cte := range stmt.CTEs {
+			cteResolver := &Resolver{
+				Lookup:         r.withCTELookup(mergedCTETables),
+				DefaultCharset: r.DefaultCharset,
+			}
+			cteResolver.resolveWithCTEs(cte.Select, mergedCTETables)
+			if vt := buildCTEVirtualTable(cte); vt != nil {
+				mergedCTETables[strings.ToLower(cte.Name)] = vt
+			}
+		}
+	}
+
+	r.resolveWithCTEs(stmt.ParenSource, mergedCTETables)
+
+	if len(stmt.OrderBy) == 0 {
+		return
+	}
+	// Outer ORDER BY ordinals resolve against the inner's leftmost output SELECT.
+	resolveOrderByOrdinals(stmt.OrderBy, ast.LeftmostQueryLeaf(stmt.ParenSource))
+}
+
 func (r *Resolver) resolveWithCTEs(stmt *ast.SelectStmt, cteTables map[string]*ResolverTable) *ast.SelectStmt {
 	if stmt == nil {
 		return nil
 	}
 	// Handle set operations recursively
 	if stmt.SetOp != ast.SetOpNone {
-		// Before recursing, hoist CTEs from the leftmost leaf so they are
-		// visible to both sides of the set operation (matching MySQL semantics
-		// where WITH ... applies to the entire UNION).
+		// The query-expression WITH lives on the set-op root node; register it
+		// so it is visible to both sides of the set operation (matching MySQL
+		// semantics where WITH ... applies to the entire UNION).
 		mergedCTETables := cteTables
-		if leftCTEs := collectLeftmostCTEs(stmt); len(leftCTEs) > 0 {
+		if leftCTEs := collectSetOpCTEs(stmt); len(leftCTEs) > 0 {
 			mergedCTETables = make(map[string]*ResolverTable)
 			if cteTables != nil {
 				for k, v := range cteTables {
@@ -78,30 +142,15 @@ func (r *Resolver) resolveWithCTEs(stmt *ast.SelectStmt, cteTables map[string]*R
 		// Resolve ORDER BY ordinals (e.g., ORDER BY 1) to column aliases
 		// from the leftmost SELECT's target list, matching MySQL 8.0 behavior.
 		if len(stmt.OrderBy) > 0 {
-			leftmost := stmt
-			for leftmost.SetOp != ast.SetOpNone && leftmost.Left != nil {
-				leftmost = leftmost.Left
-			}
-			for _, item := range stmt.OrderBy {
-				if lit, ok := item.Expr.(*ast.IntLit); ok {
-					idx := int(lit.Value) - 1 // 1-based to 0-based
-					if idx >= 0 && idx < len(leftmost.TargetList) {
-						if rt, ok := leftmost.TargetList[idx].(*ast.ResTarget); ok {
-							alias := rt.Name
-							if alias == "" {
-								// Derive alias from column ref
-								if cr, ok := rt.Val.(*ast.ColumnRef); ok {
-									alias = cr.Column
-								}
-							}
-							if alias != "" {
-								item.Expr = &ast.ColumnRef{Column: alias}
-							}
-						}
-					}
-				}
-			}
+			resolveOrderByOrdinals(stmt.OrderBy, ast.LeftmostQueryLeaf(stmt))
 		}
+		return stmt
+	}
+
+	// Parenthesized query expression: resolve the inner query (with the
+	// wrapper's CTEs visible) and the outer ORDER BY ordinals.
+	if stmt.ParenSource != nil {
+		r.resolveParenSource(stmt, cteTables)
 		return stmt
 	}
 
@@ -114,10 +163,11 @@ func (r *Resolver) resolveWithCTEs(stmt *ast.SelectStmt, cteTables map[string]*R
 		}
 	}
 	for _, cte := range stmt.CTEs {
-		if cte.Recursive && cte.Select != nil && cte.Select.SetOp != ast.SetOpNone {
+		if cte.Recursive && cte.Select != nil && ast.UnwrapParenSource(cte.Select).SetOp != ast.SetOpNone {
 			// Recursive CTE: resolve left (non-recursive) branch first to get column info,
-			// then add CTE to scope, then resolve right (recursive) branch.
-			sel := cte.Select
+			// then add CTE to scope, then resolve right (recursive) branch. The body
+			// may be a parenthesized set operation, so unwrap ParenSource first.
+			sel := ast.UnwrapParenSource(cte.Select)
 
 			// Step 1: Resolve the non-recursive (left) branch
 			leftResolver := &Resolver{
@@ -164,7 +214,6 @@ func (r *Resolver) resolveWithCTEs(stmt *ast.SelectStmt, cteTables map[string]*R
 	// Resolve JOIN ON conditions (walk FROM clause) BEFORE target list resolution
 	// so that NATURAL JOIN expansion can mark coalesced columns for star expansion.
 	r.resolveFromExprs(stmt.From, sc)
-
 
 	// Resolve target list (may expand stars)
 	stmt.TargetList = r.resolveTargetList(stmt.TargetList, sc)
@@ -759,18 +808,14 @@ func (r *Resolver) withCTELookup(cteTables map[string]*ResolverTable) TableLooku
 	}
 }
 
-// collectLeftmostCTEs walks down the left spine of a set operation tree and
-// returns CTEs from the leftmost leaf. Unlike extractCTEs in the deparser,
-// this does NOT clear the CTEs — they must remain in the AST for the deparser
-// to emit the WITH clause later. Instead, it marks them as already-resolved
-// by removing them from a copy so the resolver doesn't double-process.
-func collectLeftmostCTEs(stmt *ast.SelectStmt) []*ast.CommonTableExpr {
-	cur := stmt
-	for cur.SetOp != ast.SetOpNone && cur.Left != nil {
-		cur = cur.Left
-	}
-	if len(cur.CTEs) > 0 {
-		return cur.CTEs
+// collectSetOpCTEs returns the WITH clause of a set-operation query expression.
+// The parser attaches a query-expression-level WITH to the set-op ROOT node, so
+// both operands can see it (matching MySQL, where WITH applies to the whole
+// UNION). A parenthesized operand's own WITH lives inside its parens and is
+// resolved when that operand is recursed into.
+func collectSetOpCTEs(stmt *ast.SelectStmt) []*ast.CommonTableExpr {
+	if len(stmt.CTEs) > 0 {
+		return stmt.CTEs
 	}
 	return nil
 }
@@ -792,10 +837,8 @@ func buildCTEVirtualTableFromSelect(cteName string, cteColumns []string, sel *as
 		return &ResolverTable{Name: cteName, Columns: cols}
 	}
 
-	// Walk down to the leftmost leaf for set operations
-	for sel.SetOp != ast.SetOpNone && sel.Left != nil {
-		sel = sel.Left
-	}
+	// Resolve to the leftmost output SELECT (unwrap parens, walk set-op left arms).
+	sel = ast.LeftmostQueryLeaf(sel)
 
 	var cols []ResolverColumn
 	for i, target := range sel.TargetList {
@@ -826,10 +869,8 @@ func buildCTEVirtualTable(cte *ast.CommonTableExpr) *ResolverTable {
 
 	// Otherwise, derive columns from the CTE's SELECT target list
 	sel := cte.Select
-	// For set operations, use the left side's target list
-	for sel.SetOp != ast.SetOpNone && sel.Left != nil {
-		sel = sel.Left
-	}
+	// Resolve to the leftmost output SELECT (unwrap parens, walk set-op left arms).
+	sel = ast.LeftmostQueryLeaf(sel)
 
 	var cols []ResolverColumn
 	for i, target := range sel.TargetList {
@@ -868,10 +909,8 @@ func buildDerivedVirtualTable(sub *ast.SubqueryExpr) *ResolverTable {
 	}
 
 	sel := sub.Select
-	// For set operations, use the left side's target list
-	for sel.SetOp != ast.SetOpNone && sel.Left != nil {
-		sel = sel.Left
-	}
+	// Resolve to the leftmost output SELECT (unwrap parens, walk set-op left arms).
+	sel = ast.LeftmostQueryLeaf(sel)
 
 	var cols []ResolverColumn
 	for i, target := range sel.TargetList {

--- a/mysql/deparse/rewrite.go
+++ b/mysql/deparse/rewrite.go
@@ -265,6 +265,13 @@ func RewriteSelectStmt(stmt *ast.SelectStmt) {
 		RewriteSelectStmt(stmt.Right)
 		return
 	}
+	if stmt.ParenSource != nil {
+		RewriteSelectStmt(stmt.ParenSource)
+		for _, item := range stmt.OrderBy {
+			item.Expr = RewriteExpr(item.Expr)
+		}
+		return
+	}
 	for i, target := range stmt.TargetList {
 		if rt, ok := target.(*ast.ResTarget); ok {
 			rt.Val = RewriteExpr(rt.Val)

--- a/mysql/parser/create_table.go
+++ b/mysql/parser/create_table.go
@@ -84,15 +84,14 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 	// Parenthesized create definitions (columns and constraints)
 	if p.cur.Type == '(' {
 		next := p.peekNext()
-		// Check for CREATE TABLE ... (SELECT ...) — subquery without AS
-		if next.Type == kwSELECT {
-			// CREATE TABLE t (SELECT ...)
-			p.advance() // consume '('
+		// Check for CREATE TABLE ... (query) — query source without AS. Let
+		// parseSelectStmt consume the parentheses and any following set-op /
+		// ORDER BY / LIMIT so "(SELECT 1) UNION (SELECT 2)" stays one source.
+		if next.Type == kwSELECT || next.Type == kwWITH || next.Type == '(' {
 			sel, err := p.parseSelectStmt()
 			if err != nil {
 				return nil, err
 			}
-			p.match(')')
 			stmt.Select = sel
 			stmt.Loc.End = p.pos()
 			return stmt, nil

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -138,6 +138,9 @@ func (p *Parser) parseExprPrec(minPrec int) (nodes.ExprNode, error) {
 			if _, err := p.expect('('); err != nil {
 				return nil, err
 			}
+			if !p.isQueryExpressionStart() {
+				return nil, p.syntaxErrorAtCur()
+			}
 			subStart := p.pos()
 			sub, err := p.parseSubqueryExpr()
 			if err != nil {
@@ -1121,8 +1124,8 @@ func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
 	start := p.pos()
 	p.advance() // consume '('
 
-	// Check for subquery
-	if p.cur.Type == kwSELECT {
+	// Check for subquery.
+	if p.isQueryExpressionStart() {
 		sub, err := p.parseSubqueryExpr()
 		if err != nil {
 			return nil, err
@@ -1430,8 +1433,8 @@ func (p *Parser) parseInExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
 		Expr: left,
 	}
 
-	// Check for subquery
-	if p.cur.Type == kwSELECT {
+	// Check for subquery.
+	if p.isQueryExpressionStart() {
 		sub, err := p.parseSubqueryExpr()
 		if err != nil {
 			return nil, err
@@ -1625,6 +1628,9 @@ func (p *Parser) parseExistsExpr() (nodes.ExprNode, error) {
 		return nil, &ParseError{Message: "collecting"}
 	}
 
+	if !p.isQueryExpressionStart() {
+		return nil, p.syntaxErrorAtCur()
+	}
 	sub, err := p.parseSubqueryExpr()
 	if err != nil {
 		return nil, err

--- a/mysql/parser/insert.go
+++ b/mysql/parser/insert.go
@@ -103,17 +103,18 @@ func (p *Parser) parseInsertOrReplace(isReplace bool) (*nodes.InsertStmt, error)
 
 	// Optional column list: (col1, col2, ...)
 	if p.cur.Type == '(' {
-		// Peek ahead to distinguish column list from VALUES (...) or subquery SELECT
-		// If the next token after '(' is SELECT, this is INSERT ... (SELECT ...)
+		// Distinguish a column list from a parenthesized query SOURCE. A column
+		// list always starts with an identifier (or ')'); a parenthesized query
+		// source starts with SELECT, WITH, or a nested '(' — none of which can
+		// begin a column name. So when the token after '(' is one of those, this
+		// is INSERT ... (query) — possibly the left operand of a set operation,
+		// e.g. (SELECT 1) UNION (SELECT 2) or ((SELECT 1) UNION (SELECT 2)).
+		// parseSelectStmt (parseSelectNoParens) consumes the parentheses and any
+		// trailing set-op / ORDER BY / LIMIT, so the '(' is NOT consumed here.
 		next := p.peekNext()
-		if next.Type == kwSELECT {
-			// This is INSERT ... (SELECT ...)
-			p.advance() // consume '('
+		if next.Type == kwSELECT || next.Type == kwWITH || next.Type == '(' {
 			sel, err := p.parseSelectStmt()
 			if err != nil {
-				return nil, err
-			}
-			if _, err := p.expect(')'); err != nil {
 				return nil, err
 			}
 			stmt.Select = sel
@@ -146,7 +147,10 @@ func (p *Parser) parseInsertOrReplace(isReplace bool) (*nodes.InsertStmt, error)
 		}
 		stmt.SetList = setList
 
-	case kwSELECT, kwWITH:
+	case kwSELECT, kwWITH, '(':
+		// SELECT / WITH / parenthesized query source. A leading '(' reaches here
+		// when an explicit column list preceded it, e.g.
+		// INSERT INTO t (a) (SELECT 1) or INSERT INTO t (a) ((SELECT 1) UNION ...).
 		sel, err := p.parseSelectStmt()
 		if err != nil {
 			return nil, err

--- a/mysql/parser/parenthesized_query_test.go
+++ b/mysql/parser/parenthesized_query_test.go
@@ -1,0 +1,149 @@
+package parser
+
+import "testing"
+
+// TestParenthesizedQueryExpression pins MySQL 8.0 parenthesized query
+// expressions at statement level: a query expression may start with '(',
+// parenthesized set-op operands may carry their own clauses, and trailing
+// ORDER BY / LIMIT after the closing ')' bind to the outer query expression.
+func TestParenthesizedQueryExpression(t *testing.T) {
+	for _, sql := range []string{
+		"(SELECT 1)",
+		"((SELECT 1))",
+		"(SELECT 1) UNION (SELECT 2)",
+		"(SELECT 1) UNION SELECT 2",
+		"SELECT 1 UNION (SELECT 2)",
+		"(SELECT 1) UNION ALL (SELECT 2)",
+		"(SELECT a FROM t ORDER BY a) UNION (SELECT b FROM t)",
+		"(SELECT a FROM t LIMIT 1) UNION (SELECT b FROM t)",
+		"(SELECT 1) UNION (SELECT 2) ORDER BY 1",
+		"(SELECT 1) UNION (SELECT 2) LIMIT 1",
+		"(SELECT 1 UNION SELECT 2)",
+		"((SELECT 1) UNION (SELECT 2))",
+		"(SELECT 1) UNION (SELECT 2) UNION (SELECT 3)",
+		"(SELECT 1) INTERSECT (SELECT 2)",
+		"(SELECT 1) EXCEPT (SELECT 2)",
+		"(SELECT a FROM t) ORDER BY a",
+		"(SELECT a FROM t) LIMIT 1",
+		"(SELECT a FROM t) ORDER BY a LIMIT 1",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedQueryDelegatedContexts covers parser contexts that delegate
+// to the query-expression parser instead of starting directly at parseStmt.
+func TestParenthesizedQueryDelegatedContexts(t *testing.T) {
+	for _, sql := range []string{
+		"INSERT INTO t (SELECT 1) UNION (SELECT 2)",
+		"INSERT INTO t (SELECT 1 UNION SELECT 2)",
+		"INSERT INTO t (a) (SELECT 1)",
+		"INSERT INTO t (a) ((SELECT 1) UNION (SELECT 2))",
+		"REPLACE INTO t (a) ((SELECT 1) UNION (SELECT 2))",
+		"CREATE VIEW v AS (SELECT 1) UNION (SELECT 2)",
+		"WITH cte AS ((SELECT 1) UNION (SELECT 2)) SELECT * FROM cte",
+		"WITH cte AS (SELECT 1) (SELECT * FROM cte)",
+		"WITH cte AS (SELECT 1) (SELECT * FROM cte) UNION (SELECT 2)",
+		"CREATE TABLE tt AS (SELECT 1) UNION (SELECT 2)",
+		"CREATE TABLE tt (SELECT 1) UNION (SELECT 2)",
+		"CREATE PROCEDURE p() BEGIN (SELECT 1) UNION (SELECT 2); END",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedQueryTwoScopes ensures the AST can preserve both the inner
+// clause scope and the outer clause scope. A flat representation would overwrite
+// one of these LIMIT / ORDER BY clauses.
+func TestParenthesizedQueryTwoScopes(t *testing.T) {
+	for _, sql := range []string{
+		"(SELECT 1 LIMIT 5) LIMIT 2",
+		"(SELECT 1 ORDER BY 1) ORDER BY 2",
+		"((SELECT 1 ORDER BY 1)) ORDER BY 2",
+		"(SELECT 1) ORDER BY 1 LIMIT 2 OFFSET 1",
+		"(SELECT 1) UNION ((SELECT 2) LIMIT 1) LIMIT 5",
+		"((SELECT 1) UNION (SELECT 2)) ORDER BY 1",
+		"((SELECT 1) UNION (SELECT 2)) LIMIT 1",
+		"(SELECT a FROM t LIMIT 1) UNION (SELECT b FROM t LIMIT 2) ORDER BY 1",
+		"(SELECT 1) UNION ((SELECT 2) ORDER BY 1)",
+		"(SELECT 1 ORDER BY 1 LIMIT 3) UNION (SELECT 2) ORDER BY 1 LIMIT 9",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+func TestParenthesizedQueryRejected(t *testing.T) {
+	for _, sql := range []string{
+		"(SELECT 1",
+		"()",
+		"(SELECT 1) UNION",
+		"(SELECT 1) UNION ()",
+		"(SELECT 1) ORDER BY 1 ORDER BY 2",
+		"(SELECT 1) LIMIT 1 LIMIT 2",
+		"SELECT 1 UNION SELECT 2 ORDER BY 1 ORDER BY 1",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseExpectError(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedQueryLocking pins MySQL 8.0 locking placement. Unlike TiDB,
+// MySQL accepts FOR UPDATE after a parenthesized query expression and after a
+// parenthesized set operation.
+func TestParenthesizedQueryLocking(t *testing.T) {
+	for _, sql := range []string{
+		"(SELECT a FROM t FOR UPDATE)",
+		"(SELECT a FROM t) FOR UPDATE",
+		"(SELECT a FROM t) LOCK IN SHARE MODE",
+		"(SELECT a FROM t FOR UPDATE) UNION (SELECT a FROM t)",
+		"(SELECT a FROM t) UNION (SELECT a FROM t) FOR UPDATE",
+		"((SELECT a FROM t) UNION (SELECT a FROM t)) FOR UPDATE",
+		"(SELECT a FROM t) UNION (SELECT a FROM t) ORDER BY 1 FOR UPDATE",
+		"SELECT a FROM t UNION SELECT a FROM t FOR UPDATE",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedQueryMysqlPrimaries tracks MySQL query primaries that TiDB's
+// parenthesized-query PR explicitly deferred. These require SelectStmt to model
+// non-SELECT primaries as operands, not just SELECT leaves.
+func TestParenthesizedQueryMysqlPrimaries(t *testing.T) {
+	for _, sql := range []string{
+		"(TABLE t)",
+		"(VALUES ROW(1))",
+		"(SELECT 1) UNION (TABLE t)",
+		"(TABLE t) UNION (SELECT 1)",
+		"(SELECT 1) UNION (VALUES ROW(2))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedQueryNestedDerivedAndSubqueries tracks contexts that need
+// token-stream backtracking: after the first '(' the parser has to distinguish a
+// parenthesized query expression from a parenthesized table/value/expression
+// list, and one-token lookahead is not enough.
+func TestParenthesizedQueryNestedDerivedAndSubqueries(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2)) AS x",
+		"SELECT 1 WHERE 1 IN ((SELECT 1) UNION (SELECT 2))",
+		"SELECT (SELECT 1 UNION SELECT 2)",
+		"SELECT EXISTS ((SELECT 1) UNION (SELECT 2))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}

--- a/mysql/parser/select.go
+++ b/mysql/parser/select.go
@@ -93,22 +93,18 @@ func (p *Parser) parseWithClause() ([]*nodes.CommonTableExpr, error) {
 
 // parseWithStmt parses a statement starting with WITH: WITH ... SELECT, WITH ... UPDATE, WITH ... DELETE.
 func (p *Parser) parseWithStmt() (nodes.Node, error) {
+	start := p.pos()
 	ctes, err := p.parseWithClause()
 	if err != nil {
 		return nil, err
 	}
 
 	switch p.cur.Type {
-	case kwSELECT:
-		stmt, err := p.parseSelectStmt()
-		if err != nil {
-			return nil, err
-		}
-		stmt.CTEs = ctes
-		if len(ctes) > 0 {
-			stmt.Loc.Start = ctes[0].Loc.Start
-		}
-		return stmt, nil
+	case kwSELECT, '(':
+		// A SELECT leaf or a parenthesized query body:
+		//   WITH ... SELECT ...
+		//   WITH ... (SELECT ...) [set-op] [ORDER BY / LIMIT]
+		return p.parseSelectClauseAndTrailing(start, ctes)
 
 	case kwINSERT, kwREPLACE:
 		isReplace := p.cur.Type == kwREPLACE
@@ -134,37 +130,30 @@ func (p *Parser) parseWithStmt() (nodes.Node, error) {
 
 	default:
 		return nil, &ParseError{
-			Message:  "expected SELECT, INSERT, UPDATE, or DELETE after WITH clause",
+			Message:  "expected SELECT, INSERT, UPDATE, DELETE, or '(' after WITH clause",
 			Position: p.cur.Loc,
 		}
 	}
 }
 
-// parseSelectStmt parses a SELECT statement, optionally preceded by a WITH clause.
-//
-// Ref: https://dev.mysql.com/doc/refman/8.0/en/select.html
-//
-//	[WITH [RECURSIVE]
-//	    cte_name [(col_name [, col_name] ...)] AS (subquery)
-//	    [, cte_name [(col_name [, col_name] ...)] AS (subquery)] ...]
-//	SELECT
-//	    [ALL | DISTINCT | DISTINCTROW]
-//	    [HIGH_PRIORITY]
-//	    [STRAIGHT_JOIN]
-//	    [SQL_CALC_FOUND_ROWS]
-//	    select_expr [, select_expr] ...
-//	    [FROM table_references]
-//	    [WHERE where_condition]
-//	    [GROUP BY {col_name | expr | position} [ASC | DESC], ... [WITH ROLLUP]]
-//	    [HAVING where_condition]
-//	    [ORDER BY {col_name | expr | position} [ASC | DESC], ...]
-//	    [LIMIT {[offset,] row_count | row_count OFFSET offset}]
-//	    [FOR {UPDATE | SHARE} [OF tbl_name [, tbl_name] ...] [NOWAIT | SKIP LOCKED]]
-//	    [INTO OUTFILE 'file_name' | INTO DUMPFILE 'file_name' | INTO var_name [, var_name]]
+// parseSelectStmt parses a complete query expression as a statement: an
+// optional WITH clause, a query-expression body (a SELECT leaf, a parenthesized
+// query, or a UNION/INTERSECT/EXCEPT chain), and any trailing ORDER BY / LIMIT.
+// It is the entry point every query-bearing context uses (statement level,
+// subqueries, INSERT/CTAS/VIEW sources, routine bodies).
 func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
+	return p.parseSelectNoParens()
+}
+
+// parseSelectNoParens parses a query expression that is not itself wrapped in
+// parentheses (PostgreSQL's select_no_parens): [WITH] select_clause
+// [ORDER BY] [LIMIT/OFFSET]. The trailing ORDER BY / LIMIT bind at this OUTER
+// level, which is what gives a parenthesized inner query and an outer clause
+// distinct scopes.
+func (p *Parser) parseSelectNoParens() (*nodes.SelectStmt, error) {
 	start := p.pos()
 
-	// Parse optional WITH clause
+	// Optional WITH clause (applies to the whole query expression).
 	var ctes []*nodes.CommonTableExpr
 	if p.cur.Type == kwWITH {
 		var err error
@@ -173,6 +162,299 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 			return nil, err
 		}
 	}
+
+	return p.parseSelectClauseAndTrailing(start, ctes)
+}
+
+// parseSelectClauseAndTrailing parses a select_clause followed by the trailing
+// ORDER BY / LIMIT that applies to a parenthesized query or set-operation
+// result. ctes (already parsed by the caller) and start (the position of the
+// leading WITH / '(' / SELECT) are attached to the resulting node.
+func (p *Parser) parseSelectClauseAndTrailing(start int, ctes []*nodes.CommonTableExpr) (*nodes.SelectStmt, error) {
+	body, err := p.parseSelectClause(0)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil { // collecting completion candidates
+		return nil, nil
+	}
+	if len(ctes) > 0 {
+		body.CTEs = ctes
+	}
+	body.Loc.Start = start
+
+	// A trailing ORDER BY / LIMIT after a parenthesized query or a set operation
+	// (i.e. after a ')') applies to the whole result. A bare SELECT leaf has
+	// already consumed its own ORDER BY / LIMIT / locking greedily, so it is
+	// skipped here (a second ORDER BY on a leaf is a duplicate the leaf rejects).
+	if body.ParenSource != nil || body.SetOp != nodes.SetOpNone {
+		if err := p.parseOuterOrderByLimit(body); err != nil {
+			return nil, err
+		}
+	}
+
+	body.Loc.End = p.pos()
+	return body, nil
+}
+
+// parseOuterOrderByLimit parses trailing ORDER BY, LIMIT/OFFSET, and locking
+// clauses applying to a parenthesized query or set-operation result, onto stmt's
+// own fields. MySQL accepts FOR UPDATE / LOCK IN SHARE MODE after a closing ')',
+// unlike TiDB's leaf-only locking placement.
+func (p *Parser) parseOuterOrderByLimit(stmt *nodes.SelectStmt) error {
+	if p.cur.Type == kwORDER {
+		p.advance()
+		if _, err := p.expect(kwBY); err != nil {
+			return err
+		}
+		orderBy, err := p.parseOrderByList()
+		if err != nil {
+			return err
+		}
+		stmt.OrderBy = orderBy
+		if p.cur.Type == kwORDER {
+			return &ParseError{Message: "duplicate ORDER BY clause", Position: p.cur.Loc}
+		}
+	}
+	if _, ok := p.match(kwLIMIT); ok {
+		limit, err := p.parseLimitClause()
+		if err != nil {
+			return err
+		}
+		stmt.Limit = limit
+		if p.cur.Type == kwLIMIT {
+			return &ParseError{Message: "duplicate LIMIT clause", Position: p.cur.Loc}
+		}
+	}
+	if p.cur.Type == kwFOR {
+		fu, err := p.parseForUpdateClause()
+		if err != nil {
+			return err
+		}
+		stmt.ForUpdate = fu
+	} else if p.cur.Type == kwLOCK {
+		fu, err := p.parseLockInShareMode()
+		if err != nil {
+			return err
+		}
+		stmt.ForUpdate = fu
+	}
+	return nil
+}
+
+// parseSelectClause parses a select_clause: a query primary optionally combined
+// with others via UNION / INTERSECT / EXCEPT, using precedence climbing
+// (INTERSECT binds tighter than UNION/EXCEPT). minPrec is the minimum operator
+// precedence this call will consume; the top-level no_parens call passes 0.
+func (p *Parser) parseSelectClause(minPrec int) (*nodes.SelectStmt, error) {
+	left, err := p.parseSelectClausePrimary()
+	if err != nil {
+		return nil, err
+	}
+	if left == nil { // collecting completion candidates
+		return nil, nil
+	}
+
+	for {
+		prec := setOpPrecedence(p.cur.Type)
+		if prec == 0 || prec < minPrec {
+			return left, nil
+		}
+
+		var op nodes.SetOperation
+		switch p.cur.Type {
+		case kwUNION:
+			op = nodes.SetOpUnion
+		case kwEXCEPT:
+			op = nodes.SetOpExcept
+		case kwINTERSECT:
+			op = nodes.SetOpIntersect
+		}
+		p.advance() // consume UNION/INTERSECT/EXCEPT
+
+		// Completion: after the set-op keyword, offer ALL, DISTINCT, SELECT.
+		p.checkCursor()
+		if p.collectMode() {
+			p.addTokenCandidate(kwALL)
+			p.addTokenCandidate(kwDISTINCT)
+			p.addTokenCandidate(kwSELECT)
+			return nil, &ParseError{Message: "collecting"}
+		}
+
+		all := false
+		if _, ok := p.match(kwALL); ok {
+			all = true
+		} else {
+			p.match(kwDISTINCT)
+		}
+
+		// Completion: after ALL/DISTINCT, offer SELECT.
+		p.checkCursor()
+		if p.collectMode() {
+			p.addTokenCandidate(kwSELECT)
+			return nil, &ParseError{Message: "collecting"}
+		}
+
+		// Right operand binds higher-precedence operators first; prec+1 keeps
+		// same-precedence chains left-associative.
+		right, err := p.parseSelectClause(prec + 1)
+		if err != nil {
+			return nil, err
+		}
+
+		// Hoist a trailing ORDER BY / LIMIT off an UNPARENTHESIZED last operand
+		// onto the set-operation node: in MySQL they apply to the whole
+		// combined result. A parenthesized operand is a ParenSource wrapper whose
+		// own OrderBy/Limit are the OUTER scope, so the walk stops at it and its
+		// inner clauses stay in place — e.g. "SELECT 1 UNION (SELECT 2 LIMIT 1)"
+		// keeps LIMIT 1 on operand 2.
+		var orderBy []*nodes.OrderByItem
+		var limit *nodes.Limit
+		rightLeaf := right
+		for rightLeaf.SetOp != nodes.SetOpNone && rightLeaf.Right != nil {
+			rightLeaf = rightLeaf.Right
+		}
+		if rightLeaf.ParenSource == nil {
+			if len(rightLeaf.OrderBy) > 0 {
+				orderBy = rightLeaf.OrderBy
+				rightLeaf.OrderBy = nil
+				if rightLeaf.TableSource != nil {
+					rightLeaf.TableSource.OrderBy = nil
+				}
+				if rightLeaf.ValuesSource != nil {
+					rightLeaf.ValuesSource.OrderBy = nil
+				}
+			}
+			if rightLeaf.Limit != nil {
+				limit = rightLeaf.Limit
+				rightLeaf.Limit = nil
+				if rightLeaf.TableSource != nil {
+					rightLeaf.TableSource.Limit = nil
+				}
+				if rightLeaf.ValuesSource != nil {
+					rightLeaf.ValuesSource.Limit = nil
+				}
+			}
+		}
+
+		left = &nodes.SelectStmt{
+			Loc:     nodes.Loc{Start: left.Loc.Start, End: right.Loc.End},
+			SetOp:   op,
+			SetAll:  all,
+			Left:    left,
+			Right:   right,
+			OrderBy: orderBy,
+			Limit:   limit,
+		}
+	}
+}
+
+// parseSelectClausePrimary parses a single query primary: a parenthesized query
+// (select_with_parens), a simple SELECT leaf, TABLE, or VALUES.
+func (p *Parser) parseSelectClausePrimary() (*nodes.SelectStmt, error) {
+	if p.cur.Type == '(' {
+		return p.parseSelectWithParens()
+	}
+	if p.cur.Type == kwSELECT {
+		return p.parseSimpleSelect()
+	}
+	if p.cur.Type == kwTABLE {
+		tableStmt, err := p.parseTableStmt()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.SelectStmt{
+			Loc:         tableStmt.Loc,
+			TableSource: tableStmt,
+			OrderBy:     tableStmt.OrderBy,
+			Limit:       tableStmt.Limit,
+			Into:        tableStmt.Into,
+		}, nil
+	}
+	if p.cur.Type == kwVALUES {
+		valuesStmt, err := p.parseValuesStmt()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.SelectStmt{
+			Loc:          valuesStmt.Loc,
+			ValuesSource: valuesStmt,
+			OrderBy:      valuesStmt.OrderBy,
+			Limit:        valuesStmt.Limit,
+		}, nil
+	}
+	if p.cur.Type == tokEOF {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return nil, &ParseError{
+		Message:  "expected SELECT, TABLE, VALUES, or '('",
+		Position: p.cur.Loc,
+	}
+}
+
+func isQueryPrimaryStartToken(tokenType int) bool {
+	switch tokenType {
+	case kwSELECT, kwWITH, kwTABLE, kwVALUES:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Parser) isQueryExpressionStart() bool {
+	if isQueryPrimaryStartToken(p.cur.Type) {
+		return true
+	}
+	if p.cur.Type != '(' {
+		return false
+	}
+	next := p.peekNext()
+	return isQueryPrimaryStartToken(next.Type) || next.Type == '('
+}
+
+// parseSelectWithParens parses a parenthesized query expression (PostgreSQL's
+// select_with_parens): '(' select_no_parens ')'. It returns a WRAPPER node
+// whose ParenSource is the inner query; the wrapper's own ORDER BY / LIMIT hold
+// any OUTER trailing clauses attached by the enclosing no_parens. Unlike
+// PostgreSQL (which unwraps the inner query and would overwrite its clause),
+// MySQL accepts and must preserve BOTH scopes — e.g. "(SELECT 1 LIMIT 5) LIMIT
+// 2" — so the parens materialize as a real node. The unconditional delegation to
+// parseSelectNoParens left-factors the grammar so a nested "((...))" and a
+// parenthesized set-op operand are parsed by the same path.
+func (p *Parser) parseSelectWithParens() (*nodes.SelectStmt, error) {
+	start := p.pos()
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	inner, err := p.parseSelectNoParens()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return &nodes.SelectStmt{
+		Loc:         nodes.Loc{Start: start, End: p.pos()},
+		ParenSource: inner,
+	}, nil
+}
+
+// parseSimpleSelect parses a single SELECT query primary (no leading WITH, no
+// trailing set operation). It greedily consumes its own ORDER BY / LIMIT /
+// locking; the enclosing select_clause hoists an unparenthesized last operand's
+// ORDER BY / LIMIT onto the set-op node.
+//
+// Ref: https://dev.mysql.com/doc/refman/8.0/en/select.html
+//
+//	SELECT
+//	    [ALL | DISTINCT | DISTINCTROW] [HIGH_PRIORITY] [STRAIGHT_JOIN]
+//	    [SQL_CALC_FOUND_ROWS] select_expr [, select_expr] ...
+//	    [FROM table_references] [WHERE where_condition]
+//	    [GROUP BY ... [WITH ROLLUP]] [HAVING ...] [WINDOW ...]
+//	    [ORDER BY ...] [LIMIT {[offset,] row_count | row_count OFFSET offset}]
+//	    [FOR {UPDATE | SHARE} ...] [INTO OUTFILE 'file_name']
+func (p *Parser) parseSimpleSelect() (*nodes.SelectStmt, error) {
+	start := p.pos()
 
 	p.advance() // consume SELECT
 
@@ -186,7 +468,7 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 		return nil, &ParseError{Message: "collecting"}
 	}
 
-	stmt := &nodes.SelectStmt{Loc: nodes.Loc{Start: start}, CTEs: ctes}
+	stmt := &nodes.SelectStmt{Loc: nodes.Loc{Start: start}}
 
 	// Parse SELECT options
 	for {
@@ -340,294 +622,6 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 	}
 
 	// WINDOW clause: WINDOW window_name AS (window_spec) [, ...]
-	if p.cur.Type == kwWINDOW {
-		p.advance()
-		defs, err := p.parseNamedWindowList()
-		if err != nil {
-			return nil, err
-		}
-		stmt.WindowClause = defs
-	}
-
-	// INTO clause (position 2: after HAVING/WINDOW, before ORDER BY)
-	if p.cur.Type == kwINTO && stmt.Into == nil {
-		p.advance()
-		into, err := p.parseIntoClause()
-		if err != nil {
-			return nil, err
-		}
-		stmt.Into = into
-	}
-
-	// ORDER BY clause
-	if p.cur.Type == kwORDER {
-		p.advance()
-		if _, err := p.expect(kwBY); err != nil {
-			return nil, err
-		}
-		orderBy, err := p.parseOrderByList()
-		if err != nil {
-			return nil, err
-		}
-		stmt.OrderBy = orderBy
-
-		// WITH ROLLUP (MySQL 8.0.12+)
-		if p.cur.Type == kwWITH {
-			next := p.peekNext()
-			if next.Type == kwROLLUP {
-				p.advance() // consume WITH
-				p.advance() // consume ROLLUP
-				stmt.OrderByWithRollup = true
-			}
-		}
-
-		// Reject duplicate ORDER BY
-		if p.cur.Type == kwORDER {
-			return nil, &ParseError{
-				Message:  "duplicate ORDER BY clause",
-				Position: p.cur.Loc,
-			}
-		}
-	}
-
-	// LIMIT clause
-	if _, ok := p.match(kwLIMIT); ok {
-		limit, err := p.parseLimitClause()
-		if err != nil {
-			return nil, err
-		}
-		stmt.Limit = limit
-	}
-
-	// FOR UPDATE / FOR SHARE / LOCK IN SHARE MODE
-	if p.cur.Type == kwFOR {
-		fu, err := p.parseForUpdateClause()
-		if err != nil {
-			return nil, err
-		}
-		stmt.ForUpdate = fu
-	} else if p.cur.Type == kwLOCK {
-		fu, err := p.parseLockInShareMode()
-		if err != nil {
-			return nil, err
-		}
-		stmt.ForUpdate = fu
-	}
-
-	// INTO clause (position 3: after locking clause)
-	if p.cur.Type == kwINTO && stmt.Into == nil {
-		p.advance()
-		into, err := p.parseIntoClause()
-		if err != nil {
-			return nil, err
-		}
-		stmt.Into = into
-	}
-
-	stmt.Loc.End = p.pos()
-
-	// Check for set operations: UNION, INTERSECT, EXCEPT
-	if p.cur.Type == kwUNION || p.cur.Type == kwINTERSECT || p.cur.Type == kwEXCEPT {
-		return p.parseSetOperation(stmt)
-	}
-
-	return stmt, nil
-}
-
-// parseSelectStmtBase parses a single SELECT (no set operations consumed).
-// Used by the set operation precedence parser to get the right-hand operand.
-func (p *Parser) parseSelectStmtBase() (*nodes.SelectStmt, error) {
-	// Handle parenthesized select: (SELECT ...)
-	if p.cur.Type == '(' {
-		p.advance()
-		inner, err := p.parseSelectStmt()
-		if err != nil {
-			return nil, err
-		}
-		if _, err := p.expect(')'); err != nil {
-			return nil, err
-		}
-		return inner, nil
-	}
-
-	start := p.pos()
-
-	// Parse optional WITH clause
-	var ctes []*nodes.CommonTableExpr
-	if p.cur.Type == kwWITH {
-		var err error
-		ctes, err = p.parseWithClause()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	p.advance() // consume SELECT
-
-	// Completion: after SELECT keyword, offer select-expression candidates.
-	p.checkCursor()
-	if p.collectMode() {
-		p.addTokenCandidate(kwDISTINCT)
-		p.addTokenCandidate(kwALL)
-		p.addRuleCandidate("columnref")
-		p.addRuleCandidate("func_name")
-		return nil, &ParseError{Message: "collecting"}
-	}
-
-	stmt := &nodes.SelectStmt{Loc: nodes.Loc{Start: start}, CTEs: ctes}
-
-	// Parse SELECT options
-	for {
-		switch p.cur.Type {
-		case kwALL:
-			stmt.DistinctKind = nodes.DistinctAll
-			p.advance()
-			continue
-		case kwDISTINCT, kwDISTINCTROW:
-			stmt.DistinctKind = nodes.DistinctOn
-			p.advance()
-			continue
-		case kwHIGH_PRIORITY:
-			stmt.HighPriority = true
-			p.advance()
-			continue
-		case kwSTRAIGHT_JOIN:
-			stmt.StraightJoin = true
-			p.advance()
-			continue
-		case kwSQL_CALC_FOUND_ROWS:
-			stmt.CalcFoundRows = true
-			p.advance()
-			continue
-		case kwSQL_SMALL_RESULT:
-			stmt.SmallResult = true
-			p.advance()
-			continue
-		case kwSQL_BIG_RESULT:
-			stmt.BigResult = true
-			p.advance()
-			continue
-		case kwSQL_BUFFER_RESULT:
-			stmt.BufferResult = true
-			p.advance()
-			continue
-		case kwSQL_NO_CACHE:
-			stmt.NoCache = true
-			p.advance()
-			continue
-		}
-		break
-	}
-
-	// Parse select expression list
-	targets, err := p.parseSelectExprList()
-	if err != nil {
-		return nil, err
-	}
-	stmt.TargetList = targets
-
-	// Completion: after select target list, offer clause keywords.
-	p.checkCursor()
-	if p.collectMode() {
-		for _, tok := range []int{kwINTO, kwFROM, kwWHERE, kwGROUP, kwHAVING, kwORDER, kwLIMIT, kwFOR} {
-			p.addTokenCandidate(tok)
-		}
-		return nil, &ParseError{Message: "collecting"}
-	}
-
-	// INTO clause (position 1: after select_expr, before FROM)
-	if p.cur.Type == kwINTO {
-		p.advance()
-		into, err := p.parseIntoClause()
-		if err != nil {
-			return nil, err
-		}
-		stmt.Into = into
-	}
-
-	// FROM clause
-	if _, ok := p.match(kwFROM); ok {
-		from, err := p.parseTableReferenceList()
-		if err != nil {
-			return nil, err
-		}
-		stmt.From = from
-	}
-
-	// WHERE clause — MySQL allows WHERE without FROM (e.g., SELECT 1 WHERE 1=1)
-	if p.cur.Type == kwWHERE {
-		p.advance()
-		where, err := p.parseExpr()
-		if err != nil {
-			return nil, err
-		}
-		if !p.collectMode() && where == nil {
-			return nil, p.syntaxErrorAtCur()
-		}
-		stmt.Where = where
-
-		// Reject duplicate WHERE
-		if p.cur.Type == kwWHERE {
-			return nil, &ParseError{
-				Message:  "duplicate WHERE clause",
-				Position: p.cur.Loc,
-			}
-		}
-	}
-
-	// GROUP BY clause — MySQL allows GROUP BY without FROM
-	if p.cur.Type == kwGROUP {
-		p.advance()
-		if _, err := p.expect(kwBY); err != nil {
-			return nil, err
-		}
-		groupBy, err := p.parseExprList()
-		if err != nil {
-			return nil, err
-		}
-		stmt.GroupBy = groupBy
-
-		// Completion: after GROUP BY list, offer follow-set keywords.
-		p.checkCursor()
-		if p.collectMode() {
-			p.addTokenCandidate(kwHAVING)
-			p.addTokenCandidate(kwORDER)
-			p.addTokenCandidate(kwLIMIT)
-			p.addTokenCandidate(kwWITH)
-			return nil, &ParseError{Message: "collecting"}
-		}
-
-		// WITH ROLLUP
-		if p.cur.Type == kwWITH {
-			p.advance()
-			if _, ok := p.match(kwROLLUP); ok {
-				stmt.WithRollup = true
-			}
-		}
-
-		// Reject duplicate GROUP BY
-		if p.cur.Type == kwGROUP {
-			return nil, &ParseError{
-				Message:  "duplicate GROUP BY clause",
-				Position: p.cur.Loc,
-			}
-		}
-	}
-
-	// HAVING clause — MySQL allows HAVING without FROM
-	if p.cur.Type == kwHAVING {
-		p.advance()
-		having, err := p.parseExpr()
-		if err != nil {
-			return nil, err
-		}
-		if !p.collectMode() && having == nil {
-			return nil, p.syntaxErrorAtCur()
-		}
-		stmt.Having = having
-	}
-
-	// WINDOW clause
 	if p.cur.Type == kwWINDOW {
 		p.advance()
 		defs, err := p.parseNamedWindowList()
@@ -1133,8 +1127,9 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 		startPos := p.pos()
 		p.advance()
 
-		// Subquery (derived table): (SELECT ...) or (WITH ... SELECT ...)
-		if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
+		// Subquery (derived table): (query_expression), including
+		// parenthesized set operations like ((SELECT ...) UNION (...)).
+		if p.isQueryExpressionStart() {
 			sel, err := p.parseSelectStmt()
 			if err != nil {
 				return nil, err
@@ -1779,114 +1774,6 @@ func setOpPrecedence(tokType int) int {
 	return 0
 }
 
-// parseSetOperation parses UNION/INTERSECT/EXCEPT [ALL|DISTINCT] SELECT chains
-// with INTERSECT binding tighter than UNION/EXCEPT.
-func (p *Parser) parseSetOperation(left *nodes.SelectStmt) (*nodes.SelectStmt, error) {
-	return p.parseSetOpWithPrecedence(left, 1)
-}
-
-// parseSetOpWithPrecedence implements precedence climbing for set operations.
-func (p *Parser) parseSetOpWithPrecedence(left *nodes.SelectStmt, minPrec int) (*nodes.SelectStmt, error) {
-	for {
-		prec := setOpPrecedence(p.cur.Type)
-		if prec < minPrec {
-			break
-		}
-
-		var op nodes.SetOperation
-		switch p.cur.Type {
-		case kwUNION:
-			op = nodes.SetOpUnion
-		case kwINTERSECT:
-			op = nodes.SetOpIntersect
-		case kwEXCEPT:
-			op = nodes.SetOpExcept
-		}
-		p.advance()
-
-		// Completion: after UNION/INTERSECT/EXCEPT keyword, offer ALL, DISTINCT, SELECT.
-		p.checkCursor()
-		if p.collectMode() {
-			p.addTokenCandidate(kwALL)
-			p.addTokenCandidate(kwDISTINCT)
-			p.addTokenCandidate(kwSELECT)
-			return nil, &ParseError{Message: "collecting"}
-		}
-
-		all := false
-		if _, ok := p.match(kwALL); ok {
-			all = true
-		} else {
-			p.match(kwDISTINCT)
-		}
-
-		// Completion: after ALL/DISTINCT, offer SELECT.
-		p.checkCursor()
-		if p.collectMode() {
-			p.addTokenCandidate(kwSELECT)
-			return nil, &ParseError{Message: "collecting"}
-		}
-
-		if p.cur.Type != kwSELECT && p.cur.Type != '(' {
-			if p.cur.Type == tokEOF {
-				return nil, p.syntaxErrorAtCur()
-			}
-			return nil, &ParseError{
-				Message:  "expected SELECT after set operation",
-				Position: p.cur.Loc,
-			}
-		}
-
-		right, err := p.parseSelectStmtBase()
-		if err != nil {
-			return nil, err
-		}
-
-		// If next op has higher precedence, recurse to consume it first
-		for {
-			nextPrec := setOpPrecedence(p.cur.Type)
-			if nextPrec <= prec {
-				break
-			}
-			right, err = p.parseSetOpWithPrecedence(right, nextPrec)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		// Hoist trailing ORDER BY / LIMIT from the right-hand SELECT to the
-		// set-operation node. In MySQL, ORDER BY and LIMIT after a set
-		// operation (without parentheses) apply to the entire combined result,
-		// not just the last SELECT.
-		var orderBy []*nodes.OrderByItem
-		var limit *nodes.Limit
-		rightLeaf := right
-		for rightLeaf.SetOp != nodes.SetOpNone && rightLeaf.Right != nil {
-			rightLeaf = rightLeaf.Right
-		}
-		if len(rightLeaf.OrderBy) > 0 {
-			orderBy = rightLeaf.OrderBy
-			rightLeaf.OrderBy = nil
-		}
-		if rightLeaf.Limit != nil {
-			limit = rightLeaf.Limit
-			rightLeaf.Limit = nil
-		}
-
-		left = &nodes.SelectStmt{
-			Loc:     nodes.Loc{Start: left.Loc.Start, End: right.Loc.End},
-			SetOp:   op,
-			SetAll:  all,
-			Left:    left,
-			Right:   right,
-			OrderBy: orderBy,
-			Limit:   limit,
-		}
-	}
-
-	return left, nil
-}
-
 // parseParenIdentList parses a parenthesized comma-separated list of identifiers.
 func (p *Parser) parseParenIdentList() ([]string, error) {
 	return p.parseParenIdentListWithCompletion("")
@@ -2159,7 +2046,9 @@ func (p *Parser) parseValuesStmt() (*nodes.ValuesStmt, error) {
 	return stmt, nil
 }
 
-// parseSubqueryExpr parses a subquery expression: (SELECT ...)
+// parseSubqueryExpr parses a subquery expression: SELECT ... or a
+// parenthesized query expression. The caller owns the surrounding subquery
+// parentheses used by IN/EXISTS/scalar-subquery syntax.
 func (p *Parser) parseSubqueryExpr() (*nodes.SubqueryExpr, error) {
 	start := p.pos()
 	sel, err := p.parseSelectStmt()


### PR DESCRIPTION
## Summary
- Support MySQL 8.0 parenthesized query expressions in `omni/mysql`, including leading `(SELECT ...)`, nested parentheses, set-op operands, and inner-vs-outer `ORDER BY` / `LIMIT` / locking scopes.
- Add `SelectStmt.ParenSource` plus TABLE / VALUES query-primary leaves so `(TABLE t)`, `(VALUES ROW(...))`, and mixed set operations can be represented without flattening clause scopes.
- Wire parser consumers: deparse, resolver, rewrite, completion refs, catalog view-column derivation, outfuncs, and regenerated walker.

## MySQL-specific notes
- Verified against a real `mysql:8.0` container; MySQL accepts trailing `FOR UPDATE` after parenthesized query expressions, unlike TiDB.
- Supports nested derived table and subquery forms such as `FROM ((SELECT ...) UNION (...)) AS x` and `IN ((SELECT ...) UNION (...))`.

## Test Plan
- `git diff --check`
- `DOCKER_HOST=unix:///Users/rebeliceyang/.colima/default/docker.sock TESTCONTAINERS_RYUK_DISABLED=true go test ./mysql/...`
