### PR TITLE
test(mariadb/parser): pin 3 subtractive divergences from Phase-0 (MINUS, FOR SHARE)

### DIFF
--- a/mariadb/parser/oracle_corpus_test.go
+++ b/mariadb/parser/oracle_corpus_test.go
@@ -201,6 +201,10 @@ var categoryCaseSQLs = []string{
 	"ALTER TABLE t PARTITION BY",
 	"ALTER TABLE t PARTITION BY RANGE(id)",
 	"SELECT DATE_ADD(d, INTERVAL 1 INVALID_UNIT) FROM t",
+	// MariaDB subtractive divergences — Phase-0 mdbcheck OVER findings (omni accepts, MariaDB rejects)
+	"SELECT 1 MINUS SELECT 2",
+	"SELECT 1 MINUS SELECT 2 MINUS SELECT 3",
+	"SELECT * FROM t WHERE id = 1 FOR SHARE",
 }
 
 // containerFatalVerbs name statements whose *execution* would kill the shared
@@ -269,6 +273,21 @@ var subtractiveDivergences = []divergence{
 		sql:      "SELECT LAG(val, 2, 0) OVER (ORDER BY id) FROM t",
 		omniSide: true, // MySQL 8.0 accepts, MariaDB 11.8.8 rejects (1064); omni mirrors MySQL.
 		reason:   "LAG()/LEAD() 3rd 'default value' argument: VALID in MySQL 8.0, REJECTED by MariaDB 11.8.8 at parse (1064) — confirmed on both real engines. omni mirrors MySQL. (LEAD shares this divergence; it isn't a separate corpus statement.) P1 candidate: gate the window-function default-value arg behind a MariaDB flag.",
+	},
+	{
+		sql:      "SELECT 1 MINUS SELECT 2",
+		omniSide: true, // omni over-accepts MINUS; MariaDB rejects it in default mode (1064).
+		reason:   "MINUS set operator: omni over-accepts it unconditionally; MariaDB accepts MINUS only under sql_mode=ORACLE, rejects it in default mode (1064). Phase-0 mdbcheck OVER finding. Candidate: gate MINUS behind the Oracle sql_mode flag.",
+	},
+	{
+		sql:      "SELECT 1 MINUS SELECT 2 MINUS SELECT 3",
+		omniSide: true, // chained MINUS — same divergence as the 2-operand form.
+		reason:   "MINUS set operator (chained): same divergence as the single MINUS — omni over-accepts; MariaDB default-mode rejects (1064), Oracle-mode only.",
+	},
+	{
+		sql:      "SELECT * FROM t WHERE id = 1 FOR SHARE",
+		omniSide: true, // omni mirrors MySQL's FOR SHARE; MariaDB rejects it (1064).
+		reason:   "FOR SHARE locking clause: valid in MySQL 8.0 and omni mirrors it; MariaDB has no FOR SHARE (uses LOCK IN SHARE MODE) and rejects at parse (1064). Phase-0 mdbcheck OVER finding.",
 	},
 }
 


### PR DESCRIPTION
Folds the 3 Phase-0 `mdbcheck` OVER findings (omni over-accepts vs MariaDB) into the PR1 subtractive-divergence inventory — their home is the allowlist, not standalone tickets.

## Entries added (all MariaDB 1064 at parse; omni mirrors MySQL)
- `SELECT 1 MINUS SELECT 2` + chained — omni over-accepts `MINUS`; MariaDB accepts it only under `sql_mode=ORACLE`, rejects it in default mode.
- `SELECT * FROM t WHERE id = 1 FOR SHARE` — MariaDB has no `FOR SHARE` (only `LOCK IN SHARE MODE`).

The bidirectional gate now exercises on **4 live entries** (was 1), each confirmed `omni=accept / mariadb=reject(1064)` against the live `mariadb:11.8.8` container. **Test-only** — touches `categoryCaseSQLs` + `subtractiveDivergences`, no parser change → zero conflict with the upcoming P2 work.

Establishes an honest subtractive baseline before P2 starts mutating the grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)