### PR TITLE
feat(googlesql): PIVOT/UNPIVOT/TABLESAMPLE + differential-privacy clause (parser-query-clauses)

### DIFF
--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -250,6 +250,19 @@ const (
 	T_ElementTableDef
 	T_LabelAndProperties
 	T_DerivedProperty
+
+	// Query clauses — PIVOT / UNPIVOT / TABLESAMPLE table-source operators
+	// (parser-query-clauses node). These are table-source suffixes attached to a
+	// FROM source (TableExpr.Pivot/Unpivot/Sample), mirroring the legacy ANTLR
+	// pivot_clause / unpivot_clause / sample_clause (GoogleSQLParser.g4 §2.14),
+	// a hand-port of ZetaSQL. AT SYSTEM TIME (FOR SYSTEM_TIME AS OF) and the
+	// SELECT-level differential-privacy clause carry no dedicated node — they are
+	// recorded on TableExpr.SystemTime and SelectStmt.SelectWith respectively.
+	T_PivotClause
+	T_PivotExpr
+	T_UnpivotClause
+	T_UnpivotInItem
+	T_SampleClause
 )
 
 // String returns a human-readable representation of the tag.
@@ -569,6 +582,16 @@ func (t NodeTag) String() string {
 		return "LabelAndProperties"
 	case T_DerivedProperty:
 		return "DerivedProperty"
+	case T_PivotClause:
+		return "PivotClause"
+	case T_PivotExpr:
+		return "PivotExpr"
+	case T_UnpivotClause:
+		return "UnpivotClause"
+	case T_UnpivotInItem:
+		return "UnpivotInItem"
+	case T_SampleClause:
+		return "SampleClause"
 	default:
 		return "Unknown"
 	}

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -1367,14 +1367,25 @@ func (n *SetOperation) Tag() NodeTag { return T_SetOperation }
 // records a trailing `WITH OFFSET [[AS] name]` (the offset companion column);
 // WithOffsetAlias is its optional alias. SystemTime captures a trailing
 // `FOR SYSTEM[_TIME] AS OF expr` time-travel expression (nil if absent).
+//
+// Pivot / Unpivot / Sample carry the optional table-source operators
+// (parser-query-clauses): a PIVOT(...), an UNPIVOT(...), or a TABLESAMPLE. The
+// grammar attaches at most one pivot/unpivot per source and a sample is a
+// distinct suffix, so at most one of {Pivot, Unpivot, Sample} is set (a PIVOT
+// and a TABLESAMPLE never combine on one source — oracle-verified). The
+// pivot/unpivot operator's own trailing alias is carried on the operator node;
+// Alias is the alias preceding the operator (the table's own `[AS] name`).
 type TableExpr struct {
-	Path            *PathExpr // table / array-field path; nil for subquery / TVF
-	Subquery        Node      // ( query ) subquery; nil otherwise (*QueryStmt)
-	Func            *FuncCall // table-valued function call; nil otherwise
-	Alias           string    // [AS] alias; "" if absent
-	WithOffset      bool      // trailing WITH OFFSET
-	WithOffsetAlias string    // alias for WITH OFFSET; "" if absent or unaliased
-	SystemTime      Node      // FOR SYSTEM_TIME AS OF expr; nil if absent
+	Path            *PathExpr      // table / array-field path; nil for subquery / TVF
+	Subquery        Node           // ( query ) subquery; nil otherwise (*QueryStmt)
+	Func            *FuncCall      // table-valued function call; nil otherwise
+	Alias           string         // [AS] alias; "" if absent
+	WithOffset      bool           // trailing WITH OFFSET
+	WithOffsetAlias string         // alias for WITH OFFSET; "" if absent or unaliased
+	SystemTime      Node           // FOR SYSTEM_TIME AS OF expr; nil if absent
+	Pivot           *PivotClause   // PIVOT(...); nil if absent
+	Unpivot         *UnpivotClause // UNPIVOT(...); nil if absent
+	Sample          *SampleClause  // TABLESAMPLE …; nil if absent
 	Loc             Loc
 }
 
@@ -1385,11 +1396,22 @@ func (n *TableExpr) Tag() NodeTag { return T_TableExpr }
 // FROM source (unnest_expression as a table_path_expression_base). Array is the
 // UNNEST(...) call (a *FuncCall named UNNEST, as the expressions node builds it).
 // Alias / WithOffset / WithOffsetAlias mirror TableExpr.
+//
+// Pivot / Unpivot / Sample mirror TableExpr: the legacy grammar threads an
+// unnest_expression through table_path_expression, which carries
+// opt_pivot_or_unpivot_clause_and_alias, and through `table_primary
+// sample_clause`. These operators are always SEMANTICALLY invalid on an array
+// scan (the emulator rejects "PIVOT/TABLESAMPLE is not allowed with array
+// scans"), but the union grammar PARSES them, so they are retained for parse
+// parity. At most one of {Pivot, Unpivot, Sample} is set.
 type UnnestExpr struct {
-	Array           Node   // the UNNEST(...) call (*FuncCall); the array argument(s)
-	Alias           string // [AS] alias; "" if absent
-	WithOffset      bool   // trailing WITH OFFSET
-	WithOffsetAlias string // alias for WITH OFFSET; "" if absent or unaliased
+	Array           Node           // the UNNEST(...) call (*FuncCall); the array argument(s)
+	Alias           string         // [AS] alias; "" if absent
+	WithOffset      bool           // trailing WITH OFFSET
+	WithOffsetAlias string         // alias for WITH OFFSET; "" if absent or unaliased
+	Pivot           *PivotClause   // PIVOT(...); nil if absent
+	Unpivot         *UnpivotClause // UNPIVOT(...); nil if absent
+	Sample          *SampleClause  // TABLESAMPLE …; nil if absent
 	Loc             Loc
 }
 
@@ -1447,6 +1469,154 @@ type JoinExpr struct {
 
 // Tag implements Node.
 func (n *JoinExpr) Tag() NodeTag { return T_JoinExpr }
+
+// ---------------------------------------------------------------------------
+// PIVOT / UNPIVOT / TABLESAMPLE table-source operators (parser-query-clauses)
+// ---------------------------------------------------------------------------
+
+// PivotClause is a PIVOT operator applied to a FROM source (pivot_clause):
+//
+//	PIVOT ( <agg> [[AS] alias][, …] FOR <for_expr> IN ( <value> [[AS] alias][, …] ) )
+//	  [ [AS] alias ]
+//
+// Aggregates is the comma-separated list of aggregate expressions (each an
+// expression with an optional alias). For is the pivot input column/expression
+// (parsed at higher-than-AND precedence so the trailing `IN (...)` is the pivot
+// value list, NOT an `x IN (...)` predicate). Values is the IN (...) value list
+// (each a value expression with an optional alias). Alias is the trailing
+// `[AS] name` for the pivot result ("" if absent).
+type PivotClause struct {
+	Aggregates []*PivotExpr // aggregate expressions (>= 1)
+	For        Node         // the FOR input column/expression
+	Values     []*PivotExpr // IN (...) value list (>= 1)
+	Alias      string       // trailing [AS] alias; "" if absent
+	Loc        Loc
+}
+
+// Tag implements Node.
+func (n *PivotClause) Tag() NodeTag { return T_PivotClause }
+
+// PivotExpr is one `expression [[AS] alias]` entry of a PIVOT aggregate list or
+// IN value list (pivot_expression / pivot_value). Expr is the expression; Alias
+// is the optional `[AS] name` ("" if absent).
+type PivotExpr struct {
+	Expr  Node
+	Alias string
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *PivotExpr) Tag() NodeTag { return T_PivotExpr }
+
+// UnpivotNullsMode encodes the optional {INCLUDE|EXCLUDE} NULLS modifier on an
+// UNPIVOT (unpivot_nulls_filter).
+type UnpivotNullsMode int
+
+const (
+	// UnpivotNullsUnspecified is no modifier (the grammar default).
+	UnpivotNullsUnspecified UnpivotNullsMode = iota
+	// UnpivotIncludeNulls is INCLUDE NULLS.
+	UnpivotIncludeNulls
+	// UnpivotExcludeNulls is EXCLUDE NULLS.
+	UnpivotExcludeNulls
+)
+
+// String returns the modifier keyword phrase ("" for unspecified).
+func (m UnpivotNullsMode) String() string {
+	switch m {
+	case UnpivotIncludeNulls:
+		return "INCLUDE NULLS"
+	case UnpivotExcludeNulls:
+		return "EXCLUDE NULLS"
+	default:
+		return ""
+	}
+}
+
+// UnpivotClause is an UNPIVOT operator applied to a FROM source (unpivot_clause):
+//
+//	UNPIVOT [ {INCLUDE|EXCLUDE} NULLS ]
+//	  ( <value_col(s)> FOR <name_col> IN ( <in_item>[, …] ) ) [ [AS] alias ]
+//
+// NullsMode is the optional INCLUDE/EXCLUDE NULLS. ValueColumns is the value
+// column list: a single column for single-column UNPIVOT, or several for the
+// parenthesized multi-column form (`(c1, c2)`). NameColumn is the FOR name
+// column. Items is the IN (...) list (each an UnpivotInItem). Alias is the
+// trailing `[AS] name` ("" if absent).
+type UnpivotClause struct {
+	NullsMode    UnpivotNullsMode // INCLUDE / EXCLUDE NULLS; default unspecified
+	ValueColumns []*PathExpr      // value column(s): 1 (single) or >1 (multi-column)
+	NameColumn   *PathExpr        // FOR <name_col>
+	Items        []*UnpivotInItem // IN (...) source items (>= 1)
+	Alias        string           // trailing [AS] alias; "" if absent
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *UnpivotClause) Tag() NodeTag { return T_UnpivotClause }
+
+// UnpivotInItem is one entry of an UNPIVOT … IN ( … ) list (unpivot_in_item):
+// a column or parenthesized column group, with an optional `[AS] string|int`
+// row-value alias. Columns holds the column path(s) (one for the single-column
+// form, several for a parenthesized group). AliasString / AliasInt carry the
+// optional `AS 'name'` / `AS 1` literal alias (HasAlias flags its presence;
+// AliasIsInt selects which literal field is meaningful).
+type UnpivotInItem struct {
+	Columns     []*PathExpr // column path(s): 1 (single) or >1 (parenthesized group)
+	HasAlias    bool        // an `[AS] string|int` alias is present
+	AliasIsInt  bool        // true if the alias is an integer literal (else a string)
+	AliasString string      // the string-literal alias (when HasAlias && !AliasIsInt)
+	AliasInt    string      // the integer-literal alias spelling (when HasAlias && AliasIsInt)
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *UnpivotInItem) Tag() NodeTag { return T_UnpivotInItem }
+
+// SampleSizeUnit selects the TABLESAMPLE size unit (sample_size_unit).
+type SampleSizeUnit int
+
+const (
+	// SampleUnitPercent is PERCENT.
+	SampleUnitPercent SampleSizeUnit = iota
+	// SampleUnitRows is ROWS.
+	SampleUnitRows
+)
+
+// String returns the unit keyword.
+func (u SampleSizeUnit) String() string {
+	if u == SampleUnitRows {
+		return "ROWS"
+	}
+	return "PERCENT"
+}
+
+// SampleClause is a TABLESAMPLE operator applied to a FROM source (sample_clause):
+//
+//	TABLESAMPLE <method> ( <size> { PERCENT | ROWS } [ PARTITION BY <expr>[, …] ] )
+//	  [ REPEATABLE ( <seed> ) | WITH WEIGHT [[AS] alias] [ REPEATABLE ( <seed> ) ] ]
+//
+// Method is the sampling method identifier (SYSTEM / BERNOULLI / RESERVOIR — the
+// grammar reads it as a bare identifier, so any method name is accepted). Size
+// is the sample-size expression; Unit is PERCENT or ROWS. PartitionBy carries an
+// optional `PARTITION BY` list inside the size clause (nil if absent).
+//
+// The suffix is one of: nothing; a REPEATABLE(seed) (Repeatable set, WithWeight
+// false); or WITH WEIGHT [[AS] alias] [REPEATABLE(seed)] (WithWeight true,
+// WeightAlias the optional alias, Repeatable the optional trailing seed).
+type SampleClause struct {
+	Method      string // sampling method identifier (SYSTEM / BERNOULLI / RESERVOIR / …)
+	Size        Node   // sample-size expression
+	Unit        SampleSizeUnit
+	PartitionBy []Node // PARTITION BY exprs inside the size clause; nil if absent
+	WithWeight  bool   // a WITH WEIGHT suffix is present
+	WeightAlias string // WITH WEIGHT [AS] alias; "" if absent / unaliased
+	Repeatable  Node   // REPEATABLE ( seed ) seed expression; nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *SampleClause) Tag() NodeTag { return T_SampleClause }
 
 // ---------------------------------------------------------------------------
 // GROUP BY / WINDOW

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -707,6 +707,16 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Collate)
 	case *ParenExpr:
 		Walk(v, n.Expr)
+	case *PivotClause:
+		for _, c := range n.Aggregates {
+			Walk(v, c)
+		}
+		Walk(v, n.For)
+		for _, c := range n.Values {
+			Walk(v, c)
+		}
+	case *PivotExpr:
+		Walk(v, n.Expr)
 	case *QueryStmt:
 		if n.With != nil {
 			Walk(v, n.With)
@@ -744,6 +754,10 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Grantees {
 			Walk(v, c)
 		}
+	case *SampleClause:
+		Walk(v, n.Size)
+		walkNodes(v, n.PartitionBy)
+		Walk(v, n.Repeatable)
 	case *SearchVectorIndexStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -831,6 +845,15 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Func)
 		}
 		Walk(v, n.SystemTime)
