### PR TITLE
fix(mysql/parser): Loc.End excludes trailing comments

### DIFF
--- a/mysql/parser/alter_misc.go
+++ b/mysql/parser/alter_misc.go
@@ -133,7 +133,7 @@ func (p *Parser) parseAlterViewStmt() (*nodes.AlterViewStmt, error) {
 		stmt.CheckOption = checkOption
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -250,7 +250,7 @@ func (p *Parser) parseAlterEventStmt() (*nodes.AlterEventStmt, error) {
 		stmt.BodyText = p.inputText(bodyStart, bodyEnd)
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -300,7 +300,7 @@ func (p *Parser) parseAlterRoutineStmt(isProcedure bool) (*nodes.AlterRoutineStm
 		stmt.Characteristics = append(stmt.Characteristics, ch)
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -342,7 +342,7 @@ func (p *Parser) parseDropRoutineStmt(isProcedure bool) (*nodes.DropRoutineStmt,
 	}
 	stmt.Name = ref
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -379,7 +379,7 @@ func (p *Parser) parseDropTriggerStmt() (*nodes.DropTriggerStmt, error) {
 	}
 	stmt.Name = ref
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -416,6 +416,6 @@ func (p *Parser) parseDropEventStmt() (*nodes.DropEventStmt, error) {
 	}
 	stmt.Name = name
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }

--- a/mysql/parser/alter_table.go
+++ b/mysql/parser/alter_table.go
@@ -84,7 +84,7 @@ func (p *Parser) parseAlterTableStmt() (*nodes.AlterTableStmt, error) {
 		p.advance() // consume ','
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -141,7 +141,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 			return nil, err
 		}
 		cmd.Name = val
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwLOCK:
@@ -153,7 +153,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 			return nil, err
 		}
 		cmd.Name = val
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwCOALESCE:
@@ -240,13 +240,13 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 				return nil, err
 			}
 			p.match(kwTABLESPACE)
-			cmd.Loc.End = p.pos()
+			cmd.Loc.End = p.prev.End
 			return cmd, nil
 		}
 		// DISCARD TABLESPACE
 		p.match(kwTABLESPACE)
 		cmd.Type = nodes.ATDiscardTablespace
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwIMPORT:
@@ -258,19 +258,19 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 				return nil, err
 			}
 			p.match(kwTABLESPACE)
-			cmd.Loc.End = p.pos()
+			cmd.Loc.End = p.prev.End
 			return cmd, nil
 		}
 		// IMPORT TABLESPACE
 		p.match(kwTABLESPACE)
 		cmd.Type = nodes.ATImportTablespace
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwFORCE:
 		p.advance()
 		cmd.Type = nodes.ATForce
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwORDER:
@@ -283,7 +283,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 			return nil, err
 		}
 		cmd.OrderByItems = items
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwENABLE:
@@ -291,7 +291,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 		p.advance()
 		p.match(kwKEYS)
 		cmd.Type = nodes.ATEnableKeys
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwDISABLE:
@@ -299,7 +299,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 		p.advance()
 		p.match(kwKEYS)
 		cmd.Type = nodes.ATDisableKeys
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwWITH:
@@ -307,7 +307,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 		p.advance()
 		p.match(kwVALIDATION)
 		cmd.Type = nodes.ATWithValidation
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwWITHOUT:
@@ -315,7 +315,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 		p.advance()
 		p.match(kwVALIDATION)
 		cmd.Type = nodes.ATWithoutValidation
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwPARTITION:
@@ -327,7 +327,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 			}
 			cmd.Type = nodes.ATPartitionBy
 			cmd.PartitionBy = part
-			cmd.Loc.End = p.pos()
+			cmd.Loc.End = p.prev.End
 			return cmd, nil
 		}
 		return nil, &ParseError{
@@ -340,19 +340,19 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 		p.advance()
 		p.match(kwPARTITIONING)
 		cmd.Type = nodes.ATRemovePartitioning
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwSECONDARY_LOAD:
 		p.advance()
 		cmd.Type = nodes.ATSecondaryLoad
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwSECONDARY_UNLOAD:
 		p.advance()
 		cmd.Type = nodes.ATSecondaryUnload
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	default:
@@ -364,7 +364,7 @@ func (p *Parser) parseAlterTableCmd() (*nodes.AlterTableCmd, error) {
 		if ok {
 			cmd.Type = nodes.ATTableOption
 			cmd.Option = opt
-			cmd.Loc.End = p.pos()
+			cmd.Loc.End = p.prev.End
 			return cmd, nil
 		}
 		return nil, &ParseError{
@@ -398,7 +398,7 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 			}
 			cmd.Number = int(p.cur.Ival)
 			p.advance()
-			cmd.Loc.End = p.pos()
+			cmd.Loc.End = p.prev.End
 			return cmd, nil
 		}
 		if _, err := p.expect('('); err != nil {
@@ -421,7 +421,7 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 
@@ -433,7 +433,7 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 			return nil, err
 		}
 		cmd.Constraint = constr
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 
@@ -465,7 +465,7 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 
@@ -480,7 +480,7 @@ func (p *Parser) parseAlterAdd(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd, 
 		return nil, err
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -507,7 +507,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 			return nil, err
 		}
 		cmd.PartitionNames = names
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwPRIMARY:
@@ -516,7 +516,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 		p.match(kwKEY)
 		cmd.Type = nodes.ATDropConstraint
 		cmd.Name = "PRIMARY"
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwINDEX, kwKEY:
@@ -534,7 +534,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 			return nil, err
 		}
 		cmd.Name = name
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwFOREIGN:
@@ -553,7 +553,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 			return nil, err
 		}
 		cmd.Name = name
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwCHECK:
@@ -565,7 +565,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 			return nil, err
 		}
 		cmd.Name = name
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	case kwCONSTRAINT:
@@ -583,7 +583,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 			return nil, err
 		}
 		cmd.Name = name
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 
 	default:
