### PR TITLE
feat(snowflake): T4.8 CREATE / ALTER FAILOVER GROUP / REPLICATION GROUP / ACCOUNT / SHARE

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -119,6 +119,15 @@ const (
 	T_CreateIntegrationStmt
 	T_AlterIntegrationStmt
 
+	// Replication & sharing DDL tags (T4.8)
+	T_GroupOption
+	T_CreateReplicationGroupStmt
+	T_AlterReplicationGroupStmt
+	T_CreateAccountStmt
+	T_AlterAccountStmt
+	T_CreateShareStmt
+	T_AlterShareStmt
+
 	// Data-pipeline DDL tags (T4.3)
 	T_CreatePipeStmt
 	T_AlterPipeStmt
@@ -335,6 +344,20 @@ func (t NodeTag) String() string {
 		return "CreateIntegrationStmt"
 	case T_AlterIntegrationStmt:
 		return "AlterIntegrationStmt"
+	case T_GroupOption:
+		return "GroupOption"
+	case T_CreateReplicationGroupStmt:
+		return "CreateReplicationGroupStmt"
+	case T_AlterReplicationGroupStmt:
+		return "AlterReplicationGroupStmt"
+	case T_CreateAccountStmt:
+		return "CreateAccountStmt"
+	case T_AlterAccountStmt:
+		return "AlterAccountStmt"
+	case T_CreateShareStmt:
+		return "CreateShareStmt"
+	case T_AlterShareStmt:
+		return "AlterShareStmt"
 	case T_CreateRoutineStmt:
 		return "CreateRoutineStmt"
 	case T_AlterRoutineStmt:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -2996,6 +2996,304 @@ var (
 )
 
 // ---------------------------------------------------------------------------
+// Replication & sharing DDL — CREATE / ALTER FAILOVER GROUP / REPLICATION GROUP
+// / ACCOUNT / SHARE (T4.8)
+// ---------------------------------------------------------------------------
+//
+// These account-level objects drive Snowflake's replication and data-sharing
+// features. They share a distinctive option shape with the rest of this engine's
+// account-level DDL — large, version-growing `KEY = <value>` vocabularies — but
+// with one structural twist the COPY/STAGE option machinery does not cover: the
+// replication/sharing list parameters (OBJECT_TYPES, ALLOWED_DATABASES,
+// ALLOWED_SHARES, ALLOWED_INTEGRATION_TYPES, ALLOWED_ACCOUNTS, ...) are
+// UNPARENTHESIZED comma lists whose elements are multi-word object-type names
+// (e.g. `ACCOUNT PARAMETERS`, `RESOURCE MONITORS`, `NETWORK POLICIES`) or dotted
+// account names (`org.account`). Both the official docs (truth1) and the legacy
+// ANTLR grammar (truth2) agree on the no-parentheses form — the COPY-style
+// `KEY = ( a, b )` reader is therefore NOT reused for them. They are captured as
+// GroupOption (a `KEY = <value-list | literal>` pair). Scalar options
+// (REPLICATION_SCHEDULE = '...', OPTIMIZED_REFRESH = TRUE, ERROR_INTEGRATION =
+// <name>, ...) reuse the same GroupOption type. Only the structural anchors are
+// modeled as dedicated fields: the object discriminator (FAILOVER vs REPLICATION
+// GROUP, MANAGED ACCOUNT), the [WITH] TAG clause, the AS REPLICA OF secondary
+// form, and (on ALTER) the action keyword plus its operands (ADD/REMOVE/MOVE
+// name lists, the ALLOWED_* list target, the MOVE-TO group, RENAME's new name,
+// the account-policy forms, etc.). Per this engine's parse-permissively
+// philosophy the parser accepts the open-ended combination and the
+// catalog/semantic layer validates legality (mutually-exclusive OR REPLACE / IF
+// NOT EXISTS, which options are real for the chosen object, and so on).
+
+// GroupOption is a single `KEY = <value>` parameter of a replication/sharing
+// statement. The value is one of:
+//   - Values: an unparenthesized comma list of items, each a verbatim,
+//     uppercased multi-word token run (OBJECT_TYPES = DATABASES, ROLES;
+//     ALLOWED_DATABASES = db1, db2; ALLOWED_ACCOUNTS = org.acct1, org.acct2) or
+//     a single bareword/identifier value (OPTIMIZED_REFRESH = TRUE,
+//     ERROR_INTEGRATION = my_int, EDITION = STANDARD, ADMIN_NAME = admin).
+//   - Lit: a string or numeric literal (REPLICATION_SCHEDULE = '10 MINUTE',
+//     ADMIN_PASSWORD = 'secret', EMAIL = 'a@b.com').
+//
+// Exactly one of Values / Lit is set. Name is the uppercased option name.
+type GroupOption struct {
+	Name   string   // uppercased option name (e.g. "OBJECT_TYPES", "REPLICATION_SCHEDULE")
+	Values []string // unparenthesized comma-list of verbatim uppercased items; nil when Lit is set
+	Lit    *Literal // a string/number literal value; nil when Values is set
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *GroupOption) Tag() NodeTag { return T_GroupOption }
+
+// ReplicationGroupKind discriminates a FAILOVER GROUP from a REPLICATION GROUP.
+// The two objects share a near-identical CREATE/ALTER grammar (the docs differ
+// only in a handful of options), so they share AST node types and are told apart
+// by this flag.
+type ReplicationGroupKind int
+
+const (
+	ReplicationGroup ReplicationGroupKind = iota // REPLICATION GROUP
+	FailoverGroup                                // FAILOVER GROUP
+)
+
+// String returns the SQL keyword(s) for the kind (uppercased).
+func (k ReplicationGroupKind) String() string {
+	if k == FailoverGroup {
+		return "FAILOVER GROUP"
+	}
+	return "REPLICATION GROUP"
+}
+
+// CreateReplicationGroupStmt represents the CREATE form of a FAILOVER GROUP or
+// REPLICATION GROUP (Failover discriminates):
+//
+//	CREATE [ OR REPLACE ] { FAILOVER | REPLICATION } GROUP [ IF NOT EXISTS ] <name>
+//	  OBJECT_TYPES = <object_type> [ , ... ]
+//	  [ ALLOWED_DATABASES = <db_name> [ , ... ] ]
+//	  [ ALLOWED_EXTERNAL_VOLUMES = <ev_name> [ , ... ] ]
+//	  [ ALLOWED_SHARES = <share_name> [ , ... ] ]
+//	  [ ALLOWED_INTEGRATION_TYPES = <integration_type_name> [ , ... ] ]
+//	  ALLOWED_ACCOUNTS = <org>.<account> [ , ... ]
+//	  [ IGNORE EDITION CHECK ]
+//	  [ REPLICATION_SCHEDULE = '...' ] [ OPTIMIZED_REFRESH = { TRUE | FALSE } ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//	  [ ERROR_INTEGRATION = <integration_name> ]
+//
+//	-- secondary form:
+//	CREATE [ OR REPLACE ] { FAILOVER | REPLICATION } GROUP [ IF NOT EXISTS ] <name>
+//	  AS REPLICA OF <org>.<source_account>.<name>
+//
+// All configuration parameters are captured open-ended in Options, source order.
+// IgnoreEditionCheck records the bare `IGNORE EDITION CHECK` flag, Tags the
+// [WITH] TAG clause, and Replica the AS REPLICA OF secondary-form source (a
+// dotted ObjectName); when Replica is set the primary-form fields are empty.
+type CreateReplicationGroupStmt struct {
+	Failover           bool
+	OrReplace          bool
+	IfNotExists        bool
+	Name               *ObjectName
+	Options            []*GroupOption   // open-ended KEY = value parameters, source order
+	IgnoreEditionCheck bool             // bare IGNORE EDITION CHECK flag
+	Tags               []*TagAssignment // [WITH] TAG (...); nil if absent
+	Replica            *ObjectName      // AS REPLICA OF <org>.<account>.<name>; nil for primary form
+	Loc                Loc
+}
+
+// Tag implements Node.
+func (n *CreateReplicationGroupStmt) Tag() NodeTag { return T_CreateReplicationGroupStmt }
+
+// AlterGroupAction discriminates the action variants of ALTER FAILOVER GROUP /
+// REPLICATION GROUP.
+type AlterGroupAction int
+
+const (
+	AlterGroupRename   AlterGroupAction = iota // RENAME TO <new_name>
+	AlterGroupSet                              // SET <options>
+	AlterGroupUnset                            // UNSET <property> [ , ... ]
+	AlterGroupSetTag                           // SET TAG <tag> = '<value>' [ , ... ]
+	AlterGroupUnsetTag                         // UNSET TAG <tag> [ , ... ]
+	AlterGroupAdd                              // ADD <name-list> TO ALLOWED_{DATABASES|SHARES|ACCOUNTS} [ IGNORE EDITION CHECK ]
+	AlterGroupRemove                           // REMOVE <name-list> FROM ALLOWED_{DATABASES|SHARES|ACCOUNTS}
+	AlterGroupMove                             // MOVE { DATABASES | SHARES } <name-list> TO { FAILOVER | REPLICATION } GROUP <name>
+	AlterGroupRefresh                          // REFRESH
+	AlterGroupPrimary                          // PRIMARY (FAILOVER GROUP only)
+	AlterGroupSuspend                          // SUSPEND [ IMMEDIATE ]
+	AlterGroupResume                           // RESUME
+)
+
+// AlterReplicationGroupStmt represents the ALTER form of a FAILOVER GROUP or
+// REPLICATION GROUP (Failover discriminates). The legal action set depends on
+// the kind (validated by the semantic layer, not here):
+//
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> RENAME TO <new_name>
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> SET <options>
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> UNSET <property> [ , ... ]
+//	ALTER { FAILOVER | REPLICATION } GROUP <name> { SET | UNSET } TAG ...
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> ADD <name-list> TO ALLOWED_{DATABASES|SHARES|ACCOUNTS} [ IGNORE EDITION CHECK ]
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> MOVE { DATABASES | SHARES } <name-list> TO { FAILOVER | REPLICATION } GROUP <name>
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> REMOVE <name-list> FROM ALLOWED_{DATABASES|SHARES|ACCOUNTS}
+//	ALTER { FAILOVER | REPLICATION } GROUP [ IF EXISTS ] <name> { REFRESH | PRIMARY | SUSPEND [ IMMEDIATE ] | RESUME }
+type AlterReplicationGroupStmt struct {
+	Failover           bool
+	IfExists           bool
+	Name               *ObjectName
+	Action             AlterGroupAction
+	NewName            *ObjectName      // RENAME TO; for AlterGroupRename
+	Options            []*GroupOption   // SET <options>; for AlterGroupSet
+	Tags               []*TagAssignment // SET TAG assignments; for AlterGroupSetTag
+	UnsetTags          []*ObjectName    // UNSET TAG names; for AlterGroupUnsetTag
+	UnsetProps         []string         // UNSET <property> names; for AlterGroupUnset
+	Names              []*ObjectName    // ADD/MOVE/REMOVE name list (databases / shares / org.account)
+	ListTarget         string           // ALLOWED_DATABASES / ALLOWED_SHARES / ALLOWED_ACCOUNTS (ADD/REMOVE) — uppercased
+	MoveKind           string           // MOVE DATABASES | SHARES — uppercased; for AlterGroupMove
+	MoveTo             *ObjectName      // MOVE ... TO { FAILOVER | REPLICATION } GROUP <name>; for AlterGroupMove
+	IgnoreEditionCheck bool             // ADD ... TO ALLOWED_ACCOUNTS IGNORE EDITION CHECK
+	Immediate          bool             // SUSPEND IMMEDIATE
+	Loc                Loc
+}
+
+// Tag implements Node.
+func (n *AlterReplicationGroupStmt) Tag() NodeTag { return T_AlterReplicationGroupStmt }
+
+// CreateAccountStmt represents
+//
+//	CREATE ACCOUNT <name> ADMIN_NAME = '...' { ADMIN_PASSWORD = '...' | ADMIN_RSA_PUBLIC_KEY = '...' }
+//	  [ ADMIN_USER_TYPE = ... ] [ FIRST_NAME = '...' ] [ LAST_NAME = '...' ]
+//	  EMAIL = '...' [ MUST_CHANGE_PASSWORD = { TRUE | FALSE } ]
+//	  EDITION = { STANDARD | ENTERPRISE | BUSINESS_CRITICAL }
+//	  [ REGION_GROUP = <id> ] [ REGION = <id> ] [ COMMENT = '...' ] [ POLARIS = { TRUE | FALSE } ]
+//
+//	CREATE [ OR REPLACE ] MANAGED ACCOUNT <name>
+//	  ADMIN_NAME = <username>, ADMIN_PASSWORD = <password>, TYPE = READER [ , COMMENT = '...' ]
+//
+// Managed discriminates the MANAGED ACCOUNT form. Every parameter is captured
+// open-ended in Options (source order); CREATE ACCOUNT separates them with
+// whitespace, CREATE MANAGED ACCOUNT with commas (the parser tolerates both).
+type CreateAccountStmt struct {
+	Managed   bool
+	OrReplace bool // only MANAGED ACCOUNT accepts OR REPLACE per the docs
+	Name      *ObjectName
+	Options   []*GroupOption // ADMIN_NAME / ADMIN_PASSWORD / EMAIL / EDITION / TYPE / COMMENT / ...
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *CreateAccountStmt) Tag() NodeTag { return T_CreateAccountStmt }
+
+// AlterAccountAction discriminates the action variants of ALTER ACCOUNT.
+type AlterAccountAction int
+
+const (
+	AlterAccountSet         AlterAccountAction = iota // SET <param> = <value> [ , ... ] / SET RESOURCE_MONITOR = <name>
+	AlterAccountUnset                                 // UNSET <param> [ , ... ]
+	AlterAccountSetTag                                // SET TAG <tag> = '<value>' [ , ... ]
+	AlterAccountUnsetTag                              // UNSET TAG <tag> [ , ... ]
+	AlterAccountSetPolicy                             // SET { <policy_kind> } POLICY <name> [ <scope> ] [ FORCE ]
+	AlterAccountUnsetPolicy                           // UNSET { <policy_kind> } POLICY [ <scope> ]
+	AlterAccountRename                                // <name> RENAME TO <new_name> [ SAVE_OLD_URL = ... ]
+	AlterAccountDropURL                               // <name> DROP OLD [ ORGANIZATION ] URL
+)
+
+// AlterAccountStmt represents ALTER ACCOUNT. The current-account forms omit the
+// name (Name is nil); the cross-account forms (org admins) carry a name:
+//
+//	ALTER ACCOUNT SET <param> = <value> [ , ... ]
+//	ALTER ACCOUNT SET RESOURCE_MONITOR = <monitor_name>
+//	ALTER ACCOUNT UNSET <param> [ , ... ]
+//	ALTER ACCOUNT SET TAG <tag> = '<value>' [ , ... ]   |   UNSET TAG <tag> [ , ... ]
+//	ALTER ACCOUNT SET { AUTHENTICATION | SESSION } POLICY <name> [ FOR ALL { PERSON | SERVICE } USERS ] [ FORCE ]
+//	ALTER ACCOUNT SET { PACKAGES | PASSWORD } POLICY <name> [ FORCE ]
+//	ALTER ACCOUNT SET FEATURE POLICY <name> FOR ALL APPLICATIONS [ FORCE ]
+//	ALTER ACCOUNT UNSET { <policy_kind> } POLICY [ <scope> ]
+//	ALTER ACCOUNT <name> SET EDITION = ... | SET IS_ORG_ADMIN = ...
+//	ALTER ACCOUNT <name> RENAME TO <new_name> [ SAVE_OLD_URL = { TRUE | FALSE } ]
+//	ALTER ACCOUNT <name> DROP OLD [ ORGANIZATION ] URL
+type AlterAccountStmt struct {
+	Name         *ObjectName // nil for the current-account forms; set for the cross-account forms
+	Action       AlterAccountAction
+	Options      []*GroupOption   // SET <param> = value list; for AlterAccountSet
+	Tags         []*TagAssignment // SET TAG assignments; for AlterAccountSetTag
+	UnsetTags    []*ObjectName    // UNSET TAG names; for AlterAccountUnsetTag
+	UnsetProps   []string         // UNSET <property> names; for AlterAccountUnset
+	PolicyKind   string           // "{ AUTHENTICATION | SESSION | PACKAGES | PASSWORD | FEATURE } POLICY"; for Set/UnsetPolicy — uppercased
+	PolicyName   *ObjectName      // the policy name; for AlterAccountSetPolicy
+	PolicyScope  string           // the trailing FOR ALL ... clause, verbatim uppercased; "" if absent
+	Force        bool             // trailing FORCE; for AlterAccountSetPolicy
+	NewName      *ObjectName      // RENAME TO; for AlterAccountRename
+	SaveOldURL   *bool            // RENAME ... SAVE_OLD_URL = { TRUE | FALSE }; nil if absent
+	Organization bool             // DROP OLD ORGANIZATION URL (vs DROP OLD URL); for AlterAccountDropURL
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *AlterAccountStmt) Tag() NodeTag { return T_AlterAccountStmt }
+
+// CreateShareStmt represents
+//
+//	CREATE [ OR REPLACE ] SHARE [ IF NOT EXISTS ] <name> [ COMMENT = '<string_literal>' ]
+//
+// COMMENT (the only documented parameter) is captured open-ended in Options.
+type CreateShareStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Options     []*GroupOption // COMMENT = '...'; nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateShareStmt) Tag() NodeTag { return T_CreateShareStmt }
+
+// AlterShareAction discriminates the action variants of ALTER SHARE.
+type AlterShareAction int
+
+const (
+	AlterShareAdd      AlterShareAction = iota // ADD ACCOUNTS = <a> [ , ... ] [ SHARE_RESTRICTIONS = ... ]
+	AlterShareRemove                           // REMOVE ACCOUNTS = <a> [ , ... ]
+	AlterShareSet                              // SET [ ACCOUNTS = <a> [ , ... ] ] [ COMMENT = '...' ]
+	AlterShareSetTag                           // SET TAG <tag> = '<value>' [ , ... ]
+	AlterShareUnsetTag                         // UNSET TAG <tag> [ , ... ]
+	AlterShareUnset                            // UNSET COMMENT
+)
+
+// AlterShareStmt represents
+//
+//	ALTER SHARE [ IF EXISTS ] <name> { ADD | REMOVE } ACCOUNTS = <a> [ , ... ] [ SHARE_RESTRICTIONS = { TRUE | FALSE } ]
+//	ALTER SHARE [ IF EXISTS ] <name> SET [ ACCOUNTS = <a> [ , ... ] ] [ COMMENT = '...' ]
+//	ALTER SHARE [ IF EXISTS ] <name> SET TAG <tag> = '<value>' [ , ... ]
+//	ALTER SHARE <name> UNSET TAG <tag> [ , ... ]
+//	ALTER SHARE [ IF EXISTS ] <name> UNSET COMMENT
+//
+// Accounts holds the consumer-account list (ADD/REMOVE/SET ACCOUNTS = ...);
+// ShareRestrictions records the optional SHARE_RESTRICTIONS flag; Options holds
+// the SET COMMENT param; UnsetProps holds the UNSET property names.
+type AlterShareStmt struct {
+	IfExists          bool
+	Name              *ObjectName
+	Action            AlterShareAction
+	Accounts          []*ObjectName    // ACCOUNTS = <a> [ , ... ]; for Add/Remove/Set
+	ShareRestrictions *bool            // SHARE_RESTRICTIONS = { TRUE | FALSE }; nil if absent
+	Options           []*GroupOption   // SET COMMENT = '...'; nil if absent
+	Tags              []*TagAssignment // SET TAG assignments; for AlterShareSetTag
+	UnsetTags         []*ObjectName    // UNSET TAG names; for AlterShareUnsetTag
+	UnsetProps        []string         // UNSET <property> names (e.g. COMMENT); for AlterShareUnset
+	Loc               Loc
+}
+
+// Tag implements Node.
+func (n *AlterShareStmt) Tag() NodeTag { return T_AlterShareStmt }
+
+// Compile-time assertions for replication & sharing DDL nodes.
+var (
+	_ Node = (*GroupOption)(nil)
+	_ Node = (*CreateReplicationGroupStmt)(nil)
+	_ Node = (*AlterReplicationGroupStmt)(nil)
+	_ Node = (*CreateAccountStmt)(nil)
+	_ Node = (*AlterAccountStmt)(nil)
+	_ Node = (*CreateShareStmt)(nil)
+	_ Node = (*AlterShareStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
 // Data-pipeline DDL — CREATE / ALTER PIPE / STREAM / TASK / ALERT (T4.3)
 // ---------------------------------------------------------------------------
 //

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -9,6 +9,16 @@ func walkChildren(v Visitor, node Node) {
 	case *AccessExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.Index)
+	case *AlterAccountStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.PolicyName != nil {
+			Walk(v, n.PolicyName)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterAlertStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -65,6 +75,16 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.NewName)
 		}
 		Walk(v, n.Body)
+	case *AlterReplicationGroupStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
+		if n.MoveTo != nil {
+			Walk(v, n.MoveTo)
+		}
 	case *AlterRoleStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -92,6 +112,10 @@ func walkChildren(v Visitor, node Node) {
 		}
 		if n.NewName != nil {
 			Walk(v, n.NewName)
+		}
+	case *AlterShareStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
 		}
 	case *AlterStageStmt:
 		if n.Name != nil {
@@ -196,6 +220,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.Lit != nil {
 			Walk(v, n.Lit)
 		}
+	case *CreateAccountStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreateAlertStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -258,6 +286,13 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Returns)
 		}
 		Walk(v, n.Body)
+	case *CreateReplicationGroupStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.Replica != nil {
+			Walk(v, n.Replica)
+		}
 	case *CreateRoleStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -274,6 +309,10 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Name)
 		}
 	case *CreateSequenceStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+	case *CreateShareStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
