### PR TITLE
feat(mariadb/parser): MariaDB 11.8 container oracle + pinned subtractive-divergence inventory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
+	github.com/testcontainers/testcontainers-go/modules/mariadb v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/mssql v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/testcontainers/testcontainers-go v0.41.0 h1:mfpsD0D36YgkxGj2LrIyxuwQ9i2wCKAD+ESsYM1wais=
 github.com/testcontainers/testcontainers-go v0.41.0/go.mod h1:pdFrEIfaPl24zmBjerWTTYaY0M6UHsqA1YSvsoU40MI=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.41.0 h1:t0J/TOgzTKCO+7Pc7wE6ITJXGCZFufisuokOWYVzNaQ=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.41.0/go.mod h1:ELA34/aGm5oXG0g9OkPVWmIsw+BDdeybr7wk8i+TQCg=
 github.com/testcontainers/testcontainers-go/modules/mssql v0.41.0 h1:YAuSa+IMTn0nA6iNvSAFgJEeJsQWSghFWu0ubebWXJI=
 github.com/testcontainers/testcontainers-go/modules/mssql v0.41.0/go.mod h1:3leIIvry5kLZr8uxMIDX0iL2TRwVx2UDDSkGJGlpsvQ=
 github.com/testcontainers/testcontainers-go/modules/mysql v0.41.0 h1:5rwejaJr5nIfw8NK99eKPX7O6k27lnSMklTj5DbYybM=

--- a/mariadb/parser/oracle_corpus_test.go
+++ b/mariadb/parser/oracle_corpus_test.go
@@ -1,234 +1,321 @@
 package parser
 
