### PR TITLE
feat(pg): improve function body compatibility checks

### DIFF
--- a/pg/parser/alter_misc.go
+++ b/pg/parser/alter_misc.go
@@ -73,7 +73,10 @@ func (p *Parser) parseAlterFunctionStmt() (nodes.Node, error) {
 			}, nil
 		}
 		// Otherwise it's alterfunc_opt_list (e.g., SET search_path ...)
-		actions := p.parseAlterfuncOptList()
+		actions, err := p.parseAlterfuncOptList()
+		if err != nil {
+			return nil, err
+		}
 		if actions == nil {
 			return nil, p.syntaxErrorAtCur()
 		}
@@ -108,7 +111,10 @@ func (p *Parser) parseAlterFunctionStmt() (nodes.Node, error) {
 		}, nil
 	default:
 		// alterfunc_opt_list opt_restrict (e.g., IMMUTABLE, STABLE, etc.)
-		actions := p.parseAlterfuncOptList()
+		actions, err := p.parseAlterfuncOptList()
+		if err != nil {
+			return nil, err
+		}
 		if actions == nil {
 			return nil, p.syntaxErrorAtCur()
 		}
@@ -123,20 +129,26 @@ func (p *Parser) parseAlterFunctionStmt() (nodes.Node, error) {
 }
 
 // parseAlterfuncOptList parses alterfunc_opt_list: one or more common_func_opt_item.
