### PR TITLE
feat(starrocks/parser): DML divergences — INSERT forms, CTE DELETE/UPDATE, async-MV REFRESH (PR3)

### DIFF
--- a/starrocks/ast/dmlnodes.go
+++ b/starrocks/ast/dmlnodes.go
@@ -66,6 +66,7 @@ var _ Node = (*Assignment)(nil)
 //	    [FROM table_refs]
 //	    [WHERE condition]
 type UpdateStmt struct {
+	With        *WithClause   // optional leading CTE clause (StarRocks WITH … UPDATE); nil if absent
 	Target      *ObjectName   // table to update
 	TargetAlias string        // optional alias (AS alias or bare alias)
 	Assignments []*Assignment // SET clause assignments
@@ -91,6 +92,7 @@ var _ Node = (*UpdateStmt)(nil)
 //	    [USING table_refs]
 //	    [WHERE condition]
 type DeleteStmt struct {
+	With        *WithClause // optional leading CTE clause (StarRocks WITH … DELETE); nil if absent
 	Target      *ObjectName // table to delete from
 	TargetAlias string      // optional alias
 	Partition   []string    // optional PARTITION(p1, p2, ...) names

--- a/starrocks/ast/dmlnodes.go
+++ b/starrocks/ast/dmlnodes.go
@@ -21,6 +21,8 @@ type InsertStmt struct {
 	TempPartition bool        // true if TEMPORARY PARTITION was specified
 	PartitionStar bool        // true if PARTITION(*) was used
 	Columns       []string    // optional column list; nil if absent
+	ByName        bool        // true for INSERT ... BY NAME (column-name matching)
+	FileTarget    []*Property // FILES(propertyList) target; nil for a table target (mutually exclusive with Target)
 	// Source: exactly one of Values or Query is non-nil.
 	Values [][]Node // VALUES rows: each inner slice is one row's expressions
 	Query  Node     // SELECT or WITH…SELECT (*SelectStmt); nil if VALUES form

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -341,6 +341,9 @@ func walkChildren(v Visitor, node Node) {
 		if n.Target != nil {
 			Walk(v, n.Target)
 		}
+		for _, prop := range n.FileTarget {
+			Walk(v, prop)
+		}
 		for _, row := range n.Values {
 			walkNodes(v, row)
 		}

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -356,6 +356,9 @@ func walkChildren(v Visitor, node Node) {
 		Walk(v, n.Column)
 		Walk(v, n.Value)
 	case *UpdateStmt:
+		if n.With != nil {
+			Walk(v, n.With)
+		}
 		Walk(v, n.Target)
 		for _, a := range n.Assignments {
 			Walk(v, a)
@@ -365,6 +368,9 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Where)
 		}
 	case *DeleteStmt:
+		if n.With != nil {
+			Walk(v, n.With)
+		}
 		Walk(v, n.Target)
 		walkNodes(v, n.Using)
 		if n.Where != nil {

--- a/starrocks/parser/cte_delete_pr3_test.go
+++ b/starrocks/parser/cte_delete_pr3_test.go
@@ -1,0 +1,80 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+// CTE-prefixed DELETE (PR3): StarRocks allows a WITH clause before DELETE
+// (but NOT before UPDATE).
+
+func TestCTEDelete(t *testing.T) {
+	file, errs := Parse("WITH c AS (SELECT id FROM s) DELETE FROM t WHERE id IN (SELECT id FROM c)")
+	if len(errs) > 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	del, ok := file.Stmts[0].(*ast.DeleteStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.DeleteStmt", file.Stmts[0])
+	}
+	if del.With == nil || len(del.With.CTEs) != 1 || del.With.CTEs[0].Name != "c" {
+		t.Errorf("With = %+v, want one CTE named c", del.With)
+	}
+	if del.Target == nil || del.Target.Parts[len(del.Target.Parts)-1] != "t" {
+		t.Errorf("target = %+v, want t", del.Target)
+	}
+}
+
+func TestCTEDeleteMultiple(t *testing.T) {
+	file, errs := Parse("WITH a AS (SELECT 1), b AS (SELECT 2) DELETE FROM t WHERE k IN (SELECT x FROM a)")
+	if len(errs) > 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	del := file.Stmts[0].(*ast.DeleteStmt)
+	if del.With == nil || len(del.With.CTEs) != 2 {
+		t.Errorf("want 2 CTEs, got %+v", del.With)
+	}
+}
+
+// Regression: CTE-prefixed SELECT must still parse as a SelectStmt with its WITH.
+func TestCTESelectStillWorks(t *testing.T) {
+	file, errs := Parse("WITH c AS (SELECT a FROM real_t) SELECT a FROM c")
+	if len(errs) > 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	sel, ok := file.Stmts[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.SelectStmt", file.Stmts[0])
+	}
+	if sel.With == nil {
+		t.Error("With = nil, want the CTE clause")
+	}
+}
+
+// CTE-prefixed UPDATE is also accepted by StarRocks (the grammar's
+// updateStatement takes withClause?). The earlier "rejected" assumption came
+// from a probe that used UPDATE … FROM c, which StarRocks rejects for an
+// unrelated reason (it has no UPDATE … FROM form).
+func TestCTEUpdate(t *testing.T) {
+	file, errs := Parse("WITH c AS (SELECT id FROM s) UPDATE t SET v = 1 WHERE id IN (SELECT id FROM c)")
+	if len(errs) > 0 {
+		t.Fatalf("Parse errors: %v", errs)
+	}
+	upd, ok := file.Stmts[0].(*ast.UpdateStmt)
+	if !ok {
+		t.Fatalf("got %T, want *ast.UpdateStmt", file.Stmts[0])
+	}
+	if upd.With == nil || len(upd.With.CTEs) != 1 || upd.With.CTEs[0].Name != "c" {
+		t.Errorf("With = %+v, want one CTE named c", upd.With)
+	}
+}
+
+// WITH … INSERT is NOT allowed by StarRocks (insertStatement has no withClause)
+// and must stay rejected.
+func TestCTEInsertRejected(t *testing.T) {
+	_, errs := Parse("WITH c AS (SELECT 1) INSERT INTO t SELECT x FROM c")
+	if len(errs) == 0 {
+		t.Fatal("expected a parse error for CTE-prefixed INSERT, got none")
+	}
+}

--- a/starrocks/parser/ctes.go
+++ b/starrocks/parser/ctes.go
@@ -16,6 +16,28 @@ import (
 //
 // The WITH keyword has NOT yet been consumed when this is called.
 func (p *Parser) parseWithSelect() (*ast.SelectStmt, error) {
+	with, err := p.parseWithClause()
+	if err != nil {
+		return nil, err
+	}
+
+	// The trailing SELECT statement (WITH must be followed by SELECT here).
+	stmt, err := p.parseSelectStmt()
+	if err != nil {
+		return nil, err
+	}
+
+	// Attach the WITH clause and extend the overall Loc to cover WITH.
+	stmt.With = with
+	stmt.Loc.Start = with.Loc.Start
+
+	return stmt, nil
+}
+
+// parseWithClause parses WITH [RECURSIVE] cte (',' cte)* and returns the clause,
+// leaving the cursor at the statement keyword that follows it. The WITH keyword
+// has NOT yet been consumed when this is called.
+func (p *Parser) parseWithClause() (*ast.WithClause, error) {
 	withTok, err := p.expect(kwWITH)
 	if err != nil {
 		return nil, err
@@ -48,17 +70,47 @@ func (p *Parser) parseWithSelect() (*ast.SelectStmt, error) {
 	}
 
 	with.Loc.End = p.prev.Loc.End
+	return with, nil
+}
 
-	// The trailing SELECT statement (WITH must be followed by SELECT).
-	stmt, err := p.parseSelectStmt()
+// parseWithStatement parses a top-level WITH clause that may prefix a SELECT
+// (the common case), a DELETE, or an UPDATE — StarRocks allows a CTE before all
+// three (the grammar's deleteStatement/updateStatement both take withClause?).
+// WITH … INSERT is not allowed and falls through to the SELECT path, which
+// fails with a syntax error.
+func (p *Parser) parseWithStatement() (ast.Node, error) {
+	with, err := p.parseWithClause()
 	if err != nil {
 		return nil, err
 	}
 
-	// Attach the WITH clause and extend the overall Loc to cover WITH.
-	stmt.With = with
-	stmt.Loc.Start = withTok.Loc.Start
+	switch p.cur.Kind {
+	case kwDELETE:
+		deleteTok := p.advance() // consume DELETE
+		del, err := p.parseDeleteStmt(deleteTok.Loc.Start)
+		if err != nil {
+			return nil, err
+		}
+		del.With = with
+		del.Loc.Start = with.Loc.Start
+		return del, nil
+	case kwUPDATE:
+		updateTok := p.advance() // consume UPDATE
+		upd, err := p.parseUpdateStmt(updateTok.Loc.Start)
+		if err != nil {
+			return nil, err
+		}
+		upd.With = with
+		upd.Loc.Start = with.Loc.Start
+		return upd, nil
+	}
 
+	stmt, err := p.parseSelectStmt()
+	if err != nil {
+		return nil, err
+	}
+	stmt.With = with
+	stmt.Loc.Start = with.Loc.Start
 	return stmt, nil
 }
 

--- a/starrocks/parser/insert.go
+++ b/starrocks/parser/insert.go
@@ -72,7 +72,7 @@ func (p *Parser) parseInsert() (*ast.InsertStmt, error) {
 		}
 		stmt.Target = target
 
-		// Optional PARTITION(p1, p2, ...) or PARTITION(*)
+		// Optional PARTITION(p1, p2, ...) or PARTITION(*) — table targets only.
 		if p.cur.Kind == kwPARTITION {
 			partitions, star, err := p.parseInsertPartition()
 			if err != nil {
@@ -81,10 +81,16 @@ func (p *Parser) parseInsert() (*ast.InsertStmt, error) {
 			stmt.Partition = partitions
 			stmt.PartitionStar = star
 		}
+	}
 
-		// Optional WITH LABEL label_name (WITH not followed by LABEL is left for
-		// the query source, i.e. WITH ... SELECT ...).
-		if p.cur.Kind == kwWITH && p.peekNext().Kind == kwLABEL {
+	// Post-target modifiers in any order (grammar: insertLabelOrColumnAliases*).
+	// WITH LABEL and BY NAME apply to both table and FILES targets; the column
+	// list is table-only. BY NAME and the column list are mutually exclusive.
+	// (WITH not followed by LABEL is left for the query source: WITH ... SELECT.)
+modifiers:
+	for {
+		switch {
+		case p.cur.Kind == kwWITH && p.peekNext().Kind == kwLABEL:
 			p.advance() // consume WITH
 			p.advance() // consume LABEL
 			label, _, err := p.parseIdentifier()
@@ -92,24 +98,24 @@ func (p *Parser) parseInsert() (*ast.InsertStmt, error) {
 				return nil, err
 			}
 			stmt.Label = label
-		}
-
-		// Optional BY NAME (StarRocks column-name-matched insert).
-		if p.cur.Kind == kwBY && p.peekNext().Kind == kwNAME {
+		case p.cur.Kind == kwBY && p.peekNext().Kind == kwNAME:
+			if stmt.Columns != nil {
+				return nil, p.syntaxErrorAtCur() // BY NAME and a column list are mutually exclusive
+			}
 			p.advance() // consume BY
 			p.advance() // consume NAME
 			stmt.ByName = true
-		}
-
-		// Optional column list: (col1, col2, ...).
-		if p.cur.Kind == int('(') {
+		case p.cur.Kind == int('(') && stmt.FileTarget == nil && !stmt.ByName:
 			cols, isColList, err := p.tryParseColumnList()
 			if err != nil {
 				return nil, err
 			}
-			if isColList {
-				stmt.Columns = cols
+			if !isColList {
+				break modifiers
 			}
+			stmt.Columns = cols
+		default:
+			break modifiers
 		}
 	}
 

--- a/starrocks/parser/insert.go
+++ b/starrocks/parser/insert.go
@@ -27,13 +27,13 @@ func (p *Parser) parseInsert() (*ast.InsertStmt, error) {
 		Loc: ast.Loc{Start: insertTok.Loc.Start},
 	}
 
-	// OVERWRITE TABLE or INTO
+	// OVERWRITE [TABLE] or INTO. doris requires TABLE after OVERWRITE; StarRocks
+	// omits it (INSERT OVERWRITE t) — accept both (additive).
 	if p.cur.Kind == kwOVERWRITE {
 		p.advance() // consume OVERWRITE
 		stmt.Overwrite = true
-		// TABLE keyword is required after OVERWRITE
-		if _, err := p.expect(kwTABLE); err != nil {
-			return nil, err
+		if p.cur.Kind == kwTABLE {
+			p.advance() // optional TABLE
 		}
 	} else if p.cur.Kind == kwINTO {
 		p.advance() // consume INTO
@@ -51,28 +51,40 @@ func (p *Parser) parseInsert() (*ast.InsertStmt, error) {
 	// but in Doris the order is: INSERT INTO [TEMP] table [PARTITION(...)] [WITH LABEL] [(cols)] source)
 	// According to the legacy corpus, PARTITION comes after table name.
 	// Parse table name first.
-	target, err := p.parseMultipartIdentifier()
-	if err != nil {
-		return nil, err
+	// Target: a FILES(propertyList) sink (StarRocks) or a table name. FILES is
+	// not a keyword, and `t (cols)` looks similar, so speculatively parse the
+	// property list and fall back to the table-name path if it isn't one.
+	if isIdentText(p, "files") && p.peekNext().Kind == int('(') {
+		saved := p.save()
+		p.advance() // consume FILES
+		props, perr := p.parsePropertyList()
+		if perr == nil {
+			stmt.FileTarget = props
+		} else {
+			p.restore(saved)
+		}
 	}
-	stmt.Target = target
 
-	// Optional PARTITION(p1, p2, ...) or PARTITION(*)
-	if p.cur.Kind == kwPARTITION {
-		partitions, star, err := p.parseInsertPartition()
+	if stmt.FileTarget == nil {
+		target, err := p.parseMultipartIdentifier()
 		if err != nil {
 			return nil, err
 		}
-		stmt.Partition = partitions
-		stmt.PartitionStar = star
-	}
+		stmt.Target = target
 
-	// Optional WITH LABEL label_name
-	if p.cur.Kind == kwWITH {
-		// Peek ahead: WITH LABEL means insert label; WITH ident AS means CTE.
-		// We need to disambiguate: if WITH is followed by LABEL, it's a label clause.
-		// Otherwise leave it for the query source parser.
-		if p.peekNext().Kind == kwLABEL {
+		// Optional PARTITION(p1, p2, ...) or PARTITION(*)
+		if p.cur.Kind == kwPARTITION {
+			partitions, star, err := p.parseInsertPartition()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Partition = partitions
+			stmt.PartitionStar = star
+		}
+
+		// Optional WITH LABEL label_name (WITH not followed by LABEL is left for
+		// the query source, i.e. WITH ... SELECT ...).
+		if p.cur.Kind == kwWITH && p.peekNext().Kind == kwLABEL {
 			p.advance() // consume WITH
 			p.advance() // consume LABEL
 			label, _, err := p.parseIdentifier()
@@ -81,27 +93,23 @@ func (p *Parser) parseInsert() (*ast.InsertStmt, error) {
 			}
 			stmt.Label = label
 		}
-		// If WITH is NOT followed by LABEL, fall through — it will be parsed as
-		// part of the query source (WITH ... SELECT ...).
-	}
 
-	// Optional column list: (col1, col2, ...)
-	// Appears only when the current token is '(' and it's NOT the start of VALUES
-	// or a SELECT. We detect this by checking what follows the closing ')'.
-	// Simpler heuristic: if cur='(' and peekNext() is an identifier (not SELECT/
-	// WITH/VALUES keyword), it's a column list.
-	if p.cur.Kind == int('(') {
-		// Peek inside to determine if this is a column list or a VALUES row.
-		// A column list always has identifiers; a VALUES row may have expressions
-		// but the distinction here is that column lists appear before the source.
-		// Heuristic: if what we see is '(' <ident/keyword_as_ident> [, ...] ')'
-		// followed by VALUES or SELECT/WITH, it's a column list.
-		cols, isColList, err := p.tryParseColumnList()
-		if err != nil {
-			return nil, err
+		// Optional BY NAME (StarRocks column-name-matched insert).
+		if p.cur.Kind == kwBY && p.peekNext().Kind == kwNAME {
+			p.advance() // consume BY
+			p.advance() // consume NAME
+			stmt.ByName = true
 		}
-		if isColList {
-			stmt.Columns = cols
+
+		// Optional column list: (col1, col2, ...).
+		if p.cur.Kind == int('(') {
+			cols, isColList, err := p.tryParseColumnList()
+			if err != nil {
+				return nil, err
+			}
+			if isColList {
+				stmt.Columns = cols
+			}
 		}
 	}
 

--- a/starrocks/parser/insert_pr3_test.go
+++ b/starrocks/parser/insert_pr3_test.go
@@ -30,6 +30,30 @@ func TestInsertByName(t *testing.T) {
 	}
 }
 
+// Modifiers may appear in any order (grammar: insertLabelOrColumnAliases*).
+func TestInsertByNameThenWithLabel(t *testing.T) {
+	stmt := mustParseInsert(t, "INSERT INTO t BY NAME WITH LABEL lbl SELECT a, b FROM s")
+	if !stmt.ByName || stmt.Label != "lbl" {
+		t.Errorf("ByName=%v Label=%q, want true/lbl", stmt.ByName, stmt.Label)
+	}
+}
+
+// BY NAME and a column list are mutually exclusive — must reject.
+func TestInsertByNameWithColumnListRejected(t *testing.T) {
+	_, errs := Parse("INSERT INTO t BY NAME (a, b) SELECT a, b FROM s")
+	if len(errs) == 0 {
+		t.Fatal("expected a parse error for BY NAME + column list, got none")
+	}
+}
+
+// WITH LABEL / BY NAME apply to FILES targets too.
+func TestInsertFilesWithLabel(t *testing.T) {
+	stmt := mustParseInsert(t, "INSERT INTO FILES('path'='s3://x') WITH LABEL lbl SELECT a FROM s")
+	if len(stmt.FileTarget) != 1 || stmt.Label != "lbl" {
+		t.Errorf("FileTarget=%d Label=%q, want 1/lbl", len(stmt.FileTarget), stmt.Label)
+	}
+}
+
 func TestInsertIntoFiles(t *testing.T) {
 	stmt := mustParseInsert(t, "INSERT INTO FILES('path'='s3://x', 'format'='parquet') SELECT a FROM s")
 	if len(stmt.FileTarget) != 2 {

--- a/starrocks/parser/insert_pr3_test.go
+++ b/starrocks/parser/insert_pr3_test.go
@@ -1,0 +1,41 @@
+package parser
+
+import "testing"
+
+// StarRocks INSERT divergences (PR3): OVERWRITE no-TABLE form, BY NAME,
+// and the FILES(propertyList) target.
+
+func TestInsertOverwriteNoTable(t *testing.T) {
+	stmt := mustParseInsert(t, "INSERT OVERWRITE t SELECT a FROM src")
+	if !stmt.Overwrite {
+		t.Error("Overwrite = false, want true")
+	}
+	if stmt.Target == nil || stmt.Target.Parts[len(stmt.Target.Parts)-1] != "t" {
+		t.Errorf("target = %+v, want t", stmt.Target)
+	}
+}
+
+// Regression: the doris OVERWRITE TABLE form must still parse (additive).
+func TestInsertOverwriteTableStillParses(t *testing.T) {
+	stmt := mustParseInsert(t, "INSERT OVERWRITE TABLE test VALUES (1, 2)")
+	if !stmt.Overwrite {
+		t.Error("Overwrite = false, want true")
+	}
+}
+
+func TestInsertByName(t *testing.T) {
+	stmt := mustParseInsert(t, "INSERT INTO t BY NAME SELECT a, b FROM s")
+	if !stmt.ByName {
+		t.Error("ByName = false, want true")
+	}
+}
+
+func TestInsertIntoFiles(t *testing.T) {
+	stmt := mustParseInsert(t, "INSERT INTO FILES('path'='s3://x', 'format'='parquet') SELECT a FROM s")
+	if len(stmt.FileTarget) != 2 {
+		t.Fatalf("FileTarget = %d props, want 2", len(stmt.FileTarget))
+	}
+	if stmt.Target != nil {
+		t.Errorf("Target = %+v, want nil (FILES target)", stmt.Target)
+	}
+}

--- a/starrocks/parser/mtmv.go
+++ b/starrocks/parser/mtmv.go
@@ -73,8 +73,14 @@ func (p *Parser) parseCreateMTMV(startLoc ast.Loc) (ast.Node, error) {
 			}
 
 		case kwREFRESH:
-			// REFRESH COMPLETE | AUTO | NEVER | INCREMENTAL
+			// doris: REFRESH COMPLETE | AUTO | NEVER | INCREMENTAL [ON ...]
+			// StarRocks: REFRESH [IMMEDIATE|DEFERRED] (ASYNC [START('ts')] EVERY
+			//            '(' INTERVAL n unit ')' | MANUAL | INCREMENTAL)
 			p.advance() // consume REFRESH
+			// Optional IMMEDIATE | DEFERRED moment (StarRocks); parse-only.
+			if p.cur.Kind == kwIMMEDIATE || p.cur.Kind == kwDEFERRED {
+				p.advance()
+			}
 			switch p.cur.Kind {
 			case kwCOMPLETE:
 				stmt.RefreshMethod = "COMPLETE"
@@ -89,9 +95,18 @@ func (p *Parser) parseCreateMTMV(startLoc ast.Loc) (ast.Node, error) {
 				stmt.RefreshMethod = "INCREMENTAL"
 				p.advance()
 			default:
-				// tolerate unknown
+				// ASYNC / MANUAL / unknown — captured as the method string.
 				stmt.RefreshMethod = strings.ToUpper(p.cur.Str)
 				p.advance()
+			}
+			// StarRocks async scheduling tail (attached directly to REFRESH, no
+			// ON SCHEDULE): [START '(' string ')'] EVERY '(' INTERVAL n unit ')'.
+			if p.cur.Kind == kwSTART || p.cur.Kind == kwEVERY {
+				trigger, err := p.parseRefreshAsyncSchedule()
+				if err != nil {
+					return nil, err
+				}
+				stmt.RefreshTrigger = trigger
 			}
 
 		case kwON:
@@ -251,6 +266,64 @@ func (p *Parser) parseMTMVRefreshTrigger() (*ast.MTMVRefreshTrigger, error) {
 		// Tolerate unknown ON clause variant.
 		trigger.Loc.End = p.cur.Loc.End
 		p.advance()
+	}
+
+	return trigger, nil
+}
+
+// parseRefreshAsyncSchedule parses the StarRocks async-MV scheduling tail that
+// attaches directly to REFRESH [IMMEDIATE|DEFERRED] ASYNC (no ON SCHEDULE):
+//
+//	[START '(' string ')'] EVERY '(' INTERVAL n unit ')'
+//
+// This differs from the doris ON SCHEDULE form (bare EVERY <n unit>, STARTS
+// <string>) parsed by parseMTMVRefreshTrigger. cur is START or EVERY on entry.
+func (p *Parser) parseRefreshAsyncSchedule() (*ast.MTMVRefreshTrigger, error) {
+	trigger := &ast.MTMVRefreshTrigger{OnSchedule: true, Loc: p.cur.Loc}
+
+	// Optional START '(' string ')'
+	if p.cur.Kind == kwSTART {
+		p.advance() // consume START
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		if p.cur.Kind != tokString {
+			return nil, p.syntaxErrorAtCur()
+		}
+		trigger.StartsAt = p.cur.Str
+		p.advance()
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		trigger.Loc.End = p.prev.Loc.End
+	}
+
+	// EVERY '(' INTERVAL n unit ')'
+	if p.cur.Kind == kwEVERY {
+		p.advance() // consume EVERY
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwINTERVAL); err != nil {
+			return nil, err
+		}
+		if p.cur.Kind != tokInt {
+			return nil, p.syntaxErrorAtCur()
+		}
+		parts := []string{p.cur.Str}
+		p.advance()
+		// Unit keyword (DAY, HOUR, MINUTE, ...) or ident (MILLISECOND/MICROSECOND).
+		if p.cur.Kind < 700 && p.cur.Kind != tokIdent {
+			return nil, p.syntaxErrorAtCur()
+		}
+		parts = append(parts, strings.ToUpper(p.cur.Str))
+		p.advance()
+		trigger.Interval = strings.Join(parts, " ")
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		trigger.Loc.End = closeTok.Loc.End
 	}
 
 	return trigger, nil

--- a/starrocks/parser/mtmv.go
+++ b/starrocks/parser/mtmv.go
@@ -101,7 +101,8 @@ func (p *Parser) parseCreateMTMV(startLoc ast.Loc) (ast.Node, error) {
 			}
 			// StarRocks async scheduling tail (attached directly to REFRESH, no
 			// ON SCHEDULE): [START '(' string ')'] EVERY '(' INTERVAL n unit ')'.
-			if p.cur.Kind == kwSTART || p.cur.Kind == kwEVERY {
+			// Only the ASYNC method takes this tail — MANUAL/INCREMENTAL do not.
+			if stmt.RefreshMethod == "ASYNC" && (p.cur.Kind == kwSTART || p.cur.Kind == kwEVERY) {
 				trigger, err := p.parseRefreshAsyncSchedule()
 				if err != nil {
 					return nil, err
@@ -298,33 +299,34 @@ func (p *Parser) parseRefreshAsyncSchedule() (*ast.MTMVRefreshTrigger, error) {
 		trigger.Loc.End = p.prev.Loc.End
 	}
 
-	// EVERY '(' INTERVAL n unit ')'
-	if p.cur.Kind == kwEVERY {
-		p.advance() // consume EVERY
-		if _, err := p.expect(int('(')); err != nil {
-			return nil, err
-		}
-		if _, err := p.expect(kwINTERVAL); err != nil {
-			return nil, err
-		}
-		if p.cur.Kind != tokInt {
-			return nil, p.syntaxErrorAtCur()
-		}
-		parts := []string{p.cur.Str}
-		p.advance()
-		// Unit keyword (DAY, HOUR, MINUTE, ...) or ident (MILLISECOND/MICROSECOND).
-		if p.cur.Kind < 700 && p.cur.Kind != tokIdent {
-			return nil, p.syntaxErrorAtCur()
-		}
-		parts = append(parts, strings.ToUpper(p.cur.Str))
-		p.advance()
-		trigger.Interval = strings.Join(parts, " ")
-		closeTok, err := p.expect(int(')'))
-		if err != nil {
-			return nil, err
-		}
-		trigger.Loc.End = closeTok.Loc.End
+	// EVERY '(' INTERVAL n unit ')' — mandatory once the async tail is present
+	// (the grammar arm is `(START('...'))? EVERY '(' interval ')'`).
+	if _, err := p.expect(kwEVERY); err != nil {
+		return nil, err
 	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwINTERVAL); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != tokInt {
+		return nil, p.syntaxErrorAtCur()
+	}
+	parts := []string{p.cur.Str}
+	p.advance()
+	// Unit keyword (DAY, HOUR, MINUTE, ...) or ident (MILLISECOND/MICROSECOND).
+	if p.cur.Kind < 700 && p.cur.Kind != tokIdent {
+		return nil, p.syntaxErrorAtCur()
+	}
+	parts = append(parts, strings.ToUpper(p.cur.Str))
+	p.advance()
+	trigger.Interval = strings.Join(parts, " ")
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	trigger.Loc.End = closeTok.Loc.End
 
 	return trigger, nil
 }

--- a/starrocks/parser/mv_refresh_pr3_test.go
+++ b/starrocks/parser/mv_refresh_pr3_test.go
@@ -51,6 +51,22 @@ func TestMVRefreshAsyncPlain(t *testing.T) {
 	_ = mustParseCreateMTMV(t, "CREATE MATERIALIZED VIEW mv REFRESH ASYNC AS SELECT a FROM t")
 }
 
+// The schedule tail is ASYNC-only: MANUAL/INCREMENTAL + EVERY must reject.
+func TestMVRefreshManualEveryRejected(t *testing.T) {
+	_, errs := Parse("CREATE MATERIALIZED VIEW mv REFRESH MANUAL EVERY (INTERVAL 1 DAY) AS SELECT a FROM t")
+	if len(errs) == 0 {
+		t.Fatal("expected a parse error for MANUAL + EVERY, got none")
+	}
+}
+
+// EVERY is mandatory once the async tail starts: START without EVERY must reject.
+func TestMVRefreshAsyncStartNoEveryRejected(t *testing.T) {
+	_, errs := Parse("CREATE MATERIALIZED VIEW mv REFRESH ASYNC START('2024-12-01 20:30:00') AS SELECT a FROM t")
+	if len(errs) == 0 {
+		t.Fatal("expected a parse error for START without EVERY, got none")
+	}
+}
+
 // The no-parens form must REJECT (StarRocks requires EVERY '(' INTERVAL ... ')').
 // This was a silent false-accept before the dedicated handler.
 func TestMVRefreshAsyncEveryNoParensRejected(t *testing.T) {

--- a/starrocks/parser/mv_refresh_pr3_test.go
+++ b/starrocks/parser/mv_refresh_pr3_test.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/starrocks/ast"
+)
+
+func mustParseCreateMTMV(t *testing.T, input string) *ast.CreateMTMVStmt {
+	t.Helper()
+	file, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("Parse(%q) errors: %v", input, errs)
+	}
+	stmt, ok := file.Stmts[0].(*ast.CreateMTMVStmt)
+	if !ok {
+		t.Fatalf("Parse(%q) got %T, want *ast.CreateMTMVStmt", input, file.Stmts[0])
+	}
+	return stmt
+}
+
+// StarRocks async-MV scheduling (PR3): REFRESH ASYNC [START('ts')] EVERY
+// (INTERVAL n unit) — distinct from the doris ON SCHEDULE EVERY <bare> form.
+
+func TestMVRefreshAsyncEvery(t *testing.T) {
+	stmt := mustParseCreateMTMV(t, "CREATE MATERIALIZED VIEW mv REFRESH ASYNC EVERY (INTERVAL 1 DAY) AS SELECT a FROM t")
+	if stmt.RefreshTrigger == nil || !stmt.RefreshTrigger.OnSchedule {
+		t.Fatalf("RefreshTrigger = %+v, want OnSchedule", stmt.RefreshTrigger)
+	}
+	if stmt.RefreshTrigger.Interval != "1 DAY" {
+		t.Errorf("Interval = %q, want \"1 DAY\"", stmt.RefreshTrigger.Interval)
+	}
+}
+
+func TestMVRefreshAsyncStartEvery(t *testing.T) {
+	stmt := mustParseCreateMTMV(t, "CREATE MATERIALIZED VIEW mv REFRESH ASYNC START('2024-12-01 20:30:00') EVERY (INTERVAL 1 DAY) AS SELECT a FROM t")
+	if stmt.RefreshTrigger == nil || stmt.RefreshTrigger.StartsAt == "" {
+		t.Fatalf("RefreshTrigger = %+v, want StartsAt set", stmt.RefreshTrigger)
+	}
+	if stmt.RefreshTrigger.Interval != "1 DAY" {
+		t.Errorf("Interval = %q, want \"1 DAY\"", stmt.RefreshTrigger.Interval)
+	}
+}
+
+func TestMVRefreshImmediateAsyncEvery(t *testing.T) {
+	_ = mustParseCreateMTMV(t, "CREATE MATERIALIZED VIEW mv REFRESH IMMEDIATE ASYNC EVERY (INTERVAL 5 MINUTE) AS SELECT a FROM t")
+}
+
+// Regression: plain REFRESH ASYNC (no scheduling tail) still parses.
+func TestMVRefreshAsyncPlain(t *testing.T) {
+	_ = mustParseCreateMTMV(t, "CREATE MATERIALIZED VIEW mv REFRESH ASYNC AS SELECT a FROM t")
+}
+
+// The no-parens form must REJECT (StarRocks requires EVERY '(' INTERVAL ... ')').
+// This was a silent false-accept before the dedicated handler.
+func TestMVRefreshAsyncEveryNoParensRejected(t *testing.T) {
+	_, errs := Parse("CREATE MATERIALIZED VIEW mv REFRESH ASYNC EVERY INTERVAL 1 DAY AS SELECT a FROM t")
+	if len(errs) == 0 {
+		t.Fatal("expected a parse error for EVERY without parentheses, got none")
+	}
+}

--- a/starrocks/parser/parser.go
+++ b/starrocks/parser/parser.go
@@ -432,7 +432,7 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 		}
 		return p.parseSetOpTail(left)
 	case kwWITH:
-		return p.parseWithSelect()
+		return p.parseWithStatement()
 	case kwINSERT:
 		return p.parseInsert()
 	case kwUPDATE:

--- a/starrocks/parser/pr3_oracle_test.go
+++ b/starrocks/parser/pr3_oracle_test.go
@@ -1,0 +1,63 @@
+package parser
+
+import "testing"
+
+// TestPR3Parity is the container-grounded conformance matrix for the PR3 DML
+// features: INSERT divergences (OVERWRITE no-TABLE, BY NAME, FILES target),
+// CTE-prefixed DELETE/UPDATE, and the async-MV REFRESH ASYNC EVERY schedule.
+// Each construct is asserted accepted by BOTH the omni parser and StarRocks 3.4,
+// and each sibling-arm negative rejected by both. Short-gated via startStarRocks.
+//
+// Reject probes fail INSIDE the construct (the parser does not enforce
+// end-of-input, so trailing-garbage rejects would be false-accepted).
+func TestPR3Parity(t *testing.T) {
+	c := startStarRocks(t)
+
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		// INSERT divergences.
+		{"insert_overwrite_no_table", "INSERT OVERWRITE t SELECT a FROM src", true},
+		{"insert_by_name", "INSERT INTO t BY NAME SELECT a, b FROM s", true},
+		{"insert_into_files", "INSERT INTO FILES('path'='s3://x', 'format'='parquet') SELECT a FROM s", true},
+		{"insert_overwrite_files", "INSERT OVERWRITE FILES('path'='s3://x', 'format'='parquet') SELECT a FROM s", true},
+		{"insert_by_without_name", "INSERT INTO t BY SELECT a FROM s", false},
+		{"insert_files_no_value", "INSERT INTO FILES('path') SELECT a FROM s", false},
+		{"insert_by_name_with_label", "INSERT INTO t BY NAME WITH LABEL lbl SELECT a, b FROM s", true}, // any modifier order
+		{"insert_files_with_label", "INSERT INTO FILES('path'='s3://x') WITH LABEL lbl SELECT a FROM s", true},
+		{"insert_by_name_collist", "INSERT INTO t BY NAME (a, b) SELECT a, b FROM s", false}, // mutually exclusive
+
+		// CTE-prefixed DELETE / UPDATE (StarRocks allows WITH before both; not INSERT).
+		{"cte_delete", "WITH c AS (SELECT id FROM s) DELETE FROM t WHERE id IN (SELECT id FROM c)", true},
+		{"cte_update", "WITH c AS (SELECT id FROM s) UPDATE t SET v = 1 WHERE id IN (SELECT id FROM c)", true},
+		{"cte_insert_rejected", "WITH c AS (SELECT 1) INSERT INTO t SELECT x FROM c", false},
+
+		// Async-MV REFRESH ASYNC scheduling.
+		{"mv_refresh_async_every", "CREATE MATERIALIZED VIEW mv REFRESH ASYNC EVERY (INTERVAL 1 DAY) AS SELECT a FROM t", true},
+		{"mv_refresh_async_start_every", "CREATE MATERIALIZED VIEW mv REFRESH ASYNC START('2024-12-01 20:30:00') EVERY (INTERVAL 1 DAY) AS SELECT a FROM t", true},
+		{"mv_refresh_immediate_async", "CREATE MATERIALIZED VIEW mv REFRESH IMMEDIATE ASYNC EVERY (INTERVAL 5 MINUTE) AS SELECT a FROM t", true},
+		{"mv_refresh_async_plain", "CREATE MATERIALIZED VIEW mv REFRESH ASYNC AS SELECT a FROM t", true},
+		{"mv_refresh_every_no_parens", "CREATE MATERIALIZED VIEW mv REFRESH ASYNC EVERY INTERVAL 1 DAY AS SELECT a FROM t", false},
+		{"mv_refresh_every_no_interval_kw", "CREATE MATERIALIZED VIEW mv REFRESH ASYNC EVERY (1 DAY) AS SELECT a FROM t", false},
+		{"mv_refresh_manual_with_every", "CREATE MATERIALIZED VIEW mv REFRESH MANUAL EVERY (INTERVAL 1 DAY) AS SELECT a FROM t", false},         // tail is ASYNC-only
+		{"mv_refresh_async_start_no_every", "CREATE MATERIALIZED VIEW mv REFRESH ASYNC START('2024-12-01 20:30:00') AS SELECT a FROM t", false}, // EVERY mandatory
+
+		// Known accepted divergences (omni superset, left as-is per skip-prune):
+		//   - INSERT OVERWRITE TABLE t ...: omni keeps the doris form (26 inherited
+		//     tests), but StarRocks 3.4 has no TABLE arm and rejects it — parse-only,
+		//     not a parity case.
+		//   - UPDATE ... FROM c ...: omni over-accepts the doris UPDATE…FROM form
+		//     that StarRocks has no grammar for. Pre-existing, not from PR3.
+		//   - WITH RECURSIVE ... {DELETE|UPDATE|SELECT}: omni tolerates RECURSIVE
+		//     (StarRocks 3.4 has no RECURSIVE) — pre-existing for SELECT (an inherited
+		//     test relies on it); PR3 extends the same tolerance to DELETE/UPDATE.
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}


### PR DESCRIPTION
PR3 of the StarRocks engine epic (BYT-9140) — the DML grammar divergences the doris fork rejects. **Parse-accept** deliverable (diagnose accuracy + split correctness): omni's `analysis.GetQuerySpan` ignores all DML by design (SELECT/set-op only), so this does not produce query-span lineage — that's a separate doris-family ticket gated on a consumer needing DML lineage (none today).

## Features (all confirmed gaps vs live StarRocks 3.4)

**INSERT** (`insert.go`, `InsertStmt += ByName, FileTarget`)
- `INSERT OVERWRITE t` (no `TABLE`) — `TABLE` made optional, additive (doris `OVERWRITE TABLE` still parses).
- `INSERT INTO t BY NAME` — column-name-matched insert.
- `INSERT INTO FILES(propertyList)` — files sink target, detected via the save/restore primitive (FILES isn't a keyword; `t (cols)` looks similar), reusing `parsePropertyList`.
- Post-target modifiers (`WITH LABEL` / `BY NAME` / column list) parse in **any order** (grammar's `insertLabelOrColumnAliases*`), with the BY-NAME/column-list mutual exclusion; `WITH LABEL`/`BY NAME` apply to FILES targets too.

**CTE-prefixed DELETE and UPDATE** (`ctes.go`, `parser.go`, `DeleteStmt/UpdateStmt += With`)
- `parseWithSelect` was split into `parseWithClause` + `parseWithStatement`; the top-level WITH dispatch now routes SELECT / DELETE / UPDATE. `WITH … INSERT` stays rejected (no `withClause` on `insertStatement`). The 3 non-top-level `parseWithSelect` callers (INSERT/MV/recursive CTE) keep SELECT-only behaviour.

**async-MV `REFRESH ASYNC [START('ts')] EVERY (INTERVAL n unit)`** (`mtmv.go`)
- New `parseRefreshAsyncSchedule`, hooked in the `kwREFRESH` arm, gated to the ASYNC method (`MANUAL`/`INCREMENTAL` take no tail); `EVERY` mandatory once the tail starts; reuses `MTMVRefreshTrigger`. doris `ON SCHEDULE` path untouched. Also turns a pre-existing silent false-accept (`EVERY INTERVAL 1 DAY` without parens) into a reject.

## Testing
- `TestPR3Parity` (`testing.Short()`-gated): **20 cases** — accepts + sibling-arm rejects (BY-without-NAME, FILES-no-`=`, BY-NAME+col-list, CTE-INSERT, MANUAL+EVERY, START-without-EVERY, EVERY-no-parens/no-INTERVAL) — all agree with live StarRocks 3.4.
- Unit tests per feature; full inherited suite green (the WITH-dispatch refactor preserves all 4 callers); `go vet` clean (only the 2 pre-existing warnings).

## Review
A 3-lens adversarial review drove the final fix commit (checklist lens clean): it caught the MV schedule-tail-after-any-method over-accept, the START-without-EVERY over-accept, and the INSERT fixed-modifier-order over/under-accepts — all fixed and covered by parity tests.

## Documented over-accepts (skip-prune, parse-only)
`INSERT OVERWRITE TABLE` (omni superset; SR rejects), `UPDATE … FROM` (pre-existing doris form), `WITH RECURSIVE` (an inherited test relies on tolerating it; SR lacks it).

## Note
The recon initially assumed CTE-UPDATE was rejected — that came from a probe using `UPDATE … FROM c`; the real cause is StarRocks has no `UPDATE … FROM` form. Simple CTE-UPDATE is a genuine gap and is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)