### PR TITLE
feat(starrocks/parser): CREATE TABLE divergences — PERCENTILE, batch partition, generated col, default expr (PR2a)

### DIFF
--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -181,7 +181,7 @@ func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
 			continue
 
 		case kwMAX, kwMIN, kwSUM, kwREPLACE, kwREPLACE_IF_NOT_NULL,
-			kwHLL_UNION, kwBITMAP_UNION, kwQUANTILE_UNION, kwGENERIC:
+			kwHLL_UNION, kwBITMAP_UNION, kwQUANTILE_UNION, kwPERCENTILE_UNION, kwGENERIC:
 			col.AggType = strings.ToUpper(p.cur.Str)
 			col.Loc.End = p.cur.Loc.End
 			p.advance()

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -819,6 +819,11 @@ func (p *Parser) parsePartitionItem() (*ast.PartitionItem, error) {
 		return p.parseStepPartition(startLoc)
 	}
 
+	// StarRocks batch range: START (...) END (...) EVERY (INTERVAL n [unit] | n)
+	if p.cur.Kind == kwSTART {
+		return p.parseBatchRangePartition(startLoc)
+	}
+
 	// Named partition: PARTITION [IF NOT EXISTS] name ...
 	if p.cur.Kind != kwPARTITION {
 		return nil, p.syntaxErrorAtCur()
@@ -960,6 +965,76 @@ func (p *Parser) parseStepPartition(startLoc ast.Loc) (*ast.PartitionItem, error
 		item.Loc.End = p.cur.Loc.End
 		p.advance()
 	}
+
+	return item, nil
+}
+
+// parseBatchRangePartition parses StarRocks batch range partitioning:
+//
+//	START (value) END (value) EVERY (INTERVAL n [unit] | n)
+//
+// This is the StarRocks spelling of doris's FROM..TO..INTERVAL stepped range,
+// so it populates the same IsStep PartitionItem fields. The EVERY amount is
+// parenthesized (unlike doris's bare INTERVAL).
+func (p *Parser) parseBatchRangePartition(startLoc ast.Loc) (*ast.PartitionItem, error) {
+	p.advance() // consume START
+
+	fromVals, _, err := p.parsePartitionValueList()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expect(kwEND); err != nil {
+		return nil, err
+	}
+
+	toVals, _, err := p.parsePartitionValueList()
+	if err != nil {
+		return nil, err
+	}
+
+	item := &ast.PartitionItem{
+		IsStep:     true,
+		FromValues: fromVals,
+		ToValues:   toVals,
+		Loc:        startLoc,
+	}
+
+	if _, err := p.expect(kwEVERY); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	// EVERY (INTERVAL n [unit]) for date ranges, or EVERY (n) for numeric ranges.
+	if p.cur.Kind == kwINTERVAL {
+		p.advance()
+	}
+	if p.cur.Kind != tokInt {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected integer interval amount, got %q", p.cur.Str),
+		}
+	}
+	item.Interval = p.cur.Str
+	item.Loc.End = p.cur.Loc.End
+	p.advance()
+
+	// Optional interval unit (date ranges).
+	if p.cur.Kind == kwDAY || p.cur.Kind == kwWEEK || p.cur.Kind == kwMONTH ||
+		p.cur.Kind == kwYEAR || p.cur.Kind == kwHOUR || p.cur.Kind == kwMINUTE ||
+		p.cur.Kind == kwSECOND || p.cur.Kind == tokIdent {
+		item.IntervalUnit = strings.ToUpper(p.cur.Str)
+		item.Loc.End = p.cur.Loc.End
+		p.advance()
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	item.Loc.End = closeTok.Loc.End
 
 	return item, nil
 }

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -209,6 +209,25 @@ func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
 			col.Loc.End = closeTok.Loc.End
 			continue
 
+		case kwAS:
+			// StarRocks generated-column shorthand: col TYPE AS (expr)
+			// (doris requires the GENERATED ALWAYS prefix handled above).
+			p.advance() // consume AS
+			if _, err := p.expect(int('(')); err != nil {
+				return nil, err
+			}
+			expr, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			closeTok, err := p.expect(int(')'))
+			if err != nil {
+				return nil, err
+			}
+			col.Generated = expr
+			col.Loc.End = closeTok.Loc.End
+			continue
+
 		case kwNOT:
 			// NOT NULL
 			p.advance()

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -210,22 +210,17 @@ func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
 			continue
 
 		case kwAS:
