### PR TITLE
feat(starrocks/parser): CREATE/ALTER TABLE divergences part 2 — inline index, ROLLUP FROM, CTAS name-list, struct field (PR2b)

### DIFF
--- a/starrocks/ast/ddlnodes.go
+++ b/starrocks/ast/ddlnodes.go
@@ -43,6 +43,7 @@ type CreateTableStmt struct {
 	Comment       string            // COMMENT 'xxx'
 	Like          *ObjectName       // CREATE TABLE ... LIKE other_table
 	AsSelect      *RawQuery         // CREATE TABLE ... AS SELECT ...
+	CTASColumns   []string          // CTAS column-name list: CREATE TABLE t (a, b) AS SELECT ...
 	Loc           Loc
 }
 

--- a/starrocks/ast/ddlnodes.go
+++ b/starrocks/ast/ddlnodes.go
@@ -223,6 +223,8 @@ const (
 	AlterAddColumn                          // ADD COLUMN col_def [AFTER col | FIRST]
 	AlterDropColumn                         // DROP COLUMN col
 	AlterModifyColumn                       // MODIFY COLUMN col_def [AFTER col | FIRST]
+	AlterModifyColumnAddField               // MODIFY COLUMN col ADD FIELD name type [FIRST|AFTER f]
+	AlterModifyColumnDropField              // MODIFY COLUMN col DROP FIELD path
 	AlterRenameColumn                       // RENAME COLUMN old TO new (or old new)
 	AlterRenameTable                        // RENAME TO new_name (or RENAME new_name)
 	AlterRenameRollup                       // RENAME ROLLUP old new
@@ -254,6 +256,9 @@ type AlterTableAction struct {
 	NewName    string     // for RENAME COLUMN (new name) or RENAME ROLLUP/PARTITION
 	After      string     // optional AFTER column name
 	First      bool       // FIRST position flag
+	// Struct-field actions (MODIFY COLUMN col ADD/DROP FIELD):
+	FieldName string    // field name (ADD) or dotted field path (DROP)
+	FieldType *TypeName // field type (ADD FIELD only)
 	// Rename table:
 	NewTableName *ObjectName // for RENAME TO new_name
 	// Partition actions:

--- a/starrocks/ast/ddlnodes.go
+++ b/starrocks/ast/ddlnodes.go
@@ -189,6 +189,7 @@ type RollupDef struct {
 	Name       string
 	Columns    []string
 	DupKeys    []string    // optional DUPLICATE KEY columns
+	FromRollup string      // optional FROM <base_rollup> (StarRocks)
 	Properties []*Property // optional PROPERTIES
 	Loc        Loc
 }

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -266,6 +266,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.Column != nil {
 			Walk(v, n.Column)
 		}
+		if n.FieldType != nil {
+			Walk(v, n.FieldType)
+		}
 		if n.NewTableName != nil {
 			Walk(v, n.NewTableName)
 		}

--- a/starrocks/parser/alter_table.go
+++ b/starrocks/parser/alter_table.go
@@ -215,6 +215,75 @@ func (p *Parser) parseColumnPosition(action *ast.AlterTableAction) {
 	}
 }
 
+// parseModifyColumnField parses StarRocks struct-field evolution, with cur at
+// the struct column identifier:
+//
+//	col ADD FIELD field type [FIRST | AFTER f]
+//	col DROP FIELD path
+func (p *Parser) parseModifyColumnField(action *ast.AlterTableAction) (*ast.AlterTableAction, error) {
+	colName, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	action.ColumnName = colName
+
+	switch p.cur.Kind {
+	case kwADD:
+		p.advance() // consume ADD
+		if _, err := p.expect(kwFIELD); err != nil {
+			return nil, err
+		}
+		action.Type = ast.AlterModifyColumnAddField
+		fieldName, err := p.parseFieldPath()
+		if err != nil {
+			return nil, err
+		}
+		action.FieldName = fieldName
+		fieldType, err := p.parseDataType()
+		if err != nil {
+			return nil, err
+		}
+		action.FieldType = fieldType
+		action.Loc.End = ast.NodeLoc(fieldType).End
+		p.parseColumnPosition(action) // optional FIRST | AFTER f
+
+	case kwDROP:
+		p.advance() // consume DROP
+		if _, err := p.expect(kwFIELD); err != nil {
+			return nil, err
+		}
+		action.Type = ast.AlterModifyColumnDropField
+		path, err := p.parseFieldPath()
+		if err != nil {
+			return nil, err
+		}
+		action.FieldName = path
+		action.Loc.End = p.prev.Loc.End
+
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	return action, nil
+}
+
+// parseFieldPath parses a struct field name, possibly dotted: ident ('.' ident)*.
+func (p *Parser) parseFieldPath() (string, error) {
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		return "", err
+	}
+	for p.cur.Kind == int('.') {
+		p.advance()
+		part, _, err := p.parseIdentifier()
+		if err != nil {
+			return "", err
+		}
+		name = name + "." + part
+	}
+	return name, nil
+}
+
 // parsePartitionItemNoKeyword parses a single partition definition where the
 // leading PARTITION keyword has already been consumed. cur is the partition name
 // (or IF for IF NOT EXISTS).
@@ -503,6 +572,11 @@ func (p *Parser) parseAlterModify(action *ast.AlterTableAction) (*ast.AlterTable
 			}
 			action.Loc.End = p.prev.Loc.End
 			return action, nil
+		}
+		// StarRocks struct evolution: MODIFY COLUMN col ADD/DROP FIELD ...
+		// (after the column name, ADD/DROP can only begin a FIELD op here).
+		if isIdentifierToken(p.cur.Kind) && (p.peekNext().Kind == kwADD || p.peekNext().Kind == kwDROP) {
+			return p.parseModifyColumnField(action)
 		}
 		col, err := p.parseColumnDef()
 		if err != nil {

--- a/starrocks/parser/alter_table.go
+++ b/starrocks/parser/alter_table.go
@@ -267,21 +267,40 @@ func (p *Parser) parseModifyColumnField(action *ast.AlterTableAction) (*ast.Alte
 	return action, nil
 }
 
-// parseFieldPath parses a struct field name, possibly dotted: ident ('.' ident)*.
+// parseFieldPath parses a struct-field path: segment ('.' segment)* where each
+// segment is an identifier or the array-element marker [*] (StarRocks
+// nestedFieldName / subfieldName), e.g. c2.[*].v3.
 func (p *Parser) parseFieldPath() (string, error) {
-	name, _, err := p.parseIdentifier()
+	path, err := p.parseFieldSegment()
 	if err != nil {
 		return "", err
 	}
 	for p.cur.Kind == int('.') {
 		p.advance()
-		part, _, err := p.parseIdentifier()
+		seg, err := p.parseFieldSegment()
 		if err != nil {
 			return "", err
 		}
-		name = name + "." + part
+		path = path + "." + seg
 	}
-	return name, nil
+	return path, nil
+}
+
+// parseFieldSegment parses one struct-field path segment: an identifier or the
+// array-element traversal marker [*].
+func (p *Parser) parseFieldSegment() (string, error) {
+	if p.cur.Kind == int('[') {
+		p.advance() // consume [
+		if _, err := p.expect(int('*')); err != nil {
+			return "", err
+		}
+		if _, err := p.expect(int(']')); err != nil {
+			return "", err
+		}
+		return "[*]", nil
+	}
+	name, _, err := p.parseIdentifier()
+	return name, err
 }
 
 // parsePartitionItemNoKeyword parses a single partition definition where the

--- a/starrocks/parser/alter_table_test.go
+++ b/starrocks/parser/alter_table_test.go
@@ -153,6 +153,43 @@ func TestAlterTableDropColumn(t *testing.T) {
 
 // ---- MODIFY COLUMN ----
 
+// StarRocks struct-field evolution (BYT-9140 PR2b #17):
+// MODIFY COLUMN col ADD FIELD name type [FIRST|AFTER f] / DROP FIELD path.
+func TestAlterTableModifyColumnStructField(t *testing.T) {
+	runAlterTableTests(t, []alterTableTestCase{
+		{
+			sql: "ALTER TABLE t MODIFY COLUMN s ADD FIELD f4 DOUBLE AFTER f2",
+			check: func(t *testing.T, stmt *ast.AlterTableStmt) {
+				a := stmt.Actions[0]
+				if a.Type != ast.AlterModifyColumnAddField {
+					t.Errorf("type=%v, want AlterModifyColumnAddField", a.Type)
+				}
+				if a.ColumnName != "s" || a.FieldName != "f4" {
+					t.Errorf("col=%q field=%q, want s/f4", a.ColumnName, a.FieldName)
+				}
+				if a.FieldType == nil || a.FieldType.Name != "DOUBLE" {
+					t.Errorf("FieldType=%v, want DOUBLE", a.FieldType)
+				}
+				if a.After != "f2" {
+					t.Errorf("After=%q, want f2", a.After)
+				}
+			},
+		},
+		{
+			sql: "ALTER TABLE t MODIFY COLUMN s DROP FIELD nested",
+			check: func(t *testing.T, stmt *ast.AlterTableStmt) {
+				a := stmt.Actions[0]
+				if a.Type != ast.AlterModifyColumnDropField {
+					t.Errorf("type=%v, want AlterModifyColumnDropField", a.Type)
+				}
+				if a.ColumnName != "s" || a.FieldName != "nested" {
+					t.Errorf("col=%q field=%q, want s/nested", a.ColumnName, a.FieldName)
+				}
+			},
+		},
+	})
+}
+
 func TestAlterTableModifyColumn(t *testing.T) {
 	cases := []alterTableTestCase{
 		{

--- a/starrocks/parser/alter_table_test.go
+++ b/starrocks/parser/alter_table_test.go
@@ -190,6 +190,25 @@ func TestAlterTableModifyColumnStructField(t *testing.T) {
 	})
 }
 
+// #289 P2: struct-field paths can include array-element traversal [*],
+// e.g. DROP FIELD c2.[*].v3 (subfieldName: identifier | ARRAY_ELEMENT).
+func TestAlterTableModifyColumnDropFieldArrayPath(t *testing.T) {
+	runAlterTableTests(t, []alterTableTestCase{
+		{
+			sql: "ALTER TABLE t MODIFY COLUMN c2 DROP FIELD c2.[*].v3",
+			check: func(t *testing.T, stmt *ast.AlterTableStmt) {
+				a := stmt.Actions[0]
+				if a.Type != ast.AlterModifyColumnDropField {
+					t.Errorf("type=%v, want AlterModifyColumnDropField", a.Type)
+				}
+				if a.FieldName != "c2.[*].v3" {
+					t.Errorf("FieldName=%q, want c2.[*].v3", a.FieldName)
+				}
+			},
+		},
+	})
+}
+
 func TestAlterTableModifyColumn(t *testing.T) {
 	cases := []alterTableTestCase{
 		{

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -535,7 +535,9 @@ func (p *Parser) parseInlineIndexDef() (*ast.IndexDef, error) {
 		}
 		idx.Properties = props
 		idx.Loc.End = p.prev.Loc.End
-	} else if p.cur.Kind == int('(') {
+	} else if idx.IndexType != "" && p.cur.Kind == int('(') {
+		// The bare property list is only valid AFTER an index type
+		// (grammar: indexType propertyList?) — not on its own.
 		props, err := p.parsePropertyList()
 		if err != nil {
 			return nil, err
@@ -1110,8 +1112,8 @@ func (p *Parser) parseBatchRangePartition(startLoc ast.Loc) (*ast.PartitionItem,
 
 	// Optional interval unit (date ranges).
 	if p.cur.Kind == kwDAY || p.cur.Kind == kwWEEK || p.cur.Kind == kwMONTH ||
-		p.cur.Kind == kwYEAR || p.cur.Kind == kwHOUR || p.cur.Kind == kwMINUTE ||
-		p.cur.Kind == kwSECOND || p.cur.Kind == tokIdent {
+		p.cur.Kind == kwQUARTER || p.cur.Kind == kwYEAR || p.cur.Kind == kwHOUR ||
+		p.cur.Kind == kwMINUTE || p.cur.Kind == kwSECOND || p.cur.Kind == tokIdent {
 		item.IntervalUnit = strings.ToUpper(p.cur.Str)
 		item.Loc.End = p.cur.Loc.End
 		p.advance()

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -105,6 +105,17 @@ func (p *Parser) parseColumnDefsBlock(stmt *ast.CreateTableStmt) error {
 		return err
 	}
 
+	// StarRocks CTAS column-name list: ( ident (, ident)* (, indexDesc)* ) AS query.
+	// A CTAS column carries NO type/attributes, so its name is followed by `,`
+	// or `)`; a full-def column name is followed by a type. The token sets are
+	// disjoint, so a 2-token peek (first ident + the token after it) classifies
+	// the whole block — no backtracking needed.
+	if isIdentifierToken(p.cur.Kind) {
+		if nx := p.peekNext().Kind; nx == int(',') || nx == int(')') {
+			return p.parseCTASColumnNames(stmt)
+		}
+	}
+
 	// Parse column defs and index defs.
 	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
 		// Check if this is an INDEX definition
@@ -135,6 +146,39 @@ func (p *Parser) parseColumnDefsBlock(stmt *ast.CreateTableStmt) error {
 		}
 	}
 
+	if _, err := p.expect(int(')')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseCTASColumnNames parses a StarRocks CTAS column-name list, with cur at the
+// first identifier inside the already-consumed '(':
+//
+//	ident (, ident)* (, indexDesc)* ')'
+//
+// Names go to stmt.CTASColumns; trailing INDEX entries reuse the inline-index
+// parser. The AS query tail is parsed later by parseCreateTableClauses.
+func (p *Parser) parseCTASColumnNames(stmt *ast.CreateTableStmt) error {
+	for p.cur.Kind != int(')') && p.cur.Kind != tokEOF {
+		if p.cur.Kind == kwINDEX {
+			idx, err := p.parseInlineIndexDef()
+			if err != nil {
+				return err
+			}
+			stmt.Indexes = append(stmt.Indexes, idx)
+		} else {
+			name, _, err := p.parseIdentifier()
+			if err != nil {
+				return err
+			}
+			stmt.CTASColumns = append(stmt.CTASColumns, name)
+		}
+
+		if p.cur.Kind == int(',') {
+			p.advance()
+		}
+	}
 	if _, err := p.expect(int(')')); err != nil {
 		return err
 	}

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -473,9 +473,17 @@ func (p *Parser) parseInlineIndexDef() (*ast.IndexDef, error) {
 		p.advance()
 	}
 
-	// Optional PROPERTIES(...)
+	// Optional index property list: PROPERTIES("k"="v", ...) or the StarRocks
+	// bare form ("k"="v", ...) immediately after the index type.
 	if p.cur.Kind == kwPROPERTIES {
 		props, err := p.parseProperties()
+		if err != nil {
+			return nil, err
+		}
+		idx.Properties = props
+		idx.Loc.End = p.prev.Loc.End
+	} else if p.cur.Kind == int('(') {
+		props, err := p.parsePropertyList()
 		if err != nil {
 			return nil, err
 		}

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -91,6 +91,15 @@ func (p *Parser) parseCreateTable() (ast.Node, error) {
 		return nil, err
 	}
 
+	// A column-name list (no column types) is valid ONLY as CTAS — it requires
+	// an AS <query>. Without it the statement is invalid (StarRocks rejects it).
+	if len(stmt.CTASColumns) > 0 && stmt.AsSelect == nil {
+		return nil, &ParseError{
+			Loc: p.cur.Loc,
+			Msg: "column-name list requires AS <query> (CTAS)",
+		}
+	}
+
 	// Compute location.
 	stmt.Loc = startLoc.Merge(p.prev.Loc)
 	return stmt, nil

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -1361,6 +1361,17 @@ func (p *Parser) parseRollupDef() (*ast.RollupDef, error) {
 		rd.Loc.End = closeTok.Loc.End
 	}
 
+	// Optional FROM <base_rollup> (StarRocks: build this rollup from another).
+	if p.cur.Kind == kwFROM {
+		p.advance() // consume FROM
+		base, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		rd.FromRollup = base
+		rd.Loc.End = p.prev.Loc.End
+	}
+
 	// Optional PROPERTIES
 	if p.cur.Kind == kwPROPERTIES {
 		props, err := p.parseProperties()

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -173,6 +173,44 @@ func TestCreateTable_RollupFrom(t *testing.T) {
 	}
 }
 
+// StarRocks CTAS with a column-name list (BYT-9140 PR2b #16): the parenthesized
+// list is names-only (no types), distinguished from full column-defs by a
+// 2-token peek (a CTAS name is followed by , or ) ; a full-def name by a type).
+func TestCreateTable_CTASNameList(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE ck (new_id, new_name) DISTRIBUTED BY HASH(new_id) BUCKETS 8 AS SELECT k AS new_id, v AS new_name FROM smoke_t")
+	if len(stmt.CTASColumns) != 2 || stmt.CTASColumns[0] != "new_id" || stmt.CTASColumns[1] != "new_name" {
+		t.Fatalf("CTASColumns=%v, want [new_id new_name]", stmt.CTASColumns)
+	}
+	if stmt.AsSelect == nil {
+		t.Errorf("expected AsSelect set")
+	}
+}
+
+func TestCreateTable_CTASNameListSingle(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE ck1 (a) DISTRIBUTED BY HASH(a) AS SELECT k AS a FROM smoke_t")
+	if len(stmt.CTASColumns) != 1 || stmt.CTASColumns[0] != "a" {
+		t.Errorf("CTASColumns=%v, want [a]", stmt.CTASColumns)
+	}
+}
+
+func TestCreateTable_CTASNameListWithIndex(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE ck2 (a, b, INDEX idx_b (b) USING BITMAP) DISTRIBUTED BY HASH(a) AS SELECT k AS a, v AS b FROM smoke_t")
+	if len(stmt.CTASColumns) != 2 {
+		t.Errorf("CTASColumns=%v, want [a b]", stmt.CTASColumns)
+	}
+	if len(stmt.Indexes) != 1 {
+		t.Errorf("expected 1 trailing index, got %d", len(stmt.Indexes))
+	}
+}
+
+// Regression: full column-defs still parse as defs (not name-list).
+func TestCreateTable_FullDefsStillParse(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE reg (a INT, b VARCHAR(20)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1")
+	if len(stmt.Columns) != 2 || len(stmt.CTASColumns) != 0 {
+		t.Errorf("Columns=%d CTASColumns=%d, want 2/0", len(stmt.Columns), len(stmt.CTASColumns))
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -225,6 +225,24 @@ func TestCreateTable_FullDefsStillParse(t *testing.T) {
 	}
 }
 
+// Boundary sweep: a bare index property list is valid ONLY after a USING index
+// type (grammar: indexType propertyList?); props without USING is invalid.
+func TestCreateTable_InlineIndexPropsRequireUsing(t *testing.T) {
+	_, errs := Parse("CREATE TABLE t (k INT, INDEX idx (k) ('parser' = 'english')) DISTRIBUTED BY HASH(k)")
+	if len(errs) == 0 {
+		t.Error("expected index property list without USING to be rejected")
+	}
+}
+
+// Boundary sweep: QUARTER is a valid batch-partition interval unit (it's a
+// keyword, so it bypassed the tokIdent fallback in the unit set).
+func TestCreateTable_BatchRangePartitionQuarter(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE t (k DATE, v INT) DUPLICATE KEY(k) PARTITION BY RANGE(k) (START ('2020-01-01') END ('2021-01-01') EVERY (INTERVAL 1 QUARTER)) DISTRIBUTED BY HASH(v)")
+	if got := stmt.PartitionBy.Partitions[0].IntervalUnit; got != "QUARTER" {
+		t.Errorf("IntervalUnit=%q, want QUARTER", got)
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -161,6 +161,18 @@ func TestCreateTable_InlineIndexGINProps(t *testing.T) {
 	}
 }
 
+// StarRocks ROLLUP FROM <base_rollup> (BYT-9140 PR2b #15): build a rollup from
+// another rollup. Inline ROLLUP(...) + DUPLICATE KEY already parse; gap is FROM.
+func TestCreateTable_RollupFrom(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE rl (k1 INT, k2 INT, v BIGINT SUM) AGGREGATE KEY(k1,k2) DISTRIBUTED BY HASH(k1) ROLLUP (r1 (k1,v), r2 (k2,v) FROM r1)")
+	if len(stmt.Rollup) != 2 {
+		t.Fatalf("expected 2 rollups, got %d", len(stmt.Rollup))
+	}
+	if stmt.Rollup[1].FromRollup != "r1" {
+		t.Errorf("Rollup[1].FromRollup=%q, want r1", stmt.Rollup[1].FromRollup)
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -143,6 +143,24 @@ func TestCreateTable_DefaultExpr(t *testing.T) {
 	}
 }
 
+// StarRocks inline index with a bare property list after the index type
+// (BYT-9140 PR2b #14): INDEX i (c) USING GIN ('k'='v'). GIN/VECTOR lex as
+// identifiers (USING already accepts any), so the gap is only the bare (...)
+// property list (distinct from the PROPERTIES(...) form).
+func TestCreateTable_InlineIndexGINProps(t *testing.T) {
+	stmt := parseCreateTableStmt(t, "CREATE TABLE ix (id BIGINT, name VARCHAR(64), tags VARCHAR(255), INDEX idx_name (name) USING BITMAP COMMENT 'x', INDEX idx_tags (tags) USING GIN ('parser'='english')) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id)")
+	if len(stmt.Indexes) != 2 {
+		t.Fatalf("expected 2 inline indexes, got %d", len(stmt.Indexes))
+	}
+	gin := stmt.Indexes[1]
+	if gin.IndexType != "gin" {
+		t.Errorf("IndexType=%q, want gin", gin.IndexType)
+	}
+	if len(gin.Properties) != 1 || gin.Properties[0].Key != "parser" || gin.Properties[0].Value != "english" {
+		t.Errorf("Properties=%v, want [parser=english]", gin.Properties)
+	}
+}
+
 func TestCreateTable_WithNotNullDefault(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE t (id INT NOT NULL DEFAULT 0, name VARCHAR(50) NULL)")
 	if len(stmt.Columns) != 2 {

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -203,6 +203,20 @@ func TestCreateTable_CTASNameListWithIndex(t *testing.T) {
 	}
 }
 
+// #289 P3: a column-name list (no types) is valid ONLY as CTAS; without AS
+// SELECT it is invalid DDL and StarRocks rejects it — so must omni.
+func TestCreateTable_CTASNameListRequiresAsSelect(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE tnoas (a)",
+		"CREATE TABLE tnoas2 (a) DISTRIBUTED BY HASH(a) BUCKETS 1",
+		"CREATE TABLE tnoas3 (a, b) DISTRIBUTED BY HASH(a)",
+	} {
+		if _, errs := Parse(sql); len(errs) == 0 {
+			t.Errorf("expected %q to be rejected (name-list without AS SELECT)", sql)
+		}
+	}
+}
+
 // Regression: full column-defs still parse as defs (not name-list).
 func TestCreateTable_FullDefsStillParse(t *testing.T) {
 	stmt := parseCreateTableStmt(t, "CREATE TABLE reg (a INT, b VARCHAR(20)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1")

--- a/starrocks/parser/database.go
+++ b/starrocks/parser/database.go
@@ -169,7 +169,13 @@ func (p *Parser) parseDropDatabase() (ast.Node, error) {
 // cur must be kwPROPERTIES on entry; it is consumed here.
 func (p *Parser) parseProperties() ([]*ast.Property, error) {
 	p.advance() // consume PROPERTIES
+	return p.parsePropertyList()
+}
 
+// parsePropertyList parses a bare ('key'='value', ...) list; cur must be '('
+// on entry. Shared by parseProperties (after the PROPERTIES keyword) and the
+// bare index-property list (StarRocks `USING GIN ('k'='v')`).
+func (p *Parser) parsePropertyList() ([]*ast.Property, error) {
 	if _, err := p.expect(int('(')); err != nil {
 		return nil, err
 	}

--- a/starrocks/parser/keywords.go
+++ b/starrocks/parser/keywords.go
@@ -182,6 +182,7 @@ const (
 	kwFALSE
 	kwFAST
 	kwFEATURE
+	kwFIELD
 	kwFIELDS
 	kwFILE
 	kwFILTER
@@ -722,6 +723,7 @@ var keywordMap = map[string]TokenKind{
 	"false":                                kwFALSE,
 	"fast":                                 kwFAST,
 	"feature":                              kwFEATURE,
+	"field":                                kwFIELD,
 	"fields":                               kwFIELDS,
 	"file":                                 kwFILE,
 	"filter":                               kwFILTER,
@@ -1202,6 +1204,7 @@ var nonReservedKeywords = map[TokenKind]bool{
 	kwFAILED_LOGIN_ATTEMPTS:  true,
 	kwFAST:                   true,
 	kwFEATURE:                true,
+	kwFIELD:                  true,
 	kwFIELDS:                 true,
 	kwFILE:                   true,
 	kwFILTER:                 true,

--- a/starrocks/parser/pr2b_oracle_test.go
+++ b/starrocks/parser/pr2b_oracle_test.go
@@ -1,0 +1,65 @@
+package parser
+
+import "testing"
+
+// TestPR2bParity is the container-grounded conformance matrix for the PR2b
+// CREATE/ALTER TABLE divergences (#14–17): each StarRocks construct is asserted
+// accepted by BOTH the omni parser and StarRocks 3.4, plus regressions proving
+// the new branches don't break the pre-existing forms. Short-gated via
+// startStarRocks.
+func TestPR2bParity(t *testing.T) {
+	c := startStarRocks(t)
+
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		{
+			"inline_index_gin_props",
+			"CREATE TABLE ix (id BIGINT, name VARCHAR(64), tags VARCHAR(255), INDEX idx_name (name) USING BITMAP COMMENT 'x', INDEX idx_tags (tags) USING GIN ('parser'='english')) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id)",
+			true,
+		},
+		{
+			"rollup_from",
+			"CREATE TABLE rl (k1 INT, k2 INT, v BIGINT SUM) AGGREGATE KEY(k1,k2) DISTRIBUTED BY HASH(k1) ROLLUP (r1 (k1,v), r2 (k2,v) FROM r1)",
+			true,
+		},
+		{
+			"ctas_name_list",
+			"CREATE TABLE ck (new_id, new_name) DISTRIBUTED BY HASH(new_id) BUCKETS 8 AS SELECT k AS new_id, v AS new_name FROM smoke_t",
+			true,
+		},
+		{
+			"ctas_name_list_with_index",
+			"CREATE TABLE ck2 (a, b, INDEX idx_b (b) USING BITMAP) DISTRIBUTED BY HASH(a) AS SELECT k AS a, v AS b FROM smoke_t",
+			true,
+		},
+		{
+			"full_defs_regression", // full column-defs still parse, not name-list
+			"CREATE TABLE reg (a INT, b VARCHAR(20)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1",
+			true,
+		},
+		{
+			"alter_add_field",
+			"ALTER TABLE t MODIFY COLUMN s ADD FIELD f4 DOUBLE AFTER f2",
+			true,
+		},
+		{
+			"alter_drop_field",
+			"ALTER TABLE t MODIFY COLUMN s DROP FIELD nested",
+			true,
+		},
+		{
+			"alter_modify_column_regression", // plain MODIFY COLUMN col TYPE still parses
+			"ALTER TABLE t MODIFY COLUMN c BIGINT",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}

--- a/starrocks/parser/pr2b_oracle_test.go
+++ b/starrocks/parser/pr2b_oracle_test.go
@@ -51,6 +51,16 @@ func TestPR2bParity(t *testing.T) {
 			true,
 		},
 		{
+			"alter_drop_field_array_path", // #289 P2
+			"ALTER TABLE t MODIFY COLUMN c2 DROP FIELD c2.[*].v3",
+			true,
+		},
+		{
+			"ctas_name_list_requires_as_select", // #289 P3: invalid without AS query
+			"CREATE TABLE tnoas (a) DISTRIBUTED BY HASH(a) BUCKETS 1",
+			false,
+		},
+		{
 			"alter_modify_column_regression", // plain MODIFY COLUMN col TYPE still parses
 			"ALTER TABLE t MODIFY COLUMN c BIGINT",
 			true,


### PR DESCRIPTION
## What

PR2b of the StarRocks scoped-engine epic (BYT-9140), building on PR2a (#288). Closes the remaining CREATE/ALTER TABLE divergences so the full schema-DDL surface parses.

| # | Feature | Approach |
|---|---|---|
| 14 | inline index bare property list (`USING GIN ('k'='v')`) | extract `parsePropertyList` (DRY) + accept the bare form; no new keyword (GIN/VECTOR lex as idents, USING already takes any) |
| 15 | ROLLUP `FROM <base_rollup>` | `RollupDef.FromRollup` (walk-inert string) + the FROM arm |
| 16 | CTAS column-name list | **bounded 2-token peek** (CTAS name → `,`/`)`, full-def name → type; disjoint, no backtracking); `CTASColumns` |
| 17 | ALTER `MODIFY COLUMN col ADD/DROP FIELD` | `kwFIELD`, 2 action types, `FieldName`/`FieldType` (the `*TypeName` is walked in `walk_children`), dotted `parseFieldPath` |

**Additive, not removal:** every StarRocks arm sits alongside the doris form (distinguishable lead token), so the 1059 inherited doris-regression tests stay green; the doris over-accepts (`GENERATED ALWAYS AS`, `FROM..TO..INTERVAL`) are documented and left under skip-prune.

After 2a+2b, the full CREATE/ALTER TABLE divergence corpus closes (GAP=0).

## Tests

- TDD per feature (RED→GREEN), container-verified accept on StarRocks 3.4, with full-defs + plain-MODIFY-COLUMN regressions.
- `TestPR2bParity` — Short()-gated container matrix (8/8), reuses the PR2a `startStarRocks` harness. Skipped under CI's `go test -short ./...`.

~157 production lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)