### PR TITLE
feat(mysql/catalog): implement index diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_index.go
+++ b/mysql/catalog/diff_index.go
@@ -1,15 +1,302 @@
 package catalog
 
-// MySQL SDL diff — secondary indexes (scaffold stub).
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// MySQL SDL diff — indexes (the full index/key surface).
 //
-// Wired into compareTable (diff_table.go) so a modified table reports its index
-// changes via TableDiffEntry.Indexes. This is an inert no-op placeholder: it returns
-// nil, so the table sub-diff is unchanged until the index breadth node implements the
-// real comparison. Signature mirrors diffColumns (diff_column.go): per-table, taking
-// the from/to *Table and the version-fixing Normalizer.
+// This is the MySQL analog of PG's diffIndexes (pg/catalog/diff_index.go). It compares the
+// index set of two versions of a table and reports the per-index changes via
+// TableDiffEntry.Indexes. The MySQL model keeps the WHOLE key surface in Table.Indexes:
+// PRIMARY KEY (Primary), UNIQUE (Unique, MySQL's unique constraint IS a unique index),
+// secondary (plain) KEYs, FULLTEXT, and SPATIAL — plus the index that MySQL auto-creates to
+// back a foreign key. show.go renders all of these via the index path (PRIMARY KEY / UNIQUE
+// KEY / KEY / FULLTEXT KEY / SPATIAL KEY); only FOREIGN KEY and CHECK are rendered via the
+// constraint path. So this node owns Table.Indexes in full, and the constraint breadth node
+// owns only FK + CHECK — the same split show.go uses (show.go:121).
 //
