### PR TITLE
feat(starrocks/parser): expr-side query features — IGNORE NULLS, binary literals, map/array literals (PR4b)

### DIFF
--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -412,6 +412,28 @@ func TestGetQuerySpan_BinaryOperator(t *testing.T) {
 	}
 }
 
+func TestGetQuerySpan_CollectionLiteral(t *testing.T) {
+	// Column refs inside a map/array literal's value expressions must flow to the
+	// output column's SourceColumns (a literal key contributes nothing).
+	span, err := GetQuerySpan("SELECT map<varchar,int>{'x':a_col} AS m, array<int>[b_col, c_col] AS arr FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if !containsSig(toSigs(span.AccessTables), tableSig{Table: "t"}) {
+		t.Errorf("AccessTables = %+v, want t", span.AccessTables)
+	}
+	if len(span.Results) != 2 {
+		t.Fatalf("Results len = %d, want 2 (%+v)", len(span.Results), span.Results)
+	}
+	if got := span.Results[0].SourceColumns; len(got) != 1 || got[0].Column != "a_col" {
+		t.Errorf("map literal SourceColumns = %+v, want [a_col]", got)
+	}
+	gotArr := span.Results[1].SourceColumns
+	if len(gotArr) != 2 || gotArr[0].Column != "b_col" || gotArr[1].Column != "c_col" {
+		t.Errorf("array literal SourceColumns = %+v, want [b_col c_col]", gotArr)
+	}
+}
+
 func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
 	// Even if a physical table exists elsewhere named "real_t", a CTE with
 	// the same name inside the WITH clause means the outer reference resolves

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -391,6 +391,27 @@ func TestGetQuerySpan_LateralInParenList(t *testing.T) {
 	}
 }
 
+func TestGetQuerySpan_BinaryOperator(t *testing.T) {
+	// BINARY is a unary cast operator: the inner column must flow to lineage, a
+	// hex/bit literal contributes no source column.
+	span, err := GetQuerySpan("SELECT BINARY col1 AS c, X'4142' AS h FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if !containsSig(toSigs(span.AccessTables), tableSig{Table: "t"}) {
+		t.Errorf("AccessTables = %+v, want t", span.AccessTables)
+	}
+	if len(span.Results) != 2 {
+		t.Fatalf("Results len = %d, want 2 (%+v)", len(span.Results), span.Results)
+	}
+	if got := span.Results[0].SourceColumns; len(got) != 1 || got[0].Column != "col1" {
+		t.Errorf("Results[0].SourceColumns = %+v, want [col1]", got)
+	}
+	if got := span.Results[1].SourceColumns; len(got) != 0 {
+		t.Errorf("Results[1].SourceColumns = %+v, want empty (hex literal)", got)
+	}
+}
+
 func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
 	// Even if a physical table exists elsewhere named "real_t", a CTE with
 	// the same name inside the WITH clause means the outer reference resolves

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -233,6 +233,7 @@ type FuncCallExpr struct {
 	Star     bool   // COUNT(*)
 	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
 	Separator string // optional SEPARATOR value for GROUP_CONCAT
+	IgnoreNulls bool // IGNORE NULLS null-treatment (FIRST_VALUE/LAST_VALUE/LEAD/LAG)
 	Over     *WindowSpec // optional OVER (...) window specification
 	Loc      Loc
 }

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -98,6 +98,7 @@ const (
 	UnaryPlus                   // +
 	UnaryBitNot                 // ~
 	UnaryNot                    // NOT
+	UnaryBinary                 // BINARY (cast-to-binary operator)
 )
 
 // String returns the SQL text form of the unary operator.
@@ -111,6 +112,8 @@ func (op UnaryOp) String() string {
 		return "~"
 	case UnaryNot:
 		return "NOT"
+	case UnaryBinary:
+		return "BINARY"
 	default:
 		return "?"
 	}
@@ -126,6 +129,8 @@ const (
 	LitBool                   // TRUE or FALSE
 	LitNull                   // NULL
 	LitKeyword                // keyword used as literal value, e.g. DEFAULT
+	LitHex                    // hex-string literal, e.g. X'4142'
+	LitBit                    // bit-string literal, e.g. B'101'
 )
 
 // CaseKind classifies a CASE expression as simple or searched.

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -348,6 +348,51 @@ func (n *Literal) Tag() NodeTag { return T_Literal }
 
 var _ Node = (*Literal)(nil)
 
