### PR TITLE
feat(snowflake): CREATE / ALTER / DROP NETWORK RULE (phase-2 gap-network-rule) — close corpus gap 170

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -170,6 +170,10 @@ const (
 	T_CreateWarehouseStmt
 	T_AlterWarehouseStmt
 
+	// Network rule DDL tags (gap-network-rule)
+	T_CreateNetworkRuleStmt
+	T_AlterNetworkRuleStmt
+
 	// Access-control DDL tags (T4.6)
 	T_PolicyArg
 	T_CreateRoleStmt
@@ -452,6 +456,10 @@ func (t NodeTag) String() string {
 		return "CreateWarehouseStmt"
 	case T_AlterWarehouseStmt:
 		return "AlterWarehouseStmt"
+	case T_CreateNetworkRuleStmt:
+		return "CreateNetworkRuleStmt"
+	case T_AlterNetworkRuleStmt:
+		return "AlterNetworkRuleStmt"
 	case T_PolicyArg:
 		return "PolicyArg"
 	case T_CreateRoleStmt:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1556,6 +1556,7 @@ const (
 	DropTag                             // DROP TAG
 	DropRole                            // DROP ROLE
 	DropWarehouse                       // DROP WAREHOUSE
+	DropNetworkRule                     // DROP NETWORK RULE
 )
 
 // String returns the SQL object-type keyword for the kind.
@@ -1593,6 +1594,8 @@ func (k DropObjectKind) String() string {
 		return "ROLE"
 	case DropWarehouse:
 		return "WAREHOUSE"
+	case DropNetworkRule:
+		return "NETWORK RULE"
 	default:
 		return "UNKNOWN"
 	}
@@ -5084,6 +5087,71 @@ func (n *AlterWarehouseStmt) Tag() NodeTag { return T_AlterWarehouseStmt }
 var (
 	_ Node = (*CreateWarehouseStmt)(nil)
 	_ Node = (*AlterWarehouseStmt)(nil)
+)
+
+// ---------------------------------------------------------------------------
+// NETWORK RULE DDL statement nodes (gap-network-rule)
+// ---------------------------------------------------------------------------
+//
+// A network rule carries a small but version-growing set of `KEY = value`
+// properties — TYPE (IPV4 / IPV6 / AWSVPCEID / HOST_PORT / PRIVATE_HOST_PORT /
+// COMPUTE_POOL / ...), VALUE_LIST = ( '...' [ , ... ] ), MODE (INGRESS /
+// EGRESS / INTERNAL_STAGE / ...), and COMMENT. Rather than enumerate the
+// (already-growing) TYPE / MODE vocabularies, every property is parsed as an
+// open-ended `KEY = <value>` pair (ast.CopyOption), reusing the COPY (T5.2)
+// option machinery exactly as STAGE (T4.1), FILE FORMAT (T4.2) and WAREHOUSE
+// (gap-warehouse) do. The parenthesized VALUE_LIST string list is already a
+// native CopyOption value shape (List). Property order is free.
+
+// CreateNetworkRuleStmt represents
+//
+//	CREATE [ OR REPLACE ] NETWORK RULE [ IF NOT EXISTS ] <name> <prop> [ <prop> ... ]
+//
+// where each <prop> is an open-ended `KEY = value` pair (TYPE, VALUE_LIST,
+// MODE, COMMENT, ...). Options preserves source order.
+type CreateNetworkRuleStmt struct {
+	OrReplace   bool
+	IfNotExists bool
+	Name        *ObjectName
+	Options     []*CopyOption // open-ended network-rule properties (TYPE / VALUE_LIST / MODE / COMMENT / ...)
+	Loc         Loc
+}
+
+// Tag implements Node.
+func (n *CreateNetworkRuleStmt) Tag() NodeTag { return T_CreateNetworkRuleStmt }
+
+// AlterNetworkRuleAction discriminates the action variants of ALTER NETWORK
+// RULE.
+type AlterNetworkRuleAction int
+
+const (
+	AlterNetworkRuleSet   AlterNetworkRuleAction = iota // SET <prop> [ <prop> ... ]
+	AlterNetworkRuleUnset                               // UNSET <key> [ , ... ]
+)
+
+// AlterNetworkRuleStmt represents
+//
+//	ALTER NETWORK RULE [ IF EXISTS ] <name> { SET <prop>... | UNSET <key>,... }
+//
+// SET carries an open-ended `KEY = value` property run (VALUE_LIST, COMMENT,
+// ...) in Options; UNSET carries the uppercased key names (VALUE_LIST,
+// COMMENT, ...) in UnsetKeys.
+type AlterNetworkRuleStmt struct {
+	IfExists  bool
+	Name      *ObjectName
+	Action    AlterNetworkRuleAction
+	Options   []*CopyOption // SET <props>; for AlterNetworkRuleSet
+	UnsetKeys []string      // UNSET <key> [ , ... ]; for AlterNetworkRuleUnset
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *AlterNetworkRuleStmt) Tag() NodeTag { return T_AlterNetworkRuleStmt }
+
+// Compile-time assertions for network-rule DDL nodes.
+var (
+	_ Node = (*CreateNetworkRuleStmt)(nil)
+	_ Node = (*AlterNetworkRuleStmt)(nil)
 )
 
 // ---------------------------------------------------------------------------

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -63,6 +63,10 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.NewName)
 		}
 		walkNodes(v, n.ClusterBy)
