### PR TITLE
feat(tidb/parser): parenthesized-query derived tables (FROM) via backtracking

### DIFF
--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -3266,3 +3266,14 @@ func TestAnalyze_CTEVisibilityDoesNotLeakCorrelation(t *testing.T) {
 		t.Errorf("expected error: CTE visibility must not bring column correlation to sibling t1.a")
 	}
 }
+
+// TestAnalyze_ParenFromDerivedSetOp confirms the new PR2 FROM shape (a derived
+// table whose body is a parenthesized set-op) analyzes end-to-end: an
+// RTESubquery over the set-op body. #238 made the analyzer ParenSource-aware, so
+// no analyzer change is expected — this guards that assumption.
+func TestAnalyze_ParenFromDerivedSetOp(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "SELECT x FROM ((SELECT 1 AS x) UNION (SELECT 2)) s")
+	_, err := c.AnalyzeSelectStmt(sel)
+	assertNoError(t, err)
+}

--- a/tidb/deparse/deparse_test.go
+++ b/tidb/deparse/deparse_test.go
@@ -999,6 +999,29 @@ func TestDeparseSelect_ParenthesizedQuery(t *testing.T) {
 	}
 }
 
+// TestDeparseSelect_ParenFromDerived guards the PR2 shape: a derived table whose
+// body is a parenthesized set-op query expression must deparse back to the same
+// structure (the SubqueryExpr wrapper + the ParenSource body both survive).
+func TestDeparseSelect_ParenFromDerived(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"setop_body", "SELECT 1 FROM ((SELECT 1) UNION (SELECT 2)) x", "select 1 AS `1` from ((select 1 AS `1`) union (select 2 AS `2`)) `x`"},
+		{"nested_body", "SELECT 1 FROM ((SELECT 1)) x", "select 1 AS `1` from ((select 1 AS `1`)) `x`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := parseSelect(t, tc.input)
+			got := DeparseSelect(sel)
+			if got != tc.expected {
+				t.Errorf("DeparseSelect(%q) =\n  %q\nwant:\n  %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestDeparseSelect_Section_5_2_FromClause(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/tidb/parser/backtrack.go
+++ b/tidb/parser/backtrack.go
@@ -1,0 +1,45 @@
+package parser
+
+// tokenStreamState captures every parser+lexer field that mutates while
+// consuming tokens, so a speculative scan can be fully rewound.
+//
+// `input` is captured because the lexer rewrites it in place when expanding
+// MySQL conditional comments (lexer.go: `l.input = l.input[:l.pos] + ...`).
+// The classifier always snapshots before any splice it triggers, so position
+// alone would suffice (the splice preserves the prefix `l.input[:l.pos]`); we
+// capture `input` anyway — O(1), Go strings are immutable — as defensive
+// insurance so the primitive is correct for any caller, not just a forward
+// scan.
+//
+// Completion state (candidates/collecting) is intentionally NOT captured: the
+// classifier scan is a pure advance() loop, and advance()/peekNext() never
+// collect candidates (collection lives only in grammar-rule functions, which
+// the scan does not call).
+type tokenStreamState struct {
+	cur, prev, nextBuf Token
+	hasNext            bool
+	input              string
+	pos, start         int
+	prevToken          int
+	prevTokenEnd       int
+}
+
+// snapshotTokenStream captures the current token-stream position for later
+// restoration via restoreTokenStream.
+func (p *Parser) snapshotTokenStream() tokenStreamState {
+	return tokenStreamState{
+		cur: p.cur, prev: p.prev, nextBuf: p.nextBuf, hasNext: p.hasNext,
+		input: p.lexer.input, pos: p.lexer.pos, start: p.lexer.start,
+		prevToken: p.lexer.prevToken, prevTokenEnd: p.lexer.prevTokenEnd,
+	}
+}
+
+// restoreTokenStream rewinds parser+lexer state to a previously captured
+// snapshot. After restore, the next advance() emits the same token it would
+// have at the moment snapshotTokenStream() was called.
+func (p *Parser) restoreTokenStream(s tokenStreamState) {
+	p.cur, p.prev, p.nextBuf, p.hasNext = s.cur, s.prev, s.nextBuf, s.hasNext
+	p.lexer.input = s.input
+	p.lexer.pos, p.lexer.start = s.pos, s.start
+	p.lexer.prevToken, p.lexer.prevTokenEnd = s.prevToken, s.prevTokenEnd
+}

--- a/tidb/parser/backtrack_test.go
+++ b/tidb/parser/backtrack_test.go
@@ -1,0 +1,45 @@
+package parser
+
+import "testing"
+
+func collectToEOF(p *Parser) []Token {
+	var toks []Token
+	for p.cur.Type != tokEOF {
+		toks = append(toks, p.cur)
+		p.advance()
+	}
+	return toks
+}
+
+func assertSameTokens(t *testing.T, a, b []Token) {
+	t.Helper()
+	if len(a) != len(b) {
+		t.Fatalf("token count: first=%d second=%d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].Type != b[i].Type || a[i].Str != b[i].Str {
+			t.Errorf("token %d: first={%d,%q} second={%d,%q}", i, a[i].Type, a[i].Str, b[i].Type, b[i].Str)
+		}
+	}
+}
+
+// Snapshot at '(', scan to EOF, restore, rescan — identical token stream.
+func TestSnapshotRestore_RoundTrip(t *testing.T) {
+	p := &Parser{lexer: NewLexerWithOffset("(SELECT 1) UNION (SELECT 2)", 0)}
+	p.advance() // cur = '('
+	snap := p.snapshotTokenStream()
+	first := collectToEOF(p)
+	p.restoreTokenStream(snap)
+	assertSameTokens(t, first, collectToEOF(p))
+}
+
+// A conditional comment /*!NNNNN ... */ is spliced into l.input in place during
+// lexing. Restore (which reverts l.input) must yield an identical rescan.
+func TestSnapshotRestore_AcrossConditionalComment(t *testing.T) {
+	p := &Parser{lexer: NewLexerWithOffset("(SELECT /*!40000 a */ FROM t)", 0)}
+	p.advance() // cur = '('
+	snap := p.snapshotTokenStream()
+	first := collectToEOF(p)
+	p.restoreTokenStream(snap)
+	assertSameTokens(t, first, collectToEOF(p))
+}

--- a/tidb/parser/complete_test.go
+++ b/tidb/parser/complete_test.go
@@ -815,3 +815,23 @@ func TestTokenEndMultiChar(t *testing.T) {
 		t.Error("did not find <=> token")
 	}
 }
+
+// TestComplete_ParenFromDerivedBody locks design residual-risk #1: completion
+// with the cursor inside a parenthesized-query derived table. The classifier
+// (parenBeginsSubquery) snapshots and scans across this paren block before the
+// real parse; because advance() is collection-inert, that scan must not corrupt
+// completion state — the body still offers correct SELECT-context candidates.
+func TestComplete_ParenFromDerivedBody(t *testing.T) {
+	full := "SELECT x FROM ((SELECT 1) UNION (SELECT 2)) y"
+	cursor := len("SELECT x FROM ((SELECT ") // inside the first derived-table operand
+	cs := Collect(full, cursor)
+	if cs == nil {
+		t.Fatal("Collect returned nil")
+	}
+	if !cs.HasRule("columnref") {
+		t.Error("missing columnref candidate inside parenthesized derived-table body")
+	}
+	if !cs.HasToken(kwDISTINCT) {
+		t.Error("missing DISTINCT candidate inside parenthesized derived-table body")
+	}
+}

--- a/tidb/parser/parenthesized_query_test.go
+++ b/tidb/parser/parenthesized_query_test.go
@@ -49,9 +49,10 @@ func TestParenthesizedQueryExpression(t *testing.T) {
 // query is accepted there too (the handoff repro is the procedure-body case).
 // All container-verified accepted on pingcap/tidb:v8.5.0.
 //
-// Not yet covered (separate productions, tracked as a follow-up): a derived
-// table `FROM ((SELECT 1) UNION (SELECT 2)) x` and a subquery expression
-// `IN ((SELECT 1) UNION (SELECT 2))`, parsed by parseTableFactor / parseParenExpr.
+// The derived-table case `FROM ((SELECT 1) UNION (SELECT 2)) x` is now handled
+// via a backtracking classifier in parseTableFactor (see TestParenFromDerived).
+// Still not covered (subquery-expression production, tracked as PR3): a subquery
+// expression `IN ((SELECT 1) UNION (SELECT 2))`, parsed by parseParenExpr.
 func TestParenthesizedQueryDelegatedContexts(t *testing.T) {
 	accepted := []string{
 		"INSERT INTO t (SELECT 1) UNION (SELECT 2)",
@@ -178,5 +179,38 @@ func TestParenthesizedQueryLocking(t *testing.T) {
 		t.Run(sql, func(t *testing.T) {
 			ParseExpectError(t, sql)
 		})
+	}
+}
+
+// PR2: derived tables whose body is a parenthesized / set-op query expression.
+// All container-verified accepted on pingcap/tidb:v8.5.0. Before this change
+// parseTableFactor consumed '(' then peeked kwSELECT||kwWITH, so a leading
+// nested '(' misrouted to parseTableReferenceList and rejected.
+func TestParenFromDerived(t *testing.T) {
+	accepted := []string{
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2)) x",
+		"SELECT * FROM ((SELECT 1)) x",
+		"SELECT * FROM (((SELECT 1))) x",
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2) ORDER BY 1) x",
+		"SELECT * FROM ((SELECT 1 UNION SELECT 2)) x",
+		"SELECT * FROM ((SELECT a FROM t) UNION (SELECT b FROM t)) x",
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// Regression: the classifier must preserve every shape that parses today.
+func TestParenFromRegression(t *testing.T) {
+	accepted := []string{
+		"SELECT * FROM (SELECT 1) x",              // simple derived table
+		"SELECT * FROM (t1)",                      // parenthesized single table
+		"SELECT * FROM (t1 JOIN t2 ON t1.a=t2.b)", // parenthesized join
+		"SELECT * FROM (t1, t2)",                  // parenthesized comma cross-join
+		"SELECT * FROM t1, LATERAL (SELECT 1) x",  // LATERAL derived table
+		"(SELECT 1) UNION (SELECT 2)",             // top-level set-op (statement)
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
 	}
 }

--- a/tidb/parser/parenthesized_query_test.go
+++ b/tidb/parser/parenthesized_query_test.go
@@ -214,3 +214,30 @@ func TestParenFromRegression(t *testing.T) {
 		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
 	}
 }
+
+// TestParenFromRobustness exercises the trickier paths: a conditional comment
+// spliced inside the body during the classifier scan (validates the snapshot's
+// input capture), a set-op derived table followed by a JOIN, and a set-op body
+// with no alias. All container-verified parse on pingcap/tidb:v8.5.0.
+func TestParenFromRobustness(t *testing.T) {
+	accepted := []string{
+		"SELECT * FROM ((SELECT 1) UNION (/*!40000 SELECT 2 */)) x",
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2)) x JOIN t3 ON x.a=t3.a",
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2))",
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// TestParenFromRejected: malformed paren bodies must still be rejected. Both are
+// 1064 syntax errors on the TiDB v8.5.0 container.
+func TestParenFromRejected(t *testing.T) {
+	rejected := []string{
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2)", // unbalanced parens
+		"SELECT * FROM ((SELECT 1) (SELECT 2)) x",    // two selects, no set-op
+	}
+	for _, sql := range rejected {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}