+// MapLiteral represents a map constructor literal:
+//
+//	map<k,v>{ key:val, ... }   (typed)
+//	MAP{ key:val, ... }        (untyped)
+//
+// MapType holds the map<k,v> type for the typed form and is nil for the
+// untyped MAP{...} form. The entries may be empty.
+type MapLiteral struct {
+	MapType *TypeName // map<k,v> type for the typed form; nil for MAP{...}
+	Entries []*MapEntry
+	Loc     Loc
+}
+
+func (n *MapLiteral) Tag() NodeTag { return T_MapLiteral }
+
+var _ Node = (*MapLiteral)(nil)
+
+// MapEntry is one key:value pair inside a MapLiteral.
+type MapEntry struct {
+	Key   Node
+	Value Node
+	Loc   Loc
+}
+
+func (n *MapEntry) Tag() NodeTag { return T_MapEntry }
+
+var _ Node = (*MapEntry)(nil)
+
+// ArrayLiteral represents an array constructor literal:
+//
+//	array<t>[ e, ... ]   (typed)
+//	[ e, ... ]           (untyped)
+//
+// ElemType holds the array<t> element type for the typed form and is nil for
+// the untyped [...] form. The elements may be empty.
+type ArrayLiteral struct {
+	ElemType *TypeName // array<t> element type for the typed form; nil for [...]
+	Elements []Node
+	Loc      Loc
+}
+
+func (n *ArrayLiteral) Tag() NodeTag { return T_ArrayLiteral }
+
+var _ Node = (*ArrayLiteral)(nil)
+
 // ParenExpr represents a parenthesized expression: (expr).
 type ParenExpr struct {
 	Expr Node

--- a/starrocks/ast/loc.go
+++ b/starrocks/ast/loc.go
@@ -64,6 +64,12 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *Literal:
 		return v.Loc
+	case *MapLiteral:
+		return v.Loc
+	case *MapEntry:
+		return v.Loc
+	case *ArrayLiteral:
+		return v.Loc
 	case *ParenExpr:
 		return v.Loc
 	case *ExistsExpr:

--- a/starrocks/ast/nodetags.go
+++ b/starrocks/ast/nodetags.go
@@ -101,6 +101,15 @@ const (
 	// T_Literal is the tag for *Literal (numeric, string, boolean, NULL).
 	T_Literal
 
+	// T_MapLiteral is the tag for *MapLiteral (map<k,v>{...} / MAP{...}).
+	T_MapLiteral
+
+	// T_MapEntry is the tag for *MapEntry (one key:value pair in a MapLiteral).
+	T_MapEntry
+
+	// T_ArrayLiteral is the tag for *ArrayLiteral (array<t>[...] / [...]).
+	T_ArrayLiteral
+
 	// T_ParenExpr is the tag for *ParenExpr ((expr)).
 	T_ParenExpr
 
@@ -666,6 +675,12 @@ func (t NodeTag) String() string {
 		return "ColumnRef"
 	case T_Literal:
 		return "Literal"
+	case T_MapLiteral:
+		return "MapLiteral"
+	case T_MapEntry:
+		return "MapEntry"
+	case T_ArrayLiteral:
+		return "ArrayLiteral"
 	case T_ParenExpr:
 		return "ParenExpr"
 	case T_ExistsExpr:

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -122,6 +122,21 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Name)
 	case *Literal:
 		// leaf node, no children
+	case *MapLiteral:
+		if n.MapType != nil {
+			Walk(v, n.MapType)
+		}
+		for _, e := range n.Entries {
+			Walk(v, e)
+		}
+	case *MapEntry:
+		Walk(v, n.Key)
+		Walk(v, n.Value)
+	case *ArrayLiteral:
+		if n.ElemType != nil {
+			Walk(v, n.ElemType)
+		}
+		walkNodes(v, n.Elements)
 	case *ParenExpr:
 		Walk(v, n.Expr)
 	case *ExistsExpr:

--- a/starrocks/parser/binary_literal_test.go
+++ b/starrocks/parser/binary_literal_test.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+// Binary/hex literals (X'..', B'..') and the BINARY unary operator.
+
+func TestHexLiteral(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT X'4142' FROM t")
+	lit, ok := stmt.Items[0].Expr.(*ast.Literal)
+	if !ok {
+		t.Fatalf("item expr = %T, want *ast.Literal", stmt.Items[0].Expr)
+	}
+	if lit.Kind != ast.LitHex {
+		t.Errorf("Kind = %v, want LitHex", lit.Kind)
+	}
+}
+
+func TestBitLiteral(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT B'101' FROM t")
+	lit, ok := stmt.Items[0].Expr.(*ast.Literal)
+	if !ok {
+		t.Fatalf("item expr = %T, want *ast.Literal", stmt.Items[0].Expr)
+	}
+	if lit.Kind != ast.LitBit {
+		t.Errorf("Kind = %v, want LitBit", lit.Kind)
+	}
+}
+
+func TestBinaryOperator(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT BINARY col1 FROM t")
+	un, ok := stmt.Items[0].Expr.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("item expr = %T, want *ast.UnaryExpr", stmt.Items[0].Expr)
+	}
+	if un.Op != ast.UnaryBinary {
+		t.Errorf("Op = %v, want UnaryBinary", un.Op)
+	}
+	if _, ok := un.Expr.(*ast.ColumnRef); !ok {
+		t.Errorf("operand = %T, want *ast.ColumnRef", un.Expr)
+	}
+}
+
+// TestBinaryOperatorInWhere confirms BINARY binds at the lowest precedence:
+// BINARY name = 'abc' parses as BINARY(name = 'abc').
+func TestBinaryOperatorInWhere(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM t WHERE BINARY name = 'abc'")
+	un, ok := stmt.Where.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("where = %T, want *ast.UnaryExpr", stmt.Where)
+	}
+	if un.Op != ast.UnaryBinary {
+		t.Errorf("Op = %v, want UnaryBinary", un.Op)
+	}
+	if _, ok := un.Expr.(*ast.BinaryExpr); !ok {
+		t.Errorf("operand = %T, want *ast.BinaryExpr (name = 'abc')", un.Expr)
+	}
+}
+
+// TestHexInteger confirms the already-supported 0x form still parses.
+func TestHexInteger(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT 0x4142 FROM t")
+}

