### PR TITLE
feat(mysql/catalog): add generate-core MigrationPlan + table/column DDL (mysql SDL)

### DIFF
--- a/mysql/catalog/migration.go
+++ b/mysql/catalog/migration.go
@@ -1,0 +1,271 @@
+package catalog
+
+// MySQL declarative-schema (SDL) migration generator — tables + columns.
+//
+// This is the MySQL analog of the PostgreSQL reference at pg/catalog/migration.go. It
+// turns a SchemaDiff (produced by diff-core) into ordered MySQL DDL that transforms the
+// `from` (current/synced) catalog into the `to` (target/desired) catalog. The terminal
+// output, MigrationPlan.SQL(), is what bytebase's mysqlDiffSDLMigration returns to the
+// release executor.
+//
+// The defining correctness property is idempotence: when the diff is empty (target ==
+// current), GenerateMigration emits an EMPTY plan and SQL() == "". A non-empty no-op plan
+// is a bug — in ordering, rendering, or an upstream normalization gap — never a tolerable
+// nit (correctness-protocol.md).
+//
+// Shape note (vs PG): GenerateMigration mirrors PG's dispatcher — one generate<obj>DDL per
+// object kind, appended in dependency order, then sortMigrationOps. PG threads OIDs,
+// schema namespaces, and a catalog dep graph through its topo sort. MySQL has none of
+// that: identity is (database, table, column) by lower-cased name, and the table/column
+// subset this node owns has no cross-object dependency to topo-sort (FK ordering is the
+// FK breadth node's concern). So sortMigrationOps here is a deterministic phase + name
+// sort, not a graph sort — which is all the table/column subset needs and is REQUIRED for
+// idempotence/round-trip stability.
+//
+// Rendering principle: every column/type/option is rendered through normalize.go's
+// canonical forms (CanonicalColumnType, ResolveColumnCharsetCollation, CanonicalNotNull,
+// ...), NOT by re-stringifying the surface DDL. Because the emitted DDL IS the canonical
+// stored form for the target version, apply-correctness holds by construction: apply the
+// plan, read back SHOW CREATE, and the readback canonicalizes equal to `to`.
+//
+// Scope of THIS node (omni:generate-core): the MigrationPlan / MigrationOp types,
+// GenerateMigration dispatcher, table DDL (migration_table.go), column DDL
+// (migration_column.go), and sortMigrationOps. The breadth object kinds (indexes, FKs,
+// constraints, checks, views, triggers, routines, events, partitions) have wired-but-empty
+// generate hooks here, mirroring PG's migration_<obj>.go layout and the empty SchemaDiff
+// slices diff-core left — a breadth node fills its slice and its hook with no change here.
+
+import (
+	"sort"
+	"strings"
+)
+
+// MigrationPhase classifies when a DDL operation runs relative to others. For the
+// table/column subset only two phases are used: drops run before adds/alters so a dropped
+// table/column never collides with a re-created one of the same name. PhasePost is
+// reserved for the FK breadth node (deferred FK creation), mirroring PG.
+type MigrationPhase int
+
+const (
+	// PhasePre holds DROP operations (run first).
+	PhasePre MigrationPhase = iota
+	// PhaseMain holds CREATE + ALTER operations.
+	PhaseMain
+	// PhasePost holds deferred operations (FK constraints — breadth node).
+	PhasePost
+)
+
+// MigrationOpType classifies a single MySQL DDL operation. MySQL uses MODIFY/CHANGE for
+// column type/attribute changes (not PG's ALTER COLUMN ... TYPE), and folds index/PK/FK
+// changes into ALTER TABLE rather than standalone statements — so the op-type set diverges
+// from PG's. Only the table + column ops are emitted by this node; the rest are declared so
+// breadth nodes and the drop-advice walker have a stable key set.
+type MigrationOpType string
+
+const (
+	OpCreateTable     MigrationOpType = "CreateTable"
+	OpDropTable       MigrationOpType = "DropTable"
+	OpAlterTable      MigrationOpType = "AlterTable" // table-option change (ENGINE/CHARSET/...)
+	OpAddColumn       MigrationOpType = "AddColumn"
+	OpDropColumn      MigrationOpType = "DropColumn"
+	OpModifyColumn    MigrationOpType = "ModifyColumn" // MySQL MODIFY COLUMN (in-place redefine)
+	OpAddIndex        MigrationOpType = "AddIndex"     // breadth (index node)
+	OpDropIndex       MigrationOpType = "DropIndex"    // breadth
+	OpAddConstraint   MigrationOpType = "AddConstraint"
+	OpDropConstraint  MigrationOpType = "DropConstraint"
+	OpAddForeignKey   MigrationOpType = "AddForeignKey" // breadth (FK node)
+	OpDropForeignKey  MigrationOpType = "DropForeignKey"
+	OpAddCheck        MigrationOpType = "AddCheck" // breadth (check node)
+	OpDropCheck       MigrationOpType = "DropCheck"
+	OpCreateView      MigrationOpType = "CreateView" // breadth
+	OpDropView        MigrationOpType = "DropView"
+	OpCreateFunction  MigrationOpType = "CreateFunction" // breadth
+	OpDropFunction    MigrationOpType = "DropFunction"
+	OpCreateProcedure MigrationOpType = "CreateProcedure"
+	OpDropProcedure   MigrationOpType = "DropProcedure"
+	OpCreateTrigger   MigrationOpType = "CreateTrigger" // breadth
+	OpDropTrigger     MigrationOpType = "DropTrigger"
+	OpCreateEvent     MigrationOpType = "CreateEvent" // breadth
+	OpDropEvent       MigrationOpType = "DropEvent"
+)
+
+// MigrationOp represents a single DDL operation in a migration plan. ObjectName is the
+// table (or database-level object) name; Database is the qualifying scope (MySQL has no
+// schema namespace). ParentObject names the owning table for sub-object ops (a column op's
+// table) so the drop-advice walker can report "column x of table t". The ordering metadata
+// (Phase, Priority, sortName) drives sortMigrationOps deterministically.
+type MigrationOp struct {
+	Type         MigrationOpType
+	Database     string
+	ObjectName   string
+	SQL          string
+	Warning      string
+	ParentObject string // owning table for column/index/constraint ops; "" for table-level
+
+	// Ordering metadata (used by sortMigrationOps).
+	Phase    MigrationPhase
+	Priority int    // tie-breaker within a phase (lower = earlier)
+	sortName string // stable secondary key (table name, or table+column for column ops)
+}
+
+// Priority constants for tie-breaking within a phase. Lower runs earlier. For the
+// table/column subset the only ordering that matters is: a table's own CREATE/DROP versus
+// the column ALTERs on a surviving table. Breadth priorities are reserved so later nodes
+// slot in without renumbering.
+const (
+	priorityTable      = 10
+	priorityColumn     = 20
+	priorityIndex      = 30
+	priorityConstraint = 40
+	priorityView       = 50
+	priorityRoutine    = 60
+	priorityTrigger    = 70
+	priorityEvent      = 80
+	priorityForeignKey = 99 // FK deferred to PhasePost (breadth)
+)
+
+// MigrationPlan holds an ordered list of DDL operations that transform one catalog state
+// into another. It is the MySQL analog of PG's MigrationPlan (pg/catalog/migration.go:104).
+type MigrationPlan struct {
+	Ops []MigrationOp
+}
+
+// SQL returns all operations joined with ";\n" (matching PG's MigrationPlan.SQL at
+// pg/catalog/migration.go:109). An empty plan returns "" — the idempotence terminal: a
+// no-op release emits no DDL.
+func (p *MigrationPlan) SQL() string {
+	if len(p.Ops) == 0 {
+		return ""
+	}
+	parts := make([]string, len(p.Ops))
+	for i, op := range p.Ops {
+		parts[i] = op.SQL
+	}
+	return strings.Join(parts, ";\n")
+}
+
+// Filter returns a new MigrationPlan containing only operations for which fn returns true.
+// bytebase uses it to strip ops it does not want to apply (PG strips the archive schema;
+// pg/catalog/migration.go:163).
+func (p *MigrationPlan) Filter(fn func(MigrationOp) bool) *MigrationPlan {
+	var ops []MigrationOp
+	for _, op := range p.Ops {
+		if fn(op) {
+			ops = append(ops, op)
+		}
+	}
+	return &MigrationPlan{Ops: ops}
+}
+
+// HasWarnings reports whether any operation carries a non-empty warning.
+func (p *MigrationPlan) HasWarnings() bool {
+	for _, op := range p.Ops {
+		if op.Warning != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Warnings returns the operations that carry a non-empty warning.
+func (p *MigrationPlan) Warnings() []MigrationOp {
+	var result []MigrationOp
+	for _, op := range p.Ops {
+		if op.Warning != "" {
+			result = append(result, op)
+		}
+	}
+	return result
+}
+
+// GenerateMigration produces a MigrationPlan that transforms the `from` catalog into the
+// `to` catalog using the precomputed diff. It is the contract entry point
+// (pg/catalog/migration.go:196) and uses the modern MySQL 8.0 canonical form by default,
+// seeded — like Diff — with the `to` catalog's explicit_defaults_for_timestamp.
+//
+// Callers that know the target server version (bytebase's mysqlDiffSDLMigration, the oracle
+// apply tests where 5.7-vs-8.0 stored forms diverge) should use
+// GenerateMigrationWithNormalizer so the emitted DDL reproduces the version whose stored
+// form the readback will canonicalize against — the same Diff/DiffWithNormalizer split
+// diff-core established.
+func GenerateMigration(from, to *Catalog, diff *SchemaDiff) *MigrationPlan {
+	return GenerateMigrationWithNormalizer(from, to, diff, defaultNormalizer(to))
+}
+
+// GenerateMigrationWithNormalizer is the version-aware workhorse: the Normalizer fixes the
+// target MySQL version (and explicit_defaults_for_timestamp) whose stored form the rendered
+// DDL must reproduce, so apply-correctness holds on that engine. A nil normalizer falls
+// back to the default for `to`. GenerateMigration delegates here.
+//
+// The dispatcher mirrors PG: one generate<obj>DDL per kind, appended in dependency order,
+// then sortMigrationOps. Only the table generator (which descends into columns) is
+// implemented in generate-core; the breadth hooks are present but inert until their node
+// populates the matching SchemaDiff slice.
+func GenerateMigrationWithNormalizer(from, to *Catalog, diff *SchemaDiff, n *Normalizer) *MigrationPlan {
+	if diff == nil {
+		return &MigrationPlan{}
+	}
+	if n == nil {
+		n = defaultNormalizer(to)
+	}
+
+	var ops []MigrationOp
+
+	// Table + column DDL (this node). Order of appends does not matter — sortMigrationOps
+	// imposes the deterministic phase/name ordering.
+	ops = append(ops, generateTableDDL(from, to, diff, n)...)
+	ops = append(ops, generateColumnDDL(from, to, diff, n)...)
+
+	// Breadth extension points — inert until the owning node fills the SchemaDiff slice and
+	// implements the hook (mirroring PG's per-object generators and diff-core's empty slices):
+	//   ops = append(ops, generateIndexDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateConstraintDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateForeignKeyDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateCheckDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateViewDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateRoutineDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateTriggerDDL(from, to, diff, n)...)
+	//   ops = append(ops, generateEventDDL(from, to, diff, n)...)
+	//   ops = append(ops, generatePartitionDDL(from, to, diff, n)...)
+
+	ops = sortMigrationOps(ops)
+
+	return &MigrationPlan{Ops: ops}
+}
+
+// sortMigrationOps imposes a deterministic total order on the ops. Determinism is REQUIRED:
+// idempotence/round-trip stability depends on the same diff always producing byte-identical
+// DDL. The order is:
+//
+//  1. Phase: PhasePre (drops) before PhaseMain (creates/alters) before PhasePost (deferred FKs).
+//     Within drops, a child (column) drop precedes its parent (table) drop is NOT needed —
+//     DROP TABLE removes the whole table — but dropping a column on a SURVIVING table and
+//     dropping a whole table are independent; phase ordering keeps all drops ahead of all
+//     adds so a "drop table t / create table t" rename-in-place never reverses.
+//  2. Priority within a phase: a table create/drop (priorityTable) before column alters
+//     (priorityColumn) so CREATE TABLE precedes any ALTER ... ADD COLUMN referencing it
+//     (defensive; for the current scope a freshly-added table carries its columns inline).
+//  3. sortName lexicographic (database.table[.column]) for a stable tie-break.
+//  4. Original index as the final stable tie-break (sort.SliceStable) so multiple ALTERs on
+//     one column keep their emitted sequence (e.g. a MODIFY chain).
+//
+// This is the MySQL analog of PG's sortMigrationOps (pg/catalog/migration.go:699), reduced
+// to a phase+name sort because the table/column subset has no cross-object dep graph.
+func sortMigrationOps(ops []MigrationOp) []MigrationOp {
+	sorted := make([]MigrationOp, len(ops))
+	copy(sorted, ops)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		if a.Phase != b.Phase {
+			return a.Phase < b.Phase
+		}
+		if a.Priority != b.Priority {
+			return a.Priority < b.Priority
+		}
+		if a.sortName != b.sortName {
+			return a.sortName < b.sortName
+		}
+		return false // stable: preserve original order for equal keys
+	})
+	return sorted
+}

