### PR TITLE
feat(mysql/catalog): implement CHECK constraint diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_check.go
+++ b/mysql/catalog/diff_check.go
@@ -1,15 +1,132 @@
 package catalog
 
-// MySQL SDL diff — CHECK constraints (scaffold stub).
+import (
+	"sort"
+	"strconv"
+)
+
+// MySQL SDL diff — CHECK constraints (8.0.16+ only).
 //
-// Wired into compareTable (diff_table.go) so a modified table reports its CHECK-constraint
-// changes via TableDiffEntry.Checks. Inert no-op placeholder returning nil until the check
-// breadth node implements the real comparison. CHECK is 8.0-only (unrepresentable on 5.7;
-// see normalize.go CheckSupported) — the breadth node gates on the Normalizer's version.
-// Signature mirrors diffColumns: per-table, taking from/to *Table and the Normalizer.
+// This is the MySQL analog of PG's CHECK differ. It compares the CHECK-constraint set of two
+// versions of a table and reports the per-check changes via TableDiffEntry.Checks. It is wired
+// into compareTable (diff_table.go); tableSubdiffsChanged folds a non-empty Checks slice into the
+// "is this table modified?" decision, so this node only fills its own slice.
 //
-// implemented by omni:check breadth node
-func diffChecks(_, _ *Table, _ *Normalizer) []CheckDiffEntry {
-	// Scaffold: returns nil so the check sub-diff stays empty (self-diff inert).
-	return nil
+// VERSION GATE (the headline correctness property). CHECK constraints are 8.0.16+ only. On MySQL
+// 5.7 a CHECK clause is PARSED AND SILENTLY DROPPED — the engine never stores it, so SHOW CREATE
+// echoes nothing (normalize.go CheckSupported, entry check-constraint). The omni loader, however,
+// stores a ConCheck constraint UNCONDITIONALLY (tablecmds.go appends it regardless of version), so
+// a 5.7-targeted catalog loaded from user DDL DOES carry ConCheck entries while its engine readback
+// carries none. Comparing them would phantom-diff forever. So when the Normalizer targets a version
+// that does not represent CHECK in its stored form (5.7), this differ returns nil: no check exists
+// in the stored form, so there is nothing to diff. The gate is CheckSupported(), the single owner
+// of the version decision — this node never re-derives "is 8.0".
+//
+// Identity is the constraint name, lower-cased. MySQL auto-names an unnamed CHECK `<table>_chk_<N>`
+// at parse time, and the omni loader reproduces that same auto-name (tablecmds.go nextCheckNumber),
+// so by the time a check reaches the catalog it is ALWAYS named — both user-named and engine/loader
+// auto-named — exactly like the index node keys on the (auto-)name. Equality is decided by a
+// canonical key (canonicalCheck) folding the two stored-form-significant attributes:
+//   - the CHECK expression, routed through normalize-core's CanonicalCheckExpr (backtick idents,
+//     operator spacing, function casing, the 8.0 `_latin1` string introducer — all canonicalized
+//     there, never re-implemented here); and
+//   - the ENFORCED / NOT ENFORCED state (NotEnforced), a version-independent boolean.
+//
+// An expression whose surface form differs from its SHOW CREATE readback but whose stored form is
+// identical (e.g. `a>0` vs the readback's `(`a` > 0)`) therefore produces no phantom diff.
+func diffChecks(from, to *Table, n *Normalizer) []CheckDiffEntry {
+	// Version gate: CHECK is unrepresentable on 5.7 (parsed-and-dropped), so there is no stored
+	// check to diff. Returning nil keeps a 5.7 self/round-trip diff empty even when the loaded
+	// catalog carries ConCheck entries the engine would have discarded.
+	if !n.CheckSupported() {
+		return nil
+	}
+
+	fromMap := checkMap(from)
+	toMap := checkMap(to)
+
+	var result []CheckDiffEntry
+
+	// Dropped: in from but not in to.
+	for name, fromChk := range fromMap {
+		if _, ok := toMap[name]; !ok {
+			result = append(result, CheckDiffEntry{
+				Action: DiffDrop,
+				Name:   fromChk.Name,
+				From:   fromChk,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for name, toChk := range toMap {
+		fromChk, ok := fromMap[name]
+		if !ok {
+			result = append(result, CheckDiffEntry{
+				Action: DiffAdd,
+				Name:   toChk.Name,
+				To:     toChk,
+			})
+			continue
+		}
+		if checksChanged(fromChk, toChk, n) {
+			result = append(result, CheckDiffEntry{
+				Action: DiffModify,
+				Name:   toChk.Name,
+				From:   fromChk,
+				To:     toChk,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if a, b := toLower(result[i].Name), toLower(result[j].Name); a != b {
+			return a < b
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// checkMap indexes a table's CHECK constraints by lower-cased name. Only ConCheck constraints
+// participate — PRIMARY KEY / UNIQUE are owned by the index/constraint nodes and FOREIGN KEY by the
+// FK node (the same constraint-kind split show.go uses). A check with an empty name is skipped
+// defensively (the loader always names them, so this never fires in practice).
+func checkMap(t *Table) map[string]*Constraint {
+	m := make(map[string]*Constraint)
+	if t == nil {
+		return m
+	}
+	for _, con := range t.Constraints {
+		if con == nil || con.Type != ConCheck {
+			continue
+		}
+		name := toLower(con.Name)
+		if name == "" {
+			continue
+		}
+		m[name] = con
+	}
+	return m
+}
+
+// checksChanged reports whether two same-name CHECK constraints differ, comparing their canonical
+// keys. canonicalCheck folds every stored-form-significant attribute into one key, so this differ
+// never re-implements a per-attribute comparison (mirroring indexesChanged).
+func checksChanged(a, b *Constraint, n *Normalizer) bool {
+	return canonicalCheck(a, n) != canonicalCheck(b, n)
+}
+
+// canonicalCheck returns a single stable comparison key for a CHECK constraint, folding the
+// attributes that survive into MySQL's stored form. The expression is routed through normalize-core
+// (CanonicalCheckExpr) for all canonicalization (backtick idents, operator spacing, function
+// casing, the 8.0 `_latin1` introducer); the ENFORCED/NOT ENFORCED state is a version-independent
+// boolean compared directly. The constraint NAME is the identity key (handled by the caller's map),
+// not part of this content key.
+func canonicalCheck(con *Constraint, n *Normalizer) string {
+	return encodeKeyFields(
+		"expr", n.CanonicalCheckExpr(con.CheckExpr),
+		"enforced", strconv.FormatBool(!con.NotEnforced),
+	)
 }

--- a/mysql/catalog/diff_check_test.go
+++ b/mysql/catalog/diff_check_test.go
@@ -1,0 +1,261 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the CHECK-constraint differ (correctness-protocol.md gates 1 & 2), against
+// the LIVE MySQL engines (8.0 :13306, 5.7 :13307). CHECK is 8.0.16+ only, so the two engines play
+// opposite roles:
+//
+//  1. 8.0 IDEMPOTENCE (the spine): a schema carrying CHECK constraints in its real stored form (the
+//     engine's SHOW CREATE readback, reloaded into a catalog) self-diffs empty, and the user form
+//     vs the engine's stored form diffs empty — an unnamed CHECK (auto-named `<table>_chk_N`), a
+//     compound expression whose per-operand parens / `_utf8mb4` string introducer / function casing
+//     / operator spacing the engine rewrites, and a NOT ENFORCED check must all canonicalize equal
+//     to their readback. A non-empty diff is a normalization bug.
+//
+//  2. 5.7 NO-OP (the version gate): on 5.7 a CHECK clause is PARSED AND SILENTLY DROPPED — the
+//     engine never stores it. The omni loader, by contrast, stores a ConCheck constraint
+//     unconditionally, so a 5.7-targeted catalog loaded from CHECK DDL carries ConCheck entries the
+//     engine discarded. diffChecks MUST return nil on 5.7 (gated on CheckSupported), so a table with
+//     a CHECK clause yields NO phantom check diff. TestOracle_CheckDiff57NoPhantom proves this both
+//     directly (against a live 5.7 readback that has no CHECK) and structurally (the differ returns
+//     no entries even when the loaded catalog carries a ConCheck).
+//
+// The harness reuses diffProbe / assertDiffEmptyAgainstReadback / connectOracle / serverCharsetFor /
+// both / only / containsVersion / describeDiff from the diff + normalize oracle tests; it skips
+// cleanly when the engines are unreachable.
+
+// checkDiffProbes enumerates the CHECK FORMS that must round-trip empty on 8.0: a user-form DDL
+// whose engine-stored form differs (auto-name, per-operand parens, `_utf8mb4` introducer, function
+// lowercasing, NOT ENFORCED marker, ...) but must canonicalize equal. All are 8.0-only — CHECK is
+// not represented on 5.7, whose behavior is proven separately by TestOracle_CheckDiff57NoPhantom.
+func checkDiffProbes() []diffProbe {
+	return []diffProbe{
+		// Unnamed single CHECK → MySQL auto-names `t_chk_1`; the user form (no name) vs the stored
+		// named form must collapse. The headline auto-name canonicalization case.
+		{"unnamed-single", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a > 0))", "t", only(MySQL80)},
+		// Named single CHECK — the user name is preserved verbatim on both sides.
+		{"named-single", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT chk_a CHECK (a > 0))", "t", only(MySQL80)},
+		// Multiple unnamed → t_chk_1, t_chk_2, t_chk_3 in source order; the differ keys on the
+		// (auto-)name, so all three collapse onto their readback.
+		{"multiple-unnamed", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a > 0), CHECK (b < 100), CHECK (a < b))", "t", only(MySQL80)},
+		// Mixed named + unnamed in one table.
+		{"mixed-named-unnamed", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck1 CHECK (a > 0), CHECK (b < 100))", "t", only(MySQL80)},
+		// NOT ENFORCED — the /*!80016 NOT ENFORCED */ marker; the enforced-state boolean must
+		// round-trip.
+		{"not-enforced", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ne CHECK (a < b) NOT ENFORCED)", "t", only(MySQL80)},
+		// ENFORCED explicitly stated (default) — the readback omits ENFORCED; must still be equal.
+		{"enforced-explicit", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT en CHECK (a > 0) ENFORCED)", "t", only(MySQL80)},
+		// Compound logical AND/OR — MySQL wraps each operand in parens; the loader's nodeToSQL
+		// reproduces them on the user side too, so the canonical keys match.
+		{"compound-and", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a >= 0 AND b <= 100))", "t", only(MySQL80)},
+		{"compound-or", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a = 1 OR b = 2))", "t", only(MySQL80)},
+		// BETWEEN / IN — operator keywords lowercased in the stored form.
+		{"between", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a BETWEEN 1 AND 10))", "t", only(MySQL80)},
+		{"in-list", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a IN (1, 2, 3)))", "t", only(MySQL80)},
+		// String literal → 8.0 injects the `_utf8mb4` charset introducer on storage; CanonicalCheckExpr
+		// must strip it so the user form (no introducer) and the readback compare equal.
+		{"string-literal", "CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(20), CHECK (s = 'hello')) DEFAULT CHARSET=utf8mb4", "t", only(MySQL80)},
+		// Function call — function name lowercased in the stored form (UPPER -> upper).
+		{"function-call", "CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(20), CHECK (CHAR_LENGTH(s) > 0))", "t", only(MySQL80)},
+		// Backtick-quoted identifiers in the user form vs bare-then-rebackticked stored form.
+		{"backtick-idents", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (`a` < `b`))", "t", only(MySQL80)},
+		// Extra whitespace / odd spacing in the user form collapses to the stored single-spacing.
+		{"odd-spacing", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (   a    >0   ))", "t", only(MySQL80)},
+		// Rich compound: function + string + IN + AND on one table (the probe from the live readback
+		// investigation) plus a second NOT ENFORCED check — the realistic multi-check table.
+		{"rich-compound", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, s VARCHAR(20), CONSTRAINT c1 CHECK (UPPER(s) = 'HI' AND a IN (1,2,3)), CONSTRAINT c2 CHECK (a < b) NOT ENFORCED) DEFAULT CHARSET=utf8mb4", "t", only(MySQL80)},
+		// Column-level CHECK syntax (attached to a column definition) — MySQL treats it identically
+		// to a table-level CHECK and auto-names it; must round-trip.
+		{"column-level", "CREATE TABLE t (id INT PRIMARY KEY, a INT CHECK (a > 0))", "t", only(MySQL80)},
+	}
+}
+
+// TestOracle_CheckDiffIdempotence proves gates 1 & 2 for every 8.0 CHECK form: the user DDL vs its
+// engine readback diffs EMPTY, and the stored form self-diffs empty.
+func TestOracle_CheckDiffIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, probe := range checkDiffProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := "chk_" + strings.ReplaceAll(probe.id, "-", "_")
+				assertDiffEmptyAgainstReadback(t, o, db, probe.create, probe.table)
+			})
+		}
+	}
+}
+
+// check57Cases enumerate CHECK DDLs that 5.7 PARSES BUT DROPS. Each is applied to live 5.7, read
+// back (the readback has NO check), and the user-form catalog (which the omni loader DID populate
+// with ConCheck entries) is diffed against the 5.7 readback under a 5.7 Normalizer — the result
+// must be EMPTY. This is the no-phantom-on-5.7 guarantee made concrete: diffChecks returns nil on
+// 5.7, so the loader's ConCheck entries never surface as a diff against the check-less readback.
+func check57Cases() []diffProbe {
+	return []diffProbe{
+		{"unnamed", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a > 0))", "t", only(MySQL57)},
+		{"named", "CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT chk_a CHECK (a > 0))", "t", only(MySQL57)},
+		{"multiple", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a > 0), CONSTRAINT c2 CHECK (b < 100))", "t", only(MySQL57)},
+		{"column-level", "CREATE TABLE t (id INT PRIMARY KEY, a INT CHECK (a > 0))", "t", only(MySQL57)},
+	}
+}
+
+// TestOracle_CheckDiff57NoPhantom proves the version gate: on 5.7, a table with a CHECK clause
+// yields NO check diff. It asserts the property two ways:
+//
+//  1. STRUCTURAL — the loaded user-form catalog DOES carry a ConCheck constraint (the loader stores
+//     it unconditionally), yet diffChecks(from, to, NormalizerFor(MySQL57)) on that table returns
+//     no entries (the gate fires), so a self-diff under the 5.7 normalizer is empty.
+//  2. AGAINST THE LIVE 5.7 READBACK — apply the CHECK DDL to real 5.7, read it back (the engine
+//     dropped the CHECK), and diff the user form vs the readback under the 5.7 normalizer; the
+//     result must be EMPTY despite the user side carrying a ConCheck the readback lacks.
+func TestOracle_CheckDiff57NoPhantom(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	o := connectOracle(t, MySQL57)
+	n := NormalizerFor(MySQL57)
+	sc := serverCharsetFor(MySQL57)
+
+	// Sanity: the version gate must report CHECK unsupported on 5.7 (so diffChecks short-circuits).
+	if n.CheckSupported() {
+		t.Fatal("precondition failed: CheckSupported() must be false on MySQL57")
+	}
+
+	for _, c := range check57Cases() {
+		t.Run(c.id, func(t *testing.T) {
+			// (1) STRUCTURAL: the loaded user catalog carries a ConCheck, but the 5.7 differ ignores it.
+			userCat, userTbl := loadOneTable(t, sc, c.create, c.table)
+			if countChecks(userTbl) == 0 {
+				t.Fatalf("precondition failed: loader stored no ConCheck for %q (expected ≥1)", c.create)
+			}
+			if entries := diffChecks(userTbl, userTbl, n); len(entries) != 0 {
+				t.Errorf("diffChecks on 5.7 must return nil, got %d entries", len(entries))
+			}
+			// A full self-diff under the 5.7 normalizer must also be empty (no phantom from the check).
+			if d := DiffWithNormalizer(userCat, userCat, n); !d.IsEmpty() {
+				t.Errorf("5.7 self-diff of a CHECK table not empty: %s%s", describeDiff(d), describeChecks(d))
+			}
+
+			// (2) AGAINST LIVE 5.7 READBACK: the engine dropped the CHECK; the diff must still be empty.
+			readback, ok := o.applyAndReadback(t, "chk57_"+strings.ReplaceAll(c.id, "-", "_"), c.create, c.table)
+			if !ok {
+				t.Skipf("[5.7] could not obtain readback for %s", c.id)
+			}
+			if strings.Contains(strings.ToUpper(readback), "CHECK") {
+				t.Logf("[5.7] note: readback unexpectedly mentions CHECK (engine may have stored it): %s", strings.TrimSpace(readback))
+			}
+			storedCat, _ := loadOneTable(t, sc, readback, c.table)
+			if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+				t.Errorf("[5.7] user CHECK form vs check-less readback not empty (phantom check diff):\n  user:   %s\n  stored: %s\n  diff: %s%s",
+					strings.TrimSpace(c.create), strings.TrimSpace(readback), describeDiff(d), describeChecks(d))
+			}
+			if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+				t.Errorf("[5.7] reverse (readback vs user CHECK form) not empty: %s%s", describeDiff(d), describeChecks(d))
+			}
+		})
+	}
+}
+
+// TestOracle_CheckDiffNonEmptyCorrect proves the differ reports the RIGHT action for representative
+// (from, to) check changes on 8.0 (loaded from real engine readbacks): an added, dropped, modified
+// (expression change), and enforced-state-flipped check each produce the expected CheckDiffEntry.
+func TestOracle_CheckDiffNonEmptyCorrect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	o := connectOracle(t, MySQL80)
+	n := NormalizerFor(MySQL80)
+	sc := serverCharsetFor(MySQL80)
+
+	cases := []struct {
+		name      string
+		fromDDL   string
+		toDDL     string
+		wantName  string
+		wantCheck DiffAction
+	}{
+		{"add-check",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))",
+			"ck", DiffAdd},
+		{"drop-check",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"ck", DiffDrop},
+		{"modify-expr",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 10))",
+			"ck", DiffModify},
+		{"modify-enforced-flip",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck CHECK (a < b))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck CHECK (a < b) NOT ENFORCED)",
+			"ck", DiffModify},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rbFrom, ok1 := o.showCreate(t, "chk_nf", tc.fromDDL, "t")
+			rbTo, ok2 := o.showCreate(t, "chk_nt", tc.toDDL, "t")
+			if !ok1 || !ok2 {
+				t.Skipf("[8.0] could not obtain readbacks")
+			}
+			fromCat, _ := loadOneTable(t, sc, rbFrom, "t")
+			toCat, _ := loadOneTable(t, sc, rbTo, "t")
+			d := DiffWithNormalizer(fromCat, toCat, n)
+			te := findTable(d, "t")
+			if te == nil {
+				t.Fatalf("[8.0] expected table diff, got %s", describeDiff(d))
+			}
+			ce := findCheck(te, tc.wantName)
+			if ce == nil || ce.Action != tc.wantCheck {
+				t.Fatalf("[8.0] want check %s %s, got %s", tc.wantName, tc.wantCheck, describeChecks(d))
+			}
+		})
+	}
+}
+
+// countChecks returns the number of ConCheck constraints on a table (test helper).
+func countChecks(t *Table) int {
+	n := 0
+	if t == nil {
+		return 0
+	}
+	for _, con := range t.Constraints {
+		if con != nil && con.Type == ConCheck {
+			n++
+		}
+	}
+	return n
+}
+
+// findCheck returns the CheckDiffEntry for a check name (lower-cased match), or nil.
+func findCheck(e *TableDiffEntry, name string) *CheckDiffEntry {
+	for i := range e.Checks {
+		if toLower(e.Checks[i].Name) == toLower(name) {
+			return &e.Checks[i]
+		}
+	}
+	return nil
+}
+
+// describeChecks renders the per-table check diffs for failure output (describeDiff omits them).
+func describeChecks(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, te := range d.Tables {
+		for _, ce := range te.Checks {
+			fmt.Fprintf(&b, " chk(%s %s)", ce.Name, ce.Action)
+		}
+	}
+	return b.String()
+}

