### PR TITLE
feat(mariadb): parse parenthesized row constructors in expressions

### DIFF
--- a/mariadb/ast/outfuncs.go
+++ b/mariadb/ast/outfuncs.go
@@ -39,6 +39,8 @@ func writeNode(sb *strings.Builder, node Node) {
 		writeUpdateStmt(sb, n)
 	case *DeleteStmt:
 		writeDeleteStmt(sb, n)
+	case *ForPortionOf:
+		writeForPortionOf(sb, n)
 	case *CreateTableStmt:
 		writeCreateTableStmt(sb, n)
 	case *AlterTableStmt:
@@ -713,6 +715,10 @@ func writeUpdateStmt(sb *strings.Builder, n *UpdateStmt) {
 		sb.WriteString(" :tables ")
 		writeTableExprList(sb, n.Tables)
 	}
+	if n.ForPortionOf != nil {
+		sb.WriteString(" :for_portion_of ")
+		writeNode(sb, n.ForPortionOf)
+	}
 	if len(n.SetList) > 0 {
 		sb.WriteString(" :set ")
 		for i, a := range n.SetList {
@@ -753,6 +759,10 @@ func writeDeleteStmt(sb *strings.Builder, n *DeleteStmt) {
 		sb.WriteString(" :tables ")
 		writeTableExprList(sb, n.Tables)
 	}
+	if n.ForPortionOf != nil {
+		sb.WriteString(" :for_portion_of ")
+		writeNode(sb, n.ForPortionOf)
+	}
 	if len(n.Using) > 0 {
 		sb.WriteString(" :using ")
 		writeTableExprList(sb, n.Using)
@@ -773,6 +783,15 @@ func writeDeleteStmt(sb *strings.Builder, n *DeleteStmt) {
 		sb.WriteString(" :returning ")
 		writeNodeList(sb, n.Returning)
 	}
+	sb.WriteString("}")
+}
+
+func writeForPortionOf(sb *strings.Builder, n *ForPortionOf) {
+	sb.WriteString("{FOR_PORTION_OF")
+	fmt.Fprintf(sb, " :period %s :from ", n.PeriodName)
+	writeNode(sb, n.From)
+	sb.WriteString(" :to ")
+	writeNode(sb, n.To)
 	sb.WriteString("}")
 }
 

--- a/mariadb/ast/parsenodes.go
+++ b/mariadb/ast/parsenodes.go
@@ -139,14 +139,15 @@ const (
 
 // UpdateStmt represents an UPDATE statement.
 type UpdateStmt struct {
-	Loc         Loc
-	LowPriority bool
-	Ignore      bool
-	Tables      []TableExpr    // table references (multi-table update)
-	SetList     []*Assignment  // SET clause
-	Where       ExprNode       // WHERE condition
-	OrderBy     []*OrderByItem // ORDER BY
-	Limit       *Limit         // LIMIT
+	Loc          Loc
+	LowPriority  bool
+	Ignore       bool
+	Tables       []TableExpr    // table references (multi-table update)
+	ForPortionOf *ForPortionOf  // FOR PORTION OF <period> FROM x TO y (application-time)
+	SetList      []*Assignment  // SET clause
+	Where        ExprNode       // WHERE condition
+	OrderBy      []*OrderByItem // ORDER BY
+	Limit        *Limit         // LIMIT
 }
 
 func (s *UpdateStmt) nodeTag()  {}
@@ -154,20 +155,32 @@ func (s *UpdateStmt) stmtNode() {}
 
 // DeleteStmt represents a DELETE statement.
 type DeleteStmt struct {
-	Loc         Loc
-	LowPriority bool
-	Quick       bool
-	Ignore      bool
-	Tables      []TableExpr    // tables to delete from
-	Using       []TableExpr    // USING clause (multi-table delete)
-	Where       ExprNode       // WHERE condition
-	OrderBy     []*OrderByItem // ORDER BY
-	Limit       *Limit         // LIMIT
-	Returning   []Node         // RETURNING select-list (MariaDB; single-table DELETE only)
+	Loc          Loc
+	LowPriority  bool
+	Quick        bool
+	Ignore       bool
+	Tables       []TableExpr    // tables to delete from
+	ForPortionOf *ForPortionOf  // FOR PORTION OF <period> FROM x TO y (application-time)
+	Using        []TableExpr    // USING clause (multi-table delete)
+	Where        ExprNode       // WHERE condition
+	OrderBy      []*OrderByItem // ORDER BY
+	Limit        *Limit         // LIMIT
+	Returning    []Node         // RETURNING select-list (MariaDB; single-table DELETE only)
 }
 
 func (s *DeleteStmt) nodeTag()  {}
 func (s *DeleteStmt) stmtNode() {}
+
+// ForPortionOf is the application-time clause FOR PORTION OF <period> FROM x TO y
+// on a single-table UPDATE / DELETE.
+type ForPortionOf struct {
+	Loc        Loc
+	PeriodName string
+	From       ExprNode
+	To         ExprNode
+}
+
+func (n *ForPortionOf) nodeTag() {}
 
 // CreateTableStmt represents a CREATE TABLE statement.
 type CreateTableStmt struct {

--- a/mariadb/ast/walk_generated.go
+++ b/mariadb/ast/walk_generated.go
@@ -370,6 +370,9 @@ func walkChildren(v Visitor, node Node) {
 		for _, item := range n.Tables {
 			Walk(v, item)
 		}
+		if n.ForPortionOf != nil {
+			Walk(v, n.ForPortionOf)
+		}
 		for _, item := range n.Using {
 			Walk(v, item)
 		}
@@ -449,6 +452,9 @@ func walkChildren(v Visitor, node Node) {
 				Walk(v, item)
 			}
 		}
+	case *ForPortionOf:
+		Walk(v, n.From)
+		Walk(v, n.To)
 	case *ForUpdate:
 		for _, item := range n.Tables {
 			if item != nil {
@@ -891,6 +897,9 @@ func walkChildren(v Visitor, node Node) {
 	case *UpdateStmt:
 		for _, item := range n.Tables {
 			Walk(v, item)
+		}
+		if n.ForPortionOf != nil {
+			Walk(v, n.ForPortionOf)
 		}
 		for _, item := range n.SetList {
 			if item != nil {

--- a/mariadb/catalog/application_time_test.go
+++ b/mariadb/catalog/application_time_test.go
@@ -18,6 +18,24 @@ func TestApplicationTimePeriodCatalog(t *testing.T) {
 	}
 }
 
+// TestForPortionOfAccepted: omni accepts FOR PORTION OF UPDATE/DELETE. DML is
+// parsed and skipped (omni does not catalog-validate DML references), so there
+// is no 4156 here — matching how omni treats all DML.
+func TestForPortionOfAccepted(t *testing.T) {
+	c := New()
+	c.Exec("CREATE DATABASE test", nil)
+	c.SetCurrentDatabase("test")
+	for _, sql := range []string{
+		"UPDATE t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01' SET id = 1",
+		"DELETE FROM t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01'",
+	} {
+		r, _ := c.Exec(sql, &ExecOptions{ContinueOnError: true})
+		if r[0].Error != nil {
+			t.Errorf("%q: %v", sql, r[0].Error)
+		}
+	}
+}
+
 // TestApplicationTimePeriodValidation pins the malformed-CREATE error codes,
 // grounded vs mariadb:11.8.8.
 func TestApplicationTimePeriodValidation(t *testing.T) {

--- a/mariadb/catalog/container_reserved_kw_test.go
+++ b/mariadb/catalog/container_reserved_kw_test.go
@@ -8,6 +8,17 @@ import (
 	mysqlparser "github.com/bytebase/omni/mariadb/parser"
 )
 
+// mariaDBReservedNotInMySQL lists keywords omni reserves because MariaDB
+// reserves them, but the MySQL 8.0 container oracle does not — so MySQL accepts
+// them as names while omni correctly rejects them. These are MariaDB-vs-MySQL
+// reserved-word differences, not omni bugs, so they are excluded from the
+// mismatch report. Grounded vs mariadb:11.8.8 (SELECT 1 AS <kw>,
+// CREATE INDEX <kw> ON …, SELECT … <kw> are all 1064).
+var mariaDBReservedNotInMySQL = map[string]bool{
+	"PORTION":   true, // FOR PORTION OF (application-time DML)
+	"RETURNING": true, // INSERT / DELETE … RETURNING
+}
+
 // TestContainer_ReservedKeywordAcceptance systematically tests whether omni
 // and MySQL 8.0 agree on which reserved keywords are accepted in various
 // syntactic "name" positions. A mismatch (MySQL accepts, omni rejects)
@@ -114,7 +125,7 @@ func TestContainer_ReservedKeywordAcceptance(t *testing.T) {
 				ctrOK := ctrErr == nil
 				omniOK := omniErr == nil
 
-				if ctrOK && !omniOK {
+				if ctrOK && !omniOK && !mariaDBReservedNotInMySQL[strings.ToUpper(kw)] {
 					mismatches = append(mismatches, fmt.Sprintf(
 						"  %s: MySQL accepts, omni rejects — %v", kw, omniErr))
 				}

--- a/mariadb/parser/application_time_test.go
+++ b/mariadb/parser/application_time_test.go
@@ -146,3 +146,30 @@ func TestForPortionOfReject(t *testing.T) {
 		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
 	}
 }
+
+// TestForPortionOfAliasPosition: the table alias goes AFTER FOR PORTION OF for
+// UPDATE (the target before the clause must be a bare base table — no alias, no
+// join) but BEFORE it for DELETE. Grounded vs mariadb:11.8.8.
+func TestForPortionOfAliasPosition(t *testing.T) {
+	const p = "FROM '2020-01-01' TO '2021-01-01'"
+	for _, sql := range []string{
+		"UPDATE t FOR PORTION OF app_time " + p + " AS x SET x.id = 1", // UPDATE alias after (AS)
+		"UPDATE t FOR PORTION OF app_time " + p + " x SET x.id = 1",    // UPDATE alias after (implicit)
+		"DELETE FROM t AS x FOR PORTION OF app_time " + p,              // DELETE alias before
+	} {
+		t.Run("ok/"+sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+	for _, sql := range []string{
+		"UPDATE t AS x FOR PORTION OF app_time " + p + " SET x.id = 1",                  // UPDATE alias before (AS)
+		"UPDATE t x FOR PORTION OF app_time " + p + " SET x.id = 1",                     // UPDATE alias before (implicit)
+		"UPDATE t JOIN u ON t.id = u.id FOR PORTION OF app_time " + p + " SET t.id = 1", // joined target
+		"DELETE FROM t FOR PORTION OF app_time " + p + " AS x",                          // DELETE alias after
+	} {
+		t.Run("reject/"+sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+	// The alias after the clause is captured on the target table.
+	u := parseSeqStmt[*ast.UpdateStmt](t, "UPDATE t FOR PORTION OF app_time "+p+" AS x SET x.id = 1")
+	if tref, ok := u.Tables[0].(*ast.TableRef); !ok || tref.Alias != "x" || u.ForPortionOf == nil {
+		t.Fatalf("alias not captured after clause: %+v", u.Tables[0])
+	}
+}

--- a/mariadb/parser/application_time_test.go
+++ b/mariadb/parser/application_time_test.go
@@ -1,6 +1,11 @@
 package parser
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	ast "github.com/bytebase/omni/mariadb/ast"
+)
 
 // TestApplicationTimePeriodCreate covers CREATE TABLE with a named (application-
 // time) PERIOD FOR <name> (start, end) — container-verified accepted by
@@ -100,4 +105,44 @@ func TestWithoutOverlapsQuotedKeywordReject(t *testing.T) {
 	sql := "CREATE TABLE t (id INT, s DATE, e DATE, PERIOD FOR app_time(s, e), " +
 		"UNIQUE (id, app_time WITHOUT " + bt + "OVERLAPS" + bt + "))"
 	ParseExpectError(t, sql)
+}
+
+// TestForPortionOf covers the application-time FOR PORTION OF <period> FROM x TO y
+// clause on UPDATE / DELETE — container-verified accepted by mariadb:11.8.8.
+func TestForPortionOf(t *testing.T) {
+	for _, sql := range []string{
+		"UPDATE t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01' SET id = 1",
+		"DELETE FROM t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01'",
+		// Non-reserved keyword period names are valid.
+		"UPDATE t FOR PORTION OF history FROM '2020-01-01' TO '2021-01-01' SET id = 1",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
+// TestForPortionOfAST: the period name and FROM/TO bounds are captured.
+func TestForPortionOfAST(t *testing.T) {
+	u := parseSeqStmt[*ast.UpdateStmt](t, "UPDATE t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01' SET id = 1")
+	if u.ForPortionOf == nil || u.ForPortionOf.PeriodName != "app_time" || u.ForPortionOf.From == nil || u.ForPortionOf.To == nil {
+		t.Fatalf("UPDATE ForPortionOf = %+v", u.ForPortionOf)
+	}
+	if got := ast.NodeToString(u); !strings.Contains(got, ":for_portion_of {FOR_PORTION_OF :period app_time") {
+		t.Errorf("NodeToString missing for_portion_of:\n%s", got)
+	}
+	d := parseSeqStmt[*ast.DeleteStmt](t, "DELETE FROM t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01'")
+	if d.ForPortionOf == nil || d.ForPortionOf.PeriodName != "app_time" {
+		t.Fatalf("DELETE ForPortionOf = %+v", d.ForPortionOf)
+	}
+}
+
+// TestForPortionOfReject: SYSTEM_TIME is not a valid FOR PORTION OF period, and
+// PORTION must be the keyword (a quoted `PORTION` does not match) — 1064 vs 11.8.8.
+func TestForPortionOfReject(t *testing.T) {
+	for _, sql := range []string{
+		"UPDATE t FOR PORTION OF SYSTEM_TIME FROM '2020-01-01' TO '2021-01-01' SET id = 1",
+		"DELETE FROM t FOR PORTION OF SYSTEM_TIME FROM '2020-01-01' TO '2021-01-01'",
+		"UPDATE t FOR `PORTION` OF app_time FROM '2020-01-01' TO '2021-01-01' SET id = 1",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
 }

--- a/mariadb/parser/application_time_test.go
+++ b/mariadb/parser/application_time_test.go
@@ -147,15 +147,35 @@ func TestForPortionOfReject(t *testing.T) {
 	}
 }
 
+// TestPortionReserved: PORTION is a reserved word in MariaDB 11.8.8 — usable as
+// an identifier (alias, table name, period name) only when quoted.
+func TestPortionReserved(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1 AS portion",
+		"CREATE TABLE portion (id INT)",
+		"CREATE TABLE t (s DATE, e DATE, PERIOD FOR portion(s, e))",
+	} {
+		t.Run("reject/"+sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+	for _, sql := range []string{
+		"SELECT 1 AS `portion`",
+		"CREATE TABLE `portion` (id INT)",
+	} {
+		t.Run("ok/"+sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
 // TestForPortionOfAliasPosition: the table alias goes AFTER FOR PORTION OF for
 // UPDATE (the target before the clause must be a bare base table — no alias, no
 // join) but BEFORE it for DELETE. Grounded vs mariadb:11.8.8.
 func TestForPortionOfAliasPosition(t *testing.T) {
 	const p = "FROM '2020-01-01' TO '2021-01-01'"
 	for _, sql := range []string{
-		"UPDATE t FOR PORTION OF app_time " + p + " AS x SET x.id = 1", // UPDATE alias after (AS)
-		"UPDATE t FOR PORTION OF app_time " + p + " x SET x.id = 1",    // UPDATE alias after (implicit)
-		"DELETE FROM t AS x FOR PORTION OF app_time " + p,              // DELETE alias before
+		"UPDATE t FOR PORTION OF app_time " + p + " AS x SET x.id = 1",             // UPDATE alias after (AS)
+		"UPDATE t FOR PORTION OF app_time " + p + " x SET x.id = 1",                // UPDATE alias after (implicit)
+		"UPDATE t FOR PORTION OF app_time " + p + " history SET history.id = 3",    // non-reserved keyword alias (implicit)
+		"UPDATE t FOR PORTION OF app_time " + p + " AS history SET history.id = 3", // non-reserved keyword alias (AS)
+		"DELETE FROM t AS x FOR PORTION OF app_time " + p,                          // DELETE alias before
 	} {
 		t.Run("ok/"+sql, func(t *testing.T) { ParseAndCheck(t, sql) })
 	}

--- a/mariadb/parser/expr.go
+++ b/mariadb/parser/expr.go
@@ -1167,6 +1167,30 @@ func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
 		return nil, p.syntaxErrorAtCur()
 	}
 
+	// A comma after the first expression makes this a row constructor:
+	// `(expr, expr, ...)` with >= 2 elements (e.g. `(a, b) IN ((1, 2))`,
+	// keyset `(a, b) > (?, ?)`). A single `(expr)` stays a ParenExpr; empty
+	// parens and a trailing comma remain syntax errors, matching MariaDB.
+	if p.cur.Type == ',' {
+		row := &nodes.RowExpr{Loc: nodes.Loc{Start: start}, Items: []nodes.ExprNode{expr}}
+		for p.cur.Type == ',' {
+			p.advance() // consume ','
+			item, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			if item == nil {
+				return nil, p.syntaxErrorAtCur()
+			}
+			row.Items = append(row.Items, item)
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		row.Loc.End = p.pos()
+		return row, nil
+	}
+
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}

--- a/mariadb/parser/lexer.go
+++ b/mariadb/parser/lexer.go
@@ -559,6 +559,7 @@ const (
 	kwDAY
 	kwHISTORY
 	kwOVERLAPS
+	kwPORTION
 	kwREUSE
 	kwOPTIONAL
 	kwX509
@@ -1404,6 +1405,7 @@ var keywords = map[string]int{
 	"day":                 kwDAY,
 	"history":             kwHISTORY,
 	"overlaps":            kwOVERLAPS,
+	"portion":             kwPORTION,
 	"reuse":               kwREUSE,
 	"optional":            kwOPTIONAL,
 	"x509":                kwX509,

--- a/mariadb/parser/name.go
+++ b/mariadb/parser/name.go
@@ -233,7 +233,7 @@ var keywordCategories = map[int]keywordCategory{
 	kwDAY:                kwCatUnambiguous,
 	kwHISTORY:            kwCatUnambiguous,
 	kwOVERLAPS:           kwCatUnambiguous,
-	kwPORTION:            kwCatUnambiguous,
+	kwPORTION:            kwCatReserved,
 	kwREUSE:              kwCatUnambiguous,
 	kwOPTIONAL:           kwCatUnambiguous,
 	kwX509:               kwCatUnambiguous,

--- a/mariadb/parser/name.go
+++ b/mariadb/parser/name.go
@@ -233,6 +233,7 @@ var keywordCategories = map[int]keywordCategory{
 	kwDAY:                kwCatUnambiguous,
 	kwHISTORY:            kwCatUnambiguous,
 	kwOVERLAPS:           kwCatUnambiguous,
+	kwPORTION:            kwCatUnambiguous,
 	kwREUSE:              kwCatUnambiguous,
 	kwOPTIONAL:           kwCatUnambiguous,
 	kwX509:               kwCatUnambiguous,

--- a/mariadb/parser/row_constructor_test.go
+++ b/mariadb/parser/row_constructor_test.go
@@ -70,6 +70,22 @@ func TestParseRowConstructor_Reject(t *testing.T) {
 	}
 }
 
+// TestParseRowConstructor_RowKeyword pins the ROW(...) keyword forms. The
+// equality form already parsed; ROW(...) IN (list-of-rows) is newly enabled
+// because each parenthesized list element is now a row constructor.
+func TestParseRowConstructor_RowKeyword(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM t WHERE ROW(a, b) = ROW(1, 2)",
+		"SELECT * FROM t WHERE ROW(a, b) IN ((1, 2), (3, 4))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Errorf("Parse(%q): unexpected parse error: %v", sql, err)
+			}
+		})
+	}
+}
+
 // TestParseRowConstructor_InStatements covers the realized-value shapes the
 // SQL editor sees: composite-key IN, tuple comparison, keyset pagination, and
 // row subqueries. All are valid MariaDB 11.8.

--- a/mariadb/parser/row_constructor_test.go
+++ b/mariadb/parser/row_constructor_test.go
@@ -1,0 +1,91 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mariadb/ast"
+)
+
+// TestParseRowConstructor_Bare tests the parenthesized row constructor
+// `(expr, expr, ...)` as a primary expression (>= 2 elements).
+func TestParseRowConstructor_Bare(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"(1, 2)", "{ROW :loc 0 :items ({INT_LIT :val 1 :loc 1} {INT_LIT :val 2 :loc 4})}"},
+		{"(1, 2, 3)", "{ROW :loc 0 :items ({INT_LIT :val 1 :loc 1} {INT_LIT :val 2 :loc 4} {INT_LIT :val 3 :loc 7})}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ast.NodeToString(parseExpr(t, tt.input))
+			if got != tt.want {
+				t.Errorf("parseExpr(%q):\n  got:  %s\n  want: %s", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseRowConstructor_Nested verifies nested row constructors recurse into
+// RowExpr (composite-key list elements: `((1,2),(3,4))`).
+func TestParseRowConstructor_Nested(t *testing.T) {
+	expr := parseExpr(t, "((1, 2), (3, 4))")
+	row, ok := expr.(*ast.RowExpr)
+	if !ok {
+		t.Fatalf("expected *ast.RowExpr, got %T", expr)
+	}
+	if len(row.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(row.Items))
+	}
+	for i, item := range row.Items {
+		if _, ok := item.(*ast.RowExpr); !ok {
+			t.Errorf("item %d: expected *ast.RowExpr, got %T", i, item)
+		}
+	}
+}
+
+// TestParseRowConstructor_SingleStaysParen guards the boundary: a single
+// parenthesized expression is a ParenExpr, never a RowExpr.
+func TestParseRowConstructor_SingleStaysParen(t *testing.T) {
+	got := ast.NodeToString(parseExpr(t, "(1)"))
+	want := "{PAREN :loc 0 :expr {INT_LIT :val 1 :loc 1}}"
+	if got != want {
+		t.Errorf("parseExpr(\"(1)\"):\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestParseRowConstructor_Reject guards the reject space: empty parens and
+// trailing commas must stay parse errors (MariaDB 11.8 rejects all three).
+func TestParseRowConstructor_Reject(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT ()",
+		"SELECT (1,)",
+		"SELECT (1, 2,)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Errorf("Parse(%q): expected parse error, got nil", sql)
+			}
+		})
+	}
+}
+
+// TestParseRowConstructor_InStatements covers the realized-value shapes the
+// SQL editor sees: composite-key IN, tuple comparison, keyset pagination, and
+// row subqueries. All are valid MariaDB 11.8.
+func TestParseRowConstructor_InStatements(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM t WHERE (a, b) = (1, 2)",
+		"SELECT * FROM t WHERE (a, b) IN ((1, 2), (3, 4))",
+		"SELECT * FROM t WHERE (a, b) > (1, 2)",
+		"SELECT * FROM t WHERE (a, b) NOT IN ((1, 2))",
+		"SELECT * FROM t WHERE (a, b) <=> (1, 2)",
+		"SELECT * FROM t WHERE (a, b) IN (SELECT a, b FROM u)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Errorf("Parse(%q): unexpected parse error: %v", sql, err)
+			}
+		})
+	}
+}

--- a/mariadb/parser/update_delete.go
+++ b/mariadb/parser/update_delete.go
@@ -192,7 +192,7 @@ func singleBaseTable(tables []nodes.TableExpr) *nodes.TableRef {
 // parseOptionalTableAlias consumes an optional [AS] alias and records it on tref.
 func (p *Parser) parseOptionalTableAlias(tref *nodes.TableRef) error {
 	_, hasAS := p.match(kwAS)
-	if !hasAS && p.cur.Type != tokIDENT {
+	if !hasAS && !p.isIdentToken() {
 		return nil
 	}
 	alias, _, err := p.parseIdent()

--- a/mariadb/parser/update_delete.go
+++ b/mariadb/parser/update_delete.go
@@ -52,13 +52,22 @@ func (p *Parser) parseUpdateStmt() (*nodes.UpdateStmt, error) {
 	}
 	stmt.Tables = tables
 
-	// FOR PORTION OF <period> FROM x TO y (application-time, single-table only).
-	if len(stmt.Tables) == 1 && p.cur.Type == kwFOR {
-		fp, err := p.parseForPortionOf()
-		if err != nil {
-			return nil, err
+	// FOR PORTION OF <period> FROM x TO y (application-time). Valid only on a
+	// single bare base table (no join, no alias before the clause); for UPDATE
+	// the alias, if any, follows the clause:
+	//   UPDATE t FOR PORTION OF p FROM x TO y [AS] alias SET ...
+	if p.cur.Type == kwFOR {
+		if tref := singleBaseTable(stmt.Tables); tref != nil && tref.Alias == "" {
+			fp, err := p.parseForPortionOf()
+			if err != nil {
+				return nil, err
+			}
+			stmt.ForPortionOf = fp
+			if err := p.parseOptionalTableAlias(tref); err != nil {
+				return nil, err
+			}
 		}
-		stmt.ForPortionOf = fp
+		// Otherwise the misplaced FOR is rejected by expect(kwSET) below (1064).
 	}
 
 	// SET clause (required)
@@ -168,6 +177,31 @@ func (p *Parser) parseForPortionOf() (*nodes.ForPortionOf, error) {
 		From:       from,
 		To:         to,
 	}, nil
+}
+
+// singleBaseTable returns the table reference when tables is a single bare base
+// table (not a join or comma-list), else nil.
+func singleBaseTable(tables []nodes.TableExpr) *nodes.TableRef {
+	if len(tables) != 1 {
+		return nil
+	}
+	tref, _ := tables[0].(*nodes.TableRef)
+	return tref
+}
+
+// parseOptionalTableAlias consumes an optional [AS] alias and records it on tref.
+func (p *Parser) parseOptionalTableAlias(tref *nodes.TableRef) error {
+	_, hasAS := p.match(kwAS)
+	if !hasAS && p.cur.Type != tokIDENT {
+		return nil
+	}
+	alias, _, err := p.parseIdent()
+	if err != nil {
+		return err
+	}
+	tref.Alias = alias
+	tref.Loc.End = p.pos()
+	return nil
 }
 
 // parseDeleteStmt parses a DELETE statement.

--- a/mariadb/parser/update_delete.go
+++ b/mariadb/parser/update_delete.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	nodes "github.com/bytebase/omni/mariadb/ast"
 )
 
@@ -49,6 +51,15 @@ func (p *Parser) parseUpdateStmt() (*nodes.UpdateStmt, error) {
 		return nil, err
 	}
 	stmt.Tables = tables
+
+	// FOR PORTION OF <period> FROM x TO y (application-time, single-table only).
+	if len(stmt.Tables) == 1 && p.cur.Type == kwFOR {
+		fp, err := p.parseForPortionOf()
+		if err != nil {
+			return nil, err
+		}
+		stmt.ForPortionOf = fp
+	}
 
 	// SET clause (required)
 	if _, err := p.expect(kwSET); err != nil {
@@ -106,6 +117,57 @@ func (p *Parser) parseUpdateStmt() (*nodes.UpdateStmt, error) {
 
 	stmt.Loc.End = p.pos()
 	return stmt, nil
+}
+
+// parseForPortionOf parses the application-time clause
+//
+//	FOR PORTION OF <period> FROM <expr> TO <expr>
+//
+// on a single-table UPDATE / DELETE. FOR is the current token. The period name
+// follows the identifier rule (non-reserved keywords allowed); SYSTEM_TIME is
+// rejected (1064), matching MariaDB. PORTION is a non-reserved keyword.
+func (p *Parser) parseForPortionOf() (*nodes.ForPortionOf, error) {
+	start := p.pos()
+	p.advance() // FOR
+	if _, err := p.expect(kwPORTION); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwOF); err != nil {
+		return nil, err
+	}
+	name, _, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	if strings.EqualFold(name, "SYSTEM_TIME") {
+		return nil, p.syntaxErrorAtCur()
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	from, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if !p.collectMode() && from == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+	if _, err := p.expect(kwTO); err != nil {
+		return nil, err
+	}
+	to, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if !p.collectMode() && to == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+	return &nodes.ForPortionOf{
+		Loc:        nodes.Loc{Start: start, End: p.pos()},
+		PeriodName: name,
+		From:       from,
+		To:         to,
+	}, nil
 }
 
 // parseDeleteStmt parses a DELETE statement.
@@ -221,6 +283,15 @@ func (p *Parser) parseDeleteStmt() (*nodes.DeleteStmt, error) {
 			return nil, err
 		}
 		stmt.Using = using
+	}
+
+	// FOR PORTION OF <period> FROM x TO y (application-time, single-table only).
+	if len(stmt.Tables) == 1 && len(stmt.Using) == 0 && p.cur.Type == kwFOR {
+		fp, err := p.parseForPortionOf()
+		if err != nil {
+			return nil, err
+		}
+		stmt.ForPortionOf = fp
 	}
 
 	// WHERE clause (optional)


### PR DESCRIPTION
## What & why

`(a, b)` with ≥2 elements now parses as a row constructor (`RowExpr`). These are common in real editor SQL and were being false-flagged by MariaDB **Diagnose** (which runs on omni/mariadb's parser):

| shape | example |
|---|---|
| tuple comparison | `(a, b) = (1, 2)` |
| composite-key IN | `(a, b) IN ((1, 2), (3, 4))` |
| keyset pagination | `(a, b) > (?, ?)` |
| row subquery | `(a, b) IN (SELECT a, b FROM u)` |

## The change

One branch in `parseParenExpr`: a comma after the first expression collects a `RowExpr` (mirrors omni/pg's `parseParenExprOrRow`). A single `(expr)` stays a `ParenExpr`; empty parens and trailing commas remain syntax errors. **Reuses the existing `RowExpr` node** (already emitted by `ROW(...)`), so `deparse`/`walk`/`resolver` need no change.

## Verification

- TDD RED→GREEN: `row_constructor_test.go` (accept matrix, nested, single-stays-paren, reject space, realized-value statement shapes).
- Full `./mariadb/...` suite green (parser, catalog, deparse, validate, completion) — no regressions.
- **Adversarial accept/reject sweep vs `mariadb:11.8.8`**: 16 AGREE_ACCEPT / 8 AGREE_REJECT / **0 OVER / 0 GAP**. Malformed variants (`()`, `(1,)`, `(,1)`, trailing comma in IN-list) stay rejected; arity-mismatch / row-vs-scalar correctly parse-accept then semantic-error (1241), matching the engine.

## Follow-ups (NOT in this PR — tracked)

- **Span analyzer**: omni's `catalog/analyzeExpr` has no `RowExpr` case → returns `"unsupported expression type in analyzer"`. Pre-existing (already hit by `ROW(...)` today) and identical in omni/mysql. Not on any bytebase consumer path for MariaDB (the mariadb plugin is parse-only/Diagnose; masking runs a non-omni engine), so this rides the query-span integration lane when that activates (~15 lines: `RowExprQ` builder + `exprContainsAggregate` recursion; the IR type and its deparse are already scaffolded).
- **MySQL parser mirror**: omni/mysql has the byte-identical parser gap — mirror there.