### PR TITLE
feat(mariadb): ALTER TABLE ADD/DROP PERIOD FOR <name> (application-time)

### DIFF
--- a/mariadb/ast/application_time_outfuncs_test.go
+++ b/mariadb/ast/application_time_outfuncs_test.go
@@ -18,3 +18,17 @@ func TestCreateTableAppPeriodOutfuncs(t *testing.T) {
 		t.Errorf("NodeToString missing app-time period:\n%s", got)
 	}
 }
+
+// TestAlterTableAppPeriodOutfuncs locks outfuncs coverage of the period name on
+// ADD/DROP PERIOD AlterTableCmd nodes, so application-time and system-time
+// periods are distinguishable in NodeToString.
+func TestAlterTableAppPeriodOutfuncs(t *testing.T) {
+	add := &AlterTableCmd{Type: ATAddPeriod, PeriodName: "app_time", PeriodStartCol: "s", PeriodEndCol: "e"}
+	if got := NodeToString(add); !strings.Contains(got, ":period_for app_time (s, e)") {
+		t.Errorf("ADD PERIOD NodeToString missing period name:\n%s", got)
+	}
+	drop := &AlterTableCmd{Type: ATDropPeriod, PeriodName: "app_time"}
+	if got := NodeToString(drop); !strings.Contains(got, ":period_for app_time") {
+		t.Errorf("DROP PERIOD NodeToString missing period name:\n%s", got)
+	}
+}

