### PR TITLE
feat(mariadb): PERSISTENT generated columns + generic table options

### DIFF
--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -1469,16 +1469,11 @@ func (p *Parser) parseTableOption() (*nodes.TableOption, bool, error) {
 	// which also guards against consuming a trailing clause.
 	if p.cur.Type == tokIDENT && p.peekNext().Type == '=' {
 		optName := p.cur.Str
-		p.advance() // option name
-		p.advance() // '='
-		valStart := p.pos()
-		val, err := p.consumeOptionValue()
+		p.advance()                        // option name
+		p.advance()                        // '='
+		val, err := p.consumeOptionValue() // errors if no value token follows
 		if err != nil {
 			return nil, false, err
-		}
-		if p.pos() == valStart {
-			// '=' with no value token — MariaDB rejects with 1064.
-			return nil, false, p.syntaxErrorAtCur()
 		}
 		return &nodes.TableOption{Loc: nodes.Loc{Start: start, End: p.pos()}, Name: optName, Value: val}, true, nil
 	}
@@ -1509,7 +1504,9 @@ func (p *Parser) consumeOptionValue() (string, error) {
 			}
 			return name, nil
 		}
-		return "", nil
+		// No value token (e.g. `ENGINE=` at end of statement). MariaDB rejects an
+		// option with no value (1064); do not silently return an empty value.
+		return "", p.syntaxErrorAtCur()
 	}
 }
 

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -855,7 +855,11 @@ func (p *Parser) matchUnquotedKeyword(kw string) bool {
 	if p.cur.Type != tokIDENT || !strings.EqualFold(p.cur.Str, kw) {
 		return false
 	}
-	if p.cur.Loc < len(p.lexer.input) && p.lexer.input[p.cur.Loc] == '`' {
+	// p.cur.Loc is absolute (includes baseOffset); p.lexer.input is the current
+	// split segment, so subtract baseOffset before indexing (cf. the offset
+	// helpers in parser.go). A leading backtick means the keyword was quoted.
+	off := p.cur.Loc - p.lexer.baseOffset
+	if off >= 0 && off < len(p.lexer.input) && p.lexer.input[off] == '`' {
 		return false
 	}
 	p.advance()

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -847,6 +847,21 @@ func (p *Parser) parseReferenceAction() nodes.ReferenceAction {
 	return nodes.RefActNone
 }
 
+// matchUnquotedKeyword consumes the current token when it is an UNQUOTED
+// identifier equal (case-insensitively) to kw. A backtick-quoted identifier
+// (e.g. `PERSISTENT`) is a quoted identifier, not the keyword, and must not match
+// — MariaDB rejects a quoted keyword in a keyword position (1064).
+func (p *Parser) matchUnquotedKeyword(kw string) bool {
+	if p.cur.Type != tokIDENT || !strings.EqualFold(p.cur.Str, kw) {
+		return false
+	}
+	if p.cur.Loc < len(p.lexer.input) && p.lexer.input[p.cur.Loc] == '`' {
+		return false
+	}
+	p.advance()
+	return true
+}
+
 // parseGeneratedColumn parses a GENERATED ALWAYS AS (expr) [VIRTUAL|STORED].
 func (p *Parser) parseGeneratedColumn() (*nodes.GeneratedColumn, error) {
 	start := p.pos()
@@ -903,9 +918,8 @@ func (p *Parser) parseGeneratedColumn() (*nodes.GeneratedColumn, error) {
 		gen.Stored = false
 	} else if _, ok := p.match(kwSTORED); ok {
 		gen.Stored = true
-	} else if p.cur.Type == tokIDENT && strings.EqualFold(p.cur.Str, "PERSISTENT") {
+	} else if p.matchUnquotedKeyword("PERSISTENT") {
 		// PERSISTENT is MariaDB's non-reserved synonym for STORED.
-		p.advance()
 		gen.Stored = true
 	}
 
@@ -951,9 +965,8 @@ func (p *Parser) parseGeneratedColumnShorthand() (*nodes.GeneratedColumn, error)
 		gen.Stored = false
 	} else if _, ok := p.match(kwSTORED); ok {
 		gen.Stored = true
-	} else if p.cur.Type == tokIDENT && strings.EqualFold(p.cur.Str, "PERSISTENT") {
+	} else if p.matchUnquotedKeyword("PERSISTENT") {
 		// PERSISTENT is MariaDB's non-reserved synonym for STORED.
-		p.advance()
 		gen.Stored = true
 	}
 
@@ -1458,9 +1471,14 @@ func (p *Parser) parseTableOption() (*nodes.TableOption, bool, error) {
 		optName := p.cur.Str
 		p.advance() // option name
 		p.advance() // '='
+		valStart := p.pos()
 		val, err := p.consumeOptionValue()
 		if err != nil {
 			return nil, false, err
+		}
+		if p.pos() == valStart {
+			// '=' with no value token — MariaDB rejects with 1064.
+			return nil, false, p.syntaxErrorAtCur()
 		}
 		return &nodes.TableOption{Loc: nodes.Loc{Start: start, End: p.pos()}, Name: optName, Value: val}, true, nil
 	}

--- a/mariadb/parser/create_table.go
+++ b/mariadb/parser/create_table.go
@@ -903,6 +903,10 @@ func (p *Parser) parseGeneratedColumn() (*nodes.GeneratedColumn, error) {
 		gen.Stored = false
 	} else if _, ok := p.match(kwSTORED); ok {
 		gen.Stored = true
+	} else if p.cur.Type == tokIDENT && strings.EqualFold(p.cur.Str, "PERSISTENT") {
+		// PERSISTENT is MariaDB's non-reserved synonym for STORED.
+		p.advance()
+		gen.Stored = true
 	}
 
 	gen.Loc.End = p.pos()
@@ -946,6 +950,10 @@ func (p *Parser) parseGeneratedColumnShorthand() (*nodes.GeneratedColumn, error)
 	if _, ok := p.match(kwVIRTUAL); ok {
 		gen.Stored = false
 	} else if _, ok := p.match(kwSTORED); ok {
+		gen.Stored = true
+	} else if p.cur.Type == tokIDENT && strings.EqualFold(p.cur.Str, "PERSISTENT") {
+		// PERSISTENT is MariaDB's non-reserved synonym for STORED.
+		p.advance()
 		gen.Stored = true
 	}
 
@@ -1433,6 +1441,23 @@ func (p *Parser) parseTableOption() (*nodes.TableOption, bool, error) {
 		optName := p.cur.Str
 		p.advance()
 		p.match('=')
+		val, err := p.consumeOptionValue()
+		if err != nil {
+			return nil, false, err
+		}
+		return &nodes.TableOption{Loc: nodes.Loc{Start: start, End: p.pos()}, Name: optName, Value: val}, true, nil
+	}
+
+	// Generic MariaDB table option: `IDENT = value`. MariaDB's parser accepts an
+	// unknown option name and rejects it semantically (ER_UNKNOWN_OPTION 1911),
+	// not as a syntax error — so a parse-only check accepts the shape. This covers
+	// PAGE_COMPRESSED, PAGE_COMPRESSION_LEVEL, TRANSACTIONAL, PAGE_CHECKSUM, and
+	// any future plain option. The '=' is required (a bare option name is 1064),
+	// which also guards against consuming a trailing clause.
+	if p.cur.Type == tokIDENT && p.peekNext().Type == '=' {
+		optName := p.cur.Str
+		p.advance() // option name
+		p.advance() // '='
 		val, err := p.consumeOptionValue()
 		if err != nil {
 			return nil, false, err

--- a/mariadb/parser/storage_options_test.go
+++ b/mariadb/parser/storage_options_test.go
@@ -79,6 +79,22 @@ func TestTableOptionNoValueReject(t *testing.T) {
 	}
 }
 
+// TestPersistentQuotedRejectMultiStatement: the quoting guard must hold when the
+// statement is not first in the input — token Loc is absolute (includes
+// baseOffset) while lexer.input is the segment, so the guard must subtract
+// baseOffset before indexing. Regression for the absolute-vs-segment bug.
+func TestPersistentQuotedRejectMultiStatement(t *testing.T) {
+	ParseExpectError(t, "CREATE TABLE ok1 (a INT); CREATE TABLE t (a INT, b INT AS (a+1) `PERSISTENT`)")
+}
+
+// TestPersistentUnquotedAcceptMultiStatement: unquoted PERSISTENT in a non-first
+// statement must still parse (the baseOffset fix must not reject the valid case).
+func TestPersistentUnquotedAcceptMultiStatement(t *testing.T) {
+	if _, err := Parse("CREATE TABLE ok1 (a INT); CREATE TABLE t (a INT, b INT AS (a+1) PERSISTENT)"); err != nil {
+		t.Errorf("unexpected parse error: %v", err)
+	}
+}
+
 // TestStructuredOptionNoValueReject: structured options that take a value
 // (ENGINE, ROW_FORMAT, KEY_BLOCK_SIZE, ...) also require it — `ENGINE=` with no
 // value is a syntax error (1064 vs MariaDB 11.8.8). consumeOptionValue must not

--- a/mariadb/parser/storage_options_test.go
+++ b/mariadb/parser/storage_options_test.go
@@ -55,6 +55,39 @@ func TestTableOptionMixedWithStructured(t *testing.T) {
 	}
 }
 
+// TestGeneratedColumnPersistentQuotedReject: backtick-quoted `PERSISTENT` is a
+// quoted identifier, not the keyword — MariaDB 11.8.8 rejects it (1064). (STORED
+// and VIRTUAL match the keyword token, so they were never affected.)
+func TestGeneratedColumnPersistentQuotedReject(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE t (a INT, b INT AS (a+1) `PERSISTENT`)",
+		"CREATE TABLE t (a INT, b INT GENERATED ALWAYS AS (a+1) `PERSISTENT`)",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
+// TestTableOptionNoValueReject: a generic option with `=` but no value token is
+// a syntax error (1064 vs MariaDB 11.8.8) — consumeOptionValue returns "" at
+// EOF/non-value, so the fallback must confirm a value was actually consumed.
+func TestTableOptionNoValueReject(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE t (a INT) PAGE_COMPRESSED=",
+		"CREATE TABLE t (a INT) FOOBAR=",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
+// TestTableOptionQuotedNameAccept: a backtick-quoted option NAME is a valid
+// quoted identifier to MariaDB's parser (validated semantically), so omni must
+// keep accepting it — the quoting guard belongs on the keyword, not the name.
+func TestTableOptionQuotedNameAccept(t *testing.T) {
+	if _, err := Parse("CREATE TABLE t (a INT) `PAGE_COMPRESSED`=1"); err != nil {
+		t.Errorf("unexpected parse error: %v", err)
+	}
+}
+
 // TestTableOptionBareReject: a bare option name without `= value` is a syntax
 // error (1064 vs MariaDB 11.8.8) — the real parse rule the generic fallback keeps.
 func TestTableOptionBareReject(t *testing.T) {

--- a/mariadb/parser/storage_options_test.go
+++ b/mariadb/parser/storage_options_test.go
@@ -79,6 +79,20 @@ func TestTableOptionNoValueReject(t *testing.T) {
 	}
 }
 
+// TestStructuredOptionNoValueReject: structured options that take a value
+// (ENGINE, ROW_FORMAT, KEY_BLOCK_SIZE, ...) also require it — `ENGINE=` with no
+// value is a syntax error (1064 vs MariaDB 11.8.8). consumeOptionValue must not
+// return success without consuming a value token.
+func TestStructuredOptionNoValueReject(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE t (a INT) ENGINE=",
+		"CREATE TABLE t (a INT) ROW_FORMAT=",
+		"CREATE TABLE t (a INT) KEY_BLOCK_SIZE=",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}
+
 // TestTableOptionQuotedNameAccept: a backtick-quoted option NAME is a valid
 // quoted identifier to MariaDB's parser (validated semantically), so omni must
 // keep accepting it — the quoting guard belongs on the keyword, not the name.

--- a/mariadb/parser/storage_options_test.go
+++ b/mariadb/parser/storage_options_test.go
@@ -1,0 +1,67 @@
+package parser
+
+import "testing"
+
+// TestGeneratedColumnPersistent: PERSISTENT is MariaDB's native synonym for
+// STORED (SHOW CREATE normalizes it to STORED), so it maps to Stored=true.
+func TestGeneratedColumnPersistent(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE t (a INT, b INT AS (a+1) PERSISTENT)",
+		"CREATE TABLE t (a INT, b INT GENERATED ALWAYS AS (a+1) PERSISTENT)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ct := parseCreateTable(t, sql)
+			col := ct.Columns[1]
+			if col.Generated == nil {
+				t.Fatalf("column b: expected a generated column")
+			}
+			if !col.Generated.Stored {
+				t.Errorf("PERSISTENT should map to Stored=true")
+			}
+		})
+	}
+}
+
+// TestGeneratedColumnPersistentAlter: PERSISTENT via ALTER ADD COLUMN (shared path).
+func TestGeneratedColumnPersistentAlter(t *testing.T) {
+	if _, err := Parse("ALTER TABLE t ADD COLUMN c INT AS (a+1) PERSISTENT"); err != nil {
+		t.Errorf("unexpected parse error: %v", err)
+	}
+}
+
+// TestMariaDBTableOptions: MariaDB's parser accepts any `IDENT = value` table
+// option (an unknown name is a semantic error 1911, not a parse error), so a
+// parse-only check must accept the shape. Covers the page/transactional family.
+func TestMariaDBTableOptions(t *testing.T) {
+	ct := parseCreateTable(t, "CREATE TABLE t (a INT) PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=5 TRANSACTIONAL=1 PAGE_CHECKSUM=1")
+	got := map[string]string{}
+	for _, o := range ct.Options {
+		got[o.Name] = o.Value
+	}
+	for _, name := range []string{"PAGE_COMPRESSED", "PAGE_COMPRESSION_LEVEL", "TRANSACTIONAL", "PAGE_CHECKSUM"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("missing table option %s (got %v)", name, got)
+		}
+	}
+	if got["PAGE_COMPRESSION_LEVEL"] != "5" {
+		t.Errorf("PAGE_COMPRESSION_LEVEL value: got %q, want \"5\"", got["PAGE_COMPRESSION_LEVEL"])
+	}
+}
+
+// TestTableOptionMixedWithStructured: generic options coexist with structured ones.
+func TestTableOptionMixedWithStructured(t *testing.T) {
+	if _, err := Parse("CREATE TABLE t (a INT) ENGINE=Aria PAGE_CHECKSUM=1 ROW_FORMAT=PAGE"); err != nil {
+		t.Errorf("unexpected parse error: %v", err)
+	}
+}
+
+// TestTableOptionBareReject: a bare option name without `= value` is a syntax
+// error (1064 vs MariaDB 11.8.8) — the real parse rule the generic fallback keeps.
+func TestTableOptionBareReject(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE TABLE t (a INT) PAGE_COMPRESSED",
+		"CREATE TABLE t (a INT) PAGE_COMPRESSED PAGE_CHECKSUM",
+	} {
+		t.Run(sql, func(t *testing.T) { ParseExpectError(t, sql) })
+	}
+}


