### PR TITLE
feat(snowflake): SELECT * EXCLUDE/RENAME + ORDER BY ALL + trailing comma (phase-2 gap-select-ext) — close corpus gaps 179,180,181

### DIFF
--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -687,10 +687,16 @@ type WindowSpec struct {
 }
 
 // OrderItem represents one element in an ORDER BY clause.
+//
+// All is set for the Snowflake `ORDER BY ALL` form, where the reserved keyword
+// ALL stands for "all columns of the SELECT list". When All is true, Expr is
+// nil; the Desc / NullsFirst modifiers still apply (ORDER BY ALL [ASC|DESC]
+// [NULLS {FIRST|LAST}]).
 type OrderItem struct {
 	Expr       Node
 	Desc       bool  // true for DESC
 	NullsFirst *bool // nil = unspecified, true = NULLS FIRST, false = NULLS LAST
+	All        bool  // true for the `ORDER BY ALL` all-columns marker (Expr is nil)
 	Loc        Loc
 }
 
@@ -770,12 +776,24 @@ var _ Node = (*SelectStmt)(nil)
 // SelectTarget is one item in a SELECT list.
 // For expressions: Expr is set, Star is false.
 // For star: Star is true, Expr may be a qualifier (table.*) or nil (bare *).
+//
+// Exclude / Rename carry the Snowflake star column-transforms that may follow
+// a `*` or `tbl.*`: EXCLUDE drops the named columns; RENAME aliases them. Both
+// may appear together (EXCLUDE then RENAME). They are only valid on a star
+// target.
 type SelectTarget struct {
-	Expr    Node    // expression; nil for bare *
-	Alias   Ident   // AS alias; zero Ident if absent
-	Star    bool    // true for * or qualifier.*
-	Exclude []Ident // EXCLUDE columns; nil if absent
+	Expr    Node         // expression; nil for bare *
+	Alias   Ident        // AS alias; zero Ident if absent
+	Star    bool         // true for * or qualifier.*
+	Exclude []Ident      // EXCLUDE columns; nil if absent
+	Rename  []StarRename // RENAME col AS alias pairs; nil if absent
 	Loc     Loc
+}
+
+// StarRename is one `col AS alias` pair in a `SELECT * RENAME (...)` transform.
+type StarRename struct {
+	Col   Ident // source column name
+	Alias Ident // new alias
 }
 
 // TableRef is a table reference in the FROM clause.

