### PR TITLE
feat(mysql/catalog): implement routine (function+procedure) diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_routine.go
+++ b/mysql/catalog/diff_routine.go
@@ -1,24 +1,359 @@
 package catalog
 
-// MySQL SDL diff — stored routines (functions + procedures) (scaffold stub).
+import (
+	"sort"
+	"strings"
+)
+
+// MySQL SDL diff — stored routines (functions + procedures).
 //
-// Two hooks, because the dispatcher (DiffWithNormalizer in diff.go) packs functions and
-// procedures into separate SchemaDiff slices (SchemaDiff.Functions / SchemaDiff.Procedures),
-// both element type RoutineDiffEntry (distinguished by RoutineDiffEntry.IsProcedure). The
-// routine breadth node fills BOTH here. Inert no-op placeholders returning nil until then.
-// Signatures mirror diffTables (diff_table.go): whole-catalog, taking from/to *Catalog and
-// the version-fixing Normalizer (routines are database-level objects keyed by (database, name)).
+// This is the MySQL analog of PG's diffFunctions (pg/catalog/diff_function.go). MySQL keeps
+// functions and procedures in two separate maps on a Database (db.Functions / db.Procedures),
+// so the dispatcher (DiffWithNormalizer in diff.go) packs them into two separate SchemaDiff
+// slices (SchemaDiff.Functions / SchemaDiff.Procedures), both element type RoutineDiffEntry
+// (distinguished by RoutineDiffEntry.IsProcedure). This node fills BOTH via the shared
+// diffRoutineMaps engine; diffFunctions and diffProcedures are thin selectors over it.
 //
