### PR TITLE
fix(snowflake): PIVOT/UNPIVOT — chained-clause parse, deparse, and lineage soundness

### DIFF
--- a/snowflake/analysis/query_span.go
+++ b/snowflake/analysis/query_span.go
@@ -106,6 +106,17 @@ type tableEntry struct {
 	// For a base table with unknown schema, we synthesize a * source column
 	// rather than enumerating specific columns.
 	isUnknown bool // true when we have no schema information
+	// opaque marks a PIVOT/UNPIVOT-derived relation. The output columns of a
+	// pivoted relation are computed from its source relation but carry names
+	// that do not exist on it (pivot value columns / the UNPIVOT value+name
+	// columns), and without catalog information the projection cannot be
+	// enumerated. To stay masking-sound, every column resolved through such
+	// an entry — star or named, qualified or bare — attributes to these
+	// whole-relation ("*") sources instead of fabricating per-column
+	// attributions. Over-attribution is deliberate: claiming base.* for a
+	// pivot output is conservative, while claiming base.Q1 for a column that
+	// actually carries agg(base.amount) would let a masking consumer leak.
+	opaque []*SourceColumn
 }
 
 // ---------------------------------------------------------------------------
@@ -176,6 +187,17 @@ func extractSelectStmt(s *ast.SelectStmt, scope *queryScope) *QuerySpan {
 	// Also include "table-level" sources for every FROM entry even if no
 	// columns are explicitly referenced (e.g. SELECT 1 FROM t still "touches" t).
 	for _, entry := range fromEntries {
+		if len(entry.opaque) > 0 {
+			// Pivoted relation: the alias names a derived relation, not a
+			// real table — record the underlying whole-relation sources.
+			for _, sc := range entry.opaque {
+				k := toSourceKey(sc)
+				if _, exists := sourcesMap[k]; !exists {
+					sourcesMap[k] = sc
+				}
+			}
+			continue
+		}
 		sc := &SourceColumn{Table: entry.alias, Column: "*"}
 		k := toSourceKey(sc)
 		if _, exists := sourcesMap[k]; !exists {
@@ -281,6 +303,13 @@ func resolveFromItem(item ast.Node, scope *queryScope) []tableEntry {
 
 // resolveTableRef resolves a single TableRef to a tableEntry.
 func resolveTableRef(ref *ast.TableRef, scope *queryScope) tableEntry {
+	// PIVOT/UNPIVOT (possibly chained via Nested): the relation's output
+	// columns are derived from the source relation under names the source
+	// does not have — resolve as an opaque-derived entry.
+	if ref.Pivot != nil || ref.Unpivot != nil || ref.Nested != nil {
+		return resolvePivotedRef(ref, scope)
+	}
+
 	// Subquery: (SELECT ...) AS alias
 	if ref.Subquery != nil {
 		subSpan := extractSpan(ref.Subquery, scope)
@@ -351,6 +380,70 @@ func resolveJoin(join *ast.JoinExpr, scope *queryScope) []tableEntry {
 	return append(left, right...)
 }
 
+// resolvePivotedRef resolves a TableRef that carries PIVOT/UNPIVOT clauses
+// (or a Nested chain of them) to an opaque-derived tableEntry: the entry is
+// addressed by the clause's trailing alias (PIVOT(...) AS p) and every column
+// resolved through it attributes to the underlying relation's whole-relation
+// sources. See tableEntry.opaque for the soundness rationale.
+func resolvePivotedRef(ref *ast.TableRef, scope *queryScope) tableEntry {
+	// Resolve the underlying source relation.
+	var base tableEntry
+	if ref.Nested != nil {
+		base = resolveTableRef(ref.Nested, scope)
+	} else {
+		stripped := *ref
+		stripped.Pivot = nil
+		stripped.Unpivot = nil
+		base = resolveTableRef(&stripped, scope)
+	}
+
+	// The pivoted relation is addressed by the clause's trailing alias when
+	// present (the parser stores it on the clause, not on the TableRef).
+	alias := ""
+	if ref.Pivot != nil {
+		alias = ref.Pivot.Alias.Normalize()
+	}
+	if alias == "" && ref.Unpivot != nil {
+		alias = ref.Unpivot.Alias.Normalize()
+	}
+	if alias == "" {
+		alias = ref.Alias.Normalize()
+	}
+	if alias == "" {
+		alias = base.alias
+	}
+
+	return tableEntry{
+		alias:     alias,
+		isUnknown: true,
+		opaque:    collapseEntryToOpaque(base),
+	}
+}
+
+// collapseEntryToOpaque reduces a resolved entry to its whole-relation ("*")
+// source set, used to attribute every column of a pivoted relation.
+func collapseEntryToOpaque(e tableEntry) []*SourceColumn {
+	if len(e.opaque) > 0 {
+		// Already opaque (chained PIVOT): keep the original base sources.
+		return e.opaque
+	}
+	var out []*SourceColumn
+	named := false
+	for _, c := range e.columns {
+		if c.Column == "*" {
+			out = append(out, c)
+		} else {
+			named = true
+		}
+	}
+	if named || len(out) == 0 {
+		// Subquery/CTE entries expose named columns; collapse them to a
+		// single whole-relation source under the entry's alias.
+		out = append(out, &SourceColumn{Table: e.alias, Column: "*"})
+	}
+	return out
+}
+
 // ---------------------------------------------------------------------------
 // SelectTarget resolution
 // ---------------------------------------------------------------------------
@@ -394,6 +487,12 @@ func resolveStarTarget(target *ast.SelectTarget, fromEntries []tableEntry) *Resu
 
 // expandEntryStar expands a tableEntry for * selection, filtering excluded columns.
 func expandEntryStar(entry tableEntry, excluded map[string]bool) []*SourceColumn {
+	if len(entry.opaque) > 0 {
+		// Pivoted relation: output column names are unrelated to the base
+		// columns, so EXCLUDE filtering cannot apply — return the
+		// whole-relation sources.
+		return entry.opaque
+	}
 	if entry.isUnknown || len(entry.columns) == 0 {
 		// Unknown table: emit a * pseudo-source.
 		return []*SourceColumn{{Table: entry.alias, Column: "*"}}
@@ -475,11 +574,12 @@ func collectColumnRefs(expr ast.Node, fromEntries []tableEntry) []*SourceColumn 
 		}
 		switch n := node.(type) {
 		case *ast.ColumnRef:
-			sc := resolveColumnRef(n, fromEntries)
-			k := toSourceKey(sc)
-			if !seen[k] {
-				seen[k] = true
-				refs = append(refs, sc)
+			for _, sc := range resolveColumnRef(n, fromEntries) {
+				k := toSourceKey(sc)
+				if !seen[k] {
+					seen[k] = true
+					refs = append(refs, sc)
+				}
 			}
 			return false // don't recurse into ColumnRef parts
 		case *ast.StarExpr:
@@ -503,24 +603,59 @@ func collectColumnRefs(expr ast.Node, fromEntries []tableEntry) []*SourceColumn 
 	return refs
 }
 
-// resolveColumnRef resolves a ColumnRef to a SourceColumn, looking up the
+// resolveColumnRef resolves a ColumnRef to its SourceColumns, looking up the
 // table qualifier from the FROM entries when only a column name is provided.
-func resolveColumnRef(ref *ast.ColumnRef, fromEntries []tableEntry) *SourceColumn {
+// A reference into a pivoted (opaque) relation resolves to that relation's
+// whole-relation sources rather than a fabricated per-column attribution.
+func resolveColumnRef(ref *ast.ColumnRef, fromEntries []tableEntry) []*SourceColumn {
 	parts := ref.Parts
+
+	// Qualified ref whose qualifier names a pivoted relation: attribute to
+	// the relation's whole-relation source set (e.g. p.Q1 with
+	// `t PIVOT(...) AS p` reads derived data, not a base column "Q1").
+	if len(parts) >= 2 {
+		qual := parts[0].Normalize()
+		for _, entry := range fromEntries {
+			if len(entry.opaque) > 0 && strings.EqualFold(entry.alias, qual) {
+				return entry.opaque
+			}
+		}
+	}
+
 	switch len(parts) {
 	case 1:
 		col := parts[0].Normalize()
-		// Try to find which table this column comes from.
-		table := resolveColumnToTable(col, fromEntries)
-		return &SourceColumn{Table: table, Column: col}
+		// A bare column in a scope containing pivoted relations may name one
+		// of their derived output columns: include those relations'
+		// whole-relation sources (conservative over-attribution).
+		var out []*SourceColumn
+		var plain []tableEntry
+		for _, entry := range fromEntries {
+			if len(entry.opaque) > 0 {
+				out = append(out, entry.opaque...)
+			} else {
+				plain = append(plain, entry)
+			}
+		}
+		if len(out) == 0 {
+			// No pivoted relations: existing resolution.
+			table := resolveColumnToTable(col, fromEntries)
+			return []*SourceColumn{{Table: table, Column: col}}
+		}
+		if len(plain) > 0 {
+			// The column may equally come from a non-pivoted relation.
+			table := resolveColumnToTable(col, plain)
+			out = append(out, &SourceColumn{Table: table, Column: col})
+		}
+		return out
 	case 2:
-		return &SourceColumn{Table: parts[0].Normalize(), Column: parts[1].Normalize()}
+		return []*SourceColumn{{Table: parts[0].Normalize(), Column: parts[1].Normalize()}}
 	case 3:
-		return &SourceColumn{Schema: parts[0].Normalize(), Table: parts[1].Normalize(), Column: parts[2].Normalize()}
+		return []*SourceColumn{{Schema: parts[0].Normalize(), Table: parts[1].Normalize(), Column: parts[2].Normalize()}}
 	case 4:
-		return &SourceColumn{Database: parts[0].Normalize(), Schema: parts[1].Normalize(), Table: parts[2].Normalize(), Column: parts[3].Normalize()}
+		return []*SourceColumn{{Database: parts[0].Normalize(), Schema: parts[1].Normalize(), Table: parts[2].Normalize(), Column: parts[3].Normalize()}}
 	}
-	return &SourceColumn{Column: strings.Join(identPartsToStrings(parts), ".")}
+	return []*SourceColumn{{Column: strings.Join(identPartsToStrings(parts), ".")}}
 }
 
 // resolveColumnToTable looks up which FROM entry contains the given column name.

--- a/snowflake/analysis/query_span_test.go
+++ b/snowflake/analysis/query_span_test.go
@@ -646,3 +646,124 @@ func TestQuerySpan_WithinGroupColumns(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PIVOT / UNPIVOT: opaque-derived relations (masking soundness)
+// ---------------------------------------------------------------------------
+//
+// The output columns of a pivoted relation are computed from the source
+// relation under names that do not exist on it. Without catalog information
+// the projection cannot be enumerated, so every column resolved through a
+// pivoted relation must attribute to the source's whole-relation ("*")
+// sources. Fabricating per-column attributions (e.g. T."2023_Q1" for a pivot
+// value column that actually carries SUM(T.AMOUNT)) would under-attribute and
+// let a masking consumer leak.
+
+func TestQuerySpan_PivotStar(t *testing.T) {
+	span := mustExtract(t, "SELECT * FROM t PIVOT(SUM(a) FOR m IN ('JAN', 'FEB')) AS p")
+
+	if len(span.Results) != 1 {
+		t.Fatalf("Results: got %d, want 1", len(span.Results))
+	}
+	keys := resultSourceKeys(span, 0)
+	want := []string{"..T.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+	// The pivot alias P must not surface as a source table.
+	for _, k := range sourceKeys(span) {
+		if strings.HasPrefix(k, "..P.") {
+			t.Errorf("pivot alias leaked into sources: %v", sourceKeys(span))
+		}
+	}
+}
+
+func TestQuerySpan_PivotValueColumnNotFabricated(t *testing.T) {
+	span := mustExtract(t, `SELECT "2023_Q1" FROM quarterly_sales PIVOT(SUM(amount) FOR quarter IN ('2023_Q1', '2023_Q2')) AS p`)
+
+	keys := resultSourceKeys(span, 0)
+	want := []string{"..QUARTERLY_SALES.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+	if hasSrcKey(span, "..QUARTERLY_SALES.2023_Q1") {
+		t.Error("fabricated base-column attribution for a pivot value column")
+	}
+}
+
+func TestQuerySpan_PivotQualifiedRef(t *testing.T) {
+	span := mustExtract(t, "SELECT p.q1 FROM db1.s1.t PIVOT(SUM(a) FOR m IN ('JAN')) AS p")
+
+	keys := resultSourceKeys(span, 0)
+	want := []string{"DB1.S1.T.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+	if hasSrcKey(span, "..P.Q1") {
+		t.Error("qualified ref through pivot alias must not fabricate table P")
+	}
+}
+
+func TestQuerySpan_PivotQualifiedStar(t *testing.T) {
+	span := mustExtract(t, "SELECT p.* FROM t PIVOT(SUM(a) FOR m IN ('JAN')) AS p")
+
+	keys := resultSourceKeys(span, 0)
+	want := []string{"..T.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+}
+
+func TestQuerySpan_UnpivotValueColumn(t *testing.T) {
+	span := mustExtract(t, "SELECT sales FROM monthly_sales UNPIVOT (sales FOR month IN (jan, feb)) unpvt")
+
+	keys := resultSourceKeys(span, 0)
+	want := []string{"..MONTHLY_SALES.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+	if hasSrcKey(span, "..MONTHLY_SALES.SALES") {
+		t.Error("UNPIVOT value column attributed to a nonexistent base column")
+	}
+	if hasSrcKey(span, "..UNPVT.SALES") {
+		t.Error("UNPIVOT alias fabricated as a source table")
+	}
+}
+
+func TestQuerySpan_PivotChainedOverSubquery(t *testing.T) {
+	span := mustExtract(t, `SELECT q1 FROM (SELECT a, b FROM real_table) PIVOT (SUM(a) FOR b IN ('x')) PIVOT (MAX(a) FOR b IN ('y')) AS pp`)
+
+	// The chain collapses to the subquery's whole-relation source (the
+	// package addresses unaliased subqueries as "_subquery").
+	keys := resultSourceKeys(span, 0)
+	want := []string{".._subquery.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+}
+
+func TestQuerySpan_PivotJoinMixedAttribution(t *testing.T) {
+	// A bare column in a scope with both a pivoted relation and a plain table
+	// may come from either: both must be attributed (conservative).
+	span := mustExtract(t, "SELECT x FROM t PIVOT(SUM(a) FOR m IN ('J')) AS p, u")
+
+	keys := resultSourceKeys(span, 0)
+	if len(keys) != 2 {
+		t.Fatalf("result sources: got %v, want T.* plus U.X", keys)
+	}
+	if keys[0] != "..T.*" || keys[1] != "..U.X" {
+		t.Errorf("result sources: got %v, want [..T.* ..U.X]", keys)
+	}
+}
+
+func TestQuerySpan_PivotOverCTE(t *testing.T) {
+	span := mustExtract(t, "WITH c AS (SELECT a FROM real_table) SELECT * FROM c PIVOT(SUM(a) FOR m IN ('J')) AS p")
+
+	// The CTE's columns collapse to a whole-relation source under the CTE
+	// name (consistent with how non-pivoted CTE references are reported).
+	keys := resultSourceKeys(span, 0)
+	want := []string{"..C.*"}
+	if len(keys) != 1 || keys[0] != want[0] {
+		t.Fatalf("result sources: got %v, want %v", keys, want)
+	}
+}

--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -826,6 +826,8 @@ type StarRename struct {
 //   - Table: Name is set, others nil
 //   - Subquery: Subquery is set, Name is nil
 //   - Table function: FuncCall is set, Name is nil
+//   - Chained PIVOT/UNPIVOT: Nested is set, carrying the previous
+//     pivoted source (see Nested below)
 //   - Any of the above can have Lateral = true
 type TableRef struct {
 	Name     *ObjectName   // table name; nil for subquery/func sources
@@ -834,7 +836,13 @@ type TableRef struct {
 	Subquery Node          // (SELECT ...) or (VALUES ...) in FROM; nil for table refs
 	FuncCall *FuncCallExpr // TABLE(func(...)); nil for table refs
 	DollarN  *DollarRef    // $N result-set table ref (RESULT_SCAN of a prior result); nil otherwise
-	Lateral  bool          // LATERAL prefix
+	// Nested is the source relation of a chained PIVOT/UNPIVOT: in
+	// `src PIVOT(...) PIVOT(...)` each clause after the first applies to the
+	// result of the previous one, so the parser re-roots the TableRef with
+	// the prior pivoted ref here. When Nested is set, Name/Subquery/FuncCall/
+	// DollarN are nil and exactly one of Pivot/Unpivot is set.
+	Nested  *TableRef
+	Lateral bool // LATERAL prefix
 	// Table-attached clauses (Snowflake). Any combination may appear; the
 	// documented source order is AT/BEFORE → CHANGES → MATCH_RECOGNIZE →
 	// PIVOT/UNPIVOT → alias → SAMPLE.

--- a/snowflake/ast/walk_coverage_test.go
+++ b/snowflake/ast/walk_coverage_test.go
@@ -221,6 +221,21 @@ func TestWalkCoverage_FromClauses(t *testing.T) {
 			tags: map[ast.NodeTag]int{ast.T_UnpivotColumn: 2},
 		},
 		{
+			name: "TableRef.Nested chained PIVOT reaches both clauses",
+			sql: `SELECT * FROM (SELECT * FROM quarterly_sales)
+				PIVOT (SUM(amount) FOR quarter_amount IN ('2023_Q1' AS q1, '2023_Q2'))
+				PIVOT (MAX(discount_percent) FOR quarter_discount IN ('2023_Q3'))`,
+			cols: []string{"AMOUNT", "QUARTER_AMOUNT", "DISCOUNT_PERCENT", "QUARTER_DISCOUNT"},
+			lits: []string{"2023_Q1", "2023_Q2", "2023_Q3"},
+			tags: map[ast.NodeTag]int{ast.T_PivotClause: 2, ast.T_PivotValue: 3},
+		},
+		{
+			name: "TableRef.Nested UNPIVOT then PIVOT",
+			sql:  "SELECT * FROM t UNPIVOT (v FOR n IN (ca, cb)) PIVOT (SUM(v) FOR n IN ('x'))",
+			cols: []string{"V", "N"},
+			tags: map[ast.NodeTag]int{ast.T_UnpivotClause: 1, ast.T_PivotClause: 1, ast.T_UnpivotColumn: 2},
+		},
+		{
 			name: "MatchRecognizeClause OrderBy/Measures/Define",
 			sql: `SELECT * FROM stock_price_history MATCH_RECOGNIZE(
 				PARTITION BY company

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -1318,6 +1318,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.DollarN != nil {
 			Walk(v, n.DollarN)
 		}
+		if n.Nested != nil {
+			Walk(v, n.Nested)
+		}
 		if n.TimeTravel != nil {
 			Walk(v, n.TimeTravel)
 		}

--- a/snowflake/deparse/deparse_select.go
+++ b/snowflake/deparse/deparse_select.go
@@ -301,6 +301,11 @@ func (w *writer) writeTableRef(n *ast.TableRef) error {
 		w.buf.WriteString("LATERAL ")
 	}
 	switch {
+	case n.Nested != nil:
+		// Chained PIVOT/UNPIVOT: the source is itself a pivoted ref.
+		if err := w.writeTableRef(n.Nested); err != nil {
+			return err
+		}
 	case n.Name != nil:
 		w.buf.WriteString(n.Name.String())
 	case n.Subquery != nil:
@@ -319,6 +324,20 @@ func (w *writer) writeTableRef(n *ast.TableRef) error {
 			return err
 		}
 	}
+	// PIVOT / UNPIVOT come before the alias position in the documented
+	// clause order (each clause carries its own trailing alias).
+	if n.Pivot != nil {
+		w.buf.WriteByte(' ')
+		if err := w.writePivotClause(n.Pivot); err != nil {
+			return err
+		}
+	}
+	if n.Unpivot != nil {
+		w.buf.WriteByte(' ')
+		if err := w.writeUnpivotClause(n.Unpivot); err != nil {
+			return err
+		}
+	}
 	if !n.Alias.IsEmpty() {
 		w.buf.WriteString(" AS ")
 		w.buf.WriteString(n.Alias.String())
@@ -333,6 +352,106 @@ func (w *writer) writeTableRef(n *ast.TableRef) error {
 			w.buf.WriteString(col.String())
 		}
 		w.buf.WriteByte(')')
+	}
+	return nil
+}
+
+// writePivotClause emits PIVOT (agg [AS a] FOR col IN (...) [DEFAULT ON NULL
+// (expr)]) [AS alias].
+func (w *writer) writePivotClause(n *ast.PivotClause) error {
+	w.buf.WriteString("PIVOT (")
+	if err := writeExprNoLeadSpace(w, n.Agg); err != nil {
+		return err
+	}
+	if !n.AggAlias.IsEmpty() {
+		w.buf.WriteString(" AS ")
+		w.buf.WriteString(n.AggAlias.String())
+	}
+	w.buf.WriteString(" FOR ")
+	if err := writeExprNoLeadSpace(w, n.ForColumn); err != nil {
+		return err
+	}
+	w.buf.WriteString(" IN (")
+	if n.In == nil {
+		return fmt.Errorf("deparse: PIVOT clause without IN list")
+	}
+	switch n.In.Kind {
+	case ast.PivotInAny:
+		w.buf.WriteString("ANY")
+		if len(n.In.OrderBy) > 0 {
+			w.buf.WriteString(" ORDER BY ")
+			for i, item := range n.In.OrderBy {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				if err := w.writeOrderItem(item); err != nil {
+					return err
+				}
+			}
+		}
+	case ast.PivotInSubquery:
+		if err := w.writeQueryExpr(n.In.Subquery); err != nil {
+			return err
+		}
+	default: // PivotInValues
+		for i, val := range n.In.Values {
+			if i > 0 {
+				w.buf.WriteString(", ")
+			}
+			if err := writeExprNoLeadSpace(w, val.Value); err != nil {
+				return err
+			}
+			if !val.Alias.IsEmpty() {
+				w.buf.WriteString(" AS ")
+				w.buf.WriteString(val.Alias.String())
+			}
+		}
+	}
+	w.buf.WriteByte(')')
+	if n.DefaultVal != nil {
+		w.buf.WriteString(" DEFAULT ON NULL (")
+		if err := writeExprNoLeadSpace(w, n.DefaultVal); err != nil {
+			return err
+		}
+		w.buf.WriteByte(')')
+	}
+	w.buf.WriteByte(')')
+	if !n.Alias.IsEmpty() {
+		w.buf.WriteString(" AS ")
+		w.buf.WriteString(n.Alias.String())
+	}
+	return nil
+}
+
+// writeUnpivotClause emits UNPIVOT [INCLUDE|EXCLUDE NULLS] (val FOR name IN
+// (col [AS a], ...)) [AS alias].
+func (w *writer) writeUnpivotClause(n *ast.UnpivotClause) error {
+	w.buf.WriteString("UNPIVOT ")
+	switch n.NullsMode {
+	case ast.UnpivotIncludeNulls:
+		w.buf.WriteString("INCLUDE NULLS ")
+	case ast.UnpivotExcludeNulls:
+		w.buf.WriteString("EXCLUDE NULLS ")
+	}
+	w.buf.WriteByte('(')
+	w.buf.WriteString(n.ValueColumn.String())
+	w.buf.WriteString(" FOR ")
+	w.buf.WriteString(n.NameColumn.String())
+	w.buf.WriteString(" IN (")
+	for i, col := range n.Columns {
+		if i > 0 {
+			w.buf.WriteString(", ")
+		}
+		w.buf.WriteString(col.Column.String())
+		if !col.Alias.IsEmpty() {
+			w.buf.WriteString(" AS ")
+			w.buf.WriteString(col.Alias.String())
+		}
+	}
+	w.buf.WriteString("))")
+	if !n.Alias.IsEmpty() {
+		w.buf.WriteString(" AS ")
+		w.buf.WriteString(n.Alias.String())
 	}
 	return nil
 }

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -245,6 +245,38 @@ func TestDeparse_Select_JoinUsing(t *testing.T) {
 	assertRoundTrip(t, `SELECT a.x FROM a JOIN b USING (id)`)
 }
 
+func TestDeparse_Select_PivotValues(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM quarterly_sales PIVOT (SUM(amount) FOR quarter IN ('2023_Q1', '2023_Q2'))`)
+}
+
+func TestDeparse_Select_PivotValueAliasesDefaultOnNull(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM quarterly_sales PIVOT (SUM(amount) AS total FOR quarter IN ('2023_Q1' AS q1, '2023_Q2' AS q2) DEFAULT ON NULL (0)) AS p`)
+}
+
+func TestDeparse_Select_PivotAnyOrderBy(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM quarterly_sales PIVOT (SUM(amount) FOR quarter IN (ANY ORDER BY quarter)) ORDER BY empid`)
+}
+
+func TestDeparse_Select_PivotInSubquery(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM quarterly_sales PIVOT (SUM(amount) FOR quarter IN (SELECT DISTINCT quarter FROM ad_campaign_types_by_quarter WHERE television = TRUE))`)
+}
+
+func TestDeparse_Select_PivotChained(t *testing.T) {
+	assertRoundTrip(t, `SELECT q1 FROM (SELECT amount, quarter_amount, quarter_discount, discount_percent FROM quarterly_sales) PIVOT (SUM(amount) FOR quarter_amount IN ('2023_Q1', '2023_Q2')) PIVOT (MAX(discount_percent) FOR quarter_discount IN ('2023_Q1')) AS pp`)
+}
+
+func TestDeparse_Select_Unpivot(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM monthly_sales UNPIVOT (sales FOR month IN (jan, feb, mar, apr)) ORDER BY empid`)
+}
+
+func TestDeparse_Select_UnpivotIncludeNullsAliases(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM monthly_sales UNPIVOT INCLUDE NULLS (sales FOR month IN (jan AS january, feb AS february)) AS u`)
+}
+
+func TestDeparse_Select_UnpivotThenJoin(t *testing.T) {
+	assertRoundTrip(t, `SELECT * FROM monthly_sales UNPIVOT (sales FOR month IN (jan, feb)) AS unpvt JOIN d ON unpvt.empid = d.empid`)
+}
+
 func TestDeparse_Select_Fetch(t *testing.T) {
 	assertRoundTrip(t, `SELECT a FROM t FETCH FIRST 5 ROWS ONLY`)
 }

--- a/snowflake/parser/pivot_sample.go
+++ b/snowflake/parser/pivot_sample.go
@@ -20,6 +20,19 @@ package parser
 
 import "github.com/bytebase/omni/snowflake/ast"
 
+// parsePivotTrailingAlias parses the optional trailing alias of a PIVOT /
+// UNPIVOT clause. Unlike parseOptionalAlias it refuses to treat the head of a
+// chained PIVOT/UNPIVOT clause — the (non-reserved) keyword followed by
+// '(' — as an implicit alias, so `t PIVOT(...) PIVOT(...)` stays parseable as
+// a chain instead of the second clause being eaten as alias "PIVOT" and its
+// body discarded. An explicit `AS pivot` alias is still accepted.
+func (p *Parser) parsePivotTrailingAlias() (ast.Ident, bool) {
+	if (p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT) && p.peekNext().Type == '(' {
+		return ast.Ident{}, false
+	}
+	return p.parseOptionalAlias()
+}
+
 // parsePivotClause parses a PIVOT (...) clause. The caller has verified that
 // p.cur is kwPIVOT.
 func (p *Parser) parsePivotClause() (*ast.PivotClause, error) {
@@ -106,7 +119,7 @@ func (p *Parser) parsePivotClause() (*ast.PivotClause, error) {
 	clause.Loc.End = closeTok.Loc.End
 
 	// Optional trailing [AS] alias for the pivot result.
-	if alias, has := p.parseOptionalAlias(); has {
+	if alias, has := p.parsePivotTrailingAlias(); has {
 		clause.Alias = alias
 		clause.Loc.End = p.prev.Loc.End
 	}
@@ -291,7 +304,7 @@ func (p *Parser) parseUnpivotClause() (*ast.UnpivotClause, error) {
 	clause.Loc.End = closeTok.Loc.End
 
 	// Optional trailing alias.
-	if alias, has := p.parseOptionalAlias(); has {
+	if alias, has := p.parsePivotTrailingAlias(); has {
 		clause.Alias = alias
 		clause.Loc.End = p.prev.Loc.End
 	}

--- a/snowflake/parser/pivot_sample_test.go
+++ b/snowflake/parser/pivot_sample_test.go
@@ -172,6 +172,77 @@ func TestPivot_Chained(t *testing.T) {
 	if ref.Pivot == nil {
 		t.Fatal("outer table ref has no PIVOT")
 	}
+	// The outer clause is the SECOND pivot (MAX); the keyword PIVOT must not
+	// have been eaten as the first clause's implicit alias.
+	if got := ref.Pivot.Agg.Name.Name.Normalize(); got != "MAX" {
+		t.Errorf("outer pivot agg = %q, want MAX", got)
+	}
+	if ref.Nested == nil {
+		t.Fatal("outer table ref has no Nested source for the chain")
+	}
+	inner := ref.Nested
+	if inner.Pivot == nil {
+		t.Fatal("nested table ref has no PIVOT")
+	}
+	if got := inner.Pivot.Agg.Name.Name.Normalize(); got != "SUM" {
+		t.Errorf("inner pivot agg = %q, want SUM", got)
+	}
+	if inner.Pivot.Alias.Name != "" {
+		t.Errorf("inner pivot alias = %q, want empty (PIVOT keyword must not become an alias)", inner.Pivot.Alias.Name)
+	}
+	if inner.Subquery == nil {
+		t.Error("nested table ref lost its subquery source")
+	}
+	// Loc sanity: the outer ref spans from the subquery start through the
+	// second pivot's closing paren.
+	if ref.Loc.Start != inner.Loc.Start {
+		t.Errorf("outer Loc.Start = %d, want %d (inner start)", ref.Loc.Start, inner.Loc.Start)
+	}
+	if ref.Loc.End != ref.Pivot.Loc.End {
+		t.Errorf("outer Loc.End = %d, want %d (outer pivot end)", ref.Loc.End, ref.Pivot.Loc.End)
+	}
+}
+
+func TestPivot_ChainedTrailingAlias(t *testing.T) {
+	sel := firstSelect(t, "SELECT * FROM t PIVOT (SUM(a) FOR b IN ('x')) PIVOT (MAX(c) FOR d IN ('y')) AS pp")
+	ref := firstTableRef(t, sel)
+	if ref.Pivot == nil || ref.Nested == nil || ref.Nested.Pivot == nil {
+		t.Fatalf("chain shape: outer pivot=%v nested=%v", ref.Pivot != nil, ref.Nested != nil)
+	}
+	if ref.Pivot.Alias.Name != "pp" {
+		t.Errorf("outer pivot alias = %q, want pp", ref.Pivot.Alias.Name)
+	}
+	if ref.Nested.Name == nil {
+		t.Error("nested ref lost its table name")
+	}
+}
+
+func TestPivot_ChainedMixedUnpivotPivot(t *testing.T) {
+	sel := firstSelect(t, "SELECT * FROM t UNPIVOT (v FOR n IN (a, b)) PIVOT (SUM(v) FOR n IN ('a'))")
+	ref := firstTableRef(t, sel)
+	if ref.Pivot == nil {
+		t.Fatal("outer ref must carry the PIVOT")
+	}
+	if ref.Nested == nil || ref.Nested.Unpivot == nil {
+		t.Fatal("nested ref must carry the UNPIVOT")
+	}
+	if ref.Unpivot != nil {
+		t.Error("outer ref must not also carry the UNPIVOT")
+	}
+}
+
+func TestPivot_ChainedThenSample(t *testing.T) {
+	sel := firstSelect(t, "SELECT * FROM t PIVOT (SUM(a) FOR b IN ('x')) PIVOT (MAX(c) FOR d IN ('y')) SAMPLE (10)")
+	ref := firstTableRef(t, sel)
+	if ref.Pivot == nil || ref.Nested == nil {
+		t.Fatal("expected chained pivot shape")
+	}
+	if ref.Sample == nil {
+		t.Error("trailing SAMPLE must attach to the outer pivoted ref")
+	}
+	if ref.Nested.Sample != nil {
+		t.Error("SAMPLE must not leak onto the nested ref")
+	}
 }
 
 func TestPivot_OverSubquerySource(t *testing.T) {

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -1146,25 +1146,41 @@ func (p *Parser) parseTableSuffix(ref *ast.TableRef) error {
 		return p.parseTrailingSample(ref)
 	}
 
-	// PIVOT ( … ) | UNPIVOT ( … )
-	switch p.cur.Type {
-	case kwPIVOT:
-		pv, err := p.parsePivotClause()
-		if err != nil {
-			return err
+	// PIVOT ( … ) | UNPIVOT ( … ) — possibly chained (`src PIVOT(...)
+	// PIVOT(...)`, official docs): each subsequent clause applies to the
+	// result of the previous one, so on the second and later clauses the ref
+	// is re-rooted in place with the prior contents moved to Nested.
+	pivoted := false
+	for p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+		if ref.Pivot != nil || ref.Unpivot != nil {
+			inner := &ast.TableRef{}
+			*inner = *ref
+			*ref = ast.TableRef{
+				Nested: inner,
+				Loc:    ast.Loc{Start: inner.Loc.Start, End: inner.Loc.End},
+			}
 		}
-		ref.Pivot = pv
-		ref.Loc.End = pv.Loc.End
-		// PIVOT consumes its own trailing alias; only SAMPLE may follow.
-		return p.parseTrailingSample(ref)
-	case kwUNPIVOT:
-		uv, err := p.parseUnpivotClause()
-		if err != nil {
-			return err
+		switch p.cur.Type {
+		case kwPIVOT:
+			pv, err := p.parsePivotClause()
+			if err != nil {
+				return err
+			}
+			ref.Pivot = pv
+			ref.Loc.End = pv.Loc.End
+		case kwUNPIVOT:
+			uv, err := p.parseUnpivotClause()
+			if err != nil {
+				return err
+			}
+			ref.Unpivot = uv
+			ref.Loc.End = uv.Loc.End
 		}
-		ref.Unpivot = uv
-		ref.Loc.End = uv.Loc.End
-		// UNPIVOT consumes its own trailing alias; only SAMPLE may follow.
+		pivoted = true
+	}
+	if pivoted {
+		// PIVOT/UNPIVOT consume their own trailing alias; only SAMPLE may
+		// follow.
 		return p.parseTrailingSample(ref)
 	}
 


### PR DESCRIPTION
## Fix
PIVOT/UNPIVOT soundness (found by bytebase cutover P1 review): the AST nodes existed (#261) but (1) chained `t PIVOT(...) PIVOT(...)` mis-parsed (2nd keyword eaten as implicit alias, clause dropped), (2) deparse emitted nothing for Pivot/Unpivot, (3) analysis resolved pivoted refs as the bare base table, fabricating source columns like `T."2023_Q1"` (under-attribution leak).

New `TableRef.Nested` for chains; alias guard refuses PIVOT/UNPIVOT clause heads; deparse round-trips all forms; analysis attributes every column through a pivoted relation to whole-relation sources (masking-sound over-attribution, matching the catalog-less convention). 23 new tests; full suite + corpus green; walker regenerated (guard green). Verified on fresh checkout of aeadf5d9.

Residual chips filed: parser-wide trailing-token drop; MATCH_RECOGNIZE same-class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