--- a/mysql/catalog/migration_column.go
+++ b/mysql/catalog/migration_column.go
@@ -1,0 +1,303 @@
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// generateColumnDDL produces ALTER TABLE ... ADD/DROP/MODIFY COLUMN operations for every
+// column change within modified tables. It is the MySQL analog of PG's generateColumnDDL
+// (pg/catalog/migration_column.go:12), but where PG decomposes a column change into a chain
+// of incremental ALTER COLUMN sub-statements (DROP DEFAULT → ALTER TYPE → SET DEFAULT, ...),
+// MySQL re-declares the whole column with a single MODIFY COLUMN. So one diff column entry
+// maps to exactly one op:
+//
+//   - DiffAdd    → ALTER TABLE ... ADD COLUMN <full canonical def>
+//   - DiffDrop   → ALTER TABLE ... DROP COLUMN `name`
+//   - DiffModify → ALTER TABLE ... MODIFY COLUMN <full canonical def>
+//
+// MODIFY (not CHANGE) is used because the column name is unchanged — diff-core keys columns
+// by name, so a rename is seen as DROP+ADD, never a MODIFY. The full canonical definition
+// routes through normalize-core (the same formatColumnDefinition CREATE TABLE uses), so the
+// readback of the ALTER canonicalizes equal to `to`.
+//
+// Determinism: drops are emitted before adds/modifies (so a drop-then-add of the same name
+// never collides), each sorted by lower-cased column name; sortMigrationOps re-imposes the
+// global order.
+func generateColumnDDL(_, to *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		// Only MODIFY tables carry column changes (ADD tables ship columns inline in CREATE
+		// TABLE; DROP tables vanish whole). diff-core only populates Columns on a DiffModify
+		// entry, but guard the action explicitly so a future ADD-with-columns shape cannot
+		// leak a duplicate ALTER.
+		if entry.Action != DiffModify || len(entry.Columns) == 0 {
+			continue
+		}
+		// Use the table's original-case identifier (a MODIFY table always has To). Lower-casing
+		// the diff identity key would target the wrong object on a case-sensitive server.
+		table := tableIdent(entry.To)
+
+		for _, col := range entry.Columns {
+			switch col.Action {
+			case DiffAdd:
+				if col.To == nil {
+					continue
+				}
+				ops = append(ops, addColumnOp(entry, table, col.To, n))
+
+			case DiffDrop:
+				if col.From == nil {
+					continue
+				}
+				ops = append(ops, dropColumnOp(entry, table, col.Name, col.From))
+
+			case DiffModify:
+				if col.To == nil {
+					continue
+				}
+				// MySQL rejects an in-place MODIFY that flips a generated column's storage mode
+				// (VIRTUAL↔STORED) or that converts a plain column to/from generated (error 3106).
+				// Express such a change as DROP + ADD instead of MODIFY.
+				if generatedShapeChanged(col.From, col.To) {
+					ops = append(ops, dropColumnOp(entry, table, col.Name, col.From))
+					ops = append(ops, addColumnOp(entry, table, col.To, n))
+					continue
+				}
+				ops = append(ops, MigrationOp{
+					Type:         OpModifyColumn,
+					Database:     entry.Database,
+					ObjectName:   entry.Name,
+					ParentObject: entry.Name,
+					SQL: fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN %s",
+						table, formatColumnDefinition(entry.To, col.To, n)),
+					Phase:    PhaseMain,
+					Priority: priorityColumn,
+					sortName: columnSortName(entry.Database, entry.Name, col.Name),
+				})
+			}
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Type != ops[j].Type {
+			// Drops (PhasePre) ahead of adds/modifies — also enforced by phase, but keep the
+			// local order stable for readability when grouped by table.
+			return columnOpRank(ops[i].Type) < columnOpRank(ops[j].Type)
+		}
+		// Within the same op type, lower Priority first (generated-column drops precede plain
+		// drops so a generated→plain dependency never breaks), then name for determinism.
+		if ops[i].Priority != ops[j].Priority {
+			return ops[i].Priority < ops[j].Priority
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// addColumnOp builds an ADD COLUMN op. A generated column is added AFTER plain columns
+// (priorityColumn+1) so that any base column it references — whether freshly added or being
+// MODIFYed in the same PhaseMain batch — is already in place; this is the symmetric partner of
+// dropColumnOp's generated-first rule (generated columns drop before, and add after, the plain
+// columns they depend on). The global sortMigrationOps honors Priority within PhaseMain.
+func addColumnOp(entry *TableDiffEntry, table string, to *Column, n *Normalizer) MigrationOp {
+	return MigrationOp{
+		Type:         OpAddColumn,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", table, formatColumnDefinition(entry.To, to, n)),
+		Phase:        PhaseMain,
+		Priority:     columnAddPriority(to),
+		sortName:     columnSortName(entry.Database, entry.Name, to.Name),
+	}
+}
+
+// columnAddPriority returns priorityColumn+1 for a generated column (add it after the plain
+// columns its expression may reference) and priorityColumn for a plain column.
+func columnAddPriority(c *Column) int {
+	if c != nil && c.Generated != nil {
+		return priorityColumn + 1
+	}
+	return priorityColumn
+}
+
+// dropColumnOp builds a DROP COLUMN op, giving a generated column a lower priority so it is
+// dropped before the plain columns its expression may reference (MySQL rejects dropping a
+// column a generated column depends on — error 3108). The global sortMigrationOps also honors
+// Priority within PhasePre, so the ordering holds across the whole plan.
+func dropColumnOp(entry *TableDiffEntry, table, colName string, from *Column) MigrationOp {
+	return MigrationOp{
+		Type:         OpDropColumn,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", table, migrationQuoteIdent(colName)),
+		Phase:        PhasePre,
+		Priority:     columnDropPriority(from),
+		sortName:     columnSortName(entry.Database, entry.Name, colName),
+	}
+}
+
+// columnDropPriority returns priorityColumn-1 for a generated column (drop it first) and
+// priorityColumn for a plain column, so a generated column that references a plain column is
+// always dropped before that plain column.
+func columnDropPriority(c *Column) int {
+	if c != nil && c.Generated != nil {
+		return priorityColumn - 1
+	}
+	return priorityColumn
+}
+
+// generatedShapeChanged reports whether a column's GENERATED shape changed in a way MySQL
+// cannot express as an in-place MODIFY: gaining or losing the generated attribute, or flipping
+// VIRTUAL↔STORED. Such a change must be rendered as DROP + ADD. A change to only the generation
+// EXPRESSION (storage mode unchanged) is a normal MODIFY and is not flagged here.
+func generatedShapeChanged(from, to *Column) bool {
+	if from == nil || to == nil {
+		return false
+	}
+	fromGen, toGen := from.Generated != nil, to.Generated != nil
+	if fromGen != toGen {
+		return true
+	}
+	if fromGen && toGen && from.Generated.Stored != to.Generated.Stored {
+		return true
+	}
+	return false
+}
+
+// columnOpRank orders column op types so drops sort ahead of adds/modifies locally.
+func columnOpRank(t MigrationOpType) int {
+	if t == OpDropColumn {
+		return 0
+	}
+	return 1
+}
+
+// columnSortName is the stable secondary sort key for a column op: lower-cased
+// database.table.column.
+func columnSortName(database, table, column string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(table) + "." + strings.ToLower(column)
+}
+
+// formatColumnDefinition renders a single column in MySQL's canonical stored form for the
+// target version: `name` <type> [CHARACTER SET .. COLLATE ..] [GENERATED ALWAYS AS (..)
+// VIRTUAL|STORED] [NULL|NOT NULL] [DEFAULT ..] [AUTO_INCREMENT] [ON UPDATE ..] [COMMENT ..]
+// [INVISIBLE] [/*!80003 SRID n */]. It is shared by CREATE TABLE, ADD COLUMN, and MODIFY
+// COLUMN, so all three express a column identically and round-trip through the same
+// normalize-core canonical form diff-core compares — no ad-hoc surface rebuilding that would
+// re-introduce diff noise.
+//
+// The clause ORDER follows MySQL's own SHOW CREATE rendering (show.go), which is also the
+// order MySQL accepts on input, so a rendered definition is both valid DDL and canonical.
+func formatColumnDefinition(tbl *Table, c *Column, n *Normalizer) string {
+	var b strings.Builder
+	b.WriteString(migrationQuoteIdent(c.Name))
+	b.WriteString(" ")
+	b.WriteString(n.CanonicalColumnType(c))
+
+	// CHARACTER SET / COLLATE — emit the resolved pair when it differs from the table's
+	// effective pair, so the column's stored charset/collation matches `to` after readback. A
+	// bare column (same effective pair as the table) emits nothing and inherits, exactly as
+	// MySQL stores it; an explicit divergent charset/collation is rendered in full. Resolving
+	// through ResolveColumnCharsetCollation (the same key diff-core compares) keeps the
+	// version-flagged echo asymmetry out of the rendering.
+	if cs, coll := n.ResolveColumnCharsetCollation(tbl, c); cs != "" {
+		tcs := foldCharset(tbl.Charset)
+		tcoll := n.effectiveTableCollation(tbl)
+		if cs != tcs {
+			b.WriteString(" CHARACTER SET ")
+			b.WriteString(cs)
+			if coll != "" {
+				b.WriteString(" COLLATE ")
+				b.WriteString(coll)
+			}
+		} else if coll != "" && coll != tcoll {
+			// Same charset as table but a non-inherited collation → COLLATE only.
+			b.WriteString(" COLLATE ")
+			b.WriteString(coll)
+		}
+	}
+
+	// Generated columns: GENERATED ALWAYS AS (expr) VIRTUAL|STORED. A generated column cannot
+	// carry a DEFAULT/AUTO_INCREMENT/ON UPDATE, so this branch renders nullability + comment +
+	// invisibility and returns. The expression is rendered verbatim (its stored form); the
+	// diff compares it via CanonicalGeneratedExpr, so a round-trip matches.
+	if c.Generated != nil {
+		mode := "VIRTUAL"
+		if c.Generated.Stored {
+			mode = "STORED"
+		}
+		b.WriteString(" GENERATED ALWAYS AS (")
+		b.WriteString(c.Generated.Expr)
+		b.WriteString(") ")
+		b.WriteString(mode)
+		if n.CanonicalNotNull(tbl, c) {
+			b.WriteString(" NOT NULL")
+		}
+		writeColumnComment(&b, c)
+		if c.Invisible {
+			b.WriteString(" /*!80023 INVISIBLE */")
+		}
+		return b.String()
+	}
+
+	// Nullability. Render NOT NULL when the canonical (post-rewrite) state is NOT NULL. For a
+	// nullable column we render NULL only for TIMESTAMP (MySQL's SHOW CREATE shows an explicit
+	// NULL for a nullable TIMESTAMP, and rendering it keeps the EDFT-off magic from forcing
+	// NOT NULL on apply); other nullable columns omit the keyword (the default).
+	if n.CanonicalNotNull(tbl, c) {
+		b.WriteString(" NOT NULL")
+	} else if isTimestampType(c.DataType) {
+		b.WriteString(" NULL")
+	}
+
+	// SRID (spatial) — MySQL places it after NOT NULL, before DEFAULT.
+	if c.SRID != 0 {
+		fmt.Fprintf(&b, " /*!80003 SRID %d */", c.SRID)
+	}
+
+	// DEFAULT. Render the column's declared default in canonical surface form (reusing
+	// show.go's formatDefault, which normalizes CURRENT_TIMESTAMP and quoting). A bare first
+	// TIMESTAMP under EDFT=OFF has no declared default but the engine injects
+	// DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP on apply; CanonicalTimestampDefaults
+	// predicts the same for `to`, so omitting it here still round-trips. We render only what is
+	// declared to avoid emitting an injected default that a re-apply would also inject.
+	if c.Default != nil {
+		b.WriteString(" DEFAULT ")
+		b.WriteString(formatDefault(*c.Default, c))
+	}
+
+	// AUTO_INCREMENT.
+	if c.AutoIncrement {
+		b.WriteString(" AUTO_INCREMENT")
+	}
+
+	// ON UPDATE.
+	if c.OnUpdate != "" {
+		b.WriteString(" ON UPDATE ")
+		b.WriteString(formatOnUpdate(c.OnUpdate, c.OnUpdateKind))
+	}
+
+	writeColumnComment(&b, c)
+
+	if c.Invisible {
+		b.WriteString(" /*!80023 INVISIBLE */")
+	}
+
+	return b.String()
+}
+
+// writeColumnComment appends a COMMENT clause when the column has one, escaped the way
+// MySQL's stored form does.
+func writeColumnComment(b *strings.Builder, c *Column) {
+	if c.Comment != "" {
+		b.WriteString(" COMMENT ")
+		b.WriteString(quoteStringLiteral(c.Comment))
+	}
+}

--- a/mysql/catalog/migration_oracle_test.go
+++ b/mysql/catalog/migration_oracle_test.go
@@ -1,0 +1,381 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for generate-core (correctness-protocol.md gates 1 & 2), against the
+// LIVE MySQL engines (5.7 and 8.0). This is the first node that EMITS DDL, so it proves both
+// oracle gates mechanically:
+//
+//  1. APPLY-CORRECTNESS. For a representative (from, to) pair: build a real database in
+//     state `from` (apply from's DDL), run GenerateMigration(from, to).SQL() against it, then
+//     SHOW CREATE the result and assert its canonical form equals `to`'s canonical form
+//     (DiffWithNormalizer(result, to).IsEmpty()). The from/to catalogs are loaded from the
+//     ENGINE'S OWN readbacks so they are in authentic stored form, exactly as the release
+//     path sees them.
+//
+//  2. IDEMPOTENCE (the spine). When from == to the generated plan is EMPTY (SQL() == ""), and
+//     the full round-trip — apply `to`, dump SHOW CREATE, reload, diff against `to` → empty,
+//     generate → empty — produces no DDL. A non-empty no-op plan is a bug in ordering or
+//     rendering (or an upstream normalization gap → flagged, not patched here).
+//
+// The harness reuses connectOracle / showCreate / serverCharsetFor / loadOneTable / both()
+// from the diff + normalize oracle tests. It skips cleanly when the engines are unreachable,
+// so the unit suite stays hermetic (go test -short skips it).
+
+// readbackTable returns the SHOW CREATE TABLE for a table in an existing database.
+func (o *oracleConn) readbackTable(t *testing.T, dbName, table string) (string, bool) {
+	t.Helper()
+	var name, ddl string
+	row := o.db.QueryRowContext(context.Background(), fmt.Sprintf("SHOW CREATE TABLE %s.%s", dbName, table))
+	if err := row.Scan(&name, &ddl); err != nil {
+		t.Logf("[%s] SHOW CREATE %s.%s failed: %v", o.name, dbName, table, err)
+		return "", false
+	}
+	return ddl, true
+}
+
+// catalogFromReadback applies createSQL in a throwaway db, reads back the table's SHOW
+// CREATE, and loads it into a catalog (wrapped with the box's server charset so table-charset
+// inheritance resolves identically to loadOneTable). It returns the catalog + the table's
+// authentic stored form.
+func (o *oracleConn) catalogFromReadback(t *testing.T, dbName, createSQL, table string) (*Catalog, *Table, string, bool) {
+	t.Helper()
+	rb, ok := o.showCreate(t, dbName, createSQL, table)
+	if !ok {
+		return nil, nil, "", false
+	}
+	cat, tbl := loadOneTable(t, serverCharsetFor(o.version), rb, table)
+	return cat, tbl, rb, true
+}
+
+// migrationProbe is one apply-correctness case: transform a single table from `fromDDL` to
+// `toDDL`. An empty fromDDL means "table does not exist yet" (a pure CREATE).
+type migrationProbe struct {
+	id       string
+	table    string
+	fromDDL  string // "" → table absent in from
+	toDDL    string
+	versions []Version
+}
+
+// migrationProbes enumerates the table + column op FORMS this node covers. Each is proven on
+// the listed versions: the generated DDL, applied to a real `from` database, must yield a
+// table whose canonical form equals `to`.
+func migrationProbes() []migrationProbe {
+	return []migrationProbe{
+		// ---- CREATE TABLE (from empty) — every column rendering surface ----
+		{"create-simple", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20))", both()},
+		{"create-int-widths", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT(11), b BIGINT(20), p TINYINT, h INT UNSIGNED, z INT ZEROFILL)", both()},
+		{"create-boolean", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, m BOOLEAN, d TINYINT(1))", both()},
+		{"create-numeric", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a DECIMAL, b DECIMAL(10,2), j REAL, f FLOAT, g DOUBLE(15,4))", both()},
+		{"create-char-bit-year", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a CHAR, d BINARY, c BIT, y YEAR, v VARCHAR(40), bb VARBINARY(8))", both()},
+		{"create-enum-set", "t", "",
+			`CREATE TABLE t (id INT PRIMARY KEY, a ENUM('x','y','z'), b SET('a','b','c'))`, both()},
+		{"create-defaults", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT DEFAULT 0, b INT DEFAULT '7', f DECIMAL(10,2) DEFAULT 0, c VARCHAR(20) DEFAULT 'x', j BOOLEAN DEFAULT TRUE)", both()},
+		{"create-nullability", "t", "",
+			"CREATE TABLE t (id INT, a INT NULL, b INT DEFAULT NULL, d VARCHAR(10) NOT NULL, PRIMARY KEY (id))", both()},
+		{"create-comment", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT COMMENT 'has ''quote'' inside') COMMENT='tbl ''c'''", both()},
+		{"create-autoinc", "t", "",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT) AUTO_INCREMENT=100", both()},
+		{"create-generated", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a+1) VIRTUAL, c INT GENERATED ALWAYS AS (a*2) STORED)", both()},
+		{"create-timestamp", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a TIMESTAMP, b TIMESTAMP NULL, d TIMESTAMP DEFAULT CURRENT_TIMESTAMP)", both()},
+		{"create-datetime-default", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, g DATETIME DEFAULT CURRENT_TIMESTAMP, h DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)", both()},
+		{"create-charset-explicit", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10) CHARACTER SET utf8mb4, b VARCHAR(10)) DEFAULT CHARSET=utf8mb4", both()},
+		{"create-engine-myisam", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT) ENGINE=MyISAM", both()},
+		{"create-multi-column", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, c1 VARCHAR(10), c2 INT DEFAULT 0, c3 DATE, c4 DECIMAL(8,3), PRIMARY KEY (id))", both()},
+		{"create-functional-default", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT DEFAULT (1+1), b VARCHAR(36) DEFAULT (UUID()))", only(MySQL80)},
+		{"create-row-format", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8", both()},
+
+		// ---- DROP TABLE ----
+		{"drop-table", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"", both()},
+
+		// ---- ADD COLUMN ----
+		{"add-column", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20))", both()},
+		{"add-column-notnull-default", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, n INT NOT NULL DEFAULT 5)", both()},
+		{"add-generated-column", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a+1) STORED)", both()},
+		{"add-timestamp-column", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, ts TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP)", both()},
+
+		// ---- DROP COLUMN ----
+		{"drop-column", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20))",
+			"CREATE TABLE t (id INT PRIMARY KEY)", both()},
+
+		// ---- MODIFY COLUMN (type / nullability / default / charset / comment / autoinc) ----
+		{"modify-type", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, v BIGINT)", both()},
+		{"modify-type-width-57-vs-80", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v SMALLINT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, v BIGINT)", both()},
+		{"modify-nullability", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT NULL)",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT NOT NULL)", both()},
+		{"modify-default", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 0)",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT DEFAULT 1)", both()},
+		{"modify-charset", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) CHARACTER SET latin1) DEFAULT CHARSET=utf8mb4",
+			"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) CHARACTER SET utf8mb4) DEFAULT CHARSET=utf8mb4", both()},
+		{"modify-comment", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT COMMENT 'a')",
+			"CREATE TABLE t (id INT PRIMARY KEY, v INT COMMENT 'b')", both()},
+		{"modify-add-autoinc", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY)", both()},
+		{"modify-generated-expr", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+1) STORED)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+2) STORED)", both()},
+
+		// ---- table-option ALTER (engine / charset / comment / row_format) ----
+		{"alter-engine", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY) ENGINE=InnoDB",
+			"CREATE TABLE t (id INT PRIMARY KEY) ENGINE=MyISAM", both()},
+		{"alter-comment", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY) COMMENT='old'",
+			"CREATE TABLE t (id INT PRIMARY KEY) COMMENT='new'", both()},
+		{"alter-charset", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=latin1",
+			"CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=utf8mb4", both()},
+		{"alter-rowformat-add", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8", both()},
+		{"alter-rowformat-change", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=COMPACT",
+			"CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=DYNAMIC", both()},
+
+		// ---- review-regression apply proofs (blockers #1, #2) ----
+		// Generated storage-mode flip VIRTUAL→STORED: must be DROP+ADD (in-place MODIFY is
+		// rejected by MySQL, error 3106). 8.0 only — stored generated cols need 5.7.x patches the
+		// box may lack; proven on 8.0.
+		{"gen-storage-flip", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+1) VIRTUAL)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+1) STORED)", only(MySQL80)},
+		// Dropping a base column AND a generated column that references it: the generated column
+		// must be dropped first (error 3108 otherwise).
+		{"gen-drop-with-base", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, z INT GENERATED ALWAYS AS (a+1) STORED)",
+			"CREATE TABLE t (id INT PRIMARY KEY)", both()},
+		// Re-round N2: a generated column `g` (refs base `z`, sorts before it) flips storage
+		// (DROP+ADD) in the same plan as a type-widening MODIFY of `z`. The generated ADD must
+		// land after the base MODIFY (else the re-add references a column mid-change). 8.0 only
+		// (stored generated columns).
+		{"gen-flip-with-base-modify", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g INT GENERATED ALWAYS AS (z+1) VIRTUAL, z SMALLINT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g INT GENERATED ALWAYS AS (z+1) STORED, z BIGINT)", only(MySQL80)},
+
+		// ---- coverage: INVISIBLE column, COLLATE-only divergence (8.0 features) ----
+		{"create-invisible-column", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, secret INT INVISIBLE)", only(MySQL80)},
+		{"add-invisible-column", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, secret INT INVISIBLE)", only(MySQL80)},
+		{"create-collate-only-column", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10) COLLATE utf8mb4_unicode_ci) DEFAULT CHARSET=utf8mb4", both()},
+	}
+}
+
+// TestOracle_MigrationApplyCorrectness proves gate 2 (apply-correctness) for every probe:
+// the generated DDL transforms a real `from` database into a `to`-equal one.
+func TestOracle_MigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range migrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// assertApplyCorrect is the core gate-2 assertion. It loads from/to catalogs from the
+// engine's own readbacks, generates the plan, applies it to a from-state database, reads the
+// result back, and asserts the result canonicalizes equal to `to` (in both directions).
+func assertApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p migrationProbe) {
+	t.Helper()
+
+	// Hyphens are illegal in unquoted MySQL identifiers; slug the probe id for db names.
+	slug := strings.ReplaceAll(p.id, "-", "_")
+
+	// Build the `to` catalog from the engine's readback (authentic stored form).
+	var toCat *Catalog
+	tableInTo := strings.TrimSpace(p.toDDL) != ""
+	if tableInTo {
+		c, _, _, ok := o.catalogFromReadback(t, "gen_to_"+slug, p.toDDL, p.table)
+		if !ok {
+			t.Skipf("[%s] could not obtain `to` readback for %s", o.name, p.id)
+		}
+		toCat = c
+	} else {
+		toCat = New()
+	}
+
+	// Build the `from` catalog likewise.
+	var fromCat *Catalog
+	tableInFrom := strings.TrimSpace(p.fromDDL) != ""
+	if tableInFrom {
+		c, _, _, ok := o.catalogFromReadback(t, "gen_from_"+slug, p.fromDDL, p.table)
+		if !ok {
+			t.Skipf("[%s] could not obtain `from` readback for %s", o.name, p.id)
+		}
+		fromCat = c
+	} else {
+		fromCat = New()
+	}
+
+	// Generate the plan (version-aware).
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Build a real database in state `from` and apply the plan, all on ONE dedicated
+	// connection (database/sql pools connections, so a stray `USE` on the pool can land on a
+	// different connection than the next statement). The catalogs were loaded via loadOneTable,
+	// which wraps DDL in database `diffdb`, so the plan qualifies tables as `diffdb`.`t` — we
+	// must set up and apply in that same `diffdb`.
+	ctx := context.Background()
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	const applyDB = "diffdb"
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, serverCharsetFor(o.version)),
+		"USE " + applyDB,
+	}
+	if tableInFrom {
+		setup = append(setup, p.fromDDL)
+	}
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, p.id, s, err)
+		}
+	}
+
+	// Apply the migration statements one at a time on the same connection.
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Read back the result (on the same connection) and compare to `to`.
+	readback := func(table string) (string, bool) {
+		var name, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", applyDB, table))
+		if err := row.Scan(&name, &ddl); err != nil {
+			return "", false
+		}
+		return ddl, true
+	}
+
+	if !tableInTo {
+		// The table should be gone (DROP). Assert SHOW CREATE now fails.
+		if _, ok := readback(p.table); ok {
+			t.Errorf("[%s] %s: table %s still exists after DROP plan:\n%s", o.name, p.id, p.table, plan.SQL())
+		}
+		return
+	}
+
+	resultRB, ok := readback(p.table)
+	if !ok {
+		t.Fatalf("[%s] %s: result table %s missing after apply:\n%s", o.name, p.id, p.table, plan.SQL())
+	}
+	resultCat, _ := loadOneTable(t, serverCharsetFor(o.version), resultRB, p.table)
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		toRB, _ := o.readbackTable(t, "gen_to_"+slug, p.table)
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result: %s\n  want:   %s\n  diff: %s",
+			o.name, p.id, plan.SQL(), strings.TrimSpace(resultRB), strings.TrimSpace(toRB), describeDiff(d))
+	}
+	// Symmetry: to vs result must also be empty.
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeDiff(d))
+	}
+}
+
+// TestOracle_MigrationIdempotence proves gate 1 (the spine): for a schema in its real stored
+// form, the generated no-op plan is EMPTY — and the full round-trip (apply → dump → reload →
+// diff → generate) emits nothing. A non-empty no-op plan is a bug.
+func TestOracle_MigrationIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		// Reuse the diff idempotence corpus (the same high-risk forms), but assert the PLAN is
+		// empty rather than just the diff.
+		for _, probe := range diffIdempotenceProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				// Load the engine's stored form of the schema.
+				cat, _, rb, ok := o.catalogFromReadback(t, "gen_idem_"+strings.ReplaceAll(probe.id, "-", "_"), probe.create, probe.table)
+				if !ok {
+					t.Skipf("[%s] could not obtain readback for %s", o.name, probe.id)
+				}
+				// Self-plan must be empty (idempotence spine).
+				diff := DiffWithNormalizer(cat, cat, n)
+				plan := GenerateMigrationWithNormalizer(cat, cat, diff, n)
+				if plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s (normalization/ordering bug):\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(rb), plan.SQL())
+				}
+
+				// Round-trip: apply the user form, dump, reload, diff against the user-form
+				// catalog, generate — must be empty. This catches a rendering form that the
+				// engine would re-normalize differently from the loader.
+				userCat, _ := loadOneTable(t, serverCharsetFor(o.version), probe.create, probe.table)
+				rtDiff := DiffWithNormalizer(userCat, cat, n)
+				rtPlan := GenerateMigrationWithNormalizer(userCat, cat, rtDiff, n)
+				if rtPlan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY ROUND-TRIP PLAN (user vs stored) for %s:\n  user:   %s\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(probe.create), strings.TrimSpace(rb), rtPlan.SQL())
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/migration_table.go
+++ b/mysql/catalog/migration_table.go
@@ -1,0 +1,328 @@
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// generateTableDDL produces CREATE TABLE, DROP TABLE, and table-option ALTER TABLE
+// operations from the diff. It is the MySQL analog of PG's generateTableDDL
+// (pg/catalog/migration_table.go:21).
+//
+//   - DiffAdd  → CREATE TABLE (full canonical form: columns + table options).
+//   - DiffDrop → DROP TABLE.
+//   - DiffModify → table-option ALTER TABLE (ENGINE/CHARSET/COLLATE/COMMENT/ROW_FORMAT)
+//     when the table-level options changed. Column changes on a modified table are emitted
+//     by generateColumnDDL (one ALTER per column); this generator only handles the
+//     table-level option delta so the two never double-emit.
+//
+// Determinism: drops sorted by name, then creates sorted by name, then option-alters sorted
+// by name — and sortMigrationOps re-imposes the global phase/name order on top.
+func generateTableDDL(from, to *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		switch entry.Action {
+		case DiffAdd:
+			if entry.To == nil {
+				continue
+			}
+			ops = append(ops, MigrationOp{
+				Type:       OpCreateTable,
+				Database:   entry.Database,
+				ObjectName: entry.Name,
+				SQL:        formatCreateTable(entry.To, n),
+				Phase:      PhaseMain,
+				Priority:   priorityTable,
+				sortName:   tableSortName(entry.Database, entry.Name),
+			})
+
+		case DiffDrop:
+			if entry.From == nil {
+				continue
+			}
+			ops = append(ops, MigrationOp{
+				Type:       OpDropTable,
+				Database:   entry.Database,
+				ObjectName: entry.Name,
+				SQL:        fmt.Sprintf("DROP TABLE %s", tableIdent(entry.From)),
+				Phase:      PhasePre,
+				Priority:   priorityTable,
+				sortName:   tableSortName(entry.Database, entry.Name),
+			})
+
+		case DiffModify:
+			// Table-level option changes only; column changes are generateColumnDDL's job.
+			if entry.From == nil || entry.To == nil {
+				continue
+			}
+			if op, ok := tableOptionAlterOp(entry.Database, entry.Name, entry.From, entry.To, n); ok {
+				ops = append(ops, op)
+			}
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Type != ops[j].Type {
+			// Drops first, then creates, then option-alters — by op-type rank.
+			return tableOpRank(ops[i].Type) < tableOpRank(ops[j].Type)
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// tableOpRank orders table-level op types so a deterministic local sort places drops, then
+// creates, then option-alters (the global sortMigrationOps re-sorts by phase too).
+func tableOpRank(t MigrationOpType) int {
+	switch t {
+	case OpDropTable:
+		return 0
+	case OpCreateTable:
+		return 1
+	default: // OpAlterTable
+		return 2
+	}
+}
+
+// tableOptionAlterOp builds an ALTER TABLE that reconciles the table-level options that
+// diff-core's tableOptionsChanged compares (engine, effective charset/collation, comment,
+// significant ROW_FORMAT). It emits only the clauses that actually changed, in a stable
+// order, so a column-only modification produces NO table-option ALTER (the second return is
+// false). Each option is rendered through the same canonical form diff-core compared, so the
+// readback of the ALTER canonicalizes equal to `to`.
+func tableOptionAlterOp(database, name string, from, to *Table, n *Normalizer) (MigrationOp, bool) {
+	var clauses []string
+
+	// ENGINE — render the resolved (canonical) engine when it changed. CanonicalEngine
+	// lower-cases and defaults to innodb; we emit the declared name (or the default) so the
+	// readback echoes ENGINE=<X>.
+	if n.CanonicalEngine(from) != n.CanonicalEngine(to) {
+		clauses = append(clauses, "ENGINE="+tableEngineName(to))
+	}
+
+	// CHARSET / COLLATE — when the effective (charset, collation) pair changed, emit both.
+	// MySQL's ALTER TABLE ... DEFAULT CHARSET=cs COLLATE=coll sets the table default; it does
+	// NOT rewrite existing columns' stored charset, but bare columns inherit it and the diff
+	// compares the effective pair, so emitting both keeps the readback canonical.
+	charsetChanged := foldCharset(from.Charset) != foldCharset(to.Charset)
+	collationChanged := n.effectiveTableCollation(from) != n.effectiveTableCollation(to)
+	if charsetChanged || collationChanged {
+		cs := foldCharset(to.Charset)
+		coll := n.effectiveTableCollation(to)
+		if cs != "" {
+			clauses = append(clauses, "DEFAULT CHARSET="+cs)
+		}
+		if coll != "" {
+			clauses = append(clauses, "COLLATE="+coll)
+		}
+	}
+
+	// COMMENT.
+	if n.CanonicalComment(from.Comment) != n.CanonicalComment(to.Comment) {
+		clauses = append(clauses, "COMMENT="+quoteStringLiteral(to.Comment))
+	}
+
+	// ROW_FORMAT — only when normalize-core deems the change significant (rowFormatChanged).
+	if rowFormatChanged(from, to, n) {
+		clauses = append(clauses, "ROW_FORMAT="+strings.ToUpper(canonicalRowFormatValue(to, n)))
+	}
+
+	if len(clauses) == 0 {
+		return MigrationOp{}, false
+	}
+
+	return MigrationOp{
+		Type:       OpAlterTable,
+		Database:   database,
+		ObjectName: name,
+		SQL: fmt.Sprintf("ALTER TABLE %s %s",
+			tableIdent(to), strings.Join(clauses, ", ")),
+		Phase:    PhaseMain,
+		Priority: priorityTable,
+		sortName: tableSortName(database, name),
+	}, true
+}
+
+// canonicalRowFormatValue returns the ROW_FORMAT value to emit when it changed. An
+// ignorable (empty/DEFAULT) target side yields "DEFAULT" (reset to engine default); an
+// explicit value is emitted verbatim. This mirrors rowFormatChanged's significance rule.
+func canonicalRowFormatValue(t *Table, n *Normalizer) string {
+	if n.IgnoreRowFormat(t) {
+		return "DEFAULT"
+	}
+	return strings.TrimSpace(t.RowFormat)
+}
+
+// formatCreateTable renders a full canonical CREATE TABLE for a target table, with every
+// column and the table options in MySQL's stored form for the target version. The output,
+// applied and read back, canonicalizes equal to `tbl` because each piece routes through the
+// same normalize-core canonical form diff-core compares. It is the MySQL analog of PG's
+// FormatCreateTable (pg/catalog/migration_table.go:96).
+//
+// Scope: columns + table options + inline PRIMARY KEY. Secondary indexes, UNIQUE/foreign
+// keys, CHECK constraints, and partitioning are breadth concerns and are intentionally NOT
+// rendered here — a table created by this node carries its columns and PK; the index/FK/
+// check/partition nodes emit their own ALTER TABLE ADD ... follow-ups. (The PK is rendered
+// inline because a column's NOT NULL canonicalization is PK-aware and an AUTO_INCREMENT
+// column requires a key; emitting the PK inline keeps a single-table CREATE self-consistent
+// and apply-correct for the P0 slice.)
+//
+// KNOWN SCOPE-BOUNDARY LIMITATION: an AUTO_INCREMENT column whose ONLY supporting key is a
+// non-PK UNIQUE index renders here without that key (UNIQUE indexes are not in TableDiffEntry —
+// they belong to the index breadth node), so this CREATE TABLE would be rejected by MySQL
+// ("there can be only one auto column and it must be defined as a key") until the index node
+// supplies the key. The common AUTO_INCREMENT-as-PRIMARY-KEY case is rendered correctly and is
+// oracle-proven (probes create-autoinc, modify-add-autoinc).
+func formatCreateTable(tbl *Table, n *Normalizer) string {
+	var b strings.Builder
+	b.WriteString("CREATE TABLE ")
+	b.WriteString(tableIdent(tbl))
+	b.WriteString(" (\n")
+
+	var lines []string
+	for _, col := range diffableColumns(tbl) {
+		lines = append(lines, "  "+formatColumnDefinition(tbl, col, n))
+	}
+	if pk := formatInlinePrimaryKey(tbl); pk != "" {
+		lines = append(lines, "  "+pk)
+	}
+	b.WriteString(strings.Join(lines, ",\n"))
+	b.WriteString("\n)")
+
+	if opts := formatCreateTableOptions(tbl, n); opts != "" {
+		b.WriteString(" ")
+		b.WriteString(opts)
+	}
+
+	return b.String()
+}
+
+// formatInlinePrimaryKey renders the inline PRIMARY KEY clause for a CREATE TABLE, or ""
+// when the table has no PK. The PK can be expressed via an index (Primary) or a constraint
+// (ConPrimaryKey); the loader uses the index form for `PRIMARY KEY (...)` so that is the
+// primary source, with the constraint form as a fallback. Prefix lengths and DESC are
+// rendered (a PK may carry them); the generated invisible primary key is never emitted (it
+// is engine-synthesized).
+func formatInlinePrimaryKey(tbl *Table) string {
+	for _, idx := range tbl.Indexes {
+		if !idx.Primary {
+			continue
+		}
+		if isGeneratedInvisiblePrimaryKeyIndex(idx) {
+			return ""
+		}
+		cols := make([]string, 0, len(idx.Columns))
+		for _, ic := range idx.Columns {
+			cols = append(cols, migrationIndexColumn(ic))
+		}
+		return "PRIMARY KEY (" + strings.Join(cols, ",") + ")"
+	}
+	for _, con := range tbl.Constraints {
+		if con.Type != ConPrimaryKey {
+			continue
+		}
+		cols := make([]string, 0, len(con.Columns))
+		for _, c := range con.Columns {
+			cols = append(cols, migrationQuoteIdent(c))
+		}
+		return "PRIMARY KEY (" + strings.Join(cols, ",") + ")"
+	}
+	return ""
+}
+
+// migrationIndexColumn renders one index/PK key part: `col`[(len)][ DESC] or (expr). DESC is
+// rendered unconditionally (it is harmless on 5.7, which stores ascending — the diff already
+// drops 5.7 DESC via CanonicalIndexColumn, so a round-tripped PK key still compares equal).
+func migrationIndexColumn(ic *IndexColumn) string {
+	var b strings.Builder
+	if ic.Expr != "" {
+		b.WriteString("(")
+		b.WriteString(ic.Expr)
+		b.WriteString(")")
+	} else {
+		b.WriteString(migrationQuoteIdent(ic.Name))
+		if ic.Length > 0 {
+			fmt.Fprintf(&b, "(%d)", ic.Length)
+		}
+	}
+	if ic.Descending {
+		b.WriteString(" DESC")
+	}
+	return b.String()
+}
+
+// formatCreateTableOptions renders the trailing table options (ENGINE/CHARSET/COLLATE/
+// COMMENT/ROW_FORMAT) in canonical form for a CREATE TABLE. AUTO_INCREMENT=N is never
+// emitted (ignore-in-diff: it is a live counter, not schema). ENGINE is always emitted
+// (MySQL always echoes it); charset/collation are emitted when the table declares a charset
+// so the readback's effective pair matches.
+func formatCreateTableOptions(tbl *Table, n *Normalizer) string {
+	var parts []string
+
+	parts = append(parts, "ENGINE="+tableEngineName(tbl))
+
+	if cs := foldCharset(tbl.Charset); cs != "" {
+		parts = append(parts, "DEFAULT CHARSET="+cs)
+		if coll := n.effectiveTableCollation(tbl); coll != "" {
+			parts = append(parts, "COLLATE="+coll)
+		}
+	}
+
+	if !n.IgnoreRowFormat(tbl) {
+		parts = append(parts, "ROW_FORMAT="+strings.ToUpper(strings.TrimSpace(tbl.RowFormat)))
+	}
+
+	if c := n.CanonicalComment(tbl.Comment); c != "" {
+		parts = append(parts, "COMMENT="+quoteStringLiteral(c))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// tableEngineName returns the engine name to emit for a table — the declared engine, or the
+// server default (InnoDB) when unspecified, so the readback's ENGINE clause matches the
+// canonical engine diff-core compares.
+func tableEngineName(tbl *Table) string {
+	e := strings.TrimSpace(tbl.Engine)
+	if e == "" {
+		return "InnoDB"
+	}
+	return e
+}
+
+// tableIdent returns the backtick-quoted database.table identifier for migration DDL,
+// using the table's ORIGINAL-CASE names (Table.Name and Table.Database.Name), not the
+// lower-cased diff identity keys (TableDiffEntry.Database/Name are folded to lower case for
+// matching). On a case-sensitive server (lower_case_table_names=0, the Linux default) the
+// stored object name is case-significant, so the DDL must reproduce the declared casing or it
+// targets the wrong/non-existent object. The database qualifier is omitted when the table has
+// no Database (the synced single-database release path may load with no qualifying database).
+func tableIdent(tbl *Table) string {
+	if tbl.Database == nil || tbl.Database.Name == "" {
+		return migrationQuoteIdent(tbl.Name)
+	}
+	return migrationQuoteIdent(tbl.Database.Name) + "." + migrationQuoteIdent(tbl.Name)
+}
+
+// tableSortName is the stable secondary sort key for a table-level op: lower-cased
+// database.table.
+func tableSortName(database, table string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(table)
+}
+
+// migrationQuoteIdent backtick-quotes a MySQL identifier, doubling any embedded backtick.
+// Migration DDL always quotes identifiers to avoid reserved-word collisions.
+func migrationQuoteIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// quoteStringLiteral single-quotes a string for a DDL string-literal context (COMMENT,
+// string default), escaping backslashes and single quotes the way MySQL's stored form does
+// (reusing show.go's escapeComment, which doubles ' and escapes \).
+func quoteStringLiteral(s string) string {
+	return "'" + escapeComment(s) + "'"
+}

--- a/mysql/catalog/migration_test.go
+++ b/mysql/catalog/migration_test.go
@@ -1,0 +1,452 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// In-process, hermetic tests for generate-core. They assert MigrationPlan shape, SQL()
+// joining, Filter, the idempotence terminal (empty diff → empty plan), deterministic op
+// ordering, and the structural content of the table/column DDL — loading both sides through
+// the omni catalog (LoadSDL) so the model state is authentic. The oracle-backed
+// apply-correctness + idempotence proofs (correctness-protocol.md gates 1 & 2) live in
+// migration_oracle_test.go and run against the live engines.
+
+// planFor diffs two SDL schemas and generates a migration plan with the given normalizer.
+func planFor(t *testing.T, fromSDL, toSDL string, n *Normalizer) *MigrationPlan {
+	t.Helper()
+	from := loadCat(t, fromSDL)
+	to := loadCat(t, toSDL)
+	diff := DiffWithNormalizer(from, to, n)
+	return GenerateMigrationWithNormalizer(from, to, diff, n)
+}
+
+// onlyOp returns the single op in a plan, failing if the count differs.
+func onlyOp(t *testing.T, p *MigrationPlan) MigrationOp {
+	t.Helper()
+	if len(p.Ops) != 1 {
+		t.Fatalf("want exactly 1 op, got %d: %s", len(p.Ops), p.SQL())
+	}
+	return p.Ops[0]
+}
+
+// ---- idempotence terminal: empty diff → empty plan -------------------------
+
+func TestMigration_EmptyDiffEmptyPlan(t *testing.T) {
+	schemas := []string{
+		dbDDL + "CREATE TABLE t (id INT NOT NULL, name VARCHAR(50), PRIMARY KEY (id));",
+		dbDDL + "CREATE TABLE g (a INT, b INT GENERATED ALWAYS AS (a+1) STORED, c VARCHAR(10) DEFAULT 'x');",
+		dbDDL + "CREATE TABLE ts (id INT PRIMARY KEY, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP, n INT DEFAULT 0);",
+		dbDDL + "CREATE TABLE a (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, v DECIMAL(10,2) DEFAULT 0) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+	}
+	for _, s := range schemas {
+		c := loadCat(t, s)
+		for _, n := range []*Normalizer{NormalizerFor(MySQL80), NormalizerFor(MySQL57)} {
+			diff := DiffWithNormalizer(c, c, n)
+			plan := GenerateMigrationWithNormalizer(c, c, diff, n)
+			if len(plan.Ops) != 0 {
+				t.Errorf("self-diff plan not empty (version=%d) for %q:\n%s", n.Version, s, plan.SQL())
+			}
+			if plan.SQL() != "" {
+				t.Errorf("self-diff SQL not empty (version=%d) for %q: %q", n.Version, s, plan.SQL())
+			}
+		}
+		// Parameterless GenerateMigration must also be empty.
+		if plan := GenerateMigration(c, c, Diff(c, c)); plan.SQL() != "" {
+			t.Errorf("parameterless self-diff SQL not empty for %q: %q", s, plan.SQL())
+		}
+	}
+}
+
+func TestMigration_NilDiffEmptyPlan(t *testing.T) {
+	if p := GenerateMigration(New(), New(), nil); p == nil || len(p.Ops) != 0 || p.SQL() != "" {
+		t.Errorf("nil diff must produce empty plan, got %+v", p)
+	}
+}
+
+// ---- MigrationPlan helpers -------------------------------------------------
+
+func TestMigrationPlan_SQLJoin(t *testing.T) {
+	p := &MigrationPlan{Ops: []MigrationOp{
+		{SQL: "DROP TABLE `a`"},
+		{SQL: "CREATE TABLE `b` (\n  `id` int\n)"},
+	}}
+	got := p.SQL()
+	if !strings.Contains(got, ";\n") {
+		t.Errorf("SQL() must join ops with \";\\n\", got %q", got)
+	}
+	if strings.Count(got, ";\n") != 1 {
+		t.Errorf("two ops must have exactly one separator, got %q", got)
+	}
+	if (&MigrationPlan{}).SQL() != "" {
+		t.Errorf("empty plan SQL() must be \"\"")
+	}
+}
+
+func TestMigrationPlan_Filter(t *testing.T) {
+	p := &MigrationPlan{Ops: []MigrationOp{
+		{Type: OpCreateTable, ObjectName: "keep"},
+		{Type: OpDropTable, ObjectName: "drop"},
+	}}
+	kept := p.Filter(func(op MigrationOp) bool { return op.Type != OpDropTable })
+	if len(kept.Ops) != 1 || kept.Ops[0].ObjectName != "keep" {
+		t.Errorf("Filter did not keep the right op: %+v", kept.Ops)
+	}
+}
+
+// ---- table-level DDL --------------------------------------------------------
+
+func TestMigration_CreateTable(t *testing.T) {
+	from := dbDDL
+	to := dbDDL + "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20));"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpCreateTable {
+		t.Fatalf("want CreateTable, got %s", op.Type)
+	}
+	sql := op.SQL
+	for _, want := range []string{"CREATE TABLE `app`.`t`", "`id` int", "`name` varchar(20)", "PRIMARY KEY (`id`)", "ENGINE=InnoDB"} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("CREATE TABLE missing %q:\n%s", want, sql)
+		}
+	}
+	// AUTO_INCREMENT=N must never appear (ignore-in-diff).
+	if strings.Contains(sql, "AUTO_INCREMENT=") {
+		t.Errorf("CREATE TABLE must not emit AUTO_INCREMENT=N counter:\n%s", sql)
+	}
+}
+
+func TestMigration_DropTable(t *testing.T) {
+	from := dbDDL + "CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY);"
+	to := dbDDL + "CREATE TABLE a (id INT PRIMARY KEY);"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpDropTable {
+		t.Fatalf("want DropTable, got %s", op.Type)
+	}
+	if !strings.Contains(op.SQL, "DROP TABLE `app`.`b`") {
+		t.Errorf("want DROP TABLE `b`, got %q", op.SQL)
+	}
+	if op.Phase != PhasePre {
+		t.Errorf("DROP must be PhasePre, got %d", op.Phase)
+	}
+}
+
+func TestMigration_TableEngineChange(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY) ENGINE=InnoDB;"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY) ENGINE=MyISAM;"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpAlterTable {
+		t.Fatalf("want AlterTable, got %s", op.Type)
+	}
+	if !strings.Contains(strings.ToUpper(op.SQL), "ENGINE=MYISAM") {
+		t.Errorf("want ENGINE=MyISAM, got %q", op.SQL)
+	}
+}
+
+func TestMigration_TableCommentChange(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY) COMMENT='old';"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY) COMMENT='new';"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpAlterTable || !strings.Contains(op.SQL, "COMMENT='new'") {
+		t.Errorf("want ALTER TABLE COMMENT='new', got %q", op.SQL)
+	}
+}
+
+func TestMigration_TableCharsetChange(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=utf8mb4;"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=latin1;"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpAlterTable || !strings.Contains(strings.ToUpper(op.SQL), "CHARSET=LATIN1") {
+		t.Errorf("want ALTER TABLE DEFAULT CHARSET=latin1, got %q", op.SQL)
+	}
+}
+
+// A column-only modification must NOT produce a table-option ALTER (the two generators must
+// not double-emit the table). Only the column MODIFY should appear.
+func TestMigration_ColumnChangeNoTableOptionAlter(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, v INT);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, v BIGINT);"
+	p := planFor(t, from, to, NormalizerFor(MySQL80))
+	for _, op := range p.Ops {
+		if op.Type == OpAlterTable {
+			t.Errorf("column-only change must not emit a table-option ALTER, got %q", op.SQL)
+		}
+	}
+	op := onlyOp(t, p)
+	if op.Type != OpModifyColumn {
+		t.Fatalf("want a single MODIFY COLUMN, got %s: %s", op.Type, op.SQL)
+	}
+}
+
+// ---- column-level DDL -------------------------------------------------------
+
+func TestMigration_AddColumn(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20) NOT NULL DEFAULT 'x');"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpAddColumn {
+		t.Fatalf("want AddColumn, got %s", op.Type)
+	}
+	for _, want := range []string{"ALTER TABLE `app`.`t` ADD COLUMN", "`name` varchar(20)", "NOT NULL", "DEFAULT 'x'"} {
+		if !strings.Contains(op.SQL, want) {
+			t.Errorf("ADD COLUMN missing %q:\n%s", want, op.SQL)
+		}
+	}
+	if op.ParentObject != "t" {
+		t.Errorf("column op ParentObject must be the table, got %q", op.ParentObject)
+	}
+}
+
+func TestMigration_DropColumn(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(20));"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY);"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpDropColumn || !strings.Contains(op.SQL, "DROP COLUMN `name`") {
+		t.Errorf("want DROP COLUMN `name`, got %q", op.SQL)
+	}
+	if op.Phase != PhasePre {
+		t.Errorf("DROP COLUMN must be PhasePre, got %d", op.Phase)
+	}
+}
+
+func TestMigration_ModifyColumnUsesModify(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, v INT);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, v BIGINT NOT NULL);"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpModifyColumn {
+		t.Fatalf("want ModifyColumn, got %s", op.Type)
+	}
+	// MySQL uses MODIFY COLUMN, never PG's ALTER COLUMN ... TYPE.
+	if !strings.Contains(op.SQL, "MODIFY COLUMN `v` bigint") {
+		t.Errorf("want MODIFY COLUMN `v` bigint, got %q", op.SQL)
+	}
+	if strings.Contains(op.SQL, "ALTER COLUMN") {
+		t.Errorf("MySQL must use MODIFY, not ALTER COLUMN: %q", op.SQL)
+	}
+}
+
+// 5.7 renders integer display widths; 8.0 drops them. The MODIFY must reflect the target
+// version's canonical type (proving rendering routes through the Normalizer, not a fixed
+// 8.0 form).
+func TestMigration_ModifyColumnVersionedWidth(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, v SMALLINT);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, v BIGINT);"
+	op80 := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if !strings.Contains(op80.SQL, "`v` bigint") || strings.Contains(op80.SQL, "bigint(") {
+		t.Errorf("8.0 MODIFY must render width-less bigint, got %q", op80.SQL)
+	}
+	op57 := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL57)))
+	if !strings.Contains(op57.SQL, "`v` bigint(20)") {
+		t.Errorf("5.7 MODIFY must render bigint(20), got %q", op57.SQL)
+	}
+}
+
+func TestMigration_AddGeneratedColumn(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT GENERATED ALWAYS AS (a+1) STORED);"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpAddColumn {
+		t.Fatalf("want AddColumn, got %s", op.Type)
+	}
+	if !strings.Contains(op.SQL, "GENERATED ALWAYS AS") || !strings.Contains(op.SQL, "STORED") {
+		t.Errorf("generated column must render GENERATED ALWAYS AS (..) STORED, got %q", op.SQL)
+	}
+	// A generated column must not carry a DEFAULT.
+	if strings.Contains(op.SQL, "DEFAULT") {
+		t.Errorf("generated column must not have DEFAULT, got %q", op.SQL)
+	}
+}
+
+func TestMigration_AddAutoIncrementColumn(t *testing.T) {
+	// Adding an AUTO_INCREMENT column to a table that has it as PK already.
+	from := dbDDL + "CREATE TABLE t (id INT NOT NULL PRIMARY KEY);"
+	to := dbDDL + "CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY);"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpModifyColumn {
+		t.Fatalf("want ModifyColumn, got %s", op.Type)
+	}
+	if !strings.Contains(op.SQL, "AUTO_INCREMENT") {
+		t.Errorf("want AUTO_INCREMENT attribute in MODIFY, got %q", op.SQL)
+	}
+}
+
+// ---- deterministic ordering -------------------------------------------------
+
+// Drops must precede creates/modifies, and the whole plan must be byte-stable across runs
+// (idempotence depends on it). We construct a multi-change diff and assert ordering + that
+// two generations of the same diff are identical.
+func TestMigration_DeterministicOrdering(t *testing.T) {
+	from := dbDDL + "CREATE TABLE keep (id INT PRIMARY KEY, old_col INT); CREATE TABLE goner (id INT PRIMARY KEY); CREATE TABLE zeta (id INT PRIMARY KEY);"
+	to := dbDDL + "CREATE TABLE keep (id INT PRIMARY KEY, new_col INT); CREATE TABLE zeta (id INT PRIMARY KEY); CREATE TABLE alpha (id INT PRIMARY KEY);"
+
+	n := NormalizerFor(MySQL80)
+	fromCat := loadCat(t, from)
+	toCat := loadCat(t, to)
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+
+	p1 := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+	p2 := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+	if p1.SQL() != p2.SQL() {
+		t.Fatalf("plan generation not deterministic:\n--- p1 ---\n%s\n--- p2 ---\n%s", p1.SQL(), p2.SQL())
+	}
+
+	// All PhasePre (drops) ops must come before any PhaseMain op.
+	seenMain := false
+	for _, op := range p1.Ops {
+		switch op.Phase {
+		case PhasePre:
+			if seenMain {
+				t.Errorf("a drop (%s %s) appears after a create/alter — phase ordering broken:\n%s",
+					op.Type, op.ObjectName, p1.SQL())
+			}
+		case PhaseMain:
+			seenMain = true
+		}
+	}
+
+	// Sanity: the expected op kinds are present (drop table goner, drop column old_col, create
+	// table alpha, add column new_col).
+	kinds := map[MigrationOpType]int{}
+	for _, op := range p1.Ops {
+		kinds[op.Type]++
+	}
+	if kinds[OpDropTable] != 1 || kinds[OpCreateTable] != 1 || kinds[OpAddColumn] != 1 || kinds[OpDropColumn] != 1 {
+		t.Errorf("unexpected op mix: %+v\n%s", kinds, p1.SQL())
+	}
+}
+
+// ---- review regressions ----------------------------------------------------
+
+// Blocker #4: the rendered table identifier must preserve the DECLARED casing, not the
+// lower-cased diff identity key (on a case-sensitive server the stored name is significant).
+func TestMigration_TableNameCasePreserved(t *testing.T) {
+	from := "CREATE DATABASE App DEFAULT CHARSET=utf8mb4; USE App; CREATE TABLE MyTable (Id INT PRIMARY KEY); CREATE TABLE Goner (Id INT PRIMARY KEY);"
+	to := "CREATE DATABASE App DEFAULT CHARSET=utf8mb4; USE App; CREATE TABLE MyTable (Id INT PRIMARY KEY, NewCol INT);"
+	p := planFor(t, from, to, NormalizerFor(MySQL80))
+	sql := p.SQL()
+	if !strings.Contains(sql, "`App`.`MyTable`") {
+		t.Errorf("table identifier must preserve case `App`.`MyTable`, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "`App`.`Goner`") {
+		t.Errorf("drop must preserve case `App`.`Goner`, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "`mytable`") || strings.Contains(sql, "`app`.`goner`") {
+		t.Errorf("lower-cased identity key leaked into DDL:\n%s", sql)
+	}
+}
+
+// Blocker #1: when both a generated column and a plain column it references are dropped, the
+// generated column must be dropped FIRST (MySQL error 3108 otherwise).
+func TestMigration_GeneratedColumnDroppedBeforeBase(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT, z INT GENERATED ALWAYS AS (a+1) STORED);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY);"
+	p := planFor(t, from, to, NormalizerFor(MySQL80))
+	posA, posZ := -1, -1
+	for i, op := range p.Ops {
+		if op.Type == OpDropColumn && strings.Contains(op.SQL, "`a`") {
+			posA = i
+		}
+		if op.Type == OpDropColumn && strings.Contains(op.SQL, "`z`") {
+			posZ = i
+		}
+	}
+	if posA < 0 || posZ < 0 {
+		t.Fatalf("expected both column drops, got:\n%s", p.SQL())
+	}
+	if posZ > posA {
+		t.Errorf("generated column `z` must be dropped before base column `a`:\n%s", p.SQL())
+	}
+}
+
+// Blocker #2: a generated-column storage-mode flip (VIRTUAL↔STORED) must be rendered as
+// DROP + ADD, never an in-place MODIFY (MySQL error 3106).
+func TestMigration_GeneratedStorageFlipIsDropAdd(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+1) VIRTUAL);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+1) STORED);"
+	p := planFor(t, from, to, NormalizerFor(MySQL80))
+	var sawDrop, sawAdd, sawModify bool
+	for _, op := range p.Ops {
+		switch op.Type {
+		case OpDropColumn:
+			if strings.Contains(op.SQL, "`g`") {
+				sawDrop = true
+			}
+		case OpAddColumn:
+			if strings.Contains(op.SQL, "`g`") {
+				sawAdd = true
+			}
+		case OpModifyColumn:
+			if strings.Contains(op.SQL, "`g`") {
+				sawModify = true
+			}
+		}
+	}
+	if sawModify {
+		t.Errorf("storage-mode flip must not use MODIFY:\n%s", p.SQL())
+	}
+	if !sawDrop || !sawAdd {
+		t.Errorf("storage-mode flip must emit DROP + ADD, got drop=%v add=%v:\n%s", sawDrop, sawAdd, p.SQL())
+	}
+	// The re-added column must carry the NEW storage mode (STORED) and its generation expr.
+	for _, op := range p.Ops {
+		if op.Type == OpAddColumn && strings.Contains(op.SQL, "`g`") {
+			if !strings.Contains(op.SQL, "STORED") || !strings.Contains(op.SQL, "GENERATED ALWAYS AS") {
+				t.Errorf("re-added generated column must render the new STORED generation clause:\n%s", op.SQL)
+			}
+		}
+	}
+}
+
+// A generation EXPRESSION change with the SAME storage mode is a normal MODIFY (not DROP+ADD).
+func TestMigration_GeneratedExprChangeIsModify(t *testing.T) {
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+1) STORED);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, a INT, g INT GENERATED ALWAYS AS (a+2) STORED);"
+	op := onlyOp(t, planFor(t, from, to, NormalizerFor(MySQL80)))
+	if op.Type != OpModifyColumn {
+		t.Fatalf("generation-expr change (same storage) must be MODIFY, got %s:\n%s", op.Type, op.SQL)
+	}
+}
+
+// Review re-round N2: when a generated column is re-added (storage flip) in the same plan as a
+// MODIFY of a base column it references, the generated ADD must come AFTER the base MODIFY — even
+// when the generated name sorts lexicographically before the base name (g < z). The generated
+// column's higher add-priority enforces this.
+func TestMigration_GeneratedAddAfterBaseModify(t *testing.T) {
+	// `g` (generated, refs z) sorts before `z`; flip g VIRTUAL->STORED and widen z's type.
+	from := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, g INT GENERATED ALWAYS AS (z+1) VIRTUAL, z SMALLINT);"
+	to := dbDDL + "CREATE TABLE t (id INT PRIMARY KEY, g INT GENERATED ALWAYS AS (z+1) STORED, z BIGINT);"
+	p := planFor(t, from, to, NormalizerFor(MySQL80))
+	posGAdd, posZMod := -1, -1
+	for i, op := range p.Ops {
+		if op.Type == OpAddColumn && strings.Contains(op.SQL, "`g`") {
+			posGAdd = i
+		}
+		if op.Type == OpModifyColumn && strings.Contains(op.SQL, "`z`") {
+			posZMod = i
+		}
+	}
+	if posGAdd < 0 || posZMod < 0 {
+		t.Fatalf("expected generated `g` ADD and base `z` MODIFY, got:\n%s", p.SQL())
+	}
+	if posGAdd < posZMod {
+		t.Errorf("generated `g` ADD must come after base `z` MODIFY:\n%s", p.SQL())
+	}
+}
+
+// sortMigrationOps must be a pure, stable function of its input ordering for equal keys.
+func TestSortMigrationOps_StableAndPhased(t *testing.T) {
+	ops := []MigrationOp{
+		{Type: OpAddColumn, Phase: PhaseMain, Priority: priorityColumn, sortName: "d.t.b", SQL: "B"},
+		{Type: OpDropTable, Phase: PhasePre, Priority: priorityTable, sortName: "d.z", SQL: "DROPZ"},
+		{Type: OpAddColumn, Phase: PhaseMain, Priority: priorityColumn, sortName: "d.t.a", SQL: "A"},
+		{Type: OpCreateTable, Phase: PhaseMain, Priority: priorityTable, sortName: "d.t", SQL: "CREATE"},
+	}
+	got := sortMigrationOps(ops)
+	gotOrder := make([]string, len(got))
+	for i, op := range got {
+		gotOrder[i] = op.SQL
+	}
+	want := []string{"DROPZ", "CREATE", "A", "B"} // pre, then table-priority, then column a<b
+	if strings.Join(gotOrder, ",") != strings.Join(want, ",") {
+		t.Errorf("sortMigrationOps order = %v, want %v", gotOrder, want)
+	}
+}


