### PR TITLE
feat(snowflake): CREATE / ALTER WAREHOUSE (phase-2 gap-warehouse) — close corpus gaps 168,171

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -166,6 +166,10 @@ const (
 	T_CreateSequenceStmt
 	T_AlterSequenceStmt
 
+	// Warehouse DDL tags (gap-warehouse)
+	T_CreateWarehouseStmt
+	T_AlterWarehouseStmt
+
 	// Access-control DDL tags (T4.6)
 	T_PolicyArg
 	T_CreateRoleStmt
@@ -444,6 +448,10 @@ func (t NodeTag) String() string {
 		return "CreateSequenceStmt"
 	case T_AlterSequenceStmt:
 		return "AlterSequenceStmt"
+	case T_CreateWarehouseStmt:
+		return "CreateWarehouseStmt"
+	case T_AlterWarehouseStmt:
+		return "AlterWarehouseStmt"
 	case T_PolicyArg:
 		return "PolicyArg"
 	case T_CreateRoleStmt:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -4992,6 +4992,101 @@ var (
 )
 
 // ---------------------------------------------------------------------------
+// Warehouse DDL — CREATE / ALTER WAREHOUSE (gap-warehouse)
+// ---------------------------------------------------------------------------
+//
+// A warehouse carries an open-ended, version-growing vocabulary of object
+// properties (WAREHOUSE_SIZE, WAREHOUSE_TYPE, RESOURCE_CONSTRAINT, AUTO_RESUME,
+// AUTO_SUSPEND, INITIALLY_SUSPENDED, GENERATION, MAX_CLUSTER_COUNT,
+// MIN_CLUSTER_COUNT, SCALING_POLICY, ENABLE_QUERY_ACCELERATION, COMMENT, ...)
+// plus object-parameters and session-parameters that share the same
+// `KEY = value` shape. Rather than mirror the legacy ANTLR grammar's finite,
+// already-stale enumeration (its wh_properties / wh_common_size rules predate
+// WAREHOUSE_TYPE, RESOURCE_CONSTRAINT, GENERATION, ENABLE_QUERY_ACCELERATION,
+// QUERY_ACCELERATION_MAX_SCALE_FACTOR, ...), every property is captured as an
+// open-ended CopyOption pair, exactly like STAGE (T4.1) / FILE FORMAT (T4.2).
+// The catalog/semantic layer, not the parser, validates that a property is real
+// and legal. The trailing [ WITH ] TAG (...) clause is the one structural anchor.
+
+// CreateWarehouseStmt represents
+//
+//	CREATE [ OR REPLACE | OR ALTER ] WAREHOUSE [ IF NOT EXISTS ] <name>
+//	  [ WITH ] <prop> [ <prop> ... ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//
+// where each <prop> is an open-ended `KEY = value` pair captured in Options,
+// preserving source order. The leading optional WITH (CREATE WAREHOUSE w WITH
+// WAREHOUSE_SIZE=...) is purely cosmetic and not retained.
+type CreateWarehouseStmt struct {
+	OrReplace   bool
+	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
+	IfNotExists bool
+	Name        *ObjectName
+	Options     []*CopyOption    // open-ended warehouse properties / object+session params
+	Tags        []*TagAssignment // [WITH] TAG (...); nil if absent
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateWarehouseStmt) Tag() NodeTag { return T_CreateWarehouseStmt }
+
+// AlterWarehouseAction discriminates the action variants of ALTER WAREHOUSE.
+type AlterWarehouseAction int
+
+const (
+	AlterWarehouseSuspend      AlterWarehouseAction = iota // SUSPEND
+	AlterWarehouseResume                                   // RESUME [ IF SUSPENDED ]
+	AlterWarehouseAbort                                    // ABORT ALL QUERIES
+	AlterWarehouseRename                                   // RENAME TO <new_name>
+	AlterWarehouseSet                                      // SET <prop> [ <prop> ... ]
+	AlterWarehouseUnset                                    // UNSET <key> [ , ... ]
+	AlterWarehouseSetTag                                   // SET TAG <tag> = '<value>' [ , ... ]
+	AlterWarehouseUnsetTag                                 // UNSET TAG <tag> [ , ... ]
+	AlterWarehouseAddTables                                // ADD TABLES ( <id> [ , ... ] )
+	AlterWarehouseRemoveTables                             // { REMOVE | DROP } TABLES ( <id> [ , ... ] )
+)
+
+// AlterWarehouseStmt represents ALTER WAREHOUSE [ IF EXISTS ] <name> <action>.
+//
+//	SUSPEND
+//	RESUME [ IF SUSPENDED ]
+//	ABORT ALL QUERIES
+//	RENAME TO <new_name>
+//	SET <prop> [ <prop> ... ]               -- open-ended KEY = value params
+//	UNSET <key> [ , ... ]
+//	SET TAG <tag> = '<value>' [ , ... ]
+//	UNSET TAG <tag> [ , ... ]
+//	ADD TABLES ( <id> [ , ... ] )           -- Unistore/interactive variant
+//	{ REMOVE | DROP } TABLES ( <id> [ , ... ] )
+//
+// NewName holds the RENAME target. Options holds the SET properties. UnsetKeys
+// holds the UNSET key names. Tags / UnsetTags hold the SET TAG / UNSET TAG
+// assignments and names. Tables holds the ADD/REMOVE TABLES identifier list.
+// ResumeIfSuspended records the optional IF SUSPENDED on RESUME.
+type AlterWarehouseStmt struct {
+	IfExists          bool
+	Name              *ObjectName
+	Action            AlterWarehouseAction
+	NewName           *ObjectName      // RENAME TO target; for AlterWarehouseRename
+	Options           []*CopyOption    // SET <props>; for AlterWarehouseSet
+	UnsetKeys         []string         // UNSET <key> [, ...]; for AlterWarehouseUnset
+	Tags              []*TagAssignment // SET TAG (...) assignments; for AlterWarehouseSetTag
+	UnsetTags         []*ObjectName    // UNSET TAG (...) names; for AlterWarehouseUnsetTag
+	Tables            []*ObjectName    // ADD/REMOVE TABLES (...) ids; for the table actions
+	ResumeIfSuspended bool             // RESUME IF SUSPENDED; for AlterWarehouseResume
+	Loc               Loc
+}
+
+// Tag implements Node.
+func (n *AlterWarehouseStmt) Tag() NodeTag { return T_AlterWarehouseStmt }
+
+// Compile-time assertions for warehouse DDL nodes.
+var (
+	_ Node = (*CreateWarehouseStmt)(nil)
+	_ Node = (*AlterWarehouseStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
 // CALL / EXECUTE IMMEDIATE / EXECUTE TASK / EXPLAIN statement nodes (T5.4)
 // ---------------------------------------------------------------------------
 

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -172,6 +172,13 @@ func walkChildren(v Visitor, node Node) {
 		if n.MaskingPolicy != nil {
 			Walk(v, n.MaskingPolicy)
 		}
+	case *AlterWarehouseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.NewName != nil {
+			Walk(v, n.NewName)
+		}
 	case *ArrayLiteralExpr:
 		walkNodes(v, n.Elements)
 	case *BetweenExpr:
@@ -397,6 +404,10 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Name)
 		}
 		Walk(v, n.Query)
+	case *CreateWarehouseStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *DeleteStmt:
 		if n.Target != nil {
 			Walk(v, n.Target)

--- a/snowflake/deparse/deparse.go
+++ b/snowflake/deparse/deparse.go
@@ -107,6 +107,12 @@ func (w *writer) writeNode(node ast.Node) error {
 	case *ast.AlterMaterializedViewStmt:
 		return w.writeAlterMaterializedViewStmt(n)
 
+	// --- DDL: warehouse ---
+	case *ast.CreateWarehouseStmt:
+		return w.writeCreateWarehouseStmt(n)
+	case *ast.AlterWarehouseStmt:
+		return w.writeAlterWarehouseStmt(n)
+
 	// --- Expressions (can also be top-level in some contexts) ---
 	case *ast.Literal,
 		*ast.ColumnRef,

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -1138,3 +1138,159 @@ func (w *writer) writeObjectNameList(names []*ast.ObjectName) {
 		w.writeObjectNameNoSpace(n)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// WAREHOUSE DDL (gap-warehouse)
+// ---------------------------------------------------------------------------
+
+// writeCopyOption emits one open-ended `KEY = value` option (or a bare KEY),
+// covering every CopyOption value shape: a literal, a verbatim word run, a
+// parenthesized key/value group, or a parenthesized literal list. It is shared
+// by the warehouse writers; option names are emitted verbatim (already
+// uppercased by the parser).
+func (w *writer) writeCopyOption(opt *ast.CopyOption) error {
+	w.buf.WriteString(opt.Name)
+	if opt.Bare {
+		return nil
+	}
+	w.buf.WriteString(" = ")
+	switch {
+	case opt.Lit != nil:
+		return w.writeCopyOptionLiteral(opt.Lit)
+	case opt.Words != "":
+		w.buf.WriteString(opt.Words)
+	case opt.Group != nil:
+		w.buf.WriteByte('(')
+		for i, sub := range opt.Group {
+			if i > 0 {
+				w.buf.WriteString(", ")
+			}
+			if err := w.writeCopyOption(sub); err != nil {
+				return err
+			}
+		}
+		w.buf.WriteByte(')')
+	case opt.List != nil:
+		w.buf.WriteByte('(')
+		for i, lit := range opt.List {
+			if i > 0 {
+				w.buf.WriteString(", ")
+			}
+			if err := w.writeCopyOptionLiteral(lit); err != nil {
+				return err
+			}
+		}
+		w.buf.WriteByte(')')
+	default:
+		return fmt.Errorf("deparse: empty option value for %q", opt.Name)
+	}
+	return nil
+}
+
+// writeCopyOptionLiteral emits a CopyOption literal value without a leading
+// space (the caller has already written " = "). String literals are single
+// quoted; numeric literals use their raw text / integer value.
+func (w *writer) writeCopyOptionLiteral(lit *ast.Literal) error {
+	switch lit.Kind {
+	case ast.LitString:
+		w.buf.WriteString(quoteString(lit.Value))
+	case ast.LitInt:
+		w.buf.WriteString(strconv.FormatInt(lit.Ival, 10))
+	case ast.LitFloat:
+		w.buf.WriteString(lit.Value)
+	case ast.LitBool:
+		if lit.Bval {
+			w.buf.WriteString("TRUE")
+		} else {
+			w.buf.WriteString("FALSE")
+		}
+	case ast.LitNull:
+		w.buf.WriteString("NULL")
+	default:
+		w.buf.WriteString(lit.Value)
+	}
+	return nil
+}
+
+// writeCopyOptions emits a space-separated run of options.
+func (w *writer) writeCopyOptions(opts []*ast.CopyOption) error {
+	for _, opt := range opts {
+		w.buf.WriteByte(' ')
+		if err := w.writeCopyOption(opt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *writer) writeCreateWarehouseStmt(n *ast.CreateWarehouseStmt) error {
+	w.buf.WriteString("CREATE")
+	if n.OrReplace {
+		w.buf.WriteString(" OR REPLACE")
+	} else if n.OrAlter {
+		w.buf.WriteString(" OR ALTER")
+	}
+	w.buf.WriteString(" WAREHOUSE")
+	if n.IfNotExists {
+		w.buf.WriteString(" IF NOT EXISTS")
+	}
+	w.buf.WriteByte(' ')
+	w.writeObjectNameNoSpace(n.Name)
+	if err := w.writeCopyOptions(n.Options); err != nil {
+		return err
+	}
+	if len(n.Tags) > 0 {
+		w.buf.WriteString(" WITH TAG (")
+		w.writeTagAssignments(n.Tags)
+		w.buf.WriteByte(')')
+	}
+	return nil
+}
+
+func (w *writer) writeAlterWarehouseStmt(n *ast.AlterWarehouseStmt) error {
+	w.buf.WriteString("ALTER WAREHOUSE")
+	if n.IfExists {
+		w.buf.WriteString(" IF EXISTS")
+	}
+	w.buf.WriteByte(' ')
+	w.writeObjectNameNoSpace(n.Name)
+	switch n.Action {
+	case ast.AlterWarehouseSuspend:
+		w.buf.WriteString(" SUSPEND")
+	case ast.AlterWarehouseResume:
+		w.buf.WriteString(" RESUME")
+		if n.ResumeIfSuspended {
+			w.buf.WriteString(" IF SUSPENDED")
+		}
+	case ast.AlterWarehouseAbort:
+		w.buf.WriteString(" ABORT ALL QUERIES")
+	case ast.AlterWarehouseRename:
+		w.buf.WriteString(" RENAME TO ")
+		w.writeObjectNameNoSpace(n.NewName)
+	case ast.AlterWarehouseSet:
+		w.buf.WriteString(" SET")
+		if err := w.writeCopyOptions(n.Options); err != nil {
+			return err
+		}
+	case ast.AlterWarehouseUnset:
+		w.buf.WriteString(" UNSET ")
+		w.buf.WriteString(strings.Join(n.UnsetKeys, ", "))
+	case ast.AlterWarehouseSetTag:
+		w.buf.WriteString(" SET TAG ")
+		w.writeTagAssignments(n.Tags)
+	case ast.AlterWarehouseUnsetTag:
+		w.buf.WriteString(" UNSET TAG ")
+		w.writeObjectNameList(n.UnsetTags)
+	case ast.AlterWarehouseAddTables:
+		w.buf.WriteString(" ADD TABLES (")
+		w.writeObjectNameList(n.Tables)
+		w.buf.WriteByte(')')
+	case ast.AlterWarehouseRemoveTables:
+		w.buf.WriteString(" REMOVE TABLES (")
+		w.writeObjectNameList(n.Tables)
+		w.buf.WriteByte(')')
+	default:
+		return fmt.Errorf("deparse: unsupported ALTER WAREHOUSE action %d", n.Action)
+	}
+	return nil
+}

--- a/snowflake/deparse/warehouse_deparse_test.go
+++ b/snowflake/deparse/warehouse_deparse_test.go
@@ -1,0 +1,55 @@
+package deparse_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/deparse"
+	"github.com/bytebase/omni/snowflake/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// WAREHOUSE DDL round-trips (gap-warehouse)
+//
+// assertRoundTrip compares ASTs (Loc-stripped), so cosmetic normalizations the
+// deparser applies — dropping the optional leading WITH, uppercasing option
+// names/keys, emitting DROP TABLES as REMOVE TABLES (the same AST action) — are
+// expected and verified to be AST-equivalent.
+// ---------------------------------------------------------------------------
+
+func TestDeparse_CreateWarehouse(t *testing.T) {
+	assertRoundTrip(t, "CREATE WAREHOUSE my_wh")
+	assertRoundTrip(t, "CREATE OR REPLACE WAREHOUSE my_wh WITH WAREHOUSE_SIZE = 'X-LARGE'")
+	assertRoundTrip(t, "CREATE OR REPLACE WAREHOUSE my_wh WAREHOUSE_SIZE = LARGE INITIALLY_SUSPENDED = TRUE")
+	assertRoundTrip(t, "CREATE WAREHOUSE so_warehouse WITH WAREHOUSE_TYPE = 'SNOWPARK-OPTIMIZED' WAREHOUSE_SIZE = XLARGE RESOURCE_CONSTRAINT = 'MEMORY_16X_x86'")
+	assertRoundTrip(t, "CREATE OR ALTER WAREHOUSE so_warehouse WAREHOUSE_TYPE = 'SNOWPARK-OPTIMIZED' AUTO_RESUME = TRUE COMMENT = 'Snowpark warehouse for ingestion'")
+	assertRoundTrip(t, "CREATE WAREHOUSE w AUTO_SUSPEND = 60 GENERATION = '1'")
+	assertRoundTrip(t, "CREATE WAREHOUSE IF NOT EXISTS w WAREHOUSE_SIZE = SMALL WITH TAG (cost_center = 'eng', env = 'prod')")
+}
+
+func TestDeparse_AlterWarehouse(t *testing.T) {
+	assertRoundTrip(t, "ALTER WAREHOUSE IF EXISTS wh1 RENAME TO wh2")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh SUSPEND")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh RESUME")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh RESUME IF SUSPENDED")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh ABORT ALL QUERIES")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh SET WAREHOUSE_SIZE = MEDIUM")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh SET GENERATION = '2' AUTO_SUSPEND = 120")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh UNSET STATEMENT_TIMEOUT_IN_SECONDS")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh UNSET AUTO_SUSPEND, COMMENT")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh SET TAG cost_center = 'eng', env = 'prod'")
+	assertRoundTrip(t, "ALTER WAREHOUSE my_wh UNSET TAG cost_center, env")
+	assertRoundTrip(t, "ALTER WAREHOUSE interactive_demo ADD TABLES (orders, customers)")
+	assertRoundTrip(t, "ALTER WAREHOUSE interactive_demo REMOVE TABLES (orders, customers)")
+}
+
+// TestDeparse_AlterWarehouse_DropTablesNormalizes documents that DROP TABLES and
+// REMOVE TABLES parse to the same action and the deparser emits the REMOVE
+// spelling — exercising the exact deparsed string, not just AST equivalence.
+func TestDeparse_AlterWarehouse_DropTablesNormalizes(t *testing.T) {
+	f, err := parser.Parse("ALTER WAREHOUSE w DROP TABLES (a, b)")
+	require.NoError(t, err)
+	out, err := deparse.DeparseFile(f)
+	require.NoError(t, err)
+	require.Equal(t, "ALTER WAREHOUSE w REMOVE TABLES (a, b)", out)
+}

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -172,15 +172,7 @@ var corpusSkips = map[string]string{
 	"legacy/alter.sql":                        "RESIDUAL GAP: ALTER {ACCOUNT,DATABASE,SESSION,SHARE,...} family — parser-alter node not built",
 	"official/alter-session/example_01.sql":   "RESIDUAL GAP: ALTER SESSION SET — parser-alter node not built",
 	"official/alter-session/example_02.sql":   "RESIDUAL GAP: ALTER SESSION UNSET — parser-alter node not built",
-	"official/alter-warehouse/example_01.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
-	"official/alter-warehouse/example_02.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
-	"official/alter-warehouse/example_03.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
-	"official/alter-warehouse/example_04.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
-	"official/alter-warehouse/example_05.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
-	"official/alter-warehouse/example_06.sql": "RESIDUAL GAP: ALTER WAREHOUSE — parser-alter node not built",
 	"official/create-database/example_08.sql": "CONTEXT: file is a lone ALTER SESSION SET (create-database page follow-up) — parser-alter not built",
-	"official/create-database/example_10.sql": "CONTEXT: file is a lone ALTER DATABASE/SESSION (create-database page follow-up) — parser-alter not built",
-	"official/create-database/example_11.sql": "CONTEXT: file is a lone ALTER DATABASE/SESSION (create-database page follow-up) — parser-alter not built",
 	"official/order-by/example_04.sql":        "RESIDUAL GAP: ALTER SESSION SET DEFAULT_NULL_ORDERING — parser-alter node not built",
 	"official/order-by/example_07.sql":        "RESIDUAL GAP: ALTER SESSION SET DEFAULT_NULL_ORDERING — parser-alter node not built",
 	"official/update/example_04.sql":          "RESIDUAL GAP: ALTER SESSION SET (update page setup) — parser-alter node not built",
@@ -193,14 +185,12 @@ var corpusSkips = map[string]string{
 	// --- RESIDUAL GAP: ALTER VIEW with a re-defined query body ---
 	"official/alter-view/example_11.sql": "RESIDUAL GAP: ALTER VIEW ... AS <join query> body redefinition not parsed",
 
-	// --- RESIDUAL GAP: CREATE WAREHOUSE (object node not built) ---
-	"official/create-warehouse/example_01.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
-	"official/create-warehouse/example_02.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
-	"official/create-warehouse/example_03.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
-	"official/create-warehouse/example_04.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
-	"official/create-warehouse/example_05.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
-	"official/create-warehouse/example_06.sql": "RESIDUAL GAP: CREATE WAREHOUSE — object node not built",
-	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: CREATE OR ALTER WAREHOUSE + SHOW ->> SELECT FROM $1 — object node not built; also the $N table-ref gap",
+	// --- RESIDUAL GAP: SHOW ->> result-pipe + $N table-ref (other nodes) ---
+	// CREATE/ALTER WAREHOUSE now parse (gap-warehouse); this file remains skipped
+	// only because its two `SHOW WAREHOUSES ... ->> SELECT ... FROM $1` statements
+	// exercise the ->> result-pipe and $N table-ref gaps owned by other nodes. The
+	// CREATE OR ALTER WAREHOUSE and DROP WAREHOUSE statements in it parse clean.
+	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: SHOW WAREHOUSES ->> SELECT ... FROM $1 — ->> result-pipe + $N table-ref owned by other nodes (CREATE OR ALTER WAREHOUSE parses)",
 
 	// --- RESIDUAL GAP: CREATE HYBRID TABLE (object node not built) ---
 	"official/create-hybrid-table/example_01.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
@@ -219,11 +209,11 @@ var corpusSkips = map[string]string{
 	"official/create-network-rule/example_04.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
 	"official/create-network-rule/example_05.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
 
-	// --- RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW + ALTER WAREHOUSE ---
-	"official/create-materialized-view/example_02.sql": "RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (INTERACTIVE keyword) + ALTER WAREHOUSE ADD TABLES",
-
-	// --- RESIDUAL GAP: CREATE statement variants in the legacy create.sql ---
-	"legacy/create.sql": "RESIDUAL GAP: CREATE {ACCOUNT,API INTEGRATION,FAILOVER GROUP,MANAGED ACCOUNT,WAREHOUSE,...} object variants not all built",
+	// --- RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (object node not built) ---
+	// The ALTER WAREHOUSE ADD TABLES statement in this file now parses
+	// (gap-warehouse); it remains skipped only for the CREATE INTERACTIVE
+	// MATERIALIZED VIEW (INTERACTIVE keyword) statement owned by another node.
+	"official/create-materialized-view/example_02.sql": "RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (INTERACTIVE keyword) — object node not built (ALTER WAREHOUSE ADD TABLES parses)",
 
 	// --- RESIDUAL GAP: CREATE/ALTER/DROP ALERT (object node not built) ---
 	"legacy/alerts.sql": "RESIDUAL GAP: CREATE/ALTER/DROP ALERT — alert object node not built",

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -162,6 +162,9 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 	case kwSEQUENCE:
 		// CREATE [OR REPLACE] SEQUENCE ... (T4.4).
 		return p.parseCreateSequenceStmt(start, orReplace, orAlter)
+	case kwWAREHOUSE:
+		// CREATE [ OR REPLACE | OR ALTER ] WAREHOUSE ... (gap-warehouse).
+		return p.parseCreateWarehouseStmt(start, orReplace, orAlter)
 	case kwEXTERNAL:
 		// CREATE [OR REPLACE] EXTERNAL { FUNCTION (T4.5) | TABLE (T4.4) | VOLUME (T4.7) }.
 		// The object is disambiguated by what follows EXTERNAL. EXTERNAL TABLE keeps

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -224,6 +224,9 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 	case kwSEQUENCE:
 		// ALTER SEQUENCE ... (T4.4). (ALTER EVENT TABLE goes through ALTER TABLE.)
 		return p.parseAlterSequenceStmt()
+	case kwWAREHOUSE:
+		// ALTER WAREHOUSE ... (gap-warehouse).
+		return p.parseAlterWarehouseStmt()
 	case kwSTORAGE, kwAPI, kwNOTIFICATION, kwSECURITY, kwINTEGRATION, kwRESOURCE, kwSECRET, kwCONNECTION, kwGIT:
 		// ALTER account-level integration objects (T4.7): { [STORAGE] | API |
 		// NOTIFICATION | SECURITY } INTEGRATION, RESOURCE MONITOR, SECRET,

--- a/snowflake/parser/warehouse.go
+++ b/snowflake/parser/warehouse.go
@@ -1,0 +1,371 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Warehouse DDL — CREATE / ALTER WAREHOUSE (gap-warehouse)
+// ---------------------------------------------------------------------------
+//
+// A warehouse carries a large, version-growing vocabulary of object properties
+// (WAREHOUSE_SIZE, WAREHOUSE_TYPE, RESOURCE_CONSTRAINT, AUTO_RESUME,
+// AUTO_SUSPEND, INITIALLY_SUSPENDED, GENERATION, MAX_CLUSTER_COUNT,
+// MIN_CLUSTER_COUNT, SCALING_POLICY, ENABLE_QUERY_ACCELERATION, COMMENT, ...)
+// alongside object-parameters and session-parameters that share the same
+// `KEY = value` shape. Rather than mirror the legacy ANTLR grammar's finite,
+// already-stale wh_properties / wh_common_size enumeration (it predates
+// WAREHOUSE_TYPE, RESOURCE_CONSTRAINT, GENERATION, ENABLE_QUERY_ACCELERATION,
+// QUERY_ACCELERATION_MAX_SCALE_FACTOR, ...), every property is parsed as an
+// open-ended `KEY = <value>` pair (ast.CopyOption), reusing the merged COPY
+// (T5.2) machinery (parseCopyOption / startsCopyOption) exactly as STAGE (T4.1)
+// and FILE FORMAT (T4.2) do. The trailing [WITH] TAG (...) clause is the one
+// structural anchor; the ALTER action keywords (SUSPEND / RESUME / ABORT /
+// RENAME / SET / UNSET / ADD|REMOVE|DROP TABLES) anchor the ALTER grammar. The
+// catalog/semantic layer, not the parser, validates that a property is real.
+
+// warehouseOptionCap bounds an open-ended warehouse property run. Real
+// statements carry well under a dozen properties; a far larger run signals a
+// runaway parse and aborts loudly rather than spinning.
+const warehouseOptionCap = 1024
+
+// ---------------------------------------------------------------------------
+// CREATE WAREHOUSE
+// ---------------------------------------------------------------------------
+
+// parseCreateWarehouseStmt parses the body of a
+//
+//	CREATE [ OR REPLACE | OR ALTER ] WAREHOUSE [ IF NOT EXISTS ] <name>
+//	  [ WITH ] <prop> [ <prop> ... ]
+//	  [ [ WITH ] TAG ( <tag> = '<value>' [ , ... ] ) ]
+//
+// statement. The CREATE keyword and the optional OR REPLACE / OR ALTER
+// modifiers have already been consumed by parseCreateStmt; start is the Loc of
+// the CREATE token, and cur is the WAREHOUSE keyword.
+func (p *Parser) parseCreateWarehouseStmt(start ast.Loc, orReplace, orAlter bool) (ast.Node, error) {
+	p.advance() // consume WAREHOUSE
+
+	stmt := &ast.CreateWarehouseStmt{
+		OrReplace: orReplace,
+		OrAlter:   orAlter,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS
+	if p.cur.Type == kwIF && p.peekNext().Type == kwNOT {
+		p.advance() // consume IF
+		p.advance() // consume NOT
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
+	// Warehouse name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Optional leading WITH preceding the property list (CREATE WAREHOUSE w WITH
+	// WAREHOUSE_SIZE=...). It is purely cosmetic and only consumed when it does
+	// NOT introduce a [WITH] TAG clause (WITH TAG anchors the tag clause, handled
+	// by the property/tag loop below).
+	if p.cur.Type == kwWITH && p.peekNext().Type != kwTAG {
+		p.advance() // consume the cosmetic leading WITH
+	}
+
+	// Trailing clauses: an open-ended run of `KEY = value` properties interleaved
+	// with the [WITH] TAG (...) clause, mirroring CREATE STAGE. The loop ends at a
+	// statement boundary or any token that begins neither a property nor a tag
+	// clause. The loop-guard aborts if an iteration fails to consume any token.
+	for i := 0; ; i++ {
+		if i >= warehouseOptionCap {
+			return nil, p.syntaxErrorAtCur()
+		}
+		before := p.cur.Loc.Start
+		if p.startsWarehouseTags() {
+			tags, err := p.parseWarehouseWithTags()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Tags = append(stmt.Tags, tags...)
+		} else if p.startsWarehouseOption() {
+			opt, err := p.parseCopyOption()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Options = append(stmt.Options, opt)
+		} else {
+			break
+		}
+		if p.cur.Loc.Start == before && p.cur.Type != tokEOF {
+			// No forward progress on a non-EOF token: abort rather than spin.
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER WAREHOUSE
+// ---------------------------------------------------------------------------
+
+// parseAlterWarehouseStmt parses ALTER WAREHOUSE [ IF EXISTS ] <name> <action>.
+// The ALTER keyword has already been consumed; cur is the WAREHOUSE keyword.
+//
+//	SUSPEND
+//	RESUME [ IF SUSPENDED ]
+//	ABORT ALL QUERIES
+//	RENAME TO <new_name>
+//	SET <prop> [ <prop> ... ]               -- open-ended KEY = value params
+//	UNSET <key> [ , ... ]
+//	ADD TABLES ( <id> [ , ... ] )           -- Unistore/interactive variant
+//	{ REMOVE | DROP } TABLES ( <id> [ , ... ] )
+func (p *Parser) parseAlterWarehouseStmt() (ast.Node, error) {
+	whTok := p.advance() // consume WAREHOUSE (anchors Loc.Start at the object keyword)
+	stmt := &ast.AlterWarehouseStmt{Loc: ast.Loc{Start: whTok.Loc.Start}}
+
+	// Optional IF EXISTS.
+	if p.cur.Type == kwIF && p.peekNext().Type == kwEXISTS {
+		p.advance() // consume IF
+		p.advance() // consume EXISTS
+		stmt.IfExists = true
+	}
+
+	// Warehouse name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch.
+	switch p.cur.Type {
+	case kwSUSPEND:
+		p.advance() // consume SUSPEND
+		stmt.Action = ast.AlterWarehouseSuspend
+
+	case kwRESUME:
+		p.advance() // consume RESUME
+		stmt.Action = ast.AlterWarehouseResume
+		// Optional IF SUSPENDED.
+		if p.cur.Type == kwIF && p.peekNext().Type == kwSUSPENDED {
+			p.advance() // consume IF
+			p.advance() // consume SUSPENDED
+			stmt.ResumeIfSuspended = true
+		}
+
+	case kwABORT:
+		// ABORT ALL QUERIES
+		p.advance() // consume ABORT
+		if _, err := p.expect(kwALL); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwQUERIES); err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterWarehouseAbort
+
+	case kwRENAME:
+		// RENAME TO <new_name>
+		p.advance() // consume RENAME
+		if _, err := p.expect(kwTO); err != nil {
+			return nil, err
+		}
+		newName, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterWarehouseRename
+		stmt.NewName = newName
+
+	case kwSET:
+		p.advance() // consume SET
+		if p.cur.Type == kwTAG {
+			// SET TAG <tag> = '<value>' [ , ... ] — unparenthesized assignment list
+			// (reuses the stage SET TAG helper). Anchored before the open-ended
+			// property run so a literal property named TAG cannot shadow it.
+			tags, err := p.parseTagSetList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterWarehouseSetTag
+			stmt.Tags = tags
+		} else {
+			// SET <prop> [ <prop> ... ] — open-ended KEY = value params.
+			opts, err := p.parseWarehouseOptions()
+			if err != nil {
+				return nil, err
+			}
+			if len(opts) == 0 {
+				// SET with nothing settable is a syntax error.
+				return nil, p.syntaxErrorAtCur()
+			}
+			stmt.Action = ast.AlterWarehouseSet
+			stmt.Options = opts
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		if p.cur.Type == kwTAG {
+			// UNSET TAG <tag> [ , ... ] — unparenthesized name list (reuses the
+			// stage UNSET TAG helper). Anchored before the open-ended key run so a
+			// `UNSET TAG t` is not mis-read as unsetting keys "TAG" and "t".
+			names, err := p.parseUnsetTagNameList()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterWarehouseUnsetTag
+			stmt.UnsetTags = names
+		} else {
+			// UNSET <key> [ , ... ]
+			keys, err := p.parseWarehouseUnsetKeys()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterWarehouseUnset
+			stmt.UnsetKeys = keys
+		}
+
+	case kwADD:
+		// ADD TABLES ( <id> [ , ... ] )
+		p.advance() // consume ADD
+		if _, err := p.expect(kwTABLES); err != nil {
+			return nil, err
+		}
+		ids, err := p.parseWarehouseTableList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterWarehouseAddTables
+		stmt.Tables = ids
+
+	case kwREMOVE, kwDROP:
+		// { REMOVE | DROP } TABLES ( <id> [ , ... ] )
+		p.advance() // consume REMOVE / DROP
+		if _, err := p.expect(kwTABLES); err != nil {
+			return nil, err
+		}
+		ids, err := p.parseWarehouseTableList()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterWarehouseRemoveTables
+		stmt.Tables = ids
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared warehouse helpers
+// ---------------------------------------------------------------------------
+
+// parseWarehouseOptions parses a run of zero or more warehouse properties, each
+// an open-ended `KEY = <value>` pair (reusing parseCopyOption). The run
+// continues while the current token begins another property and terminates at a
+// statement boundary, the WITH / TAG clause, or any token that does not begin a
+// property. A loop-guard aborts if an iteration consumes no tokens.
+func (p *Parser) parseWarehouseOptions() ([]*ast.CopyOption, error) {
+	var opts []*ast.CopyOption
+	for i := 0; p.startsWarehouseOption(); i++ {
+		if i >= warehouseOptionCap {
+			return nil, p.syntaxErrorAtCur()
+		}
+		before := p.cur.Loc.Start
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+		if p.cur.Loc.Start == before && p.cur.Type != tokEOF {
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	return opts, nil
+}
+
+// startsWarehouseOption reports whether the current token can begin a warehouse
+// property. It is the COPY option predicate minus WITH and TAG, which anchor the
+// trailing [WITH] TAG clause and must not be swallowed as a property name.
+func (p *Parser) startsWarehouseOption() bool {
+	switch p.cur.Type {
+	case kwWITH, kwTAG:
+		return false
+	}
+	return p.startsCopyOption()
+}
+
+// startsWarehouseTags reports whether the current position begins a [WITH] TAG
+// clause: either the TAG keyword directly, or WITH immediately followed by TAG.
+func (p *Parser) startsWarehouseTags() bool {
+	if p.cur.Type == kwTAG {
+		return true
+	}
+	return p.cur.Type == kwWITH && p.peekNext().Type == kwTAG
+}
+
+// parseWarehouseWithTags parses a [WITH] TAG (...) clause and returns the tag
+// assignments. It accepts both the WITH TAG and the bare TAG spellings. The
+// caller must have confirmed startsWarehouseTags.
+func (p *Parser) parseWarehouseWithTags() ([]*ast.TagAssignment, error) {
+	if p.cur.Type == kwWITH {
+		p.advance() // consume WITH (peekNext == TAG guaranteed by startsWarehouseTags)
+	}
+	return p.parseTagAssignments()
+}
+
+// parseWarehouseUnsetKeys parses an UNSET <key> [ , ... ] property-name list.
+// Each key is a single name word (identifier or keyword), uppercased; a comma
+// separates keys. Consumes at least one key.
+func (p *Parser) parseWarehouseUnsetKeys() ([]string, error) {
+	var keys []string
+	for {
+		if !p.isOptionWord(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		keys = append(keys, strings.ToUpper(p.advance().Str))
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return keys, nil
+}
+
+// parseWarehouseTableList parses a parenthesized comma-separated identifier list
+// for ADD / REMOVE / DROP TABLES ( <id> [ , ... ] ). On entry cur is '('. At
+// least one identifier is required.
+func (p *Parser) parseWarehouseTableList() ([]*ast.ObjectName, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	var ids []*ast.ObjectName
+	for {
+		id, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}

--- a/snowflake/parser/warehouse_test.go
+++ b/snowflake/parser/warehouse_test.go
@@ -1,0 +1,455 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateWarehouse(t *testing.T, input string) *ast.CreateWarehouseStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateWarehouseStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateWarehouseStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterWarehouse(t *testing.T, input string) *ast.AlterWarehouseStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterWarehouseStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterWarehouseStmt", input, node)
+	}
+	return stmt
+}
+
+// optWords / optLitString / optLitInt are small accessors for asserting on the
+// open-ended CopyOption value shapes that warehouse properties use.
+func optWords(opts []*ast.CopyOption, name string) (string, bool) {
+	o := findOption(opts, name)
+	if o == nil {
+		return "", false
+	}
+	return o.Words, true
+}
+
+func optLitString(opts []*ast.CopyOption, name string) (string, bool) {
+	o := findOption(opts, name)
+	if o == nil || o.Lit == nil || o.Lit.Kind != ast.LitString {
+		return "", false
+	}
+	return o.Lit.Value, true
+}
+
+func optLitInt(opts []*ast.CopyOption, name string) (int64, bool) {
+	o := findOption(opts, name)
+	if o == nil || o.Lit == nil || o.Lit.Kind != ast.LitInt {
+		return 0, false
+	}
+	return o.Lit.Ival, true
+}
+
+// ---------------------------------------------------------------------------
+// CREATE WAREHOUSE — modifiers, name, IF NOT EXISTS
+// ---------------------------------------------------------------------------
+
+func TestParseCreateWarehouse_Modifiers(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE my_wh")
+		if stmt.Name.String() != "my_wh" {
+			t.Errorf("Name = %q, want my_wh", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.OrAlter || stmt.IfNotExists {
+			t.Errorf("unexpected modifier set: %+v", stmt)
+		}
+		if len(stmt.Options) != 0 || len(stmt.Tags) != 0 {
+			t.Errorf("expected no options/tags, got %+v / %+v", stmt.Options, stmt.Tags)
+		}
+	})
+
+	t.Run("or replace", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE OR REPLACE WAREHOUSE w")
+		if !stmt.OrReplace || stmt.OrAlter {
+			t.Errorf("OrReplace=%v OrAlter=%v, want true/false", stmt.OrReplace, stmt.OrAlter)
+		}
+	})
+
+	t.Run("or alter", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE OR ALTER WAREHOUSE w")
+		if stmt.OrReplace || !stmt.OrAlter {
+			t.Errorf("OrReplace=%v OrAlter=%v, want false/true", stmt.OrReplace, stmt.OrAlter)
+		}
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE IF NOT EXISTS w")
+		if !stmt.IfNotExists {
+			t.Error("IfNotExists not set")
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE db.sch.w")
+		if stmt.Name.String() != "db.sch.w" {
+			t.Errorf("Name = %q, want db.sch.w", stmt.Name.String())
+		}
+	})
+
+	t.Run("quoted name", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, `CREATE WAREHOUSE "My WH"`)
+		if stmt.Name.String() != `"My WH"` {
+			t.Errorf("Name = %q", stmt.Name.String())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE WAREHOUSE — official docs corpus shapes
+// ---------------------------------------------------------------------------
+
+func TestParseCreateWarehouse_CorpusShapes(t *testing.T) {
+	// example_01: CREATE OR REPLACE WAREHOUSE my_wh WITH WAREHOUSE_SIZE = 'X-LARGE'
+	t.Run("with leading WITH + string size", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE OR REPLACE WAREHOUSE my_wh WITH WAREHOUSE_SIZE = 'X-LARGE'")
+		if !stmt.OrReplace {
+			t.Error("OrReplace not set")
+		}
+		if v, ok := optLitString(stmt.Options, "WAREHOUSE_SIZE"); !ok || v != "X-LARGE" {
+			t.Errorf("WAREHOUSE_SIZE = %q (ok=%v), want 'X-LARGE'", v, ok)
+		}
+	})
+
+	// example_02: WAREHOUSE_SIZE = LARGE (word) INITIALLY_SUSPENDED = TRUE (word), no WITH
+	t.Run("bare word values, no WITH", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE OR REPLACE WAREHOUSE my_wh WAREHOUSE_SIZE = LARGE INITIALLY_SUSPENDED = TRUE")
+		if v, ok := optWords(stmt.Options, "WAREHOUSE_SIZE"); !ok || v != "LARGE" {
+			t.Errorf("WAREHOUSE_SIZE words = %q (ok=%v), want LARGE", v, ok)
+		}
+		if v, ok := optWords(stmt.Options, "INITIALLY_SUSPENDED"); !ok || v != "TRUE" {
+			t.Errorf("INITIALLY_SUSPENDED words = %q (ok=%v), want TRUE", v, ok)
+		}
+	})
+
+	// example_03: WITH + WAREHOUSE_TYPE (string) + WAREHOUSE_SIZE (word) + RESOURCE_CONSTRAINT (string)
+	t.Run("snowpark-optimized multi-prop", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE so_warehouse WITH WAREHOUSE_TYPE = 'SNOWPARK-OPTIMIZED' WAREHOUSE_SIZE = XLARGE RESOURCE_CONSTRAINT = 'MEMORY_16X_x86'")
+		if len(stmt.Options) != 3 {
+			t.Fatalf("got %d options, want 3: %+v", len(stmt.Options), stmt.Options)
+		}
+		if v, ok := optLitString(stmt.Options, "WAREHOUSE_TYPE"); !ok || v != "SNOWPARK-OPTIMIZED" {
+			t.Errorf("WAREHOUSE_TYPE = %q (ok=%v)", v, ok)
+		}
+		if v, ok := optWords(stmt.Options, "WAREHOUSE_SIZE"); !ok || v != "XLARGE" {
+			t.Errorf("WAREHOUSE_SIZE = %q (ok=%v)", v, ok)
+		}
+		if v, ok := optLitString(stmt.Options, "RESOURCE_CONSTRAINT"); !ok || v != "MEMORY_16X_x86" {
+			t.Errorf("RESOURCE_CONSTRAINT = %q (ok=%v)", v, ok)
+		}
+	})
+
+	// example_04: GENERATION = '2'
+	t.Run("generation string", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE gen2_wh WITH WAREHOUSE_SIZE = LARGE GENERATION = '2'")
+		if v, ok := optLitString(stmt.Options, "GENERATION"); !ok || v != "2" {
+			t.Errorf("GENERATION = %q (ok=%v), want '2'", v, ok)
+		}
+	})
+
+	// example_05: CREATE OR ALTER + AUTO_RESUME (word) + COMMENT (string)
+	t.Run("or alter with auto_resume + comment", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE OR ALTER WAREHOUSE so_warehouse WAREHOUSE_TYPE = 'SNOWPARK-OPTIMIZED' AUTO_RESUME = TRUE COMMENT = 'Snowpark warehouse for ingestion'")
+		if !stmt.OrAlter {
+			t.Error("OrAlter not set")
+		}
+		if v, ok := optWords(stmt.Options, "AUTO_RESUME"); !ok || v != "TRUE" {
+			t.Errorf("AUTO_RESUME = %q (ok=%v), want TRUE", v, ok)
+		}
+		if v, ok := optLitString(stmt.Options, "COMMENT"); !ok || v != "Snowpark warehouse for ingestion" {
+			t.Errorf("COMMENT = %q (ok=%v)", v, ok)
+		}
+	})
+
+	// example_07: GENERATION='1' AUTO_SUSPEND=60 (int) INITIALLY_SUSPENDED=TRUE, with leading WITH
+	t.Run("auto_suspend integer value", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE OR ALTER WAREHOUSE test_gen_warehouse WITH WAREHOUSE_SIZE = XSMALL GENERATION = '1' AUTO_SUSPEND = 60 INITIALLY_SUSPENDED = TRUE")
+		if v, ok := optLitInt(stmt.Options, "AUTO_SUSPEND"); !ok || v != 60 {
+			t.Errorf("AUTO_SUSPEND = %d (ok=%v), want 60", v, ok)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE WAREHOUSE — trailing WITH TAG clause
+// ---------------------------------------------------------------------------
+
+func TestParseCreateWarehouse_Tags(t *testing.T) {
+	t.Run("with tag", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE w WAREHOUSE_SIZE = SMALL WITH TAG (cost_center = 'eng', env = 'prod')")
+		if len(stmt.Tags) != 2 {
+			t.Fatalf("got %d tags, want 2: %+v", len(stmt.Tags), stmt.Tags)
+		}
+		if stmt.Tags[0].Name.String() != "cost_center" || stmt.Tags[0].Value != "eng" {
+			t.Errorf("tag[0] = %+v", stmt.Tags[0])
+		}
+		if stmt.Tags[1].Name.String() != "env" || stmt.Tags[1].Value != "prod" {
+			t.Errorf("tag[1] = %+v", stmt.Tags[1])
+		}
+		// The property before the tag clause must still be captured.
+		if _, ok := optWords(stmt.Options, "WAREHOUSE_SIZE"); !ok {
+			t.Error("WAREHOUSE_SIZE option lost when a TAG clause trails it")
+		}
+	})
+
+	t.Run("bare tag without WITH", func(t *testing.T) {
+		stmt := mustCreateWarehouse(t, "CREATE WAREHOUSE w TAG (t = 'v')")
+		if len(stmt.Tags) != 1 || stmt.Tags[0].Value != "v" {
+			t.Errorf("tags = %+v, want one tag t='v'", stmt.Tags)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ALTER WAREHOUSE — every action
+// ---------------------------------------------------------------------------
+
+func TestParseAlterWarehouse_Actions(t *testing.T) {
+	t.Run("suspend", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh SUSPEND")
+		if stmt.Action != ast.AlterWarehouseSuspend {
+			t.Errorf("Action = %d, want Suspend", stmt.Action)
+		}
+	})
+
+	t.Run("resume", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh RESUME")
+		if stmt.Action != ast.AlterWarehouseResume || stmt.ResumeIfSuspended {
+			t.Errorf("Action=%d ResumeIfSuspended=%v, want Resume/false", stmt.Action, stmt.ResumeIfSuspended)
+		}
+	})
+
+	t.Run("resume if suspended", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh RESUME IF SUSPENDED")
+		if stmt.Action != ast.AlterWarehouseResume || !stmt.ResumeIfSuspended {
+			t.Errorf("Action=%d ResumeIfSuspended=%v, want Resume/true", stmt.Action, stmt.ResumeIfSuspended)
+		}
+	})
+
+	t.Run("abort all queries", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh ABORT ALL QUERIES")
+		if stmt.Action != ast.AlterWarehouseAbort {
+			t.Errorf("Action = %d, want Abort", stmt.Action)
+		}
+	})
+
+	t.Run("rename to", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE IF EXISTS wh1 RENAME TO wh2")
+		if !stmt.IfExists {
+			t.Error("IfExists not set")
+		}
+		if stmt.Action != ast.AlterWarehouseRename {
+			t.Fatalf("Action = %d, want Rename", stmt.Action)
+		}
+		if stmt.NewName == nil || stmt.NewName.String() != "wh2" {
+			t.Errorf("NewName = %+v, want wh2", stmt.NewName)
+		}
+	})
+
+	t.Run("set word value", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh SET warehouse_size=MEDIUM")
+		if stmt.Action != ast.AlterWarehouseSet {
+			t.Fatalf("Action = %d, want Set", stmt.Action)
+		}
+		if v, ok := optWords(stmt.Options, "WAREHOUSE_SIZE"); !ok || v != "MEDIUM" {
+			t.Errorf("WAREHOUSE_SIZE = %q (ok=%v), want MEDIUM", v, ok)
+		}
+	})
+
+	t.Run("set string value", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE so_warehouse SET RESOURCE_CONSTRAINT = 'MEMORY_16X_x86'")
+		if v, ok := optLitString(stmt.Options, "RESOURCE_CONSTRAINT"); !ok || v != "MEMORY_16X_x86" {
+			t.Errorf("RESOURCE_CONSTRAINT = %q (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("set multiple props", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh SET GENERATION = '2' AUTO_SUSPEND = 120")
+		if len(stmt.Options) != 2 {
+			t.Fatalf("got %d options, want 2", len(stmt.Options))
+		}
+		if v, ok := optLitInt(stmt.Options, "AUTO_SUSPEND"); !ok || v != 120 {
+			t.Errorf("AUTO_SUSPEND = %d (ok=%v), want 120", v, ok)
+		}
+	})
+
+	t.Run("unset single", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh UNSET STATEMENT_TIMEOUT_IN_SECONDS")
+		if stmt.Action != ast.AlterWarehouseUnset {
+			t.Fatalf("Action = %d, want Unset", stmt.Action)
+		}
+		if len(stmt.UnsetKeys) != 1 || stmt.UnsetKeys[0] != "STATEMENT_TIMEOUT_IN_SECONDS" {
+			t.Errorf("UnsetKeys = %v, want [STATEMENT_TIMEOUT_IN_SECONDS]", stmt.UnsetKeys)
+		}
+	})
+
+	t.Run("unset multiple", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE my_wh UNSET auto_suspend, comment")
+		want := []string{"AUTO_SUSPEND", "COMMENT"}
+		if len(stmt.UnsetKeys) != len(want) {
+			t.Fatalf("UnsetKeys = %v, want %v", stmt.UnsetKeys, want)
+		}
+		for i, w := range want {
+			if stmt.UnsetKeys[i] != w {
+				t.Errorf("UnsetKeys[%d] = %q, want %q", i, stmt.UnsetKeys[i], w)
+			}
+		}
+	})
+
+	t.Run("set tag", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE w SET TAG cost_center = 'eng', env = 'prod'")
+		if stmt.Action != ast.AlterWarehouseSetTag {
+			t.Fatalf("Action = %d, want SetTag", stmt.Action)
+		}
+		if len(stmt.Tags) != 2 || stmt.Tags[0].Name.String() != "cost_center" || stmt.Tags[0].Value != "eng" {
+			t.Errorf("Tags = %+v", stmt.Tags)
+		}
+	})
+
+	t.Run("unset tag", func(t *testing.T) {
+		// Regression: UNSET TAG t must NOT be mis-parsed as UNSET keys "TAG", "t".
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE w UNSET TAG cost_center, env")
+		if stmt.Action != ast.AlterWarehouseUnsetTag {
+			t.Fatalf("Action = %d, want UnsetTag", stmt.Action)
+		}
+		if len(stmt.UnsetTags) != 2 || stmt.UnsetTags[0].String() != "cost_center" || stmt.UnsetTags[1].String() != "env" {
+			t.Errorf("UnsetTags = %v", objNames(stmt.UnsetTags))
+		}
+		if len(stmt.UnsetKeys) != 0 {
+			t.Errorf("UnsetKeys = %v, want empty (TAG must not leak into the key list)", stmt.UnsetKeys)
+		}
+	})
+
+	t.Run("unset plain key named differently is not a tag", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE w UNSET COMMENT")
+		if stmt.Action != ast.AlterWarehouseUnset {
+			t.Fatalf("Action = %d, want Unset", stmt.Action)
+		}
+		if len(stmt.UnsetKeys) != 1 || stmt.UnsetKeys[0] != "COMMENT" {
+			t.Errorf("UnsetKeys = %v, want [COMMENT]", stmt.UnsetKeys)
+		}
+	})
+
+	t.Run("add tables", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE interactive_demo ADD TABLES (orders, customers)")
+		if stmt.Action != ast.AlterWarehouseAddTables {
+			t.Fatalf("Action = %d, want AddTables", stmt.Action)
+		}
+		if len(stmt.Tables) != 2 || stmt.Tables[0].String() != "orders" || stmt.Tables[1].String() != "customers" {
+			t.Errorf("Tables = %v", objNames(stmt.Tables))
+		}
+	})
+
+	t.Run("remove tables", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE interactive_demo REMOVE TABLES (orders, customers)")
+		if stmt.Action != ast.AlterWarehouseRemoveTables {
+			t.Fatalf("Action = %d, want RemoveTables", stmt.Action)
+		}
+		if len(stmt.Tables) != 2 {
+			t.Errorf("Tables = %v, want 2", objNames(stmt.Tables))
+		}
+	})
+
+	t.Run("drop tables aliases to remove", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE interactive_demo DROP TABLES (orders, customers)")
+		if stmt.Action != ast.AlterWarehouseRemoveTables {
+			t.Errorf("Action = %d, want RemoveTables (DROP TABLES is the same action)", stmt.Action)
+		}
+	})
+
+	t.Run("add tables qualified", func(t *testing.T) {
+		stmt := mustAlterWarehouse(t, "ALTER WAREHOUSE w ADD TABLES (db.sch.t1, sch.t2)")
+		if len(stmt.Tables) != 2 || stmt.Tables[0].String() != "db.sch.t1" || stmt.Tables[1].String() != "sch.t2" {
+			t.Errorf("Tables = %v", objNames(stmt.Tables))
+		}
+	})
+}
+
+func objNames(ns []*ast.ObjectName) []string {
+	out := make([]string, len(ns))
+	for i, n := range ns {
+		out[i] = n.String()
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Loc accuracy
+// ---------------------------------------------------------------------------
+
+func TestParseWarehouse_Loc(t *testing.T) {
+	input := "CREATE WAREHOUSE my_wh"
+	stmt := mustCreateWarehouse(t, input)
+	if stmt.Loc.Start != 0 || stmt.Loc.End != len(input) {
+		t.Errorf("CREATE Loc = %+v, want {0, %d}", stmt.Loc, len(input))
+	}
+
+	// CREATE OR REPLACE: Loc.Start anchors at the CREATE keyword (offset 0).
+	rinput := "CREATE OR REPLACE WAREHOUSE w WAREHOUSE_SIZE = SMALL"
+	rstmt := mustCreateWarehouse(t, rinput)
+	if rstmt.Loc.Start != 0 || rstmt.Loc.End != len(rinput) {
+		t.Errorf("CREATE OR REPLACE Loc = %+v, want {0, %d}", rstmt.Loc, len(rinput))
+	}
+
+	// ALTER sub-parsers set Loc.Start at the object-type keyword (WAREHOUSE), not
+	// the ALTER keyword, matching the established ALTER TABLE/STAGE convention.
+	ainput := "ALTER WAREHOUSE w RENAME TO w2"
+	const whKwOff = len("ALTER ")
+	astmt := mustAlterWarehouse(t, ainput)
+	if astmt.Loc.Start != whKwOff || astmt.Loc.End != len(ainput) {
+		t.Errorf("ALTER Loc = %+v, want {%d, %d}", astmt.Loc, whKwOff, len(ainput))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases — malformed statements must produce a parse error, not hang.
+// ---------------------------------------------------------------------------
+
+func TestParseWarehouse_Errors(t *testing.T) {
+	bad := []string{
+		"CREATE WAREHOUSE",                       // missing name
+		"CREATE WAREHOUSE w WAREHOUSE_SIZE =",    // option missing value
+		"ALTER WAREHOUSE",                        // missing name + action
+		"ALTER WAREHOUSE w",                      // missing action
+		"ALTER WAREHOUSE w RENAME",               // missing TO
+		"ALTER WAREHOUSE w RENAME TO",            // missing new name
+		"ALTER WAREHOUSE w SET",                  // nothing to set
+		"ALTER WAREHOUSE w SET WAREHOUSE_SIZE =", // set value missing
+		"ALTER WAREHOUSE w SET TAG",              // missing tag assignment
+		"ALTER WAREHOUSE w SET TAG t =",          // tag missing value
+		"ALTER WAREHOUSE w UNSET TAG",            // missing tag name
+		"ALTER WAREHOUSE w UNSET",                // missing key
+		"ALTER WAREHOUSE w UNSET ,",              // empty key
+		"ALTER WAREHOUSE w ABORT",                // missing ALL QUERIES
+		"ALTER WAREHOUSE w ABORT ALL",            // missing QUERIES
+		"ALTER WAREHOUSE w ADD",                  // missing TABLES
+		"ALTER WAREHOUSE w ADD TABLES",           // missing ( ... )
+		"ALTER WAREHOUSE w ADD TABLES ()",        // empty id list
+		"ALTER WAREHOUSE w ADD TABLES (a,",       // unterminated list
+		"ALTER WAREHOUSE w REMOVE TABLES",        // missing ( ... )
+		"ALTER WAREHOUSE w FROBNICATE",           // unknown action
+	}
+	for _, in := range bad {
+		t.Run(in, func(t *testing.T) {
+			result := ParseBestEffort(in)
+			if len(result.Errors) == 0 {
+				t.Errorf("expected parse error for %q, got none (stmts=%d)", in, len(result.File.Stmts))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/gap-warehouse` (phase-2 corpus-gap closure) — **CREATE WAREHOUSE** and **ALTER WAREHOUSE**, a real regression vs the legacy ANTLR parser (legacy has `create_warehouse`/`alter_warehouse`; omni `unsupported`ed them).

## Forms
- `CREATE [OR REPLACE | OR ALTER] WAREHOUSE [IF NOT EXISTS] <name> [WITH] <KEY = value>...` — properties parsed **open-ended** (`KEY = value` via the existing `CopyOption`/`parseCopyOption` machinery, mirroring STAGE/FILE FORMAT — keys are not hard-enumerated), so WAREHOUSE_SIZE/WAREHOUSE_TYPE/RESOURCE_CONSTRAINT/AUTO_RESUME/AUTO_SUSPEND/INITIALLY_SUSPENDED/GENERATION/COMMENT/MAX_CLUSTER_COUNT/... all parse without an enum to maintain.
- `ALTER WAREHOUSE [IF EXISTS] <name> { SET <prop>... | UNSET <key>,... | SET TAG.../UNSET TAG... | RESUME | SUSPEND | ABORT ALL QUERIES | RENAME TO <name> | ADD TABLES (...) | REMOVE/DROP TABLES (...) }`.

## Design
New `parser/warehouse.go` (CreateWarehouseStmt/AlterWarehouseStmt AST in `ast/parsenodes.go`+`nodetags.go`; walker regenerated via `go run ./cmd/genwalker`). CREATE dispatch in `create_table.go`, ALTER dispatch in `database_schema.go` — honoring the already-parsed OrReplace/OrAlter/IfNotExists flags. Real round-trippable deparse for both nodes (generic `writeCopyOption` helper). Every parse loop has a zero-token-progress guard + cap; every `go test` ran `-timeout 120s`.

## Corpus delta (TestCorpusClosure)
**576 → 591 clean (Split), 81 → 66 skipped — 15 files closed:** the 12 expected (create-warehouse 01–06 + alter-warehouse 01–06) + 3 skip-list self-prune cascades (`legacy/create.sql`; `create-database/example_10`+`_11`, whose lone statements are ALTER WAREHOUSE SET/UNSET). Kept (reasons updated): `create-warehouse/example_07` (only the `SHOW … ->> SELECT … FROM $1` result-pipe/`$N` gaps remain — the CREATE OR ALTER WAREHOUSE statements verified parsing) and `create-materialized-view/example_02` (INTERACTIVE MV owned elsewhere; its ALTER WAREHOUSE ADD TABLES now parses).

## Review (`/code-review` high; Codex down) — 1 real bug found + fixed
**`UNSET TAG` silent mis-parse**: `ALTER WAREHOUSE w UNSET TAG t` parsed with no error as UNSET keys `["TAG","t"]` (semantic corruption) and `SET TAG …` hard-errored. Legacy `alter_warehouse_opts` + official docs support SET/UNSET TAG. Fixed by anchoring TAG before the open-ended run (reusing the stage parser's `parseTagSetList`/`parseUnsetTagNameList`) + dedicated AST actions/deparse + regression test. Orchestrator independently verified on a fresh checkout of the pushed commit: gofmt/vet/build clean, full `go test ./snowflake/... -timeout 120s` green (8 pkgs), corpus self-prune green.

## Divergences (recorded)
- `ALTER WAREHOUSE … DROP TABLES`/`REMOVE TABLES` map to one AST action (deparse normalizes to `REMOVE`).
- Property keys uppercased in `CopyOption.Name`; deparse drops the cosmetic leading `WITH` — all AST-equivalent on round-trip.

## Note
Opened by orchestrator from verified pushed commit `e84e688d`. No code modified. First of 9 phase-2 gap nodes (close the 81 documented corpus gaps before `bytebase-switch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
