### PR TITLE
feat(mysql/catalog): implement foreign-key diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_foreign_key.go
+++ b/mysql/catalog/diff_foreign_key.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -112,14 +113,14 @@ func foreignKeysChanged(a, b *Constraint, n *Normalizer) bool {
 //     ACTION / absent onto one "default" key (see that function for the per-version echo
 //     evidence).
 //
-// The referencing columns, referenced database/table, and referenced columns are compared
+// The referencing columns, referenced table, and referenced columns are compared
 // case-insensitively and ORDER-SENSITIVELY (a composite FK's column order is significant). The
-// referenced database is folded to lower case but kept distinct from "" — a same-database FK
-// (SHOW CREATE omits the db qualifier → RefDatabase == "") and an explicitly-qualified one are
-// the same FK only when both resolve to the same schema; since the synced readback never
-// qualifies a same-db FK, "" is the canonical same-db form and is preserved verbatim. The
-// constraint NAME is the identity key (handled by the caller's map), not part of this content
-// key.
+// referenced database is canonicalized through canonicalRefDatabase: a SAME-database FK is the
+// canonical empty form, because SHOW CREATE STRIPS the database qualifier for a same-db reference
+// (verified on the live engine: `REFERENCES d.p(id)` reads back as `REFERENCES p (id)`). So a
+// user form that explicitly qualifies the FK's own database collapses onto the unqualified
+// readback; only a genuine CROSS-database reference contributes a non-empty refdb. The constraint
+// NAME is the identity key (handled by the caller's map), not part of this content key.
 //
 // The Normalizer is threaded for symmetry with the other differs and so the action
 // canonicalization can move to normalize-core later (it is version-independent for the
@@ -129,12 +130,29 @@ func foreignKeysChanged(a, b *Constraint, n *Normalizer) bool {
 func canonicalForeignKey(con *Constraint, _ *Normalizer) string {
 	return encodeKeyFields(
 		"cols", lowerJoin(con.Columns),
-		"refdb", toLower(con.RefDatabase),
+		"refdb", canonicalRefDatabase(con),
 		"reftbl", toLower(con.RefTable),
 		"refcols", lowerJoin(con.RefColumns),
 		"ondelete", canonicalFKAction(con.OnDelete),
 		"onupdate", canonicalFKAction(con.OnUpdate),
 	)
+}
+
+// canonicalRefDatabase returns the FK's referenced database lower-cased, EXCEPT a same-database
+// reference (RefDatabase equal to the FK's own table's database, or empty) folds to "" — the form
+// SHOW CREATE stores. The loader records RefDatabase = the parsed schema qualifier (con.RefTable.
+// Schema), so a user `REFERENCES mydb.p(id)` on a table in `mydb` loads RefDatabase = "mydb",
+// while the engine readback strips it to "". Folding same-db to "" keeps those two from
+// phantom-diffing while preserving a genuine cross-db reference (RefDatabase != own db) verbatim.
+func canonicalRefDatabase(con *Constraint) string {
+	refDB := toLower(con.RefDatabase)
+	if refDB == "" {
+		return ""
+	}
+	if con.Table != nil && con.Table.Database != nil && refDB == toLower(con.Table.Database.Name) {
+		return ""
+	}
+	return refDB
 }
 
 // canonicalFKAction folds a foreign-key referential action onto a canonical key for the
@@ -167,15 +185,23 @@ func canonicalFKAction(action string) string {
 	}
 }
 
-// lowerJoin lower-cases each element and joins with a comma, preserving order (FK column order
-// is significant). Used for both the referencing and referenced column lists.
+// lowerJoin lower-cases each element and encodes the list LENGTH-PREFIXED per element
+// ("<len>:<value>|"), preserving order (FK column order is significant). Length-prefixing (rather
+// than a plain comma join) keeps two different splits from colliding when an identifier itself
+// contains the delimiter — a column name CAN contain a comma when backtick-quoted, so ["a,b","c"]
+// and ["a","b,c"] must not both encode to the same key. Used for both the referencing and
+// referenced column lists.
 func lowerJoin(parts []string) string {
 	if len(parts) == 0 {
 		return ""
 	}
-	lowered := make([]string, len(parts))
-	for i, p := range parts {
-		lowered[i] = toLower(p)
+	var b strings.Builder
+	for _, p := range parts {
+		lower := toLower(p)
+		b.WriteString(strconv.Itoa(len(lower)))
+		b.WriteByte(':')
+		b.WriteString(lower)
+		b.WriteByte('|')
 	}
-	return strings.Join(lowered, ",")
+	return b.String()
 }

--- a/mysql/catalog/diff_foreign_key.go
+++ b/mysql/catalog/diff_foreign_key.go
@@ -1,15 +1,181 @@
 package catalog
 
-// MySQL SDL diff — foreign keys (scaffold stub).
+import (
+	"sort"
+	"strings"
+)
+
+// MySQL SDL diff — foreign keys.
 //
-// Wired into compareTable (diff_table.go) so a modified table reports its FK changes
-// via TableDiffEntry.ForeignKeys. Inert no-op placeholder returning nil until the FK
-// breadth node implements the real comparison. Signature mirrors diffColumns: per-table,
-// taking from/to *Table and the version-fixing Normalizer. FK identity/equality (the
-// referenced table/columns and ON DELETE/UPDATE actions) is the breadth node's concern.
+// This is the MySQL analog of PG's foreign-key differ. It compares the FOREIGN KEY
+// constraint set of two versions of a table and reports the per-FK changes via
+// TableDiffEntry.ForeignKeys. MySQL keeps FK + CHECK on the constraint path (show.go:121);
+// PRIMARY KEY / UNIQUE / secondary indexes live on the index path and are owned by the index
+// node. So this node owns ONLY Table.Constraints entries of type ConForeignKey.
 //
-// implemented by omni:foreign-key breadth node
-func diffForeignKeys(_, _ *Table, _ *Normalizer) []ForeignKeyDiffEntry {
-	// Scaffold: returns nil so the FK sub-diff stays empty (self-diff inert).
-	return nil
+// Identity is the constraint name, lower-cased. MySQL auto-names an unnamed FK
+// `<table>_ibfk_<N>` at load time (tablecmds.go), so by the time a catalog reaches the diff
+// both the user form and the engine readback carry a concrete name — matching by name is the
+// stored-form identity. Equality is decided by a canonical key (canonicalForeignKey) that
+// folds the referencing columns, the referenced database+table+columns, and the ON DELETE/ON
+// UPDATE actions through the NORMALIZER's version-aware FK-action canonicalization
+// (CanonicalFKAction): RESTRICT, NO ACTION, and an absent clause are the same referential
+// behavior and must collapse onto one key. This is required because SHOW CREATE echoes the
+// "default" action differently per version (verified against both live engines):
+//   - 8.0 OMITS NO ACTION (the implicit default) but ECHOES RESTRICT verbatim;
+//   - 5.7 OMITS RESTRICT (its implicit default) but ECHOES NO ACTION verbatim.
+//
+// So a user `ON DELETE RESTRICT` and the engine readback (which on 5.7 drops it, on 8.0 keeps
+// it) must produce the same canonical key on both versions, else the FK phantom-diffs forever.
+// A MySQL FK cannot be altered in place, so a changed FK is a DROP followed by an ADD — emitted
+// in PhasePost by the generator (migration_foreign_key.go).
+//
+// FK-implicit backing indexes are NOT this differ's concern here — they are diffed (and
+// excluded) by the index node (diff_index.go fkImplicitIndexNames). This differ only reports
+// the FK constraint change; the generator (migration_foreign_key.go) owns the lifecycle of the
+// leftover backing index that MySQL leaves after a DROP FOREIGN KEY.
+func diffForeignKeys(from, to *Table, n *Normalizer) []ForeignKeyDiffEntry {
+	fromMap := foreignKeyMap(from)
+	toMap := foreignKeyMap(to)
+
+	var result []ForeignKeyDiffEntry
+
+	// Dropped: in from but not in to.
+	for name, fromFK := range fromMap {
+		if _, ok := toMap[name]; !ok {
+			result = append(result, ForeignKeyDiffEntry{
+				Action: DiffDrop,
+				Name:   fromFK.Name,
+				From:   fromFK,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for name, toFK := range toMap {
+		fromFK, ok := fromMap[name]
+		if !ok {
+			result = append(result, ForeignKeyDiffEntry{
+				Action: DiffAdd,
+				Name:   toFK.Name,
+				To:     toFK,
+			})
+			continue
+		}
+		if foreignKeysChanged(fromFK, toFK, n) {
+			result = append(result, ForeignKeyDiffEntry{
+				Action: DiffModify,
+				Name:   toFK.Name,
+				From:   fromFK,
+				To:     toFK,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if a, b := toLower(result[i].Name), toLower(result[j].Name); a != b {
+			return a < b
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// foreignKeyMap indexes a table's FOREIGN KEY constraints by lower-cased constraint name.
+// Only ConForeignKey constraints are included; PK/UNIQUE (index path) and CHECK (the check
+// node) are not this node's concern.
+func foreignKeyMap(t *Table) map[string]*Constraint {
+	m := map[string]*Constraint{}
+	if t == nil {
+		return m
+	}
+	for _, con := range t.Constraints {
+		if con == nil || con.Type != ConForeignKey {
+			continue
+		}
+		m[toLower(con.Name)] = con
+	}
+	return m
+}
+
+// foreignKeysChanged reports whether two same-name foreign keys differ, comparing their
+// canonical keys. canonicalForeignKey folds every stored-form-significant attribute into one
+// collision-free key, so this differ never re-implements a per-attribute comparison.
+func foreignKeysChanged(a, b *Constraint, n *Normalizer) bool {
+	return canonicalForeignKey(a, n) != canonicalForeignKey(b, n)
+}
+
+// canonicalForeignKey returns a single stable comparison key for a foreign key, folding the
+// attributes that survive into MySQL's stored form:
+//   - the ON DELETE / ON UPDATE actions via canonicalFKAction, which collapses RESTRICT / NO
+//     ACTION / absent onto one "default" key (see that function for the per-version echo
+//     evidence).
+//
+// The referencing columns, referenced database/table, and referenced columns are compared
+// case-insensitively and ORDER-SENSITIVELY (a composite FK's column order is significant). The
+// referenced database is folded to lower case but kept distinct from "" — a same-database FK
+// (SHOW CREATE omits the db qualifier → RefDatabase == "") and an explicitly-qualified one are
+// the same FK only when both resolve to the same schema; since the synced readback never
+// qualifies a same-db FK, "" is the canonical same-db form and is preserved verbatim. The
+// constraint NAME is the identity key (handled by the caller's map), not part of this content
+// key.
+//
+// The Normalizer is threaded for symmetry with the other differs and so the action
+// canonicalization can move to normalize-core later (it is version-independent for the
+// EQUALITY question — all of RESTRICT/NO ACTION/absent fold together regardless of version —
+// even though the per-version stored ECHO differs, which only the renderer in show.go cares
+// about).
+func canonicalForeignKey(con *Constraint, _ *Normalizer) string {
+	return encodeKeyFields(
+		"cols", lowerJoin(con.Columns),
+		"refdb", toLower(con.RefDatabase),
+		"reftbl", toLower(con.RefTable),
+		"refcols", lowerJoin(con.RefColumns),
+		"ondelete", canonicalFKAction(con.OnDelete),
+		"onupdate", canonicalFKAction(con.OnUpdate),
+	)
+}
+
+// canonicalFKAction folds a foreign-key referential action onto a canonical key for the
+// EQUALITY comparison. The three forms RESTRICT, NO ACTION, and an absent clause ("") are the
+// same referential behavior in MySQL (RESTRICT and NO ACTION are synonyms; no clause defaults
+// to NO ACTION), so they collapse to one "default" key. CASCADE, SET NULL, and SET DEFAULT are
+// distinct and kept verbatim (upper-cased).
+//
+// This collapse is REQUIRED for idempotence because SHOW CREATE echoes the default action
+// differently per version (verified against both live engines, 5.7 :13307 / 8.0 :13306):
+//   - 8.0 OMITS NO ACTION but ECHOES RESTRICT verbatim;
+//   - 5.7 OMITS RESTRICT but ECHOES NO ACTION verbatim.
+//
+// So `ON DELETE RESTRICT` written by the user reloads as "RESTRICT", but its 5.7 readback (which
+// drops the clause) reloads as "NO ACTION" (the loader's default) — and on 8.0 the readback
+// keeps "RESTRICT". Both must compare equal to the user form on both versions, which only a
+// version-INDEPENDENT default-collapse achieves. (The renderer's per-version echo is show.go's
+// concern, not the equality key's.)
+//
+// FLAG: this is FK-action canonicalization and arguably belongs in normalize-core alongside
+// CanonicalColumn / CanonicalComment. It is kept local to the FK node (no other node needs it)
+// pending a normalize-core CanonicalFKAction; if one is added, route through it. This mirrors
+// the index node keeping canonicalIndexKeyBlockSize local with the same FLAG.
+func canonicalFKAction(action string) string {
+	switch strings.ToUpper(strings.TrimSpace(action)) {
+	case "", "RESTRICT", "NO ACTION":
+		return "DEFAULT"
+	default:
+		return strings.ToUpper(strings.TrimSpace(action))
+	}
+}
+
+// lowerJoin lower-cases each element and joins with a comma, preserving order (FK column order
+// is significant). Used for both the referencing and referenced column lists.
+func lowerJoin(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	lowered := make([]string, len(parts))
+	for i, p := range parts {
+		lowered[i] = toLower(p)
+	}
+	return strings.Join(lowered, ",")
 }

--- a/mysql/catalog/diff_foreign_key.go
+++ b/mysql/catalog/diff_foreign_key.go
@@ -19,10 +19,9 @@ import (
 // both the user form and the engine readback carry a concrete name — matching by name is the
 // stored-form identity. Equality is decided by a canonical key (canonicalForeignKey) that
 // folds the referencing columns, the referenced database+table+columns, and the ON DELETE/ON
-// UPDATE actions through the NORMALIZER's version-aware FK-action canonicalization
-// (CanonicalFKAction): RESTRICT, NO ACTION, and an absent clause are the same referential
-// behavior and must collapse onto one key. This is required because SHOW CREATE echoes the
-// "default" action differently per version (verified against both live engines):
+// UPDATE actions through canonicalFKAction: RESTRICT, NO ACTION, and an absent clause are the
+// same referential behavior and must collapse onto one key. This is required because SHOW CREATE
+// echoes the "default" action differently per version (verified against both live engines):
 //   - 8.0 OMITS NO ACTION (the implicit default) but ECHOES RESTRICT verbatim;
 //   - 5.7 OMITS RESTRICT (its implicit default) but ECHOES NO ACTION verbatim.
 //

--- a/mysql/catalog/diff_foreign_key_test.go
+++ b/mysql/catalog/diff_foreign_key_test.go
@@ -1,0 +1,276 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the foreign-key differ (correctness-protocol.md gates 1 & 2), against the
+// LIVE MySQL engines (5.7 :13307, 8.0 :13306). A foreign key always lives on a CHILD table that
+// references a PARENT, so every FK form is proven through a multi-table round-trip: parent `p` +
+// child `c` are applied to the real engine, BOTH are read back via SHOW CREATE, reloaded as one
+// schema, and the self-diff must be empty. The headline properties:
+//
+//  1. Idempotence (the spine): the engine's stored form of an FK schema self-diffs empty.
+//  2. Action-default normalization: the user form of an FK (with no explicit ON DELETE, or an
+//     explicit RESTRICT / NO ACTION) and the engine's stored form must collapse to empty — even
+//     though SHOW CREATE echoes the default action OPPOSITELY per version (8.0 omits NO ACTION,
+//     echoes RESTRICT; 5.7 omits RESTRICT, echoes NO ACTION). canonicalFKAction folds all three
+//     onto one key, so the diff is empty on both versions regardless of which form the readback
+//     took.
+//  3. Auto-name normalization: an unnamed FK (auto-named `<table>_ibfk_N`) and an unnamed-backing
+//     index round-trip empty.
+//
+// The harness reuses connectOracle / serverCharsetFor / both / only / containsVersion /
+// describeDiff from the diff + normalize oracle tests; it skips cleanly when the engines are
+// unreachable.
+
+// fkDiffCase is a parent+child schema with one or more foreign keys, used to prove the FK diff
+// round-trips empty. childDDL defines table `c` referencing table `p`; parentDDL defines `p`.
+type fkDiffCase struct {
+	id        string
+	parentDDL string
+	childDDL  string
+	versions  []Version
+}
+
+// fkParentSingle is the common single-column-PK parent (most FK cases reference p(id)).
+const fkParentSingle = "CREATE TABLE p (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, b INT NOT NULL, UNIQUE KEY ua (a), UNIQUE KEY ub (b))"
+
+// fkParentComposite is the composite-PK parent for composite-FK cases.
+const fkParentComposite = "CREATE TABLE p (a INT NOT NULL, b INT NOT NULL, c INT, PRIMARY KEY (a,b))"
+
+// fkDiffCases enumerate the FK FORMS that must round-trip empty. Each builds parent + child,
+// reads BOTH back, reloads as one schema, and asserts the self-diff is empty (and the user form
+// vs the stored form is empty).
+func fkDiffCases() []fkDiffCase {
+	return []fkDiffCase{
+		// ---- naming ----
+		// Named FK, no backing index → MySQL auto-creates KEY `fk`, constraint kept verbatim.
+		{"named", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Unnamed FK → constraint auto-named `c_ibfk_1`; backing index named after the column.
+		{"unnamed-autoname", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// User-chosen name that matches the `<table>_ibfk_N` auto shape.
+		{"user-named-ibfk", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT c_ibfk_1 FOREIGN KEY (pid) REFERENCES p(id))", both()},
+
+		// ---- ON DELETE / ON UPDATE actions (the action-default normalization core) ----
+		// Bare FK: no action clause. Stored form has no clause on both versions.
+		{"action-bare", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Explicit RESTRICT on both: 8.0 ECHOES it, 5.7 OMITS it — must round-trip empty on both.
+		{"action-restrict", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE RESTRICT ON UPDATE RESTRICT)", both()},
+		// Explicit NO ACTION on both: 8.0 OMITS it, 5.7 ECHOES it — must round-trip empty on both.
+		{"action-no-action", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE NO ACTION ON UPDATE NO ACTION)", both()},
+		// CASCADE / SET NULL: echoed verbatim on both. (pid must be nullable for SET NULL.)
+		{"action-cascade-setnull", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE CASCADE ON UPDATE SET NULL)", both()},
+		// ON DELETE only (ON UPDATE defaults/omitted).
+		{"action-delete-only", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE CASCADE)", both()},
+		// ON UPDATE only.
+		{"action-update-only", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON UPDATE CASCADE)", both()},
+		// SET NULL on both actions.
+		{"action-setnull-both", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE SET NULL ON UPDATE SET NULL)", both()},
+
+		// ---- columns / shape ----
+		// Composite FK with its own auto-created composite backing index.
+		{"composite", fkParentComposite,
+			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (x,y) REFERENCES p(a,b))", both()},
+		// FK reusing an explicit user index (distinct name) → no separate backing index.
+		{"explicit-covering-index", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Unnamed FK whose first-column index name collides with a user index → backing `pid_2`.
+		{"backing-name-collision", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, a INT, pid INT, KEY pid (a), FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// Multiple FKs on one child (two distinct parents' columns).
+		{"multiple-fks", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pa INT, pb INT, CONSTRAINT fka FOREIGN KEY (pa) REFERENCES p(a), CONSTRAINT fkb FOREIGN KEY (pb) REFERENCES p(b))", both()},
+	}
+}
+
+// loadFKSchema applies parent+child in a throwaway db, then reloads BOTH tables wrapped in a FIXED
+// logical db name so the from/to catalogs share a database identity. Returns the reloaded catalog.
+// Skips the subtest if the engine rejects the setup DDL.
+func loadFKSchema(t *testing.T, o *oracleConn, logicalDB, execDB, parentDDL, childDDL string) *Catalog {
+	t.Helper()
+	ctx := context.Background()
+	sc := serverCharsetFor(o.version)
+	stmts := []string{
+		"DROP DATABASE IF EXISTS " + execDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", execDB, sc),
+		"USE " + execDB,
+		parentDDL,
+		childDDL,
+	}
+	for _, s := range stmts {
+		if _, err := o.db.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] setup failed (may be expected): %q: %v", o.name, s, err)
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", logicalDB, sc, logicalDB)
+	for _, tbl := range []string{"p", "c"} {
+		var nm, ddl string
+		row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", execDB, tbl))
+		if err := row.Scan(&nm, &ddl); err != nil {
+			t.Fatalf("[%s] SHOW CREATE %s: %v", o.name, tbl, err)
+		}
+		b.WriteString(ddl + ";\n")
+	}
+	cat, err := LoadSQL(b.String())
+	if err != nil {
+		t.Fatalf("[%s] reload of FK readback failed: %v\n%s", o.name, err, b.String())
+	}
+	return cat
+}
+
+// TestOracle_ForeignKeyDiffIdempotence proves gates 1 & 2 for every FK form: the engine's stored
+// form self-diffs empty, AND the user form vs the engine's stored form diffs empty (action-default
+// + auto-name normalization), on every supported version.
+func TestOracle_ForeignKeyDiffIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, fc := range fkDiffCases() {
+			if !containsVersion(fc.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, fc.id), func(t *testing.T) {
+				slug := strings.ReplaceAll(fc.id, "-", "_")
+				// Stored form (engine readback) — the idempotence spine.
+				storedCat := loadFKSchema(t, o, "fkdiff", "fkdiff_s_"+slug, fc.parentDDL, fc.childDDL)
+				if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] IDEMPOTENCE: FK stored-form self-diff not empty for %s: %s",
+						o.name, fc.id, describeForeignKeyDiff(d))
+				}
+
+				// User form: load the raw user DDL (wrapped in the same logical db) and diff it
+				// against the engine's stored form. This is the action-default / auto-name
+				// canonicalization proof — they must collapse to empty.
+				userCat := loadUserFKSchema(t, serverCharsetFor(o.version), fc.parentDDL, fc.childDDL)
+				if d := DiffWithNormalizer(userCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] user-form FK self-diff not empty for %s: %s",
+						o.name, fc.id, describeForeignKeyDiff(d))
+				}
+				if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION: user form vs stored form not empty for %s: %s",
+						o.name, fc.id, describeForeignKeyDiff(d))
+				}
+				if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION (reverse): stored vs user not empty for %s: %s",
+						o.name, fc.id, describeForeignKeyDiff(d))
+				}
+			})
+		}
+	}
+}
+
+// loadUserFKSchema loads the raw user parent+child DDL (no engine round-trip) wrapped in the same
+// FIXED logical db as loadFKSchema, so the user and stored catalogs share a database identity and
+// only the FK canonicalization is under test.
+func loadUserFKSchema(t *testing.T, serverCharset, parentDDL, childDDL string) *Catalog {
+	t.Helper()
+	wrapped := fmt.Sprintf("CREATE DATABASE fkdiff DEFAULT CHARSET=%s;\nUSE fkdiff;\n%s;\n%s;",
+		serverCharset, parentDDL, childDDL)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("LoadSQL failed for user FK schema: %v\n%s", err, wrapped)
+	}
+	return cat
+}
+
+// describeForeignKeyDiff renders a compact description of a SchemaDiff focused on FK changes for
+// failure output.
+func describeForeignKeyDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, te := range d.Tables {
+		fmt.Fprintf(&b, "[table %s %s", te.Name, te.Action)
+		for _, ce := range te.Columns {
+			fmt.Fprintf(&b, " col(%s %s)", ce.Name, ce.Action)
+		}
+		for _, ie := range te.Indexes {
+			fmt.Fprintf(&b, " idx(%s %s)", ie.Name, ie.Action)
+		}
+		for _, fe := range te.ForeignKeys {
+			fmt.Fprintf(&b, " fk(%s %s)", fe.Name, fe.Action)
+		}
+		b.WriteString("]")
+	}
+	return b.String()
+}
+
+// TestOracle_ForeignKeyDiffNonEmptyCorrect proves the differ DISTINGUISHES genuinely different FK
+// schemas (the dual of idempotence — a missed FK diff is as harmful as a phantom one). Each case
+// loads two real engine readbacks and asserts the expected FK DiffAction.
+func TestOracle_ForeignKeyDiffNonEmptyCorrect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+
+		cases := []struct {
+			name      string
+			fromChild string
+			toChild   string
+			wantFK    string
+			wantFKA   DiffAction
+		}{
+			{"add-fk",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+				"fk", DiffAdd},
+			{"drop-fk",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+				"fk", DiffDrop},
+			// Action change CASCADE→SET NULL is a real change (both echoed verbatim on both versions).
+			{"modify-action",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE CASCADE)",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE SET NULL)",
+				"fk", DiffModify},
+			// Referenced-column change a→b is a real change.
+			{"modify-refcol",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(a))",
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(b))",
+				"fk", DiffModify},
+		}
+		for _, tc := range cases {
+			t.Run(o.name+"/"+tc.name, func(t *testing.T) {
+				slug := strings.ReplaceAll(tc.name, "-", "_")
+				from := loadFKSchema(t, o, "fknec", "fknec_f_"+slug, fkParentSingle, tc.fromChild)
+				to := loadFKSchema(t, o, "fknec", "fknec_t_"+slug, fkParentSingle, tc.toChild)
+				d := DiffWithNormalizer(from, to, n)
+				te := findTable(d, "c")
+				if te == nil {
+					t.Fatalf("[%s] want table c modified, got %s", o.name, describeForeignKeyDiff(d))
+				}
+				var got *ForeignKeyDiffEntry
+				for i := range te.ForeignKeys {
+					if strings.EqualFold(te.ForeignKeys[i].Name, tc.wantFK) {
+						got = &te.ForeignKeys[i]
+						break
+					}
+				}
+				if got == nil || got.Action != tc.wantFKA {
+					t.Fatalf("[%s] want fk %s %s, got %s", o.name, tc.wantFK, tc.wantFKA, describeForeignKeyDiff(d))
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/diff_foreign_key_test.go
+++ b/mysql/catalog/diff_foreign_key_test.go
@@ -29,6 +29,68 @@ import (
 // describeDiff from the diff + normalize oracle tests; it skips cleanly when the engines are
 // unreachable.
 
+// TestForeignKeyCanonicalHelpers is a hermetic (no-engine) unit test for the canonicalization
+// helpers, locking in the action-default fold, the comma-safe column encoding, and the same-db
+// RefDatabase fold independently of the live oracle.
+func TestForeignKeyCanonicalHelpers(t *testing.T) {
+	// canonicalFKAction: RESTRICT / NO ACTION / "" all fold to the same key; CASCADE / SET NULL /
+	// SET DEFAULT stay distinct (case-insensitive).
+	def := canonicalFKAction("")
+	for _, a := range []string{"RESTRICT", "restrict", "NO ACTION", "no action", " No Action "} {
+		if canonicalFKAction(a) != def {
+			t.Errorf("canonicalFKAction(%q)=%q, want default %q", a, canonicalFKAction(a), def)
+		}
+	}
+	distinct := map[string]string{}
+	for _, a := range []string{"CASCADE", "SET NULL", "SET DEFAULT"} {
+		k := canonicalFKAction(a)
+		if k == def {
+			t.Errorf("canonicalFKAction(%q)=%q must differ from default", a, k)
+		}
+		if prev, ok := distinct[k]; ok {
+			t.Errorf("canonicalFKAction collision: %q and %q both → %q", a, prev, k)
+		}
+		distinct[k] = a
+	}
+	// canonicalFKAction is case-insensitive: cascade == CASCADE.
+	if canonicalFKAction("cascade") != canonicalFKAction("CASCADE") {
+		t.Errorf("canonicalFKAction must be case-insensitive for CASCADE")
+	}
+
+	// lowerJoin: different splits of comma-containing identifiers must NOT collide.
+	if lowerJoin([]string{"a,b", "c"}) == lowerJoin([]string{"a", "b,c"}) {
+		t.Errorf("lowerJoin must distinguish [a,b],[c] from [a],[b,c]")
+	}
+	// lowerJoin lower-cases and preserves order.
+	if lowerJoin([]string{"A", "B"}) == lowerJoin([]string{"B", "A"}) {
+		t.Errorf("lowerJoin must be order-sensitive")
+	}
+	if lowerJoin([]string{"A"}) != lowerJoin([]string{"a"}) {
+		t.Errorf("lowerJoin must be case-insensitive")
+	}
+
+	// canonicalRefDatabase: same-db (own database) and "" both fold to ""; a cross-db reference is
+	// kept verbatim (lower-cased).
+	db := &Database{Name: "mydb"}
+	tbl := &Table{Name: "c", Database: db}
+	sameDB := &Constraint{Type: ConForeignKey, Table: tbl, RefDatabase: "MyDB", RefTable: "p"}
+	noDB := &Constraint{Type: ConForeignKey, Table: tbl, RefDatabase: "", RefTable: "p"}
+	crossDB := &Constraint{Type: ConForeignKey, Table: tbl, RefDatabase: "otherdb", RefTable: "p"}
+	if canonicalRefDatabase(sameDB) != "" {
+		t.Errorf("canonicalRefDatabase(same-db) = %q, want empty", canonicalRefDatabase(sameDB))
+	}
+	if canonicalRefDatabase(noDB) != "" {
+		t.Errorf("canonicalRefDatabase(no-db) = %q, want empty", canonicalRefDatabase(noDB))
+	}
+	if canonicalRefDatabase(crossDB) != "otherdb" {
+		t.Errorf("canonicalRefDatabase(cross-db) = %q, want otherdb", canonicalRefDatabase(crossDB))
+	}
+	// A same-db FK and an unqualified FK must produce the same canonical key.
+	if canonicalForeignKey(sameDB, NormalizerFor(MySQL80)) != canonicalForeignKey(noDB, NormalizerFor(MySQL80)) {
+		t.Errorf("same-db-qualified and unqualified FK must canonicalize equal")
+	}
+}
+
 // fkDiffCase is a parent+child schema with one or more foreign keys, used to prove the FK diff
 // round-trips empty. childDDL defines table `c` referencing table `p`; parentDDL defines `p`.
 type fkDiffCase struct {
@@ -96,6 +158,70 @@ func fkDiffCases() []fkDiffCase {
 		// Multiple FKs on one child (two distinct parents' columns).
 		{"multiple-fks", fkParentSingle,
 			"CREATE TABLE c (id INT PRIMARY KEY, pa INT, pb INT, CONSTRAINT fka FOREIGN KEY (pa) REFERENCES p(a), CONSTRAINT fkb FOREIGN KEY (pb) REFERENCES p(b))", both()},
+	}
+}
+
+// TestOracle_ForeignKeySameDBQualifierNoDiff proves the same-database-qualifier canonicalization
+// (canonicalRefDatabase): a FK written with an EXPLICIT same-database qualifier (REFERENCES
+// dbname.p(id)) must diff EMPTY against the engine's readback, which STRIPS the qualifier
+// (verified live: `REFERENCES d.p(id)` → `REFERENCES p (id)`). Without the fold this phantom-diffs
+// forever. The user form references the SAME db it lives in, so the schema is applied to a db of
+// that exact name and the FK resolves.
+func TestOracle_ForeignKeySameDBQualifierNoDiff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		sc := serverCharsetFor(o.version)
+		ctx := context.Background()
+		t.Run(o.name+"/same-db-qualifier", func(t *testing.T) {
+			const db = "fksdq"
+			// Apply with an explicit same-db qualifier in the real db named `fksdq`.
+			stmts := []string{
+				"DROP DATABASE IF EXISTS " + db,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", db, sc),
+				"USE " + db,
+				"CREATE TABLE p (id INT NOT NULL PRIMARY KEY)",
+				fmt.Sprintf("CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES %s.p(id))", db),
+			}
+			for _, s := range stmts {
+				if _, err := o.db.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup: %q: %v", o.name, s, err)
+				}
+			}
+			// Stored form: read both tables back (the qualifier is stripped).
+			var stored strings.Builder
+			fmt.Fprintf(&stored, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\nSET foreign_key_checks=0;\n", db, sc, db)
+			for _, tbl := range []string{"p", "c"} {
+				var nm, ddl string
+				row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", db, tbl))
+				if err := row.Scan(&nm, &ddl); err != nil {
+					t.Fatalf("[%s] SHOW CREATE %s: %v", o.name, tbl, err)
+				}
+				stored.WriteString(ddl + ";\n")
+			}
+			storedCat, err := LoadSQL(stored.String())
+			if err != nil {
+				t.Fatalf("[%s] reload stored: %v\n%s", o.name, err, stored.String())
+			}
+			// User form: the explicit-qualifier DDL, loaded into the SAME db name.
+			userWrapped := fmt.Sprintf(
+				"CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\nCREATE TABLE p (id INT NOT NULL PRIMARY KEY);\nCREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES %s.p(id));",
+				db, sc, db, db)
+			userCat, err := LoadSQL(userWrapped)
+			if err != nil {
+				t.Fatalf("[%s] load user form: %v\n%s", o.name, err, userWrapped)
+			}
+			if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] same-db explicit qualifier phantom-diffs vs stripped readback: %s",
+					o.name, describeForeignKeyDiff(d))
+			}
+			if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] (reverse) same-db qualifier phantom-diffs: %s", o.name, describeForeignKeyDiff(d))
+			}
+		})
 	}
 }
 

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -1,15 +1,310 @@
 package catalog
 
