### PR TITLE
fix(mariadb): reject FOR SYSTEM_TIME + FOR PORTION OF on one DML target

### DIFF
--- a/mariadb/parser/application_time_test.go
+++ b/mariadb/parser/application_time_test.go
@@ -147,6 +147,26 @@ func TestForPortionOfReject(t *testing.T) {
 	}
 }
 
+// TestForPortionOfSystemTimeReject: a DML target may carry FOR SYSTEM_TIME (time
+// travel) or FOR PORTION OF (application-time), never both on the same table —
+// MariaDB 11.8.8 rejects the combination with 1064. The isolated clauses stay
+// valid (the prune is surgical).
+func TestForPortionOfSystemTimeReject(t *testing.T) {
+	for _, sql := range []string{
+		"UPDATE t FOR SYSTEM_TIME AS OF TIMESTAMP '2020-01-01 00:00:00' FOR PORTION OF app_time FROM '2020-06-01' TO '2020-07-01' SET id = 3",
+		"UPDATE t FOR PORTION OF app_time FROM '2020-06-01' TO '2020-07-01' FOR SYSTEM_TIME AS OF TIMESTAMP '2020-01-01 00:00:00' SET id = 3",
+		"DELETE FROM t FOR SYSTEM_TIME AS OF TIMESTAMP '2020-01-01 00:00:00' FOR PORTION OF app_time FROM '2020-06-01' TO '2020-07-01'",
+	} {
+		t.Run("reject/"+sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+	for _, sql := range []string{
+		"UPDATE t FOR SYSTEM_TIME AS OF TIMESTAMP '2020-01-01 00:00:00' SET id = 3",
+		"UPDATE t FOR PORTION OF app_time FROM '2020-06-01' TO '2020-07-01' SET id = 3",
+	} {
+		t.Run("accept/"+sql, func(t *testing.T) { ParseAndCheck(t, sql) })
+	}
+}
+
 // TestPortionReserved: PORTION is a reserved word in MariaDB 11.8.8 — usable as
 // an identifier (alias, table name, period name) only when quoted.
 func TestPortionReserved(t *testing.T) {

--- a/mariadb/parser/update_delete.go
+++ b/mariadb/parser/update_delete.go
@@ -57,7 +57,10 @@ func (p *Parser) parseUpdateStmt() (*nodes.UpdateStmt, error) {
 	// the alias, if any, follows the clause:
 	//   UPDATE t FOR PORTION OF p FROM x TO y [AS] alias SET ...
 	if p.cur.Type == kwFOR {
-		if tref := singleBaseTable(stmt.Tables); tref != nil && tref.Alias == "" {
+		// A FOR SYSTEM_TIME-bearing target cannot also take FOR PORTION OF
+		// (MariaDB 11.8.8 rejects the combination); leave the trailing FOR to
+		// the expect(kwSET) below, which reports 1064.
+		if tref := singleBaseTable(stmt.Tables); tref != nil && tref.Alias == "" && tref.SystemTime == nil {
 			fp, err := p.parseForPortionOf()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Bug (P2 over-accept, found in review of the #328 application-time work)

MariaDB 11.8.8 rejects a DML target that carries **both** `FOR SYSTEM_TIME` (time travel) and `FOR PORTION OF` (application-time) with a 1064 syntax error. omni accepted the forward-order UPDATE shape:

```sql
UPDATE t FOR SYSTEM_TIME AS OF TIMESTAMP '2020-01-01 00:00:00'
         FOR PORTION OF app_time FROM '2020-06-01' TO '2020-07-01'
SET id = 3;   -- MariaDB: 1064; omni: accepted (the bug)
```

Root cause: on the UPDATE path, `FOR SYSTEM_TIME` is consumed into `TableRef.SystemTime` during `parseTableReferenceList`, after which the second `FOR` reaches the `FOR PORTION OF` branch and `singleBaseTable()` still treats the (now temporal) `TableRef` as a valid single bare base table.

## Fix

Require `tref.SystemTime == nil` before parsing `FOR PORTION OF` (`update_delete.go`). The trailing `FOR` then falls to `expect(kwSET)` → 1064, matching the engine. **DELETE needs no change** — its target parse never attaches `SystemTime`, so a leading `FOR SYSTEM_TIME` hits `parseForPortionOf` and is rejected (verified).

## Verification (vs `mariadb:11.8.8`)

- TDD RED→GREEN: `TestForPortionOfSystemTimeReject` — forward-order UPDATE was RED (accepted), now rejects; reversed-order and DELETE combinations already rejected (guards); isolated `FOR SYSTEM_TIME` / `FOR PORTION OF` clauses still parse (accept guards).
- Container parity sweep: the forward-order over-accept flips OVER → AGREE_REJECT; **OVER=0**, isolated forms AGREE_ACCEPT.
- Full `./mariadb/...` suite green.

Pre-existing in #328; independent of the row-constructor work (#330).