### PR TITLE
feat(googlesql): procedural scripting (DECLARE/SET/IF/loops/BEGIN-END/EXECUTE IMMEDIATE/RAISE/labels)

### DIFF
--- a/googlesql/ast/nodetags.go
+++ b/googlesql/ast/nodetags.go
@@ -263,6 +263,28 @@ const (
 	T_UnpivotClause
 	T_UnpivotInItem
 	T_SampleClause
+
+	// Procedural / scripting statements (parser-scripting node). The control-flow
+	// and variable statements of BigQuery's procedural language
+	// (GoogleSQLParser.g4 §2.11): a hand-port of ZetaSQL's script statement_list.
+	T_DeclareStmt
+	T_SetStmt
+	T_IfStmt
+	T_ElseIfClause
+	T_CaseStmt
+	T_WhenThenClause
+	T_WhileStmt
+	T_LoopStmt
+	T_RepeatStmt
+	T_ForInStmt
+	T_BeginEndBlock
+	T_BreakStmt
+	T_ContinueStmt
+	T_ReturnStmt
+	T_RaiseStmt
+	T_ExecuteImmediateStmt
+	T_UsingArg
+	T_LabeledStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -592,6 +614,42 @@ func (t NodeTag) String() string {
 		return "UnpivotInItem"
 	case T_SampleClause:
 		return "SampleClause"
+	case T_DeclareStmt:
+		return "DeclareStmt"
+	case T_SetStmt:
+		return "SetStmt"
+	case T_IfStmt:
+		return "IfStmt"
+	case T_ElseIfClause:
+		return "ElseIfClause"
+	case T_CaseStmt:
+		return "CaseStmt"
+	case T_WhenThenClause:
+		return "WhenThenClause"
+	case T_WhileStmt:
+		return "WhileStmt"
+	case T_LoopStmt:
+		return "LoopStmt"
+	case T_RepeatStmt:
+		return "RepeatStmt"
+	case T_ForInStmt:
+		return "ForInStmt"
+	case T_BeginEndBlock:
+		return "BeginEndBlock"
+	case T_BreakStmt:
+		return "BreakStmt"
+	case T_ContinueStmt:
+		return "ContinueStmt"
+	case T_ReturnStmt:
+		return "ReturnStmt"
+	case T_RaiseStmt:
+		return "RaiseStmt"
+	case T_ExecuteImmediateStmt:
+		return "ExecuteImmediateStmt"
+	case T_UsingArg:
+		return "UsingArg"
+	case T_LabeledStmt:
+		return "LabeledStmt"
 	default:
 		return "Unknown"
 	}

--- a/googlesql/ast/parsenodes.go
+++ b/googlesql/ast/parsenodes.go
@@ -4188,3 +4188,373 @@ var (
 	_ Node = (*LabelAndProperties)(nil)
 	_ Node = (*DerivedProperty)(nil)
 )
+
+// ===========================================================================
+// Procedural / scripting statements (googlesql/parser-scripting node)
+// ===========================================================================
+//
+// BigQuery's procedural language (GoogleSQLParser.g4 §2.11, a hand-port of
+// ZetaSQL): the control-flow and variable statements that make up a multi-
+// statement script or a stored-procedure BEGIN…END body. The grammar:
+//
+//	begin_end_block:        BEGIN statement_list? opt_exception_handler? END
+//	opt_exception_handler:  EXCEPTION WHEN ERROR THEN statement_list
+//	statement_list:         unterminated_statement (';' unterminated_statement)* ';'
+//	if_statement:           IF expr THEN statement_list? elseif_clauses? opt_else? END IF
+//	elseif_clauses:         (ELSEIF expr THEN statement_list?)+
+//	opt_else:               ELSE statement_list?
+//	case_statement:         CASE expr? when_then_clauses opt_else? END CASE
+//	when_then_clauses:      (WHEN expr THEN statement_list?)+
+//	while_statement:        WHILE expr DO statement_list? END WHILE
+//	loop_statement:         LOOP statement_list? END LOOP
+//	repeat_statement:       REPEAT statement_list? UNTIL expr END REPEAT
+//	for_in_statement:       FOR id IN (query) DO statement_list? END FOR
+//	variable_declaration:   DECLARE id_list type opt_default? | DECLARE id_list DEFAULT expr
+//	set_statement:          SET TRANSACTION modes | SET id = expr | SET @p = expr
+//	                        | SET @@v = expr | SET (id_list) = expr | SET id, id = (error)
+//	execute_immediate:      EXECUTE IMMEDIATE expr (INTO id_list)? (USING arg_list)?
+//	break_statement:        BREAK id? | LEAVE id?
+//	continue_statement:     CONTINUE id? | ITERATE id?
+//	return_statement:       RETURN
+//	raise_statement:        RAISE | RAISE USING MESSAGE = expr
+//	label:                  identifier (a labeled block/loop: `id: <stmt> [id]`)
+//
+// DIALECT (oracle.md). Scripting is BigQuery-ONLY at the GoogleSQL union level
+// with two oracle-authoritative exceptions: the Spanner emulator PARSES the
+// BEGIN…END envelope (verdict accept, "Statement not supported: BeginStmt"),
+// SET (SingleAssignment / AssignmentFromStruct / ParameterAssignment /
+// SystemVariableAssignment / SetTransactionStatement), and EXECUTE IMMEDIATE
+// (ExecuteImmediateStatement) — so those LEADING forms are accepted on the
+// oracle's authority. The control-flow statements (IF/CASE/WHILE/LOOP/REPEAT/
+// FOR-IN/DECLARE/BREAK/CONTINUE/RETURN/RAISE/labels) syntax-reject on Spanner;
+// the union parser accepts them on the authority of the legacy .g4 + the
+// BigQuery truth1 corpus (SCRIPT-001…019). The emulator's BEGIN…END recognizer
+// is SHALLOW (it accepts any token run between BEGIN and END, even
+// `BEGIN SELECT 1 SELECT 2 END`), so the INTERIOR statement_list grammar is
+// NON-authoritative on Spanner and follows the .g4 — which requires `;`
+// separation and a trailing `;` (divergence ledger: Spanner over-accepts the
+// block interior, mirroring the transaction-tail divergence).
+//
+// bytebase does not consume scripting today (P1 parity); the parser accepts and
+// models it so Diagnose reports a script statement as valid rather than a false
+// syntax error, and the query-span / lineage walker can reach the embedded
+// queries (DECLARE … DEFAULT (subquery), FOR … IN (query), the SQL statements in
+// every body).
+
+// DeclareStmt is a DECLARE statement (variable_declaration):
+//
+//	DECLARE id [, id ...] type [DEFAULT expr]
+//	DECLARE id [, id ...] DEFAULT expr
+//
+// Names is the declared variable list (≥1). Type is the declared type
+// (variable_declaration's first alternative); it is nil for the DEFAULT-only
+// alternative (`DECLARE x DEFAULT 5`, where the type is inferred). Default is the
+// DEFAULT initializer expression (opt_default_expression / the DEFAULT
+// alternative); nil when absent.
+type DeclareStmt struct {
+	Names   []*Identifier // declared variable names (≥1)
+	Type    *TypeRef      // declared type; nil for the DEFAULT-only form
+	Default Node          // DEFAULT initializer expression; nil if absent
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *DeclareStmt) Tag() NodeTag { return T_DeclareStmt }
+
+// SetStmtKind discriminates the set_statement alternatives.
+type SetStmtKind int
+
+const (
+	// SetVariable is `SET <target> = expr` where the target is a single variable
+	// identifier, a named parameter (@p), or a system variable (@@v). Targets
+	// holds exactly one element (the LHS expression); Value holds the RHS.
+	SetVariable SetStmtKind = iota
+	// SetTuple is `SET ( id [, id ...] ) = expr` (tuple/struct assignment).
+	// Targets holds the parenthesized identifier list (≥1); Value holds the
+	// single RHS expression (typically a parenthesized list or a SELECT AS STRUCT).
+	SetTuple
+	// SetTransaction is `SET TRANSACTION <transaction_mode_list>`. Modes holds the
+	// mode list; Targets / Value are nil.
+	SetTransaction
+)
+
+// SetStmt is a SET statement (set_statement). Kind selects the shape:
+//   - SetVariable: Targets[0] is the LHS (an *Identifier for a plain variable, a
+//     *Parameter for @p, or a *SystemVariable for @@v) and Value is the RHS expr.
+//   - SetTuple: Targets is the parenthesized identifier list and Value is the
+//     single RHS expr.
+//   - SetTransaction: Modes is the transaction_mode_list.
+//
+// The `SET a, b = ...` form (two bare identifiers without parentheses) is a
+// grammar error alt in the .g4 ("Using SET with multiple variables requires
+// parentheses around the variable list") — the parser rejects it rather than
+// producing a SetStmt; it is NOT a SetStmt kind.
+type SetStmt struct {
+	Kind    SetStmtKind
+	Targets []Node             // LHS targets (SetVariable: 1; SetTuple: ≥1); nil for SetTransaction
+	Value   Node               // RHS expression; nil for SetTransaction
+	Modes   []*TransactionMode // SET TRANSACTION mode list; nil otherwise
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *SetStmt) Tag() NodeTag { return T_SetStmt }
+
+// IfStmt is an IF statement (if_statement):
+//
+//	IF expr THEN [statement_list] [ELSEIF expr THEN ...]... [ELSE [statement_list]] END IF
+//
+// Cond is the leading condition; Then is its (possibly empty) statement_list.
+// ElseIf holds the ELSEIF clauses (nil if none). Else is the trailing ELSE
+// statement_list; HasElse distinguishes a present-but-empty ELSE (`ELSE END IF`)
+// from an absent ELSE (both leave Else nil).
+type IfStmt struct {
+	Cond    Node            // the IF condition
+	Then    []Node          // the THEN statement_list (may be empty)
+	ElseIf  []*ElseIfClause // ELSEIF clauses; nil if none
+	Else    []Node          // ELSE statement_list; nil if HasElse is false
+	HasElse bool            // an ELSE clause was present (even if its body is empty)
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *IfStmt) Tag() NodeTag { return T_IfStmt }
+
+// ElseIfClause is one ELSEIF arm of an IF statement (elseif_clauses):
+// `ELSEIF expr THEN [statement_list]`.
+type ElseIfClause struct {
+	Cond Node   // the ELSEIF condition
+	Then []Node // the THEN statement_list (may be empty)
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *ElseIfClause) Tag() NodeTag { return T_ElseIfClause }
+
+// CaseStmt is a CASE statement (case_statement) — the procedural form, distinct
+// from the CASE expression (CaseExpr):
+//
+//	CASE [operand] WHEN expr THEN [statement_list] [WHEN ...]... [ELSE [statement_list]] END CASE
+//
+// Operand is the optional search expression (`CASE x WHEN ...`); nil for the
+// searched form (`CASE WHEN cond ...`). Whens holds the WHEN/THEN clauses (≥1).
+// Else is the trailing ELSE statement_list; HasElse marks a present (possibly
+// empty) ELSE.
+type CaseStmt struct {
+	Operand Node              // optional CASE operand; nil for the searched form
+	Whens   []*WhenThenClause // WHEN expr THEN ... clauses (≥1)
+	Else    []Node            // ELSE statement_list; nil if HasElse is false
+	HasElse bool              // an ELSE clause was present
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *CaseStmt) Tag() NodeTag { return T_CaseStmt }
+
+// WhenThenClause is one WHEN/THEN arm of a procedural CASE statement
+// (when_then_clauses): `WHEN expr THEN [statement_list]`.
+type WhenThenClause struct {
+	Cond Node   // the WHEN condition
+	Then []Node // the THEN statement_list (may be empty)
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *WhenThenClause) Tag() NodeTag { return T_WhenThenClause }
+
+// WhileStmt is a WHILE statement (while_statement):
+//
+//	WHILE expr DO [statement_list] END WHILE
+//
+// Cond is the loop condition; Body is the loop statement_list (may be empty).
+type WhileStmt struct {
+	Cond Node   // the WHILE condition
+	Body []Node // the loop body statement_list (may be empty)
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *WhileStmt) Tag() NodeTag { return T_WhileStmt }
+
+// LoopStmt is a LOOP statement (loop_statement):
+//
+//	LOOP [statement_list] END LOOP
+//
+// Body is the loop statement_list (may be empty). The loop is exited via BREAK /
+// LEAVE.
+type LoopStmt struct {
+	Body []Node // the loop body statement_list (may be empty)
+	Loc  Loc
+}
+
+// Tag implements Node.
+func (n *LoopStmt) Tag() NodeTag { return T_LoopStmt }
+
+// RepeatStmt is a REPEAT statement (repeat_statement):
+//
+//	REPEAT [statement_list] UNTIL expr END REPEAT
+//
+// Body is the loop statement_list (may be empty). Until is the until_clause
+// boolean condition evaluated after each iteration (required).
+type RepeatStmt struct {
+	Body  []Node // the loop body statement_list (may be empty)
+	Until Node   // the UNTIL condition (required)
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *RepeatStmt) Tag() NodeTag { return T_RepeatStmt }
+
+// ForInStmt is a FOR…IN statement (for_in_statement):
+//
+//	FOR id IN (query) DO [statement_list] END FOR
+//
+// Var is the loop variable identifier; Query is the parenthesized source query;
+// Body is the loop statement_list (may be empty).
+type ForInStmt struct {
+	Var   *Identifier // loop variable
+	Query *QueryStmt  // the parenthesized source query
+	Body  []Node      // the loop body statement_list (may be empty)
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ForInStmt) Tag() NodeTag { return T_ForInStmt }
+
+// BeginEndBlock is a procedural BEGIN…END block (begin_end_block):
+//
+//	BEGIN [statement_list] [EXCEPTION WHEN ERROR THEN statement_list] END
+//
+// Body is the main statement_list (may be empty). Exception is the EXCEPTION
+// handler's statement_list (opt_exception_handler); HasException marks a present
+// handler (even with an empty body), distinct from an absent one (both leave
+// Exception nil). A BEGIN…END block is the one scripting form the Spanner
+// emulator parses as a top-level statement (oracle: accept, "BeginStmt").
+type BeginEndBlock struct {
+	Body         []Node // the block statement_list (may be empty)
+	Exception    []Node // the EXCEPTION WHEN ERROR THEN statement_list; nil if HasException is false
+	HasException bool   // an EXCEPTION handler was present
+	Loc          Loc
+}
+
+// Tag implements Node.
+func (n *BeginEndBlock) Tag() NodeTag { return T_BeginEndBlock }
+
+// BreakStmt is a BREAK / LEAVE statement (break_statement): `BREAK [id]` or
+// `LEAVE [id]`. LEAVE is a synonym for BREAK; IsLeave records which keyword was
+// used so the source verb round-trips. Label is the optional target loop/block
+// label; "" if absent.
+type BreakStmt struct {
+	IsLeave bool   // LEAVE (true) vs BREAK (false)
+	Label   string // optional target label; "" if absent
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *BreakStmt) Tag() NodeTag { return T_BreakStmt }
+
+// ContinueStmt is a CONTINUE / ITERATE statement (continue_statement):
+// `CONTINUE [id]` or `ITERATE [id]`. ITERATE is a synonym for CONTINUE; IsIterate
+// records the keyword. Label is the optional target loop label; "" if absent.
+type ContinueStmt struct {
+	IsIterate bool   // ITERATE (true) vs CONTINUE (false)
+	Label     string // optional target label; "" if absent
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *ContinueStmt) Tag() NodeTag { return T_ContinueStmt }
+
+// ReturnStmt is a RETURN statement (return_statement): a bare `RETURN` that stops
+// execution of the multi-statement script. GoogleSQL's RETURN carries no value.
+type ReturnStmt struct {
+	Loc Loc
+}
+
+// Tag implements Node.
+func (n *ReturnStmt) Tag() NodeTag { return T_ReturnStmt }
+
+// RaiseStmt is a RAISE statement (raise_statement): `RAISE` (re-raise the caught
+// exception, valid only inside an EXCEPTION handler) or
+// `RAISE USING MESSAGE = expr` (raise a custom error). Message is the
+// USING MESSAGE expression; nil for a bare RAISE.
+type RaiseStmt struct {
+	Message Node // USING MESSAGE = expr; nil for a bare RAISE
+	Loc     Loc
+}
+
+// Tag implements Node.
+func (n *RaiseStmt) Tag() NodeTag { return T_RaiseStmt }
+
+// ExecuteImmediateStmt is an EXECUTE IMMEDIATE statement (execute_immediate):
+//
+//	EXECUTE IMMEDIATE sql_expr [INTO id [, id ...]] [USING arg [, arg ...]]
+//
+// SQL is the dynamic-SQL expression (a string literal or an expression that
+// produces one). Into is the optional INTO variable list (nil if absent). Using
+// is the optional USING argument list; each entry is an expression, optionally
+// `expr AS alias` (carried as a *NamedArg-free aliased wrapper — see UsingArg).
+type ExecuteImmediateStmt struct {
+	SQL   Node          // the dynamic SQL expression
+	Into  []*Identifier // INTO variable list; nil if absent
+	Using []*UsingArg   // USING argument list; nil if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *ExecuteImmediateStmt) Tag() NodeTag { return T_ExecuteImmediateStmt }
+
+// UsingArg is one entry of an EXECUTE IMMEDIATE USING list (the grammar's
+// `execute_immediate_argument`: `expr opt_as_alias_with_required_as?`). Value is
+// the argument expression; Alias is the optional `AS name` (used to bind a named
+// query parameter @name); "" if absent.
+type UsingArg struct {
+	Value Node   // the argument expression
+	Alias string // optional AS alias (binds a named @parameter); "" if absent
+	Loc   Loc
+}
+
+// Tag implements Node.
+func (n *UsingArg) Tag() NodeTag { return T_UsingArg }
+
+// LabeledStmt is a labeled procedural statement (the
+// `label ':' unterminated_unlabeled_script_statement identifier?` alternative of
+// unterminated_script_statement):
+//
+//	label: <block-or-loop> [end_label]
+//
+// Only the unlabeled block forms (BEGIN…END, WHILE, LOOP, REPEAT, FOR-IN) can be
+// labeled. Label is the leading label name; Stmt is the wrapped statement;
+// EndLabel is the optional trailing label after the END (must match Label per
+// BigQuery semantics, though the grammar does not enforce it here); "" if absent.
+type LabeledStmt struct {
+	Label    string // leading label name
+	Stmt     Node   // the labeled block/loop statement
+	EndLabel string // optional trailing label after END; "" if absent
+	Loc      Loc
+}
+
+// Tag implements Node.
+func (n *LabeledStmt) Tag() NodeTag { return T_LabeledStmt }
+
+// Compile-time assertions that the scripting node types satisfy Node.
+var (
+	_ Node = (*DeclareStmt)(nil)
+	_ Node = (*SetStmt)(nil)
+	_ Node = (*IfStmt)(nil)
+	_ Node = (*ElseIfClause)(nil)
+	_ Node = (*CaseStmt)(nil)
+	_ Node = (*WhenThenClause)(nil)
+	_ Node = (*WhileStmt)(nil)
+	_ Node = (*LoopStmt)(nil)
+	_ Node = (*RepeatStmt)(nil)
+	_ Node = (*ForInStmt)(nil)
+	_ Node = (*BeginEndBlock)(nil)
+	_ Node = (*BreakStmt)(nil)
+	_ Node = (*ContinueStmt)(nil)
+	_ Node = (*ReturnStmt)(nil)
+	_ Node = (*RaiseStmt)(nil)
+	_ Node = (*ExecuteImmediateStmt)(nil)
+	_ Node = (*UsingArg)(nil)
+	_ Node = (*LabeledStmt)(nil)
+)

--- a/googlesql/ast/walk_generated.go
+++ b/googlesql/ast/walk_generated.go
@@ -91,6 +91,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.OnTable != nil {
 			Walk(v, n.OnTable)
 		}
+	case *BeginEndBlock:
+		walkNodes(v, n.Body)
+		walkNodes(v, n.Exception)
 	case *BetweenExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.Low)
@@ -123,6 +126,12 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, c)
 		}
 		Walk(v, n.Else)
