### PR TITLE
fix(mysql): align catalog DDL validation

### DIFF
--- a/mysql/catalog/altercmds.go
+++ b/mysql/catalog/altercmds.go
@@ -146,6 +146,9 @@ func (c *Catalog) addSingleColumn(tbl *Table, colDef *nodes.ColumnDef, first boo
 	}
 
 	col := buildColumnFromDef(tbl, colDef)
+	if col.AutoIncrement && tableHasOtherAutoIncrementColumn(tbl, "") {
+		return errIncorrectAutoIncrementDefinition()
+	}
 	if err := insertColumn(tbl, col, first, after); err != nil {
 		return err
 	}
@@ -355,6 +358,9 @@ func (c *Catalog) alterReplaceColumn(tbl *Table, oldName string, cmd *nodes.Alte
 	}
 
 	col := buildColumnFromDef(tbl, colDef)
+	if col.AutoIncrement && tableHasOtherAutoIncrementColumn(tbl, oldName) {
+		return errIncorrectAutoIncrementDefinition()
+	}
 	col.Position = idx + 1
 	tbl.Columns[idx] = col
 
@@ -808,6 +814,9 @@ func (c *Catalog) alterColumnDefault(tbl *Table, cmd *nodes.AlterTableCmd) error
 
 	col := tbl.Columns[idx]
 	if cmd.DefaultExpr != nil {
+		if err := validateDefaultExprForExistingColumn(col, cmd.DefaultExpr); err != nil {
+			return err
+		}
 		setColumnDefaultFromExpr(col, cmd.DefaultExpr)
 	} else {
 		// DROP DEFAULT — MySQL shows no default at all (not even DEFAULT NULL).
@@ -968,6 +977,45 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 	}
 
 	return col
