### PR TITLE
feat(mysql/catalog): implement view diff+generate (mysql SDL breadth)

### DIFF
--- a/mysql/catalog/diff_view.go
+++ b/mysql/catalog/diff_view.go
@@ -1,15 +1,321 @@
 package catalog
 
-// MySQL SDL diff — views (scaffold stub).
+import (
+	"sort"
+	"strings"
+)
+
+// MySQL SDL diff — views.
 //
-// Wired into DiffWithNormalizer (diff.go) so the SchemaDiff reports view changes via
-// SchemaDiff.Views. Inert no-op placeholder returning nil until the view breadth node
-// implements the real comparison. Signature mirrors diffTables (diff_table.go): whole-
-// catalog, taking from/to *Catalog and the version-fixing Normalizer (views are database-
-// level objects keyed by (database, name), not per-table).
+// This is the MySQL analog of PG's view differ (pg/catalog/diff_view.go). It compares the view
+// set of two catalogs and reports per-view changes via SchemaDiff.Views. It is wired into
+// DiffWithNormalizer (diff.go); a view is a database-level object keyed by (database, name), so —
+// like diffTables — it takes the whole catalog rather than a single table.
 //
-// implemented by omni:view breadth node
-func diffViews(_, _ *Catalog, _ *Normalizer) []ViewDiffEntry {
-	// Scaffold: returns nil so the view diff stays empty (self-diff inert).
-	return nil
+// IDEMPOTENCE — the view body is the risk (correctness-protocol.md). MySQL stores a rewritten
+// canonical form of the SELECT body in SHOW CREATE VIEW (fully-qualified columns, backtick
+// quoting, expanded *, lower-cased function names, parenthesized predicates). The omni loader
+// already reproduces most of that form: createView routes the body through deparseViewSelect
+// (Resolver → RewriteSelectStmt → DeparseSelect), so a user's `SELECT a,b FROM t` and the
+// engine's readback `select ... AS ... from ...` land on the same View.Definition — EXCEPT the
+// database-name qualifier. MySQL 8.0 qualifies a same-database column/table reference with the
+// database name (`db`.`t`.`a`); the omni deparse preserves whatever the parser produced, so the
+// engine readback keeps the `db.` prefix while the user form has none. The two would phantom-diff
+// forever. canonicalViewBody folds that prefix away (the view's OWN database only — a genuine
+// cross-database reference keeps its qualifier), so the user form and the stored form collapse
+// onto one key. This is the one canonicalization this node owns; everything else in the body is
+// already canonical out of deparse. (Normalization flag in the PR: the db-qualifier stripping
+// ideally belongs in mysql/deparse's resolver so the stored Definition is symmetric; it is done
+// here because this node may not edit deparse.)
+//
+// VERSION DIVERGENCE (5.7 vs 8.0), proven against the live oracle:
+//   - Explicit column list: 8.0 stores `CREATE ... VIEW v (c1,c2) AS select e1 AS a1,e2 AS a2`
+//     (the list is kept, the SELECT aliases stay the ORIGINAL expression names). 5.7 DROPS the
+//     list and instead RENAMES the SELECT aliases to the view column names
+//     (`select e1 AS c1,e2 AS c2`). So on 5.7 the explicit column list is folded into the body
+//     and View.ExplicitColumns round-trips as false. Comparing the explicit column list is
+//     therefore an 8.0-only concern (explicitColumnsComparable); on 5.7 the renamed aliases
+//     already live in the body, which the body key compares. The 5.7 alias-rename itself is NOT
+//     reproduced by the omni loader (the user's explicit-list form keeps `AS a1`), so a 5.7
+//     round-trip of an explicit-column-list view can still differ — a documented, flagged
+//     limitation (PR normalization flags), not a silently-wrong empty.
+//   - view-on-view: 8.0 qualifies the referenced view with its database, 5.7 does not — both
+//     handled by canonicalViewBody stripping the own-database qualifier.
+//
+// DEFINER is intentionally NOT compared. On the release path the synced `from` view is loaded
+// from a metadata SDL dump that carries no DEFINER (createView defaults it to `root`@`%`), while a
+// user's target SDL DEFINER is environment-specific; comparing it would phantom-diff every release
+// whose live view has a non-root definer. ALGORITHM, SQL SECURITY and WITH CHECK OPTION ARE
+// compared — they are stored-form-significant and identical across 5.7/8.0 (oracle-verified).
+func diffViews(from, to *Catalog, n *Normalizer) []ViewDiffEntry {
+	fromMap := buildViewMap(from)
+	toMap := buildViewMap(to)
+
+	var result []ViewDiffEntry
+
+	// Dropped: in from but not in to.
+	for key, fromView := range fromMap {
+		if _, ok := toMap[key]; !ok {
+			result = append(result, ViewDiffEntry{
+				Action:   DiffDrop,
+				Database: key.db,
+				Name:     key.name,
+				From:     fromView,
+			})
+		}
+	}
+
+	// Added or modified: in to.
+	for key, toView := range toMap {
+		fromView, ok := fromMap[key]
+		if !ok {
+			result = append(result, ViewDiffEntry{
+				Action:   DiffAdd,
+				Database: key.db,
+				Name:     key.name,
+				To:       toView,
+			})
+			continue
+		}
+		if viewsChanged(fromView, toView, n) {
+			result = append(result, ViewDiffEntry{
+				Action:   DiffModify,
+				Database: key.db,
+				Name:     key.name,
+				From:     fromView,
+				To:       toView,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Database != result[j].Database {
+			return result[i].Database < result[j].Database
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Action < result[j].Action
+	})
+
+	return result
+}
+
+// buildViewMap indexes every view in a catalog by (database, name) lower-cased, mirroring
+// buildTableMap. Tables and views share one namespace in MySQL, but they live in separate
+// catalog maps, so a name collision between a table and a view cannot occur within one valid
+// catalog; the table differ and the view differ each own their own map.
+func buildViewMap(c *Catalog) map[tableKey]*View {
+	m := make(map[tableKey]*View)
+	if c == nil {
+		return m
+	}
+	for _, db := range c.Databases() {
+		for name, v := range db.Views {
+			if v == nil {
+				continue
+			}
+			m[tableKey{db: toLower(db.Name), name: name}] = v
+		}
+	}
+	return m
+}
+
+// viewsChanged reports whether two same-identity views differ, comparing their canonical keys.
+// canonicalView folds every stored-form-significant attribute into one key, so this differ never
+// re-implements a per-attribute comparison (mirroring checksChanged / indexesChanged).
+func viewsChanged(a, b *View, n *Normalizer) bool {
+	return canonicalView(a, n) != canonicalView(b, n)
+}
+
+// canonicalView returns a single stable comparison key for a view, folding the attributes that
+// survive into MySQL's stored form:
+//   - the SELECT body, canonicalized by canonicalViewBody (own-database qualifier stripped);
+//   - ALGORITHM (UNDEFINED/MERGE/TEMPTABLE), upper-cased, defaulting to UNDEFINED;
+//   - SQL SECURITY (DEFINER/INVOKER), upper-cased, defaulting to DEFINER;
+//   - WITH [CASCADED|LOCAL] CHECK OPTION, upper-cased ("" when absent);
+//   - the explicit column list, but ONLY on a version that represents it in the stored form
+//     (8.0). On 5.7 the list is folded into the body's SELECT aliases (see diffViews), so
+//     comparing it there would phantom-diff; explicitColumnsComparable gates it out.
+//
+// DEFINER is deliberately excluded (ignore-in-diff; see diffViews). The view NAME is the identity
+// key (handled by the caller's map), not part of this content key.
+func canonicalView(v *View, n *Normalizer) string {
+	fields := []string{
+		"body", canonicalViewBody(v),
+		"algorithm", canonicalViewAlgorithm(v),
+		"sqlsecurity", canonicalViewSQLSecurity(v),
+		"checkoption", strings.ToUpper(v.CheckOption),
+	}
+	if explicitColumnsComparable(v, n) {
+		fields = append(fields, "columns", strings.Join(lowerAll(v.Columns), ","))
+	}
+	return encodeKeyFields(fields...)
+}
+
+// canonicalViewAlgorithm returns the upper-cased ALGORITHM, defaulting to UNDEFINED (the form
+// SHOW CREATE VIEW emits when none was specified). The loader already defaults it on load, so
+// this is belt-and-suspenders for a view assembled without going through createView.
+func canonicalViewAlgorithm(v *View) string {
+	if v.Algorithm == "" {
+		return "UNDEFINED"
+	}
+	return strings.ToUpper(v.Algorithm)
+}
+
+// canonicalViewSQLSecurity returns the upper-cased SQL SECURITY, defaulting to DEFINER (the
+// SHOW CREATE VIEW default), mirroring canonicalViewAlgorithm.
+func canonicalViewSQLSecurity(v *View) string {
+	if v.SqlSecurity == "" {
+		return "DEFINER"
+	}
+	return strings.ToUpper(v.SqlSecurity)
+}
+
+// explicitColumnsComparable reports whether a view's explicit column list is part of the stored
+// form for the target version and is therefore safe to compare directly. It is only on 8.0:
+// 8.0 keeps `CREATE ... VIEW v (c1,c2) AS ...` verbatim, so the column list is an independent
+// stored attribute. On 5.7 MySQL rewrites the list into the SELECT aliases and drops the clause
+// (View.ExplicitColumns becomes false on the readback), so the column identity already lives in
+// the body key — comparing the list separately would phantom-diff an explicit-list `to` against
+// its alias-folded 5.7 `from`. When neither side has an explicit list, there is nothing to
+// compare and this returns false regardless of version.
+func explicitColumnsComparable(v *View, n *Normalizer) bool {
+	if !v.ExplicitColumns {
+		return false
+	}
+	return n.Version == MySQL80
+}
+
+// canonicalViewBody returns the view's SELECT body in a database-qualifier-neutral canonical form:
+// the view's OWN database prefix (`db`.) is stripped from every table/column reference, so the
+// engine readback's 8.0-style `db`.`t`.`a` and the user form's `t`.`a` (both already produced by
+// deparseViewSelect) collapse onto the same string. Only the view's own database is stripped — a
+// reference into a different database keeps its qualifier, because that qualifier is semantically
+// load-bearing (it names a different object). A view with no Database (defensive; the loader
+// always sets it) is returned unchanged.
+//
+// This is the single canonicalization this node performs on top of deparse. It is a targeted
+// fold, not a re-deparse: deparse has already done the structural canonicalization (qualified
+// columns, expanded *, function casing, parenthesization); only the redundant own-database prefix
+// remains, and stripping it yields a portable, version-symmetric body. (Normalization flag: this
+// ideally belongs in mysql/deparse's resolver so View.Definition is symmetric at load time.)
+//
+// The strip is POSITION-AWARE, not a blind substring replace, to avoid two corruptions:
+//   - inside a string literal: a single-quoted literal may contain the text "`db`." (e.g.
+//     `SELECT '`vt`.x'`); blind replacement would mutate the literal's value and make two
+//     genuinely different views collide. So single-quoted regions are skipped.
+//   - a relation literally named the same as the database: `\`vt\`.\`vt\`.\`a\“ (db vt, table vt,
+//     column a) must lose only the LEADING `\`vt\`.` (the database slot), yielding
+//     `\`vt\`.\`a\“ (table vt, column a) — NOT both, which would destroy the table qualifier. So
+//     the prefix is stripped only when its `\`db\“ segment is the HEAD of a dotted chain (it is
+//     not itself immediately preceded by a '.', which would make it a table/column segment).
+func canonicalViewBody(v *View) string {
+	body := v.Definition
+	if v.Database == nil || v.Database.Name == "" {
+		return body
+	}
+	prefix := "`" + strings.ReplaceAll(v.Database.Name, "`", "``") + "`."
+	return stripOwnDatabaseQualifier(body, prefix)
+}
+
+// stripOwnDatabaseQualifier removes every database-qualifier occurrence of prefix ("`db`.") from a
+// deparsed SQL body. Two safeguards keep the strip from corrupting the body (see canonicalViewBody):
+//   - single-quoted string literals are skipped, so a literal containing the text "`db`." is left
+//     intact (different literal values must not collapse);
+//   - the prefix is only stripped at the HEAD of a dotted-identifier chain (its leading backtick is
+//     not itself immediately preceded by '.'), AND after a strip the immediately-following
+//     identifier segment is copied verbatim. The latter is what protects a relation/column literally
+//     named the same as the database: in `\`vt\`.\`vt\`.\`a\“ the leading `\`vt\`.` (database) is
+//     dropped, then the next `\`vt\“ (the table) is copied untouched, yielding `\`vt\`.\`a\“ — not
+//     `\`a\“ (which would destroy the table qualifier).
+func stripOwnDatabaseQualifier(body, prefix string) string {
+	var b strings.Builder
+	b.Grow(len(body))
+	inString := false
+	prev := byte(0) // last byte emitted (for the "chain head = not preceded by '.'" test)
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		if inString {
+			// Inside a single-quoted literal: copy verbatim. A backslash escapes the next byte; a
+			// lone quote ends the literal (a doubled '' stays inside via the escaped-next-byte path
+			// not applying — MySQL's deparse uses backslash escaping, but handle '' defensively).
+			b.WriteByte(c)
+			if c == '\\' && i+1 < len(body) {
+				b.WriteByte(body[i+1])
+				i += 2
+				continue
+			}
+			if c == '\'' {
+				if i+1 < len(body) && body[i+1] == '\'' { // doubled quote inside the literal
+					b.WriteByte(body[i+1])
+					i += 2
+					continue
+				}
+				inString = false
+			}
+			prev = c
+			i++
+			continue
+		}
+		if c == '\'' {
+			inString = true
+			b.WriteByte(c)
+			prev = c
+			i++
+			continue
+		}
+		// Outside a string: strip the prefix only at a chain head (not preceded by '.').
+		if prev != '.' && strings.HasPrefix(body[i:], prefix) {
+			i += len(prefix)
+			// Copy the following identifier segment (the table) verbatim so a table named like the
+			// database is not re-stripped as another chain head.
+			i = copyBacktickIdent(&b, body, i)
+			prev = '`' // the segment ended with a closing backtick (or nothing was copied)
+			continue
+		}
+		b.WriteByte(c)
+		prev = c
+		i++
+	}
+	return b.String()
+}
+
+// copyBacktickIdent copies a single backtick-quoted identifier starting at i (if one is there) from
+// src into b, returning the index just past it. A backtick inside the identifier is escaped by
+// doubling (“); the scan consumes both. If src[i] is not an opening backtick, nothing is copied and
+// i is returned unchanged.
+func copyBacktickIdent(b *strings.Builder, src string, i int) int {
+	if i >= len(src) || src[i] != '`' {
+		return i
+	}
+	b.WriteByte('`')
+	i++
+	for i < len(src) {
+		if src[i] == '`' {
+			if i+1 < len(src) && src[i+1] == '`' { // doubled backtick = escaped, stays in the ident
+				b.WriteString("``")
+				i += 2
+				continue
+			}
+			b.WriteByte('`')
+			i++
+			break
+		}
+		b.WriteByte(src[i])
+		i++
+	}
+	return i
+}
+
+// lowerAll lower-cases every string in a slice, returning a new slice. Used to make the explicit
+// column-list comparison case-insensitive (MySQL view column names are case-insensitive for
+// identity, like all MySQL identifiers in the stored form).
+func lowerAll(ss []string) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = toLower(s)
+	}
+	return out
 }

--- a/mysql/catalog/diff_view_test.go
+++ b/mysql/catalog/diff_view_test.go
@@ -1,0 +1,239 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Hermetic unit tests for the view differ + generator (no live engine). They assert the
+// structural diff actions, the canonical-key folding (body db-qualifier stripping, ALGORITHM /
+// SQL SECURITY / CHECK OPTION / explicit-column comparison, DEFINER-ignored), and the generated
+// DDL shape + view-on-view ordering. The oracle gates (idempotence + apply-correctness against
+// the real 5.7 / 8.0 engines) live in diff_view_oracle_test.go and migration_view_oracle_test.go.
+
+// loadViewCatalog loads SDL describing one or more views (and their tables) at a given version
+// and returns the catalog. The schema is wrapped in a database so view identity is (db, name).
+func loadViewCatalog(t *testing.T, version Version, sdl string) *Catalog {
+	t.Helper()
+	wrapped := "CREATE DATABASE vt DEFAULT CHARSET=utf8mb4;\nUSE vt;\n" + sdl
+	cat, err := LoadSDLWithVersion(wrapped, version)
+	if err != nil {
+		t.Fatalf("LoadSDLWithVersion failed for %q: %v", sdl, err)
+	}
+	return cat
+}
+
+func getView(t *testing.T, c *Catalog, name string) *View {
+	t.Helper()
+	db := c.GetDatabase("vt")
+	if db == nil {
+		t.Fatalf("database vt not found")
+	}
+	v := db.Views[toLower(name)]
+	if v == nil {
+		t.Fatalf("view %q not found", name)
+	}
+	return v
+}
+
+// findViewDiff returns the diff entry for a named view, or nil.
+func findViewDiff(d *SchemaDiff, name string) *ViewDiffEntry {
+	for i := range d.Views {
+		if strings.EqualFold(d.Views[i].Name, name) {
+			return &d.Views[i]
+		}
+	}
+	return nil
+}
+
+func TestDiffViews_SelfDiffEmpty(t *testing.T) {
+	for _, version := range []Version{MySQL57, MySQL80} {
+		sdl := `CREATE TABLE t (a INT, b VARCHAR(20), c INT);
+CREATE VIEW v1 AS SELECT a, b FROM t;
+CREATE VIEW v2 (p, q) AS SELECT a, b FROM t;
+CREATE ALGORITHM=MERGE SQL SECURITY INVOKER VIEW v3 AS SELECT a FROM t WHERE a > 0 WITH CASCADED CHECK OPTION;`
+		cat := loadViewCatalog(t, version, sdl)
+		n := NormalizerFor(version)
+		if d := DiffWithNormalizer(cat, cat, n); !d.IsEmpty() {
+			t.Errorf("[v%d] self-diff not empty: views=%d", version, len(d.Views))
+		}
+	}
+}
+
+func TestDiffViews_Add(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT, b INT);`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT a FROM t;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	e := findViewDiff(d, "v1")
+	if e == nil || e.Action != DiffAdd {
+		t.Fatalf("want v1 ADD, got %+v", d.Views)
+	}
+	if e.To == nil || e.From != nil {
+		t.Errorf("ADD entry should carry To and no From")
+	}
+}
+
+func TestDiffViews_Drop(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE VIEW v1 AS SELECT a FROM t;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	e := findViewDiff(d, "v1")
+	if e == nil || e.Action != DiffDrop {
+		t.Fatalf("want v1 DROP, got %+v", d.Views)
+	}
+	if e.From == nil || e.To != nil {
+		t.Errorf("DROP entry should carry From and no To")
+	}
+}
+
+func TestDiffViews_ModifyBody(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT a FROM t;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT b FROM t;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	e := findViewDiff(d, "v1")
+	if e == nil || e.Action != DiffModify {
+		t.Fatalf("want v1 MODIFY, got %+v", d.Views)
+	}
+}
+
+func TestDiffViews_ModifyAlgorithm(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE ALGORITHM=UNDEFINED VIEW v1 AS SELECT a FROM t;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE ALGORITHM=MERGE VIEW v1 AS SELECT a FROM t;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	if e := findViewDiff(d, "v1"); e == nil || e.Action != DiffModify {
+		t.Fatalf("algorithm change should be a MODIFY, got %+v", d.Views)
+	}
+}
+
+func TestDiffViews_ModifySQLSecurity(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE SQL SECURITY DEFINER VIEW v1 AS SELECT a FROM t;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE SQL SECURITY INVOKER VIEW v1 AS SELECT a FROM t;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	if e := findViewDiff(d, "v1"); e == nil || e.Action != DiffModify {
+		t.Fatalf("sql security change should be a MODIFY, got %+v", d.Views)
+	}
+}
+
+func TestDiffViews_ModifyCheckOption(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE VIEW v1 AS SELECT a FROM t WHERE a > 0 WITH CASCADED CHECK OPTION;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE VIEW v1 AS SELECT a FROM t WHERE a > 0 WITH LOCAL CHECK OPTION;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	if e := findViewDiff(d, "v1"); e == nil || e.Action != DiffModify {
+		t.Fatalf("check-option change should be a MODIFY, got %+v", d.Views)
+	}
+}
+
+func TestDiffViews_AddRemoveCheckOption(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE VIEW v1 AS SELECT a FROM t WHERE a > 0;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE VIEW v1 AS SELECT a FROM t WHERE a > 0 WITH CASCADED CHECK OPTION;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	if e := findViewDiff(d, "v1"); e == nil || e.Action != DiffModify {
+		t.Fatalf("adding a check option should be a MODIFY, got %+v", d.Views)
+	}
+}
+
+// DEFINER differences must NOT produce a diff (ignore-in-diff).
+func TestDiffViews_DefinerIgnored(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE DEFINER=`+"`root`@`%`"+` VIEW v1 AS SELECT a FROM t;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT);
+CREATE DEFINER=`+"`admin`@`localhost`"+` VIEW v1 AS SELECT a FROM t;`)
+	// Sanity: the definers really differ on the loaded views.
+	if getView(t, from, "v1").Definer == getView(t, to, "v1").Definer {
+		t.Fatalf("test setup: definers should differ")
+	}
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	if !d.IsEmpty() {
+		t.Errorf("DEFINER-only change must NOT diff (ignore-in-diff), got %d view changes", len(d.Views))
+	}
+}
+
+// On 8.0, an explicit column-list change is a modify; the list is a stored attribute.
+func TestDiffViews_ExplicitColumns80(t *testing.T) {
+	from := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 (p, q) AS SELECT a, b FROM t;`)
+	to := loadViewCatalog(t, MySQL80, `CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 (x, y) AS SELECT a, b FROM t;`)
+	d := DiffWithNormalizer(from, to, NormalizerFor(MySQL80))
+	if e := findViewDiff(d, "v1"); e == nil || e.Action != DiffModify {
+		t.Fatalf("explicit column-list change should be a MODIFY on 8.0, got %+v", d.Views)
+	}
+}
+
+// canonicalViewBody strips the view's OWN database qualifier but keeps a cross-database one.
+func TestCanonicalViewBody_StripsOwnDatabase(t *testing.T) {
+	db := &Database{Name: "vt"}
+	v := &View{
+		Name:       "v1",
+		Database:   db,
+		Definition: "select `vt`.`t`.`a` AS `a` from `vt`.`t`",
+	}
+	got := canonicalViewBody(v)
+	want := "select `t`.`a` AS `a` from `t`"
+	if got != want {
+		t.Errorf("own-db strip:\n  got:  %q\n  want: %q", got, want)
+	}
+
+	// A cross-database reference keeps its qualifier.
+	v2 := &View{
+		Name:       "v2",
+		Database:   db,
+		Definition: "select `other`.`t`.`a` AS `a` from `other`.`t`",
+	}
+	if got := canonicalViewBody(v2); got != v2.Definition {
+		t.Errorf("cross-db reference must be preserved:\n  got:  %q\n  want: %q", got, v2.Definition)
+	}
+}
+
+// Regression (review blocker): the strip must be position-aware, never a blind substring replace.
+func TestCanonicalViewBody_PositionAware(t *testing.T) {
+	db := &Database{Name: "vt"}
+
+	// A relation literally named the same as the database (`vt`.`vt`): only the LEADING database
+	// slot is stripped — the table qualifier `vt` must survive.
+	v := &View{Name: "w", Database: db, Definition: "select `vt`.`vt`.`a` AS `a` from `vt`.`vt`"}
+	got := canonicalViewBody(v)
+	want := "select `vt`.`a` AS `a` from `vt`"
+	if got != want {
+		t.Errorf("db-named relation: own-db slot only must be stripped:\n  got:  %q\n  want: %q", got, want)
+	}
+
+	// A string literal that contains the token `vt`. must be left untouched (different literal
+	// values must NOT collapse to the same canonical body).
+	v1 := &View{Name: "s", Database: db, Definition: "select '`vt`.x' AS `s` from `vt`.`t`"}
+	v2 := &View{Name: "s", Database: db, Definition: "select '`vt`.y' AS `s` from `vt`.`t`"}
+	b1, b2 := canonicalViewBody(v1), canonicalViewBody(v2)
+	if b1 == b2 {
+		t.Errorf("string-literal content must not be stripped/collapsed: both = %q", b1)
+	}
+	if !strings.Contains(b1, "'`vt`.x'") {
+		t.Errorf("string literal mangled: %q", b1)
+	}
+}
+
+// User-form body (db-unqualified) and engine-form body (db-qualified) collapse to the same
+// canonical key — the core idempotence property, here exercised without a live engine.
+func TestCanonicalView_UserVsEngineBodyConverge(t *testing.T) {
+	db := &Database{Name: "vt"}
+	user := &View{Name: "v1", Database: db, Algorithm: "UNDEFINED", SqlSecurity: "DEFINER",
+		Definition: "select `t`.`a` AS `a`,`t`.`b` AS `b` from `t`"}
+	engine := &View{Name: "v1", Database: db, Algorithm: "UNDEFINED", SqlSecurity: "DEFINER",
+		Definition: "select `vt`.`t`.`a` AS `a`,`vt`.`t`.`b` AS `b` from `vt`.`t`"}
+	n := NormalizerFor(MySQL80)
+	if canonicalView(user, n) != canonicalView(engine, n) {
+		t.Errorf("user vs engine body did not converge:\n  user:   %q\n  engine: %q",
+			canonicalView(user, n), canonicalView(engine, n))
+	}
+}

--- a/mysql/catalog/migration_view.go
+++ b/mysql/catalog/migration_view.go
@@ -1,14 +1,340 @@
 package catalog
 
-// MySQL SDL generate — views (scaffold stub).
+import (
+	"fmt"
+	"strings"
+
+	nodes "github.com/bytebase/omni/mysql/ast"
+	mysqlparser "github.com/bytebase/omni/mysql/parser"
+)
+
+// MySQL SDL generate — views.
 //
-// Wired into GenerateMigrationWithNormalizer (migration.go) so view diffs (SchemaDiff.Views)
-// become DDL. Inert no-op placeholder returning nil until the view breadth node renders the
-// CREATE/DROP VIEW ops (OpCreateView/OpDropView, priorityView). Signature mirrors
-// generateTableDDL (migration_table.go).
+// This is the MySQL analog of PG's view generator (pg/catalog/migration_view.go). It turns the
+// view diff (SchemaDiff.Views, populated by diff_view.go) into CREATE OR REPLACE VIEW / DROP VIEW
+// DDL. It is wired into GenerateMigrationWithNormalizer (migration.go) against the
+// OpCreateView/OpDropView op-types at priorityView.
 //
-// implemented by omni:view breadth node
-func generateViewDDL(_, _ *Catalog, _ *SchemaDiff, _ *Normalizer) []MigrationOp {
-	// Scaffold: returns nil so the plan gains no view ops (empty diff -> empty plan).
-	return nil
+// Op mapping:
+//   - DiffAdd / DiffModify → CREATE OR REPLACE VIEW. MySQL has no ALTER-for-redefine that covers
+//     every attribute (ALTER VIEW exists but CREATE OR REPLACE is the dump/restore form and the
+//     one a declarative migration wants — it both creates a new view and atomically redefines an
+//     existing one). So an added view and a changed view emit the SAME statement; "view change =
+//     CREATE OR REPLACE VIEW".
+//   - DiffDrop → DROP VIEW IF EXISTS.
+//
+// PHASE / ORDERING (apply-correctness, oracle-verified):
+//   - CREATE runs in PhaseMain at priorityView (=50), AFTER table creation (priorityTable=10) and
+//     column ALTERs (priorityColumn=20). A view over a freshly created/altered table therefore
+//     applies against the final table — creating a view whose referenced table does not yet exist
+//     fails (live-verified), so this ordering is required.
+//   - view-on-view: a view that references another view being created in the SAME plan must be
+//     created AFTER it (the dependency must exist first — live-verified to fail otherwise). The
+//     ops all share priorityView, so the intra-priority tie-break (sortName, then stable original
+//     order) must encode the dependency order. viewCreateOrder computes a topological depth per
+//     view from the in-batch reference graph and prefixes the sortName with a zero-padded depth,
+//     so the global stable sort (Phase → Priority → sortName) emits a referenced view before its
+//     referrer. CREATE OR REPLACE of an already-existing dependency while a dependent exists does
+//     NOT require ordering (live-verified to succeed), so this only matters for brand-new
+//     view-on-view chains — but the depth ordering is harmless and uniform, so it is always
+//     applied.
+//   - DROP runs in PhasePre (before all creates), so a view dropped and re-created in one plan
+//     never collides. MySQL permits dropping a view another view still references (the dependent
+//     merely becomes invalid — live-verified), so drops need no inter-view ordering; a plain
+//     name sort is enough.
+//
+// RENDERING routes through formatCreateOrReplaceView, which emits the stored SHOW CREATE VIEW form
+// (ALGORITHM / SQL SECURITY preamble, optional explicit column list, AS <body>, optional WITH CHECK
+// OPTION) minus DEFINER — so the readback of the emitted DDL canonicalizes equal to `to` and
+// apply-correctness holds. DEFINER is omitted on purpose (ignore-in-diff + a least-privilege apply
+// hazard; see formatCreateOrReplaceView). The body is emitted as stored (v.Definition); MySQL
+// re-qualifies a database-unqualified reference against the view's database on apply (live-verified),
+// and the diff's canonical comparison — not the emitted text — is what absorbs the db-qualifier
+// difference on the readback.
+func generateViewDDL(_, _ *Catalog, diff *SchemaDiff, _ *Normalizer) []MigrationOp {
+	if diff == nil || len(diff.Views) == 0 {
+		return nil
+	}
+
+	// Depth per (created/modified) view, encoding view-on-view dependency order so a referenced
+	// view's CREATE sorts before its referrer's. Keyed by lower-cased (database, name).
+	depth := viewCreateOrder(diff.Views)
+
+	var ops []MigrationOp
+	for i := range diff.Views {
+		entry := &diff.Views[i]
+		switch entry.Action {
+		case DiffAdd, DiffModify:
+			if entry.To == nil {
+				continue
+			}
+			ops = append(ops, createViewOp(entry, depth))
+		case DiffDrop:
+			if entry.From == nil {
+				continue
+			}
+			ops = append(ops, dropViewOp(entry))
+		}
+	}
+
+	return ops
+}
+
+// createViewOp builds a CREATE OR REPLACE VIEW op (PhaseMain, priorityView). The sortName is
+// prefixed with the view's topological depth so the global stable sort creates a referenced view
+// before its referrer (see generateViewDDL ordering notes).
+func createViewOp(entry *ViewDiffEntry, depth map[tableKey]int) MigrationOp {
+	v := entry.To
+	d := depth[tableKey{db: toLower(entry.Database), name: toLower(entry.Name)}]
+	return MigrationOp{
+		Type:       OpCreateView,
+		Database:   entry.Database,
+		ObjectName: entry.Name,
+		SQL:        formatCreateOrReplaceView(v),
+		Phase:      PhaseMain,
+		Priority:   priorityView,
+		sortName:   viewCreateSortName(d, entry.Database, entry.Name),
+	}
+}
+
+// dropViewOp builds a DROP VIEW IF EXISTS op (PhasePre, priorityView). IF EXISTS keeps the drop
+// idempotent against a view already absent on the target (defensive; the diff only emits a drop
+// for a view present in `from`). Drops run in PhasePre so a drop-then-recreate of the same name
+// never collides, and need no inter-view ordering (MySQL allows dropping a referenced view).
+func dropViewOp(entry *ViewDiffEntry) MigrationOp {
+	return MigrationOp{
+		Type:       OpDropView,
+		Database:   entry.Database,
+		ObjectName: entry.Name,
+		SQL:        fmt.Sprintf("DROP VIEW IF EXISTS %s", viewIdent(entry.From, entry.Database, entry.Name)),
+		Phase:      PhasePre,
+		Priority:   priorityView,
+		sortName:   viewSortName(entry.Database, entry.Name),
+	}
+}
+
+// formatCreateOrReplaceView renders a view's full CREATE OR REPLACE statement in MySQL's canonical
+// stored form, mirroring show.go's showCreateView (ALGORITHM / SQL SECURITY preamble, optional
+// explicit column list, AS body, optional WITH CHECK OPTION) but with CREATE OR REPLACE and a
+// database-qualified view name. Because the rendered statement is the stored form for the target
+// version, the readback of the applied DDL canonicalizes equal to `to`.
+//
+// DEFINER is intentionally NOT emitted. It is ignore-in-diff (see diff_view.go), so emitting it
+// would add no declarative meaning — and `CREATE OR REPLACE DEFINER=<other> VIEW` requires the
+// applying session to hold SET_USER_ID / SUPER (else MySQL errno 1227), which would fail the whole
+// migration on a least-privilege deployment. Omitting the clause makes MySQL default the definer to
+// the current user, which is always permitted and re-reads as a definer the diff ignores anyway, so
+// apply-correctness still holds. (The loader defaults Definer to `root`@`%` on load; forcing that on
+// apply is exactly the privilege hazard we avoid.)
+func formatCreateOrReplaceView(v *View) string {
+	var b strings.Builder
+
+	b.WriteString("CREATE OR REPLACE")
+
+	algorithm := v.Algorithm
+	if algorithm == "" {
+		algorithm = "UNDEFINED"
+	}
+	fmt.Fprintf(&b, " ALGORITHM=%s", strings.ToUpper(algorithm))
+
+	sqlSecurity := v.SqlSecurity
+	if sqlSecurity == "" {
+		sqlSecurity = "DEFINER"
+	}
+	fmt.Fprintf(&b, " SQL SECURITY %s", strings.ToUpper(sqlSecurity))
+
+	fmt.Fprintf(&b, " VIEW %s", viewIdent(v, v.databaseName(), v.Name))
+
+	// Explicit column list (only when the user specified one). On 5.7 the engine folds this into
+	// the SELECT aliases and drops the clause; emitting it on a 5.7 target is still accepted
+	// (MySQL applies the rename), and the diff's 5.7 handling does not compare the list, so this
+	// rendering is safe on both versions.
+	if v.ExplicitColumns && len(v.Columns) > 0 {
+		cols := make([]string, len(v.Columns))
+		for i, c := range v.Columns {
+			cols[i] = migrationQuoteIdent(c)
+		}
+		fmt.Fprintf(&b, " (%s)", strings.Join(cols, ","))
+	}
+
+	b.WriteString(" AS ")
+	b.WriteString(v.Definition)
+
+	if v.CheckOption != "" {
+		fmt.Fprintf(&b, " WITH %s CHECK OPTION", strings.ToUpper(v.CheckOption))
+	}
+
+	return b.String()
+}
+
+// viewIdent returns the backtick-quoted database.view identifier for migration DDL, using the
+// view's ORIGINAL-CASE name and database (mirroring tableIdent for tables). The database
+// qualifier is taken from the diff entry's Database when the View carries no Database back-pointer
+// (defensive — the loader always sets it). A view with no database resolves to a bare name (the
+// synced single-database release path may load with no qualifying database).
+func viewIdent(v *View, database, name string) string {
+	// Prefer the view's own original-case names; fall back to the diff entry's lower-cased keys.
+	dbName := database
+	viewName := name
+	if v != nil {
+		if v.Name != "" {
+			viewName = v.Name
+		}
+		if dn := v.databaseName(); dn != "" {
+			dbName = dn
+		}
+	}
+	if dbName == "" {
+		return migrationQuoteIdent(viewName)
+	}
+	return migrationQuoteIdent(dbName) + "." + migrationQuoteIdent(viewName)
+}
+
+// databaseName returns the view's database name, or "" if it has no database back-pointer.
+func (v *View) databaseName() string {
+	if v == nil || v.Database == nil {
+		return ""
+	}
+	return v.Database.Name
+}
+
+// viewCreateOrder computes a topological depth for every created/modified view, so that a view
+// referencing another view in the same batch sorts after it. Depth 0 = references no other batch
+// view (only tables, or views not in this plan); depth d = one more than the deepest batch view it
+// references. The depth becomes a zero-padded sortName prefix, so the global stable sort emits
+// shallower (referenced) views before deeper (referring) ones.
+//
+// Dependencies are read from the deparsed body by extracting the relations it references at FROM /
+// JOIN positions (referencedRelations), then keeping only edges to OTHER views in this same batch.
+// Position-anchored extraction is what makes this precise: a relation appears only after `from `,
+// `join `, or an opening `(` (the deparse parenthesizes join arms), whereas a COLUMN is rendered
+// `\`tbl\`.\`col\“ and a column ALIAS as `AS \`name\“ — neither sits at a relation anchor — so a
+// column or alias that merely shares a batch view's name does NOT produce a false edge (the bug an
+// earlier substring scan had). Matching is on the full (database, name) key, so a same-named view
+// in a different database is not conflated either.
+//
+// Self-references and cycles cannot arise in a valid MySQL view set (a view cannot reference itself
+// or form a cycle), so the longest-path depth via memoized DFS terminates; a defensive visiting-
+// guard breaks any cycle at depth 0 on malformed input rather than recursing forever.
+func viewCreateOrder(entries []ViewDiffEntry) map[tableKey]int {
+	// The views being created/modified, keyed by identity, with the relation set each references.
+	type viewInfo struct {
+		key  tableKey
+		refs map[tableKey]bool // relations referenced at FROM/JOIN positions
+	}
+	creates := make([]viewInfo, 0, len(entries))
+	idxByKey := make(map[tableKey]int) // identity -> index into creates
+	for i := range entries {
+		e := &entries[i]
+		if e.Action == DiffDrop || e.To == nil {
+			continue
+		}
+		k := tableKey{db: toLower(e.Database), name: toLower(e.Name)}
+		idxByKey[k] = len(creates)
+		creates = append(creates, viewInfo{key: k, refs: referencedRelations(e.To.Definition, k.db)})
+	}
+
+	// Edge i -> j when view i references batch view j at a FROM/JOIN position.
+	refIdx := make([][]int, len(creates))
+	for i, ci := range creates {
+		for j, cj := range creates {
+			if i == j {
+				continue
+			}
+			if ci.refs[cj.key] {
+				refIdx[i] = append(refIdx[i], j)
+			}
+		}
+	}
+
+	depth := make(map[tableKey]int, len(creates))
+	memo := make([]int, len(creates))
+	for i := range memo {
+		memo[i] = -1
+	}
+	visiting := make([]bool, len(creates))
+	var compute func(i int) int
+	compute = func(i int) int {
+		if memo[i] >= 0 {
+			return memo[i]
+		}
+		if visiting[i] {
+			// Defensive: a cycle (impossible for valid views) — break it at 0.
+			return 0
+		}
+		visiting[i] = true
+		best := 0
+		for _, j := range refIdx[i] {
+			if d := compute(j) + 1; d > best {
+				best = d
+			}
+		}
+		visiting[i] = false
+		memo[i] = best
+		return best
+	}
+	for i, ci := range creates {
+		depth[ci.key] = compute(i)
+	}
+	return depth
+}
+
+// referencedRelations returns the set of (database, name) keys a deparsed view body references as
+// real relations (base tables / views), lower-cased, with an unqualified reference resolved against
+// ownDB (the view's own database) — matching how the diff keys views, so a same-database reference
+// resolves to the batch view's key.
+//
+// It works on the PARSED AST, not the body text. That is what makes it robust where a text scan is
+// not: a CTE name, a column or a column alias that matches a relation name, a relation name inside a
+// string literal, and a column reference inside an ON-clause are all correctly excluded by the
+// structural walk. Two top-level body shapes are handled:
+//   - a SELECT (including UNION/INTERSECT/EXCEPT and parenthesized selects, all *SelectStmt) — refs
+//     come from selectTableRefs, the same FROM/JOIN extractor the SDL loader uses, which drops names
+//     bound by a top-level CTE;
+//   - a `TABLE t` query primary (MySQL 8.0.19+; deparsed as `table \`t\“ and re-parsed to a
+//     *TableStmt) — a TABLE primary is `SELECT * FROM t`, so its single Table ref is the relation.
+//
+// If the body fails to re-parse, or is some other statement shape, the empty set is returned, so the
+// view simply carries no view-on-view ordering constraint; that fallback is conservative (a missing
+// edge could only matter for a brand-new view-on-view chain).
+func referencedRelations(body, ownDB string) map[tableKey]bool {
+	out := make(map[tableKey]bool)
+	list, err := mysqlparser.Parse(body)
+	if err != nil || list == nil || len(list.Items) == 0 {
+		return out
+	}
+	addRef := func(ref *nodes.TableRef) {
+		if ref == nil || ref.Name == "" {
+			return
+		}
+		db := ref.Schema
+		if db == "" {
+			db = ownDB
+		}
+		out[tableKey{db: toLower(db), name: toLower(ref.Name)}] = true
+	}
+	switch stmt := list.Items[0].(type) {
+	case *nodes.SelectStmt:
+		for _, ref := range selectTableRefs(stmt) {
+			addRef(ref)
+		}
+	case *nodes.TableStmt:
+		// `TABLE t` is sugar for `SELECT * FROM t`; its single relation is the dependency.
+		addRef(stmt.Table)
+	}
+	return out
+}
+
+// viewSortName is the stable secondary sort key for a view-level op: lower-cased database.view.
+func viewSortName(database, name string) string {
+	return strings.ToLower(database) + "." + strings.ToLower(name)
+}
+
+// viewCreateSortName prefixes the view sort name with a zero-padded topological depth so that,
+// among the priorityView CREATE ops, a referenced view (smaller depth) sorts before its referrer
+// (larger depth). The width is 5 only to keep realistic depths fixed-width; %d never truncates, so
+// even an (impossible) depth ≥ 100000 still encodes its true magnitude — it would merely lose the
+// fixed-width alignment, and a view graph that deep cannot exist anyway.
+func viewCreateSortName(depth int, database, name string) string {
+	return fmt.Sprintf("%05d.%s", depth, viewSortName(database, name))
 }

--- a/mysql/catalog/migration_view_oracle_test.go
+++ b/mysql/catalog/migration_view_oracle_test.go
@@ -1,0 +1,543 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the view differ + generator (correctness-protocol.md gates 1 & 2), against
+// the LIVE MySQL engines (5.7 :13307 ssl-disabled, 8.0 :13306). Two properties are proven
+// mechanically across every view FORM the node covers, on BOTH versions:
+//
+//  1. IDEMPOTENCE (the spine). A schema (tables + views) is applied to a real database; each
+//     view's SHOW CREATE VIEW and each table's SHOW CREATE TABLE are read back and reassembled
+//     into SDL. Loading that engine-stored SDL and diffing it against itself is empty, and —
+//     the headline property — diffing the USER-form SDL against the ENGINE-stored SDL is also
+//     empty. A non-empty diff on a no-op means the view-body canonicalization (db-qualifier
+//     stripping) disagrees with what the engine stores → a normalization bug.
+//
+//  2. APPLY-CORRECTNESS. For representative (from, to) schema pairs, the generated CREATE OR
+//     REPLACE / DROP VIEW DDL applied to a real `from` database yields a schema whose views
+//     canonicalize equal to `to` — including view-on-table and view-on-view dependency ordering.
+//
+// The harness reuses connectOracle / serverCharsetFor / both() / only() / containsVersion from the
+// normalize + diff oracle tests, and skips cleanly when the engines are unreachable (go test
+// -short skips it).
+//
+// 5.7-vs-8.0 view-body divergences this file exercises (oracle-verified, see diff_view.go):
+//   - column qualification: 8.0 qualifies same-db refs with the database, 5.7 (for view-on-view)
+//     does not — folded by canonicalViewBody on both.
+//   - explicit column list: kept on 8.0, rewritten into renamed SELECT aliases on 5.7. The 5.7
+//     rewrite is NOT reproduced by the omni loader, so explicit-column-list views are proven on
+//     8.0 and FLAGGED as a known 5.7 limitation (they are version-gated to 8.0 here).
+
+// viewSchemaProbe is one schema (a set of CREATE statements) plus the table + view names to read
+// back. `setup` are the CREATE TABLE / CREATE VIEW statements in dependency order (LoadSDL is
+// order-tolerant, but the engine apply is not, so they are listed creatable-order).
+type viewSchemaProbe struct {
+	id       string
+	setup    []string
+	tables   []string
+	views    []string
+	versions []Version
+}
+
+// viewIdempotenceProbes enumerates representative view FORMS whose user-declared body differs from
+// the engine's stored SHOW CREATE VIEW form but must canonicalize equal. Each is proven on the
+// listed versions.
+func viewIdempotenceProbes() []viewSchemaProbe {
+	return []viewSchemaProbe{
+		{"simple", []string{
+			"CREATE TABLE t (a INT, b VARCHAR(20), c INT)",
+			"CREATE VIEW v AS SELECT a, b FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"star-expanded", []string{
+			"CREATE TABLE t (a INT, b VARCHAR(20), c INT)",
+			"CREATE VIEW v AS SELECT * FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"where-expr", []string{
+			"CREATE TABLE t (a INT, b VARCHAR(20))",
+			"CREATE VIEW v AS SELECT a FROM t WHERE a > 0",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"expr-and-func", []string{
+			"CREATE TABLE t (a INT, b VARCHAR(20))",
+			"CREATE VIEW v AS SELECT a + 1 AS s, UPPER(b) AS ub FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"join", []string{
+			"CREATE TABLE t (a INT, b VARCHAR(20), c INT)",
+			"CREATE TABLE u (x INT, y INT)",
+			"CREATE VIEW v AS SELECT t.a, u.y FROM t JOIN u ON t.c = u.x",
+		}, []string{"t", "u"}, []string{"v"}, both()},
+		{"left-join", []string{
+			"CREATE TABLE t (a INT, c INT)",
+			"CREATE TABLE u (x INT, y INT)",
+			"CREATE VIEW v AS SELECT t.a, u.y FROM t LEFT JOIN u ON t.c = u.x",
+		}, []string{"t", "u"}, []string{"v"}, both()},
+		{"algorithm-merge", []string{
+			"CREATE TABLE t (a INT)",
+			"CREATE ALGORITHM=MERGE VIEW v AS SELECT a FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"algorithm-temptable", []string{
+			"CREATE TABLE t (a INT)",
+			"CREATE ALGORITHM=TEMPTABLE VIEW v AS SELECT a FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"sql-security-invoker", []string{
+			"CREATE TABLE t (a INT)",
+			"CREATE SQL SECURITY INVOKER VIEW v AS SELECT a FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"check-cascaded", []string{
+			"CREATE TABLE t (a INT)",
+			"CREATE VIEW v AS SELECT a FROM t WHERE a > 0 WITH CASCADED CHECK OPTION",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"check-local", []string{
+			"CREATE TABLE t (a INT)",
+			"CREATE VIEW v AS SELECT a FROM t WHERE a > 0 WITH LOCAL CHECK OPTION",
+		}, []string{"t"}, []string{"v"}, both()},
+		{"view-on-view", []string{
+			"CREATE TABLE t (a INT, b INT)",
+			"CREATE VIEW base AS SELECT a, b FROM t",
+			"CREATE VIEW v AS SELECT a FROM base",
+		}, []string{"t"}, []string{"base", "v"}, both()},
+		{"cte", []string{
+			"CREATE TABLE t (a INT, b INT)",
+			"CREATE VIEW v AS WITH cte AS (SELECT a, b FROM t) SELECT a FROM cte",
+		}, []string{"t"}, []string{"v"}, only(MySQL80)},
+		{"union", []string{
+			"CREATE TABLE t (a INT)",
+			"CREATE TABLE u (a INT)",
+			"CREATE VIEW v AS SELECT a FROM t UNION SELECT a FROM u",
+		}, []string{"t", "u"}, []string{"v"}, both()},
+		{"group-by-agg", []string{
+			"CREATE TABLE t (a INT, b INT)",
+			"CREATE VIEW v AS SELECT a, COUNT(*) AS n FROM t GROUP BY a",
+		}, []string{"t"}, []string{"v"}, both()},
+		// Explicit column list: 8.0 keeps the list + original aliases (round-trips); 5.7 rewrites
+		// into renamed aliases (a FLAGGED loader limitation), so proven on 8.0 only.
+		{"explicit-columns", []string{
+			"CREATE TABLE t (a INT, b VARCHAR(20))",
+			"CREATE VIEW v (p, q) AS SELECT a, b FROM t",
+		}, []string{"t"}, []string{"v"}, only(MySQL80)},
+		{"view-on-view-explicit-cols", []string{
+			"CREATE TABLE t (a INT, b INT)",
+			"CREATE VIEW base (x, y) AS SELECT a, b FROM t",
+			"CREATE VIEW v AS SELECT x FROM base",
+		}, []string{"t"}, []string{"base", "v"}, only(MySQL80)},
+	}
+}
+
+// applyViewSchema drops + recreates dbName with the box's server charset and applies every setup
+// statement on a single dedicated connection (database/sql pools connections, so USE must share
+// the connection with the following statements). Returns the connection (caller closes) or skips.
+func (o *oracleConn) applyViewSchema(t *testing.T, dbName string, setup []string) (*sql.Conn, bool) {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	stmts := append([]string{
+		"DROP DATABASE IF EXISTS " + dbName,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", dbName, serverCharsetFor(o.version)),
+		"USE " + dbName,
+	}, setup...)
+	for _, s := range stmts {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Logf("[%s] view schema setup failed (may be expected): %q: %v", o.name, s, err)
+			_ = conn.Close()
+			return nil, false
+		}
+	}
+	return conn, true
+}
+
+// dumpViewSchemaSDL reads back SHOW CREATE for the named tables and views on conn (queried in the
+// physical database `physDB`) and assembles a reloadable SDL string wrapped in the LOGICAL database
+// `logicalDB`. SHOW CREATE VIEW returns a db-qualified view name (`physDB`.`v`); to make the
+// reloaded catalog's identity independent of the throwaway physical db, that qualifier is rewritten
+// to `logicalDB`, so both the `from` and `to` catalogs (and the apply database) share one database
+// name and the generated DDL qualifies objects under it. Views are dumped in the given order
+// (dependency order); LoadSDL re-sorts anyway.
+func (o *oracleConn) dumpViewSchemaSDL(t *testing.T, conn *sql.Conn, physDB, logicalDB string, tables, views []string) (string, bool) {
+	t.Helper()
+	ctx := context.Background()
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", logicalDB, serverCharsetFor(o.version), logicalDB)
+	for _, tbl := range tables {
+		var name, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", physDB, tbl))
+		if err := row.Scan(&name, &ddl); err != nil {
+			t.Logf("[%s] SHOW CREATE TABLE %s failed: %v", o.name, tbl, err)
+			return "", false
+		}
+		// SHOW CREATE TABLE returns an unqualified `CREATE TABLE \`t\` ...`; the USE above scopes it.
+		b.WriteString(ddl)
+		b.WriteString(";\n")
+	}
+	physPrefix := "`" + physDB + "`."
+	logicalPrefix := "`" + logicalDB + "`."
+	for _, vw := range views {
+		// SHOW CREATE VIEW returns 4 columns: View, Create View, character_set_client, collation.
+		var name, ddl, csClient, coll string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE VIEW %s.%s", physDB, vw))
+		if err := row.Scan(&name, &ddl, &csClient, &coll); err != nil {
+			t.Logf("[%s] SHOW CREATE VIEW %s failed: %v", o.name, vw, err)
+			return "", false
+		}
+		// Rewrite the physical-db qualifier (on the view name and any same-db references in the
+		// body) to the logical db so the reloaded catalog is db-name-stable.
+		b.WriteString(strings.ReplaceAll(ddl, physPrefix, logicalPrefix))
+		b.WriteString(";\n")
+	}
+	return b.String(), true
+}
+
+// userFormSDL wraps a probe's setup statements into a reloadable SDL string under dbName.
+func userFormSDL(o *oracleConn, dbName string, setup []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n", dbName, serverCharsetFor(o.version), dbName)
+	for _, s := range setup {
+		b.WriteString(s)
+		b.WriteString(";\n")
+	}
+	return b.String()
+}
+
+// describeViewDiff renders a compact description of a SchemaDiff's view changes for failure output.
+func describeViewDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, ve := range d.Views {
+		fmt.Fprintf(&b, "[view %s.%s %s]", ve.Database, ve.Name, ve.Action)
+	}
+	for _, te := range d.Tables {
+		fmt.Fprintf(&b, "[table %s %s]", te.Name, te.Action)
+	}
+	return b.String()
+}
+
+// TestOracle_ViewIdempotence proves gates 1 & 2 for every view form: the user-declared schema and
+// its engine-stored readback diff EMPTY (both directions), and each side self-diffs empty.
+func TestOracle_ViewIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range viewIdempotenceProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				dbName := "videm_" + strings.ReplaceAll(probe.id, "-", "_")
+				conn, ok := o.applyViewSchema(t, dbName, probe.setup)
+				if !ok {
+					t.Skipf("[%s] could not apply schema for %s", o.name, probe.id)
+				}
+				defer func() { _ = conn.Close() }()
+
+				storedSDL, ok := o.dumpViewSchemaSDL(t, conn, dbName, dbName, probe.tables, probe.views)
+				if !ok {
+					t.Skipf("[%s] could not dump readback for %s", o.name, probe.id)
+				}
+				userSDL := userFormSDL(o, dbName, probe.setup)
+
+				storedCat, err := LoadSDLWithVersion(storedSDL, version)
+				if err != nil {
+					t.Fatalf("[%s] load stored SDL failed: %v\n%s", o.name, err, storedSDL)
+				}
+				userCat, err := LoadSDLWithVersion(userSDL, version)
+				if err != nil {
+					t.Fatalf("[%s] load user SDL failed: %v\n%s", o.name, err, userSDL)
+				}
+
+				if d := DiffWithNormalizer(storedCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] IDEMPOTENCE: stored self-diff not empty for %s: %s\n  stored SDL:\n%s",
+						o.name, probe.id, describeViewDiff(d), storedSDL)
+				}
+				if d := DiffWithNormalizer(userCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] user self-diff not empty for %s: %s", o.name, probe.id, describeViewDiff(d))
+				}
+				if d := DiffWithNormalizer(userCat, storedCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION: user vs stored not empty for %s: %s\n  user SDL:\n%s\n  stored SDL:\n%s",
+						o.name, probe.id, describeViewDiff(d), userSDL, storedSDL)
+				}
+				if d := DiffWithNormalizer(storedCat, userCat, n); !d.IsEmpty() {
+					t.Errorf("[%s] CANONICALIZATION (reverse): stored vs user not empty for %s: %s",
+						o.name, probe.id, describeViewDiff(d))
+				}
+			})
+		}
+	}
+}
+
+// viewMigrationProbe is one apply-correctness case: transform a database from the `from` schema to
+// the `to` schema. Empty `from`/`to` slices mean "no objects" on that side.
+type viewMigrationProbe struct {
+	id       string
+	from     []string
+	to       []string
+	tables   []string // table names present in `to` (for readback assembly)
+	views    []string // view names present in `to`
+	versions []Version
+}
+
+// viewMigrationProbes enumerates the CREATE / REPLACE / DROP view FORMS the generator covers,
+// including view-on-table and view-on-view dependency ordering.
+func viewMigrationProbes() []viewMigrationProbe {
+	base := func(ss ...string) []string { return ss }
+	return []viewMigrationProbe{
+		// ---- CREATE a view (from a schema that has only the table) ----
+		{"create-simple",
+			base("CREATE TABLE t (a INT, b INT)"),
+			base("CREATE TABLE t (a INT, b INT)", "CREATE VIEW v AS SELECT a FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
+		{"create-with-options",
+			base("CREATE TABLE t (a INT, b INT)"),
+			base("CREATE TABLE t (a INT, b INT)", "CREATE ALGORITHM=MERGE SQL SECURITY INVOKER VIEW v AS SELECT a FROM t WHERE a > 0 WITH CASCADED CHECK OPTION"),
+			[]string{"t"}, []string{"v"}, both()},
+		// view-on-table created together with its table in one plan (table first).
+		{"create-view-and-table",
+			base(),
+			base("CREATE TABLE t (a INT, b INT)", "CREATE VIEW v AS SELECT a FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
+		// ---- view-on-view created in one plan: dependency ordering ----
+		{"create-view-on-view",
+			base("CREATE TABLE t (a INT, b INT)"),
+			base("CREATE TABLE t (a INT, b INT)", "CREATE VIEW base AS SELECT a, b FROM t", "CREATE VIEW v AS SELECT a FROM base"),
+			[]string{"t"}, []string{"base", "v"}, both()},
+		{"create-view-chain",
+			base("CREATE TABLE t (a INT)"),
+			base("CREATE TABLE t (a INT)", "CREATE VIEW v1 AS SELECT a FROM t", "CREATE VIEW v2 AS SELECT a FROM v1", "CREATE VIEW v3 AS SELECT a FROM v2"),
+			[]string{"t"}, []string{"v1", "v2", "v3"}, both()},
+		// Regression (review blocker): base view `a` carries a column alias named `b`, and view `b`
+		// references `a` (selecting the column `b` that `a` exposes). The alias must not create a
+		// false `a->b` edge that reverses CREATE order (which would fail to apply, since `a` would be
+		// created after `b`). Only the real edge b->a exists, so `a` must be created first.
+		{"create-view-alias-name-clash",
+			base("CREATE TABLE t (id INT)"),
+			base("CREATE TABLE t (id INT)", "CREATE VIEW a AS SELECT id AS b FROM t", "CREATE VIEW b AS SELECT b FROM a"),
+			[]string{"t"}, []string{"a", "b"}, both()},
+		// ---- REPLACE (modify body / options) ----
+		{"replace-body",
+			base("CREATE TABLE t (a INT, b INT)", "CREATE VIEW v AS SELECT a FROM t"),
+			base("CREATE TABLE t (a INT, b INT)", "CREATE VIEW v AS SELECT b FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
+		{"replace-algorithm",
+			base("CREATE TABLE t (a INT)", "CREATE ALGORITHM=UNDEFINED VIEW v AS SELECT a FROM t"),
+			base("CREATE TABLE t (a INT)", "CREATE ALGORITHM=MERGE VIEW v AS SELECT a FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
+		{"replace-sql-security",
+			base("CREATE TABLE t (a INT)", "CREATE SQL SECURITY DEFINER VIEW v AS SELECT a FROM t"),
+			base("CREATE TABLE t (a INT)", "CREATE SQL SECURITY INVOKER VIEW v AS SELECT a FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
+		{"replace-add-check-option",
+			base("CREATE TABLE t (a INT)", "CREATE VIEW v AS SELECT a FROM t WHERE a > 0"),
+			base("CREATE TABLE t (a INT)", "CREATE VIEW v AS SELECT a FROM t WHERE a > 0 WITH CASCADED CHECK OPTION"),
+			[]string{"t"}, []string{"v"}, both()},
+		// ---- DROP ----
+		{"drop-view",
+			base("CREATE TABLE t (a INT)", "CREATE VIEW v AS SELECT a FROM t"),
+			base("CREATE TABLE t (a INT)"),
+			[]string{"t"}, nil, both()},
+		// Drop a dependent view and its base in one plan (both dropped; order irrelevant for DROP).
+		{"drop-view-on-view",
+			base("CREATE TABLE t (a INT)", "CREATE VIEW base AS SELECT a FROM t", "CREATE VIEW v AS SELECT a FROM base"),
+			base("CREATE TABLE t (a INT)"),
+			[]string{"t"}, nil, both()},
+		// ---- explicit column list (8.0 only — 5.7 loader limitation flagged) ----
+		{"create-explicit-columns",
+			base("CREATE TABLE t (a INT, b VARCHAR(20))"),
+			base("CREATE TABLE t (a INT, b VARCHAR(20))", "CREATE VIEW v (p, q) AS SELECT a, b FROM t"),
+			[]string{"t"}, []string{"v"}, only(MySQL80)},
+		// Regression (re-review): a `AS TABLE <view>` body (TABLE query primary, 8.0.19+) deparses to
+		// `table \`base\``, which re-parses to a *TableStmt; the dependency extractor must still see
+		// the referenced view so `tv` is created after `base`. 8.0 only (TABLE primary is 8.0.19+).
+		{"create-view-on-view-table-primary",
+			base("CREATE TABLE t (id INT)"),
+			base("CREATE TABLE t (id INT)", "CREATE VIEW base AS SELECT id FROM t", "CREATE VIEW tv AS TABLE base"),
+			[]string{"t"}, []string{"base", "tv"}, only(MySQL80)},
+	}
+}
+
+// TestOracle_ViewMigrationApplyCorrectness proves gate 2 for every view migration probe: the
+// generated DDL transforms a real `from` database into a `to`-equal one (compared via canonical
+// readback of the full schema).
+func TestOracle_ViewMigrationApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range viewMigrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertViewApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// assertViewApplyCorrect loads from/to catalogs from the engine's own readbacks, generates the
+// plan, applies it to a real `from`-state database, reads the result back, and asserts the result
+// canonicalizes equal to `to`.
+func assertViewApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p viewMigrationProbe) {
+	t.Helper()
+	slug := strings.ReplaceAll(p.id, "-", "_")
+
+	// Both catalogs load under ONE logical database (`vt`, the apply database) so the generated
+	// DDL qualifies objects with `vt` and applies against the real `vt` database below.
+	const applyDB = "vt"
+
+	// Build the `to` catalog from the engine's readback of the `to` schema, re-homed to `vt`.
+	toCat := loadSchemaFromEngine(t, o, "vgen_to_"+slug, applyDB, p.to, p.tables, p.views)
+	if toCat == nil {
+		t.Skipf("[%s] could not obtain `to` readback for %s", o.name, p.id)
+	}
+	// Build the `from` catalog likewise (its objects determine the readback set).
+	fromTables, fromViews := schemaObjectNames(p.from)
+	fromCat := loadSchemaFromEngine(t, o, "vgen_from_"+slug, applyDB, p.from, fromTables, fromViews)
+	if fromCat == nil {
+		t.Skipf("[%s] could not obtain `from` readback for %s", o.name, p.id)
+	}
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Build a real database in state `from` (wrapped in `vt`, the database both catalogs load
+	// under via dumpViewSchemaSDL/userFormSDL → matches the plan's `vt`.`obj` qualification).
+	ctx := context.Background()
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	setup := []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, serverCharsetFor(o.version)),
+		"USE " + applyDB,
+	}
+	setup = append(setup, p.from...)
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, p.id, s, err)
+		}
+	}
+
+	// Apply the migration one statement at a time on the same connection.
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Read back the resulting schema and compare to `to`.
+	resultSDL, ok := o.dumpViewSchemaSDL(t, conn, applyDB, applyDB, p.tables, p.views)
+	if !ok {
+		t.Fatalf("[%s] %s: could not read back result", o.name, p.id)
+	}
+	resultCat, err := LoadSDLWithVersion(resultSDL, o.version)
+	if err != nil {
+		t.Fatalf("[%s] %s: reload of result failed: %v\n%s", o.name, p.id, err, resultSDL)
+	}
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result SDL:\n%s\n  diff: %s",
+			o.name, p.id, plan.SQL(), resultSDL, describeViewDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeViewDiff(d))
+	}
+
+	// Also assert the dropped views are actually gone (DROP correctness): any view in `from` but
+	// not in `to` must not survive.
+	_, fromV := schemaObjectNames(p.from)
+	toSet := make(map[string]bool)
+	for _, v := range p.views {
+		toSet[strings.ToLower(v)] = true
+	}
+	for _, v := range fromV {
+		if toSet[strings.ToLower(v)] {
+			continue
+		}
+		var n2, ddl, cs, co string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE VIEW %s.%s", applyDB, v))
+		if err := row.Scan(&n2, &ddl, &cs, &co); err == nil {
+			t.Errorf("[%s] %s: dropped view %s still exists after plan:\n%s", o.name, p.id, v, plan.SQL())
+		}
+	}
+}
+
+// loadSchemaFromEngine applies a schema to a throwaway PHYSICAL db, reads back the named tables +
+// views, and loads them into a catalog re-homed under the LOGICAL db name (version-aware). Returns
+// nil (and the caller skips) on any apply/dump failure — an input a version rejects is not a
+// generator failure. An empty setup yields an empty catalog (the `from` of a pure CREATE).
+func loadSchemaFromEngine(t *testing.T, o *oracleConn, physDB, logicalDB string, setup, tables, views []string) *Catalog {
+	t.Helper()
+	if len(setup) == 0 {
+		return New()
+	}
+	conn, ok := o.applyViewSchema(t, physDB, setup)
+	if !ok {
+		return nil
+	}
+	defer func() { _ = conn.Close() }()
+	sdl, ok := o.dumpViewSchemaSDL(t, conn, physDB, logicalDB, tables, views)
+	if !ok {
+		return nil
+	}
+	cat, err := LoadSDLWithVersion(sdl, o.version)
+	if err != nil {
+		t.Fatalf("[%s] load schema-from-engine failed: %v\n%s", o.name, err, sdl)
+	}
+	return cat
+}
+
+// schemaObjectNames extracts the table and view names declared by a list of CREATE statements, so
+// the `from` side can be read back without a hand-maintained name list. It recognises
+// "CREATE [OR REPLACE] [ALGORITHM=..] [DEFINER=..] [SQL SECURITY ..] VIEW <name>" and
+// "CREATE TABLE <name>" (the only DDL the probes use), taking the unqualified name.
+func schemaObjectNames(setup []string) (tables, views []string) {
+	for _, s := range setup {
+		up := strings.ToUpper(s)
+		if idx := strings.Index(up, " VIEW "); idx >= 0 && strings.HasPrefix(strings.TrimSpace(up), "CREATE") {
+			views = append(views, firstIdentAfter(s, idx+len(" VIEW ")))
+			continue
+		}
+		if idx := strings.Index(up, "CREATE TABLE "); idx == 0 {
+			tables = append(tables, firstIdentAfter(s, idx+len("CREATE TABLE ")))
+		}
+	}
+	return tables, views
+}
+
+// firstIdentAfter returns the first identifier starting at or after pos in s, stripping optional
+// backticks, a schema qualifier, and stopping at the first space / '(' / '`'.
+func firstIdentAfter(s string, pos int) string {
+	for pos < len(s) && (s[pos] == ' ' || s[pos] == '\t') {
+		pos++
+	}
+	start := pos
+	for pos < len(s) {
+		c := s[pos]
+		if c == ' ' || c == '(' || c == '\t' || c == '\n' {
+			break
+		}
+		pos++
+	}
+	ident := s[start:pos]
+	ident = strings.ReplaceAll(ident, "`", "")
+	if dot := strings.LastIndex(ident, "."); dot >= 0 {
+		ident = ident[dot+1:]
+	}
+	return ident
+}

--- a/mysql/catalog/migration_view_test.go
+++ b/mysql/catalog/migration_view_test.go
@@ -1,0 +1,338 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Hermetic unit tests for the view generator: op types / phases / priorities, the rendered
+// CREATE OR REPLACE / DROP DDL shape, and the view-on-view CREATE ordering. Apply-correctness
+// against the live engines lives in migration_view_oracle_test.go.
+
+// viewPlanFor builds a from→to plan via the public Diff + GenerateMigration entry points at a
+// version, wrapping each SDL fragment in the `vt` database (matching loadViewCatalog) so view
+// identity is (vt, name).
+func viewPlanFor(t *testing.T, version Version, fromSDL, toSDL string) *MigrationPlan {
+	t.Helper()
+	from := loadViewCatalog(t, version, fromSDL)
+	to := loadViewCatalog(t, version, toSDL)
+	n := NormalizerFor(version)
+	diff := DiffWithNormalizer(from, to, n)
+	return GenerateMigrationWithNormalizer(from, to, diff, n)
+}
+
+func viewOps(plan *MigrationPlan) []MigrationOp {
+	var out []MigrationOp
+	for _, op := range plan.Ops {
+		if op.Type == OpCreateView || op.Type == OpDropView {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+func TestGenerateView_NoOpEmpty(t *testing.T) {
+	for _, version := range []Version{MySQL57, MySQL80} {
+		sdl := `CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT a FROM t;`
+		plan := viewPlanFor(t, version, sdl, sdl)
+		if sql := plan.SQL(); sql != "" {
+			t.Errorf("[v%d] no-op plan must be empty, got:\n%s", version, sql)
+		}
+	}
+}
+
+func TestGenerateView_CreateShape(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT, b INT);`,
+		`CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT a FROM t;`)
+	ops := viewOps(plan)
+	if len(ops) != 1 || ops[0].Type != OpCreateView {
+		t.Fatalf("want one OpCreateView, got %+v", ops)
+	}
+	op := ops[0]
+	if op.Phase != PhaseMain || op.Priority != priorityView {
+		t.Errorf("create op phase/priority = %v/%d, want PhaseMain/%d", op.Phase, op.Priority, priorityView)
+	}
+	for _, want := range []string{
+		"CREATE OR REPLACE",
+		"ALGORITHM=UNDEFINED",
+		"SQL SECURITY DEFINER",
+		"VIEW `vt`.`v1`",
+		" AS select `t`.`a` AS `a` from `t`",
+	} {
+		if !strings.Contains(op.SQL, want) {
+			t.Errorf("create SQL missing %q:\n%s", want, op.SQL)
+		}
+	}
+	// The DEFINER= clause must NOT be emitted (ignore-in-diff + least-privilege apply hazard).
+	// (Note: "SQL SECURITY DEFINER" legitimately contains the word DEFINER; check the `DEFINER=`
+	// token specifically.)
+	if strings.Contains(op.SQL, "DEFINER=") {
+		t.Errorf("create SQL must not emit a DEFINER= clause:\n%s", op.SQL)
+	}
+}
+
+func TestGenerateView_CreateWithOptions(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT, b INT);`,
+		`CREATE TABLE t (a INT, b INT);
+CREATE ALGORITHM=MERGE SQL SECURITY INVOKER VIEW v1 (p, q) AS SELECT a, b FROM t WHERE a > 0 WITH CASCADED CHECK OPTION;`)
+	ops := viewOps(plan)
+	if len(ops) != 1 {
+		t.Fatalf("want one view op, got %+v", ops)
+	}
+	for _, want := range []string{
+		"ALGORITHM=MERGE",
+		"SQL SECURITY INVOKER",
+		"VIEW `vt`.`v1` (`p`,`q`)",
+		"WITH CASCADED CHECK OPTION",
+	} {
+		if !strings.Contains(ops[0].SQL, want) {
+			t.Errorf("create SQL missing %q:\n%s", want, ops[0].SQL)
+		}
+	}
+}
+
+func TestGenerateView_ModifyEmitsCreateOrReplace(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT a FROM t;`,
+		`CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT b FROM t;`)
+	ops := viewOps(plan)
+	if len(ops) != 1 || ops[0].Type != OpCreateView {
+		t.Fatalf("modify should emit one OpCreateView (CREATE OR REPLACE), got %+v", ops)
+	}
+	if !strings.HasPrefix(ops[0].SQL, "CREATE OR REPLACE") {
+		t.Errorf("modify SQL should start with CREATE OR REPLACE:\n%s", ops[0].SQL)
+	}
+}
+
+func TestGenerateView_DropShape(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT);
+CREATE VIEW v1 AS SELECT a FROM t;`,
+		`CREATE TABLE t (a INT);`)
+	ops := viewOps(plan)
+	if len(ops) != 1 || ops[0].Type != OpDropView {
+		t.Fatalf("want one OpDropView, got %+v", ops)
+	}
+	op := ops[0]
+	if op.Phase != PhasePre {
+		t.Errorf("drop op phase = %v, want PhasePre", op.Phase)
+	}
+	if op.SQL != "DROP VIEW IF EXISTS `vt`.`v1`" {
+		t.Errorf("drop SQL = %q", op.SQL)
+	}
+}
+
+// View-on-view CREATE must order the dependency before the dependent. v_base references table t;
+// v_dep references v_base, so v_base's CREATE must precede v_dep's in the plan order.
+func TestGenerateView_ViewOnViewOrdering(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT, b INT);`,
+		`CREATE TABLE t (a INT, b INT);
+CREATE VIEW v_dep AS SELECT x FROM v_base;
+CREATE VIEW v_base (x) AS SELECT a FROM t;`)
+	ops := viewOps(plan)
+	if len(ops) != 2 {
+		t.Fatalf("want 2 view ops, got %+v", ops)
+	}
+	posBase, posDep := -1, -1
+	for i, op := range ops {
+		switch strings.ToLower(op.ObjectName) {
+		case "v_base":
+			posBase = i
+		case "v_dep":
+			posDep = i
+		}
+	}
+	if posBase < 0 || posDep < 0 {
+		t.Fatalf("missing ops: base=%d dep=%d (%+v)", posBase, posDep, ops)
+	}
+	if posBase > posDep {
+		t.Errorf("v_base (dependency) must be created before v_dep (dependent):\n%s", plan.SQL())
+	}
+}
+
+// A three-level chain (v3 → v2 → v1 → t) must come out strictly in dependency order.
+func TestGenerateView_ViewChainOrdering(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT);`,
+		`CREATE TABLE t (a INT);
+CREATE VIEW v3 AS SELECT a FROM v2;
+CREATE VIEW v1 AS SELECT a FROM t;
+CREATE VIEW v2 AS SELECT a FROM v1;`)
+	ops := viewOps(plan)
+	order := make(map[string]int)
+	for i, op := range ops {
+		order[strings.ToLower(op.ObjectName)] = i
+	}
+	if order["v1"] >= order["v2"] || order["v2"] >= order["v3"] {
+		t.Errorf("chain order wrong: v1=%d v2=%d v3=%d\n%s",
+			order["v1"], order["v2"], order["v3"], plan.SQL())
+	}
+}
+
+// Regression (review blocker): a column ALIAS that matches a batch view's name must NOT create a
+// false dependency edge that reverses CREATE order. View `a` has alias `b` but does NOT reference
+// view `b`; view `b` references view `a`. The only real edge is b→a, so `a` must be created first.
+// An earlier substring-based scan saw `a`'s alias `\`b\“ as a reference to view `b`, forming a
+// false cycle that put `b` before `a` — which fails to apply (a doesn't exist yet).
+func TestGenerateView_AliasMatchingViewNameNoFalseEdge(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (id INT, x INT);`,
+		`CREATE TABLE t (id INT, x INT);
+CREATE VIEW a AS SELECT id AS b FROM t;
+CREATE VIEW b AS SELECT x FROM a;`)
+	ops := viewOps(plan)
+	posA, posB := -1, -1
+	for i, op := range ops {
+		switch strings.ToLower(op.ObjectName) {
+		case "a":
+			posA = i
+		case "b":
+			posB = i
+		}
+	}
+	if posA < 0 || posB < 0 {
+		t.Fatalf("missing ops: a=%d b=%d (%+v)", posA, posB, ops)
+	}
+	if posA > posB {
+		t.Errorf("view a (dependency of b) must be created before b — a column alias named like a view must not reverse order:\n%s", plan.SQL())
+	}
+}
+
+// Regression: a parenthesized JOIN of two batch views must order both before a view that joins
+// them. Exercises relation extraction at the `(` anchor (join arms are parenthesized).
+func TestGenerateView_ParenJoinOfViewsOrdering(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (id INT); CREATE TABLE u (id INT);`,
+		`CREATE TABLE t (id INT); CREATE TABLE u (id INT);
+CREATE VIEW v1 AS SELECT id FROM t;
+CREATE VIEW v2 AS SELECT id FROM u;
+CREATE VIEW jv AS SELECT v1.id, v2.id AS id2 FROM v1 JOIN v2 ON v1.id = v2.id;`)
+	ops := viewOps(plan)
+	order := make(map[string]int)
+	for i, op := range ops {
+		order[strings.ToLower(op.ObjectName)] = i
+	}
+	if order["v1"] >= order["jv"] || order["v2"] >= order["jv"] {
+		t.Errorf("jv (joins v1,v2) must come after both: v1=%d v2=%d jv=%d\n%s",
+			order["v1"], order["v2"], order["jv"], plan.SQL())
+	}
+}
+
+// Regression (re-review): dependency extraction is AST-based, so a column alias / string literal /
+// ON-clause column / CTE name that coincides with a batch view name must NOT distort ordering.
+// Here `dep` references base view `b`; a sibling chain has a view literally named like a column the
+// other views alias. All real edges must be respected and no false edge may invert order.
+func TestGenerateView_DependencyExtractionRobust(t *testing.T) {
+	// base `b` (referenced by `dep`); view `c` aliases a column `b` and joins t with a literal that
+	// mentions `b`; view `dep` truly depends on `b`. `b` must precede `dep`.
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (id INT, x INT);`,
+		`CREATE TABLE t (id INT, x INT);
+CREATE VIEW b AS SELECT id FROM t;
+CREATE VIEW c AS SELECT id AS b, 'from `+"`b`"+`' AS note FROM t;
+CREATE VIEW dep AS SELECT id FROM b;`)
+	ops := viewOps(plan)
+	order := make(map[string]int)
+	for i, op := range ops {
+		order[strings.ToLower(op.ObjectName)] = i
+	}
+	// dep depends on b → b first. c depends only on t (its alias `b` and literal `b` are NOT view b).
+	if order["b"] >= order["dep"] {
+		t.Errorf("b (dependency of dep) must precede dep: b=%d dep=%d\n%s", order["b"], order["dep"], plan.SQL())
+	}
+}
+
+// Regression (re-review): a CTE whose name matches a batch view must not create a false edge. View
+// `ctev` has a CTE named `shared` AND there is a sibling view actually named `shared`; `ctev` does
+// NOT depend on the view `shared` (its `FROM shared` binds to the CTE), so no ordering constraint
+// links them — and no false cycle is formed.
+func TestGenerateView_CTENameNotAViewEdge(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (id INT);`,
+		`CREATE TABLE t (id INT);
+CREATE VIEW shared AS SELECT id FROM t;
+CREATE VIEW ctev AS WITH shared AS (SELECT id FROM t) SELECT id FROM shared;`)
+	// Must generate without forming a cycle / panic, and both views must be present.
+	ops := viewOps(plan)
+	if len(ops) != 2 {
+		t.Fatalf("want 2 view ops, got %+v", ops)
+	}
+	// ctev references the CTE `shared`, not the view `shared`, plus table t — so ctev carries no
+	// batch-view edge. The key property is that no false cycle inverts anything (both depth 0).
+}
+
+// Regression (re-review): a `AS TABLE <view>` body (MySQL 8.0.19+ TABLE query primary) deparses to
+// `table \`v\“ and re-parses to a *TableStmt, not a *SelectStmt. The dependency extractor must
+// still find the referenced view so the ordering holds — `tv AS TABLE base` must be created after
+// `base`.
+func TestGenerateView_TableQueryPrimaryOrdering(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (id INT);`,
+		`CREATE TABLE t (id INT);
+CREATE VIEW base AS SELECT id FROM t;
+CREATE VIEW tv AS TABLE base;`)
+	ops := viewOps(plan)
+	order := make(map[string]int)
+	for i, op := range ops {
+		order[strings.ToLower(op.ObjectName)] = i
+	}
+	if order["base"] >= order["tv"] {
+		t.Errorf("base (dependency) must precede tv (AS TABLE base): base=%d tv=%d\n%s",
+			order["base"], order["tv"], plan.SQL())
+	}
+}
+
+// A view over a freshly created table must be created after the table (CREATE TABLE at
+// priorityTable precedes CREATE VIEW at priorityView in the global sort).
+func TestGenerateView_ViewAfterTable(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		``,
+		`CREATE TABLE t (a INT, b INT);
+CREATE VIEW v1 AS SELECT a FROM t;`)
+	posTable, posView := -1, -1
+	for i, op := range plan.Ops {
+		if op.Type == OpCreateTable && strings.EqualFold(op.ObjectName, "t") {
+			posTable = i
+		}
+		if op.Type == OpCreateView && strings.EqualFold(op.ObjectName, "v1") {
+			posView = i
+		}
+	}
+	if posTable < 0 || posView < 0 {
+		t.Fatalf("missing ops: table=%d view=%d", posTable, posView)
+	}
+	if posTable > posView {
+		t.Errorf("CREATE TABLE must precede CREATE VIEW:\n%s", plan.SQL())
+	}
+}
+
+// All drops precede all creates: a view dropped and another created in one plan must not interleave
+// such that a create lands before the drops (PhasePre vs PhaseMain).
+func TestGenerateView_DropsBeforeCreates(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT);
+CREATE VIEW old_v AS SELECT a FROM t;`,
+		`CREATE TABLE t (a INT);
+CREATE VIEW new_v AS SELECT a FROM t;`)
+	lastDrop, firstCreate := -1, len(plan.Ops)
+	for i, op := range plan.Ops {
+		if op.Type == OpDropView {
+			if i > lastDrop {
+				lastDrop = i
+			}
+		}
+		if op.Type == OpCreateView && i < firstCreate {
+			firstCreate = i
+		}
+	}
+	if lastDrop >= 0 && lastDrop > firstCreate {
+		t.Errorf("a view DROP sorted after a view CREATE:\n%s", plan.SQL())
+	}
+}


