### PR TITLE
feat(mssql): add result limit rewrite helper

### DIFF
--- a/mssql/limit_rewrite.go
+++ b/mssql/limit_rewrite.go
@@ -1,0 +1,265 @@
+package mssql
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/mssql/ast"
+	"github.com/bytebase/omni/mssql/parser"
+)
+
+type limitEdit struct {
+	start int
+	end   int
+	text  string
+}
+
+// StatementWithResultLimit rewrites a single T-SQL SELECT statement so it
+// returns at most limit rows.
+func StatementWithResultLimit(statement string, limit int) (string, error) {
+	if limit <= 0 {
+		return "", fmt.Errorf("limit must be positive")
+	}
+	if strings.TrimSpace(statement) == "" {
+		return "", fmt.Errorf("empty statement")
+	}
+
+	stmts, err := Parse(statement)
+	if err != nil {
+		return "", err
+	}
+	if len(stmts) != 1 {
+		return "", fmt.Errorf("expected exactly 1 statement, got %d", len(stmts))
+	}
+
+	stmt, ok := stmts[0].AST.(*ast.SelectStmt)
+	if !ok {
+		return normalizeStatementTerminator(statement), nil
+	}
+
+	var edits []limitEdit
+	rewriteSelectWithLimit(&edits, statement, stmt, limit)
+	rewritten := applyLimitEdits(statement, edits)
+	return normalizeStatementTerminator(rewritten), nil
+}
+
+func rewriteSelectWithLimit(edits *[]limitEdit, sql string, stmt *ast.SelectStmt, limit int) {
+	if stmt == nil {
+		return
+	}
+	if stmt.Op != ast.SetOpNone {
+		if hasTopClause(stmt) {
+			rewriteExistingTopClauses(edits, stmt, limit)
+			return
+		}
+		if ordered := findOrderedSelect(stmt); ordered != nil {
+			rewriteOrderedSelect(edits, sql, ordered, limit)
+			return
+		}
+		addTopToSelectLeaves(edits, sql, stmt, limit)
+		return
+	}
+	if stmt.Top != nil {
+		rewriteTopClause(edits, stmt.Top, limit)
+		return
+	}
+	if stmt.OrderByClause != nil {
+		rewriteOrderedSelect(edits, sql, stmt, limit)
+		return
+	}
+	addTopClause(edits, sql, stmt, limit)
+}
+
+func rewriteExistingTopClauses(edits *[]limitEdit, stmt *ast.SelectStmt, limit int) {
+	if stmt == nil {
+		return
+	}
+	if stmt.Op != ast.SetOpNone {
+		rewriteExistingTopClauses(edits, stmt.Larg, limit)
+		rewriteExistingTopClauses(edits, stmt.Rarg, limit)
+		return
+	}
+	if stmt.Top != nil {
+		rewriteTopClause(edits, stmt.Top, limit)
+	}
+}
+
+func addTopToSelectLeaves(edits *[]limitEdit, sql string, stmt *ast.SelectStmt, limit int) {
+	if stmt == nil {
+		return
+	}
+	if stmt.Op != ast.SetOpNone {
+		addTopToSelectLeaves(edits, sql, stmt.Larg, limit)
+		addTopToSelectLeaves(edits, sql, stmt.Rarg, limit)
+		return
+	}
+	addTopClause(edits, sql, stmt, limit)
+}
+
+func rewriteTopClause(edits *[]limitEdit, top *ast.TopClause, limit int) {
+	if top == nil || !top.Loc.IsValid() {
+		return
+	}
+	topLimit := extractInt(top.Count)
+	if topLimit > 0 && topLimit <= limit {
+		return
+	}
+	*edits = append(*edits, limitEdit{
+		start: top.Loc.Start,
+		end:   top.Loc.End,
+		text:  fmt.Sprintf("TOP %d", limit),
+	})
+}
+
+func addTopClause(edits *[]limitEdit, sql string, stmt *ast.SelectStmt, limit int) {
+	if stmt == nil || stmt.TargetList == nil {
+		return
+	}
+	insertPos := topInsertPosition(sql, stmt)
+	if insertPos < 0 {
+		return
+	}
+	*edits = append(*edits, limitEdit{
+		start: insertPos,
+		end:   insertPos,
+		text:  fmt.Sprintf(" TOP %d", limit),
+	})
+}
+
+func topInsertPosition(sql string, stmt *ast.SelectStmt) int {
+	targetLoc := ast.NodeLoc(stmt.TargetList)
+	if !targetLoc.IsValid() {
+		return -1
+	}
+	tokens := parser.Tokenize(sql[:targetLoc.Start])
+	want := "SELECT"
+	if stmt.Distinct {
+		want = "DISTINCT"
+	} else if stmt.All {
+		want = "ALL"
+	}
+	for i := len(tokens) - 1; i >= 0; i-- {
+		if parser.TokenName(tokens[i].Type) == want {
+			return tokens[i].End
+		}
+	}
+	return -1
+}
+
+func rewriteOrderedSelect(edits *[]limitEdit, sql string, stmt *ast.SelectStmt, limit int) {
+	if stmt.FetchClause != nil {
+		fetchLimit := extractInt(stmt.FetchClause.Count)
+		if fetchLimit > 0 && fetchLimit <= limit {
+			return
+		}
+		loc := ast.NodeLoc(stmt.FetchClause.Count)
+		if loc.IsValid() {
+			*edits = append(*edits, limitEdit{start: loc.Start, end: loc.End, text: fmt.Sprintf("%d", limit)})
+		}
+		return
+	}
+	if stmt.OffsetClause != nil {
+		loc := ast.NodeLoc(stmt.OffsetClause)
+		if loc.IsValid() {
+			pos := offsetRowsEnd(sql, loc.End)
+			*edits = append(*edits, limitEdit{start: pos, end: pos, text: fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", limit)})
+		}
+		return
+	}
+	loc := ast.NodeLoc(stmt.OrderByClause)
+	if loc.IsValid() {
+		*edits = append(*edits, limitEdit{
+			start: loc.End,
+			end:   loc.End,
+			text:  fmt.Sprintf(" OFFSET 0 ROWS FETCH NEXT %d ROWS ONLY", limit),
+		})
+	}
+}
+
+func hasTopClause(stmt *ast.SelectStmt) bool {
+	if stmt == nil {
+		return false
+	}
+	if stmt.Op != ast.SetOpNone {
+		return hasTopClause(stmt.Larg) || hasTopClause(stmt.Rarg)
+	}
+	return stmt.Top != nil
+}
+
+func findOrderedSelect(stmt *ast.SelectStmt) *ast.SelectStmt {
+	if stmt == nil {
+		return nil
+	}
+	if stmt.OrderByClause != nil {
+		return stmt
+	}
+	if ordered := findOrderedSelect(stmt.Larg); ordered != nil {
+		return ordered
+	}
+	return findOrderedSelect(stmt.Rarg)
+}
+
+func extractInt(node ast.ExprNode) int {
+	lit, ok := node.(*ast.Literal)
+	if !ok || lit.Type != ast.LitInteger {
+		return 0
+	}
+	return int(lit.Ival)
+}
+
+func offsetRowsEnd(sql string, pos int) int {
+	pos = skipSpaces(sql, pos)
+	for _, keyword := range []string{"ROWS", "ROW"} {
+		if end, ok := consumeKeyword(sql, pos, keyword); ok {
+			return end
+		}
+	}
+	return pos
+}
+
+func skipSpaces(sql string, pos int) int {
+	for pos < len(sql) {
+		r, size := utf8.DecodeRuneInString(sql[pos:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		pos += size
+	}
+	return pos
+}
+
+func consumeKeyword(sql string, pos int, keyword string) (int, bool) {
+	if len(sql[pos:]) < len(keyword) || !strings.EqualFold(sql[pos:pos+len(keyword)], keyword) {
+		return pos, false
+	}
+	end := pos + len(keyword)
+	if end < len(sql) {
+		r := rune(sql[end])
+		if r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return pos, false
+		}
+	}
+	return end, true
+}
+
+func applyLimitEdits(sql string, edits []limitEdit) string {
+	sort.Slice(edits, func(i, j int) bool {
+		return edits[i].start > edits[j].start
+	})
+	for _, edit := range edits {
+		if edit.start < 0 || edit.end < edit.start || edit.end > len(sql) {
+			continue
+		}
+		sql = sql[:edit.start] + edit.text + sql[edit.end:]
+	}
+	return sql
+}
+
+func normalizeStatementTerminator(sql string) string {
+	return strings.TrimRightFunc(sql, func(r rune) bool {
+		return unicode.IsSpace(r) || r == ';'
+	}) + ";"
+}

--- a/mssql/limit_rewrite_test.go
+++ b/mssql/limit_rewrite_test.go
@@ -1,0 +1,180 @@
+package mssql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/omni/mssql"
+)
+
+func TestStatementWithResultLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		limit     int
+		want      string
+	}{
+		{
+			name:      "adds top after select",
+			statement: "SELECT id FROM t1;",
+			limit:     10,
+			want:      "SELECT TOP 10 id FROM t1;",
+		},
+		{
+			name:      "adds top after distinct",
+			statement: "SELECT DISTINCT S.*, DS.DistrictId FROM Streets S LEFT JOIN DistrictStreets DS ON S.StreetId = DS.StreetId;",
+			limit:     10,
+			want:      "SELECT DISTINCT TOP 10 S.*, DS.DistrictId FROM Streets S LEFT JOIN DistrictStreets DS ON S.StreetId = DS.StreetId;",
+		},
+		{
+			name:      "keeps smaller top",
+			statement: "SELECT TOP 3 id FROM t1;",
+			limit:     10,
+			want:      "SELECT TOP 3 id FROM t1;",
+		},
+		{
+			name:      "lowers larger top",
+			statement: "SELECT TOP 123 id FROM t1;",
+			limit:     10,
+			want:      "SELECT TOP 10 id FROM t1;",
+		},
+		{
+			name:      "adds offset fetch after order by",
+			statement: "SELECT id FROM t1 ORDER BY price;",
+			limit:     10,
+			want:      "SELECT id FROM t1 ORDER BY price OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;",
+		},
+		{
+			name:      "adds fetch after existing offset",
+			statement: "SELECT id FROM t1 ORDER BY price OFFSET 123 ROWS;",
+			limit:     10,
+			want:      "SELECT id FROM t1 ORDER BY price OFFSET 123 ROWS FETCH NEXT 10 ROWS ONLY;",
+		},
+		{
+			name:      "lowers existing fetch",
+			statement: "SELECT name, price FROM toy ORDER BY price OFFSET 0 ROWS FETCH FIRST 123 ROWS ONLY;",
+			limit:     10,
+			want:      "SELECT name, price FROM toy ORDER BY price OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY;",
+		},
+		{
+			name: "adds top to both union branches",
+			statement: `SELECT
+    first_name,
+    last_name
+FROM
+    sales.staffs
+UNION ALL
+SELECT
+    first_name,
+    last_name
+FROM
+    sales.customers;`,
+			limit: 10,
+			want: `SELECT TOP 10
+    first_name,
+    last_name
+FROM
+    sales.staffs
+UNION ALL
+SELECT TOP 10
+    first_name,
+    last_name
+FROM
+    sales.customers;`,
+		},
+		{
+			name: "adds fetch after union order by",
+			statement: `SELECT
+    first_name,
+    last_name
+FROM
+    sales.staffs
+UNION ALL
+SELECT
+    first_name,
+    last_name
+FROM
+    sales.customers
+ORDER BY
+    first_name,
+    last_name;`,
+			limit: 10,
+			want: `SELECT
+    first_name,
+    last_name
+FROM
+    sales.staffs
+UNION ALL
+SELECT
+    first_name,
+    last_name
+FROM
+    sales.customers
+ORDER BY
+    first_name,
+    last_name OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;`,
+		},
+		{
+			name: "adds top to cte outer select",
+			statement: `WITH cte_org AS (
+SELECT
+    staff_id,
+    first_name,
+    manager_id
+FROM
+    sales.staffs
+)
+SELECT * FROM cte_org;`,
+			limit: 10,
+			want: `WITH cte_org AS (
+SELECT
+    staff_id,
+    first_name,
+    manager_id
+FROM
+    sales.staffs
+)
+SELECT TOP 10 * FROM cte_org;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mssql.StatementWithResultLimit(tt.statement, tt.limit)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStatementWithResultLimitErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		limit     int
+	}{
+		{
+			name:      "empty statement",
+			statement: "",
+			limit:     10,
+		},
+		{
+			name:      "multi statement",
+			statement: "SELECT 1; SELECT 2;",
+			limit:     10,
+		},
+		{
+			name:      "invalid limit",
+			statement: "SELECT 1",
+			limit:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := mssql.StatementWithResultLimit(tt.statement, tt.limit)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `mssql.StatementWithResultLimit` to rewrite a single T-SQL SELECT with an upper result limit.
- Preserve smaller existing `TOP`/`FETCH` limits and lower larger or non-literal limits.
- Cover SELECT, DISTINCT, ORDER BY/OFFSET-FETCH, UNION, and CTE cases.

## Test Plan
- `go test -count=1 ./mssql`
- `go test -count=1 ./mssql ./mssql/ast ./mssql/completion`

## Notes
- `go test ./...` was attempted. It is blocked locally by container-test environment issues: default Docker socket is unavailable unless `DOCKER_HOST` is set, and with Colima/Ryuk disabled the SQL Server testcontainer exits during startup.