### PR TITLE
fix(mysql/catalog): close USING HASH fold coverage on ALTER ADD UNIQUE + CREATE INDEX

### DIFF
--- a/mysql/catalog/altercmds.go
+++ b/mysql/catalog/altercmds.go
@@ -449,14 +449,16 @@ func (c *Catalog) alterAddConstraint(tbl *Table, cmd *nodes.AlterTableCmd) error
 		if err := validateIndexColumns(tbl, idxCols, false, false); err != nil {
 			return err
 		}
-		tbl.Indexes = append(tbl.Indexes, &Index{
+		uqIdx := &Index{
 			Name:      idxName,
 			Table:     tbl,
 			Columns:   idxCols,
 			Unique:    true,
 			IndexType: resolveConstraintIndexType(con),
 			Visible:   true,
-		})
+		}
+		coerceInnoDBHashIndex(tbl, uqIdx)
+		tbl.Indexes = append(tbl.Indexes, uqIdx)
 		tbl.Constraints = append(tbl.Constraints, &Constraint{
 			Name:      idxName,
 			Type:      ConUniqueKey,

--- a/mysql/catalog/coerce_hash_test.go
+++ b/mysql/catalog/coerce_hash_test.go
@@ -37,15 +37,34 @@ func TestCoerceInnoDBHashIndex_Unit(t *testing.T) {
 		return ""
 	}
 
+	const innodb = "CREATE DATABASE d; USE d; CREATE TABLE t (c INT) ENGINE=InnoDB;"
+	const memory = "CREATE DATABASE d; USE d; CREATE TABLE t (c INT) ENGINE=MEMORY;"
 	cases := []struct {
 		name, sql, index, want string
 	}{
+		// CREATE TABLE inline index forms.
 		{"innodb-unique-hash", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, UNIQUE KEY uk (c) USING HASH) ENGINE=InnoDB;", "uk", ""},
 		{"innodb-key-hash", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING HASH) ENGINE=InnoDB;", "k", ""},
 		{"innodb-noengine-hash", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING HASH);", "k", ""},
 		{"innodb-btree-kept", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING BTREE) ENGINE=InnoDB;", "k", "BTREE"},
 		{"memory-unique-hash-kept", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, UNIQUE KEY uk (c) USING HASH) ENGINE=MEMORY;", "uk", "HASH"},
 		{"memory-key-hash-kept", "CREATE DATABASE d; USE d; CREATE TABLE t (c INT, KEY k (c) USING HASH) ENGINE=MEMORY;", "k", "HASH"},
+
+		// ALTER TABLE ADD UNIQUE / ADD KEY — the previously-uncovered ALTER paths.
+		{"alter-add-unique-hash-innodb", innodb + "ALTER TABLE t ADD UNIQUE uk (c) USING HASH;", "uk", ""},
+		{"alter-add-key-hash-innodb", innodb + "ALTER TABLE t ADD KEY k (c) USING HASH;", "k", ""},
+		{"alter-add-unique-hash-memory", memory + "ALTER TABLE t ADD UNIQUE uk (c) USING HASH;", "uk", "HASH"},
+		{"alter-add-key-hash-memory", memory + "ALTER TABLE t ADD KEY k (c) USING HASH;", "k", "HASH"},
+
+		// Standalone CREATE [UNIQUE] INDEX — trailing USING (the common form the parser routes
+		// into Options) and leading USING (before ON). Both positions must resolve + fold.
+		{"create-index-trailing-hash-innodb", innodb + "CREATE INDEX k ON t (c) USING HASH;", "k", ""},
+		{"create-index-leading-hash-innodb", innodb + "CREATE INDEX k USING HASH ON t (c);", "k", ""},
+		{"create-unique-index-hash-innodb", innodb + "CREATE UNIQUE INDEX uk ON t (c) USING HASH;", "uk", ""},
+		{"create-index-trailing-hash-memory", memory + "CREATE INDEX k ON t (c) USING HASH;", "k", "HASH"},
+		{"create-index-leading-hash-memory", memory + "CREATE INDEX k USING HASH ON t (c);", "k", "HASH"},
+		{"create-unique-index-hash-memory", memory + "CREATE UNIQUE INDEX uk ON t (c) USING HASH;", "uk", "HASH"},
+		{"create-index-btree-innodb-kept", innodb + "CREATE INDEX k ON t (c) USING BTREE;", "k", "BTREE"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -56,8 +75,11 @@ func TestCoerceInnoDBHashIndex_Unit(t *testing.T) {
 	}
 }
 
-// hashProbe is one CREATE-TABLE form whose index uses USING HASH; it must round-trip empty against
-// the engine readback (folded away on InnoDB, preserved on MEMORY).
+// hashProbe is one schema form whose index uses USING HASH; it must round-trip empty against the
+// engine readback (folded away on InnoDB, preserved on MEMORY). createSQL may be multiple
+// statements (the connection enables multiStatements and omni's LoadSQL is multi-statement too), so
+// a probe can author the index via CREATE TABLE, ALTER TABLE ADD …, or CREATE [UNIQUE] INDEX — all
+// five paths that build an index from a user USING clause.
 type hashProbe struct {
 	id        string
 	table     string
@@ -67,6 +89,7 @@ type hashProbe struct {
 
 func hashRoundTripProbes() []hashProbe {
 	return []hashProbe{
+		// ---- CREATE TABLE inline index (the originally-covered forms) --------------------------
 		// InnoDB: USING HASH must fold so the round-trip is empty on BOTH versions (5.7 keeps the
 		// echo, 8.0 drops it — both must collapse to the no-USING form).
 		{"innodb-unique-hash", "t",
@@ -85,6 +108,45 @@ func hashRoundTripProbes() []hashProbe {
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), UNIQUE KEY uk (name) USING HASH) ENGINE=MEMORY", both()},
 		{"memory-key-hash", "t",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20), KEY k (name) USING HASH) ENGINE=MEMORY", both()},
+
+		// ---- ALTER TABLE … ADD UNIQUE … USING HASH (the missing ALTER-ADD-UNIQUE path) ---------
+		// InnoDB: ADD UNIQUE USING HASH must fold → empty round-trip on both versions.
+		{"alter-add-unique-hash-innodb", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=InnoDB;" +
+				"ALTER TABLE t ADD UNIQUE uk (name) USING HASH", both()},
+		// MEMORY: ADD UNIQUE USING HASH must be PRESERVED (HASH is real there) → round-trips as HASH.
+		{"alter-add-unique-hash-memory", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=MEMORY;" +
+				"ALTER TABLE t ADD UNIQUE uk (name) USING HASH", both()},
+
+		// ---- ALTER TABLE … ADD KEY … USING HASH (the plain-KEY ALTER path) ---------------------
+		// Already folded pre-fix, but probed here so the oracle matrix covers all five paths.
+		{"alter-add-key-hash-innodb", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=InnoDB;" +
+				"ALTER TABLE t ADD KEY k (name) USING HASH", both()},
+		{"alter-add-key-hash-memory", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=MEMORY;" +
+				"ALTER TABLE t ADD KEY k (name) USING HASH", both()},
+
+		// ---- CREATE INDEX … USING HASH (non-unique standalone, the missing CREATE INDEX path) ---
+		// InnoDB: folds → empty. (Trailing USING is the common form the parser routes into Options.)
+		{"create-index-hash-innodb", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=InnoDB;" +
+				"CREATE INDEX k ON t (name) USING HASH", both()},
+		// MEMORY: preserved → round-trips as HASH.
+		{"create-index-hash-memory", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=MEMORY;" +
+				"CREATE INDEX k ON t (name) USING HASH", both()},
+
+		// ---- CREATE UNIQUE INDEX … USING HASH (the missing CREATE-UNIQUE-INDEX path) -----------
+		// InnoDB: folds → empty.
+		{"create-unique-index-hash-innodb", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=InnoDB;" +
+				"CREATE UNIQUE INDEX uk ON t (name) USING HASH", both()},
+		// MEMORY: preserved → round-trips as HASH.
+		{"create-unique-index-hash-memory", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR(20)) ENGINE=MEMORY;" +
+				"CREATE UNIQUE INDEX uk ON t (name) USING HASH", both()},
 	}
 }
 

--- a/mysql/catalog/indexcmds.go
+++ b/mysql/catalog/indexcmds.go
@@ -67,9 +67,17 @@ func (c *Catalog) createIndex(stmt *nodes.CreateIndexStmt) error {
 		idx.Spatial = true
 		idx.IndexType = "SPATIAL"
 	default:
-		idx.IndexType = stmt.IndexType
+		// `USING {BTREE|HASH}` may appear in either grammar position — before ON
+		// (stmt.IndexType) or as a trailing index_option (stmt.Options). Resolve both via the
+		// shared helper (same as the constraint paths) so the trailing form is not silently
+		// dropped (applyIndexOptions ignores USING).
+		idx.IndexType = resolveIndexUsingType(stmt.IndexType, stmt.Options)
 		idx.Unique = stmt.Unique
 	}
+	// Fold a meaningless `USING HASH` on InnoDB to the no-explicit-type form so a HASH index
+	// authored via CREATE [UNIQUE] INDEX round-trips empty (Fulltext/Spatial are never HASH, so
+	// the fold is a no-op for them). Mirrors the CREATE TABLE / ALTER ADD paths.
+	coerceInnoDBHashIndex(tbl, idx)
 
 	applyIndexOptions(idx, stmt.Options)
 	if err := synthesizeFunctionalIndexColumns(tbl, idx); err != nil {

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -1347,10 +1347,7 @@ func foldConstIntExpr(node nodes.ExprNode) (int64, bool) {
 	return 0, false
 }
 
-const (
-	minInt64 = int64(-1) << 63
-	maxInt64 = ^minInt64
-)
+const minInt64 = int64(-1) << 63
 
 // foldConstIntBinary folds a supported integer binary operation over two foldable integer operands,
 // declining (ok=false) on overflow or division by zero so the bound is rendered verbatim instead of
@@ -1448,10 +1445,19 @@ func foldConstIntFunc(e *nodes.FuncCallExpr) (int64, bool) {
 }
 
 // stringLitValue extracts the string content of a string-literal argument (unwrapping a paren),
-// returning ok=false for any non-string-literal node.
+// returning ok=false for any non-string-literal node. A DATE/TIMESTAMP temporal literal carries its
+// inner string in Value, so TO_DAYS(DATE '2020-01-01') folds symmetrically with the bare-string
+// TO_DAYS('2020-01-01') form. A TIME literal is excluded: its value is a clock string, not a date,
+// and a TIME spelled to look like a date (TIME '2020-01-01') is rejected by MySQL itself (error
+// 1525), so folding it would model a value the engine never stores — render verbatim instead.
 func stringLitValue(node nodes.ExprNode) (string, bool) {
 	switch e := node.(type) {
 	case *nodes.StringLit:
+		return e.Value, true
+	case *nodes.TemporalLit:
+		if strings.EqualFold(e.Type, "TIME") {
+			return "", false
+		}
 		return e.Value, true
 	case *nodes.ParenExpr:
 		return stringLitValue(e.Expr)

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -970,6 +970,14 @@ func TestPartitionConstantFold_Bounds(t *testing.T) {
 		{"neg-literal", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (-10));", "p0", "-10"},
 		{"plain-literal", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (100));", "p0", "100"},
 		{"todays", hdr + "CREATE TABLE t (id INT, dt DATE) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS('2020-01-01')));", "p0", "737790"},
+		// A DATE/TIMESTAMP literal arg folds symmetrically with the bare-string form above (stringLitValue
+		// reads TemporalLit.Value), so DATE '2020-01-01' and '2020-01-01' canonicalize to the same bound.
+		{"todays-date-literal", hdr + "CREATE TABLE t (id INT, dt DATE) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS(DATE '2020-01-01')));", "p0", "737790"},
+		{"todays-timestamp-literal", hdr + "CREATE TABLE t (id INT, dt DATETIME) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS(TIMESTAMP '2020-01-01 00:00:00')));", "p0", "737790"},
+		// A TIME literal is NOT folded (even one spelled to look like a date): its value is a clock
+		// string, and TIME '2020-01-01' is rejected by MySQL itself — so the bound stays verbatim
+		// rather than fold to a wrong day number.
+		{"todays-time-literal-verbatim", hdr + "CREATE TABLE t (id INT, dt DATE) PARTITION BY RANGE (TO_DAYS(dt)) (PARTITION p0 VALUES LESS THAN (TO_DAYS(TIME '2020-01-01')));", "p0", "to_days(TIME'2020-01-01')"},
 		{"year-fn", hdr + "CREATE TABLE t (dt DATE) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (YEAR('2020-06-15')));", "p0", "2020"},
 		{"list-arith", hdr + "CREATE TABLE t (id INT) PARTITION BY LIST (id) (PARTITION p0 VALUES IN (1+1, 2+2));", "p0", "2,4"},
 		// Flagged residual: an unsupported function stays verbatim (does not get a wrong fold).

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1548,11 +1548,17 @@ func fixedLengthStringColumnLimit(col *Column) (int, bool) {
 // coerceInnoDBHashIndex folds a meaningless `USING HASH` on an InnoDB index to the no-explicit-type
 // form (IndexType ""), so a HASH index on InnoDB round-trips empty on both 5.7 and 8.0.
 //
+// It must be called from EVERY path that builds a *secondary* index from a user `USING HASH`, or
+// that path phantom-diffs. Call sites: CREATE TABLE UNIQUE + plain KEY (tablecmds.go), ALTER ADD
+// UNIQUE + plain KEY (altercmds.go), and standalone CREATE [UNIQUE] INDEX (indexcmds.go). The
+// PRIMARY KEY paths are intentionally excluded: they hard-code IndexType "" (MySQL never accepts or
+// echoes a USING clause on a PK, so there is nothing to fold).
+//
 // InnoDB does not implement hash indexes: it silently treats `USING HASH` as BTREE. The SHOW CREATE
 // echo of that meaningless clause is version-, kind-, and engine-divergent (verified on live 5.7.25
-// + 8.0.32):
-//   - 8.0 InnoDB DROPS the clause entirely for every index kind (UNIQUE, plain KEY, CREATE INDEX);
-//   - 5.7 InnoDB KEEPS `USING HASH` in the echo for every kind;
+// + 8.0.32, across all of the above authoring paths):
+//   - 8.0 InnoDB DROPS the clause entirely;
+//   - 5.7 InnoDB KEEPS `USING HASH` in the echo;
 //   - `USING BTREE` on InnoDB is echoed verbatim on BOTH versions (BTREE is the real storage), so it
 //     is NOT folded — only HASH is meaningless;
 //   - MEMORY (and other engines where HASH is a real index type) KEEP `USING HASH` on both versions,
@@ -1625,13 +1631,15 @@ func indexTypeOrDefault(indexType, defaultType string) string {
 	return defaultType
 }
 
-// resolveConstraintIndexType returns the index type from a constraint,
-// checking both IndexType (USING before key parts) and IndexOptions (USING after key parts).
-func resolveConstraintIndexType(con *nodes.Constraint) string {
-	if con.IndexType != "" {
-		return strings.ToUpper(con.IndexType)
+// resolveIndexUsingType returns the declared index type from the two grammar positions MySQL allows
+// a `USING {BTREE|HASH}` clause to appear in: before the key parts (the dedicated indexType slot)
+// and as a trailing index_option (scanned from opts). The leading slot wins; "" means no USING.
+// Shared by the constraint paths (resolveConstraintIndexType) and the standalone CREATE INDEX path.
+func resolveIndexUsingType(indexType string, opts []*nodes.IndexOption) string {
+	if indexType != "" {
+		return strings.ToUpper(indexType)
 	}
-	for _, opt := range con.IndexOptions {
+	for _, opt := range opts {
 		if strings.EqualFold(opt.Name, "USING") {
 			if s, ok := opt.Value.(*nodes.StringLit); ok {
 				return strings.ToUpper(s.Value)
@@ -1639,6 +1647,12 @@ func resolveConstraintIndexType(con *nodes.Constraint) string {
 		}
 	}
 	return ""
+}
+
+// resolveConstraintIndexType returns the index type from a constraint,
+// checking both IndexType (USING before key parts) and IndexOptions (USING after key parts).
+func resolveConstraintIndexType(con *nodes.Constraint) string {
+	return resolveIndexUsingType(con.IndexType, con.IndexOptions)
 }
 
 // applyIndexOptions extracts COMMENT, VISIBLE/INVISIBLE, and KEY_BLOCK_SIZE


### PR DESCRIPTION
## What & why

`coerceInnoDBHashIndex` folds a meaningless InnoDB `USING HASH` to the no-explicit-type form (`IndexType ""`) so a HASH index round-trips empty against its `SHOW CREATE` readback. InnoDB does not implement hash indexes (it silently treats `USING HASH` as BTREE), and the echo of that clause is **version-divergent**: 8.0 **drops** it, 5.7 **keeps** it — so a user `USING HASH` on InnoDB must canonicalize to `""` to match both. On MEMORY (where HASH is a real index type, echoed verbatim on both versions) it must be **preserved**.

The fold was wired into only **3 of 5** index-authoring paths (CREATE TABLE UNIQUE, CREATE TABLE plain KEY, ALTER ADD plain KEY). It was **missing** on:

1. **ALTER ADD UNIQUE** (`altercmds.go` `ConstrUnique` arm) — built the index with `IndexType: resolveConstraintIndexType(con)` (returns `"HASH"`) and appended with no fold, so `ALTER TABLE … ADD UNIQUE … USING HASH` on InnoDB phantom-diffed.
2. **Standalone CREATE [UNIQUE] INDEX** (`indexcmds.go` `createIndex`).

### A deeper CREATE INDEX bug found while closing this

MySQL allows `USING {BTREE|HASH}` in **two** grammar positions for `CREATE INDEX`: before `ON` (parser → `stmt.IndexType`) and as a **trailing** `index_option` after the key list (parser → `stmt.Options`). The old `createIndex` read only `stmt.IndexType` and relied on `applyIndexOptions`, which **ignores the `USING` option entirely**. So the common form `CREATE INDEX k ON t (c) USING HASH` dropped the index type on the floor on **all** engines — *accidentally*-correct on InnoDB (dropped == folded), but a real **phantom-diff on MEMORY** (lost HASH). Fixed by resolving the type from both positions (shared `resolveIndexUsingType` helper, mirroring the existing `resolveConstraintIndexType`), then folding.

## Changes

| File | Change |
|---|---|
| `altercmds.go` | Fold in the `ConstrUnique` arm (mirrors the plain-KEY arm). |
| `indexcmds.go` | Resolve index type from both grammar positions via shared helper, then fold. |
| `tablecmds.go` | Extract shared `resolveIndexUsingType`; `resolveConstraintIndexType` delegates to it. Fix the call-site doc comment (CREATE INDEX + ALTER ADD UNIQUE now covered; PRIMARY KEY intentionally excluded). |
| `normalize.go` | Drop unused const `maxInt64`. Fold DATE/TIMESTAMP temporal literals in `stringLitValue` so `TO_DAYS(DATE '2020-01-01')` folds symmetrically with the bare-string form; **TIME** literals excluded (their value is a clock string; `TIME '2020-01-01'` is rejected by MySQL, error 1525). |
| `coerce_hash_test.go`, `normalize_test.go` | Unit + oracle probes (below). |

## Oracle evidence (correctness-protocol)

Proven against the **live** engines (MySQL 5.7.25 `:13307` ssl-disabled, 8.0.32 `:13306`). `TestOracle_InnoDBHashRoundTrip` now covers **all five authoring paths** — CREATE TABLE, ALTER ADD UNIQUE, ALTER ADD KEY, CREATE INDEX, CREATE UNIQUE INDEX — across both versions:

| Path | InnoDB | MEMORY |
|---|---|---|
| ALTER ADD UNIQUE `USING HASH` | round-trips **empty** | `USING HASH` **preserved** |
| ALTER ADD KEY `USING HASH` | empty | preserved |
| CREATE INDEX `USING HASH` (non-unique) | empty | preserved |
| CREATE UNIQUE INDEX `USING HASH` | empty | preserved |

**Bug confirmed pre-fix** (fold stashed, probes kept): the InnoDB `alter-add-unique-hash` and MEMORY `create-index-hash` / `create-unique-index-hash` probes **fail** on both versions; they **pass** after. `USING BTREE` on InnoDB is preserved (not folded) — pinned by `innodb-btree-kept` / `create-index-btree-innodb-kept`. DATE/TIMESTAMP partition-bound folds and the TIME-verbatim case are locked in `TestPartitionConstantFold_Bounds`.

## Testing

- `go test ./mysql/catalog/...` green on **both** live versions (5.7 + 8.0).
- `golangci-lint run --new-from-rev origin/main ./mysql/catalog/...` → **0 new issues**; `gofmt` / `go vet` clean.
- Cross-family review (Claude `/code-review` + Codex `/codex:review`, blind/parallel) → **0 surviving blockers**.

## Out of scope (flagged, not fixed here)

The ALTER ADD UNIQUE/KEY arms never call `applyIndexOptions`, so `COMMENT` / `INVISIBLE` on those statements are silently dropped (a separate pre-existing phantom-diff, distinct from the USING-clause type). Deferred to its own oracle-proven change to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)