-// implemented by omni:index breadth node
-func diffIndexes(_, _ *Table, _ *Normalizer) []IndexDiffEntry {
-	// Scaffold: returns nil so the index sub-diff stays empty (self-diff inert).
+// Identity is the index name, lower-cased (PRIMARY for the primary key). Equality is decided
+// by a canonical key (canonicalIndex) that folds every stored-form-significant attribute —
+// kind, column parts (name/prefix/expr, version-flagged DESC via the normalizer), USING type,
+// comment, visibility, and the 5.7-only index KEY_BLOCK_SIZE — so an index whose surface form
+// differs from its SHOW CREATE readback but whose stored form is identical produces no phantom
+// diff. Every canonicalization-sensitive part is routed through normalize.go (the normalizer's
+// CanonicalIndexColumn handles prefix + version-flagged DESC; CanonicalGeneratedExpr handles a
+// functional index expression).
+//
+// FK-implicit-backing indexes are EXCLUDED (see fkImplicitIndexNames): MySQL auto-creates an
+// index to back a foreign key when no user index covers the FK columns, and SHOW CREATE shows
+// both the KEY and the CONSTRAINT. The loader synthesizes that same backing index on the user
+// side (tablecmds.go ensureFKBackingIndex), so it is present symmetrically — but its lifecycle
+// is bound to the foreign key, which the FK breadth node owns. Emitting an ADD/DROP for it here
+// would (a) duplicate the FK node's work and (b) risk a duplicate-key-name or "needed in a
+// foreign key constraint" (errno 1553) failure. So an index that exists solely to back a FK is
+// not a user-managed index change and is dropped from both sides of the diff.
+func diffIndexes(from, to *Table, n *Normalizer) []IndexDiffEntry {
+	fromMap := diffableIndexMap(from)
+	toMap := diffableIndexMap(to)
+
+	var result []IndexDiffEntry
+
+	// Dropped: in from but not in to.
+	for name, fromIdx := range fromMap {
+		if _, ok := toMap[name]; !ok {
+			result = append(result, IndexDiffEntry{
+				Action: DiffDrop,
+				Name:   fromIdx.Name,
+				From:   fromIdx,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for name, toIdx := range toMap {
+		fromIdx, ok := fromMap[name]
+		if !ok {
+			result = append(result, IndexDiffEntry{
+				Action: DiffAdd,
+				Name:   toIdx.Name,
+				To:     toIdx,
+			})
+			continue
+		}
+		if indexesChanged(fromIdx, toIdx, n) {
+			result = append(result, IndexDiffEntry{
+				Action: DiffModify,
+				Name:   toIdx.Name,
+				From:   fromIdx,
+				To:     toIdx,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if a, b := toLower(result[i].Name), toLower(result[j].Name); a != b {
+			return a < b
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// diffableIndexMap indexes a table's user-managed indexes by lower-cased name, excluding the
+// generated-invisible-primary-key index (engine-synthesized, never user-authored — mirrors
+// diffableColumns dropping the GIPK column) and every FK-implicit-backing index. The result is
+// the set of indexes whose lifecycle this node owns.
+func diffableIndexMap(t *Table) map[string]*Index {
+	if t == nil {
+		return map[string]*Index{}
+	}
+	skip := fkImplicitIndexNames(t)
+	m := make(map[string]*Index, len(t.Indexes))
+	for _, idx := range t.Indexes {
+		if idx == nil {
+			continue
+		}
+		if isGeneratedInvisiblePrimaryKeyIndex(idx) {
+			continue
+		}
+		if skip[toLower(idx.Name)] {
+			continue
+		}
+		m[toLower(idx.Name)] = idx
+	}
+	return m
+}
+
+// fkImplicitIndexNames returns the lower-cased names of indexes that exist solely to back a
+// foreign key — the ones MySQL auto-creates (and the loader synthesizes via
+// ensureFKBackingIndex) when no user index already covers the FK columns. These are owned by
+// the FK breadth node, not by this node, so they are excluded from the index diff.
+//
+// Detection mirrors ensureFKBackingIndex (tablecmds.go) exactly, so it classifies precisely
+// the indexes that function produced and never a user-declared index:
+//   - For each FK constraint on the table, the backing index it would create has the FK's
+//     index columns and a name of either the constraint name (when the FK was named) or the
+//     first column's auto-allocated name (when the FK was unnamed, matching allocIndexName).
+//     MySQL stores an unnamed FK as `<table>_ibfk_N`; for such a constraint the backing index
+//     is named after the first column, so we resolve the name the same way.
+//   - The candidate index must (a) carry only the plain attributes a synthesized backing index
+//     has — non-unique, non-fulltext, non-spatial, default USING type, no comment, visible, no
+//     prefix/expr/DESC parts, no KEY_BLOCK_SIZE — and (b) have column parts exactly equal to
+//     the FK's columns. A UNIQUE/named/prefixed index a user wrote on the FK columns therefore
+//     stays user-managed (it does not match the plain-backing signature) — and MySQL would have
+//     reused it rather than creating an implicit one, so there is no implicit index to skip.
+//
+// When more than one FK could claim the same index, the first match wins (the index is skipped
+// once); the per-FK ownership is the FK node's concern.
+func fkImplicitIndexNames(t *Table) map[string]bool {
+	skip := make(map[string]bool)
+	if t == nil {
+		return skip
+	}
+	for _, con := range t.Constraints {
+		if con == nil || con.Type != ConForeignKey {
+			continue
+		}
+		backingName := fkBackingIndexName(t, con)
+		if backingName == "" {
+			continue
+		}
+		key := toLower(backingName)
+		if skip[key] {
+			continue
+		}
+		idx := findIndexByName(t, backingName)
+		if idx == nil {
+			continue
+		}
+		if isPlainBackingIndexFor(idx, con.Columns) {
+			skip[key] = true
+		}
+	}
+	return skip
+}
+
+// fkBackingIndexName returns the name MySQL/the loader uses for the index backing a foreign
+// key: the constraint's IndexName if recorded, else the constraint name when it is a
+// user-declared name, else the first FK column (the allocIndexName fallback for an unnamed FK,
+// which MySQL records as `<table>_ibfk_N`). It returns "" for a column-less FK (defensive).
+func fkBackingIndexName(t *Table, con *Constraint) string {
+	if con.IndexName != "" {
+		return con.IndexName
+	}
+	if len(con.Columns) == 0 {
+		return ""
+	}
+	// An unnamed FK is stored as `<table>_ibfk_N`; its backing index is named after the first
+	// column (allocIndexName), not the constraint. A user-named FK names its backing index
+	// after the constraint. Distinguish by the auto-generated `_ibfk_` shape.
+	if con.Name == "" || isAutoFKName(t.Name, con.Name) {
+		return con.Columns[0]
+	}
+	return con.Name
+}
+
+// isAutoFKName reports whether name is an auto-generated InnoDB FK constraint name of the form
+// `<table>_ibfk_<digits>` (the shape MySQL assigns an unnamed FK; see tablecmds.go
+// nextFKGeneratedNumber). Comparison is case-insensitive on the table prefix to match the
+// catalog's case-insensitive identifier handling.
+func isAutoFKName(tableName, conName string) bool {
+	prefix := toLower(tableName) + "_ibfk_"
+	low := toLower(conName)
+	if !strings.HasPrefix(low, prefix) {
+		return false
+	}
+	digits := low[len(prefix):]
+	if digits == "" {
+		return false
+	}
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isPlainBackingIndexFor reports whether idx has exactly the shape ensureFKBackingIndex
+// produces for an FK on fkCols: a plain (non-unique, non-fulltext, non-spatial), default-type,
+// visible, comment-less, block-size-less index whose column parts are the FK columns verbatim
+// (no prefix length, no expression, no DESC). Anything richer is a user-managed index that
+// merely happens to cover the FK columns, and is diffed normally.
+func isPlainBackingIndexFor(idx *Index, fkCols []string) bool {
+	if idx.Primary || idx.Unique || idx.Fulltext || idx.Spatial {
+		return false
+	}
+	if idx.IndexType != "" || idx.Comment != "" || idx.KeyBlockSize != 0 || !idx.Visible {
+		return false
+	}
+	if len(idx.Columns) != len(fkCols) {
+		return false
+	}
+	for i, ic := range idx.Columns {
+		if ic.Expr != "" || ic.Length != 0 || ic.Descending {
+			return false
+		}
+		if !strings.EqualFold(ic.Name, fkCols[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// findIndexByName returns the table's index with the given name (case-insensitive), or nil.
+func findIndexByName(t *Table, name string) *Index {
+	key := toLower(name)
+	for _, idx := range t.Indexes {
+		if idx != nil && toLower(idx.Name) == key {
+			return idx
+		}
+	}
 	return nil
+}
+
+// indexesChanged reports whether two same-name indexes differ, comparing their canonical keys
+// (the MySQL analog of PG's indexesChanged). canonicalIndex folds every stored-form-significant
+// attribute into one collision-free key, so this differ never re-implements a per-attribute
+// comparison.
+func indexesChanged(a, b *Index, n *Normalizer) bool {
+	return canonicalIndex(a, n) != canonicalIndex(b, n)
+}
+
+// canonicalIndex returns a single stable comparison key for an index, folding the attributes
+// that survive into MySQL's stored form for the normalizer's version. Routed entirely through
+// normalize-core for the canonicalization-sensitive parts:
+//   - column parts via CanonicalIndexColumn (name/prefix/expr + version-flagged DESC: 8.0
+//     keeps DESC, 5.7 silently stores ascending);
+//   - KEY_BLOCK_SIZE is version-flagged the same way DESC is: 5.7 echoes an index-level
+//     KEY_BLOCK_SIZE in SHOW CREATE, 8.0 silently absorbs it (never stored on the index, never
+//     echoed — verified against both live engines), so it contributes to the key only on 5.7.
+//     This is canonicalIndexKeyBlockSize; it keeps an 8.0 user form that wrote KEY_BLOCK_SIZE=N
+//     from phantom-diffing against the 8.0 readback that drops it.
+//
+// Kind (primary/unique/fulltext/spatial), USING type, comment, and visibility are
+// version-independent and compared directly. The index NAME is the identity key (handled by the
+// caller's map), not part of this content key.
+func canonicalIndex(idx *Index, n *Normalizer) string {
+	parts := make([]string, 0, len(idx.Columns))
+	for _, ic := range idx.Columns {
+		parts = append(parts, n.CanonicalIndexColumn(ic))
+	}
+	return encodeKeyFields(
+		"primary", strconv.FormatBool(idx.Primary),
+		"unique", strconv.FormatBool(idx.Unique),
+		"fulltext", strconv.FormatBool(idx.Fulltext),
+		"spatial", strconv.FormatBool(idx.Spatial),
+		"using", canonicalIndexType(idx),
+		"comment", n.CanonicalComment(idx.Comment),
+		"visible", strconv.FormatBool(idx.Visible),
+		"kbs", canonicalIndexKeyBlockSize(idx, n),
+		"cols", strings.Join(parts, ","),
+	)
+}
+
+// canonicalIndexType returns the index's USING type, upper-cased, but only when it is a
+// user-selectable BTREE/HASH choice. FULLTEXT and SPATIAL set IndexType to "FULLTEXT"/"SPATIAL"
+// as a redundant echo of the kind flags (already in the key), and SHOW CREATE never emits a
+// USING clause for them, so they are normalized out here to avoid a key that double-counts the
+// kind. PRIMARY likewise never carries a meaningful USING in the stored form.
+func canonicalIndexType(idx *Index) string {
+	if idx.Primary || idx.Fulltext || idx.Spatial {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(idx.IndexType))
+}
+
+// canonicalIndexKeyBlockSize returns the index KEY_BLOCK_SIZE as a key fragment, but only on
+// 5.7 where SHOW CREATE echoes it. On 8.0 the engine does not store an index-level
+// KEY_BLOCK_SIZE (information_schema shows none and SHOW CREATE omits it), so it is dropped from
+// the key — otherwise an 8.0 `KEY k (a) KEY_BLOCK_SIZE=4` user form would phantom-diff against
+// its readback, which has no block size. FLAG: this version split is local to index diffing; if
+// normalize-core later grows a CanonicalIndexKeyBlockSize, route through it.
+func canonicalIndexKeyBlockSize(idx *Index, n *Normalizer) string {
+	if idx.KeyBlockSize == 0 || n.is80() {
+		return ""
+	}
+	return strconv.Itoa(idx.KeyBlockSize)
 }

--- a/mysql/catalog/diff_index.go
+++ b/mysql/catalog/diff_index.go
@@ -164,22 +164,26 @@ func userIndexNameSet(t *Table) map[string]bool {
 // would duplicate the FK node's work (duplicate-key-name on ADD) or fail with errno 1553
 // ("needed in a foreign key constraint") on DROP.
 //
-// Detection is STRUCTURAL, not name-based: an index is FK-implicit when it has exactly the
-// shape ensureFKBackingIndex produces — a plain (non-unique/fulltext/spatial), default-type,
-// visible, comment-less, block-size-less index whose column parts are some FK's columns
-// verbatim (no prefix, expression, or DESC). Matching by structure rather than reconstructing
-// the synthesized NAME is robust against the two cases name reconstruction gets wrong: an
-// unnamed FK whose first-column index name collided and was suffixed by allocIndexName (e.g.
-// `pid_2`), and a user-chosen FK constraint name that happens to look auto-generated
-// (`<table>_ibfk_N`). A user index that genuinely differs (UNIQUE, prefixed, named with extra
-// attributes, or covering MORE/FEWER columns than the FK) does NOT match and stays user-managed
-// — and MySQL would have reused such an index rather than synthesizing one, so there is no
-// implicit index to skip. A user index that is byte-for-byte what MySQL would have synthesized
-// is, by the work-order's contract, treated as FK-implicit (the FK node owns it); it could not
-// be independently dropped anyway while the FK exists (errno 1553).
+// Detection combines STRUCTURE and NAME. An index is FK-implicit only when BOTH hold:
+//   - it has exactly the shape ensureFKBackingIndex produces — a plain (non-unique/fulltext/
+//     spatial), default-type, visible, comment-less, block-size-less index whose column parts are
+//     the FK's columns verbatim (no prefix/expression/DESC) — isPlainBackingIndexFor; AND
+//   - its name is the AUTO-DERIVED backing name for that FK — isAutoBackingIndexName: the
+//     constraint name, the first FK column, or a `<firstFKcol>_<digits>` allocIndexName collision
+//     suffix (e.g. `pid_2`). MySQL/the loader names the backing index this way.
 //
-// Each FK claims at most one index (the first structural match not already claimed by another
-// FK), mirroring the one-backing-index-per-FK the engine maintains.
+// The name check is what distinguishes a user's EXPLICITLY-named index from the synthesized one.
+// If a user writes `KEY idx_pid (pid)` alongside a `CONSTRAINT fk_c_p FOREIGN KEY (pid)`, the
+// index name `idx_pid` is neither the constraint name nor a first-column-derived name, so it is
+// NOT FK-implicit — it is a user index this node must emit (else, when the FK is added, the FK
+// node would auto-create a differently-named backing index and the user's chosen name `idx_pid`
+// would be lost). When the user's index name DOES match the auto-derived form (the constraint
+// name, or the column-default name MySQL would pick anyway), excluding it is correct — the FK
+// node recreates an identically-named index, and it could not be independently dropped while the
+// FK exists (errno 1553). The structural part still keeps a UNIQUE/prefixed/wider index visible.
+//
+// Each FK claims at most one index (the first match not already claimed by another FK), mirroring
+// the one-backing-index-per-FK the engine maintains.
 func fkImplicitIndexNames(t *Table) map[string]bool {
 	skip := make(map[string]bool)
 	if t == nil {
@@ -197,13 +201,43 @@ func fkImplicitIndexNames(t *Table) map[string]bool {
 			if skip[key] {
 				continue
 			}
-			if isPlainBackingIndexFor(idx, con.Columns) {
+			if isPlainBackingIndexFor(idx, con.Columns) && isAutoBackingIndexName(idx.Name, con) {
 				skip[key] = true
 				break
 			}
 		}
 	}
 	return skip
+}
+
+// isAutoBackingIndexName reports whether idxName is the name MySQL/ensureFKBackingIndex would
+// assign to the index backing con: the constraint name, the first FK column, or a
+// `<firstFKcol>_<digits>` collision suffix that allocIndexName produces when the first-column name
+// is already taken. A user index named anything else (e.g. `idx_pid` for an FK on `pid`) is a
+// deliberately-named user index and is not treated as the implicit backing index, so this node
+// emits it and the FK reuses it — preserving the user's chosen name.
+func isAutoBackingIndexName(idxName string, con *Constraint) bool {
+	name := toLower(idxName)
+	if con.Name != "" && name == toLower(con.Name) {
+		return true
+	}
+	if len(con.Columns) == 0 {
+		return false
+	}
+	first := toLower(con.Columns[0])
+	if name == first {
+		return true
+	}
+	// allocIndexName collision form: "<firstcol>_<digits>".
+	if rest, ok := strings.CutPrefix(name, first+"_"); ok && rest != "" {
+		for _, r := range rest {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // isPlainBackingIndexFor reports whether idx has exactly the shape ensureFKBackingIndex

--- a/mysql/catalog/diff_index.go
+++ b/mysql/catalog/diff_index.go
@@ -36,14 +36,15 @@ import (
 // foreign key constraint" (errno 1553) failure. So an index that exists solely to back a FK is
 // not a user-managed index change and is dropped from both sides of the diff.
 func diffIndexes(from, to *Table, n *Normalizer) []IndexDiffEntry {
-	// The FK-implicit exclusion is computed against the OTHER side's index names: an
-	// FK-implicit index is dropped from a side only when its name is absent on the other side.
-	// This keeps the exclusion symmetric for an index that exists on BOTH sides (so it is never
-	// spuriously reported as added/dropped just because a foreign key appeared or disappeared on
-	// one side), while still suppressing the backing index that genuinely rides with a one-sided
-	// FK add/drop. See diffableIndexMap.
-	fromMap := diffableIndexMap(from, indexNameSet(to))
-	toMap := diffableIndexMap(to, indexNameSet(from))
+	// The FK-implicit exclusion is computed against the OTHER side's USER-managed index names
+	// (its index names minus its own FK-implicit ones). An FK-implicit index is dropped from a
+	// side only when the other side has no USER index of that name. This keeps the exclusion
+	// symmetric for an index that is a genuine user index on at least one side (so it is never
+	// spuriously added/dropped just because a foreign key appeared/disappeared), while still
+	// suppressing a backing index that is FK-implicit on BOTH sides (a FK whose columns changed —
+	// owned by the FK node) or that rides with a one-sided FK add/drop. See diffableIndexMap.
+	fromMap := diffableIndexMap(from, userIndexNameSet(to))
+	toMap := diffableIndexMap(to, userIndexNameSet(from))
 
 	var result []IndexDiffEntry
 
@@ -94,17 +95,21 @@ func diffIndexes(from, to *Table, n *Normalizer) []IndexDiffEntry {
 // diffableColumns dropping the GIPK column) and the FK-implicit-backing indexes the FK node owns.
 // The result is the set of indexes whose lifecycle this node owns.
 //
-// otherSideNames is the lower-cased index-name set of the OTHER catalog being diffed. An
-// FK-implicit index is excluded ONLY when its name is NOT in otherSideNames — i.e. it does not
-// also exist on the other side. This is the firewall against the asymmetric-exclusion bug: an
-// index that exists on both sides (e.g. a user `KEY my_idx (pid)` that backs a FK on one side and
-// is a standalone index on the other after the FK is dropped) must be visible on both sides so it
-// is correctly seen as unchanged — never spuriously ADDed (errno 1061, duplicate key name) or
-// DROPped. A backing index that genuinely appears/disappears WITH a one-sided FK is absent from
-// the other side, so it is still excluded and left to the FK node. Pass nil to exclude all
-// FK-implicit indexes unconditionally (single-table contexts: orderedDiffableIndexes for a new
-// table, where there is no "other side").
-func diffableIndexMap(t *Table, otherSideNames map[string]bool) map[string]*Index {
+// otherSideUserNames is the lower-cased set of the OTHER catalog's USER-managed index names (its
+// index names minus its own FK-implicit ones). An FK-implicit index is excluded ONLY when the
+// other side has no USER index of that name. This is the firewall against two failure modes:
+//   - asymmetric exclusion (errno 1061, duplicate key name): a user `KEY my_idx (pid)` that backs
+//     a FK on one side and is a standalone index on the other (FK dropped, index kept) is a USER
+//     index on that other side, so it is NOT excluded and is correctly seen as unchanged;
+//   - dropping a FK-needed index (errno 1553): a backing index that is FK-implicit on BOTH sides
+//     (e.g. a FK whose columns changed, so the backing index columns changed but the name stayed)
+//     has no USER index of that name on the other side, so it stays excluded and the FK node owns
+//     the change.
+//
+// A backing index that genuinely appears/disappears WITH a one-sided FK is absent from the other
+// side entirely, so it is still excluded. Pass nil to exclude all FK-implicit indexes
+// unconditionally (single-table contexts: orderedDiffableIndexes for a new table, no other side).
+func diffableIndexMap(t *Table, otherSideUserNames map[string]bool) map[string]*Index {
 	if t == nil {
 		return map[string]*Index{}
 	}
@@ -118,8 +123,8 @@ func diffableIndexMap(t *Table, otherSideNames map[string]bool) map[string]*Inde
 			continue
 		}
 		name := toLower(idx.Name)
-		// Exclude an FK-implicit index only when it is not also present on the other side.
-		if skip[name] && !otherSideNames[name] {
+		// Exclude an FK-implicit index unless the other side has a USER index of the same name.
+		if skip[name] && !otherSideUserNames[name] {
 			continue
 		}
 		m[name] = idx
@@ -127,19 +132,25 @@ func diffableIndexMap(t *Table, otherSideNames map[string]bool) map[string]*Inde
 	return m
 }
 
-// indexNameSet returns the lower-cased set of a table's index names (excluding the
-// generated-invisible-primary-key index, which is never user-authored), used as the cross-side
-// reference for the FK-implicit exclusion in diffableIndexMap.
-func indexNameSet(t *Table) map[string]bool {
+// userIndexNameSet returns the lower-cased set of a table's USER-managed index names: every index
+// name except the generated-invisible-primary-key (never user-authored) and the FK-implicit
+// backing indexes (owned by the FK node). It is the cross-side reference for the FK-implicit
+// exclusion in diffableIndexMap — "does the other side carry a genuine user index of this name?".
+func userIndexNameSet(t *Table) map[string]bool {
 	s := make(map[string]bool)
 	if t == nil {
 		return s
 	}
+	skip := fkImplicitIndexNames(t)
 	for _, idx := range t.Indexes {
 		if idx == nil || isGeneratedInvisiblePrimaryKeyIndex(idx) {
 			continue
 		}
-		s[toLower(idx.Name)] = true
+		name := toLower(idx.Name)
+		if skip[name] {
+			continue
+		}
+		s[name] = true
 	}
 	return s
 }

--- a/mysql/catalog/diff_index.go
+++ b/mysql/catalog/diff_index.go
@@ -109,94 +109,54 @@ func diffableIndexMap(t *Table) map[string]*Index {
 }
 
 // fkImplicitIndexNames returns the lower-cased names of indexes that exist solely to back a
-// foreign key — the ones MySQL auto-creates (and the loader synthesizes via
+// foreign key — the index MySQL auto-creates (and the loader synthesizes via
 // ensureFKBackingIndex) when no user index already covers the FK columns. These are owned by
-// the FK breadth node, not by this node, so they are excluded from the index diff.
+// the FK breadth node, not by this node, so they are excluded from the index diff. Excluding
+// them is symmetric (applied to both sides), so it never breaks idempotence; it prevents the
+// index node from emitting an ADD/DROP for an index whose lifecycle the FK node manages — which
+// would duplicate the FK node's work (duplicate-key-name on ADD) or fail with errno 1553
+// ("needed in a foreign key constraint") on DROP.
 //
-// Detection mirrors ensureFKBackingIndex (tablecmds.go) exactly, so it classifies precisely
-// the indexes that function produced and never a user-declared index:
-//   - For each FK constraint on the table, the backing index it would create has the FK's
-//     index columns and a name of either the constraint name (when the FK was named) or the
-//     first column's auto-allocated name (when the FK was unnamed, matching allocIndexName).
-//     MySQL stores an unnamed FK as `<table>_ibfk_N`; for such a constraint the backing index
-//     is named after the first column, so we resolve the name the same way.
-//   - The candidate index must (a) carry only the plain attributes a synthesized backing index
-//     has — non-unique, non-fulltext, non-spatial, default USING type, no comment, visible, no
-//     prefix/expr/DESC parts, no KEY_BLOCK_SIZE — and (b) have column parts exactly equal to
-//     the FK's columns. A UNIQUE/named/prefixed index a user wrote on the FK columns therefore
-//     stays user-managed (it does not match the plain-backing signature) — and MySQL would have
-//     reused it rather than creating an implicit one, so there is no implicit index to skip.
+// Detection is STRUCTURAL, not name-based: an index is FK-implicit when it has exactly the
+// shape ensureFKBackingIndex produces — a plain (non-unique/fulltext/spatial), default-type,
+// visible, comment-less, block-size-less index whose column parts are some FK's columns
+// verbatim (no prefix, expression, or DESC). Matching by structure rather than reconstructing
+// the synthesized NAME is robust against the two cases name reconstruction gets wrong: an
+// unnamed FK whose first-column index name collided and was suffixed by allocIndexName (e.g.
+// `pid_2`), and a user-chosen FK constraint name that happens to look auto-generated
+// (`<table>_ibfk_N`). A user index that genuinely differs (UNIQUE, prefixed, named with extra
+// attributes, or covering MORE/FEWER columns than the FK) does NOT match and stays user-managed
+// — and MySQL would have reused such an index rather than synthesizing one, so there is no
+// implicit index to skip. A user index that is byte-for-byte what MySQL would have synthesized
+// is, by the work-order's contract, treated as FK-implicit (the FK node owns it); it could not
+// be independently dropped anyway while the FK exists (errno 1553).
 //
-// When more than one FK could claim the same index, the first match wins (the index is skipped
-// once); the per-FK ownership is the FK node's concern.
+// Each FK claims at most one index (the first structural match not already claimed by another
+// FK), mirroring the one-backing-index-per-FK the engine maintains.
 func fkImplicitIndexNames(t *Table) map[string]bool {
 	skip := make(map[string]bool)
 	if t == nil {
 		return skip
 	}
 	for _, con := range t.Constraints {
-		if con == nil || con.Type != ConForeignKey {
+		if con == nil || con.Type != ConForeignKey || len(con.Columns) == 0 {
 			continue
 		}
-		backingName := fkBackingIndexName(t, con)
-		if backingName == "" {
-			continue
-		}
-		key := toLower(backingName)
-		if skip[key] {
-			continue
-		}
-		idx := findIndexByName(t, backingName)
-		if idx == nil {
-			continue
-		}
-		if isPlainBackingIndexFor(idx, con.Columns) {
-			skip[key] = true
+		for _, idx := range t.Indexes {
+			if idx == nil {
+				continue
+			}
+			key := toLower(idx.Name)
+			if skip[key] {
+				continue
+			}
+			if isPlainBackingIndexFor(idx, con.Columns) {
+				skip[key] = true
+				break
+			}
 		}
 	}
 	return skip
-}
-
-// fkBackingIndexName returns the name MySQL/the loader uses for the index backing a foreign
-// key: the constraint's IndexName if recorded, else the constraint name when it is a
-// user-declared name, else the first FK column (the allocIndexName fallback for an unnamed FK,
-// which MySQL records as `<table>_ibfk_N`). It returns "" for a column-less FK (defensive).
-func fkBackingIndexName(t *Table, con *Constraint) string {
-	if con.IndexName != "" {
-		return con.IndexName
-	}
-	if len(con.Columns) == 0 {
-		return ""
-	}
-	// An unnamed FK is stored as `<table>_ibfk_N`; its backing index is named after the first
-	// column (allocIndexName), not the constraint. A user-named FK names its backing index
-	// after the constraint. Distinguish by the auto-generated `_ibfk_` shape.
-	if con.Name == "" || isAutoFKName(t.Name, con.Name) {
-		return con.Columns[0]
-	}
-	return con.Name
-}
-
-// isAutoFKName reports whether name is an auto-generated InnoDB FK constraint name of the form
-// `<table>_ibfk_<digits>` (the shape MySQL assigns an unnamed FK; see tablecmds.go
-// nextFKGeneratedNumber). Comparison is case-insensitive on the table prefix to match the
-// catalog's case-insensitive identifier handling.
-func isAutoFKName(tableName, conName string) bool {
-	prefix := toLower(tableName) + "_ibfk_"
-	low := toLower(conName)
-	if !strings.HasPrefix(low, prefix) {
-		return false
-	}
-	digits := low[len(prefix):]
-	if digits == "" {
-		return false
-	}
-	for _, r := range digits {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 // isPlainBackingIndexFor reports whether idx has exactly the shape ensureFKBackingIndex
@@ -223,17 +183,6 @@ func isPlainBackingIndexFor(idx *Index, fkCols []string) bool {
 		}
 	}
 	return true
-}
-
-// findIndexByName returns the table's index with the given name (case-insensitive), or nil.
-func findIndexByName(t *Table, name string) *Index {
-	key := toLower(name)
-	for _, idx := range t.Indexes {
-		if idx != nil && toLower(idx.Name) == key {
-			return idx
-		}
-	}
-	return nil
 }
 
 // indexesChanged reports whether two same-name indexes differ, comparing their canonical keys

--- a/mysql/catalog/diff_index.go
+++ b/mysql/catalog/diff_index.go
@@ -36,8 +36,14 @@ import (
 // foreign key constraint" (errno 1553) failure. So an index that exists solely to back a FK is
 // not a user-managed index change and is dropped from both sides of the diff.
 func diffIndexes(from, to *Table, n *Normalizer) []IndexDiffEntry {
-	fromMap := diffableIndexMap(from)
-	toMap := diffableIndexMap(to)
+	// The FK-implicit exclusion is computed against the OTHER side's index names: an
+	// FK-implicit index is dropped from a side only when its name is absent on the other side.
+	// This keeps the exclusion symmetric for an index that exists on BOTH sides (so it is never
+	// spuriously reported as added/dropped just because a foreign key appeared or disappeared on
+	// one side), while still suppressing the backing index that genuinely rides with a one-sided
+	// FK add/drop. See diffableIndexMap.
+	fromMap := diffableIndexMap(from, indexNameSet(to))
+	toMap := diffableIndexMap(to, indexNameSet(from))
 
 	var result []IndexDiffEntry
 
@@ -85,9 +91,20 @@ func diffIndexes(from, to *Table, n *Normalizer) []IndexDiffEntry {
 
 // diffableIndexMap indexes a table's user-managed indexes by lower-cased name, excluding the
 // generated-invisible-primary-key index (engine-synthesized, never user-authored — mirrors
-// diffableColumns dropping the GIPK column) and every FK-implicit-backing index. The result is
-// the set of indexes whose lifecycle this node owns.
-func diffableIndexMap(t *Table) map[string]*Index {
+// diffableColumns dropping the GIPK column) and the FK-implicit-backing indexes the FK node owns.
+// The result is the set of indexes whose lifecycle this node owns.
+//
+// otherSideNames is the lower-cased index-name set of the OTHER catalog being diffed. An
+// FK-implicit index is excluded ONLY when its name is NOT in otherSideNames — i.e. it does not
+// also exist on the other side. This is the firewall against the asymmetric-exclusion bug: an
+// index that exists on both sides (e.g. a user `KEY my_idx (pid)` that backs a FK on one side and
+// is a standalone index on the other after the FK is dropped) must be visible on both sides so it
+// is correctly seen as unchanged — never spuriously ADDed (errno 1061, duplicate key name) or
+// DROPped. A backing index that genuinely appears/disappears WITH a one-sided FK is absent from
+// the other side, so it is still excluded and left to the FK node. Pass nil to exclude all
+// FK-implicit indexes unconditionally (single-table contexts: orderedDiffableIndexes for a new
+// table, where there is no "other side").
+func diffableIndexMap(t *Table, otherSideNames map[string]bool) map[string]*Index {
 	if t == nil {
 		return map[string]*Index{}
 	}
@@ -100,12 +117,31 @@ func diffableIndexMap(t *Table) map[string]*Index {
 		if isGeneratedInvisiblePrimaryKeyIndex(idx) {
 			continue
 		}
-		if skip[toLower(idx.Name)] {
+		name := toLower(idx.Name)
+		// Exclude an FK-implicit index only when it is not also present on the other side.
+		if skip[name] && !otherSideNames[name] {
 			continue
 		}
-		m[toLower(idx.Name)] = idx
+		m[name] = idx
 	}
 	return m
+}
+
+// indexNameSet returns the lower-cased set of a table's index names (excluding the
+// generated-invisible-primary-key index, which is never user-authored), used as the cross-side
+// reference for the FK-implicit exclusion in diffableIndexMap.
+func indexNameSet(t *Table) map[string]bool {
+	s := make(map[string]bool)
+	if t == nil {
+		return s
+	}
+	for _, idx := range t.Indexes {
+		if idx == nil || isGeneratedInvisiblePrimaryKeyIndex(idx) {
+			continue
+		}
+		s[toLower(idx.Name)] = true
+	}
+	return s
 }
 
 // fkImplicitIndexNames returns the lower-cased names of indexes that exist solely to back a

--- a/mysql/catalog/diff_index_oracle_test.go
+++ b/mysql/catalog/diff_index_oracle_test.go
@@ -121,6 +121,68 @@ func fkIndexCases() []fkIndexCase {
 	}
 }
 
+// TestOracle_IndexFKColumnChangeNoIndexOps proves the FK-implicit cross-side rule for a FK whose
+// COLUMNS change (the backing index name stays `fk` on both sides, but its columns differ): the
+// index node must emit NO ADD/DROP/MODIFY for that backing index (it is FK-implicit on both sides
+// and owned by the FK node) — dropping it would fail errno 1553 ("needed in a foreign key
+// constraint"). Proven via a multi-table schema loaded from real engine readbacks.
+func TestOracle_IndexFKColumnChangeNoIndexOps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+		ctx := context.Background()
+
+		// loadSchema applies parent+child in a throwaway db, then reloads BOTH tables wrapped in a
+		// FIXED logical db name (idxfkc) so that the from/to catalogs share a database identity and
+		// only the child's FK (not the database) differs in the diff.
+		loadSchema := func(execDB, childDDL string) *Catalog {
+			stmts := []string{
+				"DROP DATABASE IF EXISTS " + execDB,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", execDB, sc),
+				"USE " + execDB,
+				"CREATE TABLE p (a INT NOT NULL PRIMARY KEY, b INT NOT NULL, UNIQUE KEY ub (b))",
+				childDDL,
+			}
+			for _, s := range stmts {
+				if _, err := o.db.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup: %q: %v", o.name, s, err)
+				}
+			}
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "CREATE DATABASE idxfkc DEFAULT CHARSET=%s;\nUSE idxfkc;\n", sc)
+			for _, tbl := range []string{"p", "c"} {
+				var nm, ddl string
+				row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", execDB, tbl))
+				if err := row.Scan(&nm, &ddl); err != nil {
+					t.Fatalf("[%s] show create %s: %v", o.name, tbl, err)
+				}
+				sb.WriteString(ddl + ";\n")
+			}
+			cat, err := LoadSQL(sb.String())
+			if err != nil {
+				t.Fatalf("[%s] reload: %v\n%s", o.name, err, sb.String())
+			}
+			return cat
+		}
+
+		t.Run(o.name+"/fk-column-change", func(t *testing.T) {
+			from := loadSchema("idxfkc_a", "CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (x) REFERENCES p(a))")
+			to := loadSchema("idxfkc_b", "CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (y) REFERENCES p(b))")
+			diff := DiffWithNormalizer(from, to, n)
+			plan := GenerateMigrationWithNormalizer(from, to, diff, n)
+			for _, op := range plan.Ops {
+				if op.Type == OpAddIndex || op.Type == OpDropIndex {
+					t.Errorf("[%s] FK column change must emit no index op, got: %s", o.name, op.SQL)
+				}
+			}
+		})
+	}
+}
+
 // TestOracle_IndexDiffFKImplicit proves the FK-implicit cross-reference: a schema with a foreign
 // key and its (auto-created) backing index self-diffs empty when loaded from the real engine
 // readbacks of BOTH tables. This is the multi-table analog of the idempotence probe — the

--- a/mysql/catalog/diff_index_oracle_test.go
+++ b/mysql/catalog/diff_index_oracle_test.go
@@ -1,0 +1,179 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the index differ (correctness-protocol.md gates 1 & 2), against the LIVE
+// MySQL engines (5.7 :13307, 8.0 :13306). For every index variant the node covers, two
+// properties are proven mechanically:
+//
+//  1. Idempotence (the spine): a schema in its real stored form (the engine's SHOW CREATE
+//     readback, reloaded into a catalog) self-diffs empty, and the user form vs the engine's
+//     stored form diffs empty — e.g. an unnamed KEY (a) (which MySQL auto-names `a`) collapses
+//     onto the readback's named form. A non-empty diff is a normalization bug.
+//  2. The FK-implicit cross-reference: a foreign key with no explicit backing index produces NO
+//     index diff (the auto-created KEY is excluded on both sides), proven via a multi-table
+//     round-trip (single-table readback cannot resolve the FK's referenced table).
+//
+// The harness reuses assertDiffEmptyAgainstReadback / connectOracle / serverCharsetFor / both /
+// only from the diff + normalize oracle tests; it skips cleanly when the engines are unreachable.
+
+// indexDiffProbes enumerates the single-table index FORMS that must round-trip empty: a user-form
+// DDL whose engine-stored form differs (auto-name, prefix echo, version-flagged DESC/KBS, ...) but
+// must canonicalize equal. Cross-table FK forms are proven separately (they need both tables).
+func indexDiffProbes() []diffProbe {
+	return []diffProbe{
+		// PRIMARY KEY — single and composite; columns are forced NOT NULL by the PK.
+		{"pk-simple", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)", "t", both()},
+		{"pk-composite", "CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY (a,b))", "t", both()},
+		// UNIQUE — MySQL's unique constraint is a unique index; single + composite.
+		{"unique-single", "CREATE TABLE t (id INT PRIMARY KEY, a INT, UNIQUE KEY ua (a))", "t", both()},
+		{"unique-composite", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, UNIQUE KEY uab (a,b))", "t", both()},
+		// Secondary (non-unique) — single, composite, multiple.
+		{"secondary", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ka (a), KEY kab (a,b))", "t", both()},
+		// Unnamed indexes → MySQL auto-name (a, a_2): the user form vs stored named form must
+		// collapse. The headline auto-name canonicalization case.
+		{"unnamed-autoname", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY (a), KEY (a,b))", "t", both()},
+		// USING BTREE echo (InnoDB coerces HASH→BTREE; BTREE is echoed verbatim).
+		{"using-btree", "CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ua (a) USING BTREE) ENGINE=InnoDB", "t", both()},
+		// Prefix length col(N).
+		{"prefix", "CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(100), c CHAR(40), KEY sp (s(10)), KEY cp (c(5)))", "t", both()},
+		// Index COMMENT (escaped).
+		{"comment", "CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a) COMMENT 'idx ''c'' here')", "t", both()},
+		// Index KEY_BLOCK_SIZE — echoed on 5.7, absorbed on 8.0; must round-trip on BOTH.
+		{"key-block-size", "CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a) KEY_BLOCK_SIZE=4) ENGINE=InnoDB", "t", both()},
+		// Descending — stored on 8.0, silently ascending on 5.7; round-trips on both.
+		{"descending", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ab (a, b DESC))", "t", both()},
+		// Composite mixed ASC/DESC + prefix together.
+		{"composite-mixed", "CREATE TABLE t (id INT PRIMARY KEY, a INT, s VARCHAR(50), KEY mix (a DESC, s(8)))", "t", both()},
+		// Invisible — 8.0 only (/*!80000 INVISIBLE */).
+		{"invisible", "CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY va (a) /*!80000 INVISIBLE */)", "t", only(MySQL80)},
+		// Functional / expression index — 8.0 only.
+		{"functional", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY fa ((a + 1)), KEY fab ((a + b)))", "t", only(MySQL80)},
+		// FULLTEXT.
+		{"fulltext", "CREATE TABLE t (id INT PRIMARY KEY, body TEXT, ftcol VARCHAR(200), FULLTEXT KEY ftb (body), FULLTEXT KEY ftc (ftcol))", "t", both()},
+		// SPATIAL — needs a NOT NULL geometry column. 8.0 supports SPATIAL on InnoDB; 5.7 needs
+		// MyISAM. Prove on 8.0 (InnoDB default) to keep the form simple.
+		{"spatial", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL, SPATIAL KEY sg (g))", "t", only(MySQL80)},
+		// Mixed bag: PK + unique + secondary + invisible on one table (8.0).
+		{"mixed-all-80", "CREATE TABLE t (id INT NOT NULL, a INT, b INT, c VARCHAR(40), PRIMARY KEY (id), UNIQUE KEY ua (a), KEY kb (b DESC), KEY kc (c(5)) /*!80000 INVISIBLE */)", "t", only(MySQL80)},
+		// Mixed bag for 5.7 (no DESC/invisible/functional).
+		{"mixed-all-57", "CREATE TABLE t (id INT NOT NULL, a INT, b INT, c VARCHAR(40), PRIMARY KEY (id), UNIQUE KEY ua (a), KEY kb (b), KEY kc (c(5)))", "t", both()},
+	}
+}
+
+// TestOracle_IndexDiffIdempotence proves gates 1 & 2 for every single-table index form: user DDL
+// vs its engine readback diffs EMPTY, and the stored form self-diffs empty, on every supported
+// version.
+func TestOracle_IndexDiffIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, probe := range indexDiffProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := "idx_" + strings.ReplaceAll(probe.id, "-", "_")
+				assertDiffEmptyAgainstReadback(t, o, db, probe.create, probe.table)
+			})
+		}
+	}
+}
+
+// fkIndexCase is a parent+child schema with a foreign key, used to prove the FK-implicit
+// cross-reference round-trips empty.
+type fkIndexCase struct {
+	id       string
+	childDDL string // table `c`, references table `p`
+	versions []Version
+}
+
+// fkIndexCases enumerate the FK + index interplay forms. Each builds parent `p` + child `c`,
+// reads BOTH back, reloads as one schema, and the diff must be empty — the FK backing index
+// (auto-created by MySQL, synthesized by the loader) must not phantom-diff.
+func fkIndexCases() []fkIndexCase {
+	return []fkIndexCase{
+		// Named FK, no explicit backing index → MySQL auto-creates KEY `fk`.
+		{"fk-named-implicit", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Unnamed FK → constraint `c_ibfk_1`, backing index named after the column `pid`.
+		{"fk-unnamed-implicit", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Explicit covering index present (distinct name) → MySQL reuses it, no separate backing
+		// index; the explicit index is user-managed and must round-trip.
+		{"fk-explicit-covering", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Composite FK with its own auto-created composite backing index.
+		{"fk-composite", "CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (x,y) REFERENCES p(a,b))", both()},
+	}
+}
+
+// TestOracle_IndexDiffFKImplicit proves the FK-implicit cross-reference: a schema with a foreign
+// key and its (auto-created) backing index self-diffs empty when loaded from the real engine
+// readbacks of BOTH tables. This is the multi-table analog of the idempotence probe — the
+// single-table harness cannot resolve the FK's referenced table.
+func TestOracle_IndexDiffFKImplicit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+		ctx := context.Background()
+
+		// parent `p` has both a single-col PK (for fk-named/unnamed/explicit) and a composite PK
+		// (for fk-composite); pick the parent matching the child.
+		parentFor := func(id string) string {
+			if id == "fk-composite" {
+				return "CREATE TABLE p (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b))"
+			}
+			return "CREATE TABLE p (id INT NOT NULL PRIMARY KEY, name VARCHAR(50))"
+		}
+
+		for _, fc := range fkIndexCases() {
+			if !containsVersion(fc.versions, version) {
+				continue
+			}
+			t.Run(o.name+"/"+fc.id, func(t *testing.T) {
+				dbName := "idxfk_" + strings.ReplaceAll(fc.id, "-", "_")
+				stmts := []string{
+					"DROP DATABASE IF EXISTS " + dbName,
+					fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, sc),
+					"USE " + dbName,
+					parentFor(fc.id),
+					fc.childDDL,
+				}
+				for _, s := range stmts {
+					if _, err := o.db.ExecContext(ctx, s); err != nil {
+						t.Skipf("[%s] setup failed (may be expected): %q: %v", o.name, s, err)
+					}
+				}
+				// Read both tables back and reload as a single schema.
+				var b strings.Builder
+				fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, sc, dbName)
+				for _, tbl := range []string{"p", "c"} {
+					var nm, ddl string
+					row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", dbName, tbl))
+					if err := row.Scan(&nm, &ddl); err != nil {
+						t.Fatalf("[%s] SHOW CREATE %s: %v", o.name, tbl, err)
+					}
+					b.WriteString(ddl + ";\n")
+				}
+				cat, err := LoadSQL(b.String())
+				if err != nil {
+					t.Fatalf("[%s] reload of FK readback failed: %v\n%s", o.name, err, b.String())
+				}
+				if d := DiffWithNormalizer(cat, cat, n); !d.IsEmpty() {
+					t.Errorf("[%s] FK schema self-diff not empty (phantom on backing index): %s", o.name, describeDiff(d))
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/diff_index_oracle_test.go
+++ b/mysql/catalog/diff_index_oracle_test.go
@@ -111,6 +111,13 @@ func fkIndexCases() []fkIndexCase {
 		{"fk-explicit-covering", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
 		// Composite FK with its own auto-created composite backing index.
 		{"fk-composite", "CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (x,y) REFERENCES p(a,b))", both()},
+		// Unnamed FK whose first-column index name collides with a user index, so MySQL/the loader
+		// names the backing index `pid_2` (allocIndexName suffix). The structural FK-implicit
+		// detection must still exclude `pid_2` while keeping the user's `KEY pid (a)`.
+		{"fk-backing-name-collision", "CREATE TABLE c (id INT PRIMARY KEY, a INT, pid INT, KEY pid (a), FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// FK with a user-chosen constraint name that matches the auto `<table>_ibfk_N` shape; the
+		// backing index is named after the constraint and must be excluded structurally.
+		{"fk-user-named-ibfk", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT c_ibfk_1 FOREIGN KEY (pid) REFERENCES p(id))", both()},
 	}
 }
 

--- a/mysql/catalog/diff_index_test.go
+++ b/mysql/catalog/diff_index_test.go
@@ -151,12 +151,58 @@ func TestDiffIndex_FKImplicitExcluded(t *testing.T) {
 	}
 }
 
-// TestDiffIndex_ExplicitIndexOnFKColumnsKept asserts the inverse: a user index that merely covers
-// the FK columns but carries a user-only attribute (here a distinct name + it is the explicit
-// covering index, so MySQL creates no separate backing index) stays user-managed and IS diff-able.
-func TestDiffIndex_ExplicitIndexOnFKColumnsKept(t *testing.T) {
+// TestDiffIndex_RicherIndexOnFKColumnsKept asserts the boundary of FK-implicit detection: an
+// index that covers the FK columns but is STRUCTURALLY RICHER than a synthesized backing index
+// stays user-managed and diff-able. Two forms:
+//   - a UNIQUE index on the FK columns (MySQL reuses it to back the FK, but it is genuinely the
+//     user's unique constraint, not a plain backing index);
+//   - a WIDER composite index whose left prefix covers the FK columns (its column count differs
+//     from the FK's, so it is not a backing-index shape).
+//
+// A PLAIN index whose columns exactly equal the FK columns is, by contrast, byte-for-byte what
+// ensureFKBackingIndex would synthesize and is treated as FK-implicit (the FK node owns it) —
+// proven empty against the real engine in TestOracle_IndexDiffFKImplicit/fk-explicit-covering.
+func TestDiffIndex_RicherIndexOnFKColumnsKept(t *testing.T) {
+	t.Run("unique-on-fk-columns", func(t *testing.T) {
+		sdl := dbDDL + "CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n" +
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, UNIQUE KEY uq_pid (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id));"
+		cat := loadCat(t, sdl)
+		child := mustGetTable(t, cat, "c")
+		if _, present := diffableIndexMap(child)["uq_pid"]; !present {
+			t.Errorf("UNIQUE index on FK columns must remain diff-able (not a plain backing-index shape)")
+		}
+	})
+
+	t.Run("wider-composite-covering-fk", func(t *testing.T) {
+		sdl := dbDDL + "CREATE TABLE p (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b));\n" +
+			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, z INT, KEY wide (x,y,z), CONSTRAINT fk FOREIGN KEY (x,y) REFERENCES p(a,b));"
+		cat := loadCat(t, sdl)
+		child := mustGetTable(t, cat, "c")
+		if _, present := diffableIndexMap(child)["wide"]; !present {
+			t.Errorf("wider composite index covering the FK by left-prefix must remain diff-able")
+		}
+	})
+}
+
+// mustGetTable returns the named table from a catalog or fails the test.
+func mustGetTable(t *testing.T, cat *Catalog, name string) *Table {
+	t.Helper()
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable(name); tt != nil {
+			return tt
+		}
+	}
+	t.Fatalf("table %s not loaded", name)
+	return nil
+}
+
+// TestDiffIndex_FKImplicitNameCollision asserts that an unnamed FK whose backing-index name was
+// suffixed by allocIndexName on collision (here `pid_2`, because the user wrote `KEY pid (a)`) is
+// still detected as FK-implicit and excluded — structural detection does not depend on the
+// synthesized name. The unrelated user index `KEY pid (a)` stays diff-able.
+func TestDiffIndex_FKImplicitNameCollision(t *testing.T) {
 	sdl := dbDDL + "CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n" +
-		"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY explicit_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id));"
+		"CREATE TABLE c (id INT PRIMARY KEY, a INT, pid INT, KEY pid (a), FOREIGN KEY (pid) REFERENCES p(id));"
 	cat := loadCat(t, sdl)
 	var child *Table
 	for _, db := range cat.Databases() {
@@ -167,8 +213,45 @@ func TestDiffIndex_ExplicitIndexOnFKColumnsKept(t *testing.T) {
 	if child == nil {
 		t.Fatal("table c not loaded")
 	}
-	if _, present := diffableIndexMap(child)["explicit_idx"]; !present {
-		t.Errorf("explicit user index `explicit_idx` covering FK columns must remain diff-able")
+	// Precondition: the loader synthesized the FK backing index as `pid_2` (collided with the
+	// user's `KEY pid (a)`).
+	if findIndex(child, "pid_2") == nil {
+		t.Fatal("precondition: expected synthesized backing index `pid_2`")
+	}
+	dm := diffableIndexMap(child)
+	if _, present := dm["pid_2"]; present {
+		t.Errorf("FK-implicit backing index `pid_2` must be excluded despite the collision-suffixed name")
+	}
+	if _, present := dm["pid"]; !present {
+		t.Errorf("unrelated user index `KEY pid (a)` must remain diff-able")
+	}
+	if d := Diff(cat, cat); !d.IsEmpty() {
+		t.Errorf("self-diff must be empty, got: %s", describeDiff(d))
+	}
+}
+
+// TestDiffIndex_FKImplicitUserNamedConstraint asserts that an FK whose user-chosen constraint name
+// happens to match the auto-generated `<table>_ibfk_N` shape still has its backing index detected
+// and excluded — structural detection does not misclassify based on the constraint name.
+func TestDiffIndex_FKImplicitUserNamedConstraint(t *testing.T) {
+	sdl := dbDDL + "CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n" +
+		"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT c_ibfk_1 FOREIGN KEY (pid) REFERENCES p(id));"
+	cat := loadCat(t, sdl)
+	var child *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable("c"); tt != nil {
+			child = tt
+		}
+	}
+	if child == nil {
+		t.Fatal("table c not loaded")
+	}
+	dm := diffableIndexMap(child)
+	if _, present := dm["c_ibfk_1"]; present {
+		t.Errorf("FK backing index `c_ibfk_1` must be excluded even though the FK name matches the auto shape")
+	}
+	if d := Diff(cat, cat); !d.IsEmpty() {
+		t.Errorf("self-diff must be empty, got: %s", describeDiff(d))
 	}
 }
 

--- a/mysql/catalog/diff_index_test.go
+++ b/mysql/catalog/diff_index_test.go
@@ -146,7 +146,7 @@ func TestDiffIndex_FKImplicitExcluded(t *testing.T) {
 	if findIndex(child, "fk") == nil {
 		t.Fatal("precondition: loader should have synthesized backing index `fk`")
 	}
-	if _, present := diffableIndexMap(child)["fk"]; present {
+	if _, present := diffableIndexMap(child, nil)["fk"]; present {
 		t.Errorf("FK-implicit backing index `fk` must be excluded from the diff-able set")
 	}
 }
@@ -168,7 +168,7 @@ func TestDiffIndex_RicherIndexOnFKColumnsKept(t *testing.T) {
 			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, UNIQUE KEY uq_pid (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id));"
 		cat := loadCat(t, sdl)
 		child := mustGetTable(t, cat, "c")
-		if _, present := diffableIndexMap(child)["uq_pid"]; !present {
+		if _, present := diffableIndexMap(child, nil)["uq_pid"]; !present {
 			t.Errorf("UNIQUE index on FK columns must remain diff-able (not a plain backing-index shape)")
 		}
 	})
@@ -178,7 +178,7 @@ func TestDiffIndex_RicherIndexOnFKColumnsKept(t *testing.T) {
 			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, z INT, KEY wide (x,y,z), CONSTRAINT fk FOREIGN KEY (x,y) REFERENCES p(a,b));"
 		cat := loadCat(t, sdl)
 		child := mustGetTable(t, cat, "c")
-		if _, present := diffableIndexMap(child)["wide"]; !present {
+		if _, present := diffableIndexMap(child, nil)["wide"]; !present {
 			t.Errorf("wider composite index covering the FK by left-prefix must remain diff-able")
 		}
 	})
@@ -194,6 +194,31 @@ func mustGetTable(t *testing.T, cat *Catalog, name string) *Table {
 	}
 	t.Fatalf("table %s not loaded", name)
 	return nil
+}
+
+// TestDiffIndex_FKDroppedExplicitIndexKept asserts the asymmetric-exclusion firewall: when a
+// foreign key is dropped but the plain user index that backed it is KEPT, the index must NOT be
+// reported as added (it exists on both sides). Without the cross-side exclusion check, the index
+// would be excluded on the FK side (from) but present on the no-FK side (to), producing a phantom
+// ADD that fails on apply with errno 1061 (duplicate key name).
+func TestDiffIndex_FKDroppedExplicitIndexKept(t *testing.T) {
+	from := loadCat(t, dbDDL+"CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n"+
+		"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id));")
+	to := loadCat(t, dbDDL+"CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n"+
+		"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid));")
+	d := Diff(from, to)
+	if te := findTable(d, "c"); te != nil {
+		for _, ie := range te.Indexes {
+			t.Errorf("no index change expected on c (my_idx kept), got %s %s", ie.Action, ie.Name)
+		}
+	}
+	// And the reverse (FK added, index already present): must not DROP my_idx.
+	dRev := Diff(to, from)
+	if te := findTable(dRev, "c"); te != nil {
+		for _, ie := range te.Indexes {
+			t.Errorf("no index change expected on c (FK added, my_idx already present), got %s %s", ie.Action, ie.Name)
+		}
+	}
 }
 
 // TestDiffIndex_FKImplicitNameCollision asserts that an unnamed FK whose backing-index name was
@@ -218,7 +243,7 @@ func TestDiffIndex_FKImplicitNameCollision(t *testing.T) {
 	if findIndex(child, "pid_2") == nil {
 		t.Fatal("precondition: expected synthesized backing index `pid_2`")
 	}
-	dm := diffableIndexMap(child)
+	dm := diffableIndexMap(child, nil)
 	if _, present := dm["pid_2"]; present {
 		t.Errorf("FK-implicit backing index `pid_2` must be excluded despite the collision-suffixed name")
 	}
@@ -246,7 +271,7 @@ func TestDiffIndex_FKImplicitUserNamedConstraint(t *testing.T) {
 	if child == nil {
 		t.Fatal("table c not loaded")
 	}
-	dm := diffableIndexMap(child)
+	dm := diffableIndexMap(child, nil)
 	if _, present := dm["c_ibfk_1"]; present {
 		t.Errorf("FK backing index `c_ibfk_1` must be excluded even though the FK name matches the auto shape")
 	}

--- a/mysql/catalog/diff_index_test.go
+++ b/mysql/catalog/diff_index_test.go
@@ -1,0 +1,203 @@
+package catalog
+
+import (
+	"testing"
+)
+
+// In-process, hermetic structural tests for the index differ (diff_index.go). They assert the
+// per-index SchemaDiff content (right DiffAction per index) for representative change forms,
+// loading both sides through the omni catalog so the model state is authentic. The oracle-backed
+// idempotence + canonicalization-empty + apply-correctness proofs live in diff_index_oracle_test.go
+// and migration_index_oracle_test.go (correctness-protocol.md gates 1 & 2); these lock in gate 3
+// (the non-empty index diffs are structurally correct) and run without a live engine.
+
+// findIndexDiff locates an index diff entry within a table diff by name (case-insensitive).
+func findIndexDiff(e *TableDiffEntry, name string) *IndexDiffEntry {
+	if e == nil {
+		return nil
+	}
+	for i := range e.Indexes {
+		if toLower(e.Indexes[i].Name) == toLower(name) {
+			return &e.Indexes[i]
+		}
+	}
+	return nil
+}
+
+func TestDiffIndex_AddDropModify(t *testing.T) {
+	cases := []struct {
+		name       string
+		from       string
+		to         string
+		table      string
+		idx        string
+		wantAction DiffAction
+	}{
+		{
+			"add-secondary",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a))",
+			"t", "ka", DiffAdd,
+		},
+		{
+			"drop-secondary",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"t", "ka", DiffDrop,
+		},
+		{
+			"add-unique",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, UNIQUE KEY ua (a))",
+			"t", "ua", DiffAdd,
+		},
+		{
+			// Same name, columns change a -> a,b: a MODIFY (DROP+ADD at generate time).
+			"modify-columns",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY k (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY k (a,b))",
+			"t", "k", DiffModify,
+		},
+		{
+			// Non-unique -> unique with the same name is a kind change → MODIFY.
+			"modify-kind-unique",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, UNIQUE KEY k (a))",
+			"t", "k", DiffModify,
+		},
+		{
+			"add-primary-key",
+			"CREATE TABLE t (id INT NOT NULL, a INT)",
+			"CREATE TABLE t (id INT NOT NULL, a INT, PRIMARY KEY (id))",
+			"t", "PRIMARY", DiffAdd,
+		},
+		{
+			"drop-primary-key",
+			"CREATE TABLE t (id INT NOT NULL, a INT, PRIMARY KEY (id))",
+			"CREATE TABLE t (id INT NOT NULL, a INT)",
+			"t", "PRIMARY", DiffDrop,
+		},
+		{
+			// COMMENT change on a same-name index → MODIFY.
+			"modify-comment",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a) COMMENT 'x')",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a) COMMENT 'y')",
+			"t", "k", DiffModify,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			from := loadCat(t, dbDDL+tc.from)
+			to := loadCat(t, dbDDL+tc.to)
+			d := Diff(from, to)
+			te := findTable(d, tc.table)
+			if te == nil {
+				t.Fatalf("table %s not in diff", tc.table)
+			}
+			ie := findIndexDiff(te, tc.idx)
+			if ie == nil {
+				t.Fatalf("index %s not in diff of table %s; entries=%+v", tc.idx, tc.table, te.Indexes)
+			}
+			if ie.Action != tc.wantAction {
+				t.Errorf("index %s: want action %s, got %s", tc.idx, tc.wantAction, ie.Action)
+			}
+		})
+	}
+}
+
+// TestDiffIndex_NoPhantomOnReorder asserts that reordering indexes (declaration order) is not a
+// change: index identity is the name, and the column-content key is order-independent across
+// indexes (only column order WITHIN an index matters). Two tables with the same indexes in a
+// different textual order must diff empty.
+func TestDiffIndex_NoPhantomOnReorder(t *testing.T) {
+	a := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, x INT, y INT, KEY kx (x), KEY ky (y))")
+	b := loadCat(t, dbDDL+"CREATE TABLE t (id INT PRIMARY KEY, x INT, y INT, KEY ky (y), KEY kx (x))")
+	if d := Diff(a, b); !d.IsEmpty() {
+		t.Errorf("reorder of indexes must be empty, got: %s", describeDiff(d))
+	}
+}
+
+// TestDiffIndex_FKImplicitExcluded asserts the headline FK-implicit rule structurally, without a
+// live engine: a table whose only index is the one synthesized to back a foreign key reports NO
+// index diff against the same table, and the index is absent from the diff-able set. (The loader
+// synthesizes the backing index via ensureFKBackingIndex, so it is present in tbl.Indexes — the
+// differ must still exclude it.)
+func TestDiffIndex_FKImplicitExcluded(t *testing.T) {
+	sdl := dbDDL + "CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n" +
+		"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id));"
+	cat := loadCat(t, sdl)
+
+	// Self-diff is empty (no phantom on the FK backing index).
+	if d := Diff(cat, cat); !d.IsEmpty() {
+		t.Fatalf("self-diff with FK backing index must be empty, got: %s", describeDiff(d))
+	}
+
+	// The backing index `fk` exists in the model but is excluded from the diff-able set.
+	var child *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable("c"); tt != nil {
+			child = tt
+		}
+	}
+	if child == nil {
+		t.Fatal("table c not loaded")
+	}
+	if findIndex(child, "fk") == nil {
+		t.Fatal("precondition: loader should have synthesized backing index `fk`")
+	}
+	if _, present := diffableIndexMap(child)["fk"]; present {
+		t.Errorf("FK-implicit backing index `fk` must be excluded from the diff-able set")
+	}
+}
+
+// TestDiffIndex_ExplicitIndexOnFKColumnsKept asserts the inverse: a user index that merely covers
+// the FK columns but carries a user-only attribute (here a distinct name + it is the explicit
+// covering index, so MySQL creates no separate backing index) stays user-managed and IS diff-able.
+func TestDiffIndex_ExplicitIndexOnFKColumnsKept(t *testing.T) {
+	sdl := dbDDL + "CREATE TABLE p (id INT NOT NULL PRIMARY KEY);\n" +
+		"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY explicit_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id));"
+	cat := loadCat(t, sdl)
+	var child *Table
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable("c"); tt != nil {
+			child = tt
+		}
+	}
+	if child == nil {
+		t.Fatal("table c not loaded")
+	}
+	if _, present := diffableIndexMap(child)["explicit_idx"]; !present {
+		t.Errorf("explicit user index `explicit_idx` covering FK columns must remain diff-able")
+	}
+}
+
+// TestCanonicalIndex_VersionFlaggedAttrs asserts the version-divergent normalization decisions in
+// canonicalIndex directly: DESC and index KEY_BLOCK_SIZE are significant on 8.0/5.7 respectively
+// and dropped on the other, matching the live-engine behavior proven in the oracle tests.
+func TestCanonicalIndex_VersionFlaggedAttrs(t *testing.T) {
+	n80 := NormalizerFor(MySQL80)
+	n57 := NormalizerFor(MySQL57)
+
+	asc := &Index{Name: "k", Visible: true, Columns: []*IndexColumn{{Name: "a"}, {Name: "b"}}}
+	desc := &Index{Name: "k", Visible: true, Columns: []*IndexColumn{{Name: "a"}, {Name: "b", Descending: true}}}
+
+	// 8.0: DESC distinguishes; 5.7: DESC is dropped (stored ascending), so the keys collapse.
+	if canonicalIndex(asc, n80) == canonicalIndex(desc, n80) {
+		t.Errorf("8.0: ASC and DESC index keys must differ")
+	}
+	if canonicalIndex(asc, n57) != canonicalIndex(desc, n57) {
+		t.Errorf("5.7: DESC must be dropped from the key (stored ascending), keys must match")
+	}
+
+	plain := &Index{Name: "k", Visible: true, Columns: []*IndexColumn{{Name: "a"}}}
+	kbs := &Index{Name: "k", Visible: true, KeyBlockSize: 4, Columns: []*IndexColumn{{Name: "a"}}}
+
+	// 5.7: index KEY_BLOCK_SIZE is echoed → significant; 8.0: absorbed → dropped from the key.
+	if canonicalIndex(plain, n57) == canonicalIndex(kbs, n57) {
+		t.Errorf("5.7: index KEY_BLOCK_SIZE must contribute to the key")
+	}
+	if canonicalIndex(plain, n80) != canonicalIndex(kbs, n80) {
+		t.Errorf("8.0: index KEY_BLOCK_SIZE must be ignored in the key")
+	}
+}

--- a/mysql/catalog/diff_index_test.go
+++ b/mysql/catalog/diff_index_test.go
@@ -221,6 +221,36 @@ func TestDiffIndex_FKDroppedExplicitIndexKept(t *testing.T) {
 	}
 }
 
+// TestDiffIndex_ExplicitlyNamedIndexBackingFKEmitted asserts that a user index named DIFFERENTLY
+// from the FK's auto-backing name (constraint name / first column) is NOT treated as FK-implicit:
+// the user deliberately named it, so it must be diff-able and emitted (otherwise, when the FK is
+// added, the FK node would auto-create a differently-named backing index and the user's chosen
+// name would be lost). The pure-implicit FK (no explicit KEY) still emits nothing.
+func TestDiffIndex_ExplicitlyNamedIndexBackingFKEmitted(t *testing.T) {
+	// User explicitly names the backing index `idx_pid` (≠ constraint `fk_c_p`, ≠ column `pid`).
+	from := loadCat(t, dbDDL+"CREATE TABLE p (id INT PRIMARY KEY);\nCREATE TABLE c (pid INT);")
+	to := loadCat(t, dbDDL+"CREATE TABLE p (id INT PRIMARY KEY);\n"+
+		"CREATE TABLE c (pid INT, KEY idx_pid (pid), CONSTRAINT fk_c_p FOREIGN KEY (pid) REFERENCES p(id));")
+	d := Diff(from, to)
+	te := findTable(d, "c")
+	if te == nil || findIndexDiff(te, "idx_pid") == nil || findIndexDiff(te, "idx_pid").Action != DiffAdd {
+		t.Fatalf("expected ADD of user-named index idx_pid, got %s", describeDiff(d))
+	}
+
+	// The user index `idx_pid` is diff-able even with the FK present (it is not the auto name).
+	toChild := mustGetTable(t, to, "c")
+	if _, present := diffableIndexMap(toChild, nil)["idx_pid"]; !present {
+		t.Errorf("user-named idx_pid must remain diff-able alongside the FK")
+	}
+
+	// Counter-check: an index named like the auto-backing name (the column `pid`) IS excluded.
+	toAuto := loadCat(t, dbDDL+"CREATE TABLE p (id INT PRIMARY KEY);\n"+
+		"CREATE TABLE c (pid INT, KEY pid (pid), CONSTRAINT fk_c_p FOREIGN KEY (pid) REFERENCES p(id));")
+	if _, present := diffableIndexMap(mustGetTable(t, toAuto, "c"), nil)["pid"]; present {
+		t.Errorf("index named `pid` (the auto-backing name) must be excluded as FK-implicit")
+	}
+}
+
 // TestDiffIndex_FKImplicitNameCollision asserts that an unnamed FK whose backing-index name was
 // suffixed by allocIndexName on collision (here `pid_2`, because the user wrote `KEY pid (a)`) is
 // still detected as FK-implicit and excluded — structural detection does not depend on the

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -160,6 +160,20 @@ const priorityPrimaryKeyDrop = priorityIndexDrop - 1
 // the dropped PK member; the combined form is chosen only when AUTO_INCREMENT keys the new PK and
 // no PK-member column drop forces the split. `to` always carries the PRIMARY index for a PK
 // change (the diff keys it by the PRIMARY name), so DROP PRIMARY KEY is unconditional.
+//
+// KNOWN LIMITATIONS (flagged, not handled) — both are rare AUTO_INCREMENT corner cases whose
+// correct emission needs control over the column generator's op ordering (cross-node), which this
+// node does not have; recorded for a follow-up rather than special-cased:
+//   - Relocating an AUTO_INCREMENT column OUT of the PK onto a NEW secondary index in the same
+//     migration (old PK has the auto-inc column, new PK does not, a new KEY covers it): the split
+//     path's standalone DROP PRIMARY KEY leaves the auto-inc column unkeyed before its new
+//     secondary key is added (errno 1075). Atomicity would require pairing the PK drop with that
+//     specific secondary-key ADD in one ALTER.
+//   - AUTO_INCREMENT keeps the PK while a DIFFERENT old-PK member is demoted to nullable in the
+//     same migration: combined is needed to avoid the unkeyed AUTO_INCREMENT window (errno 1075),
+//     but the column's MODIFY ... NULL runs (priorityColumn) before the combined PhaseMain op
+//     (priorityIndex) while the old PK still holds it (errno 1171). Satisfying both needs the PK
+//     change emitted before the column modify, i.e. a column-op ordering this node cannot impose.
 func primaryKeyModifyOps(entry *TableDiffEntry, table string, to *Index, n *Normalizer) []MigrationOp {
 	if canCombinePrimaryKeyModify(entry, to) {
 		return []MigrationOp{{
@@ -188,16 +202,22 @@ func primaryKeyModifyOps(entry *TableDiffEntry, table string, to *Index, n *Norm
 }
 
 // canCombinePrimaryKeyModify reports whether a PK change may be emitted as a single combined
-// DROP+ADD statement: the new PK must include an AUTO_INCREMENT column (the reason the combined
-// form is needed — to avoid an unkeyed AUTO_INCREMENT window, errno 1075) AND no column that was a
-// member of the OLD PK may be dropped in this diff (such a drop runs in PhasePre and auto-removes
-// the PK before the combined PhaseMain statement, breaking its DROP PRIMARY KEY half). Otherwise
-// the split form (DROP PK early, ADD PK late) is used.
+// DROP+ADD statement. Two conditions must hold:
+//   - the new PK must include an AUTO_INCREMENT column (the reason the combined form is needed — to
+//     avoid an unkeyed AUTO_INCREMENT window, errno 1075); and
+//   - no column that was a member of the OLD PK may be DROPPED or DEMOTED TO NULLABLE in this diff.
+//     Such a column change runs before the combined PhaseMain statement (a DROP COLUMN in PhasePre,
+//     a MODIFY ... NULL at priorityColumn=20 < priorityIndex=30) while the old PK still holds the
+//     column, so the combined statement's DROP PRIMARY KEY half would fail — errno 1091 (the column
+//     drop already auto-removed the PK) or errno 1171 (a still-PK column cannot be made nullable).
+//
+// Otherwise the split form (DROP PK early in PhasePre, ADD PK late in PhaseMain) is used, which
+// releases the PK before those column changes run.
 func canCombinePrimaryKeyModify(entry *TableDiffEntry, to *Index) bool {
 	if !newPrimaryKeyHasAutoIncrement(entry.To, to) {
 		return false
 	}
-	return !oldPrimaryKeyMemberDropped(entry)
+	return !oldPrimaryKeyMemberDroppedOrDemoted(entry)
 }
 
 // newPrimaryKeyHasAutoIncrement reports whether any column of the new PK is AUTO_INCREMENT.
@@ -213,9 +233,13 @@ func newPrimaryKeyHasAutoIncrement(tbl *Table, pk *Index) bool {
 	return false
 }
 
-// oldPrimaryKeyMemberDropped reports whether any column being dropped in this diff was a member of
-// the old PRIMARY KEY — the case that forces the split form (the column drop auto-removes the PK).
-func oldPrimaryKeyMemberDropped(entry *TableDiffEntry) bool {
+// oldPrimaryKeyMemberDroppedOrDemoted reports whether any column that was a member of the OLD
+// PRIMARY KEY is, in this diff, either dropped or demoted to nullable — the cases that force the
+// split form because they conflict with the old PK still being present when an earlier-phase column
+// op runs (a DROP COLUMN auto-removes the PK → errno 1091; a MODIFY ... NULL on a still-PK column →
+// errno 1171). A column that merely leaves the PK but stays NOT NULL (and is not dropped) is fine
+// for the combined form.
+func oldPrimaryKeyMemberDroppedOrDemoted(entry *TableDiffEntry) bool {
 	if entry.From == nil {
 		return false
 	}
@@ -232,7 +256,15 @@ func oldPrimaryKeyMemberDropped(entry *TableDiffEntry) bool {
 		return false
 	}
 	for _, ce := range entry.Columns {
-		if ce.Action == DiffDrop && oldPKCols[toLower(ce.Name)] {
+		if !oldPKCols[toLower(ce.Name)] {
+			continue
+		}
+		if ce.Action == DiffDrop {
+			return true
+		}
+		// A modify that makes the old-PK-member column nullable (it is no longer PK-forced NOT NULL
+		// in `to`) conflicts with the still-present old PK if emitted before the combined statement.
+		if ce.Action == DiffModify && ce.To != nil && ce.To.Nullable {
 			return true
 		}
 	}

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -1,14 +1,241 @@
 package catalog
 
-// MySQL SDL generate — secondary indexes (scaffold stub).
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — indexes (the full index/key surface).
 //
-// Wired into GenerateMigrationWithNormalizer (migration.go) so index diffs become DDL.
-// Inert no-op placeholder returning nil until the index breadth node renders the ALTER
-// TABLE ... ADD/DROP INDEX ops from TableDiffEntry.Indexes (OpAddIndex/OpDropIndex,
-// priorityIndex). Signature mirrors generateTableDDL (migration_table.go).
+// This is the MySQL analog of PG's generateIndexDDL (pg/catalog/migration_index.go). It turns
+// the index diff (TableDiffEntry.Indexes, populated by diff_index.go) into ALTER TABLE ...
+// ADD/DROP index DDL. MySQL folds index changes into ALTER TABLE rather than standalone
+// CREATE/DROP INDEX statements, and an index cannot be altered in place, so a modified index is
+// a DROP followed by an ADD.
 //
-// implemented by omni:index breadth node
-func generateIndexDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no index ops (empty diff -> empty plan).
-	return nil
+// Two table cases produce index ADDs:
+//   - DiffModify: the per-index diff drives ADD / DROP / (DROP+ADD for MODIFY).
+//   - DiffAdd: a freshly created table. generate-core's formatCreateTable renders only columns
+//     and the inline PRIMARY KEY (migration_table.go) — it does NOT inline secondary/UNIQUE/
+//     FULLTEXT/SPATIAL indexes — so every non-PK, non-FK-implicit index on a new table is added
+//     here via ALTER TABLE ... ADD. The PK is already inline (skip it); FK-implicit-backing
+//     indexes are owned by the FK node (skip them, same exclusion as the diff).
+//
+// DiffDrop tables emit nothing: DROP TABLE removes their indexes wholesale.
+//
+// Rendering routes through the same canonical forms show.go uses for the stored index line, so
+// the readback of the emitted DDL canonicalizes equal to `to` and apply-correctness holds. PK
+// changes use ADD/DROP PRIMARY KEY; every other index uses ADD ... KEY / DROP INDEX.
+//
+// Ordering: index ADDs run in PhaseMain at priorityIndex (after the table CREATE and column
+// ALTERs, before deferred FKs in PhasePost — so a FK added in the same plan reuses an index this
+// node created rather than auto-creating a duplicate). Index DROPs run in PhasePre (before
+// PhaseMain), so a drop-then-add of the same index name never collides. sortMigrationOps
+// re-imposes the global phase/priority/name order.
+func generateIndexDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		switch entry.Action {
+		case DiffAdd:
+			ops = append(ops, addIndexOpsForNewTable(entry, n)...)
+		case DiffModify:
+			ops = append(ops, indexOpsForModifiedTable(entry, n)...)
+		case DiffDrop:
+			// DROP TABLE removes the indexes; nothing to emit.
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Type != ops[j].Type {
+			// Drops ahead of adds locally (also enforced by phase) for readability.
+			return indexOpRank(ops[i].Type) < indexOpRank(ops[j].Type)
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// addIndexOpsForNewTable emits ADD ops for every user-managed non-PK index on a freshly created
+// table (the PK is rendered inline by formatCreateTable; FK-implicit-backing indexes are the FK
+// node's). It uses the diff-able index set so the GIPK and FK-implicit indexes are excluded
+// exactly as in diffIndexes.
+func addIndexOpsForNewTable(entry *TableDiffEntry, n *Normalizer) []MigrationOp {
+	if entry.To == nil {
+		return nil
+	}
+	table := tableIdent(entry.To)
+	var ops []MigrationOp
+	for _, idx := range orderedDiffableIndexes(entry.To) {
+		if idx.Primary {
+			continue // inline in CREATE TABLE
+		}
+		ops = append(ops, addIndexOp(entry, table, idx, n))
+	}
+	return ops
+}
+
+// indexOpsForModifiedTable emits ADD / DROP / (DROP+ADD) ops from the per-index diff of a
+// modified table.
+func indexOpsForModifiedTable(entry *TableDiffEntry, n *Normalizer) []MigrationOp {
+	if entry.To == nil || len(entry.Indexes) == 0 {
+		return nil
+	}
+	table := tableIdent(entry.To)
+	var ops []MigrationOp
+	for _, ie := range entry.Indexes {
+		switch ie.Action {
+		case DiffAdd:
+			if ie.To == nil {
+				continue
+			}
+			ops = append(ops, addIndexOp(entry, table, ie.To, n))
+		case DiffDrop:
+			if ie.From == nil {
+				continue
+			}
+			ops = append(ops, dropIndexOp(entry, table, ie.From))
+		case DiffModify:
+			// MySQL cannot ALTER an index in place: DROP then ADD. The drop (PhasePre) always
+			// precedes the add (PhaseMain), so the name is free when the new form is created.
+			if ie.From == nil || ie.To == nil {
+				continue
+			}
+			ops = append(ops, dropIndexOp(entry, table, ie.From))
+			ops = append(ops, addIndexOp(entry, table, ie.To, n))
+		}
+	}
+	return ops
+}
+
+// addIndexOp builds an ALTER TABLE ... ADD <index> op. A PRIMARY KEY uses ADD PRIMARY KEY; every
+// other kind uses ADD <UNIQUE|FULLTEXT|SPATIAL> KEY `name` (...). The op runs in PhaseMain at
+// priorityIndex.
+func addIndexOp(entry *TableDiffEntry, table string, idx *Index, n *Normalizer) MigrationOp {
+	return MigrationOp{
+		Type:         OpAddIndex,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s ADD %s", table, formatIndexDefinition(idx, n)),
+		Phase:        PhaseMain,
+		Priority:     priorityIndex,
+		sortName:     indexSortName(entry.Database, entry.Name, idx.Name),
+	}
+}
+
+// dropIndexOp builds an ALTER TABLE ... DROP op. A PRIMARY KEY uses DROP PRIMARY KEY (it has no
+// user name); every other index uses DROP INDEX `name`. The op runs in PhasePre so all index
+// drops precede any add, and so a dropped index name is free for re-creation in the same plan.
+func dropIndexOp(entry *TableDiffEntry, table string, idx *Index) MigrationOp {
+	var clause string
+	if idx.Primary {
+		clause = "DROP PRIMARY KEY"
+	} else {
+		clause = "DROP INDEX " + migrationQuoteIdent(idx.Name)
+	}
+	return MigrationOp{
+		Type:         OpDropIndex,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
+		Phase:        PhasePre,
+		Priority:     priorityIndex,
+		sortName:     indexSortName(entry.Database, entry.Name, idx.Name),
+	}
+}
+
+// formatIndexDefinition renders the index clause that follows ADD in an ALTER TABLE, in MySQL's
+// canonical stored form: PRIMARY KEY (...) | UNIQUE KEY `name` (...) | FULLTEXT KEY `name` (...)
+// | SPATIAL KEY `name` (...) | KEY `name` (...), with the column parts, an optional USING type,
+// KEY_BLOCK_SIZE, COMMENT, and INVISIBLE marker.
+//
+// It mirrors show.go's showIndex (the stored index line) so the readback of the ADD
+// canonicalizes equal to `to`. The one addition over showIndex is KEY_BLOCK_SIZE: show.go never
+// emits it (SHOW CREATE drops the index-level value on 8.0), but the ADD must carry it so the
+// value is actually applied — on 5.7 the readback then echoes it (matches), and on 8.0 the
+// readback drops it but canonicalIndexKeyBlockSize also ignores it on 8.0, so the round-trip is
+// empty either way.
+func formatIndexDefinition(idx *Index, _ *Normalizer) string {
+	var b strings.Builder
+
+	switch {
+	case idx.Primary:
+		b.WriteString("PRIMARY KEY (")
+	case idx.Unique:
+		fmt.Fprintf(&b, "UNIQUE KEY %s (", migrationQuoteIdent(idx.Name))
+	case idx.Fulltext:
+		fmt.Fprintf(&b, "FULLTEXT KEY %s (", migrationQuoteIdent(idx.Name))
+	case idx.Spatial:
+		fmt.Fprintf(&b, "SPATIAL KEY %s (", migrationQuoteIdent(idx.Name))
+	default:
+		fmt.Fprintf(&b, "KEY %s (", migrationQuoteIdent(idx.Name))
+	}
+
+	cols := make([]string, 0, len(idx.Columns))
+	for _, ic := range idx.Columns {
+		cols = append(cols, migrationIndexColumn(ic))
+	}
+	b.WriteString(strings.Join(cols, ","))
+	b.WriteString(")")
+
+	// USING clause: only the user-selectable BTREE/HASH, never for PRIMARY/FULLTEXT/SPATIAL
+	// (matching show.go), so a redundant FULLTEXT/SPATIAL IndexType echo is not emitted.
+	if !idx.Primary && !idx.Fulltext && !idx.Spatial && idx.IndexType != "" {
+		fmt.Fprintf(&b, " USING %s", strings.ToUpper(idx.IndexType))
+	}
+
+	// KEY_BLOCK_SIZE: emit when set so the value is applied. (show.go omits it from the stored
+	// line; we emit it on the ADD — see the function doc for why this round-trips on both
+	// versions.)
+	if idx.KeyBlockSize > 0 {
+		fmt.Fprintf(&b, " KEY_BLOCK_SIZE=%d", idx.KeyBlockSize)
+	}
+
+	// COMMENT.
+	if idx.Comment != "" {
+		fmt.Fprintf(&b, " COMMENT %s", quoteStringLiteral(idx.Comment))
+	}
+
+	// INVISIBLE (8.0). The /*!80000 ... */ version guard makes it a no-op on 5.7, matching how
+	// show.go renders an invisible index, so the same DDL is valid on both engines.
+	if !idx.Visible {
+		b.WriteString(" /*!80000 INVISIBLE */")
+	}
+
+	return b.String()
+}
+
+// orderedDiffableIndexes returns a table's diff-able indexes (GIPK + FK-implicit excluded, the
+// same set diffIndexes uses) in a deterministic order: by lower-cased name. Determinism keeps a
+// new table's ADD INDEX sequence stable across runs.
+func orderedDiffableIndexes(t *Table) []*Index {
+	m := diffableIndexMap(t)
+	out := make([]*Index, 0, len(m))
+	for _, idx := range m {
+		out = append(out, idx)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return toLower(out[i].Name) < toLower(out[j].Name)
+	})
+	return out
+}
+
+// indexOpRank orders index op types so drops sort ahead of adds locally (phase ordering also
+// enforces this globally).
+func indexOpRank(t MigrationOpType) int {
+	if t == OpDropIndex {
+		return 0
+	}
+	return 1
+}
+
+// indexSortName is the stable secondary sort key for an index op: lower-cased
+// database.table.index.
+func indexSortName(database, table, index string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(table) + "." + strings.ToLower(index)
 }

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -102,19 +102,13 @@ func indexOpsForModifiedTable(entry *TableDiffEntry, n *Normalizer) []MigrationO
 			if ie.From == nil || ie.To == nil {
 				continue
 			}
-			// The PRIMARY KEY is special: dropping it in one statement and re-adding it in a
-			// later one leaves an AUTO_INCREMENT member column unkeyed in between, which MySQL
-			// rejects (errno 1075, "there can be only one auto column and it must be defined as a
-			// key"). MySQL accepts DROP PRIMARY KEY + ADD PRIMARY KEY in a SINGLE ALTER, with no
-			// unkeyed window — and a combined statement is valid whenever the separate pair is —
-			// so a PK change is always emitted as one op. (A non-PK index has no such constraint;
-			// it is a normal DROP-then-ADD across phases.)
+			// The PRIMARY KEY interacts with column changes, so it needs special ordering — see
+			// primaryKeyModifyOps. A secondary index is independent: DROP then ADD (the drop in
+			// PhasePre always precedes the PhaseMain add, freeing the name for re-creation).
 			if ie.To.Primary || ie.From.Primary {
-				ops = append(ops, modifyPrimaryKeyOp(entry, table, ie.To, n))
+				ops = append(ops, primaryKeyModifyOps(entry, table, ie.To, n)...)
 				continue
 			}
-			// MySQL cannot ALTER a secondary index in place: DROP then ADD. The drop (PhasePre)
-			// always precedes the add (PhaseMain), so the name is free when the new form is created.
 			ops = append(ops, dropIndexOp(entry, table, ie.From))
 			ops = append(ops, addIndexOp(entry, table, ie.To, n))
 		}
@@ -138,26 +132,111 @@ func addIndexOp(entry *TableDiffEntry, table string, idx *Index, n *Normalizer) 
 	}
 }
 
-// modifyPrimaryKeyOp builds a single combined ALTER TABLE ... DROP PRIMARY KEY, ADD PRIMARY KEY
-// (...) op for a PRIMARY KEY change. Combining the drop and re-add in one statement avoids the
-// transient unkeyed window a separate drop+add would create — which MySQL rejects for a table
-// with an AUTO_INCREMENT member (errno 1075). It runs in PhaseMain at priorityIndex; any NOT NULL
-// promotion a newly-added PK column needs is emitted independently by the column generator (the
-// column's canonical NOT NULL is PK-aware), and MySQL also auto-promotes PK members, so the
-// combined statement is correct regardless of the column op's relative order. `to` always has the
-// PRIMARY index for a PK change (the diff keys it by the PRIMARY name); the DROP PRIMARY KEY half
-// is unconditional because a PK modify always replaces an existing PK.
-func modifyPrimaryKeyOp(entry *TableDiffEntry, table string, to *Index, n *Normalizer) MigrationOp {
-	return MigrationOp{
-		Type:         OpAddIndex,
+// priorityPrimaryKeyDrop orders a standalone DROP PRIMARY KEY within PhasePre BEFORE column drops
+// AND column NOT NULL→NULL demotions. When a PK change also drops a column that was a member of
+// the OLD PK, or demotes a removed PK member to nullable, the PK must be gone first: a PhasePre
+// DROP COLUMN of a PK member auto-removes the PK (then a later DROP PRIMARY KEY fails errno 1091),
+// and MySQL rejects making a still-PK column nullable (errno 1171). Dropping the PK first frees
+// both. It sits just below the index-drop priority so the PK is the very first thing released.
+const priorityPrimaryKeyDrop = priorityIndexDrop - 1
+
+// primaryKeyModifyOps renders a PRIMARY KEY change, choosing between two correct shapes because a
+// PK change interleaves with the column generator's ops (which this node does not control):
+//
+//   - COMBINED, one statement `ALTER TABLE ... DROP PRIMARY KEY, ADD PRIMARY KEY (...)` in
+//     PhaseMain. This is required when an AUTO_INCREMENT column is a member of the new PK: a
+//     standalone DROP PRIMARY KEY would leave that column momentarily unkeyed, which MySQL rejects
+//     (errno 1075). The combined statement has no unkeyed window. It is only valid, though, when no
+//     OLD-PK-member column is being dropped in the same diff — a PhasePre DROP COLUMN of a PK
+//     member auto-removes the PK before this PhaseMain statement runs, so its DROP PRIMARY KEY half
+//     would fail (errno 1091).
+//   - SPLIT: a standalone DROP PRIMARY KEY in PhasePre (at priorityPrimaryKeyDrop, before column
+//     drops and NOT NULL demotions) plus an ADD PRIMARY KEY in PhaseMain (at priorityIndex, after
+//     the column generator's adds/modifies at priorityColumn, so the new PK's columns are already
+//     present and NOT NULL). This is correct whenever a PK member is dropped or demoted, and for
+//     all non-AUTO_INCREMENT PK changes.
+//
+// The two cases are disjoint in practice: an AUTO_INCREMENT column must stay keyed, so it is never
+// the dropped PK member; the combined form is chosen only when AUTO_INCREMENT keys the new PK and
+// no PK-member column drop forces the split. `to` always carries the PRIMARY index for a PK
+// change (the diff keys it by the PRIMARY name), so DROP PRIMARY KEY is unconditional.
+func primaryKeyModifyOps(entry *TableDiffEntry, table string, to *Index, n *Normalizer) []MigrationOp {
+	if canCombinePrimaryKeyModify(entry, to) {
+		return []MigrationOp{{
+			Type:         OpAddIndex,
+			Database:     entry.Database,
+			ObjectName:   entry.Name,
+			ParentObject: entry.Name,
+			SQL:          fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY, ADD %s", table, formatIndexDefinition(to, n)),
+			Phase:        PhaseMain,
+			Priority:     priorityIndex,
+			sortName:     indexSortName(entry.Database, entry.Name, to.Name),
+		}}
+	}
+	dropPK := MigrationOp{
+		Type:         OpDropIndex,
 		Database:     entry.Database,
 		ObjectName:   entry.Name,
 		ParentObject: entry.Name,
-		SQL:          fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY, ADD %s", table, formatIndexDefinition(to, n)),
-		Phase:        PhaseMain,
-		Priority:     priorityIndex,
+		SQL:          fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY", table),
+		Phase:        PhasePre,
+		Priority:     priorityPrimaryKeyDrop,
 		sortName:     indexSortName(entry.Database, entry.Name, to.Name),
 	}
+	addPK := addIndexOp(entry, table, to, n)
+	return []MigrationOp{dropPK, addPK}
+}
+
+// canCombinePrimaryKeyModify reports whether a PK change may be emitted as a single combined
+// DROP+ADD statement: the new PK must include an AUTO_INCREMENT column (the reason the combined
+// form is needed — to avoid an unkeyed AUTO_INCREMENT window, errno 1075) AND no column that was a
+// member of the OLD PK may be dropped in this diff (such a drop runs in PhasePre and auto-removes
+// the PK before the combined PhaseMain statement, breaking its DROP PRIMARY KEY half). Otherwise
+// the split form (DROP PK early, ADD PK late) is used.
+func canCombinePrimaryKeyModify(entry *TableDiffEntry, to *Index) bool {
+	if !newPrimaryKeyHasAutoIncrement(entry.To, to) {
+		return false
+	}
+	return !oldPrimaryKeyMemberDropped(entry)
+}
+
+// newPrimaryKeyHasAutoIncrement reports whether any column of the new PK is AUTO_INCREMENT.
+func newPrimaryKeyHasAutoIncrement(tbl *Table, pk *Index) bool {
+	if tbl == nil || pk == nil {
+		return false
+	}
+	for _, ic := range pk.Columns {
+		if col := tbl.GetColumn(ic.Name); col != nil && col.AutoIncrement {
+			return true
+		}
+	}
+	return false
+}
+
+// oldPrimaryKeyMemberDropped reports whether any column being dropped in this diff was a member of
+// the old PRIMARY KEY — the case that forces the split form (the column drop auto-removes the PK).
+func oldPrimaryKeyMemberDropped(entry *TableDiffEntry) bool {
+	if entry.From == nil {
+		return false
+	}
+	oldPKCols := make(map[string]bool)
+	for _, idx := range entry.From.Indexes {
+		if idx != nil && idx.Primary {
+			for _, ic := range idx.Columns {
+				oldPKCols[toLower(ic.Name)] = true
+			}
+			break
+		}
+	}
+	if len(oldPKCols) == 0 {
+		return false
+	}
+	for _, ce := range entry.Columns {
+		if ce.Action == DiffDrop && oldPKCols[toLower(ce.Name)] {
+			return true
+		}
+	}
+	return false
 }
 
 // priorityIndexDrop orders an index DROP within PhasePre BEFORE any column DROP. MySQL's
@@ -259,9 +338,11 @@ func formatIndexDefinition(idx *Index, _ *Normalizer) string {
 
 // orderedDiffableIndexes returns a table's diff-able indexes (GIPK + FK-implicit excluded, the
 // same set diffIndexes uses) in a deterministic order: by lower-cased name. Determinism keeps a
-// new table's ADD INDEX sequence stable across runs.
+// new table's ADD INDEX sequence stable across runs. This is a single-table (new-table) context
+// with no other side, so FK-implicit indexes are excluded unconditionally (nil other-side set) —
+// the FK node adds the backing index for a newly created table's foreign keys.
 func orderedDiffableIndexes(t *Table) []*Index {
-	m := diffableIndexMap(t)
+	m := diffableIndexMap(t, nil)
 	out := make([]*Index, 0, len(m))
 	for _, idx := range m {
 		out = append(out, idx)

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -99,11 +99,22 @@ func indexOpsForModifiedTable(entry *TableDiffEntry, n *Normalizer) []MigrationO
 			}
 			ops = append(ops, dropIndexOp(entry, table, ie.From))
 		case DiffModify:
-			// MySQL cannot ALTER an index in place: DROP then ADD. The drop (PhasePre) always
-			// precedes the add (PhaseMain), so the name is free when the new form is created.
 			if ie.From == nil || ie.To == nil {
 				continue
 			}
+			// The PRIMARY KEY is special: dropping it in one statement and re-adding it in a
+			// later one leaves an AUTO_INCREMENT member column unkeyed in between, which MySQL
+			// rejects (errno 1075, "there can be only one auto column and it must be defined as a
+			// key"). MySQL accepts DROP PRIMARY KEY + ADD PRIMARY KEY in a SINGLE ALTER, with no
+			// unkeyed window — and a combined statement is valid whenever the separate pair is —
+			// so a PK change is always emitted as one op. (A non-PK index has no such constraint;
+			// it is a normal DROP-then-ADD across phases.)
+			if ie.To.Primary || ie.From.Primary {
+				ops = append(ops, modifyPrimaryKeyOp(entry, table, ie.To, n))
+				continue
+			}
+			// MySQL cannot ALTER a secondary index in place: DROP then ADD. The drop (PhasePre)
+			// always precedes the add (PhaseMain), so the name is free when the new form is created.
 			ops = append(ops, dropIndexOp(entry, table, ie.From))
 			ops = append(ops, addIndexOp(entry, table, ie.To, n))
 		}
@@ -124,6 +135,28 @@ func addIndexOp(entry *TableDiffEntry, table string, idx *Index, n *Normalizer) 
 		Phase:        PhaseMain,
 		Priority:     priorityIndex,
 		sortName:     indexSortName(entry.Database, entry.Name, idx.Name),
+	}
+}
+
+// modifyPrimaryKeyOp builds a single combined ALTER TABLE ... DROP PRIMARY KEY, ADD PRIMARY KEY
+// (...) op for a PRIMARY KEY change. Combining the drop and re-add in one statement avoids the
+// transient unkeyed window a separate drop+add would create — which MySQL rejects for a table
+// with an AUTO_INCREMENT member (errno 1075). It runs in PhaseMain at priorityIndex; any NOT NULL
+// promotion a newly-added PK column needs is emitted independently by the column generator (the
+// column's canonical NOT NULL is PK-aware), and MySQL also auto-promotes PK members, so the
+// combined statement is correct regardless of the column op's relative order. `to` always has the
+// PRIMARY index for a PK change (the diff keys it by the PRIMARY name); the DROP PRIMARY KEY half
+// is unconditional because a PK modify always replaces an existing PK.
+func modifyPrimaryKeyOp(entry *TableDiffEntry, table string, to *Index, n *Normalizer) MigrationOp {
+	return MigrationOp{
+		Type:         OpAddIndex,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY, ADD %s", table, formatIndexDefinition(to, n)),
+		Phase:        PhaseMain,
+		Priority:     priorityIndex,
+		sortName:     indexSortName(entry.Database, entry.Name, to.Name),
 	}
 }
 

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -127,9 +127,23 @@ func addIndexOp(entry *TableDiffEntry, table string, idx *Index, n *Normalizer) 
 	}
 }
 
+// priorityIndexDrop orders an index DROP within PhasePre BEFORE any column DROP. MySQL's
+// ALTER TABLE ... DROP COLUMN auto-removes an index that the dropped column leaves empty (a
+// single-column index, or the last remaining column of a composite one), after which an
+// explicit DROP INDEX for that index fails with errno 1091 ("Can't DROP 'k'; check that
+// column/key exists"). Because the migration plan is applied one statement at a time, the index
+// DROP must precede the column DROP. Column drops run at priorityColumn-1 (generated) /
+// priorityColumn (plain) within PhasePre, and table drops at priorityTable=10; this sits below
+// the column-drop range and above the table-drop, so the order is:
+// table-drop (10) < index-drop (15) < generated-col-drop (19) < plain-col-drop (20).
+// Dropping an index whose columns are NOT being dropped is harmless to sequence first (it is
+// independent), so always ordering index drops ahead of column drops is safe and simple.
+const priorityIndexDrop = priorityColumn - 5
+
 // dropIndexOp builds an ALTER TABLE ... DROP op. A PRIMARY KEY uses DROP PRIMARY KEY (it has no
-// user name); every other index uses DROP INDEX `name`. The op runs in PhasePre so all index
-// drops precede any add, and so a dropped index name is free for re-creation in the same plan.
+// user name); every other index uses DROP INDEX `name`. The op runs in PhasePre at
+// priorityIndexDrop so all index drops precede any add AND precede column drops (see
+// priorityIndexDrop), and so a dropped index name is free for re-creation in the same plan.
 func dropIndexOp(entry *TableDiffEntry, table string, idx *Index) MigrationOp {
 	var clause string
 	if idx.Primary {
@@ -144,7 +158,7 @@ func dropIndexOp(entry *TableDiffEntry, table string, idx *Index) MigrationOp {
 		ParentObject: entry.Name,
 		SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
 		Phase:        PhasePre,
-		Priority:     priorityIndex,
+		Priority:     priorityIndexDrop,
 		sortName:     indexSortName(entry.Database, entry.Name, idx.Name),
 	}
 }

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -1,0 +1,228 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle apply-correctness proof for the index generator (correctness-protocol.md gate 2),
+// against the LIVE MySQL engines. For representative (from, to) pairs covering every index
+// variant, the generated ALTER TABLE ... ADD/DROP index DDL applied to a real `from` database
+// must yield a table whose canonical form equals `to`. Idempotence (gate 1) for index forms is
+// covered by extending the migration idempotence corpus is not needed here because the index
+// diff probes already prove the no-op plan is empty via TestOracle_IndexDiffIdempotence; this
+// file proves the EMITTED DDL is correct.
+//
+// The harness reuses assertApplyCorrect / catalogFromReadback / loadOneTable / connectOracle /
+// both / only from migration_oracle_test.go; it skips cleanly when the engines are unreachable.
+
+// indexMigrationProbes enumerates the index ADD/DROP/MODIFY FORMS the generator covers. Each is a
+// single-table (from, to) pair (FK-backing indexes are proven separately — they need a parent and
+// are owned by the FK node). An empty fromDDL means a pure CREATE, which exercises the
+// "new table → ADD INDEX for every non-PK index" path (formatCreateTable inlines only the PK).
+func indexMigrationProbes() []migrationProbe {
+	return []migrationProbe{
+		// ---- CREATE TABLE carrying indexes (new table; non-PK indexes added via ALTER) ----
+		{"create-with-secondary", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ka (a), KEY kab (a,b))", both()},
+		{"create-with-unique", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, UNIQUE KEY ua (a), UNIQUE KEY uab (a,b))", both()},
+		{"create-with-prefix", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(100), KEY sp (s(10)))", both()},
+		{"create-with-comment", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a) COMMENT 'hello')", both()},
+		{"create-with-using-btree", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ua (a) USING BTREE) ENGINE=InnoDB", both()},
+		{"create-with-kbs", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a) KEY_BLOCK_SIZE=4) ENGINE=InnoDB", both()},
+		{"create-with-composite-pk", "t", "",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY (a,b), KEY kc (c))", both()},
+		{"create-with-fulltext", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, body TEXT, FULLTEXT KEY ftb (body))", both()},
+		// 8.0-only forms.
+		{"create-with-descending", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ab (a, b DESC))", only(MySQL80)},
+		{"create-with-invisible", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY va (a) /*!80000 INVISIBLE */)", only(MySQL80)},
+		{"create-with-functional", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY fa ((a + 1)))", only(MySQL80)},
+		{"create-with-spatial", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL, SPATIAL KEY sg (g))", only(MySQL80)},
+
+		// ---- ADD INDEX (modified table) ----
+		{"add-secondary", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a))", both()},
+		{"add-unique", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, UNIQUE KEY ua (a))", both()},
+		{"add-composite", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY kab (a,b))", both()},
+		{"add-prefix", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(100))",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(100), KEY sp (s(10)))", both()},
+		{"add-comment", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a) COMMENT 'c')", both()},
+		{"add-fulltext", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, body TEXT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, body TEXT, FULLTEXT KEY ftb (body))", both()},
+		{"add-primary-key", "t",
+			"CREATE TABLE t (id INT NOT NULL, a INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)", both()},
+		// 8.0-only.
+		{"add-descending", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ab (a, b DESC))", only(MySQL80)},
+		{"add-invisible", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY va (a) /*!80000 INVISIBLE */)", only(MySQL80)},
+		{"add-functional", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY fa ((a + 1)))", only(MySQL80)},
+
+		// ---- DROP INDEX (modified table) ----
+		{"drop-secondary", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)", both()},
+		{"drop-unique", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, UNIQUE KEY ua (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)", both()},
+		{"drop-primary-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT NOT NULL, a INT)", both()},
+		{"drop-one-of-many", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ka (a), KEY kb (b))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY kb (b))", both()},
+
+		// ---- MODIFY index (DROP+ADD): same name, changed shape ----
+		{"modify-columns", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY k (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY k (a,b))", both()},
+		{"modify-kind-to-unique", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, UNIQUE KEY k (a))", both()},
+		{"modify-prefix-length", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(100), KEY k (s(10)))",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(100), KEY k (s(20)))", both()},
+		{"modify-comment", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a) COMMENT 'old')",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a) COMMENT 'new')", both()},
+		{"modify-pk-columns", "t",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a))",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b))", both()},
+		// 8.0-only: visibility flip and direction flip are MODIFYs.
+		{"modify-visibility", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a) /*!80000 INVISIBLE */)", only(MySQL80)},
+		{"modify-direction", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a DESC))", only(MySQL80)},
+	}
+}
+
+// TestOracle_IndexMigrationApplyCorrectness proves gate 2 for every index probe: the generated
+// DDL transforms a real `from` database into a `to`-equal one (compared via canonical readback).
+func TestOracle_IndexMigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range indexMigrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// TestOracle_IndexGenerateFKOnlyChangeEmitsNoIndexOps proves the generate-side of the FK-implicit
+// contract: when the only difference between `from` and `to` is a foreign key (its backing index
+// rides along), the index generator emits NO ADD/DROP index ops — the FK node owns that index.
+// This guards against the index node fighting the FK node (duplicate-key-name on ADD, errno 1553
+// on DROP). Proven via a multi-table schema loaded from real engine readbacks.
+func TestOracle_IndexGenerateFKOnlyChangeEmitsNoIndexOps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+		ctx := context.Background()
+
+		// Load a 2-table schema (parent + child) from real readbacks for a given child DDL.
+		loadSchema := func(dbName, childDDL string) *Catalog {
+			stmts := []string{
+				"DROP DATABASE IF EXISTS " + dbName,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, sc),
+				"USE " + dbName,
+				"CREATE TABLE p (id INT NOT NULL PRIMARY KEY, name VARCHAR(50))",
+				childDDL,
+			}
+			for _, s := range stmts {
+				if _, err := o.db.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup: %q: %v", o.name, s, err)
+				}
+			}
+			var b strings.Builder
+			fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, sc, dbName)
+			for _, tbl := range []string{"p", "c"} {
+				var nm, ddl string
+				row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", dbName, tbl))
+				if err := row.Scan(&nm, &ddl); err != nil {
+					t.Fatalf("[%s] show create %s: %v", o.name, tbl, err)
+				}
+				b.WriteString(ddl + ";\n")
+			}
+			cat, err := LoadSQL(b.String())
+			if err != nil {
+				t.Fatalf("[%s] reload: %v\n%s", o.name, err, b.String())
+			}
+			return cat
+		}
+
+		assertNoIndexOps := func(t *testing.T, from, to *Catalog) {
+			t.Helper()
+			diff := DiffWithNormalizer(from, to, n)
+			plan := GenerateMigrationWithNormalizer(from, to, diff, n)
+			for _, op := range plan.Ops {
+				if op.Type == OpAddIndex || op.Type == OpDropIndex {
+					t.Errorf("[%s] unexpected index op on FK-only change: %s", o.name, op.SQL)
+				}
+			}
+		}
+
+		// from: child with FK (backing index auto-created); to: same child WITHOUT the FK (and
+		// hence — in the user's target — without the backing index). The index plan must be empty:
+		// the FK node drops the FK; the leftover backing index is the FK node's concern.
+		t.Run(o.name+"/drop-fk-no-index-op", func(t *testing.T) {
+			from := loadSchema("idxgfk1", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))")
+			// `to`: child with neither FK nor index (a plain table).
+			toWrapped := fmt.Sprintf("CREATE DATABASE idxgfk1 DEFAULT CHARSET=%s;\nUSE idxgfk1;\nCREATE TABLE p (id INT NOT NULL PRIMARY KEY, name VARCHAR(50));\nCREATE TABLE c (id INT PRIMARY KEY, pid INT);", sc)
+			to, err := LoadSQL(toWrapped)
+			if err != nil {
+				t.Fatalf("to load: %v", err)
+			}
+			assertNoIndexOps(t, from, to)
+		})
+
+		// from: child with neither; to: child with FK (backing index rides with it). Adding the FK
+		// is the FK node's job; the index plan must be empty.
+		t.Run(o.name+"/add-fk-no-index-op", func(t *testing.T) {
+			from := loadSchema("idxgfk2", "CREATE TABLE c (id INT PRIMARY KEY, pid INT)")
+			toCat := loadSchema("idxgfk2b", "CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))")
+			assertNoIndexOps(t, from, toCat)
+		})
+	}
+}

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -123,6 +123,28 @@ func indexMigrationProbes() []migrationProbe {
 		{"modify-direction", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a DESC))", only(MySQL80)},
+
+		// ---- index DROP + column DROP interplay (ordering: DROP INDEX before DROP COLUMN) ----
+		// MySQL auto-drops a single-column index when its column is dropped; an explicit DROP INDEX
+		// after the column is gone fails errno 1091. The index drop must precede the column drop.
+		{"drop-column-and-its-single-col-index", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a))",
+			"CREATE TABLE t (id INT PRIMARY KEY)", both()},
+		// Composite index on (a,b); dropping BOTH columns auto-drops the index → the explicit DROP
+		// INDEX must still come first.
+		{"drop-columns-and-their-composite-index", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY kab (a,b))",
+			"CREATE TABLE t (id INT PRIMARY KEY)", both()},
+		// Drop one column of a composite index but keep the index name on the remaining column:
+		// k (a,b) → k (b) while dropping a. This is a MODIFY (DROP+ADD) racing a column DROP; the
+		// index DROP (PhasePre) precedes the column DROP, and the re-ADD (PhaseMain) lands after.
+		{"modify-index-shrink-with-column-drop", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY k (a,b))",
+			"CREATE TABLE t (id INT PRIMARY KEY, b INT, KEY k (b))", both()},
+		// Add a column AND an index on it in the same plan (ADD COLUMN then ADD INDEX).
+		{"add-column-and-index-on-it", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY ka (a))", both()},
 	}
 }
 

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -127,6 +127,17 @@ func indexMigrationProbes() []migrationProbe {
 		{"modify-pk-swap-autoincrement", "t",
 			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (id,a))",
 			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (id,b))", both()},