@@ -608,7 +608,7 @@ func (p *Parser) parseAlterDrop(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCmd,
 			return nil, err
 		}
 		cmd.Name = name
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 }
@@ -637,7 +637,7 @@ func (p *Parser) parseAlterModify(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 		return nil, err
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -673,7 +673,7 @@ func (p *Parser) parseAlterChange(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 		return nil, err
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -706,7 +706,7 @@ func (p *Parser) parseAlterColumn(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 		} else if _, ok := p.match(kwINVISIBLE); ok {
 			cmd.Type = nodes.ATAlterIndexInvisible
 		}
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 
@@ -729,7 +729,7 @@ func (p *Parser) parseAlterColumn(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 			p.advance()
 			cmd.NewName = "ENFORCED"
 		}
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 
@@ -752,7 +752,7 @@ func (p *Parser) parseAlterColumn(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 			p.advance()
 			cmd.NewName = "ENFORCED"
 		}
-		cmd.Loc.End = p.pos()
+		cmd.Loc.End = p.prev.End
 		return cmd, nil
 	}
 
@@ -810,7 +810,7 @@ func (p *Parser) parseAlterColumn(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 		}
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -881,7 +881,7 @@ func (p *Parser) parseAlterRename(cmd *nodes.AlterTableCmd) (*nodes.AlterTableCm
 		cmd.NewTable = newTable
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -915,7 +915,7 @@ func (p *Parser) parseAlterConvert(cmd *nodes.AlterTableCmd) (*nodes.AlterTableC
 		cmd.NewName = collation
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -949,7 +949,7 @@ func (p *Parser) parseAlterPartitionNamesOrAll(cmd *nodes.AlterTableCmd, cmdType
 		}
 		cmd.PartitionNames = names
 	}
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -968,7 +968,7 @@ func (p *Parser) parseAlterCoalescePartition(cmd *nodes.AlterTableCmd) (*nodes.A
 		cmd.Number = int(p.cur.Ival)
 		p.advance()
 	}
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -1015,7 +1015,7 @@ func (p *Parser) parseAlterReorganizePartition(cmd *nodes.AlterTableCmd) (*nodes
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 
@@ -1064,7 +1064,7 @@ func (p *Parser) parseAlterExchangePartition(cmd *nodes.AlterTableCmd) (*nodes.A
 		cmd.WithValidation = &v
 	}
 
-	cmd.Loc.End = p.pos()
+	cmd.Loc.End = p.prev.End
 	return cmd, nil
 }
 

--- a/mysql/parser/compound.go
+++ b/mysql/parser/compound.go
@@ -72,7 +72,7 @@ func (p *Parser) parseBeginEndBlock(labelName string, labelStart int) (*nodes.Be
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -334,7 +334,7 @@ func (p *Parser) parseDeclareVarStmt(start int, firstName string) (*nodes.Declar
 		stmt.Default = val
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -363,7 +363,7 @@ func (p *Parser) parseDeclareConditionStmt(start int, name string) (*nodes.Decla
 	}
 	stmt.ConditionValue = condVal
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -415,7 +415,7 @@ func (p *Parser) parseDeclareHandlerStmt(start int) (*nodes.DeclareHandlerStmt, 
 	}
 	stmt.Stmt = body
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -630,7 +630,7 @@ func (p *Parser) parseIfStmt() (*nodes.IfStmt, error) {
 		return nil, err
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -715,7 +715,7 @@ func (p *Parser) parseCaseStmt() (*nodes.CaseStmtNode, error) {
 		return nil, err
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -773,7 +773,7 @@ func (p *Parser) parseWhileStmt(labelName string, labelStart int) (*nodes.WhileS
 
 	stmt.EndLabel = endLabel
 	stmt.Stmts = stmts
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -833,7 +833,7 @@ func (p *Parser) parseRepeatStmt(labelName string, labelStart int) (*nodes.Repea
 	stmt.Stmts = stmts
 	stmt.Cond = cond
 	stmt.EndLabel = endLabel
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -877,7 +877,7 @@ func (p *Parser) parseLoopStmt(labelName string, labelStart int) (*nodes.LoopStm
 
 	stmt.EndLabel = endLabel
 	stmt.Stmts = stmts
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/create_database.go
+++ b/mysql/parser/create_database.go
@@ -59,7 +59,7 @@ func (p *Parser) parseCreateDatabaseStmt() (*nodes.CreateDatabaseStmt, error) {
 		stmt.Options = append(stmt.Options, opt)
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -96,7 +96,7 @@ func (p *Parser) parseAlterDatabaseStmt() (*nodes.AlterDatabaseStmt, error) {
 		stmt.Options = append(stmt.Options, opt)
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -134,7 +134,7 @@ func (p *Parser) parseDropDatabaseStmt() (*nodes.DropDatabaseStmt, error) {
 	}
 	stmt.Name = name
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/create_function.go
+++ b/mysql/parser/create_function.go
@@ -66,7 +66,7 @@ func (p *Parser) finishLoadableFunction(stmt *nodes.CreateFunctionStmt) (*nodes.
 	stmt.Soname = p.cur.Str
 	p.advance()
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -204,7 +204,7 @@ func (p *Parser) parseCreateFunctionStmt(isProcedure bool) (*nodes.CreateFunctio
 	stmt.Body = body
 	stmt.BodyText = p.inputText(bodyStart, bodyEnd)
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -243,7 +243,7 @@ func (p *Parser) parseFuncParam(isProcedure bool) (*nodes.FuncParam, error) {
 	}
 	param.TypeName = dt
 
-	param.Loc.End = p.pos()
+	param.Loc.End = p.prev.End
 	return param, nil
 }
 

--- a/mysql/parser/create_index.go
+++ b/mysql/parser/create_index.go
@@ -123,7 +123,7 @@ func (p *Parser) parseCreateIndexStmt(unique bool, fulltext bool, spatial bool) 
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -191,7 +191,7 @@ func (p *Parser) parseIndexKeyPart() (*nodes.IndexColumn, error) {
 		col.Desc = true
 	}
 
-	col.Loc.End = p.pos()
+	col.Loc.End = p.prev.End
 	return col, nil
 }
 

--- a/mysql/parser/create_table.go
+++ b/mysql/parser/create_table.go
@@ -65,7 +65,7 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 			return nil, err
 		}
 		stmt.Like = likeRef
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -77,7 +77,7 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 			return nil, err
 		}
 		stmt.Select = sel
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -93,7 +93,7 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 				return nil, err
 			}
 			stmt.Select = sel
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 		// Check for CREATE TABLE ... (LIKE old_tbl_name) — parenthesized LIKE
@@ -108,7 +108,7 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 			if _, err := p.expect(')'); err != nil {
 				return nil, err
 			}
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 
@@ -129,7 +129,7 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 			return nil, err
 		}
 		stmt.Select = sel
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -181,7 +181,7 @@ func (p *Parser) parseCreateTableStmt(temporary bool) (*nodes.CreateTableStmt, e
 		stmt.Select = sel
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -283,7 +283,7 @@ func (p *Parser) parseColumnDef() (*nodes.ColumnDef, error) {
 		}
 	}
 
-	col.Loc.End = p.pos()
+	col.Loc.End = p.prev.End
 	return col, nil
 }
 
@@ -469,7 +469,7 @@ func (p *Parser) parseColumnOption(col *nodes.ColumnDef) (bool, error) {
 		} else if p.cur.Type == kwENFORCED {
 			p.advance()
 		}
-		cc.Loc.End = p.pos()
+		cc.Loc.End = p.prev.End
 		col.Constraints = append(col.Constraints, cc)
 		return true, nil
 
@@ -691,7 +691,7 @@ func (p *Parser) parseReferenceDefinition(start int) (*nodes.ColumnConstraint, e
 		}
 	}
 
-	constr.Loc.End = p.pos()
+	constr.Loc.End = p.prev.End
 	return constr, nil
 }
 
@@ -774,7 +774,7 @@ func (p *Parser) parseGeneratedColumn() (*nodes.GeneratedColumn, error) {
 		gen.Stored = true
 	}
 
-	gen.Loc.End = p.pos()
+	gen.Loc.End = p.prev.End
 	return gen, nil
 }
 
@@ -818,7 +818,7 @@ func (p *Parser) parseGeneratedColumnShorthand() (*nodes.GeneratedColumn, error)
 		gen.Stored = true
 	}
 
-	gen.Loc.End = p.pos()
+	gen.Loc.End = p.prev.End
 	return gen, nil
 }
 
@@ -1013,7 +1013,7 @@ func (p *Parser) parseTableConstraint() (*nodes.Constraint, error) {
 		}
 	}
 
-	constr.Loc.End = p.pos()
+	constr.Loc.End = p.prev.End
 	return constr, nil
 }
 
@@ -1208,7 +1208,7 @@ func (p *Parser) parseTableOption() (*nodes.TableOption, bool, error) {
 			}
 			opt.Storage = storageVal
 		}
-		opt.Loc.End = p.pos()
+		opt.Loc.End = p.prev.End
 		return opt, true, nil
 
 	case kwENCRYPTION:
@@ -1579,7 +1579,7 @@ func (p *Parser) parsePartitionClause() (*nodes.PartitionClause, error) {
 		}
 	}
 
-	part.Loc.End = p.pos()
+	part.Loc.End = p.prev.End
 	return part, nil
 }
 
