### PR TITLE
fix(mysql): support ANSI_QUOTES routine identifiers

### DIFF
--- a/mysql/parser/name.go
+++ b/mysql/parser/name.go
@@ -533,6 +533,10 @@ func (p *Parser) parseIdent() (string, int, error) {
 		tok := p.advance()
 		return tok.Str, tok.Loc, nil
 	}
+	if p.isDoubleQuotedStringToken(p.cur) {
+		tok := p.advance()
+		return tok.Str, tok.Loc, nil
+	}
 	// Accept non-reserved keyword tokens as identifiers.
 	if p.cur.Type >= 700 && !isReserved(p.cur.Type) {
 		tok := p.advance()
@@ -545,6 +549,14 @@ func (p *Parser) parseIdent() (string, int, error) {
 		Message:  "expected identifier",
 		Position: p.cur.Loc,
 	}
+}
+
+func (p *Parser) isDoubleQuotedStringToken(tok Token) bool {
+	if tok.Type != tokSCONST {
+		return false
+	}
+	offset := tok.Loc - p.lexer.baseOffset
+	return offset >= 0 && offset < len(p.lexer.input) && p.lexer.input[offset] == '"'
 }
 
 // parseIdentOrText parses MySQL's `ident_or_text` grammar rule: either an

--- a/mysql/parser/routine_body_strict_test.go
+++ b/mysql/parser/routine_body_strict_test.go
@@ -59,3 +59,27 @@ func TestTriggerAndEventBodyRequiredKeywords(t *testing.T) {
 		})
 	}
 }
+
+func TestRoutineBodyANSIQuotesIdentifiers(t *testing.T) {
+	valid := []string{
+		`CREATE PROCEDURE "p_ansi"() BEGIN SELECT 1; END`,
+		`CREATE FUNCTION "f_ansi"(a INT) RETURNS INT DETERMINISTIC RETURN a + 1`,
+		`CREATE TRIGGER "tr_ansi" BEFORE INSERT ON "t_ansi" FOR EACH ROW SET NEW.v = 1`,
+		`CREATE DEFINER="root"@"%:%" EVENT "ev_ansi" ON SCHEDULE EVERY 15 MINUTE STARTS '2026-01-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO DELETE FROM t WHERE expired_at < NOW()`,
+	}
+	for _, sql := range valid {
+		t.Run("valid/"+sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+
+	invalid := []string{
+		`CREATE PROCEDURE 'p_string'() BEGIN SELECT 1; END`,
+		`CREATE EVENT 'ev_string' ON SCHEDULE EVERY 1 HOUR DO SELECT 1`,
+	}
+	for _, sql := range invalid {
+		t.Run("invalid/"+sql, func(t *testing.T) {
+			ParseExpectError(t, sql)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- accept double-quoted tokens as identifiers in identifier positions, matching MySQL ANSI_QUOTES mode used by dumps
- cover ANSI_QUOTES routine, trigger, and event names plus double-quoted DEFINER account/host forms
- keep single-quoted routine/event names rejected so string literals are not treated as identifiers

## bb_export_2 impact
Local-only aggregate check against `~/Github/bb_export_2` improved MySQL segment parsing from `ok=8189 fail=423` to `ok=8238 fail=374`. In routine kinds, `event` improved from `4/5` to `5/5`, and `procedure` improved from `93/94` to `94/94`.

Remaining routine failures are not treated as MySQL syntax support targets in this PR: the largest function group is malformed duplicate function signatures in the dump, and the rest are PostgreSQL `RETURNS trigger` / dollar-quote / `EXECUTE FUNCTION` bodies under MYSQL paths. No raw export SQL is included in this PR.

## References
- MySQL 8.4 Schema Object Names: ANSI_QUOTES treats double-quoted strings as identifiers
- MySQL 8.4 CREATE PROCEDURE/FUNCTION, CREATE TRIGGER, and CREATE EVENT syntax allow identifiers and DEFINER forms in these object definitions

## Verification
- go test ./mysql/parser -run TestRoutineBodyANSIQuotesIdentifiers -v
- go test ./mysql/...
- go run /tmp/bb_bodycheck/main.go /Users/rebeliceyang/Github/bb_export_2 | sed -n '/ENGINE\\tMYSQL/,/ENGINE\\tORACLE/p'\n- git diff --check