--- a/mysql/catalog/migration_check.go
+++ b/mysql/catalog/migration_check.go
@@ -1,15 +1,220 @@
 package catalog
 
-// MySQL SDL generate — CHECK constraints (scaffold stub).
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — CHECK constraints (8.0.16+ only).
 //
-// Wired into GenerateMigrationWithNormalizer (migration.go) so check diffs become DDL.
-// Inert no-op placeholder returning nil until the check breadth node renders the ALTER
-// TABLE ... ADD/DROP CHECK ops from TableDiffEntry.Checks (OpAddCheck/OpDropCheck). CHECK
-// is 8.0-only (see normalize.go CheckSupported); the breadth node gates on the Normalizer's
-// version. Signature mirrors generateTableDDL (migration_table.go).
+// This is the MySQL analog of PG's CHECK generator. It turns the check diff (TableDiffEntry.Checks,
+// populated by diff_check.go) into ALTER TABLE ... ADD/DROP CHECK DDL. It is wired into
+// GenerateMigrationWithNormalizer (migration.go) against the OpAddCheck/OpDropCheck op-types.
 //
-// implemented by omni:check breadth node
-func generateCheckDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no check ops (empty diff -> empty plan).
-	return nil
+// VERSION GATE. CHECK is 8.0.16+ only; on 5.7 it is parsed-and-dropped (normalize.go
+// CheckSupported). diffChecks already returns nil on 5.7, so the diff carries no check entries and
+// this generator would emit nothing anyway — but it gates explicitly too, so the new-table path
+// (which reads To.Constraints directly, not the diff) also emits nothing on 5.7. The gate is the
+// single owner of the version decision (CheckSupported), never re-derived here.
+//
+// Two table cases produce check ADDs:
+//   - DiffModify: the per-check diff drives ADD / DROP / (DROP+ADD for MODIFY).
+//   - DiffAdd: a freshly created table. generate-core's formatCreateTable renders only columns and
+//     the inline PRIMARY KEY (migration_table.go) — it does NOT inline CHECK constraints — so every
+//     check on a new table is added here via ALTER TABLE ... ADD CONSTRAINT ... CHECK, mirroring how
+//     the index node adds a new table's non-PK indexes (addIndexOpsForNewTable).
+//
+// DiffDrop tables emit nothing: DROP TABLE removes their checks wholesale.
+//
+// A check cannot be altered in place, so a modified check (changed expression or ENFORCED state) is
+// a DROP followed by an ADD. The DROP runs in PhasePre and the ADD in PhaseMain, so a drop-then-add
+// of the same name never collides on a name still held by the old definition.
+//
+// Rendering routes through the same canonical form show.go uses for the stored CHECK line
+// (formatCheckClause mirrors showConstraint's ConCheck branch: CONSTRAINT `name` CHECK (expr) with
+// a /*!80016 NOT ENFORCED */ marker), so the readback of the emitted DDL canonicalizes equal to
+// `to` and apply-correctness holds.
+//
+// Ordering: check ADDs run in PhaseMain at priorityConstraint (after the table CREATE and column
+// ALTERs — so a CHECK that references a freshly added/modified column applies against the final
+// column). Check DROPs run in PhasePre (before PhaseMain), so a modified check's drop precedes its
+// re-add. sortMigrationOps re-imposes the global phase/priority/name order.
+func generateCheckDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	// Version gate: no CHECK in 5.7 stored form, so emit nothing (the new-table path below reads
+	// To.Constraints directly, so this guard is what keeps it silent on 5.7).
+	if !n.CheckSupported() {
+		return nil
+	}
+
+	var ops []MigrationOp
+
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		switch entry.Action {
+		case DiffAdd:
+			ops = append(ops, addCheckOpsForNewTable(entry)...)
+		case DiffModify:
+			ops = append(ops, checkOpsForModifiedTable(entry)...)
+		case DiffDrop:
+			// DROP TABLE removes the checks; nothing to emit.
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Type != ops[j].Type {
+			// Drops ahead of adds locally (also enforced by phase) for readability.
+			return checkOpRank(ops[i].Type) < checkOpRank(ops[j].Type)
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// addCheckOpsForNewTable emits ADD ops for every CHECK constraint on a freshly created table
+// (formatCreateTable inlines only columns and the PK, never CHECKs). The checks are ordered by
+// lower-cased name so a new table's ADD CHECK sequence is stable across runs.
+func addCheckOpsForNewTable(entry *TableDiffEntry) []MigrationOp {
+	if entry.To == nil {
+		return nil
+	}
+	table := tableIdent(entry.To)
+	var ops []MigrationOp
+	for _, con := range orderedChecks(entry.To) {
+		ops = append(ops, addCheckOp(entry, table, con))
+	}
+	return ops
+}
+
+// checkOpsForModifiedTable emits ADD / DROP / (DROP+ADD) ops from the per-check diff of a modified
+// table. A modified check is a DROP (PhasePre) then an ADD (PhaseMain) — a check has no in-place
+// alter, so the drop frees the name for the re-add.
+func checkOpsForModifiedTable(entry *TableDiffEntry) []MigrationOp {
+	if entry.To == nil || len(entry.Checks) == 0 {
+		return nil
+	}
+	table := tableIdent(entry.To)
+	var ops []MigrationOp
+	for _, ce := range entry.Checks {
+		switch ce.Action {
+		case DiffAdd:
+			if ce.To == nil {
+				continue
+			}
+			ops = append(ops, addCheckOp(entry, table, ce.To))
+		case DiffDrop:
+			if ce.From == nil {
+				continue
+			}
+			ops = append(ops, dropCheckOp(entry, table, ce.From))
+		case DiffModify:
+			if ce.From == nil || ce.To == nil {
+				continue
+			}
+			ops = append(ops, dropCheckOp(entry, table, ce.From))
+			ops = append(ops, addCheckOp(entry, table, ce.To))
+		}
+	}
+	return ops
+}
+
+// addCheckOp builds an ALTER TABLE ... ADD CONSTRAINT `name` CHECK (...) op, running in PhaseMain at
+// priorityConstraint (after the table CREATE at priorityTable and column ALTERs at priorityColumn,
+// so a CHECK referencing a newly added/modified column applies against the final column).
+func addCheckOp(entry *TableDiffEntry, table string, con *Constraint) MigrationOp {
+	return MigrationOp{
+		Type:         OpAddCheck,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s ADD %s", table, formatCheckClause(con)),
+		Phase:        PhaseMain,
+		Priority:     priorityConstraint,
+		sortName:     checkSortName(entry.Database, entry.Name, con.Name),
+	}
+}
+
+// priorityCheckDrop orders a CHECK DROP within PhasePre BEFORE any column DROP. MySQL CASCADE-DROPS
+// a CHECK constraint when a column the constraint references is dropped (verified against live 8.0:
+// `ALTER TABLE ... DROP COLUMN a` silently removes a `CHECK (a > 0)`), after which an explicit
+// `DROP CHECK` for that constraint fails with errno 3821 ("Check constraint is not found in the
+// table"). Because the migration plan is applied one statement at a time, the check DROP must
+// precede the column DROP so the explicit DROP CHECK runs while the constraint still exists; the
+// column DROP then proceeds with no constraint left to cascade. Column drops run at priorityColumn-1
+// (generated) / priorityColumn (plain) within PhasePre, and table drops at priorityTable=10; this
+// sits below the column-drop range and above the table-drop (matching the index node's
+// priorityIndexDrop), so the order is table-drop (10) < check-drop (15) < generated-col-drop (19) <
+// plain-col-drop (20). Dropping a check whose columns are NOT being dropped is harmless to sequence
+// first (it is independent), so always ordering check drops ahead of column drops is safe and simple
+// — and it also keeps a modified check's drop ahead of its PhaseMain re-add.
+const priorityCheckDrop = priorityColumn - 5
+
+// dropCheckOp builds an ALTER TABLE ... DROP CHECK `name` op (the 8.0.16+ syntax for removing a
+// check constraint), running in PhasePre so all check drops precede any add (a modified check's
+// drop frees its name before the re-add in PhaseMain) AND precede column drops (so a check referencing
+// a dropped column is removed explicitly before MySQL would cascade-drop it — see priorityCheckDrop).
+func dropCheckOp(entry *TableDiffEntry, table string, con *Constraint) MigrationOp {
+	return MigrationOp{
+		Type:         OpDropCheck,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s DROP CHECK %s", table, migrationQuoteIdent(con.Name)),
+		Phase:        PhasePre,
+		Priority:     priorityCheckDrop,
+		sortName:     checkSortName(entry.Database, entry.Name, con.Name),
+	}
+}
+
+// formatCheckClause renders the CHECK clause that follows ADD in an ALTER TABLE, in MySQL's
+// canonical stored form: CONSTRAINT `name` CHECK (expr) with an optional /*!80016 NOT ENFORCED */
+// marker. It mirrors show.go's showConstraint ConCheck branch (the stored CHECK line) so the
+// readback of the ADD canonicalizes equal to `to`. The expression is emitted as stored on the
+// constraint (CheckExpr); the diff's canonical comparison — not the emitted text — is what absorbs
+// surface-form differences, and the engine re-canonicalizes the emitted expression on apply.
+//
+// The /*!80016 ... */ version guard makes NOT ENFORCED a no-op below 8.0.16, matching how show.go
+// renders it, so the same DDL is valid across the 8.0 line.
+func formatCheckClause(con *Constraint) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CONSTRAINT %s CHECK (%s)", migrationQuoteIdent(con.Name), con.CheckExpr)
+	if con.NotEnforced {
+		b.WriteString(" /*!80016 NOT ENFORCED */")
+	}
+	return b.String()
+}
+
+// orderedChecks returns a table's CHECK constraints in a deterministic order (by lower-cased name),
+// so a new table's ADD CHECK sequence is stable across runs.
+func orderedChecks(t *Table) []*Constraint {
+	var out []*Constraint
+	if t == nil {
+		return out
+	}
+	for _, con := range t.Constraints {
+		if con == nil || con.Type != ConCheck || con.Name == "" {
+			continue
+		}
+		out = append(out, con)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return toLower(out[i].Name) < toLower(out[j].Name)
+	})
+	return out
+}
+
+// checkOpRank orders check op types so drops sort ahead of adds locally (phase ordering also
+// enforces this globally).
+func checkOpRank(t MigrationOpType) int {
+	if t == OpDropCheck {
+		return 0
+	}
+	return 1
+}
+
+// checkSortName is the stable secondary sort key for a check op: lower-cased
+// database.table.constraint.
+func checkSortName(database, table, check string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(table) + "." + strings.ToLower(check)
 }