--- a/starrocks/parser/collection_literal_test.go
+++ b/starrocks/parser/collection_literal_test.go
@@ -1,0 +1,114 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+func firstItemExpr(t *testing.T, input string) ast.Node {
+	t.Helper()
+	return mustParseSelect(t, input).Items[0].Expr
+}
+
+// TestMapLiteralTyped asserts the typed map produces a MapLiteral carrying the
+// map<k,v> type and its entries.
+func TestMapLiteralTyped(t *testing.T) {
+	ml, ok := firstItemExpr(t, "SELECT map<varchar,int>{'x':1,'y':2} FROM t").(*ast.MapLiteral)
+	if !ok {
+		t.Fatalf("expr = %T, want *ast.MapLiteral", firstItemExpr(t, "SELECT map<varchar,int>{'x':1} FROM t"))
+	}
+	if ml.MapType == nil {
+		t.Error("MapType = nil, want the map<varchar,int> type")
+	}
+	if len(ml.Entries) != 2 {
+		t.Errorf("entries = %d, want 2", len(ml.Entries))
+	}
+}
+
+// TestMapLiteralUntyped asserts MAP{...} produces a MapLiteral with no type
+// (without the feature it silently mis-parses to a bare ColumnRef).
+func TestMapLiteralUntyped(t *testing.T) {
+	ml, ok := firstItemExpr(t, "SELECT MAP{'x':1} FROM t").(*ast.MapLiteral)
+	if !ok {
+		t.Fatalf("expr = %T, want *ast.MapLiteral", firstItemExpr(t, "SELECT MAP{'x':1} FROM t"))
+	}
+	if ml.MapType != nil {
+		t.Error("MapType != nil, want nil for the untyped MAP{...} form")
+	}
+	if len(ml.Entries) != 1 {
+		t.Errorf("entries = %d, want 1", len(ml.Entries))
+	}
+}
+
+func TestMapLiteralEmpty(t *testing.T) {
+	ml := firstItemExpr(t, "SELECT map<int,int>{} FROM t").(*ast.MapLiteral)
+	if len(ml.Entries) != 0 {
+		t.Errorf("entries = %d, want 0", len(ml.Entries))
+	}
+}
+
+func TestArrayLiteralTyped(t *testing.T) {
+	al, ok := firstItemExpr(t, "SELECT array<int>[1,2,3] FROM t").(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("expr = %T, want *ast.ArrayLiteral", firstItemExpr(t, "SELECT array<int>[1,2,3] FROM t"))
+	}
+	if al.ElemType == nil {
+		t.Error("ElemType = nil, want the array<int> type")
+	}
+	if len(al.Elements) != 3 {
+		t.Errorf("elements = %d, want 3", len(al.Elements))
+	}
+}
+
+func TestArrayLiteralUntyped(t *testing.T) {
+	al, ok := firstItemExpr(t, "SELECT [1,2,3] FROM t").(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("expr = %T, want *ast.ArrayLiteral", firstItemExpr(t, "SELECT [1,2,3] FROM t"))
+	}
+	if al.ElemType != nil {
+		t.Error("ElemType != nil, want nil for the untyped [...] form")
+	}
+	if len(al.Elements) != 3 {
+		t.Errorf("elements = %d, want 3", len(al.Elements))
+	}
+}
+
+// Map and array collection literals: map<k,v>{..}, MAP{..}, array<t>[..], [..].
+
+func TestMapLiteralTypedParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT map<varchar,int>{'x':1} FROM t")
+}
+
+func TestMapLiteralMultiEntryParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT map<varchar,int>{'x':1,'y':2} FROM t")
+}
+
+func TestMapLiteralUntypedParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT MAP{'x':1} FROM t")
+}
+
+func TestMapLiteralEmptyParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT map<int,int>{} FROM t")
+}
+
+func TestArrayLiteralTypedParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT array<int>[1,2,3] FROM t")
+}
+
+func TestArrayLiteralEmptyParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT array<int>[] FROM t")
+}
+
+func TestArrayLiteralUntypedParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT [1,2,3] FROM t")
+}
+
+func TestMapLiteralNestedParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT map<varchar,array<int>>{'x':[1,2]} FROM t")
+}
+
+// Regression: map/array used as ordinary identifiers must still parse.
+func TestMapAsIdentifierParses(t *testing.T) {
+	_ = mustParseSelect(t, "SELECT map FROM t")
+}

--- a/starrocks/parser/collection_literal_test.go
+++ b/starrocks/parser/collection_literal_test.go
@@ -112,3 +112,27 @@ func TestMapLiteralNestedParses(t *testing.T) {
 func TestMapAsIdentifierParses(t *testing.T) {
 	_ = mustParseSelect(t, "SELECT map FROM t")
 }
+
+// TestMapColumnLessThan guards against the map-literal dispatch over-committing:
+// `map` is a non-reserved keyword usable as a column, so `map < 5` is a
+// comparison, not a map<...> type. (Single-token peek cannot tell them apart;
+// the dispatch must backtrack when no '{' follows the angle brackets.)
+func TestMapColumnLessThan(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT cnt FROM t WHERE map < 5")
+	be, ok := stmt.Where.(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("where = %T, want *ast.BinaryExpr (map < 5)", stmt.Where)
+	}
+	if _, ok := be.Left.(*ast.ColumnRef); !ok {
+		t.Errorf("where.Left = %T, want *ast.ColumnRef (map)", be.Left)
+	}
+}
+
+// TestArrayColumnLessThan is the same guard for `array` (also non-reserved in
+// omni), where `array < 5` must parse as a comparison, not array<...>.
+func TestArrayColumnLessThan(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT cnt FROM t WHERE array < 5")
+	if _, ok := stmt.Where.(*ast.BinaryExpr); !ok {
+		t.Fatalf("where = %T, want *ast.BinaryExpr (array < 5)", stmt.Where)
+	}
+}

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -447,6 +447,21 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 		}
 		fc.Args = args
 
+		// Optional IGNORE NULLS after the first argument (window null-treatment,
+		// e.g. FIRST_VALUE(v IGNORE NULLS), LAG(v IGNORE NULLS, 1)). The grammar
+		// attaches it after the first expression, so further args may follow.
+		if p.consumeIgnoreNulls() {
+			fc.IgnoreNulls = true
+			for p.cur.Kind == int(',') {
+				p.advance() // consume ','
+				arg, err := p.parseExpr()
+				if err != nil {
+					return nil, err
+				}
+				fc.Args = append(fc.Args, arg)
+			}
+		}
+
 		// Optional ORDER BY within aggregate functions (e.g., GROUP_CONCAT)
 		if p.cur.Kind == kwORDER {
 			p.advance() // consume ORDER
@@ -479,6 +494,13 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 	}
 	fc.Loc.End = closeTok.Loc.End
 
+	// Optional IGNORE NULLS after the closing paren, e.g.
+	// LEAD(v, 1) IGNORE NULLS OVER (...).
+	if !fc.IgnoreNulls && p.consumeIgnoreNulls() {
+		fc.IgnoreNulls = true
+		fc.Loc.End = p.prev.Loc.End
+	}
+
 	// Optional OVER (...) window specification — turns this call into a window
 	// function. Without consuming OVER here it is left dangling, which breaks
 	// parsing wherever a specific following token is expected (e.g. the ')'
