### PR TITLE
perf(pg/catalog): make Exec predeclare pass linear over pending candidates

### DIFF
--- a/pg/catalog/exec.go
+++ b/pg/catalog/exec.go
@@ -49,8 +49,7 @@ func (c *Catalog) Exec(sql string, opts *ExecOptions) ([]ExecResult, error) {
 	// CREATE OR REPLACE functions when possible so earlier views can resolve
 	// RETURNS TABLE/OUT columns during analysis. Errors are still surfaced
 	// during normal statement execution below.
-	predeclaredFunctions := make(map[int]bool)
-	firstFunctionIndex := firstFunctionDefinitionIndexes(list)
+	pendingPredeclare := replaceableFunctionIndexes(list)
 
 	continueOnError := false
 	if opts != nil {
@@ -62,7 +61,9 @@ func (c *Catalog) Exec(sql string, opts *ExecOptions) ([]ExecResult, error) {
 		// Drain any leftover warnings from previous operations.
 		c.DrainWarnings()
 
-		c.predeclareReplaceableFunctions(list, predeclaredFunctions, firstFunctionIndex)
+		if len(pendingPredeclare) > 0 {
+			pendingPredeclare = c.predeclareReplaceableFunctions(list, pendingPredeclare)
+		}
 
 		// Unwrap RawStmt if present.
 		stmt := unwrapRawStmt(item)
@@ -102,39 +103,43 @@ func (c *Catalog) Exec(sql string, opts *ExecOptions) ([]ExecResult, error) {
 	return results, nil
 }
 
-func firstFunctionDefinitionIndexes(list *nodes.List) map[string]int {
-	first := make(map[string]int)
+// replaceableFunctionIndexes returns the statement indexes that are candidates
+// for pre-declaration: the first definition of each function identity, when
+// that first definition is CREATE OR REPLACE.
+func replaceableFunctionIndexes(list *nodes.List) []int {
+	seen := make(map[string]bool)
+	var indexes []int
 	for i, item := range list.Items {
 		fn, ok := unwrapRawStmt(item).(*nodes.CreateFunctionStmt)
 		if !ok {
 			continue
 		}
 		identity := functionIdentity(fn)
-		if _, exists := first[identity]; !exists {
-			first[identity] = i
+		if seen[identity] {
+			continue
+		}
+		seen[identity] = true
+		if fn.IsOrReplace {
+			indexes = append(indexes, i)
 		}
 	}
-	return first
+	return indexes
 }
 
-func (c *Catalog) predeclareReplaceableFunctions(list *nodes.List, predeclared map[int]bool, firstFunctionIndex map[string]int) {
-	for i, item := range list.Items {
-		if predeclared[i] {
-			continue
-		}
-		stmt := unwrapRawStmt(item)
-		fn, ok := stmt.(*nodes.CreateFunctionStmt)
-		if !ok || !fn.IsOrReplace {
-			continue
-		}
-		if firstFunctionIndex[functionIdentity(fn)] != i {
-			continue
-		}
-		if err := c.CreateFunctionStmt(fn); err == nil {
-			predeclared[i] = true
+// predeclareReplaceableFunctions attempts to pre-declare each pending
+// candidate and returns the indexes that still failed (e.g. because a
+// dependency appears later in the script) so they can be retried before
+// the next statement.
+func (c *Catalog) predeclareReplaceableFunctions(list *nodes.List, pending []int) []int {
+	remaining := pending[:0]
+	for _, i := range pending {
+		fn := unwrapRawStmt(list.Items[i]).(*nodes.CreateFunctionStmt)
+		if err := c.CreateFunctionStmt(fn); err != nil {
+			remaining = append(remaining, i)
 		}
 		c.DrainWarnings()
 	}
+	return remaining
 }
 
 func unwrapRawStmt(item nodes.Node) nodes.Node {

--- a/pg/catalog/exec_scaling_bench_test.go
+++ b/pg/catalog/exec_scaling_bench_test.go
@@ -1,0 +1,27 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// BenchmarkExecDMLScaling measures Exec over function-free scripts of
+// increasing statement counts. Time per run should scale linearly with n.
+func BenchmarkExecDMLScaling(b *testing.B) {
+	for _, n := range []int{1000, 10000} {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "UPDATE t SET c = %d WHERE id = %d;\n", i, i)
+		}
+		sql := sb.String()
+		b.Run(fmt.Sprintf("dml_%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				c := New()
+				if _, err := c.Exec(sql, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

`Catalog.Exec` called `predeclareReplaceableFunctions` before every statement, and that helper rescanned **all** `list.Items` each call (unwrap RawStmt, type-assert, map lookups) — making an n-statement script O(n²) even when it contains zero `CREATE OR REPLACE FUNCTION` statements.

- `replaceableFunctionIndexes` now computes the candidate list once up front: the first definition of each function identity, when that definition is `OR REPLACE` (the same filter the old `firstFunctionIndex` check expressed).
- `predeclareReplaceableFunctions` iterates only the pending candidates and returns the ones that still failed; the per-statement loop skips the call entirely once none remain, so function-free scripts pay nothing after the first statement.
- Retry semantics are preserved: a candidate that fails because its dependency appears later in the script stays pending and is retried before each subsequent statement until it succeeds.

## Why

Downstream SQL review over large scripts scaled quadratically. CPU profiling of bytebase's `BenchmarkE2E/pg/review` showed ~47% of time in `predeclareReplaceableFunctions` + map accesses.

## Verification

- `go test ./pg/...` passes, including the pg catalog container-oracle tests.
- New `BenchmarkExecDMLScaling` regression guard. omni `Exec` over DML-only scripts (M4 Pro): before 1k=3.7ms / 10k=197ms (53× per decade — quadratic); after 1k=1.5ms / 10k=12.7ms (~8.6× — linear).
- bytebase `BenchmarkE2E/pg/review` with omni replaced by this branch: dml_1k 6.6ms→5.5ms, dml_10k 232ms→43ms, dml_100k 22.2s→454ms (~49× faster), now linear and in line with the mysql tiers (5.6ms/56ms/567ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)