### PR TITLE
fix(mysql/catalog): SDL correctness hardening — errno-1075 inlining, USING HASH round-trip, partition constant-folding

### DIFF
--- a/mysql/catalog/coerce_hash_test.go
+++ b/mysql/catalog/coerce_hash_test.go
@@ -1,0 +1,109 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Unit + oracle proof for the InnoDB USING HASH fold (coerceInnoDBHashIndex). InnoDB silently
+// coerces USING HASH to BTREE and its SHOW CREATE echo is version-divergent (5.7 keeps USING HASH,
+// 8.0 drops it), so a HASH index on InnoDB phantom-diffed. The fold folds InnoDB HASH to the
+// no-explicit-type form on load; MEMORY (where HASH is a real index type) is preserved.
+
+// TestCoerceInnoDBHashIndex_Unit checks the load-time fold deterministically, without an engine:
+// InnoDB (and engine-less, which defaults to InnoDB) HASH folds to "", BTREE is untouched, and a
+// real-HASH engine (MEMORY) keeps HASH.
+func TestCoerceInnoDBHashIndex_Unit(t *testing.T) {
+	idxType := func(sql, table, index string) string {
+		t.Helper()
+		cat, err := LoadSQL(sql)
+		if err != nil {
+			t.Fatalf("load %q: %v", sql, err)
+		}
+		for _, db := range cat.Databases() {
+			if tbl := db.GetTable(table); tbl != nil {
+				for _, idx := range tbl.Indexes {
+					if strings.EqualFold(idx.Name, index) {
+						return idx.IndexType
+					}
+				}
+				t.Fatalf("index %q not found on %q", index, table)
+			}
+		}
+		t.Fatalf("table %q not found", table)
+		return ""
+	}
+
+	cases := []struct {
+		name, sql, index, want string
+	}{
+		{"innodb-unique-hash", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, UNIQUE KEY uk (c) USING HASH) ENGINE=InnoDB;", "uk", ""},
+		{"innodb-key-hash", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING HASH) ENGINE=InnoDB;", "k", ""},
+		{"innodb-noengine-hash", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING HASH);", "k", ""},
+		{"innodb-btree-kept", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING BTREE) ENGINE=InnoDB;", "k", "BTREE"},
+		{"memory-unique-hash-kept", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, UNIQUE KEY uk (c) USING HASH) ENGINE=MEMORY;", "uk", "HASH"},
+		{"memory-key-hash-kept", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING HASH) ENGINE=MEMORY;", "k", "HASH"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := idxType(c.sql, "t", c.index); got != c.want {
+				t.Errorf("IndexType = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// hashProbe is one CREATE-TABLE form whose index uses USING HASH; it must round-trip empty against
+// the engine readback (folded away on InnoDB, preserved on MEMORY).
+type hashProbe struct {
+	id        string
+	table     string
+	createSQL string
+	versions  []Version
+}
+
+func hashRoundTripProbes() []hashProbe {
+	return []hashProbe{
+		// InnoDB: USING HASH must fold so the round-trip is empty on BOTH versions (5.7 keeps the
+		// echo, 8.0 drops it — both must collapse to the no-USING form).
+		{"innodb-unique-hash", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), UNIQUE KEY uk (name) USING HASH) ENGINE=InnoDB", both()},
+		{"innodb-key-hash", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), KEY k (name) USING HASH) ENGINE=InnoDB", both()},
+		// InnoDB with no explicit ENGINE (defaults to InnoDB): USING HASH still folds.
+		{"innodb-default-engine-hash", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), KEY k (name) USING HASH)", both()},
+		// InnoDB USING BTREE must round-trip too (echoed verbatim on both versions; NOT folded).
+		{"innodb-key-btree", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), KEY k (name) USING BTREE) ENGINE=InnoDB", both()},
+		// MEMORY: HASH is the real index type and is echoed on both versions, so it round-trips as
+		// HASH (the fold must NOT fire for MEMORY).
+		{"memory-unique-hash", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), UNIQUE KEY uk (name) USING HASH) ENGINE=MEMORY", both()},
+		{"memory-key-hash", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), KEY k (name) USING HASH) ENGINE=MEMORY", both()},
+	}
+}
+
+// TestOracle_InnoDBHashRoundTrip proves the USING HASH fold against the LIVE engines (5.7 :13307,
+// 8.0 :13306): every probe's user form vs its engine readback diffs empty on both versions.
+func TestOracle_InnoDBHashRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, p := range hashRoundTripProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				db := "hash_" + strings.ReplaceAll(p.id, "-", "_")
+				assertDiffEmptyAgainstReadback(t, o, db, p.createSQL, p.table)
+			})
+		}
+	}
+}

--- a/mysql/catalog/diff_partition.go
+++ b/mysql/catalog/diff_partition.go
@@ -74,13 +74,14 @@ const keyAlgorithmDefault = 2
 // PARTITIONS-N form without touching per-partition engines, so the engine resolution is a no-op
 // for them and they round-trip regardless.
 //
