### PR TITLE
feat(snowflake): (+) Oracle outer-join + MERGE ALL BY NAME (phase-2 gap-expr-misc) — close corpus gaps 182 + merge

### DIFF
--- a/snowflake/ast/loc.go
+++ b/snowflake/ast/loc.go
@@ -40,6 +40,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *CollateExpr:
 		return v.Loc
+	case *OuterJoinExpr:
+		return v.Loc
 	case *IsExpr:
 		return v.Loc
 	case *BetweenExpr:

--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -37,6 +37,7 @@ const (
 	T_FuncCallExpr
 	T_IffExpr
 	T_CollateExpr
+	T_OuterJoinExpr
 	T_IsExpr
 	T_BetweenExpr
 	T_InExpr
@@ -279,6 +280,8 @@ func (t NodeTag) String() string {
 		return "IffExpr"
 	case T_CollateExpr:
 		return "CollateExpr"
+	case T_OuterJoinExpr:
+		return "OuterJoinExpr"
 	case T_IsExpr:
 		return "IsExpr"
 	case T_BetweenExpr:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -567,6 +567,18 @@ type CollateExpr struct {
 
 func (n *CollateExpr) Tag() NodeTag { return T_CollateExpr }
 
+// OuterJoinExpr represents the legacy Oracle-style outer-join marker that
+// Snowflake supports in a WHERE join predicate: a postfix `(+)` applied to a
+// column reference, e.g. `t1.c1 = t2.c2(+)`. The `(+)` marks the side opposite
+// the outer table, requesting that unmatched rows be preserved. Operand is the
+// marked operand (typically a *ColumnRef).
+type OuterJoinExpr struct {
+	Operand Node
+	Loc     Loc
+}
+
+func (n *OuterJoinExpr) Tag() NodeTag { return T_OuterJoinExpr }
+
 // IsExpr represents expr IS [NOT] NULL or expr IS [NOT] DISTINCT FROM expr.
 type IsExpr struct {
 	Expr         Node
@@ -1952,7 +1964,12 @@ type MergeWhen struct {
 	InsertCols    []Ident      // for MergeActionInsert: optional column list
 	InsertVals    []Node       // for MergeActionInsert: VALUES expressions
 	InsertDefault bool         // for MergeActionInsert: INSERT VALUES DEFAULT
-	Loc           Loc
+	// AllByName marks the column-list-by-name forms `UPDATE ALL BY NAME` and
+	// `INSERT ALL BY NAME` (Snowflake), which match every source column to a
+	// like-named target column instead of an explicit SET / (cols) VALUES list.
+	// When set, Sets / InsertCols / InsertVals / InsertDefault are unused.
+	AllByName bool
+	Loc       Loc
 }
 
 // MergeStmt represents a MERGE statement:

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -552,6 +552,8 @@ func walkChildren(v Visitor, node Node) {
 		}
 		Walk(v, n.Source)
 		Walk(v, n.On)
+	case *OuterJoinExpr:
+		Walk(v, n.Operand)
 	case *ParenExpr:
 		Walk(v, n.Expr)
 	case *PivotClause:

--- a/snowflake/deparse/deparse_dml.go
+++ b/snowflake/deparse/deparse_dml.go
@@ -248,6 +248,10 @@ func (w *writer) writeMergeWhen(mw *ast.MergeWhen) error {
 	w.buf.WriteString(" THEN")
 	switch mw.Action {
 	case ast.MergeActionUpdate:
+		if mw.AllByName {
+			w.buf.WriteString(" UPDATE ALL BY NAME")
+			break
+		}
 		w.buf.WriteString(" UPDATE SET ")
 		for i, set := range mw.Sets {
 			if i > 0 {
@@ -263,6 +267,10 @@ func (w *writer) writeMergeWhen(mw *ast.MergeWhen) error {
 		w.buf.WriteString(" DELETE")
 	case ast.MergeActionInsert:
 		w.buf.WriteString(" INSERT")
+		if mw.AllByName {
+			w.buf.WriteString(" ALL BY NAME")
+			break
+		}
 		if mw.InsertDefault {
 			w.buf.WriteString(" VALUES DEFAULT")
 		} else {

--- a/snowflake/deparse/deparse_expr.go
+++ b/snowflake/deparse/deparse_expr.go
@@ -38,6 +38,8 @@ func (w *writer) writeExpr(node ast.Node) error {
 		return w.writeIffExpr(n)
 	case *ast.CollateExpr:
 		return w.writeCollateExpr(n)
+	case *ast.OuterJoinExpr:
+		return w.writeOuterJoinExpr(n)
 	case *ast.IsExpr:
 		return w.writeIsExpr(n)
 	case *ast.BetweenExpr:
@@ -462,6 +464,16 @@ func (w *writer) writeCollateExpr(n *ast.CollateExpr) error {
 	}
 	w.buf.WriteString(" COLLATE ")
 	w.buf.WriteString(quoteString(n.Collation))
+	return nil
+}
+
+// writeOuterJoinExpr renders the legacy Oracle-style outer-join marker as the
+// canonical `operand(+)` (no space before the marker).
+func (w *writer) writeOuterJoinExpr(n *ast.OuterJoinExpr) error {
+	if err := w.writeExpr(n.Operand); err != nil {
+		return err
+	}
+	w.buf.WriteString("(+)")
 	return nil
 }
 

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -164,6 +164,19 @@ func TestDeparse_Select_Where(t *testing.T) {
 	assertRoundTrip(t, `SELECT a FROM t WHERE a > 1`)
 }
 
+func TestDeparse_Where_OuterJoinMarker(t *testing.T) {
+	out := assertRoundTrip(t, `SELECT t1.c1, t2.c2 FROM t1, t2 WHERE t1.c1 = t2.c2(+)`)
+	require.Contains(t, out, "t2.c2(+)")
+}
+
+func TestDeparse_Where_OuterJoinMarkerMultiple(t *testing.T) {
+	// A space before the marker in the source canonicalizes to no-space on
+	// deparse; the round-trip still re-parses to an equivalent AST.
+	out := assertRoundTrip(t, `SELECT t1.c1, t2.c2 FROM t1, t2 WHERE t1.c1 = t2.c2 (+) AND t1.c3 = t2.c4 (+)`)
+	require.Contains(t, out, "t2.c2(+)")
+	require.Contains(t, out, "t2.c4(+)")
+}
+
 func TestDeparse_Select_GroupBy(t *testing.T) {
 	assertRoundTrip(t, `SELECT a, COUNT(*) FROM t GROUP BY a`)
 }
@@ -482,6 +495,20 @@ func TestDeparse_Merge_InsertWhenNotMatched(t *testing.T) {
 
 func TestDeparse_Merge_Delete(t *testing.T) {
 	assertRoundTrip(t, `MERGE INTO target t USING source s ON t.id = s.id WHEN MATCHED AND s.active = 0 THEN DELETE`)
+}
+
+func TestDeparse_Merge_UpdateAllByName(t *testing.T) {
+	out := assertRoundTrip(t, `MERGE INTO target t USING source s ON t.id = s.id WHEN MATCHED THEN UPDATE ALL BY NAME`)
+	require.Contains(t, out, "UPDATE ALL BY NAME")
+}
+
+func TestDeparse_Merge_InsertAllByName(t *testing.T) {
+	out := assertRoundTrip(t, `MERGE INTO target t USING source s ON t.id = s.id WHEN NOT MATCHED THEN INSERT ALL BY NAME`)
+	require.Contains(t, out, "INSERT ALL BY NAME")
+}
+
+func TestDeparse_Merge_BothAllByName(t *testing.T) {
+	assertRoundTrip(t, `MERGE INTO target t USING source s ON t.id = s.id WHEN MATCHED THEN UPDATE ALL BY NAME WHEN NOT MATCHED THEN INSERT ALL BY NAME`)
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -178,16 +178,6 @@ var corpusSkips = map[string]string{
 	"official/create-external-table/example_01.sql": "DEPENDENCY GAP: SELECT metadata$filename FROM @s1/ — stage-path table ref + metadata$col not parsed",
 	"official/create-table/example_06.sql":          "DEPENDENCY GAP: CTAS AS SELECT $1:o_custkey::number FROM @my_stage — $N:path semi-structured + stage table ref",
 
-	// --- RESIDUAL GAP: MERGE ... INSERT/UPDATE ALL BY NAME ---
-	// (ORDER BY ALL itself now parses via gap-select-ext; this file's residual
-	// is the MERGE `UPDATE ALL BY NAME` / `INSERT ALL BY NAME` form, owned by
-	// the merge node.)
-	"official/merge/example_09.sql": "RESIDUAL GAP: WHEN MATCHED THEN UPDATE ALL BY NAME / INSERT ALL BY NAME — MERGE column-list-by-name form not parsed",
-
-	// --- RESIDUAL GAP: (+) Oracle-style outer-join operator ---
-	"official/where/example_09.sql": "RESIDUAL GAP: WHERE t1.c1 = t2.c2(+) Oracle-style outer join operator not parsed",
-	"official/where/example_10.sql": "RESIDUAL GAP: WHERE ... (+) Oracle-style outer join operator not parsed",
-
 	// --- RESIDUAL GAP: Snowflake Scripting blocks (DECLARE..BEGIN..END, CALL ... INTO) ---
 	"official/execute-immediate/example_01.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
 	"official/execute-immediate/example_04.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -78,6 +78,8 @@ func (p *Parser) parseExprPrec(minBP int) (ast.Node, error) {
 				left, err = p.parseCollatePostfix(left)
 			case "OVER":
 				left, err = p.parseOverPostfix(left)
+			case "OUTER_JOIN":
+				left, err = p.parseOuterJoinPostfix(left)
 			case "COLON_ACCESS":
 				left, err = p.parseColonAccess(left)
 			case "BRACKET_ACCESS":
@@ -181,6 +183,16 @@ func (p *Parser) infixBindingPower() (int, ast.BinaryOp, string, bool) {
 		return bpMul, ast.BinDiv, "", true
 	case '%':
 		return bpMul, ast.BinMod, "", true
+
+	// Postfix: (+) legacy Oracle-style outer-join marker. Only treat a '('
+	// as an operator when it forms exactly `(+)`; otherwise a leading '(' is
+	// not an infix operator here (function-call parens are consumed by the
+	// primary parser).
+	case '(':
+		if p.atOuterJoinMarker() {
+			return bpPostfix, 0, "OUTER_JOIN", true
+		}
+		return 0, 0, "", false
 
 	// Postfix: :: cast
 	case tokDoubleColon:
@@ -473,8 +485,10 @@ func (p *Parser) parseIdentExpr() (ast.Node, error) {
 		return nil, err
 	}
 
-	// Check for function call: name(
-	if p.cur.Type == '(' {
+	// Check for function call: name( — but a following `(+)` is the
+	// Oracle-style outer-join marker, not a call, so leave it for the infix
+	// postfix loop to consume.
+	if p.cur.Type == '(' && !p.atOuterJoinMarker() {
 		objName := ast.ObjectName{Name: first, Loc: first.Loc}
 		return p.parseFuncCall(objName, first.Loc)
 	}
@@ -605,8 +619,10 @@ func (p *Parser) parseDottedIdentOrFunc(first ast.Ident) (ast.Node, error) {
 		}
 		parts = append(parts, ident)
 
-		// Check for function call: schema.func(
-		if p.cur.Type == '(' {
+		// Check for function call: schema.func( — but a following `(+)` is the
+		// Oracle-style outer-join marker on a qualified column ref (e.g.
+		// t2.c2(+)), not a call, so leave it for the infix postfix loop.
+		if p.cur.Type == '(' && !p.atOuterJoinMarker() {
 			var objName ast.ObjectName
 			switch len(parts) {
 			case 2:
@@ -716,6 +732,73 @@ func (p *Parser) parseFuncCall(name ast.ObjectName, startLoc ast.Loc) (*ast.Func
 	}
 
 	return fc, nil
+}
+
+// atOuterJoinMarker reports whether the parser is positioned exactly at a
+// legacy Oracle-style outer-join marker `(+)` — i.e. cur is '(', the next
+// token is '+', and the one after that is ')'. It performs a side-effect-free
+// three-token lookahead by snapshotting and restoring the token-stream state
+// (cur/prev/buffered-next plus the lexer byte position and error count), so it
+// can be called speculatively at any '(' to decide whether that paren opens a
+// function-call argument list or is the outer-join marker.
+//
+// Going through the lexer (rather than raw byte scanning) makes the check
+// robust to intervening whitespace and comments, e.g. `t2.c2 (+)` and
+// `t2.c2 /* */ ( + )` both match.
+func (p *Parser) atOuterJoinMarker() bool {
+	if p.cur.Type != '(' {
+		return false
+	}
+	// First lookahead token (immediately after '(') must be '+'.
+	if p.peekNext().Type != '+' {
+		return false
+	}
+
+	// Need one more token of lookahead (past '+'). Snapshot the full
+	// token-stream state, advance twice, inspect, then restore exactly.
+	savedCur := p.cur
+	savedPrev := p.prev
+	savedNextBuf := p.nextBuf
+	savedHasNext := p.hasNext
+	savedLexPos := p.lexer.pos
+	savedErrCount := len(p.lexer.errors)
+
+	p.advance() // consume '('  (cur is now '+')
+	p.advance() // consume '+'  (cur is the token after '+')
+	isMarker := p.cur.Type == ')'
+
+	// Restore.
+	p.cur = savedCur
+	p.prev = savedPrev
+	p.nextBuf = savedNextBuf
+	p.hasNext = savedHasNext
+	p.lexer.pos = savedLexPos
+	if len(p.lexer.errors) > savedErrCount {
+		p.lexer.errors = p.lexer.errors[:savedErrCount]
+	}
+
+	return isMarker
+}
+
+// parseOuterJoinPostfix consumes a `(+)` outer-join marker (cur is '(') and
+// wraps left in an *ast.OuterJoinExpr. The caller (the infix loop) only invokes
+// this when atOuterJoinMarker has already confirmed the `( + )` shape, so each
+// expect here is guaranteed to succeed and the function always makes progress.
+func (p *Parser) parseOuterJoinPostfix(left ast.Node) (ast.Node, error) {
+	if _, err := p.expect('('); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect('+'); err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return nil, err
+	}
+	return &ast.OuterJoinExpr{
+		Operand: left,
+		Loc:     ast.Loc{Start: ast.NodeLoc(left).Start, End: closeTok.Loc.End},
+	}, nil
 }
 
 // parseParenExpr parses a parenthesized expression or subquery.

--- a/snowflake/parser/expr_test.go
+++ b/snowflake/parser/expr_test.go
@@ -1311,6 +1311,146 @@ func TestExpr_CollateString(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// 25b. Oracle-style outer-join marker (+)
+// ---------------------------------------------------------------------------
+
+// mustOuterJoin parses input and asserts the result is an *ast.OuterJoinExpr.
+func mustOuterJoin(t *testing.T, input string) *ast.OuterJoinExpr {
+	t.Helper()
+	node, err := testParseExpr(input)
+	if err != nil {
+		t.Fatalf("parse %q: unexpected error: %v", input, err)
+	}
+	oj, ok := node.(*ast.OuterJoinExpr)
+	if !ok {
+		t.Fatalf("parse %q: got %T, want *ast.OuterJoinExpr", input, node)
+	}
+	return oj
+}
+
+func TestExpr_OuterJoinMarker_NoSpace(t *testing.T) {
+	oj := mustOuterJoin(t, "t2.c2(+)")
+	cr, ok := oj.Operand.(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("Operand = %T, want *ast.ColumnRef", oj.Operand)
+	}
+	if len(cr.Parts) != 2 || cr.Parts[0].Name != "t2" || cr.Parts[1].Name != "c2" {
+		t.Errorf("Operand parts = %+v, want [t2 c2]", cr.Parts)
+	}
+	// Loc spans the operand through the closing ')'.
+	if oj.Loc.Start != cr.Loc.Start {
+		t.Errorf("Loc.Start = %d, want operand start %d", oj.Loc.Start, cr.Loc.Start)
+	}
+	if oj.Loc.End <= cr.Loc.End {
+		t.Errorf("Loc.End = %d, want > operand end %d (must cover `(+)`)", oj.Loc.End, cr.Loc.End)
+	}
+}
+
+func TestExpr_OuterJoinMarker_WithSpace(t *testing.T) {
+	// A space before the marker is allowed: `t2.c2 (+)`.
+	oj := mustOuterJoin(t, "t2.c2 (+)")
+	if _, ok := oj.Operand.(*ast.ColumnRef); !ok {
+		t.Fatalf("Operand = %T, want *ast.ColumnRef", oj.Operand)
+	}
+}
+
+func TestExpr_OuterJoinMarker_SingleColumn(t *testing.T) {
+	// Unqualified column also accepts the marker.
+	oj := mustOuterJoin(t, "c(+)")
+	cr, ok := oj.Operand.(*ast.ColumnRef)
+	if !ok {
+		t.Fatalf("Operand = %T, want *ast.ColumnRef", oj.Operand)
+	}
+	if len(cr.Parts) != 1 || cr.Parts[0].Name != "c" {
+		t.Errorf("Operand parts = %+v, want [c]", cr.Parts)
+	}
+}
+
+func TestExpr_OuterJoinMarker_InComparison(t *testing.T) {
+	// `t1.c1 = t2.c2(+)` — the marker binds tightly to the right operand.
+	node, err := testParseExpr("t1.c1 = t2.c2(+)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("got %T, want *ast.BinaryExpr", node)
+	}
+	if bin.Op != ast.BinEq {
+		t.Errorf("Op = %v, want BinEq", bin.Op)
+	}
+	if _, ok := bin.Right.(*ast.OuterJoinExpr); !ok {
+		t.Errorf("Right = %T, want *ast.OuterJoinExpr", bin.Right)
+	}
+	if _, ok := bin.Left.(*ast.OuterJoinExpr); ok {
+		t.Errorf("Left wrongly wrapped in *ast.OuterJoinExpr")
+	}
+}
+
+func TestExpr_OuterJoinMarker_MultipleInWhere(t *testing.T) {
+	// Two markers in one WHERE (both spaced), via the full statement parser.
+	sql := "SELECT t1.c1, t2.c2 FROM t1, t2 WHERE t1.c1 = t2.c2 (+) AND t1.c3 = t2.c4 (+);"
+	f, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("parse %q: %v", sql, err)
+	}
+	if len(f.Stmts) != 1 {
+		t.Fatalf("len(Stmts) = %d, want 1", len(f.Stmts))
+	}
+	markers := 0
+	ast.Inspect(f, func(n ast.Node) bool {
+		if _, ok := n.(*ast.OuterJoinExpr); ok {
+			markers++
+		}
+		return true
+	})
+	if markers != 2 {
+		t.Errorf("OuterJoinExpr count = %d, want 2", markers)
+	}
+}
+
+// Regression: a genuine function call `count(*)` must stay a FuncCallExpr and
+// never be mistaken for the `(+)` marker.
+func TestExpr_OuterJoinMarker_CountStarUnchanged(t *testing.T) {
+	fc := mustFuncCall(t, "count(*)")
+	if !fc.Star {
+		t.Errorf("count(*) Star = false, want true")
+	}
+}
+
+// Regression: a plain call `f(a)` is unaffected by the marker lookahead.
+func TestExpr_OuterJoinMarker_PlainCallUnchanged(t *testing.T) {
+	fc := mustFuncCall(t, "f(a)")
+	if len(fc.Args) != 1 {
+		t.Errorf("f(a) Args = %d, want 1", len(fc.Args))
+	}
+}
+
+// Regression: `f(+1)` is a call whose single argument is a unary-plus literal,
+// NOT an outer-join marker (the token after '+' is an int, not ')').
+func TestExpr_OuterJoinMarker_UnaryPlusArgUnchanged(t *testing.T) {
+	fc := mustFuncCall(t, "f(+1)")
+	if len(fc.Args) != 1 {
+		t.Fatalf("f(+1) Args = %d, want 1", len(fc.Args))
+	}
+	if _, ok := fc.Args[0].(*ast.UnaryExpr); !ok {
+		t.Errorf("f(+1) arg0 = %T, want *ast.UnaryExpr", fc.Args[0])
+	}
+}
+
+// Regression: a parenthesized `(a+1)` expression is unchanged (it is not a
+// column ref followed by `(+)`).
+func TestExpr_OuterJoinMarker_ParenExprUnchanged(t *testing.T) {
+	node, err := testParseExpr("(a+1)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := node.(*ast.ParenExpr); !ok {
+		t.Errorf("(a+1) = %T, want *ast.ParenExpr", node)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // 26. Error cases
 // ---------------------------------------------------------------------------
 

--- a/snowflake/parser/merge.go
+++ b/snowflake/parser/merge.go
@@ -185,6 +185,12 @@ func (p *Parser) parseMergeWhen() (*ast.MergeWhen, error) {
 	switch p.cur.Type {
 	case kwUPDATE:
 		p.advance() // consume UPDATE
+		when.Action = ast.MergeActionUpdate
+		// `UPDATE ALL BY NAME` is an alternative to `UPDATE SET col = val, ...`.
+		if p.matchAllByName() {
+			when.AllByName = true
+			break
+		}
 		if _, err := p.expect(kwSET); err != nil {
 			return nil, err
 		}
@@ -192,7 +198,6 @@ func (p *Parser) parseMergeWhen() (*ast.MergeWhen, error) {
 		if err != nil {
 			return nil, err
 		}
-		when.Action = ast.MergeActionUpdate
 		when.Sets = sets
 
 	case kwDELETE:
@@ -202,6 +207,12 @@ func (p *Parser) parseMergeWhen() (*ast.MergeWhen, error) {
 	case kwINSERT:
 		p.advance() // consume INSERT
 		when.Action = ast.MergeActionInsert
+
+		// `INSERT ALL BY NAME` is an alternative to `INSERT (cols) VALUES (vals)`.
+		if p.matchAllByName() {
+			when.AllByName = true
+			break
+		}
 
 		// Optional column list
 		if p.cur.Type == '(' {
@@ -248,4 +259,42 @@ func (p *Parser) parseMergeWhen() (*ast.MergeWhen, error) {
 
 	when.Loc.End = p.prev.Loc.End
 	return when, nil
+}
+
+// matchAllByName consumes the `ALL BY NAME` token sequence that introduces the
+// MERGE column-list-by-name action forms (`UPDATE ALL BY NAME`,
+// `INSERT ALL BY NAME`) and reports whether it was present. It only advances
+// when the full three-token sequence matches, so a partial run is left intact
+// for the caller's normal SET / VALUES handling. ALL, BY, and NAME are all
+// non-reserved keywords (kwALL/kwBY/kwNAME).
+func (p *Parser) matchAllByName() bool {
+	if p.cur.Type != kwALL {
+		return false
+	}
+	if p.peekNext().Type != kwBY {
+		return false
+	}
+	// Confirm `NAME` follows `BY` before consuming anything. Snapshot the
+	// token-stream state, advance past ALL/BY, peek for NAME, and restore if
+	// the sequence is incomplete (no allocation, bounded by three tokens).
+	savedCur := p.cur
+	savedPrev := p.prev
+	savedNextBuf := p.nextBuf
+	savedHasNext := p.hasNext
+	savedLexPos := p.lexer.pos
+
+	p.advance() // consume ALL (cur is now BY)
+	p.advance() // consume BY  (cur is the token after BY)
+	if p.cur.Type == kwNAME {
+		p.advance() // consume NAME
+		return true
+	}
+
+	// Not `ALL BY NAME` — restore and report no match.
+	p.cur = savedCur
+	p.prev = savedPrev
+	p.nextBuf = savedNextBuf
+	p.hasNext = savedHasNext
+	p.lexer.pos = savedLexPos
+	return false
 }

--- a/snowflake/parser/merge_test.go
+++ b/snowflake/parser/merge_test.go
@@ -293,3 +293,98 @@ func TestMerge_NoAliases(t *testing.T) {
 		t.Fatalf("whens = %d, want 2", len(stmt.Whens))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// 10. MERGE ... UPDATE / INSERT ALL BY NAME
+// ---------------------------------------------------------------------------
+
+func TestMerge_UpdateAllByName(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO tgt USING src ON tgt.id = src.id
+		WHEN MATCHED THEN UPDATE ALL BY NAME
+	`)
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if !when.Matched {
+		t.Error("Matched should be true")
+	}
+	if when.Action != ast.MergeActionUpdate {
+		t.Errorf("action = %v, want MergeActionUpdate", when.Action)
+	}
+	if !when.AllByName {
+		t.Error("AllByName should be true for UPDATE ALL BY NAME")
+	}
+	if len(when.Sets) != 0 {
+		t.Errorf("Sets = %d, want 0 for ALL BY NAME", len(when.Sets))
+	}
+}
+
+func TestMerge_InsertAllByName(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO tgt USING src ON tgt.id = src.id
+		WHEN NOT MATCHED THEN INSERT ALL BY NAME
+	`)
+	if len(stmt.Whens) != 1 {
+		t.Fatalf("whens = %d, want 1", len(stmt.Whens))
+	}
+	when := stmt.Whens[0]
+	if when.Matched {
+		t.Error("Matched should be false")
+	}
+	if when.Action != ast.MergeActionInsert {
+		t.Errorf("action = %v, want MergeActionInsert", when.Action)
+	}
+	if !when.AllByName {
+		t.Error("AllByName should be true for INSERT ALL BY NAME")
+	}
+	if len(when.InsertCols) != 0 || len(when.InsertVals) != 0 {
+		t.Errorf("InsertCols/InsertVals = %d/%d, want 0/0 for ALL BY NAME",
+			len(when.InsertCols), len(when.InsertVals))
+	}
+}
+
+func TestMerge_BothAllByName(t *testing.T) {
+	// Both WHEN actions use the by-name form (mirrors official/merge/example_09).
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO tgt USING src ON tgt.id = src.id
+		WHEN MATCHED THEN UPDATE ALL BY NAME
+		WHEN NOT MATCHED THEN INSERT ALL BY NAME
+	`)
+	if len(stmt.Whens) != 2 {
+		t.Fatalf("whens = %d, want 2", len(stmt.Whens))
+	}
+	if !stmt.Whens[0].AllByName || !stmt.Whens[1].AllByName {
+		t.Errorf("both whens should be AllByName, got %v / %v",
+			stmt.Whens[0].AllByName, stmt.Whens[1].AllByName)
+	}
+}
+
+// Regression: standard `UPDATE SET` / `INSERT (cols) VALUES (...)` keep
+// AllByName=false and populate their explicit lists.
+func TestMerge_StandardFormsNotAllByName(t *testing.T) {
+	stmt := testParseMergeStmt(t, `
+		MERGE INTO tgt USING src ON tgt.id = src.id
+		WHEN MATCHED THEN UPDATE SET tgt.a = src.a
+		WHEN NOT MATCHED THEN INSERT (a, b) VALUES (src.a, src.b)
+	`)
+	if len(stmt.Whens) != 2 {
+		t.Fatalf("whens = %d, want 2", len(stmt.Whens))
+	}
+	upd := stmt.Whens[0]
+	if upd.AllByName {
+		t.Error("UPDATE SET should not set AllByName")
+	}
+	if len(upd.Sets) != 1 {
+		t.Errorf("Sets = %d, want 1", len(upd.Sets))
+	}
+	ins := stmt.Whens[1]
+	if ins.AllByName {
+		t.Error("INSERT VALUES should not set AllByName")
+	}
+	if len(ins.InsertCols) != 2 || len(ins.InsertVals) != 2 {
+		t.Errorf("InsertCols/InsertVals = %d/%d, want 2/2",
+			len(ins.InsertCols), len(ins.InsertVals))
+	}
+}


### PR DESCRIPTION
## Node
`snowflake/gap-expr-misc` (phase-2 corpus-gap closure, narrowed) — two independent residuals: **`(+)` Oracle-style outer-join operator** (real regression vs legacy `.g4`) and **MERGE `… ALL BY NAME`**.

## Forms + design
- **`(+)` outer-join**: `WHERE t1.c1 = t2.c2(+)` / `… = t2.c2 (+)` (both spacings). New `ast.OuterJoinExpr{Operand, Loc}`; a side-effect-free 3-token lookahead (`atOuterJoinMarker`, snapshot/restore of cur/prev/nextBuf/lexer.pos/errors) drives a `bpPostfix` infix case. **Both func-call detection sites** (`parseIdentExpr`, `parseDottedIdentOrFunc`) now guard `cur=='(' && !atOuterJoinMarker()`, so `name(+)`/`qual.col(+)` become a column-ref-with-marker, never a call.
- **MERGE `ALL BY NAME`**: `MergeWhen.AllByName bool`; `WHEN MATCHED THEN UPDATE ALL BY NAME` / `WHEN NOT MATCHED THEN INSERT ALL BY NAME` as alternatives to `UPDATE SET …` / `INSERT (cols) VALUES …` (consumed only on a full `ALL BY NAME` match, else restored). Existing forms untouched.

## Corpus delta (TestCorpusClosure) — 3 files closed, 11 → 8 skipped, 644 → 647 clean
`where/example_09`, `where/example_10`, `merge/example_09`.

## Review (`/code-review` high; Codex down) — no findings
Regression-tested: `count(*)` / `f(a)` / `s.f(a)` stay calls; `f(+1)` stays a call with a unary-plus arg; `(a+1)` stays a ParenExpr; bare `(+)` errors; standard MERGE `UPDATE SET`/`INSERT VALUES` keep `AllByName=false`. `query_span` lineage preserved (`ast.Inspect` recurses into `OuterJoinExpr.Operand`). Orchestrator independently verified on a fresh checkout of `512b1d9b`: build/vet/gofmt clean (gopls `undefined` errors were spurious worktree-isolation artifacts), full `go test ./snowflake/... -timeout 120s` green (7 pkgs), corpus self-prune green.

## Out-of-scope write (flagged, justified)
`ast/loc.go` — `OuterJoinExpr` case in the `NodeLoc` type-switch (else `NodeLoc(outerJoinExpr)` returns `NoLoc()` — needed for correct Loc/round-trips).

## Process note
This node was originally scoped to 4 features; the first worker was killed mid-implementation (over-broad), so it was reaped and split — this PR is `(+)` + MERGE; CTE-view-body + dynamic-table INTERVAL follow in `gap-view-dyntable`.

## Note
Opened by orchestrator from verified commit `512b1d9b`. Phase-2 gap 9/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
