### PR TITLE
feat(snowflake): parse star REPLACE transform (was silently dropped with FROM)

### DIFF
--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -802,16 +802,18 @@ var _ Node = (*SelectStmt)(nil)
 // For expressions: Expr is set, Star is false.
 // For star: Star is true, Expr may be a qualifier (table.*) or nil (bare *).
 //
-// Exclude / Rename carry the Snowflake star column-transforms that may follow
-// a `*` or `tbl.*`: EXCLUDE drops the named columns; RENAME aliases them. Both
-// may appear together (EXCLUDE then RENAME). They are only valid on a star
-// target.
+// Exclude / Replace / Rename carry the Snowflake star column-transforms that
+// may follow a `*` or `tbl.*`: EXCLUDE drops the named columns; REPLACE
+// substitutes an expression for a column while keeping its name; RENAME
+// aliases columns. Any combination may appear together, in documented order
+// (EXCLUDE, then REPLACE, then RENAME). They are only valid on a star target.
 type SelectTarget struct {
-	Expr    Node         // expression; nil for bare *
-	Alias   Ident        // AS alias; zero Ident if absent
-	Star    bool         // true for * or qualifier.*
-	Exclude []Ident      // EXCLUDE columns; nil if absent
-	Rename  []StarRename // RENAME col AS alias pairs; nil if absent
+	Expr    Node          // expression; nil for bare *
+	Alias   Ident         // AS alias; zero Ident if absent
+	Star    bool          // true for * or qualifier.*
+	Exclude []Ident       // EXCLUDE columns; nil if absent
+	Replace []StarReplace // REPLACE expr AS col pairs; nil if absent
+	Rename  []StarRename  // RENAME col AS alias pairs; nil if absent
 	Loc     Loc
 }
 
@@ -819,6 +821,14 @@ type SelectTarget struct {
 type StarRename struct {
 	Col   Ident // source column name
 	Alias Ident // new alias
+}
+
+// StarReplace is one `expr AS col` pair in a `SELECT * REPLACE (...)`
+// transform: the expression replaces the value of the existing column named
+// Col in the star expansion (the output column keeps that name).
+type StarReplace struct {
+	Expr Node  // replacement expression
+	Col  Ident // existing column name being replaced
 }
 
 // TableRef is a table reference in the FROM clause.

--- a/snowflake/ast/walk_coverage_test.go
+++ b/snowflake/ast/walk_coverage_test.go
@@ -168,6 +168,11 @@ func TestWalkCoverage_SelectClauses(t *testing.T) {
 			cols: []string{"TA", "TB"},
 		},
 		{
+			name: "SelectTarget.Replace star-transform expressions",
+			sql:  "SELECT * REPLACE (UPPER(ra) AS ssn, rb || rc AS dept) FROM t",
+			cols: []string{"RA", "RB", "RC"},
+		},
+		{
 			name: "SelectStmt.With CTE body",
 			sql:  "WITH c AS (SELECT ca FROM t) SELECT * FROM c",
 			cols: []string{"CA"},

--- a/snowflake/ast/walk_generated.go
+++ b/snowflake/ast/walk_generated.go
@@ -1597,6 +1597,9 @@ func walkSelectTarget(v Visitor, n *SelectTarget) {
 		return
 	}
 	Walk(v, n.Expr)
+	for i := range n.Replace {
+		walkStarReplace(v, &n.Replace[i])
+	}
 }
 
 // walkSetVar walks the node-bearing fields of the non-Node helper struct
@@ -1607,6 +1610,16 @@ func walkSetVar(v Visitor, n *SetVar) {
 		return
 	}
 	Walk(v, n.Value)
+}
+
+// walkStarReplace walks the node-bearing fields of the non-Node helper struct
+// StarReplace. The helper itself is not visited (it is not a Node); its child
+// nodes are walked in field order.
+func walkStarReplace(v Visitor, n *StarReplace) {
+	if n == nil {
+		return
+	}
+	Walk(v, n.Expr)
 }
 
 // walkStreamTimeTravel walks the node-bearing fields of the non-Node helper struct

