### PR TITLE
feat(trino/analysis): resolve view lineage via catalog metadata

### DIFF
--- a/trino/analysis/query_span.go
+++ b/trino/analysis/query_span.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/bytebase/omni/trino/ast"
+	"github.com/bytebase/omni/trino/catalog"
 	"github.com/bytebase/omni/trino/parser"
 )
 
@@ -102,6 +103,25 @@ type ColumnRef struct {
 // whatever parsed is still analyzed. On empty input it returns a zero-valued
 // span with Type=Unknown.
 func GetQuerySpan(statement string) (*QuerySpan, error) {
+	return GetQuerySpanWithCatalog(statement, nil)
+}
+
+// GetQuerySpanWithCatalog is GetQuerySpan with catalog metadata: a FROM
+// reference that resolves to a known VIEW is followed into its definition
+// (recursively, in the view's own catalog/schema context), so result-column
+// lineage reaches the underlying base-table columns and the definition's base
+// tables are added to AccessTables; a star over a catalog-known relation
+// expands to its exact projection. Unqualified names resolve against the
+// catalog's current session catalog/schema. A nil catalog (or names the
+// catalog cannot resolve) leaves behaviour identical to GetQuerySpan.
+func GetQuerySpanWithCatalog(statement string, cat *catalog.Catalog) (*QuerySpan, error) {
+	return getQuerySpanWithViews(statement, newViewState(cat))
+}
+
+// getQuerySpanWithViews is the shared implementation; vs carries the
+// catalog-aware resolution state across the recursive analysis of view
+// definitions (nil disables catalog resolution).
+func getQuerySpanWithViews(statement string, vs *viewState) (*QuerySpan, error) {
 	file, _ := parser.Parse(statement)
 	span := &QuerySpan{Type: Classify(statement)}
 	if file == nil || len(file.Stmts) == 0 {
@@ -117,9 +137,18 @@ func GetQuerySpan(statement string) (*QuerySpan, error) {
 	// FROM and CTE references): the primary walk records a derived column by the
 	// name written at the reference site, which has no base table to mask
 	// against. This rewrites those refs to the recovered base columns, leaving
-	// direct base-table references untouched.
+	// direct base-table references untouched. Base tables read through views
+	// resolved during the pass are collected into this statement's
+	// AccessTables.
 	if len(file.Stmts) > 0 {
-		resolveDerivedLineage(file.Stmts[0], span)
+		var viewTables []TableAccess
+		if vs != nil {
+			savedOut := vs.tablesOut
+			vs.tablesOut = &viewTables
+			defer func() { vs.tablesOut = savedOut }()
+		}
+		resolveDerivedLineage(file.Stmts[0], span, vs)
+		appendViewTables(span, viewTables)
 	}
 	return span, nil
 }

--- a/trino/analysis/query_span_resolve.go
+++ b/trino/analysis/query_span_resolve.go
@@ -37,7 +37,7 @@ import (
 // columns (width and order), so `SELECT *` over a derived table or CTE masks
 // positionally; a star that needs catalog metadata (base table, coalescing
 // join, unresolved relation) stays a single opaque "*" result, as before.
-func resolveDerivedLineage(stmt ast.Node, span *QuerySpan) {
+func resolveDerivedLineage(stmt ast.Node, span *QuerySpan, vs *viewState) {
 	if span == nil {
 		return
 	}
@@ -45,6 +45,10 @@ func resolveDerivedLineage(stmt ast.Node, span *QuerySpan) {
 	if !ok || qs.Query == nil {
 		return
 	}
+	// The root CTE scope carries the catalog-aware resolution state (nil
+	// disables catalog resolution); buildCTEDefs propagates it to nested
+	// scopes.
+	root := &cteDefs{views: vs}
 	// Recompute the outermost query's column lineage with relation-scope
 	// resolution (derived tables, CTEs, UNNEST, scalar subqueries, set-operation
 	// arm merging, and star expansion) and fold it into the primary walk's
@@ -60,7 +64,7 @@ func resolveDerivedLineage(stmt ast.Node, span *QuerySpan) {
 	//   - an opaque star (not expandable without metadata) is left byte-for-byte
 	//     untouched, preserving the exact result shape consumers key on to apply
 	//     their own metadata-based expansion.
-	cols := resolveQueryCols(qs.Query, nil)
+	cols := resolveQueryCols(qs.Query, root)
 
 	// A top-level VALUES produces no Results in the primary walk (it has no
 	// select items), leaving the consumer with zero positional maskers — a
@@ -164,10 +168,12 @@ func hasOpaque(cols []outCol) bool {
 
 // cteDefs maps a CTE name (lower-cased) to its resolved output columns, with a
 // parent link for nested WITH scopes. A CTE shadows an outer one of the same
-// name; an inner WITH's definitions chain to the outer ones.
+// name; an inner WITH's definitions chain to the outer ones. The chain also
+// carries the catalog-aware resolution state (views) from the root scope.
 type cteDefs struct {
 	defs   map[string][]outCol
 	parent *cteDefs
+	views  *viewState
 }
 
 func (c *cteDefs) lookup(name string) ([]outCol, bool) {
@@ -180,6 +186,17 @@ func (c *cteDefs) lookup(name string) ([]outCol, bool) {
 	return nil, false
 }
 
+// viewState returns the catalog-aware resolution state carried by this scope
+// chain, or nil when there is none (catalog-less analysis).
+func (c *cteDefs) viewState() *viewState {
+	for cur := c; cur != nil; cur = cur.parent {
+		if cur.views != nil {
+			return cur.views
+		}
+	}
+	return nil
+}
+
 // buildCTEDefs resolves a query's WITH clause into a cteDefs scope chained to
 // parent. Each CTE body is resolved in a scope that already includes the earlier
 // siblings (sequential visibility), matching standard non-recursive CTE scoping;
@@ -190,6 +207,9 @@ func buildCTEDefs(q *parser.Query, parent *cteDefs) *cteDefs {
 		return parent
 	}
 	d := &cteDefs{defs: make(map[string][]outCol), parent: parent}
+	if parent != nil {
+		d.views = parent.views
+	}
 	for i := range q.With.CTEs {
 		nq := q.With.CTEs[i]
 		name := identName(nq.Name)
@@ -238,10 +258,32 @@ func resolveNodeCols(node parser.QueryNode, cte *cteDefs) []outCol {
 		// TABLE name == SELECT * FROM name. Over an in-scope CTE the projection
 		// is the CTE's resolved columns (verified against Trino 481:
 		// `WITH w AS (SELECT phone, name …) TABLE w` returns [phone, name]);
-		// over a base table the star needs catalog metadata and stays opaque.
-		if parts := normalizedParts(n.Name); len(parts) == 1 && cte != nil {
-			if cols, ok := cte.lookup(parts[0]); ok && len(cols) > 0 && !hasOpaque(cols) {
-				return stampStar(cols, 0, nil)
+		// the same holds for a catalog-resolved view (its definition's
+		// projection) or table (its catalog columns). Otherwise the star needs
+		// metadata the analysis does not have and stays opaque.
+		parts := normalizedParts(n.Name)
+		if len(parts) == 1 && cte != nil {
+			if cols, ok := cte.lookup(parts[0]); ok {
+				if len(cols) > 0 && !hasOpaque(cols) {
+					return stampStar(cols, 0, nil)
+				}
+				return []outCol{{name: "*", opaque: true}}
+			}
+		}
+		if vs := cte.viewState(); vs != nil {
+			if key, view, table, found := vs.lookupRelation(parts); found {
+				var cols []outCol
+				if view != nil {
+					if proj := vs.projectionFor(key, view); proj != nil {
+						vs.collectTables(proj.tables)
+						cols = proj.cols
+					}
+				} else {
+					cols = tableCols(key, table)
+				}
+				if len(cols) > 0 && !hasOpaque(cols) {
+					return stampStar(cols, 0, nil)
+				}
 			}
 		}
 		return []outCol{{name: "*", opaque: true}}
@@ -468,9 +510,11 @@ func (s *rscope) add(rel parser.Relation, alias string, colAliases []*ast.Identi
 	case *parser.ParenRelation:
 		s.add(n.Inner, alias, colAliases)
 	case *parser.TableRelation:
+		parts := normalizedParts(n.Name)
 		// A single-part name that matches an in-scope CTE is a derived relation
-		// (the CTE's resolved columns); otherwise it is a base table.
-		if parts := normalizedParts(n.Name); len(parts) == 1 && s.cte != nil {
+		// (the CTE's resolved columns); a CTE shadows any same-named catalog
+		// object.
+		if len(parts) == 1 && s.cte != nil {
 			if cols, ok := s.cte.lookup(parts[0]); ok {
 				name := alias
 				if name == "" {
@@ -483,6 +527,29 @@ func (s *rscope) add(rel parser.Relation, alias string, colAliases []*ast.Identi
 		name := alias
 		if name == "" {
 			name = lastPart(n.Name)
+		}
+		// Resolve against the catalog when one was supplied. A VIEW binds as a
+		// derived relation carrying its definition's resolved projection, so
+		// references and stars through it reach the underlying base columns; a
+		// TABLE binds with its catalog columns, which star expansion uses (named
+		// references through a base table keep their written form — additive
+		// resolution needs no help there, see resolveRef).
+		if vs := s.cte.viewState(); vs != nil {
+			if key, view, table, found := vs.lookupRelation(parts); found {
+				if view != nil {
+					if proj := vs.projectionFor(key, view); proj != nil {
+						vs.collectTables(proj.tables)
+						s.rels = append(s.rels, rbind{name: name, derived: true, cols: applyColumnAliases(proj.cols, colAliases)})
+						return
+					}
+					// Unresolvable view (no/unanalyzable definition, cycle):
+					// bind opaquely so stars through it stay unexpanded.
+					s.rels = append(s.rels, rbind{name: name, derived: false})
+					return
+				}
+				s.rels = append(s.rels, rbind{name: name, derived: false, cols: applyColumnAliases(tableCols(key, table), colAliases)})
+				return
+			}
 		}
 		s.rels = append(s.rels, rbind{name: name, derived: false})
 	case *parser.SubqueryRelation:
@@ -542,10 +609,11 @@ func (s *rscope) unnestColumns(n *parser.UnnestRelation, colAliases []*ast.Ident
 // positional masker downstream, which is precisely the bug this resolves — so
 // it bails (nil) unless:
 //   - no USING/NATURAL join coalesces columns in this scope, and
-//   - every covered relation is a derived relation (subquery, CTE reference, or
-//     aliased UNNEST) whose projection is fully resolved: non-empty and free of
-//     opaque star placeholders. A base table (width known only to catalog
-//     metadata), a lateral/table-function relation, an UNNEST without column
+//   - every covered relation has a fully-resolved projection: non-empty and
+//     free of opaque star placeholders. That is a derived relation (subquery,
+//     CTE reference, aliased UNNEST, catalog-resolved view) or a base table
+//     whose columns the supplied catalog knows. A base table without catalog
+//     metadata, a lateral/table-function relation, an UNNEST without column
 //     aliases, or a qualifier matching zero or several relations all bail.
 //
 // A nil return leaves the star opaque — the consumer's metadata-based expansion
@@ -563,14 +631,14 @@ func (s *rscope) starExpansion(qualifier string) []outCol {
 				count++
 			}
 		}
-		if count != 1 || !match.derived || len(match.cols) == 0 || hasOpaque(match.cols) {
+		if count != 1 || len(match.cols) == 0 || hasOpaque(match.cols) {
 			return nil
 		}
 		return match.cols
 	}
 	var out []outCol
 	for _, rb := range s.rels {
-		if !rb.derived || len(rb.cols) == 0 || hasOpaque(rb.cols) {
+		if len(rb.cols) == 0 || hasOpaque(rb.cols) {
 			return nil
 		}
 		out = append(out, rb.cols...)
@@ -617,10 +685,14 @@ func (s *rscope) resolveRef(ref ColumnRef) []ColumnRef {
 	out := []ColumnRef{ref}
 	if ref.Table != "" {
 		// Qualified by a relation name: append the recovered sources of every
-		// in-scope derived relation of that name exposing the column (a reused
-		// alias yields several; unioning them over-includes, which is safe).
+		// in-scope relation of that name exposing the column (a reused alias
+		// yields several; unioning them over-includes, which is safe). A
+		// catalog-known base table's cols matter when relation column aliases
+		// rename its columns (FROM customer AS c(i, p, …): c.p must reach
+		// customer.phone); without aliases they only restate the written ref
+		// in qualified form, which is harmless.
 		for _, rb := range s.rels {
-			if rb.derived && strings.EqualFold(rb.name, ref.Table) {
+			if strings.EqualFold(rb.name, ref.Table) {
 				if src, ok := lookupOutCol(rb.cols, ref.Column); ok {
 					out = append(out, src...)
 				}
@@ -628,13 +700,10 @@ func (s *rscope) resolveRef(ref ColumnRef) []ColumnRef {
 		}
 		return out
 	}
-	// Bare reference: append the recovered sources of every in-scope derived
-	// relation exposing a column of this name. The original bare ref is retained
-	// so a base table providing the same column is still covered.
+	// Bare reference: append the recovered sources of every in-scope relation
+	// exposing a column of this name. The original bare ref is retained so a
+	// base table providing the same column is still covered.
 	for _, rb := range s.rels {
-		if !rb.derived {
-			continue
-		}
 		if src, ok := lookupOutCol(rb.cols, ref.Column); ok {
 			out = append(out, src...)
 		}

--- a/trino/analysis/query_span_views.go
+++ b/trino/analysis/query_span_views.go
@@ -1,0 +1,278 @@
+package analysis
+
+import (
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// viewState carries the catalog-aware resolution state for one
+// GetQuerySpanWithCatalog call, shared across the recursive analysis of view
+// definitions. It supplies:
+//   - the catalog itself and the CURRENT resolution context for unqualified
+//     names (the session catalog/schema at the top level; a view's own
+//     catalog/schema while its definition is being analyzed);
+//   - a cycle guard and a memo for view projections, so a view referenced
+//     several times is analyzed once and a definition cycle in malformed
+//     metadata terminates;
+//   - a per-statement collector for the base tables discovered inside view
+//     definitions, which the caller appends to that statement's AccessTables.
+//
+// A nil viewState (or one with a nil catalog) disables all catalog-aware
+// resolution: behaviour is byte-for-byte the catalog-less GetQuerySpan.
+type viewState struct {
+	cat *catalog.Catalog
+
+	// curCatalog/curSchema are the resolution context for unqualified names,
+	// mirroring catalog.ResolveRelation's session rules with an injected
+	// context (the shared catalog is never mutated).
+	curCatalog string
+	curSchema  string
+
+	// inProgress guards against view-definition cycles.
+	inProgress map[viewKey]bool
+	// cycleHit records that a cycle was encountered while computing the
+	// current projection; projections computed under an open cycle are partial
+	// and are discarded rather than memoized.
+	cycleHit bool
+	// memo caches each view's resolved projection (nil entry = unresolvable).
+	memo map[viewKey]*viewProjection
+
+	// tablesOut collects, for the statement currently being analyzed, the
+	// qualified base tables read through resolved views. Swapped per
+	// getQuerySpanWithViews invocation so nested view analyses collect into
+	// their own statement's span.
+	tablesOut *[]TableAccess
+}
+
+// viewKey identifies a view by its canonical (normalized) location.
+type viewKey struct {
+	catalog string
+	schema  string
+	view    string
+}
+
+// viewProjection is a view's resolved output: its columns (with base-column
+// lineage, names taken positionally from the view's metadata column list when
+// present) and the qualified base tables its definition reads.
+type viewProjection struct {
+	cols   []outCol
+	tables []TableAccess
+}
+
+// newViewState builds the resolution state for one top-level statement.
+// Returns nil when there is no catalog, which disables catalog resolution.
+func newViewState(cat *catalog.Catalog) *viewState {
+	if cat == nil {
+		return nil
+	}
+	return &viewState{
+		cat:        cat,
+		curCatalog: cat.CurrentCatalog(),
+		curSchema:  cat.CurrentSchema(),
+		inProgress: make(map[viewKey]bool),
+		memo:       make(map[viewKey]*viewProjection),
+	}
+}
+
+// resolveParts maps normalized dotted-name parts to a fully-qualified
+// (catalog, schema, object) triple using this state's resolution context —
+// catalog.ResolveRelation's session rules with the context injected.
+func (vs *viewState) resolveParts(parts []string) (catalogName, schemaName, objectName string, ok bool) {
+	switch len(parts) {
+	case 1:
+		if vs.curCatalog == "" || vs.curSchema == "" {
+			return "", "", "", false
+		}
+		return vs.curCatalog, vs.curSchema, parts[0], true
+	case 2:
+		if vs.curCatalog == "" {
+			return "", "", "", false
+		}
+		return vs.curCatalog, parts[0], parts[1], true
+	case 3:
+		return parts[0], parts[1], parts[2], true
+	default:
+		return "", "", "", false
+	}
+}
+
+// lookupRelation resolves normalized name parts against the catalog. Exactly
+// one of view/table is non-nil when found, with the same precedence as
+// catalog.ResolveRelation: an existing table shadows a same-named view.
+func (vs *viewState) lookupRelation(parts []string) (key viewKey, view *catalog.View, table *catalog.Table, found bool) {
+	if vs == nil || vs.cat == nil {
+		return viewKey{}, nil, nil, false
+	}
+	catalogName, schemaName, objectName, ok := vs.resolveParts(parts)
+	if !ok {
+		return viewKey{}, nil, nil, false
+	}
+	db := vs.cat.GetCatalog(catalogName)
+	if db == nil {
+		return viewKey{}, nil, nil, false
+	}
+	sch := db.GetSchema(schemaName)
+	if sch == nil {
+		return viewKey{}, nil, nil, false
+	}
+	key = viewKey{catalog: db.Name, schema: sch.Name, view: objectName}
+	if t := sch.GetTable(objectName); t != nil {
+		return key, nil, t, true
+	}
+	if v := sch.GetView(objectName); v != nil {
+		return key, v, nil, true
+	}
+	return viewKey{}, nil, nil, false
+}
+
+// tableCols renders a catalog table's columns as resolved output columns, each
+// sourced by its own fully-qualified base column. starExpansion uses these to
+// expand a star over a catalog-known base table to its exact projection.
+func tableCols(key viewKey, t *catalog.Table) []outCol {
+	cols := t.Columns()
+	out := make([]outCol, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, outCol{
+			name: c.Name,
+			sources: []ColumnRef{{
+				Catalog: key.catalog,
+				Schema:  key.schema,
+				Table:   key.view,
+				Column:  c.Name,
+			}},
+		})
+	}
+	return out
+}
+
+// projectionFor returns the view's resolved projection, computing and memoizing
+// it on first use. The definition is analyzed recursively (so views over views
+// and definitions using CTEs/derived tables resolve) in the view's own
+// catalog/schema context. Returns nil — leaving the view opaque, exactly the
+// pre-catalog behaviour — for an empty/unanalyzable definition or a definition
+// cycle.
+func (vs *viewState) projectionFor(key viewKey, v *catalog.View) *viewProjection {
+	if p, ok := vs.memo[key]; ok {
+		return p
+	}
+	if vs.inProgress[key] {
+		// Definition cycle: record the hit so every projection computed while
+		// this cycle was open is discarded rather than memoized partial.
+		vs.cycleHit = true
+		return nil
+	}
+	if v.Definition == "" {
+		vs.memo[key] = nil
+		return nil
+	}
+
+	vs.inProgress[key] = true
+	savedCatalog, savedSchema := vs.curCatalog, vs.curSchema
+	savedCycleHit := vs.cycleHit
+	vs.cycleHit = false
+	vs.curCatalog, vs.curSchema = key.catalog, key.schema
+	span, err := getQuerySpanWithViews(v.Definition, vs)
+	vs.curCatalog, vs.curSchema = savedCatalog, savedSchema
+	delete(vs.inProgress, key)
+	tainted := vs.cycleHit
+	vs.cycleHit = savedCycleHit || tainted
+
+	if tainted {
+		// This projection was computed with a cyclic dependency unresolved
+		// (treated as opaque mid-flight) — a partial result. Do not memoize and
+		// report the view unresolvable, so every view in the cycle stays fully
+		// opaque (the consumer's metadata expansion applies).
+		return nil
+	}
+	if err != nil || span == nil || len(span.Results) == 0 {
+		vs.memo[key] = nil
+		return nil
+	}
+
+	cols := make([]outCol, 0, len(span.Results))
+	for _, r := range span.Results {
+		cols = append(cols, outCol{
+			name:    r.Name,
+			sources: r.SourceColumns,
+			// A star the inner analysis could not expand (over an unknown base
+			// table, a coalescing join, …) leaves the projection's width
+			// unknown; mark it opaque so star expansion through this view
+			// bails while named-column lookups still work.
+			opaque: r.Name == "*" || isQualifiedStarName(r.Name),
+		})
+	}
+	// The view's metadata column list names the outputs the OUTER query
+	// references; apply it positionally over the definition's analyzed columns
+	// (an explicit view column list — CREATE VIEW v (ph) AS SELECT phone … —
+	// renames them). A COUNT MISMATCH between the metadata column list and the
+	// analyzed definition means one of the two is stale; the true output shape
+	// is then unknown, so the view is unresolvable — expanding or renaming on
+	// either width could misalign the consumer's positional masker.
+	if names := v.ColumnNames(); len(names) > 0 {
+		if len(names) != len(cols) {
+			vs.memo[key] = nil
+			return nil
+		}
+		for i, name := range names {
+			if name != "" {
+				cols[i].name = name
+			}
+		}
+	}
+
+	// The relations the definition reads — its base tables, and any
+	// intermediate views (a query through this view does access them) —
+	// qualified with the view's own context when the definition wrote them
+	// unqualified, so the consumer resolves them in the right namespace.
+	// Tables appended by nested view resolution arrive already qualified.
+	tables := make([]TableAccess, 0, len(span.AccessTables))
+	for _, t := range span.AccessTables {
+		if t.Catalog == "" {
+			t.Catalog = key.catalog
+		}
+		if t.Schema == "" {
+			t.Schema = key.schema
+		}
+		tables = append(tables, t)
+	}
+
+	p := &viewProjection{cols: cols, tables: tables}
+	vs.memo[key] = p
+	return p
+}
+
+// collectTables records base tables read through a resolved view for the
+// statement currently being analyzed.
+func (vs *viewState) collectTables(tables []TableAccess) {
+	if vs == nil || vs.tablesOut == nil {
+		return
+	}
+	*vs.tablesOut = append(*vs.tablesOut, tables...)
+}
+
+// isQualifiedStarName reports whether a result name has the unexpanded
+// qualified-star form "<rel>.*".
+func isQualifiedStarName(name string) bool {
+	return len(name) > 2 && name[len(name)-2:] == ".*"
+}
+
+// appendViewTables merges the base tables collected from resolved views into a
+// span's AccessTables, deduplicating on (catalog, schema, table, alias)
+// against both the existing entries and each other.
+func appendViewTables(span *QuerySpan, tables []TableAccess) {
+	if len(tables) == 0 {
+		return
+	}
+	seen := make(map[tableKey]bool, len(span.AccessTables)+len(tables))
+	for _, t := range span.AccessTables {
+		seen[tableKey{Catalog: t.Catalog, Schema: t.Schema, Table: t.Table, Alias: t.Alias}] = true
+	}
+	for _, t := range tables {
+		k := tableKey{Catalog: t.Catalog, Schema: t.Schema, Table: t.Table, Alias: t.Alias}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		span.AccessTables = append(span.AccessTables, t)
+	}
+}
+

--- a/trino/analysis/query_span_views_test.go
+++ b/trino/analysis/query_span_views_test.go
@@ -1,0 +1,399 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/trino/catalog"
+)
+
+// lineageCatalog builds the catalog used by the view-lineage tests:
+//
+//	catalog1.public.customer(id, phone, name, phones)
+//	catalog1.public.orders(id, k)
+//	catalog1.other.secrets(token)
+//	views in catalog1.public:
+//	  customer_v   AS SELECT id, phone, name FROM customer
+//	  cust_masked  AS SELECT phone AS ph FROM customer
+//	  v2           AS SELECT phone FROM customer_v            (view over view)
+//	  renamed_v(ph) AS SELECT phone FROM customer             (explicit column list)
+//	  comp_v       AS SELECT phone || name AS token FROM customer
+//	  cte_v        AS WITH c AS (SELECT phone AS pp FROM customer) SELECT pp FROM c
+//	  star_v       AS SELECT * FROM customer                  (star-bodied)
+//	  cyc_a        AS SELECT x FROM cyc_b                     (definition cycle)
+//	  cyc_b        AS SELECT x FROM cyc_a
+//	  dual         — BOTH a table and a view of this name exist (precedence)
+//	view in catalog1.other:
+//	  other_v      AS SELECT token FROM secrets               (cross-schema context)
+//
+// Session context: catalog1.public.
+func lineageCatalog() *catalog.Catalog {
+	cat := catalog.New()
+	db := cat.EnsureCatalog("catalog1")
+	pub := db.EnsureSchema("public")
+	pub.AddTable("customer",
+		catalog.NewColumn("id", "integer", false),
+		catalog.NewColumn("phone", "varchar", true),
+		catalog.NewColumn("name", "varchar", true),
+		catalog.NewColumn("phones", "array(varchar)", true),
+	)
+	pub.AddTable("orders",
+		catalog.NewColumn("id", "integer", false),
+		catalog.NewColumn("k", "integer", true),
+	)
+	pub.AddTable("dual", catalog.NewColumn("tcol", "integer", false))
+
+	addView := func(sch *catalog.Schema, name, def string, cols ...*catalog.Column) {
+		v := sch.AddView(name, cols...)
+		v.Definition = def
+	}
+	addView(pub, "customer_v", "SELECT id, phone, name FROM customer",
+		catalog.NewColumn("id", "integer", false),
+		catalog.NewColumn("phone", "varchar", true),
+		catalog.NewColumn("name", "varchar", true),
+	)
+	addView(pub, "cust_masked", "SELECT phone AS ph FROM customer",
+		catalog.NewColumn("ph", "varchar", true),
+	)
+	addView(pub, "v2", "SELECT phone FROM customer_v",
+		catalog.NewColumn("phone", "varchar", true),
+	)
+	addView(pub, "renamed_v", "SELECT phone FROM customer",
+		catalog.NewColumn("ph", "varchar", true),
+	)
+	addView(pub, "comp_v", "SELECT phone || name AS token FROM customer",
+		catalog.NewColumn("token", "varchar", true),
+	)
+	addView(pub, "cte_v", "WITH c AS (SELECT phone AS pp FROM customer) SELECT pp FROM c",
+		catalog.NewColumn("pp", "varchar", true),
+	)
+	addView(pub, "star_v", "SELECT * FROM customer",
+		catalog.NewColumn("id", "integer", false),
+		catalog.NewColumn("phone", "varchar", true),
+		catalog.NewColumn("name", "varchar", true),
+		catalog.NewColumn("phones", "array(varchar)", true),
+	)
+	addView(pub, "cyc_a", "SELECT x FROM cyc_b", catalog.NewColumn("x", "integer", true))
+	addView(pub, "cyc_b", "SELECT x FROM cyc_a", catalog.NewColumn("x", "integer", true))
+	// stale_v: metadata says two columns but the definition projects one — a
+	// stale-metadata disagreement that must make the view opaque.
+	addView(pub, "stale_v", "SELECT id FROM customer",
+		catalog.NewColumn("id", "integer", false),
+		catalog.NewColumn("phone", "varchar", true),
+	)
+	// alias_v: the definition renames customer's columns via relation column
+	// aliases; p positionally is customer.phone.
+	addView(pub, "alias_v", "SELECT p FROM customer AS c(i, p, n, ps)",
+		catalog.NewColumn("p", "varchar", true),
+	)
+	addView(pub, "dual", "SELECT phone AS vcol FROM customer", catalog.NewColumn("vcol", "varchar", true))
+
+	other := db.EnsureSchema("other")
+	other.AddTable("secrets", catalog.NewColumn("token", "varchar", true))
+	addView(other, "other_v", "SELECT token FROM secrets", catalog.NewColumn("token", "varchar", true))
+
+	cat.SetCurrentCatalog("catalog1")
+	cat.SetCurrentSchema("public")
+	return cat
+}
+
+func viewSpan(t *testing.T, sql string) *QuerySpan {
+	t.Helper()
+	span, err := GetQuerySpanWithCatalog(sql, lineageCatalog())
+	if err != nil {
+		t.Fatalf("GetQuerySpanWithCatalog returned error: %v", err)
+	}
+	return span
+}
+
+func hasTable(span *QuerySpan, catalogName, schema, table string) bool {
+	for _, t := range span.AccessTables {
+		if t.Catalog == catalogName && t.Schema == schema && t.Table == table {
+			return true
+		}
+	}
+	return false
+}
+
+// TestViewLineage_ColumnResolvesToBase covers BYT-9679: a column selected
+// through a view resolves to the underlying base column, and the view's base
+// table joins AccessTables (qualified) so the consumer can expand it.
+func TestViewLineage_ColumnResolvesToBase(t *testing.T) {
+	span := viewSpan(t, "SELECT phone FROM customer_v")
+	r, ok := resultByName(span, "phone")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named phone", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("phone.SourceColumns = %+v, want {Column:phone} (through customer_v)", r.SourceColumns)
+	}
+	if !hasTable(span, "", "", "customer_v") {
+		t.Errorf("AccessTables = %+v, want the view customer_v itself (access-control parity)", span.AccessTables)
+	}
+	if !hasTable(span, "catalog1", "public", "customer") {
+		t.Errorf("AccessTables = %+v, want qualified base table catalog1.public.customer", span.AccessTables)
+	}
+}
+
+// TestViewLineage_StarOverViewExpands expands SELECT * over a view to the
+// view's exact projection with base lineage.
+func TestViewLineage_StarOverViewExpands(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM customer_v")
+	if got := resultNames(span); !sameNames(got, "id", "phone", "name") {
+		t.Fatalf("Results = %v, want [id phone name]", got)
+	}
+	if !hasSource(span.Results[1].SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("Results[1].SourceColumns = %+v, want {Column:phone}", span.Results[1].SourceColumns)
+	}
+}
+
+// TestViewLineage_RenamingViewResolves resolves a view whose definition renames
+// the projected column (phone AS ph).
+func TestViewLineage_RenamingViewResolves(t *testing.T) {
+	span := viewSpan(t, "SELECT ph FROM cust_masked")
+	r, ok := resultByName(span, "ph")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named ph", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("ph.SourceColumns = %+v, want {Column:phone}", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_ViewOverViewResolves resolves transitively through a view
+// defined over another view.
+func TestViewLineage_ViewOverViewResolves(t *testing.T) {
+	span := viewSpan(t, "SELECT phone FROM v2")
+	r, ok := resultByName(span, "phone")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named phone", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("phone.SourceColumns = %+v, want {Column:phone} (v2 -> customer_v -> customer)", r.SourceColumns)
+	}
+	if !hasTable(span, "catalog1", "public", "customer") {
+		t.Errorf("AccessTables = %+v, want catalog1.public.customer through both views", span.AccessTables)
+	}
+}
+
+// TestViewLineage_ExplicitColumnListResolves covers a view whose metadata
+// column list renames the definition's output (CREATE VIEW renamed_v (ph) AS
+// SELECT phone ...): the outer ph maps positionally to the base column.
+func TestViewLineage_ExplicitColumnListResolves(t *testing.T) {
+	span := viewSpan(t, "SELECT ph FROM renamed_v")
+	r, ok := resultByName(span, "ph")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named ph", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("ph.SourceColumns = %+v, want {Column:phone} (positional metadata column list)", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_ComposedColumnBothSources resolves a view column composed of
+// two base columns to both.
+func TestViewLineage_ComposedColumnBothSources(t *testing.T) {
+	span := viewSpan(t, "SELECT token FROM comp_v")
+	r, ok := resultByName(span, "token")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named token", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) || !hasSource(r.SourceColumns, ColumnRef{Column: "name"}) {
+		t.Errorf("token.SourceColumns = %+v, want both {Column:phone} and {Column:name}", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_CTEDefinitionResolves resolves a view whose definition itself
+// uses a CTE — the case the consumer-side post-pass could not reach with a
+// shallow analyzer.
+func TestViewLineage_CTEDefinitionResolves(t *testing.T) {
+	span := viewSpan(t, "SELECT pp FROM cte_v")
+	r, ok := resultByName(span, "pp")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named pp", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("pp.SourceColumns = %+v, want {Column:phone} (through the view's CTE)", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_StarBodiedViewResolves resolves a view defined as SELECT *
+// over a catalog-known base table: the definition's star expands against the
+// catalog, so a named reference through the view reaches the base column.
+func TestViewLineage_StarBodiedViewResolves(t *testing.T) {
+	span := viewSpan(t, "SELECT phone FROM star_v")
+	r, ok := resultByName(span, "phone")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named phone", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Catalog: "catalog1", Schema: "public", Table: "customer", Column: "phone"}) {
+		t.Errorf("phone.SourceColumns = %+v, want qualified catalog1.public.customer.phone (def star expanded via catalog)", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_CycleTerminatesOpaque guards that a definition cycle (a -> b
+// -> a, malformed metadata) terminates and leaves the views opaque rather than
+// hanging or panicking.
+func TestViewLineage_CycleTerminatesOpaque(t *testing.T) {
+	span := viewSpan(t, "SELECT x FROM cyc_a")
+	r, ok := resultByName(span, "x")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named x", span.Results)
+	}
+	// The cycle prevents resolution; the written ref is all that remains.
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "x"}) {
+		t.Errorf("x.SourceColumns = %+v, want the original {Column:x} retained", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_CrossSchemaContext resolves a view in another schema: its
+// definition's unqualified table reference resolves in the VIEW's schema, not
+// the session schema, and surfaces qualified.
+func TestViewLineage_CrossSchemaContext(t *testing.T) {
+	span := viewSpan(t, "SELECT token FROM other.other_v")
+	r, ok := resultByName(span, "token")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named token", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "token"}) {
+		t.Errorf("token.SourceColumns = %+v, want {Column:token}", r.SourceColumns)
+	}
+	if !hasTable(span, "catalog1", "other", "secrets") {
+		t.Errorf("AccessTables = %+v, want catalog1.other.secrets (resolved in the view's schema)", span.AccessTables)
+	}
+}
+
+// TestViewLineage_TablePrecedenceOverView guards catalog.ResolveRelation
+// parity: a table shadows a same-named view, so the reference binds to the
+// table (star expands to the TABLE's columns, not the view's projection).
+func TestViewLineage_TablePrecedenceOverView(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM dual")
+	if got := resultNames(span); !sameNames(got, "tcol") {
+		t.Fatalf("Results = %v, want [tcol] (table shadows the same-named view)", got)
+	}
+}
+
+// TestViewLineage_BaseTableStarExpandsViaCatalog covers the catalog-table star:
+// SELECT * over a catalog-known base table expands to its exact projection with
+// fully-qualified sources.
+func TestViewLineage_BaseTableStarExpandsViaCatalog(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM customer")
+	if got := resultNames(span); !sameNames(got, "id", "phone", "name", "phones") {
+		t.Fatalf("Results = %v, want [id phone name phones]", got)
+	}
+	want := ColumnRef{Catalog: "catalog1", Schema: "public", Table: "customer", Column: "phone"}
+	if !hasSource(span.Results[1].SourceColumns, want) {
+		t.Errorf("Results[1].SourceColumns = %+v, want %+v", span.Results[1].SourceColumns, want)
+	}
+}
+
+// TestViewLineage_MixedBaseDerivedStarExpands covers the formerly-opaque mixed
+// case: with a catalog, a star over a base table joined with a derived relation
+// expands at the true total width.
+func TestViewLineage_MixedBaseDerivedStarExpands(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM orders JOIN (SELECT phone FROM customer) d ON true")
+	if got := resultNames(span); !sameNames(got, "id", "k", "phone") {
+		t.Fatalf("Results = %v, want [id k phone]", got)
+	}
+	if !hasSource(span.Results[2].SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("Results[2].SourceColumns = %+v, want {Column:phone}", span.Results[2].SourceColumns)
+	}
+}
+
+// TestViewLineage_UnknownNameParity guards that a name the catalog cannot
+// resolve binds exactly as without a catalog (written-form ref, opaque star).
+func TestViewLineage_UnknownNameParity(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM mystery")
+	if got := resultNames(span); !sameNames(got, "*") {
+		t.Fatalf("Results = %v, want [*] (unknown relation stays opaque)", got)
+	}
+}
+
+// TestViewLineage_TableColumnAliasResolves covers relation column aliases over
+// a catalog table: FROM customer AS c(i, p, n, ps) renames the columns
+// positionally, so p (bare or c.p) must reach customer.phone.
+func TestViewLineage_TableColumnAliasResolves(t *testing.T) {
+	want := ColumnRef{Catalog: "catalog1", Schema: "public", Table: "customer", Column: "phone"}
+	span := viewSpan(t, "SELECT p FROM customer AS c(i, p, n, ps)")
+	r, ok := resultByName(span, "p")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named p", span.Results)
+	}
+	if !hasSource(r.SourceColumns, want) {
+		t.Errorf("p.SourceColumns = %+v, want %+v (positional relation column alias)", r.SourceColumns, want)
+	}
+
+	span = viewSpan(t, "SELECT c.p FROM customer AS c(i, p, n, ps)")
+	r, ok = resultByName(span, "p")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named p", span.Results)
+	}
+	if !hasSource(r.SourceColumns, want) {
+		t.Errorf("c.p SourceColumns = %+v, want %+v", r.SourceColumns, want)
+	}
+}
+
+// TestViewLineage_ViewOverAliasedTableResolves resolves a view whose definition
+// renames the base table's columns via relation column aliases.
+func TestViewLineage_ViewOverAliasedTableResolves(t *testing.T) {
+	span := viewSpan(t, "SELECT p FROM alias_v")
+	r, ok := resultByName(span, "p")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named p", span.Results)
+	}
+	want := ColumnRef{Catalog: "catalog1", Schema: "public", Table: "customer", Column: "phone"}
+	if !hasSource(r.SourceColumns, want) {
+		t.Errorf("p.SourceColumns = %+v, want %+v (through alias_v's renamed projection)", r.SourceColumns, want)
+	}
+}
+
+// TestViewLineage_StaleMetadataCountMismatchOpaque guards that a view whose
+// metadata column count disagrees with its analyzed definition (stale metadata)
+// is unresolvable: the true output shape is unknown, so expanding on either
+// width could misalign the positional masker.
+func TestViewLineage_StaleMetadataCountMismatchOpaque(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM stale_v")
+	if got := resultNames(span); !sameNames(got, "*") {
+		t.Fatalf("Results = %v, want exactly [*] (metadata/definition disagree; must stay opaque)", got)
+	}
+	span = viewSpan(t, "SELECT phone FROM stale_v")
+	r, ok := resultByName(span, "phone")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named phone", span.Results)
+	}
+	if len(r.SourceColumns) != 1 || r.SourceColumns[0] != (ColumnRef{Column: "phone"}) {
+		t.Errorf("phone.SourceColumns = %+v, want exactly the written [{Column:phone}] (no projection trusted)", r.SourceColumns)
+	}
+}
+
+// TestViewLineage_CycleStarStaysOpaque strengthens the cycle guard: a star over
+// a cyclic view must not expand from a partial (mid-cycle) projection.
+func TestViewLineage_CycleStarStaysOpaque(t *testing.T) {
+	span := viewSpan(t, "SELECT * FROM cyc_a")
+	if got := resultNames(span); !sameNames(got, "*") {
+		t.Fatalf("Results = %v, want exactly [*] (cyclic views are fully opaque)", got)
+	}
+	// Both orders: referencing cyc_b first must not seed a partial memo either.
+	span = viewSpan(t, "SELECT * FROM cyc_b JOIN cyc_a ON true")
+	if got := resultNames(span); !sameNames(got, "*") {
+		t.Fatalf("Results = %v, want exactly [*] (no partial projection memoized)", got)
+	}
+}
+
+// TestViewLineage_BaseColumnRefRetained guards additivity for a plain column
+// reference against a catalog-known base table: the written ref is always
+// retained, with the catalog-qualified form added beside it (the addition is
+// what resolves relation column aliases; for an unaliased table it merely
+// restates the same column).
+func TestViewLineage_BaseColumnRefRetained(t *testing.T) {
+	span := viewSpan(t, "SELECT phone FROM customer")
+	r, ok := resultByName(span, "phone")
+	if !ok {
+		t.Fatalf("Results = %+v, want a column named phone", span.Results)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Column: "phone"}) {
+		t.Errorf("phone.SourceColumns = %+v, want the written {Column:phone} retained", r.SourceColumns)
+	}
+	if !hasSource(r.SourceColumns, ColumnRef{Catalog: "catalog1", Schema: "public", Table: "customer", Column: "phone"}) {
+		t.Errorf("phone.SourceColumns = %+v, want the qualified catalog form added", r.SourceColumns)
+	}
+}

--- a/trino/catalog/table.go
+++ b/trino/catalog/table.go
@@ -71,8 +71,7 @@ func (t *Table) ColumnNames() []string {
 }
 
 // View is a Trino view (including materialized views). For completion and
-// lineage purposes a view exposes a column list just like a table; this
-// catalog does not retain the view's defining query.
+// lineage purposes a view exposes a column list just like a table.
 type View struct {
 	// Name is the normalized view name.
 	Name string
@@ -80,6 +79,12 @@ type View struct {
 	schema *Schema
 	// columns are the view's output columns in order.
 	columns []*Column
+	// Definition is the view's defining query text (the SELECT it was created
+	// AS), when known. analysis resolves column lineage through the view by
+	// analyzing this text in the view's own catalog/schema context; an empty
+	// Definition leaves the view opaque (lineage stops at the view column).
+	// Consumers populate it from their synced metadata.
+	Definition string
 }
 
 // Schema returns the schema that owns this view, or nil if detached.


### PR DESCRIPTION
## Summary

Fixes **BYT-9679** (view columns bypass masking) **in omni** — supersedes the consumer-side bytebase#20560 (closed), per the decision that view lineage belongs in omni's metadata-aware layer rather than each consumer. Stacked on #293 (which stacks on #286) — review the single commit `dcee0f1`; retarget/rebase as the stack merges.

A column selected through a view had lineage pointing at the *view* column; masking config can only attach to *table* columns, so the value came back unmasked:

```sql
-- masking policy on customer.phone; customer_v AS SELECT id, phone, name FROM customer
SELECT phone FROM customer_v;   -- returned in clear
```

## Approach

`analysis.GetQuerySpanWithCatalog(stmt, *catalog.Catalog)` — the same `trino/catalog` type completion already consumes; `catalog.View` gains a `Definition` field. A FROM reference the catalog resolves to a **view** binds as a *derived relation* carrying its definition's resolved projection (computed recursively in the view's own catalog/schema context, cycle-guarded, memoized) — so named refs, **`SELECT *` over views**, views-over-views, and CTE-based definitions all resolve through the existing #286/#293 resolver machinery. The definition's relations join `AccessTables` (qualified). A catalog-known base **table** binds with its catalog columns: stars over base tables and mixed base+derived joins expand to the exact projection, and relation column aliases (`FROM customer AS c(i, p, …)`) resolve.

Safety: resolution stays **additive** (written refs always retained); a star expands only when provably width/order-correct; **stale metadata (column-count mismatch with the definition) makes the view opaque** instead of risking a width-wrong expansion; a **nil catalog is byte-identical to `GetQuerySpan`** (entire existing suite passes unchanged).

## Verification

19 view-lineage regression tests (incl. cross-schema context, cycle termination + star opacity, table-shadows-view precedence, stale-metadata opacity, relation column aliases); full `trino/analysis` + `trino/catalog` suites green. (The `trino/parser` oracle-differential backtick failure is the pre-existing tracked `lexer_oracle` follow-up, reproduced with this change stashed.)

## Cross-review

Codex adversarial pass: 4 findings — relation-column-alias lineage (P0), stale-metadata count mismatch (P0), partial-projection memoization under cycles (P2) all fixed; intermediate views in `AccessTables` kept intentionally and documented (reading through a view accesses it). A focused re-verification pass confirmed the fixes sound.

## Consumer note (for the bytebase bump PR)

Bytebase wiring becomes: fill `catalog.View.Definition` when building the catalog it already builds, set the session context, and call `GetQuerySpanWithCatalog`. The base tables surfaced through views appear in `AccessTables` — base-table access checks then apply to queries through views; flagging for product review at bump time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)