### PR TITLE
feat(starrocks/parser): FROM-side query features — VALUES inline-table + LATERAL/table-function (PR4a)

### DIFF
--- a/starrocks/analysis/query_span.go
+++ b/starrocks/analysis/query_span.go
@@ -260,6 +260,8 @@ func (w *spanWalker) visitFromItem(node ast.Node) {
 		w.visitTableRef(n)
 	case *ast.InlineTable:
 		w.visitInlineTable(n)
+	case *ast.TableFunctionRef:
+		w.visitTableFunctionRef(n)
 	case *ast.JoinClause:
 		w.visitFromItem(n.Left)
 		w.visitFromItem(n.Right)
@@ -282,6 +284,17 @@ func (w *spanWalker) visitInlineTable(n *ast.InlineTable) {
 			w.walkExpr(e)
 		}
 	}
+}
+
+// visitTableFunctionRef handles a table-function relation (e.g. unnest(t.arr)).
+// The function itself is not a physical table, so it adds nothing to
+// AccessTables; we walk the call so its argument expressions — the unnested
+// source column and any embedded subquery — are captured for lineage.
+func (w *spanWalker) visitTableFunctionRef(n *ast.TableFunctionRef) {
+	if n == nil || n.Call == nil {
+		return
+	}
+	w.walkExpr(n.Call)
 }
 
 // visitTableRef handles a single TableRef from the FROM clause. The parser

--- a/starrocks/analysis/query_span.go
+++ b/starrocks/analysis/query_span.go
@@ -258,11 +258,28 @@ func (w *spanWalker) visitFromItem(node ast.Node) {
 	switch n := node.(type) {
 	case *ast.TableRef:
 		w.visitTableRef(n)
+	case *ast.InlineTable:
+		w.visitInlineTable(n)
 	case *ast.JoinClause:
 		w.visitFromItem(n.Left)
 		w.visitFromItem(n.Right)
 		if n.On != nil {
 			w.walkExpr(n.On)
+		}
+	}
+}
+
+// visitInlineTable handles a VALUES table constructor in FROM. It is a
+// literal-derived (non-physical) relation, so it contributes NO entry to
+// AccessTables; we still walk each row expression so any subquery embedded in
+// a row contributes its physical tables.
+func (w *spanWalker) visitInlineTable(n *ast.InlineTable) {
+	if n == nil {
+		return
+	}
+	for _, row := range n.Rows {
+		for _, e := range row {
+			w.walkExpr(e)
 		}
 	}
 }

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -352,6 +352,45 @@ func TestGetQuerySpan_InlineTableSubqueryRow(t *testing.T) {
 	}
 }
 
+func TestGetQuerySpan_TableFunction(t *testing.T) {
+	// A table function (unnest) is not a physical table: only the left table t
+	// must appear in AccessTables — never a phantom table named "unnest"/"u".
+	span, err := GetQuerySpan("SELECT * FROM t, unnest(t.arr) AS u")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "t" {
+		t.Errorf("AccessTables = %+v, want [t] (no phantom unnest)", sigs)
+	}
+}
+
+func TestGetQuerySpan_LateralUnnest(t *testing.T) {
+	// LATERAL unnest correlated against t: t is the only physical table.
+	span, err := GetQuerySpan("SELECT t.id, u.unnest FROM t, LATERAL unnest(t.arr) AS u")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "t" {
+		t.Errorf("AccessTables = %+v, want [t] (no phantom unnest)", sigs)
+	}
+}
+
+func TestGetQuerySpan_LateralInParenList(t *testing.T) {
+	// LATERAL after a comma inside a parenthesized relation list must parse so
+	// lineage is not silently dropped: t and the unnest-arg subquery table both
+	// surface.
+	span, err := GetQuerySpan("SELECT * FROM (t, LATERAL unnest((SELECT arr FROM latn)) AS u)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if !containsSig(sigs, tableSig{Table: "t"}) || !containsSig(sigs, tableSig{Table: "latn"}) {
+		t.Errorf("AccessTables = %+v, want both t and latn", sigs)
+	}
+}
+
 func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
 	// Even if a physical table exists elsewhere named "real_t", a CTE with
 	// the same name inside the WITH clause means the outer reference resolves

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -323,6 +323,35 @@ func TestGetQuerySpan_SelectItemSourceColumns(t *testing.T) {
 	}
 }
 