@@ -493,6 +515,18 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 	}
 
 	return fc, nil
+}
+
+// consumeIgnoreNulls consumes an optional IGNORE NULLS null-treatment clause and
+// reports whether it was present. (RESPECT NULLS is the default and does not
+// exist as a keyword in StarRocks 3.4.)
+func (p *Parser) consumeIgnoreNulls() bool {
+	if p.cur.Kind == kwIGNORE && p.peekNext().Kind == kwNULLS {
+		p.advance() // consume IGNORE
+		p.advance() // consume NULLS
+		return true
+	}
+	return false
 }
 
 // parseWindowSpec parses an OVER clause window specification. The OVER keyword

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -256,12 +256,13 @@ func (p *Parser) parsePrefixExpr() (ast.Node, error) {
 		}, nil
 
 	case kwBINARY:
-		// BINARY <expr> cast-to-binary operator. StarRocks places it at the top
-		// of the expression rule (lowest precedence), so the operand spans the
-		// whole following boolean expression: BINARY name = 'abc' => BINARY(name = 'abc').
+		// BINARY <expr> cast-to-binary operator. StarRocks's grammar is
+		// `(BINARY)? booleanExpression`, so the operand is a booleanExpression —
+		// it spans comparisons/predicates but stops below AND/OR/NOT:
+		// BINARY name = 'abc' => BINARY(name = 'abc'); BINARY a AND b => (BINARY a) AND b.
 		start := p.cur.Loc
 		p.advance()
-		operand, err := p.parseExprPrec(bpNone + 1)
+		operand, err := p.parseExprPrec(bpNot + 1)
 		if err != nil {
 			return nil, err
 		}
@@ -377,25 +378,44 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 
 	case kwMAP:
 		// map<k,v>{...} (typed) or MAP{...} (untyped) map constructor; otherwise
-		// MAP is an ordinary identifier/function.
+		// MAP is an ordinary identifier (it is a non-reserved keyword, so e.g.
+		// `map < 5` is a column comparison).
 		switch p.peekNext().Kind {
-		case int('<'):
-			return p.parseMapLiteral(true)
 		case int('{'):
-			return p.parseMapLiteral(false)
+			// Untyped MAP{...} — unambiguous.
+			start := p.cur.Loc.Start
+			p.advance() // consume MAP
+			return p.finishMapLiteral(start, nil)
+		case int('<'):
+			// Ambiguous with `map < expr`: speculatively parse the type and
+			// commit only if '{' follows, else backtrack to the identifier path.
+			saved := p.save()
+			start := p.cur.Loc.Start
+			mapType, err := p.parseDataType()
+			if err == nil && p.cur.Kind == int('{') {
+				return p.finishMapLiteral(start, mapType)
+			}
+			p.restore(saved)
 		}
 		return p.parseIdentExpr()
 
 	case kwARRAY:
-		// array<t>[...] typed array constructor; otherwise an ordinary identifier.
+		// array<t>[...] typed array constructor; otherwise an ordinary identifier
+		// (ARRAY is non-reserved too, so `array < 5` is a column comparison).
 		if p.peekNext().Kind == int('<') {
-			return p.parseArrayLiteral(true)
+			saved := p.save()
+			start := p.cur.Loc.Start
+			elemType, err := p.parseDataType()
+			if err == nil && p.cur.Kind == int('[') {
+				return p.finishArrayLiteral(start, elemType)
+			}
+			p.restore(saved)
 		}
 		return p.parseIdentExpr()
 
 	case int('['):
 		// Untyped array constructor: [ e, ... ].
-		return p.parseArrayLiteral(false)
+		return p.finishArrayLiteral(p.cur.Loc.Start, nil)
 
 	case kwCASE:
 		return p.parseCaseExpr()
@@ -465,22 +485,11 @@ func (p *Parser) parseIdentExpr() (ast.Node, error) {
 	}, nil
 }
 