-import "testing"
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 
-func TestOracleCorpus(t *testing.T) {
+	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/testcontainers/testcontainers-go"
+	mariadb "github.com/testcontainers/testcontainers-go/modules/mariadb"
+)
+
+// ============================================================================
+// MariaDB 11.8 container oracle + pinned subtractive-divergence inventory.
+//
+// The DoD is the *pinned reviewed list* (subtractiveDivergences), NOT green
+// parity: omni's mysql-forked parser over-accepts MySQL-isms that real MariaDB
+// rejects. TestMariaDBDivergenceInventory runs the mysql corpus + category
+// probes through omni's Parse and a live mariadb:11.8.8 container and asserts
+// the live mismatch set EQUALS the allowlist, bidirectionally (UNREVIEWED if a
+// live divergence isn't pinned; STALE if a pinned entry no longer diverges).
+//
+// SUBTRACTIVE & 1064-SCOPED ONLY: blind to additive MariaDB surface (SEQUENCE,
+// RETURNING, sql_mode=ORACLE, system-versioning → Phase-0 mdbcheck) and to
+// feature-gated (1235) rejections. "Inventory pinned" != "MariaDB parity".
+// ============================================================================
+
+// startMariaDB starts mariadb:11.8.8 via the testcontainers mariadb module. The
+// module's wait strategy handles MariaDB's double-start entrypoint (temp init
+// server → shutdown → real server) that a bare port-wait would race.
+func startMariaDB(t *testing.T) *parserOracle {
+	t.Helper()
 	if testing.Short() {
-		t.Skip("skipping oracle test in short mode")
+		t.Skip("skipping MariaDB container oracle in short mode")
 	}
-	oracle := startParserOracle(t)
+	ctx := context.Background()
 
-	// Create a dummy table for SELECT statements that reference 't'.
-	oracle.db.ExecContext(oracle.ctx, "CREATE TABLE IF NOT EXISTS t (id INT, val INT, score INT, status INT, name VARCHAR(100), dept VARCHAR(50), salary DECIMAL(10,2), d DATE, created_at DATETIME)")
+	c, err := mariadb.Run(ctx, "mariadb:11.8.8",
+		mariadb.WithDatabase("test"),
+		mariadb.WithPassword("test"),
+		// no WithUsername("root"): root is the module default; setting it errors.
+	)
+	if err != nil {
+		t.Skipf("MariaDB container unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(c) })
 
-	// --- 3.1 Integer Types × Modifiers (12 cases) ---
-	t.Run("IntegerTypes", func(t *testing.T) {
-		cases := []struct{ name, sql string }{
-			{"INT baseline", "CREATE TABLE t1 (a INT)"},
-			{"INT UNSIGNED", "CREATE TABLE t2 (a INT UNSIGNED)"},
-			{"INT SIGNED", "CREATE TABLE t3 (a INT SIGNED)"},
-			{"INT display width", "CREATE TABLE t4 (a INT(11))"},
-			{"INT UNSIGNED ZEROFILL", "CREATE TABLE t5 (a INT UNSIGNED ZEROFILL)"},
-			{"TINYINT SIGNED", "CREATE TABLE t6 (a TINYINT SIGNED)"},
-			{"TINYINT UNSIGNED ZEROFILL", "CREATE TABLE t7 (a TINYINT UNSIGNED ZEROFILL)"},
-			{"SMALLINT width UNSIGNED", "CREATE TABLE t8 (a SMALLINT(5) UNSIGNED)"},
-			{"MEDIUMINT SIGNED", "CREATE TABLE t9 (a MEDIUMINT SIGNED)"},
-			{"BIGINT width UNSIGNED", "CREATE TABLE t10 (a BIGINT(20) UNSIGNED)"},
-			{"INT1 UNSIGNED", "CREATE TABLE t11 (a INT1 UNSIGNED)"},
-			{"INT8 SIGNED", "CREATE TABLE t12 (a INT8 SIGNED)"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				assertOracleMatch(t, oracle, tc.sql)
-			})
-		}
-		// Cleanup
-		for i := 1; i <= 12; i++ {
-			oracle.db.ExecContext(oracle.ctx, "DROP TABLE IF EXISTS t"+itoa(i))
-		}
-	})
-
-	// --- 3.2 Decimal & Float Types (16 cases) ---
-	t.Run("DecimalFloatTypes", func(t *testing.T) {
-		cases := []struct{ name, sql string }{
-			{"DECIMAL bare", "CREATE TABLE t13 (a DECIMAL)"},
-			{"DECIMAL single prec", "CREATE TABLE t14 (a DECIMAL(10))"},
-			{"DECIMAL full prec", "CREATE TABLE t15 (a DECIMAL(10,2))"},
-			{"DECIMAL UNSIGNED", "CREATE TABLE t16 (a DECIMAL(10,2) UNSIGNED)"},
-			{"NUMERIC", "CREATE TABLE t17 (a NUMERIC(10,2))"},
-			{"DEC", "CREATE TABLE t18 (a DEC(10,2))"},
-			{"FIXED", "CREATE TABLE t19 (a FIXED(10,2))"},
-			{"FLOAT bare", "CREATE TABLE t20 (a FLOAT)"},
-			{"FLOAT with prec", "CREATE TABLE t21 (a FLOAT(10,2))"},
-			{"FLOAT 24", "CREATE TABLE t22 (a FLOAT(24))"},
-			{"FLOAT 25", "CREATE TABLE t23 (a FLOAT(25))"},
-			{"DOUBLE", "CREATE TABLE t24 (a DOUBLE)"},
-			{"DOUBLE PRECISION", "CREATE TABLE t25 (a DOUBLE PRECISION)"},
-			{"REAL", "CREATE TABLE t26 (a REAL)"},
-			{"FLOAT4", "CREATE TABLE t27 (a FLOAT4)"},
-			{"FLOAT8", "CREATE TABLE t28 (a FLOAT8)"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				assertOracleMatch(t, oracle, tc.sql)
-			})
-		}
-		for i := 13; i <= 28; i++ {
-			oracle.db.ExecContext(oracle.ctx, "DROP TABLE IF EXISTS t"+itoa(i))
-		}
-	})
-
-	// --- 3.3 String & Binary Types (21 cases) ---
-	t.Run("StringBinaryTypes", func(t *testing.T) {
-		cases := []struct{ name, sql string }{
-			{"CHAR", "CREATE TABLE t29 (a CHAR(10))"},
-			{"CHAR with charset collate", "CREATE TABLE t30 (a CHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci)"},
-			{"VARCHAR", "CREATE TABLE t31 (a VARCHAR(255))"},
-			{"TEXT", "CREATE TABLE t32 (a TEXT)"},
-			{"TEXT with length", "CREATE TABLE t33 (a TEXT(1000))"},
-			{"TINYTEXT", "CREATE TABLE t34 (a TINYTEXT)"},
-			{"MEDIUMTEXT charset", "CREATE TABLE t35 (a MEDIUMTEXT CHARACTER SET latin1)"},
-			{"LONGTEXT", "CREATE TABLE t36 (a LONGTEXT)"},
-			{"LONG", "CREATE TABLE t37 (a LONG)"},
-			{"LONG VARCHAR", "CREATE TABLE t38 (a LONG VARCHAR)"},
-			{"BINARY", "CREATE TABLE t39 (a BINARY(16))"},
-			{"VARBINARY", "CREATE TABLE t40 (a VARBINARY(255))"},
-			{"BLOB", "CREATE TABLE t41 (a BLOB)"},
-			{"BLOB with length", "CREATE TABLE t42 (a BLOB(1000))"},
-			{"TINYBLOB", "CREATE TABLE t43 (a TINYBLOB)"},
-			{"MEDIUMBLOB", "CREATE TABLE t44 (a MEDIUMBLOB)"},
-			{"LONGBLOB", "CREATE TABLE t45 (a LONGBLOB)"},
-			{"LONG VARBINARY", "CREATE TABLE t46 (a LONG VARBINARY)"},
-			{"NATIONAL CHAR", "CREATE TABLE t47 (a NATIONAL CHAR(10))"},
-			{"NCHAR", "CREATE TABLE t48 (a NCHAR(10))"},
-			{"NVARCHAR", "CREATE TABLE t49 (a NVARCHAR(100))"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				assertOracleMatch(t, oracle, tc.sql)
-			})
-		}
-		for i := 29; i <= 49; i++ {
-			oracle.db.ExecContext(oracle.ctx, "DROP TABLE IF EXISTS t"+itoa(i))
-		}
-	})
-
-	// --- 3.4 Date/Time, JSON, Spatial & Special (19 cases) ---
-	t.Run("DateTimeJSONSpatial", func(t *testing.T) {
-		cases := []struct{ name, sql string }{
-			{"DATE", "CREATE TABLE t50 (a DATE)"},
-			{"TIME", "CREATE TABLE t51 (a TIME)"},
-			{"TIME fsp", "CREATE TABLE t52 (a TIME(3))"},
-			{"DATETIME", "CREATE TABLE t53 (a DATETIME)"},
-			{"DATETIME fsp", "CREATE TABLE t54 (a DATETIME(6))"},
-			{"TIMESTAMP", "CREATE TABLE t55 (a TIMESTAMP)"},
-			{"TIMESTAMP fsp", "CREATE TABLE t56 (a TIMESTAMP(3))"},
-			{"YEAR", "CREATE TABLE t57 (a YEAR)"},
-			{"BIT", "CREATE TABLE t58 (a BIT(8))"},
-			{"BOOL", "CREATE TABLE t59 (a BOOL)"},
-			{"JSON", "CREATE TABLE t60 (a JSON)"},
-			{"SERIAL", "CREATE TABLE t61 (a SERIAL)"},
-			{"ENUM", "CREATE TABLE t62 (a ENUM('a','b','c'))"},
-			{"SET", "CREATE TABLE t63 (a SET('x','y','z'))"},
-			{"GEOMETRY", "CREATE TABLE t64 (a GEOMETRY)"},
-			{"POINT", "CREATE TABLE t65 (a POINT)"},
-			{"LINESTRING", "CREATE TABLE t66 (a LINESTRING)"},
-			{"POLYGON", "CREATE TABLE t67 (a POLYGON)"},
-			{"GEOMETRYCOLLECTION", "CREATE TABLE t68 (a GEOMETRYCOLLECTION)"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				assertOracleMatch(t, oracle, tc.sql)
-			})
-		}
-		for i := 50; i <= 68; i++ {
-			oracle.db.ExecContext(oracle.ctx, "DROP TABLE IF EXISTS t"+itoa(i))
-		}
-	})
-
-	// --- 3.5 Window Functions (7 cases) ---
-	t.Run("WindowFunctions", func(t *testing.T) {
-		cases := []struct{ name, sql string }{
-			{"RANK named window", "SELECT RANK() OVER w FROM t WINDOW w AS (ORDER BY id)"},
-			{"ROW_NUMBER partition", "SELECT ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC) FROM t"},
-			{"LAG default offset", "SELECT LAG(val) OVER (ORDER BY id) FROM t"},
-			{"LAG all args", "SELECT LAG(val, 2, 0) OVER (ORDER BY id) FROM t"},
-			{"NTH_VALUE", "SELECT NTH_VALUE(val, 3) OVER (ORDER BY id) FROM t"},
-			{"SUM window frame", "SELECT SUM(val) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM t"},
-			{"multiple window funcs", "SELECT DENSE_RANK() OVER (ORDER BY score), PERCENT_RANK() OVER (ORDER BY score) FROM t"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				assertOracleMatch(t, oracle, tc.sql)
-			})
-		}
-	})
-
-	// --- 3.6 Interval Expressions (8 cases) ---
-	t.Run("IntervalExpressions", func(t *testing.T) {
-		cases := []struct {
-			name, sql     string
-			knownMismatch bool // true = omni/MySQL disagree; logged but not a test failure
-		}{
-			{"interval add DAY", "SELECT NOW() + INTERVAL 1 DAY", false},
-			{"interval sub HOUR", "SELECT NOW() - INTERVAL 2 HOUR", false},
-			{"DATE_ADD literal", "SELECT DATE_ADD('2024-01-01', INTERVAL 1 MONTH)", false},
-			{"DATE_SUB MINUTE", "SELECT DATE_SUB(NOW(), INTERVAL 30 MINUTE)", false},
-			{"TIMESTAMPADD", "SELECT TIMESTAMPADD(MINUTE, 30, NOW())", false},
-			{"EXTRACT", "SELECT EXTRACT(HOUR FROM NOW())", false},
-			{"interval in WHERE", "SELECT * FROM t WHERE created_at > NOW() - INTERVAL 7 DAY", false},
-			{"interval in BETWEEN", "SELECT * FROM t WHERE created_at BETWEEN NOW() - INTERVAL 1 MONTH AND NOW()", false},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				if tc.knownMismatch {
-					assertOracleMismatch(t, oracle, tc.sql)
-				} else {
-					assertOracleMatch(t, oracle, tc.sql)
-				}
-			})
-		}
-	})
-
-	// --- 3.7 Rejected SQL (8 cases) ---
-	t.Run("RejectedSQL", func(t *testing.T) {
-		cases := []struct {
-			name, sql     string
-			knownMismatch bool
-		}{
-			{"VARCHAR UNSIGNED", "CREATE TABLE t_rej1 (a VARCHAR UNSIGNED)", false},
-			{"TEXT ZEROFILL", "CREATE TABLE t_rej2 (a TEXT ZEROFILL)", false},
-			{"JSON UNSIGNED", "CREATE TABLE t_rej3 (a JSON UNSIGNED)", false},
-			// MISMATCH: omni accepts unquoted reserved words as identifiers
-			// but MySQL correctly rejects them. Parser is too lenient.
-			{"reserved word table name", "CREATE TABLE select (a INT)", true},
-			{"reserved word col name", "CREATE TABLE t_rej5 (select INT)", true},
-			{"incomplete PARTITION BY", "ALTER TABLE t PARTITION BY", false},
-			{"RANGE no partitions", "ALTER TABLE t PARTITION BY RANGE(id)", false},
-			{"invalid interval unit", "SELECT DATE_ADD(d, INTERVAL 1 INVALID_UNIT) FROM t", false},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				if tc.knownMismatch {
-					assertOracleMismatch(t, oracle, tc.sql)
-				} else {
-					assertOracleMatch(t, oracle, tc.sql)
-				}
-			})
-		}
-		// Cleanup any tables that might have been created
-		for i := 1; i <= 5; i++ {
-			oracle.db.ExecContext(oracle.ctx, "DROP TABLE IF EXISTS t_rej"+itoa(i))
-		}
-	})
+	// Server-side guards (seconds) on every pooled conn via DSN system-vars: the
+	// server aborts a slow/locked statement so the conn stays healthy (a client
+	// context cancel leaves the query running server-side and poisons the pool).
+	connStr, err := c.ConnectionString(ctx,
+		"multiStatements=true", "parseTime=true",
+		"max_statement_time=5", "lock_wait_timeout=2",
+	)
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	db, err := sql.Open("mysql", connStr)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return &parserOracle{db: db, ctx: ctx}
 }
 