### PR DESCRIPTION
Closes two common MariaDB CREATE TABLE Diagnose false-flags (BYT-9135). Both **reuse existing AST** — no new node/field, so deparse/walk/catalog are untouched.

## PERSISTENT generated columns
`b INT AS (a+1) PERSISTENT` is MariaDB's native synonym for `STORED` (SHOW CREATE normalizes it back to `STORED`, container-confirmed). Maps to the existing `GeneratedColumn.Stored=true` in both the `GENERATED ALWAYS` and shorthand `AS (...)` paths (non-reserved identifier match).

## Generic table options
MariaDB's parser accepts **any** `IDENT = value` table option and rejects an unknown *name* **semantically** (`ER_UNKNOWN_OPTION` 1911, SQLSTATE HY000) — not as a 1064 syntax error. omni's allowlist was therefore *stricter than MariaDB's own parser*, a false-flag risk for a parse-only tool. `parseTableOption`'s default now accepts a generic `IDENT '=' value` → `TableOption{Name,Value}`, covering `PAGE_COMPRESSED`, `PAGE_COMPRESSION_LEVEL`, `TRANSACTIONAL`, `PAGE_CHECKSUM` and future plain options in one shot. Structured cases (ENGINE, ROW_FORMAT, UNION=(…), …) are unchanged. The `=` is required, so a bare option name stays 1064 (and it guards against consuming a trailing clause).

## Verification (vs `mariadb:11.8.8`)
- TDD RED→GREEN: `storage_options_test.go` — PERSISTENT maps to `Stored=true` (AST asserted); the 4 page/transactional options captured; bare option / no-`=` → parse error.
- Adversarial sweep: 9 AGREE_ACCEPT / 4 AGREE_REJECT / **0 OVER / 0 GAP**. Unknown `FOOBAR=1` accepts (parse-parity with MariaDB's 1911 *semantic* reject); bare `PAGE_COMPRESSED`, `FOOBAR BAR` (no `=`) → 1064.
- Full `./mariadb/...` suite green.

## Deferred (separate PR)
Column `COMPRESSED` (`BLOB COMPRESSED [=zlib]`) — needs a **new `ColumnDef` field** (full deparse/walk/outfuncs/catalog checklist), so it's out of scope here.