+	case *AlterNetworkRuleStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *AlterPipeStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
@@ -312,6 +316,10 @@ func walkChildren(v Visitor, node Node) {
 		}
 		walkNodes(v, n.ClusterBy)
 		Walk(v, n.Query)
+	case *CreateNetworkRuleStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *CreatePipeStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)

--- a/snowflake/deparse/deparse.go
+++ b/snowflake/deparse/deparse.go
@@ -113,6 +113,12 @@ func (w *writer) writeNode(node ast.Node) error {
 	case *ast.AlterWarehouseStmt:
 		return w.writeAlterWarehouseStmt(n)
 
+	// --- DDL: network rule ---
+	case *ast.CreateNetworkRuleStmt:
+		return w.writeCreateNetworkRuleStmt(n)
+	case *ast.AlterNetworkRuleStmt:
+		return w.writeAlterNetworkRuleStmt(n)
+
 	// --- Expressions (can also be top-level in some contexts) ---
 	case *ast.Literal,
 		*ast.ColumnRef,

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -1294,3 +1294,46 @@ func (w *writer) writeAlterWarehouseStmt(n *ast.AlterWarehouseStmt) error {
 	}
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// CREATE NETWORK RULE / ALTER NETWORK RULE (gap-network-rule)
+// ---------------------------------------------------------------------------
+
+func (w *writer) writeCreateNetworkRuleStmt(n *ast.CreateNetworkRuleStmt) error {
+	w.buf.WriteString("CREATE")
+	if n.OrReplace {
+		w.buf.WriteString(" OR REPLACE")
+	}
+	w.buf.WriteString(" NETWORK RULE")
+	if n.IfNotExists {
+		w.buf.WriteString(" IF NOT EXISTS")
+	}
+	w.buf.WriteByte(' ')
+	w.writeObjectNameNoSpace(n.Name)
+	if err := w.writeCopyOptions(n.Options); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *writer) writeAlterNetworkRuleStmt(n *ast.AlterNetworkRuleStmt) error {
+	w.buf.WriteString("ALTER NETWORK RULE")
+	if n.IfExists {
+		w.buf.WriteString(" IF EXISTS")
+	}
+	w.buf.WriteByte(' ')
+	w.writeObjectNameNoSpace(n.Name)
+	switch n.Action {
+	case ast.AlterNetworkRuleSet:
+		w.buf.WriteString(" SET")
+		if err := w.writeCopyOptions(n.Options); err != nil {
+			return err
+		}
+	case ast.AlterNetworkRuleUnset:
+		w.buf.WriteString(" UNSET ")
+		w.buf.WriteString(strings.Join(n.UnsetKeys, ", "))
+	default:
+		return fmt.Errorf("deparse: unsupported ALTER NETWORK RULE action %d", n.Action)
+	}
+	return nil
+}

--- a/snowflake/deparse/network_rule_deparse_test.go
+++ b/snowflake/deparse/network_rule_deparse_test.go
@@ -1,0 +1,68 @@
+package deparse_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/deparse"
+	"github.com/bytebase/omni/snowflake/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NETWORK RULE DDL round-trips (gap-network-rule)
+//
+// assertRoundTrip compares ASTs (Loc-stripped), so cosmetic normalizations the
+// deparser applies — uppercasing option names/keys, normalizing whitespace —
+// are expected and verified to be AST-equivalent.
+// ---------------------------------------------------------------------------
+
+func TestDeparse_CreateNetworkRule(t *testing.T) {
+	assertRoundTrip(t, "CREATE NETWORK RULE corporate_network TYPE = AWSVPCEID VALUE_LIST = ('vpce-123abc3420c1931') MODE = INTERNAL_STAGE COMMENT = 'corporate privatelink endpoint'")
+	assertRoundTrip(t, "CREATE NETWORK RULE cloud_network TYPE = IPV4 VALUE_LIST = ('47.88.25.32/27') COMMENT = 'cloud egress ip range'")
+	assertRoundTrip(t, "CREATE NETWORK RULE gcp_rule TYPE = GCPPSCID MODE = INGRESS VALUE_LIST = ('31618973889077266')")
+	assertRoundTrip(t, "CREATE NETWORK RULE external_access_rule TYPE = HOST_PORT MODE = EGRESS VALUE_LIST = ('example.com', 'example.com:443')")
+	assertRoundTrip(t, "CREATE OR REPLACE NETWORK RULE ext_db.network_rules.azure_rule MODE = EGRESS TYPE = PRIVATE_HOST_PORT VALUE_LIST = ('externalaccessdemo.database.windows.net')")
+	assertRoundTrip(t, "CREATE NETWORK RULE IF NOT EXISTS r TYPE = IPV4 VALUE_LIST = ('0.0.0.0/0')")
+}
+
+func TestDeparse_AlterNetworkRule(t *testing.T) {
+	assertRoundTrip(t, "ALTER NETWORK RULE r SET VALUE_LIST = ('1.2.3.4', '5.6.7.8')")
+	assertRoundTrip(t, "ALTER NETWORK RULE r SET VALUE_LIST = ('1.2.3.4') COMMENT = 'updated'")
+	assertRoundTrip(t, "ALTER NETWORK RULE IF EXISTS r SET COMMENT = 'just a comment'")
+	assertRoundTrip(t, "ALTER NETWORK RULE r UNSET VALUE_LIST")
+	assertRoundTrip(t, "ALTER NETWORK RULE r UNSET VALUE_LIST, COMMENT")
+}
+
+func TestDeparse_DropNetworkRule(t *testing.T) {
+	assertRoundTrip(t, "DROP NETWORK RULE r")
+	assertRoundTrip(t, "DROP NETWORK RULE IF EXISTS db.sch.r")
+}
+
+// TestDeparse_NetworkRule_ExactString pins the exact deparsed output for a
+// representative CREATE and ALTER, guarding the keyword spelling and spacing.
+func TestDeparse_NetworkRule_ExactString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{
+			in:   "CREATE OR REPLACE NETWORK RULE r TYPE = ipv4 VALUE_LIST = ('1.2.3.4')",
+			want: "CREATE OR REPLACE NETWORK RULE r TYPE = IPV4 VALUE_LIST = ('1.2.3.4')",
+		},
+		{
+			in:   "ALTER NETWORK RULE r UNSET value_list, comment",
+			want: "ALTER NETWORK RULE r UNSET VALUE_LIST, COMMENT",
+		},
+		{
+			in:   "DROP NETWORK RULE IF EXISTS r",
+			want: "DROP NETWORK RULE IF EXISTS r",
+		},
+	}
+	for _, c := range cases {
+		f, err := parser.Parse(c.in)
+		require.NoError(t, err, "parse %q", c.in)
+		out, err := deparse.DeparseFile(f)
+		require.NoError(t, err, "deparse %q", c.in)
+		require.Equal(t, c.want, out)
+	}
+}