### PR DESCRIPTION
## What

Implements the **views** breadth node of MySQL declarative-schema (SDL) migration in `mysql/catalog/`, filling the two scaffolded hooks:

- **`diff_view.go`** — `diffViews(from, to, n) → SchemaDiff.Views`: compares views by `(database, name)`, folding the stored-form-significant attributes into one canonical key.
- **`migration_view.go`** — `generateViewDDL(...) → []MigrationOp`: emits `CREATE OR REPLACE VIEW` (add/modify) and `DROP VIEW IF EXISTS` (drop), with view-on-view dependency ordering.

Scope is limited to those two files plus their tests — no edits to `diff.go` / `diff_table.go` / `migration.go` (the scaffold already wired the hooks, the `ViewDiffEntry` type, `OpCreateView`/`OpDropView`, and `priorityView=50`).

## How it works

**Diff canonical key** folds: the SELECT body (own-database qualifier stripped — see below), `ALGORITHM` (UNDEFINED/MERGE/TEMPTABLE), `SQL SECURITY` (DEFINER/INVOKER), `WITH [CASCADED|LOCAL] CHECK OPTION`, and the explicit column list (8.0 only). **DEFINER is ignore-in-diff** (verified: the release-path `from` is loaded from a metadata SDL dump that carries no DEFINER, so comparing it would phantom-diff every release whose live view has a non-root definer).

