### PR TITLE
fix(redshift): accept create view resolver definitions

### DIFF
--- a/redshift/catalog/relation_resolver.go
+++ b/redshift/catalog/relation_resolver.go
@@ -26,7 +26,8 @@ type RelationSpec struct {
 	Kind       byte
 	Columns    []RelationColumnSpec
 
-	// Definition is the SELECT definition for a view or materialized view.
+	// Definition is the SELECT definition, or a full CREATE VIEW /
+	// CREATE MATERIALIZED VIEW statement, for a view or materialized view.
 	Definition string
 }
 
@@ -107,24 +108,17 @@ func (c *Catalog) materializeRelationSpec(spec *RelationSpec) error {
 	case RelationKindTable:
 		return c.materializeResolvedTable(spec)
 	case RelationKindView:
-		sel, err := parseRelationDefinitionSelect(spec)
+		stmt, err := parseRelationDefinitionView(spec)
 		if err != nil {
 			return err
 		}
-		return c.DefineView(&nodes.ViewStmt{
-			View:  &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name},
-			Query: sel,
-		})
+		return c.DefineView(stmt)
 	case RelationKindMaterializedView:
-		sel, err := parseRelationDefinitionSelect(spec)
+		stmt, err := parseRelationDefinitionMaterializedView(spec)
 		if err != nil {
 			return err
 		}