@@ -1731,7 +1731,7 @@ func (p *Parser) parsePartitionDef() (*nodes.PartitionDef, error) {
 		}
 	}
 
-	pd.Loc.End = p.pos()
+	pd.Loc.End = p.prev.End
 	return pd, nil
 }
 
@@ -1761,6 +1761,6 @@ func (p *Parser) parseSubPartitionDef() (*nodes.SubPartitionDef, error) {
 		}
 		spd.Options = append(spd.Options, opt)
 	}
-	spd.Loc.End = p.pos()
+	spd.Loc.End = p.prev.End
 	return spd, nil
 }

--- a/mysql/parser/create_view.go
+++ b/mysql/parser/create_view.go
@@ -129,6 +129,6 @@ func (p *Parser) parseCreateViewStmt(orReplace bool) (*nodes.CreateViewStmt, err
 		stmt.CheckOption = checkOption
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }

--- a/mysql/parser/drop.go
+++ b/mysql/parser/drop.go
@@ -55,7 +55,7 @@ func (p *Parser) parseDropTableStmt(temporary bool) (*nodes.DropTableStmt, error
 		stmt.Cascade = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -116,7 +116,7 @@ func (p *Parser) parseDropIndexStmt() (*nodes.DropIndexStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -167,7 +167,7 @@ func (p *Parser) parseDropViewStmt() (*nodes.DropViewStmt, error) {
 		stmt.Cascade = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -251,6 +251,6 @@ func (p *Parser) parseRenameTableStmt() (*nodes.RenameTableStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -150,7 +150,7 @@ func (p *Parser) parseExprPrec(minPrec int) (nodes.ExprNode, error) {
 				return nil, err
 			}
 			sub.Loc.Start = subStart
-			sub.Loc.End = p.pos()
+			sub.Loc.End = p.prev.End
 			sub.Quantifier = quantifier
 			left = &nodes.BinaryExpr{
 				Loc:        nodes.Loc{Start: opStart, End: p.pos()},
@@ -413,7 +413,7 @@ func (p *Parser) parsePrimaryExpr() (nodes.ExprNode, error) {
 				return nil, err
 			}
 		}
-		fc.Loc.End = p.pos()
+		fc.Loc.End = p.prev.End
 		return fc, nil
 
 	case '*':
@@ -724,7 +724,7 @@ overCheck:
 		fc.Over = wd
 	}
 
-	fc.Loc.End = p.pos()
+	fc.Loc.End = p.prev.End
 	return fc, nil
 }
 
@@ -849,7 +849,7 @@ func (p *Parser) parseOverClause() (*nodes.WindowDef, error) {
 		return nil, err
 	}
 
-	wd.Loc.End = p.pos()
+	wd.Loc.End = p.prev.End
 	return wd, nil
 }
 
@@ -901,7 +901,7 @@ func (p *Parser) parseFrameClause() (*nodes.WindowFrame, error) {
 		frame.Start = startBound
 	}
 
-	frame.Loc.End = p.pos()
+	frame.Loc.End = p.prev.End
 	return frame, nil
 }
 
@@ -948,7 +948,7 @@ func (p *Parser) parseFrameBound() (*nodes.WindowFrameBound, error) {
 		}
 	}
 
-	bound.Loc.End = p.pos()
+	bound.Loc.End = p.prev.End
 	return bound, nil
 }
 
@@ -987,7 +987,7 @@ func (p *Parser) parseTrimFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, error) {
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
-	fc.Loc.End = p.pos()
+	fc.Loc.End = p.prev.End
 	return fc, nil
 }
 
@@ -1051,7 +1051,7 @@ func (p *Parser) parseSubstringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, err
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
-	fc.Loc.End = p.pos()
+	fc.Loc.End = p.prev.End
 	return fc, nil
 }
 
@@ -1059,7 +1059,7 @@ func (p *Parser) parseSubstringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, err
 func (p *Parser) parseGroupConcatFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, error) {
 	if p.cur.Type == ')' {
 		p.advance()
-		fc.Loc.End = p.pos()
+		fc.Loc.End = p.prev.End
 		return fc, nil
 	}
 
@@ -1115,7 +1115,7 @@ func (p *Parser) parseGroupConcatFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, e
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
-	fc.Loc.End = p.pos()
+	fc.Loc.End = p.prev.End
 	return fc, nil
 }
 
@@ -1134,7 +1134,7 @@ func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
 			return nil, errP
 		}
 		sub.Loc.Start = start
-		sub.Loc.End = p.pos()
+		sub.Loc.End = p.prev.End
 		return sub, nil
 	}
 
@@ -1323,7 +1323,7 @@ func (p *Parser) parseConvertExpr() (nodes.ExprNode, error) {
 		return nil, err
 	}
 
-	conv.Loc.End = p.pos()
+	conv.Loc.End = p.prev.End
 	return conv, nil
 }
 
@@ -1378,7 +1378,7 @@ func (p *Parser) parseIsExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
 		}
 	}
 
-	is.Loc.End = p.pos()
+	is.Loc.End = p.prev.End
 	return is, nil
 }
 
@@ -1443,7 +1443,7 @@ func (p *Parser) parseInExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
 			return nil, errP
 		}
 		inExpr.Select = sub.Select
-		inExpr.Loc.End = p.pos()
+		inExpr.Loc.End = p.prev.End
 		return inExpr, nil
 	}
 
@@ -1467,7 +1467,7 @@ func (p *Parser) parseInExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
 		return nil, err
 	}
 
-	inExpr.Loc.End = p.pos()
+	inExpr.Loc.End = p.prev.End
 	return inExpr, nil
 }
 
@@ -1500,7 +1500,7 @@ func (p *Parser) parseLikeExpr(left nodes.ExprNode) (nodes.ExprNode, error) {
 		like.Escape = esc
 	}
 
-	like.Loc.End = p.pos()
+	like.Loc.End = p.prev.End
 	return like, nil
 }
 
@@ -1608,7 +1608,7 @@ func (p *Parser) parseCaseExpr() (nodes.ExprNode, error) {
 		return nil, err
 	}
 
-	ce.Loc.End = p.pos()
+	ce.Loc.End = p.prev.End
 	return ce, nil
 }
 
@@ -1821,7 +1821,7 @@ func (p *Parser) parseMatchExpr() (nodes.ExprNode, error) {
 		return nil, err
 	}
 
-	me.Loc.End = p.pos()
+	me.Loc.End = p.prev.End
 	return me, nil
 }
 
@@ -1887,7 +1887,7 @@ func (p *Parser) parseRowConstructor() (nodes.ExprNode, error) {
 		return nil, err
 	}
 
-	row.Loc.End = p.pos()
+	row.Loc.End = p.prev.End
 	return row, nil
 }
 
@@ -1916,7 +1916,7 @@ func (p *Parser) parseDefaultExpr() (nodes.ExprNode, error) {
 		}
 	}
 
-	de.Loc.End = p.pos()
+	de.Loc.End = p.prev.End
 	return de, nil
 }
 