@@ -381,6 +420,10 @@ func walkChildren(v Visitor, node Node) {
 	case *Grantee:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+	case *GroupOption:
+		if n.Lit != nil {
+			Walk(v, n.Lit)
 		}
 	case *IffExpr:
 		Walk(v, n.Cond)

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -178,6 +178,17 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// SECRET, CONNECTION, GIT REPOSITORY. parseCreateIntegrationStmt consumes the
 		// object-type keyword(s).
 		return p.parseCreateIntegrationStmt(start, orReplace)
+	case kwFAILOVER, kwREPLICATION:
+		// CREATE [OR REPLACE] { FAILOVER | REPLICATION } GROUP ... (T4.8).
+		// parseCreateReplicationGroupStmt consumes the kind keyword + GROUP.
+		return p.parseCreateReplicationGroupStmt(start, orReplace)
+	case kwACCOUNT, kwMANAGED:
+		// CREATE ACCOUNT / CREATE [OR REPLACE] MANAGED ACCOUNT ... (T4.8).
+		// parseCreateAccountStmt consumes the (MANAGED) ACCOUNT keyword(s).
+		return p.parseCreateAccountStmt(start, orReplace)
+	case kwSHARE:
+		// CREATE [OR REPLACE] SHARE ... (T4.8).
+		return p.parseCreateShareStmt(start, orReplace)
 	case kwROLE:
 		// CREATE [OR REPLACE] ROLE ... (T4.6). DATABASE ROLE is dispatched by the
 		// kwDATABASE case above.

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -228,6 +228,16 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// CONNECTION, GIT REPOSITORY. A bare ALTER INTEGRATION (qualifier omitted)
 		// dispatches here too. parseAlterIntegrationStmt consumes the keyword(s).
 		return p.parseAlterIntegrationStmt()
+	case kwFAILOVER, kwREPLICATION:
+		// ALTER { FAILOVER | REPLICATION } GROUP ... (T4.8). The sub-parser consumes
+		// the kind keyword + GROUP.
+		return p.parseAlterReplicationGroupStmt()
+	case kwACCOUNT:
+		// ALTER ACCOUNT ... (T4.8). The sub-parser consumes ACCOUNT.
+		return p.parseAlterAccountStmt()
+	case kwSHARE:
+		// ALTER SHARE ... (T4.8).
+		return p.parseAlterShareStmt()
 	case kwROLE:
 		// ALTER ROLE ... (T4.6). DATABASE ROLE is dispatched by the kwDATABASE case.
 		return p.parseAlterRoleStmt(false)

--- a/snowflake/parser/replication_share.go
+++ b/snowflake/parser/replication_share.go
@@ -1,0 +1,1138 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Replication & sharing DDL — CREATE / ALTER FAILOVER GROUP / REPLICATION GROUP
+// / ACCOUNT / SHARE (T4.8)
+// ---------------------------------------------------------------------------
+//
+// These account-level objects drive Snowflake's replication and data-sharing
+// features. Like the rest of this engine's account-level DDL (STAGE T4.1, FILE
+// FORMAT T4.2, integrations T4.7) they carry large, version-growing
+// `KEY = <value>` option vocabularies. The distinctive twist — and the reason
+// the COPY/STAGE option machinery is NOT reused for them — is that the
+// replication/sharing list parameters (OBJECT_TYPES, ALLOWED_DATABASES,
+// ALLOWED_SHARES, ALLOWED_INTEGRATION_TYPES, ALLOWED_ACCOUNTS, ...) are
+// UNPARENTHESIZED comma lists of multi-word object-type names (`ACCOUNT
+// PARAMETERS`, `RESOURCE MONITORS`, `NETWORK POLICIES`) or dotted account names
+// (`org.account`). Both the official docs (truth1) and the legacy ANTLR grammar
+// (truth2) agree on the no-parentheses form (`OBJECT_TYPES = X, Y` not
+// `OBJECT_TYPES = (X, Y)`), so these are captured as ast.GroupOption (a
+// `KEY = <value-list | literal>` pair) rather than ast.CopyOption.
+//
+// Only structural anchors are modeled as dedicated fields: the object kind
+// (FAILOVER vs REPLICATION GROUP; MANAGED ACCOUNT), the [WITH] TAG clause, the
+// AS REPLICA OF secondary form, and (on ALTER) the action keyword plus its
+// operands (ADD/REMOVE/MOVE name lists, the ALLOWED_* target, the MOVE-TO group,
+// RENAME's new name, the account-policy forms, ...). The catalog/semantic layer,
+// not the parser, validates that an option is real and legal for the chosen
+// object (mirroring the merged integration / stage parsers).
+//
+// Scope notes (per the work order):
+//   - CREATE OR ALTER (a preview form) is owned by parser-or-alter; the shared
+//     OR-prefix parser recognizes only OR REPLACE, so OR ALTER never reaches
+//     here.
+//   - $N positional bind references inside option values are owned by
+//     expr-dollar-refs and are out of scope.
+
+// ---------------------------------------------------------------------------
+// CREATE FAILOVER GROUP / REPLICATION GROUP
+// ---------------------------------------------------------------------------
+
+// parseCreateReplicationGroupStmt parses the body of a CREATE statement for a
+// FAILOVER GROUP or a REPLICATION GROUP. The CREATE keyword and optional OR
+// REPLACE modifier have already been consumed by parseCreateStmt; start is the
+// Loc of the CREATE token, and cur is the FAILOVER or REPLICATION keyword (which
+// is followed by the GROUP keyword).
+//
+//	CREATE [ OR REPLACE ] { FAILOVER | REPLICATION } GROUP [ IF NOT EXISTS ] <name>
+//	  OBJECT_TYPES = <object_type> [ , ... ]  <list/scalar options...>
+//	  ALLOWED_ACCOUNTS = <org>.<account> [ , ... ]  [ IGNORE EDITION CHECK ]  ...
+//	  [ [ WITH ] TAG (...) ]
+//	CREATE [ OR REPLACE ] { FAILOVER | REPLICATION } GROUP [ IF NOT EXISTS ] <name>
+//	  AS REPLICA OF <org>.<source_account>.<name>
+func (p *Parser) parseCreateReplicationGroupStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	failover := p.cur.Type == kwFAILOVER
+	p.advance() // consume FAILOVER / REPLICATION
+	if _, err := p.expect(kwGROUP); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateReplicationGroupStmt{
+		Failover:  failover,
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Secondary form: AS REPLICA OF <org>.<account>.<name>.
+	if p.cur.Type == kwAS {
+		p.advance() // consume AS
+		if _, err := p.expect(kwREPLICA); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwOF); err != nil {
+			return nil, err
+		}
+		src, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Replica = src
+		stmt.Loc.End = p.prev.Loc.End
+		return stmt, nil
+	}
+
+	// Primary form: an open-ended run of list/scalar options, the bare IGNORE
+	// EDITION CHECK flag, and the trailing [WITH] TAG clause, in any order (so a
+	// REPLICATION_SCHEDULE that trails the TAG clause is not dropped — mirrors the
+	// STAGE / integration loops).
+	for {
+		if p.startsGroupTags() {
+			tags, err := p.parseStageWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+			continue
+		}
+		if p.cur.Type == kwIGNORE {
+			if err := p.parseIgnoreEditionCheck(); err != nil {
+				return nil, err
+			}
+			stmt.IgnoreEditionCheck = true
+			continue
+		}
+		if p.startsGroupOption() {
+			opt, err := p.parseGroupOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+			continue
+		}
+		break
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER FAILOVER GROUP / REPLICATION GROUP
+// ---------------------------------------------------------------------------
+
+// parseAlterReplicationGroupStmt parses the body of an ALTER statement for a
+// FAILOVER GROUP or REPLICATION GROUP. The ALTER keyword has already been
+// consumed; cur is the FAILOVER or REPLICATION keyword (followed by GROUP).
+func (p *Parser) parseAlterReplicationGroupStmt() (ast.Node, error) {
+	startLoc := p.cur.Loc // object keyword anchors Loc.Start (ALTER convention)
+	failover := p.cur.Type == kwFAILOVER
+	p.advance() // consume FAILOVER / REPLICATION
+	if _, err := p.expect(kwGROUP); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.AlterReplicationGroupStmt{Failover: failover, Loc: ast.Loc{Start: startLoc.Start}}
+
+	p.parseOptionalIfExists(&stmt.IfExists)
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO <new_name>
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterGroupRename
+		stmt.NewName = newName
+
+	case kwSET:
+		if err := p.parseAlterGroupSet(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwUNSET:
+		if err := p.parseAlterGroupUnset(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwADD:
+		// ADD <name-list> TO ALLOWED_{DATABASES|SHARES|ACCOUNTS} [ IGNORE EDITION CHECK ]
+		p.advance() // consume ADD
+		names, err := p.parseObjectNameList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		target, err := p.parseAllowedListKeyword()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterGroupAdd
+		stmt.Names = names
+		stmt.ListTarget = target
+		if p.cur.Type == kwIGNORE {
+			if err := p.parseIgnoreEditionCheck(); err != nil {
+				return nil, err
+			}
+			stmt.IgnoreEditionCheck = true
+		}
+
+	case kwREMOVE:
+		// REMOVE <name-list> FROM ALLOWED_{DATABASES|SHARES|ACCOUNTS}
+		p.advance() // consume REMOVE
+		names, err := p.parseObjectNameList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwFROM); err != nil {
+			return nil, err
+		}
+		target, err := p.parseAllowedListKeyword()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterGroupRemove
+		stmt.Names = names
+		stmt.ListTarget = target
+
+	case kwMOVE:
+		// MOVE { DATABASES | SHARES } <name-list> TO { FAILOVER | REPLICATION } GROUP <name>
+		p.advance() // consume MOVE
+		switch p.cur.Type {
+		case kwDATABASES:
+			p.advance()
+			stmt.MoveKind = "DATABASES"
+		case kwSHARES:
+			p.advance()
+			stmt.MoveKind = "SHARES"
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+		names, err := p.parseObjectNameList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		// TO { FAILOVER | REPLICATION } GROUP <name>.
+		switch p.cur.Type {
+		case kwFAILOVER, kwREPLICATION:
+			p.advance()
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+		if _, err := p.expect(kwGROUP); err != nil {
+			return nil, err
+		}
+		moveTo, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterGroupMove
+		stmt.Names = names
+		stmt.MoveTo = moveTo
+
+	case kwREFRESH:
+		p.advance() // consume REFRESH
+		stmt.Action = ast.AlterGroupRefresh
+
+	case kwPRIMARY:
+		p.advance() // consume PRIMARY
+		stmt.Action = ast.AlterGroupPrimary
+
+	case kwSUSPEND:
+		p.advance() // consume SUSPEND
+		stmt.Action = ast.AlterGroupSuspend
+		if p.cur.Type == kwIMMEDIATE {
+			p.advance() // consume IMMEDIATE
+			stmt.Immediate = true
+		}
+
+	case kwRESUME:
+		p.advance() // consume RESUME
+		stmt.Action = ast.AlterGroupResume
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterGroupSet parses the SET branch of ALTER FAILOVER/REPLICATION GROUP.
+// cur is the SET keyword.
+//
+//	SET TAG <tag> = '<value>' [ , ... ]   -> AlterGroupSetTag
+//	SET <options>                         -> AlterGroupSet
+func (p *Parser) parseAlterGroupSet(stmt *ast.AlterReplicationGroupStmt) error {
+	p.advance() // consume SET
+
+	if p.cur.Type == kwTAG {
+		tags, err := p.parseTagSetList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterGroupSetTag
+		stmt.Tags = tags
+		return nil
+	}
+
+	opts, err := p.parseGroupOptions()
+	if err != nil {
+		return err
+	}
+	if len(opts) == 0 {
+		// SET with nothing settable is a syntax error.
+		return p.syntaxErrorAtCur()
+	}
+	stmt.Action = ast.AlterGroupSet
+	stmt.Options = opts
+	return nil
+}
+
+// parseAlterGroupUnset parses the UNSET branch of ALTER FAILOVER/REPLICATION
+// GROUP. cur is the UNSET keyword.
+//
+//	UNSET TAG <tag> [ , ... ]    -> AlterGroupUnsetTag
+//	UNSET <property> [ , ... ]   -> AlterGroupUnset (e.g. COMMENT / REPLICATION_SCHEDULE)
+func (p *Parser) parseAlterGroupUnset(stmt *ast.AlterReplicationGroupStmt) error {
+	p.advance() // consume UNSET
+
+	if p.cur.Type == kwTAG {
+		names, err := p.parseUnsetTagNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterGroupUnsetTag
+		stmt.UnsetTags = names
+		return nil
+	}
+
+	props, err := p.parseStageUnsetProps()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterGroupUnset
+	stmt.UnsetProps = props
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE ACCOUNT / MANAGED ACCOUNT
+// ---------------------------------------------------------------------------
+
+// parseCreateAccountStmt parses CREATE ACCOUNT / CREATE [OR REPLACE] MANAGED
+// ACCOUNT. The CREATE keyword and optional OR REPLACE modifier have already been
+// consumed; start is the Loc of the CREATE token, and cur is either the ACCOUNT
+// keyword or the MANAGED keyword (followed by ACCOUNT).
+//
+//	CREATE ACCOUNT <name> ADMIN_NAME = ... <space-separated params...>
+//	CREATE [ OR REPLACE ] MANAGED ACCOUNT <name> ADMIN_NAME = ..., <comma-separated params...>
+func (p *Parser) parseCreateAccountStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	managed := p.cur.Type == kwMANAGED
+	if managed {
+		p.advance() // consume MANAGED
+	}
+	if _, err := p.expect(kwACCOUNT); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateAccountStmt{
+		Managed:   managed,
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// The parameter list is an open-ended run of `KEY = value` pairs. CREATE
+	// ACCOUNT separates them with whitespace; CREATE MANAGED ACCOUNT separates
+	// them with commas. parseGroupOptions tolerates both (it consumes an optional
+	// comma between options).
+	opts, err := p.parseGroupOptions()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Options = opts
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER ACCOUNT
+// ---------------------------------------------------------------------------
+
+// parseAlterAccountStmt parses ALTER ACCOUNT. The ALTER keyword has already been
+// consumed; cur is the ACCOUNT keyword. The current-account forms omit the name
+// (Name stays nil); the cross-account forms (org admins) carry a name. The
+// disambiguation is structural: if the token after ACCOUNT is SET or UNSET, it
+// is a current-account form; otherwise it is a name followed by an action.
+//
+//	ALTER ACCOUNT SET <param> = <value> [ , ... ]   |   SET RESOURCE_MONITOR = <name>
+//	ALTER ACCOUNT UNSET <param> [ , ... ]
+//	ALTER ACCOUNT SET TAG ...   |   UNSET TAG ...
+//	ALTER ACCOUNT SET { <kind> } POLICY <name> [ <scope> ] [ FORCE ]
+//	ALTER ACCOUNT UNSET { <kind> } POLICY [ <scope> ]
+//	ALTER ACCOUNT <name> SET <param> = <value> [ , ... ]
+//	ALTER ACCOUNT <name> RENAME TO <new_name> [ SAVE_OLD_URL = { TRUE | FALSE } ]
+//	ALTER ACCOUNT <name> DROP OLD [ ORGANIZATION ] URL
+func (p *Parser) parseAlterAccountStmt() (ast.Node, error) {
+	startLoc := p.cur.Loc // ACCOUNT keyword anchors Loc.Start (ALTER convention)
+	p.advance()           // consume ACCOUNT
+
+	stmt := &ast.AlterAccountStmt{Loc: ast.Loc{Start: startLoc.Start}}
+
+	// Cross-account form: a name precedes the action when the next token is not
+	// SET / UNSET.
+	if p.cur.Type != kwSET && p.cur.Type != kwUNSET {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Name = name
+	}
+
+	switch p.cur.Type {
+	case kwSET:
+		if err := p.parseAlterAccountSet(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwUNSET:
+		if err := p.parseAlterAccountUnset(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwRENAME:
+		// <name> RENAME TO <new_name> [ SAVE_OLD_URL = { TRUE | FALSE } ].
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterAccountRename
+		stmt.NewName = newName
+		if p.cur.Type == kwSAVE_OLD_URL {
+			p.advance() // consume SAVE_OLD_URL
+			if _, err := p.expect('='); err != nil {
+				return nil, err
+			}
+			b, err := p.parseTrueFalse()
+			if err != nil {
+				return nil, err
+			}
+			stmt.SaveOldURL = &b
+		}
+
+	case kwDROP:
+		// <name> DROP OLD [ ORGANIZATION ] URL.
+		p.advance() // consume DROP
+		if _, err := p.expect(kwOLD); err != nil {
+			return nil, err
+		}
+		if p.cur.Type == kwORGANIZATION {
+			p.advance() // consume ORGANIZATION
+			stmt.Organization = true
+		}
+		if _, err := p.expect(kwURL); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterAccountDropURL
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterAccountSet parses the SET branch of ALTER ACCOUNT. cur is the SET
+// keyword.
+//
+//	SET TAG <tag> = '<value>' [ , ... ]                      -> AlterAccountSetTag
+//	SET { <kind> } POLICY <name> [ <scope> ] [ FORCE ]       -> AlterAccountSetPolicy
+//	SET <param> = <value> [ , ... ] / SET RESOURCE_MONITOR=. -> AlterAccountSet
+func (p *Parser) parseAlterAccountSet(stmt *ast.AlterAccountStmt) error {
+	p.advance() // consume SET
+
+	if p.cur.Type == kwTAG {
+		tags, err := p.parseTagSetList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterAccountSetTag
+		stmt.Tags = tags
+		return nil
+	}
+
+	if p.startsAccountPolicy() {
+		return p.parseAlterAccountSetPolicy(stmt)
+	}
+
+	opts, err := p.parseGroupOptions()
+	if err != nil {
+		return err
+	}
+	if len(opts) == 0 {
+		return p.syntaxErrorAtCur()
+	}
+	stmt.Action = ast.AlterAccountSet
+	stmt.Options = opts
+	return nil
+}
+
+// parseAlterAccountUnset parses the UNSET branch of ALTER ACCOUNT. cur is the
+// UNSET keyword.
+//
+//	UNSET TAG <tag> [ , ... ]              -> AlterAccountUnsetTag
+//	UNSET { <kind> } POLICY [ <scope> ]    -> AlterAccountUnsetPolicy
+//	UNSET <param> [ , ... ]                -> AlterAccountUnset
+func (p *Parser) parseAlterAccountUnset(stmt *ast.AlterAccountStmt) error {
+	p.advance() // consume UNSET
+
+	if p.cur.Type == kwTAG {
+		names, err := p.parseUnsetTagNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterAccountUnsetTag
+		stmt.UnsetTags = names
+		return nil
+	}
+
+	if p.startsAccountPolicy() {
+		kind, err := p.parseAccountPolicyKind()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterAccountUnsetPolicy
+		stmt.PolicyKind = kind
+		// Optional trailing scope (FOR ALL ... ).
+		if p.cur.Type == kwFOR {
+			scope, err := p.parseAccountPolicyScope()
+			if err != nil {
+				return err
+			}
+			stmt.PolicyScope = scope
+		}
+		return nil
+	}
+
+	props, err := p.parseStageUnsetProps()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterAccountUnset
+	stmt.UnsetProps = props
+	return nil
+}
+
+// parseAlterAccountSetPolicy parses the SET { <kind> } POLICY <name> [ <scope> ]
+// [ FORCE ] form. cur is the first policy-kind word (the caller confirmed
+// startsAccountPolicy).
+func (p *Parser) parseAlterAccountSetPolicy(stmt *ast.AlterAccountStmt) error {
+	kind, err := p.parseAccountPolicyKind()
+	if err != nil {
+		return err
+	}
+	name, err := p.parseObjectName()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterAccountSetPolicy
+	stmt.PolicyKind = kind
+	stmt.PolicyName = name
+
+	// Optional FOR ALL ... scope.
+	if p.cur.Type == kwFOR {
+		scope, err := p.parseAccountPolicyScope()
+		if err != nil {
+			return err
+		}
+		stmt.PolicyScope = scope
+	}
+	// Optional trailing FORCE.
+	if p.cur.Type == kwFORCE {
+		p.advance() // consume FORCE
+		stmt.Force = true
+	}
+	return nil
+}
+
+// startsAccountPolicy reports whether the current position begins an ALTER
+// ACCOUNT policy form, i.e. a policy-kind word (AUTHENTICATION / SESSION /
+// PACKAGES / PASSWORD / FEATURE) immediately followed by the POLICY keyword.
+// AUTHENTICATION and FEATURE are not reserved keywords, so they arrive as plain
+// identifiers; SESSION / PACKAGES / PASSWORD are keywords. The next-token POLICY
+// check is what distinguishes the policy form from an ordinary
+// `SET <param> = value` whose param happens to share a prefix.
+func (p *Parser) startsAccountPolicy() bool {
+	switch {
+	case p.cur.Type == kwSESSION, p.cur.Type == kwPACKAGES, p.cur.Type == kwPASSWORD:
+		return p.peekNext().Type == kwPOLICY
+	case p.curIsWord("AUTHENTICATION"), p.curIsWord("FEATURE"):
+		return p.peekNext().Type == kwPOLICY
+	}
+	return false
+}
+
+// parseAccountPolicyKind consumes the policy-kind word(s) and the POLICY keyword
+// and returns the uppercased "<KIND> POLICY" text (e.g. "PACKAGES POLICY"). The
+// caller has confirmed startsAccountPolicy.
+func (p *Parser) parseAccountPolicyKind() (string, error) {
+	kindTok := p.advance() // consume the policy-kind word
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return "", err
+	}
+	return strings.ToUpper(kindTok.Str) + " POLICY", nil
+}
+
+// parseAccountPolicyScope parses a trailing policy scope clause and returns it
+// verbatim (uppercased, space-joined). cur is the FOR keyword. The two documented
+// shapes are `FOR ALL { PERSON | SERVICE } USERS` and `FOR ALL APPLICATIONS`;
+// rather than enumerate them, the run of words after FOR is captured whole (it
+// runs to the FORCE keyword or the statement boundary).
+func (p *Parser) parseAccountPolicyScope() (string, error) {
+	if _, err := p.expect(kwFOR); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString("FOR")
+	for p.isOptionWord(p.cur.Type) && p.cur.Type != kwFORCE {
+		b.WriteByte(' ')
+		b.WriteString(strings.ToUpper(p.advance().Str))
+	}
+	return b.String(), nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SHARE
+// ---------------------------------------------------------------------------
+
+// parseCreateShareStmt parses
+//
+//	CREATE [ OR REPLACE ] SHARE [ IF NOT EXISTS ] <name> [ COMMENT = '<string>' ]
+//
+// The CREATE keyword and optional OR REPLACE modifier have already been consumed;
+// start is the Loc of the CREATE token, and cur is the SHARE keyword.
+func (p *Parser) parseCreateShareStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume SHARE
+
+	stmt := &ast.CreateShareStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// COMMENT is the only documented parameter, but capture any trailing
+	// `KEY = value` option open-ended (mirrors the engine's parse-permissively
+	// stance).
+	opts, err := p.parseGroupOptions()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Options = opts
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SHARE
+// ---------------------------------------------------------------------------
+
+// parseAlterShareStmt parses ALTER SHARE. The ALTER keyword has already been
+// consumed; cur is the SHARE keyword.
+//
+//	ALTER SHARE [ IF EXISTS ] <name> { ADD | REMOVE } ACCOUNTS = <a> [ , ... ] [ SHARE_RESTRICTIONS = ... ]
+//	ALTER SHARE [ IF EXISTS ] <name> SET [ ACCOUNTS = <a> [ , ... ] ] [ COMMENT = '...' ]
+//	ALTER SHARE [ IF EXISTS ] <name> SET TAG <tag> = '<value>' [ , ... ]
+//	ALTER SHARE <name> UNSET TAG <tag> [ , ... ]
+//	ALTER SHARE [ IF EXISTS ] <name> UNSET COMMENT
+func (p *Parser) parseAlterShareStmt() (ast.Node, error) {
+	altTok := p.advance() // consume SHARE
+	stmt := &ast.AlterShareStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	p.parseOptionalIfExists(&stmt.IfExists)
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwADD, kwREMOVE:
+		// { ADD | REMOVE } ACCOUNTS = <a> [ , ... ] [ SHARE_RESTRICTIONS = ... ]
+		add := p.cur.Type == kwADD
+		p.advance() // consume ADD / REMOVE
+		if _, err := p.expect(kwACCOUNTS); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect('='); err != nil {
+			return nil, err
+		}
+		accounts, err := p.parseObjectNameList()
+		if err != nil {
+			return nil, err
+		}
+		if add {
+			stmt.Action = ast.AlterShareAdd
+		} else {
+			stmt.Action = ast.AlterShareRemove
+		}
+		stmt.Accounts = accounts
+		if p.cur.Type == kwSHARE_RESTRICTIONS {
+			p.advance() // consume SHARE_RESTRICTIONS
+			if _, err := p.expect('='); err != nil {
+				return nil, err
+			}
+			b, err := p.parseTrueFalse()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ShareRestrictions = &b
+		}
+
+	case kwSET:
+		if err := p.parseAlterShareSet(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwUNSET:
+		if err := p.parseAlterShareUnset(stmt); err != nil {
+			return nil, err
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterShareSet parses the SET branch of ALTER SHARE. cur is the SET keyword.
+//
+//	SET TAG <tag> = '<value>' [ , ... ]                  -> AlterShareSetTag
+//	SET [ ACCOUNTS = <a> [ , ... ] ] [ COMMENT = '...' ] -> AlterShareSet
+func (p *Parser) parseAlterShareSet(stmt *ast.AlterShareStmt) error {
+	p.advance() // consume SET
+
+	if p.cur.Type == kwTAG {
+		tags, err := p.parseTagSetList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterShareSetTag
+		stmt.Tags = tags
+		return nil
+	}
+
+	stmt.Action = ast.AlterShareSet
+	settable := false
+
+	// Optional ACCOUNTS = <a> [ , ... ].
+	if p.cur.Type == kwACCOUNTS {
+		p.advance() // consume ACCOUNTS
+		if _, err := p.expect('='); err != nil {
+			return err
+		}
+		accounts, err := p.parseObjectNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Accounts = accounts
+		settable = true
+	}
+
+	// Optional COMMENT / other open-ended params.
+	opts, err := p.parseGroupOptions()
+	if err != nil {
+		return err
+	}
+	if len(opts) > 0 {
+		stmt.Options = opts
+		settable = true
+	}
+
+	if !settable {
+		// SET with nothing settable is a syntax error.
+		return p.syntaxErrorAtCur()
+	}
+	return nil
+}
+
+// parseAlterShareUnset parses the UNSET branch of ALTER SHARE. cur is the UNSET
+// keyword.
+//
+//	UNSET TAG <tag> [ , ... ]   -> AlterShareUnsetTag
+//	UNSET COMMENT [ , ... ]     -> AlterShareUnset
+func (p *Parser) parseAlterShareUnset(stmt *ast.AlterShareStmt) error {
+	p.advance() // consume UNSET
+
+	if p.cur.Type == kwTAG {
+		names, err := p.parseUnsetTagNameList()
+		if err != nil {
+			return err
+		}
+		stmt.Action = ast.AlterShareUnsetTag
+		stmt.UnsetTags = names
+		return nil
+	}
+
+	props, err := p.parseStageUnsetProps()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterShareUnset
+	stmt.UnsetProps = props
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers — GroupOption (KEY = <value-list | literal>)
+// ---------------------------------------------------------------------------
+
+// parseGroupOptions parses a run of zero or more GroupOptions. Each is a
+// `KEY = <value>` pair where the value is an unparenthesized comma list of
+// word/dotted items or a string/number literal. The run continues while the
+// current token begins another option, optionally consuming a comma separator
+// between options (CREATE MANAGED ACCOUNT separates its options with commas; the
+// group/share/account list-options are space-separated). It terminates at a
+// statement boundary, at the [WITH] TAG clause, at the IGNORE EDITION CHECK
+// flag, or at any token that does not begin an option.
+func (p *Parser) parseGroupOptions() ([]*ast.GroupOption, error) {
+	var opts []*ast.GroupOption
+	for p.startsGroupOption() {
+		opt, err := p.parseGroupOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+		if p.cur.Type == ',' {
+			p.advance() // consume optional ',' separator (CREATE MANAGED ACCOUNT)
+		}
+	}
+	return opts, nil
+}
+
+// startsGroupOption reports whether the current token can begin a GroupOption.
+// An option name is an identifier or a keyword. The structural keywords that
+// anchor a trailing clause (WITH / TAG for [WITH] TAG, IGNORE for IGNORE EDITION
+// CHECK) are excluded so they are not swallowed as an option name.
+func (p *Parser) startsGroupOption() bool {
+	switch p.cur.Type {
+	case kwWITH, kwTAG, kwIGNORE:
+		return false
+	}
+	if p.cur.Type == tokIdent || p.cur.Type == tokQuotedIdent {
+		return true
+	}
+	if p.cur.Type == tokEOF || p.cur.Type == ';' {
+		return false
+	}
+	return p.cur.Type >= 700
+}
+
+// startsGroupTags reports whether the current position begins a [WITH] TAG
+// clause: the TAG keyword directly, or WITH immediately followed by TAG.
+func (p *Parser) startsGroupTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// parseGroupOption parses one `KEY = <value>` option. The value is either a
+// string/number literal (REPLICATION_SCHEDULE = '10 MINUTE', ADMIN_PASSWORD =
+// 'secret') or a run of word/dotted items. Whether the value is a comma list is
+// driven by the option NAME, not by punctuation: only the closed set of
+// replication/sharing list options (OBJECT_TYPES, ALLOWED_DATABASES,
+// ALLOWED_EXTERNAL_VOLUMES, ALLOWED_SHARES, ALLOWED_INTEGRATION_TYPES,
+// ALLOWED_ACCOUNTS) take an UNPARENTHESIZED comma list of elements (each itself a
+// multi-word object-type name or a dotted org.account). Every other option is
+// scalar (a single word/dotted value: ERROR_INTEGRATION = my_int,
+// OPTIMIZED_REFRESH = TRUE, ADMIN_NAME = admin, EDITION = STANDARD, TYPE =
+// READER, ...), so a trailing comma is an OPTION separator (CREATE MANAGED
+// ACCOUNT comma-separates its params) — it is left for parseGroupOptions, NOT
+// swallowed into this option's value. This name-driven rule is what
+// disambiguates `OBJECT_TYPES = ROLES, DATABASES` (one option, two list
+// elements) from `ADMIN_NAME = admin, ADMIN_PASSWORD = '...'` (two options) with
+// only one token of lookahead. cur is the option name.
+func (p *Parser) parseGroupOption() (*ast.GroupOption, error) {
+	nameTok := p.advance() // consume the option name
+	opt := &ast.GroupOption{
+		Name: strings.ToUpper(nameTok.Str),
+		Loc:  ast.Loc{Start: nameTok.Loc.Start, End: nameTok.Loc.End},
+	}
+
+	if _, err := p.expect('='); err != nil {
+		return nil, err
+	}
+
+	// A string/number literal value.
+	switch p.cur.Type {
+	case tokString:
+		tok := p.advance()
+		opt.Lit = &ast.Literal{Kind: ast.LitString, Value: tok.Str, Loc: tok.Loc}
+		opt.Loc.End = tok.Loc.End
+		return opt, nil
+	case tokInt:
+		tok := p.advance()
+		opt.Lit = &ast.Literal{Kind: ast.LitInt, Value: tok.Str, Ival: tok.Ival, Loc: tok.Loc}
+		opt.Loc.End = tok.Loc.End
+		return opt, nil
+	case tokFloat, tokReal:
+		tok := p.advance()
+		opt.Lit = &ast.Literal{Kind: ast.LitFloat, Value: tok.Str, Loc: tok.Loc}
+		opt.Loc.End = tok.Loc.End
+		return opt, nil
+	}
+
+	// A run of word/dotted items: a comma list for the known list options, a
+	// single element otherwise.
+	values, end, err := p.parseGroupValueList(isGroupListOption(opt.Name))
+	if err != nil {
+		return nil, err
+	}
+	opt.Values = values
+	opt.Loc.End = end
+	return opt, nil
+}
+
+// isGroupListOption reports whether name is one of the replication/sharing list
+// options whose value is an unparenthesized comma list of elements (so a comma
+// within its value is a list separator, not an option separator). Every other
+// option is scalar. The set is closed per the docs + legacy grammar.
+func isGroupListOption(name string) bool {
+	switch name {
+	case "OBJECT_TYPES",
+		"ALLOWED_DATABASES",
+		"ALLOWED_EXTERNAL_VOLUMES",
+		"ALLOWED_SHARES",
+		"ALLOWED_INTEGRATION_TYPES",
+		"ALLOWED_ACCOUNTS":
+		return true
+	}
+	return false
+}
+
+// parseGroupValueList parses a value made of one or more word/dotted/'$' items,
+// each captured verbatim and uppercased. Each element may be multi-word
+// (`ACCOUNT PARAMETERS`, `RESOURCE MONITORS`, `SECURITY INTEGRATIONS`) or dotted
+// (`org.account`). When list is true it parses a comma-separated list (the comma
+// is the element separator); when list is false it parses exactly one element
+// (any trailing comma is an option separator, left for the caller). Consumes at
+// least one element. Returns the joined elements and the end offset.
+//
+// The element reader stops at a comma, at a token that begins the next
+// `KEY = value` option (a word immediately followed by '='), or at a non-word
+// token / clause anchor / statement boundary — which keeps a space-separated
+// follow-on option (e.g. the ALLOWED_ACCOUNTS after an unparenthesized
+// OBJECT_TYPES list) from being absorbed into the current value.
+func (p *Parser) parseGroupValueList(list bool) ([]string, int, error) {
+	if !p.isOptionWord(p.cur.Type) {
+		return nil, 0, p.syntaxErrorAtCur()
+	}
+	var values []string
+	end := p.cur.Loc.End
+	for {
+		elem, elemEnd, err := p.parseGroupValueElement()
+		if err != nil {
+			return nil, 0, err
+		}
+		values = append(values, elem)
+		end = elemEnd
+		if list && p.cur.Type == ',' {
+			p.advance() // consume ',' list separator
+			continue
+		}
+		break
+	}
+	return values, end, nil
+}
+
+// parseGroupValueElement parses one comma-list element: a run of one or more
+// word tokens (joined with single spaces) plus any source-adjacent dotted / '$'
+// continuations (joined verbatim with no space). The run stops at:
+//   - a comma (the list separator), or
+//   - a word that begins the NEXT option, detected as a word immediately
+//     followed by '=' (e.g. the ALLOWED_ACCOUNTS in `OBJECT_TYPES = DATABASES
+//     ALLOWED_ACCOUNTS = ...`), or
+//   - a non-word token / the WITH / TAG / IGNORE clause anchors / EOF.
+func (p *Parser) parseGroupValueElement() (string, int, error) {
+	if !p.isOptionWord(p.cur.Type) {
+		return "", 0, p.syntaxErrorAtCur()
+	}
+	var b strings.Builder
+	first := p.advance()
+	b.WriteString(strings.ToUpper(first.Str))
+	end := first.Loc.End
+
+	for {
+		// Adjacency-joined dotted / '$' continuations (no intervening space):
+		// dotted account names (org.account) and $-segments.
+		if (p.cur.Type == '.' || p.cur.Type == '$') && p.cur.Loc.Start == end {
+			sep := p.advance()
+			b.WriteString(p.srcSlice(sep.Loc.Start, sep.Loc.End))
+			end = sep.Loc.End
+			if p.isOptionWord(p.cur.Type) && p.cur.Loc.Start == end {
+				part := p.advance()
+				b.WriteString(strings.ToUpper(part.Str))
+				end = part.Loc.End
+			}
+			continue
+		}
+		// A further space-separated word continues this element ONLY if it is part
+		// of a multi-word object-type name, i.e. it is not the start of the next
+		// `KEY = value` option (a word followed by '=') and not a clause anchor.
+		if p.continuesGroupElement() {
+			part := p.advance()
+			b.WriteByte(' ')
+			b.WriteString(strings.ToUpper(part.Str))
+			end = part.Loc.End
+			continue
+		}
+		break
+	}
+	return b.String(), end, nil
+}
+
+// continuesGroupElement reports whether the current token extends the current
+// multi-word list element (e.g. PARAMETERS in `ACCOUNT PARAMETERS`, MONITORS in
+// `RESOURCE MONITORS`, INTEGRATIONS in `SECURITY INTEGRATIONS`) rather than
+// beginning the next option or a trailing clause. A word that is immediately
+// followed by '=' starts the next option; the WITH / TAG / IGNORE anchors and
+// any non-word token end the element.
+func (p *Parser) continuesGroupElement() bool {
+	switch p.cur.Type {
+	case kwWITH, kwTAG, kwIGNORE:
+		return false
+	}
+	if !p.isOptionWord(p.cur.Type) {
+		return false
+	}
+	// A word followed by '=' is the next option name, not a continuation.
+	return p.peekNext().Type != '='
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers — name lists, ALLOWED_* targets, IGNORE EDITION CHECK, booleans
+// ---------------------------------------------------------------------------
+
+// parseObjectNameList parses a comma-separated list of object names (each a
+// 1/2/3-part dotted ObjectName — used for database/share name lists and the
+// dotted org.account lists). Consumes at least one.
+func (p *Parser) parseObjectNameList() ([]*ast.ObjectName, error) {
+	var names []*ast.ObjectName
+	for {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return names, nil
+}
+
+// parseAllowedListKeyword consumes an ALLOWED_DATABASES / ALLOWED_SHARES /
+// ALLOWED_ACCOUNTS keyword (the target of an ADD ... TO / REMOVE ... FROM
+// action) and returns its uppercased text.
+func (p *Parser) parseAllowedListKeyword() (string, error) {
+	switch p.cur.Type {
+	case kwALLOWED_DATABASES:
+		p.advance()
+		return "ALLOWED_DATABASES", nil
+	case kwALLOWED_SHARES:
+		p.advance()
+		return "ALLOWED_SHARES", nil
+	case kwALLOWED_ACCOUNTS:
+		p.advance()
+		return "ALLOWED_ACCOUNTS", nil
+	default:
+		return "", p.syntaxErrorAtCur()
+	}
+}
+
+// parseIgnoreEditionCheck consumes the bare IGNORE EDITION CHECK flag. cur is the
+// IGNORE keyword.
+func (p *Parser) parseIgnoreEditionCheck() error {
+	p.advance() // consume IGNORE
+	if _, err := p.expect(kwEDITION); err != nil {
+		return err
+	}
+	if _, err := p.expect(kwCHECK); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseTrueFalse parses a { TRUE | FALSE } boolean value, returning the bool. The
+// lexer keywordizes TRUE / FALSE; they are also accepted as bare identifiers
+// defensively (some are not reserved).
+func (p *Parser) parseTrueFalse() (bool, error) {
+	switch {
+	case p.curIsWord("TRUE"):
+		p.advance()
+		return true, nil
+	case p.curIsWord("FALSE"):
+		p.advance()
+		return false, nil
+	default:
+		return false, p.syntaxErrorAtCur()
+	}
+}

--- a/snowflake/parser/replication_share_test.go
+++ b/snowflake/parser/replication_share_test.go
@@ -1,0 +1,974 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateGroup(t *testing.T, input string) *ast.CreateReplicationGroupStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateReplicationGroupStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateReplicationGroupStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterGroup(t *testing.T, input string) *ast.AlterReplicationGroupStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterReplicationGroupStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterReplicationGroupStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateAccount(t *testing.T, input string) *ast.CreateAccountStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateAccountStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateAccountStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterAccount(t *testing.T, input string) *ast.AlterAccountStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterAccountStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterAccountStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateShare(t *testing.T, input string) *ast.CreateShareStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateShareStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateShareStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterShare(t *testing.T, input string) *ast.AlterShareStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterShareStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterShareStmt", input, node)
+	}
+	return stmt
+}
+
+// findGroupOption returns the named option, or nil.
+func findGroupOption(opts []*ast.GroupOption, name string) *ast.GroupOption {
+	for _, o := range opts {
+		if o.Name == name {
+			return o
+		}
+	}
+	return nil
+}
+
+// names joins a list of object names with commas for assertions.
+func names(ns []*ast.ObjectName) string {
+	parts := make([]string, len(ns))
+	for i, n := range ns {
+		parts[i] = n.String()
+	}
+	return strings.Join(parts, ",")
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FAILOVER GROUP / REPLICATION GROUP — primary form
+// ---------------------------------------------------------------------------
+
+func TestParseCreateGroup_Primary(t *testing.T) {
+	t.Run("failover minimal", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct")
+		if !stmt.Failover {
+			t.Error("Failover not set")
+		}
+		if stmt.Name.String() != "fg" {
+			t.Errorf("Name = %q, want fg", stmt.Name.String())
+		}
+		if stmt.Replica != nil {
+			t.Errorf("unexpected Replica: %v", stmt.Replica)
+		}
+		ot := findGroupOption(stmt.Options, "OBJECT_TYPES")
+		if ot == nil || len(ot.Values) != 1 || ot.Values[0] != "ROLES" {
+			t.Errorf("OBJECT_TYPES = %v, want [ROLES]", ot)
+		}
+		aa := findGroupOption(stmt.Options, "ALLOWED_ACCOUNTS")
+		if aa == nil || len(aa.Values) != 1 || aa.Values[0] != "ORG.ACCT" {
+			t.Errorf("ALLOWED_ACCOUNTS = %v, want [ORG.ACCT]", aa)
+		}
+	})
+
+	t.Run("replication minimal", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE REPLICATION GROUP rg OBJECT_TYPES = DATABASES ALLOWED_ACCOUNTS = org.acct")
+		if stmt.Failover {
+			t.Error("Failover should be false for REPLICATION GROUP")
+		}
+	})
+
+	t.Run("or replace + if not exists", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE OR REPLACE FAILOVER GROUP IF NOT EXISTS fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct")
+		if !stmt.OrReplace || !stmt.IfNotExists {
+			t.Errorf("OrReplace=%v IfNotExists=%v, want both true", stmt.OrReplace, stmt.IfNotExists)
+		}
+	})
+
+	t.Run("multi-word object types", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP fg OBJECT_TYPES = ACCOUNT PARAMETERS, RESOURCE MONITORS, NETWORK POLICIES ALLOWED_ACCOUNTS = org.acct")
+		ot := findGroupOption(stmt.Options, "OBJECT_TYPES")
+		want := []string{"ACCOUNT PARAMETERS", "RESOURCE MONITORS", "NETWORK POLICIES"}
+		if ot == nil || strings.Join(ot.Values, "|") != strings.Join(want, "|") {
+			t.Errorf("OBJECT_TYPES = %v, want %v", ot.Values, want)
+		}
+	})
+
+	// Structural correctness for the trickiest behavior: an unparenthesized
+	// comma list of multi-word object types must NOT absorb the following
+	// space-separated option name (ALLOWED_ACCOUNTS) as a list element, and the
+	// two options must come out distinct.
+	t.Run("list boundary stops at next option", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP fg OBJECT_TYPES = DATABASES, ROLES ALLOWED_ACCOUNTS = org.a, org.b")
+		ot := findGroupOption(stmt.Options, "OBJECT_TYPES")
+		if ot == nil || strings.Join(ot.Values, "|") != "DATABASES|ROLES" {
+			t.Errorf("OBJECT_TYPES = %v, want [DATABASES ROLES]", ot)
+		}
+		aa := findGroupOption(stmt.Options, "ALLOWED_ACCOUNTS")
+		if aa == nil || strings.Join(aa.Values, "|") != "ORG.A|ORG.B" {
+			t.Errorf("ALLOWED_ACCOUNTS = %v, want [ORG.A ORG.B]", aa)
+		}
+		if len(stmt.Options) != 2 {
+			t.Errorf("expected exactly 2 options, got %d: %+v", len(stmt.Options), stmt.Options)
+		}
+	})
+
+	t.Run("all optional list options", func(t *testing.T) {
+		in := "CREATE FAILOVER GROUP fg " +
+			"OBJECT_TYPES = DATABASES, INTEGRATIONS " +
+			"ALLOWED_DATABASES = db1, db2 " +
+			"ALLOWED_EXTERNAL_VOLUMES = ev1 " +
+			"ALLOWED_SHARES = sh1, sh2 " +
+			"ALLOWED_INTEGRATION_TYPES = SECURITY INTEGRATIONS, API INTEGRATIONS " +
+			"ALLOWED_ACCOUNTS = org.a1, org.a2 " +
+			"IGNORE EDITION CHECK " +
+			"REPLICATION_SCHEDULE = '10 MINUTE' " +
+			"OPTIMIZED_REFRESH = TRUE " +
+			"ERROR_INTEGRATION = my_int"
+		stmt := mustCreateGroup(t, in)
+		if !stmt.IgnoreEditionCheck {
+			t.Error("IgnoreEditionCheck not set")
+		}
+		if ad := findGroupOption(stmt.Options, "ALLOWED_DATABASES"); ad == nil || len(ad.Values) != 2 {
+			t.Errorf("ALLOWED_DATABASES = %v, want 2 values", ad)
+		}
+		if sh := findGroupOption(stmt.Options, "ALLOWED_SHARES"); sh == nil || len(sh.Values) != 2 {
+			t.Errorf("ALLOWED_SHARES = %v, want 2 values", sh)
+		}
+		rs := findGroupOption(stmt.Options, "REPLICATION_SCHEDULE")
+		if rs == nil || rs.Lit == nil || rs.Lit.Value != "10 MINUTE" {
+			t.Errorf("REPLICATION_SCHEDULE = %v, want literal '10 MINUTE'", rs)
+		}
+		opt := findGroupOption(stmt.Options, "OPTIMIZED_REFRESH")
+		if opt == nil || len(opt.Values) != 1 || opt.Values[0] != "TRUE" {
+			t.Errorf("OPTIMIZED_REFRESH = %v, want [TRUE]", opt)
+		}
+		ei := findGroupOption(stmt.Options, "ERROR_INTEGRATION")
+		if ei == nil || len(ei.Values) != 1 || ei.Values[0] != "MY_INT" {
+			t.Errorf("ERROR_INTEGRATION = %v, want [MY_INT]", ei)
+		}
+	})
+
+	t.Run("with tag clause", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct WITH TAG (cost_center = 'sales')")
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Name.String() != "cost_center" || stmt.Tags[0].Value != "sales" {
+			t.Errorf("Tags = %+v, want one cost_center=sales", stmt.Tags)
+		}
+	})
+
+	t.Run("bare tag clause (no WITH)", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct TAG (t = 'v')")
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags = %+v, want one", stmt.Tags)
+		}
+	})
+
+	t.Run("replication_schedule cron string", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct REPLICATION_SCHEDULE = 'USING CRON 0 0 10-20 * TUE,THU UTC'")
+		rs := findGroupOption(stmt.Options, "REPLICATION_SCHEDULE")
+		if rs == nil || rs.Lit == nil || !strings.HasPrefix(rs.Lit.Value, "USING CRON") {
+			t.Errorf("REPLICATION_SCHEDULE = %v", rs)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE FAILOVER GROUP / REPLICATION GROUP — secondary AS REPLICA OF form
+// ---------------------------------------------------------------------------
+
+func TestParseCreateGroup_Secondary(t *testing.T) {
+	t.Run("failover replica", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE FAILOVER GROUP myfg2 AS REPLICA OF myorg.myaccount.myfg")
+		if stmt.Replica == nil {
+			t.Fatal("Replica not set")
+		}
+		if stmt.Replica.String() != "myorg.myaccount.myfg" {
+			t.Errorf("Replica = %q, want myorg.myaccount.myfg", stmt.Replica.String())
+		}
+		if len(stmt.Options) != 0 {
+			t.Errorf("secondary form should have no options, got %v", stmt.Options)
+		}
+	})
+
+	t.Run("replication replica", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE REPLICATION GROUP myrg2 AS REPLICA OF myorg.myaccount.myrg")
+		if stmt.Failover {
+			t.Error("Failover should be false")
+		}
+		if stmt.Replica == nil || stmt.Replica.String() != "myorg.myaccount.myrg" {
+			t.Errorf("Replica = %v", stmt.Replica)
+		}
+	})
+
+	t.Run("or replace + if not exists replica", func(t *testing.T) {
+		stmt := mustCreateGroup(t, "CREATE OR REPLACE FAILOVER GROUP IF NOT EXISTS fg2 AS REPLICA OF a.b.c")
+		if !stmt.OrReplace || !stmt.IfNotExists || stmt.Replica == nil {
+			t.Errorf("OrReplace=%v IfNotExists=%v Replica=%v", stmt.OrReplace, stmt.IfNotExists, stmt.Replica)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER FAILOVER GROUP / REPLICATION GROUP — all action variants
+// ---------------------------------------------------------------------------
+
+func TestParseAlterGroup_Actions(t *testing.T) {
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg RENAME TO fg2")
+		if stmt.Action != ast.AlterGroupRename || stmt.NewName.String() != "fg2" {
+			t.Errorf("Action=%d NewName=%v", stmt.Action, stmt.NewName)
+		}
+	})
+
+	t.Run("if exists rename", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP IF EXISTS fg RENAME TO fg2")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+	})
+
+	t.Run("set object types + schedule", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg SET OBJECT_TYPES = DATABASES, ROLES REPLICATION_SCHEDULE = '20 MINUTE'")
+		if stmt.Action != ast.AlterGroupSet {
+			t.Fatalf("Action=%d, want AlterGroupSet", stmt.Action)
+		}
+		if ot := findGroupOption(stmt.Options, "OBJECT_TYPES"); ot == nil || len(ot.Values) != 2 {
+			t.Errorf("OBJECT_TYPES = %v", ot)
+		}
+	})
+
+	t.Run("set integration types", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER REPLICATION GROUP rg SET OBJECT_TYPES = INTEGRATIONS ALLOWED_INTEGRATION_TYPES = SECURITY INTEGRATIONS")
+		if stmt.Action != ast.AlterGroupSet {
+			t.Errorf("Action=%d", stmt.Action)
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg SET TAG t1 = 'v1', t2 = 'v2'")
+		if stmt.Action != ast.AlterGroupSetTag || len(stmt.Tags) != 2 {
+			t.Errorf("Action=%d Tags=%+v", stmt.Action, stmt.Tags)
+		}
+	})
+
+	t.Run("unset property", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER REPLICATION GROUP rg UNSET REPLICATION_SCHEDULE")
+		if stmt.Action != ast.AlterGroupUnset || len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "REPLICATION_SCHEDULE" {
+			t.Errorf("Action=%d UnsetProps=%v", stmt.Action, stmt.UnsetProps)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg UNSET TAG t1, t2")
+		if stmt.Action != ast.AlterGroupUnsetTag || len(stmt.UnsetTags) != 2 {
+			t.Errorf("Action=%d UnsetTags=%v", stmt.Action, stmt.UnsetTags)
+		}
+	})
+
+	t.Run("add to allowed databases", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg ADD db1, db2 TO ALLOWED_DATABASES")
+		if stmt.Action != ast.AlterGroupAdd || stmt.ListTarget != "ALLOWED_DATABASES" || names(stmt.Names) != "db1,db2" {
+			t.Errorf("Action=%d Target=%q Names=%q", stmt.Action, stmt.ListTarget, names(stmt.Names))
+		}
+	})
+
+	t.Run("add to allowed shares", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg ADD sh1 TO ALLOWED_SHARES")
+		if stmt.ListTarget != "ALLOWED_SHARES" {
+			t.Errorf("Target=%q", stmt.ListTarget)
+		}
+	})
+
+	t.Run("add to allowed accounts ignore edition check", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg ADD org.a1, org.a2 TO ALLOWED_ACCOUNTS IGNORE EDITION CHECK")
+		if stmt.ListTarget != "ALLOWED_ACCOUNTS" || !stmt.IgnoreEditionCheck || names(stmt.Names) != "org.a1,org.a2" {
+			t.Errorf("Target=%q Ignore=%v Names=%q", stmt.ListTarget, stmt.IgnoreEditionCheck, names(stmt.Names))
+		}
+	})
+
+	t.Run("remove from allowed databases", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg REMOVE db1 FROM ALLOWED_DATABASES")
+		if stmt.Action != ast.AlterGroupRemove || stmt.ListTarget != "ALLOWED_DATABASES" {
+			t.Errorf("Action=%d Target=%q", stmt.Action, stmt.ListTarget)
+		}
+	})
+
+	t.Run("move databases to failover group", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg MOVE DATABASES db1, db2 TO FAILOVER GROUP fg2")
+		if stmt.Action != ast.AlterGroupMove || stmt.MoveKind != "DATABASES" || stmt.MoveTo.String() != "fg2" {
+			t.Errorf("Action=%d MoveKind=%q MoveTo=%v", stmt.Action, stmt.MoveKind, stmt.MoveTo)
+		}
+		if names(stmt.Names) != "db1,db2" {
+			t.Errorf("Names=%q", names(stmt.Names))
+		}
+	})
+
+	t.Run("move shares to replication group", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER REPLICATION GROUP rg MOVE SHARES sh1 TO REPLICATION GROUP rg2")
+		if stmt.MoveKind != "SHARES" || stmt.MoveTo.String() != "rg2" {
+			t.Errorf("MoveKind=%q MoveTo=%v", stmt.MoveKind, stmt.MoveTo)
+		}
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER REPLICATION GROUP rg REFRESH")
+		if stmt.Action != ast.AlterGroupRefresh {
+			t.Errorf("Action=%d", stmt.Action)
+		}
+	})
+
+	t.Run("primary", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg PRIMARY")
+		if stmt.Action != ast.AlterGroupPrimary {
+			t.Errorf("Action=%d", stmt.Action)
+		}
+	})
+
+	t.Run("suspend", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg SUSPEND")
+		if stmt.Action != ast.AlterGroupSuspend || stmt.Immediate {
+			t.Errorf("Action=%d Immediate=%v", stmt.Action, stmt.Immediate)
+		}
+	})
+
+	t.Run("suspend immediate", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER FAILOVER GROUP fg SUSPEND IMMEDIATE")
+		if !stmt.Immediate {
+			t.Error("Immediate not set")
+		}
+	})
+
+	t.Run("resume", func(t *testing.T) {
+		stmt := mustAlterGroup(t, "ALTER REPLICATION GROUP rg RESUME")
+		if stmt.Action != ast.AlterGroupResume {
+			t.Errorf("Action=%d", stmt.Action)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE ACCOUNT / MANAGED ACCOUNT
+// ---------------------------------------------------------------------------
+
+func TestParseCreateAccount(t *testing.T) {
+	t.Run("account full", func(t *testing.T) {
+		in := "CREATE ACCOUNT myaccount1 " +
+			"ADMIN_NAME = admin ADMIN_PASSWORD = 'TestPassword1' " +
+			"FIRST_NAME = Jane LAST_NAME = Smith EMAIL = 'myemail@myorg.org' " +
+			"MUST_CHANGE_PASSWORD = TRUE EDITION = ENTERPRISE"
+		stmt := mustCreateAccount(t, in)
+		if stmt.Managed {
+			t.Error("Managed should be false")
+		}
+		if stmt.Name.String() != "myaccount1" {
+			t.Errorf("Name=%q", stmt.Name.String())
+		}
+		an := findGroupOption(stmt.Options, "ADMIN_NAME")
+		if an == nil || len(an.Values) != 1 || an.Values[0] != "ADMIN" {
+			t.Errorf("ADMIN_NAME=%v", an)
+		}
+		ap := findGroupOption(stmt.Options, "ADMIN_PASSWORD")
+		if ap == nil || ap.Lit == nil || ap.Lit.Value != "TestPassword1" {
+			t.Errorf("ADMIN_PASSWORD=%v", ap)
+		}
+		ed := findGroupOption(stmt.Options, "EDITION")
+		if ed == nil || len(ed.Values) != 1 || ed.Values[0] != "ENTERPRISE" {
+			t.Errorf("EDITION=%v", ed)
+		}
+	})
+
+	t.Run("account with rsa public key", func(t *testing.T) {
+		stmt := mustCreateAccount(t, "CREATE ACCOUNT a ADMIN_NAME = admin ADMIN_RSA_PUBLIC_KEY = 'key' EMAIL = 'e@x.com' EDITION = STANDARD")
+		if findGroupOption(stmt.Options, "ADMIN_RSA_PUBLIC_KEY") == nil {
+			t.Error("ADMIN_RSA_PUBLIC_KEY not captured")
+		}
+	})
+
+	t.Run("account region + comment", func(t *testing.T) {
+		stmt := mustCreateAccount(t, "CREATE ACCOUNT a ADMIN_NAME = admin ADMIN_PASSWORD = 'p' EMAIL = 'e@x.com' EDITION = BUSINESS_CRITICAL REGION = aws_us_west_2 COMMENT = 'hi'")
+		if findGroupOption(stmt.Options, "REGION") == nil {
+			t.Error("REGION not captured")
+		}
+		c := findGroupOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "hi" {
+			t.Errorf("COMMENT=%v", c)
+		}
+	})
+
+	t.Run("managed account comma-separated", func(t *testing.T) {
+		stmt := mustCreateAccount(t, "CREATE MANAGED ACCOUNT ra1 ADMIN_NAME = admin, ADMIN_PASSWORD = 'pw', TYPE = READER")
+		if !stmt.Managed {
+			t.Error("Managed not set")
+		}
+		ty := findGroupOption(stmt.Options, "TYPE")
+		if ty == nil || len(ty.Values) != 1 || ty.Values[0] != "READER" {
+			t.Errorf("TYPE=%v", ty)
+		}
+		if len(stmt.Options) != 3 {
+			t.Errorf("expected 3 options, got %d: %+v", len(stmt.Options), stmt.Options)
+		}
+	})
+
+	t.Run("managed account with comment", func(t *testing.T) {
+		stmt := mustCreateAccount(t, "CREATE MANAGED ACCOUNT ra1 ADMIN_NAME = admin, ADMIN_PASSWORD = 'pw', TYPE = READER, COMMENT = 'reader'")
+		if len(stmt.Options) != 4 {
+			t.Errorf("expected 4 options, got %d", len(stmt.Options))
+		}
+	})
+
+	t.Run("or replace managed account", func(t *testing.T) {
+		stmt := mustCreateAccount(t, "CREATE OR REPLACE MANAGED ACCOUNT ra1 ADMIN_NAME = admin, ADMIN_PASSWORD = 'pw', TYPE = READER")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER ACCOUNT — current-account + cross-account forms
+// ---------------------------------------------------------------------------
+
+func TestParseAlterAccount(t *testing.T) {
+	t.Run("set param", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET NETWORK_POLICY = mypolicy")
+		if stmt.Name != nil {
+			t.Errorf("Name should be nil for current-account, got %v", stmt.Name)
+		}
+		if stmt.Action != ast.AlterAccountSet {
+			t.Fatalf("Action=%d", stmt.Action)
+		}
+		np := findGroupOption(stmt.Options, "NETWORK_POLICY")
+		if np == nil || len(np.Values) != 1 || np.Values[0] != "MYPOLICY" {
+			t.Errorf("NETWORK_POLICY=%v", np)
+		}
+	})
+
+	t.Run("set boolean param", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET DISABLE_USER_PRIVILEGE_GRANTS = TRUE")
+		o := findGroupOption(stmt.Options, "DISABLE_USER_PRIVILEGE_GRANTS")
+		if o == nil || len(o.Values) != 1 || o.Values[0] != "TRUE" {
+			t.Errorf("opt=%v", o)
+		}
+	})
+
+	t.Run("set multiple params", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET TIMEZONE = 'UTC', STATEMENT_TIMEOUT_IN_SECONDS = 3600")
+		if len(stmt.Options) != 2 {
+			t.Errorf("expected 2 options, got %d: %+v", len(stmt.Options), stmt.Options)
+		}
+	})
+
+	t.Run("set resource monitor", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET RESOURCE_MONITOR = my_monitor")
+		o := findGroupOption(stmt.Options, "RESOURCE_MONITOR")
+		if o == nil || o.Values[0] != "MY_MONITOR" {
+			t.Errorf("RESOURCE_MONITOR=%v", o)
+		}
+	})
+
+	t.Run("unset param", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT UNSET NETWORK_POLICY")
+		if stmt.Action != ast.AlterAccountUnset || len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "NETWORK_POLICY" {
+			t.Errorf("Action=%d UnsetProps=%v", stmt.Action, stmt.UnsetProps)
+		}
+	})
+
+	t.Run("unset multiple params", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT UNSET TIMEZONE, NETWORK_POLICY")
+		if len(stmt.UnsetProps) != 2 {
+			t.Errorf("UnsetProps=%v", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET TAG cost_center = 'sales'")
+		if stmt.Action != ast.AlterAccountSetTag || len(stmt.Tags) != 1 {
+			t.Errorf("Action=%d Tags=%+v", stmt.Action, stmt.Tags)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT UNSET TAG cost_center")
+		if stmt.Action != ast.AlterAccountUnsetTag || len(stmt.UnsetTags) != 1 {
+			t.Errorf("Action=%d UnsetTags=%v", stmt.Action, stmt.UnsetTags)
+		}
+	})
+
+	t.Run("set packages policy force", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET PACKAGES POLICY packages_policy_prod_1 FORCE")
+		if stmt.Action != ast.AlterAccountSetPolicy {
+			t.Fatalf("Action=%d, want SetPolicy", stmt.Action)
+		}
+		if stmt.PolicyKind != "PACKAGES POLICY" || stmt.PolicyName.String() != "packages_policy_prod_1" || !stmt.Force {
+			t.Errorf("Kind=%q Name=%v Force=%v", stmt.PolicyKind, stmt.PolicyName, stmt.Force)
+		}
+	})
+
+	t.Run("set password policy", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET PASSWORD POLICY my_pp")
+		if stmt.PolicyKind != "PASSWORD POLICY" || stmt.Force {
+			t.Errorf("Kind=%q Force=%v", stmt.PolicyKind, stmt.Force)
+		}
+	})
+
+	t.Run("set authentication policy with scope + force", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET AUTHENTICATION POLICY my_ap FOR ALL PERSON USERS FORCE")
+		if stmt.PolicyKind != "AUTHENTICATION POLICY" || stmt.PolicyScope != "FOR ALL PERSON USERS" || !stmt.Force {
+			t.Errorf("Kind=%q Scope=%q Force=%v", stmt.PolicyKind, stmt.PolicyScope, stmt.Force)
+		}
+	})
+
+	t.Run("set session policy", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET SESSION POLICY my_sp")
+		if stmt.PolicyKind != "SESSION POLICY" {
+			t.Errorf("Kind=%q", stmt.PolicyKind)
+		}
+	})
+
+	t.Run("set feature policy for all applications", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT SET FEATURE POLICY my_fp FOR ALL APPLICATIONS FORCE")
+		if stmt.PolicyKind != "FEATURE POLICY" || stmt.PolicyScope != "FOR ALL APPLICATIONS" || !stmt.Force {
+			t.Errorf("Kind=%q Scope=%q Force=%v", stmt.PolicyKind, stmt.PolicyScope, stmt.Force)
+		}
+	})
+
+	t.Run("unset packages policy", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT UNSET PACKAGES POLICY")
+		if stmt.Action != ast.AlterAccountUnsetPolicy || stmt.PolicyKind != "PACKAGES POLICY" {
+			t.Errorf("Action=%d Kind=%q", stmt.Action, stmt.PolicyKind)
+		}
+	})
+
+	t.Run("unset authentication policy with scope", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT UNSET AUTHENTICATION POLICY FOR ALL SERVICE USERS")
+		if stmt.Action != ast.AlterAccountUnsetPolicy || stmt.PolicyScope != "FOR ALL SERVICE USERS" {
+			t.Errorf("Action=%d Scope=%q", stmt.Action, stmt.PolicyScope)
+		}
+	})
+
+	t.Run("cross-account set edition", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT myaccount SET EDITION = 'ENTERPRISE'")
+		if stmt.Name == nil || stmt.Name.String() != "myaccount" {
+			t.Errorf("Name=%v", stmt.Name)
+		}
+		if stmt.Action != ast.AlterAccountSet {
+			t.Errorf("Action=%d", stmt.Action)
+		}
+	})
+
+	t.Run("cross-account set is_org_admin", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT myaccount SET IS_ORG_ADMIN = TRUE")
+		if stmt.Name == nil {
+			t.Error("Name not set")
+		}
+	})
+
+	t.Run("rename", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT myaccount RENAME TO myaccount2")
+		if stmt.Action != ast.AlterAccountRename || stmt.Name.String() != "myaccount" || stmt.NewName.String() != "myaccount2" {
+			t.Errorf("Action=%d Name=%v NewName=%v", stmt.Action, stmt.Name, stmt.NewName)
+		}
+		if stmt.SaveOldURL != nil {
+			t.Errorf("SaveOldURL should be nil, got %v", *stmt.SaveOldURL)
+		}
+	})
+
+	t.Run("rename save old url", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT myaccount RENAME TO myaccount2 SAVE_OLD_URL = FALSE")
+		if stmt.SaveOldURL == nil || *stmt.SaveOldURL {
+			t.Errorf("SaveOldURL=%v, want false", stmt.SaveOldURL)
+		}
+	})
+
+	t.Run("drop old url", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT myaccount DROP OLD URL")
+		if stmt.Action != ast.AlterAccountDropURL || stmt.Organization {
+			t.Errorf("Action=%d Organization=%v", stmt.Action, stmt.Organization)
+		}
+	})
+
+	t.Run("drop old organization url", func(t *testing.T) {
+		stmt := mustAlterAccount(t, "ALTER ACCOUNT myaccount DROP OLD ORGANIZATION URL")
+		if !stmt.Organization {
+			t.Error("Organization not set")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SHARE
+// ---------------------------------------------------------------------------
+
+func TestParseCreateShare(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		stmt := mustCreateShare(t, "CREATE SHARE sales_s")
+		if stmt.Name.String() != "sales_s" {
+			t.Errorf("Name=%q", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.IfNotExists || len(stmt.Options) != 0 {
+			t.Errorf("unexpected: %+v", stmt)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateShare(t, "CREATE OR REPLACE SHARE s")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateShare(t, "CREATE SHARE IF NOT EXISTS s")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("comment", func(t *testing.T) {
+		stmt := mustCreateShare(t, "CREATE SHARE s COMMENT = 'my share'")
+		c := findGroupOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "my share" {
+			t.Errorf("COMMENT=%v", c)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SHARE
+// ---------------------------------------------------------------------------
+
+func TestParseAlterShare(t *testing.T) {
+	t.Run("add accounts", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s ADD ACCOUNTS = org.acct1, org.acct2")
+		if stmt.Action != ast.AlterShareAdd || names(stmt.Accounts) != "org.acct1,org.acct2" {
+			t.Errorf("Action=%d Accounts=%q", stmt.Action, names(stmt.Accounts))
+		}
+	})
+
+	t.Run("add accounts share restrictions", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s ADD ACCOUNTS = org.a SHARE_RESTRICTIONS = FALSE")
+		if stmt.ShareRestrictions == nil || *stmt.ShareRestrictions {
+			t.Errorf("ShareRestrictions=%v, want false", stmt.ShareRestrictions)
+		}
+	})
+
+	t.Run("remove accounts", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s REMOVE ACCOUNTS = org.a")
+		if stmt.Action != ast.AlterShareRemove {
+			t.Errorf("Action=%d", stmt.Action)
+		}
+	})
+
+	t.Run("if exists add accounts", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE IF EXISTS s ADD ACCOUNTS = org.a")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+	})
+
+	t.Run("set accounts + comment", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s SET ACCOUNTS = org.a1, org.a2 COMMENT = 'updated'")
+		if stmt.Action != ast.AlterShareSet || names(stmt.Accounts) != "org.a1,org.a2" {
+			t.Errorf("Action=%d Accounts=%q", stmt.Action, names(stmt.Accounts))
+		}
+		c := findGroupOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit.Value != "updated" {
+			t.Errorf("COMMENT=%v", c)
+		}
+	})
+
+	t.Run("set comment only", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s SET COMMENT = 'x'")
+		if stmt.Action != ast.AlterShareSet || len(stmt.Accounts) != 0 {
+			t.Errorf("Action=%d Accounts=%v", stmt.Action, stmt.Accounts)
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s SET TAG t = 'v'")
+		if stmt.Action != ast.AlterShareSetTag || len(stmt.Tags) != 1 {
+			t.Errorf("Action=%d Tags=%+v", stmt.Action, stmt.Tags)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s UNSET TAG t1, t2")
+		if stmt.Action != ast.AlterShareUnsetTag || len(stmt.UnsetTags) != 2 {
+			t.Errorf("Action=%d UnsetTags=%v", stmt.Action, stmt.UnsetTags)
+		}
+	})
+
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterShare(t, "ALTER SHARE s UNSET COMMENT")
+		if stmt.Action != ast.AlterShareUnset || len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("Action=%d UnsetProps=%v", stmt.Action, stmt.UnsetProps)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — malformed statements must be rejected
+// ---------------------------------------------------------------------------
+
+func TestParseReplicationShare_Negative(t *testing.T) {
+	bad := []string{
+		// FAILOVER / REPLICATION GROUP
+		"CREATE FAILOVER GROUP", // missing GROUP? no — missing name
+		"CREATE FAILOVER GROUP fg OBJECT_TYPES = (DATABASES) ALLOWED_ACCOUNTS = o.a", // parenthesized list not valid (docs+grammar use bare comma lists)
+		"CREATE FAILOVER fg OBJECT_TYPES = ROLES",                                    // missing GROUP keyword
+		"CREATE FAILOVER GROUP fg OBJECT_TYPES =",                                    // option missing value
+		"CREATE FAILOVER GROUP fg AS REPLICA",                                        // missing OF
+		"CREATE FAILOVER GROUP fg AS REPLICA OF",                                     // missing source name
+		"CREATE FAILOVER GROUP fg AS OF a.b.c",                                       // missing REPLICA
+		"CREATE REPLICATION fg OBJECT_TYPES = ROLES",                                 // missing GROUP keyword
+		"ALTER FAILOVER GROUP",                                                       // missing name
+		"ALTER FAILOVER GROUP fg",                                                    // missing action
+		"ALTER FAILOVER GROUP fg RENAME",                                             // missing TO
+		"ALTER FAILOVER GROUP fg RENAME TO",                                          // missing new name
+		"ALTER FAILOVER GROUP fg SET",                                                // nothing to set
+		"ALTER FAILOVER GROUP fg SET TAG",                                            // missing tag assignment
+		"ALTER FAILOVER GROUP fg SET TAG t =",                                        // tag missing value
+		"ALTER FAILOVER GROUP fg UNSET",                                              // missing property
+		"ALTER FAILOVER GROUP fg UNSET TAG",                                          // missing tag name
+		"ALTER FAILOVER GROUP fg ADD db1 TO",                                         // missing target
+		"ALTER FAILOVER GROUP fg ADD db1 TO FROBNICATE",                              // bad target
+		"ALTER FAILOVER GROUP fg ADD TO ALLOWED_DATABASES",                           // missing name list
+		"ALTER FAILOVER GROUP fg REMOVE db1 ALLOWED_DATABASES",                       // missing FROM
+		"ALTER FAILOVER GROUP fg MOVE db1 TO FAILOVER GROUP fg2",                     // missing DATABASES/SHARES
+		"ALTER FAILOVER GROUP fg MOVE DATABASES db1 TO fg2",                          // missing FAILOVER/REPLICATION GROUP
+		"ALTER FAILOVER GROUP fg MOVE DATABASES db1 TO FAILOVER fg2",                 // missing GROUP
+		"ALTER FAILOVER GROUP fg FROBNICATE",                                         // unknown action
+		// ACCOUNT
+		"CREATE ACCOUNT",                    // missing name
+		"CREATE ACCOUNT a ADMIN_NAME =",     // option missing value
+		"CREATE MANAGED a ADMIN_NAME = x",   // missing ACCOUNT keyword
+		"ALTER ACCOUNT",                     // missing action
+		"ALTER ACCOUNT SET",                 // nothing to set
+		"ALTER ACCOUNT SET TAG",             // missing tag assignment
+		"ALTER ACCOUNT UNSET",               // missing property
+		"ALTER ACCOUNT a RENAME",            // missing TO
+		"ALTER ACCOUNT a RENAME TO",         // missing new name
+		"ALTER ACCOUNT a DROP OLD",          // missing URL
+		"ALTER ACCOUNT a DROP URL",          // missing OLD
+		"ALTER ACCOUNT a FROBNICATE",        // unknown action
+		"ALTER ACCOUNT SET PACKAGES POLICY", // missing policy name
+		// SHARE
+		"CREATE SHARE",                 // missing name
+		"CREATE SHARE IF NOT s",        // malformed IF NOT EXISTS
+		"ALTER SHARE",                  // missing name
+		"ALTER SHARE s",                // missing action
+		"ALTER SHARE s ADD",            // missing ACCOUNTS
+		"ALTER SHARE s ADD ACCOUNTS",   // missing =
+		"ALTER SHARE s ADD ACCOUNTS =", // missing account list
+		"ALTER SHARE s SET",            // nothing to set
+		"ALTER SHARE s SET TAG",        // missing tag assignment
+		"ALTER SHARE s UNSET",          // missing property
+		"ALTER SHARE s UNSET TAG",      // missing tag name
+		"ALTER SHARE s FROBNICATE",     // unknown action
+	}
+	for _, in := range bad {
+		t.Run(in, func(t *testing.T) {
+			result := ParseBestEffort(in)
+			if len(result.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got none (stmts=%d)", in, len(result.File.Stmts))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loc accuracy
+// ---------------------------------------------------------------------------
+
+func TestParseReplicationShare_Loc(t *testing.T) {
+	// CREATE Loc starts at the CREATE keyword (offset 0).
+	in := "CREATE SHARE s"
+	stmt := mustCreateShare(t, in)
+	if stmt.Loc.Start != 0 || stmt.Loc.End != len(in) {
+		t.Errorf("CREATE SHARE Loc = %+v, want {0, %d}", stmt.Loc, len(in))
+	}
+
+	in2 := "CREATE FAILOVER GROUP fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct"
+	g := mustCreateGroup(t, in2)
+	if g.Loc.Start != 0 || g.Loc.End != len(in2) {
+		t.Errorf("CREATE GROUP Loc = %+v, want {0, %d}", g.Loc, len(in2))
+	}
+
+	// ALTER sub-parsers anchor Loc.Start at the object-type keyword, not ALTER
+	// (matching the established ALTER TABLE/STAGE/integration convention).
+	const alterPrefix = len("ALTER ")
+	ai := "ALTER SHARE s UNSET COMMENT"
+	as := mustAlterShare(t, ai)
+	if as.Loc.Start != alterPrefix || as.Loc.End != len(ai) {
+		t.Errorf("ALTER SHARE Loc = %+v, want {%d, %d}", as.Loc, alterPrefix, len(ai))
+	}
+
+	ag := "ALTER FAILOVER GROUP fg PRIMARY"
+	gs := mustAlterGroup(t, ag)
+	if gs.Loc.Start != alterPrefix || gs.Loc.End != len(ag) {
+		t.Errorf("ALTER GROUP Loc = %+v, want {%d, %d}", gs.Loc, alterPrefix, len(ag))
+	}
+
+	// ALTER ACCOUNT anchors at the ACCOUNT keyword.
+	aa := "ALTER ACCOUNT SET NETWORK_POLICY = mypolicy"
+	aas := mustAlterAccount(t, aa)
+	if aas.Loc.Start != alterPrefix || aas.Loc.End != len(aa) {
+		t.Errorf("ALTER ACCOUNT Loc = %+v, want {%d, %d}", aas.Loc, alterPrefix, len(aa))
+	}
+
+	// Second statement gets a non-zero base offset; Loc must still be absolute.
+	multi := "SELECT 1;\nCREATE SHARE s COMMENT = 'x'"
+	res := ParseBestEffort(multi)
+	if len(res.Errors) != 0 {
+		t.Fatalf("multi parse errors: %v", res.Errors)
+	}
+	if len(res.File.Stmts) != 2 {
+		t.Fatalf("expected 2 stmts, got %d", len(res.File.Stmts))
+	}
+	cs := res.File.Stmts[1].(*ast.CreateShareStmt)
+	base := strings.Index(multi, "CREATE SHARE")
+	if cs.Loc.Start != base {
+		t.Errorf("second-stmt Loc.Start = %d, want %d", cs.Loc.Start, base)
+	}
+	c := findGroupOption(cs.Options, "COMMENT")
+	if c == nil || c.Lit == nil || c.Lit.Value != "x" {
+		t.Errorf("COMMENT literal not correct after base offset: %v", c)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk integration — the new statements must be walkable without panic, and the
+// walker must reach their ObjectName children.
+// ---------------------------------------------------------------------------
+
+func TestParseReplicationShare_Walk(t *testing.T) {
+	inputs := []string{
+		"CREATE FAILOVER GROUP fg OBJECT_TYPES = ROLES ALLOWED_ACCOUNTS = org.acct",
+		"CREATE FAILOVER GROUP fg2 AS REPLICA OF a.b.c",
+		"ALTER FAILOVER GROUP fg ADD db1 TO ALLOWED_DATABASES",
+		"ALTER FAILOVER GROUP fg MOVE DATABASES db1 TO FAILOVER GROUP fg2",
+		"CREATE ACCOUNT a ADMIN_NAME = x ADMIN_PASSWORD = 'p' EMAIL = 'e@x.com' EDITION = STANDARD",
+		"ALTER ACCOUNT a RENAME TO b",
+		"CREATE SHARE s COMMENT = 'x'",
+		"ALTER SHARE s SET ACCOUNTS = org.a COMMENT = 'x'",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			node := mustParseOne(t, in)
+			count := 0
+			ast.Inspect(node, func(n ast.Node) bool {
+				if n != nil {
+					count++
+				}
+				return true
+			})
+			if count == 0 {
+				t.Errorf("walk visited no nodes for %q", in)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official docs corpus — every CREATE SHARE / ALTER ACCOUNT statement in the
+// corresponding corpus directory must parse with zero errors to its expected AST
+// type. The official docs are the authoritative oracle (truth1).
+// ---------------------------------------------------------------------------
+
+func TestReplicationShare_OfficialCorpus(t *testing.T) {
+	t.Run("create-share", func(t *testing.T) {
+		runReplShareCorpus(t, "testdata/official/create-share", "CREATE", "SHARE",
+			func(n ast.Node) bool { _, ok := n.(*ast.CreateShareStmt); return ok })
+	})
+	t.Run("alter-account", func(t *testing.T) {
+		runReplShareCorpus(t, "testdata/official/alter-account", "ALTER", "ACCOUNT",
+			func(n ast.Node) bool { _, ok := n.(*ast.AlterAccountStmt); return ok })
+	})
+}
+
+// runReplShareCorpus parses every .sql file in dir and asserts each statement
+// whose first two words are <verb> <obj> parses cleanly to the wanted type.
+func runReplShareCorpus(t *testing.T, dir, verb, obj string, wantFn func(ast.Node) bool) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read corpus dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			for _, seg := range Split(string(data)) {
+				text := strings.TrimSpace(seg.Text)
+				if text == "" {
+					continue
+				}
+				fields := strings.Fields(strings.ToUpper(text))
+				if len(fields) < 2 || fields[0] != verb || fields[1] != obj {
+					continue
+				}
+				node, errs := parseSingle(seg.Text, seg.ByteStart)
+				if len(errs) > 0 {
+					t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+					continue
+				}
+				if !wantFn(node) {
+					t.Errorf("statement %q parsed to unexpected type %T", text, node)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-replication` (v1 DAG **T4.8**) — `CREATE`/`ALTER` replication & sharing objects: `FAILOVER GROUP`, `REPLICATION GROUP` (incl. `AS REPLICA OF` secondary form), `ACCOUNT` / `MANAGED ACCOUNT`, `SHARE`. `DROP` for these was already merged (drop.go), untouched.

## Design
Config + object-type/database/account/share lists parsed as open-ended `KEY = <value>` options (`ast.CopyOption`), mirroring the merged STAGE/FILE-FORMAT/integration machinery. CREATE dispatch wired into `parseCreateStmt` (`kwFAILOVER`/`kwREPLICATION` → GROUP, `kwACCOUNT`, `kwMANAGED` → ACCOUNT, `kwSHARE`), ALTER into `parseAlterStmt`; new AST nodes + tags (valid Loc), `walk_generated.go` regenerated via `genwalker`.

## Oracle / tests
Triangulation — legacy ANTLR (`create_failover_group`/`create_replication_group`/`create_account`/`create_managed_account`/`create_share`/`alter_*`) + official docs (docs win) + corpus `testdata/official/{create-share, alter-account}` (no failover/replication-group corpus — covered from docs + .g4). `go build`/`go vet`/`gofmt` clean; `go test ./snowflake/parser/... ./snowflake/ast/... -timeout 120s` green.

## Divergences (flagged)
- Open-ended `KEY=value` options + lists vs the stale legacy enumerations (docs win) — consistent with the merged STAGE/FILE-FORMAT/integration siblings. Standard `CREATE OR ALTER`/`$N` corpus filters apply (owned by `parser-or-alter`/`expr-dollar-refs`).

## Review / provenance
The worker completed the code (build + `-timeout` tests green, scope = the 6 declared files, gofmt clean) but **froze at its finish step before committing** — confirmed via a clock-independent transcript-size delta probe (0 bytes growth over 90s). The orchestrator independently verified (build / tests / scope / gofmt), committed it (`c5ed7c87`), and opened this PR. The worker's full divergence write-up was lost to the freeze; `corpus-closure` (M2) re-verifies all parsing at the end. Codex lens unavailable (out of credits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)