### PR TITLE
fix(mysql/catalog): resolve VARCHAR/CHAR/TEXT BINARY modifier to <charset>_bin collation

### DIFF
--- a/mysql/catalog/diff_oracle_test.go
+++ b/mysql/catalog/diff_oracle_test.go
@@ -156,6 +156,15 @@ func diffIdempotenceProbes() []diffProbe {
 		{"implicit-table-opts", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10))", "t", both()},
 		// explicit table charset + column echo (version-flagged echo rules).
 		{"charset-echo", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(10) CHARACTER SET utf8mb4, b VARCHAR(10)) DEFAULT CHARSET=utf8mb4", "t", both()},
+		// bug (Roundcube et al.): the legacy `BINARY` string-column modifier resolves to the
+		// charset's `_bin` collation (stored as CHARACTER SET <cs> COLLATE <cs>_bin on both
+		// versions). The user's `varchar(n) BINARY` form must diff EMPTY against that stored
+		// pair — the regression was a phantom MODIFY COLUMN on every no-op. Covers varchar/char/
+		// text/tinytext on a utf8mb4 table (-> utf8mb4_bin) plus an explicit ascii column
+		// (-> ascii_bin). (entry char-binary-attribute)
+		{"binary-modifier-utf8mb4", "CREATE TABLE t (id INT PRIMARY KEY, k VARCHAR(128) BINARY NOT NULL, c CHAR(5) BINARY, tx TEXT BINARY, ti TINYTEXT BINARY, ac VARCHAR(10) CHARACTER SET ascii BINARY) DEFAULT CHARSET=utf8mb4", "t", both()},
+		// latin1 table -> latin1_bin.
+		{"binary-modifier-latin1", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(50) BINARY) DEFAULT CHARSET=latin1", "t", both()},
 		// comment escaping (table COMMENT carries an embedded single-quoted token `'c'` via
 		// doubled quotes; the closing quote balances the literal — the previous fixture dropped it,
 		// so MySQL rejected the DDL and the probe silently skipped on both engines).

--- a/mysql/catalog/migration_oracle_test.go
+++ b/mysql/catalog/migration_oracle_test.go
@@ -166,6 +166,19 @@ func migrationProbes() []migrationProbe {
 		{"modify-charset", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) CHARACTER SET latin1) DEFAULT CHARSET=utf8mb4",
 			"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) CHARACTER SET utf8mb4) DEFAULT CHARSET=utf8mb4", both()},
+		// bug (Roundcube et al.): the legacy `BINARY` string-column modifier resolves to the
+		// charset's `_bin` collation. The generated DDL for a `varchar BINARY` target must
+		// apply to a real engine and yield a column whose stored form (COLLATE <cs>_bin) equals
+		// the target — i.e. ADD/MODIFY emits the resolved _bin collation, not the table default.
+		// (entry char-binary-attribute)
+		{"add-column-binary-modifier", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY) DEFAULT CHARSET=utf8mb4",
+			"CREATE TABLE t (id INT PRIMARY KEY, k VARCHAR(128) BINARY NOT NULL) DEFAULT CHARSET=utf8mb4", both()},
+		// MODIFY a plain column TO its BINARY (_bin) form — a genuine collation change that must
+		// be emitted and applied (proves the fix doesn't make plain↔BINARY an invisible no-op).
+		{"modify-column-to-binary-modifier", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10)) DEFAULT CHARSET=utf8mb4",
+			"CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(10) BINARY) DEFAULT CHARSET=utf8mb4", both()},
 		{"modify-comment", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, v INT COMMENT 'a')",
 			"CREATE TABLE t (id INT PRIMARY KEY, v INT COMMENT 'b')", both()},