-// implemented by omni:routine breadth node
-func diffFunctions(_, _ *Catalog, _ *Normalizer) []RoutineDiffEntry {
-	// Scaffold: returns nil so the function diff stays empty (self-diff inert).
-	return nil
+// Identity is (database, name) lower-cased — within a kind. A function and a procedure of the
+// same name are different objects (different maps), so there is no cross-kind collision: the
+// dispatcher calls diffFunctions and diffProcedures independently.
+//
+// Equality is decided by canonicalRoutine, which folds the stored-form-significant attributes:
+// the parameter list (direction/name/type), the RETURNS type (functions), the routine BODY, and
+// the in-scope characteristics (DETERMINISTIC, DATA ACCESS, SQL SECURITY, COMMENT). Two routines
+// whose surface DDL differs but whose stored form is identical produce no phantom diff. Every
+// canonicalization-sensitive decision is oracle-backed (see canonicalRoutine).
+//
+// DEFINER is NOT part of the comparison: it is an environment attribute (the creating account),
+// not schema-as-code, and the loader defaults it to `root`@`%` when absent (routinecmds.go).
+// Diffing it would emit spurious DROP+CREATE on every cross-deployment release. (Verified: a
+// no-op release must not re-create a routine merely because the synced DEFINER differs.)
+func diffFunctions(from, to *Catalog, n *Normalizer) []RoutineDiffEntry {
+	return diffRoutineMaps(from, to, n, false)
 }
 
 // diffProcedures is the stored-procedure half of the routine breadth node; see diffFunctions.
+func diffProcedures(from, to *Catalog, n *Normalizer) []RoutineDiffEntry {
+	return diffRoutineMaps(from, to, n, true)
+}
+
+// diffRoutineMaps compares the routine maps (functions or procedures, selected by isProcedure)
+// across all databases of the two catalogs and returns the per-routine changes. It mirrors the
+// table differ's whole-catalog shape: walk every database present on either side, match routines
+// by lower-cased (database, name), and emit Add/Drop/Modify.
+func diffRoutineMaps(from, to *Catalog, n *Normalizer, isProcedure bool) []RoutineDiffEntry {
+	fromMap := routineEntries(from, isProcedure)
+	toMap := routineEntries(to, isProcedure)
+
+	var result []RoutineDiffEntry
+
+	// Dropped: in from but not in to.
+	for key, fr := range fromMap {
+		if _, ok := toMap[key]; !ok {
+			result = append(result, RoutineDiffEntry{
+				Action:      DiffDrop,
+				Database:    fr.dbName,
+				Name:        fr.routine.Name,
+				IsProcedure: isProcedure,
+				From:        fr.routine,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for key, tr := range toMap {
+		fr, ok := fromMap[key]
+		if !ok {
+			result = append(result, RoutineDiffEntry{
+				Action:      DiffAdd,
+				Database:    tr.dbName,
+				Name:        tr.routine.Name,
+				IsProcedure: isProcedure,
+				To:          tr.routine,
+			})
+			continue
+		}
+		if routinesChanged(fr.routine, tr.routine, n) {
+			result = append(result, RoutineDiffEntry{
+				Action:      DiffModify,
+				Database:    tr.dbName,
+				Name:        tr.routine.Name,
+				IsProcedure: isProcedure,
+				From:        fr.routine,
+				To:          tr.routine,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if a, b := toLower(result[i].Database), toLower(result[j].Database); a != b {
+			return a < b
+		}
+		if a, b := toLower(result[i].Name), toLower(result[j].Name); a != b {
+			return a < b
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// routineRef bundles a routine with the original-case name of the database it lives in, so the
+// diff entry can carry the declared database casing (matching tableIdent's case discipline) while
+// the map is keyed by the lower-cased (database, name) identity.
+type routineRef struct {
+	dbName  string
+	routine *Routine
+}
+
+// routineEntries indexes every function (or procedure, per isProcedure) in every database of the
+// catalog by lower-cased "database\x00name". The NUL separator keeps a routine `b` in database
+// `a` from colliding with a routine in database `a\x00b` (database/name both lower-cased).
+func routineEntries(c *Catalog, isProcedure bool) map[string]routineRef {
+	m := make(map[string]routineRef)
+	if c == nil {
+		return m
+	}
+	for _, db := range c.Databases() {
+		routineMap := db.Functions
+		if isProcedure {
+			routineMap = db.Procedures
+		}
+		for _, r := range routineMap {
+			if r == nil {
+				continue
+			}
+			key := toLower(db.Name) + "\x00" + toLower(r.Name)
+			m[key] = routineRef{dbName: db.Name, routine: r}
+		}
+	}
+	return m
+}
+
+// routinesChanged reports whether two same-identity routines differ, comparing their canonical
+// keys (the MySQL analog of PG's per-object change check). canonicalRoutine folds every
+// stored-form-significant attribute into one collision-free key, so this differ never
+// re-implements a per-attribute comparison.
+func routinesChanged(a, b *Routine, n *Normalizer) bool {
+	return canonicalRoutine(a, n) != canonicalRoutine(b, n)
+}
+
+// canonicalRoutine returns a single stable comparison key for a routine, folding the attributes
+// that survive into MySQL's stored form. The comparison is whole-routine: MySQL has no
+// CREATE OR REPLACE and no ALTER for a routine's body/params/RETURNS, so any change to those is a
+// DROP+CREATE (migration_routine.go decides DROP+CREATE vs the characteristic-only ALTER).
 //
-// implemented by omni:routine breadth node
-func diffProcedures(_, _ *Catalog, _ *Normalizer) []RoutineDiffEntry {
-	// Scaffold: returns nil so the procedure diff stays empty (self-diff inert).
-	return nil
+// Folded fields and their oracle grounding (probed on live 5.7 :13307 and 8.0 :13306):
+//   - params: direction + name + type, in order. The type strings are taken verbatim from the
+//     loader (routinecmds.go formatParamType), which renders the same form the engine stores —
+//     so a 5.7 `int(11)` vs 8.0 `int` divergence is already baked into each side's loaded value
+//     and never cross-compared (Diff is always single-version). Order is significant.
+//   - returns (functions only): the RETURNS type string, likewise loader-rendered.
+//   - body: the routine body is stored BYTE-FOR-BYTE verbatim by the engine (internal
+//     whitespace, tabs, blank lines all preserved — verified), and the loader stores
+//     strings.TrimSpace(BodyText), so two routines with the same source body have identical Body.
+//     Compared as an opaque string.
+//   - characteristics: DEFAULT-FOLDED via canonicalRoutineCharacteristics — a missing or
+//     explicitly-default characteristic collapses to its canonical default, because SHOW CREATE
+//     DROPS default characteristics (CONTAINS SQL, SQL SECURITY DEFINER, NOT DETERMINISTIC are all
+//     omitted from the readback — verified). Without this fold a user form that spells out a
+//     default would phantom-diff against the readback that omits it.
+//
+// NOT folded (deliberately): DEFINER (environment, see diffFunctions) and LANGUAGE (always SQL,
+// never echoed distinctly by SHOW CREATE — verified — so it carries no stored-form signal).
+func canonicalRoutine(r *Routine, n *Normalizer) string {
+	if r == nil {
+		return ""
+	}
+	params := make([]string, 0, len(r.Params))
+	for _, p := range r.Params {
+		params = append(params, canonicalRoutineParam(p, n))
+	}
+	return encodeKeyFields(
+		"isproc", boolKey(r.IsProcedure),
+		"params", strings.Join(params, ","),
+		"returns", canonicalRoutineReturns(r, n),
+		"chars", canonicalRoutineCharacteristics(r, n),
+		"body", r.Body,
+	)
+}
+
+// canonicalRoutineParam encodes one routine parameter: direction (procedures only), name
+// (lower-cased — MySQL parameter names are case-insensitive identifiers), and type. The type is
+// Direction is folded to upper-case; an empty direction (function param, or a procedure IN that
+// the user omitted) collapses to "IN" — MySQL's default parameter direction — so `p(x INT)` and
+// `p(IN x INT)` compare equal.
+//
+// The TYPE is canonicalized the SAME way as the RETURNS type (canonicalRoutineType), NOT by a flat
+// strings.ToUpper of the whole string: upper-casing the entire type would fold ENUM/SET member
+// VALUES too (collapsing ENUM('a','b') and ENUM('A','b')), making a legitimate member-case change
+// invisible to the differ — the comparison-side mirror of the render-side corruption. Routing
+// through parseColumnType + canonicalType (→ canonicalEnumSuffix) keeps the keyword case-stable
+// while preserving member-value case, matching the column path.
+func canonicalRoutineParam(p *RoutineParam, n *Normalizer) string {
+	if p == nil {
+		return ""
+	}
+	dir := strings.ToUpper(strings.TrimSpace(p.Direction))
+	if dir == "" {
+		dir = "IN"
+	}
+	return encodeKeyFields(
+		"dir", dir,
+		"name", toLower(p.Name),
+		"type", canonicalRoutineType(p.TypeName, n),
+	)
+}
+
+// canonicalRoutineType canonicalizes a routine parameter/return type string: the base type goes
+// through normalize-core's parseColumnType + canonicalType (folding int display width, aliases,
+// decimal precision, and — crucially — preserving ENUM/SET member-value case via
+// canonicalEnumSuffix), and any "CHARSET <cs> [COLLATE <coll>]" suffix is split off and re-appended
+// lower-cased. This is the single type-key builder shared by params and RETURNS, so both compare a
+// type the same case-correct way.
+func canonicalRoutineType(typeStr string, n *Normalizer) string {
+	base, suffix := splitRoutineTypeCharset(typeStr)
+	if strings.TrimSpace(base) == "" {
+		return suffix
+	}
+	canonical := n.canonicalType(parseColumnType(base))
+	if suffix != "" {
+		canonical += " " + suffix
+	}
+	return canonical
+}
+
+// canonicalRoutineReturns returns the canonical RETURNS-type key for a function, "" for a
+// procedure (procedures have no RETURNS).
+//
+// Unlike the PARAMETER list — which SHOW CREATE stores VERBATIM as the user typed it, identically
+// on 5.7 and 8.0 (verified: a param `b INT(11)` reads back `b INT(11)` on both, so params need no
+// version folding) — the RETURNS type IS rendered in the engine's version-canonical form: 5.7
+// shows `RETURNS int(11)`, 8.0 shows `RETURNS int` (the same integer-display-width divergence
+// columns have). So a user form `RETURNS INT` must canonicalize equal to a 5.7 readback's
+// `RETURNS int(11)`. The base type is therefore routed through normalize-core's type canonicalizer
+// (parseColumnType + canonicalType — the SAME int-width / alias / decimal-precision rules
+// CanonicalColumnType uses), NOT compared as a raw string.
+//
+// The CHARSET/COLLATE suffix (the loader appends "CHARSET <cs>" for string return types, matching
+// SHOW CREATE) is split off, lower-cased, and re-appended so it still participates in the key
+// (an 8.0 `CHARSET utf8mb4` return differs from a 5.7 `CHARSET latin1` one). Both sides are loaded
+// the same way per version, so an identical function self-compares equal.
+func canonicalRoutineReturns(r *Routine, n *Normalizer) string {
+	if r.IsProcedure || strings.TrimSpace(r.Returns) == "" {
+		return ""
+	}
+	return canonicalRoutineType(r.Returns, n)
+}
+
+// splitRoutineTypeCharset separates a routine type string into its base type and a normalized
+// "CHARSET <cs> [COLLATE <coll>]" suffix (lower-cased keyword, lower-cased charset/collation). The
+// loader renders string return types as e.g. "varchar(100) CHARSET utf8mb4"; the base
+// ("varchar(100)") goes through the type canonicalizer while the charset rides along as a stable
+// key fragment. A type with no CHARSET/COLLATE returns (type, "").
+//
+// The CHARSET/COLLATE clause always follows the base type and any parenthesized argument list, so
+// the search starts AFTER the last ')'. This prevents mis-splitting a type whose ENUM/SET member
+// literal contains the substring " charset "/" collate " (e.g. enum('x charset y')) — the member
+// text lives inside the parentheses, before the search window.
+func splitRoutineTypeCharset(typeStr string) (base, suffix string) {
+	s := strings.TrimSpace(typeStr)
+	// Search for the suffix keyword only past any member/argument list.
+	searchFrom := strings.LastIndexByte(s, ')') + 1 // 0 when there is no ')'
+	low := strings.ToLower(s)
+	rel := strings.Index(low[searchFrom:], " charset ")
+	if rel < 0 {
+		// COLLATE may appear without an explicit CHARSET in rare forms; handle it too.
+		rel = strings.Index(low[searchFrom:], " collate ")
+		if rel < 0 {
+			return s, ""
+		}
+	}
+	idx := searchFrom + rel
+	base = strings.TrimSpace(s[:idx])
+	// Normalize the suffix: collapse internal whitespace and lower-case keywords + values.
+	suffix = strings.Join(strings.Fields(strings.ToLower(s[idx:])), " ")
+	return base, suffix
+}
+
+// canonicalRoutineCharacteristics builds the default-folded characteristics key. The four
+// in-scope characteristics are each collapsed to a canonical value, defaulting a missing key to
+// MySQL's default (verified: SHOW CREATE omits defaults), so a user form that states a default
+// and the readback that drops it produce the same key:
+//   - DETERMINISTIC: "YES" | "NO"; missing → "NO" (NOT DETERMINISTIC is the default).
+//   - DATA ACCESS: one of CONTAINS SQL | NO SQL | READS SQL DATA | MODIFIES SQL DATA; missing →
+//     "CONTAINS SQL" (the default, which SHOW CREATE never echoes).
+//   - SQL SECURITY: "DEFINER" | "INVOKER" (upper-cased); missing → "DEFINER" (the default).
+//   - COMMENT: the comment content (decoded by the loader; routed through CanonicalComment);
+//     missing → "".
+//
+// LANGUAGE is intentionally absent (always SQL, no stored-form signal).
+func canonicalRoutineCharacteristics(r *Routine, n *Normalizer) string {
+	det := r.Characteristics["DETERMINISTIC"]
+	if det == "" {
+		det = "NO"
+	}
+	dataAccess := r.Characteristics["DATA ACCESS"]
+	if dataAccess == "" {
+		dataAccess = "CONTAINS SQL"
+	}
+	security := strings.ToUpper(strings.TrimSpace(r.Characteristics["SQL SECURITY"]))
+	if security == "" {
+		security = "DEFINER"
+	}
+	comment := n.CanonicalComment(r.Characteristics["COMMENT"])
+	return encodeKeyFields(
+		"det", strings.ToUpper(det),
+		"data", strings.ToUpper(strings.TrimSpace(dataAccess)),
+		"sec", security,
+		"comment", comment,
+	)
+}
+
+// routineAlterSuffices reports whether a routine MODIFY can be applied with ALTER
+// FUNCTION/PROCEDURE alone, rather than DROP+CREATE. ALTER can change ONLY the characteristics
+// SQL SECURITY, COMMENT, and DATA ACCESS (verified against both live engines: ALTER accepts
+// COMMENT / SQL SECURITY / {CONTAINS SQL|NO SQL|READS SQL DATA|MODIFIES SQL DATA} / LANGUAGE SQL,
+// and REJECTS DETERMINISTIC with a syntax error). So ALTER suffices iff the routines are equal
+// EXCEPT for those three characteristics — i.e. params, RETURNS, body, and DETERMINISTIC are all
+// unchanged. Anything else requires DROP+CREATE (no CREATE OR REPLACE in MySQL).
+//
+// Implemented as: equal once SQL SECURITY / COMMENT / DATA ACCESS are masked out of BOTH canonical
+// keys. If the masked keys are equal, every remaining (DROP+CREATE-only) field already matched, so
+// the only differences live in the ALTER-able set.
+func routineAlterSuffices(from, to *Routine, n *Normalizer) bool {
+	return canonicalRoutineExceptAlterable(from, n) == canonicalRoutineExceptAlterable(to, n)
+}
+
+// canonicalRoutineExceptAlterable is canonicalRoutine with the ALTER-able characteristics
+// (SQL SECURITY, COMMENT, DATA ACCESS) removed, leaving only the DROP+CREATE-significant fields
+// (params, RETURNS, body, DETERMINISTIC). Two routines that differ only in ALTER-able
+// characteristics share this key.
+func canonicalRoutineExceptAlterable(r *Routine, n *Normalizer) string {
+	if r == nil {
+		return ""
+	}
+	params := make([]string, 0, len(r.Params))
+	for _, p := range r.Params {
+		params = append(params, canonicalRoutineParam(p, n))
+	}
+	det := r.Characteristics["DETERMINISTIC"]
+	if det == "" {
+		det = "NO"
+	}
+	return encodeKeyFields(
+		"isproc", boolKey(r.IsProcedure),
+		"params", strings.Join(params, ","),
+		"returns", canonicalRoutineReturns(r, n),
+		"det", strings.ToUpper(det),
+		"body", r.Body,
+	)
+}
+
+// boolKey renders a bool as a stable single-char key fragment.
+func boolKey(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
 }

--- a/mysql/catalog/diff_routine_test.go
+++ b/mysql/catalog/diff_routine_test.go
@@ -1,0 +1,341 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the routine (function + procedure) differ (correctness-protocol.md
+// gate 1: idempotence), against the LIVE MySQL engines (5.7 :13307, 8.0 :13306). Two
+// properties are proven mechanically for every routine FORM:
+//
+//  1. Idempotence (the spine): a routine in its real stored form (the engine's own SHOW
+//     CREATE FUNCTION/PROCEDURE readback, reloaded into a catalog) self-diffs empty —
+//     Diff(c, c).IsEmpty().
+//  2. Canonicalization-driven empties: a routine written in a USER form (explicit default
+//     characteristics that SHOW CREATE drops, varied whitespace) diffed against the engine's
+//     STORED form of the same routine must be EMPTY. This proves the differ folds defaults
+//     (CONTAINS SQL, SQL SECURITY DEFINER, NOT DETERMINISTIC) and compares the body opaquely —
+//     if it compared surface tokens these would phantom-diff forever.
+//
+// Both sides are loaded under the SAME database name (routineProbeDB) so identity matches the
+// single-database release path; the harness reuses connectOracle / serverCharsetFor / both()
+// from the diff + normalize oracle tests and skips cleanly when the engines are unreachable.
+
+const routineProbeDB = "rtn_idem"
+
+// routineProbe is one idempotence/canonicalization case: a routine DDL whose engine-stored form
+// may differ from the user form but must canonicalize equal. kind is "FUNCTION"/"PROCEDURE".
+type routineProbe struct {
+	id       string
+	kind     string
+	name     string
+	create   string // bare CREATE FUNCTION/PROCEDURE (no DEFINER, no leading CREATE DATABASE)
+	versions []Version
+}
+
+// routineIdempotenceProbes enumerates representative routine FORMS that must round-trip empty.
+// Functions on 8.0 must declare DETERMINISTIC / NO SQL / READS SQL DATA (the box has
+// log_bin_trust_function_creators off, so a non-deterministic CONTAINS-SQL function is rejected
+// at CREATE — error 1418); each function probe satisfies that. Procedures have no such rule.
+func routineIdempotenceProbes() []routineProbe {
+	return []routineProbe{
+		// ---- functions ----
+		{"fn-simple", "FUNCTION", "f", "CREATE FUNCTION f(a INT, b INT) RETURNS INT DETERMINISTIC RETURN a + b", both()},
+		{"fn-string-return", "FUNCTION", "f", "CREATE FUNCTION f(s VARCHAR(50)) RETURNS VARCHAR(100) DETERMINISTIC RETURN CONCAT(s, s)", both()},
+		{"fn-all-characteristics", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC READS SQL DATA SQL SECURITY INVOKER COMMENT 'hi' RETURN a", both()},
+		{"fn-no-sql", "FUNCTION", "f", "CREATE FUNCTION f() RETURNS INT NO SQL RETURN 42", both()},
+		{"fn-modifies", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC MODIFIES SQL DATA RETURN a", both()},
+		// Explicit-default characteristics the readback DROPS — must still canonicalize empty.
+		{"fn-explicit-defaults", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC CONTAINS SQL SQL SECURITY DEFINER RETURN a", both()},
+		// LANGUAGE SQL is never echoed distinctly — must not phantom-diff.
+		{"fn-language-sql", "FUNCTION", "f", "CREATE FUNCTION f() RETURNS INT LANGUAGE SQL DETERMINISTIC RETURN 7", both()},
+		// Multi-statement BEGIN...END body with internal whitespace (stored verbatim).
+		{"fn-begin-body", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC\nBEGIN\n  DECLARE r INT;\n  SET r = a * 2;\n  RETURN r;\nEND", both()},
+		// Comment with an embedded single quote (escaping round-trip).
+		{"fn-comment-quote", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'it''s here' RETURN a", both()},
+		// Comment with an embedded backslash: the engine echoes it backslash-escaped and the loader
+		// decodes it back consistently, so the no-op diff stays empty (guards against an
+		// escape-asymmetry idempotence break).
+		{"fn-comment-backslash", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'a\\\\b' RETURN a", both()},
+		// DECIMAL RETURNS: precision/scale padding via the type canonicalizer.
+		{"fn-decimal-return", "FUNCTION", "f", "CREATE FUNCTION f(a DECIMAL(10,2)) RETURNS DECIMAL(10,2) DETERMINISTIC RETURN a", both()},
+		// ENUM RETURNS + ENUM/SET params: the member list must survive the load (was dropped before
+		// the formatDataType fix) so the type round-trips.
+		{"fn-enum-return", "FUNCTION", "f", "CREATE FUNCTION f() RETURNS ENUM('a','b','c') DETERMINISTIC RETURN 'a'", both()},
+		{"proc-enum-set-params", "PROCEDURE", "p", "CREATE PROCEDURE p(IN s SET('x','y'), IN e ENUM('p','q')) BEGIN SET @v = s; END", both()},
+		// Reserved-word parameter name (must be backtick-quoted in the rendered CREATE).
+		{"proc-reserved-param", "PROCEDURE", "p", "CREATE PROCEDURE p(IN `select` INT, IN `from` INT) BEGIN SET @v = `select`; END", both()},
+
+		// ---- procedures ----
+		{"proc-in-out-inout", "PROCEDURE", "p", "CREATE PROCEDURE p(IN x INT, OUT y INT, INOUT z INT) BEGIN SET y = x + z; SET z = z + 1; END", both()},
+		{"proc-no-params", "PROCEDURE", "p", "CREATE PROCEDURE p() BEGIN DECLARE n INT; SET n = 1; END", both()},
+		{"proc-modifies", "PROCEDURE", "p", "CREATE PROCEDURE p() MODIFIES SQL DATA BEGIN SET @v = 1; END", both()},
+		{"proc-default-in-direction", "PROCEDURE", "p", "CREATE PROCEDURE p(x INT, y INT) BEGIN SET @v = x + y; END", both()},
+		{"proc-all-characteristics", "PROCEDURE", "p", "CREATE PROCEDURE p(IN a INT) DETERMINISTIC READS SQL DATA SQL SECURITY INVOKER COMMENT 'pc' BEGIN SET @v = a; END", both()},
+		{"proc-explicit-defaults", "PROCEDURE", "p", "CREATE PROCEDURE p(IN a INT) NOT DETERMINISTIC CONTAINS SQL SQL SECURITY DEFINER BEGIN SET @v = a; END", both()},
+	}
+}
+
+// loadRoutineReadback applies a CREATE FUNCTION/PROCEDURE in a throwaway database, reads back its
+// SHOW CREATE form (the engine's canonical stored form), and reloads it into a catalog under
+// dbName. It returns the catalog + the routine's authentic stored DDL.
+func (o *oracleConn) loadRoutineReadback(t *testing.T, dbName, createSQL, kind, name string) (*Catalog, string, bool) {
+	t.Helper()
+	ctx := context.Background()
+	sc := serverCharsetFor(o.version)
+	stmts := []string{
+		"DROP DATABASE IF EXISTS " + dbName,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, sc),
+		"USE " + dbName,
+		createSQL,
+	}
+	for _, s := range stmts {
+		if _, err := o.db.ExecContext(ctx, s); err != nil {
+			t.Logf("[%s] exec failed (may be expected): %q: %v", o.name, s, err)
+			return nil, "", false
+		}
+	}
+	rb, ok := o.showCreateRoutine(t, dbName, kind, name)
+	if !ok {
+		return nil, "", false
+	}
+	wrapped := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s", dbName, sc, dbName, rb)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("[%s] reload of routine readback failed: %v\n%s", o.name, err, wrapped)
+	}
+	return cat, rb, true
+}
+
+// showCreateRoutine runs SHOW CREATE FUNCTION/PROCEDURE and returns the create DDL column. The
+// statement returns six columns (Name, sql_mode, Create <kind>, character_set_client,
+// collation_connection, Database Collation); only the third (the DDL) is needed.
+func (o *oracleConn) showCreateRoutine(t *testing.T, dbName, kind, name string) (string, bool) {
+	t.Helper()
+	var c1, c2, c3, c4, c5, c6 sql.NullString
+	row := o.db.QueryRowContext(context.Background(), fmt.Sprintf("SHOW CREATE %s %s.%s", kind, dbName, name))
+	if err := row.Scan(&c1, &c2, &c3, &c4, &c5, &c6); err != nil {
+		t.Logf("[%s] SHOW CREATE %s %s.%s failed: %v", o.name, kind, dbName, name, err)
+		return "", false
+	}
+	return c3.String, true
+}
+
+// TestOracle_RoutineDiffIdempotence proves gate 1 & 2 for every routine form: the user DDL vs its
+// engine readback diffs EMPTY, and the stored form self-diffs empty, on every supported version.
+func TestOracle_RoutineDiffIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		sc := serverCharsetFor(version)
+		for _, probe := range routineIdempotenceProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := routineProbeDB + "_" + strings.ReplaceAll(probe.id, "-", "_")
+				storedCat, rb, ok := o.loadRoutineReadback(t, db, probe.create, probe.kind, probe.name)
+				if !ok {
+					t.Skipf("[%s] could not obtain readback for %s", o.name, probe.id)
+				}
+
+				// Idempotence spine: the stored form self-diffs empty.
+				if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] IDEMPOTENCE: self-diff of stored form not empty for %s:\n  stored: %s\n  diff: %s",
+						o.name, probe.id, strings.TrimSpace(rb), describeRoutineDiff(d))
+				}
+
+				// Canonicalization: the USER form vs the engine STORED form must collapse to empty.
+				userWrapped := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s", db, sc, db, probe.create)
+				userCat, err := LoadSQL(userWrapped)
+				if err != nil {
+					t.Fatalf("[%s] user-form load failed for %s: %v", o.name, probe.id, err)
+				}
+				if d := DiffWithNormalizer(userCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] user-form self-diff not empty for %s: %s", o.name, probe.id, describeRoutineDiff(d))
+				}
+				if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION: user vs stored not empty for %s:\n  user:   %s\n  stored: %s\n  diff: %s",
+						o.name, probe.id, strings.TrimSpace(probe.create), strings.TrimSpace(rb), describeRoutineDiff(d))
+				}
+				// Symmetry: stored vs user must also be empty (Drop/Add are direction-sensitive).
+				if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION (reverse): stored vs user not empty for %s: %s",
+						o.name, probe.id, describeRoutineDiff(d))
+				}
+			})
+		}
+	}
+}
+
+// TestRoutineDiffActions is a hermetic (no-oracle) check that the differ reports the right
+// DiffAction for in-memory routine catalogs: add, drop, modify (body), and no-op for an identical
+// pair. It pins the structural behavior independent of a live engine.
+func TestRoutineDiffActions(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	load := func(t *testing.T, ddl string) *Catalog {
+		t.Helper()
+		cat, err := LoadSQL("CREATE DATABASE d DEFAULT CHARSET=utf8mb4;\nUSE d;\n" + ddl)
+		if err != nil {
+			t.Fatalf("load %q: %v", ddl, err)
+		}
+		return cat
+	}
+
+	base := "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a"
+
+	t.Run("identical-empty", func(t *testing.T) {
+		from := load(t, base)
+		to := load(t, base)
+		if d := DiffWithNormalizer(from, to, n); !d.IsEmpty() {
+			t.Fatalf("identical routines diff not empty: %s", describeRoutineDiff(d))
+		}
+	})
+	t.Run("add", func(t *testing.T) {
+		from := load(t, "CREATE FUNCTION other() RETURNS INT DETERMINISTIC RETURN 1")
+		to := load(t, "CREATE FUNCTION other() RETURNS INT DETERMINISTIC RETURN 1;\n"+base)
+		d := DiffWithNormalizer(from, to, n)
+		if len(d.Functions) != 1 || d.Functions[0].Action != DiffAdd || d.Functions[0].Name != "f" {
+			t.Fatalf("want one ADD of f, got %s", describeRoutineDiff(d))
+		}
+	})
+	t.Run("drop", func(t *testing.T) {
+		from := load(t, base)
+		to := load(t, "CREATE FUNCTION g() RETURNS INT DETERMINISTIC RETURN 1")
+		d := DiffWithNormalizer(from, to, n)
+		// f dropped, g added.
+		var dropF bool
+		for _, e := range d.Functions {
+			if e.Action == DiffDrop && e.Name == "f" {
+				dropF = true
+			}
+		}
+		if !dropF {
+			t.Fatalf("want DROP of f, got %s", describeRoutineDiff(d))
+		}
+	})
+	t.Run("modify-body", func(t *testing.T) {
+		from := load(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 1")
+		to := load(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 2")
+		d := DiffWithNormalizer(from, to, n)
+		if len(d.Functions) != 1 || d.Functions[0].Action != DiffModify {
+			t.Fatalf("want one MODIFY of f, got %s", describeRoutineDiff(d))
+		}
+	})
+	t.Run("function-and-procedure-same-name-distinct", func(t *testing.T) {
+		// A function `x` and a procedure `x` are different objects; adding the procedure must not
+		// be seen as modifying the function.
+		from := load(t, "CREATE FUNCTION x() RETURNS INT DETERMINISTIC RETURN 1")
+		to := load(t, "CREATE FUNCTION x() RETURNS INT DETERMINISTIC RETURN 1;\nCREATE PROCEDURE x() BEGIN SET @v = 1; END")
+		d := DiffWithNormalizer(from, to, n)
+		if len(d.Functions) != 0 {
+			t.Fatalf("function x should be unchanged, got %s", describeRoutineDiff(d))
+		}
+		if len(d.Procedures) != 1 || d.Procedures[0].Action != DiffAdd {
+			t.Fatalf("want one ADD procedure x, got %s", describeRoutineDiff(d))
+		}
+	})
+	t.Run("modify-comment-only-alter-suffices", func(t *testing.T) {
+		from := load(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'old' RETURN a")
+		to := load(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'new' RETURN a")
+		d := DiffWithNormalizer(from, to, n)
+		if len(d.Functions) != 1 || d.Functions[0].Action != DiffModify {
+			t.Fatalf("want MODIFY, got %s", describeRoutineDiff(d))
+		}
+		if !routineAlterSuffices(d.Functions[0].From, d.Functions[0].To, n) {
+			t.Fatalf("comment-only change should be ALTER-able")
+		}
+		// And the generated plan must be a single ALTER, not DROP+CREATE.
+		plan := GenerateMigrationWithNormalizer(from, to, d, n)
+		if len(plan.Ops) != 1 || !strings.HasPrefix(plan.Ops[0].SQL, "ALTER FUNCTION") {
+			t.Fatalf("want single ALTER FUNCTION, got plan:\n%s", plan.SQL())
+		}
+	})
+	t.Run("enum-return-renders-members-and-self-diffs-empty", func(t *testing.T) {
+		// The ENUM member list must survive load and render in the generated CREATE (else invalid
+		// DDL). Self-diff empty proves the loaded form is stable; the rendered CREATE must carry
+		// the members.
+		from := load(t, "CREATE FUNCTION f() RETURNS ENUM('a','b','c') DETERMINISTIC RETURN 'a'")
+		if d := DiffWithNormalizer(from, from, n); !d.IsEmpty() {
+			t.Fatalf("enum-return self-diff not empty: %s", describeRoutineDiff(d))
+		}
+		plan := GenerateMigrationWithNormalizer(New(), from, DiffWithNormalizer(New(), from, n), n)
+		if !strings.Contains(plan.SQL(), "enum('a','b','c')") {
+			t.Fatalf("rendered CREATE dropped enum members:\n%s", plan.SQL())
+		}
+	})
+	t.Run("reserved-param-name-is-quoted", func(t *testing.T) {
+		from := load(t, "CREATE PROCEDURE p(IN `select` INT) BEGIN SET @v = `select`; END")
+		plan := GenerateMigrationWithNormalizer(New(), from, DiffWithNormalizer(New(), from, n), n)
+		if !strings.Contains(plan.SQL(), "`select`") {
+			t.Fatalf("reserved param name not backtick-quoted in rendered CREATE:\n%s", plan.SQL())
+		}
+	})
+	t.Run("procedure-implicit-in-equals-explicit-in", func(t *testing.T) {
+		// `p(x INT)` and `p(IN x INT)` are the SAME procedure (IN is the default direction); the
+		// differ must treat them as equal (no spurious DROP+CREATE on a cosmetic direction keyword).
+		from := load(t, "CREATE PROCEDURE p(x INT) BEGIN SET @v = x; END")
+		to := load(t, "CREATE PROCEDURE p(IN x INT) BEGIN SET @v = x; END")
+		if d := DiffWithNormalizer(from, to, n); !d.IsEmpty() {
+			t.Fatalf("implicit-IN vs explicit-IN should be equal, got %s", describeRoutineDiff(d))
+		}
+	})
+	t.Run("param-enum-member-case-change-detected", func(t *testing.T) {
+		// A case-only ENUM member change in a parameter is a real domain change and MUST be
+		// detected (the differ must not fold member case). Guards the comparison-side mirror of the
+		// render-side member-case fix.
+		from := load(t, "CREATE PROCEDURE p(IN e ENUM('a','b')) BEGIN SET @v = e; END")
+		to := load(t, "CREATE PROCEDURE p(IN e ENUM('A','b')) BEGIN SET @v = e; END")
+		d := DiffWithNormalizer(from, to, n)
+		if len(d.Procedures) != 1 || d.Procedures[0].Action != DiffModify {
+			t.Fatalf("enum-member-case param change must be a MODIFY, got %s", describeRoutineDiff(d))
+		}
+		// A param-type change is not ALTER-able → DROP+CREATE.
+		if routineAlterSuffices(d.Procedures[0].From, d.Procedures[0].To, n) {
+			t.Fatalf("param type change must NOT be ALTER-able")
+		}
+	})
+	t.Run("modify-deterministic-requires-dropcreate", func(t *testing.T) {
+		from := load(t, "CREATE FUNCTION f(a INT) RETURNS INT NOT DETERMINISTIC READS SQL DATA RETURN a")
+		to := load(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC READS SQL DATA RETURN a")
+		d := DiffWithNormalizer(from, to, n)
+		if len(d.Functions) != 1 {
+			t.Fatalf("want one function diff, got %s", describeRoutineDiff(d))
+		}
+		if routineAlterSuffices(d.Functions[0].From, d.Functions[0].To, n) {
+			t.Fatalf("DETERMINISTIC change must NOT be ALTER-able")
+		}
+		plan := GenerateMigrationWithNormalizer(from, to, d, n)
+		if len(plan.Ops) != 2 {
+			t.Fatalf("want DROP+CREATE (2 ops), got:\n%s", plan.SQL())
+		}
+		if plan.Ops[0].Type != OpDropFunction || plan.Ops[1].Type != OpCreateFunction {
+			t.Fatalf("want DROP then CREATE, got %v then %v", plan.Ops[0].Type, plan.Ops[1].Type)
+		}
+	})
+}
+
+// describeRoutineDiff renders a compact human description of the routine slices of a SchemaDiff.
+func describeRoutineDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, e := range d.Functions {
+		fmt.Fprintf(&b, "[fn %s.%s %s]", e.Database, e.Name, e.Action)
+	}
+	for _, e := range d.Procedures {
+		fmt.Fprintf(&b, "[proc %s.%s %s]", e.Database, e.Name, e.Action)
+	}
+	if b.Len() == 0 {
+		// Fall back to the table description so a stray table diff is visible too.
+		return describeDiff(d)
+	}
+	return b.String()
+}

--- a/mysql/catalog/migration_routine.go
+++ b/mysql/catalog/migration_routine.go
@@ -1,16 +1,273 @@
 package catalog
 
-// MySQL SDL generate — stored routines (functions + procedures) (scaffold stub).
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — stored routines (functions + procedures).
 //
-// A single generate hook covers both routine kinds: wired into
-// GenerateMigrationWithNormalizer (migration.go), it consumes BOTH SchemaDiff.Functions and
-// SchemaDiff.Procedures and emits the CREATE/DROP FUNCTION|PROCEDURE ops
-// (OpCreateFunction/OpDropFunction/OpCreateProcedure/OpDropProcedure, priorityRoutine).
-// Inert no-op placeholder returning nil until the routine breadth node implements it.
-// Signature mirrors generateTableDDL (migration_table.go).
+// This is the MySQL analog of PG's generateFunctionDDL (pg/catalog/migration_function.go). A
+// single generate hook covers both routine kinds: wired into GenerateMigrationWithNormalizer
+// (migration.go), it consumes BOTH SchemaDiff.Functions and SchemaDiff.Procedures and emits the
+// CREATE / DROP / ALTER ops (OpCreateFunction / OpDropFunction / OpCreateProcedure /
+// OpDropProcedure, priorityRoutine).
 //
-// implemented by omni:routine breadth node
-func generateRoutineDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no routine ops (empty diff -> empty plan).
+// MySQL has NO `CREATE OR REPLACE` and NO `ALTER` for a routine's body/params/RETURNS. So a
+// change to any of those is a DROP followed by a CREATE. `ALTER FUNCTION/PROCEDURE` can change
+// ONLY the characteristics SQL SECURITY, COMMENT, and DATA ACCESS (verified on both live
+// engines — DETERMINISTIC is NOT alterable). diff_routine.go's routineAlterSuffices decides
+// which path a MODIFY takes; this generator renders it:
+//   - DiffAdd                       → CREATE.
+//   - DiffDrop                      → DROP.
+//   - DiffModify, ALTER suffices    → ALTER (one statement, the changed characteristics).
+//   - DiffModify, ALTER insufficient → DROP + CREATE.
+//
+// Ordering (mirrors the index node's drop-before-add discipline): DROPs run in PhasePre, CREATEs
+// and ALTERs in PhaseMain, both at priorityRoutine. So a MODIFY's DROP (PhasePre) always precedes
+// its CREATE (PhaseMain) — the name is free for re-creation — and a routine dropped in one place
+// and created in another never reverses. sortMigrationOps re-imposes the global phase/priority/
+// name order.
+//
+// Rendering routes through the same form SHOW CREATE uses (showCreateRoutineBody), MINUS the
+// DEFINER clause: DEFINER is ignored in the diff (it is environment, not schema-as-code), so the
+// emitted CREATE must NOT pin a definer — a DEFINER-less CREATE adopts CURRENT_USER on apply,
+// which is the correct release behavior and avoids requiring SET_USER_ID/SUPER for an account the
+// user never named. Because the body/params/characteristics are rendered in the engine's stored
+// form, the readback of the emitted CREATE canonicalizes equal to `to` and apply-correctness holds.
+func generateRoutineDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	if diff == nil {
+		return nil
+	}
+	var ops []MigrationOp
+	for i := range diff.Functions {
+		ops = append(ops, routineOps(&diff.Functions[i], n)...)
+	}
+	for i := range diff.Procedures {
+		ops = append(ops, routineOps(&diff.Procedures[i], n)...)
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Phase != ops[j].Phase {
+			return ops[i].Phase < ops[j].Phase
+		}
+		return ops[i].sortName < ops[j].sortName
+	})
+	return ops
+}
+
+// routineOps renders the ops for a single routine diff entry, choosing CREATE / DROP / ALTER /
+// DROP+CREATE per the entry's action and the ALTER-suffices test.
+func routineOps(e *RoutineDiffEntry, n *Normalizer) []MigrationOp {
+	switch e.Action {
+	case DiffAdd:
+		if e.To == nil {
+			return nil
+		}
+		return []MigrationOp{createRoutineOp(e, e.To, n)}
+	case DiffDrop:
+		if e.From == nil {
+			return nil
+		}
+		return []MigrationOp{dropRoutineOp(e, e.From)}
+	case DiffModify:
+		if e.From == nil || e.To == nil {
+			return nil
+		}
+		if routineAlterSuffices(e.From, e.To, n) {
+			return []MigrationOp{alterRoutineOp(e, e.To)}
+		}
+		// Body/params/RETURNS/DETERMINISTIC changed → DROP (PhasePre) then CREATE (PhaseMain).
+		return []MigrationOp{dropRoutineOp(e, e.From), createRoutineOp(e, e.To, n)}
+	}
 	return nil
+}
+
+// createRoutineOp builds a CREATE FUNCTION/PROCEDURE op (PhaseMain). The SQL is the DEFINER-less
+// stored form (see the file doc).
+func createRoutineOp(e *RoutineDiffEntry, r *Routine, n *Normalizer) MigrationOp {
+	return MigrationOp{
+		Type:       createRoutineOpType(e.IsProcedure),
+		Database:   e.Database,
+		ObjectName: e.Name,
+		SQL:        renderCreateRoutine(e.Database, r, n),
+		Phase:      PhaseMain,
+		Priority:   priorityRoutine,
+		sortName:   routineSortName(e.Database, e.Name),
+	}
+}
+
+// dropRoutineOp builds a DROP FUNCTION/PROCEDURE op (PhasePre, so it precedes any re-CREATE in
+// the same plan). IF EXISTS is NOT used: the diff already established the routine is present in
+// `from`, and an unconditional DROP keeps the emitted DDL minimal and explicit (matching the
+// table node's DROP TABLE, which is likewise unconditional).
+func dropRoutineOp(e *RoutineDiffEntry, r *Routine) MigrationOp {
+	kw := "FUNCTION"
+	if e.IsProcedure {
+		kw = "PROCEDURE"
+	}
+	return MigrationOp{
+		Type:       dropRoutineOpType(e.IsProcedure),
+		Database:   e.Database,
+		ObjectName: e.Name,
+		SQL:        fmt.Sprintf("DROP %s %s", kw, routineIdent(e.Database, r.Name)),
+		Phase:      PhasePre,
+		Priority:   priorityRoutine,
+		sortName:   routineSortName(e.Database, e.Name),
+	}
+}
+
+// alterRoutineOp builds an ALTER FUNCTION/PROCEDURE op carrying the routine's full ALTER-able
+// characteristic set (DATA ACCESS, SQL SECURITY, COMMENT) in their canonical default-folded
+// form. It re-states ALL three (not just the changed ones): re-applying a characteristic to its
+// existing value is a harmless no-op, and emitting the whole set keeps the op self-contained and
+// order-independent of what the synced side held. The op runs in PhaseMain at priorityRoutine.
+//
+// ALTER is chosen only when routineAlterSuffices(from, to) held — i.e. params, RETURNS, body, and
+// DETERMINISTIC are unchanged — so this never needs to touch a DROP+CREATE-only attribute.
+func alterRoutineOp(e *RoutineDiffEntry, to *Routine) MigrationOp {
+	kw := "FUNCTION"
+	if e.IsProcedure {
+		kw = "PROCEDURE"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "ALTER %s %s", kw, routineIdent(e.Database, to.Name))
+	for _, clause := range routineAlterableCharacteristicClauses(to) {
+		b.WriteString(" ")
+		b.WriteString(clause)
+	}
+	return MigrationOp{
+		Type:       createRoutineOpType(e.IsProcedure), // ALTER reuses the CREATE op-type key (no OpAlter* in the set)
+		Database:   e.Database,
+		ObjectName: e.Name,
+		SQL:        b.String(),
+		Phase:      PhaseMain,
+		Priority:   priorityRoutine,
+		sortName:   routineSortName(e.Database, e.Name),
+	}
+}
+
+// renderCreateRoutine renders a DEFINER-less CREATE FUNCTION/PROCEDURE in MySQL's canonical
+// stored form. It mirrors showCreateRoutine (routinecmds.go) — same parameter rendering, same
+// RETURNS, same characteristic lines, same body placement — but omits the DEFINER clause (see the
+// file doc) and emits characteristics in default-folded canonical form so the readback matches.
+//
+// Characteristic emission policy: only NON-DEFAULT characteristics are emitted (SHOW CREATE drops
+// defaults, so emitting them would still round-trip, but matching SHOW CREATE's policy keeps the
+// emitted DDL byte-identical to a subsequent readback's shape):
+//   - DETERMINISTIC only when YES (NOT DETERMINISTIC is the default and is omitted).
+//   - DATA ACCESS only when not CONTAINS SQL (the default).
+//   - SQL SECURITY only when INVOKER (DEFINER is the default).
+//   - COMMENT only when non-empty.
+func renderCreateRoutine(database string, r *Routine, _ *Normalizer) string {
+	var b strings.Builder
+	kw := "FUNCTION"
+	if r.IsProcedure {
+		kw = "PROCEDURE"
+	}
+	fmt.Fprintf(&b, "CREATE %s %s(", kw, routineIdent(database, r.Name))
+
+	// Parameters: "DIR `name` type" for procedures (direction shown), "`name` type" for functions.
+	// The parameter NAME is backtick-quoted: a name that is a reserved word (e.g. `select`) or
+	// needs quoting would otherwise produce invalid DDL. Always-quoting is safe for round-trip —
+	// the loader strips backticks from a parameter name (the canonical key uses the decoded name),
+	// so a quoted emission and an unquoted user form canonicalize equal. MySQL stores the
+	// parameter list verbatim, so the readback echoes the quoted form, which reloads to the same
+	// decoded name.
+	for i, p := range r.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		if r.IsProcedure && strings.TrimSpace(p.Direction) != "" {
+			fmt.Fprintf(&b, "%s %s %s", strings.ToUpper(p.Direction), migrationQuoteIdent(p.Name), p.TypeName)
+		} else {
+			fmt.Fprintf(&b, "%s %s", migrationQuoteIdent(p.Name), p.TypeName)
+		}
+	}
+	b.WriteString(")")
+
+	// RETURNS (functions only).
+	if !r.IsProcedure && strings.TrimSpace(r.Returns) != "" {
+		fmt.Fprintf(&b, " RETURNS %s", r.Returns)
+	}
+
+	// Characteristics, default-folded (non-defaults only), each on its own indented line, in the
+	// order SHOW CREATE uses for a freshly created routine (DETERMINISTIC, DATA ACCESS, SQL
+	// SECURITY, COMMENT).
+	if strings.EqualFold(r.Characteristics["DETERMINISTIC"], "YES") {
+		b.WriteString("\n    DETERMINISTIC")
+	}
+	if da := strings.ToUpper(strings.TrimSpace(r.Characteristics["DATA ACCESS"])); da != "" && da != "CONTAINS SQL" {
+		fmt.Fprintf(&b, "\n    %s", da)
+	}
+	if sec := strings.ToUpper(strings.TrimSpace(r.Characteristics["SQL SECURITY"])); sec == "INVOKER" {
+		b.WriteString("\n    SQL SECURITY INVOKER")
+	}
+	if cmt := r.Characteristics["COMMENT"]; cmt != "" {
+		fmt.Fprintf(&b, "\n    COMMENT '%s'", escapeComment(cmt))
+	}
+
+	// Body on its own line (matches SHOW CREATE).
+	if r.Body != "" {
+		b.WriteString("\n")
+		b.WriteString(r.Body)
+	}
+	return b.String()
+}
+
+// routineAlterableCharacteristicClauses returns the ALTER-able characteristic clauses for a
+// routine in canonical default-folded form, always all three (DATA ACCESS, SQL SECURITY,
+// COMMENT) so the ALTER fully establishes the target characteristic state regardless of the
+// synced side. DETERMINISTIC is excluded (not ALTER-able). The DATA ACCESS clause is the keyword
+// itself (CONTAINS SQL / NO SQL / READS SQL DATA / MODIFIES SQL DATA).
+func routineAlterableCharacteristicClauses(r *Routine) []string {
+	clauses := make([]string, 0, 3)
+
+	da := strings.ToUpper(strings.TrimSpace(r.Characteristics["DATA ACCESS"]))
+	if da == "" {
+		da = "CONTAINS SQL"
+	}
+	clauses = append(clauses, da)
+
+	sec := strings.ToUpper(strings.TrimSpace(r.Characteristics["SQL SECURITY"]))
+	if sec == "" {
+		sec = "DEFINER"
+	}
+	clauses = append(clauses, "SQL SECURITY "+sec)
+
+	clauses = append(clauses, fmt.Sprintf("COMMENT '%s'", escapeComment(r.Characteristics["COMMENT"])))
+	return clauses
+}
+
+// createRoutineOpType returns the CREATE op-type for the routine kind.
+func createRoutineOpType(isProcedure bool) MigrationOpType {
+	if isProcedure {
+		return OpCreateProcedure
+	}
+	return OpCreateFunction
+}
+
+// dropRoutineOpType returns the DROP op-type for the routine kind.
+func dropRoutineOpType(isProcedure bool) MigrationOpType {
+	if isProcedure {
+		return OpDropProcedure
+	}
+	return OpDropFunction
+}
+
+// routineIdent returns the backtick-quoted database.routine identifier for migration DDL, using
+// ORIGINAL-CASE names (matching tableIdent's case discipline — a case-sensitive server stores the
+// declared casing). The database qualifier is omitted when empty (the synced single-database
+// release path may load with no qualifying database).
+func routineIdent(database, name string) string {
+	if database == "" {
+		return migrationQuoteIdent(name)
+	}
+	return migrationQuoteIdent(database) + "." + migrationQuoteIdent(name)
+}
+
+// routineSortName is the stable secondary sort key for a routine op: lower-cased database.name.
+func routineSortName(database, name string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(name)
 }

--- a/mysql/catalog/migration_routine_oracle_test.go
+++ b/mysql/catalog/migration_routine_oracle_test.go
@@ -1,0 +1,326 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle apply-correctness proof for the routine generator (correctness-protocol.md gate 2),
+// against the LIVE MySQL engines (5.7 :13307, 8.0 :13306). For representative (from, to) pairs
+// covering every routine variant — function vs procedure, CREATE / DROP / characteristic-ALTER /
+// body-change(=DROP+CREATE) / param-change / RETURNS-change / DETERMINISTIC-change — the generated
+// DDL applied to a real `from` database must yield a routine whose canonical form equals `to`.
+//
+// Both from/to catalogs are loaded from the ENGINE'S OWN SHOW CREATE readbacks under the SAME
+// database name (so routine identity matches), then the plan is applied to a from-state database
+// and the result read back and compared. Idempotence (gate 1) is covered by
+// TestOracle_RoutineDiffIdempotence; this file proves the EMITTED DDL is correct, and additionally
+// asserts the chosen PATH (single ALTER vs DROP+CREATE) for the characteristic-only cases.
+//
+// The harness reuses connectOracle / serverCharsetFor / both() and skips cleanly when the engines
+// are unreachable.
+
+const routineApplyDB = "rtn_apply"
+
+// routineMigrationProbe is one apply-correctness case: transform a routine from `fromDDL` to
+// `toDDL`. An empty fromDDL means the routine does not exist yet (a pure CREATE); an empty toDDL
+// means it is dropped. wantAlter asserts the plan path: true → a single ALTER, false → CREATE-only
+// or DROP-only or DROP+CREATE (the default; only checked when both sides are present).
+type routineMigrationProbe struct {
+	id        string
+	kind      string // "FUNCTION" | "PROCEDURE"
+	name      string
+	fromDDL   string
+	toDDL     string
+	wantAlter bool // only meaningful for a modify (both DDLs present)
+	versions  []Version
+}
+
+// routineMigrationProbes enumerates the routine ADD/DROP/MODIFY FORMS the generator covers.
+// Functions declare a binlog-safe characteristic (DETERMINISTIC / NO SQL / READS SQL DATA) so they
+// create on the 8.0 box (log_bin_trust_function_creators off → error 1418 otherwise).
+func routineMigrationProbes() []routineMigrationProbe {
+	return []routineMigrationProbe{
+		// ---- CREATE (from empty) ----
+		{"create-fn-simple", "FUNCTION", "f", "", "CREATE FUNCTION f(a INT, b INT) RETURNS INT DETERMINISTIC RETURN a + b", false, both()},
+		{"create-fn-string", "FUNCTION", "f", "", "CREATE FUNCTION f(s VARCHAR(50)) RETURNS VARCHAR(100) DETERMINISTIC RETURN CONCAT(s, s)", false, both()},
+		{"create-fn-all-chars", "FUNCTION", "f", "", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC READS SQL DATA SQL SECURITY INVOKER COMMENT 'c' RETURN a", false, both()},
+		{"create-fn-begin", "FUNCTION", "f", "", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC\nBEGIN\n  DECLARE r INT;\n  SET r = a * 2;\n  RETURN r;\nEND", false, both()},
+		{"create-proc-inout", "PROCEDURE", "p", "", "CREATE PROCEDURE p(IN x INT, OUT y INT, INOUT z INT) BEGIN SET y = x + z; SET z = z + 1; END", false, both()},
+		{"create-proc-modifies", "PROCEDURE", "p", "", "CREATE PROCEDURE p() MODIFIES SQL DATA BEGIN SET @v = 1; END", false, both()},
+		{"create-proc-comment", "PROCEDURE", "p", "", "CREATE PROCEDURE p(IN a INT) SQL SECURITY INVOKER COMMENT 'pc' BEGIN SET @v = a; END", false, both()},
+		// Type-rendering surfaces: DECIMAL precision, ENUM/SET member lists, reserved-word param.
+		{"create-fn-decimal", "FUNCTION", "f", "", "CREATE FUNCTION f(a DECIMAL(10,2)) RETURNS DECIMAL(12,4) DETERMINISTIC RETURN a", false, both()},
+		{"create-fn-enum-return", "FUNCTION", "f", "", "CREATE FUNCTION f() RETURNS ENUM('a','b','c') DETERMINISTIC RETURN 'a'", false, both()},
+		{"create-proc-enum-set-params", "PROCEDURE", "p", "", "CREATE PROCEDURE p(IN s SET('x','y'), IN e ENUM('p','q')) BEGIN SET @v = s; END", false, both()},
+		{"create-proc-reserved-param", "PROCEDURE", "p", "", "CREATE PROCEDURE p(IN `select` INT, IN `from` INT) BEGIN SET @v = `select`; END", false, both()},
+
+		// ---- DROP (to empty) ----
+		{"drop-fn", "FUNCTION", "f", "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a", "", false, both()},
+		{"drop-proc", "PROCEDURE", "p", "CREATE PROCEDURE p() BEGIN SET @v = 1; END", "", false, both()},
+
+		// ---- MODIFY via ALTER (only SQL SECURITY / COMMENT / DATA ACCESS change) ----
+		{"alter-fn-comment", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'old' RETURN a",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'new' RETURN a", true, both()},
+		{"alter-fn-security", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC SQL SECURITY DEFINER RETURN a",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC SQL SECURITY INVOKER RETURN a", true, both()},
+		{"alter-fn-dataaccess", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC READS SQL DATA RETURN a", true, both()},
+		{"alter-fn-add-comment", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'added' RETURN a", true, both()},
+		{"alter-proc-security", "PROCEDURE", "p",
+			"CREATE PROCEDURE p(IN a INT) SQL SECURITY DEFINER BEGIN SET @v = a; END",
+			"CREATE PROCEDURE p(IN a INT) SQL SECURITY INVOKER BEGIN SET @v = a; END", true, both()},
+		{"alter-proc-dataaccess", "PROCEDURE", "p",
+			"CREATE PROCEDURE p() CONTAINS SQL BEGIN SET @v = 1; END",
+			"CREATE PROCEDURE p() MODIFIES SQL DATA BEGIN SET @v = 1; END", true, both()},
+
+		// ---- MODIFY via DROP+CREATE (body / params / RETURNS / DETERMINISTIC change) ----
+		{"body-change-fn", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 1",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 2", false, both()},
+		{"param-change-fn", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a",
+			"CREATE FUNCTION f(a INT, b INT) RETURNS INT DETERMINISTIC RETURN a + b", false, both()},
+		{"returns-change-fn", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a",
+			"CREATE FUNCTION f(a INT) RETURNS BIGINT DETERMINISTIC RETURN a", false, both()},
+		{"determ-change-fn", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT NOT DETERMINISTIC READS SQL DATA RETURN a",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC READS SQL DATA RETURN a", false, both()},
+		{"body-change-proc", "PROCEDURE", "p",
+			"CREATE PROCEDURE p() BEGIN SET @v = 1; END",
+			"CREATE PROCEDURE p() BEGIN SET @v = 2; END", false, both()},
+		{"param-change-proc", "PROCEDURE", "p",
+			"CREATE PROCEDURE p(IN x INT) BEGIN SET @v = x; END",
+			"CREATE PROCEDURE p(IN x INT, OUT y INT) BEGIN SET y = x; END", false, both()},
+		// ENUM member-case change in a parameter: a real domain change → DROP+CREATE, and the
+		// re-created routine must carry the NEW member case (proves member case survives render).
+		{"param-enum-case-change-proc", "PROCEDURE", "p",
+			"CREATE PROCEDURE p(IN e ENUM('a','b')) BEGIN SET @v = e; END",
+			"CREATE PROCEDURE p(IN e ENUM('A','b')) BEGIN SET @v = e; END", false, both()},
+		// Combined: a body change AND a comment change at once → still DROP+CREATE (body forces it),
+		// and the re-created routine carries the new comment.
+		{"body-and-comment-fn", "FUNCTION", "f",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'old' RETURN a + 1",
+			"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'new' RETURN a + 2", false, both()},
+	}
+}
+
+// TestOracle_RoutineMigrationApplyCorrectness proves gate 2 for every routine probe: the generated
+// DDL transforms a real `from` database into a `to`-equal one (compared via canonical readback),
+// and the chosen path (ALTER vs DROP+CREATE) matches the probe's expectation.
+func TestOracle_RoutineMigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range routineMigrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertRoutineApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// assertRoutineApplyCorrect loads from/to catalogs from the engine's readbacks (under the SAME db
+// name so identity matches), generates the plan, applies it to a from-state database, reads the
+// result back, and asserts the result canonicalizes equal to `to`.
+func assertRoutineApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p routineMigrationProbe) {
+	t.Helper()
+	ctx := context.Background()
+	sc := serverCharsetFor(o.version)
+	db := routineApplyDB + "_" + strings.ReplaceAll(p.id, "-", "_")
+
+	// Build the `from` and `to` catalogs from engine readbacks, BOTH under db name `db`.
+	loadSide := func(ddl string) (*Catalog, bool) {
+		if strings.TrimSpace(ddl) == "" {
+			return New(), true
+		}
+		cat, _, ok := o.loadRoutineReadback(t, db, ddl, p.kind, p.name)
+		return cat, ok
+	}
+	toCat, ok := loadSide(p.toDDL)
+	if !ok {
+		t.Skipf("[%s] could not obtain `to` readback for %s", o.name, p.id)
+	}
+	fromCat, ok := loadSide(p.fromDDL)
+	if !ok {
+		t.Skipf("[%s] could not obtain `from` readback for %s", o.name, p.id)
+	}
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Path assertion (modify cases only): ALTER vs DROP+CREATE.
+	bothPresent := strings.TrimSpace(p.fromDDL) != "" && strings.TrimSpace(p.toDDL) != ""
+	if bothPresent {
+		alterOps, createOps, dropOps := classifyRoutineOps(plan.Ops)
+		if p.wantAlter {
+			if alterOps != 1 || createOps != 0 || dropOps != 0 {
+				t.Errorf("[%s] %s: expected a single ALTER, got plan:\n%s", o.name, p.id, plan.SQL())
+			}
+		} else {
+			if dropOps != 1 || createOps != 1 {
+				t.Errorf("[%s] %s: expected DROP+CREATE, got plan:\n%s", o.name, p.id, plan.SQL())
+			}
+		}
+	}
+
+	// Apply the plan to a real database in `from` state, on ONE dedicated connection.
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + db,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", db, sc),
+		"USE " + db,
+	}
+	if strings.TrimSpace(p.fromDDL) != "" {
+		setup = append(setup, p.fromDDL)
+	}
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, p.id, s, err)
+		}
+	}
+
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Readback the result on the same connection.
+	readback := func() (string, bool) {
+		var c1, c2, c3, c4, c5, c6 sql.NullString
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE %s %s.%s", p.kind, db, p.name))
+		if err := row.Scan(&c1, &c2, &c3, &c4, &c5, &c6); err != nil {
+			return "", false
+		}
+		return c3.String, true
+	}
+
+	if strings.TrimSpace(p.toDDL) == "" {
+		if _, ok := readback(); ok {
+			t.Errorf("[%s] %s: routine %s still exists after DROP plan:\n%s", o.name, p.id, p.name, plan.SQL())
+		}
+		return
+	}
+
+	resultRB, ok := readback()
+	if !ok {
+		t.Fatalf("[%s] %s: result routine %s missing after apply:\n%s", o.name, p.id, p.name, plan.SQL())
+	}
+	resultWrapped := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s", db, sc, db, resultRB)
+	resultCat, err := LoadSQL(resultWrapped)
+	if err != nil {
+		t.Fatalf("[%s] %s: result load failed: %v\n%s", o.name, p.id, err, resultWrapped)
+	}
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result: %s\n  diff: %s",
+			o.name, p.id, plan.SQL(), strings.TrimSpace(resultRB), describeRoutineDiff(d))
+	}
+	// Symmetry.
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeRoutineDiff(d))
+	}
+}
+
+// classifyRoutineOps counts the routine op kinds in a plan: ALTER (a CREATE-type op whose SQL
+// begins with ALTER), CREATE (a CREATE-type op whose SQL begins with CREATE), and DROP.
+func classifyRoutineOps(ops []MigrationOp) (alter, create, drop int) {
+	for _, op := range ops {
+		switch op.Type {
+		case OpDropFunction, OpDropProcedure:
+			drop++
+		case OpCreateFunction, OpCreateProcedure:
+			if strings.HasPrefix(strings.TrimSpace(op.SQL), "ALTER ") {
+				alter++
+			} else {
+				create++
+			}
+		}
+	}
+	return alter, create, drop
+}
+
+// TestOracle_RoutineMultiObjectRoundTrip proves a database carrying several routines of both kinds
+// (loaded from real engine readbacks) self-diffs empty and yields an empty plan — the realistic
+// release-path idempotence check across the whole routine set, not just single forms.
+func TestOracle_RoutineMultiObjectRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+		ctx := context.Background()
+
+		t.Run(o.name+"/mixed-routines", func(t *testing.T) {
+			dbName := "rtn_multi"
+			stmts := []string{
+				"DROP DATABASE IF EXISTS " + dbName,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, sc),
+				"USE " + dbName,
+				"CREATE FUNCTION add2(a INT, b INT) RETURNS INT DETERMINISTIC RETURN a + b",
+				"CREATE FUNCTION greet(s VARCHAR(20)) RETURNS VARCHAR(40) DETERMINISTIC READS SQL DATA COMMENT 'g' RETURN CONCAT('hi ', s)",
+				"CREATE PROCEDURE bump(INOUT n INT) BEGIN SET n = n + 1; END",
+				"CREATE PROCEDURE noop() MODIFIES SQL DATA BEGIN SET @v = 1; END",
+			}
+			for _, s := range stmts {
+				if _, err := o.db.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup failed (may be expected): %q: %v", o.name, s, err)
+				}
+			}
+
+			// Read back each routine and reload as a single schema.
+			var b strings.Builder
+			fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, sc, dbName)
+			routines := []struct{ kind, name string }{
+				{"FUNCTION", "add2"}, {"FUNCTION", "greet"},
+				{"PROCEDURE", "bump"}, {"PROCEDURE", "noop"},
+			}
+			for _, r := range routines {
+				rb, ok := o.showCreateRoutine(t, dbName, r.kind, r.name)
+				if !ok {
+					t.Fatalf("[%s] readback %s %s failed", o.name, r.kind, r.name)
+				}
+				b.WriteString(rb)
+				b.WriteString(";\n")
+			}
+			cat, err := LoadSQL(b.String())
+			if err != nil {
+				t.Fatalf("[%s] reload of multi-routine readback failed: %v\n%s", o.name, err, b.String())
+			}
+			diff := DiffWithNormalizer(cat, cat, n)
+			if !diff.IsEmpty() {
+				t.Errorf("[%s] multi-routine self-diff not empty: %s", o.name, describeRoutineDiff(diff))
+			}
+			plan := GenerateMigrationWithNormalizer(cat, cat, diff, n)
+			if plan.SQL() != "" {
+				t.Errorf("[%s] multi-routine no-op plan not empty:\n%s", o.name, plan.SQL())
+			}
+		})
+	}
+}

