### PR TITLE
fix(mariadb): validate partition count, empty list, and count mismatch

### DIFF
--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -1589,13 +1589,14 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 		}
 	}
 
-	// PARTITIONS num
+	// PARTITIONS num (the count is required)
 	if p.cur.Type == kwPARTITIONS {
 		p.advance()
-		if p.cur.Type == tokICONST {
-			part.NumParts = int(p.cur.Ival)
-			p.advance()
+		if p.cur.Type != tokICONST {
+			return nil, p.syntaxErrorAtCur()
 		}
+		part.NumParts = int(p.cur.Ival)
+		p.advance()
 	}
 
 	// SUBPARTITION BY {HASH(expr) | KEY [ALGORITHM=N] (column_list)}
@@ -1710,8 +1711,20 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 			}
 			p.advance()
 		}
+		// An empty partition list "()" is a syntax error.
+		if len(part.Partitions) == 0 {
+			return nil, p.syntaxErrorAtCur()
+		}
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
+		}
+	}
+
+	// A PARTITIONS count and an explicit partition list must agree.
+	if part.NumParts > 0 && len(part.Partitions) > 0 && len(part.Partitions) != part.NumParts {
+		return nil, &ParseError{
+			Position: part.Loc.Start,
+			Message:  "Wrong number of partitions defined, mismatch with previous setting",
 		}
 	}
 

--- a/mariadb/parser/partition_validation_test.go
+++ b/mariadb/parser/partition_validation_test.go
@@ -1,0 +1,29 @@
+package parser
+
+import "testing"
+
+// TestPartitionCountValidation covers general partition-clause leniencies that
+// omni accepted but MariaDB 11.8.8 rejects with 1064 (verified across types):
+// PARTITIONS without a count, an empty partition list, and a PARTITIONS count
+// that mismatches the explicit partition list length.
+func TestPartitionCountValidation(t *testing.T) {
+	t.Run("reject", func(t *testing.T) {
+		for _, sql := range []string{
+			"CREATE TABLE t (x INT) PARTITION BY HASH(x) PARTITIONS",                 // no count
+			"CREATE TABLE t (x INT) PARTITION BY HASH(x) ()",                         // empty list
+			"CREATE TABLE t (x INT) PARTITION BY HASH(x) PARTITIONS 2 (PARTITION a)", // count > list
+			"CREATE TABLE t (x INT) PARTITION BY RANGE(x) ()",                        // empty list (range)
+		} {
+			t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+		}
+	})
+	t.Run("accept", func(t *testing.T) {
+		for _, sql := range []string{
+			"CREATE TABLE t (x INT) PARTITION BY HASH(x) PARTITIONS 2",
+			"CREATE TABLE t (x INT) PARTITION BY HASH(x) PARTITIONS 2 (PARTITION a, PARTITION b)",
+			"CREATE TABLE t (x INT) PARTITION BY RANGE(x) (PARTITION p VALUES LESS THAN (10))",
+		} {
+			t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+		}
+	})
+}


### PR DESCRIPTION
## What & why

omni's partition parser accepted several forms MariaDB 11.8.8 rejects with **1064**, for **all** partition types (HASH/KEY/RANGE/LIST):

| Form | omni (before) | MariaDB |
|---|---|---|
| `PARTITION BY HASH(x) PARTITIONS` (no count) | accepted | 1064 |
| `PARTITION BY HASH(x) ()` (empty list) | accepted | 1064 |
| `PARTITION BY HASH(x) PARTITIONS 2 (PARTITION a)` (count > list) | accepted | 1064 "Wrong number of partitions" |

These are long-standing leniencies in `parsePartitionClause`, independent of any one partition type. (Surfaced while adding `PARTITION BY SYSTEM_TIME` in #322, but they pre-date it and affect every type — hence a separate, general fix.)

## Fix

In `parsePartitionClause`:
- require the integer count after `PARTITIONS`,
- reject an empty `()` partition list,
- reject a `PARTITIONS n` count that disagrees with an explicit partition-definition list length (a matching count stays valid, e.g. `PARTITIONS 2 (PARTITION a, PARTITION b)`).

## Verification (grounded vs `mariadb:11.8.8`)

- mdbcheck: the 4 negatives → AGREE_REJECT, the 2 positives → AGREE_ACCEPT, OVER 0.
- New `TestPartitionCountValidation` (reject + accept). Full `mariadb/...` suite green; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)