--- a/mysql/catalog/normalize_oracle_test.go
+++ b/mysql/catalog/normalize_oracle_test.go
@@ -201,6 +201,41 @@ func normalizationProbes() []ruleProbe {
 		{"char-binary-length-default",
 			"CREATE TABLE t_char (a CHAR, b CHAR(10), d BINARY, e BINARY(16), f VARBINARY(32))",
 			"t_char", []string{"a", "b", "d", "e", "f"}, both()},
+		// bug (Roundcube/phpBB/MediaWiki dumps): the legacy `BINARY` column modifier on a
+		// string type is NOT the BINARY data type — it means "use the binary collation of
+		// the column's charset", which MySQL stores as an explicit
+		// `CHARACTER SET <cs> COLLATE <cs>_bin` pair on BOTH 5.7 and 8.0. The user's
+		// `varchar(n) BINARY` form must canonicalize onto that stored `<cs>_bin` pair, else
+		// every declarative no-op emits a phantom `MODIFY COLUMN`. (entry char-binary-attribute)
+		// The string-charset-attribute family (varchar/char/text/tinytext/mediumtext/longtext)
+		// all resolve to <table-charset>_bin; explicit table CHARSET keeps it version-stable.
+		{"char-binary-attribute-utf8mb4",
+			"CREATE TABLE t_binu (k VARCHAR(128) BINARY NOT NULL, c CHAR(5) BINARY, t TEXT BINARY, ti TINYTEXT BINARY, me MEDIUMTEXT BINARY, lo LONGTEXT BINARY) DEFAULT CHARSET=utf8mb4",
+			"t_binu", []string{"k", "c", "t", "ti", "me", "lo"}, both()},
+		// latin1 table → latin1_bin (the column inherits the table charset, BINARY picks its _bin).
+		{"char-binary-attribute-latin1",
+			"CREATE TABLE t_binl (a VARCHAR(50) BINARY, c CHAR(8) BINARY) DEFAULT CHARSET=latin1",
+			"t_binl", []string{"a", "c"}, both()},
+		// explicit column CHARACTER SET ascii + BINARY → ascii_bin (column charset, not table's).
+		{"char-binary-attribute-ascii-explicit",
+			"CREATE TABLE t_bina (a VARCHAR(10) CHARACTER SET ascii BINARY, c CHAR(4) CHARACTER SET ascii BINARY) DEFAULT CHARSET=utf8mb4",
+			"t_bina", []string{"a", "c"}, both()},
+		// utf8/utf8mb3 alias + BINARY → utf8_bin (5.7) / utf8mb3_bin (8.0); the fold must collapse them.
+		{"char-binary-attribute-utf8-alias",
+			"CREATE TABLE t_binm (a VARCHAR(10) CHARACTER SET utf8 BINARY, b VARCHAR(10) CHARACTER SET utf8mb3 BINARY) DEFAULT CHARSET=utf8mb4",
+			"t_binm", []string{"a", "b"}, both()},
+		// precedence edge: `BINARY` after the type silently OVERRIDES a trailing explicit
+		// COLLATE — MySQL stores utf8mb4_bin, NOT utf8mb4_unicode_ci (verified on the engine;
+		// the reversed order `COLLATE ... BINARY` is a syntax error MySQL rejects). So the
+		// BINARY-derived _bin collation must win the canonical key.
+		{"char-binary-attribute-collate-precedence",
+			"CREATE TABLE t_binp (a VARCHAR(10) BINARY COLLATE utf8mb4_unicode_ci) DEFAULT CHARSET=utf8mb4",
+			"t_binp", []string{"a"}, both()},
+		// don't over-match: a real BINARY/VARBINARY DATA TYPE column carries no charset/collation
+		// and must NOT be touched by the BINARY-modifier resolution (it has no _bin pair).
+		{"char-binary-attribute-real-binary-type",
+			"CREATE TABLE t_binr (a BINARY(8), b VARBINARY(16), c BLOB) DEFAULT CHARSET=utf8mb4",
+			"t_binr", []string{"a", "b", "c"}, both()},
 		{"text-blob-no-default-null",
 			"CREATE TABLE t_tb (g TEXT, h BLOB, j LONGTEXT, k TINYTEXT)",
 			"t_tb", []string{"g", "h", "j", "k"}, both()},
@@ -348,6 +383,26 @@ func TestOracle_MissedDiffGuards(t *testing.T) {
 			if n.CanonicalColumn(tA, cA) == n.CanonicalColumn(tB, cB) {
 				t.Errorf("[%s] bare column must follow table COLLATE change:\n A=%s\n B=%s",
 					o.name, n.CanonicalColumn(tA, cA), n.CanonicalColumn(tB, cB))
+			}
+		})
+
+		t.Run(o.name+"/binary-modifier-vs-plain-collation", func(t *testing.T) {
+			// BINARY-modifier over-collapse guard: `varchar BINARY` resolves to the
+			// `<cs>_bin` collation, which is a GENUINE difference from a plain `varchar`
+			// (table-default collation). The fix must not make them share a key, else a
+			// real collation change (plain → BINARY) would be an invisible diff. Loaded
+			// from the engine's authentic readbacks (binary side stores COLLATE utf8mb4_bin,
+			// plain side stores the table default).
+			ddl := "CREATE TABLE t (b VARCHAR(10) BINARY, p VARCHAR(10)) DEFAULT CHARSET=utf8mb4"
+			rb, ok := o.showCreate(t, "mdg_bin", ddl, "t")
+			if !ok {
+				t.Skip("could not obtain readback")
+			}
+			tbl, bCol := loadColumn(t, sc, rb, "t", "b")
+			_, pCol := loadColumn(t, sc, rb, "t", "p")
+			if n.CanonicalColumn(tbl, bCol) == n.CanonicalColumn(tbl, pCol) {
+				t.Errorf("[%s] varchar BINARY (_bin) and plain varchar (default) must differ:\n  b=%s\n  p=%s",
+					o.name, n.CanonicalColumn(tbl, bCol), n.CanonicalColumn(tbl, pCol))
 			}
 		})
 

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1844,11 +1844,26 @@ func convertToBinaryType(col *Column, dt *nodes.DataType) *Column {
 	return col
 }
 
