### PR TITLE
feat(snowflake): M2 corpus-closure — full legacy+official corpus parse verification (576/657 clean, 81 documented gaps)

### DIFF
--- a/snowflake/parser/copy.go
+++ b/snowflake/parser/copy.go
@@ -661,12 +661,25 @@ func (p *Parser) parseCopyOptionParen(opt *ast.CopyOption) error {
 // INCLUDE_METADATA uses `key = METADATA$col` values, captured as a word value
 // (the lexer emits a single METADATA$col identifier).
 func (p *Parser) parseGroupEntry() (*ast.CopyOption, error) {
-	if !p.startsCopyOption() {
+	// A group entry key is normally a name word, but a few documented option
+	// groups key on a single-quoted string instead — e.g. CREATE PROCEDURE's
+	// SECRETS = ('secret_variable_name' = secret_name) (official create-procedure
+	// example_06). A string key reaches here only when the literal is followed by
+	// '=' (a string followed by ','/')' is a literal LIST, handled in
+	// parseCopyOptionParen before we are called), so accepting it does not
+	// reinterpret any list. The string's text is stored verbatim (not uppercased)
+	// since it is a literal name, not a keyword.
+	quotedKey := p.cur.Type == tokString
+	if !quotedKey && !p.startsCopyOption() {
 		return nil, p.syntaxErrorAtCur()
 	}
 	nameTok := p.advance()
+	name := strings.ToUpper(nameTok.Str)
+	if quotedKey {
+		name = nameTok.Str
+	}
 	entry := &ast.CopyOption{
-		Name: strings.ToUpper(nameTok.Str),
+		Name: name,
 		Loc:  ast.Loc{Start: nameTok.Loc.Start, End: nameTok.Loc.End},
 	}
 

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -1,0 +1,297 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestCorpusClosure (M2 — corpus-closure) is the whole-corpus parse-verification
+// gate for the Snowflake engine. It walks EVERY .sql file under
+// testdata/legacy/ (the legacy ANTLR lift) and testdata/official/ (the official
+// docs scrape, one directory per Snowflake command) and, for each file, splits
+// it with F3's Split and parses every segment with ParseBestEffort/parseSingle,
+// asserting ZERO parse errors for every owned, complete statement.
+//
+// Files that exercise a genuine residual grammar gap (a clause/object the engine
+// does not parse yet) or carry context-only / illustrative fragments are listed
+// in corpusSkips with a precise reason. The skip-list self-prunes: a skipped
+// file that starts parsing clean fails the test with a "REMOVE me" note, so the
+// list cannot silently rot as the grammar grows.
+//
+// Two files (create-function example_01 / example_03) carry a multi-line
+// single-quoted routine body. F3's Split mis-segments those because the omni
+// lexer's scanString cannot span a newline, so a ';' that follows a newline
+// inside the body looks like a statement terminator. They are NOT a parser gap —
+// the whole file parses clean when handed to parseSingle directly — so they are
+// driven whole-file (corpusWholeFile) instead of being skipped.
+//
+// Coverage snapshot at authoring time: 576/657 files parse clean
+// (574 via Split + 2 via whole-file), 81 files skipped (categorized below).
+func TestCorpusClosure(t *testing.T) {
+	files := collectCorpusFiles(t)
+	if len(files) != 657 {
+		t.Errorf("found %d corpus .sql files, expected 657 (27 legacy + 630 official) — corpus changed; re-baseline the skip-list", len(files))
+	}
+
+	var (
+		cleanSplit int // files that parse clean via Split + parseSingle
+		cleanWhole int // single-quoted-body files that parse clean whole-file
+		skipped    int // files matched by corpusSkips
+	)
+
+	for _, rel := range files {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata", rel))
+			if err != nil {
+				t.Fatalf("read %s: %v", rel, err)
+			}
+			src := string(data)
+
+			// Whole-file single-statement files: Split mis-segments the embedded
+			// single-quoted body, but the statement itself is valid and parses
+			// clean via parseSingle on the whole text.
+			if reason, ok := corpusWholeFile[rel]; ok {
+				text := strings.TrimRight(strings.TrimSpace(src), ";")
+				if _, errs := parseSingle(text, 0); len(errs) > 0 {
+					t.Errorf("whole-file %s (%s) produced %d error(s): %v", rel, reason, len(errs), errs)
+				}
+				cleanWhole++
+				return
+			}
+
+			// Skip-listed files: must STILL fail to parse, else the gap was
+			// closed and the entry should be removed.
+			if reason, ok := corpusSkips[rel]; ok {
+				skipped++
+				if corpusFileParsesClean(src) {
+					t.Errorf("SKIP-LIST STALE: %s now parses clean — REMOVE it from corpusSkips (was skipped for: %s)", rel, reason)
+				}
+				return
+			}
+
+			// The contract: every segment of every non-skipped file parses with
+			// zero errors.
+			for _, seg := range Split(src) {
+				if strings.TrimSpace(seg.Text) == "" {
+					continue
+				}
+				if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) > 0 {
+					text := strings.TrimSpace(seg.Text)
+					t.Errorf("statement produced %d error(s): %v\n  stmt: %s", len(errs), errs, text)
+				}
+			}
+			cleanSplit++
+		})
+	}
+
+	t.Logf("corpus closure: %d files total — %d clean (Split) + %d clean (whole-file) + %d skipped",
+		len(files), cleanSplit, cleanWhole, skipped)
+}
+
+// corpusFileParsesClean reports whether every non-empty Split segment of src
+// parses with zero errors. Used by the skip-list self-prune check so that the
+// "still fails" verdict is computed with the exact path the main assertion uses.
+func corpusFileParsesClean(src string) bool {
+	any := false
+	for _, seg := range Split(src) {
+		if strings.TrimSpace(seg.Text) == "" {
+			continue
+		}
+		any = true
+		if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) > 0 {
+			return false
+		}
+	}
+	return any
+}
+
+// collectCorpusFiles returns every .sql file under testdata/legacy and
+// testdata/official as a slice of paths RELATIVE to testdata/ (e.g.
+// "official/select/example_01.sql"), sorted for deterministic ordering.
+func collectCorpusFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, dir := range []string{"legacy", "official"} {
+		root := filepath.Join("testdata", dir)
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".sql") {
+				return nil
+			}
+			rel, rerr := filepath.Rel("testdata", path)
+			if rerr != nil {
+				return rerr
+			}
+			out = append(out, filepath.ToSlash(rel))
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// corpusWholeFile lists files that are a SINGLE valid statement whose multi-line
+// single-quoted body defeats F3's Split (a Split-layer limitation tracked as a
+// flagged divergence, not a parser gap). They are parsed whole-file via
+// parseSingle and must parse clean.
+var corpusWholeFile = map[string]string{
+	"official/create-function/example_01.sql": "single CREATE FUNCTION with a multi-line single-quoted Java body (embedded ';' defeats Split)",
+	"official/create-function/example_03.sql": "single CREATE FUNCTION with a multi-line single-quoted JavaScript body (embedded ';' defeats Split)",
+}
+
+// corpusSkips is the explicit, categorized skip-list. Each key is a corpus file
+// (relative to testdata/) that contains at least one statement the engine cannot
+// yet parse; the value is the reason. Skips fall into three buckets:
+//
+//   - RESIDUAL GAP — a real clause/object the grammar does not implement yet.
+//     These are mirrored as flagged divergences in the v2 migration store and
+//     are the to-do list for the remaining Snowflake grammar nodes.
+//   - DEPENDENCY GAP — the statement is owned by a built node but trips a shared
+//     sub-parser (expression / table-reference) that lacks a form. Closing the
+//     dependency clears the skip with no change to the owning node.
+//   - CONTEXT — the file's statements are entirely owned by an unbuilt node or
+//     are illustrative-only on a docs page whose primary command lives in sibling
+//     example files.
+//
+// Grouped by root cause. Counts in comments are at authoring time.
+var corpusSkips = map[string]string{
+	// --- RESIDUAL GAP: ALTER statement family (parser-alter node not built) ---
+	// The generic ALTER dispatcher returns "ALTER statement parsing is not yet
+	// supported"; ALTER SESSION / WAREHOUSE / DATABASE / ACCOUNT / ... are all
+	// pending. Some files are docs pages for a *built* command whose page also
+	// shows an ALTER follow-up as their only statement(s).
+	"legacy/alter.sql":                        "RESIDUAL GAP: ALTER {ACCOUNT,DATABASE,SESSION,SHARE,...} family — parser-alter node not built",
+	"official/alter-session/example_01.sql":   "RESIDUAL GAP: ALTER SESSION SET — parser-alter node not built",
+	"official/alter-session/example_02.sql":   "RESIDUAL GAP: ALTER SESSION UNSET — parser-alter node not built",
+	"official/alter-warehouse/example_01.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
+	"official/alter-warehouse/example_02.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
+	"official/alter-warehouse/example_03.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
+	"official/alter-warehouse/example_04.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
+	"official/alter-warehouse/example_05.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
+	"official/alter-warehouse/example_06.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
+	"official/create-database/example_08.sql": "CONTEXT: file is a lone ALTER SESSION SET (create-database page follow-up) — parser-alter not built",
+	"official/create-database/example_10.sql": "CONTEXT: file is a lone ALTER DATABASE/SESSION (create-database page follow-up) — parser-alter not built",
+	"official/create-database/example_11.sql": "CONTEXT: file is a lone ALTER DATABASE/SESSION (create-database page follow-up) — parser-alter not built",
+	"official/order-by/example_04.sql":        "RESIDUAL GAP: ALTER SESSION SET DEFAULT_NULL_ORDERING — parser-alter node not built",
+	"official/order-by/example_07.sql":        "RESIDUAL GAP: ALTER SESSION SET DEFAULT_NULL_ORDERING — parser-alter node not built",
+	"official/update/example_04.sql":          "RESIDUAL GAP: ALTER SESSION SET (update page setup) — parser-alter node not built",
+
+	// --- RESIDUAL GAP: ALTER TABLE ADD SEARCH OPTIMIZATION ON method-list ---
+	"official/alter-table-event-table/example_07.sql": "RESIDUAL GAP: ALTER TABLE ADD SEARCH OPTIMIZATION ON EQUALITY(c1), EQUALITY(c2,c3) — comma-separated method list not parsed",
+	"official/alter-table-event-table/example_08.sql": "RESIDUAL GAP: ALTER TABLE ADD/DROP SEARCH OPTIMIZATION ON comma-separated method list not parsed",
+	"official/alter-table-event-table/example_09.sql": "RESIDUAL GAP: ALTER TABLE DROP SEARCH OPTIMIZATION ON comma-separated method list not parsed",
+
+	// --- RESIDUAL GAP: ALTER VIEW with a re-defined query body ---
+	"official/alter-view/example_11.sql": "RESIDUAL GAP: ALTER VIEW ... AS <join query> body redefinition not parsed",
+
+	// --- RESIDUAL GAP: CREATE WAREHOUSE (object node not built) ---
+	"official/create-warehouse/example_01.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
+	"official/create-warehouse/example_02.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
+	"official/create-warehouse/example_03.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
+	"official/create-warehouse/example_04.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
+	"official/create-warehouse/example_05.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
+	"official/create-warehouse/example_06.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
+	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: CREATE OR ALTER WAREHOUSE + SHOW ->> SELECT FROM $1 — object node not built; also the $N table-ref gap",
+
+	// --- RESIDUAL GAP: CREATE HYBRID TABLE (object node not built) ---
+	"official/create-hybrid-table/example_01.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/create-hybrid-table/example_07.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/create-hybrid-table/example_08.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/create-hybrid-table/example_13.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/create-hybrid-table/example_14.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/create-hybrid-table/example_15.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/create-hybrid-table/example_16.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
+	"official/drop-table/example_05.sql":          "CONTEXT: setup is CREATE OR REPLACE HYBRID TABLE (drop-table page) — hybrid-table object node not built",
+
+	// --- RESIDUAL GAP: CREATE NETWORK RULE (object node not built; NETWORK POLICY is) ---
+	"official/create-network-rule/example_01.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built (NETWORK POLICY is)",
+	"official/create-network-rule/example_02.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
+	"official/create-network-rule/example_03.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
+	"official/create-network-rule/example_04.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
+	"official/create-network-rule/example_05.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
+
+	// --- RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW + ALTER WAREHOUSE ---
+	"official/create-materialized-view/example_02.sql": "RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (INTERACTIVE keyword) + ALTER WAREHOUSE ADD TABLES",
+
+	// --- RESIDUAL GAP: CREATE statement variants in the legacy create.sql ---
+	"legacy/create.sql": "RESIDUAL GAP: CREATE {ACCOUNT,API INTEGRATION,FAILOVER GROUP,MANAGED ACCOUNT,WAREHOUSE,...} object variants not all built",
+
+	// --- RESIDUAL GAP: CREATE/ALTER/DROP ALERT (object node not built) ---
+	"legacy/alerts.sql": "RESIDUAL GAP: CREATE/ALTER/DROP ALERT — alert object node not built",
+
+	// --- RESIDUAL GAP: DROP object variants (parser-drop covers only some objects) ---
+	"legacy/drop.sql": "RESIDUAL GAP: DROP {CONNECTION,FAILOVER GROUP,INTEGRATION,MASKING POLICY,NETWORK POLICY,REPLICATION GROUP,RESOURCE MONITOR,ROW ACCESS POLICY,SESSION POLICY,SHARE,USER,...} not all built",
+
+	// --- RESIDUAL GAP: dynamic-table clauses (named-arg => and INTERVAL/refresh-mode) ---
+	"official/create-dynamic-table/example_04.sql": "RESIDUAL GAP: CLONE ... AT (TIMESTAMP => TO_TIMESTAMP_TZ(...)) named-arg => in time-travel clause",
+	"official/create-dynamic-table/example_07.sql": "RESIDUAL GAP: IMMUTABLE WHERE (... - INTERVAL '1 day') refresh-mode + interval literal not parsed",
+
+	// --- RESIDUAL GAP: named function arguments  name => value  (expr/func-call) ---
+	"official/copy-into-table/example_06.sql":       "RESIDUAL GAP: TABLE(DATA_SOURCE(TYPE => 'STREAMING')) named-arg => in function call",
+	"official/create-external-table/example_09.sql": "RESIDUAL GAP: INFER_SCHEMA(LOCATION=>'...', FILE_FORMAT=>'...') named-arg => in function call",
+	"official/create-external-table/example_10.sql": "RESIDUAL GAP: INFER_SCHEMA(...) named-arg => in function call",
+	"official/create-pipe/example_08.sql":           "RESIDUAL GAP: TABLE(DATA_SOURCE(TYPE => 'STREAMING')) named-arg => in function call",
+	"official/create-pipe/example_09.sql":           "RESIDUAL GAP: named-arg => in function call (pipe streaming source)",
+	"official/create-pipe/example_10.sql":           "RESIDUAL GAP: named-arg => in function call (pipe streaming source)",
+	"official/join-lateral/example_05.sql":          "RESIDUAL GAP: LATERAL FLATTEN(INPUT => ..., PATH => ...) named-arg => in function call",
+	"official/truncate-table/example_02.sql":        "RESIDUAL GAP: table(generator(rowcount=>20)) named-arg => in function call",
+
+	// --- DEPENDENCY GAP: $N / $N:path result-set ref + stage path as a table ref (T5) ---
+	"official/create-external-table/example_01.sql":  "DEPENDENCY GAP: SELECT metadata$filename FROM @s1/ — stage-path table ref + metadata$col not parsed",
+	"official/create-external-volume/example_05.sql": "DEPENDENCY GAP: SHOW ... ->> SELECT * FROM $1 — $N result-set table ref (T5) not parsed",
+	"official/create-table/example_06.sql":           "DEPENDENCY GAP: CTAS AS SELECT $1:o_custkey::number FROM @my_stage — $N:path semi-structured + stage table ref",
+	"official/show-tables/example_07.sql":            "DEPENDENCY GAP: SHOW ... ->> SELECT * FROM $1 — $N result-set table ref (T5) not parsed",
+	"official/show-tables/example_08.sql":            "DEPENDENCY GAP: SHOW ... ->> SELECT ... FROM $1 — $N result-set table ref (T5) not parsed",
+	"official/show-tables/example_09.sql":            "DEPENDENCY GAP: SHOW ... ->> SELECT ... FROM $1 — $N result-set table ref (T5) not parsed",
+
+	// --- RESIDUAL GAP: VALUES as a table source  FROM (VALUES (...), ...) ---
+	"official/values/example_01.sql": "RESIDUAL GAP: SELECT * FROM (VALUES (...), ...) — VALUES table source not parsed",
+	"official/values/example_02.sql": "RESIDUAL GAP: FROM (VALUES ...) with positional $N column refs — VALUES table source not parsed",
+	"official/values/example_03.sql": "RESIDUAL GAP: FROM (VALUES ...) AS v(...) join — VALUES table source not parsed",
+	"official/values/example_04.sql": "RESIDUAL GAP: FROM (VALUES ...) AS v(c1, c2) — VALUES table source + derived column list not parsed",
+
+	// --- RESIDUAL GAP: ORDER BY ALL ---
+	"official/order-by/example_01.sql": "RESIDUAL GAP: ORDER BY ALL not parsed",
+	"official/order-by/example_11.sql": "RESIDUAL GAP: ORDER BY ALL not parsed",
+	"official/order-by/example_12.sql": "RESIDUAL GAP: ORDER BY ALL ASC not parsed",
+	"official/order-by/example_13.sql": "RESIDUAL GAP: ORDER BY ALL not parsed (also ALTER SESSION)",
+	"official/order-by/example_14.sql": "RESIDUAL GAP: ORDER BY ALL NULLS FIRST not parsed",
+	"official/order-by/example_15.sql": "RESIDUAL GAP: ORDER BY ALL NULLS LAST not parsed",
+	"official/merge/example_09.sql":    "RESIDUAL GAP: WHEN MATCHED ... DELETE / ORDER BY ALL form not parsed",
+
+	// --- RESIDUAL GAP: SELECT * EXCLUDE / RENAME column transforms ---
+	"official/select/example_07.sql": "RESIDUAL GAP: SELECT * EXCLUDE col not parsed",
+	"official/select/example_11.sql": "RESIDUAL GAP: SELECT * EXCLUDE col RENAME (...) not parsed",
+	"official/select/example_16.sql": "RESIDUAL GAP: SELECT tbl.* EXCLUDE / RENAME column transforms not parsed",
+
+	// --- RESIDUAL GAP: trailing comma in SELECT list ---
+	"official/select/example_24.sql": "RESIDUAL GAP: trailing comma before FROM in SELECT list (Snowflake permits it) not parsed",
+
+	// --- RESIDUAL GAP: (+) Oracle-style outer-join operator ---
+	"official/where/example_09.sql": "RESIDUAL GAP: WHERE t1.c1 = t2.c2(+) Oracle-style outer join operator not parsed",
+	"official/where/example_10.sql": "RESIDUAL GAP: WHERE ... (+) Oracle-style outer join operator not parsed",
+
+	// --- RESIDUAL GAP: Snowflake Scripting blocks (DECLARE..BEGIN..END, CALL ... INTO) ---
+	"official/execute-immediate/example_01.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
+	"official/execute-immediate/example_04.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
+	"official/call/example_07.sql":              "RESIDUAL GAP: DECLARE ... BEGIN CALL p(...) INTO :var ... END scripting block not parsed",
+
+	// --- RESIDUAL GAP: parenthesized view body with leading WITH (CTE) ---
+	"official/create-view/example_05.sql": "RESIDUAL GAP: CREATE VIEW ... AS ( WITH ... SELECT ... ) — parenthesized CTE view body not parsed",
+
+	// --- RESIDUAL GAP / MALFORMED: legacy select.sql expression corpus ---
+	// LEFT(...)/ILIKE(...) used as function names, lowercase `union` inside a
+	// derived-table subquery, and to_date(SELECT ...) (a scalar subquery written
+	// without parentheses — a legacy-corpus malformation). Mixed residual-gap and
+	// docs-typo; tracked as one entry.
+	"legacy/select.sql": "RESIDUAL GAP/MALFORMED: LEFT()/ILIKE() as function names, lowercase `union` in derived table, and to_date(SELECT...) (unparenthesized scalar subquery, a legacy malformation)",
+}