-// itoa converts an int to string without importing strconv.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
+type verdict int
+
+const (
+	vAccepted verdict = iota
+	vRejected
+	vErrored
+)
+
+// classify runs sqlStr against MariaDB and maps the result to a PARSE verdict.
+// Only 1064 (ER_PARSE_ERROR) is a reject — MariaDB reserves 1064 for parse-time
+// errors (unlike StarRocks's 1064 overload). Any other *gomysql.MySQLError means
+// it PARSED → accepted (code captured): 1146 (missing table), 1235
+// (ER_NOT_SUPPORTED_YET feature-gate), and 1969 (ER_STATEMENT_TIMEOUT from the
+// server-side max_statement_time guard) all surface as MySQLErrors = "parsed
+// fine, failed/killed at runtime" → accepted. A NON-MySQLError (conn reset, pool
+// exhaustion) is a distinct vErrored state — surfaced loudly, never folded into
+// accept (that would corrupt the exact-set gate).
+func (o *parserOracle) classify(sqlStr string) (verdict, uint16, string) {
+	_, err := o.db.ExecContext(o.ctx, sqlStr)
+	if err == nil {
+		return vAccepted, 0, ""
 	}
-	var digits []byte
-	neg := n < 0
-	if neg {
-		n = -n
+	if myErr, ok := err.(*gomysql.MySQLError); ok {
+		if myErr.Number == 1064 {
+			return vRejected, 1064, myErr.Message
+		}
+		return vAccepted, myErr.Number, myErr.Message
 	}
-	for n > 0 {
-		digits = append([]byte{byte('0' + n%10)}, digits...)
-		n /= 10
+	return vErrored, 0, err.Error()
+}
+
+// categoryCaseSQLs are the hand-written type/window/interval/reject probes lifted
+// from the former TestOracleCorpus, fed into the one inventory gate below.
+var categoryCaseSQLs = []string{
+	// integer types × modifiers
+	"CREATE TABLE t1 (a INT)",
+	"CREATE TABLE t2 (a INT UNSIGNED)",
+	"CREATE TABLE t3 (a INT SIGNED)",
+	"CREATE TABLE t4 (a INT(11))",
+	"CREATE TABLE t5 (a INT UNSIGNED ZEROFILL)",
+	"CREATE TABLE t6 (a TINYINT SIGNED)",
+	"CREATE TABLE t7 (a TINYINT UNSIGNED ZEROFILL)",
+	"CREATE TABLE t8 (a SMALLINT(5) UNSIGNED)",
+	"CREATE TABLE t9 (a MEDIUMINT SIGNED)",
+	"CREATE TABLE t10 (a BIGINT(20) UNSIGNED)",
+	"CREATE TABLE t11 (a INT1 UNSIGNED)",
+	"CREATE TABLE t12 (a INT8 SIGNED)",
+	// decimal & float types
+	"CREATE TABLE t13 (a DECIMAL)",
+	"CREATE TABLE t14 (a DECIMAL(10))",
+	"CREATE TABLE t15 (a DECIMAL(10,2))",
+	"CREATE TABLE t16 (a DECIMAL(10,2) UNSIGNED)",
+	"CREATE TABLE t17 (a NUMERIC(10,2))",
+	"CREATE TABLE t18 (a DEC(10,2))",
+	"CREATE TABLE t19 (a FIXED(10,2))",
+	"CREATE TABLE t20 (a FLOAT)",
+	"CREATE TABLE t21 (a FLOAT(10,2))",
+	"CREATE TABLE t22 (a FLOAT(24))",
+	"CREATE TABLE t23 (a FLOAT(25))",
+	"CREATE TABLE t24 (a DOUBLE)",
+	"CREATE TABLE t25 (a DOUBLE PRECISION)",
+	"CREATE TABLE t26 (a REAL)",
+	"CREATE TABLE t27 (a FLOAT4)",
+	"CREATE TABLE t28 (a FLOAT8)",
+	// string & binary types
+	"CREATE TABLE t29 (a CHAR(10))",
+	"CREATE TABLE t30 (a CHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci)",
+	"CREATE TABLE t31 (a VARCHAR(255))",
+	"CREATE TABLE t32 (a TEXT)",
+	"CREATE TABLE t33 (a TEXT(1000))",
+	"CREATE TABLE t34 (a TINYTEXT)",
+	"CREATE TABLE t35 (a MEDIUMTEXT CHARACTER SET latin1)",
+	"CREATE TABLE t36 (a LONGTEXT)",
+	"CREATE TABLE t37 (a LONG)",
+	"CREATE TABLE t38 (a LONG VARCHAR)",
+	"CREATE TABLE t39 (a BINARY(16))",
+	"CREATE TABLE t40 (a VARBINARY(255))",
+	"CREATE TABLE t41 (a BLOB)",
+	"CREATE TABLE t42 (a BLOB(1000))",
+	"CREATE TABLE t43 (a TINYBLOB)",
+	"CREATE TABLE t44 (a MEDIUMBLOB)",
+	"CREATE TABLE t45 (a LONGBLOB)",
+	"CREATE TABLE t46 (a LONG VARBINARY)",
+	"CREATE TABLE t47 (a NATIONAL CHAR(10))",
+	"CREATE TABLE t48 (a NCHAR(10))",
+	"CREATE TABLE t49 (a NVARCHAR(100))",
+	// date/time, json, spatial & special
+	"CREATE TABLE t50 (a DATE)",
+	"CREATE TABLE t51 (a TIME)",
+	"CREATE TABLE t52 (a TIME(3))",
+	"CREATE TABLE t53 (a DATETIME)",
+	"CREATE TABLE t54 (a DATETIME(6))",
+	"CREATE TABLE t55 (a TIMESTAMP)",
+	"CREATE TABLE t56 (a TIMESTAMP(3))",
+	"CREATE TABLE t57 (a YEAR)",
+	"CREATE TABLE t58 (a BIT(8))",
+	"CREATE TABLE t59 (a BOOL)",
+	"CREATE TABLE t60 (a JSON)",
+	"CREATE TABLE t61 (a SERIAL)",
+	"CREATE TABLE t62 (a ENUM('a','b','c'))",
+	"CREATE TABLE t63 (a SET('x','y','z'))",
+	"CREATE TABLE t64 (a GEOMETRY)",
+	"CREATE TABLE t65 (a POINT)",
+	"CREATE TABLE t66 (a LINESTRING)",
+	"CREATE TABLE t67 (a POLYGON)",
+	"CREATE TABLE t68 (a GEOMETRYCOLLECTION)",
+	// window functions
+	"SELECT RANK() OVER w FROM t WINDOW w AS (ORDER BY id)",
+	"SELECT ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC) FROM t",
+	"SELECT LAG(val) OVER (ORDER BY id) FROM t",
+	"SELECT LAG(val, 2, 0) OVER (ORDER BY id) FROM t",
+	"SELECT NTH_VALUE(val, 3) OVER (ORDER BY id) FROM t",
+	"SELECT SUM(val) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM t",
+	"SELECT DENSE_RANK() OVER (ORDER BY score), PERCENT_RANK() OVER (ORDER BY score) FROM t",
+	// interval expressions
+	"SELECT NOW() + INTERVAL 1 DAY",
+	"SELECT NOW() - INTERVAL 2 HOUR",
+	"SELECT DATE_ADD('2024-01-01', INTERVAL 1 MONTH)",
+	"SELECT DATE_SUB(NOW(), INTERVAL 30 MINUTE)",
+	"SELECT TIMESTAMPADD(MINUTE, 30, NOW())",
+	"SELECT EXTRACT(HOUR FROM NOW())",
+	"SELECT * FROM t WHERE created_at > NOW() - INTERVAL 7 DAY",
+	"SELECT * FROM t WHERE created_at BETWEEN NOW() - INTERVAL 1 MONTH AND NOW()",
+	// expected-reject probes (incl. the former knownMismatch reserved-word cases)
+	"CREATE TABLE t_rej1 (a VARCHAR UNSIGNED)",
+	"CREATE TABLE t_rej2 (a TEXT ZEROFILL)",
+	"CREATE TABLE t_rej3 (a JSON UNSIGNED)",
+	"CREATE TABLE select (a INT)",
+	"CREATE TABLE t_rej5 (select INT)",
+	"ALTER TABLE t PARTITION BY",
+	"ALTER TABLE t PARTITION BY RANGE(id)",
+	"SELECT DATE_ADD(d, INTERVAL 1 INVALID_UNIT) FROM t",
+}
+
+// containerFatalVerbs name statements whose *execution* would kill the shared
+// container or connection (not caught by max_statement_time); skip-listed.
+var containerFatalVerbs = []string{"SHUTDOWN", "KILL"}
+
+// gatherOracleInputs collects the corpus statements + category cases, deduped on
+// the EXACT statement text. No whitespace normalization: collapsing whitespace
+// would corrupt string literals; the corpus is stable committed data, so
+// reformat-churn is low-risk and would surface as UNREVIEWED+STALE pairs to re-pin.
+func gatherOracleInputs(t *testing.T) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	var out []string
+	add := func(sqlStr string) {
+		sqlStr = strings.TrimSpace(sqlStr)
+		if sqlStr == "" || seen[sqlStr] {
+			return
+		}
+		up := strings.ToUpper(sqlStr)
+		for _, v := range containerFatalVerbs {
+			if strings.HasPrefix(up, v) {
+				t.Logf("skip (container-fatal verb %s): %q", v, sqlStr)
+				return
+			}
+		}
+		seen[sqlStr] = true
+		out = append(out, sqlStr)
 	}
-	if neg {
-		digits = append([]byte{'-'}, digits...)
+	dir := filepath.Join("..", "quality", "corpus")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read corpus dir: %v", err)
 	}
-	return string(digits)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		for _, s := range loadCorpusStatements(t, filepath.Join(dir, e.Name())) {
+			add(s.sql)
+		}
+	}
+	for _, s := range categoryCaseSQLs {
+		add(s)
+	}
+	return out
+}
+
+// divergence is one reviewed entry: a statement where omni's parser and real
+// MariaDB 11.8 disagree, with the attributed MariaDB reason.
+type divergence struct {
+	sql      string // EXACT statement text (must match gatherOracleInputs output)
+	omniSide bool   // true: omni accepts & MariaDB rejects (subtractive over-accept); false: omni rejects & MariaDB accepts
+	reason   string
+}
+
+// subtractiveDivergences — the REVIEWED inventory and the P1+ backlog. Authored
+// from the measure run against mariadb:11.8.8 over the mysql corpus + category
+// probes, each entry's engine behavior re-confirmed on real MySQL 8.0 AND
+// MariaDB 11.8.8. The corpus exercises subtractive divergence only incidentally
+// — "1 entry" is a LOWER BOUND, not the full subtractive surface; the authored
+// MariaDB corpus (Phase-0 mdbcheck) is where the bulk (additive + more
+// subtractive) lives.
+var subtractiveDivergences = []divergence{
+	{
+		sql:      "SELECT LAG(val, 2, 0) OVER (ORDER BY id) FROM t",
+		omniSide: true, // MySQL 8.0 accepts, MariaDB 11.8.8 rejects (1064); omni mirrors MySQL.
+		reason:   "LAG()/LEAD() 3rd 'default value' argument: VALID in MySQL 8.0, REJECTED by MariaDB 11.8.8 at parse (1064) — confirmed on both real engines. omni mirrors MySQL. (LEAD shares this divergence; it isn't a separate corpus statement.) P1 candidate: gate the window-function default-value arg behind a MariaDB flag.",
+	},
+}
+
+func TestMariaDBDivergenceInventory(t *testing.T) {
+	o := startMariaDB(t)
+
+	// Seed the referent table a few category SELECTs reference (window/interval).
+	_, _ = o.db.ExecContext(o.ctx,
+		"CREATE TABLE IF NOT EXISTS t (id INT, val INT, score INT, status INT, name VARCHAR(100), dept VARCHAR(50), salary DECIMAL(10,2), d DATE, created_at DATETIME)")
+
+	want := map[string]divergence{}
+	for _, d := range subtractiveDivergences {
+		want[d.sql] = d
+	}
+
+	live := map[string]bool{} // exact sql → omniAccepts, for diverging stmts only
+	codeTally := map[uint16]int{}
+	for _, sqlStr := range gatherOracleInputs(t) {
+		_, perr := Parse(sqlStr)
+		omniAccepts := perr == nil
+		v, code, msg := o.classify(sqlStr)
+		codeTally[code]++
+		if v == vErrored {
+			t.Errorf("ERRORED (infra, not a parse verdict) for %q: %s", sqlStr, msg)
+			continue
+		}
+		mdbAccepts := v == vAccepted
+		if omniAccepts != mdbAccepts {
+			live[sqlStr] = omniAccepts
+			t.Logf("divergence omni=%v mariadb=%v code=%d %q", omniAccepts, mdbAccepts, code, sqlStr)
+		}
+	}
+
+	for sqlStr, omniAccepts := range live {
+		d, ok := want[sqlStr]
+		if !ok {
+			t.Errorf("UNREVIEWED divergence (omni=%v mariadb=%v): %q\n  → add to subtractiveDivergences with a reason, or fix the parser", omniAccepts, !omniAccepts, sqlStr)
+			continue
+		}
+		if d.omniSide != omniAccepts {
+			t.Errorf("divergence DIRECTION changed for %q (was omniSide=%v, now omniAccepts=%v)", sqlStr, d.omniSide, omniAccepts)
+		}
+	}
+	for sqlStr := range want {
+		if _, ok := live[sqlStr]; !ok {
+			t.Errorf("STALE allowlist entry (no longer diverges): %q\n  → remove from subtractiveDivergences (resolved)", sqlStr)
+		}
+	}
+	t.Logf("MariaDB inventory: %d pinned, %d live | code tally (0=clean accept): %v", len(want), len(live), codeTally)
 }

