### PR TITLE
feat(mysql/catalog): implement event diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_event.go
+++ b/mysql/catalog/diff_event.go
@@ -1,15 +1,407 @@
 package catalog
 
-// MySQL SDL diff — scheduled events (scaffold stub).
+import (
+	"sort"
+	"strings"
+)
+
+// MySQL SDL diff — scheduled events.
 //
 // Wired into DiffWithNormalizer (diff.go) so the SchemaDiff reports event changes via
-// SchemaDiff.Events. Inert no-op placeholder returning nil until the event breadth node
-// implements the real comparison. Signature mirrors diffTables (diff_table.go): whole-
-// catalog, taking from/to *Catalog and the version-fixing Normalizer (events are database-
-// level objects keyed by (database, name)).
+// SchemaDiff.Events. Mirrors diffTables' shape: whole-catalog, taking from/to *Catalog and the
+// version-fixing Normalizer. Events are database-level objects keyed by (database, lower(name)) —
+// the same key eventcmds.go stores under db.Events — so the differ uses a buildEventMap index
+// exactly like diffTables/buildTableMap, then sorts the result for determinism.
 //
-// implemented by omni:event breadth node
-func diffEvents(_, _ *Catalog, _ *Normalizer) []EventDiffEntry {
-	// Scaffold: returns nil so the event diff stays empty (self-diff inert).
-	return nil
+// Equality is decided by a single canonical comparison key (eventCanonicalKey) — the event
+// analog of CanonicalColumn — so an event whose surface form differs from its synced
+// SHOW CREATE EVENT readback but whose canonical form is identical produces no phantom diff.
+// The canonicalization is grounded in what the engine actually stores (probed on live 5.7.25 +
+// 8.0.32); the high-risk surfaces are:
+//
+//   - SCHEDULE. A recurring `EVERY <interval>` event ALWAYS gets a `STARTS '<create-time>'`
+//     clause auto-injected by the engine when the user omits STARTS, and that injected timestamp
+//     is (a) non-deterministic (it is NOW() at apply time) and (b) indistinguishable in the
+//     stored form from a user-written STARTS — both `information_schema.EVENTS.STARTS` and
+//     `SHOW CREATE EVENT` render them identically. So STARTS is dropped from the schedule key
+//     (canonicalizeSchedule); see the FLAG below. ENDS, by contrast, is never auto-injected
+//     (NULL when absent), so it is meaningful and kept. The EVERY interval itself is re-rendered
+//     by the engine — quoted multi-field intervals lose per-field leading zeros
+//     (`'12:30:00'`→`'12:30:0'`) and single-field quoted intervals are unquoted (`'05'`→`5`) — so
+//     the interval literal is canonicalized to match.
+//   - STATUS. ENABLE is the default and is always shown explicitly by SHOW CREATE EVENT; the
+//     catalog stores "" for an unspecified status, which canonicalizes to ENABLE. DISABLE ON
+//     SLAVE stays distinct from DISABLE (information_schema reports it as SLAVESIDE_DISABLED).
+//   - ON COMPLETION. NOT PRESERVE is the default and is always shown explicitly; "" canonicalizes
+//     to NOT PRESERVE.
+//   - DEFINER. Always resolves to the executing user (`root`@`%` on the oracle box) regardless of
+//     whether the user wrote it (verified on live 8.0: `DEFINER=CURRENT_USER` and an omitted
+//     definer both store as “ `root`@`%` “), so it is NOT part of the schema's logical identity
+//     and is dropped from the key (ignore-in-diff).
+//
+// FLAG 1 (recorded to the state document): because the engine stores an auto-injected STARTS
+// identically to an explicit one, a release that changes ONLY an explicit STARTS on a recurring
+// event is not detected as a diff. There is no signal in the stored form to distinguish the two,
+// and the idempotence gate (user `EVERY 1 HOUR` ≡ stored `EVERY 1 HOUR STARTS '<now>'`) forces
+// STARTS to be normalized out. This is the most authoritative behavior given the evidence.
+//
+// FLAG 2 (recorded to the state document): the schedule is compared as text, but MySQL EVALUATES a
+// non-literal schedule expression to a literal at create time — `AT CURRENT_TIMESTAMP + INTERVAL 1
+// DAY` is stored as `AT '<evaluated-ts>'`, and `EVERY 60*60 SECOND` as `EVERY 3600 SECOND`
+// (verified on live 8.0.32). So a HAND-AUTHORED SDL that writes such an expression would phantom-
+// diff against its synced literal form. This does not affect the real release path: bytebase syncs
+// events via SHOW CREATE EVENT (oracle.md), which always yields the evaluated literal, so both
+// sides of a release-path comparison are already literals. Offline expression evaluation is
+// infeasible (it needs the server clock / NOW()), so this is flagged, not normalized — the same
+// class of limitation as FLAG 1.
+//
+// implemented by omni:events breadth node
+func diffEvents(from, to *Catalog, n *Normalizer) []EventDiffEntry {
+	fromMap := buildEventMap(from)
+	toMap := buildEventMap(to)
+
+	var result []EventDiffEntry
+
+	// Dropped: in from but not in to.
+	for key, fromEvent := range fromMap {
+		if _, ok := toMap[key]; !ok {
+			result = append(result, EventDiffEntry{
+				Action:   DiffDrop,
+				Database: key.db,
+				Name:     fromEvent.Name,
+				From:     fromEvent,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for key, toEvent := range toMap {
+		fromEvent, ok := fromMap[key]
+		if !ok {
+			result = append(result, EventDiffEntry{
+				Action:   DiffAdd,
+				Database: key.db,
+				Name:     toEvent.Name,
+				To:       toEvent,
+			})
+			continue
+		}
+		if eventCanonicalKey(fromEvent, n) != eventCanonicalKey(toEvent, n) {
+			result = append(result, EventDiffEntry{
+				Action:   DiffModify,
+				Database: key.db,
+				Name:     toEvent.Name,
+				From:     fromEvent,
+				To:       toEvent,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Database != result[j].Database {
+			return result[i].Database < result[j].Database
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// buildEventMap indexes every event in a catalog by (database, name), both lower-cased — the
+// identity key db.Events is already keyed by. Mirrors buildTableMap.
+func buildEventMap(c *Catalog) map[eventKey]*Event {
+	m := make(map[eventKey]*Event)
+	if c == nil {
+		return m
+	}
+	for _, db := range c.Databases() {
+		for name, e := range db.Events {
+			if e == nil {
+				continue
+			}
+			m[eventKey{db: toLower(db.Name), name: name}] = e
+		}
+	}
+	return m
+}
+
+// eventKey is the identity key for an event: (database, name) lower-cased. MySQL has no
+// schemas/namespaces, so the database is the qualifying scope.
+type eventKey struct {
+	db   string
+	name string
+}
+
+// eventCanonicalKey returns a single stable comparison key for an event, folding every
+// canonicalized aspect (schedule, ON COMPLETION, status, comment, body) into one string. DEFINER
+// is intentionally excluded (ignore-in-diff). Equal keys mean no change. This is the event analog
+// of Normalizer.CanonicalColumn.
+func eventCanonicalKey(e *Event, n *Normalizer) string {
+	return encodeKeyFields(
+		"schedule", canonicalizeSchedule(e.Schedule),
+		"oncompletion", canonicalOnCompletion(e.OnCompletion),
+		"status", canonicalEventStatus(e.Enable),
+		"comment", n.CanonicalComment(e.Comment),
+		"body", trimSQLSpace(e.Body),
+	)
+}
+
+// canonicalOnCompletion folds the ON COMPLETION clause to its canonical stored form. MySQL's
+// default is NOT PRESERVE, which SHOW CREATE EVENT always renders explicitly; the catalog stores
+// "" for an unspecified clause, so "" and "NOT PRESERVE" compare equal.
+func canonicalOnCompletion(v string) string {
+	if eqFoldStr(strings.TrimSpace(v), "PRESERVE") {
+		return "PRESERVE"
+	}
+	return "NOT PRESERVE"
+}
+
+// canonicalEventStatus folds the ENABLE/DISABLE/DISABLE ON SLAVE status to its canonical stored
+// form. ENABLE is the default and is always shown explicitly by SHOW CREATE EVENT; the catalog
+// stores "" for an unspecified status, so "" and "ENABLE" compare equal.
+func canonicalEventStatus(v string) string {
+	switch {
+	case eqFoldStr(strings.TrimSpace(v), "DISABLE"):
+		return "DISABLE"
+	case eqFoldStr(collapseSpaces(v), "DISABLE ON SLAVE"):
+		return "DISABLE ON SLAVE"
+	default:
+		return "ENABLE"
+	}
+}
+
+// trimSQLSpace trims surrounding ASCII whitespace from an opaque SQL fragment (event body, etc.).
+// eventcmds already TrimSpace's the body on load, but a stored readback may carry different outer
+// spacing, so trim again for a stable key.
+func trimSQLSpace(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// collapseSpaces lower-cases nothing but collapses internal runs of ASCII whitespace to a single
+// space and trims the ends, so "DISABLE   ON  SLAVE" and "DISABLE ON SLAVE" compare equal.
+func collapseSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// canonicalizeSchedule folds an event's ON SCHEDULE clause (the raw schedule text the catalog
+// stores in Event.Schedule, e.g. "EVERY 1 HOUR STARTS '2026-01-01 00:00:00'" or "AT '2030-01-01
+// 00:00:00'") to a version-independent canonical key. It is the single owner of the schedule
+// normalization decisions documented above:
+//
+//   - splits off a trailing STARTS '<ts>' clause and DROPS it (auto-injected, indistinguishable
+//     from explicit — see the FLAG in the package doc);
+//   - keeps a trailing ENDS '<ts>' clause (never auto-injected → meaningful);
+//   - canonicalizes the EVERY interval literal so the engine's re-rendering of quoted intervals
+//     (per-field leading-zero stripping; single-field unquoting) round-trips empty;
+//   - upper-cases keywords and collapses whitespace so surface spacing/case never diffs.
+//
+// A one-shot `AT <expr>` schedule is kept whole (the engine evaluates the expression to a literal
+// at create time; the literal is the schedule's identity). The clause structure MySQL guarantees
+// is `EVERY <interval> [STARTS <ts>] [ENDS <ts>]` — STARTS always precedes ENDS — so a simple
+// keyword scan suffices; we never need to re-parse the interval grammar.
+func canonicalizeSchedule(raw string) string {
+	s := collapseSpaces(raw)
+	if s == "" {
+		return ""
+	}
+
+	upper := strings.ToUpper(s)
+	if strings.HasPrefix(upper, "EVERY") {
+		body := strings.TrimSpace(s[len("EVERY"):])
+
+		// Peel a trailing ENDS '<ts>' first (it comes after STARTS), then a STARTS '<ts>'. Because
+		// STARTS precedes ENDS in the grammar, the remaining head after both peels is the interval.
+		var ends string
+		body, ends = peelScheduleClause(body, "ENDS")
+		body, _ = peelScheduleClause(body, "STARTS") // STARTS dropped (auto-injected/explicit indistinguishable)
+
+		interval := canonicalizeInterval(strings.TrimSpace(body))
+		out := "EVERY " + interval
+		if ends != "" {
+			out += " ENDS " + ends
+		}
+		return out
+	}
+
+	if strings.HasPrefix(upper, "AT") {
+		at := strings.TrimSpace(s[len("AT"):])
+		return "AT " + at
+	}
+
+	// Unknown shape (defensive): return the whitespace/clause-collapsed form so identical inputs
+	// still compare equal.
+	return s
+}
+
+// peelScheduleClause splits a schedule body at the LAST top-level ` <keyword> ` boundary
+// (case-insensitive), returning the head before it and the value after it (trimmed). If the
+// keyword is absent, head == body and value == "". The match is quote-aware: occurrences inside a
+// single- or double-quoted region are skipped, so a keyword that appears inside a timestamp
+// literal (pathological, but defensively handled) never causes a mis-split. The keyword must be
+// space-delimited so it does not match inside an interval unit name (HOUR, DAY, ...).
+func peelScheduleClause(body, keyword string) (head, value string) {
+	idx := lastTopLevelKeyword(body, keyword)
+	if idx < 0 {
+		return body, ""
+	}
+	needleLen := len(keyword) + 2 // surrounding spaces
+	head = strings.TrimSpace(body[:idx])
+	value = strings.TrimSpace(body[idx+needleLen:])
+	return head, value
+}
+
+// lastTopLevelKeyword returns the byte index of the last ` <keyword> ` (case-insensitive,
+// space-delimited) occurrence that is NOT inside a quoted region, or -1 if none. Quoting tracks
+// both ' and " and treats a doubled quote (”) as an escaped quote within the same region — which
+// is exactly how MySQL's SHOW CREATE EVENT renders quotes inside a stored schedule literal (the
+// only quoting form that appears here). Backslash escapes are not interpreted; they do not occur in
+// canonical stored-schedule timestamps, so this is sufficient for the inputs this scan sees.
+func lastTopLevelKeyword(s, keyword string) int {
+	needle := " " + keyword + " "
+	last := -1
+	var quote byte // 0 when outside any quote
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == quote {
+				// A doubled quote is an escaped quote, not a close.
+				if i+1 < len(s) && s[i+1] == quote {
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+			continue
+		}
+		// Fold case with a per-byte ASCII upcase (asciiEqualFold), NOT strings.ToUpper: ToUpper can
+		// change a string's byte length (e.g. 'ı' U+0131 -> "I", 'ſ' U+017F -> "S"), which would
+		// desync the upper-cased string from the s-derived index i and slice out of bounds (panic)
+		// or misalign (silent mis-split). Schedule keywords are pure ASCII, so an ASCII fold is
+		// correct and panic-free on any input.
+		if i+len(needle) <= len(s) && asciiEqualFold(s[i:i+len(needle)], needle) {
+			last = i
+		}
+	}
+	return last
+}
+
+// asciiEqualFold reports whether a and b are equal under ASCII case folding (A–Z ↔ a–z only). It
+// never changes byte length, so callers can match in the original byte-index space. b is the ASCII
+// needle.
+func asciiEqualFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if asciiUpper(a[i]) != asciiUpper(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// asciiUpper upper-cases a single ASCII byte; non-letters and non-ASCII bytes pass through.
+func asciiUpper(c byte) byte {
+	if c >= 'a' && c <= 'z' {
+		return c - ('a' - 'A')
+	}
+	return c
+}
+
+// canonicalizeInterval canonicalizes an EVERY interval (the `<value> <unit>` head of a recurring
+// schedule, e.g. "1 HOUR", "'1 12:30:00' DAY_SECOND", "'05' MINUTE") to match the engine's stored
+// re-rendering:
+//   - a single-field quoted value is unquoted and stripped of leading zeros: "'05'" -> "5";
+//   - a multi-field quoted value (containing ':' or a space inside the quotes) keeps the quotes
+//     and separators but strips each numeric field's leading zeros: "'1 12:30:00'" -> "'1 12:30:0'";
+//   - the unit keyword is upper-cased.
+//
+// The value is whatever precedes the final unit token. Units may be compound (HOUR_MINUTE,
+// DAY_SECOND), so the unit is taken as the last whitespace-separated token and the value is the
+// rest. A bare numeric value ("100") is left as-is (no quotes, no leading zeros to strip in the
+// forms the engine produces).
+func canonicalizeInterval(s string) string {
+	if s == "" {
+		return ""
+	}
+	fields := strings.Fields(s)
+	if len(fields) < 2 {
+		// No unit token to split on; return upper-cased as a defensive fallback.
+		return strings.ToUpper(s)
+	}
+	unit := strings.ToUpper(fields[len(fields)-1])
+	value := strings.TrimSpace(strings.Join(fields[:len(fields)-1], " "))
+	return canonicalizeIntervalValue(value) + " " + unit
+}
+
+// canonicalizeIntervalValue canonicalizes the numeric value portion of an EVERY interval to the
+// engine's stored form (see canonicalizeInterval). It strips leading zeros from every maximal
+// digit run, then unquotes a value that collapsed to a single bare integer.
+func canonicalizeIntervalValue(v string) string {
+	quoted := len(v) >= 2 && (v[0] == '\'' || v[0] == '"') && v[len(v)-1] == v[0]
+	inner := v
+	if quoted {
+		inner = v[1 : len(v)-1]
+	}
+
+	stripped := stripFieldLeadingZeros(inner)
+
+	// A quoted value that is now a single bare integer (no separators) is stored unquoted by the
+	// engine ('05' -> 5). A multi-field value (still containing ':' or space) keeps its quotes.
+	if quoted {
+		if isAllDigits(stripped) {
+			return stripped
+		}
+		return "'" + stripped + "'"
+	}
+	return stripped
+}
+
+// stripFieldLeadingZeros strips leading zeros from each maximal run of ASCII digits in s,
+// preserving every non-digit separator (':', ' ', '-', '.') verbatim. A run that is all zeros
+// collapses to a single "0".
+func stripFieldLeadingZeros(s string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c < '0' || c > '9' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		// Consume a digit run.
+		j := i
+		for j < len(s) && s[j] >= '0' && s[j] <= '9' {
+			j++
+		}
+		run := s[i:j]
+		trimmed := strings.TrimLeft(run, "0")
+		if trimmed == "" {
+			trimmed = "0"
+		}
+		b.WriteString(trimmed)
+		i = j
+	}
+	return b.String()
+}
+
+// isAllDigits reports whether s is non-empty and every byte is an ASCII digit.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/mysql/catalog/diff_event_test.go
+++ b/mysql/catalog/diff_event_test.go
@@ -1,0 +1,324 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// In-process, hermetic tests for the event differ + its canonicalization. They assert the
+// SchemaDiff.Events content (right DiffAction per event) for representative change forms and lock
+// in the canonical-key normalization decisions (schedule STARTS-stripping, interval re-rendering,
+// status/ON COMPLETION defaults, DEFINER ignore) without a live engine. The oracle-backed
+// idempotence + apply-correctness proofs live in migration_event_oracle_test.go
+// (correctness-protocol.md gates 1 & 2).
+
+// findEvent locates an event entry in a SchemaDiff by name (lower-cased).
+func findEvent(d *SchemaDiff, name string) *EventDiffEntry {
+	for i := range d.Events {
+		if strings.EqualFold(d.Events[i].Name, name) {
+			return &d.Events[i]
+		}
+	}
+	return nil
+}
+
+const evDBDDL = "CREATE DATABASE app DEFAULT CHARSET=utf8mb4;\nUSE app;\n"
+
+func diffEventsOnly(t *testing.T, fromSQL, toSQL string) *SchemaDiff {
+	t.Helper()
+	from := loadCat(t, evDBDDL+fromSQL)
+	to := loadCat(t, evDBDDL+toSQL)
+	return DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+}
+
+// ---- canonicalizeSchedule: the headline normalization -----------------------
+
+func TestCanonicalizeSchedule(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string // two schedules that must canonicalize EQUAL
+	}{
+		// STARTS auto-injected (synced) vs omitted (user SDL) → equal.
+		{"every-starts-stripped",
+			"EVERY 1 HOUR STARTS '2026-06-26 12:32:56'",
+			"EVERY 1 HOUR"},
+		// Two different STARTS on the same EVERY schedule → equal (STARTS dropped entirely).
+		{"every-different-starts-equal",
+			"EVERY 1 HOUR STARTS '2025-01-01 00:00:00'",
+			"EVERY 1 HOUR STARTS '2025-06-01 00:00:00'"},
+		// ENDS kept; STARTS between interval and ENDS stripped.
+		{"every-ends-kept-starts-stripped",
+			"EVERY 1 DAY STARTS '2026-06-26 12:32:56' ENDS '2030-01-01 00:00:00'",
+			"EVERY 1 DAY ENDS '2030-01-01 00:00:00'"},
+		// Quoted single-field interval unquoted + leading-zero stripped.
+		{"interval-single-field-unquote",
+			"EVERY '05' MINUTE STARTS '2026-06-26 12:32:56'",
+			"EVERY 5 MINUTE"},
+		// Quoted multi-field interval: per-field leading zeros stripped, quotes kept.
+		{"interval-multi-field-leading-zeros",
+			"EVERY '2:03:04' HOUR_SECOND",
+			"EVERY '2:3:4' HOUR_SECOND"},
+		{"interval-day-second-leading-zeros",
+			"EVERY '1 12:30:00' DAY_SECOND",
+			"EVERY '1 12:30:0' DAY_SECOND"},
+		// Whitespace / case insensitivity.
+		{"whitespace-case",
+			"every   1    hour",
+			"EVERY 1 HOUR"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ka := canonicalizeSchedule(c.a)
+			kb := canonicalizeSchedule(c.b)
+			if ka != kb {
+				t.Errorf("schedules must canonicalize equal:\n  a=%q -> %q\n  b=%q -> %q", c.a, ka, c.b, kb)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeSchedule_Distinct(t *testing.T) {
+	// Schedules that must NOT collapse to the same key (real differences).
+	cases := []struct {
+		name string
+		a, b string
+	}{
+		{"different-interval-value", "EVERY 1 HOUR", "EVERY 2 HOUR"},
+		{"different-interval-unit", "EVERY 1 HOUR", "EVERY 1 DAY"},
+		{"every-vs-at", "EVERY 1 HOUR", "AT '2030-01-01 00:00:00'"},
+		{"different-at", "AT '2030-01-01 00:00:00'", "AT '2031-01-01 00:00:00'"},
+		{"ends-presence", "EVERY 1 DAY ENDS '2030-01-01 00:00:00'", "EVERY 1 DAY"},
+		{"different-ends", "EVERY 1 DAY ENDS '2030-01-01 00:00:00'", "EVERY 1 DAY ENDS '2031-01-01 00:00:00'"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if canonicalizeSchedule(c.a) == canonicalizeSchedule(c.b) {
+				t.Errorf("schedules must be distinct but both -> %q (a=%q b=%q)",
+					canonicalizeSchedule(c.a), c.a, c.b)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeSchedule_QuoteAwarePeel(t *testing.T) {
+	// A timestamp literal that pathologically contains the bare word STARTS/ENDS must NOT be
+	// mis-split by the clause peeler (quote-aware). The whole quoted value stays in the schedule.
+	got := canonicalizeSchedule("EVERY 1 DAY STARTS '2025-01-01 ENDS HERE 00:00:00'")
+	// STARTS is stripped (auto/explicit indistinguishable), but the ENDS inside the quote must not
+	// be promoted to a real ENDS clause — so there is no " ENDS " token in the canonical form.
+	if strings.Contains(got, "ENDS") {
+		t.Errorf("quoted ENDS must not become a clause; got %q", got)
+	}
+	if got != "EVERY 1 DAY" {
+		t.Errorf("want canonical %q, got %q", "EVERY 1 DAY", got)
+	}
+
+	// A real ENDS following a quoted STARTS that contains 'ENDS' must still be peeled.
+	got2 := canonicalizeSchedule("EVERY 1 DAY STARTS '2025-01-01 ENDS X 00:00:00' ENDS '2030-01-01 00:00:00'")
+	if got2 != "EVERY 1 DAY ENDS '2030-01-01 00:00:00'" {
+		t.Errorf("want real trailing ENDS kept, got %q", got2)
+	}
+}
+
+func TestCanonicalizeSchedule_UTF8Safe(t *testing.T) {
+	// Regression: lastTopLevelKeyword must not panic or mis-split when the schedule text contains a
+	// rune whose ToUpper changes byte length ('ı' U+0131 -> "I", 'ſ' U+017F -> "S"). Folding with a
+	// per-byte ASCII upcase keeps index space and slice space aligned. These must simply not panic
+	// and must not invent a clause from the non-ASCII bytes.
+	inputs := []string{
+		"EVERY 1 DAY ENDS '2030' " + strings.Repeat("ı", 30),
+		"EVERY 1 DAY STARTS 'ıııııııı' ENDS '2030-01-01 00:00:00'",
+		"EVERY 1 HOUR ſſſ",
+		"AT 'ı2030-01-01 00:00:00ſ'",
+	}
+	for _, in := range inputs {
+		// Must not panic.
+		got := canonicalizeSchedule(in)
+		_ = got
+		// scheduleHasEnds must also not panic on the same inputs (it shares the scan).
+		_ = scheduleHasEnds(in)
+	}
+	// The real trailing ENDS after a non-ASCII STARTS literal must still be detected.
+	if !scheduleHasEnds("EVERY 1 DAY STARTS 'ıııı' ENDS '2030-01-01 00:00:00'") {
+		t.Errorf("real trailing ENDS after non-ASCII STARTS must be detected")
+	}
+	if got := canonicalizeSchedule("EVERY 1 DAY STARTS 'ıııı' ENDS '2030-01-01 00:00:00'"); got != "EVERY 1 DAY ENDS '2030-01-01 00:00:00'" {
+		t.Errorf("want ENDS kept after non-ASCII STARTS, got %q", got)
+	}
+}
+
+func TestCanonicalEventStatusAndCompletion(t *testing.T) {
+	// "" defaults to ENABLE / NOT PRESERVE; explicit forms preserved; DISABLE ON SLAVE distinct.
+	if canonicalEventStatus("") != "ENABLE" {
+		t.Errorf("empty status must canonicalize to ENABLE, got %q", canonicalEventStatus(""))
+	}
+	if canonicalEventStatus("enable") != "ENABLE" {
+		t.Errorf("enable -> ENABLE")
+	}
+	if canonicalEventStatus("DISABLE") != "DISABLE" {
+		t.Errorf("DISABLE preserved")
+	}
+	if canonicalEventStatus("disable on slave") != "DISABLE ON SLAVE" {
+		t.Errorf("disable on slave -> DISABLE ON SLAVE, got %q", canonicalEventStatus("disable on slave"))
+	}
+	if canonicalEventStatus("DISABLE") == canonicalEventStatus("DISABLE ON SLAVE") {
+		t.Errorf("DISABLE and DISABLE ON SLAVE must be distinct")
+	}
+	if canonicalOnCompletion("") != "NOT PRESERVE" {
+		t.Errorf("empty ON COMPLETION must canonicalize to NOT PRESERVE")
+	}
+	if canonicalOnCompletion("PRESERVE") != "PRESERVE" {
+		t.Errorf("PRESERVE preserved")
+	}
+	if canonicalOnCompletion("NOT PRESERVE") != "NOT PRESERVE" {
+		t.Errorf("NOT PRESERVE preserved")
+	}
+}
+
+// ---- structural diff (Add / Drop / Modify / no-op) --------------------------
+
+func TestDiffEvents_SelfEmpty(t *testing.T) {
+	schemas := []string{
+		"CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1;",
+		"CREATE EVENT e ON SCHEDULE EVERY 1 DAY STARTS '2025-01-01 00:00:00' ENDS '2026-01-01 00:00:00' ON COMPLETION PRESERVE DISABLE COMMENT 'c' DO SET @q = 1;",
+		"CREATE EVENT e ON SCHEDULE AT '2030-01-01 00:00:00' ON COMPLETION PRESERVE DO SET @y = 2;",
+	}
+	for _, s := range schemas {
+		c := loadCat(t, evDBDDL+s)
+		if d := DiffWithNormalizer(c, c, NormalizerFor(MySQL80)); !d.IsEmpty() {
+			t.Errorf("self-diff not empty for %q: events=%d", s, len(d.Events))
+		}
+	}
+}
+
+func TestDiffEvents_StartsInjectionNoOp(t *testing.T) {
+	// The headline idempotence case in-process: user form (no STARTS) vs synced form (auto STARTS)
+	// must diff EMPTY.
+	from := loadCat(t, evDBDDL+"CREATE EVENT e ON SCHEDULE EVERY 1 HOUR STARTS '2026-06-26 12:32:56' DO SET @x = 1;")
+	to := loadCat(t, evDBDDL+"CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1;")
+	if d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80)); !d.IsEmpty() {
+		t.Errorf("STARTS-injection no-op must diff empty, got %d event changes", len(d.Events))
+	}
+}
+
+func TestDiffEvents_Add(t *testing.T) {
+	d := diffEventsOnly(t, "", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1;")
+	e := findEvent(d, "e")
+	if e == nil || e.Action != DiffAdd {
+		t.Fatalf("want ADD event e, got %+v", d.Events)
+	}
+}
+
+func TestDiffEvents_Drop(t *testing.T) {
+	d := diffEventsOnly(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1;", "")
+	e := findEvent(d, "e")
+	if e == nil || e.Action != DiffDrop {
+		t.Fatalf("want DROP event e, got %+v", d.Events)
+	}
+}
+
+func TestDiffEvents_Modify(t *testing.T) {
+	cases := []struct {
+		name     string
+		from, to string
+	}{
+		{"schedule", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 2 HOUR DO SET @x=1;"},
+		{"status", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENABLE DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x=1;"},
+		{"completion", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ON COMPLETION NOT PRESERVE DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE DO SET @x=1;"},
+		{"comment", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'a' DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'b' DO SET @x=1;"},
+		{"body", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=2;"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := diffEventsOnly(t, c.from, c.to)
+			e := findEvent(d, "e")
+			if e == nil || e.Action != DiffModify {
+				t.Fatalf("want MODIFY event e for %s, got %+v", c.name, d.Events)
+			}
+		})
+	}
+}
+
+func TestDiffEvents_DefinerIgnored(t *testing.T) {
+	// Two events differing ONLY in DEFINER must NOT diff (DEFINER is ignore-in-diff).
+	from := loadCat(t, evDBDDL+"CREATE DEFINER=`a`@`%` EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	to := loadCat(t, evDBDDL+"CREATE DEFINER=`b`@`localhost` EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	if d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80)); !d.IsEmpty() {
+		t.Errorf("DEFINER-only change must not diff, got %d event changes", len(d.Events))
+	}
+}
+
+// ---- generate: the rendered DDL shape ---------------------------------------
+
+func TestGenerateEventDDL_Shapes(t *testing.T) {
+	// ADD → CREATE EVENT; DROP → DROP EVENT IF EXISTS; MODIFY → ALTER EVENT. COMMENT is always
+	// rendered (COMMENT '' when empty) so an ALTER that clears a comment resets it.
+	add := genEventPlan(t, "", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	mustContain(t, add, "CREATE EVENT `e` ON SCHEDULE EVERY 1 HOUR ON COMPLETION NOT PRESERVE ENABLE COMMENT '' DO SET @x=1")
+
+	drop := genEventPlan(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;", "")
+	mustContain(t, drop, "DROP EVENT IF EXISTS `e`")
+
+	mod := genEventPlan(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 2 HOUR DISABLE DO SET @x=1;")
+	mustContain(t, mod, "ALTER EVENT `e` ON SCHEDULE EVERY 2 HOUR ON COMPLETION NOT PRESERVE DISABLE COMMENT '' DO SET @x=1")
+
+	// MODIFY that CLEARS a comment must render COMMENT '' (regression for the comment-removal bug).
+	clr := genEventPlan(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'old' DO SET @x=1;", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	mustContain(t, clr, "ALTER EVENT `e` ON SCHEDULE EVERY 1 HOUR ON COMPLETION NOT PRESERVE ENABLE COMMENT '' DO SET @x=1")
+}
+
+func TestGenerateEventDDL_CommentEscaping(t *testing.T) {
+	// Identifier + comment escaping must survive into the rendered DDL.
+	add := genEventPlan(t, "", "CREATE EVENT `weird``name` ON SCHEDULE EVERY 1 HOUR COMMENT 'it''s a test' DO SET @x=1;")
+	mustContain(t, add, "CREATE EVENT `weird``name`")
+	mustContain(t, add, "COMMENT 'it''s a test'")
+}
+
+func TestGenerateEventDDL_EmptyOnNoOp(t *testing.T) {
+	from := loadCat(t, evDBDDL+"CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	diff := DiffWithNormalizer(from, from, NormalizerFor(MySQL80))
+	plan := GenerateMigrationWithNormalizer(from, from, diff, NormalizerFor(MySQL80))
+	if plan.SQL() != "" {
+		t.Errorf("no-op plan must be empty, got:\n%s", plan.SQL())
+	}
+}
+
+func TestGenerateEventDDL_DropPhaseBeforeCreate(t *testing.T) {
+	// A plan that drops one event and creates another: the DROP must sort before the CREATE
+	// (PhasePre < PhaseMain).
+	from := loadCat(t, evDBDDL+"CREATE EVENT old ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	to := loadCat(t, evDBDDL+"CREATE EVENT new ON SCHEDULE EVERY 1 HOUR DO SET @x=1;")
+	diff := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	plan := GenerateMigrationWithNormalizer(from, to, diff, NormalizerFor(MySQL80))
+	sql := plan.SQL()
+	di := strings.Index(sql, "DROP EVENT")
+	ci := strings.Index(sql, "CREATE EVENT")
+	if di < 0 || ci < 0 || di > ci {
+		t.Errorf("DROP must precede CREATE in:\n%s", sql)
+	}
+}
+
+func genEventPlan(t *testing.T, fromSQL, toSQL string) string {
+	t.Helper()
+	var from, to *Catalog
+	if strings.TrimSpace(fromSQL) == "" {
+		from = New()
+	} else {
+		from = loadCat(t, evDBDDL+fromSQL)
+	}
+	if strings.TrimSpace(toSQL) == "" {
+		to = New()
+	} else {
+		to = loadCat(t, evDBDDL+toSQL)
+	}
+	n := NormalizerFor(MySQL80)
+	diff := DiffWithNormalizer(from, to, n)
+	return GenerateMigrationWithNormalizer(from, to, diff, n).SQL()
+}
+
+func mustContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected to contain:\n  %q\ngot:\n  %q", needle, haystack)
+	}
+}

--- a/mysql/catalog/migration_event.go
+++ b/mysql/catalog/migration_event.go
@@ -1,14 +1,217 @@
 package catalog
 
-// MySQL SDL generate — scheduled events (scaffold stub).
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — scheduled events (CREATE / ALTER / DROP EVENT).
 //
 // Wired into GenerateMigrationWithNormalizer (migration.go) so event diffs (SchemaDiff.Events)
-// become DDL. Inert no-op placeholder returning nil until the event breadth node renders the
-// CREATE/DROP EVENT ops (OpCreateEvent/OpDropEvent, priorityEvent). Signature mirrors
-// generateTableDDL (migration_table.go).
+// become DDL. Mirrors generateTableDDL's shape. The three cases, from EventDiffEntry.Action:
 //
-// implemented by omni:event breadth node
-func generateEventDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no event ops (empty diff -> empty plan).
-	return nil
+//   - DiffAdd    → CREATE EVENT … (PhaseMain, priorityEvent)
+//   - DiffModify → ALTER EVENT  … (PhaseMain, priorityEvent) — preferred over DROP+CREATE
+//   - DiffDrop   → DROP EVENT   … (PhasePre,  priorityEvent) — drops run before creates
+//
+// ALTER vs DROP+CREATE: MySQL's ALTER EVENT can change every mutable aspect an SDL diff can
+// observe — the schedule (ON SCHEDULE …), ON COMPLETION, status (ENABLE/DISABLE/DISABLE ON SLAVE),
+// COMMENT, and body (DO …). The event name is its identity (a rename is a drop+add of distinct
+// keys, handled by the Add/Drop arms), so a MODIFY never needs to change the name. ALTER is
+// therefore always applicable for a same-name change and is preferred: it preserves the event
+// object (and its bookkeeping) instead of dropping and recreating it. Both forms are apply-correct
+// — verified on live 5.7.25 + 8.0.32 — but ALTER is the smaller, safer change.
+//
+// Only OpCreateEvent / OpDropEvent op-types exist (declared in migration.go); a MODIFY is rendered
+// as an OpCreateEvent-typed op carrying ALTER EVENT SQL (the op-type is a coarse drop-vs-forward
+// classifier for ordering/advice; the SQL string is what executes). This keeps the op-type set as
+// declared without an OpAlterEvent.
+//
+// DEFINER is never emitted: it is ignore-in-diff (always resolves to the executing user) and
+// omitting it lets the apply readback match the synced form (“ DEFINER=`root`@`%` “). The
+// schedule is emitted verbatim from the target — applying `EVERY 1 HOUR` lets the engine inject
+// its own STARTS, whose readback canonicalizes equal to the target (canonicalizeSchedule strips
+// STARTS), so apply-correctness holds.
+//
+// implemented by omni:events breadth node
+func generateEventDDL(_, _ *Catalog, diff *SchemaDiff, _ *Normalizer) []MigrationOp {
+	var ops []MigrationOp
+
+	for i := range diff.Events {
+		e := &diff.Events[i]
+		switch e.Action {
+		case DiffAdd:
+			ops = append(ops, MigrationOp{
+				Type:       OpCreateEvent,
+				Database:   e.Database,
+				ObjectName: e.Name,
+				SQL:        renderCreateEvent(e.To),
+				Phase:      PhaseMain,
+				Priority:   priorityEvent,
+				sortName:   eventSortName(e.Database, e.Name),
+			})
+		case DiffModify:
+			if eventModifyNeedsRecreate(e.From, e.To) {
+				// ALTER EVENT cannot express this change on every supported version (the one known
+				// case: 5.7's ALTER EVENT … ON SCHEDULE does NOT clear an existing ENDS — verified
+				// on live 5.7.25, where the old ENDS survives; 8.0.32 clears it). Fall back to
+				// DROP + CREATE, which is always correct: a PhasePre DROP removes the old event
+				// before the PhaseMain CREATE re-establishes the target with no ENDS.
+				ops = append(ops,
+					MigrationOp{
+						Type:       OpDropEvent,
+						Database:   e.Database,
+						ObjectName: e.Name,
+						SQL:        renderDropEvent(e.From),
+						Phase:      PhasePre,
+						Priority:   priorityEvent,
+						sortName:   eventSortName(e.Database, e.Name),
+					},
+					MigrationOp{
+						Type:       OpCreateEvent,
+						Database:   e.Database,
+						ObjectName: e.Name,
+						SQL:        renderCreateEvent(e.To),
+						Phase:      PhaseMain,
+						Priority:   priorityEvent,
+						sortName:   eventSortName(e.Database, e.Name),
+					},
+				)
+				continue
+			}
+			ops = append(ops, MigrationOp{
+				Type:       OpCreateEvent, // forward (PhaseMain) op; SQL is ALTER EVENT (see file doc)
+				Database:   e.Database,
+				ObjectName: e.Name,
+				SQL:        renderAlterEvent(e.To),
+				Phase:      PhaseMain,
+				Priority:   priorityEvent,
+				sortName:   eventSortName(e.Database, e.Name),
+			})
+		case DiffDrop:
+			ops = append(ops, MigrationOp{
+				Type:       OpDropEvent,
+				Database:   e.Database,
+				ObjectName: e.Name,
+				SQL:        renderDropEvent(e.From),
+				Phase:      PhasePre,
+				Priority:   priorityEvent,
+				sortName:   eventSortName(e.Database, e.Name),
+			})
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		return ops[i].sortName < ops[j].sortName
+	})
+
+	return ops
+}
+
+// eventSortName is the stable secondary sort key for an event op: database.name lower-cased.
+func eventSortName(database, name string) string {
+	return toLower(database) + "." + toLower(name)
+}
+
+// eventModifyNeedsRecreate reports whether a same-name event MODIFY must be applied as DROP+CREATE
+// rather than ALTER EVENT, because ALTER cannot express the change on every supported version.
+//
+// The one known case is ENDS removal: 5.7's ALTER EVENT … ON SCHEDULE does not clear a previously
+// set ENDS (the old ENDS survives the re-specification — verified on live 5.7.25), so an event that
+// drops its ENDS bound can only reach the target via DROP+CREATE there. 8.0 clears ENDS on ALTER,
+// but DROP+CREATE is correct on 8.0 too, so the fallback is applied version-independently for a
+// single, simple code path. Every other mutable aspect (schedule interval/unit, EVERY↔AT, status,
+// ON COMPLETION, comment, body) is reachable via ALTER on both versions (verified), so this is the
+// only trigger.
+func eventModifyNeedsRecreate(from, to *Event) bool {
+	if from == nil || to == nil {
+		return false
+	}
+	return scheduleHasEnds(from.Schedule) && !scheduleHasEnds(to.Schedule)
+}
+
+// scheduleHasEnds reports whether a raw schedule string carries a top-level ENDS clause. It reuses
+// the same quote-aware clause scan the canonical key uses, so a timestamp literal that happens to
+// contain the word ENDS is not mistaken for a clause.
+func scheduleHasEnds(raw string) bool {
+	_, ends := peelScheduleClause(collapseSpaces(raw), "ENDS")
+	return ends != ""
+}
+
+// renderCreateEvent renders a CREATE EVENT statement for the target event. The clauses follow
+// MySQL's SHOW CREATE EVENT order (sans DEFINER): name, ON SCHEDULE, ON COMPLETION, status,
+// COMMENT, DO body. Defaults (ON COMPLETION NOT PRESERVE, ENABLE) are emitted explicitly so the
+// statement is self-describing and matches the readback form.
+func renderCreateEvent(e *Event) string {
+	var b strings.Builder
+	b.WriteString("CREATE EVENT ")
+	b.WriteString(quoteIdent(e.Name))
+	writeEventBodyClauses(&b, e)
+	return b.String()
+}
+
+// renderAlterEvent renders an ALTER EVENT that re-establishes every mutable aspect of the target
+// event in one statement. ALTER EVENT accepts the same clause set as CREATE (minus IF NOT EXISTS),
+// and re-specifying all of them makes the event match the target regardless of its prior state.
+func renderAlterEvent(e *Event) string {
+	var b strings.Builder
+	b.WriteString("ALTER EVENT ")
+	b.WriteString(quoteIdent(e.Name))
+	writeEventBodyClauses(&b, e)
+	return b.String()
+}
+
+// renderDropEvent renders DROP EVENT IF EXISTS for the source event. IF EXISTS makes the drop
+// tolerant of an event already gone (idempotent apply).
+func renderDropEvent(e *Event) string {
+	return "DROP EVENT IF EXISTS " + quoteIdent(e.Name)
+}
+
+// writeEventBodyClauses appends the shared CREATE/ALTER EVENT clause sequence (everything after
+// the event name): ON SCHEDULE, ON COMPLETION, status, COMMENT, DO body. Every clause is emitted
+// UNCONDITIONALLY (including the explicit defaults NOT PRESERVE / ENABLE and an explicit
+// COMMENT ”) so that for the ALTER path a clause omitted from the target actually RESETS the
+// event to that target value. MySQL's ALTER EVENT leaves any omitted clause unchanged, so to
+// CLEAR a comment the statement must say COMMENT ” — verified on live 5.7.25 + 8.0.32: an ALTER
+// without a COMMENT clause keeps the old comment, while COMMENT ” removes it (and a CREATE/ALTER
+// with COMMENT ” reads back with no COMMENT clause, canonicalizing equal to an empty comment). The
+// same reasoning is why status and ON COMPLETION are always rendered. The schedule is the one
+// clause that cannot be empty for a valid event, so it is emitted whenever present.
+func writeEventBodyClauses(b *strings.Builder, e *Event) {
+	if sched := strings.TrimSpace(e.Schedule); sched != "" {
+		b.WriteString(" ON SCHEDULE ")
+		b.WriteString(sched)
+	}
+
+	if eqFoldStr(strings.TrimSpace(e.OnCompletion), "PRESERVE") {
+		b.WriteString(" ON COMPLETION PRESERVE")
+	} else {
+		b.WriteString(" ON COMPLETION NOT PRESERVE")
+	}
+
+	switch canonicalEventStatus(e.Enable) {
+	case "DISABLE":
+		b.WriteString(" DISABLE")
+	case "DISABLE ON SLAVE":
+		b.WriteString(" DISABLE ON SLAVE")
+	default:
+		b.WriteString(" ENABLE")
+	}
+
+	// Always emit COMMENT (COMMENT '' when empty) so an ALTER that drops a comment actually clears
+	// it; an empty comment reads back as no clause on both versions, so this stays apply-correct.
+	fmt.Fprintf(b, " COMMENT '%s'", escapeComment(e.Comment))
+
+	if body := strings.TrimSpace(e.Body); body != "" {
+		b.WriteString(" DO ")
+		b.WriteString(body)
+	}
+}
+
+// quoteIdent wraps an identifier in backticks, escaping any embedded backtick by doubling it
+// (MySQL's identifier-quoting rule). Event names are simple identifiers in practice, but this
+// keeps the rendered DDL correct for any legal name.
+func quoteIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }

--- a/mysql/catalog/migration_event_oracle_test.go
+++ b/mysql/catalog/migration_event_oracle_test.go
@@ -1,0 +1,337 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the event differ + generator (correctness-protocol.md gates 1 & 2),
+// against the LIVE MySQL engines (5.7 :13307 ssl-disabled, 8.0 :13306). Events are database-level
+// objects, so this harness is event-shaped (SHOW CREATE EVENT, a per-probe apply database) rather
+// than reusing the table harness. Two properties are proven on EVERY supported version:
+//
+//  1. IDEMPOTENCE (the spine). For each event form, the user-form CREATE EVENT applied to a real
+//     database and read back via SHOW CREATE EVENT must diff EMPTY against the user form — proving
+//     the canonicalization (STARTS-stripping, interval re-rendering, status / ON COMPLETION /
+//     DEFINER normalization) matches what the engine stores. The stored form also self-diffs empty
+//     and the no-op plan is "".
+//
+//  2. APPLY-CORRECTNESS. For each (from, to) event transition, the generated plan applied to a
+//     real `from` database yields an event whose canonical form equals `to` (both directions).
+//     Covers CREATE (add), DROP, and ALTER (every mutable aspect: schedule, status, ON COMPLETION,
+//     comment, body). When nothing changed the plan is empty.
+//
+// The harness reuses connectOracle / serverCharsetFor / both / only / containsVersion /
+// NormalizerFor from the existing oracle tests; it skips cleanly when the engines are unreachable,
+// so the unit suite stays hermetic (go test -short skips it). Event DDL applies regardless of
+// event_scheduler state, so these run with the scheduler at the box default.
+
+// loadOneEvent loads a CREATE EVENT (wrapped in a database whose default charset matches the
+// oracle box) and returns the named event from the catalog. Mirrors loadOneTable.
+func loadOneEvent(t *testing.T, serverCharset, createSQL, event string) (*Catalog, *Event) {
+	t.Helper()
+	wrapped := fmt.Sprintf("CREATE DATABASE evdb DEFAULT CHARSET=%s;\nUSE evdb;\n%s", serverCharset, createSQL)
+	cat, err := LoadSQL(wrapped)
+	if err != nil {
+		t.Fatalf("LoadSQL failed for %q: %v", createSQL, err)
+	}
+	for _, db := range cat.Databases() {
+		if e := db.Events[toLower(event)]; e != nil {
+			return cat, e
+		}
+	}
+	t.Fatalf("event %q not found after load of %q", event, createSQL)
+	return nil, nil
+}
+
+// eventReadback applies createSQL in a throwaway database (on the given pinned connection) and
+// returns the SHOW CREATE EVENT readback (the engine's canonical stored form) as a reloadable
+// CREATE EVENT statement. Returns ok=false (and logs) when the version rejects the input — the
+// caller decides whether that is expected (e.g. 5.7 rejecting a far-future AT value).
+func eventReadback(t *testing.T, conn *sql.Conn, name, sc, dbName, createSQL, event string) (string, bool) {
+	t.Helper()
+	ctx := context.Background()
+	for _, s := range []string{
+		"DROP DATABASE IF EXISTS " + dbName,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, sc),
+		"USE " + dbName,
+		createSQL,
+	} {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Logf("[%s] event readback setup failed (may be expected): %q: %v", name, s, err)
+			return "", false
+		}
+	}
+	ddl, ok := scanShowCreateEvent(conn, dbName, event)
+	if !ok {
+		t.Logf("[%s] SHOW CREATE EVENT %s.%s failed", name, dbName, event)
+	}
+	return ddl, ok
+}
+
+// scanShowCreateEvent runs SHOW CREATE EVENT and returns the "Create Event" column. The result set
+// has seven columns: Event, sql_mode, time_zone, Create Event, character_set_client,
+// collation_connection, Database Collation.
+func scanShowCreateEvent(conn *sql.Conn, dbName, event string) (string, bool) {
+	var name, sqlMode, tz, ddl, csClient, collConn, dbColl string
+	row := conn.QueryRowContext(context.Background(), fmt.Sprintf("SHOW CREATE EVENT %s.%s", dbName, event))
+	if err := row.Scan(&name, &sqlMode, &tz, &ddl, &csClient, &collConn, &dbColl); err != nil {
+		return "", false
+	}
+	return ddl, true
+}
+
+// eventIdempotenceProbes enumerates representative event FORMS that must round-trip empty: user
+// DDL whose engine-stored form differs (auto-injected STARTS, re-rendered intervals, explicit
+// default status/completion) but must canonicalize equal. Recurring + one-shot, varied
+// schedule/status/options.
+func eventIdempotenceProbes() []struct {
+	id, event, create string
+	versions          []Version
+} {
+	return []struct {
+		id, event, create string
+		versions          []Version
+	}{
+		{"every-default", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1", both()},
+		{"every-explicit-enable", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 SECOND ENABLE DO SET @x = 1", both()},
+		{"every-disable", "e", "CREATE EVENT e ON SCHEDULE EVERY 5 MINUTE DISABLE DO SET @x = 1", both()},
+		{"every-disable-on-slave", "e", "CREATE EVENT e ON SCHEDULE EVERY 30 MINUTE ON COMPLETION NOT PRESERVE DISABLE ON SLAVE DO SET @x = 1", both()},
+		{"every-preserve", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 DAY ON COMPLETION PRESERVE DO SET @x = 1", both()},
+		{"every-explicit-starts", "e", "CREATE EVENT e ON SCHEDULE EVERY 5 MINUTE STARTS '2025-03-01 12:00:00' DO SET @x = 1", both()},
+		{"every-starts-ends", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 DAY STARTS '2025-01-01 00:00:00' ENDS '2030-01-01 00:00:00' ON COMPLETION PRESERVE DISABLE COMMENT 'c' DO SET @q = 1", both()},
+		{"every-only-ends", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENDS '2030-01-01 00:00:00' DO SET @x = 1", both()},
+		{"every-interval-quoted-hm", "e", "CREATE EVENT e ON SCHEDULE EVERY '1:30' HOUR_MINUTE DO SET @x = 1", both()},
+		{"every-interval-quoted-leadingzero", "e", "CREATE EVENT e ON SCHEDULE EVERY '02:03:04' HOUR_SECOND DO SET @x = 1", both()},
+		{"every-interval-quoted-daysecond", "e", "CREATE EVENT e ON SCHEDULE EVERY '1 12:30:00' DAY_SECOND DO SET @x = 1", both()},
+		{"every-interval-single-quoted", "e", "CREATE EVENT e ON SCHEDULE EVERY '05' MINUTE DO SET @x = 1", both()},
+		{"every-comment", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'it''s a test' DO SET @x = 1", both()},
+		// One-shot AT: near-future literal works on both versions (5.7 rejects far-future AT values).
+		{"at-literal", "e", "CREATE EVENT e ON SCHEDULE AT '2030-01-01 00:00:00' ON COMPLETION PRESERVE DO SET @y = 2", both()},
+		{"at-preserve-disable", "e", "CREATE EVENT e ON SCHEDULE AT '2030-06-01 00:00:00' ON COMPLETION PRESERVE DISABLE DO SET @y = 2", both()},
+	}
+}
+
+// TestOracle_EventIdempotence proves gate 1: each event form's user DDL vs its engine readback
+// diffs EMPTY, the stored form self-diffs empty, and the no-op plan is "", on every supported
+// version.
+func TestOracle_EventIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(version)
+		n := NormalizerFor(version)
+		ctx := context.Background()
+		conn, err := o.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("[%s] grab conn: %v", o.name, err)
+		}
+
+		for _, p := range eventIdempotenceProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				slug := strings.ReplaceAll(p.id, "-", "_")
+				rb, ok := eventReadback(t, conn, o.name, sc, "ev_idem_"+slug, p.create, p.event)
+				if !ok {
+					t.Skipf("[%s] could not obtain readback for %s", o.name, p.id)
+				}
+
+				userCat, _ := loadOneEvent(t, sc, p.create, p.event)
+				storedCat, _ := loadOneEvent(t, sc, rb, p.event)
+
+				if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] IDEMPOTENCE: stored self-diff not empty for %s:\n  stored: %s",
+						o.name, p.id, strings.TrimSpace(rb))
+				}
+				if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION: user vs stored not empty for %s:\n  user:   %s\n  stored: %s\n  events: %s",
+						o.name, p.id, strings.TrimSpace(p.create), strings.TrimSpace(rb), describeEventDiff(d))
+				}
+				if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION (reverse): stored vs user not empty for %s:\n  events: %s",
+						o.name, p.id, describeEventDiff(d))
+				}
+				plan := GenerateMigrationWithNormalizer(storedCat, storedCat, DiffWithNormalizer(storedCat, storedCat, n), n)
+				if plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s:\n%s", o.name, p.id, plan.SQL())
+				}
+			})
+		}
+		_ = conn.Close()
+	}
+}
+
+// eventMigrationProbes enumerates the (from, to) event transitions the generator covers: CREATE
+// (add), DROP, and ALTER for every mutable aspect (schedule, status, ON COMPLETION, comment, body)
+// and EVERY↔AT.
+func eventMigrationProbes() []struct {
+	id, event, fromCreate, toCreate string
+	versions                        []Version
+} {
+	const base = "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1"
+	return []struct {
+		id, event, fromCreate, toCreate string
+		versions                        []Version
+	}{
+		// CREATE (add).
+		{"create-every", "e", "", base, both()},
+		{"create-at", "e", "", "CREATE EVENT e ON SCHEDULE AT '2030-01-01 00:00:00' ON COMPLETION PRESERVE DO SET @y = 2", both()},
+		{"create-full", "e", "", "CREATE EVENT e ON SCHEDULE EVERY 1 DAY STARTS '2025-01-01 00:00:00' ENDS '2030-01-01 00:00:00' ON COMPLETION PRESERVE DISABLE COMMENT 'c' DO SET @q = 1", both()},
+		// DROP.
+		{"drop", "e", base, "", both()},
+		// ALTER — schedule interval.
+		{"alter-schedule-interval", "e", base, "CREATE EVENT e ON SCHEDULE EVERY 2 HOUR DO SET @x = 1", both()},
+		// ALTER — schedule unit.
+		{"alter-schedule-unit", "e", base, "CREATE EVENT e ON SCHEDULE EVERY 1 DAY DO SET @x = 1", both()},
+		// ALTER — EVERY -> AT (recurring to one-shot).
+		{"alter-every-to-at", "e", base, "CREATE EVENT e ON SCHEDULE AT '2030-01-01 00:00:00' ON COMPLETION PRESERVE DO SET @x = 1", both()},
+		// ALTER — status enable -> disable.
+		{"alter-status-disable", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENABLE DO SET @x = 1", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x = 1", both()},
+		// ALTER — status disable -> disable on slave.
+		{"alter-status-slave", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x = 1", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE ON SLAVE DO SET @x = 1", both()},
+		// ALTER — ON COMPLETION not preserve -> preserve.
+		{"alter-completion", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ON COMPLETION NOT PRESERVE DO SET @x = 1", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE DO SET @x = 1", both()},
+		// ALTER — comment.
+		{"alter-comment", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'a' DO SET @x = 1", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'b' DO SET @x = 1", both()},
+		// ALTER — add a comment where none existed.
+		{"alter-add-comment", "e", base, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'new' DO SET @x = 1", both()},
+		// ALTER — body.
+		{"alter-body", "e", base, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 2", both()},
+		// ALTER — add ENDS.
+		{"alter-add-ends", "e", base, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENDS '2030-01-01 00:00:00' DO SET @x = 1", both()},
+
+		// ---- field-CLEARING transitions (an ALTER that omits a clause must RESET it, not keep the
+		// old value). These are the class that hides the comment-removal bug. ----
+		{"alter-remove-comment", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR COMMENT 'old' DO SET @x = 1", base, both()},
+		{"alter-remove-ends", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENDS '2030-01-01 00:00:00' DO SET @x = 1", base, both()},
+		{"alter-status-reenable", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x = 1", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENABLE DO SET @x = 1", both()},
+		{"alter-completion-reset", "e", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ON COMPLETION PRESERVE DO SET @x = 1", "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ON COMPLETION NOT PRESERVE DO SET @x = 1", both()},
+		// AT one-shot -> recurring EVERY (reverse of alter-every-to-at).
+		{"alter-at-to-every", "e", "CREATE EVENT e ON SCHEDULE AT '2030-01-01 00:00:00' ON COMPLETION PRESERVE DO SET @x = 1", base, both()},
+	}
+}
+
+// TestOracle_EventApplyCorrectness proves gate 2: the generated plan transforms a real `from`
+// event-database into a `to`-equal one, for CREATE / DROP / ALTER across every form.
+func TestOracle_EventApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(version)
+		n := NormalizerFor(version)
+		for _, p := range eventMigrationProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				assertEventApplyCorrect(t, o, n, sc, p.id, p.event, p.fromCreate, p.toCreate)
+			})
+		}
+	}
+}
+
+// assertEventApplyCorrect loads from/to catalogs from the engine's own readbacks (authentic stored
+// forms), generates the plan, applies it to a from-state database, reads the result back, and
+// asserts the result canonicalizes equal to `to` (both directions). Each probe uses its own apply
+// database on ONE pinned connection, so the test is hermetic.
+func assertEventApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, sc, id, event, fromCreate, toCreate string) {
+	t.Helper()
+	slug := strings.ReplaceAll(id, "-", "_")
+	applyDB := "eva_" + slug
+	ctx := context.Background()
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	eventInTo := strings.TrimSpace(toCreate) != ""
+	eventInFrom := strings.TrimSpace(fromCreate) != ""
+
+	var toCat, fromCat *Catalog
+	if eventInTo {
+		rb, ok := eventReadback(t, conn, o.name, sc, "evto_"+slug, toCreate, event)
+		if !ok {
+			t.Skipf("[%s] could not obtain `to` readback for %s", o.name, id)
+		}
+		toCat, _ = loadOneEvent(t, sc, rb, event)
+	} else {
+		toCat = New()
+	}
+	if eventInFrom {
+		rb, ok := eventReadback(t, conn, o.name, sc, "evfrom_"+slug, fromCreate, event)
+		if !ok {
+			t.Skipf("[%s] could not obtain `from` readback for %s", o.name, id)
+		}
+		fromCat, _ = loadOneEvent(t, sc, rb, event)
+	} else {
+		fromCat = New()
+	}
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
+		"USE " + applyDB,
+	}
+	if eventInFrom {
+		setup = append(setup, fromCreate)
+	}
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, id, s, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	if !eventInTo {
+		if _, ok := scanShowCreateEvent(conn, applyDB, event); ok {
+			t.Errorf("[%s] %s: event %s still exists after DROP plan:\n%s", o.name, id, event, plan.SQL())
+		}
+		return
+	}
+
+	resultRB, ok := scanShowCreateEvent(conn, applyDB, event)
+	if !ok {
+		t.Fatalf("[%s] %s: result event %s missing after apply:\n%s", o.name, id, event, plan.SQL())
+	}
+	resultCat, _ := loadOneEvent(t, sc, resultRB, event)
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result: %s\n  events: %s",
+			o.name, id, plan.SQL(), strings.TrimSpace(resultRB), describeEventDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, id, describeEventDiff(d))
+	}
+}
+
+// describeEventDiff renders a compact human description of a SchemaDiff's event changes.
+func describeEventDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, e := range d.Events {
+		fmt.Fprintf(&b, "[event %s %s]", e.Name, e.Action)
+	}
+	if b.Len() == 0 {
+		return "(no event changes)"
+	}
+	return b.String()
+}


### PR DESCRIPTION
## What

Fills the scheduled-event breadth node for MySQL SDL: `diffEvents` → `SchemaDiff.Events` (`mysql/catalog/diff_event.go`) and `generateEventDDL` → `CREATE`/`ALTER`/`DROP EVENT` ops (`mysql/catalog/migration_event.go`, op-types `OpCreateEvent`/`OpDropEvent`, `priorityEvent=80`). Reuses the existing `EventDiffEntry` type and the wired hooks in `diff.go`/`migration.go` (those files are **not** edited). Events are database-level objects keyed by `(database, lower(name))`; equality is one canonical key (`eventCanonicalKey`), the event analog of `CanonicalColumn`.

Contract slice: `docs/migration/mysql/sdl/{contract.md,objects.md}` (events row); oracle: `docs/migration/mysql/sdl/oracle.md`.

## Scope covered

`CREATE EVENT`; schedule (`AT <ts>` one-shot vs `EVERY <interval> [STARTS..ENDS]` recurring); `ON COMPLETION [NOT] PRESERVE`; status `ENABLE`/`DISABLE`/`DISABLE ON SLAVE`; `COMMENT`; body. `ALTER EVENT` is preferred over `DROP`+`CREATE` where it applies.

## Canonicalization (grounded in live 5.7.25 + 8.0.32 probing)

- **SCHEDULE** — the engine auto-injects `STARTS '<create-time>'` for `EVERY` events when the user omits `STARTS`, and that injected value is indistinguishable in `SHOW CREATE EVENT` and `information_schema.EVENTS` from an explicit `STARTS`. `STARTS` is therefore dropped from the schedule key. `ENDS` is never auto-injected (NULL when absent) → kept. The engine re-renders quoted intervals (per-field leading-zero strip `'02:03:04'`→`'2:3:4'`; single-field unquoting `'05'`→`5`) → the interval literal is canonicalized to match.
- **STATUS / ON COMPLETION** — `ENABLE` / `NOT PRESERVE` are the defaults, always shown explicitly by `SHOW CREATE EVENT`; the catalog stores `""` for an unspecified value → folded to the default. `DISABLE ON SLAVE` kept distinct from `DISABLE`.
- **DEFINER** — ignore-in-diff: always resolves to the executing user (verified: `DEFINER=CURRENT_USER` and an omitted definer both store as `` `root`@`%` ``), and the `EventMetadata` proto carries no definer field.

### Normalization flags (recorded, evidence-backed)

- **FLAG 1 — STARTS** — a release changing ONLY an explicit `STARTS` on a recurring event is not detected (no signal distinguishes auto vs explicit `STARTS` in the stored form; the idempotence gate `EVERY 1 HOUR` ≡ `EVERY 1 HOUR STARTS '<now>'` forces the strip).
- **FLAG 2 — schedule expressions** — non-literal schedule expressions (`AT NOW()+INTERVAL 1 DAY`, `EVERY 60*60 SECOND`) are evaluated to literals by the engine, so hand-authored expression SDL would phantom-diff. Not normalized (offline evaluation needs the server clock). Does not affect the release path: bytebase syncs via `SHOW CREATE EVENT`, which always yields the evaluated literal.

## ALTER vs DROP+CREATE

`ALTER EVENT` is preferred (preserves the object). Fallback to `DROP`+`CREATE` only when `ENDS` is removed: **5.7's `ALTER EVENT … ON SCHEDULE` does not clear an existing `ENDS`** (verified on 5.7.25; 8.0.32 clears it). `COMMENT` is always rendered (`COMMENT ''` when empty) so an `ALTER` that drops a comment actually clears it (5.7 keeps an omitted comment otherwise).

## Proof — both gates, live oracle (5.7 :13307 ssl-disabled, 8.0 :13306)

`go test ./mysql/catalog/...` green. Event oracle tests (`migration_event_oracle_test.go`):
- **Idempotence** (`TestOracle_EventIdempotence`) — 15 forms × 2 versions: user-form `CREATE EVENT` vs its `SHOW CREATE EVENT` readback diffs empty; stored form self-diffs empty; no-op plan is `""`. Covers recurring/one-shot, varied schedule/status/options, quoted intervals, explicit/auto STARTS, ENDS, comments.
- **Apply-correctness** (`TestOracle_EventApplyCorrectness`) — 19 transitions × 2 versions: generated plan applied to a real `from` DB yields a `to`-equal event (both directions). Covers CREATE/DROP/ALTER for every mutable aspect (schedule interval/unit, EVERY↔AT, status, ON COMPLETION, comment, body) **and the field-clearing transitions** (comment→none, ENDS→none via the DROP+CREATE fallback, DISABLE→ENABLE, PRESERVE→NOT PRESERVE).

In-process unit tests (`diff_event_test.go`) lock the canonicalization (STARTS-strip, interval re-rendering, status/completion folding, DEFINER-ignore), the diff actions, the rendered DDL shapes, quote-aware schedule peeling, and UTF-8 safety of the keyword scan.

## Cross-family review

Reviewed by Claude (`/code-review`) and Codex (`/codex:review`), independently, blind. Two rounds: round 1 found a comment-removal apply bug and a non-quote-aware schedule peel → fixed (unconditional `COMMENT ''`; quote-aware `lastTopLevelKeyword`) + a 5.7 ENDS-removal `DROP`+`CREATE` fallback added; round 2 found a UTF-8 byte-index hazard in the keyword scan → fixed (per-byte ASCII fold). Both reviewers report **0 surviving blockers**.

## Dependency note (out of scope here)

End-to-end via bytebase needs `bb:bridge-triggers-events` to emit `EventMetadata` from `catalogToProto` (the generic `schema.MetadataDiff` already has `EventChanges`). This omni-level diff/generate works on the omni catalog (events loaded by `LoadSDL`) and is proven independently against the oracle — that is the deliverable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)