-// parseMapLiteral parses a map constructor literal. When typed, the leading
-// map<k,v> type is consumed via parseDataType; when untyped, the MAP keyword is
-// consumed directly. Both forms are then followed by { key:val, ... }.
-func (p *Parser) parseMapLiteral(typed bool) (ast.Node, error) {
-	start := p.cur.Loc.Start
-
-	lit := &ast.MapLiteral{}
-	if typed {
-		mapType, err := p.parseDataType() // consumes map<k,v>
-		if err != nil {
-			return nil, err
-		}
-		lit.MapType = mapType
-	} else {
-		p.advance() // consume MAP
-	}
+// finishMapLiteral parses the { key:val, ... } body of a map constructor. The
+// optional map<k,v> type (nil for the untyped MAP{...} form) and the MAP keyword
+// have already been consumed; the current token is '{'.
+func (p *Parser) finishMapLiteral(start int, mapType *ast.TypeName) (ast.Node, error) {
+	lit := &ast.MapLiteral{MapType: mapType}
 
 	if _, err := p.expect(int('{')); err != nil {
 		return nil, err
@@ -528,20 +537,11 @@ func (p *Parser) parseMapEntry() (*ast.MapEntry, error) {
 	}, nil
 }
 
-// parseArrayLiteral parses an array constructor literal. When typed, the leading
-// array<t> type is consumed via parseDataType; both forms are then followed by
-// [ e, ... ].
-func (p *Parser) parseArrayLiteral(typed bool) (ast.Node, error) {
-	start := p.cur.Loc.Start
-
-	lit := &ast.ArrayLiteral{}
-	if typed {
-		elemType, err := p.parseDataType() // consumes array<t>
-		if err != nil {
-			return nil, err
-		}
-		lit.ElemType = elemType
-	}
+// finishArrayLiteral parses the [ e, ... ] body of an array constructor. The
+// optional array<t> type (nil for the untyped [...] form) has already been
+// consumed; the current token is '['.
+func (p *Parser) finishArrayLiteral(start int, elemType *ast.TypeName) (ast.Node, error) {
+	lit := &ast.ArrayLiteral{ElemType: elemType}
 
 	if _, err := p.expect(int('[')); err != nil {
 		return nil, err
@@ -605,10 +605,11 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 		}
 		fc.Args = args
 
-		// Optional IGNORE NULLS after the first argument (window null-treatment,
+		// Optional IGNORE NULLS after the FIRST argument (window null-treatment,
 		// e.g. FIRST_VALUE(v IGNORE NULLS), LAG(v IGNORE NULLS, 1)). The grammar
-		// attaches it after the first expression, so further args may follow.
-		if p.consumeIgnoreNulls() {
+		// attaches it only after the first expression, so we require exactly one
+		// arg so far; further args may follow it.
+		if len(fc.Args) == 1 && p.consumeIgnoreNulls() {
 			fc.IgnoreNulls = true
 			for p.cur.Kind == int(',') {
 				p.advance() // consume ','
@@ -672,7 +673,25 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 		fc.Loc.End = over.Loc.End
 	}
 
+	// IGNORE NULLS is valid only on the four window value functions and requires
+	// an OVER clause (StarRocks grammar: windowFunction is one of LEAD/LAG/
+	// FIRST_VALUE/LAST_VALUE, used as `windowFunction over`). Reject otherwise.
+	if fc.IgnoreNulls && (fc.Over == nil || !isIgnoreNullsWindowFunc(funcName)) {
+		return nil, p.syntaxErrorAtCur()
+	}
+
 	return fc, nil
+}
+
+// isIgnoreNullsWindowFunc reports whether name is one of the window value
+// functions that accept an IGNORE NULLS null-treatment clause.
+func isIgnoreNullsWindowFunc(name string) bool {
+	switch name {
+	case "FIRST_VALUE", "LAST_VALUE", "LEAD", "LAG":
+		return true
+	default:
+		return false
+	}
 }
 
 // consumeIgnoreNulls consumes an optional IGNORE NULLS null-treatment clause and

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -375,6 +375,28 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 	case int('('):
 		return p.parseParenExprOrSubquery()
 
+	case kwMAP:
+		// map<k,v>{...} (typed) or MAP{...} (untyped) map constructor; otherwise
+		// MAP is an ordinary identifier/function.
+		switch p.peekNext().Kind {
+		case int('<'):
+			return p.parseMapLiteral(true)
+		case int('{'):
+			return p.parseMapLiteral(false)
+		}
+		return p.parseIdentExpr()
+
+	case kwARRAY:
+		// array<t>[...] typed array constructor; otherwise an ordinary identifier.
+		if p.peekNext().Kind == int('<') {
+			return p.parseArrayLiteral(true)
+		}
+		return p.parseIdentExpr()
+
+	case int('['):
+		// Untyped array constructor: [ e, ... ].
+		return p.parseArrayLiteral(false)
+
 	case kwCASE:
 		return p.parseCaseExpr()
 
@@ -441,6 +463,110 @@ func (p *Parser) parseIdentExpr() (ast.Node, error) {
 		Name: name,
 		Loc:  name.Loc,
 	}, nil
+}
+
+// parseMapLiteral parses a map constructor literal. When typed, the leading
+// map<k,v> type is consumed via parseDataType; when untyped, the MAP keyword is
+// consumed directly. Both forms are then followed by { key:val, ... }.
+func (p *Parser) parseMapLiteral(typed bool) (ast.Node, error) {
+	start := p.cur.Loc.Start
+
+	lit := &ast.MapLiteral{}
+	if typed {
+		mapType, err := p.parseDataType() // consumes map<k,v>
+		if err != nil {
+			return nil, err
+		}
+		lit.MapType = mapType
+	} else {
+		p.advance() // consume MAP
+	}
+
+	if _, err := p.expect(int('{')); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int('}') {
+		entry, err := p.parseMapEntry()
+		if err != nil {
+			return nil, err
+		}
+		lit.Entries = append(lit.Entries, entry)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			entry, err = p.parseMapEntry()
+			if err != nil {
+				return nil, err
+			}
+			lit.Entries = append(lit.Entries, entry)
+		}
+	}
+	closeTok, err := p.expect(int('}'))
+	if err != nil {
+		return nil, err
+	}
+	lit.Loc = ast.Loc{Start: start, End: closeTok.Loc.End}
+	return lit, nil
+}
+
+// parseMapEntry parses one key:value pair of a map constructor.
+func (p *Parser) parseMapEntry() (*ast.MapEntry, error) {
+	key, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(':')); err != nil {
+		return nil, err
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.MapEntry{
+		Key:   key,
+		Value: value,
+		Loc:   ast.Loc{Start: ast.NodeLoc(key).Start, End: ast.NodeLoc(value).End},
+	}, nil
+}
+
+// parseArrayLiteral parses an array constructor literal. When typed, the leading
+// array<t> type is consumed via parseDataType; both forms are then followed by
+// [ e, ... ].
+func (p *Parser) parseArrayLiteral(typed bool) (ast.Node, error) {
+	start := p.cur.Loc.Start
+
+	lit := &ast.ArrayLiteral{}
+	if typed {
+		elemType, err := p.parseDataType() // consumes array<t>
+		if err != nil {
+			return nil, err
+		}
+		lit.ElemType = elemType
+	}
+
+	if _, err := p.expect(int('[')); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int(']') {
+		el, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		lit.Elements = append(lit.Elements, el)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			el, err = p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			lit.Elements = append(lit.Elements, el)
+		}
+	}
+	closeTok, err := p.expect(int(']'))
+	if err != nil {
+		return nil, err
+	}
+	lit.Loc = ast.Loc{Start: start, End: closeTok.Loc.End}
+	return lit, nil
 }
 
 // parseFuncCall parses a function call starting at the opening '('.

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -255,6 +255,22 @@ func (p *Parser) parsePrefixExpr() (ast.Node, error) {
 			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
 		}, nil
 
+	case kwBINARY:
+		// BINARY <expr> cast-to-binary operator. StarRocks places it at the top
+		// of the expression rule (lowest precedence), so the operand spans the
+		// whole following boolean expression: BINARY name = 'abc' => BINARY(name = 'abc').
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpNone + 1)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryBinary,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
 	case kwEXISTS:
 		return p.parseExistsExpr()
 
@@ -312,6 +328,22 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		tok := p.advance()
 		return &ast.Literal{
 			Kind:  ast.LitString,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokHexLiteral:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitHex,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokBitLiteral:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitBit,
 			Value: tok.Str,
 			Loc:   tok.Loc,
 		}, nil

--- a/starrocks/parser/ignore_nulls_test.go
+++ b/starrocks/parser/ignore_nulls_test.go
@@ -1,0 +1,70 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+// IGNORE NULLS null-treatment in window functions. Two grammar positions:
+// inside the parens after the first argument, and after the closing paren.
+
+func ignoreNullsFunc(t *testing.T, input string) *ast.FuncCallExpr {
+	t.Helper()
+	stmt := mustParseSelect(t, input)
+	fc, ok := stmt.Items[0].Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("item expr = %T, want *ast.FuncCallExpr", stmt.Items[0].Expr)
+	}
+	return fc
+}
+
+// TestIgnoreNullsInside covers IGNORE NULLS after the (only) argument.
+func TestIgnoreNullsInside(t *testing.T) {
+	fc := ignoreNullsFunc(t, "SELECT FIRST_VALUE(v IGNORE NULLS) OVER (PARTITION BY g ORDER BY ts) FROM t")
+	if !fc.IgnoreNulls {
+		t.Error("IgnoreNulls = false, want true")
+	}
+	if fc.Over == nil {
+		t.Error("Over = nil, want the OVER clause to be parsed")
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("args = %d, want 1", len(fc.Args))
+	}
+}
+
+// TestIgnoreNullsOutside covers IGNORE NULLS after the closing paren. (Without
+// the feature, IGNORE is silently mis-consumed as a column alias.)
+func TestIgnoreNullsOutside(t *testing.T) {
+	fc := ignoreNullsFunc(t, "SELECT LEAD(v, 1) IGNORE NULLS OVER (ORDER BY ts) FROM t")
+	if !fc.IgnoreNulls {
+		t.Error("IgnoreNulls = false, want true")
+	}
+	if fc.Over == nil {
+		t.Error("Over = nil, want the OVER clause to be parsed")
+	}
+	if stmt := mustParseSelect(t, "SELECT LEAD(v, 1) IGNORE NULLS OVER (ORDER BY ts) FROM t"); stmt.Items[0].Alias != "" {
+		t.Errorf("alias = %q, want empty (IGNORE must not be consumed as an alias)", stmt.Items[0].Alias)
+	}
+}
+
+// TestIgnoreNullsMidArgs covers IGNORE NULLS after the first arg with more args
+// following (LAG(v IGNORE NULLS, 1)).
+func TestIgnoreNullsMidArgs(t *testing.T) {
+	fc := ignoreNullsFunc(t, "SELECT LAG(v IGNORE NULLS, 1) OVER (ORDER BY ts) FROM t")
+	if !fc.IgnoreNulls {
+		t.Error("IgnoreNulls = false, want true")
+	}
+	if len(fc.Args) != 2 {
+		t.Errorf("args = %d, want 2 (v, 1)", len(fc.Args))
+	}
+}
+
+// TestFuncCallNoIgnoreNulls is the regression guard: a plain window function
+// still parses with IgnoreNulls=false.
+func TestFuncCallNoIgnoreNulls(t *testing.T) {
+	fc := ignoreNullsFunc(t, "SELECT FIRST_VALUE(v) OVER (PARTITION BY g ORDER BY ts) FROM t")
+	if fc.IgnoreNulls {
+		t.Error("IgnoreNulls = true, want false")
+	}
+}

