### PR TITLE
fix(mysql/catalog): make SDL diff/generate version-aware (5.7 vs 8.0)

### DIFF
--- a/mysql/catalog/catalog.go
+++ b/mysql/catalog/catalog.go
@@ -22,6 +22,13 @@ type SessionState struct {
 	CollationConnection          string
 	ExplicitDefaultsForTimestamp bool
 	SQLMode                      string
+	// Version is the MySQL major version (MySQL57/MySQL80) whose stored form the
+	// diff/generate canonicalizer must reproduce. It defaults to MySQL80 so an
+	// unset catalog keeps the historical 8.0 behavior; bytebase sets it from the
+	// synced database's server version before diffing a 5.7 schema so a bare
+	// CHARSET=utf8mb4 does not phantom-diff against the 8.0 default collation, and
+	// so generated DDL never emits a collation (utf8mb4_0900_ai_ci) that 5.7 lacks.
+	Version Version
 }
 
 func New() *Catalog {
@@ -46,6 +53,9 @@ func defaultSessionState() SessionState {
 		CollationConnection:          "utf8mb4_0900_ai_ci",
 		ExplicitDefaultsForTimestamp: true,
 		SQLMode:                      "DEFAULT",
+		// Default to the modern 8.0 stored form (Version's zero value is MySQL57, so
+		// this MUST be set explicitly to preserve the historical default behavior).
+		Version: MySQL80,
 	}
 }
 
@@ -57,6 +67,16 @@ func (c *Catalog) SetForeignKeyChecks(v bool) {
 	c.foreignKeyChecks = v
 	c.session.ForeignKeyChecks = v
 }
+
+// Version returns the MySQL major version whose stored form this catalog's diff and
+// generate paths canonicalize against (default MySQL80).
+func (c *Catalog) Version() Version { return c.session.Version }
+
+// SetVersion fixes the MySQL major version (MySQL57/MySQL80) whose stored form the
+// diff/generate canonicalizer reproduces for this catalog. bytebase's
+// mysqlDiffSDLMigration sets it from the synced database's server version so a
+// 5.7-synced schema canonicalizes (and generates DDL) as 5.7 rather than 8.0.
+func (c *Catalog) SetVersion(v Version) { c.session.Version = v }
 
 func (c *Catalog) SetCurrentDatabase(name string) { c.currentDB = name }
 func (c *Catalog) CurrentDatabase() string        { return c.currentDB }

--- a/mysql/catalog/diff.go
+++ b/mysql/catalog/diff.go
@@ -212,15 +212,17 @@ func (d *SchemaDiff) IsEmpty() bool {
 // ---------------------------------------------------------------------------
 
 // Diff compares two catalog states (from = old/current, to = new/target) and returns
-// all differences, using the modern MySQL 8.0 canonical form by default. The
-// explicit_defaults_for_timestamp value is taken from the `to` catalog's session when
-// it carries one (the synced schema records the source server's effective setting),
-// so bare-TIMESTAMP nullability canonicalizes correctly without a version override.
+// all differences, canonicalizing against the version recorded on the `to` catalog's
+// session (default MySQL 8.0). Both the version and the explicit_defaults_for_timestamp
+// value are taken from the `to` catalog's session — the synced schema records the source
+// server's version and effective settings — so a 5.7-synced schema is diffed in 5.7
+// stored form (a bare CHARSET=utf8mb4 resolves to utf8mb4_general_ci, not the 8.0
+// default) without a separate version override.
 //
-// Diff is the contract entry point (pg/catalog/diff.go:210). Callers that know the
-// target server version — bytebase's mysqlDiffSDLMigration and the oracle tests, where
-// 5.7-vs-8.0 stored forms genuinely diverge — should use DiffWithNormalizer to select
-// the version whose stored form the canonicalizer must reproduce.
+// Diff is the contract entry point (pg/catalog/diff.go:210). Callers that need to fix
+// the version explicitly (the oracle tests, where 5.7-vs-8.0 stored forms genuinely
+// diverge) can still use DiffWithNormalizer; bytebase's mysqlDiffSDLMigration sets the
+// version on the catalog via SetVersion/LoadSDLWithVersion and uses this entry point.
 func Diff(from, to *Catalog) *SchemaDiff {
 	return DiffWithNormalizer(from, to, defaultNormalizer(to))
 }
@@ -249,15 +251,18 @@ func DiffWithNormalizer(from, to *Catalog, n *Normalizer) *SchemaDiff {
 	}
 }
 
