### PR TITLE
feat(snowflake): T5.4 CALL / EXECUTE IMMEDIATE / EXECUTE TASK / EXPLAIN

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -173,6 +173,13 @@ const (
 	T_AlterRoleStmt
 	T_AlterUserStmt
 	T_AlterPolicyStmt
+
+	// CALL / EXECUTE IMMEDIATE / EXECUTE TASK / EXPLAIN tags (T5.4)
+	T_CallArg
+	T_CallStmt
+	T_ExecuteImmediateStmt
+	T_ExecuteTaskStmt
+	T_ExplainStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -418,6 +425,16 @@ func (t NodeTag) String() string {
 		return "AlterSemanticViewStmt"
 	case T_CreateDatasetStmt:
 		return "CreateDatasetStmt"
+	case T_CallArg:
+		return "CallArg"
+	case T_CallStmt:
+		return "CallStmt"
+	case T_ExecuteImmediateStmt:
+		return "ExecuteImmediateStmt"
+	case T_ExecuteTaskStmt:
+		return "ExecuteTaskStmt"
+	case T_ExplainStmt:
+		return "ExplainStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -4608,3 +4608,184 @@ var (
 	_ Node = (*CreateSequenceStmt)(nil)
 	_ Node = (*AlterSequenceStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// CALL / EXECUTE IMMEDIATE / EXECUTE TASK / EXPLAIN statement nodes (T5.4)
+// ---------------------------------------------------------------------------
+
+// CallArg is one argument of a CALL statement. Snowflake stored procedures
+// accept either positional arguments or named arguments using the `=>` syntax
+// (CALL p(province => 'MB')). For a positional argument Name is the zero Ident
+// (IsEmpty); for a named argument Name carries the parameter name. Value is the
+// argument expression (any expression node; a subquery argument is a
+// SubqueryExpr or, per Snowflake docs, a bare SELECT — see ParenlessQuery).
+type CallArg struct {
+	Name  Ident // optional parameter name for `name => value`; zero Ident when positional
+	Value Node  // the argument expression
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *CallArg) Tag() NodeTag { return T_CallArg }
+
+// CallStmt represents `CALL <proc_name> ( [ <arg> [ , ... ] ] )`.
+//
+// Syntax (docs + legacy .g4):
+//
+//	CALL <procedure_name> ( [ <arg> , ... ] )
+//
+// Args carries the (possibly empty) argument list. Every element is a *CallArg
+// (a positional argument has a zero Name; a named argument records its name).
+// Args is typed []Node so the generated walker descends into each *CallArg —
+// and thence into the argument expression — via walkNodes.
+type CallStmt struct {
+	Name *ObjectName
+	Args []Node // each element is a *CallArg
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *CallStmt) Tag() NodeTag { return T_CallStmt }
+
+// ExecImmSource classifies the input form of an EXECUTE IMMEDIATE statement.
+//
+// Snowflake documents three forms (docs win over the legacy grammar, which adds
+// the equivalent DBL_DOLLAR alternative):
+//
+//	EXECUTE IMMEDIATE '<string_literal>'   -> ExecImmString
+//	EXECUTE IMMEDIATE $$<dollar_body>$$    -> ExecImmDollar
+//	EXECUTE IMMEDIATE <variable>           -> ExecImmVariable  (Snowflake Scripting local var, no $)
+//	EXECUTE IMMEDIATE $<session_variable>  -> ExecImmSessionVar ($-prefixed session variable)
+type ExecImmSource int
+
+const (
+	// ExecImmString is a single-quoted string-literal body.
+	ExecImmString ExecImmSource = iota
+	// ExecImmDollar is a $$...$$ dollar-quoted body.
+	ExecImmDollar
+	// ExecImmVariable is a bare Snowflake Scripting local variable (no $).
+	ExecImmVariable
+	// ExecImmSessionVar is a $-prefixed session variable.
+	ExecImmSessionVar
+)
+
+// String returns a human-readable name for the source kind.
+func (k ExecImmSource) String() string {
+	switch k {
+	case ExecImmString:
+		return "STRING"
+	case ExecImmDollar:
+		return "DOLLAR"
+	case ExecImmVariable:
+		return "VARIABLE"
+	case ExecImmSessionVar:
+		return "SESSION_VARIABLE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ExecuteImmediateStmt represents an EXECUTE IMMEDIATE statement.
+//
+// Syntax (docs):
+//
+//	EXECUTE IMMEDIATE { '<string_literal>' | $$<body>$$ | <variable> | $<session_variable> }
+//	  [ USING ( <bind_variable> [ , ... ] ) ]
+//
+// The body of the string / dollar forms is OPAQUE: it is captured VERBATIM
+// (delimiters included for the dollar form; quotes included for the string form)
+// and never parsed as SQL — its contents may be a Snowflake Scripting block, a
+// single SQL statement, or any string the engine evaluates at runtime. Source
+// records which form was used. For the string / dollar forms Body holds the
+// verbatim text; for the variable / session-variable forms Var holds the name
+// (for $<session_variable>, Var.Name excludes the leading $). Using holds the
+// optional bind-variable list (bare identifiers per the legacy grammar and the
+// official corpus).
+type ExecuteImmediateStmt struct {
+	Source ExecImmSource
+	Body   string  // verbatim body for ExecImmString / ExecImmDollar (incl. delimiters); "" otherwise
+	Var    Ident   // variable name for ExecImmVariable / ExecImmSessionVar; zero Ident otherwise
+	Using  []Ident // optional USING ( <bind_variable> , ... ) list
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ExecuteImmediateStmt) Tag() NodeTag { return T_ExecuteImmediateStmt }
+
+// ExecuteTaskStmt represents an EXECUTE TASK statement.
+//
+// Syntax (docs):
+//
+//	EXECUTE TASK <name> [ USING CONFIG = <configuration_string> ]
+//	EXECUTE TASK <name> RETRY LAST
+//
+// RetryLast records the RETRY LAST form. UsingConfig holds the verbatim
+// configuration string (including quotes) when `USING CONFIG = '<...>'` is
+// present, or "" when absent. The two trailing forms are mutually exclusive per
+// the docs.
+type ExecuteTaskStmt struct {
+	Name        *ObjectName
+	RetryLast   bool
+	UsingConfig string // verbatim USING CONFIG = value (incl. quotes); "" when absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *ExecuteTaskStmt) Tag() NodeTag { return T_ExecuteTaskStmt }
+
+// ExplainFormat enumerates the EXPLAIN output format selected by the optional
+// USING clause. ExplainDefault is the bare `EXPLAIN <statement>` form (no USING).
+type ExplainFormat int
+
+const (
+	// ExplainDefault is `EXPLAIN <statement>` with no USING clause.
+	ExplainDefault ExplainFormat = iota
+	// ExplainTabular is `EXPLAIN USING TABULAR <statement>`.
+	ExplainTabular
+	// ExplainJSON is `EXPLAIN USING JSON <statement>`.
+	ExplainJSON
+	// ExplainText is `EXPLAIN USING TEXT <statement>`.
+	ExplainText
+)
+
+// String returns the USING-clause keyword for the format (or "DEFAULT").
+func (f ExplainFormat) String() string {
+	switch f {
+	case ExplainDefault:
+		return "DEFAULT"
+	case ExplainTabular:
+		return "TABULAR"
+	case ExplainJSON:
+		return "JSON"
+	case ExplainText:
+		return "TEXT"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ExplainStmt represents an EXPLAIN statement.
+//
+// Syntax (docs + legacy .g4):
+//
+//	EXPLAIN [ USING { TABULAR | JSON | TEXT } ] <statement>
+//
+// Format records the optional USING format (ExplainDefault when absent). Stmt is
+// the inner statement, parsed structurally via the top-level statement parser.
+type ExplainStmt struct {
+	Format ExplainFormat
+	Stmt   Node
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ExplainStmt) Tag() NodeTag { return T_ExplainStmt }
+
+// Compile-time assertions for CALL / EXECUTE / EXPLAIN nodes (T5.4).
+var (
+	_ Node = (*CallArg)(nil)
+	_ Node = (*CallStmt)(nil)
+	_ Node = (*ExecuteImmediateStmt)(nil)
+	_ Node = (*ExecuteTaskStmt)(nil)
+	_ Node = (*ExplainStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -181,6 +181,13 @@ func walkChildren(v Visitor, node Node) {
 	case *BinaryExpr:
 		Walk(v, n.Left)
 		Walk(v, n.Right)
+	case *CallArg:
+		Walk(v, n.Value)
+	case *CallStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		walkNodes(v, n.Args)
 	case *CaseExpr:
 		Walk(v, n.Operand)
 		Walk(v, n.Else)
@@ -408,8 +415,14 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *ExecuteTaskStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *ExistsExpr:
 		Walk(v, n.Query)
+	case *ExplainStmt:
+		Walk(v, n.Stmt)
 	case *ExternalColumnDef:
 		if n.DataType != nil {
 			Walk(v, n.DataType)

--- a/snowflake/parser/call_execute.go
+++ b/snowflake/parser/call_execute.go
@@ -1,0 +1,460 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// CALL / EXECUTE IMMEDIATE / EXECUTE TASK / EXPLAIN (T5.4)
+//
+// Triangulated oracle: legacy SnowflakeParser.g4 (truth2) + the official
+// Snowflake docs (truth1, which win on conflict) + the official example corpus
+// under testdata/official/{call,execute-immediate,explain}.
+//
+// Grammar:
+//
+//	CALL <proc_name> ( [ <arg> [ , ... ] ] )
+//	  -- legacy: CALL object_name '(' expr_list? ')'.  Args are expressions;
+//	  -- named arguments (name => value) are documented and accepted here even
+//	  -- though the legacy expr_list rule omits them (docs win).
+//
+//	EXECUTE IMMEDIATE { '<string>' | $$<body>$$ | <variable> | $<session_var> }
+//	                  [ USING ( <bind_var> [ , ... ] ) ]
+//	  -- The string / dollar body is OPAQUE and raw-scanned VERBATIM (delimiters
+//	  -- included).  The legacy grammar's USING list and the docs' bind-variable
+//	  -- list are bare identifiers (matched by the official corpus).
+//
+//	EXECUTE TASK <name> [ USING CONFIG = <config_string> ]
+//	EXECUTE TASK <name> RETRY LAST
+//	  -- legacy: EXECUTE TASK object_name retry_last? .  USING CONFIG is docs-only.
+//
+//	EXPLAIN [ USING { TABULAR | JSON | TEXT } ] <statement>
+//	  -- The inner statement is parsed structurally via parseStmt.
+//
+// EXECUTE is NOT an omni keyword (it is absent from the F2 keyword table), so it
+// arrives as a plain identifier and is dispatched from parseStmt's default
+// branch by its uppercased text (mirroring LS / RM).  CALL and EXPLAIN have
+// dedicated dispatch cases.
+//
+// $-prefixed CALL arguments (CALL p($v)) depend on session-variable expression
+// support owned by a separate node (expr-dollar-refs) and are NOT handled here;
+// the EXECUTE IMMEDIATE $<session_var> form below reads the $-variable token
+// directly (not through the expression parser) and is therefore self-contained.
+// ---------------------------------------------------------------------------
+
+// parseCallStmt parses `CALL <proc_name> ( [ <arg> [ , ... ] ] )`. The CALL
+// keyword has NOT yet been consumed when this function is called.
+func (p *Parser) parseCallStmt() (ast.Node, error) {
+	callTok := p.advance() // consume CALL
+	stmt := &ast.CallStmt{
+		Loc: ast.Loc{Start: callTok.Loc.Start},
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+
+	// Empty argument list: CALL p().
+	if p.cur.Type == ')' {
+		closeTok := p.advance() // consume ')'
+		stmt.Loc.End = closeTok.Loc.End
+		return stmt, nil
+	}
+
+	for {
+		arg, err := p.parseCallArg()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Args = append(stmt.Args, arg)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = closeTok.Loc.End
+	return stmt, nil
+}
+
+// parseCallArg parses one CALL argument: either a positional expression or a
+// named argument `<name> => <expr>`. A named argument is detected by a leading
+// identifier immediately followed by the `=>` (tokAssoc) operator.
+func (p *Parser) parseCallArg() (*ast.CallArg, error) {
+	start := p.cur.Loc.Start
+
+	// Named argument: <name> => <expr>.
+	if p.isIdentToken() && p.peekNext().Type == tokAssoc {
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		p.advance() // consume '=>'
+		value, err := p.parseCallArgValue()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.CallArg{
+			Name:  name,
+			Value: value,
+			Loc:   ast.Loc{Start: start, End: p.prev.Loc.End},
+		}, nil
+	}
+
+	value, err := p.parseCallArgValue()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CallArg{
+		Value: value,
+		Loc:   ast.Loc{Start: start, End: p.prev.Loc.End},
+	}, nil
+}
+
+// parseCallArgValue parses a single CALL argument value. Arguments are
+// expressions; the official docs additionally permit a bare scalar subquery
+// (CALL p(SELECT COUNT(*) FROM t)) without surrounding parentheses, so a leading
+// SELECT / WITH is parsed as a query expression. (The legacy expr_list rule does
+// not allow this; docs win.)
+func (p *Parser) parseCallArgValue() (ast.Node, error) {
+	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
+		if p.cur.Type == kwWITH {
+			return p.parseWithQueryExpr()
+		}
+		return p.parseQueryExpr()
+	}
+	return p.parseExpr()
+}
+
+// ---------------------------------------------------------------------------
+// EXECUTE dispatch (EXECUTE IMMEDIATE | EXECUTE TASK)
+// ---------------------------------------------------------------------------
+
+// parseExecuteStmt dispatches an EXECUTE statement on the keyword that follows
+// EXECUTE (IMMEDIATE or TASK). The EXECUTE word (a plain identifier, not a
+// keyword) has NOT yet been consumed when this function is called.
+func (p *Parser) parseExecuteStmt() (ast.Node, error) {
+	execTok := p.advance() // consume EXECUTE
+	switch p.cur.Type {
+	case kwIMMEDIATE:
+		return p.parseExecuteImmediateStmt(execTok.Loc)
+	case kwTASK:
+		return p.parseExecuteTaskStmt(execTok.Loc)
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// parseExecuteImmediateStmt parses
+//
+//	EXECUTE IMMEDIATE { '<string>' | $$<body>$$ | <variable> | $<session_var> }
+//	                  [ USING ( <bind_var> [ , ... ] ) ]
+//
+// On entry cur is the IMMEDIATE keyword. start is the Loc of the EXECUTE word.
+func (p *Parser) parseExecuteImmediateStmt(start ast.Loc) (ast.Node, error) {
+	// Snapshot the lexer error count BEFORE consuming IMMEDIATE — consuming it
+	// primes cur with the body's first token, and for a multi-line single-quoted
+	// body that priming makes scanString append a spurious "unterminated string
+	// literal" error that scanExecImmBody must later drop.
+	errLenBefore := len(p.lexer.errors)
+
+	p.advance() // consume IMMEDIATE
+	stmt := &ast.ExecuteImmediateStmt{
+		Loc: ast.Loc{Start: start.Start},
+	}
+
+	switch {
+	case p.cur.Type == tokVariable:
+		// $<session_variable>. The lexer strips the leading $; Str is the name.
+		varTok := p.advance()
+		stmt.Source = ast.ExecImmSessionVar
+		stmt.Var = ast.Ident{Name: varTok.Str, Loc: varTok.Loc}
+		stmt.Loc.End = varTok.Loc.End
+
+	case p.curIsStringOrDollarBody():
+		// '<string>' or $$<body>$$ — opaque body captured verbatim by raw-scan.
+		body, dollar, end, err := p.scanExecImmBody(errLenBefore)
+		if err != nil {
+			return nil, err
+		}
+		if dollar {
+			stmt.Source = ast.ExecImmDollar
+		} else {
+			stmt.Source = ast.ExecImmString
+		}
+		stmt.Body = body
+		stmt.Loc.End = end
+
+	case p.isIdentToken():
+		// <variable> — a bare Snowflake Scripting local variable.
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Source = ast.ExecImmVariable
+		stmt.Var = name
+		stmt.Loc.End = name.Loc.End
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	// Optional USING ( <bind_variable> [ , ... ] ).
+	if p.cur.Type == kwUSING {
+		p.advance() // consume USING
+		using, end, err := p.parseExecImmUsing()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Using = using
+		stmt.Loc.End = end
+	}
+
+	return stmt, nil
+}
+
+// curIsStringOrDollarBody reports whether the current token begins an EXECUTE
+// IMMEDIATE string ('...') or dollar ($$...$$) body. The lexer emits tokString
+// for both a single-line single-quoted string and a complete $$...$$ run; a
+// multi-line single-quoted body fails to lex (emitting tokInvalid) but still
+// begins with a single quote in the source, so the source byte is consulted as
+// well.
+func (p *Parser) curIsStringOrDollarBody() bool {
+	if p.cur.Type == tokString {
+		return true
+	}
+	i := p.cur.Loc.Start - p.base
+	if i < 0 || i >= len(p.input) {
+		return false
+	}
+	return p.input[i] == '\'' || p.input[i] == '$'
+}
+
+// scanExecImmBody raw-scans the EXECUTE IMMEDIATE string / dollar body directly
+// from the source text and returns it VERBATIM (delimiters included), whether
+// the dollar form was used, and the absolute end offset. On entry cur is the
+// body's first token.
+//
+// The body is raw-scanned rather than read from the token stream for the same
+// reason routine bodies are (see function_procedure.go): omni's lexer rejects a
+// single-quoted string that spans newlines, and the dollar form is scanned the
+// same way for uniformity so the body never depends on the token stream.
+//
+// LOOP-GUARD: each scan loop is bounded by len(p.input) and advances its cursor
+// by at least one byte every iteration; the bound and the unconditional j++
+// guarantee termination. An unterminated or malformed body returns a ParseError
+// rather than looping. A negative test (TestExecuteImmediate_Reject) feeds an
+// unterminated body and asserts a fast error return.
+//
+// errLenBefore is the lexer's error count captured before cur was primed with
+// the body token (see parseExecuteImmediateStmt); any spurious lex error the
+// discarded body token produced is truncated back to it after a successful scan.
+func (p *Parser) scanExecImmBody(errLenBefore int) (body string, dollar bool, end int, err error) {
+	startLocal := p.cur.Loc.Start - p.base
+	if startLocal < 0 || startLocal >= len(p.input) {
+		return "", false, 0, p.syntaxErrorAtCur()
+	}
+
+	var endLocal int
+	switch p.input[startLocal] {
+	case '$':
+		// Dollar-quoted body: $$ ... $$ (no nesting, no escapes).
+		if startLocal+1 >= len(p.input) || p.input[startLocal+1] != '$' {
+			return "", false, 0, p.syntaxErrorAtCur()
+		}
+		j := startLocal + 2
+		closed := false
+		for j+1 < len(p.input) {
+			if p.input[j] == '$' && p.input[j+1] == '$' {
+				j += 2 // include the closing $$
+				closed = true
+				break
+			}
+			j++ // LOOP-GUARD: always advances; bounded by len(p.input).
+		}
+		if !closed {
+			return "", false, 0, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "unterminated dollar-quoted EXECUTE IMMEDIATE body",
+			}
+		}
+		endLocal = j
+		dollar = true
+
+	case '\'':
+		// Single-quoted body: ' ... ' where '' is an escaped quote and the body
+		// may span newlines. Scan to the matching unescaped closing quote.
+		j := startLocal + 1
+		closed := false
+		for j < len(p.input) {
+			if p.input[j] == '\'' {
+				if j+1 < len(p.input) && p.input[j+1] == '\'' {
+					j += 2 // '' escaped quote; LOOP-GUARD: advances by two.
+					continue
+				}
+				j++ // consume closing quote
+				closed = true
+				break
+			}
+			j++ // LOOP-GUARD: always advances; bounded by len(p.input).
+		}
+		if !closed {
+			return "", false, 0, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "unterminated EXECUTE IMMEDIATE body string literal",
+			}
+		}
+		endLocal = j
+		dollar = false
+
+	default:
+		return "", false, 0, p.syntaxErrorAtCur()
+	}
+
+	body = p.input[startLocal:endLocal]
+	end = endLocal + p.base
+
+	// Drop any spurious lex error a discarded multi-line single-quoted body
+	// token produced.
+	if len(p.lexer.errors) > errLenBefore {
+		p.lexer.errors = p.lexer.errors[:errLenBefore]
+	}
+
+	// Re-sync the lexer past the body and re-prime cur, discarding the buffered
+	// lookahead the bypassed token stream left behind.
+	p.lexer.pos = endLocal
+	p.hasNext = false
+	p.advance()
+
+	return body, dollar, end, nil
+}
+
+// parseExecImmUsing parses the EXECUTE IMMEDIATE `USING ( <bind_variable>
+// [ , ... ] )` list. The USING keyword has already been consumed. Returns the
+// bind-variable identifiers and the absolute end offset (the closing ')'). The
+// list must be non-empty.
+func (p *Parser) parseExecImmUsing() ([]ast.Ident, int, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, 0, err
+	}
+
+	var binds []ast.Ident
+	for {
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, 0, err
+		}
+		binds = append(binds, name)
+
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, 0, err
+	}
+	return binds, closeTok.Loc.End, nil
+}
+
+// parseExecuteTaskStmt parses
+//
+//	EXECUTE TASK <name> [ USING CONFIG = <config_string> ]
+//	EXECUTE TASK <name> RETRY LAST
+//
+// On entry cur is the TASK keyword. start is the Loc of the EXECUTE word.
+func (p *Parser) parseExecuteTaskStmt(start ast.Loc) (ast.Node, error) {
+	p.advance() // consume TASK
+	stmt := &ast.ExecuteTaskStmt{
+		Loc: ast.Loc{Start: start.Start},
+	}
+
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	switch {
+	case p.cur.Type == kwRETRY:
+		p.advance() // consume RETRY
+		if _, err := p.expect(kwLAST); err != nil {
+			return nil, err
+		}
+		stmt.RetryLast = true
+
+	case p.cur.Type == kwUSING:
+		p.advance() // consume USING
+		if !p.curIsWord("CONFIG") {
+			return nil, p.syntaxErrorAtCur()
+		}
+		p.advance() // consume CONFIG
+		if _, err := p.expect('='); err != nil {
+			return nil, err
+		}
+		if p.cur.Type != tokString {
+			return nil, p.syntaxErrorAtCur()
+		}
+		cfgTok := p.advance() // consume the config string literal
+		stmt.UsingConfig = p.srcSlice(cfgTok.Loc.Start, cfgTok.Loc.End)
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// EXPLAIN
+// ---------------------------------------------------------------------------
+
+// parseExplainStmt parses `EXPLAIN [ USING { TABULAR | JSON | TEXT } ]
+// <statement>`. The EXPLAIN keyword has NOT yet been consumed when this function
+// is called. The inner statement is parsed structurally via parseStmt.
+func (p *Parser) parseExplainStmt() (ast.Node, error) {
+	explainTok := p.advance() // consume EXPLAIN
+	stmt := &ast.ExplainStmt{
+		Format: ast.ExplainDefault,
+		Loc:    ast.Loc{Start: explainTok.Loc.Start},
+	}
+
+	// Optional USING { TABULAR | JSON | TEXT }.
+	if p.cur.Type == kwUSING {
+		p.advance() // consume USING
+		switch p.cur.Type {
+		case kwTABULAR:
+			stmt.Format = ast.ExplainTabular
+		case kwJSON:
+			stmt.Format = ast.ExplainJSON
+		case kwTEXT:
+			stmt.Format = ast.ExplainText
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+		p.advance() // consume the format keyword
+	}
+
+	// The inner statement, parsed via the top-level statement dispatcher.
+	inner, err := p.parseStmt()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Stmt = inner
+	// Use the last consumed token's end rather than NodeLoc(inner): the inner
+	// statement may be a node type not enumerated in ast.NodeLoc (which is a
+	// partial switch), and p.prev always carries a valid end offset.
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}

--- a/snowflake/parser/call_execute_test.go
+++ b/snowflake/parser/call_execute_test.go
@@ -1,0 +1,632 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func mustCall(t *testing.T, input string) *ast.CallStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CallStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CallStmt", input, node)
+	}
+	return stmt
+}
+
+func mustExecImm(t *testing.T, input string) *ast.ExecuteImmediateStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.ExecuteImmediateStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.ExecuteImmediateStmt", input, node)
+	}
+	return stmt
+}
+
+func mustExecTask(t *testing.T, input string) *ast.ExecuteTaskStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.ExecuteTaskStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.ExecuteTaskStmt", input, node)
+	}
+	return stmt
+}
+
+func mustExplain(t *testing.T, input string) *ast.ExplainStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.ExplainStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.ExplainStmt", input, node)
+	}
+	return stmt
+}
+
+// assertValidLoc fails if loc has a negative or inverted span.
+func assertValidLoc(t *testing.T, what string, loc ast.Loc) {
+	t.Helper()
+	if loc.Start < 0 || loc.End < 0 {
+		t.Errorf("%s: Loc = %+v, want Start/End >= 0", what, loc)
+	}
+	if loc.End < loc.Start {
+		t.Errorf("%s: Loc = %+v, want End >= Start", what, loc)
+	}
+}
+
+// callArg returns the i-th argument of a CALL statement as a *ast.CallArg.
+func callArg(t *testing.T, stmt *ast.CallStmt, i int) *ast.CallArg {
+	t.Helper()
+	if i >= len(stmt.Args) {
+		t.Fatalf("arg index %d out of range (len=%d)", i, len(stmt.Args))
+	}
+	arg, ok := stmt.Args[i].(*ast.CallArg)
+	if !ok {
+		t.Fatalf("arg %d: got %T, want *ast.CallArg", i, stmt.Args[i])
+	}
+	return arg
+}
+
+// ---------------------------------------------------------------------------
+// CALL
+//   Syntax (legacy .g4 + docs): CALL <proc_name> ( [ <arg> [ , ... ] ] )
+//   Args are expressions; named args (name => value) are docs-driven.
+// ---------------------------------------------------------------------------
+
+func TestCall_PositionalArgs(t *testing.T) {
+	// Corpus call/example_01: CALL stproc1(5.14::FLOAT);
+	stmt := mustCall(t, "CALL stproc1(5.14::FLOAT)")
+	if stmt.Name.String() != "stproc1" {
+		t.Errorf("Name = %q, want stproc1", stmt.Name.String())
+	}
+	if len(stmt.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(stmt.Args))
+	}
+	arg := callArg(t, stmt, 0)
+	if !arg.Name.IsEmpty() {
+		t.Errorf("arg 0 Name = %q, want empty (positional)", arg.Name.Normalize())
+	}
+	if _, ok := arg.Value.(*ast.CastExpr); !ok {
+		t.Errorf("arg 0 Value = %T, want *ast.CastExpr", arg.Value)
+	}
+	assertValidLoc(t, "CallStmt", stmt.Loc)
+	assertValidLoc(t, "CallArg", arg.Loc)
+}
+
+func TestCall_ArithmeticArg(t *testing.T) {
+	// Corpus call/example_02: CALL stproc1(2 * 5.14::FLOAT);
+	stmt := mustCall(t, "CALL stproc1(2 * 5.14::FLOAT)")
+	if len(stmt.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(stmt.Args))
+	}
+	if _, ok := callArg(t, stmt, 0).Value.(*ast.BinaryExpr); !ok {
+		t.Errorf("arg 0 Value = %T, want *ast.BinaryExpr", callArg(t, stmt, 0).Value)
+	}
+}
+
+func TestCall_BareSubqueryArg(t *testing.T) {
+	// Corpus call/example_03: CALL stproc1(SELECT COUNT(*) FROM stproc_test_table1);
+	// DOCS DIVERGENCE: the docs permit a bare SELECT as a CALL argument; the
+	// legacy expr_list rule does not. Docs win.
+	stmt := mustCall(t, "CALL stproc1(SELECT COUNT(*) FROM stproc_test_table1)")
+	if len(stmt.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(stmt.Args))
+	}
+	if _, ok := callArg(t, stmt, 0).Value.(*ast.SelectStmt); !ok {
+		t.Errorf("arg 0 Value = %T, want *ast.SelectStmt", callArg(t, stmt, 0).Value)
+	}
+}
+
+func TestCall_StringAndNumberArgs(t *testing.T) {
+	// Corpus call/example_04: CALL sv_proc1('Manitoba', 127.4);
+	stmt := mustCall(t, "CALL sv_proc1('Manitoba', 127.4)")
+	if len(stmt.Args) != 2 {
+		t.Fatalf("len(Args) = %d, want 2", len(stmt.Args))
+	}
+	if _, ok := callArg(t, stmt, 0).Value.(*ast.Literal); !ok {
+		t.Errorf("arg 0 Value = %T, want *ast.Literal", callArg(t, stmt, 0).Value)
+	}
+	if _, ok := callArg(t, stmt, 1).Value.(*ast.Literal); !ok {
+		t.Errorf("arg 1 Value = %T, want *ast.Literal", callArg(t, stmt, 1).Value)
+	}
+}
+
+func TestCall_NamedArgs(t *testing.T) {
+	// Corpus call/example_05: CALL sv_proc1(province => 'Manitoba', amount => 127.4);
+	stmt := mustCall(t, "CALL sv_proc1(province => 'Manitoba', amount => 127.4)")
+	if len(stmt.Args) != 2 {
+		t.Fatalf("len(Args) = %d, want 2", len(stmt.Args))
+	}
+	a0 := callArg(t, stmt, 0)
+	if a0.Name.Normalize() != "PROVINCE" {
+		t.Errorf("arg 0 Name = %q, want PROVINCE", a0.Name.Normalize())
+	}
+	if _, ok := a0.Value.(*ast.Literal); !ok {
+		t.Errorf("arg 0 Value = %T, want *ast.Literal", a0.Value)
+	}
+	a1 := callArg(t, stmt, 1)
+	if a1.Name.Normalize() != "AMOUNT" {
+		t.Errorf("arg 1 Name = %q, want AMOUNT", a1.Name.Normalize())
+	}
+	assertValidLoc(t, "named CallArg", a0.Loc)
+}
+
+func TestCall_SystemFunctionArg(t *testing.T) {
+	// SYSTEM$... contains a mid-identifier '$' that lexes as one identifier token.
+	stmt := mustCall(t, "CALL my_sp(SYSTEM$WAIT(1))")
+	if len(stmt.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(stmt.Args))
+	}
+	if _, ok := callArg(t, stmt, 0).Value.(*ast.FuncCallExpr); !ok {
+		t.Errorf("arg 0 Value = %T, want *ast.FuncCallExpr", callArg(t, stmt, 0).Value)
+	}
+}
+
+func TestCall_EmptyArgs(t *testing.T) {
+	stmt := mustCall(t, "CALL my_sp()")
+	if len(stmt.Args) != 0 {
+		t.Errorf("len(Args) = %d, want 0", len(stmt.Args))
+	}
+	assertValidLoc(t, "CallStmt", stmt.Loc)
+}
+
+func TestCall_QualifiedName(t *testing.T) {
+	stmt := mustCall(t, "CALL db.sch.my_sp(1, 2)")
+	if stmt.Name.Normalize() != "DB.SCH.MY_SP" {
+		t.Errorf("Name = %q, want DB.SCH.MY_SP", stmt.Name.Normalize())
+	}
+}
+
+func TestCall_LocCoversWholeStatement(t *testing.T) {
+	input := "CALL my_sp(1)"
+	stmt := mustCall(t, input)
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}
+
+func TestCall_Reject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"missing parens", "CALL my_sp"},
+		{"missing close paren", "CALL my_sp(1, 2"},
+		{"missing name", "CALL ()"},
+		{"trailing comma then close", "CALL my_sp(1,)"},
+		{"named arg missing value", "CALL my_sp(x =>)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mustNotParse(t, tc.input)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXECUTE IMMEDIATE
+//   Syntax (docs): EXECUTE IMMEDIATE { '<string>' | $$<body>$$ | <variable>
+//     | $<session_variable> } [ USING ( <bind_var> [ , ... ] ) ]
+// ---------------------------------------------------------------------------
+
+func TestExecuteImmediate_StringBody(t *testing.T) {
+	stmt := mustExecImm(t, "EXECUTE IMMEDIATE 'SELECT 1'")
+	if stmt.Source != ast.ExecImmString {
+		t.Errorf("Source = %v, want ExecImmString", stmt.Source)
+	}
+	if stmt.Body != "'SELECT 1'" {
+		t.Errorf("Body = %q, want \"'SELECT 1'\" (verbatim, quotes included)", stmt.Body)
+	}
+	assertValidLoc(t, "ExecuteImmediateStmt", stmt.Loc)
+}
+
+func TestExecuteImmediate_DollarBody(t *testing.T) {
+	stmt := mustExecImm(t, "EXECUTE IMMEDIATE $$ SELECT PI(); $$")
+	if stmt.Source != ast.ExecImmDollar {
+		t.Errorf("Source = %v, want ExecImmDollar", stmt.Source)
+	}
+	if !strings.HasPrefix(stmt.Body, "$$") || !strings.HasSuffix(stmt.Body, "$$") {
+		t.Errorf("Body = %q, want it to retain the $$ delimiters", stmt.Body)
+	}
+	if !strings.Contains(stmt.Body, "SELECT PI()") {
+		t.Errorf("Body = %q, want it to contain SELECT PI()", stmt.Body)
+	}
+}
+
+func TestExecuteImmediate_MultilineDollarBody(t *testing.T) {
+	// Corpus execute-immediate/example_08: a multi-line $$...$$ scripting block.
+	input := "EXECUTE IMMEDIATE $$\nDECLARE\n  x FLOAT;\nBEGIN\n  RETURN x;\nEND;\n$$"
+	stmt := mustExecImm(t, input)
+	if stmt.Source != ast.ExecImmDollar {
+		t.Errorf("Source = %v, want ExecImmDollar", stmt.Source)
+	}
+	if !strings.Contains(stmt.Body, "DECLARE") || !strings.Contains(stmt.Body, "END;") {
+		t.Errorf("Body = %q, want the full scripting block verbatim", stmt.Body)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d (end of $$ body)", stmt.Loc.End, len(input))
+	}
+}
+
+func TestExecuteImmediate_MultilineStringBody(t *testing.T) {
+	// A single-quoted body that spans newlines: the lexer alone rejects it
+	// (unterminated string on the newline); the raw-scan captures it verbatim
+	// with no spurious lex error leaking to the result.
+	input := "EXECUTE IMMEDIATE 'CREATE TABLE t (\n  i INTEGER\n)'"
+	stmt := mustExecImm(t, input)
+	if stmt.Source != ast.ExecImmString {
+		t.Errorf("Source = %v, want ExecImmString", stmt.Source)
+	}
+	if !strings.Contains(stmt.Body, "CREATE TABLE t") {
+		t.Errorf("Body = %q, want the verbatim multi-line string", stmt.Body)
+	}
+	if !strings.HasPrefix(stmt.Body, "'") || !strings.HasSuffix(stmt.Body, "'") {
+		t.Errorf("Body = %q, want surrounding quotes retained", stmt.Body)
+	}
+}
+
+func TestExecuteImmediate_Variable(t *testing.T) {
+	// Corpus execute-immediate/example_01: EXECUTE IMMEDIATE v1;
+	stmt := mustExecImm(t, "EXECUTE IMMEDIATE v1")
+	if stmt.Source != ast.ExecImmVariable {
+		t.Errorf("Source = %v, want ExecImmVariable", stmt.Source)
+	}
+	if stmt.Var.Normalize() != "V1" {
+		t.Errorf("Var = %q, want V1", stmt.Var.Normalize())
+	}
+}
+
+func TestExecuteImmediate_SessionVariable(t *testing.T) {
+	// Corpus execute-immediate/example_07: EXECUTE IMMEDIATE $stmt;
+	stmt := mustExecImm(t, "EXECUTE IMMEDIATE $stmt")
+	if stmt.Source != ast.ExecImmSessionVar {
+		t.Errorf("Source = %v, want ExecImmSessionVar", stmt.Source)
+	}
+	if stmt.Var.Name != "stmt" {
+		t.Errorf("Var.Name = %q, want stmt (no leading $)", stmt.Var.Name)
+	}
+	assertValidLoc(t, "ExecuteImmediateStmt", stmt.Loc)
+}
+
+func TestExecuteImmediate_UsingClause(t *testing.T) {
+	// Corpus execute-immediate/example_04 (inner): EXECUTE IMMEDIATE :query
+	// USING (minimum_price, maximum_price). The :query bind is a scripting-var
+	// reference; here we exercise the USING list against a variable form.
+	stmt := mustExecImm(t, "EXECUTE IMMEDIATE query USING (minimum_price, maximum_price)")
+	if stmt.Source != ast.ExecImmVariable {
+		t.Errorf("Source = %v, want ExecImmVariable", stmt.Source)
+	}
+	if len(stmt.Using) != 2 {
+		t.Fatalf("len(Using) = %d, want 2", len(stmt.Using))
+	}
+	if stmt.Using[0].Normalize() != "MINIMUM_PRICE" || stmt.Using[1].Normalize() != "MAXIMUM_PRICE" {
+		t.Errorf("Using = %v, want [MINIMUM_PRICE MAXIMUM_PRICE]", stmt.Using)
+	}
+	if stmt.Loc.End <= stmt.Loc.Start {
+		t.Errorf("Loc = %+v, want End past the USING clause", stmt.Loc)
+	}
+}
+
+func TestExecuteImmediate_StringWithUsing(t *testing.T) {
+	stmt := mustExecImm(t, "EXECUTE IMMEDIATE 'SELECT ?' USING (a)")
+	if stmt.Source != ast.ExecImmString {
+		t.Errorf("Source = %v, want ExecImmString", stmt.Source)
+	}
+	if len(stmt.Using) != 1 || stmt.Using[0].Normalize() != "A" {
+		t.Errorf("Using = %v, want [A]", stmt.Using)
+	}
+}
+
+func TestExecuteImmediate_Reject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"no body", "EXECUTE IMMEDIATE"},
+		// Unterminated bodies MUST return fast with an error, never loop
+		// (LOOP-GUARD coverage).
+		{"unterminated dollar body", "EXECUTE IMMEDIATE $$ SELECT 1"},
+		{"unterminated string body", "EXECUTE IMMEDIATE 'SELECT 1"},
+		{"empty using list", "EXECUTE IMMEDIATE 'x' USING ()"},
+		{"using missing close", "EXECUTE IMMEDIATE 'x' USING (a"},
+		{"using missing open", "EXECUTE IMMEDIATE 'x' USING a)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mustNotParse(t, tc.input)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXECUTE TASK
+//   Syntax (docs + legacy .g4):
+//     EXECUTE TASK <name> [ USING CONFIG = <config_string> ]
+//     EXECUTE TASK <name> RETRY LAST
+// ---------------------------------------------------------------------------
+
+func TestExecuteTask_Bare(t *testing.T) {
+	stmt := mustExecTask(t, "EXECUTE TASK mytask")
+	if stmt.Name.Normalize() != "MYTASK" {
+		t.Errorf("Name = %q, want MYTASK", stmt.Name.Normalize())
+	}
+	if stmt.RetryLast {
+		t.Error("RetryLast = true, want false")
+	}
+	if stmt.UsingConfig != "" {
+		t.Errorf("UsingConfig = %q, want empty", stmt.UsingConfig)
+	}
+	assertValidLoc(t, "ExecuteTaskStmt", stmt.Loc)
+}
+
+func TestExecuteTask_QualifiedName(t *testing.T) {
+	stmt := mustExecTask(t, "EXECUTE TASK db.sch.mytask")
+	if stmt.Name.Normalize() != "DB.SCH.MYTASK" {
+		t.Errorf("Name = %q, want DB.SCH.MYTASK", stmt.Name.Normalize())
+	}
+}
+
+func TestExecuteTask_RetryLast(t *testing.T) {
+	stmt := mustExecTask(t, "EXECUTE TASK mytask RETRY LAST")
+	if !stmt.RetryLast {
+		t.Error("RetryLast = false, want true")
+	}
+	assertValidLoc(t, "ExecuteTaskStmt", stmt.Loc)
+}
+
+func TestExecuteTask_UsingConfig(t *testing.T) {
+	stmt := mustExecTask(t, "EXECUTE TASK mytask USING CONFIG = '{\"k\": 1}'")
+	if stmt.UsingConfig == "" || !strings.Contains(stmt.UsingConfig, "\"k\"") {
+		t.Errorf("UsingConfig = %q, want the config string literal", stmt.UsingConfig)
+	}
+}
+
+func TestExecuteTask_Reject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"missing name", "EXECUTE TASK"},
+		{"retry without last", "EXECUTE TASK t RETRY"},
+		{"config missing equals", "EXECUTE TASK t USING CONFIG '{}'"},
+		{"config missing value", "EXECUTE TASK t USING CONFIG ="},
+		{"using missing config keyword", "EXECUTE TASK t USING '{}'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mustNotParse(t, tc.input)
+		})
+	}
+}
+
+func TestExecute_Reject(t *testing.T) {
+	// EXECUTE followed by neither IMMEDIATE nor TASK is a syntax error.
+	mustNotParse(t, "EXECUTE FOO")
+	mustNotParse(t, "EXECUTE")
+}
+
+// ---------------------------------------------------------------------------
+// EXPLAIN
+//   Syntax (docs + legacy .g4): EXPLAIN [ USING { TABULAR | JSON | TEXT } ] <stmt>
+// ---------------------------------------------------------------------------
+
+func TestExplain_Default(t *testing.T) {
+	stmt := mustExplain(t, "EXPLAIN SELECT 1")
+	if stmt.Format != ast.ExplainDefault {
+		t.Errorf("Format = %v, want ExplainDefault", stmt.Format)
+	}
+	if _, ok := stmt.Stmt.(*ast.SelectStmt); !ok {
+		t.Errorf("Stmt = %T, want *ast.SelectStmt", stmt.Stmt)
+	}
+	assertValidLoc(t, "ExplainStmt", stmt.Loc)
+}
+
+func TestExplain_UsingFormats(t *testing.T) {
+	cases := []struct {
+		input string
+		want  ast.ExplainFormat
+	}{
+		// Corpus explain/example_02..04.
+		{"EXPLAIN USING TABULAR SELECT Z1.ID FROM Z1", ast.ExplainTabular},
+		{"EXPLAIN USING JSON SELECT Z1.ID FROM Z1", ast.ExplainJSON},
+		{"EXPLAIN USING TEXT SELECT Z1.ID FROM Z1", ast.ExplainText},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want.String(), func(t *testing.T) {
+			stmt := mustExplain(t, tc.input)
+			if stmt.Format != tc.want {
+				t.Errorf("Format = %v, want %v", stmt.Format, tc.want)
+			}
+			if _, ok := stmt.Stmt.(*ast.SelectStmt); !ok {
+				t.Errorf("Stmt = %T, want *ast.SelectStmt", stmt.Stmt)
+			}
+			assertValidLoc(t, "ExplainStmt", stmt.Loc)
+		})
+	}
+}
+
+func TestExplain_InnerInsert(t *testing.T) {
+	// EXPLAIN over a non-SELECT statement (the inner uses parseStmt dispatch).
+	stmt := mustExplain(t, "EXPLAIN INSERT INTO t VALUES (1)")
+	if _, ok := stmt.Stmt.(*ast.InsertStmt); !ok {
+		t.Errorf("Stmt = %T, want *ast.InsertStmt", stmt.Stmt)
+	}
+	assertValidLoc(t, "ExplainStmt", stmt.Loc)
+}
+
+func TestExplain_LocCoversInner(t *testing.T) {
+	input := "EXPLAIN SELECT 1"
+	stmt := mustExplain(t, input)
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if stmt.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}
+
+func TestExplain_Reject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"using without format", "EXPLAIN USING SELECT 1"},
+		{"bad format", "EXPLAIN USING XML SELECT 1"},
+		{"no inner statement", "EXPLAIN"},
+		{"using format no inner", "EXPLAIN USING JSON"},
+		{"inner garbage", "EXPLAIN FROBNICATE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mustNotParse(t, tc.input)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walker — confirm CALL argument expressions (and EXPLAIN's inner statement)
+// are reachable via ast.Inspect so analysis / query-span can see them.
+// ---------------------------------------------------------------------------
+
+func TestCall_ArgsAreWalkable(t *testing.T) {
+	stmt := mustCall(t, "CALL my_sp(SELECT id FROM users)")
+	var sawSelect bool
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if _, ok := n.(*ast.SelectStmt); ok {
+			sawSelect = true
+		}
+		return true
+	})
+	if !sawSelect {
+		t.Error("walker did not reach the subquery argument's SelectStmt")
+	}
+}
+
+func TestExplain_InnerIsWalkable(t *testing.T) {
+	stmt := mustExplain(t, "EXPLAIN SELECT id FROM users")
+	var sawSelect bool
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if _, ok := n.(*ast.SelectStmt); ok {
+			sawSelect = true
+		}
+		return true
+	})
+	if !sawSelect {
+		t.Error("walker did not reach EXPLAIN's inner SelectStmt")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Official docs corpus — every CALL / EXECUTE IMMEDIATE / EXPLAIN statement in
+// the call, execute-immediate, and explain corpora must parse with zero errors
+// and to its expected AST type. The official docs are the authoritative oracle
+// (truth1). Context / setup statements owned by other DAG nodes (CREATE / SET /
+// INSERT / the DECLARE…BEGIN scripting block) are skipped, and the $-variable
+// argument forms blocked by the shared expression parser's missing tokVariable
+// support (CALL p($v)) are filtered as a flagged divergence (see
+// execCallDollarLimited).
+// ---------------------------------------------------------------------------
+
+var execCallCorpusDirs = []string{
+	"testdata/official/call",
+	"testdata/official/execute-immediate",
+	"testdata/official/explain",
+}
+
+// execCallDollarLimited reports whether a CALL statement uses a $-prefixed
+// session-variable ARGUMENT (CALL p($v)), which depends on the shared
+// expression parser's tokVariable support owned by a separate node
+// (expr-dollar-refs). EXECUTE IMMEDIATE's own $<session_var> form is handled by
+// this node directly (it reads the $-token, not an expression) and is therefore
+// NOT filtered here. Flagged in the divergence ledger.
+func execCallDollarLimited(upper string) bool {
+	return strings.HasPrefix(upper, "CALL") && strings.Contains(upper, "($")
+}
+
+func TestExecCall_OfficialCorpus(t *testing.T) {
+	for _, dir := range execCallCorpusDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read corpus dir %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			t.Run(path, func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				assertExecCallStatementsParse(t, string(data))
+			})
+		}
+	}
+}
+
+// assertExecCallStatementsParse parses sql and asserts every CALL / EXECUTE
+// IMMEDIATE / EXECUTE TASK / EXPLAIN statement parses with no errors and to the
+// expected AST type. Statements owned by other DAG nodes are skipped; the
+// $-argument-limited CALL statements are filtered (flagged divergence).
+func assertExecCallStatementsParse(t *testing.T, sql string) {
+	t.Helper()
+	for _, seg := range Split(sql) {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		upper := strings.ToUpper(text)
+		kind, want := execCallStmtKind(upper)
+		if kind == "" {
+			continue // context statement owned by another DAG node
+		}
+		if execCallDollarLimited(upper) {
+			// Known dependency limitation: must currently fail to parse. If it
+			// starts parsing, the dependency lifted the limitation — surface it.
+			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
+				t.Logf("note: $-arg CALL now parses, drop it from execCallDollarLimited: %q", text)
+			}
+			continue
+		}
+		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		if len(errs) > 0 {
+			t.Errorf("statement %q produced %d error(s): %v", text, len(errs), errs)
+			continue
+		}
+		if !want(node) {
+			t.Errorf("statement %q (%s) parsed to unexpected type %T", text, kind, node)
+		}
+	}
+}
+
+// execCallStmtKind classifies an uppercased statement by its leading keyword(s),
+// returning the kind label and a predicate checking the parsed node type.
+// Returns ("", nil) for statements this node does not own (CREATE / SET /
+// INSERT / CALL setup lines and DECLARE…BEGIN scripting blocks).
+func execCallStmtKind(upper string) (string, func(ast.Node) bool) {
+	switch {
+	case hasWordPrefix(upper, "EXECUTE") && strings.HasPrefix(strings.TrimSpace(strings.TrimPrefix(upper, "EXECUTE")), "IMMEDIATE"):
+		return "EXECUTE-IMMEDIATE", func(n ast.Node) bool { _, ok := n.(*ast.ExecuteImmediateStmt); return ok }
+	case hasWordPrefix(upper, "EXECUTE") && strings.HasPrefix(strings.TrimSpace(strings.TrimPrefix(upper, "EXECUTE")), "TASK"):
+		return "EXECUTE-TASK", func(n ast.Node) bool { _, ok := n.(*ast.ExecuteTaskStmt); return ok }
+	case hasWordPrefix(upper, "EXPLAIN"):
+		return "EXPLAIN", func(n ast.Node) bool { _, ok := n.(*ast.ExplainStmt); return ok }
+	case hasWordPrefix(upper, "CALL"):
+		return "CALL", func(n ast.Node) bool { _, ok := n.(*ast.CallStmt); return ok }
+	}
+	return "", nil
+}

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -178,11 +178,15 @@ func (p *Parser) unknownStatementError() *ParseError {
 // The dispatch switch itself is not expected to change — only the
 // bodies of individual case branches.
 //
-// Keywords NOT in this switch (SAVEPOINT, EXECUTE, WHILE, REPEAT, LET,
-// LOOP, BREAK) are currently absent from F2's keyword table because
-// they're either missing from the legacy grammar or defined via
-// non-standard ANTLR rule forms. When Tier 7 Snowflake Scripting support
-// lands, F2 gains those constants and this switch gains matching cases.
+// EXECUTE (IMMEDIATE / TASK) is absent from F2's keyword table, so it is
+// dispatched from the default branch by its uppercased identifier text
+// (alongside LS / RM) rather than from a keyword case here.
+//
+// Other keywords NOT in this switch (SAVEPOINT, WHILE, REPEAT, LET, LOOP,
+// BREAK) are currently absent from F2's keyword table because they're either
+// missing from the legacy grammar or defined via non-standard ANTLR rule forms.
+// When Tier 7 Snowflake Scripting support lands, F2 gains those constants and
+// this switch gains matching cases.
 func (p *Parser) parseStmt() (ast.Node, error) {
 	switch p.cur.Type {
 	// DDL (6 cases)
@@ -227,7 +231,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwREMOVE:
 		return p.parseRemoveStmt(false)
 	case kwCALL:
-		return p.unsupported("CALL")
+		return p.parseCallStmt()
 
 	// DCL (2 cases)
 	case kwGRANT:
@@ -253,7 +257,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwDESC:
 		return p.parseDescribeStmt(true)
 	case kwEXPLAIN:
-		return p.unsupported("EXPLAIN")
+		return p.parseExplainStmt()
 	case kwUSE:
 		return p.parseUseStmt()
 
@@ -278,15 +282,18 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		return p.unsupported("CONTINUE")
 
 	default:
-		// LS and RM are the documented aliases of LIST and REMOVE. Snowflake's
-		// lexer (and omni's) does not reserve them, so they arrive as plain
-		// identifiers and are dispatched here by their uppercased text.
+		// LS and RM are the documented aliases of LIST and REMOVE. EXECUTE
+		// (IMMEDIATE / TASK) is likewise absent from the keyword table.
+		// Snowflake's lexer (and omni's) does not reserve any of them, so they
+		// arrive as plain identifiers and are dispatched here by uppercased text.
 		if p.cur.Type == tokIdent {
 			switch strings.ToUpper(p.cur.Str) {
 			case "LS":
 				return p.parseListStmt(true)
 			case "RM":
 				return p.parseRemoveStmt(true)
+			case "EXECUTE":
+				return p.parseExecuteStmt()
 			}
 		}
 		return nil, p.unknownStatementError()

--- a/snowflake/parser/parser_test.go
+++ b/snowflake/parser/parser_test.go
@@ -159,11 +159,11 @@ func TestParse_BeginEndBlockOneSegment(t *testing.T) {
 }
 
 func TestParse_StrictVsBestEffort(t *testing.T) {
-	// SELECT now parses successfully; BEGIN is now a real TCL statement too.
-	// Use a CALL statement (still unsupported) to produce the error that
-	// distinguishes strict Parse (returns first error) from ParseBestEffort
-	// (collects all errors).
-	input := "SELECT 1; CALL p();"
+	// SELECT now parses successfully; BEGIN and CALL are real statements too.
+	// Use a DECLARE statement (still unsupported — Snowflake Scripting lands in
+	// Tier 7) to produce the error that distinguishes strict Parse (returns first
+	// error) from ParseBestEffort (collects all errors).
+	input := "SELECT 1; DECLARE x INT;"
 
 	file, err := Parse(input)
 	if err == nil {
@@ -172,8 +172,8 @@ func TestParse_StrictVsBestEffort(t *testing.T) {
 		pe, ok := err.(*ParseError)
 		if !ok {
 			t.Errorf("Parse: expected *ParseError, got %T", err)
-		} else if !strings.Contains(pe.Msg, "CALL") {
-			t.Errorf("Parse: first error Msg = %q, want to contain CALL", pe.Msg)
+		} else if !strings.Contains(pe.Msg, "DECLARE") {
+			t.Errorf("Parse: first error Msg = %q, want to contain DECLARE", pe.Msg)
 		}
 	}
 	if file == nil {

--- a/snowflake/parser/pipe_stream_task_test.go
+++ b/snowflake/parser/pipe_stream_task_test.go
@@ -600,12 +600,12 @@ func TestParseCreateTask(t *testing.T) {
 		}
 	})
 
-	t.Run("call body (parseStmt unsupported, raw fallback)", func(t *testing.T) {
-		// CALL is not yet supported by parseStmt; the body must still be captured
-		// verbatim so the task parses. Body is nil, BodyRaw holds the text.
+	t.Run("call body (parses to CallStmt)", func(t *testing.T) {
+		// CALL is now supported by parseStmt, so the task body parses structurally
+		// to a *ast.CallStmt; BodyRaw still holds the verbatim text.
 		stmt := mustCreateTask(t, "CREATE TASK t WAREHOUSE = wh SCHEDULE = '60 MINUTES' AS CALL my_sp()")
-		if stmt.Body != nil {
-			t.Errorf("Body = %T, want nil (CALL unsupported)", stmt.Body)
+		if _, ok := stmt.Body.(*ast.CallStmt); !ok {
+			t.Errorf("Body = %T, want *ast.CallStmt", stmt.Body)
 		}
 		if !strings.Contains(strings.ToUpper(stmt.BodyRaw), "CALL MY_SP()") {
 			t.Errorf("BodyRaw = %q, want it to contain CALL MY_SP()", stmt.BodyRaw)
@@ -877,10 +877,10 @@ func TestParseCreateAlert(t *testing.T) {
 		}
 	})
 
-	t.Run("call action (raw fallback)", func(t *testing.T) {
+	t.Run("call action (parses to CallStmt)", func(t *testing.T) {
 		stmt := mustCreateAlert(t, "CREATE ALERT a SCHEDULE = '1 MINUTE' IF (EXISTS (SELECT 1)) THEN CALL SYSTEM$SEND_EMAIL('i', 'a@b.c', 's', 'm')")
-		if stmt.Action != nil {
-			t.Errorf("Action = %T, want nil (CALL unsupported)", stmt.Action)
+		if _, ok := stmt.Action.(*ast.CallStmt); !ok {
+			t.Errorf("Action = %T, want *ast.CallStmt", stmt.Action)
 		}
 		if !strings.Contains(strings.ToUpper(stmt.ActionRaw), "CALL SYSTEM$SEND_EMAIL") {
 			t.Errorf("ActionRaw = %q", stmt.ActionRaw)
@@ -974,13 +974,13 @@ func TestParseAlterAlert(t *testing.T) {
 		}
 	})
 
-	t.Run("modify action call (raw fallback)", func(t *testing.T) {
+	t.Run("modify action call (parses to CallStmt)", func(t *testing.T) {
 		stmt := mustAlterAlert(t, "ALTER ALERT a MODIFY ACTION CALL my_sp()")
 		if stmt.Action != ast.AlterAlertModifyAction {
 			t.Errorf("Action = %v, want AlterAlertModifyAction", stmt.Action)
 		}
-		if stmt.ActionBody != nil {
-			t.Errorf("ActionBody = %T, want nil", stmt.ActionBody)
+		if _, ok := stmt.ActionBody.(*ast.CallStmt); !ok {
+			t.Errorf("ActionBody = %T, want *ast.CallStmt", stmt.ActionBody)
 		}
 		if !strings.Contains(strings.ToUpper(stmt.ActionRaw), "CALL MY_SP()") {
 			t.Errorf("ActionRaw = %q", stmt.ActionRaw)


### PR DESCRIPTION
## Node
`snowflake/exec-call` (v1 DAG **T5.4**) — `CALL` / `EXECUTE IMMEDIATE` / `EXECUTE TASK` / `EXPLAIN`.

## Forms
- **`CALL <proc>(args)`** → `ast.CallStmt` + `ast.CallArg`: positional + named (`name => value`) expression args, plus the docs-only bare-SELECT subquery arg.
- **`EXECUTE IMMEDIATE { '<string>' | $$body$$ | <variable> | $<session_var> } [USING (binds)]`** → `ast.ExecuteImmediateStmt`; string/`$$` body OPAQUE, raw-scanned verbatim with a defensive loop-guard.
- **`EXECUTE TASK <name> [USING CONFIG='…' | RETRY LAST]`** → `ast.ExecuteTaskStmt`.
- **`EXPLAIN [USING {TABULAR|JSON|TEXT}] <stmt>`** → `ast.ExplainStmt`; inner via `parseStmt`.

`EXECUTE` (non-keyword) dispatched from `parseStmt`'s default identifier branch; CALL/EXPLAIN dedicated cases. `walk_generated.go` regenerated (CALL arg exprs + EXPLAIN inner walkable).

## Body raw-scan loop-guard (the part that hung 4 prior attempts)
`scanExecImmBody` scans the body from `p.input`, **bounded by `len(p.input)`** and **advancing ≥1 every iteration** (`j++`, or `j += 2` for `''`/closing `$$`). Unterminated/malformed bodies exit the bounded loop and return a `ParseError` — it can never infinite-loop. A negative test feeds unterminated `$$ SELECT 1` / `'SELECT 1` and asserts a fast error return. This attempt also enforced `go test -timeout 60s` + explicit Bash timeouts so a loop aborts loudly instead of freezing the worker — nothing hung.

## Oracle / tests
Triangulation — legacy ANTLR + official docs (docs win) + corpus `testdata/official/{call,execute-immediate,explain}` (all 20 files pass). `go test ./snowflake/... -timeout 60s` green; `gofmt` clean. 100% form coverage incl. multi-line `$$`/single-quoted bodies, Loc spans, walker reachability, and ~21 negatives.

## Divergences (flagged/confirmed — ledger 144-146)
1. CALL bare-SELECT arg (docs win over legacy `expr_list`).
2. CALL `$session_var` arg deferred to `expr-dollar-refs` (shared expr parser lacks `tokVariable`); filtered via `execCallDollarLimited`. (EXECUTE IMMEDIATE `$<session_var>` is unaffected — reads the `$`-token directly.)
3. EXECUTE IMMEDIATE `FROM {@stage|'<uri>'}` omitted — absent from both docs and legacy grammar (followed the oracle).

## Out-of-scope writes (anticipated)
- `snowflake/parser/parser_test.go` — `TestParse_StrictVsBestEffort` trigger repointed `CALL p()` → `DECLARE x INT;`.
- `snowflake/parser/pipe_stream_task_test.go` — 3 subtests now assert `*ast.CallStmt` instead of nil+raw (CALL is now parsed); BEGIN/DECLARE scripting raw-fallback kept as-is.

## Review
Claude `/code-review` (inline; Codex down) — zero blockers. Orchestrator independently verified build/`-timeout` tests/scope/gofmt. Opened from verified commit `52a374e4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)