+	case *CaseStmt:
+		Walk(v, n.Operand)
+		for _, c := range n.Whens {
+			Walk(v, c)
+		}
+		walkNodes(v, n.Else)
 	case *CastExpr:
 		Walk(v, n.Expr)
 		if n.Type != nil {
@@ -353,6 +362,14 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, c)
 		}
 		Walk(v, n.AsQuery)
+	case *DeclareStmt:
+		for _, c := range n.Names {
+			Walk(v, c)
+		}
+		if n.Type != nil {
+			Walk(v, n.Type)
+		}
+		Walk(v, n.Default)
 	case *DeleteStmt:
 		if n.Target != nil {
 			Walk(v, n.Target)
@@ -405,6 +422,17 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.Labels {
 			Walk(v, c)
 		}
+	case *ElseIfClause:
+		Walk(v, n.Cond)
+		walkNodes(v, n.Then)
+	case *ExecuteImmediateStmt:
+		Walk(v, n.SQL)
+		for _, c := range n.Into {
+			Walk(v, c)
+		}
+		for _, c := range n.Using {
+			Walk(v, c)
+		}
 	case *ExistsExpr:
 		Walk(v, n.Query)
 	case *ExportDataStmt:
@@ -432,6 +460,14 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Expr)
 	case *File:
 		walkNodes(v, n.Stmts)
