### PR TITLE
feat(redshift): add lazy relation resolver

### DIFF
--- a/redshift/catalog/catalog.go
+++ b/redshift/catalog/catalog.go
@@ -129,45 +129,49 @@ type Catalog struct {
 	// partially-defined CTE.
 	// pg: src/backend/parser/analyze.c — determineRecursiveColTypes
 	visibleCTEs []*CommonTableExprQ
+
+	relationResolver        RelationResolver
+	relationResolutionStack map[string]bool
 }
 
 // New creates a fully initialized Catalog with all built-in data indexed.
 func New() *Catalog {
 	c := &Catalog{
-		oidGen:             NewOIDGenerator(),
-		schemas:            make(map[uint32]*Schema),
-		schemaByName:       make(map[string]*Schema),
-		typeByOID:          make(map[uint32]*BuiltinType, len(BuiltinTypes)),
-		typeByName:         make(map[typeKey]*BuiltinType, len(BuiltinTypes)),
-		castIndex:          make(map[castKey]*BuiltinCast, len(BuiltinCasts)),
-		operByOID:          make(map[uint32]*BuiltinOperator, len(BuiltinOperators)),
-		operByKey:          make(map[operKey][]*BuiltinOperator, len(BuiltinOperators)),
-		procByOID:          make(map[uint32]*BuiltinProc, len(BuiltinProcs)),
-		procByName:         make(map[string][]*BuiltinProc),
-		relationByOID:      make(map[uint32]*Relation),
-		constraints:        make(map[uint32]*Constraint),
-		consByRel:          make(map[uint32][]*Constraint),
-		indexes:            make(map[uint32]*Index),
-		indexesByRel:       make(map[uint32][]*Index),
-		sequenceByOID:      make(map[uint32]*Sequence),
-		enumTypes:          make(map[uint32]*EnumType),
-		domainTypes:        make(map[uint32]*DomainType),
-		rangeTypes:         make(map[uint32]*RangeType),
-		userProcs:          make(map[uint32]*UserProc),
-		triggers:           make(map[uint32]*Trigger),
-		triggersByRel:      make(map[uint32][]*Trigger),
-		eventTriggers:      make(map[uint32]*EventTrigger),
-		eventTriggerByName: make(map[string]*EventTrigger),
-		comments:           make(map[commentKey]string),
-		policies:           make(map[uint32]*Policy),
-		policiesByRel:      make(map[uint32][]*Policy),
-		extensions:         make(map[uint32]*Extension),
-		extByName:          make(map[string]*Extension),
-		accessMethods:      make(map[uint32]*AccessMethod),
-		accessMethodByName: make(map[string]*AccessMethod),
-		opFamilies:         make(map[uint32]*OpFamily),
-		opClasses:          make(map[uint32]*OpClass),
-		opClassByKey:       make(map[opClassKey]*OpClass),
+		oidGen:                  NewOIDGenerator(),
+		schemas:                 make(map[uint32]*Schema),
+		schemaByName:            make(map[string]*Schema),
+		typeByOID:               make(map[uint32]*BuiltinType, len(BuiltinTypes)),
+		typeByName:              make(map[typeKey]*BuiltinType, len(BuiltinTypes)),
+		castIndex:               make(map[castKey]*BuiltinCast, len(BuiltinCasts)),
+		operByOID:               make(map[uint32]*BuiltinOperator, len(BuiltinOperators)),
+		operByKey:               make(map[operKey][]*BuiltinOperator, len(BuiltinOperators)),
+		procByOID:               make(map[uint32]*BuiltinProc, len(BuiltinProcs)),
+		procByName:              make(map[string][]*BuiltinProc),
+		relationByOID:           make(map[uint32]*Relation),
+		constraints:             make(map[uint32]*Constraint),
+		consByRel:               make(map[uint32][]*Constraint),
+		indexes:                 make(map[uint32]*Index),
+		indexesByRel:            make(map[uint32][]*Index),
+		sequenceByOID:           make(map[uint32]*Sequence),
+		enumTypes:               make(map[uint32]*EnumType),
+		domainTypes:             make(map[uint32]*DomainType),
+		rangeTypes:              make(map[uint32]*RangeType),
+		userProcs:               make(map[uint32]*UserProc),
+		triggers:                make(map[uint32]*Trigger),
+		triggersByRel:           make(map[uint32][]*Trigger),
+		eventTriggers:           make(map[uint32]*EventTrigger),
+		eventTriggerByName:      make(map[string]*EventTrigger),
+		comments:                make(map[commentKey]string),
+		policies:                make(map[uint32]*Policy),
+		policiesByRel:           make(map[uint32][]*Policy),
+		extensions:              make(map[uint32]*Extension),
+		extByName:               make(map[string]*Extension),
+		accessMethods:           make(map[uint32]*AccessMethod),
+		accessMethodByName:      make(map[string]*AccessMethod),
+		opFamilies:              make(map[uint32]*OpFamily),
+		opClasses:               make(map[uint32]*OpClass),
+		opClassByKey:            make(map[opClassKey]*OpClass),
+		relationResolutionStack: make(map[string]bool),
 	}
 
 	// Index types.
@@ -222,6 +226,12 @@ func New() *Catalog {
 	c.searchPath = []string{"public"}
 
 	return c
+}
+
+// SetRelationResolver installs a lazy relation resolver used when relation
+// lookup misses the in-memory catalog.
+func (c *Catalog) SetRelationResolver(resolver RelationResolver) {
+	c.relationResolver = resolver
 }
 
 func (c *Catalog) addBuiltinSchema(oid uint32, name string) {

--- a/redshift/catalog/clone.go
+++ b/redshift/catalog/clone.go
@@ -414,5 +414,8 @@ func (c *Catalog) Clone() *Catalog {
 	// Warnings: start clean (not copied from source).
 	// clone.warnings is nil by default.
 
+	clone.relationResolver = c.relationResolver
+	clone.relationResolutionStack = make(map[string]bool)
+
 	return clone
 }

--- a/redshift/catalog/relation.go
+++ b/redshift/catalog/relation.go
@@ -96,16 +96,33 @@ type Relation struct {
 
 // findRelation locates a relation by schema (or search path) and name.
 func (c *Catalog) findRelation(schemaName, relName string) (*Schema, *Relation, error) {
+	if schema, rel := c.lookupRelation(schemaName, relName); rel != nil {
+		return schema, rel, nil
+	}
+	if err := c.resolveMissingRelation(schemaName, relName); err != nil {
+		return nil, nil, err
+	}
+	if schema, rel := c.lookupRelation(schemaName, relName); rel != nil {
+		return schema, rel, nil
+	}
+
 	if schemaName != "" {
 		s := c.schemaByName[schemaName]
 		if s == nil {
 			return nil, nil, errUndefinedSchema(schemaName)
 		}
-		r := s.Relations[relName]
-		if r == nil {
-			return nil, nil, errUndefinedTable(relName)
+		return nil, nil, errUndefinedTable(relName)
+	}
+	return nil, nil, errUndefinedTable(relName)
+}
+
+func (c *Catalog) lookupRelation(schemaName, relName string) (*Schema, *Relation) {
+	if schemaName != "" {
+		s := c.schemaByName[schemaName]
+		if s == nil {
+			return nil, nil
 		}
-		return s, r, nil
+		return s, s.Relations[relName]
 	}
 	for _, nsOID := range c.searchPathWithCatalog() {
 		s := c.schemas[nsOID]
@@ -113,10 +130,10 @@ func (c *Catalog) findRelation(schemaName, relName string) (*Schema, *Relation, 
 			continue
 		}
 		if r := s.Relations[relName]; r != nil {
-			return s, r, nil
+			return s, r
 		}
 	}
-	return nil, nil, errUndefinedTable(relName)
+	return nil, nil
 }
 
 // findRelByOID locates a relation by its OID across all schemas.

--- a/redshift/catalog/relation_resolver.go
+++ b/redshift/catalog/relation_resolver.go
@@ -1,0 +1,196 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	nodes "github.com/bytebase/omni/redshift/ast"
+	pgparser "github.com/bytebase/omni/redshift/parser"
+)
+
+const (
+	RelationKindTable            byte = 'r'
+	RelationKindView             byte = 'v'
+	RelationKindMaterializedView byte = 'm'
+)
+
+// RelationResolver lazily supplies relation metadata for catalog misses.
+type RelationResolver interface {
+	ResolveRelation(schemaName, relationName string, searchPath []string) (*RelationSpec, error)
+}
+
+// RelationSpec describes a relation returned by a RelationResolver.
+type RelationSpec struct {
+	SchemaName string
+	Name       string
+	Kind       byte
+	Columns    []RelationColumnSpec
+
+	// Definition is the SELECT definition for a view or materialized view.
+	Definition string
+}
+
+// RelationColumnSpec describes one relation column in a resolver result.
+type RelationColumnSpec struct {
+	Name string
+	Type string
+}
+
+func (c *Catalog) resolveMissingRelation(schemaName, relName string) error {
+	if c.relationResolver == nil {
+		return nil
+	}
+
+	requestKey := relationResolutionKey(schemaName, relName)
+	if c.relationResolutionStack[requestKey] {
+		return errCyclicRelationResolution(requestKey)
+	}
+	c.relationResolutionStack[requestKey] = true
+	defer delete(c.relationResolutionStack, requestKey)
+
+	searchPath := append([]string(nil), c.searchPath...)
+	spec, err := c.relationResolver.ResolveRelation(schemaName, relName, searchPath)
+	if err != nil {
+		return err
+	}
+	if spec == nil {
+		return nil
+	}
+
+	spec = normalizeRelationSpec(spec, schemaName, relName)
+	specKey := relationResolutionKey(spec.SchemaName, spec.Name)
+	if specKey != requestKey {
+		if c.relationResolutionStack[specKey] {
+			return errCyclicRelationResolution(specKey)
+		}
+		c.relationResolutionStack[specKey] = true
+		defer delete(c.relationResolutionStack, specKey)
+	}
+
+	return c.materializeRelationSpec(spec)
+}
+
+func normalizeRelationSpec(spec *RelationSpec, schemaName, relName string) *RelationSpec {
+	normalized := *spec
+	if normalized.SchemaName == "" {
+		normalized.SchemaName = schemaName
+	}
+	if normalized.SchemaName == "" {
+		normalized.SchemaName = "public"
+	}
+	if normalized.Name == "" {
+		normalized.Name = relName
+	}
+	return &normalized
+}
+
+func relationResolutionKey(schemaName, relName string) string {
+	return schemaName + "." + relName
+}
+
+func errCyclicRelationResolution(key string) error {
+	return &Error{
+		Code:    CodeInvalidObjectDefinition,
+		Message: fmt.Sprintf("cyclic relation resolution detected for %q", key),
+	}
+}
+
+func (c *Catalog) materializeRelationSpec(spec *RelationSpec) error {
+	if spec.SchemaName == "" || spec.Name == "" {
+		return &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver returned an incomplete relation name"}
+	}
+	if err := c.ensureResolverSchema(spec.SchemaName); err != nil {
+		return err
+	}
+
+	switch spec.Kind {
+	case RelationKindTable:
+		return c.materializeResolvedTable(spec)
+	case RelationKindView:
+		sel, err := parseRelationDefinitionSelect(spec)
+		if err != nil {
+			return err
+		}
+		return c.DefineView(&nodes.ViewStmt{
+			View:  &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name},
+			Query: sel,
+		})
+	case RelationKindMaterializedView:
+		sel, err := parseRelationDefinitionSelect(spec)
+		if err != nil {
+			return err
+		}
+		return c.ExecCreateTableAs(&nodes.CreateTableAsStmt{
+			Query:   sel,
+			Into:    &nodes.IntoClause{Rel: &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name}},
+			Objtype: nodes.OBJECT_MATVIEW,
+		})
+	default:
+		return &Error{
+			Code:    CodeFeatureNotSupported,
+			Message: fmt.Sprintf("relation resolver returned unsupported relation kind %q", spec.Kind),
+		}
+	}
+}
+
+func (c *Catalog) ensureResolverSchema(schemaName string) error {
+	if c.schemaByName[schemaName] != nil {
+		return nil
+	}
+	return c.CreateSchemaCommand(&nodes.CreateSchemaStmt{Schemaname: schemaName})
+}
+
+func (c *Catalog) materializeResolvedTable(spec *RelationSpec) error {
+	if len(spec.Columns) == 0 {
+		return &Error{Code: CodeInvalidTableDefinition, Message: "relation resolver table spec requires at least one column"}
+	}
+
+	parts := make([]string, 0, len(spec.Columns))
+	for _, col := range spec.Columns {
+		if col.Name == "" || strings.TrimSpace(col.Type) == "" {
+			return &Error{Code: CodeInvalidColumnDefinition, Message: "relation resolver table column requires name and type"}
+		}
+		parts = append(parts, fmt.Sprintf("%s %s", quoteIdentAlways(col.Name), col.Type))
+	}
+	ddl := fmt.Sprintf("CREATE TABLE %s.%s (%s)", quoteIdentAlways(spec.SchemaName), quoteIdentAlways(spec.Name), strings.Join(parts, ", "))
+
+	list, err := pgparser.Parse(ddl)
+	if err != nil {
+		return err
+	}
+	if list == nil || len(list.Items) != 1 {
+		return &Error{Code: CodeInvalidTableDefinition, Message: "relation resolver table definition did not parse to one statement"}
+	}
+	raw, ok := list.Items[0].(*nodes.RawStmt)
+	if !ok {
+		return &Error{Code: CodeInvalidTableDefinition, Message: "relation resolver table definition did not parse to a raw statement"}
+	}
+	stmt, ok := raw.Stmt.(*nodes.CreateStmt)
+	if !ok {
+		return &Error{Code: CodeInvalidTableDefinition, Message: "relation resolver table definition did not parse to CREATE TABLE"}
+	}
+	return c.DefineRelation(stmt, RelationKindTable)
+}
+
+func parseRelationDefinitionSelect(spec *RelationSpec) (*nodes.SelectStmt, error) {
+	definition := strings.TrimSpace(spec.Definition)
+	if definition == "" {
+		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+	}
+	list, err := pgparser.Parse(definition)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || len(list.Items) != 1 {
+		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+	}
+	raw, ok := list.Items[0].(*nodes.RawStmt)
+	if !ok {
+		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+	}
+	sel, ok := raw.Stmt.(*nodes.SelectStmt)
+	if !ok {
+		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+	}
+	return sel, nil
+}

--- a/redshift/catalog/relation_resolver_test.go
+++ b/redshift/catalog/relation_resolver_test.go
@@ -1,0 +1,287 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	nodes "github.com/bytebase/omni/redshift/ast"
+	pgparser "github.com/bytebase/omni/redshift/parser"
+)
+
+type testRelationResolver map[string]*RelationSpec
+
+func (r testRelationResolver) ResolveRelation(schemaName, relationName string, searchPath []string) (*RelationSpec, error) {
+	if schemaName != "" {
+		return r[schemaName+"."+relationName], nil
+	}
+	for _, schema := range searchPath {
+		if spec := r[schema+"."+relationName]; spec != nil {
+			return spec, nil
+		}
+	}
+	return nil, nil
+}
+
+func TestRelationResolverLazyTable(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns: []RelationColumnSpec{
+				{Name: "id", Type: "int4"},
+				{Name: "name", Type: "text"},
+			},
+		},
+	})
+
+	q := analyzeSelectSQL(t, c, "SELECT id, name FROM accounts")
+
+	if len(q.TargetList) != 2 {
+		t.Fatalf("target list length = %d, want 2", len(q.TargetList))
+	}
+	_, rel, err := c.findRelation("public", "accounts")
+	if err != nil {
+		t.Fatalf("find materialized relation: %v", err)
+	}
+	if rel.RelKind != 'r' {
+		t.Fatalf("relkind = %q, want table", rel.RelKind)
+	}
+	if got := columnNames(rel); strings.Join(got, ",") != "id,name" {
+		t.Fatalf("columns = %v, want [id name]", got)
+	}
+}
+
+func TestRelationResolverViewToTable(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.active_accounts": {
+			SchemaName: "public",
+			Name:       "active_accounts",
+			Kind:       'v',
+			Definition: "SELECT id FROM accounts WHERE active",
+		},
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns: []RelationColumnSpec{
+				{Name: "id", Type: "int4"},
+				{Name: "active", Type: "bool"},
+			},
+		},
+	})
+
+	q := analyzeSelectSQL(t, c, "SELECT id FROM active_accounts")
+
+	if len(q.TargetList) != 1 || q.TargetList[0].ResName != "id" {
+		t.Fatalf("target list = %+v, want id", q.TargetList)
+	}
+	_, rel, err := c.findRelation("public", "active_accounts")
+	if err != nil {
+		t.Fatalf("find materialized view: %v", err)
+	}
+	if rel.RelKind != 'v' || rel.AnalyzedQuery == nil {
+		t.Fatalf("view relkind/analyzed = %q/%v, want analyzed view", rel.RelKind, rel.AnalyzedQuery)
+	}
+}
+
+func TestRelationResolverViewToLaterView(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.outer_v": {
+			SchemaName: "public",
+			Name:       "outer_v",
+			Kind:       'v',
+			Definition: "SELECT id FROM inner_v",
+		},
+		"public.inner_v": {
+			SchemaName: "public",
+			Name:       "inner_v",
+			Kind:       'v',
+			Definition: "SELECT id FROM base_t",
+		},
+		"public.base_t": {
+			SchemaName: "public",
+			Name:       "base_t",
+			Kind:       'r',
+			Columns:    []RelationColumnSpec{{Name: "id", Type: "int8"}},
+		},
+	})
+
+	analyzeSelectSQL(t, c, "SELECT id FROM outer_v")
+
+	for _, name := range []string{"outer_v", "inner_v", "base_t"} {
+		if _, _, err := c.findRelation("public", name); err != nil {
+			t.Fatalf("relation %s was not materialized: %v", name, err)
+		}
+	}
+}
+
+func TestRelationResolverUsesSearchPath(t *testing.T) {
+	c := New()
+	c.SetSearchPath([]string{"tenant", "public"})
+	c.SetRelationResolver(testRelationResolver{
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns:    []RelationColumnSpec{{Name: "public_id", Type: "int4"}},
+		},
+		"tenant.accounts": {
+			SchemaName: "tenant",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns:    []RelationColumnSpec{{Name: "tenant_id", Type: "int4"}},
+		},
+	})
+
+	q := analyzeSelectSQL(t, c, "SELECT tenant_id FROM accounts")
+
+	if got := q.TargetList[0].ResName; got != "tenant_id" {
+		t.Fatalf("resolved column = %q, want tenant_id", got)
+	}
+	if _, _, err := c.findRelation("tenant", "accounts"); err != nil {
+		t.Fatalf("tenant relation was not materialized: %v", err)
+	}
+}
+
+func TestRelationResolverCyclicView(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.a_view": {
+			SchemaName: "public",
+			Name:       "a_view",
+			Kind:       'v',
+			Definition: "SELECT id FROM b_view",
+		},
+		"public.b_view": {
+			SchemaName: "public",
+			Name:       "b_view",
+			Kind:       'v',
+			Definition: "SELECT id FROM a_view",
+		},
+	})
+
+	_, err := analyzeSelectSQLError(c, "SELECT id FROM a_view")
+	if err == nil || !strings.Contains(err.Error(), "cyclic relation resolution") {
+		t.Fatalf("error = %v, want cyclic relation resolution", err)
+	}
+}
+
+func TestRelationResolverMissingDependency(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.v": {
+			SchemaName: "public",
+			Name:       "v",
+			Kind:       'v',
+			Definition: "SELECT id FROM missing_t",
+		},
+	})
+
+	_, err := analyzeSelectSQLError(c, "SELECT id FROM v")
+	if err == nil || !strings.Contains(err.Error(), "missing_t") {
+		t.Fatalf("error = %v, want missing dependency error", err)
+	}
+	if _, _, findErr := c.findRelation("public", "v"); findErr == nil {
+		t.Fatalf("view was materialized despite missing dependency")
+	}
+}
+
+func TestRelationResolverUnsupportedDefinition(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.bad_v": {
+			SchemaName: "public",
+			Name:       "bad_v",
+			Kind:       'v',
+			Definition: "DELETE FROM accounts",
+		},
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns:    []RelationColumnSpec{{Name: "id", Type: "int4"}},
+		},
+	})
+
+	_, err := analyzeSelectSQLError(c, "SELECT id FROM bad_v")
+	if err == nil || !strings.Contains(err.Error(), "requires a SELECT definition") {
+		t.Fatalf("error = %v, want unsupported definition error", err)
+	}
+}
+
+func TestRelationResolverLazyMaterializedView(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.recent_accounts": {
+			SchemaName: "public",
+			Name:       "recent_accounts",
+			Kind:       'm',
+			Definition: "SELECT id FROM accounts",
+		},
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns:    []RelationColumnSpec{{Name: "id", Type: "int4"}},
+		},
+	})
+
+	analyzeSelectSQL(t, c, "SELECT id FROM recent_accounts")
+
+	_, rel, err := c.findRelation("public", "recent_accounts")
+	if err != nil {
+		t.Fatalf("find materialized view: %v", err)
+	}
+	if rel.RelKind != 'm' || rel.AnalyzedQuery == nil {
+		t.Fatalf("relkind/analyzed = %q/%v, want analyzed matview", rel.RelKind, rel.AnalyzedQuery)
+	}
+}
+
+func analyzeSelectSQL(t *testing.T, c *Catalog, sql string) *Query {
+	t.Helper()
+	q, err := analyzeSelectSQLError(c, sql)
+	if err != nil {
+		t.Fatalf("AnalyzeSelectStmt(%q): %v", sql, err)
+	}
+	return q
+}
+
+func analyzeSelectSQLError(c *Catalog, sql string) (*Query, error) {
+	stmt, err := parseSingleSelect(sql)
+	if err != nil {
+		return nil, err
+	}
+	return c.AnalyzeSelectStmt(stmt)
+}
+
+func parseSingleSelect(sql string) (*nodes.SelectStmt, error) {
+	list, err := pgparser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || len(list.Items) != 1 {
+		return nil, fmt.Errorf("expected one statement")
+	}
+	raw, ok := list.Items[0].(*nodes.RawStmt)
+	if !ok {
+		return nil, fmt.Errorf("expected RawStmt, got %T", list.Items[0])
+	}
+	stmt, ok := raw.Stmt.(*nodes.SelectStmt)
+	if !ok {
+		return nil, fmt.Errorf("expected SelectStmt, got %T", raw.Stmt)
+	}
+	return stmt, nil
+}
+
+func columnNames(rel *Relation) []string {
+	names := make([]string, len(rel.Columns))
+	for i, col := range rel.Columns {
+		names[i] = col.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Summary
- Add a Redshift catalog `RelationResolver` API and `SetRelationResolver` hook for lazy relation lookup.
- Materialize resolver-provided tables, views, and materialized views into the catalog while keeping view definition parsing and `AnalyzeSelectStmt` in Omni.
- Add cyclic view-resolution guard and resolver coverage for lazy tables, chained views, search path, missing dependencies, unsupported definitions, and matviews.

## Test Plan
- `go test ./redshift/catalog -run 'TestRelationResolver'`\n- `go test ./redshift/catalog`\n- `go test ./redshift/...`\n- `git diff --check`