### PR TITLE
refactor(pg/catalog): use explicit pretty bool for view-def getters

### DIFF
--- a/pg/catalog/diff_view.go
+++ b/pg/catalog/diff_view.go
@@ -132,9 +132,9 @@ func getViewDef(c *Catalog, key relKey, rel *Relation) string {
 	var def string
 	var err error
 	if rel.RelKind == 'm' {
-		def, err = c.GetMatViewDefinition(key.schema, key.name)
+		def, err = c.GetMatViewDefinition(key.schema, key.name, false)
 	} else {
-		def, err = c.GetViewDefinition(key.schema, key.name)
+		def, err = c.GetViewDefinition(key.schema, key.name, false)
 	}
 	if err != nil {
 		return ""

--- a/pg/catalog/migration.go
+++ b/pg/catalog/migration.go
@@ -372,7 +372,7 @@ func wrapColumnTypeChangesWithViewOps(from, to *Catalog, diff *SchemaDiff, ops [
 		if toRel != nil {
 			toOID = toRel.OID
 		}
-		def, _ := to.GetViewDefinition(v.schema, v.name)
+		def, _ := to.GetViewDefinition(v.schema, v.name, false)
 		extraOps = append(extraOps, MigrationOp{
 			Type:          OpCreateView,
 			SchemaName:    v.schema,

--- a/pg/catalog/migration_view.go
+++ b/pg/catalog/migration_view.go
@@ -139,7 +139,7 @@ func generateViewDDL(from, to *Catalog, diff *SchemaDiff) []MigrationOp {
 // buildCreateViewOp creates a CREATE VIEW op for an added view.
 func buildCreateViewOp(to *Catalog, entry RelationDiffEntry) MigrationOp {
 	qn := migrationQualifiedName(entry.SchemaName, entry.Name)
-	def, _ := to.GetViewDefinition(entry.SchemaName, entry.Name)
+	def, _ := to.GetViewDefinition(entry.SchemaName, entry.Name, false)
 
 	var b strings.Builder
 	b.WriteString("CREATE VIEW ")
@@ -171,7 +171,7 @@ func buildCreateViewOp(to *Catalog, entry RelationDiffEntry) MigrationOp {
 // buildCreateMatViewOp creates a CREATE MATERIALIZED VIEW op.
 func buildCreateMatViewOp(to *Catalog, entry RelationDiffEntry) MigrationOp {
 	qn := migrationQualifiedName(entry.SchemaName, entry.Name)
-	def, _ := to.GetMatViewDefinition(entry.SchemaName, entry.Name)
+	def, _ := to.GetMatViewDefinition(entry.SchemaName, entry.Name, false)
 
 	sql := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s",
 		qn, strings.TrimRight(def, " \t\n\r;"))
@@ -218,7 +218,7 @@ func buildModifyViewOps(from, to *Catalog, entry RelationDiffEntry) []MigrationO
 	}
 
 	qn := migrationQualifiedName(entry.SchemaName, entry.Name)
-	def, _ := to.GetViewDefinition(entry.SchemaName, entry.Name)
+	def, _ := to.GetViewDefinition(entry.SchemaName, entry.Name, false)
 
 	var b strings.Builder
 	b.WriteString("CREATE OR REPLACE VIEW ")
@@ -252,7 +252,7 @@ func buildModifyViewOps(from, to *Catalog, entry RelationDiffEntry) []MigrationO
 // Materialized views don't support CREATE OR REPLACE.
 func buildModifyMatViewOps(to *Catalog, entry RelationDiffEntry) []MigrationOp {
 	qn := migrationQualifiedName(entry.SchemaName, entry.Name)
-	def, _ := to.GetMatViewDefinition(entry.SchemaName, entry.Name)
+	def, _ := to.GetMatViewDefinition(entry.SchemaName, entry.Name, false)
 
 	dropOp := MigrationOp{
 		Type:          OpDropView,
@@ -306,7 +306,7 @@ func findDependentViews(c *Catalog, schemaName, viewName string) []viewRef {
 				continue
 			}
 			// Check if this view references the target view.
-			def, err := c.GetViewDefinition(s.Name, rel.Name)
+			def, err := c.GetViewDefinition(s.Name, rel.Name, false)
 			if err != nil {
 				continue
 			}

--- a/pg/catalog/phase4_analyze_test.go
+++ b/pg/catalog/phase4_analyze_test.go
@@ -48,7 +48,7 @@ func viewDef(t *testing.T, c *Catalog, sql string) string {
 			item = raw.Stmt
 		}
 		if vs, ok := item.(*nodes.ViewStmt); ok {
-			def, err := c.GetViewDefinition("", vs.View.Relname)
+			def, err := c.GetViewDefinition("", vs.View.Relname, false)
 			if err != nil {
 				t.Fatalf("get view def: %v", err)
 			}

--- a/pg/catalog/phase5_types_test.go
+++ b/pg/catalog/phase5_types_test.go
@@ -354,7 +354,7 @@ func TestPhase5_ExistingRangeStillWorks(t *testing.T) {
 
 func assertViewDefContains(t *testing.T, c *Catalog, viewName, expected string) {
 	t.Helper()
-	def, err := c.GetViewDefinition("", viewName)
+	def, err := c.GetViewDefinition("", viewName, false)
 	if err != nil {
 		t.Fatalf("get view def: %v", err)
 	}

--- a/pg/catalog/ruleutils.go
+++ b/pg/catalog/ruleutils.go
@@ -12,7 +12,7 @@ import (
 // When pretty is true, matches pg_get_viewdef(oid, true) (PRETTYFLAG_INDENT | PRETTYFLAG_PAREN).
 //
 // pg: src/backend/utils/adt/ruleutils.c — pg_get_viewdef_worker
-func (c *Catalog) GetViewDefinition(schema, name string, pretty ...bool) (string, error) {
+func (c *Catalog) GetViewDefinition(schema, name string, pretty bool) (string, error) {
 	rel := c.GetRelation(schema, name)
 	if rel == nil {
 		return "", errUndefinedTable(name)
@@ -20,11 +20,7 @@ func (c *Catalog) GetViewDefinition(schema, name string, pretty ...bool) (string
 	if rel.RelKind != 'v' {
 		return "", errWrongObjectType(name, "a view")
 	}
-	p := false
-	if len(pretty) > 0 {
-		p = pretty[0]
-	}
-	return c.deparseRelationQuery(rel, p)
+	return c.deparseRelationQuery(rel, pretty)
 }
 
 // GetMatViewDefinition returns the SQL definition of a materialized view,
@@ -34,7 +30,7 @@ func (c *Catalog) GetViewDefinition(schema, name string, pretty ...bool) (string
 // When pretty is true, matches pg_get_viewdef(oid, true) (PRETTYFLAG_INDENT | PRETTYFLAG_PAREN).
 //
 // pg: src/backend/utils/adt/ruleutils.c — pg_get_viewdef_worker
-func (c *Catalog) GetMatViewDefinition(schema, name string, pretty ...bool) (string, error) {
+func (c *Catalog) GetMatViewDefinition(schema, name string, pretty bool) (string, error) {
 	rel := c.GetRelation(schema, name)
 	if rel == nil {
 		return "", errUndefinedTable(name)
@@ -42,11 +38,7 @@ func (c *Catalog) GetMatViewDefinition(schema, name string, pretty ...bool) (str
 	if rel.RelKind != 'm' {
 		return "", errWrongObjectType(name, "a materialized view")
 	}
-	p := false
-	if len(pretty) > 0 {
-		p = pretty[0]
-	}
-	return c.deparseRelationQuery(rel, p)
+	return c.deparseRelationQuery(rel, pretty)
 }
 
 // deparseRelationQuery deparses the AnalyzedQuery of a view or matview.


### PR DESCRIPTION
## What

`Catalog.GetViewDefinition` and `Catalog.GetMatViewDefinition` took `pretty ...bool`. The variadic existed only to make the flag optional (Go has no default arguments) — the body just read `pretty[0]` and defaulted to `false`.

In practice **every one of the ~10 call sites omitted the argument** and relied on that default; none ever requested pretty output. The variadic also weakens the contract: `GetViewDefinition(s, n, true, false)` compiles and silently ignores the extra bool, with no compile-time arity check.

This switches both methods to an explicit `pretty bool` and updates all callers to pass `false`.

## Why

- Precise signature: exactly one bool, can't pass zero or several.
- More self-documenting / discoverable at call sites.
- No behavior change — `pretty=false` was already the universal default.

## Changes

- `pg/catalog/ruleutils.go` — `pretty ...bool` → `pretty bool` on both getters; drop the `len(pretty) > 0` unwrap.
- Call sites updated to pass `false`: `migration_view.go` (5), `diff_view.go` (2), `migration.go` (1), `phase4_analyze_test.go` (1), `phase5_types_test.go` (1).

## Verification

`go build`, `go vet`, and `go test ./pg/catalog/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)