### PR TITLE
feat(mariadb): parse PARTITION BY SYSTEM_TIME (system-versioned partitioning)

### DIFF
--- a/mariadb/ast/outfuncs.go
+++ b/mariadb/ast/outfuncs.go
@@ -2989,6 +2989,23 @@ func writePartitionClause(sb *strings.Builder, n *PartitionClause) {
 	if n.NumSubParts > 0 {
 		fmt.Fprintf(sb, " :num_sub_parts %d", n.NumSubParts)
 	}
+	if n.IntervalValue != nil {
+		sb.WriteString(" :interval_value ")
+		writeNode(sb, n.IntervalValue)
+	}
+	if n.IntervalUnit != "" {
+		fmt.Fprintf(sb, " :interval_unit %s", n.IntervalUnit)
+	}
+	if n.Limit > 0 {
+		fmt.Fprintf(sb, " :limit %d", n.Limit)
+	}
+	if n.Starts != nil {
+		sb.WriteString(" :starts ")
+		writeNode(sb, n.Starts)
+	}
+	if n.Auto {
+		sb.WriteString(" :auto true")
+	}
 	sb.WriteString("}")
 }
 
@@ -2998,6 +3015,9 @@ func writePartitionDef(sb *strings.Builder, n *PartitionDef) {
 	if n.Values != nil {
 		sb.WriteString(" :values ")
 		writeNode(sb, n.Values)
+	}
+	if n.SystemTime != "" {
+		fmt.Fprintf(sb, " :system_time %s", n.SystemTime)
 	}
 	if len(n.Options) > 0 {
 		sb.WriteString(" :options ")

--- a/mariadb/ast/parsenodes.go
+++ b/mariadb/ast/parsenodes.go
@@ -572,6 +572,14 @@ type PartitionClause struct {
 	SubPartColumns []string      // SUBPARTITION BY KEY (columns)
 	SubPartAlgo    int           // ALGORITHM={1|2} for SUBPARTITION BY KEY (0 if not specified)
 	NumSubParts    int           // SUBPARTITIONS num
+
+	// SYSTEM_TIME partitioning (MariaDB), used when Type == PartitionSystemTime:
+	//   PARTITION BY SYSTEM_TIME [INTERVAL value unit | LIMIT n] [STARTS expr] [AUTO]
+	IntervalValue ExprNode // INTERVAL <value> unit
+	IntervalUnit  string   // the interval unit (WEEK, MONTH, ...)
+	Limit         int      // LIMIT n (0 if not specified)
+	Starts        ExprNode // STARTS <expr>
+	Auto          bool     // AUTO (auto-create history partitions)
 }
 
 func (p *PartitionClause) nodeTag() {}
@@ -584,13 +592,15 @@ const (
 	PartitionList
 	PartitionHash
 	PartitionKey
+	PartitionSystemTime
 )
 
 // PartitionDef represents a single partition definition.
 type PartitionDef struct {
 	Loc           Loc
 	Name          string
-	Values        Node // VALUES LESS THAN (expr) or IN (list) — kept as Node to support heterogeneous partition value types
+	Values        Node   // VALUES LESS THAN (expr) or IN (list) — kept as Node to support heterogeneous partition value types
+	SystemTime    string // "HISTORY" | "CURRENT" for SYSTEM_TIME partitions ("" otherwise)
 	Options       []*TableOption
 	SubPartitions []*SubPartitionDef
 }

--- a/mariadb/ast/system_time_outfuncs_test.go
+++ b/mariadb/ast/system_time_outfuncs_test.go
@@ -1,6 +1,35 @@
 package ast
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// TestPartitionClauseSystemTimeOutfuncs locks outfuncs coverage of the SYSTEM_TIME
+// partition fields (interval/limit/starts/auto + per-partition HISTORY/CURRENT) so
+// AST dumps don't silently drop them.
+func TestPartitionClauseSystemTimeOutfuncs(t *testing.T) {
+	n := &PartitionClause{
+		Type:          PartitionSystemTime,
+		IntervalValue: &IntLit{Value: 1},
+		IntervalUnit:  "MONTH",
+		Starts:        &StringLit{Value: "2020-01-01"},
+		Auto:          true,
+		Partitions: []*PartitionDef{
+			{Name: "p0", SystemTime: "HISTORY"},
+			{Name: "pn", SystemTime: "CURRENT"},
+		},
+	}
+	got := NodeToString(n)
+	for _, want := range []string{
+		":interval_value ", ":interval_unit MONTH", ":starts ", ":auto true",
+		":system_time HISTORY", ":system_time CURRENT",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("NodeToString missing %q:\n%s", want, got)
+		}
+	}
+}
 
 // TestSystemTimeOutfuncs locks the outfuncs serialization of the FOR SYSTEM_TIME
 // range bounds, including the per-bound TRANSACTION qualifier so AST dumps keep

--- a/mariadb/ast/walk_generated.go
+++ b/mariadb/ast/walk_generated.go
@@ -686,6 +686,8 @@ func walkChildren(v Visitor, node Node) {
 			}
 		}
 		Walk(v, n.SubPartExpr)
