### PR TITLE
feat(mysql/catalog): implement partition diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_partition.go
+++ b/mysql/catalog/diff_partition.go
@@ -48,22 +48,46 @@ func canonicalPartitionSpec(t *Table, n *Normalizer) string {
 	return showPartitioning(partitionSpecWithResolvedEngine(t, n))
 }
 
-// partitionSpecWithResolvedEngine returns a copy of the table's PartitionInfo with every
-// explicitly-defined partition's and subpartition's Engine resolved to the table's effective
-// storage engine when empty. The table default (InnoDB unless ENGINE=... says otherwise) is
-// what SHOW CREATE echoes per partition, so folding empty → that value makes the user form (no
-// per-partition ENGINE) and the stored form (every partition carries ENGINE = <engine>) compare
-// equal — including a MyISAM table, whose readback echoes ENGINE = MyISAM, not InnoDB.
+// keyAlgorithmDefault is the KEY-partitioning ALGORITHM that MySQL omits from SHOW CREATE: the
+// modern algorithm (2) is the default and is NOT echoed, while the legacy algorithm (1) IS echoed
+// (via a /*!50611 ALGORITHM = 1 */ split comment). The catalog uses 0 to mean "no ALGORITHM
+// written"; the loader stores 2 only when the user wrote it explicitly. Folding 2 → 0 makes an
+// explicit `KEY ALGORITHM=2` compare equal to the engine's stripped `KEY` form (verified on live
+// 5.7.25 + 8.0.32). Algorithm 1 is left intact so its echoed form round-trips. (Concern raised by
+// cross-family review and confirmed on both engines.)
+const keyAlgorithmDefault = 2
+
+// partitionSpecWithResolvedEngine returns a copy of the table's PartitionInfo canonicalized so that
+// the user form and the engine's SHOW CREATE readback collapse onto the same showPartitioning
+// output. Two surface differences are folded:
+//
+//   - per-partition / per-subpartition Engine: resolved to the table's effective storage engine
+//     when empty. The table default (InnoDB unless ENGINE=... says otherwise) is what SHOW CREATE
+//     echoes per partition, so folding empty → that value makes the user form (no per-partition
+//     ENGINE) and the stored form (every partition carries ENGINE = <engine>) compare equal —
+//     including a MyISAM table, whose readback echoes ENGINE = MyISAM, not InnoDB.
+//   - KEY partitioning ALGORITHM = 2: the default algorithm, stripped from SHOW CREATE, is folded
+//     to 0 (unspecified) so an explicit `ALGORITHM=2` matches the readback (keyAlgorithmDefault).
 //
 // HASH/KEY partitions defined only by PARTITIONS N (no explicit definitions) read back as
 // `PARTITIONS N` with NO per-partition engine on either side; showPartitioning renders that
-// PARTITIONS-N form without touching per-partition engines, so the resolution below is a no-op
+// PARTITIONS-N form without touching per-partition engines, so the engine resolution is a no-op
 // for them and they round-trip regardless.
