### PR TITLE
fix(oracle): parse wrapped procedures

### DIFF
--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -3172,6 +3172,12 @@ func writeCreateProcedureStmt(sb *strings.Builder, n *CreateProcedureStmt) {
 		sb.WriteString(" :parameters ")
 		writeNode(sb, n.Parameters)
 	}
+	if n.Wrapped {
+		sb.WriteString(" :wrapped true")
+	}
+	if n.WrappedSource != "" {
+		sb.WriteString(fmt.Sprintf(" :wrappedSource %q", n.WrappedSource))
+	}
 	if n.Body != nil {
 		sb.WriteString(" :body ")
 		writeNode(sb, n.Body)

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -1991,6 +1991,8 @@ type CreateProcedureStmt struct {
 	AuthID         string      // AUTHID CURRENT_USER | DEFINER
 	Name           *ObjectName // procedure name
 	Parameters     *List       // parameter list (list of *Parameter)
+	Wrapped        bool        // WRAPPED procedure body
+	WrappedSource  string      // raw text from WRAPPED through the wrapped payload
 	Body           StmtNode    // procedure body (PL/SQL block)
 	Loc            Loc         // start location
 }

--- a/oracle/parse_test.go
+++ b/oracle/parse_test.go
@@ -48,6 +48,35 @@ func TestParseSplitScript(t *testing.T) {
 	}
 }
 
+func TestParseWrappedProcedure(t *testing.T) {
+	sql := "CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\n" +
+		"a000000\n" +
+		"abcd\n" +
+		"/\n" +
+		"SELECT 1 FROM dual;"
+
+	stmts, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("got %d statements, want 2", len(stmts))
+	}
+	if stmts[0].Text != "CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\na000000\nabcd" {
+		t.Fatalf("stmt[0].Text = %q", stmts[0].Text)
+	}
+	proc, ok := stmts[0].AST.(*ast.CreateProcedureStmt)
+	if !ok {
+		t.Fatalf("stmt[0].AST = %T, want CreateProcedureStmt", stmts[0].AST)
+	}
+	if !proc.Wrapped {
+		t.Fatal("stmt[0].AST.Wrapped = false, want true")
+	}
+	if proc.Body != nil {
+		t.Fatalf("stmt[0].AST.Body = %T, want nil", proc.Body)
+	}
+}
+
 func TestParseReturnsErrorForSQLPlusCommands(t *testing.T) {
 	sql := "SET DEFINE OFF\n" +
 		"PROMPT setup\n" +

--- a/oracle/parser/create_proc.go
+++ b/oracle/parser/create_proc.go
@@ -66,6 +66,10 @@ func (p *Parser) parseCreateProcedureStmt(start int, orReplace, ifNotExists, edi
 		return nil, parseErr456
 	}
 
+	if p.isIdentLikeStr("WRAPPED") {
+		return p.parseWrappedProcedure(stmt)
+	}
+
 	if p.cur.Type != kwIS && p.cur.Type != kwAS {
 		return nil, p.syntaxErrorAtCur()
 	}
@@ -78,6 +82,28 @@ func (p *Parser) parseCreateProcedureStmt(start int, orReplace, ifNotExists, edi
 	}
 
 	stmt.Loc.End = p.prev.End
+	return stmt, nil
+}
+
+func (p *Parser) parseWrappedProcedure(stmt *nodes.CreateProcedureStmt) (*nodes.CreateProcedureStmt, error) {
+	wrappedStart := p.cur.Loc
+	stmt.Wrapped = true
+
+	p.advance() // consume WRAPPED
+	if p.cur.Type == ';' || p.cur.Type == tokEOF {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	wrappedEnd := p.prev.End
+	for p.cur.Type != ';' && p.cur.Type != tokEOF {
+		wrappedEnd = p.cur.End
+		p.advance()
+	}
+
+	if wrappedStart >= 0 && wrappedEnd <= len(p.source) && wrappedStart < wrappedEnd {
+		stmt.WrappedSource = p.source[wrappedStart:wrappedEnd]
+	}
+	stmt.Loc.End = wrappedEnd
 	return stmt, nil
 }
 

--- a/oracle/parser/create_proc_test.go
+++ b/oracle/parser/create_proc_test.go
@@ -64,6 +64,48 @@ func TestParseCreateOrReplaceProcedure(t *testing.T) {
 	}
 }
 
