### PR TITLE
feat(snowflake): ALTER SESSION params + SEARCH OPTIMIZATION method-list + ALTER VIEW policies (phase-2 gap-alter-family) — close corpus gaps 165,166,167

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -175,6 +175,9 @@ const (
 	T_CreateNetworkRuleStmt
 	T_AlterNetworkRuleStmt
 
+	// Session DDL tags (gap-alter-family)
+	T_AlterSessionStmt
+
 	// Access-control DDL tags (T4.6)
 	T_PolicyArg
 	T_CreateRoleStmt
@@ -463,6 +466,8 @@ func (t NodeTag) String() string {
 		return "CreateNetworkRuleStmt"
 	case T_AlterNetworkRuleStmt:
 		return "AlterNetworkRuleStmt"
+	case T_AlterSessionStmt:
+		return "AlterSessionStmt"
 	case T_PolicyArg:
 		return "PolicyArg"
 	case T_CreateRoleStmt:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1985,6 +1985,10 @@ const (
 	AlterViewColumnUnsetMaskingPolicy                        // ALTER COLUMN col UNSET MASKING POLICY
 	AlterViewColumnSetTag                                    // ALTER COLUMN col SET TAG (...)
 	AlterViewColumnUnsetTag                                  // ALTER COLUMN col UNSET TAG (...)
+	AlterViewSetAggregationPolicy                            // SET AGGREGATION POLICY name [ ENTITY KEY (...) ] [ FORCE ]
+	AlterViewUnsetAggregationPolicy                          // UNSET AGGREGATION POLICY
+	AlterViewSetJoinPolicy                                   // SET JOIN POLICY name [ ALLOWED/ENFORCED JOIN KEYS (...) ]
+	AlterViewUnsetJoinPolicy                                 // UNSET JOIN POLICY
 )
 
 // AlterViewStmt represents ALTER VIEW ... (all action variants).
@@ -1997,8 +2001,11 @@ type AlterViewStmt struct {
 	Secure        bool             // true = SET SECURE; false = UNSET SECURE (check Action)
 	Tags          []*TagAssignment // SET TAG (...)
 	UnsetTags     []*ObjectName    // UNSET TAG (...)
-	PolicyName    *ObjectName      // ADD/DROP ROW ACCESS POLICY name
+	PolicyName    *ObjectName      // ADD/DROP ROW ACCESS POLICY name; also SET {AGGREGATION|JOIN} POLICY name
 	PolicyCols    []Ident          // ON (col, ...) for ADD ROW ACCESS POLICY
+	PolicyKeyCols []Ident          // ENTITY KEY (...) / ALLOWED|ENFORCED JOIN KEYS (...) for SET {AGGREGATION|JOIN} POLICY
+	PolicyKeyKind string           // "ALLOWED" or "ENFORCED" for SET JOIN POLICY ... JOIN KEYS; "" if no keys clause
+	PolicyForce   bool             // FORCE for SET AGGREGATION POLICY
 	Column        Ident            // ALTER COLUMN col name
 	MaskingPolicy *ObjectName      // SET MASKING POLICY p
 	MaskingUsing  []Ident          // USING (col, ...)
@@ -5167,6 +5174,36 @@ var (
 	_ Node = (*CreateNetworkRuleStmt)(nil)
 	_ Node = (*AlterNetworkRuleStmt)(nil)
 )
+
+// ---------------------------------------------------------------------------
+// ALTER SESSION (session parameters) node (gap-alter-family)
+// ---------------------------------------------------------------------------
+
+// AlterSessionAction enumerates the ALTER SESSION action variants.
+type AlterSessionAction int
+
+const (
+	AlterSessionSet   AlterSessionAction = iota // SET <param> = <value> [ , ... ]
+	AlterSessionUnset                           // UNSET <param> [ , ... ]
+)
+
+// AlterSessionStmt represents ALTER SESSION { SET | UNSET } <session_parameter> ...
+// (session parameters, distinct from ALTER SESSION POLICY which is an
+// AlterPolicyStmt). The SET form carries open-ended `<key> = <value>` options
+// (e.g. AUTOCOMMIT = TRUE, LOCK_TIMEOUT = 3600, DEFAULT_NULL_ORDERING = 'LAST');
+// the UNSET form carries a list of parameter names.
+type AlterSessionStmt struct {
+	Action    AlterSessionAction
+	Options   []*CopyOption // SET <param> = <value> [ , ... ]; for AlterSessionSet
+	UnsetKeys []string      // UNSET <param> [ , ... ]; for AlterSessionUnset
+	Loc       Loc
+}
+
+// Tag implements Node.
+func (n *AlterSessionStmt) Tag() NodeTag { return T_AlterSessionStmt }
+
+// Compile-time assertion for the session DDL node.
+var _ Node = (*AlterSessionStmt)(nil)
 
 // ---------------------------------------------------------------------------
 // CALL / EXECUTE IMMEDIATE / EXECUTE TASK / EXPLAIN statement nodes (T5.4)

--- a/snowflake/deparse/alter_family_deparse_test.go
+++ b/snowflake/deparse/alter_family_deparse_test.go
@@ -1,0 +1,96 @@
+package deparse_test
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/deparse"
+	"github.com/bytebase/omni/snowflake/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ALTER-family round-trips (gap-alter-family): ALTER SESSION parameters,
+// ALTER TABLE SEARCH OPTIMIZATION method-lists, ALTER VIEW SET/UNSET
+// {JOIN|AGGREGATION} POLICY.
+//
+// assertRoundTrip compares ASTs (Loc-stripped), so cosmetic normalizations the
+// deparser applies — uppercasing option names/keys, normalizing whitespace —
+// are expected and verified to be AST-equivalent.
+// ---------------------------------------------------------------------------
+
+func TestDeparse_AlterSessionSet(t *testing.T) {
+	assertRoundTrip(t, "ALTER SESSION SET LOCK_TIMEOUT = 3600")
+	assertRoundTrip(t, "ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = 604800")
+	assertRoundTrip(t, "ALTER SESSION SET ERROR_ON_NONDETERMINISTIC_UPDATE = TRUE")
+	assertRoundTrip(t, "ALTER SESSION SET DEFAULT_NULL_ORDERING = 'LAST'")
+	assertRoundTrip(t, "ALTER SESSION SET AUTOCOMMIT = TRUE")
+	// Multiple space-separated parameters.
+	assertRoundTrip(t, "ALTER SESSION SET AUTOCOMMIT = TRUE LOCK_TIMEOUT = 3600")
+}
+
+func TestDeparse_AlterSessionUnset(t *testing.T) {
+	assertRoundTrip(t, "ALTER SESSION UNSET LOCK_TIMEOUT")
+	assertRoundTrip(t, "ALTER SESSION UNSET LOCK_TIMEOUT, AUTOCOMMIT")
+	assertRoundTrip(t, "ALTER SESSION UNSET DEFAULT_NULL_ORDERING")
+}
+
+func TestDeparse_AlterTableSearchOptimizationMethodList(t *testing.T) {
+	assertRoundTrip(t, "ALTER TABLE t1 ADD SEARCH OPTIMIZATION ON EQUALITY(c1), EQUALITY(c2, c3)")
+	assertRoundTrip(t, "ALTER TABLE t1 ADD SEARCH OPTIMIZATION ON EQUALITY(c1, c2, c3, c4)")
+	assertRoundTrip(t, "ALTER TABLE t1 DROP SEARCH OPTIMIZATION ON EQUALITY(c1, c2)")
+	assertRoundTrip(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(*)")
+	assertRoundTrip(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION ON SUBSTRING(c1), GEO(c2)")
+	// No-target form (bare SEARCH OPTIMIZATION) still round-trips.
+	assertRoundTrip(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION")
+}
+
+func TestDeparse_AlterViewJoinPolicy(t *testing.T) {
+	assertRoundTrip(t, "ALTER VIEW join_view SET JOIN POLICY jp1")
+	assertRoundTrip(t, "ALTER VIEW v SET JOIN POLICY jp1 ALLOWED JOIN KEYS (a, b)")
+	assertRoundTrip(t, "ALTER VIEW v SET JOIN POLICY jp1 ENFORCED JOIN KEYS (a)")
+	assertRoundTrip(t, "ALTER VIEW v UNSET JOIN POLICY")
+}
+
+func TestDeparse_AlterViewAggregationPolicy(t *testing.T) {
+	assertRoundTrip(t, "ALTER VIEW v SET AGGREGATION POLICY ap1")
+	assertRoundTrip(t, "ALTER VIEW v SET AGGREGATION POLICY ap1 ENTITY KEY (id)")
+	assertRoundTrip(t, "ALTER VIEW v SET AGGREGATION POLICY ap1 ENTITY KEY (a, b) FORCE")
+	assertRoundTrip(t, "ALTER VIEW v UNSET AGGREGATION POLICY")
+}
+
+// TestDeparse_AlterFamily_ExactString pins the exact deparsed output for
+// representative statements, guarding keyword spelling and spacing.
+func TestDeparse_AlterFamily_ExactString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{
+			in:   "alter session set lock_timeout = 3600",
+			want: "ALTER SESSION SET LOCK_TIMEOUT = 3600",
+		},
+		{
+			in:   "ALTER SESSION UNSET lock_timeout, autocommit",
+			want: "ALTER SESSION UNSET LOCK_TIMEOUT, AUTOCOMMIT",
+		},
+		{
+			in:   "ALTER VIEW join_view SET JOIN POLICY jp1",
+			want: "ALTER VIEW join_view SET JOIN POLICY jp1",
+		},
+		{
+			in:   "ALTER VIEW v SET AGGREGATION POLICY ap1 ENTITY KEY (id) FORCE",
+			want: "ALTER VIEW v SET AGGREGATION POLICY ap1 ENTITY KEY (id) FORCE",
+		},
+		{
+			in:   "ALTER TABLE t1 ADD SEARCH OPTIMIZATION ON EQUALITY(c1), EQUALITY(c2, c3)",
+			want: "ALTER TABLE t1 ADD SEARCH OPTIMIZATION ON EQUALITY(c1), EQUALITY(c2, c3)",
+		},
+	}
+	for _, c := range cases {
+		f, err := parser.Parse(c.in)
+		require.NoError(t, err, "parse %q", c.in)
+		out, err := deparse.DeparseFile(f)
+		require.NoError(t, err, "deparse %q", c.in)
+		require.Equal(t, c.want, out)
+	}
+}

--- a/snowflake/deparse/deparse.go
+++ b/snowflake/deparse/deparse.go
@@ -119,6 +119,10 @@ func (w *writer) writeNode(node ast.Node) error {
 	case *ast.AlterNetworkRuleStmt:
 		return w.writeAlterNetworkRuleStmt(n)
 
+	// --- DDL: session ---
+	case *ast.AlterSessionStmt:
+		return w.writeAlterSessionStmt(n)
+
 	// --- Expressions (can also be top-level in some contexts) ---
 	case *ast.Literal,
 		*ast.ColumnRef,

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -781,6 +781,41 @@ func (w *writer) writeAlterViewStmt(n *ast.AlterViewStmt) error {
 		w.buf.WriteString(" UNSET TAG (")
 		w.writeObjectNameList(n.UnsetTags)
 		w.buf.WriteByte(')')
+	case ast.AlterViewSetAggregationPolicy:
+		w.buf.WriteString(" SET AGGREGATION POLICY ")
+		w.writeObjectNameNoSpace(n.PolicyName)
+		if len(n.PolicyKeyCols) > 0 {
+			w.buf.WriteString(" ENTITY KEY (")
+			for i, col := range n.PolicyKeyCols {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				w.buf.WriteString(col.String())
+			}
+			w.buf.WriteByte(')')
+		}
+		if n.PolicyForce {
+			w.buf.WriteString(" FORCE")
+		}
+	case ast.AlterViewUnsetAggregationPolicy:
+		w.buf.WriteString(" UNSET AGGREGATION POLICY")
+	case ast.AlterViewSetJoinPolicy:
+		w.buf.WriteString(" SET JOIN POLICY ")
+		w.writeObjectNameNoSpace(n.PolicyName)
+		if len(n.PolicyKeyCols) > 0 {
+			w.buf.WriteByte(' ')
+			w.buf.WriteString(n.PolicyKeyKind)
+			w.buf.WriteString(" JOIN KEYS (")
+			for i, col := range n.PolicyKeyCols {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				w.buf.WriteString(col.String())
+			}
+			w.buf.WriteByte(')')
+		}
+	case ast.AlterViewUnsetJoinPolicy:
+		w.buf.WriteString(" UNSET JOIN POLICY")
 	default:
 		return fmt.Errorf("deparse: unsupported ALTER VIEW action %d", n.Action)
 	}
@@ -1358,6 +1393,25 @@ func (w *writer) writeAlterNetworkRuleStmt(n *ast.AlterNetworkRuleStmt) error {
 		w.buf.WriteString(strings.Join(n.UnsetKeys, ", "))
 	default:
 		return fmt.Errorf("deparse: unsupported ALTER NETWORK RULE action %d", n.Action)
+	}
+	return nil
+}
+
+// writeAlterSessionStmt emits ALTER SESSION { SET | UNSET } <session_parameter>
+// ... (session parameters, gap-alter-family).
+func (w *writer) writeAlterSessionStmt(n *ast.AlterSessionStmt) error {
+	w.buf.WriteString("ALTER SESSION")
+	switch n.Action {
+	case ast.AlterSessionSet:
+		w.buf.WriteString(" SET")
+		if err := w.writeCopyOptions(n.Options); err != nil {
+			return err
+		}
+	case ast.AlterSessionUnset:
+		w.buf.WriteString(" UNSET ")
+		w.buf.WriteString(strings.Join(n.UnsetKeys, ", "))
+	default:
+		return fmt.Errorf("deparse: unsupported ALTER SESSION action %d", n.Action)
 	}
 	return nil
 }

--- a/snowflake/parser/alter_family_test.go
+++ b/snowflake/parser/alter_family_test.go
@@ -1,0 +1,319 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// ALTER SESSION { SET | UNSET } <session_parameter> ... (gap-alter-family)
+// ---------------------------------------------------------------------------
+
+func mustAlterSession(t *testing.T, input string) *ast.AlterSessionStmt {
+	t.Helper()
+	node := mustParseOne(t, input)
+	stmt, ok := node.(*ast.AlterSessionStmt)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.AlterSessionStmt", input, node)
+	}
+	return stmt
+}
+
+func TestAlterSession_Set(t *testing.T) {
+	stmt := mustAlterSession(t, "ALTER SESSION SET LOCK_TIMEOUT = 3600")
+	if stmt.Action != ast.AlterSessionSet {
+		t.Fatalf("action = %v, want AlterSessionSet", stmt.Action)
+	}
+	if len(stmt.Options) != 1 {
+		t.Fatalf("Options len = %d, want 1", len(stmt.Options))
+	}
+	opt := stmt.Options[0]
+	if opt.Name != "LOCK_TIMEOUT" {
+		t.Errorf("option name = %q, want LOCK_TIMEOUT", opt.Name)
+	}
+	if opt.Lit == nil || opt.Lit.Ival != 3600 {
+		t.Errorf("option value = %+v, want int 3600", opt.Lit)
+	}
+}
+
+func TestAlterSession_SetStringValue(t *testing.T) {
+	stmt := mustAlterSession(t, "ALTER SESSION SET DEFAULT_NULL_ORDERING = 'LAST'")
+	if stmt.Action != ast.AlterSessionSet {
+		t.Fatalf("action = %v, want AlterSessionSet", stmt.Action)
+	}
+	opt := stmt.Options[0]
+	if opt.Name != "DEFAULT_NULL_ORDERING" {
+		t.Errorf("option name = %q, want DEFAULT_NULL_ORDERING", opt.Name)
+	}
+	if opt.Lit == nil || opt.Lit.Kind != ast.LitString || opt.Lit.Value != "LAST" {
+		t.Errorf("option value = %+v, want string 'LAST'", opt.Lit)
+	}
+}
+
+func TestAlterSession_SetNoSpaceWord(t *testing.T) {
+	// ERROR_ON_NONDETERMINISTIC_UPDATE=TRUE (no surrounding spaces, word value).
+	stmt := mustAlterSession(t, "ALTER SESSION SET ERROR_ON_NONDETERMINISTIC_UPDATE=TRUE")
+	opt := stmt.Options[0]
+	if opt.Name != "ERROR_ON_NONDETERMINISTIC_UPDATE" {
+		t.Errorf("option name = %q", opt.Name)
+	}
+	if opt.Words != "TRUE" {
+		t.Errorf("option words = %q, want TRUE", opt.Words)
+	}
+}
+
+func TestAlterSession_SetMultiple(t *testing.T) {
+	stmt := mustAlterSession(t, "ALTER SESSION SET AUTOCOMMIT = TRUE LOCK_TIMEOUT = 3600")
+	if len(stmt.Options) != 2 {
+		t.Fatalf("Options len = %d, want 2", len(stmt.Options))
+	}
+	if stmt.Options[0].Name != "AUTOCOMMIT" || stmt.Options[1].Name != "LOCK_TIMEOUT" {
+		t.Errorf("option names = [%q %q], want [AUTOCOMMIT LOCK_TIMEOUT]",
+			stmt.Options[0].Name, stmt.Options[1].Name)
+	}
+}
+
+func TestAlterSession_Unset(t *testing.T) {
+	stmt := mustAlterSession(t, "ALTER SESSION UNSET LOCK_TIMEOUT")
+	if stmt.Action != ast.AlterSessionUnset {
+		t.Fatalf("action = %v, want AlterSessionUnset", stmt.Action)
+	}
+	if len(stmt.UnsetKeys) != 1 || stmt.UnsetKeys[0] != "LOCK_TIMEOUT" {
+		t.Errorf("UnsetKeys = %v, want [LOCK_TIMEOUT]", stmt.UnsetKeys)
+	}
+}
+
+func TestAlterSession_UnsetMultiple(t *testing.T) {
+	stmt := mustAlterSession(t, "ALTER SESSION UNSET LOCK_TIMEOUT, AUTOCOMMIT")
+	if len(stmt.UnsetKeys) != 2 || stmt.UnsetKeys[0] != "LOCK_TIMEOUT" || stmt.UnsetKeys[1] != "AUTOCOMMIT" {
+		t.Errorf("UnsetKeys = %v, want [LOCK_TIMEOUT AUTOCOMMIT]", stmt.UnsetKeys)
+	}
+}
+
+func TestAlterSession_Loc(t *testing.T) {
+	input := "ALTER SESSION SET LOCK_TIMEOUT = 3600"
+	stmt := mustAlterSession(t, input)
+	// Loc.Start anchors at the SESSION keyword (ALTER convention), not ALTER.
+	if stmt.Loc.Start != len("ALTER ") {
+		t.Errorf("Loc.Start = %d, want %d (SESSION keyword)", stmt.Loc.Start, len("ALTER "))
+	}
+	if int(stmt.Loc.End) != len(input) {
+		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
+	}
+}
+
+func TestAlterSession_Negatives(t *testing.T) {
+	for _, in := range []string{
+		"ALTER SESSION SET",          // SET with nothing settable
+		"ALTER SESSION UNSET",        // UNSET with no keys
+		"ALTER SESSION SET = 3600",   // missing parameter name
+		"ALTER SESSION FROBNICATE x", // unknown action keyword
+	} {
+		if _, errs := parseSingle(in, 0); len(errs) == 0 {
+			t.Errorf("expected parse error for %q, got none", in)
+		}
+	}
+}
+
+// TestAlterSessionPolicy_NotRegressed confirms that ALTER SESSION POLICY (a
+// policy object) is still routed to the policy parser and NOT to the new
+// session-parameter parser.
+func TestAlterSessionPolicy_NotRegressed(t *testing.T) {
+	node := mustParseOne(t, "ALTER SESSION POLICY sp RENAME TO sp2")
+	if _, ok := node.(*ast.AlterSessionStmt); ok {
+		t.Fatalf("ALTER SESSION POLICY mis-routed to *ast.AlterSessionStmt")
+	}
+	stmt, ok := node.(*ast.AlterPolicyStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.AlterPolicyStmt", node)
+	}
+	_ = stmt
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TABLE ... SEARCH OPTIMIZATION ON <method>(<cols>) [, ...]
+// ---------------------------------------------------------------------------
+
+func TestAlterTable_SearchOptMultiColumn(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(c1, c2, c3)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableAddSearchOpt {
+		t.Fatalf("kind = %v, want AlterTableAddSearchOpt", a.Kind)
+	}
+	if len(a.SearchOptOn) != 1 || a.SearchOptOn[0] != "EQUALITY(c1, c2, c3)" {
+		t.Errorf("SearchOptOn = %v, want [EQUALITY(c1, c2, c3)]", a.SearchOptOn)
+	}
+}
+
+func TestAlterTable_SearchOptMethodList(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t1 ADD SEARCH OPTIMIZATION ON EQUALITY(c1), EQUALITY(c2, c3)")
+	a := requireAction(t, stmt, 0)
+	if len(a.SearchOptOn) != 2 {
+		t.Fatalf("SearchOptOn len = %d, want 2 (%v)", len(a.SearchOptOn), a.SearchOptOn)
+	}
+	if a.SearchOptOn[0] != "EQUALITY(c1)" || a.SearchOptOn[1] != "EQUALITY(c2, c3)" {
+		t.Errorf("SearchOptOn = %v, want [EQUALITY(c1) EQUALITY(c2, c3)]", a.SearchOptOn)
+	}
+}
+
+func TestAlterTable_SearchOptDropMethodList(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t1 DROP SEARCH OPTIMIZATION ON EQUALITY(c1, c2)")
+	a := requireAction(t, stmt, 0)
+	if a.Kind != ast.AlterTableDropSearchOpt {
+		t.Fatalf("kind = %v, want AlterTableDropSearchOpt", a.Kind)
+	}
+	if len(a.SearchOptOn) != 1 || a.SearchOptOn[0] != "EQUALITY(c1, c2)" {
+		t.Errorf("SearchOptOn = %v, want [EQUALITY(c1, c2)]", a.SearchOptOn)
+	}
+}
+
+func TestAlterTable_SearchOptStar(t *testing.T) {
+	stmt := requireAlterTable(t, "ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(*)")
+	a := requireAction(t, stmt, 0)
+	if len(a.SearchOptOn) != 1 || a.SearchOptOn[0] != "EQUALITY(*)" {
+		t.Errorf("SearchOptOn = %v, want [EQUALITY(*)]", a.SearchOptOn)
+	}
+}
+
+func TestAlterTable_SearchOptNegatives(t *testing.T) {
+	for _, in := range []string{
+		"ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(",      // unterminated
+		"ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(c1,",   // trailing comma, no col
+		"ALTER TABLE t ADD SEARCH OPTIMIZATION ON EQUALITY(c1) ,", // trailing comma, no method
+	} {
+		if _, errs := parseSingle(in, 0); len(errs) == 0 {
+			t.Errorf("expected parse error for %q, got none", in)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ALTER VIEW ... SET/UNSET { JOIN | AGGREGATION } POLICY
+// ---------------------------------------------------------------------------
+
+func TestAlterView_SetJoinPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW join_view SET JOIN POLICY jp1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewSetJoinPolicy {
+		t.Errorf("action = %v, want AlterViewSetJoinPolicy", stmt.Action)
+	}
+	if stmt.PolicyName == nil || stmt.PolicyName.Normalize() != "JP1" {
+		t.Errorf("policy name = %v, want JP1", stmt.PolicyName)
+	}
+	if stmt.PolicyKeyKind != "" || len(stmt.PolicyKeyCols) != 0 {
+		t.Errorf("unexpected key clause: kind=%q cols=%v", stmt.PolicyKeyKind, stmt.PolicyKeyCols)
+	}
+}
+
+func TestAlterView_SetJoinPolicyAllowedKeys(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET JOIN POLICY jp1 ALLOWED JOIN KEYS (a, b)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.PolicyKeyKind != "ALLOWED" {
+		t.Errorf("key kind = %q, want ALLOWED", stmt.PolicyKeyKind)
+	}
+	if len(stmt.PolicyKeyCols) != 2 {
+		t.Errorf("key cols = %v, want 2", stmt.PolicyKeyCols)
+	}
+}
+
+func TestAlterView_SetJoinPolicyEnforcedKeys(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET JOIN POLICY jp1 ENFORCED JOIN KEYS (a)")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.PolicyKeyKind != "ENFORCED" {
+		t.Errorf("key kind = %q, want ENFORCED", stmt.PolicyKeyKind)
+	}
+}
+
+func TestAlterView_UnsetJoinPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v UNSET JOIN POLICY")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewUnsetJoinPolicy {
+		t.Errorf("action = %v, want AlterViewUnsetJoinPolicy", stmt.Action)
+	}
+}
+
+func TestAlterView_SetAggregationPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET AGGREGATION POLICY ap1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewSetAggregationPolicy {
+		t.Errorf("action = %v, want AlterViewSetAggregationPolicy", stmt.Action)
+	}
+	if stmt.PolicyName == nil || stmt.PolicyName.Normalize() != "AP1" {
+		t.Errorf("policy name = %v, want AP1", stmt.PolicyName)
+	}
+}
+
+func TestAlterView_SetAggregationPolicyEntityKeyForce(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v SET AGGREGATION POLICY ap1 ENTITY KEY (a, b) FORCE")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.PolicyKeyCols) != 2 {
+		t.Errorf("entity key cols = %v, want 2", stmt.PolicyKeyCols)
+	}
+	if !stmt.PolicyForce {
+		t.Error("expected PolicyForce=true")
+	}
+}
+
+func TestAlterView_UnsetAggregationPolicy(t *testing.T) {
+	stmt, errs := testParseAlterView("ALTER VIEW v UNSET AGGREGATION POLICY")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Action != ast.AlterViewUnsetAggregationPolicy {
+		t.Errorf("action = %v, want AlterViewUnsetAggregationPolicy", stmt.Action)
+	}
+}
+
+func TestAlterView_PolicyNegatives(t *testing.T) {
+	for _, in := range []string{
+		"ALTER VIEW v SET JOIN jp1",                // missing POLICY
+		"ALTER VIEW v SET JOIN POLICY",             // missing name
+		"ALTER VIEW v SET AGGREGATION jp1",         // missing POLICY
+		"ALTER VIEW v SET JOIN POLICY jp1 ALLOWED", // ALLOWED with no JOIN KEYS (...)
+		"ALTER VIEW v UNSET JOIN",                  // missing POLICY
+	} {
+		if _, errs := parseSingle(in, 0); len(errs) == 0 {
+			t.Errorf("expected parse error for %q, got none", in)
+		}
+	}
+}
+
+// TestAlterView_ExistingFormsNotRegressed confirms the previously-supported
+// ALTER VIEW forms still parse unchanged after adding the policy SET branches.
+func TestAlterView_ExistingFormsNotRegressed(t *testing.T) {
+	cases := []struct {
+		in   string
+		want ast.AlterViewAction
+	}{
+		{"ALTER VIEW v RENAME TO v2", ast.AlterViewRename},
+		{"ALTER VIEW v SET SECURE", ast.AlterViewSetSecure},
+		{"ALTER VIEW v UNSET SECURE", ast.AlterViewUnsetSecure},
+		{"ALTER VIEW v SET COMMENT = 'x'", ast.AlterViewSetComment},
+		{"ALTER VIEW v SET TAG (t = 'v')", ast.AlterViewSetTag},
+		{"ALTER VIEW v ADD ROW ACCESS POLICY rap ON (c1)", ast.AlterViewAddRowAccessPolicy},
+		{"ALTER VIEW v DROP ROW ACCESS POLICY rap", ast.AlterViewDropRowAccessPolicy},
+	}
+	for _, c := range cases {
+		stmt, errs := testParseAlterView(c.in)
+		if len(errs) > 0 {
+			t.Errorf("unexpected errors for %q: %v", c.in, errs)
+			continue
+		}
+		if stmt.Action != c.want {
+			t.Errorf("%q: action = %v, want %v", c.in, stmt.Action, c.want)
+		}
+	}
+}

--- a/snowflake/parser/alter_table.go
+++ b/snowflake/parser/alter_table.go
@@ -389,9 +389,22 @@ func (p *Parser) parseAddColumnList(action *ast.AlterTableAction) error {
 	return nil
 }
 
-// parseSearchOptTargets parses the ON method(target) list for SEARCH OPTIMIZATION.
+// searchOptMethodCap bounds the comma-separated method list so a malformed
+// input can never spin.
+const searchOptMethodCap = 1024
+
+// parseSearchOptTargets parses the `ON <method>(<target> [, ...]) [, ...]` list
+// for SEARCH OPTIMIZATION. Each method (EQUALITY, SUBSTRING, GEO, or an
+// identifier) takes a parenthesized target that is either '*' or a
+// comma-separated list of column/path expressions (e.g.
+// EQUALITY(c1, c2, c3) or EQUALITY(src:user.id)). The whole methods list may be
+// comma-separated (e.g. EQUALITY(c1), EQUALITY(c2, c3)). The verbatim source of
+// each method clause is recorded in SearchOptOn so the form round-trips.
 func (p *Parser) parseSearchOptTargets(action *ast.AlterTableAction) error {
-	for {
+	for i := 0; ; i++ {
+		if i >= searchOptMethodCap {
+			return p.syntaxErrorAtCur()
+		}
 		// method can be EQUALITY, SUBSTRING, GEO, or an identifier
 		var method string
 		switch p.cur.Type {
@@ -410,22 +423,30 @@ func (p *Parser) parseSearchOptTargets(action *ast.AlterTableAction) error {
 		default:
 			return p.syntaxErrorAtCur()
 		}
-		// (STAR | expr)
+		// ( STAR | expr [, expr ...] )
 		if _, err := p.expect('('); err != nil {
 			return err
 		}
+		// Capture the verbatim target text spanning the parenthesized content.
+		innerStart := p.cur.Loc.Start
 		var target string
 		if p.cur.Type == '*' {
 			p.advance()
 			target = "*"
 		} else {
-			// skip expression tokens until matching ')'
-			expr, err := p.parseExpr()
-			if err != nil {
-				return err
+			for j := 0; ; j++ {
+				if j >= searchOptMethodCap {
+					return p.syntaxErrorAtCur()
+				}
+				if _, err := p.parseExpr(); err != nil {
+					return err
+				}
+				if p.cur.Type != ',' {
+					break
+				}
+				p.advance() // consume ',' between target columns
 			}
-			_ = expr
-			target = "expr"
+			target = p.srcSlice(innerStart, p.prev.Loc.End)
 		}
 		if _, err := p.expect(')'); err != nil {
 			return err
@@ -434,7 +455,7 @@ func (p *Parser) parseSearchOptTargets(action *ast.AlterTableAction) error {
 		if p.cur.Type != ',' {
 			break
 		}
-		p.advance() // consume ','
+		p.advance() // consume ',' between methods
 	}
 	return nil
 }

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -164,27 +164,6 @@ var corpusWholeFile = map[string]string{
 //
 // Grouped by root cause. Counts in comments are at authoring time.
 var corpusSkips = map[string]string{
-	// --- RESIDUAL GAP: ALTER statement family (parser-alter node not built) ---
-	// The generic ALTER dispatcher returns "ALTER statement parsing is not yet
-	// supported"; ALTER SESSION / WAREHOUSE / DATABASE / ACCOUNT / ... are all
-	// pending. Some files are docs pages for a *built* command whose page also
-	// shows an ALTER follow-up as their only statement(s).
-	"legacy/alter.sql":                        "RESIDUAL GAP: ALTER {ACCOUNT,DATABASE,SESSION,SHARE,...} family — parser-alter node not built",
-	"official/alter-session/example_01.sql":   "RESIDUAL GAP: ALTER SESSION SET — parser-alter node not built",
-	"official/alter-session/example_02.sql":   "RESIDUAL GAP: ALTER SESSION UNSET — parser-alter node not built",
-	"official/create-database/example_08.sql": "CONTEXT: file is a lone ALTER SESSION SET (create-database page follow-up) — parser-alter not built",
-	"official/order-by/example_04.sql":        "RESIDUAL GAP: ALTER SESSION SET DEFAULT_NULL_ORDERING — parser-alter node not built",
-	"official/order-by/example_07.sql":        "RESIDUAL GAP: ALTER SESSION SET DEFAULT_NULL_ORDERING — parser-alter node not built",
-	"official/update/example_04.sql":          "RESIDUAL GAP: ALTER SESSION SET (update page setup) — parser-alter node not built",
-
-	// --- RESIDUAL GAP: ALTER TABLE ADD SEARCH OPTIMIZATION ON method-list ---
-	"official/alter-table-event-table/example_07.sql": "RESIDUAL GAP: ALTER TABLE ADD SEARCH OPTIMIZATION ON EQUALITY(c1), EQUALITY(c2,c3) — comma-separated method list not parsed",
-	"official/alter-table-event-table/example_08.sql": "RESIDUAL GAP: ALTER TABLE ADD/DROP SEARCH OPTIMIZATION ON comma-separated method list not parsed",
-	"official/alter-table-event-table/example_09.sql": "RESIDUAL GAP: ALTER TABLE DROP SEARCH OPTIMIZATION ON comma-separated method list not parsed",
-
-	// --- RESIDUAL GAP: ALTER VIEW with a re-defined query body ---
-	"official/alter-view/example_11.sql": "RESIDUAL GAP: ALTER VIEW ... AS <join query> body redefinition not parsed",
-
 	// --- RESIDUAL GAP: SHOW ->> result-pipe + $N table-ref (other nodes) ---
 	// CREATE/ALTER WAREHOUSE now parse (gap-warehouse); this file remains skipped
 	// only because its two `SHOW WAREHOUSES ... ->> SELECT ... FROM $1` statements
@@ -236,7 +215,7 @@ var corpusSkips = map[string]string{
 	"official/order-by/example_01.sql": "RESIDUAL GAP: ORDER BY ALL not parsed",
 	"official/order-by/example_11.sql": "RESIDUAL GAP: ORDER BY ALL not parsed",
 	"official/order-by/example_12.sql": "RESIDUAL GAP: ORDER BY ALL ASC not parsed",
-	"official/order-by/example_13.sql": "RESIDUAL GAP: ORDER BY ALL not parsed (also ALTER SESSION)",
+	"official/order-by/example_13.sql": "RESIDUAL GAP: ORDER BY ALL not parsed (ALTER SESSION setup now parses)",
 	"official/order-by/example_14.sql": "RESIDUAL GAP: ORDER BY ALL NULLS FIRST not parsed",
 	"official/order-by/example_15.sql": "RESIDUAL GAP: ORDER BY ALL NULLS LAST not parsed",
 	"official/merge/example_09.sql":    "RESIDUAL GAP: WHEN MATCHED ... DELETE / ORDER BY ALL form not parsed",

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -1,6 +1,10 @@
 package parser
 
-import "github.com/bytebase/omni/snowflake/ast"
+import (
+	"strings"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
 
 // ---------------------------------------------------------------------------
 // CREATE DATABASE
@@ -262,6 +266,15 @@ func (p *Parser) parseAlterStmt() (ast.Node, error) {
 		// by kwPOLICY. The RULE form is dispatched here before the shared policy path.
 		if p.cur.Type == kwNETWORK && p.peekIsWord("RULE") {
 			return p.parseAlterNetworkRuleStmt()
+		}
+		// ALTER SESSION { SET | UNSET } <param> ... (session parameters,
+		// gap-alter-family) vs ALTER SESSION POLICY <name> ... (a policy object).
+		// SESSION followed by SET/UNSET is session parameters; SESSION followed by
+		// POLICY stays on the policy path below.
+		if p.cur.Type == kwSESSION {
+			if next := p.peekNext().Type; next == kwSET || next == kwUNSET {
+				return p.parseAlterSessionStmt()
+			}
 		}
 		// ALTER { MASKING | ROW ACCESS | SESSION | PASSWORD | NETWORK } POLICY ...
 		// (T4.6). Only routed to the policy parser when the kind keyword is actually
@@ -594,6 +607,102 @@ func (p *Parser) parseAlterSchemaStmt() (ast.Node, error) {
 
 	stmt.Loc.End = p.prev.Loc.End
 	return stmt, nil
+}
+
+// ---------------------------------------------------------------------------
+// ALTER SESSION (session parameters)
+// ---------------------------------------------------------------------------
+
+// sessionParamCap bounds the open-ended `<param> = <value>` run of an
+// ALTER SESSION SET so a malformed input can never spin.
+const sessionParamCap = 1024
+
+// parseAlterSessionStmt parses ALTER SESSION { SET | UNSET } <session_parameter>
+// ... (session parameters). The ALTER keyword has already been consumed; cur is
+// SESSION. ALTER SESSION POLICY ... is routed to the policy parser by the
+// dispatch in parseAlterStmt, so SESSION here is always followed by SET/UNSET.
+func (p *Parser) parseAlterSessionStmt() (ast.Node, error) {
+	sessTok := p.advance() // consume SESSION (anchors Loc.Start at the object keyword)
+	stmt := &ast.AlterSessionStmt{Loc: ast.Loc{Start: sessTok.Loc.Start}}
+
+	switch p.cur.Type {
+	case kwSET:
+		p.advance() // consume SET
+		opts, err := p.parseSessionParamOptions()
+		if err != nil {
+			return nil, err
+		}
+		if len(opts) == 0 {
+			// SET with nothing settable is a syntax error.
+			return nil, p.syntaxErrorAtCur()
+		}
+		stmt.Action = ast.AlterSessionSet
+		stmt.Options = opts
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		keys, err := p.parseSessionParamUnsetKeys()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Action = ast.AlterSessionUnset
+		stmt.UnsetKeys = keys
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseSessionParamUnsetKeys reads the comma-separated parameter-name list of an
+// ALTER SESSION UNSET. Session parameter names are open-ended: most lex as
+// reserved keywords (LOCK_TIMEOUT, AUTOCOMMIT, ...), so any option word is
+// accepted (not only the closed DB-property set parsePropertyName allows). The
+// names are uppercased; the loop is bounded.
+func (p *Parser) parseSessionParamUnsetKeys() ([]string, error) {
+	var keys []string
+	for i := 0; ; i++ {
+		if i >= sessionParamCap {
+			return nil, p.syntaxErrorAtCur()
+		}
+		if !p.isOptionWord(p.cur.Type) {
+			return nil, p.syntaxErrorAtCur()
+		}
+		keys = append(keys, strings.ToUpper(p.advance().Str))
+		if p.cur.Type == ',' {
+			p.advance() // consume ','
+			continue
+		}
+		break
+	}
+	return keys, nil
+}
+
+// parseSessionParamOptions reads the open-ended `<param> = <value>` run of an
+// ALTER SESSION SET (e.g. AUTOCOMMIT = TRUE, LOCK_TIMEOUT = 3600,
+// DEFAULT_NULL_ORDERING = 'LAST'). Each entry is a CopyOption so any name/value
+// shape (word, number, or string literal) is captured. The loop is bounded and
+// guards against a non-advancing token.
+func (p *Parser) parseSessionParamOptions() ([]*ast.CopyOption, error) {
+	var opts []*ast.CopyOption
+	for i := 0; p.startsCopyOption(); i++ {
+		if i >= sessionParamCap {
+			return nil, p.syntaxErrorAtCur()
+		}
+		before := p.cur.Loc.Start
+		opt, err := p.parseCopyOption()
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, opt)
+		if p.cur.Loc.Start == before && p.cur.Type != tokEOF {
+			// No forward progress on a non-EOF token: abort rather than spin.
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	return opts, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/view.go
+++ b/snowflake/parser/view.go
@@ -585,7 +585,21 @@ func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
 			stmt.Action = ast.AlterViewSetTag
 			stmt.Tags = tags
 
+		case kwJOIN:
+			// SET JOIN POLICY name [ { ALLOWED | ENFORCED } JOIN KEYS ( col, ... ) ]
+			if err := p.parseAlterViewSetJoinPolicy(stmt); err != nil {
+				return nil, err
+			}
+
 		default:
+			// SET AGGREGATION POLICY name [ ENTITY KEY ( col, ... ) ] [ FORCE ].
+			// AGGREGATION is not a reserved keyword, so it lexes as an identifier.
+			if p.curIsWord("AGGREGATION") {
+				if err := p.parseAlterViewSetAggregationPolicy(stmt); err != nil {
+					return nil, err
+				}
+				break
+			}
 			return nil, p.syntaxErrorAtCur()
 		}
 
@@ -608,7 +622,24 @@ func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
 			stmt.Action = ast.AlterViewUnsetTag
 			stmt.UnsetTags = names
 
+		case kwJOIN:
+			// UNSET JOIN POLICY
+			p.advance() // consume JOIN
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return nil, err
+			}
+			stmt.Action = ast.AlterViewUnsetJoinPolicy
+
 		default:
+			// UNSET AGGREGATION POLICY (AGGREGATION lexes as an identifier).
+			if p.curIsWord("AGGREGATION") {
+				p.advance() // consume AGGREGATION
+				if _, err := p.expect(kwPOLICY); err != nil {
+					return nil, err
+				}
+				stmt.Action = ast.AlterViewUnsetAggregationPolicy
+				break
+			}
 			return nil, p.syntaxErrorAtCur()
 		}
 
@@ -783,6 +814,88 @@ func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
 
 	stmt.Loc.End = p.prev.Loc.End
 	return stmt, nil
+}
+
+// parseAlterViewSetJoinPolicy parses
+//
+//	SET JOIN POLICY <name> [ { ALLOWED | ENFORCED } JOIN KEYS ( col, ... ) ]
+//
+// On entry cur is the JOIN keyword. ALLOWED lexes as an identifier; ENFORCED is
+// a reserved keyword.
+func (p *Parser) parseAlterViewSetJoinPolicy(stmt *ast.AlterViewStmt) error {
+	p.advance() // consume JOIN
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return err
+	}
+	name, err := p.parseObjectName()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterViewSetJoinPolicy
+	stmt.PolicyName = name
+
+	// Optional { ALLOWED | ENFORCED } JOIN KEYS ( col, ... ).
+	var kind string
+	if p.curIsWord("ALLOWED") {
+		kind = "ALLOWED"
+		p.advance() // consume ALLOWED
+	} else if p.cur.Type == kwENFORCED {
+		kind = "ENFORCED"
+		p.advance() // consume ENFORCED
+	}
+	if kind != "" {
+		if _, err := p.expect(kwJOIN); err != nil {
+			return err
+		}
+		if _, err := p.expect(kwKEYS); err != nil {
+			return err
+		}
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return err
+		}
+		stmt.PolicyKeyKind = kind
+		stmt.PolicyKeyCols = cols
+	}
+	return nil
+}
+
+// parseAlterViewSetAggregationPolicy parses
+//
+//	SET AGGREGATION POLICY <name> [ ENTITY KEY ( col, ... ) ] [ FORCE ]
+//
+// On entry cur is the AGGREGATION identifier. ENTITY lexes as an identifier.
+func (p *Parser) parseAlterViewSetAggregationPolicy(stmt *ast.AlterViewStmt) error {
+	p.advance() // consume AGGREGATION
+	if _, err := p.expect(kwPOLICY); err != nil {
+		return err
+	}
+	name, err := p.parseObjectName()
+	if err != nil {
+		return err
+	}
+	stmt.Action = ast.AlterViewSetAggregationPolicy
+	stmt.PolicyName = name
+
+	// Optional ENTITY KEY ( col, ... ).
+	if p.curIsWord("ENTITY") {
+		p.advance() // consume ENTITY
+		if _, err := p.expect(kwKEY); err != nil {
+			return err
+		}
+		cols, err := p.parseIdentListInParens()
+		if err != nil {
+			return err
+		}
+		stmt.PolicyKeyCols = cols
+	}
+
+	// Optional FORCE.
+	if p.cur.Type == kwFORCE {
+		p.advance() // consume FORCE
+		stmt.PolicyForce = true
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Node
`snowflake/gap-alter-family` (phase-2 corpus-gap closure) — close the remaining ALTER-statement gaps (corpus-test-driven). The existing `parseAlterStmt` already covered ~25 object types; this fills the genuine gaps the corpus surfaced.

## What was actually missing (narrower than the v1 skip-reasons implied)
INTEGRATION / CONNECTION / RESOURCE MONITOR / ACCOUNT / SHARE ALTERs already parsed (existing `parseAlterIntegrationStmt`). The three real gaps:
1. **ALTER SESSION SET/UNSET `<param>`** — was mis-routed to the policy dispatch (which expects `SESSION POLICY`) → `unsupported`. Now: after `ALTER SESSION`, `SET`/`UNSET` → new `AlterSessionStmt` (params), `POLICY` → unchanged policy path. **(real regression vs legacy — fixed)**
2. **ALTER TABLE … ADD/DROP SEARCH OPTIMIZATION ON `<method>(<cols>) [, …]`** — the old handler couldn't parse multiple columns in one method, let alone a comma-separated method list. Rewrote `parseSearchOptTargets` with verbatim source capture (`srcSlice`), which also **fixes a pre-existing deparse bug** (old code emitted the literal placeholder `"expr"`).
3. **ALTER VIEW SET/UNSET JOIN POLICY / AGGREGATION POLICY** — docs-ahead (absent from the 2026-04 legacy `.g4`). The skip's "AS body redefinition" reason was wrong; the file is `SET JOIN POLICY`.

## Corpus delta (TestCorpusClosure)
**602 → 613 clean, 53 → 42 skipped — 11 files closed** (`legacy/alter.sql`, `alter-session/01-02`, `create-database/08`, `order-by/04,07`, `update/04`, `alter-table-event-table/07-09`, `alter-view/11`). `order-by/example_13` left skipped (still needs ORDER BY ALL, owned by gap-select-ext) with its reason narrowed.

## Regression confirmation (explicit tests)
- `TestAlterSessionPolicy_NotRegressed` — `ALTER SESSION POLICY … RENAME TO …` still → `*ast.AlterPolicyStmt`.
- `TestAlterView_ExistingFormsNotRegressed` — RENAME / SET SECURE / SET COMMENT / SET TAG / ADD+DROP ROW ACCESS POLICY unchanged.

## Review (`/code-review` high; Codex down) — no correctness bugs
Verified: no trailing-whitespace in `srcSlice`; all loops bounded + progress-guarded (cap 1024); case-insensitive matching for non-keyword words (AGGREGATION/ALLOWED/ENTITY); NodeTag insertion safe (in-memory dispatch). 35 new tests (parse + Loc + negatives + deparse round-trips). Orchestrator independently verified on a fresh checkout of `00c81e0b`: gofmt/vet/build clean, full `go test ./snowflake/... -timeout 120s` green (7 pkgs), both regression tests green, corpus self-prune green.

## Divergences / notes
- ALTER VIEW JOIN/AGGREGATION POLICY: docs-ahead (no legacy rule).
- INTEGRATION/CONNECTION/RESOURCE MONITOR ALTERs parse but (like sequence/account/share, pre-existing) have no deparse — not introduced here; the new `AlterSessionStmt` does deparse.

## Note
Opened by orchestrator from verified pushed commit `00c81e0b`. Phase-2 gap 4/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