-// MySQL SDL generate — foreign keys (scaffold stub).
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — foreign keys.
 //
-// Wired into GenerateMigrationWithNormalizer (migration.go) so FK diffs become DDL.
-// Inert no-op placeholder returning nil until the FK breadth node renders the ALTER
-// TABLE ... ADD/DROP FOREIGN KEY ops from TableDiffEntry.ForeignKeys. FK creation is
-// deferred to PhasePost (priorityForeignKey) so every referenced table exists first —
-// mirroring PG. Signature mirrors generateTableDDL (migration_table.go).
+// This is the MySQL analog of PG's foreign-key generator. It turns the FK diff
+// (TableDiffEntry.ForeignKeys, populated by diff_foreign_key.go) into ALTER TABLE ... ADD/DROP
+// FOREIGN KEY DDL. MySQL folds FK changes into ALTER TABLE; a FK cannot be altered in place, so
+// a modified FK is a DROP followed by an ADD.
 //
-// implemented by omni:foreign-key breadth node
-func generateForeignKeyDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no FK ops (empty diff -> empty plan).
-	return nil
+// Phase ordering — the crux of coordinating with the index node:
+//   - FK ADDs run in PhasePost (priorityForeignKey=99), AFTER the index node's PhaseMain index
+//     ADDs (priorityIndex=30) and after table/column DDL. MySQL's ADD CONSTRAINT ... FOREIGN KEY
+//     auto-creates a backing index ONLY when no covering index already exists; by deferring the
+//     FK add to PhasePost, an index the user declared (added by the index node in PhaseMain) is
+//     in place first and is REUSED — no duplicate index, no errno 1061/1553. It also guarantees
+//     every referenced table/column exists before the FK is created (the reason PG defers FKs).
+//   - FK DROPs run in PhasePost too, but BEFORE the adds (priorityForeignKeyDrop) so a
+//     drop-then-add of the same constraint name never collides, and before the leftover backing
+//     index drop (errno 1553 — see below).
+//
+// Backing-index lifecycle on DROP — owned HERE, by contract with the index node:
+//
+//	When a FK is dropped, MySQL LEAVES the auto-created backing index behind (verified on both
+//	live engines: after `ALTER TABLE c DROP FOREIGN KEY fk`, `KEY fk (pid)` remains). The index
+//	node EXCLUDES FK-implicit backing indexes from its diff (diff_index.go fkImplicitIndexNames),
+//	so it emits no DROP for that leftover — this node owns it. We drop the leftover index iff it
+//	was FK-implicit on the `from` side (plain, auto-named after the constraint/first column) AND
+//	the user's target has no USER index of that name (so the index node is not keeping it as a
+//	real index). The DROP INDEX is emitted AFTER the DROP FOREIGN KEY, because MySQL refuses to
+//	drop an index still needed by a FK (errno 1553).
+//
+// Rendering routes through the same canonical form show.go uses for the stored FK line, so the
+// readback of the emitted DDL canonicalizes equal to `to` and apply-correctness holds.
+func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		switch entry.Action {
+		case DiffAdd:
+			ops = append(ops, addForeignKeyOpsForNewTable(entry)...)
+		case DiffModify:
+			ops = append(ops, foreignKeyOpsForModifiedTable(entry)...)
+		case DiffDrop:
+			// DROP TABLE removes the FKs (and their backing indexes); nothing to emit.
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Priority != ops[j].Priority {
+			return ops[i].Priority < ops[j].Priority
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// priorityForeignKeyDrop orders FK DROPs (and the leftover-backing-index DROPs they own) within
+// PhasePost BEFORE the FK ADDs (priorityForeignKey=99). A drop-then-add of the same constraint
+// name (a MODIFY) must drop first so the name is free; and an FK that moves between tables in the
+// same plan must release the old one before the new one is added. It sits just below
+// priorityForeignKey so all FK releases precede all FK creations.
+const priorityForeignKeyDrop = priorityForeignKey - 1
+
+// addForeignKeyOpsForNewTable emits ADD CONSTRAINT ... FOREIGN KEY ops for every FK on a freshly
+// created table. formatCreateTable (migration_table.go) renders only columns and the inline
+// PRIMARY KEY — it does NOT inline FK constraints — so every FK on a new table is added here in
+// PhasePost, after the table (and any referenced tables) exist.
+func addForeignKeyOpsForNewTable(entry *TableDiffEntry) []MigrationOp {
+	if entry.To == nil {
+		return nil
+	}
+	table := tableIdent(entry.To)
+	var ops []MigrationOp
+	for _, con := range orderedForeignKeys(entry.To) {
+		ops = append(ops, addForeignKeyOp(entry, table, con))
+	}
+	return ops
+}
+
+// foreignKeyOpsForModifiedTable emits ADD / DROP / (DROP+ADD) ops from the per-FK diff of a
+// modified table. A MODIFY is a DROP followed by an ADD (an FK cannot be altered in place); the
+// drop in priorityForeignKeyDrop always precedes the add in priorityForeignKey, freeing the
+// constraint name for re-creation.
+func foreignKeyOpsForModifiedTable(entry *TableDiffEntry) []MigrationOp {
+	if len(entry.ForeignKeys) == 0 {
+		return nil
+	}
+	var ops []MigrationOp
+	for _, fe := range entry.ForeignKeys {
+		switch fe.Action {
+		case DiffAdd:
+			if fe.To == nil || entry.To == nil {
+				continue
+			}
+			ops = append(ops, addForeignKeyOp(entry, tableIdent(entry.To), fe.To))
+		case DiffDrop:
+			if fe.From == nil {
+				continue
+			}
+			ops = append(ops, dropForeignKeyOps(entry, fe.From)...)
+		case DiffModify:
+			if fe.From == nil || fe.To == nil || entry.To == nil {
+				continue
+			}
+			// DROP the old FK (and its leftover backing index, if FK-implicit and not reused),
+			// then ADD the new one. The drop's PhasePost priority precedes the add's.
+			ops = append(ops, dropForeignKeyOps(entry, fe.From)...)
+			ops = append(ops, addForeignKeyOp(entry, tableIdent(entry.To), fe.To))
+		}
+	}
+	return ops
+}
+
+// addForeignKeyOp builds an ALTER TABLE ... ADD CONSTRAINT `name` FOREIGN KEY (...) REFERENCES
+// ... op. It runs in PhasePost at priorityForeignKey so it lands after table/column/index DDL —
+// every referenced table exists and any user-declared covering index is already present (so MySQL
+// reuses it instead of auto-creating a duplicate backing index).
+func addForeignKeyOp(entry *TableDiffEntry, table string, con *Constraint) MigrationOp {
+	return MigrationOp{
+		Type:         OpAddForeignKey,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s ADD %s", table, formatForeignKeyDefinition(con)),
+		Phase:        PhasePost,
+		Priority:     priorityForeignKey,
+		sortName:     foreignKeySortName(entry.Database, entry.Name, con.Name),
+	}
+}
+
+// dropForeignKeyOps builds the ops to drop a foreign key: an ALTER TABLE ... DROP FOREIGN KEY
+// `name`, plus — when the FK leaves behind an auto-created backing index that the target no
+// longer keeps — an ALTER TABLE ... DROP INDEX `name` for that leftover. Both run in PhasePost at
+// priorityForeignKeyDrop; the DROP FOREIGN KEY is emitted first and the DROP INDEX second
+// (errno 1553 — MySQL refuses to drop an index a FK still needs).
+//
+// The leftover index is dropped ONLY when it was FK-implicit on the `from` side (plain,
+// auto-named after the constraint / first FK column, reusing the index node's exact detection)
+// AND the `to` table has no USER index of that name. This is the mirror of the index node's
+// FK-implicit exclusion (diff_index.go diffableIndexMap with userIndexNameSet(to)): the index
+// node keeps a user-named index when its FK is dropped, so this node must NOT drop such an index;
+// it drops only the engine-synthesized backing index the index node deliberately ignores.
+func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint) []MigrationOp {
+	if entry.From == nil {
+		return nil
+	}
+	table := tableIdent(entry.From)
+	ops := []MigrationOp{{
+		Type:         OpDropForeignKey,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s DROP FOREIGN KEY %s", table, migrationQuoteIdent(con.Name)),
+		Phase:        PhasePost,
+		Priority:     priorityForeignKeyDrop,
+		sortName:     foreignKeySortName(entry.Database, entry.Name, con.Name) + ".0",
+	}}
+
+	if idxName, ok := leftoverBackingIndexToDrop(entry, con); ok {
+		ops = append(ops, MigrationOp{
+			Type:         OpDropForeignKey,
+			Database:     entry.Database,
+			ObjectName:   entry.Name,
+			ParentObject: entry.Name,
+			SQL:          fmt.Sprintf("ALTER TABLE %s DROP INDEX %s", table, migrationQuoteIdent(idxName)),
+			Phase:        PhasePost,
+			Priority:     priorityForeignKeyDrop,
+			// ".1" sorts after the DROP FOREIGN KEY ".0" for the same constraint (errno 1553).
+			sortName: foreignKeySortName(entry.Database, entry.Name, con.Name) + ".1",
+		})
+	}
+	return ops
+}
+
+// leftoverBackingIndexToDrop decides whether dropping `con` (a FK on the `from` table) leaves an
+// auto-created backing index this node must drop, and returns its actual (original-case) name.
+// It returns the index iff:
+//   - the `from` table has an FK-implicit backing index for `con` (the index node's exact
+//     detection: fkImplicitIndexNames over `from`), AND
+//   - the `to` table has no USER index of that name (so the index node is not keeping it).
+//
+// When the `to` table keeps a user index of that name, the index node owns it and MySQL leaves it
+// intentionally; this node must not drop it. When `to` is absent (the whole table is being
+// dropped) this is never reached — DiffDrop tables emit nothing.
+func leftoverBackingIndexToDrop(entry *TableDiffEntry, con *Constraint) (string, bool) {
+	from := entry.From
+	if from == nil {
+		return "", false
+	}
+	implicit := fkImplicitIndexNames(from)
+	// Find the backing-index name for THIS constraint: the FK-implicit index whose name matches
+	// the auto-derived form for `con` (constraint name / first-column / collision suffix).
+	var backing *Index
+	for _, idx := range from.Indexes {
+		if idx == nil {
+			continue
+		}
+		if !implicit[toLower(idx.Name)] {
+			continue
+		}
+		if isAutoBackingIndexName(idx.Name, con) && isPlainBackingIndexFor(idx, con.Columns) {
+			backing = idx
+			break
+		}
+	}
+	if backing == nil {
+		return "", false
+	}
+	// Keep it if the target still carries a USER index of that name (index node's domain).
+	if userIndexNameSet(entry.To)[toLower(backing.Name)] {
+		return "", false
+	}
+	return backing.Name, true
+}
+
+// orderedForeignKeys returns a table's FOREIGN KEY constraints in a deterministic order (by
+// lower-cased constraint name) so a new table's ADD FOREIGN KEY sequence is stable across runs.
+func orderedForeignKeys(t *Table) []*Constraint {
+	if t == nil {
+		return nil
+	}
+	var fks []*Constraint
+	for _, con := range t.Constraints {
+		if con != nil && con.Type == ConForeignKey {
+			fks = append(fks, con)
+		}
+	}
+	sort.Slice(fks, func(i, j int) bool {
+		return toLower(fks[i].Name) < toLower(fks[j].Name)
+	})
+	return fks
+}
+
+// formatForeignKeyDefinition renders the constraint clause that follows ADD in an ALTER TABLE, in
+// MySQL's canonical stored form:
+//
+//	CONSTRAINT `name` FOREIGN KEY (`c1`, `c2`) REFERENCES `db`.`tbl` (`r1`, `r2`)
+//	    [ON DELETE <action>] [ON UPDATE <action>]
+//
+// It mirrors show.go's showConstraint (the stored FK line) so the readback of the ADD
+// canonicalizes equal to `to`. The ON DELETE / ON UPDATE clauses are emitted ONLY for a
+// non-default action (CASCADE / SET NULL / SET DEFAULT): RESTRICT and NO ACTION (and an absent
+// clause) are the engine's default and are omitted, so the emitted DDL round-trips to the same
+// stored form the canonical key folds to (see diff_foreign_key.go canonicalFKAction). Emitting an
+// explicit RESTRICT/NO ACTION would also round-trip on equality, but omitting matches show.go and
+// keeps the surface minimal.
+func formatForeignKeyDefinition(con *Constraint) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CONSTRAINT %s FOREIGN KEY (", migrationQuoteIdent(con.Name))
+	b.WriteString(quoteIdentList(con.Columns))
+	b.WriteString(") REFERENCES ")
+	if con.RefDatabase != "" {
+		b.WriteString(migrationQuoteIdent(con.RefDatabase) + "." + migrationQuoteIdent(con.RefTable))
+	} else {
+		b.WriteString(migrationQuoteIdent(con.RefTable))
+	}
+	b.WriteString(" (")
+	b.WriteString(quoteIdentList(con.RefColumns))
+	b.WriteString(")")
+
+	if con.OnDelete != "" && !isFKDefaultAction(con.OnDelete) {
+		fmt.Fprintf(&b, " ON DELETE %s", strings.ToUpper(con.OnDelete))
+	}
+	if con.OnUpdate != "" && !isFKDefaultAction(con.OnUpdate) {
+		fmt.Fprintf(&b, " ON UPDATE %s", strings.ToUpper(con.OnUpdate))
+	}
+	return b.String()
+}
+
+// isFKDefaultAction reports whether a referential action is a MySQL default that is omitted from
+// the rendered FK clause. RESTRICT, NO ACTION, and an absent clause are all the "default" (no
+// referential action) and are omitted — matching the canonical-equality collapse in
+// canonicalFKAction, so the emitted DDL reads back to a form that diffs empty against `to` on both
+// versions (8.0 omits NO ACTION but would echo RESTRICT; 5.7 omits RESTRICT but would echo NO
+// ACTION — omitting BOTH from what we emit sidesteps the per-version echo entirely).
+func isFKDefaultAction(action string) bool {
+	switch strings.ToUpper(strings.TrimSpace(action)) {
+	case "", "RESTRICT", "NO ACTION":
+		return true
+	default:
+		return false
+	}
+}
+
+// quoteIdentList backtick-quotes each identifier and joins with ", " (the spacing show.go's FK
+// line uses), preserving order.
+func quoteIdentList(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(names))
+	for i, nm := range names {
+		quoted[i] = migrationQuoteIdent(nm)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// foreignKeySortName is the stable secondary sort key for a FK op: lower-cased
+// database.table.constraint.
+func foreignKeySortName(database, table, constraint string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(table) + "." + strings.ToLower(constraint)
 }

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -45,8 +45,15 @@ import (
 //
 // Rendering routes through the same canonical form show.go uses for the stored FK line, so the
 // readback of the emitted DDL canonicalizes equal to `to` and apply-correctness holds.
+//
+// A per-table seenBackingDrop set deduplicates the leftover-backing-index DROP INDEX: MySQL keeps
+// ONE backing index for several FKs on the same leading columns (two unnamed FKs on `pid` share
+// `KEY pid (pid)`), so when both such FKs are dropped, each would otherwise select the same index
+// and emit a duplicate DROP INDEX — the second failing errno 1091. The set keeps exactly one drop
+// per (table, index).
 func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
 	var ops []MigrationOp
+	seenBackingDrop := map[string]bool{}
 
 	for i := range diff.Tables {
 		entry := &diff.Tables[i]
@@ -54,13 +61,15 @@ func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []Mig
 		case DiffAdd:
 			ops = append(ops, addForeignKeyOpsForNewTable(entry)...)
 		case DiffModify:
-			ops = append(ops, foreignKeyOpsForModifiedTable(entry)...)
+			ops = append(ops, foreignKeyOpsForModifiedTable(entry, seenBackingDrop)...)
 		case DiffDrop:
-			// DROP TABLE removes the FKs (and their backing indexes); nothing to emit. A FK on a
-			// SURVIVING table that REFERENCES this dropped table is released by that surviving
-			// table's own DiffModify entry (its FK vanishes in `to`), whose constraint drop runs at
-			// priorityForeignKeyConstraintDrop — ahead of this table's DROP (priorityTable), so the
-			// reference is gone before the referenced table is dropped (errno 3730).
+			// The table itself is being dropped, but its FKs must be RELEASED first: a FK on this
+			// table that references ANOTHER table being dropped in the same plan would otherwise
+			// block that table's DROP (errno 3730 / 1451) — table drops all share priorityTable, so
+			// the referenced parent can sort before this child. Emit DROP FOREIGN KEY for every FK
+			// here in PhasePre (priorityForeignKeyConstraintDrop), ahead of all table drops. No
+			// backing-index drop is needed — DROP TABLE removes the indexes.
+			ops = append(ops, dropForeignKeyConstraintOpsForDroppedTable(entry)...)
 		}
 	}
 
@@ -71,6 +80,31 @@ func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []Mig
 		return ops[i].sortName < ops[j].sortName
 	})
 
