### PR TITLE
fix(mssql): support LEFT/RIGHT and niladic keyword functions in expressions

### DIFF
--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -748,6 +748,14 @@ func (p *Parser) parsePrimary() (nodes.ExprNode, error) {
 		return p.parseIdentExpr()
 	case kwTRY_CONVERT:
 		return p.parseTryConvert()
+	case kwLEFT, kwRIGHT:
+		if p.peekNext().Type == '(' {
+			return p.parseIdentExpr()
+		}
+		return nil, nil
+	case kwCURRENT_TIMESTAMP, kwCURRENT_USER, kwSESSION_USER,
+		kwSYSTEM_USER, kwUSER, kwCURRENT_DATE, kwCURRENT_TIME:
+		return p.parseNiladicKeywordFunc()
 	case tokIDENT:
 		return p.parseIdentExpr()
 	default:
@@ -762,6 +770,16 @@ func (p *Parser) parsePrimary() (nodes.ExprNode, error) {
 		}
 		return nil, nil
 	}
+}
+
+// parseNiladicKeywordFunc handles SQL-standard niladic functions that are
+// CoreKeywords and take no parentheses: CURRENT_TIMESTAMP, CURRENT_USER, etc.
+func (p *Parser) parseNiladicKeywordFunc() (nodes.ExprNode, error) {
+	tok := p.advance()
+	return &nodes.FuncCallExpr{
+		Name: &nodes.TableRef{Object: tok.Str, Loc: nodes.Loc{Start: tok.Loc, End: p.prevEnd()}},
+		Loc:  nodes.Loc{Start: tok.Loc, End: p.prevEnd()},
+	}, nil
 }
 
 // parseCast parses CAST(expr AS data_type).

--- a/mssql/parser/keyword_callable_test.go
+++ b/mssql/parser/keyword_callable_test.go
@@ -51,6 +51,9 @@ const (
 	// ast.SemanticTableRef. SEMANTICKEYPHRASETABLE /
 	// SEMANTICSIMILARITYTABLE / SEMANTICSIMILARITYDETAILSTABLE.
 	roleSemanticTable
+	// roleNiladic — SQL-standard niladic functions that take no parentheses
+	// in expression position (CURRENT_TIMESTAMP, CURRENT_USER, etc.).
+	roleNiladic
 )
 
 type callableKeyword struct {
@@ -103,6 +106,17 @@ var callableKeywordManifest = []callableKeyword{
 	{keyword: "SEMANTICKEYPHRASETABLE", role: roleSemanticTable, acceptSample: "SELECT * FROM SEMANTICKEYPHRASETABLE(t, b) s"},
 	{keyword: "SEMANTICSIMILARITYTABLE", role: roleSemanticTable, acceptSample: "SELECT * FROM SEMANTICSIMILARITYTABLE(t, b, 1) s"},
 	{keyword: "SEMANTICSIMILARITYDETAILSTABLE", role: roleSemanticTable, acceptSample: "SELECT * FROM SEMANTICSIMILARITYDETAILSTABLE(t, a, 1, b, 2) s"},
+	// --- roleExprScalar (CoreKeyword scalar functions) ---
+	{keyword: "LEFT", role: roleExprScalar, acceptSample: "SELECT LEFT('abcdef', 3)"},
+	{keyword: "RIGHT", role: roleExprScalar, acceptSample: "SELECT RIGHT('abcdef', 3)"},
+	// --- roleNiladic (no-parentheses niladic functions) ---
+	{keyword: "CURRENT_TIMESTAMP", role: roleNiladic, acceptSample: "SELECT CURRENT_TIMESTAMP"},
+	{keyword: "CURRENT_USER", role: roleNiladic, acceptSample: "SELECT CURRENT_USER"},
+	{keyword: "SESSION_USER", role: roleNiladic, acceptSample: "SELECT SESSION_USER"},
+	{keyword: "SYSTEM_USER", role: roleNiladic, acceptSample: "SELECT SYSTEM_USER"},
+	{keyword: "USER", role: roleNiladic, acceptSample: "SELECT USER"},
+	{keyword: "CURRENT_DATE", role: roleNiladic, acceptSample: "SELECT CURRENT_DATE"},
+	{keyword: "CURRENT_TIME", role: roleNiladic, acceptSample: "SELECT CURRENT_TIME"},
 }
 
 // rejectContexts are the "wrong-context" shapes we spray each keyword into
@@ -154,6 +168,11 @@ var rejectContexts = []rejectContext{
 			roleExprScalar,
 		},
 	},
+	{
+		name:       "niladic-with-empty-parens",
+		render:     func(k string) string { return "SELECT " + k + "()" },
+		allowRoles: []keywordRole{roleExprScalar},
+	},
 }
 
 // TestCallableKeywordManifest asserts each manifest entry parses in its
@@ -181,8 +200,9 @@ func TestCallableKeywordRoleRejection(t *testing.T) {
 				continue
 			}
 			// Hybrid scalar/FROM keywords (OPENJSON today) are also
-			// legal as generic scalar FunctionCalls.
-			if entry.alsoScalar && strings.HasPrefix(ctx.name, "scalar-") {
+			// legal as generic scalar FunctionCalls — skip scalar and
+			// niladic-shaped contexts for them.
+			if entry.alsoScalar && (strings.HasPrefix(ctx.name, "scalar-") || strings.HasPrefix(ctx.name, "niladic-")) {
 				continue
 			}
 			sql := ctx.render(entry.keyword)


### PR DESCRIPTION
## Summary

- Add `parsePrimary()` cases for 9 CoreKeyword tokens that are legally callable in expression position
- **LEFT/RIGHT** (BYT-9747): dispatch to `parseIdentExpr()` when followed by `(`, enabling `LEFT(str, n)` / `RIGHT(str, n)` scalar calls. `LEFT/RIGHT JOIN` handling in `matchJoinType()` is unaffected.
- **Niladic functions**: `CURRENT_TIMESTAMP`, `CURRENT_USER`, `SESSION_USER`, `SYSTEM_USER`, `USER`, `CURRENT_DATE`, `CURRENT_TIME` — parsed as `FuncCallExpr` without parentheses via `parseNiladicKeywordFunc()`. `KEYWORD()` with parens is correctly rejected.
- Extend `callableKeywordManifest` with 9 entries (2 `roleExprScalar` + 7 `roleNiladic`) and add `niladic-with-empty-parens` reject context.

Fixes BYT-9747.

## Test plan

- [x] `TestCallableKeywordManifest` — all 29 entries pass (accept contexts)
- [x] `TestCallableKeywordRoleRejection` — all rejection contexts pass including new `niladic-with-empty-parens`
- [x] `TestCallableKeywordManifestIsExhaustive` — passes
- [x] Manual verification: `SELECT LEFT('abc', 2)`, `SELECT RIGHT('abc', 2)`, `SELECT CURRENT_TIMESTAMP`, `SELECT CURRENT_USER` all parse correctly
- [x] Regression: `LEFT JOIN`, `RIGHT OUTER JOIN`, `CREATE PARTITION FUNCTION ... RANGE LEFT/RIGHT`, `CREATE USER` unaffected
- [x] Reject: `SELECT CURRENT_TIMESTAMP()` and `SELECT CURRENT_USER()` correctly fail