### PR TITLE
chore(mysql/catalog): SDL test-infra + comment cleanup (diffdb hermetic, COMMENT probe, FK dedup-key, stale comments)

### DIFF
--- a/mysql/catalog/diff.go
+++ b/mysql/catalog/diff.go
@@ -26,9 +26,11 @@ package catalog
 //
 // Scope of THIS node (omni:diff-core): the dispatcher, the SchemaDiff aggregate, the
 // table differ (diff_table.go), and the column differ (diff_column.go). The breadth
-// object kinds (indexes, foreign keys, constraints, checks, views, triggers, routines,
-// events, partitions) have their extension points wired here — empty diff sections and
-// per-kind seams — but are populated by later nodes, mirroring PG's diff_<obj>.go layout.
+// object kinds (indexes, foreign keys, checks, views, triggers, routines, events,
+// partitions) have their extension points wired here — diff sections and per-kind seams
+// — and are now implemented by their owning breadth nodes in diff_<obj>.go, mirroring
+// PG's layout. (PRIMARY KEY / UNIQUE constraints are folded into the index differ, so
+// diff_constraint.go's diffConstraints stays a deliberate no-op — omni:constraints deferred.)
 
 // DiffAction describes what happened to an object between two catalog states.
 type DiffAction int
@@ -233,20 +235,18 @@ func Diff(from, to *Catalog) *SchemaDiff {
 // delegates to it with a default normalizer. A nil normalizer falls back to the
 // default for `to`.
 //
-// The dispatcher mirrors PG: one diffX per object kind, packed into SchemaDiff. Only
-// the table differ (which descends into columns) carries real logic; every breadth
-// differ is wired here against an inert no-op stub (returns nil) until its owning node
-// implements it, so the breadth slices stay empty and a breadth node touches only its
-// own diff_<obj>.go.
+// The dispatcher mirrors PG: one diffX per object kind, packed into SchemaDiff. The
+// table differ (which descends into columns) and every database-level breadth differ
+// are wired here; each diffX lives in its own diff_<obj>.go owned by its breadth node,
+// so adding or revising an object kind touches only that file.
 func DiffWithNormalizer(from, to *Catalog, n *Normalizer) *SchemaDiff {
 	if n == nil {
 		n = defaultNormalizer(to)
 	}
 	return &SchemaDiff{
 		Tables: diffTables(from, to, n),
-		// Breadth object kinds (database-level). Each differ is an inert no-op stub today
-		// (returns nil), so the diff stays empty until the owning breadth node implements it —
-		// a breadth node then only fills its own diff_<obj>.go.
+		// Database-level breadth object kinds, each implemented in its own diff_<obj>.go by the
+		// owning breadth node.
 		Views:      diffViews(from, to, n),
 		Functions:  diffFunctions(from, to, n),
 		Procedures: diffProcedures(from, to, n),

--- a/mysql/catalog/diff_oracle_test.go
+++ b/mysql/catalog/diff_oracle_test.go
@@ -143,8 +143,10 @@ func diffIdempotenceProbes() []diffProbe {
 		{"implicit-table-opts", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10))", "t", both()},
 		// explicit table charset + column echo (version-flagged echo rules).
 		{"charset-echo", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10) CHARACTER SET utf8mb4, b VARCHAR(10)) DEFAULT CHARSET=utf8mb4", "t", both()},
-		// comment escaping.
-		{"comment", "CREATE TABLE t (id INT PRIMARY KEY, a INT COMMENT 'has ''quote'' inside') COMMENT='tbl ''c''", "t", both()},
+		// comment escaping (table COMMENT carries an embedded single-quoted token `'c'` via
+		// doubled quotes; the closing quote balances the literal — the previous fixture dropped it,
+		// so MySQL rejected the DDL and the probe silently skipped on both engines).
+		{"comment", "CREATE TABLE t (id INT PRIMARY KEY, a INT COMMENT 'has ''quote'' inside') COMMENT='tbl ''c'''", "t", both()},
 		// AUTO_INCREMENT column attribute (real schema) + table counter (ignored).
 		{"autoinc", "CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT) AUTO_INCREMENT=100", "t", both()},
 		// TIMESTAMP magic — opposite behavior across versions (EDFT box default).

--- a/mysql/catalog/diff_table.go
+++ b/mysql/catalog/diff_table.go
@@ -101,10 +101,11 @@ func compareTable(key tableKey, from, to *Table, n *Normalizer) (TableDiffEntry,
 		From:     from,
 		To:       to,
 		Columns:  diffColumns(from, to, n),
-		// Table-level sub-object diffs, owned by the breadth nodes (mirroring PG's
-		// compareRelation, which calls diffConstraints/diffIndexes/... inline). Each is an
-		// inert no-op stub today (returns nil/false), so the breadth node only fills its own
-		// differ — compareTable and tableSubdiffsChanged already fold the result in.
+		// Table-level sub-object diffs, each owned by a breadth node in its own differ (mirroring
+		// PG's compareRelation, which calls diffConstraints/diffIndexes/... inline). compareTable
+		// and tableSubdiffsChanged fold their results into the "is this table modified?" decision.
+		// diffConstraints alone stays a deliberate no-op (PK/UNIQUE are folded into diffIndexes;
+		// omni:constraints deferred).
 		Indexes:          diffIndexes(from, to, n),
 		Constraints:      diffConstraints(from, to, n),
 		ForeignKeys:      diffForeignKeys(from, to, n),

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -46,12 +46,13 @@ import (
 // Rendering routes through the same canonical form show.go uses for the stored FK line, so the
 // readback of the emitted DDL canonicalizes equal to `to` and apply-correctness holds.
 //
-// A per-plan seenBackingDrop set (keyed by db.table.index, so it never conflates indexes on
-// different tables) deduplicates the leftover-backing-index DROP INDEX: MySQL keeps ONE backing
-// index for several FKs on the same leading columns (two unnamed FKs on `pid` share
+// A per-plan seenBackingDrop set (keyed by the collision-free encodeKeyFields(db, table, index),
+// so it never conflates indexes on different tables — and stays unambiguous even when an identifier
+// contains a literal `.`) deduplicates the leftover-backing-index DROP INDEX: MySQL keeps ONE
+// backing index for several FKs on the same leading columns (two unnamed FKs on `pid` share
 // `KEY pid (pid)`), so when both such FKs are dropped, each would otherwise select the same index
 // and emit a duplicate DROP INDEX — the second failing errno 1091. The set keeps exactly one drop
-// per (table, index).
+// per (database, table, index).
 func generateForeignKeyDDL(_, _ *Catalog, diff *SchemaDiff, n *Normalizer) []MigrationOp {
 	var ops []MigrationOp
 	seenBackingDrop := map[string]bool{}
@@ -223,9 +224,15 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint, seenBackingDrop m
 	}}
 
 	if idxName, ok := leftoverBackingIndexToDrop(entry, con); ok {
-		key := foreignKeySortName(entry.Database, entry.Name, idxName)
-		if !seenBackingDrop[key] {
-			seenBackingDrop[key] = true
+		// Dedup the leftover-backing-index DROP across FKs sharing one index using a COLLISION-FREE
+		// key (encodeKeyFields length-prefixes each field), not the dotted db.table.index string:
+		// the dotted form is ambiguous when an identifier itself contains a `.` (e.g. db `d`, table
+		// `a`, index `b.c` and db `d`, table `a.b`, index `c` both fold to `d.a.b.c`), which would
+		// suppress a legitimate second DROP. The op's sortName stays the dotted form so ordinary
+		// identifiers keep their existing ordering.
+		dedupKey := encodeKeyFields("db", entry.Database, "table", entry.Name, "index", idxName)
+		if !seenBackingDrop[dedupKey] {
+			seenBackingDrop[dedupKey] = true
 			ops = append(ops, MigrationOp{
 				// Op-type is OpDropForeignKey (NOT OpDropIndex) even though the SQL is DROP INDEX:
 				// this index drop is part of the FK's lifecycle, owned by the FK node. Tagging it
@@ -240,7 +247,7 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint, seenBackingDrop m
 				SQL:          fmt.Sprintf("ALTER TABLE %s DROP INDEX %s", table, migrationQuoteIdent(idxName)),
 				Phase:        PhasePre,
 				Priority:     priorityForeignKeyBackingIndexDrop,
-				sortName:     key,
+				sortName:     foreignKeySortName(entry.Database, entry.Name, idxName),
 			})
 		}
 	}
@@ -259,8 +266,10 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint, seenBackingDrop m
 //   - the `to` table keeps no USER index of that name (the index node owns a user-named index and
 //     leaves it intentionally — diff_index.go userIndexNameSet).
 //
-// When `to` is absent (the whole table is being dropped) this is never reached — DiffDrop tables
-// emit nothing.
+// A whole-table DROP (DiffDrop) never reaches this helper: that path goes through
+// dropForeignKeyConstraintOpsForDroppedTable, which releases the FK constraints but emits NO
+// backing-index drop (DROP TABLE removes the indexes), so it never consults leftoverBackingIndexToDrop.
+// This helper therefore always runs with a non-nil entry.To (the DiffModify path).
 func leftoverBackingIndexToDrop(entry *TableDiffEntry, con *Constraint) (string, bool) {
 	from := entry.From
 	if from == nil {

--- a/mysql/catalog/migration_oracle_test.go
+++ b/mysql/catalog/migration_oracle_test.go
@@ -3,6 +3,9 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -232,31 +235,71 @@ func TestOracle_MigrationApplyCorrectness(t *testing.T) {
 func assertApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p migrationProbe) {
 	t.Helper()
 
-	// Hyphens are illegal in unquoted MySQL identifiers; slug the probe id for db names.
-	slug := strings.ReplaceAll(p.id, "-", "_")
+	// Each probe gets its OWN apply database (and its own throwaway readback databases) so the
+	// suite is hermetic: the shared apply harness used to contend on one fixed `diffdb` across the
+	// generate-core, index, and check apply suites — a pre-existing pooled-`USE` race that surfaced
+	// as `Unknown database 'diffdb'` when several apply suites ran in one process (or two
+	// concurrent `go test` processes). applyDBName derives a per-probe-unique, identifier-safe name
+	// (mirrors the partition harness's pa_<slug> convention; see assertPartitionApplyCorrect).
+	applyDB := applyDBName(t, p.id)
+	sc := serverCharsetFor(o.version)
+	ctx := context.Background()
 
-	// Build the `to` catalog from the engine's readback (authentic stored form).
+	// One pinned connection for ALL of this probe's statements (readbacks + setup + apply), so the
+	// pool never lands a `USE` on a different connection than the next statement.
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// readbackVia applies a CREATE in a throwaway db on this connection and returns its SHOW
+	// CREATE (the engine's authentic stored form). The throwaway db name is derived per-probe so
+	// it never collides with another suite's readback db.
+	readbackVia := func(throwaway, createSQL, table string) (string, bool) {
+		for _, s := range []string{
+			"DROP DATABASE IF EXISTS " + throwaway,
+			fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", throwaway, sc),
+			"USE " + throwaway,
+			createSQL,
+		} {
+			if _, err := conn.ExecContext(ctx, s); err != nil {
+				t.Logf("[%s] %s readback setup failed (may be expected): %q: %v", o.name, p.id, s, err)
+				return "", false
+			}
+		}
+		var name, ddl string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", throwaway, table))
+		if err := row.Scan(&name, &ddl); err != nil {
+			t.Logf("[%s] %s SHOW CREATE failed: %v", o.name, p.id, err)
+			return "", false
+		}
+		return ddl, true
+	}
+
+	// Build `to` and `from` catalogs from the engine's own readbacks (authentic stored form),
+	// each wrapped in applyDB so the generated plan qualifies tables as `applyDB`.`t` — the same
+	// database we set up and apply in below.
 	var toCat *Catalog
 	tableInTo := strings.TrimSpace(p.toDDL) != ""
 	if tableInTo {
-		c, _, _, ok := o.catalogFromReadback(t, "gen_to_"+slug, p.toDDL, p.table)
+		rb, ok := readbackVia(applyDB+"_to", p.toDDL, p.table)
 		if !ok {
 			t.Skipf("[%s] could not obtain `to` readback for %s", o.name, p.id)
 		}
-		toCat = c
+		toCat, _ = loadOnePartTable(t, applyDB, sc, rb, p.table)
 	} else {
 		toCat = New()
 	}
 
-	// Build the `from` catalog likewise.
 	var fromCat *Catalog
 	tableInFrom := strings.TrimSpace(p.fromDDL) != ""
 	if tableInFrom {
-		c, _, _, ok := o.catalogFromReadback(t, "gen_from_"+slug, p.fromDDL, p.table)
+		rb, ok := readbackVia(applyDB+"_from", p.fromDDL, p.table)
 		if !ok {
 			t.Skipf("[%s] could not obtain `from` readback for %s", o.name, p.id)
 		}
-		fromCat = c
+		fromCat, _ = loadOnePartTable(t, applyDB, sc, rb, p.table)
 	} else {
 		fromCat = New()
 	}
@@ -265,22 +308,10 @@ func assertApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p migrationP
 	diff := DiffWithNormalizer(fromCat, toCat, n)
 	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
 
-	// Build a real database in state `from` and apply the plan, all on ONE dedicated
-	// connection (database/sql pools connections, so a stray `USE` on the pool can land on a
-	// different connection than the next statement). The catalogs were loaded via loadOneTable,
-	// which wraps DDL in database `diffdb`, so the plan qualifies tables as `diffdb`.`t` — we
-	// must set up and apply in that same `diffdb`.
-	ctx := context.Background()
-	conn, err := o.db.Conn(ctx)
-	if err != nil {
-		t.Fatalf("[%s] grab conn: %v", o.name, err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	const applyDB = "diffdb"
+	// Build a real database in state `from` and apply the plan, on the same pinned connection.
 	setup := []string{
 		"DROP DATABASE IF EXISTS " + applyDB,
-		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, serverCharsetFor(o.version)),
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
 		"USE " + applyDB,
 	}
 	if tableInFrom {
@@ -322,10 +353,12 @@ func assertApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p migrationP
 	if !ok {
 		t.Fatalf("[%s] %s: result table %s missing after apply:\n%s", o.name, p.id, p.table, plan.SQL())
 	}
-	resultCat, _ := loadOneTable(t, serverCharsetFor(o.version), resultRB, p.table)
+	// Load the result into the SAME applyDB so it shares the (database, table) identity with toCat
+	// — loading into a different db name would phantom a whole-table DROP+ADD in the diff.
+	resultCat, _ := loadOnePartTable(t, applyDB, sc, resultRB, p.table)
 
 	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
-		toRB, _ := o.readbackTable(t, "gen_to_"+slug, p.table)
+		toRB, _ := o.readbackTable(t, applyDB+"_to", p.table)
 		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result: %s\n  want:   %s\n  diff: %s",
 			o.name, p.id, plan.SQL(), strings.TrimSpace(resultRB), strings.TrimSpace(toRB), describeDiff(d))
 	}
@@ -333,6 +366,27 @@ func assertApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p migrationP
 	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
 		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeDiff(d))
 	}
+}
+
+// applyDBName builds a per-probe, identifier-safe apply-database name for the shared apply harness
+// so each probe (and each suite that reuses assertApplyCorrect) is isolated instead of contending
+// on one fixed `diffdb`. It combines the slugged probe id with a short hash of (process pid +
+// full test name): the test name (t.Name()) carries the suite path
+// (e.g. TestOracle_IndexMigrationApplyCorrectness/8.0/...) so two probes sharing an id across suites
+// get distinct databases within a process, and the pid salts the hash so two CONCURRENT `go test`
+// processes targeting the same engine never compute the same DROP/CREATE DATABASE name (the
+// remaining cross-process race the fixed `diffdb` had). The result stays well under MySQL's 64-char
+// identifier limit even with the harness's `_to` / `_from` throwaway suffixes appended. The `pa_`
+// prefix mirrors the partition harness's convention (assertPartitionApplyCorrect).
+func applyDBName(t *testing.T, probeID string) string {
+	t.Helper()
+	slug := strings.ReplaceAll(probeID, "-", "_")
+	if len(slug) > 40 {
+		slug = slug[:40]
+	}
+	h := fnv.New32a()
+	_, _ = fmt.Fprintf(h, "%d:%s", os.Getpid(), t.Name())
+	return "pa_" + slug + "_" + strconv.FormatUint(uint64(h.Sum32()), 16)
 }
 
 // TestOracle_MigrationIdempotence proves gate 1 (the spine): for a schema in its real stored
@@ -377,5 +431,64 @@ func TestOracle_MigrationIdempotence(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// fkDropTableEntry builds a DiffModify TableDiffEntry whose `from` table has a single foreign key
+// (named fkName, on column col) backed by a plain auto-created index of the SAME name, and whose
+// `to` table keeps neither — so dropForeignKeyOps emits both the DROP FOREIGN KEY and the
+// leftover-backing-index DROP INDEX. It is the minimal fixture that drives leftoverBackingIndexToDrop
+// down its positive branch.
+func fkDropTableEntry(dbName, table, fkName, col string) TableDiffEntry {
+	db := &Database{Name: dbName}
+	fk := &Constraint{Name: fkName, Type: ConForeignKey, Columns: []string{col}, RefTable: "ref", RefColumns: []string{"id"}}
+	backing := &Index{Name: fkName, Columns: []*IndexColumn{{Name: col}}, Visible: true}
+	from := &Table{Name: table, Database: db, Constraints: []*Constraint{fk}, Indexes: []*Index{backing}}
+	to := &Table{Name: table, Database: db} // FK gone, no surviving index of that name
+	return TableDiffEntry{
+		Action:      DiffModify,
+		Database:    dbName,
+		Name:        table,
+		From:        from,
+		To:          to,
+		ForeignKeys: []ForeignKeyDiffEntry{{Action: DiffDrop, Name: fkName, From: fk}},
+	}
+}
+
+// TestForeignKeyBackingDropDedupDottedIdentifiers is the regression for the FK dedup-key collision.
+// The leftover-backing-index DROP is deduplicated per (database, table, index). The old key joined
+// those three with '.', so two DISTINCT triples whose names contain a literal '.' could collapse to
+// the same string and wrongly suppress a legitimate second DROP INDEX:
+//
+//	(db "d", table "a",   index "b.c")  -> "d.a.b.c"
+//	(db "d", table "a.b", index "c")    -> "d.a.b.c"   // collision!
+//
+// Both tables legitimately need their backing index dropped, so a correct plan emits TWO DROP INDEX
+// ops. encodeKeyFields length-prefixes each field, so the two triples encode distinctly and both
+// drops survive. This test fails (only one DROP INDEX) under the dotted key and passes under the
+// collision-free key. It is a pure unit test (no engine) and ordinary-identifier behavior is
+// unaffected.
+func TestForeignKeyBackingDropDedupDottedIdentifiers(t *testing.T) {
+	diff := &SchemaDiff{Tables: []TableDiffEntry{
+		fkDropTableEntry("d", "a", "b.c", "x"),
+		fkDropTableEntry("d", "a.b", "c", "y"),
+	}}
+
+	ops := generateForeignKeyDDL(nil, nil, diff, NormalizerFor(MySQL80))
+
+	var dropIndex []string
+	for _, op := range ops {
+		if strings.Contains(op.SQL, "DROP INDEX") {
+			dropIndex = append(dropIndex, op.SQL)
+		}
+	}
+	if len(dropIndex) != 2 {
+		t.Fatalf("dotted-identifier dedup collision: want 2 DROP INDEX ops (one per table), got %d:\n%s",
+			len(dropIndex), strings.Join(dropIndex, "\n"))
+	}
+	// Both tables' leftover indexes must be present — the collision would drop exactly one of these.
+	joined := strings.Join(dropIndex, "\n")
+	if !strings.Contains(joined, "`d`.`a`") || !strings.Contains(joined, "`d`.`a.b`") {
+		t.Errorf("expected a DROP INDEX for both `d`.`a` and `d`.`a.b`, got:\n%s", joined)
 	}
 }


### PR DESCRIPTION
## What & why

Test-infra + cosmetic cleanup for the MySQL declarative-schema (SDL) build (`mysql/catalog`). Four independent fixes from the post-breadth cleanup backlog. **No behavior change for ordinary inputs**; the FK change is a robustness hardening with a regression test.

Touches only test harness + comments + one dedup-key line. Scope: `migration_oracle_test.go`, `diff_oracle_test.go`, `migration_foreign_key.go`, `diff.go`, `diff_table.go` (5 files, no others).

## Fixes

### 1. Hermetic apply harness (`migration_oracle_test.go`)
`assertApplyCorrect` hardcoded `applyDB = "diffdb"`. The generate-core, index, and check apply suites all reuse this helper and contended on that single DB name — a pre-existing pooled-`USE` race that surfaced as `Unknown database 'diffdb'` when several apply suites ran in one process, or two concurrent `go test` processes hit the same engine. Now parameterized to a per-probe-unique name via `applyDBName` = `pa_<slug>_<hash>` (hash over **pid + `t.Name()`**, so it is unique per-probe, across suites within a process, and across concurrent processes). The from/to/result catalogs are built from engine readbacks on **one pinned connection** wrapped in that DB, so the generated plan qualifies tables as `` `applyDB`.`t` `` matching the apply DB. Mirrors the existing partition harness (`assertPartitionApplyCorrect`). **Signature unchanged** — the three sharing suites keep calling it as-is.

### 2. Malformed COMMENT probe (`diff_oracle_test.go`)
The shared `diffIdempotenceProbes` `"comment"` fixture had an unbalanced table COMMENT (`COMMENT='tbl ''c''` — missing the closing quote). MySQL rejected the DDL (`Error 1064`), so the probe **silently skipped on both engines**. Balanced to `COMMENT='tbl ''c'''` (the form the sibling `create-comment` probe already uses), so it actually runs and passes idempotence on 5.7 + 8.0.

### 3. FK dedup-key collision (`migration_foreign_key.go`)
The leftover-backing-index `DROP INDEX` dedup map (`seenBackingDrop`) was keyed by `lower(db).lower(table).lower(index)`. That dotted join is ambiguous when an identifier contains a literal `.`:

```
(db "d", table "a",   index "b.c")  -> "d.a.b.c"
(db "d", table "a.b", index "c")    -> "d.a.b.c"   // collision -> second DROP suppressed
```

Switched the **dedup key** to the repo's collision-free `encodeKeyFields` (length-prefixed: `db:1:d|table:1:a|index:3:b.c|`). The op's `sortName` deliberately stays the dotted `foreignKeySortName`, so ordinary-identifier **ordering is unchanged**. Added `TestForeignKeyBackingDropDedupDottedIdentifiers` (engine-free) as a regression guard.

### 4. Stale comments (`diff.go`, `diff_table.go`, `migration_foreign_key.go`)
The breadth-scaffold left "inert no-op stub (returns nil)" comments on the breadth differs in `diff.go`/`diff_table.go`; those differs are implemented now (the comments now say so — `diffConstraints` alone remains a deliberate no-op, omni:constraints deferred). `migration_foreign_key.go`'s "DiffDrop tables emit nothing" comment on `leftoverBackingIndexToDrop` is corrected (the whole-table DROP path goes through `dropForeignKeyConstraintOpsForDroppedTable`, which never reaches that helper), and the `seenBackingDrop` key description is updated to `encodeKeyFields`. Cosmetic only.

## Correctness evidence (live MySQL 5.7.25 + 8.0.32)

- **Flake removed:** `go test ./mysql/catalog/...` green with **all suites running together** (~53s) — the generate-core, index, check, and partition apply suites no longer share `diffdb`.
- **Concurrent-safe:** two parallel `go test` apply-suite processes both green, **zero** `Unknown database`/errno/race hits; verified the two processes use disjoint pid-salted DB names (same probe slug → two distinct hash suffixes).
- **Fix 2:** the `comment` probe runs and PASSES on both engines (was SKIP); confirmed the old fixture is rejected by the engine (`Error 1064`) and the new one round-trips (`COMMENT='tbl ''c'''` → comment `tbl 'c'`).
- **Fix 3:** the regression test **fails** (1 `DROP INDEX`, collision) under the old dotted key and **passes** (2 `DROP INDEX`) under `encodeKeyFields`; the full FK oracle suite stays green (shared-backing-index dedup for ordinary identifiers preserved).
- `gofmt` + `golangci-lint` clean on all five touched files.

## Review

Cross-family review (Claude `/code-review` high + Codex `/codex:review`), run blind in parallel. **0 surviving blockers.** Codex's two findings were both addressed: the cross-process collision (added the pid salt) and a stale `db.table.index` comment (updated to `encodeKeyFields`). One Claude-finder flag (that the Fix-2 justification comment was wrong) was refuted by oracle evidence — the engine rejects the old fixture.