### PR TITLE
fix(snowflake/parser): optional column list in DROP PRIMARY KEY (legacy parity)

### DIFF
--- a/snowflake/parser/alter_table.go
+++ b/snowflake/parser/alter_table.go
@@ -495,13 +495,22 @@ func (p *Parser) parseAlterTableDropAction(action *ast.AlterTableAction) error {
 		return nil
 
 	case kwPRIMARY:
-		// DROP PRIMARY KEY [CASCADE|RESTRICT]
+		// DROP PRIMARY KEY (cols)? [CASCADE|RESTRICT] — the column list is not
+		// in current docs but the legacy ANTLR parser tolerated it (real
+		// migrations use it), mirroring the UNIQUE/FOREIGN KEY forms. It was
+		// previously absorbed by the silent trailing-token drop; strict Parse
+		// (#303) made the gap visible.
 		p.advance() // consume PRIMARY
 		if _, err := p.expect(kwKEY); err != nil {
 			return err
 		}
 		action.Kind = ast.AlterTableDropConstraint
 		action.IsPrimaryKey = true
+		if p.cur.Type == '(' {
+			if err := p.skipParenthesized(); err != nil {
+				return err
+			}
+		}
 		p.parseDropCascadeRestrict(action)
 		return nil
 

--- a/snowflake/parser/alter_table_test.go
+++ b/snowflake/parser/alter_table_test.go
@@ -788,3 +788,20 @@ func TestAlterTable_LocTracking(t *testing.T) {
 		t.Errorf("stmt.Loc.End (%d) <= Start (%d)", stmt.Loc.End, stmt.Loc.Start)
 	}
 }
+
+// TestAlterTable_DropPrimaryKeyWithColumns covers the legacy-tolerated
+// `DROP PRIMARY KEY (cols)` form (strict Parse #303 exposed that the column
+// list was previously absorbed by the silent trailing-token drop).
+func TestAlterTable_DropPrimaryKeyWithColumns(t *testing.T) {
+	file, err := Parse("ALTER TABLE CUSTOMER DROP PRIMARY KEY(ID);")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	stmt, ok := file.Stmts[0].(*ast.AlterTableStmt)
+	if !ok {
+		t.Fatalf("expected AlterTableStmt, got %T", file.Stmts[0])
+	}
+	if len(stmt.Actions) != 1 || stmt.Actions[0].Kind != ast.AlterTableDropConstraint || !stmt.Actions[0].IsPrimaryKey {
+		t.Fatalf("expected DROP PRIMARY KEY action, got %+v", stmt.Actions[0])
+	}
+}


### PR DESCRIPTION
Strict Parse (#303) exposed that `ALTER TABLE … DROP PRIMARY KEY(ID)` only "parsed" via the silent trailing-token drop — the column list now mirrors the optional `(cols)` already accepted on DROP UNIQUE / DROP FOREIGN KEY (legacy ANTLR tolerated it; bytebase advisor yaml differential caught the regression). Test added; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
