### PR TITLE
fix(snowflake/parser): strict Parse rejects trailing tokens + 11 constructs the silent drop was hiding

### DIFF
--- a/snowflake/ast/parsenodes.go
+++ b/snowflake/ast/parsenodes.go
@@ -1538,6 +1538,7 @@ type CreateDatabaseStmt struct {
 	IfNotExists bool
 	Name        *ObjectName
 	Clone       *CloneSource     // CLONE source [AT|BEFORE (...)]; nil if absent
+	FromShare   *ObjectName      // FROM SHARE <provider>.<share>; nil if absent
 	Props       DBSchemaProps    // optional properties
 	Tags        []*TagAssignment // WITH TAG (...); nil if absent
 	Loc         Loc
@@ -1765,6 +1766,12 @@ type DropStmt struct {
 	Kind     DropObjectKind
 	IfExists bool
 	Name     *ObjectName
+	// HasArgs / ArgTypes carry the argument-type signature of a DROP
+	// FUNCTION / DROP PROCEDURE — `DROP FUNCTION f(NUMBER, VARCHAR)`.
+	// Snowflake requires the signature to disambiguate overloads; the
+	// empty form `f()` sets HasArgs with an empty ArgTypes.
+	HasArgs  bool
+	ArgTypes []*TypeName
 	Cascade  bool // CASCADE option (mutually exclusive with Restrict)
 	Restrict bool // RESTRICT option (mutually exclusive with Cascade)
 	Loc      Loc
@@ -2158,6 +2165,38 @@ type AlterViewStmt struct {
 	Column        Ident            // ALTER COLUMN col name
 	MaskingPolicy *ObjectName      // SET MASKING POLICY p
 	MaskingUsing  []Ident          // USING (col, ...)
+	// ColumnActions is the full comma-separated MODIFY/ALTER column action
+	// list — ALTER VIEW v MODIFY COLUMN a SET MASKING POLICY p, COLUMN b
+	// UNSET MASKING POLICY. It is populated (len >= 1) for every column
+	// action statement; the FIRST element is mirrored into the legacy
+	// single-action fields above (Action / Column / MaskingPolicy /
+	// MaskingUsing / Tags / UnsetTags) for backward compatibility.
+	ColumnActions []*AlterViewColumnAction
+	// AddPolicyName / AddPolicyCols carry the `, ADD ROW ACCESS POLICY p ON
+	// (cols)` tail of the documented drop-and-add combination form:
+	// ALTER VIEW v DROP ROW ACCESS POLICY p1, ADD ROW ACCESS POLICY p2 ON (c).
+	// They are set only when Action == AlterViewDropRowAccessPolicy.
+	AddPolicyName *ObjectName
+	AddPolicyCols []Ident
+	Loc           Loc
+}
+
+// AlterViewColumnAction is one element of an ALTER VIEW column action list:
+//
+//	{ALTER|MODIFY} [COLUMN] <col> SET MASKING POLICY <p> [USING (...)] [FORCE]
+//	                        | UNSET MASKING POLICY
+//	                        | SET TAG <t> = '<v>' [, ...]
+//	                        | UNSET TAG <t> [, ...]
+//
+// Action is one of the AlterViewColumn* values.
+type AlterViewColumnAction struct {
+	Column        Ident
+	Action        AlterViewAction
+	MaskingPolicy *ObjectName      // SET MASKING POLICY p
+	MaskingUsing  []Ident          // USING (col, ...)
+	Force         bool             // FORCE after SET MASKING POLICY
+	Tags          []*TagAssignment // SET TAG (...)
+	UnsetTags     []*ObjectName    // UNSET TAG (...)
 	Loc           Loc
 }
 
@@ -2471,6 +2510,7 @@ const (
 	GranteeShare                              // [TO|FROM] SHARE <name>
 	GranteeApplication                        // TO APPLICATION <name>
 	GranteeApplicationRole                    // TO APPLICATION ROLE <name>
+	GranteeClassRole                          // TO <class> ROLE <instance>!<role> (class instance role)
 )
 
 // String returns the SQL keyword(s) for the grantee kind.
@@ -2488,6 +2528,8 @@ func (k GranteeKind) String() string {
 		return "APPLICATION"
 	case GranteeApplicationRole:
 		return "APPLICATION ROLE"
+	case GranteeClassRole:
+		return "ROLE"
 	default:
 		return "UNKNOWN"
 	}
@@ -2496,12 +2538,20 @@ func (k GranteeKind) String() string {
 // Grantee is the recipient of a GRANT (after TO) or the subject of a REVOKE
 // (after FROM). Name is the (possibly qualified) role/user/share name.
 //
+// For GranteeClassRole — SHOW GRANTS TO SNOWFLAKE.CORE.BUDGET ROLE
+// cost.budgets.my_budget!ADMIN — Class is the class name
+// (SNOWFLAKE.CORE.BUDGET), Name is the instance name
+// (cost.budgets.my_budget), and InstanceRole is the role on the instance
+// (ADMIN, the part after the `!`).
+//
 // Grantee is a Node so the walker visits its Name. (Name is itself an
 // *ObjectName Node.)
 type Grantee struct {
-	Kind GranteeKind
-	Name *ObjectName
-	Loc  Loc
+	Kind         GranteeKind
+	Name         *ObjectName
+	Class        *ObjectName // class name for GranteeClassRole; nil otherwise
+	InstanceRole Ident       // `!<role>` suffix for GranteeClassRole; zero otherwise
+	Loc          Loc
 }
 
 // Tag implements Node.

--- a/snowflake/deparse/deparse_ddl.go
+++ b/snowflake/deparse/deparse_ddl.go
@@ -404,6 +404,10 @@ func (w *writer) writeCreateDatabaseStmt(n *ast.CreateDatabaseStmt) error {
 			return err
 		}
 	}
+	if n.FromShare != nil {
+		w.buf.WriteString(" FROM SHARE ")
+		w.writeObjectNameNoSpace(n.FromShare)
+	}
 	w.writeDBSchemaProps(&n.Props)
 	if len(n.Tags) > 0 {
 		w.buf.WriteString(" WITH TAG (")
@@ -594,6 +598,17 @@ func (w *writer) writeDropStmt(n *ast.DropStmt) error {
 	}
 	w.buf.WriteByte(' ')
 	w.writeObjectNameNoSpace(n.Name)
+	if n.HasArgs {
+		// DROP FUNCTION / PROCEDURE overload signature: f(NUMBER, VARCHAR).
+		w.buf.WriteByte('(')
+		for i, t := range n.ArgTypes {
+			if i > 0 {
+				w.buf.WriteString(", ")
+			}
+			w.writeTypeName(t)
+		}
+		w.buf.WriteByte(')')
+	}
 	if n.Cascade {
 		w.buf.WriteString(" CASCADE")
 	} else if n.Restrict {
@@ -717,6 +732,19 @@ func (w *writer) writeAlterViewStmt(n *ast.AlterViewStmt) error {
 	}
 	w.buf.WriteByte(' ')
 	w.writeObjectNameNoSpace(n.Name)
+	// Multi-element column action list: MODIFY COLUMN a SET MASKING POLICY p,
+	// COLUMN b UNSET MASKING POLICY. (A single action keeps the legacy
+	// single-action rendering below, driven by the mirrored fields.)
+	if len(n.ColumnActions) > 1 {
+		w.buf.WriteString(" MODIFY ")
+		for i, a := range n.ColumnActions {
+			if i > 0 {
+				w.buf.WriteString(", ")
+			}
+			w.writeAlterViewColumnAction(a)
+		}
+		return nil
+	}
 	switch n.Action {
 	case ast.AlterViewRename:
 		w.buf.WriteString(" RENAME TO ")
@@ -758,6 +786,19 @@ func (w *writer) writeAlterViewStmt(n *ast.AlterViewStmt) error {
 	case ast.AlterViewDropRowAccessPolicy:
 		w.buf.WriteString(" DROP ROW ACCESS POLICY ")
 		w.writeObjectNameNoSpace(n.PolicyName)
+		if n.AddPolicyName != nil {
+			// Drop-and-add combination form.
+			w.buf.WriteString(", ADD ROW ACCESS POLICY ")
+			w.writeObjectNameNoSpace(n.AddPolicyName)
+			w.buf.WriteString(" ON (")
+			for i, col := range n.AddPolicyCols {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				w.buf.WriteString(col.String())
+			}
+			w.buf.WriteByte(')')
+		}
 	case ast.AlterViewDropAllRowAccessPolicies:
 		w.buf.WriteString(" DROP ALL ROW ACCESS POLICIES")
 	case ast.AlterViewColumnSetMaskingPolicy:
@@ -830,6 +871,42 @@ func (w *writer) writeAlterViewStmt(n *ast.AlterViewStmt) error {
 		return fmt.Errorf("deparse: unsupported ALTER VIEW action %d", n.Action)
 	}
 	return nil
+}
+
+// writeAlterViewColumnAction emits one element of a multi-element ALTER VIEW
+// MODIFY column action list: COLUMN <col> SET MASKING POLICY <p> [USING (...)]
+// [FORCE] | UNSET MASKING POLICY | SET TAG (...) | UNSET TAG (...).
+func (w *writer) writeAlterViewColumnAction(a *ast.AlterViewColumnAction) {
+	w.buf.WriteString("COLUMN ")
+	w.buf.WriteString(a.Column.String())
+	switch a.Action {
+	case ast.AlterViewColumnSetMaskingPolicy:
+		w.buf.WriteString(" SET MASKING POLICY ")
+		w.writeObjectNameNoSpace(a.MaskingPolicy)
+		if len(a.MaskingUsing) > 0 {
+			w.buf.WriteString(" USING (")
+			for i, col := range a.MaskingUsing {
+				if i > 0 {
+					w.buf.WriteString(", ")
+				}
+				w.buf.WriteString(col.String())
+			}
+			w.buf.WriteByte(')')
+		}
+		if a.Force {
+			w.buf.WriteString(" FORCE")
+		}
+	case ast.AlterViewColumnUnsetMaskingPolicy:
+		w.buf.WriteString(" UNSET MASKING POLICY")
+	case ast.AlterViewColumnSetTag:
+		w.buf.WriteString(" SET TAG (")
+		w.writeTagAssignments(a.Tags)
+		w.buf.WriteByte(')')
+	case ast.AlterViewColumnUnsetTag:
+		w.buf.WriteString(" UNSET TAG (")
+		w.writeObjectNameList(a.UnsetTags)
+		w.buf.WriteByte(')')
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/snowflake/diagnostics/diagnostics.go
+++ b/snowflake/diagnostics/diagnostics.go
@@ -89,8 +89,14 @@ type Diagnostic struct {
 
 const source = "snowflake-parser"
 
-// Analyze parses sql using the Snowflake best-effort parser and converts
+// Analyze parses sql using the Snowflake parser in strict mode and converts
 // every parse or lex error into a Diagnostic with a populated source range.
+//
+// Strict mode means unconsumed trailing tokens after an otherwise-valid
+// statement prefix are rejected too: `SELECT * FFROM users` produces a
+// diagnostic at FFROM rather than silently parsing as `SELECT *`. Errors
+// are still collected across ALL statements (per-statement recovery), so a
+// multi-statement input yields one diagnostic per offending statement.
 //
 // Returns nil when sql is syntactically valid or empty. The returned slice
 // is ordered by the byte offset at which each error was detected.
@@ -98,7 +104,7 @@ const source = "snowflake-parser"
 // Line and column numbers are 1-based and measured in bytes. Callers that
 // need Unicode-aware column numbers should post-process the Offset field.
 func Analyze(sql string) []Diagnostic {
-	result := parser.ParseBestEffort(sql)
+	result := parser.ParseStrict(sql)
 	if len(result.Errors) == 0 {
 		return nil
 	}

--- a/snowflake/diagnostics/diagnostics_test.go
+++ b/snowflake/diagnostics/diagnostics_test.go
@@ -121,6 +121,67 @@ func TestAnalyze_UnsupportedStatementInMiddle(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
+// Trailing-token rejection (strict parse path)
+// -----------------------------------------------------------------------
+
+func TestAnalyze_TrailingTokensRejected(t *testing.T) {
+	// `SELECT *` is a valid prefix; FFROM and everything after it used to be
+	// silently dropped. Analyze runs the strict path, so the stray token is
+	// a diagnostic with an accurate position: FFROM starts at byte 9 →
+	// line 1, column 10; it is 5 bytes long → end column 15.
+	diags := Analyze("SELECT * FFROM users")
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+	if d.Severity != SeverityError {
+		t.Errorf("severity = %v, want SeverityError", d.Severity)
+	}
+	if !strings.Contains(d.Message, "syntax error at or near FFROM") {
+		t.Errorf("message = %q, want to contain %q", d.Message, "syntax error at or near FFROM")
+	}
+	if d.Range.Start.Line != 1 || d.Range.Start.Column != 10 || d.Range.Start.Offset != 9 {
+		t.Errorf("start = %+v, want line 1, column 10, offset 9", d.Range.Start)
+	}
+	if d.Range.End.Line != 1 || d.Range.End.Column != 15 || d.Range.End.Offset != 14 {
+		t.Errorf("end = %+v, want line 1, column 15, offset 14", d.Range.End)
+	}
+}
+
+func TestAnalyze_TrailingTokensMultiLine(t *testing.T) {
+	// Same shape with the garbage on line 2: position must track the line.
+	diags := Analyze("SELECT *\nFFROM users")
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+	if d.Range.Start.Line != 2 || d.Range.Start.Column != 1 || d.Range.Start.Offset != 9 {
+		t.Errorf("start = %+v, want line 2, column 1, offset 9", d.Range.Start)
+	}
+}
+
+func TestAnalyze_TrailingTokensPerStatement(t *testing.T) {
+	// Per-statement reporting: only the offending statement diagnoses; a
+	// second garbage statement adds a second diagnostic.
+	diags := Analyze("SELECT 1 2; SELECT 3")
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	if diags[0].Range.Start.Offset != 9 {
+		t.Errorf("offset = %d, want 9 (the stray 2)", diags[0].Range.Start.Offset)
+	}
+	diags = Analyze("SELECT 1 2; SELECT 3 4")
+	if len(diags) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %d: %+v", len(diags), diags)
+	}
+}
+
+func TestAnalyze_ImplicitAliasStillValid(t *testing.T) {
+	// `garbage` is a legal implicit table alias — NOT a trailing token.
+	assertNoDiags(t, "implicit alias", Analyze("SELECT a FROM b garbage"))
+}
+
+// -----------------------------------------------------------------------
 // Multi-line inputs
 // -----------------------------------------------------------------------
 

--- a/snowflake/parser/corpus_closure_test.go
+++ b/snowflake/parser/corpus_closure_test.go
@@ -28,8 +28,11 @@ import (
 // in multilineString mode (split.go), so those segment correctly and parse via
 // the normal Split path; corpusWholeFile is consequently empty.
 //
-// Coverage snapshot at authoring time: 651/657 files parse clean (all via
-// Split), 6 files skipped (categorized below).
+// Coverage snapshot: 650/657 files parse clean (all via Split), 7 files
+// skipped (categorized below). Since the strict trailing-token check landed
+// in parseSingle, "parses clean" additionally proves every statement consumes
+// its input to the end — a prefix-parse with silently-dropped trailing tokens
+// now fails the gate.
 func TestCorpusClosure(t *testing.T) {
 	files := collectCorpusFiles(t)
 	if len(files) != 657 {
@@ -191,4 +194,13 @@ var corpusSkips = map[string]string{
 	// without parentheses — a legacy-corpus malformation). Mixed residual-gap and
 	// docs-typo; tracked as one entry.
 	"legacy/select.sql": "RESIDUAL GAP/MALFORMED: LEFT()/ILIKE() as function names, lowercase `union` in derived table, and to_date(SELECT...) (unparenthesized scalar subquery, a legacy malformation)",
+
+	// --- MALFORMED: docs typo, surfaced by the strict trailing-token check ---
+	// The example's SELECT list is missing the comma between
+	// COUNT(DISTINCT order_id) and DATE_TRUNC('DAY', order_timestamp_ns), so
+	// DATE_TRUNC parses as an implicit alias of the COUNT and the following
+	// `(` is genuinely invalid SQL. The parser used to "accept" the file only
+	// by silently dropping everything from that `(` on; strict Parse now
+	// correctly rejects it.
+	"official/create-dynamic-table/example_12.sql": "MALFORMED: docs example missing comma in SELECT list (COUNT(...) DATE_TRUNC(...)) — invalid SQL, correctly rejected since the strict trailing-token check",
 }

--- a/snowflake/parser/create_table.go
+++ b/snowflake/parser/create_table.go
@@ -325,6 +325,17 @@ func (p *Parser) parseCreateTableStmt(start ast.Loc, orReplace, orAlter, transie
 	}
 	stmt.Name = name
 
+	// Postfix IF NOT EXISTS: Snowflake (and the legacy grammar) also accept
+	// the clause AFTER the table name — CREATE TABLE t1 IF NOT EXISTS (...).
+	if !stmt.IfNotExists && p.cur.Type == kwIF && p.peekNext().Type == kwNOT {
+		p.advance() // consume IF
+		p.advance() // consume NOT
+		if _, err := p.expect(kwEXISTS); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
 	// Branch on what follows the table name
 	switch p.cur.Type {
 	case kwLIKE:

--- a/snowflake/parser/database_schema.go
+++ b/snowflake/parser/database_schema.go
@@ -52,6 +52,18 @@ func (p *Parser) parseCreateDatabaseStmt(start ast.Loc, orReplace, orAlter, tran
 		stmt.Clone = clone
 	}
 
+	// Optional FROM SHARE <provider_account>.<share_name> — creates the
+	// database from an inbound share.
+	if p.cur.Type == kwFROM && p.peekNext().Type == kwSHARE {
+		p.advance() // consume FROM
+		p.advance() // consume SHARE
+		share, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		stmt.FromShare = share
+	}
+
 	// Optional properties
 	if err := p.parseDBSchemaPropsInto(&stmt.Props); err != nil {
 		return nil, err

--- a/snowflake/parser/drop.go
+++ b/snowflake/parser/drop.go
@@ -254,6 +254,28 @@ func (p *Parser) parseDropObject(kind ast.DropObjectKind, start ast.Loc, ifExist
 	}
 	stmt.Name = name
 
+	// Optional argument-type signature for FUNCTION / PROCEDURE overload
+	// disambiguation: DROP FUNCTION f(NUMBER, VARCHAR) / DROP PROCEDURE p().
+	if (kind == ast.DropFunction || kind == ast.DropProcedure) && p.cur.Type == '(' {
+		p.advance() // consume '('
+		stmt.HasArgs = true
+		for p.cur.Type != ')' && p.cur.Type != tokEOF {
+			argType, err := p.parseDataType()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ArgTypes = append(stmt.ArgTypes, argType)
+			if p.cur.Type == ',' {
+				p.advance() // consume ','
+				continue
+			}
+			break
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+	}
+
 	// Optional CASCADE | RESTRICT
 	if cascadeOK {
 		switch p.cur.Type {

--- a/snowflake/parser/error_recovery_test.go
+++ b/snowflake/parser/error_recovery_test.go
@@ -4,16 +4,41 @@ import (
 	"testing"
 )
 
-func TestRecovery_TwoUnterminatedStrings(t *testing.T) {
-	// 'unterm1' is actually terminated; 'unterm2 is not. So this only
-	// produces one real error. Use a multiline form for two errors.
+func TestRecovery_MultilineStringAndUnterminated(t *testing.T) {
+	// Snowflake string constants may span newlines, so "'unterm1\n'unterm2"
+	// lexes as ONE multi-line string ("unterm1\n") followed by the identifier
+	// unterm2 — zero errors. (Under the historical one-line rule this input
+	// produced two unterminated-string errors; that rule falsely rejected
+	// valid multi-line strings, e.g. the official-docs JSON literals.)
 	input := "'unterm1\n'unterm2"
 	tokens, errs := Tokenize(input)
-	if len(errs) != 2 {
-		t.Errorf("expected 2 errors, got %d: %+v", len(errs), errs)
+	if len(errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %+v", len(errs), errs)
 	}
-	if len(tokens) < 1 {
-		t.Errorf("expected at least 1 token, got 0")
+	if len(tokens) != 3 { // string, ident, EOF
+		t.Fatalf("expected 3 tokens (string, ident, EOF), got %d: %+v", len(tokens), tokens)
+	}
+	if tokens[0].Type != tokString || tokens[0].Str != "unterm1\n" {
+		t.Errorf("token[0] = %+v, want tokString with content \"unterm1\\n\"", tokens[0])
+	}
+	if tokens[1].Type != tokIdent || tokens[1].Str != "unterm2" {
+		t.Errorf("token[1] = %+v, want tokIdent unterm2", tokens[1])
+	}
+
+	// A string with NO closing quote anywhere runs to EOF and reports exactly
+	// one unterminated-string error.
+	tokens, errs = Tokenize("SELECT 'never closed\nFROM t")
+	if len(errs) != 1 {
+		t.Errorf("unterminated: expected 1 error, got %d: %+v", len(errs), errs)
+	}
+	hasInvalid := false
+	for _, tok := range tokens {
+		if tok.Type == tokInvalid {
+			hasInvalid = true
+		}
+	}
+	if !hasInvalid {
+		t.Errorf("unterminated: expected a tokInvalid token, got %+v", tokens)
 	}
 }
 

--- a/snowflake/parser/grant_revoke.go
+++ b/snowflake/parser/grant_revoke.go
@@ -657,9 +657,11 @@ func (p *Parser) parseGrantSignature() ([]*ast.TypeName, error) {
 //	SHARE <name>
 //	APPLICATION <name>
 //	APPLICATION ROLE <name>
+//	<class> ROLE <instance>!<role>   (class instance role)
 func (p *Parser) parseGrantee() (*ast.Grantee, error) {
 	startLoc := p.cur.Loc
 	var kind ast.GranteeKind
+	bare := false
 
 	switch p.cur.Type {
 	case kwROLE:
@@ -692,11 +694,38 @@ func (p *Parser) parseGrantee() (*ast.Grantee, error) {
 			return nil, p.syntaxErrorAtCur()
 		}
 		kind = ast.GranteeRole
+		bare = true
 	}
 
 	name, err := p.parseObjectName()
 	if err != nil {
 		return nil, err
+	}
+
+	// Class instance role: <class_name> ROLE <instance>!<role>, e.g.
+	// SHOW GRANTS TO SNOWFLAKE.CORE.BUDGET ROLE cost.budgets.my_budget!ADMIN.
+	// Only a bare leading name can be a class name (the keyworded forms above
+	// already consumed their kind keyword).
+	if bare && p.cur.Type == kwROLE {
+		p.advance() // consume ROLE
+		instance, err := p.parseObjectName()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokBang); err != nil {
+			return nil, err
+		}
+		role, err := p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.Grantee{
+			Kind:         ast.GranteeClassRole,
+			Name:         instance,
+			Class:        name,
+			InstanceRole: role,
+			Loc:          ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
+		}, nil
 	}
 
 	return &ast.Grantee{

--- a/snowflake/parser/identifiers.go
+++ b/snowflake/parser/identifiers.go
@@ -81,8 +81,19 @@ func (p *Parser) parseNamePart() (ast.Ident, error) {
 //
 // Each name part is parsed with parseNamePart, which accepts any keyword
 // (including reserved keywords such as SCHEMA or DATABASE) as an identifier.
+//
+// The first part may also be Snowflake's IDENTIFIER(<expr>) literal form —
+// USE WAREHOUSE IDENTIFIER($wh), UNDROP TABLE IDENTIFIER(408578) — which is
+// captured verbatim as a single (unquoted) Ident part; see
+// parseIdentifierFuncPart.
 func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
-	first, err := p.parseNamePart()
+	var first ast.Ident
+	var err error
+	if p.cur.Type == kwIDENTIFIER && p.peekNext().Type == '(' {
+		first, err = p.parseIdentifierFuncPart()
+	} else {
+		first, err = p.parseNamePart()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +133,37 @@ func (p *Parser) parseObjectName() (*ast.ObjectName, error) {
 		Schema:   second,
 		Name:     third,
 		Loc:      ast.Loc{Start: first.Loc.Start, End: third.Loc.End},
+	}, nil
+}
+
+// parseIdentifierFuncPart parses Snowflake's IDENTIFIER(<expr>) name form,
+// used wherever an object name is expected with the name supplied as a
+// string / session variable / bind / object id:
+//
+//	USE WAREHOUSE IDENTIFIER($current_wh_name)
+//	UNDROP TABLE IDENTIFIER(408578)
+//	SELECT * FROM IDENTIFIER('db.sch.t')
+//
+// The whole construct is captured VERBATIM (source text, including the
+// IDENTIFIER keyword and parentheses) as one unquoted Ident part, so
+// consumers and deparse round-trip it unchanged; the argument's structure is
+// validated by parsing it as an expression but not retained.
+//
+// The caller must have checked cur == kwIDENTIFIER and peekNext == '('.
+func (p *Parser) parseIdentifierFuncPart() (ast.Ident, error) {
+	startTok := p.advance() // consume IDENTIFIER
+	p.advance()             // consume '('
+	if _, err := p.parseExpr(); err != nil {
+		return ast.Ident{}, err
+	}
+	closeTok, err := p.expect(')')
+	if err != nil {
+		return ast.Ident{}, err
+	}
+	loc := ast.Loc{Start: startTok.Loc.Start, End: closeTok.Loc.End}
+	return ast.Ident{
+		Name: p.srcSlice(loc.Start, loc.End),
+		Loc:  loc,
 	}, nil
 }
 

--- a/snowflake/parser/lexer.go
+++ b/snowflake/parser/lexer.go
@@ -19,31 +19,29 @@ type Lexer struct {
 	start      int // start byte of the token currently being scanned
 	errors     []LexError
 	baseOffset int // added to token Loc.Start/End and error Loc.Start/End when returned via public API
-	// multilineString, when set, lets a single-quoted string literal span
-	// newlines (the matching unescaped closing ' may be on a later line). It is
-	// OFF by default — the parser's lexer keeps the conventional one-line string
-	// rule. Split turns it ON: statement-segmentation must treat a multi-line
-	// single-quoted routine body (a Java / JavaScript / SQL handler) as one
-	// opaque string so an embedded ';' on a continuation line does not look like
-	// a statement terminator. See split.go and parseRoutineBody (which itself
-	// raw-scans the body verbatim once Split delivers the whole statement).
-	multilineString bool
 }
 
 // NewLexer constructs a Lexer for the given input. Token positions are
 // zero-based byte offsets into input.
+//
+// Single-quoted string literals may span newlines: Snowflake string
+// constants can contain literal newline bytes (the official-docs corpus
+// uses multi-line JSON strings and routine bodies in runnable examples).
+// The parser's lexer historically tore strings at the first newline, which
+// went unnoticed only because statement-prefix parses silently dropped the
+// multi-line tail before ever lexing it; the strict trailing-token check
+// exposed that gap, and the parser and Split lexers now agree on string
+// extent.
 func NewLexer(input string) *Lexer {
 	return &Lexer{input: input}
 }
 
 // newSplitLexer constructs a Lexer for statement segmentation (Split). It is
-// identical to NewLexer except that single-quoted string literals may span
-// newlines (multilineString), so a multi-line single-quoted routine body is
-// tokenized as ONE string rather than being torn at the first embedded newline.
-// This mode is intentionally NOT exposed on the parser's lexer: only Split needs
-// it, and only for finding statement boundaries.
+// identical to NewLexer (single-quoted strings span newlines in both); the
+// separate constructor is retained as the seam where Split-specific lexing
+// behavior would attach.
 func newSplitLexer(input string) *Lexer {
-	return &Lexer{input: input, multilineString: true}
+	return &Lexer{input: input}
 }
 
 // NewLexerWithOffset constructs a Lexer whose emitted token Loc values
@@ -188,7 +186,16 @@ func (l *Lexer) skipWhitespaceAndComments() {
 			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
 				l.pos++
 			}
-		case ch == '/' && l.peek(1) == '/':
+		case ch == '/' && l.peek(1) == '/' && !l.afterColon():
+			// `//` opens a line comment — EXCEPT when it directly follows a
+			// `:` (no intervening byte), where `://` is a URL scheme separator
+			// (PUT file://…, s3://, https://). Treating `file://` as
+			// comment-opening made the rest of the line — including a real
+			// `;` statement terminator — vanish, so Split fused the next
+			// statement into the same segment and the parser silently
+			// dropped it. With the guard the slashes lex as ordinary `/`
+			// tokens; PUT/GET re-scan the URL from raw source anyway
+			// (scanRawLocation).
 			l.pos += 2
 			for l.pos < len(l.input) && l.input[l.pos] != '\n' {
 				l.pos++
@@ -199,6 +206,13 @@ func (l *Lexer) skipWhitespaceAndComments() {
 			return
 		}
 	}
+}
+
+// afterColon reports whether the byte immediately before l.pos is ':'.
+// Used to keep `://` (a URL scheme separator) from opening a `//` line
+// comment in skipWhitespaceAndComments.
+func (l *Lexer) afterColon() bool {
+	return l.pos > 0 && l.input[l.pos-1] == ':'
 }
 
 // scanBlockComment advances past a /* ... */ block comment. Block comments
@@ -233,10 +247,11 @@ func (l *Lexer) scanBlockComment() {
 //   - backslash escapes: \n \t \r \0 \\ \' \"  (and \<other> → <other>)
 //   - doubled-quote escape: ” inside a string is a literal '
 //
-// Token.Str contains the unescaped content (no surrounding quotes).
-// On unterminated string, appends an unterminated-string LexError, emits
-// a tokInvalid token covering the bad span, and advances to the next
-// newline or EOF.
+// Token.Str contains the unescaped content (no surrounding quotes). The
+// literal may span newlines (Snowflake string constants can contain literal
+// newline bytes). On unterminated string (no closing quote before EOF),
+// appends an unterminated-string LexError and emits a tokInvalid token
+// covering the bad span.
 func (l *Lexer) scanString() Token {
 	start := l.start // l.start is the byte offset of the opening quote
 	l.pos++          // consume opening quote
@@ -287,16 +302,9 @@ func (l *Lexer) scanString() Token {
 			l.pos++
 			continue
 		}
-		if ch == '\n' && !l.multilineString {
-			// Unterminated single-quoted string — strings cannot span newlines.
-			// In multilineString mode (Split's segmentation lexer) a newline is an
-			// ordinary body byte; the string runs on to its matching closing quote.
-			l.errors = append(l.errors, LexError{
-				Loc: ast.Loc{Start: start, End: l.pos},
-				Msg: errUnterminatedString,
-			})
-			return Token{Type: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
-		}
+		// A newline is an ordinary body byte: Snowflake string constants may
+		// span lines, so the string runs on to its matching closing quote
+		// (or to EOF, which reports unterminated below).
 		sb.WriteByte(ch)
 		l.pos++
 	}
@@ -566,12 +574,12 @@ func (l *Lexer) scanOperatorOrPunct(ch byte) Token {
 			l.pos += 2
 			return Token{Type: tokNotEq, Loc: ast.Loc{Start: start, End: l.pos}}
 		}
-		l.errors = append(l.errors, LexError{
-			Loc: ast.Loc{Start: start, End: start + 1},
-			Msg: errInvalidByte,
-		})
+		// Bare `!` is the class instance role separator in names like
+		// cost.budgets.my_budget!ADMIN (SHOW GRANTS TO <class> ROLE
+		// <instance>!<role>). It lexes as its own token; contexts that do
+		// not expect it reject it at parse time.
 		l.pos++
-		return Token{Type: tokInvalid, Loc: ast.Loc{Start: start, End: l.pos}}
+		return Token{Type: tokBang, Str: "!", Loc: ast.Loc{Start: start, End: l.pos}}
 	case '<':
 		if l.peek(1) == '=' {
 			l.pos += 2

--- a/snowflake/parser/parser.go
+++ b/snowflake/parser/parser.go
@@ -378,30 +378,61 @@ type ParseResult struct {
 // statement fails. Callers that want partial results should use
 // ParseBestEffort instead.
 //
+// Strictness includes trailing-token rejection: after each statement
+// parses, the next token must be `;` or end-of-segment. Inputs like
+// `SELECT * FFROM users` (where the parser consumes only the valid
+// `SELECT *` prefix) therefore fail with "syntax error at or near FFROM"
+// instead of silently dropping the rest.
+//
 // The returned *ast.File always reflects whatever statements parsed
 // successfully before the first error — even in the error case, the
 // File may be non-empty.
 func Parse(input string) (*ast.File, error) {
-	result := ParseBestEffort(input)
+	result := ParseStrict(input)
 	if len(result.Errors) > 0 {
 		return result.File, &result.Errors[0]
 	}
 	return result.File, nil
 }
 
-// ParseBestEffort runs F3's Split to segment the input, then parses each
-// segment via parseSingle. Errors from individual segments are collected;
-// all successfully-parsed statements are appended to the result File.
+// ParseStrict runs the same segmentation and per-statement parsing as
+// ParseBestEffort, but applies the strict trailing-token check: a
+// statement followed by anything other than `;` or end-of-segment gets a
+// "syntax error at or near <token>" ParseError at the first stray token.
+// All errors across all statements are collected (per-statement
+// reporting), so diagnostics callers see every offending statement, not
+// just the first.
 //
-// This is the canonical entry point for bytebase consumers (diagnose.go,
-// query_type.go, query_span_extractor.go) that need partial results plus
-// error diagnostics.
+// This is the entry point for diagnostics.Analyze and any consumer that
+// must REJECT garbage suffixes rather than tolerate them.
+func ParseStrict(input string) *ParseResult {
+	return parseAll(input, true)
+}
+
+// ParseBestEffort runs F3's Split to segment the input, then parses each
+// segment. Errors from individual segments are collected; all
+// successfully-parsed statements are appended to the result File.
+//
+// Unlike Parse / ParseStrict, ParseBestEffort TOLERATES unconsumed
+// trailing tokens after a successfully-parsed statement prefix: partial
+// or in-progress input such as `SELECT a FROM` + stray fragments still
+// yields whatever prefix parsed. Completion and other partial-input
+// callers depend on this tolerance — do not add the strict
+// trailing-token check here.
 func ParseBestEffort(input string) *ParseResult {
+	return parseAll(input, false)
+}
+
+// parseAll is the shared implementation behind ParseStrict and
+// ParseBestEffort: Split the input, parse each segment, collect nodes and
+// errors. strictTrailing selects whether parseSegment rejects unconsumed
+// trailing tokens.
+func parseAll(input string, strictTrailing bool) *ParseResult {
 	file := &ast.File{Loc: ast.Loc{Start: 0, End: len(input)}}
 	result := &ParseResult{File: file}
 
 	for _, seg := range Split(input) {
-		node, errs := parseSingle(seg.Text, seg.ByteStart)
+		node, errs := parseSegment(seg.Text, seg.ByteStart, strictTrailing)
 		if node != nil {
 			file.Stmts = append(file.Stmts, node)
 		}
@@ -412,6 +443,15 @@ func ParseBestEffort(input string) *ParseResult {
 }
 
 // parseSingle parses one segment (one top-level statement) into a single
+// ast.Node with the STRICT trailing-token check enabled. It is the
+// internal single-statement entry used by tests (including the
+// whole-corpus closure gate, so every corpus statement also proves it
+// leaves no unconsumed tokens behind).
+func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
+	return parseSegment(segText, baseOffset, true)
+}
+
+// parseSegment parses one segment (one top-level statement) into a single
 // ast.Node. Returns (node, errors) where node may be nil if the segment
 // failed to parse and errors is the list of ParseErrors encountered,
 // including any LexErrors promoted from the underlying Lexer.
@@ -420,7 +460,14 @@ func ParseBestEffort(input string) *ParseResult {
 // comes from F3.Segment.Text. baseOffset is the byte offset of segText
 // within the original input — passed to NewLexerWithOffset so token Loc
 // values are absolute.
-func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
+//
+// strictTrailing controls the trailing-token check: when true, a
+// successfully-parsed statement must be followed by `;` or end-of-segment;
+// any other token produces a "syntax error at or near <token>" ParseError
+// at the stray token's position (the historical behavior — silently
+// ignoring the unconsumed tail, e.g. `SELECT * FFROM users` parsing clean
+// as `SELECT *` — is preserved only for the best-effort path).
+func parseSegment(segText string, baseOffset int, strictTrailing bool) (ast.Node, []ParseError) {
 	p := &Parser{
 		lexer: NewLexerWithOffset(segText, baseOffset),
 		input: segText,
@@ -439,6 +486,22 @@ func parseSingle(segText string, baseOffset int) (ast.Node, []ParseError) {
 					Loc: p.cur.Loc,
 					Msg: err.Error(),
 				})
+			}
+		} else if strictTrailing {
+			// The statement parsed cleanly: the only legal continuations
+			// are end-of-segment or a `;` statement terminator (Split
+			// strips the terminator, so EOF is the common case; `;` shows
+			// up when callers hand un-split text to the parser).
+			// Anything else is a trailing run the parser used to drop
+			// silently — report it at the first stray token, then recover
+			// to the next statement boundary so the rest of the tail
+			// (including any lex errors in it) is still scanned.
+			for p.cur.Type == ';' {
+				p.advance()
+			}
+			if p.cur.Type != tokEOF {
+				p.errors = append(p.errors, *p.syntaxErrorAtCur())
+				p.skipToNextStatement()
 			}
 		}
 		result = node

--- a/snowflake/parser/select.go
+++ b/snowflake/parser/select.go
@@ -905,6 +905,25 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 		return ref, nil
 	}
 
+	// Bare (unparenthesized) VALUES row source: FROM VALUES (1, 'a'), (2, 'b').
+	// Snowflake accepts the inline VALUES list without the surrounding
+	// parentheses that the derived-table form above requires. VALUES is a
+	// reserved keyword, so `VALUES (` in FROM position is unambiguous.
+	if p.cur.Type == kwVALUES && p.peekNext().Type == '(' {
+		query, err := p.parseValuesClause()
+		if err != nil {
+			return nil, err
+		}
+		ref := &ast.TableRef{
+			Subquery: query,
+			Loc:      ast.Loc{Start: startLoc.Start},
+		}
+		if err := p.parseTableSuffix(ref); err != nil {
+			return nil, err
+		}
+		return ref, nil
+	}
+
 	// $N result-set table reference: FROM $1. A bare positional $-reference in
 	// FROM position names the result set of the preceding statement (the source
 	// of a `->>` result-pipe). A qualified $N (t.$1) is a column expression, not
@@ -1025,7 +1044,7 @@ func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
 // (joinType, natural, directed, true). If not, returns (0, false, false, false)
 // without consuming any tokens.
 func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
-	// NATURAL [LEFT|RIGHT|FULL] [OUTER] JOIN
+	// NATURAL [INNER | {LEFT|RIGHT|FULL} [OUTER]] JOIN
 	if p.cur.Type == kwNATURAL {
 		next := p.peekNext()
 		// NATURAL JOIN
@@ -1034,10 +1053,20 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
 			p.advance() // consume JOIN
 			return ast.JoinInner, true, false, true
 		}
+		// NATURAL INNER JOIN
+		if next.Type == kwINNER {
+			p.advance() // consume NATURAL
+			p.advance() // consume INNER
+			if p.cur.Type == kwJOIN {
+				p.advance() // consume JOIN
+				return ast.JoinInner, true, false, true
+			}
+			return 0, false, false, false
+		}
 		// NATURAL LEFT/RIGHT/FULL [OUTER] JOIN
 		if next.Type == kwLEFT || next.Type == kwRIGHT || next.Type == kwFULL {
 			p.advance() // consume NATURAL
-			jt := p.consumeDirectionAndJoin()
+			jt, _ := p.consumeDirectionAndJoin()
 			return jt, true, false, true
 		}
 		return 0, false, false, false
@@ -1060,7 +1089,7 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
 			return 0, false, false, false
 		case kwLEFT, kwRIGHT, kwFULL:
 			p.advance() // consume DIRECTED
-			jt := p.consumeDirectionAndJoin()
+			jt, _ := p.consumeDirectionAndJoin()
 			return jt, false, true, true
 		case kwCROSS:
 			p.advance() // consume DIRECTED
@@ -1084,7 +1113,8 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
 		return 0, false, false, false
 	}
 
-	// INNER JOIN
+	// INNER [DIRECTED] JOIN — Snowflake's documented placement of DIRECTED is
+	// between the join-type keyword and JOIN (t1 INNER DIRECTED JOIN t2).
 	if p.cur.Type == kwINNER {
 		next := p.peekNext()
 		if next.Type == kwJOIN {
@@ -1092,32 +1122,41 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
 			p.advance() // consume JOIN
 			return ast.JoinInner, false, false, true
 		}
+		if next.Type == kwDIRECTED {
+			p.advance() // consume INNER
+			p.advance() // consume DIRECTED
+			if p.cur.Type == kwJOIN {
+				p.advance() // consume JOIN
+				return ast.JoinInner, false, true, true
+			}
+			return 0, false, false, false
+		}
 		return 0, false, false, false
 	}
 
-	// LEFT [OUTER] JOIN
+	// LEFT [OUTER] [DIRECTED] JOIN
 	if p.cur.Type == kwLEFT {
-		jt := p.consumeDirectionAndJoin()
+		jt, directed := p.consumeDirectionAndJoin()
 		if jt == ast.JoinLeft {
-			return jt, false, false, true
+			return jt, false, directed, true
 		}
 		return 0, false, false, false
 	}
 
-	// RIGHT [OUTER] JOIN
+	// RIGHT [OUTER] [DIRECTED] JOIN
 	if p.cur.Type == kwRIGHT {
-		jt := p.consumeDirectionAndJoin()
+		jt, directed := p.consumeDirectionAndJoin()
 		if jt == ast.JoinRight {
-			return jt, false, false, true
+			return jt, false, directed, true
 		}
 		return 0, false, false, false
 	}
 
-	// FULL [OUTER] JOIN
+	// FULL [OUTER] [DIRECTED] JOIN
 	if p.cur.Type == kwFULL {
-		jt := p.consumeDirectionAndJoin()
+		jt, directed := p.consumeDirectionAndJoin()
 		if jt == ast.JoinFull {
-			return jt, false, false, true
+			return jt, false, directed, true
 		}
 		return 0, false, false, false
 	}
@@ -1142,12 +1181,13 @@ func (p *Parser) parseJoinKeywords() (ast.JoinType, bool, bool, bool) {
 	return 0, false, false, false
 }
 
-// consumeDirectionAndJoin consumes LEFT/RIGHT/FULL [OUTER] JOIN and returns
-// the corresponding JoinType. The caller must have already checked that
-// p.cur.Type is kwLEFT, kwRIGHT, or kwFULL.
+// consumeDirectionAndJoin consumes LEFT/RIGHT/FULL [OUTER] [DIRECTED] JOIN
+// and returns the corresponding JoinType plus whether the DIRECTED keyword
+// was present. The caller must have already checked that p.cur.Type is
+// kwLEFT, kwRIGHT, or kwFULL.
 // If the sequence doesn't end with JOIN, this returns JoinInner as a sentinel
 // (the caller checks the return value).
-func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
+func (p *Parser) consumeDirectionAndJoin() (ast.JoinType, bool) {
 	dir := p.cur.Type
 	p.advance() // consume LEFT/RIGHT/FULL
 
@@ -1156,23 +1196,30 @@ func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
 		p.advance() // consume OUTER
 	}
 
+	// Optional DIRECTED (Snowflake places it directly before JOIN).
+	directed := false
+	if p.cur.Type == kwDIRECTED {
+		p.advance() // consume DIRECTED
+		directed = true
+	}
+
 	// Expect JOIN
 	if p.cur.Type != kwJOIN {
 		// Not a join sequence — but we already consumed tokens.
 		// This is an issue; for safety, return a sentinel and let caller handle.
-		return ast.JoinInner
+		return ast.JoinInner, false
 	}
 	p.advance() // consume JOIN
 
 	switch dir {
 	case kwLEFT:
-		return ast.JoinLeft
+		return ast.JoinLeft, directed
 	case kwRIGHT:
-		return ast.JoinRight
+		return ast.JoinRight, directed
 	case kwFULL:
-		return ast.JoinFull
+		return ast.JoinFull, directed
 	default:
-		return ast.JoinInner
+		return ast.JoinInner, directed
 	}
 }
 

--- a/snowflake/parser/show.go
+++ b/snowflake/parser/show.go
@@ -236,6 +236,19 @@ func (p *Parser) parseShowScope(stmt *ast.ShowStmt) error {
 			return p.parseOptionalScopeName(stmt)
 		}
 		return nil
+	case kwFAILOVER, kwREPLICATION:
+		// IN FAILOVER GROUP <name> | IN REPLICATION GROUP <name>
+		// (SHOW DATABASES / SHOW SHARES scopes). Without this case the
+		// bare-name fallback below consumed FAILOVER/REPLICATION as a schema
+		// name and left `GROUP <name>` behind as silently-dropped trailing
+		// tokens.
+		tok := p.advance()
+		if _, err := p.expect(kwGROUP); err != nil {
+			return err
+		}
+		stmt.Scope = ast.ShowScopeOther
+		stmt.ScopeText = strings.ToUpper(tok.Str) + " GROUP"
+		return p.parseOptionalScopeName(stmt)
 	}
 
 	// Bare name → schema scope (e.g. SHOW TABLES IN tpch_sf1).

--- a/snowflake/parser/split.go
+++ b/snowflake/parser/split.go
@@ -60,11 +60,11 @@ func Split(input string) []Segment {
 		return nil
 	}
 
-	// Split's lexer runs in multilineString mode so a multi-line single-quoted
-	// routine body ('class Foo { ...; ... }' spanning several lines, a Java / JS /
-	// SQL handler) tokenizes as ONE string. The parser's own lexer keeps the
-	// conventional one-line string rule; only segmentation needs a ';' on a
-	// continuation line inside such a body to NOT read as a statement terminator.
+	// Single-quoted strings span newlines in every lexer (see NewLexer), so a
+	// multi-line single-quoted routine body ('class Foo { ...; ... }' spanning
+	// several lines, a Java / JS / SQL handler) tokenizes as ONE string and a
+	// ';' on a continuation line inside it does NOT read as a statement
+	// terminator.
 	l := newSplitLexer(input)
 	var segments []Segment
 	stmtStart := 0

--- a/snowflake/parser/tokens.go
+++ b/snowflake/parser/tokens.go
@@ -28,6 +28,7 @@ const (
 	tokNotEq       // != or <> (legacy NE / LTGT — folded into one token)
 	tokLessEq      // <=  (legacy LE)
 	tokGreaterEq   // >=  (legacy GE)
+	tokBang        // !   (class instance role separator: <instance>!<role>)
 )
 
 // Token represents a single lexical token.
@@ -1005,6 +1006,8 @@ func TokenName(t int) string {
 		return "<="
 	case tokGreaterEq:
 		return ">="
+	case tokBang:
+		return "!"
 	}
 	if t >= 700 {
 		// Keyword token — look up by reverse-mapping the keywordMap. The

--- a/snowflake/parser/trailing_tokens_test.go
+++ b/snowflake/parser/trailing_tokens_test.go
@@ -1,0 +1,371 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/snowflake/ast"
+)
+
+// ---------------------------------------------------------------------------
+// Strict trailing-token rejection (parseSegment strictTrailing).
+//
+// Historically the parser consumed a valid statement PREFIX and silently
+// ignored every token after it: `SELECT * FFROM users` parsed clean as
+// `SELECT *`. The strict path (Parse / ParseStrict / parseSingle) now
+// requires the token after a successfully-parsed statement to be `;` or
+// end-of-segment and reports "syntax error at or near <token>" at the first
+// stray token. ParseBestEffort keeps the historical tolerance for
+// completion / partial-input callers.
+// ---------------------------------------------------------------------------
+
+func TestTrailing_GarbageShapesRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantLoc int    // Loc.Start of the stray token
+		wantTok string // token text in the error message
+	}{
+		// `SELECT *` parses, FFROM is not a star alias (stars take none).
+		{"misspelled FROM", "SELECT * FFROM users", 9, "FFROM"},
+		// `SELECT 1` parses; a number cannot be an implicit alias.
+		{"numbers run", "SELECT 1 2 3", 9, "2"},
+		// `garbage` IS a legal implicit table alias, `extra` is not.
+		{"garbage after alias", "SELECT a FROM b garbage extra", 24, "extra"},
+		// Stray token after a complete WHERE clause.
+		{"garbage after where", "SELECT a FROM b WHERE c garbage", 24, "garbage"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Strict Parse: first error reported, prefix statement still in File.
+			file, err := Parse(c.input)
+			if err == nil {
+				t.Fatalf("Parse(%q): expected error, got nil", c.input)
+			}
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("Parse(%q): error type = %T, want *ParseError", c.input, err)
+			}
+			if want := "syntax error at or near " + c.wantTok; pe.Msg != want {
+				t.Errorf("Parse(%q): Msg = %q, want %q", c.input, pe.Msg, want)
+			}
+			if pe.Loc.Start != c.wantLoc {
+				t.Errorf("Parse(%q): Loc.Start = %d, want %d", c.input, pe.Loc.Start, c.wantLoc)
+			}
+			if len(file.Stmts) != 1 {
+				t.Errorf("Parse(%q): File.Stmts = %d, want 1 (prefix statement retained)", c.input, len(file.Stmts))
+			}
+
+			// ParseStrict: same error, all-errors shape.
+			result := ParseStrict(c.input)
+			if len(result.Errors) != 1 {
+				t.Errorf("ParseStrict(%q): %d errors, want 1: %+v", c.input, len(result.Errors), result.Errors)
+			}
+
+			// ParseBestEffort keeps the historical tolerance.
+			be := ParseBestEffort(c.input)
+			if len(be.Errors) != 0 {
+				t.Errorf("ParseBestEffort(%q): %d errors, want 0 (prefix tolerance): %+v", c.input, len(be.Errors), be.Errors)
+			}
+			if len(be.File.Stmts) != 1 {
+				t.Errorf("ParseBestEffort(%q): File.Stmts = %d, want 1", c.input, len(be.File.Stmts))
+			}
+		})
+	}
+}
+
+func TestTrailing_MultiStatementPerStatementReporting(t *testing.T) {
+	// The first statement has trailing garbage; the second is valid. Strict
+	// parsing reports the first statement's error AND still parses the second.
+	input := "SELECT 1 2; SELECT 3"
+	result := ParseStrict(input)
+	if len(result.Errors) != 1 {
+		t.Fatalf("errors = %d, want 1: %+v", len(result.Errors), result.Errors)
+	}
+	if result.Errors[0].Loc.Start != 9 {
+		t.Errorf("error Loc.Start = %d, want 9 (the stray `2`)", result.Errors[0].Loc.Start)
+	}
+	if !strings.Contains(result.Errors[0].Msg, "at or near 2") {
+		t.Errorf("error Msg = %q, want to mention `2`", result.Errors[0].Msg)
+	}
+	if len(result.File.Stmts) != 2 {
+		t.Fatalf("stmts = %d, want 2 (both statements parsed)", len(result.File.Stmts))
+	}
+	// Both errors when both statements have garbage.
+	result = ParseStrict("SELECT 1 2; SELECT 3 4")
+	if len(result.Errors) != 2 {
+		t.Errorf("two-garbage errors = %d, want 2: %+v", len(result.Errors), result.Errors)
+	}
+}
+
+func TestTrailing_ValidStatementsUnchanged(t *testing.T) {
+	valid := []string{
+		"SELECT 1",
+		"SELECT 1;",
+		"SELECT 1 ;",
+		"SELECT 1; ",
+		"SELECT 1 -- trailing comment",
+		"SELECT 1; -- trailing comment\n",
+		"SELECT 1 /* block */;",
+		"SELECT a FROM b garbage", // implicit table alias — legal SQL
+		"SELECT * FROM t",
+		"BEGIN SELECT 1; END;",                 // scripting block: inner ';' belongs to the block
+		"SHOW TABLES ->> SELECT * FROM $1",     // result pipe consumed by parseTopStmt
+		"SELECT 1;;",                           // empty statement segments are filtered
+		"SELECT 1\n;\nSELECT 2;",               // newline-separated
+		"EXECUTE IMMEDIATE 'SELECT 1'",         // EXECUTE dispatched by identifier text
+		"SELECT column1 FROM VALUES (1), (2);", // bare VALUES row source
+	}
+	for _, sql := range valid {
+		if _, err := Parse(sql); err != nil {
+			t.Errorf("Parse(%q) error = %v, want nil", sql, err)
+		}
+	}
+}
+
+func TestTrailing_SemicolonInsideSegmentAccepted(t *testing.T) {
+	// parseSingle on un-split text: a trailing `;` is a legal terminator.
+	node, errs := parseSingle("SELECT 1;", 0)
+	if len(errs) != 0 {
+		t.Errorf("parseSingle(\"SELECT 1;\") errors = %+v, want none", errs)
+	}
+	if node == nil {
+		t.Errorf("parseSingle(\"SELECT 1;\") node = nil, want statement")
+	}
+	// ... but tokens AFTER the terminator within one segment are rejected
+	// (one segment == one statement).
+	_, errs = parseSingle("SELECT 1; SELECT 2", 0)
+	if len(errs) != 1 {
+		t.Errorf("parseSingle(\"SELECT 1; SELECT 2\") errors = %d, want 1: %+v", len(errs), errs)
+	}
+}
+
+func TestTrailing_LexErrorInDroppedTailNowSurfaces(t *testing.T) {
+	// The recovery scan consumes the garbage tail, so lex errors hiding in it
+	// are promoted instead of vanishing with the silent drop.
+	result := ParseStrict("SELECT 1 ⊕")
+	if len(result.Errors) == 0 {
+		t.Fatalf("expected errors for garbage tail with invalid byte, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Construct regressions — every shape below previously "parsed clean" only
+// because its tail was silently dropped (found empirically by running the
+// 657-file corpus closure in strict mode). Each now parses COMPLETELY.
+// ---------------------------------------------------------------------------
+
+func TestTrailing_FixedConstructsParseCompletely(t *testing.T) {
+	cases := []string{
+		// Bare VALUES row source in FROM (order-by/pivot/values docs files).
+		"SELECT column1 FROM VALUES (1), (null), (2) ORDER BY column1",
+		"SELECT t.column1 FROM VALUES (1), (2) AS t",
+		// Join variants with DIRECTED in documented position / NATURAL INNER.
+		"SELECT t1.col1 FROM t1 INNER DIRECTED JOIN t2 ON t2.col1 = t1.col1",
+		"SELECT * FROM d1 NATURAL INNER JOIN d2 ORDER BY id",
+		"SELECT * FROM t1 LEFT OUTER DIRECTED JOIN t2 ON t1.a = t2.a",
+		// SHOW scopes for failover / replication groups.
+		"SHOW DATABASES IN FAILOVER GROUP grp",
+		"SHOW SHARES IN REPLICATION GROUP grp",
+		// DROP FUNCTION / PROCEDURE overload signatures.
+		"DROP FUNCTION obj()",
+		"DROP FUNCTION obj(int)",
+		"DROP PROCEDURE obj(VARCHAR, NUMBER(10,2))",
+		// Postfix IF NOT EXISTS (legacy grammar placement).
+		"CREATE TABLE t1 IF NOT EXISTS (v VARCHAR(16777216))",
+		// CREATE DATABASE from an inbound share.
+		"CREATE DATABASE snow_sales FROM SHARE ab67890.sales_s",
+		// IDENTIFIER(...) object names.
+		"USE WAREHOUSE IDENTIFIER($current_wh_name)",
+		"UNDROP TABLE IDENTIFIER(408578)",
+		// Class instance role grantee (budget instance roles).
+		"SHOW GRANTS TO SNOWFLAKE.CORE.BUDGET ROLE cost.budgets.my_budget!ADMIN",
+		// ALTER VIEW comma-separated column actions + drop-and-add policies.
+		"ALTER VIEW v MODIFY COLUMN a SET MASKING POLICY p1, COLUMN b SET MASKING POLICY p2",
+		"ALTER VIEW v MODIFY COLUMN a UNSET MASKING POLICY, COLUMN b UNSET MASKING POLICY",
+		"ALTER VIEW v1 DROP ROW ACCESS POLICY rap_1, ADD ROW ACCESS POLICY rap_2 ON (empl_id)",
+		// Multi-line single-quoted string (Snowflake strings may span lines).
+		"SELECT PARSE_JSON(column1) FROM VALUES ('{\n  \"a\": 1\n}')",
+	}
+	for _, sql := range cases {
+		if _, err := Parse(sql); err != nil {
+			t.Errorf("Parse(%q) error = %v, want nil", sql, err)
+		}
+	}
+}
+
+func TestTrailing_FromValuesAST(t *testing.T) {
+	file, err := Parse("SELECT column1 FROM VALUES (1), (2), (3)")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	sel, ok := file.Stmts[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("stmt = %T, want *ast.SelectStmt", file.Stmts[0])
+	}
+	ref, ok := sel.From[0].(*ast.TableRef)
+	if !ok {
+		t.Fatalf("from = %T, want *ast.TableRef", sel.From[0])
+	}
+	values, ok := ref.Subquery.(*ast.ValuesClause)
+	if !ok {
+		t.Fatalf("subquery = %T, want *ast.ValuesClause", ref.Subquery)
+	}
+	if len(values.Rows) != 3 {
+		t.Errorf("rows = %d, want 3", len(values.Rows))
+	}
+}
+
+func TestTrailing_DirectedJoinAST(t *testing.T) {
+	file, err := Parse("SELECT * FROM t1 INNER DIRECTED JOIN t2 ON t1.a = t2.a")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	sel := file.Stmts[0].(*ast.SelectStmt)
+	join, ok := sel.From[0].(*ast.JoinExpr)
+	if !ok {
+		t.Fatalf("from = %T, want *ast.JoinExpr", sel.From[0])
+	}
+	if !join.Directed || join.Type != ast.JoinInner || join.Natural {
+		t.Errorf("join = {Type:%v Natural:%v Directed:%v}, want inner directed non-natural",
+			join.Type, join.Natural, join.Directed)
+	}
+
+	file, err = Parse("SELECT * FROM d1 NATURAL INNER JOIN d2")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	sel = file.Stmts[0].(*ast.SelectStmt)
+	join = sel.From[0].(*ast.JoinExpr)
+	if !join.Natural || join.Type != ast.JoinInner {
+		t.Errorf("NATURAL INNER JOIN: got {Type:%v Natural:%v}", join.Type, join.Natural)
+	}
+}
+
+func TestTrailing_DropFunctionSignatureAST(t *testing.T) {
+	file, err := Parse("DROP FUNCTION obj(int, VARCHAR)")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	drop := file.Stmts[0].(*ast.DropStmt)
+	if !drop.HasArgs || len(drop.ArgTypes) != 2 {
+		t.Errorf("HasArgs=%v ArgTypes=%d, want true/2", drop.HasArgs, len(drop.ArgTypes))
+	}
+	// Empty signature: HasArgs true, zero types.
+	file, err = Parse("DROP PROCEDURE obj()")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	drop = file.Stmts[0].(*ast.DropStmt)
+	if !drop.HasArgs || len(drop.ArgTypes) != 0 {
+		t.Errorf("empty signature: HasArgs=%v ArgTypes=%d, want true/0", drop.HasArgs, len(drop.ArgTypes))
+	}
+	// No signature at all: HasArgs false.
+	file, err = Parse("DROP FUNCTION obj")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	drop = file.Stmts[0].(*ast.DropStmt)
+	if drop.HasArgs {
+		t.Errorf("no signature: HasArgs = true, want false")
+	}
+}
+
+func TestTrailing_ClassRoleGranteeAST(t *testing.T) {
+	file, err := Parse("SHOW GRANTS TO SNOWFLAKE.CORE.BUDGET ROLE cost.budgets.my_budget!ADMIN")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	show := file.Stmts[0].(*ast.ShowStmt)
+	g := show.GrantsTo
+	if g == nil {
+		t.Fatalf("GrantsTo = nil")
+	}
+	if g.Kind != ast.GranteeClassRole {
+		t.Errorf("Kind = %v, want GranteeClassRole", g.Kind)
+	}
+	if g.Class == nil || g.Class.Normalize() != "SNOWFLAKE.CORE.BUDGET" {
+		t.Errorf("Class = %v, want SNOWFLAKE.CORE.BUDGET", g.Class)
+	}
+	if g.Name == nil || g.Name.Normalize() != "COST.BUDGETS.MY_BUDGET" {
+		t.Errorf("Name = %v, want COST.BUDGETS.MY_BUDGET", g.Name)
+	}
+	if g.InstanceRole.Normalize() != "ADMIN" {
+		t.Errorf("InstanceRole = %q, want ADMIN", g.InstanceRole.Name)
+	}
+}
+
+func TestTrailing_AlterViewColumnActionsAST(t *testing.T) {
+	file, err := Parse("ALTER VIEW v MODIFY COLUMN a SET MASKING POLICY p1, COLUMN b UNSET MASKING POLICY")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	av := file.Stmts[0].(*ast.AlterViewStmt)
+	if len(av.ColumnActions) != 2 {
+		t.Fatalf("ColumnActions = %d, want 2", len(av.ColumnActions))
+	}
+	// First action mirrored into legacy fields.
+	if av.Action != ast.AlterViewColumnSetMaskingPolicy || av.Column.Normalize() != "A" {
+		t.Errorf("mirror: Action=%v Column=%q", av.Action, av.Column.Name)
+	}
+	if av.ColumnActions[1].Action != ast.AlterViewColumnUnsetMaskingPolicy ||
+		av.ColumnActions[1].Column.Normalize() != "B" {
+		t.Errorf("second action = {%v %q}", av.ColumnActions[1].Action, av.ColumnActions[1].Column.Name)
+	}
+
+	file, err = Parse("ALTER VIEW v1 DROP ROW ACCESS POLICY r1, ADD ROW ACCESS POLICY r2 ON (empl_id)")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	av = file.Stmts[0].(*ast.AlterViewStmt)
+	if av.Action != ast.AlterViewDropRowAccessPolicy {
+		t.Errorf("Action = %v, want AlterViewDropRowAccessPolicy", av.Action)
+	}
+	if av.AddPolicyName == nil || av.AddPolicyName.Normalize() != "R2" || len(av.AddPolicyCols) != 1 {
+		t.Errorf("AddPolicyName = %v, AddPolicyCols = %v", av.AddPolicyName, av.AddPolicyCols)
+	}
+}
+
+func TestTrailing_PutFileURLDoesNotEatNextStatement(t *testing.T) {
+	// `file://` used to open a `//` line comment in Split's lexer, hiding the
+	// real `;` so the following statement fused into the PUT's segment and
+	// was silently dropped. The `://` guard keeps the `;` visible.
+	input := "put file:// @stage/;\nremove @stage/"
+	segs := Split(input)
+	if len(segs) != 2 {
+		t.Fatalf("Split produced %d segments, want 2: %+v", len(segs), segs)
+	}
+	result := ParseStrict(input)
+	if len(result.Errors) != 0 {
+		t.Errorf("errors = %+v, want none", result.Errors)
+	}
+	if len(result.File.Stmts) != 2 {
+		t.Fatalf("stmts = %d, want 2 (PUT and REMOVE)", len(result.File.Stmts))
+	}
+	if _, ok := result.File.Stmts[0].(*ast.PutStmt); !ok {
+		t.Errorf("stmt[0] = %T, want *ast.PutStmt", result.File.Stmts[0])
+	}
+	if _, ok := result.File.Stmts[1].(*ast.RemoveStmt); !ok {
+		t.Errorf("stmt[1] = %T, want *ast.RemoveStmt", result.File.Stmts[1])
+	}
+	// A real `//` line comment (not preceded by `:`) still comments.
+	if _, err := Parse("SELECT 1 // trailing comment"); err != nil {
+		t.Errorf("// comment broken: %v", err)
+	}
+}
+
+func TestTrailing_IdentifierFuncName(t *testing.T) {
+	file, err := Parse("USE WAREHOUSE IDENTIFIER($current_wh_name)")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	use := file.Stmts[0].(*ast.UseStmt)
+	if use.Name == nil || use.Name.Name.Name != "IDENTIFIER($current_wh_name)" {
+		t.Errorf("Name = %+v, want verbatim IDENTIFIER($current_wh_name)", use.Name)
+	}
+	// A table genuinely named identifier (no parens) is untouched.
+	file, err = Parse("SELECT * FROM identifier")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+}

--- a/snowflake/parser/view.go
+++ b/snowflake/parser/view.go
@@ -689,6 +689,35 @@ func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
 				}
 				stmt.Action = ast.AlterViewDropRowAccessPolicy
 				stmt.PolicyName = policyName
+
+				// Documented drop-and-add combination:
+				// DROP ROW ACCESS POLICY p1, ADD ROW ACCESS POLICY p2 ON (cols)
+				if p.cur.Type == ',' && p.peekNext().Type == kwADD {
+					p.advance() // consume ','
+					p.advance() // consume ADD
+					if _, err := p.expect(kwROW); err != nil {
+						return nil, err
+					}
+					if _, err := p.expect(kwACCESS); err != nil {
+						return nil, err
+					}
+					if _, err := p.expect(kwPOLICY); err != nil {
+						return nil, err
+					}
+					addName, err := p.parseObjectName()
+					if err != nil {
+						return nil, err
+					}
+					if _, err := p.expect(kwON); err != nil {
+						return nil, err
+					}
+					addCols, err := p.parseIdentListInParens()
+					if err != nil {
+						return nil, err
+					}
+					stmt.AddPolicyName = addName
+					stmt.AddPolicyCols = addCols
+				}
 			} else if p.cur.Type == kwPOLICIES {
 				p.advance() // consume POLICIES
 				stmt.Action = ast.AlterViewDropAllRowAccessPolicies
@@ -713,97 +742,137 @@ func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
 		}
 
 	case kwALTER, kwMODIFY:
-		// ALTER|MODIFY [COLUMN] col_name SET MASKING POLICY / UNSET MASKING POLICY
-		// ALTER|MODIFY [COLUMN] col_name SET TAG / UNSET TAG
+		// ALTER|MODIFY [COLUMN] col SET MASKING POLICY / UNSET MASKING POLICY
+		//                          | SET TAG / UNSET TAG
+		// — comma-separated list form included:
+		// MODIFY COLUMN a SET MASKING POLICY p1, COLUMN b SET MASKING POLICY p2
 		p.advance() // consume ALTER or MODIFY
-		// Optional COLUMN keyword
-		if p.cur.Type == kwCOLUMN {
-			p.advance() // consume COLUMN
+		for {
+			action, err := p.parseAlterViewColumnAction()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ColumnActions = append(stmt.ColumnActions, action)
+			if p.cur.Type != ',' {
+				break
+			}
+			p.advance() // consume ','
 		}
-		colName, err := p.parseIdent()
-		if err != nil {
-			return nil, err
-		}
-		stmt.Column = colName
+		// Mirror the first action into the legacy single-action fields.
+		first := stmt.ColumnActions[0]
+		stmt.Action = first.Action
+		stmt.Column = first.Column
+		stmt.MaskingPolicy = first.MaskingPolicy
+		stmt.MaskingUsing = first.MaskingUsing
+		stmt.Tags = first.Tags
+		stmt.UnsetTags = first.UnsetTags
 
+	default:
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	stmt.Loc.End = p.prev.Loc.End
+	return stmt, nil
+}
+
+// parseAlterViewColumnAction parses ONE element of an ALTER VIEW
+// MODIFY/ALTER column action list:
+//
+//	[COLUMN] <col> { SET MASKING POLICY <p> [USING (col, ...)] [FORCE]
+//	               | UNSET MASKING POLICY
+//	               | SET TAG <t> = '<v>' [, ...]
+//	               | UNSET TAG <t> [, ...] }
+//
+// The leading ALTER|MODIFY keyword (or the list comma) has already been
+// consumed.
+func (p *Parser) parseAlterViewColumnAction() (*ast.AlterViewColumnAction, error) {
+	action := &ast.AlterViewColumnAction{Loc: ast.Loc{Start: p.cur.Loc.Start}}
+
+	// Optional COLUMN keyword
+	if p.cur.Type == kwCOLUMN {
+		p.advance() // consume COLUMN
+	}
+	colName, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	action.Column = colName
+
+	switch p.cur.Type {
+	case kwSET:
+		p.advance() // consume SET
 		switch p.cur.Type {
-		case kwSET:
-			p.advance() // consume SET
-			switch p.cur.Type {
-			case kwMASKING:
-				// SET MASKING POLICY policy_name [USING (col, ...)] [FORCE]
-				p.advance() // consume MASKING
-				if _, err := p.expect(kwPOLICY); err != nil {
-					return nil, err
-				}
-				policyName, err := p.parseObjectName()
-				if err != nil {
-					return nil, err
-				}
-				stmt.Action = ast.AlterViewColumnSetMaskingPolicy
-				stmt.MaskingPolicy = policyName
+		case kwMASKING:
+			// SET MASKING POLICY policy_name [USING (col, ...)] [FORCE]
+			p.advance() // consume MASKING
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return nil, err
+			}
+			policyName, err := p.parseObjectName()
+			if err != nil {
+				return nil, err
+			}
+			action.Action = ast.AlterViewColumnSetMaskingPolicy
+			action.MaskingPolicy = policyName
 
-				// Optional USING (col, ...)
-				if p.cur.Type == kwUSING {
-					p.advance() // consume USING
-					if _, err := p.expect('('); err != nil {
+			// Optional USING (col, ...)
+			if p.cur.Type == kwUSING {
+				p.advance() // consume USING
+				if _, err := p.expect('('); err != nil {
+					return nil, err
+				}
+				for p.cur.Type != ')' && p.cur.Type != tokEOF {
+					id, err := p.parseIdent()
+					if err != nil {
 						return nil, err
 					}
-					for p.cur.Type != ')' && p.cur.Type != tokEOF {
-						id, err := p.parseIdent()
-						if err != nil {
-							return nil, err
-						}
-						stmt.MaskingUsing = append(stmt.MaskingUsing, id)
-						if p.cur.Type == ',' {
-							p.advance()
-						} else {
-							break
-						}
-					}
-					if _, err := p.expect(')'); err != nil {
-						return nil, err
+					action.MaskingUsing = append(action.MaskingUsing, id)
+					if p.cur.Type == ',' {
+						p.advance()
+					} else {
+						break
 					}
 				}
-
-				// Optional FORCE
-				if p.cur.Type == kwFORCE {
-					p.advance() // consume FORCE
-				}
-
-			case kwTAG:
-				tags, err := p.parseTagAssignments()
-				if err != nil {
+				if _, err := p.expect(')'); err != nil {
 					return nil, err
 				}
-				stmt.Action = ast.AlterViewColumnSetTag
-				stmt.Tags = tags
-
-			default:
-				return nil, p.syntaxErrorAtCur()
 			}
 
-		case kwUNSET:
-			p.advance() // consume UNSET
-			switch p.cur.Type {
-			case kwMASKING:
-				p.advance() // consume MASKING
-				if _, err := p.expect(kwPOLICY); err != nil {
-					return nil, err
-				}
-				stmt.Action = ast.AlterViewColumnUnsetMaskingPolicy
-
-			case kwTAG:
-				names, err := p.parseUnsetTagList()
-				if err != nil {
-					return nil, err
-				}
-				stmt.Action = ast.AlterViewColumnUnsetTag
-				stmt.UnsetTags = names
-
-			default:
-				return nil, p.syntaxErrorAtCur()
+			// Optional FORCE
+			if p.cur.Type == kwFORCE {
+				p.advance() // consume FORCE
+				action.Force = true
 			}
+
+		case kwTAG:
+			tags, err := p.parseTagAssignments()
+			if err != nil {
+				return nil, err
+			}
+			action.Action = ast.AlterViewColumnSetTag
+			action.Tags = tags
+
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+
+	case kwUNSET:
+		p.advance() // consume UNSET
+		switch p.cur.Type {
+		case kwMASKING:
+			p.advance() // consume MASKING
+			if _, err := p.expect(kwPOLICY); err != nil {
+				return nil, err
+			}
+			action.Action = ast.AlterViewColumnUnsetMaskingPolicy
+
+		case kwTAG:
+			names, err := p.parseUnsetTagList()
+			if err != nil {
+				return nil, err
+			}
+			action.Action = ast.AlterViewColumnUnsetTag
+			action.UnsetTags = names
 
 		default:
 			return nil, p.syntaxErrorAtCur()
@@ -813,8 +882,8 @@ func (p *Parser) parseAlterViewStmt() (ast.Node, error) {
 		return nil, p.syntaxErrorAtCur()
 	}
 
-	stmt.Loc.End = p.prev.Loc.End
-	return stmt, nil
+	action.Loc.End = p.prev.Loc.End
+	return action, nil
 }
 
 // parseAlterViewSetJoinPolicy parses


### PR DESCRIPTION
Strict Parse now rejects unconsumed trailing tokens (`SELECT * FFROM users`, `SELECT 1 2 3` → syntax error at the stray token; per-statement recovery; new ParseStrict; ParseBestEffort tolerance unchanged for completion). diagnostics.Analyze uses the strict path — requested by the bytebase #20567 cloud review.

Running the corpus in strict mode exposed 26 files relying on the silent drop — 11 missing constructs implemented rather than exempted: bare FROM VALUES rows; multi-line single-quoted strings (parser lexer one-line rule removed, now agrees with Split); `file://` vs `//`-comment guard; DIRECTED/NATURAL-INNER JOIN orders; SHOW ... IN FAILOVER|REPLICATION GROUP; DROP FUNCTION/PROCEDURE overload signatures; postfix IF NOT EXISTS; CREATE DATABASE FROM SHARE; IDENTIFIER($var) object names; SHOW GRANTS TO class!role (new tokBang); ALTER VIEW column-action lists. 1 corpus file is a genuine docs typo → MALFORMED skip. Corpus: 650 clean strict + 7 categorized skips; full suite green. Verified on fresh checkout of 04040d76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