+	return ops
+}
+
+// dropForeignKeyConstraintOpsForDroppedTable emits a DROP FOREIGN KEY for every FK on a table that
+// is itself being DROPPED, in PhasePre ahead of all table drops. This releases the references so a
+// referenced table dropped in the same plan is not blocked (errno 3730 / 1451). It deliberately
+// emits NO backing-index drop: DROP TABLE removes the indexes, and the table is gone regardless.
+func dropForeignKeyConstraintOpsForDroppedTable(entry *TableDiffEntry) []MigrationOp {
+	if entry.From == nil {
+		return nil
+	}
+	table := tableIdent(entry.From)
+	var ops []MigrationOp
+	for _, con := range orderedForeignKeys(entry.From) {
+		ops = append(ops, MigrationOp{
+			Type:         OpDropForeignKey,
+			Database:     entry.Database,
+			ObjectName:   entry.Name,
+			ParentObject: entry.Name,
+			SQL:          fmt.Sprintf("ALTER TABLE %s DROP FOREIGN KEY %s", table, migrationQuoteIdent(con.Name)),
+			Phase:        PhasePre,
+			Priority:     priorityForeignKeyConstraintDrop,
+			sortName:     foreignKeySortName(entry.Database, entry.Name, con.Name),
+		})
+	}
 	return ops
 }
 
