### PR TITLE
feat(mysql/catalog): implement trigger diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_trigger.go
+++ b/mysql/catalog/diff_trigger.go
@@ -1,15 +1,158 @@
 package catalog
 
-// MySQL SDL diff — triggers (scaffold stub).
+import (
+	"sort"
+	"strings"
+)
+
+// MySQL SDL diff — triggers (the full BEFORE/AFTER × INSERT/UPDATE/DELETE surface).
 //
-// Wired into DiffWithNormalizer (diff.go) so the SchemaDiff reports trigger changes via
-// SchemaDiff.Triggers. Inert no-op placeholder returning nil until the trigger breadth node
-// implements the real comparison. Signature mirrors diffTables (diff_table.go): whole-
-// catalog, taking from/to *Catalog and the version-fixing Normalizer (MySQL triggers are
-// database-level objects keyed by (database, name), each bound to a table via Trigger.Table).
+// Triggers are DATABASE-level objects in MySQL (keyed by (database, name), each bound to a
+// table via Trigger.Table), unlike PG where a trigger hangs off a relation. So diffTriggers
+// mirrors diffTables' whole-catalog shape — build a (database, name) map from each side and
+// report Add / Drop / Modify — rather than PG's per-relation diffTriggers. It is wired into
+// DiffWithNormalizer (diff.go) and reported via SchemaDiff.Triggers.
 //
