### PR TITLE
feat(mysql/catalog): add LoadSDL order-tolerant SDL loader (mysql SDL vertical slice)

### DIFF
--- a/mysql/catalog/sdl.go
+++ b/mysql/catalog/sdl.go
@@ -1,0 +1,463 @@
+package catalog
+
+import (
+	"container/heap"
+	"fmt"
+
+	nodes "github.com/bytebase/omni/mysql/ast"
+	mysqlparser "github.com/bytebase/omni/mysql/parser"
+)
+
+// LoadSDL parses a declarative MySQL schema (SDL) and loads it into a new
+// Catalog order-tolerantly. Unlike LoadSQL — which applies statements in textual
+// order and therefore fails when an object references a not-yet-created object
+// (a view over a later table, an index/trigger declared ahead of its table) —
+// LoadSDL accepts a full target schema whose objects may reference each other
+// out of declaration order.
+//
+// SDL describes a desired end state, so only the constructive subset of DDL is
+// allowed: CREATE {DATABASE,TABLE,INDEX,VIEW,FUNCTION,PROCEDURE,TRIGGER,EVENT}
+// plus the session statements USE and SET. DML (INSERT/UPDATE/DELETE/SELECT),
+// destructive/mutating DDL (DROP, TRUNCATE, RENAME, ALTER) and the imperative
+// CREATE TABLE ... AS SELECT are rejected with a clear error.
+//
+// Pipeline: parse → validate → extractDeps → topoSort → execute (with
+// foreign_key_checks disabled and the per-statement current database restored).
+//
+// Order-tolerance is achieved the way MySQL itself loads a dump:
+//   - Foreign keys: validation is disabled for the whole load (foreign_key_checks
+//     off), so a forward FK reference never errors; the constraint is still
+//     recorded on the table. Because FK creation never requires the parent table
+//     to exist, foreign keys impose no ordering constraint and are deliberately
+//     left out of the dependency graph — including them would turn a valid
+//     circular-FK schema into a false "dependency cycle". This is the analog of
+//     PostgreSQL deferring FK constraints to post-creation ALTER TABLE.
+//   - Views, indexes, triggers: these require their target table to already
+//     exist (createIndex/createTrigger error otherwise; createView silently
+//     yields an unresolved query). A dependency-respecting topological sort
+//     places every dependent after the objects it references, so the resulting
+//     catalog is identical regardless of input statement order.
+//
+// Session statements are positional: USE selects the current database and SET
+// configures the session. The topological sort may freely reorder object
+// statements, so rather than rely on the sorted position of USE, LoadSDL records
+// the current database at each statement's original position and restores it
+// before executing that statement. foreign_key_checks is likewise held off for
+// the entire load regardless of any SET inside the SDL.
+func LoadSDL(sql string) (*Catalog, error) {
+	c := New()
+
+	list, err := mysqlparser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || len(list.Items) == 0 {
+		return c, nil
+	}
+	stmts := list.Items
+
+	// Validate every statement before mutating any catalog state.
+	if err := validateSDL(stmts); err != nil {
+		return nil, err
+	}
+
+	// Resolve the current database at each statement's ORIGINAL position so that,
+	// after the sort reorders statements, every object is created under the
+	// database that lexically governed it.
+	dbAtIndex := currentDBPerStatement(stmts)
+
+	// Disable FK validation for the whole load so forward references resolve, and
+	// restore the normal session default on the way out. The returned catalog
+	// then reflects a fully-validated schema for any later mutation.
+	c.SetForeignKeyChecks(false)
+	defer c.SetForeignKeyChecks(true)
+
+	// Order statements so every dependent runs after the objects it references.
+	deps := extractSDLDeps(stmts)
+	order, err := topoSortSDL(stmts, deps)
+	if err != nil {
+		return c, err
+	}
+
+	for _, idx := range order {
+		// Restore the database current at this statement's original position, and
+		// keep FK checks off (a SET inside the SDL must not re-arm validation).
+		c.SetCurrentDatabase(dbAtIndex[idx])
+		c.SetForeignKeyChecks(false)
+		if err := c.processUtility(stmts[idx]); err != nil {
+			return c, err
+		}
+	}
+
+	return c, nil
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+// validateSDL checks that every statement is allowed in SDL, returning the
+// first disallowed statement as an error.
+func validateSDL(stmts []nodes.Node) error {
+	for _, stmt := range stmts {
+		if err := validateSDLStmt(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateSDLStmt validates a single statement for SDL compliance.
+func validateSDLStmt(stmt nodes.Node) error {
+	switch s := stmt.(type) {
+	// ---- Allowed constructive DDL ----
+	case *nodes.CreateTableStmt:
+		// CREATE TABLE ... AS SELECT is imperative: createTable cannot
+		// faithfully materialize it as a schema snapshot and silently drops the
+		// table. Reject it so the loader never reports success while omitting an
+		// object.
+		if s.Select != nil {
+			return fmt.Errorf("SDL does not allow CREATE TABLE ... AS SELECT statements")
+		}
+		return nil
+	case *nodes.CreateDatabaseStmt,
+		*nodes.CreateIndexStmt,
+		*nodes.CreateViewStmt,
+		*nodes.CreateFunctionStmt, // function or procedure (IsProcedure)
+		*nodes.CreateTriggerStmt,
+		*nodes.CreateEventStmt:
+		return nil
+
+	// ---- Allowed session statements ----
+	case *nodes.UseStmt, *nodes.SetStmt:
+		return nil
+
+	// ---- Rejected DML ----
+	case *nodes.InsertStmt:
+		return fmt.Errorf("SDL does not allow INSERT statements")
+	case *nodes.UpdateStmt:
+		return fmt.Errorf("SDL does not allow UPDATE statements")
+	case *nodes.DeleteStmt:
+		return fmt.Errorf("SDL does not allow DELETE statements")
+	case *nodes.SelectStmt:
+		return fmt.Errorf("SDL does not allow SELECT statements")
+
+	// ---- Rejected destructive / mutating DDL ----
+	case *nodes.DropTableStmt,
+		*nodes.DropDatabaseStmt,
+		*nodes.DropIndexStmt,
+		*nodes.DropViewStmt,
+		*nodes.DropRoutineStmt,
+		*nodes.DropTriggerStmt,
+		*nodes.DropEventStmt:
+		return fmt.Errorf("SDL does not allow DROP statements")
+	case *nodes.TruncateStmt:
+		return fmt.Errorf("SDL does not allow TRUNCATE statements")
+	case *nodes.RenameTableStmt:
+		return fmt.Errorf("SDL does not allow RENAME statements")
+	case *nodes.AlterTableStmt:
+		return fmt.Errorf("SDL does not allow ALTER TABLE statements")
+	case *nodes.AlterViewStmt:
+		return fmt.Errorf("SDL does not allow ALTER VIEW statements")
+	case *nodes.AlterDatabaseStmt:
+		return fmt.Errorf("SDL does not allow ALTER DATABASE statements")
+	case *nodes.AlterRoutineStmt:
+		return fmt.Errorf("SDL does not allow ALTER routine statements")
+	case *nodes.AlterEventStmt:
+		return fmt.Errorf("SDL does not allow ALTER EVENT statements")
+
+	default:
+		return fmt.Errorf("SDL does not allow %T statements", stmt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Name resolution
+// ---------------------------------------------------------------------------
+
+// objectKey identifies a schema object by (database, name), both lower-cased.
+// MySQL has no schemas/namespaces or OIDs: "schema" == database, and table and
+// view names share one namespace. An empty database means the current database
+// at the point of reference.
+type objectKey struct {
+	db   string
+	name string
+}
+
+// resolveTableRef returns the object key for a table/view reference, qualifying
+// an unqualified name with the supplied current database.
+func resolveTableRef(ref *nodes.TableRef, currentDB string) objectKey {
+	if ref == nil {
+		return objectKey{}
+	}
+	db := ref.Schema
+	if db == "" {
+		db = currentDB
+	}
+	return objectKey{db: toLower(db), name: toLower(ref.Name)}
+}
+
+// currentDBPerStatement returns, for each statement index, the database that is
+// current at that point — i.e. the database selected by the most recent USE.
+// CREATE DATABASE does not change the current database in MySQL.
+func currentDBPerStatement(stmts []nodes.Node) []string {
+	out := make([]string, len(stmts))
+	current := ""
+	for i, stmt := range stmts {
+		if use, ok := stmt.(*nodes.UseStmt); ok {
+			current = use.Database
+		}
+		out[i] = current
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Dependency extraction
+// ---------------------------------------------------------------------------
+
+// sdlDep is a dependency edge: statement at index `from` must run after the
+// statement at index `to`.
+type sdlDep struct {
+	from int
+	to   int
+}
+
+// extractSDLDeps walks each statement's structural references and produces edges
+// to the declared objects whose prior existence the catalog requires. Only
+// references that resolve to a table/view declared in the same SDL produce an
+// edge; references to objects outside the SDL are ignored. Foreign keys are not
+// included: with foreign_key_checks off, a FK never requires its parent to exist.
+func extractSDLDeps(stmts []nodes.Node) []sdlDep {
+	dbAt := currentDBPerStatement(stmts)
+
+	// Map each declared table/view object key to its defining statement index.
+	keyToIdx := make(map[objectKey]int, len(stmts))
+	for i, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *nodes.CreateTableStmt:
+			if s.Table != nil {
+				keyToIdx[resolveTableRef(s.Table, dbAt[i])] = i
+			}
+		case *nodes.CreateViewStmt:
+			if s.Name != nil {
+				keyToIdx[resolveTableRef(s.Name, dbAt[i])] = i
+			}
+		}
+	}
+
+	var deps []sdlDep
+	for i, stmt := range stmts {
+		for _, ref := range sdlRefs(stmt, dbAt[i]) {
+			if j, ok := keyToIdx[ref]; ok && j != i {
+				deps = append(deps, sdlDep{from: i, to: j})
+			}
+		}
+	}
+	return deps
+}
+
+// sdlRefs returns the object keys a statement structurally depends on among
+// declared objects, qualifying unqualified names with currentDB.
+func sdlRefs(stmt nodes.Node, currentDB string) []objectKey {
+	var refs []objectKey
+	add := func(ref *nodes.TableRef) {
+		if ref != nil && ref.Name != "" {
+			refs = append(refs, resolveTableRef(ref, currentDB))
+		}
+	}
+
+	switch s := stmt.(type) {
+	case *nodes.CreateTableStmt:
+		// CREATE TABLE ... LIKE source table must exist first. (FK references are
+		// intentionally excluded — see extractSDLDeps.)
+		if s.Like != nil {
+			add(s.Like)
+		}
+
+	case *nodes.CreateViewStmt:
+		// A view depends on every table/view in its SELECT body, excluding names
+		// bound by the query's own CTEs.
+		for _, ref := range selectTableRefs(s.Select) {
+			add(ref)
+		}
+
+	case *nodes.CreateIndexStmt:
+		// An index requires its target table.
+		add(s.Table)
+
+	case *nodes.CreateTriggerStmt:
+		// A trigger requires its target table.
+		add(s.Table)
+	}
+
+	return refs
+}
+
+// selectTableRefs returns the base table/view references in a SELECT that denote
+// real schema objects (for dependency edges), including those nested in joins,
+// subqueries and derived tables. References whose unqualified name is bound by a
+// CTE in the top-level query scope are excluded: a CTE is query-local and shadows
+// a same-named schema object.
+//
+// CTE shadowing is applied only for top-level CTEs (the WITH clause on the view
+// body and the set-operation branches that share its scope), not CTEs declared in
+// nested subqueries — a nested CTE does not shadow an outer reference. Treating a
+// nested CTE name as a top-level shadow could drop a real dependency edge; under-
+// approximating the shadow set is safe because a stray edge to a non-existent
+// object is simply ignored by extractSDLDeps.
+func selectTableRefs(sel *nodes.SelectStmt) []*nodes.TableRef {
+	if sel == nil {
+		return nil
+	}
+	cteNames := make(map[string]bool)
+	collectTopLevelCTENames(sel, cteNames)
+
+	var refs []*nodes.TableRef
+	nodes.Inspect(sel, func(n nodes.Node) bool {
+		if tr, ok := n.(*nodes.TableRef); ok {
+			// Only unqualified references can match a CTE name; a schema-qualified
+			// reference always denotes a real object.
+			if tr.Schema == "" && cteNames[toLower(tr.Name)] {
+				return true
+			}
+			refs = append(refs, tr)
+		}
+		return true
+	})
+	return refs
+}
+
+// collectTopLevelCTENames adds the CTE names declared in the top-level scope of a
+// query into names. The top-level scope spans the query's own WITH clause plus the
+// set-operation branches and parenthesized wrapper that share that scope; it does
+// not descend into FROM-clause subqueries or CTE bodies (those open their own
+// scopes).
+func collectTopLevelCTENames(sel *nodes.SelectStmt, names map[string]bool) {
+	if sel == nil {
+		return
+	}
+	for _, cte := range sel.CTEs {
+		if cte != nil && cte.Name != "" {
+			names[toLower(cte.Name)] = true
+		}
+	}
+	// UNION/INTERSECT/EXCEPT branches and a parenthesized wrapper share the
+	// enclosing WITH scope.
+	collectTopLevelCTENames(sel.Left, names)
+	collectTopLevelCTENames(sel.Right, names)
+	collectTopLevelCTENames(sel.ParenSource, names)
+}
+
+// ---------------------------------------------------------------------------
+// Topological ordering
+// ---------------------------------------------------------------------------
+
+// sdlPriority assigns an ordering layer to each statement type; lower runs
+// first. Session statements (SET, USE) and CREATE DATABASE share the lowest
+// layer so the database exists and the session is configured before any object
+// is created. Their relative order is preserved by the original-index tie-break,
+// and object placement into the correct database is handled separately via the
+// per-statement current-database restore in LoadSDL.
+func sdlPriority(stmt nodes.Node) int {
+	switch stmt.(type) {
+	case *nodes.SetStmt, *nodes.UseStmt, *nodes.CreateDatabaseStmt:
+		return 0
+	case *nodes.CreateTableStmt:
+		return 1
+	case *nodes.CreateFunctionStmt:
+		// Routines before views/triggers in case a view or trigger body calls a
+		// routine (best-effort; routine bodies are not analyzed at load).
+		return 2
+	case *nodes.CreateViewStmt:
+		return 3
+	case *nodes.CreateIndexStmt:
+		return 4
+	case *nodes.CreateTriggerStmt:
+		return 5
+	case *nodes.CreateEventStmt:
+		return 6
+	default:
+		return 7
+	}
+}
+
+// topoSortSDL returns statement indices ordered so every dependent runs after
+// its dependencies (Kahn's algorithm), breaking ties by (priority, original
+// index) for determinism. A genuine dependency cycle (e.g. two views referencing
+// each other) is reported as an error.
+func topoSortSDL(stmts []nodes.Node, deps []sdlDep) ([]int, error) {
+	n := len(stmts)
+
+	priority := make([]int, n)
+	for i, stmt := range stmts {
+		priority[i] = sdlPriority(stmt)
+	}
+
+	// dep.from depends on dep.to → edge to.from must precede from. De-duplicate
+	// edges so parallel references don't inflate the in-degree.
+	adj := make([][]int, n)
+	inDegree := make([]int, n)
+	seen := make(map[sdlDep]bool, len(deps))
+	for _, d := range deps {
+		if seen[d] {
+			continue
+		}
+		seen[d] = true
+		adj[d.to] = append(adj[d.to], d.from)
+		inDegree[d.from]++
+	}
+
+	h := make(sdlHeap, 0, n)
+	for i := 0; i < n; i++ {
+		if inDegree[i] == 0 {
+			h = append(h, sdlHeapEntry{idx: i, pri: priority[i]})
+		}
+	}
+	heap.Init(&h)
+
+	order := make([]int, 0, n)
+	for h.Len() > 0 {
+		e := heap.Pop(&h).(sdlHeapEntry)
+		order = append(order, e.idx)
+		for _, next := range adj[e.idx] {
+			inDegree[next]--
+			if inDegree[next] == 0 {
+				heap.Push(&h, sdlHeapEntry{idx: next, pri: priority[next]})
+			}
+		}
+	}
+
+	if len(order) != n {
+		return nil, fmt.Errorf("SDL dependency cycle detected")
+	}
+	return order, nil
+}
+
+// sdlHeapEntry is a priority-queue entry for Kahn's algorithm: order by
+// (priority ASC, original index ASC).
+type sdlHeapEntry struct {
+	idx int
+	pri int
+}
+
+type sdlHeap []sdlHeapEntry
+
+func (h sdlHeap) Len() int      { return len(h) }
+func (h sdlHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h sdlHeap) Less(i, j int) bool {
+	if h[i].pri != h[j].pri {
+		return h[i].pri < h[j].pri
+	}
+	return h[i].idx < h[j].idx
+}
+func (h *sdlHeap) Push(x any) {
+	*h = append(*h, x.(sdlHeapEntry))
+}
+func (h *sdlHeap) Pop() any {
+	old := *h
+	n := len(old)
+	e := old[n-1]
+	*h = old[:n-1]
+	return e
+}

--- a/mysql/catalog/sdl_test.go
+++ b/mysql/catalog/sdl_test.go
@@ -1,0 +1,690 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// loadSDLForDB is a test helper: it loads SDL and returns the named database
+// from the resulting catalog, failing the test on error or a missing database.
+func loadSDLForDB(t *testing.T, sql, dbName string) *Database {
+	t.Helper()
+	c, err := LoadSDL(sql)
+	if err != nil {
+		t.Fatalf("LoadSDL error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("LoadSDL returned nil catalog")
+	}
+	db := c.GetDatabase(dbName)
+	if db == nil {
+		t.Fatalf("database %q not found in catalog", dbName)
+	}
+	return db
+}
+
+func TestSDLValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr string // if non-empty, expect error containing this
+	}{
+		// ---- Accepted statements ----
+		{
+			name: "empty string returns empty catalog",
+			sql:  "",
+		},
+		{
+			name: "valid CREATE DATABASE",
+			sql:  "CREATE DATABASE app;",
+		},
+		{
+			name: "valid CREATE TABLE",
+			sql:  "CREATE DATABASE app; USE app; CREATE TABLE t (id int);",
+		},
+		{
+			name: "valid CREATE VIEW",
+			sql:  "CREATE DATABASE app; USE app; CREATE TABLE t (id int); CREATE VIEW v AS SELECT id FROM t;",
+		},
+		{
+			name: "valid CREATE INDEX",
+			sql:  "CREATE DATABASE app; USE app; CREATE TABLE t (id int); CREATE INDEX idx ON t (id);",
+		},
+		{
+			name: "valid CREATE FUNCTION",
+			sql:  "CREATE DATABASE app; USE app; CREATE FUNCTION f() RETURNS int DETERMINISTIC RETURN 1;",
+		},
+		{
+			name: "valid CREATE PROCEDURE",
+			sql:  "CREATE DATABASE app; USE app; CREATE PROCEDURE p() BEGIN SELECT 1; END;",
+		},
+		{
+			name: "valid CREATE TRIGGER",
+			sql:  "CREATE DATABASE app; USE app; CREATE TABLE t (id int); CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET NEW.id = 1;",
+		},
+		{
+			name: "valid CREATE EVENT",
+			sql:  "CREATE DATABASE app; USE app; CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1;",
+		},
+		{
+			name: "valid SET",
+			sql:  "SET foreign_key_checks = 0;",
+		},
+
+		// ---- Rejected DML ----
+		{
+			name:    "INSERT rejected",
+			sql:     "CREATE DATABASE app; USE app; CREATE TABLE t (id int); INSERT INTO t VALUES (1);",
+			wantErr: "SDL does not allow INSERT statements",
+		},
+		{
+			name:    "UPDATE rejected",
+			sql:     "UPDATE t SET x = 1;",
+			wantErr: "SDL does not allow UPDATE statements",
+		},
+		{
+			name:    "DELETE rejected",
+			sql:     "DELETE FROM t;",
+			wantErr: "SDL does not allow DELETE statements",
+		},
+		{
+			name:    "SELECT rejected",
+			sql:     "SELECT 1;",
+			wantErr: "SDL does not allow SELECT statements",
+		},
+		// ---- Rejected destructive DDL ----
+		{
+			name:    "DROP TABLE rejected",
+			sql:     "DROP TABLE t;",
+			wantErr: "SDL does not allow DROP statements",
+		},
+		{
+			name:    "DROP DATABASE rejected",
+			sql:     "DROP DATABASE app;",
+			wantErr: "SDL does not allow DROP statements",
+		},
+		{
+			name:    "DROP INDEX rejected",
+			sql:     "DROP INDEX idx ON t;",
+			wantErr: "SDL does not allow DROP statements",
+		},
+		{
+			name:    "DROP VIEW rejected",
+			sql:     "DROP VIEW v;",
+			wantErr: "SDL does not allow DROP statements",
+		},
+		{
+			name:    "TRUNCATE rejected",
+			sql:     "TRUNCATE TABLE t;",
+			wantErr: "SDL does not allow TRUNCATE statements",
+		},
+		{
+			name:    "RENAME TABLE rejected",
+			sql:     "RENAME TABLE a TO b;",
+			wantErr: "SDL does not allow RENAME statements",
+		},
+		{
+			name:    "ALTER TABLE ADD COLUMN rejected",
+			sql:     "ALTER TABLE t ADD COLUMN x int;",
+			wantErr: "SDL does not allow ALTER TABLE",
+		},
+		{
+			name:    "ALTER TABLE DROP COLUMN rejected",
+			sql:     "ALTER TABLE t DROP COLUMN x;",
+			wantErr: "SDL does not allow ALTER TABLE",
+		},
+		// ---- Parse error ----
+		{
+			name:    "parse error returns error",
+			sql:     "CREATE TABL t (id int);",
+			wantErr: "", // non-empty error from parser, asserted specially below
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "parse error returns error" {
+				_, err := LoadSDL(tt.sql)
+				if err == nil {
+					t.Fatal("expected parse error, got nil")
+				}
+				return
+			}
+
+			c, err := LoadSDL(tt.sql)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c == nil {
+				t.Fatal("expected non-nil catalog")
+			}
+		})
+	}
+}
+
+// TestSDLForwardForeignKey verifies a table with a forward FK reference (the
+// referenced table is declared *after* the referencing table) loads cleanly.
+// LoadSQL would fail here because foreign_key_checks defaults on and the parent
+// table does not yet exist.
+func TestSDLForwardForeignKey(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE child (
+  id int PRIMARY KEY,
+  parent_id int,
+  CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent (id)
+);
+CREATE TABLE parent (
+  id int PRIMARY KEY
+);
+`
+	db := loadSDLForDB(t, sql, "app")
+	child := db.GetTable("child")
+	if child == nil {
+		t.Fatal("expected table child")
+	}
+	if db.GetTable("parent") == nil {
+		t.Fatal("expected table parent")
+	}
+	// The FK constraint must be present on child.
+	var fkFound bool
+	for _, con := range child.Constraints {
+		if con.Type == ConForeignKey && strings.EqualFold(con.RefTable, "parent") {
+			fkFound = true
+		}
+	}
+	if !fkFound {
+		t.Fatalf("expected FK constraint on child referencing parent, constraints: %+v", child.Constraints)
+	}
+}
+
+// TestSDLForwardViewReference verifies a view referencing a table declared after
+// it loads and resolves correctly (AnalyzedQuery populated regardless of order).
+func TestSDLForwardViewReference(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE VIEW v AS SELECT id, name FROM t;
+CREATE TABLE t (id int, name varchar(50));
+`
+	db := loadSDLForDB(t, sql, "app")
+	v := db.Views["v"]
+	if v == nil {
+		t.Fatal("expected view v")
+	}
+	if v.AnalyzedQuery == nil {
+		t.Fatal("expected view v to have a populated AnalyzedQuery (referenced table ordered before view)")
+	}
+}
+
+// TestSDLOrderIndependence is the spine of the loader: the same set of objects
+// declared in different statement orders must yield an equivalent catalog.
+func TestSDLOrderIndependence(t *testing.T) {
+	// A representative multi-object schema: tables with a forward FK, a view
+	// referencing a later table, a secondary/composite index, a generated
+	// column, a trigger, and a routine.
+	objects := []string{
+		`CREATE TABLE parent (id int PRIMARY KEY, code varchar(20))`,
+		`CREATE TABLE child (
+			id int PRIMARY KEY,
+			parent_id int,
+			amount int,
+			doubled int AS (amount * 2) STORED,
+			CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent (id)
+		)`,
+		`CREATE INDEX idx_child_parent ON child (parent_id, amount)`,
+		`CREATE VIEW v_join AS SELECT c.id, p.code FROM child c JOIN parent p ON c.parent_id = p.id`,
+		`CREATE TRIGGER trg_child BEFORE INSERT ON child FOR EACH ROW SET NEW.amount = NEW.amount`,
+		`CREATE FUNCTION fn_double(x int) RETURNS int DETERMINISTIC RETURN x * 2`,
+	}
+
+	build := func(order []int) *Database {
+		var b strings.Builder
+		b.WriteString("CREATE DATABASE app; USE app;\n")
+		for _, i := range order {
+			b.WriteString(objects[i])
+			b.WriteString(";\n")
+		}
+		return loadSDLForDB(t, b.String(), "app")
+	}
+
+	// Canonical (declaration) order.
+	canonical := build([]int{0, 1, 2, 3, 4, 5})
+
+	// Several shuffled orders that all place dependents before dependencies.
+	shuffles := [][]int{
+		{5, 4, 3, 2, 1, 0}, // fully reversed
+		{3, 2, 1, 0, 5, 4}, // view & index first
+		{4, 3, 5, 2, 0, 1}, // trigger/view/fn before tables
+		{2, 5, 3, 4, 0, 1}, // index & view before tables, parent last
+	}
+
+	for idx, order := range shuffles {
+		got := build(order)
+		assertDatabasesEquivalent(t, canonical, got, idx)
+	}
+}
+
+// assertDatabasesEquivalent checks that two databases loaded from the same set
+// of objects (in different orders) contain the same objects with the same
+// salient shape. It compares object names per kind plus key per-table details.
+func assertDatabasesEquivalent(t *testing.T, want, got *Database, shuffleIdx int) {
+	t.Helper()
+
+	assertKeySetsEqual(t, "tables", keys(want.Tables), keys(got.Tables), shuffleIdx)
+	assertKeySetsEqual(t, "views", keys(want.Views), keys(got.Views), shuffleIdx)
+	assertKeySetsEqual(t, "functions", keys(want.Functions), keys(got.Functions), shuffleIdx)
+	assertKeySetsEqual(t, "procedures", keys(want.Procedures), keys(got.Procedures), shuffleIdx)
+	assertKeySetsEqual(t, "triggers", keys(want.Triggers), keys(got.Triggers), shuffleIdx)
+	assertKeySetsEqual(t, "events", keys(want.Events), keys(got.Events), shuffleIdx)
+
+	for name, wantTbl := range want.Tables {
+		gotTbl := got.Tables[name]
+		if gotTbl == nil {
+			t.Fatalf("shuffle %d: table %q missing", shuffleIdx, name)
+		}
+		// Columns: same names in the same order.
+		if len(wantTbl.Columns) != len(gotTbl.Columns) {
+			t.Fatalf("shuffle %d: table %q column count: want %d got %d", shuffleIdx, name, len(wantTbl.Columns), len(gotTbl.Columns))
+		}
+		for i := range wantTbl.Columns {
+			if !strings.EqualFold(wantTbl.Columns[i].Name, gotTbl.Columns[i].Name) {
+				t.Fatalf("shuffle %d: table %q column %d: want %q got %q", shuffleIdx, name, i, wantTbl.Columns[i].Name, gotTbl.Columns[i].Name)
+			}
+			if (wantTbl.Columns[i].Generated == nil) != (gotTbl.Columns[i].Generated == nil) {
+				t.Fatalf("shuffle %d: table %q column %q generated mismatch", shuffleIdx, name, wantTbl.Columns[i].Name)
+			}
+		}
+		// Indexes: same names.
+		assertStringSetsEqual(t, "indexes of "+name, sdlIndexNames(wantTbl), sdlIndexNames(gotTbl), shuffleIdx)
+		// FK constraints: same names.
+		assertStringSetsEqual(t, "fks of "+name, fkNames(wantTbl), fkNames(gotTbl), shuffleIdx)
+	}
+
+	// Views must resolve identically: AnalyzedQuery populated in both.
+	for name, wantView := range want.Views {
+		gotView := got.Views[name]
+		if gotView == nil {
+			t.Fatalf("shuffle %d: view %q missing", shuffleIdx, name)
+		}
+		if (wantView.AnalyzedQuery == nil) != (gotView.AnalyzedQuery == nil) {
+			t.Fatalf("shuffle %d: view %q AnalyzedQuery populated mismatch (want nil=%v got nil=%v)",
+				shuffleIdx, name, wantView.AnalyzedQuery == nil, gotView.AnalyzedQuery == nil)
+		}
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func sdlIndexNames(t *Table) []string {
+	out := make([]string, 0, len(t.Indexes))
+	for _, idx := range t.Indexes {
+		out = append(out, strings.ToLower(idx.Name))
+	}
+	return out
+}
+
+func fkNames(t *Table) []string {
+	var out []string
+	for _, con := range t.Constraints {
+		if con.Type == ConForeignKey {
+			out = append(out, strings.ToLower(con.Name))
+		}
+	}
+	return out
+}
+
+func assertKeySetsEqual(t *testing.T, label string, want, got []string, shuffleIdx int) {
+	t.Helper()
+	assertStringSetsEqual(t, label, want, got, shuffleIdx)
+}
+
+func assertStringSetsEqual(t *testing.T, label string, want, got []string, shuffleIdx int) {
+	t.Helper()
+	wantSet := make(map[string]bool, len(want))
+	for _, w := range want {
+		wantSet[w] = true
+	}
+	gotSet := make(map[string]bool, len(got))
+	for _, g := range got {
+		gotSet[g] = true
+	}
+	for w := range wantSet {
+		if !gotSet[w] {
+			t.Fatalf("shuffle %d: %s: missing %q (want %v, got %v)", shuffleIdx, label, w, want, got)
+		}
+	}
+	for g := range gotSet {
+		if !wantSet[g] {
+			t.Fatalf("shuffle %d: %s: unexpected %q (want %v, got %v)", shuffleIdx, label, g, want, got)
+		}
+	}
+}
+
+// TestSDLCoverage enumerates the object kinds the loader must handle and asserts
+// each loads into the catalog.
+func TestSDLCoverage(t *testing.T) {
+	sql := `
+CREATE DATABASE app CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+USE app;
+
+CREATE TABLE parent (
+  id int PRIMARY KEY,
+  code varchar(20) NOT NULL,
+  UNIQUE KEY uq_code (code)
+);
+
+CREATE TABLE t (
+  id int AUTO_INCREMENT PRIMARY KEY,
+  parent_id int,
+  name varchar(100) NOT NULL,
+  price decimal(10,2) DEFAULT 0.00,
+  total decimal(12,2) AS (price * id) VIRTUAL,
+  tags varchar(255),
+  body text,
+  CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parent (id) ON DELETE CASCADE,
+  CONSTRAINT chk_price CHECK (price >= 0),
+  KEY idx_name_prefix (name(10)),
+  KEY idx_expr ((price + 1)),
+  FULLTEXT KEY ft_body (body)
+);
+
+CREATE INDEX idx_parent ON t (parent_id);
+
+CREATE VIEW v AS SELECT id, name FROM t;
+
+CREATE FUNCTION fn_inc(x int) RETURNS int DETERMINISTIC RETURN x + 1;
+
+CREATE PROCEDURE pr_noop() BEGIN SELECT 1; END;
+
+CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET NEW.name = NEW.name;
+
+CREATE EVENT ev ON SCHEDULE EVERY 1 DAY DO SET @y = 1;
+`
+	db := loadSDLForDB(t, sql, "app")
+
+	// database
+	if db.Name == "" {
+		t.Fatal("expected database name set")
+	}
+	// table + columns
+	tbl := db.GetTable("t")
+	if tbl == nil {
+		t.Fatal("expected table t")
+	}
+	if tbl.GetColumn("id") == nil || tbl.GetColumn("name") == nil {
+		t.Fatal("expected columns id and name on t")
+	}
+	// generated column
+	total := tbl.GetColumn("total")
+	if total == nil || total.Generated == nil {
+		t.Fatal("expected generated column total")
+	}
+	// indexes: prefix, functional, plus standalone CREATE INDEX
+	if len(tbl.Indexes) == 0 {
+		t.Fatal("expected indexes on t")
+	}
+	var haveStandalone bool
+	for _, idx := range tbl.Indexes {
+		if strings.EqualFold(idx.Name, "idx_parent") {
+			haveStandalone = true
+		}
+	}
+	if !haveStandalone {
+		t.Fatal("expected standalone CREATE INDEX idx_parent on t")
+	}
+	// FK + CHECK constraints
+	var haveFK, haveCheck bool
+	for _, con := range tbl.Constraints {
+		switch con.Type {
+		case ConForeignKey:
+			haveFK = true
+		case ConCheck:
+			haveCheck = true
+		}
+	}
+	if !haveFK {
+		t.Fatal("expected FK constraint on t")
+	}
+	if !haveCheck {
+		t.Fatal("expected CHECK constraint on t")
+	}
+	// view
+	if db.Views["v"] == nil {
+		t.Fatal("expected view v")
+	}
+	// function + procedure
+	if db.Functions["fn_inc"] == nil {
+		t.Fatal("expected function fn_inc")
+	}
+	if db.Procedures["pr_noop"] == nil {
+		t.Fatal("expected procedure pr_noop")
+	}
+	// trigger
+	if db.Triggers["trg"] == nil {
+		t.Fatal("expected trigger trg")
+	}
+	// event
+	if db.Events["ev"] == nil {
+		t.Fatal("expected event ev")
+	}
+}
+
+// TestSDLEquivalentToLoadSQLWhenOrdered verifies that, for a schema whose
+// statements are already in dependency order, LoadSDL yields the same catalog
+// shape as LoadSQL (LoadSDL must not lose or alter objects).
+func TestSDLEquivalentToLoadSQLWhenOrdered(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE parent (id int PRIMARY KEY);
+CREATE TABLE child (id int PRIMARY KEY, parent_id int,
+  CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES parent (id));
+CREATE INDEX idx ON child (parent_id);
+CREATE VIEW v AS SELECT id FROM child;
+`
+	sdlCat, err := LoadSDL(sql)
+	if err != nil {
+		t.Fatalf("LoadSDL: %v", err)
+	}
+	sqlCat, err := LoadSQL(sql)
+	if err != nil {
+		t.Fatalf("LoadSQL: %v", err)
+	}
+	sdlDB := sdlCat.GetDatabase("app")
+	sqlDB := sqlCat.GetDatabase("app")
+	if sdlDB == nil || sqlDB == nil {
+		t.Fatal("expected app database from both loaders")
+	}
+	assertKeySetsEqual(t, "tables", keys(sqlDB.Tables), keys(sdlDB.Tables), 0)
+	assertKeySetsEqual(t, "views", keys(sqlDB.Views), keys(sdlDB.Views), 0)
+}
+
+// TestSDLMultiDatabaseScoping verifies that unqualified objects in a multi-database
+// SDL are created in the database that was current at their declaration position —
+// not in whichever database the last USE happened to select. The topological sort
+// must not float USE statements past the objects they scope.
+func TestSDLMultiDatabaseScoping(t *testing.T) {
+	sql := `
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+USE db1;
+CREATE TABLE t1 (id int);
+USE db2;
+CREATE TABLE t2 (id int);
+`
+	c, err := LoadSDL(sql)
+	if err != nil {
+		t.Fatalf("LoadSDL: %v", err)
+	}
+	db1 := c.GetDatabase("db1")
+	db2 := c.GetDatabase("db2")
+	if db1 == nil || db2 == nil {
+		t.Fatal("expected both db1 and db2")
+	}
+	if db1.GetTable("t1") == nil {
+		t.Errorf("t1 must be in db1, db1 tables: %v", keys(db1.Tables))
+	}
+	if db2.GetTable("t2") == nil {
+		t.Errorf("t2 must be in db2, db2 tables: %v", keys(db2.Tables))
+	}
+	// And not crossed.
+	if db2.GetTable("t1") != nil {
+		t.Errorf("t1 wrongly created in db2")
+	}
+	if db1.GetTable("t2") != nil {
+		t.Errorf("t2 wrongly created in db1")
+	}
+}
+
+// TestSDLCircularForeignKey verifies that two tables with mutually-referencing
+// foreign keys load successfully. With foreign_key_checks disabled (the loader's
+// strategy), a FK does not require its parent to exist, so a FK cycle is a valid
+// MySQL schema and must not be reported as a dependency cycle.
+func TestSDLCircularForeignKey(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE a (
+  id int PRIMARY KEY,
+  b_id int,
+  CONSTRAINT fk_a FOREIGN KEY (b_id) REFERENCES b (id)
+);
+CREATE TABLE b (
+  id int PRIMARY KEY,
+  a_id int,
+  CONSTRAINT fk_b FOREIGN KEY (a_id) REFERENCES a (id)
+);
+`
+	db := loadSDLForDB(t, sql, "app")
+	if db.GetTable("a") == nil || db.GetTable("b") == nil {
+		t.Fatalf("expected both tables a and b, got %v", keys(db.Tables))
+	}
+}
+
+// TestSDLSelfReferentialForeignKey verifies a table whose FK references itself
+// loads cleanly (no spurious self-cycle).
+func TestSDLSelfReferentialForeignKey(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE node (
+  id int PRIMARY KEY,
+  parent_id int,
+  CONSTRAINT fk_self FOREIGN KEY (parent_id) REFERENCES node (id)
+);
+`
+	db := loadSDLForDB(t, sql, "app")
+	if db.GetTable("node") == nil {
+		t.Fatal("expected table node")
+	}
+}
+
+// TestSDLSetForeignKeyChecksDoesNotBreakForwardFK verifies that a SET
+// foreign_key_checks statement inside the SDL (as emitted by mysqldump) does not
+// re-enable FK validation and break a forward FK reference. The loader owns the
+// FK-check state for the duration of the load.
+func TestSDLSetForeignKeyChecksDoesNotBreakForwardFK(t *testing.T) {
+	sql := `
+SET FOREIGN_KEY_CHECKS = 1;
+CREATE DATABASE app;
+USE app;
+CREATE TABLE child (
+  id int PRIMARY KEY,
+  parent_id int,
+  CONSTRAINT fk FOREIGN KEY (parent_id) REFERENCES parent (id)
+);
+CREATE TABLE parent (id int PRIMARY KEY);
+SET FOREIGN_KEY_CHECKS = 1;
+`
+	db := loadSDLForDB(t, sql, "app")
+	if db.GetTable("child") == nil || db.GetTable("parent") == nil {
+		t.Fatalf("expected child and parent, got %v", keys(db.Tables))
+	}
+}
+
+// TestSDLViewCTEShadowsTable verifies that a top-level CTE whose name collides
+// with a declared table does not create a spurious dependency edge to that table
+// (the CTE is query-local scope and shadows the real object). The view must still
+// load; the point is that no false ordering constraint is introduced.
+func TestSDLViewCTEShadowsTable(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE parent (id int PRIMARY KEY);
+CREATE VIEW v AS WITH parent AS (SELECT 1 AS id) SELECT id FROM parent;
+`
+	// extractSDLDeps must not emit an edge v -> parent (the FROM parent resolves to
+	// the CTE, not the table).
+	c, err := LoadSDL(sql)
+	if err != nil {
+		t.Fatalf("LoadSDL: %v", err)
+	}
+	db := c.GetDatabase("app")
+	if db == nil || db.Views["v"] == nil || db.GetTable("parent") == nil {
+		t.Fatal("expected app.v and app.parent")
+	}
+}
+
+// TestSDLViewNestedCTEDoesNotShadowOuterView verifies that a CTE defined only in
+// a nested subquery does NOT suppress an unqualified reference to a real VIEW in
+// the outer query. View-on-view dependencies share a priority layer, so the edge
+// (not priority) is what orders them: if the nested CTE wrongly shadowed the outer
+// reference, the dependent view could be analyzed before the view it builds on.
+func TestSDLViewNestedCTEDoesNotShadowOuterView(t *testing.T) {
+	// base_v is a real view. dependent_v references base_v unqualified in its outer
+	// query and also nests a CTE named base_v in a subquery. The outer reference
+	// must bind to the real view, forcing dependent_v to be ordered after base_v.
+	// dependent_v is declared FIRST, so only a correct edge yields a populated
+	// AnalyzedQuery.
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE VIEW dependent_v AS
+  SELECT id FROM base_v
+  WHERE id IN (WITH base_v AS (SELECT 7 AS id) SELECT id FROM base_v);
+CREATE TABLE t (id int PRIMARY KEY);
+CREATE VIEW base_v AS SELECT id FROM t;
+`
+	db := loadSDLForDB(t, sql, "app")
+	dep := db.Views["dependent_v"]
+	base := db.Views["base_v"]
+	if dep == nil || base == nil {
+		t.Fatal("expected both dependent_v and base_v")
+	}
+	if dep.AnalyzedQuery == nil {
+		t.Fatal("dependent_v must be ordered after base_v: its outer FROM base_v binds to the real view, not the nested CTE of the same name")
+	}
+}
+
+// TestSDLRejectsCTAS verifies CREATE TABLE ... AS SELECT is rejected: it is an
+// imperative construct the loader cannot faithfully materialize as a schema
+// snapshot, and the catalog silently drops it otherwise.
+func TestSDLRejectsCTAS(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE src (id int);
+CREATE TABLE derived AS SELECT id FROM src;
+`
+	_, err := LoadSDL(sql)
+	if err == nil {
+		t.Fatal("expected CTAS to be rejected")
+	}
+	if !strings.Contains(err.Error(), "SELECT") {
+		t.Fatalf("expected CTAS rejection error mentioning SELECT, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What & why

Adds `func LoadSDL(sql string) (*Catalog, error)` to `mysql/catalog` — an **order-tolerant** full-schema loader for MySQL declarative-schema (SDL) migration. This is the **first node of the MySQL SDL vertical slice**; everything downstream (diff, generate, the bytebase release round-trip) blocks on it.

Contract slice: `docs/migration/mysql/sdl/contract.md` §1 (the `LoadSDL` / `LoadSQL` / `Catalog` rows + the "Shape note for the MySQL port") and `docs/migration/mysql/sdl/omni_inventory.md` (the loader row). PostgreSQL's `pg/catalog/sdl.go` is the spec; this re-expresses it for MySQL's **database-keyed identity model** (MySQL has no schemas/namespaces/OIDs — "schema" == database; tables and views share one namespace).

## What `LoadSDL` does + how it achieves order-tolerance

`LoadSQL` applies statements in textual order, so it fails when an object references a not-yet-created object (a view over a later table, an index/trigger ahead of its table, a forward FK). `LoadSDL` accepts a full target schema whose objects reference each other out of declaration order. Pipeline: `parse → validate → extractDeps → topoSort → execute`.

Order-tolerance is achieved the way MySQL itself loads a dump:

- **Foreign keys** — `foreign_key_checks` is held off for the entire load, so a forward FK never errors; the constraint is still recorded on the table. FK references are **deliberately excluded from the dependency graph**: with checks off, `createTable` never requires the parent to exist, so FK edges impose no real ordering constraint and would only manufacture a false "dependency cycle" for a valid circular-FK schema. This is the analog of PostgreSQL deferring FK constraints into post-creation `ALTER TABLE`.
- **Views / indexes / triggers** — these require their target table to already exist (`createIndex`/`createTrigger` error otherwise; `createView` silently yields an unresolved query). A dependency-respecting **topological sort** (Kahn's algorithm, priority layers, deterministic `(priority, original-index)` tie-break) places every dependent after the objects it references, so the catalog is identical regardless of input statement order.
- **Session statements are positional** — the current database at each statement's *original* index is restored before that statement executes, so unqualified objects in a multi-database SDL land in the correct database even though the sort reorders object statements. `foreign_key_checks` is likewise held off for the whole load regardless of any `SET` inside the SDL.

SDL accepts only constructive DDL — `CREATE {DATABASE,TABLE,INDEX,VIEW,FUNCTION,PROCEDURE,TRIGGER,EVENT}` + session `USE`/`SET` — and rejects DML (`INSERT`/`UPDATE`/`DELETE`/`SELECT`), destructive/mutating DDL (`DROP`/`TRUNCATE`/`RENAME`/`ALTER`), and the imperative `CREATE TABLE ... AS SELECT` (which the catalog would silently drop).

Reuses existing catalog infrastructure — `(*Catalog).processUtility`, `New`, `SetForeignKeyChecks`, `SetCurrentDatabase`, the `mysql/ast` walker (`nodes.Inspect`) — and builds nothing that other nodes own.

## Object-kind coverage

| Object kind | Loads | Notes |
|---|---|---|
| database | ✓ | charset/collation options preserved |
| table + columns | ✓ | |
| generated column (STORED/VIRTUAL) | ✓ | |
| index — secondary/composite | ✓ | standalone `CREATE INDEX` + inline `KEY` |
| index — prefix `name(10)` | ✓ | |
| index — functional `((expr))` | ✓ | 8.0 only; 5.7 rejects (engine version floor, flagged) |
| index — fulltext | ✓ | |
| foreign key (incl. forward + circular) | ✓ | recorded with FK checks off; excluded from dep graph |
| CHECK constraint | ✓ | |
| view (incl. forward ref, view-on-view) | ✓ | CTE names shadow same-named tables (scope-aware) |
| function / procedure | ✓ | |
| trigger | ✓ | `FOLLOWS`/`PRECEDES` ordering not modeled — see below |
| event | ✓ | |

## Oracle evidence (live MySQL, both versions)

Proven against **MySQL 8.0.32** (`:13306`) and **MySQL 5.7.25** (`:13307`):

1. **Parse/accept parity** — the full coverage schema is accepted by the real engine (8.0 and a 5.7-compatible variant) and materializes every object kind; `LoadSDL` loads the identical object set.
2. **Order-independence** — a shuffled schema (view/index/trigger declared *before* their target table, child FK before parent) that **raw MySQL rejects** (`Table '…' doesn't exist`) loads successfully through `LoadSDL`; the same schema applied dependency-ordered with FK checks off succeeds on the live engine, confirming `LoadSDL`'s strategy is engine-faithful.
3. **Circular FK** — a mutually-referencing FK pair is a valid MySQL schema (loads with `foreign_key_checks=0` → 2 tables + 2 FKs on the live engine); `LoadSDL` loads it (earlier it was wrongly rejected as a dependency cycle — fixed during review).
4. **Version divergence (flagged)** — functional index `((expr))` is accepted by 8.0, rejected by 5.7 (8.0.13+ feature); `LoadSDL` accepts the 8.0 superset, consistent with "8.0 = primary SDL target, 5.7 = compatibility floor."

## Testing

`go test ./mysql/catalog/...` — 13 SDL test groups, all green; full package suite passes; `golangci-lint` clean for the new files. Tests cover validation (accept/reject matrix), forward FK, forward view ref, **order-independence across 4 shuffles**, full object-kind coverage, multi-database scoping, circular + self-referential FK, `SET foreign_key_checks` neutralization, CTE shadowing (top-level + nested-scope), CTAS rejection, and parity with `LoadSQL` when ordered.

## Known limitations (non-blocking)

- Trigger `FOLLOWS`/`PRECEDES` ordering is not modeled as a dependency. `createTrigger` does not validate or order on it and triggers live in an unordered map, so no observable catalog divergence today; if a future `createTrigger` enforces the relationship this becomes a dependency to add.

## Downstream

The full SDL idempotence proof (`apply → dump → MetadataToSDL → DiffSDLMigration(self) == empty`) **lands with `omni:diff-core` and `omni:normalize-core`**, which don't exist yet — this loader is the first node, so the round-trip can't be wired through unbuilt nodes. This PR proves the loader at the level it owns (order-tolerance + parse/accept parity + coverage) against the live oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