@@ -106,10 +140,11 @@ func addForeignKeyOpsForNewTable(entry *TableDiffEntry) []MigrationOp {
 }
 
 // foreignKeyOpsForModifiedTable emits ADD / DROP / (DROP+ADD) ops from the per-FK diff of a
-// modified table. A MODIFY is a DROP followed by an ADD (an FK cannot be altered in place); the
-// drop in priorityForeignKeyDrop always precedes the add in priorityForeignKey, freeing the
-// constraint name for re-creation.
-func foreignKeyOpsForModifiedTable(entry *TableDiffEntry) []MigrationOp {
+// modified table. A MODIFY is a DROP followed by an ADD (an FK cannot be altered in place): the
+// DROP runs in PhasePre (priorityForeignKeyConstraintDrop) and the ADD in PhasePost
+// (priorityForeignKey), so the old constraint is fully released before the new one is created —
+// the name is free and any backing index the new FK needs is settled by then.
+func foreignKeyOpsForModifiedTable(entry *TableDiffEntry, seenBackingDrop map[string]bool) []MigrationOp {
 	if len(entry.ForeignKeys) == 0 {
 		return nil
 	}
@@ -125,14 +160,15 @@ func foreignKeyOpsForModifiedTable(entry *TableDiffEntry) []MigrationOp {
 			if fe.From == nil {
 				continue
 			}
-			ops = append(ops, dropForeignKeyOps(entry, fe.From)...)
+			ops = append(ops, dropForeignKeyOps(entry, fe.From, seenBackingDrop)...)
 		case DiffModify:
 			if fe.From == nil || fe.To == nil || entry.To == nil {
 				continue
 			}
-			// DROP the old FK (and its leftover backing index, if FK-implicit and not reused),
-			// then ADD the new one. The drop's PhasePost priority precedes the add's.
-			ops = append(ops, dropForeignKeyOps(entry, fe.From)...)
+			// DROP the old FK (and its leftover backing index, if FK-implicit and no longer
+			// needed), then ADD the new one. The DROP is in PhasePre, the ADD in PhasePost, so the
+			// drop always precedes the add.
+			ops = append(ops, dropForeignKeyOps(entry, fe.From, seenBackingDrop)...)
 			ops = append(ops, addForeignKeyOp(entry, tableIdent(entry.To), fe.To))
 		}
 	}
@@ -166,8 +202,10 @@ func addForeignKeyOp(entry *TableDiffEntry, table string, con *Constraint) Migra
 //
 // The leftover index is dropped ONLY when leftoverBackingIndexToDrop says so: it was FK-implicit
 // on `from` for `con`, no FK surviving in `to` still needs it, and the target keeps no USER index
-// of that name. See that function.
-func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint) []MigrationOp {
+// of that name. seenBackingDrop deduplicates that DROP INDEX across FKs SHARING one backing index
+// (two unnamed FKs on `pid` share `KEY pid (pid)`; without dedup each FK drop would emit
+// `DROP INDEX pid` and the second fail errno 1091). The set is keyed by (db.table.index).
+func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint, seenBackingDrop map[string]bool) []MigrationOp {
 	if entry.From == nil {
 		return nil
 	}
@@ -184,22 +222,26 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint) []MigrationOp {
 	}}
 
 	if idxName, ok := leftoverBackingIndexToDrop(entry, con); ok {
-		ops = append(ops, MigrationOp{
-			// Op-type is OpDropForeignKey (NOT OpDropIndex) even though the SQL is DROP INDEX: this
-			// index drop is part of the FK's lifecycle, owned by the FK node. Tagging it
-			// OpDropForeignKey keeps it out of the index node's op-type space, which its contract
-			// tests assert is empty on FK-only changes (no OpAddIndex/OpDropIndex). Nothing keys off
-			// OpDropForeignKey expecting only literal DROP FOREIGN KEY statements — the only consumer
-			// is MigrationPlan.SQL(), which concatenates op.SQL verbatim.
-			Type:         OpDropForeignKey,
-			Database:     entry.Database,
-			ObjectName:   entry.Name,
-			ParentObject: entry.Name,
-			SQL:          fmt.Sprintf("ALTER TABLE %s DROP INDEX %s", table, migrationQuoteIdent(idxName)),
-			Phase:        PhasePre,
-			Priority:     priorityForeignKeyBackingIndexDrop,
-			sortName:     foreignKeySortName(entry.Database, entry.Name, idxName),
-		})
+		key := foreignKeySortName(entry.Database, entry.Name, idxName)
+		if !seenBackingDrop[key] {
+			seenBackingDrop[key] = true
+			ops = append(ops, MigrationOp{
+				// Op-type is OpDropForeignKey (NOT OpDropIndex) even though the SQL is DROP INDEX:
+				// this index drop is part of the FK's lifecycle, owned by the FK node. Tagging it
+				// OpDropForeignKey keeps it out of the index node's op-type space, which its contract
+				// tests assert is empty on FK-only changes (no OpAddIndex/OpDropIndex). Nothing keys
+				// off OpDropForeignKey expecting only literal DROP FOREIGN KEY statements — the only
+				// consumer is MigrationPlan.SQL(), which concatenates op.SQL verbatim.
+				Type:         OpDropForeignKey,
+				Database:     entry.Database,
+				ObjectName:   entry.Name,
+				ParentObject: entry.Name,
+				SQL:          fmt.Sprintf("ALTER TABLE %s DROP INDEX %s", table, migrationQuoteIdent(idxName)),
+				Phase:        PhasePre,
+				Priority:     priorityForeignKeyBackingIndexDrop,
+				sortName:     key,
+			})
+		}
 	}
 	return ops
 }

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -46,8 +46,9 @@ import (
 // Rendering routes through the same canonical form show.go uses for the stored FK line, so the
 // readback of the emitted DDL canonicalizes equal to `to` and apply-correctness holds.
 //
-// A per-table seenBackingDrop set deduplicates the leftover-backing-index DROP INDEX: MySQL keeps
-// ONE backing index for several FKs on the same leading columns (two unnamed FKs on `pid` share
+// A per-plan seenBackingDrop set (keyed by db.table.index, so it never conflates indexes on
+// different tables) deduplicates the leftover-backing-index DROP INDEX: MySQL keeps ONE backing
+// index for several FKs on the same leading columns (two unnamed FKs on `pid` share
 // `KEY pid (pid)`), so when both such FKs are dropped, each would otherwise select the same index
 // and emit a duplicate DROP INDEX — the second failing errno 1091. The set keeps exactly one drop
 // per (table, index).

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -13,27 +13,35 @@ import (
 // FOREIGN KEY DDL. MySQL folds FK changes into ALTER TABLE; a FK cannot be altered in place, so
 // a modified FK is a DROP followed by an ADD.
 //
-// Phase ordering — the crux of coordinating with the index node:
+// Phase ordering — the crux of coordinating with the index node AND with the table/column
+// generators. FK ADDs and FK DROPs sit in OPPOSITE phases:
+//
 //   - FK ADDs run in PhasePost (priorityForeignKey=99), AFTER the index node's PhaseMain index
 //     ADDs (priorityIndex=30) and after table/column DDL. MySQL's ADD CONSTRAINT ... FOREIGN KEY
 //     auto-creates a backing index ONLY when no covering index already exists; by deferring the
 //     FK add to PhasePost, an index the user declared (added by the index node in PhaseMain) is
 //     in place first and is REUSED — no duplicate index, no errno 1061/1553. It also guarantees
 //     every referenced table/column exists before the FK is created (the reason PG defers FKs).
-//   - FK DROPs run in PhasePost too, but BEFORE the adds (priorityForeignKeyDrop) so a
-//     drop-then-add of the same constraint name never collides, and before the leftover backing
-//     index drop (errno 1553 — see below).
+//   - FK DROPs run in PhasePre, BEFORE every dependent drop: a referenced table (errno 3730), a
+//     referencing column (errno 1828), and the FK's own backing index (errno 1553). MySQL refuses
+//     to drop any object a live FK still needs, so the FK constraint must be released FIRST. FK
+//     constraint drops therefore use priorityForeignKeyConstraintDrop, ordered ahead of the
+//     table-drop / index-drop / column-drop priorities the other generators use in PhasePre.
 //
 // Backing-index lifecycle on DROP — owned HERE, by contract with the index node:
 //
 //	When a FK is dropped, MySQL LEAVES the auto-created backing index behind (verified on both
 //	live engines: after `ALTER TABLE c DROP FOREIGN KEY fk`, `KEY fk (pid)` remains). The index
 //	node EXCLUDES FK-implicit backing indexes from its diff (diff_index.go fkImplicitIndexNames),
-//	so it emits no DROP for that leftover — this node owns it. We drop the leftover index iff it
-//	was FK-implicit on the `from` side (plain, auto-named after the constraint/first column) AND
-//	the user's target has no USER index of that name (so the index node is not keeping it as a
-//	real index). The DROP INDEX is emitted AFTER the DROP FOREIGN KEY, because MySQL refuses to
-//	drop an index still needed by a FK (errno 1553).
+//	so it emits no DROP for that leftover — this node owns it. The leftover DROP INDEX runs in
+//	PhasePre at priorityForeignKeyBackingIndexDrop: AFTER all FK constraint drops (so a backing
+//	index SHARED by several FKs — MySQL keeps one index for FKs on the same columns — is not
+//	dropped while another of those FKs still references it, errno 1553) and BEFORE column drops (a
+//	DROP COLUMN auto-removes an index it empties, after which an explicit DROP INDEX fails errno
+//	1091 — same hazard the index node guards with priorityIndexDrop). We drop the leftover index
+//	only when (a) it was FK-implicit on the `from` side for `con`, (b) NO foreign key SURVIVING in
+//	`to` still needs it (no `to` FK whose columns it covers), and (c) the target keeps no USER
+//	index of that name — see leftoverBackingIndexToDrop.
 //
 // Rendering routes through the same canonical form show.go uses for the stored FK line, so the
 // readback of the emitted DDL canonicalizes equal to `to` and apply-correctness holds.
@@ -48,7 +56,11 @@ func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []Mig
 		case DiffModify:
 			ops = append(ops, foreignKeyOpsForModifiedTable(entry)...)
 		case DiffDrop:
-			// DROP TABLE removes the FKs (and their backing indexes); nothing to emit.
+			// DROP TABLE removes the FKs (and their backing indexes); nothing to emit. A FK on a
+			// SURVIVING table that REFERENCES this dropped table is released by that surviving
+			// table's own DiffModify entry (its FK vanishes in `to`), whose constraint drop runs at
+			// priorityForeignKeyConstraintDrop — ahead of this table's DROP (priorityTable), so the
+			// reference is gone before the referenced table is dropped (errno 3730).
 		}
 	}
 