### PR DESCRIPTION
## What

Adds the MySQL declarative-schema (SDL) **migration generator** — `GenerateMigration(from, to, diff) *MigrationPlan` — which turns a `SchemaDiff` (from the merged diff-core node) into ordered, canonical MySQL DDL. This is the last omni node of the single-table vertical slice; its terminal output (`MigrationPlan.SQL()`) is what bytebase's `mysqlDiffSDLMigration` will call.

Contract: `docs/migration/mysql/sdl/contract.md` §1 (the `GenerateMigration` / `MigrationPlan` / `MigrationOp` / `sortMigrationOps` rows). It mirrors the PostgreSQL reference *shape* (`pg/catalog/migration.go` + `migration_{table,column}.go`), re-expressed in MySQL identity (`database.table.column`, no OIDs/namespaces).

## Surface (this node)

- **`MigrationPlan`** `{ Ops []MigrationOp }` with **`SQL()`** (ops joined `;\n`; empty plan → `""`) and **`Filter(fn)`** (bytebase strips ops it won't apply), plus `HasWarnings`/`Warnings`.
- **`MigrationOp`** `{ Type, Database, ObjectName, SQL, Warning, ParentObject, Phase, Priority, … }` and the MySQL **`MigrationOpType`** set: `OpCreateTable` / `OpDropTable` / `OpAlterTable` / `OpAddColumn` / `OpDropColumn` / `OpModifyColumn`, plus reserved breadth keys (index/FK/constraint/check/view/routine/trigger/event).
- **`GenerateMigration(from, to, diff)`** — defaults to the 8.0 canonical form, seeding `explicit_defaults_for_timestamp` from `to` exactly like diff-core's `Diff`; and the version-aware workhorse **`GenerateMigrationWithNormalizer(from, to, diff, n)`** (the `Diff`/`DiffWithNormalizer` split, so callers that know the target version — bytebase, the oracle tests where 5.7-vs-8.0 stored forms diverge — pin the version the rendered DDL must reproduce).
- **Table DDL** (`migration_table.go`): full canonical `CREATE TABLE` (columns + table options + inline PRIMARY KEY), `DROP TABLE`, and table-option `ALTER TABLE` (ENGINE / CHARSET / COLLATE / COMMENT / significant ROW_FORMAT).
- **Column DDL** (`migration_column.go`): `ALTER TABLE … ADD / DROP / MODIFY COLUMN` — MySQL **MODIFY** (whole-column redefine), not PG's incremental `ALTER COLUMN … TYPE`.
- **`sortMigrationOps`** — deterministic ordering: phase (`PhasePre` drops < `PhaseMain` creates/alters < `PhasePost`), then priority, then `database.table[.column]`, then stable original order. Determinism is required for idempotence/round-trip stability.
- **Wired-but-empty breadth hooks** for indexes / FKs / constraints / checks / views / routines / triggers / events / partitions, matching the empty `SchemaDiff` slices diff-core left — a breadth node fills its slice and its hook with no change here.

## Canonical rendering (no diff-noise)

Every column/type/option is rendered through normalize-core's canonical forms — `CanonicalColumnType`, `ResolveColumnCharsetCollation` (version-flagged echo rules), `CanonicalNotNull` (PK + TIMESTAMP magic), `CanonicalTimestampDefaults`, `CanonicalEngine`, `CanonicalComment`, `IgnoreRowFormat` — **not** by re-stringifying surface DDL. Because the emitted DDL *is* the canonical stored form for the target version, **apply-correctness holds by construction**, and a no-op diff yields an **empty** plan. The table-level `AUTO_INCREMENT=N` counter is never emitted (ignore-in-diff); the column `AUTO_INCREMENT` attribute is.

## Proof — live oracle, both versions (MySQL 5.7.25 + 8.0.32)

Per `docs/migration/mysql/sdl/correctness-protocol.md`, both gates are proven against real MySQL (`migration_oracle_test.go`, gated like the merged `diff_oracle_test.go` / `normalize_oracle_test.go`, skips cleanly when unreachable). **113 oracle subtests pass across both engines; 2 skip** (a pre-existing malformed `comment` fixture in diff-core's shared corpus, not this node).

- **Apply-correctness** — for representative `(from, to)` pairs: build a real DB in state `from`, run `GenerateMigration(from,to).SQL()`, then `SHOW CREATE` and assert the result canonicalizes equal to `to` (both directions). Covers: create table, drop table, add column, drop column, modify column (type incl. 5.7-vs-8.0 width, nullability, default, charset/collation, generated, auto_increment, comment), table-option change (engine/charset/comment/row_format), invisible + collate-only columns.
- **Idempotence (the spine)** — for every high-risk form: `from == to` → **empty** plan (`SQL() == ""`), plus the full round-trip (apply → dump → reload → diff → generate → empty).

## Cross-family review

Claude `/code-review` + Codex `/codex:review`, parallel and blind. All blockers fixed and **re-proven on the oracle**:
- generated columns are dropped **before**, and added **after**, the plain columns their expressions reference (MySQL rejects the dependency-violating order);
- a `VIRTUAL`↔`STORED` storage-mode flip is rendered as **DROP + ADD** (in-place MODIFY is rejected by MySQL);
- table identifiers preserve the **declared casing** (correct on case-sensitive `lower_case_table_names=0` servers).

One documented scope-boundary limitation: an AUTO_INCREMENT column whose only key is a non-PK UNIQUE index needs that key from the index breadth node (UNIQUE indexes aren't in the table/column diff); the dominant AUTO_INCREMENT-as-PRIMARY-KEY case is rendered and oracle-proven.

## Scope / follow-ups

Tables + columns only. Index / FK / constraint / check / view / trigger / routine / event / partition DDL are breadth nodes (hooks wired, empty). The full SDL release round-trip lands with the bytebase wiring (gomod-bump → register-diff-sdl → sdlformat-dump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
