### PR TITLE
feat(snowflake): $N positional + $var references as expressions

### DIFF
--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -22,6 +22,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *StarExpr:
 		return v.Loc
+	case *DollarRef:
+		return v.Loc
 	case *BinaryExpr:
 		return v.Loc
 	case *UnaryExpr:

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -28,6 +28,7 @@ const (
 	T_Literal
 	T_ColumnRef
 	T_StarExpr
+	T_DollarRef
 	T_BinaryExpr
 	T_UnaryExpr
 	T_ParenExpr
@@ -241,6 +242,8 @@ func (t NodeTag) String() string {
 		return "ColumnRef"
 	case T_StarExpr:
 		return "StarExpr"
+	case T_DollarRef:
+		return "DollarRef"
 	case T_BinaryExpr:
 		return "BinaryExpr"
 	case T_UnaryExpr:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -453,6 +453,27 @@ type StarExpr struct {
 
 func (n *StarExpr) Tag() NodeTag { return T_StarExpr }
 
+// DollarRef represents a Snowflake '$'-reference used as a primary expression:
+//
+//   - $N          positional column reference (Positional=true, Name="N").
+//     Used in COPY-transform / stage queries (SELECT $1, $2 FROM @stage) and
+//     anywhere a column may appear.
+//   - $<name>     session-variable / scripting-variable reference
+//     (Positional=false), e.g. $min, $Variable1.
+//   - <qual>.$N   positional reference qualified by a table alias or name
+//     (e.g. d.$1), with the leading qualifier captured in Qualifier.
+//
+// The lexer strips the leading '$' and emits a single tokVariable whose text is
+// stored in Name; Positional records whether that text is all decimal digits.
+type DollarRef struct {
+	Qualifier  *ObjectName // optional leading qualifier (e.g. d in d.$1); nil when bare
+	Name       string      // text after '$': digits for positional, identifier otherwise
+	Positional bool        // true when Name is all decimal digits ($1, $2, ...)
+	Loc        Loc
+}
+
+func (n *DollarRef) Tag() NodeTag { return T_DollarRef }
+
 // BinaryExpr represents a binary operation: left op right.
 type BinaryExpr struct {
 	Op    BinaryOp

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -410,6 +410,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.NameLiteral != nil {
 			Walk(v, n.NameLiteral)
 		}
+	case *DollarRef:
+		if n.Qualifier != nil {
+			Walk(v, n.Qualifier)
+		}
 	case *DropDatabaseStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)

--- a/snowflake/deparse/deparse_expr.go
+++ b/snowflake/deparse/deparse_expr.go
@@ -20,6 +20,8 @@ func (w *writer) writeExpr(node ast.Node) error {
 		return w.writeColumnRef(n)
 	case *ast.StarExpr:
 		return w.writeStarExpr(n)
+	case *ast.DollarRef:
+		return w.writeDollarRef(n)
 	case *ast.BinaryExpr:
 		return w.writeBinaryExpr(n)
 	case *ast.UnaryExpr:
@@ -109,6 +111,20 @@ func (w *writer) writeStarExpr(n *ast.StarExpr) error {
 	} else {
 		w.buf.WriteByte('*')
 	}
+	return nil
+}
+
+// writeDollarRef emits a $-reference: [qualifier.]$Name. The leading '$' is
+// re-attached (the lexer stripped it; Name holds only the bare text). Mirrors
+// writeStarExpr's qualifier handling.
+func (w *writer) writeDollarRef(n *ast.DollarRef) error {
+	w.ensureSpace()
+	if n.Qualifier != nil {
+		w.writeObjectNameNoSpace(n.Qualifier)
+		w.buf.WriteByte('.')
+	}
+	w.buf.WriteByte('$')
+	w.buf.WriteString(n.Name)
 	return nil
 }
 

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -760,3 +760,30 @@ func TestDeparse_UnsupportedNode(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported")
 }
+
+// ---------------------------------------------------------------------------
+// $-reference deparse (positional $N + named $var, optional qualifier).
+// Round-trip is the structural correctness gate for the DollarRef node.
+// ---------------------------------------------------------------------------
+
+func TestDeparse_DollarPositional(t *testing.T) {
+	assertRoundTrip(t, `SELECT $1, $2 FROM t`)
+}
+
+func TestDeparse_DollarQualified(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT d.$1 FROM t AS d`)
+	require.Contains(t, out, "d.$1")
+}
+
+func TestDeparse_DollarNamedVar(t *testing.T) {
+	assertRoundTrip(t, `SELECT 2 * $min FROM t`)
+}
+
+func TestDeparse_DollarColonCast(t *testing.T) {
+	assertRoundTrip(t, `SELECT $1:num::NUMBER AS num FROM t`)
+}
+
+func TestDeparse_DollarFuncArg(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT TO_DATE($1) FROM t`)
+	require.Contains(t, out, "$1")
+}

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -414,6 +414,13 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		tok := p.advance()
 		return &ast.StarExpr{Loc: tok.Loc}, nil
 
+	case tokVariable:
+		// $N positional column ref or $<name> session/scripting variable. The
+		// lexer strips the leading '$' (Str holds the bare name) and folds both
+		// forms into tokVariable. A lone '$' is emitted as a bare ASCII token,
+		// not tokVariable, so it falls through to the default error branch.
+		return p.parseDollarRef(nil), nil
+
 	// Reserved keywords that are also common zero-argument functions:
 	// CURRENT_TIMESTAMP([prec]), CURRENT_DATE, CURRENT_TIME([prec]).
 	// Snowflake allows them both with and without parentheses.
@@ -488,8 +495,46 @@ func (p *Parser) parseIdentExpr() (ast.Node, error) {
 	}, nil
 }
 
+// parseDollarRef builds a *ast.DollarRef from the current tokVariable token,
+// consuming it. qualifier is the optional leading table/alias qualifier (e.g.
+// the d in d.$1) or nil for a bare $-reference. The leading '$' was stripped by
+// the lexer, so the token text is the bare name; Positional is set when that
+// text is composed solely of decimal digits ($1, $2, ...).
+//
+// The caller must ensure p.cur.Type == tokVariable.
+func (p *Parser) parseDollarRef(qualifier *ast.ObjectName) *ast.DollarRef {
+	tok := p.advance() // consume the $-token
+	start := tok.Loc.Start
+	if qualifier != nil {
+		start = qualifier.Loc.Start
+	}
+	return &ast.DollarRef{
+		Qualifier:  qualifier,
+		Name:       tok.Str,
+		Positional: isAllDigits(tok.Str),
+		Loc:        ast.Loc{Start: start, End: tok.Loc.End},
+	}
+}
+
+// isAllDigits reports whether s is non-empty and every byte is a decimal digit.
+// A tokVariable text is always non-empty (the lexer only emits it for '$'
+// followed by at least one [A-Za-z0-9_] character), but the empty guard keeps
+// the predicate honest for any other caller.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // parseDottedIdentOrFunc handles dotted names after the first ident.
-// Returns a ColumnRef, StarExpr, or FuncCallExpr depending on what follows.
+// Returns a ColumnRef, StarExpr, DollarRef, or FuncCallExpr depending on what
+// follows.
 func (p *Parser) parseDottedIdentOrFunc(first ast.Ident) (ast.Node, error) {
 	parts := []ast.Ident{first}
 
@@ -524,6 +569,34 @@ func (p *Parser) parseDottedIdentOrFunc(first ast.Ident) (ast.Node, error) {
 				Qualifier: qualifier,
 				Loc:       ast.Loc{Start: first.Loc.Start, End: starTok.Loc.End},
 			}, nil
+		}
+
+		// table.$N — positional column ref qualified by a table alias/name
+		// (e.g. d.$1 in a COPY transform). The accumulated dotted parts become
+		// the DollarRef qualifier, mirroring the table.* case above.
+		if p.cur.Type == tokVariable {
+			var qualifier *ast.ObjectName
+			switch len(parts) {
+			case 1:
+				qualifier = &ast.ObjectName{
+					Name: parts[0],
+					Loc:  parts[0].Loc,
+				}
+			case 2:
+				qualifier = &ast.ObjectName{
+					Schema: parts[0],
+					Name:   parts[1],
+					Loc:    ast.Loc{Start: parts[0].Loc.Start, End: parts[1].Loc.End},
+				}
+			case 3:
+				qualifier = &ast.ObjectName{
+					Database: parts[0],
+					Schema:   parts[1],
+					Name:     parts[2],
+					Loc:      ast.Loc{Start: parts[0].Loc.Start, End: parts[2].Loc.End},
+				}
+			}
+			return p.parseDollarRef(qualifier), nil
 		}
 
 		ident, err := p.parseIdent()

--- a/snowflake/parser/expr_test.go
+++ b/snowflake/parser/expr_test.go
@@ -1516,3 +1516,277 @@ func TestExpr_WindowSingleBound(t *testing.T) {
 		t.Errorf("Start.Kind = %v, want BoundUnboundedPreceding", fc.Over.Frame.Start.Kind)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// $-references ($N positional column refs, $<name> variable refs)
+//
+// Oracle: official Snowflake docs (truth1) + the previously-filtered corpus
+// forms (copyDollarLimited / execCallDollarLimited / SET $var). The legacy
+// SnowflakeParser.g4 is not vendored in this tree, so docs + corpus are the
+// authoritative sources. The lexer collapses both forms into a single
+// tokVariable (leading '$' stripped); Positional is derived from the text.
+// ---------------------------------------------------------------------------
+
+func TestExpr_DollarPositional(t *testing.T) {
+	node, err := testParseExpr("$1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dr, ok := node.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("expected *ast.DollarRef, got %T", node)
+	}
+	if dr.Name != "1" {
+		t.Errorf("Name = %q, want %q", dr.Name, "1")
+	}
+	if !dr.Positional {
+		t.Error("Positional should be true for $1")
+	}
+	if dr.Qualifier != nil {
+		t.Error("expected nil Qualifier for bare $1")
+	}
+	// Loc must span the whole token including the leading '$'.
+	if dr.Loc.Start != 0 || dr.Loc.End != 2 {
+		t.Errorf("Loc = %+v, want {0 2}", dr.Loc)
+	}
+}
+
+func TestExpr_DollarPositionalMultiDigit(t *testing.T) {
+	node, err := testParseExpr("$42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dr, ok := node.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("expected *ast.DollarRef, got %T", node)
+	}
+	if dr.Name != "42" || !dr.Positional {
+		t.Errorf("got Name=%q Positional=%v, want \"42\" true", dr.Name, dr.Positional)
+	}
+}
+
+func TestExpr_DollarNamedVar(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantName string
+	}{
+		{"$min", "min"},
+		{"$Variable1", "Variable1"},
+		{"$ABC_123", "ABC_123"},
+		{"$_x", "_x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node, err := testParseExpr(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			dr, ok := node.(*ast.DollarRef)
+			if !ok {
+				t.Fatalf("expected *ast.DollarRef, got %T", node)
+			}
+			if dr.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", dr.Name, tt.wantName)
+			}
+			if dr.Positional {
+				t.Errorf("Positional should be false for %s", tt.input)
+			}
+			if dr.Qualifier != nil {
+				t.Error("expected nil Qualifier")
+			}
+		})
+	}
+}
+
+func TestExpr_DollarQualifiedPositional(t *testing.T) {
+	// d.$1 — positional column ref qualified by table alias d (COPY transform).
+	node, err := testParseExpr("d.$1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dr, ok := node.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("expected *ast.DollarRef, got %T", node)
+	}
+	if dr.Name != "1" || !dr.Positional {
+		t.Errorf("got Name=%q Positional=%v, want \"1\" true", dr.Name, dr.Positional)
+	}
+	if dr.Qualifier == nil {
+		t.Fatal("expected non-nil Qualifier for d.$1")
+	}
+	if dr.Qualifier.Name.Name != "d" {
+		t.Errorf("Qualifier.Name = %q, want %q", dr.Qualifier.Name.Name, "d")
+	}
+	// Loc spans from the qualifier start to the $-token end.
+	if dr.Loc.Start != 0 || dr.Loc.End != 4 {
+		t.Errorf("Loc = %+v, want {0 4}", dr.Loc)
+	}
+}
+
+func TestExpr_DollarQualifiedSchemaTable(t *testing.T) {
+	// s.t.$1 — two-part qualifier on a positional ref.
+	node, err := testParseExpr("s.t.$1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dr, ok := node.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("expected *ast.DollarRef, got %T", node)
+	}
+	if dr.Qualifier == nil {
+		t.Fatal("expected non-nil Qualifier")
+	}
+	if dr.Qualifier.Schema.Name != "s" || dr.Qualifier.Name.Name != "t" {
+		t.Errorf("Qualifier = %s.%s, want s.t", dr.Qualifier.Schema.Name, dr.Qualifier.Name.Name)
+	}
+}
+
+func TestExpr_DollarColonCast(t *testing.T) {
+	// $1:num::number — positional ref, semi-structured colon access, then cast.
+	// Composes through the infix loop: CastExpr(AccessExpr(Colon, DollarRef, num)).
+	node, err := testParseExpr("$1:num::number")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if !cast.ColonColon {
+		t.Error("ColonColon should be true")
+	}
+	acc, ok := cast.Expr.(*ast.AccessExpr)
+	if !ok {
+		t.Fatalf("expected *ast.AccessExpr, got %T", cast.Expr)
+	}
+	if acc.Kind != ast.AccessColon || acc.Field.Name != "num" {
+		t.Errorf("access = %v %q, want Colon num", acc.Kind, acc.Field.Name)
+	}
+	dr, ok := acc.Expr.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("expected *ast.DollarRef, got %T", acc.Expr)
+	}
+	if dr.Name != "1" || !dr.Positional {
+		t.Errorf("got Name=%q Positional=%v, want \"1\" true", dr.Name, dr.Positional)
+	}
+}
+
+func TestExpr_DollarArithmetic(t *testing.T) {
+	// $1 + $2 — DollarRefs compose as arithmetic operands.
+	node, err := testParseExpr("$1 + $2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if bin.Op != ast.BinAdd {
+		t.Errorf("Op = %v, want BinAdd", bin.Op)
+	}
+	if _, ok := bin.Left.(*ast.DollarRef); !ok {
+		t.Errorf("Left = %T, want *ast.DollarRef", bin.Left)
+	}
+	if _, ok := bin.Right.(*ast.DollarRef); !ok {
+		t.Errorf("Right = %T, want *ast.DollarRef", bin.Right)
+	}
+}
+
+func TestExpr_DollarInArithmeticWithVar(t *testing.T) {
+	// 2 * $min — the SET corpus form (set/example_06.sql value).
+	node, err := testParseExpr("2 * $min")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	dr, ok := bin.Right.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("Right = %T, want *ast.DollarRef", bin.Right)
+	}
+	if dr.Name != "min" || dr.Positional {
+		t.Errorf("got Name=%q Positional=%v, want \"min\" false", dr.Name, dr.Positional)
+	}
+}
+
+func TestExpr_DollarAsFuncArg(t *testing.T) {
+	// TO_DATE($1) — positional ref as a function argument (copy-into-location).
+	node, err := testParseExpr("TO_DATE($1)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(fc.Args))
+	}
+	dr, ok := fc.Args[0].(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("Args[0] = %T, want *ast.DollarRef", fc.Args[0])
+	}
+	if dr.Name != "1" || !dr.Positional {
+		t.Errorf("got Name=%q Positional=%v, want \"1\" true", dr.Name, dr.Positional)
+	}
+}
+
+func TestExpr_DollarVarAsFuncArg(t *testing.T) {
+	// p($v) argument form — the execCallDollarLimited corpus case.
+	node, err := testParseExpr("p($v)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(fc.Args))
+	}
+	dr, ok := fc.Args[0].(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("Args[0] = %T, want *ast.DollarRef", fc.Args[0])
+	}
+	if dr.Name != "v" || dr.Positional {
+		t.Errorf("got Name=%q Positional=%v, want \"v\" false", dr.Name, dr.Positional)
+	}
+}
+
+func TestExpr_DollarBracketAccess(t *testing.T) {
+	// $1[0] — positional ref with array subscript (semi-structured).
+	node, err := testParseExpr("$1[0]")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acc, ok := node.(*ast.AccessExpr)
+	if !ok {
+		t.Fatalf("expected *ast.AccessExpr, got %T", node)
+	}
+	if acc.Kind != ast.AccessBracket {
+		t.Errorf("Kind = %v, want AccessBracket", acc.Kind)
+	}
+	if _, ok := acc.Expr.(*ast.DollarRef); !ok {
+		t.Errorf("Expr = %T, want *ast.DollarRef", acc.Expr)
+	}
+}
+
+// Negative: a lone '$' with no following name/number is not a DollarRef — the
+// lexer emits a bare '$' ASCII token which the expression parser must reject.
+func TestExpr_DollarBareIsError(t *testing.T) {
+	_, err := testParseExpr("$")
+	if err == nil {
+		t.Fatal("expected an error for a lone '$'")
+	}
+}
+
+// Negative: '$' followed by whitespace then a number is still a lone '$' (the
+// digits are a separate token) and must error.
+func TestExpr_DollarSpaceNumberIsError(t *testing.T) {
+	_, err := testParseExpr("$ 1")
+	if err == nil {
+		t.Fatal("expected an error for '$ 1' (bare $ followed by separate number)")
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/expr-dollar-refs` (cross-cutting fix) — adds Snowflake `$`-references as primary expressions via a new `ast.DollarRef` node.

## Forms
- `$N` — positional column ref (`Positional=true`), e.g. `SELECT $1, $2 FROM @stage`.
- `$<name>` — session/scripting variable (`Positional=false`), e.g. `$min`, `$Variable1`.
- `<qual>.$N` — positional ref qualified by table alias/name (`d.$1`), mirroring `table.*`.

## Design
The lexer already folds both forms into a single `tokVariable` (leading `$` stripped) — **no lexer change**. The parser derives `Positional` from all-digits text; `DollarRef` composes through the existing infix loop, so `$1:num`, `$1::number`, `$1[0]`, `$1 + $2`, `TO_DATE($1)` parse for free. A lone `$` is rejected. Removes the expression-parser blocker behind `copyDollarLimited`/`execCallDollarLimited`/SET-`$var` filters (filters left untouched — `corpus-closure` owns cleanup).

## Oracle / tests
Triangulation — official docs + previously-filtered corpus forms. 14 expr unit tests (positional/named, 1-/2-part qualifier, colon-access+cast, bracket, arithmetic, func args, 2 negatives) + **5 deparse round-trip tests** (parse→deparse→re-parse→AST-equal — the structural gate). Full `go test ./snowflake/...` + `go vet` green; gofmt clean.

## Review (Claude `/code-review`; Codex down) — 2 confirmed bugs fixed
1. `ast/loc.go` `NodeLoc` was missing the `*DollarRef` case → the Loc of any expression composing a DollarRef (`$1+$2`, `$1::number`) was corrupted to `{-1,-1}`. Fixed + verified.
2. `deparse/deparse_expr.go` `writeExpr` hard-errored on the new node → fixed with `writeDollarRef`. Verified `analysis` degrades gracefully (no fix needed).

## Out-of-scope writes (required, recorded)
- `ast/loc.go` — NodeLoc `*DollarRef` case (non-negotiable; corrupts Loc otherwise).
- `deparse/deparse_expr.go` + `deparse_test.go` — DollarRef deparse case + 5 round-trip tests.

## Divergences (ledger 158-160)
- 158 confirmed — `$N`/`$<name>` as primary expression (additive support).
- 159 flagged — positional-vs-named derives from lexer text (mixed `$1abc` → named); no live oracle to verify the exact boundary.
- 160 flagged — residual `SELECT … FROM @stage` / `FROM TABLE(…)` blockers on some corpus forms are NOT `$`-refs (proven — fail without `$` too); owned by table-reference handling.

## Note
Opened by orchestrator from verified commit `d42802fd`. No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)