+	case *ForInStmt:
+		if n.Var != nil {
+			Walk(v, n.Var)
+		}
+		if n.Query != nil {
+			Walk(v, n.Query)
+		}
+		walkNodes(v, n.Body)
 	case *ForeignKeyRef:
 		if n.Table != nil {
 			Walk(v, n.Table)
@@ -574,6 +610,13 @@ func walkChildren(v Visitor, node Node) {
 		walkNodes(v, n.Items)
 	case *HavingModifier:
 		Walk(v, n.Expr)
+	case *IfStmt:
+		Walk(v, n.Cond)
+		walkNodes(v, n.Then)
+		for _, c := range n.ElseIf {
+			Walk(v, c)
+		}
+		walkNodes(v, n.Else)
 	case *InExpr:
 		Walk(v, n.Expr)
 		walkNodes(v, n.Values)
@@ -632,6 +675,8 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.PropsList {
 			Walk(v, c)
 		}
+	case *LabeledStmt:
+		Walk(v, n.Stmt)
 	case *LambdaExpr:
 		Walk(v, n.Body)
 	case *LikeExpr:
@@ -662,6 +707,8 @@ func walkChildren(v Visitor, node Node) {
 		for _, c := range n.PartitionColumns {
 			Walk(v, c)
 		}
+	case *LoopStmt:
+		walkNodes(v, n.Body)
 	case *MergeAction:
 		if n.InsertRow != nil {
 			Walk(v, n.InsertRow)
@@ -727,6 +774,8 @@ func walkChildren(v Visitor, node Node) {
 		}
 		Walk(v, n.Limit)
 		Walk(v, n.Offset)
+	case *RaiseStmt:
+		Walk(v, n.Message)
 	case *RecursionDepth:
 		Walk(v, n.Lower)
 		Walk(v, n.Upper)
@@ -738,6 +787,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.To != nil {
 			Walk(v, n.To)
 		}
+	case *RepeatStmt:
+		walkNodes(v, n.Body)
+		Walk(v, n.Until)
 	case *ReplaceFieldsExpr:
 		Walk(v, n.Expr)
 		for _, c := range n.Items {
@@ -802,6 +854,12 @@ func walkChildren(v Visitor, node Node) {
 	case *SetOperation:
 		Walk(v, n.Left)
 		Walk(v, n.Right)
+	case *SetStmt:
+		walkNodes(v, n.Targets)
+		Walk(v, n.Value)
+		for _, c := range n.Modes {
+			Walk(v, c)
+		}
 	case *StarExpr:
 		if n.Modifiers != nil {
 			Walk(v, n.Modifiers)
@@ -906,6 +964,8 @@ func walkChildren(v Visitor, node Node) {
 		if n.Returning != nil {
 			Walk(v, n.Returning)
 		}
+	case *UsingArg:
+		Walk(v, n.Value)
 	case *ViewColumn:
 		for _, c := range n.Options {
 			Walk(v, c)
@@ -913,6 +973,12 @@ func walkChildren(v Visitor, node Node) {
 	case *WhenClause:
 		Walk(v, n.Cond)
 		Walk(v, n.Result)
+	case *WhenThenClause:
+		Walk(v, n.Cond)
+		walkNodes(v, n.Then)
+	case *WhileStmt:
+		Walk(v, n.Cond)
+		walkNodes(v, n.Body)
 	case *WindowDef:
 		if n.Spec != nil {
 			Walk(v, n.Spec)

--- a/googlesql/parser/parser.go
+++ b/googlesql/parser/parser.go
@@ -318,6 +318,14 @@ func (p *Parser) skipBalancedBraces(hintStart ast.Loc) *ParseError {
 // them at top level so a standalone script fragment fed to Diagnose is reported
 // as "not yet supported" rather than "unknown statement".
 func (p *Parser) parseStmt() (ast.Node, error) {
+	// A labeled procedural statement (`label: BEGIN|WHILE|LOOP|REPEAT|FOR …`) leads
+	// with an identifier followed by ':'. It is the only statement form that starts
+	// with a bare identifier, so check it before the keyword dispatch (owned by the
+	// parser-scripting node). Reachable both at the top level and inside a
+	// statement_list.
+	if p.isScriptLabelStart() {
+		return p.parseLabeledStmt()
+	}
 	switch p.cur.Type {
 	// --- Query (query_statement / GQL) ---
 	case kwSELECT:
@@ -392,7 +400,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		if isTCLBeginFollower(p.peekNext()) {
 			return p.parseBeginStmt()
 		}
-		return p.unsupported("BEGIN...END block")
+		return p.parseBeginEndBlock()
 	case kwSTART:
 		// START TRANSACTION (begin_statement) | START BATCH (start_batch_statement).
 		return p.parseStartStmt()
@@ -401,9 +409,11 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	case kwROLLBACK:
 		return p.parseRollbackStmt()
 	case kwSET:
-		// SET TRANSACTION / SET variable / SET system-var (set_statement) — owned by
-		// a separate node (not parser-utility).
-		return p.unsupported("SET")
+		// SET TRANSACTION / SET variable / SET @p / SET @@v / SET (tuple)
+		// (set_statement) — owned by the parser-scripting node. The RHS / tuple
+		// values are full expressions that may embed subqueries, filled by
+		// parseSetStmt itself.
+		return p.parseSetStmt()
 	case kwRUN:
 		return p.parseRunBatchStmt()
 	case kwABORT:
@@ -429,8 +439,10 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		// they are re-parsed (fillSubqueries) like the query / DML paths.
 		return p.parseStmtWithSubqueries(p.parseCallStmt)
 	case kwEXECUTE:
-		// EXECUTE IMMEDIATE.
-		return p.unsupported("EXECUTE")
+		// EXECUTE IMMEDIATE <sql> [INTO ...] [USING ...] (execute_immediate) — owned
+		// by the parser-scripting node. The SQL / USING expressions may embed
+		// subqueries, filled by parseExecuteImmediateStmt itself.
+		return p.parseExecuteImmediateStmt()
 	case kwIMPORT:
 		return p.unsupported("IMPORT")
 	case kwMODULE:
@@ -451,34 +463,37 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		// wrap for fillSubqueries.
 		return p.parseStmtWithSubqueries(p.parseCloneData)
 
-	// --- Procedural / scripting (legal inside a script body; recognized at
-	// top level so a script fragment is reported as unsupported, not unknown) ---
+	// --- Procedural / scripting (parser-scripting node) ---
+	//
+	// These are legal inside a procedural body (statement_list) and, for the
+	// BEGIN…END block / SET / EXECUTE IMMEDIATE forms, also as the top-level
+	// statement of a script (oracle: the Spanner emulator parses a top-level
+	// BEGIN…END / SET / EXECUTE IMMEDIATE). The control-flow forms are
+	// BigQuery-only at the union level (Spanner syntax-rejects them standalone);
+	// omni accepts them on the authority of the legacy .g4 + the BigQuery truth1
+	// corpus so a script fragment parses rather than drawing a false syntax error.
 	case kwIF:
-		return p.unsupported("IF")
+		return p.parseIfStmt()
 	case kwCASE:
-		return p.unsupported("CASE")
+		return p.parseCaseStmt()
 	case kwWHILE:
-		return p.unsupported("WHILE")
+		return p.parseWhileStmt()
 	case kwLOOP:
-		return p.unsupported("LOOP")
+		return p.parseLoopStmt()
 	case kwREPEAT:
-		return p.unsupported("REPEAT")
+		return p.parseRepeatStmt()
 	case kwFOR:
-		return p.unsupported("FOR")
+		return p.parseForInStmt()
 	case kwDECLARE:
-		return p.unsupported("DECLARE")
-	case kwBREAK:
-		return p.unsupported("BREAK")
-	case kwLEAVE:
-		return p.unsupported("LEAVE")
-	case kwCONTINUE:
-		return p.unsupported("CONTINUE")
-	case kwITERATE:
-		return p.unsupported("ITERATE")
+		return p.parseDeclareStmt()
+	case kwBREAK, kwLEAVE:
+		return p.parseBreakStmt()
+	case kwCONTINUE, kwITERATE:
+		return p.parseContinueStmt()
 	case kwRETURN:
-		return p.unsupported("RETURN")
+		return p.parseReturnStmt()
 	case kwRAISE:
-		return p.unsupported("RAISE")
+		return p.parseRaiseStmt()
 
 	default:
 		return nil, p.unknownStatementError()

--- a/googlesql/parser/parser_test.go
+++ b/googlesql/parser/parser_test.go
@@ -248,42 +248,57 @@ func TestParse_EmptyHintReported(t *testing.T) {
 // dispatchPrefix is one representative leading token sequence per documented
 // GoogleSQL top-level statement kind (antlr_rules.md §4: sql_statement_body
 // alternatives + the procedural-script forms recognized at top level). The body
-// after the keyword does not matter — the foundation stubs it — so we only need
-// the leading keyword(s) to land in a real dispatch case rather than default.
-var dispatchPrefixes = []string{
+// after the keyword does not matter for the leading-keyword dispatch check — we
+// only need the leading keyword(s) to land in a real dispatch case rather than
+// default. A bare " x" tail suffices for most; the three block forms whose body
+// is a statement_list that begins immediately after the opener (BEGIN / LOOP /
+// REPEAT) need a benign complete tail so the parsed body does not itself produce
+// an inner "unknown statement starting with x" (the now-implemented
+// parser-scripting bodies parse their statement_list, so a bare `x` body is a
+// real — but irrelevant-to-this-test — reject).
+var dispatchPrefixes = []struct{ prefix, tail string }{
 	// Query / GQL.
-	"SELECT", "WITH", "GRAPH", "FROM", "(",
+	{"SELECT", "x"}, {"WITH", "x"}, {"GRAPH", "x"}, {"FROM", "x"}, {"(", "x"},
 	// DDL.
-	"CREATE", "ALTER", "DROP", "RENAME", "UNDROP", "TRUNCATE", "DEFINE",
+	{"CREATE", "x"}, {"ALTER", "x"}, {"DROP", "x"}, {"RENAME", "x"},
+	{"UNDROP", "x"}, {"TRUNCATE", "x"}, {"DEFINE", "x"},
 	// DML.
-	"INSERT", "UPDATE", "DELETE", "MERGE",
+	{"INSERT", "x"}, {"UPDATE", "x"}, {"DELETE", "x"}, {"MERGE", "x"},
 	// DCL.
-	"GRANT", "REVOKE",
-	// Transactions / batch / session.
-	"BEGIN", "START", "COMMIT", "ROLLBACK", "SET", "RUN", "ABORT",
+	{"GRANT", "x"}, {"REVOKE", "x"},
+	// Transactions / batch / session. A top-level BEGIN is a TCL transaction only
+	// when followed by a TCL follower (here TRANSACTION); a non-follower opens a
+	// BEGIN…END block (covered by the scripting `{"BEGIN","END"}` entry below).
+	{"BEGIN", "TRANSACTION"}, {"START", "x"}, {"COMMIT", "x"}, {"ROLLBACK", "x"},
+	{"SET", "x"}, {"RUN", "x"}, {"ABORT", "x"},
 	// Utility / metadata.
-	"EXPLAIN", "DESCRIBE", "DESC", "SHOW", "ANALYZE", "ASSERT", "CALL",
-	"EXECUTE", "IMPORT", "MODULE", "EXPORT", "LOAD", "CLONE",
-	// Procedural / scripting (recognized at top level).
-	"IF", "CASE", "WHILE", "LOOP", "REPEAT", "FOR", "DECLARE", "BREAK",
-	"LEAVE", "CONTINUE", "ITERATE", "RETURN", "RAISE",
+	{"EXPLAIN", "x"}, {"DESCRIBE", "x"}, {"DESC", "x"}, {"SHOW", "x"},
+	{"ANALYZE", "x"}, {"ASSERT", "x"}, {"CALL", "x"}, {"EXECUTE", "x"},
+	{"IMPORT", "x"}, {"MODULE", "x"}, {"EXPORT", "x"}, {"LOAD", "x"}, {"CLONE", "x"},
+	// Procedural / scripting (now implemented by parser-scripting). BEGIN / LOOP /
+	// REPEAT have a statement_list body that starts right after the opener, so
+	// their tails are complete benign blocks rather than a bare `x` (which would
+	// be parsed as an invalid body statement, not a leading-keyword miss).
+	{"IF", "x"}, {"CASE", "x"}, {"WHILE", "x"}, {"LOOP", "END LOOP"},
+	{"REPEAT", "UNTIL TRUE END REPEAT"}, {"FOR", "x"}, {"DECLARE", "x"},
+	{"BREAK", "x"}, {"LEAVE", "x"}, {"CONTINUE", "x"}, {"ITERATE", "x"},
+	{"RETURN", "x"}, {"RAISE", "x"}, {"BEGIN", "END"},
 }
 
 // TestParse_DispatchKeywordsRecognized verifies every documented top-level
-// statement keyword is routed by the dispatch switch — it produces a "not yet
-// supported" (stubbed) error, NOT an "unknown statement" error. This is the
-// foundation's completeness contract: all statement forms must be reachable so
-// bytebase's Diagnose never emits a false "unknown statement" diagnostic for
-// valid GoogleSQL.
+// statement keyword is routed by the dispatch switch — it does NOT hit the
+// default "unknown statement" branch. This is the foundation's completeness
+// contract: all statement forms must be reachable so bytebase's Diagnose never
+// emits a false "unknown statement" diagnostic for valid GoogleSQL.
 func TestParse_DispatchKeywordsRecognized(t *testing.T) {
 	for _, p := range dispatchPrefixes {
-		t.Run(p, func(t *testing.T) {
-			sql := p + " x" // minimal tail; the leading token is the keyword
+		t.Run(p.prefix, func(t *testing.T) {
+			sql := p.prefix + " " + p.tail // leading token is the keyword
 			_, errs := Parse(sql)
 			for _, e := range errs {
 				if strings.Contains(e.Msg, "unknown or unsupported statement") {
 					t.Errorf("Parse(%q): leading keyword %q hit the UNKNOWN branch; "+
-						"it must be in the dispatch switch (got %q)", sql, p, e.Msg)
+						"it must be in the dispatch switch (got %q)", sql, p.prefix, e.Msg)
 				}
 			}
 		})

--- a/googlesql/parser/scripting.go
+++ b/googlesql/parser/scripting.go
@@ -1,0 +1,917 @@
+package parser
+
+// This file is the `parser-scripting` DAG node. It implements GoogleSQL's
+// procedural language (GoogleSQLParser.g4 §2.11, a hand-port of Google's
+// open-source ZetaSQL reference and the grammar bytebase consumes):
+//
+//	begin_end_block:        BEGIN statement_list? opt_exception_handler? END
+//	opt_exception_handler:  EXCEPTION WHEN ERROR THEN statement_list
+//	statement_list:         unterminated_statement (';' unterminated_statement)* ';'
+//	unterminated_statement: unterminated_sql_statement | unterminated_script_statement
+//	if_statement:           IF expr THEN statement_list? elseif_clauses? opt_else? END IF
+//	case_statement:         CASE expr? when_then_clauses opt_else? END CASE
+//	while_statement:        WHILE expr DO statement_list? END WHILE
+//	loop_statement:         LOOP statement_list? END LOOP
+//	repeat_statement:       REPEAT statement_list? UNTIL expr END REPEAT
+//	for_in_statement:       FOR id IN (query) DO statement_list? END FOR
+//	variable_declaration:   DECLARE id_list type opt_default? | DECLARE id_list DEFAULT expr
+//	set_statement:          SET TRANSACTION modes | SET id|@p|@@v = expr
+//	                        | SET (id_list) = expr | SET id, id = (error alt)
+//	execute_immediate:      EXECUTE IMMEDIATE expr (INTO id_list)? (USING arg_list)?
+//	break_statement:        BREAK id? | LEAVE id?
+//	continue_statement:     CONTINUE id? | ITERATE id?
+//	return_statement:       RETURN
+//	raise_statement:        RAISE | RAISE USING MESSAGE = expr
+//	(labeled)               label ':' (begin|while|loop|repeat|for_in) identifier?
+//
+// CORRECTNESS (correctness-protocol.md). Scripting is BigQuery-ONLY at the
+// GoogleSQL union level, with two oracle-authoritative exceptions confirmed on
+// the live Cloud Spanner emulator (scripting_oracle_test.go):
+//   - the BEGIN…END envelope (verdict accept, "Statement not supported:
+//     BeginStmt"), SET (SingleAssignment / AssignmentFromStruct /
+//     ParameterAssignment / SystemVariableAssignment / SetTransactionStatement),
+//     and EXECUTE IMMEDIATE (ExecuteImmediateStatement) — the LEADING forms are
+//     ACCEPTED on the oracle's authority.
+//   - the control-flow statements (IF / CASE / WHILE / LOOP / REPEAT / FOR-IN /
+//     DECLARE / BREAK / CONTINUE / RETURN / RAISE / labels) syntax-reject on
+//     Spanner; the union parser accepts them on the authority of the legacy .g4
+//     + the BigQuery truth1 corpus (SCRIPT-001…019), triangulated.
+//
+// The emulator's BEGIN…END recognizer is SHALLOW — it accepts ANY token run
+// between BEGIN and END (`BEGIN SELECT 1 SELECT 2 END`, `BEGIN; END`), so the
+// INTERIOR statement_list grammar is NON-authoritative on Spanner. omni follows
+// the .g4: statement_list requires `;`-separated statements and a trailing `;`
+// (divergence ledger: Spanner over-accepts the block interior, exactly mirroring
+// the transaction-tail divergence in transaction.go).
+//
+// SPLITTING. The block-aware Split (split.go) keeps a procedural block (and a
+// top-level BEGIN…END) whole, so a whole block — internal `;` and all — arrives
+// at parseSingle as ONE segment. parseStmt dispatches the leading keyword to one
+// of the functions here; the statement_list parser consumes the internal `;`
+// itself. The trailing `;` after the block at top level is consumed by Split's
+// segmentation, not seen here.
+
+import (
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// statement_list — the procedural body shared by every block form.
+// ---------------------------------------------------------------------------
+
+// scriptListEnd is the set of keywords that terminate a statement_list. A
+// statement_list is `unterminated_statement (';' unterminated_statement)* ';'`,
+// so parsing continues while the parser is at a statement start; it stops at the
+// block-closing / clause-introducing keyword that follows the body (END, ELSE,
+// ELSEIF, UNTIL, WHEN, EXCEPTION) or at EOF.
+//
+// The grammar requires a trailing ';' after the last statement, so the body
+// statements are separated by ';' AND every statement (including the last) is
+// followed by ';' before the terminator. parseStatementList enforces that.
+
+// parseStatementList parses a statement_list: a sequence of
+// `unterminated_statement ';'` pairs, stopping when the current token is one of
+// the terminator keywords (or EOF). Returns the parsed statements (empty slice
+// when the optional statement_list is absent).
+//
+// Per the .g4, statement_list is `unterminated_non_empty_statement_list ';'`,
+// i.e. EVERY statement — the last one included — must be followed by ';'. So
+// after each parsed statement we REQUIRE a ';' before the next statement or the
+// terminator. An empty body (terminator immediately after the opener) yields an
+// empty slice (the enclosing rule's `statement_list?`).
+func (p *Parser) parseStatementList(terminators ...int) ([]ast.Node, error) {
+	var stmts []ast.Node
+	for {
+		if p.atStatementListEnd(terminators) {
+			return stmts, nil
+		}
+		stmt, err := p.parseScriptElement()
+		if err != nil {
+			return nil, err
+		}
+		if stmt != nil {
+			stmts = append(stmts, stmt)
+		}
+		// statement_list requires a ';' after every statement (the trailing
+		// SEMI_SYMBOL of unterminated_non_empty_statement_list ';'). Without it the
+		// body is not a well-formed statement_list.
+		if _, err := p.expect(int(';')); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// atStatementListEnd reports whether the current token ends a statement_list:
+// EOF or one of the caller-supplied terminator keywords.
+func (p *Parser) atStatementListEnd(terminators []int) bool {
+	if p.cur.Type == tokEOF {
+		return true
+	}
+	for _, t := range terminators {
+		if p.cur.Type == t {
+			return true
+		}
+	}
+	return false
+}
+
+// parseScriptElement parses one unterminated_statement inside a statement_list:
+// either an unterminated_sql_statement (any top-level SQL statement) or an
+// unterminated_script_statement (a nested control-flow / variable statement).
+//
+// It reuses parseStmt — the same dispatcher used at the top level — so a nested
+// SQL statement (SELECT / INSERT / CALL / …) and a nested script statement
+// (IF / WHILE / DECLARE / …) are both handled. parseStmt does NOT consume the
+// trailing ';'; the enclosing parseStatementList does. A leading statement-level
+// hint (`@{…}` / `@n`) on a body statement is skipped first, matching
+// unterminated_sql_statement's `statement_level_hint?`.
+func (p *Parser) parseScriptElement() (ast.Node, error) {
+	if p.cur.Type == int('@') {
+		if hintErr := p.skipStatementLevelHint(); hintErr != nil {
+			return nil, hintErr
+		}
+	}
+	return p.parseStmt()
+}
+
+// ---------------------------------------------------------------------------
+// BEGIN … END block
+// ---------------------------------------------------------------------------
+
+// parseBeginEndBlock parses a begin_end_block:
+//
+//	BEGIN statement_list? opt_exception_handler? END
+//	opt_exception_handler: EXCEPTION WHEN ERROR THEN statement_list
+//
+// BEGIN is the current token. This is reached from parseStmt's BEGIN arm when the
+// follower is not a TCL transaction follower (isTCLBeginFollower), and from
+// parseScriptElement for a nested block.
+func (p *Parser) parseBeginEndBlock() (ast.Node, error) {
+	begin := p.advance() // BEGIN
+	block := &ast.BeginEndBlock{Loc: begin.Loc}
+
+	// statement_list? — the main body, terminated by EXCEPTION or END.
+	body, err := p.parseStatementList(kwEXCEPTION, kwEND)
+	if err != nil {
+		return nil, err
+	}
+	block.Body = body
+
+	// opt_exception_handler? — EXCEPTION WHEN ERROR THEN statement_list.
+	if p.cur.Type == kwEXCEPTION {
+		p.advance() // EXCEPTION
+		if _, err := p.expect(kwWHEN); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwERROR); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		// The handler statement_list is REQUIRED (the grammar has statement_list,
+		// not statement_list?); it is terminated by END.
+		handler, err := p.parseStatementList(kwEND)
+		if err != nil {
+			return nil, err
+		}
+		block.HasException = true
+		block.Exception = handler
+	}
+
+	end, err := p.expect(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	block.Loc.End = end.Loc.End
+	return block, nil
+}
+
+// ---------------------------------------------------------------------------
+// IF
+// ---------------------------------------------------------------------------
+
+// parseIfStmt parses an if_statement:
+//
+//	IF expr THEN statement_list? elseif_clauses? opt_else? END IF
+//
+// IF is the current token.
+func (p *Parser) parseIfStmt() (ast.Node, error) {
+	ifTok := p.advance() // IF
+	stmt := &ast.IfStmt{Loc: ifTok.Loc}
+
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Cond = cond
+
+	if _, err := p.expect(kwTHEN); err != nil {
+		return nil, err
+	}
+	// statement_list? terminated by ELSEIF / ELSE / END.
+	then, err := p.parseStatementList(kwELSEIF, kwELSE, kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Then = then
+
+	// elseif_clauses? — (ELSEIF expr THEN statement_list?)+.
+	for p.cur.Type == kwELSEIF {
+		elseifTok := p.advance() // ELSEIF
+		clause := &ast.ElseIfClause{Loc: elseifTok.Loc}
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		clause.Cond = cond
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		body, err := p.parseStatementList(kwELSEIF, kwELSE, kwEND)
+		if err != nil {
+			return nil, err
+		}
+		clause.Then = body
+		clause.Loc.End = p.prev.Loc.End
+		stmt.ElseIf = append(stmt.ElseIf, clause)
+	}
+
+	// opt_else? — ELSE statement_list?.
+	if p.cur.Type == kwELSE {
+		p.advance() // ELSE
+		elseBody, err := p.parseStatementList(kwEND)
+		if err != nil {
+			return nil, err
+		}
+		stmt.HasElse = true
+		stmt.Else = elseBody
+	}
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endIf, err := p.expect(kwIF)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = endIf.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// CASE (statement form)
+// ---------------------------------------------------------------------------
+
+// parseCaseStmt parses a case_statement:
+//
+//	CASE expr? when_then_clauses opt_else? END CASE
+//	when_then_clauses: (WHEN expr THEN statement_list?)+
+//
+// CASE is the current token. The optional operand distinguishes the simple form
+// (`CASE x WHEN …`) from the searched form (`CASE WHEN …`); it is present when
+// the token after CASE is not WHEN.
+func (p *Parser) parseCaseStmt() (ast.Node, error) {
+	caseTok := p.advance() // CASE
+	stmt := &ast.CaseStmt{Loc: caseTok.Loc}
+
+	// expr? — the operand of the simple form; absent when WHEN follows directly.
+	if p.cur.Type != kwWHEN {
+		operand, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Operand = operand
+	}
+
+	// when_then_clauses — at least one WHEN…THEN.
+	if p.cur.Type != kwWHEN {
+		return nil, p.syntaxErrorAtCur()
+	}
+	for p.cur.Type == kwWHEN {
+		whenTok := p.advance() // WHEN
+		clause := &ast.WhenThenClause{Loc: whenTok.Loc}
+		cond, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		clause.Cond = cond
+		if _, err := p.expect(kwTHEN); err != nil {
+			return nil, err
+		}
+		body, err := p.parseStatementList(kwWHEN, kwELSE, kwEND)
+		if err != nil {
+			return nil, err
+		}
+		clause.Then = body
+		clause.Loc.End = p.prev.Loc.End
+		stmt.Whens = append(stmt.Whens, clause)
+	}
+
+	// opt_else? — ELSE statement_list?.
+	if p.cur.Type == kwELSE {
+		p.advance() // ELSE
+		elseBody, err := p.parseStatementList(kwEND)
+		if err != nil {
+			return nil, err
+		}
+		stmt.HasElse = true
+		stmt.Else = elseBody
+	}
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endCase, err := p.expect(kwCASE)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = endCase.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// WHILE / LOOP / REPEAT
+// ---------------------------------------------------------------------------
+
+// parseWhileStmt parses a while_statement: `WHILE expr DO statement_list? END
+// WHILE`. WHILE is the current token.
+func (p *Parser) parseWhileStmt() (ast.Node, error) {
+	whileTok := p.advance() // WHILE
+	stmt := &ast.WhileStmt{Loc: whileTok.Loc}
+
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Cond = cond
+
+	if _, err := p.expect(kwDO); err != nil {
+		return nil, err
+	}
+	body, err := p.parseStatementList(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endWhile, err := p.expect(kwWHILE)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = endWhile.Loc.End
+	return stmt, nil
+}
+
+// parseLoopStmt parses a loop_statement: `LOOP statement_list? END LOOP`. LOOP is
+// the current token.
+func (p *Parser) parseLoopStmt() (ast.Node, error) {
+	loopTok := p.advance() // LOOP
+	stmt := &ast.LoopStmt{Loc: loopTok.Loc}
+
+	body, err := p.parseStatementList(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endLoop, err := p.expect(kwLOOP)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = endLoop.Loc.End
+	return stmt, nil
+}
+
+// parseRepeatStmt parses a repeat_statement: `REPEAT statement_list? until_clause
+// END REPEAT`, where until_clause is `UNTIL expr`. REPEAT is the current token.
+func (p *Parser) parseRepeatStmt() (ast.Node, error) {
+	repeatTok := p.advance() // REPEAT
+	stmt := &ast.RepeatStmt{Loc: repeatTok.Loc}
+
+	body, err := p.parseStatementList(kwUNTIL)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	// until_clause — UNTIL expr (required).
+	if _, err := p.expect(kwUNTIL); err != nil {
+		return nil, err
+	}
+	until, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Until = until
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endRepeat, err := p.expect(kwREPEAT)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = endRepeat.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// FOR … IN
+// ---------------------------------------------------------------------------
+
+// parseForInStmt parses a for_in_statement:
+//
+//	FOR identifier IN (query) DO statement_list? END FOR
+//
+// FOR is the current token. The loop source is a parenthesized_query.
+func (p *Parser) parseForInStmt() (ast.Node, error) {
+	forTok := p.advance() // FOR
+	stmt := &ast.ForInStmt{Loc: forTok.Loc}
+
+	// loop variable.
+	varTok, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.identifierText(varTok)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Var = &ast.Identifier{Name: name, Loc: varTok.Loc}
+
+	if _, err := p.expect(kwIN); err != nil {
+		return nil, err
+	}
+	// parenthesized_query: '(' query ')'.
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	query, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	p.fillSubqueries(query)
+	stmt.Query = query
+
+	if _, err := p.expect(kwDO); err != nil {
+		return nil, err
+	}
+	body, err := p.parseStatementList(kwEND)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Body = body
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+	endFor, err := p.expect(kwFOR)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Loc.End = endFor.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// DECLARE
+// ---------------------------------------------------------------------------
+
+// parseDeclareStmt parses a variable_declaration:
+//
+//	DECLARE identifier_list type opt_default_expression?
+//	DECLARE identifier_list DEFAULT expression
+//
+// DECLARE is the current token. The two alternatives are disambiguated after the
+// identifier_list: a DEFAULT keyword next selects the type-less alternative; any
+// other token begins the required type.
+func (p *Parser) parseDeclareStmt() (ast.Node, error) {
+	declareTok := p.advance() // DECLARE
+	stmt := &ast.DeclareStmt{Loc: declareTok.Loc}
+
+	names, err := p.parseScriptIdentifierList()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Names = names
+
+	if p.cur.Type == kwDEFAULT {
+		// DECLARE id_list DEFAULT expr — no type.
+		p.advance() // DEFAULT
+		def, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Default = def
+	} else {
+		// DECLARE id_list type opt_default_expression? — type required.
+		dt, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Type = &ast.TypeRef{Text: dt.String(), Loc: dt.Loc}
+		// opt_default_expression: DEFAULT expression.
+		if p.cur.Type == kwDEFAULT {
+			p.advance() // DEFAULT
+			def, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Default = def
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	// The DEFAULT expression may embed subqueries (e.g.
+	// `DECLARE x DEFAULT (SELECT … LIMIT 1)`); fill them so the query-span walker
+	// can reach the source query.
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// parseScriptIdentifierList parses an identifier_list: `identifier (',' identifier)*`,
+// returning the names as *ast.Identifier nodes (≥1). Used by DECLARE and the SET
+// tuple LHS.
+func (p *Parser) parseScriptIdentifierList() ([]*ast.Identifier, error) {
+	var ids []*ast.Identifier
+	for {
+		tok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.identifierText(tok)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, &ast.Identifier{Name: name, Loc: tok.Loc})
+		if _, ok := p.match(int(',')); ok {
+			continue
+		}
+		break
+	}
+	return ids, nil
+}
+
+// ---------------------------------------------------------------------------
+// SET
+// ---------------------------------------------------------------------------
+
+// parseSetStmt parses a set_statement:
+//
+//	SET TRANSACTION transaction_mode_list
+//	SET identifier = expression
+//	SET named_parameter_expression = expression          (@p = expr)
+//	SET system_variable_expression = expression          (@@v = expr)
+//	SET ( identifier_list ) = expression
+//	SET identifier ',' identifier '=' …                  (error alt: requires parens)
+//
+// SET is the current token. All forms are reachable; the error alt is reported
+// with the ZetaSQL message (the .g4 NotifyErrorListeners text, which the Spanner
+// emulator echoes verbatim) so the over-permissive bare multi-variable form is
+// rejected rather than mis-parsed.
+func (p *Parser) parseSetStmt() (ast.Node, error) {
+	setTok := p.advance() // SET
+	stmt := &ast.SetStmt{Loc: setTok.Loc}
+
+	switch p.cur.Type {
+	case kwTRANSACTION:
+		// SET TRANSACTION transaction_mode_list — reuse the transaction node's mode
+		// parser (transaction.go). The mode list is required (≥1 mode).
+		p.advance() // TRANSACTION
+		if !p.atTransactionModeStart() {
+			return nil, p.syntaxErrorAtCur()
+		}
+		modes, err := p.parseTransactionModeList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = ast.SetTransaction
+		stmt.Modes = modes
+		stmt.Loc.End = modes[len(modes)-1].Loc.End
+		return stmt, nil
+
+	case int('('):
+		// SET ( identifier_list ) = expression.
+		p.advance() // '('
+		ids, err := p.parseScriptIdentifierList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int('=')); err != nil {
+			return nil, err
+		}
+		value, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Kind = ast.SetTuple
+		stmt.Targets = make([]ast.Node, len(ids))
+		for i, id := range ids {
+			stmt.Targets[i] = id
+		}
+		stmt.Value = value
+		stmt.Loc.End = p.prev.Loc.End
+		p.fillSubqueries(stmt)
+		return stmt, nil
+
+	case int('@'), tokAtAt:
+		// SET @p = expr (named parameter, '@') or SET @@v = expr (system variable,
+		// '@@'). The lexer emits '@' as int('@') and '@@' as tokAtAt.
+		target, err := p.parseSetParameterTarget()
+		if err != nil {
+			return nil, err
+		}
+		return p.finishSetVariable(stmt, target)
+
+	default:
+		// SET identifier = expression — OR the error alt `SET id, id = …`.
+		if !isIdentifierStart(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		idTok := p.advance()
+		name, err := p.identifierText(idTok)
+		if err != nil {
+			return nil, err
+		}
+		// A ',' here is the error alt: multiple bare variables without parentheses.
+		// The .g4 emits a fixed message (echoed verbatim by the Spanner emulator).
+		if p.cur.Type == int(',') {
+			return nil, &ParseError{
+				Loc: idTok.Loc,
+				Msg: "Using SET with multiple variables requires parentheses around the variable list",
+			}
+		}
+		target := &ast.Identifier{Name: name, Loc: idTok.Loc}
+		return p.finishSetVariable(stmt, target)
+	}
+}
+
+// parseSetParameterTarget parses the LHS of a SET when it begins with '@':
+// `@identifier` (named_parameter_expression) → *ast.Parameter, or `@@path`
+// (system_variable_expression) → *ast.SystemVariable. The current token is '@'
+// or '@@'.
+func (p *Parser) parseSetParameterTarget() (ast.Node, error) {
+	if p.cur.Type == tokAtAt {
+		return p.parseSystemVariable()
+	}
+	return p.parseNamedParameter()
+}
+
+// finishSetVariable consumes `= expression` for the SetVariable forms (plain
+// identifier / @p / @@v) and returns the completed SetStmt. target is the parsed
+// LHS.
+func (p *Parser) finishSetVariable(stmt *ast.SetStmt, target ast.Node) (ast.Node, error) {
+	if _, err := p.expect(int('=')); err != nil {
+		return nil, err
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Kind = ast.SetVariable
+	stmt.Targets = []ast.Node{target}
+	stmt.Value = value
+	stmt.Loc.End = p.prev.Loc.End
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// EXECUTE IMMEDIATE
+// ---------------------------------------------------------------------------
+
+// parseExecuteImmediateStmt parses an execute_immediate:
+//
+//	EXECUTE IMMEDIATE expression (INTO identifier_list)? (USING arg_list)?
+//	arg: expression (AS alias)?
+//
+// EXECUTE is the current token (parseStmt's EXECUTE arm routes here after
+// confirming nothing — the IMMEDIATE keyword is required and validated here).
+func (p *Parser) parseExecuteImmediateStmt() (ast.Node, error) {
+	execTok := p.advance() // EXECUTE
+	if _, err := p.expect(kwIMMEDIATE); err != nil {
+		return nil, err
+	}
+	stmt := &ast.ExecuteImmediateStmt{Loc: execTok.Loc}
+
+	sql, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.SQL = sql
+
+	// (INTO identifier_list)?
+	if p.cur.Type == kwINTO {
+		p.advance() // INTO
+		ids, err := p.parseScriptIdentifierList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Into = ids
+	}
+
+	// (USING arg_list)? — each arg is `expression (AS alias)?`.
+	if p.cur.Type == kwUSING {
+		p.advance() // USING
+		for {
+			arg, err := p.parseUsingArg()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Using = append(stmt.Using, arg)
+			if _, ok := p.match(int(',')); ok {
+				continue
+			}
+			break
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	// The dynamic SQL expression and USING argument expressions may embed
+	// subqueries; fill them for the query-span walker.
+	p.fillSubqueries(stmt)
+	return stmt, nil
+}
+
+// parseUsingArg parses one EXECUTE IMMEDIATE USING argument:
+// `expression (AS alias)?`. The alias binds a named @parameter in the dynamic
+// SQL; it is recorded as the spelled name.
+func (p *Parser) parseUsingArg() (*ast.UsingArg, error) {
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	arg := &ast.UsingArg{Value: value}
+	arg.Loc = ast.NodeLoc(value)
+	if p.cur.Type == kwAS {
+		p.advance() // AS
+		aliasTok, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		name, err := p.identifierText(aliasTok)
+		if err != nil {
+			return nil, err
+		}
+		arg.Alias = name
+		arg.Loc.End = aliasTok.Loc.End
+	}
+	return arg, nil
+}
+
+// ---------------------------------------------------------------------------
+// BREAK / LEAVE / CONTINUE / ITERATE / RETURN / RAISE
+// ---------------------------------------------------------------------------
+
+// parseBreakStmt parses a break_statement: `BREAK identifier?` or
+// `LEAVE identifier?`. The current token is BREAK or LEAVE.
+func (p *Parser) parseBreakStmt() (ast.Node, error) {
+	tok := p.advance() // BREAK | LEAVE
+	stmt := &ast.BreakStmt{IsLeave: tok.Type == kwLEAVE, Loc: tok.Loc}
+	if isIdentifierStart(p.cur.Type) {
+		labelTok := p.advance()
+		name, err := p.identifierText(labelTok)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Label = name
+		stmt.Loc.End = labelTok.Loc.End
+	}
+	return stmt, nil
+}
+
+// parseContinueStmt parses a continue_statement: `CONTINUE identifier?` or
+// `ITERATE identifier?`. The current token is CONTINUE or ITERATE.
+func (p *Parser) parseContinueStmt() (ast.Node, error) {
+	tok := p.advance() // CONTINUE | ITERATE
+	stmt := &ast.ContinueStmt{IsIterate: tok.Type == kwITERATE, Loc: tok.Loc}
+	if isIdentifierStart(p.cur.Type) {
+		labelTok := p.advance()
+		name, err := p.identifierText(labelTok)
+		if err != nil {
+			return nil, err
+		}
+		stmt.Label = name
+		stmt.Loc.End = labelTok.Loc.End
+	}
+	return stmt, nil
+}
+
+// parseReturnStmt parses a return_statement: a bare `RETURN`. RETURN is the
+// current token; GoogleSQL's RETURN carries no value.
+func (p *Parser) parseReturnStmt() (ast.Node, error) {
+	tok := p.advance() // RETURN
+	return &ast.ReturnStmt{Loc: tok.Loc}, nil
+}
+
+// parseRaiseStmt parses a raise_statement:
+//
+//	RAISE
+//	RAISE USING MESSAGE = expression
+//
+// RAISE is the current token.
+func (p *Parser) parseRaiseStmt() (ast.Node, error) {
+	raiseTok := p.advance() // RAISE
+	stmt := &ast.RaiseStmt{Loc: raiseTok.Loc}
+	if p.cur.Type == kwUSING {
+		p.advance() // USING
+		if _, err := p.expect(kwMESSAGE); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int('=')); err != nil {
+			return nil, err
+		}
+		msg, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Message = msg
+		stmt.Loc.End = p.prev.Loc.End
+		p.fillSubqueries(stmt)
+	}
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Labeled statements
+// ---------------------------------------------------------------------------
+
+// parseLabeledStmt parses the labeled-statement alternative of
+// unterminated_script_statement:
+//
+//	label ':' unterminated_unlabeled_script_statement identifier?
+//	unterminated_unlabeled_script_statement: begin_end_block | while | loop | repeat | for_in
+//
+// The current token is the label identifier; the next token is ':'. Only the
+// block / loop forms may be labeled (NOT IF / CASE / DECLARE / SET / …). A
+// trailing identifier after the block's END is the optional end-label.
+func (p *Parser) parseLabeledStmt() (ast.Node, error) {
+	labelTok := p.advance() // label identifier
+	name, err := p.identifierText(labelTok)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(':')); err != nil {
+		return nil, err
+	}
+
+	stmt := &ast.LabeledStmt{Label: name, Loc: labelTok.Loc}
+
+	var inner ast.Node
+	switch p.cur.Type {
+	case kwBEGIN:
+		inner, err = p.parseBeginEndBlock()
+	case kwWHILE:
+		inner, err = p.parseWhileStmt()
+	case kwLOOP:
+		inner, err = p.parseLoopStmt()
+	case kwREPEAT:
+		inner, err = p.parseRepeatStmt()
+	case kwFOR:
+		inner, err = p.parseForInStmt()
+	default:
+		// Only the unlabeled block forms can carry a label.
+		return nil, p.syntaxErrorAtCur()
+	}
+	if err != nil {
+		return nil, err
+	}
+	stmt.Stmt = inner
+	stmt.Loc.End = p.prev.Loc.End
+
+	// Optional trailing end-label (identifier?). It must not be consumed if it is
+	// actually the next statement — but at this point the block has fully closed,
+	// and inside a statement_list the next token after a statement is ';' or a
+	// terminator, never a bare identifier. So a bare identifier here is the
+	// end-label.
+	if isIdentifierStart(p.cur.Type) {
+		endTok := p.advance()
+		endName, err := p.identifierText(endTok)
+		if err != nil {
+			return nil, err
+		}
+		stmt.EndLabel = endName
+		stmt.Loc.End = endTok.Loc.End
+	}
+	return stmt, nil
+}
+
+// isScriptLabelStart reports whether the current position begins a labeled
+// script statement: an identifier immediately followed by ':'. Used by parseStmt
+// to route a `label: <block>` before the ordinary keyword dispatch.
+func (p *Parser) isScriptLabelStart() bool {
+	return isIdentifierStart(p.cur.Type) && p.peekNext().Type == int(':')
+}

--- a/googlesql/parser/scripting.go
+++ b/googlesql/parser/scripting.go
@@ -175,6 +175,14 @@ func (p *Parser) parseBeginEndBlock() (ast.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(handler) == 0 {
+			// statement_list is non-empty (.g4: unterminated_non_empty_statement_list
+			// ';'), so `EXCEPTION WHEN ERROR THEN END` with no handler statement is a
+			// syntax error. The Spanner emulator's BeginStmt recognizer is shallow
+			// here (divergence #161 — it accepts any interior token run at parse and
+			// rejects BeginStmt only at the resolver), so the .g4 governs.
+			return nil, p.syntaxErrorAtCur()
+		}
 		block.HasException = true
 		block.Exception = handler
 	}

--- a/googlesql/parser/scripting_oracle_test.go
+++ b/googlesql/parser/scripting_oracle_test.go
@@ -1,0 +1,251 @@
+//go:build googlesql_oracle
+
+// Differential test for the `parser-scripting` node against the live Cloud
+// Spanner emulator oracle. Run with:
+//
+//	SPANNER_EMULATOR_HOST=localhost:9010 \
+//	  go test -tags googlesql_oracle ./googlesql/parser/ -run TestScriptingDifferential
+//
+// It is the PROVE gate for googlesql/parser-scripting (correctness-protocol.md):
+// for every AUTHORITATIVE fixture it (1) feeds the statement to the emulator via
+// the harness/googlesql-spanner CLI and reads the accept/reject verdict, then
+// (2) parses the same statement with omni's Parse, and asserts the two agree —
+// BOTH polarities. A harness `error` verdict fails loudly; it is never folded
+// into accept or reject. The harness plumbing (newSelectHarness / verdict /
+// close) is shared with select_oracle_test.go.
+//
+// DIALECT (oracle.md). Scripting is BigQuery-ONLY at the GoogleSQL union level,
+// with three oracle-authoritative LEADING forms — the emulator PARSES them
+// (verdict accept, "Statement not supported: …"):
+//   - BEGIN…END block            → "BeginStmt"
+//   - SET                        → "SingleAssignment" / "AssignmentFromStruct" /
+//                                  "ParameterAssignment" / "SystemVariableAssignment" /
+//                                  "SetTransactionStatement"
+//   - EXECUTE IMMEDIATE          → "ExecuteImmediateStatement"
+// plus genuine SHARED syntax rejects (a bare `SET`, `SET x` with no `= expr`).
+// These are diffed here.
+//
+// EXCLUDED — NON-authoritative on Spanner (covered by scripting_test.go + the
+// divergence ledger, NOT here, because the emulator's verdict would manufacture
+// a false divergence):
+//   - The control-flow statements (IF / CASE / WHILE / LOOP / REPEAT / FOR-IN /
+//     DECLARE / BREAK / CONTINUE / RETURN / RAISE / labels). The emulator
+//     SYNTAX-rejects them ("Unexpected keyword IF/WHILE/…"); they are
+//     BigQuery-valid (the .g4 procedural grammar + truth1 SCRIPT-001…019) and
+//     omni accepts them. A Spanner reject here would be a false divergence.
+//     These are asserted omni-side in scriptingBigQueryOnly below.
+//   - The INTERIOR statement_list grammar of a BEGIN…END block. The emulator's
+//     BEGIN…END recognizer is SHALLOW — it accepts ANY token run between BEGIN
+//     and END (`BEGIN SELECT 1 SELECT 2 END`, `BEGIN SELECT 1 END` with no
+//     trailing `;`, `BEGIN; END`), while the .g4 requires `;`-separated
+//     statements and a trailing `;`. omni follows the .g4, so those shallow
+//     over-accepts are deliberate divergences (ledger), excluded from this diff
+//     and asserted omni-side in scriptingBlockInteriorReject.
+
+package parser
+
+import (
+	"os"
+	"testing"
+)
+
+// scriptingFixture is one statement fed to BOTH the oracle and omni's Parse.
+// wantParse is the expected omni outcome and MUST equal the emulator's grammar
+// verdict.
+type scriptingFixture struct {
+	sql       string
+	wantParse bool
+}
+
+// scriptingAuthoritative are the forms whose Spanner verdict is authoritative
+// (the emulator parses the leading form, or genuinely syntax-rejects) AND on
+// which omni and the oracle agree.
+var scriptingAuthoritative = []scriptingFixture{
+	// ===================== BEGIN…END — accept (envelope) ================
+	{"BEGIN END", true},
+	{"BEGIN SELECT 1; END", true},
+	{"BEGIN DECLARE x INT64; SET x = 1; SELECT x; END", true},
+	{"BEGIN SELECT 1; EXCEPTION WHEN ERROR THEN SELECT 2; END", true},
+	{"BEGIN BEGIN SELECT 1; END; SELECT 2; END", true},
+	// A labeled BEGIN…END is parsed by the emulator's shallow recognizer as a
+	// BeginStmt (the label is swallowed) — accept on both sides.
+	{"label_1: BEGIN SELECT 1; BREAK label_1; END", true},
+
+	// ===================== SET — accept (parsed) ========================
+	{"SET x = 5", true},
+	{"SET x = 1 + 2 * 3", true},
+	{"SET (a, b, c) = (1, 'foo', false)", true},
+	{"SET (a) = (1)", true},
+	{"SET @p = 5", true},
+	{"SET @@x.y = 5", true},
+	{"SET TRANSACTION READ ONLY", true},
+	{"SET TRANSACTION READ WRITE", true},
+	{"SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", true},
+
+	// ===================== EXECUTE IMMEDIATE — accept (parsed) ===========
+	{`EXECUTE IMMEDIATE "SELECT 1"`, true},
+	{`EXECUTE IMMEDIATE "SELECT ? * (? + 2)" INTO y USING 1, 3`, true},
+	{`EXECUTE IMMEDIATE "SELECT @a" INTO y USING 1 AS a`, true},
+	{`EXECUTE IMMEDIATE "SELECT 1, 2" INTO a, b`, true},
+	{`EXECUTE IMMEDIATE CONCAT("SELECT ", "1")`, true},
+
+	// ===================== SET — reject (shared syntax) =================
+	{"SET", false},   // missing target ("Unexpected end of statement")
+	{"SET x", false}, // missing '=' / ',' ("Expected ',' or '='")
+
+	// ===================== EXECUTE — reject (shared syntax) =============
+	{"EXECUTE", false}, // missing IMMEDIATE
+}
+
+func TestScriptingDifferential(t *testing.T) {
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		t.Skip("SPANNER_EMULATOR_HOST not set; skipping live differential")
+	}
+	h := newSelectHarness(t)
+	defer h.close()
+
+	for _, fx := range scriptingAuthoritative {
+		fx := fx
+		t.Run(fx.sql, func(t *testing.T) {
+			// 1. Oracle verdict.
+			v := h.verdict(t, fx.sql)
+			switch v.Verdict {
+			case "accept", "reject":
+				// proceed
+			case "error":
+				t.Fatalf("oracle returned ERROR (no verdict) for %q: reason=%s code=%s msg=%s\n"+
+					"the oracle could not decide; fix the wrapper/emulator — do NOT treat as accept/reject",
+					fx.sql, v.Reason, v.Code, v.Message)
+			default:
+				t.Fatalf("unexpected harness verdict %q for %q", v.Verdict, fx.sql)
+			}
+			oracleAccepts := v.Verdict == "accept"
+
+			// Sanity: the asserted wantParse must match the live oracle. A mismatch
+			// here means the fixture is mis-tagged (or the form is actually
+			// non-authoritative on Spanner and should move to the omni-only sets).
+			if oracleAccepts != fx.wantParse {
+				t.Fatalf("fixture wantParse=%v but oracle says %q (%s) for %q",
+					fx.wantParse, v.Verdict, v.Message, fx.sql)
+			}
+
+			// 2. omni Parse verdict.
+			_, errs := Parse(fx.sql)
+			omniAccepts := len(errs) == 0
+
+			if omniAccepts != oracleAccepts {
+				t.Errorf("DIVERGENCE on %q: omni accepts=%v, oracle accepts=%v (%s: %s)",
+					fx.sql, omniAccepts, oracleAccepts, v.Reason, v.Message)
+			}
+		})
+	}
+}
+
+// scriptingBigQueryOnly are control-flow forms the Spanner emulator
+// syntax-rejects (BigQuery-only) but which omni must ACCEPT on the authority of
+// the legacy .g4 + the BigQuery truth1 corpus. They are NOT diffed against the
+// oracle (its reject is non-authoritative); they assert omni's accept and, when
+// the emulator is reachable, that the emulator indeed REJECTS (so the BigQuery-
+// only classification stays honest — if a future emulator started parsing these,
+// this test flags that the form should move to the authoritative set).
+var scriptingBigQueryOnly = []string{
+	"DECLARE x INT64",
+	"DECLARE d DATE DEFAULT CURRENT_DATE()",
+	"DECLARE x, y, z INT64 DEFAULT 0",
+	"DECLARE item DEFAULT (SELECT col FROM s.products LIMIT 1)",
+	"IF x > 0 THEN SELECT 1; END IF",
+	"IF c1 THEN SELECT 1; ELSEIF c2 THEN SELECT 2; ELSE SELECT 3; END IF",
+	"CASE WHEN c THEN SELECT 1; ELSE SELECT 2; END CASE",
+	"CASE x WHEN 1 THEN SELECT 'one'; ELSE SELECT 'other'; END CASE",
+	"WHILE x < 10 DO SET x = x + 1; END WHILE",
+	"LOOP SET x = x + 1; IF x >= 10 THEN LEAVE; END IF; END LOOP",
+	"REPEAT SET x = x + 1; UNTIL x >= 3 END REPEAT",
+	"FOR rec IN (SELECT word FROM s.shakespeare LIMIT 5) DO SELECT rec.word; END FOR",
+	"BREAK",
+	"LEAVE my_label",
+	"CONTINUE",
+	"ITERATE outer_loop",
+	"RETURN",
+	"RAISE",
+	"RAISE USING MESSAGE = 'error'",
+	// A labeled LOOP/WHILE/REPEAT/FOR is BigQuery-only: the emulator
+	// syntax-rejects it ("Unexpected <label>"). (A labeled BEGIN…END, by contrast,
+	// the emulator's shallow recognizer ACCEPTS as a BeginStmt — the label is
+	// swallowed — so it lives in scriptingAuthoritative, not here.)
+	"label_1: LOOP SELECT 1; END LOOP label_1",
+	"lbl: WHILE x DO SELECT 1; END WHILE",
+}
+
+func TestScriptingBigQueryOnlyAcceptedByOmni(t *testing.T) {
+	// omni must accept every BigQuery-only control-flow form.
+	for _, sql := range scriptingBigQueryOnly {
+		sql := sql
+		t.Run(sql, func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) != 0 {
+				t.Errorf("omni rejected BigQuery-only form %q: %v", sql, errs)
+			}
+		})
+	}
+
+	// When the emulator is reachable, confirm it SYNTAX-rejects these (the basis
+	// for treating them as BigQuery-only / non-authoritative). A standalone
+	// labeled top-level form may be reported differently; we only require that the
+	// emulator does NOT cleanly accept it as a Spanner statement.
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		return
+	}
+	h := newSelectHarness(t)
+	defer h.close()
+	for _, sql := range scriptingBigQueryOnly {
+		sql := sql
+		t.Run("oracle-rejects/"+sql, func(t *testing.T) {
+			v := h.verdict(t, sql)
+			if v.Verdict == "accept" {
+				t.Errorf("emulator now ACCEPTS %q (%s) — it is no longer Spanner-non-authoritative; "+
+					"move it to scriptingAuthoritative and diff it", sql, v.Message)
+			}
+		})
+	}
+}
+
+// scriptingBlockInteriorReject documents the deliberate divergence: the Spanner
+// emulator's BEGIN…END recognizer is SHALLOW and ACCEPTS these, but the .g4
+// statement_list grammar (which bytebase consumes) requires `;`-separated
+// statements and a trailing `;`, so omni REJECTS them. This asserts omni's
+// reject and (when reachable) records that the emulator over-accepts.
+var scriptingBlockInteriorReject = []string{
+	"BEGIN SELECT 1 END",           // no trailing ';' after the single statement
+	"BEGIN SELECT 1 SELECT 2 END",  // no ';' between statements
+	"BEGIN SELECT 1; SELECT 2 END", // no trailing ';' after the last statement
+}
+
+func TestScriptingBlockInteriorRejectedByOmni(t *testing.T) {
+	for _, sql := range scriptingBlockInteriorReject {
+		sql := sql
+		t.Run(sql, func(t *testing.T) {
+			_, errs := Parse(sql)
+			if len(errs) == 0 {
+				t.Errorf("omni accepted %q, but the .g4 statement_list requires `;` "+
+					"termination — omni must reject (Spanner's shallow recognizer over-accepts)", sql)
+			}
+		})
+	}
+
+	// Confirm the emulator's shallow over-accept (the basis for the divergence).
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		return
+	}
+	h := newSelectHarness(t)
+	defer h.close()
+	for _, sql := range scriptingBlockInteriorReject {
+		sql := sql
+		t.Run("oracle-overaccepts/"+sql, func(t *testing.T) {
+			v := h.verdict(t, sql)
+			if v.Verdict != "accept" {
+				t.Logf("note: emulator verdict for %q is %q (%s) — the documented shallow "+
+					"over-accept may have changed", sql, v.Verdict, v.Message)
+			}
+		})
+	}
+}

--- a/googlesql/parser/scripting_test.go
+++ b/googlesql/parser/scripting_test.go
@@ -1,0 +1,702 @@
+package parser
+
+// Unit tests for the parser-scripting node: GoogleSQL's procedural language
+// (DECLARE / SET / IF / CASE / WHILE / LOOP / REPEAT / FOR-IN / BEGIN…END with
+// EXCEPTION / RAISE / RETURN / BREAK / CONTINUE / EXECUTE IMMEDIATE / labels).
+//
+// These assert the AST shape and accept/reject polarity on hand-authored
+// fixtures. The differential against the live Spanner emulator (the PROVE gate
+// per correctness-protocol.md) lives in scripting_oracle_test.go (build tag
+// googlesql_oracle); scripting is BigQuery-only except the BEGIN…END envelope /
+// SET / EXECUTE IMMEDIATE, so the control-flow forms are triangulated against the
+// legacy .g4 + the BigQuery truth1 corpus, not the Spanner oracle.
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/googlesql/ast"
+)
+
+// parseOneScript parses src (one top-level statement / block) and returns the
+// single resulting node, failing on any parse error or a missing/extra node.
+func parseOneScript(t *testing.T, src string) ast.Node {
+	t.Helper()
+	file, errs := Parse(src)
+	if len(errs) != 0 {
+		t.Fatalf("Parse(%q) returned errors: %v", src, errs)
+	}
+	if file == nil || len(file.Stmts) != 1 {
+		got := 0
+		if file != nil {
+			got = len(file.Stmts)
+		}
+		t.Fatalf("Parse(%q): expected exactly 1 statement, got %d", src, got)
+	}
+	return file.Stmts[0]
+}
+
+// ----------------------------------------------------------------------------
+// DECLARE
+// ----------------------------------------------------------------------------
+
+func TestParseDeclareTyped(t *testing.T) {
+	n := parseOneScript(t, "DECLARE x INT64")
+	d, ok := n.(*ast.DeclareStmt)
+	if !ok {
+		t.Fatalf("expected *ast.DeclareStmt, got %T", n)
+	}
+	if len(d.Names) != 1 || d.Names[0].Name != "x" {
+		t.Fatalf("Names = %+v, want [x]", d.Names)
+	}
+	if d.Type == nil || d.Type.Text != "INT64" {
+		t.Fatalf("Type = %+v, want INT64", d.Type)
+	}
+	if d.Default != nil {
+		t.Fatalf("Default = %+v, want nil", d.Default)
+	}
+}
+
+func TestParseDeclareTypedWithDefault(t *testing.T) {
+	n := parseOneScript(t, "DECLARE d DATE DEFAULT CURRENT_DATE()")
+	d := n.(*ast.DeclareStmt)
+	if d.Type == nil || d.Type.Text != "DATE" {
+		t.Fatalf("Type = %+v, want DATE", d.Type)
+	}
+	if d.Default == nil {
+		t.Fatalf("Default = nil, want CURRENT_DATE() expr")
+	}
+}
+
+func TestParseDeclareMultipleNames(t *testing.T) {
+	n := parseOneScript(t, "DECLARE x, y, z INT64 DEFAULT 0")
+	d := n.(*ast.DeclareStmt)
+	if len(d.Names) != 3 {
+		t.Fatalf("Names = %+v, want 3 names", d.Names)
+	}
+	if d.Names[0].Name != "x" || d.Names[1].Name != "y" || d.Names[2].Name != "z" {
+		t.Fatalf("Names spelling = %+v", d.Names)
+	}
+	if d.Type == nil || d.Type.Text != "INT64" {
+		t.Fatalf("Type = %+v, want INT64", d.Type)
+	}
+}
+
+func TestParseDeclareDefaultOnly(t *testing.T) {
+	n := parseOneScript(t, "DECLARE item DEFAULT (SELECT 1)")
+	d := n.(*ast.DeclareStmt)
+	if d.Type != nil {
+		t.Fatalf("Type = %+v, want nil (DEFAULT-only form)", d.Type)
+	}
+	if d.Default == nil {
+		t.Fatalf("Default = nil, want subquery expr")
+	}
+}
+
+func TestParseDeclareDefaultSubqueryFilled(t *testing.T) {
+	// The DEFAULT initializer's subquery must be re-parsed (fillSubqueries) so the
+	// query-span walker can reach it.
+	n := parseOneScript(t, "DECLARE item DEFAULT (SELECT col FROM s.products LIMIT 1)")
+	d := n.(*ast.DeclareStmt)
+	sq, ok := d.Default.(*ast.SubqueryExpr)
+	if !ok {
+		t.Fatalf("Default = %T, want *ast.SubqueryExpr", d.Default)
+	}
+	if sq.Query == nil {
+		t.Fatalf("subquery Query is nil — fillSubqueries did not reach the DECLARE DEFAULT")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// SET
+// ----------------------------------------------------------------------------
+
+func TestParseSetSingleVariable(t *testing.T) {
+	n := parseOneScript(t, "SET x = 5")
+	s, ok := n.(*ast.SetStmt)
+	if !ok {
+		t.Fatalf("expected *ast.SetStmt, got %T", n)
+	}
+	if s.Kind != ast.SetVariable {
+		t.Fatalf("Kind = %v, want SetVariable", s.Kind)
+	}
+	if len(s.Targets) != 1 {
+		t.Fatalf("Targets = %+v, want 1", s.Targets)
+	}
+	id, ok := s.Targets[0].(*ast.Identifier)
+	if !ok || id.Name != "x" {
+		t.Fatalf("Targets[0] = %+v, want Identifier x", s.Targets[0])
+	}
+	if s.Value == nil {
+		t.Fatalf("Value = nil, want 5")
+	}
+}
+
+func TestParseSetTuple(t *testing.T) {
+	n := parseOneScript(t, "SET (a, b, c) = (1 + 3, 'foo', false)")
+	s := n.(*ast.SetStmt)
+	if s.Kind != ast.SetTuple {
+		t.Fatalf("Kind = %v, want SetTuple", s.Kind)
+	}
+	if len(s.Targets) != 3 {
+		t.Fatalf("Targets = %+v, want 3", s.Targets)
+	}
+	if s.Value == nil {
+		t.Fatalf("Value = nil, want RHS tuple")
+	}
+}
+
+func TestParseSetParameter(t *testing.T) {
+	n := parseOneScript(t, "SET @p = 5")
+	s := n.(*ast.SetStmt)
+	if s.Kind != ast.SetVariable {
+		t.Fatalf("Kind = %v, want SetVariable", s.Kind)
+	}
+	if _, ok := s.Targets[0].(*ast.Parameter); !ok {
+		t.Fatalf("Targets[0] = %T, want *ast.Parameter", s.Targets[0])
+	}
+}
+
+func TestParseSetSystemVariable(t *testing.T) {
+	n := parseOneScript(t, "SET @@x.y = 5")
+	s := n.(*ast.SetStmt)
+	if _, ok := s.Targets[0].(*ast.SystemVariable); !ok {
+		t.Fatalf("Targets[0] = %T, want *ast.SystemVariable", s.Targets[0])
+	}
+}
+
+func TestParseSetTransaction(t *testing.T) {
+	n := parseOneScript(t, "SET TRANSACTION READ ONLY")
+	s := n.(*ast.SetStmt)
+	if s.Kind != ast.SetTransaction {
+		t.Fatalf("Kind = %v, want SetTransaction", s.Kind)
+	}
+	if len(s.Modes) != 1 || s.Modes[0].Kind != ast.TransactionModeReadOnly {
+		t.Fatalf("Modes = %+v, want [READ ONLY]", s.Modes)
+	}
+}
+
+func TestParseSetTransactionIsolation(t *testing.T) {
+	n := parseOneScript(t, "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+	s := n.(*ast.SetStmt)
+	if s.Kind != ast.SetTransaction {
+		t.Fatalf("Kind = %v, want SetTransaction", s.Kind)
+	}
+	if len(s.Modes) != 1 || s.Modes[0].Kind != ast.TransactionModeIsolationLevel {
+		t.Fatalf("Modes = %+v, want [ISOLATION LEVEL]", s.Modes)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// EXECUTE IMMEDIATE
+// ----------------------------------------------------------------------------
+
+func TestParseExecuteImmediateBare(t *testing.T) {
+	n := parseOneScript(t, `EXECUTE IMMEDIATE "SELECT 1"`)
+	e, ok := n.(*ast.ExecuteImmediateStmt)
+	if !ok {
+		t.Fatalf("expected *ast.ExecuteImmediateStmt, got %T", n)
+	}
+	if e.SQL == nil {
+		t.Fatalf("SQL = nil")
+	}
+	if e.Into != nil || e.Using != nil {
+		t.Fatalf("Into/Using should be nil, got %+v / %+v", e.Into, e.Using)
+	}
+}
+
+func TestParseExecuteImmediateIntoUsingPositional(t *testing.T) {
+	n := parseOneScript(t, `EXECUTE IMMEDIATE "SELECT ? * (? + 2)" INTO y USING 1, 3`)
+	e := n.(*ast.ExecuteImmediateStmt)
+	if len(e.Into) != 1 || e.Into[0].Name != "y" {
+		t.Fatalf("Into = %+v, want [y]", e.Into)
+	}
+	if len(e.Using) != 2 {
+		t.Fatalf("Using = %+v, want 2 args", e.Using)
+	}
+	if e.Using[0].Alias != "" || e.Using[1].Alias != "" {
+		t.Fatalf("positional USING args should have no alias, got %q / %q", e.Using[0].Alias, e.Using[1].Alias)
+	}
+}
+
+func TestParseExecuteImmediateUsingNamed(t *testing.T) {
+	n := parseOneScript(t, `EXECUTE IMMEDIATE "SELECT @a * (@b + 2)" INTO y USING 1 AS a, 3 AS b`)
+	e := n.(*ast.ExecuteImmediateStmt)
+	if len(e.Using) != 2 {
+		t.Fatalf("Using = %+v, want 2 args", e.Using)
+	}
+	if e.Using[0].Alias != "a" || e.Using[1].Alias != "b" {
+		t.Fatalf("USING aliases = %q / %q, want a / b", e.Using[0].Alias, e.Using[1].Alias)
+	}
+}
+
+func TestParseExecuteImmediateIntoMultiple(t *testing.T) {
+	n := parseOneScript(t, `EXECUTE IMMEDIATE "SELECT 1, 2" INTO a, b`)
+	e := n.(*ast.ExecuteImmediateStmt)
+	if len(e.Into) != 2 || e.Into[0].Name != "a" || e.Into[1].Name != "b" {
+		t.Fatalf("Into = %+v, want [a b]", e.Into)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// IF
+// ----------------------------------------------------------------------------
+
+func TestParseIfSimple(t *testing.T) {
+	n := parseOneScript(t, "IF x > 0 THEN SELECT 1; END IF")
+	f, ok := n.(*ast.IfStmt)
+	if !ok {
+		t.Fatalf("expected *ast.IfStmt, got %T", n)
+	}
+	if f.Cond == nil {
+		t.Fatalf("Cond = nil")
+	}
+	if len(f.Then) != 1 {
+		t.Fatalf("Then = %+v, want 1 statement", f.Then)
+	}
+	if f.HasElse {
+		t.Fatalf("HasElse = true, want false")
+	}
+}
+
+func TestParseIfElseifElse(t *testing.T) {
+	src := "IF c1 THEN SELECT 1; ELSEIF c2 THEN SELECT 2; ELSE SELECT 3; END IF"
+	n := parseOneScript(t, src)
+	f := n.(*ast.IfStmt)
+	if len(f.ElseIf) != 1 {
+		t.Fatalf("ElseIf = %+v, want 1", f.ElseIf)
+	}
+	if f.ElseIf[0].Cond == nil || len(f.ElseIf[0].Then) != 1 {
+		t.Fatalf("ElseIf[0] = %+v", f.ElseIf[0])
+	}
+	if !f.HasElse || len(f.Else) != 1 {
+		t.Fatalf("Else = %+v (HasElse=%v), want 1 statement", f.Else, f.HasElse)
+	}
+}
+
+func TestParseIfEmptyThen(t *testing.T) {
+	// statement_list is optional after THEN.
+	n := parseOneScript(t, "IF x THEN END IF")
+	f := n.(*ast.IfStmt)
+	if len(f.Then) != 0 {
+		t.Fatalf("Then = %+v, want empty", f.Then)
+	}
+}
+
+func TestParseIfMultipleStatements(t *testing.T) {
+	n := parseOneScript(t, "IF x THEN SELECT 1; SELECT 2; SET y = 3; END IF")
+	f := n.(*ast.IfStmt)
+	if len(f.Then) != 3 {
+		t.Fatalf("Then = %+v, want 3 statements", f.Then)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// CASE (statement)
+// ----------------------------------------------------------------------------
+
+func TestParseCaseSearched(t *testing.T) {
+	src := "CASE WHEN c1 THEN SELECT 1; WHEN c2 THEN SELECT 2; ELSE SELECT 3; END CASE"
+	n := parseOneScript(t, src)
+	c, ok := n.(*ast.CaseStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CaseStmt, got %T", n)
+	}
+	if c.Operand != nil {
+		t.Fatalf("Operand = %+v, want nil (searched form)", c.Operand)
+	}
+	if len(c.Whens) != 2 {
+		t.Fatalf("Whens = %+v, want 2", c.Whens)
+	}
+	if !c.HasElse {
+		t.Fatalf("HasElse = false, want true")
+	}
+}
+
+func TestParseCaseSimple(t *testing.T) {
+	src := "CASE product_id WHEN 1 THEN SELECT 'one'; WHEN 2 THEN SELECT 'two'; ELSE SELECT 'other'; END CASE"
+	n := parseOneScript(t, src)
+	c := n.(*ast.CaseStmt)
+	if c.Operand == nil {
+		t.Fatalf("Operand = nil, want product_id (simple form)")
+	}
+	if len(c.Whens) != 2 {
+		t.Fatalf("Whens = %+v, want 2", c.Whens)
+	}
+}
+
+func TestParseCaseNoElse(t *testing.T) {
+	n := parseOneScript(t, "CASE WHEN c THEN SELECT 1; END CASE")
+	c := n.(*ast.CaseStmt)
+	if c.HasElse {
+		t.Fatalf("HasElse = true, want false")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// WHILE / LOOP / REPEAT
+// ----------------------------------------------------------------------------
+
+func TestParseWhile(t *testing.T) {
+	n := parseOneScript(t, "WHILE x < 10 DO SET x = x + 1; END WHILE")
+	w, ok := n.(*ast.WhileStmt)
+	if !ok {
+		t.Fatalf("expected *ast.WhileStmt, got %T", n)
+	}
+	if w.Cond == nil {
+		t.Fatalf("Cond = nil")
+	}
+	if len(w.Body) != 1 {
+		t.Fatalf("Body = %+v, want 1 statement", w.Body)
+	}
+}
+
+func TestParseLoop(t *testing.T) {
+	n := parseOneScript(t, "LOOP SET x = x + 1; IF x >= 10 THEN LEAVE; END IF; END LOOP")
+	l, ok := n.(*ast.LoopStmt)
+	if !ok {
+		t.Fatalf("expected *ast.LoopStmt, got %T", n)
+	}
+	if len(l.Body) != 2 {
+		t.Fatalf("Body = %+v, want 2 statements", l.Body)
+	}
+}
+
+func TestParseRepeat(t *testing.T) {
+	n := parseOneScript(t, "REPEAT SET x = x + 1; SELECT x; UNTIL x >= 3 END REPEAT")
+	r, ok := n.(*ast.RepeatStmt)
+	if !ok {
+		t.Fatalf("expected *ast.RepeatStmt, got %T", n)
+	}
+	if len(r.Body) != 2 {
+		t.Fatalf("Body = %+v, want 2 statements", r.Body)
+	}
+	if r.Until == nil {
+		t.Fatalf("Until = nil, want condition")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// FOR ... IN
+// ----------------------------------------------------------------------------
+
+func TestParseForIn(t *testing.T) {
+	src := "FOR record IN (SELECT word, cnt FROM s.shakespeare LIMIT 5) DO SELECT record.word; END FOR"
+	n := parseOneScript(t, src)
+	f, ok := n.(*ast.ForInStmt)
+	if !ok {
+		t.Fatalf("expected *ast.ForInStmt, got %T", n)
+	}
+	if f.Var == nil || f.Var.Name != "record" {
+		t.Fatalf("Var = %+v, want record", f.Var)
+	}
+	if f.Query == nil {
+		t.Fatalf("Query = nil, want the source query")
+	}
+	if len(f.Body) != 1 {
+		t.Fatalf("Body = %+v, want 1 statement", f.Body)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// BEGIN ... END
+// ----------------------------------------------------------------------------
+
+func TestParseBeginEndSimple(t *testing.T) {
+	n := parseOneScript(t, "BEGIN SELECT 1; END")
+	b, ok := n.(*ast.BeginEndBlock)
+	if !ok {
+		t.Fatalf("expected *ast.BeginEndBlock, got %T", n)
+	}
+	if len(b.Body) != 1 {
+		t.Fatalf("Body = %+v, want 1 statement", b.Body)
+	}
+	if b.HasException {
+		t.Fatalf("HasException = true, want false")
+	}
+}
+
+func TestParseBeginEndEmpty(t *testing.T) {
+	n := parseOneScript(t, "BEGIN END")
+	b := n.(*ast.BeginEndBlock)
+	if len(b.Body) != 0 {
+		t.Fatalf("Body = %+v, want empty", b.Body)
+	}
+}
+
+func TestParseBeginEndMultiStatement(t *testing.T) {
+	n := parseOneScript(t, "BEGIN DECLARE y INT64; SET y = 1; SELECT y; END")
+	b := n.(*ast.BeginEndBlock)
+	if len(b.Body) != 3 {
+		t.Fatalf("Body = %+v, want 3 statements", b.Body)
+	}
+	if _, ok := b.Body[0].(*ast.DeclareStmt); !ok {
+		t.Fatalf("Body[0] = %T, want DeclareStmt", b.Body[0])
+	}
+}
+
+func TestParseBeginExceptionEnd(t *testing.T) {
+	src := "BEGIN CALL s.proc2(); EXCEPTION WHEN ERROR THEN SELECT @@error.message; END"
+	n := parseOneScript(t, src)
+	b := n.(*ast.BeginEndBlock)
+	if !b.HasException {
+		t.Fatalf("HasException = false, want true")
+	}
+	if len(b.Exception) != 1 {
+		t.Fatalf("Exception = %+v, want 1 statement", b.Exception)
+	}
+}
+
+func TestParseBeginEndNested(t *testing.T) {
+	n := parseOneScript(t, "BEGIN BEGIN SELECT 1; END; SELECT 2; END")
+	b := n.(*ast.BeginEndBlock)
+	if len(b.Body) != 2 {
+		t.Fatalf("Body = %+v, want 2 statements (nested block + select)", b.Body)
+	}
+	if _, ok := b.Body[0].(*ast.BeginEndBlock); !ok {
+		t.Fatalf("Body[0] = %T, want nested BeginEndBlock", b.Body[0])
+	}
+}
+
+func TestParseBeginEndSubqueryFilled(t *testing.T) {
+	// An expression subquery inside a block statement (here a SET RHS) must be
+	// re-parsed (fillSubqueries) so the query-span walker can reach its inner
+	// query. (A FROM-clause derived table is parsed directly into a *QueryStmt by
+	// parser-select and is not a SubqueryExpr, so it is not what this asserts.)
+	n := parseOneScript(t, "BEGIN SET x = (SELECT a FROM s); END")
+	b := n.(*ast.BeginEndBlock)
+	found := false
+	ast.Inspect(b, func(node ast.Node) bool {
+		if sq, ok := node.(*ast.SubqueryExpr); ok && sq.Query != nil {
+			found = true
+		}
+		return true
+	})
+	if !found {
+		t.Fatalf("no filled subquery found inside the block — fillSubqueries did not descend")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// BREAK / LEAVE / CONTINUE / ITERATE / RETURN
+// ----------------------------------------------------------------------------
+
+func TestParseBreak(t *testing.T) {
+	n := parseOneScript(t, "BREAK")
+	b, ok := n.(*ast.BreakStmt)
+	if !ok {
+		t.Fatalf("expected *ast.BreakStmt, got %T", n)
+	}
+	if b.IsLeave || b.Label != "" {
+		t.Fatalf("got IsLeave=%v Label=%q, want false/empty", b.IsLeave, b.Label)
+	}
+}
+
+func TestParseLeaveWithLabel(t *testing.T) {
+	n := parseOneScript(t, "LEAVE my_label")
+	b := n.(*ast.BreakStmt)
+	if !b.IsLeave {
+		t.Fatalf("IsLeave = false, want true")
+	}
+	if b.Label != "my_label" {
+		t.Fatalf("Label = %q, want my_label", b.Label)
+	}
+}
+
+func TestParseContinue(t *testing.T) {
+	n := parseOneScript(t, "CONTINUE")
+	c, ok := n.(*ast.ContinueStmt)
+	if !ok {
+		t.Fatalf("expected *ast.ContinueStmt, got %T", n)
+	}
+	if c.IsIterate || c.Label != "" {
+		t.Fatalf("got IsIterate=%v Label=%q", c.IsIterate, c.Label)
+	}
+}
+
+func TestParseIterateWithLabel(t *testing.T) {
+	n := parseOneScript(t, "ITERATE outer_loop")
+	c := n.(*ast.ContinueStmt)
+	if !c.IsIterate {
+		t.Fatalf("IsIterate = false, want true")
+	}
+	if c.Label != "outer_loop" {
+		t.Fatalf("Label = %q, want outer_loop", c.Label)
+	}
+}
+
+func TestParseReturn(t *testing.T) {
+	n := parseOneScript(t, "RETURN")
+	if _, ok := n.(*ast.ReturnStmt); !ok {
+		t.Fatalf("expected *ast.ReturnStmt, got %T", n)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// RAISE
+// ----------------------------------------------------------------------------
+
+func TestParseRaiseBare(t *testing.T) {
+	n := parseOneScript(t, "RAISE")
+	r, ok := n.(*ast.RaiseStmt)
+	if !ok {
+		t.Fatalf("expected *ast.RaiseStmt, got %T", n)
+	}
+	if r.Message != nil {
+		t.Fatalf("Message = %+v, want nil", r.Message)
+	}
+}
+
+func TestParseRaiseUsingMessage(t *testing.T) {
+	n := parseOneScript(t, "RAISE USING MESSAGE = 'something went wrong'")
+	r := n.(*ast.RaiseStmt)
+	if r.Message == nil {
+		t.Fatalf("Message = nil, want the message expr")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Labels
+// ----------------------------------------------------------------------------
+
+func TestParseLabeledLoop(t *testing.T) {
+	n := parseOneScript(t, "label_1: LOOP SELECT 1; END LOOP label_1")
+	l, ok := n.(*ast.LabeledStmt)
+	if !ok {
+		t.Fatalf("expected *ast.LabeledStmt, got %T", n)
+	}
+	if l.Label != "label_1" {
+		t.Fatalf("Label = %q, want label_1", l.Label)
+	}
+	if l.EndLabel != "label_1" {
+		t.Fatalf("EndLabel = %q, want label_1", l.EndLabel)
+	}
+	if _, ok := l.Stmt.(*ast.LoopStmt); !ok {
+		t.Fatalf("Stmt = %T, want LoopStmt", l.Stmt)
+	}
+}
+
+func TestParseLabeledBlockNoEndLabel(t *testing.T) {
+	n := parseOneScript(t, "label_1: BEGIN SELECT 1; BREAK label_1; END")
+	l := n.(*ast.LabeledStmt)
+	if l.Label != "label_1" {
+		t.Fatalf("Label = %q, want label_1", l.Label)
+	}
+	if l.EndLabel != "" {
+		t.Fatalf("EndLabel = %q, want empty", l.EndLabel)
+	}
+	if _, ok := l.Stmt.(*ast.BeginEndBlock); !ok {
+		t.Fatalf("Stmt = %T, want BeginEndBlock", l.Stmt)
+	}
+}
+
+func TestParseLabeledWhile(t *testing.T) {
+	n := parseOneScript(t, "lbl: WHILE x DO SELECT 1; END WHILE")
+	l := n.(*ast.LabeledStmt)
+	if _, ok := l.Stmt.(*ast.WhileStmt); !ok {
+		t.Fatalf("Stmt = %T, want WhileStmt", l.Stmt)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Deep nesting (truth1 doc examples)
+// ----------------------------------------------------------------------------
+
+// TestParseNestedLabeledLoop is SCRIPT-009's nested labeled LOOP / WHILE / IF
+// with CONTINUE / BREAK to the outer label — the deepest control-flow nesting in
+// the BigQuery procedural docs.
+func TestParseNestedLabeledLoop(t *testing.T) {
+	src := "label_1: LOOP WHILE x < 1 DO IF y < 1 THEN CONTINUE label_1; ELSE BREAK label_1; END IF; END WHILE; END LOOP label_1"
+	n := parseOneScript(t, src)
+	lbl, ok := n.(*ast.LabeledStmt)
+	if !ok {
+		t.Fatalf("expected *ast.LabeledStmt, got %T", n)
+	}
+	loop, ok := lbl.Stmt.(*ast.LoopStmt)
+	if !ok || len(loop.Body) != 1 {
+		t.Fatalf("loop body = %+v", lbl.Stmt)
+	}
+	while, ok := loop.Body[0].(*ast.WhileStmt)
+	if !ok || len(while.Body) != 1 {
+		t.Fatalf("while body = %+v", loop.Body[0])
+	}
+	ifStmt, ok := while.Body[0].(*ast.IfStmt)
+	if !ok {
+		t.Fatalf("expected nested IfStmt, got %T", while.Body[0])
+	}
+	cont, ok := ifStmt.Then[0].(*ast.ContinueStmt)
+	if !ok || cont.Label != "label_1" {
+		t.Fatalf("THEN[0] = %+v, want CONTINUE label_1", ifStmt.Then[0])
+	}
+	brk, ok := ifStmt.Else[0].(*ast.BreakStmt)
+	if !ok || brk.Label != "label_1" {
+		t.Fatalf("ELSE[0] = %+v, want BREAK label_1", ifStmt.Else[0])
+	}
+}
+
+// TestParseBlockTransactionWithException is SCRIPT-016's nested BEGIN
+// TRANSACTION / COMMIT / ROLLBACK inside a block with an EXCEPTION handler.
+func TestParseBlockTransactionWithException(t *testing.T) {
+	src := "BEGIN BEGIN TRANSACTION; SELECT 1; COMMIT TRANSACTION; EXCEPTION WHEN ERROR THEN SELECT @@error.message; ROLLBACK TRANSACTION; END"
+	n := parseOneScript(t, src)
+	b := n.(*ast.BeginEndBlock)
+	if len(b.Body) != 3 {
+		t.Fatalf("Body = %+v, want 3 (BEGIN TRANSACTION / SELECT / COMMIT)", b.Body)
+	}
+	if !b.HasException || len(b.Exception) != 2 {
+		t.Fatalf("Exception = %+v (HasException=%v), want 2 statements", b.Exception, b.HasException)
+	}
+	if _, ok := b.Body[0].(*ast.TransactionStmt); !ok {
+		t.Fatalf("Body[0] = %T, want TransactionStmt (BEGIN TRANSACTION)", b.Body[0])
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Reject cases (negative tests)
+// ----------------------------------------------------------------------------
+
+func TestScriptingRejects(t *testing.T) {
+	rejects := []string{
+		// SET shapes the .g4 rejects.
+		"SET",           // missing target
+		"SET x",         // missing = expr
+		"SET x =",       // missing RHS
+		"SET a, b = 1",  // multiple vars without parens (grammar error alt)
+		"SET (a, b) = ", // missing RHS
+		"SET () = (1)",  // empty identifier list
+		// DECLARE shapes.
+		"DECLARE",         // missing name
+		"DECLARE x",       // missing type and DEFAULT
+		"DECLARE 1 INT64", // name is not an identifier
+		// Control flow missing required keywords.
+		"IF x SELECT 1; END IF",                  // missing THEN
+		"IF x THEN SELECT 1;",                    // missing END IF
+		"WHILE x SELECT 1; END WHILE",            // missing DO
+		"WHILE x DO SELECT 1; END",               // END not followed by WHILE
+		"REPEAT SELECT 1; END REPEAT",            // missing UNTIL clause
+		"LOOP SELECT 1; END WHILE",               // mismatched closer
+		"FOR x (SELECT 1) DO SELECT 1; END FOR",  // missing IN
+		"FOR x IN SELECT 1 DO SELECT 1; END FOR", // IN source not parenthesized
+		"CASE WHEN c THEN SELECT 1; END",         // END not followed by CASE
+		"CASE END CASE",                          // no WHEN clause
+		// EXECUTE IMMEDIATE shapes.
+		"EXECUTE",                      // missing IMMEDIATE
+		"EXECUTE IMMEDIATE",            // missing sql expr
+		`EXECUTE IMMEDIATE "x" INTO`,   // INTO with no variable
+		`EXECUTE IMMEDIATE "x" USING`,  // USING with no arg
+		`EXECUTE IMMEDIATE "x" INTO 1`, // INTO target not an identifier
+		// BEGIN ... END.
+		"BEGIN SELECT 1;", // unterminated block (no END)
+		"BEGIN EXCEPTION WHEN ERROR THEN SELECT 1; END", // EXCEPTION needs a body before? actually valid; remove
+	}
+	for _, src := range rejects {
+		if src == "BEGIN EXCEPTION WHEN ERROR THEN SELECT 1; END" {
+			continue // handled below as accept
+		}
+		t.Run(src, func(t *testing.T) {
+			_, errs := Parse(src)
+			if len(errs) == 0 {
+				t.Errorf("Parse(%q) accepted, want a syntax error", src)
+			}
+		})
+	}
+}

--- a/googlesql/parser/scripting_test.go
+++ b/googlesql/parser/scripting_test.go
@@ -446,6 +446,28 @@ func TestParseBeginExceptionEnd(t *testing.T) {
 	}
 }
 
+// TestParseBeginExceptionEmptyRejected pins the fix for the empty-handler
+// over-accept (Codex review): opt_exception_handler's statement_list is non-empty
+// in the .g4 (unterminated_non_empty_statement_list ';'), so `EXCEPTION WHEN
+// ERROR THEN` with no handler statement is a syntax error. The Spanner emulator's
+// BeginStmt recognizer is shallow here (divergence #161), so the grammar governs.
+func TestParseBeginExceptionEmptyRejected(t *testing.T) {
+	assertReject(t, "BEGIN EXCEPTION WHEN ERROR THEN END")
+	// A non-empty handler is still accepted.
+	parseOneScript(t, "BEGIN EXCEPTION WHEN ERROR THEN SELECT 1; END")
+}
+
+// TestParseLabeledEndLabelNotMatched defends a Codex finding: a labeled
+// statement's optional END label is grammatically just `identifier?`
+// (.g4: `label ':' unterminated_unlabeled_script_statement identifier?`), with NO
+// syntactic requirement that it match the opening label — matching is a SEMANTIC
+// check, not the parser's job. So omni accepts a mismatched end label (parity with
+// the legacy ANTLR parser); this guards against a future change that wrongly
+// rejects it at parse time. (parseOneScript fatals on any parse error.)
+func TestParseLabeledEndLabelNotMatched(t *testing.T) {
+	parseOneScript(t, "label_1: LOOP SELECT 1; END LOOP different")
+}
+
 func TestParseBeginEndNested(t *testing.T) {
 	n := parseOneScript(t, "BEGIN BEGIN SELECT 1; END; SELECT 2; END")
 	b := n.(*ast.BeginEndBlock)

--- a/googlesql/parser/split.go
+++ b/googlesql/parser/split.go
@@ -209,6 +209,20 @@ func Split(input string) []Segment {
 
 		switch state {
 		case stateTop:
+			// A statement-leading `label:` prefix introduces a labeled procedural
+			// block (`label: BEGIN|LOOP|WHILE|REPEAT|FOR …`, GoogleSQLParser.g4
+			// unterminated_script_statement's labeled alternative). The label name
+			// and its ':' must stay TRANSPARENT to statement-leading position so the
+			// block opener that follows still opens a block — otherwise the block's
+			// internal ';' would split the labeled statement. Consume the ':' here
+			// and keep atStmtStart true. (Only a non-reserved identifier can be a
+			// bare label; a reserved word would be backtick-quoted → tokIdentifier.)
+			if atStmtStart && isIdentifierStart(tok.Type) && peekToken().Type == int(':') {
+				nextToken() // consume ':'
+				// atStmtStart stays true: the next token (the block opener) is still
+				// statement-leading.
+				continue
+			}
 			switch tok.Type {
 			case kwBEGIN:
 				// BEGIN opens a procedural block whenever the following token is

--- a/googlesql/parser/split.go
+++ b/googlesql/parser/split.go
@@ -263,9 +263,27 @@ func Split(input string) []Segment {
 
 		case stateInBlock:
 			switch tok.Type {
-			case kwBEGIN, kwIF, kwCASE, kwLOOP, kwWHILE, kwREPEAT, kwFOR:
+			case kwIF:
+				// A block keyword right after END is the suffix of a typed closer
+				// (END IF), not a new opener.
+				if prevWasEnd {
+					prevWasEnd = false
+				} else if peekToken().Type != int('(') {
+					// `IF(` is the IF() scalar function (no matching END), not a
+					// nested IF statement — counting it inflates depth and swallows
+					// the block's terminating ';' (e.g. `BEGIN SELECT IF(a,b,c); END`).
+					// The IF statement (`IF <expr> THEN`) is not followed by '('. The
+					// rare `IF (paren-condition) THEN` nested form is the one this
+					// under-counts; it degrades to a best-effort mis-split rather than
+					// breaking on the far more common IF()-call. (Top-level IF is
+					// statement-position-gated above; the block interior cannot track
+					// statement position without full parsing.)
+					depth++
+				}
+			case kwBEGIN, kwCASE, kwLOOP, kwWHILE, kwREPEAT, kwFOR:
 				// A block keyword right after END is the suffix of a typed
-				// closer (END IF / END CASE / …), not a new opener.
+				// closer (END CASE / END LOOP / …), not a new opener. A CASE
+				// *expression* self-balances (CASE … END).
 				if prevWasEnd {
 					prevWasEnd = false
 				} else {

--- a/googlesql/parser/split_test.go
+++ b/googlesql/parser/split_test.go
@@ -137,6 +137,31 @@ func TestSplit_SemicolonInHiddenContent(t *testing.T) {
 
 // Block-aware Split keeps procedural BEGIN/END (and IF/CASE/LOOP/WHILE/REPEAT/
 // FOR) blocks whole; SplitFlat (BigQuery lexer-split) does not.
+// TestSplit_BlockWithFunctionKeyword pins the fix for the block-interior
+// function-keyword bug (Codex review): a control-flow KEYWORD used as a scalar
+// function inside a block body — IF(...) — must NOT be counted as a nested block
+// opener. Counting it inflated the block depth so the ';' after END was swallowed
+// and the following statement became trailing junk (Split returned 1, not 2).
+func TestSplit_BlockWithFunctionKeyword(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"if_function_in_block", "BEGIN SELECT IF(TRUE, 1, 0); END; SELECT 2;", 2},
+		{"case_expr_with_if_function", "BEGIN SELECT CASE WHEN x THEN IF(a,b,c) ELSE 0 END; END; SELECT 2;", 2},
+		{"real_nested_if_statement", "BEGIN IF x THEN SELECT 1; END IF; END; SELECT 2;", 2},
+		{"plain_block", "BEGIN SELECT 1; END; SELECT 2;", 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Split(c.input); len(got) != c.want {
+				t.Fatalf("Split(%q) = %d segments, want %d: %+v", c.input, len(got), c.want, got)
+			}
+		})
+	}
+}
+
 func TestSplit_BeginEndBlock(t *testing.T) {
 	// A stored-procedure body with internal ';' separators.
 	const proc = "CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 2; END"


### PR DESCRIPTION
## Node: `googlesql/parser-scripting`

Implements GoogleSQL's procedural language (BigQuery scripting), the
`parser-scripting` DAG node. Replaces the foundation's `unsupported(...)` stubs
for every procedural-script form with real recursive-descent parsers + AST.

**Spec:** `docs/migration/googlesql/` (analysis.md §2.11 / antlr_rules.md §2.11+§4.8 / truth1/bigquery/scripting.md SCRIPT-001…019); legacy `GoogleSQLParser.g4` procedural grammar.

### What it adds
- **AST** (`ast/parsenodes.go`, +tags, regenerated `walk_generated.go`): 18 node
  types — `DeclareStmt`, `SetStmt`, `IfStmt`/`ElseIfClause`, `CaseStmt`/`WhenThenClause`,
  `WhileStmt`, `LoopStmt`, `RepeatStmt`, `ForInStmt`, `BeginEndBlock`, `BreakStmt`,
  `ContinueStmt`, `ReturnStmt`, `RaiseStmt`, `ExecuteImmediateStmt`/`UsingArg`, `LabeledStmt`.
- **`parser/scripting.go`**: a recursive `statement_list` parser shared by every
  block form (it reuses the top-level `parseStmt` dispatcher for nested SQL/script
  statements). Subqueries embedded in `DECLARE … DEFAULT (…)`, `SET x = (…)`,
  `FOR … IN (query)`, and `EXECUTE IMMEDIATE …` are re-parsed (`fillSubqueries`)
  so the query-span / lineage walker can reach them.
- **`parser.go`**: wires the dispatch arms (IF/CASE/WHILE/LOOP/REPEAT/FOR/DECLARE/
  BREAK/LEAVE/CONTINUE/ITERATE/RETURN/RAISE/SET/EXECUTE IMMEDIATE/BEGIN…END) +
  a `label:` prefix check.
- **`split.go`** (out-of-scope, recorded): recognizes a statement-leading
  `label:` prefix so a top-level labeled block (`label: LOOP … END LOOP label`,
  SCRIPT-009) segments whole instead of splitting on its interior `;`.

`SET` and `EXECUTE IMMEDIATE` (both in this node's display_name; no other node
owns `set_statement`) are implemented here. `CALL` and `BEGIN/COMMIT/ROLLBACK
TRANSACTION` were already done by parser-utility/transaction.go and are reused
(e.g. `SET TRANSACTION` reuses `parseTransactionModeList`).

### PROVE — differential vs the live Cloud Spanner emulator (`scripting_oracle_test.go`)
Run: `SPANNER_EMULATOR_HOST=localhost:9010 go test -tags googlesql_oracle ./googlesql/parser/ -run TestScripting…`

Scripting is **BigQuery-only** at the union level, with three oracle-authoritative
LEADING forms (the emulator PARSES them, then feature-rejects "Statement not supported: …"):
- **BEGIN…END** → `BeginStmt`; **SET** → `SingleAssignment`/`AssignmentFromStruct`/`ParameterAssignment`/`SystemVariableAssignment`/`SetTransactionStatement`; **EXECUTE IMMEDIATE** → `ExecuteImmediateStatement`.

These (+ genuine shared syntax rejects like bare `SET`, `SET x`) are diffed both
polarities and **agree**. The control-flow forms (IF/CASE/WHILE/LOOP/REPEAT/FOR-IN/
DECLARE/BREAK/CONTINUE/RETURN/RAISE/labeled LOOP) are BigQuery-only — the emulator
syntax-rejects them; omni accepts on the `.g4` + truth1 authority. The test asserts
omni accepts AND confirms the emulator rejects (so the BigQuery-only tag stays honest).

### Divergences (ledger #161, #162 — `confirmed`)
1. **BEGIN…END interior strictness.** omni follows the `.g4` `statement_list`
   (`;`-separated statements + a trailing `;`); the emulator's BEGIN…END recognizer
   is **shallow** and over-accepts any interior token run (`BEGIN SELECT 1 SELECT 2 END`,
   `BEGIN SELECT 1 END`). omni rejects those (asserted in `TestScriptingBlockInteriorRejectedByOmni`).
   Mirrors the existing transaction-tail divergence (transaction.go).
2. **`SET a, b = 1`** (bare multi-variable) is rejected with the ZetaSQL message
   "requires parentheses around the variable list" (the `.g4` error-alt); the
   parenthesized `SET (a, b) = (…)` is the accepted form.

### Coverage
All 20 antlr §2.11 scripting rules + all truth1 SCRIPT-001…019 forms accounted-for
(see scripting_test.go + the doc-example regression tests). `go test ./googlesql/parser/...
./googlesql/ast/...` green; `go vet` clean; oracle-tagged suite green; no panics/hangs
on malformed input.

### Review
- **Claude lens**: rigorous adversarial self-review (line-by-line, removed-behavior,
  cross-file/caller, reuse/simplification/altitude) + concrete edge-case and
  no-panic probes. No blocking findings.
- **Codex lens**: timed out (>7 min on the large new file / branch-scope diff — a known
  degradation); substituted with the self-review per review-gate.md. Cloud-bot review
  will converge cross-wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)