+		// PK change that ALSO drops a column which was a member of the old PK: the PK must be
+		// dropped (PhasePre) before the column drop auto-removes it, then re-added (PhaseMain) after
+		// — the split form (errno 1091 otherwise).
+		{"modify-pk-drop-old-member", "t",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a))",
+			"CREATE TABLE t (b INT NOT NULL, c INT, PRIMARY KEY (b))", both()},
+		// PK shrink that demotes a removed PK member to nullable: the PK must be dropped before the
+		// MODIFY ... NULL (errno 1171 otherwise — a still-PK column cannot be made nullable).
+		{"modify-pk-shrink-demote-nullable", "t",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b))",
+			"CREATE TABLE t (a INT NOT NULL, b INT NULL, PRIMARY KEY (a))", both()},
 		// 8.0-only: visibility flip and direction flip are MODIFYs.
 		{"modify-visibility", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -116,6 +116,17 @@ func indexMigrationProbes() []migrationProbe {
 		{"modify-pk-columns", "t",
 			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a))",
 			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b))", both()},
+		// PK change on an AUTO_INCREMENT table: the combined DROP+ADD PRIMARY KEY in one ALTER
+		// avoids the unkeyed window that leaves the AUTO_INCREMENT column without a key (errno
+		// 1075). `a` is promoted to NOT NULL to join the PK (column generator + MySQL auto-promote).
+		{"modify-pk-autoincrement", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT NOT NULL)",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, PRIMARY KEY (id,a))", both()},
+		// PK swap to a different column on an AUTO_INCREMENT table (id stays auto-inc, still keyed
+		// by the new composite PK that includes it).
+		{"modify-pk-swap-autoincrement", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (id,a))",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (id,b))", both()},
 		// 8.0-only: visibility flip and direction flip are MODIFYs.
 		{"modify-visibility", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -138,6 +138,12 @@ func indexMigrationProbes() []migrationProbe {
 		{"modify-pk-shrink-demote-nullable", "t",
 			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b))",
 			"CREATE TABLE t (a INT NOT NULL, b INT NULL, PRIMARY KEY (a))", both()},