+func TestGetQuerySpan_InlineTable(t *testing.T) {
+	// A VALUES table constructor is literal-derived: it must parse and must NOT
+	// leak a phantom physical table (named "v" or "VALUES") into AccessTables.
+	span, err := GetQuerySpan("SELECT * FROM (VALUES (1,'a'),(2,'b')) AS v(id,name)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 0 {
+		t.Errorf("AccessTables = %+v, want empty (inline table is not physical)", span.AccessTables)
+	}
+	if len(span.Results) != 1 || span.Results[0].Name != "*" {
+		t.Errorf("Results = %+v, want [*]", span.Results)
+	}
+}
+
+func TestGetQuerySpan_InlineTableSubqueryRow(t *testing.T) {
+	// A subquery embedded in a VALUES row must still contribute its physical
+	// table to AccessTables (this is the discriminating lineage probe: it fails
+	// unless visitFromItem walks the inline table's row expressions).
+	span, err := GetQuerySpan("SELECT * FROM (VALUES ((SELECT a FROM inner_t))) AS v(x)")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	if len(sigs) != 1 || sigs[0].Table != "inner_t" {
+		t.Errorf("AccessTables = %+v, want [inner_t]", sigs)
+	}
+}
+
 func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
 	// Even if a physical table exists elsewhere named "real_t", a CTE with
 	// the same name inside the WITH clause means the outer reference resolves

--- a/starrocks/ast/loc.go
+++ b/starrocks/ast/loc.go
@@ -82,6 +82,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *TableRef:
 		return v.Loc
+	case *InlineTable:
+		return v.Loc
 	case *JoinClause:
 		return v.Loc
 	case *SetOpStmt:

--- a/starrocks/ast/loc.go
+++ b/starrocks/ast/loc.go
@@ -84,6 +84,8 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *InlineTable:
 		return v.Loc
+	case *TableFunctionRef:
+		return v.Loc
 	case *JoinClause:
 		return v.Loc
 	case *SetOpStmt:

--- a/starrocks/ast/nodetags.go
+++ b/starrocks/ast/nodetags.go
@@ -135,6 +135,9 @@ const (
 	// T_InlineTable is the tag for *InlineTable (VALUES table constructor in FROM).
 	T_InlineTable
 
+	// T_TableFunctionRef is the tag for *TableFunctionRef (table function in FROM).
+	T_TableFunctionRef
+
 	// T_JoinClause is the tag for *JoinClause (JOIN expression in FROM).
 	T_JoinClause
 
@@ -683,6 +686,8 @@ func (t NodeTag) String() string {
 		return "TableRef"
 	case T_InlineTable:
 		return "InlineTable"
+	case T_TableFunctionRef:
+		return "TableFunctionRef"
 	case T_JoinClause:
 		return "JoinClause"
 	case T_SetOpStmt:

--- a/starrocks/ast/nodetags.go
+++ b/starrocks/ast/nodetags.go
@@ -132,6 +132,9 @@ const (
 	// T_TableRef is the tag for *TableRef (table reference in FROM clause).
 	T_TableRef
 
+	// T_InlineTable is the tag for *InlineTable (VALUES table constructor in FROM).
+	T_InlineTable
+
 	// T_JoinClause is the tag for *JoinClause (JOIN expression in FROM).
 	T_JoinClause
 
@@ -678,6 +681,8 @@ func (t NodeTag) String() string {
 		return "SelectItem"
 	case T_TableRef:
 		return "TableRef"
+	case T_InlineTable:
+		return "InlineTable"
 	case T_JoinClause:
 		return "JoinClause"
 	case T_SetOpStmt:

--- a/starrocks/ast/selectnodes.go
+++ b/starrocks/ast/selectnodes.go
@@ -139,6 +139,29 @@ func (n *InlineTable) Tag() NodeTag { return T_InlineTable }
 // Compile-time assertion that *InlineTable satisfies Node.
 var _ Node = (*InlineTable)(nil)
 
+// TableFunctionRef represents a table-function relation primary in the FROM
+// clause (StarRocks's #tableFunction relation primary):
+//
+//	func(args) [AS? alias [(cols)]]      e.g. unnest(t.arr) AS u(elem)
+//
+// The optional LATERAL prefix (StarRocks allows LATERAL before any relation
+// primary; it is most common before a table function such as unnest) is
+// recorded in Lateral. The call reuses FuncCallExpr so the argument
+// expressions stay walkable for lineage. It references no physical table.
+type TableFunctionRef struct {
+	Call          *FuncCallExpr // the table function call, e.g. unnest(t.arr)
+	Alias         string        // optional table alias; empty if absent
+	ColumnAliases []string      // optional column-alias list; nil if absent
+	Lateral       bool          // LATERAL prefix present
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *TableFunctionRef) Tag() NodeTag { return T_TableFunctionRef }
+
+// Compile-time assertion that *TableFunctionRef satisfies Node.
+var _ Node = (*TableFunctionRef)(nil)
+
 // ---------------------------------------------------------------------------
 // JOIN clause (basic structure for T1.4; T1.5 will flesh out)
 // ---------------------------------------------------------------------------

--- a/starrocks/ast/selectnodes.go
+++ b/starrocks/ast/selectnodes.go
@@ -117,6 +117,28 @@ func (n *TableRef) Tag() NodeTag { return T_TableRef }
 // Compile-time assertion that *TableRef satisfies Node.
 var _ Node = (*TableRef)(nil)
 
+// InlineTable represents a VALUES table constructor in the FROM clause
+// (StarRocks's #inlineTable relation primary):
+//
+//	(VALUES (expr, ...), (expr, ...), ...) [AS] alias [(col, ...)]
+//
+// The wrapping parens are part of the construct. The alias and the
+// column-alias list are both optional. It is a literal-derived relation — it
+// references no physical table — so the analysis layer must not record it as
+// one.
+type InlineTable struct {
+	Rows          [][]Node // each row is a list of value expressions
+	Alias         string   // optional table alias; empty if absent
+	ColumnAliases []string // optional column-alias list; nil if absent
+	Loc           Loc
+}
+
+// Tag implements Node.
+func (n *InlineTable) Tag() NodeTag { return T_InlineTable }
+
+// Compile-time assertion that *InlineTable satisfies Node.
+var _ Node = (*InlineTable)(nil)
+
 // ---------------------------------------------------------------------------
 // JOIN clause (basic structure for T1.4; T1.5 will flesh out)
 // ---------------------------------------------------------------------------

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -184,6 +184,10 @@ func walkChildren(v Visitor, node Node) {
 		for _, row := range n.Rows {
 			walkNodes(v, row)
 		}
+	case *TableFunctionRef:
+		if n.Call != nil {
+			Walk(v, n.Call)
+		}
 	case *JoinClause:
 		Walk(v, n.Left)
 		Walk(v, n.Right)

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -180,6 +180,10 @@ func walkChildren(v Visitor, node Node) {
 		if n.Name != nil {
 			Walk(v, n.Name)
 		}
+	case *InlineTable:
+		for _, row := range n.Rows {
+			walkNodes(v, row)
+		}
 	case *JoinClause:
 		Walk(v, n.Left)
 		Walk(v, n.Right)

--- a/starrocks/parser/inline_table_test.go
+++ b/starrocks/parser/inline_table_test.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+// mustParseInlineTable parses input, expects exactly one FROM item which must
+// be an *ast.InlineTable, and returns it.
+func mustParseInlineTable(t *testing.T, input string) *ast.InlineTable {
+	t.Helper()
+	stmt := mustParseSelect(t, input)
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	it, ok := stmt.From[0].(*ast.InlineTable)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.InlineTable", stmt.From[0])
+	}
+	return it
+}
+
+// TestInlineTableValues covers the headline form: a VALUES table constructor
+// with an alias and a column-alias list.
+func TestInlineTableValues(t *testing.T) {
+	it := mustParseInlineTable(t, "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS v(id, name)")
+	if len(it.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(it.Rows))
+	}
+	if len(it.Rows[0]) != 2 {
+		t.Errorf("row[0] cols = %d, want 2", len(it.Rows[0]))
+	}
+	if it.Alias != "v" {
+		t.Errorf("alias = %q, want v", it.Alias)
+	}
+	if got := it.ColumnAliases; len(got) != 2 || got[0] != "id" || got[1] != "name" {
+		t.Errorf("columnAliases = %v, want [id name]", got)
+	}
+}
+
+// TestInlineTableNoAlias confirms the alias is optional in FROM position
+// (unlike a bare top-level VALUES, which StarRocks does not accept).
+func TestInlineTableNoAlias(t *testing.T) {
+	it := mustParseInlineTable(t, "SELECT * FROM (VALUES (1), (2))")
+	if len(it.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(it.Rows))
+	}
+	if it.Alias != "" {
+		t.Errorf("alias = %q, want empty", it.Alias)
+	}
+	if it.ColumnAliases != nil {
+		t.Errorf("columnAliases = %v, want nil", it.ColumnAliases)
+	}
+}
+
+// TestInlineTableAliasNoColumns covers an alias without a column-alias list.
+func TestInlineTableAliasNoColumns(t *testing.T) {
+	it := mustParseInlineTable(t, "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) v")
+	if it.Alias != "v" {
+		t.Errorf("alias = %q, want v", it.Alias)
+	}
+	if it.ColumnAliases != nil {
+		t.Errorf("columnAliases = %v, want nil", it.ColumnAliases)
+	}
+}

--- a/starrocks/parser/lateral_test.go
+++ b/starrocks/parser/lateral_test.go
@@ -1,0 +1,97 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+// TestTableFunctionInFrom covers the #tableFunction relation primary
+// (unnest(...) AS u) parsed without a LATERAL prefix — a previously dropped
+// construct (the args used to be silently discarded).
+func TestTableFunctionInFrom(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM t, unnest(t.arr) AS u")
+	if len(stmt.From) != 2 {
+		t.Fatalf("from = %d, want 2", len(stmt.From))
+	}
+	tf, ok := stmt.From[1].(*ast.TableFunctionRef)
+	if !ok {
+		t.Fatalf("from[1] = %T, want *ast.TableFunctionRef", stmt.From[1])
+	}
+	if tf.Lateral {
+		t.Error("Lateral = true, want false (no LATERAL prefix)")
+	}
+	if tf.Alias != "u" {
+		t.Errorf("alias = %q, want u", tf.Alias)
+	}
+	if tf.Call == nil || tf.Call.Name == nil ||
+		tf.Call.Name.Parts[len(tf.Call.Name.Parts)-1] != "unnest" {
+		t.Fatalf("call = %+v, want unnest(...)", tf.Call)
+	}
+	if len(tf.Call.Args) != 1 {
+		t.Errorf("call args = %d, want 1 (t.arr)", len(tf.Call.Args))
+	}
+}
+
+// TestTableFunctionColumnAliases covers the AS u(col) column-alias list form.
+func TestTableFunctionColumnAliases(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM t, unnest(t.arr) AS u(elem)")
+	tf := stmt.From[1].(*ast.TableFunctionRef)
+	if got := tf.ColumnAliases; len(got) != 1 || got[0] != "elem" {
+		t.Errorf("columnAliases = %v, want [elem]", got)
+	}
+}
+
+// TestLateralUnnestComma covers LATERAL in the comma relation list.
+func TestLateralUnnestComma(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT t.id, u.unnest FROM t, LATERAL unnest(t.arr) AS u")
+	if len(stmt.From) != 2 {
+		t.Fatalf("from = %d, want 2", len(stmt.From))
+	}
+	tf, ok := stmt.From[1].(*ast.TableFunctionRef)
+	if !ok {
+		t.Fatalf("from[1] = %T, want *ast.TableFunctionRef", stmt.From[1])
+	}
+	if !tf.Lateral {
+		t.Error("Lateral = false, want true")
+	}
+}
+
+// TestLateralUnnestInParenList covers LATERAL after a comma inside a
+// parenthesized relation list: (t, LATERAL unnest(t.arr) AS u). The comma list
+// folds into a cross JoinClause whose right side is the lateral table function.
+func TestLateralUnnestInParenList(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM (t, LATERAL unnest(t.arr) AS u)")
+	if len(stmt.From) != 1 {
+		t.Fatalf("from = %d, want 1", len(stmt.From))
+	}
+	join, ok := stmt.From[0].(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("from[0] = %T, want *ast.JoinClause", stmt.From[0])
+	}
+	tf, ok := join.Right.(*ast.TableFunctionRef)
+	if !ok {
+		t.Fatalf("join.Right = %T, want *ast.TableFunctionRef", join.Right)
+	}
+	if !tf.Lateral {
+		t.Error("Lateral = false, want true")
+	}
+}
+
+// TestLateralUnnestJoin covers LATERAL on the right side of a JOIN.
+func TestLateralUnnestJoin(t *testing.T) {
+	join := mustParseJoin(t, "SELECT * FROM t INNER JOIN LATERAL unnest(t.tags) AS g ON TRUE")
+	if join.Type != ast.JoinInner {
+		t.Errorf("join.Type = %v, want JoinInner", join.Type)
+	}
+	tf, ok := join.Right.(*ast.TableFunctionRef)
+	if !ok {
+		t.Fatalf("join.Right = %T, want *ast.TableFunctionRef", join.Right)
+	}
+	if !tf.Lateral {
+		t.Error("Lateral = false, want true")
+	}
+	if tf.Alias != "g" {
+		t.Errorf("alias = %q, want g", tf.Alias)
+	}
+}

--- a/starrocks/parser/pr4a_oracle_test.go
+++ b/starrocks/parser/pr4a_oracle_test.go
@@ -72,6 +72,81 @@ func TestPR4aParity(t *testing.T) {
 			"VALUES (1,'a'),(2,'b')",
 			false,
 		},
+
+		// LATERAL + table function (unnest) — accept probes.
+		{
+			"lateral_unnest_comma",
+			"SELECT t.id, u.unnest FROM t, LATERAL unnest(t.arr) AS u",
+			true,
+		},
+		{
+			"lateral_unnest_join_inner",
+			"SELECT * FROM t INNER JOIN LATERAL unnest(t.tags) AS g ON TRUE",
+			true,
+		},
+		{
+			"lateral_unnest_join_left",
+			"SELECT * FROM t LEFT JOIN LATERAL unnest(t.arr) AS u ON TRUE",
+			true,
+		},
+		{
+			"lateral_unnest_cross",
+			"SELECT * FROM t CROSS JOIN LATERAL unnest(t.arr) AS u",
+			true,
+		},
+		{
+			"lateral_unnest_multi_arg",
+			"SELECT * FROM t, LATERAL unnest(t.arr, t.tags) AS u",
+			true,
+		},
+		{
+			"lateral_unnest_col_alias",
+			"SELECT * FROM t, LATERAL unnest(t.arr) AS u(col)",
+			true,
+		},
+		{
+			"lateral_unnest_no_as",
+			"SELECT * FROM t, LATERAL unnest(t.arr) u",
+			true,
+		},
+		{
+			"lateral_subquery", // LATERAL applies to any relation primary, not just functions
+			"SELECT * FROM t, LATERAL (SELECT 1) x",
+			true,
+		},
+		{
+			"table_function_no_lateral", // unnest without LATERAL still parses (semantic-only error)
+			"SELECT * FROM t, unnest(t.arr) AS u",
+			true,
+		},
+		{
+			"lateral_unnest_chained",
+			"SELECT * FROM t, LATERAL unnest(t.arr) AS u, LATERAL unnest(t.tags) AS v",
+			true,
+		},
+		{
+			"lateral_unnest_in_paren_list", // LATERAL after a comma inside ( relations )
+			"SELECT * FROM (t, LATERAL unnest(t.arr) AS u)",
+			true,
+		},
+		{
+			"lateral_no_source", // LATERAL with nothing after it fails inside the construct
+			"SELECT * FROM t, LATERAL",
+			false,
+		},
+		// Known accepted divergences (omni over-accepts vs StarRocks 3.4), left
+		// as-is per the skip-prune policy — no Bytebase consumer needs StarRocks
+		// rejection, and forcing them would regress shared behaviour:
+		//   - unnest() (zero-arg): StarRocks syntax-rejects, but omni must keep
+		//     parsing zero-arg table functions like FRONTENDS()/BACKENDS() that
+		//     the inherited corpus relies on.
+		//   - unnest(t.arr) WITH ORDINALITY ...: StarRocks rejects WITH ORDINALITY;
+		//     omni tolerates the trailing tokens (no end-of-input enforcement, a
+		//     parser-wide property out of scope for PR4).
+		// Unimplemented adjacent relation-primary arms (StarRocks parse-accepts,
+		// omni rejects — deferred, not covered by PR4a): #normalizedTableFunction
+		// TABLE(func(args)) and the #tableAtom decorators (PIVOT, queryPeriod,
+		// tabletList). The #fileTableFunction FILES(...) form is already handled.
 	}
 
 	for _, tc := range cases {

--- a/starrocks/parser/pr4a_oracle_test.go
+++ b/starrocks/parser/pr4a_oracle_test.go
@@ -1,0 +1,82 @@
+package parser
+
+import "testing"
+
+// TestPR4aParity is the container-grounded conformance matrix for the PR4a
+// FROM-side query features: the VALUES inline-table constructor and (added in
+// the LATERAL task) LATERAL table functions. Each StarRocks construct is
+// asserted accepted by BOTH the omni parser and StarRocks 3.4, and each
+// sibling-arm negative rejected by both. Short-gated via startStarRocks.
+//
+// Reject probes are chosen so the failure occurs INSIDE the construct: the omni
+// parser does not enforce trailing-EOF, so trailing-garbage rejects (e.g. a
+// column-alias list with no alias name) would be false-accepted and are
+// deliberately omitted.
+func TestPR4aParity(t *testing.T) {
+	c := startStarRocks(t)
+
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		// VALUES inline-table — accept probes.
+		{
+			"values_alias_collist",
+			"SELECT * FROM (VALUES (1,'a'),(2,'b')) AS v(id,name)",
+			true,
+		},
+		{
+			"values_alias_no_collist",
+			"SELECT * FROM (VALUES (1,'a'),(2,'b')) v",
+			true,
+		},
+		{
+			"values_no_alias",
+			"SELECT * FROM (VALUES (1,'a'),(2,'b'))",
+			true,
+		},
+		{
+			"values_single_column",
+			"SELECT id FROM (VALUES (1),(2),(3)) AS v(id)",
+			true,
+		},
+		{
+			"values_row_expressions",
+			"SELECT * FROM (VALUES (1+1, concat('a','b'))) AS v(x,y)",
+			true,
+		},
+		{
+			"values_joined",
+			"SELECT * FROM t JOIN (VALUES (1),(2)) AS v(id) ON t.id = v.id",
+			true,
+		},
+		// VALUES inline-table — sibling-arm negatives (fail inside the construct).
+		{
+			"values_default_in_row", // DEFAULT is INSERT-only, not a FROM-VALUES expr
+			"SELECT * FROM (VALUES (1, DEFAULT)) AS v(a,b)",
+			false,
+		},
+		{
+			"values_empty", // at least one row constructor is required
+			"SELECT * FROM (VALUES) AS v",
+			false,
+		},
+		{
+			"values_missing_parens", // the wrapping parens are mandatory
+			"SELECT * FROM VALUES (1),(2)",
+			false,
+		},
+		{
+			"values_bare_toplevel", // VALUES is not a top-level statement in StarRocks
+			"VALUES (1,'a'),(2,'b')",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -467,7 +467,9 @@ func (p *Parser) parseFromClause() ([]ast.Node, error) {
 
 	for p.cur.Kind == int(',') {
 		p.advance() // consume ','
-		item, err = p.parseFromItem()
+		// A comma-joined relation may carry a LATERAL prefix (relation list:
+		// relation (',' LATERAL? relation)*); the join chain attaches after it.
+		item, err = p.parseCommaRelation()
 		if err != nil {
 			return nil, err
 		}
@@ -489,8 +491,8 @@ func (p *Parser) parseFromItem() (ast.Node, error) {
 
 // parsePrimarySource dispatches on the current token to parse a single
 // FROM source:
-//   - ( → subquery or parenthesized from-item
-//   - otherwise → parseTableRef (ObjectName + alias)
+//   - ( → VALUES inline-table, subquery, or parenthesized from-item
+//   - otherwise → a table reference or a table function (ObjectName + alias)
 func (p *Parser) parsePrimarySource() (ast.Node, error) {
 	startLoc := p.cur.Loc
 
@@ -529,10 +531,11 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Implicit cross-join: comma-separated table list inside parens.
+		// Implicit cross-join: comma-separated table list inside parens. Each
+		// continuation may carry a LATERAL prefix, just like the top-level list.
 		for p.cur.Kind == int(',') {
 			p.advance() // consume ','
-			right, err := p.parseFromItem()
+			right, err := p.parseCommaRelation()
 			if err != nil {
 				return nil, err
 			}
@@ -549,29 +552,102 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 		return inner, nil
 	}
 
-	// Default: simple table reference (ObjectName + alias)
-	return p.parseTableRef()
+	// Default: a table reference or a table function.
+	return p.parseTableOrFunction()
 }
 
-// parseTableRef parses one simple table reference: object_name [AS alias].
-func (p *Parser) parseTableRef() (*ast.TableRef, error) {
+// parseLateralPrimary parses an optional LATERAL prefix followed by a relation
+// primary. LATERAL marks the relation as able to reference columns from the
+// preceding FROM items; StarRocks allows it before any relation primary, most
+// commonly a table function (unnest). It is valid only after a comma or a JOIN
+// keyword — never on the first FROM item — so it is consumed here rather than
+// in parsePrimarySource.
+func (p *Parser) parseLateralPrimary() (ast.Node, error) {
+	lateral := false
+	lateralStart := 0
+	if p.cur.Kind == kwLATERAL {
+		lateralStart = p.cur.Loc.Start
+		p.advance() // consume LATERAL
+		lateral = true
+	}
+	src, err := p.parsePrimarySource()
+	if err != nil {
+		return nil, err
+	}
+	if lateral {
+		if tf, ok := src.(*ast.TableFunctionRef); ok {
+			tf.Lateral = true
+			tf.Loc.Start = lateralStart // include the LATERAL keyword in the span
+		}
+	}
+	return src, nil
+}
+
+// parseCommaRelation parses a relation following a comma in a FROM list: an
+// optional LATERAL prefix, a primary source, then its join chain. Shared by the
+// top-level FROM list and the parenthesized relation list so the two paths
+// cannot drift on LATERAL handling.
+func (p *Parser) parseCommaRelation() (ast.Node, error) {
+	primary, err := p.parseLateralPrimary()
+	if err != nil {
+		return nil, err
+	}
+	return p.parseJoinChain(primary)
+}
+
+// parseTableOrFunction parses a FROM relation primary that is either a plain
+// table reference (object_name [AS alias]) or a table function
+// (func(args) [AS? alias [(cols)]], e.g. unnest(t.arr) AS u).
+func (p *Parser) parseTableOrFunction() (ast.Node, error) {
 	name, err := p.parseMultipartIdentifier()
 	if err != nil {
 		return nil, err
+	}
+
+	// Table function: the name is immediately followed by an argument list.
+	if p.cur.Kind == int('(') {
+		return p.parseTableFunction(name)
 	}
 
 	ref := &ast.TableRef{
 		Name: name,
 		Loc:  ast.Loc{Start: name.Loc.Start},
 	}
-
-	alias := p.parseOptionalAlias()
-	if alias != "" {
+	if alias := p.parseOptionalAlias(); alias != "" {
 		ref.Alias = alias
 	}
-
 	ref.Loc.End = p.prev.Loc.End
 	return ref, nil
+}
+
+// parseTableFunction parses a table-function relation primary:
+//
+//	func '(' args ')' [AS? alias [(col, ...)]]
+//
+// The multipart name has been parsed; the current token is '('. It reuses
+// parseFuncCall so the argument expressions are captured as a FuncCallExpr and
+// stay walkable for lineage.
+func (p *Parser) parseTableFunction(name *ast.ObjectName) (ast.Node, error) {
+	call, err := p.parseFuncCall(name)
+	if err != nil {
+		return nil, err
+	}
+	tf := &ast.TableFunctionRef{
+		Call: call,
+		Loc:  ast.Loc{Start: name.Loc.Start},
+	}
+	if alias := p.parseOptionalAlias(); alias != "" {
+		tf.Alias = alias
+		if p.cur.Kind == int('(') {
+			cols, err := p.parseColumnAliasList()
+			if err != nil {
+				return nil, err
+			}
+			tf.ColumnAliases = cols
+		}
+	}
+	tf.Loc.End = p.prev.Loc.End
+	return tf, nil
 }
 
 // parseInlineTable parses a VALUES table constructor in FROM position:
@@ -710,7 +786,9 @@ func (p *Parser) parseJoinChain(left ast.Node) (ast.Node, error) {
 		// Skip optional Doris execution hints: [shuffle], [broadcast], etc.
 		hints := p.parseJoinHints()
 
-		right, err := p.parsePrimarySource()
+		// The right-hand relation may carry a LATERAL prefix
+		// (joinRelation: ... LATERAL? rightRelation).
+		right, err := p.parseLateralPrimary()
 		if err != nil {
 			return nil, err
 		}

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -497,6 +497,10 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 	// Parenthesized: subquery
 	if p.cur.Kind == int('(') {
 		next := p.peekNext()
+		if next.Kind == kwVALUES {
+			// VALUES table constructor: (VALUES (..), (..)) [AS alias [(cols)]]
+			return p.parseInlineTable(startLoc.Start)
+		}
 		if next.Kind == kwSELECT || next.Kind == kwWITH {
 			// Subquery in FROM: (SELECT ...) [AS] alias
 			openTok := p.advance() // consume '('
@@ -568,6 +572,126 @@ func (p *Parser) parseTableRef() (*ast.TableRef, error) {
 
 	ref.Loc.End = p.prev.Loc.End
 	return ref, nil
+}
+
+// parseInlineTable parses a VALUES table constructor in FROM position:
+//
+//	'(' VALUES rowConstructor (',' rowConstructor)* ')' [AS? alias [(col, ...)]]
+//
+// The leading '(' has not yet been consumed. StarRocks requires the wrapping
+// parens; the alias and the column-alias list are both optional.
+func (p *Parser) parseInlineTable(start int) (ast.Node, error) {
+	p.advance() // consume '('
+	p.advance() // consume VALUES
+
+	rows, err := p.parseValuesRows()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	tbl := &ast.InlineTable{
+		Rows: rows,
+		Loc:  ast.Loc{Start: start},
+	}
+
+	// Optional alias, then an optional column-alias list (requires the alias).
+	alias := p.parseOptionalAlias()
+	if alias != "" {
+		tbl.Alias = alias
+		if p.cur.Kind == int('(') {
+			cols, err := p.parseColumnAliasList()
+			if err != nil {
+				return nil, err
+			}
+			tbl.ColumnAliases = cols
+		}
+	}
+
+	tbl.Loc.End = p.prev.Loc.End
+	return tbl, nil
+}
+
+// parseValuesRows parses the rowConstructor list of a VALUES table constructor:
+//
+//	rowConstructor (',' rowConstructor)*
+//
+// Unlike INSERT ... VALUES, FROM-position rows use plain expressions (DEFAULT
+// is INSERT-only). The VALUES keyword has already been consumed.
+func (p *Parser) parseValuesRows() ([][]ast.Node, error) {
+	row, err := p.parseValuesRow()
+	if err != nil {
+		return nil, err
+	}
+	rows := [][]ast.Node{row}
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		row, err = p.parseValuesRow()
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// parseValuesRow parses one row constructor: '(' expr [, expr]* ')'.
+func (p *Parser) parseValuesRow() ([]ast.Node, error) {
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	exprs := []ast.Node{expr}
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		expr, err = p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return exprs, nil
+}
+
+// parseColumnAliasList parses a parenthesized column-alias list:
+//
+//	'(' identifier (',' identifier)* ')'
+//
+// The leading '(' has not yet been consumed.
+func (p *Parser) parseColumnAliasList() ([]string, error) {
+	p.advance() // consume '('
+
+	name, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	cols := []string{name}
+
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		name, _, err = p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, name)
+	}
+
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+	return cols, nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
PR4a of the StarRocks query-features epic (BYT-9140). The two highest-value FROM-clause features that feed **query-span lineage** through the now-routed `omni/starrocks` fork. Both are oracle-pinned against live StarRocks 3.4; the deliverable is lineage, not just parse-accept.

## Features

**VALUES inline-table** — `(VALUES (…),(…)) [AS v(cols)]` (StarRocks `#inlineTable`)
- New `ast.InlineTable` (`Rows`/`Alias`/`ColumnAliases`).
- Dispatched on `(VALUES` in `parsePrimarySource` before the subquery arm; rows use plain expressions (`DEFAULT` is INSERT-only and rejected).
- Query-span treats it as a literal-derived relation: **no phantom `AccessTable`**, but a subquery embedded in a row still contributes its physical tables.

**LATERAL + table function** — `unnest(t.arr) AS u`, `[…JOIN] LATERAL …` (StarRocks `#tableFunction` + the optional `LATERAL` prefix)
- New `ast.TableFunctionRef` (the call reuses `FuncCallExpr`, so the args stay walkable for lineage).
- Fixes a **pre-existing bug**: a `name(args)` relation in FROM (e.g. `unnest(t.arr) AS u`) used to misparse to `TableRef{unnest}` and silently drop the args — losing the unnested source column from lineage.
- `LATERAL` is consumed via a shared `parseCommaRelation` helper used by the top-level FROM list, the parenthesized relation list, and the join chain, so the paths can't drift. It is rejected on the first FROM item, per the grammar.

`LATERAL`/`unnest` need **no new keywords** — `unnest` is a generic function identifier and StarRocks has no `UNNEST` keyword or `WITH ORDINALITY`.

## New-node checklist
Both new nodes are registered in `nodetags.go` (const + `String()`), `walk_children.go`, `loc.go`, and `analysis/query_span.go` `visitFromItem` (the walk/analysis layer has no default arm — a missing case silently yields wrong lineage).

## Testing
- Unit parser tests + `analysis/query_span` lineage tests (no phantom tables; row/arg subqueries contribute their tables).
- `TestPR4aParity` (`testing.Short()`-gated): **22 cases** — accepts + sibling-arm rejects — all agree with live StarRocks 3.4 (classified by the `"Getting syntax error"` message, not code 1064).
- Full inherited suite green (no regression); `go vet` clean (only the 2 pre-existing warnings).

## Documented divergences / deferrals
- VALUES `SELECT *` → declared-column expansion (needs a general FROM column scope) — deferred; MVP surfaces no phantom table + walks row subqueries.
- Zero-arg `unnest()` over-accept — can't reject without breaking zero-arg table functions like `FRONTENDS()` in the inherited corpus.
- `WITH ORDINALITY` trailing tokens tolerated (omni doesn't enforce end-of-input — parser-wide, out of scope).
- `TABLE(func())` `#normalizedTableFunction` / PIVOT relation arms — not implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)