-			// StarRocks generated-column shorthand: col TYPE AS (expr)
-			// (doris requires the GENERATED ALWAYS prefix handled above).
+			// StarRocks generated-column shorthand: col TYPE AS <expr>
+			// (doris requires the GENERATED ALWAYS prefix handled above). The
+			// expression may be parenthesized — AS (a+b) — or not — AS abs(a) /
+			// AS a + b; parseExpr handles both, so don't mandate outer parens.
 			p.advance() // consume AS
-			if _, err := p.expect(int('(')); err != nil {
-				return nil, err
-			}
 			expr, err := p.parseExpr()
 			if err != nil {
 				return nil, err
 			}
-			closeTok, err := p.expect(int(')'))
-			if err != nil {
-				return nil, err
-			}
 			col.Generated = expr
-			col.Loc.End = closeTok.Loc.End
+			col.Loc.End = ast.NodeLoc(expr).End
 			continue
 
 		case kwNOT:

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -402,6 +402,18 @@ func (p *Parser) parseDefaultValue() (ast.Node, error) {
 		tok := p.advance()
 		return &ast.Literal{Kind: ast.LitString, Value: tok.Str, Loc: tok.Loc}, nil
 
+	case int('('):
+		// StarRocks parenthesized expression default: DEFAULT (uuid()), DEFAULT (expr).
+		p.advance() // consume (
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		return expr, nil
+
 	default:
 		return nil, &ParseError{
 			Loc: p.cur.Loc,

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -52,6 +52,21 @@ func TestCreateTable_Basic(t *testing.T) {
 	}
 }
 
+// StarRocks PERCENTILE type + PERCENTILE_UNION aggregate (BYT-9140 PR2a #10).
+// doris uses QUANTILE_STATE/QUANTILE_UNION; StarRocks uses PERCENTILE.
+func TestCreateTable_PercentileAggType(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE agg_pct (k INT, p PERCENTILE PERCENTILE_UNION) AGGREGATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1")
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.Columns[1].Type.Name != "PERCENTILE" {
+		t.Errorf("Columns[1].Type.Name = %q, want PERCENTILE", stmt.Columns[1].Type.Name)
+	}
+	if stmt.Columns[1].AggType != "PERCENTILE_UNION" {
+		t.Errorf("Columns[1].AggType = %q, want PERCENTILE_UNION", stmt.Columns[1].AggType)
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -67,6 +67,41 @@ func TestCreateTable_PercentileAggType(t *testing.T) {
 	}
 }
 
+// StarRocks batch range partition START..END..EVERY (BYT-9140 PR2a #13).
+// doris uses FROM..TO..INTERVAL; semantically a stepped range (reuses IsStep).
+func TestCreateTable_BatchRangePartition(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE bp (dt DATE, k INT) DUPLICATE KEY(dt) PARTITION BY RANGE(dt) (START ('2024-01-01') END ('2024-04-01') EVERY (INTERVAL 1 MONTH)) DISTRIBUTED BY HASH(k)")
+	if stmt.PartitionBy == nil || len(stmt.PartitionBy.Partitions) != 1 {
+		t.Fatalf("expected 1 partition item, got %+v", stmt.PartitionBy)
+	}
+	item := stmt.PartitionBy.Partitions[0]
+	if !item.IsStep {
+		t.Errorf("expected stepped batch partition (IsStep)")
+	}
+	if item.Interval != "1" || item.IntervalUnit != "MONTH" {
+		t.Errorf("Interval=%q Unit=%q, want 1/MONTH", item.Interval, item.IntervalUnit)
+	}
+}
+
+func TestCreateTable_BatchRangePartitionNumeric(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE bpn (id INT, v BIGINT) DUPLICATE KEY(id) PARTITION BY RANGE(id) (START ('1') END ('100') EVERY (10)) DISTRIBUTED BY HASH(id)")
+	if stmt.PartitionBy == nil || len(stmt.PartitionBy.Partitions) != 1 {
+		t.Fatalf("expected 1 partition item, got %+v", stmt.PartitionBy)
+	}
+	if got := stmt.PartitionBy.Partitions[0].Interval; got != "10" {
+		t.Errorf("Interval=%q, want 10", got)
+	}
+}
+
+// Sibling-arm negative: START..END without EVERY is rejected (container-confirmed
+// StarRocks also rejects it).
+func TestCreateTable_BatchRangePartitionRequiresEvery(t *testing.T) {
+	_, errs := Parse("CREATE TABLE bpno (dt DATE) DUPLICATE KEY(dt) PARTITION BY RANGE(dt) (START ('2024-01-01') END ('2024-04-01')) DISTRIBUTED BY HASH(dt)")
+	if len(errs) == 0 {
+		t.Error("expected START..END without EVERY to be rejected")
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -114,6 +114,18 @@ func TestCreateTable_GeneratedColumnAS(t *testing.T) {
 	}
 }
 
+// StarRocks parenthesized expression default `DEFAULT (expr)` (BYT-9140 PR2a #12).
+// (Bare CURRENT_TIMESTAMP already parses; the gap is the (expr) form.)
+func TestCreateTable_DefaultExpr(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE dft (id BIGINT, token VARCHAR(64) DEFAULT (uuid())) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)")
+	if len(stmt.Columns) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.Columns[1].Default == nil {
+		t.Errorf("expected Columns[1].Default set for DEFAULT (expr)")
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -102,6 +102,18 @@ func TestCreateTable_BatchRangePartitionRequiresEvery(t *testing.T) {
 	}
 }
 
+// StarRocks generated column shorthand `c TYPE AS (expr)` (BYT-9140 PR2a #11).
+// doris uses GENERATED ALWAYS AS (expr); StarRocks drops the GENERATED ALWAYS.
+func TestCreateTable_GeneratedColumnAS(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE gc (id BIGINT, price DECIMAL(18,2), qty INT, total DECIMAL(18,2) AS (price*qty)) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id)")
+	if len(stmt.Columns) != 4 {
+		t.Fatalf("expected 4 columns, got %d", len(stmt.Columns))
+	}
+	if stmt.Columns[3].Generated == nil {
+		t.Errorf("expected Columns[3].Generated to be set for AS (expr)")
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -114,6 +114,23 @@ func TestCreateTable_GeneratedColumnAS(t *testing.T) {
 	}
 }
 
+// StarRocks generated columns allow AS <expr> with NO outer parens, e.g.
+// `c DOUBLE AS array_avg(data)` or `c BIGINT AS a + b` (docs + SHOW CREATE TABLE
+// output). The arm must not mandate the parenthesized form. (#288 P2 review.)
+func TestCreateTable_GeneratedColumnASUnparenthesizedCall(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE g1 (a INT, b INT, c BIGINT AS abs(a)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1")
+	if stmt.Columns[2].Generated == nil {
+		t.Errorf("expected Columns[2].Generated set for unparenthesized AS abs(a)")
+	}
+}
+
+func TestCreateTable_GeneratedColumnASBareBinary(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE g2 (a INT, b INT, c BIGINT AS a + b) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1")
+	if stmt.Columns[2].Generated == nil {
+		t.Errorf("expected Columns[2].Generated set for unparenthesized AS a + b")
+	}
+}
+
 // StarRocks parenthesized expression default `DEFAULT (expr)` (BYT-9140 PR2a #12).
 // (Bare CURRENT_TIMESTAMP already parses; the gap is the (expr) form.)
 func TestCreateTable_DefaultExpr(t *testing.T) {

--- a/starrocks/parser/datatypes.go
+++ b/starrocks/parser/datatypes.go
@@ -28,7 +28,7 @@ func isPrimitiveTypeKeyword(kind TokenKind) bool {
 	case kwDATE, kwDATETIME, kwTIME, kwDATEV1, kwDATEV2, kwDATETIMEV1, kwDATETIMEV2:
 		return true
 	// Special Doris types
-	case kwBITMAP, kwHLL, kwQUANTILE_STATE, kwJSON, kwJSONB:
+	case kwBITMAP, kwHLL, kwQUANTILE_STATE, kwPERCENTILE, kwJSON, kwJSONB:
 		return true
 	case kwIPV4, kwIPV6, kwVARIANT, kwAGG_STATE:
 		return true
@@ -99,6 +99,8 @@ func typeKeywordName(tok Token) string {
 		return "HLL"
 	case kwQUANTILE_STATE:
 		return "QUANTILE_STATE"
+	case kwPERCENTILE:
+		return "PERCENTILE"
 	case kwJSON:
 		return "JSON"
 	case kwJSONB:

--- a/starrocks/parser/keywords.go
+++ b/starrocks/parser/keywords.go
@@ -350,6 +350,8 @@ const (
 	kwPATH
 	kwPAUSE
 	kwPERCENT
+	kwPERCENTILE
+	kwPERCENTILE_UNION
 	kwPERIOD
 	kwPERMISSIVE
 	kwPHYSICAL
@@ -888,6 +890,8 @@ var keywordMap = map[string]TokenKind{
 	"path":                                 kwPATH,
 	"pause":                                kwPAUSE,
 	"percent":                              kwPERCENT,
+	"percentile":                           kwPERCENTILE,
+	"percentile_union":                     kwPERCENTILE_UNION,
 	"period":                               kwPERIOD,
 	"permissive":                           kwPERMISSIVE,
 	"physical":                             kwPHYSICAL,
@@ -1307,6 +1311,8 @@ var nonReservedKeywords = map[TokenKind]bool{
 	kwPATH:                   true,
 	kwPAUSE:                  true,
 	kwPERCENT:                true,
+	kwPERCENTILE:             true,
+	kwPERCENTILE_UNION:       true,
 	kwPERIOD:                 true,
 	kwPERMISSIVE:             true,
 	kwPHYSICAL:               true,

--- a/starrocks/parser/pr2a_oracle_test.go
+++ b/starrocks/parser/pr2a_oracle_test.go
@@ -1,0 +1,54 @@
+package parser
+
+import "testing"
+
+// TestPR2aParity is the container-grounded conformance matrix for the PR2a
+// CREATE TABLE divergences (#10–13): each StarRocks construct is asserted to be
+// accepted by BOTH the omni parser and StarRocks 3.4 (and the sibling-arm
+// negative rejected by both). Short-gated via startStarRocks.
+func TestPR2aParity(t *testing.T) {
+	c := startStarRocks(t)
+
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		{
+			"percentile_agg",
+			"CREATE TABLE agg_pct (k INT, p PERCENTILE PERCENTILE_UNION) AGGREGATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1",
+			true,
+		},
+		{
+			"batch_partition_date",
+			"CREATE TABLE bp (dt DATE, k INT) DUPLICATE KEY(dt) PARTITION BY RANGE(dt) (START ('2024-01-01') END ('2024-04-01') EVERY (INTERVAL 1 MONTH)) DISTRIBUTED BY HASH(k)",
+			true,
+		},
+		{
+			"batch_partition_numeric",
+			"CREATE TABLE bpn (id INT, v BIGINT) DUPLICATE KEY(id) PARTITION BY RANGE(id) (START ('1') END ('100') EVERY (10)) DISTRIBUTED BY HASH(id)",
+			true,
+		},
+		{
+			"batch_partition_requires_every", // sibling-arm negative
+			"CREATE TABLE bpno (dt DATE) DUPLICATE KEY(dt) PARTITION BY RANGE(dt) (START ('2024-01-01') END ('2024-04-01')) DISTRIBUTED BY HASH(dt)",
+			false,
+		},
+		{
+			"generated_column_as",
+			"CREATE TABLE gc (id BIGINT, price DECIMAL(18,2), qty INT, total DECIMAL(18,2) AS (price*qty)) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id)",
+			true,
+		},
+		{
+			"default_expr",
+			"CREATE TABLE dft (id BIGINT, created DATETIME DEFAULT CURRENT_TIMESTAMP, token VARCHAR(64) DEFAULT (uuid())) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}

--- a/starrocks/parser/pr2a_oracle_test.go
+++ b/starrocks/parser/pr2a_oracle_test.go
@@ -35,8 +35,13 @@ func TestPR2aParity(t *testing.T) {
 			false,
 		},
 		{
-			"generated_column_as",
+			"generated_column_as_parens",
 			"CREATE TABLE gc (id BIGINT, price DECIMAL(18,2), qty INT, total DECIMAL(18,2) AS (price*qty)) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id)",
+			true,
+		},
+		{
+			"generated_column_as_unparenthesized", // #288 P2: AS <expr> without outer parens
+			"CREATE TABLE g1 (a INT, b INT, c BIGINT AS abs(a)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1",
 			true,
 		},
 		{

--- a/starrocks/parser/starrocks_container_test.go
+++ b/starrocks/parser/starrocks_container_test.go
@@ -1,0 +1,171 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// srContainer wraps a StarRocks allin1 container for parse-conformance testing.
+// StarRocks speaks the MySQL wire protocol on port 9030 (not 3306), so we
+// connect with go-sql-driver/mysql via a raw GenericContainer (there is no
+// testcontainers StarRocks module). arm64 note (#65095): the FE can come up
+// without a healthy BE on arm64, so we force linux/amd64 (qemu emulation).
+type srContainer struct {
+	db  *sql.DB
+	ctx context.Context
+}
+
+var (
+	srOnce    sync.Once
+	srInst    *srContainer
+	srInitErr error
+)
+
+// startStarRocks starts (once) the StarRocks 3.4 container and returns a ready
+// srContainer. Skipped in -short mode — omni CI runs `go test -short ./...`, so
+// container tests must be Short-gated (mirrors tidb/parser/tidb_container_test.go).
+func startStarRocks(t *testing.T) *srContainer {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping StarRocks container test in short mode")
+	}
+
+	srOnce.Do(func() {
+		ctx := context.Background()
+		req := testcontainers.ContainerRequest{
+			Image:         "starrocks/allin1-ubuntu:3.4.10",
+			ImagePlatform: "linux/amd64", // arm64 #65095 workaround
+			ExposedPorts:  []string{"9030/tcp"},
+			WaitingFor:    wait.ForListeningPort("9030/tcp").WithStartupTimeout(4 * time.Minute),
+		}
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			srInitErr = fmt.Errorf("start StarRocks container: %w", err)
+			return
+		}
+		host, err := container.Host(ctx)
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			srInitErr = err
+			return
+		}
+		port, err := container.MappedPort(ctx, "9030")
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			srInitErr = err
+			return
+		}
+		dsn := fmt.Sprintf("root@tcp(%s:%s)/?multiStatements=true&timeout=10s", host, port.Port())
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			srInitErr = err
+			return
+		}
+
+		// Active readiness: the FE accepts connections before it can serve
+		// queries. Poll until SELECT 1 succeeds. FE readiness suffices for a
+		// parse oracle (syntax errors are raised at parse time, before BE).
+		deadline := time.Now().Add(4 * time.Minute)
+		for {
+			ok := func() bool {
+				cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				var one int
+				return db.QueryRowContext(cctx, "SELECT 1").Scan(&one) == nil && one == 1
+			}()
+			if ok {
+				break
+			}
+			if time.Now().After(deadline) {
+				_ = db.Close()
+				_ = testcontainers.TerminateContainer(container)
+				srInitErr = fmt.Errorf("readiness: SELECT 1 never succeeded")
+				return
+			}
+			time.Sleep(3 * time.Second)
+		}
+
+		// Select a default database so analysis-stage probes don't all fail with
+		// "No database selected" (which would obscure whether they parsed).
+		if _, err := db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS srtest"); err != nil {
+			_ = db.Close()
+			_ = testcontainers.TerminateContainer(container)
+			srInitErr = fmt.Errorf("create srtest db: %w", err)
+			return
+		}
+		_ = db.Close()
+		db, err = sql.Open("mysql", fmt.Sprintf("root@tcp(%s:%s)/srtest?multiStatements=true&timeout=10s", host, port.Port()))
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			srInitErr = err
+			return
+		}
+		// Container intentionally leaked for singleton reuse; process exit reaps it.
+		srInst = &srContainer{db: db, ctx: ctx}
+	})
+
+	if srInitErr != nil {
+		t.Fatalf("StarRocks container: %v", srInitErr)
+	}
+	return srInst
+}
+
+// syntaxErrMarker is the prefix StarRocks' parser emits for a genuine PARSE
+// failure. CRITICAL: StarRocks codes BOTH parse AND semantic ("analyzing")
+// errors as MySQL 1064, so 1064 alone does not mean rejected — the reliable
+// discriminator is this message. (See reference_starrocks_oracle_1064_gotcha.)
+const syntaxErrMarker = "Getting syntax error"
+
+// accepts reports whether StarRocks accepted sql at the PARSE layer: executed
+// OK, or failed with any non-syntax error (semantic/runtime) — both imply it
+// parsed. Only a "Getting syntax error" message means rejected.
+func (c *srContainer) accepts(sql string) bool {
+	ctx, cancel := context.WithTimeout(c.ctx, 8*time.Second)
+	defer cancel()
+	_, err := c.db.ExecContext(ctx, sql)
+	if err == nil {
+		return true
+	}
+	if myErr, ok := err.(*gomysql.MySQLError); ok {
+		return !strings.Contains(myErr.Message, syntaxErrMarker)
+	}
+	return true // non-driver error (conn/timeout) — treat as accepted
+}
+
+// assertParity asserts the omni parser and StarRocks agree on sql (both accept
+// or both reject) — the accept+reject conformance discipline.
+func (c *srContainer) assertParity(t *testing.T, sql string, wantAccept bool) {
+	t.Helper()
+	_, errs := Parse(sql)
+	omni := len(errs) == 0
+	sr := c.accepts(sql)
+	if omni != sr {
+		t.Errorf("MISMATCH %q: omni=%v starrocks=%v (omniErrs=%v)", sql, omni, sr, errs)
+	}
+	if omni != wantAccept {
+		t.Errorf("omni %q: got accept=%v, want %v (errs=%v)", sql, omni, wantAccept, errs)
+	}
+}
+
+// TestStarRocksConnectivity is the harness smoke test: the container is reachable.
+func TestStarRocksConnectivity(t *testing.T) {
+	c := startStarRocks(t)
+	var one int
+	if err := c.db.QueryRowContext(c.ctx, "SELECT 1").Scan(&one); err != nil || one != 1 {
+		t.Fatalf("SELECT 1 = %d, err=%v", one, err)
+	}
+}

--- a/starrocks/parser/starrocks_container_test.go
+++ b/starrocks/parser/starrocks_container_test.go
@@ -132,18 +132,20 @@ const syntaxErrMarker = "Getting syntax error"
 
 // accepts reports whether StarRocks accepted sql at the PARSE layer: executed
 // OK, or failed with any non-syntax error (semantic/runtime) — both imply it
-// parsed. Only a "Getting syntax error" message means rejected.
-func (c *srContainer) accepts(sql string) bool {
+// parsed. Only a "Getting syntax error" message means rejected. A non-driver
+// error (connection drop/timeout) is NOT a parse verdict — it's returned so the
+// caller fails the test rather than silently passing an accept it never proved.
+func (c *srContainer) accepts(sql string) (bool, error) {
 	ctx, cancel := context.WithTimeout(c.ctx, 8*time.Second)
 	defer cancel()
 	_, err := c.db.ExecContext(ctx, sql)
 	if err == nil {
-		return true
+		return true, nil
 	}
 	if myErr, ok := err.(*gomysql.MySQLError); ok {
-		return !strings.Contains(myErr.Message, syntaxErrMarker)
+		return !strings.Contains(myErr.Message, syntaxErrMarker), nil
 	}
-	return true // non-driver error (conn/timeout) — treat as accepted
+	return false, fmt.Errorf("non-driver error (cannot determine parse verdict): %w", err)
 }
 
 // assertParity asserts the omni parser and StarRocks agree on sql (both accept
@@ -152,7 +154,10 @@ func (c *srContainer) assertParity(t *testing.T, sql string, wantAccept bool) {
 	t.Helper()
 	_, errs := Parse(sql)
 	omni := len(errs) == 0
-	sr := c.accepts(sql)
+	sr, err := c.accepts(sql)
+	if err != nil {
+		t.Fatalf("StarRocks oracle could not verdict %q: %v", sql, err)
+	}
 	if omni != sr {
 		t.Errorf("MISMATCH %q: omni=%v starrocks=%v (omniErrs=%v)", sql, omni, sr, errs)
 	}


### PR DESCRIPTION
## What

PR2a of the StarRocks scoped-engine epic (BYT-9140). Lifts the highest-frequency CREATE TABLE divergences where StarRocks 3.4 diverges from doris, so `resource-change` (schema sync) and `query-span` stop bailing on real StarRocks DDL.

| # | Feature | Approach |
|---|---|---|
| 10 | `PERCENTILE` type + `PERCENTILE_UNION` agg-type | new keywords + type/agg dispatch (doris uses QUANTILE) |
| 13 | batch range partition `START..END..EVERY` | `parseBatchRangePartition`, reuses the `IsStep` fields (doris uses `FROM..TO..INTERVAL`) |
| 11 | generated col `c TYPE AS (expr)` | `kwAS` arm alongside the doris `GENERATED ALWAYS AS` arm |
| 12 | `DEFAULT (expr)` | parenthesized-expression arm in the default-value parser |

**Divergence, not removal:** every StarRocks arm is added *alongside* the doris form (distinguishable lead token — `AS` vs `GENERATED`, `START` vs `FROM`), so the 1059 inherited doris-regression tests stay green and the shared core is untouched. Per the agreed skip-prune, the doris over-accepts are harmless (no Bytebase consumer reads rejection).

## Tests

- TDD per feature (RED→GREEN), container-verified accept on StarRocks 3.4.
- `TestPR2aParity` — `testing.Short()`-gated container matrix asserting omni and StarRocks agree on each accept + the `START..END`-without-`EVERY` sibling-reject. Skipped under CI's `go test -short ./...`.
- Re-adds the gated `startStarRocks` harness (message-based classifier: StarRocks codes analyzing errors as 1064 too, so we key on the "Getting syntax error" message).

~116 production lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)