### PR TITLE
fix(oracle): treat wrapped procedure payload as opaque

### DIFF
--- a/oracle/parse_test.go
+++ b/oracle/parse_test.go
@@ -77,6 +77,34 @@ func TestParseWrappedProcedure(t *testing.T) {
 	}
 }
 
+func TestParseWrappedProcedureWithOperatorPayload(t *testing.T) {
+	sql := "CREATE OR REPLACE procedure\n" +
+		"--++WRAP_VERSION:1\n" +
+		"         wrapped_proc wrapped\n" +
+		"a000000\n" +
+		"abc=\n" +
+		"/\n" +
+		"SELECT 1 FROM dual;"
+
+	stmts, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("got %d statements, want 2", len(stmts))
+	}
+	proc, ok := stmts[0].AST.(*ast.CreateProcedureStmt)
+	if !ok {
+		t.Fatalf("stmt[0].AST = %T, want CreateProcedureStmt", stmts[0].AST)
+	}
+	if !proc.Wrapped {
+		t.Fatal("stmt[0].AST.Wrapped = false, want true")
+	}
+	if proc.Body != nil {
+		t.Fatalf("stmt[0].AST.Body = %T, want nil", proc.Body)
+	}
+}
+
 func TestParseReturnsErrorForSQLPlusCommands(t *testing.T) {
 	sql := "SET DEFINE OFF\n" +
 		"PROMPT setup\n" +

--- a/oracle/parser/create_proc.go
+++ b/oracle/parser/create_proc.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	nodes "github.com/bytebase/omni/oracle/ast"
 )
 
@@ -86,24 +88,32 @@ func (p *Parser) parseCreateProcedureStmt(start int, orReplace, ifNotExists, edi
 }
 
 func (p *Parser) parseWrappedProcedure(stmt *nodes.CreateProcedureStmt) (*nodes.CreateProcedureStmt, error) {
+	wrappedTok := p.cur
 	wrappedStart := p.cur.Loc
 	stmt.Wrapped = true
 
-	p.advance() // consume WRAPPED
-	if p.cur.Type == ';' || p.cur.Type == tokEOF {
+	wrappedEnd := len(p.source)
+	if idx := strings.IndexByte(p.source[wrappedTok.End:], ';'); idx >= 0 {
+		wrappedEnd = wrappedTok.End + idx
+	}
+	wrappedSourceEnd := trimRightSpace(p.source, wrappedEnd)
+	if strings.TrimSpace(p.source[wrappedTok.End:wrappedSourceEnd]) == "" {
 		return nil, p.syntaxErrorAtCur()
 	}
 
-	wrappedEnd := p.prev.End
-	for p.cur.Type != ';' && p.cur.Type != tokEOF {
-		wrappedEnd = p.cur.End
-		p.advance()
+	if wrappedStart >= 0 && wrappedSourceEnd <= len(p.source) && wrappedStart < wrappedSourceEnd {
+		stmt.WrappedSource = p.source[wrappedStart:wrappedSourceEnd]
 	}
-
-	if wrappedStart >= 0 && wrappedEnd <= len(p.source) && wrappedStart < wrappedEnd {
-		stmt.WrappedSource = p.source[wrappedStart:wrappedEnd]
+	stmt.Loc.End = wrappedSourceEnd
+	p.prev = Token{Type: tokIDENT, Str: "WRAPPED", Loc: wrappedStart, End: wrappedSourceEnd}
+	p.hasNext = false
+	if wrappedEnd < len(p.source) && p.source[wrappedEnd] == ';' {
+		p.cur = Token{Type: ';', Str: ";", Loc: wrappedEnd, End: wrappedEnd + 1}
+		p.lexer.pos = wrappedEnd + 1
+	} else {
+		p.cur = Token{Type: tokEOF, Loc: wrappedEnd, End: wrappedEnd}
+		p.lexer.pos = wrappedEnd
 	}
-	stmt.Loc.End = wrappedEnd
 	return stmt, nil
 }
 

--- a/oracle/parser/create_proc_test.go
+++ b/oracle/parser/create_proc_test.go
@@ -97,6 +97,30 @@ func TestParseCreateWrappedProcedure(t *testing.T) {
 	}
 }
 
+func TestParseCreateWrappedProcedureWithOperatorPayload(t *testing.T) {
+	result := ParseAndCheck(t, "CREATE PROCEDURE wrapped_proc WRAPPED\na000000\nabc=\n")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.CreateProcedureStmt)
+	if !stmt.Wrapped {
+		t.Fatal("expected Wrapped to be true")
+	}
+	if stmt.WrappedSource != "WRAPPED\na000000\nabc=" {
+		t.Fatalf("expected wrapped source to preserve opaque payload, got %q", stmt.WrappedSource)
+	}
+}
+
+func TestParseCreateWrappedProcedureWithCommentBeforeName(t *testing.T) {
+	result := ParseAndCheck(t, "CREATE OR REPLACE PROCEDURE\n--++WRAP_VERSION:1\n  wrapped_proc wrapped\na000000\nabc=\n")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.CreateProcedureStmt)
+	if stmt.Name == nil || stmt.Name.Name != "WRAPPED_PROC" {
+		t.Fatalf("expected name WRAPPED_PROC, got %v", stmt.Name)
+	}
+	if !stmt.Wrapped {
+		t.Fatal("expected Wrapped to be true")
+	}
+}
+
 func TestParseCreateWrappedProcedureWithSemicolon(t *testing.T) {
 	result := ParseAndCheck(t, "CREATE PROCEDURE wrapped_proc WRAPPED\na000000\nabcd;")
 	raw := result.Items[0].(*ast.RawStmt)


### PR DESCRIPTION
## Summary
- avoid lexing Oracle wrapped procedure payload as normal SQL tokens
- preserve wrapped source while keeping parser state at the statement boundary
- add regressions for wrapped payloads ending in operator-like characters and wrapped procedure headers with comments before the object name

## Context
Follow-up to #254. The merged fix recognized the WRAPPED header, but the parser still lexed the opaque payload; payloads ending in operator-like characters could trip the generic EOF incomplete-statement guard.

## Test Plan
- go test ./oracle/... -count=1
- local-only check against bb_export_2 Oracle wrapped segments (data not committed)