-// NOT folded — flagged idempotence limitation: a partition EXPRESSION or bound VALUE containing a
-// non-literal constant expression (e.g. `VALUES LESS THAN (TO_DAYS('2020-01-01'))`, `LESS THAN
-// (5+5)`) is constant-folded by the engine at storage time (→ `737790`, `10`) but kept verbatim by
-// the loader, so it phantom-diffs. Folding it requires a constant-expression evaluator — a
-// normalize-core/analyzer capability (the same one CanonicalGeneratedExpr would need to evaluate,
-// not just reformat), out of scope for this node. See the package doc / PR flag. Literal bounds
-// (the overwhelmingly common case) are unaffected.
+// Partition BOUND values (`VALUES LESS THAN (...)` / `VALUES IN (...)`) and the partition
+// EXPRESSION are routed through n.CanonicalPartitionValue / n.CanonicalPartitionExpr. MySQL
+// constant-folds a non-literal bound at storage time (`5+5`→`10`, `TO_DAYS('2020-01-01')`→`737790`)
+// and echoes only the folded literal; the loader (partitionValueItemSQL) folds the user form the
+// same way at load, and these canonicalizers collapse incidental whitespace so the two compare
+// equal. A bound the folder cannot evaluate (an unsupported/non-deterministic function) is kept
+// verbatim — a flagged round-trip limitation (see normalize.go entry partition-constant-folding /
+// the PR flag); literal bounds (the common case) are unaffected.
 func partitionSpecWithResolvedEngine(t *Table, n *Normalizer) *PartitionInfo {
 	pi := t.Partitioning
 	engine := n.CanonicalEngine(t) // lower-cased effective engine; never returns ""
@@ -88,10 +89,13 @@ func partitionSpecWithResolvedEngine(t *Table, n *Normalizer) *PartitionInfo {
 	out := *pi
 	out.Algorithm = foldKeyAlgorithm(pi.Algorithm)
 	out.SubAlgo = foldKeyAlgorithm(pi.SubAlgo)
+	out.Expr = n.CanonicalPartitionExpr(pi.Expr)
+	out.SubExpr = n.CanonicalPartitionExpr(pi.SubExpr)
 	out.Partitions = make([]*PartitionDefInfo, len(pi.Partitions))
 	for i, pd := range pi.Partitions {
 		cp := *pd
 		cp.Engine = resolvePartitionEngine(pd.Engine, engine)
+		cp.ValueExpr = canonicalPartitionValueExpr(pd.ValueExpr, n)
 		if len(pd.SubPartitions) > 0 {
 			cp.SubPartitions = make([]*SubPartitionDefInfo, len(pd.SubPartitions))
 			for j, sp := range pd.SubPartitions {
@@ -103,6 +107,16 @@ func partitionSpecWithResolvedEngine(t *Table, n *Normalizer) *PartitionInfo {
 		out.Partitions[i] = &cp
 	}
 	return &out
+}
+
+// canonicalPartitionValueExpr canonicalizes a partition definition's bound value, preserving the
+// MAXVALUE sentinel verbatim (CanonicalPartitionValue's whitespace collapse must never rewrite it,
+// and showPartitioning special-cases it). Empty (HASH/KEY partitions carry no bound) stays empty.
+func canonicalPartitionValueExpr(value string, n *Normalizer) string {
+	if value == "" || value == "MAXVALUE" {
+		return value
+	}
+	return n.CanonicalPartitionValue(value)
 }
 
 // resolvePartitionEngine resolves a partition's declared engine against the table's effective

--- a/mysql/catalog/diff_partition_test.go
+++ b/mysql/catalog/diff_partition_test.go
@@ -73,6 +73,26 @@ func partitionDiffProbes() []diffProbe {
 		// per-partition engine echo is ENGINE = MyISAM, so the empty→table-engine fold must use
 		// the table's engine, not a hardcoded InnoDB.
 		{"myisam-explicit", "CREATE TABLE t (id INT NOT NULL, c INT NOT NULL, PRIMARY KEY (id,c)) ENGINE=MyISAM PARTITION BY LIST (c) (PARTITION pa VALUES IN (1,2,3), PARTITION pb VALUES IN (4,5,6))", "t", only(MySQL57)},
+
+		// --- Constant-folded partition bounds (entry partition-constant-folding). The engine folds
+		//     a non-literal RANGE/LIST bound to an integer literal at storage time (verified on both
+		//     5.7 and 8.0); the loader must fold the user form identically or it phantom-diffs. ---
+		// Integer arithmetic in RANGE bounds: 5+5→10, 10*2→20.
+		{"range-bound-arith", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (5+5), PARTITION p1 VALUES LESS THAN (10*2), PARTITION pmax VALUES LESS THAN MAXVALUE)", "t", both()},
+		// DIV / parenthesized arithmetic (folded values must stay strictly increasing): 100 DIV 3 →
+		// 33, (20+5)*4 → 100.
+		{"range-bound-divmod", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (100 DIV 3), PARTITION p1 VALUES LESS THAN ((20+5)*4), PARTITION pmax VALUES LESS THAN MAXVALUE)", "t", both()},
+		// TO_DAYS on a literal date in a RANGE bound: TO_DAYS('2020-01-01') → 737790.
+		{"range-bound-todays", "CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS('2020-01-01')), PARTITION p1 VALUES LESS THAN (TO_DAYS('2021-01-01')), PARTITION pmax VALUES LESS THAN MAXVALUE)", "t", both()},
+		// YEAR on a literal date in a RANGE bound: YEAR('2020-06-15') → 2020.
+		{"range-bound-year-fn", "CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (YEAR('2020-06-15')), PARTITION pmax VALUES LESS THAN MAXVALUE)", "t", both()},
+		// Arithmetic in LIST bounds: 1+1,2+2 → 2,4.
+		{"list-bound-arith", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY LIST (id) (PARTITION p0 VALUES IN (1+1, 2+2), PARTITION p1 VALUES IN (10, 20))", "t", both()},
+		// RANGE COLUMNS tuple: the integer position folds (5+5→10), the string position stays quoted.
+		{"range-columns-bound-arith", "CREATE TABLE t (a INT NOT NULL, b VARCHAR(10) NOT NULL, PRIMARY KEY (a,b)) PARTITION BY RANGE COLUMNS(a,b) (PARTITION p0 VALUES LESS THAN (5+5, 'm'), PARTITION p1 VALUES LESS THAN (MAXVALUE, MAXVALUE))", "t", both()},
+		// REGRESSION GUARD: already-literal bounds (the common case) must stay idempotent — folding
+		// must be a no-op on a plain integer literal and on a negative literal.
+		{"range-bound-literal-guard", "CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (-10), PARTITION p1 VALUES LESS THAN (0), PARTITION p2 VALUES LESS THAN (100), PARTITION pmax VALUES LESS THAN MAXVALUE)", "t", both()},
 	}
 }
 

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -68,10 +68,18 @@ func addIndexOpsForNewTable(entry *TableDiffEntry, n *Normalizer) []MigrationOp 
 		return nil
 	}
 	table := tableIdent(entry.To)
+	// The AUTO_INCREMENT column's supporting key is rendered inline by formatCreateTable (MySQL
+	// requires the AUTO_INCREMENT column to be a key at CREATE time, errno 1075). Skip that same
+	// index here so it is not also added by an ALTER (errno 1061, duplicate key name). The inline
+	// decision is the single shared predicate autoIncSupportingIndex (migration_table.go).
+	inlined := autoIncSupportingIndex(entry.To)
 	var ops []MigrationOp
 	for _, idx := range orderedDiffableIndexes(entry.To) {
 		if idx.Primary {
 			continue // inline in CREATE TABLE
+		}
+		if inlined != nil && idx == inlined {
+			continue // inline in CREATE TABLE (AUTO_INCREMENT supporting key)
 		}
 		ops = append(ops, addIndexOp(entry, table, idx, n))
 	}

--- a/mysql/catalog/migration_partition_oracle_test.go
+++ b/mysql/catalog/migration_partition_oracle_test.go
@@ -258,6 +258,14 @@ func partitionMigrationProbes() []migrationProbe {
 		{"repartition-drop-special-col", "t",
 			"CREATE TABLE t (`a-b` INT NOT NULL, id INT NOT NULL, PRIMARY KEY (`a-b`, id)) PARTITION BY HASH (`a-b`) PARTITIONS 4",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY HASH (id) PARTITIONS 2", both()},
+
+		// ---- Constant-folded bounds in the GENERATED PARTITION BY (entry partition-constant-folding):
+		//      defining partitioning whose `to` was written with non-literal bounds must emit a
+		//      PARTITION BY whose folded literals apply and read back equal to `to`. ----
+		{"create-range-bound-arith", "t", "",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (5+5), PARTITION p1 VALUES LESS THAN (10*2), PARTITION pmax VALUES LESS THAN MAXVALUE)", both()},
+		{"create-range-bound-todays", "t", "",
+			"CREATE TABLE t (id INT NOT NULL, dt DATE NOT NULL, PRIMARY KEY (id, dt)) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS('2020-01-01')), PARTITION pmax VALUES LESS THAN MAXVALUE)", both()},
 	}
 }
 

--- a/mysql/catalog/migration_table.go
+++ b/mysql/catalog/migration_table.go
@@ -168,20 +168,14 @@ func canonicalRowFormatValue(t *Table, n *Normalizer) string {
 // same normalize-core canonical form diff-core compares. It is the MySQL analog of PG's
 // FormatCreateTable (pg/catalog/migration_table.go:96).
 //
-// Scope: columns + table options + inline PRIMARY KEY. Secondary indexes, UNIQUE/foreign
-// keys, CHECK constraints, and partitioning are breadth concerns and are intentionally NOT
-// rendered here — a table created by this node carries its columns and PK; the index/FK/
-// check/partition nodes emit their own ALTER TABLE ADD ... follow-ups. (The PK is rendered
-// inline because a column's NOT NULL canonicalization is PK-aware and an AUTO_INCREMENT
-// column requires a key; emitting the PK inline keeps a single-table CREATE self-consistent
-// and apply-correct for the P0 slice.)
-//
-// KNOWN SCOPE-BOUNDARY LIMITATION: an AUTO_INCREMENT column whose ONLY supporting key is a
-// non-PK UNIQUE index renders here without that key (UNIQUE indexes are not in TableDiffEntry —
-// they belong to the index breadth node), so this CREATE TABLE would be rejected by MySQL
-// ("there can be only one auto column and it must be defined as a key") until the index node
-// supplies the key. The common AUTO_INCREMENT-as-PRIMARY-KEY case is rendered correctly and is
-// oracle-proven (probes create-autoinc, modify-add-autoinc).
+// Scope: columns + table options + inline PRIMARY KEY + (when needed) the AUTO_INCREMENT
+// column's supporting key. Other secondary indexes, foreign keys, CHECK constraints, and
+// partitioning are breadth concerns and are intentionally NOT rendered here — a table created
+// by this node carries its columns, PK, and the one key an AUTO_INCREMENT column must have;
+// the index/FK/check/partition nodes emit their own ALTER TABLE ADD ... follow-ups. (The PK is
+// rendered inline because a column's NOT NULL canonicalization is PK-aware; the AUTO_INCREMENT
+// supporting key is rendered inline because MySQL requires the AUTO_INCREMENT column to be the
+// first column of a key AT CREATE TIME — see autoIncSupportingIndex.)
 func formatCreateTable(tbl *Table, n *Normalizer) string {
 	var b strings.Builder
 	b.WriteString("CREATE TABLE ")
@@ -195,6 +189,15 @@ func formatCreateTable(tbl *Table, n *Normalizer) string {
 	if pk := formatInlinePrimaryKey(tbl); pk != "" {
 		lines = append(lines, "  "+pk)
 	}
+	// Inline the AUTO_INCREMENT column's supporting key when its only backing key is a non-PK
+	// index (a UNIQUE or secondary key). MySQL rejects CREATE TABLE for an AUTO_INCREMENT column
+	// that is not the first column of a key ("there can be only one auto column and it must be
+	// defined as a key", errno 1075), and the index node's ADD runs only AFTER the CREATE — so the
+	// CREATE itself would fail without the key inline. The index node skips this same index (it
+	// consults autoIncSupportingIndex) so the key is not also re-added.
+	if idx := autoIncSupportingIndex(tbl); idx != nil {
+		lines = append(lines, "  "+formatIndexDefinition(idx, n))
+	}
 	b.WriteString(strings.Join(lines, ",\n"))
 	b.WriteString("\n)")
 
@@ -204,6 +207,110 @@ func formatCreateTable(tbl *Table, n *Normalizer) string {
 	}
 
 	return b.String()
+}
+
+// autoIncSupportingIndex returns the index that formatCreateTable must inline so a table's
+// AUTO_INCREMENT column is the first column of a key at CREATE time (MySQL errno 1075), or nil
+// when no such inline is needed. It is the single shared predicate for the inline decision: the
+// table generator renders the returned index inline, and the index node (addIndexOpsForNewTable)
+// skips the SAME index so it is not also added by a follow-up ALTER (which would fail errno 1061,
+// duplicate key name).
+//
+// nil is returned when:
+//   - the table has no AUTO_INCREMENT column;
+//   - the AUTO_INCREMENT column is already the first column of the inline PRIMARY KEY (the PK
+//     satisfies errno 1075, and the PK is rendered by formatInlinePrimaryKey);
+//   - no key at all has the AUTO_INCREMENT column first (such a table is invalid in MySQL anyway
+//     and the engine would reject it regardless of how the CREATE is rendered).
+//
+// Selection prefers a USER index (UNIQUE over plain secondary; ties break on lower-cased name) so
+// the inline key matches the most common authoring. An FK-IMPLICIT backing index is used only as a
+// LAST RESORT — when the AUTO_INCREMENT column's only first-column key is the index MySQL
+// auto-creates for a FOREIGN KEY on it. That case is real (a `FOREIGN KEY (id)` on an
+// AUTO_INCREMENT `id` with no other key), and without inlining that backing index the CREATE TABLE
+// would have an unkeyed AUTO_INCREMENT column (errno 1075): the index node skips FK-implicit
+// indexes and the FK node adds the constraint only in a later phase. Inlining the backing index is
+// safe — the index node skips it (both because it is FK-implicit and because it is the inlined
+// index), and the deferred FK reuses the existing covering index rather than creating a duplicate.
+// The generated invisible primary key is never chosen.
+func autoIncSupportingIndex(tbl *Table) *Index {
+	autoCol := autoIncrementColumnName(tbl)
+	if autoCol == "" {
+		return nil
+	}
+	// If the inline PK already starts with the AUTO_INCREMENT column, the PK is the key — no
+	// extra inline. (A GIPK-only table has no AUTO_INCREMENT column, handled above.)
+	if pk := primaryKeyIndex(tbl); pk != nil && indexFirstColumnIs(pk, autoCol) {
+		return nil
+	}
+	skip := fkImplicitIndexNames(tbl)
+	var best, fkBackup *Index
+	for _, idx := range tbl.Indexes {
+		if idx == nil || idx.Primary || isGeneratedInvisiblePrimaryKeyIndex(idx) {
+			continue
+		}
+		if !indexFirstColumnIs(idx, autoCol) {
+			continue
+		}
+		if skip[toLower(idx.Name)] {
+			// FK-implicit backing index: remember it as a fallback only.
+			if fkBackup == nil || toLower(idx.Name) < toLower(fkBackup.Name) {
+				fkBackup = idx
+			}
+			continue
+		}
+		if best == nil || autoIncIndexPreferred(idx, best) {
+			best = idx
+		}
+	}
+	if best != nil {
+		return best
+	}
+	return fkBackup
+}
+
+// autoIncrementColumnName returns the name of the table's AUTO_INCREMENT column (MySQL allows at
+// most one), or "" when there is none. The generated invisible primary key column is never
+// AUTO_INCREMENT, so it is naturally excluded.
+func autoIncrementColumnName(tbl *Table) string {
+	for _, col := range tbl.Columns {
+		if col != nil && col.AutoIncrement {
+			return col.Name
+		}
+	}
+	return ""
+}
+
+// primaryKeyIndex returns the table's PRIMARY KEY index (excluding the generated invisible
+// primary key), or nil.
+func primaryKeyIndex(tbl *Table) *Index {
+	for _, idx := range tbl.Indexes {
+		if idx != nil && idx.Primary && !isGeneratedInvisiblePrimaryKeyIndex(idx) {
+			return idx
+		}
+	}
+	return nil
+}
+
+// indexFirstColumnIs reports whether the index's first key part is the named column (a plain
+// column reference, not an expression), case-insensitively. MySQL's errno-1075 rule is about the
+// FIRST column of a key, so only the leading part matters.
+func indexFirstColumnIs(idx *Index, col string) bool {
+	if idx == nil || len(idx.Columns) == 0 {
+		return false
+	}
+	first := idx.Columns[0]
+	return first.Expr == "" && strings.EqualFold(first.Name, col)
+}
+
+// autoIncIndexPreferred reports whether candidate should be chosen over current as the inlined
+// AUTO_INCREMENT supporting key: a UNIQUE key wins over a non-unique one; otherwise the
+// lower-cased index name breaks the tie deterministically.
+func autoIncIndexPreferred(candidate, current *Index) bool {
+	if candidate.Unique != current.Unique {
+		return candidate.Unique
+	}
+	return toLower(candidate.Name) < toLower(current.Name)
 }
 
 // formatInlinePrimaryKey renders the inline PRIMARY KEY clause for a CREATE TABLE, or ""

--- a/mysql/catalog/migration_table_test.go
+++ b/mysql/catalog/migration_table_test.go
@@ -1,0 +1,283 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Oracle proof for the AUTO_INCREMENT-supporting-key inlining in formatCreateTable (the errno-1075
+// fix), against the LIVE MySQL engines (5.7 :13307, 8.0 :13306). MySQL rejects CREATE TABLE for an
+// AUTO_INCREMENT column that is not the first column of a key ("there can be only one auto column
+// and it must be defined as a key", errno 1075). When the only backing key is a non-PK index,
+// generate-core previously rendered the CREATE without that key, so the statement failed on apply.
+//
+// Two properties per case, on every supported version:
+//   - APPLY-CORRECTNESS: the full generated plan (CREATE TABLE + any follow-up index ADDs) applies
+//     to a real database and the result reads back equal to `to` — proving the CREATE is accepted
+//     (the supporting key is inline) AND that the inlined key is NOT also re-added by the index
+//     node (which would fail errno 1061, duplicate key name).
+//   - IDEMPOTENCE: the stored form self-diffs empty and the user form vs the stored form diffs
+//     empty (no phantom diff from the inlined key).
+//
+// The apply is SELF-CONTAINED (its own per-probe database via loadOnePartTable), like the partition
+// oracle test, so it does not contend on the shared `diffdb`. It reuses connectOracle / NormalizerFor
+// / serverCharsetFor / both from the shared harness and skips cleanly when the engines are down.
+
+// autoIncProbe is a single CREATE-TABLE form whose AUTO_INCREMENT column is backed only by a non-PK
+// key; the generated plan must apply cleanly and round-trip empty.
+type autoIncProbe struct {
+	id        string
+	table     string
+	createSQL string
+	versions  []Version
+}
+
+func autoIncSupportProbes() []autoIncProbe {
+	return []autoIncProbe{
+		// The headline case: AUTO_INCREMENT on a single-column NON-PK UNIQUE key (errno 1075 without
+		// the inline key).
+		{"autoinc-nonpk-unique", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, name VARCHAR(20), UNIQUE KEY uk (id)) ENGINE=InnoDB", both()},
+		// AUTO_INCREMENT first in a COMPOSITE unique key (valid: it is the leading column).
+		{"autoinc-nonpk-unique-composite", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk (id, a)) ENGINE=InnoDB", both()},
+		// AUTO_INCREMENT backed only by a PLAIN (non-unique) secondary key.
+		{"autoinc-plain-key", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT, KEY k (id)) ENGINE=InnoDB", both()},
+		// AUTO_INCREMENT backed by a non-PK unique while the table ALSO has a separate PRIMARY KEY on
+		// another column (the PK does not cover the auto column, so the unique key must be inline).
+		{"autoinc-unique-with-other-pk", "t",
+			"CREATE TABLE t (pk INT NOT NULL, id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (pk), UNIQUE KEY uk (id)) ENGINE=InnoDB", both()},
+		// REGRESSION GUARD: AUTO_INCREMENT AS the PRIMARY KEY — the common case must keep rendering
+		// the PK inline (and NOT additionally inline a supporting key).
+		{"autoinc-primary-key-guard", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(20)) ENGINE=InnoDB", both()},
+	}
+}
+
+// autoIncFKProbes covers the AUTO_INCREMENT column whose ONLY first-column key is the index MySQL
+// auto-creates for a FOREIGN KEY on it. The CREATE TABLE must inline that backing key (else errno
+// 1075), and the deferred FK must reuse it (no duplicate-index / errno-1061). The referenced parent
+// table is created in the same plan, so these are full multi-table apply cases.
+func autoIncFKProbes() []struct {
+	id, parentDDL, childDDL, table string
+	versions                       []Version
+} {
+	return []struct {
+		id, parentDDL, childDDL, table string
+		versions                       []Version
+	}{
+		{"autoinc-fk-implicit-only",
+			"CREATE TABLE p (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE c (id INT NOT NULL AUTO_INCREMENT, x INT, FOREIGN KEY (id) REFERENCES p(id)) ENGINE=InnoDB",
+			"c", both()},
+	}
+}
+
+// TestOracle_AutoIncFKImplicitApply proves the FK-implicit-backed AUTO_INCREMENT case: the
+// generated multi-table plan (parent + child + deferred FK) applies cleanly and the child reads
+// back equal to its stored form.
+func TestOracle_AutoIncFKImplicitApply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, p := range autoIncFKProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				assertAutoIncFKApply(t, o, n, p.id, p.parentDDL, p.childDDL, p.table)
+			})
+		}
+	}
+}
+
+func assertAutoIncFKApply(t *testing.T, o *oracleConn, n *Normalizer, id, parentDDL, childDDL, childTable string) {
+	t.Helper()
+	slug := strings.ReplaceAll(id, "-", "_")
+	sc := serverCharsetFor(o.version)
+	ctx := context.Background()
+
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	applyDB := "aifk_" + slug
+	// Build the `to` catalog by applying both tables in the apply db, then reading them back.
+	for _, s := range []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
+		"USE " + applyDB,
+		parentDDL,
+		childDDL,
+	} {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] %s `to` setup failed: %q: %v", o.name, id, s, err)
+		}
+	}
+	readback := func(tbl string) string {
+		var name, ddl string
+		if err := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", applyDB, tbl)).Scan(&name, &ddl); err != nil {
+			t.Skipf("[%s] %s SHOW CREATE %s failed: %v", o.name, id, tbl, err)
+		}
+		return ddl
+	}
+	parentRB, childRB := readback("p"), readback(childTable)
+	// Compose both readbacks into one apply-db catalog so FK references resolve.
+	toSQL := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s;\n%s;", applyDB, sc, applyDB, parentRB, childRB)
+	toCat, err := LoadSQL(toSQL)
+	if err != nil {
+		t.Fatalf("[%s] %s load `to`: %v", o.name, id, err)
+	}
+
+	from := New()
+	diff := DiffWithNormalizer(from, toCat, n)
+	plan := GenerateMigrationWithNormalizer(from, toCat, diff, n)
+
+	// Apply to a fresh database.
+	for _, s := range []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
+		"USE " + applyDB,
+	} {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] %s apply db reset failed: %v", o.name, id, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, id, op.SQL, err, plan.SQL())
+		}
+	}
+	// Reload the applied child and diff against `to`.
+	resultSQL := fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s;\n%s;", applyDB, sc, applyDB, readback("p"), readback(childTable))
+	resultCat, err := LoadSQL(resultSQL)
+	if err != nil {
+		t.Fatalf("[%s] %s load result: %v", o.name, id, err)
+	}
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  diff: %s",
+			o.name, id, plan.SQL(), describeDiff(d))
+	}
+}
+
+// TestOracle_AutoIncSupportingKeyApply proves the generated plan for an AUTO_INCREMENT column backed
+// only by a non-PK key applies cleanly on a real engine and reads back equal to `to`.
+func TestOracle_AutoIncSupportingKeyApply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, p := range autoIncSupportProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				assertAutoIncApply(t, o, n, p)
+			})
+		}
+	}
+}
+
+// assertAutoIncApply builds `to` from the engine's own readback, generates the plan from empty→to,
+// applies it to a fresh per-probe database, and asserts the apply succeeds and the result diffs
+// empty against `to` (both directions). A failure here is either errno 1075 (supporting key not
+// inline) or errno 1061 (inlined key also re-added by the index node).
+func assertAutoIncApply(t *testing.T, o *oracleConn, n *Normalizer, p autoIncProbe) {
+	t.Helper()
+	slug := strings.ReplaceAll(p.id, "-", "_")
+	sc := serverCharsetFor(o.version)
+	ctx := context.Background()
+
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Readback `to` in a throwaway db, then load it into the apply db so identities match.
+	for _, s := range []string{
+		"DROP DATABASE IF EXISTS rto_" + slug,
+		fmt.Sprintf("CREATE DATABASE rto_%s DEFAULT CHARSET=%s", slug, sc),
+		"USE rto_" + slug,
+		p.createSQL,
+	} {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] %s `to` readback setup failed: %q: %v", o.name, p.id, s, err)
+		}
+	}
+	var name, rb string
+	if err := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE rto_%s.%s", slug, p.table)).Scan(&name, &rb); err != nil {
+		t.Skipf("[%s] %s SHOW CREATE failed: %v", o.name, p.id, err)
+	}
+
+	applyDB := "ai_" + slug
+	toCat, _ := loadOnePartTable(t, applyDB, sc, rb, p.table)
+
+	from := New()
+	diff := DiffWithNormalizer(from, toCat, n)
+	plan := GenerateMigrationWithNormalizer(from, toCat, diff, n)
+
+	for _, s := range []string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, sc),
+		"USE " + applyDB,
+	} {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] %s apply db setup failed: %v", o.name, p.id, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	var rname, resultRB string
+	if err := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE %s.%s", applyDB, p.table)).Scan(&rname, &resultRB); err != nil {
+		t.Fatalf("[%s] %s: result table missing after apply:\n%s", o.name, p.id, plan.SQL())
+	}
+	resultCat, _ := loadOnePartTable(t, applyDB, sc, resultRB, p.table)
+
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result: %s\n  diff: %s",
+			o.name, p.id, plan.SQL(), strings.TrimSpace(resultRB), describeDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeDiff(d))
+	}
+}
+
+// TestOracle_AutoIncSupportingKeyIdempotence proves the AUTO_INCREMENT-supporting-key forms
+// round-trip empty: the stored form self-diffs empty and the user form vs the stored form diffs
+// empty (no phantom diff introduced by the inlined key).
+func TestOracle_AutoIncSupportingKeyIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		for _, p := range autoIncSupportProbes() {
+			if !containsVersion(p.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, p.id), func(t *testing.T) {
+				db := "aidem_" + strings.ReplaceAll(p.id, "-", "_")
+				assertDiffEmptyAgainstReadback(t, o, db, p.createSQL, p.table)
+			})
+		}
+	}
+}

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	nodes "github.com/bytebase/omni/mysql/ast"
 )
 
 // Version identifies the target MySQL major version whose stored form the