+		if n.Pivot != nil {
+			Walk(v, n.Pivot)
+		}
+		if n.Unpivot != nil {
+			Walk(v, n.Unpivot)
+		}
+		if n.Sample != nil {
+			Walk(v, n.Sample)
+		}
 	case *TransactionStmt:
 		for _, c := range n.Modes {
 			Walk(v, c)
@@ -844,6 +867,29 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Expr)
 	case *UnnestExpr:
 		Walk(v, n.Array)
+		if n.Pivot != nil {
+			Walk(v, n.Pivot)
+		}
+		if n.Unpivot != nil {
+			Walk(v, n.Unpivot)
+		}
+		if n.Sample != nil {
+			Walk(v, n.Sample)
+		}
+	case *UnpivotClause:
+		for _, c := range n.ValueColumns {
+			Walk(v, c)
+		}
+		if n.NameColumn != nil {
+			Walk(v, n.NameColumn)
+		}
+		for _, c := range n.Items {
+			Walk(v, c)
+		}
+	case *UnpivotInItem:
+		for _, c := range n.Columns {
+			Walk(v, c)
+		}
 	case *UpdateItem:
 		Walk(v, n.Value)
 		Walk(v, n.Nested)

--- a/googlesql/parser/differential_privacy.go
+++ b/googlesql/parser/differential_privacy.go
@@ -1,0 +1,73 @@
+package parser
+
+// This file is part of the `parser-query-clauses` DAG node. It implements
+// GoogleSQL's SELECT-level differential-privacy / aggregation-threshold clause
+// (GoogleSQLParser.g4 §2.13 opt_select_with), a hand-port of Google's
+// open-source ZetaSQL reference.
+//
+// The clause is the `WITH <name> [OPTIONS(...)]` that may follow SELECT before
+// the set quantifier, e.g.
+//
+//	SELECT WITH DIFFERENTIAL_PRIVACY OPTIONS(epsilon=1, ...) col FROM t
+//	SELECT WITH ANONYMIZATION OPTIONS(...) col FROM t
+//	SELECT WITH AGGREGATION_THRESHOLD OPTIONS(...) col FROM t
+//
+// The grammar reads the privacy mechanism as a bare `identifier`
+// (DIFFERENTIAL_PRIVACY / ANONYMIZATION / AGGREGATION_THRESHOLD are accepted as
+// names, not dedicated keywords), so any name is accepted. The clause name is
+// the load-bearing fact for the downstream consumers (query-span / diagnose);
+// the OPTIONS body is validated semantically, not syntactically, so it is parsed
+// and skipped (its key/value vocabulary is open in the grammar). The presence +
+// name is recorded on SelectStmt.SelectWith.
+//
+// DIALECT NOTE. This is a BigQuery-only form. The Spanner emulator does not
+// support `SELECT WITH ...` and reports "Unexpected keyword WITH" WITHOUT the
+// canonical `Syntax error:` prefix, so the differential harness misclassifies it
+// as a (semantic) ACCEPT — i.e. the oracle is NON-authoritative here (oracle.md
+// dialect caveat). It is therefore proven by the hand-written unit tests +
+// triangulation against truth1/bigquery + the legacy .g4, NOT by the differential
+// (mirroring the parser-select node's exclusion of differential-privacy fixtures
+// from its oracle test).
+
+// atSelectWith reports whether the current position begins an opt_select_with
+// clause: `WITH <identifier>` (NOT `WITH (`, which would be an inline WITH-expr
+// column). SELECT's hint has already been consumed by the caller.
+func (p *Parser) atSelectWith() bool {
+	return p.cur.Type == kwWITH && p.peekNext().Type != int('(')
+}
+
+// parseSelectWith parses the opt_select_with clause and returns its mechanism
+// name (the identifier after WITH). The current token is WITH. The optional
+// trailing `OPTIONS(...)` is parsed and skipped (its body is semantic, not
+// grammatical). The caller (parseSelectStmt) must have already checked
+// atSelectWith.
+//
+// The mechanism name is the legacy grammar's `identifier`. The two name-shaped
+// mechanisms ANONYMIZATION / AGGREGATION_THRESHOLD lex as plain identifiers, but
+// DIFFERENTIAL_PRIVACY is lexed by the omni lexer as a RESERVED keyword
+// (kwDIFFERENTIAL_PRIVACY) — an over-reservation versus the legacy grammar,
+// which has no such token and treats the word as an ordinary identifier (the
+// emulator likewise accepts `differential_privacy` as a bare identifier). So
+// this name slot explicitly admits that one over-reserved keyword in addition to
+// the normal identifier set, to keep the documented
+// `SELECT WITH DIFFERENTIAL_PRIVACY OPTIONS(...)` form parseable. (The broader
+// lexer over-reservation — `differential_privacy` cannot be used as a column /
+// alias name — is a separate lexer-node concern outside this node's files.)
+func (p *Parser) parseSelectWith() (string, error) {
+	p.advance() // WITH
+	if !isIdentifierStart(p.cur.Type) && p.cur.Type != kwDIFFERENTIAL_PRIVACY {
+		return "", p.syntaxErrorAtCur()
+	}
+	nameTok := p.advance()
+	name, err := p.identifierText(nameTok)
+	if err != nil {
+		return "", err
+	}
+	if p.cur.Type == kwOPTIONS {
+		p.advance() // OPTIONS
+		if err := p.skipOptionsList(); err != nil {
+			return "", err
+		}
+	}
+	return name, nil
+}

