### PR TITLE
feat(snowflake): parenthesized CTE view body + dynamic-table IMMUTABLE WHERE/INTERVAL (phase-2 gap-view-dyntable) — close corpus gaps 176,184

### DIFF
--- a/snowflake/ast/nodetags.go
+++ b/snowflake/ast/nodetags.go
@@ -36,6 +36,7 @@ const (
 	T_CaseExpr
 	T_FuncCallExpr
 	T_IffExpr
+	T_IntervalExpr
 	T_CollateExpr
 	T_OuterJoinExpr
 	T_IsExpr
@@ -278,6 +279,8 @@ func (t NodeTag) String() string {
 		return "FuncCallExpr"
 	case T_IffExpr:
 		return "IffExpr"
+	case T_IntervalExpr:
+		return "IntervalExpr"
 	case T_CollateExpr:
 		return "CollateExpr"
 	case T_OuterJoinExpr:

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -558,6 +558,19 @@ type IffExpr struct {
 
 func (n *IffExpr) Tag() NodeTag { return T_IffExpr }
 
+// IntervalExpr represents an interval literal: INTERVAL <value>, where <value>
+// is normally a string literal describing the span (e.g. INTERVAL '1 day',
+// INTERVAL '2 hours, 30 minutes'). Mirroring the legacy grammar's typed-string
+// form ((TIMESTAMP | DATE | TIME | INTERVAL) expr), the value is kept as a
+// general expression node rather than decomposed into quantity/unit pairs, so
+// every documented spelling is accepted without enumerating the date-time parts.
+type IntervalExpr struct {
+	Value Node // the interval value expression (typically a string literal)
+	Loc   Loc
+}
+
+func (n *IntervalExpr) Tag() NodeTag { return T_IntervalExpr }
+
 // CollateExpr represents expr COLLATE collation_name.
 type CollateExpr struct {
 	Expr      Node

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -509,6 +509,8 @@ func walkChildren(v Visitor, node Node) {
 		}
 		walkNodeRows(v, n.Values)
 		Walk(v, n.Select)
+	case *IntervalExpr:
+		Walk(v, n.Value)
 	case *IsExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.DistinctFrom)

--- a/snowflake/deparse/deparse.go
+++ b/snowflake/deparse/deparse.go
@@ -136,6 +136,7 @@ func (w *writer) writeNode(node ast.Node) error {
 		*ast.CaseExpr,
 		*ast.FuncCallExpr,
 		*ast.IffExpr,
+		*ast.IntervalExpr,
 		*ast.CollateExpr,
 		*ast.IsExpr,
 		*ast.BetweenExpr,

--- a/snowflake/deparse/deparse_expr.go
+++ b/snowflake/deparse/deparse_expr.go
@@ -36,6 +36,8 @@ func (w *writer) writeExpr(node ast.Node) error {
 		return w.writeFuncCallExpr(n)
 	case *ast.IffExpr:
 		return w.writeIffExpr(n)
+	case *ast.IntervalExpr:
+		return w.writeIntervalExpr(n)
 	case *ast.CollateExpr:
 		return w.writeCollateExpr(n)
 	case *ast.OuterJoinExpr:
@@ -456,6 +458,14 @@ func (w *writer) writeIffExpr(n *ast.IffExpr) error {
 	}
 	w.buf.WriteByte(')')
 	return nil
+}
+
+// writeIntervalExpr renders an interval literal as `INTERVAL <value>` (e.g.
+// INTERVAL '1 day'). The value writer supplies its own leading space.
+func (w *writer) writeIntervalExpr(n *ast.IntervalExpr) error {
+	w.ensureSpace()
+	w.buf.WriteString("INTERVAL")
+	return w.writeExpr(n.Value)
 }
 
 func (w *writer) writeCollateExpr(n *ast.CollateExpr) error {

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -317,6 +317,18 @@ func TestDeparse_Expr_Iff(t *testing.T) {
 	assertRoundTrip(t, `SELECT IFF(a > 0, 'positive', 'non-positive') FROM t`)
 }
 
+func TestDeparse_Expr_Interval(t *testing.T) {
+	assertRoundTrip(t, `SELECT INTERVAL '1 day'`)
+}
+
+func TestDeparse_Expr_IntervalArithmetic(t *testing.T) {
+	assertRoundTrip(t, `SELECT ts + INTERVAL '7 days' FROM t`)
+}
+
+func TestDeparse_Expr_IntervalInPredicate(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM t WHERE ts < CURRENT_TIMESTAMP() - INTERVAL '1 day'`)
+}
+
 func TestDeparse_Expr_IsNull(t *testing.T) {
 	assertRoundTrip(t, `SELECT * FROM t WHERE a IS NULL`)
 }
@@ -854,6 +866,17 @@ func TestDeparse_CreateView_Secure(t *testing.T) {
 
 func TestDeparse_CreateView_WithColumns(t *testing.T) {
 	assertRoundTrip(t, `CREATE VIEW v (a, b) AS SELECT x, y FROM t`)
+}
+
+// A parenthesized view body whose query begins with WITH (a CTE) deparses to
+// the canonical unparenthesized form (the surrounding parens are not modeled);
+// both forms parse to the same AST, so the round-trip holds.
+func TestDeparse_CreateView_ParenCTEBody(t *testing.T) {
+	assertRoundTrip(t, `CREATE VIEW v AS ( WITH x AS ( SELECT 1 ) SELECT * FROM x )`)
+}
+
+func TestDeparse_CreateView_ParenRecursiveCTEBody(t *testing.T) {
+	assertRoundTrip(t, `CREATE VIEW v (a, b) AS ( WITH RECURSIVE cte (a, b) AS ( SELECT 1, 2 FROM t WHERE a = 1 UNION ALL SELECT a, b FROM t INNER JOIN cte WHERE cte.a = t.b ) SELECT * FROM cte )`)
 }
 
 func TestDeparse_AlterView_Rename(t *testing.T) {

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -164,13 +164,6 @@ var corpusWholeFile = map[string]string{
 //
 // Grouped by root cause. Counts in comments are at authoring time.
 var corpusSkips = map[string]string{
-	// --- RESIDUAL GAP: dynamic-table IMMUTABLE WHERE + INTERVAL literal ---
-	// example_04 (CLONE ... AT (TIMESTAMP => TO_TIMESTAMP_TZ(...))) is now closed
-	// by gap-named-args (named function arguments + general clone time-travel
-	// value). example_07 remains: IMMUTABLE WHERE (... - INTERVAL '1 day') needs
-	// the INTERVAL literal / refresh-mode clause owned by gap-expr-misc.
-	"official/create-dynamic-table/example_07.sql": "RESIDUAL GAP: IMMUTABLE WHERE (... - INTERVAL '1 day') refresh-mode + interval literal not parsed",
-
 	// --- DEPENDENCY GAP: $N:path semi-structured ref + stage path as a table ref (T5) ---
 	// (Bare $N as a table ref and the SHOW ... ->> ... FROM $1 result-pipe now
 	// parse via gap-from-values; these two remain because they additionally need
@@ -182,9 +175,6 @@ var corpusSkips = map[string]string{
 	"official/execute-immediate/example_01.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
 	"official/execute-immediate/example_04.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
 	"official/call/example_07.sql":              "RESIDUAL GAP: DECLARE ... BEGIN CALL p(...) INTO :var ... END scripting block not parsed",
-
-	// --- RESIDUAL GAP: parenthesized view body with leading WITH (CTE) ---
-	"official/create-view/example_05.sql": "RESIDUAL GAP: CREATE VIEW ... AS ( WITH ... SELECT ... ) — parenthesized CTE view body not parsed",
 
 	// --- RESIDUAL GAP / MALFORMED: legacy select.sql expression corpus ---
 	// LEFT(...)/ILIKE(...) used as function names, lowercase `union` inside a

--- a/snowflake/parser/dynamic_external_table_test.go
+++ b/snowflake/parser/dynamic_external_table_test.go
@@ -196,6 +196,29 @@ func TestParseCreateDynamicTable(t *testing.T) {
 		}
 	})
 
+	// The official create-dynamic-table example_07 shape: an IMMUTABLE WHERE
+	// predicate whose expression contains an INTERVAL literal.
+	t.Run("immutable where with interval", func(t *testing.T) {
+		stmt := mustCreateDynamicTable(t, "CREATE DYNAMIC TABLE my_dynamic_table TARGET_LAG = '1 hour' WAREHOUSE = my_warehouse IMMUTABLE WHERE (ts < CURRENT_TIMESTAMP() - INTERVAL '1 day') AS SELECT * FROM source_table")
+		if stmt.ImmutableKind != "IMMUTABLE" {
+			t.Errorf("ImmutableKind = %q, want IMMUTABLE", stmt.ImmutableKind)
+		}
+		if stmt.ImmutableWhere == nil {
+			t.Fatal("ImmutableWhere nil")
+		}
+		// The predicate must contain an INTERVAL literal node.
+		sawInterval := false
+		ast.Inspect(stmt.ImmutableWhere, func(n ast.Node) bool {
+			if _, ok := n.(*ast.IntervalExpr); ok {
+				sawInterval = true
+			}
+			return true
+		})
+		if !sawInterval {
+			t.Error("expected an *ast.IntervalExpr inside the IMMUTABLE WHERE predicate")
+		}
+	})
+
 	t.Run("refresh using dml body", func(t *testing.T) {
 		stmt := mustCreateDynamicTable(t, "CREATE DYNAMIC TABLE dt TARGET_LAG = '1 hour' WAREHOUSE = w REFRESH USING (INSERT INTO dt SELECT * FROM s)")
 		if stmt.AsQuery != nil {
@@ -797,10 +820,6 @@ func TestTableVariants_WalkerVisitsChildren(t *testing.T) {
 //   - CREATE OR ALTER (preview): the OR-prefix parser recognizes only OR
 //     REPLACE, not OR ALTER (owned by parser-or-alter / create_table.go,
 //     out of this node's writes-scope). create-dynamic-table examples 08-11.
-//   - INTERVAL '<n> <unit>' nested inside a parenthesized group fails in the
-//     shared expression parser (`SELECT (CURRENT_TIMESTAMP() - INTERVAL '1
-//     day')` fails identically). create-dynamic-table example_07's IMMUTABLE
-//     WHERE predicate uses it.
 //   - example_12 is malformed in the docs themselves (the AS query
 //     `SELECT COUNT(DISTINCT order_id) DATE_TRUNC(...)` is missing the comma
 //     between two select items); it is skipped as a known-bad doc example.
@@ -879,9 +898,6 @@ func sharedLayerGap(t *testing.T, text, upper string, seg Segment) bool {
 	case orAlterLimited(upper):
 		expectStillFails(t, text, seg, "OR ALTER")
 		return true
-	case intervalInParensLimited(text):
-		expectStillFails(t, text, seg, "INTERVAL-in-parens")
-		return true
 	case malformedDocExample(upper):
 		// example_12: missing comma in the AS query is a doc bug, not a parser bug.
 		return true
@@ -896,13 +912,6 @@ func expectStillFails(t *testing.T, text string, seg Segment, gap string) {
 	if _, errs := parseSingle(seg.Text, seg.ByteStart); len(errs) == 0 {
 		t.Logf("note: %s statement now parses, drop it from the filter: %q", gap, text)
 	}
-}
-
-// intervalInParensLimited reports whether sql contains an INTERVAL literal that
-// sits inside a parenthesized group, which the shared expression parser does not
-// yet handle. Heuristic: the text contains both '(' and the word INTERVAL.
-func intervalInParensLimited(sql string) bool {
-	return strings.Contains(strings.ToUpper(sql), "INTERVAL") && strings.Contains(sql, "(")
 }
 
 // malformedDocExample reports whether the statement is a known-malformed docs

--- a/snowflake/parser/expr.go
+++ b/snowflake/parser/expr.go
@@ -449,6 +449,14 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		return &ast.FuncCallExpr{Name: name, Loc: tok.Loc}, nil
 
 	default:
+		// INTERVAL '<value>' literal (e.g. INTERVAL '1 day'). INTERVAL is a
+		// non-reserved keyword, so it is only treated as an interval literal when
+		// immediately followed by a string literal; otherwise it falls through to
+		// identifier handling so a column literally named "interval" still parses.
+		if p.cur.Type == kwINTERVAL && p.peekNext().Type == tokString {
+			return p.parseIntervalExpr()
+		}
+
 		// Lambda detection: single ident followed by ->
 		if p.isIdentToken() && p.peekNext().Type == tokArrow {
 			return p.parseLambdaExpr()
@@ -461,6 +469,23 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 
 		return nil, p.syntaxErrorAtCur()
 	}
+}
+
+// parseIntervalExpr parses an INTERVAL '<value>' literal. On entry cur is the
+// INTERVAL keyword and the following token is a string literal (the caller has
+// confirmed both). The value is parsed as a primary expression (a string
+// literal) and stored verbatim, mirroring the legacy grammar's typed-string
+// form; the date-time components inside the string are not decomposed.
+func (p *Parser) parseIntervalExpr() (ast.Node, error) {
+	kwTok := p.advance() // consume INTERVAL
+	value, err := p.parsePrimaryExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.IntervalExpr{
+		Value: value,
+		Loc:   ast.Loc{Start: kwTok.Loc.Start, End: ast.NodeLoc(value).End},
+	}, nil
 }
 
 // isIdentToken reports whether the current token is usable as an identifier

--- a/snowflake/parser/expr_test.go
+++ b/snowflake/parser/expr_test.go
@@ -72,6 +72,77 @@ func TestExpr_StringLiteral(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// 1b. INTERVAL literals
+// ---------------------------------------------------------------------------
+
+func TestExpr_IntervalLiteral(t *testing.T) {
+	node, err := testParseExpr("INTERVAL '1 day'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	iv, ok := node.(*ast.IntervalExpr)
+	if !ok {
+		t.Fatalf("expected *ast.IntervalExpr, got %T", node)
+	}
+	lit, ok := iv.Value.(*ast.Literal)
+	if !ok {
+		t.Fatalf("Value = %T, want *ast.Literal", iv.Value)
+	}
+	if lit.Kind != ast.LitString || lit.Value != "1 day" {
+		t.Errorf("Value literal = (%v, %q), want (LitString, %q)", lit.Kind, lit.Value, "1 day")
+	}
+	// Loc spans from the INTERVAL keyword (offset 0) through the string literal.
+	if iv.Loc.Start != 0 {
+		t.Errorf("Loc.Start = %d, want 0", iv.Loc.Start)
+	}
+	if iv.Loc.End != lit.Loc.End {
+		t.Errorf("Loc.End = %d, want %d (the value's end)", iv.Loc.End, lit.Loc.End)
+	}
+}
+
+// An INTERVAL literal as the right operand of arithmetic: the binary expression
+// must carry an *ast.IntervalExpr on its right.
+func TestExpr_IntervalInArithmetic(t *testing.T) {
+	node, err := testParseExpr("ts - INTERVAL '1 day'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bin, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryExpr, got %T", node)
+	}
+	if _, ok := bin.Right.(*ast.IntervalExpr); !ok {
+		t.Errorf("Right = %T, want *ast.IntervalExpr", bin.Right)
+	}
+}
+
+// Regression: INTERVAL is a non-reserved keyword and must remain usable as a
+// bare column name when it is NOT followed by a string literal.
+func TestExpr_IntervalAsColumn(t *testing.T) {
+	for _, in := range []string{"interval", "interval + 1", "interval = 5"} {
+		t.Run(in, func(t *testing.T) {
+			node, err := testParseExpr(in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// The leading `interval` must resolve to a column ref, never an
+			// interval literal.
+			var first ast.Node = node
+			if bin, ok := node.(*ast.BinaryExpr); ok {
+				first = bin.Left
+			}
+			cr, ok := first.(*ast.ColumnRef)
+			if !ok {
+				t.Fatalf("expected leading *ast.ColumnRef, got %T", first)
+			}
+			if cr.Parts[0].Normalize() != "INTERVAL" {
+				t.Errorf("column name = %q, want INTERVAL", cr.Parts[0].Normalize())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // 2. Column refs
 // ---------------------------------------------------------------------------
 

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -23,23 +23,44 @@ import (
 func (p *Parser) parseQueryExpr() (ast.Node, error) {
 	var left ast.Node
 	var err error
-	if p.cur.Type == '(' {
-		// Parenthesized SELECT: consume '(', parse inner query, then ')'
+	switch {
+	case p.cur.Type == '(':
+		// Parenthesized query body: consume '(', parse inner query, then ')'.
+		// The inner query may itself begin with WITH (a CTE / RECURSIVE), e.g.
+		// CREATE VIEW v AS ( WITH cte AS (...) SELECT ... ), so dispatch on WITH
+		// rather than always recursing into the bare-SELECT path.
 		p.advance() // consume '('
-		left, err = p.parseQueryExpr()
+		left, err = p.parseQueryBody()
 		if err != nil {
 			return nil, err
 		}
 		if _, err = p.expect(')'); err != nil {
 			return nil, err
 		}
-	} else {
+	case p.cur.Type == kwWITH:
+		left, err = p.parseWithQueryExpr()
+		if err != nil {
+			return nil, err
+		}
+	default:
 		left, err = p.parseSelectStmt()
 		if err != nil {
 			return nil, err
 		}
 	}
 	return p.parseSetOpChain(left)
+}
+
+// parseQueryBody parses a query expression that may begin with WITH (a CTE /
+// RECURSIVE block) or be a plain SELECT / set-operation / parenthesized query.
+// It is the shared dispatch used wherever a query can appear after a '(' — the
+// parenthesized operand of a set-op chain, a CTE body, and a parenthesized view
+// body — so a leading WITH is never mistaken for a bare SELECT.
+func (p *Parser) parseQueryBody() (ast.Node, error) {
+	if p.cur.Type == kwWITH {
+		return p.parseWithQueryExpr()
+	}
+	return p.parseQueryExpr()
 }
 
 // parseWithQueryExpr parses WITH ... SELECT ... [set operators].

--- a/snowflake/parser/view_test.go
+++ b/snowflake/parser/view_test.go
@@ -261,6 +261,111 @@ func TestCreateView_WithCTE(t *testing.T) {
 	}
 }
 
+// A parenthesized view body whose query begins with WITH: CREATE VIEW v AS (
+// WITH x AS (...) SELECT ... ). The surrounding parens around the query are
+// optional in Snowflake; the inner query is a CTE / RECURSIVE block.
+func TestCreateView_ParenCTEBody(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v AS ( WITH x AS ( SELECT 1 ) SELECT * FROM x )")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	sel, ok := stmt.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Query = %T, want *ast.SelectStmt", stmt.Query)
+	}
+	if len(sel.With) != 1 {
+		t.Fatalf("CTE count = %d, want 1", len(sel.With))
+	}
+	if sel.With[0].Name.Normalize() != "X" {
+		t.Errorf("CTE name = %q, want X", sel.With[0].Name.Normalize())
+	}
+	// The view statement Loc must span to the final ')'.
+	if stmt.Loc.End == 0 {
+		t.Error("stmt.Loc.End not set")
+	}
+}
+
+// The official create-view example_05 shape: a parenthesized RECURSIVE CTE view
+// body with a UNION ALL recursive member and quoted/spaced column names.
+func TestCreateView_ParenRecursiveCTEBody(t *testing.T) {
+	sql := `CREATE VIEW employee_hierarchy (title, employee_ID, manager_ID, "MGR_EMP_ID (SHOULD BE SAME)", "MGR TITLE") AS (
+   WITH RECURSIVE employee_hierarchy_cte (title, employee_ID, manager_ID, "MGR_EMP_ID (SHOULD BE SAME)", "MGR TITLE") AS (
+      SELECT title, employee_ID, manager_ID, NULL AS "MGR_EMP_ID (SHOULD BE SAME)", 'President' AS "MGR TITLE"
+        FROM employees
+        WHERE title = 'President'
+      UNION ALL
+      SELECT employees.title, employees.employee_ID, employees.manager_ID,
+             employee_hierarchy_cte.employee_id AS "MGR_EMP_ID (SHOULD BE SAME)",
+             employee_hierarchy_cte.title AS "MGR TITLE"
+        FROM employees INNER JOIN employee_hierarchy_cte
+       WHERE employee_hierarchy_cte.employee_ID = employees.manager_ID
+   )
+   SELECT * FROM employee_hierarchy_cte
+)`
+	stmt, errs := testParseCreateView(sql)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(stmt.Columns) != 5 {
+		t.Errorf("view column count = %d, want 5", len(stmt.Columns))
+	}
+	sel, ok := stmt.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Query = %T, want *ast.SelectStmt", stmt.Query)
+	}
+	if len(sel.With) != 1 {
+		t.Fatalf("CTE count = %d, want 1", len(sel.With))
+	}
+	if !sel.With[0].Recursive {
+		t.Error("expected the CTE to carry the RECURSIVE flag")
+	}
+	if len(sel.With[0].Columns) != 5 {
+		t.Errorf("CTE column count = %d, want 5", len(sel.With[0].Columns))
+	}
+}
+
+// A parenthesized view body wrapping a plain SELECT (no WITH) must still parse —
+// guards the paren branch from regressing for the non-CTE case.
+func TestCreateView_ParenSelectBody(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v AS ( SELECT 1 )")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if _, ok := stmt.Query.(*ast.SelectStmt); !ok {
+		t.Fatalf("Query = %T, want *ast.SelectStmt", stmt.Query)
+	}
+}
+
+// Regression: a plain (unparenthesized) view body is unchanged.
+func TestCreateView_PlainBodyUnchanged(t *testing.T) {
+	stmt, errs := testParseCreateView("CREATE VIEW v AS SELECT a, b FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	sel, ok := stmt.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Query = %T, want *ast.SelectStmt", stmt.Query)
+	}
+	if len(sel.With) != 0 {
+		t.Errorf("plain body should have no CTEs, got %d", len(sel.With))
+	}
+}
+
+// A parenthesized CTE body is accepted for MATERIALIZED VIEW too.
+func TestCreateMaterializedView_ParenCTEBody(t *testing.T) {
+	stmt, errs := testParseCreateMaterializedView("CREATE MATERIALIZED VIEW mv AS ( WITH x AS (SELECT 1) SELECT * FROM x )")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	sel, ok := stmt.Query.(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Query = %T, want *ast.SelectStmt", stmt.Query)
+	}
+	if len(sel.With) != 1 {
+		t.Fatalf("CTE count = %d, want 1", len(sel.With))
+	}
+}
+
 func TestCreateView_AllModifiers(t *testing.T) {
 	sql := `CREATE OR REPLACE SECURE VIEW v
 		COMMENT = 'test'


### PR DESCRIPTION
## Node
`snowflake/gap-view-dyntable` (phase-2 corpus-gap closure) — **parenthesized CTE view body** and **dynamic-table `IMMUTABLE WHERE … INTERVAL`**.

## What closed (2 corpus files)
- **`create-view/example_05`** — `CREATE VIEW v (cols) AS ( WITH RECURSIVE cte (…) AS (…) SELECT … )`. Fixed minimally by making `parseQueryExpr` (`select.go`) accept a leading `WITH` (CTE/RECURSIVE), so the parenthesized view body reuses the existing query+CTE parser. **Purely additive** — it accepts `WITH` where it was previously rejected; cannot regress any valid input (verified: full suite + top-level-WITH / set-op-operand probes green).
- **`create-dynamic-table/example_07`** — `… IMMUTABLE WHERE (ts < CURRENT_TIMESTAMP() - INTERVAL '1 day') AS SELECT …`. The `IMMUTABLE WHERE` clause already parsed; the only blocker was the **`INTERVAL '1 day'` literal**, added as an expression in `expr.go`.

## Corpus delta (TestCorpusClosure) — 2 files closed, 8 → 6 skipped, 647 → 649 clean.

## Review + salvage note
The worker finished the implementation and all tests (build/suite/corpus green) but was **killed while doing extra belt-and-suspenders regression analysis** of the `parseQueryExpr`/`WITH` change (it had not yet committed). Orchestrator independently re-verified on the worktree, fresh/uncached: full `go test ./snowflake/... -count=1 -timeout 120s` green (7 pkgs), corpus self-prune green (both target files PASS), and the worker's specific worry confirmed safe — the change is additive, top-level `WITH` and `SELECT … UNION ALL …` still parse, no caller regressed. Then committed + pushed (`045f90e8`). `INTERVAL` literal + CTE-view-body have new unit tests; deparse round-trips included.

## Note
Opened by orchestrator from verified commit `045f90e8`. Phase-2 gap 10/11 (second half of the reaped 4-feature node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
