### PR TITLE
fix(mssql): remove CURRENT_TIME from niladic keyword functions

### DIFF
--- a/mssql/parser/expr.go
+++ b/mssql/parser/expr.go
@@ -754,7 +754,7 @@ func (p *Parser) parsePrimary() (nodes.ExprNode, error) {
 		}
 		return nil, nil
 	case kwCURRENT_TIMESTAMP, kwCURRENT_USER, kwSESSION_USER,
-		kwSYSTEM_USER, kwUSER, kwCURRENT_DATE, kwCURRENT_TIME:
+		kwSYSTEM_USER, kwUSER, kwCURRENT_DATE:
 		return p.parseNiladicKeywordFunc()
 	case tokIDENT:
 		return p.parseIdentExpr()

--- a/mssql/parser/keyword_callable_test.go
+++ b/mssql/parser/keyword_callable_test.go
@@ -116,7 +116,6 @@ var callableKeywordManifest = []callableKeyword{
 	{keyword: "SYSTEM_USER", role: roleNiladic, acceptSample: "SELECT SYSTEM_USER"},
 	{keyword: "USER", role: roleNiladic, acceptSample: "SELECT USER"},
 	{keyword: "CURRENT_DATE", role: roleNiladic, acceptSample: "SELECT CURRENT_DATE"},
-	{keyword: "CURRENT_TIME", role: roleNiladic, acceptSample: "SELECT CURRENT_TIME"},
 }
 
 // rejectContexts are the "wrong-context" shapes we spray each keyword into


### PR DESCRIPTION
## Summary

- Remove `CURRENT_TIME` from MSSQL niladic keyword function list in `parsePrimary()`
- Remove corresponding test manifest entry

`CURRENT_TIME` is not a native T-SQL function. Microsoft's [date/time function table](https://learn.microsoft.com/en-us/sql/t-sql/functions/date-and-time-data-types-and-functions-transact-sql) lists `CURRENT_TIMESTAMP` and `CURRENT_DATE` but not `CURRENT_TIME`. It only appears in [ODBC scalar functions](https://learn.microsoft.com/en-us/sql/t-sql/functions/odbc-scalar-functions-transact-sql) with `{fn ...}` escape syntax.

This was flagged by Codex review on bytebase/bytebase#20654.

## Test plan

- [x] `TestCallableKeyword` passes — `CURRENT_TIME` is no longer in the manifest
- [x] Verified `SELECT CURRENT_TIME` is rejected by parser
- [x] Verified `SELECT CURRENT_TIMESTAMP`, `SELECT CURRENT_DATE`, `SELECT CURRENT_USER` still accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)