### PR TITLE
fix(mssql): bound TOP PERCENT result limit

### DIFF
--- a/mssql/limit_rewrite.go
+++ b/mssql/limit_rewrite.go
@@ -104,7 +104,7 @@ func rewriteTopClause(edits *[]limitEdit, top *ast.TopClause, limit int) {
 		return
 	}
 	topLimit := extractInt(top.Count)
-	if topLimit > 0 && topLimit <= limit {
+	if !top.Percent && !top.WithTies && topLimit > 0 && topLimit <= limit {
 		return
 	}
 	*edits = append(*edits, limitEdit{

--- a/mssql/limit_rewrite_test.go
+++ b/mssql/limit_rewrite_test.go
@@ -40,6 +40,18 @@ func TestStatementWithResultLimit(t *testing.T) {
 			want:      "SELECT TOP 10 id FROM t1;",
 		},
 		{
+			name:      "lowers top percent even when numeric value is smaller",
+			statement: "SELECT TOP (3) PERCENT id FROM t1;",
+			limit:     10,
+			want:      "SELECT TOP 10 id FROM t1;",
+		},
+		{
+			name:      "lowers top with ties even when numeric value is smaller",
+			statement: "SELECT TOP (3) WITH TIES id FROM t1 ORDER BY id;",
+			limit:     10,
+			want:      "SELECT TOP 10 id FROM t1 ORDER BY id;",
+		},
+		{
 			name:      "adds offset fetch after order by",
 			statement: "SELECT id FROM t1 ORDER BY price;",
 			limit:     10,


### PR DESCRIPTION
## Summary
- Treat `TOP ... PERCENT` and `TOP ... WITH TIES` as unbounded relative to the requested row cap.
- Rewrite those clauses to a plain `TOP <limit>` even when the numeric expression is smaller than the requested limit.
- Add regression coverage for both cases.

## Test Plan
- `go test -count=1 ./mssql`
- `go test -count=1 ./mssql ./mssql/ast ./mssql/completion`