--- a/mysql/catalog/migration_check_oracle_test.go
+++ b/mysql/catalog/migration_check_oracle_test.go
@@ -1,0 +1,160 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle apply-correctness proof for the CHECK-constraint generator (correctness-protocol.md
+// gate 2), against the LIVE MySQL 8.0 engine (CHECK is 8.0.16+ only). For representative (from, to)
+// pairs covering every CHECK variant, the generated ALTER TABLE ... ADD/DROP CHECK DDL applied to a
+// real `from` database must yield a table whose canonical form equals `to`. Idempotence (gate 1) for
+// CHECK forms is covered by TestOracle_CheckDiffIdempotence (the no-op plan is empty because the
+// diff is empty); this file proves the EMITTED DDL is correct.
+//
+// 5.7 is intentionally absent: CHECK is parsed-and-dropped there, diffChecks returns nil, and the
+// generator emits nothing — proven by TestOracle_CheckDiff57NoPhantom on the diff side. There is no
+// apply-correctness to prove for an empty plan.
+//
+// The harness reuses assertApplyCorrect / catalogFromReadback / loadOneTable / connectOracle /
+// only(MySQL80) from migration_oracle_test.go; it skips cleanly when the engine is unreachable.
+
+// checkMigrationProbes enumerates the CHECK ADD/DROP/MODIFY FORMS the generator covers. Each is a
+// single-table (from, to) pair. An empty fromDDL means a pure CREATE, which exercises the
+// "new table → ADD CHECK for every check" path (formatCreateTable inlines columns + PK only, never
+// CHECKs — so each check is added via a post-create ALTER, mirroring the index node).
+func checkMigrationProbes() []migrationProbe {
+	return []migrationProbe{
+		// ---- CREATE TABLE carrying checks (new table; checks added via ALTER) ----
+		{"create-with-named-check", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))", only(MySQL80)},
+		{"create-with-unnamed-check", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a > 0))", only(MySQL80)},
+		{"create-with-multiple-checks", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a > 0), CONSTRAINT cb CHECK (b < 100), CHECK (a < b))", only(MySQL80)},
+		{"create-with-not-enforced", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ne CHECK (a < b) NOT ENFORCED)", only(MySQL80)},
+		{"create-with-compound", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a >= 0 AND b <= 100))", only(MySQL80)},
+		{"create-with-string-literal", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(20), CHECK (s = 'hello')) DEFAULT CHARSET=utf8mb4", only(MySQL80)},
+		{"create-with-function", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, s VARCHAR(20), CHECK (CHAR_LENGTH(s) > 0))", only(MySQL80)},
+		{"create-with-column-level-check", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT CHECK (a > 0))", only(MySQL80)},
+
+		// ---- ADD CHECK (modified table) ----
+		{"add-named-check", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))", only(MySQL80)},
+		{"add-unnamed-check", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a > 0))", only(MySQL80)},
+		{"add-not-enforced", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ne CHECK (a < b) NOT ENFORCED)", only(MySQL80)},
+		{"add-second-check", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT c1 CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT c1 CHECK (a > 0), CONSTRAINT c2 CHECK (b < 100))", only(MySQL80)},
+		{"add-compound", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CHECK (a >= 0 AND b <= 100))", only(MySQL80)},
+
+		// ---- DROP CHECK (modified table) ----
+		{"drop-named-check", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)", only(MySQL80)},
+		{"drop-unnamed-check", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT)", only(MySQL80)},
+		{"drop-one-of-many", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT c1 CHECK (a > 0), CONSTRAINT c2 CHECK (b < 100))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT c2 CHECK (b < 100))", only(MySQL80)},
+
+		// ---- MODIFY check (DROP+ADD): same name, changed expression or enforced state ----
+		{"modify-expr", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 10))", only(MySQL80)},
+		{"modify-enforced-to-not", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck CHECK (a < b))",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck CHECK (a < b) NOT ENFORCED)", only(MySQL80)},
+		{"modify-not-to-enforced", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck CHECK (a < b) NOT ENFORCED)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, CONSTRAINT ck CHECK (a < b))", only(MySQL80)},
+
+		// ---- check + column interplay ----
+		// Add a column AND a CHECK that references it in the same plan (ADD COLUMN at priorityColumn
+		// runs before ADD CHECK at priorityConstraint, so the column exists when the check applies).
+		{"add-column-and-check-on-it", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))", only(MySQL80)},
+		// Drop a CHECK and the column it references in the same plan: the CHECK must be dropped first
+		// (PhasePre DROP CHECK before the column drop). Otherwise MySQL CASCADE-DROPS the single-column
+		// CHECK together with the column (the column drop itself succeeds), after which this node's
+		// explicit DROP CHECK fails with errno 3821 ("Check constraint is not found in the table") —
+		// live-verified on 8.0. Ordering the DROP CHECK first runs it while the constraint still
+		// exists, so the explicit drop succeeds and the column drop then has nothing left to cascade.
+		{"drop-check-and-its-column", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))",
+			"CREATE TABLE t (id INT PRIMARY KEY)", only(MySQL80)},
+	}
+}
+
+// TestOracle_CheckMigrationApplyCorrectness proves gate 2 for every check probe: the generated DDL
+// transforms a real `from` database into a `to`-equal one (compared via canonical readback).
+func TestOracle_CheckMigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	// CHECK is 8.0-only; the generator emits nothing on 5.7 (proven on the diff side). Apply
+	// correctness is therefore an 8.0-only concern.
+	o := connectOracle(t, MySQL80)
+	n := NormalizerFor(MySQL80)
+	for _, probe := range checkMigrationProbes() {
+		if !containsVersion(probe.versions, MySQL80) {
+			continue
+		}
+		t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+			assertApplyCorrect(t, o, n, probe)
+		})
+	}
+}
+
+// TestOracle_CheckGenerate57EmitsNothing proves the generate-side version gate: even when a `to`
+// catalog carries CHECK constraints (the loader stores them unconditionally), the generator under a
+// 5.7 Normalizer emits NO check ops — neither on a fresh CREATE (the new-table path reads
+// To.Constraints directly) nor on a modify. This is the generate-side mirror of
+// TestOracle_CheckDiff57NoPhantom, and it needs no live engine (it asserts on the plan).
+func TestOracle_CheckGenerate57EmitsNothing(t *testing.T) {
+	n57 := NormalizerFor(MySQL57)
+	sc := serverCharsetFor(MySQL57)
+
+	// from: no table; to: a new table carrying a CHECK. The new-table path must emit no ADD CHECK.
+	t.Run("new-table", func(t *testing.T) {
+		toCat, _ := loadOneTable(t, sc, "CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))", "t")
+		fromCat := New()
+		diff := DiffWithNormalizer(fromCat, toCat, n57)
+		plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n57)
+		for _, op := range plan.Ops {
+			if op.Type == OpAddCheck || op.Type == OpDropCheck {
+				t.Errorf("[5.7] new-table plan must emit no check op, got: %s", op.SQL)
+			}
+		}
+	})
+
+	// from: table with a CHECK; to: same table without it. Under the 5.7 gate the differ reports no
+	// check change, so the generator emits no DROP CHECK.
+	t.Run("drop-check", func(t *testing.T) {
+		fromCat, _ := loadOneTable(t, sc, "CREATE TABLE t (id INT PRIMARY KEY, a INT, CONSTRAINT ck CHECK (a > 0))", "t")
+		toCat, _ := loadOneTable(t, sc, "CREATE TABLE t (id INT PRIMARY KEY, a INT)", "t")
+		diff := DiffWithNormalizer(fromCat, toCat, n57)
+		plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n57)
+		for _, op := range plan.Ops {
+			if op.Type == OpAddCheck || op.Type == OpDropCheck {
+				t.Errorf("[5.7] drop-check plan must emit no check op, got: %s", op.SQL)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Scope

Fills the two MySQL SDL CHECK-constraint breadth-node hooks (the scaffold wired everything else):
- `mysql/catalog/diff_check.go` — `diffChecks(from, to *Table, n *Normalizer) []CheckDiffEntry` (stub → real; populates `TableDiffEntry.Checks` from `compareTable`).
- `mysql/catalog/migration_check.go` — `generateCheckDDL(from, to *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp` (emits `OpAddCheck` / `OpDropCheck`).

No other production files changed (`diff.go` / `diff_table.go` / `migration.go` untouched; the `CheckDiffEntry` type and op-types were already declared).

CHECK identity is the constraint name lower-cased — the loader auto-names unnamed checks `<table>_chk_N`, so checks are always named in the catalog (same model as the index node). Equality folds two stored-form-significant attributes: the canonicalized expression and the `ENFORCED` / `NOT ENFORCED` state.

## 8.0-only version gating (the headline correctness property)

CHECK constraints are **MySQL 8.0.16+ only**. On 5.7 a `CHECK` clause is **parsed and silently dropped** — the engine never stores it, so `SHOW CREATE` echoes nothing. The omni loader, however, stores a `ConCheck` constraint **unconditionally** (regardless of version), so a 5.7-targeted catalog loaded from `CHECK` DDL carries `ConCheck` entries the engine discarded.

Both `diffChecks` and `generateCheckDDL` therefore gate on the Normalizer's `CheckSupported()` (`== is80()`) and **return nil on 5.7** — no phantom diff against a check-less readback, no emitted DDL. The generator's gate is independently load-bearing: the new-table (`DiffAdd`) path reads `To.Constraints` directly (not the diff), so the diff-side gate alone would not suppress it.

## Expression canonicalization

The CHECK expression is routed entirely through normalize-core's `CanonicalCheckExpr` (which delegates to `CanonicalGeneratedExpr`) — no canonicalization is re-implemented in the differ. It absorbs every user-vs-stored difference 8.0 introduces on storage: backtick-quoted identifiers, operator spacing, function-name casing, the per-operand parentheses MySQL injects into compound expressions, and the 8.0 `_utf8mb4` / `_latin1` string-literal charset introducer. The `NotEnforced` boolean is version-independent and compared directly.

Emitted DDL mirrors `show.go`'s stored CHECK line — `CONSTRAINT \`name\` CHECK (expr)` with a `/*!80016 NOT ENFORCED */` marker — so the readback of an `ADD` canonicalizes equal to the target.

## Ordering

- **ADD CHECK** runs in `PhaseMain` at `priorityConstraint` (after `CREATE TABLE` and after column ADD/MODIFY), so a check referencing a freshly added/modified column applies against the final column. A new table's checks are added via post-create `ALTER TABLE ... ADD CONSTRAINT` because `formatCreateTable` inlines only columns + the primary key (mirroring the index node's `addIndexOpsForNewTable`).
- **DROP CHECK** uses the 8.0.16+ `ALTER TABLE ... DROP CHECK \`name\`` and runs in `PhasePre` at `priorityColumn - 5`, **before any column drop**. MySQL cascade-drops a single-column CHECK when its column is dropped (live-verified: a subsequent explicit `DROP CHECK` then fails errno 3821), so the explicit drop must fire while the constraint still exists. Same priority mechanism as the index node's `priorityIndexDrop`.
- **MODIFY** (expression or enforced-state change) is a `DROP` (`PhasePre`) then `ADD` (`PhaseMain`) — a check has no in-place alter; the cross-phase split frees the name before the re-add.

## Oracle evidence (live engines: 8.0 :13306, 5.7 :13307)

Both correctness gates proven mechanically, across every covered form:

- **`TestOracle_CheckDiffIdempotence`** (gates 1 & 2, 8.0) — 16 forms self-diff empty: unnamed/named/multiple/mixed naming, `NOT ENFORCED`, explicit `ENFORCED`, compound `AND`/`OR`, `BETWEEN`, `IN`, string literal (introducer), function call, backtick idents, odd spacing, rich-compound multi-check, column-level CHECK.
- **`TestOracle_CheckDiff57NoPhantom`** (the version gate) — 4 forms prove `diffChecks` returns nil on 5.7 both structurally (the loaded catalog carries a `ConCheck`, yet the differ ignores it) and against the live 5.7 readback (which has no check).
- **`TestOracle_CheckMigrationApplyCorrectness`** (apply-correctness, 8.0) — 21 ADD/DROP/MODIFY forms applied to real 8.0 yield the target schema (canonical-readback compare), including the `add-column-and-check-on-it` and `drop-check-and-its-column` ordering interplay.
- **`TestOracle_CheckGenerate57EmitsNothing`** — the generator emits no check ops on 5.7 (new-table and modify paths).

The discovery loop caught one real ordering bug via the apply gate (`DROP CHECK` originally ordered after the column drop → errno 3821), now fixed by `priorityCheckDrop = priorityColumn - 5`.

## Normalization flags

None — `CanonicalCheckExpr` covers every required canonicalization; no gap to flag for normalize-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