--- a/mariadb/parser/oracle_test.go
+++ b/mariadb/parser/oracle_test.go
@@ -5,19 +5,20 @@ import (
 	"database/sql"
 	"testing"
 
-	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/testcontainers/testcontainers-go"
 	tcmysql "github.com/testcontainers/testcontainers-go/modules/mysql"
 )
 
-// parserOracle wraps a MySQL 8.0 container for syntax-level oracle testing.
+// parserOracle wraps a SQL container for syntax-level oracle testing.
 type parserOracle struct {
 	db  *sql.DB
 	ctx context.Context
 }
 
-// startParserOracle starts MySQL 8.0 via testcontainers and returns a
-// parserOracle. The container is cleaned up automatically when the test ends.
+// startParserOracle starts MySQL 8.0 via testcontainers. Used by the routine
+// alignment oracle (routine_alignment_test.go). The MariaDB 11.8 divergence
+// inventory uses startMariaDB (oracle_corpus_test.go) instead — repointing the
+// routine oracle to MariaDB is follow-up (P1+) work, out of PR1 scope.
 func startParserOracle(t *testing.T) *parserOracle {
 	t.Helper()
 	if testing.Short() {
@@ -52,58 +53,4 @@ func startParserOracle(t *testing.T) *parserOracle {
 	}
 
 	return &parserOracle{db: db, ctx: ctx}
-}
-
-// checkSyntax sends SQL to MySQL 8.0 and returns true if syntactically valid.
-// Strategy: execute the SQL. If MySQL returns error code 1064 (ER_PARSE_ERROR),
-// the SQL is syntactically invalid (rejected). Any other error (e.g. 1146 table
-// not found) means the SQL parsed fine but failed for semantic reasons (accepted).
-func (o *parserOracle) checkSyntax(sql string) bool {
-	_, err := o.db.ExecContext(o.ctx, sql)
-	if err == nil {
-		return true // executed successfully — valid syntax
-	}
-	if myErr, ok := err.(*gomysql.MySQLError); ok {
-		return myErr.Number != 1064 // 1064 = ER_PARSE_ERROR
-	}
-	// Non-MySQL error (connection issue, etc.) — treat as valid to avoid
-	// false negatives; the caller should investigate.
-	return true
-}
-
-// assertOracleMatch parses with omni parser AND checks against MySQL 8.0,
-// asserting both accept or both reject.
-func assertOracleMatch(t *testing.T, o *parserOracle, sql string) {
-	t.Helper()
-
-	_, omniErr := Parse(sql)
-	omniAccepts := omniErr == nil
-
-	mysqlAccepts := o.checkSyntax(sql)
-
-	if omniAccepts != mysqlAccepts {
-		t.Errorf("MISMATCH for %q:\n  omni accepts=%v (err=%v)\n  mysql accepts=%v",
-			sql, omniAccepts, omniErr, mysqlAccepts)
-	} else {
-		t.Logf("MATCH for %q: both accept=%v", sql, omniAccepts)
-	}
-}
-
-// assertOracleMismatch logs a known mismatch between omni and MySQL 8.0 without
-// failing the test. These are tracked as [~] partial in the SCENARIOS file.
-func assertOracleMismatch(t *testing.T, o *parserOracle, sql string) {
-	t.Helper()
-
-	_, omniErr := Parse(sql)
-	omniAccepts := omniErr == nil
-
-	mysqlAccepts := o.checkSyntax(sql)
-
-	if omniAccepts != mysqlAccepts {
-		t.Logf("KNOWN MISMATCH for %q:\n  omni accepts=%v (err=%v)\n  mysql accepts=%v",
-			sql, omniAccepts, omniErr, mysqlAccepts)
-	} else {
-		// If the mismatch is resolved (e.g. by a parser fix), promote to match.
-		t.Logf("RESOLVED — now MATCH for %q: both accept=%v (was known mismatch)", sql, omniAccepts)
-	}
 }


### PR DESCRIPTION
MariaDB 11.8 container oracle + a **pinned subtractive-divergence inventory** — the deliverable is the reviewed allowlist, not "green parity" (BYT-9135, PR1).

## What this adds
- `startMariaDB` — `mariadb:11.8.8` via the testcontainers `modules/mariadb` helper (its wait strategy handles MariaDB's double-start entrypoint that a bare port-wait races); `testing.Short()`-gated.
- `classify` — 3-valued (`accepted`/`rejected`/`errored`), **1064-scoped** (MariaDB reserves 1064 for parse errors). Server-side `max_statement_time`/`lock_wait_timeout` guard hangs without poisoning the pooled conn; a non-`MySQLError` surfaces as `ERRORED`, never silently accepted.
- `TestMariaDBDivergenceInventory` — runs the mysql corpus + category probes through omni's `Parse` and the live container; asserts the live mismatch set **equals** the reviewed `subtractiveDivergences` allowlist, **bidirectionally** (`UNREVIEWED` if a live divergence isn't pinned; `STALE` if a pinned entry no longer diverges). Replaces the scattered, never-failing `knownMismatch` bools.

## The inventory — 1 entry (a lower bound)
`LAG()`/`LEAD()` 3rd "default value" argument: **valid in MySQL 8.0, rejected by MariaDB 11.8.8 (1064)** — confirmed on both real engines; omni mirrors MySQL.

"1 entry" is a **lower bound** — the mysql corpus exercises subtractive divergence only incidentally (LEAD shares it but isn't a standalone corpus statement). The authored MariaDB corpus (Phase-0 `mdbcheck`) holds the bulk: additive + more subtractive.

## Findings
- **The gate immediately earned its keep:** the 2 inherited reserved-word `knownMismatch: true` bools were **stale** — omni rejects `CREATE TABLE select` now; the never-failing `assertOracleMismatch` had logged "RESOLVED" forever. Re-validated against MariaDB, dropped — not blind-ported.
- **omni arity-fidelity gap (out of scope) → BYT-9737:** omni accepts `LAG()` / `LAG(val,2,0,99)` which **MySQL itself** rejects (1064) — generic `parseFuncCall`, no per-function arity. Independent of MariaDB.

## Scope
- Subtractive & 1064-scoped only; blind to additive surface and 1235 feature-gates (none in this corpus).
- `routine_alignment_test.go` keeps its mysql:8.0 oracle (repoint = P1+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)