### PR TITLE
feat(snowflake): DROP object variants + DROP ALERT + INTERACTIVE MATERIALIZED VIEW (phase-2 gap-drop-create-variants) — close corpus gaps 172,173,174

### DIFF
--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1571,6 +1571,19 @@ const (
 	DropRole                            // DROP ROLE
 	DropWarehouse                       // DROP WAREHOUSE
 	DropNetworkRule                     // DROP NETWORK RULE
+	DropAlert                           // DROP ALERT
+	DropConnection                      // DROP CONNECTION
+	DropFailoverGroup                   // DROP FAILOVER GROUP
+	DropIntegration                     // DROP INTEGRATION
+	DropManagedAccount                  // DROP MANAGED ACCOUNT
+	DropMaskingPolicy                   // DROP MASKING POLICY
+	DropNetworkPolicy                   // DROP NETWORK POLICY
+	DropReplicationGroup                // DROP REPLICATION GROUP
+	DropResourceMonitor                 // DROP RESOURCE MONITOR
+	DropRowAccessPolicy                 // DROP ROW ACCESS POLICY
+	DropSessionPolicy                   // DROP SESSION POLICY
+	DropShare                           // DROP SHARE
+	DropUser                            // DROP USER
 )
 
 // String returns the SQL object-type keyword for the kind.
@@ -1610,6 +1623,32 @@ func (k DropObjectKind) String() string {
 		return "WAREHOUSE"
 	case DropNetworkRule:
 		return "NETWORK RULE"
+	case DropAlert:
+		return "ALERT"
+	case DropConnection:
+		return "CONNECTION"
+	case DropFailoverGroup:
+		return "FAILOVER GROUP"
+	case DropIntegration:
+		return "INTEGRATION"
+	case DropManagedAccount:
+		return "MANAGED ACCOUNT"
+	case DropMaskingPolicy:
+		return "MASKING POLICY"
+	case DropNetworkPolicy:
+		return "NETWORK POLICY"
+	case DropReplicationGroup:
+		return "REPLICATION GROUP"
+	case DropResourceMonitor:
+		return "RESOURCE MONITOR"
+	case DropRowAccessPolicy:
+		return "ROW ACCESS POLICY"
+	case DropSessionPolicy:
+		return "SESSION POLICY"
+	case DropShare:
+		return "SHARE"
+	case DropUser:
+		return "USER"
 	default:
 		return "UNKNOWN"
 	}