-// defaultNormalizer builds the Normalizer used by the parameterless Diff: MySQL 8.0
-// stored form, seeded from the `to` catalog's captured explicit_defaults_for_timestamp
-// when available. Using `to` (the target/desired schema, which on the release path is
-// re-loaded from the source's synced metadata) keeps the EDFT value aligned with the
-// server whose stored form we must match.
+// defaultNormalizer builds the Normalizer used by the parameterless Diff/Generate,
+// taking BOTH the target MySQL version and explicit_defaults_for_timestamp from the
+// `to` catalog's session. `to` is the target/desired schema, which on the release path
+// is re-loaded from the source's synced metadata, so its session carries the source
+// server's version and EDFT — exactly the stored form the canonicalizer must match. A
+// nil `to` falls back to MySQL80 (the historical default), so existing 8.0 callers that
+// never set a version are unaffected.
 func defaultNormalizer(to *Catalog) *Normalizer {
-	n := NormalizerFor(MySQL80)
-	if to != nil {
-		n.ExplicitDefaultsForTimestamp = to.session.ExplicitDefaultsForTimestamp
+	if to == nil {
+		return NormalizerFor(MySQL80)
 	}
+	n := NormalizerFor(to.session.Version)
+	n.ExplicitDefaultsForTimestamp = to.session.ExplicitDefaultsForTimestamp
 	return n
 }

--- a/mysql/catalog/migration_column.go
+++ b/mysql/catalog/migration_column.go
@@ -213,12 +213,23 @@ func formatColumnDefinition(tbl *Table, c *Column, n *Normalizer) string {
 		if cs != tcs {
 			b.WriteString(" CHARACTER SET ")
 			b.WriteString(cs)
-			if coll != "" {
+			// The column declares a DIFFERENT charset than the table, so it cannot inherit the
+			// table COLLATE; a bare `CHARACTER SET cs` falls back to cs's SERVER default. Emit
+			// COLLATE only when the target collation is NOT that charset's version default — so
+			// a column whose collation IS the default renders no COLLATE (valid on 5.7 and 8.0,
+			// never naming a collation the target lacks), while a non-default one is explicit.
+			if coll != "" && !n.isCharsetDefaultCollation(cs, coll) {
 				b.WriteString(" COLLATE ")
 				b.WriteString(coll)
 			}
 		} else if coll != "" && coll != tcoll {
-			// Same charset as table but a non-inherited collation → COLLATE only.
+			// Same charset as the table but a collation that differs from what the column would
+			// INHERIT from the table (tcoll) → emit COLLATE. The comparison is against the
+			// table's effective collation, NOT the charset default: when the table itself
+			// carries a non-default collation, a column at the charset default still differs
+			// from the table and MUST be rendered explicitly, or it would wrongly inherit the
+			// table's collation on apply (non-convergent). tcoll is already the version-correct
+			// effective table collation, so this stays version-robust.
 			b.WriteString(" COLLATE ")
 			b.WriteString(coll)
 		}

--- a/mysql/catalog/migration_table.go
+++ b/mysql/catalog/migration_table.go
@@ -116,7 +116,12 @@ func tableOptionAlterOp(database, name string, from, to *Table, n *Normalizer) (
 		if cs != "" {
 			clauses = append(clauses, "DEFAULT CHARSET="+cs)
 		}
-		if coll != "" {
+		// Emit COLLATE only for a non-default collation. When `coll` is the charset's
+		// version default it is redundant — and emitting it risks naming a collation the
+		// target server lacks (utf8mb4_0900_ai_ci does not exist on 5.7). Omitting it lets
+		// the server apply its own default, which is valid on either version and reads back
+		// canonically equal (entry utf8mb4-default-collation).
+		if coll != "" && !n.isCharsetDefaultCollation(cs, coll) {
 			clauses = append(clauses, "COLLATE="+coll)
 		}
 	}
@@ -267,7 +272,10 @@ func formatCreateTableOptions(tbl *Table, n *Normalizer) string {
 
 	if cs := foldCharset(tbl.Charset); cs != "" {
 		parts = append(parts, "DEFAULT CHARSET="+cs)
-		if coll := n.effectiveTableCollation(tbl); coll != "" {
+		// Emit COLLATE only for a non-default collation (see tableOptionAlterOp): a bare
+		// CHARSET table renders no COLLATE, so the server applies its version default and
+		// the DDL is valid on both 5.7 and 8.0 (never naming a missing utf8mb4_0900_ai_ci).
+		if coll := n.effectiveTableCollation(tbl); coll != "" && !n.isCharsetDefaultCollation(cs, coll) {
 			parts = append(parts, "COLLATE="+coll)
 		}
 	}

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -184,23 +184,53 @@ func (n *Normalizer) ResolveColumnCharsetCollation(table *Table, c *Column) (cha
 }
 
 // effectiveTableCollation returns the table's collation, folded and re-resolved to the
-// target version. The omni loader bakes the 8.0 charset-default collation into
-// table.Collation when the table has no explicit COLLATE clause (it cannot know the
-// target version at load time). We detect that case — table.Collation equals the 8.0
-// default for table.Charset — and substitute the version-correct default; an explicit,
-// non-default table COLLATE is honored as-is.
+// target version. Two distinct "this is really the charset default" cases must both
+// collapse onto the version-correct default so a bare CHARSET table never phantom-diffs:
+//
+//   - The omni loader bakes the STATIC (8.0) charset-default collation into
+//     table.Collation when the table has no explicit COLLATE (it cannot know the target
+//     version at load time) — so a user's `... DEFAULT CHARSET=utf8mb4` arrives carrying
+//     utf8mb4_0900_ai_ci even when the target is 5.7.
+//   - The SYNCED side is dumped by MetadataToSDL with the server's STORED default spelled
+//     out as an explicit COLLATE (a 5.7 utf8mb4 table reads back
+//     `DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`) — so it arrives carrying the
+//     version's stored default as an "explicit" clause.
+//
+// Both are the charset default for SOME version and are indistinguishable from a bare
+// charset on the engine, so we fold any collation equal to either the loader-baked
+// static default OR the version-appropriate default down to defaultCollationFor. A
+// genuinely non-default table COLLATE (e.g. utf8mb4_unicode_ci) is honored as-is.
 func (n *Normalizer) effectiveTableCollation(table *Table) string {
 	tableCharset := foldCharset(table.Charset)
 	tableCollation := foldCollation(table.Collation)
 	if tableCollation == "" {
 		return n.defaultCollationFor(tableCharset)
 	}
-	// If the stored table collation is the 8.0 charset default, the table had no explicit
-	// COLLATE (the loader filled the 8.0 default); re-resolve to the version default.
-	if tableCharset == "utf8mb4" && tableCollation == "utf8mb4_0900_ai_ci" {
-		return n.defaultCollationFor("utf8mb4")
+	if n.isCharsetDefaultCollation(tableCharset, tableCollation) {
+		return n.defaultCollationFor(tableCharset)
 	}
 	return tableCollation
+}
+
+// isCharsetDefaultCollation reports whether folded collation `coll` is "the default" for
+// folded charset `cs` for the purpose of effective-collation resolution: it matches
+// either the version-appropriate default (defaultCollationFor) or the static collation
+// the omni loader bakes for a bare charset (the 8.0 default, from
+// defaultCollationForCharset). The utf8mb4 case is the only one whose default diverges by
+// version (5.7 utf8mb4_general_ci vs 8.0 utf8mb4_0900_ai_ci); folding both spellings keeps
+// a 5.7-synced `COLLATE=utf8mb4_general_ci` and a loader-baked `utf8mb4_0900_ai_ci` equal
+// to each other and to a bare charset under either version's normalizer.
+func (n *Normalizer) isCharsetDefaultCollation(cs, coll string) bool {
+	if coll == "" {
+		return true
+	}
+	if coll == n.defaultCollationFor(cs) {
+		return true
+	}
+	if baked, ok := defaultCollationForCharset[cs]; ok && coll == foldCollation(baked) {
+		return true
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/mysql/catalog/sdl.go
+++ b/mysql/catalog/sdl.go
@@ -45,7 +45,27 @@ import (
 // before executing that statement. foreign_key_checks is likewise held off for
 // the entire load regardless of any SET inside the SDL.
 func LoadSDL(sql string) (*Catalog, error) {
+	return LoadSDLWithVersion(sql, MySQL80)
+}
+
+// LoadSDLWithVersion is LoadSDL with an explicit target MySQL version recorded on the
+// returned catalog's session. The version does not change how the SDL is parsed or how
+// objects are stored (the loader always bakes the static 8.0 default collation for a
+// bare CHARSET); it is the version the later Diff/GenerateMigration canonicalize
+// against. bytebase passes the synced database's server version so a 5.7 schema is
+// diffed and rendered as 5.7. LoadSDL delegates here with MySQL80 to preserve the
+// historical default.
+//
+// Setting the version also seeds the session's explicit_defaults_for_timestamp to that
+// version's SERVER-BOX default (OFF on 5.7, ON on 8.0), because a synced schema dumped to
+// SDL carries no `SET explicit_defaults_for_timestamp` and otherwise the session would
+// keep New()'s 8.0 default — making a bare TIMESTAMP synced from 5.7 phantom-diff. EDFT
+// remains a session variable, not a version trait: an explicit `SET` inside the SDL is
+// processed after this and still wins (exec.go), so a captured non-box value is honored.
+func LoadSDLWithVersion(sql string, version Version) (*Catalog, error) {
 	c := New()
+	c.SetVersion(version)
+	c.session.ExplicitDefaultsForTimestamp = NormalizerFor(version).ExplicitDefaultsForTimestamp
 
 	list, err := mysqlparser.Parse(sql)
 	if err != nil {

--- a/mysql/catalog/version_dispatch_test.go
+++ b/mysql/catalog/version_dispatch_test.go
@@ -1,0 +1,379 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Version-dispatch tests for the MySQL SDL catalog (node omni:version-dispatch).
+//
+// The bug these lock in: the catalog had no notion of server version, so the diff/generate
+// canonicalizer always assumed 8.0. A bare `CHARSET=utf8mb4` synced from a 5.7 server is
+// dumped (by bytebase MetadataToSDL) as `DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`
+// (the 5.7 stored default), while the user's target DDL `... DEFAULT CHARSET=utf8mb4` (no
+// COLLATE) is loaded carrying the loader-baked STATIC 8.0 default `utf8mb4_0900_ai_ci`. Under
+// an 8.0-only normalizer the two resolve to different collations -> a phantom table-collation
+// diff that cascades into inherited varchar columns, and the generated DDL emits
+// `COLLATE=utf8mb4_0900_ai_ci` — a collation that DOES NOT EXIST on 5.7 (Error 1273).
+//
+// The version-correct defaults are oracle-verified (SHOW COLLATION ... Default='Yes'):
+//   utf8mb4 -> utf8mb4_general_ci (5.7) vs utf8mb4_0900_ai_ci (8.0)
+//   utf8/utf8mb3 -> utf8mb3_general_ci ; latin1 -> latin1_swedish_ci (both stable)
+
+// loadOneTableWithVersion loads a CREATE TABLE wrapped in a database with the given server
+// charset and records the target version on the catalog (the bytebase wiring path:
+// LoadSDLWithVersion). It returns the catalog + the named table.
+func loadTableVersioned(t *testing.T, serverCharset, createSQL, table string, v Version) (*Catalog, *Table) {
+	t.Helper()
+	wrapped := fmt.Sprintf("CREATE DATABASE vdb DEFAULT CHARSET=%s;\nUSE vdb;\n%s", serverCharset, createSQL)
+	cat, err := LoadSDLWithVersion(wrapped, v)
+	if err != nil {
+		t.Fatalf("LoadSDLWithVersion(%v) failed for %q: %v", v, createSQL, err)
+	}
+	var tbl *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable(table); tt != nil {
+			tbl = tt
+			break
+		}
+	}
+	if tbl == nil {
+		t.Fatalf("table %q not found after load of %q", table, createSQL)
+	}
+	return cat, tbl
+}
+
+// --- Unit proof (no live engine): the exact phantom-diff scenario --------------------
+
+// TestVersionDispatch_BareCharsetNoPhantom is the headline unit proof. It reproduces the
+// bug's two input forms and asserts the diff is EMPTY under BOTH versions' normalizers:
+//   - synced/stored form: bare CHARSET=utf8mb4 with the version's stored default COLLATE
+//     spelled out (as MetadataToSDL emits), differing per version.
+//   - target/user form: bare CHARSET=utf8mb4 (no COLLATE) — loader bakes the static 8.0
+//     default regardless of version.
+func TestVersionDispatch_BareCharsetNoPhantom(t *testing.T) {
+	const userTarget = "CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(50)) DEFAULT CHARSET=utf8mb4"
+
+	cases := []struct {
+		version    Version
+		syncedDump string // what MetadataToSDL emits for this version's synced table
+	}{
+		{
+			version:    MySQL57,
+			syncedDump: "CREATE TABLE t (id INT NOT NULL, name VARCHAR(50) DEFAULT NULL, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci",
+		},
+		{
+			version:    MySQL80,
+			syncedDump: "CREATE TABLE t (id INT NOT NULL, name VARCHAR(50) DEFAULT NULL, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		},
+	}
+
+	for _, c := range cases {
+		v := c.version
+		t.Run(versionName(v), func(t *testing.T) {
+			n := NormalizerFor(v)
+			// serverCharset must match the version box default so inheritance resolves the
+			// same way on both sides (utf8mb4 on the 8.0 box, latin1 on the 5.7 box) — but the
+			// tables here declare their own utf8mb4 charset, so it is moot; use the box default.
+			sc := serverCharsetFor(v)
+
+			fromCat, fromTbl := loadTableVersioned(t, sc, c.syncedDump, "t", v)
+			toCat, toTbl := loadTableVersioned(t, sc, userTarget, "t", v)
+
+			// effectiveTableCollation must collapse both forms onto the version default.
+			wantColl := n.defaultCollationFor("utf8mb4")
+			if got := n.effectiveTableCollation(fromTbl); got != wantColl {
+				t.Errorf("[%s] synced-dump effectiveTableCollation = %q, want %q", versionName(v), got, wantColl)
+			}
+			if got := n.effectiveTableCollation(toTbl); got != wantColl {
+				t.Errorf("[%s] user-target effectiveTableCollation = %q, want %q", versionName(v), got, wantColl)
+			}
+
+			// The full diff (both directions) must be EMPTY — no phantom table-option ALTER
+			// and no cascaded column MODIFY.
+			if d := DiffWithNormalizer(fromCat, toCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] PHANTOM DIFF synced->target not empty:\n  %s", versionName(v), describeDiff(d))
+			}
+			if d := DiffWithNormalizer(toCat, fromCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] PHANTOM DIFF target->synced not empty:\n  %s", versionName(v), describeDiff(d))
+			}
+
+			// And via the version-on-catalog entry point (Diff reads to.session.Version),
+			// which is exactly how bytebase calls it.
+			if d := Diff(fromCat, toCat); !d.IsEmpty() {
+				t.Errorf("[%s] PHANTOM DIFF via Diff() (catalog version) not empty:\n  %s", versionName(v), describeDiff(d))
+			}
+		})
+	}
+}
+
+// TestVersionDispatch_DefaultVersionIs80 guards the back-compat contract: a catalog with no
+// version set canonicalizes as 8.0 (Version's zero value is MySQL57, so defaultSessionState
+// must force MySQL80).
+func TestVersionDispatch_DefaultVersionIs80(t *testing.T) {
+	c := New()
+	if c.Version() != MySQL80 {
+		t.Fatalf("New() catalog Version = %v, want MySQL80 (back-compat)", c.Version())
+	}
+	cat, err := LoadSDL("CREATE DATABASE d; USE d; CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=utf8mb4;")
+	if err != nil {
+		t.Fatalf("LoadSDL: %v", err)
+	}
+	if cat.Version() != MySQL80 {
+		t.Fatalf("LoadSDL catalog Version = %v, want MySQL80", cat.Version())
+	}
+	// defaultNormalizer(to) must therefore be 8.0.
+	if got := defaultNormalizer(cat).Version; got != MySQL80 {
+		t.Fatalf("defaultNormalizer version = %v, want MySQL80", got)
+	}
+}
+
+// TestVersionDispatch_GeneratedDDLNoMissingCollation proves the generate path never emits the
+// 5.7-missing collation for a bare-charset table/column: the rendered CREATE/ALTER carries no
+// COLLATE for a default-collation charset, so it is valid on either version.
+func TestVersionDispatch_GeneratedDDLNoMissingCollation(t *testing.T) {
+	// from: empty; to: a bare CHARSET=utf8mb4 table (CREATE TABLE rendering).
+	for _, v := range both() {
+		t.Run(versionName(v), func(t *testing.T) {
+			n := NormalizerFor(v)
+			sc := serverCharsetFor(v)
+			toCat, _ := loadTableVersioned(t, sc,
+				"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(50)) DEFAULT CHARSET=utf8mb4", "t", v)
+			fromCat := New()
+			fromCat.SetVersion(v)
+
+			diff := DiffWithNormalizer(fromCat, toCat, n)
+			plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+			sql := plan.SQL()
+			if strings.Contains(sql, "utf8mb4_0900_ai_ci") {
+				t.Errorf("[%s] generated DDL names utf8mb4_0900_ai_ci (invalid on 5.7):\n%s", versionName(v), sql)
+			}
+			// A bare CHARSET table renders DEFAULT CHARSET=utf8mb4 but NO COLLATE clause.
+			if strings.Contains(strings.ToUpper(sql), "COLLATE") {
+				t.Errorf("[%s] bare-charset CREATE should emit no COLLATE, got:\n%s", versionName(v), sql)
+			}
+		})
+	}
+}
+
+func versionName(v Version) string {
+	if v == MySQL80 {
+		return "8.0"
+	}
+	return "5.7"
+}
+
+// TestVersionDispatch_BareTimestampNoPhantom locks in the EDFT half of the 5.7 fix:
+// LoadSDLWithVersion seeds the session explicit_defaults_for_timestamp to the version's
+// box default (OFF on 5.7), so a bare TIMESTAMP synced from 5.7 (which the server
+// materializes to NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP) does
+// not phantom-diff against the user's bare `TIMESTAMP` target. Without the EDFT seed the
+// 5.7 catalog would keep New()'s 8.0 default (ON) and the bare TIMESTAMP would diff.
+func TestVersionDispatch_BareTimestampNoPhantom(t *testing.T) {
+	// 5.7 server stored form of a bare first TIMESTAMP under EDFT=OFF.
+	synced57 := "CREATE TABLE t (id INT NOT NULL, ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+	target := "CREATE TABLE t (id INT PRIMARY KEY, ts TIMESTAMP) DEFAULT CHARSET=utf8mb4"
+
+	from, err := LoadSDLWithVersion("CREATE DATABASE d; USE d;\n"+synced57, MySQL57)
+	if err != nil {
+		t.Fatalf("load synced: %v", err)
+	}
+	to, err := LoadSDLWithVersion("CREATE DATABASE d; USE d;\n"+target, MySQL57)
+	if err != nil {
+		t.Fatalf("load target: %v", err)
+	}
+	if from.Version() != MySQL57 {
+		t.Fatalf("from version = %v, want MySQL57", from.Version())
+	}
+	if d := Diff(from, to); !d.IsEmpty() {
+		t.Errorf("5.7 bare-TIMESTAMP no-op diff not empty:\n  %s", describeDiff(d))
+	}
+
+	// And on 8.0 a bare TIMESTAMP stays nullable (EDFT ON), so the same user target vs an
+	// 8.0 stored form (nullable, no implicit default) is also empty.
+	synced80 := "CREATE TABLE t (id INT NOT NULL, ts TIMESTAMP NULL DEFAULT NULL, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+	from80, err := LoadSDLWithVersion("CREATE DATABASE d; USE d;\n"+synced80, MySQL80)
+	if err != nil {
+		t.Fatalf("load synced80: %v", err)
+	}
+	to80, err := LoadSDLWithVersion("CREATE DATABASE d; USE d;\n"+target, MySQL80)
+	if err != nil {
+		t.Fatalf("load target80: %v", err)
+	}
+	if d := Diff(from80, to80); !d.IsEmpty() {
+		t.Errorf("8.0 bare-TIMESTAMP no-op diff not empty:\n  %s", describeDiff(d))
+	}
+}
+
+// TestVersionDispatch_EDFTExplicitSetWins proves EDFT remains a SESSION variable, not a
+// version trait: LoadSDLWithVersion seeds the session to the version box default, but an
+// explicit `SET explicit_defaults_for_timestamp` inside the SDL (processed after the seed)
+// still wins. A 5.7 schema that ran with EDFT explicitly ON must therefore leave a bare
+// TIMESTAMP nullable (no implicit NOT NULL / DEFAULT CURRENT_TIMESTAMP magic).
+func TestVersionDispatch_EDFTExplicitSetWins(t *testing.T) {
+	// 5.7 catalog (box default EDFT OFF) but the SDL carries SET ...=1 (ON).
+	sdl := "CREATE DATABASE d; USE d; SET SESSION explicit_defaults_for_timestamp=1;\n" +
+		"CREATE TABLE t (id INT PRIMARY KEY, ts TIMESTAMP)"
+	cat, err := LoadSDLWithVersion(sdl, MySQL57)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !cat.session.ExplicitDefaultsForTimestamp {
+		t.Fatalf("explicit SET ...=1 must win over the 5.7 box-default seed; session EDFT = false")
+	}
+	var tbl *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable("t"); tt != nil {
+			tbl = tt
+		}
+	}
+	if tbl == nil {
+		t.Fatal("table t not found")
+	}
+	ts := tbl.GetColumn("ts")
+	if ts == nil {
+		t.Fatal("column ts not found")
+	}
+	// EDFT ON: bare TIMESTAMP stays nullable, no implicit default materialized at load.
+	if !ts.Nullable {
+		t.Errorf("with EDFT explicitly ON, bare TIMESTAMP must stay nullable, got NOT NULL")
+	}
+	if ts.Default != nil {
+		t.Errorf("with EDFT explicitly ON, bare TIMESTAMP must have no implicit default, got %q", *ts.Default)
+	}
+	// And the diff-time normalizer (which reads the session EDFT) agrees it is nullable.
+	n := defaultNormalizer(cat)
+	if n.ExplicitDefaultsForTimestamp != true {
+		t.Errorf("defaultNormalizer EDFT = false, want true (session override)")
+	}
+	if n.CanonicalNotNull(tbl, ts) {
+		t.Errorf("CanonicalNotNull(bare TIMESTAMP) = true under EDFT ON, want false (nullable)")
+	}
+}
+
+// TestVersionDispatch_ColumnDefaultUnderNonDefaultTable locks in the COLLATE-omission
+// correctness fix (Codex blocking finding): when a table carries a NON-default collation
+// and a column's resolved collation is the charset DEFAULT, the generated column MUST
+// render an explicit COLLATE — omitting it would make the column wrongly inherit the
+// table's non-default collation on apply (non-convergent). The omission is keyed off the
+// table's effective collation (inheritance), not the charset default.
+func TestVersionDispatch_ColumnDefaultUnderNonDefaultTable(t *testing.T) {
+	for _, v := range both() {
+		t.Run(versionName(v), func(t *testing.T) {
+			n := NormalizerFor(v)
+			defColl := n.defaultCollationFor("utf8mb4")
+			// Table COLLATE=utf8mb4_unicode_ci (non-default); column at the charset default.
+			create := fmt.Sprintf(
+				"CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(20) CHARACTER SET utf8mb4 COLLATE %s) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+				defColl)
+			toCat, _ := loadTableVersioned(t, serverCharsetFor(v), create, "t", v)
+			fromCat := New()
+			fromCat.SetVersion(v)
+			diff := DiffWithNormalizer(fromCat, toCat, n)
+			plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+			sql := plan.SQL()
+			// The column line must carry an explicit COLLATE for the charset default, because
+			// the table collation differs from it.
+			if !strings.Contains(sql, "COLLATE "+defColl) && !strings.Contains(sql, "COLLATE="+defColl) {
+				t.Errorf("[%s] column at charset default under non-default table must emit explicit COLLATE %s, got:\n%s",
+					versionName(v), defColl, sql)
+			}
+		})
+	}
+}
+
+// --- Oracle proof (live engines): apply-clean on 5.7 and 8.0 -------------------------
+
+// TestOracle_VersionDispatchBareCharset is the live spine for this node. For each version it:
+//  1. applies the user target to a real DB, reads back the engine's stored form, and dumps a
+//     "synced" SDL form (bare charset + the version's explicit stored default collation —
+//     mirroring what bytebase MetadataToSDL produces);
+//  2. asserts Diff(synced, target) is EMPTY under the version normalizer (idempotence);
+//  3. generates the change DDL for a real modification, applies it to the real 5.7/8.0 DB
+//     (proving no Error 1273), and asserts convergence (re-diff empty).
+func TestOracle_VersionDispatchBareCharset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	const userTarget = "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(50)) DEFAULT CHARSET=utf8mb4"
+
+	for _, v := range both() {
+		o := connectOracle(t, v)
+		t.Run(o.name, func(t *testing.T) {
+			// (1) engine's authentic stored form of the bare-charset target.
+			readback, ok := o.showCreate(t, "vd_bare", userTarget, "t")
+			if !ok {
+				t.Skipf("[%s] no readback for bare-charset target", o.name)
+			}
+			n := NormalizerFor(v)
+			sc := serverCharsetFor(v)
+
+			// The "synced" SDL is the engine's own SHOW CREATE — the most authentic stored
+			// form, equivalent to (stricter than) MetadataToSDL's dump.
+			fromCat, _ := loadTableVersioned(t, sc, readback, "t", v)
+			toCat, _ := loadTableVersioned(t, sc, userTarget, "t", v)
+
+			// (2) idempotence: no-op diff empty, both directions, and via catalog-version Diff.
+			if d := DiffWithNormalizer(fromCat, toCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] no-op diff (stored vs target) not empty:\n  stored: %s\n  diff: %s",
+					o.name, strings.TrimSpace(readback), describeDiff(d))
+			}
+			if d := Diff(fromCat, toCat); !d.IsEmpty() {
+				t.Errorf("[%s] no-op Diff() (catalog version) not empty:\n  diff: %s", o.name, describeDiff(d))
+			}
+
+			// (3) apply-correctness of a real change: add an isbn column. Generate, apply to a
+			// real DB seeded in the stored `from` state, and confirm it applies (no Error 1273)
+			// and converges.
+			targetPlus := "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(50), isbn VARCHAR(20) NULL) DEFAULT CHARSET=utf8mb4"
+			toPlusCat, _ := loadTableVersioned(t, sc, targetPlus, "t", v)
+			diff := DiffWithNormalizer(fromCat, toPlusCat, n)
+			if diff.IsEmpty() {
+				t.Fatalf("[%s] expected a non-empty change diff for the added column", o.name)
+			}
+			plan := GenerateMigrationWithNormalizer(fromCat, toPlusCat, diff, n)
+			planSQL := plan.SQL()
+			if strings.Contains(planSQL, "utf8mb4_0900_ai_ci") && v == MySQL57 {
+				t.Errorf("[%s] change DDL names utf8mb4_0900_ai_ci (invalid on 5.7):\n%s", o.name, planSQL)
+			}
+
+			ctx := context.Background()
+			conn, err := o.db.Conn(ctx)
+			if err != nil {
+				t.Fatalf("[%s] conn: %v", o.name, err)
+			}
+			defer func() { _ = conn.Close() }()
+			const applyDB = "vdb" // loadTableVersioned wraps in database `vdb`
+			setup := []string{
+				"DROP DATABASE IF EXISTS " + applyDB,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
+				"USE " + applyDB,
+				userTarget,
+			}
+			for _, s := range setup {
+				if _, err := conn.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup failed: %q: %v", o.name, s, err)
+				}
+			}
+			for _, op := range plan.Ops {
+				if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+					t.Fatalf("[%s] APPLY FAILED (Error here on 5.7 = the bug):\n  stmt: %s\n  err: %v\n  plan:\n%s",
+						o.name, op.SQL, err, planSQL)
+				}
+			}
+			// Converge: read back, reload, re-diff against target → empty.
+			var nm, ddl string
+			if err := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.t", applyDB)).Scan(&nm, &ddl); err != nil {
+				t.Fatalf("[%s] readback after apply: %v", o.name, err)
+			}
+			resultCat, _ := loadTableVersioned(t, sc, ddl, "t", v)
+			if d := DiffWithNormalizer(resultCat, toPlusCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] apply did not converge:\n  result: %s\n  diff: %s", o.name, strings.TrimSpace(ddl), describeDiff(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What & why

The MySQL declarative-schema (SDL) catalog had **no notion of server version**, so the diff/generate canonicalizer always assumed MySQL 8.0. End-to-end smoke testing of the bytebase declarative path surfaced a real correctness bug on **MySQL 5.7**:

- A no-op declarative diff of a 5.7-synced schema was **non-empty** — e.g. `ALTER TABLE t DEFAULT CHARSET=utf8mb4, COLLATE=utf8mb4_0900_ai_ci; ALTER TABLE t MODIFY COLUMN name varchar(50) NOT NULL;`
- That generated DDL is **invalid on 5.7**: `Error 1273 (HY000): Unknown collation: 'utf8mb4_0900_ai_ci'` (that collation does not exist on 5.7).

### Root cause

A bare `CHARSET=utf8mb4` synced from 5.7 is dumped (bytebase `MetadataToSDL`) as `DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci` (the 5.7 stored default), while the user's target DDL (`... DEFAULT CHARSET=utf8mb4`, no COLLATE) is loaded carrying the loader-baked **static 8.0 default** `utf8mb4_0900_ai_ci`. Under the 8.0-only normalizer the two resolve to different collations → a phantom table-collation diff that cascades into inherited `varchar` columns, and the generator emits a 5.7-missing collation.

## The fix (version-aware catalog, end to end)

All changes are in `mysql/catalog/`:

1. **`catalog.go`** — `SessionState` gains a `Version` field (defaults to `MySQL80`); `Catalog.Version()` / `SetVersion()`.
2. **`sdl.go`** — `LoadSDLWithVersion(sql, version)` records the version and seeds the session `explicit_defaults_for_timestamp` to that version's box default (OFF on 5.7, ON on 8.0), because a 5.7-synced SDL dump carries no `SET` statement and a bare TIMESTAMP would otherwise phantom-diff. `LoadSDL` delegates with `MySQL80`, preserving the historical default. An explicit `SET explicit_defaults_for_timestamp` in the SDL still wins.
3. **`diff.go`** — `defaultNormalizer` reads the version off the `to` catalog instead of hardcoding `MySQL80` (a nil `to` → `MySQL80`). `Diff` / `GenerateMigration` therefore honor the catalog's version.
4. **`normalize.go`** — `effectiveTableCollation` + a new `isCharsetDefaultCollation(cs, coll)` fold any collation equal to the version-appropriate default **or** the loader-baked static 8.0 default down to the version default, so a bare `CHARSET=utf8mb4` canonicalizes-equal to the stored default of either version (mirroring how `utf8`↔`utf8mb3` is folded).
5. **`migration_table.go` / `migration_column.go`** — the generate path omits a `COLLATE` clause when it is the charset's version default, so a bare-charset table/column renders no COLLATE and is valid on either version (never naming `utf8mb4_0900_ai_ci` on 5.7). The column *same-charset* branch keys the omission off the table's **effective collation** (true inheritance), not the charset default — so a column at the charset default under a *non-default* table collation still emits an explicit COLLATE and stays apply-convergent.

`MySQL80` is the default everywhere a version is unset, so existing 8.0 behavior is unchanged.

## Oracle evidence (live MySQL 5.7 :13307 and 8.0 :13306)

Verified default collation per charset per version (`SHOW COLLATION ... Default='Yes'`, `information_schema.CHARACTER_SETS`):

| charset | 5.7 default | 8.0 default |
|---|---|---|
| utf8mb4 | `utf8mb4_general_ci` | `utf8mb4_0900_ai_ci` |
| utf8 / utf8mb3 | `utf8_general_ci` / `utf8mb3_general_ci` | `utf8mb3_general_ci` |
| latin1 | `latin1_swedish_ci` | `latin1_swedish_ci` |

utf8mb4 is the only charset whose default collation diverges by version. `explicit_defaults_for_timestamp` box default: **0 (OFF) on 5.7, 1 (ON) on 8.0** — also verified live.

### Proven (both versions, mechanically)

- **Idempotence**: bare-charset and bare-TIMESTAMP no-op diffs are **empty** on both 5.7 and 8.0 (`Diff(synced, target).IsEmpty()`).
- **Apply-correctness**: generated change DDL applies cleanly on real 5.7 (**no Error 1273**) and 8.0, and the re-diff converges to empty.
- **No 8.0 regression**: the full existing oracle suite (`TestOracle_*`) passes unchanged against both live engines.

Tests added in `version_dispatch_test.go` (unit + live-oracle): bare-charset round-trips empty under both `NormalizerFor(MySQL57)` and `MySQL80`; back-compat default is `MySQL80`; generated DDL never names `utf8mb4_0900_ai_ci`; bare-TIMESTAMP no-phantom; and the non-default-table-collation column case stays convergent.

Scope: `go test ./mysql/catalog/...` (short + oracle) green on both engines.

## Review

Cross-family review (Claude `/code-review` + Codex `/codex:review`, parallel, blind). Codex caught a real blocker — the column COLLATE omission was unsound when the table carried a non-default collation — confirmed non-convergent on both live engines and fixed (omission now keys off table-effective collation). A second concrete issue (the EDFT box-default seed for bare TIMESTAMP) was found and fixed. Both fixes have regression tests. Converged to 0 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