-func (p *Parser) parseAlterfuncOptList() *nodes.List {
-	item := p.parseCommonFuncOptItem()
+func (p *Parser) parseAlterfuncOptList() (*nodes.List, error) {
+	item, err := p.parseCommonFuncOptItem()
+	if err != nil {
+		return nil, err
+	}
 	if item == nil {
-		return nil
+		return nil, nil
 	}
 	items := []nodes.Node{item}
 	for {
-		item = p.parseCommonFuncOptItem()
+		item, err = p.parseCommonFuncOptItem()
+		if err != nil {
+			return nil, err
+		}
 		if item == nil {
 			break
 		}
 		items = append(items, item)
 	}
-	return &nodes.List{Items: items}
+	return &nodes.List{Items: items}, nil
 }
 
 // parseOptRestrict consumes an optional RESTRICT keyword (ignored, for SQL compliance).

--- a/pg/parser/create_function.go
+++ b/pg/parser/create_function.go
@@ -131,7 +131,6 @@ func (p *Parser) parseFuncNameForCreate() *nodes.List {
 	return result
 }
 
-
 // parseFuncArgsWithDefaults parses function arguments with defaults.
 //
 //	func_args_with_defaults:
@@ -399,12 +398,18 @@ func (p *Parser) parseCreatefuncOptItem() (*nodes.DefElem, error) {
 	switch p.cur.Type {
 	case AS:
 		p.advance()
-		funcAs := p.parseFuncAs()
+		funcAs, err := p.parseFuncAs()
+		if err != nil {
+			return nil, err
+		}
 		de = &nodes.DefElem{Defname: "as", Arg: funcAs}
 
 	case LANGUAGE:
 		p.advance()
-		lang := p.parseNonReservedWordOrSconst()
+		lang, err := p.parseCreateFunctionLanguageName()
+		if err != nil {
+			return nil, err
+		}
 		de = &nodes.DefElem{Defname: "language", Arg: &nodes.String{Str: lang}}
 
 	case TRANSFORM:
@@ -420,7 +425,11 @@ func (p *Parser) parseCreatefuncOptItem() (*nodes.DefElem, error) {
 		de = &nodes.DefElem{Defname: "window", Arg: &nodes.Integer{Ival: 1}}
 
 	default:
-		de = p.parseCommonFuncOptItem()
+		var err error
+		de, err = p.parseCommonFuncOptItem()
+		if err != nil {
+			return nil, err
+		}
 	}
 	if de != nil {
 		de.Loc = nodes.Loc{Start: loc, End: p.pos()}
@@ -433,21 +442,45 @@ func (p *Parser) parseCreatefuncOptItem() (*nodes.DefElem, error) {
 //	func_as:
 //	    Sconst
 //	    | Sconst ',' Sconst
-func (p *Parser) parseFuncAs() *nodes.List {
+func (p *Parser) parseFuncAs() (*nodes.List, error) {
 	s1 := p.cur.Str
-	p.expect(SCONST)
+	if _, err := p.expect(SCONST); err != nil {
+		return nil, err
+	}
 	if p.cur.Type == ',' {
 		p.advance()
 		s2 := p.cur.Str
-		p.expect(SCONST)
+		if _, err := p.expect(SCONST); err != nil {
+			return nil, err
+		}
 		return &nodes.List{Items: []nodes.Node{
 			&nodes.String{Str: s1},
 			&nodes.String{Str: s2},
-		}}
+		}}, nil
 	}
 	return &nodes.List{Items: []nodes.Node{
 		&nodes.String{Str: s1},
-	}}
+	}}, nil
+}
+
+func (p *Parser) parseCreateFunctionLanguageName() (string, error) {
+	if p.cur.Type == SCONST {
+		s := p.cur.Str
+		p.advance()
+		return s, nil
+	}
+	if p.cur.Type == IDENT {
+		s := p.cur.Str
+		p.advance()
+		return s, nil
+	}
+	if kw := LookupKeyword(p.cur.Str); kw != nil && kw.Token == p.cur.Type &&
+		(kw.Category == UnreservedKeyword || kw.Category == ColNameKeyword || kw.Category == TypeFuncNameKeyword) {
+		s := p.cur.Str
+		p.advance()
+		return s, nil
+	}
+	return "", p.syntaxErrorAtCur()
 }
 
 // parseNonReservedWordOrSconst parses a non-reserved word or string constant.
@@ -472,8 +505,12 @@ func (p *Parser) parseNonReservedWordOrSconst() string {
 //	    FOR TYPE_P Typename
 //	    | transform_type_list ',' FOR TYPE_P Typename
 func (p *Parser) parseTransformTypeList() (*nodes.List, error) {
-	p.expect(FOR)
-	p.expect(TYPE_P)
+	if _, err := p.expect(FOR); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TYPE_P); err != nil {
+		return nil, err
+	}
 	tn, err := p.parseTypename()
 	if err != nil {
 		return nil, err
@@ -481,8 +518,12 @@ func (p *Parser) parseTransformTypeList() (*nodes.List, error) {
 	items := []nodes.Node{tn}
 	for p.cur.Type == ',' {
 		p.advance()
-		p.expect(FOR)
-		p.expect(TYPE_P)
+		if _, err := p.expect(FOR); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(TYPE_P); err != nil {
+			return nil, err
+		}
 		tn, err = p.parseTypename()
 		if err != nil {
 			return nil, err
@@ -506,78 +547,114 @@ func (p *Parser) parseTransformTypeList() (*nodes.List, error) {
 //	    | SET set_rest_more
 //	    | VariableResetStmt
 //	    | SUPPORT any_name
-func (p *Parser) parseCommonFuncOptItem() *nodes.DefElem {
+func (p *Parser) parseCommonFuncOptItem() (*nodes.DefElem, error) {
 	switch p.cur.Type {
 	case IMMUTABLE:
 		p.advance()
-		return &nodes.DefElem{Defname: "volatility", Arg: &nodes.String{Str: "immutable"}}
+		return &nodes.DefElem{Defname: "volatility", Arg: &nodes.String{Str: "immutable"}}, nil
 	case STABLE:
 		p.advance()
-		return &nodes.DefElem{Defname: "volatility", Arg: &nodes.String{Str: "stable"}}
+		return &nodes.DefElem{Defname: "volatility", Arg: &nodes.String{Str: "stable"}}, nil
 	case VOLATILE:
 		p.advance()
-		return &nodes.DefElem{Defname: "volatility", Arg: &nodes.String{Str: "volatile"}}
+		return &nodes.DefElem{Defname: "volatility", Arg: &nodes.String{Str: "volatile"}}, nil
 	case STRICT_P:
 		p.advance()
-		return &nodes.DefElem{Defname: "strict", Arg: &nodes.Integer{Ival: 1}}
+		return &nodes.DefElem{Defname: "strict", Arg: &nodes.Integer{Ival: 1}}, nil
 	case CALLED:
 		p.advance()
-		p.expect(ON)
-		p.expect(NULL_P)
-		p.expect(INPUT_P)
-		return &nodes.DefElem{Defname: "strict", Arg: &nodes.Integer{Ival: 0}}
+		if _, err := p.expect(ON); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(NULL_P); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(INPUT_P); err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "strict", Arg: &nodes.Integer{Ival: 0}}, nil
 	case RETURNS:
 		// RETURNS NULL ON NULL INPUT (note: this is ambiguous with RETURNS func_return
 		// but only appears in createfunc_opt_list, not at the top level)
 		p.advance()
-		p.expect(NULL_P)
-		p.expect(ON)
-		p.expect(NULL_P)
-		p.expect(INPUT_P)
-		return &nodes.DefElem{Defname: "strict", Arg: &nodes.Integer{Ival: 1}}
+		if _, err := p.expect(NULL_P); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(ON); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(NULL_P); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(INPUT_P); err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "strict", Arg: &nodes.Integer{Ival: 1}}, nil
 	case SECURITY:
 		p.advance()
 		if p.cur.Type == DEFINER {
 			p.advance()
-			return &nodes.DefElem{Defname: "security", Arg: &nodes.Integer{Ival: 1}}
+			return &nodes.DefElem{Defname: "security", Arg: &nodes.Integer{Ival: 1}}, nil
 		}
-		p.expect(INVOKER)
-		return &nodes.DefElem{Defname: "security", Arg: &nodes.Integer{Ival: 0}}
+		if _, err := p.expect(INVOKER); err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "security", Arg: &nodes.Integer{Ival: 0}}, nil
 	case LEAKPROOF:
 		p.advance()
-		return &nodes.DefElem{Defname: "leakproof", Arg: &nodes.Integer{Ival: 1}}
+		return &nodes.DefElem{Defname: "leakproof", Arg: &nodes.Integer{Ival: 1}}, nil
 	case NOT:
 		p.advance()
-		p.expect(LEAKPROOF)
-		return &nodes.DefElem{Defname: "leakproof", Arg: &nodes.Integer{Ival: 0}}
+		if _, err := p.expect(LEAKPROOF); err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "leakproof", Arg: &nodes.Integer{Ival: 0}}, nil
 	case COST:
 		p.advance()
 		val := p.parseNumericOnly()
-		return &nodes.DefElem{Defname: "cost", Arg: val}
+		if val == nil {
+			return nil, p.syntaxErrorAtCur()
+		}
+		return &nodes.DefElem{Defname: "cost", Arg: val}, nil
 	case ROWS:
 		p.advance()
 		val := p.parseNumericOnly()
-		return &nodes.DefElem{Defname: "rows", Arg: val}
+		if val == nil {
+			return nil, p.syntaxErrorAtCur()
+		}
+		return &nodes.DefElem{Defname: "rows", Arg: val}, nil
 	case PARALLEL:
 		p.advance()
-		name, _ := p.parseColId()
-		return &nodes.DefElem{Defname: "parallel", Arg: &nodes.String{Str: name}}
+		name, err := p.parseColId()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "parallel", Arg: &nodes.String{Str: name}}, nil
 	case SUPPORT:
 		p.advance()
-		name, _ := p.parseAnyName()
-		return &nodes.DefElem{Defname: "support", Arg: name}
+		name, err := p.parseAnyName()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "support", Arg: name}, nil
 	case SET:
 		// SET set_rest_more
 		p.advance() // consume SET
-		arg, _ := p.parseSetRestMore()
-		return &nodes.DefElem{Defname: "set", Arg: arg}
+		arg, err := p.parseSetRestMore()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "set", Arg: arg}, nil
 	case RESET:
 		// VariableResetStmt (RESET reset_rest)
 		p.advance() // consume RESET
-		arg, _ := p.parseVariableResetStmt()
-		return &nodes.DefElem{Defname: "set", Arg: arg}
+		arg, err := p.parseVariableResetStmt()
+		if err != nil {
+			return nil, err
+		}
+		return &nodes.DefElem{Defname: "set", Arg: arg}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // parseOptRoutineBody parses an optional routine body.
@@ -601,7 +678,9 @@ func (p *Parser) parseOptRoutineBody() (nodes.Node, error) {
 	}
 	if p.cur.Type == BEGIN_P {
 		p.advance() // consume BEGIN
-		p.expect(ATOMIC)
+		if _, err := p.expect(ATOMIC); err != nil {
+			return nil, err
+		}
 
 		// Parse routine_body_stmt_list: (routine_body_stmt ';')*
 		var stmts []nodes.Node
@@ -610,10 +689,20 @@ func (p *Parser) parseOptRoutineBody() (nodes.Node, error) {
 			if p.cur.Type == RETURN {
 				innerRetLoc := p.pos()
 				p.advance()
-				expr, _ := p.parseAExpr(0)
+				expr, err := p.parseAExpr(0)
+				if err != nil {
+					return nil, err
+				}
+				if expr == nil {
+					return nil, p.syntaxErrorAtCur()
+				}
 				stmt = &nodes.ReturnStmt{Returnval: expr, Loc: nodes.Loc{Start: innerRetLoc, End: p.prev.End}}
 			} else {
-				stmt, _ = p.parseStmt()
+				var err error
+				stmt, err = p.parseStmt()
+				if err != nil {
+					return nil, err
+				}
 			}
 			if stmt != nil {
 				stmts = append(stmts, stmt)
@@ -623,7 +712,9 @@ func (p *Parser) parseOptRoutineBody() (nodes.Node, error) {
 				p.advance()
 			}
 		}
-		p.expect(END_P)
+		if _, err := p.expect(END_P); err != nil {
+			return nil, err
+		}
 
 		// Yacc wraps the stmt list in makeList(stmtList):
 		// a single-element list containing the statement list

--- a/pg/parser/function_body_compat_test.go
+++ b/pg/parser/function_body_compat_test.go
@@ -1,0 +1,409 @@
+package parser_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	nodes "github.com/bytebase/omni/pg/ast"
+	pgparser "github.com/bytebase/omni/pg/parser"
+	plpgsqlparser "github.com/bytebase/omni/pg/plpgsql/parser"
+)
+
+func TestCreateFunctionBodyExtractionForms(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		wantLang   string
+		wantBodies []string
+		wantSQLStd bool
+	}{
+		{
+			name:       "as before language",
+			sql:        `CREATE FUNCTION f() RETURNS int AS $$SELECT 1$$ LANGUAGE sql`,
+			wantLang:   "sql",
+			wantBodies: []string{"SELECT 1"},
+		},
+		{
+			name:       "language before tagged dollar body",
+			sql:        `CREATE FUNCTION f() RETURNS int LANGUAGE plpgsql AS $body$BEGIN RETURN 1; END$body$`,
+			wantLang:   "plpgsql",
+			wantBodies: []string{"BEGIN RETURN 1; END"},
+		},
+		{
+			name:       "quoted language and quoted body",
+			sql:        `CREATE FUNCTION f() RETURNS int AS 'SELECT 1' LANGUAGE 'sql'`,
+			wantLang:   "sql",
+			wantBodies: []string{"SELECT 1"},
+		},
+		{
+			name:       "procedure plpgsql body",
+			sql:        `CREATE PROCEDURE p() LANGUAGE plpgsql AS $$BEGIN NULL; END$$`,
+			wantLang:   "plpgsql",
+			wantBodies: []string{"BEGIN NULL; END"},
+		},
+		{
+			name:       "multi string as clause",
+			sql:        `CREATE FUNCTION f() RETURNS int AS 'objfile', 'link_symbol' LANGUAGE c`,
+			wantLang:   "c",
+			wantBodies: []string{"objfile", "link_symbol"},
+		},
+		{
+			name:       "sql standard return body",
+			sql:        `CREATE FUNCTION f() RETURNS int LANGUAGE sql RETURN 1`,
+			wantLang:   "sql",
+			wantSQLStd: true,
+		},
+		{
+			name:       "sql standard atomic body",
+			sql:        `CREATE FUNCTION f() RETURNS int LANGUAGE sql BEGIN ATOMIC RETURN 1; END`,
+			wantLang:   "sql",
+			wantSQLStd: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := parseCreateFunction(t, tt.sql)
+			if got := functionLanguage(fn); got != tt.wantLang {
+				t.Fatalf("language = %q, want %q", got, tt.wantLang)
+			}
+			if got := functionASBodies(fn); !sameStrings(got, tt.wantBodies) {
+				t.Fatalf("AS bodies = %#v, want %#v", got, tt.wantBodies)
+			}
+			if got := fn.SqlBody != nil; got != tt.wantSQLStd {
+				t.Fatalf("SqlBody present = %v, want %v", got, tt.wantSQLStd)
+			}
+		})
+	}
+}
+
+func TestLanguageSQLStringBodyCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"select scalar", `SELECT 1`},
+		{"select parameter", `SELECT $1 + 1`},
+		{"qualified argument reference", `SELECT f.x`},
+		{"cte select", `WITH x AS (SELECT 1 AS a) SELECT a FROM x`},
+		{"insert returning", `INSERT INTO t(id) VALUES (1) RETURNING id`},
+		{"update returning", `UPDATE t SET v = v + 1 WHERE id = 1 RETURNING v`},
+		{"delete returning", `DELETE FROM t WHERE id = 1 RETURNING id`},
+		{"modifying cte", `WITH moved AS (DELETE FROM t WHERE id > 10 RETURNING *) INSERT INTO archive SELECT * FROM moved`},
+		{"multi statement void style", `CREATE TABLE tmp(id int); INSERT INTO tmp VALUES (1); SELECT 1`},
+		{"case expression", `SELECT CASE WHEN $1 > 0 THEN $1 ELSE 0 END`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := "CREATE FUNCTION f(x int) RETURNS int LANGUAGE sql AS $fn$" + tt.body + "$fn$"
+			fn := parseCreateFunction(t, sql)
+			body := singleASBody(t, fn)
+			if _, err := pgparser.Parse(body); err != nil {
+				t.Fatalf("LANGUAGE sql body parse failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestLanguageSQLRejectsPLpgSQLOnlyBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"plpgsql block", `BEGIN RETURN 1; END`},
+		{"declaration block", `DECLARE x int; BEGIN RETURN x; END`},
+		{"if statement", `IF true THEN SELECT 1; END IF`},
+		{"loop statement", `LOOP SELECT 1; END LOOP`},
+		{"exception clause", `EXCEPTION WHEN others THEN SELECT 1`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := "CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $fn$" + tt.body + "$fn$"
+			fn := parseCreateFunction(t, sql)
+			body := singleASBody(t, fn)
+			if _, err := pgparser.Parse(body); err == nil {
+				t.Fatalf("LANGUAGE sql body parsed successfully, want error")
+			}
+		})
+	}
+}
+
+func TestSQLStandardFunctionBodyRejectsMalformedBody(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "return without expression",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE sql RETURN`,
+		},
+		{
+			name: "atomic return without expression",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE sql BEGIN ATOMIC RETURN; END`,
+		},
+		{
+			name: "atomic invalid sql statement",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE sql BEGIN ATOMIC SELECT FROM; END`,
+		},
+		{
+			name: "atomic body missing atomic keyword",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE sql BEGIN RETURN 1; END`,
+		},
+		{
+			name: "atomic body missing end keyword",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE sql BEGIN ATOMIC RETURN 1;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := pgparser.Parse(tt.sql); err == nil {
+				t.Fatalf("Parse succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestCreateFunctionRejectsMalformedOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "as without string body",
+			sql:  `CREATE FUNCTION f() RETURNS int AS LANGUAGE sql`,
+		},
+		{
+			name: "as second string missing",
+			sql:  `CREATE FUNCTION f() RETURNS int AS 'objfile', LANGUAGE c`,
+		},
+		{
+			name: "language without name",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE`,
+		},
+		{
+			name: "language name cannot be AS keyword",
+			sql:  `CREATE FUNCTION f() RETURNS int LANGUAGE AS 'SELECT 1'`,
+		},
+		{
+			name: "transform missing for type",
+			sql:  `CREATE FUNCTION f() RETURNS int TRANSFORM int LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "called missing on",
+			sql:  `CREATE FUNCTION f() RETURNS int CALLED NULL INPUT LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "security missing mode",
+			sql:  `CREATE FUNCTION f() RETURNS int SECURITY LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "not without leakproof",
+			sql:  `CREATE FUNCTION f() RETURNS int NOT STABLE LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "set time missing zone",
+			sql:  `CREATE FUNCTION f() RETURNS int SET TIME 'UTC' LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "set catalog requires string",
+			sql:  `CREATE FUNCTION f() RETURNS int SET CATALOG current_catalog LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "set session requires authorization",
+			sql:  `CREATE FUNCTION f() RETURNS int SET SESSION ROLE LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "set xml requires option",
+			sql:  `CREATE FUNCTION f() RETURNS int SET XML DOCUMENT LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "set transaction requires snapshot",
+			sql:  `CREATE FUNCTION f() RETURNS int SET TRANSACTION 'abc' LANGUAGE sql AS 'SELECT 1'`,
+		},
+		{
+			name: "set from requires current",
+			sql:  `CREATE FUNCTION f() RETURNS int SET search_path FROM 'public' LANGUAGE sql AS 'SELECT 1'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := pgparser.Parse(tt.sql); err == nil {
+				t.Fatalf("Parse succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestLanguagePLpgSQLStringBodyCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"empty block", `BEGIN END`},
+		{"declarations", `DECLARE x character varying(255) := 'a'; y timestamp with time zone; BEGIN NULL; END`},
+		{"assignment", `BEGIN x := y + 1; END`},
+		{"perform", `BEGIN PERFORM do_work(1, 2); END`},
+		{"select into", `BEGIN SELECT a, b INTO x, y FROM t WHERE id = 1; END`},
+		{"returning into", `BEGIN INSERT INTO t(a) VALUES (1) RETURNING id INTO new_id; END`},
+		{"utility sql", `BEGIN REFRESH MATERIALIZED VIEW CONCURRENTLY mv; GRANT USAGE ON SCHEMA api TO web_anon; END`},
+		{"if case", `BEGIN IF x > 0 THEN y := 1; ELSIF x = 0 THEN y := 0; ELSE y := -1; END IF; CASE y WHEN 1 THEN NULL; ELSE NULL; END CASE; END`},
+		{"loops", `BEGIN WHILE x < 10 LOOP x := x + 1; END LOOP; FOR i IN 1..10 BY 2 LOOP NULL; END LOOP; END`},
+		{"query for target list", `BEGIN FOR a, b IN SELECT x, y FROM t LOOP NULL; END LOOP; END`},
+		{"dynamic return query", `BEGIN RETURN QUERY EXECUTE 'SELECT * FROM ' || quote_ident(tbl) USING id; END`},
+		{"exception block", `BEGIN INSERT INTO t VALUES (1); EXCEPTION WHEN unique_violation THEN NULL; WHEN others THEN RAISE; END`},
+		{"cursor", `DECLARE c CURSOR FOR SELECT id FROM t; v int; BEGIN OPEN c; FETCH c INTO v; CLOSE c; END`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := "CREATE FUNCTION f() RETURNS int LANGUAGE plpgsql AS $fn$" + tt.body + "$fn$"
+			fn := parseCreateFunction(t, sql)
+			body := singleASBody(t, fn)
+			if _, err := plpgsqlparser.Parse(body); err != nil {
+				t.Fatalf("LANGUAGE plpgsql body parse failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestLanguagePLpgSQLRejectsMalformedBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"not null without default", `DECLARE x int NOT NULL; BEGIN END`},
+		{"missing end if", `BEGIN IF true THEN NULL; END`},
+		{"for missing loop", `BEGIN FOR i IN 1..10 NULL; END LOOP; END`},
+		{"execute missing query", `BEGIN EXECUTE; END`},
+		{"select into missing target", `BEGIN SELECT 1 INTO; END`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := "CREATE FUNCTION f() RETURNS int LANGUAGE plpgsql AS $fn$" + tt.body + "$fn$"
+			fn := parseCreateFunction(t, sql)
+			body := singleASBody(t, fn)
+			if _, err := plpgsqlparser.Parse(body); err == nil {
+				t.Fatalf("LANGUAGE plpgsql body parsed successfully, want error")
+			}
+		})
+	}
+}
+
+func parseCreateFunction(t *testing.T, sql string) *nodes.CreateFunctionStmt {
+	t.Helper()
+	fn, err := pgParseCreateFunction(sql)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", sql, err)
+	}
+	return fn
+}
+
+func pgParseWithBodyCheck(sql string) (*nodes.CreateFunctionStmt, error) {
+	fn, err := pgParseCreateFunction(sql)
+	if err != nil {
+		return nil, err
+	}
+	bodies := functionASBodies(fn)
+	if len(bodies) != 1 {
+		return fn, nil
+	}
+	switch functionLanguage(fn) {
+	case "sql":
+		if _, err := pgparser.Parse(bodies[0]); err != nil {
+			return nil, err
+		}
+	case "plpgsql":
+		if _, err := plpgsqlparser.Parse(bodies[0]); err != nil {
+			return nil, err
+		}
+	}
+	return fn, nil
+}
+
+func pgParseCreateFunction(sql string) (*nodes.CreateFunctionStmt, error) {
+	stmts, err := pgparser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+	if stmts == nil || len(stmts.Items) != 1 {
+		return nil, fmt.Errorf("expected one statement, got %#v", stmts)
+	}
+	raw, ok := stmts.Items[0].(*nodes.RawStmt)
+	if !ok {
+		return nil, fmt.Errorf("expected RawStmt, got %T", stmts.Items[0])
+	}
+	fn, ok := raw.Stmt.(*nodes.CreateFunctionStmt)
+	if !ok {
+		return nil, fmt.Errorf("expected CreateFunctionStmt, got %T", raw.Stmt)
+	}
+	return fn, nil
+}
+
+func functionLanguage(fn *nodes.CreateFunctionStmt) string {
+	if fn.Options == nil {
+		return ""
+	}
+	for _, item := range fn.Options.Items {
+		d, ok := item.(*nodes.DefElem)
+		if !ok || !strings.EqualFold(d.Defname, "language") {
+			continue
+		}
+		if s, ok := d.Arg.(*nodes.String); ok {
+			return strings.ToLower(s.Str)
+		}
+	}
+	return ""
+}
+
+func functionASBodies(fn *nodes.CreateFunctionStmt) []string {
+	if fn.Options == nil {
+		return nil
+	}
+	for _, item := range fn.Options.Items {
+		d, ok := item.(*nodes.DefElem)
+		if !ok || !strings.EqualFold(d.Defname, "as") {
+			continue
+		}
+		l, ok := d.Arg.(*nodes.List)
+		if !ok {
+			return nil
+		}
+		var out []string
+		for _, body := range l.Items {
+			s, ok := body.(*nodes.String)
+			if !ok {
+				continue
+			}
+			out = append(out, s.Str)
+		}
+		return out
+	}
+	return nil
+}
+
+func singleASBody(t *testing.T, fn *nodes.CreateFunctionStmt) string {
+	t.Helper()
+	bodies := functionASBodies(fn)
+	if len(bodies) != 1 {
+		t.Fatalf("expected exactly one AS body, got %#v", bodies)
+	}
+	return bodies[0]
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pg/parser/function_body_reference_oracle_test.go
+++ b/pg/parser/function_body_reference_oracle_test.go
@@ -1,0 +1,201 @@
+//go:build oracle
+
+package parser_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	tcpg "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestFunctionBodyReferenceOracle(t *testing.T) {
+	db, cleanup := startFunctionBodyOracle(t)
+	defer cleanup()
+
+	fixtures := []string{
+		`SET check_function_bodies = on`,
+		`CREATE TABLE t(id int PRIMARY KEY, v int)`,
+		`CREATE TABLE archive(id int, v int)`,
+		`CREATE SCHEMA api`,
+		`CREATE MATERIALIZED VIEW mv AS SELECT 1 AS id`,
+	}
+	for _, sql := range fixtures {
+		if _, err := db.ExecContext(context.Background(), sql); err != nil {
+			t.Fatalf("fixture %q: %v", sql, err)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		sql    string
+		accept bool
+	}{
+		{
+			name:   "language sql select body",
+			sql:    `CREATE FUNCTION ref_sql_select(x int) RETURNS int LANGUAGE sql AS $$ SELECT x + 1 $$`,
+			accept: true,
+		},
+		{
+			name:   "language sql dml returning body",
+			sql:    `CREATE FUNCTION ref_sql_insert() RETURNS int LANGUAGE sql AS $$ INSERT INTO t(id, v) VALUES (1, 1) RETURNING id $$`,
+			accept: true,
+		},
+		{
+			name:   "language sql rejects plpgsql if",
+			sql:    `CREATE FUNCTION ref_sql_bad_if() RETURNS int LANGUAGE sql AS $$ IF true THEN SELECT 1; END IF $$`,
+			accept: false,
+		},
+		{
+			name:   "language plpgsql returning into",
+			sql:    `CREATE FUNCTION ref_plpgsql_returning() RETURNS int LANGUAGE plpgsql AS $$ DECLARE x int; BEGIN INSERT INTO t(id, v) VALUES (2, 2) RETURNING id INTO x; RETURN x; END $$`,
+			accept: true,
+		},
+		{
+			name:   "language plpgsql utility sql",
+			sql:    `CREATE FUNCTION ref_plpgsql_utility() RETURNS void LANGUAGE plpgsql AS $$ BEGIN REFRESH MATERIALIZED VIEW mv; GRANT USAGE ON SCHEMA api TO public; END $$`,
+			accept: true,
+		},
+		{
+			name:   "language plpgsql rejects missing into target",
+			sql:    `CREATE FUNCTION ref_plpgsql_bad_into() RETURNS int LANGUAGE plpgsql AS $$ BEGIN SELECT 1 INTO; END $$`,
+			accept: false,
+		},
+		{
+			name:   "sql standard return body",
+			sql:    `CREATE FUNCTION ref_sql_standard_return() RETURNS int LANGUAGE sql RETURN 1`,
+			accept: true,
+		},
+		{
+			name:   "sql standard rejects malformed atomic body",
+			sql:    `CREATE FUNCTION ref_sql_standard_bad() RETURNS int LANGUAGE sql BEGIN ATOMIC SELECT FROM; END`,
+			accept: false,
+		},
+		{
+			name:   "sql standard rejects missing atomic keyword",
+			sql:    `CREATE FUNCTION ref_sql_standard_missing_atomic() RETURNS int LANGUAGE sql BEGIN RETURN 1; END`,
+			accept: false,
+		},
+		{
+			name:   "sql standard rejects missing end keyword",
+			sql:    `CREATE FUNCTION ref_sql_standard_missing_end() RETURNS int LANGUAGE sql BEGIN ATOMIC RETURN 1;`,
+			accept: false,
+		},
+		{
+			name:   "rejects AS without string body",
+			sql:    `CREATE FUNCTION ref_bad_as() RETURNS int AS LANGUAGE sql`,
+			accept: false,
+		},
+		{
+			name:   "rejects LANGUAGE without name",
+			sql:    `CREATE FUNCTION ref_bad_language() RETURNS int LANGUAGE`,
+			accept: false,
+		},
+		{
+			name:   "rejects malformed TRANSFORM clause",
+			sql:    `CREATE FUNCTION ref_bad_transform() RETURNS int TRANSFORM int LANGUAGE sql AS 'SELECT 1'`,
+			accept: false,
+		},
+		{
+			name:   "rejects malformed SECURITY clause",
+			sql:    `CREATE FUNCTION ref_bad_security() RETURNS int SECURITY LANGUAGE sql AS 'SELECT 1'`,
+			accept: false,
+		},
+		{
+			name:   "rejects malformed SET TIME clause",
+			sql:    `CREATE FUNCTION ref_bad_set_time() RETURNS int SET TIME 'UTC' LANGUAGE sql AS 'SELECT 1'`,
+			accept: false,
+		},
+		{
+			name:   "rejects malformed SET SESSION clause",
+			sql:    `CREATE FUNCTION ref_bad_set_session() RETURNS int SET SESSION ROLE LANGUAGE sql AS 'SELECT 1'`,
+			accept: false,
+		},
+		{
+			name:   "rejects malformed SET FROM clause",
+			sql:    `CREATE FUNCTION ref_bad_set_from() RETURNS int SET search_path FROM 'public' LANGUAGE sql AS 'SELECT 1'`,
+			accept: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, omniErr := pgParseWithBodyCheck(tt.sql)
+			omniAccept := omniErr == nil
+			if omniAccept != tt.accept {
+				t.Fatalf("omni accept = %v, want %v, err=%v", omniAccept, tt.accept, omniErr)
+			}
+
+			_, pgErr := db.ExecContext(context.Background(), tt.sql)
+			pgAccept := pgErr == nil
+			if pgAccept != tt.accept {
+				t.Fatalf("postgres accept = %v, want %v, err=%v", pgAccept, tt.accept, pgErr)
+			}
+		})
+	}
+}
+
+func startFunctionBodyOracle(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	var setupErr error
+	var container *tcpg.PostgresContainer
+
+	ctx := context.Background()
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				setupErr = fmt.Errorf("docker provider panic: %v", r)
+			}
+		}()
+		var err error
+		container, err = tcpg.Run(ctx, "postgres:17-alpine",
+			tcpg.WithDatabase("omni_body"),
+			tcpg.WithUsername("postgres"),
+			tcpg.WithPassword("test"),
+			testcontainers.WithWaitStrategy(
+				wait.ForLog("database system is ready to accept connections").
+					WithOccurrence(2)),
+		)
+		if err != nil {
+			setupErr = fmt.Errorf("container start: %w", err)
+		}
+	}()
+	if setupErr != nil {
+		if isFunctionBodyOracleCI() {
+			t.Fatalf("function body oracle unavailable in CI: %v", setupErr)
+		}
+		t.Skipf("function body oracle unavailable (local dev): %v", setupErr)
+	}
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = testcontainers.TerminateContainer(container)
+		t.Fatalf("conn string: %v", err)
+	}
+	db, err := sql.Open("pgx", connStr)
+	if err != nil {
+		_ = testcontainers.TerminateContainer(container)
+		t.Fatalf("db open: %v", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		_ = testcontainers.TerminateContainer(container)
+		t.Fatalf("ping: %v", err)
+	}
+
+	cleanup := func() {
+		db.Close()
+		_ = testcontainers.TerminateContainer(container)
+	}
+	return db, cleanup
+}
+
+func isFunctionBodyOracleCI() bool {
+	return os.Getenv("CI") == "true" || os.Getenv("CI") == "1"
+}

--- a/pg/parser/set.go
+++ b/pg/parser/set.go
@@ -81,8 +81,12 @@ func (p *Parser) parseSetRest() (nodes.Node, error) {
 		if next.Type == CHARACTERISTICS {
 			p.advance() // consume SESSION
 			p.advance() // consume CHARACTERISTICS
-			p.expect(AS)
-			p.expect(TRANSACTION)
+			if _, err := p.expect(AS); err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(TRANSACTION); err != nil {
+				return nil, err
+			}
 			modes, _ := p.parseTransactionModeListOrEmpty()
 			return &nodes.VariableSetStmt{
 				Kind: nodes.VAR_SET_MULTI,
@@ -117,8 +121,14 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 	switch p.cur.Type {
 	case TIME:
 		p.advance() // consume TIME
-		p.expect(ZONE)
+		if _, err := p.expect(ZONE); err != nil {
+			return nil, err
+		}
+		zoneType := p.cur.Type
 		val := p.parseZoneValue()
+		if val == nil && zoneType != DEFAULT && zoneType != LOCAL {
+			return nil, p.syntaxErrorAtCur()
+		}
 		n := &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_VALUE,
 			Name: "timezone",
@@ -135,7 +145,9 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 		// PostgreSQL parses this but rejects it at execution time.
 		p.advance() // consume CATALOG
 		s := p.cur.Str
-		p.expect(SCONST)
+		if _, err := p.expect(SCONST); err != nil {
+			return nil, err
+		}
 		return &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_VALUE,
 			Name: "catalog",
@@ -145,7 +157,9 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 	case SCHEMA:
 		p.advance() // consume SCHEMA
 		s := p.cur.Str
-		p.expect(SCONST)
+		if _, err := p.expect(SCONST); err != nil {
+			return nil, err
+		}
 		return &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_VALUE,
 			Name: "search_path",
@@ -173,7 +187,10 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 			return p.parseGenericSetOrFromCurrent()
 		}
 		p.advance() // consume ROLE
-		val := p.parseNonReservedWordOrSconst()
+		val, err := p.parseSetNonReservedWordOrSconst()
+		if err != nil {
+			return nil, err
+		}
 		return &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_VALUE,
 			Name: "role",
@@ -183,7 +200,9 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 	case SESSION:
 		// SESSION AUTHORIZATION NonReservedWord_or_Sconst | SESSION AUTHORIZATION DEFAULT
 		p.advance() // consume SESSION
-		p.expect(AUTHORIZATION)
+		if _, err := p.expect(AUTHORIZATION); err != nil {
+			return nil, err
+		}
 		if p.cur.Type == DEFAULT {
 			p.advance()
 			return &nodes.VariableSetStmt{
@@ -191,7 +210,10 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 				Name: "session_authorization",
 			}, nil
 		}
-		val := p.parseNonReservedWordOrSconst()
+		val, err := p.parseSetNonReservedWordOrSconst()
+		if err != nil {
+			return nil, err
+		}
 		return &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_VALUE,
 			Name: "session_authorization",
@@ -200,8 +222,13 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 
 	case XML_P:
 		p.advance() // consume XML
-		p.expect(OPTION)
-		docOrContent, _ := p.parseDocumentOrContent()
+		if _, err := p.expect(OPTION); err != nil {
+			return nil, err
+		}
+		docOrContent, err := p.parseDocumentOrContent()
+		if err != nil {
+			return nil, err
+		}
 		var val string
 		if docOrContent == int64(nodes.XMLOPTION_DOCUMENT) {
 			val = "DOCUMENT"
@@ -217,9 +244,13 @@ func (p *Parser) parseSetRestMore() (nodes.Node, error) {
 	case TRANSACTION:
 		// TRANSACTION SNAPSHOT Sconst
 		p.advance() // consume TRANSACTION
-		p.expect(SNAPSHOT)
+		if _, err := p.expect(SNAPSHOT); err != nil {
+			return nil, err
+		}
 		s := p.cur.Str
-		p.expect(SCONST)
+		if _, err := p.expect(SCONST); err != nil {
+			return nil, err
+		}
 		return &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_MULTI,
 			Name: "TRANSACTION SNAPSHOT",
@@ -254,7 +285,9 @@ func (p *Parser) parseGenericSetOrFromCurrent() (nodes.Node, error) {
 	case FROM:
 		// var_name FROM CURRENT_P
 		p.advance() // consume FROM
-		p.expect(CURRENT_P)
+		if _, err := p.expect(CURRENT_P); err != nil {
+			return nil, err
+		}
 		return &nodes.VariableSetStmt{
 			Kind: nodes.VAR_SET_CURRENT,
 			Name: varName,
@@ -286,6 +319,15 @@ func (p *Parser) parseGenericSetOrFromCurrent() (nodes.Node, error) {
 	default:
 		return nil, p.syntaxErrorAtCur()
 	}
+}
+
+func (p *Parser) parseSetNonReservedWordOrSconst() (string, error) {
+	if p.cur.Type == SCONST || p.cur.Type == IDENT || p.cur.Type == DEFAULT || p.isNonReservedWord() {
+		s := p.cur.Str
+		p.advance()
+		return s, nil
+	}
+	return "", p.syntaxErrorAtCur()
 }
 
 // parseVarName parses a dotted variable name.
@@ -660,7 +702,7 @@ func (p *Parser) parseVariableResetStmt() (nodes.Node, error) {
 //	| IMMEDIATE
 func (p *Parser) parseConstraintsSetStmt() (nodes.Node, error) {
 	loc := p.prev.Loc // SET was already consumed
-	p.advance() // consume CONSTRAINTS
+	p.advance()       // consume CONSTRAINTS
 
 	var constraints *nodes.List
 	if p.cur.Type == ALL {
@@ -717,7 +759,7 @@ func (p *Parser) parseConstraintsNameList() *nodes.List {
 //	ALTER SYSTEM RESET ALL
 func (p *Parser) parseAlterSystemStmt() (nodes.Node, error) {
 	loc := p.prev.Loc // ALTER was already consumed
-	p.advance() // consume SYSTEM_P
+	p.advance()       // consume SYSTEM_P
 
 	switch p.cur.Type {
 	case SET:

--- a/pg/pgregress/extract.go
+++ b/pg/pgregress/extract.go
@@ -239,6 +239,7 @@ func splitStatements(filename string, lines []processedLine) []ExtractedStmt {
 	inCopyData := false
 	parenDepth := 0         // tracks nesting depth of (...) in normal SQL
 	atomicDepth := 0        // tracks nesting depth of BEGIN ATOMIC ... END blocks
+	atomicCaseDepth := 0    // tracks CASE ... END expressions inside BEGIN ATOMIC
 	lastWord := ""          // previous completed word (uppercase)
 	currentWord := []byte{} // word currently being accumulated
 
@@ -254,8 +255,14 @@ func splitStatements(filename string, lines []processedLine) []ExtractedStmt {
 
 		if word == "ATOMIC" && lastWord == "BEGIN" {
 			atomicDepth++
+		} else if word == "CASE" && atomicDepth > 0 {
+			atomicCaseDepth++
 		} else if word == "END" && atomicDepth > 0 && parenDepth == 0 {
-			atomicDepth--
+			if atomicCaseDepth > 0 {
+				atomicCaseDepth--
+			} else {
+				atomicDepth--
+			}
 		}
 		lastWord = word
 	}
@@ -280,6 +287,7 @@ func splitStatements(filename string, lines []processedLine) []ExtractedStmt {
 		stmtStartLine = 0
 		parenDepth = 0
 		atomicDepth = 0
+		atomicCaseDepth = 0
 		lastWord = ""
 		currentWord = currentWord[:0]
 	}

--- a/pg/pgregress/extract_test.go
+++ b/pg/pgregress/extract_test.go
@@ -111,6 +111,25 @@ func TestExtract_DollarQuoteWithTag(t *testing.T) {
 	}
 }
 
+func TestExtract_BeginAtomicWithCaseExpression(t *testing.T) {
+	input := `CREATE FUNCTION f(x int) RETURNS boolean
+LANGUAGE SQL
+BEGIN ATOMIC
+    select case when x % 2 = 0 then true else false end;
+END;
+SELECT 1;`
+	stmts := ExtractStatements("test.sql", []byte(input))
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 statements, got %d: %v", len(stmts), stmtsSQL(stmts))
+	}
+	if !strings.Contains(stmts[0].SQL, "case when") || !strings.Contains(stmts[0].SQL, "END") {
+		t.Fatalf("first statement was split incorrectly: %q", stmts[0].SQL)
+	}
+	if stmts[1].SQL != "SELECT 1" {
+		t.Fatalf("stmt[1] = %q, want SELECT 1", stmts[1].SQL)
+	}
+}
+
 func TestExtract_NestedDollarQuote(t *testing.T) {
 	input := "DO $$ BEGIN EXECUTE $q$ SELECT 1; $q$; END $$;"
 	stmts := ExtractStatements("test.sql", []byte(input))

--- a/pg/plpgsql/parser/decl.go
+++ b/pg/plpgsql/parser/decl.go
@@ -182,39 +182,50 @@ func (p *Parser) parseDeclTypeName() (string, error) {
 	}
 
 	start := p.pos()
-	p.advance() // consume first part of type name
 
-	// Check for dot-qualified name (schema.type or table.column)
-	for p.cur.Type == '.' {
-		p.advance() // consume '.'
-		if !p.isIdent() && !p.isAnyKeywordAsIdent() {
-			return "", p.errorf("syntax error at or near %q, expected identifier after '.'", p.tokenText(p.cur))
+	var closers []int
+	for !p.isEOF() {
+		if len(closers) == 0 {
+			if p.cur.Type == ',' || p.cur.Type == ')' || p.cur.Type == ';' ||
+				p.cur.Type == pgparser.COLON_EQUALS || p.cur.Type == '=' ||
+				p.isKeyword("COLLATE") || p.isKeyword("NOT") || p.isKeyword("DEFAULT") {
+				break
+			}
 		}
-		p.advance() // consume next part
-	}
 
-	// Check for %TYPE or %ROWTYPE
-	// The % token comes through as ASCII char 37, not as an Op
-	if p.cur.Type == '%' {
-		p.advance() // consume %
-		if p.isKeyword("TYPE") || p.isKeyword("ROWTYPE") {
+		switch p.cur.Type {
+		case '(':
+			closers = append(closers, ')')
 			p.advance()
-		} else {
+			continue
+		case '[':
+			closers = append(closers, ']')
+			p.advance()
+			continue
+		case ')', ']':
+			if len(closers) == 0 {
+				return "", p.errorf("syntax error at or near %q, unexpected closing delimiter", p.tokenText(p.cur))
+			}
+			want := closers[len(closers)-1]
+			if p.cur.Type != want {
+				return "", p.errorf("syntax error at or near %q, expected closing delimiter", p.tokenText(p.cur))
+			}
+			closers = closers[:len(closers)-1]
+			p.advance()
+			continue
+		case '%':
+			p.advance()
+			if p.isKeyword("TYPE") || p.isKeyword("ROWTYPE") {
+				p.advance()
+				continue
+			}
 			return "", p.errorf("syntax error at or near %q, expected TYPE or ROWTYPE after %%", p.tokenText(p.cur))
 		}
-	}
 
-	// Check for array brackets []
-	if p.cur.Type == '[' {
-		p.advance() // consume [
-		// Optional dimension
-		if p.cur.Type == pgparser.ICONST {
-			p.advance()
-		}
-		if p.cur.Type != ']' {
-			return "", p.errorf("syntax error at or near %q, expected ]", p.tokenText(p.cur))
-		}
-		p.advance() // consume ]
+		p.advance()
+	}
+	if len(closers) > 0 {
+		return "", p.errorf("syntax error at or near %q, expected closing delimiter", p.tokenText(p.cur))
 	}
 
 	typeName := strings.TrimSpace(p.source[start:p.prev.End])

--- a/pg/plpgsql/parser/decl_test.go
+++ b/pg/plpgsql/parser/decl_test.go
@@ -20,6 +20,9 @@ func TestDeclScalar(t *testing.T) {
 		{"scalar integer", "DECLARE x integer; BEGIN END", "x", "integer"},
 		{"record type", "DECLARE r record; BEGIN END", "r", "record"},
 		{"qualified type", "DECLARE x public.my_type; BEGIN END", "x", "public.my_type"},
+		{"multiword type", "DECLARE x character varying; BEGIN END", "x", "character varying"},
+		{"parameterized type", "DECLARE x character varying(255); BEGIN END", "x", "character varying(255)"},
+		{"timestamp type", "DECLARE x timestamp with time zone; BEGIN END", "x", "timestamp with time zone"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,6 +150,23 @@ func TestDeclTypeRef(t *testing.T) {
 			if d.TypeName != tt.wantType {
 				t.Errorf("type: want %q, got %q", tt.wantType, d.TypeName)
 			}
+		})
+	}
+}
+
+func TestDeclRejectsMalformedTypeName(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"bad percent type ref", "DECLARE x my_table%BAD; BEGIN END", "expected TYPE or ROWTYPE"},
+		{"unclosed typmod", "DECLARE x numeric(10; BEGIN END", "expected closing delimiter"},
+		{"unclosed array", "DECLARE x integer[; BEGIN END", "expected closing delimiter"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parseErr(t, tt.body, tt.want)
 		})
 	}
 }

--- a/pg/plpgsql/parser/loop.go
+++ b/pg/plpgsql/parser/loop.go
@@ -101,12 +101,10 @@ func (p *Parser) parseFor(label string) (ast.Node, error) {
 	startPos := p.pos()
 	p.advance() // consume FOR
 
-	// Parse loop variable name
-	if !p.isIdent() && !p.isAnyKeywordAsIdent() {
-		return nil, p.errorf("syntax error at or near %q, expected loop variable name", p.tokenText(p.cur))
+	varName, err := p.parseForTargetList()
+	if err != nil {
+		return nil, err
 	}
-	varName := p.identText()
-	p.advance()
 
 	// Expect IN
 	if err := p.expectKeyword("IN"); err != nil {
@@ -129,12 +127,54 @@ func (p *Parser) parseFor(label string) (ast.Node, error) {
 		return p.parseForDynamic(label, varName, startPos)
 	}
 
-	if p.isKeyword("SELECT") || p.isKeyword("WITH") {
+	if p.isKeyword("SELECT") || p.isKeyword("WITH") || p.isParenthesizedQueryStart() {
 		return p.parseForQuery(label, varName, startPos)
 	}
 
 	// Collect tokens until LOOP, looking for DOT_DOT to disambiguate integer vs cursor
 	return p.parseForIntOrCursor(label, varName, reverse, startPos)
+}
+
+func (p *Parser) isParenthesizedQueryStart() bool {
+	if p.cur.Type != '(' {
+		return false
+	}
+	next := p.peekNext()
+	return next.Type == pgparser.SELECT || next.Type == pgparser.WITH ||
+		next.Type == pgparser.VALUES || next.Type == pgparser.TABLE
+}
+
+// parseForTargetList parses the target before IN in a FOR statement. Query FOR
+// accepts a record/row target or a comma-separated scalar-variable list.
+func (p *Parser) parseForTargetList() (string, error) {
+	if !p.isIdent() && !p.isAnyKeywordAsIdent() {
+		return "", p.errorf("syntax error at or near %q, expected loop variable name", p.tokenText(p.cur))
+	}
+	start := p.pos()
+	depth := 0
+	for !p.isEOF() {
+		if p.cur.Type == '(' || p.cur.Type == '[' {
+			depth++
+			p.advance()
+			continue
+		}
+		if p.cur.Type == ')' || p.cur.Type == ']' {
+			if depth > 0 {
+				depth--
+			}
+			p.advance()
+			continue
+		}
+		if depth == 0 && p.isKeyword("IN") {
+			break
+		}
+		p.advance()
+	}
+	target := strings.TrimSpace(p.source[start:p.prev.End])
+	if target == "" {
+		return "", p.errorf("syntax error at or near %q, expected loop variable name", p.tokenText(p.cur))
+	}
+	return target, nil
 }
 
 // parseForDynamic parses: FOR rec IN EXECUTE expr [USING params] LOOP stmts END LOOP [label] ;
@@ -281,6 +321,10 @@ func (p *Parser) parseForIntOrCursor(label, varName string, reverse bool, startP
 	}
 
 	if hasDotDot {
+		if hasTopLevelComma(varName) {
+			return nil, p.errorf("syntax error at or near %q, expected single loop variable", varName)
+		}
+
 		// Integer FOR: lower..upper [BY step]
 		lower := strings.TrimSpace(p.source[exprStart:p.cur.Loc])
 		p.advance() // consume DOT_DOT
@@ -329,6 +373,9 @@ func (p *Parser) parseForIntOrCursor(label, varName string, reverse bool, startP
 
 	// Cursor FOR: the tokens we collected form the cursor variable name,
 	// possibly followed by (args)
+	if hasTopLevelComma(varName) {
+		return nil, p.errorf("syntax error at or near %q, expected single loop variable", varName)
+	}
 	cursorText := strings.TrimSpace(p.source[exprStart:p.cur.Loc])
 
 	// Parse cursor variable name and optional args from the collected text
@@ -369,6 +416,25 @@ func (p *Parser) parseForIntOrCursor(label, varName string, reverse bool, startP
 		Body:      body,
 		Loc:       ast.Loc{Start: startPos, End: p.prev.End},
 	}, nil
+}
+
+func hasTopLevelComma(text string) bool {
+	depth := 0
+	for _, r := range text {
+		switch r {
+		case '(', '[':
+			depth++
+		case ')', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // parseForEach parses: FOREACH var [SLICE n] IN ARRAY expr LOOP stmts END LOOP [label] ;

--- a/pg/plpgsql/parser/loop_test.go
+++ b/pg/plpgsql/parser/loop_test.go
@@ -229,6 +229,10 @@ func TestForIntegerExprBounds(t *testing.T) {
 	}
 }
 
+func TestForIntegerRejectsTargetList(t *testing.T) {
+	parseErr(t, `BEGIN FOR a, b IN 1..10 LOOP NULL; END LOOP; END`, "expected single loop variable")
+}
+
 func TestForQuery(t *testing.T) {
 	// Query FOR: FOR rec IN SELECT * FROM t LOOP x := rec.a; END LOOP;
 	block := parseOK(t, `BEGIN FOR rec IN SELECT * FROM t LOOP x := rec.a; END LOOP; END`)
@@ -253,6 +257,34 @@ func TestForQueryComplex(t *testing.T) {
 	f := block.Body[0].(*ast.PLForS)
 	if f.Query != "SELECT a, b FROM t WHERE c > 0 ORDER BY a" {
 		t.Errorf("unexpected query %q", f.Query)
+	}
+}
+
+func TestForQueryTargetList(t *testing.T) {
+	block := parseOK(t, `BEGIN FOR a, b IN SELECT x, y FROM t LOOP NULL; END LOOP; END`)
+	f, ok := block.Body[0].(*ast.PLForS)
+	if !ok {
+		t.Fatalf("expected PLForS, got %T", block.Body[0])
+	}
+	if f.Var != "a, b" {
+		t.Errorf("expected var 'a, b', got %q", f.Var)
+	}
+	if f.Query != "SELECT x, y FROM t" {
+		t.Errorf("expected query 'SELECT x, y FROM t', got %q", f.Query)
+	}
+}
+
+func TestForQueryParenthesizedTargetList(t *testing.T) {
+	block := parseOK(t, `BEGIN FOR a, b IN (SELECT x, y FROM t) LOOP NULL; END LOOP; END`)
+	f, ok := block.Body[0].(*ast.PLForS)
+	if !ok {
+		t.Fatalf("expected PLForS, got %T", block.Body[0])
+	}
+	if f.Var != "a, b" {
+		t.Errorf("expected var 'a, b', got %q", f.Var)
+	}
+	if f.Query != "(SELECT x, y FROM t)" {
+		t.Errorf("expected query '(SELECT x, y FROM t)', got %q", f.Query)
 	}
 }
 
@@ -287,6 +319,10 @@ func TestForCursorWithArgs(t *testing.T) {
 	if f.ArgQuery != "1, 'a'" {
 		t.Errorf("expected arg query \"1, 'a'\", got %q", f.ArgQuery)
 	}
+}
+
+func TestForCursorRejectsTargetList(t *testing.T) {
+	parseErr(t, `BEGIN FOR a, b IN cur LOOP NULL; END LOOP; END`, "expected single loop variable")
 }
 
 func TestForDynamic(t *testing.T) {

--- a/pg/plpgsql/parser/parser.go
+++ b/pg/plpgsql/parser/parser.go
@@ -607,9 +607,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		return p.parseFetch()
 	case p.isKeyword("MOVE"):
 		return p.parseMove()
-	case p.cur.Type == pgparser.INSERT || p.cur.Type == pgparser.UPDATE ||
-		p.cur.Type == pgparser.DELETE_P || p.cur.Type == pgparser.SELECT ||
-		p.cur.Type == pgparser.MERGE || p.isKeyword("IMPORT"):
+	case p.isSQLCommandStart():
 		return p.parseExecSQL()
 	}
 
@@ -619,6 +617,31 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	}
 
 	return nil, p.errorf("syntax error at or near %q", p.tokenText(p.cur))
+}
+
+// isSQLCommandStart reports whether the current token can start a PostgreSQL
+// SQL command inside PL/pgSQL. PL/pgSQL explicitly handles its own statement
+// keywords before this fallback; PostgreSQL's PL/pgSQL docs say anything not
+// recognized as a PL/pgSQL statement is presumed to be an SQL command.
+func (p *Parser) isSQLCommandStart() bool {
+	switch p.cur.Type {
+	case pgparser.SELECT, pgparser.VALUES, pgparser.TABLE, pgparser.WITH,
+		pgparser.INSERT, pgparser.UPDATE, pgparser.DELETE_P, pgparser.MERGE,
+		pgparser.CREATE, pgparser.COMMENT, pgparser.SECURITY, pgparser.ALTER,
+		pgparser.REFRESH, pgparser.BEGIN_P, pgparser.START, pgparser.COMMIT,
+		pgparser.END_P, pgparser.ABORT_P, pgparser.SAVEPOINT, pgparser.RELEASE,
+		pgparser.ROLLBACK, pgparser.PREPARE, pgparser.EXECUTE, pgparser.DEALLOCATE,
+		pgparser.SET, pgparser.SHOW, pgparser.RESET, pgparser.GRANT, pgparser.REVOKE,
+		pgparser.DROP, pgparser.TRUNCATE, pgparser.LOCK_P, pgparser.DECLARE,
+		pgparser.FETCH, pgparser.MOVE, pgparser.CLOSE, pgparser.VACUUM,
+		pgparser.ANALYZE, pgparser.ANALYSE, pgparser.CLUSTER, pgparser.REINDEX,
+		pgparser.COPY, pgparser.IMPORT_P, pgparser.EXPLAIN, pgparser.DO,
+		pgparser.CHECKPOINT, pgparser.DISCARD, pgparser.LISTEN, pgparser.UNLISTEN,
+		pgparser.NOTIFY, pgparser.LOAD, pgparser.CALL, pgparser.REASSIGN:
+		return true
+	default:
+		return false
+	}
 }
 
 // parseIf, parseCase are implemented in control.go

--- a/pg/plpgsql/parser/stmt.go
+++ b/pg/plpgsql/parser/stmt.go
@@ -287,24 +287,21 @@ func (p *Parser) parsePerform() (ast.Node, error) {
 	}, nil
 }
 
-// parseExecSQL parses an inline SQL statement (INSERT, UPDATE, DELETE, SELECT, MERGE, IMPORT).
+// parseExecSQL parses an inline SQL statement (INSERT, UPDATE, DELETE, SELECT, MERGE, WITH, IMPORT).
 //
 // Ref: https://www.postgresql.org/docs/17/plpgsql-statements.html#PLPGSQL-STATEMENTS-SQL-ONEROW
 //
 //	sql_statement [ INTO [STRICT] target [, ...] ] ;
 //
-// For SELECT statements, INTO [STRICT] can appear after the select list
-// (e.g., SELECT a, b INTO [STRICT] x, y FROM t WHERE ...).
+// For SELECT statements, INTO [STRICT] can appear after the select list.
+// For INSERT/UPDATE/DELETE/MERGE, INTO [STRICT] applies after RETURNING.
 func (p *Parser) parseExecSQL() (ast.Node, error) {
 	startPos := p.pos()
 
-	// Determine if this is a SELECT (which may have INTO inside it)
-	isSelect := (p.cur.Type == pgparser.SELECT)
-
 	// Collect the entire SQL statement while tracking INTO within it.
-	// For SELECT, we detect INTO within the statement (between SELECT columns and FROM).
-	// For other statements, INTO does not appear inline.
-	sqlText, into, strict, err := p.collectSQLWithInto(isSelect)
+	// PL/pgSQL INTO is not the same as SQL's INSERT INTO, so detection is
+	// enabled only after a top-level SELECT or top-level RETURNING clause.
+	sqlText, into, strict, err := p.collectSQLWithInto()
 	if err != nil {
 		return nil, err
 	}
@@ -322,10 +319,12 @@ func (p *Parser) parseExecSQL() (ast.Node, error) {
 }
 
 // collectSQLWithInto collects an SQL statement text until semicolon,
-// while detecting INTO [STRICT] target within SELECT statements.
-// For SELECT: INTO can appear after the select list (before FROM, WHERE, etc.)
+// while detecting PL/pgSQL INTO [STRICT] target clauses.
+// SELECT can place INTO after the select list. Row-returning DML places INTO
+// after RETURNING. WITH is handled by observing the top-level command that
+// follows the CTE list, while nested CTE query text is ignored by depth.
 // The INTO clause is extracted from the SQL text and the remaining SQL is reassembled.
-func (p *Parser) collectSQLWithInto(isSelect bool) (string, []string, bool, error) {
+func (p *Parser) collectSQLWithInto() (string, []string, bool, error) {
 	start := p.pos()
 	depth := 0
 	var into []string
@@ -333,7 +332,7 @@ func (p *Parser) collectSQLWithInto(isSelect bool) (string, []string, bool, erro
 	intoStart := -1
 	intoEnd := -1
 
-	// Track whether we've seen INTO for this SELECT
+	intoAllowed := false
 	foundInto := false
 
 	for !p.isEOF() {
@@ -353,8 +352,17 @@ func (p *Parser) collectSQLWithInto(isSelect bool) (string, []string, bool, erro
 			break
 		}
 
-		// Detect INTO at depth 0 in SELECT statements
-		if isSelect && depth == 0 && !foundInto && p.isKeyword("INTO") {
+		if depth == 0 {
+			switch p.cur.Type {
+			case pgparser.SELECT, pgparser.RETURNING:
+				intoAllowed = true
+			case pgparser.INSERT, pgparser.UPDATE, pgparser.DELETE_P, pgparser.MERGE:
+				intoAllowed = false
+			}
+		}
+
+		// Detect PL/pgSQL INTO at depth 0 after SELECT or RETURNING.
+		if intoAllowed && depth == 0 && !foundInto && p.isKeyword("INTO") {
 			intoStart = p.cur.Loc
 			p.advance() // consume INTO
 
@@ -365,6 +373,7 @@ func (p *Parser) collectSQLWithInto(isSelect bool) (string, []string, bool, erro
 			}
 
 			// Parse comma-separated target identifiers
+			targetStart := len(into)
 			for {
 				if !p.isIdent() && !p.isAnyKeywordAsIdent() {
 					break
@@ -383,6 +392,9 @@ func (p *Parser) collectSQLWithInto(isSelect bool) (string, []string, bool, erro
 				} else {
 					break
 				}
+			}
+			if len(into) == targetStart {
+				return "", nil, false, p.errorf("syntax error at or near %q, expected identifier", p.tokenText(p.cur))
 			}
 			intoEnd = p.cur.Loc
 			foundInto = true

--- a/pg/plpgsql/parser/stmt_test.go
+++ b/pg/plpgsql/parser/stmt_test.go
@@ -294,6 +294,97 @@ func TestBareSQLDelete(t *testing.T) {
 	}
 }
 
+func TestBareSQLWithSelectInto(t *testing.T) {
+	block := parseOK(t, `BEGIN WITH rows AS (SELECT 1 AS id) SELECT id INTO result FROM rows; END`)
+	exec, ok := block.Body[0].(*ast.PLExecSQL)
+	if !ok {
+		t.Fatalf("expected PLExecSQL, got %T", block.Body[0])
+	}
+	if len(exec.Into) != 1 || exec.Into[0] != "result" {
+		t.Errorf("into = %v, want [result]", exec.Into)
+	}
+	if exec.SQLText != "WITH rows AS (SELECT 1 AS id) SELECT id FROM rows" {
+		t.Errorf("sql = %q, want %q", exec.SQLText, "WITH rows AS (SELECT 1 AS id) SELECT id FROM rows")
+	}
+}
+
+func TestBareSQLWithInsertDoesNotExtractInsertInto(t *testing.T) {
+	block := parseOK(t, `BEGIN WITH rows AS (SELECT 1 AS id) INSERT INTO t SELECT id FROM rows; END`)
+	exec, ok := block.Body[0].(*ast.PLExecSQL)
+	if !ok {
+		t.Fatalf("expected PLExecSQL, got %T", block.Body[0])
+	}
+	if len(exec.Into) != 0 {
+		t.Errorf("into = %v, want empty", exec.Into)
+	}
+	if exec.SQLText != "WITH rows AS (SELECT 1 AS id) INSERT INTO t SELECT id FROM rows" {
+		t.Errorf("sql = %q, want %q", exec.SQLText, "WITH rows AS (SELECT 1 AS id) INSERT INTO t SELECT id FROM rows")
+	}
+}
+
+func TestBareSQLInsertReturningInto(t *testing.T) {
+	block := parseOK(t, `BEGIN INSERT INTO t (a) VALUES (1) RETURNING id INTO new_id; END`)
+	exec, ok := block.Body[0].(*ast.PLExecSQL)
+	if !ok {
+		t.Fatalf("expected PLExecSQL, got %T", block.Body[0])
+	}
+	if len(exec.Into) != 1 || exec.Into[0] != "new_id" {
+		t.Errorf("into = %v, want [new_id]", exec.Into)
+	}
+	if exec.SQLText != "INSERT INTO t (a) VALUES (1) RETURNING id" {
+		t.Errorf("sql = %q, want %q", exec.SQLText, "INSERT INTO t (a) VALUES (1) RETURNING id")
+	}
+}
+
+func TestBareSQLUpdateReturningIntoStrict(t *testing.T) {
+	block := parseOK(t, `BEGIN UPDATE t SET a = 1 WHERE id = 2 RETURNING a INTO STRICT updated_a; END`)
+	exec, ok := block.Body[0].(*ast.PLExecSQL)
+	if !ok {
+		t.Fatalf("expected PLExecSQL, got %T", block.Body[0])
+	}
+	if len(exec.Into) != 1 || exec.Into[0] != "updated_a" {
+		t.Errorf("into = %v, want [updated_a]", exec.Into)
+	}
+	if !exec.Strict {
+		t.Errorf("strict = false, want true")
+	}
+	if exec.SQLText != "UPDATE t SET a = 1 WHERE id = 2 RETURNING a" {
+		t.Errorf("sql = %q, want %q", exec.SQLText, "UPDATE t SET a = 1 WHERE id = 2 RETURNING a")
+	}
+}
+
+func TestBareSQLUtilityCommands(t *testing.T) {
+	tests := []struct {
+		body string
+		want string
+	}{
+		{
+			body: `BEGIN REFRESH MATERIALIZED VIEW CONCURRENTLY mv; END`,
+			want: "REFRESH MATERIALIZED VIEW CONCURRENTLY mv",
+		},
+		{
+			body: `BEGIN GRANT USAGE ON SCHEMA api TO web_anon; END`,
+			want: "GRANT USAGE ON SCHEMA api TO web_anon",
+		},
+		{
+			body: `BEGIN CREATE OR REPLACE FUNCTION helper() RETURNS void LANGUAGE sql AS 'SELECT 1'; END`,
+			want: "CREATE OR REPLACE FUNCTION helper() RETURNS void LANGUAGE sql AS 'SELECT 1'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			block := parseOK(t, tt.body)
+			exec, ok := block.Body[0].(*ast.PLExecSQL)
+			if !ok {
+				t.Fatalf("expected PLExecSQL, got %T", block.Body[0])
+			}
+			if exec.SQLText != tt.want {
+				t.Errorf("sql = %q, want %q", exec.SQLText, tt.want)
+			}
+		})
+	}
+}
+
 func TestSelectInto(t *testing.T) {
 	block := parseOK(t, `BEGIN SELECT a, b INTO x, y FROM t WHERE id = 1; END`)
 	exec, ok := block.Body[0].(*ast.PLExecSQL)


### PR DESCRIPTION
## Summary

- improve PostgreSQL `CREATE FUNCTION` / `CREATE PROCEDURE` option parsing so malformed `AS`, `LANGUAGE`, `TRANSFORM`, common function options, and `SET` clauses report syntax errors instead of being accepted silently
- expand `LANGUAGE sql` and `LANGUAGE plpgsql` function body compatibility coverage, including PostgreSQL 17 oracle-backed tests
- improve PL/pgSQL body parsing for broader SQL statement starts, declaration types, query `FOR` target lists, and SQL `INTO` handling
- fix pgregress statement extraction for `BEGIN ATOMIC` bodies containing `CASE ... END;`

## Verification

- `go test ./pg/...`
- `go test ./pg/parser ./pg/plpgsql/...`
- `go test -tags oracle ./pg/parser -run 'TestFunctionBodyReferenceOracle'`
- `git diff --check`
- local-only export harness over `~/Github/bb_export_2`: PostgreSQL `language sql` body 37/37, `language plpgsql` body 181/181