--- a/snowflake/deparse/deparse_select.go
+++ b/snowflake/deparse/deparse_select.go
@@ -249,6 +249,21 @@ func (w *writer) writeSelectTarget(t *ast.SelectTarget) error {
 			}
 			w.buf.WriteByte(')')
 		}
+		// REPLACE (expr AS col, ...)
+		if len(t.Replace) > 0 {
+			w.buf.WriteString(" REPLACE (")
+			for i, r := range t.Replace {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				if err := writeExprNoLeadSpace(w, r.Expr); err != nil {
+					return err
+				}
+				w.buf.WriteString(" AS ")
+				w.buf.WriteString(r.Col.String())
+			}
+			w.buf.WriteByte(')')
+		}
 		// RENAME (col AS alias, ...)
 		if len(t.Rename) > 0 {
 			w.buf.WriteString(" RENAME (")

--- a/snowflake/deparse/deparse_test.go
+++ b/snowflake/deparse/deparse_test.go
@@ -134,8 +134,25 @@ func TestDeparse_Select_RenameStarList(t *testing.T) {
 	assertRoundTrip(t, `SELECT * RENAME (a AS b, c AS d) FROM t`)
 }
 
+func TestDeparse_Select_ReplaceStar(t *testing.T) {
+	assertRoundTrip(t, `SELECT * REPLACE (UPPER(SSN) AS SSN) FROM T`)
+}
+
+func TestDeparse_Select_ReplaceStarList(t *testing.T) {
+	assertRoundTrip(t, `SELECT * REPLACE ('DEPT-' || department_id AS department_id, UPPER(name) AS name) FROM t`)
+}
+
+func TestDeparse_Select_QualifiedStarReplace(t *testing.T) {
+	assertRoundTrip(t, `SELECT t.* REPLACE (UPPER(x) AS x) FROM t`)
+}
+
 func TestDeparse_Select_ExcludeAndRenameStar(t *testing.T) {
 	assertRoundTrip(t, `SELECT * EXCLUDE x RENAME (a AS b, c AS d) FROM t`)
+}
+
+func TestDeparse_Select_ExcludeReplaceRenameStar(t *testing.T) {
+	// All three star transforms in Snowflake's documented order.
+	assertRoundTrip(t, `SELECT * EXCLUDE x REPLACE (UPPER(s) AS s) RENAME (a AS b) FROM t`)
 }
 
 func TestDeparse_Select_QualifiedStarExcludeRename(t *testing.T) {

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -490,7 +490,7 @@ func (p *Parser) selectListTerminator() bool {
 }
 
 // parseSelectTarget parses one item in the SELECT list:
-//   - * [EXCLUDE (col, ...)]
+//   - * [EXCLUDE (col, ...)] [REPLACE (expr AS col, ...)] [RENAME (col AS alias, ...)]
 //   - expr [AS alias]
 //
 // The expression parser already handles * (StarExpr) and qualifier.*
@@ -513,9 +513,10 @@ func (p *Parser) parseSelectTarget() (*ast.SelectTarget, error) {
 		target.Star = true
 		target.Expr = expr
 
-		// Star column-transforms: EXCLUDE then RENAME (Snowflake documents
-		// EXCLUDE before RENAME; either or both may be present).
+		// Star column-transforms, in Snowflake's documented order: EXCLUDE,
+		// then REPLACE, then RENAME (any subset may be present).
 		//   EXCLUDE <col> | EXCLUDE (<col>, ...)
+		//   REPLACE (<expr> AS <col>, ...)
 		//   RENAME <col> AS <alias> | RENAME (<col> AS <alias>, ...)
 		if p.cur.Type == kwEXCLUDE {
 			p.advance() // consume EXCLUDE
@@ -523,10 +524,28 @@ func (p *Parser) parseSelectTarget() (*ast.SelectTarget, error) {
 				return nil, err
 			}
 		}
+		if p.cur.Type == kwREPLACE {
+			p.advance() // consume REPLACE
+			if err := p.parseStarReplace(target); err != nil {
+				return nil, err
+			}
+		}
 		if p.cur.Type == kwRENAME {
 			p.advance() // consume RENAME
 			if err := p.parseStarRename(target); err != nil {
 				return nil, err
+			}
+		}
+		// A transform keyword still pending here is out of documented order
+		// (e.g. `* RENAME (...) REPLACE (...)`). parseSingle ignores tokens
+		// after a completed statement, so without this check the rest of the
+		// statement — including FROM — would be dropped silently. Fail loudly
+		// instead.
+		switch p.cur.Type {
+		case kwEXCLUDE, kwREPLACE, kwRENAME:
+			return nil, &ParseError{
+				Loc: p.cur.Loc,
+				Msg: "star column-transforms must appear in EXCLUDE, REPLACE, RENAME order",
 			}
 		}
 	} else {
@@ -642,6 +661,58 @@ func (p *Parser) parseStarRenamePair() (ast.StarRename, error) {
 		return ast.StarRename{}, err
 	}
 	return ast.StarRename{Col: col, Alias: alias}, nil
+}
+
+// parseStarReplace parses the REPLACE column-transform that may follow a star
+// in a SELECT list. The REPLACE keyword has already been consumed. Unlike
+// EXCLUDE and RENAME, Snowflake documents only the parenthesized form (the
+// replacement is an arbitrary expression, so the parentheses are required):
+//
+//	REPLACE (<expr> AS <col> [, <expr> AS <col>, ...])
+func (p *Parser) parseStarReplace(target *ast.SelectTarget) error {
+	if _, err := p.expect('('); err != nil {
+		return err
+	}
+	for {
+		// Progress guard: see parseStarExclude — the cursor must strictly
+		// advance each iteration.
+		before := p.cur.Loc.Start
+		pair, err := p.parseStarReplacePair()
+		if err != nil {
+			return err
+		}
+		target.Replace = append(target.Replace, pair)
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance() // consume ','
+		if p.cur.Loc.Start <= before {
+			return &ParseError{Loc: p.cur.Loc, Msg: "malformed REPLACE list"}
+		}
+	}
+	if _, err := p.expect(')'); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseStarReplacePair parses one `<expr> AS <col>` pair of a REPLACE
+// transform. The AS keyword is required (Snowflake's documented syntax); Col
+// must name an existing column of the star expansion, which the parser cannot
+// check — it records whatever identifier follows AS.
+func (p *Parser) parseStarReplacePair() (ast.StarReplace, error) {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return ast.StarReplace{}, err
+	}
+	if _, err := p.expect(kwAS); err != nil {
+		return ast.StarReplace{}, err
+	}
+	col, err := p.parseIdent()
+	if err != nil {
+		return ast.StarReplace{}, err
+	}
+	return ast.StarReplace{Expr: expr, Col: col}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/parser/select_test.go
+++ b/snowflake/parser/select_test.go
@@ -2196,6 +2196,206 @@ func TestSelect_StarExcludeLoc(t *testing.T) {
 	}
 }
 
+// Regression for the star-REPLACE silent drop: this statement used to
+// parse-prefix to just `SELECT *` with ZERO errors — REPLACE, its pairs, AND
+// the FROM clause were dropped from the AST (SelectStmt.From empty), which is
+// masking-unsound for query-span consumers. It must now parse fully: Replace
+// populated and From non-empty.
+func TestSelect_StarReplaceSingle(t *testing.T) {
+	const sql = "SELECT * REPLACE (UPPER(SSN) AS SSN) FROM T"
+	sel, errs := testParseSelectStmt(sql)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if !target.Star {
+		t.Fatal("target should be star")
+	}
+	if len(target.Replace) != 1 {
+		t.Fatalf("replace = %d, want 1", len(target.Replace))
+	}
+	if target.Replace[0].Col.Name != "SSN" {
+		t.Errorf("replace[0].Col = %q, want %q", target.Replace[0].Col.Name, "SSN")
+	}
+	fn, ok := target.Replace[0].Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("replace[0].Expr = %T, want *ast.FuncCallExpr", target.Replace[0].Expr)
+	}
+	if fn.Name.Normalize() != "UPPER" {
+		t.Errorf("replace[0].Expr func = %q, want UPPER", fn.Name.Normalize())
+	}
+	// The FROM clause must survive — this is the silent-drop regression check.
+	if len(sel.From) != 1 {
+		t.Fatalf("From = %d entries, want 1 (FROM clause was dropped)", len(sel.From))
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok || ref.Name == nil || ref.Name.Normalize() != "T" {
+		t.Errorf("From[0] = %#v, want table T", sel.From[0])
+	}
+	// And the statement must span the whole input, not a prefix.
+	if got := sql[sel.Loc.Start:sel.Loc.End]; got != sql {
+		t.Errorf("stmt Loc slice = %q, want full input", got)
+	}
+}
+
+func TestSelect_StarReplaceList(t *testing.T) {
+	sel, errs := testParseSelectStmt(
+		"SELECT * REPLACE ('DEPT-' || department_id AS department_id, UPPER(name) AS name) FROM employee_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if len(target.Replace) != 2 {
+		t.Fatalf("replace = %d, want 2", len(target.Replace))
+	}
+	if target.Replace[0].Col.Name != "department_id" {
+		t.Errorf("replace[0].Col = %q, want department_id", target.Replace[0].Col.Name)
+	}
+	if _, ok := target.Replace[0].Expr.(*ast.BinaryExpr); !ok {
+		t.Errorf("replace[0].Expr = %T, want *ast.BinaryExpr (concat)", target.Replace[0].Expr)
+	}
+	if target.Replace[1].Col.Name != "name" {
+		t.Errorf("replace[1].Col = %q, want name", target.Replace[1].Col.Name)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("From = %d entries, want 1", len(sel.From))
+	}
+}
+
+// Combined transforms in Snowflake's documented order: EXCLUDE, REPLACE, RENAME.
+func TestSelect_StarExcludeReplaceRename(t *testing.T) {
+	sel, errs := testParseSelectStmt(
+		"SELECT * EXCLUDE first_name REPLACE (UPPER(ssn) AS ssn) RENAME (department_id AS department) FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if len(target.Exclude) != 1 || target.Exclude[0].Name != "first_name" {
+		t.Fatalf("exclude = %v, want [first_name]", target.Exclude)
+	}
+	if len(target.Replace) != 1 || target.Replace[0].Col.Name != "ssn" {
+		t.Fatalf("replace = %v, want one ssn pair", target.Replace)
+	}
+	if len(target.Rename) != 1 || target.Rename[0].Col.Name != "department_id" {
+		t.Fatalf("rename = %v, want one department_id pair", target.Rename)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("From = %d entries, want 1", len(sel.From))
+	}
+}
+
+// REPLACE then RENAME (corpus official/select/example_14).
+func TestSelect_StarReplaceThenRename(t *testing.T) {
+	sel, errs := testParseSelectStmt(
+		"SELECT * REPLACE ('DEPT-' || department_id AS department_id) RENAME department_id AS department FROM employee_table")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	if len(target.Replace) != 1 || target.Replace[0].Col.Name != "department_id" {
+		t.Fatalf("replace = %v, want one department_id pair", target.Replace)
+	}
+	if len(target.Rename) != 1 || target.Rename[0].Alias.Name != "department" {
+		t.Fatalf("rename = %v, want department_id AS department", target.Rename)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("From = %d entries, want 1", len(sel.From))
+	}
+}
+
+func TestSelect_QualifiedStarReplace(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT t.* REPLACE (UPPER(x) AS x) FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	star, ok := target.Expr.(*ast.StarExpr)
+	if !ok || star.Qualifier == nil || star.Qualifier.Name.Name != "t" {
+		t.Fatalf("qualifier mismatch: %#v", target.Expr)
+	}
+	if len(target.Replace) != 1 || target.Replace[0].Col.Name != "x" {
+		t.Fatalf("replace = %v, want one x pair", target.Replace)
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("From = %d entries, want 1", len(sel.From))
+	}
+}
+
+func TestSelect_StarReplaceLoc(t *testing.T) {
+	const sql = "SELECT * REPLACE (UPPER(ssn) AS ssn) FROM t"
+	sel, errs := testParseSelectStmt(sql)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	target := sel.Targets[0]
+	got := sql[target.Loc.Start:target.Loc.End]
+	if got != "* REPLACE (UPPER(ssn) AS ssn)" {
+		t.Errorf("target Loc slice = %q, want %q", got, "* REPLACE (UPPER(ssn) AS ssn)")
+	}
+}
+
+// Negative: REPLACE without parentheses. Snowflake documents only the
+// parenthesized form (the replacement is an arbitrary expression). This must
+// be a loud error, not a silent truncation.
+func TestSelect_StarReplaceNoParens(t *testing.T) {
+	_, err := Parse("SELECT * REPLACE UPPER(ssn) AS ssn FROM t")
+	if err == nil {
+		t.Fatal("expected error for `* REPLACE` without parentheses")
+	}
+}
+
+// Negative: REPLACE pair without AS.
+func TestSelect_StarReplaceNoAs(t *testing.T) {
+	_, err := Parse("SELECT * REPLACE (UPPER(ssn) ssn) FROM t")
+	if err == nil {
+		t.Fatal("expected error for `* REPLACE (expr col)` without AS")
+	}
+}
+
+// Negative: empty REPLACE list.
+func TestSelect_StarReplaceEmpty(t *testing.T) {
+	_, err := Parse("SELECT * REPLACE () FROM t")
+	if err == nil {
+		t.Fatal("expected error for `* REPLACE ()` with no pairs")
+	}
+}
+
+// Negative: out-of-documented-order transforms must error loudly rather than
+// have the trailing transform (and everything after it, including FROM)
+// silently dropped by the statement-entry trailing-token gap.
+func TestSelect_StarTransformsOutOfOrder(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * RENAME (a AS b) REPLACE (UPPER(c) AS c) FROM t",
+		"SELECT * REPLACE (UPPER(c) AS c) EXCLUDE a FROM t",
+		"SELECT * RENAME (a AS b) EXCLUDE c FROM t",
+	} {
+		if _, err := Parse(sql); err == nil {
+			t.Errorf("expected error for out-of-order transforms: %s", sql)
+		}
+	}
+}
+
+// Regression: a column literally named "replace" still parses as a plain
+// column reference (REPLACE is a non-reserved keyword), and the REPLACE()
+// string function is untouched by the star-transform path.
+func TestSelect_ReplaceAsColumnAndFunction(t *testing.T) {
+	sel, errs := testParseSelectStmt("SELECT replace, REPLACE(a, 'x', 'y') FROM t")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(sel.Targets) != 2 {
+		t.Fatalf("targets = %d, want 2", len(sel.Targets))
+	}
+	col, ok := sel.Targets[0].Expr.(*ast.ColumnRef)
+	if !ok || len(col.Parts) != 1 || col.Parts[0].Name != "replace" {
+		t.Errorf("target[0] = %#v, want column replace", sel.Targets[0].Expr)
+	}
+	fn, ok := sel.Targets[1].Expr.(*ast.FuncCallExpr)
+	if !ok || fn.Name.Normalize() != "REPLACE" {
+		t.Errorf("target[1] = %#v, want REPLACE() call", sel.Targets[1].Expr)
+	}
+}
+
 // Negative: `* EXCLUDE` with no column.
 func TestSelect_StarExcludeNoColumn(t *testing.T) {
 	_, err := Parse("SELECT * EXCLUDE FROM t")


### PR DESCRIPTION
Star REPLACE transform was unparsed: `SELECT * REPLACE (UPPER(SSN) AS SSN) FROM T` parse-prefixed to `SELECT *` and SILENTLY DROPPED the transform AND the FROM clause (masking-unsound for lineage consumers; found by the bytebase #20567 cloud review). Adds SelectTarget.Replace []StarReplace{Expr,Col}, parser (docs order EXCLUDE/REPLACE/RENAME, parens required per docs), walker regen, deparse, fail-loud guard for out-of-order transforms, silent-drop regression test (From non-empty + full-span Loc). Corpus select/example_13/14 now parse genuinely. Star ILIKE same-class gap flagged as follow-up chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