--- a/snowflake/parser/function_procedure_test.go
+++ b/snowflake/parser/function_procedure_test.go
@@ -471,6 +471,50 @@ func TestCreateProcedure(t *testing.T) {
 			t.Errorf("Kind/Body = %v/%q", stmt.Kind, stmt.Body)
 		}
 	})
+	t.Run("secrets quoted-key group", func(t *testing.T) {
+		// SECRETS = ('secret_variable_name' = secret_name [, ...]) — a group whose
+		// entry KEY is a quoted string (official create-procedure example_06). Each
+		// entry binds a string-name to a secret identifier.
+		stmt := mustCreateRoutine(t, "CREATE OR ALTER PROCEDURE python_add1(A NUMBER) RETURNS NUMBER LANGUAGE PYTHON HANDLER='main' RUNTIME_VERSION=3.10 EXTERNAL_ACCESS_INTEGRATIONS=(example_integration) secrets=('secret_variable_name'=secret_name) PACKAGES = ('snowflake-snowpark-python') EXECUTE AS CALLER AS $$ x $$")
+		var secrets *ast.CopyOption
+		for _, o := range stmt.Options {
+			if o.Name == "SECRETS" {
+				secrets = o
+			}
+		}
+		if secrets == nil {
+			t.Fatalf("SECRETS option not captured; got %v", optNames(stmt.Options))
+		}
+		if len(secrets.Group) != 1 {
+			t.Fatalf("SECRETS group len = %d, want 1", len(secrets.Group))
+		}
+		if got := secrets.Group[0].Name; got != "secret_variable_name" {
+			t.Errorf("SECRETS entry key = %q, want %q", got, "secret_variable_name")
+		}
+	})
+	t.Run("secrets multi quoted-key", func(t *testing.T) {
+		stmt := mustCreateRoutine(t, "CREATE PROCEDURE p() RETURNS NUMBER LANGUAGE PYTHON HANDLER='main' RUNTIME_VERSION=3.10 SECRETS=('a'=s1,'b'=s2) PACKAGES=('x') AS $$ y $$")
+		var secrets *ast.CopyOption
+		for _, o := range stmt.Options {
+			if o.Name == "SECRETS" {
+				secrets = o
+			}
+		}
+		if secrets == nil || len(secrets.Group) != 2 {
+			t.Fatalf("SECRETS group = %#v, want 2 entries", secrets)
+		}
+		if secrets.Group[0].Name != "a" || secrets.Group[1].Name != "b" {
+			t.Errorf("SECRETS keys = %q/%q, want a/b", secrets.Group[0].Name, secrets.Group[1].Name)
+		}
+	})
+}
+
+func optNames(opts []*ast.CopyOption) []string {
+	names := make([]string, 0, len(opts))
+	for _, o := range opts {
+		names = append(names, o.Name)
+	}
+	return names
 }
 
 // ---------------------------------------------------------------------------
