### PR TITLE
feat(snowflake): CREATE HYBRID TABLE + inline INDEX (phase-2 gap-hybrid-table) — close corpus gap 169

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -54,6 +54,7 @@ const (
 	T_CreateTableStmt
 	T_ColumnDef
 	T_TableConstraint
+	T_TableIndex
 	T_CreateDatabaseStmt
 	T_AlterDatabaseStmt
 	T_DropDatabaseStmt
@@ -302,6 +303,8 @@ func (t NodeTag) String() string {
 		return "ColumnDef"
 	case T_TableConstraint:
 		return "TableConstraint"
+	case T_TableIndex:
+		return "TableIndex"
 	case T_CreateDatabaseStmt:
 		return "CreateDatabaseStmt"
 	case T_AlterDatabaseStmt:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1307,13 +1307,15 @@ type CreateTableStmt struct {
 	Transient   bool
 	Temporary   bool
 	Volatile    bool
+	Hybrid      bool // CREATE HYBRID TABLE (Unistore); mutually exclusive with the temp modifiers
 	IfNotExists bool
 	Name        *ObjectName
 	Columns     []*ColumnDef
 	Constraints []*TableConstraint
-	ClusterBy   []Node  // CLUSTER BY expressions; nil if absent
-	Linear      bool    // CLUSTER BY LINEAR modifier
-	Comment     *string // COMMENT = 'text'; nil if absent
+	Indexes     []*TableIndex // inline INDEX name (cols) elements (HYBRID TABLE only); nil if absent
+	ClusterBy   []Node        // CLUSTER BY expressions; nil if absent
+	Linear      bool          // CLUSTER BY LINEAR modifier
+	Comment     *string       // COMMENT = 'text'; nil if absent
 	CopyGrants  bool
 	Tags        []*TagAssignment // WITH TAG (...); nil if absent
 	AsSelect    Node             // CREATE TABLE ... AS SELECT; nil if absent
@@ -1355,11 +1357,23 @@ type TableConstraint struct {
 
 func (n *TableConstraint) Tag() NodeTag { return T_TableConstraint }
 
+// TableIndex represents an inline secondary-index element in a CREATE HYBRID
+// TABLE column list: INDEX <name> ( <col> [, <col>...] ). This construct is
+// specific to hybrid (Unistore) tables.
+type TableIndex struct {
+	Name    Ident   // index name
+	Columns []Ident // indexed column names (one or more)
+	Loc     Loc
+}
+
+func (n *TableIndex) Tag() NodeTag { return T_TableIndex }
+
 // Compile-time assertions.
 var (
 	_ Node = (*CreateTableStmt)(nil)
 	_ Node = (*ColumnDef)(nil)
 	_ Node = (*TableConstraint)(nil)
+	_ Node = (*TableIndex)(nil)
 )
 
 // ---------------------------------------------------------------------------

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -26,6 +26,9 @@ func (w *writer) writeCreateTableStmt(n *ast.CreateTableStmt) error {
 	} else if n.Volatile {
 		w.buf.WriteString(" VOLATILE")
 	}
+	if n.Hybrid {
+		w.buf.WriteString(" HYBRID")
+	}
 	w.buf.WriteString(" TABLE")
 	if n.IfNotExists {
 		w.buf.WriteString(" IF NOT EXISTS")
@@ -48,8 +51,8 @@ func (w *writer) writeCreateTableStmt(n *ast.CreateTableStmt) error {
 		return nil
 	}
 
-	// Column definitions and table constraints
-	if len(n.Columns) > 0 || len(n.Constraints) > 0 {
+	// Column definitions, table constraints and inline INDEX elements (HYBRID).
+	if len(n.Columns) > 0 || len(n.Constraints) > 0 || len(n.Indexes) > 0 {
 		w.buf.WriteString(" (")
 		idx := 0
 		for _, col := range n.Columns {
@@ -68,6 +71,13 @@ func (w *writer) writeCreateTableStmt(n *ast.CreateTableStmt) error {
 			if err := w.writeTableConstraint(con); err != nil {
 				return err
 			}
+			idx++
+		}
+		for _, ti := range n.Indexes {
+			if idx > 0 {
+				w.buf.WriteString(", ")
+			}
+			w.writeTableIndex(ti)
 			idx++
 		}
 		w.buf.WriteByte(')')
@@ -266,6 +276,20 @@ func (w *writer) writeTableConstraint(n *ast.TableConstraint) error {
 		w.buf.WriteString(quoteString(*n.Comment))
 	}
 	return nil
+}
+
+// writeTableIndex emits an inline INDEX element: INDEX name (col, col, ...).
+func (w *writer) writeTableIndex(n *ast.TableIndex) {
+	w.buf.WriteString("INDEX ")
+	w.buf.WriteString(n.Name.String())
+	w.buf.WriteString(" (")
+	for i, col := range n.Columns {
+		if i > 0 {
+			w.buf.WriteString(", ")
+		}
+		w.buf.WriteString(col.String())
+	}
+	w.buf.WriteByte(')')
 }
 
 func (w *writer) writeRefActions(onDelete, onUpdate ast.ReferenceAction) {

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -482,6 +482,50 @@ func TestDeparse_CreateTable_Transient(t *testing.T) {
 	assertRoundTrip(t, `CREATE TRANSIENT TABLE t (id INT)`)
 }
 
+// HYBRID must round-trip distinctly: a deparse that dropped the modifier would
+// change the reparsed AST (Hybrid false vs true) and fail the DeepEqual.
+func TestDeparse_CreateTable_Hybrid(t *testing.T) {
+	out := assertRoundTrip(t, `CREATE HYBRID TABLE t (id INT)`)
+	if !strings.Contains(out, "HYBRID TABLE") {
+		t.Errorf("deparsed SQL missing HYBRID TABLE: %q", out)
+	}
+}
+
+func TestDeparse_CreateTable_HybridOrReplace(t *testing.T) {
+	out := assertRoundTrip(t, `CREATE OR REPLACE HYBRID TABLE t (id INT)`)
+	if !strings.Contains(out, "OR REPLACE HYBRID TABLE") {
+		t.Errorf("deparsed SQL missing OR REPLACE HYBRID TABLE: %q", out)
+	}
+}
+
+// Inline INDEX elements round-trip: name + parenthesized column list.
+func TestDeparse_CreateTable_HybridIndexSingle(t *testing.T) {
+	out := assertRoundTrip(t,
+		`CREATE HYBRID TABLE t (id INT, full_name VARCHAR(255), INDEX index_full_name (full_name))`)
+	if !strings.Contains(out, "INDEX index_full_name (full_name)") {
+		t.Errorf("deparsed SQL missing INDEX element: %q", out)
+	}
+}
+
+func TestDeparse_CreateTable_HybridIndexMulti(t *testing.T) {
+	out := assertRoundTrip(t,
+		`CREATE HYBRID TABLE t (a INT, b INT, c INT, INDEX idx_abc (a, b, c))`)
+	if !strings.Contains(out, "INDEX idx_abc (a, b, c)") {
+		t.Errorf("deparsed SQL missing multi-column INDEX element: %q", out)
+	}
+}
+
+// Full corpus example_01 shape round-trips (AUTOINCREMENT/PK/UNIQUE/VARIANT +
+// inline INDEX in one statement).
+func TestDeparse_CreateTable_HybridCorpus01(t *testing.T) {
+	assertRoundTrip(t, `CREATE HYBRID TABLE mytable (customer_id INT AUTOINCREMENT PRIMARY KEY, full_name VARCHAR(255), email VARCHAR(255) UNIQUE, extended_customer_info VARIANT, INDEX index_full_name (full_name))`)
+}
+
+// INDEX element alongside an out-of-line constraint round-trips.
+func TestDeparse_CreateTable_HybridIndexWithConstraint(t *testing.T) {
+	assertRoundTrip(t, `CREATE OR REPLACE HYBRID TABLE ht2 (c1 INT PRIMARY KEY, c2 VARCHAR(10), INDEX idx_c2 (c2))`)
+}
+
 func TestDeparse_CreateTable_Temporary(t *testing.T) {
 	assertRoundTrip(t, `CREATE TEMPORARY TABLE t (id INT)`)
 }

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -192,16 +192,6 @@ var corpusSkips = map[string]string{
 	// CREATE OR ALTER WAREHOUSE and DROP WAREHOUSE statements in it parse clean.
 	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: SHOW WAREHOUSES ->> SELECT ... FROM $1 — ->> result-pipe + $N table-ref owned by other nodes (CREATE OR ALTER WAREHOUSE parses)",
 
-	// --- RESIDUAL GAP: CREATE HYBRID TABLE (object node not built) ---
-	"official/create-hybrid-table/example_01.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/create-hybrid-table/example_07.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/create-hybrid-table/example_08.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/create-hybrid-table/example_13.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/create-hybrid-table/example_14.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/create-hybrid-table/example_15.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/create-hybrid-table/example_16.sql": "RESIDUAL GAP: CREATE HYBRID TABLE — object node not built",
-	"official/drop-table/example_05.sql":          "CONTEXT: setup is CREATE OR REPLACE HYBRID TABLE (drop-table page) — hybrid-table object node not built",
-
 	// --- RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (object node not built) ---
 	// The ALTER WAREHOUSE ADD TABLES statement in this file now parses
 	// (gap-warehouse); it remains skipped only for the CREATE INTERACTIVE

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -108,9 +108,21 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		volatile = true
 	}
 
+	// Optional HYBRID modifier (Unistore). HYBRID is not a reserved keyword (it
+	// lexes as a plain identifier), so it is detected the non-reserved way via
+	// curIsWord and only when immediately followed by TABLE — otherwise a bare
+	// "HYBRID" identifier object (e.g. CREATE HYBRID VIEW, were that a thing) is
+	// left for the dispatch switch to reject. CREATE HYBRID TABLE is the only
+	// documented form, so HYBRID pairs only with TABLE.
+	hybrid := false
+	if p.curIsWord("HYBRID") && p.peekNext().Type == kwTABLE {
+		p.advance() // consume HYBRID
+		hybrid = true
+	}
+
 	switch p.cur.Type {
 	case kwTABLE:
-		return p.parseCreateTableStmt(start, orReplace, orAlter, transient, temporary, volatile)
+		return p.parseCreateTableStmt(start, orReplace, orAlter, transient, temporary, volatile, hybrid)
 	case kwDATABASE:
 		// CREATE [OR REPLACE] DATABASE ROLE ... (T4.6) vs CREATE DATABASE ... (T2.1).
 		// DATABASE ROLE is disambiguated by the ROLE keyword following DATABASE.
@@ -268,7 +280,7 @@ func (p *Parser) parseCreatePolicyDispatch(start ast.Loc, orReplace, orAlter boo
 // parseCreateTableStmt parses the body of a CREATE [OR REPLACE] [...] TABLE
 // statement. The CREATE keyword and optional modifiers have already been
 // consumed; start is the Loc of the CREATE token.
-func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, orAlter, transient, temporary, volatile bool) (ast.Node, error) {
+func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, orAlter, transient, temporary, volatile, hybrid bool) (ast.Node, error) {
 	p.advance() // consume TABLE
 
 	stmt := &ast.CreateTableStmt{
@@ -277,6 +289,7 @@ func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, orAlter, transie
 		Transient: transient,
 		Temporary: temporary,
 		Volatile:  volatile,
+		Hybrid:    hybrid,
 		Loc:       ast.Loc{Start: start.Start},
 	}
 
@@ -372,6 +385,26 @@ func (p *Parser) parseColumnDeclItems(stmt *ast.CreateTableStmt) error {
 	}
 
 	for p.cur.Type != ')' && p.cur.Type != tokEOF {
+		// An inline INDEX element (HYBRID TABLE) shares its leading keyword with a
+		// column whose name is literally "index" (INDEX is non-reserved).
+		// tryParseTableIndex speculatively matches the INDEX <name> ( ... ) shape
+		// and reports matched=false (rolling back) when it is actually a column
+		// named "index", which then falls through to parseColumnDef below.
+		if p.cur.Type == kwINDEX {
+			idx, matched, err := p.tryParseTableIndex()
+			if err != nil {
+				return err
+			}
+			if matched {
+				stmt.Indexes = append(stmt.Indexes, idx)
+				if p.cur.Type == ',' {
+					p.advance() // consume ','
+					continue
+				}
+				break
+			}
+		}
+
 		if p.isOutOfLineConstraintStart() {
 			con, err := p.parseOutOfLineConstraint()
 			if err != nil {
@@ -407,6 +440,50 @@ func (p *Parser) isOutOfLineConstraintStart() bool {
 		return true
 	}
 	return false
+}
+
+// tryParseTableIndex speculatively parses an inline INDEX element of a HYBRID
+// TABLE column list:
+//
+//	INDEX <index_name> ( <col_name> [, <col_name>...] )
+//
+// On entry cur is the INDEX keyword. Because INDEX is a non-reserved keyword,
+// the same leading token can begin a column definition whose name is literally
+// "index" — e.g. `index INT`, `index VARCHAR(10)`, or even `index NUMBER(38,0)`
+// (where the type's own parenthesized params would superficially resemble an
+// index column list). To disambiguate unambiguously, the whole element shape is
+// parsed under a snapshot: the index name, '(', a non-empty identifier list, and
+// ')'. If every part matches, the index is committed (matched=true). If any part
+// fails — wrong name, no '(', a numeric type param instead of a column name,
+// missing ')' — the parser is rolled back to the INDEX keyword and matched=false
+// is returned, so the caller parses a column definition instead. This never
+// surfaces a hard error from the speculative path; a genuinely malformed INDEX
+// element instead produces a column-definition error downstream.
+func (p *Parser) tryParseTableIndex() (idx *ast.TableIndex, matched bool, err error) {
+	snap := p.snapshot()
+
+	start := p.cur.Loc.Start
+	p.advance() // consume INDEX
+
+	name, nameErr := p.parseIdent()
+	if nameErr != nil || p.cur.Type != '(' {
+		p.restore(snap)
+		return nil, false, nil
+	}
+
+	cols, colsErr := p.parseIdentListInParens()
+	if colsErr != nil {
+		// Not an index element after all (e.g. a column named "index" with a
+		// parenthesized type): roll back and let parseColumnDef handle it.
+		p.restore(snap)
+		return nil, false, nil
+	}
+
+	return &ast.TableIndex{
+		Name:    name,
+		Columns: cols,
+		Loc:     ast.Loc{Start: start, End: p.prev.Loc.End},
+	}, true, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/hybrid_table_test.go
+++ b/snowflake/parser/hybrid_table_test.go
@@ -1,0 +1,358 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// CREATE HYBRID TABLE — Hybrid flag + inline INDEX element (gap-hybrid-table)
+// ---------------------------------------------------------------------------
+
+// The HYBRID modifier sets CreateTableStmt.Hybrid and does not disturb the
+// reuse of the standard column-def grammar.
+func TestCreateHybridTable_Flag(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE HYBRID TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Hybrid {
+		t.Error("expected Hybrid=true")
+	}
+	if stmt.Transient || stmt.Temporary || stmt.Volatile {
+		t.Error("temp modifiers must be false for a plain HYBRID TABLE")
+	}
+	if len(stmt.Columns) != 1 || stmt.Columns[0].Name.Normalize() != "ID" {
+		t.Fatalf("unexpected columns: %+v", stmt.Columns)
+	}
+}
+
+// A regular (non-HYBRID) CREATE TABLE must be unaffected: Hybrid=false and no
+// spurious indexes. Guards against the HYBRID/INDEX additions regressing the
+// common path.
+func TestCreateHybridTable_NonHybridUnaffected(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE t (id INT, name VARCHAR(100))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Hybrid {
+		t.Error("expected Hybrid=false for a non-HYBRID CREATE TABLE")
+	}
+	if len(stmt.Indexes) != 0 {
+		t.Errorf("expected no indexes, got %d", len(stmt.Indexes))
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+}
+
+func TestCreateHybridTable_OrReplace(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE OR REPLACE HYBRID TABLE t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Hybrid {
+		t.Error("expected Hybrid=true")
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+}
+
+func TestCreateHybridTable_IfNotExists(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE HYBRID TABLE IF NOT EXISTS t (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Hybrid {
+		t.Error("expected Hybrid=true")
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inline INDEX element
+// ---------------------------------------------------------------------------
+
+func TestCreateHybridTable_IndexSingleColumn(t *testing.T) {
+	stmt, errs := testParseCreateTable(
+		"CREATE HYBRID TABLE t (id INT, full_name VARCHAR(255), INDEX index_full_name (full_name))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("columns = %d, want 2", len(stmt.Columns))
+	}
+	if len(stmt.Indexes) != 1 {
+		t.Fatalf("indexes = %d, want 1", len(stmt.Indexes))
+	}
+	idx := stmt.Indexes[0]
+	if idx.Name.Normalize() != "INDEX_FULL_NAME" {
+		t.Errorf("index name = %q, want INDEX_FULL_NAME", idx.Name.Normalize())
+	}
+	if len(idx.Columns) != 1 || idx.Columns[0].Normalize() != "FULL_NAME" {
+		t.Errorf("index columns = %+v, want [FULL_NAME]", idx.Columns)
+	}
+}
+
+func TestCreateHybridTable_IndexMultiColumn(t *testing.T) {
+	stmt, errs := testParseCreateTable(
+		"CREATE HYBRID TABLE t (a INT, b INT, c INT, INDEX idx_abc (a, b, c))")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Indexes) != 1 {
+		t.Fatalf("indexes = %d, want 1", len(stmt.Indexes))
+	}
+	idx := stmt.Indexes[0]
+	if idx.Name.Normalize() != "IDX_ABC" {
+		t.Errorf("index name = %q, want IDX_ABC", idx.Name.Normalize())
+	}
+	got := make([]string, len(idx.Columns))
+	for i, c := range idx.Columns {
+		got[i] = c.Normalize()
+	}
+	want := []string{"A", "B", "C"}
+	if len(got) != len(want) {
+		t.Fatalf("index columns = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index column[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// Loc on a parsed INDEX element must span "INDEX ... )".
+func TestCreateHybridTable_IndexLoc(t *testing.T) {
+	src := "CREATE HYBRID TABLE t (a INT, INDEX idx_a (a))"
+	stmt, errs := testParseCreateTable(src)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Indexes) != 1 {
+		t.Fatalf("indexes = %d, want 1", len(stmt.Indexes))
+	}
+	idx := stmt.Indexes[0]
+	got := src[idx.Loc.Start:idx.Loc.End]
+	want := "INDEX idx_a (a)"
+	if got != want {
+		t.Errorf("index Loc slice = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Corpus shapes (official/create-hybrid-table)
+// ---------------------------------------------------------------------------
+
+// example_01: AUTOINCREMENT PRIMARY KEY, UNIQUE, VARIANT, inline INDEX.
+func TestCreateHybridTable_CorpusExample01(t *testing.T) {
+	stmt, errs := testParseCreateTable(`CREATE HYBRID TABLE mytable (
+  customer_id INT AUTOINCREMENT PRIMARY KEY,
+  full_name VARCHAR(255),
+  email VARCHAR(255) UNIQUE,
+  extended_customer_info VARIANT,
+  INDEX index_full_name (full_name)
+)`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Hybrid {
+		t.Error("expected Hybrid=true")
+	}
+	if len(stmt.Columns) != 4 {
+		t.Fatalf("columns = %d, want 4", len(stmt.Columns))
+	}
+	// customer_id INT AUTOINCREMENT PRIMARY KEY
+	c0 := stmt.Columns[0]
+	if c0.Identity == nil {
+		t.Error("customer_id: expected AUTOINCREMENT (Identity != nil)")
+	}
+	if c0.InlineConstraint == nil || c0.InlineConstraint.Type != ast.ConstrPrimaryKey {
+		t.Error("customer_id: expected inline PRIMARY KEY")
+	}
+	// email VARCHAR(255) UNIQUE
+	c2 := stmt.Columns[2]
+	if c2.InlineConstraint == nil || c2.InlineConstraint.Type != ast.ConstrUnique {
+		t.Error("email: expected inline UNIQUE")
+	}
+	// extended_customer_info VARIANT
+	c3 := stmt.Columns[3]
+	if c3.DataType == nil || c3.DataType.Kind != ast.TypeVariant {
+		t.Errorf("extended_customer_info: type = %v, want TypeVariant", c3.DataType)
+	}
+	if len(stmt.Indexes) != 1 || stmt.Indexes[0].Name.Normalize() != "INDEX_FULL_NAME" {
+		t.Errorf("expected one INDEX index_full_name, got %+v", stmt.Indexes)
+	}
+}
+
+// example_07: OR REPLACE + out-of-line CONSTRAINT ... PRIMARY KEY (multi-col).
+func TestCreateHybridTable_CorpusExample07(t *testing.T) {
+	stmt, errs := testParseCreateTable(`CREATE OR REPLACE HYBRID TABLE ht2pk (
+  col1 INTEGER NOT NULL,
+  col2 INTEGER NOT NULL,
+  col3 VARCHAR,
+  CONSTRAINT pkey_1 PRIMARY KEY (col1, col2)
+)`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Hybrid || !stmt.OrReplace {
+		t.Error("expected Hybrid=true and OrReplace=true")
+	}
+	if len(stmt.Columns) != 3 {
+		t.Fatalf("columns = %d, want 3", len(stmt.Columns))
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if con.Type != ast.ConstrPrimaryKey || con.Name.Normalize() != "PKEY_1" {
+		t.Errorf("constraint = %v/%q, want PRIMARY KEY/PKEY_1", con.Type, con.Name.Normalize())
+	}
+	if len(con.Columns) != 2 {
+		t.Errorf("PK columns = %d, want 2", len(con.Columns))
+	}
+}
+
+// example_08: out-of-line FOREIGN KEY (col) REFERENCES team(team_id).
+func TestCreateHybridTable_CorpusExample08_ForeignKey(t *testing.T) {
+	stmt, errs := testParseCreateTable(`CREATE OR REPLACE HYBRID TABLE player
+  (player_id INT PRIMARY KEY,
+  first_name VARCHAR(40),
+  team_id INT,
+  FOREIGN KEY (team_id) REFERENCES team(team_id))`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Constraints) != 1 {
+		t.Fatalf("constraints = %d, want 1", len(stmt.Constraints))
+	}
+	con := stmt.Constraints[0]
+	if con.Type != ast.ConstrForeignKey {
+		t.Errorf("constraint type = %v, want FOREIGN KEY", con.Type)
+	}
+	if con.References == nil || con.References.Table.Normalize() != "TEAM" {
+		t.Errorf("FK references = %+v, want team", con.References)
+	}
+}
+
+// example_13: COLLATE 'de' column + INDEX + (the DESCRIBE TABLE is a separate
+// statement, exercised by the corpus test).
+func TestCreateHybridTable_CorpusExample13_Collate(t *testing.T) {
+	stmt, errs := testParseCreateTable(
+		"CREATE OR REPLACE HYBRID TABLE ht1 (c1 INT PRIMARY KEY, c2 VARCHAR(10) COLLATE 'de')")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Columns[1].Collate != "de" {
+		t.Errorf("c2 collate = %q, want de", stmt.Columns[1].Collate)
+	}
+}
+
+// example_15: INDEX element followed by a DEFAULT_DDL_COLLATION table property.
+func TestCreateHybridTable_CorpusExample15_IndexPlusTableProperty(t *testing.T) {
+	stmt, errs := testParseCreateTable(
+		"CREATE OR REPLACE HYBRID TABLE ht2 (c1 INT PRIMARY KEY, c2 VARCHAR(10), INDEX idx_c2 (c2)) DEFAULT_DDL_COLLATION = ''")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Indexes) != 1 || stmt.Indexes[0].Name.Normalize() != "IDX_C2" {
+		t.Errorf("expected INDEX idx_c2, got %+v", stmt.Indexes)
+	}
+}
+
+// example_16: NUMBER(38,0) NOT NULL COMMENT 'text' + out-of-line PK.
+func TestCreateHybridTable_CorpusExample16_NumberCommentPK(t *testing.T) {
+	stmt, errs := testParseCreateTable(`CREATE OR REPLACE HYBRID TABLE ht1pk
+  (COL1 NUMBER(38,0) NOT NULL COMMENT 'Primary key',
+  COL2 NUMBER(38,0) NOT NULL,
+  CONSTRAINT PKEY_1 PRIMARY KEY (COL1))`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	c0 := stmt.Columns[0]
+	if c0.DataType == nil || c0.DataType.Kind != ast.TypeNumber {
+		t.Errorf("COL1 type = %v, want TypeNumber", c0.DataType)
+	}
+	if len(c0.DataType.Params) != 2 || c0.DataType.Params[0] != 38 || c0.DataType.Params[1] != 0 {
+		t.Errorf("COL1 params = %v, want [38 0]", c0.DataType.Params)
+	}
+	if !c0.NotNull {
+		t.Error("COL1: expected NOT NULL")
+	}
+	if c0.Comment == nil || *c0.Comment != "Primary key" {
+		t.Errorf("COL1 comment = %v, want 'Primary key'", c0.Comment)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Disambiguation: INDEX is a non-reserved keyword, so a column literally named
+// "index" must still parse as a column, not an INDEX element.
+// ---------------------------------------------------------------------------
+
+func TestCreateHybridTable_ColumnNamedIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{"plain type", "CREATE TABLE t (index INT)"},
+		{"parameterized type", "CREATE TABLE t (index NUMBER(38,0))"},
+		{"varchar param", "CREATE TABLE t (index VARCHAR(10), other INT)"},
+		{"hybrid table column named index", "CREATE HYBRID TABLE t (index INT, other VARCHAR)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, errs := testParseCreateTable(tc.sql)
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if len(stmt.Indexes) != 0 {
+				t.Errorf("expected no INDEX elements, got %d", len(stmt.Indexes))
+			}
+			if len(stmt.Columns) == 0 || stmt.Columns[0].Name.Normalize() != "INDEX" {
+				t.Errorf("expected first column named INDEX, got %+v", stmt.Columns)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negatives
+// ---------------------------------------------------------------------------
+
+// INDEX with no name followed by a column list is rejected (it is not a valid
+// column def either — a column named "index" cannot be followed by '(').
+func TestCreateHybridTable_IndexWithoutNameRejected(t *testing.T) {
+	result := ParseBestEffort("CREATE HYBRID TABLE t (a INT, INDEX (a))")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected a parse error for INDEX (a) with no name, got none")
+	}
+}
+
+// HYBRID pairs only with TABLE. CREATE HYBRID VIEW must be rejected (HYBRID is
+// only consumed when immediately followed by TABLE, so HYBRID is left as an
+// unexpected object keyword).
+func TestCreateHybridTable_HybridViewRejected(t *testing.T) {
+	result := ParseBestEffort("CREATE HYBRID VIEW v AS SELECT 1")
+	if len(result.Errors) == 0 {
+		t.Fatal("expected a parse error for CREATE HYBRID VIEW, got none")
+	}
+}
+
+// HYBRID remains usable as an ordinary identifier elsewhere (it is not a
+// reserved keyword). A table named HYBRID must parse with Hybrid=false.
+func TestCreateHybridTable_HybridAsIdentifier(t *testing.T) {
+	stmt, errs := testParseCreateTable("CREATE TABLE hybrid (id INT)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Hybrid {
+		t.Error("expected Hybrid=false for a table named HYBRID")
+	}
+	if stmt.Name.Normalize() != "HYBRID" {
+		t.Errorf("name = %q, want HYBRID", stmt.Name.Normalize())
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/gap-hybrid-table` (phase-2 corpus-gap closure) — **CREATE HYBRID TABLE** (Unistore; docs-ahead — legacy ANTLR has no hybrid-table rule).

## Forms
`CREATE [OR REPLACE] HYBRID TABLE [IF NOT EXISTS] <name> ( <column_def | out-of-line-constraint | INDEX name (cols)>, ... )`. A hybrid table is a regular CREATE TABLE with a `HYBRID` modifier plus inline secondary-index definitions.

## Design
- **`HYBRID` modifier**: parsed the non-reserved way (`curIsWord("HYBRID")` — the established convention; not made a reserved keyword, so HYBRID stays usable as an identifier elsewhere). Threaded as `Hybrid bool` on `ast.CreateTableStmt`, mirroring the existing `Transient`/`Temporary`/`Volatile` flags exactly (field + parse threading + deparse).
- **Inline `INDEX name (cols)`**: new `ast.TableIndex{Name Ident; Columns []Ident}` + `CreateTableStmt.Indexes []*TableIndex`, parsed as a new table element. A column literally named `index` is disambiguated via snapshot-rollback (`tryParseTableIndex` — if `INDEX` isn't followed by `name (` it rolls back and parses as a column). `restore` truncates `p.errors` to the snapshot, so the speculative parse leaks no spurious errors.
- Walker: genwalker re-run is a **no-op** — `TableIndex`'s fields are all `Ident` value-types (not `Node`), so no walk case is generated (139 cases unchanged); correct by design. Reused the existing column/constraint grammar unchanged.

## Corpus delta (TestCorpusClosure)
**594 → 602 clean, 61 → 53 skipped** — the 7 `official/create-hybrid-table/example_*` files + `official/drop-table/example_05.sql` (its `CREATE OR REPLACE HYBRID TABLE` setup) now parse. Non-hybrid CREATE TABLE confirmed unaffected (`Hybrid=false`, regression test green).

## Review (`/code-review` high; Codex down) — no findings survived verification
Verified-and-refuted: column-named-"index" handling (snapshot-rollback correct), trailing-comma parity with existing column/constraint behavior, spurious-error leakage (refuted — `restore` truncates `p.errors`).

## Salvage note
The worker completed implementation + `/code-review` but stopped before commit/push. Orchestrator independently verified the uncommitted work on the worktree — gofmt/vet/build clean, full `go test ./snowflake/... -timeout 120s` green (7 pkgs), genwalker regen no-op confirmed, corpus self-prune green, non-hybrid CREATE TABLE regression green — then committed + pushed (`c7222ecd`). No code modified beyond gofmt.

## Note
Opened by orchestrator from verified commit `c7222ecd`. Phase-2 gap 3/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