--- a/starrocks/parser/parser.go
+++ b/starrocks/parser/parser.go
@@ -44,6 +44,45 @@ func (p *Parser) peek() Token {
 	return p.cur
 }
 
+// parserCheckpoint snapshots the parser + lexer position so a speculative parse
+// can be rolled back. It is a bounded backtracking primitive for prefix-
+// ambiguous grammar (e.g. map<k,v>{...} literal vs the column `map` compared
+// with `<`). It is NOT safe across input-rewriting lexer paths (conditional
+// comments), which do not occur inside the constructs it is used for.
+type parserCheckpoint struct {
+	cur, prev, nextBuf Token
+	hasNext            bool
+	lexPos, lexStart   int
+	errLen, lexErrLen  int
+}
+
+// save captures the current parser state.
+func (p *Parser) save() parserCheckpoint {
+	return parserCheckpoint{
+		cur:       p.cur,
+		prev:      p.prev,
+		nextBuf:   p.nextBuf,
+		hasNext:   p.hasNext,
+		lexPos:    p.lexer.pos,
+		lexStart:  p.lexer.start,
+		errLen:    len(p.errors),
+		lexErrLen: len(p.lexer.errors),
+	}
+}
+
+// restore rolls the parser + lexer back to a saved checkpoint, discarding any
+// tokens consumed and errors collected since.
+func (p *Parser) restore(c parserCheckpoint) {
+	p.cur = c.cur
+	p.prev = c.prev
+	p.nextBuf = c.nextBuf
+	p.hasNext = c.hasNext
+	p.lexer.pos = c.lexPos
+	p.lexer.start = c.lexStart
+	p.errors = p.errors[:c.errLen]
+	p.lexer.errors = p.lexer.errors[:c.lexErrLen]
+}
+
 // peekNext returns the token AFTER the current one without consuming it
 // (one-token lookahead beyond cur). Used to disambiguate based on the
 // token following the current position.

