### PR TITLE
feat(mysql/catalog): scaffold breadth diff/generate hooks (inert stubs) for parallel SDL breadth

### DIFF
--- a/mysql/catalog/diff.go
+++ b/mysql/catalog/diff.go
@@ -234,20 +234,24 @@ func Diff(from, to *Catalog) *SchemaDiff {
 // default for `to`.
 //
 // The dispatcher mirrors PG: one diffX per object kind, packed into SchemaDiff. Only
-// the table differ (which descends into columns) is implemented in diff-core; the
-// breadth slices are left nil for later nodes.
+// the table differ (which descends into columns) carries real logic; every breadth
+// differ is wired here against an inert no-op stub (returns nil) until its owning node
+// implements it, so the breadth slices stay empty and a breadth node touches only its
+// own diff_<obj>.go.
 func DiffWithNormalizer(from, to *Catalog, n *Normalizer) *SchemaDiff {
 	if n == nil {
 		n = defaultNormalizer(to)
 	}
 	return &SchemaDiff{
 		Tables: diffTables(from, to, n),
-		// Breadth extension points — populated by later nodes:
-		//   Views:      diffViews(from, to, n),
-		//   Functions:  diffFunctions(from, to, n),
-		//   Procedures: diffProcedures(from, to, n),
-		//   Triggers:   diffTriggers(from, to, n),
-		//   Events:     diffEvents(from, to, n),
+		// Breadth object kinds (database-level). Each differ is an inert no-op stub today
+		// (returns nil), so the diff stays empty until the owning breadth node implements it —
+		// a breadth node then only fills its own diff_<obj>.go.
+		Views:      diffViews(from, to, n),
+		Functions:  diffFunctions(from, to, n),
+		Procedures: diffProcedures(from, to, n),
+		Triggers:   diffTriggers(from, to, n),
+		Events:     diffEvents(from, to, n),
 	}
 }
 

--- a/mysql/catalog/diff_check.go
+++ b/mysql/catalog/diff_check.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL diff — CHECK constraints (scaffold stub).
+//
+// Wired into compareTable (diff_table.go) so a modified table reports its CHECK-constraint
+// changes via TableDiffEntry.Checks. Inert no-op placeholder returning nil until the check
+// breadth node implements the real comparison. CHECK is 8.0-only (unrepresentable on 5.7;
+// see normalize.go CheckSupported) — the breadth node gates on the Normalizer's version.
+// Signature mirrors diffColumns: per-table, taking from/to *Table and the Normalizer.
+//
+// implemented by omni:check breadth node
+func diffChecks(_, _ *Table, _ *Normalizer) []CheckDiffEntry {
+	// Scaffold: returns nil so the check sub-diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_constraint.go
+++ b/mysql/catalog/diff_constraint.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL diff — PRIMARY KEY / UNIQUE constraints (scaffold stub).
+//
+// Wired into compareTable (diff_table.go) so a modified table reports its PK/UNIQUE
+// constraint changes via TableDiffEntry.Constraints. Inert no-op placeholder returning
+// nil until the constraint breadth node implements the real comparison. Signature mirrors
+// diffColumns: per-table, taking from/to *Table and the version-fixing Normalizer.
+//
+// implemented by omni:constraint breadth node
+func diffConstraints(_, _ *Table, _ *Normalizer) []ConstraintDiffEntry {
+	// Scaffold: returns nil so the constraint sub-diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_event.go
+++ b/mysql/catalog/diff_event.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL diff — scheduled events (scaffold stub).
+//
+// Wired into DiffWithNormalizer (diff.go) so the SchemaDiff reports event changes via
+// SchemaDiff.Events. Inert no-op placeholder returning nil until the event breadth node
+// implements the real comparison. Signature mirrors diffTables (diff_table.go): whole-
+// catalog, taking from/to *Catalog and the version-fixing Normalizer (events are database-
+// level objects keyed by (database, name)).
+//
+// implemented by omni:event breadth node
+func diffEvents(_, _ *Catalog, _ *Normalizer) []EventDiffEntry {
+	// Scaffold: returns nil so the event diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_foreign_key.go
+++ b/mysql/catalog/diff_foreign_key.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL diff — foreign keys (scaffold stub).
+//
+// Wired into compareTable (diff_table.go) so a modified table reports its FK changes
+// via TableDiffEntry.ForeignKeys. Inert no-op placeholder returning nil until the FK
+// breadth node implements the real comparison. Signature mirrors diffColumns: per-table,
+// taking from/to *Table and the version-fixing Normalizer. FK identity/equality (the
+// referenced table/columns and ON DELETE/UPDATE actions) is the breadth node's concern.
+//
+// implemented by omni:foreign-key breadth node
+func diffForeignKeys(_, _ *Table, _ *Normalizer) []ForeignKeyDiffEntry {
+	// Scaffold: returns nil so the FK sub-diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_index.go
+++ b/mysql/catalog/diff_index.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL diff — secondary indexes (scaffold stub).
+//
+// Wired into compareTable (diff_table.go) so a modified table reports its index
+// changes via TableDiffEntry.Indexes. This is an inert no-op placeholder: it returns
+// nil, so the table sub-diff is unchanged until the index breadth node implements the
+// real comparison. Signature mirrors diffColumns (diff_column.go): per-table, taking
+// the from/to *Table and the version-fixing Normalizer.
+//
+// implemented by omni:index breadth node
+func diffIndexes(_, _ *Table, _ *Normalizer) []IndexDiffEntry {
+	// Scaffold: returns nil so the index sub-diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_partition.go
+++ b/mysql/catalog/diff_partition.go
@@ -1,0 +1,16 @@
+package catalog
+
+// MySQL SDL diff — table partitioning (scaffold stub).
+//
+// Wired into compareTable (diff_table.go) so a modified table records a partitioning
+// change via the TableDiffEntry.PartitionChanged flag (a bool, not a slice — MySQL
+// partitioning is a single per-table clause, compared as one PARTITION BY ... spec via
+// Table.Partitioning). Inert no-op placeholder returning false until the partition breadth
+// node implements the real comparison. Signature mirrors diffColumns: per-table, taking
+// from/to *Table and the version-fixing Normalizer.
+//
+// implemented by omni:partition breadth node
+func diffPartitions(_, _ *Table, _ *Normalizer) bool {
+	// Scaffold: returns false so PartitionChanged stays unset (self-diff inert).
+	return false
+}

--- a/mysql/catalog/diff_routine.go
+++ b/mysql/catalog/diff_routine.go
@@ -1,0 +1,24 @@
+package catalog
+
+// MySQL SDL diff — stored routines (functions + procedures) (scaffold stub).
+//
+// Two hooks, because the dispatcher (DiffWithNormalizer in diff.go) packs functions and
+// procedures into separate SchemaDiff slices (SchemaDiff.Functions / SchemaDiff.Procedures),
+// both element type RoutineDiffEntry (distinguished by RoutineDiffEntry.IsProcedure). The
+// routine breadth node fills BOTH here. Inert no-op placeholders returning nil until then.
+// Signatures mirror diffTables (diff_table.go): whole-catalog, taking from/to *Catalog and
+// the version-fixing Normalizer (routines are database-level objects keyed by (database, name)).
+//
+// implemented by omni:routine breadth node
+func diffFunctions(_, _ *Catalog, _ *Normalizer) []RoutineDiffEntry {
+	// Scaffold: returns nil so the function diff stays empty (self-diff inert).
+	return nil
+}
+
+// diffProcedures is the stored-procedure half of the routine breadth node; see diffFunctions.
+//
+// implemented by omni:routine breadth node
+func diffProcedures(_, _ *Catalog, _ *Normalizer) []RoutineDiffEntry {
+	// Scaffold: returns nil so the procedure diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_table.go
+++ b/mysql/catalog/diff_table.go
@@ -101,7 +101,15 @@ func compareTable(key tableKey, from, to *Table, n *Normalizer) (TableDiffEntry,
 		From:     from,
 		To:       to,
 		Columns:  diffColumns(from, to, n),
-		// Indexes/Constraints/ForeignKeys/Checks/PartitionChanged: populated by breadth nodes.
+		// Table-level sub-object diffs, owned by the breadth nodes (mirroring PG's
+		// compareRelation, which calls diffConstraints/diffIndexes/... inline). Each is an
+		// inert no-op stub today (returns nil/false), so the breadth node only fills its own
+		// differ — compareTable and tableSubdiffsChanged already fold the result in.
+		Indexes:          diffIndexes(from, to, n),
+		Constraints:      diffConstraints(from, to, n),
+		ForeignKeys:      diffForeignKeys(from, to, n),
+		Checks:           diffChecks(from, to, n),
+		PartitionChanged: diffPartitions(from, to, n),
 	}
 
 	if !tableOptionsChanged(from, to, n) && !tableSubdiffsChanged(&entry) {

--- a/mysql/catalog/diff_trigger.go
+++ b/mysql/catalog/diff_trigger.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL diff — triggers (scaffold stub).
+//
+// Wired into DiffWithNormalizer (diff.go) so the SchemaDiff reports trigger changes via
+// SchemaDiff.Triggers. Inert no-op placeholder returning nil until the trigger breadth node
+// implements the real comparison. Signature mirrors diffTables (diff_table.go): whole-
+// catalog, taking from/to *Catalog and the version-fixing Normalizer (MySQL triggers are
+// database-level objects keyed by (database, name), each bound to a table via Trigger.Table).
+//
+// implemented by omni:trigger breadth node
+func diffTriggers(_, _ *Catalog, _ *Normalizer) []TriggerDiffEntry {
+	// Scaffold: returns nil so the trigger diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/diff_view.go
+++ b/mysql/catalog/diff_view.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL diff — views (scaffold stub).
+//
+// Wired into DiffWithNormalizer (diff.go) so the SchemaDiff reports view changes via
+// SchemaDiff.Views. Inert no-op placeholder returning nil until the view breadth node
+// implements the real comparison. Signature mirrors diffTables (diff_table.go): whole-
+// catalog, taking from/to *Catalog and the version-fixing Normalizer (views are database-
+// level objects keyed by (database, name), not per-table).
+//
+// implemented by omni:view breadth node
+func diffViews(_, _ *Catalog, _ *Normalizer) []ViewDiffEntry {
+	// Scaffold: returns nil so the view diff stays empty (self-diff inert).
+	return nil
+}

--- a/mysql/catalog/migration.go
+++ b/mysql/catalog/migration.go
@@ -31,9 +31,10 @@ package catalog
 // Scope of THIS node (omni:generate-core): the MigrationPlan / MigrationOp types,
 // GenerateMigration dispatcher, table DDL (migration_table.go), column DDL
 // (migration_column.go), and sortMigrationOps. The breadth object kinds (indexes, FKs,
-// constraints, checks, views, triggers, routines, events, partitions) have wired-but-empty
-// generate hooks here, mirroring PG's migration_<obj>.go layout and the empty SchemaDiff
-// slices diff-core left — a breadth node fills its slice and its hook with no change here.
+// constraints, checks, views, triggers, routines, events, partitions) are wired here against
+// inert no-op generate stubs (each returns nil), mirroring PG's migration_<obj>.go layout;
+// paired with the empty breadth SchemaDiff slices they contribute no ops, so a breadth node
+// fills its slice and its hook with no change here.
 
 import (
 	"sort"
@@ -216,17 +217,19 @@ func GenerateMigrationWithNormalizer(from, to *Catalog, diff *SchemaDiff, n *Nor
 	ops = append(ops, generateTableDDL(from, to, diff, n)...)
 	ops = append(ops, generateColumnDDL(from, to, diff, n)...)
 
-	// Breadth extension points — inert until the owning node fills the SchemaDiff slice and
-	// implements the hook (mirroring PG's per-object generators and diff-core's empty slices):
-	//   ops = append(ops, generateIndexDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateConstraintDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateForeignKeyDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateCheckDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateViewDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateRoutineDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateTriggerDDL(from, to, diff, n)...)
-	//   ops = append(ops, generateEventDDL(from, to, diff, n)...)
-	//   ops = append(ops, generatePartitionDDL(from, to, diff, n)...)
+	// Breadth object kinds (mirroring PG's per-object generators and diff-core's empty slices).
+	// Each generator is an inert no-op stub today (returns nil) — the matching SchemaDiff slice
+	// is empty, so these contribute no ops and the plan stays empty on a no-op release. A breadth
+	// node fills its slice and its generator with no change here.
+	ops = append(ops, generateIndexDDL(from, to, diff, n)...)
+	ops = append(ops, generateConstraintDDL(from, to, diff, n)...)
+	ops = append(ops, generateForeignKeyDDL(from, to, diff, n)...)
+	ops = append(ops, generateCheckDDL(from, to, diff, n)...)
+	ops = append(ops, generateViewDDL(from, to, diff, n)...)
+	ops = append(ops, generateRoutineDDL(from, to, diff, n)...)
+	ops = append(ops, generateTriggerDDL(from, to, diff, n)...)
+	ops = append(ops, generateEventDDL(from, to, diff, n)...)
+	ops = append(ops, generatePartitionDDL(from, to, diff, n)...)
 
 	ops = sortMigrationOps(ops)
 

--- a/mysql/catalog/migration_check.go
+++ b/mysql/catalog/migration_check.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL generate — CHECK constraints (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so check diffs become DDL.
+// Inert no-op placeholder returning nil until the check breadth node renders the ALTER
+// TABLE ... ADD/DROP CHECK ops from TableDiffEntry.Checks (OpAddCheck/OpDropCheck). CHECK
+// is 8.0-only (see normalize.go CheckSupported); the breadth node gates on the Normalizer's
+// version. Signature mirrors generateTableDDL (migration_table.go).
+//
+// implemented by omni:check breadth node
+func generateCheckDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no check ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_constraint.go
+++ b/mysql/catalog/migration_constraint.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL generate — PRIMARY KEY / UNIQUE constraints (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so constraint diffs become DDL.
+// Inert no-op placeholder returning nil until the constraint breadth node renders the
+// ALTER TABLE ... ADD/DROP PRIMARY KEY|UNIQUE ops from TableDiffEntry.Constraints
+// (OpAddConstraint/OpDropConstraint, priorityConstraint). Signature mirrors generateTableDDL.
+//
+// implemented by omni:constraint breadth node
+func generateConstraintDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no constraint ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_event.go
+++ b/mysql/catalog/migration_event.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL generate — scheduled events (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so event diffs (SchemaDiff.Events)
+// become DDL. Inert no-op placeholder returning nil until the event breadth node renders the
+// CREATE/DROP EVENT ops (OpCreateEvent/OpDropEvent, priorityEvent). Signature mirrors
+// generateTableDDL (migration_table.go).
+//
+// implemented by omni:event breadth node
+func generateEventDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no event ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -1,0 +1,15 @@
+package catalog
+
+// MySQL SDL generate — foreign keys (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so FK diffs become DDL.
+// Inert no-op placeholder returning nil until the FK breadth node renders the ALTER
+// TABLE ... ADD/DROP FOREIGN KEY ops from TableDiffEntry.ForeignKeys. FK creation is
+// deferred to PhasePost (priorityForeignKey) so every referenced table exists first —
+// mirroring PG. Signature mirrors generateTableDDL (migration_table.go).
+//
+// implemented by omni:foreign-key breadth node
+func generateForeignKeyDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no FK ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL generate — secondary indexes (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so index diffs become DDL.
+// Inert no-op placeholder returning nil until the index breadth node renders the ALTER
+// TABLE ... ADD/DROP INDEX ops from TableDiffEntry.Indexes (OpAddIndex/OpDropIndex,
+// priorityIndex). Signature mirrors generateTableDDL (migration_table.go).
+//
+// implemented by omni:index breadth node
+func generateIndexDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no index ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_partition.go
+++ b/mysql/catalog/migration_partition.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL generate — table partitioning (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so a partitioning change
+// (TableDiffEntry.PartitionChanged) becomes DDL. Inert no-op placeholder returning nil
+// until the partition breadth node renders the ALTER TABLE ... PARTITION BY / REMOVE
+// PARTITIONING op. Signature mirrors generateTableDDL (migration_table.go).
+//
+// implemented by omni:partition breadth node
+func generatePartitionDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no partition ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_routine.go
+++ b/mysql/catalog/migration_routine.go
@@ -1,0 +1,16 @@
+package catalog
+
+// MySQL SDL generate — stored routines (functions + procedures) (scaffold stub).
+//
+// A single generate hook covers both routine kinds: wired into
+// GenerateMigrationWithNormalizer (migration.go), it consumes BOTH SchemaDiff.Functions and
+// SchemaDiff.Procedures and emits the CREATE/DROP FUNCTION|PROCEDURE ops
+// (OpCreateFunction/OpDropFunction/OpCreateProcedure/OpDropProcedure, priorityRoutine).
+// Inert no-op placeholder returning nil until the routine breadth node implements it.
+// Signature mirrors generateTableDDL (migration_table.go).
+//
+// implemented by omni:routine breadth node
+func generateRoutineDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no routine ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_trigger.go
+++ b/mysql/catalog/migration_trigger.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL generate — triggers (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so trigger diffs
+// (SchemaDiff.Triggers) become DDL. Inert no-op placeholder returning nil until the trigger
+// breadth node renders the CREATE/DROP TRIGGER ops (OpCreateTrigger/OpDropTrigger,
+// priorityTrigger). Signature mirrors generateTableDDL (migration_table.go).
+//
+// implemented by omni:trigger breadth node
+func generateTriggerDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no trigger ops (empty diff -> empty plan).
+	return nil
+}

--- a/mysql/catalog/migration_view.go
+++ b/mysql/catalog/migration_view.go
@@ -1,0 +1,14 @@
+package catalog
+
+// MySQL SDL generate — views (scaffold stub).
+//
+// Wired into GenerateMigrationWithNormalizer (migration.go) so view diffs (SchemaDiff.Views)
+// become DDL. Inert no-op placeholder returning nil until the view breadth node renders the
+// CREATE/DROP VIEW ops (OpCreateView/OpDropView, priorityView). Signature mirrors
+// generateTableDDL (migration_table.go).
+//
+// implemented by omni:view breadth node
+func generateViewDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
+	// Scaffold: returns nil so the plan gains no view ops (empty diff -> empty plan).
+	return nil
+}


### PR DESCRIPTION
## What

Wires all MySQL SDL (declarative-schema migration) **breadth dispatch hooks** against **no-op stub functions**, so the 8 downstream breadth nodes (indexes, foreign keys, constraints, checks, partitions, views, routines, triggers, events) become **purely additive single-file edits** — none of them has to touch the shared dispatcher files (`diff.go`, `diff_table.go`, `migration.go`), so they never conflict on merge.

This is an **enabling scaffold**: every stub deliberately returns `nil`/`false`. **Behavior is unchanged** — a self-diff still reports empty (`SchemaDiff.IsEmpty`) and a no-op release still emits an empty migration plan.

## Why

The merged diff-core / generate-core dispatchers left the breadth hooks commented out in contiguous blocks. If 8 breadth workers each uncommented their adjacent line in those blocks in parallel, they would conflict. Activating every hook now against inert stubs means each breadth node afterward only fills its **own** `diff_<obj>.go` / `migration_<obj>.go`.

## Changes

**New stub files** (one diff + one migration file per object kind, mirroring `pg/catalog`'s `diff_<obj>.go` / `migration_<obj>.go` layout). Each stub returns `nil`/`false` and carries an `// implemented by omni:<kind> breadth node` marker:

| Object kind | diff stub(s) → target field | generate stub |
|---|---|---|
| index | `diffIndexes` → `TableDiffEntry.Indexes` | `generateIndexDDL` |
| foreign key | `diffForeignKeys` → `TableDiffEntry.ForeignKeys` | `generateForeignKeyDDL` |
| constraint (PK/UNIQUE) | `diffConstraints` → `TableDiffEntry.Constraints` | `generateConstraintDDL` |
| check | `diffChecks` → `TableDiffEntry.Checks` | `generateCheckDDL` |
| partition | `diffPartitions` → `TableDiffEntry.PartitionChanged` (`bool`) | `generatePartitionDDL` |
| view | `diffViews` → `SchemaDiff.Views` | `generateViewDDL` |
| routine | `diffFunctions` → `SchemaDiff.Functions`, `diffProcedures` → `SchemaDiff.Procedures` | `generateRoutineDDL` (consumes both) |
| trigger | `diffTriggers` → `SchemaDiff.Triggers` | `generateTriggerDDL` |
| event | `diffEvents` → `SchemaDiff.Events` | `generateEventDDL` |

**Wiring** (the only edits to shared dispatcher files):
- `diff.go` `DiffWithNormalizer` — calls the 5 database-level diff stubs into the `SchemaDiff` breadth slices.
- `diff_table.go` `compareTable` — calls the 5 table-level diff stubs into the `TableDiffEntry` sub-object slices / `PartitionChanged`, mirroring PG's `compareRelation`. `tableSubdiffsChanged` already folds them into the modified-table decision.
- `migration.go` `GenerateMigrationWithNormalizer` — appends all 9 `generate<obj>DDL` hooks.

## Signatures (stable contract for breadth nodes)

Matched to the existing sibling pattern (`diffColumns`, `diffTables`, `generateTableDDL`):

- Table-level diff: `func diffX(from, to *Table, n *Normalizer) []XDiffEntry` (`diffPartitions` returns `bool`).
- Catalog-level diff: `func diffX(from, to *Catalog, n *Normalizer) []XDiffEntry`.
- All generate: `func generateXDDL(from, to *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp`.

The per-object diff-entry types and the `SchemaDiff`/`TableDiffEntry` fields were defined upstream by diff-core; this PR adds **only** the stub functions and the wiring.

## Testing

- `go build ./mysql/catalog/...` — green
- `go vet ./mysql/catalog/...` — clean
- `gofmt -l` on all 21 changed files — clean
- `golangci-lint run` — **0 new issues** (baseline count identical with and without this change)
- `go test ./mysql/catalog/...` — all existing tests pass (the authoritative inert-behavior proof: stubs returning nil cannot change diff/plan output, so the existing diff/migration assertions still hold)

Reviewed cross-family (Claude `/code-review` + Codex `/codex:review`): 0 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)