### PR TITLE
feat(snowflake): CREATE OR ALTER prefix for create statements

### DIFF
--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1303,6 +1303,7 @@ type CloneSource struct {
 // CreateTableStmt represents CREATE [OR REPLACE] [TRANSIENT|TEMPORARY|VOLATILE] TABLE ...
 type CreateTableStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Transient   bool
 	Temporary   bool
 	Volatile    bool
@@ -1414,6 +1415,7 @@ type DBSchemaProps struct {
 // CreateDatabaseStmt represents CREATE [OR REPLACE] [TRANSIENT] DATABASE ...
 type CreateDatabaseStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Transient   bool
 	IfNotExists bool
 	Name        *ObjectName
@@ -1474,6 +1476,7 @@ var _ Node = (*UndropDatabaseStmt)(nil)
 // CreateSchemaStmt represents CREATE [OR REPLACE] [TRANSIENT] SCHEMA ...
 type CreateSchemaStmt struct {
 	OrReplace     bool
+	OrAlter       bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Transient     bool
 	IfNotExists   bool
 	Name          *ObjectName
@@ -1895,6 +1898,7 @@ type RowAccessPolicy struct {
 // CreateViewStmt represents CREATE [OR REPLACE] [SECURE] [RECURSIVE] VIEW ...
 type CreateViewStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Secure      bool
 	Recursive   bool
 	IfNotExists bool
@@ -1921,6 +1925,7 @@ var _ Node = (*CreateViewStmt)(nil)
 // CreateMaterializedViewStmt represents CREATE [OR REPLACE] [SECURE] MATERIALIZED VIEW ...
 type CreateMaterializedViewStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Secure      bool
 	IfNotExists bool
 	Name        *ObjectName
@@ -3029,6 +3034,7 @@ var (
 // consumers can detect.
 type CreateStageStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Temporary   bool
 	IfNotExists bool
 	Name        *ObjectName
@@ -3115,6 +3121,7 @@ var (
 // Temporary.
 type CreateFileFormatStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Temporary   bool
 	IfNotExists bool
 	Name        *ObjectName
@@ -3275,6 +3282,7 @@ func (n *ConnectionReplica) Tag() NodeTag { return T_ConnectionReplica }
 type CreateIntegrationStmt struct {
 	Kind        IntegrationObjectKind
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	With        bool                      // RESOURCE MONITOR's mandatory WITH keyword was present
@@ -3445,6 +3453,7 @@ func (k ReplicationGroupKind) String() string {
 type CreateReplicationGroupStmt struct {
 	Failover           bool
 	OrReplace          bool
+	OrAlter            bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists        bool
 	Name               *ObjectName
 	Options            []*GroupOption   // open-ended KEY = value parameters, source order
@@ -3527,6 +3536,7 @@ func (n *AlterReplicationGroupStmt) Tag() NodeTag { return T_AlterReplicationGro
 type CreateAccountStmt struct {
 	Managed   bool
 	OrReplace bool // only MANAGED ACCOUNT accepts OR REPLACE per the docs
+	OrAlter   bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Name      *ObjectName
 	Options   []*GroupOption // ADMIN_NAME / ADMIN_PASSWORD / EMAIL / EDITION / TYPE / COMMENT / ...
 	Loc       Loc
@@ -3590,6 +3600,7 @@ func (n *AlterAccountStmt) Tag() NodeTag { return T_AlterAccountStmt }
 // COMMENT (the only documented parameter) is captured open-ended in Options.
 type CreateShareStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Options     []*GroupOption // COMMENT = '...'; nil if absent
@@ -3691,6 +3702,7 @@ var (
 // clauses open-ended, in source order.
 type CreateTagStmt struct {
 	OrReplace     bool
+	OrAlter       bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists   bool
 	Name          *ObjectName
 	AllowedValues []string      // ALLOWED_VALUES 'v1', 'v2', ...; nil if absent
@@ -3775,6 +3787,7 @@ func (n *SemanticViewSection) Tag() NodeTag { return T_SemanticViewSection }
 // open-ended. Tags holds a [WITH] TAG clause; CopyGrants records COPY GRANTS.
 type CreateSemanticViewStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Sections    []*SemanticViewSection // TABLES / RELATIONSHIPS / FACTS / DIMENSIONS / METRICS / AI_VERIFIED_QUERIES, source order
@@ -3830,6 +3843,7 @@ func (n *AlterSemanticViewStmt) Tag() NodeTag { return T_AlterSemanticViewStmt }
 // accepted here for consistency; see the divergence note in semantic_view.go.)
 type CreateDatasetStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Loc         Loc
@@ -3903,6 +3917,7 @@ var (
 // parens are not retained.
 type CreatePipeStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Options     []*CopyOption // AUTO_INGEST / ERROR_INTEGRATION / AWS_SNS_TOPIC / INTEGRATION / COMMENT / ...
@@ -3991,6 +4006,7 @@ type StreamTimeTravel struct {
 // SourceKind/Source/Options are zero.
 type CreateStreamStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Tags        []*TagAssignment  // [WITH] TAG (...); nil if absent
@@ -4062,6 +4078,7 @@ func (n *AlterStreamStmt) Tag() NodeTag { return T_AlterStreamStmt }
 // <source_task>), recorded via Clone with Options/After/When/Body all zero.
 type CreateTaskStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Tags        []*TagAssignment // [WITH] TAG (...); nil if absent
@@ -4143,6 +4160,7 @@ func (n *AlterTaskStmt) Tag() NodeTag { return T_AlterTaskStmt }
 // verbatim action source text.
 type CreateAlertStmt struct {
 	OrReplace    bool
+	OrAlter      bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists  bool
 	Name         *ObjectName
 	Tags         []*TagAssignment // [WITH] TAG (...); nil if absent
@@ -4277,6 +4295,7 @@ func (n *PolicyArg) Tag() NodeTag { return T_PolicyArg }
 // db-qualified, db_name.role_name). Account roles take an unqualified name.
 type CreateRoleStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Database    bool // CREATE DATABASE ROLE
 	IfNotExists bool
 	Name        *ObjectName
@@ -4300,6 +4319,7 @@ func (n *CreateRoleStmt) Tag() NodeTag { return T_CreateRoleStmt }
 // open-ended as a CopyOption, preserving source order.
 type CreateUserStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Options     []*CopyOption    // open-ended objectProperties / objectParams / sessionParams
@@ -4332,6 +4352,7 @@ func (n *CreateUserStmt) Tag() NodeTag { return T_CreateUserStmt }
 type CreatePolicyStmt struct {
 	Kind        PolicyKind
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Args        []*PolicyArg  // MASKING / ROW ACCESS signature; nil for option-bag policies
@@ -4571,6 +4592,7 @@ const (
 type CreateRoutineStmt struct {
 	Kind          RoutineKind
 	OrReplace     bool
+	OrAlter       bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Secure        bool
 	Temporary     bool
 	IfNotExists   bool
@@ -4683,6 +4705,7 @@ var (
 // other body fields zero).
 type CreateDynamicTableStmt struct {
 	OrReplace      bool
+	OrAlter        bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Transient      bool
 	Iceberg        bool
 	IfNotExists    bool
@@ -4797,6 +4820,7 @@ func (n *ExternalColumnDef) Tag() NodeTag { return T_ExternalColumnDef }
 // GRANTS; Tags holds the [WITH] TAG assignments.
 type CreateExternalTableStmt struct {
 	OrReplace     bool
+	OrAlter       bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists   bool
 	Name          *ObjectName
 	Columns       []*ExternalColumnDef // explicit column list; nil for USING TEMPLATE
@@ -4880,6 +4904,7 @@ func (n *AlterExternalTableStmt) Tag() NodeTag { return T_AlterExternalTableStmt
 // holds the [WITH] TAG assignments.
 type CreateEventTableStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	ClusterBy   []Node           // CLUSTER BY ( exprs ); nil if absent
@@ -4907,6 +4932,7 @@ func (n *CreateEventTableStmt) Tag() NodeTag { return T_CreateEventTableStmt }
 // for NOORDER, nil when unspecified. Comment holds the COMMENT clause text.
 type CreateSequenceStmt struct {
 	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	IfNotExists bool
 	Name        *ObjectName
 	Start       *int64  // START [WITH] [=] <n>; nil if absent

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -16,6 +16,8 @@ func (w *writer) writeCreateTableStmt(n *ast.CreateTableStmt) error {
 	w.buf.WriteString("CREATE")
 	if n.OrReplace {
 		w.buf.WriteString(" OR REPLACE")
+	} else if n.OrAlter {
+		w.buf.WriteString(" OR ALTER")
 	}
 	if n.Transient {
 		w.buf.WriteString(" TRANSIENT")
@@ -353,6 +355,8 @@ func (w *writer) writeCreateDatabaseStmt(n *ast.CreateDatabaseStmt) error {
 	w.buf.WriteString("CREATE")
 	if n.OrReplace {
 		w.buf.WriteString(" OR REPLACE")
+	} else if n.OrAlter {
+		w.buf.WriteString(" OR ALTER")
 	}
 	if n.Transient {
 		w.buf.WriteString(" TRANSIENT")
@@ -454,6 +458,8 @@ func (w *writer) writeCreateSchemaStmt(n *ast.CreateSchemaStmt) error {
 	w.buf.WriteString("CREATE")
 	if n.OrReplace {
 		w.buf.WriteString(" OR REPLACE")
+	} else if n.OrAlter {
+		w.buf.WriteString(" OR ALTER")
 	}
 	if n.Transient {
 		w.buf.WriteString(" TRANSIENT")
@@ -578,6 +584,8 @@ func (w *writer) writeCreateViewStmt(n *ast.CreateViewStmt) error {
 	w.buf.WriteString("CREATE")
 	if n.OrReplace {
 		w.buf.WriteString(" OR REPLACE")
+	} else if n.OrAlter {
+		w.buf.WriteString(" OR ALTER")
 	}
 	if n.Secure {
 		w.buf.WriteString(" SECURE")
@@ -763,6 +771,8 @@ func (w *writer) writeCreateMaterializedViewStmt(n *ast.CreateMaterializedViewSt
 	w.buf.WriteString("CREATE")
 	if n.OrReplace {
 		w.buf.WriteString(" OR REPLACE")
+	} else if n.OrAlter {
+		w.buf.WriteString(" OR ALTER")
 	}
 	if n.Secure {
 		w.buf.WriteString(" SECURE")

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -2,6 +2,7 @@ package deparse_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/snowflake/ast"
@@ -453,6 +454,28 @@ func TestDeparse_CreateTable_Simple(t *testing.T) {
 
 func TestDeparse_CreateTable_OrReplace(t *testing.T) {
 	assertRoundTrip(t, `CREATE OR REPLACE TABLE t (id INT)`)
+}
+
+// OR ALTER must round-trip distinctly from OR REPLACE: a deparse that emitted
+// OR REPLACE (or dropped the modifier) would change the reparsed AST and fail
+// the DeepEqual in assertRoundTrip.
+func TestDeparse_CreateTable_OrAlter(t *testing.T) {
+	out := assertRoundTrip(t, `CREATE OR ALTER TABLE t (id INT)`)
+	if !strings.Contains(out, "OR ALTER") {
+		t.Errorf("deparsed SQL missing OR ALTER: %q", out)
+	}
+}
+
+func TestDeparse_CreateDatabase_OrAlter(t *testing.T) {
+	assertRoundTrip(t, `CREATE OR ALTER DATABASE db1`)
+}
+
+func TestDeparse_CreateSchema_OrAlter(t *testing.T) {
+	assertRoundTrip(t, `CREATE OR ALTER SCHEMA s1`)
+}
+
+func TestDeparse_CreateView_OrAlter(t *testing.T) {
+	assertRoundTrip(t, `CREATE OR ALTER VIEW v2 (one) AS SELECT a FROM my_table`)
 }
 
 func TestDeparse_CreateTable_Transient(t *testing.T) {

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -12,14 +12,23 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	createTok := p.advance() // consume CREATE
 	start := createTok.Loc
 
-	// OR REPLACE
+	// OR { REPLACE | ALTER }. These are mutually exclusive prefixes: REPLACE
+	// drops and recreates the object, ALTER (a preview form documented at
+	// CREATE OR ALTER) modifies it in place. Only one OR-modifier is consumed
+	// here, so a second one (CREATE OR ALTER OR REPLACE ...) is left for the
+	// object-type dispatch to reject.
 	orReplace := false
+	orAlter := false
 	if p.cur.Type == kwOR {
-		next := p.peekNext()
-		if next.Type == kwREPLACE {
+		switch p.peekNext().Type {
+		case kwREPLACE:
 			p.advance() // consume OR
 			p.advance() // consume REPLACE
 			orReplace = true
+		case kwALTER:
+			p.advance() // consume OR
+			p.advance() // consume ALTER
+			orAlter = true
 		}
 	}
 
@@ -45,22 +54,22 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	if secure || recursive {
 		switch p.cur.Type {
 		case kwVIEW:
-			return p.parseCreateViewStmt(start, orReplace, secure, recursive)
+			return p.parseCreateViewStmt(start, orReplace, orAlter, secure, recursive)
 		case kwMATERIALIZED:
 			p.advance() // consume MATERIALIZED
-			return p.parseCreateMaterializedViewStmt(start, orReplace, secure)
+			return p.parseCreateMaterializedViewStmt(start, orReplace, orAlter, secure)
 		case kwFUNCTION:
 			if recursive {
 				return p.unsupported("CREATE")
 			}
 			// CREATE [OR REPLACE] SECURE FUNCTION ... (T4.5).
-			return p.parseCreateFunctionStmt(start, orReplace, true, false)
+			return p.parseCreateFunctionStmt(start, orReplace, orAlter, true, false)
 		case kwPROCEDURE:
 			if recursive {
 				return p.unsupported("CREATE")
 			}
 			// CREATE [OR REPLACE] SECURE PROCEDURE ... (T4.5).
-			return p.parseCreateProcedureStmt(start, orReplace, true)
+			return p.parseCreateProcedureStmt(start, orReplace, orAlter, true)
 		case kwEXTERNAL:
 			if recursive {
 				return p.unsupported("CREATE")
@@ -71,7 +80,7 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 				// EXTERNAL TABLE (and any other EXTERNAL object) is owned by another node.
 				return p.unsupported("CREATE")
 			}
-			return p.parseCreateExternalFunctionStmt(start, orReplace, true)
+			return p.parseCreateExternalFunctionStmt(start, orReplace, orAlter, true)
 		default:
 			return p.unsupported("CREATE")
 		}
@@ -101,58 +110,58 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 
 	switch p.cur.Type {
 	case kwTABLE:
-		return p.parseCreateTableStmt(start, orReplace, transient, temporary, volatile)
+		return p.parseCreateTableStmt(start, orReplace, orAlter, transient, temporary, volatile)
 	case kwDATABASE:
 		// CREATE [OR REPLACE] DATABASE ROLE ... (T4.6) vs CREATE DATABASE ... (T2.1).
 		// DATABASE ROLE is disambiguated by the ROLE keyword following DATABASE.
 		if p.peekNext().Type == kwROLE {
 			p.advance() // consume DATABASE
-			return p.parseCreateRoleStmt(start, orReplace, true)
+			return p.parseCreateRoleStmt(start, orReplace, orAlter, true)
 		}
-		return p.parseCreateDatabaseStmt(start, orReplace, transient)
+		return p.parseCreateDatabaseStmt(start, orReplace, orAlter, transient)
 	case kwSCHEMA:
-		return p.parseCreateSchemaStmt(start, orReplace, transient)
+		return p.parseCreateSchemaStmt(start, orReplace, orAlter, transient)
 	case kwVIEW:
-		return p.parseCreateViewStmt(start, orReplace, false, false)
+		return p.parseCreateViewStmt(start, orReplace, orAlter, false, false)
 	case kwMATERIALIZED:
 		p.advance() // consume MATERIALIZED
-		return p.parseCreateMaterializedViewStmt(start, orReplace, false)
+		return p.parseCreateMaterializedViewStmt(start, orReplace, orAlter, false)
 	case kwSTAGE:
 		// CREATE [OR REPLACE] [TEMP|TEMPORARY] STAGE ... (T4.1).
-		return p.parseCreateStageStmt(start, orReplace, temporary)
+		return p.parseCreateStageStmt(start, orReplace, orAlter, temporary)
 	case kwFILE_FORMAT, kwFILE:
 		// CREATE [OR REPLACE] [TEMP|TEMPORARY|VOLATILE] FILE FORMAT ... (T4.2).
 		// FILE FORMAT lexes as one FILE_FORMAT token or two FILE+FORMAT tokens;
 		// both dispatch here. Per the docs VOLATILE is a synonym of TEMPORARY for
 		// a file format, so either modifier sets the statement's Temporary flag.
-		return p.parseCreateFileFormatStmt(start, orReplace, temporary || volatile)
+		return p.parseCreateFileFormatStmt(start, orReplace, orAlter, temporary || volatile)
 	case kwPIPE:
 		// CREATE [OR REPLACE] PIPE ... (T4.3).
-		return p.parseCreatePipeStmt(start, orReplace)
+		return p.parseCreatePipeStmt(start, orReplace, orAlter)
 	case kwSTREAM:
 		// CREATE [OR REPLACE] STREAM ... (T4.3).
-		return p.parseCreateStreamStmt(start, orReplace)
+		return p.parseCreateStreamStmt(start, orReplace, orAlter)
 	case kwTASK:
 		// CREATE [OR REPLACE] TASK ... (T4.3).
-		return p.parseCreateTaskStmt(start, orReplace)
+		return p.parseCreateTaskStmt(start, orReplace, orAlter)
 	case kwALERT:
 		// CREATE [OR REPLACE] ALERT ... (T4.3).
-		return p.parseCreateAlertStmt(start, orReplace)
+		return p.parseCreateAlertStmt(start, orReplace, orAlter)
 	case kwFUNCTION:
 		// CREATE [OR REPLACE] [TEMP|TEMPORARY] FUNCTION ... (T4.5).
-		return p.parseCreateFunctionStmt(start, orReplace, false, temporary)
+		return p.parseCreateFunctionStmt(start, orReplace, orAlter, false, temporary)
 	case kwPROCEDURE:
 		// CREATE [OR REPLACE] PROCEDURE ... (T4.5).
-		return p.parseCreateProcedureStmt(start, orReplace, false)
+		return p.parseCreateProcedureStmt(start, orReplace, orAlter, false)
 	case kwDYNAMIC:
 		// CREATE [OR REPLACE] [TRANSIENT] DYNAMIC [ICEBERG] TABLE ... (T4.4).
-		return p.parseCreateDynamicTableStmt(start, orReplace, transient)
+		return p.parseCreateDynamicTableStmt(start, orReplace, orAlter, transient)
 	case kwEVENT:
 		// CREATE [OR REPLACE] EVENT TABLE ... (T4.4).
-		return p.parseCreateEventTableStmt(start, orReplace)
+		return p.parseCreateEventTableStmt(start, orReplace, orAlter)
 	case kwSEQUENCE:
 		// CREATE [OR REPLACE] SEQUENCE ... (T4.4).
-		return p.parseCreateSequenceStmt(start, orReplace)
+		return p.parseCreateSequenceStmt(start, orReplace, orAlter)
 	case kwEXTERNAL:
 		// CREATE [OR REPLACE] EXTERNAL { FUNCTION (T4.5) | TABLE (T4.4) | VOLUME (T4.7) }.
 		// The object is disambiguated by what follows EXTERNAL. EXTERNAL TABLE keeps
@@ -161,63 +170,63 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// reserved keyword, so EXTERNAL VOLUME lexes as kwEXTERNAL followed by a
 		// "VOLUME" identifier; that branch is taken here.
 		if p.peekNext().Type == kwTABLE {
-			return p.parseCreateExternalTableStmt(start, orReplace)
+			return p.parseCreateExternalTableStmt(start, orReplace, orAlter)
 		}
 		p.advance() // consume EXTERNAL
 		if p.curIsWord("VOLUME") {
 			p.advance() // consume VOLUME (a plain identifier; not a reserved keyword)
-			return p.parseCreateExternalVolumeStmt(start, orReplace)
+			return p.parseCreateExternalVolumeStmt(start, orReplace, orAlter)
 		}
 		if p.cur.Type != kwFUNCTION {
 			return p.unsupported("CREATE")
 		}
-		return p.parseCreateExternalFunctionStmt(start, orReplace, false)
+		return p.parseCreateExternalFunctionStmt(start, orReplace, orAlter, false)
 	case kwSTORAGE, kwAPI, kwNOTIFICATION, kwSECURITY, kwRESOURCE, kwSECRET, kwCONNECTION, kwGIT:
 		// CREATE [OR REPLACE] account-level integration objects (T4.7):
 		// { STORAGE | API | NOTIFICATION | SECURITY } INTEGRATION, RESOURCE MONITOR,
 		// SECRET, CONNECTION, GIT REPOSITORY. parseCreateIntegrationStmt consumes the
 		// object-type keyword(s).
-		return p.parseCreateIntegrationStmt(start, orReplace)
+		return p.parseCreateIntegrationStmt(start, orReplace, orAlter)
 	case kwTAG:
 		// CREATE [OR REPLACE] TAG ... (T4.9).
-		return p.parseCreateTagStmt(start, orReplace)
+		return p.parseCreateTagStmt(start, orReplace, orAlter)
 	case kwSEMANTIC:
 		// CREATE [OR REPLACE] SEMANTIC VIEW ... (T4.9). The sub-parser consumes
 		// SEMANTIC + VIEW.
-		return p.parseCreateSemanticViewStmt(start, orReplace)
+		return p.parseCreateSemanticViewStmt(start, orReplace, orAlter)
 	case kwDATASET:
 		// CREATE [OR REPLACE] DATASET ... (T4.9).
-		return p.parseCreateDatasetStmt(start, orReplace)
+		return p.parseCreateDatasetStmt(start, orReplace, orAlter)
 	case kwFAILOVER, kwREPLICATION:
 		// CREATE [OR REPLACE] { FAILOVER | REPLICATION } GROUP ... (T4.8).
 		// parseCreateReplicationGroupStmt consumes the kind keyword + GROUP.
-		return p.parseCreateReplicationGroupStmt(start, orReplace)
+		return p.parseCreateReplicationGroupStmt(start, orReplace, orAlter)
 	case kwACCOUNT, kwMANAGED:
 		// CREATE ACCOUNT / CREATE [OR REPLACE] MANAGED ACCOUNT ... (T4.8).
 		// parseCreateAccountStmt consumes the (MANAGED) ACCOUNT keyword(s).
-		return p.parseCreateAccountStmt(start, orReplace)
+		return p.parseCreateAccountStmt(start, orReplace, orAlter)
 	case kwSHARE:
 		// CREATE [OR REPLACE] SHARE ... (T4.8).
-		return p.parseCreateShareStmt(start, orReplace)
+		return p.parseCreateShareStmt(start, orReplace, orAlter)
 	case kwROLE:
 		// CREATE [OR REPLACE] ROLE ... (T4.6). DATABASE ROLE is dispatched by the
 		// kwDATABASE case above.
-		return p.parseCreateRoleStmt(start, orReplace, false)
+		return p.parseCreateRoleStmt(start, orReplace, orAlter, false)
 	case kwUSER:
 		// CREATE [OR REPLACE] USER ... (T4.6).
-		return p.parseCreateUserStmt(start, orReplace)
+		return p.parseCreateUserStmt(start, orReplace, orAlter)
 	case kwMASKING, kwSESSION, kwPASSWORD, kwNETWORK, kwROW:
 		// CREATE [OR REPLACE] { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK }
 		// POLICY ... (T4.6). parseCreatePolicyDispatch consumes the kind keyword(s)
 		// and the POLICY keyword, then delegates. A leading keyword not followed by
 		// the expected POLICY (or ACCESS POLICY, for ROW) is not a policy statement.
-		return p.parseCreatePolicyDispatch(start, orReplace)
+		return p.parseCreatePolicyDispatch(start, orReplace, orAlter)
 	default:
 		// AUTHENTICATION is not a reserved keyword, so CREATE AUTHENTICATION POLICY
 		// lexes as an "AUTHENTICATION" identifier followed by the POLICY keyword;
 		// that form is dispatched here (T4.6).
 		if p.curIsWord("AUTHENTICATION") && p.peekNext().Type == kwPOLICY {
-			return p.parseCreatePolicyDispatch(start, orReplace)
+			return p.parseCreatePolicyDispatch(start, orReplace, orAlter)
 		}
 		return p.unsupported("CREATE")
 	}
@@ -233,12 +242,12 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 //	PASSWORD POLICY           -> PolicyPassword
 //	NETWORK POLICY            -> PolicyNetwork
 //	AUTHENTICATION POLICY     -> PolicyAuthentication  (AUTHENTICATION is an identifier)
-func (p *Parser) parseCreatePolicyDispatch(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreatePolicyDispatch(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	kind, err := p.consumePolicyKeywords()
 	if err != nil {
 		return nil, err
 	}
-	return p.parseCreatePolicyStmt(start, orReplace, kind)
+	return p.parseCreatePolicyStmt(start, orReplace, orAlter, kind)
 }
 
 // ---------------------------------------------------------------------------
@@ -248,11 +257,12 @@ func (p *Parser) parseCreatePolicyDispatch(start ast.Loc, orReplace bool) (ast.N
 // parseCreateTableStmt parses the body of a CREATE [OR REPLACE] [...] TABLE
 // statement. The CREATE keyword and optional modifiers have already been
 // consumed; start is the Loc of the CREATE token.
-func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, transient, temporary, volatile bool) (ast.Node, error) {
+func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, orAlter, transient, temporary, volatile bool) (ast.Node, error) {
 	p.advance() // consume TABLE
 
 	stmt := &ast.CreateTableStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Transient: transient,
 		Temporary: temporary,
 		Volatile:  volatile,

--- a/snowflake/parser/create_table_test.go
+++ b/snowflake/parser/create_table_test.go
@@ -78,6 +78,51 @@ func TestCreateTable_OrReplace(t *testing.T) {
 	if !stmt.OrReplace {
 		t.Error("expected OrReplace=true")
 	}
+	if stmt.OrAlter {
+		t.Error("expected OrAlter=false for OR REPLACE")
+	}
+}
+
+func TestCreateTable_OrAlter(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE OR ALTER TABLE my_table (a INT PRIMARY KEY, c VARCHAR(200)) DEFAULT_DDL_COLLATION = 'de'")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false for OR ALTER")
+	}
+	if stmt.Name.Normalize() != "MY_TABLE" {
+		t.Errorf("name = %q, want %q", stmt.Name.Normalize(), "MY_TABLE")
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+}
+
+// CREATE OR FOO (OR followed by neither REPLACE nor ALTER) must be rejected.
+func TestCreateTable_OrUnknownRejected(t *testing.T) {
+	result := ParseBestEffort("CREATE OR FOO TABLE t (id INT)")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected a parse error for CREATE OR FOO, got none")
+	}
+}
+
+// OR ALTER and OR REPLACE are mutually exclusive; CREATE OR ALTER OR REPLACE
+// (and the reverse) must be rejected — only one OR-modifier is consumed and the
+// trailing one is not a valid object keyword.
+func TestCreateTable_OrAlterOrReplaceRejected(t *testing.T) {
+	for _, input := range []string{
+		"CREATE OR ALTER OR REPLACE TABLE t (id INT)",
+		"CREATE OR REPLACE OR ALTER TABLE t (id INT)",
+	} {
+		result := ParseBestEffort(input)
+		if len(result.Errors) == 0 {
+			t.Errorf("expected a parse error for %q, got none", input)
+		}
+	}
 }
 
 func TestCreateTable_Transient(t *testing.T) {

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -9,11 +9,12 @@ import "github.com/bytebase/omni/snowflake/ast"
 // parseCreateDatabaseStmt parses CREATE [OR REPLACE] [TRANSIENT] DATABASE ...
 // The CREATE keyword and optional OR REPLACE / TRANSIENT modifiers have already
 // been consumed by parseCreateStmt; start is the Loc of the CREATE token.
-func (p *Parser) parseCreateDatabaseStmt(start ast.Loc, orReplace, transient bool) (ast.Node, error) {
+func (p *Parser) parseCreateDatabaseStmt(start ast.Loc, orReplace, orAlter, transient bool) (ast.Node, error) {
 	p.advance() // consume DATABASE
 
 	stmt := &ast.CreateDatabaseStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Transient: transient,
 		Loc:       ast.Loc{Start: start.Start},
 	}
@@ -76,11 +77,12 @@ func (p *Parser) parseCreateDatabaseStmt(start ast.Loc, orReplace, transient boo
 // ---------------------------------------------------------------------------
 
 // parseCreateSchemaStmt parses CREATE [OR REPLACE] [TRANSIENT] SCHEMA ...
-func (p *Parser) parseCreateSchemaStmt(start ast.Loc, orReplace, transient bool) (ast.Node, error) {
+func (p *Parser) parseCreateSchemaStmt(start ast.Loc, orReplace, orAlter, transient bool) (ast.Node, error) {
 	p.advance() // consume SCHEMA
 
 	stmt := &ast.CreateSchemaStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Transient: transient,
 		Loc:       ast.Loc{Start: start.Start},
 	}

--- a/snowflake/parser/database_schema_test.go
+++ b/snowflake/parser/database_schema_test.go
@@ -118,6 +118,32 @@ func TestCreateDatabase_OrReplace(t *testing.T) {
 	}
 }
 
+func TestCreateDatabase_OrAlter(t *testing.T) {
+	stmt, errs := testParseCreateDatabase("CREATE OR ALTER DATABASE db1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
+func TestCreateSchema_OrAlter(t *testing.T) {
+	stmt, errs := testParseCreateSchema("CREATE OR ALTER SCHEMA s1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
 func TestCreateDatabase_Transient(t *testing.T) {
 	stmt, errs := testParseCreateDatabase("CREATE TRANSIENT DATABASE mydb")
 	if len(errs) > 0 {

--- a/snowflake/parser/dynamic_external_table.go
+++ b/snowflake/parser/dynamic_external_table.go
@@ -50,11 +50,12 @@ import (
 // transient records a preceding TRANSIENT, and cur is the DYNAMIC keyword. The
 // two-keyword `DYNAMIC TABLE` (with an optional ICEBERG between them) is consumed
 // here.
-func (p *Parser) parseCreateDynamicTableStmt(start ast.Loc, orReplace, transient bool) (ast.Node, error) {
+func (p *Parser) parseCreateDynamicTableStmt(start ast.Loc, orReplace, orAlter, transient bool) (ast.Node, error) {
 	p.advance() // consume DYNAMIC
 
 	stmt := &ast.CreateDynamicTableStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Transient: transient,
 		Loc:       ast.Loc{Start: start.Start},
 	}
@@ -486,7 +487,7 @@ func (p *Parser) parseAlterDynamicTableStmt() (ast.Node, error) {
 // INTEGRATION / COMMENT / ...) is captured open-ended, with PARTITION BY, the
 // column list / USING TEMPLATE, COPY GRANTS, and [WITH] TAG as the structural
 // anchors.
-func (p *Parser) parseCreateExternalTableStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateExternalTableStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume EXTERNAL
 	if _, err := p.expect(kwTABLE); err != nil {
 		return nil, err
@@ -494,6 +495,7 @@ func (p *Parser) parseCreateExternalTableStmt(start ast.Loc, orReplace bool) (as
 
 	stmt := &ast.CreateExternalTableStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -1003,7 +1005,7 @@ func (p *Parser) parsePartitionAssignments() ([]*ast.ExternalTablePartition, err
 // COPY GRANTS / [WITH] TAG are anchors; every other parameter
 // (DATA_RETENTION_TIME_IN_DAYS / MAX_DATA_EXTENSION_TIME_IN_DAYS / CHANGE_TRACKING
 // / DEFAULT_DDL_COLLATION / COMMENT / ...) is captured open-ended.
-func (p *Parser) parseCreateEventTableStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateEventTableStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume EVENT
 	if _, err := p.expect(kwTABLE); err != nil {
 		return nil, err
@@ -1011,6 +1013,7 @@ func (p *Parser) parseCreateEventTableStmt(start ast.Loc, orReplace bool) (ast.N
 
 	stmt := &ast.CreateEventTableStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/dynamic_external_table_test.go
+++ b/snowflake/parser/dynamic_external_table_test.go
@@ -82,6 +82,16 @@ func mustCreateEventTable(t *testing.T, input string) *ast.CreateEventTableStmt 
 // docs-only form), so each is implemented and flagged in the divergence ledger.
 // ---------------------------------------------------------------------------
 
+func TestParseCreateDynamicTable_OrAlter(t *testing.T) {
+	stmt := mustCreateDynamicTable(t, "CREATE OR ALTER DYNAMIC TABLE my_dynamic_table TARGET_LAG = DOWNSTREAM WAREHOUSE = mywh AS SELECT a, b FROM t")
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
 func TestParseCreateDynamicTable(t *testing.T) {
 	t.Run("minimal target_lag warehouse AS", func(t *testing.T) {
 		stmt := mustCreateDynamicTable(t, "CREATE OR REPLACE DYNAMIC TABLE dt TARGET_LAG = '20 minutes' WAREHOUSE = mywh AS SELECT a FROM t")

--- a/snowflake/parser/file_format.go
+++ b/snowflake/parser/file_format.go
@@ -45,13 +45,14 @@ import (
 // the CREATE token, and cur is the FILE_FORMAT keyword (or the FILE keyword of
 // the two-token spelling). temporary is set when any of TEMP / TEMPORARY /
 // VOLATILE preceded FILE FORMAT.
-func (p *Parser) parseCreateFileFormatStmt(start ast.Loc, orReplace, temporary bool) (ast.Node, error) {
+func (p *Parser) parseCreateFileFormatStmt(start ast.Loc, orReplace, orAlter, temporary bool) (ast.Node, error) {
 	if err := p.consumeFileFormatKeyword(); err != nil {
 		return nil, err
 	}
 
 	stmt := &ast.CreateFileFormatStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Temporary: temporary,
 		Loc:       ast.Loc{Start: start.Start},
 	}

--- a/snowflake/parser/file_format_test.go
+++ b/snowflake/parser/file_format_test.go
@@ -44,6 +44,16 @@ func mustAlterFileFormat(t *testing.T, input string) *ast.AlterFileFormatStmt {
 //	  [ formatTypeOptions ] [ COMMENT = '<string_literal>' ]
 // ---------------------------------------------------------------------------
 
+func TestParseCreateFileFormat_OrAlter(t *testing.T) {
+	stmt := mustCreateFileFormat(t, "CREATE OR ALTER FILE FORMAT my_csv_format TYPE = CSV FIELD_DELIMITER = '|'")
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
 func TestParseCreateFileFormat_Modifiers(t *testing.T) {
 	t.Run("minimal (no type)", func(t *testing.T) {
 		// TYPE is optional per the docs (defaults to CSV); the legacy ANTLR

--- a/snowflake/parser/function_procedure.go
+++ b/snowflake/parser/function_procedure.go
@@ -41,9 +41,9 @@ import "github.com/bytebase/omni/snowflake/ast"
 // FUNCTION ... . The CREATE keyword and the OR REPLACE / SECURE / TEMPORARY
 // modifiers have already been consumed by parseCreateStmt; start is the Loc of
 // the CREATE token and cur is the FUNCTION keyword.
-func (p *Parser) parseCreateFunctionStmt(start ast.Loc, orReplace, secure, temporary bool) (ast.Node, error) {
+func (p *Parser) parseCreateFunctionStmt(start ast.Loc, orReplace, orAlter, secure, temporary bool) (ast.Node, error) {
 	p.advance() // consume FUNCTION
-	return p.parseCreateRoutineBody(start, ast.RoutineFunction, orReplace, secure, temporary)
+	return p.parseCreateRoutineBody(start, ast.RoutineFunction, orReplace, orAlter, secure, temporary)
 }
 
 // parseCreateExternalFunctionStmt parses CREATE [OR REPLACE] [SECURE] EXTERNAL
@@ -55,18 +55,18 @@ func (p *Parser) parseCreateFunctionStmt(start ast.Loc, orReplace, secure, tempo
 // path (its API_INTEGRATION / HEADERS / CONTEXT_HEADERS / ... clauses are
 // captured open-ended like any other property, and its `AS '<url>'` body is the
 // single-quoted form).
-func (p *Parser) parseCreateExternalFunctionStmt(start ast.Loc, orReplace, secure bool) (ast.Node, error) {
+func (p *Parser) parseCreateExternalFunctionStmt(start ast.Loc, orReplace, orAlter, secure bool) (ast.Node, error) {
 	p.advance() // consume FUNCTION
-	return p.parseCreateRoutineBody(start, ast.RoutineExternalFunction, orReplace, secure, false)
+	return p.parseCreateRoutineBody(start, ast.RoutineExternalFunction, orReplace, orAlter, secure, false)
 }
 
 // parseCreateProcedureStmt parses CREATE [OR REPLACE] [SECURE] PROCEDURE ... .
 // The CREATE / OR REPLACE / SECURE modifiers have already been consumed by
 // parseCreateStmt; start is the Loc of the CREATE token and cur is the PROCEDURE
 // keyword.
-func (p *Parser) parseCreateProcedureStmt(start ast.Loc, orReplace, secure bool) (ast.Node, error) {
+func (p *Parser) parseCreateProcedureStmt(start ast.Loc, orReplace, orAlter, secure bool) (ast.Node, error) {
 	p.advance() // consume PROCEDURE
-	return p.parseCreateRoutineBody(start, ast.RoutineProcedure, orReplace, secure, false)
+	return p.parseCreateRoutineBody(start, ast.RoutineProcedure, orReplace, orAlter, secure, false)
 }
 
 // parseCreateRoutineBody parses the shared tail common to CREATE FUNCTION /
@@ -82,10 +82,11 @@ func (p *Parser) parseCreateProcedureStmt(start ast.Loc, orReplace, secure bool)
 // semantic, not syntactic, concern). The body is optional: the docs permit a
 // function defined entirely by its handler (no AS clause), in which case Body
 // stays "".
-func (p *Parser) parseCreateRoutineBody(start ast.Loc, kind ast.RoutineKind, orReplace, secure, temporary bool) (ast.Node, error) {
+func (p *Parser) parseCreateRoutineBody(start ast.Loc, kind ast.RoutineKind, orReplace, orAlter, secure, temporary bool) (ast.Node, error) {
 	stmt := &ast.CreateRoutineStmt{
 		Kind:      kind,
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Secure:    secure,
 		Temporary: temporary,
 		Loc:       ast.Loc{Start: start.Start},

--- a/snowflake/parser/function_procedure_test.go
+++ b/snowflake/parser/function_procedure_test.go
@@ -71,6 +71,24 @@ func assertParseError(t *testing.T, input string) {
 // ⭐ CANARY — body handling: single-line '…', MULTI-LINE '…', and $$…$$
 // ---------------------------------------------------------------------------
 
+func TestCreateRoutine_OrAlter(t *testing.T) {
+	// FUNCTION (T4.5) and PROCEDURE both flow through parseCreateRoutineBody;
+	// CREATE OR ALTER threads OrAlter to the shared CreateRoutineStmt node.
+	fn := mustCreateRoutine(t, "CREATE OR ALTER FUNCTION multiply(a NUMBER, b NUMBER) RETURNS NUMBER AS 'a * b'")
+	if !fn.OrAlter || fn.OrReplace || fn.Kind != ast.RoutineFunction {
+		t.Errorf("function: OrAlter=%v OrReplace=%v Kind=%v, want true/false/RoutineFunction", fn.OrAlter, fn.OrReplace, fn.Kind)
+	}
+	proc := mustCreateRoutine(t, "CREATE OR ALTER PROCEDURE p(a NUMBER) RETURNS NUMBER LANGUAGE SQL AS 'BEGIN RETURN a; END'")
+	if !proc.OrAlter || proc.OrReplace || proc.Kind != ast.RoutineProcedure {
+		t.Errorf("procedure: OrAlter=%v OrReplace=%v Kind=%v, want true/false/RoutineProcedure", proc.OrAlter, proc.OrReplace, proc.Kind)
+	}
+	// SECURE pairs with OR ALTER (early-dispatch path in parseCreateStmt).
+	secFn := mustCreateRoutine(t, "CREATE OR ALTER SECURE FUNCTION sf(a NUMBER) RETURNS NUMBER AS 'a'")
+	if !secFn.OrAlter || !secFn.Secure || secFn.OrReplace {
+		t.Errorf("secure function: OrAlter=%v Secure=%v OrReplace=%v, want true/true/false", secFn.OrAlter, secFn.Secure, secFn.OrReplace)
+	}
+}
+
 func TestRoutineBody_SingleLineSingleQuote(t *testing.T) {
 	stmt := mustCreateRoutine(t, "CREATE FUNCTION multiply1 (a number, b number) RETURNS number AS 'a * b'")
 	if stmt.Body != "'a * b'" {

--- a/snowflake/parser/integration.go
+++ b/snowflake/parser/integration.go
@@ -56,7 +56,7 @@ import (
 // RESOURCE / SECRET / CONNECTION / GIT). EXTERNAL VOLUME enters through
 // parseCreateExternalVolumeStmt instead (its dispatch already consumed EXTERNAL +
 // VOLUME).
-func (p *Parser) parseCreateIntegrationStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateIntegrationStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	kind, err := p.consumeIntegrationObjectKeyword()
 	if err != nil {
 		return nil, err
@@ -65,6 +65,7 @@ func (p *Parser) parseCreateIntegrationStmt(start ast.Loc, orReplace bool) (ast.
 	stmt := &ast.CreateIntegrationStmt{
 		Kind:      kind,
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -155,10 +156,11 @@ func (p *Parser) parseCreateIntegrationStmt(start ast.Loc, orReplace bool) (ast.
 // The CREATE / OR REPLACE / EXTERNAL / VOLUME tokens have already been consumed by
 // the dispatch in create_table.go; start is the Loc of the CREATE token. Every
 // parameter is open-ended; only STORAGE_LOCATIONS needs the list-of-groups reader.
-func (p *Parser) parseCreateExternalVolumeStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateExternalVolumeStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	stmt := &ast.CreateIntegrationStmt{
 		Kind:      ast.ExternalVolume,
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/pipe_stream_task.go
+++ b/snowflake/parser/pipe_stream_task.go
@@ -47,11 +47,12 @@ import (
 // the PIPE keyword. Every option before AS (AUTO_INGEST / ERROR_INTEGRATION /
 // AWS_SNS_TOPIC / INTEGRATION / COMMENT / …) is captured open-ended. AS is the
 // structural anchor; its body is a COPY INTO, optionally wrapped in parens.
-func (p *Parser) parseCreatePipeStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreatePipeStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume PIPE
 
 	stmt := &ast.CreatePipeStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -212,11 +213,12 @@ func (p *Parser) parseAlterPipeStmt() (ast.Node, error) {
 // keyword. Per the docs the [WITH] TAG clause precedes COPY GRANTS, which
 // precedes ON. The trailing config options (APPEND_ONLY / INSERT_ONLY /
 // SHOW_INITIAL_ROWS / COMMENT / …) are captured open-ended.
-func (p *Parser) parseCreateStreamStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateStreamStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume STREAM
 
 	stmt := &ast.CreateStreamStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -472,11 +474,12 @@ func (p *Parser) parseAlterStreamStmt() (ast.Node, error) {
 // session params / …) are captured open-ended, with AFTER / WHEN / AS as the
 // structural anchors. AS's body is captured by parseEmbeddedBody (reuses
 // parseStmt, with verbatim fallback for scripting / unsupported bodies).
-func (p *Parser) parseCreateTaskStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateTaskStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume TASK
 
 	stmt := &ast.CreateTaskStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -727,11 +730,12 @@ func (p *Parser) parseAlterTaskStmt() (ast.Node, error) {
 // serverless alerts and SCHEDULE's value grows — so all config is open-ended.
 // IF / THEN are the structural anchors. The condition reuses parseQueryExpr; the
 // action reuses parseEmbeddedBody (parseStmt + verbatim fallback).
-func (p *Parser) parseCreateAlertStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateAlertStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume ALERT
 
 	stmt := &ast.CreateAlertStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/pipe_stream_task_test.go
+++ b/snowflake/parser/pipe_stream_task_test.go
@@ -125,6 +125,16 @@ func optByName(opts []*ast.CopyOption, name string) *ast.CopyOption {
 //	  AS <copy_into_table>
 // ---------------------------------------------------------------------------
 
+func TestParseCreateTask_OrAlter(t *testing.T) {
+	stmt := mustCreateTask(t, "CREATE OR ALTER TASK my_task WAREHOUSE = my_warehouse SCHEDULE = '60 MINUTES' AS SELECT 1")
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
 func TestParseCreatePipe(t *testing.T) {
 	t.Run("minimal AS COPY", func(t *testing.T) {
 		stmt := mustCreatePipe(t, "CREATE PIPE mypipe AS COPY INTO mytable FROM @mystage FILE_FORMAT = (TYPE = 'JSON')")

--- a/snowflake/parser/replication_share.go
+++ b/snowflake/parser/replication_share.go
@@ -56,7 +56,7 @@ import (
 //	  [ [ WITH ] TAG (...) ]
 //	CREATE [ OR REPLACE ] { FAILOVER | REPLICATION } GROUP [ IF NOT EXISTS ] <name>
 //	  AS REPLICA OF <org>.<source_account>.<name>
-func (p *Parser) parseCreateReplicationGroupStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateReplicationGroupStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	failover := p.cur.Type == kwFAILOVER
 	p.advance() // consume FAILOVER / REPLICATION
 	if _, err := p.expect(kwGROUP); err != nil {
@@ -66,6 +66,7 @@ func (p *Parser) parseCreateReplicationGroupStmt(start ast.Loc, orReplace bool) 
 	stmt := &ast.CreateReplicationGroupStmt{
 		Failover:  failover,
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -358,7 +359,7 @@ func (p *Parser) parseAlterGroupUnset(stmt *ast.AlterReplicationGroupStmt) error
 //
 //	CREATE ACCOUNT <name> ADMIN_NAME = ... <space-separated params...>
 //	CREATE [ OR REPLACE ] MANAGED ACCOUNT <name> ADMIN_NAME = ..., <comma-separated params...>
-func (p *Parser) parseCreateAccountStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateAccountStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	managed := p.cur.Type == kwMANAGED
 	if managed {
 		p.advance() // consume MANAGED
@@ -370,6 +371,7 @@ func (p *Parser) parseCreateAccountStmt(start ast.Loc, orReplace bool) (ast.Node
 	stmt := &ast.CreateAccountStmt{
 		Managed:   managed,
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -654,11 +656,12 @@ func (p *Parser) parseAccountPolicyScope() (string, error) {
 //
 // The CREATE keyword and optional OR REPLACE modifier have already been consumed;
 // start is the Loc of the CREATE token, and cur is the SHARE keyword.
-func (p *Parser) parseCreateShareStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateShareStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume SHARE
 
 	stmt := &ast.CreateShareStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/role_user_policy.go
+++ b/snowflake/parser/role_user_policy.go
@@ -53,11 +53,12 @@ import (
 // `with_tags? comment_clause?` (TAG before COMMENT). Accepting either order (a)
 // follows the docs, (b) regresses neither, and (c) avoids silently dropping a
 // COMMENT that trails the TAG clause — matching the merged STAGE (T4.1) handling.
-func (p *Parser) parseCreateRoleStmt(start ast.Loc, orReplace, database bool) (ast.Node, error) {
+func (p *Parser) parseCreateRoleStmt(start ast.Loc, orReplace, orAlter, database bool) (ast.Node, error) {
 	p.advance() // consume ROLE
 
 	stmt := &ast.CreateRoleStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Database:  database,
 		Loc:       ast.Loc{Start: start.Start},
 	}
@@ -107,11 +108,12 @@ func (p *Parser) parseCreateRoleStmt(start ast.Loc, orReplace, database bool) (a
 //
 // Every property/parameter is an open-ended `KEY = value` pair (CopyOption).
 // The CREATE keyword and OR REPLACE have already been consumed; cur is USER.
-func (p *Parser) parseCreateUserStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateUserStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume USER
 
 	stmt := &ast.CreateUserStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -172,10 +174,11 @@ func (p *Parser) parseCreateUserStmt(start ast.Loc, orReplace bool) (ast.Node, e
 // SESSION / PASSWORD / NETWORK / AUTHENTICATION:
 //
 //	... [ IF NOT EXISTS ] <name> [ <option> ... ]
-func (p *Parser) parseCreatePolicyStmt(start ast.Loc, orReplace bool, kind ast.PolicyKind) (ast.Node, error) {
+func (p *Parser) parseCreatePolicyStmt(start ast.Loc, orReplace, orAlter bool, kind ast.PolicyKind) (ast.Node, error) {
 	stmt := &ast.CreatePolicyStmt{
 		Kind:      kind,
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/semantic_view.go
+++ b/snowflake/parser/semantic_view.go
@@ -50,11 +50,12 @@ import (
 // The CREATE keyword and the optional OR REPLACE modifier have already been
 // consumed by parseCreateStmt; start is the Loc of the CREATE token, and cur is
 // the TAG keyword.
-func (p *Parser) parseCreateTagStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateTagStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume TAG
 
 	stmt := &ast.CreateTagStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -252,7 +253,7 @@ func (p *Parser) parseAlterTagSet(stmt *ast.AlterTagStmt) error {
 //
 // The CREATE / OR REPLACE tokens have already been consumed by parseCreateStmt;
 // start is the Loc of the CREATE token, and cur is the SEMANTIC keyword.
-func (p *Parser) parseCreateSemanticViewStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateSemanticViewStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume SEMANTIC
 	if _, err := p.expect(kwVIEW); err != nil {
 		return nil, err
@@ -260,6 +261,7 @@ func (p *Parser) parseCreateSemanticViewStmt(start ast.Loc, orReplace bool) (ast
 
 	stmt := &ast.CreateSemanticViewStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -513,11 +515,12 @@ func (p *Parser) parseAlterSemanticViewStmt() (ast.Node, error) {
 // it *after* the object keyword. The post-keyword spelling is accepted here for
 // consistency with the rest of the engine; the docs' pre-keyword spelling is a
 // flagged divergence (likely a docs rendering quirk).
-func (p *Parser) parseCreateDatasetStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateDatasetStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume DATASET
 
 	stmt := &ast.CreateDatasetStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/semantic_view_test.go
+++ b/snowflake/parser/semantic_view_test.go
@@ -94,6 +94,16 @@ func assertFullLoc(t *testing.T, loc ast.Loc, input string) {
 //	  [COMMENT = '<string>']
 // ---------------------------------------------------------------------------
 
+func TestParseCreateTag_OrAlter(t *testing.T) {
+	stmt := mustCreateTag(t, "CREATE OR ALTER TAG cost_center ALLOWED_VALUES 'finance', 'engineering', 'sales'")
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
 func TestParseCreateTag_Modifiers(t *testing.T) {
 	t.Run("minimal", func(t *testing.T) {
 		stmt := mustCreateTag(t, "CREATE TAG cost_center")

--- a/snowflake/parser/sequence.go
+++ b/snowflake/parser/sequence.go
@@ -36,11 +36,12 @@ import "github.com/bytebase/omni/snowflake/ast"
 // SEQUENCE keyword. The leading [ WITH ] is an optional no-op connector; the
 // START / INCREMENT / ORDER|NOORDER / COMMENT clauses follow in that documented
 // order.
-func (p *Parser) parseCreateSequenceStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+func (p *Parser) parseCreateSequenceStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
 	p.advance() // consume SEQUENCE
 
 	stmt := &ast.CreateSequenceStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 

--- a/snowflake/parser/stage.go
+++ b/snowflake/parser/stage.go
@@ -40,11 +40,12 @@ import (
 // statement. The CREATE keyword and the optional OR REPLACE / TEMPORARY
 // modifiers have already been consumed by parseCreateStmt; start is the Loc of
 // the CREATE token, and cur is the STAGE keyword.
-func (p *Parser) parseCreateStageStmt(start ast.Loc, orReplace, temporary bool) (ast.Node, error) {
+func (p *Parser) parseCreateStageStmt(start ast.Loc, orReplace, orAlter, temporary bool) (ast.Node, error) {
 	p.advance() // consume STAGE
 
 	stmt := &ast.CreateStageStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Temporary: temporary,
 		Loc:       ast.Loc{Start: start.Start},
 	}

--- a/snowflake/parser/view.go
+++ b/snowflake/parser/view.go
@@ -10,11 +10,12 @@ import "github.com/bytebase/omni/snowflake/ast"
 // [RECURSIVE] VIEW statement. The CREATE keyword and OR REPLACE / SECURE /
 // RECURSIVE modifiers have already been consumed; start is the Loc of the
 // CREATE token.
-func (p *Parser) parseCreateViewStmt(start ast.Loc, orReplace, secure, recursive bool) (ast.Node, error) {
+func (p *Parser) parseCreateViewStmt(start ast.Loc, orReplace, orAlter, secure, recursive bool) (ast.Node, error) {
 	p.advance() // consume VIEW
 
 	stmt := &ast.CreateViewStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Secure:    secure,
 		Recursive: recursive,
 		Loc:       ast.Loc{Start: start.Start},
@@ -412,11 +413,12 @@ func (p *Parser) parseRowAccessPolicyClause() (*ast.RowAccessPolicy, error) {
 // [SECURE] MATERIALIZED VIEW statement. The CREATE keyword and OR REPLACE /
 // SECURE modifiers have already been consumed; MATERIALIZED has also been
 // consumed. start is the Loc of the CREATE token.
-func (p *Parser) parseCreateMaterializedViewStmt(start ast.Loc, orReplace, secure bool) (ast.Node, error) {
+func (p *Parser) parseCreateMaterializedViewStmt(start ast.Loc, orReplace, orAlter, secure bool) (ast.Node, error) {
 	p.advance() // consume VIEW
 
 	stmt := &ast.CreateMaterializedViewStmt{
 		OrReplace: orReplace,
+		OrAlter:   orAlter,
 		Secure:    secure,
 		Loc:       ast.Loc{Start: start.Start},
 	}

--- a/snowflake/parser/view_test.go
+++ b/snowflake/parser/view_test.go
@@ -91,6 +91,19 @@ func TestCreateView_OrReplace(t *testing.T) {
 	}
 }
 
+func TestCreateView_OrAlter(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE OR ALTER VIEW v2(one) AS SELECT a FROM my_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.OrAlter {
+		t.Error("expected OrAlter=true")
+	}
+	if stmt.OrReplace {
+		t.Error("expected OrReplace=false")
+	}
+}
+
 func TestCreateView_Secure(t *testing.T) {
 	stmt, errs := testParseCreateView("CREATE SECURE VIEW v AS SELECT 1")
 	if len(errs) > 0 {


### PR DESCRIPTION
## Node
`snowflake/parser-or-alter` (cross-cutting fix) — adds the **`CREATE OR ALTER`** prefix to the create-statement parser (Snowflake's docs-only modifier; alters in place vs. dropping like `OR REPLACE`).

## Design
`parseCreateStmt` now parses `OR { REPLACE | ALTER }` (mutually exclusive — `CREATE OR ALTER OR REPLACE` rejected, either ordering). An `OrAlter bool` is threaded alongside `OrReplace` through every create sub-parser and stored on each `Create*Stmt` AST node — mirroring exactly how `OrReplace`/transient/temporary already thread. Deparse emits `OR ALTER` for the DDL nodes it handles (table/database/schema/view), so the modifier survives parse→deparse→reparse distinctly from `OrReplace`. `nodetags.go`/`walk_generated.go` correctly untouched (scalar bool, no new node types).

## Coverage
`OrAlter` threaded to **all 26 `Create*Stmt` nodes** (TABLE/TASK/DYNAMIC-EVENT-EXTERNAL TABLE/TAG/FILE FORMAT/SCHEMA/DATABASE/VIEW/MV/FUNCTION/PROCEDURE/STAGE/SEQUENCE/PIPE/STREAM/ALERT/SEMANTIC VIEW/DATASET/INTEGRATION/SHARE/ACCOUNT/REPLICATION GROUP/ROLE/USER/POLICY). Oracle = official `create-or-alter` docs + the 21/24 previously-`orAlterLimited`-filtered corpus statements that now parse. 15 new tests + 4 deparse round-trips; negatives (`CREATE OR FOO`, `OR ALTER OR REPLACE`). Full `go test ./snowflake/...` + `go vet` + `gofmt` green. The other nodes' `orAlterLimited` filters are left in place (corpus-closure cleans up) and now emit a "now parses" note.

## Divergences (ledger 163-164)
- 163 confirmed — `CREATE OR ALTER` now accepted (was rejected). 
- 164 flagged — 2 OR-ALTER corpus statements still fail for **pre-existing object-body gaps unrelated to the prefix** (PROCEDURE `secrets=('name'=ident)`; VIEW `CHANGE_TRACKING=true`) — proven prefix-independent (fail identically with plain CREATE). Spun off as 2 follow-up tasks.

## Out-of-scope writes (recorded, required — threading is inherently cross-cutting)
`ast/parsenodes.go` (26 OrAlter fields), `deparse/deparse_ddl.go` (5 writers), and the create sub-parsers `database_schema.go`/`dynamic_external_table.go`/`file_format.go`/`function_procedure.go`/`integration.go`/`pipe_stream_task.go`/`replication_share.go`/`role_user_policy.go`/`semantic_view.go`/`sequence.go`/`stage.go`/`view.go` (each: `orAlter bool` param + `OrAlter:` literal).

## Review
Claude `/code-review` (high, inline; Codex down) — no blockers; cross-file tracer confirmed all 30+ threaded call sites updated (compiler + full suite verify). Surfaced (orthogonal, out of scope) a pre-existing `analysis.Classify` gap (no `*ast.CreateTaskStmt` case → CREATE TASK classifies Unknown). Orchestrator independently verified build / full `-timeout` suite / scope / gofmt.

## Note
Opened by orchestrator from verified commit `93a25430` (rebased onto current main). No code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)