### PR TITLE
feat(tidb/parser): parenthesized-query expression subqueries (IN + scalar)

### DIFF
--- a/tidb/catalog/analyze_test.go
+++ b/tidb/catalog/analyze_test.go
@@ -3277,3 +3277,15 @@ func TestAnalyze_ParenFromDerivedSetOp(t *testing.T) {
 	_, err := c.AnalyzeSelectStmt(sel)
 	assertNoError(t, err)
 }
+
+// TestAnalyze_ParenInSubquerySetOp guards the PR3 shape: an IN-subquery whose
+// body is a parenthesized set-op must analyze end-to-end. #238 made the analyzer
+// ParenSource-aware, so no analyzer change is expected — if this FAILS, the
+// analyzer is additional PR3 scope (stop and re-plan).
+func TestAnalyze_ParenInSubquerySetOp(t *testing.T) {
+	c := wtSetup(t)
+	sel := parseSelect(t, "SELECT 1 WHERE 1 IN ((SELECT 1) UNION (SELECT 2))")
+	if _, err := c.AnalyzeSelectStmt(sel); err != nil {
+		t.Fatalf("analyzer does not handle paren-setop IN subquery (PR3 scope grows): %v", err)
+	}
+}

--- a/tidb/deparse/deparse_test.go
+++ b/tidb/deparse/deparse_test.go
@@ -1022,6 +1022,27 @@ func TestDeparseSelect_ParenFromDerived(t *testing.T) {
 	}
 }
 