--- a/mysql/catalog/routinecmds.go
+++ b/mysql/catalog/routinecmds.go
@@ -174,13 +174,28 @@ func formatDataType(dt *nodes.DataType) string {
 		name = "json"
 	case "bool", "boolean":
 		name = "tinyint"
+	case "enum", "set":
+		// keep as-is; the member list is rendered below.
 	}
 
 	var b strings.Builder
 	b.WriteString(name)
 
-	// Length/precision.
-	if dt.Length > 0 {
+	// ENUM/SET carry a quoted member list, not a numeric length. MySQL stores and echoes the
+	// member list verbatim in a routine's parameter/return type (e.g. RETURNS enum('a','b')), so
+	// it must be rendered or the type is invalid DDL and loses identity. Mirrors the column
+	// renderer (tablecmds.go normalizedColumnDataType).
+	if len(dt.EnumValues) > 0 {
+		b.WriteString("(")
+		for i, v := range dt.EnumValues {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString("'" + escapeEnumValue(v) + "'")
+		}
+		b.WriteString(")")
+	} else if dt.Length > 0 {
+		// Length/precision (non-ENUM/SET types).
 		if dt.Scale > 0 {
 			b.WriteString(fmt.Sprintf("(%d,%d)", dt.Length, dt.Scale))
 		} else {
@@ -196,9 +211,16 @@ func formatDataType(dt *nodes.DataType) string {
 }
 
 // formatParamType formats a DataType for display in a routine parameter list.
-// MySQL 8.0 shows parameter types in UPPERCASE (INT, VARCHAR(100), etc.)
+// MySQL 8.0 shows parameter types in UPPERCASE (INT, VARCHAR(100), etc.), but ENUM/SET member
+// VALUES are case-significant and must be preserved verbatim — upper-casing the whole rendered
+// string would corrupt 'Lower' into 'LOWER' and change the column domain on apply. So only the
+// portion up to the first '(' (the type keyword) is upper-cased; the parenthesized argument/member
+// list (and any trailing modifier) is kept as formatDataType rendered it.
 func formatParamType(dt *nodes.DataType) string {
 	raw := formatDataType(dt)
+	if open := strings.IndexByte(raw, '('); open >= 0 {
+		return strings.ToUpper(raw[:open]) + raw[open:]
+	}
 	return strings.ToUpper(raw)
 }
 


### PR DESCRIPTION
## What

Fills the **routine** (stored functions + procedures) breadth node for MySQL declarative-schema (SDL) migration — the MySQL analog of PG's `diffFunctions`/`generateFunctionDDL`. Wires the previously-inert scaffold hooks (`diffFunctions`, `diffProcedures`, `generateRoutineDDL`) to real implementations.

Contract slice: `docs/migration/mysql/sdl/contract.md` (`diffFunctions`/`diffProcedures` rows) + `objects.md` (stored functions/procedures).

## Scope

`CREATE FUNCTION`/`CREATE PROCEDURE`, parameters (IN/OUT/INOUT + types incl. ENUM/SET), `RETURNS` (functions), characteristics (`DETERMINISTIC`, DATA ACCESS `CONTAINS SQL`/`NO SQL`/`READS SQL DATA`/`MODIFIES SQL DATA`, `SQL SECURITY DEFINER|INVOKER`, `COMMENT`, `LANGUAGE SQL`), and the opaque `BEGIN…END` body.

## Design (oracle-backed, MySQL 5.7 :13307 + 8.0 :13306)

**DROP+CREATE vs ALTER.** MySQL has no `CREATE OR REPLACE` and no `ALTER` for a routine's body/params/RETURNS. Probed on both engines: `ALTER FUNCTION/PROCEDURE` accepts **only** `SQL SECURITY`, `COMMENT`, DATA ACCESS, `LANGUAGE` — and **rejects `DETERMINISTIC`** (syntax error). So a MODIFY emits a single `ALTER` iff only SQL SECURITY/COMMENT/DATA ACCESS changed; otherwise (params/RETURNS/body/DETERMINISTIC) it's `DROP` (PhasePre) + `CREATE` (PhaseMain). The emitted `CREATE` is **DEFINER-less** (DEFINER is ignored in the diff; a DEFINER-less CREATE adopts CURRENT_USER on apply, the correct release behavior).

**Body canonicalization.** Verified the body is stored **byte-for-byte verbatim** (whitespace/tabs/blank lines preserved); the loader stores `TrimSpace(BodyText)`, so identical source bodies compare equal. Compared opaquely.

**Characteristic default-folding (idempotence linchpin).** `SHOW CREATE` **omits** default characteristics — verified `CONTAINS SQL`, `SQL SECURITY DEFINER`, and `NOT DETERMINISTIC` are all dropped from the readback. The canonical key default-folds a missing characteristic to its default so a user form that spells out a default doesn't phantom-diff against the readback that drops it.

**5.7 vs 8.0.** The `RETURNS` type is version-canonical (5.7 `int(11)`, 8.0 `int`) — routed through normalize-core (`parseColumnType`+`canonicalType`), same int-width rule columns use. The parameter list is stored verbatim and identical on both versions, so params need no version fold (only case folding), with ENUM/SET member **values** preserved case-exact.

## Normalization rules applied

| rule | grounding |
|---|---|
| Body compared opaque (verbatim store) | live probe both versions |
| Characteristic default-fold (DETERMINISTIC→NO, DATA ACCESS→CONTAINS SQL, SQL SECURITY→DEFINER, COMMENT→"") | `SHOW CREATE` drops defaults (probed) |
| RETURNS int-width via normalize-core | 5.7 `int(11)` vs 8.0 `int` |
| ENUM/SET member case preserved (param + RETURNS) | column-path parity (`canonicalEnumSuffix`) |
| DEFINER ignored; LANGUAGE ignored | environment / never echoed |
| param `IN`≡omitted (default direction) | semantically identical |

## Proof — both oracle gates, live engines

`go test ./mysql/catalog/...` — **99 routine oracle subtests pass, 0 fail, 0 skip** on 5.7 **and** 8.0:
- **Idempotence** (`TestOracle_RoutineDiffIdempotence`, `TestOracle_RoutineMultiObjectRoundTrip`): user form vs engine `SHOW CREATE` readback self-diffs empty; no-op plan empty.
- **Apply-correctness** (`TestOracle_RoutineMigrationApplyCorrectness`): generated CREATE/DROP/ALTER/DROP+CREATE applied to a real `from` DB yields a routine canonically equal to `to`, with the ALTER-vs-DROP+CREATE path asserted per case.

Variants covered: function vs procedure; CREATE/DROP; characteristic-only ALTER (comment/security/data-access); DROP+CREATE for body/param/RETURNS/DETERMINISTIC change; ENUM/SET RETURNS + params; DECIMAL RETURNS; reserved-word param name; multi-line `BEGIN…END` body; comment with embedded quote/backslash; multi-routine round-trip.

## Note on `routinecmds.go` (loader)

The loader's `formatDataType` dropped ENUM/SET member lists (→ invalid `RETURNS enum` DDL) and `formatParamType` upper-cased member **values** (corrupting `'Lower'`→`'LOWER'` on apply). Both surfaced via the apply-correctness gate and are fixed here (member list rendered; only the type keyword upper-cased). This is the one file outside the routine diff/generate node touched, required for routine apply-correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)