### PR TITLE
feat(snowflake): T4.9 CREATE / ALTER TAG / SEMANTIC VIEW / DATASET

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -128,6 +128,14 @@ const (
 	T_CreateShareStmt
 	T_AlterShareStmt
 
+	// Tag / semantic-view / dataset DDL tags (T4.9)
+	T_CreateTagStmt
+	T_AlterTagStmt
+	T_SemanticViewSection
+	T_CreateSemanticViewStmt
+	T_AlterSemanticViewStmt
+	T_CreateDatasetStmt
+
 	// Data-pipeline DDL tags (T4.3)
 	T_CreatePipeStmt
 	T_AlterPipeStmt
@@ -398,6 +406,18 @@ func (t NodeTag) String() string {
 		return "AlterUserStmt"
 	case T_AlterPolicyStmt:
 		return "AlterPolicyStmt"
+	case T_CreateTagStmt:
+		return "CreateTagStmt"
+	case T_AlterTagStmt:
+		return "AlterTagStmt"
+	case T_SemanticViewSection:
+		return "SemanticViewSection"
+	case T_CreateSemanticViewStmt:
+		return "CreateSemanticViewStmt"
+	case T_AlterSemanticViewStmt:
+		return "AlterSemanticViewStmt"
+	case T_CreateDatasetStmt:
+		return "CreateDatasetStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -3294,6 +3294,205 @@ var (
 )
 
 // ---------------------------------------------------------------------------
+// Tag / semantic-view / dataset DDL — CREATE / ALTER (T4.9)
+// ---------------------------------------------------------------------------
+//
+// Three governance / semantic-layer objects:
+//
+//   - TAG: a named label whose CREATE carries an ALLOWED_VALUES string list plus
+//     a small, version-growing option vocabulary (PROPAGATE, ON_CONFLICT,
+//     COMMENT). The legacy ANTLR grammar's create_tag rule modeled only
+//     `tag_allowed_values? comment_clause?` and so lacks PROPAGATE / ON_CONFLICT
+//     (both present in the official docs and the create-tag corpus). To avoid
+//     re-staling, every clause after ALLOWED_VALUES is captured open-ended as a
+//     CopyOption; only ALLOWED_VALUES — the one structural anchor the docs pin
+//     to first position — is lifted into a dedicated field.
+//   - SEMANTIC VIEW: a logical model over tables. Its TABLES / RELATIONSHIPS /
+//     FACTS / DIMENSIONS / METRICS / AI_VERIFIED_QUERIES sections are each a
+//     comma-separated definition list inside a parenthesized group whose inner
+//     grammar is large and version-growing; rather than model each inner
+//     definition, each section's body is captured as a balanced raw group
+//     (SemanticViewSection). The trailing scalar clauses (COMMENT,
+//     AI_SQL_GENERATION, AI_QUESTION_CATEGORIZATION) are open-ended options, and
+//     the [WITH] TAG / COPY GRANTS clauses are the remaining structural anchors.
+//   - DATASET: a newer ML object whose CREATE is, per both the docs and the
+//     legacy grammar, just a name (no options).
+//
+// This mirrors the merged STAGE (T4.1) / FILE FORMAT (T4.2) / integration (T4.7)
+// open-ended philosophy: the catalog/semantic layer, not the parser, validates
+// that an option is real and legal.
+
+// CreateTagStmt represents
+//
+//	CREATE [ OR REPLACE ] TAG [ IF NOT EXISTS ] <name>
+//	  [ ALLOWED_VALUES '<v1>' [ , '<v2>' ... ] ]
+//	  [ PROPAGATE = { ON_DEPENDENCY_AND_DATA_MOVEMENT | ON_DEPENDENCY | ON_DATA_MOVEMENT }
+//	    [ ON_CONFLICT = { '<string>' | ALLOWED_VALUES_SEQUENCE } ] ]
+//	  [ COMMENT = '<string_literal>' ]
+//
+// AllowedValues holds the ALLOWED_VALUES string list (nil when the clause is
+// absent). Options captures the trailing PROPAGATE / ON_CONFLICT / COMMENT
+// clauses open-ended, in source order.
+type CreateTagStmt struct {
+	OrReplace     bool
+	IfNotExists   bool
+	Name          *ObjectName
+	AllowedValues []string      // ALLOWED_VALUES 'v1', 'v2', ...; nil if absent
+	Options       []*CopyOption // PROPAGATE / ON_CONFLICT / COMMENT; source order
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *CreateTagStmt) Tag() NodeTag { return T_CreateTagStmt }
+
+// AlterTagAction discriminates the action variants of ALTER TAG.
+type AlterTagAction int
+
+const (
+	AlterTagRename             AlterTagAction = iota // RENAME TO <new_name>
+	AlterTagAddAllowedValues                         // ADD ALLOWED_VALUES '<v>' [ , ... ]
+	AlterTagDropAllowedValues                        // DROP ALLOWED_VALUES '<v>' [ , ... ]
+	AlterTagSet                                      // SET [ ALLOWED_VALUES ... ] [ PROPAGATE ... ] [ COMMENT ... ]
+	AlterTagUnset                                    // UNSET { ALLOWED_VALUES | PROPAGATE | ON_CONFLICT | COMMENT | DCM PROJECT }
+	AlterTagSetMaskingPolicy                         // SET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ] [ FORCE ]
+	AlterTagUnsetMaskingPolicy                       // UNSET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ]
+)
+
+// AlterTagStmt represents ALTER TAG [ IF EXISTS ] <name> <action>.
+//
+//	RENAME TO <new_name>
+//	{ ADD | DROP } ALLOWED_VALUES '<v>' [ , ... ]
+//	SET [ ALLOWED_VALUES '<v>' [ , ... ] ] [ PROPAGATE = ... [ ON_CONFLICT = ... ] ] [ COMMENT = '...' ]
+//	UNSET { ALLOWED_VALUES | PROPAGATE | ON_CONFLICT | COMMENT | DCM PROJECT }
+//	SET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ] [ FORCE ]
+//	UNSET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ]
+type AlterTagStmt struct {
+	IfExists        bool
+	Name            *ObjectName
+	Action          AlterTagAction
+	NewName         *ObjectName   // RENAME TO target; for AlterTagRename
+	AllowedValues   []string      // ADD/DROP/SET ALLOWED_VALUES list
+	Options         []*CopyOption // SET <options> (ALLOWED_VALUES lives in AllowedValues; PROPAGATE / ON_CONFLICT / COMMENT here)
+	UnsetProps      []string      // UNSET <property> names (ALLOWED_VALUES / PROPAGATE / ON_CONFLICT / COMMENT / DCM PROJECT)
+	MaskingPolicies []*ObjectName // SET/UNSET MASKING POLICY names
+	Force           bool          // SET MASKING POLICY ... FORCE
+	Loc             Loc
+}
+
+// Tag implements Node.
+func (n *AlterTagStmt) Tag() NodeTag { return T_AlterTagStmt }
+
+// SemanticViewSection is one section of a CREATE SEMANTIC VIEW body — a keyword
+// (TABLES / RELATIONSHIPS / FACTS / DIMENSIONS / METRICS / AI_VERIFIED_QUERIES)
+// followed by a parenthesized, comma-separated definition list. The inner
+// grammar of each section is large and version-growing, so the body is captured
+// as the verbatim source text between the section's outer parentheses (the
+// parentheses themselves are not included in Body) rather than fully modeled.
+type SemanticViewSection struct {
+	Keyword string // uppercased section keyword: TABLES, RELATIONSHIPS, FACTS, DIMENSIONS, METRICS, AI_VERIFIED_QUERIES
+	Body    string // verbatim source text inside the section's ( ... ); excludes the parens
+	Loc     Loc    // spans the keyword through the closing ')'
+}
+
+// Tag implements Node.
+func (n *SemanticViewSection) Tag() NodeTag { return T_SemanticViewSection }
+
+// CreateSemanticViewStmt represents
+//
+//	CREATE [ OR REPLACE ] SEMANTIC VIEW [ IF NOT EXISTS ] <name>
+//	  TABLES ( ... )
+//	  [ RELATIONSHIPS ( ... ) ]
+//	  [ FACTS ( ... ) ]
+//	  [ DIMENSIONS ( ... ) ]
+//	  [ METRICS ( ... ) ]
+//	  [ COMMENT = '<string>' ]
+//	  [ AI_SQL_GENERATION '<instructions>' ]
+//	  [ AI_QUESTION_CATEGORIZATION '<instructions>' ]
+//	  [ AI_VERIFIED_QUERIES ( ... ) ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//	  [ COPY GRANTS ]
+//
+// Sections holds the parenthesized definition-list sections (TABLES first, per
+// the docs, then the optional RELATIONSHIPS / FACTS / DIMENSIONS / METRICS /
+// AI_VERIFIED_QUERIES), each as a balanced raw group. Options captures the
+// scalar trailing clauses (COMMENT, AI_SQL_GENERATION, AI_QUESTION_CATEGORIZATION)
+// open-ended. Tags holds a [WITH] TAG clause; CopyGrants records COPY GRANTS.
+type CreateSemanticViewStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Sections    []*SemanticViewSection // TABLES / RELATIONSHIPS / FACTS / DIMENSIONS / METRICS / AI_VERIFIED_QUERIES, source order
+	Options     []*CopyOption          // COMMENT / AI_SQL_GENERATION / AI_QUESTION_CATEGORIZATION; source order
+	Tags        []*TagAssignment       // [WITH] TAG (...); nil if absent
+	CopyGrants  bool
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateSemanticViewStmt) Tag() NodeTag { return T_CreateSemanticViewStmt }
+
+// AlterSemanticViewAction discriminates the action variants of ALTER SEMANTIC
+// VIEW.
+type AlterSemanticViewAction int
+
+const (
+	AlterSemanticViewRename   AlterSemanticViewAction = iota // RENAME TO <new_name>
+	AlterSemanticViewSet                                     // SET COMMENT = '...'
+	AlterSemanticViewUnset                                   // UNSET COMMENT
+	AlterSemanticViewSetTag                                  // SET TAG <tag> = '<value>' [ , ... ]
+	AlterSemanticViewUnsetTag                                // UNSET TAG <tag> [ , ... ]
+)
+
+// AlterSemanticViewStmt represents ALTER SEMANTIC VIEW [ IF EXISTS ] <name>
+// <action>.
+//
+//	RENAME TO <new_name>
+//	SET COMMENT = '<string_literal>'
+//	UNSET COMMENT
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+type AlterSemanticViewStmt struct {
+	IfExists   bool
+	Name       *ObjectName
+	Action     AlterSemanticViewAction
+	NewName    *ObjectName      // RENAME TO target; for AlterSemanticViewRename
+	Options    []*CopyOption    // SET COMMENT; for AlterSemanticViewSet
+	Tags       []*TagAssignment // SET TAG assignments; for AlterSemanticViewSetTag
+	UnsetTags  []*ObjectName    // UNSET TAG names; for AlterSemanticViewUnsetTag
+	UnsetProps []string         // UNSET <property> names (COMMENT); for AlterSemanticViewUnset
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *AlterSemanticViewStmt) Tag() NodeTag { return T_AlterSemanticViewStmt }
+
+// CreateDatasetStmt represents CREATE [ OR REPLACE ] DATASET [ IF NOT EXISTS ]
+// <name>. DATASET is a newer ML object whose CREATE carries no options in either
+// the docs or the legacy grammar — only the name. (The official docs render
+// IF NOT EXISTS before DATASET; the legacy grammar and every other CREATE object
+// in this engine place it after the object keyword. The post-keyword spelling is
+// accepted here for consistency; see the divergence note in semantic_view.go.)
+type CreateDatasetStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateDatasetStmt) Tag() NodeTag { return T_CreateDatasetStmt }
+
+// Compile-time assertions for tag / semantic-view / dataset DDL nodes.
+var (
+	_ Node = (*CreateTagStmt)(nil)
+	_ Node = (*AlterTagStmt)(nil)
+	_ Node = (*SemanticViewSection)(nil)
+	_ Node = (*CreateSemanticViewStmt)(nil)
+	_ Node = (*AlterSemanticViewStmt)(nil)
+	_ Node = (*CreateDatasetStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
 // Data-pipeline DDL — CREATE / ALTER PIPE / STREAM / TASK / ALERT (T4.3)
 // ---------------------------------------------------------------------------
 //

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -106,6 +106,13 @@ func walkChildren(v Visitor, node Node) {
 		if n.NewName != nil {
 			Walk(v, n.NewName)
 		}
+	case *AlterSemanticViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *AlterSequenceStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -131,6 +138,13 @@ func walkChildren(v Visitor, node Node) {
 	case *AlterTableStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+	case *AlterTagStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
 		}
 	case *AlterTaskStmt:
 		if n.Name != nil {
@@ -234,6 +248,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *CreateDatasetStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreateDynamicTableStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -308,6 +326,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *CreateSemanticViewStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreateSequenceStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -338,6 +360,10 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.AsSelect)
 		if n.Like != nil {
 			Walk(v, n.Like)
+		}
+	case *CreateTagStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
 		}
 	case *CreateTaskStmt:
 		if n.Name != nil {

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -178,6 +178,16 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// SECRET, CONNECTION, GIT REPOSITORY. parseCreateIntegrationStmt consumes the
 		// object-type keyword(s).
 		return p.parseCreateIntegrationStmt(start, orReplace)
+	case kwTAG:
+		// CREATE [OR REPLACE] TAG ... (T4.9).
+		return p.parseCreateTagStmt(start, orReplace)
+	case kwSEMANTIC:
+		// CREATE [OR REPLACE] SEMANTIC VIEW ... (T4.9). The sub-parser consumes
+		// SEMANTIC + VIEW.
+		return p.parseCreateSemanticViewStmt(start, orReplace)
+	case kwDATASET:
+		// CREATE [OR REPLACE] DATASET ... (T4.9).
+		return p.parseCreateDatasetStmt(start, orReplace)
 	case kwFAILOVER, kwREPLICATION:
 		// CREATE [OR REPLACE] { FAILOVER | REPLICATION } GROUP ... (T4.8).
 		// parseCreateReplicationGroupStmt consumes the kind keyword + GROUP.

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -228,6 +228,12 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// CONNECTION, GIT REPOSITORY. A bare ALTER INTEGRATION (qualifier omitted)
 		// dispatches here too. parseAlterIntegrationStmt consumes the keyword(s).
 		return p.parseAlterIntegrationStmt()
+	case kwTAG:
+		// ALTER TAG ... (T4.9).
+		return p.parseAlterTagStmt()
+	case kwSEMANTIC:
+		// ALTER SEMANTIC VIEW ... (T4.9). The sub-parser consumes SEMANTIC + VIEW.
+		return p.parseAlterSemanticViewStmt()
 	case kwFAILOVER, kwREPLICATION:
 		// ALTER { FAILOVER | REPLICATION } GROUP ... (T4.8). The sub-parser consumes
 		// the kind keyword + GROUP.

--- a/snowflake/parser/semantic_view.go
+++ b/snowflake/parser/semantic_view.go
@@ -1,0 +1,589 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Tag / semantic-view / dataset DDL — CREATE / ALTER (T4.9)
+// ---------------------------------------------------------------------------
+//
+// Three governance / semantic-layer objects, all following the merged STAGE
+// (T4.1) / FILE FORMAT (T4.2) / integration (T4.7) open-ended philosophy: the
+// option vocabularies are large and version-growing, so every clause after a
+// structural anchor is captured as an open-ended `KEY = <value>` CopyOption and
+// the catalog/semantic layer (not the parser) validates legality.
+//
+//   - TAG: CREATE carries an ALLOWED_VALUES string list (the one anchor the docs
+//     pin to first position) plus PROPAGATE / ON_CONFLICT / COMMENT options. The
+//     legacy ANTLR create_tag rule modeled only `tag_allowed_values?
+//     comment_clause?` and so lacks PROPAGATE / ON_CONFLICT — both present in the
+//     official docs and the create-tag corpus (example_02). The docs (truth1)
+//     win: trailing clauses are open-ended. ALTER TAG mirrors the docs' richer
+//     surface (RENAME / ADD|DROP ALLOWED_VALUES / SET / UNSET multi-property /
+//     SET|UNSET MASKING POLICY [FORCE] / UNSET DCM PROJECT), which exceeds the
+//     legacy alter_tag_opts rule.
+//   - SEMANTIC VIEW: the TABLES / RELATIONSHIPS / FACTS / DIMENSIONS / METRICS /
+//     AI_VERIFIED_QUERIES sections are comma-separated definition lists whose
+//     inner grammar is large and version-growing; each section's body is captured
+//     as a balanced raw group rather than fully modeled. The scalar trailing
+//     clauses (COMMENT, AI_SQL_GENERATION, AI_QUESTION_CATEGORIZATION) are
+//     open-ended options; [WITH] TAG and COPY GRANTS are the remaining anchors.
+//     The legacy create_semantic_view rule lacks the AI_* clauses and the
+//     [WITH] TAG clause (docs win).
+//   - DATASET: a newer ML object whose CREATE is, per both the docs and the
+//     legacy grammar, just a name.
+
+// ---------------------------------------------------------------------------
+// CREATE TAG
+// ---------------------------------------------------------------------------
+
+// parseCreateTagStmt parses
+//
+//	CREATE [ OR REPLACE ] TAG [ IF NOT EXISTS ] <name>
+//	  [ ALLOWED_VALUES '<v1>' [ , '<v2>' ... ] ]
+//	  [ PROPAGATE = ... [ ON_CONFLICT = ... ] ]
+//	  [ COMMENT = '<string_literal>' ]
+//
+// The CREATE keyword and the optional OR REPLACE modifier have already been
+// consumed by parseCreateStmt; start is the Loc of the CREATE token, and cur is
+// the TAG keyword.
+func (p *Parser) parseCreateTagStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume TAG
+
+	stmt := &ast.CreateTagStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional ALLOWED_VALUES '<v>' [, ...] — the one anchor the docs require
+	// first. PROPAGATE is NOT a starter for ALLOWED_VALUES, so it is captured as
+	// an ordinary option below.
+	if p.cur.Type == kwALLOWED_VALUES {
+		p.advance() // consume ALLOWED_VALUES
+		values, err := p.parseTagStringList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.AllowedValues = values
+	}
+
+	// Trailing PROPAGATE / ON_CONFLICT / COMMENT clauses, each an open-ended
+	// KEY = value option. The loop ends at a statement boundary or any token that
+	// does not begin an option.
+	for p.startsCopyOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Options = append(stmt.Options, opt)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TAG
+// ---------------------------------------------------------------------------
+
+// parseAlterTagStmt parses ALTER TAG [ IF EXISTS ] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the TAG keyword.
+//
+//	RENAME TO <new_name>
+//	{ ADD | DROP } ALLOWED_VALUES '<v>' [ , ... ]
+//	SET [ ALLOWED_VALUES '<v>' [ , ... ] ] [ PROPAGATE = ... [ ON_CONFLICT = ... ] ] [ COMMENT = '...' ]
+//	SET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ] [ FORCE ]
+//	UNSET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ]
+//	UNSET { ALLOWED_VALUES | PROPAGATE | ON_CONFLICT | COMMENT | DCM PROJECT }
+func (p *Parser) parseAlterTagStmt() (ast.Node, error) {
+	altTok := p.advance() // consume TAG (anchors Loc.Start, ALTER convention)
+	stmt := &ast.AlterTagStmt{Loc: ast.Loc{Start: altTok.Loc.Start}}
+
+	p.parseOptionalIfExists(&stmt.IfExists)
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO <new_name>
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterTagRename
+		stmt.NewName = newName
+
+	case kwADD, kwDROP:
+		// { ADD | DROP } ALLOWED_VALUES '<v>' [ , ... ]
+		add := p.cur.Type == kwADD
+		p.advance() // consume ADD / DROP
+		if _, err := p.expect(kwALLOWED_VALUES); err != nil {
+			return nil, err
+		}
+		values, err := p.parseTagStringList()
+		if err != nil {
+			return nil, err
+		}
+		if add {
+			stmt.Action = ast.AlterTagAddAllowedValues
+		} else {
+			stmt.Action = ast.AlterTagDropAllowedValues
+		}
+		stmt.AllowedValues = values
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwMASKING {
+			// SET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ] [ FORCE ]
+			policies, err := p.parseMaskingPolicyList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTagSetMaskingPolicy
+			stmt.MaskingPolicies = policies
+			if p.cur.Type == kwFORCE {
+				p.advance() // consume FORCE
+				stmt.Force = true
+			}
+			break
+		}
+		// SET [ ALLOWED_VALUES ... ] [ PROPAGATE ... ] [ COMMENT ... ]
+		if err := p.parseAlterTagSet(stmt); err != nil {
+			return nil, err
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwMASKING {
+			// UNSET MASKING POLICY <p> [ , MASKING POLICY <p2> ... ]
+			policies, err := p.parseMaskingPolicyList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterTagUnsetMaskingPolicy
+			stmt.MaskingPolicies = policies
+			break
+		}
+		// UNSET { ALLOWED_VALUES | PROPAGATE | ON_CONFLICT | COMMENT | DCM PROJECT }
+		// — an open-ended property list (DCM PROJECT is two words), reusing the
+		// STAGE UNSET-property reader.
+		props, err := p.parseStageUnsetProps()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterTagUnset
+		stmt.UnsetProps = props
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterTagSet parses the SET branch's options:
+//
+//	SET [ ALLOWED_VALUES '<v>' [ , ... ] ] [ PROPAGATE = ... [ ON_CONFLICT = ... ] ] [ COMMENT = '...' ]
+//
+// ALLOWED_VALUES is lifted into AllowedValues; every other clause is open-ended.
+// SET with nothing settable is a syntax error. cur is positioned just past SET.
+func (p *Parser) parseAlterTagSet(stmt *ast.AlterTagStmt) error {
+	if p.cur.Type == kwALLOWED_VALUES {
+		p.advance() // consume ALLOWED_VALUES
+		values, err := p.parseTagStringList()
+		if err != nil {
+			return err
+		}
+		stmt.AllowedValues = values
+	}
+
+	var opts []*ast.CopyOption
+	for p.startsCopyOption() {
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return err
+		}
+		opts = append(opts, opt)
+	}
+	stmt.Options = opts
+
+	if stmt.AllowedValues == nil && len(opts) == 0 {
+		// SET with nothing settable is a syntax error.
+		return p.syntaxErrorAtCur()
+	}
+	stmt.Action = ast.AlterTagSet
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SEMANTIC VIEW
+// ---------------------------------------------------------------------------
+
+// parseCreateSemanticViewStmt parses
+//
+//	CREATE [ OR REPLACE ] SEMANTIC VIEW [ IF NOT EXISTS ] <name>
+//	  TABLES ( ... )
+//	  [ RELATIONSHIPS ( ... ) ] [ FACTS ( ... ) ] [ DIMENSIONS ( ... ) ]
+//	  [ METRICS ( ... ) ] [ AI_VERIFIED_QUERIES ( ... ) ]
+//	  [ COMMENT = '<string>' ] [ AI_SQL_GENERATION '<...>' ] [ AI_QUESTION_CATEGORIZATION '<...>' ]
+//	  [ [ WITH ] TAG ( ... ) ] [ COPY GRANTS ]
+//
+// The CREATE / OR REPLACE tokens have already been consumed by parseCreateStmt;
+// start is the Loc of the CREATE token, and cur is the SEMANTIC keyword.
+func (p *Parser) parseCreateSemanticViewStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume SEMANTIC
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.CreateSemanticViewStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Body clauses, in one order-tolerant loop: the parenthesized definition-list
+	// sections (TABLES first per the docs, then RELATIONSHIPS / FACTS / DIMENSIONS
+	// / METRICS / AI_VERIFIED_QUERIES), the scalar options (COMMENT /
+	// AI_SQL_GENERATION / AI_QUESTION_CATEGORIZATION), the [WITH] TAG clause, and
+	// COPY GRANTS. The docs fix a section order and place AI_VERIFIED_QUERIES after
+	// the scalar AI_* options, so a single loop that accepts any of them in any
+	// order (mirrors STAGE's order-tolerant tail) parses every documented ordering;
+	// the semantic layer enforces the canonical order.
+	for {
+		if p.startsSemanticViewSection() {
+			section, err := p.parseSemanticViewSection()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Sections = append(stmt.Sections, section)
+			continue
+		}
+		if p.startsSemanticViewTags() {
+			tags, err := p.parseStageWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+			continue
+		}
+		if p.startsCopyGrants() {
+			p.advance() // consume COPY
+			p.advance() // consume GRANTS
+			stmt.CopyGrants = true
+			continue
+		}
+		if p.startsSemanticViewOption() {
+			opt, err := p.parseSemanticViewOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+			continue
+		}
+		break
+	}
+	if len(stmt.Sections) == 0 {
+		// A SEMANTIC VIEW with no section is invalid (the docs require at least the
+		// TABLES section). Rejecting here also prevents a bare section keyword such
+		// as TABLES from being silently absorbed as the view name.
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// startsSemanticViewSection reports whether the current token begins a SEMANTIC
+// VIEW section (TABLES / RELATIONSHIPS / FACTS / DIMENSIONS / METRICS /
+// AI_VERIFIED_QUERIES). AI_VERIFIED_QUERIES is not a reserved keyword, so it
+// lexes as an identifier and is matched by text.
+func (p *Parser) startsSemanticViewSection() bool {
+	switch p.cur.Type {
+	case kwTABLES, kwRELATIONSHIPS, kwFACTS, kwDIMENSIONS, kwMETRICS:
+		return true
+	}
+	return p.curIsWord("AI_VERIFIED_QUERIES")
+}
+
+// parseSemanticViewSection parses one `<KEYWORD> ( <body> )` section, capturing
+// the body verbatim as a balanced raw group (the parentheses are not included in
+// Body). cur is the section keyword.
+func (p *Parser) parseSemanticViewSection() (*ast.SemanticViewSection, error) {
+	kwTok := p.advance() // consume the section keyword
+	section := &ast.SemanticViewSection{
+		Keyword: strings.ToUpper(kwTok.Str),
+		Loc:     ast.Loc{Start: kwTok.Loc.Start},
+	}
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	// Capture the inner body verbatim up to the matching ')'.
+	bodyStart := p.cur.Loc.Start
+	section.Body = p.captureBalancedRaw(bodyStart)
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	section.Loc.End = p.prev.Loc.End
+	return section, nil
+}
+
+// startsSemanticViewTags reports whether the current position begins a [WITH]
+// TAG clause (TAG directly, or WITH immediately followed by TAG).
+func (p *Parser) startsSemanticViewTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// startsSemanticViewOption reports whether the current token can begin a trailing
+// scalar option (COMMENT / AI_SQL_GENERATION / AI_QUESTION_CATEGORIZATION). It is
+// the COPY option predicate minus the structural keywords that anchor a trailing
+// clause: WITH / TAG ([WITH] TAG) and COPY (COPY GRANTS).
+func (p *Parser) startsSemanticViewOption() bool {
+	switch p.cur.Type {
+	case kwWITH, kwTAG, kwCOPY:
+		return false
+	}
+	return p.startsCopyOption()
+}
+
+// parseSemanticViewOption parses one trailing scalar option. COMMENT uses the
+// `KEY = value` shape; AI_SQL_GENERATION / AI_QUESTION_CATEGORIZATION use a bare
+// `KEY '<string>'` shape (no '='), captured here as a CopyOption whose Lit holds
+// the string. A `KEY = value` option falls through to the shared parseCopyOption.
+func (p *Parser) parseSemanticViewOption() (*ast.CopyOption, error) {
+	// AI_SQL_GENERATION / AI_QUESTION_CATEGORIZATION '<string>' — the value
+	// follows the keyword directly with no '='. A string literal immediately after
+	// the option name (with no intervening '=') marks this bare form; COMMENT = '…'
+	// instead has '=' as the next token and so falls through to parseCopyOption.
+	if p.peekNext().Type == tokString {
+		nameTok := p.advance() // consume the option name
+		valTok := p.advance()  // consume the string literal
+		return &ast.CopyOption{
+			Name: strings.ToUpper(nameTok.Str),
+			Lit:  &ast.Literal{Kind: ast.LitString, Value: valTok.Str, Loc: valTok.Loc},
+			Loc:  ast.Loc{Start: nameTok.Loc.Start, End: valTok.Loc.End},
+		}, nil
+	}
+	return p.parseCopyOption()
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SEMANTIC VIEW
+// ---------------------------------------------------------------------------
+
+// parseAlterSemanticViewStmt parses ALTER SEMANTIC VIEW [ IF EXISTS ] <name>
+// <action>. The ALTER keyword has already been consumed; cur is the SEMANTIC
+// keyword.
+//
+//	RENAME TO <new_name>
+//	SET COMMENT = '<string_literal>'
+//	UNSET COMMENT
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+func (p *Parser) parseAlterSemanticViewStmt() (ast.Node, error) {
+	startLoc := p.cur.Loc // SEMANTIC keyword anchors Loc.Start (ALTER convention)
+	p.advance()           // consume SEMANTIC
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+	stmt := &ast.AlterSemanticViewStmt{Loc: ast.Loc{Start: startLoc.Start}}
+
+	p.parseOptionalIfExists(&stmt.IfExists)
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch p.cur.Type {
+	case kwRENAME:
+		// RENAME TO <new_name>
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterSemanticViewRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			// SET TAG <tag> = '<value>' [ , ... ]
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSemanticViewSetTag
+			stmt.Tags = tags
+		} else {
+			// SET COMMENT = '<string>' — open-ended (only COMMENT is documented).
+			var opts []*ast.CopyOption
+			for p.startsCopyOption() {
+				opt, err := p.parseCopyOption()
+				if err != nil {
+					return nil, err
+				}
+				opts = append(opts, opt)
+			}
+			if len(opts) == 0 {
+				return nil, p.syntaxErrorAtCur()
+			}
+			stmt.Action = ast.AlterSemanticViewSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			// UNSET TAG <tag> [ , ... ]
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSemanticViewUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET COMMENT (and, permissively, any other property word).
+			props, err := p.parseStageUnsetProps()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterSemanticViewUnset
+			stmt.UnsetProps = props
+		}
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CREATE DATASET
+// ---------------------------------------------------------------------------
+
+// parseCreateDatasetStmt parses CREATE [ OR REPLACE ] DATASET [ IF NOT EXISTS ]
+// <name>. The CREATE / OR REPLACE tokens have already been consumed; start is
+// the Loc of the CREATE token, and cur is the DATASET keyword. DATASET carries
+// no options (per both the docs and the legacy grammar).
+//
+// Divergence note: the official docs render IF NOT EXISTS *before* DATASET,
+// whereas the legacy grammar and every other CREATE object in this engine place
+// it *after* the object keyword. The post-keyword spelling is accepted here for
+// consistency with the rest of the engine; the docs' pre-keyword spelling is a
+// flagged divergence (likely a docs rendering quirk).
+func (p *Parser) parseCreateDatasetStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume DATASET
+
+	stmt := &ast.CreateDatasetStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	if err := p.parseOptionalIfNotExists(&stmt.IfNotExists); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// parseTagStringList parses a comma-separated list of string literals:
+// '<v1>' [ , '<v2>' ... ]. Consumes at least one. Used by ALLOWED_VALUES (CREATE
+// TAG, ALTER TAG ADD/DROP/SET).
+func (p *Parser) parseTagStringList() ([]string, error) {
+	var values []string
+	for {
+		tok, err := p.expect(tokString)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, tok.Str)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return values, nil
+}
+
+// parseMaskingPolicyList parses a MASKING POLICY name list:
+//
+//	MASKING POLICY <p1> [ , MASKING POLICY <p2> ... ]
+//
+// Each entry repeats the MASKING POLICY keywords (per the docs and the legacy
+// alter_tag_opts rule). cur is the first MASKING keyword. Consumes at least one.
+func (p *Parser) parseMaskingPolicyList() ([]*ast.ObjectName, error) {
+	var policies []*ast.ObjectName
+	for {
+		if _, err := p.expect(kwMASKING); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return nil, err
+		}
+		name, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		policies = append(policies, name)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return policies, nil
+}

--- a/snowflake/parser/semantic_view_test.go
+++ b/snowflake/parser/semantic_view_test.go
@@ -1,0 +1,806 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateTag(t *testing.T, input string) *ast.CreateTagStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateTagStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateTagStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterTag(t *testing.T, input string) *ast.AlterTagStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterTagStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterTagStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateSemanticView(t *testing.T, input string) *ast.CreateSemanticViewStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateSemanticViewStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateSemanticViewStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterSemanticView(t *testing.T, input string) *ast.AlterSemanticViewStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterSemanticViewStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterSemanticViewStmt", input, node)
+	}
+	return stmt
+}
+
+func mustCreateDataset(t *testing.T, input string) *ast.CreateDatasetStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateDatasetStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateDatasetStmt", input, node)
+	}
+	return stmt
+}
+
+// section returns the named section of a semantic view, or nil.
+func section(stmt *ast.CreateSemanticViewStmt, keyword string) *ast.SemanticViewSection {
+	for _, s := range stmt.Sections {
+		if s.Keyword == keyword {
+			return s
+		}
+	}
+	return nil
+}
+
+// assertLoc asserts that a node's Loc spans the whole statement (Start at 0,
+// End at len(input)) for a single-statement input with no trailing semicolon.
+func assertFullLoc(t *testing.T, loc ast.Loc, input string) {
+	t.Helper()
+	if loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", loc.Start)
+	}
+	if loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d (len input)", loc.End, len(input))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TAG — docs (truth1):
+//
+//	CREATE [OR REPLACE] TAG [IF NOT EXISTS] <name>
+//	  [ALLOWED_VALUES '<v>' [, ...]]
+//	  [PROPAGATE = {...} [ON_CONFLICT = {...}]]
+//	  [COMMENT = '<string>']
+// ---------------------------------------------------------------------------
+
+func TestParseCreateTag_Modifiers(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG cost_center")
+		if stmt.Name.String() != "cost_center" {
+			t.Errorf("Name = %q, want cost_center", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.IfNotExists {
+			t.Errorf("unexpected modifier: %+v", stmt)
+		}
+		if stmt.AllowedValues != nil || len(stmt.Options) != 0 {
+			t.Errorf("expected no allowed values/options, got %+v / %+v", stmt.AllowedValues, stmt.Options)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE OR REPLACE TAG t")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG IF NOT EXISTS t")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("or replace if not exists is permissive", func(t *testing.T) {
+		// Docs say OR REPLACE and IF NOT EXISTS are mutually exclusive, but the
+		// engine parses permissively and defers the check to the semantic layer.
+		stmt := mustCreateTag(t, "CREATE OR REPLACE TAG IF NOT EXISTS t")
+		if !stmt.OrReplace || !stmt.IfNotExists {
+			t.Errorf("OrReplace=%v IfNotExists=%v, want both", stmt.OrReplace, stmt.IfNotExists)
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG db.sch.t")
+		if stmt.Name.String() != "db.sch.t" {
+			t.Errorf("Name = %q, want db.sch.t", stmt.Name.String())
+		}
+	})
+
+	t.Run("quoted name", func(t *testing.T) {
+		stmt := mustCreateTag(t, `CREATE TAG "My Tag"`)
+		if stmt.Name.String() != `"My Tag"` {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+
+	t.Run("loc spans statement", func(t *testing.T) {
+		input := "CREATE TAG cost_center"
+		stmt := mustCreateTag(t, input)
+		assertFullLoc(t, stmt.Loc, input)
+	})
+}
+
+func TestParseCreateTag_AllowedValues(t *testing.T) {
+	t.Run("single value", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG t ALLOWED_VALUES 'red'")
+		if len(stmt.AllowedValues) != 1 || stmt.AllowedValues[0] != "red" {
+			t.Errorf("AllowedValues = %v, want [red]", stmt.AllowedValues)
+		}
+	})
+
+	t.Run("multiple values", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG t ALLOWED_VALUES 'finance', 'engineering', 'sales'")
+		want := []string{"finance", "engineering", "sales"}
+		if len(stmt.AllowedValues) != len(want) {
+			t.Fatalf("AllowedValues = %v, want %v", stmt.AllowedValues, want)
+		}
+		for i, v := range want {
+			if stmt.AllowedValues[i] != v {
+				t.Errorf("AllowedValues[%d] = %q, want %q", i, stmt.AllowedValues[i], v)
+			}
+		}
+	})
+
+	t.Run("allowed values then comment", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG t ALLOWED_VALUES 'a', 'b' COMMENT = 'note'")
+		if len(stmt.AllowedValues) != 2 {
+			t.Fatalf("AllowedValues = %v", stmt.AllowedValues)
+		}
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "note" {
+			t.Errorf("COMMENT option wrong: %+v", stmt.Options)
+		}
+	})
+}
+
+func TestParseCreateTag_Options(t *testing.T) {
+	t.Run("comment only", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG cost_center COMMENT = 'cost_center tag'")
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit.Value != "cost_center tag" {
+			t.Errorf("COMMENT option wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("propagate and on_conflict (docs/corpus, beyond legacy g4)", func(t *testing.T) {
+		// example_02 from the create-tag corpus. PROPAGATE / ON_CONFLICT are not in
+		// the legacy g4 create_tag rule (flagged divergence: docs win).
+		stmt := mustCreateTag(t, "CREATE TAG my_tag ALLOWED_VALUES 'blue', 'red' PROPAGATE = ON_DEPENDENCY ON_CONFLICT = ALLOWED_VALUES_SEQUENCE")
+		if len(stmt.AllowedValues) != 2 {
+			t.Fatalf("AllowedValues = %v", stmt.AllowedValues)
+		}
+		prop := findOption(stmt.Options, "PROPAGATE")
+		if prop == nil || prop.Words != "ON_DEPENDENCY" {
+			t.Errorf("PROPAGATE option wrong: %+v", stmt.Options)
+		}
+		oc := findOption(stmt.Options, "ON_CONFLICT")
+		if oc == nil || oc.Words != "ALLOWED_VALUES_SEQUENCE" {
+			t.Errorf("ON_CONFLICT option wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("propagate string on_conflict", func(t *testing.T) {
+		stmt := mustCreateTag(t, "CREATE TAG t PROPAGATE = ON_DATA_MOVEMENT ON_CONFLICT = 'custom'")
+		oc := findOption(stmt.Options, "ON_CONFLICT")
+		if oc == nil || oc.Lit == nil || oc.Lit.Value != "custom" {
+			t.Errorf("ON_CONFLICT string wrong: %+v", stmt.Options)
+		}
+	})
+}
+
+func TestParseCreateTag_Negatives(t *testing.T) {
+	// Missing name.
+	assertParseError(t, "CREATE TAG")
+	// ALLOWED_VALUES with no value.
+	assertParseError(t, "CREATE TAG t ALLOWED_VALUES")
+	// ALLOWED_VALUES trailing comma with no value.
+	assertParseError(t, "CREATE TAG t ALLOWED_VALUES 'a',")
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TAG — docs (truth1):
+//
+//	RENAME TO <new_name>
+//	{ADD|DROP} ALLOWED_VALUES '<v>' [, ...]
+//	SET [ALLOWED_VALUES ...] [PROPAGATE ...] [COMMENT ...]
+//	UNSET {ALLOWED_VALUES | PROPAGATE | ON_CONFLICT | COMMENT | DCM PROJECT}
+//	SET MASKING POLICY <p> [, MASKING POLICY <p2> ...] [FORCE]
+//	UNSET MASKING POLICY <p> [, MASKING POLICY <p2> ...]
+// ---------------------------------------------------------------------------
+
+func TestParseAlterTag_Rename(t *testing.T) {
+	stmt := mustAlterTag(t, "ALTER TAG t RENAME TO t2")
+	if stmt.Action != ast.AlterTagRename {
+		t.Errorf("Action = %v, want Rename", stmt.Action)
+	}
+	if stmt.NewName.String() != "t2" {
+		t.Errorf("NewName = %q, want t2", stmt.NewName.String())
+	}
+}
+
+func TestParseAlterTag_IfExists(t *testing.T) {
+	stmt := mustAlterTag(t, "ALTER TAG IF EXISTS t RENAME TO t2")
+	if !stmt.IfExists {
+		t.Error("IfExists not set")
+	}
+}
+
+func TestParseAlterTag_AllowedValues(t *testing.T) {
+	t.Run("add", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t ADD ALLOWED_VALUES 'x', 'y'")
+		if stmt.Action != ast.AlterTagAddAllowedValues {
+			t.Errorf("Action = %v, want AddAllowedValues", stmt.Action)
+		}
+		if len(stmt.AllowedValues) != 2 {
+			t.Errorf("AllowedValues = %v", stmt.AllowedValues)
+		}
+	})
+
+	t.Run("drop", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t DROP ALLOWED_VALUES 'x'")
+		if stmt.Action != ast.AlterTagDropAllowedValues {
+			t.Errorf("Action = %v, want DropAllowedValues", stmt.Action)
+		}
+	})
+}
+
+func TestParseAlterTag_Set(t *testing.T) {
+	t.Run("set allowed values", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t SET ALLOWED_VALUES 'a', 'b'")
+		if stmt.Action != ast.AlterTagSet {
+			t.Errorf("Action = %v, want Set", stmt.Action)
+		}
+		if len(stmt.AllowedValues) != 2 {
+			t.Errorf("AllowedValues = %v", stmt.AllowedValues)
+		}
+	})
+
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t SET COMMENT = 'note'")
+		if stmt.Action != ast.AlterTagSet {
+			t.Errorf("Action = %v, want Set", stmt.Action)
+		}
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit.Value != "note" {
+			t.Errorf("COMMENT wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("set propagate and comment", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t SET PROPAGATE = ON_DEPENDENCY COMMENT = 'n'")
+		if findOption(stmt.Options, "PROPAGATE") == nil {
+			t.Errorf("PROPAGATE missing: %+v", stmt.Options)
+		}
+		if findOption(stmt.Options, "COMMENT") == nil {
+			t.Errorf("COMMENT missing: %+v", stmt.Options)
+		}
+	})
+}
+
+func TestParseAlterTag_Unset(t *testing.T) {
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t UNSET COMMENT")
+		if stmt.Action != ast.AlterTagUnset {
+			t.Errorf("Action = %v, want Unset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("UnsetProps = %v, want [COMMENT]", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("unset allowed values", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t UNSET ALLOWED_VALUES")
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "ALLOWED_VALUES" {
+			t.Errorf("UnsetProps = %v, want [ALLOWED_VALUES]", stmt.UnsetProps)
+		}
+	})
+
+	t.Run("unset dcm project (two words)", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t UNSET DCM PROJECT")
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "DCM PROJECT" {
+			t.Errorf("UnsetProps = %v, want [DCM PROJECT]", stmt.UnsetProps)
+		}
+	})
+}
+
+func TestParseAlterTag_MaskingPolicy(t *testing.T) {
+	t.Run("set single", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t SET MASKING POLICY p")
+		if stmt.Action != ast.AlterTagSetMaskingPolicy {
+			t.Errorf("Action = %v, want SetMaskingPolicy", stmt.Action)
+		}
+		if len(stmt.MaskingPolicies) != 1 || stmt.MaskingPolicies[0].String() != "p" {
+			t.Errorf("MaskingPolicies = %v", stmt.MaskingPolicies)
+		}
+		if stmt.Force {
+			t.Error("Force should be false")
+		}
+	})
+
+	t.Run("set multiple", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t SET MASKING POLICY p1, MASKING POLICY p2")
+		if len(stmt.MaskingPolicies) != 2 {
+			t.Errorf("MaskingPolicies = %v, want 2", stmt.MaskingPolicies)
+		}
+	})
+
+	t.Run("set with force", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t SET MASKING POLICY p FORCE")
+		if !stmt.Force {
+			t.Error("Force not set")
+		}
+	})
+
+	t.Run("unset single", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t UNSET MASKING POLICY p")
+		if stmt.Action != ast.AlterTagUnsetMaskingPolicy {
+			t.Errorf("Action = %v, want UnsetMaskingPolicy", stmt.Action)
+		}
+		if len(stmt.MaskingPolicies) != 1 {
+			t.Errorf("MaskingPolicies = %v", stmt.MaskingPolicies)
+		}
+	})
+
+	t.Run("unset multiple", func(t *testing.T) {
+		stmt := mustAlterTag(t, "ALTER TAG t UNSET MASKING POLICY p1, MASKING POLICY p2")
+		if len(stmt.MaskingPolicies) != 2 {
+			t.Errorf("MaskingPolicies = %v, want 2", stmt.MaskingPolicies)
+		}
+	})
+}
+
+func TestParseAlterTag_Negatives(t *testing.T) {
+	// Bare ALTER TAG with no name.
+	assertParseError(t, "ALTER TAG")
+	// No action.
+	assertParseError(t, "ALTER TAG t")
+	// RENAME without TO.
+	assertParseError(t, "ALTER TAG t RENAME t2")
+	// ADD without ALLOWED_VALUES.
+	assertParseError(t, "ALTER TAG t ADD 'x'")
+	// SET with nothing settable.
+	assertParseError(t, "ALTER TAG t SET")
+	// SET MASKING without POLICY.
+	assertParseError(t, "ALTER TAG t SET MASKING p")
+}
+
+// ---------------------------------------------------------------------------
+// CREATE SEMANTIC VIEW — docs (truth1):
+//
+//	CREATE [OR REPLACE] SEMANTIC VIEW [IF NOT EXISTS] <name>
+//	  TABLES (...) [RELATIONSHIPS (...)] [FACTS (...)] [DIMENSIONS (...)]
+//	  [METRICS (...)] [COMMENT = '...'] [AI_SQL_GENERATION '...']
+//	  [AI_QUESTION_CATEGORIZATION '...'] [AI_VERIFIED_QUERIES (...)]
+//	  [[WITH] TAG (...)] [COPY GRANTS]
+// ---------------------------------------------------------------------------
+
+func TestParseCreateSemanticView_Minimal(t *testing.T) {
+	t.Run("tables and metrics", func(t *testing.T) {
+		input := "CREATE SEMANTIC VIEW sv TABLES (orders) METRICS (orders.total AS SUM(amount))"
+		stmt := mustCreateSemanticView(t, input)
+		if stmt.Name.String() != "sv" {
+			t.Errorf("Name = %q, want sv", stmt.Name.String())
+		}
+		tbl := section(stmt, "TABLES")
+		if tbl == nil || tbl.Body != "orders" {
+			t.Errorf("TABLES body = %q, want orders", bodyOf(tbl))
+		}
+		m := section(stmt, "METRICS")
+		if m == nil || m.Body != "orders.total AS SUM(amount)" {
+			t.Errorf("METRICS body = %q", bodyOf(m))
+		}
+		assertFullLoc(t, stmt.Loc, input)
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE OR REPLACE SEMANTIC VIEW sv TABLES (t) DIMENSIONS (t.d AS d)")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW IF NOT EXISTS sv TABLES (t) DIMENSIONS (t.d AS d)")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW db.sch.sv TABLES (t) METRICS (t.m AS COUNT(*))")
+		if stmt.Name.String() != "db.sch.sv" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+}
+
+func TestParseCreateSemanticView_AllSections(t *testing.T) {
+	// Every documented section, with nested parens inside section bodies to
+	// exercise the balanced-group reader.
+	input := `CREATE SEMANTIC VIEW sv
+		TABLES (
+			o AS orders PRIMARY KEY (id),
+			c AS customers PRIMARY KEY (id)
+		)
+		RELATIONSHIPS (
+			orders_to_customers AS o (cust_id) REFERENCES c (id)
+		)
+		FACTS (
+			o.amount AS amount
+		)
+		DIMENSIONS (
+			c.name AS name,
+			o.date AS order_date
+		)
+		METRICS (
+			o.total AS SUM(o.amount)
+		)`
+	stmt := mustCreateSemanticView(t, input)
+	for _, kw := range []string{"TABLES", "RELATIONSHIPS", "FACTS", "DIMENSIONS", "METRICS"} {
+		if section(stmt, kw) == nil {
+			t.Errorf("missing section %s", kw)
+		}
+	}
+	// Balanced-group reader must capture nested parens whole.
+	tbl := section(stmt, "TABLES")
+	if !strings.Contains(tbl.Body, "PRIMARY KEY (id)") {
+		t.Errorf("TABLES body did not capture nested parens: %q", tbl.Body)
+	}
+	rel := section(stmt, "RELATIONSHIPS")
+	if !strings.Contains(rel.Body, "REFERENCES c (id)") {
+		t.Errorf("RELATIONSHIPS body wrong: %q", rel.Body)
+	}
+}
+
+func TestParseCreateSemanticView_TrailingClauses(t *testing.T) {
+	t.Run("comment", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) COMMENT = 'a view'")
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit == nil || c.Lit.Value != "a view" {
+			t.Errorf("COMMENT wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("ai_sql_generation bare string", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) AI_SQL_GENERATION 'use the metrics'")
+		ai := findOption(stmt.Options, "AI_SQL_GENERATION")
+		if ai == nil || ai.Lit == nil || ai.Lit.Value != "use the metrics" {
+			t.Errorf("AI_SQL_GENERATION wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("ai_question_categorization bare string", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) AI_QUESTION_CATEGORIZATION 'categorize'")
+		ai := findOption(stmt.Options, "AI_QUESTION_CATEGORIZATION")
+		if ai == nil || ai.Lit == nil || ai.Lit.Value != "categorize" {
+			t.Errorf("AI_QUESTION_CATEGORIZATION wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("ai_verified_queries section", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) AI_VERIFIED_QUERIES (q AS 'SELECT 1')")
+		if section(stmt, "AI_VERIFIED_QUERIES") == nil {
+			t.Errorf("missing AI_VERIFIED_QUERIES section: %+v", stmt.Sections)
+		}
+	})
+
+	t.Run("ai_verified_queries after scalar ai options (doc order)", func(t *testing.T) {
+		// Per the docs AI_VERIFIED_QUERIES follows the scalar AI_SQL_GENERATION /
+		// AI_QUESTION_CATEGORIZATION options; the order-tolerant body loop must
+		// still capture it as a section.
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) COMMENT = 'c' AI_SQL_GENERATION 'g' AI_VERIFIED_QUERIES (q AS 'SELECT 1')")
+		if section(stmt, "AI_VERIFIED_QUERIES") == nil {
+			t.Errorf("missing AI_VERIFIED_QUERIES section: %+v", stmt.Sections)
+		}
+		if findOption(stmt.Options, "AI_SQL_GENERATION") == nil {
+			t.Errorf("missing AI_SQL_GENERATION option: %+v", stmt.Options)
+		}
+		if findOption(stmt.Options, "COMMENT") == nil {
+			t.Errorf("missing COMMENT option: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("with tag", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) WITH TAG (cost = 'high')")
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Name.String() != "cost" || stmt.Tags[0].Value != "high" {
+			t.Errorf("Tags wrong: %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("bare tag", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) TAG (cost = 'high')")
+		if len(stmt.Tags) != 1 {
+			t.Errorf("Tags wrong: %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("copy grants", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) COPY GRANTS")
+		if !stmt.CopyGrants {
+			t.Error("CopyGrants not set")
+		}
+	})
+
+	t.Run("comment then tag then copy grants", func(t *testing.T) {
+		stmt := mustCreateSemanticView(t, "CREATE SEMANTIC VIEW sv TABLES (t) METRICS (t.m AS COUNT(*)) COMMENT = 'c' WITH TAG (k = 'v') COPY GRANTS")
+		if findOption(stmt.Options, "COMMENT") == nil {
+			t.Error("COMMENT missing")
+		}
+		if len(stmt.Tags) != 1 {
+			t.Error("Tags missing")
+		}
+		if !stmt.CopyGrants {
+			t.Error("CopyGrants missing")
+		}
+	})
+}
+
+func TestParseCreateSemanticView_Negatives(t *testing.T) {
+	// Missing VIEW keyword.
+	assertParseError(t, "CREATE SEMANTIC sv TABLES (t)")
+	// Missing name.
+	assertParseError(t, "CREATE SEMANTIC VIEW TABLES (t)")
+	// Unbalanced section parens.
+	assertParseError(t, "CREATE SEMANTIC VIEW sv TABLES (t")
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SEMANTIC VIEW — docs (truth1):
+//
+//	RENAME TO <new_name>
+//	SET COMMENT = '<string>'
+//	UNSET COMMENT
+//	SET TAG <tag> = '<value>' [, ...]
+//	UNSET TAG <tag> [, ...]
+// ---------------------------------------------------------------------------
+
+func TestParseAlterSemanticView_Rename(t *testing.T) {
+	stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv RENAME TO sv2")
+	if stmt.Action != ast.AlterSemanticViewRename {
+		t.Errorf("Action = %v, want Rename", stmt.Action)
+	}
+	if stmt.NewName.String() != "sv2" {
+		t.Errorf("NewName = %q", stmt.NewName.String())
+	}
+}
+
+func TestParseAlterSemanticView_IfExists(t *testing.T) {
+	stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW IF EXISTS sv RENAME TO sv2")
+	if !stmt.IfExists {
+		t.Error("IfExists not set")
+	}
+}
+
+func TestParseAlterSemanticView_SetUnsetComment(t *testing.T) {
+	t.Run("set comment", func(t *testing.T) {
+		stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv SET COMMENT = 'note'")
+		if stmt.Action != ast.AlterSemanticViewSet {
+			t.Errorf("Action = %v, want Set", stmt.Action)
+		}
+		c := findOption(stmt.Options, "COMMENT")
+		if c == nil || c.Lit.Value != "note" {
+			t.Errorf("COMMENT wrong: %+v", stmt.Options)
+		}
+	})
+
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv UNSET COMMENT")
+		if stmt.Action != ast.AlterSemanticViewUnset {
+			t.Errorf("Action = %v, want Unset", stmt.Action)
+		}
+		if len(stmt.UnsetProps) != 1 || stmt.UnsetProps[0] != "COMMENT" {
+			t.Errorf("UnsetProps = %v", stmt.UnsetProps)
+		}
+	})
+}
+
+func TestParseAlterSemanticView_Tags(t *testing.T) {
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv SET TAG cost = 'high'")
+		if stmt.Action != ast.AlterSemanticViewSetTag {
+			t.Errorf("Action = %v, want SetTag", stmt.Action)
+		}
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Value != "high" {
+			t.Errorf("Tags = %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("set multiple tags", func(t *testing.T) {
+		stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv SET TAG a = '1', b = '2'")
+		if len(stmt.Tags) != 2 {
+			t.Errorf("Tags = %+v, want 2", stmt.Tags)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv UNSET TAG cost")
+		if stmt.Action != ast.AlterSemanticViewUnsetTag {
+			t.Errorf("Action = %v, want UnsetTag", stmt.Action)
+		}
+		if len(stmt.UnsetTags) != 1 || stmt.UnsetTags[0].String() != "cost" {
+			t.Errorf("UnsetTags = %v", stmt.UnsetTags)
+		}
+	})
+
+	t.Run("unset multiple tags", func(t *testing.T) {
+		stmt := mustAlterSemanticView(t, "ALTER SEMANTIC VIEW sv UNSET TAG a, b")
+		if len(stmt.UnsetTags) != 2 {
+			t.Errorf("UnsetTags = %v, want 2", stmt.UnsetTags)
+		}
+	})
+}
+
+func TestParseAlterSemanticView_Negatives(t *testing.T) {
+	// Missing VIEW keyword.
+	assertParseError(t, "ALTER SEMANTIC sv RENAME TO sv2")
+	// No action.
+	assertParseError(t, "ALTER SEMANTIC VIEW sv")
+	// SET with nothing settable.
+	assertParseError(t, "ALTER SEMANTIC VIEW sv SET")
+	// RENAME without TO.
+	assertParseError(t, "ALTER SEMANTIC VIEW sv RENAME sv2")
+}
+
+// ---------------------------------------------------------------------------
+// CREATE DATASET — docs (truth1) + legacy g4 (truth2):
+//
+//	CREATE [OR REPLACE] DATASET [IF NOT EXISTS] <name>
+//
+// (Docs render IF NOT EXISTS before DATASET; the post-keyword spelling is
+// accepted here, matching the legacy grammar and the rest of the engine — a
+// flagged divergence.)
+// ---------------------------------------------------------------------------
+
+func TestParseCreateDataset(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		input := "CREATE DATASET my_dataset"
+		stmt := mustCreateDataset(t, input)
+		if stmt.Name.String() != "my_dataset" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.IfNotExists {
+			t.Errorf("unexpected modifier: %+v", stmt)
+		}
+		assertFullLoc(t, stmt.Loc, input)
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateDataset(t, "CREATE OR REPLACE DATASET my_dataset")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+	})
+
+	t.Run("if not exists (post-keyword, legacy spelling)", func(t *testing.T) {
+		stmt := mustCreateDataset(t, "CREATE DATASET IF NOT EXISTS my_dataset")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateDataset(t, "CREATE DATASET db.sch.ds")
+		if stmt.Name.String() != "db.sch.ds" {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+}
+
+func TestParseCreateDataset_Negatives(t *testing.T) {
+	// Missing name.
+	assertParseError(t, "CREATE DATASET")
+}
+
+// ---------------------------------------------------------------------------
+// Official docs corpus — every CREATE TAG statement in the create-tag corpus
+// must parse with zero errors. The official docs are the authoritative oracle
+// (truth1). There is no semantic-view / dataset corpus; those forms are covered
+// from the docs above.
+//
+// example_03.sql uses `CREATE OR ALTER TAG`, a preview feature whose OR ALTER
+// prefix the shared parseCreateStmt parser does not yet recognize (owned by
+// parser.go / parseCreateStmt — out of this node's writes-scope). Such
+// statements are skipped here and tracked as a flagged divergence (see
+// orAlterLimited).
+// ---------------------------------------------------------------------------
+
+func TestCreateTag_OfficialCorpus(t *testing.T) {
+	const dir = "testdata/official/create-tag"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read corpus dir %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		t.Run(path, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			assertTagStatementsParse(t, string(data))
+		})
+	}
+}
+
+// assertTagStatementsParse parses sql and asserts every CREATE / ALTER TAG
+// statement parses with no errors and to the expected AST type. OR ALTER preview
+// statements are skipped (see orAlterLimited).
+func assertTagStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+		var want func(ast.Node) bool
+		switch {
+		case strings.HasPrefix(upper, "CREATE"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.CreateTagStmt); return ok }
+		case strings.HasPrefix(upper, "ALTER"):
+			want = func(n ast.Node) bool { _, ok := n.(*ast.AlterTagStmt); return ok }
+		default:
+			continue // context statement owned by another DAG node
+		}
+		if orAlterLimited(upper) {
+			// Known dependency limitation: must currently fail to parse. If it
+			// starts parsing, the OR ALTER gap was closed — surface that so the
+			// filter can be removed.
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: OR ALTER statement now parses, drop it from orAlterLimited: %q", text)
+			}
+			continue
+		}
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+			continue
+		}
+		if !want(node) {
+			t.Errorf("statement %q parsed to unexpected type %T", text, node)
+		}
+	}
+}
+
+// bodyOf returns the section body or a sentinel for nil (test diagnostics only).
+func bodyOf(s *ast.SemanticViewSection) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return s.Body
+}