@@ -62,12 +74,20 @@ func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []Mig
 	return ops
 }
 
-// priorityForeignKeyDrop orders FK DROPs (and the leftover-backing-index DROPs they own) within
-// PhasePost BEFORE the FK ADDs (priorityForeignKey=99). A drop-then-add of the same constraint
-// name (a MODIFY) must drop first so the name is free; and an FK that moves between tables in the
-// same plan must release the old one before the new one is added. It sits just below
-// priorityForeignKey so all FK releases precede all FK creations.
-const priorityForeignKeyDrop = priorityForeignKey - 1
+// priorityForeignKeyConstraintDrop orders FK CONSTRAINT drops at the very front of PhasePre —
+// ahead of table drops (priorityTable=10), index drops (priorityIndexDrop=15), and column drops
+// (priorityColumn-1=19 / priorityColumn=20). A live FK blocks dropping any object it needs (a
+// referenced table → errno 3730, a referencing column → errno 1828, its backing index → errno
+// 1553), so every FK constraint must be released before any of those drops run. It is negative so
+// it sorts before priorityTable without renumbering the shared constants.
+const priorityForeignKeyConstraintDrop = -10
+
+// priorityForeignKeyBackingIndexDrop orders the leftover-backing-index drop AFTER all FK
+// constraint drops (so a backing index shared by multiple same-column FKs survives until the last
+// of them is gone, errno 1553) and BEFORE column drops (a DROP COLUMN auto-removes the index,
+// after which an explicit DROP INDEX fails errno 1091). It sits just below priorityIndexDrop so it
+// shares the index node's "drop indexes before columns" guarantee.
+const priorityForeignKeyBackingIndexDrop = priorityIndexDrop - 1
 
 // addForeignKeyOpsForNewTable emits ADD CONSTRAINT ... FOREIGN KEY ops for every FK on a freshly
 // created table. formatCreateTable (migration_table.go) renders only columns and the inline