+		Walk(v, n.IntervalValue)
+		Walk(v, n.Starts)
 	case *PartitionDef:
 		Walk(v, n.Values)
 		for _, item := range n.Options {

--- a/mariadb/catalog/errors.go
+++ b/mariadb/catalog/errors.go
@@ -62,6 +62,9 @@ const (
 	ErrTruncateSystemVersioned           = 4137
 	ErrMissingSystemVersioning           = 4125
 	ErrPeriodWrongColumns                = 4126
+	ErrWrongPartitionType                = 4113
+	ErrWrongSystemTimePartitions         = 4128
+	ErrValuesOnlyForRange                = 1480
 )
 
 var sqlStateMap = map[int]string{
@@ -102,6 +105,9 @@ var sqlStateMap = map[int]string{
 	ErrTruncateSystemVersioned:           "HY000",
 	ErrMissingSystemVersioning:           "HY000",
 	ErrPeriodWrongColumns:                "HY000",
+	ErrWrongPartitionType:                "HY000",
+	ErrWrongSystemTimePartitions:         "HY000",
+	ErrValuesOnlyForRange:                "HY000",
 	ErrWrongArguments:                    "HY000",
 	ErrWrongNameForIndex:                 "42000",
 	ErrInvalidOnUpdate:                   "HY000",
@@ -307,6 +313,21 @@ func errMissingRowStart(table string) error {
 func errMissingPeriod(table string) error {
 	return &Error{Code: ErrMissingSystemVersioning, SQLState: sqlState(ErrMissingSystemVersioning),
 		Message: fmt.Sprintf("Wrong parameters for `%s`: missing 'PERIOD FOR SYSTEM_TIME'", table)}
+}
+
+func errWrongPartitionType(byType string) error {
+	return &Error{Code: ErrWrongPartitionType, SQLState: sqlState(ErrWrongPartitionType),
+		Message: fmt.Sprintf("Wrong partition type `SYSTEM_TIME` for partitioning by `%s`", byType)}
+}
+
+func errWrongSystemTimePartitions(table string) error {
+	return &Error{Code: ErrWrongSystemTimePartitions, SQLState: sqlState(ErrWrongSystemTimePartitions),
+		Message: fmt.Sprintf("Wrong partitions for `%s`: must have at least one HISTORY and exactly one last CURRENT", table)}
+}
+
+func errValuesOnlyForRange() error {
+	return &Error{Code: ErrValuesOnlyForRange, SQLState: sqlState(ErrValuesOnlyForRange),
+		Message: "Only RANGE PARTITIONING can use VALUES LESS THAN in partition definition"}
 }
 
 func errNotSystemVersioned(table string) error {

--- a/mariadb/catalog/show.go
+++ b/mariadb/catalog/show.go
@@ -670,6 +670,19 @@ func showPartitioning(pi *PartitionInfo) string {
 		} else {
 			b.WriteString(fmt.Sprintf("KEY (%s)", formatPartitionColumnsPlain(pi.Columns)))
 		}
+	case "SYSTEM_TIME":
+		b.WriteString("SYSTEM_TIME")
+		if pi.IntervalValue != "" {
+			b.WriteString(fmt.Sprintf(" INTERVAL %s %s", pi.IntervalValue, pi.IntervalUnit))
+		} else if pi.Limit > 0 {
+			b.WriteString(fmt.Sprintf(" LIMIT %d", pi.Limit))
+		}
+		if pi.Starts != "" {
+			b.WriteString(fmt.Sprintf(" STARTS %s", pi.Starts))
+		}
+		if pi.Auto {
+			b.WriteString(" AUTO")
+		}
 	}
 
 	// Subpartition clause.
@@ -697,8 +710,9 @@ func showPartitioning(pi *PartitionInfo) string {
 	// Partition definitions.
 	// For HASH/KEY partitions with NumParts > 0, auto-generated partition defs
 	// are rendered as "PARTITIONS N" (matching MySQL 8.0's SHOW CREATE TABLE).
-	hashKeyAutoGen := pi.NumParts > 0 && (pi.Type == "HASH" || pi.Type == "KEY")
-	if hashKeyAutoGen {
+	autoGenParts := pi.NumParts > 0 && (pi.Type == "HASH" || pi.Type == "KEY" ||
+		(pi.Type == "SYSTEM_TIME" && len(pi.Partitions) == 0))
+	if autoGenParts {
 		b.WriteString(fmt.Sprintf("\nPARTITIONS %d", pi.NumParts))
 	} else if len(pi.Partitions) > 0 {
 		b.WriteString("\n(")
@@ -708,6 +722,9 @@ func showPartitioning(pi *PartitionInfo) string {
 			}
 			b.WriteString("PARTITION ")
 			b.WriteString(pd.Name)
+			if pd.SystemTime != "" {
+				b.WriteString(" " + pd.SystemTime)
+			}
 			if pd.ValueExpr != "" {
 				switch {
 				case strings.HasPrefix(pi.Type, "RANGE"):

--- a/mariadb/catalog/system_time_partition_test.go
+++ b/mariadb/catalog/system_time_partition_test.go
@@ -31,4 +31,31 @@ func TestSystemTimePartitioningCatalog(t *testing.T) {
 			t.Fatalf("want *Error 4124, got %v", err)
 		}
 	})
+
+	const sv = "CREATE TABLE t (x INT) WITH SYSTEM VERSIONING PARTITION BY SYSTEM_TIME"
+	reject := []struct {
+		name string
+		ddl  string
+		code int
+	}{
+		{"history_under_hash", "CREATE TABLE t (x INT) PARTITION BY HASH(x) (PARTITION p0 HISTORY)", 4113},
+		{"history_under_range", "CREATE TABLE t (x INT) PARTITION BY RANGE(x) (PARTITION p0 HISTORY)", 4113},
+		{"no_current", sv + " (PARTITION p0 HISTORY)", 4128},
+		{"multiple_current", sv + " (PARTITION p0 CURRENT, PARTITION p1 CURRENT)", 4128},
+		{"current_not_last", sv + " (PARTITION pc CURRENT, PARTITION p0 HISTORY)", 4128},
+		{"only_current", sv + " (PARTITION pc CURRENT)", 4128},
+		{"values_under_system_time", sv + " (PARTITION p0 VALUES LESS THAN (10))", 1480},
+	}
+	for _, tc := range reject {
+		t.Run(tc.name, func(t *testing.T) {
+			err := execErr(t, tc.ddl)
+			catErr, ok := err.(*Error)
+			if !ok {
+				t.Fatalf("expected *Error, got %v", err)
+			}
+			if catErr.Code != tc.code {
+				t.Errorf("Code = %d, want %d (message: %q)", catErr.Code, tc.code, catErr.Message)
+			}
+		})
+	}
 }

--- a/mariadb/catalog/system_time_partition_test.go
+++ b/mariadb/catalog/system_time_partition_test.go
@@ -1,0 +1,34 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSystemTimePartitioningCatalog: the catalog stores SYSTEM_TIME partitioning
+// (structural, not byte-exact — MariaDB injects a non-deterministic STARTS
+// timestamp and omni's partition renderer is MySQL-flavored) and rejects it on a
+// non-versioned table with 4124 (grounded vs 11.8.8).
+func TestSystemTimePartitioningCatalog(t *testing.T) {
+	t.Run("versioned renders PARTITION BY SYSTEM_TIME", func(t *testing.T) {
+		ddl := defineAndShow(t, "t",
+			"CREATE TABLE t (x INT) WITH SYSTEM VERSIONING PARTITION BY SYSTEM_TIME (PARTITION p0 HISTORY, PARTITION pn CURRENT)")
+		if !strings.Contains(ddl, "PARTITION BY SYSTEM_TIME") {
+			t.Errorf("ShowCreateTable missing SYSTEM_TIME partitioning:\n%s", ddl)
+		}
+	})
+	t.Run("versioned interval form stores interval", func(t *testing.T) {
+		ddl := defineAndShow(t, "t",
+			"CREATE TABLE t (x INT) WITH SYSTEM VERSIONING PARTITION BY SYSTEM_TIME INTERVAL 1 MONTH PARTITIONS 12")
+		if !strings.Contains(ddl, "PARTITION BY SYSTEM_TIME") || !strings.Contains(ddl, "INTERVAL 1 MONTH") {
+			t.Errorf("ShowCreateTable missing SYSTEM_TIME INTERVAL:\n%s", ddl)
+		}
+	})
+	t.Run("non-versioned rejected 4124", func(t *testing.T) {
+		err := execErr(t, "CREATE TABLE t (x INT) PARTITION BY SYSTEM_TIME (PARTITION p0 HISTORY, PARTITION pn CURRENT)")
+		catErr, ok := err.(*Error)
+		if !ok || catErr.Code != 4124 {
+			t.Fatalf("want *Error 4124, got %v", err)
+		}
+	})
+}

--- a/mariadb/catalog/table.go
+++ b/mariadb/catalog/table.go
@@ -61,12 +61,20 @@ type PartitionInfo struct {
 	// partition_info::use_default_num_subpartitions.
 	UseDefaultSubpartitions    bool
 	UseDefaultNumSubpartitions bool
+
+	// SYSTEM_TIME partitioning (Type == "SYSTEM_TIME").
+	IntervalValue string // INTERVAL <value>
+	IntervalUnit  string // interval unit (MONTH, WEEK, ...)
+	Limit         int    // LIMIT n (0 if none)
+	Starts        string // STARTS <expr> ("" if none)
+	Auto          bool   // AUTO
 }
 
 // PartitionDefInfo holds a single partition definition.
 type PartitionDefInfo struct {
 	Name          string
 	ValueExpr     string // "LESS THAN (...)" or "IN (...)" or ""
+	SystemTime    string // "HISTORY" | "CURRENT" for SYSTEM_TIME partitions
 	Engine        string // ENGINE option for this partition
 	Comment       string // COMMENT option for this partition
 	SubPartitions []*SubPartitionDefInfo

--- a/mariadb/catalog/tablecmds.go
+++ b/mariadb/catalog/tablecmds.go
@@ -870,6 +870,13 @@ func buildPartitionInfo(tbl *Table, pc *nodes.PartitionClause) *PartitionInfo {
 			pi.Columns = primaryKeyColumns(tbl)
 		}
 		pi.Algorithm = pc.Algorithm
+	case nodes.PartitionSystemTime:
+		pi.Type = "SYSTEM_TIME"
+		pi.IntervalValue = nodeToSQL(pc.IntervalValue)
+		pi.IntervalUnit = pc.IntervalUnit
+		pi.Limit = pc.Limit
+		pi.Starts = nodeToSQL(pc.Starts)
+		pi.Auto = pc.Auto
 	}
 
 	// Subpartition info.
@@ -899,7 +906,8 @@ func buildPartitionInfo(tbl *Table, pc *nodes.PartitionClause) *PartitionInfo {
 	explicitSubpartitionCount := 0
 	for _, pd := range pc.Partitions {
 		pdi := &PartitionDefInfo{
-			Name: pd.Name,
+			Name:       pd.Name,
+			SystemTime: pd.SystemTime,
 		}
 		// Values.
 		if pd.Values != nil {
@@ -947,8 +955,8 @@ func buildPartitionInfo(tbl *Table, pc *nodes.PartitionClause) *PartitionInfo {
 
 	// Auto-generate partition definitions for HASH/KEY/LINEAR HASH/LINEAR KEY
 	// when PARTITIONS N is specified without explicit partition definitions.
-	// MySQL naming convention: p0, p1, p2, ...
-	if len(pi.Partitions) == 0 && pi.NumParts > 0 {
+	// MySQL naming convention: p0, p1, p2, ... (SYSTEM_TIME keeps PARTITIONS N).
+	if len(pi.Partitions) == 0 && pi.NumParts > 0 && pi.Type != "SYSTEM_TIME" {
 		for i := 0; i < pi.NumParts; i++ {
 			pi.Partitions = append(pi.Partitions, &PartitionDefInfo{
 				Name: fmt.Sprintf("p%d", i),
@@ -1139,6 +1147,10 @@ func canonicalBitLiteral(bits string) string {
 }
 
 func validatePartitionClause(tbl *Table, pc *nodes.PartitionClause) error {
+	// SYSTEM_TIME partitioning is only valid on a system-versioned table (4124).
+	if pc.Type == nodes.PartitionSystemTime && !tbl.SystemVersioned {
+		return errNotSystemVersioned(tbl.Name)
+	}
 	if (pc.Type == nodes.PartitionRange || pc.Type == nodes.PartitionList) && len(pc.Partitions) == 0 {
 		return &Error{Code: 1492, SQLState: "HY000", Message: "Partitions must be defined for RANGE/LIST partitioning"}
 	}

--- a/mariadb/catalog/tablecmds.go
+++ b/mariadb/catalog/tablecmds.go
@@ -1146,10 +1146,67 @@ func canonicalBitLiteral(bits string) string {
 	return "b'" + bits + "'"
 }
 
-func validatePartitionClause(tbl *Table, pc *nodes.PartitionClause) error {
-	// SYSTEM_TIME partitioning is only valid on a system-versioned table (4124).
-	if pc.Type == nodes.PartitionSystemTime && !tbl.SystemVersioned {
+// partitionTypeName maps a partition type to its SQL keyword.
+func partitionTypeName(t nodes.PartitionType) string {
+	switch t {
+	case nodes.PartitionRange:
+		return "RANGE"
+	case nodes.PartitionList:
+		return "LIST"
+	case nodes.PartitionHash:
+		return "HASH"
+	case nodes.PartitionKey:
+		return "KEY"
+	case nodes.PartitionSystemTime:
+		return "SYSTEM_TIME"
+	default:
+		return ""
+	}
+}
+
+// validateSystemTimePartitioning enforces MariaDB's SYSTEM_TIME partitioning
+// rules (grounded vs 11.8.8) and rejects HISTORY/CURRENT tags under other
+// partition types:
+//   - HISTORY/CURRENT only under SYSTEM_TIME            -> 4113
+//   - SYSTEM_TIME requires a system-versioned table     -> 4124
+//   - no VALUES under SYSTEM_TIME                        -> 1480
+//   - an explicit list needs >=1 HISTORY + one final CURRENT -> 4128
+func validateSystemTimePartitioning(tbl *Table, pc *nodes.PartitionClause) error {
+	if pc.Type != nodes.PartitionSystemTime {
+		for _, pd := range pc.Partitions {
+			if pd.SystemTime != "" {
+				return errWrongPartitionType(partitionTypeName(pc.Type))
+			}
+		}
+		return nil
+	}
+	if !tbl.SystemVersioned {
 		return errNotSystemVersioned(tbl.Name)
+	}
+	historyCount, currentCount := 0, 0
+	for i, pd := range pc.Partitions {
+		if pd.Values != nil {
+			return errValuesOnlyForRange()
+		}
+		switch pd.SystemTime {
+		case "HISTORY":
+			historyCount++
+		case "CURRENT":
+			currentCount++
+			if i != len(pc.Partitions)-1 {
+				return errWrongSystemTimePartitions(tbl.Name)
+			}
+		}
+	}
+	if len(pc.Partitions) > 0 && (historyCount == 0 || currentCount != 1) {
+		return errWrongSystemTimePartitions(tbl.Name)
+	}
+	return nil
+}
+
+func validatePartitionClause(tbl *Table, pc *nodes.PartitionClause) error {
+	if err := validateSystemTimePartitioning(tbl, pc); err != nil {
+		return err
 	}
 	if (pc.Type == nodes.PartitionRange || pc.Type == nodes.PartitionList) && len(pc.Partitions) == 0 {
 		return &Error{Code: 1492, SQLState: "HY000", Message: "Partitions must be defined for RANGE/LIST partitioning"}

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -1583,9 +1583,18 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 		}
 
 	default:
-		return nil, &ParseError{
-			Message:  "expected HASH, KEY, RANGE, or LIST after PARTITION BY",
-			Position: p.cur.Loc,
+		// SYSTEM_TIME is non-reserved (matched by identifier text).
+		if p.cur.Type == tokIDENT && strings.EqualFold(p.cur.Str, "SYSTEM_TIME") {
+			p.advance() // SYSTEM_TIME
+			part.Type = nodes.PartitionSystemTime
+			if err := p.parseSystemTimePartitionSpec(part); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, &ParseError{
+				Message:  "expected HASH, KEY, RANGE, LIST, or SYSTEM_TIME after PARTITION BY",
+				Position: p.cur.Loc,
+			}
 		}
 	}
 
@@ -1719,10 +1728,48 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 	return part, nil
 }
 
+// parseSystemTimePartitionSpec parses the SYSTEM_TIME specifics that follow
+// PARTITION BY SYSTEM_TIME, before the PARTITIONS count and partition list:
+//
+//	[INTERVAL value unit | LIMIT n] [STARTS expr] [AUTO]
+func (p *Parser) parseSystemTimePartitionSpec(part *nodes.PartitionClause) error {
+	switch p.cur.Type {
+	case kwINTERVAL:
+		p.advance() // INTERVAL
+		val, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		part.IntervalValue = val
+		// The interval unit (WEEK, MONTH, ...) follows; capture its text.
+		part.IntervalUnit = p.cur.Str
+		p.advance()
+	case kwLIMIT:
+		p.advance() // LIMIT
+		if p.cur.Type == tokICONST {
+			part.Limit = int(p.cur.Ival)
+			p.advance()
+		}
+	}
+	if p.cur.Type == kwSTARTS {
+		p.advance() // STARTS
+		expr, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		part.Starts = expr
+	}
+	if p.cur.Type == kwAUTO {
+		p.advance() // AUTO
+		part.Auto = true
+	}
+	return nil
+}
+
 // parsePartitionDef parses a single partition definition.
 //
 //	PARTITION partition_name
-//	    [VALUES {LESS THAN (expr|MAXVALUE) | IN (value_list)}]
+//	    [VALUES {LESS THAN (expr|MAXVALUE) | IN (value_list)} | {HISTORY | CURRENT}]
 //	    [table_options]
 func (p *Parser) parsePartitionDef() (*nodes.PartitionDef, error) {
 	start := p.pos()
@@ -1738,6 +1785,15 @@ func (p *Parser) parsePartitionDef() (*nodes.PartitionDef, error) {
 	pd := &nodes.PartitionDef{
 		Loc:  nodes.Loc{Start: start},
 		Name: name,
+	}
+
+	// SYSTEM_TIME partitions are tagged HISTORY or CURRENT instead of VALUES.
+	if p.cur.Type == kwHISTORY {
+		p.advance()
+		pd.SystemTime = "HISTORY"
+	} else if p.cur.Type == kwCURRENT {
+		p.advance()
+		pd.SystemTime = "CURRENT"
 	}
 
 	// VALUES LESS THAN or VALUES IN

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -1731,7 +1731,12 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 // parseSystemTimePartitionSpec parses the SYSTEM_TIME specifics that follow
 // PARTITION BY SYSTEM_TIME, before the PARTITIONS count and partition list:
 //
-//	[INTERVAL value unit | LIMIT n] [STARTS expr] [AUTO]
+// Each arm encodes the exact MariaDB grammar (STARTS only after INTERVAL; AUTO
+// not valid bare); other shapes fall through unconsumed and fail as 1064:
+//
+//	INTERVAL value unit [STARTS expr] [AUTO]
+//	LIMIT n [AUTO]
+//	(no modifier)
 func (p *Parser) parseSystemTimePartitionSpec(part *nodes.PartitionClause) error {
 	switch p.cur.Type {
 	case kwINTERVAL:
@@ -1741,27 +1746,41 @@ func (p *Parser) parseSystemTimePartitionSpec(part *nodes.PartitionClause) error
 			return err
 		}
 		part.IntervalValue = val
-		// The interval unit (WEEK, MONTH, ...) follows; capture its text.
-		part.IntervalUnit = p.cur.Str
-		p.advance()
-	case kwLIMIT:
-		p.advance() // LIMIT
-		if p.cur.Type == tokICONST {
-			part.Limit = int(p.cur.Ival)
-			p.advance()
-		}
-	}
-	if p.cur.Type == kwSTARTS {
-		p.advance() // STARTS
-		expr, err := p.parseExpr()
+		// The unit is required and must be a valid interval unit (mirrors
+		// parseIntervalExpr; compound units like DAY_HOUR are reserved keywords).
+		unit, _, err := p.parseKeywordOrIdent()
 		if err != nil {
 			return err
 		}
-		part.Starts = expr
-	}
-	if p.cur.Type == kwAUTO {
-		p.advance() // AUTO
-		part.Auto = true
+		upper := strings.ToUpper(unit)
+		if !isValidIntervalUnit(upper) {
+			return &ParseError{Position: p.pos(), Message: "invalid INTERVAL unit: " + unit}
+		}
+		part.IntervalUnit = upper
+		// STARTS is only valid after INTERVAL.
+		if p.cur.Type == kwSTARTS {
+			p.advance() // STARTS
+			expr, err := p.parseExpr()
+			if err != nil {
+				return err
+			}
+			part.Starts = expr
+		}
+		if p.cur.Type == kwAUTO {
+			p.advance() // AUTO
+			part.Auto = true
+		}
+	case kwLIMIT:
+		p.advance() // LIMIT
+		if p.cur.Type != tokICONST {
+			return p.syntaxErrorAtCur()
+		}
+		part.Limit = int(p.cur.Ival)
+		p.advance()
+		if p.cur.Type == kwAUTO {
+			p.advance() // AUTO
+			part.Auto = true
+		}
 	}
 	return nil
 }

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -1713,6 +1713,15 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 			if err != nil {
 				return nil, err
 			}
+			// A SYSTEM_TIME HISTORY/CURRENT partition cannot also carry VALUES
+			// (MariaDB 1064). VALUES without HISTORY/CURRENT is left to the catalog
+			// (1480); HISTORY/CURRENT under another type is left to the catalog (4113).
+			if part.Type == nodes.PartitionSystemTime && pd.SystemTime != "" && pd.Values != nil {
+				return nil, &ParseError{
+					Position: pd.Loc.Start,
+					Message:  "VALUES is not allowed for a SYSTEM_TIME HISTORY/CURRENT partition",
+				}
+			}
 			part.Partitions = append(part.Partitions, pd)
 			if p.cur.Type != ',' {
 				break

--- a/mariadb/parser/system_time_partition_test.go
+++ b/mariadb/parser/system_time_partition_test.go
@@ -1,0 +1,21 @@
+package parser
+
+import "testing"
+
+// TestSystemTimePartitioning covers PARTITION BY SYSTEM_TIME on a system-versioned
+// table — all container-verified accepted by mariadb:11.8.8: bare, INTERVAL,
+// LIMIT, PARTITIONS n, STARTS, AUTO, and explicit HISTORY/CURRENT partitions.
+func TestSystemTimePartitioning(t *testing.T) {
+	const sv = "CREATE TABLE t (x INT) WITH SYSTEM VERSIONING PARTITION BY SYSTEM_TIME"
+	for _, sql := range []string{
+		sv + " (PARTITION p0 HISTORY, PARTITION pn CURRENT)",
+		sv + " INTERVAL 1 WEEK (PARTITION p0 HISTORY, PARTITION pn CURRENT)",
+		sv + " LIMIT 1000 (PARTITION p0 HISTORY, PARTITION pn CURRENT)",
+		sv + " INTERVAL 1 MONTH PARTITIONS 12",
+		sv + " LIMIT 1000 PARTITIONS 5",
+		sv + " INTERVAL 1 MONTH STARTS '2020-01-01 00:00:00' PARTITIONS 4",
+		sv + " INTERVAL 1 MONTH AUTO",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}

--- a/mariadb/parser/system_time_partition_test.go
+++ b/mariadb/parser/system_time_partition_test.go
@@ -33,6 +33,8 @@ func TestSystemTimePartitioningReject(t *testing.T) {
 		sv + " STARTS '2020-01-01 00:00:00' (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // bare STARTS
 		sv + " AUTO", // bare AUTO
 		sv + " LIMIT 1000 STARTS '2020-01-01 00:00:00' (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // STARTS after LIMIT
+		sv + " (PARTITION p0 HISTORY VALUES LESS THAN (1), PARTITION pn CURRENT)",                    // HISTORY + VALUES
+		sv + " (PARTITION p0 HISTORY, PARTITION pn CURRENT VALUES LESS THAN (1))",                    // CURRENT + VALUES
 	} {
 		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
 	}

--- a/mariadb/parser/system_time_partition_test.go
+++ b/mariadb/parser/system_time_partition_test.go
@@ -15,7 +15,25 @@ func TestSystemTimePartitioning(t *testing.T) {
 		sv + " LIMIT 1000 PARTITIONS 5",
 		sv + " INTERVAL 1 MONTH STARTS '2020-01-01 00:00:00' PARTITIONS 4",
 		sv + " INTERVAL 1 MONTH AUTO",
+		sv + " LIMIT 1000 AUTO",
+		sv + " INTERVAL 1 MONTH STARTS '2020-01-01 00:00:00' AUTO",
 	} {
 		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// TestSystemTimePartitioningReject pins the SYSTEM_TIME option grammar:
+// INTERVAL value unit [STARTS expr] [AUTO] | LIMIT n [AUTO] | (no modifier).
+// All container-verified 1064 vs mariadb:11.8.8.
+func TestSystemTimePartitioningReject(t *testing.T) {
+	const sv = "CREATE TABLE t (x INT) WITH SYSTEM VERSIONING PARTITION BY SYSTEM_TIME"
+	for _, sql := range []string{
+		sv + " INTERVAL 1 (PARTITION p0 HISTORY, PARTITION pn CURRENT)",        // missing unit
+		sv + " INTERVAL 1 FOOBAR (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // invalid unit
+		sv + " STARTS '2020-01-01 00:00:00' (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // bare STARTS
+		sv + " AUTO", // bare AUTO
+		sv + " LIMIT 1000 STARTS '2020-01-01 00:00:00' (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // STARTS after LIMIT
+	} {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
 	}
 }

--- a/mariadb/parser/system_time_partition_test.go
+++ b/mariadb/parser/system_time_partition_test.go
@@ -28,8 +28,8 @@ func TestSystemTimePartitioning(t *testing.T) {
 func TestSystemTimePartitioningReject(t *testing.T) {
 	const sv = "CREATE TABLE t (x INT) WITH SYSTEM VERSIONING PARTITION BY SYSTEM_TIME"
 	for _, sql := range []string{
-		sv + " INTERVAL 1 (PARTITION p0 HISTORY, PARTITION pn CURRENT)",        // missing unit
-		sv + " INTERVAL 1 FOOBAR (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // invalid unit
+		sv + " INTERVAL 1 (PARTITION p0 HISTORY, PARTITION pn CURRENT)",                   // missing unit
+		sv + " INTERVAL 1 FOOBAR (PARTITION p0 HISTORY, PARTITION pn CURRENT)",            // invalid unit
 		sv + " STARTS '2020-01-01 00:00:00' (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // bare STARTS
 		sv + " AUTO", // bare AUTO
 		sv + " LIMIT 1000 STARTS '2020-01-01 00:00:00' (PARTITION p0 HISTORY, PARTITION pn CURRENT)", // STARTS after LIMIT


### PR DESCRIPTION
## What & why

MariaDB lets system-versioned tables be partitioned by `SYSTEM_TIME` (`INTERVAL` / `LIMIT` / `PARTITIONS` / `STARTS` / `AUTO`, with `HISTORY`/`CURRENT` partitions). omni hard-failed all of it at parse time (1064), so any schema containing such a table was unparseable — breaking lineage/sync for that table. This is the deferred follow-up to #319.

## Scope — parse-acceptance MVP

- **Parser**: `SYSTEM_TIME` arm in `parsePartitionClause` (INTERVAL/LIMIT/STARTS/AUTO) + a `HISTORY`/`CURRENT` branch in `parsePartitionDef`.
- **AST**: `PartitionSystemTime` + interval value/unit, limit, starts, auto on `PartitionClause`; `HISTORY`/`CURRENT` on `PartitionDef`. genwalker regenerated (walks the new expr children); outfuncs covered.
- **Catalog**: stores it (`buildPartitionInfo` → `PartitionInfo`), best-effort `showPartitioning`, and **rejects `SYSTEM_TIME` partitioning on a non-versioned table with 4124** (matching MariaDB — otherwise the new parser acceptance would become a semantic over-accept).

## Deliberately deferred: byte-exact SHOW CREATE

Faithful `SHOW CREATE TABLE` round-trip is **not** attempted here and is left to the rendering-calibration work, because it's blocked independently of this change:
- MariaDB injects a **non-deterministic** `STARTS TIMESTAMP'<table-creation-time>'` and normalizes intervals (`1 WEEK` → `7 DAY`).
- omni's partition renderer is already MySQL-flavored (`/*!50100 PARTITION BY …`) vs MariaDB's plain form — it diverges for *every* partition type today.

So the render is best-effort/structural.

## Verification (grounded vs `mariadb:11.8.8`)

- Parser accept: `mdbcheck` GAP 3 → 0 (all forms parse).
- Catalog: `OMNI_OVER_REJECT` 4 → 0, `CODE_DIVERGE` 1 → 0 (non-versioned now 4124); structural assertions, **not** byte-diff.
- New unit tests: parser forms, catalog (render + 4124), outfuncs serialization. Full `mariadb/...` suite green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)