--- a/mysql/parser/grant.go
+++ b/mysql/parser/grant.go
@@ -62,7 +62,7 @@ func (p *Parser) parseGrantStmt() (nodes.Node, error) {
 				stmt.WithAdmin = true
 			}
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -99,7 +99,7 @@ func (p *Parser) parseGrantStmt() (nodes.Node, error) {
 				stmt.WithGrant = true
 			}
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -230,7 +230,7 @@ func (p *Parser) parseGrantStmt() (nodes.Node, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -298,7 +298,7 @@ func (p *Parser) parseRevokeStmt() (nodes.Node, error) {
 				}
 				stmt.IgnoreUnknownUser = true
 			}
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 	}
@@ -328,7 +328,7 @@ func (p *Parser) parseRevokeStmt() (nodes.Node, error) {
 			}
 			stmt.IgnoreUnknownUser = true
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -363,7 +363,7 @@ func (p *Parser) parseRevokeStmt() (nodes.Node, error) {
 			}
 			stmt.IgnoreUnknownUser = true
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -407,7 +407,7 @@ func (p *Parser) parseRevokeStmt() (nodes.Node, error) {
 		stmt.IgnoreUnknownUser = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -604,7 +604,7 @@ func (p *Parser) parseGrantTarget() (*nodes.GrantTarget, error) {
 			}
 			if p.cur.Type == '*' {
 				p.advance()
-				ref.Loc.End = p.pos()
+				ref.Loc.End = p.prev.End
 			} else {
 				// *.tbl_name (unusual but handle)
 				name, _, err := p.parseIdent()
@@ -612,7 +612,7 @@ func (p *Parser) parseGrantTarget() (*nodes.GrantTarget, error) {
 					return nil, err
 				}
 				ref.Name = name
-				ref.Loc.End = p.pos()
+				ref.Loc.End = p.prev.End
 			}
 			target.Name = ref
 		} else {
@@ -631,7 +631,7 @@ func (p *Parser) parseGrantTarget() (*nodes.GrantTarget, error) {
 		target.Name = ref
 	}
 
-	target.Loc.End = p.pos()
+	target.Loc.End = p.prev.End
 	return target, nil
 }
 
@@ -665,7 +665,7 @@ func (p *Parser) parseGrantPrivLevel() (*nodes.TableRef, error) {
 		}
 	}
 
-	ref.Loc.End = p.pos()
+	ref.Loc.End = p.prev.End
 	return ref, nil
 }
 
@@ -812,7 +812,7 @@ func (p *Parser) parseCreateUserStmt() (*nodes.CreateUserStmt, error) {
 		&stmt.Comment, &stmt.Attribute,
 	)
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -841,7 +841,7 @@ func (p *Parser) parseDropUserStmt() (*nodes.DropUserStmt, error) {
 	}
 	stmt.Users = users
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -879,7 +879,7 @@ func (p *Parser) parseAlterUserStmt() (*nodes.AlterUserStmt, error) {
 				return nil, err
 			}
 			stmt.RegistrationOp = op
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 
@@ -912,9 +912,9 @@ func (p *Parser) parseAlterUserStmt() (*nodes.AlterUserStmt, error) {
 			p.advance()
 			userSpec.DiscardOldPassword = true
 		}
-		userSpec.Loc.End = p.pos()
+		userSpec.Loc.End = p.prev.End
 		stmt.Users = append(stmt.Users, userSpec)
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -935,7 +935,7 @@ func (p *Parser) parseAlterUserStmt() (*nodes.AlterUserStmt, error) {
 				return nil, err
 			}
 			stmt.RegistrationOp = op
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 	}
@@ -949,7 +949,7 @@ func (p *Parser) parseAlterUserStmt() (*nodes.AlterUserStmt, error) {
 				return nil, err
 			}
 			stmt.FactorOps = ops
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 	}
@@ -977,7 +977,7 @@ func (p *Parser) parseAlterUserStmt() (*nodes.AlterUserStmt, error) {
 				}
 				stmt.DefaultRoles = roles
 			}
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 	}
@@ -1018,7 +1018,7 @@ func (p *Parser) parseAlterUserStmt() (*nodes.AlterUserStmt, error) {
 		&stmt.Comment, &stmt.Attribute,
 	)
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1079,7 +1079,7 @@ func (p *Parser) parseRegistrationOption() (*nodes.RegistrationOp, error) {
 		p.advance()
 	}
 
-	op.Loc.End = p.pos()
+	op.Loc.End = p.prev.End
 	return op, nil
 }
 
@@ -1125,7 +1125,7 @@ func (p *Parser) parseFactorOps() ([]*nodes.FactorOp, error) {
 			}
 		}
 
-		op.Loc.End = p.pos()
+		op.Loc.End = p.prev.End
 		ops = append(ops, op)
 	}
 	return ops, nil
@@ -1283,7 +1283,7 @@ func (p *Parser) parseUserSpec() (*nodes.UserSpec, error) {
 		if err := p.parseUserAuthOption(factor); err != nil {
 			return nil, err
 		}
-		factor.Loc.End = p.pos()
+		factor.Loc.End = p.prev.End
 		spec.AuthFactors = append(spec.AuthFactors, factor)
 	}
 
@@ -1328,7 +1328,7 @@ func (p *Parser) parseUserSpec() (*nodes.UserSpec, error) {
 		}
 	}
 
-	spec.Loc.End = p.pos()
+	spec.Loc.End = p.prev.End
 	return spec, nil
 }
 
@@ -1356,7 +1356,7 @@ func (p *Parser) parseCreateRoleStmt() (*nodes.CreateRoleStmt, error) {
 	}
 	stmt.Roles = roles
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1383,7 +1383,7 @@ func (p *Parser) parseDropRoleStmt() (*nodes.DropRoleStmt, error) {
 	}
 	stmt.Roles = roles
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1468,7 +1468,7 @@ func (p *Parser) parseSetDefaultRoleStmt(start int) (*nodes.SetDefaultRoleStmt, 
 	}
 	stmt.To = users
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1506,7 +1506,7 @@ func (p *Parser) parseSetRoleStmt(start int) (*nodes.SetRoleStmt, error) {
 		stmt.Roles = roles
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1543,7 +1543,7 @@ func (p *Parser) parseRenameUserStmt(start int) (*nodes.RenameUserStmt, error) {
 			return nil, err
 		}
 
-		pair.Loc.End = p.pos()
+		pair.Loc.End = p.prev.End
 		stmt.Pairs = append(stmt.Pairs, pair)
 
 		if p.cur.Type != ',' {
@@ -1552,7 +1552,7 @@ func (p *Parser) parseRenameUserStmt(start int) (*nodes.RenameUserStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1635,7 +1635,7 @@ func (p *Parser) parseRequireClause() (*nodes.RequireClause, error) {
 				p.advance()
 			}
 		default:
-			req.Loc.End = p.pos()
+			req.Loc.End = p.prev.End
 			return req, nil
 		}
 
@@ -1694,7 +1694,7 @@ func (p *Parser) parseResourceOptions() *nodes.ResourceOption {
 		}
 	}
 	if res != nil {
-		res.Loc.End = p.pos()
+		res.Loc.End = p.prev.End
 	}
 	return res
 }
@@ -1887,6 +1887,6 @@ func (p *Parser) parseSetResourceGroupStmt(start int) (*nodes.SetResourceGroupSt
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }

--- a/mysql/parser/insert.go
+++ b/mysql/parser/insert.go
@@ -118,7 +118,7 @@ func (p *Parser) parseInsertOrReplace(isReplace bool) (*nodes.InsertStmt, error)
 				return nil, err
 			}
 			stmt.Select = sel
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 		// Otherwise, parse column list
@@ -220,7 +220,7 @@ func (p *Parser) parseInsertOrReplace(isReplace bool) (*nodes.InsertStmt, error)
 		stmt.OnDuplicateKey = onDup
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/load_data.go
+++ b/mysql/parser/load_data.go
@@ -204,7 +204,7 @@ func (p *Parser) parseLoadDataStmt(start int) (*nodes.LoadDataStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/loc_test.go
+++ b/mysql/parser/loc_test.go
@@ -448,3 +448,50 @@ func TestLocAudit(t *testing.T) {
 		t.Logf("%-30s %d", tag, len(violationsByTag[tag]))
 	}
 }