--- a/googlesql/parser/from_join.go
+++ b/googlesql/parser/from_join.go
@@ -258,18 +258,62 @@ func (p *Parser) parseUsingClause() ([]string, error) {
 //	UNNEST ( … ) [alias] …   — unnest table source
 //	<path> [( args )] …      — table path, or a table-valued function call
 //
-// followed by an optional `[AS] alias` and (for path sources) `WITH OFFSET` /
-// `FOR SYSTEM_TIME AS OF`. PIVOT/UNPIVOT/TABLESAMPLE/MATCH_RECOGNIZE suffixes are
-// left for the parser-query-clauses node and are not consumed here.
+// followed by an optional `[AS] alias`, (for path/subquery/TVF sources) a
+// PIVOT/UNPIVOT operator, (for path sources) `WITH OFFSET` / `FOR SYSTEM_TIME AS
+// OF`, and finally an optional TABLESAMPLE that wraps the whole source.
+// PIVOT/UNPIVOT/TABLESAMPLE are parsed by the parser-query-clauses node
+// (pivot_unpivot.go / tablesample.go); MATCH_RECOGNIZE is not yet implemented.
 func (p *Parser) parseTablePrimary() (ast.Node, error) {
+	var (
+		src ast.Node
+		err error
+	)
 	switch p.cur.Type {
 	case int('('):
-		return p.parseParenTableSource()
+		src, err = p.parseParenTableSource()
 	case kwUNNEST:
-		return p.parseUnnestTableSource()
+		src, err = p.parseUnnestTableSource()
 	default:
-		return p.parsePathTableSource()
+		src, err = p.parsePathTableSource()
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	// TABLESAMPLE wraps a complete table_primary (grammar:
+	// `table_primary sample_clause`), binding after the source's own alias /
+	// PIVOT / WITH OFFSET / FOR SYSTEM_TIME. It attaches to the TableExpr / UNNEST
+	// source shapes (a parenthesized join carries no sample field — sampling a
+	// raw join is not a documented form). The grammar allows it to chain
+	// (`table_primary sample_clause` is itself a table_primary), so loop.
+	for p.atTableSample() {
+		sc, serr := p.parseTableSample()
+		if serr != nil {
+			return nil, serr
+		}
+		if !attachSample(src, sc) {
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	return src, nil
+}
+
+// attachSample stores a parsed TABLESAMPLE clause on a table source, updating
+// its end Loc. It supports the TableExpr / UnnestExpr source shapes; for any
+// other node (e.g. a parenthesized join) it returns false so the caller can
+// surface a syntax error.
+func attachSample(src ast.Node, sc *ast.SampleClause) bool {
+	switch s := src.(type) {
+	case *ast.TableExpr:
+		s.Sample = sc
+		s.Loc.End = sc.Loc.End
+	case *ast.UnnestExpr:
+		s.Sample = sc
+		s.Loc.End = sc.Loc.End
+	default:
+		return false
+	}
+	return true
 }
 
 // parseParenTableSource parses a parenthesized table source: either a
@@ -336,14 +380,20 @@ func (p *Parser) parseUnnestTableSource() (ast.Node, error) {
 	}
 	ue := &ast.UnnestExpr{Array: arr, Loc: ast.Loc{Start: start, End: nodeLoc(arr).End}}
 
-	// Optional `[AS] alias` then `WITH OFFSET [[AS] name]` (UNNEST supports the
-	// offset companion column). UnnestExpr has its own fields, so it is done
-	// inline rather than via the path-source suffix parser.
+	// Optional `[AS] alias`, then a PIVOT/UNPIVOT operator (parser-query-clauses),
+	// then `WITH OFFSET [[AS] name]` (UNNEST supports the offset companion
+	// column). UnnestExpr has its own fields, so it is done inline rather than via
+	// the path-source suffix parser. PIVOT/UNPIVOT/TABLESAMPLE on an array scan
+	// are always SEMANTIC errors but PARSE in the union grammar (retained for
+	// parity); TABLESAMPLE wraps the source in parseTablePrimary.
 	if alias, ok, err := p.tryParseTableAlias(); err != nil {
 		return nil, err
 	} else if ok {
 		ue.Alias = alias
 		ue.Loc.End = p.prev.Loc.End
+	}
+	if err := p.parsePivotOrUnpivot(ue); err != nil {
+		return nil, err
 	}
 	if p.cur.Type == kwWITH && p.peekNext().Type == kwOFFSET {
 		p.advance()           // WITH
@@ -470,11 +520,14 @@ func (p *Parser) tokenSource(tok Token) string {
 	return TokenName(tok.Type)
 }
 
-// parseTableAliasOnly parses ONLY the optional `[AS] alias` suffix of a table
-// source, filling te.Alias. It is used for subquery and TVF sources, which
-// (unlike path / UNNEST sources) take NO WITH OFFSET or FOR SYSTEM_TIME suffix
-// (oracle: those reject on subqueries/TVFs). A per-source `@{...}` hint may
-// precede the alias.
+// parseTableAliasOnly parses the optional `[AS] alias` suffix of a table source
+// plus an optional PIVOT/UNPIVOT operator (parser-query-clauses), filling
+// te.Alias / te.Pivot / te.Unpivot. It is used for subquery and TVF sources,
+// which (unlike path / UNNEST sources) take NO WITH OFFSET or FOR SYSTEM_TIME
+// suffix (oracle: those reject on subqueries/TVFs) but DO accept PIVOT/UNPIVOT
+// (grammar: table_subquery / tvf_with_suffixes carry opt_pivot_or_unpivot_
+// clause_and_alias; oracle: `(SELECT …) PIVOT(…)` parses). A per-source `@{...}`
+// hint may precede the alias.
 func (p *Parser) parseTableAliasOnly(te *ast.TableExpr) error {
 	if p.cur.Type == int('@') {
 		if herr := p.skipHint(); herr != nil {
@@ -489,15 +542,20 @@ func (p *Parser) parseTableAliasOnly(te *ast.TableExpr) error {
 		te.Alias = alias
 		te.Loc.End = p.prev.Loc.End
 	}
-	return nil
+	// PIVOT / UNPIVOT operator (after the optional alias).
+	return p.parsePivotOrUnpivot(te)
 }
 
 // parseTableSuffixes parses the optional trailing suffixes of a PATH table
-// source: `[AS] alias`, `WITH OFFSET [[AS] name]`, and `FOR SYSTEM_TIME AS OF
-// expr`. It fills the corresponding TableExpr fields. (PIVOT/UNPIVOT/TABLESAMPLE/
-// MATCH_RECOGNIZE are NOT handled — they belong to parser-query-clauses. Subquery
-// and TVF sources use parseTableAliasOnly instead, since the offset / time-travel
-// suffixes are path-source-only.)
+// source: `[AS] alias`, a PIVOT/UNPIVOT operator, `WITH OFFSET [[AS] name]`, and
+// `FOR SYSTEM_TIME AS OF expr`. It fills the corresponding TableExpr fields.
+// (PIVOT/UNPIVOT are owned by parser-query-clauses via parsePivotOrUnpivot;
+// TABLESAMPLE wraps the whole source in parseTablePrimary. Subquery and TVF
+// sources use parseTableAliasOnly instead, since the offset / time-travel
+// suffixes are path-source-only.) The grammar's ordering is
+// `opt_pivot_or_unpivot_clause_and_alias? opt_with_offset_and_alias?
+// opt_at_system_time?`, i.e. alias+pivot bind before WITH OFFSET / FOR SYSTEM_
+// TIME.
 func (p *Parser) parseTableSuffixes(te *ast.TableExpr) error {
 	// Per-source hint @{...} (table_hint_expr) may precede the alias.
 	if p.cur.Type == int('@') {
@@ -520,6 +578,11 @@ func (p *Parser) parseTableSuffixes(te *ast.TableExpr) error {
 	} else if ok {
 		te.Alias = alias
 		te.Loc.End = p.prev.Loc.End
+	}
+
+	// PIVOT / UNPIVOT operator (after the optional alias, before WITH OFFSET).
+	if err := p.parsePivotOrUnpivot(te); err != nil {
+		return err
 	}
 
 	if p.cur.Type == kwWITH && p.peekNext().Type == kwOFFSET {
@@ -624,16 +687,34 @@ func (p *Parser) tryParseTableAlias() (string, bool, error) {
 
 // atTableAliasStop reports whether the current (identifier-start) token must NOT
 // be consumed as an implicit table alias because it begins a following
-// clause/join/table-operator. These are the non-reserved keywords that, in
-// table-source position, introduce a suffix rather than serve as an alias:
-// WITH (OFFSET), and the table-operator keywords PIVOT/UNPIVOT/TABLESAMPLE/
-// MATCH_RECOGNIZE (owned by parser-query-clauses, but must not be eaten as an
-// alias here). Reserved clause keywords (FROM/WHERE/JOIN/…) are already excluded
-// by isIdentifierStart.
+// clause/table-operator suffix rather than serving as an alias.
+//
+//   - WITH always stops: it begins `WITH OFFSET` (the only WITH that follows a
+//     table source); a table is never implicitly aliased `WITH`.
+//   - PIVOT / UNPIVOT are NON-reserved, so a bare `FROM t pivot` / `FROM t
+//     unpivot` is a valid implicit alias (oracle-confirmed accept). They stop
+//     alias parsing ONLY when they actually START the operator: `PIVOT (`,
+//     `UNPIVOT (`, or `UNPIVOT {INCLUDE|EXCLUDE}`. Anything else (a bare keyword
+//     at end of source, before a comma/JOIN/clause) is the implicit alias.
+//
+// TABLESAMPLE / MATCH_RECOGNIZE are RESERVED keywords (keywordReserved), so they
+// are never identifier-start and never reach this predicate as alias candidates;
+// they are consumed as operators by parseTablePrimary. Reserved clause keywords
+// (FROM/WHERE/JOIN/…) are likewise already excluded by isIdentifierStart.
 func (p *Parser) atTableAliasStop() bool {
 	switch p.cur.Type {
-	case kwWITH, kwPIVOT, kwUNPIVOT, kwTABLESAMPLE, kwMATCH_RECOGNIZE:
+	case kwWITH:
 		return true
+	case kwPIVOT:
+		// Operator iff `PIVOT (`; otherwise a bare implicit alias named "pivot".
+		return p.peekNext().Type == int('(')
+	case kwUNPIVOT:
+		// Operator iff `UNPIVOT (` or `UNPIVOT INCLUDE|EXCLUDE`; otherwise alias.
+		switch p.peekNext().Type {
+		case int('('), kwINCLUDE, kwEXCLUDE:
+			return true
+		}
+		return false
 	}
 	return false
 }

--- a/googlesql/parser/pivot_unpivot.go
+++ b/googlesql/parser/pivot_unpivot.go
@@ -1,0 +1,404 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-query-clauses` DAG node. It implements
+// GoogleSQL's PIVOT and UNPIVOT table-source operators (GoogleSQLParser.g4
+// §2.14 pivot_clause / unpivot_clause and the opt_pivot_or_unpivot_clause_and_
+// alias / pivot_or_unpivot_clause_and_aliases productions), a hand-port of
+// Google's open-source ZetaSQL reference.
+//
+// PIVOT/UNPIVOT attach to a FROM source (a path table, a parenthesized
+// subquery, or a table-valued-function call — the grammar's table_path_
+// expression, table_subquery, and tvf_with_suffixes all carry the operator).
+// The operator binds AFTER the source's own `[AS] alias` and BEFORE WITH OFFSET
+// / FOR SYSTEM_TIME, matching the grammar's ordering of
+// `opt_pivot_or_unpivot_clause_and_alias`. At most one PIVOT or UNPIVOT applies
+// to a single source (oracle: `t PIVOT(...) UNPIVOT(...)` rejects).
+//
+// DIALECT NOTE. PIVOT/UNPIVOT are documented as BigQuery-only (truth1/bigquery
+// QUERY-013/014), but the live Cluster Spanner emulator's ZetaSQL ACCEPTS them
+// (parsing them, then feature-rejecting with "PIVOT is not supported") — so the
+// oracle is authoritative for these forms after all (both polarities), and the
+// pivot_unpivot_oracle differential drives the PROVE gate. This is the union
+// grammar bytebase needs for BigQuery + Spanner.
+
+// atPivotOrUnpivot reports whether the current token begins a PIVOT or UNPIVOT
+// operator. Both PIVOT and UNPIVOT are non-reserved keywords, so this guards
+// against eating them as bare table aliases (see atTableAliasStop in
+// from_join.go).
+func (p *Parser) atPivotOrUnpivot() bool {
+	return p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT
+}
+
+// parsePivotOrUnpivot parses an optional PIVOT(...) or UNPIVOT(...) operator and
+// its trailing `[AS] alias`, storing the result on the source's Pivot / Unpivot
+// field (TableExpr or UnnestExpr). The current token is the source's first
+// post-alias token. If it is not PIVOT or UNPIVOT this is a no-op (the source
+// has no pivot operator). At most one operator is consumed.
+func (p *Parser) parsePivotOrUnpivot(src ast.Node) error {
+	switch p.cur.Type {
+	case kwPIVOT:
+		pv, err := p.parsePivotClause()
+		if err != nil {
+			return err
+		}
+		attachPivot(src, pv)
+	case kwUNPIVOT:
+		up, err := p.parseUnpivotClause()
+		if err != nil {
+			return err
+		}
+		attachUnpivot(src, up)
+	default:
+		return nil
+	}
+	return nil
+}
+
+// attachPivot stores a parsed PIVOT clause on a table source (TableExpr /
+// UnnestExpr), updating its end Loc.
+func attachPivot(src ast.Node, pv *ast.PivotClause) {
+	switch s := src.(type) {
+	case *ast.TableExpr:
+		s.Pivot = pv
+		s.Loc.End = pv.Loc.End
+	case *ast.UnnestExpr:
+		s.Pivot = pv
+		s.Loc.End = pv.Loc.End
+	}
+}
+
+// attachUnpivot stores a parsed UNPIVOT clause on a table source (TableExpr /
+// UnnestExpr), updating its end Loc.
+func attachUnpivot(src ast.Node, up *ast.UnpivotClause) {
+	switch s := src.(type) {
+	case *ast.TableExpr:
+		s.Unpivot = up
+		s.Loc.End = up.Loc.End
+	case *ast.UnnestExpr:
+		s.Unpivot = up
+		s.Loc.End = up.Loc.End
+	}
+}
+
+// parsePivotClause parses a PIVOT operator (pivot_clause + trailing as_alias):
+//
+//	PIVOT ( <agg>[, …] FOR <for_expr> IN ( <value>[, …] ) ) [ [AS] alias ]
+//
+// PIVOT is the current token. The FOR expression is parsed at higher-than-AND
+// precedence (expression_higher_prec_than_and) so the following `IN (...)` is
+// read as the pivot value list rather than folded into an `expr IN (...)`
+// predicate.
+func (p *Parser) parsePivotClause() (*ast.PivotClause, error) {
+	pivotTok := p.advance() // PIVOT
+	pv := &ast.PivotClause{Loc: pivotTok.Loc}
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// Aggregate list: pivot_expression (, pivot_expression)* — each
+	// `expression [[AS] alias]`. At least one is required (oracle:
+	// `PIVOT(FOR q IN ...)` rejects on the missing aggregate).
+	aggs, err := p.parsePivotExprList()
+	if err != nil {
+		return nil, err
+	}
+	pv.Aggregates = aggs
+
+	if _, err := p.expect(kwFOR); err != nil {
+		return nil, err
+	}
+
+	// FOR input column/expression. parseBinaryExpr(bpBitOr) is the
+	// expression_higher_prec_than_and band — it stops before IN/comparison, so
+	// the trailing IN starts the value list (NOT a predicate on this expression).
+	forExpr, err := p.parseBinaryExpr(bpBitOr)
+	if err != nil {
+		return nil, err
+	}
+	pv.For = forExpr
+
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	// Value list: pivot_value (, pivot_value)* — `expression [[AS] alias]`.
+	vals, err := p.parsePivotExprList()
+	if err != nil {
+		return nil, err
+	}
+	pv.Values = vals
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	pv.Loc.End = closeTok.Loc.End
+
+	// Trailing `[AS] alias` for the pivot result (as_alias?).
+	if alias, ok, err := p.tryParseTableAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		pv.Alias = alias
+		pv.Loc.End = p.prev.Loc.End
+	}
+	return pv, nil
+}
+
+// parsePivotExprList parses a comma-separated list of `expression [[AS] alias]`
+// (pivot_expression_list / pivot_value_list). At least one item is required.
+// The current token is the first expression; parsing stops at the closing token
+// of the enclosing parens (FOR for the aggregate list, ')' for the value list),
+// which the caller consumes.
+func (p *Parser) parsePivotExprList() ([]*ast.PivotExpr, error) {
+	var items []*ast.PivotExpr
+	for {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		pe := &ast.PivotExpr{Expr: expr, Loc: nodeLoc(expr)}
+		// Optional `[AS] alias` (as_alias).
+		if alias, ok, err := p.tryParsePivotAlias(); err != nil {
+			return nil, err
+		} else if ok {
+			pe.Alias = alias
+			pe.Loc.End = p.prev.Loc.End
+		}
+		items = append(items, pe)
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ','
+	}
+	return items, nil
+}
+
+// tryParsePivotAlias parses an optional `[AS] alias` for a pivot aggregate /
+// value (as_alias). Unlike tryParseTableAlias, a bare (AS-less) identifier is
+// accepted as an alias only when it does NOT begin a list/clause continuation
+// (FOR / IN / ',' / ')'). An explicit AS requires a following identifier.
+func (p *Parser) tryParsePivotAlias() (string, bool, error) {
+	if p.cur.Type == kwAS {
+		p.advance()
+		aliasTok, err := p.expectIdentifier()
+		if err != nil {
+			return "", false, err
+		}
+		alias, err := p.identifierText(aliasTok)
+		if err != nil {
+			return "", false, err
+		}
+		return alias, true, nil
+	}
+	// A bare identifier that is not FOR/IN (those terminate the aggregate list)
+	// and not a separator is an implicit alias. isIdentifierStart excludes
+	// reserved keywords; FOR and IN are reserved, so they already stop here.
+	if isIdentifierStart(p.cur.Type) {
+		aliasTok := p.advance()
+		alias, err := p.identifierText(aliasTok)
+		if err != nil {
+			return "", false, err
+		}
+		return alias, true, nil
+	}
+	return "", false, nil
+}
+
+// parseUnpivotClause parses an UNPIVOT operator (unpivot_clause + trailing
+// as_alias):
+//
+//	UNPIVOT [ {INCLUDE|EXCLUDE} NULLS ]
+//	  ( <value_col(s)> FOR <name_col> IN ( <in_item>[, …] ) ) [ [AS] alias ]
+//
+// UNPIVOT is the current token. The value-column list is `path_expression_list_
+// with_opt_parens` — a bare column for single-column UNPIVOT or a parenthesized
+// group `(c1, c2)` for multi-column UNPIVOT.
+func (p *Parser) parseUnpivotClause() (*ast.UnpivotClause, error) {
+	unpivotTok := p.advance() // UNPIVOT
+	up := &ast.UnpivotClause{Loc: unpivotTok.Loc}
+
+	// Optional INCLUDE NULLS | EXCLUDE NULLS (unpivot_nulls_filter).
+	switch p.cur.Type {
+	case kwINCLUDE:
+		p.advance()
+		if _, err := p.expect(kwNULLS); err != nil {
+			return nil, err
+		}
+		up.NullsMode = ast.UnpivotIncludeNulls
+	case kwEXCLUDE:
+		p.advance()
+		if _, err := p.expect(kwNULLS); err != nil {
+			return nil, err
+		}
+		up.NullsMode = ast.UnpivotExcludeNulls
+	}
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// Value column(s): a single path or a parenthesized list (multi-column).
+	cols, err := p.parsePathListWithOptParens()
+	if err != nil {
+		return nil, err
+	}
+	up.ValueColumns = cols
+
+	if _, err := p.expect(kwFOR); err != nil {
+		return nil, err
+	}
+	// Name column (a single path_expression).
+	nameCol, err := p.parsePathExpr()
+	if err != nil {
+		return nil, err
+	}
+	up.NameColumn = nameCol
+
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+	// IN ( unpivot_in_item (, unpivot_in_item)* ).
+	items, err := p.parseUnpivotInItemList()
+	if err != nil {
+		return nil, err
+	}
+	up.Items = items
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	up.Loc.End = closeTok.Loc.End
+
+	// Trailing `[AS] alias` (unpivot_alias).
+	if alias, ok, err := p.tryParseTableAlias(); err != nil {
+		return nil, err
+	} else if ok {
+		up.Alias = alias
+		up.Loc.End = p.prev.Loc.End
+	}
+	return up, nil
+}
+
+// parseUnpivotInItemList parses `( unpivot_in_item (, unpivot_in_item)* )`
+// (unpivot_in_item_list). The current token is the opening '('. At least one
+// item is required (oracle: `UNPIVOT(... IN ())` rejects). The closing ')' is
+// consumed.
+func (p *Parser) parseUnpivotInItemList() ([]*ast.UnpivotInItem, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	var items []*ast.UnpivotInItem
+	for {
+		item, err := p.parseUnpivotInItem()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+		if p.cur.Type != int(',') {
+			break
+		}
+		p.advance() // ','
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// parseUnpivotInItem parses one IN-list entry (unpivot_in_item):
+// `path_expression_list_with_opt_parens [ [AS] string|int ]` — a column or
+// parenthesized column group, with an optional string/integer row-value alias.
+func (p *Parser) parseUnpivotInItem() (*ast.UnpivotInItem, error) {
+	cols, err := p.parsePathListWithOptParens()
+	if err != nil {
+		return nil, err
+	}
+	item := &ast.UnpivotInItem{Columns: cols}
+	if len(cols) > 0 {
+		item.Loc = ast.Loc{Start: cols[0].Loc.Start, End: cols[len(cols)-1].Loc.End}
+	}
+
+	// Optional `[AS] string|int` (opt_as_string_or_integer). AS is optional; the
+	// alias is a string OR integer literal.
+	if p.cur.Type == kwAS {
+		p.advance()
+		if err := p.parseUnpivotInItemAlias(item); err != nil {
+			return nil, err
+		}
+	} else if p.cur.Type == tokString || p.cur.Type == tokInteger {
+		// AS-less alias is only the literal forms (a following column would be a
+		// separate IN item, separated by a comma).
+		if err := p.parseUnpivotInItemAlias(item); err != nil {
+			return nil, err
+		}
+	}
+	return item, nil
+}
+
+// parseUnpivotInItemAlias consumes the string- or integer-literal alias of an
+// unpivot IN item (opt_as_string_or_integer body) and records it on item. The
+// current token must be a string or integer literal.
+func (p *Parser) parseUnpivotInItemAlias(item *ast.UnpivotInItem) error {
+	switch p.cur.Type {
+	case tokString:
+		tok := p.advance()
+		item.HasAlias = true
+		item.AliasIsInt = false
+		item.AliasString = tok.Str
+		item.Loc.End = tok.Loc.End
+		return nil
+	case tokInteger:
+		tok := p.advance()
+		item.HasAlias = true
+		item.AliasIsInt = true
+		item.AliasInt = tok.Str
+		item.Loc.End = tok.Loc.End
+		return nil
+	default:
+		return p.syntaxErrorAtCur()
+	}
+}
+
+// parsePathListWithOptParens parses path_expression_list_with_opt_parens: either
+// `( path (, path)* )` (a parenthesized group, used for multi-column UNPIVOT) or
+// a bare comma-less single `path`. (Note: outside parens the grammar's
+// path_expression_list allows commas, but in the UNPIVOT value-column and
+// in-item contexts the comma at the top level separates IN items / belongs to
+// the enclosing list, so a bare path is single here; multi-column groups are
+// always parenthesized.)
+func (p *Parser) parsePathListWithOptParens() ([]*ast.PathExpr, error) {
+	if p.cur.Type == int('(') {
+		p.advance() // '('
+		var paths []*ast.PathExpr
+		for {
+			path, err := p.parsePathExpr()
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, path)
+			if p.cur.Type != int(',') {
+				break
+			}
+			p.advance() // ','
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		return paths, nil
+	}
+	path, err := p.parsePathExpr()
+	if err != nil {
+		return nil, err
+	}
+	return []*ast.PathExpr{path}, nil
+}

--- a/googlesql/parser/pivot_unpivot_oracle_test.go
+++ b/googlesql/parser/pivot_unpivot_oracle_test.go
@@ -1,0 +1,256 @@
+//go:build googlesql_oracle
+
+// Differential test for the `parser-query-clauses` node against the live Cloud
+// Spanner emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestQueryClausesDifferential
+//
+// It is the PROVE gate for googlesql/parser-query-clauses (correctness-
+// protocol.md): for every fixture it (1) feeds the full query to the emulator
+// via the harness/googlesql-spanner CLI and reads the accept/reject verdict,
+// then (2) parses the same query with omni's Parse, and asserts the two agree —
+// BOTH polarities (the corpus has accept AND reject cases). A harness `error`
+// verdict (oracle could not decide) fails the fixture loudly; it is never folded
+// into accept or reject.
+//
+// SCOPE — what is oracle-authoritative here. Although PIVOT/UNPIVOT are
+// documented as BigQuery-only, the live Spanner emulator's ZetaSQL grammar
+// PARSES them (then feature-rejects: "PIVOT is not supported" / "... is not
+// allowed with array scans") — so the harness classifies those as ACCEPT (the
+// grammar accepted), and the emulator IS authoritative for PIVOT / UNPIVOT /
+// TABLESAMPLE / FOR SYSTEM_TIME in BOTH polarities. The hard SYNTAX rejects
+// (missing FOR, empty IN, missing TABLESAMPLE unit, double pivot, trailing
+// sample alias) carry the canonical `Syntax error:` prefix and so verdict
+// reject. This file drives all four constructs except:
+//
+// EXCLUDED — the SELECT-level differential-privacy clause
+// (`SELECT WITH DIFFERENTIAL_PRIVACY OPTIONS(...)`). It is BigQuery-only and the
+// emulator reports "Unexpected keyword WITH" WITHOUT the `Syntax error:` prefix,
+// so the fail-closed harness misclassifies it as a (semantic) ACCEPT — the
+// oracle is NON-authoritative for it (oracle.md dialect caveat). It is proven by
+// the hand-written unit tests (pivot_unpivot_test.go) + truth1/bigquery
+// triangulation instead, mirroring parser-select's exclusion of DP fixtures.
+package parser
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// qcFixture is a full query statement (no trailing ';') fed to BOTH the oracle
+// and omni's Parse. wantParse is the expected omni outcome and MUST equal the
+// emulator's grammar verdict.
+type qcFixture struct {
+	sql       string
+	wantParse bool
+}
+
+var queryClausesFixtures = []qcFixture{
+	// ===================== ACCEPT — PIVOT =========================
+	{"SELECT * FROM Produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))", true},
+	{"SELECT * FROM t PIVOT(SUM(s) AS tot, COUNT(*) AS n FOR q IN ('Q1' AS first, 'Q2'))", true},
+	{"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1')) AS p", true},
+	{"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1')) p", true},
+	{"SELECT * FROM t AS x PIVOT(SUM(s) FOR q IN ('a'))", true},
+	{"SELECT * FROM t x PIVOT(SUM(s) FOR q IN ('a'))", true},
+	// PIVOT / UNPIVOT are non-reserved: a bare trailing keyword is an implicit
+	// table alias, not a (malformed) operator.
+	{"SELECT * FROM t pivot", true},
+	{"SELECT * FROM t unpivot", true},
+	{"SELECT * FROM t pivot, s", true},
+	{"SELECT * FROM t AS x PIVOT(SUM(s) FOR q IN ('a')) AS p", true},
+	{"SELECT * FROM (SELECT 1 AS s, 2 AS q) PIVOT(SUM(s) FOR q IN (2))", true},
+	{"SELECT * FROM (SELECT 1 AS s, 2 AS q) AS t PIVOT(SUM(s) FOR q IN (2))", true},
+	// The FOR input is parsed at higher-than-AND precedence so the trailing IN is
+	// the value list, not an `expr IN (...)` predicate: arithmetic / field access
+	// in FOR accepts; a top-level AND in FOR rejects.
+	{"SELECT * FROM t PIVOT(SUM(s) FOR a + b IN ('x'))", true},
+	{"SELECT * FROM t PIVOT(SUM(s) FOR a AND b IN ('x'))", false},
+
+	// ===================== ACCEPT — UNPIVOT =======================
+	{"SELECT * FROM sales_table UNPIVOT(total_sales FOR quarter IN (Q1, Q2, Q3, Q4))", true},
+	{"SELECT * FROM t UNPIVOT INCLUDE NULLS (total_sales FOR quarter IN (Q1, Q2))", true},
+	{"SELECT * FROM t UNPIVOT EXCLUDE NULLS (sales FOR q IN (Q1, Q2))", true},
+	{"SELECT * FROM t UNPIVOT ((s1, s2) FOR q IN ((Q1, Q2), (Q3, Q4)))", true},
+	{"SELECT * FROM t UNPIVOT (s FOR q IN (Q1 AS 'a', Q2 AS 2)) AS u", true},
+	{"SELECT * FROM t AS x UNPIVOT(v FOR n IN (a, b)) AS u", true},
+
+	// ===================== ACCEPT — TABLESAMPLE ===================
+	{"SELECT * FROM Singers TABLESAMPLE BERNOULLI (10 PERCENT)", true},
+	{"SELECT * FROM Albums TABLESAMPLE RESERVOIR (100 ROWS)", true},
+	{"SELECT * FROM t TABLESAMPLE SYSTEM (10 PERCENT)", true},
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (5 PERCENT) REPEATABLE (42)", true},
+	{"SELECT * FROM t TABLESAMPLE RESERVOIR (100 ROWS) WITH WEIGHT", true},
+	{"SELECT * FROM t TABLESAMPLE RESERVOIR (100 ROWS) WITH WEIGHT AS w", true},
+	{"SELECT * FROM t AS x TABLESAMPLE BERNOULLI (10 PERCENT)", true},
+	{"SELECT * FROM (SELECT 1 AS s) TABLESAMPLE BERNOULLI (10 PERCENT)", true},
+	// PIVOT then TABLESAMPLE: sample is the outermost suffix.
+	{"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('a')) TABLESAMPLE BERNOULLI (10 PERCENT)", true},
+	// TABLESAMPLE then a trailing clause (WHERE) — sample is complete.
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT) WHERE x > 1", true},
+
+	// ===================== ACCEPT — FOR SYSTEM_TIME ===============
+	{"SELECT * FROM t FOR SYSTEM_TIME AS OF '2020-01-01'", true},
+	{"SELECT * FROM t FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)", true},
+	{"SELECT * FROM t FOR SYSTEM TIME AS OF '2020-01-01'", true},
+	{"SELECT * FROM t a FOR SYSTEM_TIME AS OF '2020-01-01'", true},
+
+	// ===================== REJECT — hard syntax errors ============
+	// PIVOT: missing aggregate / empty IN / missing FOR.
+	{"SELECT * FROM t PIVOT(FOR q IN ('Q1'))", false},
+	{"SELECT * FROM t PIVOT(SUM(s) FOR q IN ())", false},
+	// UNPIVOT: empty body / empty IN.
+	{"SELECT * FROM t UNPIVOT()", false},
+	{"SELECT * FROM t UNPIVOT(s FOR q IN ())", false},
+	// At most one pivot/unpivot per source.
+	{"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1')) UNPIVOT(x FOR y IN (a))", false},
+	// TABLESAMPLE: missing unit / no method paren / trailing alias.
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (10)", false},
+	{"SELECT * FROM t TABLESAMPLE (10 PERCENT)", false},
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT) AS x", false},
+	// TABLESAMPLE size is a literal/cast/param, NOT an arbitrary expression.
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (1 + 1 ROWS)", false},
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (x ROWS)", false},
+	// PIVOT FOR input is higher-than-AND precedence: a top-level comparison / NOT
+	// in FOR is a syntax error (the IN is the pivot value list, not a predicate).
+	{"SELECT * FROM t PIVOT(SUM(s) FOR a = b IN ('x'))", false},
+	{"SELECT * FROM t PIVOT(SUM(s) FOR NOT flag IN ('x'))", false},
+	// A bare (unparenthesized) multi-column UNPIVOT value list rejects.
+	{"SELECT * FROM t UNPIVOT(s1, s2 FOR q IN ((Q1, Q2)))", false},
+	// TABLESAMPLE before PIVOT is rejected (sample is outermost).
+	{"SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT) PIVOT(SUM(s) FOR q IN ('a'))", false},
+	// PIVOT alias may not carry a column list.
+	{"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1')) AS p (x, y)", false},
+	// FOR SYSTEM (two-word) requires the TIME keyword.
+	{"SELECT * FROM t FOR SYSTEM AS OF '2020-01-01'", false},
+}
+
+func TestQueryClausesDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live differential")
+	}
+	h := newQCHarness(t)
+	defer h.close()
+
+	for _, fx := range queryClausesFixtures {
+		fx := fx
+		t.Run(fx.sql, func(t *testing.T) {
+			v := h.verdict(t, fx.sql)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; do NOT treat as accept/reject",
+					fx.sql, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.sql)
+			}
+			oracleAccepts := v.Verdict == "accept"
+
+			if oracleAccepts != fx.wantParse {
+				t.Fatalf("fixture wantParse=%v but oracle says %q (%s) for %q",
+					fx.wantParse, v.Verdict, v.Message, fx.sql)
+			}
+
+			_, errs := Parse(fx.sql)
+			omniAccepts := len(errs) == 0
+
+			if omniAccepts != oracleAccepts {
+				t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s)",
+					fx.sql, omniAccepts, oracleAccepts, v.Reason, v.Message)
+			}
+		})
+	}
+}
+
+// --- harness plumbing (one persistent batch process, mirrors select_oracle_test) ---
+
+type qcHarnessVerdict struct {
+	Verdict string `json:"verdict"`
+	Kind    string `json:"kind"`
+	Reason  string `json:"reason"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type qcHarness struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	mu     sync.Mutex
+}
+
+func newQCHarness(t *testing.T) *qcHarness {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	projDir := filepath.Join(repoRoot, "harness", "googlesql-spanner")
+	if _, err := os.Stat(projDir); err != nil {
+		t.Skipf("harness project not found at %s", projDir)
+	}
+
+	bin := filepath.Join(projDir, "googlesql-spanner")
+	if _, err := os.Stat(bin); err != nil {
+		build := exec.Command("go", "build", "-o", bin, ".")
+		build.Dir = projDir
+		if out, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("building harness failed: %v\n%s", err, out)
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(), "GOOGLESQL_HARNESS_LINE=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting harness: %v", err)
+	}
+	return &qcHarness{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdoutPipe)}
+}
+
+func (h *qcHarness) verdict(t *testing.T, stmt string) qcHarnessVerdict {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	enc := base64.StdEncoding.EncodeToString([]byte(stmt))
+	if _, err := fmt.Fprintln(h.stdin, enc); err != nil {
+		t.Fatalf("writing to harness: %v", err)
+	}
+	line, err := h.stdout.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading harness verdict: %v", err)
+	}
+	var v qcHarnessVerdict
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &v); err != nil {
+		t.Fatalf("decoding harness verdict %q: %v", line, err)
+	}
+	return v
+}
+
+func (h *qcHarness) close() {
+	if h.stdin != nil {
+		_ = h.stdin.Close()
+	}
+	if h.cmd != nil && h.cmd.Process != nil {
+		_ = h.cmd.Wait()
+	}
+}

--- a/googlesql/parser/pivot_unpivot_test.go
+++ b/googlesql/parser/pivot_unpivot_test.go
@@ -1,0 +1,600 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// Unit tests for the parser-query-clauses node: PIVOT / UNPIVOT / TABLESAMPLE
+// table-source operators, the AT SYSTEM TIME (FOR SYSTEM_TIME AS OF) suffix, and
+// the SELECT-level differential-privacy clause. Accept/reject is also proven
+// against the live Cloud Spanner emulator in pivot_unpivot_oracle_test.go (build
+// tag googlesql_oracle) for the oracle-authoritative forms; these hand-written
+// tests assert the AST STRUCTURE and cover the BigQuery-only differential-
+// privacy clause that is non-authoritative against that emulator.
+
+// selFrom0 parses one SELECT statement and returns its first FROM item.
+func selFrom0(t *testing.T, sql string) ast.Node {
+	t.Helper()
+	q := parseQ(t, sql)
+	sel := selectOf(t, q)
+	if len(sel.From) == 0 {
+		t.Fatalf("Parse(%q): SELECT has no FROM items", sql)
+	}
+	return sel.From[0]
+}
+
+// tableExpr0 parses one SELECT and returns its first FROM item as a *TableExpr.
+func tableExpr0(t *testing.T, sql string) *ast.TableExpr {
+	t.Helper()
+	te, ok := selFrom0(t, sql).(*ast.TableExpr)
+	if !ok {
+		t.Fatalf("Parse(%q): FROM[0] = %T, want *ast.TableExpr", sql, selFrom0(t, sql))
+	}
+	return te
+}
+
+// --- PIVOT structure ---------------------------------------------------------
+
+func TestPivot_Structure(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM Produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))")
+	if te.Pivot == nil {
+		t.Fatalf("PIVOT not parsed: te.Pivot is nil")
+	}
+	if te.Unpivot != nil || te.Sample != nil {
+		t.Errorf("only Pivot should be set; got Unpivot=%v Sample=%v", te.Unpivot, te.Sample)
+	}
+	if got := len(te.Pivot.Aggregates); got != 1 {
+		t.Errorf("aggregates: got %d, want 1", got)
+	}
+	if te.Pivot.For == nil {
+		t.Errorf("FOR expression is nil")
+	}
+	if got := len(te.Pivot.Values); got != 4 {
+		t.Errorf("IN values: got %d, want 4", got)
+	}
+	if te.Pivot.Alias != "" {
+		t.Errorf("alias: got %q, want empty", te.Pivot.Alias)
+	}
+}
+
+func TestPivot_MultiAggregateWithAliases(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM (SELECT product, sales, quarter FROM Produce) PIVOT(SUM(sales) AS total_sales, COUNT(*) AS num_records FOR quarter IN ('Q1', 'Q2'))")
+	if te.Pivot == nil {
+		t.Fatalf("PIVOT not parsed")
+	}
+	if got := len(te.Pivot.Aggregates); got != 2 {
+		t.Fatalf("aggregates: got %d, want 2", got)
+	}
+	if te.Pivot.Aggregates[0].Alias != "total_sales" {
+		t.Errorf("agg[0] alias: got %q, want total_sales", te.Pivot.Aggregates[0].Alias)
+	}
+	if te.Pivot.Aggregates[1].Alias != "num_records" {
+		t.Errorf("agg[1] alias: got %q, want num_records", te.Pivot.Aggregates[1].Alias)
+	}
+	// The source is a parenthesized subquery.
+	if te.Subquery == nil {
+		t.Errorf("expected a subquery source under PIVOT")
+	}
+}
+
+func TestPivot_ValueAliases(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1' AS first, 'Q2'))")
+	if te.Pivot == nil {
+		t.Fatalf("PIVOT not parsed")
+	}
+	if got := len(te.Pivot.Values); got != 2 {
+		t.Fatalf("values: got %d, want 2", got)
+	}
+	if te.Pivot.Values[0].Alias != "first" {
+		t.Errorf("value[0] alias: got %q, want first", te.Pivot.Values[0].Alias)
+	}
+	if te.Pivot.Values[1].Alias != "" {
+		t.Errorf("value[1] alias: got %q, want empty", te.Pivot.Values[1].Alias)
+	}
+}
+
+func TestPivot_TableAndPivotAlias(t *testing.T) {
+	// `t AS x PIVOT(...) AS p`: x is the table alias, p is the pivot alias.
+	te := tableExpr0(t, "SELECT * FROM t AS x PIVOT(SUM(s) FOR q IN ('a')) AS p")
+	if te.Alias != "x" {
+		t.Errorf("table alias: got %q, want x", te.Alias)
+	}
+	if te.Pivot == nil {
+		t.Fatalf("PIVOT not parsed")
+	}
+	if te.Pivot.Alias != "p" {
+		t.Errorf("pivot alias: got %q, want p", te.Pivot.Alias)
+	}
+}
+
+func TestPivot_BarePivotAlias(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t PIVOT(SUM(s) FOR q IN ('a')) p")
+	if te.Alias != "" {
+		t.Errorf("table alias: got %q, want empty", te.Alias)
+	}
+	if te.Pivot == nil || te.Pivot.Alias != "p" {
+		t.Errorf("pivot alias: want p, got %+v", te.Pivot)
+	}
+}
+
+// --- UNPIVOT structure -------------------------------------------------------
+
+func TestUnpivot_SingleColumn(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM sales_table UNPIVOT(total_sales FOR quarter IN (Q1, Q2, Q3, Q4))")
+	if te.Unpivot == nil {
+		t.Fatalf("UNPIVOT not parsed")
+	}
+	if te.Pivot != nil || te.Sample != nil {
+		t.Errorf("only Unpivot should be set")
+	}
+	if got := len(te.Unpivot.ValueColumns); got != 1 {
+		t.Errorf("value columns: got %d, want 1", got)
+	}
+	if te.Unpivot.NameColumn == nil {
+		t.Errorf("name column is nil")
+	}
+	if got := len(te.Unpivot.Items); got != 4 {
+		t.Errorf("IN items: got %d, want 4", got)
+	}
+	if te.Unpivot.NullsMode != ast.UnpivotNullsUnspecified {
+		t.Errorf("nulls mode: got %v, want unspecified", te.Unpivot.NullsMode)
+	}
+}
+
+func TestUnpivot_IncludeNulls(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t UNPIVOT INCLUDE NULLS (total_sales FOR quarter IN (Q1, Q2))")
+	if te.Unpivot == nil {
+		t.Fatalf("UNPIVOT not parsed")
+	}
+	if te.Unpivot.NullsMode != ast.UnpivotIncludeNulls {
+		t.Errorf("nulls mode: got %v, want IncludeNulls", te.Unpivot.NullsMode)
+	}
+}
+
+func TestUnpivot_ExcludeNulls(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t UNPIVOT EXCLUDE NULLS (s FOR q IN (Q1, Q2))")
+	if te.Unpivot == nil || te.Unpivot.NullsMode != ast.UnpivotExcludeNulls {
+		t.Errorf("want ExcludeNulls, got %+v", te.Unpivot)
+	}
+}
+
+func TestUnpivot_MultiColumn(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t UNPIVOT ((s1, s2) FOR q IN ((Q1, Q2), (Q3, Q4)))")
+	if te.Unpivot == nil {
+		t.Fatalf("UNPIVOT not parsed")
+	}
+	if got := len(te.Unpivot.ValueColumns); got != 2 {
+		t.Errorf("value columns: got %d, want 2 (multi-column)", got)
+	}
+	if got := len(te.Unpivot.Items); got != 2 {
+		t.Fatalf("IN items: got %d, want 2", got)
+	}
+	if got := len(te.Unpivot.Items[0].Columns); got != 2 {
+		t.Errorf("item[0] columns: got %d, want 2 (parenthesized group)", got)
+	}
+}
+
+func TestUnpivot_InItemAliases(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t UNPIVOT (s FOR q IN (Q1 AS 'a', Q2 AS 2)) AS u")
+	if te.Unpivot == nil {
+		t.Fatalf("UNPIVOT not parsed")
+	}
+	if te.Unpivot.Alias != "u" {
+		t.Errorf("unpivot alias: got %q, want u", te.Unpivot.Alias)
+	}
+	if got := len(te.Unpivot.Items); got != 2 {
+		t.Fatalf("IN items: got %d, want 2", got)
+	}
+	it0 := te.Unpivot.Items[0]
+	if !it0.HasAlias || it0.AliasIsInt || it0.AliasString != "a" {
+		t.Errorf("item[0]: want string alias 'a', got %+v", it0)
+	}
+	it1 := te.Unpivot.Items[1]
+	if !it1.HasAlias || !it1.AliasIsInt || it1.AliasInt != "2" {
+		t.Errorf("item[1]: want int alias 2, got %+v", it1)
+	}
+}
+
+// --- TABLESAMPLE structure ---------------------------------------------------
+
+func TestTableSample_Percent(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM dataset.my_table TABLESAMPLE SYSTEM (10 PERCENT)")
+	if te.Sample == nil {
+		t.Fatalf("TABLESAMPLE not parsed")
+	}
+	if te.Pivot != nil || te.Unpivot != nil {
+		t.Errorf("only Sample should be set")
+	}
+	if te.Sample.Method != "SYSTEM" {
+		t.Errorf("method: got %q, want SYSTEM", te.Sample.Method)
+	}
+	if te.Sample.Unit != ast.SampleUnitPercent {
+		t.Errorf("unit: got %v, want PERCENT", te.Sample.Unit)
+	}
+	if te.Sample.Size == nil {
+		t.Errorf("size is nil")
+	}
+}
+
+func TestTableSample_Rows(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM Albums TABLESAMPLE RESERVOIR (100 ROWS)")
+	if te.Sample == nil {
+		t.Fatalf("TABLESAMPLE not parsed")
+	}
+	if te.Sample.Method != "RESERVOIR" {
+		t.Errorf("method: got %q, want RESERVOIR", te.Sample.Method)
+	}
+	if te.Sample.Unit != ast.SampleUnitRows {
+		t.Errorf("unit: got %v, want ROWS", te.Sample.Unit)
+	}
+}
+
+func TestTableSample_Bernoulli(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM Singers TABLESAMPLE BERNOULLI (10 PERCENT)")
+	if te.Sample == nil || te.Sample.Method != "BERNOULLI" {
+		t.Errorf("want BERNOULLI sample, got %+v", te.Sample)
+	}
+}
+
+func TestTableSample_Repeatable(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t TABLESAMPLE BERNOULLI (5 PERCENT) REPEATABLE (42)")
+	if te.Sample == nil {
+		t.Fatalf("TABLESAMPLE not parsed")
+	}
+	if te.Sample.Repeatable == nil {
+		t.Errorf("REPEATABLE seed not captured")
+	}
+	if te.Sample.WithWeight {
+		t.Errorf("WithWeight should be false")
+	}
+}
+
+func TestTableSample_WithWeight(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t TABLESAMPLE RESERVOIR (100 ROWS) WITH WEIGHT")
+	if te.Sample == nil {
+		t.Fatalf("TABLESAMPLE not parsed")
+	}
+	if !te.Sample.WithWeight {
+		t.Errorf("WITH WEIGHT not captured")
+	}
+}
+
+func TestTableSample_WithWeightAlias(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t TABLESAMPLE RESERVOIR (100 ROWS) WITH WEIGHT AS w")
+	if te.Sample == nil || !te.Sample.WithWeight {
+		t.Fatalf("WITH WEIGHT not parsed")
+	}
+	if te.Sample.WeightAlias != "w" {
+		t.Errorf("weight alias: got %q, want w", te.Sample.WeightAlias)
+	}
+}
+
+func TestTableSample_PartitionBy(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t TABLESAMPLE SYSTEM (10 PERCENT PARTITION BY x, y)")
+	if te.Sample == nil {
+		t.Fatalf("TABLESAMPLE not parsed")
+	}
+	if got := len(te.Sample.PartitionBy); got != 2 {
+		t.Errorf("PARTITION BY exprs: got %d, want 2", got)
+	}
+}
+
+func TestTableSample_WithWeightAliasRepeatable(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT) WITH WEIGHT w REPEATABLE (1)")
+	if te.Sample == nil || !te.Sample.WithWeight {
+		t.Fatalf("WITH WEIGHT not parsed")
+	}
+	if te.Sample.WeightAlias != "w" {
+		t.Errorf("weight alias: got %q, want w", te.Sample.WeightAlias)
+	}
+	if te.Sample.Repeatable == nil {
+		t.Errorf("trailing REPEATABLE seed not captured")
+	}
+}
+
+func TestTableSample_TableAliasBefore(t *testing.T) {
+	// `t AS x TABLESAMPLE(...)`: x is the table alias, sample wraps it.
+	te := tableExpr0(t, "SELECT * FROM t AS x TABLESAMPLE BERNOULLI (10 PERCENT)")
+	if te.Alias != "x" {
+		t.Errorf("table alias: got %q, want x", te.Alias)
+	}
+	if te.Sample == nil {
+		t.Errorf("TABLESAMPLE not parsed")
+	}
+}
+
+// --- combinations ------------------------------------------------------------
+
+func TestPivot_ThenTableSample(t *testing.T) {
+	// `t PIVOT(...) TABLESAMPLE(...)`: PIVOT binds to the source, then TABLESAMPLE
+	// wraps the whole thing (oracle-accepted). Both fields set on the same source.
+	te := tableExpr0(t, "SELECT * FROM t PIVOT(SUM(s) FOR q IN ('a')) TABLESAMPLE BERNOULLI (10 PERCENT)")
+	if te.Pivot == nil {
+		t.Errorf("PIVOT not parsed")
+	}
+	if te.Sample == nil {
+		t.Errorf("TABLESAMPLE not parsed")
+	}
+}
+
+func TestSubquery_TableSample(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM (SELECT 1 AS s, 2 AS q) TABLESAMPLE BERNOULLI (10 PERCENT)")
+	if te.Subquery == nil {
+		t.Errorf("expected subquery source")
+	}
+	if te.Sample == nil {
+		t.Errorf("TABLESAMPLE not parsed on subquery")
+	}
+}
+
+func TestSubquery_Pivot(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM (SELECT 1 AS s, 2 AS q) AS sub PIVOT(SUM(s) FOR q IN (2)) AS p")
+	if te.Subquery == nil {
+		t.Errorf("expected subquery source")
+	}
+	if te.Alias != "sub" {
+		t.Errorf("subquery alias: got %q, want sub", te.Alias)
+	}
+	if te.Pivot == nil || te.Pivot.Alias != "p" {
+		t.Errorf("pivot/alias not parsed: %+v", te.Pivot)
+	}
+}
+
+// --- AT SYSTEM TIME (FOR SYSTEM_TIME AS OF) ----------------------------------
+
+func TestForSystemTime_Captured(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t FOR SYSTEM_TIME AS OF '2017-01-01 10:00:00-07:00'")
+	if te.SystemTime == nil {
+		t.Errorf("FOR SYSTEM_TIME AS OF not captured")
+	}
+}
+
+func TestForSystemTime_Expression(t *testing.T) {
+	te := tableExpr0(t, "SELECT * FROM t FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)")
+	if te.SystemTime == nil {
+		t.Errorf("FOR SYSTEM_TIME AS OF expression not captured")
+	}
+}
+
+// --- differential-privacy SELECT clause (BigQuery-only) ----------------------
+
+func TestSelectWith_DifferentialPrivacy(t *testing.T) {
+	// DIFFERENTIAL_PRIVACY is over-reserved by the omni lexer; the select-with
+	// clause must still parse it (parseSelectWith admits that one keyword). The
+	// mechanism name is source-preserved (not folded).
+	q := parseQ(t, "SELECT WITH DIFFERENTIAL_PRIVACY OPTIONS(epsilon=1, delta=1e-10) a FROM t")
+	sel := selectOf(t, q)
+	if !strings.EqualFold(sel.SelectWith, "differential_privacy") {
+		t.Errorf("SelectWith: got %q, want differential_privacy (any case)", sel.SelectWith)
+	}
+	if sel.SelectWith == "" {
+		t.Errorf("SelectWith is empty; clause not captured")
+	}
+	if len(sel.Items) != 1 {
+		t.Errorf("select items: got %d, want 1", len(sel.Items))
+	}
+}
+
+func TestSelectWith_Anonymization(t *testing.T) {
+	q := parseQ(t, "SELECT WITH ANONYMIZATION OPTIONS(epsilon=1) a FROM t")
+	sel := selectOf(t, q)
+	if !strings.EqualFold(sel.SelectWith, "anonymization") {
+		t.Errorf("SelectWith: got %q, want anonymization (any case)", sel.SelectWith)
+	}
+}
+
+func TestSelectWith_AggregationThreshold(t *testing.T) {
+	q := parseQ(t, "SELECT WITH AGGREGATION_THRESHOLD OPTIONS(threshold=10, privacy_unit_column=id) COUNT(*) FROM t")
+	sel := selectOf(t, q)
+	if !strings.EqualFold(sel.SelectWith, "aggregation_threshold") {
+		t.Errorf("SelectWith: got %q, want aggregation_threshold (any case)", sel.SelectWith)
+	}
+}
+
+func TestSelectWith_NoOptions(t *testing.T) {
+	q := parseQ(t, "SELECT WITH DIFFERENTIAL_PRIVACY a FROM t")
+	sel := selectOf(t, q)
+	if !strings.EqualFold(sel.SelectWith, "differential_privacy") {
+		t.Errorf("SelectWith: got %q, want differential_privacy (any case)", sel.SelectWith)
+	}
+}
+
+// WITH (...) inline expression must NOT be read as a select-with clause.
+func TestSelectWith_NotInlineWithExpr(t *testing.T) {
+	// `SELECT WITH(...)` is an inline WITH expression column, not opt_select_with.
+	// (The disambiguator is `WITH (` vs `WITH <identifier>`.) Just assert it does
+	// not get mis-captured as a differential-privacy clause name.
+	file, errs := Parse("SELECT WITH(x AS 1, x + 1) FROM t")
+	if len(errs) == 0 {
+		q := file.Stmts[0].(*ast.QueryStmt)
+		sel := q.Body.(*ast.SelectStmt)
+		if sel.SelectWith != "" {
+			t.Errorf("inline WITH() mis-captured as select-with %q", sel.SelectWith)
+		}
+	}
+}
+
+// --- regression: Codex review findings ---------------------------------------
+
+// PIVOT / UNPIVOT are non-reserved, so a bare `FROM t pivot` is an implicit table
+// alias (oracle-confirmed accept), NOT a malformed operator. Regression for the
+// atTableAliasStop over-reject (Codex finding).
+func TestPivot_NonReservedImplicitAlias(t *testing.T) {
+	// Simple cases where FROM[0] is the aliased TableExpr itself.
+	for _, sql := range []string{
+		"SELECT * FROM t pivot",
+		"SELECT * FROM t unpivot",
+		"SELECT * FROM t AS pivot",
+		"SELECT * FROM t pivot WHERE x > 1",
+	} {
+		te := tableExpr0(t, sql)
+		if te.Pivot != nil || te.Unpivot != nil {
+			t.Errorf("%q: bare keyword wrongly parsed as operator (Pivot=%v Unpivot=%v)", sql, te.Pivot, te.Unpivot)
+		}
+		if !strings.EqualFold(te.Alias, "pivot") && !strings.EqualFold(te.Alias, "unpivot") {
+			t.Errorf("%q: alias = %q, want pivot/unpivot", sql, te.Alias)
+		}
+	}
+	// `t pivot, s` and `t pivot JOIN s ...` must also parse cleanly (the bare
+	// keyword is the alias of t, then a comma/explicit join follows).
+	for _, sql := range []string{
+		"SELECT * FROM t pivot, s",
+		"SELECT * FROM t pivot JOIN s ON s.x = t.x",
+	} {
+		if _, errs := Parse(sql); len(errs) != 0 {
+			t.Errorf("%q: expected accept (pivot is an alias, then a join), got %v", sql, errs)
+		}
+	}
+	// But `t PIVOT(...)` (operator-start) is still the operator, not an alias.
+	te := tableExpr0(t, "SELECT * FROM t PIVOT(SUM(s) FOR q IN ('a'))")
+	if te.Pivot == nil {
+		t.Errorf("`t PIVOT(...)` should be an operator")
+	}
+	if te.Alias != "" {
+		t.Errorf("`t PIVOT(...)`: table alias should be empty, got %q", te.Alias)
+	}
+}
+
+// TABLESAMPLE size is restricted to possibly_cast_int_literal_or_parameter |
+// floating_point_literal — a bare identifier / arithmetic / function call before
+// the unit must reject (oracle-confirmed). Regression for the size over-accept
+// (Codex finding).
+func TestTableSample_SizeRestricted(t *testing.T) {
+	reject := []string{
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (1 + 1 ROWS)",
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (foo() ROWS)",
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (x ROWS)",
+	}
+	for _, sql := range reject {
+		if _, errs := Parse(sql); len(errs) == 0 {
+			t.Errorf("%q: expected reject (non-literal sample size), got accept", sql)
+		}
+	}
+	accept := []string{
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT)",
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (10.5 PERCENT)",
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (CAST(10 AS INT64) PERCENT)",
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (@p PERCENT)",
+	}
+	for _, sql := range accept {
+		if _, errs := Parse(sql); len(errs) != 0 {
+			t.Errorf("%q: expected accept (literal/cast/param size), got %v", sql, errs)
+		}
+	}
+}
+
+// The PIVOT FOR input is expression_higher_prec_than_and: arithmetic / field
+// access accept, but a top-level comparison / NOT / AND in FOR rejects
+// (oracle-confirmed). DEFEND of the FOR-precedence choice (Codex finding 1 was a
+// grammar misread — the emulator rejects `FOR a = b IN` and `FOR NOT f IN`).
+func TestPivot_ForPrecedence(t *testing.T) {
+	accept := []string{
+		"SELECT * FROM t PIVOT(SUM(s) FOR a + b IN ('x'))",
+		"SELECT * FROM t PIVOT(SUM(s) FOR q.x IN ('x'))",
+	}
+	for _, sql := range accept {
+		if _, errs := Parse(sql); len(errs) != 0 {
+			t.Errorf("%q: expected accept, got %v", sql, errs)
+		}
+	}
+	reject := []string{
+		"SELECT * FROM t PIVOT(SUM(s) FOR a = b IN ('x'))",
+		"SELECT * FROM t PIVOT(SUM(s) FOR NOT flag IN ('x'))",
+		"SELECT * FROM t PIVOT(SUM(s) FOR a AND b IN ('x'))",
+	}
+	for _, sql := range reject {
+		if _, errs := Parse(sql); len(errs) == 0 {
+			t.Errorf("%q: expected reject (FOR is higher-prec-than-AND), got accept", sql)
+		}
+	}
+}
+
+// A bare (unparenthesized) multi-column UNPIVOT value list rejects; only the
+// parenthesized group is valid (oracle-confirmed). DEFEND of the
+// parsePathListWithOptParens single-vs-parenthesized handling (Codex finding 2).
+func TestUnpivot_BareMultiColumnRejects(t *testing.T) {
+	if _, errs := Parse("SELECT * FROM t UNPIVOT(s1, s2 FOR q IN ((Q1, Q2)))"); len(errs) == 0 {
+		t.Errorf("bare multi-column value list should reject (must be parenthesized)")
+	}
+	if _, errs := Parse("SELECT * FROM t UNPIVOT((s1, s2) FOR q IN ((Q1, Q2)))"); len(errs) != 0 {
+		t.Errorf("parenthesized multi-column value list should accept, got %v", errs)
+	}
+}
+
+// The AST walker must descend into PIVOT/UNPIVOT/TABLESAMPLE child expressions —
+// including on an UNNEST source (UnnestExpr.Pivot/Unpivot/Sample). Regression for
+// the generated-walker hole on UNNEST operators (Codex finding 5): a visitor
+// must observe the aggregate expression inside `UNNEST(...) PIVOT(SUM(x) ...)`.
+func TestWalker_DescendsIntoOperators(t *testing.T) {
+	// A FuncCall named SUM_SENTINEL under a PIVOT on a TableExpr source.
+	if !walkFindsFuncCall(t, "SELECT * FROM t PIVOT(SUM_SENTINEL(s) FOR q IN ('a'))", "SUM_SENTINEL") {
+		t.Errorf("walker did not reach the PIVOT aggregate on a TableExpr source")
+	}
+	// The same operator on an UNNEST source must also be walked (the UnnestExpr
+	// case must visit Pivot/Unpivot/Sample, not just Array).
+	if !walkFindsFuncCall(t, "SELECT * FROM UNNEST([1, 2]) PIVOT(SUM_SENTINEL(s) FOR q IN ('a'))", "SUM_SENTINEL") {
+		t.Errorf("walker did not reach the PIVOT aggregate on an UNNEST source (walker hole)")
+	}
+	// A TABLESAMPLE size CAST under an UNNEST source must be reachable too.
+	if !walkFindsFuncCall(t, "SELECT * FROM UNNEST([1, 2]) AS x PIVOT(SUM_SENTINEL(s) FOR q IN ('a')) TABLESAMPLE BERNOULLI (10 PERCENT)", "SUM_SENTINEL") {
+		t.Errorf("walker did not reach a PIVOT aggregate under an UNNEST+TABLESAMPLE source")
+	}
+}
+
+// walkFindsFuncCall parses sql and reports whether ast.Inspect reaches a
+// *FuncCall whose name path matches name (case-insensitive last component).
+func walkFindsFuncCall(t *testing.T, sql, name string) bool {
+	t.Helper()
+	file, errs := Parse(sql)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q): %v", sql, errs)
+	}
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if fc, ok := n.(*ast.FuncCall); ok && fc.Name != nil {
+			parts := fc.Name.Parts
+			if len(parts) > 0 && strings.EqualFold(parts[len(parts)-1], name) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// --- reject cases ------------------------------------------------------------
+
+func TestQueryClauses_Reject(t *testing.T) {
+	reject := []string{
+		// PIVOT requires an aggregate, a FOR, and a non-empty IN list.
+		"SELECT * FROM t PIVOT(FOR q IN ('Q1'))",
+		"SELECT * FROM t PIVOT(SUM(s) FOR q IN ())",
+		"SELECT * FROM t PIVOT(SUM(s) q IN ('Q1'))", // missing FOR
+		// UNPIVOT requires value col / FOR / non-empty IN.
+		"SELECT * FROM t UNPIVOT()",
+		"SELECT * FROM t UNPIVOT(s FOR q IN ())",
+		// At most one pivot/unpivot per source.
+		"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1')) UNPIVOT(x FOR y IN (a))",
+		// TABLESAMPLE requires a method, a size, and a unit.
+		"SELECT * FROM t TABLESAMPLE (10 PERCENT)",       // missing method
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (10)",     // missing unit
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (10 FOO)", // bad unit
+		// TABLESAMPLE takes no trailing alias.
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT) AS x",
+		// TABLESAMPLE before PIVOT is rejected (sample is outermost).
+		"SELECT * FROM t TABLESAMPLE BERNOULLI (10 PERCENT) PIVOT(SUM(s) FOR q IN ('a'))",
+		// PIVOT alias cannot carry a column list.
+		"SELECT * FROM t PIVOT(SUM(s) FOR q IN ('Q1')) AS p (x, y)",
+	}
+	for _, sql := range reject {
+		t.Run(sql, func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) == 0 {
+				t.Errorf("Parse(%q): expected a parse error, got none", sql)
+			}
+		})
+	}
+}

--- a/googlesql/parser/select.go
+++ b/googlesql/parser/select.go
@@ -219,26 +219,16 @@ func (p *Parser) parseSelectStmt() (*ast.SelectStmt, error) {
 	}
 
 	// Optional `WITH <name> [OPTIONS(…)]` differential-privacy / aggregation-
-	// threshold clause (opt_select_with). This is BEFORE ALL/DISTINCT.
-	// Disambiguate from a column named via WITH(...) inline expression: the
-	// select-with clause is `WITH <identifier>` (NOT `WITH (`).
-	if p.cur.Type == kwWITH && p.peekNext().Type != int('(') {
-		p.advance() // WITH
-		nameTok, err := p.expectIdentifier()
-		if err != nil {
-			return nil, err
-		}
-		name, err := p.identifierText(nameTok)
+	// threshold clause (opt_select_with), BEFORE ALL/DISTINCT. Parsed by the
+	// parser-query-clauses node (differential_privacy.go); disambiguated from a
+	// column named via an inline WITH(...) expression by the `WITH <identifier>`
+	// (NOT `WITH (`) shape.
+	if p.atSelectWith() {
+		name, err := p.parseSelectWith()
 		if err != nil {
 			return nil, err
 		}
 		stmt.SelectWith = name
-		if p.cur.Type == kwOPTIONS {
-			p.advance()
-			if err := p.skipOptionsList(); err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	// ALL | DISTINCT set quantifier.

--- a/googlesql/parser/tablesample.go
+++ b/googlesql/parser/tablesample.go
@@ -1,0 +1,188 @@
+package parser
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// This file is part of the `parser-query-clauses` DAG node. It implements
+// GoogleSQL's TABLESAMPLE table-source operator (GoogleSQLParser.g4 §2.14
+// sample_clause / opt_sample_clause_suffix / sample_size / repeatable_clause),
+// a hand-port of Google's open-source ZetaSQL reference.
+//
+// TABLESAMPLE is the OUTERMOST table-source suffix: the grammar models it as
+// `table_primary sample_clause`, so it wraps a whole table_primary (which may
+// itself already carry a PIVOT/UNPIVOT and an `[AS] alias`). It therefore binds
+// AFTER everything else on the source, and takes NO trailing alias of its own
+// (oracle: `t TABLESAMPLE BERNOULLI (10 PERCENT) AS x` rejects;
+// `t PIVOT(...) TABLESAMPLE BERNOULLI (10 PERCENT)` accepts).
+//
+// DIALECT NOTE. TABLESAMPLE is a SHARED form — both BigQuery (TABLESAMPLE SYSTEM
+// (n PERCENT)) and Spanner (TABLESAMPLE {BERNOULLI|RESERVOIR} (n {PERCENT|ROWS}))
+// document it (truth1 QUERY-015 / QUERY-019), so the Spanner emulator oracle is
+// authoritative for it (both polarities). The sample method is a bare
+// identifier in the grammar, so omni accepts any method name (the union).
+
+// atTableSample reports whether the current token begins a TABLESAMPLE operator.
+func (p *Parser) atTableSample() bool {
+	return p.cur.Type == kwTABLESAMPLE
+}
+
+// parseTableSample parses a TABLESAMPLE operator (sample_clause):
+//
+//	TABLESAMPLE <method> ( <size> {PERCENT|ROWS} [PARTITION BY <expr>[, …]] )
+//	  [ <suffix> ]
+//
+// TABLESAMPLE is the current token. The method is a bare identifier (SYSTEM /
+// BERNOULLI / RESERVOIR — the grammar reads an `identifier`). The suffix is an
+// optional REPEATABLE(seed) or WITH WEIGHT [[AS] alias] [REPEATABLE(seed)]
+// (opt_sample_clause_suffix). Returns the populated *SampleClause.
+func (p *Parser) parseTableSample() (*ast.SampleClause, error) {
+	sampleTok := p.advance() // TABLESAMPLE
+	sc := &ast.SampleClause{Loc: sampleTok.Loc}
+
+	// Sampling method identifier.
+	methodTok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	method, err := p.identifierText(methodTok)
+	if err != nil {
+		return nil, err
+	}
+	sc.Method = method
+
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	// sample_size: sample_size_value sample_size_unit [PARTITION BY …].
+	// sample_size_value is the STRICT possibly_cast_int_literal_or_parameter |
+	// floating_point_literal — NOT a full expression: a bare identifier, an
+	// arithmetic expression, or a function call before the unit is a syntax error
+	// (oracle: `(1 + 1 ROWS)` / `(foo() ROWS)` / `(x ROWS)` all reject). This is
+	// the same sample_size_value the graph TABLESAMPLE uses, so reuse that helper.
+	size, err := p.parseGraphSampleSizeValue()
+	if err != nil {
+		return nil, err
+	}
+	sc.Size = size
+
+	// Unit: PERCENT | ROWS (required — oracle: `TABLESAMPLE BERNOULLI (10)`
+	// rejects with "Expected keyword PERCENT or keyword ROWS").
+	switch p.cur.Type {
+	case kwPERCENT:
+		p.advance()
+		sc.Unit = ast.SampleUnitPercent
+	case kwROWS:
+		p.advance()
+		sc.Unit = ast.SampleUnitRows
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	// Optional PARTITION BY <expr>[, …] inside the size clause
+	// (partition_by_clause_prefix_no_hint).
+	if p.cur.Type == kwPARTITION {
+		p.advance() // PARTITION
+		if _, err := p.expect(kwBY); err != nil {
+			return nil, err
+		}
+		for {
+			expr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			sc.PartitionBy = append(sc.PartitionBy, expr)
+			if p.cur.Type != int(',') {
+				break
+			}
+			p.advance() // ','
+		}
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	sc.Loc.End = closeTok.Loc.End
+
+	// Optional suffix (opt_sample_clause_suffix): REPEATABLE(seed) | WITH WEIGHT …
+	if err := p.parseSampleSuffix(sc); err != nil {
+		return nil, err
+	}
+	return sc, nil
+}
+
+// parseSampleSuffix parses the optional TABLESAMPLE suffix
+// (opt_sample_clause_suffix): either a bare REPEATABLE(seed), or
+// `WITH WEIGHT [[AS] alias] [REPEATABLE(seed)]`. The current token is just past
+// the size-clause ')'. A no-suffix position is a no-op.
+func (p *Parser) parseSampleSuffix(sc *ast.SampleClause) error {
+	switch p.cur.Type {
+	case kwREPEATABLE:
+		seed, err := p.parseRepeatableClause()
+		if err != nil {
+			return err
+		}
+		sc.Repeatable = seed
+		sc.Loc.End = p.prev.Loc.End
+	case kwWITH:
+		// WITH WEIGHT [identifier|AS identifier] [REPEATABLE(seed)].
+		p.advance() // WITH
+		if _, err := p.expect(kwWEIGHT); err != nil {
+			return err
+		}
+		sc.WithWeight = true
+		sc.Loc.End = p.prev.Loc.End
+		// Optional weight-column alias: `WEIGHT alias` or `WEIGHT AS alias`.
+		if p.cur.Type == kwAS {
+			p.advance()
+			aliasTok, err := p.expectIdentifier()
+			if err != nil {
+				return err
+			}
+			alias, err := p.identifierText(aliasTok)
+			if err != nil {
+				return err
+			}
+			sc.WeightAlias = alias
+			sc.Loc.End = p.prev.Loc.End
+		} else if isIdentifierStart(p.cur.Type) && p.cur.Type != kwREPEATABLE {
+			aliasTok := p.advance()
+			alias, err := p.identifierText(aliasTok)
+			if err != nil {
+				return err
+			}
+			sc.WeightAlias = alias
+			sc.Loc.End = p.prev.Loc.End
+		}
+		// Optional trailing REPEATABLE(seed).
+		if p.cur.Type == kwREPEATABLE {
+			seed, err := p.parseRepeatableClause()
+			if err != nil {
+				return err
+			}
+			sc.Repeatable = seed
+			sc.Loc.End = p.prev.Loc.End
+		}
+	}
+	return nil
+}
+
+// parseRepeatableClause parses `REPEATABLE ( <seed> )` (repeatable_clause). The
+// seed is a possibly-cast integer literal or parameter; we parse it as a general
+// expression (which subsumes CAST(...) and @param). REPEATABLE is the current
+// token. Returns the seed expression.
+func (p *Parser) parseRepeatableClause() (ast.Node, error) {
+	p.advance() // REPEATABLE
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	seed, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return seed, nil
+}


### PR DESCRIPTION
## What

Implements the `parser-query-clauses` node for the omni `googlesql` engine (one ZetaSQL-hand-port grammar serving bytebase **BigQuery + Spanner**): the FROM-clause table-source operators **PIVOT / UNPIVOT / TABLESAMPLE**, the SELECT-level **differential-privacy** clause, and **AT SYSTEM TIME** coverage.

### Grammar implemented (GoogleSQLParser.g4 §2.14 / §2.13)
- **PIVOT** (`pivot_unpivot.go`): aggregate list (`expr [AS] alias`), `FOR` input parsed at `expression_higher_prec_than_and` precedence (so the trailing `IN (...)` is the pivot value list, not an `x IN (...)` predicate), `IN` value list, trailing alias. Table alias before + pivot alias after both supported.
- **UNPIVOT**: `INCLUDE`/`EXCLUDE NULLS`, single- and parenthesized multi-column value lists, `FOR` name column, `IN`-item groups with optional `AS string|int` row-value aliases, trailing alias.
- **TABLESAMPLE** (`tablesample.go`): method identifier, **strict** `sample_size_value` (literal / cast-int / param / float — not an arbitrary expression), `PERCENT|ROWS` unit, `PARTITION BY`, and the `REPEATABLE` / `WITH WEIGHT [alias] [REPEATABLE]` suffix. Wraps the whole `table_primary` (binds *after* PIVOT/alias), takes no alias of its own.
- **Differential-privacy clause** (`differential_privacy.go`): `SELECT WITH <mechanism> [OPTIONS(...)]` — extracts `opt_select_with` from select.go; admits the over-reserved `DIFFERENTIAL_PRIVACY` keyword as the mechanism name.
- **AT SYSTEM TIME** (`FOR SYSTEM_TIME AS OF`) was already captured on `TableExpr` by parser-select; covered here by structural + differential tests.

### AST
New nodes `PivotClause` / `PivotExpr` / `UnpivotClause` / `UnpivotInItem` / `SampleClause`, plus `Pivot`/`Unpivot`/`Sample` fields on `TableExpr` and `UnnestExpr`; walker regenerated. FROM-clause wiring (`from_join.go`) hooks the operators into path / subquery / TVF / UNNEST sources and makes `atTableAliasStop` operator-aware (a bare `FROM t pivot` binds `pivot` as an implicit alias — PIVOT/UNPIVOT are non-reserved).

## Proof
- **Differential (`pivot_unpivot_oracle_test.go`, tag `googlesql_oracle`)**: runs against the live Cloud Spanner emulator in **both polarities** — 50+ fixtures. The emulator's ZetaSQL *parses* PIVOT/UNPIVOT/TABLESAMPLE (then feature-rejects), so it is authoritative for accept and reject. Hard syntax rejects (missing FOR, empty IN, missing unit, double pivot, trailing sample alias, non-literal sample size, comparison/NOT in FOR, bare multi-col UNPIVOT) all verified.
- **Unit (`pivot_unpivot_test.go`)**: AST-structure assertions + the BigQuery-only differential-privacy clause (emulator non-authoritative → triangulated against truth1/bigquery).
- `go test ./googlesql/...` green; full `googlesql_oracle` suite green (no parser-select regression); `go vet` + `gofmt` clean.

## Two-model review (Claude + Codex)
Codex (shared-runtime lens) caught three real issues — all fixed with permanent regression tests:
1. Stale-generated walker hole on `UnnestExpr` operators (regenerated).
2. TABLESAMPLE size over-accept (now uses the strict `sample_size_value` helper).
3. Implicit-alias over-reject for bare `t pivot` / `t unpivot` (`atTableAliasStop` made operator-aware).

Two further Codex findings were grammar misreads, **defended** with live-oracle evidence: the FOR-precedence band (emulator rejects `FOR a = b IN`/`FOR NOT f IN`) and the bare-multi-column UNPIVOT (emulator + BigQuery docs require parentheses; the looser legacy `.g4` is the outlier). The latter is recorded as divergence #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)