--- a/mariadb/ast/outfuncs.go
+++ b/mariadb/ast/outfuncs.go
@@ -2849,8 +2849,12 @@ func writeAlterTableCmd(sb *strings.Builder, n *AlterTableCmd) {
 	if n.Name != "" {
 		fmt.Fprintf(sb, " :name %s", n.Name)
 	}
-	if n.PeriodStartCol != "" {
-		fmt.Fprintf(sb, " :period_for_system_time (%s, %s)", n.PeriodStartCol, n.PeriodEndCol)
+	if n.PeriodName != "" {
+		if n.PeriodStartCol != "" {
+			fmt.Fprintf(sb, " :period_for %s (%s, %s)", n.PeriodName, n.PeriodStartCol, n.PeriodEndCol)
+		} else {
+			fmt.Fprintf(sb, " :period_for %s", n.PeriodName)
+		}
 	}
 	if n.NewName != "" {
 		fmt.Fprintf(sb, " :new_name %s", n.NewName)

--- a/mariadb/ast/parsenodes.go
+++ b/mariadb/ast/parsenodes.go
@@ -293,9 +293,11 @@ type AlterTableCmd struct {
 	WithValidation *bool            // for EXCHANGE PARTITION: true=WITH VALIDATION, false=WITHOUT VALIDATION, nil=not specified
 	OrderByItems   []*OrderByItem   // for ORDER BY operation
 	PartitionBy    *PartitionClause // for PARTITION BY (repartition)
-	// PeriodStartCol / PeriodEndCol carry ADD PERIOD FOR SYSTEM_TIME (start, end).
+	// PeriodStartCol / PeriodEndCol carry ADD PERIOD FOR <name> (start, end);
+	// PeriodName is the period name ("SYSTEM_TIME" or an application-time name).
 	PeriodStartCol string
 	PeriodEndCol   string
+	PeriodName     string
 }
 
 func (c *AlterTableCmd) nodeTag() {}

--- a/mariadb/catalog/altercmds.go
+++ b/mariadb/catalog/altercmds.go
@@ -235,7 +235,7 @@ func (c *Catalog) alterAddAppPeriod(tbl *Table, cmd *nodes.AlterTableCmd) error 
 	// MariaDB makes application-time period columns NOT NULL.
 	for _, colName := range []string{cmd.PeriodStartCol, cmd.PeriodEndCol} {
 		if col := tbl.GetColumn(colName); col != nil {
-			col.Nullable = false
+			normalizeAppPeriodColumn(col)
 		}
 	}
 	return nil

--- a/mariadb/catalog/altercmds.go
+++ b/mariadb/catalog/altercmds.go
@@ -174,6 +174,9 @@ func (c *Catalog) execAlterCmd(db *Database, tbl *Table, cmd *nodes.AlterTableCm
 		tbl.SystemVersioned = false
 		return nil
 	case nodes.ATAddPeriod:
+		if !isSystemTimePeriodName(cmd.PeriodName) {
+			return c.alterAddAppPeriod(tbl, cmd)
+		}
 		if tbl.PeriodStartCol != "" {
 			return errAlreadySystemVersioned(tbl.Name)
 		}
@@ -181,6 +184,9 @@ func (c *Catalog) execAlterCmd(db *Database, tbl *Table, cmd *nodes.AlterTableCm
 		tbl.PeriodEndCol = cmd.PeriodEndCol
 		return nil
 	case nodes.ATDropPeriod:
+		if !isSystemTimePeriodName(cmd.PeriodName) {
+			return c.alterDropAppPeriod(tbl, cmd)
+		}
 		// Check period presence first so the result is independent of command
 		// order: a DROP SYSTEM VERSIONING earlier in the same statement flips the
 		// versioned flag but does not clear the period.
@@ -197,6 +203,54 @@ func (c *Catalog) execAlterCmd(db *Database, tbl *Table, cmd *nodes.AlterTableCm
 		// Unsupported alter command; silently ignore.
 		return nil
 	}
+}
+
+// isSystemTimePeriodName reports whether an ADD/DROP PERIOD command targets the
+// system-versioning period rather than an application-time period.
+func isSystemTimePeriodName(name string) bool {
+	return name == "" || strings.EqualFold(name, "SYSTEM_TIME")
+}
+
+// alterAddAppPeriod adds an application-time period to an existing table,
+// applying the same validations as CREATE (4154/1110/1060/1054/1063) and making
+// the period columns NOT NULL. Grounded vs 11.8.8.
+func (c *Catalog) alterAddAppPeriod(tbl *Table, cmd *nodes.AlterTableCmd) error {
+	if tbl.AppPeriodName != "" {
+		return errMultipleAppPeriods() // 4154
+	}
+	if err := validateAppPeriodColumns(tbl, cmd.PeriodName, cmd.PeriodStartCol, cmd.PeriodEndCol); err != nil {
+		return err
+	}
+	tbl.AppPeriodName = cmd.PeriodName
+	tbl.AppPeriodStartCol = cmd.PeriodStartCol
+	tbl.AppPeriodEndCol = cmd.PeriodEndCol
+	// MariaDB makes application-time period columns NOT NULL.
+	for _, colName := range []string{cmd.PeriodStartCol, cmd.PeriodEndCol} {
+		if col := tbl.GetColumn(colName); col != nil {
+			col.Nullable = false
+		}
+	}
+	return nil
+}
+
+// alterDropAppPeriod removes the application-time period: 1091 if no such period
+// exists, or 4156 if a WITHOUT OVERLAPS key still references it. The period
+// columns keep their NOT NULL. Grounded vs 11.8.8.
+func (c *Catalog) alterDropAppPeriod(tbl *Table, cmd *nodes.AlterTableCmd) error {
+	if tbl.AppPeriodName == "" || !strings.EqualFold(tbl.AppPeriodName, cmd.PeriodName) {
+		return errCantDropPeriod(cmd.PeriodName) // 1091
+	}
+	for _, idx := range tbl.Indexes {
+		for _, ic := range idx.Columns {
+			if ic.WithoutOverlaps && strings.EqualFold(ic.Name, tbl.AppPeriodName) {
+				return errPeriodNotFound(tbl.AppPeriodName) // 4156
+			}
+		}
+	}
+	tbl.AppPeriodName = ""
+	tbl.AppPeriodStartCol = ""
+	tbl.AppPeriodEndCol = ""
+	return nil
 }
 
 // cmdAffectsVersioning reports whether an ALTER command can change a table's

--- a/mariadb/catalog/altercmds.go
+++ b/mariadb/catalog/altercmds.go
@@ -58,7 +58,7 @@ func (c *Catalog) alterTable(stmt *nodes.AlterTableStmt) error {
 		// command through post-mutation validation when the table is already
 		// versioned or the command itself carries versioning metadata. Plain
 		// tables keep the no-clone fast path.
-		if !tbl.SystemVersioned && !cmdAffectsVersioning(cmd) {
+		if !alterNeedsFinalValidation(tbl, cmd) {
 			return c.execAlterCmd(db, tbl, cmd)
 		}
 		// Versioning commands need a post-mutation consistency check, so snapshot
@@ -70,6 +70,10 @@ func (c *Catalog) alterTable(stmt *nodes.AlterTableStmt) error {
 			return err
 		}
 		if err := validateSystemVersioning(tbl); err != nil {
+			*tbl = snapshot
+			return err
+		}
+		if err := validateApplicationTimeFinalState(tbl); err != nil {
 			*tbl = snapshot
 			return err
 		}
@@ -100,6 +104,10 @@ func (c *Catalog) alterTable(stmt *nodes.AlterTableStmt) error {
 	// Validate system-versioning consistency across the atomic ALTER as a whole
 	// ("ADD PERIOD ..., ADD SYSTEM VERSIONING" is valid; either one alone is not).
 	if err := validateSystemVersioning(tbl); err != nil {
+		rollback()
+		return err
+	}
+	if err := validateApplicationTimeFinalState(tbl); err != nil {
 		rollback()
 		return err
 	}
@@ -234,23 +242,34 @@ func (c *Catalog) alterAddAppPeriod(tbl *Table, cmd *nodes.AlterTableCmd) error 
 }
 
 // alterDropAppPeriod removes the application-time period: 1091 if no such period
-// exists, or 4156 if a WITHOUT OVERLAPS key still references it. The period
-// columns keep their NOT NULL. Grounded vs 11.8.8.
+// exists. A WITHOUT OVERLAPS key still referencing it is caught by the
+// final-state pass (4156), so a later DROP KEY in the same statement can remove
+// the dependency first. The period columns keep their NOT NULL. Grounded vs 11.8.8.
 func (c *Catalog) alterDropAppPeriod(tbl *Table, cmd *nodes.AlterTableCmd) error {
 	if tbl.AppPeriodName == "" || !strings.EqualFold(tbl.AppPeriodName, cmd.PeriodName) {
 		return errCantDropPeriod(cmd.PeriodName) // 1091
-	}
-	for _, idx := range tbl.Indexes {
-		for _, ic := range idx.Columns {
-			if ic.WithoutOverlaps && strings.EqualFold(ic.Name, tbl.AppPeriodName) {
-				return errPeriodNotFound(tbl.AppPeriodName) // 4156
-			}
-		}
 	}
 	tbl.AppPeriodName = ""
 	tbl.AppPeriodStartCol = ""
 	tbl.AppPeriodEndCol = ""
 	return nil
+}
+
+// alterNeedsFinalValidation reports whether an ALTER command requires the
+// post-mutation consistency checks (system-versioning + application-time), so the
+// no-snapshot fast path is unsafe: the table is already system-versioned or has
+// an application-time period (any column change can invalidate it), the command
+// adds a key (a WITHOUT OVERLAPS key needs the final-state period check), or the
+// command carries versioning / period metadata.
+func alterNeedsFinalValidation(tbl *Table, cmd *nodes.AlterTableCmd) bool {
+	if tbl.SystemVersioned || tbl.AppPeriodName != "" {
+		return true
+	}
+	switch cmd.Type {
+	case nodes.ATAddIndex, nodes.ATAddConstraint:
+		return true
+	}
+	return cmdAffectsVersioning(cmd)
 }
 
 // cmdAffectsVersioning reports whether an ALTER command can change a table's
@@ -626,9 +645,6 @@ func (c *Catalog) alterAddConstraint(tbl *Table, cmd *nodes.AlterTableCmd) error
 			}
 		}
 		idxCols := buildIndexColumns(con)
-		if err := validateColsWithoutOverlaps(tbl, "PRIMARY", idxCols); err != nil {
-			return err
-		}
 		pkIdx := &Index{
 			Name:      "PRIMARY",
 			Table:     tbl,
@@ -665,9 +681,6 @@ func (c *Catalog) alterAddConstraint(tbl *Table, cmd *nodes.AlterTableCmd) error
 		}
 		idxCols := buildIndexColumns(con)
 		if err := validateIndexColumns(tbl, idxCols, false, false); err != nil {
-			return err
-		}
-		if err := validateColsWithoutOverlaps(tbl, idxName, idxCols); err != nil {
 			return err
 		}
 		tbl.Indexes = append(tbl.Indexes, &Index{
@@ -918,6 +931,13 @@ func (c *Catalog) alterRenameColumn(tbl *Table, cmd *nodes.AlterTableCmd) error 
 	}
 	if strings.EqualFold(tbl.PeriodEndCol, cmd.Name) {
 		tbl.PeriodEndCol = cmd.NewName
+	}
+	// Likewise keep the application-time period referencing the renamed column.
+	if strings.EqualFold(tbl.AppPeriodStartCol, cmd.Name) {
+		tbl.AppPeriodStartCol = cmd.NewName
+	}
+	if strings.EqualFold(tbl.AppPeriodEndCol, cmd.Name) {
+		tbl.AppPeriodEndCol = cmd.NewName
 	}
 	rebuildColIndex(tbl)
 	return nil

--- a/mariadb/catalog/application_time_test.go
+++ b/mariadb/catalog/application_time_test.go
@@ -31,6 +31,8 @@ func TestApplicationTimePeriodValidation(t *testing.T) {
 		{"same_col", "CREATE TABLE t (id INT, s DATE, PERIOD FOR app_time(s, s))", 1110},
 		{"wrong_type", "CREATE TABLE t (id INT, s VARCHAR(10), e VARCHAR(10), PERIOD FOR app_time(s, e))", 1063},
 		{"name_is_column", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR id(s, e))", 1060},
+		{"different_types", "CREATE TABLE t (id INT, s DATE, e DATETIME, PERIOD FOR app_time(s, e))", 4153},
+		{"different_precision", "CREATE TABLE t (id INT, s DATETIME(3), e DATETIME(6), PERIOD FOR app_time(s, e))", 4153},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -41,6 +43,83 @@ func TestApplicationTimePeriodValidation(t *testing.T) {
 			}
 			if catErr.Code != tc.code {
 				t.Errorf("Code = %d, want %d (message: %q)", catErr.Code, tc.code, catErr.Message)
+			}
+		})
+	}
+}
+
+// TestAlterApplicationTimeFinalState: the application-time period and its
+// WITHOUT OVERLAPS keys are validated on the FINAL ALTER state, not per command.
+// Column mutations that invalidate a period are caught; valid ones keep the
+// period columns NOT NULL; RENAME rewrites the period reference; and the
+// WITHOUT OVERLAPS ↔ period dependency holds regardless of command order.
+// Grounded vs mariadb:11.8.8.
+func TestAlterApplicationTimeFinalState(t *testing.T) {
+	// A column mutation that leaves the period invalid is rejected (final state).
+	for _, tc := range []struct {
+		name, create, alter string
+		code                int
+	}{
+		{"modify_period_col_nontemporal", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t MODIFY s INT", 1063},
+		{"modify_period_col_type_mismatch", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t MODIFY s DATETIME", 4153},
+		{"drop_period_col", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t DROP COLUMN s", 1054},
+		{"multicmd_add_then_modify", "CREATE TABLE t (id INT, s DATE, e DATE)", "ALTER TABLE t ADD PERIOD FOR app_time(s,e), MODIFY s INT", 1063},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			c.Exec("CREATE DATABASE test", nil)
+			c.SetCurrentDatabase("test")
+			c.Exec(tc.create, nil)
+			r, _ := c.Exec(tc.alter, &ExecOptions{ContinueOnError: true})
+			if catErr, ok := r[0].Error.(*Error); !ok || catErr.Code != tc.code {
+				t.Fatalf("want %d, got %v", tc.code, r[0].Error)
+			}
+		})
+	}
+	// A valid mutation keeps the period columns NOT NULL; RENAME follows.
+	for _, tc := range []struct{ name, create, alter, want string }{
+		{"modify_keeps_not_null", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t MODIFY s DATE", "`s` date NOT NULL"},
+		{"rename_rewrites_period", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t RENAME COLUMN s TO s2", "PERIOD FOR `app_time` (`s2`, `e`)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			c.Exec("CREATE DATABASE test", nil)
+			c.SetCurrentDatabase("test")
+			c.Exec(tc.create, nil)
+			if r, _ := c.Exec(tc.alter, &ExecOptions{ContinueOnError: true}); r[0].Error != nil {
+				t.Fatalf("alter: %v", r[0].Error)
+			}
+			if show := c.ShowCreateTable("test", "t"); !strings.Contains(show, tc.want) {
+				t.Fatalf("want %q in:\n%s", tc.want, show)
+			}
+		})
+	}
+	// WITHOUT OVERLAPS ↔ period dependency is final-state: DROP in either order
+	// and reversed ADD both work; DROP PERIOD with the key still present fails.
+	wo := "PERIOD FOR app_time(s,e), UNIQUE uk (id, app_time WITHOUT OVERLAPS)"
+	for _, tc := range []struct {
+		name, create, alter string
+		wantErr             int // 0 = success
+	}{
+		{"drop_key_then_period", "CREATE TABLE t (id INT, s DATE, e DATE, " + wo + ")", "ALTER TABLE t DROP KEY uk, DROP PERIOD FOR app_time", 0},
+		{"drop_period_then_key", "CREATE TABLE t (id INT, s DATE, e DATE, " + wo + ")", "ALTER TABLE t DROP PERIOD FOR app_time, DROP KEY uk", 0},
+		{"reversed_add", "CREATE TABLE t (id INT, s DATE, e DATE)", "ALTER TABLE t ADD UNIQUE uk (id, app_time WITHOUT OVERLAPS), ADD PERIOD FOR app_time(s,e)", 0},
+		{"drop_period_key_remains", "CREATE TABLE t (id INT, s DATE, e DATE, " + wo + ")", "ALTER TABLE t DROP PERIOD FOR app_time", 4156},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			c.Exec("CREATE DATABASE test", nil)
+			c.SetCurrentDatabase("test")
+			c.Exec(tc.create, nil)
+			r, _ := c.Exec(tc.alter, &ExecOptions{ContinueOnError: true})
+			if tc.wantErr == 0 {
+				if r[0].Error != nil {
+					t.Fatalf("want success, got %v", r[0].Error)
+				}
+				return
+			}
+			if catErr, ok := r[0].Error.(*Error); !ok || catErr.Code != tc.wantErr {
+				t.Fatalf("want %d, got %v", tc.wantErr, r[0].Error)
 			}
 		})
 	}

--- a/mariadb/catalog/application_time_test.go
+++ b/mariadb/catalog/application_time_test.go
@@ -48,6 +48,40 @@ func TestApplicationTimePeriodValidation(t *testing.T) {
 	}
 }
 
+// TestApplicationTimePeriodNotNullDefault: coercing an application-time period
+// column to NOT NULL drops an explicit DEFAULT NULL (MariaDB strips it) but
+// keeps a non-null default. Grounded vs mariadb:11.8.8.
+func TestApplicationTimePeriodNotNullDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		stmts        []string
+		want, absent string
+	}{
+		{"create_strips_null_default", []string{"CREATE TABLE t (s DATE DEFAULT NULL, e DATE DEFAULT NULL, PERIOD FOR app_time(s,e))"}, "`s` date NOT NULL", "DEFAULT NULL"},
+		{"alter_add_strips_null_default", []string{"CREATE TABLE t (s DATE DEFAULT NULL, e DATE DEFAULT NULL)", "ALTER TABLE t ADD PERIOD FOR app_time(s,e)"}, "`s` date NOT NULL", "DEFAULT NULL"},
+		{"modify_strips_null_default", []string{"CREATE TABLE t (s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t MODIFY s DATE DEFAULT NULL"}, "`s` date NOT NULL", "DEFAULT NULL"},
+		{"keeps_non_null_default", []string{"CREATE TABLE t (s DATE DEFAULT '2020-01-01', e DATE DEFAULT '2020-01-01', PERIOD FOR app_time(s,e))"}, "`s` date NOT NULL DEFAULT '2020-01-01'", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			c.Exec("CREATE DATABASE test", nil)
+			c.SetCurrentDatabase("test")
+			for _, s := range tc.stmts {
+				if r, _ := c.Exec(s, &ExecOptions{ContinueOnError: true}); r[0].Error != nil {
+					t.Fatalf("%q: %v", s, r[0].Error)
+				}
+			}
+			show := c.ShowCreateTable("test", "t")
+			if !strings.Contains(show, tc.want) {
+				t.Fatalf("want %q in:\n%s", tc.want, show)
+			}
+			if tc.absent != "" && strings.Contains(show, tc.absent) {
+				t.Fatalf("%q should be absent in:\n%s", tc.absent, show)
+			}
+		})
+	}
+}
+
 // TestAlterApplicationTimeFinalState: the application-time period and its
 // WITHOUT OVERLAPS keys are validated on the FINAL ALTER state, not per command.
 // Column mutations that invalidate a period are caught; valid ones keep the