+
+func TestLocEndExcludesTrailingComments(t *testing.T) {
+	tests := []struct {
+		sql     string
+		wantEnd int
+	}{
+		{"SELECT * FROM t -- note", len("SELECT * FROM t")},
+		{"SELECT * FROM t /* block */", len("SELECT * FROM t")},
+		{"SELECT * FROM t # mysql comment", len("SELECT * FROM t")},
+		{"SELECT * FROM t  -- note", len("SELECT * FROM t")},
+		{"SELECT 1 -- trailing", len("SELECT 1")},
+		{"INSERT INTO t VALUES (1) -- done", len("INSERT INTO t VALUES (1)")},
+		{"CREATE TABLE t (id INT) -- comment", len("CREATE TABLE t (id INT)")},
+		{"DELETE FROM t WHERE id = 1 -- cleanup", len("DELETE FROM t WHERE id = 1")},
+		{"UPDATE t SET a = 1 -- fix", len("UPDATE t SET a = 1")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.sql, func(t *testing.T) {
+			result, err := Parse(tc.sql)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.sql, err)
+			}
+			if result == nil || len(result.Items) == 0 {
+				t.Fatalf("Parse(%q): no statements", tc.sql)
+			}
+			stmt := result.Items[0]
+			locEnd := stmtLocEnd(stmt)
+			if locEnd != tc.wantEnd {
+				t.Errorf("Parse(%q): Loc.End = %d, want %d (sql[Loc.End:] = %q)",
+					tc.sql, locEnd, tc.wantEnd, tc.sql[locEnd:])
+			}
+		})
+	}
+}
+
+func stmtLocEnd(node ast.Node) int {
+	v := reflect.ValueOf(node)
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	loc := v.FieldByName("Loc")
+	if !loc.IsValid() {
+		return -1
+	}
+	return loc.FieldByName("End").Interface().(int)
+}

--- a/mysql/parser/name.go
+++ b/mysql/parser/name.go
@@ -702,7 +702,7 @@ func (p *Parser) parseColumnRef() (*nodes.ColumnRef, error) {
 			ref.Table = name
 			ref.Column = ""
 			ref.Star = true
-			ref.Loc.End = p.pos()
+			ref.Loc.End = p.prev.End
 			return ref, nil
 		}
 
@@ -721,7 +721,7 @@ func (p *Parser) parseColumnRef() (*nodes.ColumnRef, error) {
 				ref.Table = name2
 				ref.Column = ""
 				ref.Star = true
-				ref.Loc.End = p.pos()
+				ref.Loc.End = p.prev.End
 				return ref, nil
 			}
 
@@ -732,7 +732,7 @@ func (p *Parser) parseColumnRef() (*nodes.ColumnRef, error) {
 			ref.Schema = name
 			ref.Table = name2
 			ref.Column = name3
-			ref.Loc.End = p.pos()
+			ref.Loc.End = p.prev.End
 			return ref, nil
 		}
 
@@ -741,7 +741,7 @@ func (p *Parser) parseColumnRef() (*nodes.ColumnRef, error) {
 		ref.Column = name2
 	}
 
-	ref.Loc.End = p.pos()
+	ref.Loc.End = p.prev.End
 	return ref, nil
 }
 
@@ -783,7 +783,7 @@ func (p *Parser) parseTableRef() (*nodes.TableRef, error) {
 		ref.Name = name2
 	}
 
-	ref.Loc.End = p.pos()
+	ref.Loc.End = p.prev.End
 	return ref, nil
 }
 
@@ -805,7 +805,7 @@ func (p *Parser) parseTableRefWithAlias() (*nodes.TableRef, error) {
 			return nil, err
 		}
 		ref.Partitions = parts
-		ref.Loc.End = p.pos()
+		ref.Loc.End = p.prev.End
 	}
 
 	// Optional AS alias
@@ -815,13 +815,13 @@ func (p *Parser) parseTableRefWithAlias() (*nodes.TableRef, error) {
 			return nil, err
 		}
 		ref.Alias = alias
-		ref.Loc.End = p.pos()
+		ref.Loc.End = p.prev.End
 	} else if p.isIdentToken() || p.cur.Type == tokSCONST {
 		// Alias without AS keyword — accepts non-reserved keywords and string
 		// literals, matching MySQL's opt_table_alias: [AS] ident_or_text
 		alias, _, _ := p.parseIdentOrText()
 		ref.Alias = alias
-		ref.Loc.End = p.pos()
+		ref.Loc.End = p.prev.End
 	}
 
 	// Optional index hints: USE/FORCE/IGNORE {INDEX|KEY} ...
@@ -831,7 +831,7 @@ func (p *Parser) parseTableRefWithAlias() (*nodes.TableRef, error) {
 			return nil, err
 		}
 		ref.IndexHints = hints
-		ref.Loc.End = p.pos()
+		ref.Loc.End = p.prev.End
 	}
 
 	return ref, nil
@@ -887,7 +887,7 @@ func (p *Parser) parseVariableRef() (*nodes.VariableRef, error) {
 					return nil, err
 				}
 				ref.Name = name
-				ref.Loc.End = p.pos()
+				ref.Loc.End = p.prev.End
 				return ref, nil
 			}
 		}
@@ -898,7 +898,7 @@ func (p *Parser) parseVariableRef() (*nodes.VariableRef, error) {
 			return nil, err
 		}
 		ref.Name = name
-		ref.Loc.End = p.pos()
+		ref.Loc.End = p.prev.End
 		return ref, nil
 	}
 
@@ -910,7 +910,7 @@ func (p *Parser) parseVariableRef() (*nodes.VariableRef, error) {
 			Loc:  nodes.Loc{Start: tok.Loc},
 			Name: tok.Str[1:],
 		}
-		ref.Loc.End = p.pos()
+		ref.Loc.End = p.prev.End
 		return ref, nil
 	}
 

--- a/mysql/parser/prepare.go
+++ b/mysql/parser/prepare.go
@@ -39,7 +39,7 @@ func (p *Parser) parsePrepareStmt() (*nodes.PrepareStmt, error) {
 		stmt.Stmt = "@" + vref.Name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -80,7 +80,7 @@ func (p *Parser) parseExecuteStmt() (*nodes.ExecuteStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -104,6 +104,6 @@ func (p *Parser) parseDeallocateStmt() (*nodes.DeallocateStmt, error) {
 	}
 	stmt.Name = name
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }

--- a/mysql/parser/replication.go
+++ b/mysql/parser/replication.go
@@ -93,7 +93,7 @@ func (p *Parser) parseChangeReplicationSourceStmtInner(start int) (*nodes.Change
 		stmt.Channel = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -135,7 +135,7 @@ func (p *Parser) parseReplicationSourceOption() (*nodes.ReplicationOption, error
 			}
 		}
 		p.match(')')
-		opt.Loc.End = p.pos()
+		opt.Loc.End = p.prev.End
 		return opt, nil
 	}
 
@@ -160,7 +160,7 @@ func (p *Parser) parseReplicationSourceOption() (*nodes.ReplicationOption, error
 		opt.Value = val
 	}
 
-	opt.Loc.End = p.pos()
+	opt.Loc.End = p.prev.End
 	return opt, nil
 }
 