### PR DESCRIPTION
## Node
`snowflake/ddl-semantic` (v1 DAG **T4.9**) — `CREATE`/`ALTER` for governance / semantic-layer DDL: `TAG`, `SEMANTIC VIEW`, `DATASET`. `DROP` for these was already merged (drop.go), untouched.

## Forms
- **TAG**: `CREATE [OR REPLACE] TAG [IF NOT EXISTS] <name> [ALLOWED_VALUES '<v>' [,…]] [PROPAGATE=… [ON_CONFLICT=…]] [COMMENT=…]`; `ALTER TAG` (RENAME, ADD/DROP/SET ALLOWED_VALUES, SET/UNSET incl. DCM PROJECT, SET/UNSET MASKING POLICY … [FORCE]).
- **SEMANTIC VIEW**: `CREATE [OR REPLACE] SEMANTIC VIEW <name> TABLES(…) [RELATIONSHIPS(…)] [FACTS(…)] [DIMENSIONS(…)] [METRICS(…)] [AI_VERIFIED_QUERIES(…)] [AI_* opts] [[WITH] TAG] [COPY GRANTS] [COMMENT=…]` — section bodies captured as balanced raw groups (`captureBalancedRaw`); ≥1 section required; order-tolerant body loop. `ALTER SEMANTIC VIEW` (RENAME, SET/UNSET COMMENT, SET/UNSET TAG).
- **DATASET**: `CREATE [OR REPLACE] DATASET [IF NOT EXISTS] <name>`.