+func TestParseCreateWrappedProcedure(t *testing.T) {
+	sql := "CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\n" +
+		"a000000\n" +
+		"abcd\n"
+	result, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 statement, got %d", result.Len())
+	}
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt, ok := raw.Stmt.(*ast.CreateProcedureStmt)
+	if !ok {
+		t.Fatalf("expected CreateProcedureStmt, got %T", raw.Stmt)
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace to be true")
+	}
+	if stmt.Name == nil || stmt.Name.Name != "WRAPPED_PROC" {
+		t.Errorf("expected name WRAPPED_PROC, got %v", stmt.Name)
+	}
+	if !stmt.Wrapped {
+		t.Error("expected Wrapped to be true")
+	}
+	if stmt.WrappedSource != "WRAPPED\na000000\nabcd" {
+		t.Fatalf("expected wrapped source to preserve raw payload, got %q", stmt.WrappedSource)
+	}
+	if stmt.Body != nil {
+		t.Fatalf("expected nil body for wrapped procedure, got %T", stmt.Body)
+	}
+}
+
+func TestParseCreateWrappedProcedureWithSemicolon(t *testing.T) {
+	result := ParseAndCheck(t, "CREATE PROCEDURE wrapped_proc WRAPPED\na000000\nabcd;")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.CreateProcedureStmt)
+	if !stmt.Wrapped {
+		t.Fatal("expected Wrapped to be true")
+	}
+}
+
 func TestParseCreateProcedureAuthID(t *testing.T) {
 	sql := `CREATE PROCEDURE my_proc AUTHID CURRENT_USER IS BEGIN NULL; END;`
 	result, err := Parse(sql)

--- a/oracle/parser/split.go
+++ b/oracle/parser/split.go
@@ -322,7 +322,7 @@ func (s *splitState) observePLSQL(tok Token) {
 	if len(s.frames) == 1 && !top.bodyStarted {
 		switch top.kind {
 		case splitPLSQLStoredUnit:
-			if tok.Str == "LANGUAGE" || tok.Str == "EXTERNAL" {
+			if tok.Str == "LANGUAGE" || tok.Str == "EXTERNAL" || tok.Str == "WRAPPED" {
 				s.callSpecStarted = true
 			}
 		case splitPLSQLTrigger:

--- a/oracle/parser/split_test.go
+++ b/oracle/parser/split_test.go
@@ -173,6 +173,29 @@ func TestSplitPLSQLBlocks(t *testing.T) {
 			},
 		},
 		{
+			name: "wrapped procedure with slash separator",
+			sql: "CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\n" +
+				"a000000\n" +
+				"abcd\n" +
+				"/\n" +
+				"CREATE TABLE t (id NUMBER);",
+			want: []string{
+				"CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\na000000\nabcd",
+				"\nCREATE TABLE t (id NUMBER)",
+			},
+		},
+		{
+			name: "wrapped procedure with semicolon separator",
+			sql: "CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\n" +
+				"a000000\n" +
+				"abcd;\n" +
+				"CREATE TABLE t (id NUMBER);",
+			want: []string{
+				"CREATE OR REPLACE PROCEDURE wrapped_proc WRAPPED\na000000\nabcd",
+				"\nCREATE TABLE t (id NUMBER)",
+			},
+		},
+		{
 			name: "create function with declarations without slash separator",
 			sql: "CREATE FUNCTION calc_bonus(p_start_date DATE)\n" +
 				"RETURN DATE\n" +


### PR DESCRIPTION
## Summary
- accept CREATE PROCEDURE ... WRAPPED without parsing the wrapped payload as a PL/SQL block
- expose wrapped procedure metadata on CreateProcedureStmt while preserving raw wrapped source
- add parser, splitter, and public oracle.Parse regression coverage

## Test Plan
- go test ./oracle/... -count=1