### PR TITLE
feat(googlesql): parameterized ARRAY vector-length column type (ARRAY<T>(vector_length => N))

### DIFF
--- a/googlesql/parser/alter_table.go
+++ b/googlesql/parser/alter_table.go
@@ -538,7 +538,9 @@ func (p *Parser) parseAlterColumnSet(start ast.Loc, ifExists bool, name string) 
 		// field_schema: column_schema_inner collate_clause? not_null? OPTIONS? —
 		// the core captures the type (and a trailing NOT NULL/collate are absorbed
 		// by parseType's collate handling + the optional NOT NULL below).
-		dt, err := p.parseType()
+		// parseColumnSchemaType so an ARRAY column type may carry the Spanner
+		// vector-length parameter `ARRAY<FLOAT32>(vector_length => N)`.
+		dt, err := p.parseColumnSchemaType()
 		if err != nil {
 			return nil, err
 		}
@@ -595,7 +597,10 @@ func (p *Parser) parseAlterColumnDrop(start ast.Loc, ifExists bool, name string)
 // not_null_column_attribute? spanner_generated_or_default? opt_options_list?`.
 // cur is at the type token.
 func (p *Parser) parseSpannerAlterColumn(start ast.Loc, ifExists bool, name string) (*ast.AlterAction, error) {
-	dt, err := p.parseType()
+	// column_schema_inner — parseColumnSchemaType so an ARRAY column type may
+	// carry the Spanner vector-length parameter `ARRAY<FLOAT32>(vector_length => N)`
+	// (oracle: ALTER TABLE t ALTER COLUMN e ARRAY<FLOAT32>(vector_length=>128) parses).
+	dt, err := p.parseColumnSchemaType()
 	if err != nil {
 		return nil, err
 	}

--- a/googlesql/parser/create_table.go
+++ b/googlesql/parser/create_table.go
@@ -464,8 +464,11 @@ func (p *Parser) parseColumnDefinition() (*ast.ColumnDef, error) {
 		}
 	} else {
 		// column_schema_inner — the column type (parseType covers
-		// simple/array/struct/range + type parameters).
-		dt, err := p.parseType()
+		// simple/array/struct/range + type parameters). inArrayColumnSchema lets
+		// parseType admit the Spanner ARRAY vector-length parameter
+		// `ARRAY<FLOAT32>(vector_length => N)` here (and in nested ARRAY elements),
+		// which the general `type` rule does not accept.
+		dt, err := p.parseColumnSchemaType()
 		if err != nil {
 			return nil, err
 		}

--- a/googlesql/parser/datatypes.go
+++ b/googlesql/parser/datatypes.go
@@ -132,16 +132,30 @@ func (k TypeKind) String() string {
 // float) so a faithful round-trip is possible without re-classifying them.
 // IntText preserves an integer's exact source spelling (faithful even on int64
 // overflow, where the lexer leaves IntVal at 0 but keeps the text).
+//
+// Name is the named-argument spelling for the one parameterized form that takes
+// a `name => value` shape: the Spanner ARRAY column vector-length parameter
+// `ARRAY<FLOAT32>(vector_length => N)`. It is "" for an ordinary positional
+// type_parameter. When Name != "" the value is always an integer (IsInt +
+// IntVal/IntText); writeTo renders it as `name => value`. This named form is
+// admitted ONLY on an ARRAY type in column-schema position (parseType's
+// inArrayColumnSchema guard); the general `type` rule (CAST targets, function
+// params) never accepts it (oracle: a CAST<ARRAY<…>(vector_length=>…)> rejects).
 type TypeParam struct {
 	IsInt   bool
 	IsMax   bool
 	IntVal  int64
 	IntText string // exact source spelling of an integer parameter
 	Text    string // source spelling of a non-integer literal parameter
+	Name    string // named-arg spelling (e.g. "vector_length"); "" for positional
 	Loc     ast.Loc
 }
 
 func (p TypeParam) writeTo(b *strings.Builder) {
+	if p.Name != "" {
+		b.WriteString(p.Name)
+		b.WriteString(" => ")
+	}
 	switch {
 	case p.IsMax:
 		b.WriteString("MAX")
@@ -331,14 +345,31 @@ func (p *Parser) parseType() (*DataType, error) {
 		return nil, err
 	}
 
-	// opt_type_parameters — `( type_parameter (, type_parameter)* )`.
+	// opt_type_parameters — `( type_parameter (, type_parameter)* )`, OR the
+	// Spanner ARRAY vector-length parameter `( vector_length => integer )`.
+	//
+	// On an ARRAY in column-schema position the ONLY admissible parameter is the
+	// vector-length form: a positional `ARRAY<FLOAT32>(128)` is a syntax error
+	// there (oracle: rejects "Error parsing Spanner DDL statement"). In a general
+	// `type` position the array carries an ordinary opt_type_parameters list
+	// (oracle: a CAST<ARRAY<…>(128)> PARSES — "Parameterized types are not
+	// supported" is a semantic message), so the strict list path is kept.
 	if p.cur.Type == int('(') {
-		params, endLoc, err := p.parseTypeParameters()
-		if err != nil {
-			return nil, err
+		if dt.Kind == TypeArray && p.inArrayColumnSchema {
+			param, endLoc, err := p.parseVectorLengthParam()
+			if err != nil {
+				return nil, err
+			}
+			dt.Params = []TypeParam{param}
+			dt.Loc.End = endLoc.End
+		} else {
+			params, endLoc, err := p.parseTypeParameters()
+			if err != nil {
+				return nil, err
+			}
+			dt.Params = params
+			dt.Loc.End = endLoc.End
 		}
-		dt.Params = params
-		dt.Loc.End = endLoc.End
 	}
 
 	// collate_clause — `COLLATE string_literal_or_parameter`.
@@ -352,6 +383,33 @@ func (p *Parser) parseType() (*DataType, error) {
 	}
 
 	return dt, nil
+}
+
+// parseColumnSchemaType parses a column's type (a column_schema_inner position)
+// with the ARRAY vector-length parameter enabled. It is parseType wrapped in
+// the inArrayColumnSchema flag: an ARRAY column type (and nested ARRAY elements)
+// may carry `(vector_length => N)`, but the flag is cleared on descent into a
+// STRUCT/RANGE/MAP/FUNCTION template (those inner positions are general types,
+// not column schemas — oracle: STRUCT<v ARRAY<…>(vector_length=>…)> rejects).
+func (p *Parser) parseColumnSchemaType() (*DataType, error) {
+	saved := p.inArrayColumnSchema
+	p.inArrayColumnSchema = true
+	dt, err := p.parseType()
+	p.inArrayColumnSchema = saved
+	return dt, err
+}
+
+// parseInnerType parses a `type` in a position that is NOT an array-column
+// schema (a STRUCT/RANGE/MAP/FUNCTION template element). It clears
+// inArrayColumnSchema for the duration so the vector-length parameter is not
+// admitted there, then restores it. ARRAY elements are the one exception that
+// keeps the flag set, so they call parseType directly rather than this.
+func (p *Parser) parseInnerType() (*DataType, error) {
+	saved := p.inArrayColumnSchema
+	p.inArrayColumnSchema = false
+	dt, err := p.parseType()
+	p.inArrayColumnSchema = saved
+	return dt, err
 }
 
 // parseRawType parses one raw_type alternative (without the trailing
@@ -504,7 +562,7 @@ func (p *Parser) parseRangeType() (*DataType, error) {
 	if err := p.expectTemplateOpen(); err != nil {
 		return nil, err
 	}
-	elem, err := p.parseType()
+	elem, err := p.parseInnerType()
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +658,7 @@ func (p *Parser) parseStructField() (StructField, error) {
 		if err != nil {
 			return StructField{}, err
 		}
-		fieldType, err := p.parseType()
+		fieldType, err := p.parseInnerType()
 		if err != nil {
 			return StructField{}, err
 		}
@@ -612,7 +670,7 @@ func (p *Parser) parseStructField() (StructField, error) {
 	}
 
 	// Anonymous form: a bare `type`.
-	fieldType, err := p.parseType()
+	fieldType, err := p.parseInnerType()
 	if err != nil {
 		return StructField{}, err
 	}
@@ -643,14 +701,14 @@ func (p *Parser) parseMapType() (*DataType, error) {
 	if err := p.expectTemplateOpen(); err != nil {
 		return nil, err
 	}
-	keyType, err := p.parseType()
+	keyType, err := p.parseInnerType()
 	if err != nil {
 		return nil, err
 	}
 	if _, err := p.expect(int(',')); err != nil {
 		return nil, err
 	}
-	valueType, err := p.parseType()
+	valueType, err := p.parseInnerType()
 	if err != nil {
 		return nil, err
 	}
@@ -683,14 +741,14 @@ func (p *Parser) parseFunctionType() (*DataType, error) {
 		// Parenthesized argument list (possibly empty).
 		p.advance() // consume '('
 		if p.cur.Type != int(')') {
-			arg, err := p.parseType()
+			arg, err := p.parseInnerType()
 			if err != nil {
 				return nil, err
 			}
 			dt.ArgTypes = append(dt.ArgTypes, arg)
 			for p.cur.Type == int(',') {
 				p.advance() // consume ','
-				a, err := p.parseType()
+				a, err := p.parseInnerType()
 				if err != nil {
 					return nil, err
 				}
@@ -702,7 +760,7 @@ func (p *Parser) parseFunctionType() (*DataType, error) {
 		}
 	} else {
 		// Single bare argument type.
-		arg, err := p.parseType()
+		arg, err := p.parseInnerType()
 		if err != nil {
 			return nil, err
 		}
@@ -712,7 +770,7 @@ func (p *Parser) parseFunctionType() (*DataType, error) {
 	if _, err := p.expect(tokArrow); err != nil {
 		return nil, err
 	}
-	ret, err := p.parseType()
+	ret, err := p.parseInnerType()
 	if err != nil {
 		return nil, err
 	}
@@ -872,6 +930,88 @@ func (p *Parser) parseTypeParameter() (TypeParam, error) {
 	default:
 		return TypeParam{}, p.typeErrorAt("expected a type parameter (integer, boolean, string, bytes, float, or MAX)")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// ARRAY vector-length parameter — `( vector_length => integer )`.
+//
+// Spanner allows a vector-length parameter on an ARRAY column type:
+//
+//	column_name ARRAY<FLOAT32>(vector_length => integer_literal)
+//
+// (legacy ZetaSQL array_type: `ARRAY < scalar_type > [ ( vector_length =>
+// integer_literal ) ]`). It is admitted ONLY on an ARRAY type in column-schema
+// position (parseType's inArrayColumnSchema guard) — never in a CAST target or
+// any general `type` position. The empirically-verified grammar (Spanner
+// emulator @ sha256:caf1bd24) is tight:
+//
+//   - the name must be the bare keyword `vector_length`, case-insensitive
+//     (VECTOR_LENGTH accepts); a backtick-quoted `vector_length` rejects, and
+//     any other name (length => …) rejects "Expecting 'VECTOR_LENGTH'";
+//   - the value must be a single integer literal (MAX rejects);
+//   - exactly ONE parameter — a trailing comma or a second parameter rejects
+//     "Expecting ')'".
+//
+// The element-type restriction (FLOAT32/FLOAT64 only) and the
+// not-on-generated-column rule are SEMANTIC (the emulator parses the form, then
+// rejects with a non-syntax message), so they are not enforced here.
+
+// parseVectorLengthParam parses the sole parameter form an ARRAY column type
+// admits: `( vector_length => integer )`. The current token is the opening '('.
+// Any other parenthesized content — a positional type_parameter list
+// (ARRAY<FLOAT32>(128)), a wrong name, a quoted name, a non-integer value, a
+// trailing comma, or a second parameter — is a syntax error here (the oracle
+// rejects each: "Error parsing Spanner DDL statement: … Expecting 'VECTOR_LENGTH'
+// / '<INTEGER_LITERAL>' / ')'"). Returns the named TypeParam and the Loc through
+// the closing ')'.
+func (p *Parser) parseVectorLengthParam() (TypeParam, ast.Loc, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return TypeParam{}, ast.NoLoc(), err
+	}
+	// Name: the bare keyword `vector_length`, case-insensitive. A backtick-quoted
+	// `vector_length` is rejected (oracle: "Expecting 'VECTOR_LENGTH'"); the lexer
+	// collapses both spellings to tokIdentifier, so the source byte is checked.
+	if p.cur.Type != tokIdentifier ||
+		!strings.EqualFold(p.cur.Str, vectorLengthParamName) ||
+		p.isQuotedIdentifier(p.cur) {
+		return TypeParam{}, ast.NoLoc(), p.typeErrorAt("expected the vector_length parameter on an ARRAY column type")
+	}
+	nameTok := p.advance()
+	if _, err := p.expect(tokFatArrow); err != nil {
+		return TypeParam{}, ast.NoLoc(), err
+	}
+	if p.cur.Type != tokInteger {
+		return TypeParam{}, ast.NoLoc(), p.typeErrorAt("expected an integer literal for the vector_length parameter")
+	}
+	valTok := p.advance()
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return TypeParam{}, ast.NoLoc(), err
+	}
+	param := TypeParam{
+		IsInt:   true,
+		IntVal:  valTok.Ival,
+		IntText: valTok.Str,
+		Name:    nameTok.Str,
+		Loc:     ast.Loc{Start: nameTok.Loc.Start, End: valTok.Loc.End},
+	}
+	return param, closeTok.Loc, nil
+}
+
+// vectorLengthParamName is the (case-insensitive) name of the ARRAY column
+// vector-length parameter.
+const vectorLengthParamName = "vector_length"
+
+// isQuotedIdentifier reports whether an identifier token was written with
+// surrounding backticks in the source (the lexer collapses `x` and x to the
+// same tokIdentifier, so this peeks at the original source byte at the token's
+// start). Used to reject a backtick-quoted vector_length parameter name.
+func (p *Parser) isQuotedIdentifier(tok Token) bool {
+	idx := tok.Loc.Start - p.baseOffset
+	if idx < 0 || idx >= len(p.input) {
+		return false
+	}
+	return p.input[idx] == '`'
 }
 
 // ---------------------------------------------------------------------------

--- a/googlesql/parser/datatypes_test.go
+++ b/googlesql/parser/datatypes_test.go
@@ -793,6 +793,182 @@ func TestParseType_ArrayTypeParametersRejectNamedArg(t *testing.T) {
 	}
 }
 
+// testParseColumnSchemaType parses input as a column type (a column_schema_inner
+// position, where the ARRAY vector-length parameter is admitted), asserting the
+// whole input is consumed. It is testParseType with the inArrayColumnSchema flag
+// set, mirroring how parseColumnDefinition / parseSpannerAlterColumn call in.
+func testParseColumnSchemaType(input string) (*DataType, error) {
+	p := &Parser{lexer: NewLexer(input), input: input}
+	p.advance()
+	dt, err := p.parseColumnSchemaType()
+	if err != nil {
+		return nil, err
+	}
+	if p.cur.Type != tokEOF {
+		return dt, &ParseError{Loc: p.cur.Loc, Msg: "trailing tokens after type: " + TokenName(p.cur.Type)}
+	}
+	return dt, nil
+}
+
+// TestParseType_ArrayVectorLength is the focused regression for the Spanner
+// ARRAY vector-length parameter `ARRAY<scalar>(vector_length => N)`
+// (googlesql/maint-vector-array-type; divergence #202). The empirically-verified
+// grammar (Spanner emulator @ sha256:caf1bd24) is admitted ONLY in a
+// column-schema position, on an ARRAY type, with the exact bare name
+// `vector_length` (case-insensitive) and a single integer value.
+func TestParseType_ArrayVectorLength(t *testing.T) {
+	// --- accepts in column-schema position (oracle: CREATE TABLE … accepts) ---
+	accepts := []struct {
+		input    string
+		wantText string // round-trip rendering via DataType.String()
+	}{
+		{"ARRAY<FLOAT32>(vector_length=>128)", "ARRAY<FLOAT32>(vector_length => 128)"},
+		{"ARRAY<FLOAT64>(vector_length => 256)", "ARRAY<FLOAT64>(vector_length => 256)"},
+		// Case-insensitive name (oracle: VECTOR_LENGTH accepts); spelling preserved.
+		{"ARRAY<FLOAT32>(VECTOR_LENGTH=>8)", "ARRAY<FLOAT32>(VECTOR_LENGTH => 8)"},
+		// Grammar admits any element type + nested ARRAY (FLOAT-only / array-of-array
+		// is a SEMANTIC restriction, not syntax — oracle parses then semantic-rejects).
+		{"ARRAY<INT64>(vector_length=>4)", "ARRAY<INT64>(vector_length => 4)"},
+		{"ARRAY<ARRAY<FLOAT32>(vector_length=>8)>", "ARRAY<ARRAY<FLOAT32>(vector_length => 8)>"},
+	}
+	for _, tc := range accepts {
+		dt, err := testParseColumnSchemaType(tc.input)
+		if err != nil {
+			t.Errorf("column-schema parseType(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got := dt.String(); got != tc.wantText {
+			t.Errorf("column-schema parseType(%q) round-trip = %q, want %q", tc.input, got, tc.wantText)
+		}
+	}
+
+	// --- rejects even in column-schema position (oracle rejects each) ---
+	rejects := []struct {
+		input  string
+		reason string
+	}{
+		// Wrong name (oracle: "Expecting 'VECTOR_LENGTH' but found 'length'").
+		{"ARRAY<FLOAT32>(length=>8)", "non-vector_length name"},
+		// MAX value (oracle: "Expecting '<INTEGER_LITERAL>'").
+		{"ARRAY<FLOAT32>(vector_length=>MAX)", "non-integer value"},
+		// String value — not an integer literal.
+		{"ARRAY<FLOAT32>(vector_length=>'8')", "string value"},
+		// Trailing comma / second param (oracle: "Expecting ')'").
+		{"ARRAY<FLOAT32>(vector_length=>8,)", "trailing comma"},
+		{"ARRAY<FLOAT32>(vector_length=>8, foo=>9)", "second parameter"},
+		// Backtick-quoted name (oracle: "Expecting 'VECTOR_LENGTH'").
+		{"ARRAY<FLOAT32>(`vector_length`=>8)", "quoted name"},
+		// Not an ARRAY type — the parameter only attaches to ARRAY.
+		{"STRING(vector_length=>8)", "non-array type"},
+		// A positional type_parameter on an ARRAY is a syntax error in column
+		// schema (oracle rejects "Error parsing Spanner DDL statement"); only the
+		// vector_length named form is admissible. (In a general `type` position the
+		// same `ARRAY<FLOAT32>(128)` PARSES — see TestParseType below.)
+		{"ARRAY<FLOAT32>(128)", "positional param on array column"},
+		{"ARRAY<FLOAT32>(MAX)", "positional MAX on array column"},
+		// Missing `=>` after the name (oracle rejects).
+		{"ARRAY<FLOAT32>(vector_length)", "missing => and value"},
+		// Negative value — a sign is not part of an integer literal (oracle rejects).
+		{"ARRAY<FLOAT32>(vector_length=>-5)", "negative value"},
+		// Empty parens (oracle rejects).
+		{"ARRAY<FLOAT32>()", "empty parens"},
+	}
+	for _, tc := range rejects {
+		if _, err := testParseColumnSchemaType(tc.input); err == nil {
+			t.Errorf("column-schema parseType(%q): want error (%s), got nil", tc.input, tc.reason)
+		}
+	}
+
+	// --- the vector-length parameter is NOT admitted in a general `type` position
+	// (a CAST target / standalone ParseDataType) even on an ARRAY (oracle: a
+	// CAST<ARRAY<…>(vector_length=>…)> rejects "Unexpected identifier"). ---
+	for _, in := range []string{
+		"ARRAY<FLOAT32>(vector_length=>8)",
+		"ARRAY<INT64>(vector_length=>128)",
+	} {
+		if _, err := testParseType(in); err == nil {
+			t.Errorf("bare parseType(%q): want error (vector_length is column-schema-only), got nil", in)
+		}
+	}
+
+	// --- conversely, a POSITIONAL type_parameter list on an ARRAY is fine in a
+	// general `type` position (oracle: a CAST<ARRAY<FLOAT32>(128)> PARSES,
+	// "Parameterized types are not supported" being a semantic message). Only the
+	// column-schema position restricts an array to the vector_length form. ---
+	for _, in := range []string{
+		"ARRAY<FLOAT32>(128)",
+		"ARRAY<INT64>(10, 2)",
+	} {
+		if _, err := testParseType(in); err != nil {
+			t.Errorf("bare parseType(%q): unexpected error (positional array type-params parse in a general type position): %v", in, err)
+		}
+	}
+
+	// --- value spellings the column-schema vector_length form accepts (oracle:
+	// 0 and hex both accept). ---
+	for _, in := range []string{
+		"ARRAY<FLOAT32>(vector_length=>0)",
+		"ARRAY<FLOAT32>(vector_length=>0x80)",
+	} {
+		if _, err := testParseColumnSchemaType(in); err != nil {
+			t.Errorf("column-schema parseType(%q): unexpected error: %v", in, err)
+		}
+	}
+}
+
+// TestParseType_ArrayVectorLengthStatements exercises the ARRAY vector-length
+// parameter through the real statement entry point Parse — the CREATE
+// TABLE / ALTER TABLE column-schema positions a consumer hits — plus the
+// negatives the live oracle rejects (STRUCT-of-ARRAY, and the SELECT value
+// constructor, which the oracle itself rejects so omni's reject is parity).
+func TestParseType_ArrayVectorLengthStatements(t *testing.T) {
+	accepts := []string{
+		// CREATE TABLE column (oracle: accept).
+		"CREATE TABLE Products (ProductId INT64 NOT NULL, Embedding ARRAY<FLOAT32>(vector_length=>128)) PRIMARY KEY (ProductId)",
+		"CREATE TABLE Products (ProductId INT64 NOT NULL, Embedding ARRAY<FLOAT64>(vector_length => 256)) PRIMARY KEY (ProductId)",
+		// With a trailing NOT NULL on the same column (oracle: accept).
+		"CREATE TABLE Products (ProductId INT64 NOT NULL, Embedding ARRAY<FLOAT32>(vector_length=>128) NOT NULL) PRIMARY KEY (ProductId)",
+		// Spanner ALTER COLUMN <name> <column_schema_inner> (oracle: parses,
+		// semantic-rejects the change).
+		"ALTER TABLE Products ALTER COLUMN Embedding ARRAY<FLOAT32>(vector_length=>128)",
+		// BigQuery ALTER COLUMN … SET DATA TYPE field_schema (column-schema position).
+		"ALTER TABLE Products ALTER COLUMN Embedding SET DATA TYPE ARRAY<FLOAT32>(vector_length=>128)",
+		// ADD COLUMN with the parameter (oracle: accept).
+		"ALTER TABLE Products ADD COLUMN E2 ARRAY<FLOAT32>(vector_length=>64)",
+	}
+	for _, sql := range accepts {
+		if _, errs := Parse(sql); len(errs) > 0 {
+			t.Errorf("Parse(%q): unexpected errors: %v", sql, errs)
+		}
+	}
+
+	rejects := []struct {
+		sql    string
+		reason string
+	}{
+		// STRUCT-of-ARRAY column (oracle: "'vector_length' is not supported in
+		// STRUCT of ARRAY" — a true syntax reject). The flag is cleared inside a
+		// STRUCT template, so omni rejects too.
+		{
+			"CREATE TABLE T (Id INT64 NOT NULL, E STRUCT<v ARRAY<FLOAT32>(vector_length=>8)>) PRIMARY KEY (Id)",
+			"STRUCT-of-ARRAY",
+		},
+		// The SELECT value-constructor form: oracle REJECTS ("Expected '[' but got
+		// '('"); omni rejects too — parity (defended against the stale divergence
+		// #202 claim that it ACCEPTS).
+		{"SELECT ARRAY<FLOAT32>(vector_length => 128)", "value constructor (oracle rejects)"},
+		{"SELECT ARRAY<FLOAT32>()", "empty typed-array constructor (oracle rejects)"},
+		// CAST target: vector_length is not a type_parameter in a general type
+		// position (oracle: "Unexpected identifier vector_length").
+		{"SELECT CAST(NULL AS ARRAY<FLOAT32>(vector_length=>2))", "CAST target"},
+	}
+	for _, tc := range rejects {
+		if _, errs := Parse(tc.sql); len(errs) == 0 {
+			t.Errorf("Parse(%q): want parse error (%s), got none", tc.sql, tc.reason)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // collate_clause — type COLLATE 'string-or-parameter'
 // ---------------------------------------------------------------------------

--- a/googlesql/parser/ddl_oracle_test.go
+++ b/googlesql/parser/ddl_oracle_test.go
@@ -73,6 +73,13 @@ var ddlFixtures = []ddlFixture{
 	{"CREATE TABLE T (x INT64, a BOOL, b FLOAT64, c NUMERIC, d DATE, e TIMESTAMP, f BYTES(MAX), g JSON) PRIMARY KEY (x)", true},
 	{"CREATE TABLE T (x INT64, tags ARRAY<INT64>) PRIMARY KEY (x)", true}, // ARRAY<STRING> (no length) is BigQuery-only — see unit test
 	{"CREATE TABLE T (x INT64, tags ARRAY<STRING(MAX)>) PRIMARY KEY (x)", true},
+	// ARRAY vector-length parameter (Spanner column-schema; divergence #202).
+	// The element-type FLOAT32/FLOAT64 restriction is semantic — ARRAY<INT64>(...)
+	// PARSES (oracle accepts the grammar, then semantic-rejects), so wantParse=true.
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length=>128)) PRIMARY KEY (x)", true},
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT64>(vector_length => 256)) PRIMARY KEY (x)", true},
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length=>128) NOT NULL) PRIMARY KEY (x)", true},
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<INT64>(vector_length=>4)) PRIMARY KEY (x)", true},
 	// Generated / default / options / constraints (Spanner-authoritative).
 	{"CREATE TABLE T (x INT64, f STRING(10) AS (CONCAT(x)) STORED) PRIMARY KEY (x)", true},
 	{"CREATE TABLE T (x INT64, s STRING(20) DEFAULT ('a')) PRIMARY KEY (x)", true},
@@ -90,6 +97,11 @@ var ddlFixtures = []ddlFixture{
 	{"ALTER TABLE T ADD COLUMN IF NOT EXISTS c STRING(MAX)", true},
 	{"ALTER TABLE T DROP COLUMN c", true},
 	{"ALTER TABLE T ALTER COLUMN c STRING(20)", true},
+	// Spanner ALTER COLUMN <name> <column_schema_inner> with the vector-length
+	// parameter (oracle parses, semantic-rejects the change). SET DATA TYPE is a
+	// BigQuery-only form excluded from this differential (covered by unit tests).
+	{"ALTER TABLE T ALTER COLUMN e ARRAY<FLOAT32>(vector_length=>128)", true},
+	{"ALTER TABLE T ADD COLUMN e ARRAY<FLOAT32>(vector_length=>64)", true},
 	{"ALTER TABLE T ALTER COLUMN c SET OPTIONS (allow_commit_timestamp = true)", true},
 	{"ALTER TABLE T ALTER COLUMN c SET DEFAULT (1)", true},
 	{"ALTER TABLE T ALTER COLUMN c DROP DEFAULT", true},
@@ -160,6 +172,19 @@ var ddlFixtures = []ddlFixture{
 	// Plain DROP INDEX (schema_object_kind) has no on_path_expression — a trailing
 	// `ON <table>` rejects (regression: parser-ddl PR #220 finding 2).
 	{"DROP INDEX idx ON T", false},
+	// ARRAY vector-length parameter — the grammar is tight (divergence #202):
+	// exactly `( vector_length => integer )`. The oracle rejects each of these.
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length=>8,)) PRIMARY KEY (x)", false},        // trailing comma
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length=>8, foo=>9)) PRIMARY KEY (x)", false}, // second parameter
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(length=>8)) PRIMARY KEY (x)", false},                // wrong name
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length=>MAX)) PRIMARY KEY (x)", false},       // non-integer value
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(`vector_length`=>8)) PRIMARY KEY (x)", false},       // backtick-quoted name
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(128)) PRIMARY KEY (x)", false},                      // positional param (only vector_length allowed on an array column)
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length)) PRIMARY KEY (x)", false},            // missing => value
+	{"CREATE TABLE T (x INT64 NOT NULL, e ARRAY<FLOAT32>(vector_length=>-5)) PRIMARY KEY (x)", false},        // negative value
+	// vector_length is unsupported inside a STRUCT-of-ARRAY (oracle: a true syntax
+	// reject "'vector_length' is not supported in STRUCT of ARRAY").
+	{"CREATE TABLE T (x INT64 NOT NULL, e STRUCT<v ARRAY<FLOAT32>(vector_length=>8)>) PRIMARY KEY (x)", false},
 }
 
 func TestDDLDifferential(t *testing.T) {

--- a/googlesql/parser/official_corpus_test.go
+++ b/googlesql/parser/official_corpus_test.go
@@ -48,8 +48,11 @@ import (
 //     v2 migration store and are the to-do list for a future grammar fix. Each is
 //     annotated with the oracle verdict that proves it is a real gap.
 //
-// Coverage at authoring time: 307/350 blocks parse clean, 43 skipped (see the
-// counts on each bucket below).
+// Coverage: 310/350 blocks parse clean, 40 skipped (see the counts on each
+// bucket below). (The vector-array column-type block spanner/ddl.md#51 graduated
+// from the skip-list when googlesql/maint-vector-array-type wired the ARRAY
+// vector-length parameter; spanner/expressions.md#6 stays skipped as DOC-REJECTED
+// — its constructor statement is rejected by the oracle itself.)
 func TestOfficialCorpusParses(t *testing.T) {
 	blocks := collectOfficialCorpus(t)
 
@@ -200,8 +203,20 @@ var officialCorpusSkips = map[string]string{
 	// AlterSearchIndex). It is a documented Spanner form the union parser accepts;
 	// the live emulator non-authoritatively rejects it (proven in the
 	// bq_ddl_oracle_test.go triangulation guard). Divergence #203.
-	"spanner/expressions.md#6": "RESIDUAL GAP: parameterized vector-array constructor `ARRAY<FLOAT32>(vector_length => N)` — live Spanner oracle ACCEPTS `SELECT ARRAY<FLOAT32>(vector_length => 128)`, omni rejects (\"syntax error at or near =>\"). Named args in a typed ARRAY constructor not parsed (plain named args f(a=>1) DO parse). TOKENIZE_NGRAMS(... =>) in the same block parses.",
-	"spanner/ddl.md#51":        "RESIDUAL GAP: parameterized vector-array column type `Embedding ARRAY<FLOAT32>(vector_length=>128)` — live Spanner oracle ACCEPTS the CREATE TABLE, omni rejects (\"expected a type parameter\"). The CREATE VECTOR INDEX in the same block parses on omni.",
+	// DOC-REJECTED: the block's `SELECT ARRAY<FLOAT32>(vector_length => 128)`
+	// statement is rejected by the live Spanner oracle itself — a value
+	// constructor `ARRAY<scalar>(...)` is not a query expression form (oracle @
+	// sha256:caf1bd24: "Syntax error: Expected \"[\" but got \"(\"", same reject
+	// for the bare `SELECT ARRAY<FLOAT32>()`). omni's reject ("syntax error at or
+	// near =>") MATCHES the oracle, so parity holds; the block is skipped only
+	// because that one statement is not valid. (The vector_length parameter is a
+	// COLUMN-SCHEMA feature, not an expression — its DDL form parses clean and is
+	// covered by TestParseType_ArrayVectorLength + the live differential. This was
+	// re-classified from a "RESIDUAL GAP" after the maint-vector-array-type node
+	// re-probed the oracle: the prior divergence-#202 evidence claiming the
+	// constructor ACCEPTS was stale.) The TOKENIZE_NGRAMS(... =>) statement in the
+	// same block parses fine.
+	"spanner/expressions.md#6": "DOC-REJECTED: `SELECT ARRAY<FLOAT32>(vector_length => 128)` — the live Spanner oracle REJECTS a typed-ARRAY value constructor (\"Expected '[' but got '('\"); omni's reject (\"syntax error at or near =>\") matches. vector_length is a column-schema parameter, not an expression form. (The first statement, TOKENIZE_NGRAMS named args, parses.)",
 
 	// ===== RESIDUAL GAP / pipe & FROM-first & MATCH_RECOGNIZE (BigQuery) (6) =====
 	// BigQuery-only query forms; the Spanner oracle is non-authoritative, so

--- a/googlesql/parser/parser.go
+++ b/googlesql/parser/parser.go
@@ -48,6 +48,15 @@ type Parser struct {
 	nextBuf    Token        // buffered lookahead token
 	hasNext    bool         // whether nextBuf is valid
 	errors     []ParseError // collected errors for best-effort mode
+
+	// inArrayColumnSchema is set while parsing a table column's type (a
+	// column_schema_inner position) so parseType admits the Spanner ARRAY
+	// vector-length parameter `ARRAY<FLOAT32>(vector_length => N)`. It propagates
+	// into nested ARRAY elements (ARRAY<ARRAY<…>(vector_length=>…)> parses) but is
+	// cleared when descending into a STRUCT/RANGE/MAP/FUNCTION template, where the
+	// parameter is not a column schema (oracle: STRUCT<v ARRAY<…>(vector_length=>…)>
+	// rejects). It is never set for a CAST target or any general `type` position.
+	inArrayColumnSchema bool
 }
 
 // advance consumes the current token and moves to the next one. Returns the


### PR DESCRIPTION
## Summary

Wires the Spanner **ARRAY vector-length parameter** `ARRAY<scalar>(vector_length => N)` as a CREATE TABLE / ALTER TABLE column type. Node `googlesql/maint-vector-array-type` (divergence #202 — an oracle-parity enhancement from newer ZetaSQL, not a legacy regression). omni previously over-rejected the column-type form with `expected a type parameter`.

## What changed

- **`datatypes.go`**: `parseType` admits the vector-length param on an ARRAY when `inArrayColumnSchema` is set; new `parseVectorLengthParam` (exactly `( vector_length => integer )`), `parseColumnSchemaType` / `parseInnerType` flag helpers, `isQuotedIdentifier`, and a `Name` field on `TypeParam` (rendered as `name => value`).
- **`create_table.go` / `alter_table.go`**: column-definition + Spanner `ALTER COLUMN` + `SET DATA TYPE` call sites enable the flag.
- **`parser.go`**: the `inArrayColumnSchema` parser-state field.
- No AST changes — the column type is stored as `TypeRef.Text` via `DataType.String()`, which round-trips the rendered `vector_length => N`.

## Scope is tight (verified against the live Spanner emulator @ `sha256:caf1bd24`)

The parameter is admitted **only** on an ARRAY in a **column-schema** position; it propagates into nested ARRAY elements (`ARRAY<ARRAY<…>(vector_length=>…)>`) but is cleared on descent into a STRUCT/RANGE/MAP/FUNCTION template (oracle: `STRUCT<v ARRAY<…>(vector_length=>…)>` rejects). The general `type` rule (CAST targets, function params, TVF schema columns, DECLARE) is unchanged. The accepted grammar is exactly `( vector_length => integer )`: case-insensitive bare name, single integer value, one parameter (trailing comma / second param / wrong name / quoted name / MAX value all reject).

A positional `ARRAY<FLOAT32>(128)` now also rejects in column position (oracle rejects it as DDL), while still parsing in a general `type` position (oracle treats it as semantic-unsupported) — a pre-existing over-accept the same code path closes.

## Divergence #202: one half implemented, one half DEFENDED

- **Implemented**: the DDL column-type form (oracle ACCEPTS → over-reject closed).
- **Defended**: the SELECT value-constructor `ARRAY<FLOAT32>(vector_length => 128)` stays a **reject**. The live oracle REJECTS it (`Expected "[" but got "("`) — `vector_length` is a column-schema attribute, not an expression — so omni's reject is parity. The divergence-#202 evidence claiming the constructor ACCEPTS was **stale** (re-probed against the same pinned emulator). `spanner/expressions.md#6` is re-classified RESIDUAL GAP → DOC-REJECTED; `spanner/ddl.md#51` graduates from the official-corpus skip-list (now parses clean).

## Tests

- `TestParseType_ArrayVectorLength` (+ `…Statements`): both polarities, the precise boundary, the dialect split (column vs general type), and round-trip rendering.
- `ddl_oracle_test.go`: new accept + reject fixtures verified against the live emulator (both polarities).
- `go test ./googlesql/...` green; `go test -tags googlesql_oracle ./googlesql/parser/...` (live differential) green.

## Review

Two-lens gate: a rigorous adversarial self-review (which itself caught and fixed the positional-param over-accept) plus the Codex lens via the shared runtime — Codex traced every `parseType` entry point and the flag save/restore lifecycle across four substantive rounds and reported **no findings** (its final synthesis was cut short by the hard timeout, but all intermediate verdicts were findings-empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)