### PR TITLE
fix(mysql,tidb,mariadb): only recognize DELIMITER directive at statement start

### DIFF
--- a/mariadb/parser/split.go
+++ b/mariadb/parser/split.go
@@ -196,8 +196,8 @@ func Split(sql string) []Segment {
 	atStmtStart := true
 
 	for i < len(sql) {
-		// Check for DELIMITER directive.
-		if matchWord(sql, i, "DELIMITER") {
+		// Check for DELIMITER directive (only at statement-start position).
+		if atStmtStart && matchWord(sql, i, "DELIMITER") {
 			j := skipToEndOfWord(sql, i)
 			j = skipWhitespace(sql, j)
 			delimStart := j

--- a/mariadb/parser/split.go
+++ b/mariadb/parser/split.go
@@ -197,30 +197,34 @@ func Split(sql string) []Segment {
 
 	for i < len(sql) {
 		// Check for DELIMITER directive (only at statement-start position).
+		// Require DELIMITER followed by whitespace to distinguish from labels
+		// like "delimiter: LOOP".
 		if atStmtStart && matchWord(sql, i, "DELIMITER") {
 			j := skipToEndOfWord(sql, i)
-			j = skipWhitespace(sql, j)
-			delimStart := j
-			for j < len(sql) && sql[j] != '\n' && sql[j] != '\r' {
-				j++
+			if j < len(sql) && (sql[j] == ' ' || sql[j] == '\t') {
+				j = skipWhitespace(sql, j)
+				delimStart := j
+				for j < len(sql) && sql[j] != '\n' && sql[j] != '\r' {
+					j++
+				}
+				delimEnd := j
+				for delimEnd > delimStart && (sql[delimEnd-1] == ' ' || sql[delimEnd-1] == '\t') {
+					delimEnd--
+				}
+				if delimEnd > delimStart {
+					delim = sql[delimStart:delimEnd]
+				}
+				if j < len(sql) && sql[j] == '\r' {
+					j++
+				}
+				if j < len(sql) && sql[j] == '\n' {
+					j++
+				}
+				i = j
+				stmtStart = i
+				atStmtStart = true
+				continue
 			}
-			delimEnd := j
-			for delimEnd > delimStart && (sql[delimEnd-1] == ' ' || sql[delimEnd-1] == '\t') {
-				delimEnd--
-			}
-			if delimEnd > delimStart {
-				delim = sql[delimStart:delimEnd]
-			}
-			if j < len(sql) && sql[j] == '\r' {
-				j++
-			}
-			if j < len(sql) && sql[j] == '\n' {
-				j++
-			}
-			i = j
-			stmtStart = i
-			atStmtStart = true
-			continue
 		}
 
 		b := sql[i]

--- a/mysql/parser/split.go
+++ b/mysql/parser/split.go
@@ -196,8 +196,8 @@ func Split(sql string) []Segment {
 	atStmtStart := true
 
 	for i < len(sql) {
-		// Check for DELIMITER directive.
-		if matchWord(sql, i, "DELIMITER") {
+		// Check for DELIMITER directive (only at statement-start position).
+		if atStmtStart && matchWord(sql, i, "DELIMITER") {
 			j := skipToEndOfWord(sql, i)
 			j = skipWhitespace(sql, j)
 			delimStart := j

--- a/mysql/parser/split.go
+++ b/mysql/parser/split.go
@@ -197,30 +197,34 @@ func Split(sql string) []Segment {
 
 	for i < len(sql) {
 		// Check for DELIMITER directive (only at statement-start position).
+		// Require DELIMITER followed by whitespace to distinguish from labels
+		// like "delimiter: LOOP".
 		if atStmtStart && matchWord(sql, i, "DELIMITER") {
 			j := skipToEndOfWord(sql, i)
-			j = skipWhitespace(sql, j)
-			delimStart := j
-			for j < len(sql) && sql[j] != '\n' && sql[j] != '\r' {
-				j++
+			if j < len(sql) && (sql[j] == ' ' || sql[j] == '\t') {
+				j = skipWhitespace(sql, j)
+				delimStart := j
+				for j < len(sql) && sql[j] != '\n' && sql[j] != '\r' {
+					j++
+				}
+				delimEnd := j
+				for delimEnd > delimStart && (sql[delimEnd-1] == ' ' || sql[delimEnd-1] == '\t') {
+					delimEnd--
+				}
+				if delimEnd > delimStart {
+					delim = sql[delimStart:delimEnd]
+				}
+				if j < len(sql) && sql[j] == '\r' {
+					j++
+				}
+				if j < len(sql) && sql[j] == '\n' {
+					j++
+				}
+				i = j
+				stmtStart = i
+				atStmtStart = true
+				continue
 			}
-			delimEnd := j
-			for delimEnd > delimStart && (sql[delimEnd-1] == ' ' || sql[delimEnd-1] == '\t') {
-				delimEnd--
-			}
-			if delimEnd > delimStart {
-				delim = sql[delimStart:delimEnd]
-			}
-			if j < len(sql) && sql[j] == '\r' {
-				j++
-			}
-			if j < len(sql) && sql[j] == '\n' {
-				j++
-			}
-			i = j
-			stmtStart = i
-			atStmtStart = true
-			continue
 		}
 
 		b := sql[i]

--- a/mysql/parser/split_realworld_test.go
+++ b/mysql/parser/split_realworld_test.go
@@ -377,6 +377,11 @@ SELECT 3;`,
 			sql:  "DELIMITER ;;\nCREATE PROCEDURE p() BEGIN\n  SELECT delimiter FROM t;\nEND;;\nDELIMITER ;\nCALL p();",
 			want: 2,
 		},
+		{
+			name: "delimiter as label name is not a directive",
+			sql:  "DELIMITER ;;\nCREATE PROCEDURE p() BEGIN\n  delimiter: LOOP\n    SELECT 1;\n    LEAVE delimiter;\n  END LOOP delimiter;\nEND;;\nDELIMITER ;\n",
+			want: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/mysql/parser/split_realworld_test.go
+++ b/mysql/parser/split_realworld_test.go
@@ -357,6 +357,26 @@ DELIMITER ;
 SELECT 3;`,
 			want: 3,
 		},
+		{
+			name: "delimiter as column name is not a directive",
+			sql:  "SELECT delimiter FROM t;",
+			want: 1,
+		},
+		{
+			name: "delimiter as column name in multi-statement",
+			sql:  "SELECT 1;\nSELECT delimiter FROM t;\nSELECT 2;",
+			want: 3,
+		},
+		{
+			name: "delimiter in CREATE TABLE column definition",
+			sql:  "CREATE TABLE t (\n  delimiter INT,\n  c INT\n);",
+			want: 1,
+		},
+		{
+			name: "delimiter identifier inside procedure body with DELIMITER directive",
+			sql:  "DELIMITER ;;\nCREATE PROCEDURE p() BEGIN\n  SELECT delimiter FROM t;\nEND;;\nDELIMITER ;\nCALL p();",
+			want: 2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -202,30 +202,34 @@ func Split(sql string) []Segment {
 
 	for i < len(sql) {
 		// Check for DELIMITER directive (only at statement-start position).
+		// Require DELIMITER followed by whitespace to distinguish from labels
+		// like "delimiter: LOOP".
 		if atStmtStart && matchWord(sql, i, "DELIMITER") {
 			j := skipToEndOfWord(sql, i)
-			j = skipWhitespace(sql, j)
-			delimStart := j
-			for j < len(sql) && sql[j] != '\n' && sql[j] != '\r' {
-				j++
+			if j < len(sql) && (sql[j] == ' ' || sql[j] == '\t') {
+				j = skipWhitespace(sql, j)
+				delimStart := j
+				for j < len(sql) && sql[j] != '\n' && sql[j] != '\r' {
+					j++
+				}
+				delimEnd := j
+				for delimEnd > delimStart && (sql[delimEnd-1] == ' ' || sql[delimEnd-1] == '\t') {
+					delimEnd--
+				}
+				if delimEnd > delimStart {
+					delim = sql[delimStart:delimEnd]
+				}
+				if j < len(sql) && sql[j] == '\r' {
+					j++
+				}
+				if j < len(sql) && sql[j] == '\n' {
+					j++
+				}
+				i = j
+				stmtStart = i
+				atStmtStart = true
+				continue
 			}
-			delimEnd := j
-			for delimEnd > delimStart && (sql[delimEnd-1] == ' ' || sql[delimEnd-1] == '\t') {
-				delimEnd--
-			}
-			if delimEnd > delimStart {
-				delim = sql[delimStart:delimEnd]
-			}
-			if j < len(sql) && sql[j] == '\r' {
-				j++
-			}
-			if j < len(sql) && sql[j] == '\n' {
-				j++
-			}
-			i = j
-			stmtStart = i
-			atStmtStart = true
-			continue
 		}
 
 		b := sql[i]

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -201,8 +201,8 @@ func Split(sql string) []Segment {
 	atStmtStart := true
 
 	for i < len(sql) {
-		// Check for DELIMITER directive.
-		if matchWord(sql, i, "DELIMITER") {
+		// Check for DELIMITER directive (only at statement-start position).
+		if atStmtStart && matchWord(sql, i, "DELIMITER") {
 			j := skipToEndOfWord(sql, i)
 			j = skipWhitespace(sql, j)
 			delimStart := j


### PR DESCRIPTION
## Summary
- Gate the DELIMITER directive check on `atStmtStart` in MySQL, TiDB, and MariaDB Split functions
- Previously, any line containing the word "delimiter" (even as an identifier like `SELECT delimiter FROM t`) was treated as a client DELIMITER directive
- Now DELIMITER is only recognized at statement-start position, matching mysql client behavior
- Require whitespace (space/tab) after the `DELIMITER` keyword — labels like `delimiter: LOOP` are no longer misrecognized as directives

## Delimiter scope
The Split function supports common custom delimiters (`;;`, `$$`, `//`, etc.). Comment-opener delimiters (`DELIMITER --`, `DELIMITER #`) are **deliberately unsupported** — they conflict with line-comment detection and are not used in practice.

## Test plan
- Added 5 new test cases in `mysql/parser/split_realworld_test.go`:
  - `delimiter` as column name in SELECT
  - `delimiter` as column name in multi-statement
  - `delimiter` in CREATE TABLE column definition
  - `delimiter` identifier inside procedure body with actual DELIMITER directive
  - `delimiter` as label name (with colon) is not treated as directive
- All existing Split tests continue to pass across MySQL, TiDB, and MariaDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)