@@ -250,7 +250,7 @@ func (p *Parser) parseChangeMasterStmtInner(start int) (*nodes.ChangeReplication
 		stmt.Channel = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -318,7 +318,7 @@ func (p *Parser) parseChangeReplicationFilterStmtInner(start int) (*nodes.Change
 		stmt.Channel = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -400,7 +400,7 @@ func (p *Parser) parseReplicationFilter() (*nodes.ReplicationFilter, error) {
 
 	p.match(')') // close outer paren
 
-	f.Loc.End = p.pos()
+	f.Loc.End = p.prev.End
 	return f, nil
 }
 
@@ -525,7 +525,7 @@ doneConnOpts:
 		stmt.Channel = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -594,7 +594,7 @@ func (p *Parser) parseStopReplicaStmt(start int) (*nodes.StopReplicaStmt, error)
 		stmt.Channel = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -631,7 +631,7 @@ func (p *Parser) parseResetReplicaStmt(start int) (*nodes.ResetReplicaStmt, erro
 		stmt.Channel = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -669,7 +669,7 @@ func (p *Parser) parsePurgeBinaryLogsStmt() (*nodes.PurgeBinaryLogsStmt, error) 
 		stmt.BeforeExpr = expr
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -695,7 +695,7 @@ func (p *Parser) parseResetMasterStmt(start int) (*nodes.ResetMasterStmt, error)
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -739,7 +739,7 @@ func (p *Parser) parseStartGroupReplicationStmt(start int) (*nodes.StartGroupRep
 		}
 	}
 groupReplDone:
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/select.go
+++ b/mysql/parser/select.go
@@ -79,7 +79,7 @@ func (p *Parser) parseWithClause() ([]*nodes.CommonTableExpr, error) {
 			return nil, err
 		}
 
-		cte.Loc.End = p.pos()
+		cte.Loc.End = p.prev.End
 		ctes = append(ctes, cte)
 
 		if p.cur.Type != ',' {
@@ -193,7 +193,7 @@ func (p *Parser) parseSelectClauseAndTrailing(start int, ctes []*nodes.CommonTab
 		}
 	}
 
-	body.Loc.End = p.pos()
+	body.Loc.End = p.prev.End
 	return body, nil
 }
 
@@ -706,7 +706,7 @@ func (p *Parser) parseSimpleSelect() (*nodes.SelectStmt, error) {
 		stmt.Into = into
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -994,7 +994,7 @@ func (p *Parser) parseTableReference() (nodes.TableExpr, error) {
 			join.Condition = &nodes.UsingCondition{Loc: nodes.Loc{Start: condStart, End: p.pos()}, Columns: cols}
 		}
 
-		join.Loc.End = p.pos()
+		join.Loc.End = p.prev.End
 		left = join
 	}
 
@@ -1119,7 +1119,7 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 			sub.Columns = cols
 		}
 
-		sub.Loc.End = p.pos()
+		sub.Loc.End = p.prev.End
 		return sub, nil
 	}
 
@@ -1167,7 +1167,7 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 				sub.Columns = cols
 			}
 
-			sub.Loc.End = p.pos()
+			sub.Loc.End = p.prev.End
 			return sub, nil
 		}
 
@@ -1357,7 +1357,7 @@ func (p *Parser) parseJsonTableColumn() (*nodes.JsonTableColumn, error) {
 		p.advance()
 		p.match(kwORDINALITY)
 		col.Ordinality = true
-		col.Loc.End = p.pos()
+		col.Loc.End = p.prev.End
 		return col, nil
 	}
 
@@ -1417,7 +1417,7 @@ func (p *Parser) parseJsonTableColumn() (*nodes.JsonTableColumn, error) {
 		}
 	}
 
-	col.Loc.End = p.pos()
+	col.Loc.End = p.prev.End
 	return col, nil
 }
 
@@ -1459,7 +1459,7 @@ func (p *Parser) parseOrderByList() ([]*nodes.OrderByItem, error) {
 			item.Direction = nodes.OrderDirectionDefault
 		}
 
-		item.Loc.End = p.pos()
+		item.Loc.End = p.prev.End
 		items = append(items, item)
 
 		if p.cur.Type != ',' {
@@ -1515,7 +1515,7 @@ func (p *Parser) parseLimitClause() (*nodes.Limit, error) {
 		limit.Offset = offset
 	}
 
-	limit.Loc.End = p.pos()
+	limit.Loc.End = p.prev.End
 	return limit, nil
 }
 
@@ -1577,7 +1577,7 @@ func (p *Parser) parseForUpdateClause() (*nodes.ForUpdate, error) {
 		fu.SkipLocked = true
 	}
 
-	fu.Loc.End = p.pos()
+	fu.Loc.End = p.prev.End
 	return fu, nil
 }
 
@@ -1758,7 +1758,7 @@ func (p *Parser) parseIntoClause() (*nodes.IntoClause, error) {
 		}
 	}
 
-	into.Loc.End = p.pos()
+	into.Loc.End = p.prev.End
 	return into, nil
 }
 
@@ -1898,7 +1898,7 @@ func (p *Parser) parseNamedWindowList() ([]*nodes.WindowDef, error) {
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
 		}
-		wd.Loc.End = p.pos()
+		wd.Loc.End = p.prev.End
 		defs = append(defs, wd)
 
 		if p.cur.Type != ',' {
@@ -1973,7 +1973,7 @@ func (p *Parser) parseTableStmt() (*nodes.TableStmt, error) {
 		stmt.Into = into
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2042,7 +2042,7 @@ func (p *Parser) parseValuesStmt() (*nodes.ValuesStmt, error) {
 		stmt.Limit = limit
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2176,6 +2176,6 @@ func (p *Parser) parseIndexHint() (*nodes.IndexHint, error) {
 		return nil, err
 	}
 
-	hint.Loc.End = p.pos()
+	hint.Loc.End = p.prev.End
 	return hint, nil
 }

--- a/mysql/parser/set_show.go
+++ b/mysql/parser/set_show.go
@@ -76,7 +76,7 @@ func (p *Parser) parseSetStmt() (nodes.Node, error) {
 				Value:  &nodes.StringLit{Loc: nodes.Loc{Start: collLoc, End: p.pos()}, Value: collation},
 			})
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -114,7 +114,7 @@ func (p *Parser) parseSetStmt() (nodes.Node, error) {
 				Column: &nodes.ColumnRef{Loc: nodes.Loc{Start: charsetLoc, End: p.pos()}, Column: "CHARACTER SET"},
 				Value:  &nodes.StringLit{Loc: nodes.Loc{Start: charsetLoc, End: p.pos()}, Value: charset},
 			})
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 	}
@@ -196,7 +196,7 @@ func (p *Parser) parseSetStmt() (nodes.Node, error) {
 		p.advance() // consume ','
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -276,7 +276,7 @@ func (p *Parser) parseSetPasswordStmt(start int) (*nodes.SetPasswordStmt, error)
 		stmt.RetainCurrentPassword = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -345,7 +345,7 @@ func (p *Parser) parseSetAssignment() (*nodes.Assignment, error) {
 			col.Table = name
 			col.Column = name2
 		}
-		col.Loc.End = p.pos()
+		col.Loc.End = p.prev.End
 	}
 
 	// Expect '=' or ':='
