### PR TITLE
feat(mysql/catalog): add diff-core SchemaDiff + table/column differ (mysql SDL)

### DIFF
--- a/mysql/catalog/diff.go
+++ b/mysql/catalog/diff.go
@@ -1,0 +1,263 @@
+package catalog
+
+// MySQL declarative-schema (SDL) diff engine — tables + columns.
+//
+// This is the MySQL analog of the PostgreSQL reference at pg/catalog/diff.go. It
+// compares two in-memory catalogs (a desired TARGET against the synced CURRENT
+// schema read back via SHOW CREATE TABLE) and reports the structural differences as
+// a SchemaDiff. generate-core turns a SchemaDiff into DDL; the defining correctness
+// property is idempotence: when target == current, Diff is empty (IsEmpty), so the
+// release emits no DDL.
+//
+// Shape note (vs PG): PostgreSQL is OID/namespace-keyed and threads relOID/SchemaName
+// through every differ. MySQL has no OIDs and no schema/namespace layer — "schema" IS
+// the database — so identity here is (database, table, column) by lower-cased name.
+// The PG *shape* transfers (a thin top-level Diff dispatcher calling one diffX per
+// object kind, packing the results into SchemaDiff), but the plumbing is re-expressed
+// in database.table terms.
+//
+// Every canonicalization-sensitive comparison is routed through normalize.go (the
+// single owner of MySQL's stored-form canonical key). Column equality is decided by
+// Normalizer.CanonicalColumn; table-level engine/charset/collation comparisons go
+// through CanonicalEngine / foldCharset / effectiveTableCollation. The table-level
+// AUTO_INCREMENT=N counter is never compared (IgnoreTableAutoIncrement is constant true);
+// ROW_FORMAT is compared only when normalize.go's IgnoreRowFormat says it is significant.
+// diff-core never re-implements canonicalization.
+//
+// Scope of THIS node (omni:diff-core): the dispatcher, the SchemaDiff aggregate, the
+// table differ (diff_table.go), and the column differ (diff_column.go). The breadth
+// object kinds (indexes, foreign keys, constraints, checks, views, triggers, routines,
+// events, partitions) have their extension points wired here — empty diff sections and
+// per-kind seams — but are populated by later nodes, mirroring PG's diff_<obj>.go layout.
+
+// DiffAction describes what happened to an object between two catalog states.
+type DiffAction int
+
+const (
+	// DiffAdd means the object exists in `to` but not in `from`.
+	DiffAdd DiffAction = iota + 1
+	// DiffDrop means the object exists in `from` but not in `to`.
+	DiffDrop
+	// DiffModify means the object exists in both but has changed.
+	DiffModify
+)
+
+// String renders a DiffAction for diagnostics.
+func (a DiffAction) String() string {
+	switch a {
+	case DiffAdd:
+		return "ADD"
+	case DiffDrop:
+		return "DROP"
+	case DiffModify:
+		return "MODIFY"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-object diff entry types
+// ---------------------------------------------------------------------------
+
+// TableDiffEntry describes a table that was added, dropped, or modified. It is the
+// MySQL analog of PG's RelationDiffEntry: it carries the per-table sub-object diffs.
+// Columns is populated by this node (diff-core). Indexes / Constraints / ForeignKeys
+// / Checks / PartitionChanged are extension points for the breadth nodes — they are
+// always present (empty) so generate-core and the breadth differs can append into a
+// stable shape without a struct change.
+type TableDiffEntry struct {
+	Action   DiffAction
+	Database string
+	Name     string
+	From     *Table
+	To       *Table
+
+	// Populated by diff-core.
+	Columns []ColumnDiffEntry
+
+	// Extension points for breadth nodes (left empty by diff-core). A modified table
+	// is reported whenever ANY of these is non-empty, so wiring them here means a
+	// breadth node only has to fill its own slice — compareTable already folds them
+	// into the change decision via tableSubdiffsChanged.
+	Indexes          []IndexDiffEntry
+	Constraints      []ConstraintDiffEntry
+	ForeignKeys      []ForeignKeyDiffEntry
+	Checks           []CheckDiffEntry
+	PartitionChanged bool
+}
+
+// ColumnDiffEntry describes a column change within a table. Identity is the column
+// name (lower-cased); equality is decided by the normalize-core CanonicalColumn key.
+type ColumnDiffEntry struct {
+	Action DiffAction
+	Name   string
+	From   *Column
+	To     *Column
+}
+
+// IndexDiffEntry describes a secondary-index change within a table.
+// Extension point: populated by the index breadth node, not diff-core.
+type IndexDiffEntry struct {
+	Action DiffAction
+	Name   string
+	From   *Index
+	To     *Index
+}
+
+// ConstraintDiffEntry describes a PRIMARY KEY / UNIQUE constraint change.
+// Extension point: populated by a breadth node, not diff-core.
+type ConstraintDiffEntry struct {
+	Action DiffAction
+	Name   string
+	From   *Constraint
+	To     *Constraint
+}
+
+// ForeignKeyDiffEntry describes a foreign-key change within a table.
+// Extension point: populated by the FK breadth node, not diff-core.
+type ForeignKeyDiffEntry struct {
+	Action DiffAction
+	Name   string
+	From   *Constraint
+	To     *Constraint
+}
+
+// CheckDiffEntry describes a CHECK-constraint change within a table (8.0 only — on
+// 5.7 CHECK is unrepresentable; see normalize.go CheckSupported).
+// Extension point: populated by a breadth node, not diff-core.
+type CheckDiffEntry struct {
+	Action DiffAction
+	Name   string
+	From   *Constraint
+	To     *Constraint
+}
+
+// ViewDiffEntry describes a view change.
+// Extension point: populated by the view breadth node, not diff-core.
+type ViewDiffEntry struct {
+	Action   DiffAction
+	Database string
+	Name     string
+	From     *View
+	To       *View
+}
+
+// RoutineDiffEntry describes a stored function or procedure change.
+// Extension point: populated by the routine breadth node, not diff-core.
+type RoutineDiffEntry struct {
+	Action      DiffAction
+	Database    string
+	Name        string
+	IsProcedure bool
+	From        *Routine
+	To          *Routine
+}
+
+// TriggerDiffEntry describes a trigger change.
+// Extension point: populated by the trigger breadth node, not diff-core.
+type TriggerDiffEntry struct {
+	Action   DiffAction
+	Database string
+	Name     string
+	From     *Trigger
+	To       *Trigger
+}
+
+// EventDiffEntry describes a scheduled-event change.
+// Extension point: populated by the event breadth node, not diff-core.
+type EventDiffEntry struct {
+	Action   DiffAction
+	Database string
+	Name     string
+	From     *Event
+	To       *Event
+}
+
+// ---------------------------------------------------------------------------
+// SchemaDiff — aggregate result of comparing two catalogs
+// ---------------------------------------------------------------------------
+
+// SchemaDiff holds all differences between two catalog states. It is intentionally
+// extensible: diff-core populates Tables (and the per-table Columns inside each
+// entry); every other slice is an extension point a breadth node fills later. The
+// dispatcher (Diff) calls one diffX per object kind, so a breadth node adds its kind
+// by implementing diff_<obj>.go and appending here — no other node changes.
+type SchemaDiff struct {
+	// Populated by diff-core.
+	Tables []TableDiffEntry
+
+	// Extension points for breadth nodes (database-level objects).
+	Views      []ViewDiffEntry
+	Functions  []RoutineDiffEntry
+	Procedures []RoutineDiffEntry
+	Triggers   []TriggerDiffEntry
+	Events     []EventDiffEntry
+}
+
+// IsEmpty reports whether there are no differences. This is the idempotence gate read
+// by bytebase's DiffSDLMigration: an empty diff means the release emits no DDL. A
+// non-empty diff on a no-op release is a normalization bug, not a tolerable nit.
+func (d *SchemaDiff) IsEmpty() bool {
+	return len(d.Tables) == 0 &&
+		len(d.Views) == 0 &&
+		len(d.Functions) == 0 &&
+		len(d.Procedures) == 0 &&
+		len(d.Triggers) == 0 &&
+		len(d.Events) == 0
+}
+
+// ---------------------------------------------------------------------------
+// Top-level dispatcher
+// ---------------------------------------------------------------------------
+
+// Diff compares two catalog states (from = old/current, to = new/target) and returns
+// all differences, using the modern MySQL 8.0 canonical form by default. The
+// explicit_defaults_for_timestamp value is taken from the `to` catalog's session when
+// it carries one (the synced schema records the source server's effective setting),
+// so bare-TIMESTAMP nullability canonicalizes correctly without a version override.
+//
+// Diff is the contract entry point (pg/catalog/diff.go:210). Callers that know the
+// target server version — bytebase's mysqlDiffSDLMigration and the oracle tests, where
+// 5.7-vs-8.0 stored forms genuinely diverge — should use DiffWithNormalizer to select
+// the version whose stored form the canonicalizer must reproduce.
+func Diff(from, to *Catalog) *SchemaDiff {
+	return DiffWithNormalizer(from, to, defaultNormalizer(to))
+}
+
+// DiffWithNormalizer compares two catalogs using an explicit Normalizer, which fixes
+// the target MySQL version (and explicit_defaults_for_timestamp) whose stored form the
+// canonical comparison must reproduce. This is the version-aware workhorse; Diff
+// delegates to it with a default normalizer. A nil normalizer falls back to the
+// default for `to`.
+//
+// The dispatcher mirrors PG: one diffX per object kind, packed into SchemaDiff. Only
+// the table differ (which descends into columns) is implemented in diff-core; the
+// breadth slices are left nil for later nodes.
+func DiffWithNormalizer(from, to *Catalog, n *Normalizer) *SchemaDiff {
+	if n == nil {
+		n = defaultNormalizer(to)
+	}
+	return &SchemaDiff{
+		Tables: diffTables(from, to, n),
+		// Breadth extension points — populated by later nodes:
+		//   Views:      diffViews(from, to, n),
+		//   Functions:  diffFunctions(from, to, n),
+		//   Procedures: diffProcedures(from, to, n),
+		//   Triggers:   diffTriggers(from, to, n),
+		//   Events:     diffEvents(from, to, n),
+	}
+}
+
+// defaultNormalizer builds the Normalizer used by the parameterless Diff: MySQL 8.0
+// stored form, seeded from the `to` catalog's captured explicit_defaults_for_timestamp
+// when available. Using `to` (the target/desired schema, which on the release path is
+// re-loaded from the source's synced metadata) keeps the EDFT value aligned with the
+// server whose stored form we must match.
+func defaultNormalizer(to *Catalog) *Normalizer {
+	n := NormalizerFor(MySQL80)
+	if to != nil {
+		n.ExplicitDefaultsForTimestamp = to.session.ExplicitDefaultsForTimestamp
+	}
+	return n
+}

--- a/mysql/catalog/diff_column.go
+++ b/mysql/catalog/diff_column.go
@@ -1,0 +1,120 @@
+package catalog
+
+import "sort"
+
+// diffColumns compares the columns of two versions of a table (the MySQL analog of PG's
+// diffColumns at pg/catalog/diff_column.go:7). Identity is the column name (lower-cased)
+// within the table; equality is decided by the normalize-core CanonicalColumn aggregate
+// key, so a column whose surface form differs from its synced SHOW CREATE readback but
+// whose canonical form is identical produces NO phantom diff.
+//
+// Only DIFFABLE columns are compared — see diffableColumns. MySQL synthesizes columns
+// that never appear in user-authored SDL (the my_row_id generated invisible primary key
+// and the hidden expression columns that back functional indexes); including them would
+// manufacture a phantom column diff on every synced table that has a functional index or
+// GIPK. A user-declared INVISIBLE column is genuine schema and IS diffed; only
+// engine-synthesized columns are skipped.
+func diffColumns(from, to *Table, n *Normalizer) []ColumnDiffEntry {
+	fromCols := diffableColumns(from)
+	toCols := diffableColumns(to)
+
+	fromMap := make(map[string]*Column, len(fromCols))
+	for _, col := range fromCols {
+		fromMap[toLower(col.Name)] = col
+	}
+	toMap := make(map[string]*Column, len(toCols))
+	for _, col := range toCols {
+		toMap[toLower(col.Name)] = col
+	}
+
+	var result []ColumnDiffEntry
+
+	// Dropped: in from but not in to.
+	for name, fromCol := range fromMap {
+		if _, ok := toMap[name]; !ok {
+			result = append(result, ColumnDiffEntry{
+				Action: DiffDrop,
+				Name:   fromCol.Name,
+				From:   fromCol,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for name, toCol := range toMap {
+		fromCol, ok := fromMap[name]
+		if !ok {
+			result = append(result, ColumnDiffEntry{
+				Action: DiffAdd,
+				Name:   toCol.Name,
+				To:     toCol,
+			})
+			continue
+		}
+		if columnsChanged(from, to, fromCol, toCol, n) {
+			result = append(result, ColumnDiffEntry{
+				Action: DiffModify,
+				Name:   toCol.Name,
+				From:   fromCol,
+				To:     toCol,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if a, b := toLower(result[i].Name), toLower(result[j].Name); a != b {
+			return a < b
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// columnsChanged reports whether two same-name columns differ, comparing the
+// normalize-core CanonicalColumn key of each (the MySQL analog of PG's columnsChanged at
+// pg/catalog/diff_column.go:66, which compares FormatType). CanonicalColumn folds every
+// canonicalization-sensitive aspect into one collision-free key — type (with the
+// version's integer-display-width / BOOLEAN / decimal / year rules), the resolved
+// (charset, collation) pair, default and ON UPDATE (value-based, EDFT-aware), effective
+// nullability (PK-forced + TIMESTAMP magic), generated-column expression and storage,
+// AUTO_INCREMENT attribute, comment, invisibility, and SRID — so this differ never
+// re-implements any per-aspect comparison.
+//
+// Column position is intentionally NOT folded into the key: a pure reorder is not a
+// column-content change, and MySQL preserves declared order without reordering, so the
+// synced readback and a same-order target agree. (Re-positioning support, if generate-
+// core ever needs it, belongs in generate-core's ALTER ordering, not in column
+// identity.) `from`/`to` are passed for the table context CanonicalColumn needs to
+// resolve table-inherited charset/collation, PK membership, and the first-TIMESTAMP rule.
+func columnsChanged(fromTbl, toTbl *Table, a, b *Column, n *Normalizer) bool {
+	return n.CanonicalColumn(fromTbl, a) != n.CanonicalColumn(toTbl, b)
+}
+
+// diffableColumns returns the columns of a table that participate in a declarative diff:
+// the user-authored columns, excluding every column MySQL synthesizes on its own. Two
+// kinds of synthesized column must be dropped, and VisibleColumns() alone is NOT enough:
+//   - functional-index expression columns: marked Hidden == ColumnHiddenSystem, so
+//     VisibleColumns() already excludes them; and
+//   - the generated invisible primary key (my_row_id): marked GeneratedInvisiblePrimaryKey
+//     and Invisible, but left Hidden == ColumnHiddenNone, so VisibleColumns() WOULD return
+//     it. SHOW CREATE TABLE suppresses it via a separate check (show.go), and a synced
+//     dump taken with sql_generate_invisible_primary_key=ON carries it — so comparing it
+//     against a target that does not declare it produces a phantom DROP. We exclude it
+//     here explicitly.
+//
+// A user-declared INVISIBLE column (Invisible == true, Hidden == None,
+// GeneratedInvisiblePrimaryKey == false) is real schema and is kept.
+func diffableColumns(t *Table) []*Column {
+	cols := make([]*Column, 0, len(t.Columns))
+	for _, col := range t.Columns {
+		if col.Hidden != ColumnHiddenNone {
+			continue
+		}
+		if col.GeneratedInvisiblePrimaryKey {
+			continue
+		}
+		cols = append(cols, col)
+	}
+	return cols
+}

--- a/mysql/catalog/diff_oracle_test.go
+++ b/mysql/catalog/diff_oracle_test.go
@@ -1,0 +1,301 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for diff-core (correctness-protocol.md gates 1 & 2), against the
+// LIVE MySQL engines (5.7 and 8.0). Two properties are proven mechanically:
+//
+//  1. Idempotence (the spine): for a schema in its real stored form (the engine's own
+//     SHOW CREATE readback, loaded into a catalog), Diff(c, c).IsEmpty() — and, more
+//     strongly, Diff(userForm, storedForm).IsEmpty() where storedForm is the engine's
+//     readback of userForm. A non-empty self/round-trip diff is a normalization bug.
+//
+//  2. Canonicalization-driven empties: a schema written in a USER form (INT(11),
+//     BOOLEAN, implicit charset, DEFAULT 0, generated-col spacing, ...) diffed against
+//     the engine's STORED form of the same schema must be EMPTY. This is the proof that
+//     diff-core routes column equality through normalize-core's CanonicalColumn — if it
+//     compared surface tokens, these would phantom-diff forever.
+//
+// The harness reuses the connection + load helpers from normalize_oracle_test.go
+// (connectOracle, loadColumn's wrapping convention, serverCharsetFor). It skips cleanly
+// when the engines are unreachable, so the unit suite stays hermetic.
+
+// applyAndReadback applies a single CREATE TABLE in a throwaway database and returns the
+// SHOW CREATE TABLE readback (the engine's canonical stored form). It reuses oracleConn
+// from normalize_oracle_test.go.
+func (o *oracleConn) applyAndReadback(t *testing.T, dbName, createSQL, table string) (string, bool) {
+	t.Helper()
+	return o.showCreate(t, dbName, createSQL, table)
+}
+
+// loadOneTable loads a CREATE TABLE (wrapped in a database whose default charset matches
+// the oracle box, so table-charset inheritance resolves identically on both sides) and
+// returns the named table.
+func loadOneTable(t *testing.T, serverCharset, createSQL, table string) (*Catalog, *Table) {
+	t.Helper()
+	wrapped := fmt.Sprintf("CREATE DATABASE diffdb DEFAULT CHARSET=%s;\nUSE diffdb;\n%s", serverCharset, createSQL)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("LoadSQL failed for %q: %v", createSQL, err)
+	}
+	var tbl *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable(table); tt != nil {
+			tbl = tt
+			break
+		}
+	}
+	if tbl == nil {
+		t.Fatalf("table %q not found after load of %q", table, createSQL)
+	}
+	return cat, tbl
+}
+
+// assertDiffEmptyAgainstReadback applies userDDL to the engine, reads back the stored
+// form, loads BOTH the user form and the stored form, and asserts:
+//   - Diff(userCat, storedCat) is empty  (canonicalization-driven, gate 2)
+//   - Diff(storedCat, storedCat) is empty (idempotence spine, gate 1)
+//   - Diff(userCat, userCat) is empty     (user form self-consistency)
+//
+// all under a version-correct Normalizer.
+func assertDiffEmptyAgainstReadback(t *testing.T, o *oracleConn, dbName, userDDL, table string) {
+	t.Helper()
+	readback, ok := o.applyAndReadback(t, dbName, userDDL, table)
+	if !ok {
+		t.Skipf("[%s] could not obtain readback for %s", o.name, table)
+	}
+	sc := serverCharsetFor(o.version)
+	n := NormalizerFor(o.version)
+
+	userCat, _ := loadOneTable(t, sc, userDDL, table)
+	storedCat, _ := loadOneTable(t, sc, readback, table)
+
+	if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] IDEMPOTENCE: self-diff of stored form not empty for %s:\n  stored: %s\n  diff: %s",
+			o.name, table, strings.TrimSpace(readback), describeDiff(d))
+	}
+	if d := DiffWithNormalizer(userCat, userCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] self-diff of user form not empty for %s:\n  user: %s\n  diff: %s",
+			o.name, table, strings.TrimSpace(userDDL), describeDiff(d))
+	}
+	// The headline property: user form vs engine-stored form must collapse to empty.
+	if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] CANONICALIZATION: user form vs stored form not empty for %s:\n  user:   %s\n  stored: %s\n  diff: %s",
+			o.name, table, strings.TrimSpace(userDDL), strings.TrimSpace(readback), describeDiff(d))
+	}
+	// Symmetry: stored vs user must also be empty (Drop/Add are direction-sensitive).
+	if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] CANONICALIZATION (reverse): stored vs user not empty for %s:\n  diff: %s",
+			o.name, table, describeDiff(d))
+	}
+}
+
+// describeDiff renders a compact human description of a SchemaDiff for failure output.
+func describeDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, te := range d.Tables {
+		fmt.Fprintf(&b, "[table %s %s", te.Name, te.Action)
+		for _, ce := range te.Columns {
+			fmt.Fprintf(&b, " col(%s %s)", ce.Name, ce.Action)
+		}
+		b.WriteString("]")
+	}
+	return b.String()
+}
+
+// diffProbe is one (id, userDDL, table, versions) idempotence/canonicalization case.
+type diffProbe struct {
+	id       string
+	create   string
+	table    string
+	versions []Version
+}
+
+// diffIdempotenceProbes enumerates representative table/column FORMS that must round-trip
+// empty: user-form DDL whose engine-stored form differs but must canonicalize equal.
+// These exercise the high-risk normalization surfaces through the full diff path.
+func diffIdempotenceProbes() []diffProbe {
+	return []diffProbe{
+		// Integer display width: 8.0 drops, 5.7 injects default — must round-trip on both.
+		{"int-widths", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT(11), b BIGINT(20), c INT, p TINYINT, h INT UNSIGNED)", "t", both()},
+		// BOOLEAN/BOOL -> tinyint(1).
+		{"boolean", "CREATE TABLE t (id INT PRIMARY KEY, m BOOLEAN, n BOOL, d TINYINT(1))", "t", both()},
+		// decimal/float aliasing + default precision.
+		{"numeric", "CREATE TABLE t (id INT PRIMARY KEY, a DECIMAL, b DECIMAL(10,2), d NUMERIC, j REAL, f FLOAT)", "t", both()},
+		// char/binary/bit length-1, year width.
+		{"char-bit-year", "CREATE TABLE t (id INT PRIMARY KEY, a CHAR, d BINARY, c BIT, y YEAR)", "t", both()},
+		// literal default quoting (numeric + string), decimal scale padding, boolean default.
+		{"defaults", "CREATE TABLE t (id INT PRIMARY KEY, a INT DEFAULT 0, b INT DEFAULT '7', f DECIMAL(10,2) DEFAULT 0, c VARCHAR(20) DEFAULT 'x', j BOOLEAN DEFAULT TRUE)", "t", both()},
+		// nullability collapse to DEFAULT NULL; PK forces NOT NULL.
+		{"nullability", "CREATE TABLE t (id INT, a INT NULL, b INT DEFAULT NULL, d VARCHAR(10) NULL, PRIMARY KEY (id))", "t", both()},
+		// enum/set quoting + order.
+		{"enum-set", `CREATE TABLE t (id INT PRIMARY KEY, a ENUM('x','y','z'), b SET('a','b','c'), e ENUM("dq1","dq2"))`, "t", both()},
+		// generated column expression normalization.
+		{"generated", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a+1) VIRTUAL, c INT GENERATED ALWAYS AS ( a * 2 ) STORED, d INT AS (a+1))", "t", both()},
+		// implicit table charset/engine (no clause): must not phantom an ADD CHARSET/ENGINE.
+		{"implicit-table-opts", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10))", "t", both()},
+		// explicit table charset + column echo (version-flagged echo rules).
+		{"charset-echo", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10) CHARACTER SET utf8mb4, b VARCHAR(10)) DEFAULT CHARSET=utf8mb4", "t", both()},
+		// comment escaping.
+		{"comment", "CREATE TABLE t (id INT PRIMARY KEY, a INT COMMENT 'has ''quote'' inside') COMMENT='tbl ''c''", "t", both()},
+		// AUTO_INCREMENT column attribute (real schema) + table counter (ignored).
+		{"autoinc", "CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT) AUTO_INCREMENT=100", "t", both()},
+		// TIMESTAMP magic — opposite behavior across versions (EDFT box default).
+		{"timestamp", "CREATE TABLE t (id INT PRIMARY KEY, a TIMESTAMP, b TIMESTAMP NULL, d TIMESTAMP DEFAULT CURRENT_TIMESTAMP)", "t", both()},
+		{"datetime-default", "CREATE TABLE t (id INT PRIMARY KEY, g DATETIME DEFAULT CURRENT_TIMESTAMP, h DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)", "t", both()},
+		// functional / expression default — 8.0 only.
+		{"functional-default", "CREATE TABLE t (id INT PRIMARY KEY, a INT DEFAULT (1+1), b VARCHAR(36) DEFAULT (UUID()))", "t", only(MySQL80)},
+		// 8.0 expression string introducer (_latin1'x') inside a generated expr.
+		{"gen-introducer", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(20), e VARCHAR(20) GENERATED ALWAYS AS (CONCAT(a,'x')) VIRTUAL) DEFAULT CHARSET=utf8mb4", "t", only(MySQL80)},
+		// multi-column ordering preserved.
+		{"multi-column", "CREATE TABLE t (id INT NOT NULL, c1 VARCHAR(10), c2 INT DEFAULT 0, c3 DATE, c4 DECIMAL(8,3), PRIMARY KEY (id))", "t", both()},
+		// explicit ROW_FORMAT round-trips (SHOW CREATE echoes the declared option, so the
+		// user form and the readback both carry it → empty diff). Idempotence guard for the
+		// rowFormatChanged gate.
+		{"row-format-explicit", "CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8", "t", both()},
+	}
+}
+
+// TestOracle_DiffIdempotence proves gate 1 & 2 for every form: user DDL vs its engine
+// readback diffs EMPTY, and the stored form self-diffs empty, on every supported version.
+func TestOracle_DiffIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, probe := range diffIdempotenceProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := "diff_" + strings.ReplaceAll(probe.id, "-", "_")
+				assertDiffEmptyAgainstReadback(t, o, db, probe.create, probe.table)
+			})
+		}
+	}
+}
+
+// TestOracle_DiffMultiTableRoundTrip proves a multi-table schema (with cross-table FKs
+// and an index) loaded from its real engine readbacks self-diffs empty — the realistic
+// release-path idempotence check, not just single-table forms.
+func TestOracle_DiffMultiTableRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+		ctx := context.Background()
+
+		t.Run(o.name+"/two-tables-fk", func(t *testing.T) {
+			dbName := "diff_multi"
+			stmts := []string{
+				fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName),
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, sc),
+				fmt.Sprintf("USE %s", dbName),
+				"CREATE TABLE parent (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(50) NOT NULL)",
+				"CREATE TABLE child (id INT NOT NULL PRIMARY KEY, pid INT, amount DECIMAL(10,2) DEFAULT 0, KEY pid_idx (pid), CONSTRAINT fk_pid FOREIGN KEY (pid) REFERENCES parent (id))",
+			}
+			for _, s := range stmts {
+				if _, err := o.db.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup failed (may be expected): %q: %v", o.name, s, err)
+				}
+			}
+			// Read back both tables and reload as a single schema.
+			var b strings.Builder
+			fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, sc, dbName)
+			for _, tbl := range []string{"parent", "child"} {
+				var name, ddl string
+				row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", dbName, tbl))
+				if err := row.Scan(&name, &ddl); err != nil {
+					t.Fatalf("[%s] SHOW CREATE %s: %v", o.name, tbl, err)
+				}
+				b.WriteString(ddl)
+				b.WriteString(";\n")
+			}
+			cat, err := LoadSQL(b.String())
+			if err != nil {
+				t.Fatalf("[%s] reload of multi-table readback failed: %v\n%s", o.name, err, b.String())
+			}
+			if d := DiffWithNormalizer(cat, cat, n); !d.IsEmpty() {
+				t.Errorf("[%s] multi-table self-diff not empty: %s", o.name, describeDiff(d))
+			}
+		})
+	}
+}
+
+// TestOracle_DiffNonEmptyCorrect proves gate 3 against the live engine: representative
+// (from, to) pairs loaded from REAL engine readbacks produce the correct DiffAction.
+// (Apply-correctness — that the generated DDL transforms from into to — is generate-
+// core's gate; here we assert the SchemaDiff content is structurally right.)
+func TestOracle_DiffNonEmptyCorrect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+
+		// Each case: two DDLs applied to the engine; we diff their readbacks and assert.
+		cases := []struct {
+			name       string
+			fromDDL    string
+			toDDL      string
+			wantTable  string
+			wantTableA DiffAction
+			wantCol    string
+			wantColA   DiffAction
+		}{
+			{"add-column",
+				"CREATE TABLE t (id INT PRIMARY KEY)",
+				"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20))",
+				"t", DiffModify, "name", DiffAdd},
+			{"drop-column",
+				"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20))",
+				"CREATE TABLE t (id INT PRIMARY KEY)",
+				"t", DiffModify, "name", DiffDrop},
+			{"modify-type",
+				"CREATE TABLE t (id INT PRIMARY KEY, v INT)",
+				"CREATE TABLE t (id INT PRIMARY KEY, v BIGINT)",
+				"t", DiffModify, "v", DiffModify},
+			{"modify-default",
+				"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 0)",
+				"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 1)",
+				"t", DiffModify, "v", DiffModify},
+			{"modify-nullability",
+				"CREATE TABLE t (id INT PRIMARY KEY, v INT NULL)",
+				"CREATE TABLE t (id INT PRIMARY KEY, v INT NOT NULL)",
+				"t", DiffModify, "v", DiffModify},
+		}
+		for _, tc := range cases {
+			t.Run(o.name+"/"+tc.name, func(t *testing.T) {
+				rbFrom, ok1 := o.showCreate(t, "diff_nf", tc.fromDDL, tc.wantTable)
+				rbTo, ok2 := o.showCreate(t, "diff_nt", tc.toDDL, tc.wantTable)
+				if !ok1 || !ok2 {
+					t.Skipf("[%s] could not obtain readbacks", o.name)
+				}
+				fromCat, _ := loadOneTable(t, sc, rbFrom, tc.wantTable)
+				toCat, _ := loadOneTable(t, sc, rbTo, tc.wantTable)
+				d := DiffWithNormalizer(fromCat, toCat, n)
+				te := findTable(d, tc.wantTable)
+				if te == nil || te.Action != tc.wantTableA {
+					t.Fatalf("[%s] want table %s %s, got %s", o.name, tc.wantTable, tc.wantTableA, describeDiff(d))
+				}
+				ce := findColumn(te, tc.wantCol)
+				if ce == nil || ce.Action != tc.wantColA {
+					t.Fatalf("[%s] want col %s %s, got %s", o.name, tc.wantCol, tc.wantColA, describeDiff(d))
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/diff_table.go
+++ b/mysql/catalog/diff_table.go
@@ -1,0 +1,198 @@
+package catalog
+
+import (
+	"sort"
+	"strings"
+)
+
+// tableKey is the identity key for a table: (database, table) lower-cased. MySQL has
+// no schemas/namespaces, so the database is the qualifying scope.
+type tableKey struct {
+	db   string
+	name string
+}
+
+// diffTables compares base tables between two catalogs (the MySQL analog of PG's
+// diffRelations at pg/catalog/diff_table.go:13). It reports tables added (in `to`
+// only), dropped (in `from` only), and modified (present in both but differing in
+// table-level options or columns). Determinism: results are sorted by (database,
+// name, action) so the diff — and the DDL generate-core derives from it — is stable.
+func diffTables(from, to *Catalog, n *Normalizer) []TableDiffEntry {
+	fromMap := buildTableMap(from)
+	toMap := buildTableMap(to)
+
+	var result []TableDiffEntry
+
+	// Dropped: in from but not in to.
+	for key, fromTbl := range fromMap {
+		if _, ok := toMap[key]; !ok {
+			result = append(result, TableDiffEntry{
+				Action:   DiffDrop,
+				Database: key.db,
+				Name:     key.name,
+				From:     fromTbl,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for key, toTbl := range toMap {
+		fromTbl, ok := fromMap[key]
+		if !ok {
+			result = append(result, TableDiffEntry{
+				Action:   DiffAdd,
+				Database: key.db,
+				Name:     key.name,
+				To:       toTbl,
+			})
+			continue
+		}
+		if entry, changed := compareTable(key, fromTbl, toTbl, n); changed {
+			result = append(result, entry)
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Database != result[j].Database {
+			return result[i].Database < result[j].Database
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// buildTableMap indexes every base table in a catalog by (database, name). Temporary
+// tables are excluded: they are session-scoped and never part of a persisted schema
+// snapshot, so they must not appear in a declarative diff.
+func buildTableMap(c *Catalog) map[tableKey]*Table {
+	m := make(map[tableKey]*Table)
+	if c == nil {
+		return m
+	}
+	for _, db := range c.Databases() {
+		for name, tbl := range db.Tables {
+			// Guard a nil entry (defensive — the loader never stores nil) and skip
+			// temporary tables (session-scoped, never part of a persisted snapshot).
+			if tbl == nil || tbl.Temporary {
+				continue
+			}
+			m[tableKey{db: toLower(db.Name), name: name}] = tbl
+		}
+	}
+	return m
+}
+
+// compareTable reports whether two same-identity tables differ in table-level options
+// or sub-objects, returning a fully populated DiffModify entry when they do. It is the
+// MySQL analog of PG's compareRelation. Every option comparison that MySQL rewrites on
+// storage is routed through normalize.go. The column sub-diff is the dominant signal;
+// the breadth sub-object slices (Indexes/Constraints/ForeignKeys/Checks/PartitionChanged)
+// are empty in diff-core but are folded into the "is this table modified?" decision via
+// tableSubdiffsChanged, so a breadth node that populates one of them needs no change here.
+func compareTable(key tableKey, from, to *Table, n *Normalizer) (TableDiffEntry, bool) {
+	entry := TableDiffEntry{
+		Action:   DiffModify,
+		Database: key.db,
+		Name:     key.name,
+		From:     from,
+		To:       to,
+		Columns:  diffColumns(from, to, n),
+		// Indexes/Constraints/ForeignKeys/Checks/PartitionChanged: populated by breadth nodes.
+	}
+
+	if !tableOptionsChanged(from, to, n) && !tableSubdiffsChanged(&entry) {
+		return TableDiffEntry{}, false
+	}
+	return entry, true
+}
+
+// tableOptionsChanged compares the table-level attributes that survive into MySQL's
+// stored form, each through normalize-core:
+//   - storage engine, resolved to the server default (CanonicalEngine);
+//   - the effective (charset, collation) pair, folded to a version-independent identity
+//     so utf8/utf8mb3 and the version-divergent utf8mb4 default collation do not
+//     phantom-diff (foldCharset + effectiveTableCollation, the same helpers the column
+//     resolver uses);
+//   - the table COMMENT content (CanonicalComment);
+//   - ROW_FORMAT, but ONLY when normalize-core says it is significant: IgnoreRowFormat
+//     returns true for an empty/DEFAULT format (environment-dependent, not reconstructible
+//     from DDL) and false for an explicit non-default value — so a real DYNAMIC↔COMPRESSED
+//     change is detected while a phantom default↔unspecified change is not.
+//
+// AUTO_INCREMENT=N is a live next-value counter, never schema, so it is unconditionally
+// not compared (the constant-true IgnoreTableAutoIncrement documents that choice).
+func tableOptionsChanged(from, to *Table, n *Normalizer) bool {
+	if n.CanonicalEngine(from) != n.CanonicalEngine(to) {
+		return true
+	}
+	if foldCharset(from.Charset) != foldCharset(to.Charset) {
+		return true
+	}
+	if n.effectiveTableCollation(from) != n.effectiveTableCollation(to) {
+		return true
+	}
+	if n.CanonicalComment(from.Comment) != n.CanonicalComment(to.Comment) {
+		return true
+	}
+	if rowFormatChanged(from, to, n) {
+		return true
+	}
+	return false
+}
+
+// rowFormatChanged reports whether the table ROW_FORMAT differs in a way that matters.
+// ROW_FORMAT in both the target SDL and the synced SHOW CREATE readback is a DECLARED
+// option, not the table's physical row format: the oracle confirms SHOW CREATE echoes
+// ROW_FORMAT=X iff the user explicitly declared a non-DEFAULT value (a bare table, and a
+// ROW_FORMAT=DEFAULT table, both read back with NO clause; an explicit ROW_FORMAT=DYNAMIC
+// — even though DYNAMIC is the 8.0 physical default — IS echoed). So both sides are the
+// same kind of declared-option string and are compared directly.
+//
+// The ignore DECISION is owned by normalize-core's IgnoreRowFormat (empty / DEFAULT →
+// ignorable, mapped to "" here; an explicit non-default value is significant). The
+// comparison is then:
+//   - both ignorable → no diff;
+//   - otherwise compare the canonical values (ignorable normalized to "") — so an
+//     explicit COMPRESSED vs an unspecified/DEFAULT side IS a real change (the user is
+//     adding or removing a recorded create-option), while a bare side and a
+//     ROW_FORMAT=DEFAULT side still compare equal (both "").
+//
+// Normalizing ignorable → "" (NOT to a physical default like DYNAMIC) keeps the result
+// independent of innodb_default_row_format, the environment dependency flag
+// row-format-default-source warns about: a bare table never acquires a phantom format.
+// FLAG: if normalize-core grows a CanonicalRowFormat key, compare those instead — see PR.
+func rowFormatChanged(from, to *Table, n *Normalizer) bool {
+	if n.IgnoreRowFormat(from) && n.IgnoreRowFormat(to) {
+		return false
+	}
+	return !strings.EqualFold(canonicalRowFormat(from, n), canonicalRowFormat(to, n))
+}
+
+// canonicalRowFormat returns the table's declared ROW_FORMAT, or "" when normalize-core
+// deems it ignorable (empty / DEFAULT). The value match in rowFormatChanged is a plain
+// case-insensitive compare because ROW_FORMAT names (DYNAMIC, COMPRESSED, COMPACT,
+// REDUNDANT) have no aliasing or version rules.
+func canonicalRowFormat(t *Table, n *Normalizer) string {
+	if n.IgnoreRowFormat(t) {
+		return ""
+	}
+	return strings.TrimSpace(t.RowFormat)
+}
+
+// tableSubdiffsChanged reports whether any sub-object slice on a TableDiffEntry signals
+// a change: the column diff (populated by diff-core) or the breadth-owned
+// Indexes/Constraints/ForeignKeys/Checks slices or the PartitionChanged flag (populated
+// by later nodes). compareTable calls it so the "is this table modified?" decision lives
+// in one place — a breadth node that fills its slice needs no edit to compareTable.
+func tableSubdiffsChanged(e *TableDiffEntry) bool {
+	return len(e.Columns) > 0 ||
+		len(e.Indexes) > 0 ||
+		len(e.Constraints) > 0 ||
+		len(e.ForeignKeys) > 0 ||
+		len(e.Checks) > 0 ||
+		e.PartitionChanged
+}

--- a/mysql/catalog/diff_test.go
+++ b/mysql/catalog/diff_test.go
@@ -1,0 +1,444 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// In-process, hermetic structural tests for diff-core. They assert the SchemaDiff
+// content (right DiffAction per object) for representative table/column change forms,
+// loading both sides through the omni catalog (LoadSDL/LoadSQL) so the model state is
+// authentic. The oracle-backed idempotence + canonicalization-empty proofs live in
+// diff_oracle_test.go (correctness-protocol.md gate 1 & 2); these lock in gate 3 (the
+// non-empty diffs are structurally correct) and run without a live engine.
+
+// loadCat parses SDL into a catalog or fails the test.
+func loadCat(t *testing.T, sql string) *Catalog {
+	t.Helper()
+	c, err := LoadSDL(sql)
+	if err != nil {
+		t.Fatalf("LoadSDL failed for %q: %v", sql, err)
+	}
+	return c
+}
+
+// findTable locates a table entry in a SchemaDiff by name (lower-cased).
+func findTable(d *SchemaDiff, name string) *TableDiffEntry {
+	for i := range d.Tables {
+		if strings.EqualFold(d.Tables[i].Name, name) {
+			return &d.Tables[i]
+		}
+	}
+	return nil
+}
+
+// findColumn locates a column entry within a table diff by name (lower-cased).
+func findColumn(e *TableDiffEntry, name string) *ColumnDiffEntry {
+	if e == nil {
+		return nil
+	}
+	for i := range e.Columns {
+		if strings.EqualFold(e.Columns[i].Name, name) {
+			return &e.Columns[i]
+		}
+	}
+	return nil
+}
+
+const dbDDL = "CREATE DATABASE app DEFAULT CHARSET=utf8mb4;\nUSE app;\n"
+
+// ---- self-diff empty (the idempotence spine, in-process) -------------------
+
+func TestDiff_SelfEmpty(t *testing.T) {
+	schemas := []string{
+		dbDDL + "CREATE TABLE t (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id));",
+		dbDDL + "CREATE TABLE a (id INT NOT NULL PRIMARY KEY); CREATE TABLE b (a_id INT, v DECIMAL(10,2) DEFAULT 0);",
+		dbDDL + "CREATE TABLE g (a INT, b INT GENERATED ALWAYS AS (a+1) STORED, c VARCHAR(10) DEFAULT 'x');",
+		dbDDL + "CREATE TABLE ts (id INT PRIMARY KEY, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP, n INT DEFAULT 0);",
+	}
+	for _, s := range schemas {
+		c := loadCat(t, s)
+		for _, n := range []*Normalizer{NormalizerFor(MySQL80), NormalizerFor(MySQL57)} {
+			d := DiffWithNormalizer(c, c, n)
+			if !d.IsEmpty() {
+				t.Errorf("self-diff not empty (version=%d) for %q:\n%+v", n.Version, s, d.Tables)
+			}
+		}
+		// Parameterless Diff must also be empty.
+		if d := Diff(c, c); !d.IsEmpty() {
+			t.Errorf("parameterless self-diff not empty for %q:\n%+v", s, d.Tables)
+		}
+	}
+}
+
+func TestDiff_EmptyCatalogs(t *testing.T) {
+	if d := Diff(New(), New()); !d.IsEmpty() {
+		t.Errorf("two empty catalogs must diff empty, got %+v", d)
+	}
+}
+
+// ---- table-level change forms ----------------------------------------------
+
+func TestDiff_AddTable(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE a (id INT PRIMARY KEY);")
+	to := loadCat(t, dbDDL+"CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY);")
+	d := Diff(from, to)
+	if len(d.Tables) != 1 {
+		t.Fatalf("want 1 table diff, got %d: %+v", len(d.Tables), d.Tables)
+	}
+	e := findTable(d, "b")
+	if e == nil || e.Action != DiffAdd {
+		t.Fatalf("want ADD table b, got %+v", d.Tables)
+	}
+	if e.To == nil || e.From != nil {
+		t.Errorf("ADD entry must carry To and not From, got From=%v To=%v", e.From, e.To)
+	}
+}
+
+func TestDiff_DropTable(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY);")
+	to := loadCat(t, dbDDL+"CREATE TABLE a (id INT PRIMARY KEY);")
+	d := Diff(from, to)
+	e := findTable(d, "b")
+	if e == nil || e.Action != DiffDrop {
+		t.Fatalf("want DROP table b, got %+v", d.Tables)
+	}
+	if e.From == nil || e.To != nil {
+		t.Errorf("DROP entry must carry From and not To, got From=%v To=%v", e.From, e.To)
+	}
+}
+
+func TestDiff_TableEngineChange(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) ENGINE=InnoDB;")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) ENGINE=MyISAM;")
+	d := Diff(from, to)
+	e := findTable(d, "t")
+	if e == nil || e.Action != DiffModify {
+		t.Fatalf("want MODIFY table t on engine change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_TableCommentChange(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) COMMENT='old';")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) COMMENT='new';")
+	d := Diff(from, to)
+	if e := findTable(d, "t"); e == nil || e.Action != DiffModify {
+		t.Fatalf("want MODIFY table t on comment change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_TableCharsetChange(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=utf8mb4;")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=latin1;")
+	d := Diff(from, to)
+	if e := findTable(d, "t"); e == nil || e.Action != DiffModify {
+		t.Fatalf("want MODIFY table t on charset change, got %+v", d.Tables)
+	}
+}
+
+// AUTO_INCREMENT=N counter must be ignored (it is a live counter, not schema).
+func TestDiff_TableAutoIncrementCounterIgnored(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY) AUTO_INCREMENT=1;")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY) AUTO_INCREMENT=5000;")
+	if d := Diff(from, to); !d.IsEmpty() {
+		t.Errorf("AUTO_INCREMENT counter change must not diff, got %+v", d.Tables)
+	}
+}
+
+// A default ROW_FORMAT must not diff against an unspecified one.
+func TestDiff_RowFormatDefaultIgnored(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=DEFAULT;")
+	if d := Diff(from, to); !d.IsEmpty() {
+		t.Errorf("default ROW_FORMAT must not diff, got %+v", d.Tables)
+	}
+}
+
+// A genuine non-default ROW_FORMAT change MUST be detected. Regression for the review
+// finding that ROW_FORMAT was not compared at all. Oracle-grounded: SHOW CREATE echoes
+// ROW_FORMAT=X iff the user explicitly declared a non-DEFAULT value, so an explicit
+// format vs an unspecified side is a real declared-option change (the user adds/removes a
+// recorded create-option) — not an environment artifact.
+func TestDiff_RowFormatExplicitChange(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=COMPRESSED;")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=DYNAMIC;")
+	if e := findTable(d_(from, to), "t"); e == nil || e.Action != DiffModify {
+		t.Errorf("explicit ROW_FORMAT change (COMPRESSED->DYNAMIC) must diff, got %+v", d_(from, to).Tables)
+	}
+	// Explicit non-default format vs unspecified IS a real change (declared-option
+	// added/removed). The oracle confirms a bare table reads back with no ROW_FORMAT clause.
+	bare := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY);")
+	if e := findTable(d_(from, bare), "t"); e == nil || e.Action != DiffModify {
+		t.Errorf("explicit COMPRESSED vs unspecified must diff (declared option removed), got %+v", d_(from, bare).Tables)
+	}
+}
+
+// ROW_FORMAT=DEFAULT and an unspecified ROW_FORMAT must NOT diff: the oracle confirms
+// MySQL strips ROW_FORMAT=DEFAULT (a DEFAULT-declared table reads back with no clause), so
+// IgnoreRowFormat treats both as "" and they canonicalize equal. This is the idempotence
+// guard for the ignorable case.
+func TestDiff_RowFormatDefaultVsBareEmpty(t *testing.T) {
+	withDefault := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=DEFAULT;")
+	bare := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY);")
+	if d := Diff(withDefault, bare); !d.IsEmpty() {
+		t.Errorf("ROW_FORMAT=DEFAULT vs unspecified must not diff, got %+v", d.Tables)
+	}
+	if d := Diff(bare, withDefault); !d.IsEmpty() {
+		t.Errorf("unspecified vs ROW_FORMAT=DEFAULT must not diff (reverse), got %+v", d.Tables)
+	}
+}
+
+// d_ is a Diff shorthand for table-only assertions.
+func d_(from, to *Catalog) *SchemaDiff { return Diff(from, to) }
+
+// The generated invisible primary key (my_row_id) is engine-synthesized and must NEVER
+// produce a column diff. A schema synced with sql_generate_invisible_primary_key=ON
+// carries my_row_id; the same schema declared without it must diff EMPTY. Regression for
+// the review finding that VisibleColumns() leaks the GIPK (it is Invisible but not
+// Hidden).
+func TestDiff_GIPKExcluded(t *testing.T) {
+	withGIPK := loadCat(t, "SET sql_generate_invisible_primary_key=ON;\n"+dbDDL+"CREATE TABLE t (a INT, b VARCHAR(10));")
+	withoutGIPK := loadCat(t, dbDDL+"CREATE TABLE t (a INT, b VARCHAR(10));")
+
+	// Confirm the GIPK column actually exists on the synced side (else the test is moot).
+	var tbl *Table
+	for _, db := range withGIPK.Databases() {
+		if x := db.GetTable("t"); x != nil {
+			tbl = x
+		}
+	}
+	if tbl == nil {
+		t.Fatal("table t not found")
+	}
+	hasGIPK := false
+	for _, c := range tbl.Columns {
+		if c.GeneratedInvisiblePrimaryKey {
+			hasGIPK = true
+		}
+	}
+	if !hasGIPK {
+		t.Skip("GIPK not generated in this build; nothing to assert")
+	}
+
+	if d := Diff(withGIPK, withoutGIPK); !d.IsEmpty() {
+		t.Errorf("GIPK my_row_id must not produce a diff (synced ON vs declared without), got %+v", d.Tables)
+	}
+	if d := Diff(withoutGIPK, withGIPK); !d.IsEmpty() {
+		t.Errorf("GIPK my_row_id must not produce a diff (reverse direction), got %+v", d.Tables)
+	}
+	// Self-diff of the GIPK table must be empty too.
+	if d := Diff(withGIPK, withGIPK); !d.IsEmpty() {
+		t.Errorf("self-diff of a GIPK table must be empty, got %+v", d.Tables)
+	}
+}
+
+// A user-declared INVISIBLE column is REAL schema and must be diffed (added/dropped),
+// unlike the engine-synthesized GIPK. This guards against an over-broad exclusion.
+func TestDiff_UserInvisibleColumnDiffed(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, a INT);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, a INT, secret INT INVISIBLE);")
+	e := findTable(d_(from, to), "t")
+	c := findColumn(e, "secret")
+	if c == nil || c.Action != DiffAdd {
+		t.Fatalf("user-declared INVISIBLE column must be diffed as ADD, got %+v", e)
+	}
+}
+
+// ---- column-level change forms ---------------------------------------------
+
+func TestDiff_AddColumn(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20));")
+	d := Diff(from, to)
+	e := findTable(d, "t")
+	if e == nil || e.Action != DiffModify {
+		t.Fatalf("want MODIFY table t, got %+v", d.Tables)
+	}
+	c := findColumn(e, "name")
+	if c == nil || c.Action != DiffAdd {
+		t.Fatalf("want ADD column name, got %+v", e.Columns)
+	}
+	if c.To == nil || c.From != nil {
+		t.Errorf("ADD column must carry To not From, got From=%v To=%v", c.From, c.To)
+	}
+}
+
+func TestDiff_DropColumn(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20));")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY);")
+	d := Diff(from, to)
+	e := findTable(d, "t")
+	c := findColumn(e, "name")
+	if c == nil || c.Action != DiffDrop {
+		t.Fatalf("want DROP column name, got %+v", e.Columns)
+	}
+}
+
+func TestDiff_ModifyColumnType(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v BIGINT);")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "v")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column v (int->bigint), got %+v", d.Tables)
+	}
+}
+
+func TestDiff_ModifyColumnNullability(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT NULL);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT NOT NULL);")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "v")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column v on nullability change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_ModifyColumnDefault(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 0);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 1);")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "v")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column v on default change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_ModifyColumnCharset(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) CHARACTER SET utf8mb4);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) CHARACTER SET latin1);")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "v")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column v on charset change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_ModifyColumnComment(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT COMMENT 'a');")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT COMMENT 'b');")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "v")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column v on comment change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_ModifyGeneratedExpr(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (a INT, g INT GENERATED ALWAYS AS (a+1) STORED);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (a INT, g INT GENERATED ALWAYS AS (a+2) STORED);")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "g")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column g on generated-expr change, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_ModifyColumnAutoIncrementAttr(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT NOT NULL PRIMARY KEY);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY);")
+	d := Diff(from, to)
+	c := findColumn(findTable(d, "t"), "id")
+	if c == nil || c.Action != DiffModify {
+		t.Fatalf("want MODIFY column id on AUTO_INCREMENT attribute change, got %+v", d.Tables)
+	}
+}
+
+// ---- canonicalization-driven empties (in-process, no engine) ----------------
+// A schema written in a user form must diff EMPTY against the same schema written in
+// a form the engine would normalize to — proving column equality routes through
+// CanonicalColumn. (The authoritative version is the oracle test loading the real
+// SHOW CREATE; these are the fast, engine-free siblings.)
+
+func TestDiff_CanonicalEmpty_BooleanVsTinyint1(t *testing.T) {
+	// BOOLEAN canonicalizes to tinyint(1) on both versions.
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, flag BOOLEAN);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, flag TINYINT(1));")
+	for _, n := range []*Normalizer{NormalizerFor(MySQL80), NormalizerFor(MySQL57)} {
+		if d := DiffWithNormalizer(from, to, n); !d.IsEmpty() {
+			t.Errorf("BOOLEAN vs tinyint(1) must be empty (version=%d), got %+v", n.Version, d.Tables)
+		}
+	}
+}
+
+func TestDiff_CanonicalEmpty_NumericDefaultQuoting(t *testing.T) {
+	// DEFAULT 0 and DEFAULT '0' are value-equal.
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 0);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT '0');")
+	if d := Diff(from, to); !d.IsEmpty() {
+		t.Errorf("DEFAULT 0 vs DEFAULT '0' must be empty, got %+v", d.Tables)
+	}
+}
+
+func TestDiff_CanonicalEmpty_IntDisplayWidth80(t *testing.T) {
+	// On 8.0, INT(11) and INT collapse to the same canonical type.
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT(11));")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT);")
+	if d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80)); !d.IsEmpty() {
+		t.Errorf("INT(11) vs INT must be empty on 8.0, got %+v", d.Tables)
+	}
+}
+
+// FLAG (normalize-core / loader): on 5.7, a NON-DEFAULT integer display width such as
+// INT(5) is invisible to the diff. The shared omni loader (formatColumnType in
+// tablecmds.go) bakes MySQL 8.0's width-less stored form into Column.ColumnType at load
+// time — it strips non-zerofill int display widths unconditionally — so INT(5) and INT
+// both load as ColumnType="int" before normalize-core sees them. normalize-core's
+// CanonicalColumnType then re-injects 5.7's *default* width (int(11)) for both, so they
+// compare equal. This is NOT a diff-core defect: diff-core routes type comparison
+// through CanonicalColumn correctly; the width is discarded upstream in the loader.
+//
+// Idempotence is unaffected (the release path runs target and current through the same
+// loader, so both collapse to int identically — no phantom diff). The only loss is
+// detecting a width-ONLY change on 5.7, where display width is cosmetic. To distinguish
+// non-default int widths on 5.7, the loader must preserve the user width and
+// CanonicalColumnType must honor it — owned by normalize-core/loader, flagged not patched.
+//
+// This test pins the CURRENT diff-core contract: a default-width int change is a no-op
+// on 5.7. A genuine type change (int -> bigint) is still detected on 5.7.
+func TestDiff_IntDisplayWidth57_LoaderNormalizesAway(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT(5));")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v INT(11));")
+	if d := DiffWithNormalizer(from, to, NormalizerFor(MySQL57)); !d.IsEmpty() {
+		t.Errorf("loader strips int width: INT(5) vs INT(11) currently collapse on 5.7; got %+v", d.Tables)
+	}
+	// But a real base-type change is detected on 5.7.
+	to2 := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v BIGINT);")
+	if d := DiffWithNormalizer(from, to2, NormalizerFor(MySQL57)); d.IsEmpty() {
+		t.Errorf("INT vs BIGINT must diff on 5.7")
+	}
+}
+
+func TestDiff_CanonicalEmpty_DecimalAlias(t *testing.T) {
+	// NUMERIC -> decimal, default precision/scale filled.
+	from := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v NUMERIC);")
+	to := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, v DECIMAL(10,0));")
+	if d := Diff(from, to); !d.IsEmpty() {
+		t.Errorf("NUMERIC vs DECIMAL(10,0) must be empty, got %+v", d.Tables)
+	}
+}
+
+// ---- hidden / system columns are not diffed --------------------------------
+
+// A functional index creates a hidden system column on the synced side; it must not
+// manufacture a phantom column diff against a target that declares only the index.
+func TestDiff_FunctionalIndexHiddenColumnIgnored(t *testing.T) {
+	ddl := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(20), INDEX idx ((UPPER(a))));"
+	c := loadCat(t, ddl)
+	// Confirm the hidden column exists, so the test is meaningful.
+	var tbl *Table
+	for _, db := range c.Databases() {
+		if tt := db.GetTable("t"); tt != nil {
+			tbl = tt
+		}
+	}
+	if tbl == nil {
+		t.Fatal("table t not found")
+	}
+	if len(tbl.HiddenColumns()) == 0 {
+		t.Skip("functional index did not create a hidden column in this build; nothing to assert")
+	}
+	if d := Diff(c, c); !d.IsEmpty() {
+		t.Errorf("self-diff of a table with a functional-index hidden column must be empty, got %+v", d.Tables)
+	}
+}


