### PR TITLE
fix(mysql): support qualified alter table rename target

### DIFF
--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -2813,6 +2813,10 @@ func writeAlterTableCmd(sb *strings.Builder, n *AlterTableCmd) {
 	if n.NewName != "" {
 		fmt.Fprintf(sb, " :new_name %s", n.NewName)
 	}
+	if n.NewTable != nil {
+		sb.WriteString(" :new_table ")
+		writeNode(sb, n.NewTable)
+	}
 	if n.Column != nil {
 		sb.WriteString(" :col ")
 		writeNode(sb, n.Column)

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -259,6 +259,7 @@ type AlterTableCmd struct {
 	Type           AlterTableCmdType
 	Name           string       // column/constraint/index name
 	NewName        string       // for RENAME operations
+	NewTable       *TableRef    // for RENAME TABLE
 	Column         *ColumnDef   // for ADD/MODIFY/CHANGE COLUMN
 	Columns        []*ColumnDef // for ADD (col1, col2, ...) multi-column form
 	Constraint     *Constraint  // for ADD CONSTRAINT

--- a/mysql/ast/walk_generated.go
+++ b/mysql/ast/walk_generated.go
@@ -27,6 +27,9 @@ func walkChildren(v Visitor, node Node) {
 			}
 		}
 	case *AlterTableCmd:
+		if n.NewTable != nil {
+			Walk(v, n.NewTable)
+		}
 		if n.Column != nil {
 			Walk(v, n.Column)
 		}

--- a/mysql/catalog/altercmds.go
+++ b/mysql/catalog/altercmds.go
@@ -734,19 +734,26 @@ func (c *Catalog) alterRenameIndex(tbl *Table, cmd *nodes.AlterTableCmd) error {
 
 // alterRenameTable moves a table to a new name.
 func (c *Catalog) alterRenameTable(db *Database, tbl *Table, cmd *nodes.AlterTableCmd) error {
-	newName := cmd.NewName
+	newTable := cmd.NewTable
+	if newTable == nil {
+		newTable = &nodes.TableRef{Name: cmd.NewName}
+	}
+	newDB, err := c.resolveDatabase(newTable.Schema)
+	if err != nil {
+		return err
+	}
+	newName := newTable.Name
 	newKey := toLower(newName)
 	oldKey := toLower(tbl.Name)
 
-	if newKey != oldKey {
-		if db.Tables[newKey] != nil {
-			return errDupTable(newName)
-		}
+	if (newDB != db || newKey != oldKey) && newDB.Tables[newKey] != nil {
+		return errDupTable(newName)
 	}
 
 	delete(db.Tables, oldKey)
 	tbl.Name = newName
-	db.Tables[newKey] = tbl
+	tbl.Database = newDB
+	newDB.Tables[newKey] = tbl
 	return nil
 }
 

--- a/mysql/catalog/renamecmds_test.go
+++ b/mysql/catalog/renamecmds_test.go
@@ -38,6 +38,51 @@ func TestRenameTableCrossDatabase(t *testing.T) {
 	}
 }
 
+func TestAlterTableRenameTableCrossDatabase(t *testing.T) {
+	c := New()
+	c.Exec("CREATE DATABASE db1", nil)
+	c.Exec("CREATE DATABASE db2", nil)
+	c.SetCurrentDatabase("db1")
+	c.Exec("CREATE TABLE t1 (id INT)", nil)
+	_, err := c.Exec("ALTER TABLE db1.t1 RENAME TO db2.t2", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.GetDatabase("db1").GetTable("t1") != nil {
+		t.Fatal("old table should not exist in db1")
+	}
+	if c.GetDatabase("db2").GetTable("t2") == nil {
+		t.Fatal("new table should exist in db2")
+	}
+}
+
+func TestAlterTableRenameTableUnknownTargetDatabase(t *testing.T) {
+	c := New()
+	c.Exec("CREATE DATABASE db1", nil)
+	c.SetCurrentDatabase("db1")
+	c.Exec("CREATE TABLE t1 (id INT)", nil)
+	results, err := c.Exec("ALTER TABLE db1.t1 RENAME TO missing.t2", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	assertError(t, results[0].Error, ErrUnknownDatabase)
+}
+
+func TestAlterTableRenameTableDuplicateTarget(t *testing.T) {
+	c := New()
+	c.Exec("CREATE DATABASE db1", nil)
+	c.Exec("CREATE DATABASE db2", nil)
+	c.SetCurrentDatabase("db1")
+	c.Exec("CREATE TABLE t1 (id INT)", nil)
+	c.SetCurrentDatabase("db2")
+	c.Exec("CREATE TABLE t2 (id INT)", nil)
+	results, err := c.Exec("ALTER TABLE db1.t1 RENAME TO db2.t2", nil)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	assertError(t, results[0].Error, ErrDupTable)
+}
+
 func TestRenameTableNotFound(t *testing.T) {
 	c := New()
 	c.Exec("CREATE DATABASE test", nil)

--- a/mysql/parser/alter_table.go
+++ b/mysql/parser/alter_table.go
@@ -874,11 +874,11 @@ func (p *Parser) parseAlterRename(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 		// RENAME [TO | AS] new_tbl_name
 		cmd.Type = nodes.ATRenameTable
 		p.match(kwTO, kwAS)
-		newName, _, err := p.parseIdentifier()
+		newTable, err := p.parseTableRef()
 		if err != nil {
 			return nil, err
 		}
-		cmd.NewName = newName
+		cmd.NewTable = newTable
 	}
 
 	cmd.Loc.End = p.pos()

--- a/mysql/parser/compare_test.go
+++ b/mysql/parser/compare_test.go
@@ -3674,16 +3674,25 @@ func TestParseAlterTableRename(t *testing.T) {
 		if cmd.Type != ast.ATRenameTable {
 			t.Errorf("Type = %d, want ATRenameTable", cmd.Type)
 		}
-		if cmd.NewName != "new_t" {
-			t.Errorf("NewName = %s, want new_t", cmd.NewName)
+		if cmd.NewTable == nil {
+			t.Fatal("NewTable is nil")
+		}
+		if cmd.NewTable.Schema != "" || cmd.NewTable.Name != "new_t" {
+			t.Errorf("NewTable = %v.%v, want .new_t", cmd.NewTable.Schema, cmd.NewTable.Name)
 		}
 	})
 
 	t.Run("rename table as", func(t *testing.T) {
-		stmt := parseAlterTable(t, "ALTER TABLE t RENAME AS new_t")
+		stmt := parseAlterTable(t, "ALTER TABLE t RENAME AS db2.new_t")
 		cmd := stmt.Commands[0]
 		if cmd.Type != ast.ATRenameTable {
 			t.Errorf("Type = %d, want ATRenameTable", cmd.Type)
+		}
+		if cmd.NewTable == nil {
+			t.Fatal("NewTable is nil")
+		}
+		if cmd.NewTable.Schema != "db2" || cmd.NewTable.Name != "new_t" {
+			t.Errorf("NewTable = %v.%v, want db2.new_t", cmd.NewTable.Schema, cmd.NewTable.Name)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Parse ALTER TABLE ... RENAME {TO|AS} target as a TableRef so qualified targets like db.table are preserved in the AST
- Move ATRenameTable catalog updates across databases, including unknown target database and duplicate target table errors
- Add parser/catalog regressions for qualified ALTER TABLE rename targets

## Test Plan
- git diff --check
- DOCKER_HOST=unix:///Users/rebeliceyang/.colima/default/docker.sock TESTCONTAINERS_RYUK_DISABLED=true go test ./mysql/...