@@ -1944,6 +1983,7 @@ type CreateMaterializedViewStmt struct {
 	OrReplace   bool
 	OrAlter     bool // CREATE OR ALTER (mutually exclusive with OrReplace)
 	Secure      bool
+	Interactive bool // CREATE INTERACTIVE MATERIALIZED VIEW (INTERACTIVE modifier)
 	IfNotExists bool
 	Name        *ObjectName
 	Columns     []*ViewColumn // optional column list

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -836,6 +836,9 @@ func (w *writer) writeCreateMaterializedViewStmt(n *ast.CreateMaterializedViewSt
 	if n.Secure {
 		w.buf.WriteString(" SECURE")
 	}
+	if n.Interactive {
+		w.buf.WriteString(" INTERACTIVE")
+	}
 	w.buf.WriteString(" MATERIALIZED VIEW")
 	if n.IfNotExists {
 		w.buf.WriteString(" IF NOT EXISTS")

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -742,6 +742,33 @@ func TestDeparse_UndropTable(t *testing.T) {
 	assertRoundTrip(t, `UNDROP TABLE t`)
 }
 
+func TestDeparse_DropObjectVariants(t *testing.T) {
+	// Each newly-supported DROP object variant must round-trip exactly via
+	// DropObjectKind.String(); multi-word kinds reproduce the spaced spelling.
+	cases := []string{
+		`DROP ALERT a`,
+		`DROP CONNECTION c`,
+		`DROP FAILOVER GROUP fg`,
+		`DROP INTEGRATION i`,
+		`DROP MANAGED ACCOUNT ma`,
+		`DROP MASKING POLICY mp`,
+		`DROP NETWORK POLICY np`,
+		`DROP REPLICATION GROUP rg`,
+		`DROP RESOURCE MONITOR rm`,
+		`DROP ROW ACCESS POLICY rap`,
+		`DROP SESSION POLICY sp`,
+		`DROP SHARE s`,
+		`DROP USER u`,
+		`DROP CONNECTION IF EXISTS c`,
+		`DROP MASKING POLICY IF EXISTS mp`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			assertRoundTrip(t, sql)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // VIEW tests
 // ---------------------------------------------------------------------------
@@ -780,6 +807,14 @@ func TestDeparse_CreateMaterializedView_Simple(t *testing.T) {
 
 func TestDeparse_CreateMaterializedView_ClusterBy(t *testing.T) {
 	assertRoundTrip(t, `CREATE MATERIALIZED VIEW mv CLUSTER BY (a) AS SELECT a, b FROM t`)
+}
+
+func TestDeparse_CreateInteractiveMaterializedView(t *testing.T) {
+	assertRoundTrip(t, `CREATE INTERACTIVE MATERIALIZED VIEW mv AS SELECT * FROM t`)
+}
+
+func TestDeparse_CreateInteractiveMaterializedView_OrReplaceIfNotExists(t *testing.T) {
+	assertRoundTrip(t, `CREATE OR REPLACE INTERACTIVE MATERIALIZED VIEW IF NOT EXISTS mv AS SELECT a FROM t`)
 }
 
 func TestDeparse_AlterMaterializedView_Rename(t *testing.T) {

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -171,18 +171,6 @@ var corpusSkips = map[string]string{
 	// CREATE OR ALTER WAREHOUSE and DROP WAREHOUSE statements in it parse clean.
 	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: SHOW WAREHOUSES ->> SELECT ... FROM $1 — ->> result-pipe + $N table-ref owned by other nodes (CREATE OR ALTER WAREHOUSE parses)",
 
-	// --- RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (object node not built) ---
-	// The ALTER WAREHOUSE ADD TABLES statement in this file now parses
-	// (gap-warehouse); it remains skipped only for the CREATE INTERACTIVE
-	// MATERIALIZED VIEW (INTERACTIVE keyword) statement owned by another node.
-	"official/create-materialized-view/example_02.sql": "RESIDUAL GAP: CREATE INTERACTIVE MATERIALIZED VIEW (INTERACTIVE keyword) — object node not built (ALTER WAREHOUSE ADD TABLES parses)",
-
-	// --- RESIDUAL GAP: CREATE/ALTER/DROP ALERT (object node not built) ---
-	"legacy/alerts.sql": "RESIDUAL GAP: CREATE/ALTER/DROP ALERT — alert object node not built",
-
-	// --- RESIDUAL GAP: DROP object variants (parser-drop covers only some objects) ---
-	"legacy/drop.sql": "RESIDUAL GAP: DROP {CONNECTION,FAILOVER GROUP,INTEGRATION,MASKING POLICY,NETWORK POLICY,REPLICATION GROUP,RESOURCE MONITOR,ROW ACCESS POLICY,SESSION POLICY,SHARE,USER,...} not all built",
-
 	// --- RESIDUAL GAP: dynamic-table clauses (named-arg => and INTERVAL/refresh-mode) ---
 	"official/create-dynamic-table/example_04.sql": "RESIDUAL GAP: CLONE ... AT (TIMESTAMP => TO_TIMESTAMP_TZ(...)) named-arg => in time-travel clause",
 	"official/create-dynamic-table/example_07.sql": "RESIDUAL GAP: IMMUTABLE WHERE (... - INTERVAL '1 day') refresh-mode + interval literal not parsed",

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -48,16 +48,28 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		recursive = true
 	}
 
-	// If SECURE or RECURSIVE were consumed, dispatch early on the object type.
-	// RECURSIVE pairs only with VIEW; SECURE additionally precedes
-	// FUNCTION / EXTERNAL FUNCTION / PROCEDURE.
-	if secure || recursive {
+	// Optional INTERACTIVE modifier (MATERIALIZED VIEW-only). INTERACTIVE is not a
+	// reserved keyword (it lexes as a plain identifier), so it is detected the
+	// non-reserved way via curIsWord and only when immediately followed by
+	// MATERIALIZED — otherwise a bare "INTERACTIVE" identifier object is left for
+	// the dispatch switch to reject. INTERACTIVE pairs only with MATERIALIZED VIEW.
+	interactive := false
+	if p.curIsWord("INTERACTIVE") && p.peekNext().Type == kwMATERIALIZED {
+		p.advance() // consume INTERACTIVE
+		interactive = true
+	}
+
+	// If SECURE / RECURSIVE / INTERACTIVE were consumed, dispatch early on the
+	// object type. RECURSIVE pairs only with VIEW; INTERACTIVE only with
+	// MATERIALIZED VIEW; SECURE additionally precedes FUNCTION / EXTERNAL
+	// FUNCTION / PROCEDURE.
+	if secure || recursive || interactive {
 		switch p.cur.Type {
 		case kwVIEW:
 			return p.parseCreateViewStmt(start, orReplace, orAlter, secure, recursive)
 		case kwMATERIALIZED:
 			p.advance() // consume MATERIALIZED
-			return p.parseCreateMaterializedViewStmt(start, orReplace, orAlter, secure)
+			return p.parseCreateMaterializedViewStmt(start, orReplace, orAlter, secure, interactive)
 		case kwFUNCTION:
 			if recursive {
 				return p.unsupported("CREATE")
@@ -137,7 +149,7 @@ func (p *Parser) parseCreateStmt() (ast.Node, error) {
 		return p.parseCreateViewStmt(start, orReplace, orAlter, false, false)
 	case kwMATERIALIZED:
 		p.advance() // consume MATERIALIZED
-		return p.parseCreateMaterializedViewStmt(start, orReplace, orAlter, false)
+		return p.parseCreateMaterializedViewStmt(start, orReplace, orAlter, false, false)
 	case kwSTAGE:
 		// CREATE [OR REPLACE] [TEMP|TEMPORARY] STAGE ... (T4.1).
 		return p.parseCreateStageStmt(start, orReplace, orAlter, temporary)

--- a/snowflake/parser/drop.go
+++ b/snowflake/parser/drop.go
@@ -106,16 +106,100 @@ func (p *Parser) parseDropStmt() (ast.Node, error) {
 		return p.parseDropObject(ast.DropWarehouse, start, true, false)
 
 	case kwNETWORK:
-		// DROP NETWORK RULE (gap-network-rule). NETWORK is reserved but RULE is not,
-		// so NETWORK RULE lexes as kwNETWORK followed by a "RULE" identifier. Only the
-		// RULE form is handled here; other NETWORK objects (e.g. NETWORK POLICY) are
-		// reported as unsupported.
+		// DROP NETWORK RULE (gap-network-rule) and DROP NETWORK POLICY. NETWORK is
+		// reserved but RULE is not, so NETWORK RULE lexes as kwNETWORK followed by a
+		// "RULE" identifier; POLICY is a reserved keyword, so NETWORK POLICY lexes as
+		// kwNETWORK followed by kwPOLICY.
 		if p.peekIsWord("RULE") {
 			p.advance() // consume NETWORK
 			p.advance() // consume RULE
 			return p.parseDropObject(ast.DropNetworkRule, start, true, false)
 		}
+		if p.peekNext().Type == kwPOLICY {
+			p.advance() // consume NETWORK
+			p.advance() // consume POLICY
+			return p.parseDropObject(ast.DropNetworkPolicy, start, true, false)
+		}
 		return p.unsupportedDrop()
+
+	case kwALERT:
+		p.advance() // consume ALERT
+		return p.parseDropObject(ast.DropAlert, start, true, false)
+
+	case kwCONNECTION:
+		p.advance() // consume CONNECTION
+		return p.parseDropObject(ast.DropConnection, start, true, false)
+
+	case kwFAILOVER:
+		// FAILOVER GROUP
+		p.advance() // consume FAILOVER
+		if _, err := p.expect(kwGROUP); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropFailoverGroup, start, true, false)
+
+	case kwINTEGRATION:
+		p.advance() // consume INTEGRATION
+		return p.parseDropObject(ast.DropIntegration, start, true, false)
+
+	case kwMANAGED:
+		// MANAGED ACCOUNT
+		p.advance() // consume MANAGED
+		if _, err := p.expect(kwACCOUNT); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropManagedAccount, start, true, false)
+
+	case kwMASKING:
+		// MASKING POLICY
+		p.advance() // consume MASKING
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropMaskingPolicy, start, true, false)
+
+	case kwREPLICATION:
+		// REPLICATION GROUP
+		p.advance() // consume REPLICATION
+		if _, err := p.expect(kwGROUP); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropReplicationGroup, start, true, false)
+
+	case kwRESOURCE:
+		// RESOURCE MONITOR
+		p.advance() // consume RESOURCE
+		if _, err := p.expect(kwMONITOR); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropResourceMonitor, start, true, false)
+
+	case kwROW:
+		// ROW ACCESS POLICY
+		p.advance() // consume ROW
+		if _, err := p.expect(kwACCESS); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropRowAccessPolicy, start, true, false)
+
+	case kwSESSION:
+		// SESSION POLICY
+		p.advance() // consume SESSION
+		if _, err := p.expect(kwPOLICY); err != nil {
+			return nil, err
+		}
+		return p.parseDropObject(ast.DropSessionPolicy, start, true, false)
+
+	case kwSHARE:
+		p.advance() // consume SHARE
+		return p.parseDropObject(ast.DropShare, start, true, false)
+
+	case kwUSER:
+		p.advance() // consume USER
+		return p.parseDropObject(ast.DropUser, start, true, false)
 
 	default:
 		// Emit a targeted error for recognized-but-unimplemented DROP forms,

--- a/snowflake/parser/drop_test.go
+++ b/snowflake/parser/drop_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/snowflake/ast"
@@ -490,19 +491,182 @@ func TestDropWarehouse_IfExists(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// DROP object variants (gap-drop-create-variants) — single- and multi-word
+// kinds added to close legacy/drop.sql + legacy/alerts.sql (DROP ALERT).
+// ---------------------------------------------------------------------------
+
+func TestDropObjectVariants_Kinds(t *testing.T) {
+	cases := []struct {
+		sql  string
+		kind ast.DropObjectKind
+	}{
+		{"DROP ALERT a", ast.DropAlert},
+		{"DROP CONNECTION c", ast.DropConnection},
+		{"DROP FAILOVER GROUP fg", ast.DropFailoverGroup},
+		{"DROP INTEGRATION i", ast.DropIntegration},
+		{"DROP MANAGED ACCOUNT ma", ast.DropManagedAccount},
+		{"DROP MASKING POLICY mp", ast.DropMaskingPolicy},
+		{"DROP NETWORK POLICY np", ast.DropNetworkPolicy},
+		{"DROP REPLICATION GROUP rg", ast.DropReplicationGroup},
+		{"DROP RESOURCE MONITOR rm", ast.DropResourceMonitor},
+		{"DROP ROW ACCESS POLICY rap", ast.DropRowAccessPolicy},
+		{"DROP SESSION POLICY sp", ast.DropSessionPolicy},
+		{"DROP SHARE s", ast.DropShare},
+		{"DROP USER u", ast.DropUser},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			stmt, errs := testParseDropStmt(tc.sql)
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if stmt.Kind != tc.kind {
+				t.Errorf("kind = %v, want %v", stmt.Kind, tc.kind)
+			}
+			// The trailing identifier is the object name, not stolen by a
+			// multi-word kind matcher.
+			if stmt.Name == nil {
+				t.Fatal("expected an object name")
+			}
+		})
+	}
+}
+
+func TestDropObjectVariants_NameNotStolenByMultiWordKind(t *testing.T) {
+	// The second keyword of a 2-word kind must be consumed as part of the kind,
+	// leaving the following identifier as the object name.
+	stmt, errs := testParseDropStmt("DROP MASKING POLICY my_policy")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropMaskingPolicy {
+		t.Errorf("kind = %v, want DropMaskingPolicy", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "MY_POLICY" {
+		t.Errorf("name = %q, want MY_POLICY", stmt.Name.Normalize())
+	}
+}
+
+func TestDropObjectVariants_IfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP MASKING POLICY IF EXISTS mp")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+	if stmt.Kind != ast.DropMaskingPolicy {
+		t.Errorf("kind = %v, want DropMaskingPolicy", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "MP" {
+		t.Errorf("name = %q, want MP", stmt.Name.Normalize())
+	}
+}
+
+func TestDropObjectVariants_AlertIfExists(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP ALERT IF EXISTS my_alert")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropAlert {
+		t.Errorf("kind = %v, want DropAlert", stmt.Kind)
+	}
+	if !stmt.IfExists {
+		t.Error("expected IfExists=true")
+	}
+}
+
+func TestDropObjectVariants_RowAccessPolicyThreeWord(t *testing.T) {
+	// ROW ACCESS POLICY is a 3-keyword kind; all three must be consumed.
+	stmt, errs := testParseDropStmt("DROP ROW ACCESS POLICY rap1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Kind != ast.DropRowAccessPolicy {
+		t.Errorf("kind = %v, want DropRowAccessPolicy", stmt.Kind)
+	}
+	if stmt.Name.Normalize() != "RAP1" {
+		t.Errorf("name = %q, want RAP1", stmt.Name.Normalize())
+	}
+}
+
+func TestDropObjectVariants_Qualified(t *testing.T) {
+	stmt, errs := testParseDropStmt("DROP MASKING POLICY db.sch.mp")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Name.Normalize() != "DB.SCH.MP" {
+		t.Errorf("name = %q, want DB.SCH.MP", stmt.Name.Normalize())
+	}
+}
+
+// TestDropNetworkRuleVsPolicy is a regression guard: DROP NETWORK RULE (RULE is
+// a non-reserved identifier) and DROP NETWORK POLICY (POLICY is a reserved
+// keyword) must disambiguate to the correct kinds and not collide.
+func TestDropNetworkRuleVsPolicy(t *testing.T) {
+	ruleStmt, errs := testParseDropStmt("DROP NETWORK RULE nr")
+	if len(errs) > 0 {
+		t.Fatalf("DROP NETWORK RULE: unexpected errors: %v", errs)
+	}
+	if ruleStmt.Kind != ast.DropNetworkRule {
+		t.Errorf("kind = %v, want DropNetworkRule", ruleStmt.Kind)
+	}
+
+	policyStmt, errs := testParseDropStmt("DROP NETWORK POLICY np")
+	if len(errs) > 0 {
+		t.Fatalf("DROP NETWORK POLICY: unexpected errors: %v", errs)
+	}
+	if policyStmt.Kind != ast.DropNetworkPolicy {
+		t.Errorf("kind = %v, want DropNetworkPolicy", policyStmt.Kind)
+	}
+}
+
+func TestDropObjectVariants_DropStmtString(t *testing.T) {
+	// DropObjectKind.String() drives deparse; verify the spaced spelling for the
+	// multi-word kinds.
+	cases := []struct {
+		kind ast.DropObjectKind
+		want string
+	}{
+		{ast.DropAlert, "ALERT"},
+		{ast.DropConnection, "CONNECTION"},
+		{ast.DropFailoverGroup, "FAILOVER GROUP"},
+		{ast.DropIntegration, "INTEGRATION"},
+		{ast.DropManagedAccount, "MANAGED ACCOUNT"},
+		{ast.DropMaskingPolicy, "MASKING POLICY"},
+		{ast.DropNetworkPolicy, "NETWORK POLICY"},
+		{ast.DropReplicationGroup, "REPLICATION GROUP"},
+		{ast.DropResourceMonitor, "RESOURCE MONITOR"},
+		{ast.DropRowAccessPolicy, "ROW ACCESS POLICY"},
+		{ast.DropSessionPolicy, "SESSION POLICY"},
+		{ast.DropShare, "SHARE"},
+		{ast.DropUser, "USER"},
+	}
+	for _, tc := range cases {
+		if got := tc.kind.String(); got != tc.want {
+			t.Errorf("DropObjectKind(%d).String() = %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Unsupported DROP object types — targeted error, not generic
 // ---------------------------------------------------------------------------
 
 func TestDropUnsupported_TargetedError(t *testing.T) {
-	// DROP <unrecognized object> should produce a targeted error rather than
-	// a generic "DROP not supported" error.
-	result := ParseBestEffort("DROP NETWORK POLICY foo")
+	// DROP <unrecognized object> should produce a targeted error naming the
+	// object type rather than a generic "DROP not supported" error. SECRET is a
+	// recognized keyword whose DROP form is not yet implemented.
+	result := ParseBestEffort("DROP SECRET foo")
 	if len(result.Errors) == 0 {
-		t.Fatal("expected an error for DROP NETWORK POLICY, got none")
+		t.Fatal("expected an error for DROP SECRET, got none")
 	}
 	msg := result.Errors[0].Msg
 	if msg == "DROP statement parsing is not yet supported" {
 		t.Errorf("got generic DROP error; want targeted error, got: %q", msg)
+	}
+	if !strings.Contains(strings.ToUpper(msg), "SECRET") {
+		t.Errorf("targeted error should name the object type; got: %q", msg)
 	}
 }
 

--- a/snowflake/parser/view.go
+++ b/snowflake/parser/view.go
@@ -424,17 +424,18 @@ func (p *Parser) parseRowAccessPolicyClause() (*ast.RowAccessPolicy, error) {
 // ---------------------------------------------------------------------------
 
 // parseCreateMaterializedViewStmt parses the body of a CREATE [OR REPLACE]
-// [SECURE] MATERIALIZED VIEW statement. The CREATE keyword and OR REPLACE /
-// SECURE modifiers have already been consumed; MATERIALIZED has also been
-// consumed. start is the Loc of the CREATE token.
-func (p *Parser) parseCreateMaterializedViewStmt(start ast.Loc, orReplace, orAlter, secure bool) (ast.Node, error) {
+// [SECURE] [INTERACTIVE] MATERIALIZED VIEW statement. The CREATE keyword and OR
+// REPLACE / SECURE / INTERACTIVE modifiers have already been consumed;
+// MATERIALIZED has also been consumed. start is the Loc of the CREATE token.
+func (p *Parser) parseCreateMaterializedViewStmt(start ast.Loc, orReplace, orAlter, secure, interactive bool) (ast.Node, error) {
 	p.advance() // consume VIEW
 
 	stmt := &ast.CreateMaterializedViewStmt{
-		OrReplace: orReplace,
-		OrAlter:   orAlter,
-		Secure:    secure,
-		Loc:       ast.Loc{Start: start.Start},
+		OrReplace:   orReplace,
+		OrAlter:     orAlter,
+		Secure:      secure,
+		Interactive: interactive,
+		Loc:         ast.Loc{Start: start.Start},
 	}
 
 	// IF NOT EXISTS

--- a/snowflake/parser/view_test.go
+++ b/snowflake/parser/view_test.go
@@ -331,6 +331,80 @@ func TestCreateMaterializedView_IfNotExists(t *testing.T) {
 	}
 }
 
+func TestCreateMaterializedView_Interactive(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE INTERACTIVE MATERIALIZED VIEW mv AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Interactive {
+		t.Error("expected Interactive=true")
+	}
+	if stmt.Name.Normalize() != "MV" {
+		t.Errorf("name = %q, want MV", stmt.Name.Normalize())
+	}
+}
+
+func TestCreateMaterializedView_InteractiveOrReplaceIfNotExists(t *testing.T) {
+	// The exact form from official/create-materialized-view/example_02.sql.
+	stmt, errs := testParseCreateMaterializedView(
+		"CREATE OR REPLACE INTERACTIVE MATERIALIZED VIEW IF NOT EXISTS mv_summary AS SELECT SUM(quantity) FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !stmt.Interactive {
+		t.Error("expected Interactive=true")
+	}
+	if !stmt.OrReplace {
+		t.Error("expected OrReplace=true")
+	}
+	if !stmt.IfNotExists {
+		t.Error("expected IfNotExists=true")
+	}
+}
+
+func TestCreateMaterializedView_NotInteractiveByDefault(t *testing.T) {
+	// Regression: a plain MATERIALIZED VIEW must keep Interactive=false.
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Interactive {
+		t.Error("expected Interactive=false for a plain MATERIALIZED VIEW")
+	}
+}
+
+func TestCreateMaterializedView_InteractiveAsViewName(t *testing.T) {
+	// Regression: "interactive" used as the view name (after MATERIALIZED VIEW)
+	// must NOT set the Interactive modifier — the INTERACTIVE modifier only
+	// triggers when it precedes MATERIALIZED.
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW interactive AS SELECT 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stmt.Interactive {
+		t.Error("expected Interactive=false when 'interactive' is the view name")
+	}
+	if stmt.Name.Normalize() != "INTERACTIVE" {
+		t.Errorf("name = %q, want INTERACTIVE", stmt.Name.Normalize())
+	}
+}
+
+func TestCreateTable_InteractiveAsTableName(t *testing.T) {
+	// Regression: the INTERACTIVE modifier must not steal a table named
+	// "interactive" (INTERACTIVE only pairs with MATERIALIZED VIEW).
+	result := ParseBestEffort("CREATE TABLE interactive (id INT)")
+	if len(result.Errors) > 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	stmt, ok := result.File.Stmts[0].(*ast.CreateTableStmt)
+	if !ok {
+		t.Fatalf("expected CreateTableStmt, got %T", result.File.Stmts[0])
+	}
+	if stmt.Name.Normalize() != "INTERACTIVE" {
+		t.Errorf("name = %q, want INTERACTIVE", stmt.Name.Normalize())
+	}
+}
+
 func TestCreateMaterializedView_ClusterBy(t *testing.T) {
 	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv CLUSTER BY (col1, col2) AS SELECT col1, col2 FROM t")
 	if len(errs) > 0 {


### PR DESCRIPTION
## Node
`snowflake/gap-drop-create-variants` (phase-2 corpus-gap closure) — DROP object variants, DROP ALERT, and CREATE INTERACTIVE MATERIALIZED VIEW (corpus-test-driven; the exact failing set was diffed, not assumed).

## What closed (3 corpus files)
1. **`legacy/drop.sql`** — 12 missing DROP kinds: `CONNECTION`, `FAILOVER GROUP`, `INTEGRATION`, `MANAGED ACCOUNT`, `MASKING POLICY`, `NETWORK POLICY`, `REPLICATION GROUP`, `RESOURCE MONITOR`, `ROW ACCESS POLICY`, `SESSION POLICY`, `SHARE`, `USER`. Grammar `DROP <kind> [IF EXISTS] <name>`; multi-word kinds matched via `curIsWord`/`peekIsWord` (no name-token theft). Each is a `DropObjectKind` enum value whose `String()` makes deparse automatic — **no new AST node** (walker regen is a no-op).
2. **`legacy/alerts.sql`** — the only failing statement was `DROP ALERT` (the `ALTER ALERT … MODIFY CONDITION/ACTION` forms already existed). *Note: the commit message says "ALERT MODIFY/DROP" — the actual delta is DROP ALERT only.*
3. **`official/create-materialized-view/example_02.sql`** — `CREATE [OR REPLACE] INTERACTIVE MATERIALIZED VIEW …`; `INTERACTIVE` modifier (non-reserved, `curIsWord("INTERACTIVE") && peekNext==MATERIALIZED`) → `Interactive bool` on the MV node + deparse.

## Corpus delta (TestCorpusClosure)
**613 → 616 clean, 42 → 39 skipped — 3 files closed.** Skip-list self-prune green.

## Review (`/code-review` high; Codex down) — no bugs
Empirically verified the risky cases: multi-word DROP kinds don't steal the name token; incomplete `DROP MASKING foo`/`DROP ROW ACCESS foo` error cleanly via `expect()` (no panic); `DROP NETWORK RULE`-vs-`POLICY` disambiguation both ways; `SECURE INTERACTIVE MV` works, `CREATE INTERACTIVE VIEW` correctly rejected; "interactive" still usable as a view/table name. A stale negative test (`TestDropUnsupported_TargetedError`, which asserted DROP NETWORK POLICY errors — now supported) was migrated to `DROP SECRET`. Orchestrator independently verified on a fresh checkout of `7a8447c0`: gofmt/vet/build clean, full `go test ./snowflake/... -timeout 120s` green (7 pkgs), corpus self-prune green.

## Divergences
None. New DROP kinds use `cascadeOK=false` (matching legacy corpus + conservative sibling kinds like DROP STREAM/TASK); CASCADE/RESTRICT on them isn't exercised by the corpus — noted for MAINTAIN.

## Note
Opened by orchestrator from verified pushed commit `7a8447c0`. Phase-2 gap 5/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