--- a/snowflake/deparse/deparse_expr.go
+++ b/snowflake/deparse/deparse_expr.go
@@ -659,7 +659,10 @@ func (w *writer) writeExistsExpr(n *ast.ExistsExpr) error {
 
 // writeOrderItem writes a single ORDER BY item.
 func (w *writer) writeOrderItem(item *ast.OrderItem) error {
-	if err := writeExprNoLeadSpace(w, item.Expr); err != nil {
+	if item.All {
+		// ORDER BY ALL — all-columns marker (no expression).
+		w.buf.WriteString("ALL")
+	} else if err := writeExprNoLeadSpace(w, item.Expr); err != nil {
 		return err
 	}
 	if item.Desc {

--- a/snowflake/deparse/deparse_select.go
+++ b/snowflake/deparse/deparse_select.go
@@ -214,6 +214,19 @@ func (w *writer) writeSelectTarget(t *ast.SelectTarget) error {
 			}
 			w.buf.WriteByte(')')
 		}
+		// RENAME (col AS alias, ...)
+		if len(t.Rename) > 0 {
+			w.buf.WriteString(" RENAME (")
+			for i, r := range t.Rename {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				w.buf.WriteString(r.Col.String())
+				w.buf.WriteString(" AS ")
+				w.buf.WriteString(r.Alias.String())
+			}
+			w.buf.WriteByte(')')
+		}
 		return nil
 	}
 	if err := writeExprNoLeadSpace(w, t.Expr); err != nil {

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -120,6 +120,46 @@ func TestDeparse_Select_ExcludeStar(t *testing.T) {
 	assertRoundTrip(t, `SELECT * EXCLUDE (a, b) FROM t`)
 }
 
+func TestDeparse_Select_ExcludeStarBare(t *testing.T) {
+	// Bare single-column EXCLUDE deparses to the parenthesized form, which
+	// re-parses to the same AST (single Exclude entry).
+	assertRoundTrip(t, `SELECT * EXCLUDE a FROM t`)
+}
+
+func TestDeparse_Select_RenameStar(t *testing.T) {
+	assertRoundTrip(t, `SELECT * RENAME a AS b FROM t`)
+}
+
+func TestDeparse_Select_RenameStarList(t *testing.T) {
+	assertRoundTrip(t, `SELECT * RENAME (a AS b, c AS d) FROM t`)
+}
+
+func TestDeparse_Select_ExcludeAndRenameStar(t *testing.T) {
+	assertRoundTrip(t, `SELECT * EXCLUDE x RENAME (a AS b, c AS d) FROM t`)
+}
+
+func TestDeparse_Select_QualifiedStarExcludeRename(t *testing.T) {
+	assertRoundTrip(t, `SELECT t.* EXCLUDE a, u.* RENAME b AS c FROM t INNER JOIN u ON t.id = u.id`)
+}
+
+func TestDeparse_Select_OrderByAll(t *testing.T) {
+	assertRoundTrip(t, `SELECT a, b FROM t ORDER BY ALL`)
+}
+
+func TestDeparse_Select_OrderByAllDesc(t *testing.T) {
+	assertRoundTrip(t, `SELECT a, b FROM t ORDER BY ALL DESC`)
+}
+
+func TestDeparse_Select_OrderByAllNullsFirst(t *testing.T) {
+	assertRoundTrip(t, `SELECT a, b FROM t ORDER BY ALL NULLS FIRST`)
+}
+
+func TestDeparse_Select_TrailingComma(t *testing.T) {
+	// The trailing comma is normalized away on deparse; the AST (3 targets)
+	// must round-trip identically.
+	assertRoundTrip(t, `SELECT a, b, c, FROM t`)
+}
+
 func TestDeparse_Select_Where(t *testing.T) {
 	assertRoundTrip(t, `SELECT a FROM t WHERE a > 1`)
 }

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -192,22 +192,11 @@ var corpusSkips = map[string]string{
 	"official/values/example_03.sql": "RESIDUAL GAP: FROM (VALUES ...) AS v(...) join — VALUES table source not parsed",
 	"official/values/example_04.sql": "RESIDUAL GAP: FROM (VALUES ...) AS v(c1, c2) — VALUES table source + derived column list not parsed",
 
-	// --- RESIDUAL GAP: ORDER BY ALL ---
-	"official/order-by/example_01.sql": "RESIDUAL GAP: ORDER BY ALL not parsed",
-	"official/order-by/example_11.sql": "RESIDUAL GAP: ORDER BY ALL not parsed",
-	"official/order-by/example_12.sql": "RESIDUAL GAP: ORDER BY ALL ASC not parsed",
-	"official/order-by/example_13.sql": "RESIDUAL GAP: ORDER BY ALL not parsed (ALTER SESSION setup now parses)",
-	"official/order-by/example_14.sql": "RESIDUAL GAP: ORDER BY ALL NULLS FIRST not parsed",
-	"official/order-by/example_15.sql": "RESIDUAL GAP: ORDER BY ALL NULLS LAST not parsed",
-	"official/merge/example_09.sql":    "RESIDUAL GAP: WHEN MATCHED ... DELETE / ORDER BY ALL form not parsed",
-
-	// --- RESIDUAL GAP: SELECT * EXCLUDE / RENAME column transforms ---
-	"official/select/example_07.sql": "RESIDUAL GAP: SELECT * EXCLUDE col not parsed",
-	"official/select/example_11.sql": "RESIDUAL GAP: SELECT * EXCLUDE col RENAME (...) not parsed",
-	"official/select/example_16.sql": "RESIDUAL GAP: SELECT tbl.* EXCLUDE / RENAME column transforms not parsed",
-
-	// --- RESIDUAL GAP: trailing comma in SELECT list ---
-	"official/select/example_24.sql": "RESIDUAL GAP: trailing comma before FROM in SELECT list (Snowflake permits it) not parsed",
+	// --- RESIDUAL GAP: MERGE ... INSERT/UPDATE ALL BY NAME ---
+	// (ORDER BY ALL itself now parses via gap-select-ext; this file's residual
+	// is the MERGE `UPDATE ALL BY NAME` / `INSERT ALL BY NAME` form, owned by
+	// the merge node.)
+	"official/merge/example_09.sql": "RESIDUAL GAP: WHEN MATCHED THEN UPDATE ALL BY NAME / INSERT ALL BY NAME — MERGE column-list-by-name form not parsed",
 
 	// --- RESIDUAL GAP: (+) Oracle-style outer-join operator ---
 	"official/where/example_09.sql": "RESIDUAL GAP: WHERE t1.c1 = t2.c2(+) Oracle-style outer join operator not parsed",

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -1712,6 +1712,24 @@ func (p *Parser) parseOrderByList() ([]*ast.OrderItem, error) {
 
 // parseOrderItem parses a single ORDER BY item.
 func (p *Parser) parseOrderItem() (*ast.OrderItem, error) {
+	// ORDER BY ALL — the reserved keyword ALL stands for "all columns of the
+	// SELECT list" (Snowflake). It is only the all-columns marker when it is
+	// the entire order term: a lone ALL followed by a sort modifier (ASC/DESC/
+	// NULLS) or a list/clause terminator (`,`, `;`, `)`, EOF). Because ALL is
+	// reserved it can never begin a real ORDER BY expression, so this never
+	// shadows a legitimate `ORDER BY <expr>`.
+	if p.cur.Type == kwALL && p.orderByAllFollows() {
+		allTok := p.advance() // consume ALL
+		item := &ast.OrderItem{
+			All: true,
+			Loc: allTok.Loc,
+		}
+		if err := p.parseOrderItemModifiers(item); err != nil {
+			return nil, err
+		}
+		return item, nil
+	}
+
 	expr, err := p.parseExpr()
 	if err != nil {
 		return nil, err
@@ -1722,6 +1740,30 @@ func (p *Parser) parseOrderItem() (*ast.OrderItem, error) {
 		Loc:  ast.NodeLoc(expr),
 	}
 
+	if err := p.parseOrderItemModifiers(item); err != nil {
+		return nil, err
+	}
+
+	return item, nil
+}
+
+// orderByAllFollows reports whether a `kwALL` at the current position is the
+// `ORDER BY ALL` all-columns marker rather than something else. It is the
+// marker only when, after ALL, the next token is a sort modifier (ASC/DESC/
+// NULLS) or a term/clause terminator (`,`, `;`, `)`, EOF). The caller must
+// already be positioned on the ALL token; this peeks one token ahead.
+func (p *Parser) orderByAllFollows() bool {
+	switch p.peekNext().Type {
+	case kwASC, kwDESC, kwNULLS, ',', ';', ')', tokEOF:
+		return true
+	}
+	return false
+}
+
+// parseOrderItemModifiers consumes the optional [ASC|DESC] and
+// [NULLS {FIRST|LAST}] modifiers that may follow an ORDER BY term, recording
+// them on item. Shared by the expression and the `ORDER BY ALL` forms.
+func (p *Parser) parseOrderItemModifiers(item *ast.OrderItem) error {
 	// ASC / DESC
 	if p.cur.Type == kwASC {
 		p.advance()
@@ -1747,14 +1789,14 @@ func (p *Parser) parseOrderItem() (*ast.OrderItem, error) {
 			item.NullsFirst = &nf
 			item.Loc.End = p.prev.Loc.End
 		} else {
-			return nil, &ParseError{
+			return &ParseError{
 				Loc: p.cur.Loc,
 				Msg: "expected FIRST or LAST after NULLS",
 			}
 		}
 	}
 
-	return item, nil
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -383,6 +383,11 @@ func (p *Parser) parseCTE(recursive bool) (*ast.CTE, error) {
 // ---------------------------------------------------------------------------
 
 // parseSelectList parses comma-separated SELECT targets.
+//
+// Snowflake permits a trailing comma right before the clause that follows the
+// SELECT list (e.g. `SELECT a, b, FROM t`). After consuming a comma, if the
+// next token terminates the list (FROM or another query clause, a `)`, `;`, or
+// EOF) we stop without parsing — and erroring on — an empty target.
 func (p *Parser) parseSelectList() ([]*ast.SelectTarget, error) {
 	var targets []*ast.SelectTarget
 
@@ -394,6 +399,10 @@ func (p *Parser) parseSelectList() ([]*ast.SelectTarget, error) {
 
 	for p.cur.Type == ',' {
 		p.advance() // consume ','
+		if p.selectListTerminator() {
+			// Trailing comma before a clause terminator — allowed.
+			break
+		}
 		target, err = p.parseSelectTarget()
 		if err != nil {
 			return nil, err
@@ -402,6 +411,23 @@ func (p *Parser) parseSelectList() ([]*ast.SelectTarget, error) {
 	}
 
 	return targets, nil
+}
+
+// selectListTerminator reports whether the current token ends the SELECT list.
+// Used to accept a trailing comma: a comma immediately followed by one of these
+// tokens is a permitted trailing comma rather than an empty list item. It is
+// deliberately narrow — only genuine list-ending tokens — so a stray comma in
+// the middle of the list (e.g. `SELECT a, , b`) still errors.
+func (p *Parser) selectListTerminator() bool {
+	switch p.cur.Type {
+	case tokEOF, ')', ';':
+		return true
+	case kwFROM, kwWHERE, kwGROUP, kwHAVING, kwQUALIFY, kwORDER,
+		kwLIMIT, kwOFFSET, kwFETCH, kwUNION, kwEXCEPT, kwMINUS, kwINTERSECT,
+		kwINTO, kwSTART, kwCONNECT:
+		return true
+	}
+	return false
 }
 
 // parseSelectTarget parses one item in the SELECT list:
@@ -428,24 +454,19 @@ func (p *Parser) parseSelectTarget() (*ast.SelectTarget, error) {
 		target.Star = true
 		target.Expr = expr
 
-		// Check for EXCLUDE (col1, col2, ...)
+		// Star column-transforms: EXCLUDE then RENAME (Snowflake documents
+		// EXCLUDE before RENAME; either or both may be present).
+		//   EXCLUDE <col> | EXCLUDE (<col>, ...)
+		//   RENAME <col> AS <alias> | RENAME (<col> AS <alias>, ...)
 		if p.cur.Type == kwEXCLUDE {
 			p.advance() // consume EXCLUDE
-			if _, err := p.expect('('); err != nil {
+			if err := p.parseStarExclude(target); err != nil {
 				return nil, err
 			}
-			for {
-				col, err := p.parseIdent()
-				if err != nil {
-					return nil, err
-				}
-				target.Exclude = append(target.Exclude, col)
-				if p.cur.Type != ',' {
-					break
-				}
-				p.advance() // consume ','
-			}
-			if _, err := p.expect(')'); err != nil {
+		}
+		if p.cur.Type == kwRENAME {
+			p.advance() // consume RENAME
+			if err := p.parseStarRename(target); err != nil {
 				return nil, err
 			}
 		}
@@ -463,6 +484,105 @@ func (p *Parser) parseSelectTarget() (*ast.SelectTarget, error) {
 
 	target.Loc.End = p.prev.Loc.End
 	return target, nil
+}
+
+// parseStarExclude parses the EXCLUDE column-transform that may follow a star
+// in a SELECT list. The EXCLUDE keyword has already been consumed. Accepts
+// either a single bare column or a parenthesized comma-separated list:
+//
+//	EXCLUDE <col>
+//	EXCLUDE (<col>, <col>, ...)
+func (p *Parser) parseStarExclude(target *ast.SelectTarget) error {
+	if p.cur.Type == '(' {
+		p.advance() // consume '('
+		for {
+			// Progress guard: each iteration must consume at least one token
+			// (parseIdent advances or errors; the comma is consumed below), so
+			// a stalled cursor means a malformed list rather than an infinite
+			// loop.
+			before := p.cur.Loc.Start
+			col, err := p.parseIdent()
+			if err != nil {
+				return err
+			}
+			target.Exclude = append(target.Exclude, col)
+			if p.cur.Type != ',' {
+				break
+			}
+			p.advance() // consume ','
+			if p.cur.Loc.Start <= before {
+				return &ParseError{Loc: p.cur.Loc, Msg: "malformed EXCLUDE list"}
+			}
+		}
+		if _, err := p.expect(')'); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Single bare column.
+	col, err := p.parseIdent()
+	if err != nil {
+		return err
+	}
+	target.Exclude = append(target.Exclude, col)
+	return nil
+}
+
+// parseStarRename parses the RENAME column-transform that may follow a star in
+// a SELECT list. The RENAME keyword has already been consumed. Accepts either a
+// single bare `col AS alias` or a parenthesized comma-separated list of them:
+//
+//	RENAME <col> AS <alias>
+//	RENAME (<col> AS <alias>, <col> AS <alias>, ...)
+func (p *Parser) parseStarRename(target *ast.SelectTarget) error {
+	if p.cur.Type == '(' {
+		p.advance() // consume '('
+		for {
+			// Progress guard: see parseStarExclude — the cursor must strictly
+			// advance each iteration.
+			before := p.cur.Loc.Start
+			pair, err := p.parseStarRenamePair()
+			if err != nil {
+				return err
+			}
+			target.Rename = append(target.Rename, pair)
+			if p.cur.Type != ',' {
+				break
+			}
+			p.advance() // consume ','
+			if p.cur.Loc.Start <= before {
+				return &ParseError{Loc: p.cur.Loc, Msg: "malformed RENAME list"}
+			}
+		}
+		if _, err := p.expect(')'); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Single bare `col AS alias`.
+	pair, err := p.parseStarRenamePair()
+	if err != nil {
+		return err
+	}
+	target.Rename = append(target.Rename, pair)
+	return nil
+}
+
+// parseStarRenamePair parses one `<col> AS <alias>` pair of a RENAME transform.
+// The AS keyword is required (Snowflake's documented syntax).
+func (p *Parser) parseStarRenamePair() (ast.StarRename, error) {
+	col, err := p.parseIdent()
+	if err != nil {
+		return ast.StarRename{}, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return ast.StarRename{}, err
+	}
+	alias, err := p.parseIdent()
+	if err != nil {
+		return ast.StarRename{}, err
+	}
+	return ast.StarRename{Col: col, Alias: alias}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/select_test.go
+++ b/snowflake/parser/select_test.go
@@ -1925,3 +1925,399 @@ func TestJoin_JoinWithOrderByLimit(t *testing.T) {
 		t.Fatal("expected LIMIT to be set")
 	}
 }
+
+// ===========================================================================
+// gap-select-ext: SELECT * EXCLUDE/RENAME, ORDER BY ALL, trailing comma
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// A. Star column-transforms — EXCLUDE (bare + list), RENAME (bare + list)
+// ---------------------------------------------------------------------------
+
+func TestSelect_StarExcludeBare(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * EXCLUDE department_id FROM employee_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if !target.Star {
+		t.Fatal("target should be star")
+	}
+	if len(target.Exclude) != 1 || target.Exclude[0].Name != "department_id" {
+		t.Fatalf("exclude = %v, want [department_id]", target.Exclude)
+	}
+	if len(target.Rename) != 0 {
+		t.Errorf("rename = %v, want empty", target.Rename)
+	}
+}
+
+func TestSelect_StarRenameBare(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * RENAME department_id AS department FROM employee_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if !target.Star {
+		t.Fatal("target should be star")
+	}
+	if len(target.Rename) != 1 {
+		t.Fatalf("rename = %d, want 1", len(target.Rename))
+	}
+	if target.Rename[0].Col.Name != "department_id" || target.Rename[0].Alias.Name != "department" {
+		t.Errorf("rename[0] = %q AS %q, want department_id AS department",
+			target.Rename[0].Col.Name, target.Rename[0].Alias.Name)
+	}
+}
+
+func TestSelect_StarRenameList(t *testing.T) {
+	sel, errs := testParseSelectStmt(
+		"SELECT * RENAME (department_id AS department, employee_id AS id) FROM employee_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if len(target.Rename) != 2 {
+		t.Fatalf("rename = %d, want 2", len(target.Rename))
+	}
+	if target.Rename[0].Col.Name != "department_id" || target.Rename[0].Alias.Name != "department" {
+		t.Errorf("rename[0] = %q AS %q", target.Rename[0].Col.Name, target.Rename[0].Alias.Name)
+	}
+	if target.Rename[1].Col.Name != "employee_id" || target.Rename[1].Alias.Name != "id" {
+		t.Errorf("rename[1] = %q AS %q", target.Rename[1].Col.Name, target.Rename[1].Alias.Name)
+	}
+}
+
+func TestSelect_StarExcludeThenRename(t *testing.T) {
+	sel, errs := testParseSelectStmt(
+		"SELECT * EXCLUDE first_name RENAME (department_id AS department, employee_id AS id) FROM employee_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if len(target.Exclude) != 1 || target.Exclude[0].Name != "first_name" {
+		t.Fatalf("exclude = %v, want [first_name]", target.Exclude)
+	}
+	if len(target.Rename) != 2 {
+		t.Fatalf("rename = %d, want 2", len(target.Rename))
+	}
+}
+
+func TestSelect_QualifiedStarExcludeAndRename(t *testing.T) {
+	sel, errs := testParseSelectStmt(
+		"SELECT employee_table.* EXCLUDE department_id, department_table.* RENAME department_name AS department " +
+			"FROM employee_table INNER JOIN department_table ON employee_table.id = department_table.id")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.Targets) != 2 {
+		t.Fatalf("targets = %d, want 2", len(sel.Targets))
+	}
+	t0 := sel.Targets[0]
+	if !t0.Star {
+		t.Error("target[0] should be star")
+	}
+	star0, ok := t0.Expr.(*ast.StarExpr)
+	if !ok || star0.Qualifier == nil || star0.Qualifier.Name.Name != "employee_table" {
+		t.Errorf("target[0] qualifier mismatch: %#v", t0.Expr)
+	}
+	if len(t0.Exclude) != 1 || t0.Exclude[0].Name != "department_id" {
+		t.Errorf("target[0] exclude = %v", t0.Exclude)
+	}
+	t1 := sel.Targets[1]
+	star1, ok := t1.Expr.(*ast.StarExpr)
+	if !ok || star1.Qualifier == nil || star1.Qualifier.Name.Name != "department_table" {
+		t.Errorf("target[1] qualifier mismatch: %#v", t1.Expr)
+	}
+	if len(t1.Rename) != 1 || t1.Rename[0].Col.Name != "department_name" || t1.Rename[0].Alias.Name != "department" {
+		t.Errorf("target[1] rename = %v", t1.Rename)
+	}
+}
+
+func TestSelect_StarExcludeLoc(t *testing.T) {
+	const sql = "SELECT * EXCLUDE department_id FROM employee_table"
+	sel, errs := testParseSelectStmt(sql)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	// The target Loc should span from the '*' through the end of the EXCLUDE col.
+	got := sql[target.Loc.Start:target.Loc.End]
+	if got != "* EXCLUDE department_id" {
+		t.Errorf("target Loc slice = %q, want %q", got, "* EXCLUDE department_id")
+	}
+}
+
+// Negative: `* EXCLUDE` with no column.
+func TestSelect_StarExcludeNoColumn(t *testing.T) {
+	_, err := Parse("SELECT * EXCLUDE FROM t")
+	if err == nil {
+		t.Fatal("expected error for `* EXCLUDE` with no column")
+	}
+}
+
+// Negative: `* RENAME x` with no AS.
+func TestSelect_StarRenameNoAs(t *testing.T) {
+	_, err := Parse("SELECT * RENAME x FROM t")
+	if err == nil {
+		t.Fatal("expected error for `* RENAME x` with no AS alias")
+	}
+}
+
+// Regression: a column literally named "exclude" / "rename" still parses as a
+// plain column reference (these are non-reserved keywords).
+func TestSelect_ColumnNamedExcludeRename(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT exclude, rename FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.Targets) != 2 {
+		t.Fatalf("targets = %d, want 2", len(sel.Targets))
+	}
+	for i, want := range []string{"exclude", "rename"} {
+		col, ok := sel.Targets[i].Expr.(*ast.ColumnRef)
+		if !ok {
+			t.Fatalf("target[%d] = %T, want *ast.ColumnRef", i, sel.Targets[i].Expr)
+		}
+		if len(col.Parts) != 1 || col.Parts[0].Name != want {
+			t.Errorf("target[%d] = %v, want [%q]", i, col.Parts, want)
+		}
+		if sel.Targets[i].Star {
+			t.Errorf("target[%d] should not be star", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B. ORDER BY ALL
+// ---------------------------------------------------------------------------
+
+func TestSelect_OrderByAll(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT col_1, col_2 FROM my_table ORDER BY ALL")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.OrderBy) != 1 {
+		t.Fatalf("OrderBy = %d, want 1", len(sel.OrderBy))
+	}
+	item := sel.OrderBy[0]
+	if !item.All {
+		t.Error("OrderBy[0].All should be true")
+	}
+	if item.Expr != nil {
+		t.Errorf("OrderBy[0].Expr should be nil for ALL, got %T", item.Expr)
+	}
+	if item.Desc {
+		t.Error("OrderBy[0].Desc should be false (default ASC)")
+	}
+	if item.NullsFirst != nil {
+		t.Error("OrderBy[0].NullsFirst should be nil")
+	}
+}
+
+func TestSelect_OrderByAllAsc(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM my_sort_example ORDER BY ALL ASC")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	item := sel.OrderBy[0]
+	if !item.All {
+		t.Error("OrderBy[0].All should be true")
+	}
+	if item.Desc {
+		t.Error("ALL ASC should not be Desc")
+	}
+}
+
+func TestSelect_OrderByAllDesc(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM my_sort_example ORDER BY ALL DESC")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	item := sel.OrderBy[0]
+	if !item.All {
+		t.Error("OrderBy[0].All should be true")
+	}
+	if !item.Desc {
+		t.Error("ALL DESC should be Desc")
+	}
+}
+
+func TestSelect_OrderByAllNullsFirst(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT * FROM my_sort_example ORDER BY ALL NULLS FIRST")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	item := sel.OrderBy[0]
+	if !item.All {
+		t.Error("OrderBy[0].All should be true")
+	}
+	if item.NullsFirst == nil || !*item.NullsFirst {
+		t.Errorf("ALL NULLS FIRST: NullsFirst = %v, want true", item.NullsFirst)
+	}
+}
+
+func TestSelect_OrderByAllNullsLast(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT b, s, a FROM my_sort_example ORDER BY ALL NULLS LAST")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	item := sel.OrderBy[0]
+	if !item.All {
+		t.Error("OrderBy[0].All should be true")
+	}
+	if item.NullsFirst == nil || *item.NullsFirst {
+		t.Errorf("ALL NULLS LAST: NullsFirst = %v, want false", item.NullsFirst)
+	}
+}
+
+func TestSelect_OrderByAllLoc(t *testing.T) {
+	const sql = "SELECT * FROM t ORDER BY ALL"
+	sel, errs := testParseSelectStmt(sql)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	item := sel.OrderBy[0]
+	got := sql[item.Loc.Start:item.Loc.End]
+	if got != "ALL" {
+		t.Errorf("OrderBy[0] Loc slice = %q, want %q", got, "ALL")
+	}
+}
+
+// Negative: `ORDER BY ALL NULLS <garbage>` must error just like the
+// expression path does — the ALL branch must not swallow the modifier error.
+func TestSelect_OrderByAllNullsGarbageErrors(t *testing.T) {
+	_, err := Parse("SELECT a FROM t ORDER BY ALL NULLS SOMETHING")
+	if err == nil {
+		t.Fatal("expected error for `ORDER BY ALL NULLS SOMETHING`")
+	}
+}
+
+// Regression: ORDER BY with real expressions still works, and a column named
+// "all" inside an expression context is unaffected by the ALL marker (note:
+// ALL is reserved, so a *bare* `ORDER BY all` is always the marker; this guards
+// the multi-term and modifier paths).
+func TestSelect_OrderByExprNotStolenByAll(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT x, y FROM t ORDER BY x, y DESC")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.OrderBy) != 2 {
+		t.Fatalf("OrderBy = %d, want 2", len(sel.OrderBy))
+	}
+	if sel.OrderBy[0].All || sel.OrderBy[1].All {
+		t.Error("neither ORDER BY term should be flagged All")
+	}
+	if sel.OrderBy[0].Expr == nil || sel.OrderBy[1].Expr == nil {
+		t.Error("both ORDER BY terms should carry an Expr")
+	}
+	if !sel.OrderBy[1].Desc {
+		t.Error("second ORDER BY term should be DESC")
+	}
+}
+
+// Regression: `ALL` as the *argument of a function* in ORDER BY (e.g. a hand-
+// written ORDER BY over a function) is not the ALL marker because it is not a
+// lone term — guard that ORDER BY ALL only fires when ALL is the whole term.
+// `ORDER BY x + 1` exercises the expression path adjacent to a possible ALL.
+func TestSelect_OrderByExpression(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT x FROM t ORDER BY x + 1")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.OrderBy) != 1 {
+		t.Fatalf("OrderBy = %d, want 1", len(sel.OrderBy))
+	}
+	if sel.OrderBy[0].All {
+		t.Error("ORDER BY x + 1 should not be flagged All")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C. Trailing comma in SELECT list
+// ---------------------------------------------------------------------------
+
+func TestSelect_TrailingCommaBeforeFrom(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT emp_id, name, dept, FROM employees")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.Targets) != 3 {
+		t.Fatalf("targets = %d, want 3 (trailing comma must not add an empty item)", len(sel.Targets))
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+}
+
+func TestSelect_TrailingCommaNoFrom(t *testing.T) {
+	// Trailing comma before end-of-statement (no FROM).
+	sel, errs := testParseSelectStmt("SELECT 1, 2,")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.Targets) != 2 {
+		t.Fatalf("targets = %d, want 2", len(sel.Targets))
+	}
+}
+
+func TestSelect_TrailingCommaInSubquery(t *testing.T) {
+	// Trailing comma before `)` inside a derived-table subquery.
+	sel, errs := testParseSelectStmt("SELECT * FROM (SELECT a, b, FROM t) x")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(sel.From))
+	}
+}
+
+// Regression: a genuine empty item mid-list (double comma) must still error.
+func TestSelect_DoubleCommaErrors(t *testing.T) {
+	_, err := Parse("SELECT a, , b FROM t")
+	if err == nil {
+		t.Fatal("expected error for empty select item (`a, , b`)")
+	}
+}
+
+// Regression: a leading comma (`SELECT , a`) must still error.
+func TestSelect_LeadingCommaErrors(t *testing.T) {
+	_, err := Parse("SELECT , a FROM t")
+	if err == nil {
+		t.Fatal("expected error for leading comma in select list")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D. Plain-form regressions (must be unaffected by the new code)
+// ---------------------------------------------------------------------------
+
+func TestSelect_PlainStarAndQualifiedStarRegression(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM t",
+		"SELECT tbl.* FROM tbl",
+		"SELECT a, b FROM t",
+		"SELECT a, b FROM t ORDER BY x, y DESC",
+	} {
+		sel, errs := testParseSelectStmt(sql)
+		if len(errs) > 0 {
+			t.Errorf("%q: unexpected errors: %v", sql, errs)
+		}
+		if sel == nil {
+			t.Errorf("%q: nil select", sql)
+		}
+	}
+}
+
+// Regression: a column/alias literally named "all" is parseable where it is a
+// legal identifier — e.g. as an alias via AS (ALL is reserved so it cannot be a
+// bare column, but AS "all" quoted, or other non-bare positions are fine). Use
+// the AS-quoted alias form which is unambiguously an identifier.
+func TestSelect_AllAsQuotedAlias(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT x AS "all" FROM t`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if sel.Targets[0].Alias.Name != "all" {
+		t.Errorf("alias = %q, want all", sel.Targets[0].Alias.Name)
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/gap-select-ext` (phase-2 corpus-gap closure) — three SELECT/ORDER-BY extensions: **`SELECT *`/`tbl.*` EXCLUDE/RENAME** (real regression vs legacy `.g4`), **`ORDER BY ALL`** (docs-ahead), **trailing comma in SELECT list**.

## Forms + design
- `SELECT * EXCLUDE col | EXCLUDE (c1,c2)`, `* RENAME c AS a | RENAME (c1 AS a1, …)`, `* EXCLUDE … RENAME …`, and per-table `tbl.* …`. AST: added `SelectTarget.Rename []StarRename` (+ `StarRename{Col,Alias}` type); EXCLUDE reused existing field. (`SelectTarget` is not a walked Node — no walker change.)
- `ORDER BY ALL [ASC|DESC] [NULLS {FIRST|LAST}]` via `OrderItem.All bool`, guarded by an `orderByAllFollows` lookahead so a real expression starting with something else is unaffected; ASC/DESC/NULLS refactored into a shared `parseOrderItemModifiers`.
- Trailing comma before `FROM` via a `selectListTerminator` check in `parseSelectList`.

## Corpus delta (TestCorpusClosure) — 10 files closed, 30 → 20 skipped, 625 → 635 clean
`order-by/example_{01,11,12,13,14,15}`, `select/example_{07,11,16,24}`. (`merge/example_09` left skipped — residual is MERGE `… ALL BY NAME`, owned by the merge node; its misleading skip comment corrected.)

## Review (`/code-review` high; Codex down) — 1 real bug fixed
**Swallowed-error bug:** the `ORDER BY ALL` branch ignored `parseOrderItemModifiers`'s return, silently accepting `ORDER BY ALL NULLS <garbage>` (the expression path rejected the same input). Fixed (error propagated) + regression test `TestSelect_OrderByAllNullsGarbageErrors`. Also hardened two list progress-guards to a strict-advance invariant. Orchestrator independently verified on a fresh checkout of `7dc7cc4d`: **build clean** (gopls had shown spurious `undefined` errors from mis-loading the worktree module in isolation — `go build ./snowflake/...` succeeds), gofmt/vet clean, full `go test ./snowflake/... -timeout 120s` green (7 pkgs), corpus self-prune green.

## Regression confirmation
Plain `SELECT *` / `SELECT tbl.*` / `SELECT a, b FROM t` / `ORDER BY x, y DESC` parse; columns/aliases named `exclude`/`rename`/`all` parse as identifiers; double-/leading-comma + `SELECT FROM t` still error.

## Divergences (noted)
- `ORDER BY ALL` parses via the shared `parseOrderItem`, so it's also accepted in window `OVER(...)`/PIVOT/MATCH_RECOGNIZE order-by contexts where Snowflake doesn't document it — no valid query regresses (consistent with the engine's union-superset tolerance); deparse handles `All` everywhere.
- EXCLUDE/RENAME deparse to the parenthesized canonical form; round-trips verified.

## Note
Opened by orchestrator from verified commit `7dc7cc4d`. Phase-2 gap 7/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