--- a/snowflake/parser/copy.go
+++ b/snowflake/parser/copy.go
@@ -430,6 +430,19 @@ func (p *Parser) curIsWord(upper string) bool {
 	return strings.ToUpper(p.cur.Str) == upper
 }
 
+// peekIsWord reports whether the next token (one past cur) has the given
+// uppercase spelling, treating keyword and identifier tokens uniformly by
+// their text. Used for one-token lookahead disambiguation of non-reserved
+// object qualifiers (e.g. NETWORK RULE vs NETWORK POLICY, where RULE is not a
+// reserved keyword).
+func (p *Parser) peekIsWord(upper string) bool {
+	next := p.peekNext()
+	if next.Str == "" {
+		return false
+	}
+	return strings.ToUpper(next.Str) == upper
+}
+
 // lookaheadColonSlashSlash reports whether the source immediately following the
 // current token is "://" — i.e. the current 'file' word begins a file:// URI.
 // It inspects the raw source rather than tokens because '//' is lexed as a

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -202,13 +202,6 @@ var corpusSkips = map[string]string{
 	"official/create-hybrid-table/example_16.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
 	"official/drop-table/example_05.sql":          "CONTEXT: setup is CREATE OR REPLACE HYBRID TABLE (drop-table page) — hybrid-table object node not built",
 
-	// --- RESIDUAL GAP: CREATE NETWORK RULE (object node not built; NETWORK POLICY is) ---
-	"official/create-network-rule/example_01.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built (NETWORK POLICY is)",
-	"official/create-network-rule/example_02.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
-	"official/create-network-rule/example_03.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
-	"official/create-network-rule/example_04.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
-	"official/create-network-rule/example_05.sql": "RESIDUAL GAP: CREATE NETWORK RULE — object node not built",
-
 	// --- RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (object node not built) ---
 	// The ALTER WAREHOUSE ADD TABLES statement in this file now parses
 	// (gap-warehouse); it remains skipped only for the CREATE INTERACTIVE

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -219,6 +219,14 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		// CREATE [OR REPLACE] USER ... (T4.6).
 		return p.parseCreateUserStmt(start, orReplace, orAlter)
 	case kwMASKING, kwSESSION, kwPASSWORD, kwNETWORK, kwROW:
+		// CREATE [OR REPLACE] NETWORK RULE ... (gap-network-rule) vs the policy
+		// objects below. NETWORK is reserved but RULE is not, so NETWORK RULE lexes
+		// as kwNETWORK followed by a "RULE" identifier; NETWORK POLICY lexes as
+		// kwNETWORK followed by kwPOLICY. The RULE form is dispatched here before the
+		// shared policy path.
+		if p.cur.Type == kwNETWORK && p.peekIsWord("RULE") {
+			return p.parseCreateNetworkRuleStmt(start, orReplace)
+		}
 		// CREATE [OR REPLACE] { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK }
 		// POLICY ... (T4.6). parseCreatePolicyDispatch consumes the kind keyword(s)
 		// and the POLICY keyword, then delegates. A leading keyword not followed by

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -256,6 +256,13 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// ALTER USER ... (T4.6).
 		return p.parseAlterUserStmt()
 	case kwMASKING, kwSESSION, kwPASSWORD, kwNETWORK, kwROW:
+		// ALTER NETWORK RULE ... (gap-network-rule) vs the policy objects below.
+		// NETWORK is reserved but RULE is not, so NETWORK RULE lexes as kwNETWORK
+		// followed by a "RULE" identifier; NETWORK POLICY lexes as kwNETWORK followed
+		// by kwPOLICY. The RULE form is dispatched here before the shared policy path.
+		if p.cur.Type == kwNETWORK && p.peekIsWord("RULE") {
+			return p.parseAlterNetworkRuleStmt()
+		}
 		// ALTER { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK } POLICY ...
 		// (T4.6). Only routed to the policy parser when the kind keyword is actually
 		// followed by POLICY (and, for ROW, ACCESS POLICY); otherwise a same-prefix

--- a/snowflake/parser/drop.go
+++ b/snowflake/parser/drop.go
@@ -105,20 +105,39 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 		p.advance() // consume WAREHOUSE
 		return p.parseDropObject(ast.DropWarehouse, start, true, false)
 
+	case kwNETWORK:
+		// DROP NETWORK RULE (gap-network-rule). NETWORK is reserved but RULE is not,
+		// so NETWORK RULE lexes as kwNETWORK followed by a "RULE" identifier. Only the
+		// RULE form is handled here; other NETWORK objects (e.g. NETWORK POLICY) are
+		// reported as unsupported.
+		if p.peekIsWord("RULE") {
+			p.advance() // consume NETWORK
+			p.advance() // consume RULE
+			return p.parseDropObject(ast.DropNetworkRule, start, true, false)
+		}
+		return p.unsupportedDrop()
+
 	default:
 		// Emit a targeted error for recognized-but-unimplemented DROP forms,
 		// or a generic error for completely unknown object types.
-		objText := p.cur.Str
-		if objText == "" {
-			objText = TokenName(p.cur.Type)
-		}
-		err := &ParseError{
-			Loc: p.cur.Loc,
-			Msg: "DROP " + objText + " statement parsing is not yet supported",
-		}
-		p.skipToNextStatement()
-		return nil, err
+		return p.unsupportedDrop()
 	}
