### PR TITLE
feat(snowflake): VALUES table source + ->> result-pipe + $N table ref (phase-2 gap-from-values) — close corpus gaps 177,178

### DIFF
--- a/snowflake/ast/cmd/genwalker/main.go
+++ b/snowflake/ast/cmd/genwalker/main.go
@@ -165,6 +165,8 @@ func main() {
 				fmt.Fprintf(&buf, "\t\tWalk(v, n.%s)\n", f.Name)
 			case "[]Node":
 				fmt.Fprintf(&buf, "\t\twalkNodes(v, n.%s)\n", f.Name)
+			case "[][]Node":
+				fmt.Fprintf(&buf, "\t\twalkNodeRows(v, n.%s)\n", f.Name)
 			default:
 				// Pointer to a known struct type (e.g. *SelectStmt).
 				fmt.Fprintf(&buf, "\t\tif n.%s != nil {\n", f.Name)
@@ -226,6 +228,7 @@ func typeString(expr ast.Expr) string {
 // Recognized shapes:
 //   - "Node"             — the Node interface
 //   - "[]Node"           — slice of nodes
+//   - "[][]Node"         — slice of rows of nodes (e.g. VALUES rows)
 //   - "*<NodeStruct>"    — pointer to a struct that implements Node (has Tag() method)
 //
 // Excluded: pointer to "Loc" (Loc is not a node), pointer to non-Node structs
@@ -235,6 +238,9 @@ func isChildType(typStr string, nodeStructs map[string]bool) bool {
 		return true
 	}
 	if typStr == "[]Node" {
+		return true
+	}
+	if typStr == "[][]Node" {
 		return true
 	}
 	if strings.HasPrefix(typStr, "*") {

--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -68,6 +68,10 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *JoinExpr:
 		return v.Loc
+	case *ValuesClause:
+		return v.Loc
+	case *ResultScanStmt:
+		return v.Loc
 	default:
 		return NoLoc()
 	}

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -235,6 +235,13 @@ const (
 	T_ScriptFetchStmt
 	T_ScriptCloseStmt
 	T_ScriptRaiseStmt
+
+	// T_ValuesClause is the tag for *ValuesClause, a VALUES (row), (row), …
+	// query expression usable as a derived-table source.
+	T_ValuesClause
+	// T_ResultScanStmt is the tag for *ResultScanStmt, the `<stmt> ->> <query>`
+	// result-pipe that feeds a statement's result set into a following query.
+	T_ResultScanStmt
 )
 
 // String returns a human-readable representation of the tag.
@@ -572,6 +579,10 @@ func (t NodeTag) String() string {
 		return "ScriptCloseStmt"
 	case T_ScriptRaiseStmt:
 		return "ScriptRaiseStmt"
+	case T_ValuesClause:
+		return "ValuesClause"
+	case T_ResultScanStmt:
+		return "ResultScanStmt"
 	default:
 		return "Unknown"
 	}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -805,8 +805,10 @@ type StarRename struct {
 type TableRef struct {
 	Name     *ObjectName   // table name; nil for subquery/func sources
 	Alias    Ident         // AS alias; zero if absent
-	Subquery Node          // (SELECT ...) in FROM; nil for table refs
+	Columns  []Ident       // derived column list: AS v(c1, c2); nil if absent
+	Subquery Node          // (SELECT ...) or (VALUES ...) in FROM; nil for table refs
 	FuncCall *FuncCallExpr // TABLE(func(...)); nil for table refs
+	DollarN  *DollarRef    // $N result-set table ref (RESULT_SCAN of a prior result); nil otherwise
 	Lateral  bool          // LATERAL prefix
 	// Table-attached clauses (Snowflake). Any combination may appear; the
 	// documented source order is AT/BEFORE → CHANGES → MATCH_RECOGNIZE →
@@ -861,6 +863,43 @@ type CTE struct {
 	Recursive bool    // WITH RECURSIVE flag
 	Loc       Loc
 }
+
+// ValuesClause is a VALUES query expression usable as a row source:
+//
+//	VALUES (expr, …) [, (expr, …) …]
+//
+// In Snowflake a VALUES list is a query expression: parenthesized as
+// `( VALUES (1,'a'), (2,'b') )` it is a derived-table source (carried on
+// TableRef.Subquery), and an optional `AS v (c1, c2)` aliases it and its
+// columns. Each row is a slice of value expressions; rows need not share
+// arity (Snowflake accepts ragged rows and resolves widths downstream).
+type ValuesClause struct {
+	Rows [][]Node // one slice of value expressions per row; len(Rows) >= 1
+	Loc  Loc
+}
+
+func (n *ValuesClause) Tag() NodeTag { return T_ValuesClause }
+
+var _ Node = (*ValuesClause)(nil)
+
+// ResultScanStmt is the Snowflake result-pipe operator `->>`:
+//
+//	<source-stmt> ->> <query>
+//
+// The source statement (typically a SHOW / metadata command) is executed and
+// its result set is exposed to the following query as `$1` (a $N table ref).
+// Source holds the left statement; Query holds the right query expression.
+// It is only recognized at the top level of a statement (not inside a
+// procedure body or EXECUTE IMMEDIATE), mirroring Snowflake.
+type ResultScanStmt struct {
+	Source Node // the left statement whose result set feeds the pipe
+	Query  Node // the right query expression consuming $1
+	Loc    Loc
+}
+
+func (n *ResultScanStmt) Tag() NodeTag { return T_ResultScanStmt }
+
+var _ Node = (*ResultScanStmt)(nil)
 
 // GroupByClause represents a GROUP BY clause with optional variant.
 type GroupByClause struct {

--- a/snowflake/ast/walk.go
+++ b/snowflake/ast/walk.go
@@ -53,3 +53,14 @@ func walkNodes(v Visitor, nodes []Node) {
 		Walk(v, n)
 	}
 }
+
+// walkNodeRows visits every node in a slice-of-rows child field ([][]Node),
+// e.g. the VALUES rows on *ValuesClause / *InsertStmt. Used by
+// walk_generated.go.
+func walkNodeRows(v Visitor, rows [][]Node) {
+	for _, row := range rows {
+		for _, n := range row {
+			Walk(v, n)
+		}
+	}
+}

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -507,6 +507,7 @@ func walkChildren(v Visitor, node Node) {
 		if n.Target != nil {
 			Walk(v, n.Target)
 		}
+		walkNodeRows(v, n.Values)
 		Walk(v, n.Select)
 	case *IsExpr:
 		Walk(v, n.Expr)
@@ -586,6 +587,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.Pattern != nil {
 			Walk(v, n.Pattern)
 		}
+	case *ResultScanStmt:
+		Walk(v, n.Source)
+		Walk(v, n.Query)
 	case *RevokeStmt:
 		if n.On != nil {
 			Walk(v, n.On)
@@ -687,6 +691,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.FuncCall != nil {
 			Walk(v, n.FuncCall)
 		}
+		if n.DollarN != nil {
+			Walk(v, n.DollarN)
+		}
 		if n.TimeTravel != nil {
 			Walk(v, n.TimeTravel)
 		}
@@ -739,5 +746,7 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *ValuesClause:
+		walkNodeRows(v, n.Rows)
 	}
 }

--- a/snowflake/deparse/deparse.go
+++ b/snowflake/deparse/deparse.go
@@ -52,6 +52,8 @@ func (w *writer) writeNode(node ast.Node) error {
 		return w.writeSelectStmt(n)
 	case *ast.SetOperationStmt:
 		return w.writeSetOperationStmt(n)
+	case *ast.ResultScanStmt:
+		return w.writeResultScanStmt(n)
 
 	// --- DML ---
 	case *ast.InsertStmt:

--- a/snowflake/deparse/deparse_select.go
+++ b/snowflake/deparse/deparse_select.go
@@ -14,9 +14,44 @@ func (w *writer) writeQueryExpr(node ast.Node) error {
 		return w.writeSelectStmt(n)
 	case *ast.SetOperationStmt:
 		return w.writeSetOperationStmt(n)
+	case *ast.ValuesClause:
+		return w.writeValuesClause(n)
 	default:
 		return fmt.Errorf("deparse: expected query expression, got %T", node)
 	}
+}
+
+// writeResultScanStmt emits the result-pipe: <source> ->> <query>. The source
+// node may be any deparsable statement (a non-deparsable source — e.g. SHOW,
+// which the deparser does not render — surfaces as the underlying writeNode
+// error rather than a panic).
+func (w *writer) writeResultScanStmt(n *ast.ResultScanStmt) error {
+	if err := w.writeNode(n.Source); err != nil {
+		return err
+	}
+	w.buf.WriteString(" ->> ")
+	return w.writeQueryExpr(n.Query)
+}
+
+// writeValuesClause emits a VALUES row source: VALUES (e, …), (e, …).
+func (w *writer) writeValuesClause(n *ast.ValuesClause) error {
+	w.buf.WriteString("VALUES ")
+	for i, row := range n.Rows {
+		if i > 0 {
+			w.buf.WriteString(", ")
+		}
+		w.buf.WriteByte('(')
+		for j, val := range row {
+			if j > 0 {
+				w.buf.WriteString(", ")
+			}
+			if err := writeExprNoLeadSpace(w, val); err != nil {
+				return err
+			}
+		}
+		w.buf.WriteByte(')')
+	}
+	return nil
 }
 
 // writeCTEs writes the WITH clause (all CTEs).
@@ -265,22 +300,39 @@ func (w *writer) writeTableRef(n *ast.TableRef) error {
 	if n.Lateral {
 		w.buf.WriteString("LATERAL ")
 	}
-	if n.Name != nil {
+	switch {
+	case n.Name != nil:
 		w.buf.WriteString(n.Name.String())
-	} else if n.Subquery != nil {
+	case n.Subquery != nil:
 		w.buf.WriteByte('(')
 		if err := w.writeQueryExpr(n.Subquery); err != nil {
 			return err
 		}
 		w.buf.WriteByte(')')
-	} else if n.FuncCall != nil {
+	case n.FuncCall != nil:
 		if err := writeExprNoLeadSpace(w, n.FuncCall); err != nil {
+			return err
+		}
+	case n.DollarN != nil:
+		// $N result-set table reference (e.g. FROM $1).
+		if err := writeExprNoLeadSpace(w, n.DollarN); err != nil {
 			return err
 		}
 	}
 	if !n.Alias.IsEmpty() {
 		w.buf.WriteString(" AS ")
 		w.buf.WriteString(n.Alias.String())
+	}
+	// Derived column list: AS v (c1, c2).
+	if len(n.Columns) > 0 {
+		w.buf.WriteString(" (")
+		for i, col := range n.Columns {
+			if i > 0 {
+				w.buf.WriteString(", ")
+			}
+			w.buf.WriteString(col.String())
+		}
+		w.buf.WriteByte(')')
 	}
 	return nil
 }

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -1000,3 +1000,39 @@ func TestDeparse_CloneBeforeStatementValue(t *testing.T) {
 	out := assertRoundTrip(t, `CREATE TABLE t2 CLONE t1 BEFORE (STATEMENT => '8e5d0ca1-e866-44fa-843b-5e6ad35e8bb7')`)
 	require.Contains(t, out, "BEFORE (STATEMENT => '8e5d0ca1-e866-44fa-843b-5e6ad35e8bb7')")
 }
+
+// ---------------------------------------------------------------------------
+// VALUES table source + $N table ref + ->> result-pipe (gap-from-values)
+// ---------------------------------------------------------------------------
+
+func TestDeparse_ValuesTableSource(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three'))`)
+	require.Contains(t, out, "(VALUES (1, 'one'), (2, 'two'), (3, 'three'))")
+}
+
+func TestDeparse_ValuesTableSourceDerivedColumnList(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT c1, c2 FROM (VALUES (1, 'one'), (2, 'two')) AS v1 (c1, c2)`)
+	require.Contains(t, out, "AS v1 (c1, c2)")
+}
+
+func TestDeparse_ValuesTableSourceJoin(t *testing.T) {
+	assertRoundTrip(t,
+		`SELECT v1.$2, v2.$2 FROM (VALUES (1, 'one'), (2, 'two')) AS v1 `+
+			`INNER JOIN (VALUES (1, 'One'), (3, 'three')) AS v2 WHERE v2.$1 = v1.$1`)
+}
+
+func TestDeparse_DollarTableRef(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT * FROM $1`)
+	require.Contains(t, out, "FROM $1")
+}
+
+func TestDeparse_DollarTableRefAlias(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT d.x FROM $1 AS d`)
+	require.Contains(t, out, "FROM $1 AS d")
+}
+
+func TestDeparse_ResultPipeGeneral(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT 1 ->> SELECT * FROM $1`)
+	require.Contains(t, out, "->>")
+	require.Contains(t, out, "FROM $1")
+}

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -164,13 +164,6 @@ var corpusWholeFile = map[string]string{
 //
 // Grouped by root cause. Counts in comments are at authoring time.
 var corpusSkips = map[string]string{
-	// --- RESIDUAL GAP: SHOW ->> result-pipe + $N table-ref (other nodes) ---
-	// CREATE/ALTER WAREHOUSE now parse (gap-warehouse); this file remains skipped
-	// only because its two `SHOW WAREHOUSES ... ->> SELECT ... FROM $1` statements
-	// exercise the ->> result-pipe and $N table-ref gaps owned by other nodes. The
-	// CREATE OR ALTER WAREHOUSE and DROP WAREHOUSE statements in it parse clean.
-	"official/create-warehouse/example_07.sql": "RESIDUAL GAP: SHOW WAREHOUSES ->> SELECT ... FROM $1 — ->> result-pipe + $N table-ref owned by other nodes (CREATE OR ALTER WAREHOUSE parses)",
-
 	// --- RESIDUAL GAP: dynamic-table IMMUTABLE WHERE + INTERVAL literal ---
 	// example_04 (CLONE ... AT (TIMESTAMP => TO_TIMESTAMP_TZ(...))) is now closed
 	// by gap-named-args (named function arguments + general clone time-travel
@@ -178,19 +171,12 @@ var corpusSkips = map[string]string{
 	// the INTERVAL literal / refresh-mode clause owned by gap-expr-misc.
 	"official/create-dynamic-table/example_07.sql": "RESIDUAL GAP: IMMUTABLE WHERE (... - INTERVAL '1 day') refresh-mode + interval literal not parsed",
 
-	// --- DEPENDENCY GAP: $N / $N:path result-set ref + stage path as a table ref (T5) ---
-	"official/create-external-table/example_01.sql":  "DEPENDENCY GAP: SELECT metadata$filename FROM @s1/ — stage-path table ref + metadata$col not parsed",
-	"official/create-external-volume/example_05.sql": "DEPENDENCY GAP: SHOW ... ->> SELECT * FROM $1 — $N result-set table ref (T5) not parsed",
-	"official/create-table/example_06.sql":           "DEPENDENCY GAP: CTAS AS SELECT $1:o_custkey::number FROM @my_stage — $N:path semi-structured + stage table ref",
-	"official/show-tables/example_07.sql":            "DEPENDENCY GAP: SHOW ... ->> SELECT * FROM $1 — $N result-set table ref (T5) not parsed",
-	"official/show-tables/example_08.sql":            "DEPENDENCY GAP: SHOW ... ->> SELECT ... FROM $1 — $N result-set table ref (T5) not parsed",
-	"official/show-tables/example_09.sql":            "DEPENDENCY GAP: SHOW ... ->> SELECT ... FROM $1 — $N result-set table ref (T5) not parsed",
-
-	// --- RESIDUAL GAP: VALUES as a table source  FROM (VALUES (...), ...) ---
-	"official/values/example_01.sql": "RESIDUAL GAP: SELECT * FROM (VALUES (...), ...) — VALUES table source not parsed",
-	"official/values/example_02.sql": "RESIDUAL GAP: FROM (VALUES ...) with positional $N column refs — VALUES table source not parsed",
-	"official/values/example_03.sql": "RESIDUAL GAP: FROM (VALUES ...) AS v(...) join — VALUES table source not parsed",
-	"official/values/example_04.sql": "RESIDUAL GAP: FROM (VALUES ...) AS v(c1, c2) — VALUES table source + derived column list not parsed",
+	// --- DEPENDENCY GAP: $N:path semi-structured ref + stage path as a table ref (T5) ---
+	// (Bare $N as a table ref and the SHOW ... ->> ... FROM $1 result-pipe now
+	// parse via gap-from-values; these two remain because they additionally need
+	// a stage-path source (@s1/, @my_stage) and the $N:path semi-structured cast.)
+	"official/create-external-table/example_01.sql": "DEPENDENCY GAP: SELECT metadata$filename FROM @s1/ — stage-path table ref + metadata$col not parsed",
+	"official/create-table/example_06.sql":          "DEPENDENCY GAP: CTAS AS SELECT $1:o_custkey::number FROM @my_stage — $N:path semi-structured + stage table ref",
 
 	// --- RESIDUAL GAP: MERGE ... INSERT/UPDATE ALL BY NAME ---
 	// (ORDER BY ALL itself now parses via gap-select-ext; this file's residual

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -329,6 +329,42 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	}
 }
 
+// parseTopStmt parses one top-level statement and applies the Snowflake
+// result-pipe operator `->>` when it follows:
+//
+//	<source-stmt> ->> <query>
+//
+// The source statement (typically a SHOW / metadata command) runs and exposes
+// its result set to the right-hand query as `$1`. `->>` is a top-level-only
+// construct in Snowflake, so it is recognized here — at the genuine statement
+// entry (parseSingle) — and NOT inside nested statement contexts (procedure
+// bodies, EXECUTE IMMEDIATE, pipe/task/dynamic-table bodies, scripting), all of
+// which call parseStmt directly and are therefore unaffected. Chained pipes
+// (`a ->> b ->> c`) nest left-associatively.
+func (p *Parser) parseTopStmt() (ast.Node, error) {
+	// Capture the start offset from the first token: the source statement may be
+	// a node type (e.g. *ShowStmt) that ast.NodeLoc does not cover, so we cannot
+	// rely on NodeLoc(stmt) for the wrapper's start.
+	startOff := p.cur.Loc.Start
+	stmt, err := p.parseStmt()
+	if err != nil {
+		return nil, err
+	}
+	for p.cur.Type == tokFlow {
+		p.advance() // consume '->>'
+		query, qerr := p.parseQueryExpr()
+		if qerr != nil {
+			return nil, qerr
+		}
+		stmt = &ast.ResultScanStmt{
+			Source: stmt,
+			Query:  query,
+			Loc:    ast.Loc{Start: startOff, End: p.prev.Loc.End},
+		}
+	}
+	return stmt, nil
+}
+
 // ParseResult holds the outcome of a best-effort parse. File contains
 // all successfully-parsed statements (empty for stubs-only F4); Errors
 // contains every ParseError encountered plus any LexErrors promoted
@@ -394,7 +430,7 @@ func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
 
 	var result ast.Node
 	if p.cur.Type != tokEOF {
-		node, err := p.parseStmt()
+		node, err := p.parseTopStmt()
 		if err != nil {
 			if pe, ok := err.(*ParseError); ok {
 				p.errors = append(p.errors, *pe)

--- a/snowflake/parser/result_pipe_test.go
+++ b/snowflake/parser/result_pipe_test.go
@@ -1,0 +1,122 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// The Snowflake result-pipe operator `->>` feeds a statement's result set into
+// a following query, where the prior result is named $1. A SHOW source carries
+// the pipe on ShowStmt.Pipe (see show.go / show_test.go); any other source is
+// wrapped in a top-level *ast.ResultScanStmt by parseTopStmt. Both rely on the
+// $N table reference (FROM $1) added in gap-from-values.
+
+// TestResultPipe_ShowCorpusShapes covers the exact official-corpus SHOW pipes
+// closed by gap-from-values (show-tables/example_07..09,
+// create-external-volume/example_05, create-warehouse/example_07). They flow
+// through ShowStmt.Pipe; the blocker was FROM $1, now parseable.
+func TestResultPipe_ShowCorpusShapes(t *testing.T) {
+	cases := []string{
+		`SHOW TERSE TABLES ->> SELECT * FROM $1 ORDER BY "created_on" DESC`,
+		`SHOW TABLES ->> SELECT "name", "database_name", "schema_name", "bytes" FROM $1 ORDER BY "bytes" DESC`,
+		`SHOW TABLES IN ACCOUNT ->> SELECT "database_name" || '.' || "schema_name" || '.' || "name" AS fully_qualified_name FROM $1 ORDER BY fully_qualified_name`,
+		`SHOW ICEBERG TABLES ->> SELECT * FROM $1 WHERE "external_volume_name" = 'my_external_volume_1'`,
+		`SHOW WAREHOUSES LIKE 'test_gen_warehouse' ->> SELECT "name", "resource_constraint" FROM $1`,
+	}
+	for _, c := range cases {
+		node, errs := parseSingle(c, 0)
+		if len(errs) > 0 {
+			t.Errorf("%q: %v", c, errs)
+			continue
+		}
+		show, ok := node.(*ast.ShowStmt)
+		if !ok {
+			t.Errorf("%q: got %T, want *ast.ShowStmt", c, node)
+			continue
+		}
+		if show.Pipe == nil {
+			t.Errorf("%q: ShowStmt.Pipe is nil", c)
+		}
+	}
+}
+
+// TestResultPipe_GeneralStmt verifies a non-SHOW source is wrapped in a
+// *ast.ResultScanStmt with Source and Query set, and a valid span Loc.
+func TestResultPipe_GeneralStmt(t *testing.T) {
+	node, errs := parseSingle(`SELECT 1 AS x ->> SELECT * FROM $1`, 0)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	rs, ok := node.(*ast.ResultScanStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.ResultScanStmt", node)
+	}
+	if _, ok := rs.Source.(*ast.SelectStmt); !ok {
+		t.Errorf("Source = %T, want *ast.SelectStmt", rs.Source)
+	}
+	sel, ok := rs.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Query = %T, want *ast.SelectStmt", rs.Query)
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok || ref.DollarN == nil {
+		t.Errorf("Query.From[0] = %T, want *ast.TableRef with DollarN", sel.From[0])
+	}
+	if !rs.Loc.IsValid() {
+		t.Errorf("ResultScanStmt.Loc invalid: %+v", rs.Loc)
+	}
+}
+
+// TestResultPipe_Chained verifies a ->> b ->> c nests left-associatively into
+// two ResultScanStmt levels (outer.Source is the inner ResultScanStmt).
+func TestResultPipe_Chained(t *testing.T) {
+	node, errs := parseSingle(`SELECT 1 ->> SELECT * FROM $1 ->> SELECT * FROM $1`, 0)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	outer, ok := node.(*ast.ResultScanStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.ResultScanStmt", node)
+	}
+	if _, ok := outer.Source.(*ast.ResultScanStmt); !ok {
+		t.Errorf("outer.Source = %T, want nested *ast.ResultScanStmt", outer.Source)
+	}
+}
+
+// Negative: `->>` with no following query is an error (parseQueryExpr fails).
+func TestResultPipe_NoFollowingQuery(t *testing.T) {
+	result := ParseBestEffort(`SELECT 1 ->>`)
+	if len(result.Errors) == 0 {
+		t.Error("expected an error for trailing `->>` with no query, got none")
+	}
+}
+
+// Regression: a plain SHOW with no `->>` is unchanged (Pipe stays nil).
+func TestResultPipe_ShowWithoutPipeUnchanged(t *testing.T) {
+	node, errs := parseSingle(`SHOW TABLES`, 0)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	show, ok := node.(*ast.ShowStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.ShowStmt", node)
+	}
+	if show.Pipe != nil {
+		t.Errorf("ShowStmt.Pipe = %v, want nil for SHOW without ->>", show.Pipe)
+	}
+}
+
+// Regression: the single-arrow operator `->` (tokArrow, e.g. lambda) is not
+// confused with `->>` (tokFlow) by max-munch. A lambda x -> x + 1 still parses
+// as an expression, not a result pipe.
+func TestResultPipe_SingleArrowUnaffected(t *testing.T) {
+	// TRANSFORM-style higher-order function with a lambda using ->.
+	sel, errs := testParseSelectStmt(`SELECT FILTER(a, x -> x > 0) FROM t`)
+	if len(errs) > 0 {
+		t.Fatalf("single-arrow lambda should parse, got: %v", errs)
+	}
+	if _, ok := sel.Targets[0].Expr.(*ast.FuncCallExpr); !ok {
+		t.Errorf("target[0] = %T, want *ast.FuncCallExpr", sel.Targets[0].Expr)
+	}
+}

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -378,6 +378,27 @@ func (p *Parser) parseCTE(recursive bool) (*ast.CTE, error) {
 	return cte, nil
 }
 
+// parseValuesClause parses a VALUES query expression used as a row source:
+//
+//	VALUES (expr, …) [, (expr, …) …]
+//
+// It is reached from parsePrimarySource when a parenthesized derived table
+// opens with VALUES (i.e. `( VALUES … )`). Row parsing is delegated to the
+// shared parseValuesRows (the same code path INSERT uses); its loop makes
+// progress only on a `, (` and so cannot spin. Rows need not be uniform in
+// arity — Snowflake accepts ragged VALUES lists.
+func (p *Parser) parseValuesClause() (ast.Node, error) {
+	start := p.cur.Loc.Start
+	rows, err := p.parseValuesRows()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ValuesClause{
+		Rows: rows,
+		Loc:  ast.Loc{Start: start, End: p.prev.Loc.End},
+	}, nil
+}
+
 // ---------------------------------------------------------------------------
 // SELECT list
 // ---------------------------------------------------------------------------
@@ -632,17 +653,20 @@ func (p *Parser) parseFromItem() (ast.Node, error) {
 func (p *Parser) parsePrimarySource() (ast.Node, error) {
 	startLoc := p.cur.Loc
 
-	// Parenthesized: subquery or parenthesized from-item.
+	// Parenthesized: subquery, VALUES row-source, or parenthesized from-item.
 	if p.cur.Type == '(' {
 		next := p.peekNext()
-		if next.Type == kwSELECT || next.Type == kwWITH {
-			// Subquery in FROM: (SELECT ...) [AS] alias
+		if next.Type == kwSELECT || next.Type == kwWITH || next.Type == kwVALUES {
+			// Derived table in FROM: ( SELECT … ) | ( VALUES … ) [AS] alias
 			p.advance() // consume '('
 			var query ast.Node
 			var err error
-			if p.cur.Type == kwWITH {
+			switch p.cur.Type {
+			case kwWITH:
 				query, err = p.parseWithSelect()
-			} else {
+			case kwVALUES:
+				query, err = p.parseValuesClause()
+			default:
 				query, err = p.parseSelectStmt()
 			}
 			if err != nil {
@@ -743,6 +767,23 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 			ref.Alias = alias
 		}
 		ref.Loc.End = p.prev.Loc.End
+		return ref, nil
+	}
+
+	// $N result-set table reference: FROM $1. A bare positional $-reference in
+	// FROM position names the result set of the preceding statement (the source
+	// of a `->>` result-pipe). A qualified $N (t.$1) is a column expression, not
+	// a source, and never reaches FROM position, so only the bare token is
+	// handled here.
+	if p.cur.Type == tokVariable {
+		dollar := p.parseDollarRef(nil)
+		ref := &ast.TableRef{
+			DollarN: dollar,
+			Loc:     ast.Loc{Start: startLoc.Start, End: dollar.Loc.End},
+		}
+		if err := p.parseTableSuffix(ref); err != nil {
+			return nil, err
+		}
 		return ref, nil
 	}
 
@@ -1093,10 +1134,53 @@ func (p *Parser) parseTableSuffix(ref *ast.TableRef) error {
 	if alias, has := p.parseOptionalAlias(); has {
 		ref.Alias = alias
 		ref.Loc.End = p.prev.Loc.End
+
+		// Derived column list: alias (c1, c2, …). Only valid on a derived
+		// table (subquery / VALUES); a parenthesis after a plain table name is
+		// not a column list and is left for the caller. Requires an explicit
+		// alias to precede it, which the IsEmpty guard above ensures.
+		if ref.Subquery != nil && p.cur.Type == '(' {
+			cols, err := p.parseDerivedColumnList()
+			if err != nil {
+				return err
+			}
+			ref.Columns = cols
+			ref.Loc.End = p.prev.Loc.End
+		}
 	}
 
 	// SAMPLE | TABLESAMPLE ( … )
 	return p.parseTrailingSample(ref)
+}
+
+// parseDerivedColumnList parses a parenthesized derived-table column list:
+//
+//	( col1 [, col2 …] )
+//
+// The caller must have already verified p.cur is '('. The list must be
+// non-empty (an empty "()" is rejected). Each iteration consumes one
+// identifier and either a ',' (continue) or ')' (stop), so the loop always
+// makes progress.
+func (p *Parser) parseDerivedColumnList() ([]ast.Ident, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	var cols []ast.Ident
+	for {
+		col, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, col)
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	return cols, nil
 }
 
 // parseTrailingSample parses an optional SAMPLE / TABLESAMPLE clause and

--- a/snowflake/parser/select_test.go
+++ b/snowflake/parser/select_test.go
@@ -2321,3 +2321,203 @@ func TestSelect_AllAsQuotedAlias(t *testing.T) {
 		t.Errorf("alias = %q, want all", sel.Targets[0].Alias.Name)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// VALUES as a table source  (gap-from-values, official/values/example_01..04)
+// ---------------------------------------------------------------------------
+
+// fromTableRef returns sel.From[i] as a *ast.TableRef or fails the test.
+func fromTableRef(t *testing.T, sel *ast.SelectStmt, i int) *ast.TableRef {
+	t.Helper()
+	if len(sel.From) <= i {
+		t.Fatalf("from len = %d, want > %d", len(sel.From), i)
+	}
+	ref, ok := sel.From[i].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from[%d] = %T, want *ast.TableRef", i, sel.From[i])
+	}
+	return ref
+}
+
+func TestSelect_ValuesTableSource(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three'))`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	vc, ok := ref.Subquery.(*ast.ValuesClause)
+	if !ok {
+		t.Fatalf("Subquery = %T, want *ast.ValuesClause", ref.Subquery)
+	}
+	if len(vc.Rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(vc.Rows))
+	}
+	for i, row := range vc.Rows {
+		if len(row) != 2 {
+			t.Errorf("row %d arity = %d, want 2", i, len(row))
+		}
+	}
+	if !vc.Loc.IsValid() {
+		t.Errorf("ValuesClause.Loc invalid: %+v", vc.Loc)
+	}
+}
+
+func TestSelect_ValuesTableSourcePositionalRef(t *testing.T) {
+	// official/values/example_02: positional $2 column ref over a VALUES source.
+	sel, errs := testParseSelectStmt(`SELECT column1, $2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three'))`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	if _, ok := ref.Subquery.(*ast.ValuesClause); !ok {
+		t.Fatalf("Subquery = %T, want *ast.ValuesClause", ref.Subquery)
+	}
+	// $2 is a positional DollarRef in the select list.
+	d, ok := sel.Targets[1].Expr.(*ast.DollarRef)
+	if !ok {
+		t.Fatalf("target[1] = %T, want *ast.DollarRef", sel.Targets[1].Expr)
+	}
+	if d.Name != "2" || !d.Positional {
+		t.Errorf("DollarRef = %+v, want positional $2", d)
+	}
+}
+
+func TestSelect_ValuesTableSourceDerivedColumnList(t *testing.T) {
+	// official/values/example_04: AS v1 (c1, c2) derived column list.
+	sel, errs := testParseSelectStmt(`SELECT c1, c2 FROM (VALUES (1, 'one'), (2, 'two')) AS v1 (c1, c2)`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	if ref.Alias.Name != "v1" {
+		t.Errorf("alias = %q, want v1", ref.Alias.Name)
+	}
+	if len(ref.Columns) != 2 || ref.Columns[0].Name != "c1" || ref.Columns[1].Name != "c2" {
+		t.Errorf("columns = %+v, want [c1 c2]", ref.Columns)
+	}
+}
+
+func TestSelect_ValuesTableSourceJoinQualifiedDollar(t *testing.T) {
+	// official/values/example_03: two aliased VALUES sources joined, with
+	// qualified positional refs (v1.$2, v2.$1).
+	sel, errs := testParseSelectStmt(
+		`SELECT v1.$2, v2.$2 FROM (VALUES (1, 'one'), (2, 'two')) AS v1 ` +
+			`INNER JOIN (VALUES (1, 'One'), (3, 'three')) AS v2 WHERE v2.$1 = v1.$1`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("from len = %d, want 1 (join)", len(sel.From))
+	}
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinExpr", sel.From[0])
+	}
+	left, ok := join.Left.(*ast.TableRef)
+	if !ok || left.Alias.Name != "v1" {
+		t.Errorf("join.Left = %T alias=%q, want *ast.TableRef v1", join.Left, aliasOf(join.Left))
+	}
+	if _, ok := left.Subquery.(*ast.ValuesClause); !ok {
+		t.Errorf("join.Left.Subquery = %T, want *ast.ValuesClause", left.Subquery)
+	}
+}
+
+func aliasOf(n ast.Node) string {
+	if ref, ok := n.(*ast.TableRef); ok {
+		return ref.Alias.Name
+	}
+	return ""
+}
+
+// Snowflake accepts ragged VALUES rows (differing arity); the parser must not
+// reject them. Resolution of column widths is a downstream concern.
+func TestSelect_ValuesTableSourceRaggedRows(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT * FROM (VALUES (1, 'a'), (2), (3, 'c', 4))`)
+	if len(errs) > 0 {
+		t.Fatalf("ragged VALUES rows should parse, got: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	vc := ref.Subquery.(*ast.ValuesClause)
+	if got := []int{len(vc.Rows[0]), len(vc.Rows[1]), len(vc.Rows[2])}; got[0] != 2 || got[1] != 1 || got[2] != 3 {
+		t.Errorf("row arities = %v, want [2 1 3]", got)
+	}
+}
+
+// Regression: a plain ( SELECT … ) AS d derived table is unchanged by the
+// VALUES additions.
+func TestSelect_DerivedSubqueryStillParses(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT d.x FROM (SELECT 1 AS x) AS d`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	if ref.Alias.Name != "d" {
+		t.Errorf("alias = %q, want d", ref.Alias.Name)
+	}
+	if _, ok := ref.Subquery.(*ast.SelectStmt); !ok {
+		t.Errorf("Subquery = %T, want *ast.SelectStmt", ref.Subquery)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// $N as a result-set table reference  (gap-from-values, FROM $1)
+// ---------------------------------------------------------------------------
+
+func TestSelect_DollarTableRef(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT * FROM $1 ORDER BY 1`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	if ref.DollarN == nil {
+		t.Fatalf("DollarN is nil, want $1")
+	}
+	if ref.DollarN.Name != "1" || !ref.DollarN.Positional {
+		t.Errorf("DollarN = %+v, want positional $1", ref.DollarN)
+	}
+	if ref.Name != nil || ref.Subquery != nil || ref.FuncCall != nil {
+		t.Errorf("expected $N-only TableRef, got Name=%v Subquery=%v FuncCall=%v", ref.Name, ref.Subquery, ref.FuncCall)
+	}
+	if !ref.Loc.IsValid() {
+		t.Errorf("TableRef.Loc invalid: %+v", ref.Loc)
+	}
+}
+
+func TestSelect_DollarTableRefAlias(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT d.x FROM $1 AS d`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	ref := fromTableRef(t, sel, 0)
+	if ref.DollarN == nil || ref.DollarN.Name != "1" {
+		t.Fatalf("DollarN = %+v, want $1", ref.DollarN)
+	}
+	if ref.Alias.Name != "d" {
+		t.Errorf("alias = %q, want d", ref.Alias.Name)
+	}
+}
+
+// Regression: $1 as a column expression (not a FROM source) still parses as a
+// DollarRef in the select list.
+func TestSelect_DollarColumnExprUnchanged(t *testing.T) {
+	sel, errs := testParseSelectStmt(`SELECT $1, $2 FROM t`)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if _, ok := sel.Targets[0].Expr.(*ast.DollarRef); !ok {
+		t.Errorf("target[0] = %T, want *ast.DollarRef", sel.Targets[0].Expr)
+	}
+	ref := fromTableRef(t, sel, 0)
+	if ref.Name == nil || ref.Name.String() != "t" {
+		t.Errorf("from[0] = %+v, want table t", ref)
+	}
+}
+
+// Negative: FROM $ with no name is not a valid table reference. The lexer only
+// emits tokVariable for $ followed by a name, so a bare $ is a lex error.
+func TestSelect_DollarBareIsError(t *testing.T) {
+	result := ParseBestEffort(`SELECT * FROM $`)
+	if len(result.Errors) == 0 {
+		t.Error("expected an error for bare `FROM $`, got none")
+	}
+}

--- a/snowflake/parser/show_test.go
+++ b/snowflake/parser/show_test.go
@@ -173,17 +173,33 @@ func TestParseShow_Pipe(t *testing.T) {
 	})
 }
 
-// TestParseShow_PipeDollarLimitation documents that a SHOW ... ->> SELECT ...
-// FROM $1 result pipe cannot yet parse, because the table-reference / expression
-// parser (T3/T5) does not implement the $N result-set reference. The SHOW pipe
-// machinery is correct — it delegates the piped query to parseStmt — so when the
-// table-ref parser gains $N support these official examples
-// (show-tables/example_07..09) will parse with no change to show.go. Flagged
-// divergence (shared root cause with the SET $var limitation).
-func TestParseShow_PipeDollarLimitation(t *testing.T) {
-	result := ParseBestEffort(`SHOW TABLES ->> SELECT * FROM $1 ORDER BY 1`)
-	if len(result.Errors) == 0 {
-		t.Skip("table-ref parser now supports $N — wire show-tables/example_07..09 into the corpus filter")
+// TestParseShow_PipeDollar verifies that a SHOW ... ->> SELECT ... FROM $1
+// result pipe parses end-to-end now that the table-reference parser accepts a
+// bare positional $N as a result-set source (gap-from-values). The SHOW pipe
+// machinery delegates the piped query to parseStmt, so the $N table ref is the
+// only piece that was missing; the official examples (show-tables/example_07..09,
+// create-external-volume/example_05) are now wired into the corpus filter.
+func TestParseShow_PipeDollar(t *testing.T) {
+	stmt := mustParseShow(t, `SHOW TABLES ->> SELECT * FROM $1 ORDER BY 1`)
+	if stmt.Pipe == nil {
+		t.Fatalf("Pipe is nil, want a piped SELECT statement")
+	}
+	sel, ok := stmt.Pipe.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Pipe = %T, want *ast.SelectStmt", stmt.Pipe)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("piped SELECT From len = %d, want 1", len(sel.From))
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("From[0] = %T, want *ast.TableRef", sel.From[0])
+	}
+	if ref.DollarN == nil {
+		t.Fatalf("From[0].DollarN is nil, want a $1 result-set ref")
+	}
+	if ref.DollarN.Name != "1" || !ref.DollarN.Positional {
+		t.Errorf("DollarN = %+v, want positional $1", ref.DollarN)
 	}
 }
 


### PR DESCRIPTION
## Node
`snowflake/gap-from-values` (phase-2 corpus-gap closure) — two FROM-clause / table-source features: **`VALUES` as a table source** (real regression vs legacy `.g4`) and the **`->>` result-pipe** with **`$N` as a table reference**.

## What was built
- **VALUES table source** — `( VALUES (row),… ) [AS v (c1,c2)]` as a derived table. New `ast.ValuesClause{Rows [][]Node}` on `TableRef.Subquery`; new `TableRef.Columns []Ident` derived column list (parsed only when `ref.Subquery != nil`, so plain-table parens aren't swallowed). Reuses existing `parseValuesRows`.
- **`$N` table ref** — `FROM $1` via new `TableRef.DollarN *DollarRef`, reusing merged `ast.DollarRef` (#264).
- **`->>` result-pipe** — `tokFlow` already lexed `->>`. SHOW's pipe was already `ShowStmt.Pipe` (merged + tested) — the only blocker for the SHOW corpus files was the `$N` table ref. Kept `ShowStmt.Pipe`; added `ast.ResultScanStmt{Source,Query}` + a top-level `parseTopStmt` wrapper for the general (non-SHOW) `stmt ->> query` case (additive — doesn't touch the SHOW contract or nested callers).

## genwalker extension (out-of-scope but justified)
`ast/cmd/genwalker/main.go` now recognizes `[][]Node` fields (emits `walkNodeRows`) so `ValuesClause.Rows` is walker-reachable — which also closed a **latent gap**: `InsertStmt.Values` (already `[][]Node`) was never walked before, now is. Walker regen is self-consistent (re-run is a no-op: 141 cases / 287 child fields). `ast/loc.go` got `NodeLoc` cases for the two new nodes.

## Corpus delta (TestCorpusClosure) — 9 files closed, 20 → 11 skipped, 635 → 644 clean
`values/example_01..04`, `show-tables/example_07..09`, `create-external-volume/example_05`, and **`create-warehouse/example_07`** (the last file gap-warehouse left). `create-external-table/01` + `create-table/06` skips narrowed to their residual stage-path / `$N:path` gaps (bare `$N` + `->>` now parse).

## Review (`/code-review` high; Codex down) — no correctness bugs
Empirically probed chained pipes, ragged/expr/NULL/scalar-subquery VALUES rows, implicit-alias + col-list, `$var`, plain-table paren. Analysis (`query_span`/`classify`) handles all three new node types gracefully (no panic). Orchestrator independently verified on a fresh checkout of `bb895d99`: build clean (gopls `undefined` errors were spurious worktree-isolation artifacts), gofmt/vet clean, genwalker re-run no-op, full `go test ./snowflake/... -timeout 120s` green (7 pkgs incl. analysis), corpus self-prune green.

## Regression confirmation
`(SELECT …) AS d` derived tables, `SHOW TABLES;` without `->>` (Pipe nil), `->` (tokArrow) lambdas (max-munch), `$1` as a column expression — all unchanged. The old self-skipping `TestParseShow_PipeDollarLimitation` converted to a positive assertion.

## Divergences (lenient over-accepts, harmless)
`FROM $myvar` (non-positional) accepts as a `$N` table ref; chained `SHOW … ->> q1 ->> q2` nests as `ResultScanStmt{Source: Show{Pipe:q1}, Query:q2}` (asymmetric but correct); `FROM t (c1)` plain-table paren absorption is pre-existing on origin/main (not introduced here).

## Note
Opened by orchestrator from verified commit `bb895d99`. Phase-2 gap 8/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