--- a/tidb/parser/parenthesized_query_test.go
+++ b/tidb/parser/parenthesized_query_test.go
@@ -200,6 +200,24 @@ func TestParenFromDerived(t *testing.T) {
 	}
 }
 
+// TestParenFromDerivedOuterClause covers a derived-table body that is a
+// parenthesized query with an OUTER ORDER BY / LIMIT (no set op). TiDB v8.5.0
+// accepts all of these (container-verified); the classifier must inherit the
+// nested verdict across a trailing ORDER/LIMIT, not just across a set-op
+// keyword. This is the bare sibling of the already-passing
+// `((SELECT 1) UNION (SELECT 2) ORDER BY 1) x`.
+func TestParenFromDerivedOuterClause(t *testing.T) {
+	accepted := []string{
+		"SELECT * FROM ((SELECT 1) ORDER BY 1) x",
+		"SELECT * FROM ((SELECT 1) LIMIT 1) x",
+		"SELECT * FROM (((SELECT 1) LIMIT 1)) x",
+		"SELECT * FROM ((SELECT 1) ORDER BY 1 LIMIT 1) x",
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
 // Regression: the classifier must preserve every shape that parses today.
 func TestParenFromRegression(t *testing.T) {
 	accepted := []string{
@@ -236,6 +254,7 @@ func TestParenFromRejected(t *testing.T) {
 	rejected := []string{
 		"SELECT * FROM ((SELECT 1) UNION (SELECT 2)", // unbalanced parens
 		"SELECT * FROM ((SELECT 1) (SELECT 2)) x",    // two selects, no set-op
+		"SELECT * FROM ((SELECT 1) FOR UPDATE) x",    // FOR UPDATE binds to the leaf, not the outer level (TiDB rejects)
 	}
 	for _, sql := range rejected {
 		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })

--- a/tidb/parser/select.go
+++ b/tidb/parser/select.go
@@ -995,6 +995,68 @@ func (p *Parser) matchJoinType() (nodes.JoinType, bool, error) {
 	return 0, false, nil
 }
 
+// parenBeginsSubquery reports whether the '(' at p.cur opens a parenthesized
+// query expression (a derived table) rather than a parenthesized table
+// reference (a join). It classifies WITHOUT consuming: snapshot, scan, restore.
+// One-token lookahead cannot decide this because the disambiguating token (a
+// depth-1 SELECT/WITH, or a post-')' UNION/JOIN) can sit behind an unbounded
+// run of '('. Ported from pg/parser/select.go parenBeginsSubquery.
+func (p *Parser) parenBeginsSubquery() bool {
+	if p.cur.Type != '(' {
+		return false
+	}
+	snap := p.snapshotTokenStream()
+	defer p.restoreTokenStream(snap)
+	return p.consumeMatchedParenIsSubquery()
+}
+
+// consumeMatchedParenIsSubquery consumes the matched '(' ... ')' block at p.cur
+// and reports whether its content is a query expression. The lead set is
+// {SELECT, WITH} ((VALUES)/(TABLE) primaries are a separate follow-up that
+// parseSelectNoParens cannot parse as a body, so excluding them preserves
+// today's reject behavior). A nested '(' recurses, and the outer is classified
+// by what follows the nested block: ')' or a set-op keyword inherits the nested
+// verdict; anything else (e.g. a JOIN keyword) means the nested block is a join
+// operand, not a wrapped subquery. Must run inside a snapshot/restore scope.
+func (p *Parser) consumeMatchedParenIsSubquery() bool {
+	if p.cur.Type != '(' {
+		return false
+	}
+	p.advance() // consume '('
+
+	var isSubquery bool
+	switch p.cur.Type {
+	case kwSELECT, kwWITH:
+		isSubquery = true
+	case '(':
+		nested := p.consumeMatchedParenIsSubquery()
+		switch p.cur.Type {
+		case ')', kwUNION, kwINTERSECT, kwEXCEPT:
+			isSubquery = nested
+		default:
+			isSubquery = false
+		}
+	default:
+		isSubquery = false
+	}
+
+	depth := 1
+	for depth > 0 && p.cur.Type != tokEOF {
+		switch p.cur.Type {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				p.advance()
+				return isSubquery
+			}
+		}
+		p.advance()
+	}
+	return isSubquery
+}
+
 // parseTableFactor parses a table factor: table_ref, subquery, LATERAL subquery, or parenthesized table_references.
 func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 	// LATERAL (SELECT ...) — LATERAL derived table
@@ -1058,11 +1120,16 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 
 	if p.cur.Type == '(' {
 		startPos := p.pos()
-		p.advance()
 
-		// Subquery (derived table): (SELECT ...) or (WITH ... SELECT ...)
-		if p.cur.Type == kwSELECT || p.cur.Type == kwWITH {
-			sel, err := p.parseSelectStmt()
+		// One-token lookahead can't separate a parenthesized-query derived table
+		// `((SELECT 1) UNION (SELECT 2)) x` from a parenthesized join `(t1 JOIN
+		// t2)`, so classify with a backtracking scan before consuming the '('.
+		if p.parenBeginsSubquery() {
+			p.advance() // consume '('
+
+			// Body is a query expression (possibly a paren set-op); parseSelectNoParens
+			// (#238) parses paren operands via parseSelectClause/parseSelectWithParens.
+			sel, err := p.parseSelectNoParens()
 			if err != nil {
 				return nil, err
 			}
@@ -1105,6 +1172,7 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 		}
 
 		// Parenthesized table references use MySQL nested-join semantics.
+		p.advance() // consume '('
 		refs, err := p.parseTableReferenceList()
 		if err != nil {
 			return nil, err

--- a/tidb/parser/select.go
+++ b/tidb/parser/select.go
@@ -1030,8 +1030,17 @@ func (p *Parser) consumeMatchedParenIsSubquery() bool {
 		isSubquery = true
 	case '(':
 		nested := p.consumeMatchedParenIsSubquery()
+		// Classify the outer by what follows the nested block. A trailing set-op
+		// keyword OR an outer ORDER BY / LIMIT continues the OUTER query
+		// expression, so it inherits the nested verdict (TiDB accepts
+		// `((SELECT 1) UNION (SELECT 2)) x` and `((SELECT 1) ORDER BY 1) x`).
+		// Adding ORDER/LIMIT DIVERGES from pg, whose set omits them; both are
+		// container-verified on v8.5.0. FOR UPDATE is deliberately excluded — it
+		// binds to the leaf, not this outer level, and TiDB rejects
+		// `((SELECT 1) FOR UPDATE) x`. Inheriting `nested` (not blind true) keeps
+		// a join body safe: `((t1 JOIN t2) ORDER BY 1)` inherits false → join.
 		switch p.cur.Type {
-		case ')', kwUNION, kwINTERSECT, kwEXCEPT:
+		case ')', kwUNION, kwINTERSECT, kwEXCEPT, kwORDER, kwLIMIT:
 			isSubquery = nested
 		default:
 			isSubquery = false


### PR DESCRIPTION
Accepts the parenthesized-query **derived table** forms #238 deferred:

```sql
SELECT * FROM ((SELECT 1) UNION (SELECT 2)) x
SELECT * FROM ((SELECT 1)) x
SELECT * FROM ((SELECT 1) ORDER BY 1) x      -- outer ORDER BY / LIMIT
```

All container-verified on `pingcap/tidb:v8.5.0`.

### Why backtracking

At `(` in FROM the parser must decide **derived-table vs parenthesized-join**. The disambiguating token (a depth-1 `SELECT`/`WITH`, or a post-`)` `UNION`/`JOIN`) can sit behind an unbounded run of `(`, so no fixed lookahead suffices — both engines confirm this (mysql #253 deferred the identical cases for the same reason; the parsers have identical 1-token lookahead). The fix mirrors pg's proven structural-scan classifier, not try-parse-and-rollback.

### What's here (~100 production lines)

1. **`backtrack.go`** — token-stream `snapshotTokenStream`/`restoreTokenStream` over parser `{cur,prev,nextBuf,hasNext}` + lexer `{input,pos,start,prevToken,prevTokenEnd}`. Captures `input` (which pg omits) because the lexer rewrites it in place for `/*! … */` conditional comments; Go strings are immutable so it's O(1). No completion/`CandidateSet` variant — tidb's `advance()`/`peekNext()` are collection-inert (`checkCursor` lives only in grammar-rule functions), so a pure advance-loop scan can't corrupt completion state.
2. **Classifier** (`parenBeginsSubquery` → `consumeMatchedParenIsSubquery`) — ports pg's scan: classify by depth-1 lead token `{SELECT,WITH}`, recurse on nested `(`, and inherit the nested verdict across `) / UNION / INTERSECT / EXCEPT / ORDER / LIMIT`. The subquery branch reuses #238's `parseSelectNoParens`; the join branch keeps tidb's `parseTableReferenceList` (MySQL comma-join).
3. Stale tracked-gap comment updated; PR3 (IN/scalar/EXISTS) and `(VALUES)`/`(TABLE)` primaries remain follow-ups.

### Container-verified divergences from the pg port (TiDB ≠ PG)

- **ORDER/LIMIT in the inherit set** — pg's set omits them, but TiDB accepts `((SELECT 1) ORDER BY 1) x`. Inheriting the *nested* verdict (not blind `true`) keeps a join body like `((t1 JOIN t2) ORDER BY 1)` routed to the join branch.
- **`FOR UPDATE` excluded** — it binds to the leaf, not this outer level; TiDB rejects `((SELECT 1) FOR UPDATE) x`, and so do we.

### Tests (TDD, container-grounded)

Primitive round-trip incl. across a conditional-comment splice; classifier accept/regression/robustness/reject matrices; outer ORDER/LIMIT acceptance + FOR UPDATE rejection; deparse round-trip; an end-to-end analyze guard (passes — #238's ParenSource-aware analyzer needs no change); and a **completion-cursor-inside-a-FROM-paren** test (honors the design's residual-risk #1). `go test ./tidb/... -short` + `go vet ./tidb/...` green.

Design + plan: `plans/2026-06-08-tidb-paren-backtracking-{design,plan}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)