### PR DESCRIPTION
## What

Adds the MySQL declarative-schema (SDL) **diff engine — tables + columns only** (`omni:diff-core`, P0 vertical slice). It compares two in-memory catalogs (a desired **target** against the synced **current** schema read back via `SHOW CREATE TABLE`) and reports the structural differences as a `SchemaDiff`. `generate-core` (next node) turns a `SchemaDiff` into DDL; `omni:generate-core` depends on the `SchemaDiff` shape defined here.

Contract: [`docs/migration/mysql/sdl/contract.md`](https://github.com/bytebase/omni/blob/main/docs/migration/mysql/sdl/contract.md) §1 (the `Diff` / `SchemaDiff` / `IsEmpty` / `diffRelations` / `diffColumns` rows + "Shape note for the MySQL port"). PostgreSQL (`pg/catalog/diff.go`) is the **spec for what each seam returns**, re-expressed in MySQL's **database-keyed identity** (`databases map[string]*Database`, no OIDs/namespaces — schema == database).

Scope is tables + columns only; the breadth object kinds (indexes, FKs, constraints, checks, views, routines, triggers, events, partitions) have their **extension points wired but unpopulated** for later nodes.

## API

| symbol | role |
|---|---|
| `Diff(from, to *Catalog) *SchemaDiff` | contract entry point; defaults to MySQL 8.0 canonical form, seeds `explicit_defaults_for_timestamp` from `to`'s session |
| `DiffWithNormalizer(from, to *Catalog, n *Normalizer) *SchemaDiff` | version-aware workhorse — the target version (5.7 vs 8.0) genuinely diverges in stored form, so the caller (bytebase `mysqlDiffSDLMigration`, oracle tests) selects it |
| `SchemaDiff` / `(*SchemaDiff).IsEmpty()` | aggregate + the idempotence gate read by `DiffSDLMigration` |
| `DiffAction` (`DiffAdd`/`DiffDrop`/`DiffModify`) | per-object action |

**`SchemaDiff` shape (extension points for breadth nodes):** `Tables []TableDiffEntry` is populated by diff-core; `Views`/`Functions`/`Procedures`/`Triggers`/`Events` are empty database-level sections for later nodes. Each `TableDiffEntry` carries `Columns []ColumnDiffEntry` (populated) plus empty per-table sub-object slices `Indexes`/`Constraints`/`ForeignKeys`/`Checks` + `PartitionChanged`. `compareTable` folds all sub-object slices into the "is this table modified?" decision via `tableSubdiffsChanged`, so a breadth node that fills its slice needs **no edit to `compareTable`** — it slots into the `diff_<obj>.go` layout mirroring PG.

## How column equality is decided (consume normalize-core, never duplicate it)

Column equality is the equality of the **`Normalizer.CanonicalColumn(table, col)` aggregate key** (the MySQL analog of PG's `columnsChanged` → `FormatType`). That single key folds type (version int-display-width / BOOLEAN / decimal / year rules), the resolved (charset, collation) pair, default + ON UPDATE (value-based, EDFT-aware), effective nullability (PK-forced + TIMESTAMP magic), generated-column expr + storage, AUTO_INCREMENT attribute, comment, invisibility, SRID. **Equal key ⇒ unchanged** — so a column whose surface form differs from its synced readback but whose canonical form is identical produces no phantom diff. Only **diffable** columns are compared (`diffableColumns` excludes engine-synthesized columns: functional-index system columns and the `my_row_id` GIPK); a user-declared `INVISIBLE` column is real schema and is diffed.

Table-level options route through normalize-core too: `CanonicalEngine`, `foldCharset` + `effectiveTableCollation`, `CanonicalComment`; `ROW_FORMAT` is compared only when `IgnoreRowFormat` deems it significant (ignorable normalized to `""`, not to a physical default, to stay independent of `innodb_default_row_format`); the `AUTO_INCREMENT=N` counter is never compared. **No canonicalization is re-implemented in diff-core.**

## Oracle idempotence evidence (proven against live MySQL 5.7.25 + 8.0.32)

`mysql/catalog/diff_oracle_test.go` applies each form to the **live engine**, reads back `SHOW CREATE TABLE`, loads both the user form and the stored form, and asserts (correctness-protocol gates 1 & 2):

- **Idempotence (the spine):** `Diff(storedForm, storedForm).IsEmpty()`, on both versions; plus a multi-table FK round-trip from real readbacks.
- **Canonicalization-driven empties:** `Diff(userForm, engineStoredForm).IsEmpty()` across the high-risk surfaces — int display widths (8.0 drop / 5.7 inject), `BOOLEAN`→`tinyint(1)`, decimal/float aliasing, char/binary/bit/year defaults, default literal quoting + scale padding, nullability collapse + PK-forces-NOT-NULL, ENUM/SET, generated-col expr normalization, implicit + explicit table charset/engine + column charset echo, comments, AUTO_INCREMENT, the `TIMESTAMP` `explicit_defaults_for_timestamp` magic (opposite across versions), functional/expression defaults (8.0), the 8.0 `_latin1` expression introducer, and explicit `ROW_FORMAT` round-trip.
- **Non-empty correctness (gate 3):** add/drop table, add/drop/modify column, type/nullability/default change — each asserts the right `DiffAction` per object (DDL-apply correctness is `generate-core`'s gate).

Hermetic in-process tests (`diff_test.go`) cover the same change forms without a live engine, including regression tests for the review findings below (GIPK exclusion, user-INVISIBLE diffed, explicit ROW_FORMAT change, DEFAULT-vs-bare empty). Run scoped: `go test ./mysql/catalog/...`.

## Cross-family review

Reviewed by Claude `/code-review` + Codex `/codex:review` (parallel, blind). Three blockers found and fixed: (1) GIPK `my_row_id` leaked through `VisibleColumns()` (it is `Invisible` but `Hidden==None`) → phantom column DROP — fixed with `diffableColumns`; (2) non-default `ROW_FORMAT` change was not compared — fixed and **adjudicated against the live oracle** (the reviewers disagreed; the oracle showed `SHOW CREATE` echoes `ROW_FORMAT` as a declared option, so explicit-vs-unspecified is a real change, while `ROW_FORMAT=DEFAULT` is stripped and equals bare); (3) defensive nil-`Table` guard in `buildTableMap`. No blockers survive.

## Flags for normalize-core (found, NOT patched here)

1. **Int display width is lost at load on 5.7.** The shared loader `formatColumnType` (`mysql/catalog/tablecmds.go`) bakes MySQL 8.0's width-less stored form into `Column.ColumnType` at load time — it strips non-zerofill integer display widths unconditionally — so `INT(5)` and `INT` both load as `int` before normalize-core sees them. On 5.7 this makes a **non-default** width change (e.g. `INT(5)`→`INT(11)`) invisible to the diff. Idempotence is unaffected (target and current run through the same loader). Owned by normalize-core/loader; flagged not patched (test `TestDiff_IntDisplayWidth57_LoaderNormalizesAway` pins the current behavior).
2. **No `CanonicalRowFormat` in normalize-core.** diff-core routes the ROW_FORMAT *ignore* decision through `IgnoreRowFormat` but does the surviving value compare inline (ROW_FORMAT names have no aliasing/version rules, so this is trivial, not a canonicalization bypass). If normalize-core later resolves the environment default into a `CanonicalRowFormat` key, diff-core should compare those instead.

## Not in this node

`GenerateMigration`/`MigrationPlan` (→ `omni:generate-core`), the breadth differs (indexes/FKs/constraints/views/triggers/routines/events/partitions), and any new normalization. **Apply-correctness + the full `MetadataToSDL → DiffSDLMigration` SDL round-trip land with `generate-core` and the bytebase wiring (gomod-bump + register-diff-sdl + sdlformat-dump).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)