--- a/mariadb/catalog/application_time_test.go
+++ b/mariadb/catalog/application_time_test.go
@@ -46,6 +46,86 @@ func TestApplicationTimePeriodValidation(t *testing.T) {
 	}
 }
 
+// TestAlterAddApplicationTimePeriod: ALTER TABLE ... ADD PERIOD FOR <name>(s,e)
+// adds an application-time period — same validation codes as CREATE, and the
+// period columns become NOT NULL. Grounded vs mariadb:11.8.8.
+func TestAlterAddApplicationTimePeriod(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		c := New()
+		c.Exec("CREATE DATABASE test", nil)
+		c.SetCurrentDatabase("test")
+		c.Exec("CREATE TABLE t (id INT, s DATE, e DATE)", nil)
+		if r, _ := c.Exec("ALTER TABLE t ADD PERIOD FOR app_time(s, e)", &ExecOptions{ContinueOnError: true}); r[0].Error != nil {
+			t.Fatalf("add period: %v", r[0].Error)
+		}
+		show := c.ShowCreateTable("test", "t")
+		if !strings.Contains(show, "PERIOD FOR `app_time` (`s`, `e`)") {
+			t.Fatalf("missing period clause:\n%s", show)
+		}
+		if !strings.Contains(show, "`s` date NOT NULL") || !strings.Contains(show, "`e` date NOT NULL") {
+			t.Fatalf("period columns should be NOT NULL:\n%s", show)
+		}
+	})
+	for _, tc := range []struct {
+		name, create, add string
+		code              int
+	}{
+		{"already_has_period", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t ADD PERIOD FOR p2(s, e)", 4154},
+		{"nonexistent_col", "CREATE TABLE t (id INT)", "ALTER TABLE t ADD PERIOD FOR app_time(s, e)", 1054},
+		{"non_temporal", "CREATE TABLE t (id INT, s INT, e INT)", "ALTER TABLE t ADD PERIOD FOR app_time(s, e)", 1063},
+		{"same_col", "CREATE TABLE t (id INT, s DATE)", "ALTER TABLE t ADD PERIOD FOR app_time(s, s)", 1110},
+		{"name_is_column", "CREATE TABLE t (id INT, s DATE, e DATE)", "ALTER TABLE t ADD PERIOD FOR id(s, e)", 1060},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			c.Exec("CREATE DATABASE test", nil)
+			c.SetCurrentDatabase("test")
+			c.Exec(tc.create, nil)
+			r, _ := c.Exec(tc.add, &ExecOptions{ContinueOnError: true})
+			if catErr, ok := r[0].Error.(*Error); !ok || catErr.Code != tc.code {
+				t.Fatalf("want %d, got %v", tc.code, r[0].Error)
+			}
+		})
+	}
+}
+
+// TestAlterDropApplicationTimePeriod: ALTER TABLE ... DROP PERIOD FOR <name>
+// removes the application-time period (1091 if absent; 4156 if a WITHOUT
+// OVERLAPS key still references it). Grounded vs mariadb:11.8.8.
+func TestAlterDropApplicationTimePeriod(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		c := New()
+		c.Exec("CREATE DATABASE test", nil)
+		c.SetCurrentDatabase("test")
+		c.Exec("CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", nil)
+		if r, _ := c.Exec("ALTER TABLE t DROP PERIOD FOR app_time", &ExecOptions{ContinueOnError: true}); r[0].Error != nil {
+			t.Fatalf("drop period: %v", r[0].Error)
+		}
+		if show := c.ShowCreateTable("test", "t"); strings.Contains(show, "PERIOD FOR") {
+			t.Fatalf("period should be gone:\n%s", show)
+		}
+	})
+	for _, tc := range []struct {
+		name, create, drop string
+		code               int
+	}{
+		{"nonexistent", "CREATE TABLE t (id INT)", "ALTER TABLE t DROP PERIOD FOR app_time", 1091},
+		{"wrong_name", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e))", "ALTER TABLE t DROP PERIOD FOR other", 1091},
+		{"used_by_without_overlaps", "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s,e), UNIQUE(id, app_time WITHOUT OVERLAPS))", "ALTER TABLE t DROP PERIOD FOR app_time", 4156},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New()
+			c.Exec("CREATE DATABASE test", nil)
+			c.SetCurrentDatabase("test")
+			c.Exec(tc.create, nil)
+			r, _ := c.Exec(tc.drop, &ExecOptions{ContinueOnError: true})
+			if catErr, ok := r[0].Error.(*Error); !ok || catErr.Code != tc.code {
+				t.Fatalf("want %d, got %v", tc.code, r[0].Error)
+			}
+		})
+	}
+}
+
 // TestWithoutOverlapsCatalog: WITHOUT OVERLAPS renders on the period key part.
 func TestWithoutOverlapsCatalog(t *testing.T) {
 	for _, tc := range []struct{ name, ddl, want string }{

--- a/mariadb/catalog/errors.go
+++ b/mariadb/catalog/errors.go
@@ -72,6 +72,7 @@ const (
 	ErrKeyPartZeroLength                 = 1391
 	ErrKeyColumnDoesNotExist             = 1072
 	ErrKeyIncludesPeriodColumn           = 4170
+	ErrPeriodFieldsDifferentTypes        = 4153
 )
 
 var sqlStateMap = map[int]string{
@@ -122,6 +123,7 @@ var sqlStateMap = map[int]string{
 	ErrKeyPartZeroLength:                 "HY000",
 	ErrKeyColumnDoesNotExist:             "42000",
 	ErrKeyIncludesPeriodColumn:           "HY000",
+	ErrPeriodFieldsDifferentTypes:        "HY000",
 	ErrWrongArguments:                    "HY000",
 	ErrWrongNameForIndex:                 "42000",
 	ErrInvalidOnUpdate:                   "HY000",
@@ -380,6 +382,13 @@ func errColumnSpecifiedTwice(col string) error {
 func errCantDropPeriod(name string) error {
 	return &Error{Code: ErrCantDropKey, SQLState: sqlState(ErrCantDropKey),
 		Message: fmt.Sprintf("Can't DROP PERIOD `%s`; check that it exists", name)}
+}
+
+// errPeriodFieldsDifferentTypes reports that a period's start and end columns
+// have different types — they must match exactly, including precision. 4153.
+func errPeriodFieldsDifferentTypes(name string) error {
+	return &Error{Code: ErrPeriodFieldsDifferentTypes, SQLState: sqlState(ErrPeriodFieldsDifferentTypes),
+		Message: fmt.Sprintf("Fields of PERIOD FOR `%s` have different types", name)}
 }
 
 func errPeriodNotFound(name string) error {

--- a/mariadb/catalog/errors.go
+++ b/mariadb/catalog/errors.go
@@ -376,6 +376,12 @@ func errColumnSpecifiedTwice(col string) error {
 		Message: fmt.Sprintf("Column '%s' specified twice", col)}
 }
 
+// errCantDropPeriod reports DROP PERIOD for a period that does not exist. 1091.
+func errCantDropPeriod(name string) error {
+	return &Error{Code: ErrCantDropKey, SQLState: sqlState(ErrCantDropKey),
+		Message: fmt.Sprintf("Can't DROP PERIOD `%s`; check that it exists", name)}
+}
+
 func errPeriodNotFound(name string) error {
 	return &Error{Code: ErrPeriodNotFound, SQLState: sqlState(ErrPeriodNotFound),
 		Message: fmt.Sprintf("Period `%s` is not found in table", name)}

--- a/mariadb/catalog/tablecmds.go
+++ b/mariadb/catalog/tablecmds.go
@@ -2038,16 +2038,24 @@ func validateApplicationTimePeriod(tbl *Table, stmt *nodes.CreateTableStmt) erro
 	if stmt.AppPeriodDuplicate {
 		return errMultipleAppPeriods() // 4154
 	}
-	if strings.EqualFold(tbl.AppPeriodStartCol, tbl.AppPeriodEndCol) {
-		return errColumnSpecifiedTwice(tbl.AppPeriodStartCol) // 1110
+	return validateAppPeriodColumns(tbl, tbl.AppPeriodName, tbl.AppPeriodStartCol, tbl.AppPeriodEndCol)
+}
+
+// validateAppPeriodColumns enforces the column-level rules for an application-
+// time period: distinct start/end (1110), the period name not colliding with a
+// column (1060), and both columns existing (1054) with a temporal type (1063).
+// Shared by CREATE TABLE and ALTER TABLE ... ADD PERIOD. Grounded vs 11.8.8.
+func validateAppPeriodColumns(tbl *Table, name, startCol, endCol string) error {
+	if strings.EqualFold(startCol, endCol) {
+		return errColumnSpecifiedTwice(startCol) // 1110
 	}
-	if tbl.GetColumn(tbl.AppPeriodName) != nil {
-		return errDupColumn(tbl.AppPeriodName) // 1060: period name collides with a column
+	if tbl.GetColumn(name) != nil {
+		return errDupColumn(name) // 1060: period name collides with a column
 	}
-	for _, colName := range []string{tbl.AppPeriodStartCol, tbl.AppPeriodEndCol} {
+	for _, colName := range []string{startCol, endCol} {
 		col := tbl.GetColumn(colName)
 		if col == nil {
-			return errNoSuchColumn(colName, tbl.AppPeriodName) // 1054
+			return errNoSuchColumn(colName, name) // 1054
 		}
 		if !isTemporalPeriodType(col.DataType) {
 			return errIncorrectColumnSpecifier(colName) // 1063

--- a/mariadb/catalog/tablecmds.go
+++ b/mariadb/catalog/tablecmds.go
@@ -748,6 +748,26 @@ func validateWithoutOverlaps(tbl *Table) error {
 	return nil
 }
 
+// validateApplicationTimeFinalState validates the application-time period and its
+// WITHOUT OVERLAPS keys against the FINAL table state after an ALTER, so a
+// multi-command statement (ADD PERIOD then MODIFY a column, DROP KEY then DROP
+// PERIOD, or a reversed ADD UNIQUE … WITHOUT OVERLAPS / ADD PERIOD) is judged on
+// its end result like MariaDB. When an application-time period remains, its
+// columns are re-normalized to NOT NULL. Grounded vs 11.8.8.
+func validateApplicationTimeFinalState(tbl *Table) error {
+	if tbl.AppPeriodName != "" {
+		if err := validateAppPeriodColumns(tbl, tbl.AppPeriodName, tbl.AppPeriodStartCol, tbl.AppPeriodEndCol); err != nil {
+			return err
+		}
+		for _, colName := range []string{tbl.AppPeriodStartCol, tbl.AppPeriodEndCol} {
+			if col := tbl.GetColumn(colName); col != nil {
+				col.Nullable = false
+			}
+		}
+	}
+	return validateWithoutOverlaps(tbl)
+}
+
 // validateColsWithoutOverlaps validates a WITHOUT OVERLAPS key. Used by CREATE
 // TABLE, CREATE INDEX, and ALTER ADD — every path that builds a key. For a key
 // that carries a WO part: the flagged part must name the application-time period
@@ -2060,6 +2080,11 @@ func validateAppPeriodColumns(tbl *Table, name, startCol, endCol string) error {
 		if !isTemporalPeriodType(col.DataType) {
 			return errIncorrectColumnSpecifier(colName) // 1063
 		}
+	}
+	// Both columns must have the same type, including precision (e.g. date vs
+	// datetime, or datetime(3) vs datetime(6), is rejected).
+	if s, e := tbl.GetColumn(startCol), tbl.GetColumn(endCol); !strings.EqualFold(s.ColumnType, e.ColumnType) {
+		return errPeriodFieldsDifferentTypes(name) // 4153
 	}
 	return nil
 }

--- a/mariadb/catalog/tablecmds.go
+++ b/mariadb/catalog/tablecmds.go
@@ -418,7 +418,7 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 		for _, col := range tbl.Columns {
 			if strings.EqualFold(col.Name, tbl.AppPeriodStartCol) ||
 				strings.EqualFold(col.Name, tbl.AppPeriodEndCol) {
-				col.Nullable = false
+				normalizeAppPeriodColumn(col)
 			}
 		}
 	}
@@ -748,6 +748,16 @@ func validateWithoutOverlaps(tbl *Table) error {
 	return nil
 }
 
+// normalizeAppPeriodColumn coerces an application-time period column to NOT NULL
+// and drops an explicit DEFAULT NULL — MariaDB strips a NULL default when the
+// column becomes NOT NULL, while keeping a non-null default.
+func normalizeAppPeriodColumn(col *Column) {
+	col.Nullable = false
+	if col.Default != nil && strings.EqualFold(*col.Default, "NULL") {
+		col.Default = nil
+	}
+}
+
 // validateApplicationTimeFinalState validates the application-time period and its
 // WITHOUT OVERLAPS keys against the FINAL table state after an ALTER, so a
 // multi-command statement (ADD PERIOD then MODIFY a column, DROP KEY then DROP
@@ -761,7 +771,7 @@ func validateApplicationTimeFinalState(tbl *Table) error {
 		}
 		for _, colName := range []string{tbl.AppPeriodStartCol, tbl.AppPeriodEndCol} {
 			if col := tbl.GetColumn(colName); col != nil {
-				col.Nullable = false
+				normalizeAppPeriodColumn(col)
 			}
 		}
 	}

--- a/mariadb/parser/alter_table.go
+++ b/mariadb/parser/alter_table.go
@@ -448,17 +448,15 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 		return cmd, nil
 	}
 
-	// ADD PERIOD FOR SYSTEM_TIME (start_col, end_col).
-	// (Application-time ALTER ... ADD PERIOD is not yet supported.)
+	// ADD PERIOD FOR <name> (start_col, end_col): SYSTEM_TIME for the
+	// system-versioning period, any other name for the application-time period.
 	if p.atPeriodForSystemTime() {
 		name, startCol, endCol, err := p.parsePeriodForCols()
 		if err != nil {
 			return nil, err
 		}
-		if !strings.EqualFold(name, "SYSTEM_TIME") {
-			return nil, p.syntaxErrorAtCur()
-		}
 		cmd.Type = nodes.ATAddPeriod
+		cmd.PeriodName = name
 		cmd.PeriodStartCol = startCol
 		cmd.PeriodEndCol = endCol
 		cmd.Loc.End = p.pos()
@@ -525,15 +523,18 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 		return nil, &ParseError{Message: "collecting"}
 	}
 
-	// DROP PERIOD FOR SYSTEM_TIME (PERIOD is non-reserved, intercepted here)
+	// DROP PERIOD FOR <name> (PERIOD is non-reserved, intercepted here):
+	// SYSTEM_TIME for the system-versioning period, else application-time. The
+	// period name follows the identifier rule (non-reserved keywords allowed).
 	if p.atPeriodForSystemTime() {
 		p.advance() // PERIOD
 		p.advance() // FOR
-		if p.cur.Type != tokIDENT || !strings.EqualFold(p.cur.Str, "SYSTEM_TIME") {
-			return nil, p.syntaxErrorAtCur()
+		name, _, err := p.parseIdent()
+		if err != nil {
+			return nil, err
 		}
-		p.advance() // SYSTEM_TIME
 		cmd.Type = nodes.ATDropPeriod
+		cmd.PeriodName = name
 		cmd.Loc.End = p.pos()
 		return cmd, nil
 	}

--- a/mariadb/parser/system_versioning_alter_test.go
+++ b/mariadb/parser/system_versioning_alter_test.go
@@ -51,7 +51,10 @@ func TestSystemVersioningAlterAST(t *testing.T) {
 		if cmd.PeriodStartCol != "rs" || cmd.PeriodEndCol != "re" {
 			t.Errorf("period cols = (%q, %q), want (rs, re)", cmd.PeriodStartCol, cmd.PeriodEndCol)
 		}
-		if got := ast.NodeToString(stmt); !strings.Contains(got, ":period_for_system_time (rs, re)") {
+		if cmd.PeriodName != "SYSTEM_TIME" {
+			t.Errorf("PeriodName = %q, want SYSTEM_TIME", cmd.PeriodName)
+		}
+		if got := ast.NodeToString(stmt); !strings.Contains(got, ":period_for SYSTEM_TIME (rs, re)") {
 			t.Errorf("NodeToString missing period clause:\n%s", got)
 		}
 	})


### PR DESCRIPTION
## What & why

MariaDB allows adding/removing an application-time period on an existing table — `ALTER TABLE … ADD PERIOD FOR <name> (start, end)` and `ALTER TABLE … DROP PERIOD FOR <name>` — not only at CREATE. omni rejected any non-SYSTEM_TIME period name in the ALTER PERIOD paths (parse error). Follows #325 (WITHOUT OVERLAPS keys) and #324 (application-time CREATE).

## Scope

- **Parser**: the ADD/DROP PERIOD paths capture the period name (new `AlterTableCmd.PeriodName`; `parseIdent`, so non-reserved keyword names work) instead of rejecting non-SYSTEM_TIME. The catalog routes by name — SYSTEM_TIME → the existing system-versioning path, any other name → application-time.
- **Catalog**: `alterAddAppPeriod` / `alterDropAppPeriod`. `validateAppPeriodColumns` is extracted from the CREATE validator and shared by both paths.
- **Validation** (grounded vs `mariadb:11.8.8`):
  - ADD — same codes as CREATE: **4154** (a second application-time period), **1054** (column absent), **1063** (non-temporal), **1110** (start = end), **1060** (period name collides with a column). Period columns become NOT NULL.
  - DROP — **1091** if no such period; **4156** if a `WITHOUT OVERLAPS` key still references it. Period columns keep their NOT NULL.

## Verification

- New catalog tests: `TestAlterAddApplicationTimePeriod` (basic render/NOT NULL + 5 validation codes), `TestAlterDropApplicationTimePeriod` (basic + 1091 ×2 + 4156).
- Reject-space sweep vs container: bitemporal add, multi-command `ADD PERIOD + ADD WITHOUT OVERLAPS key` (natural order), and drop-then-readd all agree.
- Full `mariadb/...` suite green (SYSTEM_TIME ADD/DROP PERIOD unchanged — no regression); gofmt/vet clean.

## Follow-ups

- `FOR PORTION OF` in UPDATE/DELETE (the last application-time piece).
- **Not folded in (deferred):** SYSTEM_TIME `ADD PERIOD` no-op (the #319 P2 gap — doesn't fall out of this work; still 4125); and reversed multi-command order `ADD UNIQUE(… WITHOUT OVERLAPS), ADD PERIOD` (MariaDB final-state-accepts, omni over-rejects 4156 because WO validation is immediate) — both would touch error timing / a post-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