@@ -407,7 +407,7 @@ func (p *Parser) parseShowStmt() (*nodes.ShowStmt, error) {
 			stmt.Type = "COUNT WARNINGS"
 			p.advance()
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -1175,7 +1175,7 @@ func (p *Parser) parseShowStmt() (*nodes.ShowStmt, error) {
 			if err := p.parseShowProfileOptions(stmt); err != nil {
 				return nil, err
 			}
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 
@@ -1183,7 +1183,7 @@ func (p *Parser) parseShowStmt() (*nodes.ShowStmt, error) {
 		if p.cur.Type == kwREPLICAS {
 			stmt.Type = "REPLICAS"
 			p.advance()
-			stmt.Loc.End = p.pos()
+			stmt.Loc.End = p.prev.End
 			return stmt, nil
 		}
 
@@ -1275,7 +1275,7 @@ func (p *Parser) parseShowStmt() (*nodes.ShowStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1550,9 +1550,9 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 			}
 			showStmt.Like = colExpr
 		}
-		showStmt.Loc.End = p.pos()
+		showStmt.Loc.End = p.prev.End
 		stmt.Stmt = showStmt
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -1601,7 +1601,7 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 			stmt.ForConnection = p.cur.Ival
 			p.advance()
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -1683,10 +1683,10 @@ func (p *Parser) parseExplainStmt() (*nodes.ExplainStmt, error) {
 			}
 			showStmt.Like = colExpr
 		}
-		showStmt.Loc.End = p.pos()
+		showStmt.Loc.End = p.prev.End
 		stmt.Stmt = showStmt
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }

