### PR TITLE
feat(snowflake): T7.1 Snowflake Scripting blocks (DECLARE/BEGIN..END/IF/CASE/FOR/WHILE/REPEAT/LOOP/RETURN/cursors) — structural parse

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -196,6 +196,32 @@ const (
 	T_SampleClause
 	T_TimeTravelClause
 	T_ChangesClause
+
+	// Snowflake Scripting (T7.1) — statement nodes plus the structural
+	// sub-nodes (declarations, IF/CASE branches, exception handlers). The
+	// sub-nodes are Nodes (unlike the CaseExpr/WhenClause precedent) so the
+	// generated walker descends into their nested bodies and queries, which an
+	// analysis pass needs to reach.
+	T_ScriptDeclaration
+	T_ScriptExceptionHandler
+	T_ScriptIfBranch
+	T_ScriptCaseWhen
+	T_ScriptBlockStmt
+	T_ScriptAssignStmt
+	T_ScriptLetStmt
+	T_ScriptIfStmt
+	T_ScriptCaseStmt
+	T_ScriptForStmt
+	T_ScriptWhileStmt
+	T_ScriptRepeatStmt
+	T_ScriptLoopStmt
+	T_ScriptBreakStmt
+	T_ScriptContinueStmt
+	T_ScriptReturnStmt
+	T_ScriptOpenStmt
+	T_ScriptFetchStmt
+	T_ScriptCloseStmt
+	T_ScriptRaiseStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -479,6 +505,46 @@ func (t NodeTag) String() string {
 		return "TimeTravelClause"
 	case T_ChangesClause:
 		return "ChangesClause"
+	case T_ScriptDeclaration:
+		return "ScriptDeclaration"
+	case T_ScriptExceptionHandler:
+		return "ScriptExceptionHandler"
+	case T_ScriptIfBranch:
+		return "ScriptIfBranch"
+	case T_ScriptCaseWhen:
+		return "ScriptCaseWhen"
+	case T_ScriptBlockStmt:
+		return "ScriptBlockStmt"
+	case T_ScriptAssignStmt:
+		return "ScriptAssignStmt"
+	case T_ScriptLetStmt:
+		return "ScriptLetStmt"
+	case T_ScriptIfStmt:
+		return "ScriptIfStmt"
+	case T_ScriptCaseStmt:
+		return "ScriptCaseStmt"
+	case T_ScriptForStmt:
+		return "ScriptForStmt"
+	case T_ScriptWhileStmt:
+		return "ScriptWhileStmt"
+	case T_ScriptRepeatStmt:
+		return "ScriptRepeatStmt"
+	case T_ScriptLoopStmt:
+		return "ScriptLoopStmt"
+	case T_ScriptBreakStmt:
+		return "ScriptBreakStmt"
+	case T_ScriptContinueStmt:
+		return "ScriptContinueStmt"
+	case T_ScriptReturnStmt:
+		return "ScriptReturnStmt"
+	case T_ScriptOpenStmt:
+		return "ScriptOpenStmt"
+	case T_ScriptFetchStmt:
+		return "ScriptFetchStmt"
+	case T_ScriptCloseStmt:
+		return "ScriptCloseStmt"
+	case T_ScriptRaiseStmt:
+		return "ScriptRaiseStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -5124,3 +5124,344 @@ var (
 	_ Node = (*ExecuteTaskStmt)(nil)
 	_ Node = (*ExplainStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// Snowflake Scripting (T7.1)
+//
+// A Snowflake Scripting block is a structured procedural body that may appear
+// as a top-level statement (an anonymous block) or as the body of a CREATE
+// PROCEDURE / TASK. These nodes model the body STRUCTURALLY: the block, its
+// declarations, its statements, and the control-flow constructs (IF / CASE /
+// FOR / WHILE / REPEAT / LOOP / cursors / exceptions). Expressions and nested
+// SQL are parsed by the engine's existing parseExpr / parseStmt machinery.
+//
+// Grammar (Snowflake Scripting reference; docs are authoritative — the legacy
+// SnowflakeParser.g4 modeled only a thin subset: BEGIN..END, a DECLARE list of
+// `id data_type`, `id := expr`, and `RETURN expr`):
+//
+//	[ DECLARE <declaration>; [ <declaration>; ... ] ]
+//	BEGIN
+//	    <statement>; [ <statement>; ... ]
+//	[ EXCEPTION <handler> ... ]
+//	END [ <label> ] ;
+//
+// Walker note: the structural sub-nodes (ScriptDeclaration, ScriptIfBranch,
+// ScriptCaseWhen, ScriptExceptionHandler) ARE Nodes and are held in []Node
+// slices, so the generated walker descends into the nested bodies and queries
+// they carry. (This deviates from the CaseExpr/WhenClause precedent, whose WHEN
+// bodies are unreachable — a gap an analysis pass over scripting must not have.)
+// ---------------------------------------------------------------------------
+
+// ScriptDeclKind classifies a single entry in a DECLARE section.
+type ScriptDeclKind int
+
+const (
+	// ScriptDeclVar is `<name> [<type>] [ { DEFAULT | := } <expr> ]`.
+	ScriptDeclVar ScriptDeclKind = iota
+	// ScriptDeclCursor is `<name> CURSOR FOR <query>`.
+	ScriptDeclCursor
+	// ScriptDeclResultset is `<name> RESULTSET [ { DEFAULT | := } [ ASYNC ] ( <query> ) ]`.
+	ScriptDeclResultset
+	// ScriptDeclException is `<name> EXCEPTION [ ( <number>, '<message>' ) ]`.
+	ScriptDeclException
+)
+
+// ScriptDeclaration is one entry in a DECLARE section. The active fields depend
+// on Kind:
+//
+//	ScriptDeclVar       — Name, optional Type, optional Default (the := / DEFAULT value)
+//	ScriptDeclCursor    — Name, Query (the SELECT after CURSOR FOR)
+//	ScriptDeclResultset — Name, optional Query (the ( <query> ) after := / DEFAULT), Async
+//	ScriptDeclException — Name, optional ExcArgs (the ( number, 'message' ) expr list)
+type ScriptDeclaration struct {
+	Kind    ScriptDeclKind
+	Name    Ident
+	Type    *TypeName // ScriptDeclVar only; nil when the type is inferred from the value
+	Default Node      // ScriptDeclVar value (DEFAULT / := expr); nil if none
+	Query   Node      // ScriptDeclCursor query; ScriptDeclResultset query; nil otherwise
+	Async   bool      // ScriptDeclResultset: the ASYNC modifier was present
+	ExcArgs []Node    // ScriptDeclException ( number, 'message' ) args; nil if none
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *ScriptDeclaration) Tag() NodeTag { return T_ScriptDeclaration }
+
+// ScriptBlockStmt represents a Snowflake Scripting block:
+//
+//	[ DECLARE <decls> ] BEGIN <stmts> [ EXCEPTION <handlers> ] END [ <label> ]
+//
+// Decls is nil when there is no DECLARE section (elements are
+// *ScriptDeclaration). Handlers is nil when there is no EXCEPTION section
+// (elements are *ScriptExceptionHandler). Label is the zero Ident when END
+// carries no label.
+type ScriptBlockStmt struct {
+	Decls    []Node // *ScriptDeclaration entries
+	Body     []Node // BEGIN ... statements
+	Handlers []Node // *ScriptExceptionHandler entries
+	Label    Ident  // optional label after END; zero Ident when absent
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *ScriptBlockStmt) Tag() NodeTag { return T_ScriptBlockStmt }
+
+// ScriptExceptionHandler is one WHEN clause in an EXCEPTION section:
+//
+//	WHEN <exc_name> [ OR <exc_name> ... ] THEN <stmts>
+//	WHEN OTHER THEN <stmts>
+//
+// Other is true for the `WHEN OTHER` catch-all (in which case Names is nil).
+type ScriptExceptionHandler struct {
+	Names []Ident // exception names (OR-separated); nil when Other is true
+	Other bool    // WHEN OTHER catch-all
+	Body  []Node  // statements after THEN
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptExceptionHandler) Tag() NodeTag { return T_ScriptExceptionHandler }
+
+// ScriptAssignStmt represents a scripting assignment `<var> := <expr>`. The
+// target may be a qualified name (e.g. a RESULTSET) but is captured as a plain
+// Ident path component; only single-identifier targets occur in practice.
+type ScriptAssignStmt struct {
+	Target Ident
+	Value  Node
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ScriptAssignStmt) Tag() NodeTag { return T_ScriptAssignStmt }
+
+// ScriptLetStmt represents a LET declaration-statement inside a block:
+//
+//	LET <var> [ <type> ] { DEFAULT | := } <expr>
+//	LET <cursor> CURSOR FOR <query>
+//	LET <resultset> RESULTSET { DEFAULT | := } [ ASYNC ] ( <query> )
+//
+// Kind reuses ScriptDeclKind (LET cannot declare an EXCEPTION; only Var /
+// Cursor / Resultset are valid). The active fields mirror ScriptDeclaration.
+type ScriptLetStmt struct {
+	Kind    ScriptDeclKind
+	Name    Ident
+	Type    *TypeName // Var only; nil when inferred
+	Default Node      // Var value; nil if none (a LET var always has a value, but kept Node-typed)
+	Query   Node      // Cursor / Resultset query
+	Async   bool      // Resultset ASYNC
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *ScriptLetStmt) Tag() NodeTag { return T_ScriptLetStmt }
+
+// ScriptIfBranch is one IF / ELSEIF arm: a condition plus its THEN body.
+type ScriptIfBranch struct {
+	Cond Node
+	Body []Node
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ScriptIfBranch) Tag() NodeTag { return T_ScriptIfBranch }
+
+// ScriptIfStmt represents an IF statement:
+//
+//	IF ( <cond> ) THEN <stmts>
+//	[ ELSEIF ( <cond> ) THEN <stmts> ]*
+//	[ ELSE <stmts> ]
+//	END IF
+//
+// Branches holds the leading IF arm followed by each ELSEIF arm (in order;
+// elements are *ScriptIfBranch). Else holds the optional ELSE body (nil when
+// absent).
+type ScriptIfStmt struct {
+	Branches []Node // *ScriptIfBranch entries
+	Else     []Node
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *ScriptIfStmt) Tag() NodeTag { return T_ScriptIfStmt }
+
+// ScriptCaseWhen is one WHEN arm of a CASE statement: a match/condition
+// expression plus its THEN body.
+type ScriptCaseWhen struct {
+	Match Node // simple form: value to compare; searched form: boolean condition
+	Body  []Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptCaseWhen) Tag() NodeTag { return T_ScriptCaseWhen }
+
+// ScriptCaseStmt represents a CASE statement (simple or searched):
+//
+//	CASE [ ( <operand> ) ] WHEN <expr> THEN <stmts> [ WHEN ... ]* [ ELSE <stmts> ] END [ CASE ]
+//
+// Operand is non-nil for the simple form (CASE <expr> WHEN ...) and nil for the
+// searched form (CASE WHEN <cond> ...). Whens elements are *ScriptCaseWhen.
+// Else holds the optional ELSE body.
+type ScriptCaseStmt struct {
+	Operand Node   // nil for searched form
+	Whens   []Node // *ScriptCaseWhen entries
+	Else    []Node
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *ScriptCaseStmt) Tag() NodeTag { return T_ScriptCaseStmt }
+
+// ScriptForKind distinguishes the counter and cursor/resultset FOR forms.
+type ScriptForKind int
+
+const (
+	// ScriptForCounter is `FOR <var> IN [ REVERSE ] <start> TO <end> { DO | LOOP } ... END { FOR | LOOP }`.
+	ScriptForCounter ScriptForKind = iota
+	// ScriptForCursor is `FOR <row> IN { <cursor> | <resultset> } DO ... END FOR`.
+	ScriptForCursor
+)
+
+// ScriptForStmt represents a FOR loop in either form.
+//
+// Counter form fields: Var, Reverse, Start, End.
+// Cursor form fields:  Var, Source (the cursor / resultset name).
+type ScriptForStmt struct {
+	Kind    ScriptForKind
+	Var     Ident
+	Reverse bool  // counter form: the REVERSE modifier
+	Start   Node  // counter form: lower bound
+	End     Node  // counter form: upper bound
+	Source  Ident // cursor form: the cursor / resultset name
+	Body    []Node
+	Label   Ident // optional label after END; zero Ident when absent
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *ScriptForStmt) Tag() NodeTag { return T_ScriptForStmt }
+
+// ScriptWhileStmt represents `WHILE ( <cond> ) { DO | LOOP } ... END { WHILE | LOOP } [ <label> ]`.
+type ScriptWhileStmt struct {
+	Cond  Node
+	Body  []Node
+	Label Ident // optional label after END; zero Ident when absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptWhileStmt) Tag() NodeTag { return T_ScriptWhileStmt }
+
+// ScriptRepeatStmt represents `REPEAT ... UNTIL ( <cond> ) END REPEAT [ <label> ]`.
+type ScriptRepeatStmt struct {
+	Body  []Node
+	Cond  Node  // the UNTIL condition
+	Label Ident // optional label after END; zero Ident when absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptRepeatStmt) Tag() NodeTag { return T_ScriptRepeatStmt }
+
+// ScriptLoopStmt represents `LOOP ... END LOOP [ <label> ]`.
+type ScriptLoopStmt struct {
+	Body  []Node
+	Label Ident // optional label after END; zero Ident when absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptLoopStmt) Tag() NodeTag { return T_ScriptLoopStmt }
+
+// ScriptBreakStmt represents `BREAK [ <label> ]` (alias EXIT). Label is the
+// zero Ident when no label follows.
+type ScriptBreakStmt struct {
+	Label Ident
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptBreakStmt) Tag() NodeTag { return T_ScriptBreakStmt }
+
+// ScriptContinueStmt represents `CONTINUE [ <label> ]` (alias ITERATE). Label
+// is the zero Ident when no label follows.
+type ScriptContinueStmt struct {
+	Label Ident
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptContinueStmt) Tag() NodeTag { return T_ScriptContinueStmt }
+
+// ScriptReturnStmt represents `RETURN [ <expr> ]`. Value is nil for a bare
+// RETURN.
+type ScriptReturnStmt struct {
+	Value Node
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ScriptReturnStmt) Tag() NodeTag { return T_ScriptReturnStmt }
+
+// ScriptOpenStmt represents `OPEN <cursor> [ USING ( <bind> [ , ... ] ) ]`.
+type ScriptOpenStmt struct {
+	Cursor Ident
+	Using  []Node // optional USING ( ... ) bind expressions; nil when absent
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ScriptOpenStmt) Tag() NodeTag { return T_ScriptOpenStmt }
+
+// ScriptFetchStmt represents `FETCH <cursor> INTO <var> [ , ... ]`.
+type ScriptFetchStmt struct {
+	Cursor Ident
+	Into   []Ident // target variables
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ScriptFetchStmt) Tag() NodeTag { return T_ScriptFetchStmt }
+
+// ScriptCloseStmt represents `CLOSE <cursor>`.
+type ScriptCloseStmt struct {
+	Cursor Ident
+	Loc    Loc
+}
+
+// Tag implements Node.
+func (n *ScriptCloseStmt) Tag() NodeTag { return T_ScriptCloseStmt }
+
+// ScriptRaiseStmt represents `RAISE [ <exc_name> ]`. Name is the zero Ident for
+// a bare `RAISE` (re-raise the current exception inside a handler).
+type ScriptRaiseStmt struct {
+	Name Ident
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ScriptRaiseStmt) Tag() NodeTag { return T_ScriptRaiseStmt }
+
+// Compile-time assertions for Snowflake Scripting nodes (T7.1).
+var (
+	_ Node = (*ScriptDeclaration)(nil)
+	_ Node = (*ScriptExceptionHandler)(nil)
+	_ Node = (*ScriptIfBranch)(nil)
+	_ Node = (*ScriptCaseWhen)(nil)
+	_ Node = (*ScriptBlockStmt)(nil)
+	_ Node = (*ScriptAssignStmt)(nil)
+	_ Node = (*ScriptLetStmt)(nil)
+	_ Node = (*ScriptIfStmt)(nil)
+	_ Node = (*ScriptCaseStmt)(nil)
+	_ Node = (*ScriptForStmt)(nil)
+	_ Node = (*ScriptWhileStmt)(nil)
+	_ Node = (*ScriptRepeatStmt)(nil)
+	_ Node = (*ScriptLoopStmt)(nil)
+	_ Node = (*ScriptBreakStmt)(nil)
+	_ Node = (*ScriptContinueStmt)(nil)
+	_ Node = (*ScriptReturnStmt)(nil)
+	_ Node = (*ScriptOpenStmt)(nil)
+	_ Node = (*ScriptFetchStmt)(nil)
+	_ Node = (*ScriptCloseStmt)(nil)
+	_ Node = (*ScriptRaiseStmt)(nil)
+)

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -576,6 +576,56 @@ func walkChildren(v Visitor, node Node) {
 	case *SampleClause:
 		Walk(v, n.Quantity)
 		Walk(v, n.Seed)
+	case *ScriptAssignStmt:
+		Walk(v, n.Value)
+	case *ScriptBlockStmt:
+		walkNodes(v, n.Decls)
+		walkNodes(v, n.Body)
+		walkNodes(v, n.Handlers)
+	case *ScriptCaseStmt:
+		Walk(v, n.Operand)
+		walkNodes(v, n.Whens)
+		walkNodes(v, n.Else)
+	case *ScriptCaseWhen:
+		Walk(v, n.Match)
+		walkNodes(v, n.Body)
+	case *ScriptDeclaration:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		Walk(v, n.Default)
+		Walk(v, n.Query)
+		walkNodes(v, n.ExcArgs)
+	case *ScriptExceptionHandler:
+		walkNodes(v, n.Body)
+	case *ScriptForStmt:
+		Walk(v, n.Start)
+		Walk(v, n.End)
+		walkNodes(v, n.Body)
+	case *ScriptIfBranch:
+		Walk(v, n.Cond)
+		walkNodes(v, n.Body)
+	case *ScriptIfStmt:
+		walkNodes(v, n.Branches)
+		walkNodes(v, n.Else)
+	case *ScriptLetStmt:
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		Walk(v, n.Default)
+		Walk(v, n.Query)
+	case *ScriptLoopStmt:
+		walkNodes(v, n.Body)
+	case *ScriptOpenStmt:
+		walkNodes(v, n.Using)
+	case *ScriptRepeatStmt:
+		walkNodes(v, n.Body)
+		Walk(v, n.Cond)
+	case *ScriptReturnStmt:
+		Walk(v, n.Value)
+	case *ScriptWhileStmt:
+		Walk(v, n.Cond)
+		walkNodes(v, n.Body)
 	case *SelectStmt:
 		Walk(v, n.Top)
 		walkNodes(v, n.From)

--- a/snowflake/parser/keywords.go
+++ b/snowflake/parser/keywords.go
@@ -1032,4 +1032,26 @@ var keywordMap = map[string]int{
 	"yearly":                                   kwYEARLY,
 	"zstd":                                     kwZSTD,
 	// KEYWORD_MAP_END
+
+	// Snowflake Scripting keywords (T7.1). Not present in SnowflakeLexer.g4's
+	// generated set; all NON-RESERVED (absent from keywordReserved), so they
+	// remain usable as ordinary identifiers via parseIdent / isIdentToken.
+	"while":     kwSCRIPT_WHILE,
+	"loop":      kwSCRIPT_LOOP,
+	"repeat":    kwSCRIPT_REPEAT,
+	"until":     kwSCRIPT_UNTIL,
+	"let":       kwSCRIPT_LET,
+	"break":     kwSCRIPT_BREAK,
+	"exception": kwSCRIPT_EXCEPTION,
+	"raise":     kwSCRIPT_RAISE,
+	"cursor":    kwSCRIPT_CURSOR,
+	"resultset": kwSCRIPT_RESULTSET,
+	"reverse":   kwSCRIPT_REVERSE,
+	"async":     kwSCRIPT_ASYNC,
+	"other":     kwSCRIPT_OTHER,
+	"exit":      kwSCRIPT_EXIT,
+	"iterate":   kwSCRIPT_ITERATE,
+	"open":      kwSCRIPT_OPEN,
+	"close":     kwSCRIPT_CLOSE,
+	"elseif":    kwSCRIPT_ELSEIF,
 }

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -36,6 +36,11 @@ type Parser struct {
 	// PRIOR on this flag avoids mis-parsing a column literally named "prior"
 	// in ordinary expression positions.
 	inConnectBy bool
+	// scriptDepth bounds Snowflake Scripting block / control-flow nesting
+	// (T7.1). It is incremented on entry to every nested scripting construct and
+	// checked against maxScriptDepth so a pathologically deep (or adversarial)
+	// body cannot blow the Go stack. See scripting.go.
+	scriptDepth int
 }
 
 // advance consumes the current token and moves to the next one.
@@ -257,7 +262,15 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 
 	// TCL (4 cases)
 	case kwBEGIN:
-		return p.parseBeginStmt()
+		// BEGIN is overloaded: a TCL transaction opener
+		// (BEGIN [WORK|TRANSACTION] [NAME ...]) versus a Snowflake Scripting
+		// block (BEGIN <stmts> [EXCEPTION ...] END). Disambiguate on the token
+		// after BEGIN: WORK / TRANSACTION / NAME / ; / EOF → TCL; anything else
+		// opens a scripting block. See beginIsTransaction.
+		if p.beginIsTransaction() {
+			return p.parseBeginStmt()
+		}
+		return p.parseScriptBlock()
 	case kwSTART:
 		return p.parseStartTransactionStmt()
 	case kwCOMMIT:
@@ -283,19 +296,19 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwUNSET:
 		return p.parseUnsetStmt()
 
-	// Snowflake Scripting (subset available as F2 keywords — 6 cases)
+	// Snowflake Scripting (T7.1). A top-level DECLARE opens a scripting block
+	// (DECLARE <decls> BEGIN <stmts> ... END). The remaining scripting
+	// keywords introduce individual scripting statements; Snowflake itself
+	// only accepts them inside a block, but omni parses them structurally at
+	// the top level too (a lenient superset, flagged in the divergence ledger)
+	// so best-effort parsing of partial / extracted bodies still yields an AST.
 	case kwDECLARE:
-		return p.unsupported("DECLARE")
-	case kwIF:
-		return p.unsupported("IF")
-	case kwCASE:
-		return p.unsupported("CASE")
-	case kwFOR:
-		return p.unsupported("FOR")
-	case kwRETURN:
-		return p.unsupported("RETURN")
-	case kwCONTINUE:
-		return p.unsupported("CONTINUE")
+		return p.parseScriptBlock()
+	case kwIF, kwCASE, kwFOR, kwRETURN, kwCONTINUE,
+		kwSCRIPT_WHILE, kwSCRIPT_LOOP, kwSCRIPT_REPEAT, kwSCRIPT_LET,
+		kwSCRIPT_BREAK, kwSCRIPT_EXIT, kwSCRIPT_ITERATE, kwSCRIPT_RAISE,
+		kwSCRIPT_OPEN, kwSCRIPT_CLOSE, kwFETCH:
+		return p.parseScriptStatement()
 
 	default:
 		// LS and RM are the documented aliases of LIST and REMOVE. EXECUTE

--- a/snowflake/parser/parser_test.go
+++ b/snowflake/parser/parser_test.go
@@ -136,12 +136,11 @@ func TestParse_BeginEndBlockOneSegment(t *testing.T) {
 	// BEGIN..END scripting blocks and does not split on the inner ';'), so
 	// parseSingle sees the whole block as one statement starting with BEGIN.
 	//
-	// As of T6.2, BEGIN is a real transaction-control statement: parseBeginStmt
-	// consumes the leading BEGIN and produces a *ast.BeginStmt. The remaining
-	// "SELECT 1; END" tail is left unconsumed without error (the engine-wide
-	// trailing-token convention shared with DROP/TRUNCATE/USE). Full Snowflake
-	// Scripting BEGIN..END block parsing is a separate Tier 7 feature; until it
-	// lands, a script block opener is captured as a bare BeginStmt.
+	// As of T7.1 (Snowflake Scripting), a BEGIN not followed by a TCL modifier
+	// (WORK / TRANSACTION / NAME / ; / EOF) opens a scripting BLOCK rather than
+	// a transaction. "BEGIN SELECT 1; END;" therefore parses to a
+	// *ast.ScriptBlockStmt whose single body statement is the SELECT. (The TCL
+	// BEGIN forms remain BeginStmt — see the transaction tests.)
 	result := ParseBestEffort("BEGIN SELECT 1; END;")
 	if len(result.Errors) != 0 {
 		t.Fatalf("error count = %d, want 0: %+v", len(result.Errors), result.Errors)
@@ -149,12 +148,18 @@ func TestParse_BeginEndBlockOneSegment(t *testing.T) {
 	if len(result.File.Stmts) != 1 {
 		t.Fatalf("stmt count = %d, want 1", len(result.File.Stmts))
 	}
-	begin, ok := result.File.Stmts[0].(*ast.BeginStmt)
+	block, ok := result.File.Stmts[0].(*ast.ScriptBlockStmt)
 	if !ok {
-		t.Fatalf("stmt[0] = %T, want *ast.BeginStmt", result.File.Stmts[0])
+		t.Fatalf("stmt[0] = %T, want *ast.ScriptBlockStmt", result.File.Stmts[0])
 	}
-	if begin.Kind != ast.BeginBare {
-		t.Errorf("kind = %v, want BeginBare", begin.Kind)
+	if len(block.Decls) != 0 {
+		t.Errorf("decls = %d, want 0 (no DECLARE section)", len(block.Decls))
+	}
+	if len(block.Body) != 1 {
+		t.Fatalf("body stmt count = %d, want 1", len(block.Body))
+	}
+	if _, ok := block.Body[0].(*ast.SelectStmt); !ok {
+		t.Errorf("body[0] = %T, want *ast.SelectStmt", block.Body[0])
 	}
 }
 

--- a/snowflake/parser/scripting.go
+++ b/snowflake/parser/scripting.go
@@ -1,0 +1,1209 @@
+package parser
+
+import "github.com/bytebase/omni/snowflake/ast"
+
+// ---------------------------------------------------------------------------
+// Snowflake Scripting (T7.1) — STRUCTURAL parser
+//
+// A Snowflake Scripting block is a structured procedural body:
+//
+//	[ DECLARE <declaration>; ... ] BEGIN <statement>; ... [ EXCEPTION <handler> ... ] END [ <label> ]
+//
+// The body is parsed STRUCTURALLY (control flow, declarations, cursors,
+// exceptions) but NOT semantically — expressions and nested SQL reuse the
+// engine's existing parseExpr / parseStmt. The grammar follows the Snowflake
+// Scripting reference (docs are authoritative); the legacy SnowflakeParser.g4
+// modeled only a thin subset (BEGIN..END, a DECLARE list of `id data_type`,
+// `id := expr`, RETURN expr), so this node deliberately exceeds it (recorded as
+// a divergence: omni now parses the full scripting surface, legacy ANTLR did
+// not).
+//
+// ---------------------------------------------------------------------------
+// Non-termination safety (this is the highest loop-risk node)
+//
+// Scripting bodies nest arbitrarily (blocks within IF within FOR within ...).
+// Two structural guards make an infinite loop impossible:
+//
+//  1. Depth bound. scriptDepth is incremented on entry to every nested
+//     construct and checked against maxScriptDepth; exceeding it returns a
+//     ParseError rather than recursing further. This caps stack growth.
+//
+//  2. Per-iteration progress. Every statement-list / declaration-list loop
+//     records p.cur.Loc.Start before parsing an item and, on a successful
+//     parse that did NOT advance the token (a structurally-impossible-to-make
+//     case, guarded defensively), returns a ParseError. Each loop also treats
+//     tokEOF as an unconditional terminator: a list that reaches EOF before its
+//     closing keyword (END / END IF / END FOR / ...) yields a "unterminated"
+//     ParseError. Together these guarantee every loop both advances and is
+//     bounded, so a malformed (e.g. never-closed) block fails fast instead of
+//     hanging.
+// ---------------------------------------------------------------------------
+
+// maxScriptDepth bounds Snowflake Scripting nesting. Real scripts nest only a
+// handful of levels deep; this generous ceiling exists solely to fail fast on
+// adversarial / corrupt input rather than recurse until the Go stack overflows.
+const maxScriptDepth = 200
+
+// errScriptTooDeep is returned when scriptDepth exceeds maxScriptDepth.
+func (p *Parser) errScriptTooDeep() *ParseError {
+	return &ParseError{Loc: p.cur.Loc, Msg: "snowflake scripting block nested too deeply"}
+}
+
+// enterScript increments the nesting depth and reports whether the new depth is
+// within bounds. Callers must pair a true result with a deferred leaveScript.
+func (p *Parser) enterScript() bool {
+	p.scriptDepth++
+	return p.scriptDepth <= maxScriptDepth
+}
+
+func (p *Parser) leaveScript() { p.scriptDepth-- }
+
+// beginIsTransaction reports whether a BEGIN at the current position opens a
+// TCL transaction (BEGIN [WORK|TRANSACTION] [NAME ...]) rather than a Snowflake
+// Scripting block. cur must be the BEGIN keyword. The decision is made on the
+// token AFTER BEGIN: WORK / TRANSACTION / NAME, or a statement boundary
+// (`;` / EOF), means TCL; anything else (a statement opener) means a scripting
+// block. This keeps every documented TCL BEGIN form working while routing a
+// `BEGIN <statement> ... END` body to the scripting parser.
+func (p *Parser) beginIsTransaction() bool {
+	switch p.peekNext().Type {
+	case kwWORK, kwTRANSACTION, kwNAME, ';', tokEOF:
+		return true
+	default:
+		return false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Block
+// ---------------------------------------------------------------------------
+
+// parseScriptBlock parses a Snowflake Scripting block. cur is either DECLARE or
+// BEGIN (already known to open a block, not a TCL BEGIN):
+//
+//	[ DECLARE <declaration>; ... ] BEGIN <statement>; ... [ EXCEPTION <handler> ... ] END [ <label> ]
+func (p *Parser) parseScriptBlock() (ast.Node, error) {
+	if !p.enterScript() {
+		return nil, p.errScriptTooDeep()
+	}
+	defer p.leaveScript()
+
+	start := p.cur.Loc.Start
+	stmt := &ast.ScriptBlockStmt{Loc: ast.Loc{Start: start}}
+
+	// Optional DECLARE section.
+	if p.cur.Type == kwDECLARE {
+		p.advance() // consume DECLARE
+		decls, err := p.parseScriptDeclarationList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Decls = decls
+	}
+
+	// BEGIN <statement_list>.
+	if _, err := p.expect(kwBEGIN); err != nil {
+		return nil, err
+	}
+	body, err := p.parseScriptStatementList(kwEND, kwSCRIPT_EXCEPTION)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	// Optional EXCEPTION section.
+	if p.cur.Type == kwSCRIPT_EXCEPTION {
+		p.advance() // consume EXCEPTION
+		handlers, err := p.parseScriptExceptionHandlers()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Handlers = handlers
+	}
+
+	// END [ <label> ].
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// tryParseScriptLabel consumes an optional trailing block/loop label after an
+// END (or END FOR / END LOOP / ...) and reports whether one was present.
+//
+// A label is accepted ONLY as a bare or quoted identifier (tokIdent /
+// tokQuotedIdent) — NOT as a non-reserved keyword. This is deliberate: keyword
+// tokens are not valid labels (a user label that happens to collide with a
+// keyword must be quoted), and accepting them would let a structural keyword be
+// swallowed as a label. In particular, in a nested block `BEGIN BEGIN ... END
+// END` (no `;` between the inner and outer END) the inner block's
+// tryParseScriptLabel must NOT consume the outer END (a non-reserved keyword)
+// as a label, which would leave the outer block unterminated.
+func (p *Parser) tryParseScriptLabel() (ast.Ident, bool) {
+	switch p.cur.Type {
+	case tokIdent, tokQuotedIdent:
+		tok := p.advance()
+		return ast.Ident{Name: tok.Str, Quoted: tok.Type == tokQuotedIdent, Loc: tok.Loc}, true
+	default:
+		return ast.Ident{}, false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DECLARE section
+// ---------------------------------------------------------------------------
+
+// parseScriptDeclarationList parses one or more declarations, each terminated
+// by a semicolon, stopping at BEGIN:
+//
+//	<declaration>; [ <declaration>; ... ] BEGIN
+//
+// Per the docs every declaration (including the last) is `;`-terminated.
+func (p *Parser) parseScriptDeclarationList() ([]ast.Node, error) {
+	var decls []ast.Node
+	for p.cur.Type != kwBEGIN {
+		if p.cur.Type == tokEOF {
+			return nil, p.unterminated("DECLARE section (expected BEGIN)")
+		}
+		startPos := p.cur.Loc.Start
+
+		decl, err := p.parseScriptDeclaration()
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, decl)
+
+		// Each declaration must be terminated by ';'.
+		if _, err := p.expect(';'); err != nil {
+			return nil, err
+		}
+
+		if p.cur.Loc.Start == startPos {
+			// Defensive: a declaration that consumed nothing would loop forever.
+			return nil, p.noProgress("DECLARE section")
+		}
+	}
+	return decls, nil
+}
+
+// parseScriptDeclaration parses one DECLARE entry. The form is selected by the
+// token that follows the declared name:
+//
+//	<name> CURSOR FOR <query>
+//	<name> RESULTSET [ { DEFAULT | := } [ ASYNC ] ( <query> ) ]
+//	<name> EXCEPTION [ ( <number>, '<message>' ) ]
+//	<name> [ <type> ] [ { DEFAULT | := } <expr> ]      (variable; type optional)
+func (p *Parser) parseScriptDeclaration() (*ast.ScriptDeclaration, error) {
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	decl := &ast.ScriptDeclaration{Name: name, Loc: ast.Loc{Start: name.Loc.Start, End: name.Loc.End}}
+
+	switch p.cur.Type {
+	case kwSCRIPT_CURSOR:
+		p.advance() // consume CURSOR
+		if _, err := p.expect(kwFOR); err != nil {
+			return nil, err
+		}
+		q, err := p.parseScriptQuery()
+		if err != nil {
+			return nil, err
+		}
+		decl.Kind = ast.ScriptDeclCursor
+		decl.Query = q
+		decl.Loc.End = ast.NodeLoc(q).End
+
+	case kwSCRIPT_RESULTSET:
+		p.advance() // consume RESULTSET
+		decl.Kind = ast.ScriptDeclResultset
+		// Optional { DEFAULT | := } [ ASYNC ] ( <query> ).
+		if p.tryParseAssignOp() {
+			async, q, end, err := p.parseResultsetValue()
+			if err != nil {
+				return nil, err
+			}
+			decl.Async = async
+			decl.Query = q
+			decl.Loc.End = end
+		} else {
+			decl.Loc.End = p.prev.Loc.End
+		}
+
+	case kwSCRIPT_EXCEPTION:
+		p.advance() // consume EXCEPTION
+		decl.Kind = ast.ScriptDeclException
+		// Optional ( <number>, '<message>' ).
+		if p.cur.Type == '(' {
+			args, end, err := p.parseScriptParenExprList()
+			if err != nil {
+				return nil, err
+			}
+			decl.ExcArgs = args
+			decl.Loc.End = end
+		} else {
+			decl.Loc.End = p.prev.Loc.End
+		}
+
+	default:
+		// Variable: <name> [ <type> ] [ { DEFAULT | := } <expr> ]. The type is
+		// optional only when a value follows (inferred); a bare `<name>;` with
+		// neither type nor value is not a valid declaration, but the assignment
+		// operator below is checked first so `<name> := <expr>` works typeless.
+		decl.Kind = ast.ScriptDeclVar
+		if !p.startsAssignOp() {
+			typ, err := p.parseDataType()
+			if err != nil {
+				return nil, err
+			}
+			decl.Type = typ
+			decl.Loc.End = typ.Loc.End
+		}
+		if p.tryParseAssignOp() {
+			val, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			decl.Default = val
+			decl.Loc.End = ast.NodeLoc(val).End
+		}
+	}
+
+	return decl, nil
+}
+
+// parseResultsetValue parses the value tail of a RESULTSET, after the
+// `{ DEFAULT | := }` operator has been consumed:
+//
+//	[ ASYNC ] ( <query> )
+//
+// Returns whether ASYNC was present, the query node, and the end offset.
+func (p *Parser) parseResultsetValue() (async bool, query ast.Node, end int, err error) {
+	if p.cur.Type == kwSCRIPT_ASYNC {
+		p.advance() // consume ASYNC
+		async = true
+	}
+	if _, err := p.expect('('); err != nil {
+		return false, nil, 0, err
+	}
+	q, err := p.parseScriptQuery()
+	if err != nil {
+		return false, nil, 0, err
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return false, nil, 0, err
+	}
+	return async, q, closeTok.Loc.End, nil
+}
+
+// ---------------------------------------------------------------------------
+// EXCEPTION section
+// ---------------------------------------------------------------------------
+
+// parseScriptExceptionHandlers parses one or more WHEN handlers, stopping at
+// END:
+//
+//	WHEN <exc_name> [ OR <exc_name> ... ] THEN <stmts>
+//	WHEN OTHER THEN <stmts>
+func (p *Parser) parseScriptExceptionHandlers() ([]ast.Node, error) {
+	var handlers []ast.Node
+	for p.cur.Type == kwWHEN {
+		startPos := p.cur.Loc.Start
+		whenTok := p.advance() // consume WHEN
+
+		h := &ast.ScriptExceptionHandler{Loc: ast.Loc{Start: whenTok.Loc.Start}}
+
+		if p.cur.Type == kwSCRIPT_OTHER {
+			p.advance() // consume OTHER
+			h.Other = true
+		} else {
+			// <exc_name> [ OR <exc_name> ... ].
+			for {
+				n, err := p.parseIdent()
+				if err != nil {
+					return nil, err
+				}
+				h.Names = append(h.Names, n)
+				if p.cur.Type != kwOR {
+					break
+				}
+				p.advance() // consume OR
+			}
+		}
+
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		body, err := p.parseScriptStatementList(kwWHEN, kwEND)
+		if err != nil {
+			return nil, err
+		}
+		h.Body = body
+		h.Loc.End = p.prev.Loc.End
+		handlers = append(handlers, h)
+
+		if p.cur.Loc.Start == startPos {
+			return nil, p.noProgress("EXCEPTION section")
+		}
+	}
+	if len(handlers) == 0 {
+		// EXCEPTION with no WHEN handler is malformed.
+		return nil, p.syntaxErrorAtCur()
+	}
+	return handlers, nil
+}
+
+// ---------------------------------------------------------------------------
+// Statement list
+// ---------------------------------------------------------------------------
+
+// parseScriptStatementList parses a `;`-separated run of scripting statements,
+// stopping (without consuming) at any of the given terminator keywords or EOF.
+//
+// Snowflake Scripting requires each statement to be `;`-terminated; this parser
+// also tolerates a missing final `;` before the terminator (lenient, matching
+// the legacy task_scripting_statement_list `SEMI?`). EOF before a terminator is
+// an "unterminated" error — that is the structural guarantee against a runaway
+// loop on a never-closed block.
+func (p *Parser) parseScriptStatementList(terminators ...int) ([]ast.Node, error) {
+	var stmts []ast.Node
+	for {
+		if p.cur.Type == tokEOF {
+			return nil, p.unterminated("scripting block")
+		}
+		if p.isScriptTerminator(p.cur.Type, terminators) {
+			return stmts, nil
+		}
+
+		startPos := p.cur.Loc.Start
+		s, err := p.parseScriptStatement()
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+
+		if p.cur.Loc.Start == startPos {
+			// Defensive: a statement that consumed nothing would loop forever.
+			return nil, p.noProgress("scripting block")
+		}
+
+		// Consume the statement separator. A statement may be immediately
+		// followed by a terminator with no trailing ';' (lenient).
+		if p.cur.Type == ';' {
+			p.advance()
+			continue
+		}
+		if p.isScriptTerminator(p.cur.Type, terminators) {
+			return stmts, nil
+		}
+		if p.cur.Type == tokEOF {
+			return nil, p.unterminated("scripting block")
+		}
+		// Anything else after a complete statement (and not a separator /
+		// terminator) is a syntax error rather than a silent stop.
+		return nil, p.syntaxErrorAtCur()
+	}
+}
+
+// isScriptTerminator reports whether tokType is one of terminators.
+func (p *Parser) isScriptTerminator(tokType int, terminators []int) bool {
+	for _, t := range terminators {
+		if tokType == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Statement dispatch
+// ---------------------------------------------------------------------------
+
+// parseScriptStatement parses ONE scripting statement and guarantees it
+// consumes at least one token. It dispatches on the leading token:
+//
+//	nested block ...................... DECLARE / BEGIN
+//	IF / CASE / FOR / WHILE / REPEAT / LOOP ... control flow
+//	BREAK / CONTINUE / RETURN / RAISE ... jump statements
+//	LET ............................... declaration-statement
+//	OPEN / FETCH / CLOSE .............. cursor statements
+//	<var> := <expr> ................... assignment
+//	<sql> ............................. any SQL statement (reuses parseStmt)
+func (p *Parser) parseScriptStatement() (ast.Node, error) {
+	if !p.enterScript() {
+		return nil, p.errScriptTooDeep()
+	}
+	defer p.leaveScript()
+
+	switch p.cur.Type {
+	case kwDECLARE:
+		return p.parseScriptBlock()
+	case kwBEGIN:
+		// A bare BEGIN inside a block always opens a nested scripting block
+		// (transaction control is not a scripting statement). Route directly.
+		return p.parseScriptBlock()
+	case kwIF:
+		return p.parseScriptIf()
+	case kwCASE:
+		return p.parseScriptCase()
+	case kwFOR:
+		return p.parseScriptFor()
+	case kwSCRIPT_WHILE:
+		return p.parseScriptWhile()
+	case kwSCRIPT_REPEAT:
+		return p.parseScriptRepeat()
+	case kwSCRIPT_LOOP:
+		return p.parseScriptLoop()
+	case kwSCRIPT_BREAK, kwSCRIPT_EXIT:
+		return p.parseScriptBreak()
+	case kwCONTINUE, kwSCRIPT_ITERATE:
+		return p.parseScriptContinue()
+	case kwRETURN:
+		return p.parseScriptReturn()
+	case kwSCRIPT_RAISE:
+		return p.parseScriptRaise()
+	case kwSCRIPT_LET:
+		return p.parseScriptLet()
+	case kwSCRIPT_OPEN:
+		return p.parseScriptOpen()
+	case kwFETCH:
+		return p.parseScriptFetch()
+	case kwSCRIPT_CLOSE:
+		return p.parseScriptClose()
+	default:
+		// Either an assignment (<var> := <expr>) or a nested SQL statement.
+		// An assignment is detected by an identifier-like leading token whose
+		// successor is the `:=` operator; everything else is delegated to the
+		// top-level statement parser (SELECT / INSERT / CALL / EXECUTE / ...).
+		if p.isIdentToken() && p.assignFollows() {
+			return p.parseScriptAssign()
+		}
+		return p.parseStmt()
+	}
+}
+
+// assignFollows reports whether the token AFTER the current identifier-like
+// token begins the `:=` assignment operator (a ':' followed by '='). cur is the
+// candidate target identifier.
+func (p *Parser) assignFollows() bool {
+	return p.peekNext().Type == ':'
+}
+
+// parseScriptAssign parses `<var> := <expr>`. cur is the target identifier.
+func (p *Parser) parseScriptAssign() (ast.Node, error) {
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	if !p.tryParseAssignOp() {
+		return nil, p.syntaxErrorAtCur()
+	}
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ScriptAssignStmt{
+		Target: name,
+		Value:  val,
+		Loc:    ast.Loc{Start: name.Loc.Start, End: ast.NodeLoc(val).End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// LET
+// ---------------------------------------------------------------------------
+
+// parseScriptLet parses a LET declaration-statement. cur is LET:
+//
+//	LET <var> [ <type> ] { DEFAULT | := } <expr>
+//	LET <cursor> CURSOR FOR <query>
+//	LET <resultset> RESULTSET { DEFAULT | := } [ ASYNC ] ( <query> )
+func (p *Parser) parseScriptLet() (ast.Node, error) {
+	letTok := p.advance() // consume LET
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &ast.ScriptLetStmt{Name: name, Loc: ast.Loc{Start: letTok.Loc.Start}}
+
+	switch p.cur.Type {
+	case kwSCRIPT_CURSOR:
+		p.advance() // consume CURSOR
+		if _, err := p.expect(kwFOR); err != nil {
+			return nil, err
+		}
+		q, err := p.parseScriptQuery()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = ast.ScriptDeclCursor
+		stmt.Query = q
+		stmt.Loc.End = ast.NodeLoc(q).End
+
+	case kwSCRIPT_RESULTSET:
+		p.advance() // consume RESULTSET
+		stmt.Kind = ast.ScriptDeclResultset
+		if !p.tryParseAssignOp() {
+			return nil, p.syntaxErrorAtCur()
+		}
+		async, q, end, err := p.parseResultsetValue()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Async = async
+		stmt.Query = q
+		stmt.Loc.End = end
+
+	default:
+		// Variable: LET <var> [ <type> ] { DEFAULT | := } <expr>.
+		stmt.Kind = ast.ScriptDeclVar
+		if !p.startsAssignOp() {
+			typ, err := p.parseDataType()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Type = typ
+		}
+		if !p.tryParseAssignOp() {
+			return nil, p.syntaxErrorAtCur()
+		}
+		val, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Default = val
+		stmt.Loc.End = ast.NodeLoc(val).End
+	}
+
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// IF
+// ---------------------------------------------------------------------------
+
+// parseScriptIf parses an IF statement. cur is IF:
+//
+//	IF ( <cond> ) THEN <stmts> [ ELSEIF ( <cond> ) THEN <stmts> ]* [ ELSE <stmts> ] END IF
+func (p *Parser) parseScriptIf() (ast.Node, error) {
+	ifTok := p.advance() // consume IF
+	stmt := &ast.ScriptIfStmt{Loc: ast.Loc{Start: ifTok.Loc.Start}}
+
+	// Leading IF arm.
+	branch, err := p.parseScriptIfBranch()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Branches = append(stmt.Branches, branch)
+
+	// Zero or more ELSEIF arms.
+	for p.cur.Type == kwSCRIPT_ELSEIF {
+		p.advance() // consume ELSEIF
+		b, err := p.parseScriptIfBranch()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Branches = append(stmt.Branches, b)
+	}
+
+	// Optional ELSE.
+	if p.cur.Type == kwELSE {
+		p.advance() // consume ELSE
+		body, err := p.parseScriptStatementList(kwEND)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Else = body
+	}
+
+	// END IF.
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwIF); err != nil {
+		return nil, err
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseScriptIfBranch parses `( <cond> ) THEN <stmts>` for one IF / ELSEIF arm.
+// The body terminates at ELSEIF / ELSE / END (whichever comes first).
+func (p *Parser) parseScriptIfBranch() (*ast.ScriptIfBranch, error) {
+	startPos := p.cur.Loc.Start
+	cond, err := p.parseScriptParenCondition()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwTHEN); err != nil {
+		return nil, err
+	}
+	body, err := p.parseScriptStatementList(kwSCRIPT_ELSEIF, kwELSE, kwEND)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ScriptIfBranch{
+		Cond: cond,
+		Body: body,
+		Loc:  ast.Loc{Start: startPos, End: p.prev.Loc.End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// CASE
+// ---------------------------------------------------------------------------
+
+// parseScriptCase parses a CASE statement (simple or searched). cur is CASE:
+//
+//	CASE [ ( <operand> ) ] WHEN <expr> THEN <stmts> [ WHEN ... ]* [ ELSE <stmts> ] END [ CASE ]
+//
+// The simple form has an operand expression after CASE (commonly parenthesized,
+// e.g. `CASE (x)`); the searched form goes straight to WHEN. The operand is
+// detected as "anything that is not the WHEN keyword".
+func (p *Parser) parseScriptCase() (ast.Node, error) {
+	caseTok := p.advance() // consume CASE
+	stmt := &ast.ScriptCaseStmt{Loc: ast.Loc{Start: caseTok.Loc.Start}}
+
+	// Optional operand (simple CASE). Searched CASE begins directly with WHEN.
+	if p.cur.Type != kwWHEN {
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Operand = operand
+	}
+
+	// One or more WHEN <expr> THEN <stmts> arms.
+	for p.cur.Type == kwWHEN {
+		startPos := p.cur.Loc.Start
+		p.advance() // consume WHEN
+		match, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		body, err := p.parseScriptStatementList(kwWHEN, kwELSE, kwEND)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Whens = append(stmt.Whens, &ast.ScriptCaseWhen{
+			Match: match,
+			Body:  body,
+			Loc:   ast.Loc{Start: startPos, End: p.prev.Loc.End},
+		})
+	}
+	if len(stmt.Whens) == 0 {
+		// CASE with no WHEN arm is malformed.
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	// Optional ELSE.
+	if p.cur.Type == kwELSE {
+		p.advance() // consume ELSE
+		body, err := p.parseScriptStatementList(kwEND)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Else = body
+	}
+
+	// END [ CASE ].
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if p.cur.Type == kwCASE {
+		p.advance() // consume optional CASE
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// FOR
+// ---------------------------------------------------------------------------
+
+// parseScriptFor parses a FOR loop in either form. cur is FOR:
+//
+//	FOR <counter> IN [ REVERSE ] <start> TO <end> { DO | LOOP } <stmts> END { FOR | LOOP } [ <label> ]
+//	FOR <row> IN { <cursor> | <resultset> } DO <stmts> END FOR [ <label> ]
+//
+// The two forms are disambiguated AFTER `IN`: a REVERSE modifier or a `<start>
+// TO <end>` range marks the counter form; a bare cursor/resultset name (i.e.
+// the loop body opener `DO`/`LOOP` follows the name) marks the cursor form.
+func (p *Parser) parseScriptFor() (ast.Node, error) {
+	forTok := p.advance() // consume FOR
+	stmt := &ast.ScriptForStmt{Loc: ast.Loc{Start: forTok.Loc.Start}}
+
+	v, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Var = v
+
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+
+	// REVERSE forces the counter form.
+	if p.cur.Type == kwSCRIPT_REVERSE {
+		p.advance() // consume REVERSE
+		stmt.Kind = ast.ScriptForCounter
+		stmt.Reverse = true
+		if err := p.parseScriptForCounterRange(stmt); err != nil {
+			return nil, err
+		}
+	} else {
+		// Disambiguate counter vs cursor: a cursor/resultset source is a single
+		// identifier immediately followed by the loop opener DO / LOOP. Anything
+		// else is a counter range expression `<start> TO <end>`.
+		if p.isIdentToken() && p.scriptForSourceFollows() {
+			src, err := p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Kind = ast.ScriptForCursor
+			stmt.Source = src
+		} else {
+			stmt.Kind = ast.ScriptForCounter
+			if err := p.parseScriptForCounterRange(stmt); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Loop opener: DO or LOOP.
+	if _, err := p.expectLoopOpener(); err != nil {
+		return nil, err
+	}
+
+	// Body terminates at END.
+	body, err := p.parseScriptStatementList(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	// END { FOR | LOOP } [ <label> ].
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if _, err := p.expectForLoopCloser(); err != nil {
+		return nil, err
+	}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// scriptForSourceFollows reports whether the current identifier is a bare
+// FOR-loop cursor/resultset source — i.e. the token AFTER it is a loop opener
+// (DO / LOOP). A counter range instead has `TO` (or a larger expression) after
+// the start value, so the loop opener does not immediately follow.
+func (p *Parser) scriptForSourceFollows() bool {
+	switch p.peekNext().Type {
+	case kwDO, kwSCRIPT_LOOP:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseScriptForCounterRange parses `<start> TO <end>` into the counter-form
+// stmt fields.
+func (p *Parser) parseScriptForCounterRange(stmt *ast.ScriptForStmt) error {
+	start, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	stmt.Start = start
+	if _, err := p.expect(kwTO); err != nil {
+		return err
+	}
+	end, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	stmt.End = end
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// WHILE / REPEAT / LOOP
+// ---------------------------------------------------------------------------
+
+// parseScriptWhile parses `WHILE ( <cond> ) { DO | LOOP } <stmts> END { WHILE | LOOP } [ <label> ]`.
+func (p *Parser) parseScriptWhile() (ast.Node, error) {
+	whileTok := p.advance() // consume WHILE
+	stmt := &ast.ScriptWhileStmt{Loc: ast.Loc{Start: whileTok.Loc.Start}}
+
+	cond, err := p.parseScriptParenCondition()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Cond = cond
+
+	if _, err := p.expectLoopOpener(); err != nil {
+		return nil, err
+	}
+	body, err := p.parseScriptStatementList(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if _, err := p.expectWhileLoopCloser(); err != nil {
+		return nil, err
+	}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseScriptRepeat parses `REPEAT <stmts> UNTIL ( <cond> ) END REPEAT [ <label> ]`.
+func (p *Parser) parseScriptRepeat() (ast.Node, error) {
+	repeatTok := p.advance() // consume REPEAT
+	stmt := &ast.ScriptRepeatStmt{Loc: ast.Loc{Start: repeatTok.Loc.Start}}
+
+	body, err := p.parseScriptStatementList(kwSCRIPT_UNTIL)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	if _, err := p.expect(kwSCRIPT_UNTIL); err != nil {
+		return nil, err
+	}
+	cond, err := p.parseScriptParenCondition()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Cond = cond
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwSCRIPT_REPEAT); err != nil {
+		return nil, err
+	}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseScriptLoop parses `LOOP <stmts> END LOOP [ <label> ]`.
+func (p *Parser) parseScriptLoop() (ast.Node, error) {
+	loopTok := p.advance() // consume LOOP
+	stmt := &ast.ScriptLoopStmt{Loc: ast.Loc{Start: loopTok.Loc.Start}}
+
+	body, err := p.parseScriptStatementList(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwSCRIPT_LOOP); err != nil {
+		return nil, err
+	}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Jump statements: BREAK / CONTINUE / RETURN / RAISE
+// ---------------------------------------------------------------------------
+
+// parseScriptBreak parses `BREAK [ <label> ]` (alias EXIT). cur is BREAK/EXIT.
+func (p *Parser) parseScriptBreak() (ast.Node, error) {
+	tok := p.advance() // consume BREAK / EXIT
+	stmt := &ast.ScriptBreakStmt{Loc: tok.Loc}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+		stmt.Loc.End = label.Loc.End
+	}
+	return stmt, nil
+}
+
+// parseScriptContinue parses `CONTINUE [ <label> ]` (alias ITERATE). cur is
+// CONTINUE/ITERATE.
+func (p *Parser) parseScriptContinue() (ast.Node, error) {
+	tok := p.advance() // consume CONTINUE / ITERATE
+	stmt := &ast.ScriptContinueStmt{Loc: tok.Loc}
+	if label, ok := p.tryParseScriptLabel(); ok {
+		stmt.Label = label
+		stmt.Loc.End = label.Loc.End
+	}
+	return stmt, nil
+}
+
+// parseScriptReturn parses `RETURN [ <expr> ]`. cur is RETURN. A bare RETURN
+// (immediately followed by a statement separator / terminator) has no value.
+func (p *Parser) parseScriptReturn() (ast.Node, error) {
+	tok := p.advance() // consume RETURN
+	stmt := &ast.ScriptReturnStmt{Loc: tok.Loc}
+	if p.scriptExprEnds() {
+		return stmt, nil
+	}
+	val, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Value = val
+	stmt.Loc.End = ast.NodeLoc(val).End
+	return stmt, nil
+}
+
+// parseScriptRaise parses `RAISE [ <exc_name> ]`. cur is RAISE. A bare RAISE
+// re-raises the current exception (valid only inside a handler, but parsed
+// structurally regardless).
+func (p *Parser) parseScriptRaise() (ast.Node, error) {
+	tok := p.advance() // consume RAISE
+	stmt := &ast.ScriptRaiseStmt{Loc: tok.Loc}
+	if p.scriptExprEnds() {
+		return stmt, nil
+	}
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+	stmt.Loc.End = name.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Cursor statements: OPEN / FETCH / CLOSE
+// ---------------------------------------------------------------------------
+
+// parseScriptOpen parses `OPEN <cursor> [ USING ( <bind> [ , ... ] ) ]`. cur is OPEN.
+func (p *Parser) parseScriptOpen() (ast.Node, error) {
+	openTok := p.advance() // consume OPEN
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &ast.ScriptOpenStmt{Cursor: name, Loc: ast.Loc{Start: openTok.Loc.Start, End: name.Loc.End}}
+
+	if p.cur.Type == kwUSING {
+		p.advance() // consume USING
+		args, end, err := p.parseScriptParenExprList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Using = args
+		stmt.Loc.End = end
+	}
+	return stmt, nil
+}
+
+// parseScriptFetch parses `FETCH <cursor> INTO <var> [ , ... ]`. cur is FETCH.
+func (p *Parser) parseScriptFetch() (ast.Node, error) {
+	fetchTok := p.advance() // consume FETCH
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	stmt := &ast.ScriptFetchStmt{Cursor: name, Loc: ast.Loc{Start: fetchTok.Loc.Start, End: name.Loc.End}}
+
+	if _, err := p.expect(kwINTO); err != nil {
+		return nil, err
+	}
+	for {
+		v, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Into = append(stmt.Into, v)
+		stmt.Loc.End = v.Loc.End
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return stmt, nil
+}
+
+// parseScriptClose parses `CLOSE <cursor>`. cur is CLOSE.
+func (p *Parser) parseScriptClose() (ast.Node, error) {
+	closeTok := p.advance() // consume CLOSE
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ScriptCloseStmt{
+		Cursor: name,
+		Loc:    ast.Loc{Start: closeTok.Loc.Start, End: name.Loc.End},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// parseScriptParenCondition parses `( <cond> )` — the parenthesized boolean
+// condition shared by IF / ELSEIF / WHILE / UNTIL. The parentheses are required
+// by the docs. The returned node is the inner condition expression (the
+// surrounding ParenExpr is preserved so the source round-trips).
+func (p *Parser) parseScriptParenCondition() (ast.Node, error) {
+	if p.cur.Type != '(' {
+		return nil, p.syntaxErrorAtCur()
+	}
+	// parseExpr handles a leading '(' as a ParenExpr, keeping the parens in the
+	// AST. This is sufficient for structural fidelity.
+	return p.parseExpr()
+}
+
+// parseScriptQuery parses a nested query (the body of a CURSOR FOR / RESULTSET).
+// It accepts SELECT, WITH ... SELECT, and a parenthesized query, reusing the
+// engine's query-expression parser.
+func (p *Parser) parseScriptQuery() (ast.Node, error) {
+	switch p.cur.Type {
+	case kwWITH:
+		return p.parseWithQueryExpr()
+	default:
+		return p.parseQueryExpr()
+	}
+}
+
+// parseScriptParenExprList parses `( <expr> [ , <expr> ... ] )` and returns the
+// expressions plus the end offset of the closing ')'. An empty list `()` is
+// permitted (yields nil). cur must be '('.
+func (p *Parser) parseScriptParenExprList() ([]ast.Node, int, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, 0, err
+	}
+	if p.cur.Type == ')' {
+		closeTok := p.advance()
+		return nil, closeTok.Loc.End, nil
+	}
+	var args []ast.Node
+	for {
+		e, err := p.parseExpr()
+		if err != nil {
+			return nil, 0, err
+		}
+		args = append(args, e)
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, 0, err
+	}
+	return args, closeTok.Loc.End, nil
+}
+
+// startsAssignOp reports whether cur begins an assignment operator: either the
+// `:=` operator (a ':' followed by '=') or the DEFAULT keyword. Used to decide
+// whether a declaration / LET has reached its value (so the optional type slot
+// is skipped).
+func (p *Parser) startsAssignOp() bool {
+	if p.cur.Type == kwDEFAULT {
+		return true
+	}
+	return p.cur.Type == ':' && p.peekNext().Type == '='
+}
+
+// tryParseAssignOp consumes an assignment operator — `:=` or the DEFAULT keyword
+// — if present, and reports whether one was consumed.
+func (p *Parser) tryParseAssignOp() bool {
+	if p.cur.Type == kwDEFAULT {
+		p.advance() // consume DEFAULT
+		return true
+	}
+	if p.cur.Type == ':' && p.peekNext().Type == '=' {
+		p.advance() // consume ':'
+		p.advance() // consume '='
+		return true
+	}
+	return false
+}
+
+// scriptExprEnds reports whether the current token ends an optional-expression
+// statement (RETURN / RAISE) without a value — i.e. a statement separator,
+// terminator keyword, or EOF follows immediately.
+func (p *Parser) scriptExprEnds() bool {
+	switch p.cur.Type {
+	case ';', tokEOF,
+		kwEND, kwELSE, kwSCRIPT_ELSEIF, kwWHEN, kwSCRIPT_UNTIL:
+		return true
+	default:
+		return false
+	}
+}
+
+// expectLoopOpener consumes the loop-body opener DO or LOOP (shared by FOR /
+// WHILE). Returns a syntax error if neither is present.
+func (p *Parser) expectLoopOpener() (Token, error) {
+	switch p.cur.Type {
+	case kwDO, kwSCRIPT_LOOP:
+		return p.advance(), nil
+	default:
+		return Token{}, p.syntaxErrorAtCur()
+	}
+}
+
+// expectForLoopCloser consumes the FOR-loop closer FOR or LOOP after END.
+func (p *Parser) expectForLoopCloser() (Token, error) {
+	switch p.cur.Type {
+	case kwFOR, kwSCRIPT_LOOP:
+		return p.advance(), nil
+	default:
+		return Token{}, p.syntaxErrorAtCur()
+	}
+}
+
+// expectWhileLoopCloser consumes the WHILE-loop closer WHILE or LOOP after END.
+func (p *Parser) expectWhileLoopCloser() (Token, error) {
+	switch p.cur.Type {
+	case kwSCRIPT_WHILE, kwSCRIPT_LOOP:
+		return p.advance(), nil
+	default:
+		return Token{}, p.syntaxErrorAtCur()
+	}
+}
+
+// unterminated returns a ParseError for a scripting construct that hit EOF
+// before its closing keyword. This is the fast-fail path that prevents a
+// never-closed block from looping.
+func (p *Parser) unterminated(what string) *ParseError {
+	return &ParseError{Loc: p.cur.Loc, Msg: "unterminated " + what + " at end of input"}
+}
+
+// noProgress returns a ParseError for the defensive case where a list loop
+// parsed an item without consuming any token. It can only fire on a parser bug;
+// returning an error (rather than spinning) keeps non-termination structurally
+// impossible.
+func (p *Parser) noProgress(what string) *ParseError {
+	return &ParseError{Loc: p.cur.Loc, Msg: "internal: no progress parsing " + what}
+}

--- a/snowflake/parser/scripting_test.go
+++ b/snowflake/parser/scripting_test.go
@@ -1,0 +1,1134 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// mustScriptBlock parses input (a single segment) into a *ast.ScriptBlockStmt
+// via the public best-effort entry point, asserting no errors and exactly one
+// statement.
+func mustScriptBlock(t *testing.T, input string) *ast.ScriptBlockStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	block, ok := node.(*ast.ScriptBlockStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.ScriptBlockStmt", input, node)
+	}
+	return block
+}
+
+// parseScriptErr parses input and returns the collected errors. It does NOT
+// fail the test, so callers can assert that an error occurred (negatives /
+// unterminated-block fast-fail).
+func parseScriptErr(input string) []ParseError {
+	return ParseBestEffort(input).Errors
+}
+
+// firstStmtType returns the concrete type name of the first body statement of a
+// block (helper for table-driven dispatch assertions).
+func firstBodyStmt(t *testing.T, block *ast.ScriptBlockStmt) ast.Node {
+	t.Helper()
+	if len(block.Body) == 0 {
+		t.Fatalf("block has empty body")
+	}
+	return block.Body[0]
+}
+
+// decl returns the i-th declaration of a block as a *ast.ScriptDeclaration.
+func decl(t *testing.T, block *ast.ScriptBlockStmt, i int) *ast.ScriptDeclaration {
+	t.Helper()
+	if i >= len(block.Decls) {
+		t.Fatalf("decl index %d out of range (have %d)", i, len(block.Decls))
+	}
+	d, ok := block.Decls[i].(*ast.ScriptDeclaration)
+	if !ok {
+		t.Fatalf("decl[%d] = %T, want *ast.ScriptDeclaration", i, block.Decls[i])
+	}
+	return d
+}
+
+// handler returns the i-th exception handler of a block.
+func handler(t *testing.T, block *ast.ScriptBlockStmt, i int) *ast.ScriptExceptionHandler {
+	t.Helper()
+	if i >= len(block.Handlers) {
+		t.Fatalf("handler index %d out of range (have %d)", i, len(block.Handlers))
+	}
+	h, ok := block.Handlers[i].(*ast.ScriptExceptionHandler)
+	if !ok {
+		t.Fatalf("handler[%d] = %T, want *ast.ScriptExceptionHandler", i, block.Handlers[i])
+	}
+	return h
+}
+
+// ifBranch returns the i-th branch of an IF statement.
+func ifBranch(t *testing.T, s *ast.ScriptIfStmt, i int) *ast.ScriptIfBranch {
+	t.Helper()
+	if i >= len(s.Branches) {
+		t.Fatalf("branch index %d out of range (have %d)", i, len(s.Branches))
+	}
+	b, ok := s.Branches[i].(*ast.ScriptIfBranch)
+	if !ok {
+		t.Fatalf("branch[%d] = %T, want *ast.ScriptIfBranch", i, s.Branches[i])
+	}
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// Block: BEGIN..END / DECLARE..BEGIN..END / EXCEPTION / label
+// ---------------------------------------------------------------------------
+
+func TestScript_BareBeginEnd(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN SELECT 1; END")
+	if len(block.Decls) != 0 {
+		t.Errorf("decls = %d, want 0", len(block.Decls))
+	}
+	if len(block.Handlers) != 0 {
+		t.Errorf("handlers = %d, want 0", len(block.Handlers))
+	}
+	if !block.Label.IsEmpty() {
+		t.Errorf("label = %q, want empty", block.Label.Normalize())
+	}
+	if len(block.Body) != 1 {
+		t.Fatalf("body = %d, want 1", len(block.Body))
+	}
+	if _, ok := block.Body[0].(*ast.SelectStmt); !ok {
+		t.Errorf("body[0] = %T, want *ast.SelectStmt", block.Body[0])
+	}
+}
+
+func TestScript_MultipleBodyStatements(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN SELECT 1; INSERT INTO t VALUES (1); SELECT 2; END")
+	if len(block.Body) != 3 {
+		t.Fatalf("body = %d, want 3", len(block.Body))
+	}
+}
+
+func TestScript_TrailingSemicolonOptionalBeforeEnd(t *testing.T) {
+	// No ';' before END (lenient — legacy task_scripting_statement_list SEMI?).
+	block := mustScriptBlock(t, "BEGIN SELECT 1; SELECT 2 END")
+	if len(block.Body) != 2 {
+		t.Fatalf("body = %d, want 2", len(block.Body))
+	}
+}
+
+func TestScript_DeclareBeginEnd(t *testing.T) {
+	block := mustScriptBlock(t, "DECLARE x INT; BEGIN RETURN x; END")
+	if len(block.Decls) != 1 {
+		t.Fatalf("decls = %d, want 1", len(block.Decls))
+	}
+	d := decl(t, block, 0)
+	if d.Kind != ast.ScriptDeclVar {
+		t.Errorf("decl kind = %v, want ScriptDeclVar", d.Kind)
+	}
+	if d.Name.Name != "x" {
+		t.Errorf("decl name = %q, want x", d.Name.Normalize())
+	}
+	if d.Type == nil {
+		t.Errorf("decl type = nil, want INT")
+	}
+}
+
+func TestScript_EndLabel(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN SELECT 1; END my_label")
+	if block.Label.Name != "my_label" {
+		t.Errorf("label = %q, want my_label", block.Label.Normalize())
+	}
+}
+
+// TestScript_NestedEndNoSemicolon guards that an inner block's END does not
+// swallow the OUTER block's END as a label when no ';' separates them
+// (`BEGIN BEGIN ... END END`). END is a non-reserved keyword, so a naive
+// label scan would consume it; tryParseScriptLabel must reject keyword tokens.
+func TestScript_NestedEndNoSemicolon(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN BEGIN SELECT 1; END END")
+	if !block.Label.IsEmpty() {
+		t.Errorf("outer label = %q, want empty (END is not a label)", block.Label.Name)
+	}
+	if len(block.Body) != 1 {
+		t.Fatalf("outer body = %d, want 1 (the inner block)", len(block.Body))
+	}
+	if _, ok := block.Body[0].(*ast.ScriptBlockStmt); !ok {
+		t.Errorf("body[0] = %T, want *ast.ScriptBlockStmt", block.Body[0])
+	}
+}
+
+func TestScript_NestedBlock(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN BEGIN SELECT 1; END; SELECT 2; END")
+	if len(block.Body) != 2 {
+		t.Fatalf("outer body = %d, want 2", len(block.Body))
+	}
+	inner, ok := block.Body[0].(*ast.ScriptBlockStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptBlockStmt (nested)", block.Body[0])
+	}
+	if len(inner.Body) != 1 {
+		t.Errorf("inner body = %d, want 1", len(inner.Body))
+	}
+}
+
+func TestScript_BlockLoc(t *testing.T) {
+	input := "BEGIN SELECT 1; END"
+	block := mustScriptBlock(t, input)
+	if block.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", block.Loc.Start)
+	}
+	if block.Loc.End != len(input) {
+		t.Errorf("Loc.End = %d, want %d", block.Loc.End, len(input))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DECLARE forms
+// ---------------------------------------------------------------------------
+
+func TestScript_DeclareVarForms(t *testing.T) {
+	tests := []struct {
+		name     string
+		decl     string // the declaration text (without trailing ';')
+		wantType bool
+		wantDef  bool
+	}{
+		{"type only", "x INT", true, false},
+		{"type and default kw", "x INT DEFAULT 0", true, true},
+		{"type and assign", "x INT := 0", true, true},
+		{"typeless assign", "x := 0", false, true},
+		{"varchar typed", "name VARCHAR DEFAULT 'a'", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "DECLARE "+tt.decl+"; BEGIN RETURN x; END")
+			if len(block.Decls) != 1 {
+				t.Fatalf("decls = %d, want 1", len(block.Decls))
+			}
+			d := decl(t, block, 0)
+			if d.Kind != ast.ScriptDeclVar {
+				t.Fatalf("kind = %v, want ScriptDeclVar", d.Kind)
+			}
+			if (d.Type != nil) != tt.wantType {
+				t.Errorf("hasType = %v, want %v", d.Type != nil, tt.wantType)
+			}
+			if (d.Default != nil) != tt.wantDef {
+				t.Errorf("hasDefault = %v, want %v", d.Default != nil, tt.wantDef)
+			}
+		})
+	}
+}
+
+func TestScript_DeclareCursor(t *testing.T) {
+	block := mustScriptBlock(t, "DECLARE c1 CURSOR FOR SELECT price FROM invoices; BEGIN OPEN c1; END")
+	d := decl(t, block, 0)
+	if d.Kind != ast.ScriptDeclCursor {
+		t.Fatalf("kind = %v, want ScriptDeclCursor", d.Kind)
+	}
+	if d.Query == nil {
+		t.Errorf("cursor query = nil, want a SELECT")
+	}
+	if _, ok := d.Query.(*ast.SelectStmt); !ok {
+		t.Errorf("cursor query = %T, want *ast.SelectStmt", d.Query)
+	}
+}
+
+func TestScript_DeclareResultset(t *testing.T) {
+	tests := []struct {
+		name      string
+		decl      string
+		wantQuery bool
+		wantAsync bool
+	}{
+		{"bare", "rs RESULTSET", false, false},
+		{"assigned", "rs RESULTSET := (SELECT 1)", true, false},
+		{"default", "rs RESULTSET DEFAULT (SELECT 1)", true, false},
+		{"async", "rs RESULTSET := ASYNC (SELECT 1)", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "DECLARE "+tt.decl+"; BEGIN RETURN 1; END")
+			d := decl(t, block, 0)
+			if d.Kind != ast.ScriptDeclResultset {
+				t.Fatalf("kind = %v, want ScriptDeclResultset", d.Kind)
+			}
+			if (d.Query != nil) != tt.wantQuery {
+				t.Errorf("hasQuery = %v, want %v", d.Query != nil, tt.wantQuery)
+			}
+			if d.Async != tt.wantAsync {
+				t.Errorf("async = %v, want %v", d.Async, tt.wantAsync)
+			}
+		})
+	}
+}
+
+func TestScript_DeclareException(t *testing.T) {
+	tests := []struct {
+		name    string
+		decl    string
+		wantArg int
+	}{
+		{"bare", "e EXCEPTION", 0},
+		{"with args", "e EXCEPTION (-20002, 'Raised E.')", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "DECLARE "+tt.decl+"; BEGIN RETURN 1; END")
+			d := decl(t, block, 0)
+			if d.Kind != ast.ScriptDeclException {
+				t.Fatalf("kind = %v, want ScriptDeclException", d.Kind)
+			}
+			if len(d.ExcArgs) != tt.wantArg {
+				t.Errorf("excArgs = %d, want %d", len(d.ExcArgs), tt.wantArg)
+			}
+		})
+	}
+}
+
+func TestScript_DeclareMultiple(t *testing.T) {
+	block := mustScriptBlock(t, `DECLARE
+		x INT;
+		y FLOAT DEFAULT 1.0;
+		c CURSOR FOR SELECT 1;
+		e EXCEPTION;
+	BEGIN RETURN x; END`)
+	if len(block.Decls) != 4 {
+		t.Fatalf("decls = %d, want 4", len(block.Decls))
+	}
+	wantKinds := []ast.ScriptDeclKind{
+		ast.ScriptDeclVar, ast.ScriptDeclVar, ast.ScriptDeclCursor, ast.ScriptDeclException,
+	}
+	for i, k := range wantKinds {
+		if got := decl(t, block, i).Kind; got != k {
+			t.Errorf("decl[%d] kind = %v, want %v", i, got, k)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Assignment / LET
+// ---------------------------------------------------------------------------
+
+func TestScript_Assignment(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN x := 3; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptAssignStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptAssignStmt", block.Body[0])
+	}
+	if s.Target.Name != "x" {
+		t.Errorf("target = %q, want x", s.Target.Normalize())
+	}
+	if s.Value == nil {
+		t.Errorf("value = nil")
+	}
+}
+
+func TestScript_AssignmentResultsetSubquery(t *testing.T) {
+	// rs := (SELECT ...) — RESULTSET assignment via the plain assignment path.
+	block := mustScriptBlock(t, "BEGIN rs := (SELECT 1); END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptAssignStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptAssignStmt", block.Body[0])
+	}
+	if _, ok := s.Value.(*ast.SubqueryExpr); !ok {
+		t.Errorf("value = %T, want *ast.SubqueryExpr", s.Value)
+	}
+}
+
+func TestScript_LetForms(t *testing.T) {
+	tests := []struct {
+		name     string
+		stmt     string
+		wantKind ast.ScriptDeclKind
+		wantType bool
+		wantQ    bool
+	}{
+		{"var typed assign", "LET x INT := 1", ast.ScriptDeclVar, true, false},
+		{"var typed default", "LET x INT DEFAULT 1", ast.ScriptDeclVar, true, false},
+		{"var inferred", "LET x := 1", ast.ScriptDeclVar, false, false},
+		{"cursor", "LET c CURSOR FOR SELECT 1", ast.ScriptDeclCursor, false, true},
+		{"resultset", "LET rs RESULTSET := (SELECT 1)", ast.ScriptDeclResultset, false, true},
+		{"resultset async", "LET rs RESULTSET := ASYNC (SELECT 1)", ast.ScriptDeclResultset, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "BEGIN "+tt.stmt+"; END")
+			s, ok := firstBodyStmt(t, block).(*ast.ScriptLetStmt)
+			if !ok {
+				t.Fatalf("body[0] = %T, want *ast.ScriptLetStmt", block.Body[0])
+			}
+			if s.Kind != tt.wantKind {
+				t.Errorf("kind = %v, want %v", s.Kind, tt.wantKind)
+			}
+			if (s.Type != nil) != tt.wantType {
+				t.Errorf("hasType = %v, want %v", s.Type != nil, tt.wantType)
+			}
+			if (s.Query != nil) != tt.wantQ {
+				t.Errorf("hasQuery = %v, want %v", s.Query != nil, tt.wantQ)
+			}
+		})
+	}
+}
+
+func TestScript_LetResultsetAsync(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN LET rs RESULTSET := ASYNC (SELECT 1); END")
+	s := firstBodyStmt(t, block).(*ast.ScriptLetStmt)
+	if !s.Async {
+		t.Errorf("async = false, want true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IF
+// ---------------------------------------------------------------------------
+
+func TestScript_IfThenEnd(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN IF (x = 1) THEN SELECT 1; END IF; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptIfStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptIfStmt", block.Body[0])
+	}
+	if len(s.Branches) != 1 {
+		t.Fatalf("branches = %d, want 1", len(s.Branches))
+	}
+	b0 := ifBranch(t, s, 0)
+	if b0.Cond == nil {
+		t.Errorf("branch cond = nil")
+	}
+	if len(b0.Body) != 1 {
+		t.Errorf("branch body = %d, want 1", len(b0.Body))
+	}
+	if s.Else != nil {
+		t.Errorf("else = %v, want nil", s.Else)
+	}
+}
+
+func TestScript_IfElseifElse(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		IF (x = 1) THEN SELECT 1;
+		ELSEIF (x = 2) THEN SELECT 2;
+		ELSEIF (x = 3) THEN SELECT 3;
+		ELSE SELECT 4;
+		END IF;
+	END`)
+	s := firstBodyStmt(t, block).(*ast.ScriptIfStmt)
+	if len(s.Branches) != 3 {
+		t.Fatalf("branches = %d, want 3 (IF + 2 ELSEIF)", len(s.Branches))
+	}
+	if len(s.Else) != 1 {
+		t.Errorf("else body = %d, want 1", len(s.Else))
+	}
+}
+
+func TestScript_IfMultiStmtBranch(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN IF (x) THEN SELECT 1; SELECT 2; SELECT 3; END IF; END")
+	s := firstBodyStmt(t, block).(*ast.ScriptIfStmt)
+	if len(ifBranch(t, s, 0).Body) != 3 {
+		t.Errorf("branch body = %d, want 3", len(ifBranch(t, s, 0).Body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CASE
+// ---------------------------------------------------------------------------
+
+func TestScript_CaseSimple(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		CASE (x)
+			WHEN 1 THEN SELECT 'one';
+			WHEN 2 THEN SELECT 'two';
+			ELSE SELECT 'other';
+		END CASE;
+	END`)
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptCaseStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptCaseStmt", block.Body[0])
+	}
+	if s.Operand == nil {
+		t.Errorf("operand = nil, want simple-CASE operand")
+	}
+	if len(s.Whens) != 2 {
+		t.Errorf("whens = %d, want 2", len(s.Whens))
+	}
+	if len(s.Else) != 1 {
+		t.Errorf("else = %d, want 1", len(s.Else))
+	}
+}
+
+func TestScript_CaseSearched(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		CASE
+			WHEN x = 1 THEN SELECT 1;
+			WHEN x = 2 THEN SELECT 2;
+		END;
+	END`)
+	s := firstBodyStmt(t, block).(*ast.ScriptCaseStmt)
+	if s.Operand != nil {
+		t.Errorf("operand = %v, want nil (searched form)", s.Operand)
+	}
+	if len(s.Whens) != 2 {
+		t.Errorf("whens = %d, want 2", len(s.Whens))
+	}
+}
+
+func TestScript_CaseEndWithoutCaseKeyword(t *testing.T) {
+	// END (no CASE) is valid per docs: END [ CASE ].
+	block := mustScriptBlock(t, "BEGIN CASE WHEN x THEN SELECT 1; END; END")
+	if _, ok := firstBodyStmt(t, block).(*ast.ScriptCaseStmt); !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptCaseStmt", block.Body[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FOR
+// ---------------------------------------------------------------------------
+
+func TestScript_ForCounter(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN FOR i IN 1 TO 10 DO SELECT i; END FOR; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptForStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptForStmt", block.Body[0])
+	}
+	if s.Kind != ast.ScriptForCounter {
+		t.Fatalf("kind = %v, want ScriptForCounter", s.Kind)
+	}
+	if s.Var.Name != "i" {
+		t.Errorf("var = %q, want i", s.Var.Normalize())
+	}
+	if s.Start == nil || s.End == nil {
+		t.Errorf("start/end = %v/%v, want non-nil", s.Start, s.End)
+	}
+	if s.Reverse {
+		t.Errorf("reverse = true, want false")
+	}
+}
+
+func TestScript_ForCounterReverse(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN FOR i IN REVERSE 1 TO 10 DO SELECT i; END FOR; END")
+	s := firstBodyStmt(t, block).(*ast.ScriptForStmt)
+	if !s.Reverse {
+		t.Errorf("reverse = false, want true")
+	}
+}
+
+func TestScript_ForCounterLoopKeyword(t *testing.T) {
+	// Counter FOR may use LOOP/END LOOP instead of DO/END FOR.
+	block := mustScriptBlock(t, "BEGIN FOR i IN 1 TO 3 LOOP SELECT i; END LOOP; END")
+	s := firstBodyStmt(t, block).(*ast.ScriptForStmt)
+	if s.Kind != ast.ScriptForCounter {
+		t.Errorf("kind = %v, want ScriptForCounter", s.Kind)
+	}
+}
+
+func TestScript_ForCursor(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN FOR rec IN c1 DO SELECT rec.x; END FOR; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptForStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptForStmt", block.Body[0])
+	}
+	if s.Kind != ast.ScriptForCursor {
+		t.Fatalf("kind = %v, want ScriptForCursor", s.Kind)
+	}
+	if s.Source.Name != "c1" {
+		t.Errorf("source = %q, want c1", s.Source.Normalize())
+	}
+}
+
+func TestScript_ForLabel(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN FOR i IN 1 TO 3 DO SELECT i; END FOR loop_label; END")
+	s := firstBodyStmt(t, block).(*ast.ScriptForStmt)
+	if s.Label.Name != "loop_label" {
+		t.Errorf("label = %q, want loop_label", s.Label.Normalize())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WHILE / REPEAT / LOOP
+// ---------------------------------------------------------------------------
+
+func TestScript_While(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN WHILE (x < 10) DO SELECT x; END WHILE; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptWhileStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptWhileStmt", block.Body[0])
+	}
+	if s.Cond == nil {
+		t.Errorf("cond = nil")
+	}
+	if len(s.Body) != 1 {
+		t.Errorf("body = %d, want 1", len(s.Body))
+	}
+}
+
+func TestScript_WhileLoopKeyword(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN WHILE (x < 10) LOOP SELECT x; END LOOP; END")
+	if _, ok := firstBodyStmt(t, block).(*ast.ScriptWhileStmt); !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptWhileStmt", block.Body[0])
+	}
+}
+
+func TestScript_Repeat(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN REPEAT SELECT 1; UNTIL (x > 5) END REPEAT; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptRepeatStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptRepeatStmt", block.Body[0])
+	}
+	if s.Cond == nil {
+		t.Errorf("until cond = nil")
+	}
+	if len(s.Body) != 1 {
+		t.Errorf("body = %d, want 1", len(s.Body))
+	}
+}
+
+func TestScript_Loop(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN LOOP SELECT 1; BREAK; END LOOP; END")
+	s, ok := firstBodyStmt(t, block).(*ast.ScriptLoopStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptLoopStmt", block.Body[0])
+	}
+	if len(s.Body) != 2 {
+		t.Errorf("body = %d, want 2 (SELECT + BREAK)", len(s.Body))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Jump statements
+// ---------------------------------------------------------------------------
+
+func TestScript_BreakContinue(t *testing.T) {
+	tests := []struct {
+		name  string
+		stmt  string
+		check func(t *testing.T, n ast.Node)
+	}{
+		{"break", "BREAK", func(t *testing.T, n ast.Node) {
+			if _, ok := n.(*ast.ScriptBreakStmt); !ok {
+				t.Errorf("got %T, want *ast.ScriptBreakStmt", n)
+			}
+		}},
+		{"break label", "BREAK lbl", func(t *testing.T, n ast.Node) {
+			s := n.(*ast.ScriptBreakStmt)
+			if s.Label.Name != "lbl" {
+				t.Errorf("label = %q, want lbl", s.Label.Normalize())
+			}
+		}},
+		{"exit alias", "EXIT", func(t *testing.T, n ast.Node) {
+			if _, ok := n.(*ast.ScriptBreakStmt); !ok {
+				t.Errorf("got %T, want *ast.ScriptBreakStmt", n)
+			}
+		}},
+		{"continue", "CONTINUE", func(t *testing.T, n ast.Node) {
+			if _, ok := n.(*ast.ScriptContinueStmt); !ok {
+				t.Errorf("got %T, want *ast.ScriptContinueStmt", n)
+			}
+		}},
+		{"continue label", "CONTINUE lbl", func(t *testing.T, n ast.Node) {
+			s := n.(*ast.ScriptContinueStmt)
+			if s.Label.Name != "lbl" {
+				t.Errorf("label = %q, want lbl", s.Label.Normalize())
+			}
+		}},
+		{"iterate alias", "ITERATE", func(t *testing.T, n ast.Node) {
+			if _, ok := n.(*ast.ScriptContinueStmt); !ok {
+				t.Errorf("got %T, want *ast.ScriptContinueStmt", n)
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "BEGIN LOOP "+tt.stmt+"; END LOOP; END")
+			loop := firstBodyStmt(t, block).(*ast.ScriptLoopStmt)
+			tt.check(t, loop.Body[0])
+		})
+	}
+}
+
+func TestScript_Return(t *testing.T) {
+	tests := []struct {
+		name     string
+		stmt     string
+		wantExpr bool
+	}{
+		{"bare", "RETURN", false},
+		{"with expr", "RETURN x + 1", true},
+		{"with func call", "RETURN pi() * 2", true},
+		{"with subquery", "RETURN (SELECT count(*) FROM t)", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "BEGIN "+tt.stmt+"; END")
+			s, ok := firstBodyStmt(t, block).(*ast.ScriptReturnStmt)
+			if !ok {
+				t.Fatalf("body[0] = %T, want *ast.ScriptReturnStmt", block.Body[0])
+			}
+			if (s.Value != nil) != tt.wantExpr {
+				t.Errorf("hasValue = %v, want %v", s.Value != nil, tt.wantExpr)
+			}
+		})
+	}
+}
+
+func TestScript_Raise(t *testing.T) {
+	tests := []struct {
+		name     string
+		stmt     string
+		wantName string
+	}{
+		{"bare reraise", "RAISE", ""},
+		{"named", "RAISE my_exception", "my_exception"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			block := mustScriptBlock(t, "BEGIN "+tt.stmt+"; END")
+			s, ok := firstBodyStmt(t, block).(*ast.ScriptRaiseStmt)
+			if !ok {
+				t.Fatalf("body[0] = %T, want *ast.ScriptRaiseStmt", block.Body[0])
+			}
+			if s.Name.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", s.Name.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cursor statements
+// ---------------------------------------------------------------------------
+
+func TestScript_OpenFetchClose(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		OPEN c1;
+		FETCH c1 INTO v1;
+		CLOSE c1;
+	END`)
+	if len(block.Body) != 3 {
+		t.Fatalf("body = %d, want 3", len(block.Body))
+	}
+	open, ok := block.Body[0].(*ast.ScriptOpenStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptOpenStmt", block.Body[0])
+	}
+	if open.Cursor.Name != "c1" {
+		t.Errorf("open cursor = %q, want c1", open.Cursor.Normalize())
+	}
+	if open.Using != nil {
+		t.Errorf("open using = %v, want nil", open.Using)
+	}
+	fetch, ok := block.Body[1].(*ast.ScriptFetchStmt)
+	if !ok {
+		t.Fatalf("body[1] = %T, want *ast.ScriptFetchStmt", block.Body[1])
+	}
+	if len(fetch.Into) != 1 || fetch.Into[0].Name != "v1" {
+		t.Errorf("fetch into = %v, want [v1]", fetch.Into)
+	}
+	if _, ok := block.Body[2].(*ast.ScriptCloseStmt); !ok {
+		t.Fatalf("body[2] = %T, want *ast.ScriptCloseStmt", block.Body[2])
+	}
+}
+
+func TestScript_OpenUsing(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN OPEN c1 USING (min_price, max_price); END")
+	open := firstBodyStmt(t, block).(*ast.ScriptOpenStmt)
+	if len(open.Using) != 2 {
+		t.Errorf("using = %d, want 2", len(open.Using))
+	}
+}
+
+func TestScript_FetchMultipleInto(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN FETCH c1 INTO a, b, c; END")
+	fetch := firstBodyStmt(t, block).(*ast.ScriptFetchStmt)
+	if len(fetch.Into) != 3 {
+		t.Errorf("into = %d, want 3", len(fetch.Into))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXCEPTION handlers
+// ---------------------------------------------------------------------------
+
+func TestScript_ExceptionHandlers(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		SELECT 1;
+	EXCEPTION
+		WHEN my_exc THEN SELECT 2;
+		WHEN OTHER THEN SELECT 3;
+	END`)
+	if len(block.Handlers) != 2 {
+		t.Fatalf("handlers = %d, want 2", len(block.Handlers))
+	}
+	h0 := handler(t, block, 0)
+	if h0.Other {
+		t.Errorf("handler[0].Other = true, want false")
+	}
+	if len(h0.Names) != 1 || h0.Names[0].Name != "my_exc" {
+		t.Errorf("handler[0].Names = %v, want [my_exc]", h0.Names)
+	}
+	if !handler(t, block, 1).Other {
+		t.Errorf("handler[1].Other = false, want true (WHEN OTHER)")
+	}
+}
+
+func TestScript_ExceptionHandlerOrNames(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		SELECT 1;
+	EXCEPTION
+		WHEN exc_a OR exc_b OR exc_c THEN SELECT 2;
+	END`)
+	if len(block.Handlers) != 1 {
+		t.Fatalf("handlers = %d, want 1", len(block.Handlers))
+	}
+	if len(handler(t, block, 0).Names) != 3 {
+		t.Errorf("names = %d, want 3 (OR-separated)", len(handler(t, block, 0).Names))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nested SQL inside a block (reuse parseStmt)
+// ---------------------------------------------------------------------------
+
+func TestScript_NestedSQLStatements(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		CREATE TEMP TABLE t (id INT);
+		INSERT INTO t VALUES (1);
+		UPDATE t SET id = 2 WHERE id = 1;
+		DELETE FROM t WHERE id = 2;
+		MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.id = s.id;
+	END`)
+	if len(block.Body) != 5 {
+		t.Fatalf("body = %d, want 5", len(block.Body))
+	}
+}
+
+func TestScript_ExecuteImmediateInBlock(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN EXECUTE IMMEDIATE 'SELECT 1'; END")
+	if _, ok := firstBodyStmt(t, block).(*ast.ExecuteImmediateStmt); !ok {
+		t.Fatalf("body[0] = %T, want *ast.ExecuteImmediateStmt", block.Body[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Real-world example from the legacy corpus (task body, area-of-circle)
+// ---------------------------------------------------------------------------
+
+func TestScript_LegacyCorpusAreaOfCircle(t *testing.T) {
+	block := mustScriptBlock(t, `DECLARE
+		radius_of_circle float;
+		area_of_circle float;
+	BEGIN
+		radius_of_circle := 3;
+		area_of_circle := pi() * radius_of_circle * radius_of_circle;
+		return area_of_circle;
+	END`)
+	if len(block.Decls) != 2 {
+		t.Errorf("decls = %d, want 2", len(block.Decls))
+	}
+	if len(block.Body) != 3 {
+		t.Errorf("body = %d, want 3 (2 assigns + return)", len(block.Body))
+	}
+	if _, ok := block.Body[0].(*ast.ScriptAssignStmt); !ok {
+		t.Errorf("body[0] = %T, want *ast.ScriptAssignStmt", block.Body[0])
+	}
+	if _, ok := block.Body[2].(*ast.ScriptReturnStmt); !ok {
+		t.Errorf("body[2] = %T, want *ast.ScriptReturnStmt", block.Body[2])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deeply nested control flow (exercises depth + segmentation end-to-end)
+// ---------------------------------------------------------------------------
+
+func TestScript_DeeplyNestedControlFlow(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		FOR i IN 1 TO 3 DO
+			IF (i = 2) THEN
+				WHILE (x > 0) DO
+					CASE
+						WHEN x = 1 THEN BREAK;
+						ELSE CONTINUE;
+					END CASE;
+				END WHILE;
+			END IF;
+		END FOR;
+	END`)
+	forStmt, ok := firstBodyStmt(t, block).(*ast.ScriptForStmt)
+	if !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptForStmt", block.Body[0])
+	}
+	ifStmt, ok := forStmt.Body[0].(*ast.ScriptIfStmt)
+	if !ok {
+		t.Fatalf("for body[0] = %T, want *ast.ScriptIfStmt", forStmt.Body[0])
+	}
+	thenBody := ifBranch(t, ifStmt, 0).Body
+	whileStmt, ok := thenBody[0].(*ast.ScriptWhileStmt)
+	if !ok {
+		t.Fatalf("if body[0] = %T, want *ast.ScriptWhileStmt", thenBody[0])
+	}
+	if _, ok := whileStmt.Body[0].(*ast.ScriptCaseStmt); !ok {
+		t.Fatalf("while body[0] = %T, want *ast.ScriptCaseStmt", whileStmt.Body[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negatives — every malformed form must ERROR (and never hang)
+//
+// These are the loop-safety guarantees: an unterminated block / construct must
+// fail fast with a ParseError rather than spin. The Go test runner's package
+// timeout (60s) would catch a hang; these complete in microseconds.
+// ---------------------------------------------------------------------------
+
+func TestScript_Negatives(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"unterminated block (no END)", "BEGIN SELECT 1;"},
+		{"unterminated declare (no BEGIN)", "DECLARE x INT;"},
+		{"unterminated if (no END IF)", "BEGIN IF (x) THEN SELECT 1; END"},
+		{"if missing THEN", "BEGIN IF (x) SELECT 1; END IF; END"},
+		{"if missing parens", "BEGIN IF x THEN SELECT 1; END IF; END"},
+		{"unterminated for", "BEGIN FOR i IN 1 TO 3 DO SELECT i; END"},
+		{"for missing TO", "BEGIN FOR i IN 1 DO SELECT i; END FOR; END"},
+		{"unterminated while", "BEGIN WHILE (x) DO SELECT 1; END"},
+		{"unterminated loop", "BEGIN LOOP SELECT 1; END"},
+		{"repeat missing until", "BEGIN REPEAT SELECT 1; END REPEAT; END"},
+		{"case no when", "BEGIN CASE END CASE; END"},
+		{"exception no when", "BEGIN SELECT 1; EXCEPTION END"},
+		{"fetch missing into", "BEGIN FETCH c1; END"},
+		{"let missing value", "BEGIN LET x INT; END"},
+		{"cursor missing for", "DECLARE c CURSOR SELECT 1; BEGIN RETURN 1; END"},
+		{"declare missing semicolon", "DECLARE x INT y FLOAT; BEGIN RETURN 1; END"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := parseScriptErr(tt.input)
+			if len(errs) == 0 {
+				t.Errorf("%q: expected a parse error, got none", tt.input)
+			}
+		})
+	}
+}
+
+// TestScript_UnterminatedDoesNotHang specifically exercises the most dangerous
+// non-termination shapes (never-closed nested blocks) and asserts they return
+// quickly with an error. If the loop guards regressed, this would hang and the
+// package timeout would fire.
+func TestScript_UnterminatedDoesNotHang(t *testing.T) {
+	// Note: a bare "BEGIN" (BEGIN followed by EOF) is a VALID TCL transaction
+	// opener, not an unterminated scripting block — so it is intentionally NOT
+	// listed here. Every input below opens a scripting block (BEGIN followed by
+	// a statement opener, or DECLARE) that is never closed.
+	inputs := []string{
+		"BEGIN SELECT 1",
+		"BEGIN BEGIN BEGIN",
+		"BEGIN IF (x) THEN",
+		"BEGIN FOR i IN 1 TO 3 DO",
+		"BEGIN LOOP",
+		"BEGIN WHILE (x) DO",
+		"BEGIN REPEAT",
+		"DECLARE x INT",
+		strings.Repeat("BEGIN SELECT 1; ", 50), // 50 unterminated nested-ish blocks
+	}
+	for _, in := range inputs {
+		errs := parseScriptErr(in)
+		if len(errs) == 0 {
+			t.Errorf("%q: expected an error (unterminated), got none", in)
+		}
+	}
+}
+
+// TestScript_DepthBound asserts that pathologically deep nesting fails with a
+// "too deeply" error rather than overflowing the stack. The depth ceiling is
+// maxScriptDepth (200); 1000 nested BEGINs is comfortably past it.
+func TestScript_DepthBound(t *testing.T) {
+	deep := strings.Repeat("BEGIN ", 1000) + strings.Repeat("END ", 1000)
+	errs := parseScriptErr(deep)
+	if len(errs) == 0 {
+		t.Fatal("expected a depth-bound error for 1000-deep nesting, got none")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Msg, "nested too deeply") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a 'nested too deeply' error; got: %v", errs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walker integration — the block and its body statements are reachable.
+// ---------------------------------------------------------------------------
+
+func TestScript_WalkerVisitsBody(t *testing.T) {
+	block := mustScriptBlock(t, "BEGIN SELECT 1; SELECT 2; END")
+	var selects int
+	ast.Inspect(block, func(n ast.Node) bool {
+		if _, ok := n.(*ast.SelectStmt); ok {
+			selects++
+		}
+		return true
+	})
+	if selects != 2 {
+		t.Errorf("walker visited %d SelectStmt, want 2", selects)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Case-insensitivity (Snowflake keywords are case-insensitive)
+// ---------------------------------------------------------------------------
+
+func TestScript_CaseInsensitiveKeywords(t *testing.T) {
+	block := mustScriptBlock(t, "begin if (x = 1) then select 1; end if; end")
+	if _, ok := firstBodyStmt(t, block).(*ast.ScriptIfStmt); !ok {
+		t.Fatalf("body[0] = %T, want *ast.ScriptIfStmt", block.Body[0])
+	}
+}
+
+// TestScript_WalkerReachesNestedSelect confirms the generated walker descends
+// through control-flow body slices (FOR -> IF -> SELECT), since those are
+// []Node fields that genwalker walks.
+func TestScript_WalkerReachesNestedSelect(t *testing.T) {
+	block := mustScriptBlock(t, `BEGIN
+		FOR i IN 1 TO 3 DO
+			IF (i = 1) THEN SELECT 100; END IF;
+		END FOR;
+	END`)
+	var found bool
+	ast.Inspect(block, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectStmt); ok {
+			_ = sel
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Errorf("walker did not reach the nested SELECT inside FOR/IF body")
+	}
+}
+
+// TestScript_AssignExprForms checks assignment RHS reuses the full expression
+// grammar (function calls, casts, semi-structured access, arithmetic).
+func TestScript_AssignExprForms(t *testing.T) {
+	exprs := []string{
+		"x := pi() * 2",
+		"x := y::INT",
+		"x := obj:field",
+		"x := CASE WHEN y > 0 THEN 1 ELSE 0 END",
+		"x := (SELECT max(c) FROM t)",
+	}
+	for _, e := range exprs {
+		t.Run(e, func(t *testing.T) {
+			block := mustScriptBlock(t, "BEGIN "+e+"; END")
+			s, ok := firstBodyStmt(t, block).(*ast.ScriptAssignStmt)
+			if !ok {
+				t.Fatalf("body[0] = %T, want *ast.ScriptAssignStmt", block.Body[0])
+			}
+			if s.Value == nil {
+				t.Errorf("value = nil for %q", e)
+			}
+		})
+	}
+}
+
+// TestScript_FullFormDeclareBodyException exercises a complete block with all
+// three sections: DECLARE, BEGIN body, and EXCEPTION.
+func TestScript_FullFormDeclareBodyException(t *testing.T) {
+	block := mustScriptBlock(t, `DECLARE
+		result INT DEFAULT 0;
+		my_exc EXCEPTION (-20001, 'boom');
+	BEGIN
+		result := 1;
+		IF (result = 1) THEN
+			RAISE my_exc;
+		END IF;
+		RETURN result;
+	EXCEPTION
+		WHEN my_exc THEN
+			RETURN -1;
+		WHEN OTHER THEN
+			RETURN -2;
+	END`)
+	if len(block.Decls) != 2 {
+		t.Errorf("decls = %d, want 2", len(block.Decls))
+	}
+	if len(block.Body) != 3 {
+		t.Errorf("body = %d, want 3 (assign, if, return)", len(block.Body))
+	}
+	if len(block.Handlers) != 2 {
+		t.Errorf("handlers = %d, want 2", len(block.Handlers))
+	}
+}
+
+// TestScript_BeginTransactionStillTCL is a guard that the disambiguation did
+// NOT capture the TCL BEGIN forms into the scripting parser.
+func TestScript_BeginTransactionStillTCL(t *testing.T) {
+	tcl := []string{"BEGIN", "BEGIN;", "BEGIN WORK", "BEGIN TRANSACTION", "BEGIN NAME t1"}
+	for _, in := range tcl {
+		t.Run(in, func(t *testing.T) {
+			result := ParseBestEffort(in)
+			if len(result.Errors) != 0 {
+				t.Fatalf("%q: unexpected errors %v", in, result.Errors)
+			}
+			if len(result.File.Stmts) == 0 {
+				t.Fatalf("%q: no statement parsed", in)
+			}
+			if _, ok := result.File.Stmts[0].(*ast.BeginStmt); !ok {
+				t.Errorf("%q: got %T, want *ast.BeginStmt (TCL)", in, result.File.Stmts[0])
+			}
+		})
+	}
+}
+
+// TestScript_BlockThenStatementSegmentation locks in that a scripting block is
+// kept as ONE segment by Split (even when its loop headers embed CASE/IF
+// expressions, or it contains bare-END CASE), and that a statement following
+// the block is NOT absorbed into it. This guards the Split construct-depth
+// bookkeeping (block extent) end-to-end through ParseBestEffort.
+func TestScript_BlockThenStatementSegmentation(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantStmts int
+	}{
+		{
+			"case-in-while-header then trailing select",
+			"BEGIN WHILE (CASE WHEN x THEN 1 ELSE 0 END > 0) LOOP SELECT 1; END LOOP; END; SELECT 999",
+			2,
+		},
+		{
+			"bare-end case in block then trailing select",
+			"BEGIN CASE WHEN x THEN SELECT 1; END; END; SELECT 2",
+			2,
+		},
+		{
+			"nested standalone loop inside while-do then trailing select",
+			"BEGIN WHILE (x) DO LOOP SELECT 1; END LOOP; END WHILE; END; SELECT 7",
+			2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseBestEffort(tt.input)
+			if len(result.Errors) != 0 {
+				t.Fatalf("%q: unexpected errors %v", tt.input, result.Errors)
+			}
+			if len(result.File.Stmts) != tt.wantStmts {
+				t.Fatalf("%q: got %d statements, want %d", tt.input, len(result.File.Stmts), tt.wantStmts)
+			}
+			// The first statement must be the scripting block; the last must be
+			// the trailing SELECT (not absorbed).
+			if _, ok := result.File.Stmts[0].(*ast.ScriptBlockStmt); !ok {
+				t.Errorf("stmt[0] = %T, want *ast.ScriptBlockStmt", result.File.Stmts[0])
+			}
+			last := result.File.Stmts[len(result.File.Stmts)-1]
+			if _, ok := last.(*ast.SelectStmt); !ok {
+				t.Errorf("last stmt = %T, want *ast.SelectStmt (trailing, not absorbed)", last)
+			}
+		})
+	}
+}

--- a/snowflake/parser/split.go
+++ b/snowflake/parser/split.go
@@ -46,7 +46,9 @@ const (
 //   - $$...$$ dollar strings
 //   - X'...' hex literals
 //   - Line comments (-- and //) and block comments (/* */ including nested)
-//   - Snowflake Scripting BEGIN..END blocks (including nested and DECLARE..BEGIN..END)
+//   - Snowflake Scripting BEGIN..END blocks (including nested and DECLARE..BEGIN..END),
+//     including bodies that contain control-flow closers END IF / END FOR / END WHILE /
+//     END LOOP / END REPEAT / END CASE (these do not prematurely close the block)
 //   - Inline procedure bodies (CREATE TASK/PROCEDURE/FUNCTION ... AS BEGIN ... END;)
 //
 // Split does NOT handle:
@@ -63,6 +65,20 @@ func Split(input string) []Segment {
 	stmtStart := 0
 	state := stateTop
 	depth := 0
+	// prevSig is the previous significant token type inside a block, used to
+	// disambiguate a loop FOR from a CURSOR FOR (the latter must not be counted
+	// as a construct opener). awaitBodyDepth records the block depth at which a
+	// FOR/WHILE header was opened and is still waiting for its body opener
+	// (DO / LOOP); it is -1 when no header is pending. Matching the body opener
+	// on depth (rather than a bare flag) keeps a construct nested INSIDE the
+	// loop header — e.g. a CASE expression in a WHILE condition — from clobbering
+	// the pending-body state, so the real body-opener LOOP is not mistaken for a
+	// standalone LOOP construct. afterEnd is set immediately after an END so the
+	// construct keyword of a closer suffix (END IF / END FOR / END WHILE /
+	// END LOOP / END REPEAT / END CASE) is not re-counted as an opener.
+	prevSig := 0
+	awaitBodyDepth := -1
+	afterEnd := false
 
 	// We need one-token lookahead after kwBEGIN to disambiguate TCL from
 	// scripting. Use a one-slot buffered lookahead.
@@ -117,6 +133,8 @@ func Split(input string) []Segment {
 				} else {
 					state = stateInBlock
 					depth = 1
+					prevSig = kwBEGIN
+					awaitBodyDepth = -1
 				}
 			case int(';'):
 				// tok.Loc.Start is the position of the `;`, tok.Loc.End is
@@ -131,21 +149,69 @@ func Split(input string) []Segment {
 			case kwBEGIN:
 				state = stateInBlock
 				depth = 1
+				prevSig = kwBEGIN
+				awaitBodyDepth = -1
 			}
 			// Semicolons and all other tokens are absorbed in stateInDeclare.
 
 		case stateInBlock:
-			switch tok.Type {
-			case kwBEGIN:
+			// Inside a scripting block, segment boundaries are suppressed: the
+			// whole block (and everything nested in it) is one segment. Track
+			// nesting by counting construct OPENERS against their closing END
+			// tokens. Every scripting construct — the BEGIN block itself, IF,
+			// CASE, FOR/WHILE/REPEAT/LOOP — is closed by exactly one END token
+			// (END, END IF, END FOR, END CASE, ...), so a balanced opener/END
+			// count returns to zero precisely at the block's terminating END,
+			// regardless of whether a CASE closes with bare `END` or `END CASE`.
+			//
+			// Two keyword overloads are excluded from the opener count:
+			//   - FOR in `CURSOR FOR <query>` (a declaration clause, not a loop).
+			//   - LOOP / DO acting as a FOR/WHILE body opener (not a standalone
+			//     LOOP construct).
+			switch {
+			case afterEnd && isEndCloserKeyword(tok.Type):
+				// Closer suffix of the just-seen END (END IF / END FOR / ...).
+				// Consume without counting it as an opener.
+				afterEnd = false
+			case tok.Type == kwBEGIN || tok.Type == kwIF || tok.Type == kwCASE ||
+				tok.Type == kwSCRIPT_REPEAT:
 				depth++
-			case kwEND:
+				afterEnd = false
+			case tok.Type == kwSCRIPT_WHILE:
+				depth++
+				awaitBodyDepth = depth // WHILE ( cond ) { DO | LOOP }
+				afterEnd = false
+			case tok.Type == kwFOR:
+				if prevSig != kwSCRIPT_CURSOR {
+					depth++
+					awaitBodyDepth = depth // FOR ... { DO | LOOP }
+				}
+				afterEnd = false
+			case tok.Type == kwSCRIPT_LOOP:
+				if awaitBodyDepth == depth {
+					// Body opener of the FOR/WHILE at this depth — not a construct.
+					awaitBodyDepth = -1
+				} else {
+					depth++ // standalone LOOP ... END LOOP
+				}
+				afterEnd = false
+			case tok.Type == kwDO:
+				if awaitBodyDepth == depth {
+					awaitBodyDepth = -1 // FOR/WHILE body opener
+				}
+				afterEnd = false
+			case tok.Type == kwEND:
 				if depth > 0 {
 					depth--
 					if depth == 0 {
 						state = stateTop
 					}
 				}
+				afterEnd = true
+			default:
+				afterEnd = false
 			}
+			prevSig = tok.Type
 			// Semicolons and all other tokens are absorbed in stateInBlock.
 		}
 	}
@@ -167,6 +233,19 @@ func Split(input string) []Segment {
 func isTCLBeginFollower(tok Token) bool {
 	switch tok.Type {
 	case int(';'), tokEOF, kwTRANSACTION, kwWORK, kwNAME:
+		return true
+	}
+	return false
+}
+
+// isEndCloserKeyword reports whether tokType is a construct keyword that can
+// immediately follow END to form a control-flow closer (END IF / END FOR /
+// END WHILE / END LOOP / END REPEAT / END CASE). When Split sees one of these
+// right after an END, it consumes it as a closer suffix rather than counting it
+// as a new construct opener.
+func isEndCloserKeyword(tokType int) bool {
+	switch tokType {
+	case kwIF, kwFOR, kwCASE, kwSCRIPT_WHILE, kwSCRIPT_LOOP, kwSCRIPT_REPEAT:
 		return true
 	}
 	return false

--- a/snowflake/parser/tokens.go
+++ b/snowflake/parser/tokens.go
@@ -933,6 +933,31 @@ const (
 	kwYEARLY
 	kwZSTD
 	// KEYWORD_CONSTANTS_END
+
+	// Snowflake Scripting keywords (T7.1). These are absent from the
+	// SnowflakeLexer.g4 extraction (the legacy grammar modeled scripting only
+	// minimally), so they are appended here rather than in the generated region
+	// above. They are non-reserved (usable as identifiers); see keywordMap. As
+	// bare entries they continue the enclosing `700 + iota` const block, so each
+	// gets a distinct value just past kwZSTD.
+	kwSCRIPT_WHILE
+	kwSCRIPT_LOOP
+	kwSCRIPT_REPEAT
+	kwSCRIPT_UNTIL
+	kwSCRIPT_LET
+	kwSCRIPT_BREAK
+	kwSCRIPT_EXCEPTION
+	kwSCRIPT_RAISE
+	kwSCRIPT_CURSOR
+	kwSCRIPT_RESULTSET
+	kwSCRIPT_REVERSE
+	kwSCRIPT_ASYNC
+	kwSCRIPT_OTHER
+	kwSCRIPT_EXIT
+	kwSCRIPT_ITERATE
+	kwSCRIPT_OPEN
+	kwSCRIPT_CLOSE
+	kwSCRIPT_ELSEIF
 )
 
 // TokenName returns a human-readable name for a token type. Used by tests

--- a/snowflake/parser/transaction_test.go
+++ b/snowflake/parser/transaction_test.go
@@ -198,25 +198,23 @@ func TestBegin_Loc(t *testing.T) {
 	}
 }
 
-// Trailing-junk leniency: like every other omni snowflake statement parser
-// (verified against parseDropStmt / parseTruncateStmt / parseUseStmt, which all
-// accept "<stmt> junk" with zero errors), parseBeginStmt consumes exactly the
-// grammar it owns and leaves any trailing tokens unconsumed without raising an
-// error. Real Snowflake rejects "BEGIN FOO" as a syntax error; omni's
-// engine-wide convention is to trust the F3 splitter and not enforce
-// trailing-token strictness per node. This is a pre-existing engine-wide
-// divergence (recorded in the divergence ledger), not specific to TCL. The
-// statement still parses to the correct BeginStmt with the right Kind.
-func TestBegin_TrailingJunkLenient(t *testing.T) {
-	stmt, errs := testParseBeginStmt("BEGIN FOO")
-	if len(errs) != 0 {
-		t.Fatalf("BEGIN FOO: expected lenient parse (engine-wide convention), got errors: %v", errs)
+// BEGIN disambiguation (T7.1): a BEGIN followed by a token that is NOT a TCL
+// modifier (WORK / TRANSACTION / NAME / ; / EOF) no longer opens a transaction
+// — it opens a Snowflake Scripting BLOCK. "BEGIN FOO" is therefore a scripting
+// block whose body begins with FOO; because the block is never closed (no END),
+// it is a malformed block and errors. This supersedes the old TCL trailing-junk
+// leniency for the "BEGIN FOO" shape (the real TCL forms below are unaffected
+// because WORK / TRANSACTION / NAME keep BEGIN on the transaction path).
+func TestBegin_FooRoutesToScriptBlock(t *testing.T) {
+	result := ParseBestEffort("BEGIN FOO")
+	if len(result.Errors) == 0 {
+		t.Fatal("BEGIN FOO: expected an error (unterminated scripting block), got none")
 	}
-	if stmt.Kind != ast.BeginBare {
-		t.Errorf("kind = %v, want BeginBare", stmt.Kind)
-	}
-	if !stmt.Name.IsEmpty() {
-		t.Errorf("expected no NAME (FOO is trailing junk, not consumed), got %q", stmt.Name.Normalize())
+	// It must NOT be parsed as a TCL BeginStmt.
+	if len(result.File.Stmts) > 0 {
+		if _, ok := result.File.Stmts[0].(*ast.BeginStmt); ok {
+			t.Errorf("BEGIN FOO parsed as *ast.BeginStmt; expected a scripting-block routing")
+		}
 	}
 }
 


### PR DESCRIPTION
## Node
`snowflake/scripting` (v1 DAG **T7.1**) — Snowflake Scripting blocks, **structural parse only** (no semantic/type checking — matches legacy depth).

## Forms
`[DECLARE <decls>] BEGIN <stmts> [EXCEPTION <handlers>] END [<label>];` with: variable/cursor/resultset/exception declarations; `LET`/`:=` assignment; `IF/ELSEIF/ELSE … END IF`; `CASE … END [CASE]`; counter & cursor `FOR … END FOR`; `WHILE … END WHILE`; `REPEAT … UNTIL … END REPEAT`; `LOOP … END LOOP`; `BREAK`/`CONTINUE [<label>]`; `RETURN`; `OPEN`/`FETCH`/`CLOSE` cursor; `RAISE`; `EXECUTE IMMEDIATE` (reused); nested SQL (reuses `parseStmt`); nested blocks. 20 new AST nodes, sub-nodes as real `Node`s in `[]Node` slices so the regenerated walker reaches nested bodies/queries. Scripting keywords added to `keywords.go`/`tokens.go`.

## BEGIN disambiguation
`BEGIN` followed by `WORK`/`TRANSACTION`/`NAME`/`;`/EOF → TCL `BeginStmt`; otherwise → a scripting block. Made consistent across `parser.go` dispatch **and** the `split.go` segmenter (which previously mis-split blocks containing control-flow `END`s).

## Infinite-loop protection (highest-risk concern — verified)
Three structural guarantees: (1) every statement/decl loop treats `tokEOF` as an unconditional terminator → never-closed block = fast "unterminated …" error; (2) a `noProgress` guard returns an error if an iteration consumes 0 tokens; (3) a `scriptDepth` bound (`maxScriptDepth=200`) caps recursion. Tested with `BEGIN`×1000 (depth error), 8 unterminated shapes, never-closed nested blocks.

## Oracle / tests
Triangulation — official docs (authoritative; legacy `.g4` modeled only a thin BEGIN..END/DECLARE subset) + corpus `testdata/official/begin`. **110+ tests**, every documented form + Loc + negatives + loop/depth guards. **Full `go test ./snowflake/...` green** (incl. `split_test.go` — the segmenter change breaks nothing); `go vet`/`gofmt` clean.

## Divergences (ledger; docs win)
1. flagged — full scripting surface vs legacy's thin subset. 2. confirmed — non-TCL `BEGIN` now opens a scripting block (`BEGIN FOO` now errors). 3. flagged — counter FOR supports `REVERSE` but not a `BY` step (docs show none). 4. flagged — top-level standalone scripting statements accepted leniently.

## Out-of-scope writes (recorded, justified)
- `snowflake/parser/split.go` — rewrote `stateInBlock` to balanced construct-opener/END counting (CURSOR-FOR + body-opener-LOOP depth-matched guards) so a whole scripting block stays one segment.
- `snowflake/parser/parser_test.go` + `transaction_test.go` — 2 pre-existing placeholder tests that explicitly anticipated T7.1, updated (BeginEndBlock now expects `ScriptBlockStmt`); all other TCL BEGIN tests unchanged + green.

## Review
Claude `/code-review` (high, inline; Codex down) — found + fixed **2 real bugs** (Split `awaitBody` clobbered by a CASE/IF in a loop header → depth-matched fix; `tryParseScriptLabel` accepting non-reserved keywords → restricted to idents), each with a regression test. Orchestrator independently verified build / full `-timeout` suite / split tests / scope / gofmt.

## Follow-up (non-blocking)
Deparse + analysis support for the new scripting nodes (currently graceful "unsupported" error — parity with legacy, which had no scripting deparse). The AST is fully walker-reachable for a future analysis pass.

## Note
Opened by orchestrator from the worker's verified, pushed commit `d9644f0d`. No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)