### PR TITLE
feat(mariadb): parse SEQUENCE objects + NEXT/PREVIOUS VALUE FOR

### DIFF
--- a/mariadb/ast/outfuncs.go
+++ b/mariadb/ast/outfuncs.go
@@ -459,6 +459,16 @@ func writeNode(sb *strings.Builder, node Node) {
 		fmt.Fprintf(sb, "{HELP :loc %d :topic %q}", n.Loc.Start, n.Topic)
 	case *VCPUSpec:
 		writeVCPUSpec(sb, n)
+	case *CreateSequenceStmt:
+		writeCreateSequenceStmt(sb, n)
+	case *AlterSequenceStmt:
+		writeAlterSequenceStmt(sb, n)
+	case *DropSequenceStmt:
+		writeDropSequenceStmt(sb, n)
+	case *NextValueForExpr:
+		writeNextValueForExpr(sb, n)
+	case *PreviousValueForExpr:
+		writePreviousValueForExpr(sb, n)
 
 	default:
 		fmt.Fprintf(sb, "{UNKNOWN %T}", node)
@@ -4905,4 +4915,156 @@ func writeVCPUSpec(sb *strings.Builder, n *VCPUSpec) {
 	} else {
 		fmt.Fprintf(sb, "{VCPU %d-%d}", n.Start, n.End)
 	}
+}
+
+func writeCreateSequenceStmt(sb *strings.Builder, n *CreateSequenceStmt) {
+	sb.WriteString("{CREATE_SEQUENCE")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.OrReplace {
+		sb.WriteString(" :or_replace true")
+	}
+	if n.Temporary {
+		sb.WriteString(" :temporary true")
+	}
+	if n.IfNotExists {
+		sb.WriteString(" :if_not_exists true")
+	}
+	if n.Name != nil {
+		sb.WriteString(" :name ")
+		writeNode(sb, n.Name)
+	}
+	if n.DataType != nil {
+		sb.WriteString(" :as ")
+		writeNode(sb, n.DataType)
+	}
+	if n.Start != nil {
+		sb.WriteString(" :start ")
+		writeNode(sb, n.Start)
+	}
+	if n.Increment != nil {
+		sb.WriteString(" :increment ")
+		writeNode(sb, n.Increment)
+	}
+	if n.MinValue != nil {
+		sb.WriteString(" :minvalue ")
+		writeNode(sb, n.MinValue)
+	}
+	if n.MaxValue != nil {
+		sb.WriteString(" :maxvalue ")
+		writeNode(sb, n.MaxValue)
+	}
+	if n.NoMinValue {
+		sb.WriteString(" :nominvalue true")
+	}
+	if n.NoMaxValue {
+		sb.WriteString(" :nomaxvalue true")
+	}
+	if n.Cache != nil {
+		sb.WriteString(" :cache ")
+		writeNode(sb, n.Cache)
+	}
+	if n.NoCache {
+		sb.WriteString(" :nocache true")
+	}
+	if n.Cycle != nil {
+		fmt.Fprintf(sb, " :cycle %t", *n.Cycle)
+	}
+	sb.WriteString("}")
+}
+
+func writeAlterSequenceStmt(sb *strings.Builder, n *AlterSequenceStmt) {
+	sb.WriteString("{ALTER_SEQUENCE")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.IfExists {
+		sb.WriteString(" :if_exists true")
+	}
+	if n.Name != nil {
+		sb.WriteString(" :name ")
+		writeNode(sb, n.Name)
+	}
+	if n.DataType != nil {
+		sb.WriteString(" :as ")
+		writeNode(sb, n.DataType)
+	}
+	if n.Start != nil {
+		sb.WriteString(" :start ")
+		writeNode(sb, n.Start)
+	}
+	if n.Restart {
+		sb.WriteString(" :restart true")
+	}
+	if n.RestartWith != nil {
+		sb.WriteString(" :restart_with ")
+		writeNode(sb, n.RestartWith)
+	}
+	if n.Increment != nil {
+		sb.WriteString(" :increment ")
+		writeNode(sb, n.Increment)
+	}
+	if n.MinValue != nil {
+		sb.WriteString(" :minvalue ")
+		writeNode(sb, n.MinValue)
+	}
+	if n.MaxValue != nil {
+		sb.WriteString(" :maxvalue ")
+		writeNode(sb, n.MaxValue)
+	}
+	if n.NoMinValue {
+		sb.WriteString(" :nominvalue true")
+	}
+	if n.NoMaxValue {
+		sb.WriteString(" :nomaxvalue true")
+	}
+	if n.Cache != nil {
+		sb.WriteString(" :cache ")
+		writeNode(sb, n.Cache)
+	}
+	if n.NoCache {
+		sb.WriteString(" :nocache true")
+	}
+	if n.Cycle != nil {
+		fmt.Fprintf(sb, " :cycle %t", *n.Cycle)
+	}
+	sb.WriteString("}")
+}
+
+func writeDropSequenceStmt(sb *strings.Builder, n *DropSequenceStmt) {
+	sb.WriteString("{DROP_SEQUENCE")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.Temporary {
+		sb.WriteString(" :temporary true")
+	}
+	if n.IfExists {
+		sb.WriteString(" :if_exists true")
+	}
+	if len(n.Sequences) > 0 {
+		sb.WriteString(" :sequences ")
+		for i, s := range n.Sequences {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			writeNode(sb, s)
+		}
+	}
+	sb.WriteString("}")
+}
+
+func writeNextValueForExpr(sb *strings.Builder, n *NextValueForExpr) {
+	sb.WriteString("{NEXT_VALUE_FOR")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.Sequence != nil {
+		sb.WriteString(" :sequence ")
+		writeNode(sb, n.Sequence)
+	}
+	sb.WriteString("}")
+}
+
+func writePreviousValueForExpr(sb *strings.Builder, n *PreviousValueForExpr) {
+	sb.WriteString("{PREVIOUS_VALUE_FOR")
+	fmt.Fprintf(sb, " :loc %d", n.Loc.Start)
+	if n.Sequence != nil {
+		sb.WriteString(" :sequence ")
+		writeNode(sb, n.Sequence)
+	}
+	sb.WriteString("}")
 }