@@ -137,17 +157,16 @@ func addForeignKeyOp(entry *TableDiffEntry, table string, con *Constraint) Migra
 }
 
 // dropForeignKeyOps builds the ops to drop a foreign key: an ALTER TABLE ... DROP FOREIGN KEY
-// `name`, plus — when the FK leaves behind an auto-created backing index that the target no
-// longer keeps — an ALTER TABLE ... DROP INDEX `name` for that leftover. Both run in PhasePost at
-// priorityForeignKeyDrop; the DROP FOREIGN KEY is emitted first and the DROP INDEX second
-// (errno 1553 — MySQL refuses to drop an index a FK still needs).
+// `name` (PhasePre, priorityForeignKeyConstraintDrop — ahead of every dependent drop), plus —
+// when the FK leaves behind an auto-created backing index nothing surviving needs — an ALTER
+// TABLE ... DROP INDEX `name` for that leftover (PhasePre, priorityForeignKeyBackingIndexDrop —
+// after ALL FK constraint drops, before column drops). The two priorities (not a sortName
+// suffix) are what guarantee the constraint drop precedes the index drop globally, even across
+// multiple FKs sharing one backing index.
 //
-// The leftover index is dropped ONLY when it was FK-implicit on the `from` side (plain,
-// auto-named after the constraint / first FK column, reusing the index node's exact detection)
-// AND the `to` table has no USER index of that name. This is the mirror of the index node's
-// FK-implicit exclusion (diff_index.go diffableIndexMap with userIndexNameSet(to)): the index
-// node keeps a user-named index when its FK is dropped, so this node must NOT drop such an index;
-// it drops only the engine-synthesized backing index the index node deliberately ignores.
+// The leftover index is dropped ONLY when leftoverBackingIndexToDrop says so: it was FK-implicit
+// on `from` for `con`, no FK surviving in `to` still needs it, and the target keeps no USER index
+// of that name. See that function.
 func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint) []MigrationOp {
 	if entry.From == nil {
 		return nil
@@ -159,22 +178,27 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint) []MigrationOp {
 		ObjectName:   entry.Name,
 		ParentObject: entry.Name,
 		SQL:          fmt.Sprintf("ALTER TABLE %s DROP FOREIGN KEY %s", table, migrationQuoteIdent(con.Name)),
-		Phase:        PhasePost,
-		Priority:     priorityForeignKeyDrop,
-		sortName:     foreignKeySortName(entry.Database, entry.Name, con.Name) + ".0",
+		Phase:        PhasePre,
+		Priority:     priorityForeignKeyConstraintDrop,
+		sortName:     foreignKeySortName(entry.Database, entry.Name, con.Name),
 	}}
 
 	if idxName, ok := leftoverBackingIndexToDrop(entry, con); ok {
 		ops = append(ops, MigrationOp{
+			// Op-type is OpDropForeignKey (NOT OpDropIndex) even though the SQL is DROP INDEX: this
+			// index drop is part of the FK's lifecycle, owned by the FK node. Tagging it
+			// OpDropForeignKey keeps it out of the index node's op-type space, which its contract
+			// tests assert is empty on FK-only changes (no OpAddIndex/OpDropIndex). Nothing keys off
+			// OpDropForeignKey expecting only literal DROP FOREIGN KEY statements — the only consumer
+			// is MigrationPlan.SQL(), which concatenates op.SQL verbatim.
 			Type:         OpDropForeignKey,
 			Database:     entry.Database,
 			ObjectName:   entry.Name,
 			ParentObject: entry.Name,
 			SQL:          fmt.Sprintf("ALTER TABLE %s DROP INDEX %s", table, migrationQuoteIdent(idxName)),
-			Phase:        PhasePost,
-			Priority:     priorityForeignKeyDrop,
-			// ".1" sorts after the DROP FOREIGN KEY ".0" for the same constraint (errno 1553).
-			sortName: foreignKeySortName(entry.Database, entry.Name, con.Name) + ".1",
+			Phase:        PhasePre,
+			Priority:     priorityForeignKeyBackingIndexDrop,
+			sortName:     foreignKeySortName(entry.Database, entry.Name, idxName),
 		})
 	}
 	return ops