@@ -694,9 +738,9 @@ func TestRoutine_LegacyCorpus(t *testing.T) {
 // assertRoutineFileParses treats a single-statement corpus file as ONE
 // statement: it strips a trailing ';' and parses the whole text via parseSingle
 // (bypassing F3's Split, which mis-segments multi-line single-quoted bodies). It
-// asserts the statement parses with no errors and to a routine node, unless it is
-// owned by another DAG node (CREATE OR ALTER → parser-or-alter; SELECT →
-// select-core), which is skipped with a logged note.
+// asserts the statement parses with no errors and to a routine node. CREATE OR
+// ALTER FUNCTION/PROCEDURE is a routine and is asserted; a non-routine statement
+// owned by another DAG node (e.g. a SELECT) is skipped via routineStmtKind.
 func assertRoutineFileParses(t *testing.T, sql string) {
 	t.Helper()
 	text := strings.TrimRight(strings.TrimSpace(sql), ";")
@@ -705,15 +749,6 @@ func assertRoutineFileParses(t *testing.T, sql string) {
 		return
 	}
 	upper := strings.ToUpper(text)
-
-	if routineOrAlterLimited(upper) {
-		// CREATE OR ALTER is owned by the parser-or-alter node. If it starts
-		// parsing here, surface that so the filter can be removed.
-		if _, errs := parseSingle(text, 0); len(errs) == 0 {
-			t.Logf("note: CREATE OR ALTER now parses, drop it from routineOrAlterLimited: %q", text)
-		}
-		return
-	}
 
 	kind, want := routineStmtKind(upper)
 	if kind == "" {
@@ -730,14 +765,6 @@ func assertRoutineFileParses(t *testing.T, sql string) {
 	}
 }
 
-// routineOrAlterLimited reports whether a statement uses the CREATE OR ALTER form
-// (owned by the separate parser-or-alter DAG node). Those are skipped with a
-// logged note + a flagged divergence, mirroring the copy / file-format / pipeline
-// corpus harnesses' skip-with-note pattern.
-func routineOrAlterLimited(upper string) bool {
-	return strings.HasPrefix(upper, "CREATE OR ALTER ")
-}
-
 // assertRoutineStatementsParse parses sql via Split + parseSingle and asserts
 // that every CREATE FUNCTION / EXTERNAL FUNCTION / PROCEDURE and ALTER FUNCTION /
 // PROCEDURE statement parses with no errors and to the expected AST type.
@@ -751,13 +778,6 @@ func assertRoutineStatementsParse(t *testing.T, sql string) {
 			continue
 		}
 		upper := strings.ToUpper(text)
-
-		if routineOrAlterLimited(upper) {
-			if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
-				t.Logf("note: CREATE OR ALTER now parses, drop it from routineOrAlterLimited: %q", text)
-			}
-			continue
-		}
 
 		kind, want := routineStmtKind(upper)
 		if kind == "" {
@@ -797,7 +817,7 @@ func routineHasCreatePrefix(upper string) bool {
 		return false
 	}
 	rest := strings.TrimPrefix(upper, "CREATE ")
-	for _, mod := range []string{"OR REPLACE ", "SECURE ", "TEMPORARY ", "TEMP ", "EXTERNAL "} {
+	for _, mod := range []string{"OR REPLACE ", "OR ALTER ", "SECURE ", "TEMPORARY ", "TEMP ", "EXTERNAL "} {
 		rest = strings.TrimPrefix(rest, mod)
 	}
 	return strings.HasPrefix(rest, "FUNCTION ") || strings.HasPrefix(rest, "FUNCTION(") ||

--- a/snowflake/parser/show_test.go
+++ b/snowflake/parser/show_test.go
@@ -564,19 +564,18 @@ func TestUtility_LegacyCorpus(t *testing.T) {
 }
 
 // utilityDollarLimited matches the corpus statements that are owned by this node
-// but cannot yet parse because the shared expression / table-reference parser
-// (T3/T5) does not implement the $N result-set reference or $var session-variable
-// reference. They are excluded from the zero-error corpus assertion and tracked
-// as a flagged divergence; their root cause is the dependency, not this node's
-// grammar. When the expression/table-ref parser gains $-support, these will
-// parse with no change to this node.
+// but cannot yet parse because the shared table-reference parser (T5) does not
+// implement the $N result-set reference (FROM $1). They are excluded from the
+// zero-error corpus assertion and tracked as a flagged divergence; their root
+// cause is the dependency, not this node's grammar. When the table-ref parser
+// gains $-support, these will parse with no change to this node.
+//
+// NOTE: the expression-position $var case (SET (min, max) = (50, 2 * $min),
+// set/example_06) used to live here but now parses since the expression parser
+// gained $-support — it has been removed from this filter.
 func utilityDollarLimited(upper string) bool {
 	// SHOW ... ->> SELECT ... FROM $1 ...   (show-tables/example_07..09)
 	if strings.Contains(upper, "->>") && strings.Contains(upper, "$1") {
-		return true
-	}
-	// SET (min, max) = (50, 2 * $min)       (set/example_06)
-	if strings.HasPrefix(upper, "SET") && strings.Contains(upper, "$") {
 		return true
 	}
 	return false

--- a/snowflake/parser/view.go
+++ b/snowflake/parser/view.go
@@ -352,6 +352,20 @@ func (p *Parser) parseViewProperties(stmt interface{}) error {
 				v.Comment = &s
 			}
 
+		case kwCHANGE_TRACKING:
+			// CHANGE_TRACKING [=] { TRUE | FALSE } — consume and discard, mirroring
+			// the CREATE TABLE handling in create_table.go. Documented for CREATE
+			// VIEW (official create-view example_11 / example_13).
+			p.advance() // consume CHANGE_TRACKING
+			if p.cur.Type == '=' {
+				p.advance() // consume optional '='
+			}
+			if p.cur.Type == kwTRUE || p.cur.Type == kwFALSE {
+				p.advance()
+			} else {
+				return p.syntaxErrorAtCur()
+			}
+
 		default:
 			return nil
 		}

--- a/snowflake/parser/view_test.go
+++ b/snowflake/parser/view_test.go
@@ -114,6 +114,32 @@ func TestCreateView_Secure(t *testing.T) {
 	}
 }
 
+// TestCreateView_ChangeTracking covers the CHANGE_TRACKING = { TRUE | FALSE }
+// view property (official create-view example_11 and example_13). It is consumed
+// and discarded, mirroring the CREATE TABLE handling in create_table.go.
+func TestCreateView_ChangeTracking(t *testing.T) {
+	cases := []string{
+		// example_11: COMMENT then CHANGE_TRACKING, column list.
+		"CREATE OR ALTER VIEW v2(one) COMMENT='fff' CHANGE_TRACKING=true AS SELECT a FROM my_table",
+		// example_13: per-column COMMENT then CHANGE_TRACKING.
+		"CREATE OR ALTER VIEW v2(one COMMENT 'bar') CHANGE_TRACKING=true AS SELECT a FROM my_table",
+		// FALSE and spaced '=' variants.
+		"CREATE VIEW v CHANGE_TRACKING = FALSE AS SELECT 1",
+		"CREATE VIEW v CHANGE_TRACKING TRUE AS SELECT 1",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			stmt, errs := testParseCreateView(in)
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if stmt == nil || stmt.Query == nil {
+				t.Fatalf("expected a CreateViewStmt with a query body, got %#v", stmt)
+			}
+		})
+	}
+}
+
 func TestCreateView_Recursive(t *testing.T) {
 	stmt, errs := testParseCreateView("CREATE RECURSIVE VIEW v AS SELECT 1")
 	if len(errs) > 0 {


### PR DESCRIPTION
## Node
`snowflake/corpus-closure` (**M2**) — comprehensive corpus parse-verification.

## Deliverable
`TestCorpusClosure` (`snowflake/parser/corpus_closure_test.go`) walks every `.sql` under `testdata/{legacy(27),official(630)}` = **657 files**, splits each (F3 `Split`) and parses every segment, asserting zero parse errors for owned complete statements. Maintains an explicit, categorized, **self-pruning** skip-list (a skipped file that starts parsing clean fails the test with a "REMOVE me" note).

## Result: **576 / 657 parse clean (87.7%)**, 81 skipped — exact accounting (0 stale, 0 unaccounted)
Fixed 2 residual gaps (TDD-tested) + removed 2 now-stale `$N`/`OR-ALTER` per-node filters (skips → positive coverage). Full `go test ./snowflake/...` + `go vet` + `gofmt` green.

### The 81 skips = genuine grammar not yet built (the documented residual tail, NOT in the v1 DAG)
ALTER family (15) · CREATE WAREHOUSE (7) · CREATE HYBRID TABLE (8) · named-arg `f(x => 1)` (9) · `$N`/stage-path table-ref (6) · ORDER BY ALL (7) · VALUES table-source (4) · CREATE NETWORK RULE (5) · SELECT `*` EXCLUDE/RENAME (3) · Scripting `DECLARE..BEGIN`/`CALL..INTO` (3) · ALTER TABLE SEARCH OPTIMIZATION method-list (3) · `(+)` outer-join (2) · legacy object variants (4) · single-file gaps (ALTER VIEW body, paren-WITH view, trailing comma, INTERACTIVE MV, dynamic-table INTERVAL, legacy expr).

## Fixes (out-of-scope, recorded)
- `view.go` — `CHANGE_TRACKING [=] {TRUE|FALSE}` consume-and-discard (closes create-view example_11/13).
- `copy.go` — `parseGroupEntry` accepts a single-quoted group-entry key (only when followed by `=`; list-vs-group routing provably unchanged — closes procedure `SECRETS=('name'=secret)`).
- Tests: `view_test.go`, `function_procedure_test.go` (+ `OR ALTER` routine prefix now positively asserted), `show_test.go` (dropped stale `SET ($var)` filter; `FROM $1` remains a real gap).

## Divergences (ledger; 2 confirmed fixes + 23 flagged residual gaps)
The 23 flagged = the remaining Snowflake grammar to-do surfaced by the full corpus + the F3 single-quoted-body Split limitation + one flagged over-permissiveness (CHANGE_TRACKING also accepted on MV via the shared `parseViewProperties`).

## Review
Claude `/code-review` (high, inline; Codex down) — no blockers; verified list-vs-group routing intact, CREATE OR ALTER routines parse, full module green. Orchestrator independently verified build / full `-timeout` suite / scope / gofmt.

## Note
Opened by orchestrator from verified commit `37936e09`. No code modified. The 81-gap categorized skip-list is the input to deciding the `bytebase-switch` (M1) scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)