--- a/mariadb/ast/parsenodes.go
+++ b/mariadb/ast/parsenodes.go
@@ -2911,3 +2911,97 @@ type RawStmt struct {
 
 func (s *RawStmt) nodeTag()  {}
 func (s *RawStmt) stmtNode() {}
+
+// ---------------------------------------------------------------------------
+// Sequence statements and expressions (BYT-9135, MariaDB 11.8).
+//
+// Ported from the mssql donor (CreateSequenceStmt/AlterSequenceStmt/
+// NextValueForExpr), adapted to the MariaDB grammar: the SQL-Server-only OVER
+// clause on the value expression is dropped (MariaDB rejects
+// NEXT VALUE FOR seq OVER (...) with 1064), and CREATE carries MariaDB's
+// OR REPLACE / IF NOT EXISTS.
+// ---------------------------------------------------------------------------
+
+// CreateSequenceStmt represents CREATE [OR REPLACE] SEQUENCE [IF NOT EXISTS]
+// name with any-order options.
+//
+//	CREATE [OR REPLACE] SEQUENCE [IF NOT EXISTS] name
+//	    [AS int_type] [START [WITH] n] [INCREMENT [BY] n]
+//	    [MINVALUE n | NOMINVALUE | NO MINVALUE]
+//	    [MAXVALUE n | NOMAXVALUE | NO MAXVALUE]
+//	    [CACHE n | NOCACHE] [CYCLE | NOCYCLE]
+type CreateSequenceStmt struct {
+	Loc         Loc
+	Name        *TableRef // [schema.]sequence_name
+	OrReplace   bool      // CREATE OR REPLACE SEQUENCE
+	Temporary   bool      // CREATE TEMPORARY SEQUENCE
+	IfNotExists bool      // IF NOT EXISTS
+	DataType    *DataType // AS int_type (optional)
+	Start       ExprNode  // START [WITH] n
+	Increment   ExprNode  // INCREMENT [BY] n
+	MinValue    ExprNode  // MINVALUE n
+	MaxValue    ExprNode  // MAXVALUE n
+	NoMinValue  bool      // NOMINVALUE / NO MINVALUE
+	NoMaxValue  bool      // NOMAXVALUE / NO MAXVALUE
+	Cache       ExprNode  // CACHE n
+	NoCache     bool      // NOCACHE
+	Cycle       *bool     // CYCLE (true) / NOCYCLE (false) / nil unset
+}
+
+func (n *CreateSequenceStmt) nodeTag()  {}
+func (n *CreateSequenceStmt) stmtNode() {}
+
+// AlterSequenceStmt represents ALTER SEQUENCE [IF EXISTS] name with any-order
+// options. Per the MariaDB 11.8 grammar (container-verified), ALTER accepts the
+// same options as CREATE — including AS int_type and START — plus RESTART; the
+// only CREATE/ALTER difference is that RESTART is rejected in CREATE.
+type AlterSequenceStmt struct {
+	Loc         Loc
+	Name        *TableRef
+	IfExists    bool
+	DataType    *DataType // AS int_type (optional)
+	Start       ExprNode  // START [WITH] n
+	Restart     bool      // RESTART
+	RestartWith ExprNode  // RESTART [WITH] n
+	Increment   ExprNode  // INCREMENT [BY] n
+	MinValue    ExprNode  // MINVALUE n
+	MaxValue    ExprNode  // MAXVALUE n
+	NoMinValue  bool      // NOMINVALUE / NO MINVALUE
+	NoMaxValue  bool      // NOMAXVALUE / NO MAXVALUE
+	Cache       ExprNode  // CACHE n
+	NoCache     bool      // NOCACHE
+	Cycle       *bool     // CYCLE / NOCYCLE / nil unset
+}
+
+func (n *AlterSequenceStmt) nodeTag()  {}
+func (n *AlterSequenceStmt) stmtNode() {}
+
+// DropSequenceStmt represents DROP SEQUENCE [IF EXISTS] name [, name ...].
+type DropSequenceStmt struct {
+	Loc       Loc
+	Temporary bool
+	IfExists  bool
+	Sequences []*TableRef
+}
+
+func (n *DropSequenceStmt) nodeTag()  {}
+func (n *DropSequenceStmt) stmtNode() {}
+
+// NextValueForExpr represents NEXT VALUE FOR sequence_name. The SQL-Server OVER
+// clause is intentionally absent (MariaDB rejects it with 1064).
+type NextValueForExpr struct {
+	Loc      Loc
+	Sequence *TableRef
+}
+
+func (n *NextValueForExpr) nodeTag()  {}
+func (n *NextValueForExpr) exprNode() {}
+
+// PreviousValueForExpr represents PREVIOUS VALUE FOR sequence_name.
+type PreviousValueForExpr struct {
+	Loc      Loc
+	Sequence *TableRef
+}
+
+func (n *PreviousValueForExpr) nodeTag()  {}
+func (n *PreviousValueForExpr) exprNode() {}

--- a/mariadb/ast/sequence_ast_test.go
+++ b/mariadb/ast/sequence_ast_test.go
@@ -1,0 +1,140 @@
+package ast
+
+import (
+	"reflect"
+	"testing"
+)
+
+func seqBoolPtr(b bool) *bool { return &b }
+
+// TestSequenceNodesOutput is the outfuncs round-trip assertion for the 5 sequence
+// nodes (BYT-9135). Each node is serialized via NodeToString and matched against
+// its deterministic S-expression form, which exercises the writeNode dispatch +
+// per-node writer and locks the field set.
+func TestSequenceNodesOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		node Node
+		want string
+	}{
+		{
+			name: "create sequence with value options",
+			node: &CreateSequenceStmt{
+				Name:      &TableRef{Name: "s"},
+				OrReplace: true,
+				Start:     &IntLit{Value: 1},
+			},
+			want: "{CREATE_SEQUENCE :loc 0 :or_replace true :name {TABLEREF :loc 0 :name s} :start {INT_LIT :val 1 :loc 0}}",
+		},
+		{
+			name: "create sequence with no-form flags and nocycle",
+			node: &CreateSequenceStmt{
+				Name:        &TableRef{Name: "s"},
+				IfNotExists: true,
+				NoMinValue:  true,
+				NoMaxValue:  true,
+				NoCache:     true,
+				Cycle:       seqBoolPtr(false),
+			},
+			want: "{CREATE_SEQUENCE :loc 0 :if_not_exists true :name {TABLEREF :loc 0 :name s} :nominvalue true :nomaxvalue true :nocache true :cycle false}",
+		},
+		{
+			name: "alter sequence restart with",
+			node: &AlterSequenceStmt{
+				Name:        &TableRef{Name: "s"},
+				IfExists:    true,
+				Restart:     true,
+				RestartWith: &IntLit{Value: 500},
+			},
+			want: "{ALTER_SEQUENCE :loc 0 :if_exists true :name {TABLEREF :loc 0 :name s} :restart true :restart_with {INT_LIT :val 500 :loc 0}}",
+		},
+		{
+			name: "drop sequence multiple",
+			node: &DropSequenceStmt{
+				IfExists:  true,
+				Sequences: []*TableRef{{Name: "a"}, {Name: "b"}},
+			},
+			want: "{DROP_SEQUENCE :loc 0 :if_exists true :sequences {TABLEREF :loc 0 :name a} {TABLEREF :loc 0 :name b}}",
+		},
+		{
+			name: "next value for",
+			node: &NextValueForExpr{Sequence: &TableRef{Name: "s"}},
+			want: "{NEXT_VALUE_FOR :loc 0 :sequence {TABLEREF :loc 0 :name s}}",
+		},
+		{
+			name: "previous value for",
+			node: &PreviousValueForExpr{Sequence: &TableRef{Name: "s"}},
+			want: "{PREVIOUS_VALUE_FOR :loc 0 :sequence {TABLEREF :loc 0 :name s}}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NodeToString(tt.node); got != tt.want {
+				t.Errorf("NodeToString mismatch\n got: %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSequenceNodesWalkChildren verifies genwalker wired each new node's Node-typed
+// children so Walk/Inspect recurses into them (the silent-wrong-lineage guard: a
+// missing walk case drops children without error).
+func TestSequenceNodesWalkChildren(t *testing.T) {
+	tests := []struct {
+		name string
+		node Node
+		want []string
+	}{
+		{
+			name: "create sequence walks name + option exprs",
+			node: &CreateSequenceStmt{
+				Name:      &TableRef{Name: "s"},
+				Start:     &IntLit{Value: 1},
+				Increment: &IntLit{Value: 5},
+			},
+			want: []string{"CreateSequenceStmt", "TableRef", "IntLit"},
+		},
+		{
+			name: "alter sequence walks name + restart_with",
+			node: &AlterSequenceStmt{
+				Name:        &TableRef{Name: "s"},
+				RestartWith: &IntLit{Value: 500},
+			},
+			want: []string{"AlterSequenceStmt", "TableRef", "IntLit"},
+		},
+		{
+			name: "drop sequence walks each name",
+			node: &DropSequenceStmt{
+				Sequences: []*TableRef{{Name: "a"}, {Name: "b"}},
+			},
+			want: []string{"DropSequenceStmt", "TableRef"},
+		},
+		{
+			name: "next value for walks sequence",
+			node: &NextValueForExpr{Sequence: &TableRef{Name: "s"}},
+			want: []string{"NextValueForExpr", "TableRef"},
+		},
+		{
+			name: "previous value for walks sequence",
+			node: &PreviousValueForExpr{Sequence: &TableRef{Name: "s"}},
+			want: []string{"PreviousValueForExpr", "TableRef"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			visited := map[string]bool{}
+			Inspect(tt.node, func(n Node) bool {
+				if n == nil {
+					return false
+				}
+				visited[reflect.TypeOf(n).Elem().Name()] = true
+				return true
+			})
+			for _, w := range tt.want {
+				if !visited[w] {
+					t.Errorf("expected Walk to visit %s; visited: %v", w, visited)
+				}
+			}
+		})
+	}
+}

--- a/mariadb/ast/walk_generated.go
+++ b/mariadb/ast/walk_generated.go
@@ -26,6 +26,19 @@ func walkChildren(v Visitor, node Node) {
 				Walk(v, item)
 			}
 		}
+	case *AlterSequenceStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.DataType != nil {
+			Walk(v, n.DataType)
+		}
+		Walk(v, n.Start)
+		Walk(v, n.RestartWith)
+		Walk(v, n.Increment)
+		Walk(v, n.MinValue)
+		Walk(v, n.MaxValue)
+		Walk(v, n.Cache)
 	case *AlterTableCmd:
 		if n.NewTable != nil {
 			Walk(v, n.NewTable)
@@ -275,6 +288,18 @@ func walkChildren(v Visitor, node Node) {
 				Walk(v, item)
 			}
 		}
+	case *CreateSequenceStmt:
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+		if n.DataType != nil {
+			Walk(v, n.DataType)
+		}
+		Walk(v, n.Start)
+		Walk(v, n.Increment)
+		Walk(v, n.MinValue)
+		Walk(v, n.MaxValue)
+		Walk(v, n.Cache)
 	case *CreateTableStmt:
 		if n.Table != nil {
 			Walk(v, n.Table)
@@ -370,6 +395,12 @@ func walkChildren(v Visitor, node Node) {
 	case *DropRoutineStmt:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+	case *DropSequenceStmt:
+		for _, item := range n.Sequences {
+			if item != nil {
+				Walk(v, item)
+			}
 		}
 	case *DropTableStmt:
 		for _, item := range n.Tables {
@@ -628,6 +659,10 @@ func walkChildren(v Visitor, node Node) {
 	case *MemberOfExpr:
 		Walk(v, n.Value)
 		Walk(v, n.Array)
+	case *NextValueForExpr:
+		if n.Sequence != nil {
+			Walk(v, n.Sequence)
+		}
 	case *OnCondition:
 		Walk(v, n.Expr)
 	case *OptimizeTableStmt:
@@ -659,6 +694,10 @@ func walkChildren(v Visitor, node Node) {
 			if item != nil {
 				Walk(v, item)
 			}
+		}
+	case *PreviousValueForExpr:
+		if n.Sequence != nil {
+			Walk(v, n.Sequence)
 		}
 	case *PurgeBinaryLogsStmt:
 		Walk(v, n.BeforeExpr)

--- a/mariadb/ast/walk_test.go
+++ b/mariadb/ast/walk_test.go
@@ -180,6 +180,8 @@ func allKnownNodes() []Node {
 		&BinlogStmt{}, &CloneStmt{}, &RestartStmt{}, &ShutdownStmt{},
 		&HelpStmt{}, &PurgeBinaryLogsStmt{}, &ImportTableStmt{},
 		&RawStmt{},
+		// Sequence statements (BYT-9135)
+		&CreateSequenceStmt{}, &AlterSequenceStmt{}, &DropSequenceStmt{},
 
 		// Expressions
 		&ColumnRef{}, &IntLit{}, &FloatLit{}, &StringLit{},
@@ -194,6 +196,8 @@ func allKnownNodes() []Node {
 		&MatchExpr{}, &MemberOfExpr{}, &VariableRef{},
 		&ValuesStmt{}, // also an expression in some contexts
 		&JsonTableExpr{}, &JsonTableColumn{},
+		// Sequence value expressions (BYT-9135)
+		&NextValueForExpr{}, &PreviousValueForExpr{},
 
 		// Table expressions
 		&TableRef{}, &JoinClause{},

--- a/mariadb/parser/expr.go
+++ b/mariadb/parser/expr.go
@@ -438,6 +438,21 @@ func (p *Parser) parsePrimaryExpr() (nodes.ExprNode, error) {
 	case kwVALUES:
 		return p.parseValuesFunc()
 
+	case kwNEXT:
+		// NEXT VALUE FOR seq — MariaDB sequence value function. NEXT is otherwise
+		// a plain identifier (e.g. a column named "next").
+		if p.peekNext().Type == kwVALUE {
+			return p.parseNextValueFor()
+		}
+		return p.parseIdentExpr()
+
+	case kwPREVIOUS:
+		// PREVIOUS VALUE FOR seq — likewise a plain identifier otherwise.
+		if p.peekNext().Type == kwVALUE {
+			return p.parsePreviousValueFor()
+		}
+		return p.parseIdentExpr()
+
 	// Window functions and GROUPING — reserved keywords used as function calls.
 	// After registration as reserved keywords, they no longer match isIdentToken(),
 	// so we dispatch them here to parseFuncCall explicitly.

--- a/mariadb/parser/lexer.go
+++ b/mariadb/parser/lexer.go
@@ -872,6 +872,18 @@ const (
 	kwMASTER_TLS_VERSION
 	kwMASTER_USER
 	kwMASTER_ZSTD_COMPRESSION_LEVEL
+
+	// MariaDB sequence keywords (BYT-9135). The 6 siblings next/value/maxvalue/
+	// cache/restart/start are inherited from the mysql fork base.
+	kwSEQUENCE
+	kwPREVIOUS
+	kwMINVALUE
+	kwCYCLE
+	kwINCREMENT
+	kwNOCACHE
+	kwNOCYCLE
+	kwNOMINVALUE
+	kwNOMAXVALUE
 )
 
 // keywords maps lowercase keyword strings to their token types.
@@ -1677,6 +1689,17 @@ var keywords = map[string]int{
 	"week":                                   kwWEEK,
 	"weight_string":                          kwWEIGHT_STRING,
 	"zone":                                   kwZONE,
+
+	// MariaDB sequence keywords (BYT-9135).
+	"sequence":   kwSEQUENCE,
+	"previous":   kwPREVIOUS,
+	"minvalue":   kwMINVALUE,
+	"cycle":      kwCYCLE,
+	"increment":  kwINCREMENT,
+	"nocache":    kwNOCACHE,
+	"nocycle":    kwNOCYCLE,
+	"nominvalue": kwNOMINVALUE,
+	"nomaxvalue": kwNOMAXVALUE,
 }
 
 // Token represents a lexical token.

--- a/mariadb/parser/name.go
+++ b/mariadb/parser/name.go
@@ -472,6 +472,21 @@ var keywordCategories = map[int]keywordCategory{
 	kwRESOURCE:            kwCatAmbiguous3,
 	// Ambiguous 4 (not lvalue)
 	kwPERSIST:             kwCatAmbiguous4,
+
+	// MariaDB sequence keywords (BYT-9135) — all non-reserved in MariaDB, so
+	// usable as label/role/lvalue identifiers (the contexts that route through
+	// isLabelKeyword/isRoleKeyword/isLvalueKeyword, which fail closed for tokens
+	// absent here). The column-name path (parseIdent) accepts them regardless,
+	// since it gates on ">= 700 && !isReserved" rather than this map.
+	kwSEQUENCE:   kwCatUnambiguous,
+	kwPREVIOUS:   kwCatUnambiguous,
+	kwMINVALUE:   kwCatUnambiguous,
+	kwCYCLE:      kwCatUnambiguous,
+	kwINCREMENT:  kwCatUnambiguous,
+	kwNOCACHE:    kwCatUnambiguous,
+	kwNOCYCLE:    kwCatUnambiguous,
+	kwNOMINVALUE: kwCatUnambiguous,
+	kwNOMAXVALUE: kwCatUnambiguous,
 }
 
 // isReserved returns true if the token type is a reserved keyword that cannot

--- a/mariadb/parser/sequence.go
+++ b/mariadb/parser/sequence.go
@@ -1,0 +1,414 @@
+// Package parser - sequence.go implements CREATE/ALTER/DROP SEQUENCE parsing
+// for MariaDB 11.8 (BYT-9135).
+//
+// The option grammar is shared between CREATE and ALTER (container-verified):
+// both accept the same any-order options including AS int_type and START; the
+// only difference is RESTART, which is ALTER-only (CREATE ... RESTART is 1064).
+// Option values are integer literals (not expressions), and each value is
+// mandatory — bare CACHE/INCREMENT/START/MINVALUE/MAXVALUE are 1064.
+package parser
+
+import (
+	"strings"
+
+	nodes "github.com/bytebase/omni/mariadb/ast"
+)
+
+// sequenceASIntTypes is the set of integer type names MariaDB accepts after the
+// sequence AS clause. Non-integer types and any display width (INT(11)) are 1064.
+var sequenceASIntTypes = map[string]bool{
+	"TINYINT":   true,
+	"SMALLINT":  true,
+	"MEDIUMINT": true,
+	"INT":       true,
+	"INTEGER":   true,
+	"BIGINT":    true,
+}
+
+// sequenceOptions accumulates the any-order CREATE/ALTER SEQUENCE options before
+// they are copied onto the concrete statement node.
+type sequenceOptions struct {
+	dataType    *nodes.DataType
+	start       nodes.ExprNode
+	restart     bool
+	restartWith nodes.ExprNode
+	increment   nodes.ExprNode
+	minValue    nodes.ExprNode
+	maxValue    nodes.ExprNode
+	noMinValue  bool
+	noMaxValue  bool
+	cache       nodes.ExprNode
+	noCache     bool
+	cycle       *bool
+}
+
+// isEmpty reports whether no option was parsed. ALTER SEQUENCE requires at least
+// one option — MariaDB rejects a bare `ALTER SEQUENCE name` with 1064 — whereas
+// CREATE SEQUENCE permits no options.
+func (o *sequenceOptions) isEmpty() bool {
+	return o.dataType == nil && o.start == nil && !o.restart && o.restartWith == nil &&
+		o.increment == nil && o.minValue == nil && o.maxValue == nil &&
+		!o.noMinValue && !o.noMaxValue && o.cache == nil && !o.noCache && o.cycle == nil
+}
+
+// parseCreateSequenceStmt parses CREATE [OR REPLACE] SEQUENCE [IF NOT EXISTS].
+// The CREATE keyword (and any OR REPLACE / TEMPORARY) is already consumed by the
+// dispatcher; orReplace is propagated in. p.cur is the SEQUENCE keyword.
+func (p *Parser) parseCreateSequenceStmt(orReplace, temporary bool) (*nodes.CreateSequenceStmt, error) {
+	start := p.pos()
+	p.advance() // consume SEQUENCE
+
+	stmt := &nodes.CreateSequenceStmt{
+		Loc:       nodes.Loc{Start: start},
+		OrReplace: orReplace,
+		Temporary: temporary,
+	}
+
+	if p.cur.Type == kwIF {
+		p.advance()
+		if _, err := p.expect(kwNOT); err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(kwEXISTS_KW); err != nil {
+			return nil, err
+		}
+		stmt.IfNotExists = true
+	}
+
+	// Completion: sequence name is a new identifier (no candidates).
+	p.checkCursor()
+	if p.collectMode() {
+		return nil, &ParseError{Message: "collecting"}
+	}
+
+	name, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	opts, err := p.parseSequenceOptions(false)
+	if err != nil {
+		return nil, err
+	}
+	stmt.DataType = opts.dataType
+	stmt.Start = opts.start
+	stmt.Increment = opts.increment
+	stmt.MinValue = opts.minValue
+	stmt.MaxValue = opts.maxValue
+	stmt.NoMinValue = opts.noMinValue
+	stmt.NoMaxValue = opts.noMaxValue
+	stmt.Cache = opts.cache
+	stmt.NoCache = opts.noCache
+	stmt.Cycle = opts.cycle
+
+	stmt.Loc.End = p.pos()
+	return stmt, nil
+}
+
+// parseAlterSequenceStmt parses ALTER SEQUENCE [IF EXISTS] name with any-order
+// options. p.cur is the SEQUENCE keyword (ALTER already consumed).
+func (p *Parser) parseAlterSequenceStmt() (*nodes.AlterSequenceStmt, error) {
+	start := p.pos()
+	p.advance() // consume SEQUENCE
+
+	stmt := &nodes.AlterSequenceStmt{Loc: nodes.Loc{Start: start}}
+
+	if p.cur.Type == kwIF {
+		p.advance()
+		if _, err := p.expect(kwEXISTS_KW); err != nil {
+			return nil, err
+		}
+		stmt.IfExists = true
+	}
+
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("table_ref")
+		return nil, &ParseError{Message: "collecting"}
+	}
+
+	name, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	stmt.Name = name
+
+	opts, err := p.parseSequenceOptions(true)
+	if err != nil {
+		return nil, err
+	}
+	if opts.isEmpty() {
+		// MariaDB rejects a bare ALTER SEQUENCE with no options (1064).
+		return nil, p.syntaxErrorAtCur()
+	}
+	stmt.DataType = opts.dataType
+	stmt.Start = opts.start
+	stmt.Restart = opts.restart
+	stmt.RestartWith = opts.restartWith
+	stmt.Increment = opts.increment
+	stmt.MinValue = opts.minValue
+	stmt.MaxValue = opts.maxValue
+	stmt.NoMinValue = opts.noMinValue
+	stmt.NoMaxValue = opts.noMaxValue
+	stmt.Cache = opts.cache
+	stmt.NoCache = opts.noCache
+	stmt.Cycle = opts.cycle
+
+	stmt.Loc.End = p.pos()
+	return stmt, nil
+}
+
+// parseDropSequenceStmt parses DROP SEQUENCE [IF EXISTS] name [, name ...].
+// p.cur is the SEQUENCE keyword (DROP and any TEMPORARY already consumed).
+func (p *Parser) parseDropSequenceStmt(temporary bool) (*nodes.DropSequenceStmt, error) {
+	start := p.pos()
+	p.advance() // consume SEQUENCE
+
+	stmt := &nodes.DropSequenceStmt{Loc: nodes.Loc{Start: start}, Temporary: temporary}
+
+	if p.cur.Type == kwIF {
+		p.advance()
+		if _, err := p.expect(kwEXISTS_KW); err != nil {
+			return nil, err
+		}
+		stmt.IfExists = true
+	}
+
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("table_ref")
+		return nil, &ParseError{Message: "collecting"}
+	}
+
+	for {
+		ref, err := p.parseTableRef()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Sequences = append(stmt.Sequences, ref)
+		if p.cur.Type != ',' {
+			break
+		}
+		p.advance()
+	}
+
+	stmt.Loc.End = p.pos()
+	return stmt, nil
+}
+
+// parseSequenceOptions parses the any-order CREATE/ALTER SEQUENCE option list.
+// RESTART is accepted only when isAlter is true (CREATE ... RESTART is 1064).
+func (p *Parser) parseSequenceOptions(isAlter bool) (*sequenceOptions, error) {
+	opts := &sequenceOptions{}
+	for {
+		switch p.cur.Type {
+		case kwAS:
+			p.advance()
+			dt, err := p.parseSequenceASType()
+			if err != nil {
+				return nil, err
+			}
+			opts.dataType = dt
+		case kwSTART:
+			p.advance()
+			if p.cur.Type == kwWITH {
+				p.advance()
+			} else {
+				p.match('=')
+			}
+			v, err := p.parseSequenceValue()
+			if err != nil {
+				return nil, err
+			}
+			opts.start = v
+		case kwINCREMENT:
+			p.advance()
+			if p.cur.Type == kwBY {
+				p.advance()
+			} else {
+				p.match('=')
+			}
+			v, err := p.parseSequenceValue()
+			if err != nil {
+				return nil, err
+			}
+			opts.increment = v
+		case kwMINVALUE:
+			p.advance()
+			p.match('=')
+			v, err := p.parseSequenceValue()
+			if err != nil {
+				return nil, err
+			}
+			opts.minValue = v
+		case kwMAXVALUE:
+			p.advance()
+			p.match('=')
+			v, err := p.parseSequenceValue()
+			if err != nil {
+				return nil, err
+			}
+			opts.maxValue = v
+		case kwCACHE:
+			p.advance()
+			p.match('=')
+			v, err := p.parseSequenceValue()
+			if err != nil {
+				return nil, err
+			}
+			opts.cache = v
+		case kwNOCACHE:
+			p.advance()
+			opts.noCache = true
+		case kwCYCLE:
+			p.advance()
+			cycle := true
+			opts.cycle = &cycle
+		case kwNOCYCLE:
+			p.advance()
+			cycle := false
+			opts.cycle = &cycle
+		case kwNOMINVALUE:
+			p.advance()
+			opts.noMinValue = true
+		case kwNOMAXVALUE:
+			p.advance()
+			opts.noMaxValue = true
+		case kwNO:
+			// MariaDB accepts spaced NO MINVALUE / NO MAXVALUE, but NO CACHE /
+			// NO CYCLE are 1064 (one-word NOCACHE / NOCYCLE only).
+			p.advance()
+			switch p.cur.Type {
+			case kwMINVALUE:
+				p.advance()
+				opts.noMinValue = true
+			case kwMAXVALUE:
+				p.advance()
+				opts.noMaxValue = true
+			default:
+				return nil, p.syntaxErrorAtCur()
+			}
+		case kwRESTART:
+			if !isAlter {
+				return nil, p.syntaxErrorAtCur()
+			}
+			p.advance()
+			opts.restart = true
+			if p.cur.Type == kwWITH || p.cur.Type == '=' {
+				p.advance()
+				v, err := p.parseSequenceValue()
+				if err != nil {
+					return nil, err
+				}
+				opts.restartWith = v
+			} else if p.isSequenceValueStart() {
+				v, err := p.parseSequenceValue()
+				if err != nil {
+					return nil, err
+				}
+				opts.restartWith = v
+			}
+		default:
+			return opts, nil
+		}
+	}
+}
+
+// parseSequenceValue parses a sequence option value: an optionally-negated
+// integer literal. MariaDB rejects expressions/parentheses here (1064), so this
+// deliberately does not call parseExpr (which would also swallow a following
+// non-reserved option keyword such as CYCLE).
+func (p *Parser) parseSequenceValue() (nodes.ExprNode, error) {
+	start := p.pos()
+	neg := false
+	switch p.cur.Type {
+	case '-':
+		neg = true
+		p.advance()
+	case '+':
+		p.advance()
+	}
+	if p.cur.Type != tokICONST {
+		return nil, p.syntaxErrorAtCur()
+	}
+	tok := p.advance()
+	lit := &nodes.IntLit{Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}, Value: tok.Ival}
+	if neg {
+		return &nodes.UnaryExpr{
+			Loc:        nodes.Loc{Start: start, End: p.pos()},
+			Op:         nodes.UnaryMinus,
+			Operand:    lit,
+			OriginalOp: "-",
+		}, nil
+	}
+	return lit, nil
+}
+
+// isSequenceValueStart reports whether the current token can begin a sequence
+// option value, used to decide if RESTART has an (optional) value.
+func (p *Parser) isSequenceValueStart() bool {
+	return p.cur.Type == '-' || p.cur.Type == '+' || p.cur.Type == tokICONST
+}
+
+// parseSequenceASType parses and validates the AS clause type. MariaDB restricts
+// it to integer types without display width; everything else is 1064.
+func (p *Parser) parseSequenceASType() (*nodes.DataType, error) {
+	loc := p.cur.Loc
+	dt, err := p.parseDataType()
+	if err != nil {
+		return nil, err
+	}
+	if !sequenceASIntTypes[strings.ToUpper(dt.Name)] || dt.Length != 0 || dt.Scale != 0 {
+		return nil, &ParseError{
+			Message:  "sequence AS type must be an integer type without display width",
+			Position: loc,
+		}
+	}
+	return dt, nil
+}
+
+// parseNextValueFor parses NEXT VALUE FOR sequence_name as a primary expression.
+// MariaDB admits it in any expression position (the CHECK / generated-column /
+// partition restrictions are semantic, not 1064), but rejects a trailing OVER
+// clause (1064) — so, unlike the mssql donor, no OVER is parsed. The caller has
+// already confirmed p.cur is NEXT and the next token is VALUE.
+func (p *Parser) parseNextValueFor() (nodes.ExprNode, error) {
+	start := p.pos()
+	p.advance() // consume NEXT
+	if _, err := p.expect(kwVALUE); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFOR); err != nil {
+		return nil, err
+	}
+	seq, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	return &nodes.NextValueForExpr{
+		Loc:      nodes.Loc{Start: start, End: p.pos()},
+		Sequence: seq,
+	}, nil
+}
+
+// parsePreviousValueFor parses PREVIOUS VALUE FOR sequence_name (the SQL-standard
+// spelling alongside the generic LASTVAL() function). Mirrors parseNextValueFor.
+func (p *Parser) parsePreviousValueFor() (nodes.ExprNode, error) {
+	start := p.pos()
+	p.advance() // consume PREVIOUS
+	if _, err := p.expect(kwVALUE); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFOR); err != nil {
+		return nil, err
+	}
+	seq, err := p.parseTableRef()
+	if err != nil {
+		return nil, err
+	}
+	return &nodes.PreviousValueForExpr{
+		Loc:      nodes.Loc{Start: start, End: p.pos()},
+		Sequence: seq,
+	}, nil
+}

--- a/mariadb/parser/sequence_keywords_test.go
+++ b/mariadb/parser/sequence_keywords_test.go
@@ -1,0 +1,58 @@
+package parser
+
+import "testing"
+
+// newSequenceKeywords are the 9 MariaDB sequence-related keywords added in P2
+// (BYT-9135). The other 6 needed by the feature — next/value/maxvalue/cache/
+// restart/start — are already inherited from the mysql fork base.
+//
+// Each must be wired at two structural sites that the Task 3/4 parser depends on:
+//   - the lexer keywords map (so it lexes to a kw* token the parser can dispatch
+//     on via p.cur.Type == kwX, instead of an opaque tokIDENT);
+//   - keywordCategories as kwCatUnambiguous (MariaDB reserves none of them, and
+//     they are usable as label/role/lvalue identifiers — the contexts that route
+//     through isLabelKeyword/isRoleKeyword/isLvalueKeyword, all of which fail
+//     closed for tokens absent from keywordCategories).
+var newSequenceKeywords = []string{
+	"sequence", "previous", "minvalue", "cycle", "increment",
+	"nocache", "nocycle", "nominvalue", "nomaxvalue",
+}
+
+// TestSequenceKeywordsRegistered asserts each new keyword lexes to a registered
+// token AND is classified kwCatUnambiguous. This is the structural guard for all
+// three wiring sites (const + lexer map + category); a missing const/map entry
+// trips the keywords lookup, a missing category entry trips the classification.
+func TestSequenceKeywordsRegistered(t *testing.T) {
+	for _, kw := range newSequenceKeywords {
+		tok, ok := keywords[kw]
+		if !ok {
+			t.Errorf("keyword %q is not registered in the lexer keywords map", kw)
+			continue
+		}
+		cat, ok := keywordCategories[tok]
+		if !ok {
+			t.Errorf("keyword %q (token %d) is absent from keywordCategories", kw, tok)
+			continue
+		}
+		if cat != kwCatUnambiguous {
+			t.Errorf("keyword %q: want category kwCatUnambiguous (%d), got %d", kw, kwCatUnambiguous, cat)
+		}
+	}
+}
+
+// TestSequenceKeywordsUsableAsColumnNames guards the fail-open column-name path,
+// NOT the keywordCategories registration (TestSequenceKeywordsRegistered owns
+// that). Column names parse via parseColumnDef -> parseIdent, which accepts any
+// token >= 700 that is not reserved; this stays green whether or not the 9 are
+// present in keywordCategories, and would only break if one were mis-marked
+// kwCatReserved. It passed even in the pre-implementation RED state (the words
+// lexed as tokIDENT), which is exactly why it cannot catch a missing keyword
+// registration — that is the registration test's job.
+func TestSequenceKeywordsUsableAsColumnNames(t *testing.T) {
+	sql := "CREATE TABLE t (" +
+		"sequence INT, previous INT, increment INT, cycle INT, minvalue INT, " +
+		"nocache INT, nocycle INT, nominvalue INT, nomaxvalue INT)"
+	if _, err := Parse(sql); err != nil {
+		t.Fatalf("the 9 sequence keywords must remain usable as column names; got: %v", err)
+	}
+}

--- a/mariadb/parser/sequence_oracle_test.go
+++ b/mariadb/parser/sequence_oracle_test.go
@@ -68,6 +68,8 @@ var sequenceOracleCorpus = []string{
 	"CREATE SEQUENCE cr14 START WITH (5)",
 	"CREATE SEQUENCE cr15 CACHE CYCLE",
 	"CREATE SEQUENCE",
+	"CREATE OR SEQUENCE cr16",           // OR without REPLACE
+	"CREATE OR TEMPORARY SEQUENCE cr17", // OR without REPLACE (+ TEMPORARY)
 
 	// --- ALTER SEQUENCE (accept) ---
 	"ALTER SEQUENCE sq RESTART",

--- a/mariadb/parser/sequence_oracle_test.go
+++ b/mariadb/parser/sequence_oracle_test.go
@@ -1,0 +1,158 @@
+package parser
+
+import "testing"
+
+// ============================================================================
+// MariaDB 11.8 SEQUENCE conformance oracle (BYT-9135).
+//
+// Unlike TestMariaDBDivergenceInventory (which pins a subtractive allowlist),
+// the sequence surface is FULL PARITY: omni must agree with the container on
+// every statement (0 OVER, 0 GAP). sequenceOracleCorpus is the consolidated
+// container-truth set — the option matrix, the NEXT/PREVIOUS VALUE FOR position
+// matrix, and the non-reserved-keyword identifier edges — each verified parse
+// accept/reject against a live mariadb:11.8.8. Any disagreement fails.
+//
+// The identifier edges are the durable regression guard: a future keyword
+// addition (P3 system-versioning adds PERIOD/SYSTEM_TIME on the same
+// keywordCategories surface) that accidentally reserves one of these words would
+// break its column/alias use and surface here as a live divergence.
+// ============================================================================
+
+var sequenceOracleCorpus = []string{
+	// --- CREATE SEQUENCE: flags + name forms (accept) ---
+	"CREATE SEQUENCE cs_plain",
+	"CREATE SEQUENCE IF NOT EXISTS cs_ine",
+	"CREATE OR REPLACE SEQUENCE cs_cor",
+	"CREATE OR REPLACE SEQUENCE IF NOT EXISTS cs_both",
+	"CREATE TEMPORARY SEQUENCE cs_tmp",
+	// --- START / INCREMENT: WITH | BY | = | bare | signed ---
+	"CREATE OR REPLACE SEQUENCE cs1 START WITH 1000",
+	"CREATE OR REPLACE SEQUENCE cs2 START = 5",
+	"CREATE OR REPLACE SEQUENCE cs3 START 5",
+	"CREATE OR REPLACE SEQUENCE cs4 INCREMENT BY 5",
+	"CREATE OR REPLACE SEQUENCE cs5 INCREMENT = 5",
+	"CREATE OR REPLACE SEQUENCE cs6 INCREMENT 5",
+	"CREATE OR REPLACE SEQUENCE cs7 INCREMENT BY -1 MAXVALUE -1 MINVALUE -100",
+	"CREATE OR REPLACE SEQUENCE cs8 INCREMENT BY +5 START WITH +5",
+	// --- MIN/MAX/CACHE/CYCLE + NO-forms ---
+	"CREATE OR REPLACE SEQUENCE cs9 MINVALUE 10 MAXVALUE 9999",
+	"CREATE OR REPLACE SEQUENCE cs10 MINVALUE = 1 MAXVALUE = 99",
+	"CREATE OR REPLACE SEQUENCE cs11 NOMINVALUE NOMAXVALUE",
+	"CREATE OR REPLACE SEQUENCE cs12 NO MINVALUE NO MAXVALUE",
+	"CREATE OR REPLACE SEQUENCE cs13 CACHE 50",
+	"CREATE OR REPLACE SEQUENCE cs14 CACHE = 50",
+	"CREATE OR REPLACE SEQUENCE cs15 NOCACHE",
+	"CREATE OR REPLACE SEQUENCE cs16 MINVALUE 1 MAXVALUE 5 CYCLE",
+	"CREATE OR REPLACE SEQUENCE cs17 MINVALUE 1 MAXVALUE 5 NOCYCLE",
+	"CREATE OR REPLACE SEQUENCE cs18 START WITH 100 MINVALUE 10 MAXVALUE 100000 INCREMENT BY 5 CACHE 20 CYCLE",
+	// --- AS int_type (any-order) ---
+	"CREATE OR REPLACE SEQUENCE cs19 AS BIGINT",
+	"CREATE OR REPLACE SEQUENCE cs20 AS INT UNSIGNED",
+	"CREATE OR REPLACE SEQUENCE cs21 START WITH 1 AS BIGINT",
+	"CREATE OR REPLACE SEQUENCE cs22 AS TINYINT START WITH 1",
+
+	// --- CREATE rejects (1064) ---
+	"CREATE SEQUENCE cr1 RESTART",
+	"CREATE SEQUENCE cr2 RESTART WITH 5",
+	"CREATE SEQUENCE cr3 CACHE",
+	"CREATE SEQUENCE cr4 INCREMENT",
+	"CREATE SEQUENCE cr5 START",
+	"CREATE SEQUENCE cr6 INCREMENT BY",
+	"CREATE SEQUENCE cr7 NO CACHE",
+	"CREATE SEQUENCE cr8 NO CYCLE",
+	"CREATE SEQUENCE cr9 AS VARCHAR(10)",
+	"CREATE SEQUENCE cr10 AS DECIMAL(10)",
+	"CREATE SEQUENCE cr11 AS INT(11)",
+	"CREATE SEQUENCE cr12 AS DATE",
+	"CREATE SEQUENCE cr13 START WITH 1+1",
+	"CREATE SEQUENCE cr14 START WITH (5)",
+	"CREATE SEQUENCE cr15 CACHE CYCLE",
+	"CREATE SEQUENCE",
+
+	// --- ALTER SEQUENCE (accept) ---
+	"ALTER SEQUENCE sq RESTART",
+	"ALTER SEQUENCE sq RESTART WITH 500",
+	"ALTER SEQUENCE sq RESTART = 5",
+	"ALTER SEQUENCE sq RESTART 5",
+	"ALTER SEQUENCE sq INCREMENT BY 10",
+	"ALTER SEQUENCE sq MINVALUE 1 NOCACHE",
+	"ALTER SEQUENCE IF EXISTS sq RESTART WITH 1",
+	"ALTER SEQUENCE sq START WITH 5",
+	"ALTER SEQUENCE sq AS BIGINT",
+	"ALTER SEQUENCE sq RESTART INCREMENT BY 5",
+	"ALTER SEQUENCE sq INCREMENT BY 5 RESTART",
+	// --- ALTER rejects (1064) ---
+	"ALTER SEQUENCE sq", // requires at least one option
+
+	// --- DROP SEQUENCE ---
+	"DROP SEQUENCE IF EXISTS d_a",
+	"DROP SEQUENCE IF EXISTS d_a, d_b",
+	"DROP TEMPORARY SEQUENCE IF EXISTS d_c",
+	"DROP SEQUENCE d_a,", // trailing comma (1064)
+
+	// --- NEXT / PREVIOUS VALUE FOR positions (all parse-accept; OVER rejects) ---
+	"SELECT NEXT VALUE FOR sq",
+	"SELECT PREVIOUS VALUE FOR sq",
+	"SELECT NEXT VALUE FOR sq + 1",
+	"INSERT INTO pt (id, v) VALUES (NEXT VALUE FOR sq, 1)",
+	"INSERT INTO pt (id) VALUES (PREVIOUS VALUE FOR sq)",
+	"UPDATE pt SET id = NEXT VALUE FOR sq WHERE v = 1",
+	"SELECT * FROM pt WHERE id = NEXT VALUE FOR sq",
+	"SELECT id FROM pt HAVING id = NEXT VALUE FOR sq",
+	"SELECT id FROM pt ORDER BY NEXT VALUE FOR sq",
+	"CREATE OR REPLACE TABLE dseq1 (id INT DEFAULT NEXT VALUE FOR sq, v INT)",
+	"CREATE OR REPLACE TABLE dseq2 (id INT DEFAULT (NEXT VALUE FOR sq), v INT)",
+	"CREATE TABLE cseq1 (id INT CHECK (id < NEXT VALUE FOR sq))",
+	"CREATE TABLE gseq1 (id INT, g INT AS (NEXT VALUE FOR sq))",
+	"SELECT ABS(NEXT VALUE FOR sq)",
+	// --- value-function rejects (1064) ---
+	"SELECT NEXT VALUE FOR sq OVER (ORDER BY 1)",
+	"SELECT next value",     // bare NEXT VALUE without FOR
+	"SELECT previous value", // bare PREVIOUS VALUE without FOR
+
+	// --- identifier edges: non-reserved keywords as columns/aliases (durable guard) ---
+	"SELECT next FROM pt",
+	"SELECT previous FROM pt",
+	"SELECT id AS next FROM pt",
+	"SELECT id AS previous FROM pt",
+	"SELECT next, value FROM pt",
+	"CREATE OR REPLACE TABLE icols (sequence INT, previous INT, increment INT, cycle INT, minvalue INT, nocache INT, nocycle INT, nominvalue INT, nomaxvalue INT)",
+
+	// --- adversarial accepts: case-insensitivity, quoting, comments ---
+	"select nExT vAlUe fOr sq",
+	"CREATE OR REPLACE SEQUENCE `seq two` START WITH 1",
+	"SELECT NEXT /* c */ VALUE FOR sq",
+}
+
+// TestMariaDBSequenceOracle asserts omni's parser agrees with a live MariaDB
+// 11.8.8 on every statement in sequenceOracleCorpus (Short-gated container test).
+func TestMariaDBSequenceOracle(t *testing.T) {
+	o := startMariaDB(t)
+
+	// Seed the objects the position/identifier cases reference so accepts execute
+	// cleanly; non-existence would still classify as accepted (4091 != 1064), but
+	// seeding keeps the signal a clean code-0 accept.
+	for _, ddl := range []string{
+		"CREATE TABLE IF NOT EXISTS pt (id INT, v INT)",
+		"CREATE SEQUENCE IF NOT EXISTS sq",
+	} {
+		if _, err := o.db.ExecContext(o.ctx, ddl); err != nil {
+			t.Fatalf("seed %q: %v", ddl, err)
+		}
+	}
+
+	for _, sqlStr := range sequenceOracleCorpus {
+		_, perr := Parse(sqlStr)
+		omniAccepts := perr == nil
+		v, code, msg := o.classify(sqlStr)
+		if v == vErrored {
+			t.Errorf("ERRORED (infra, not a parse verdict) for %q: %s", sqlStr, msg)
+			continue
+		}
+		mdbAccepts := v == vAccepted
+		if omniAccepts != mdbAccepts {
+			t.Errorf("DIVERGENCE omni=%v mariadb=%v (code %d) for %q: %s",
+				omniAccepts, mdbAccepts, code, sqlStr, msg)
+		}
+	}
+}

--- a/mariadb/parser/sequence_test.go
+++ b/mariadb/parser/sequence_test.go
@@ -80,6 +80,9 @@ func TestSequenceAccept(t *testing.T) {
 // restrictions. Guards against over-acceptance.
 func TestSequenceReject(t *testing.T) {
 	reject := []string{
+		// OR must be followed by REPLACE (CREATE OR <object> without REPLACE → 1064)
+		"CREATE OR SEQUENCE s",
+		"CREATE OR TEMPORARY SEQUENCE s",
 		// RESTART is ALTER-only
 		"CREATE SEQUENCE s RESTART",
 		"CREATE SEQUENCE s RESTART WITH 5",

--- a/mariadb/parser/sequence_test.go
+++ b/mariadb/parser/sequence_test.go
@@ -1,0 +1,206 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mariadb/ast"
+)
+
+// TestSequenceAccept covers the CREATE/ALTER/DROP SEQUENCE accept surface
+// (BYT-9135), sourced from mdbcheck/corpus/core-sequences-returning.sql and the
+// container option-matrix recon (all verified parse-accepted by mariadb:11.8.8).
+func TestSequenceAccept(t *testing.T) {
+	accept := []string{
+		// CREATE — flags + name forms
+		"CREATE SEQUENCE s",
+		"CREATE SEQUENCE IF NOT EXISTS s",
+		"CREATE OR REPLACE SEQUENCE s",
+		"CREATE SEQUENCE db.s",
+		"CREATE TEMPORARY SEQUENCE s",
+		// CREATE — START: WITH / = / bare
+		"CREATE OR REPLACE SEQUENCE s START WITH 1000",
+		"CREATE OR REPLACE SEQUENCE s START = 5",
+		"CREATE OR REPLACE SEQUENCE s START 5",
+		// CREATE — INCREMENT: BY / = / bare / negative
+		"CREATE OR REPLACE SEQUENCE s INCREMENT BY 5",
+		"CREATE OR REPLACE SEQUENCE s INCREMENT = 5",
+		"CREATE OR REPLACE SEQUENCE s INCREMENT 5",
+		"CREATE OR REPLACE SEQUENCE s INCREMENT BY -1 MAXVALUE -1 MINVALUE -100",
+		"CREATE OR REPLACE SEQUENCE s INCREMENT BY +5",
+		"CREATE OR REPLACE SEQUENCE s START WITH +5",
+		// CREATE — MIN/MAX: value / = / NO-forms (one-word + spaced)
+		"CREATE OR REPLACE SEQUENCE s MINVALUE 10 MAXVALUE 9999",
+		"CREATE OR REPLACE SEQUENCE s MINVALUE = 1 MAXVALUE = 99",
+		"CREATE OR REPLACE SEQUENCE s NOMINVALUE NOMAXVALUE",
+		"CREATE OR REPLACE SEQUENCE s NO MINVALUE NO MAXVALUE",
+		// CREATE — CACHE / CYCLE
+		"CREATE OR REPLACE SEQUENCE s CACHE 50",
+		"CREATE OR REPLACE SEQUENCE s CACHE = 50",
+		"CREATE OR REPLACE SEQUENCE s NOCACHE",
+		"CREATE OR REPLACE SEQUENCE s MINVALUE 1 MAXVALUE 5 CYCLE",
+		"CREATE OR REPLACE SEQUENCE s MINVALUE 1 MAXVALUE 5 NOCYCLE",
+		// CREATE — all options combined (corpus)
+		"CREATE OR REPLACE SEQUENCE s START WITH 100 MINVALUE 10 MAXVALUE 100000 INCREMENT BY 5 CACHE 20 CYCLE",
+		"CREATE OR REPLACE SEQUENCE s START WITH 1 NOMINVALUE NOMAXVALUE NOCACHE NOCYCLE INCREMENT BY 1",
+		// CREATE — AS int_type (any-order with options)
+		"CREATE OR REPLACE SEQUENCE s AS BIGINT",
+		"CREATE OR REPLACE SEQUENCE s AS INT UNSIGNED",
+		"CREATE OR REPLACE SEQUENCE s AS TINYINT",
+		"CREATE OR REPLACE SEQUENCE s START WITH 1 AS BIGINT",
+		"CREATE OR REPLACE SEQUENCE s AS BIGINT START WITH 1",
+		"CREATE OR REPLACE SEQUENCE s INCREMENT BY 1 AS INT MINVALUE 1",
+		// ALTER — RESTART forms + value options + IF EXISTS
+		"ALTER SEQUENCE s RESTART",
+		"ALTER SEQUENCE s RESTART WITH 500",
+		"ALTER SEQUENCE s RESTART = 5",
+		"ALTER SEQUENCE s RESTART 5",
+		"ALTER SEQUENCE s INCREMENT BY 10",
+		"ALTER SEQUENCE s MAXVALUE 1000000",
+		"ALTER SEQUENCE s MINVALUE 1 NOCACHE",
+		"ALTER SEQUENCE IF EXISTS s RESTART WITH 1",
+		// ALTER — MariaDB also accepts START and AS (container-verified)
+		"ALTER SEQUENCE s START WITH 5",
+		"ALTER SEQUENCE s AS BIGINT",
+		"ALTER SEQUENCE s RESTART INCREMENT BY 5",
+		"ALTER SEQUENCE s INCREMENT BY 5 RESTART",
+		// DROP — single / IF EXISTS / multi / TEMPORARY
+		"DROP SEQUENCE s",
+		"DROP SEQUENCE IF EXISTS s",
+		"DROP SEQUENCE IF EXISTS a, b",
+		"DROP SEQUENCE a, b, c",
+		"DROP TEMPORARY SEQUENCE s",
+	}
+	for _, sql := range accept {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// TestSequenceReject covers the container-verified 1064 rejects: the donor
+// SQL-Server/Oracle supersets MariaDB does not accept, and the value/grammar
+// restrictions. Guards against over-acceptance.
+func TestSequenceReject(t *testing.T) {
+	reject := []string{
+		// RESTART is ALTER-only
+		"CREATE SEQUENCE s RESTART",
+		"CREATE SEQUENCE s RESTART WITH 5",
+		// option values are mandatory (bare keyword rejects)
+		"CREATE SEQUENCE s CACHE",
+		"CREATE SEQUENCE s INCREMENT",
+		"CREATE SEQUENCE s START",
+		"CREATE SEQUENCE s MINVALUE",
+		"CREATE SEQUENCE s MAXVALUE",
+		"CREATE SEQUENCE s INCREMENT BY",
+		// spaced NO CACHE / NO CYCLE (one-word NOCACHE/NOCYCLE only)
+		"CREATE SEQUENCE s NO CACHE",
+		"CREATE SEQUENCE s NO CYCLE",
+		// AS restricted to integer types without display width
+		"CREATE SEQUENCE s AS VARCHAR(10)",
+		"CREATE SEQUENCE s AS DECIMAL(10)",
+		"CREATE SEQUENCE s AS INT(11)",
+		"CREATE SEQUENCE s AS DATE",
+		// option values are integer literals, not expressions
+		"CREATE SEQUENCE s START WITH 1+1",
+		"CREATE SEQUENCE s START WITH (5)",
+		"CREATE SEQUENCE s CACHE CYCLE",
+		"CREATE SEQUENCE s MINVALUE MAXVALUE 9",
+		// ALTER requires at least one option (CREATE does not)
+		"ALTER SEQUENCE s",
+	}
+	for _, sql := range reject {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
+// TestSequenceAST verifies field population for representative statements
+// (robust against byte-offset churn, unlike a full NodeToString match).
+func TestSequenceAST(t *testing.T) {
+	t.Run("create or replace", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE OR REPLACE SEQUENCE s")
+		if !stmt.OrReplace || stmt.IfNotExists {
+			t.Errorf("OrReplace=%v IfNotExists=%v, want true/false", stmt.OrReplace, stmt.IfNotExists)
+		}
+		if stmt.Name == nil || stmt.Name.Name != "s" {
+			t.Errorf("Name = %+v, want s", stmt.Name)
+		}
+	})
+	t.Run("if not exists", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE SEQUENCE IF NOT EXISTS s")
+		if !stmt.IfNotExists {
+			t.Errorf("IfNotExists = false, want true")
+		}
+	})
+	t.Run("nocache", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE SEQUENCE s NOCACHE")
+		if !stmt.NoCache {
+			t.Errorf("NoCache = false, want true")
+		}
+	})
+	t.Run("cycle true", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE SEQUENCE s CYCLE")
+		if stmt.Cycle == nil || !*stmt.Cycle {
+			t.Errorf("Cycle = %v, want &true", stmt.Cycle)
+		}
+	})
+	t.Run("nocycle false", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE SEQUENCE s NOCYCLE")
+		if stmt.Cycle == nil || *stmt.Cycle {
+			t.Errorf("Cycle = %v, want &false", stmt.Cycle)
+		}
+	})
+	t.Run("as bigint", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE SEQUENCE s AS BIGINT")
+		if stmt.DataType == nil || stmt.DataType.Name != "BIGINT" {
+			t.Errorf("DataType = %+v, want BIGINT", stmt.DataType)
+		}
+	})
+	t.Run("start/increment populated", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE SEQUENCE s START WITH 1 INCREMENT BY 5")
+		if stmt.Start == nil || stmt.Increment == nil {
+			t.Errorf("Start=%v Increment=%v, want both set", stmt.Start, stmt.Increment)
+		}
+	})
+	t.Run("alter if exists restart with", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.AlterSequenceStmt](t, "ALTER SEQUENCE IF EXISTS s RESTART WITH 500")
+		if !stmt.IfExists || !stmt.Restart || stmt.RestartWith == nil {
+			t.Errorf("IfExists=%v Restart=%v RestartWith=%v", stmt.IfExists, stmt.Restart, stmt.RestartWith)
+		}
+	})
+	t.Run("alter start", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.AlterSequenceStmt](t, "ALTER SEQUENCE s START WITH 5")
+		if stmt.Start == nil {
+			t.Errorf("Start = nil, want set")
+		}
+	})
+	t.Run("drop multi if exists", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.DropSequenceStmt](t, "DROP SEQUENCE IF EXISTS a, b")
+		if !stmt.IfExists || len(stmt.Sequences) != 2 {
+			t.Errorf("IfExists=%v len(Sequences)=%d, want true/2", stmt.IfExists, len(stmt.Sequences))
+		}
+	})
+	t.Run("create temporary", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.CreateSequenceStmt](t, "CREATE TEMPORARY SEQUENCE s")
+		if !stmt.Temporary {
+			t.Errorf("Temporary = false, want true")
+		}
+	})
+	t.Run("drop temporary", func(t *testing.T) {
+		stmt := parseSeqStmt[*ast.DropSequenceStmt](t, "DROP TEMPORARY SEQUENCE s")
+		if !stmt.Temporary {
+			t.Errorf("Temporary = false, want true")
+		}
+	})
+}
+
+// parseSeqStmt parses sql and returns its single statement as type T.
+func parseSeqStmt[T ast.Node](t *testing.T, sql string) T {
+	t.Helper()
+	result := ParseAndCheck(t, sql)
+	if result.Len() != 1 {
+		t.Fatalf("Parse(%q) returned %d statements, want 1", sql, result.Len())
+	}
+	stmt, ok := result.Items[0].(T)
+	if !ok {
+		t.Fatalf("Parse(%q) = %T, want %T", sql, result.Items[0], *new(T))
+	}
+	return stmt
+}