@@ -1185,4 +1187,391 @@ func (n *Normalizer) CheckSupported() bool { return n.is80() }
 // first; this still returns a normalized key for completeness.
 func (n *Normalizer) CanonicalCheckExpr(expr string) string {
 	return n.CanonicalGeneratedExpr(expr)
+}
+
+// ---------------------------------------------------------------------------
+// Partition bound / expression canonicalization (entry partition-constant-folding).
+//
+// MySQL constant-folds a non-literal RANGE/LIST partition BOUND at storage time and SHOW CREATE
+// echoes only the folded integer literal (verified on live 5.7.25 + 8.0.32):
+//
+//	VALUES LESS THAN (5+5)                  -> (10)
+//	VALUES LESS THAN (100 DIV 3)            -> (33)
+//	VALUES LESS THAN (TO_DAYS('2020-01-01'))-> (737790)
+//	VALUES IN (1+1, 2+2)                    -> (2,4)
+//
+// The partition EXPRESSION itself (RANGE (YEAR(`dt`)), HASH (`id`+0)) is NOT constant-folded by the
+// engine — it references columns — so only its surface (backticks/case) differs across versions,
+// which the loader already canonicalizes. The bound value is the residual phantom-diff.
+//
+// The bound fold is done at LOAD time (partitionValueItemSQL in tablecmds.go) using the parsed AST,
+// which is the only place the structured expression is available; foldConstIntExpr below is the
+// shared evaluator. The diff comparison key for a partition (showPartitioning over the resolved
+// spec) is built in diff_partition.go, which routes the stored bound/expression text through
+// CanonicalPartitionValue / CanonicalPartitionExpr so two equal-after-fold specs compare equal
+// regardless of incidental whitespace.
+//
+// FLAGGED RESIDUAL LIMITATION: a bound whose expression the folder cannot evaluate — a
+// non-deterministic or unsupported function, or any non-integer-constant expression — is kept
+// verbatim and only round-trips when the user already wrote the engine's folded form. Folding the
+// full general case needs a complete constant-expression evaluator; the common integer-arithmetic
+// and TO_DAYS/YEAR-on-literal cases are handled here. See the PR summary flag.
+// ---------------------------------------------------------------------------
+
+// CanonicalPartitionValue canonicalizes a stored partition bound value list (the text inside
+// `VALUES LESS THAN (...)` / `VALUES IN (...)`) for the partition comparison key. The integer
+// constant-folding itself happens at load (partitionValueItemSQL); this collapses incidental
+// whitespace around the comma/paren separators so two bound lists that fold to the same literals
+// compare equal. MAXVALUE and string literals pass through unchanged.
+func (n *Normalizer) CanonicalPartitionValue(value string) string {
+	return canonicalPartitionText(value)
+}
+
+// CanonicalPartitionExpr canonicalizes a stored partition expression (the text inside
+// `RANGE (...)` / `LIST (...)` / `HASH (...)`) for the partition comparison key. The loader already
+// folds the version-divergent surface (backtick quoting, function-name case) into one form; this
+// only normalizes incidental whitespace so the comparison is insensitive to it. The expression is
+// not constant-folded (it references columns).
+func (n *Normalizer) CanonicalPartitionExpr(expr string) string {
+	return canonicalPartitionText(expr)
+}
+
+// canonicalPartitionText normalizes incidental whitespace OUTSIDE quoted string literals in
+// partition bound/expression text: runs of spaces collapse to one and spaces around commas/parens
+// are removed, so two specs that fold to the same values do not diff on formatting alone. Content
+// INSIDE a single-quoted string literal (a LIST/RANGE COLUMNS string bound such as `'a, b'`) is
+// copied byte-for-byte — MySQL echoes string bounds verbatim, so collapsing spaces or commas inside
+// them would corrupt the value and could mask a real partition-bound change.
+func canonicalPartitionText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	inString := false
+	bs := []byte(s)
+	for i := 0; i < len(bs); i++ {
+		c := bs[i]
+		if inString {
+			b.WriteByte(c)
+			switch {
+			case c == '\\' && i+1 < len(bs):
+				// Backslash escape: copy the escaped byte verbatim too.
+				i++
+				b.WriteByte(bs[i])
+			case c == '\'':
+				if i+1 < len(bs) && bs[i+1] == '\'' {
+					// Doubled '' escape inside the string: copy the second quote, stay in-string.
+					i++
+					b.WriteByte('\'')
+				} else {
+					inString = false
+				}
+			}
+			continue
+		}
+		if c == '\'' {
+			if prevSpace && b.Len() > 0 && lastWritten(&b) != ',' && lastWritten(&b) != '(' {
+				b.WriteByte(' ')
+			}
+			prevSpace = false
+			inString = true
+			b.WriteByte(c)
+			continue
+		}
+		if c == ' ' || c == '\t' || c == '\n' {
+			prevSpace = true
+			continue
+		}
+		if prevSpace {
+			// Drop the pending space around a comma/paren; otherwise keep a single separator.
+			if b.Len() > 0 && c != ',' && c != ')' && lastWritten(&b) != ',' && lastWritten(&b) != '(' {
+				b.WriteByte(' ')
+			}
+			prevSpace = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func lastWritten(b *strings.Builder) byte {
+	s := b.String()
+	if len(s) == 0 {
+		return 0
+	}
+	return s[len(s)-1]
+}
+
+// foldConstIntExpr evaluates a partition bound expression to a signed 64-bit integer when it is a
+// constant integer expression, returning ok=false for anything it cannot fold. It is intentionally
+// conservative: a false result means "render verbatim", NEVER a wrong literal. It declines on
+// overflow, division by zero, non-even real division, column references, string/float results, and
+// any operator or function outside the supported set.
+//
+// Supported (deliberately narrow — the common RANGE/LIST bound idioms verified against the live
+// engine): integer literals; unary + and - (overflow-checked); the integer binary operators
+// + - * (overflow-checked), DIV (truncating integer division), and / (only when it divides evenly,
+// since otherwise MySQL stores a decimal this cannot represent); parenthesized subexpressions; and
+// the deterministic functions TO_DAYS, TO_SECONDS, YEAR on a single literal date string.
+//
+// Deliberately NOT supported (declined → verbatim): MOD and the bitwise/shift operators (& | ^ << >>
+// and ~). MySQL evaluates those with UNSIGNED 64-bit semantics that signed Go int64 does not match
+// (e.g. MySQL `~0` = 18446744073709551615, `-1 >> 1` = 9223372036854775807), and they are exotic in
+// partition bounds — folding them risks a WRONG literal, so they are left verbatim instead.
+func foldConstIntExpr(node nodes.ExprNode) (int64, bool) {
+	switch e := node.(type) {
+	case *nodes.IntLit:
+		return e.Value, true
+	case *nodes.ParenExpr:
+		return foldConstIntExpr(e.Expr)
+	case *nodes.UnaryExpr:
+		v, ok := foldConstIntExpr(e.Operand)
+		if !ok {
+			return 0, false
+		}
+		switch e.Op {
+		case nodes.UnaryPlus:
+			return v, true
+		case nodes.UnaryMinus:
+			// Negating math.MinInt64 overflows; decline rather than wrap.
+			if v == minInt64 {
+				return 0, false
+			}
+			return -v, true
+		}
+		return 0, false
+	case *nodes.BinaryExpr:
+		return foldConstIntBinary(e)
+	case *nodes.FuncCallExpr:
+		return foldConstIntFunc(e)
+	}
+	return 0, false
+}
+
+const (
+	minInt64 = int64(-1) << 63
+	maxInt64 = ^minInt64
+)
+
+// foldConstIntBinary folds a supported integer binary operation over two foldable integer operands,
+// declining (ok=false) on overflow or division by zero so the bound is rendered verbatim instead of
+// as a wrong literal.
+func foldConstIntBinary(e *nodes.BinaryExpr) (int64, bool) {
+	l, ok := foldConstIntExpr(e.Left)
+	if !ok {
+		return 0, false
+	}
+	r, ok := foldConstIntExpr(e.Right)
+	if !ok {
+		return 0, false
+	}
+	switch e.Op {
+	case nodes.BinOpAdd:
+		return addChecked(l, r)
+	case nodes.BinOpSub:
+		return subChecked(l, r)
+	case nodes.BinOpMul:
+		return mulChecked(l, r)
+	case nodes.BinOpDiv:
+		// Real division: fold only when it divides evenly to an integer; otherwise the engine
+		// stores a decimal this cannot represent, so decline. (`||` short-circuits, so l%r is not
+		// evaluated when r == 0.)
+		if r == 0 || l%r != 0 {
+			return 0, false
+		}
+		return l / r, true
+	case nodes.BinOpDivInt:
+		// MySQL DIV is truncating integer division. MinInt64 / -1 overflows; decline it.
+		if r == 0 || (l == minInt64 && r == -1) {
+			return 0, false
+		}
+		return l / r, true
+	}
+	return 0, false
+}
+
+// addChecked / subChecked / mulChecked return ok=false on signed 64-bit overflow so the folder
+// declines rather than emitting a wrapped (wrong) literal.
+func addChecked(a, b int64) (int64, bool) {
+	s := a + b
+	if (b > 0 && s < a) || (b < 0 && s > a) {
+		return 0, false
+	}
+	return s, true
+}
+
+func subChecked(a, b int64) (int64, bool) {
+	d := a - b
+	if (b < 0 && d < a) || (b > 0 && d > a) {
+		return 0, false
+	}
+	return d, true
+}
+
+func mulChecked(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+	p := a * b
+	// p/a == b detects overflow except for the MinInt64 * -1 edge, handled explicitly.
+	if (a == minInt64 && b == -1) || (b == minInt64 && a == -1) || p/a != b {
+		return 0, false
+	}
+	return p, true
+}
+
+// foldConstIntFunc folds a small set of deterministic date functions whose argument is a single
+// literal date string: TO_DAYS, TO_SECONDS, YEAR. These are the date idioms that appear in RANGE
+// partition bounds; the engine evaluates them at storage time to an integer. Any other function, or
+// a non-literal / non-parseable argument, declines (rendered verbatim).
+func foldConstIntFunc(e *nodes.FuncCallExpr) (int64, bool) {
+	if e.Schema != "" || len(e.Args) != 1 {
+		return 0, false
+	}
+	s, ok := stringLitValue(e.Args[0])
+	if !ok {
+		return 0, false
+	}
+	y, mo, d, hh, mi, ss, ok := parseDateTimeLiteral(s)
+	if !ok {
+		return 0, false
+	}
+	switch strings.ToUpper(e.Name) {
+	case "YEAR":
+		return int64(y), true
+	case "TO_DAYS":
+		return calcDayNumber(y, mo, d), true
+	case "TO_SECONDS":
+		// TO_SECONDS = TO_DAYS*86400 + time-of-day seconds (MySQL definition).
+		return calcDayNumber(y, mo, d)*86400 + int64(hh*3600+mi*60+ss), true
+	}
+	return 0, false
+}
+
+// stringLitValue extracts the string content of a string-literal argument (unwrapping a paren),
+// returning ok=false for any non-string-literal node.
+func stringLitValue(node nodes.ExprNode) (string, bool) {
+	switch e := node.(type) {
+	case *nodes.StringLit:
+		return e.Value, true
+	case *nodes.ParenExpr:
+		return stringLitValue(e.Expr)
+	}
+	return "", false
+}
+
+// parseDateTimeLiteral parses a MySQL date or datetime string literal in the canonical
+// `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS` form into its components. It is deliberately strict: the
+// year MUST be exactly four digits and every other field exactly two (the fully zero-padded forms a
+// partition bound literal realistically uses), and the date is validated against the proleptic
+// Gregorian calendar. Anything else — notably a TWO-DIGIT year (which MySQL expands via its own
+// 70→1970 / 69→2069 rule that this folder does not reproduce) — declines, so the caller renders the
+// expression verbatim rather than risk a wrong fold.
+func parseDateTimeLiteral(s string) (y, mo, d, hh, mi, ss int, ok bool) {
+	s = strings.TrimSpace(s)
+	datePart := s
+	timePart := ""
+	if i := strings.IndexByte(s, ' '); i >= 0 {
+		datePart = s[:i]
+		timePart = strings.TrimSpace(s[i+1:])
+	}
+	dp := strings.Split(datePart, "-")
+	if len(dp) != 3 {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	y, ok = parseFixedWidthUint(dp[0], 4)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	mo, ok = parseFixedWidthUint(dp[1], 2)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	d, ok = parseFixedWidthUint(dp[2], 2)
+	if !ok {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	if !validGregorianDate(y, mo, d) {
+		return 0, 0, 0, 0, 0, 0, false
+	}
+	if timePart != "" {
+		tp := strings.Split(timePart, ":")
+		if len(tp) != 3 {
+			return 0, 0, 0, 0, 0, 0, false
+		}
+		hh, ok = parseFixedWidthUint(tp[0], 2)
+		if !ok || hh > 23 {
+			return 0, 0, 0, 0, 0, 0, false
+		}
+		mi, ok = parseFixedWidthUint(tp[1], 2)
+		if !ok || mi > 59 {
+			return 0, 0, 0, 0, 0, 0, false
+		}
+		ss, ok = parseFixedWidthUint(tp[2], 2)
+		if !ok || ss > 59 {
+			return 0, 0, 0, 0, 0, 0, false
+		}
+	}
+	return y, mo, d, hh, mi, ss, true
+}
+
+// parseFixedWidthUint parses an unsigned integer field of EXACTLY width digits (all zero-padded),
+// declining anything shorter or longer. The exact-width requirement is what rejects a two-digit
+// year, whose MySQL expansion rule this folder does not reproduce.
+func parseFixedWidthUint(s string, width int) (int, bool) {
+	if len(s) != width {
+		return 0, false
+	}
+	v := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		v = v*10 + int(r-'0')
+	}
+	return v, true
+}
+
+// validGregorianDate validates a (year, month, day) triple against the proleptic Gregorian
+// calendar (the calendar MySQL's date functions assume), including leap-year rules.
+func validGregorianDate(y, mo, d int) bool {
+	if mo < 1 || mo > 12 || d < 1 {
+		return false
+	}
+	return d <= daysInMonth(y, mo)
+}
+
+func daysInMonth(y, mo int) int {
+	switch mo {
+	case 1, 3, 5, 7, 8, 10, 12:
+		return 31
+	case 4, 6, 9, 11:
+		return 30
+	case 2:
+		if isLeapYear(y) {
+			return 29
+		}
+		return 28
+	}
+	return 0
+}
+
+func isLeapYear(y int) bool {
+	return (y%4 == 0 && y%100 != 0) || y%400 == 0
+}
+
+// calcDayNumber reproduces MySQL's calc_daynr (sql-common/my_time.cc): the number of days since
+// year 0, which is exactly what TO_DAYS returns. Verified against the live engine
+// (TO_DAYS('2020-01-01')=737790, TO_DAYS('2021-01-01')=738156).
+func calcDayNumber(y, mo, d int) int64 {
+	if y == 0 && mo == 0 {
+		return 0
+	}
+	delsum := int64(365*y + 31*(mo-1) + d)
+	if mo <= 2 {
+		y--
+	} else {
+		delsum -= int64((mo*4 + 23) / 10)
+	}
+	temp := int64((y/100 + 1) * 3 / 4)
+	return delsum + int64(y)/4 - temp
 }

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -903,3 +903,139 @@ func TestCanonicalDefault_FloatFractionPreserved(t *testing.T) {
 	// A scaled float(10,2) DOES pad to scale.
 	eq("float(10,2)", "1.5", "'1.50'")
 }
+
+// TestPartitionConstantFold_DateHelpers locks the date helpers used by the partition bound
+// constant-folder (entry partition-constant-folding) without an engine: calcDayNumber reproduces
+// MySQL TO_DAYS exactly, and parseDateTimeLiteral is strict.
+func TestPartitionConstantFold_DateHelpers(t *testing.T) {
+	// calcDayNumber == MySQL TO_DAYS (verified values against the live engine).
+	days := []struct {
+		y, m, d int
+		want    int64
+	}{
+		{2020, 1, 1, 737790},
+		{2021, 1, 1, 738156},
+		{2010, 1, 1, 734138},
+		{0, 0, 0, 0},
+	}
+	for _, c := range days {
+		if got := calcDayNumber(c.y, c.m, c.d); got != c.want {
+			t.Errorf("calcDayNumber(%d,%d,%d) = %d, want %d", c.y, c.m, c.d, got, c.want)
+		}
+	}
+
+	// parseDateTimeLiteral accepts canonical date/datetime forms and rejects malformed ones.
+	if y, mo, d, _, _, _, ok := parseDateTimeLiteral("2020-06-15"); !ok || y != 2020 || mo != 6 || d != 15 {
+		t.Errorf("parseDateTimeLiteral(date) = %d-%d-%d ok=%v", y, mo, d, ok)
+	}
+	if _, _, _, hh, mi, ss, ok := parseDateTimeLiteral("2020-06-15 13:45:30"); !ok || hh != 13 || mi != 45 || ss != 30 {
+		t.Errorf("parseDateTimeLiteral(datetime) time = %d:%d:%d ok=%v", hh, mi, ss, ok)
+	}
+	for _, bad := range []string{"2020/06/15", "2020-13-01", "2020-02-30", "not-a-date", "2020-06-15 25:00:00", "20200615"} {
+		if _, _, _, _, _, _, ok := parseDateTimeLiteral(bad); ok {
+			t.Errorf("parseDateTimeLiteral(%q) unexpectedly ok", bad)
+		}
+	}
+}
+
+// TestPartitionConstantFold_Bounds locks the end-to-end load-time fold through the public LoadSQL
+// path: a non-literal bound folds to the engine's stored integer literal, an unsupported expression
+// stays verbatim (the flagged residual), and a literal bound is unchanged.
+func TestPartitionConstantFold_Bounds(t *testing.T) {
+	boundOf := func(sql, part string) string {
+		t.Helper()
+		cat, err := LoadSQL(sql)
+		if err != nil {
+			t.Fatalf("load %q: %v", sql, err)
+		}
+		for _, db := range cat.Databases() {
+			if tbl := db.GetTable("t"); tbl != nil && tbl.Partitioning != nil {
+				for _, pd := range tbl.Partitioning.Partitions {
+					if pd.Name == part {
+						return pd.ValueExpr
+					}
+				}
+			}
+		}
+		t.Fatalf("partition %q not found", part)
+		return ""
+	}
+	const hdr = "CREATE DATABASE d; USE d; "
+	cases := []struct {
+		name, sql, part, want string
+	}{
+		{"add", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (5+5));", "p0", "10"},
+		{"mul", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (10*2));", "p0", "20"},
+		{"div-int", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (100 DIV 3));", "p0", "33"},
+		{"neg-literal", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (-10));", "p0", "-10"},
+		{"plain-literal", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (100));", "p0", "100"},
+		{"todays", hdr + "CREATE TABLE t (id INT, dt DATE) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS('2020-01-01')));", "p0", "737790"},
+		{"year-fn", hdr + "CREATE TABLE t (dt DATE) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (YEAR('2020-06-15')));", "p0", "2020"},
+		{"list-arith", hdr + "CREATE TABLE t (id INT) PARTITION BY LIST (id) (PARTITION p0 VALUES IN (1+1, 2+2));", "p0", "2,4"},
+		// Flagged residual: an unsupported function stays verbatim (does not get a wrong fold).
+		{"unsupported-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (ABS(-5)));", "p0", "abs(-5)"},
+		// Deliberately-declined operators stay verbatim rather than fold to a wrong literal. MySQL
+		// evaluates MOD and the bitwise/shift operators with UNSIGNED 64-bit semantics that signed
+		// int64 does not match, so foldConstIntExpr declines them (the value the engine actually
+		// stores is the verbatim expression on both versions; folding would phantom-diff).
+		{"mod-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (10 MOD 3));", "p0", "(10 % 3)"},
+		{"bitand-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (6 & 3));", "p0", "(6 & 3)"},
+		{"shift-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (1 << 4));", "p0", "(1 << 4)"},
+		// Overflow is declined (not wrapped): the multiply would overflow int64, so the bound stays
+		// verbatim. A non-evenly-dividing `/` likewise declines (the engine stores a decimal).
+		{"overflow-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (9223372036854775807 * 2));", "p0", "(9223372036854775807 * 2)"},
+		{"uneven-div-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (10 / 3));", "p0", "(10 / 3)"},
+		// A two-digit-year date literal is declined (MySQL's 70→1970 expansion is not reproduced),
+		// so YEAR on it stays verbatim instead of folding to a wrong year.
+		{"two-digit-year-verbatim", hdr + "CREATE TABLE t (dt DATE) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (YEAR('20-06-15')));", "p0", "year('20-06-15')"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := boundOf(c.sql, c.part); got != c.want {
+				t.Errorf("ValueExpr = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalPartitionText locks the diff-time whitespace canonicalization (entry
+// partition-constant-folding) used by CanonicalPartitionValue/Expr. Incidental whitespace OUTSIDE a
+// quoted string literal is collapsed so two specs that fold to the same values compare equal, while
+// the content INSIDE a single-quoted string bound (a LIST/RANGE COLUMNS string value) is copied
+// byte-for-byte — MySQL echoes string bounds verbatim, so a space or comma inside one is part of the
+// value and must NOT be collapsed (doing so would mask a real bound change).
+func TestCanonicalPartitionText(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		// Whitespace outside strings collapses; spaces around commas/parens are dropped.
+		{"collapse-runs", "10  +   5", "10 + 5"},
+		{"comma-spacing", "1 ,  2 , 3", "1,2,3"},
+		{"paren-spacing", "( 1 , 2 )", "(1,2)"},
+		{"tab-newline", "1\t,\n2", "1,2"},
+		// A quoted string bound is preserved exactly — interior spaces and commas are part of the
+		// value, not separators.
+		{"string-with-space", "'a b'", "'a b'"},
+		{"string-with-comma", "'a, b'", "'a, b'"},
+		{"tuple-mixed", "( 10 , 'x, y' )", "(10,'x, y')"},
+		// Escapes inside the string must not end it early: a backslash-escaped quote and a doubled
+		// '' quote both stay inside the literal.
+		{"backslash-escaped-quote", "'a\\'b, c'", "'a\\'b, c'"},
+		{"doubled-quote", "'a''b, c'", "'a''b, c'"},
+		// Two adjacent string values separated by a comma: each is preserved, the separator space is
+		// dropped.
+		{"two-strings", "'a, b' , 'c d'", "'a, b','c d'"},
+	}
+	n := NormalizerFor(MySQL80)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := n.CanonicalPartitionExpr(c.in); got != c.want {
+				t.Errorf("CanonicalPartitionExpr(%q) = %q, want %q", c.in, got, c.want)
+			}
+			// CanonicalPartitionValue shares the same text canonicalizer.
+			if got := n.CanonicalPartitionValue(c.in); got != c.want {
+				t.Errorf("CanonicalPartitionValue(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	nodes "github.com/bytebase/omni/mysql/ast"
@@ -466,6 +467,7 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 				Visible:   true,
 			}
 			applyIndexOptions(uqIdx, con.IndexOptions)
+			coerceInnoDBHashIndex(tbl, uqIdx)
 			if err := synthesizeFunctionalIndexColumns(tbl, uqIdx); err != nil {
 				return err
 			}
@@ -1209,6 +1211,14 @@ func validateUniqueKeysCoverPartitionColumns(tbl *Table, partCols []string) erro
 }
 
 // partitionValueToString converts a partition value node to SQL string.
+//
+// Each scalar bound expression is constant-folded (partitionValueItemSQL): MySQL evaluates a
+// non-literal RANGE/LIST bound at storage time (`5+5`→`10`, `100 DIV 3`→`33`, `TO_DAYS('2020-01-01')`
+// →`737790`) and SHOW CREATE echoes only the folded literal, so the user form must fold to the same
+// literal or it phantom-diffs against the readback (verified on live 5.7.25 + 8.0.32). Folding is
+// best-effort: anything the folder cannot evaluate (a non-deterministic function, a column
+// reference, an unsupported function) is rendered verbatim via nodeToSQL and round-trips only when
+// the user already wrote the engine's stored form.
 func partitionValueToString(v nodes.Node, ptype nodes.PartitionType) string {
 	switch n := v.(type) {
 	case *nodes.String:
@@ -1223,19 +1233,31 @@ func partitionValueToString(v nodes.Node, ptype nodes.PartitionType) string {
 				// Tuple: (val1, val2) for multi-column LIST COLUMNS
 				subParts := make([]string, len(subList.Items))
 				for j, sub := range subList.Items {
-					subParts[j] = nodeToSQL(sub.(nodes.ExprNode))
+					subParts[j] = partitionValueItemSQL(sub.(nodes.ExprNode))
 				}
 				parts[i] = "(" + strings.Join(subParts, ",") + ")"
 			} else {
-				parts[i] = nodeToSQL(item.(nodes.ExprNode))
+				parts[i] = partitionValueItemSQL(item.(nodes.ExprNode))
 			}
 		}
 		return strings.Join(parts, ",")
 	case nodes.ExprNode:
-		return nodeToSQL(n)
+		return partitionValueItemSQL(n)
 	default:
 		return ""
 	}
+}
+
+// partitionValueItemSQL renders one scalar partition bound, constant-folding it to an integer
+// literal when the expression is a constant integer expression (integer arithmetic, or a supported
+// deterministic function on a literal — see foldConstIntExpr). On any non-foldable expression it
+// falls back to the verbatim deparse, so a literal bound (the common case) is rendered unchanged and
+// an unsupported expression is preserved (and flagged as a documented round-trip limitation).
+func partitionValueItemSQL(n nodes.ExprNode) string {
+	if v, ok := foldConstIntExpr(n); ok {
+		return strconv.FormatInt(v, 10)
+	}
+	return nodeToSQL(n)
 }
 
 // validateForeignKeys checks all FK constraints on a table against the referenced tables.
@@ -1523,10 +1545,37 @@ func fixedLengthStringColumnLimit(col *Column) (int, bool) {
 	return n, n > 0
 }
 
+// coerceInnoDBHashIndex folds a meaningless `USING HASH` on an InnoDB index to the no-explicit-type
+// form (IndexType ""), so a HASH index on InnoDB round-trips empty on both 5.7 and 8.0.
+//
+// InnoDB does not implement hash indexes: it silently treats `USING HASH` as BTREE. The SHOW CREATE
+// echo of that meaningless clause is version-, kind-, and engine-divergent (verified on live 5.7.25
+// + 8.0.32):
+//   - 8.0 InnoDB DROPS the clause entirely for every index kind (UNIQUE, plain KEY, CREATE INDEX);
+//   - 5.7 InnoDB KEEPS `USING HASH` in the echo for every kind;
+//   - `USING BTREE` on InnoDB is echoed verbatim on BOTH versions (BTREE is the real storage), so it
+//     is NOT folded — only HASH is meaningless;
+//   - MEMORY (and other engines where HASH is a real index type) KEEP `USING HASH` on both versions,
+//     so the engine guard below leaves them untouched.
+//
+// Folding HASH → "" (rather than → "BTREE") is what makes both echoes converge: a user's `USING
+// HASH`, 5.7's kept `USING HASH`, and 8.0's dropped clause all load to IndexType "" on InnoDB, which
+// the index differ (canonicalIndexType) and the index generator (formatIndexDefinition) both treat
+// as "no USING clause" — matching the plain no-USING readback on either version. (The earlier
+// HASH → "BTREE" fold matched 5.7's echo but still phantom-diffed against 8.0's dropped clause.)
 func coerceInnoDBHashIndex(tbl *Table, idx *Index) {
-	if strings.EqualFold(tbl.Engine, "InnoDB") && strings.EqualFold(idx.IndexType, "HASH") {
-		idx.IndexType = "BTREE"
+	if isInnoDBEngine(tbl.Engine) && strings.EqualFold(idx.IndexType, "HASH") {
+		idx.IndexType = ""
 	}
+}
+
+// isInnoDBEngine reports whether a table's declared engine is InnoDB, treating an empty (omitted)
+// engine as InnoDB — the MySQL default storage engine. The user form often omits ENGINE while the
+// SHOW CREATE readback always echoes ENGINE=InnoDB, so the HASH fold must apply to both or a `USING
+// HASH` written on an engine-less CREATE TABLE would phantom-diff against its InnoDB readback.
+func isInnoDBEngine(engine string) bool {
+	e := strings.TrimSpace(engine)
+	return e == "" || strings.EqualFold(e, "InnoDB")
 }
 
 func constraintNameExistsInTable(tbl *Table, typ ConstraintType, name string) bool {


### PR DESCRIPTION
Correctness-hardening cleanup for MySQL SDL (3 fixes, each oracle-proven on live MySQL 5.7 + 8.0).

## Fixes
1. **errno 1075** — `formatCreateTable` now inlines the AUTO_INCREMENT column's supporting key (MySQL requires the AUTO_INCREMENT column to be a key at CREATE time); `migration_index.go` skips that same key in ALTER (shared `autoIncSupportingIndex` predicate) to avoid errno 1061. CREATE TABLE with AUTO_INCREMENT on a non-PK unique key now generates, applies, and round-trips idempotently.
2. **USING HASH InnoDB round-trip** — InnoDB coerces HASH→BTREE with a version/kind/engine-divergent echo; the loader/normalizer now folds the canonical USING form so a HASH index on InnoDB round-trips empty on both versions (MEMORY HASH preserved where real).
3. **Partition bound constant-folding** — the engine folds non-literal partition bounds at storage (TO_DAYS('…')→int, 5+5→10); added partition value/expression canonicalization so common constant cases round-trip empty (literal bounds idempotent; arbitrary non-literal expressions flagged as a residual limitation).

Oracle-proven (idempotence + apply-correctness) on 5.7.25 + 8.0.32. Full mysql/catalog suite green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)