### PR TITLE
feat(mariadb): parse application-time PERIOD FOR <name> in CREATE TABLE

### DIFF
--- a/mariadb/ast/application_time_outfuncs_test.go
+++ b/mariadb/ast/application_time_outfuncs_test.go
@@ -1,0 +1,20 @@
+package ast
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCreateTableAppPeriodOutfuncs locks outfuncs coverage of the application-
+// time PERIOD FOR <name> fields on CreateTableStmt.
+func TestCreateTableAppPeriodOutfuncs(t *testing.T) {
+	n := &CreateTableStmt{
+		Table:             &TableRef{Name: "t"},
+		AppPeriodName:     "app_time",
+		AppPeriodStartCol: "s",
+		AppPeriodEndCol:   "e",
+	}
+	if got := NodeToString(n); !strings.Contains(got, ":period_for app_time (s, e)") {
+		t.Errorf("NodeToString missing app-time period:\n%s", got)
+	}
+}

--- a/mariadb/ast/outfuncs.go
+++ b/mariadb/ast/outfuncs.go
@@ -837,6 +837,9 @@ func writeCreateTableStmt(sb *strings.Builder, n *CreateTableStmt) {
 	if n.PeriodStartCol != "" {
 		fmt.Fprintf(sb, " :period_for_system_time (%s, %s)", n.PeriodStartCol, n.PeriodEndCol)
 	}
+	if n.AppPeriodName != "" {
+		fmt.Fprintf(sb, " :period_for %s (%s, %s)", n.AppPeriodName, n.AppPeriodStartCol, n.AppPeriodEndCol)
+	}
 	sb.WriteString("}")
 }
 

--- a/mariadb/ast/parsenodes.go
+++ b/mariadb/ast/parsenodes.go
@@ -187,6 +187,15 @@ type CreateTableStmt struct {
 	// PERIOD FOR SYSTEM_TIME (start_col, end_col) — system-versioning period.
 	PeriodStartCol string
 	PeriodEndCol   string
+
+	// Application-time period: PERIOD FOR <name> (start_col, end_col). A table
+	// may have at most one; AppPeriodName is empty when absent.
+	AppPeriodName     string
+	AppPeriodStartCol string
+	AppPeriodEndCol   string
+	// AppPeriodDuplicate is set when more than one application-time period was
+	// specified (rejected by the catalog as 4154).
+	AppPeriodDuplicate bool
 }
 
 func (s *CreateTableStmt) nodeTag()  {}

--- a/mariadb/catalog/application_time_test.go
+++ b/mariadb/catalog/application_time_test.go
@@ -1,0 +1,47 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestApplicationTimePeriodCatalog: a named (application-time) PERIOD FOR <name>
+// renders with a backtick-quoted period name and NOT NULL period columns, and
+// coexists with SYSTEM_TIME (bitemporal). Grounded vs mariadb:11.8.8.
+func TestApplicationTimePeriodCatalog(t *testing.T) {
+	ddl := defineAndShow(t, "t", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s, e))")
+	if !strings.Contains(ddl, "PERIOD FOR `app_time` (`s`, `e`)") {
+		t.Errorf("missing app-time period clause:\n%s", ddl)
+	}
+	if !strings.Contains(ddl, "`s` date NOT NULL") || !strings.Contains(ddl, "`e` date NOT NULL") {
+		t.Errorf("period columns should be NOT NULL:\n%s", ddl)
+	}
+}
+
+// TestApplicationTimePeriodValidation pins the malformed-CREATE error codes,
+// grounded vs mariadb:11.8.8.
+func TestApplicationTimePeriodValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		ddl  string
+		code int
+	}{
+		{"cols_dont_exist", "CREATE TABLE t (id INT, PERIOD FOR app_time(nope1, nope2))", 1054},
+		{"two_app_periods", "CREATE TABLE t (id INT, s DATE, e DATE, s2 DATE, e2 DATE, PERIOD FOR p1(s,e), PERIOD FOR p2(s2,e2))", 4154},
+		{"same_col", "CREATE TABLE t (id INT, s DATE, PERIOD FOR app_time(s, s))", 1110},
+		{"wrong_type", "CREATE TABLE t (id INT, s VARCHAR(10), e VARCHAR(10), PERIOD FOR app_time(s, e))", 1063},
+		{"name_is_column", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR id(s, e))", 1060},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := execErr(t, tc.ddl)
+			catErr, ok := err.(*Error)
+			if !ok {
+				t.Fatalf("expected *Error, got %v", err)
+			}
+			if catErr.Code != tc.code {
+				t.Errorf("Code = %d, want %d (message: %q)", catErr.Code, tc.code, catErr.Message)
+			}
+		})
+	}
+}

