### PR TITLE
feat(mysql): parse parenthesized row constructors in expressions

### DIFF
--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -1150,6 +1150,26 @@ func (p *Parser) parseParenExpr() (nodes.ExprNode, error) {
 		return nil, p.syntaxErrorAtCur()
 	}
 
+	if p.cur.Type == ',' {
+		row := &nodes.RowExpr{Loc: nodes.Loc{Start: start}, Items: []nodes.ExprNode{expr}}
+		for p.cur.Type == ',' {
+			p.advance()
+			item, err := p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			if item == nil {
+				return nil, p.syntaxErrorAtCur()
+			}
+			row.Items = append(row.Items, item)
+		}
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		row.Loc.End = p.pos()
+		return row, nil
+	}
+
 	if _, err := p.expect(')'); err != nil {
 		return nil, err
 	}

--- a/mysql/parser/row_constructor_test.go
+++ b/mysql/parser/row_constructor_test.go
@@ -1,0 +1,93 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/mysql/ast"
+)
+
+func TestParseRowConstructor_Bare(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"(1, 2)", "{ROW :loc 0 :items ({INT_LIT :val 1 :loc 1} {INT_LIT :val 2 :loc 4})}"},
+		{"(1, 2, 3)", "{ROW :loc 0 :items ({INT_LIT :val 1 :loc 1} {INT_LIT :val 2 :loc 4} {INT_LIT :val 3 :loc 7})}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ast.NodeToString(parseExpr(t, tt.input))
+			if got != tt.want {
+				t.Errorf("parseExpr(%q):\n  got:  %s\n  want: %s", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRowConstructor_Nested(t *testing.T) {
+	expr := parseExpr(t, "((1, 2), (3, 4))")
+	row, ok := expr.(*ast.RowExpr)
+	if !ok {
+		t.Fatalf("expected *ast.RowExpr, got %T", expr)
+	}
+	if len(row.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(row.Items))
+	}
+	for i, item := range row.Items {
+		if _, ok := item.(*ast.RowExpr); !ok {
+			t.Errorf("item %d: expected *ast.RowExpr, got %T", i, item)
+		}
+	}
+}
+
+func TestParseRowConstructor_SingleStaysParen(t *testing.T) {
+	got := ast.NodeToString(parseExpr(t, "(1)"))
+	want := "{PAREN :loc 0 :expr {INT_LIT :val 1 :loc 1}}"
+	if got != want {
+		t.Errorf("parseExpr(\"(1)\"):\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+func TestParseRowConstructor_Reject(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT ()",
+		"SELECT (1,)",
+		"SELECT (1, 2,)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Errorf("Parse(%q): expected parse error, got nil", sql)
+			}
+		})
+	}
+}
+
+func TestParseRowConstructor_RowKeyword(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM t WHERE ROW(a, b) = ROW(1, 2)",
+		"SELECT * FROM t WHERE ROW(a, b) IN ((1, 2), (3, 4))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Errorf("Parse(%q): unexpected parse error: %v", sql, err)
+			}
+		})
+	}
+}
+
+func TestParseRowConstructor_InStatements(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM t WHERE (a, b) = (1, 2)",
+		"SELECT * FROM t WHERE (a, b) IN ((1, 2), (3, 4))",
+		"SELECT * FROM t WHERE (a, b) > (1, 2)",
+		"SELECT * FROM t WHERE (a, b) NOT IN ((1, 2))",
+		"SELECT * FROM t WHERE (a, b) <=> (1, 2)",
+		"SELECT * FROM t WHERE (a, b) IN (SELECT a, b FROM u)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Errorf("Parse(%q): unexpected parse error: %v", sql, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `(a, b)` with >= 2 elements now parses as a `RowExpr` in MySQL engine
- Mirrors mariadb PR #330 — identical fix in `parseParenExpr()`
- Reuses existing `RowExpr` node (already emitted by `ROW(...)`), so deparse/walk/resolver need no changes

Covers the common shapes Bytebase SQL editor (Diagnose) sees:
- Tuple comparison: `(a, b) = (1, 2)`
- Composite-key IN: `(a, b) IN ((1, 2), (3, 4))`
- Keyset pagination: `(a, b) > (?, ?)`
- Row subquery: `(a, b) IN (SELECT a, b FROM u)`
- Nested: `((1, 2), (3, 4))`

Reject space preserved (matching MySQL 8.0):
- `()` — empty parens
- `(1,)` — trailing comma
- Single `(1)` stays a `ParenExpr`

Grounded against MySQL 8.0 `sql/sql_yacc.yy` source (`simple_expr` rule lines 10521-10529).

Closes BYT-9778

## Test plan

- [x] `TestParseRowConstructor_Bare` — AST shape verification
- [x] `TestParseRowConstructor_Nested` — nested row constructors
- [x] `TestParseRowConstructor_SingleStaysParen` — boundary guard
- [x] `TestParseRowConstructor_Reject` — empty/trailing comma rejection
- [x] `TestParseRowConstructor_RowKeyword` — explicit `ROW()` still works
- [x] `TestParseRowConstructor_InStatements` — real-world SQL patterns
- [x] Existing `TestParse*`, `TestKeyword*`, `TestSplit*`, `TestDeparse*` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)