## Design
Follows the merged STAGE/FILE-FORMAT/integration open-ended option-bag philosophy (`ast.CopyOption`); anchors only the structural keywords (ALLOWED_VALUES, the SEMANTIC VIEW sections, TAG/COPY GRANTS). New AST nodes + tags (valid Loc); `walk_generated.go` regenerated via `genwalker`; dispatch in `parseCreateStmt`/`parseAlterStmt`.

## Oracle / tests
Triangulation — legacy ANTLR (`create_tag`/`create_semantic_view`/`alter_tag`/…) + official docs (docs win) + corpus `testdata/official/create-tag`. `go build`/`go vet`/`gofmt`/`golangci-lint` clean; `go test ./snowflake/parser/... ./snowflake/ast/... -timeout 120s` green. Per-function coverage 86-100% (uncovered = defensive error paths); exhaustive forms + negatives.

## Divergences (flagged — ledger 139-143; docs win)
1. CREATE TAG PROPAGATE/ON_CONFLICT (docs+corpus beyond legacy).
2. ALTER TAG surface exceeds legacy (general SET, multi-UNSET, FORCE, DCM PROJECT).
3. SEMANTIC VIEW AI_* clauses + [WITH] TAG + ALTER SET/UNSET TAG; section bodies raw.
4. CREATE DATASET post-keyword `IF NOT EXISTS` (g4 + engine convention; docs render pre-keyword — medium confidence).
5. `CREATE OR ALTER TAG` filtered (owned by `parser-or-alter`).

## Review
Claude `/code-review` (high, inline) — 3 findings fixed (reuse `startsCopyGrants`; order-tolerant AI_VERIFIED_QUERIES; require ≥1 SEMANTIC VIEW section), no surviving blockers. Orchestrator independently verified build/`-timeout` tests/scope/gofmt. Codex lens unavailable (out of credits).

## Note
Opened by orchestrator from the worker's verified, pushed commit `51332968` (clean completion; watchdog confirmed PUSHED). No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)