--- a/mariadb/catalog/errors.go
+++ b/mariadb/catalog/errors.go
@@ -65,6 +65,9 @@ const (
 	ErrWrongPartitionType                = 4113
 	ErrWrongSystemTimePartitions         = 4128
 	ErrValuesOnlyForRange                = 1480
+	ErrMultipleAppPeriods                = 4154
+	ErrColumnSpecifiedTwice              = 1110
+	ErrIncorrectColumnSpecifier          = 1063
 )
 
 var sqlStateMap = map[int]string{
@@ -108,6 +111,9 @@ var sqlStateMap = map[int]string{
 	ErrWrongPartitionType:                "HY000",
 	ErrWrongSystemTimePartitions:         "HY000",
 	ErrValuesOnlyForRange:                "HY000",
+	ErrMultipleAppPeriods:                "HY000",
+	ErrColumnSpecifiedTwice:              "42000",
+	ErrIncorrectColumnSpecifier:          "42000",
 	ErrWrongArguments:                    "HY000",
 	ErrWrongNameForIndex:                 "42000",
 	ErrInvalidOnUpdate:                   "HY000",
@@ -328,6 +334,21 @@ func errWrongSystemTimePartitions(table string) error {
 func errValuesOnlyForRange() error {
 	return &Error{Code: ErrValuesOnlyForRange, SQLState: sqlState(ErrValuesOnlyForRange),
 		Message: "Only RANGE PARTITIONING can use VALUES LESS THAN in partition definition"}
+}
+
+func errMultipleAppPeriods() error {
+	return &Error{Code: ErrMultipleAppPeriods, SQLState: sqlState(ErrMultipleAppPeriods),
+		Message: "Cannot specify more than one application-time period"}
+}
+
+func errColumnSpecifiedTwice(col string) error {
+	return &Error{Code: ErrColumnSpecifiedTwice, SQLState: sqlState(ErrColumnSpecifiedTwice),
+		Message: fmt.Sprintf("Column '%s' specified twice", col)}
+}
+
+func errIncorrectColumnSpecifier(col string) error {
+	return &Error{Code: ErrIncorrectColumnSpecifier, SQLState: sqlState(ErrIncorrectColumnSpecifier),
+		Message: fmt.Sprintf("Incorrect column specifier for column '%s'", col)}
 }
 
 func errNotSystemVersioned(table string) error {

--- a/mariadb/catalog/show.go
+++ b/mariadb/catalog/show.go
@@ -88,6 +88,12 @@ func (c *Catalog) ShowCreateTable(database, table string) string {
 		parts = append(parts, showColumnWithTable(col, tbl))
 	}
 
+	// Application-time period — rendered before SYSTEM_TIME; the name is
+	// backtick-quoted (unlike the SYSTEM_TIME keyword).
+	if tbl.AppPeriodName != "" {
+		parts = append(parts, fmt.Sprintf("PERIOD FOR `%s` (`%s`, `%s`)", tbl.AppPeriodName, tbl.AppPeriodStartCol, tbl.AppPeriodEndCol))
+	}
+
 	// PERIOD FOR SYSTEM_TIME — after columns, before keys/constraints.
 	if tbl.PeriodStartCol != "" {
 		parts = append(parts, fmt.Sprintf("PERIOD FOR SYSTEM_TIME (`%s`, `%s`)", tbl.PeriodStartCol, tbl.PeriodEndCol))

--- a/mariadb/catalog/table.go
+++ b/mariadb/catalog/table.go
@@ -35,6 +35,12 @@ type Table struct {
 	PeriodStartCol  string
 	PeriodEndCol    string
 
+	// Application-time period: PERIOD FOR <name> (start, end). A table may have
+	// at most one; AppPeriodName is empty when absent.
+	AppPeriodName     string
+	AppPeriodStartCol string
+	AppPeriodEndCol   string
+
 	// droppedByCleanup tracks indexes auto-removed by DROP COLUMN cleanup
 	// during multi-command ALTER TABLE. This allows a subsequent explicit
 	// DROP INDEX in the same ALTER to succeed (matching MySQL 8.0 behavior).

--- a/mariadb/catalog/tablecmds.go
+++ b/mariadb/catalog/tablecmds.go
@@ -170,6 +170,9 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 	// WITH SYSTEM VERSIONING).
 	tbl.PeriodStartCol = stmt.PeriodStartCol
 	tbl.PeriodEndCol = stmt.PeriodEndCol
+	tbl.AppPeriodName = stmt.AppPeriodName
+	tbl.AppPeriodStartCol = stmt.AppPeriodStartCol
+	tbl.AppPeriodEndCol = stmt.AppPeriodEndCol
 
 	// Process columns.
 	for i, colDef := range stmt.Columns {
@@ -407,6 +410,19 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			}
 		}
 	}
+	if err := validateApplicationTimePeriod(tbl, stmt); err != nil {
+		return err
+	}
+	// Application-time period columns are implicitly NOT NULL.
+	if tbl.AppPeriodName != "" {
+		for _, col := range tbl.Columns {
+			if strings.EqualFold(col.Name, tbl.AppPeriodStartCol) ||
+				strings.EqualFold(col.Name, tbl.AppPeriodEndCol) {
+				col.Nullable = false
+			}
+		}
+	}
+
 	if err := validateSystemVersioning(tbl); err != nil {
 		return err
 	}
@@ -1918,6 +1934,42 @@ func checkDuplicateRowColumns(tbl *Table) error {
 	return nil
 }
 
+// validateApplicationTimePeriod enforces MariaDB's rules for a named
+// (application-time) PERIOD FOR <name> (start, end), grounded vs 11.8.8.
+func validateApplicationTimePeriod(tbl *Table, stmt *nodes.CreateTableStmt) error {
+	if tbl.AppPeriodName == "" {
+		return nil
+	}
+	if stmt.AppPeriodDuplicate {
+		return errMultipleAppPeriods() // 4154
+	}
+	if strings.EqualFold(tbl.AppPeriodStartCol, tbl.AppPeriodEndCol) {
+		return errColumnSpecifiedTwice(tbl.AppPeriodStartCol) // 1110
+	}
+	if tbl.GetColumn(tbl.AppPeriodName) != nil {
+		return errDupColumn(tbl.AppPeriodName) // 1060: period name collides with a column
+	}
+	for _, colName := range []string{tbl.AppPeriodStartCol, tbl.AppPeriodEndCol} {
+		col := tbl.GetColumn(colName)
+		if col == nil {
+			return errNoSuchColumn(colName, tbl.AppPeriodName) // 1054
+		}
+		if !isTemporalPeriodType(col.DataType) {
+			return errIncorrectColumnSpecifier(colName) // 1063
+		}
+	}
+	return nil
+}
+
+// isTemporalPeriodType reports whether a type is valid for a period column.
+func isTemporalPeriodType(dataType string) bool {
+	switch toLower(dataType) {
+	case "date", "datetime", "timestamp":
+		return true
+	}
+	return false
+}
+
 // validateSystemVersioning enforces MariaDB's structural rules for
 // system-versioned tables. It is applied after CREATE and after an ALTER (so a
 // multi-command "ADD COLUMN ... ROW START, ADD PERIOD, ADD SYSTEM VERSIONING"
@@ -2426,34 +2478,37 @@ func (c *Catalog) createTableLike(db *Database, tableName, key string, stmt *nod
 	}
 
 	tbl := &Table{
-		Name:             tableName,
-		Database:         db,
-		Columns:          make([]*Column, 0, len(srcTbl.Columns)),
-		colByName:        make(map[string]int),
-		Indexes:          make([]*Index, 0, len(srcTbl.Indexes)),
-		Constraints:      make([]*Constraint, 0, len(srcTbl.Constraints)),
-		Engine:           srcTbl.Engine,
-		Charset:          srcTbl.Charset,
-		Collation:        srcTbl.Collation,
-		Comment:          srcTbl.Comment,
-		RowFormat:        srcTbl.RowFormat,
-		KeyBlockSize:     srcTbl.KeyBlockSize,
-		Compression:      srcTbl.Compression,
-		Encryption:       srcTbl.Encryption,
-		StatsPersistent:  srcTbl.StatsPersistent,
-		StatsAutoRecalc:  srcTbl.StatsAutoRecalc,
-		StatsSamplePages: srcTbl.StatsSamplePages,
-		MinRows:          srcTbl.MinRows,
-		MaxRows:          srcTbl.MaxRows,
-		AvgRowLength:     srcTbl.AvgRowLength,
-		Tablespace:       srcTbl.Tablespace,
-		PackKeys:         srcTbl.PackKeys,
-		Checksum:         srcTbl.Checksum,
-		DelayKeyWrite:    srcTbl.DelayKeyWrite,
-		Temporary:        stmt.Temporary,
-		SystemVersioned:  srcTbl.SystemVersioned,
-		PeriodStartCol:   srcTbl.PeriodStartCol,
-		PeriodEndCol:     srcTbl.PeriodEndCol,
+		Name:              tableName,
+		Database:          db,
+		Columns:           make([]*Column, 0, len(srcTbl.Columns)),
+		colByName:         make(map[string]int),
+		Indexes:           make([]*Index, 0, len(srcTbl.Indexes)),
+		Constraints:       make([]*Constraint, 0, len(srcTbl.Constraints)),
+		Engine:            srcTbl.Engine,
+		Charset:           srcTbl.Charset,
+		Collation:         srcTbl.Collation,
+		Comment:           srcTbl.Comment,
+		RowFormat:         srcTbl.RowFormat,
+		KeyBlockSize:      srcTbl.KeyBlockSize,
+		Compression:       srcTbl.Compression,
+		Encryption:        srcTbl.Encryption,
+		StatsPersistent:   srcTbl.StatsPersistent,
+		StatsAutoRecalc:   srcTbl.StatsAutoRecalc,
+		StatsSamplePages:  srcTbl.StatsSamplePages,
+		MinRows:           srcTbl.MinRows,
+		MaxRows:           srcTbl.MaxRows,
+		AvgRowLength:      srcTbl.AvgRowLength,
+		Tablespace:        srcTbl.Tablespace,
+		PackKeys:          srcTbl.PackKeys,
+		Checksum:          srcTbl.Checksum,
+		DelayKeyWrite:     srcTbl.DelayKeyWrite,
+		Temporary:         stmt.Temporary,
+		SystemVersioned:   srcTbl.SystemVersioned,
+		PeriodStartCol:    srcTbl.PeriodStartCol,
+		PeriodEndCol:      srcTbl.PeriodEndCol,
+		AppPeriodName:     srcTbl.AppPeriodName,
+		AppPeriodStartCol: srcTbl.AppPeriodStartCol,
+		AppPeriodEndCol:   srcTbl.AppPeriodEndCol,
 	}
 
 	// Copy columns.

--- a/mariadb/parser/alter_table.go
+++ b/mariadb/parser/alter_table.go
@@ -448,11 +448,15 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 		return cmd, nil
 	}
 
-	// ADD PERIOD FOR SYSTEM_TIME (start_col, end_col)
+	// ADD PERIOD FOR SYSTEM_TIME (start_col, end_col).
+	// (Application-time ALTER ... ADD PERIOD is not yet supported.)
 	if p.atPeriodForSystemTime() {
-		startCol, endCol, err := p.parsePeriodForSystemTimeCols()
+		name, startCol, endCol, err := p.parsePeriodForCols()
 		if err != nil {
 			return nil, err
+		}
+		if !strings.EqualFold(name, "SYSTEM_TIME") {
+			return nil, p.syntaxErrorAtCur()
 		}
 		cmd.Type = nodes.ATAddPeriod
 		cmd.PeriodStartCol = startCol

--- a/mariadb/parser/application_time_test.go
+++ b/mariadb/parser/application_time_test.go
@@ -9,6 +9,10 @@ func TestApplicationTimePeriodCreate(t *testing.T) {
 	for _, sql := range []string{
 		"CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s, e))",
 		"CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time (s, e))",
+		// The period name follows the identifier rule — non-reserved keywords
+		// (history, current, ...) are valid period names.
+		"CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR history(s, e))",
+		"CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR current(s, e))",
 		"CREATE TABLE t (x INT, rs TIMESTAMP(6) GENERATED ALWAYS AS ROW START, " +
 			"re TIMESTAMP(6) GENERATED ALWAYS AS ROW END, s DATE, e DATE, " +
 			"PERIOD FOR SYSTEM_TIME(rs, re), PERIOD FOR app_time(s, e)) WITH SYSTEM VERSIONING",

--- a/mariadb/parser/application_time_test.go
+++ b/mariadb/parser/application_time_test.go
@@ -1,0 +1,18 @@
+package parser
+
+import "testing"
+
+// TestApplicationTimePeriodCreate covers CREATE TABLE with a named (application-
+// time) PERIOD FOR <name> (start, end) — container-verified accepted by
+// mariadb:11.8.8, including alongside SYSTEM_TIME (bitemporal).
+func TestApplicationTimePeriodCreate(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s, e))",
+		"CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time (s, e))",
+		"CREATE TABLE t (x INT, rs TIMESTAMP(6) GENERATED ALWAYS AS ROW START, " +
+			"re TIMESTAMP(6) GENERATED ALWAYS AS ROW END, s DATE, e DATE, " +
+			"PERIOD FOR SYSTEM_TIME(rs, re), PERIOD FOR app_time(s, e)) WITH SYSTEM VERSIONING",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -205,7 +205,7 @@ func (p *Parser) parseCreateDefinitions(stmt *nodes.CreateTableStmt) error {
 		// PERIOD FOR SYSTEM_TIME (start_col, end_col) — a table element, not a
 		// column. Intercepted before parseColumnDef would read PERIOD as a name.
 		if p.atPeriodForSystemTime() {
-			if err := p.parsePeriodForSystemTime(stmt); err != nil {
+			if err := p.parsePeriodFor(stmt); err != nil {
 				return err
 			}
 		} else if p.isTableConstraintStart() {
@@ -251,46 +251,55 @@ func (p *Parser) atPeriodForSystemTime() bool {
 		p.peekNext().Type == kwFOR
 }
 
-// parsePeriodForSystemTime parses PERIOD FOR SYSTEM_TIME (start_col, end_col)
-// and records the period columns on the statement.
-func (p *Parser) parsePeriodForSystemTime(stmt *nodes.CreateTableStmt) error {
-	startCol, endCol, err := p.parsePeriodForSystemTimeCols()
+// parsePeriodFor parses a CREATE TABLE PERIOD FOR <name> (start, end) element,
+// routing SYSTEM_TIME to the system-versioning period and any other name to the
+// application-time period.
+func (p *Parser) parsePeriodFor(stmt *nodes.CreateTableStmt) error {
+	name, startCol, endCol, err := p.parsePeriodForCols()
 	if err != nil {
 		return err
 	}
-	stmt.PeriodStartCol = startCol
-	stmt.PeriodEndCol = endCol
+	if strings.EqualFold(name, "SYSTEM_TIME") {
+		stmt.PeriodStartCol = startCol
+		stmt.PeriodEndCol = endCol
+	} else {
+		if stmt.AppPeriodName != "" {
+			stmt.AppPeriodDuplicate = true
+		}
+		stmt.AppPeriodName = name
+		stmt.AppPeriodStartCol = startCol
+		stmt.AppPeriodEndCol = endCol
+	}
 	return nil
 }
 
-// parsePeriodForSystemTimeCols parses PERIOD FOR SYSTEM_TIME (start_col, end_col)
-// and returns the two period column names. Shared by CREATE TABLE and
+// parsePeriodForCols parses PERIOD FOR <name> (start_col, end_col) and returns
+// the period name and the two column names. Shared by CREATE TABLE and
 // ALTER TABLE ... ADD PERIOD. PERIOD is the current token.
-func (p *Parser) parsePeriodForSystemTimeCols() (string, string, error) {
+func (p *Parser) parsePeriodForCols() (name, startCol, endCol string, err error) {
 	p.advance() // PERIOD
 	p.advance() // FOR
-	if p.cur.Type != tokIDENT || !strings.EqualFold(p.cur.Str, "SYSTEM_TIME") {
-		return "", "", p.syntaxErrorAtCur()
+	if p.cur.Type != tokIDENT {
+		return "", "", "", p.syntaxErrorAtCur()
 	}
-	p.advance() // SYSTEM_TIME
-	if _, err := p.expect('('); err != nil {
-		return "", "", err
+	name = p.cur.Str
+	p.advance() // period name
+	if _, err = p.expect('('); err != nil {
+		return "", "", "", err
 	}
-	startCol, _, err := p.parseIdent()
-	if err != nil {
-		return "", "", err
+	if startCol, _, err = p.parseIdent(); err != nil {
+		return "", "", "", err
 	}
-	if _, err := p.expect(','); err != nil {
-		return "", "", err
+	if _, err = p.expect(','); err != nil {
+		return "", "", "", err
 	}
-	endCol, _, err := p.parseIdent()
-	if err != nil {
-		return "", "", err
+	if endCol, _, err = p.parseIdent(); err != nil {
+		return "", "", "", err
 	}
-	if _, err := p.expect(')'); err != nil {
-		return "", "", err
+	if _, err = p.expect(')'); err != nil {
+		return "", "", "", err
 	}
-	return startCol, endCol, nil
+	return name, startCol, endCol, nil
 }
 
 // parseRowBound parses ROW START | ROW END (the system-versioning period bound a

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -279,11 +279,11 @@ func (p *Parser) parsePeriodFor(stmt *nodes.CreateTableStmt) error {
 func (p *Parser) parsePeriodForCols() (name, startCol, endCol string, err error) {
 	p.advance() // PERIOD
 	p.advance() // FOR
-	if p.cur.Type != tokIDENT {
-		return "", "", "", p.syntaxErrorAtCur()
+	// The period name follows the identifier rule (non-reserved keywords allowed),
+	// like the start/end column names below.
+	if name, _, err = p.parseIdent(); err != nil {
+		return "", "", "", err
 	}
-	name = p.cur.Str
-	p.advance() // period name
 	if _, err = p.expect('('); err != nil {
 		return "", "", "", err
 	}


### PR DESCRIPTION
## What & why

MariaDB supports **application-time periods** — a user-named `PERIOD FOR <name> (start, end)` over regular date/datetime/timestamp columns — independent of (or alongside) `SYSTEM_TIME` (bitemporal). omni's parser only accepted `SYSTEM_TIME`, so any schema declaring an application-time period was **unparseable** (1064), breaking lineage/sync for that table.

This is PR1 of the deferred application-time work (the non-system-versioned temporal that #319 left out).

## Scope — CREATE TABLE

- **Parser**: generalize the period parser to capture the period *name* — `SYSTEM_TIME` routes to the system-versioning period; any other name to the application-time period.
- **Catalog**: model it on `Table` (one optional app-time period); period columns are implicitly `NOT NULL`.
- **Render**: `PERIOD FOR \`name\` (\`s\`, \`e\`)` — backtick-quoted name, rendered before `SYSTEM_TIME` (bitemporal-correct).
- **Validation** (grounded vs `mariadb:11.8.8`): nonexistent period columns (**1054**), more than one application-time period (**4154**), same column for start+end (**1110**), non-temporal period column (**1063**), period name colliding with a column (**1060**).

## Verification

- mdbcheck: CREATE app-time forms (incl. bitemporal) → `AGREE_ACCEPT`, GAP 0.
- New tests: parser accept, catalog render + NOT NULL, all 5 validation codes, outfuncs serialization. Full `mariadb/...` suite green; gofmt/vet clean.

## Follow-ups (deferred, tracked)

- `WITHOUT OVERLAPS` keys + `ALTER ... ADD/DROP PERIOD` for application-time (PR2).
- `FOR PORTION OF` in UPDATE/DELETE (PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)