### PR TITLE
feat(snowflake): named function arguments name => value (phase-2 gap-named-args) — close corpus gap 175

### DIFF
--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1293,7 +1293,7 @@ type CloneSource struct {
 	Source   *ObjectName
 	AtBefore string // "AT" or "BEFORE"; empty if no time travel
 	Kind     string // "TIMESTAMP"/"OFFSET"/"STATEMENT"
-	Value    string // the time travel value
+	Value    Node   // the time-travel value expression (e.g. a string literal or TO_TIMESTAMP_TZ(...))
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -47,7 +47,9 @@ func (w *writer) writeCreateTableStmt(n *ast.CreateTableStmt) error {
 	if n.Clone != nil {
 		w.buf.WriteString(" CLONE ")
 		w.writeObjectNameNoSpace(n.Clone.Source)
-		w.writeCloneTimeTravelSuffix(n.Clone)
+		if err := w.writeCloneTimeTravelSuffix(n.Clone); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -354,11 +356,12 @@ func (w *writer) writeTagAssignments(tags []*ast.TagAssignment) {
 	}
 }
 
-// writeCloneTimeTravelSuffix writes the AT/BEFORE time travel qualifier.
-// The value is always a string literal (single-quoted in SQL).
-func (w *writer) writeCloneTimeTravelSuffix(c *ast.CloneSource) {
+// writeCloneTimeTravelSuffix writes the AT/BEFORE time travel qualifier
+// `{ AT | BEFORE } ( <kind> => <value> )`. The value is a general expression
+// (a string literal, a TO_TIMESTAMP_TZ(...) call, an offset arithmetic, …).
+func (w *writer) writeCloneTimeTravelSuffix(c *ast.CloneSource) error {
 	if c.AtBefore == "" {
-		return
+		return nil
 	}
 	if c.AtBefore == "BEFORE" {
 		w.buf.WriteString(" BEFORE (")
@@ -367,8 +370,11 @@ func (w *writer) writeCloneTimeTravelSuffix(c *ast.CloneSource) {
 	}
 	w.buf.WriteString(c.Kind)
 	w.buf.WriteString(" => ")
-	w.buf.WriteString(quoteString(c.Value))
+	if err := w.writeExpr(c.Value); err != nil {
+		return err
+	}
 	w.buf.WriteByte(')')
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -394,7 +400,9 @@ func (w *writer) writeCreateDatabaseStmt(n *ast.CreateDatabaseStmt) error {
 	if n.Clone != nil {
 		w.buf.WriteString(" CLONE ")
 		w.writeObjectNameNoSpace(n.Clone.Source)
-		w.writeCloneTimeTravelSuffix(n.Clone)
+		if err := w.writeCloneTimeTravelSuffix(n.Clone); err != nil {
+			return err
+		}
 	}
 	w.writeDBSchemaProps(&n.Props)
 	if len(n.Tags) > 0 {
@@ -497,7 +505,9 @@ func (w *writer) writeCreateSchemaStmt(n *ast.CreateSchemaStmt) error {
 	if n.Clone != nil {
 		w.buf.WriteString(" CLONE ")
 		w.writeObjectNameNoSpace(n.Clone.Source)
-		w.writeCloneTimeTravelSuffix(n.Clone)
+		if err := w.writeCloneTimeTravelSuffix(n.Clone); err != nil {
+			return err
+		}
 	}
 	if n.ManagedAccess {
 		w.buf.WriteString(" WITH MANAGED ACCESS")

--- a/snowflake/deparse/deparse_expr.go
+++ b/snowflake/deparse/deparse_expr.go
@@ -58,9 +58,23 @@ func (w *writer) writeExpr(node ast.Node) error {
 		return w.writeSubqueryExpr(n)
 	case *ast.ExistsExpr:
 		return w.writeExistsExpr(n)
+	case *ast.CallArg:
+		return w.writeCallArg(n)
 	default:
 		return fmt.Errorf("deparse: unsupported expression node type %T", node)
 	}
+}
+
+// writeCallArg deparses a function-call argument. A named (keyword) argument is
+// written as `name => value`; a bare positional argument (zero Name) writes
+// just the value. Named call args appear inside FuncCallExpr.Args.
+func (w *writer) writeCallArg(n *ast.CallArg) error {
+	if n.Name.Name == "" {
+		return w.writeExpr(n.Value)
+	}
+	w.writeIdent(n.Name)
+	w.buf.WriteString(" => ")
+	return w.writeExpr(n.Value)
 }
 
 func (w *writer) writeLiteral(n *ast.Literal) error {

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -889,3 +889,74 @@ func TestDeparse_DollarFuncArg(t *testing.T) {
 	out := assertRoundTrip(t, `SELECT TO_DATE($1) FROM t`)
 	require.Contains(t, out, "$1")
 }
+
+// ---------------------------------------------------------------------------
+// Named (keyword) function arguments  name => value
+// ---------------------------------------------------------------------------
+
+func TestDeparse_NamedArgSingle(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT f(LOCATION => '@s') FROM t`)
+	require.Contains(t, out, "LOCATION => '@s'")
+}
+
+func TestDeparse_NamedArgMultiple(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT f(A => 1, B => 'x', C => TRUE) FROM t`)
+	require.Contains(t, out, "A => 1")
+	require.Contains(t, out, "B => 'x'")
+	require.Contains(t, out, "C => TRUE")
+}
+
+func TestDeparse_NamedArgMixedPositionalThenNamed(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT f(1, x, TYPE => 'STREAMING') FROM t`)
+	require.Contains(t, out, "f(1, x, TYPE => 'STREAMING')")
+}
+
+func TestDeparse_NamedArgValueIsFuncCall(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT f(TS => TO_TIMESTAMP_TZ('x', 'fmt')) FROM t`)
+	require.Contains(t, out, "TS => TO_TIMESTAMP_TZ('x', 'fmt')")
+}
+
+func TestDeparse_NamedArgValueIsCast(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT f(N => $1::NUMBER) FROM t`)
+	require.Contains(t, out, "N => $1::NUMBER")
+}
+
+// Table-function named args (INFER_SCHEMA / DATA_SOURCE / FLATTEN). The TABLE()
+// wrapper is normalized away by the table-function deparse, so we assert the
+// named `=>` argument survives rather than a full structural round-trip.
+func TestDeparse_NamedArgInferSchema(t *testing.T) {
+	f, err := parser.Parse(`SELECT * FROM TABLE(INFER_SCHEMA(LOCATION => '@s', FILE_FORMAT => 'fmt'))`)
+	require.NoError(t, err)
+	out, err := deparse.DeparseFile(f)
+	require.NoError(t, err)
+	require.Contains(t, out, "LOCATION => '@s'")
+	require.Contains(t, out, "FILE_FORMAT => 'fmt'")
+}
+
+func TestDeparse_NamedArgFlatten(t *testing.T) {
+	f, err := parser.Parse(`SELECT * FROM persons p, LATERAL FLATTEN(INPUT => p.c, PATH => 'contact') f`)
+	require.NoError(t, err)
+	out, err := deparse.DeparseFile(f)
+	require.NoError(t, err)
+	require.Contains(t, out, "INPUT => p.c")
+	require.Contains(t, out, "PATH => 'contact'")
+}
+
+// ---------------------------------------------------------------------------
+// CLONE ... { AT | BEFORE } ( kind => value ) time-travel
+// ---------------------------------------------------------------------------
+
+func TestDeparse_CloneAtStringValue(t *testing.T) {
+	out := assertRoundTrip(t, `CREATE TABLE t2 CLONE t1 AT (TIMESTAMP => '2024-01-01')`)
+	require.Contains(t, out, "AT (TIMESTAMP => '2024-01-01')")
+}
+
+func TestDeparse_CloneAtFuncValue(t *testing.T) {
+	out := assertRoundTrip(t, `CREATE TABLE t2 CLONE t1 AT (TIMESTAMP => TO_TIMESTAMP_TZ('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss'))`)
+	require.Contains(t, out, "AT (TIMESTAMP => TO_TIMESTAMP_TZ(")
+}
+
+func TestDeparse_CloneBeforeStatementValue(t *testing.T) {
+	out := assertRoundTrip(t, `CREATE TABLE t2 CLONE t1 BEFORE (STATEMENT => '8e5d0ca1-e866-44fa-843b-5e6ad35e8bb7')`)
+	require.Contains(t, out, "BEFORE (STATEMENT => '8e5d0ca1-e866-44fa-843b-5e6ad35e8bb7')")
+}

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -171,19 +171,12 @@ var corpusSkips = map[string]string{
 	// CREATE OR ALTER WAREHOUSE and DROP WAREHOUSE statements in it parse clean.
 	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: SHOW WAREHOUSES ->> SELECT ... FROM $1 — ->> result-pipe + $N table-ref owned by other nodes (CREATE OR ALTER WAREHOUSE parses)",
 
-	// --- RESIDUAL GAP: dynamic-table clauses (named-arg => and INTERVAL/refresh-mode) ---
-	"official/create-dynamic-table/example_04.sql": "RESIDUAL GAP: CLONE ... AT (TIMESTAMP => TO_TIMESTAMP_TZ(...)) named-arg => in time-travel clause",
+	// --- RESIDUAL GAP: dynamic-table IMMUTABLE WHERE + INTERVAL literal ---
+	// example_04 (CLONE ... AT (TIMESTAMP => TO_TIMESTAMP_TZ(...))) is now closed
+	// by gap-named-args (named function arguments + general clone time-travel
+	// value). example_07 remains: IMMUTABLE WHERE (... - INTERVAL '1 day') needs
+	// the INTERVAL literal / refresh-mode clause owned by gap-expr-misc.
 	"official/create-dynamic-table/example_07.sql": "RESIDUAL GAP: IMMUTABLE WHERE (... - INTERVAL '1 day') refresh-mode + interval literal not parsed",
-
-	// --- RESIDUAL GAP: named function arguments  name => value  (expr/func-call) ---
-	"official/copy-into-table/example_06.sql":       "RESIDUAL GAP: TABLE(DATA_SOURCE(TYPE => 'STREAMING')) named-arg => in function call",
-	"official/create-external-table/example_09.sql": "RESIDUAL GAP: INFER_SCHEMA(LOCATION=>'...', FILE_FORMAT=>'...') named-arg => in function call",
-	"official/create-external-table/example_10.sql": "RESIDUAL GAP: INFER_SCHEMA(...) named-arg => in function call",
-	"official/create-pipe/example_08.sql":           "RESIDUAL GAP: TABLE(DATA_SOURCE(TYPE => 'STREAMING')) named-arg => in function call",
-	"official/create-pipe/example_09.sql":           "RESIDUAL GAP: named-arg => in function call (pipe streaming source)",
-	"official/create-pipe/example_10.sql":           "RESIDUAL GAP: named-arg => in function call (pipe streaming source)",
-	"official/join-lateral/example_05.sql":          "RESIDUAL GAP: LATERAL FLATTEN(INPUT => ..., PATH => ...) named-arg => in function call",
-	"official/truncate-table/example_02.sql":        "RESIDUAL GAP: table(generator(rowcount=>20)) named-arg => in function call",
 
 	// --- DEPENDENCY GAP: $N / $N:path result-set ref + stage path as a table ref (T5) ---
 	"official/create-external-table/example_01.sql":  "DEPENDENCY GAP: SELECT metadata$filename FROM @s1/ — stage-path table ref + metadata$col not parsed",

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -1241,8 +1241,11 @@ func (p *Parser) parseCloneSource() (*ast.CloneSource, error) {
 			return nil, err
 		}
 
-		// Value: string or expression — consume as a string token or expression
-		valueTok, err := p.expect(tokString)
+		// Value: any expression. The docs accept a string literal for STATEMENT,
+		// but TIMESTAMP/OFFSET commonly take a function call (e.g.
+		// TO_TIMESTAMP_TZ('…')) or an arithmetic expression, so we parse the full
+		// expression grammar here rather than only a bare string token.
+		value, err := p.parseExpr()
 		if err != nil {
 			return nil, err
 		}
@@ -1253,7 +1256,7 @@ func (p *Parser) parseCloneSource() (*ast.CloneSource, error) {
 
 		clone.AtBefore = atBefore
 		clone.Kind = kind
-		clone.Value = valueTok.Str
+		clone.Value = value
 	}
 
 	return clone, nil

--- a/snowflake/parser/create_table_test.go
+++ b/snowflake/parser/create_table_test.go
@@ -247,8 +247,12 @@ func TestCreateTable_CloneAtTimestamp(t *testing.T) {
 	if stmt.Clone.Kind != "TIMESTAMP" {
 		t.Errorf("Kind = %q, want %q", stmt.Clone.Kind, "TIMESTAMP")
 	}
-	if stmt.Clone.Value != "2024-01-01" {
-		t.Errorf("Value = %q, want %q", stmt.Clone.Value, "2024-01-01")
+	lit, ok := stmt.Clone.Value.(*ast.Literal)
+	if !ok {
+		t.Fatalf("Value type = %T, want *ast.Literal", stmt.Clone.Value)
+	}
+	if lit.Kind != ast.LitString || lit.Value != "2024-01-01" {
+		t.Errorf("Value = %v %q, want LitString %q", lit.Kind, lit.Value, "2024-01-01")
 	}
 }
 

--- a/snowflake/parser/dynamic_external_table_test.go
+++ b/snowflake/parser/dynamic_external_table_test.go
@@ -801,14 +801,6 @@ func TestTableVariants_WalkerVisitsChildren(t *testing.T) {
 //     shared expression parser (`SELECT (CURRENT_TIMESTAMP() - INTERVAL '1
 //     day')` fails identically). create-dynamic-table example_07's IMMUTABLE
 //     WHERE predicate uses it.
-//   - A function call with a named argument `f(name => value)` fails in the
-//     shared expression parser (`SELECT f(a=>1)` fails identically). The
-//     create-external-table USING TEMPLATE examples 09/10 use INFER_SCHEMA(
-//     LOCATION=>'@mystage', ...).
-//   - A time-travel clone value that is a function call `CLONE s AT (TIMESTAMP
-//     => f(...))` fails in the shared parseCloneSource (a plain `CREATE TABLE t
-//     CLONE s AT (TIMESTAMP => TO_TIMESTAMP('x'))` fails identically). The
-//     create-dynamic-table example_04 uses it.
 //   - example_12 is malformed in the docs themselves (the AS query
 //     `SELECT COUNT(DISTINCT order_id) DATE_TRUNC(...)` is missing the comma
 //     between two select items); it is skipped as a known-bad doc example.
@@ -890,12 +882,6 @@ func sharedLayerGap(t *testing.T, text, upper string, seg Segment) bool {
 	case intervalInParensLimited(text):
 		expectStillFails(t, text, seg, "INTERVAL-in-parens")
 		return true
-	case namedArgLimited(text):
-		expectStillFails(t, text, seg, "named function argument =>")
-		return true
-	case cloneFuncValueLimited(upper):
-		expectStillFails(t, text, seg, "clone time-travel function value")
-		return true
 	case malformedDocExample(upper):
 		// example_12: missing comma in the AS query is a doc bug, not a parser bug.
 		return true
@@ -917,24 +903,6 @@ func expectStillFails(t *testing.T, text string, seg Segment, gap string) {
 // yet handle. Heuristic: the text contains both '(' and the word INTERVAL.
 func intervalInParensLimited(sql string) bool {
 	return strings.Contains(strings.ToUpper(sql), "INTERVAL") && strings.Contains(sql, "(")
-}
-
-// namedArgLimited reports whether sql contains a `<word> => ` named function
-// argument (e.g. INFER_SCHEMA(LOCATION=>'@s')), unsupported by the shared
-// expression parser. Distinguished from a time-travel `AT (KEY => ...)` clause
-// by not requiring the AT/BEFORE context — any `=>` inside the statement that is
-// not part of a recognized clause is treated as the named-arg gap. The corpus
-// files that hit this are the USING TEMPLATE examples.
-func namedArgLimited(sql string) bool {
-	return strings.Contains(sql, "=>") && strings.Contains(strings.ToUpper(sql), "USING TEMPLATE")
-}
-
-// cloneFuncValueLimited reports whether sql is a CLONE ... AT/BEFORE (KEY =>
-// <function-call>) form, whose function-valued time-travel argument the shared
-// parseCloneSource does not yet parse. Heuristic: a CLONE with a '(' '=>' and a
-// function-call-looking token (an identifier immediately followed by '(').
-func cloneFuncValueLimited(upper string) bool {
-	return strings.Contains(upper, "CLONE") && strings.Contains(upper, "=>")
 }
 
 // malformedDocExample reports whether the statement is a known-malformed docs

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -675,7 +675,7 @@ func (p *Parser) parseFuncCall(name ast.ObjectName, startLoc ast.Loc) (*ast.Func
 	// We parse TRIM as a regular function call with arguments.
 
 	if p.cur.Type != ')' {
-		args, err := p.parseExprList()
+		args, err := p.parseFuncArgList()
 		if err != nil {
 			return nil, err
 		}
@@ -1627,6 +1627,67 @@ func (p *Parser) parseExprList() ([]ast.Node, error) {
 	}
 
 	return exprs, nil
+}
+
+// parseFuncArgList parses a comma-separated function-call argument list where
+// each argument is either a positional expression or a named (keyword) argument
+// `<name> => <value>` (e.g. INFER_SCHEMA(LOCATION => '@s'), FLATTEN(INPUT => x,
+// PATH => 'p'), DATA_SOURCE(TYPE => 'STREAMING')). Positional and named
+// arguments may be freely intermixed; Snowflake itself requires positional
+// first, but the parser is lenient. A named argument is represented as an
+// *ast.CallArg with a non-zero Name placed directly in the arg slice; a
+// positional argument is the bare expression node.
+//
+// The loop is progress-guarded: each iteration must consume at least one token,
+// otherwise it returns a syntax error rather than spinning.
+func (p *Parser) parseFuncArgList() ([]ast.Node, error) {
+	var args []ast.Node
+	for {
+		before := p.cur.Loc.Start
+		arg, err := p.parseFuncArg()
+		if err != nil {
+			return nil, err
+		}
+		// Progress guard: parseFuncArg must always consume at least one token.
+		// parseExpr already errors on an empty production, so this is a
+		// defensive backstop against an infinite loop.
+		if p.cur.Loc.Start == before {
+			return nil, p.syntaxErrorAtCur()
+		}
+		args = append(args, arg)
+
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return args, nil
+}
+
+// parseFuncArg parses one function-call argument: a named argument
+// `<name> => <value>` when the current token is an identifier (or non-reserved
+// word) immediately followed by `=>` (tokAssoc), otherwise a positional
+// expression. The value of a named argument may be any expression (so casts,
+// `$N` refs, colon paths, nested calls compose through).
+func (p *Parser) parseFuncArg() (ast.Node, error) {
+	if p.isIdentToken() && p.peekNext().Type == tokAssoc {
+		start := p.cur.Loc.Start
+		name, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		p.advance() // consume '=>'
+		value, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.CallArg{
+			Name:  name,
+			Value: value,
+			Loc:   ast.Loc{Start: start, End: p.prev.Loc.End},
+		}, nil
+	}
+	return p.parseExpr()
 }
 
 // parseOrderByList parses ORDER BY items: expr [ASC|DESC] [NULLS FIRST|LAST].

--- a/snowflake/parser/expr_test.go
+++ b/snowflake/parser/expr_test.go
@@ -1790,3 +1790,308 @@ func TestExpr_DollarSpaceNumberIsError(t *testing.T) {
 		t.Fatal("expected an error for '$ 1' (bare $ followed by separate number)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Named (keyword) function arguments:  f(name => value)
+// ---------------------------------------------------------------------------
+
+// namedArg fetches the i-th argument of a function call, asserting it is a
+// named argument (*ast.CallArg with a non-zero Name) and returning it.
+func namedArg(t *testing.T, fc *ast.FuncCallExpr, i int) *ast.CallArg {
+	t.Helper()
+	if i >= len(fc.Args) {
+		t.Fatalf("arg index %d out of range (len=%d)", i, len(fc.Args))
+	}
+	ca, ok := fc.Args[i].(*ast.CallArg)
+	if !ok {
+		t.Fatalf("arg %d type = %T, want *ast.CallArg", i, fc.Args[i])
+	}
+	if ca.Name.Name == "" {
+		t.Fatalf("arg %d has empty Name, want a named argument", i)
+	}
+	return ca
+}
+
+func mustFuncCall(t *testing.T, input string) *ast.FuncCallExpr {
+	t.Helper()
+	node, err := testParseExpr(input)
+	if err != nil {
+		t.Fatalf("parse %q: unexpected error: %v", input, err)
+	}
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.FuncCallExpr", input, node)
+	}
+	return fc
+}
+
+func TestExpr_NamedArgSingle(t *testing.T) {
+	fc := mustFuncCall(t, "INFER_SCHEMA(LOCATION => '@stage')")
+	if len(fc.Args) != 1 {
+		t.Fatalf("len(Args) = %d, want 1", len(fc.Args))
+	}
+	ca := namedArg(t, fc, 0)
+	if ca.Name.Name != "LOCATION" {
+		t.Errorf("Name = %q, want LOCATION", ca.Name.Name)
+	}
+	lit, ok := ca.Value.(*ast.Literal)
+	if !ok || lit.Kind != ast.LitString || lit.Value != "@stage" {
+		t.Errorf("Value = %#v, want string literal '@stage'", ca.Value)
+	}
+}
+
+func TestExpr_NamedArgNoSpaces(t *testing.T) {
+	// LOCATION=>'@s' with no surrounding whitespace (=> is its own token).
+	fc := mustFuncCall(t, "INFER_SCHEMA(LOCATION=>'@s', FILE_FORMAT=>'fmt')")
+	if len(fc.Args) != 2 {
+		t.Fatalf("len(Args) = %d, want 2", len(fc.Args))
+	}
+	if a := namedArg(t, fc, 0); a.Name.Name != "LOCATION" {
+		t.Errorf("arg0 Name = %q, want LOCATION", a.Name.Name)
+	}
+	if a := namedArg(t, fc, 1); a.Name.Name != "FILE_FORMAT" {
+		t.Errorf("arg1 Name = %q, want FILE_FORMAT", a.Name.Name)
+	}
+}
+
+func TestExpr_NamedArgMultiple(t *testing.T) {
+	fc := mustFuncCall(t, "FLATTEN(INPUT => a.b, PATH => 'contact', OUTER => TRUE)")
+	if len(fc.Args) != 3 {
+		t.Fatalf("len(Args) = %d, want 3", len(fc.Args))
+	}
+	for i, want := range []string{"INPUT", "PATH", "OUTER"} {
+		if a := namedArg(t, fc, i); a.Name.Name != want {
+			t.Errorf("arg%d Name = %q, want %q", i, a.Name.Name, want)
+		}
+	}
+}
+
+func TestExpr_NamedArgMixedPositionalThenNamed(t *testing.T) {
+	// Positional args first, then named — the common Snowflake form.
+	fc := mustFuncCall(t, "f(1, x, TYPE => 'STREAMING')")
+	if len(fc.Args) != 3 {
+		t.Fatalf("len(Args) = %d, want 3", len(fc.Args))
+	}
+	if _, ok := fc.Args[0].(*ast.CallArg); ok {
+		t.Errorf("arg0 should be positional, got *ast.CallArg")
+	}
+	if _, ok := fc.Args[1].(*ast.CallArg); ok {
+		t.Errorf("arg1 should be positional, got *ast.CallArg")
+	}
+	if a := namedArg(t, fc, 2); a.Name.Name != "TYPE" {
+		t.Errorf("arg2 Name = %q, want TYPE", a.Name.Name)
+	}
+}
+
+func TestExpr_NamedArgInterleaved(t *testing.T) {
+	// Lenient: named, then positional, then named (Snowflake itself is stricter,
+	// but the parser accepts interleaving).
+	fc := mustFuncCall(t, "f(A => 1, 2, B => 3)")
+	if len(fc.Args) != 3 {
+		t.Fatalf("len(Args) = %d, want 3", len(fc.Args))
+	}
+	if a := namedArg(t, fc, 0); a.Name.Name != "A" {
+		t.Errorf("arg0 Name = %q, want A", a.Name.Name)
+	}
+	if _, ok := fc.Args[1].(*ast.CallArg); ok {
+		t.Errorf("arg1 should be positional")
+	}
+	if a := namedArg(t, fc, 2); a.Name.Name != "B" {
+		t.Errorf("arg2 Name = %q, want B", a.Name.Name)
+	}
+}
+
+func TestExpr_NamedArgNested(t *testing.T) {
+	// A function call whose single argument is itself a named-arg call:
+	// WRAP(DATA_SOURCE(TYPE => 'STREAMING')). (TABLE is a reserved word and only
+	// legal as a FROM table-function, so the bare-expression nesting uses a
+	// non-reserved outer name; the TABLE(DATA_SOURCE(...)) statement form is
+	// covered by TestStmt_NamedArgInTableFunction.)
+	fc := mustFuncCall(t, "WRAP(DATA_SOURCE(TYPE => 'STREAMING'))")
+	if len(fc.Args) != 1 {
+		t.Fatalf("outer len(Args) = %d, want 1", len(fc.Args))
+	}
+	inner, ok := fc.Args[0].(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("outer arg0 = %T, want *ast.FuncCallExpr (DATA_SOURCE)", fc.Args[0])
+	}
+	if inner.Name.Name.Name != "DATA_SOURCE" {
+		t.Errorf("inner func = %q, want DATA_SOURCE", inner.Name.Name.Name)
+	}
+	ca := namedArg(t, inner, 0)
+	if ca.Name.Name != "TYPE" {
+		t.Errorf("inner arg Name = %q, want TYPE", ca.Name.Name)
+	}
+	if lit, ok := ca.Value.(*ast.Literal); !ok || lit.Value != "STREAMING" {
+		t.Errorf("inner arg value = %#v, want literal 'STREAMING'", ca.Value)
+	}
+}
+
+// TestStmt_NamedArgInTableFunction exercises the literal TABLE(DATA_SOURCE(TYPE
+// => 'STREAMING')) table-function form (pipe / COPY streaming source) at the
+// statement level, where TABLE() is a legal FROM table function.
+func TestStmt_NamedArgInTableFunction(t *testing.T) {
+	sql := "SELECT $1 FROM TABLE(DATA_SOURCE(TYPE => 'STREAMING'))"
+	result, errs := parseSingle(sql, 0)
+	if len(errs) > 0 {
+		t.Fatalf("parse %q: %v", sql, errs)
+	}
+	// Walk the AST and confirm a DATA_SOURCE call with a named TYPE argument
+	// appears.
+	found := false
+	ast.Inspect(result, func(n ast.Node) bool {
+		fc, ok := n.(*ast.FuncCallExpr)
+		if !ok || fc.Name.Name.Name != "DATA_SOURCE" {
+			return true
+		}
+		if len(fc.Args) == 1 {
+			if ca, ok := fc.Args[0].(*ast.CallArg); ok && ca.Name.Name == "TYPE" {
+				found = true
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Errorf("did not find DATA_SOURCE(TYPE => ...) named arg in %q", sql)
+	}
+}
+
+func TestExpr_NamedArgValueIsComplexExpr(t *testing.T) {
+	// The value of a named arg may be any expression: a function call, a cast,
+	// a $N ref, and a colon path all compose through.
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, v ast.Node)
+	}{
+		{
+			name:  "func-call value",
+			input: "CLONE_AT(TIMESTAMP => TO_TIMESTAMP_TZ('x', 'fmt'))",
+			check: func(t *testing.T, v ast.Node) {
+				if _, ok := v.(*ast.FuncCallExpr); !ok {
+					t.Errorf("value = %T, want *ast.FuncCallExpr", v)
+				}
+			},
+		},
+		{
+			name:  "cast value",
+			input: "f(X => $1::number)",
+			check: func(t *testing.T, v ast.Node) {
+				if _, ok := v.(*ast.CastExpr); !ok {
+					t.Errorf("value = %T, want *ast.CastExpr", v)
+				}
+			},
+		},
+		{
+			name:  "dollar-ref value",
+			input: "f(X => $1)",
+			check: func(t *testing.T, v ast.Node) {
+				if _, ok := v.(*ast.DollarRef); !ok {
+					t.Errorf("value = %T, want *ast.DollarRef", v)
+				}
+			},
+		},
+		{
+			name:  "colon-path value",
+			input: "f(X => col:field)",
+			check: func(t *testing.T, v ast.Node) {
+				if v == nil {
+					t.Errorf("value is nil")
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := mustFuncCall(t, tc.input)
+			ca := namedArg(t, fc, 0)
+			tc.check(t, ca.Value)
+		})
+	}
+}
+
+func TestExpr_NamedArgLoc(t *testing.T) {
+	// Loc must span from the name's start to the value's end.
+	input := "f(NAME => 123)"
+	fc := mustFuncCall(t, input)
+	ca := namedArg(t, fc, 0)
+	// "NAME" starts at offset 2; the value "123" ends at offset 13.
+	if ca.Loc.Start != 2 {
+		t.Errorf("Loc.Start = %d, want 2 (start of NAME)", ca.Loc.Start)
+	}
+	if ca.Loc.End != 13 {
+		t.Errorf("Loc.End = %d, want 13 (end of 123)", ca.Loc.End)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Named-arg negatives + regression
+// ---------------------------------------------------------------------------
+
+func TestExpr_NamedArgBareAssocIsError(t *testing.T) {
+	// `f(=> 1)` — `=>` with no name must error cleanly, not loop.
+	if _, err := testParseExpr("f(=> 1)"); err == nil {
+		t.Fatal("expected an error for f(=> 1)")
+	}
+}
+
+func TestExpr_NamedArgMissingValueIsError(t *testing.T) {
+	// `f(x =>)` — name with no value must error cleanly.
+	if _, err := testParseExpr("f(x =>)"); err == nil {
+		t.Fatal("expected an error for f(x =>)")
+	}
+}
+
+func TestExpr_NamedArgMissingValueBeforeCommaIsError(t *testing.T) {
+	// `f(x =>, y)` — the value is missing before the comma.
+	if _, err := testParseExpr("f(x =>, y)"); err == nil {
+		t.Fatal("expected an error for f(x =>, y)")
+	}
+}
+
+// Regression: an ordinary positional call whose argument is a bare identifier
+// must NOT be mistaken for a named argument (no `=>` follows).
+func TestExpr_PositionalIdentArgsUnchanged(t *testing.T) {
+	fc := mustFuncCall(t, "f(a, b)")
+	if len(fc.Args) != 2 {
+		t.Fatalf("len(Args) = %d, want 2", len(fc.Args))
+	}
+	for i := range fc.Args {
+		if _, ok := fc.Args[i].(*ast.CallArg); ok {
+			t.Errorf("arg %d wrongly parsed as a named *ast.CallArg", i)
+		}
+	}
+}
+
+// Regression: the `->` (tokArrow) lambda/operator is distinct from `=>` and must
+// keep parsing unchanged inside a higher-order function argument.
+func TestExpr_ArrowOperatorUnchanged(t *testing.T) {
+	// TRANSFORM(arr, x -> x + 1): the second argument is a lambda using ->, not
+	// a named argument. It must parse as a LambdaExpr, never a *ast.CallArg.
+	fc := mustFuncCall(t, "TRANSFORM(arr, x -> x + 1)")
+	if len(fc.Args) != 2 {
+		t.Fatalf("len(Args) = %d, want 2", len(fc.Args))
+	}
+	if _, ok := fc.Args[1].(*ast.CallArg); ok {
+		t.Errorf("arg1 (x -> x + 1) wrongly parsed as a named *ast.CallArg")
+	}
+	if _, ok := fc.Args[1].(*ast.LambdaExpr); !ok {
+		t.Errorf("arg1 = %T, want *ast.LambdaExpr", fc.Args[1])
+	}
+}
+
+// Regression: a comparison `a >= b` must not be confused with a named arg — its
+// operator is its own token, distinct from tokAssoc. (Sanity at the arg-list
+// level; a plain function is used because IFF is a dedicated AST node.)
+func TestExpr_GreaterEqualArgUnchanged(t *testing.T) {
+	fc := mustFuncCall(t, "f(a >= b, 1, 0)")
+	if len(fc.Args) != 3 {
+		t.Fatalf("len(Args) = %d, want 3", len(fc.Args))
+	}
+	if _, ok := fc.Args[0].(*ast.CallArg); ok {
+		t.Errorf("arg0 (a >= b) wrongly parsed as a named *ast.CallArg")
+	}
+	if _, ok := fc.Args[0].(*ast.BinaryExpr); !ok {
+		t.Errorf("arg0 = %T, want *ast.BinaryExpr (a >= b)", fc.Args[0])
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/gap-named-args` (phase-2 corpus-gap closure) — **named function arguments `name => value`** (the lexer already produced `tokAssoc` for `=>`; this is the parser wiring). Closes 9 corpus files at once.

## Design (minimal — reuses existing structures, no new Node)
- Function-call args: `parseFuncArgList` now checks `isIdentToken() && peekNext()==tokAssoc` → populates the **existing** `ast.CallArg.Name` field (previously never set); positional args unchanged. CallArg is already walker-visited, so no AST/nodetags/walker change.
- Time-travel `AT (TIMESTAMP => <expr>)`: `CloneSource.Value` changed `string`→`Node` to hold the expression (e.g. `TO_TIMESTAMP_TZ(...)`); deparse updated. Not walker-tracked (DDL metadata, same as the prior string — no regression).

## Corpus delta (TestCorpusClosure) — 9 files closed, 39 → 30 skipped, 616 → 625 clean
`copy-into-table/06` (`TABLE(DATA_SOURCE(TYPE=>...))`), `create-external-table/09,10` (`INFER_SCHEMA(LOCATION=>...)`), `create-pipe/08,09,10` (streaming source), `join-lateral/05` (`LATERAL FLATTEN(INPUT=>..,PATH=>..)`), `truncate-table/02` (`generator(rowcount=>20)`), `create-dynamic-table/04` (`CLONE … AT(TIMESTAMP => TO_TIMESTAMP_TZ(...))`). Skip-list self-prune green.

## Review + salvage note
The worker finished implementation, `/code-review` (high), and full verification (gofmt/vet/build/suite/corpus all green) but was **killed mid-self-reconciliation of a skip-count detail, before commit/push**. Orchestrator independently re-verified on the worktree: full `go test ./snowflake/... -timeout 120s` green (7 pkgs incl. analysis), genwalker regen no-op (139 cases — confirms CallArg/CloneSource representations need no walker change), corpus self-prune green; resolved the worker's open question (it removed **9** skips, not 10 — `truncate-table/02` was a bonus; 39→30 is exactly consistent). Then committed + pushed (`f042b59c`). 305 lines of new expr tests (single/multiple/mixed/nested named args, FLATTEN, value-expr composition, negatives, deparse round-trips) + positional/`->`-operator regression.

## Note
Opened by orchestrator from verified commit `f042b59c`. Phase-2 gap 6/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