--- a/mariadb/parser/sequence_value_test.go
+++ b/mariadb/parser/sequence_value_test.go
@@ -1,0 +1,130 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mariadb/ast"
+)
+
+// TestSequenceValueAccept covers NEXT/PREVIOUS VALUE FOR in every position the
+// container parse-accepts (BYT-9135). Per the position-matrix recon, MariaDB's
+// grammar admits it as a universal primary expression — the CHECK/generated-col/
+// partition restrictions are semantic (1970/1901/1564), not 1064 — so the parser
+// must accept all of these.
+func TestSequenceValueAccept(t *testing.T) {
+	accept := []string{
+		"SELECT NEXT VALUE FOR sq",
+		"SELECT PREVIOUS VALUE FOR sq",
+		"SELECT NEXT VALUE FOR sq + 1",
+		"SELECT NEXT VALUE FOR s.sq",
+		"INSERT INTO pt (id, v) VALUES (NEXT VALUE FOR sq, 1)",
+		"INSERT INTO pt (id) VALUES (PREVIOUS VALUE FOR sq)",
+		"UPDATE pt SET id = NEXT VALUE FOR sq WHERE v = 1",
+		"SELECT * FROM pt WHERE id = NEXT VALUE FOR sq",
+		"SELECT id FROM pt HAVING id = NEXT VALUE FOR sq",
+		"SELECT id FROM pt ORDER BY NEXT VALUE FOR sq",
+		"SELECT * FROM pt WHERE id IN (NEXT VALUE FOR sq)",
+		"CREATE TABLE d1 (id INT DEFAULT NEXT VALUE FOR sq, v INT)",
+		"CREATE TABLE d2 (id INT DEFAULT (NEXT VALUE FOR sq), v INT)",
+		"CREATE TABLE c1 (id INT CHECK (id < NEXT VALUE FOR sq))",
+		"CREATE TABLE g1 (id INT, g INT AS (NEXT VALUE FOR sq))",
+	}
+	for _, sql := range accept {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// TestSequenceValueReject covers the only parse-level (1064) rejects: a trailing
+// OVER clause (SQL-Server superset MariaDB lacks) and NEXT VALUE without FOR
+// (which MariaDB also rejects, since it reserves NEXT VALUE as special syntax).
+func TestSequenceValueReject(t *testing.T) {
+	reject := []string{
+		"SELECT NEXT VALUE FOR sq OVER (ORDER BY 1)",
+		"SELECT NEXT VALUE FOR sq OVER ()",
+		"SELECT next value",
+		"SELECT previous value",
+	}
+	for _, sql := range reject {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
+// TestSequenceValueIdentStillWorks guards that wiring the NEXT/PREVIOUS dispatch
+// does not break their use as plain identifiers when not followed by VALUE.
+func TestSequenceValueIdentStillWorks(t *testing.T) {
+	accept := []string{
+		"SELECT next FROM pt",
+		"SELECT previous FROM pt",
+		"SELECT id AS next FROM pt",
+		"SELECT next, value FROM pt",
+		"SELECT next.value FROM pt",
+	}
+	for _, sql := range accept {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// TestSequenceValueAST verifies the produced expression nodes and their sequence
+// reference (robust via Inspect, no byte-offset coupling).
+func TestSequenceValueAST(t *testing.T) {
+	t.Run("next value for", func(t *testing.T) {
+		nvf := findNextValueFor(t, "SELECT NEXT VALUE FOR sq")
+		if nvf.Sequence == nil || nvf.Sequence.Name != "sq" {
+			t.Errorf("Sequence = %+v, want sq", nvf.Sequence)
+		}
+	})
+	t.Run("next value for schema-qualified", func(t *testing.T) {
+		nvf := findNextValueFor(t, "SELECT NEXT VALUE FOR s.sq")
+		if nvf.Sequence == nil || nvf.Sequence.Schema != "s" || nvf.Sequence.Name != "sq" {
+			t.Errorf("Sequence = %+v, want s.sq", nvf.Sequence)
+		}
+	})
+	t.Run("previous value for", func(t *testing.T) {
+		var pvf *ast.PreviousValueForExpr
+		ast.Inspect(parseOne(t, "SELECT PREVIOUS VALUE FOR sq"), func(n ast.Node) bool {
+			if x, ok := n.(*ast.PreviousValueForExpr); ok {
+				pvf = x
+				return false
+			}
+			return true
+		})
+		if pvf == nil || pvf.Sequence == nil || pvf.Sequence.Name != "sq" {
+			t.Errorf("PreviousValueForExpr = %+v", pvf)
+		}
+	})
+	t.Run("default bare produces NextValueForExpr", func(t *testing.T) {
+		if findNextValueFor(t, "CREATE TABLE d (id INT DEFAULT NEXT VALUE FOR sq)") == nil {
+			t.Error("bare DEFAULT did not yield a NextValueForExpr")
+		}
+	})
+	// Watch-item #4: PREVIOUS VALUE FOR (keyword arm) and LASTVAL (generic func)
+	// are two valid spellings of last-value; both must parse.
+	t.Run("lastval generic func parses", func(t *testing.T) {
+		ParseAndCheck(t, "SELECT LASTVAL(sq)")
+	})
+}
+
+func parseOne(t *testing.T, sql string) ast.Node {
+	t.Helper()
+	result := ParseAndCheck(t, sql)
+	if result.Len() == 0 {
+		t.Fatalf("Parse(%q) returned no statements", sql)
+	}
+	return result.Items[0]
+}
+
+func findNextValueFor(t *testing.T, sql string) *ast.NextValueForExpr {
+	t.Helper()
+	var found *ast.NextValueForExpr
+	ast.Inspect(parseOne(t, sql), func(n ast.Node) bool {
+		if x, ok := n.(*ast.NextValueForExpr); ok {
+			found = x
+			return false
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatalf("Parse(%q) produced no NextValueForExpr", sql)
+	}
+	return found
+}

--- a/mariadb/parser/stmt.go
+++ b/mariadb/parser/stmt.go
@@ -411,10 +411,13 @@ func (p *Parser) parseCreateDispatch() (nodes.Node, error) {
 	orReplace := false
 	temporary := false
 
-	// OR REPLACE
+	// OR REPLACE — OR must be followed by REPLACE; MariaDB rejects a bare
+	// CREATE OR <object> (without REPLACE) at parse (1064).
 	if p.cur.Type == kwOR {
 		p.advance()
-		p.match(kwREPLACE)
+		if _, err := p.expect(kwREPLACE); err != nil {
+			return nil, err
+		}
 		orReplace = true
 	}
 

--- a/mariadb/parser/stmt.go
+++ b/mariadb/parser/stmt.go
@@ -402,7 +402,7 @@ func (p *Parser) parseCreateDispatch() (nodes.Node, error) {
 	// Completion: after CREATE keyword, offer object type candidates.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwTABLE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT} {
+		for _, t := range []int{kwTABLE, kwSEQUENCE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -436,6 +436,9 @@ func (p *Parser) parseCreateDispatch() (nodes.Node, error) {
 	switch p.cur.Type {
 	case kwTABLE:
 		return p.parseCreateTableStmt(temporary)
+
+	case kwSEQUENCE:
+		return p.parseCreateSequenceStmt(orReplace, temporary)
 
 	case kwINDEX:
 		return p.parseCreateIndexStmt(false, false, false)
@@ -596,7 +599,7 @@ func (p *Parser) parseAlterDispatch() (nodes.Node, error) {
 	// Completion: after ALTER keyword, offer object type candidates.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwTABLE, kwDATABASE, kwVIEW, kwFUNCTION, kwPROCEDURE, kwEVENT} {
+		for _, t := range []int{kwTABLE, kwSEQUENCE, kwDATABASE, kwVIEW, kwFUNCTION, kwPROCEDURE, kwEVENT} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -614,6 +617,9 @@ func (p *Parser) parseAlterDispatch() (nodes.Node, error) {
 	switch p.cur.Type {
 	case kwTABLE:
 		return p.parseAlterTableStmt()
+
+	case kwSEQUENCE:
+		return p.parseAlterSequenceStmt()
 
 	case kwDATABASE, kwSCHEMA:
 		return p.parseAlterDatabaseStmt()
@@ -712,7 +718,7 @@ func (p *Parser) parseDropDispatch() (nodes.Node, error) {
 	// Completion: after DROP keyword, offer object type candidates.
 	p.checkCursor()
 	if p.collectMode() {
-		for _, t := range []int{kwTABLE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT, kwIF} {
+		for _, t := range []int{kwTABLE, kwSEQUENCE, kwINDEX, kwVIEW, kwDATABASE, kwFUNCTION, kwPROCEDURE, kwTRIGGER, kwEVENT, kwIF} {
 			p.addTokenCandidate(t)
 		}
 		return nil, &ParseError{Message: "collecting"}
@@ -736,6 +742,9 @@ func (p *Parser) parseDropDispatch() (nodes.Node, error) {
 	switch p.cur.Type {
 	case kwTABLE:
 		return p.parseDropTableStmt(temporary)
+
+	case kwSEQUENCE:
+		return p.parseDropSequenceStmt(temporary)
 
 	case kwINDEX:
 		return p.parseDropIndexStmt()


### PR DESCRIPTION
## What

Parse MariaDB 11.8 **SEQUENCE** objects in `omni/mariadb` (BYT-9135 P2): `CREATE/ALTER/DROP SEQUENCE` with the any-order option matrix, and `NEXT VALUE FOR` / `PREVIOUS VALUE FOR` as primary expressions (including in column `DEFAULT`).

**Closes ~33 Phase-0 sequence GAPs at full parity vs `mariadb:11.8.8` — 0 OVER, 0 GAP** across the consolidated option + position + identifier-edge matrix. A Short-gated container oracle (`sequence_oracle_test.go`) asserts omni ≡ the live container on ~85 statements.

## Donor-superset traps dropped (mssql is a SQL Server parser)
- `NextValueForExpr.Over` — MariaDB rejects `NEXT VALUE FOR seq OVER (…)` (1064)
- spaced `NO CACHE` / `NO CYCLE` — MariaDB is one-word `NOCACHE`/`NOCYCLE` only
- bare `CACHE` (no value) — MariaDB requires a value

## MariaDB-specific grammar (container-verified)
- `AS` restricted to integer types, no display width (`AS VARCHAR(10)` / `INT(11)` → 1064)
- `RESTART` is ALTER-only; `START` accepted in both CREATE and ALTER; ALTER requires ≥1 option
- option values are signed integer literals, not expressions (`START WITH 1+1` → 1064)
- also fixes a pre-existing over-accept: bare `SELECT next value` (no `FOR`)

## Scope
SEQUENCE only. **RETURNING, UUID/INET4/INET6, general CREATE OR REPLACE, and EXECUTE IMMEDIATE are separate P2 PRs.**

## Tests
Five new AST nodes (Create/Alter/DropSequenceStmt, Next/PreviousValueForExpr) with full walk/outfuncs wiring; parser accept/reject/AST unit tests; the Short-gated container conformance oracle (skipped in CI's `-short`, like PR1's oracle). `go build ./...` + `go test -short ./...` green; inventory gate stays green.

## Follow-up
BYT-9740 — genwalker should emit the AST node registry + an outfuncs completeness test (the hand-maintained `allKnownNodes()` doesn't auto-cover new nodes; surfaced reviewing this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)