@@ -182,14 +206,18 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint) []MigrationOp {
 
 // leftoverBackingIndexToDrop decides whether dropping `con` (a FK on the `from` table) leaves an
 // auto-created backing index this node must drop, and returns its actual (original-case) name.
-// It returns the index iff:
+// It returns the index iff ALL of:
 //   - the `from` table has an FK-implicit backing index for `con` (the index node's exact
-//     detection: fkImplicitIndexNames over `from`), AND
-//   - the `to` table has no USER index of that name (so the index node is not keeping it).
+//     detection: fkImplicitIndexNames over `from` + isAutoBackingIndexName + isPlainBackingIndexFor);
+//   - NO foreign key SURVIVING in `to` still needs that index — i.e. no `to` FK whose columns the
+//     index covers (left-prefix). MySQL keeps a SINGLE backing index for several FKs on the same
+//     columns; dropping it while any of those FKs survives fails errno 1553. fkBackingIndexStillNeeded
+//     enforces this; AND
+//   - the `to` table keeps no USER index of that name (the index node owns a user-named index and
+//     leaves it intentionally — diff_index.go userIndexNameSet).
 //
-// When the `to` table keeps a user index of that name, the index node owns it and MySQL leaves it
-// intentionally; this node must not drop it. When `to` is absent (the whole table is being
-// dropped) this is never reached — DiffDrop tables emit nothing.
+// When `to` is absent (the whole table is being dropped) this is never reached — DiffDrop tables
+// emit nothing.
 func leftoverBackingIndexToDrop(entry *TableDiffEntry, con *Constraint) (string, bool) {
 	from := entry.From
 	if from == nil {
@@ -214,11 +242,53 @@ func leftoverBackingIndexToDrop(entry *TableDiffEntry, con *Constraint) (string,
 	if backing == nil {
 		return "", false
 	}
+	// Keep it if a surviving FK in `to` still needs it (shared backing index, errno 1553).
+	if fkBackingIndexStillNeeded(entry.To, backing) {
+		return "", false
+	}
 	// Keep it if the target still carries a USER index of that name (index node's domain).
 	if userIndexNameSet(entry.To)[toLower(backing.Name)] {
 		return "", false
 	}
 	return backing.Name, true
+}
+
+// fkBackingIndexStillNeeded reports whether any FOREIGN KEY surviving in `to` would still need
+// `idx` as a backing index — i.e. a `to` FK whose columns `idx` covers as a left-prefix. MySQL
+// maintains ONE backing index for all FKs on the same leading columns, so dropping `idx` while
+// such an FK survives fails errno 1553 ("needed in a foreign key constraint"). This mirrors the
+// engine's own rule for whether an index is still required. A nil `to` (no surviving table) needs
+// nothing.
+func fkBackingIndexStillNeeded(to *Table, idx *Index) bool {
+	if to == nil || idx == nil {
+		return false
+	}
+	for _, con := range to.Constraints {
+		if con == nil || con.Type != ConForeignKey || len(con.Columns) == 0 {
+			continue
+		}
+		if indexCoversColumns(idx, con.Columns) {
+			return true
+		}
+	}
+	return false
+}
+
+// indexCoversColumns reports whether idx's leading columns match fkCols in order (a left-prefix
+// cover), the condition under which MySQL treats idx as a usable backing index for an FK on
+// fkCols. Prefix lengths / expressions / direction are ignored here — they do not change whether
+// the index can back the FK for the purpose of the errno-1553 "still needed" check (this matches
+// hasIndexCoveringColumns in tablecmds.go, the loader's own cover test).
+func indexCoversColumns(idx *Index, fkCols []string) bool {
+	if len(idx.Columns) < len(fkCols) {
+		return false
+	}
+	for i, c := range fkCols {
+		if !strings.EqualFold(idx.Columns[i].Name, c) {
+			return false
+		}
+	}
+	return true
 }
 
 // orderedForeignKeys returns a table's FOREIGN KEY constraints in a deterministic order (by

--- a/mysql/catalog/migration_foreign_key_oracle_test.go
+++ b/mysql/catalog/migration_foreign_key_oracle_test.go
@@ -78,6 +78,15 @@ func fkMigrationCases() []fkMigrationCase {
 		{"drop-fk-unnamed", fkParentSingle,
 			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, FOREIGN KEY (pid) REFERENCES p(id))",
 			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)", both()},
+		// Two plain same-column indexes (`pid`, `pid_2`) both matching the FK-implicit name/shape,
+		// plus an FK reusing one of them. Dropping the FK and `pid_2` while keeping `pid`: the FK
+		// node and the index node call the SAME fkImplicitIndexNames on the SAME `from` table, so
+		// they agree on which index is FK-implicit (the first match, `pid`). Because `pid` survives
+		// in `to`, the FK node drops only the FK; the index node drops `pid_2`. No orphan, no
+		// double-drop. (Guards the first-match edge case raised in review.)
+		{"drop-fk-two-covering-indexes", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY pid (pid), KEY pid_2 (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY pid (pid))", both()},
 
 		// ---- MODIFY FK (DROP+ADD) ----
 		// Action change CASCADE→SET NULL: DROP the old FK, ADD the new one (same name).
@@ -241,6 +250,208 @@ func TestOracle_ForeignKeyMigrationIdempotence(t *testing.T) {
 			})
 		}
 	}
+}
+
+// fkMultiCase is an arbitrary multi-table from→to schema transition (BOTH tables may differ),
+// used to prove the cross-object DROP ordering: a FK constraint drop must precede a referenced
+// table drop (errno 3730), a referencing column drop (errno 1828), the index node's reshape of a
+// same-named FK-backing index (errno 1553), and the leftover backing-index drop must respect a
+// surviving FK sharing it. fromSQL/toSQL are full schemas (USE-prefixed by the harness).
+type fkMultiCase struct {
+	id       string
+	fromSQL  string // statements after USE; defines all tables
+	toSQL    string
+	tables   []string // tables to compare in the result (existing in `to`)
+	versions []Version
+}
+
+// fkMultiCases enumerate the cross-object DROP-ordering forms (the review-found ordering bugs).
+func fkMultiCases() []fkMultiCase {
+	return []fkMultiCase{
+		// Drop a column that a FK references, together with the FK: the FK constraint drop
+		// (PhasePre, priorityForeignKeyConstraintDrop) must precede the column drop (errno 1828).
+		{"drop-column-and-its-fk",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY)",
+			[]string{"p", "c"}, both()},
+		// Drop a table that is REFERENCED by a surviving child's FK: the child's FK drop must
+		// precede the parent table drop (errno 3730). Child keeps its (now-FK-less) column.
+		{"drop-referenced-table",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+			[]string{"c"}, both()},
+		// Two FKs on the SAME column share ONE backing index; drop BOTH: every FK constraint drop
+		// must precede the single backing-index drop (errno 1553 if interleaved).
+		{"drop-two-fks-sharing-index",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fka FOREIGN KEY (pid) REFERENCES p(id), CONSTRAINT fkb FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+			[]string{"p", "c"}, both()},
+		// Two FKs sharing one backing index; drop only ONE: the shared backing index must SURVIVE
+		// because the other FK still needs it (errno 1553 if dropped).
+		{"drop-one-of-two-fks-sharing-index",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fka FOREIGN KEY (pid) REFERENCES p(id), CONSTRAINT fkb FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fkb FOREIGN KEY (pid) REFERENCES p(id))",
+			[]string{"p", "c"}, both()},
+		// Drop a FK whose auto backing index name (`fk`) is REUSED by the target as a differently
+		// shaped USER index: the FK constraint drop must precede the index node's DROP INDEX `fk`
+		// reshape (errno 1553 if the reshape runs while the FK lives).
+		{"drop-fk-reuse-name-for-other-index",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, other_col INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, other_col INT, KEY fk (other_col))",
+			[]string{"p", "c"}, both()},
+	}
+}
+
+// TestOracle_ForeignKeyMultiTableApplyCorrectness proves the cross-object DROP ordering for the
+// review-found scenarios: each `from→to` schema is applied via the FULL generated plan and every
+// `to` table's canonical form must match.
+func TestOracle_ForeignKeyMultiTableApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, mc := range fkMultiCases() {
+			if !containsVersion(mc.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, mc.id), func(t *testing.T) {
+				assertFKMultiApplyCorrect(t, o, n, mc)
+			})
+		}
+	}
+}
+
+// assertFKMultiApplyCorrect loads from/to catalogs by applying each full schema to the engine and
+// reading every table back (authentic stored form), generates the plan, builds the `from` state,
+// applies the plan one statement at a time, and asserts every `to` table's readback canonicalizes
+// equal to `to`.
+func assertFKMultiApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, mc fkMultiCase) {
+	t.Helper()
+	slug := strings.ReplaceAll(mc.id, "-", "_")
+	sc := serverCharsetFor(o.version)
+	ctx := context.Background()
+	const logicalDB = "fkmulti"
+
+	fromCat := loadMultiSchema(t, o, logicalDB, "fkmulti_f_"+slug, sc, mc.fromSQL)
+	toCat := loadMultiSchema(t, o, logicalDB, "fkmulti_t_"+slug, sc, mc.toSQL)
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + logicalDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", logicalDB, sc),
+		"USE " + logicalDB,
+	}
+	setup = append(setup, splitSemiStatements(mc.fromSQL)...)
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` for %s: %q: %v", o.name, mc.id, s, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, mc.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Read every `to` table back and compare to `to`. foreign_key_checks=0 guards a forward FK
+	// reference when tables are listed child-before-parent.
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\nSET foreign_key_checks=0;\n", logicalDB, sc, logicalDB)
+	for _, tbl := range mc.tables {
+		var nm, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", logicalDB, tbl))
+		if err := row.Scan(&nm, &ddl); err != nil {
+			t.Fatalf("[%s] %s: result table %s missing after apply:\n%s", o.name, mc.id, tbl, plan.SQL())
+		}
+		b.WriteString(ddl + ";\n")
+	}
+	resultCat, err := LoadSQL(b.String())
+	if err != nil {
+		t.Fatalf("[%s] reload result failed: %v\n%s", o.name, err, b.String())
+	}
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  diff: %s",
+			o.name, mc.id, plan.SQL(), describeForeignKeyDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, mc.id, describeForeignKeyDiff(d))
+	}
+}
+
+// loadMultiSchema applies a full multi-table schema to a throwaway db, reads every base table back,
+// and reloads all of them wrapped in a FIXED logical db (so the from/to catalogs share a database
+// identity and FK references resolve identically).
+func loadMultiSchema(t *testing.T, o *oracleConn, logicalDB, execDB, sc, schemaSQL string) *Catalog {
+	t.Helper()
+	ctx := context.Background()
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + execDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", execDB, sc),
+		"USE " + execDB,
+	}
+	setup = append(setup, splitSemiStatements(schemaSQL)...)
+	for _, s := range setup {
+		if _, err := o.db.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] setup failed (may be expected): %q: %v", o.name, s, err)
+		}
+	}
+	// Discover the base tables in deterministic order.
+	rows, err := o.db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT table_name FROM information_schema.tables WHERE table_schema = '%s' AND table_type='BASE TABLE' ORDER BY table_name", execDB))
+	if err != nil {
+		t.Fatalf("[%s] list tables: %v", o.name, err)
+	}
+	var tables []string
+	for rows.Next() {
+		var nm string
+		if err := rows.Scan(&nm); err != nil {
+			_ = rows.Close()
+			t.Fatalf("[%s] scan table name: %v", o.name, err)
+		}
+		tables = append(tables, nm)
+	}
+	_ = rows.Close()
+
+	// Reload with foreign_key_checks=0 so a child table read back before its parent (tables are
+	// discovered alphabetically) does not fail on a forward FK reference (errno 1824). The omni
+	// loader honors this SET (exec.go).
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\nSET foreign_key_checks=0;\n", logicalDB, sc, logicalDB)
+	for _, tbl := range tables {
+		var nm, ddl string
+		row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", execDB, tbl))
+		if err := row.Scan(&nm, &ddl); err != nil {
+			t.Fatalf("[%s] SHOW CREATE %s: %v", o.name, tbl, err)
+		}
+		b.WriteString(ddl + ";\n")
+	}
+	cat, err := LoadSQL(b.String())
+	if err != nil {
+		t.Fatalf("[%s] reload multi-schema failed: %v\n%s", o.name, err, b.String())
+	}
+	return cat
+}
+
+// splitSemiStatements splits a ";"-separated DDL string into trimmed, non-empty statements.
+func splitSemiStatements(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ";") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // TestOracle_ForeignKeyAddReusesExistingIndex proves the index↔FK ADD interaction at the plan

--- a/mysql/catalog/migration_foreign_key_oracle_test.go
+++ b/mysql/catalog/migration_foreign_key_oracle_test.go
@@ -1,0 +1,283 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle apply-correctness proof for the foreign-key generator (correctness-protocol.md gate
+// 2), against the LIVE MySQL engines. For representative (from, to) pairs covering every FK
+// variant, the generated ALTER TABLE ... ADD/DROP FOREIGN KEY DDL applied to a real `from`
+// database must yield a child table whose canonical form equals `to`. This file ALSO proves the
+// index↔FK interaction explicitly (the contract with the merged index node):
+//   - ADD FK reusing a user index (no duplicate backing index);
+//   - ADD FK auto-creating a backing index;
+//   - DROP FK leaving / dropping the backing index (the FK node owns the leftover);
+//   - FK column change (DROP+ADD with the backing index handled).
+//
+// FKs always span a parent and a child, so the harness is multi-table: it sets up parent `p` +
+// child `c` in state `from`, runs the FULL plan (table/column/index DDL from the other nodes is
+// inert here since only the child's FK differs, but the FK ops include the PhasePost ordering and
+// backing-index drops), reads the child back, and compares. The harness reuses connectOracle /
+// serverCharsetFor / both / only / containsVersion from the shared oracle tests.
+
+// fkMigrationCase is one apply-correctness case: transform child `c` (referencing parent `p`) from
+// fromChild to toChild. parentDDL is shared by both states. An empty fromChild/toChild means the
+// child does not exist in that state (pure CREATE / DROP of the whole child).
+type fkMigrationCase struct {
+	id        string
+	parentDDL string
+	fromChild string
+	toChild   string
+	versions  []Version
+}
+
+// fkMigrationCases enumerate the FK ADD/DROP/MODIFY forms the generator covers, each proven as a
+// (from, to) child transition applied to a real database.
+func fkMigrationCases() []fkMigrationCase {
+	return []fkMigrationCase{
+		// ---- ADD FK (modified child) ----
+		// ADD FK with no covering index → engine auto-creates the backing index (named `fk`).
+		{"add-fk-autoindex", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// ADD FK reusing an existing user index (distinct name) → NO duplicate backing index. The
+		// index is already present in `from`, so the FK add in PhasePost reuses it.
+		{"add-fk-reuse-user-index", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// ADD FK with explicit actions.
+		{"add-fk-cascade", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE CASCADE ON UPDATE SET NULL)", both()},
+		// ADD unnamed FK (auto-named constraint + backing index).
+		{"add-fk-unnamed", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, FOREIGN KEY (pid) REFERENCES p(id))", both()},
+		// ADD composite FK (auto-creates a composite backing index).
+		{"add-fk-composite", fkParentComposite,
+			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT)",
+			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (x,y) REFERENCES p(a,b))", both()},
+
+		// ---- DROP FK (modified child) ----
+		// DROP FK whose backing index was auto-created → the FK node drops the leftover index too
+		// (target child has neither FK nor index).
+		{"drop-fk-and-backing-index", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)", both()},
+		// DROP FK while a distinctly-named user index covers the columns → the FK node drops ONLY
+		// the FK; the user index `my_idx` is kept (index node's domain) and must remain.
+		{"drop-fk-keep-user-index", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid))", both()},
+		// DROP unnamed FK (backing index named after the column `pid`) → drop both.
+		{"drop-fk-unnamed", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT)", both()},
+
+		// ---- MODIFY FK (DROP+ADD) ----
+		// Action change CASCADE→SET NULL: DROP the old FK, ADD the new one (same name).
+		{"modify-fk-action", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE CASCADE)",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id) ON DELETE SET NULL)", both()},
+		// Referenced-column change a→b: DROP+ADD. The backing index rides along; reused.
+		{"modify-fk-refcol", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(a))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(b))", both()},
+		// FK referencing-column change x→y: the backing index changes columns with it (the FK node
+		// owns it; the index node emits nothing). DROP+ADD.
+		{"modify-fk-column", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (x) REFERENCES p(a))",
+			"CREATE TABLE c (id INT PRIMARY KEY, x INT, y INT, CONSTRAINT fk FOREIGN KEY (y) REFERENCES p(b))", both()},
+
+		// ---- self-referential + multiple ----
+		// Self-referential FK (child references itself). Parent `p` exists but is unused by `c`.
+		{"self-referential", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, parent_id INT)",
+			"CREATE TABLE c (id INT PRIMARY KEY, parent_id INT, CONSTRAINT fk_self FOREIGN KEY (parent_id) REFERENCES c(id))", both()},
+		// Add a second FK alongside an existing one (only the new FK is added; the existing one is
+		// untouched).
+		{"add-second-fk", fkParentSingle,
+			"CREATE TABLE c (id INT PRIMARY KEY, pa INT, pb INT, CONSTRAINT fka FOREIGN KEY (pa) REFERENCES p(a))",
+			"CREATE TABLE c (id INT PRIMARY KEY, pa INT, pb INT, CONSTRAINT fka FOREIGN KEY (pa) REFERENCES p(a), CONSTRAINT fkb FOREIGN KEY (pb) REFERENCES p(b))", both()},
+	}
+}
+
+// TestOracle_ForeignKeyMigrationApplyCorrectness proves gate 2 for every FK case: the generated
+// DDL transforms a real `from` database into a `to`-equal one (child compared via canonical
+// readback), including the PhasePost ordering and backing-index handling.
+func TestOracle_ForeignKeyMigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, fc := range fkMigrationCases() {
+			if !containsVersion(fc.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, fc.id), func(t *testing.T) {
+				assertFKApplyCorrect(t, o, n, fc)
+			})
+		}
+	}
+}
+
+// assertFKApplyCorrect is the multi-table apply-correctness assertion. It loads from/to catalogs
+// (parent + child) from the engine's own readbacks (authentic stored form), generates the plan,
+// builds a real database in state `from`, applies the plan one statement at a time, reads the
+// child back, and asserts the child canonicalizes equal to `to` (both directions).
+func assertFKApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, fc fkMigrationCase) {
+	t.Helper()
+	slug := strings.ReplaceAll(fc.id, "-", "_")
+	sc := serverCharsetFor(o.version)
+	ctx := context.Background()
+
+	// Build the from/to catalogs from engine readbacks, wrapped in a FIXED logical db so the FK
+	// references resolve and the plan qualifies tables consistently with the apply db.
+	const logicalDB = "fkapply"
+	fromCat := loadFKSchema(t, o, logicalDB, "fkapply_f_"+slug, fc.parentDDL, fc.fromChild)
+	toCat := loadFKSchema(t, o, logicalDB, "fkapply_t_"+slug, fc.parentDDL, fc.toChild)
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Build a real database in state `from` on ONE dedicated connection (USE must stick).
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + logicalDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", logicalDB, sc),
+		"USE " + logicalDB,
+		fc.parentDDL,
+		fc.fromChild,
+	}
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, fc.id, s, err)
+		}
+	}
+
+	// Apply the migration statements one at a time on the same connection.
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, fc.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Read the child back and compare to `to`'s child. Wrap both in the same logical db (the diff
+	// shares it) so the comparison is FK-resolution-consistent.
+	var nm, resultDDL string
+	row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.c", logicalDB))
+	if err := row.Scan(&nm, &resultDDL); err != nil {
+		t.Fatalf("[%s] %s: result child missing after apply:\n%s", o.name, fc.id, plan.SQL())
+	}
+	// Build a result catalog that mirrors the `to` catalog shape: parent readback + result child,
+	// so FK references resolve identically on both sides.
+	resultCat := loadResultChildSchema(t, o, logicalDB, sc, resultDDL)
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result child: %s\n  diff: %s",
+			o.name, fc.id, plan.SQL(), strings.TrimSpace(resultDDL), describeForeignKeyDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, fc.id, describeForeignKeyDiff(d))
+	}
+}
+
+// loadResultChildSchema reads the parent `p` back from the live apply db and combines it with the
+// already-read result child DDL into a single-catalog schema (wrapped in the logical db), so the
+// result catalog has the same parent+child shape as `to` and FK references resolve on both sides.
+func loadResultChildSchema(t *testing.T, o *oracleConn, logicalDB, sc, childDDL string) *Catalog {
+	t.Helper()
+	ctx := context.Background()
+	var nm, parentDDL string
+	row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.p", logicalDB))
+	if err := row.Scan(&nm, &parentDDL); err != nil {
+		t.Fatalf("[%s] SHOW CREATE parent after apply: %v", o.name, err)
+	}
+	wrapped := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s;\n%s;",
+		logicalDB, sc, logicalDB, parentDDL, childDDL)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("[%s] reload result schema failed: %v\n%s", o.name, err, wrapped)
+	}
+	return cat
+}
+
+// TestOracle_ForeignKeyMigrationIdempotence proves gate 1 (the spine) for the generator: for an FK
+// schema in its real stored form, the generated no-op plan is EMPTY — including the FK ops. A
+// non-empty no-op plan is a normalization/ordering bug.
+func TestOracle_ForeignKeyMigrationIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, fc := range fkDiffCases() {
+			if !containsVersion(fc.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, fc.id), func(t *testing.T) {
+				slug := strings.ReplaceAll(fc.id, "-", "_")
+				cat := loadFKSchema(t, o, "fkidem", "fkidem_"+slug, fc.parentDDL, fc.childDDL)
+				diff := DiffWithNormalizer(cat, cat, n)
+				plan := GenerateMigrationWithNormalizer(cat, cat, diff, n)
+				if plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s (FK normalization/ordering bug):\n%s",
+						o.name, fc.id, plan.SQL())
+				}
+			})
+		}
+	}
+}
+
+// TestOracle_ForeignKeyAddReusesExistingIndex proves the index↔FK ADD interaction at the plan
+// level: when `from` already has a user index covering the FK columns, the plan's FK ADD does NOT
+// also emit an ADD INDEX (the index is reused), and applying the plan does not create a duplicate
+// index. This is the generate-side guard against errno 1061 (duplicate key name).
+func TestOracle_ForeignKeyAddReusesExistingIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		t.Run(o.name+"/add-fk-no-extra-index-op", func(t *testing.T) {
+			from := loadFKSchema(t, o, "fkreuse", "fkreuse_f", fkParentSingle,
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid))")
+			to := loadFKSchema(t, o, "fkreuse", "fkreuse_t", fkParentSingle,
+				"CREATE TABLE c (id INT PRIMARY KEY, pid INT, KEY my_idx (pid), CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))")
+			diff := DiffWithNormalizer(from, to, n)
+			plan := GenerateMigrationWithNormalizer(from, to, diff, n)
+			// The plan must contain exactly one ADD FOREIGN KEY and NO ADD INDEX (the user index is
+			// already present and reused).
+			var addFK, addIdx int
+			for _, op := range plan.Ops {
+				switch op.Type {
+				case OpAddForeignKey:
+					addFK++
+				case OpAddIndex:
+					addIdx++
+				}
+			}
+			if addFK != 1 {
+				t.Errorf("[%s] expected exactly 1 ADD FOREIGN KEY, got %d:\n%s", o.name, addFK, plan.SQL())
+			}
+			if addIdx != 0 {
+				t.Errorf("[%s] expected NO ADD INDEX (user index reused), got %d:\n%s", o.name, addIdx, plan.SQL())
+			}
+		})
+	}
+}

--- a/mysql/catalog/migration_foreign_key_oracle_test.go
+++ b/mysql/catalog/migration_foreign_key_oracle_test.go
@@ -299,6 +299,21 @@ func fkMultiCases() []fkMultiCase {
 			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, other_col INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES p(id))",
 			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, other_col INT, KEY fk (other_col))",
 			[]string{"p", "c"}, both()},
+		// Drop BOTH a parent and a child table where the parent name sorts BEFORE the child
+		// (a_parent < z_child): all DROP TABLE ops share priorityTable and sort by name, so the
+		// parent would be dropped first — blocked by the child's FK (errno 3730/1451) — UNLESS the
+		// child's FK is released in PhasePre first. Guards the dropped-table FK-release path.
+		{"drop-parent-and-child-name-order",
+			"CREATE TABLE a_parent (id INT NOT NULL PRIMARY KEY); CREATE TABLE z_child (id INT PRIMARY KEY, pid INT, CONSTRAINT fk FOREIGN KEY (pid) REFERENCES a_parent(id))",
+			"",
+			nil, both()},
+		// Two UNNAMED FKs on the SAME column share ONE backing index (`KEY pid (pid)`); drop BOTH:
+		// each dropped FK selects the same implicit index, so the leftover DROP INDEX must be
+		// EMITTED ONCE (dedup) — else the second DROP INDEX fails errno 1091.
+		{"drop-two-unnamed-fks-sharing-index",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT, FOREIGN KEY (pid) REFERENCES p(id), FOREIGN KEY (pid) REFERENCES p(id))",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY, pid INT)",
+			[]string{"p", "c"}, both()},
 	}
 }
 


### PR DESCRIPTION
Implements the **foreign-keys** breadth node for MySQL declarative (SDL) migration.

## Scope
FK diff + generate DDL: referencing/referenced columns, ON DELETE/UPDATE actions with action-default normalization (RESTRICT≡NO ACTION → no clause), auto-naming (`<table>_ibfk_N`) vs user-named, composite, self-referential + circular FKs. Fills `diff_foreign_key.go` + `migration_foreign_key.go` against the scaffolded hooks (no dispatcher edits).

## Index↔FK coordination (honors the merged omni:indexes contract)
- FK adds emitted in **PhasePost** (after index PhaseMain adds) so an existing/user index is reused, not duplicated (no errno 1061/1553).
- On FK drop, this node owns dropping the **leftover auto-created backing index** (the index node keeps plain user indexes).
- User indexes named differently from the FK auto-name are reused, not touched.

## Correctness
Both oracle gates proven on live **MySQL 5.7.25 + 8.0.32**: idempotence (user-form vs stored SHOW CREATE diffs empty — auto-name + action-default) and apply-correctness (ADD/DROP FK + column-change + backing-index lifecycle applied to a real DB yields the target). Cross-family review (Claude + Codex) rounds 1-2 fixed 4 bugs: FK drop ordering, backing-index lifecycle, dedupe shared backing-index drop, release FKs on dropped tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)