-// implemented by omni:trigger breadth node
-func diffTriggers(_, _ *Catalog, _ *Normalizer) []TriggerDiffEntry {
-	// Scaffold: returns nil so the trigger diff stays empty (self-diff inert).
-	return nil
+// IDEMPOTENCE is the point of this node. A trigger has no ALTER form in MySQL, and the synced
+// (stored) schema is read back from information_schema.triggers / SHOW CREATE TRIGGER. The
+// canonical key the diff compares is the set of fields that survive that round-trip identically:
+//
+//   - Timing (BEFORE/AFTER)     — the parser upper-cases it on both the user and the readback
+//     side, so it compares directly.
+//   - Event (INSERT/UPDATE/DELETE) — likewise upper-cased by the parser.
+//   - Table (the owning table)  — compared case-insensitively (MySQL identifier folding).
+//   - Body (the trigger action statement) — MySQL stores the body VERBATIM (byte-for-byte the
+//     text the user wrote: whitespace, newlines, case, and any BEGIN…END block are preserved in
+//     both information_schema.triggers.ACTION_STATEMENT and SHOW CREATE TRIGGER). Verified on
+//     live 5.7.25 + 8.0.32. So body equality is an exact compare after trimming surrounding
+//     whitespace (the loader already TrimSpaces it in createTrigger).
+//
+// DELIBERATELY NOT COMPARED (each would phantom-diff a no-op trigger against its own readback —
+// see the normalization flags in the PR body):
+//
+//   - Definer — the user form usually omits DEFINER (the loader defaults it to `root`@`%`),
+//     while the readback always carries the server's DEFINER; the two spellings also differ
+//     (the SHOW-CREATE backtick form vs the parser's bare form). DEFINER is an ownership/security
+//     attribute, not schema shape, and is conventionally ignored in a declarative schema diff.
+//   - Order (FOLLOWS/PRECEDES) — the relative ordering of multiple triggers on the same
+//     table+timing+event. SHOW CREATE TRIGGER does NOT echo FOLLOWS/PRECEDES, and the loader
+//     stores triggers in an unordered map without modelling the resolved information_schema
+//     ACTION_ORDER as a dependency. A trigger declared with `FOLLOWS x` therefore loads with a
+//     non-nil Order that its own readback (no FOLLOWS) lacks. Comparing Order would phantom-diff
+//     every ordered trigger. Trigger ordering is FLAGGED as not-diffed (see the PR flag
+//     trigger-order-not-modelled); the omission has no observable schema divergence for the
+//     overwhelmingly common single-trigger-per-event case, and the loader limitation is the
+//     proper home for a fix.
+//   - CharacterSetClient / CollationConnection / DatabaseCollation — session/connection charset
+//     metadata captured at create time, not part of the trigger's declarative shape; the user
+//     SDL form carries the loader's session defaults, the readback carries the creating
+//     session's. Ignored, same rationale as DEFINER.
+//
+// implemented by omni:triggers breadth node
+func diffTriggers(from, to *Catalog, n *Normalizer) []TriggerDiffEntry {
+	fromMap := buildTriggerMap(from)
+	toMap := buildTriggerMap(to)
+
+	var result []TriggerDiffEntry
+
+	// Dropped: in from but not in to.
+	for key, fromTrig := range fromMap {
+		if _, ok := toMap[key]; !ok {
+			result = append(result, TriggerDiffEntry{
+				Action:   DiffDrop,
+				Database: key.db,
+				Name:     key.name,
+				From:     fromTrig,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for key, toTrig := range toMap {
+		fromTrig, ok := fromMap[key]
+		if !ok {
+			result = append(result, TriggerDiffEntry{
+				Action:   DiffAdd,
+				Database: key.db,
+				Name:     key.name,
+				To:       toTrig,
+			})
+			continue
+		}
+		// Both exist — a change is rendered as DROP + CREATE (no ALTER TRIGGER in MySQL).
+		if triggersChanged(fromTrig, toTrig, n) {
+			result = append(result, TriggerDiffEntry{
+				Action:   DiffModify,
+				Database: key.db,
+				Name:     key.name,
+				From:     fromTrig,
+				To:       toTrig,
+			})
+		}
+	}
+
+	// Determinism: sort by (database, name, action) so the diff — and the DDL generate-core
+	// derives from it — is stable across runs.
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Database != result[j].Database {
+			return result[i].Database < result[j].Database
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// buildTriggerMap indexes every trigger in a catalog by (database, name), both lower-cased.
+// MySQL has no schemas/namespaces, so the database is the qualifying scope.
+func buildTriggerMap(c *Catalog) map[triggerKey]*Trigger {
+	m := make(map[triggerKey]*Trigger)
+	if c == nil {
+		return m
+	}
+	for _, db := range c.Databases() {
+		for name, trig := range db.Triggers {
+			if trig == nil {
+				continue // defensive; the loader never stores nil
+			}
+			m[triggerKey{db: toLower(db.Name), name: name}] = trig
+		}
+	}
+	return m
+}
+
+// triggerKey is the identity key for a trigger: (database, name) lower-cased.
+type triggerKey struct {
+	db   string
+	name string
+}
+
+// triggersChanged reports whether two same-identity triggers differ in any compared field.
+// The compared set is Timing, Event, Table, and canonical Body (see the diffTriggers doc for
+// what is deliberately excluded and why). Any difference means DROP + CREATE.
+func triggersChanged(from, to *Trigger, n *Normalizer) bool {
+	if !strings.EqualFold(from.Timing, to.Timing) {
+		return true
+	}
+	if !strings.EqualFold(from.Event, to.Event) {
+		return true
+	}
+	if !strings.EqualFold(from.Table, to.Table) {
+		return true
+	}
+	return canonicalTriggerBody(from.Body, n) != canonicalTriggerBody(to.Body, n)
+}
+
+// canonicalTriggerBody reduces a trigger action statement to its canonical comparison form.
+// MySQL preserves the body verbatim on storage (verified on live 5.7.25 + 8.0.32), so the
+// user form and the engine readback are already byte-identical for the body; the only
+// canonicalization needed is trimming surrounding whitespace (which the loader's createTrigger
+// already applies, so this is belt-and-suspenders for any caller that builds a Trigger directly).
+// The Normalizer is threaded for signature symmetry with the other Canonical* helpers and to
+// leave a single seam should a future version diverge in stored-body form.
+func canonicalTriggerBody(body string, _ *Normalizer) string {
+	return strings.TrimSpace(body)
 }

--- a/mysql/catalog/diff_trigger_test.go
+++ b/mysql/catalog/diff_trigger_test.go
@@ -1,0 +1,353 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Hermetic unit tests for the trigger differ + generator (no oracle). They pin the diff
+// semantics — identity, the compared-field set, the deliberate Definer/Order ignores — and the
+// rendered DDL shape. The live-engine idempotence + apply-correctness proofs are in
+// migration_trigger_oracle_test.go.
+
+// loadTriggerCatalog loads an SDL snippet (wrapped in a utf8mb4 database) and returns the catalog.
+func loadTriggerCatalog(t *testing.T, body string) *Catalog {
+	t.Helper()
+	cat, err := LoadSDL("CREATE DATABASE d DEFAULT CHARSET=utf8mb4;\nUSE d;\n" + body)
+	if err != nil {
+		t.Fatalf("LoadSDL failed for %q: %v", body, err)
+	}
+	return cat
+}
+
+// triggerEntry returns the single trigger diff entry for name, or fails.
+func triggerEntry(t *testing.T, d *SchemaDiff, name string) *TriggerDiffEntry {
+	t.Helper()
+	for i := range d.Triggers {
+		if strings.EqualFold(d.Triggers[i].Name, name) {
+			return &d.Triggers[i]
+		}
+	}
+	t.Fatalf("no trigger diff entry for %q (have %d entries)", name, len(d.Triggers))
+	return nil
+}
+
+func TestTriggerDiff_SelfEmpty(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	cat := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;
+CREATE TRIGGER au AFTER UPDATE ON t FOR EACH ROW SET @x = NEW.b;`)
+	if d := DiffWithNormalizer(cat, cat, n); !d.IsEmpty() {
+		t.Fatalf("self-diff not empty: %s", describeTriggerDiff(d))
+	}
+}
+
+func TestTriggerDiff_Add(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `CREATE TABLE t (id INT PRIMARY KEY, a INT);`)
+	to := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	d := DiffWithNormalizer(from, to, n)
+	e := triggerEntry(t, d, "bi")
+	if e.Action != DiffAdd || e.To == nil || e.From != nil {
+		t.Fatalf("want DiffAdd with To set, got %v", e.Action)
+	}
+}
+
+func TestTriggerDiff_Drop(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	to := loadTriggerCatalog(t, `CREATE TABLE t (id INT PRIMARY KEY, a INT);`)
+	d := DiffWithNormalizer(from, to, n)
+	e := triggerEntry(t, d, "bi")
+	if e.Action != DiffDrop || e.From == nil || e.To != nil {
+		t.Fatalf("want DiffDrop with From set, got %v", e.Action)
+	}
+}
+
+// TestTriggerDiff_ModifyEachField proves every compared field independently triggers a MODIFY.
+func TestTriggerDiff_ModifyEachField(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	base := "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT);\nCREATE TABLE u (id INT PRIMARY KEY, a INT);\n"
+	cases := []struct {
+		name string
+		from string
+		to   string
+	}{
+		{"timing", "CREATE TRIGGER x BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;",
+			"CREATE TRIGGER x AFTER INSERT ON t FOR EACH ROW SET @z = NEW.a;"},
+		{"event", "CREATE TRIGGER x BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;",
+			"CREATE TRIGGER x BEFORE UPDATE ON t FOR EACH ROW SET NEW.a = 1;"},
+		{"table", "CREATE TRIGGER x BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;",
+			"CREATE TRIGGER x BEFORE INSERT ON u FOR EACH ROW SET NEW.a = 1;"},
+		{"body", "CREATE TRIGGER x BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;",
+			"CREATE TRIGGER x BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 2;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			from := loadTriggerCatalog(t, base+tc.from)
+			to := loadTriggerCatalog(t, base+tc.to)
+			d := DiffWithNormalizer(from, to, n)
+			e := triggerEntry(t, d, "x")
+			if e.Action != DiffModify {
+				t.Fatalf("want DiffModify for changed %s, got %v", tc.name, e.Action)
+			}
+		})
+	}
+}
+
+// TestTriggerDiff_IgnoreDefiner proves a DEFINER difference does NOT produce a diff: the user form
+// (no DEFINER → loader default `root`@`%`) and a stored form carrying an explicit DEFINER must
+// collapse to empty.
+func TestTriggerDiff_IgnoreDefiner(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	userForm := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	storedForm := loadTriggerCatalog(t, "CREATE TABLE t (id INT PRIMARY KEY, a INT);\n"+
+		"CREATE DEFINER=`someuser`@`localhost` TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;")
+	if d := DiffWithNormalizer(userForm, storedForm, n); !d.IsEmpty() {
+		t.Fatalf("DEFINER difference phantom-diffed (should be ignored): %s", describeTriggerDiff(d))
+	}
+	if d := DiffWithNormalizer(storedForm, userForm, n); !d.IsEmpty() {
+		t.Fatalf("DEFINER difference phantom-diffed (reverse): %s", describeTriggerDiff(d))
+	}
+}
+
+// TestTriggerDiff_IgnoreOrder proves FOLLOWS/PRECEDES is NOT diffed: a trigger declared with
+// FOLLOWS (non-nil Order) and the same trigger declared without it (the readback form, nil Order)
+// must collapse to empty. This is the deliberate trigger-order-not-modelled flag.
+func TestTriggerDiff_IgnoreOrder(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	withFollows := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT);
+CREATE TRIGGER bi1 BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;
+CREATE TRIGGER bi2 BEFORE INSERT ON t FOR EACH ROW FOLLOWS bi1 SET NEW.b = 2;`)
+	// Sanity: the loader actually captured the FOLLOWS so the test is meaningful.
+	if got := withFollows.GetDatabase("d").Triggers["bi2"]; got == nil || got.Order == nil {
+		t.Fatalf("precondition: expected bi2.Order non-nil (FOLLOWS captured)")
+	}
+	noFollows := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT);
+CREATE TRIGGER bi1 BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;
+CREATE TRIGGER bi2 BEFORE INSERT ON t FOR EACH ROW SET NEW.b = 2;`)
+	if d := DiffWithNormalizer(withFollows, noFollows, n); !d.IsEmpty() {
+		t.Fatalf("FOLLOWS/PRECEDES phantom-diffed (should be ignored): %s", describeTriggerDiff(d))
+	}
+}
+
+// TestTriggerDiff_BodyCaseWhitespaceTrim proves leading/trailing whitespace on the body is folded
+// (the loader TrimSpaces). Interior whitespace/case is significant (MySQL stores it verbatim) and
+// is NOT folded — a genuine body change must still diff.
+func TestTriggerDiff_BodyWhitespaceTrim(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	a := &Trigger{Name: "x", Table: "t", Timing: "BEFORE", Event: "INSERT", Body: "SET NEW.a = 1"}
+	b := &Trigger{Name: "x", Table: "t", Timing: "BEFORE", Event: "INSERT", Body: "  SET NEW.a = 1  "}
+	if triggersChanged(a, b, n) {
+		t.Fatalf("surrounding whitespace should not count as a change")
+	}
+	c := &Trigger{Name: "x", Table: "t", Timing: "BEFORE", Event: "INSERT", Body: "SET NEW.a = 2"}
+	if !triggersChanged(a, c, n) {
+		t.Fatalf("a genuine body change must diff")
+	}
+}
+
+// ---- generator unit tests ----
+
+func TestTriggerGenerate_CreateDDL(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `CREATE TABLE t (id INT PRIMARY KEY, a INT);`)
+	to := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	op := singleTriggerOp(t, plan, OpCreateTrigger)
+	want := "CREATE TRIGGER `d`.`bi` BEFORE INSERT ON `d`.`t` FOR EACH ROW SET NEW.a = 1"
+	if op.SQL != want {
+		t.Fatalf("CREATE DDL mismatch:\n  got:  %s\n  want: %s", op.SQL, want)
+	}
+	if op.Phase != PhaseMain || op.Priority != priorityTrigger {
+		t.Fatalf("CREATE op phase/priority wrong: phase=%v pri=%d", op.Phase, op.Priority)
+	}
+}
+
+func TestTriggerGenerate_DropDDL(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	to := loadTriggerCatalog(t, `CREATE TABLE t (id INT PRIMARY KEY, a INT);`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	op := singleTriggerOp(t, plan, OpDropTrigger)
+	want := "DROP TRIGGER `d`.`bi`"
+	if op.SQL != want {
+		t.Fatalf("DROP DDL mismatch:\n  got:  %s\n  want: %s", op.SQL, want)
+	}
+	if op.Phase != PhasePre {
+		t.Fatalf("DROP op must be PhasePre, got %v", op.Phase)
+	}
+}
+
+// TestTriggerGenerate_ModifyIsDropThenCreate proves a changed trigger emits exactly DROP then
+// CREATE (no ALTER TRIGGER), and the DROP (PhasePre) sorts before the CREATE (PhaseMain).
+func TestTriggerGenerate_ModifyIsDropThenCreate(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	to := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 2;`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	var trigOps []MigrationOp
+	for _, op := range plan.Ops {
+		if op.Type == OpCreateTrigger || op.Type == OpDropTrigger {
+			trigOps = append(trigOps, op)
+		}
+	}
+	if len(trigOps) != 2 {
+		t.Fatalf("want 2 trigger ops (DROP+CREATE), got %d: %s", len(trigOps), plan.SQL())
+	}
+	if trigOps[0].Type != OpDropTrigger || trigOps[1].Type != OpCreateTrigger {
+		t.Fatalf("want DROP then CREATE, got %s then %s", trigOps[0].Type, trigOps[1].Type)
+	}
+}
+
+// TestTriggerGenerate_DropTableSuppressesTriggerDrop proves that when a trigger's owning table is
+// dropped, no explicit DROP TRIGGER is emitted (the DROP TABLE cascades).
+func TestTriggerGenerate_DropTableSuppressesTriggerDrop(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	to := loadTriggerCatalog(t, `CREATE TABLE keep (id INT PRIMARY KEY);`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	for _, op := range plan.Ops {
+		if op.Type == OpDropTrigger {
+			t.Fatalf("DROP TRIGGER should be suppressed when its table is dropped:\n%s", plan.SQL())
+		}
+	}
+	// And a DROP TABLE for t must be present (sanity that the table really is being dropped).
+	sawDropTable := false
+	for _, op := range plan.Ops {
+		if op.Type == OpDropTable && strings.Contains(op.SQL, "`t`") {
+			sawDropTable = true
+		}
+	}
+	if !sawDropTable {
+		t.Fatalf("expected DROP TABLE `t` in plan:\n%s", plan.SQL())
+	}
+}
+
+// TestTriggerGenerate_ModifyTableMoveOldTableDropped is a regression guard: a trigger whose owning
+// table is RELOCATED (identity is (database, name), so a table move is a MODIFY) while its OLD table
+// is dropped in the same plan must NOT emit an explicit DROP TRIGGER on the old table — the DROP
+// TABLE cascades the trigger away first, and a standalone DROP TRIGGER would fail (errno 1360). Only
+// the CREATE half (on the surviving new table) is emitted. (Confirmed against live MySQL: without
+// the suppression the apply fails with "Trigger does not exist".)
+func TestTriggerGenerate_ModifyTableMoveOldTableDropped(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `
+CREATE TABLE old_t (id INT PRIMARY KEY, a INT);
+CREATE TABLE new_t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER tr BEFORE INSERT ON old_t FOR EACH ROW SET NEW.a = 1;`)
+	to := loadTriggerCatalog(t, `
+CREATE TABLE new_t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER tr BEFORE INSERT ON new_t FOR EACH ROW SET NEW.a = 1;`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	for _, op := range plan.Ops {
+		if op.Type == OpDropTrigger {
+			t.Fatalf("DROP TRIGGER must be suppressed when the trigger's old table is dropped (cascade):\n%s", plan.SQL())
+		}
+	}
+	// The CREATE on the surviving new table must still be emitted.
+	if op := singleTriggerOp(t, plan, OpCreateTrigger); !strings.Contains(op.SQL, "`new_t`") {
+		t.Fatalf("CREATE TRIGGER must target the new table:\n%s", op.SQL)
+	}
+}
+
+// TestTriggerGenerate_ModifyInPlaceStillDrops is the counterpart: an in-place body change (same
+// table, table NOT dropped) must still emit DROP+CREATE — the suppression must not over-fire.
+func TestTriggerGenerate_ModifyInPlaceStillDrops(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	to := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 2;`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	sawDrop, sawCreate := false, false
+	for _, op := range plan.Ops {
+		switch op.Type {
+		case OpDropTrigger:
+			sawDrop = true
+		case OpCreateTrigger:
+			sawCreate = true
+		}
+	}
+	if !sawDrop || !sawCreate {
+		t.Fatalf("in-place modify must emit both DROP and CREATE (suppression must not over-fire):\n%s", plan.SQL())
+	}
+}
+
+// TestTriggerGenerate_CreateOnNewTable proves a trigger on a freshly-created table is emitted (the
+// CREATE TRIGGER sorts after the CREATE TABLE via priorityTrigger > priorityTable).
+func TestTriggerGenerate_CreateOnNewTable(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := New()
+	to := loadTriggerCatalog(t, `
+CREATE TABLE t (id INT PRIMARY KEY, a INT);
+CREATE TRIGGER bi BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1;`)
+	plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+	var createTableIdx, createTrigIdx = -1, -1
+	for i, op := range plan.Ops {
+		switch op.Type {
+		case OpCreateTable:
+			createTableIdx = i
+		case OpCreateTrigger:
+			createTrigIdx = i
+		}
+	}
+	if createTableIdx < 0 || createTrigIdx < 0 {
+		t.Fatalf("expected both CREATE TABLE and CREATE TRIGGER:\n%s", plan.SQL())
+	}
+	if createTrigIdx < createTableIdx {
+		t.Fatalf("CREATE TRIGGER must follow CREATE TABLE:\n%s", plan.SQL())
+	}
+}
+
+func singleTriggerOp(t *testing.T, plan *MigrationPlan, typ MigrationOpType) MigrationOp {
+	t.Helper()
+	var found []MigrationOp
+	for _, op := range plan.Ops {
+		if op.Type == typ {
+			found = append(found, op)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want exactly one %s op, got %d:\n%s", typ, len(found), plan.SQL())
+	}
+	return found[0]
+}
+
+// describeTriggerDiff renders a compact description of a SchemaDiff's trigger entries for failure
+// output (the shared describeDiff only renders tables).
+func describeTriggerDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, te := range d.Triggers {
+		b.WriteString("[trigger ")
+		b.WriteString(te.Name)
+		b.WriteString(" ")
+		b.WriteString(te.Action.String())
+		b.WriteString("]")
+	}
+	if len(d.Tables) > 0 {
+		b.WriteString(describeDiff(d))
+	}
+	return b.String()
+}

--- a/mysql/catalog/migration_trigger.go
+++ b/mysql/catalog/migration_trigger.go
@@ -1,14 +1,183 @@
 package catalog
 
-// MySQL SDL generate — triggers (scaffold stub).
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — triggers (CREATE TRIGGER / DROP TRIGGER).
 //
-// Wired into GenerateMigrationWithNormalizer (migration.go) so trigger diffs
-// (SchemaDiff.Triggers) become DDL. Inert no-op placeholder returning nil until the trigger
-// breadth node renders the CREATE/DROP TRIGGER ops (OpCreateTrigger/OpDropTrigger,
-// priorityTrigger). Signature mirrors generateTableDDL (migration_table.go).
+// Turns the trigger diff (SchemaDiff.Triggers, populated by diff_trigger.go) into DDL. MySQL has
+// NO ALTER TRIGGER, so every modification is a DROP followed by a CREATE — diff_trigger.go already
+// emits DiffModify for a changed trigger, and this generator renders it as the drop+create pair.
 //
-// implemented by omni:trigger breadth node
-func generateTriggerDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no trigger ops (empty diff -> empty plan).
-	return nil
+// Triggers are database-level objects, so unlike the index/partition generators this one reads
+// SchemaDiff.Triggers directly (not the per-table entries). It is wired into
+// GenerateMigrationWithNormalizer (migration.go) via the OpCreateTrigger / OpDropTrigger op-types
+// at priorityTrigger.
+//
+// Ordering (sortMigrationOps imposes the global order):
+//   - CREATE TRIGGER runs in PhaseMain at priorityTrigger (70). priorityTrigger > priorityTable
+//     (10) and > priorityColumn (20), so a trigger is created AFTER its table's CREATE TABLE and
+//     any column ALTERs in the same plan — the table the trigger binds to already exists.
+//   - DROP TRIGGER runs in PhasePre, so it precedes a same-name re-create (a DiffModify) and any
+//     table re-create, and is emitted BEFORE the PhaseMain CREATE half of a modify.
+//
+// Table-drop cascade: MySQL auto-drops a table's triggers when the table is dropped (verified on
+// live 5.7.25 + 8.0.32). When a trigger's owning table is itself being dropped in this plan
+// (absent in `to`), emitting an explicit DROP TRIGGER would fail — the table drop already removed
+// it. dropTriggerSuppressed detects that case and skips the redundant op; the DROP TABLE
+// (PhasePre, priorityTable) cascades to the trigger.
+//
+// Rendering uses the fully-qualified form CREATE TRIGGER db.trig ... ON db.table (and
+// DROP TRIGGER db.trig), every identifier backtick-quoted, which is current-database-independent
+// and matches what the engine accepts (verified on live engines). The body is emitted verbatim —
+// MySQL stores it verbatim, so the readback of the emitted DDL canonicalizes equal to `to` and
+// apply-correctness holds by construction.
+//
+// implemented by omni:triggers breadth node
+func generateTriggerDDL(_, to *Catalog, diff *SchemaDiff, _ *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Triggers {
+		te := &diff.Triggers[i]
+		switch te.Action {
+		case DiffAdd:
+			if te.To == nil {
+				continue
+			}
+			ops = append(ops, buildCreateTriggerOp(te.Database, te.To))
+		case DiffDrop:
+			if te.From == nil || dropTriggerSuppressed(to, te.From) {
+				continue
+			}
+			ops = append(ops, buildDropTriggerOp(te.Database, te.From))
+		case DiffModify:
+			// No ALTER TRIGGER in MySQL: DROP old then CREATE new. The drop (PhasePre) always
+			// precedes the create (PhaseMain), freeing the name for re-creation. The DROP half is
+			// gated by the SAME table-drop-cascade suppression as a plain DiffDrop: a trigger whose
+			// owning table is dropped in this plan (e.g. a trigger relocated to a new table while its
+			// OLD table is dropped — identity is (database, name), so a table move is a MODIFY) has
+			// already been cascade-removed by the DROP TABLE, so an explicit DROP TRIGGER on the old
+			// table would fail (errno 1360). The CREATE half (on te.To's surviving table) still runs.
+			if te.From != nil && !dropTriggerSuppressed(to, te.From) {
+				ops = append(ops, buildDropTriggerOp(te.Database, te.From))
+			}
+			if te.To != nil {
+				ops = append(ops, buildCreateTriggerOp(te.Database, te.To))
+			}
+		}
+	}
+
+	// Determinism: stable by (op-rank, sortName) so drops sort ahead of creates locally (phase
+	// ordering also enforces this globally) and the emitted sequence is byte-stable across runs.
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ri, rj := triggerOpRank(ops[i].Type), triggerOpRank(ops[j].Type); ri != rj {
+			return ri < rj
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// dropTriggerSuppressed reports whether an explicit DROP TRIGGER for `trig` must be skipped
+// because the trigger's owning table is being dropped in the same plan (absent in `to`), in
+// which case DROP TABLE already cascades to the trigger and a standalone DROP TRIGGER would
+// fail. The table is looked up in `to` under the trigger's own database; if the database or
+// table is gone, the drop is cascaded and the op is suppressed.
+func dropTriggerSuppressed(to *Catalog, trig *Trigger) bool {
+	if to == nil || trig == nil || trig.Database == nil || trig.Table == "" {
+		return false
+	}
+	db := to.GetDatabase(trig.Database.Name)
+	if db == nil {
+		return true // whole database gone → table (and its triggers) cascaded
+	}
+	return db.GetTable(trig.Table) == nil
+}
+
+// buildCreateTriggerOp renders a CREATE TRIGGER op in MySQL's fully-qualified canonical form. The
+// trigger name and its ON table are both qualified by the trigger's OWN database (a trigger always
+// lives in the same database as its table). Timing/Event are emitted in their stored upper-case
+// form; the body is appended verbatim.
+//
+// Identifiers use the ORIGINAL-CASE names (trig.Database.Name, trig.Name, trig.Table), not the
+// lower-cased diff key `database` — on a case-sensitive server (lower_case_table_names=0, the Linux
+// default) the stored object name is case-significant, so the DDL must reproduce the declared
+// casing, the same rationale as tableIdent in migration_table.go. `database` (the lower-cased diff
+// key) is retained only for the Database/sortName ordering metadata.
+func buildCreateTriggerOp(database string, trig *Trigger) MigrationOp {
+	dbName := triggerDatabaseName(trig)
+	trigIdent := qualifiedTriggerIdent(dbName, trig.Name)
+	onTableIdent := qualifiedTriggerIdent(dbName, trig.Table)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE TRIGGER %s %s %s ON %s FOR EACH ROW",
+		trigIdent, strings.ToUpper(trig.Timing), strings.ToUpper(trig.Event), onTableIdent)
+	if body := strings.TrimSpace(trig.Body); body != "" {
+		b.WriteString(" ")
+		b.WriteString(body)
+	}
+
+	return MigrationOp{
+		Type:         OpCreateTrigger,
+		Database:     database,
+		ObjectName:   trig.Name,
+		ParentObject: trig.Table,
+		SQL:          b.String(),
+		Phase:        PhaseMain,
+		Priority:     priorityTrigger,
+		sortName:     triggerSortName(database, trig.Name),
+	}
+}
+
+// buildDropTriggerOp renders a DROP TRIGGER op (PhasePre, so it precedes a same-name re-create
+// and the PhaseMain CREATE half of a modify). The trigger name is qualified by its own database
+// (original case, like buildCreateTriggerOp).
+func buildDropTriggerOp(database string, trig *Trigger) MigrationOp {
+	return MigrationOp{
+		Type:         OpDropTrigger,
+		Database:     database,
+		ObjectName:   trig.Name,
+		ParentObject: trig.Table,
+		SQL:          fmt.Sprintf("DROP TRIGGER %s", qualifiedTriggerIdent(triggerDatabaseName(trig), trig.Name)),
+		Phase:        PhasePre,
+		Priority:     priorityTrigger,
+		sortName:     triggerSortName(database, trig.Name),
+	}
+}
+
+// triggerDatabaseName returns the trigger's owning database name in its original case, or "" when
+// the trigger was loaded without a qualifying database (the synced single-database release path).
+func triggerDatabaseName(trig *Trigger) string {
+	if trig.Database == nil {
+		return ""
+	}
+	return trig.Database.Name
+}
+
+// qualifiedTriggerIdent backtick-quotes `db`.`name`, omitting the database qualifier when the
+// database scope is empty (the synced single-database release path may load with no qualifying
+// database, exactly like tableIdent in migration_table.go).
+func qualifiedTriggerIdent(database, name string) string {
+	if database == "" {
+		return migrationQuoteIdent(name)
+	}
+	return migrationQuoteIdent(database) + "." + migrationQuoteIdent(name)
+}
+
+// triggerOpRank orders trigger op types so drops sort ahead of creates locally (phase ordering
+// also enforces this globally).
+func triggerOpRank(t MigrationOpType) int {
+	if t == OpDropTrigger {
+		return 0
+	}
+	return 1
+}
+
+// triggerSortName is the stable secondary sort key for a trigger op: lower-cased database.name.
+func triggerSortName(database, name string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(name)
 }

--- a/mysql/catalog/migration_trigger_oracle_test.go
+++ b/mysql/catalog/migration_trigger_oracle_test.go
@@ -1,0 +1,488 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the trigger differ + generator (correctness-protocol.md gates 1 & 2),
+// against the LIVE MySQL engines (5.7 :13307 ssl-disabled, 8.0 :13306). Triggers are database-
+// level objects whose stored form is read from information_schema.triggers (the exact path the
+// bytebase MySQL driver syncs them with), so the table-centric harness in migration_oracle_test.go
+// does not fit — this file carries a trigger-shaped harness that:
+//
+//   - applies a schema (a base table plus its triggers) to a throwaway database;
+//   - reads the triggers back from information_schema.triggers (TRIGGER_NAME / ACTION_TIMING /
+//     EVENT_MANIPULATION / EVENT_OBJECT_TABLE / ACTION_STATEMENT) and reconstructs CREATE TRIGGER
+//     statements — the engine's authentic stored form — then loads them via LoadSDL;
+//   - proves both gates on that stored-form catalog.
+//
+// GATE 1 — IDEMPOTENCE (the spine): for a schema in its real stored form, Diff(c,c) is empty and
+// the no-op plan SQL() == "". Additionally the user-written form diffed against its engine readback
+// is empty (the canonicalization property: DEFINER/whitespace differences must not phantom-diff).
+//
+// GATE 2 — APPLY-CORRECTNESS: for representative (from, to) pairs, GenerateMigration(from,to).SQL()
+// applied to a real `from` database yields a trigger set whose stored form equals `to`'s.
+//
+// The harness skips cleanly when the engines are unreachable (go test -short skips it).
+
+// triggerOracleDB is the database the trigger harness applies generated plans into (mirrors the
+// table harness's diffdb convention but kept distinct so parallel oracle tests don't collide).
+const triggerOracleDB = "trigdb"
+
+// triggerSchemaSDL wraps a schema DDL list (base tables + CREATE TRIGGER statements) in a
+// CREATE DATABASE + USE under dbName, returning a loadable SDL snippet. Used to build the
+// user-written form for the canonicalization check, under the same database name AND server
+// charset as the engine's reconstructed stored form (serverCharsetFor(version) — latin1 on 5.7,
+// utf8mb4 on 8.0) so only trigger differences can surface, not a table-charset mismatch (the same
+// wrapping convention loadOneTable uses for the table harness).
+func triggerSchemaSDL(dbName string, version Version, schema []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, serverCharsetFor(version), dbName)
+	for _, s := range schema {
+		b.WriteString(s)
+		b.WriteString(";\n")
+	}
+	return b.String()
+}
+
+// reconstructTriggersSQL applies the given schema DDL to a throwaway database (probeDB), reads the
+// triggers back from information_schema, and returns an SDL snippet (CREATE DATABASE + USE + every
+// base table's SHOW CREATE + every reconstructed CREATE TRIGGER) representing the engine's stored
+// form — but with the database name in the returned SDL rewritten to emitDB. Separating probeDB
+// from emitDB lets the apply-correctness harness load BOTH the `from` and `to` catalogs under the
+// SAME database name (the apply target), so the table differ doesn't see a spurious DROP+CREATE of
+// the carried base table just because the two probes ran in differently-named scratch databases —
+// exactly the loadOneTable-wraps-everything-in-diffdb convention the table harness uses.
+// tables lists the base tables to carry over (their SHOW CREATE TABLE), so the reloaded catalog has
+// the trigger's target table present.
+func (o *oracleConn) reconstructTriggersSQL(t *testing.T, probeDB, emitDB string, schemaDDL []string, tables []string) (string, bool) {
+	t.Helper()
+	ctx := context.Background()
+	stmts := append([]string{
+		"DROP DATABASE IF EXISTS " + probeDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", probeDB, serverCharsetFor(o.version)),
+		"USE " + probeDB,
+	}, schemaDDL...)
+	for _, s := range stmts {
+		if _, err := o.db.ExecContext(ctx, s); err != nil {
+			t.Logf("[%s] trigger setup failed (may be expected): %q: %v", o.name, s, err)
+			return "", false
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", emitDB, serverCharsetFor(o.version), emitDB)
+	// Carry the base tables (so the trigger's ON table exists when the SDL reloads).
+	for _, tbl := range tables {
+		var name, ddl string
+		row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", probeDB, tbl))
+		if err := row.Scan(&name, &ddl); err != nil {
+			t.Logf("[%s] SHOW CREATE TABLE %s failed: %v", o.name, tbl, err)
+			return "", false
+		}
+		b.WriteString(ddl)
+		b.WriteString(";\n")
+	}
+	// Reconstruct every trigger from information_schema, ordered by ACTION_ORDER for determinism.
+	rows, err := o.db.QueryContext(ctx,
+		"SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, EVENT_OBJECT_TABLE, ACTION_STATEMENT "+
+			"FROM information_schema.triggers WHERE TRIGGER_SCHEMA = ? ORDER BY EVENT_OBJECT_TABLE, ACTION_TIMING, EVENT_MANIPULATION, ACTION_ORDER", probeDB)
+	if err != nil {
+		t.Logf("[%s] query information_schema.triggers failed: %v", o.name, err)
+		return "", false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, timing, event, table, stmt string
+		if err := rows.Scan(&name, &timing, &event, &table, &stmt); err != nil {
+			t.Logf("[%s] scan trigger row failed: %v", o.name, err)
+			return "", false
+		}
+		fmt.Fprintf(&b, "CREATE TRIGGER `%s` %s %s ON `%s` FOR EACH ROW %s;\n", name, timing, event, table, stmt)
+	}
+	if err := rows.Err(); err != nil {
+		t.Logf("[%s] iterate trigger rows failed: %v", o.name, err)
+		return "", false
+	}
+	return b.String(), true
+}
+
+// triggerStoredCatalog reconstructs and loads the engine's stored form of a schema into a catalog.
+// The schema is applied in probeDB but the loaded catalog's database is named emitDB.
+func (o *oracleConn) triggerStoredCatalog(t *testing.T, probeDB, emitDB string, schemaDDL []string, tables []string) (*Catalog, bool) {
+	t.Helper()
+	sdl, ok := o.reconstructTriggersSQL(t, probeDB, emitDB, schemaDDL, tables)
+	if !ok {
+		return nil, false
+	}
+	cat, err := LoadSDLWithVersion(sdl, o.version)
+	if err != nil {
+		t.Fatalf("[%s] reload of reconstructed trigger SDL failed: %v\n%s", o.name, err, sdl)
+	}
+	return cat, true
+}
+
+// triggerIdemProbe is one idempotence case: a base-table set + the trigger DDL applied on top.
+type triggerIdemProbe struct {
+	id       string
+	tables   []string // base tables (SHOW CREATE carried into the reload)
+	schema   []string // full schema DDL (tables + CREATE TRIGGER ...) applied to the engine
+	versions []Version
+}
+
+// triggerIdempotenceProbes enumerates the trigger FORMS that must round-trip empty: every
+// timing×event, multi-trigger-per-table, BEGIN…END bodies, OLD/NEW references, and a trigger with
+// FOLLOWS (whose readback drops the FOLLOWS — the order-not-modelled flag).
+func triggerIdempotenceProbes() []triggerIdemProbe {
+	tbl := "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, c INT)"
+	mk := func(id, trig string, vs []Version) triggerIdemProbe {
+		return triggerIdemProbe{
+			id:       id,
+			tables:   []string{"t"},
+			schema:   []string{tbl, trig},
+			versions: vs,
+		}
+	}
+	return []triggerIdemProbe{
+		// ---- every timing × event ----
+		mk("before-insert", "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1", both()),
+		mk("after-insert", "CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW SET @x = NEW.a", both()),
+		mk("before-update", "CREATE TRIGGER tr BEFORE UPDATE ON t FOR EACH ROW SET NEW.a = OLD.a + 1", both()),
+		mk("after-update", "CREATE TRIGGER tr AFTER UPDATE ON t FOR EACH ROW SET @x = NEW.b", both()),
+		mk("before-delete", "CREATE TRIGGER tr BEFORE DELETE ON t FOR EACH ROW SET @x = OLD.a", both()),
+		mk("after-delete", "CREATE TRIGGER tr AFTER DELETE ON t FOR EACH ROW SET @x = OLD.b", both()),
+
+		// ---- body shapes ----
+		// BEGIN…END multi-statement body (verbatim storage incl. newlines/indentation).
+		mk("begin-end", "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW BEGIN\n  SET NEW.a = 1;\n  IF NEW.b IS NULL THEN\n    SET NEW.b = 0;\n  END IF;\nEND", both()),
+		// OLD/NEW + a string literal in the body (quoting must survive).
+		mk("string-literal", "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.c = (SELECT 'literal value')", both()),
+		// Lower-case keywords in the user form (MySQL preserves body case verbatim).
+		mk("lowercase-body", "CREATE TRIGGER tr before insert on t for each row set new.a = new.b + 1", both()),
+
+		// ---- multiple triggers, distinct events on one table ----
+		// (handled by the multi-trigger probe below, which needs >1 CREATE)
+	}
+}
+
+// TestOracle_TriggerIdempotence proves gate 1: a schema in its real stored form self-diffs empty
+// and the no-op plan is empty, and the user form vs its engine readback is empty (canonicalization
+// — DEFINER, whitespace and FOLLOWS must not phantom-diff). Probed on every supported version.
+func TestOracle_TriggerIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range triggerIdempotenceProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				dbName := "trig_idem_" + strings.ReplaceAll(probe.id, "-", "_")
+				storedCat, ok := o.triggerStoredCatalog(t, dbName, dbName, probe.schema, probe.tables)
+				if !ok {
+					t.Skipf("[%s] could not obtain stored form for %s", o.name, probe.id)
+				}
+
+				// Self-diff + self-plan must be empty (idempotence spine).
+				if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] IDEMPOTENCE: self-diff not empty for %s: %s", o.name, probe.id, describeTriggerDiff(d))
+				}
+				plan := GenerateMigrationWithNormalizer(storedCat, storedCat, DiffWithNormalizer(storedCat, storedCat, n), n)
+				if plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s:\n%s", o.name, probe.id, plan.SQL())
+				}
+
+				// User form vs engine stored form must collapse to empty (the canonicalization
+				// property: the user wrote no DEFINER / maybe a FOLLOWS / odd spacing; the readback
+				// carries the engine's form — they must not phantom-diff). The user form is loaded
+				// under the SAME database name as the stored form so only trigger differences (not a
+				// database-name mismatch) can surface.
+				userSDL := triggerSchemaSDL(dbName, version, probe.schema)
+				userCat, err := LoadSDLWithVersion(userSDL, version)
+				if err != nil {
+					t.Fatalf("[%s] user-form load failed for %s: %v", o.name, probe.id, err)
+				}
+				if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION: user vs stored not empty for %s: %s", o.name, probe.id, describeTriggerDiff(d))
+				}
+				if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION (reverse): stored vs user not empty for %s: %s", o.name, probe.id, describeTriggerDiff(d))
+				}
+			})
+		}
+	}
+}
+
+// TestOracle_TriggerMultiPerTableIdempotence proves a table carrying MULTIPLE triggers (across
+// several timing/event slots, including two on the same timing+event linked by FOLLOWS) round-trips
+// empty. The FOLLOWS is dropped by the readback (order-not-modelled flag): the stored form and the
+// user form must still collapse to empty.
+func TestOracle_TriggerMultiPerTableIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		t.Run(o.name+"/multi", func(t *testing.T) {
+			tbl := "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, c INT)"
+			schema := []string{
+				tbl,
+				"CREATE TRIGGER bi1 BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1",
+				"CREATE TRIGGER bi2 BEFORE INSERT ON t FOR EACH ROW FOLLOWS bi1 SET NEW.b = 2",
+				"CREATE TRIGGER au AFTER UPDATE ON t FOR EACH ROW SET @x = NEW.c",
+				"CREATE TRIGGER bd BEFORE DELETE ON t FOR EACH ROW SET @y = OLD.a",
+			}
+			storedCat, ok := o.triggerStoredCatalog(t, "trig_multi", "trig_multi", schema, []string{"t"})
+			if !ok {
+				t.Skipf("[%s] could not obtain stored form", o.name)
+			}
+			if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] multi-trigger self-diff not empty: %s", o.name, describeTriggerDiff(d))
+			}
+			if plan := GenerateMigrationWithNormalizer(storedCat, storedCat, DiffWithNormalizer(storedCat, storedCat, n), n); plan.SQL() != "" {
+				t.Errorf("[%s] multi-trigger non-empty no-op plan:\n%s", o.name, plan.SQL())
+			}
+
+			// User form (with the FOLLOWS) vs stored form (FOLLOWS dropped) must be empty.
+			userCat, err := LoadSDLWithVersion(triggerSchemaSDL("trig_multi", version, schema), version)
+			if err != nil {
+				t.Fatalf("[%s] user-form load failed: %v", o.name, err)
+			}
+			if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+				t.Errorf("[%s] multi-trigger user vs stored not empty (FOLLOWS must not diff): %s", o.name, describeTriggerDiff(d))
+			}
+		})
+	}
+}
+
+// triggerMigProbe is one apply-correctness case: transform a from-schema into a to-schema. Both
+// are full schema DDL lists (base table + triggers); an empty trigger set means "no trigger".
+//
+// tables is the base-table set carried into the from/to/result readbacks (so the trigger's ON table
+// is present when the reconstructed SDL reloads). When the from and to schemas carry DIFFERENT base
+// tables (a trigger relocated to a new table while the old table is dropped), fromTables and toTables
+// override tables for the from and to+result readbacks respectively.
+type triggerMigProbe struct {
+	id         string
+	tables     []string
+	fromTables []string // overrides tables for the `from` readback when set
+	toTables   []string // overrides tables for the `to` (and post-apply result) readback when set
+	fromDDL    []string
+	toDDL      []string
+	versions   []Version
+}
+
+// fromTableSet / toTableSet resolve the effective base-table list for each side.
+func (p triggerMigProbe) fromTableSet() []string {
+	if p.fromTables != nil {
+		return p.fromTables
+	}
+	return p.tables
+}
+
+func (p triggerMigProbe) toTableSet() []string {
+	if p.toTables != nil {
+		return p.toTables
+	}
+	return p.tables
+}
+
+// triggerMigrationProbes enumerates the CREATE / DROP / CHANGE(=DROP+CREATE) forms the generator
+// covers, each proven by applying the generated plan to a real `from` database and comparing the
+// trigger readback to `to`.
+func triggerMigrationProbes() []triggerMigProbe {
+	tbl := "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, c INT)"
+	return []triggerMigProbe{
+		// ---- CREATE (add a trigger to an existing table) ----
+		{"create-before-insert", []string{"t"}, nil, nil, []string{tbl},
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1"}, both()},
+		{"create-after-update", []string{"t"}, nil, nil, []string{tbl},
+			[]string{tbl, "CREATE TRIGGER tr AFTER UPDATE ON t FOR EACH ROW SET @x = NEW.b"}, both()},
+		{"create-before-delete", []string{"t"}, nil, nil, []string{tbl},
+			[]string{tbl, "CREATE TRIGGER tr BEFORE DELETE ON t FOR EACH ROW SET @x = OLD.a"}, both()},
+		{"create-begin-end", []string{"t"}, nil, nil, []string{tbl},
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW BEGIN\n  SET NEW.a = 1;\n  SET NEW.b = 2;\nEND"}, both()},
+
+		// ---- DROP (remove a trigger, table stays) ----
+		{"drop-trigger", []string{"t"}, nil, nil,
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1"},
+			[]string{tbl}, both()},
+
+		// ---- CHANGE (= DROP + CREATE) ----
+		{"change-body", []string{"t"}, nil, nil,
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1"},
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 2"}, both()},
+		{"change-timing", []string{"t"}, nil, nil,
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET @x = NEW.a"},
+			[]string{tbl, "CREATE TRIGGER tr AFTER INSERT ON t FOR EACH ROW SET @x = NEW.a"}, both()},
+		{"change-event", []string{"t"}, nil, nil,
+			[]string{tbl, "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1"},
+			[]string{tbl, "CREATE TRIGGER tr BEFORE UPDATE ON t FOR EACH ROW SET NEW.a = 1"}, both()},
+
+		// ---- multi-trigger plan: add one, drop one, keep one ----
+		{"multi-add-drop", []string{"t"}, nil, nil,
+			[]string{tbl,
+				"CREATE TRIGGER keep AFTER UPDATE ON t FOR EACH ROW SET @x = NEW.a",
+				"CREATE TRIGGER goes BEFORE INSERT ON t FOR EACH ROW SET NEW.a = 1"},
+			[]string{tbl,
+				"CREATE TRIGGER keep AFTER UPDATE ON t FOR EACH ROW SET @x = NEW.a",
+				"CREATE TRIGGER comes BEFORE DELETE ON t FOR EACH ROW SET @y = OLD.a"}, both()},
+
+		// ---- regression: trigger RELOCATED to a new table while the OLD table is dropped ----
+		// Identity is (database, name), so moving `tr` from old_t to new_t is a MODIFY (DROP+CREATE).
+		// The DROP half targets old_t, which is dropped in the same plan — MySQL cascades the trigger
+		// when DROP TABLE old_t runs, so an explicit DROP TRIGGER would fail (errno 1360). The
+		// suppression in generateTriggerDDL's DiffModify branch must skip that DROP; only the CREATE
+		// on the surviving new_t is emitted. (Without the fix this probe fails at apply.)
+		{"modify-table-move-drop-old", nil,
+			[]string{"old_t", "new_t"}, []string{"new_t"},
+			[]string{
+				"CREATE TABLE old_t (id INT PRIMARY KEY, a INT)",
+				"CREATE TABLE new_t (id INT PRIMARY KEY, a INT)",
+				"CREATE TRIGGER tr BEFORE INSERT ON old_t FOR EACH ROW SET NEW.a = 1"},
+			[]string{
+				"CREATE TABLE new_t (id INT PRIMARY KEY, a INT)",
+				"CREATE TRIGGER tr BEFORE INSERT ON new_t FOR EACH ROW SET NEW.a = 1"}, both()},
+	}
+}
+
+// TestOracle_TriggerMigrationApplyCorrectness proves gate 2: the generated DDL transforms a real
+// `from` database's trigger set into a `to`-equal one (compared via information_schema readback,
+// reloaded and diffed).
+func TestOracle_TriggerMigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range triggerMigrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertTriggerApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// assertTriggerApplyCorrect builds from/to catalogs from the engine's own readbacks, generates the
+// plan, applies it to a real from-state database, reads the result's triggers back, and asserts the
+// result canonicalizes equal to `to`.
+func assertTriggerApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p triggerMigProbe) {
+	t.Helper()
+	slug := strings.ReplaceAll(p.id, "-", "_")
+
+	// Both probes reconstruct under DIFFERENT scratch databases but EMIT under triggerOracleDB —
+	// the apply target — so the table differ compares the carried base table against itself (no
+	// spurious DROP+CREATE table) and only the trigger set differs.
+	fromCat, ok := o.triggerStoredCatalog(t, "trig_from_"+slug, triggerOracleDB, p.fromDDL, p.fromTableSet())
+	if !ok {
+		t.Skipf("[%s] could not obtain `from` stored form for %s", o.name, p.id)
+	}
+	toCat, ok := o.triggerStoredCatalog(t, "trig_to_"+slug, triggerOracleDB, p.toDDL, p.toTableSet())
+	if !ok {
+		t.Skipf("[%s] could not obtain `to` stored form for %s", o.name, p.id)
+	}
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Build a real database in state `from` on a dedicated connection (so a stray USE stays on the
+	// same pooled connection as the following statements), then apply the plan.
+	ctx := context.Background()
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	setup := append([]string{
+		"DROP DATABASE IF EXISTS " + triggerOracleDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", triggerOracleDB, serverCharsetFor(o.version)),
+		"USE " + triggerOracleDB,
+	}, p.fromDDL...)
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, p.id, s, err)
+		}
+	}
+
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s", o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Read back the resulting triggers and reload as a catalog (in the applied database, on the
+	// SAME connection the plan was applied on). After apply the schema equals `to`, so the result
+	// readback carries the `to` base-table set.
+	resultSDL, ok := o.reconstructTriggersFromConn(t, conn, triggerOracleDB, p.toTableSet())
+	if !ok {
+		t.Fatalf("[%s] could not read back result for %s after apply:\n%s", o.name, p.id, plan.SQL())
+	}
+	resultCat, err := LoadSDLWithVersion(resultSDL, o.version)
+	if err != nil {
+		t.Fatalf("[%s] reload of result SDL failed for %s: %v\n%s", o.name, p.id, err, resultSDL)
+	}
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  diff: %s", o.name, p.id, plan.SQL(), describeTriggerDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeTriggerDiff(d))
+	}
+}
+
+// reconstructTriggersFromConn reads the triggers (and carries the base tables' SHOW CREATE) of an
+// already-applied database on a specific *sql.Conn, returning the stored-form SDL. Unlike
+// reconstructTriggersSQL it does NOT re-create the database — it inspects the just-applied state on
+// the same connection the plan ran on.
+func (o *oracleConn) reconstructTriggersFromConn(t *testing.T, conn *sql.Conn, dbName string, tables []string) (string, bool) {
+	t.Helper()
+	ctx := context.Background()
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, serverCharsetFor(o.version), dbName)
+	for _, tbl := range tables {
+		var name, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", dbName, tbl))
+		if err := row.Scan(&name, &ddl); err != nil {
+			t.Logf("[%s] SHOW CREATE TABLE %s failed: %v", o.name, tbl, err)
+			return "", false
+		}
+		b.WriteString(ddl)
+		b.WriteString(";\n")
+	}
+	rows, err := conn.QueryContext(ctx,
+		"SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, EVENT_OBJECT_TABLE, ACTION_STATEMENT "+
+			"FROM information_schema.triggers WHERE TRIGGER_SCHEMA = ? ORDER BY EVENT_OBJECT_TABLE, ACTION_TIMING, EVENT_MANIPULATION, ACTION_ORDER", dbName)
+	if err != nil {
+		t.Logf("[%s] query information_schema.triggers failed: %v", o.name, err)
+		return "", false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, timing, event, table, stmt string
+		if err := rows.Scan(&name, &timing, &event, &table, &stmt); err != nil {
+			t.Logf("[%s] scan trigger row failed: %v", o.name, err)
+			return "", false
+		}
+		fmt.Fprintf(&b, "CREATE TRIGGER `%s` %s %s ON `%s` FOR EACH ROW %s;\n", name, timing, event, table, stmt)
+	}
+	if err := rows.Err(); err != nil {
+		t.Logf("[%s] iterate trigger rows failed: %v", o.name, err)
+		return "", false
+	}
+	return b.String(), true
+}


### PR DESCRIPTION
## What

Implements the **triggers** breadth node for MySQL SDL (declarative schema migration) in `mysql/catalog`. Fills the two scaffolded hooks:

- `diff_trigger.go` — `diffTriggers` (database-level trigger comparison → `SchemaDiff.Triggers`)
- `migration_trigger.go` — `generateTriggerDDL` (`CREATE TRIGGER` / `DROP TRIGGER` → `MigrationOp`)

Triggers are MySQL database-level objects keyed by `(database, name)`, each bound to a table via `Trigger.Table`. Scope: `CREATE TRIGGER`, timing (`BEFORE`/`AFTER`), event (`INSERT`/`UPDATE`/`DELETE`), and the trigger body. **No `ALTER TRIGGER` in MySQL → any change is `DROP` + `CREATE`.**

## Correctness — proven against the live oracle (MySQL 5.7.25 :13307 + 8.0.32 :13306)

Both gates pass on **both versions** (`go test ./mysql/catalog/...`):

**Gate 1 — Idempotence** (`TestOracle_TriggerIdempotence`, `TestOracle_TriggerMultiPerTableIdempotence`): for a schema in its real stored form (reconstructed from `information_schema.triggers` — the exact path the bytebase MySQL driver syncs with), the self-diff is empty and the no-op plan is empty; and the user-written form vs the engine readback collapses to empty. Covers every timing×event, `BEGIN…END` bodies, string-literal bodies, lowercase-keyword bodies, multi-trigger-per-table, and a `FOLLOWS`-ordered pair.

**Gate 2 — Apply-correctness** (`TestOracle_TriggerMigrationApplyCorrectness`): the generated DDL applied to a real `from` database yields a trigger set whose stored form equals `to`. Covers CREATE (each timing×event + `BEGIN…END`), DROP, change=`DROP`+`CREATE` (body/timing/event), multi add-drop-keep, and a trigger relocated to a new table while the old table is dropped.

Hermetic unit tests in `diff_trigger_test.go` pin the diff semantics and DDL shape.

## Normalization rules

**Compared:** `Timing`, `Event`, `Table` (case-insensitive), `Body` (exact compare after `TrimSpace`).

Body is an exact compare because **MySQL stores the trigger action statement verbatim** — `information_schema.triggers.ACTION_STATEMENT` and `SHOW CREATE TRIGGER` both preserve whitespace, case, and `BEGIN…END` structure byte-for-byte (verified on live 5.7.25 + 8.0.32). The idempotence gate proves the user form and the engine readback agree.

**Deliberately ignored** (each would phantom-diff a no-op trigger against its own readback):

- **`Definer`** — the user form usually omits `DEFINER` (loader defaults to `` `root`@`%` ``); the readback always carries the server `DEFINER`, and the spellings diverge. Ownership/security attribute, not schema shape. *(Generated `CREATE TRIGGER` omits `DEFINER`, so a re-create runs as the executing session's user — the conventional SDL behavior.)*
- **`CharacterSetClient` / `CollationConnection` / `DatabaseCollation`** — session/connection charset metadata captured at create time, not declarative shape.

## ⚠️ Flags

- **`trigger-order-not-modelled` (FOLLOWS/PRECEDES):** the relative firing order of multiple triggers on the same `table+timing+event` is **not diffed**. `SHOW CREATE TRIGGER` does not echo `FOLLOWS`/`PRECEDES`, and the omni loader stores triggers in an unordered map without resolving `information_schema.triggers.ACTION_ORDER` into a dependency — so a trigger declared with `FOLLOWS x` loads with a non-nil `Order` that its own readback lacks. Comparing `Order` would phantom-diff every ordered trigger. The omission has no observable schema divergence for the overwhelmingly common single-trigger-per-event case; the proper fix is loader-side (model `ACTION_ORDER`). Both versions verified to round-trip empty for a `FOLLOWS`-ordered pair.
- **Multi-statement body + `MigrationPlan.SQL()`:** a `BEGIN…END` body contains internal `;`. The omni apply path is op-by-op (`plan.Ops`, one statement each) and is proven correct here. The joined `MigrationPlan.SQL()` text (owned by generate-core, not this node) embeds those `;` — the downstream **bytebase bridge** consumer must apply op-by-op or use a `DELIMITER`-aware splitter. Noted for the bridge node.

## Dependencies / out of scope

- **`bb:bridge-triggers-events` (deferred bytebase node):** end-to-end via bytebase needs `catalogToProto` to emit `TriggerMetadata` (it currently does **not** emit `db.Triggers`). This omni-level diff/generate operates on the omni catalog (triggers loaded by `LoadSDL`) and is proven independently against the oracle — that is this PR's deliverable.

## Cross-family review

Reviewed by Claude (`/code-review`, 10-angle) + Codex (`/codex:review`), independently. Both converged on one blocker — the `DiffModify` `DROP` half bypassed the table-drop-cascade suppression — now fixed (gated by `dropTriggerSuppressed`) and proven on the live engine via the `modify-table-move-drop-old` probe + two hermetic regression tests. Normalization decisions (Body exact-compare, Definer/charset ignores) audited as sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