+// TestDeparseSelect_ParenExprSubquery guards the PR3 shape: an IN-subquery whose
+// body is a parenthesized set-op must deparse back to the same structure.
+func TestDeparseSelect_ParenExprSubquery(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"in_setop", "SELECT 1 WHERE 1 IN ((SELECT 1) UNION (SELECT 2))", "select 1 AS `1` where 1 in ((select 1 AS `1`) union (select 2 AS `2`))"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := parseSelect(t, tc.input)
+			got := DeparseSelect(sel)
+			if got != tc.expected {
+				t.Errorf("DeparseSelect(%q) =\n  %q\nwant:\n  %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestDeparseSelect_Section_5_2_FromClause(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/tidb/parser/complete_test.go
+++ b/tidb/parser/complete_test.go
@@ -835,3 +835,20 @@ func TestComplete_ParenFromDerivedBody(t *testing.T) {
 		t.Error("missing DISTINCT candidate inside parenthesized derived-table body")
 	}
 }
+
+// TestComplete_ParenInSubqueryBody locks the no-completion-guard decision for the
+// PR3 expr classifier: completion with the cursor inside a parenthesized
+// IN-subquery body must still yield correct candidates. lookaheadParenContentIsSubquery
+// scans across this paren block before the real parse; because advance() is
+// collection-inert, that scan must not corrupt completion state.
+func TestComplete_ParenInSubqueryBody(t *testing.T) {
+	full := "SELECT 1 WHERE 1 IN ((SELECT 1) UNION (SELECT 2))"
+	cursor := len("SELECT 1 WHERE 1 IN ((SELECT ") // inside the first IN-subquery operand
+	cs := Collect(full, cursor)
+	if cs == nil {
+		t.Fatal("Collect returned nil")
+	}
+	if !cs.HasRule("columnref") {
+		t.Error("missing columnref candidate inside parenthesized IN-subquery body")
+	}
+}

--- a/tidb/parser/expr.go
+++ b/tidb/parser/expr.go
@@ -1076,13 +1076,76 @@ func (p *Parser) parseGroupConcatFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, e
 	return fc, nil
 }
 
+// lookaheadParenContentIsSubquery reports whether the content just inside an
+// already-consumed '(' (p.cur is at the content's leading '(') is a query
+// expression (subquery) rather than an expression / value list. It classifies
+// WITHOUT consuming: snapshot, flat depth-scan, restore. Only invoked when
+// p.cur == '(' — simple (SELECT ...)/(WITH ...) bodies are caught by the cheaper
+// peek before this. Ported from pg/parser/expr.go lookaheadParenContentIsSubquery.
+func (p *Parser) lookaheadParenContentIsSubquery() bool {
+	if p.cur.Type != '(' {
+		return false
+	}
+	snap := p.snapshotTokenStream()
+	defer p.restoreTokenStream(snap)
+
+	// Pass 1: first event at depth 0 (relative to the consumed outer '('). A
+	// top-level ',' commits to a value list; a top-level set-op or ORDER/LIMIT
+	// commits to a subquery; the matching ')' means a single element → pass 2.
+	depth := 0
+	for p.cur.Type != tokEOF {
+		switch p.cur.Type {
+		case '(':
+			depth++
+		case ')':
+			if depth == 0 {
+				goto singleElement
+			}
+			depth--
+		case ',':
+			if depth == 0 {
+				return false // value list, e.g. IN ((SELECT 1), (SELECT 2))
+			}
+		case kwUNION, kwINTERSECT, kwEXCEPT, kwORDER, kwLIMIT:
+			if depth == 0 {
+				return true // query-expression continuation
+			}
+		default:
+			if depth == 0 {
+				return false // ordinary expression, e.g. ((SELECT 1) + 1)
+			}
+		}
+		p.advance()
+	}
+	return false // EOF before matching ')': malformed → value-list branch errors
+
+singleElement:
+	// Walk past leading '(' and probe the element's first non-'(' token.
+	// Subquery iff SELECT-start. FOR is excluded (TiDB rejects
+	// `IN ((SELECT 1) FOR UPDATE)`); VALUES/TABLE excluded (deferred backlog).
+	p.restoreTokenStream(snap)
+	for p.cur.Type == '(' {
+		p.advance()
+	}
+	return isSelectStartToken(p.cur.Type)
+}
+
+// isSelectStartToken reports whether tok begins a parsable query-expression
+// body. {SELECT, WITH} only — (VALUES)/(TABLE) primaries are a deferred
+// follow-up (parseSelectNoParens cannot parse them as a body).
+func isSelectStartToken(tok int) bool {
+	return tok == kwSELECT || tok == kwWITH
+}
+
 // parseParenExpr parses a parenthesized expression or subquery.
 func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
 	start := p.pos()
 	p.advance() // consume '('
 
-	// Check for subquery
-	if p.cur.Type == kwSELECT {
+	// Check for subquery (incl. a parenthesized query expression like
+	// ((SELECT 1) UNION (SELECT 2)) — classified by a backtracking scan).
+	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH ||
+		(p.cur.Type == '(' && p.lookaheadParenContentIsSubquery()) {
 		sub, err := p.parseSubqueryExpr()
 		if err != nil {
 			return nil, err
@@ -1390,8 +1453,11 @@ func (p *Parser) parseInExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
 		Expr: left,
 	}
 
-	// Check for subquery
-	if p.cur.Type == kwSELECT {
+	// Check for subquery (incl. a parenthesized query expression like
+	// ((SELECT 1) UNION (SELECT 2)) — classified by a backtracking scan; a
+	// top-level comma instead routes to the value-list branch below).
+	if p.cur.Type == kwSELECT || p.cur.Type == kwWITH ||
+		(p.cur.Type == '(' && p.lookaheadParenContentIsSubquery()) {
 		sub, err := p.parseSubqueryExpr()
 		if err != nil {
 			return nil, err

--- a/tidb/parser/parenthesized_query_test.go
+++ b/tidb/parser/parenthesized_query_test.go
@@ -329,3 +329,27 @@ func TestParenExprRegression(t *testing.T) {
 		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
 	}
 }
+
+// KNOWN DIVERGENCE vs TiDB v8.5.0 (deliberate, documented over-acceptance):
+// TiDB rejects a redundantly double-parenthesized FIRST set-op operand, but ONLY
+// in expr-subquery position — `IN (((SELECT 1)) UNION (SELECT 2))` and scalar
+// `(((SELECT 1)) UNION (SELECT 2))` are 1064 — while ACCEPTING the identical body
+// in FROM, EXISTS, and statement position (all container-verified). The
+// rejection is also narrow: `IN ((SELECT 1) UNION ((SELECT 2)))` (double SECOND
+// operand) and `IN (((SELECT 1) UNION (SELECT 2)))` (whole double-wrapped) are
+// accepted. omni accepts the IN/scalar form too: the expr-subquery path routes to
+// the shared parseSelectNoParens, which is correctly lax for the other three
+// contexts. Replicating TiDB's context-specific rejection would require a fragile
+// AST post-check (top-level set-op whose leftmost operand is a double-ParenSource,
+// worsening for chained set-ops) for a pathological shape no real query uses — so
+// it is left as a documented divergence. This test pins the current behavior; if
+// it ever flips to reject, revisit whether exact parity is warranted.
+func TestParenExprKnownDivergence_DoubleParenFirstOperand(t *testing.T) {
+	accepted := []string{
+		"SELECT 1 WHERE 1 IN (((SELECT 1)) UNION (SELECT 2))",
+		"SELECT (((SELECT 1)) UNION (SELECT 2))",
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}

--- a/tidb/parser/parenthesized_query_test.go
+++ b/tidb/parser/parenthesized_query_test.go
@@ -260,3 +260,24 @@ func TestParenFromRejected(t *testing.T) {
 		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
 	}
 }
+
+// PR3: parenthesized-query expression subqueries (IN + scalar). All container-
+// verified parse on pingcap/tidb:v8.5.0. Before this change the kwSELECT-only
+// peek in parseInExpr/parseParenExpr misrouted a leading nested '('.
+func TestParenExprSubqueryAccept(t *testing.T) {
+	accepted := []string{
+		// IN
+		"SELECT 1 WHERE 1 IN ((SELECT 1) UNION (SELECT 2))",
+		"SELECT 1 WHERE 1 IN ((SELECT 1))",
+		"SELECT 1 WHERE 1 IN ((SELECT 1) ORDER BY 1)",
+		"SELECT 1 WHERE 1 IN ((SELECT 1) LIMIT 1)",
+		"SELECT 1 WHERE 1 IN ((WITH x AS (SELECT 1) SELECT 1 FROM x))",
+		// scalar / comparison
+		"SELECT ((SELECT 1) UNION (SELECT 2))",
+		"SELECT 1 WHERE 1 > ((SELECT 1) UNION (SELECT 2))",
+		"SELECT 1 WHERE 1 > (WITH x AS (SELECT 1) SELECT 1 FROM x)",
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}

--- a/tidb/parser/parenthesized_query_test.go
+++ b/tidb/parser/parenthesized_query_test.go
@@ -281,3 +281,51 @@ func TestParenExprSubqueryAccept(t *testing.T) {
 		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
 	}
 }
+
+// A top-level comma makes the paren content a value list, NOT a single
+// subquery — the classifier must not misclassify it. Container-verified parse.
+func TestParenExprValueListNotSubquery(t *testing.T) {
+	accepted := []string{
+		"SELECT 1 WHERE 1 IN ((SELECT 1), (SELECT 2))", // value list of scalar subqueries
+		"SELECT 1 WHERE 1 IN (1, 2, 3)",                // plain value list
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+func TestParenExprSubqueryRejected(t *testing.T) {
+	rejected := []string{
+		"SELECT 1 WHERE 1 IN ((SELECT 1) FOR UPDATE)",      // FOR binds to the leaf (TiDB 1064)
+		"SELECT 1 WHERE 1 IN ((SELECT 1) UNION (SELECT 2)", // unbalanced parens
+	}
+	for _, sql := range rejected {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
+// Deferred boundary: TiDB PARSES (TABLE)/(VALUES) primaries as subquery bodies
+// (semantic 1054/1051), but they need non-SELECT-primary AST — a separate
+// backlog feature. The classifier lead set is {SELECT, WITH}, so omni rejects
+// them today. These document the boundary and trip if the lead set is widened.
+func TestParenExprDeferredPrimaries(t *testing.T) {
+	rejected := []string{
+		"SELECT 1 WHERE 1 IN ((TABLE t))",
+		"SELECT 1 WHERE 1 IN ((VALUES ROW(1)))",
+	}
+	for _, sql := range rejected {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
+// Regression: EXISTS (unambiguous) and simple single-paren subqueries unaffected.
+func TestParenExprRegression(t *testing.T) {
+	accepted := []string{
+		"SELECT 1 WHERE EXISTS ((SELECT 1) UNION (SELECT 2))", // EXISTS already works
+		"SELECT 1 WHERE 1 IN (SELECT 1)",                      // simple IN subquery
+		"SELECT 1 WHERE 1 > (SELECT 1)",                       // simple scalar subquery
+	}
+	for _, sql := range accepted {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}


### PR DESCRIPTION
Accepts the parenthesized-query **expression subquery** forms #238/#268 deferred:

```sql
… WHERE x IN ((SELECT 1) UNION (SELECT 2))
… WHERE x > ((SELECT 1) UNION (SELECT 2))
SELECT ((SELECT 1) UNION (SELECT 2))
```

All container-verified parse on `pingcap/tidb:v8.5.0`. Third in the series after #238 (paren queries) and #268 (FROM derived tables + the backtracking primitive).

### What's here

Ports pg's **comma-aware** `lookaheadParenContentIsSubquery` classifier (a flat depth-scan: top-level `,` → value-list, set-op/`ORDER`/`LIMIT` → subquery, single-element → pass-2 SELECT-start probe), reusing #268's `snapshotTokenStream`/`restoreTokenStream`. Wired into the two ambiguous sites via the same shape pg uses:

```go
if cur == kwSELECT || kwWITH || (cur == '(' && lookaheadParenContentIsSubquery()) { subquery } else { exprList }
```

- `parseInExpr` and `parseParenExpr` — the only two sites that misrouted `((` (via a `kwSELECT`-only peek). Subquery branch reuses the existing `parseSubqueryExpr` unchanged.
- **`kwWITH` also closes a live gap** — `x > (WITH …)` / `IN ((WITH …))` parse on TiDB but omni rejected them today.
- **EXISTS untouched** (already unambiguous); **ANY/ALL** out (unimplemented entirely — separate feature).

### Divergences from the pg port (all container-verified, TiDB ≠ PG)

- **Drop `FOR`** — `IN ((SELECT 1) FOR UPDATE)` → 1064 (same as #268). Keep `ORDER`/`LIMIT`.
- **`{SELECT,WITH}` lead set** — `(TABLE)`/`(VALUES)` primaries parse on TiDB but need non-SELECT-primary AST (backlog); explicit deferred-boundary reject tests document the line.
- **No completion guard** — `advance()` is collection-inert (#268 established + tested); locked by a completion-cursor-inside-IN-paren test.

### Known divergence (documented, not fixed)

TiDB rejects a redundantly **double-parenthesized first set-op operand** *only* in expr-subquery position — `IN/scalar (((SELECT 1)) UNION (SELECT 2))` → 1064 — while accepting the identical body in FROM/EXISTS/statement (and accepting double-*second*-operand / whole-double-wrapped variants in IN). omni accepts the IN/scalar form too, because the expr path routes to the shared `parseSelectNoParens` (correctly lax for the other three contexts). Matching TiDB's context-specific rejection would need a fragile AST post-check for a pathological shape no real query uses, so it's left as a documented over-acceptance pinned by `TestParenExprKnownDivergence_DoubleParenFirstOperand`.

### Tests

Accept (IN/scalar setop, single-element, ORDER/LIMIT, WITH-led); value-list discrimination (top-level comma); rejects (FOR, unbalanced); deferred-boundary (`(TABLE)`/`(VALUES)`); EXISTS + simple-subquery regression; deparse round-trip; end-to-end analyze guard (passes — #238's analyzer needs no change); completion test. `go test ./tidb/... -short` + `go vet ./tidb/...` green.

Design + plan: `plans/2026-06-09-tidb-paren-expr-subquery-{design,plan}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)