### PR TITLE
feat(mysql/parser): accept ARRAY in CAST target for multi-valued indexes (mysql SDL)

### DIFF
--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -2317,6 +2317,9 @@ func writeCastExpr(sb *strings.Builder, n *CastExpr) {
 	writeNode(sb, n.Expr)
 	sb.WriteString(" :type ")
 	writeNode(sb, n.TypeName)
+	if n.Array {
+		sb.WriteString(" :array true")
+	}
 	sb.WriteString("}")
 }
 

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -782,6 +782,11 @@ type CastExpr struct {
 	Loc      Loc
 	Expr     ExprNode
 	TypeName *DataType
+	// Array is set for the multi-valued-index form CAST(expr AS type ARRAY)
+	// (MySQL 8.0.17+). It maps to the grammar's opt_array_cast, an optional
+	// trailing ARRAY keyword after the cast target type. ARRAY is a
+	// non-reserved (contextual) keyword; it only attaches to CAST, never CONVERT.
+	Array bool
 }
 
 func (e *CastExpr) nodeTag()  {}

--- a/mysql/catalog/diff_index_oracle_test.go
+++ b/mysql/catalog/diff_index_oracle_test.go
@@ -56,6 +56,15 @@ func indexDiffProbes() []diffProbe {
 		{"invisible", "CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY va (a) /*!80000 INVISIBLE */)", "t", only(MySQL80)},
 		// Functional / expression index — 8.0 only.
 		{"functional", "CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY fa ((a + 1)), KEY fab ((a + b)))", "t", only(MySQL80)},
+		// Multi-valued (JSON array) functional index — 8.0.17+ only. The CAST(... AS <type> ARRAY)
+		// key part must parse, deparse with the trailing `array`, and round-trip empty. Cover the
+		// representative cast targets (UNSIGNED/CHAR(n)/DECIMAL(m,n)/DATE) MySQL allows in MV keys.
+		{"mv-unsigned", "CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.ids' AS UNSIGNED ARRAY))))", "t", only(MySQL80)},
+		{"mv-char", "CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.codes' AS CHAR(40) ARRAY))))", "t", only(MySQL80)},
+		{"mv-decimal", "CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.amts' AS DECIMAL(10,2) ARRAY))))", "t", only(MySQL80)},
+		{"mv-date", "CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.days' AS DATE ARRAY))))", "t", only(MySQL80)},
+		// Composite MV index: a regular column part combined with an MV (array-cast) part.
+		{"mv-composite", "CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(50), j JSON, KEY mv (name, (CAST(j->'$.ids' AS UNSIGNED ARRAY))))", "t", only(MySQL80)},
 		// FULLTEXT.
 		{"fulltext", "CREATE TABLE t (id INT PRIMARY KEY, body TEXT, ftcol VARCHAR(200), FULLTEXT KEY ftb (body), FULLTEXT KEY ftc (ftcol))", "t", both()},
 		// SPATIAL — needs a NOT NULL geometry column. 8.0 supports SPATIAL on InnoDB; 5.7 needs

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -50,6 +50,8 @@ func indexMigrationProbes() []migrationProbe {
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY va (a) /*!80000 INVISIBLE */)", only(MySQL80)},
 		{"create-with-functional", "t", "",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY fa ((a + 1)))", only(MySQL80)},
+		{"create-with-mv-index", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.ids' AS UNSIGNED ARRAY))))", only(MySQL80)},
 		{"create-with-spatial", "t", "",
 			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL, SPATIAL KEY sg (g))", only(MySQL80)},
 
@@ -85,6 +87,9 @@ func indexMigrationProbes() []migrationProbe {
 		{"add-functional", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT)",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY fa ((a + 1)))", only(MySQL80)},
+		{"add-mv-index", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, j JSON)",
+			"CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.ids' AS UNSIGNED ARRAY))))", only(MySQL80)},
 
 		// ---- DROP INDEX (modified table) ----
 		{"drop-secondary", "t",
@@ -99,6 +104,9 @@ func indexMigrationProbes() []migrationProbe {
 		{"drop-one-of-many", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY ka (a), KEY kb (b))",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT, KEY kb (b))", both()},
+		{"drop-mv-index", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, j JSON, KEY mv ((CAST(j->'$.ids' AS UNSIGNED ARRAY))))",
+			"CREATE TABLE t (id INT PRIMARY KEY, j JSON)", only(MySQL80)},
 
 		// ---- MODIFY index (DROP+ADD): same name, changed shape ----
 		{"modify-columns", "t",

--- a/mysql/deparse/deparse.go
+++ b/mysql/deparse/deparse.go
@@ -714,7 +714,11 @@ func deparseExprAlias(node ast.ExprNode) string {
 		return "(" + deparseExprAlias(n.Expr) + ")"
 	case *ast.CastExpr:
 		// MySQL 8.0 auto-alias: "CAST(a AS CHAR)" — uppercase keywords, no charset.
-		return "CAST(" + deparseExprAlias(n.Expr) + " AS " + deparseDataTypeAlias(n.TypeName) + ")"
+		typeName := deparseDataTypeAlias(n.TypeName)
+		if n.Array {
+			typeName += " ARRAY"
+		}
+		return "CAST(" + deparseExprAlias(n.Expr) + " AS " + typeName + ")"
 	case *ast.ConvertExpr:
 		if n.Charset != "" {
 			return "CONVERT(" + deparseExprAlias(n.Expr) + " USING " + strings.ToLower(n.Charset) + ")"
@@ -1464,6 +1468,11 @@ func deparseCaseExpr(n *ast.CaseExpr) string {
 func deparseCastExpr(n *ast.CastExpr) string {
 	expr := deparseExpr(n.Expr)
 	typeName := deparseDataType(n.TypeName)
+	// Multi-valued-index form CAST(expr AS type ARRAY); MySQL stores the trailing
+	// ARRAY in lowercase in SHOW CREATE TABLE, so emit it to keep the round-trip stable.
+	if n.Array {
+		typeName += " array"
+	}
 	return "cast(" + expr + " as " + typeName + ")"
 }
 

--- a/mysql/deparse/deparse_test.go
+++ b/mysql/deparse/deparse_test.go
@@ -381,6 +381,13 @@ func TestDeparse_Section_2_6_CaseCastConvert(t *testing.T) {
 		{"convert_using", "CONVERT(a USING utf8mb4)", "convert(`a` using utf8mb4)"},
 		// CONVERT type — rewritten to cast
 		{"convert_type_char", "CONVERT(a, CHAR)", "cast(`a` as char charset utf8mb4)"},
+		// Multi-valued-index CAST(... AS type ARRAY): the trailing `array` must be emitted
+		// (lowercase, after the type) so the functional-index expr round-trips. 8.0.17+.
+		{"cast_unsigned_array", "CAST(a AS UNSIGNED ARRAY)", "cast(`a` as unsigned array)"},
+		{"cast_signed_array", "CAST(a AS SIGNED ARRAY)", "cast(`a` as signed array)"},
+		{"cast_char_array", "CAST(a AS CHAR(40) ARRAY)", "cast(`a` as char(40) charset utf8mb4 array)"},
+		{"cast_decimal_array", "CAST(a AS DECIMAL(10,2) ARRAY)", "cast(`a` as decimal(10,2) array)"},
+		{"cast_date_array", "CAST(a AS DATE ARRAY)", "cast(`a` as date array)"},
 	}
 
 	for _, tc := range cases {

--- a/mysql/parser/compare_test.go
+++ b/mysql/parser/compare_test.go
@@ -12338,6 +12338,64 @@ func TestParseCastSIGNEDRegression(t *testing.T) {
 	}
 }
 
+// TestParseCastArray covers the multi-valued-index form CAST(expr AS type ARRAY)
+// (MySQL 8.0.17+): the optional trailing ARRAY keyword sets CastExpr.Array, the base
+// cast target type is unaffected, and ARRAY stays non-reserved (usable as an identifier).
+func TestParseCastArray(t *testing.T) {
+	arrayCases := []struct {
+		input    string
+		typeName string
+	}{
+		{"CAST(x AS UNSIGNED ARRAY)", "UNSIGNED"},
+		{"CAST(x AS SIGNED ARRAY)", "SIGNED"},
+		{"CAST(x AS CHAR(40) ARRAY)", "CHAR"},
+		{"CAST(x AS DECIMAL(10,2) ARRAY)", "DECIMAL"},
+		{"CAST(x AS DATE ARRAY)", "DATE"},
+		{"CAST(x AS TIME ARRAY)", "TIME"},
+		{"CAST(x AS DATETIME ARRAY)", "DATETIME"},
+		{"CAST(x AS BINARY(16) ARRAY)", "BINARY"},
+	}
+	for _, tt := range arrayCases {
+		t.Run(tt.input, func(t *testing.T) {
+			expr := parseExpr(t, tt.input)
+			ce, ok := expr.(*ast.CastExpr)
+			if !ok {
+				t.Fatalf("expected *ast.CastExpr, got %T", expr)
+			}
+			if !ce.Array {
+				t.Errorf("Array = false, want true for %q", tt.input)
+			}
+			if ce.TypeName.Name != tt.typeName {
+				t.Errorf("TypeName = %s, want %s", ce.TypeName.Name, tt.typeName)
+			}
+		})
+	}
+
+	// Without the trailing ARRAY, Array must stay false (no regression).
+	t.Run("no-array", func(t *testing.T) {
+		ce, ok := parseExpr(t, "CAST(x AS UNSIGNED)").(*ast.CastExpr)
+		if !ok {
+			t.Fatalf("expected *ast.CastExpr")
+		}
+		if ce.Array {
+			t.Errorf("Array = true, want false for CAST(x AS UNSIGNED)")
+		}
+	})
+
+	// ARRAY is contextual: it must remain usable as a bare and a quoted identifier.
+	t.Run("array-as-identifier", func(t *testing.T) {
+		for _, sql := range []string{
+			"CREATE TABLE t (array INT)",
+			"CREATE TABLE t (`array` INT)",
+			"SELECT array FROM t",
+		} {
+			if _, err := Parse(sql); err != nil {
+				t.Errorf("Parse(%q) error: %v (ARRAY must stay non-reserved)", sql, err)
+			}
+		}
+	})
+}
+
 // ============================================================================
 // Section 2.1: ALTER TABLE PARTITION BY
 // ============================================================================

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -1190,6 +1190,14 @@ func (p *Parser) parseCastExpr() (nodes.ExprNode, error) {
 		return nil, err
 	}
 
+	// Optional trailing ARRAY for multi-valued functional indexes (8.0.17+):
+	// CAST(expr AS type ARRAY). Maps to the grammar's opt_array_cast. ARRAY is a
+	// non-reserved keyword, consumed only in this cast-target position.
+	isArray := false
+	if _, ok := p.match(kwARRAY); ok {
+		isArray = true
+	}
+
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}
@@ -1198,6 +1206,7 @@ func (p *Parser) parseCastExpr() (nodes.ExprNode, error) {
 		Loc:      nodes.Loc{Start: start, End: p.pos()},
 		Expr:     expr,
 		TypeName: dt,
+		Array:    isArray,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes the last deep-stress bug: omni's parser rejected the `ARRAY` keyword in a CAST target type, so a table with a JSON **multi-valued index** (`KEY mvi ((CAST(tags->'$.ids' AS UNSIGNED ARRAY)))`, MySQL 8.0.17+) failed `LoadSDL` — hard-breaking the SDL round-trip for the **entire schema**, not just a phantom diff.

## Fix
- `mysql/parser/expr.go` — accept an optional trailing `ARRAY` on the CAST target type (contextual keyword; `array` stays a valid identifier).
- `mysql/ast/parsenodes.go` — `CastExpr.Array bool`; `mysql/ast/outfuncs.go` dump.
- `mysql/deparse/deparse.go` — round-trips ` ARRAY` so the canonical form is stable + idempotent.

## Verified
Oracle-proven on live 8.0: `CAST(… AS UNSIGNED/CHAR(n)/DECIMAL/DATE ARRAY)` parse; MV-index table LoadSDL → no-op diff empty; ADD/DROP MV index applies + converges; identifier `array` still parses; no 5.7 regression. Broader tree (parser/ast/deparse/catalog) all green. Cross-family review (Claude lens): 0 blockers, 5 correctness candidates refuted under verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)