### PR TITLE
feat(mysql/catalog): add normalize-core diff-time canonicalization (mysql SDL)

### DIFF
--- a/mysql/catalog/altercmds.go
+++ b/mysql/catalog/altercmds.go
@@ -907,9 +907,11 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 		}
 		if colDef.TypeName.Charset != "" {
 			col.Charset = normalizeCharsetName(colDef.TypeName.Charset)
+			col.CharsetExplicit = true
 		}
 		if colDef.TypeName.Collate != "" {
 			col.Collation = colDef.TypeName.Collate
+			col.CollationExplicit = true
 			if col.Charset == "" {
 				col.Charset = normalizeCharsetName(charsetForCollation(col.Collation))
 			}
@@ -961,8 +963,10 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 		switch cc.Type {
 		case nodes.ColConstrNotNull:
 			col.Nullable = false
+			col.NullExplicit = true
 		case nodes.ColConstrNull:
 			col.Nullable = true
+			col.NullExplicit = true
 		case nodes.ColConstrDefault:
 			if cc.Expr != nil {
 				setColumnDefaultFromExpr(col, cc.Expr)
@@ -978,6 +982,7 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 			if cc.Expr != nil {
 				if s, ok := cc.Expr.(*nodes.StringLit); ok {
 					col.Collation = s.Value
+					col.CollationExplicit = true
 				}
 			}
 		}

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -1,0 +1,1000 @@
+package catalog
+
+// Package-level diff-time canonicalization for MySQL SDL (declarative) migration.
+//
+// MySQL implicitly rewrites DDL on storage: it drops integer display widths (8.0),
+// injects them (5.7), folds BOOLEAN to tinyint(1), echoes or strips column charset
+// clauses depending on version, single-quotes numeric defaults, and so on. A
+// declarative diff compares the user's TARGET schema against the SYNCED (stored)
+// schema read back via SHOW CREATE TABLE. Unless both sides are reduced to MySQL's
+// canonical stored form first, every implicit rewrite produces a phantom diff forever.
+//
+// This file is the single owner of that canonical form. diff-core calls the
+// Canonical* / Resolve* methods below wherever it compares columns, types, defaults,
+// charset/collation, generated expressions, or table options. The defining property,
+// proven against the live oracle, is:
+//
+//	Canonical(userTargetForm) == Canonical(syncedStoredForm)   (for a given engine version)
+//
+// Every entry in docs/migration/mysql/sdl/normalization.md is a readback that this
+// layer must collapse onto its target form. Behavior that diverges across MySQL 5.7
+// and 8.0 is branched on Version; behavior that depends on a session variable
+// (explicit_defaults_for_timestamp) is taken from the Normalizer context, never
+// hardcoded to a version (see the flag explicit-defaults-for-timestamp-is-session-var).
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version identifies the target MySQL major version whose stored form the
+// canonicalizer must reproduce. Charset spelling, integer display width, YEAR width,
+// descending indexes, the utf8mb4 default collation, CHECK persistence, functional
+// defaults, and the expression charset introducer all diverge across these.
+type Version int
+
+const (
+	// MySQL57 reproduces MySQL 5.7's stored form (display widths injected,
+	// utf8 spelling, utf8mb4_general_ci default, no descending indexes, CHECK dropped).
+	MySQL57 Version = iota
+	// MySQL80 reproduces MySQL 8.0's stored form (display widths dropped except
+	// tinyint(1)/zerofill, utf8mb3 spelling, utf8mb4_0900_ai_ci default, descending
+	// indexes, CHECK kept, functional defaults, _latin1 expression introducer).
+	MySQL80
+)
+
+// Normalizer carries the engine version plus the session/server variables that the
+// canonical stored form depends on. diff-core constructs one per side from the
+// synced schema's captured version and variables, then resolves both the target and
+// the current catalog through it so the two are compared in the same normal form.
+type Normalizer struct {
+	Version Version
+	// ExplicitDefaultsForTimestamp is the effective explicit_defaults_for_timestamp.
+	// It governs the implicit NOT NULL / DEFAULT CURRENT_TIMESTAMP magic on bare
+	// TIMESTAMP columns. It is a session/server variable, NOT a version trait: a 5.7
+	// server can run with it ON and an 8.0 server with it OFF. diff-core must capture
+	// it per source database and pass it here. NormalizerFor seeds it to each
+	// version's box default for convenience, but callers should override it from the
+	// synced schema when known.
+	ExplicitDefaultsForTimestamp bool
+}
+
+// NormalizerFor builds a Normalizer for a version, seeding session variables to that
+// version's oracle-box default (explicit_defaults_for_timestamp=0 on 5.7, 1 on 8.0).
+// Callers with a captured value should set ExplicitDefaultsForTimestamp explicitly.
+func NormalizerFor(v Version) *Normalizer {
+	return &Normalizer{
+		Version:                      v,
+		ExplicitDefaultsForTimestamp: v == MySQL80,
+	}
+}
+
+// is80 reports whether the target reproduces 8.0 stored form.
+func (n *Normalizer) is80() bool { return n.Version == MySQL80 }
+
+// ---------------------------------------------------------------------------
+// Charset / collation — the dominant phantom-diff surface (HIGHEST RISK).
+// ---------------------------------------------------------------------------
+
+// foldCharset maps a charset name to a version-independent identity so that the two
+// spellings of the same charset compare equal. MySQL stores utf8 (5.7) vs utf8mb3
+// (8.0) for the same charset; folding both to utf8mb3 lets the resolved pair compare
+// equal regardless of which version's surface spelling each side carried.
+// (entry utf8-utf8mb3-alias)
+func foldCharset(cs string) string {
+	cs = strings.ToLower(strings.TrimSpace(cs))
+	if cs == "utf8" {
+		return "utf8mb3"
+	}
+	return cs
+}
+
+// foldCollation maps a collation name to a version-independent identity. It rewrites a
+// utf8_* collation prefix to utf8mb3_* to match foldCharset, so utf8_general_ci (5.7)
+// and utf8mb3_general_ci (8.0) — the same collation — compare equal.
+func foldCollation(coll string) string {
+	coll = strings.ToLower(strings.TrimSpace(coll))
+	if strings.HasPrefix(coll, "utf8_") {
+		return "utf8mb3_" + coll[len("utf8_"):]
+	}
+	return coll
+}
+
+// defaultCollationFor returns the version-correct default collation for a charset,
+// already folded. The utf8mb4 default is the single most dangerous case: 8.0 uses
+// utf8mb4_0900_ai_ci (which does not even exist on 5.7) while 5.7 uses
+// utf8mb4_general_ci. (entry utf8mb4-default-collation)
+func (n *Normalizer) defaultCollationFor(charset string) string {
+	cs := foldCharset(charset)
+	if cs == "utf8mb4" {
+		if n.is80() {
+			return "utf8mb4_0900_ai_ci"
+		}
+		return "utf8mb4_general_ci"
+	}
+	if dc, ok := defaultCollationForCharset[cs]; ok {
+		return foldCollation(dc)
+	}
+	// Last resort: derive <charset>_general_ci.
+	if cs != "" {
+		return foldCollation(cs + "_general_ci")
+	}
+	return ""
+}
+
+// ResolveColumnCharsetCollation returns the effective (charset, collation) pair of a
+// column, folded to a version-independent identity, so that diff-core can compare the
+// resolved pair instead of the surface CHARACTER SET/COLLATE tokens. This is the
+// canonical strategy for the whole charset family (flag
+// column-charset-collation-echo-asymmetry): surface-token comparison phantom-diffs
+// across versions because 5.7 STRIPS a column's charset when it equals the table's
+// while 8.0 KEEPS it as a full pair; resolving the effective pair on BOTH sides and
+// comparing that is version-robust.
+//
+// Resolution rules (entries column-charset-echo-57/-80, -only-collation-resolution):
+//   - charset: the column's own charset if set, else the table's charset.
+//   - collation: the column's own collation if set; else, if the column set a charset,
+//     that CHARSET's default collation (NOT the table's COLLATE — this is the subtle
+//     -only-collation-resolution rule); else the table's collation; else the table
+//     charset's default collation.
+//
+// For non-string columns (no charset concept) it returns ("", "").
+func (n *Normalizer) ResolveColumnCharsetCollation(table *Table, c *Column) (charset, collation string) {
+	if !isStringType(c.DataType) && !isEnumSetType(c.DataType) {
+		return "", ""
+	}
+
+	tableCharset := foldCharset(table.Charset)
+	tableCollation := foldCollation(table.Collation)
+
+	colCharset := foldCharset(c.Charset)
+	colCollation := foldCollation(c.Collation)
+
+	// Effective charset: the column's own charset if set, else the table's. (The omni
+	// loader pre-fills col.Charset from the table for bare columns, so an empty
+	// colCharset and colCharset==tableCharset are both treated as "inherits table".)
+	if colCharset == "" {
+		charset = tableCharset
+	} else {
+		charset = colCharset
+	}
+
+	// Effective collation — the subtle part. The omni loader pre-fills col.Collation at
+	// load time using 8.0 rules, even when targeting 5.7 and even for bare/charset-only
+	// columns (where it wrongly copies the table COLLATE). So col.Collation cannot be
+	// read as "user explicitly set this". We re-derive the version-correct collation and
+	// honor col.Collation ONLY as a genuine override — detected as a value that differs
+	// from the table's collation (the loader's inheritance source). See flag
+	// column-collation-explicit-vs-inherited for the residual edge.
+	switch {
+	case colCollation != "" && colCollation != tableCollation:
+		// Genuine column-level override (differs from the loader's inheritance source).
+		collation = colCollation
+	case colCharset != "" && colCharset != tableCharset:
+		// Column set a charset different from the table: collation resolves from THAT
+		// charset's default, never the table COLLATE.
+		// (entry column-charset-only-collation-resolution)
+		collation = n.defaultCollationFor(colCharset)
+	default:
+		// Bare column, or column whose charset/collation equals the table's: the
+		// effective collation is the version-correct default for the effective charset.
+		// This re-resolves the loader's baked-in 8.0 default to the target version's
+		// default (e.g. utf8mb4 → utf8mb4_general_ci on 5.7).
+		collation = n.defaultCollationFor(charset)
+	}
+	return charset, collation
+}
+
+// ---------------------------------------------------------------------------
+// Column type — integer display width, BOOLEAN, decimal/float, year, zerofill.
+// ---------------------------------------------------------------------------
+
+// parsedType is a decomposed column-type string. The loader stores the 8.0 form (e.g.
+// "int"); raw readback strings may carry widths (e.g. "int(11)"). CanonicalColumnType
+// parses either and re-emits the version-correct canonical form, so both collapse onto
+// one value and never phantom-diff.
+type parsedType struct {
+	base     string // lowercased base type name (already alias-folded: numeric→decimal, etc.)
+	length   int    // first paren arg (display width, char length, precision); 0 = absent
+	scale    int    // second paren arg (decimal/float scale); -1 = absent
+	hasLen   bool
+	hasScale bool
+	unsigned bool
+	zerofill bool
+	suffix   string // verbatim tail for types we do not reformat (enum/set member list)
+}
+
+// parseColumnType decomposes a column-type string into base/length/scale/modifiers.
+func parseColumnType(columnType string) parsedType {
+	s := strings.TrimSpace(columnType)
+	low := strings.ToLower(s)
+
+	p := parsedType{scale: -1}
+
+	// Trailing modifiers.
+	if strings.Contains(low, "zerofill") {
+		p.zerofill = true
+		p.unsigned = true // zerofill implies unsigned
+	}
+	if strings.Contains(low, "unsigned") {
+		p.unsigned = true
+	}
+	// Strip the modifier words to isolate "<base>[(args)]".
+	low = strings.TrimSpace(strings.NewReplacer("unsigned", "", "zerofill", "").Replace(low))
+
+	// enum/set: keep the member list verbatim (order is significant), normalize quoting.
+	if strings.HasPrefix(low, "enum(") || strings.HasPrefix(low, "set(") {
+		open := strings.IndexByte(low, '(')
+		p.base = normalizedTypeName(low[:open])
+		p.suffix = s[open:] // original-cased member list
+		return p
+	}
+
+	if open := strings.IndexByte(low, '('); open >= 0 {
+		close := strings.LastIndexByte(low, ')')
+		argStr := low[open+1 : close]
+		name := strings.TrimSpace(low[:open])
+		p.base = normalizedTypeName(name)
+		args := strings.SplitN(argStr, ",", 2)
+		if v, err := strconv.Atoi(strings.TrimSpace(args[0])); err == nil {
+			p.length = v
+			p.hasLen = true
+		}
+		if len(args) == 2 {
+			if v, err := strconv.Atoi(strings.TrimSpace(args[1])); err == nil {
+				p.scale = v
+				p.hasScale = true
+			}
+		}
+	} else {
+		p.base = normalizedTypeName(low)
+	}
+	return p
+}
+
+// CanonicalColumnType returns the canonical stored column type for the target version.
+// It folds aliases (BOOLEAN/BOOL→tinyint(1), NUMERIC/DEC/FIXED→decimal, REAL→double,
+// integer→int), applies the version's integer-display-width rule (8.0 drops widths
+// except tinyint(1) and zerofill; 5.7 injects the type's default width), pads DECIMAL
+// precision/scale, drops single-arg FLOAT precision, injects length-1 for bare
+// CHAR/BINARY/BIT, and reproduces the version's YEAR width. The result is a stable
+// comparison key, not necessarily a SHOW CREATE rendering.
+func (n *Normalizer) CanonicalColumnType(c *Column) string {
+	p := parseColumnType(c.ColumnType)
+	return n.canonicalType(p)
+}
+
+func (n *Normalizer) canonicalType(p parsedType) string {
+	switch p.base {
+	case "boolean", "bool":
+		// BOOLEAN/BOOL → tinyint(1) on both versions.
+		return "tinyint(1)"
+	case "serial":
+		return "bigint unsigned"
+	}
+
+	if isIntegerType(p.base) {
+		return n.canonicalIntType(p)
+	}
+	if p.base == "decimal" {
+		length, scale := p.length, p.scale
+		if !p.hasLen {
+			length = 10
+		}
+		if !p.hasScale {
+			scale = 0
+		}
+		return n.withUnsigned(fmt.Sprintf("decimal(%d,%d)", length, scale), p)
+	}
+	if p.base == "float" || p.base == "double" {
+		base := p.base
+		// FLOAT(M,D)/DOUBLE(M,D) retained; single-arg FLOAT(p) precision dropped;
+		// FLOAT with precision > 24 was already folded to double upstream — fold here too.
+		if p.base == "float" && p.hasLen && !p.hasScale && p.length > 24 {
+			base = "double"
+		}
+		if p.hasLen && p.hasScale {
+			return n.withUnsigned(fmt.Sprintf("%s(%d,%d)", base, p.length, p.scale), p)
+		}
+		return n.withUnsigned(base, p)
+	}
+
+	switch p.base {
+	case "year":
+		if n.is80() {
+			return "year"
+		}
+		return "year(4)"
+	case "bit":
+		if !p.hasLen {
+			return "bit(1)"
+		}
+		return fmt.Sprintf("bit(%d)", p.length)
+	case "char", "binary":
+		if !p.hasLen {
+			return p.base + "(1)"
+		}
+		return fmt.Sprintf("%s(%d)", p.base, p.length)
+	case "enum", "set":
+		return p.base + canonicalEnumSuffix(p.suffix)
+	}
+
+	// Text/blob: never carry a width.
+	if isTextBlobLengthStripped(p.base) {
+		return p.base
+	}
+
+	// Default: keep length/scale verbatim (varchar(N), varbinary(N), time(N), etc.).
+	if p.hasLen && p.hasScale {
+		return fmt.Sprintf("%s(%d,%d)", p.base, p.length, p.scale)
+	}
+	if p.hasLen {
+		return fmt.Sprintf("%s(%d)", p.base, p.length)
+	}
+	return p.base
+}
+
+// canonicalIntType applies the version-specific integer display-width rule.
+func (n *Normalizer) canonicalIntType(p parsedType) string {
+	base := p.base
+	if base == "integer" {
+		base = "int"
+	}
+
+	// tinyint(1) is the boolean marker: width survives on BOTH versions (only when
+	// signed and not zerofill — tinyint(1) unsigned/zerofill is a plain narrow int).
+	if base == "tinyint" && p.hasLen && p.length == 1 && !p.unsigned && !p.zerofill {
+		return "tinyint(1)"
+	}
+
+	// ZEROFILL retains the display width on both versions (8.0 does NOT drop it).
+	if p.zerofill {
+		width := p.length
+		if !p.hasLen {
+			width = defaultIntDisplayWidth(base, true)
+		}
+		return fmt.Sprintf("%s(%d) unsigned zerofill", base, width)
+	}
+
+	if n.is80() {
+		// 8.0 drops the display width from all (non-zerofill) integer types.
+		return n.withUnsigned(base, p)
+	}
+	// 5.7 keeps/injects the default width.
+	width := p.length
+	if !p.hasLen {
+		width = defaultIntDisplayWidth(base, p.unsigned)
+	}
+	return n.withUnsigned(fmt.Sprintf("%s(%d)", base, width), p)
+}
+
+// withUnsigned appends " unsigned" to a rendered type when the column is unsigned
+// (but not zerofill, which renders its own "unsigned zerofill").
+func (n *Normalizer) withUnsigned(typeStr string, p parsedType) string {
+	if p.unsigned && !p.zerofill {
+		return typeStr + " unsigned"
+	}
+	return typeStr
+}
+
+// canonicalEnumSuffix normalizes an enum/set member list "('a','b',...)" to a canonical
+// form: each member single-quoted, order preserved (order is semantically significant
+// for ENUM/SET and is never reordered). Double-quoted members become single-quoted.
+// (entry enum-set-quoting)
+func canonicalEnumSuffix(suffix string) string {
+	s := strings.TrimSpace(suffix)
+	if len(s) < 2 || s[0] != '(' || s[len(s)-1] != ')' {
+		return suffix
+	}
+	inner := s[1 : len(s)-1]
+	members := splitEnumMembers(inner)
+	parts := make([]string, len(members))
+	for i, m := range members {
+		parts[i] = "'" + strings.ReplaceAll(m, "'", "''") + "'"
+	}
+	return "(" + strings.Join(parts, ",") + ")"
+}
+
+// splitEnumMembers splits a comma-separated quoted member list into decoded member
+// contents, honoring single- or double-quoting and doubled-quote escapes.
+func splitEnumMembers(inner string) []string {
+	var members []string
+	i := 0
+	for i < len(inner) {
+		// Skip separators/whitespace.
+		for i < len(inner) && (inner[i] == ',' || inner[i] == ' ' || inner[i] == '\t') {
+			i++
+		}
+		if i >= len(inner) {
+			break
+		}
+		q := inner[i]
+		if q != '\'' && q != '"' {
+			// Unexpected; bail with whatever remains as one member.
+			members = append(members, inner[i:])
+			break
+		}
+		i++
+		var b strings.Builder
+		for i < len(inner) {
+			if inner[i] == q {
+				if i+1 < len(inner) && inner[i+1] == q {
+					b.WriteByte(q)
+					i += 2
+					continue
+				}
+				i++
+				break
+			}
+			b.WriteByte(inner[i])
+			i++
+		}
+		members = append(members, b.String())
+	}
+	return members
+}
+
+// ---------------------------------------------------------------------------
+// Column default — value-based canonicalization.
+// ---------------------------------------------------------------------------
+
+// CanonicalDefault returns a comparison key for a column's DEFAULT. It is value-based,
+// not string-based (flag numeric-default-quote-version): DEFAULT 0 and DEFAULT '0'
+// yield the same key, because MySQL quotes numeric defaults in storage but the exact
+// quoting drifts across 8.0 point releases. Rules:
+//   - absent default OR explicit NULL → a single "no value" key (they are equivalent
+//     for a nullable column; the differ compares nullability separately).
+//   - CURRENT_TIMESTAMP family (incl. NOW/LOCALTIME/LOCALTIMESTAMP and (N) variants)
+//     → "CURRENT_TIMESTAMP[(N)]" unquoted, by DefaultKind.
+//   - functional DEFAULT (expression) → the expression run through the same generated-
+//     expression normalizer (8.0-only construct).
+//   - numeric literal on a scaled DECIMAL → padded to scale ('0' → '0.00') then keyed
+//     as the numeric value.
+//   - numeric literal otherwise → keyed by parsed numeric value (quote-insensitive).
+//   - string literal → keyed by its decoded content (quote style/charset-independent).
+func (n *Normalizer) CanonicalDefault(c *Column) string {
+	// Absent / dropped default.
+	if c.Default == nil {
+		return defaultAbsentKey
+	}
+	raw := strings.TrimSpace(*c.Default)
+	if strings.EqualFold(raw, "NULL") {
+		return defaultAbsentKey
+	}
+
+	switch c.DefaultKind {
+	case ColumnDefaultCurrentTimestamp:
+		if ts, ok := normalizeCurrentTimestamp(raw); ok {
+			return "ts:" + ts
+		}
+		return "ts:CURRENT_TIMESTAMP"
+	case ColumnDefaultExpression:
+		return "expr:" + n.CanonicalGeneratedExpr(stripOuterParens(raw))
+	}
+
+	// Constant. Decide numeric vs string by the column's data type and the literal shape.
+	unq, wasQuoted := unquoteDefault(raw)
+
+	if isNumericType(c.DataType) {
+		// Numeric column: compare by numeric value, padded to the column's scale.
+		if key, ok := numericDefaultKey(c.ColumnType, unq); ok {
+			return key
+		}
+	}
+	// Bit literal default (b'...' / 0b...).
+	if looksLikeBitLiteral(raw) {
+		return "bit:" + canonicalBitLiteral(raw)
+	}
+	// If it parses as a number and the column is not obviously a string type, key by value.
+	if !wasQuoted && !isStringType(c.DataType) && !isEnumSetType(c.DataType) {
+		if key, ok := numericDefaultKey(c.ColumnType, unq); ok {
+			return key
+		}
+	}
+	// String/other literal: key by decoded content.
+	return "str:" + unq
+}
+
+const defaultAbsentKey = "<none>"
+
+// normalizeCurrentTimestamp folds CURRENT_TIMESTAMP synonyms (NOW, LOCALTIME,
+// LOCALTIMESTAMP) and (N) variants to "CURRENT_TIMESTAMP[(N)]".
+func normalizeCurrentTimestamp(val string) (string, bool) {
+	if ts, ok := currentTimestampSQL(val); ok {
+		return ts, true
+	}
+	upper := strings.ToUpper(strings.TrimSpace(val))
+	switch upper {
+	case "LOCALTIME", "LOCALTIME()", "LOCALTIMESTAMP", "LOCALTIMESTAMP()":
+		return "CURRENT_TIMESTAMP", true
+	}
+	for _, prefix := range []string{"LOCALTIME(", "LOCALTIMESTAMP("} {
+		if strings.HasPrefix(upper, prefix) && strings.HasSuffix(upper, ")") {
+			return "CURRENT_TIMESTAMP" + upper[len(prefix)-1:], true
+		}
+	}
+	return "", false
+}
+
+// unquoteDefault strips one layer of surrounding single or double quotes from a default
+// literal and un-doubles embedded quotes, returning the decoded content and whether it
+// was quoted.
+func unquoteDefault(s string) (string, bool) {
+	if len(s) >= 2 {
+		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
+			q := s[0]
+			inner := s[1 : len(s)-1]
+			inner = strings.ReplaceAll(inner, string([]byte{q, q}), string(q))
+			return inner, true
+		}
+	}
+	return s, false
+}
+
+// numericDefaultKey parses a numeric default and renders a canonical value key, padded
+// to the column's DECIMAL scale where applicable so '0' and '0.00' compare equal.
+func numericDefaultKey(columnType, literal string) (string, bool) {
+	literal = strings.TrimSpace(literal)
+	f, err := strconv.ParseFloat(literal, 64)
+	if err != nil {
+		return "", false
+	}
+	// Scale: from a decimal(M,D) column type, else from the literal's own precision.
+	if scale, ok := decimalScaleOf(columnType); ok {
+		return "num:" + strconv.FormatFloat(f, 'f', scale, 64), true
+	}
+	// Integer or unscaled: a canonical shortest form.
+	return "num:" + strconv.FormatFloat(f, 'f', -1, 64), true
+}
+
+// decimalScaleOf extracts the scale D from a decimal(M,D) column type.
+func decimalScaleOf(columnType string) (int, bool) {
+	p := parseColumnType(columnType)
+	if p.base == "decimal" && p.hasScale {
+		return p.scale, true
+	}
+	return 0, false
+}
+
+// isNumericType reports whether a base data type carries a numeric default.
+func isNumericType(dt string) bool {
+	switch dt {
+	case "tinyint", "smallint", "mediumint", "int", "integer", "bigint",
+		"decimal", "numeric", "dec", "fixed", "float", "double", "real", "bit":
+		return true
+	}
+	return false
+}
+
+func looksLikeBitLiteral(s string) bool {
+	low := strings.ToLower(strings.TrimSpace(s))
+	return strings.HasPrefix(low, "b'") || strings.HasPrefix(low, "0b")
+}
+
+// stripOuterParens removes one balanced layer of outer parentheses, used to normalize
+// functional-default expressions whose stored form is double-parenthesized.
+func stripOuterParens(s string) string {
+	s = strings.TrimSpace(s)
+	for len(s) >= 2 && s[0] == '(' && s[len(s)-1] == ')' && balancedFirstParenWrapsAll(s) {
+		s = strings.TrimSpace(s[1 : len(s)-1])
+	}
+	return s
+}
+
+// balancedFirstParenWrapsAll reports whether the opening paren at index 0 matches the
+// closing paren at the end (i.e. the whole string is one parenthesized group).
+func balancedFirstParenWrapsAll(s string) bool {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(s)-1 {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}
+
+// ---------------------------------------------------------------------------
+// Generated / functional-default expression canonicalization.
+// ---------------------------------------------------------------------------
+
+// CanonicalGeneratedExpr returns a comparison key for a generated-column expression,
+// functional DEFAULT (expression), or CHECK expression. MySQL rewrites these on
+// storage: identifiers are backticked, binary operators single-spaced, an outer paren
+// pair is added, function names lowercased, and — on 8.0 only — string literals gain a
+// charset introducer (_latin1'x') reflecting the connection charset at create time.
+// The introducer is connection-dependent noise that makes 8.0 readbacks non-portable,
+// so this canonical key strips it (entry generated-expr-string-introducer), collapses
+// whitespace, removes outer parentheses, and lowercases identifiers/keywords outside
+// string literals. The result lets a user's expression, a 5.7 readback, and an 8.0
+// readback of the same logical expression all compare equal.
+func (n *Normalizer) CanonicalGeneratedExpr(expr string) string {
+	s := stripCharsetIntroducers(expr)
+	s = stripOuterParens(s)
+	s = collapseExprWhitespace(s)
+	return s
+}
+
+// stripCharsetIntroducers removes a charset introducer (e.g. _latin1, _utf8mb4) that
+// immediately precedes a single-quoted string literal, leaving the bare literal.
+func stripCharsetIntroducers(expr string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(expr) {
+		c := expr[i]
+		if c == '\'' {
+			// Copy the whole string literal verbatim (respecting doubled quotes).
+			j := i + 1
+			for j < len(expr) {
+				if expr[j] == '\'' {
+					if j+1 < len(expr) && expr[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			b.WriteString(expr[i : j+1])
+			i = j + 1
+			continue
+		}
+		if c == '_' {
+			// Possible charset introducer: _<ident>' — drop the "_<ident>" if a quote
+			// follows the identifier run.
+			j := i + 1
+			for j < len(expr) && (isIdentByte(expr[j])) {
+				j++
+			}
+			if j < len(expr) && expr[j] == '\'' && j > i+1 {
+				// Skip the introducer; the literal is copied on the next loop turn.
+				i = j
+				continue
+			}
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+func isIdentByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// collapseExprWhitespace lowercases the expression outside string literals, strips
+// backtick identifier quoting (lowercasing the inner name), and removes all whitespace,
+// so cosmetic spacing and quoting differences do not diff. String literals are copied
+// verbatim (case and spacing inside them are significant).
+func collapseExprWhitespace(expr string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(expr) {
+		c := expr[i]
+		switch c {
+		case '\'':
+			j := i + 1
+			for j < len(expr) {
+				if expr[j] == '\'' {
+					if j+1 < len(expr) && expr[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			b.WriteString(expr[i : j+1])
+			i = j + 1
+		case '`':
+			// Backticks are identifier quoting; drop them and lowercase the inner name
+			// so a backticked identifier and the bare identifier compare equal. The
+			// loader backticks both sides, but stripping is strictly more robust.
+			j := i + 1
+			for j < len(expr) && expr[j] != '`' {
+				j++
+			}
+			inner := expr[i+1 : j]
+			for k := 0; k < len(inner); k++ {
+				ch := inner[k]
+				if ch >= 'A' && ch <= 'Z' {
+					b.WriteByte(ch + ('a' - 'A'))
+				} else {
+					b.WriteByte(ch)
+				}
+			}
+			i = j + 1
+		case ' ', '\t', '\n', '\r':
+			// Skip whitespace entirely; tokens are re-joined without spaces. Operators
+			// and identifiers remain unambiguous because identifiers are backticked and
+			// numeric/keyword tokens are separated by punctuation in normalized MySQL
+			// expressions.
+			i++
+		default:
+			if c >= 'A' && c <= 'Z' {
+				b.WriteByte(c + ('a' - 'A'))
+			} else {
+				b.WriteByte(c)
+			}
+			i++
+		}
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Nullability + PK + the TIMESTAMP magic (explicit_defaults_for_timestamp).
+// ---------------------------------------------------------------------------
+
+// CanonicalNotNull returns the effective NOT NULL state of a column after MySQL's
+// implicit rewrites:
+//   - a PRIMARY KEY member is forced NOT NULL regardless of its declaration
+//     (entry pk-implies-not-null);
+//   - when explicit_defaults_for_timestamp is OFF, every bare TIMESTAMP column (no
+//     explicit nullability) becomes NOT NULL (entry timestamp-magic-first-57). This is
+//     governed by the captured session variable, NOT the version (flag #3): a 5.7
+//     server with the variable ON leaves TIMESTAMP nullable, an 8.0 server with it OFF
+//     forces NOT NULL.
+//
+// For all other columns it returns the declared !Nullable.
+func (n *Normalizer) CanonicalNotNull(table *Table, c *Column) bool {
+	if !c.Nullable {
+		return true
+	}
+	if n.columnInPrimaryKey(table, c) {
+		return true
+	}
+	// EDFT OFF: MySQL forces NOT NULL on a TIMESTAMP column that lacks an explicit NULL
+	// clause. The loader collapses `TIMESTAMP` (→ NOT NULL) and `TIMESTAMP NULL`
+	// (→ nullable) to the SAME catalog state (Nullable=true, no explicit-NULL flag), so
+	// in general they are indistinguishable. We force NOT NULL only where the catalog
+	// gives an unambiguous signal that the column is not the explicit-NULL form:
+	//   - it is the FIRST TIMESTAMP column (which also receives the implicit
+	//     DEFAULT CURRENT_TIMESTAMP — see CanonicalTimestampDefaults), or
+	//   - it carries a non-NULL explicit default (a `TIMESTAMP NULL` would have either no
+	//     default or DEFAULT NULL, never a real default).
+	// A non-first, default-less bare TIMESTAMP is indistinguishable from `TIMESTAMP NULL`
+	// post-load, so we conservatively keep it nullable to avoid a phantom nullability
+	// diff. This is the conservative ruling for the explicit_defaults_for_timestamp flag.
+	// See flag column-timestamp-explicit-null-lost.
+	if isTimestampType(c.DataType) && !n.ExplicitDefaultsForTimestamp && !c.userSetNullable() {
+		if n.isFirstTimestampColumn(table, c) || c.hasNonNullDefault() {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNonNullDefault reports whether the column carries an explicit non-NULL default.
+func (c *Column) hasNonNullDefault() bool {
+	return c.Default != nil && !strings.EqualFold(strings.TrimSpace(*c.Default), "NULL")
+}
+
+// userSetNullable reports whether the user explicitly chose this column nullable. The
+// catalog does not record an explicit-NULL flag distinct from the default, so we treat
+// a column carrying an explicit DEFAULT NULL (Default=="NULL") as user-chosen nullable.
+func (c *Column) userSetNullable() bool {
+	return c.Default != nil && strings.EqualFold(strings.TrimSpace(*c.Default), "NULL")
+}
+
+// columnInPrimaryKey reports whether the column participates in the table's PK.
+func (n *Normalizer) columnInPrimaryKey(table *Table, c *Column) bool {
+	for _, idx := range table.Indexes {
+		if !idx.Primary {
+			continue
+		}
+		for _, ic := range idx.Columns {
+			if strings.EqualFold(ic.Name, c.Name) {
+				return true
+			}
+		}
+	}
+	// Constraints may also express PK.
+	for _, con := range table.Constraints {
+		if con.Type != ConPrimaryKey {
+			continue
+		}
+		for _, col := range con.Columns {
+			if strings.EqualFold(col, c.Name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CanonicalTimestampDefaults returns the canonical (default, onUpdate) keys for a
+// TIMESTAMP/DATETIME column, applying the explicit_defaults_for_timestamp=OFF magic:
+// the FIRST bare TIMESTAMP column in the table gets an implicit
+// DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP. Both keys use the same
+// value-based form as CanonicalDefault ("ts:CURRENT_TIMESTAMP", "<none>", etc.).
+// When the user wrote an explicit default/on-update, that wins.
+func (n *Normalizer) CanonicalTimestampDefaults(table *Table, c *Column) (def, onUpdate string) {
+	def = n.CanonicalDefault(c)
+	onUpdate = n.canonicalOnUpdate(c)
+
+	if !isTimestampType(c.DataType) {
+		return def, onUpdate
+	}
+	if n.ExplicitDefaultsForTimestamp {
+		return def, onUpdate
+	}
+	// EDFT OFF and this is the first TIMESTAMP column with no explicit default: inject
+	// the implicit CURRENT_TIMESTAMP default + on-update.
+	if def == defaultAbsentKey && onUpdate == defaultAbsentKey && n.isFirstTimestampColumn(table, c) && !c.userSetNullable() {
+		return "ts:CURRENT_TIMESTAMP", "ts:CURRENT_TIMESTAMP"
+	}
+	return def, onUpdate
+}
+
+// canonicalOnUpdate returns the canonical ON UPDATE key for a column.
+func (n *Normalizer) canonicalOnUpdate(c *Column) string {
+	if c.OnUpdate == "" {
+		return defaultAbsentKey
+	}
+	if ts, ok := normalizeCurrentTimestamp(c.OnUpdate); ok {
+		return "ts:" + ts
+	}
+	return "str:" + c.OnUpdate
+}
+
+// isFirstTimestampColumn reports whether c is the first TIMESTAMP column (by position)
+// in the table — the one that receives the EDFT-off implicit default.
+func (n *Normalizer) isFirstTimestampColumn(table *Table, c *Column) bool {
+	for _, col := range table.Columns {
+		if isTimestampType(col.DataType) {
+			return strings.EqualFold(col.Name, c.Name)
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Table options — engine default + ignore-in-diff (AUTO_INCREMENT, ROW_FORMAT).
+// ---------------------------------------------------------------------------
+
+// defaultEngine is the server default storage engine that MySQL always emits in
+// SHOW CREATE even when the user omits ENGINE.
+const defaultEngine = "innodb"
+
+// CanonicalEngine returns the table's effective storage engine, lowercased, resolving
+// an empty value to the server default (InnoDB) so an omitted ENGINE matches the
+// always-emitted ENGINE=InnoDB readback (entry engine-always-emitted).
+func (n *Normalizer) CanonicalEngine(table *Table) string {
+	e := strings.ToLower(strings.TrimSpace(table.Engine))
+	if e == "" {
+		return defaultEngine
+	}
+	return e
+}
+
+// IgnoreTableAutoIncrement always reports true: the table-level AUTO_INCREMENT=N option
+// is the live next-value counter, not schema, and changes with every insert. diff-core
+// must never compare it (entry auto-increment-counter). The column-level AUTO_INCREMENT
+// attribute is real schema and is compared separately.
+func (n *Normalizer) IgnoreTableAutoIncrement() bool { return true }
+
+// IgnoreRowFormat reports whether the table's ROW_FORMAT should be excluded from the
+// diff. The default ROW_FORMAT is environment-dependent (innodb_default_row_format) and
+// not reliably reconstructible from DDL, so it is ignored unless the user explicitly set
+// a non-default value (entry row-format-default-omitted; flag row-format-default-source).
+func (n *Normalizer) IgnoreRowFormat(table *Table) bool {
+	rf := strings.ToUpper(strings.TrimSpace(table.RowFormat))
+	return rf == "" || rf == "DEFAULT"
+}
+
+// ---------------------------------------------------------------------------
+// Comments — content comparison (decoded).
+// ---------------------------------------------------------------------------
+
+// CanonicalComment returns a comment's decoded content for comparison. Comments are
+// stored single-quoted with embedded single quotes doubled; the diff compares content,
+// not the quoted surface form (entry comment-escaping). The catalog already stores the
+// decoded content, but un-doubling here makes the key robust to either form.
+func (n *Normalizer) CanonicalComment(comment string) string {
+	return strings.ReplaceAll(comment, "''", "'")
+}
+
+// ---------------------------------------------------------------------------
+// Index columns — descending direction is version-flagged.
+// ---------------------------------------------------------------------------
+
+// CanonicalIndexColumn returns a comparison key for one index column part, including
+// its prefix length (entry prefix-index) and — only on 8.0 — its DESC direction. 5.7
+// has no descending indexes and silently stores ascending, so direction is dropped from
+// the 5.7 key (entry index-desc-asc). Explicit ASC is the default and never contributes.
+func (n *Normalizer) CanonicalIndexColumn(ic *IndexColumn) string {
+	var b strings.Builder
+	if ic.Expr != "" {
+		b.WriteString("expr:")
+		b.WriteString(n.CanonicalGeneratedExpr(ic.Expr))
+	} else {
+		b.WriteString("col:")
+		b.WriteString(strings.ToLower(ic.Name))
+	}
+	if ic.Length > 0 {
+		fmt.Fprintf(&b, "(%d)", ic.Length)
+	}
+	// DESC is meaningful only on 8.0; 5.7 stores ascending regardless.
+	if n.is80() && ic.Descending {
+		b.WriteString(" desc")
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// CanonicalColumn — the aggregate comparison key (the phantom-diff firewall).
+// ---------------------------------------------------------------------------
+
+// CanonicalColumn returns a single stable comparison key for a column, folding every
+// per-aspect canonicalizer (type, resolved charset/collation pair, default, on-update,
+// nullability, generated expression, auto-increment, invisibility) into one string.
+// diff-core's column comparison (the MySQL analog of PG's columnsChanged at
+// pg/catalog/diff_column.go:66) compares two columns by equality of this key: equal
+// keys mean no change, so a column whose surface form differs from its synced readback
+// but whose canonical form is identical produces no phantom diff.
+//
+// It is the primary entry point; the individual Canonical*/Resolve* methods are exposed
+// for differs that need a single aspect (e.g. an ALTER that only touches the default).
+func (n *Normalizer) CanonicalColumn(table *Table, c *Column) string {
+	charset, collation := n.ResolveColumnCharsetCollation(table, c)
+	def, onUpdate := n.CanonicalTimestampDefaults(table, c)
+
+	var b strings.Builder
+	b.WriteString("name=")
+	b.WriteString(strings.ToLower(c.Name))
+	b.WriteString(";type=")
+	b.WriteString(n.CanonicalColumnType(c))
+	b.WriteString(";cs=")
+	b.WriteString(charset)
+	b.WriteString(";coll=")
+	b.WriteString(collation)
+	b.WriteString(";notnull=")
+	b.WriteString(strconv.FormatBool(n.CanonicalNotNull(table, c)))
+	b.WriteString(";default=")
+	b.WriteString(def)
+	b.WriteString(";onupdate=")
+	b.WriteString(onUpdate)
+	b.WriteString(";autoinc=")
+	b.WriteString(strconv.FormatBool(c.AutoIncrement))
+	b.WriteString(";comment=")
+	b.WriteString(n.CanonicalComment(c.Comment))
+	if c.Generated != nil {
+		b.WriteString(";gen=")
+		b.WriteString(n.CanonicalGeneratedExpr(c.Generated.Expr))
+		b.WriteString(";stored=")
+		b.WriteString(strconv.FormatBool(c.Generated.Stored))
+	}
+	if c.Invisible {
+		b.WriteString(";invisible=true")
+	}
+	if c.SRID != 0 {
+		fmt.Fprintf(&b, ";srid=%d", c.SRID)
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// CHECK constraints — version-flagged (8.0 normalized + auto-named; 5.7 dropped).
+// ---------------------------------------------------------------------------
+
+// CheckSupported reports whether CHECK constraints are represented in the stored form
+// for the target version. 8.0 keeps and normalizes CHECK; 5.7 parses and silently drops
+// it, so any target CHECK is unrepresentable and cannot round-trip (entry
+// check-constraint). diff-core must skip CHECK on 5.7 (treat as unsupported) and compare
+// the normalized expression on 8.0.
+func (n *Normalizer) CheckSupported() bool { return n.is80() }
+
+// CanonicalCheckExpr returns the canonical key for a CHECK constraint expression on 8.0,
+// using the same expression normalizer as generated columns (entry check-constraint:
+// "(a > 0)" -> "((`a` > 0))" normalized). On 5.7 callers should consult CheckSupported
+// first; this still returns a normalized key for completeness.
+func (n *Normalizer) CanonicalCheckExpr(expr string) string {
+	return n.CanonicalGeneratedExpr(expr)
+}

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -150,12 +150,17 @@ func (n *Normalizer) ResolveColumnCharsetCollation(table *Table, c *Column) (cha
 	tableCharset := foldCharset(table.Charset)
 	tableCollation := n.effectiveTableCollation(table)
 
-	// Effective charset: the column's explicit charset if it wrote one, else the table's.
-	// (Col.CharsetExplicit distinguishes a user CHARACTER SET clause from the loader's
-	// inheritance fill.)
-	if c.CharsetExplicit && c.Charset != "" {
+	// Effective charset:
+	//   - an explicit column CHARACTER SET wins;
+	//   - an explicit column COLLATE (without CHARACTER SET) implies the collation's
+	//     charset — the loader derives c.Charset from the collation, so honor it;
+	//   - otherwise the column inherits the table charset.
+	switch {
+	case c.CharsetExplicit && c.Charset != "":
 		charset = foldCharset(c.Charset)
-	} else {
+	case c.CollationExplicit && c.Charset != "":
+		charset = foldCharset(c.Charset)
+	default:
 		charset = tableCharset
 	}
 
@@ -560,11 +565,21 @@ func numericDefaultKey(columnType, literal string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	scale, hasScale := decimalScaleOf(columnType)
-	if hasScale {
-		fracPart = fitFractionToScale(fracPart, scale)
+	if scale, hasScale := decimalScaleOf(columnType); hasScale {
+		// A numeric default on a scaled column is ROUNDED (half-up) to the column scale
+		// on storage, with carry into the integer part (MySQL: 0.999 → 1.00, 9.999 →
+		// 10.00, INT DEFAULT 1.9 → 2). Round rather than truncate.
+		intPart, fracPart = roundToScale(intPart, fracPart, scale)
+	} else if scale == 0 {
+		// Integer column (DECIMAL(M,0) or INT-family rendered as decimal(_,0)): round to
+		// zero fractional digits, again with carry (INT DEFAULT 1.9 → 2).
+		intPart, fracPart = roundToScale(intPart, fracPart, 0)
 	} else {
 		fracPart = strings.TrimRight(fracPart, "0")
+	}
+	// Re-normalize a negative zero produced by rounding (e.g. -0.4 at scale 0 → 0).
+	if sign == "-" && intPart == "0" && strings.Trim(fracPart, "0") == "" {
+		sign = ""
 	}
 	key := sign + intPart
 	if fracPart != "" {
@@ -575,7 +590,8 @@ func numericDefaultKey(columnType, literal string) (string, bool) {
 
 // parseDecimalLiteral splits a numeric literal into (sign, integerDigits, fractionDigits)
 // with leading integer zeros stripped (but a single "0" kept). Returns ok=false for
-// non-numeric input. Exponent notation is not used by MySQL stored numeric defaults.
+// non-numeric input or a literal with no digits at all. Exponent notation is not used by
+// MySQL stored numeric defaults.
 func parseDecimalLiteral(literal string) (sign, intPart, fracPart string, ok bool) {
 	s := strings.TrimSpace(literal)
 	if s == "" {
@@ -598,6 +614,10 @@ func parseDecimalLiteral(literal string) (sign, intPart, fracPart string, ok boo
 	if !allDigits(intDigits) || !allDigits(fracDigits) {
 		return "", "", "", false
 	}
+	// Require at least one digit somewhere (reject "." / "+" / "-").
+	if intDigits == "" && fracDigits == "" {
+		return "", "", "", false
+	}
 	intDigits = strings.TrimLeft(intDigits, "0")
 	if intDigits == "" {
 		intDigits = "0"
@@ -609,15 +629,40 @@ func parseDecimalLiteral(literal string) (sign, intPart, fracPart string, ok boo
 	return sign, intDigits, fracDigits, true
 }
 
-// fitFractionToScale pads or truncates a fraction-digit string to exactly scale digits.
-func fitFractionToScale(frac string, scale int) string {
-	if scale <= 0 {
-		return ""
+// roundToScale rounds (intPart, fracPart) half-up to exactly scale fractional digits,
+// propagating carry into the integer digits. Both inputs are bare digit strings; it
+// returns the rounded (integerDigits, fractionDigits). Operating on digit strings keeps
+// full precision for values beyond float64 range.
+func roundToScale(intPart, fracPart string, scale int) (string, string) {
+	if len(fracPart) <= scale {
+		// No rounding needed; pad to scale.
+		return intPart, fracPart + strings.Repeat("0", scale-len(fracPart))
 	}
-	if len(frac) >= scale {
-		return frac[:scale]
+	kept := fracPart[:scale]
+	roundUp := fracPart[scale] >= '5'
+	if !roundUp {
+		return intPart, kept
 	}
-	return frac + strings.Repeat("0", scale-len(frac))
+	// Increment the digit string formed by intPart+kept by one, then split back.
+	combined := incrementDigits(intPart + kept)
+	// combined may have grown by one digit (carry out of the most-significant place).
+	if scale == 0 {
+		return combined, ""
+	}
+	return combined[:len(combined)-scale], combined[len(combined)-scale:]
+}
+
+// incrementDigits returns the decimal digit string plus one (e.g. "999" → "1000").
+func incrementDigits(digits string) string {
+	b := []byte(digits)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] < '9' {
+			b[i]++
+			return string(b)
+		}
+		b[i] = '0'
+	}
+	return "1" + string(b)
 }
 
 func allDigits(s string) bool {
@@ -824,16 +869,20 @@ func collapseExprWhitespace(expr string) string {
 }
 
 // exprSpaceIsSignificant reports whether a whitespace run between the already-emitted
-// prefix and the next byte (expr[next]) must be preserved as a single space. Whitespace
-// is significant only when it separates two "word" bytes (identifier/number chars) —
-// e.g. between a keyword and an identifier — and is dropped at the boundaries or next to
-// punctuation/operators where MySQL never needs it.
+// prefix and the next source byte (expr[next]) must be preserved as a single space.
+// Whitespace is significant only when it separates two "word" tokens (identifier/number
+// runs) — e.g. between a keyword and an identifier — and is dropped at the boundaries or
+// next to punctuation/operators where MySQL never needs it. A backtick at expr[next]
+// starts an identifier token, so it counts as a word boundary even though the backtick
+// byte itself is not an identifier char (this is the fix for `a` and `b` → must stay
+// `a and b`, not `a andb`).
 func exprSpaceIsSignificant(emitted, expr string, next int) bool {
 	if emitted == "" || next >= len(expr) {
 		return false
 	}
 	prev := emitted[len(emitted)-1]
-	return isIdentByte(prev) && isIdentByte(expr[next])
+	nextStartsWord := isIdentByte(expr[next]) || expr[next] == '`'
+	return isIdentByte(prev) && nextStartsWord
 }
 
 // ---------------------------------------------------------------------------
@@ -908,11 +957,15 @@ func (n *Normalizer) CanonicalTimestampDefaults(table *Table, c *Column) (def, o
 	if n.ExplicitDefaultsForTimestamp {
 		return def, onUpdate
 	}
-	// EDFT OFF and this is the first TIMESTAMP column with no explicit nullability or
-	// default: inject the implicit DEFAULT CURRENT_TIMESTAMP(N) ON UPDATE
-	// CURRENT_TIMESTAMP(N), matching the column's fractional-seconds precision.
+	// EDFT OFF: the FIRST TIMESTAMP column gets an implicit
+	// DEFAULT CURRENT_TIMESTAMP(N) ON UPDATE CURRENT_TIMESTAMP(N) (matching its
+	// fractional-seconds precision) UNLESS it has an explicit default or is explicitly
+	// NULL. An explicit `TIMESTAMP NULL` suppresses the magic and reads back
+	// `NULL DEFAULT NULL`; an explicit `TIMESTAMP NOT NULL` still receives the magic. We
+	// key the condition off the canonical NOT NULL state (which already encodes the
+	// explicit-NULL / EDFT rules), so both bare and `NOT NULL` first columns get it.
 	if def == defaultAbsentKey && onUpdate == defaultAbsentKey &&
-		n.isFirstTimestampColumn(table, c) && !c.NullExplicit {
+		n.isFirstTimestampColumn(table, c) && n.CanonicalNotNull(table, c) {
 		ts := "ts:CURRENT_TIMESTAMP" + fractionalSecondsSuffix(c.ColumnType)
 		return ts, ts
 	}

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -132,12 +132,14 @@ func (n *Normalizer) defaultCollationFor(charset string) string {
 // while 8.0 KEEPS it as a full pair; resolving the effective pair on BOTH sides and
 // comparing that is version-robust.
 //
-// Resolution rules (entries column-charset-echo-57/-80, -only-collation-resolution):
-//   - charset: the column's own charset if set, else the table's charset.
-//   - collation: the column's own collation if set; else, if the column set a charset,
-//     that CHARSET's default collation (NOT the table's COLLATE — this is the subtle
-//     -only-collation-resolution rule); else the table's collation; else the table
-//     charset's default collation.
+// Resolution rules (entries column-charset-echo-57/-80, -only-collation-resolution),
+// driven by the loader's explicit-clause flags so the three cases MySQL distinguishes
+// are kept apart even though the loader fills Charset/Collation from inheritance:
+//   - charset: the column's explicit CHARACTER SET if it wrote one, else the table's.
+//   - collation: the column's explicit COLLATE if it wrote one; else, if it wrote only a
+//     CHARACTER SET, that charset's default collation (NOT the table COLLATE — the subtle
+//     -only-collation-resolution rule); else (a bare column) the table's effective
+//     collation, re-resolved to the target version.
 //
 // For non-string columns (no charset concept) it returns ("", "").
 func (n *Normalizer) ResolveColumnCharsetCollation(table *Table, c *Column) (charset, collation string) {
@@ -146,44 +148,54 @@ func (n *Normalizer) ResolveColumnCharsetCollation(table *Table, c *Column) (cha
 	}
 
 	tableCharset := foldCharset(table.Charset)
-	tableCollation := foldCollation(table.Collation)
+	tableCollation := n.effectiveTableCollation(table)
 
-	colCharset := foldCharset(c.Charset)
-	colCollation := foldCollation(c.Collation)
-
-	// Effective charset: the column's own charset if set, else the table's. (The omni
-	// loader pre-fills col.Charset from the table for bare columns, so an empty
-	// colCharset and colCharset==tableCharset are both treated as "inherits table".)
-	if colCharset == "" {
-		charset = tableCharset
+	// Effective charset: the column's explicit charset if it wrote one, else the table's.
+	// (Col.CharsetExplicit distinguishes a user CHARACTER SET clause from the loader's
+	// inheritance fill.)
+	if c.CharsetExplicit && c.Charset != "" {
+		charset = foldCharset(c.Charset)
 	} else {
-		charset = colCharset
+		charset = tableCharset
 	}
 
-	// Effective collation — the subtle part. The omni loader pre-fills col.Collation at
-	// load time using 8.0 rules, even when targeting 5.7 and even for bare/charset-only
-	// columns (where it wrongly copies the table COLLATE). So col.Collation cannot be
-	// read as "user explicitly set this". We re-derive the version-correct collation and
-	// honor col.Collation ONLY as a genuine override — detected as a value that differs
-	// from the table's collation (the loader's inheritance source). See flag
-	// column-collation-explicit-vs-inherited for the residual edge.
+	// Effective collation, resolved with the version-correct rules. The explicit flags
+	// let us tell apart the three otherwise-indistinguishable cases the loader collapses:
 	switch {
-	case colCollation != "" && colCollation != tableCollation:
-		// Genuine column-level override (differs from the loader's inheritance source).
-		collation = colCollation
-	case colCharset != "" && colCharset != tableCharset:
-		// Column set a charset different from the table: collation resolves from THAT
-		// charset's default, never the table COLLATE.
-		// (entry column-charset-only-collation-resolution)
-		collation = n.defaultCollationFor(colCharset)
+	case c.CollationExplicit && c.Collation != "":
+		// The user wrote COLLATE: honor it verbatim (folded).
+		collation = foldCollation(c.Collation)
+	case c.CharsetExplicit && c.Charset != "":
+		// The user wrote only CHARACTER SET: the collation is THAT charset's default,
+		// never the table COLLATE. (entry column-charset-only-collation-resolution)
+		collation = n.defaultCollationFor(c.Charset)
 	default:
-		// Bare column, or column whose charset/collation equals the table's: the
-		// effective collation is the version-correct default for the effective charset.
-		// This re-resolves the loader's baked-in 8.0 default to the target version's
-		// default (e.g. utf8mb4 → utf8mb4_general_ci on 5.7).
-		collation = n.defaultCollationFor(charset)
+		// Bare column: inherits the table's effective collation (re-resolved to the
+		// target version). MySQL stores a bare column with the table's collation, not the
+		// charset default — so a table-level COLLATE change must propagate to bare columns.
+		collation = tableCollation
 	}
 	return charset, collation
+}
+
+// effectiveTableCollation returns the table's collation, folded and re-resolved to the
+// target version. The omni loader bakes the 8.0 charset-default collation into
+// table.Collation when the table has no explicit COLLATE clause (it cannot know the
+// target version at load time). We detect that case — table.Collation equals the 8.0
+// default for table.Charset — and substitute the version-correct default; an explicit,
+// non-default table COLLATE is honored as-is.
+func (n *Normalizer) effectiveTableCollation(table *Table) string {
+	tableCharset := foldCharset(table.Charset)
+	tableCollation := foldCollation(table.Collation)
+	if tableCollation == "" {
+		return n.defaultCollationFor(tableCharset)
+	}
+	// If the stored table collation is the 8.0 charset default, the table had no explicit
+	// COLLATE (the loader filled the 8.0 default); re-resolve to the version default.
+	if tableCharset == "utf8mb4" && tableCollation == "utf8mb4_0900_ai_ci" {
+		return n.defaultCollationFor("utf8mb4")
+	}
+	return tableCollation
 }
 
 // ---------------------------------------------------------------------------
@@ -232,8 +244,14 @@ func parseColumnType(columnType string) parsedType {
 	}
 
 	if open := strings.IndexByte(low, '('); open >= 0 {
-		close := strings.LastIndexByte(low, ')')
-		argStr := low[open+1 : close]
+		closeIdx := strings.LastIndexByte(low, ')')
+		// Guard against a malformed type with no closing paren, or ')' before '('
+		// (e.g. a truncated readback "int(11"): treat the paren as absent.
+		if closeIdx <= open {
+			p.base = normalizedTypeName(strings.TrimSpace(low[:open]))
+			return p
+		}
+		argStr := low[open+1 : closeIdx]
 		name := strings.TrimSpace(low[:open])
 		p.base = normalizedTypeName(name)
 		args := strings.SplitN(argStr, ",", 2)
@@ -267,8 +285,9 @@ func (n *Normalizer) CanonicalColumnType(c *Column) string {
 
 func (n *Normalizer) canonicalType(p parsedType) string {
 	switch p.base {
-	case "boolean", "bool":
-		// BOOLEAN/BOOL → tinyint(1) on both versions.
+	case "boolean":
+		// BOOLEAN/BOOL → tinyint(1) on both versions. (parseColumnType already folds
+		// "bool" → "boolean" via normalizedTypeName, so only "boolean" reaches here.)
 		return "tinyint(1)"
 	case "serial":
 		return "bigint unsigned"
@@ -336,11 +355,10 @@ func (n *Normalizer) canonicalType(p parsedType) string {
 }
 
 // canonicalIntType applies the version-specific integer display-width rule.
+// p.base is already alias-folded by normalizedTypeName (integer→int), so it is one of
+// tinyint/smallint/mediumint/int/bigint here.
 func (n *Normalizer) canonicalIntType(p parsedType) string {
 	base := p.base
-	if base == "integer" {
-		base = "int"
-	}
 
 	// tinyint(1) is the boolean marker: width survives on BOTH versions (only when
 	// signed and not zerofill — tinyint(1) unsigned/zerofill is a plain narrow int).
@@ -532,20 +550,83 @@ func unquoteDefault(s string) (string, bool) {
 	return s, false
 }
 
-// numericDefaultKey parses a numeric default and renders a canonical value key, padded
-// to the column's DECIMAL scale where applicable so '0' and '0.00' compare equal.
+// numericDefaultKey renders a canonical value key for a numeric default by normalizing
+// the literal AS A DECIMAL STRING — never via float64, which would lose precision for
+// BIGINT/DECIMAL values beyond 2^53 and collide distinct defaults. It normalizes sign,
+// strips redundant leading/trailing zeros, and pads to the column's DECIMAL scale so
+// '0' and '0.00' compare equal while 9223372036854775806 and ...807 stay distinct.
 func numericDefaultKey(columnType, literal string) (string, bool) {
-	literal = strings.TrimSpace(literal)
-	f, err := strconv.ParseFloat(literal, 64)
-	if err != nil {
+	sign, intPart, fracPart, ok := parseDecimalLiteral(literal)
+	if !ok {
 		return "", false
 	}
-	// Scale: from a decimal(M,D) column type, else from the literal's own precision.
-	if scale, ok := decimalScaleOf(columnType); ok {
-		return "num:" + strconv.FormatFloat(f, 'f', scale, 64), true
+	scale, hasScale := decimalScaleOf(columnType)
+	if hasScale {
+		fracPart = fitFractionToScale(fracPart, scale)
+	} else {
+		fracPart = strings.TrimRight(fracPart, "0")
 	}
-	// Integer or unscaled: a canonical shortest form.
-	return "num:" + strconv.FormatFloat(f, 'f', -1, 64), true
+	key := sign + intPart
+	if fracPart != "" {
+		key += "." + fracPart
+	}
+	return "num:" + key, true
+}
+
+// parseDecimalLiteral splits a numeric literal into (sign, integerDigits, fractionDigits)
+// with leading integer zeros stripped (but a single "0" kept). Returns ok=false for
+// non-numeric input. Exponent notation is not used by MySQL stored numeric defaults.
+func parseDecimalLiteral(literal string) (sign, intPart, fracPart string, ok bool) {
+	s := strings.TrimSpace(literal)
+	if s == "" {
+		return "", "", "", false
+	}
+	if s[0] == '+' || s[0] == '-' {
+		if s[0] == '-' {
+			sign = "-"
+		}
+		s = s[1:]
+	}
+	if s == "" {
+		return "", "", "", false
+	}
+	intDigits, fracDigits := s, ""
+	if dot := strings.IndexByte(s, '.'); dot >= 0 {
+		intDigits = s[:dot]
+		fracDigits = s[dot+1:]
+	}
+	if !allDigits(intDigits) || !allDigits(fracDigits) {
+		return "", "", "", false
+	}
+	intDigits = strings.TrimLeft(intDigits, "0")
+	if intDigits == "" {
+		intDigits = "0"
+	}
+	// Normalize negative zero to positive.
+	if intDigits == "0" && strings.Trim(fracDigits, "0") == "" {
+		sign = ""
+	}
+	return sign, intDigits, fracDigits, true
+}
+
+// fitFractionToScale pads or truncates a fraction-digit string to exactly scale digits.
+func fitFractionToScale(frac string, scale int) string {
+	if scale <= 0 {
+		return ""
+	}
+	if len(frac) >= scale {
+		return frac[:scale]
+	}
+	return frac + strings.Repeat("0", scale-len(frac))
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // decimalScaleOf extracts the scale D from a decimal(M,D) column type.
@@ -621,6 +702,29 @@ func (n *Normalizer) CanonicalGeneratedExpr(expr string) string {
 	return s
 }
 
+// scanStringLiteral returns the index just past a single-quoted string literal that
+// starts at i (expr[i]=='\”), honoring doubled-quote escapes (”) and backslash
+// escapes (\'). If the literal is unterminated it returns len(expr). The returned index
+// is always a valid slice bound (≤ len(expr)), so callers never read past the end.
+func scanStringLiteral(expr string, i int) int {
+	j := i + 1
+	for j < len(expr) {
+		switch expr[j] {
+		case '\\':
+			j += 2 // skip the escaped char (\' \\ etc.)
+		case '\'':
+			if j+1 < len(expr) && expr[j+1] == '\'' {
+				j += 2 // doubled-quote escape
+				continue
+			}
+			return j + 1 // past the closing quote
+		default:
+			j++
+		}
+	}
+	return len(expr) // unterminated: consume to EOF
+}
+
 // stripCharsetIntroducers removes a charset introducer (e.g. _latin1, _utf8mb4) that
 // immediately precedes a single-quoted string literal, leaving the bare literal.
 func stripCharsetIntroducers(expr string) string {
@@ -629,27 +733,16 @@ func stripCharsetIntroducers(expr string) string {
 	for i < len(expr) {
 		c := expr[i]
 		if c == '\'' {
-			// Copy the whole string literal verbatim (respecting doubled quotes).
-			j := i + 1
-			for j < len(expr) {
-				if expr[j] == '\'' {
-					if j+1 < len(expr) && expr[j+1] == '\'' {
-						j += 2
-						continue
-					}
-					break
-				}
-				j++
-			}
-			b.WriteString(expr[i : j+1])
-			i = j + 1
+			end := scanStringLiteral(expr, i)
+			b.WriteString(expr[i:end])
+			i = end
 			continue
 		}
 		if c == '_' {
 			// Possible charset introducer: _<ident>' — drop the "_<ident>" if a quote
 			// follows the identifier run.
 			j := i + 1
-			for j < len(expr) && (isIdentByte(expr[j])) {
+			for j < len(expr) && isIdentByte(expr[j]) {
 				j++
 			}
 			if j < len(expr) && expr[j] == '\'' && j > i+1 {
@@ -669,9 +762,11 @@ func isIdentByte(b byte) bool {
 }
 
 // collapseExprWhitespace lowercases the expression outside string literals, strips
-// backtick identifier quoting (lowercasing the inner name), and removes all whitespace,
-// so cosmetic spacing and quoting differences do not diff. String literals are copied
-// verbatim (case and spacing inside them are significant).
+// backtick identifier quoting (lowercasing the inner name), and collapses each run of
+// whitespace to a SINGLE space, so cosmetic spacing and quoting differences do not diff
+// while token boundaries are preserved (e.g. `a` and `b` must not merge into `aandb`).
+// String literals are copied verbatim (case and spacing inside them are significant) and
+// unterminated literals/identifiers are consumed safely to EOF.
 func collapseExprWhitespace(expr string) string {
 	var b strings.Builder
 	i := 0
@@ -679,23 +774,13 @@ func collapseExprWhitespace(expr string) string {
 		c := expr[i]
 		switch c {
 		case '\'':
-			j := i + 1
-			for j < len(expr) {
-				if expr[j] == '\'' {
-					if j+1 < len(expr) && expr[j+1] == '\'' {
-						j += 2
-						continue
-					}
-					break
-				}
-				j++
-			}
-			b.WriteString(expr[i : j+1])
-			i = j + 1
+			end := scanStringLiteral(expr, i)
+			b.WriteString(expr[i:end])
+			i = end
 		case '`':
 			// Backticks are identifier quoting; drop them and lowercase the inner name
-			// so a backticked identifier and the bare identifier compare equal. The
-			// loader backticks both sides, but stripping is strictly more robust.
+			// so a backticked identifier and the bare identifier compare equal. An
+			// unterminated backtick is consumed to EOF.
 			j := i + 1
 			for j < len(expr) && expr[j] != '`' {
 				j++
@@ -709,13 +794,23 @@ func collapseExprWhitespace(expr string) string {
 					b.WriteByte(ch)
 				}
 			}
-			i = j + 1
+			if j < len(expr) {
+				j++ // past the closing backtick
+			}
+			i = j
 		case ' ', '\t', '\n', '\r':
-			// Skip whitespace entirely; tokens are re-joined without spaces. Operators
-			// and identifiers remain unambiguous because identifiers are backticked and
-			// numeric/keyword tokens are separated by punctuation in normalized MySQL
-			// expressions.
-			i++
+			// Collapse a run of whitespace to a single space, but only between tokens —
+			// drop it entirely at the start/end and adjacent to punctuation where it is
+			// never significant. Keeping one space preserves keyword/identifier
+			// boundaries so `a and b` does not become `aandb`.
+			j := i
+			for j < len(expr) && (expr[j] == ' ' || expr[j] == '\t' || expr[j] == '\n' || expr[j] == '\r') {
+				j++
+			}
+			if exprSpaceIsSignificant(b.String(), expr, j) {
+				b.WriteByte(' ')
+			}
+			i = j
 		default:
 			if c >= 'A' && c <= 'Z' {
 				b.WriteByte(c + ('a' - 'A'))
@@ -728,6 +823,19 @@ func collapseExprWhitespace(expr string) string {
 	return b.String()
 }
 
+// exprSpaceIsSignificant reports whether a whitespace run between the already-emitted
+// prefix and the next byte (expr[next]) must be preserved as a single space. Whitespace
+// is significant only when it separates two "word" bytes (identifier/number chars) —
+// e.g. between a keyword and an identifier — and is dropped at the boundaries or next to
+// punctuation/operators where MySQL never needs it.
+func exprSpaceIsSignificant(emitted, expr string, next int) bool {
+	if emitted == "" || next >= len(expr) {
+		return false
+	}
+	prev := emitted[len(emitted)-1]
+	return isIdentByte(prev) && isIdentByte(expr[next])
+}
+
 // ---------------------------------------------------------------------------
 // Nullability + PK + the TIMESTAMP magic (explicit_defaults_for_timestamp).
 // ---------------------------------------------------------------------------
@@ -736,11 +844,13 @@ func collapseExprWhitespace(expr string) string {
 // implicit rewrites:
 //   - a PRIMARY KEY member is forced NOT NULL regardless of its declaration
 //     (entry pk-implies-not-null);
-//   - when explicit_defaults_for_timestamp is OFF, every bare TIMESTAMP column (no
-//     explicit nullability) becomes NOT NULL (entry timestamp-magic-first-57). This is
+//   - when explicit_defaults_for_timestamp is OFF, a TIMESTAMP column with NO explicit
+//     nullability clause becomes NOT NULL (entry timestamp-magic-first-57). This is
 //     governed by the captured session variable, NOT the version (flag #3): a 5.7
 //     server with the variable ON leaves TIMESTAMP nullable, an 8.0 server with it OFF
-//     forces NOT NULL.
+//     forces NOT NULL. The Column.NullExplicit flag (set by the loader) tells a bare
+//     `TIMESTAMP` apart from an explicit `TIMESTAMP NULL`, so a genuinely-nullable
+//     `TIMESTAMP NULL` — even one with a constant default — is left nullable.
 //
 // For all other columns it returns the declared !Nullable.
 func (n *Normalizer) CanonicalNotNull(table *Table, c *Column) bool {
@@ -750,37 +860,10 @@ func (n *Normalizer) CanonicalNotNull(table *Table, c *Column) bool {
 	if n.columnInPrimaryKey(table, c) {
 		return true
 	}
-	// EDFT OFF: MySQL forces NOT NULL on a TIMESTAMP column that lacks an explicit NULL
-	// clause. The loader collapses `TIMESTAMP` (→ NOT NULL) and `TIMESTAMP NULL`
-	// (→ nullable) to the SAME catalog state (Nullable=true, no explicit-NULL flag), so
-	// in general they are indistinguishable. We force NOT NULL only where the catalog
-	// gives an unambiguous signal that the column is not the explicit-NULL form:
-	//   - it is the FIRST TIMESTAMP column (which also receives the implicit
-	//     DEFAULT CURRENT_TIMESTAMP — see CanonicalTimestampDefaults), or
-	//   - it carries a non-NULL explicit default (a `TIMESTAMP NULL` would have either no
-	//     default or DEFAULT NULL, never a real default).
-	// A non-first, default-less bare TIMESTAMP is indistinguishable from `TIMESTAMP NULL`
-	// post-load, so we conservatively keep it nullable to avoid a phantom nullability
-	// diff. This is the conservative ruling for the explicit_defaults_for_timestamp flag.
-	// See flag column-timestamp-explicit-null-lost.
-	if isTimestampType(c.DataType) && !n.ExplicitDefaultsForTimestamp && !c.userSetNullable() {
-		if n.isFirstTimestampColumn(table, c) || c.hasNonNullDefault() {
-			return true
-		}
+	if isTimestampType(c.DataType) && !n.ExplicitDefaultsForTimestamp && !c.NullExplicit {
+		return true
 	}
 	return false
-}
-
-// hasNonNullDefault reports whether the column carries an explicit non-NULL default.
-func (c *Column) hasNonNullDefault() bool {
-	return c.Default != nil && !strings.EqualFold(strings.TrimSpace(*c.Default), "NULL")
-}
-
-// userSetNullable reports whether the user explicitly chose this column nullable. The
-// catalog does not record an explicit-NULL flag distinct from the default, so we treat
-// a column carrying an explicit DEFAULT NULL (Default=="NULL") as user-chosen nullable.
-func (c *Column) userSetNullable() bool {
-	return c.Default != nil && strings.EqualFold(strings.TrimSpace(*c.Default), "NULL")
 }
 
 // columnInPrimaryKey reports whether the column participates in the table's PK.
@@ -825,12 +908,27 @@ func (n *Normalizer) CanonicalTimestampDefaults(table *Table, c *Column) (def, o
 	if n.ExplicitDefaultsForTimestamp {
 		return def, onUpdate
 	}
-	// EDFT OFF and this is the first TIMESTAMP column with no explicit default: inject
-	// the implicit CURRENT_TIMESTAMP default + on-update.
-	if def == defaultAbsentKey && onUpdate == defaultAbsentKey && n.isFirstTimestampColumn(table, c) && !c.userSetNullable() {
-		return "ts:CURRENT_TIMESTAMP", "ts:CURRENT_TIMESTAMP"
+	// EDFT OFF and this is the first TIMESTAMP column with no explicit nullability or
+	// default: inject the implicit DEFAULT CURRENT_TIMESTAMP(N) ON UPDATE
+	// CURRENT_TIMESTAMP(N), matching the column's fractional-seconds precision.
+	if def == defaultAbsentKey && onUpdate == defaultAbsentKey &&
+		n.isFirstTimestampColumn(table, c) && !c.NullExplicit {
+		ts := "ts:CURRENT_TIMESTAMP" + fractionalSecondsSuffix(c.ColumnType)
+		return ts, ts
 	}
 	return def, onUpdate
+}
+
+// fractionalSecondsSuffix returns "(N)" for a TIMESTAMP(N)/DATETIME(N) column type, or
+// "" when no fractional precision is declared, so the injected CURRENT_TIMESTAMP default
+// carries the same precision MySQL stores (entry timestamp-magic-first-57: TIMESTAMP(3)
+// → CURRENT_TIMESTAMP(3)).
+func fractionalSecondsSuffix(columnType string) string {
+	p := parseColumnType(columnType)
+	if p.hasLen && p.length > 0 {
+		return fmt.Sprintf("(%d)", p.length)
+	}
+	return ""
 }
 
 // canonicalOnUpdate returns the canonical ON UPDATE key for a column.
@@ -893,12 +991,13 @@ func (n *Normalizer) IgnoreRowFormat(table *Table) bool {
 // Comments — content comparison (decoded).
 // ---------------------------------------------------------------------------
 
-// CanonicalComment returns a comment's decoded content for comparison. Comments are
-// stored single-quoted with embedded single quotes doubled; the diff compares content,
-// not the quoted surface form (entry comment-escaping). The catalog already stores the
-// decoded content, but un-doubling here makes the key robust to either form.
+// CanonicalComment returns a comment's content for comparison. The omni loader already
+// stores the DECODED comment content (embedded single quotes un-doubled), so the stored
+// value IS the canonical content and is returned as-is. (entry comment-escaping: the diff
+// compares decoded content, not the quoted surface form.) Re-running an un-doubling pass
+// here would be wrong — it would collapse a genuine `a”b` content down to `a'b`.
 func (n *Normalizer) CanonicalComment(comment string) string {
-	return strings.ReplaceAll(comment, "''", "'")
+	return comment
 }
 
 // ---------------------------------------------------------------------------
@@ -946,36 +1045,44 @@ func (n *Normalizer) CanonicalColumn(table *Table, c *Column) string {
 	charset, collation := n.ResolveColumnCharsetCollation(table, c)
 	def, onUpdate := n.CanonicalTimestampDefaults(table, c)
 
-	var b strings.Builder
-	b.WriteString("name=")
-	b.WriteString(strings.ToLower(c.Name))
-	b.WriteString(";type=")
-	b.WriteString(n.CanonicalColumnType(c))
-	b.WriteString(";cs=")
-	b.WriteString(charset)
-	b.WriteString(";coll=")
-	b.WriteString(collation)
-	b.WriteString(";notnull=")
-	b.WriteString(strconv.FormatBool(n.CanonicalNotNull(table, c)))
-	b.WriteString(";default=")
-	b.WriteString(def)
-	b.WriteString(";onupdate=")
-	b.WriteString(onUpdate)
-	b.WriteString(";autoinc=")
-	b.WriteString(strconv.FormatBool(c.AutoIncrement))
-	b.WriteString(";comment=")
-	b.WriteString(n.CanonicalComment(c.Comment))
+	gen, stored := "", ""
 	if c.Generated != nil {
-		b.WriteString(";gen=")
-		b.WriteString(n.CanonicalGeneratedExpr(c.Generated.Expr))
-		b.WriteString(";stored=")
-		b.WriteString(strconv.FormatBool(c.Generated.Stored))
+		gen = n.CanonicalGeneratedExpr(c.Generated.Expr)
+		stored = strconv.FormatBool(c.Generated.Stored)
 	}
-	if c.Invisible {
-		b.WriteString(";invisible=true")
-	}
-	if c.SRID != 0 {
-		fmt.Fprintf(&b, ";srid=%d", c.SRID)
+	// Length-delimited field encoding: each value is prefixed with its byte length, so a
+	// value containing the field separator (e.g. a comment of ";gen=...") cannot be
+	// mistaken for another field and collide with a different column's key.
+	return encodeKeyFields(
+		"name", strings.ToLower(c.Name),
+		"type", n.CanonicalColumnType(c),
+		"cs", charset,
+		"coll", collation,
+		"notnull", strconv.FormatBool(n.CanonicalNotNull(table, c)),
+		"default", def,
+		"onupdate", onUpdate,
+		"autoinc", strconv.FormatBool(c.AutoIncrement),
+		"comment", n.CanonicalComment(c.Comment),
+		"gen", gen,
+		"stored", stored,
+		"invisible", strconv.FormatBool(c.Invisible),
+		"srid", strconv.Itoa(c.SRID),
+	)
+}
+
+// encodeKeyFields joins (label, value) pairs into an unambiguous comparison key. Each
+// value is written as "<label>:<len>:<value>" so no value byte sequence can be confused
+// with a delimiter or another field — making the aggregate key collision-free regardless
+// of value content (comments, defaults, expressions).
+func encodeKeyFields(pairs ...string) string {
+	var b strings.Builder
+	for i := 0; i+1 < len(pairs); i += 2 {
+		b.WriteString(pairs[i])
+		b.WriteByte(':')
+		b.WriteString(strconv.Itoa(len(pairs[i+1])))
+		b.WriteByte(':')
+		b.WriteString(pairs[i+1])
+		b.WriteByte('|')
 	}
 	return b.String()
 }

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -557,24 +557,31 @@ func unquoteDefault(s string) (string, bool) {
 
 // numericDefaultKey renders a canonical value key for a numeric default by normalizing
 // the literal AS A DECIMAL STRING — never via float64, which would lose precision for
-// BIGINT/DECIMAL values beyond 2^53 and collide distinct defaults. It normalizes sign,
-// strips redundant leading/trailing zeros, and pads to the column's DECIMAL scale so
-// '0' and '0.00' compare equal while 9223372036854775806 and ...807 stay distinct.
+// BIGINT/DECIMAL values beyond 2^53 and collide distinct defaults. It normalizes sign and
+// leading zeros, then applies the column-kind-specific storage rule: scaled types
+// (decimal(M,D), float(M,D)) round to scale with carry; integer types and bare DECIMAL
+// round to integer; bare FLOAT/DOUBLE preserve their fraction (trailing zeros stripped).
+// So '0' and '0.00' compare equal while 9223372036854775806 and ...807 stay distinct.
 func numericDefaultKey(columnType, literal string) (string, bool) {
 	sign, intPart, fracPart, ok := parseDecimalLiteral(literal)
 	if !ok {
 		return "", false
 	}
-	if scale, hasScale := decimalScaleOf(columnType); hasScale {
-		// A numeric default on a scaled column is ROUNDED (half-up) to the column scale
-		// on storage, with carry into the integer part (MySQL: 0.999 → 1.00, 9.999 →
-		// 10.00, INT DEFAULT 1.9 → 2). Round rather than truncate.
-		intPart, fracPart = roundToScale(intPart, fracPart, scale)
-	} else if scale == 0 {
-		// Integer column (DECIMAL(M,0) or INT-family rendered as decimal(_,0)): round to
-		// zero fractional digits, again with carry (INT DEFAULT 1.9 → 2).
+	p := parseColumnType(columnType)
+	switch {
+	case p.hasScale:
+		// A scaled type — decimal(M,D) or float(M,D)/double(M,D) — ROUNDS the default
+		// (half-up) to the column scale on storage, with carry into the integer part
+		// (MySQL: decimal(10,2) 0.999 → '1.00', 9.999 → '10.00'; float(10,2) 1.5 → '1.50').
+		intPart, fracPart = roundToScale(intPart, fracPart, p.scale)
+	case isIntegerType(p.base) || p.base == "decimal":
+		// Integer types, and bare DECIMAL (which has implicit scale 0): round to zero
+		// fractional digits, with carry (INT DEFAULT 1.9 → '2', decimal(10,0) 0.9 → '1').
 		intPart, fracPart = roundToScale(intPart, fracPart, 0)
-	} else {
+	default:
+		// Bare FLOAT/DOUBLE/REAL (no explicit scale): the fraction is preserved verbatim
+		// with only trailing zeros stripped (MySQL: float 1.9 → '1.9', 2.0 → '2',
+		// double 3.14159 → '3.14159'). Rounding here would collapse distinct defaults.
 		fracPart = strings.TrimRight(fracPart, "0")
 	}
 	// Re-normalize a negative zero produced by rounding (e.g. -0.4 at scale 0 → 0).
@@ -672,15 +679,6 @@ func allDigits(s string) bool {
 		}
 	}
 	return true
-}
-
-// decimalScaleOf extracts the scale D from a decimal(M,D) column type.
-func decimalScaleOf(columnType string) (int, bool) {
-	p := parseColumnType(columnType)
-	if p.base == "decimal" && p.hasScale {
-		return p.scale, true
-	}
-	return 0, false
 }
 
 // isNumericType reports whether a base data type carries a numeric default.

--- a/mysql/catalog/normalize_oracle_test.go
+++ b/mysql/catalog/normalize_oracle_test.go
@@ -290,3 +290,54 @@ func containsVersion(vs []Version, v Version) bool {
 	}
 	return false
 }
+
+// TestOracle_MissedDiffGuards proves the canonical key DISTINGUISHES schemas that
+// genuinely differ — the dual of phantom-diff elimination. These lock in the review
+// findings where the canonicalizer was over-collapsing (a missed diff is as harmful as
+// a phantom one). Each asserts two real, different MySQL schemas produce different keys,
+// loaded through the real engine's SHOW CREATE so the catalog state is authentic.
+func TestOracle_MissedDiffGuards(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+
+		t.Run(o.name+"/bare-column-follows-table-collation", func(t *testing.T) {
+			// A bare column inherits the table COLLATE; changing the table COLLATE must
+			// change the bare column's canonical key (else the column change is invisible).
+			ddlA := "CREATE TABLE t (a VARCHAR(10)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+			ddlB := "CREATE TABLE t (a VARCHAR(10)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+			rbA, okA := o.showCreate(t, "mdg_a", ddlA, "t")
+			rbB, okB := o.showCreate(t, "mdg_b", ddlB, "t")
+			if !okA || !okB {
+				t.Skip("could not obtain readbacks")
+			}
+			tA, cA := loadColumn(t, sc, rbA, "t", "a")
+			tB, cB := loadColumn(t, sc, rbB, "t", "a")
+			if n.CanonicalColumn(tA, cA) == n.CanonicalColumn(tB, cB) {
+				t.Errorf("[%s] bare column must follow table COLLATE change:\n A=%s\n B=%s",
+					o.name, n.CanonicalColumn(tA, cA), n.CanonicalColumn(tB, cB))
+			}
+		})
+
+		if version == MySQL57 {
+			t.Run(o.name+"/timestamp-null-vs-notnull-with-default", func(t *testing.T) {
+				// EDFT=0: `TIMESTAMP NULL DEFAULT '<const>'` (nullable) must produce a
+				// different key from a bare `TIMESTAMP DEFAULT '<const>'` (NOT NULL).
+				ddl := "CREATE TABLE t (x INT, n TIMESTAMP NULL DEFAULT '2020-01-01 00:00:00', b TIMESTAMP DEFAULT '2020-01-01 00:00:00')"
+				rb, ok := o.showCreate(t, "mdg_ts", ddl, "t")
+				if !ok {
+					t.Skip("could not obtain readback")
+				}
+				tbl, nCol := loadColumn(t, sc, rb, "t", "n")
+				_, bCol := loadColumn(t, sc, rb, "t", "b")
+				if n.CanonicalColumn(tbl, nCol) == n.CanonicalColumn(tbl, bCol) {
+					t.Errorf("[%s] nullable TIMESTAMP NULL and NOT NULL TIMESTAMP must differ", o.name)
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/normalize_oracle_test.go
+++ b/mysql/catalog/normalize_oracle_test.go
@@ -1,0 +1,292 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for normalize-core. For every normalization.md entry, this applies
+// the input DDL to a LIVE MySQL engine (both 5.7 and 8.0 where they diverge), reads back
+// SHOW CREATE TABLE, and asserts the phantom-diff-elimination property:
+//
+//	CanonicalColumn(loaded(input_ddl))  ==  CanonicalColumn(loaded(SHOW CREATE readback))
+//
+// i.e. the user's declared form and the engine's stored form collapse onto the same
+// canonical key for the target version. A failure here is a real normalization bug — the
+// canonicalizer disagrees with what the engine actually stores, which would produce a
+// phantom diff forever. These tests are the correctness spine (correctness-protocol.md).
+//
+// Connection: the local oracle instances from the work order, overridable via env.
+// They skip cleanly when the engines are unreachable so the unit suite stays hermetic.
+
+type oracleConn struct {
+	db      *sql.DB
+	version Version
+	name    string
+}
+
+func dsnOr(env, def string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	return def
+}
+
+// connectOracle dials one engine; returns nil (and skips) if unreachable.
+func connectOracle(t *testing.T, version Version) *oracleConn {
+	t.Helper()
+	var dsn, name string
+	switch version {
+	case MySQL80:
+		dsn = dsnOr("OMNI_MYSQL80_DSN", "root:010424@tcp(127.0.0.1:13306)/?multiStatements=true")
+		name = "8.0"
+	case MySQL57:
+		dsn = dsnOr("OMNI_MYSQL57_DSN", "root:010424@tcp(127.0.0.1:13307)/?multiStatements=true&tls=false")
+		name = "5.7"
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Skipf("oracle %s unavailable (open): %v", name, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		t.Skipf("oracle %s unavailable (ping): %v", name, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return &oracleConn{db: db, version: version, name: name}
+}
+
+// showCreate applies the CREATE statements in a throwaway database and returns the
+// SHOW CREATE TABLE readback for the named table.
+func (o *oracleConn) showCreate(t *testing.T, dbName, createSQL, table string) (string, bool) {
+	t.Helper()
+	ctx := context.Background()
+	stmts := []string{
+		fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName),
+		fmt.Sprintf("CREATE DATABASE %s", dbName),
+		fmt.Sprintf("USE %s", dbName),
+		createSQL,
+	}
+	for _, s := range stmts {
+		if _, err := o.db.ExecContext(ctx, s); err != nil {
+			// An input the version rejects (e.g. functional DEFAULT on 5.7) is not a
+			// canonicalizer failure; the caller decides whether that is expected.
+			t.Logf("[%s] exec failed (may be expected): %q: %v", o.name, s, err)
+			return "", false
+		}
+	}
+	var name, ddl string
+	row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", dbName, table))
+	if err := row.Scan(&name, &ddl); err != nil {
+		t.Logf("[%s] SHOW CREATE failed: %v", o.name, err)
+		return "", false
+	}
+	return ddl, true
+}
+
+// loadColumn loads DDL through the omni catalog and returns the table + named column.
+// The CREATE TABLE is wrapped in a database whose default charset matches the oracle's
+// server default (utf8mb4 on the 8.0 box, latin1 on the 5.7 box) so that table-charset
+// inheritance resolves identically on both the user-input and the SHOW CREATE readback
+// sides — without this, db-inherited charset rules (e.g. column-charset-echo-57) would
+// not be comparable.
+func loadColumn(t *testing.T, serverCharset, createSQL, table, column string) (*Table, *Column) {
+	t.Helper()
+	wrapped := fmt.Sprintf("CREATE DATABASE nrmdb DEFAULT CHARSET=%s;\nUSE nrmdb;\n%s", serverCharset, createSQL)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("LoadSQL failed for %q: %v", createSQL, err)
+	}
+	var tbl *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable(table); tt != nil {
+			tbl = tt
+			break
+		}
+	}
+	if tbl == nil {
+		t.Fatalf("table %q not found after load of %q", table, createSQL)
+	}
+	return tbl, tbl.GetColumn(column)
+}
+
+// serverCharsetFor returns the oracle box's default server charset for a version, used
+// to wrap loads so table-charset inheritance matches the readback.
+func serverCharsetFor(v Version) string {
+	if v == MySQL80 {
+		return "utf8mb4"
+	}
+	return "latin1"
+}
+
+// assertPhantomFree is the core assertion: input form and stored readback must produce
+// the same canonical column key for the engine's version.
+func assertPhantomFree(t *testing.T, o *oracleConn, dbName, inputDDL, table, column string) {
+	t.Helper()
+	readback, ok := o.showCreate(t, dbName, inputDDL, table)
+	if !ok {
+		t.Skipf("[%s] could not obtain readback for %s.%s", o.name, table, column)
+	}
+	// The readback is a CREATE TABLE we can reload through the same loader.
+	readbackCreate := normalizeReadbackForLoad(readback)
+
+	n := NormalizerFor(o.version)
+	sc := serverCharsetFor(o.version)
+
+	userTbl, userCol := loadColumn(t, sc, inputDDL, table, column)
+	storTbl, storCol := loadColumn(t, sc, readbackCreate, table, column)
+	if userCol == nil || storCol == nil {
+		t.Fatalf("[%s] column %q missing (user=%v stored=%v)", o.name, column, userCol != nil, storCol != nil)
+	}
+
+	uk := n.CanonicalColumn(userTbl, userCol)
+	sk := n.CanonicalColumn(storTbl, storCol)
+	if uk != sk {
+		t.Errorf("[%s] PHANTOM DIFF on column %q:\n  input  DDL: %s\n  stored DDL: %s\n  user  key: %s\n  store key: %s",
+			o.name, column, strings.TrimSpace(inputDDL), strings.TrimSpace(readback), uk, sk)
+	}
+}
+
+// normalizeReadbackForLoad strips MySQL version-specific comment syntax that the omni
+// loader does not need (e.g. /*!80023 ... */ inline hints stay; AUTO_INCREMENT counter
+// is harmless). The readback is otherwise valid CREATE TABLE DDL.
+func normalizeReadbackForLoad(ddl string) string {
+	// Strip a trailing AUTO_INCREMENT=N table option so reload does not depend on it
+	// (it is ignore-in-diff anyway).
+	return ddl
+}
+
+// ---- the rule corpus: (id, inputDDL, table, columns, which versions diverge) --------
+
+type ruleProbe struct {
+	id       string
+	create   string
+	table    string
+	columns  []string
+	versions []Version // which engines to prove against
+}
+
+func both() []Version          { return []Version{MySQL57, MySQL80} }
+func only(v Version) []Version { return []Version{v} }
+
+func normalizationProbes() []ruleProbe {
+	return []ruleProbe{
+		{"int-display-width",
+			"CREATE TABLE t_int (a INT(11), b BIGINT(20), c INT, f SMALLINT(6), o BIGINT, p TINYINT, q SMALLINT, r MEDIUMINT)",
+			"t_int", []string{"a", "b", "c", "f", "o", "p", "q", "r"}, both()},
+		{"tinyint1-boolean",
+			"CREATE TABLE t_bool (d TINYINT(1), e TINYINT(4), m BOOLEAN, n BOOL, p TINYINT)",
+			"t_bool", []string{"d", "e", "m", "n", "p"}, both()},
+		{"int-unsigned-width",
+			"CREATE TABLE t_uns (h INT UNSIGNED, i INT(11) UNSIGNED, b BIGINT UNSIGNED, ti TINYINT UNSIGNED)",
+			"t_uns", []string{"h", "i", "b", "ti"}, both()},
+		{"int-zerofill",
+			"CREATE TABLE t_zf (j INT ZEROFILL, k INT(5) ZEROFILL, l INT UNSIGNED ZEROFILL)",
+			"t_zf", []string{"j", "k", "l"}, both()},
+		{"decimal-precision-scale",
+			"CREATE TABLE t_num (a DECIMAL, b DECIMAL(10), c DECIMAL(10,2), d NUMERIC, e NUMERIC(8,3), k DEC, l FIXED)",
+			"t_num", []string{"a", "b", "c", "d", "e", "k", "l"}, both()},
+		{"float-double-aliasing",
+			"CREATE TABLE t_fd (f FLOAT, g FLOAT(10,2), h DOUBLE, i DOUBLE(15,4), j REAL, m FLOAT(5))",
+			"t_fd", []string{"f", "g", "h", "i", "j", "m"}, both()},
+		{"char-binary-length-default",
+			"CREATE TABLE t_char (a CHAR, b CHAR(10), d BINARY, e BINARY(16), f VARBINARY(32))",
+			"t_char", []string{"a", "b", "d", "e", "f"}, both()},
+		{"text-blob-no-default-null",
+			"CREATE TABLE t_tb (g TEXT, h BLOB, j LONGTEXT, k TINYTEXT)",
+			"t_tb", []string{"g", "h", "j", "k"}, both()},
+		{"year-width",
+			"CREATE TABLE t_year (a YEAR, b YEAR(4))",
+			"t_year", []string{"a", "b"}, both()},
+		{"bit-length-default",
+			"CREATE TABLE t_bit (c BIT, d BIT(8))",
+			"t_bit", []string{"c", "d"}, both()},
+		{"time-json-date-stable",
+			"CREATE TABLE t_tjd (e JSON, f DATE, g TIME, h TIME(3))",
+			"t_tjd", []string{"e", "f", "g", "h"}, both()},
+		{"default-literal-quoting",
+			"CREATE TABLE t_def (a INT DEFAULT 0, b INT DEFAULT 5, h INT DEFAULT '7', c VARCHAR(20) DEFAULT 'hello', d VARCHAR(20) DEFAULT '', e VARCHAR(20) DEFAULT 'it''s')",
+			"t_def", []string{"a", "b", "h", "c", "d", "e"}, both()},
+		{"decimal-default-padding",
+			"CREATE TABLE t_dpad (f DECIMAL(10,2) DEFAULT 0, g DECIMAL(10,2) DEFAULT 0.00)",
+			"t_dpad", []string{"f", "g"}, both()},
+		{"boolean-default",
+			"CREATE TABLE t_bdef (j BOOLEAN DEFAULT TRUE, k BOOLEAN DEFAULT FALSE)",
+			"t_bdef", []string{"j", "k"}, both()},
+		{"nullable-default-null",
+			"CREATE TABLE t_null (a INT NULL, b INT DEFAULT NULL, c INT NULL DEFAULT NULL, d VARCHAR(10) NULL)",
+			"t_null", []string{"a", "b", "c", "d"}, both()},
+		{"enum-set-quoting",
+			`CREATE TABLE t_enum (a ENUM('x','y','z'), b SET('a','b','c'), e ENUM("dq1","dq2"))`,
+			"t_enum", []string{"a", "b", "e"}, both()},
+		{"comment-escaping",
+			"CREATE TABLE t_comment (a INT COMMENT 'has ''quote'' inside')",
+			"t_comment", []string{"a"}, both()},
+		// version-flagged: charset echo. Only prove on the version whose readback diverges.
+		{"column-charset-echo-80",
+			"CREATE TABLE t_ce80 (a VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci, c VARCHAR(10) CHARACTER SET utf8mb4, d VARCHAR(10)) DEFAULT CHARSET=utf8mb4",
+			"t_ce80", []string{"a", "c", "d"}, only(MySQL80)},
+		{"column-charset-echo-57",
+			"CREATE TABLE t_ce57 (a VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci, b VARCHAR(10) COLLATE utf8mb4_general_ci, c VARCHAR(10) CHARACTER SET utf8mb4, d VARCHAR(10)) DEFAULT CHARSET=utf8mb4",
+			"t_ce57", []string{"a", "b", "c", "d"}, only(MySQL57)},
+		{"column-charset-only-collation-resolution",
+			"CREATE TABLE t_d1 (a VARCHAR(10) CHARACTER SET utf8mb4) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+			"t_d1", []string{"a"}, both()},
+		// generated columns.
+		{"generated-expr-normalization",
+			"CREATE TABLE t_gen (a INT, b INT GENERATED ALWAYS AS (a+1) VIRTUAL, c INT GENERATED ALWAYS AS ( a * 2 ) STORED, d INT AS (a+1))",
+			"t_gen", []string{"b", "c", "d"}, both()},
+		{"generated-expr-string-introducer",
+			"CREATE TABLE t_gen2 (a VARCHAR(20), e VARCHAR(20) GENERATED ALWAYS AS (CONCAT(a,'x')) VIRTUAL) DEFAULT CHARSET=utf8mb4",
+			"t_gen2", []string{"e"}, both()},
+		// functional default — 8.0 only.
+		{"functional-default",
+			"CREATE TABLE t_funcdef (a INT DEFAULT (1+1), b VARCHAR(36) DEFAULT (UUID()), c JSON DEFAULT (JSON_ARRAY()))",
+			"t_funcdef", []string{"a", "b", "c"}, only(MySQL80)},
+		// TIMESTAMP magic — both, opposite behavior.
+		{"timestamp-magic",
+			"CREATE TABLE t_ts (a TIMESTAMP, b TIMESTAMP NULL, d TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
+			"t_ts", []string{"a", "b", "d"}, both()},
+		{"timestamp-datetime-default-expr",
+			"CREATE TABLE t_ts2 (g DATETIME DEFAULT CURRENT_TIMESTAMP, h DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, i TIMESTAMP(3) NULL DEFAULT CURRENT_TIMESTAMP(3))",
+			"t_ts2", []string{"g", "h", "i"}, both()},
+	}
+}
+
+func TestOracle_PhantomDiffElimination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, probe := range normalizationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := "nrm_" + strings.ReplaceAll(probe.id, "-", "_")
+				for _, c := range probe.columns {
+					assertPhantomFree(t, o, db, probe.create, probe.table, c)
+				}
+			})
+		}
+	}
+}
+
+func containsVersion(vs []Version, v Version) bool {
+	for _, x := range vs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -1,6 +1,9 @@
 package catalog
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The normalize-core module is the diff-time canonicalization layer. Its defining
 // property is phantom-diff elimination: for a given target engine version,
@@ -800,5 +803,79 @@ func TestCanonicalColumn_NoKeyInjectionViaComment(t *testing.T) {
 		Comment: "x", Generated: &GeneratedColumnInfo{Expr: "a+1", Stored: false}}
 	if n.CanonicalColumn(tbl, withComment) == n.CanonicalColumn(tbl, gen) {
 		t.Fatal("a comment mimicking field syntax must not collide with a generated column")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for review round 2.
+// ---------------------------------------------------------------------------
+
+func TestCanonicalDefault_DecimalRoundsNotTruncates(t *testing.T) {
+	// MySQL ROUNDS a numeric default to the column scale on storage, with carry:
+	// 0.999 → '1.00', 9.999 → '10.00', INT DEFAULT 1.9 → '2'.
+	n := NormalizerFor(MySQL80)
+	eq := func(colType, lit, storedReadback string) {
+		a := n.CanonicalDefault(defCol(colType, sp(lit), ColumnDefaultConstant))
+		b := n.CanonicalDefault(defCol(colType, sp(storedReadback), ColumnDefaultConstant))
+		if a != b {
+			t.Errorf("%s DEFAULT %s must equal stored %s: %q vs %q", colType, lit, storedReadback, a, b)
+		}
+	}
+	eq("decimal(10,2)", "0.999", "'1.00'")
+	eq("decimal(10,2)", "9.999", "'10.00'")
+	eq("decimal(10,2)", "0.005", "'0.01'")
+	eq("int", "1.9", "'2'")
+	eq("decimal(10,2)", "0.994", "'0.99'") // rounds down
+	// Negative rounding to zero must normalize sign.
+	if n.CanonicalDefault(defCol("int", sp("-0.4"), ColumnDefaultConstant)) !=
+		n.CanonicalDefault(defCol("int", sp("0"), ColumnDefaultConstant)) {
+		t.Error("-0.4 at scale 0 must round to 0")
+	}
+}
+
+func TestCanonicalGeneratedExpr_SpaceBeforeBacktickPreserved(t *testing.T) {
+	// `a` and `b` must NOT become `a andb` — a space before a backticked identifier is a
+	// token boundary even though the backtick byte is not an identifier char.
+	n := NormalizerFor(MySQL80)
+	got := n.CanonicalGeneratedExpr("`a` and `b`")
+	if strings.Contains(got, "andb") {
+		t.Fatalf("space before backtick must be preserved, got %q", got)
+	}
+	// The bare user form and the 8.0 backticked readback must still compare equal.
+	if n.CanonicalGeneratedExpr("a and b") != n.CanonicalGeneratedExpr("`a` and `b`") {
+		t.Fatalf("user `a and b` must equal readback `\\`a\\` and \\`b\\``: %q vs %q",
+			n.CanonicalGeneratedExpr("a and b"), n.CanonicalGeneratedExpr("`a` and `b`"))
+	}
+}
+
+func TestResolveColumnCharsetCollation_CollateOnlyDerivesCharset(t *testing.T) {
+	// A column with only COLLATE (no CHARACTER SET) under a different-charset table: the
+	// effective charset is the collation's charset, not the table's.
+	tbl := &Table{Name: "t", Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+	// Loader derives col.Charset=latin1 from the collation and sets CollationExplicit.
+	c := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "latin1", Collation: "latin1_german1_ci", CollationExplicit: true, Nullable: true}
+	n := NormalizerFor(MySQL80)
+	cs, coll := n.ResolveColumnCharsetCollation(tbl, c)
+	if cs != "latin1" || coll != "latin1_german1_ci" {
+		t.Fatalf("COLLATE-only column must resolve to (latin1, latin1_german1_ci), got (%q,%q)", cs, coll)
+	}
+}
+
+func TestCanonicalTimestamp_NotNullFirstColumnGetsMagic(t *testing.T) {
+	// EDFT=0: the first TIMESTAMP column gets the implicit CURRENT_TIMESTAMP default even
+	// when explicitly NOT NULL (only an explicit NULL suppresses it).
+	n := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: false}
+	a := &Column{Name: "a", DataType: "timestamp", ColumnType: "timestamp", Nullable: false, NullExplicit: true}
+	tbl := tsTable(a)
+	def, onUpdate := n.CanonicalTimestampDefaults(tbl, a)
+	if def != "ts:CURRENT_TIMESTAMP" || onUpdate != "ts:CURRENT_TIMESTAMP" {
+		t.Fatalf("first TIMESTAMP NOT NULL must get CURRENT_TIMESTAMP magic; got def=%q onUpdate=%q", def, onUpdate)
+	}
+	// Explicit NULL first column suppresses the magic.
+	b := &Column{Name: "a", DataType: "timestamp", ColumnType: "timestamp", Nullable: true, NullExplicit: true}
+	defB, _ := n.CanonicalTimestampDefaults(tsTable(b), b)
+	if defB != defaultAbsentKey {
+		t.Fatalf("first TIMESTAMP NULL must NOT get magic; got %q", defB)
 	}
 }

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -879,3 +879,27 @@ func TestCanonicalTimestamp_NotNullFirstColumnGetsMagic(t *testing.T) {
 		t.Fatalf("first TIMESTAMP NULL must NOT get magic; got %q", defB)
 	}
 }
+
+func TestCanonicalDefault_FloatFractionPreserved(t *testing.T) {
+	// Bare FLOAT/DOUBLE defaults preserve their fraction (NOT rounded to int): MySQL
+	// stores float 1.9 → '1.9', double 3.14159 → '3.14159', float 2.0 → '2'.
+	n := NormalizerFor(MySQL80)
+	// Distinct float defaults must NOT collapse.
+	if n.CanonicalDefault(defCol("float", sp("1.9"), ColumnDefaultConstant)) ==
+		n.CanonicalDefault(defCol("float", sp("2.1"), ColumnDefaultConstant)) {
+		t.Fatal("FLOAT DEFAULT 1.9 and 2.1 must not collapse")
+	}
+	// Value-equality with the quoted readback and trailing-zero stripping still hold.
+	eq := func(colType, lit, readback string) {
+		a := n.CanonicalDefault(defCol(colType, sp(lit), ColumnDefaultConstant))
+		b := n.CanonicalDefault(defCol(colType, sp(readback), ColumnDefaultConstant))
+		if a != b {
+			t.Errorf("%s DEFAULT %s must equal stored %s: %q vs %q", colType, lit, readback, a, b)
+		}
+	}
+	eq("float", "1.9", "'1.9'")
+	eq("double", "3.14159", "'3.14159'")
+	eq("float", "2.0", "'2'")
+	// A scaled float(10,2) DOES pad to scale.
+	eq("float(10,2)", "1.5", "'1.50'")
+}

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -1,0 +1,706 @@
+package catalog
+
+import "testing"
+
+// The normalize-core module is the diff-time canonicalization layer. Its defining
+// property is phantom-diff elimination: for a given target engine version,
+//
+//	Canonical(userTargetForm) == Canonical(syncedStoredForm)
+//
+// where both forms describe the same logical schema. The synced stored form is what
+// MySQL writes back via SHOW CREATE TABLE (captured in normalization.md as oracle
+// readbacks); the user target form is what the user declares. These tests assert the
+// canonicalizer collapses both onto the same value, version by version.
+
+func col(name, columnType string) *Column {
+	return &Column{Name: name, DataType: baseTypeOf(columnType), ColumnType: columnType, Nullable: true}
+}
+
+// baseTypeOf extracts the lowercased base type name from a column-type string for
+// test fixtures (the real loader sets DataType directly; this mirrors it).
+func baseTypeOf(columnType string) string {
+	for i := 0; i < len(columnType); i++ {
+		c := columnType[i]
+		if c == '(' || c == ' ' {
+			return columnType[:i]
+		}
+	}
+	return columnType
+}
+
+// ---------------------------------------------------------------------------
+// Highest-risk rule: ResolveColumnCharsetCollation — resolved-pair comparison.
+// (flag column-charset-collation-echo-asymmetry; entries column-charset-echo-57/-80,
+//  column-charset-only-collation-resolution, utf8mb4-default-collation)
+// ---------------------------------------------------------------------------
+
+func TestResolveColumnCharsetCollation_57_StripsWhenEqualsTable(t *testing.T) {
+	// 5.7 readback: a column whose charset == table charset stores NO charset/collation
+	// clause (all four columns read back as bare `varchar(10)`). The user's target may
+	// write the clause explicitly. Both must resolve to the same effective pair.
+	tbl := &Table{Name: "c1", Charset: "utf8mb4", Collation: "utf8mb4_general_ci"}
+
+	// User target: explicit charset+collation equal to the table default.
+	userCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8mb4", Collation: "utf8mb4_general_ci", Nullable: true}
+	// Synced stored form: 5.7 stripped both clauses, leaving them empty.
+	storedCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "", Collation: "", Nullable: true}
+
+	n := NormalizerFor(MySQL57)
+	uc, ucol := n.ResolveColumnCharsetCollation(tbl, userCol)
+	sc, scol := n.ResolveColumnCharsetCollation(tbl, storedCol)
+	if uc != sc || ucol != scol {
+		t.Fatalf("5.7 equal-to-table charset must resolve identically: user=(%q,%q) stored=(%q,%q)", uc, ucol, sc, scol)
+	}
+	if uc != "utf8mb4" || ucol != "utf8mb4_general_ci" {
+		t.Fatalf("expected resolved pair (utf8mb4, utf8mb4_general_ci), got (%q,%q)", uc, ucol)
+	}
+}
+
+func TestResolveColumnCharsetCollation_57_KeepsGenuineOverride(t *testing.T) {
+	// 5.7 readback: a column whose charset differs from the table keeps it
+	// (`CHARACTER SET utf8` under a utf8mb4 table).
+	tbl := &Table{Name: "cu", Charset: "utf8mb4", Collation: "utf8mb4_general_ci"}
+	userCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8", Nullable: true} // user wrote CHARACTER SET utf8, no collate
+	storedCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8", Nullable: true} // 5.7 keeps `CHARACTER SET utf8`
+
+	n := NormalizerFor(MySQL57)
+	uc, ucol := n.ResolveColumnCharsetCollation(tbl, userCol)
+	sc, scol := n.ResolveColumnCharsetCollation(tbl, storedCol)
+	if uc != sc || ucol != scol {
+		t.Fatalf("override must resolve identically: user=(%q,%q) stored=(%q,%q)", uc, ucol, sc, scol)
+	}
+	// utf8 ≡ utf8mb3; collation resolves to the charset default, not the table's.
+	if uc != "utf8mb3" {
+		t.Fatalf("expected resolved charset utf8mb3 (utf8 alias), got %q", uc)
+	}
+	if ucol != "utf8_general_ci" && ucol != "utf8mb3_general_ci" {
+		t.Fatalf("expected utf8 charset-default collation, got %q", ucol)
+	}
+}
+
+func TestResolveColumnCharsetCollation_80_KeepsRedundantPair(t *testing.T) {
+	// 8.0 readback: when the user specifies charset OR collation, 8.0 echoes BOTH as a
+	// pair even if it equals the table default. A bare column collapses to varchar(10).
+	tbl := &Table{Name: "c1", Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+
+	// `c` -> CHARACTER SET utf8mb4 (no collate). Stored as the resolved pair.
+	userCol := &Column{Name: "c", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8mb4", Nullable: true}
+	storedCol := &Column{Name: "c", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci", Nullable: true}
+
+	n := NormalizerFor(MySQL80)
+	uc, ucol := n.ResolveColumnCharsetCollation(tbl, userCol)
+	sc, scol := n.ResolveColumnCharsetCollation(tbl, storedCol)
+	if uc != sc || ucol != scol {
+		t.Fatalf("8.0 pair must resolve identically: user=(%q,%q) stored=(%q,%q)", uc, ucol, sc, scol)
+	}
+	if ucol != "utf8mb4_0900_ai_ci" {
+		t.Fatalf("8.0 must resolve missing collation to charset default, got %q", ucol)
+	}
+}
+
+func TestResolveColumnCharsetCollation_80_BareInheritsTable(t *testing.T) {
+	// 8.0 readback: a fully-bare column (`d`) collapses to varchar(10) — it inherits
+	// the table's charset+collation. The resolved pair equals the table's.
+	tbl := &Table{Name: "c1", Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+	bare := &Column{Name: "d", DataType: "varchar", ColumnType: "varchar(10)", Nullable: true}
+
+	n := NormalizerFor(MySQL80)
+	cs, coll := n.ResolveColumnCharsetCollation(tbl, bare)
+	if cs != "utf8mb4" || coll != "utf8mb4_0900_ai_ci" {
+		t.Fatalf("bare column must inherit table pair, got (%q,%q)", cs, coll)
+	}
+}
+
+func TestResolveColumnCharsetCollation_80_CharsetOnlyResolvesFromCharsetDefault(t *testing.T) {
+	// entry column-charset-only-collation-resolution: under a table collated
+	// utf8mb4_unicode_ci, a column with only CHARACTER SET utf8mb4 resolves its
+	// collation from the CHARSET default (utf8mb4_0900_ai_ci on 8.0), NOT the table COLLATE.
+	tbl := &Table{Name: "t_d1", Charset: "utf8mb4", Collation: "utf8mb4_unicode_ci"}
+	userCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8mb4", Nullable: true}
+
+	n := NormalizerFor(MySQL80)
+	_, coll := n.ResolveColumnCharsetCollation(tbl, userCol)
+	if coll != "utf8mb4_0900_ai_ci" {
+		t.Fatalf("charset-only column must resolve to charset default utf8mb4_0900_ai_ci, not table COLLATE; got %q", coll)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CanonicalColumnType — integer display width, BOOLEAN, decimal, year, unsigned,
+// zerofill. (entries int-display-width, tinyint1-boolean, int-unsigned-width,
+//  int-zerofill, decimal-precision-scale, float-double-aliasing, year-width,
+//  bit/char/binary length defaults)
+// ---------------------------------------------------------------------------
+
+// canonTypeEq asserts that every input spelling maps to the same canonical type for
+// the given version. The loader stores the 8.0 form (e.g. "int"); a raw 5.7 readback
+// string would be "int(11)". Both, plus any user spelling, must collapse to one value.
+func canonTypeEq(t *testing.T, v Version, want string, inputs ...string) {
+	t.Helper()
+	n := NormalizerFor(v)
+	for _, in := range inputs {
+		got := n.CanonicalColumnType(col("x", in))
+		if got != want {
+			t.Errorf("[%v] CanonicalColumnType(%q) = %q, want %q", v, in, got, want)
+		}
+	}
+}
+
+func TestCanonicalColumnType_IntWidth_80DropsWidth(t *testing.T) {
+	canonTypeEq(t, MySQL80, "int", "int", "int(11)", "INT(11)", "integer", "int(5)")
+	canonTypeEq(t, MySQL80, "bigint", "bigint", "bigint(20)")
+	canonTypeEq(t, MySQL80, "smallint", "smallint", "smallint(6)")
+	canonTypeEq(t, MySQL80, "mediumint", "mediumint", "mediumint(9)")
+	canonTypeEq(t, MySQL80, "tinyint", "tinyint", "tinyint", "tinyint(4)")
+}
+
+func TestCanonicalColumnType_IntWidth_57InjectsDefault(t *testing.T) {
+	// 5.7 injects the default width when omitted. Loader-form "int" and readback
+	// "int(11)" must both canonicalize to "int(11)".
+	canonTypeEq(t, MySQL57, "int(11)", "int", "int(11)", "integer")
+	canonTypeEq(t, MySQL57, "bigint(20)", "bigint", "bigint(20)")
+	canonTypeEq(t, MySQL57, "smallint(6)", "smallint", "smallint(6)")
+	canonTypeEq(t, MySQL57, "mediumint(9)", "mediumint", "mediumint(9)")
+	canonTypeEq(t, MySQL57, "tinyint(4)", "tinyint", "tinyint(4)")
+}
+
+func TestCanonicalColumnType_Tinyint1Boolean(t *testing.T) {
+	// tinyint(1) survives on BOTH versions (boolean marker); BOOLEAN/BOOL → tinyint(1).
+	canonTypeEq(t, MySQL80, "tinyint(1)", "tinyint(1)", "boolean", "bool")
+	canonTypeEq(t, MySQL57, "tinyint(1)", "tinyint(1)", "boolean", "bool")
+	// bare tinyint differs: 8.0 drops to tinyint, 5.7 injects tinyint(4).
+	canonTypeEq(t, MySQL80, "tinyint", "tinyint(4)")
+	canonTypeEq(t, MySQL57, "tinyint(4)", "tinyint")
+}
+
+func TestCanonicalColumnType_UnsignedWidth(t *testing.T) {
+	canonTypeEq(t, MySQL80, "int unsigned", "int unsigned", "int(11) unsigned", "int(10) unsigned")
+	// 5.7 bare INT UNSIGNED → int(10) unsigned (unsigned default width is 10, not 11).
+	canonTypeEq(t, MySQL57, "int(10) unsigned", "int unsigned", "int(10) unsigned")
+	canonTypeEq(t, MySQL57, "bigint(20) unsigned", "bigint unsigned", "bigint(20) unsigned")
+	canonTypeEq(t, MySQL57, "tinyint(3) unsigned", "tinyint unsigned")
+}
+
+func TestCanonicalColumnType_Zerofill_WidthKeptBothVersions(t *testing.T) {
+	// ZEROFILL retains display width on BOTH versions and implies unsigned.
+	want := "int(5) unsigned zerofill"
+	canonTypeEq(t, MySQL80, want, "int(5) zerofill", "int(5) unsigned zerofill")
+	canonTypeEq(t, MySQL57, want, "int(5) zerofill", "int(5) unsigned zerofill")
+	// bare INT ZEROFILL → width 10 injected, both versions.
+	canonTypeEq(t, MySQL80, "int(10) unsigned zerofill", "int zerofill")
+	canonTypeEq(t, MySQL57, "int(10) unsigned zerofill", "int zerofill")
+}
+
+func TestCanonicalColumnType_DecimalPrecisionScale(t *testing.T) {
+	// NUMERIC/DEC/FIXED → decimal; bare → decimal(10,0); DECIMAL(10) → decimal(10,0).
+	for _, v := range []Version{MySQL57, MySQL80} {
+		canonTypeEq(t, v, "decimal(10,0)", "decimal", "decimal(10)", "numeric", "dec", "fixed", "decimal(10,0)")
+		canonTypeEq(t, v, "decimal(8,3)", "decimal(8,3)", "numeric(8,3)")
+	}
+}
+
+func TestCanonicalColumnType_FloatDoubleAliasing(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		canonTypeEq(t, v, "float", "float", "float(5)") // single-arg precision dropped
+		canonTypeEq(t, v, "double", "double", "real")
+		canonTypeEq(t, v, "float(10,2)", "float(10,2)")
+		canonTypeEq(t, v, "double(15,4)", "double(15,4)")
+	}
+}
+
+func TestCanonicalColumnType_YearWidth(t *testing.T) {
+	canonTypeEq(t, MySQL80, "year", "year", "year(4)")
+	canonTypeEq(t, MySQL57, "year(4)", "year", "year(4)")
+}
+
+func TestCanonicalColumnType_BitCharBinaryLengthDefault(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		canonTypeEq(t, v, "bit(1)", "bit", "bit(1)")
+		canonTypeEq(t, v, "char(1)", "char", "char(1)")
+		canonTypeEq(t, v, "binary(1)", "binary", "binary(1)")
+		canonTypeEq(t, v, "varchar(10)", "varchar(10)")
+		canonTypeEq(t, v, "varbinary(32)", "varbinary(32)")
+	}
+}
+
+func TestCanonicalColumnType_TextBlobNoWidth(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		canonTypeEq(t, v, "text", "text")
+		canonTypeEq(t, v, "blob", "blob")
+		canonTypeEq(t, v, "longtext", "longtext")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CanonicalDefault — value-based comparison. (entries default-literal-quoting,
+//  decimal-default-padding, boolean-default, functional-default,
+//  nullable-default-null, timestamp-datetime-default-expr; flag
+//  numeric-default-quote-version)
+// ---------------------------------------------------------------------------
+
+func defCol(columnType string, def *string, kind ColumnDefaultKind) *Column {
+	c := col("x", columnType)
+	c.Default = def
+	c.DefaultKind = kind
+	return c
+}
+func sp(s string) *string { return &s }
+
+func defaultKeyEq(t *testing.T, v Version, a, b *Column) {
+	t.Helper()
+	n := NormalizerFor(v)
+	ka, kb := n.CanonicalDefault(a), n.CanonicalDefault(b)
+	if ka != kb {
+		t.Fatalf("[%v] defaults must canonicalize equal: %q vs %q", v, ka, kb)
+	}
+}
+
+func TestCanonicalDefault_NumericValueBased(t *testing.T) {
+	// flag numeric-default-quote-version: compare numeric defaults by VALUE, not string.
+	// Loader stores "0" for DEFAULT 0; readback is "'0'". Both must be equal.
+	for _, v := range []Version{MySQL57, MySQL80} {
+		defaultKeyEq(t, v,
+			defCol("int", sp("0"), ColumnDefaultConstant),
+			defCol("int", sp("'0'"), ColumnDefaultConstant))
+		defaultKeyEq(t, v,
+			defCol("int", sp("5"), ColumnDefaultConstant),
+			defCol("int", sp("'5'"), ColumnDefaultConstant))
+	}
+}
+
+func TestCanonicalDefault_DecimalScalePadding(t *testing.T) {
+	// A numeric default on a scaled DECIMAL is padded to the column scale: 0 → '0.00'.
+	for _, v := range []Version{MySQL57, MySQL80} {
+		defaultKeyEq(t, v,
+			defCol("decimal(10,2)", sp("0"), ColumnDefaultConstant),
+			defCol("decimal(10,2)", sp("'0.00'"), ColumnDefaultConstant))
+		defaultKeyEq(t, v,
+			defCol("decimal(10,2)", sp("0.00"), ColumnDefaultConstant),
+			defCol("decimal(10,2)", sp("'0.00'"), ColumnDefaultConstant))
+	}
+}
+
+func TestCanonicalDefault_StringQuoting(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		// Double-quoted vs single-quoted string default are equal.
+		defaultKeyEq(t, v,
+			defCol("varchar(10)", sp(`"double"`), ColumnDefaultConstant),
+			defCol("varchar(10)", sp(`'double'`), ColumnDefaultConstant))
+		// Empty-string default.
+		defaultKeyEq(t, v,
+			defCol("varchar(10)", sp(`''`), ColumnDefaultConstant),
+			defCol("varchar(10)", sp(`''`), ColumnDefaultConstant))
+	}
+}
+
+func TestCanonicalDefault_NullHandling(t *testing.T) {
+	// A nullable column with explicit NULL / DEFAULT NULL / no default are equivalent.
+	for _, v := range []Version{MySQL57, MySQL80} {
+		nullDef := defCol("int", sp("NULL"), ColumnDefaultConstant)
+		noDef := col("x", "int") // Default == nil
+		defaultKeyEq(t, v, nullDef, noDef)
+	}
+}
+
+func TestCanonicalDefault_BooleanLiteral(t *testing.T) {
+	// BOOLEAN DEFAULT TRUE/FALSE → '1'/'0'. Loader already folds TRUE→"1".
+	for _, v := range []Version{MySQL57, MySQL80} {
+		defaultKeyEq(t, v,
+			defCol("tinyint(1)", sp("1"), ColumnDefaultConstant),
+			defCol("tinyint(1)", sp("'1'"), ColumnDefaultConstant))
+	}
+}
+
+func TestCanonicalDefault_CurrentTimestampSynonyms(t *testing.T) {
+	// NOW()/LOCALTIME/LOCALTIMESTAMP → CURRENT_TIMESTAMP, unquoted, case-insensitive.
+	for _, v := range []Version{MySQL57, MySQL80} {
+		defaultKeyEq(t, v,
+			defCol("datetime", sp("CURRENT_TIMESTAMP"), ColumnDefaultCurrentTimestamp),
+			defCol("datetime", sp("now()"), ColumnDefaultCurrentTimestamp))
+		defaultKeyEq(t, v,
+			defCol("timestamp(3)", sp("CURRENT_TIMESTAMP(3)"), ColumnDefaultCurrentTimestamp),
+			defCol("timestamp(3)", sp("current_timestamp(3)"), ColumnDefaultCurrentTimestamp))
+	}
+}
+
+func TestCanonicalDefault_DistinctValuesDiffer(t *testing.T) {
+	// Guard against over-collapsing: different defaults must NOT compare equal.
+	n := NormalizerFor(MySQL80)
+	if n.CanonicalDefault(defCol("int", sp("0"), ColumnDefaultConstant)) ==
+		n.CanonicalDefault(defCol("int", sp("1"), ColumnDefaultConstant)) {
+		t.Fatal("DEFAULT 0 and DEFAULT 1 must not be equal")
+	}
+	if n.CanonicalDefault(defCol("varchar(10)", sp("'a'"), ColumnDefaultConstant)) ==
+		n.CanonicalDefault(defCol("varchar(10)", sp("'b'"), ColumnDefaultConstant)) {
+		t.Fatal("DEFAULT 'a' and DEFAULT 'b' must not be equal")
+	}
+	// A NULL default and a non-null default must differ.
+	if n.CanonicalDefault(col("x", "int")) ==
+		n.CanonicalDefault(defCol("int", sp("0"), ColumnDefaultConstant)) {
+		t.Fatal("no default and DEFAULT 0 must not be equal")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CanonicalGeneratedExpr — expression canonicalization. (entries
+//  generated-expr-normalization, generated-expr-string-introducer, functional-default,
+//  check-constraint)
+// ---------------------------------------------------------------------------
+
+func genExprEq(t *testing.T, v Version, inputs ...string) {
+	t.Helper()
+	n := NormalizerFor(v)
+	want := n.CanonicalGeneratedExpr(inputs[0])
+	for _, in := range inputs[1:] {
+		if got := n.CanonicalGeneratedExpr(in); got != want {
+			t.Errorf("[%v] CanonicalGeneratedExpr(%q)=%q != CanonicalGeneratedExpr(%q)=%q", v, in, got, inputs[0], want)
+		}
+	}
+}
+
+func TestCanonicalGeneratedExpr_WhitespaceAndParens(t *testing.T) {
+	// (a+1), ( a + 1 ), `a` + 1, ((`a` + 1)) all collapse to one canonical form.
+	for _, v := range []Version{MySQL57, MySQL80} {
+		genExprEq(t, v,
+			"`a` + 1",
+			"(`a` + 1)",
+			"((`a` + 1))",
+			"a+1",
+			"( a   +   1 )",
+		)
+	}
+}
+
+func TestCanonicalGeneratedExpr_LatinIntroducerStripped(t *testing.T) {
+	// 8.0 readback injects _latin1 before string literals; 5.7 and user input do not.
+	// Both must compare equal (the introducer is connection-dependent noise).
+	for _, v := range []Version{MySQL57, MySQL80} {
+		genExprEq(t, v,
+			"concat(`a`,'x')",
+			"concat(`a`,_latin1'x')",
+			"concat(`a`, 'x')",
+		)
+	}
+}
+
+func TestCanonicalGeneratedExpr_FunctionLowercasing(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		genExprEq(t, v,
+			"concat(`a`,`b`)",
+			"CONCAT(`a`,`b`)",
+			"Concat(`a`, `b`)",
+		)
+	}
+}
+
+func TestCanonicalGeneratedExpr_DistinctExprsDiffer(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	if n.CanonicalGeneratedExpr("`a` + 1") == n.CanonicalGeneratedExpr("`a` + 2") {
+		t.Fatal("a+1 and a+2 must not compare equal")
+	}
+	if n.CanonicalGeneratedExpr("`a` * 2") == n.CanonicalGeneratedExpr("`a` + 2") {
+		t.Fatal("a*2 and a+2 must not compare equal")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nullability + PK. (entries nullable-default-null, pk-implies-not-null)
+// ---------------------------------------------------------------------------
+
+func TestCanonicalNullability_PKForcesNotNull(t *testing.T) {
+	// A PK-member column is forced NOT NULL even if declared nullable.
+	tbl := &Table{Name: "t_pk"}
+	idCol := &Column{Name: "id", DataType: "int", ColumnType: "int", Nullable: true}
+	tbl.Columns = []*Column{idCol}
+	tbl.Indexes = []*Index{{Primary: true, Columns: []*IndexColumn{{Name: "id"}}}}
+
+	n := NormalizerFor(MySQL80)
+	if n.CanonicalNotNull(tbl, idCol) != true {
+		t.Fatal("PK column must canonicalize to NOT NULL")
+	}
+}
+
+func TestCanonicalNullability_NonPKNullablePreserved(t *testing.T) {
+	tbl := &Table{Name: "t"}
+	c := &Column{Name: "a", DataType: "int", ColumnType: "int", Nullable: true}
+	tbl.Columns = []*Column{c}
+	n := NormalizerFor(MySQL80)
+	if n.CanonicalNotNull(tbl, c) != false {
+		t.Fatal("non-PK nullable column must stay nullable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TIMESTAMP magic — governed by explicit_defaults_for_timestamp (a session var, not a
+// version trait). (entry timestamp-magic-first-57; flag explicit-defaults-for-timestamp)
+// ---------------------------------------------------------------------------
+
+func tsTable(cols ...*Column) *Table {
+	t := &Table{Name: "t_ts"}
+	t.Columns = cols
+	return t
+}
+func tsCol(name string) *Column {
+	return &Column{Name: name, DataType: "timestamp", ColumnType: "timestamp", Nullable: true}
+}
+
+func TestCanonicalTimestamp_EDFTOff_FirstBareGetsMagic(t *testing.T) {
+	// explicit_defaults_for_timestamp=0: the FIRST bare TIMESTAMP gets
+	// NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP.
+	n := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: false}
+	a := tsCol("a")
+	tbl := tsTable(a)
+
+	if !n.CanonicalNotNull(tbl, a) {
+		t.Fatal("EDFT=0: first bare TIMESTAMP must be NOT NULL")
+	}
+	def, onUpdate := n.CanonicalTimestampDefaults(tbl, a)
+	if def != "ts:CURRENT_TIMESTAMP" {
+		t.Fatalf("EDFT=0: first bare TIMESTAMP default = %q, want ts:CURRENT_TIMESTAMP", def)
+	}
+	if onUpdate != "ts:CURRENT_TIMESTAMP" {
+		t.Fatalf("EDFT=0: first bare TIMESTAMP on-update = %q, want ts:CURRENT_TIMESTAMP", onUpdate)
+	}
+}
+
+func TestCanonicalTimestamp_EDFTOff_NonFirstRespectsLoadedNullability(t *testing.T) {
+	// EDFT=0: a TIMESTAMP that is NOT the first one keeps its loaded nullability. The
+	// loader collapses `TIMESTAMP` (NOT NULL) and `TIMESTAMP NULL` (nullable) to the
+	// same catalog state, so we cannot distinguish them; the conservative ruling keeps
+	// the loaded value to avoid phantom-diffing a genuine `TIMESTAMP NULL` against its
+	// readback (which reads back as `timestamp NULL DEFAULT NULL`). The first column,
+	// which is unambiguous, still gets NOT NULL (covered above).
+	n := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: false}
+	a, b := tsCol("a"), tsCol("b")
+	tbl := tsTable(a, b)
+	if n.CanonicalNotNull(tbl, b) {
+		t.Fatal("EDFT=0: non-first TIMESTAMP must respect loaded nullability (conservative)")
+	}
+}
+
+func TestCanonicalTimestamp_EDFTOn_BareIsNullable(t *testing.T) {
+	// explicit_defaults_for_timestamp=1 (8.0 box default): bare TIMESTAMP → NULL DEFAULT NULL.
+	n := &Normalizer{Version: MySQL80, ExplicitDefaultsForTimestamp: true}
+	a := tsCol("a")
+	tbl := tsTable(a)
+	if n.CanonicalNotNull(tbl, a) {
+		t.Fatal("EDFT=1: bare TIMESTAMP must be NULLABLE")
+	}
+}
+
+func TestCanonicalTimestamp_SameVersionDifferentEDFT_Diverges(t *testing.T) {
+	// The whole point of flag #3: a 5.7 server with EDFT=1 behaves like 8.0, NOT like
+	// the 5.7 box. Nullability must follow the captured variable, not the version.
+	a1 := tsCol("a")
+	a2 := tsCol("a")
+	on := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: true}   // 5.7 + EDFT ON
+	off := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: false} // 5.7 + EDFT OFF
+	if on.CanonicalNotNull(tsTable(a1), a1) == off.CanonicalNotNull(tsTable(a2), a2) {
+		t.Fatal("TIMESTAMP nullability must depend on explicit_defaults_for_timestamp, not version")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Table options — engine default, ignore-in-diff (AUTO_INCREMENT, ROW_FORMAT).
+// (entries engine-always-emitted, row-format-default-omitted, auto-increment-counter;
+//  flag row-format-default-source)
+// ---------------------------------------------------------------------------
+
+func TestCanonicalEngine_DefaultResolved(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	// Empty engine resolves to the server default InnoDB; explicit InnoDB matches.
+	if n.CanonicalEngine(&Table{Engine: ""}) != n.CanonicalEngine(&Table{Engine: "InnoDB"}) {
+		t.Fatal("empty engine must resolve to default InnoDB")
+	}
+	if n.CanonicalEngine(&Table{Engine: "innodb"}) != n.CanonicalEngine(&Table{Engine: "INNODB"}) {
+		t.Fatal("engine comparison must be case-insensitive")
+	}
+}
+
+func TestIgnoreInDiff_AutoIncrementCounter(t *testing.T) {
+	// The table-level AUTO_INCREMENT=N counter is a runtime value, ignored in diff.
+	n := NormalizerFor(MySQL80)
+	if !n.IgnoreTableAutoIncrement() {
+		t.Fatal("table AUTO_INCREMENT counter must be ignored in diff")
+	}
+}
+
+func TestIgnoreInDiff_RowFormatDefault(t *testing.T) {
+	// ROW_FORMAT is ignored when it is empty/the environment default; a user-set value
+	// is not ignored. (flag row-format-default-source: exclude unless explicitly set)
+	n := NormalizerFor(MySQL80)
+	if !n.IgnoreRowFormat(&Table{RowFormat: ""}) {
+		t.Fatal("default (empty) ROW_FORMAT must be ignored")
+	}
+	if !n.IgnoreRowFormat(&Table{RowFormat: "DEFAULT"}) {
+		t.Fatal("ROW_FORMAT=DEFAULT must be ignored")
+	}
+	if n.IgnoreRowFormat(&Table{RowFormat: "DYNAMIC"}) {
+		t.Fatal("explicit ROW_FORMAT=DYNAMIC must NOT be ignored")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Comments — content comparison, decoded. (entry comment-escaping)
+// ---------------------------------------------------------------------------
+
+func TestCanonicalComment_DecodedContent(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	// Embedded doubled single-quote decodes to a single quote; compare content.
+	if n.CanonicalComment("has ''quote'' inside") != n.CanonicalComment("has 'quote' inside") {
+		t.Fatal("comment comparison must be on decoded content")
+	}
+	if n.CanonicalComment("") != "" {
+		t.Fatal("empty comment must yield empty key")
+	}
+	if n.CanonicalComment("a") == n.CanonicalComment("b") {
+		t.Fatal("distinct comments must differ")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Index column direction — descending is version-flagged. (entry index-desc-asc)
+// ---------------------------------------------------------------------------
+
+func TestCanonicalIndexColumn_DescendingVersionFlagged(t *testing.T) {
+	descCol := &IndexColumn{Name: "a", Descending: true}
+	ascCol := &IndexColumn{Name: "a", Descending: false}
+
+	// 8.0 supports descending: DESC and ASC produce different keys.
+	n80 := NormalizerFor(MySQL80)
+	if n80.CanonicalIndexColumn(descCol) == n80.CanonicalIndexColumn(ascCol) {
+		t.Fatal("8.0: DESC and ASC index columns must differ")
+	}
+	// 5.7 ignores direction: DESC and ASC produce the SAME key (stored ascending).
+	n57 := NormalizerFor(MySQL57)
+	if n57.CanonicalIndexColumn(descCol) != n57.CanonicalIndexColumn(ascCol) {
+		t.Fatal("5.7: direction must be ignored (no descending indexes)")
+	}
+}
+
+func TestCanonicalIndexColumn_PrefixLengthPreserved(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		n := NormalizerFor(v)
+		a10 := &IndexColumn{Name: "a", Length: 10}
+		a20 := &IndexColumn{Name: "a", Length: 20}
+		if n.CanonicalIndexColumn(a10) == n.CanonicalIndexColumn(a20) {
+			t.Fatalf("[%v] prefix lengths 10 and 20 must differ", v)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ENUM / SET quoting. (entry enum-set-quoting)
+// ---------------------------------------------------------------------------
+
+func TestCanonicalColumnType_EnumSetQuoting(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		// Double-quoted members canonicalize to single-quoted; order preserved.
+		canonTypeEq(t, v, "enum('x','y','z')", "enum('x','y','z')", `enum("x","y","z")`)
+		canonTypeEq(t, v, "set('a','b','c')", "set('a','b','c')")
+	}
+	// Different member ORDER must NOT be equal (order is significant for ENUM).
+	n := NormalizerFor(MySQL80)
+	if n.CanonicalColumnType(col("x", "enum('a','b')")) == n.CanonicalColumnType(col("x", "enum('b','a')")) {
+		t.Fatal("ENUM member order is significant; reordered members must differ")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CanonicalColumn — the aggregate key diff-core's column comparison calls. Ties
+// type + resolved charset/collation + default + nullability + generated expr into one
+// comparison key per column, so equal logical columns produce equal keys regardless of
+// surface form. This is the phantom-diff firewall.
+// ---------------------------------------------------------------------------
+
+func TestCanonicalColumn_8080PhantomDiffEliminated(t *testing.T) {
+	// 8.0: user writes `INT(11)` with redundant explicit charset; synced readback is
+	// `int` bare. The aggregate keys must be equal — no phantom diff.
+	tbl := &Table{Name: "t", Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+	n := NormalizerFor(MySQL80)
+
+	user := &Column{Name: "a", DataType: "int", ColumnType: "int(11)", Nullable: true}
+	stored := &Column{Name: "a", DataType: "int", ColumnType: "int", Nullable: true}
+	if n.CanonicalColumn(tbl, user) != n.CanonicalColumn(tbl, stored) {
+		t.Fatalf("8.0 int(11) vs int must not phantom-diff:\n user=%s\n stor=%s",
+			n.CanonicalColumn(tbl, user), n.CanonicalColumn(tbl, stored))
+	}
+}
+
+func TestCanonicalColumn_57CharsetEchoPhantomEliminated(t *testing.T) {
+	// 5.7: user writes explicit `CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci`
+	// equal to the table default; synced readback dropped both. Keys must match.
+	tbl := &Table{Name: "t", Charset: "utf8mb4", Collation: "utf8mb4_general_ci"}
+	n := NormalizerFor(MySQL57)
+
+	user := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
+		Charset: "utf8mb4", Collation: "utf8mb4_general_ci", Nullable: true}
+	stored := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)", Nullable: true}
+	if n.CanonicalColumn(tbl, user) != n.CanonicalColumn(tbl, stored) {
+		t.Fatalf("5.7 charset-echo must not phantom-diff:\n user=%s\n stor=%s",
+			n.CanonicalColumn(tbl, user), n.CanonicalColumn(tbl, stored))
+	}
+}
+
+func TestCanonicalColumn_GenuineDifferenceDetected(t *testing.T) {
+	// The firewall must still detect a REAL change (int → bigint).
+	tbl := &Table{Name: "t", Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+	n := NormalizerFor(MySQL80)
+	a := &Column{Name: "a", DataType: "int", ColumnType: "int", Nullable: true}
+	b := &Column{Name: "a", DataType: "bigint", ColumnType: "bigint", Nullable: true}
+	if n.CanonicalColumn(tbl, a) == n.CanonicalColumn(tbl, b) {
+		t.Fatal("int vs bigint must produce different keys")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Idempotence: Canonical(Canonical(x)) == Canonical(x) for every canonicalizer.
+// ---------------------------------------------------------------------------
+
+func TestIdempotence_ColumnType(t *testing.T) {
+	for _, v := range []Version{MySQL57, MySQL80} {
+		n := NormalizerFor(v)
+		for _, in := range []string{"int(11)", "int", "bigint", "tinyint(1)", "boolean",
+			"decimal(10,2)", "decimal", "float(10,2)", "year(4)", "varchar(10)",
+			"int(5) zerofill", "int unsigned", "enum('a','b')", "char", "bit"} {
+			once := n.CanonicalColumnType(col("x", in))
+			twice := n.CanonicalColumnType(col("x", once))
+			if once != twice {
+				t.Errorf("[%v] CanonicalColumnType not idempotent for %q: %q -> %q", v, in, once, twice)
+			}
+		}
+	}
+}
+
+func TestIdempotence_GeneratedExpr(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	for _, in := range []string{"`a` + 1", "((`a` + 1))", "concat(`a`,_latin1'x')", "CONCAT(`a`, `b`)"} {
+		once := n.CanonicalGeneratedExpr(in)
+		twice := n.CanonicalGeneratedExpr(once)
+		if once != twice {
+			t.Errorf("CanonicalGeneratedExpr not idempotent for %q: %q -> %q", in, once, twice)
+		}
+	}
+}
+
+func TestIdempotence_CharsetCollation(t *testing.T) {
+	tbl := &Table{Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+	for _, v := range []Version{MySQL57, MySQL80} {
+		n := NormalizerFor(v)
+		in := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)", Charset: "utf8", Nullable: true}
+		cs, coll := n.ResolveColumnCharsetCollation(tbl, in)
+		// Feed the resolved pair back as an explicit column; must be stable.
+		in2 := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)", Charset: cs, Collation: coll, Nullable: true}
+		cs2, coll2 := n.ResolveColumnCharsetCollation(tbl, in2)
+		if cs != cs2 || coll != coll2 {
+			t.Errorf("[%v] charset/collation resolution not idempotent: (%q,%q) -> (%q,%q)", v, cs, coll, cs2, coll2)
+		}
+	}
+}

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -42,8 +42,8 @@ func TestResolveColumnCharsetCollation_57_StripsWhenEqualsTable(t *testing.T) {
 
 	// User target: explicit charset+collation equal to the table default.
 	userCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
-		Charset: "utf8mb4", Collation: "utf8mb4_general_ci", Nullable: true}
-	// Synced stored form: 5.7 stripped both clauses, leaving them empty.
+		Charset: "utf8mb4", CharsetExplicit: true, Collation: "utf8mb4_general_ci", CollationExplicit: true, Nullable: true}
+	// Synced stored form: 5.7 stripped both clauses, leaving them empty (inherited).
 	storedCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
 		Charset: "", Collation: "", Nullable: true}
 
@@ -63,9 +63,9 @@ func TestResolveColumnCharsetCollation_57_KeepsGenuineOverride(t *testing.T) {
 	// (`CHARACTER SET utf8` under a utf8mb4 table).
 	tbl := &Table{Name: "cu", Charset: "utf8mb4", Collation: "utf8mb4_general_ci"}
 	userCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
-		Charset: "utf8", Nullable: true} // user wrote CHARACTER SET utf8, no collate
+		Charset: "utf8", CharsetExplicit: true, Nullable: true} // user wrote CHARACTER SET utf8, no collate
 	storedCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
-		Charset: "utf8", Nullable: true} // 5.7 keeps `CHARACTER SET utf8`
+		Charset: "utf8", CharsetExplicit: true, Nullable: true} // 5.7 keeps `CHARACTER SET utf8`
 
 	n := NormalizerFor(MySQL57)
 	uc, ucol := n.ResolveColumnCharsetCollation(tbl, userCol)
@@ -89,9 +89,9 @@ func TestResolveColumnCharsetCollation_80_KeepsRedundantPair(t *testing.T) {
 
 	// `c` -> CHARACTER SET utf8mb4 (no collate). Stored as the resolved pair.
 	userCol := &Column{Name: "c", DataType: "varchar", ColumnType: "varchar(10)",
-		Charset: "utf8mb4", Nullable: true}
+		Charset: "utf8mb4", CharsetExplicit: true, Nullable: true}
 	storedCol := &Column{Name: "c", DataType: "varchar", ColumnType: "varchar(10)",
-		Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci", Nullable: true}
+		Charset: "utf8mb4", CharsetExplicit: true, Collation: "utf8mb4_0900_ai_ci", CollationExplicit: true, Nullable: true}
 
 	n := NormalizerFor(MySQL80)
 	uc, ucol := n.ResolveColumnCharsetCollation(tbl, userCol)
@@ -123,7 +123,7 @@ func TestResolveColumnCharsetCollation_80_CharsetOnlyResolvesFromCharsetDefault(
 	// collation from the CHARSET default (utf8mb4_0900_ai_ci on 8.0), NOT the table COLLATE.
 	tbl := &Table{Name: "t_d1", Charset: "utf8mb4", Collation: "utf8mb4_unicode_ci"}
 	userCol := &Column{Name: "a", DataType: "varchar", ColumnType: "varchar(10)",
-		Charset: "utf8mb4", Nullable: true}
+		Charset: "utf8mb4", CharsetExplicit: true, Nullable: true}
 
 	n := NormalizerFor(MySQL80)
 	_, coll := n.ResolveColumnCharsetCollation(tbl, userCol)
@@ -470,18 +470,35 @@ func TestCanonicalTimestamp_EDFTOff_FirstBareGetsMagic(t *testing.T) {
 	}
 }
 
-func TestCanonicalTimestamp_EDFTOff_NonFirstRespectsLoadedNullability(t *testing.T) {
-	// EDFT=0: a TIMESTAMP that is NOT the first one keeps its loaded nullability. The
-	// loader collapses `TIMESTAMP` (NOT NULL) and `TIMESTAMP NULL` (nullable) to the
-	// same catalog state, so we cannot distinguish them; the conservative ruling keeps
-	// the loaded value to avoid phantom-diffing a genuine `TIMESTAMP NULL` against its
-	// readback (which reads back as `timestamp NULL DEFAULT NULL`). The first column,
-	// which is unambiguous, still gets NOT NULL (covered above).
+func TestCanonicalTimestamp_EDFTOff_NullExplicitDistinguishesBareFromNull(t *testing.T) {
+	// EDFT=0: a TIMESTAMP with NO explicit nullability clause is forced NOT NULL — even a
+	// non-first one — while an explicit `TIMESTAMP NULL` stays nullable. The loader's
+	// NullExplicit flag tells them apart (a bare TIMESTAMP and `TIMESTAMP NULL` are
+	// otherwise the same catalog state).
 	n := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: false}
-	a, b := tsCol("a"), tsCol("b")
-	tbl := tsTable(a, b)
-	if n.CanonicalNotNull(tbl, b) {
-		t.Fatal("EDFT=0: non-first TIMESTAMP must respect loaded nullability (conservative)")
+	a := tsCol("a")            // first, bare
+	bare := tsCol("b")         // non-first, bare → NOT NULL
+	explicitNull := tsCol("c") // non-first, explicit NULL → nullable
+	explicitNull.NullExplicit = true
+	tbl := tsTable(a, bare, explicitNull)
+
+	if !n.CanonicalNotNull(tbl, bare) {
+		t.Fatal("EDFT=0: a non-first bare TIMESTAMP must be NOT NULL")
+	}
+	if n.CanonicalNotNull(tbl, explicitNull) {
+		t.Fatal("EDFT=0: an explicit `TIMESTAMP NULL` must stay nullable")
+	}
+}
+
+func TestCanonicalTimestamp_EDFTOff_FirstWithPrecisionGetsPreciseDefault(t *testing.T) {
+	// First TIMESTAMP(3) under EDFT=0 → DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE
+	// CURRENT_TIMESTAMP(3), matching the column's fractional precision.
+	n := &Normalizer{Version: MySQL57, ExplicitDefaultsForTimestamp: false}
+	a := &Column{Name: "a", DataType: "timestamp", ColumnType: "timestamp(3)", Nullable: true}
+	tbl := tsTable(a)
+	def, onUpdate := n.CanonicalTimestampDefaults(tbl, a)
+	if def != "ts:CURRENT_TIMESTAMP(3)" || onUpdate != "ts:CURRENT_TIMESTAMP(3)" {
+		t.Fatalf("TIMESTAMP(3) first column must inject CURRENT_TIMESTAMP(3); got def=%q onUpdate=%q", def, onUpdate)
 	}
 }
 
@@ -551,11 +568,13 @@ func TestIgnoreInDiff_RowFormatDefault(t *testing.T) {
 // Comments — content comparison, decoded. (entry comment-escaping)
 // ---------------------------------------------------------------------------
 
-func TestCanonicalComment_DecodedContent(t *testing.T) {
+func TestCanonicalComment_ContentIsAlreadyDecoded(t *testing.T) {
 	n := NormalizerFor(MySQL80)
-	// Embedded doubled single-quote decodes to a single quote; compare content.
-	if n.CanonicalComment("has ''quote'' inside") != n.CanonicalComment("has 'quote' inside") {
-		t.Fatal("comment comparison must be on decoded content")
+	// The loader stores DECODED comment content. The canonicalizer must NOT re-decode:
+	// a genuine content of `a''b` (from DDL COMMENT 'a''''b') must stay distinct from a
+	// content of `a'b` (from DDL COMMENT 'a''b').
+	if n.CanonicalComment("a''b") == n.CanonicalComment("a'b") {
+		t.Fatal("distinct decoded comments `a''b` and `a'b` must not collapse")
 	}
 	if n.CanonicalComment("") != "" {
 		t.Fatal("empty comment must yield empty key")
@@ -702,5 +721,84 @@ func TestIdempotence_CharsetCollation(t *testing.T) {
 		if cs != cs2 || coll != coll2 {
 			t.Errorf("[%v] charset/collation resolution not idempotent: (%q,%q) -> (%q,%q)", v, cs, coll, cs2, coll2)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for review findings (correctness fixes).
+// ---------------------------------------------------------------------------
+
+func TestCanonicalDefault_LargeBigintPrecisionPreserved(t *testing.T) {
+	// Numeric defaults must compare by full-precision decimal string, never float64,
+	// or large BIGINT values beyond 2^53 collide (a missed diff).
+	n := NormalizerFor(MySQL80)
+	a := defCol("bigint", sp("9223372036854775806"), ColumnDefaultConstant)
+	b := defCol("bigint", sp("9223372036854775807"), ColumnDefaultConstant)
+	if n.CanonicalDefault(a) == n.CanonicalDefault(b) {
+		t.Fatalf("distinct large bigint defaults must differ: %q vs %q", n.CanonicalDefault(a), n.CanonicalDefault(b))
+	}
+	// Quote-insensitivity and value-equality must still hold at full precision.
+	c := defCol("bigint", sp("'9223372036854775807'"), ColumnDefaultConstant)
+	if n.CanonicalDefault(b) != n.CanonicalDefault(c) {
+		t.Fatal("quoted and unquoted large bigint default must be equal")
+	}
+	// Negative and negative-zero handling.
+	if n.CanonicalDefault(defCol("int", sp("-0"), ColumnDefaultConstant)) !=
+		n.CanonicalDefault(defCol("int", sp("0"), ColumnDefaultConstant)) {
+		t.Fatal("-0 and 0 must be equal")
+	}
+	if n.CanonicalDefault(defCol("int", sp("-5"), ColumnDefaultConstant)) ==
+		n.CanonicalDefault(defCol("int", sp("5"), ColumnDefaultConstant)) {
+		t.Fatal("-5 and 5 must differ")
+	}
+}
+
+func TestCanonicalGeneratedExpr_TokenBoundaryPreserved(t *testing.T) {
+	// Whitespace must collapse to a single space between word tokens, not vanish, so
+	// `a` and `b` (an AND expression) does not merge into the identifier `aandb`.
+	n := NormalizerFor(MySQL80)
+	if n.CanonicalGeneratedExpr("`a` and `b`") == n.CanonicalGeneratedExpr("`aandb`") {
+		t.Fatal("`a` and `b` must not collapse to aandb")
+	}
+	// But spacing variants of the same expression are still equal.
+	if n.CanonicalGeneratedExpr("`a`  and  `b`") != n.CanonicalGeneratedExpr("`a` and `b`") {
+		t.Fatal("spacing variants of the same AND expression must be equal")
+	}
+}
+
+func TestExpressionTokenizers_NoPanicOnMalformedInput(t *testing.T) {
+	// The hand-written tokenizers must never panic on malformed/truncated input
+	// (unterminated quotes, backslash escapes, missing parens, unterminated backticks).
+	n := NormalizerFor(MySQL80)
+	inputs := []string{
+		"concat(`a`,'x",  // unterminated string
+		`concat(a,'\'')`, // backslash-escaped quote
+		"_latin1'x",      // introducer + unterminated literal
+		"`unterminated",  // unterminated backtick
+		"'",              // lone quote
+		"",               // empty
+		"((((",           // unbalanced parens
+	}
+	for _, in := range inputs {
+		_ = n.CanonicalGeneratedExpr(in) // must not panic
+	}
+	// parseColumnType on malformed types must not panic.
+	for _, in := range []string{"int(", "int(11", "a)b(c", "varchar(", "(", ")", "decimal(10,"} {
+		_ = n.CanonicalColumnType(col("x", in)) // must not panic
+	}
+}
+
+func TestCanonicalColumn_NoKeyInjectionViaComment(t *testing.T) {
+	// A column whose comment contains the field-delimiter syntax must not collide with a
+	// genuinely different column (length-delimited field encoding prevents injection).
+	tbl := &Table{Name: "t", Charset: "utf8mb4", Collation: "utf8mb4_0900_ai_ci"}
+	n := NormalizerFor(MySQL80)
+
+	withComment := &Column{Name: "a", DataType: "int", ColumnType: "int", Nullable: true,
+		Comment: "x|gen:3:a+1|stored:5:false|"}
+	gen := &Column{Name: "a", DataType: "int", ColumnType: "int", Nullable: true,
+		Comment: "x", Generated: &GeneratedColumnInfo{Expr: "a+1", Stored: false}}
+	if n.CanonicalColumn(tbl, withComment) == n.CanonicalColumn(tbl, gen) {
+		t.Fatal("a comment mimicking field syntax must not collide with a generated column")
 	}
 }

--- a/mysql/catalog/table.go
+++ b/mysql/catalog/table.go
@@ -74,17 +74,32 @@ type SubPartitionDefInfo struct {
 }
 
 type Column struct {
-	Position                     int
-	Name                         string
-	DataType                     string // normalized (int, varchar, etc.)
-	ColumnType                   string // full type string (varchar(100), int unsigned)
-	Nullable                     bool
-	Default                      *string
-	DefaultKind                  ColumnDefaultKind
-	DefaultDropped               bool // true when ALTER COLUMN DROP DEFAULT was used
-	AutoIncrement                bool
-	Charset                      string
-	Collation                    string
+	Position   int
+	Name       string
+	DataType   string // normalized (int, varchar, etc.)
+	ColumnType string // full type string (varchar(100), int unsigned)
+	Nullable   bool
+	// NullExplicit records whether the user wrote an explicit NULL or NOT NULL clause on
+	// the column. The diff-time canonicalizer needs it to apply MySQL's
+	// explicit_defaults_for_timestamp=OFF rule, which forces a TIMESTAMP to NOT NULL
+	// only when the column has NO explicit nullability clause — a bare `TIMESTAMP` and an
+	// explicit `TIMESTAMP NULL` are otherwise indistinguishable once loaded.
+	NullExplicit   bool
+	Default        *string
+	DefaultKind    ColumnDefaultKind
+	DefaultDropped bool // true when ALTER COLUMN DROP DEFAULT was used
+	AutoIncrement  bool
+	Charset        string
+	Collation      string
+	// CharsetExplicit / CollationExplicit record whether the user wrote a column-level
+	// CHARACTER SET / COLLATE clause, as opposed to the value being inherited from the
+	// table at load time. The diff-time canonicalizer (normalize.go) needs this to
+	// resolve the version-correct effective collation: a bare column inherits the
+	// table's collation, a CHARACTER-SET-only column resolves to the charset default,
+	// and an explicit COLLATE is honored verbatim — three cases that are otherwise
+	// indistinguishable once the loader fills Charset/Collation from inheritance.
+	CharsetExplicit              bool
+	CollationExplicit            bool
 	Comment                      string
 	OnUpdate                     string
 	OnUpdateKind                 ColumnDefaultKind

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -199,9 +199,11 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			}
 			if colDef.TypeName.Charset != "" {
 				col.Charset = normalizeCharsetName(colDef.TypeName.Charset)
+				col.CharsetExplicit = true
 			}
 			if colDef.TypeName.Collate != "" {
 				col.Collation = colDef.TypeName.Collate
+				col.CollationExplicit = true
 				if col.Charset == "" {
 					col.Charset = normalizeCharsetName(charsetForCollation(col.Collation))
 				}
@@ -268,8 +270,10 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			switch cc.Type {
 			case nodes.ColConstrNotNull:
 				col.Nullable = false
+				col.NullExplicit = true
 			case nodes.ColConstrNull:
 				col.Nullable = true
+				col.NullExplicit = true
 			case nodes.ColConstrDefault:
 				if cc.Expr != nil {
 					setColumnDefaultFromExpr(col, cc.Expr)

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1917,7 +1917,12 @@ func formatColumnType(dt *nodes.DataType) string {
 		} else if dt.Zerofill {
 			width := dt.Length
 			if width == 0 {
-				width = defaultIntDisplayWidth(name, dt.Unsigned)
+				// ZEROFILL forces the column UNSIGNED, so a bare INT ZEROFILL takes the
+				// UNSIGNED default width (int → 10), not the signed default (11). MySQL
+				// stores `int(10) unsigned zerofill` for `INT ZEROFILL`. (Passing
+				// dt.Unsigned here was a bug: the zerofill-implies-unsigned promotion has
+				// not yet flipped dt.Unsigned at this point.)
+				width = defaultIntDisplayWidth(name, true)
 			}
 			fmt.Fprintf(&buf, "(%d)", width)
 		}


### PR DESCRIPTION
## What

Adds **`mysql/catalog/normalize.go`** — the single owner of MySQL's **diff-time canonical (stored) form** for declarative-schema (SDL) migration. A declarative diff compares the user's target schema against the synced (`SHOW CREATE`) schema; MySQL implicitly rewrites DDL on storage, so unless both sides are reduced to the same canonical form first, every rewrite produces a phantom diff forever. This module reduces both sides to one comparison key. The next node (**diff-core**) consumes this API where it compares columns/types/defaults/charset/table-options.

Spec: [`docs/migration/mysql/sdl/normalization.md`](docs/migration/mysql/sdl/normalization.md) — 28 entries, each an oracle `SHOW CREATE` readback from live MySQL 5.7.25 / 8.0.32.

## Rule classes implemented (all 28 entries)

- **canonicalize-on-load (17):** integer width / BOOLEAN→`tinyint(1)` / decimal padding / float aliasing / char-binary length / bit / year / enum-set quoting / value-based defaults / decimal default rounding / boolean default / nullable-default-null / pk-implies-not-null / generated-expr normalization / comment content / current_timestamp synonyms / column-key order.
- **ignore-in-diff (2):** table `AUTO_INCREMENT=N` counter, default `ROW_FORMAT`.
- **version-flagged (9):** int display width (8.0 drops / 5.7 injects), `utf8`↔`utf8mb3` spelling, `utf8mb4` default collation (`utf8mb4_0900_ai_ci` 8.0 vs `utf8mb4_general_ci` 5.7), `YEAR(4)`, descending index direction, the 8.0 `_latin1` expression introducer, functional `DEFAULT (expr)` (8.0-only), CHECK kept-vs-dropped, the charset echo asymmetry.

## Resolved-pair charset approach (highest-risk rule)

`ResolveColumnCharsetCollation(table, col)` resolves each column's **effective `(charset, collation)` pair** on both sides and compares the resolved pair, never the surface `CHARACTER SET`/`COLLATE` tokens (which phantom-diff across versions: 5.7 strips a column's charset when it equals the table's, 8.0 keeps it as a full pair). To distinguish a bare column, a `CHARACTER SET`-only column (resolves collation from the **charset default**, not the table COLLATE), and an explicit `COLLATE` — which the loader otherwise collapses by filling from inheritance — three explicit-clause flags (`CharsetExplicit` / `CollationExplicit` / `NullExplicit`) were added to `catalog.Column` and set by the loader. Charsets are folded to a version-independent identity (`utf8`≡`utf8mb3`) so the pair compares equal regardless of which version's spelling each side carried.

## Version branching (5.7 vs 8.0)

The `Normalizer` takes the engine `Version` as input. 8.0 drops integer display widths (except `tinyint(1)`/zerofill), spells `utf8mb3`, defaults `utf8mb4_0900_ai_ci`, drops `YEAR(4)`, keeps descending indexes, injects the `_latin1` introducer, supports functional defaults and CHECK. 5.7 injects display widths, spells `utf8`, defaults `utf8mb4_general_ci`, keeps `year(4)`, ignores index direction, drops CHECK. **`explicit_defaults_for_timestamp` is a session/server variable, not a version trait** — it is a separate `Normalizer` field (seeded to each box's default but overridable), governing the TIMESTAMP NOT-NULL / implicit `CURRENT_TIMESTAMP` magic.

## Oracle evidence (correctness proof)

`normalize_oracle_test.go` applies each rule's `input_ddl` to **both live engines**, reads back `SHOW CREATE TABLE`, and asserts the phantom-diff-elimination property `canonical(userInput) == canonical(storedReadback)` for every rule, plus the dual `TestOracle_MissedDiffGuards` (genuinely-different schemas produce different keys), plus idempotence `canonical(canonical(x)) == canonical(x)`. All pass against 5.7.25 and 8.0.32. (Tests skip cleanly when the engines are unreachable, so CI stays hermetic; point them at instances via `OMNI_MYSQL57_DSN` / `OMNI_MYSQL80_DSN`.)

Also fixes a pre-existing loader bug: bare `INT ZEROFILL` stored `int(11)` instead of `int(10)` (zerofill implies unsigned → unsigned default width).

## Review

Cross-family review (Claude `/code-review` + Codex `/codex:review`, blind, in parallel) over 3 fix rounds; converged to zero surviving blockers. Findings fixed include tokenizer panics on malformed input, full-precision numeric default comparison (string-decimal, not float64), value-based decimal rounding with carry, FLOAT/DOUBLE fraction preservation, expression token-boundary preservation, comment double-decode, and collision-free key encoding.

## Note

**diff-core consumes this API** (`CanonicalColumn` is the primary entry point; per-aspect `Canonical*`/`Resolve*` methods are exposed for differs touching a single attribute). It is not yet wired into a production diff path — that is diff-core's node. The full SDL round-trip idempotence proof (`MetadataToSDL → DiffSDLMigration(self)`) lands once diff-core and the bytebase wiring exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