+// applyBinaryModifierCollation resolves the legacy BINARY column modifier
+// (e.g. `VARCHAR(n) BINARY`, `CHAR(n) BINARY`, `TEXT BINARY`) to the binary
+// collation of the column's effective charset. MySQL treats the trailing
+// BINARY attribute as shorthand for `COLLATE <charset>_bin` and stores the
+// column with an explicit `CHARACTER SET <cs> COLLATE <cs>_bin` pair (verified
+// on 5.7 + 8.0; see normalization.md entry char-binary-attribute). The charset
+// is resolved by the caller (column charset if specified, else table/db
+// default) before this runs, so col.Charset already holds the effective
+// charset. Both the charset and the derived collation must be flagged explicit
+// so the normalizer's ResolveColumnCharsetCollation honors the _bin collation
+// instead of falling back to the table-default collation — otherwise the
+// user's `BINARY` form and the stored `<cs>_bin` form canonicalize differently
+// and phantom-diff forever.
 func applyBinaryModifierCollation(col *Column, dt *nodes.DataType) {
 	if col == nil || dt == nil || !dt.Binary || col.Charset == "" {
 		return
 	}
 	col.Collation = fmt.Sprintf("%s_bin", normalizeCharsetName(col.Charset))
+	col.CharsetExplicit = true
+	col.CollationExplicit = true
 }
 
 // nodeToSQLGenerated converts an AST expression to SQL for use in a generated


### PR DESCRIPTION
Real-world-schema smoke (Roundcube) found this: the legacy **`VARCHAR(n) BINARY`** column modifier (also `CHAR/TEXT BINARY`) is not the BINARY data type — it means "use the charset's **`_bin`** collation". MySQL stores it as `CHARACTER SET <cs> COLLATE <cs>_bin` (verified live 5.7+8.0).

The loader derived `col.Collation = <cs>_bin` but left `CharsetExplicit`/`CollationExplicit` unset, so the normalizer's `ResolveColumnCharsetCollation` discarded it and fell back to the table default → a **phantom `MODIFY COLUMN`** on every declarative no-op (breaks idempotence for Roundcube/phpBB/MediaWiki-era dumps that use `varchar BINARY`). Fix: flag the BINARY-derived charset+collation explicit so the normalizer honors the `_bin` pair.

Proven both gates, both versions (12 probes): utf8mb4/latin1/ascii-explicit/utf8-alias/COLLATE-precedence + real BINARY/VARBINARY data-type non-match guard; diff idempotence; ADD + MODIFY apply-correctness; missed-diff guard. The Roundcube `cache` headline now diffs empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)