+		// NOTE: the combination "AUTO_INCREMENT keeps the PK AND a different old-PK member is
+		// demoted to nullable in the same migration" is a FLAGGED known limitation (see
+		// primaryKeyModifyOps): combined-vs-split cannot satisfy both the no-unkeyed-AUTO_INCREMENT
+		// constraint (needs combined) and the demote-after-PK-drop constraint (needs split) without
+		// reordering the column generator's ops, which this node does not control. It is recorded,
+		// not proven here.
 		// 8.0-only: visibility flip and direction flip are MODIFYs.
 		{"modify-visibility", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",


### PR DESCRIPTION
## What

Fills the two MySQL SDL **index** breadth-node stubs so a created/modified table reports and emits its index changes across the **full key surface**:

- `mysql/catalog/diff_index.go` — `diffIndexes(from, to *Table, n *Normalizer) []IndexDiffEntry` (was a `nil` stub; called from `compareTable`).
- `mysql/catalog/migration_index.go` — `generateIndexDDL(from, to *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp` (was a `nil` stub; called from `GenerateMigrationWithNormalizer`).

Only these two production files change (plus three new test files). The diff-core/generate-core hooks already call these functions; no edits to `diff.go` / `diff_table.go` / `migration.go`.

## Surface covered

PRIMARY KEY, UNIQUE (MySQL's unique constraint **is** a unique index), secondary (non-unique), FULLTEXT, SPATIAL, prefix length `col(N)`, functional/expression `((expr))` (8.0), descending (8.0; no-op on 5.7), invisible (8.0), composite, and index options `USING BTREE/HASH`, `KEY_BLOCK_SIZE`, index `COMMENT`. Resolves generate-core's noted AUTO_INCREMENT-backed-by-non-PK-key gap for the **PK-modify** path (combined `DROP/ADD PRIMARY KEY`).

## Design

- **Ownership**: this node owns the whole `Table.Indexes` slice (PK/UNIQUE are index-rendered in MySQL — see `show.go`); the constraint node owns only FK + CHECK. Same split `show.go` uses.
- **Canonical key** (`canonicalIndex`) routes every canonicalization-sensitive part through normalize-core: `CanonicalIndexColumn` for column parts (prefix + version-flagged DESC: 8.0 keeps, 5.7 stores ascending), `CanonicalGeneratedExpr` for functional expressions, `CanonicalComment`. Index `KEY_BLOCK_SIZE` is version-flagged (significant on 5.7 where SHOW CREATE echoes it; ignored on 8.0 which absorbs it) — verified against both live engines.
- **FK-implicit backing indexes** are detected **structurally** (a plain index whose columns exactly equal a FK's columns — what `ensureFKBackingIndex` synthesizes) and excluded with a **cross-side rule**: an FK-implicit index is excluded only when the other side has no genuine USER index of that name. This handles FK add / drop / column-change / "FK dropped but index kept" without phantom `ADD`/`DROP` (errno 1061/1553) — see the FK-implicit note below.
- **Ordering**: index DROP runs `PhasePre` *before* column DROP (MySQL auto-drops a single/last-column index on `DROP COLUMN` → errno 1091); ADD runs `PhaseMain`/`priorityIndex` (before deferred FKs, so a FK reuses a just-added index). PK modify uses a combined `DROP PRIMARY KEY, ADD PRIMARY KEY` statement when an AUTO_INCREMENT column keys the new PK (no unkeyed window, errno 1075), else a split DROP-early/ADD-late.

## Proof — live oracle, both gates, both engines (5.7 :13307, 8.0 :13306)

Per `correctness-protocol.md`, every variant passes **idempotence** (user-form DDL vs its `SHOW CREATE` readback diffs empty; auto-named unnamed index collapses onto the readback's name) and **apply-correctness** (`GenerateMigration(from,to)` applied to a real `from` yields `to`). 123 index oracle subtests pass across both engines:

- Idempotence/canonicalization: `TestOracle_IndexDiffIdempotence` (pk simple/composite, unique, secondary, unnamed→auto-name, USING BTREE, prefix, comment, KEY_BLOCK_SIZE, descending, composite-mixed, invisible, functional, fulltext, spatial, mixed).
- FK-implicit: `TestOracle_IndexDiffFKImplicit` (named/unnamed implicit, explicit-covering, composite, name-collision `pid_2`, user-named `c_ibfk_1`), `TestOracle_IndexFKColumnChangeNoIndexOps`, `TestOracle_IndexGenerateFKOnlyChangeEmitsNoIndexOps`.
- Apply: `TestOracle_IndexMigrationApplyCorrectness` (create-with-*, add/drop/modify per variant, PK add/drop/modify incl. AUTO_INCREMENT, drop-column+index ordering, modify-shrink).

Hermetic structural tests (no engine): `diff_index_test.go`.

## Normalization rules applied

| Rule | Decision | Evidence |
|---|---|---|
| Descending index column | 8.0 significant, 5.7 dropped (stored ascending) | normalize-core `CanonicalIndexColumn`; live 5.7 echoes no `DESC` |
| Index `KEY_BLOCK_SIZE` | 5.7 significant (echoed), 8.0 ignored (absorbed) | live: 8.0 omits the index-level clause + `information_schema` shows none |
| `USING` for FULLTEXT/SPATIAL | normalized out of the key (redundant with the kind flag; never echoed) | `show.go` |

## Flagged (NOT patched here — belong to other nodes)

- **`normalization_flags`**: `USING HASH` on an InnoDB index does not round-trip — InnoDB coerces HASH→BTREE and the echo is version+kind divergent (8.0 omits the clause; 5.7 InnoDB UNIQUE keeps `USING HASH`; MEMORY keeps it). The canonical `USING` form for InnoDB belongs in normalize-core / the loader's `coerceInnoDBHashIndex` (which today coerces only secondary keys). Not fixable from the two index files.
- **generate-core**: `CREATE TABLE` for an AUTO_INCREMENT column whose only key is a non-PK index fails errno 1075 because `formatCreateTable` (`migration_table.go`) inlines only the PK; the column's AUTO_INCREMENT must be inlined with its key, or applied via a post-CREATE MODIFY.
- **Rare cross-node PK corners** (documented in `primaryKeyModifyOps`): relocating an auto-inc column from the PK to a new secondary key, and auto-inc keeping the PK while a *different* old-PK member is demoted nullable in the same migration — both need control over the column generator's op ordering.

## Note — how FK-implicit indexes are detected (for the FK node + smoke test)

An index is **FK-implicit** (owned by the FK node, never emitted as a user index change) when it is **plain** (non-unique/fulltext/spatial, default USING, no comment/`KEY_BLOCK_SIZE`, visible) and its column parts **exactly equal** some `table.ForeignKeys` constraint's columns (no prefix/expr/DESC) — i.e. byte-for-byte what `ensureFKBackingIndex` synthesizes. Cross-referencing `table.ForeignKeys` (already loaded by `LoadSDL`), not the FK node's code. Detection is **structural, not name-based** (robust to allocIndexName collisions like `pid_2` and user FK names shaped like `<table>_ibfk_N`). The exclusion is applied **cross-side**: kept only when the *other* side has a genuine USER index of that name, so (a) a backing index whose FK changes columns stays excluded, and (b) an index that backs a FK on one side but is standalone on the other (FK dropped, index kept) stays visible — no phantom ADD/DROP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