--- a/mysql/parser/signal.go
+++ b/mysql/parser/signal.go
@@ -56,7 +56,7 @@ func (p *Parser) parseSignalStmt() (*nodes.SignalStmt, error) {
 		stmt.SetItems = items
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -123,7 +123,7 @@ func (p *Parser) parseResignalStmt() (*nodes.ResignalStmt, error) {
 		stmt.SetItems = items
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -218,7 +218,7 @@ func (p *Parser) parseGetDiagnosticsStmt() (*nodes.GetDiagnosticsStmt, error) {
 		stmt.Items = items
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/stmt.go
+++ b/mysql/parser/stmt.go
@@ -310,7 +310,7 @@ func (p *Parser) parseStartDispatch() (nodes.Node, error) {
 		}
 		p.advance()
 	}
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -356,7 +356,7 @@ func (p *Parser) parseResetDispatch() (nodes.Node, error) {
 			p.advance()
 		}
 	}
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/transaction.go
+++ b/mysql/parser/transaction.go
@@ -60,7 +60,7 @@ func (p *Parser) parseBeginStmt() (*nodes.BeginStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -107,7 +107,7 @@ func (p *Parser) parseCommitStmt() (*nodes.CommitStmt, error) {
 		stmt.Release = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -150,7 +150,7 @@ func (p *Parser) parseRollbackStmt() (*nodes.RollbackStmt, error) {
 			return nil, err
 		}
 		stmt.Savepoint = name
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -174,7 +174,7 @@ func (p *Parser) parseRollbackStmt() (*nodes.RollbackStmt, error) {
 		stmt.Release = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -291,7 +291,7 @@ func (p *Parser) parseLockTablesStmt() (*nodes.LockTablesStmt, error) {
 			lt.LockType = "WRITE"
 		}
 
-		lt.Loc.End = p.pos()
+		lt.Loc.End = p.prev.End
 		stmt.Tables = append(stmt.Tables, lt)
 
 		if p.cur.Type != ',' {
@@ -300,7 +300,7 @@ func (p *Parser) parseLockTablesStmt() (*nodes.LockTablesStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -387,7 +387,7 @@ func (p *Parser) parseSetTransactionStmt(start int, scope string) (*nodes.SetTra
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -490,7 +490,7 @@ func (p *Parser) parseXAStmt() (*nodes.XAStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 

--- a/mysql/parser/trigger.go
+++ b/mysql/parser/trigger.go
@@ -141,7 +141,7 @@ func (p *Parser) parseCreateTriggerStmt() (*nodes.CreateTriggerStmt, error) {
 	stmt.Body = body
 	stmt.BodyText = p.inputText(bodyStart, bodyEnd)
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -263,7 +263,7 @@ func (p *Parser) parseCreateEventStmt() (*nodes.CreateEventStmt, error) {
 	stmt.Body = body
 	stmt.BodyText = p.inputText(bodyStart, bodyEnd)
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -328,7 +328,7 @@ func (p *Parser) parseEventSchedule() (*nodes.EventSchedule, error) {
 		}
 	}
 
-	sched.Loc.End = p.pos()
+	sched.Loc.End = p.prev.End
 	sched.RawText = strings.TrimSpace(p.inputText(start, sched.Loc.End))
 	return sched, nil
 }

--- a/mysql/parser/type.go
+++ b/mysql/parser/type.go
@@ -394,7 +394,7 @@ func (p *Parser) parseDataType() (*nodes.DataType, error) {
 		}
 	}
 
-	dt.Loc.End = p.pos()
+	dt.Loc.End = p.prev.End
 	return dt, nil
 }
 

--- a/mysql/parser/update_delete.go
+++ b/mysql/parser/update_delete.go
@@ -104,7 +104,7 @@ func (p *Parser) parseUpdateStmt() (*nodes.UpdateStmt, error) {
 		stmt.Limit = limit
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -168,11 +168,11 @@ func (p *Parser) parseDeleteStmt() (*nodes.DeleteStmt, error) {
 						return nil, err
 					}
 					tblRef.Alias = alias
-					tblRef.Loc.End = p.pos()
+					tblRef.Loc.End = p.prev.End
 				} else if p.cur.Type == tokIDENT {
 					alias, _, _ := p.parseIdent()
 					tblRef.Alias = alias
-					tblRef.Loc.End = p.pos()
+					tblRef.Loc.End = p.prev.End
 				}
 				// Optional PARTITION (p0, p1, ...)
 				if p.cur.Type == kwPARTITION {
@@ -182,7 +182,7 @@ func (p *Parser) parseDeleteStmt() (*nodes.DeleteStmt, error) {
 						return nil, err
 					}
 					tblRef.Partitions = parts
-					tblRef.Loc.End = p.pos()
+					tblRef.Loc.End = p.prev.End
 				}
 			}
 		}
@@ -257,7 +257,7 @@ func (p *Parser) parseDeleteStmt() (*nodes.DeleteStmt, error) {
 		stmt.Limit = limit
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -368,7 +368,7 @@ func (p *Parser) parseDeleteTableName() (*nodes.TableRef, error) {
 			// name.* -- skip the .* suffix
 			p.advance() // consume '.'
 			p.advance() // consume '*'
-			ref.Loc.End = p.pos()
+			ref.Loc.End = p.prev.End
 			return ref, nil
 		}
 		// schema.table or schema.table.*
@@ -396,6 +396,6 @@ func (p *Parser) parseDeleteTableName() (*nodes.TableRef, error) {
 		}
 	}
 
-	ref.Loc.End = p.pos()
+	ref.Loc.End = p.prev.End
 	return ref, nil
 }

--- a/mysql/parser/utility.go
+++ b/mysql/parser/utility.go
@@ -128,7 +128,7 @@ func (p *Parser) parseAnalyzeTableStmt() (*nodes.AnalyzeTableStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -172,7 +172,7 @@ func (p *Parser) parseOptimizeTableStmt() (*nodes.OptimizeTableStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -230,7 +230,7 @@ func (p *Parser) parseCheckTableStmt() (*nodes.CheckTableStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -290,7 +290,7 @@ func (p *Parser) parseRepairTableStmt() (*nodes.RepairTableStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -388,7 +388,7 @@ func (p *Parser) parseFlushStmt() (*nodes.FlushStmt, error) {
 			}
 			stmt.ForExport = true
 		}
-		stmt.Loc.End = p.pos()
+		stmt.Loc.End = p.prev.End
 		return stmt, nil
 	}
 
@@ -408,7 +408,7 @@ func (p *Parser) parseFlushStmt() (*nodes.FlushStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -511,7 +511,7 @@ func (p *Parser) parseResetStmt() (*nodes.FlushStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -544,7 +544,7 @@ func (p *Parser) parseKillStmt() (*nodes.KillStmt, error) {
 	}
 	stmt.ConnectionID = expr
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -597,7 +597,7 @@ func (p *Parser) parseCallStmt() (*nodes.CallStmt, error) {
 		p.expect(')')
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -630,7 +630,7 @@ func (p *Parser) parseHandlerOpenStmt(start int, table *nodes.TableRef) (*nodes.
 		stmt.Alias = alias
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -731,7 +731,7 @@ func (p *Parser) parseHandlerReadStmt(start int, table *nodes.TableRef) (*nodes.
 		stmt.Limit = lim
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -748,7 +748,7 @@ func (p *Parser) parseHandlerCloseStmt(start int, table *nodes.TableRef) (*nodes
 		Table: table,
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -811,7 +811,7 @@ func (p *Parser) parseDoStmt() (*nodes.DoStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -849,7 +849,7 @@ func (p *Parser) parseChecksumTableStmt() (*nodes.ChecksumTableStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -863,7 +863,7 @@ func (p *Parser) parseShutdownStmt() (*nodes.ShutdownStmt, error) {
 	p.advance() // consume SHUTDOWN
 
 	stmt := &nodes.ShutdownStmt{Loc: nodes.Loc{Start: start}}
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -877,7 +877,7 @@ func (p *Parser) parseRestartStmt() (*nodes.RestartStmt, error) {
 	p.advance() // consume RESTART
 
 	stmt := &nodes.RestartStmt{Loc: nodes.Loc{Start: start}}
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1013,7 +1013,7 @@ func (p *Parser) parseCloneStmt() (*nodes.CloneStmt, error) {
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1062,7 +1062,7 @@ func (p *Parser) parseInstallPluginStmt(start int) (*nodes.InstallPluginStmt, er
 		PluginName: name,
 		Soname:     soname,
 	}
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1107,7 +1107,7 @@ func (p *Parser) parseInstallComponentStmt(start int) (*nodes.InstallComponentSt
 		}
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1150,7 +1150,7 @@ func (p *Parser) parseUninstallPluginStmt(start int) (*nodes.UninstallPluginStmt
 		Loc:        nodes.Loc{Start: start},
 		PluginName: name,
 	}
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1172,7 +1172,7 @@ func (p *Parser) parseUninstallComponentStmt(start int) (*nodes.UninstallCompone
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1294,7 +1294,7 @@ func (p *Parser) parseCreateTablespaceStmt(start int, undo bool) (*nodes.CreateT
 		}
 	}
 done:
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1407,7 +1407,7 @@ func (p *Parser) parseAlterTablespaceStmt(start int, undo bool) (*nodes.AlterTab
 		}
 	}
 done:
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1443,7 +1443,7 @@ func (p *Parser) parseDropTablespaceStmt(start int, undo bool) (*nodes.DropTable
 		stmt.Engine = ename
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1524,7 +1524,7 @@ func (p *Parser) parseCreateServerStmt(start int) (*nodes.CreateServerStmt, erro
 		stmt.Options = opts
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1555,7 +1555,7 @@ func (p *Parser) parseAlterServerStmt(start int) (*nodes.AlterServerStmt, error)
 		stmt.Options = opts
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1582,7 +1582,7 @@ func (p *Parser) parseDropServerStmt(start int) (*nodes.DropServerStmt, error) {
 	}
 	stmt.Name = name
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1703,7 +1703,7 @@ func (p *Parser) parseCreateSpatialRefSysStmt(start int, orReplace bool) (*nodes
 		}
 	}
 done_srs:
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1749,7 +1749,7 @@ func (p *Parser) parseDropSpatialRefSysStmt(start int) (*nodes.DropSpatialRefSys
 	stmt.SRID = p.cur.Ival
 	p.advance()
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1897,7 +1897,7 @@ func (p *Parser) parseCreateResourceGroupStmt(start int) (*nodes.CreateResourceG
 		return nil, err
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1943,7 +1943,7 @@ func (p *Parser) parseAlterResourceGroupStmt(start int) (*nodes.AlterResourceGro
 		stmt.Force = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -1979,7 +1979,7 @@ func (p *Parser) parseDropResourceGroupStmt(start int) (*nodes.DropResourceGroup
 		stmt.Force = true
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2041,7 +2041,7 @@ func (p *Parser) parseAlterInstanceStmt(start int) (*nodes.AlterInstanceStmt, er
 		stmt.Action += w
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2094,7 +2094,7 @@ func (p *Parser) parseImportTableStmt() (*nodes.ImportTableStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2113,7 +2113,7 @@ func (p *Parser) parseBinlogStmt() (*nodes.BinlogStmt, error) {
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2182,7 +2182,7 @@ func (p *Parser) parseCacheIndexStmt() (*nodes.CacheIndexStmt, error) {
 		stmt.CacheName = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2273,7 +2273,7 @@ func (p *Parser) parseLoadIndexIntoCacheStmt(start int) (*nodes.LoadIndexIntoCac
 			entry.IgnoreLeaves = true
 		}
 
-		entry.Loc.End = p.pos()
+		entry.Loc.End = p.prev.End
 		stmt.Tables = append(stmt.Tables, entry)
 
 		if p.cur.Type != ',' {
@@ -2282,7 +2282,7 @@ func (p *Parser) parseLoadIndexIntoCacheStmt(start int) (*nodes.LoadIndexIntoCac
 		p.advance()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2306,7 +2306,7 @@ func (p *Parser) parseResetPersistStmt(start int) (*nodes.ResetPersistStmt, erro
 		stmt.Variable = name
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2334,7 +2334,7 @@ func (p *Parser) parseHelpStmt() (*nodes.HelpStmt, error) {
 		return nil, p.syntaxErrorAtCur()
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2449,7 +2449,7 @@ func (p *Parser) parseCreateLogfileGroupStmt(start int) (*nodes.CreateLogfileGro
 		}
 	}
 createLGDone:
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2515,7 +2515,7 @@ func (p *Parser) parseAlterLogfileGroupStmt(start int) (*nodes.AlterLogfileGroup
 		}
 	}
 alterLGDone:
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }
 
@@ -2552,6 +2552,6 @@ func (p *Parser) parseDropLogfileGroupStmt(start int) (*nodes.DropLogfileGroupSt
 		stmt.Engine = ename
 	}
 
-	stmt.Loc.End = p.pos()
+	stmt.Loc.End = p.prev.End
 	return stmt, nil
 }


### PR DESCRIPTION
## Summary
- Replace all `.Loc.End = p.pos()` with `.Loc.End = p.prev.End` across the MySQL parser (266 occurrences in 25 files)
- This aligns MySQL with PG/StarRocks/Doris/Snowflake convention where `Loc.End` points to the end of the last semantic token, not the start of the next token
- Add `TestLocEndExcludesTrailingComments` regression test covering `--`, `/* */`, and `#` comments for SELECT, INSERT, CREATE TABLE, DELETE, and UPDATE

## Root cause
`p.pos()` returns `p.cur.Loc` (start of the current/next token). After the lexer's `skipWhitespaceAndComments()` skips trailing comments, the EOF token's `Loc` is past the comment. This made `Loc.End` include the comment span, causing Bytebase's LIMIT insertion to land inside `--` comments (e.g., `SELECT * FROM t -- note LIMIT 10` where LIMIT is commented out).

## Test plan
- [x] `TestLocEndExcludesTrailingComments` — 9 cases (SELECT, INSERT, CREATE TABLE, DELETE, UPDATE with `--`, `/* */`, `#` comments)
- [x] `go test ./mysql/parser/... -short` passes (no regressions)
- [x] `TestLocAudit` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)