+}
+
+func tableHasOtherAutoIncrementColumn(tbl *Table, exceptName string) bool {
+	exceptKey := toLower(exceptName)
+	for _, col := range tbl.Columns {
+		if col.AutoIncrement && (exceptKey == "" || toLower(col.Name) != exceptKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateDefaultExprForExistingColumn(col *Column, expr nodes.ExprNode) error {
+	if isNullDefault(expr) && !col.Nullable {
+		return errInvalidDefault(col.Name)
+	}
+	if isLiteralDefaultForbiddenType(col.DataType) && isLiteralDefault(expr) {
+		return &Error{Code: 1101, SQLState: "42000", Message: fmtCantHaveDefault(col.Name)}
+	}
+	return validateTemporalExprForColumn(col.Name, col.DataType, columnTemporalFSP(col), expr, true)
+}
+
+func columnTemporalFSP(col *Column) int {
+	if col == nil || (col.DataType != "datetime" && col.DataType != "timestamp" && col.DataType != "time") {
+		return 0
+	}
+	open := strings.IndexByte(col.ColumnType, '(')
+	close := strings.IndexByte(col.ColumnType, ')')
+	if open < 0 || close <= open+1 {
+		return 0
+	}
+	n := 0
+	for _, ch := range col.ColumnType[open+1 : close] {
+		if ch < '0' || ch > '9' {
+			return 0
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n
 }
 
 // updateColumnRefsInIndexes updates index and constraint column references

--- a/mysql/catalog/errors.go
+++ b/mysql/catalog/errors.go
@@ -22,6 +22,7 @@ const (
 	ErrDupEntry                          = 1062
 	ErrMultiplePriKey                    = 1068
 	ErrInvalidDefault                    = 1067
+	ErrIncorrectTableDefinition          = 1075
 	ErrNoSuchTable                       = 1146
 	ErrNoSuchColumn                      = 1054
 	ErrNoDatabaseSelected                = 1046
@@ -46,6 +47,7 @@ const (
 	ErrDependentByGenCol                 = 3108
 	ErrWrongArguments                    = 1210
 	ErrWrongNameForIndex                 = 1280
+	ErrInvalidOnUpdate                   = 1294
 	ErrTooBigPrecision                   = 1426
 	ErrInvalidYearColumnLength           = 1818
 	ErrFKDupName                         = 1826
@@ -63,6 +65,7 @@ var sqlStateMap = map[int]string{
 	ErrDupEntry:                          "23000",
 	ErrMultiplePriKey:                    "42000",
 	ErrInvalidDefault:                    "42000",
+	ErrIncorrectTableDefinition:          "42000",
 	ErrNoSuchTable:                       "42S02",
 	ErrNoSuchColumn:                      "42S22",
 	ErrNoDatabaseSelected:                "3D000",
@@ -83,6 +86,7 @@ var sqlStateMap = map[int]string{
 	ErrDependentByGenCol:                 "HY000",
 	ErrWrongArguments:                    "HY000",
 	ErrWrongNameForIndex:                 "42000",
+	ErrInvalidOnUpdate:                   "HY000",
 	ErrTooBigPrecision:                   "42000",
 	ErrInvalidYearColumnLength:           "HY000",
 	ErrFKDupName:                         "HY000",
@@ -145,6 +149,16 @@ func errMultiplePriKey() error {
 func errInvalidDefault(name string) error {
 	return &Error{Code: ErrInvalidDefault, SQLState: sqlState(ErrInvalidDefault),
 		Message: fmt.Sprintf("Invalid default value for '%s'", name)}
+}
+
+func errIncorrectAutoIncrementDefinition() error {
+	return &Error{Code: ErrIncorrectTableDefinition, SQLState: sqlState(ErrIncorrectTableDefinition),
+		Message: "Incorrect table definition; there can be only one auto column and it must be defined as a key"}
+}
+
+func errInvalidOnUpdate(name string) error {
+	return &Error{Code: ErrInvalidOnUpdate, SQLState: sqlState(ErrInvalidOnUpdate),
+		Message: fmt.Sprintf("Invalid ON UPDATE clause for '%s' column", name)}
 }
 
 func errTooBigPrecision(precision int, typ string) error {

--- a/mysql/catalog/indexcmds.go
+++ b/mysql/catalog/indexcmds.go
@@ -47,6 +47,9 @@ func (c *Catalog) createIndex(stmt *nodes.CreateIndexStmt) error {
 		}
 		idxCols = append(idxCols, col)
 	}
+	if err := validateIndexColumns(tbl, idxCols, stmt.Fulltext, stmt.Spatial); err != nil {
+		return err
+	}
 
 	// Determine index type: Fulltext/Spatial override IndexType.
 	idx := &Index{

--- a/mysql/catalog/mysql_semantics_regression_test.go
+++ b/mysql/catalog/mysql_semantics_regression_test.go
@@ -1,0 +1,77 @@
+package catalog
+
+import "testing"
+
+func TestMySQLSemanticsRegression_InvalidColumnAndIndexDDL(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		code int
+	}{
+		{
+			name: "create_spatial_index_requires_not_null_column",
+			sql: `CREATE TABLE t (g GEOMETRY);
+CREATE SPATIAL INDEX sp_g ON t (g);`,
+			code: 1252,
+		},
+		{
+			name: "alter_column_set_default_null_rejects_not_null_column",
+			sql: `CREATE TABLE t (a INT NOT NULL);
+ALTER TABLE t ALTER COLUMN a SET DEFAULT NULL;`,
+			code: ErrInvalidDefault,
+		},
+		{
+			name: "alter_column_set_default_rejects_lob_literal_default",
+			sql: `CREATE TABLE t (a INT);
+ALTER TABLE t CHANGE COLUMN a a BLOB;
+ALTER TABLE t ALTER COLUMN a SET DEFAULT 'x';`,
+			code: 1101,
+		},
+		{
+			name: "create_table_rejects_duplicate_auto_increment",
+			sql:  `CREATE TABLE t (a INT AUTO_INCREMENT KEY, b INT AUTO_INCREMENT KEY);`,
+			code: 1075,
+		},
+		{
+			name: "create_table_rejects_not_null_default_null",
+			sql:  `CREATE TABLE t (a INT NOT NULL DEFAULT NULL);`,
+			code: ErrInvalidDefault,
+		},
+		{
+			name: "create_table_rejects_non_temporal_on_update",
+			sql:  `CREATE TABLE t (a INT ON UPDATE NOW());`,
+			code: 1294,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			mustExec(t, c, "CREATE DATABASE testdb; USE testdb")
+			results, err := c.Exec(tt.sql, &ExecOptions{ContinueOnError: true})
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			catErr := lastExecError(results)
+			if catErr == nil {
+				t.Fatalf("expected catalog error code %d, got nil", tt.code)
+			}
+			if catErr.Code != tt.code {
+				t.Fatalf("expected catalog error code %d, got %d: %v", tt.code, catErr.Code, catErr)
+			}
+		})
+	}
+}
+
+func lastExecError(results []ExecResult) *Error {
+	for i := len(results) - 1; i >= 0; i-- {
+		if results[i].Error == nil {
+			continue
+		}
+		if catErr, ok := results[i].Error.(*Error); ok {
+			return catErr
+		}
+		return nil
+	}
+	return nil
+}

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -122,6 +122,7 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 	}
 	// Track whether we have a primary key (to detect multiple PKs).
 	hasPK := false
+	autoIncrementColumn := ""
 
 	// Defer FK backing index creation until after all explicit indexes are added,
 	// so that explicit indexes can satisfy FK requirements without creating duplicates.
@@ -254,6 +255,12 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 				Expr:   nodeToSQLGenerated(colDef.Generated.Expr, tbl.Charset),
 				Stored: colDef.Generated.Stored,
 			}
+		}
+		if col.AutoIncrement {
+			if autoIncrementColumn != "" {
+				return errIncorrectAutoIncrementDefinition()
+			}
+			autoIncrementColumn = colDef.Name
 		}
 
 		// Process column-level constraints.

--- a/mysql/catalog/validation.go
+++ b/mysql/catalog/validation.go
@@ -76,6 +76,9 @@ func validateColumnDefSemantics(colDef *nodes.ColumnDef) error {
 	if hasExplicitNullPrimaryKey(colDef) {
 		return &Error{Code: 1171, SQLState: "42000", Message: "All parts of a PRIMARY KEY must be NOT NULL"}
 	}
+	if !columnDefNullable(colDef) && hasNullDefault(colDef) {
+		return errInvalidDefault(colDef.Name)
+	}
 	if isLiteralDefaultForbiddenType(typeName) {
 		if isLiteralDefault(colDef.DefaultValue) || hasLiteralColumnDefaultConstraint(colDef) {
 			return &Error{Code: 1101, SQLState: "42000", Message: fmtCantHaveDefault(colDef.Name)}
@@ -119,6 +122,22 @@ func hasExplicitNullPrimaryKey(colDef *nodes.ColumnDef) bool {
 		}
 	}
 	return hasNull && hasPK
+}
+
+func columnDefNullable(colDef *nodes.ColumnDef) bool {
+	nullable := true
+	if colDef.AutoIncrement {
+		nullable = false
+	}
+	for _, cc := range colDef.Constraints {
+		switch cc.Type {
+		case nodes.ColConstrNotNull, nodes.ColConstrPrimaryKey, nodes.ColConstrAutoIncrement:
+			nullable = false
+		case nodes.ColConstrNull:
+			nullable = true
+		}
+	}
+	return nullable
 }
 
 func validateGeneratedExpr(colName string, expr nodes.ExprNode) error {
@@ -186,6 +205,18 @@ func hasColumnDefaultConstraint(colDef *nodes.ColumnDef) bool {
 	return false
 }
 
+func hasNullDefault(colDef *nodes.ColumnDef) bool {
+	if isNullDefault(colDef.DefaultValue) {
+		return true
+	}
+	for _, cc := range colDef.Constraints {
+		if cc.Type == nodes.ColConstrDefault && isNullDefault(cc.Expr) {
+			return true
+		}
+	}
+	return false
+}
+
 func hasLiteralColumnDefaultConstraint(colDef *nodes.ColumnDef) bool {
 	for _, cc := range colDef.Constraints {
 		if cc.Type == nodes.ColConstrDefault && isLiteralDefault(cc.Expr) {
@@ -201,6 +232,17 @@ func isLiteralDefault(expr nodes.ExprNode) bool {
 		return true
 	case *nodes.ParenExpr:
 		return isLiteralDefault(e.Expr)
+	default:
+		return false
+	}
+}
+
+func isNullDefault(expr nodes.ExprNode) bool {
+	switch e := expr.(type) {
+	case *nodes.NullLit:
+		return true
+	case *nodes.ParenExpr:
+		return isNullDefault(e.Expr)
 	default:
 		return false
 	}
@@ -238,10 +280,13 @@ func validateTemporalExprForColumn(colName, typeName string, colFsp int, expr no
 		return errInvalidDefault(colName)
 	}
 	if !isDefault && typeName != "datetime" && typeName != "timestamp" {
-		return errInvalidDefault(colName)
+		return errInvalidOnUpdate(colName)
 	}
 	if typeName == "datetime" || typeName == "timestamp" {
 		if fsp, ok := temporalFuncFSP(fn); ok && fsp != colFsp {
+			if !isDefault {
+				return errInvalidOnUpdate(colName)
+			}
 			return errInvalidDefault(colName)
 		}
 	}


### PR DESCRIPTION
## Summary
- Reject standalone `CREATE SPATIAL INDEX` on nullable spatial columns by reusing index-column validation.
- Validate `ALTER COLUMN ... SET DEFAULT` against existing column nullability and LOB/JSON/GEOMETRY default rules.
- Reject duplicate `AUTO_INCREMENT`, `NOT NULL DEFAULT NULL`, and non-temporal `ON UPDATE` with MySQL-aligned errors.

## Test Plan
- `DOCKER_HOST=unix:///Users/rebeliceyang/.colima/default/docker.sock TESTCONTAINERS_RYUK_DISABLED=true go test ./mysql/... -count=1`