**Generate**: a view change is a `CREATE OR REPLACE VIEW`. CREATE runs in `PhaseMain` at `priorityView` (after tables/columns, so a view over a fresh table applies against the final table). View-on-view ordering is encoded as a topological-depth prefix on the op `sortName`, so a referenced view's CREATE sorts before its referrer's. DROP runs in `PhasePre`. DEFINER is **not** emitted (omitting it makes MySQL default the definer to the current user — avoiding the `errno 1227` privilege hazard of `CREATE OR REPLACE DEFINER=<other>` on a least-privilege deployment — and re-reads as a definer the diff ignores).

## Idempotence — the view body

The body is the idempotence risk: MySQL stores a rewritten canonical form in `SHOW CREATE VIEW` (fully-qualified columns, backtick quoting, expanded `*`, lower-cased functions, parenthesized predicates). The omni `mysql/deparse` package (via `createView` → `deparseViewSelect`) already reproduces that form for **both** the user's SDL and the engine readback — **except the database-name qualifier**: 8.0 qualifies same-database refs with the database (`` `db`.`t`.`a` ``), 5.7's view-on-view form does not, and the user form has none. `canonicalViewBody` folds that own-database prefix away (a **position-aware** strip that skips string literals and only strips at a dotted-chain head, so a relation/column named like the database keeps its qualifier), so all forms collapse to one key.