+}
+
+// unsupportedDrop emits a targeted "DROP <obj> ... not yet supported" error for
+// a recognized-but-unimplemented (or unknown) DROP object type at cur, and
+// skips to the next statement for error recovery.
+func (p *Parser) unsupportedDrop() (ast.Node, error) {
+	objText := p.cur.Str
+	if objText == "" {
+		objText = TokenName(p.cur.Type)
+	}
+	err := &ParseError{
+		Loc: p.cur.Loc,
+		Msg: "DROP " + objText + " statement parsing is not yet supported",
+	}
+	p.skipToNextStatement()
+	return nil, err
 }
 
 // parseDropObject is the shared helper that parses the [IF EXISTS] name

--- a/snowflake/parser/network_rule.go
+++ b/snowflake/parser/network_rule.go
@@ -1,0 +1,206 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Network rule DDL — CREATE / ALTER / DROP NETWORK RULE (gap-network-rule)
+// ---------------------------------------------------------------------------
+//
+// A network rule carries a small, version-growing set of `KEY = value`
+// properties (TYPE, VALUE_LIST, MODE, COMMENT, ...). The TYPE and MODE
+// vocabularies grow with the service (IPV4 / IPV6 / AWSVPCEID / AZURELINKID /
+// GCPPSCID / HOST_PORT / PRIVATE_HOST_PORT / COMPUTE_POOL / ...; INGRESS /
+// EGRESS / INTERNAL_STAGE / SNOWFLAKE_MANAGED_STORAGE_VOLUME / ...). Rather
+// than enumerate them, every property is parsed as an open-ended `KEY =
+// <value>` pair (ast.CopyOption), reusing the COPY (T5.2) machinery
+// (parseCopyOption / startsCopyOption) exactly as STAGE (T4.1), FILE FORMAT
+// (T4.2) and WAREHOUSE (gap-warehouse) do. The parenthesized
+// VALUE_LIST = ( '<str>' [ , ... ] ) string list is already a native
+// CopyOption value shape (List). Property order is free; the catalog/semantic
+// layer, not the parser, validates that a property is real.
+//
+// NETWORK RULE is distinguished from the pre-existing NETWORK POLICY object at
+// dispatch: NETWORK is a reserved keyword but RULE is not, so `NETWORK RULE`
+// lexes as kwNETWORK followed by a "RULE" identifier (curIsWord), whereas
+// `NETWORK POLICY` lexes as kwNETWORK followed by kwPOLICY.
+
+// networkRuleOptionCap bounds an open-ended network-rule property run. Real
+// statements carry a handful of properties; a far larger run signals a runaway
+// parse and aborts loudly rather than spinning.
+const networkRuleOptionCap = 1024
+
+// ---------------------------------------------------------------------------
+// CREATE NETWORK RULE
+// ---------------------------------------------------------------------------
+
+// parseCreateNetworkRuleStmt parses the body of a
+//
+//	CREATE [ OR REPLACE ] NETWORK RULE [ IF NOT EXISTS ] <name>
+//	  <prop> [ <prop> ... ]
+//
+// statement, where each <prop> is an open-ended `KEY = value` pair (TYPE,
+// VALUE_LIST, MODE, COMMENT, ...). The CREATE keyword and the optional OR
+// REPLACE modifier have already been consumed by parseCreateStmt; start is the
+// Loc of the CREATE token, and cur is the NETWORK keyword.
+func (p *Parser) parseCreateNetworkRuleStmt(start ast.Loc, orReplace bool) (ast.Node, error) {
+	p.advance() // consume NETWORK
+	// RULE is not a reserved keyword; the dispatcher confirmed it via curIsWord.
+	if !p.curIsWord("RULE") {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // consume RULE
+
+	stmt := &ast.CreateNetworkRuleStmt{
+		OrReplace: orReplace,
+		Loc:       ast.Loc{Start: start.Start},
+	}
+
+	// IF NOT EXISTS (lenient; the official grammar omits it, but it is accepted
+	// here to mirror the other CREATE-object parsers).
+	if p.cur.Type == kwIF && p.peekNext().Type == kwNOT {
+		p.advance() // consume IF
+		p.advance() // consume NOT
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
+	// Network rule name (optionally qualified db.schema.name).
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Open-ended `KEY = value` property run. The loop ends at a statement
+	// boundary or any token that does not begin a property. The loop-guard
+	// aborts if an iteration fails to consume any token.
+	opts, err := p.parseNetworkRuleOptions()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Options = opts
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER NETWORK RULE
+// ---------------------------------------------------------------------------
+
+// parseAlterNetworkRuleStmt parses
+//
+//	ALTER NETWORK RULE [ IF EXISTS ] <name> { SET <prop>... | UNSET <key>,... }
+//
+// The ALTER keyword has already been consumed; cur is the NETWORK keyword.
+// SET carries an open-ended `KEY = value` property run (VALUE_LIST, COMMENT,
+// ...); UNSET carries a comma-separated key-name list (VALUE_LIST, COMMENT,
+// ...). The surface is kept lenient and open-ended, mirroring ALTER WAREHOUSE.
+func (p *Parser) parseAlterNetworkRuleStmt() (ast.Node, error) {
+	netTok := p.advance() // consume NETWORK (anchors Loc.Start at the object keyword)
+	if !p.curIsWord("RULE") {
+		return nil, p.syntaxErrorAtCur()
+	}
+	p.advance() // consume RULE
+
+	stmt := &ast.AlterNetworkRuleStmt{Loc: ast.Loc{Start: netTok.Loc.Start}}
+
+	// Optional IF EXISTS.
+	if p.cur.Type == kwIF && p.peekNext().Type == kwEXISTS {
+		p.advance() // consume IF
+		p.advance() // consume EXISTS
+		stmt.IfExists = true
+	}
+
+	// Network rule name.
+	name, err := p.parseObjectName()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	// Action branch.
+	switch p.cur.Type {
+	case kwSET:
+		p.advance() // consume SET
+		opts, err := p.parseNetworkRuleOptions()
+		if err != nil {
+			return nil, err
+		}
+		if len(opts) == 0 {
+			// SET with nothing settable is a syntax error.
+			return nil, p.syntaxErrorAtCur()
+		}
+		stmt.Action = ast.AlterNetworkRuleSet
+		stmt.Options = opts
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		keys, err := p.parseNetworkRuleUnsetKeys()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterNetworkRuleUnset
+		stmt.UnsetKeys = keys
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared network-rule helpers
+// ---------------------------------------------------------------------------
+
+// parseNetworkRuleOptions parses a run of zero or more network-rule properties,
+// each an open-ended `KEY = <value>` pair (reusing parseCopyOption). The run
+// continues while the current token begins another property and terminates at a
+// statement boundary or any token that does not begin a property. A loop-guard
+// aborts if an iteration consumes no tokens.
+func (p *Parser) parseNetworkRuleOptions() ([]*ast.CopyOption, error) {
+	var opts []*ast.CopyOption
+	for i := 0; p.startsCopyOption(); i++ {
+		if i >= networkRuleOptionCap {
+			return nil, p.syntaxErrorAtCur()
+		}
+		before := p.cur.Loc.Start
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+		if p.cur.Loc.Start == before && p.cur.Type != tokEOF {
+			// No forward progress on a non-EOF token: abort rather than spin.
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	return opts, nil
+}
+
+// parseNetworkRuleUnsetKeys parses an UNSET <key> [ , ... ] property-name list.
+// Each key is a single name word (identifier or keyword), uppercased; a comma
+// separates keys. Consumes at least one key.
+func (p *Parser) parseNetworkRuleUnsetKeys() ([]string, error) {
+	var keys []string
+	for {
+		if !p.isOptionWord(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		keys = append(keys, strings.ToUpper(p.advance().Str))
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return keys, nil
+}

--- a/snowflake/parser/network_rule_test.go
+++ b/snowflake/parser/network_rule_test.go
@@ -1,0 +1,362 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCreateNetworkRule(t *testing.T, input string) *ast.CreateNetworkRuleStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.CreateNetworkRuleStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.CreateNetworkRuleStmt", input, node)
+	}
+	return stmt
+}
+
+func mustAlterNetworkRule(t *testing.T, input string) *ast.AlterNetworkRuleStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterNetworkRuleStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterNetworkRuleStmt", input, node)
+	}
+	return stmt
+}
+
+func mustDropNetworkRule(t *testing.T, input string) *ast.DropStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.DropStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.DropStmt", input, node)
+	}
+	return stmt
+}
+
+// optList returns the parenthesized literal-list values of a CopyOption by
+// name (e.g. VALUE_LIST = ('a', 'b')), or nil if the option is absent / not a
+// list.
+func optList(opts []*ast.CopyOption, name string) []*ast.Literal {
+	o := findOption(opts, name)
+	if o == nil {
+		return nil
+	}
+	return o.List
+}
+
+// ---------------------------------------------------------------------------
+// CREATE NETWORK RULE — corpus shapes
+// ---------------------------------------------------------------------------
+
+func TestParseCreateNetworkRule_Corpus(t *testing.T) {
+	// example_01: TYPE = AWSVPCEID, parenthesized single-element VALUE_LIST,
+	// MODE = INTERNAL_STAGE, COMMENT.
+	t.Run("example_01", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE NETWORK RULE corporate_network\n"+
+			"  TYPE = AWSVPCEID\n"+
+			"  VALUE_LIST = ('vpce-123abc3420c1931')\n"+
+			"  MODE = INTERNAL_STAGE\n"+
+			"  COMMENT = 'corporate privatelink endpoint'")
+		if stmt.Name.String() != "corporate_network" {
+			t.Errorf("Name = %q, want corporate_network", stmt.Name.String())
+		}
+		if stmt.OrReplace || stmt.IfNotExists {
+			t.Errorf("unexpected modifier set: %+v", stmt)
+		}
+		if w, ok := optWords(stmt.Options, "TYPE"); !ok || w != "AWSVPCEID" {
+			t.Errorf("TYPE = %q (ok=%v), want AWSVPCEID", w, ok)
+		}
+		if w, ok := optWords(stmt.Options, "MODE"); !ok || w != "INTERNAL_STAGE" {
+			t.Errorf("MODE = %q (ok=%v), want INTERNAL_STAGE", w, ok)
+		}
+		if c, ok := optLitString(stmt.Options, "COMMENT"); !ok || c != "corporate privatelink endpoint" {
+			t.Errorf("COMMENT = %q (ok=%v)", c, ok)
+		}
+		vl := optList(stmt.Options, "VALUE_LIST")
+		if len(vl) != 1 || vl[0].Value != "vpce-123abc3420c1931" {
+			t.Errorf("VALUE_LIST = %+v, want single 'vpce-123abc3420c1931'", vl)
+		}
+	})
+
+	// example_02: TYPE = IPV4, no MODE, COMMENT.
+	t.Run("example_02", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE NETWORK RULE cloud_network\n"+
+			"  TYPE = IPV4\n"+
+			"  VALUE_LIST = ('47.88.25.32/27')\n"+
+			"  COMMENT = 'cloud egress ip range'")
+		if w, ok := optWords(stmt.Options, "TYPE"); !ok || w != "IPV4" {
+			t.Errorf("TYPE = %q (ok=%v), want IPV4", w, ok)
+		}
+		if findOption(stmt.Options, "MODE") != nil {
+			t.Errorf("unexpected MODE option present")
+		}
+		vl := optList(stmt.Options, "VALUE_LIST")
+		if len(vl) != 1 || vl[0].Value != "47.88.25.32/27" {
+			t.Errorf("VALUE_LIST = %+v", vl)
+		}
+	})
+
+	// example_03: property order MODE before VALUE_LIST; no COMMENT.
+	t.Run("example_03_free_order", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE NETWORK RULE gcp_rule\n"+
+			"  TYPE = GCPPSCID\n"+
+			"  MODE = INGRESS\n"+
+			"  VALUE_LIST = ('31618973889077266')")
+		if w, ok := optWords(stmt.Options, "TYPE"); !ok || w != "GCPPSCID" {
+			t.Errorf("TYPE = %q (ok=%v), want GCPPSCID", w, ok)
+		}
+		if w, ok := optWords(stmt.Options, "MODE"); !ok || w != "INGRESS" {
+			t.Errorf("MODE = %q (ok=%v), want INGRESS", w, ok)
+		}
+		if len(stmt.Options) != 3 {
+			t.Errorf("expected 3 options, got %d: %+v", len(stmt.Options), stmt.Options)
+		}
+	})
+
+	// example_04: HOST_PORT with a multi-element VALUE_LIST.
+	t.Run("example_04_multi_value_list", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE NETWORK RULE external_access_rule\n"+
+			"  TYPE = HOST_PORT\n"+
+			"  MODE = EGRESS\n"+
+			"  VALUE_LIST = ('example.com', 'example.com:443')")
+		vl := optList(stmt.Options, "VALUE_LIST")
+		if len(vl) != 2 {
+			t.Fatalf("VALUE_LIST len = %d, want 2: %+v", len(vl), vl)
+		}
+		if vl[0].Value != "example.com" || vl[1].Value != "example.com:443" {
+			t.Errorf("VALUE_LIST = [%q, %q]", vl[0].Value, vl[1].Value)
+		}
+	})
+
+	// example_05: CREATE OR REPLACE + 3-part qualified name + free property order.
+	t.Run("example_05_or_replace_qualified", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE OR REPLACE NETWORK RULE ext_network_access_db.network_rules.azure_sql_private_rule\n"+
+			"  MODE = EGRESS\n"+
+			"  TYPE = PRIVATE_HOST_PORT\n"+
+			"  VALUE_LIST = ('externalaccessdemo.database.windows.net')")
+		if !stmt.OrReplace {
+			t.Errorf("OrReplace = false, want true")
+		}
+		if stmt.Name.Database.String() != "ext_network_access_db" ||
+			stmt.Name.Schema.String() != "network_rules" ||
+			stmt.Name.Name.String() != "azure_sql_private_rule" {
+			t.Errorf("qualified name = %q (db=%q schema=%q name=%q)",
+				stmt.Name.String(), stmt.Name.Database, stmt.Name.Schema, stmt.Name.Name)
+		}
+		if w, ok := optWords(stmt.Options, "TYPE"); !ok || w != "PRIVATE_HOST_PORT" {
+			t.Errorf("TYPE = %q (ok=%v), want PRIVATE_HOST_PORT", w, ok)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CREATE NETWORK RULE — modifiers, name, IF NOT EXISTS, Loc
+// ---------------------------------------------------------------------------
+
+func TestParseCreateNetworkRule_Modifiers(t *testing.T) {
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE NETWORK RULE IF NOT EXISTS r TYPE = IPV4 VALUE_LIST = ('0.0.0.0/0')")
+		if !stmt.IfNotExists {
+			t.Errorf("IfNotExists = false, want true")
+		}
+		if stmt.OrReplace {
+			t.Errorf("OrReplace = true, want false")
+		}
+		if stmt.Name.String() != "r" {
+			t.Errorf("Name = %q, want r", stmt.Name.String())
+		}
+	})
+
+	t.Run("or replace if not exists", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, "CREATE OR REPLACE NETWORK RULE r TYPE = IPV4 VALUE_LIST = ('0.0.0.0/0')")
+		if !stmt.OrReplace {
+			t.Errorf("OrReplace = false, want true")
+		}
+	})
+
+	t.Run("quoted identifier name", func(t *testing.T) {
+		stmt := mustCreateNetworkRule(t, `CREATE NETWORK RULE "My Rule" TYPE = IPV4 VALUE_LIST = ('1.2.3.4')`)
+		if stmt.Name.Name.String() != `"My Rule"` {
+			t.Errorf("Name = %q", stmt.Name.Name.String())
+		}
+	})
+}
+
+func TestParseCreateNetworkRule_Loc(t *testing.T) {
+	input := "CREATE NETWORK RULE r TYPE = IPV4 VALUE_LIST = ('1.2.3.4')"
+	stmt := mustCreateNetworkRule(t, input)
+	if stmt.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", stmt.Loc.Start)
+	}
+	if int(stmt.Loc.End) != len(input) {
+		t.Errorf("Loc.End = %d, want %d (whole statement)", stmt.Loc.End, len(input))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NETWORK RULE vs NETWORK POLICY disambiguation
+// ---------------------------------------------------------------------------
+
+func TestParseNetworkRule_NotPolicy(t *testing.T) {
+	// CREATE NETWORK POLICY must still route to the policy parser, not the rule
+	// parser — the kwNETWORK case must not swallow POLICY as a rule.
+	node := mustParseOne(t, "CREATE NETWORK POLICY my_pol ALLOWED_IP_LIST = ('1.2.3.4')")
+	if _, ok := node.(*ast.CreateNetworkRuleStmt); ok {
+		t.Fatalf("CREATE NETWORK POLICY mis-routed to CreateNetworkRuleStmt")
+	}
+	if _, ok := node.(*ast.CreatePolicyStmt); !ok {
+		t.Errorf("CREATE NETWORK POLICY = %T, want *ast.CreatePolicyStmt", node)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER NETWORK RULE
+// ---------------------------------------------------------------------------
+
+func TestParseAlterNetworkRule_Set(t *testing.T) {
+	t.Run("set value_list", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE r SET VALUE_LIST = ('1.2.3.4', '5.6.7.8')")
+		if stmt.Action != ast.AlterNetworkRuleSet {
+			t.Errorf("Action = %d, want Set", stmt.Action)
+		}
+		vl := optList(stmt.Options, "VALUE_LIST")
+		if len(vl) != 2 {
+			t.Errorf("VALUE_LIST len = %d, want 2", len(vl))
+		}
+	})
+
+	t.Run("set value_list and comment", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE r SET VALUE_LIST = ('1.2.3.4') COMMENT = 'updated'")
+		if c, ok := optLitString(stmt.Options, "COMMENT"); !ok || c != "updated" {
+			t.Errorf("COMMENT = %q (ok=%v)", c, ok)
+		}
+	})
+
+	t.Run("set comment only", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE r SET COMMENT = 'just a comment'")
+		if len(stmt.Options) != 1 {
+			t.Errorf("expected 1 option, got %d", len(stmt.Options))
+		}
+	})
+
+	t.Run("if exists", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE IF EXISTS r SET VALUE_LIST = ('1.2.3.4')")
+		if !stmt.IfExists {
+			t.Errorf("IfExists = false, want true")
+		}
+	})
+
+	t.Run("qualified name", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE db.sch.r SET COMMENT = 'x'")
+		if stmt.Name.String() != "db.sch.r" {
+			t.Errorf("Name = %q, want db.sch.r", stmt.Name.String())
+		}
+	})
+}
+
+func TestParseAlterNetworkRule_Unset(t *testing.T) {
+	t.Run("unset value_list", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE r UNSET VALUE_LIST")
+		if stmt.Action != ast.AlterNetworkRuleUnset {
+			t.Errorf("Action = %d, want Unset", stmt.Action)
+		}
+		if len(stmt.UnsetKeys) != 1 || stmt.UnsetKeys[0] != "VALUE_LIST" {
+			t.Errorf("UnsetKeys = %v, want [VALUE_LIST]", stmt.UnsetKeys)
+		}
+	})
+
+	t.Run("unset comment", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE r UNSET COMMENT")
+		if len(stmt.UnsetKeys) != 1 || stmt.UnsetKeys[0] != "COMMENT" {
+			t.Errorf("UnsetKeys = %v, want [COMMENT]", stmt.UnsetKeys)
+		}
+	})
+
+	t.Run("unset multiple keys", func(t *testing.T) {
+		stmt := mustAlterNetworkRule(t, "ALTER NETWORK RULE r UNSET VALUE_LIST, COMMENT")
+		if len(stmt.UnsetKeys) != 2 || stmt.UnsetKeys[0] != "VALUE_LIST" || stmt.UnsetKeys[1] != "COMMENT" {
+			t.Errorf("UnsetKeys = %v, want [VALUE_LIST COMMENT]", stmt.UnsetKeys)
+		}
+	})
+
+	t.Run("loc", func(t *testing.T) {
+		input := "ALTER NETWORK RULE r UNSET COMMENT"
+		stmt := mustAlterNetworkRule(t, input)
+		// Loc.Start anchors at the NETWORK keyword (ALTER convention), not ALTER.
+		if stmt.Loc.Start != int(len("ALTER ")) {
+			t.Errorf("Loc.Start = %d, want %d (NETWORK keyword)", stmt.Loc.Start, len("ALTER "))
+		}
+		if int(stmt.Loc.End) != len(input) {
+			t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// DROP NETWORK RULE
+// ---------------------------------------------------------------------------
+
+func TestParseDropNetworkRule(t *testing.T) {
+	t.Run("plain", func(t *testing.T) {
+		stmt := mustDropNetworkRule(t, "DROP NETWORK RULE r")
+		if stmt.Kind != ast.DropNetworkRule {
+			t.Errorf("Kind = %v, want DropNetworkRule", stmt.Kind)
+		}
+		if stmt.IfExists {
+			t.Errorf("IfExists = true, want false")
+		}
+		if stmt.Name.String() != "r" {
+			t.Errorf("Name = %q, want r", stmt.Name.String())
+		}
+	})
+
+	t.Run("if exists qualified", func(t *testing.T) {
+		stmt := mustDropNetworkRule(t, "DROP NETWORK RULE IF EXISTS db.sch.r")
+		if !stmt.IfExists {
+			t.Errorf("IfExists = false, want true")
+		}
+		if stmt.Name.String() != "db.sch.r" {
+			t.Errorf("Name = %q, want db.sch.r", stmt.Name.String())
+		}
+	})
+
+	t.Run("kind string", func(t *testing.T) {
+		if got := ast.DropNetworkRule.String(); got != "NETWORK RULE" {
+			t.Errorf("DropNetworkRule.String() = %q, want %q", got, "NETWORK RULE")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Negatives
+// ---------------------------------------------------------------------------
+
+func TestParseNetworkRule_Negatives(t *testing.T) {
+	cases := []string{
+		// Missing name after RULE.
+		"CREATE NETWORK RULE",
+		// ALTER with no action.
+		"ALTER NETWORK RULE r",
+		// ALTER SET with nothing settable.
+		"ALTER NETWORK RULE r SET",
+		// ALTER UNSET with no key.
+		"ALTER NETWORK RULE r UNSET",
+		// IF NOT EXISTS truncated.
+		"CREATE NETWORK RULE IF NOT r TYPE = IPV4",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			_, err := Parse(input)
+			if err == nil {
+				t.Errorf("Parse(%q) = nil error, want a parse error", input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/gap-network-rule` (phase-2 corpus-gap closure) — **CREATE / ALTER / DROP NETWORK RULE** (docs-ahead coverage; NETWORK POLICY existed, NETWORK RULE did not; legacy ANTLR has no `network_rule` rule).

## Forms
- `CREATE [OR REPLACE] NETWORK RULE [IF NOT EXISTS] <qualified_name> <KEY = value>...` — properties open-ended via the existing `CopyOption` machinery (TYPE / VALUE_LIST / MODE / COMMENT in any order). `VALUE_LIST = ('a','b')` uses the native `CopyOption.List` shape; `TYPE`/`MODE` captured as ident words, not enumerated (absorbs the growing AWSVPCEID/GCPPSCID/HOST_PORT/PRIVATE_HOST_PORT… vocabularies without parser changes).
- `ALTER NETWORK RULE [IF EXISTS] <name> { SET <prop>... | UNSET <key>,... }`.
- `DROP NETWORK RULE [IF EXISTS] <name>` — reuses generic `parseDropObject` + a new `DropNetworkRule` kind (its `String()` makes deparse automatic).

## Design
`NETWORK RULE` disambiguated from `NETWORK POLICY` by a new one-token `peekIsWord("RULE")` lookahead (RULE isn't reserved → kwNETWORK + "RULE" ident), mirroring the parser-wide `curIsWord` convention used for EXTERNAL VOLUME / AUTHENTICATION POLICY. New `parser/network_rule.go`; AST `CreateNetworkRuleStmt`/`AlterNetworkRuleStmt` + tags; walker regenerated; deparse writers mirror the WAREHOUSE precedent. Option loop has a 1024 cap + zero-token-progress guard; every `go test` ran `-timeout 120s`.

## Corpus delta (TestCorpusClosure)
**589 → 594 clean, 66 → 61 skipped** — the 5 `official/create-network-rule/example_01..05.sql` files now parse (skip-list self-prune clean).

## Review (`/code-review` high; Codex down) — no correctness bugs
Verified-and-refuted: option-loop statement-bleed (tested `;`-separated + rule-then-CREATE-TABLE → 2 stmts), NETWORK POLICY mis-routing (still → CreatePolicyStmt), DROP non-RULE equivalence, quoted-`"RULE"` matching (refuted — established convention). Orchestrator independently verified on a fresh checkout of `cea75e52`: gofmt/vet/build clean, full `go test ./snowflake/... -timeout 120s` green (7 pkgs), corpus self-prune green.

## Out-of-scope writes (small, justified)
- `parser/copy.go` (+13) — shared `peekIsWord` one-token lookahead helper (the disambiguation primitive; belongs with the other shared lexer-peek helpers).
- `deparse/deparse.go` (+6) — deparse dispatch entry for the new nodes (same as the WAREHOUSE node).

## Note
Opened by orchestrator from verified pushed commit `cea75e52`. No code modified. Phase-2 gap 2/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
