### PR TITLE
feat(snowflake): multi-line single-quoted routine body Split + PROCEDURE AS DECLARE/BEGIN body (phase-2 gap-scripting-split) — close corpus gap 186

### DIFF
--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -21,15 +21,15 @@ import (
 // file that starts parsing clean fails the test with a "REMOVE me" note, so the
 // list cannot silently rot as the grammar grows.
 //
-// Two files (create-function example_01 / example_03) carry a multi-line
-// single-quoted routine body. F3's Split mis-segments those because the omni
-// lexer's scanString cannot span a newline, so a ';' that follows a newline
-// inside the body looks like a statement terminator. They are NOT a parser gap —
-// the whole file parses clean when handed to parseSingle directly — so they are
-// driven whole-file (corpusWholeFile) instead of being skipped.
+// Multi-line single-quoted routine bodies (e.g. create-function example_01 /
+// example_03, a Java / JavaScript handler) used to defeat F3's Split because the
+// omni lexer's scanString could not span a newline, so a ';' on a continuation
+// line inside the body read as a statement terminator. Split now runs its lexer
+// in multilineString mode (split.go), so those segment correctly and parse via
+// the normal Split path; corpusWholeFile is consequently empty.
 //
-// Coverage snapshot at authoring time: 576/657 files parse clean
-// (574 via Split + 2 via whole-file), 81 files skipped (categorized below).
+// Coverage snapshot at authoring time: 651/657 files parse clean (all via
+// Split), 6 files skipped (categorized below).
 func TestCorpusClosure(t *testing.T) {
 	files := collectCorpusFiles(t)
 	if len(files) != 657 {
@@ -139,14 +139,16 @@ func collectCorpusFiles(t *testing.T) []string {
 	return out
 }
 
-// corpusWholeFile lists files that are a SINGLE valid statement whose multi-line
-// single-quoted body defeats F3's Split (a Split-layer limitation tracked as a
-// flagged divergence, not a parser gap). They are parsed whole-file via
-// parseSingle and must parse clean.
-var corpusWholeFile = map[string]string{
-	"official/create-function/example_01.sql": "single CREATE FUNCTION with a multi-line single-quoted Java body (embedded ';' defeats Split)",
-	"official/create-function/example_03.sql": "single CREATE FUNCTION with a multi-line single-quoted JavaScript body (embedded ';' defeats Split)",
-}
+// corpusWholeFile lists files that are a SINGLE valid statement whose body
+// defeats F3's Split and so must be parsed whole-file via parseSingle.
+//
+// It is now EMPTY: Split runs its lexer in multilineString mode (split.go), so a
+// multi-line single-quoted routine body — the Java / JavaScript handler bodies
+// in create-function example_01 / example_03 that used to live here — segments
+// correctly and parses end-to-end through the normal Split path. The map and its
+// branch are retained as a safety hatch for any future single-statement file
+// whose body genuinely cannot be segmented.
+var corpusWholeFile = map[string]string{}
 
 // corpusSkips is the explicit, categorized skip-list. Each key is a corpus file
 // (relative to testdata/) that contains at least one statement the engine cannot
@@ -172,8 +174,15 @@ var corpusSkips = map[string]string{
 	"official/create-table/example_06.sql":          "DEPENDENCY GAP: CTAS AS SELECT $1:o_custkey::number FROM @my_stage — $N:path semi-structured + stage table ref",
 
 	// --- RESIDUAL GAP: Snowflake Scripting blocks (DECLARE..BEGIN..END, CALL ... INTO) ---
-	"official/execute-immediate/example_01.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
-	"official/execute-immediate/example_04.sql": "RESIDUAL GAP: CREATE PROCEDURE ... AS DECLARE ... BEGIN ... END scripting body (non-$$) not parsed",
+	// The PROCEDURE AS DECLARE..BEGIN..END body now routes to the scripting parser
+	// (gap-scripting-split), so the block itself parses; these two remain only for
+	// an EXECUTE IMMEDIATE argument-grammar gap inside the body, NOT a split/body
+	// gap: example_01 uses `EXECUTE IMMEDIATE <var> || '...'` (a string EXPRESSION
+	// argument, not a bare variable) and example_04 uses `rs := (EXECUTE IMMEDIATE
+	// :bind USING (...))` (a parenthesized EXECUTE IMMEDIATE assigned to a RESULTSET
+	// + a `:`-bind argument). Both are owned by the EXECUTE IMMEDIATE node.
+	"official/execute-immediate/example_01.sql": "RESIDUAL GAP: EXECUTE IMMEDIATE <var> || '...' string-expression argument (block body now parses; EXECUTE IMMEDIATE expr-arg not yet supported)",
+	"official/execute-immediate/example_04.sql": "RESIDUAL GAP: rs := (EXECUTE IMMEDIATE :bind USING (...)) parenthesized-statement assignment + :bind arg (block body now parses; this EXECUTE IMMEDIATE form not yet supported)",
 	"official/call/example_07.sql":              "RESIDUAL GAP: DECLARE ... BEGIN CALL p(...) INTO :var ... END scripting block not parsed",
 
 	// --- RESIDUAL GAP / MALFORMED: legacy select.sql expression corpus ---

--- a/snowflake/parser/function_procedure.go
+++ b/snowflake/parser/function_procedure.go
@@ -382,6 +382,27 @@ func (p *Parser) parseRoutineBody() (body string, dollar bool, end int, err erro
 		return "", false, 0, p.syntaxErrorAtCur()
 	}
 
+	// Bare Snowflake Scripting body: AS DECLARE ... BEGIN ... END (no quotes, no
+	// $$). A SQL stored procedure may give its body directly as a scripting block
+	// instead of a quoted literal. This is NOT raw-scanned: it is parsed through
+	// the scripting parser (which validates the block and leaves cur positioned
+	// just past the terminating END), and the verbatim block text is captured into
+	// Body for parity with the quoted forms. A leading BEGIN here is unambiguously
+	// a block opener (we are in a routine body, not at the statement top where
+	// BEGIN could start a transaction).
+	if p.cur.Type == kwDECLARE || p.cur.Type == kwBEGIN {
+		if _, berr := p.parseScriptBlock(); berr != nil {
+			return "", false, 0, berr
+		}
+		// p.prev is the last token the block consumed (END or its trailing label);
+		// its absolute End bounds the verbatim body.
+		blockEnd := p.prev.Loc.End - p.base
+		if blockEnd < startLocal || blockEnd > len(p.input) {
+			return "", false, 0, p.syntaxErrorAtCur()
+		}
+		return p.input[startLocal:blockEnd], false, p.prev.Loc.End, nil
+	}
+
 	var endLocal int
 	switch p.input[startLocal] {
 	case '$':

--- a/snowflake/parser/function_procedure_test.go
+++ b/snowflake/parser/function_procedure_test.go
@@ -185,6 +185,69 @@ func TestRoutineBody_TrailingSemicolonNotInBody(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// PROCEDURE AS <bare scripting block> body — the non-$$, non-quoted form
+//
+//	CREATE PROCEDURE p() RETURNS ... AS DECLARE ... BEGIN ... END
+//
+// The body after AS is a Snowflake Scripting block (DECLARE..BEGIN..END or a
+// bare BEGIN..END) with NO surrounding quotes or $$. F3's Split already keeps
+// the whole block in one segment (the DECLARE/BEGIN..END state machine), and
+// parseRoutineBody routes a leading DECLARE/BEGIN body to the scripting parser,
+// capturing the block text verbatim into Body. These flow end-to-end through
+// mustCreateRoutine (the full Split + parse pipeline).
+// ---------------------------------------------------------------------------
+
+func TestRoutineBody_AsDeclareBeginBlock(t *testing.T) {
+	input := "CREATE PROCEDURE p() RETURNS INTEGER AS\n" +
+		"DECLARE\n  x INTEGER DEFAULT 0;\nBEGIN\n  x := 1;\n  RETURN x;\nEND"
+	stmt := mustCreateRoutine(t, input)
+	if stmt.Kind != ast.RoutineProcedure {
+		t.Errorf("Kind = %v, want RoutineProcedure", stmt.Kind)
+	}
+	if stmt.BodyDollar {
+		t.Errorf("BodyDollar = true, want false")
+	}
+	if !strings.HasPrefix(stmt.Body, "DECLARE") || !strings.HasSuffix(stmt.Body, "END") {
+		t.Errorf("Body = %q, want the verbatim DECLARE..BEGIN..END block", stmt.Body)
+	}
+	if !strings.Contains(stmt.Body, "x := 1;") {
+		t.Errorf("Body = %q, want it to contain the verbatim block statements", stmt.Body)
+	}
+}
+
+func TestRoutineBody_AsBareBeginBlock(t *testing.T) {
+	// AS BEGIN ... END (no DECLARE) — BEGIN here is a block opener, not a TCL
+	// transaction (we are in a routine body).
+	stmt := mustCreateRoutine(t, "CREATE PROCEDURE p() RETURNS INTEGER AS BEGIN RETURN 1; END")
+	if stmt.Body != "BEGIN RETURN 1; END" {
+		t.Errorf("Body = %q, want %q", stmt.Body, "BEGIN RETURN 1; END")
+	}
+	if stmt.BodyDollar {
+		t.Errorf("BodyDollar = true, want false")
+	}
+}
+
+func TestRoutineBody_AsBlockNestedEndIf(t *testing.T) {
+	// A nested IF..END IF inside the body must NOT close the outer block early:
+	// the whole block through the terminating END is the body.
+	input := "CREATE PROCEDURE p() RETURNS INTEGER AS\n" +
+		"BEGIN\n  IF (1 = 1) THEN\n    RETURN 1;\n  END IF;\n  RETURN 0;\nEND"
+	stmt := mustCreateRoutine(t, input)
+	if !strings.HasSuffix(stmt.Body, "RETURN 0;\nEND") {
+		t.Errorf("Body = %q, want it to end at the terminating END (not END IF)", stmt.Body)
+	}
+}
+
+func TestRoutineBody_AsBlockTrailingSemicolon(t *testing.T) {
+	// The trailing ';' after the block's END is the statement delimiter and must
+	// not be part of Body.
+	stmt := mustCreateRoutine(t, "CREATE PROCEDURE p() RETURNS INTEGER AS BEGIN RETURN 1; END;")
+	if stmt.Body != "BEGIN RETURN 1; END" {
+		t.Errorf("Body = %q, want %q (no trailing ';')", stmt.Body, "BEGIN RETURN 1; END")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // CREATE FUNCTION — language × body matrix
 //
 // Asserted via parseSingle (mustCreateRoutineDirect): the multi-line

--- a/snowflake/parser/lexer.go
+++ b/snowflake/parser/lexer.go
@@ -19,12 +19,31 @@ type Lexer struct {
 	start      int // start byte of the token currently being scanned
 	errors     []LexError
 	baseOffset int // added to token Loc.Start/End and error Loc.Start/End when returned via public API
+	// multilineString, when set, lets a single-quoted string literal span
+	// newlines (the matching unescaped closing ' may be on a later line). It is
+	// OFF by default — the parser's lexer keeps the conventional one-line string
+	// rule. Split turns it ON: statement-segmentation must treat a multi-line
+	// single-quoted routine body (a Java / JavaScript / SQL handler) as one
+	// opaque string so an embedded ';' on a continuation line does not look like
+	// a statement terminator. See split.go and parseRoutineBody (which itself
+	// raw-scans the body verbatim once Split delivers the whole statement).
+	multilineString bool
 }
 
 // NewLexer constructs a Lexer for the given input. Token positions are
 // zero-based byte offsets into input.
 func NewLexer(input string) *Lexer {
 	return &Lexer{input: input}
+}
+
+// newSplitLexer constructs a Lexer for statement segmentation (Split). It is
+// identical to NewLexer except that single-quoted string literals may span
+// newlines (multilineString), so a multi-line single-quoted routine body is
+// tokenized as ONE string rather than being torn at the first embedded newline.
+// This mode is intentionally NOT exposed on the parser's lexer: only Split needs
+// it, and only for finding statement boundaries.
+func newSplitLexer(input string) *Lexer {
+	return &Lexer{input: input, multilineString: true}
 }
 
 // NewLexerWithOffset constructs a Lexer whose emitted token Loc values
@@ -268,8 +287,10 @@ func (l *Lexer) scanString() Token {
 			l.pos++
 			continue
 		}
-		if ch == '\n' {
+		if ch == '\n' && !l.multilineString {
 			// Unterminated single-quoted string — strings cannot span newlines.
+			// In multilineString mode (Split's segmentation lexer) a newline is an
+			// ordinary body byte; the string runs on to its matching closing quote.
 			l.errors = append(l.errors, LexError{
 				Loc: ast.Loc{Start: start, End: l.pos},
 				Msg: errUnterminatedString,

--- a/snowflake/parser/split.go
+++ b/snowflake/parser/split.go
@@ -60,7 +60,12 @@ func Split(input string) []Segment {
 		return nil
 	}
 
-	l := NewLexer(input)
+	// Split's lexer runs in multilineString mode so a multi-line single-quoted
+	// routine body ('class Foo { ...; ... }' spanning several lines, a Java / JS /
+	// SQL handler) tokenizes as ONE string. The parser's own lexer keeps the
+	// conventional one-line string rule; only segmentation needs a ';' on a
+	// continuation line inside such a body to NOT read as a statement terminator.
+	l := newSplitLexer(input)
 	var segments []Segment
 	stmtStart := 0
 	state := stateTop

--- a/snowflake/parser/split_test.go
+++ b/snowflake/parser/split_test.go
@@ -240,6 +240,59 @@ func TestSplit_DollarQuotedBody(t *testing.T) {
 	runSplitCases(t, cases)
 }
 
+func TestSplit_MultiLineSingleQuotedBody(t *testing.T) {
+	// A single-quoted routine body that SPANS NEWLINES and embeds ';', '{', '}'
+	// (a Java / JavaScript / SQL handler) must stay in ONE segment. Split runs its
+	// lexer in multilineString mode so the opening ' only ends at the matching
+	// unescaped ' — the embedded ';' on a continuation line is NOT a terminator.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"java body", "CREATE FUNCTION f() RETURNS VARCHAR LANGUAGE JAVA AS\n'class T {\n  String e(String x){ return x; }\n}';", []Segment{
+			{"CREATE FUNCTION f() RETURNS VARCHAR LANGUAGE JAVA AS\n'class T {\n  String e(String x){ return x; }\n}'", 0, 100},
+		}},
+		{"js body with semicolons and braces", "CREATE FUNCTION f(d double) RETURNS double LANGUAGE JAVASCRIPT AS '\n  if (D <= 0) { return 1; }\n  return D;\n';", []Segment{
+			{"CREATE FUNCTION f(d double) RETURNS double LANGUAGE JAVASCRIPT AS '\n  if (D <= 0) { return 1; }\n  return D;\n'", 0, 109},
+		}},
+		{"doubled-quote escape spanning newline", "CREATE FUNCTION f() RETURNS VARCHAR AS 'a;\nit''s b;\nc';", []Segment{
+			{"CREATE FUNCTION f() RETURNS VARCHAR AS 'a;\nit''s b;\nc'", 0, 54},
+		}},
+		{"multi-line body then a following statement", "CREATE FUNCTION f() RETURNS INT AS 'x;\ny';\nSELECT 2;", []Segment{
+			{"CREATE FUNCTION f() RETURNS INT AS 'x;\ny'", 0, 41},
+			{"\nSELECT 2", 42, 51},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
+func TestSplit_StringStateRegression(t *testing.T) {
+	// The multilineString change must NOT alter segmentation of ordinary inputs:
+	// a single-line string with an embedded ';' is still one segment, a $$ body
+	// with ';' is unchanged, and a ';'-separated pair of plain statements still
+	// splits into two.
+	cases := []struct {
+		name  string
+		input string
+		want  []Segment
+	}{
+		{"single-line string", "SELECT 'a;b';", []Segment{{"SELECT 'a;b'", 0, 12}}},
+		{"single-line string two stmts", "SELECT 'a;b'; SELECT 2;", []Segment{
+			{"SELECT 'a;b'", 0, 12},
+			{" SELECT 2", 13, 22},
+		}},
+		{"dollar body with semicolons", "CREATE PROCEDURE p() AS $$ body; with; semicolons $$;", []Segment{
+			{"CREATE PROCEDURE p() AS $$ body; with; semicolons $$", 0, 52},
+		}},
+		{"plain pair", "SELECT 1; SELECT 2;", []Segment{
+			{"SELECT 1", 0, 8},
+			{" SELECT 2", 9, 18},
+		}},
+	}
+	runSplitCases(t, cases)
+}
+
 func TestSplit_UnclosedBlock(t *testing.T) {
 	// BEGIN without a matching END should produce a best-effort single
 	// segment covering the whole input.
@@ -247,6 +300,17 @@ func TestSplit_UnclosedBlock(t *testing.T) {
 	want := []Segment{{"BEGIN SELECT 1;", 0, 15}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Split(unclosed BEGIN) = %+v, want %+v", got, want)
+	}
+}
+
+func TestSplit_UnterminatedMultiLineString(t *testing.T) {
+	// LOOP-GUARD: an unterminated single-quoted body (no closing ') in
+	// multilineString mode must not loop — Split treats EOF as terminating and
+	// returns one best-effort segment covering the whole input.
+	got := Split("CREATE FUNCTION f() RETURNS INT AS 'x;\ny")
+	want := []Segment{{"CREATE FUNCTION f() RETURNS INT AS 'x;\ny", 0, 40}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Split(unterminated multi-line string) = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Node
`snowflake/gap-scripting-split` (phase-2 corpus-gap closure, final gap node) — fix statement-splitting for routine bodies that embed `;`.

## What changed
- **Multi-line single-quoted routine bodies** (`create-function/example_01` Java, `example_03` JavaScript): `split.go` now uses a `newSplitLexer` in `multilineString` mode — a `'…'` string spans newlines (with `''` escape) so the internal `;`/`{`/`}` don't split the `CREATE FUNCTION … AS '…';`. These two files **move from the `corpusWholeFile` workaround to real clean-Split** (`corpusWholeFile` is now empty).
- **`CREATE PROCEDURE … AS DECLARE…BEGIN…END`** (non-`$$` body): `function_procedure.go` `parseRoutineBody` now routes a leading `DECLARE`/`BEGIN` body to the scripting parser (`parseScriptBlock`), so the block parses.

## Isolation (no parser regression)
The newline-spanning string behavior is **opt-in** — a `multilineString` flag + `newSplitLexer` constructor on the lexer, default-off. The normal parser lexer path is byte-for-byte unchanged; only `Split` enables it.

## Corpus delta (TestCorpusClosure)
`649 clean-Split + 2 whole-file` → **`651 clean-Split + 0 whole-file`** (the 2 function bodies now segment correctly via the real Split path). 6 skipped, unchanged.

## Left skipped (precise residual, different owner)
`execute-immediate/example_01,04` — Split + body-routing now work, but the residual is an **EXECUTE IMMEDIATE argument-grammar** gap owned by `call_execute.go`: `EXECUTE IMMEDIATE <var> || '…'` (string-expression arg) and `rs := (EXECUTE IMMEDIATE :bind USING (…))` (parenthesized-statement / RESULTSET assignment + `:`-bind). Skip reasons updated; **skips not removed** (files still fail). Follow-up recommended.

## split.go not regressed (load-bearing — verified)
FULL `TestSplit*` suite green. Regression cases confirmed: single-line `'a;b'` → 1 segment; `$$ body; with; semicolons $$` → unchanged; plain `;`-separated pair → 2 segments; `--`/`//`/`/* */` comments + dollar bodies unaffected; unterminated multi-line string terminates at EOF (no infinite loop). Empirically a strict improvement (recovers a statement the old behavior swallowed). Orchestrator independently verified on a fresh checkout of `7fa320ed`: build/vet/gofmt clean, FULL split suite + full `go test ./snowflake/... -count=1 -timeout 120s` green (7 pkgs), corpus self-prune green.

## Review (`/code-review` max; Codex down) — no bugs
Lexer-flag isolation, Split improvement-not-regression, bounds-checked block-end, token-state consistency after `parseScriptBlock`, escapes/EOF/loop-guards all verified.

## Note
Opened by orchestrator from verified commit `7fa320ed`. Phase-2 gap 11/11 (final gap node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