## Proof — live oracle (both gates, both versions)

Run against the live engines (5.7 `:13307` ssl-disabled, 8.0 `:13306`). `go test ./mysql/catalog/...`.

**Idempotence** (`TestOracle_ViewIdempotence`): user view body vs the engine `SHOW CREATE VIEW` readback diffs **empty**, on 5.7 and 8.0, across: simple, expanded `*`, where/expr/function, inner & left joins, view-on-view, CTE (8.0), UNION, GROUP BY/agg, ALGORITHM MERGE/TEMPTABLE, SQL SECURITY INVOKER, CASCADED/LOCAL CHECK OPTION, explicit column list (8.0).

**Apply-correctness** (`TestOracle_ViewMigrationApplyCorrectness`): generated CREATE/REPLACE/DROP applied to a real `from` DB yields the target, on 5.7 and 8.0, across: CREATE (with options), REPLACE (body/algorithm/sql-security/check-option), DROP, **view-on-table** + **view-on-view** dependency ordering (incl. a 3-level chain), and an alias-name-clash regression (a base view whose column alias matches a dependent view's name must not reverse CREATE order).

Hermetic unit tests (`diff_view_test.go`, `migration_view_test.go`) cover the diff actions, the canonical-key folding (position-aware strip, DEFINER-ignored, 8.0 explicit columns), the DDL shape, and the dependency ordering including AST-based extraction robust to string literals, ON-clause column refs, and CTE names that coincide with view names.

## Normalization flags (deparse/normalize-core gaps — flagged, not papered over)

1. **Own-database qualifier stripping** ideally belongs in `mysql/deparse`'s resolver, so `View.Definition` is symmetric at load time; it is done in this node because the node may not edit deparse.
2. **5.7 explicit column list**: 5.7 rewrites an explicit column list into renamed SELECT aliases and drops the clause; the omni loader does not reproduce that rewrite. Explicit-column-list views are proven on 8.0; on 5.7 the column-list comparison is gated off (the renamed aliases live in the body, which is compared). On the **release path** this is safe (synced `from` is the engine's alias-rewritten readback → a genuine change still diffs); it is a documented limitation only for a direct user-SDL-vs-user-SDL 5.7 diff.

## Cross-family review

Reviewed with Claude `/code-review` + Codex `/codex:review` (parallel, blind). Three converged blockers were fixed: (1) a blind-substring db-qualifier strip that corrupted string literals / db-named relations → now position-aware; (2) a substring-based view-dependency scan that produced false/missed edges and could reverse CREATE order → now an **AST walk** reusing the SDL loader's `selectTableRefs` (CTE names, columns, aliases, ON-clause refs all structurally excluded); (3) emitting `DEFINER=` → now omitted. Re-review found the AST-based fix correct (UNION/set-op/parenthesized bodies, nested-CTE shadowing, and nil-safety all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