-		return c.ExecCreateTableAs(&nodes.CreateTableAsStmt{
-			Query:   sel,
-			Into:    &nodes.IntoClause{Rel: &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name}},
-			Objtype: nodes.OBJECT_MATVIEW,
-		})
+		return c.ExecCreateTableAs(stmt)
 	default:
 		return &Error{
 			Code:    CodeFeatureNotSupported,
@@ -172,7 +166,58 @@ func (c *Catalog) materializeResolvedTable(spec *RelationSpec) error {
 	return c.DefineRelation(stmt, RelationKindTable)
 }
 
-func parseRelationDefinitionSelect(spec *RelationSpec) (*nodes.SelectStmt, error) {
+func parseRelationDefinitionView(spec *RelationSpec) (*nodes.ViewStmt, error) {
+	stmt, err := parseRelationDefinitionStatement(spec)
+	if err != nil {
+		return nil, err
+	}
+	switch n := stmt.(type) {
+	case *nodes.SelectStmt:
+		return &nodes.ViewStmt{
+			View:  &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name},
+			Query: n,
+		}, nil
+	case *nodes.ViewStmt:
+		copy := *n
+		copy.View = &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name}
+		return &copy, nil
+	default:
+		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+	}
+}
+
+func parseRelationDefinitionMaterializedView(spec *RelationSpec) (*nodes.CreateTableAsStmt, error) {
+	stmt, err := parseRelationDefinitionStatement(spec)
+	if err != nil {
+		return nil, err
+	}
+	switch n := stmt.(type) {
+	case *nodes.SelectStmt:
+		return &nodes.CreateTableAsStmt{
+			Query:   n,
+			Into:    &nodes.IntoClause{Rel: &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name}},
+			Objtype: nodes.OBJECT_MATVIEW,
+		}, nil
+	case *nodes.CreateTableAsStmt:
+		if n.Objtype != nodes.OBJECT_MATVIEW {
+			return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+		}
+		copy := *n
+		if copy.Into == nil {
+			copy.Into = &nodes.IntoClause{}
+		} else {
+			into := *copy.Into
+			copy.Into = &into
+		}
+		copy.Into.Rel = &nodes.RangeVar{Schemaname: spec.SchemaName, Relname: spec.Name}
+		copy.Objtype = nodes.OBJECT_MATVIEW
+		return &copy, nil
+	default:
+		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
+	}
+}
+
+func parseRelationDefinitionStatement(spec *RelationSpec) (nodes.Node, error) {
 	definition := strings.TrimSpace(spec.Definition)
 	if definition == "" {
 		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
@@ -188,9 +233,5 @@ func parseRelationDefinitionSelect(spec *RelationSpec) (*nodes.SelectStmt, error
 	if !ok {
 		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
 	}
-	sel, ok := raw.Stmt.(*nodes.SelectStmt)
-	if !ok {
-		return nil, &Error{Code: CodeInvalidObjectDefinition, Message: "relation resolver view requires a SELECT definition"}
-	}
-	return sel, nil
+	return raw.Stmt, nil
 }

--- a/redshift/catalog/relation_resolver_test.go
+++ b/redshift/catalog/relation_resolver_test.go
@@ -88,6 +88,40 @@ func TestRelationResolverViewToTable(t *testing.T) {
 	}
 }
 
+func TestRelationResolverFullCreateViewDefinition(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.active_accounts": {
+			SchemaName: "public",
+			Name:       "active_accounts",
+			Kind:       'v',
+			Definition: "CREATE VIEW public.active_accounts(account_id) AS SELECT id FROM accounts WHERE active",
+		},
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns: []RelationColumnSpec{
+				{Name: "id", Type: "int4"},
+				{Name: "active", Type: "bool"},
+			},
+		},
+	})
+
+	q := analyzeSelectSQL(t, c, "SELECT account_id FROM active_accounts")
+
+	if len(q.TargetList) != 1 || q.TargetList[0].ResName != "account_id" {
+		t.Fatalf("target list = %+v, want account_id", q.TargetList)
+	}
+	_, rel, err := c.findRelation("public", "active_accounts")
+	if err != nil {
+		t.Fatalf("find materialized view: %v", err)
+	}
+	if got := columnNames(rel); strings.Join(got, ",") != "account_id" {
+		t.Fatalf("columns = %v, want [account_id]", got)
+	}
+}
+
 func TestRelationResolverViewToLaterView(t *testing.T) {
 	c := New()
 	c.SetRelationResolver(testRelationResolver{
@@ -239,6 +273,37 @@ func TestRelationResolverLazyMaterializedView(t *testing.T) {
 	}
 	if rel.RelKind != 'm' || rel.AnalyzedQuery == nil {
 		t.Fatalf("relkind/analyzed = %q/%v, want analyzed matview", rel.RelKind, rel.AnalyzedQuery)
+	}
+}
+
+func TestRelationResolverFullCreateMaterializedViewDefinition(t *testing.T) {
+	c := New()
+	c.SetRelationResolver(testRelationResolver{
+		"public.recent_accounts": {
+			SchemaName: "public",
+			Name:       "recent_accounts",
+			Kind:       'm',
+			Definition: "CREATE MATERIALIZED VIEW public.recent_accounts(account_id) AS SELECT id FROM accounts",
+		},
+		"public.accounts": {
+			SchemaName: "public",
+			Name:       "accounts",
+			Kind:       'r',
+			Columns:    []RelationColumnSpec{{Name: "id", Type: "int4"}},
+		},
+	})
+
+	analyzeSelectSQL(t, c, "SELECT account_id FROM recent_accounts")
+
+	_, rel, err := c.findRelation("public", "recent_accounts")
+	if err != nil {
+		t.Fatalf("find materialized view: %v", err)
+	}
+	if rel.RelKind != 'm' || rel.AnalyzedQuery == nil {
+		t.Fatalf("relkind/analyzed = %q/%v, want analyzed matview", rel.RelKind, rel.AnalyzedQuery)
+	}
+	if got := columnNames(rel); strings.Join(got, ",") != "account_id" {
+		t.Fatalf("columns = %v, want [account_id]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Accept resolver view definitions as either bare `SELECT` or full `CREATE VIEW ... AS SELECT ...`.
- Accept resolver materialized-view definitions as either bare `SELECT` or full `CREATE MATERIALIZED VIEW ... AS SELECT ...`.
- Preserve parsed column aliases from full DDL while materializing into the resolver-provided schema/name.

## Test Plan
- `go test ./redshift/catalog -run 'TestRelationResolverFullCreate(View|MaterializedView)Definition'`\n- `go test ./redshift/catalog -run 'TestRelationResolver'`\n- `go test ./redshift/...`\n- `git diff --check`