+//
+// NOT folded — flagged idempotence limitation: a partition EXPRESSION or bound VALUE containing a
+// non-literal constant expression (e.g. `VALUES LESS THAN (TO_DAYS('2020-01-01'))`, `LESS THAN
+// (5+5)`) is constant-folded by the engine at storage time (→ `737790`, `10`) but kept verbatim by
+// the loader, so it phantom-diffs. Folding it requires a constant-expression evaluator — a
+// normalize-core/analyzer capability (the same one CanonicalGeneratedExpr would need to evaluate,
+// not just reformat), out of scope for this node. See the package doc / PR flag. Literal bounds
+// (the overwhelmingly common case) are unaffected.
 func partitionSpecWithResolvedEngine(t *Table, n *Normalizer) *PartitionInfo {
 	pi := t.Partitioning
 	engine := n.CanonicalEngine(t) // lower-cased effective engine; never returns ""
 
 	out := *pi
+	out.Algorithm = foldKeyAlgorithm(pi.Algorithm)
+	out.SubAlgo = foldKeyAlgorithm(pi.SubAlgo)
 	out.Partitions = make([]*PartitionDefInfo, len(pi.Partitions))
 	for i, pd := range pi.Partitions {
 		cp := *pd
@@ -92,4 +116,14 @@ func resolvePartitionEngine(declared, tableEngine string) string {
 		return tableEngine
 	}
 	return d
+}
+
+// foldKeyAlgorithm maps the default KEY-partitioning ALGORITHM (2) to 0 (unspecified), so an
+// explicit `ALGORITHM=2` and the engine's stripped readback compare equal. Algorithm 1 (legacy,
+// echoed by SHOW CREATE) and 0 (unwritten) pass through unchanged.
+func foldKeyAlgorithm(algo int) int {
+	if algo == keyAlgorithmDefault {
+		return 0
+	}
+	return algo
 }

--- a/mysql/catalog/diff_partition.go
+++ b/mysql/catalog/diff_partition.go
@@ -1,16 +1,95 @@
 package catalog
 
-// MySQL SDL diff — table partitioning (scaffold stub).
+import "strings"
+
+// MySQL SDL diff — table partitioning (the PARTITION BY clause, compared as one spec).
 //
-// Wired into compareTable (diff_table.go) so a modified table records a partitioning
-// change via the TableDiffEntry.PartitionChanged flag (a bool, not a slice — MySQL
-// partitioning is a single per-table clause, compared as one PARTITION BY ... spec via
-// Table.Partitioning). Inert no-op placeholder returning false until the partition breadth
-// node implements the real comparison. Signature mirrors diffColumns: per-table, taking
-// from/to *Table and the version-fixing Normalizer.
+// MySQL partitioning is a single per-table clause, not a set of independent sub-objects, so
+// the diff signal is a coarse bool (TableDiffEntry.PartitionChanged): "does the partition
+// spec differ?". diffPartitions is wired into compareTable (diff_table.go) and folded into
+// the "is this table modified?" decision via tableSubdiffsChanged.
 //
-// implemented by omni:partition breadth node
-func diffPartitions(_, _ *Table, _ *Normalizer) bool {
-	// Scaffold: returns false so PartitionChanged stays unset (self-diff inert).
-	return false
+// IDEMPOTENCE is the whole point of this node. A partitioned table's SHOW CREATE emits a
+// canonical partition clause whose surface form differs from the user's DDL — most visibly,
+// every explicitly-defined partition is echoed with a trailing `ENGINE = <engine>` even when
+// the user wrote none. The omni loader (buildPartitionInfo in tablecmds.go) already absorbs
+// the OTHER surface differences into a single canonical PartitionInfo: it normalizes the
+// partition EXPRESSION identically for the user form and the engine readback (so 8.0's
+// backtick-quoted, lower-cased `RANGE (year(`dt`))`, 5.7's bare `RANGE (YEAR(dt))`, and the
+// user's `RANGE (YEAR(dt))` all load to the same Expr), folds RANGE/LIST COLUMNS and KEY
+// columns into Columns, and expands `PARTITIONS N` / `SUBPARTITIONS N` defaulting into the
+// UseDefault* flags. (Verified on live 5.7.25 + 8.0.32: for every partition form the ONLY
+// field that differs between the user DDL and its SHOW CREATE readback is the per-partition /
+// per-subpartition Engine — empty in the user form, the table's storage engine in the
+// readback.)
+//
+// So canonicalization here is exactly: resolve each partition's (and subpartition's) effective
+// storage engine — empty means "the table's engine" — and otherwise compare the partition spec
+// rendered through the SAME deparser show.go uses for the stored form (showPartitioning). Using
+// the deparser as the comparison key keeps a single source of truth: the form the diff treats
+// as canonical is byte-for-byte the form generatePartitionDDL re-emits, which is the form the
+// engine stores — so apply-correctness and idempotence hold by construction.
+//
+// implemented by omni:partitions breadth node
+func diffPartitions(from, to *Table, n *Normalizer) bool {
+	return canonicalPartitionSpec(from, n) != canonicalPartitionSpec(to, n)
+}
+
+// canonicalPartitionSpec returns the canonical signature of a table's partitioning, or "" when
+// the table is not partitioned. Two tables have the same partitioning iff their signatures are
+// equal. The signature is showPartitioning over a copy whose per-partition/subpartition engine
+// is resolved to the effective engine (empty → the table's storage engine), folding the only
+// user-vs-stored surface difference; every other surface difference is already canonicalized by
+// the loader (see diffPartitions doc).
+func canonicalPartitionSpec(t *Table, n *Normalizer) string {
+	if t == nil || t.Partitioning == nil {
+		return ""
+	}
+	return showPartitioning(partitionSpecWithResolvedEngine(t, n))
+}
+
+// partitionSpecWithResolvedEngine returns a copy of the table's PartitionInfo with every
+// explicitly-defined partition's and subpartition's Engine resolved to the table's effective
+// storage engine when empty. The table default (InnoDB unless ENGINE=... says otherwise) is
+// what SHOW CREATE echoes per partition, so folding empty → that value makes the user form (no
+// per-partition ENGINE) and the stored form (every partition carries ENGINE = <engine>) compare
+// equal — including a MyISAM table, whose readback echoes ENGINE = MyISAM, not InnoDB.
+//
+// HASH/KEY partitions defined only by PARTITIONS N (no explicit definitions) read back as
+// `PARTITIONS N` with NO per-partition engine on either side; showPartitioning renders that
+// PARTITIONS-N form without touching per-partition engines, so the resolution below is a no-op
+// for them and they round-trip regardless.
+func partitionSpecWithResolvedEngine(t *Table, n *Normalizer) *PartitionInfo {
+	pi := t.Partitioning
+	engine := n.CanonicalEngine(t) // lower-cased effective engine; never returns ""
+
+	out := *pi
+	out.Partitions = make([]*PartitionDefInfo, len(pi.Partitions))
+	for i, pd := range pi.Partitions {
+		cp := *pd
+		cp.Engine = resolvePartitionEngine(pd.Engine, engine)
+		if len(pd.SubPartitions) > 0 {
+			cp.SubPartitions = make([]*SubPartitionDefInfo, len(pd.SubPartitions))
+			for j, sp := range pd.SubPartitions {
+				csp := *sp
+				csp.Engine = resolvePartitionEngine(sp.Engine, engine)
+				cp.SubPartitions[j] = &csp
+			}
+		}
+		out.Partitions[i] = &cp
+	}
+	return &out
+}
+
+// resolvePartitionEngine resolves a partition's declared engine against the table's effective
+// engine, case-insensitively. An empty declared engine inherits the table engine; a declared
+// engine equal to the table engine is normalized to the table-engine spelling (so a user's
+// lower-case `engine=innodb` and a readback's `ENGINE = InnoDB` agree). The comparison is
+// case-insensitive because MySQL engine names are.
+func resolvePartitionEngine(declared, tableEngine string) string {
+	d := strings.TrimSpace(declared)
+	if d == "" || strings.EqualFold(d, tableEngine) {
+		return tableEngine
+	}
+	return d
 }

--- a/mysql/catalog/diff_partition_test.go
+++ b/mysql/catalog/diff_partition_test.go
@@ -53,6 +53,12 @@ func partitionDiffProbes() []diffProbe {
 		{"key-implicit", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY KEY () PARTITIONS 3", "t", both()},
 		// KEY over an explicit column.
 		{"key-explicit", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY KEY (id) PARTITIONS 3", "t", both()},
+		// KEY ALGORITHM=2 — the DEFAULT algorithm, STRIPPED from SHOW CREATE (`KEY (id)`), so the
+		// explicit user form must fold to the stripped stored form (keyAlgorithmDefault fold).
+		{"key-algorithm-2", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY KEY ALGORITHM=2 (id) PARTITIONS 3", "t", both()},
+		// KEY ALGORITHM=1 — the LEGACY algorithm, ECHOED by SHOW CREATE via a /*!50611 ALGORITHM = 1
+		// */ split comment, so it must round-trip WITHOUT being folded.
+		{"key-algorithm-1", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY KEY ALGORITHM=1 (id) PARTITIONS 3", "t", both()},
 		// LINEAR KEY.
 		{"linear-key", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LINEAR KEY (id) PARTITIONS 2", "t", both()},
 		// Per-partition COMMENT (echoed as `COMMENT = '...' ENGINE = ...`).

--- a/mysql/catalog/diff_partition_test.go
+++ b/mysql/catalog/diff_partition_test.go
@@ -1,0 +1,178 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the partition differ (correctness-protocol.md gates 1 & 2), against the
+// LIVE MySQL engines (5.7 :13307, 8.0 :13306). Partitioning is the diff-core idempotence gap the
+// breadth node closes: a partitioned table's SHOW CREATE emits a canonical partition clause whose
+// surface form differs from the user DDL (per-partition `ENGINE = ...` echo, 8.0's backtick-quoted
+// lower-cased expression, `PARTITIONS N` defaulting), and diff-core deliberately deferred it, so
+// before this node a partitioned table is NOT idempotent.
+//
+// Two properties are proven mechanically for every partition variant:
+//
+//  1. Idempotence (the spine): a schema in its real stored form (the engine's SHOW CREATE
+//     readback, reloaded) self-diffs empty, AND the user DDL vs the engine's stored form diffs
+//     empty (PartitionChanged=false). A non-empty diff is a partition-canonicalization bug.
+//  2. Real changes ARE detected (gate-2 complement): two genuinely different partition specs
+//     (and partitioned-vs-not) diff with PartitionChanged=true. Without this, a differ that
+//     always returned false would pass the idempotence gate vacuously.
+//
+// The harness reuses assertDiffEmptyAgainstReadback / connectOracle / serverCharsetFor / both /
+// only from the diff oracle tests; it skips cleanly when the engines are unreachable.
+
+// partitionDiffProbes enumerates the single-table partition FORMS that must round-trip empty: a
+// user-form DDL whose engine-stored partition clause differs (engine echo, expr quoting, default
+// expansion) but must canonicalize equal. Every PARTITION BY kind is covered, on every version
+// that supports it.
+func partitionDiffProbes() []diffProbe {
+	return []diffProbe{
+		// RANGE over an expression — the headline expr-canonicalization case (8.0 backtick-quotes
+		// + lower-cases `year(`dt`)`, 5.7 keeps `YEAR(dt)`, user wrote `YEAR(dt)`).
+		{"range-expr", "CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN (2020), PARTITION pmax VALUES LESS THAN MAXVALUE)", "t", both()},
+		// RANGE COLUMNS (single + multi) — /*!50500*/ comment, double-space `RANGE  COLUMNS`.
+		{"range-columns", "CREATE TABLE t (id INT NOT NULL, a INT NOT NULL, PRIMARY KEY (id,a)) PARTITION BY RANGE COLUMNS(a) (PARTITION p0 VALUES LESS THAN (10), PARTITION p1 VALUES LESS THAN (MAXVALUE))", "t", both()},
+		{"range-columns-multi", "CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b)) PARTITION BY RANGE COLUMNS(a,b) (PARTITION p0 VALUES LESS THAN (10,10), PARTITION p1 VALUES LESS THAN (MAXVALUE,MAXVALUE))", "t", both()},
+		// LIST over an expression.
+		{"list-expr", "CREATE TABLE t (id INT NOT NULL, c INT NOT NULL, PRIMARY KEY (id,c)) PARTITION BY LIST (c) (PARTITION pa VALUES IN (1,2,3), PARTITION pb VALUES IN (4,5,6))", "t", both()},
+		// LIST COLUMNS with multi-column tuple values IN ((1,1),(2,2)).
+		{"list-columns-multi", "CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b)) PARTITION BY LIST COLUMNS(a,b) (PARTITION p0 VALUES IN ((1,1),(2,2)), PARTITION p1 VALUES IN ((3,3),(4,4)))", "t", both()},
+		// HASH with PARTITIONS N (auto-gen defs → `PARTITIONS 4`, no per-partition engine echo).
+		{"hash-n", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4", "t", both()},
+		// HASH with explicit named partitions (each echoed with ENGINE = InnoDB).
+		{"hash-explicit", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) (PARTITION pa, PARTITION pb, PARTITION pc)", "t", both()},
+		// LINEAR HASH.
+		{"linear-hash", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LINEAR HASH (id) PARTITIONS 4", "t", both()},
+		// KEY over the PK (no explicit column list → loader fills from PK).
+		{"key-implicit", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY KEY () PARTITIONS 3", "t", both()},
+		// KEY over an explicit column.
+		{"key-explicit", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY KEY (id) PARTITIONS 3", "t", both()},
+		// LINEAR KEY.
+		{"linear-key", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LINEAR KEY (id) PARTITIONS 2", "t", both()},
+		// Per-partition COMMENT (echoed as `COMMENT = '...' ENGINE = ...`).
+		{"part-comment", "CREATE TABLE t (id INT NOT NULL, c INT NOT NULL, PRIMARY KEY (id,c)) PARTITION BY LIST (c) (PARTITION pa VALUES IN (1,2,3) COMMENT 'first', PARTITION pb VALUES IN (4,5,6) COMMENT 'second')", "t", both()},
+		// Subpartitions via SUBPARTITIONS N (default subpartition names psp).
+		{"subpart-n", "CREATE TABLE t (id INT NOT NULL, d DATE NOT NULL, PRIMARY KEY (id,d)) PARTITION BY RANGE (YEAR(d)) SUBPARTITION BY HASH (id) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN MAXVALUE)", "t", both()},
+		// Subpartitions with explicit subpartition definitions (named, parenthesized per partition).
+		{"subpart-explicit", "CREATE TABLE t (id INT NOT NULL, d DATE NOT NULL, PRIMARY KEY (id,d)) PARTITION BY RANGE (YEAR(d)) SUBPARTITION BY HASH (id) (PARTITION p0 VALUES LESS THAN (2010) (SUBPARTITION s0a, SUBPARTITION s0b), PARTITION p1 VALUES LESS THAN MAXVALUE (SUBPARTITION s1a, SUBPARTITION s1b))", "t", both()},
+		// Subpartition BY KEY.
+		{"subpart-key", "CREATE TABLE t (id INT NOT NULL, d DATE NOT NULL, PRIMARY KEY (id,d)) PARTITION BY RANGE (YEAR(d)) SUBPARTITION BY KEY (id) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN MAXVALUE)", "t", both()},
+		// MyISAM-partitioned table (5.7 only — 8.0 rejects native MyISAM partitioning): the
+		// per-partition engine echo is ENGINE = MyISAM, so the empty→table-engine fold must use
+		// the table's engine, not a hardcoded InnoDB.
+		{"myisam-explicit", "CREATE TABLE t (id INT NOT NULL, c INT NOT NULL, PRIMARY KEY (id,c)) ENGINE=MyISAM PARTITION BY LIST (c) (PARTITION pa VALUES IN (1,2,3), PARTITION pb VALUES IN (4,5,6))", "t", only(MySQL57)},
+	}
+}
+
+// TestOracle_PartitionDiffIdempotence proves gates 1 & 2 for every partition form: the user DDL
+// vs its engine readback diffs EMPTY (PartitionChanged=false), and the stored form self-diffs
+// empty, on every supported version.
+func TestOracle_PartitionDiffIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, probe := range partitionDiffProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := "part_" + strings.ReplaceAll(probe.id, "-", "_")
+				assertDiffEmptyAgainstReadback(t, o, db, probe.create, probe.table)
+			})
+		}
+	}
+}
+
+// partitionChangeCase is a (from, to) pair whose partition specs genuinely differ; the differ
+// must report PartitionChanged=true (and the table as DiffModify). This is the gate-2 complement:
+// proof the differ is not a vacuous always-false.
+type partitionChangeCase struct {
+	id       string
+	fromDDL  string
+	toDDL    string
+	table    string
+	versions []Version
+}
+
+func partitionChangeCases() []partitionChangeCase {
+	return []partitionChangeCase{
+		// Add partitioning to an unpartitioned table.
+		{"add-partitioning",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4",
+			"t", both()},
+		// Remove partitioning.
+		{"remove-partitioning",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"t", both()},
+		// Change the partition count.
+		{"change-count",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 8",
+			"t", both()},
+		// Change the partition TYPE (HASH → KEY).
+		{"change-type",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY (id) PARTITIONS 4",
+			"t", both()},
+		// Change a RANGE boundary.
+		{"change-range-bound",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2015), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"t", both()},
+		// Add a partition (RANGE).
+		{"add-range-partition",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN (2020), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"t", both()},
+		// LINEAR flag flip.
+		{"toggle-linear",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LINEAR KEY (id) PARTITIONS 4",
+			"t", both()},
+	}
+}
+
+// TestOracle_PartitionChangeDetected proves the gate-2 complement: a real partition-spec change
+// (loaded from the engines' own readbacks) is reported as PartitionChanged=true with the table
+// marked DiffModify. Run from real readbacks so it exercises the same canonical path as the
+// idempotence proof.
+func TestOracle_PartitionChangeDetected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, tc := range partitionChangeCases() {
+			if !containsVersion(tc.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, tc.id), func(t *testing.T) {
+				slug := strings.ReplaceAll(tc.id, "-", "_")
+				fromCat, _, _, ok1 := o.catalogFromReadback(t, "pc_from_"+slug, tc.fromDDL, tc.table)
+				toCat, _, _, ok2 := o.catalogFromReadback(t, "pc_to_"+slug, tc.toDDL, tc.table)
+				if !ok1 || !ok2 {
+					t.Skipf("[%s] could not obtain readbacks for %s", o.name, tc.id)
+				}
+				d := DiffWithNormalizer(fromCat, toCat, n)
+				te := findTable(d, tc.table)
+				if te == nil {
+					t.Fatalf("[%s] %s: expected table %s to be modified, got empty diff", o.name, tc.id, tc.table)
+				}
+				if !te.PartitionChanged {
+					t.Errorf("[%s] %s: expected PartitionChanged=true, got false (table action %s)", o.name, tc.id, te.Action)
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/migration_partition.go
+++ b/mysql/catalog/migration_partition.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // MySQL SDL generate — table partitioning (ALTER TABLE ... PARTITION BY / REMOVE PARTITIONING).
@@ -44,17 +45,11 @@ import (
 //     LIVE partition function/key still references (errno 1505/1054-class), so the table must be
 //     un-partitioned first when the same plan also drops an old partitioning column.
 //
-// A table either gains/changes partitioning or loses it in a single plan, never both, so at most
-// one partition op per table — ops are ordered by table name (sortName) alone.
-//
-// KNOWN LIMITATION (flagged, not handled): repartitioning a table (to stays partitioned) whose
-// OLD partition function references a column DROPPED in the same plan emits the new PARTITION BY
-// in PhaseMain, after the PhasePre column drop — which MySQL rejects because the column is still
-// bound by the live old partition function when the drop runs. Correct emission would require
-// stripping the old partitioning (a PhasePre REMOVE PARTITIONING) before the column drop AND then
-// applying the new scheme in PhaseMain — i.e. splitting one logical change across phases, which
-// the coarse bool diff does not model. The REMOVE-to-unpartitioned case IS handled (above); only
-// the drop-old-key-column-while-repartitioning combination is out of scope. Not in any probe.
+// Repartitioning a table whose OLD partition function references a column DROPPED in the same plan
+// is handled by splitting the change across phases: a PhasePre REMOVE PARTITIONING (so the column
+// drop is no longer blocked by the live partition function) followed by the PhaseMain PARTITION BY
+// that establishes the new scheme (see partitionModifyOps / oldPartitionColumnDropped). Otherwise a
+// table emits at most one partition op, ordered by table name (sortName).
 //
 // implemented by omni:partitions breadth node
 func generatePartitionDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
@@ -88,8 +83,12 @@ func generatePartitionDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []Migr
 	return ops
 }
 
-// partitionModifyOps renders the partition change for a modified table: REMOVE PARTITIONING when
-// the target is unpartitioned, otherwise a wholesale PARTITION BY re-definition.
+// partitionModifyOps renders the partition change for a modified table:
+//   - to unpartitioned  → a single PhasePre REMOVE PARTITIONING.
+//   - to (re)partitioned → a PhaseMain PARTITION BY. When the same plan ALSO drops a column the
+//     OLD partition function references, a PhasePre REMOVE PARTITIONING is prepended so the table
+//     is un-partitioned before that column drop runs (MySQL rejects dropping a column bound by the
+//     live partition function); the PhaseMain PARTITION BY then re-establishes the new scheme.
 func partitionModifyOps(entry *TableDiffEntry, n *Normalizer) []MigrationOp {
 	if entry.To == nil {
 		return nil
@@ -98,10 +97,99 @@ func partitionModifyOps(entry *TableDiffEntry, n *Normalizer) []MigrationOp {
 		// from was partitioned (PartitionChanged true + to unpartitioned), so strip it.
 		return []MigrationOp{removePartitioningOp(entry, entry.To)}
 	}
-	if op, ok := partitionByOp(entry, entry.To, n); ok {
-		return []MigrationOp{op}
+	op, ok := partitionByOp(entry, entry.To, n)
+	if !ok {
+		return nil
 	}
-	return nil
+	// Repartition: if a column referenced by the OLD partitioning is dropped in this plan, the
+	// PhasePre DROP COLUMN would fail while the table is still partitioned by it — strip the old
+	// partitioning first (PhasePre), then apply the new scheme (PhaseMain).
+	if oldPartitionColumnDropped(entry) {
+		return []MigrationOp{removePartitioningOp(entry, entry.To), op}
+	}
+	return []MigrationOp{op}
+}
+
+// oldPartitionColumnDropped reports whether any column the FROM partitioning references is being
+// DROPPED in this diff. A dropped partition-key column requires the old partitioning to be removed
+// first (a column bound by the live partition function cannot be dropped). Column references are
+// taken from the structured KEY/COLUMNS lists and, for expression partitioning (RANGE/LIST/HASH
+// over an expr), from an identifier scan of the expression — a superset that may also match a
+// column merely named inside the expression, which only ever causes an extra, harmless PhasePre
+// REMOVE PARTITIONING (the new PARTITION BY re-establishes the scheme regardless).
+func oldPartitionColumnDropped(entry *TableDiffEntry) bool {
+	if entry.From == nil || entry.From.Partitioning == nil {
+		return false
+	}
+	dropped := droppedColumnSet(entry)
+	if len(dropped) == 0 {
+		return false
+	}
+	for _, col := range partitionReferencedColumns(entry.From.Partitioning) {
+		if dropped[toLower(col)] {
+			return true
+		}
+	}
+	return false
+}
+
+// droppedColumnSet returns the lower-cased names of columns dropped in this table diff.
+func droppedColumnSet(entry *TableDiffEntry) map[string]bool {
+	var set map[string]bool
+	for _, ce := range entry.Columns {
+		if ce.Action == DiffDrop {
+			if set == nil {
+				set = make(map[string]bool)
+			}
+			set[toLower(ce.Name)] = true
+		}
+	}
+	return set
+}
+
+// partitionReferencedColumns returns the column names a partition spec depends on: the explicit
+// KEY / RANGE COLUMNS / LIST COLUMNS column lists (and subpartition columns), plus identifiers
+// scanned out of an expression-based partition/subpartition expression (RANGE/LIST/HASH over an
+// expr). The expression scan is a conservative superset (it may include non-column identifiers
+// such as function names), which is safe here: a false positive only adds a harmless REMOVE
+// PARTITIONING before the repartition.
+func partitionReferencedColumns(pi *PartitionInfo) []string {
+	var cols []string
+	cols = append(cols, pi.Columns...)
+	cols = append(cols, pi.SubColumns...)
+	cols = append(cols, identifiersInExpr(pi.Expr)...)
+	cols = append(cols, identifiersInExpr(pi.SubExpr)...)
+	return cols
+}
+
+// identifiersInExpr extracts identifier-like tokens from a partition expression, skipping
+// backtick-quoted and string-literal content boundaries. It is used only to spot a dropped column
+// referenced by an expression partition function; over-matching (e.g. catching a function name)
+// is harmless (see partitionReferencedColumns).
+func identifiersInExpr(expr string) []string {
+	if expr == "" {
+		return nil
+	}
+	var out []string
+	var b strings.Builder
+	flush := func() {
+		if b.Len() > 0 {
+			out = append(out, b.String())
+			b.Reset()
+		}
+	}
+	for _, r := range expr {
+		switch {
+		case r == '_' || r == '$' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		default:
+			// Backticks, quotes, parentheses, operators, spaces all terminate an identifier run.
+			flush()
+		}
+	}
+	flush()
+	return out
 }
 
 // partitionByOp builds an ALTER TABLE ... PARTITION BY ... op that (re)defines tbl's

--- a/mysql/catalog/migration_partition.go
+++ b/mysql/catalog/migration_partition.go
@@ -1,14 +1,129 @@
 package catalog
 
-// MySQL SDL generate — table partitioning (scaffold stub).
+import (
+	"fmt"
+	"sort"
+)
+
+// MySQL SDL generate — table partitioning (ALTER TABLE ... PARTITION BY / REMOVE PARTITIONING).
 //
-// Wired into GenerateMigrationWithNormalizer (migration.go) so a partitioning change
-// (TableDiffEntry.PartitionChanged) becomes DDL. Inert no-op placeholder returning nil
-// until the partition breadth node renders the ALTER TABLE ... PARTITION BY / REMOVE
-// PARTITIONING op. Signature mirrors generateTableDDL (migration_table.go).
+// Turns the coarse partition signal (TableDiffEntry.PartitionChanged, plus the partitioning
+// state of added/dropped tables) into the DDL that re-defines a table's partitioning. MySQL
+// folds partitioning into ALTER TABLE; there is no in-place "modify one partition clause", so a
+// changed partition spec is re-applied wholesale with `ALTER TABLE ... <PARTITION BY ...>` — the
+// engine drops the old scheme and repartitions in one statement. The three cases:
 //
-// implemented by omni:partition breadth node
-func generatePartitionDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no partition ops (empty diff -> empty plan).
+//   - to partitioned, from not (or different spec)  → ALTER TABLE ... PARTITION BY ...   (define/repartition)
+//   - from partitioned, to not                       → ALTER TABLE ... REMOVE PARTITIONING (strip)
+//   - both partitioned, same canonical spec          → nothing (diff said PartitionChanged=false)
+//
+// A coarse re-emit of the full PARTITION BY clause is apply-correct: `ALTER TABLE t PARTITION
+// BY ...` is accepted on both 5.7 and 8.0 and yields exactly the target scheme, so the readback
+// canonicalizes equal to `to`. Add/drop/reorganize-partition (which preserve data more cheaply)
+// are not attempted — the bool diff cannot tell which partitions changed, and the wholesale
+// re-emit is always correct for a declarative apply.
+//
+// The PARTITION BY clause is rendered by showPartitioning — the SAME deparser show.go uses for
+// the stored form — over a copy whose per-partition engine is resolved to the table's engine
+// (partitionSpecWithResolvedEngine, shared with the diff). That guarantees the emitted clause is
+// byte-for-byte what the engine stores, so the apply readback diffs empty. showPartitioning wraps
+// the clause in a /*!50100 ... */ (or /*!50500 ... */ for RANGE/LIST COLUMNS) version comment;
+// MySQL executes that comment as an ALTER suffix on every supported version (verified on live
+// 5.7.25 + 8.0.32), so the same DDL is valid on both engines.
+//
+// Ordering: partition ops run in PhaseMain at priorityPartition — AFTER the table CREATE
+// (priorityTable), the column adds/modifies (priorityColumn), and the index adds (priorityIndex),
+// because PARTITION BY requires its referenced columns to exist and every unique key (the PK
+// included) to cover the partitioning columns; the PK/indexes must therefore already be in place.
+// They run BEFORE deferred FKs (PhasePost): a table cannot be partitioned while it is the child
+// of a foreign key, so partitioning must be established before FKs are added. A table either
+// gains/changes partitioning or loses it in a single plan, never both, so at most one partition
+// op per table — ops are ordered by table name (sortName) alone.
+//
+// implemented by omni:partitions breadth node
+func generatePartitionDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		switch entry.Action {
+		case DiffAdd:
+			// A freshly created table carries its partitioning via a follow-up ALTER (the CREATE
+			// from generate-core renders only columns + PK, not the partition clause).
+			if op, ok := partitionByOp(entry, entry.To, n); ok {
+				ops = append(ops, op)
+			}
+		case DiffModify:
+			// Only emit when the spec actually changed (PartitionChanged folds the canonical
+			// comparison; re-checking it keeps this generator inert on a no-op table).
+			if !entry.PartitionChanged {
+				continue
+			}
+			ops = append(ops, partitionModifyOps(entry, n)...)
+		case DiffDrop:
+			// DROP TABLE removes the partitioning with the table; nothing to emit.
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// partitionModifyOps renders the partition change for a modified table: REMOVE PARTITIONING when
+// the target is unpartitioned, otherwise a wholesale PARTITION BY re-definition.
+func partitionModifyOps(entry *TableDiffEntry, n *Normalizer) []MigrationOp {
+	if entry.To == nil {
+		return nil
+	}
+	if entry.To.Partitioning == nil {
+		// from was partitioned (PartitionChanged true + to unpartitioned), so strip it.
+		return []MigrationOp{removePartitioningOp(entry, entry.To)}
+	}
+	if op, ok := partitionByOp(entry, entry.To, n); ok {
+		return []MigrationOp{op}
+	}
 	return nil
 }
+
+// partitionByOp builds an ALTER TABLE ... PARTITION BY ... op that (re)defines tbl's
+// partitioning. Returns ok=false when the table is not partitioned (nothing to define).
+func partitionByOp(entry *TableDiffEntry, tbl *Table, n *Normalizer) (MigrationOp, bool) {
+	if tbl == nil || tbl.Partitioning == nil {
+		return MigrationOp{}, false
+	}
+	clause := showPartitioning(partitionSpecWithResolvedEngine(tbl, n))
+	return MigrationOp{
+		Type:         OpAlterTable,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s %s", tableIdent(tbl), clause),
+		Phase:        PhaseMain,
+		Priority:     priorityPartition,
+		sortName:     tableSortName(entry.Database, entry.Name),
+	}, true
+}
+
+// removePartitioningOp builds an ALTER TABLE ... REMOVE PARTITIONING op.
+func removePartitioningOp(entry *TableDiffEntry, tbl *Table) MigrationOp {
+	return MigrationOp{
+		Type:         OpAlterTable,
+		Database:     entry.Database,
+		ObjectName:   entry.Name,
+		ParentObject: entry.Name,
+		SQL:          fmt.Sprintf("ALTER TABLE %s REMOVE PARTITIONING", tableIdent(tbl)),
+		Phase:        PhaseMain,
+		Priority:     priorityPartition,
+		sortName:     tableSortName(entry.Database, entry.Name),
+	}
+}
+
+// priorityPartition orders partition ops within PhaseMain after the table create (priorityTable),
+// column alters (priorityColumn), and index adds (priorityIndex) — PARTITION BY needs the columns
+// present and every unique key (PK) to cover the partitioning columns — and before deferred FKs
+// (PhasePost), since a table cannot be partitioned while it is an FK child. It sits just above
+// priorityForeignKey so partitioning is the last in-phase structural change before FKs.
+const priorityPartition = priorityForeignKey - 1

--- a/mysql/catalog/migration_partition.go
+++ b/mysql/catalog/migration_partition.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"fmt"
 	"sort"
-	"strings"
 )
 
 // MySQL SDL generate — table partitioning (ALTER TABLE ... PARTITION BY / REMOVE PARTITIONING).
@@ -110,13 +109,20 @@ func partitionModifyOps(entry *TableDiffEntry, n *Normalizer) []MigrationOp {
 	return []MigrationOp{op}
 }
 
-// oldPartitionColumnDropped reports whether any column the FROM partitioning references is being
-// DROPPED in this diff. A dropped partition-key column requires the old partitioning to be removed
-// first (a column bound by the live partition function cannot be dropped). Column references are
-// taken from the structured KEY/COLUMNS lists and, for expression partitioning (RANGE/LIST/HASH
-// over an expr), from an identifier scan of the expression — a superset that may also match a
-// column merely named inside the expression, which only ever causes an extra, harmless PhasePre
-// REMOVE PARTITIONING (the new PARTITION BY re-establishes the scheme regardless).
+// oldPartitionColumnDropped reports whether dropping a column in this diff could be blocked by the
+// table's OLD (from) partition function — in which case the partitioning must be stripped first.
+// MySQL rejects dropping a column bound by a live partition function (errno 3855), so this errs
+// toward stripping:
+//
+//   - COLUMNS / KEY partitioning lists its dependency columns verbatim in Columns/SubColumns; an
+//     exact (case-insensitive) match against the dropped set is reliable, including for names with
+//     special characters.
+//   - EXPRESSION partitioning (RANGE/LIST/HASH over Expr/SubExpr) embeds its columns inside SQL
+//     text whose identifiers cannot be extracted reliably for every column name (quoting, special
+//     characters). Rather than parse the expression, ANY column drop while the from is
+//     expression-partitioned triggers the strip. A REMOVE PARTITIONING that was not strictly needed
+//     is harmless: the PhaseMain PARTITION BY re-establishes the scheme regardless (and an
+//     expression-partitioned table dropping any column is already an uncommon, high-risk change).
 func oldPartitionColumnDropped(entry *TableDiffEntry) bool {
 	if entry.From == nil || entry.From.Partitioning == nil {
 		return false
@@ -125,7 +131,13 @@ func oldPartitionColumnDropped(entry *TableDiffEntry) bool {
 	if len(dropped) == 0 {
 		return false
 	}
-	for _, col := range partitionReferencedColumns(entry.From.Partitioning) {
+	pi := entry.From.Partitioning
+	if pi.Expr != "" || pi.SubExpr != "" {
+		// Expression partitioning: cannot reliably extract the referenced columns from SQL text;
+		// any drop conservatively strips first (harmless if unnecessary).
+		return true
+	}
+	for _, col := range append(append([]string{}, pi.Columns...), pi.SubColumns...) {
 		if dropped[toLower(col)] {
 			return true
 		}
@@ -145,51 +157,6 @@ func droppedColumnSet(entry *TableDiffEntry) map[string]bool {
 		}
 	}
 	return set
-}
-
-// partitionReferencedColumns returns the column names a partition spec depends on: the explicit
-// KEY / RANGE COLUMNS / LIST COLUMNS column lists (and subpartition columns), plus identifiers
-// scanned out of an expression-based partition/subpartition expression (RANGE/LIST/HASH over an
-// expr). The expression scan is a conservative superset (it may include non-column identifiers
-// such as function names), which is safe here: a false positive only adds a harmless REMOVE
-// PARTITIONING before the repartition.
-func partitionReferencedColumns(pi *PartitionInfo) []string {
-	var cols []string
-	cols = append(cols, pi.Columns...)
-	cols = append(cols, pi.SubColumns...)
-	cols = append(cols, identifiersInExpr(pi.Expr)...)
-	cols = append(cols, identifiersInExpr(pi.SubExpr)...)
-	return cols
-}
-
-// identifiersInExpr extracts identifier-like tokens from a partition expression, skipping
-// backtick-quoted and string-literal content boundaries. It is used only to spot a dropped column
-// referenced by an expression partition function; over-matching (e.g. catching a function name)
-// is harmless (see partitionReferencedColumns).
-func identifiersInExpr(expr string) []string {
-	if expr == "" {
-		return nil
-	}
-	var out []string
-	var b strings.Builder
-	flush := func() {
-		if b.Len() > 0 {
-			out = append(out, b.String())
-			b.Reset()
-		}
-	}
-	for _, r := range expr {
-		switch {
-		case r == '_' || r == '$' ||
-			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
-			b.WriteRune(r)
-		default:
-			// Backticks, quotes, parentheses, operators, spaces all terminate an identifier run.
-			flush()
-		}
-	}
-	flush()
-	return out
 }
 
 // partitionByOp builds an ALTER TABLE ... PARTITION BY ... op that (re)defines tbl's

--- a/mysql/catalog/migration_partition.go
+++ b/mysql/catalog/migration_partition.go
@@ -31,14 +31,30 @@ import (
 // MySQL executes that comment as an ALTER suffix on every supported version (verified on live
 // 5.7.25 + 8.0.32), so the same DDL is valid on both engines.
 //
-// Ordering: partition ops run in PhaseMain at priorityPartition — AFTER the table CREATE
-// (priorityTable), the column adds/modifies (priorityColumn), and the index adds (priorityIndex),
-// because PARTITION BY requires its referenced columns to exist and every unique key (the PK
-// included) to cover the partitioning columns; the PK/indexes must therefore already be in place.
-// They run BEFORE deferred FKs (PhasePost): a table cannot be partitioned while it is the child
-// of a foreign key, so partitioning must be established before FKs are added. A table either
-// gains/changes partitioning or loses it in a single plan, never both, so at most one partition
-// op per table — ops are ordered by table name (sortName) alone.
+// Ordering has two cases, because a PARTITION BY and a REMOVE PARTITIONING have opposite
+// dependencies on the column ops:
+//
+//   - PARTITION BY (define / repartition) runs in PhaseMain at priorityPartition — AFTER the
+//     table CREATE (priorityTable), column adds/modifies (priorityColumn), and index adds
+//     (priorityIndex), because PARTITION BY requires its referenced columns to exist and every
+//     unique key (the PK included) to cover the partitioning columns. It runs BEFORE deferred
+//     FKs (PhasePost): a table cannot be partitioned while it is the child of a foreign key.
+//   - REMOVE PARTITIONING runs in PhasePre at priorityRemovePartitioning — BEFORE any column
+//     DROP (PhasePre, priorityColumn-1/priorityColumn). MySQL rejects dropping a column that the
+//     LIVE partition function/key still references (errno 1505/1054-class), so the table must be
+//     un-partitioned first when the same plan also drops an old partitioning column.
+//
+// A table either gains/changes partitioning or loses it in a single plan, never both, so at most
+// one partition op per table — ops are ordered by table name (sortName) alone.
+//
+// KNOWN LIMITATION (flagged, not handled): repartitioning a table (to stays partitioned) whose
+// OLD partition function references a column DROPPED in the same plan emits the new PARTITION BY
+// in PhaseMain, after the PhasePre column drop — which MySQL rejects because the column is still
+// bound by the live old partition function when the drop runs. Correct emission would require
+// stripping the old partitioning (a PhasePre REMOVE PARTITIONING) before the column drop AND then
+// applying the new scheme in PhaseMain — i.e. splitting one logical change across phases, which
+// the coarse bool diff does not model. The REMOVE-to-unpartitioned case IS handled (above); only
+// the drop-old-key-column-while-repartitioning combination is out of scope. Not in any probe.
 //
 // implemented by omni:partitions breadth node
 func generatePartitionDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
@@ -107,7 +123,10 @@ func partitionByOp(entry *TableDiffEntry, tbl *Table, n *Normalizer) (MigrationO
 	}, true
 }
 
-// removePartitioningOp builds an ALTER TABLE ... REMOVE PARTITIONING op.
+// removePartitioningOp builds an ALTER TABLE ... REMOVE PARTITIONING op. It runs in PhasePre at
+// priorityRemovePartitioning, ahead of any column DROP, so a table partitioned by a column that is
+// also dropped in the same plan is un-partitioned before the drop (which MySQL would otherwise
+// reject — the column is still bound by the live partition function).
 func removePartitioningOp(entry *TableDiffEntry, tbl *Table) MigrationOp {
 	return MigrationOp{
 		Type:         OpAlterTable,
@@ -115,15 +134,25 @@ func removePartitioningOp(entry *TableDiffEntry, tbl *Table) MigrationOp {
 		ObjectName:   entry.Name,
 		ParentObject: entry.Name,
 		SQL:          fmt.Sprintf("ALTER TABLE %s REMOVE PARTITIONING", tableIdent(tbl)),
-		Phase:        PhaseMain,
-		Priority:     priorityPartition,
+		Phase:        PhasePre,
+		Priority:     priorityRemovePartitioning,
 		sortName:     tableSortName(entry.Database, entry.Name),
 	}
 }
 
-// priorityPartition orders partition ops within PhaseMain after the table create (priorityTable),
-// column alters (priorityColumn), and index adds (priorityIndex) — PARTITION BY needs the columns
-// present and every unique key (PK) to cover the partitioning columns — and before deferred FKs
-// (PhasePost), since a table cannot be partitioned while it is an FK child. It sits just above
-// priorityForeignKey so partitioning is the last in-phase structural change before FKs.
+// priorityPartition orders a PARTITION BY op within PhaseMain after the table create
+// (priorityTable), column alters (priorityColumn), and index adds (priorityIndex) — PARTITION BY
+// needs the columns present and every unique key (PK) to cover the partitioning columns — and
+// before deferred FKs (PhasePost), since a table cannot be partitioned while it is an FK child. It
+// sits just above priorityForeignKey so partitioning is the last in-phase structural change before
+// FKs.
 const priorityPartition = priorityForeignKey - 1
+
+// priorityRemovePartitioning orders a REMOVE PARTITIONING op within PhasePre BEFORE every column
+// DROP. A column referenced by the live partition function cannot be dropped while the table is
+// partitioned, so the stripping must run first. Column drops run at priorityColumn-1 (generated) /
+// priorityColumn (plain) and index/PK drops at priorityIndexDrop/priorityPrimaryKeyDrop; this sits
+// below all of them so REMOVE PARTITIONING is the very first PhasePre statement. (Dropping
+// partitioning first is harmless when no partitioning column is dropped, so ordering it first
+// unconditionally is safe.)
+const priorityRemovePartitioning = priorityPrimaryKeyDrop - 1

--- a/mysql/catalog/migration_partition_oracle_test.go
+++ b/mysql/catalog/migration_partition_oracle_test.go
@@ -231,6 +231,18 @@ func partitionMigrationProbes() []migrationProbe {
 		{"add-column-keep-partitioning", "t",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4", both()},
+
+		// ---- REMOVE PARTITIONING while DROPPING a column the OLD partition function references:
+		//      the REMOVE must run (PhasePre) before the DROP COLUMN, else MySQL rejects dropping a
+		//      column bound by the live partition function. Regression guard for the ordering fix. ----
+		{"remove-partitioning-drop-key-column", "t",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)", both()},
+
+		// ---- KEY ALGORITHM=2 (the stripped default) defined on a fresh table: the generated
+		//      PARTITION BY must apply and read back equal to `to` (which folds ALGORITHM=2 away). ----
+		{"create-key-algorithm-2", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY ALGORITHM=2 (id) PARTITIONS 3", both()},
 	}
 }
 

--- a/mysql/catalog/migration_partition_oracle_test.go
+++ b/mysql/catalog/migration_partition_oracle_test.go
@@ -251,6 +251,13 @@ func partitionMigrationProbes() []migrationProbe {
 		{"repartition-drop-old-key-column", "t",
 			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4", both()},
+		// ---- Same, but the OLD expression-partition column has a SPECIAL-CHARACTER name (`a-b`):
+		//      column references can't be extracted from the expression SQL text, so ANY drop while
+		//      expression-partitioned must conservatively strip first. Without that, the DROP COLUMN
+		//      fails errno 3855. Regression guard for the expression-path conservative strip. ----
+		{"repartition-drop-special-col", "t",
+			"CREATE TABLE t (`a-b` INT NOT NULL, id INT NOT NULL, PRIMARY KEY (`a-b`, id)) PARTITION BY HASH (`a-b`) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 2", both()},
 	}
 }
 

--- a/mysql/catalog/migration_partition_oracle_test.go
+++ b/mysql/catalog/migration_partition_oracle_test.go
@@ -243,6 +243,14 @@ func partitionMigrationProbes() []migrationProbe {
 		//      PARTITION BY must apply and read back equal to `to` (which folds ALGORITHM=2 away). ----
 		{"create-key-algorithm-2", "t", "",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY ALGORITHM=2 (id) PARTITIONS 3", both()},
+
+		// ---- REPARTITION while DROPPING a column the OLD partition function references: the old
+		//      RANGE(YEAR(dt)) scheme references dt, which `to` drops while repartitioning to
+		//      HASH(id). Must emit PhasePre REMOVE PARTITIONING before the dt drop, then PhaseMain
+		//      PARTITION BY HASH. Regression guard for oldPartitionColumnDropped. ----
+		{"repartition-drop-old-key-column", "t",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4", both()},
 	}
 }
 

--- a/mysql/catalog/migration_partition_oracle_test.go
+++ b/mysql/catalog/migration_partition_oracle_test.go
@@ -1,0 +1,293 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the partition generator (correctness-protocol.md gate 2 + the gate-1
+// spine), against the LIVE MySQL engines (5.7 :13307, 8.0 :13306). Two properties:
+//
+//  1. Apply-correctness: for each (from, to) partition transition the node covers, the generated
+//     plan applied to a real `from` database yields a table whose canonical form equals `to`
+//     (in both directions). Covers defining partitioning on a fresh/existing table, removing it,
+//     and re-partitioning (count / type / boundary / subpartitions).
+//  2. Migration idempotence: a partitioned table in its real stored form generates an EMPTY plan
+//     (no-op), and the full apply→dump→reload→diff→generate round-trip emits nothing.
+//
+// The apply assertion (assertPartitionApplyCorrect) is SELF-CONTAINED rather than reusing the
+// shared assertApplyCorrect, so it can give each probe its OWN apply database (loadOnePartTable)
+// instead of the harness-wide fixed `diffdb`. That keeps these tests hermetic when the whole
+// package runs together: the shared apply harness contends on one `diffdb` across the generate-core
+// and index apply suites (a pre-existing pooled-`USE` race), and adding more `diffdb` users widens
+// that window — a per-probe database sidesteps it entirely. The harness reuses connectOracle /
+// NormalizerFor / serverCharsetFor / both / only; it skips cleanly when the engines are unreachable.
+
+// loadOnePartTable wraps a CREATE TABLE in a NAMED database (so each probe gets an isolated apply
+// DB, not the shared `diffdb`) whose default charset matches the oracle box, and returns the named
+// table. Mirrors loadOneTable but with a caller-chosen database name.
+func loadOnePartTable(t *testing.T, dbName, serverCharset, createSQL, table string) (*Catalog, *Table) {
+	t.Helper()
+	wrapped := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s", dbName, serverCharset, dbName, createSQL)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("LoadSQL failed for %q: %v", createSQL, err)
+	}
+	for _, db := range cat.Databases() {
+		if tt := db.GetTable(table); tt != nil {
+			return cat, tt
+		}
+	}
+	t.Fatalf("table %q not found after load of %q", table, createSQL)
+	return nil, nil
+}
+
+// assertPartitionApplyCorrect builds `from` and `to` from the engine's own readbacks (authentic
+// stored forms), generates the plan, applies it to a from-state database, reads the result back,
+// and asserts the result canonicalizes equal to `to` (both directions). Each probe uses its own
+// database (pa_<slug>), on ONE dedicated connection, so the test is hermetic.
+func assertPartitionApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p migrationProbe) {
+	t.Helper()
+
+	slug := strings.ReplaceAll(p.id, "-", "_")
+	applyDB := "pa_" + slug
+	sc := serverCharsetFor(o.version)
+	ctx := context.Background()
+
+	// One pinned connection for ALL of this probe's statements (readbacks + apply), so the
+	// pool never lands a `USE` on a different connection than the next statement.
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// readbackVia applies a CREATE in a throwaway db on this connection and returns SHOW CREATE.
+	readbackVia := func(throwaway, createSQL, table string) (string, bool) {
+		for _, s := range []string{
+			"DROP DATABASE IF EXISTS " + throwaway,
+			fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", throwaway, sc),
+			"USE " + throwaway,
+			createSQL,
+		} {
+			if _, err := conn.ExecContext(ctx, s); err != nil {
+				t.Logf("[%s] %s readback setup failed (may be expected): %q: %v", o.name, p.id, s, err)
+				return "", false
+			}
+		}
+		var name, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", throwaway, table))
+		if err := row.Scan(&name, &ddl); err != nil {
+			t.Logf("[%s] %s SHOW CREATE failed: %v", o.name, p.id, err)
+			return "", false
+		}
+		return ddl, true
+	}
+
+	// Build `to` and `from` catalogs from authentic readbacks, wrapped in applyDB so the plan
+	// qualifies tables as `applyDB`.`t`.
+	var toCat, fromCat *Catalog
+	tableInTo := strings.TrimSpace(p.toDDL) != ""
+	tableInFrom := strings.TrimSpace(p.fromDDL) != ""
+
+	if tableInTo {
+		rb, ok := readbackVia("pto_"+slug, p.toDDL, p.table)
+		if !ok {
+			t.Skipf("[%s] could not obtain `to` readback for %s", o.name, p.id)
+		}
+		toCat, _ = loadOnePartTable(t, applyDB, sc, rb, p.table)
+	} else {
+		toCat = New()
+	}
+	if tableInFrom {
+		rb, ok := readbackVia("pfrom_"+slug, p.fromDDL, p.table)
+		if !ok {
+			t.Skipf("[%s] could not obtain `from` readback for %s", o.name, p.id)
+		}
+		fromCat, _ = loadOnePartTable(t, applyDB, sc, rb, p.table)
+	} else {
+		fromCat = New()
+	}
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Build the real database in state `from` and apply the plan.
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
+		"USE " + applyDB,
+	}
+	if tableInFrom {
+		setup = append(setup, p.fromDDL)
+	}
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, p.id, s, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	readback := func(table string) (string, bool) {
+		var name, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", applyDB, table))
+		if err := row.Scan(&name, &ddl); err != nil {
+			return "", false
+		}
+		return ddl, true
+	}
+
+	if !tableInTo {
+		if _, ok := readback(p.table); ok {
+			t.Errorf("[%s] %s: table %s still exists after DROP plan:\n%s", o.name, p.id, p.table, plan.SQL())
+		}
+		return
+	}
+
+	resultRB, ok := readback(p.table)
+	if !ok {
+		t.Fatalf("[%s] %s: result table %s missing after apply:\n%s", o.name, p.id, p.table, plan.SQL())
+	}
+	// Load the result into the SAME applyDB so it shares the table identity (database.table) with
+	// toCat — loading into a different db name would phantom a whole-table DROP+ADD in the diff.
+	resultCat, _ := loadOnePartTable(t, applyDB, sc, resultRB, p.table)
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result: %s\n  diff: %s",
+			o.name, p.id, plan.SQL(), strings.TrimSpace(resultRB), describeDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeDiff(d))
+	}
+}
+
+// partitionMigrationProbes enumerates the partition transition FORMS this node covers. Each is
+// proven on the listed versions: the generated DDL, applied to a real `from` database, must yield
+// a table whose canonical form equals `to`.
+func partitionMigrationProbes() []migrationProbe {
+	return []migrationProbe{
+		// ---- Define partitioning on a freshly created table (DiffAdd → CREATE + ALTER PARTITION BY) ----
+		{"create-range", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN (2020), PARTITION pmax VALUES LESS THAN MAXVALUE)", both()},
+		{"create-range-columns", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, a INT NOT NULL, PRIMARY KEY (id,a)) PARTITION BY RANGE COLUMNS(a) (PARTITION p0 VALUES LESS THAN (10), PARTITION p1 VALUES LESS THAN (MAXVALUE))", both()},
+		{"create-list", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, c INT NOT NULL, PRIMARY KEY (id,c)) PARTITION BY LIST (c) (PARTITION pa VALUES IN (1,2,3), PARTITION pb VALUES IN (4,5,6))", both()},
+		{"create-hash-n", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4", both()},
+		{"create-key", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY (id) PARTITIONS 3", both()},
+		{"create-linear-key", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LINEAR KEY (id) PARTITIONS 2", both()},
+		{"create-subpart-n", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, d DATE NOT NULL, PRIMARY KEY (id,d)) PARTITION BY RANGE (YEAR(d)) SUBPARTITION BY HASH (id) SUBPARTITIONS 2 (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN MAXVALUE)", both()},
+		{"create-part-comment", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, c INT NOT NULL, PRIMARY KEY (id,c)) PARTITION BY LIST (c) (PARTITION pa VALUES IN (1,2,3) COMMENT 'first', PARTITION pb VALUES IN (4,5,6) COMMENT 'second')", both()},
+
+		// ---- Add partitioning to an existing (unpartitioned) table ----
+		{"add-partitioning-hash", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4", both()},
+		{"add-partitioning-range", "t",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt))",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)", both()},
+
+		// ---- Remove partitioning ----
+		{"remove-partitioning", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)", both()},
+		{"remove-partitioning-range", "t",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt))", both()},
+
+		// ---- Re-partition (change the scheme on an existing partitioned table) ----
+		{"repartition-count", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 8", both()},
+		{"repartition-type", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY (id) PARTITIONS 4", both()},
+		{"repartition-range-bound", "t",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2015), PARTITION pmax VALUES LESS THAN MAXVALUE)", both()},
+		{"repartition-add-range", "t",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION pmax VALUES LESS THAN MAXVALUE)",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (2010), PARTITION p1 VALUES LESS THAN (2020), PARTITION pmax VALUES LESS THAN MAXVALUE)", both()},
+		{"repartition-toggle-linear", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY KEY (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LINEAR KEY (id) PARTITIONS 4", both()},
+
+		// ---- A non-partition table change leaves partitioning untouched (partitioned both sides,
+		//      only a column is added): the partition generator must emit NOTHING for it. ----
+		{"add-column-keep-partitioning", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 4",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT) PARTITION BY HASH (id) PARTITIONS 4", both()},
+	}
+}
+
+// TestOracle_PartitionApplyCorrectness proves gate 2 for every partition transition: the generated
+// DDL, applied to a real `from` database, yields a table whose canonical form equals `to`.
+func TestOracle_PartitionApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, p := range partitionMigrationProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				assertPartitionApplyCorrect(t, o, n, p)
+			})
+		}
+	}
+}
+
+// TestOracle_PartitionMigrationIdempotence proves the gate-1 spine for partitioning: a partitioned
+// table in its real stored form generates an EMPTY plan, and the user-form-vs-stored round-trip
+// plan is empty too. A non-empty no-op plan is a partition normalization/ordering bug.
+func TestOracle_PartitionMigrationIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range partitionDiffProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				slug := strings.ReplaceAll(probe.id, "-", "_")
+				cat, _, rb, ok := o.catalogFromReadback(t, "pgen_idem_"+slug, probe.create, probe.table)
+				if !ok {
+					t.Skipf("[%s] could not obtain readback for %s", o.name, probe.id)
+				}
+				diff := DiffWithNormalizer(cat, cat, n)
+				plan := GenerateMigrationWithNormalizer(cat, cat, diff, n)
+				if plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s (partition normalization/ordering bug):\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(rb), plan.SQL())
+				}
+				userCat, _ := loadOneTable(t, serverCharsetFor(o.version), probe.create, probe.table)
+				rtDiff := DiffWithNormalizer(userCat, cat, n)
+				rtPlan := GenerateMigrationWithNormalizer(userCat, cat, rtDiff, n)
+				if rtPlan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY ROUND-TRIP PLAN (user vs stored) for %s:\n  user:   %s\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(probe.create), strings.TrimSpace(rb), rtPlan.SQL())
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Scope

Fills the `omni:partitions` breadth node for MySQL SDL — the partition-clause diff + generate, conflict-free in two files (plus their tests):

- `mysql/catalog/diff_partition.go` — `diffPartitions(from, to *Table, n *Normalizer) bool` (stub→real; sets `TableDiffEntry.PartitionChanged`, called from `compareTable`).
- `mysql/catalog/migration_partition.go` — `generatePartitionDDL(...) []MigrationOp` (emits `ALTER TABLE ... PARTITION BY ...` / `REMOVE PARTITIONING`; reuses `OpAlterTable`).

No edits to `diff.go` / `diff_table.go` / `migration.go` (scaffold already wired the hooks). Covers `PARTITION BY` RANGE / RANGE COLUMNS / LIST / LIST COLUMNS / HASH / KEY (incl. `LINEAR`, `ALGORITHM`), partition count, explicit partition definitions (names, `VALUES LESS THAN`/`IN`, per-partition `ENGINE`/`COMMENT`), and subpartitions (HASH/KEY, `SUBPARTITIONS N` + explicit defs).

## Idempotence focus (the main risk)

diff-core deliberately deferred partitioning, so partitioned tables were not idempotent before this node. A partitioned table's `SHOW CREATE` emits a canonical partition clause whose surface form differs from the user's DDL. The design canonicalizes the partition spec so a no-op partitioned table yields `PartitionChanged=false`:

- The omni loader (`buildPartitionInfo`) already absorbs **most** surface differences identically for the user form and the engine readback — the partition **expression** (8.0's backtick-quoted lower-cased `RANGE (year(`dt`))`, 5.7's `RANGE (YEAR(dt))`, and the user's `RANGE (YEAR(dt))` all load to the same `Expr`), RANGE/LIST `COLUMNS` folding, and `PARTITIONS N` / `SUBPARTITIONS N` defaulting.
- The diff signature is `showPartitioning(spec)` — the **same deparser** `show.go` uses for the stored form — over a copy with two folds applied:
  - **per-partition / per-subpartition `ENGINE`**: empty → the table's effective engine (SHOW CREATE always echoes `ENGINE = <engine>`; a MyISAM table echoes `ENGINE = MyISAM`, not InnoDB).
  - **KEY `ALGORITHM = 2`** (the default, stripped from SHOW CREATE) → unspecified, so an explicit `ALGORITHM=2` matches the readback.

Using the deparser as the comparison key keeps **one canonical source**: the form the diff treats as canonical is byte-for-byte the form `generatePartitionDDL` re-emits (a `/*!50100 ... */`-wrapped clause MySQL runs as an `ALTER` suffix), which is the form the engine stores — so apply-correctness and idempotence hold by construction.

## 5.7-vs-8.0 partition-clause format differences

Verified on both engines; all absorbed by the loader/deparser so no version branch is needed in the diff:
- **Expression quoting**: 8.0 backtick-quotes + lower-cases columns in the partition expr (`RANGE (year(`dt`))`, `LIST (`c`)`, `HASH (`id`)`); 5.7 keeps the bare user text (`RANGE (YEAR(dt))`). Both load to the same `Expr`.
- **`KEY ALGORITHM`**: `=2` (default) is stripped on both; `=1` (legacy) is echoed via a `/*!50611 ALGORITHM = 1 */` split comment on both. (`=2` folded; `=1` round-trips intact.)
- **MyISAM partitioning** is 5.7-only (8.0 rejects native MyISAM partitioning); its per-partition engine echo is `ENGINE = MyISAM`.

## Ordering

- `PARTITION BY` (define / repartition) → PhaseMain at `priorityPartition` (after columns + indexes — the PK/unique keys must cover the partition columns; before deferred FKs — a table can't be partitioned while an FK child).
- `REMOVE PARTITIONING` → PhasePre at `priorityRemovePartitioning` (before column drops — a column bound by the live partition function can't be dropped, errno 3855). A repartition that drops a column the **old** partition function references prepends a PhasePre `REMOVE PARTITIONING` so the drop is unblocked, then re-partitions in PhaseMain.

## Oracle evidence (live MySQL 5.7.25 :13307 + 8.0.32 :13306)

128 partition oracle subtests pass on both versions:
- **Idempotence (the spine)** — 35 diff-idempotence + 35 migration-idempotence: every form's user DDL vs its `SHOW CREATE` readback → `PartitionChanged=false` / empty plan; stored form self-diffs empty.
- **Apply-correctness** — 44: generated DDL applied to a real `from` DB yields a table canonically equal to `to` (define partitioning, remove, re-partition by count/type/bound/linear/subpartitions, plus the column-drop-ordering edge cases).
- **Change detection** — 14: real partition-spec changes report `PartitionChanged=true`.

Run: `go test ./mysql/catalog/ -run '^TestOracle_Partition' -count=1`. Full `mysql/catalog` package suite stays green.

## Normalization flags

- **Partition bound/expression constant-folding (NOT handled, flagged).** The engine constant-folds non-literal partition bounds at storage time — `VALUES LESS THAN (TO_DAYS('2020-01-01'))` → `737790`, `LESS THAN (5+5)` → `10` (verified on both versions) — but the loader keeps the user's unfolded text, so such bounds phantom-diff forever. Folding them needs a constant-expression **evaluator** (date arithmetic, not just reformatting — beyond `CanonicalGeneratedExpr`), which is a **normalize-core / analyzer** capability, out of this node's scope. Literal bounds (the overwhelmingly common case) are unaffected. A `CanonicalPartitionValue`/`CanonicalPartitionExpr` belongs in normalize-core alongside the other `Canonical*` methods.

## Review

Cross-family review (Claude `/code-review` + Codex `/codex:review`), converged to 0 surviving blockers. Bugs found and fixed (each oracle-proven):
1. `REMOVE PARTITIONING` ran in PhaseMain after a PhasePre `DROP COLUMN` → moved to PhasePre.
2. `KEY ALGORITHM=2` phantom-diff → folded to the stripped default.
3. Repartition + drop old-partition-key-column → prepend PhasePre `REMOVE PARTITIONING`; expression partitioning uses a conservative "any drop strips first" rule (reliable for special-character column names that can't be parsed out of the expr text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)