--- a/starrocks/parser/pr4b_oracle_test.go
+++ b/starrocks/parser/pr4b_oracle_test.go
@@ -68,6 +68,20 @@ func TestPR4bParity(t *testing.T) {
 		//     — BINARY is reserved in omni and handled as the unary operator, while
 		//     StarRocks treats it as a nonReserved identifier here. Pre-existing
 		//     (omni rejected bare BINARY before this feature too), not a regression.
+
+		// Map / array collection literals — accept probes.
+		{"map_typed", "SELECT map<varchar,int>{'x':1} FROM t", true},
+		{"map_typed_multi", "SELECT map<varchar,int>{'x':1,'y':2} FROM t", true},
+		{"map_typed_empty", "SELECT map<int,int>{} FROM t", true},
+		{"map_untyped", "SELECT MAP{'x':1} FROM t", true},
+		{"array_typed", "SELECT array<int>[1,2,3] FROM t", true},
+		{"array_typed_empty", "SELECT array<int>[] FROM t", true},
+		{"array_untyped", "SELECT [1,2,3] FROM t", true},
+		{"map_nested_array", "SELECT map<varchar,array<int>>{'x':[1,2]} FROM t", true},
+		// Map / array — sibling-arm negatives (fail inside the construct).
+		{"map_entry_missing_value", "SELECT map<varchar,int>{'x'} FROM t", false},
+		{"map_missing_value_type", "SELECT map<varchar,>{} FROM t", false},
+		{"map_trailing_comma", "SELECT map<varchar,int>{'x':1,} FROM t", false},
 	}
 
 	for _, tc := range cases {

--- a/starrocks/parser/pr4b_oracle_test.go
+++ b/starrocks/parser/pr4b_oracle_test.go
@@ -1,0 +1,62 @@
+package parser
+
+import "testing"
+
+// TestPR4bParity is the container-grounded conformance matrix for the PR4b
+// expr-side query features: IGNORE NULLS null-treatment, binary/hex literals +
+// the BINARY operator, and map/array collection literals. Each construct is
+// asserted accepted by BOTH the omni parser and StarRocks 3.4, and each
+// sibling-arm negative rejected by both. Short-gated via startStarRocks.
+func TestPR4bParity(t *testing.T) {
+	c := startStarRocks(t)
+
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		// IGNORE NULLS — accept probes.
+		{
+			"ignore_nulls_inside",
+			"SELECT FIRST_VALUE(v IGNORE NULLS) OVER (PARTITION BY g ORDER BY ts) FROM t",
+			true,
+		},
+		{
+			"ignore_nulls_last_value",
+			"SELECT LAST_VALUE(v IGNORE NULLS) OVER (ORDER BY ts) FROM t",
+			true,
+		},
+		{
+			"ignore_nulls_outside",
+			"SELECT LEAD(v, 1) IGNORE NULLS OVER (ORDER BY ts) FROM t",
+			true,
+		},
+		{
+			"ignore_nulls_mid_args",
+			"SELECT LAG(v IGNORE NULLS, 1) OVER (ORDER BY ts) FROM t",
+			true,
+		},
+		{
+			"window_no_ignore_nulls", // regression: plain window fn still parses
+			"SELECT FIRST_VALUE(v) OVER (PARTITION BY g ORDER BY ts) FROM t",
+			true,
+		},
+		// IGNORE NULLS — sibling-arm negatives.
+		{
+			"respect_nulls_rejected", // RESPECT NULLS does not exist in StarRocks 3.4
+			"SELECT FIRST_VALUE(v RESPECT NULLS) OVER (ORDER BY ts) FROM t",
+			false,
+		},
+		{
+			"ignore_without_nulls", // IGNORE alone is malformed
+			"SELECT FIRST_VALUE(v IGNORE) OVER (ORDER BY ts) FROM t",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}

--- a/starrocks/parser/pr4b_oracle_test.go
+++ b/starrocks/parser/pr4b_oracle_test.go
@@ -52,6 +52,22 @@ func TestPR4bParity(t *testing.T) {
 			"SELECT FIRST_VALUE(v IGNORE) OVER (ORDER BY ts) FROM t",
 			false,
 		},
+
+		// Binary/hex literals + the BINARY operator — accept probes.
+		{"hex_literal_upper", "SELECT X'4142' FROM t", true},
+		{"hex_literal_lower", "SELECT x'ff' FROM t", true},
+		{"bit_literal", "SELECT B'101' FROM t", true},
+		{"hex_integer_0x", "SELECT 0x4142 FROM t", true},
+		{"binary_operator_select", "SELECT BINARY col1 FROM t", true},
+		{"binary_operator_where", "SELECT * FROM t WHERE BINARY name = 'abc'", true},
+		{"binary_operator_lowprec", "SELECT BINARY name = 'abc' FROM t", true},
+		// Known divergences (documented, left as-is per skip-prune):
+		//   - X'zz' (non-hex / odd-length content): omni over-accepts — the lexer
+		//     scans the hex body verbatim without validating it; StarRocks rejects.
+		//   - SELECT BINARY FROM t (BINARY as a bare column name): omni under-accepts
+		//     — BINARY is reserved in omni and handled as the unary operator, while
+		//     StarRocks treats it as a nonReserved identifier here. Pre-existing
+		//     (omni rejected bare BINARY before this feature too), not a regression.
 	}
 
 	for _, tc := range cases {

--- a/starrocks/parser/pr4b_oracle_test.go
+++ b/starrocks/parser/pr4b_oracle_test.go
@@ -52,6 +52,21 @@ func TestPR4bParity(t *testing.T) {
 			"SELECT FIRST_VALUE(v IGNORE) OVER (ORDER BY ts) FROM t",
 			false,
 		},
+		{
+			"ignore_nulls_non_window_func", // only LEAD/LAG/FIRST_VALUE/LAST_VALUE allow it
+			"SELECT SUM(x IGNORE NULLS) OVER (ORDER BY ts) FROM t",
+			false,
+		},
+		{
+			"ignore_nulls_requires_over", // a window function requires OVER
+			"SELECT FIRST_VALUE(v IGNORE NULLS) FROM t",
+			false,
+		},
+		{
+			"ignore_nulls_non_first_arg", // IGNORE NULLS attaches only after the first arg
+			"SELECT FIRST_VALUE(a, b IGNORE NULLS) OVER (ORDER BY ts) FROM t",
+			false,
+		},
 
 		// Binary/hex literals + the BINARY operator — accept probes.
 		{"hex_literal_upper", "SELECT X'4142' FROM t", true},
@@ -61,6 +76,7 @@ func TestPR4bParity(t *testing.T) {
 		{"binary_operator_select", "SELECT BINARY col1 FROM t", true},
 		{"binary_operator_where", "SELECT * FROM t WHERE BINARY name = 'abc'", true},
 		{"binary_operator_lowprec", "SELECT BINARY name = 'abc' FROM t", true},
+		{"binary_below_and", "SELECT BINARY a AND b FROM t", true}, // (BINARY a) AND b
 		// Known divergences (documented, left as-is per skip-prune):
 		//   - X'zz' (non-hex / odd-length content): omni over-accepts — the lexer
 		//     scans the hex body verbatim without validating it; StarRocks rejects.
@@ -68,6 +84,9 @@ func TestPR4bParity(t *testing.T) {
 		//     — BINARY is reserved in omni and handled as the unary operator, while
 		//     StarRocks treats it as a nonReserved identifier here. Pre-existing
 		//     (omni rejected bare BINARY before this feature too), not a regression.
+		//   - 1 + BINARY 2 (BINARY in a nested operand position): omni over-accepts
+		//     — BINARY is reachable as a general prefix operator, while StarRocks
+		//     allows it only at the top of an expression. Lineage-neutral.
 
 		// Map / array collection literals — accept probes.
 		{"map_typed", "SELECT map<varchar,int>{'x':1} FROM t", true},
@@ -82,6 +101,12 @@ func TestPR4bParity(t *testing.T) {
 		{"map_entry_missing_value", "SELECT map<varchar,int>{'x'} FROM t", false},
 		{"map_missing_value_type", "SELECT map<varchar,>{} FROM t", false},
 		{"map_trailing_comma", "SELECT map<varchar,int>{'x':1,} FROM t", false},
+		// Regression guard: `map` is non-reserved, so `map < 5` is a comparison,
+		// not a map<...> type — the dispatch must backtrack when no '{' follows.
+		{"map_column_comparison", "SELECT cnt FROM t WHERE map < 5", true},
+		// Known divergence: `array < 5` — omni accepts it as a comparison (ARRAY
+		// is non-reserved in omni, matching prior behaviour), while StarRocks
+		// reserves ARRAY and rejects it. Over-accept, lineage-neutral.
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
PR4b of the StarRocks query-features epic (BYT-9140), completing the 5 PR4 query features (PR4a #305 covered the FROM side). These three expr-side features feed query-span **lineage** through the routed `omni/starrocks` fork; all are oracle-pinned against live StarRocks 3.4.

## Features

**IGNORE NULLS** in window functions — `FIRST_VALUE(v IGNORE NULLS) OVER (...)`, `LEAD(v,1) IGNORE NULLS OVER (...)`, `LAG(v IGNORE NULLS, 1) OVER (...)`
- `FuncCallExpr.IgnoreNulls` (walk-inert; lineage unaffected — args flow generically).
- Handled at both grammar positions (inside the parens after the first arg; after `)`), gated to the four window value functions (LEAD/LAG/FIRST_VALUE/LAST_VALUE) with OVER required and the first-arg-only restriction, matching the grammar. `RESPECT NULLS` does not exist in 3.4.

**Binary/hex literals + BINARY operator** — `X'4142'`, `B'101'`, `BINARY col`
- The lexer already tokenizes `X'..'`/`B'..'`; only parser arms + AST enums (`LitHex`/`LitBit`, `UnaryBinary`) were needed — zero `walk_children`/`loc` change. BINARY parses as a `booleanExpression` operand (`BINARY a AND b` => `(BINARY a) AND b`).

**Map/array collection literals** — `map<k,v>{...}`, `MAP{...}`, `array<t>[...]`, `[...]`
- New `ast.MapLiteral`/`MapEntry`/`ArrayLiteral` + full new-node checklist; the typed `<k,v>`/`<t>` prefix reuses `parseDataType`; column refs inside literal values flow to lineage. `struct<>{}` is not a StarRocks literal and is omitted.
- `MAP`/`ARRAY` are non-reserved, so `map < 5` / `array < 5` are column comparisons, not types. A **save/restore checkpoint** (a bounded backtracking primitive, new in `parser.go`) commits to the typed-literal path only when the angle-bracket type is followed by the literal opener (`{`/`[`), otherwise falls back to the identifier path.

## Testing
- Unit parser tests + `analysis/query_span` lineage tests (column refs inside map keys/values, array elements, nested literals, and unnest/binary operands all flow; literals contribute none).
- `TestPR4bParity` (`testing.Short()`-gated): **30 cases** — accepts + sibling-arm rejects (RESPECT NULLS, IGNORE-without-OVER / non-window-func / non-first-arg, map missing-value/value-type/trailing-comma) + the `map < 5` comparison regression guard — all agree with live StarRocks 3.4.
- Full inherited suite green (no regression); `go vet` clean (only the 2 pre-existing warnings).

## Review
A 3-lens adversarial review (correctness / grammar-parity / lineage) drove the final fix commit: it caught a `map < 5` parse regression, an IGNORE NULLS over-accept, and a BINARY precedence issue — all fixed and covered by parity tests. Lineage lens verified all three new-node checklists complete with no holes.

## Documented over-accepts (skip-prune, lineage-neutral)
`array < 5` (omni keeps prior lenience; StarRocks reserves ARRAY), nested `1 + BINARY 2`, `X'zz'` unvalidated hex content, bare `BINARY`-as-column-name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)