### PR TITLE
fix(mysql): parse parenthesized JOIN groups in FROM clause (multi-table view round-trip)

### DIFF
--- a/mysql/catalog/migration_view_oracle_test.go
+++ b/mysql/catalog/migration_view_oracle_test.go
@@ -78,6 +78,72 @@ func viewIdempotenceProbes() []viewSchemaProbe {
 			"CREATE TABLE u (x INT, y INT)",
 			"CREATE VIEW v AS SELECT t.a, u.y FROM t LEFT JOIN u ON t.c = u.x",
 		}, []string{"t", "u"}, []string{"v"}, both()},
+		// Multi-table joins: the engine stores these as nested parenthesized join
+		// groups — `((t join u on(..)) join w on(..))` — the canonical SHOW CREATE
+		// VIEW form that the FROM-clause table_reference parser must accept. These
+		// are the regression guards for the parenthesized-join-group parser fix.
+		{"join-3-table", []string{
+			"CREATE TABLE t (a INT, c INT)",
+			"CREATE TABLE u (x INT, y INT)",
+			"CREATE TABLE w (m INT, n INT)",
+			"CREATE VIEW v AS SELECT t.a, u.y, w.n FROM t JOIN u ON t.c = u.x JOIN w ON u.y = w.m",
+		}, []string{"t", "u", "w"}, []string{"v"}, both()},
+		{"join-4-table", []string{
+			"CREATE TABLE t (a INT, c INT)",
+			"CREATE TABLE u (x INT, y INT)",
+			"CREATE TABLE w (m INT, n INT)",
+			"CREATE TABLE z (p INT, q INT)",
+			"CREATE VIEW v AS SELECT t.a FROM t JOIN u ON t.c = u.x JOIN w ON u.y = w.m JOIN z ON w.n = z.p",
+		}, []string{"t", "u", "w", "z"}, []string{"v"}, both()},
+		// LEFT/INNER mix over 3+ tables (the sakila film_list join shape).
+		{"join-left-inner-mix", []string{
+			"CREATE TABLE category (category_id INT, name VARCHAR(50))",
+			"CREATE TABLE film_category (film_id INT, category_id INT)",
+			"CREATE TABLE film (film_id INT, title VARCHAR(50))",
+			"CREATE TABLE film_actor (actor_id INT, film_id INT)",
+			"CREATE TABLE actor (actor_id INT, name VARCHAR(50))",
+			"CREATE VIEW v AS SELECT film.film_id AS FID, category.name AS category, actor.name AS actor " +
+				"FROM category " +
+				"LEFT JOIN film_category ON category.category_id = film_category.category_id " +
+				"LEFT JOIN film ON film_category.film_id = film.film_id " +
+				"JOIN film_actor ON film.film_id = film_actor.film_id " +
+				"JOIN actor ON film_actor.actor_id = actor.actor_id",
+		}, []string{"category", "film_category", "film", "film_actor", "actor"}, []string{"v"}, both()},
+		// GROUP BY over a multi-table join (full sakila film_list shape).
+		{"join-group-by", []string{
+			"CREATE TABLE category (category_id INT, name VARCHAR(50))",
+			"CREATE TABLE film_category (film_id INT, category_id INT)",
+			"CREATE TABLE film (film_id INT, title VARCHAR(50))",
+			"CREATE TABLE film_actor (actor_id INT, film_id INT)",
+			"CREATE TABLE actor (actor_id INT, name VARCHAR(50))",
+			"CREATE VIEW v AS SELECT film.film_id AS FID, COUNT(*) AS n " +
+				"FROM category " +
+				"LEFT JOIN film_category ON category.category_id = film_category.category_id " +
+				"LEFT JOIN film ON film_category.film_id = film.film_id " +
+				"JOIN film_actor ON film.film_id = film_actor.film_id " +
+				"JOIN actor ON film_actor.actor_id = actor.actor_id " +
+				"GROUP BY film.film_id",
+		}, []string{"category", "film_category", "film", "film_actor", "actor"}, []string{"v"}, both()},
+		// view-on-view layered over a multi-table-join base view.
+		{"view-on-multi-join-view", []string{
+			"CREATE TABLE t (a INT, c INT)",
+			"CREATE TABLE u (x INT, y INT)",
+			"CREATE TABLE w (m INT, n INT)",
+			"CREATE VIEW base AS SELECT t.a AS a, u.y AS y, w.n AS n FROM t JOIN u ON t.c = u.x JOIN w ON u.y = w.m",
+			"CREATE VIEW v AS SELECT a, n FROM base WHERE a > 0",
+		}, []string{"t", "u", "w"}, []string{"base", "v"}, both()},
+		// Derived table (subquery) in FROM — must still parse as a subquery, not a
+		// join group (regression guard for the disambiguation).
+		{"derived-table-from", []string{
+			"CREATE TABLE t (a INT, b INT)",
+			"CREATE VIEW v AS SELECT d.a FROM (SELECT a, b FROM t WHERE b > 0) d",
+		}, []string{"t"}, []string{"v"}, both()},
+		// Derived table joined to a base table inside the FROM (mixed subquery + join).
+		{"derived-table-join", []string{
+			"CREATE TABLE t (a INT, c INT)",
+			"CREATE TABLE u (x INT, y INT)",
+			"CREATE VIEW v AS SELECT t.a, d.y FROM t JOIN (SELECT x, y FROM u) d ON t.c = d.x",
+		}, []string{"t", "u"}, []string{"v"}, both()},
 		{"algorithm-merge", []string{
 			"CREATE TABLE t (a INT)",
 			"CREATE ALGORITHM=MERGE VIEW v AS SELECT a FROM t",
@@ -322,6 +388,40 @@ func viewMigrationProbes() []viewMigrationProbe {
 			base("CREATE TABLE t (id INT)"),
 			base("CREATE TABLE t (id INT)", "CREATE VIEW a AS SELECT id AS b FROM t", "CREATE VIEW b AS SELECT b FROM a"),
 			[]string{"t"}, []string{"a", "b"}, both()},
+		// ---- multi-table-join views (parenthesized-join-group apply-correctness) ----
+		// CREATE a view whose stored body is a nested parenthesized join group.
+		{"create-multi-join",
+			base("CREATE TABLE t (a INT, c INT)", "CREATE TABLE u (x INT, y INT)", "CREATE TABLE w (m INT, n INT)"),
+			base("CREATE TABLE t (a INT, c INT)", "CREATE TABLE u (x INT, y INT)", "CREATE TABLE w (m INT, n INT)",
+				"CREATE VIEW v AS SELECT t.a, u.y, w.n FROM t JOIN u ON t.c = u.x JOIN w ON u.y = w.m"),
+			[]string{"t", "u", "w"}, []string{"v"}, both()},
+		// CREATE the sakila film_list join shape (5-table LEFT/INNER mix + GROUP BY).
+		{"create-sakila-film-list",
+			base("CREATE TABLE category (category_id INT, name VARCHAR(50))",
+				"CREATE TABLE film_category (film_id INT, category_id INT)",
+				"CREATE TABLE film (film_id INT, title VARCHAR(50))",
+				"CREATE TABLE film_actor (actor_id INT, film_id INT)",
+				"CREATE TABLE actor (actor_id INT, name VARCHAR(50))"),
+			base("CREATE TABLE category (category_id INT, name VARCHAR(50))",
+				"CREATE TABLE film_category (film_id INT, category_id INT)",
+				"CREATE TABLE film (film_id INT, title VARCHAR(50))",
+				"CREATE TABLE film_actor (actor_id INT, film_id INT)",
+				"CREATE TABLE actor (actor_id INT, name VARCHAR(50))",
+				"CREATE VIEW v AS SELECT film.film_id AS FID, category.name AS category, actor.name AS actor "+
+					"FROM category "+
+					"LEFT JOIN film_category ON category.category_id = film_category.category_id "+
+					"LEFT JOIN film ON film_category.film_id = film.film_id "+
+					"JOIN film_actor ON film.film_id = film_actor.film_id "+
+					"JOIN actor ON film_actor.actor_id = actor.actor_id "+
+					"GROUP BY film.film_id"),
+			[]string{"category", "film_category", "film", "film_actor", "actor"}, []string{"v"}, both()},
+		// REPLACE a single-table body with a multi-table-join body.
+		{"replace-into-multi-join",
+			base("CREATE TABLE t (a INT, c INT)", "CREATE TABLE u (x INT, y INT)", "CREATE TABLE w (m INT, n INT)",
+				"CREATE VIEW v AS SELECT a FROM t"),
+			base("CREATE TABLE t (a INT, c INT)", "CREATE TABLE u (x INT, y INT)", "CREATE TABLE w (m INT, n INT)",
+				"CREATE VIEW v AS SELECT t.a, w.n FROM t JOIN u ON t.c = u.x JOIN w ON u.y = w.m"),
+			[]string{"t", "u", "w"}, []string{"v"}, both()},
 		// ---- REPLACE (modify body / options) ----
 		{"replace-body",
 			base("CREATE TABLE t (a INT, b INT)", "CREATE VIEW v AS SELECT a FROM t"),

--- a/mysql/parser/parenthesized_join_test.go
+++ b/mysql/parser/parenthesized_join_test.go
@@ -1,0 +1,155 @@
+package parser
+
+import (
+	"testing"
+
+	ast "github.com/bytebase/omni/mysql/ast"
+)
+
+// TestParenthesizedJoinGroup pins the FROM-clause table_reference parser on
+// parenthesized join groups — `( table_reference )` where the inner is itself a
+// (possibly joined) table reference. MySQL stores a multi-table-join view's FROM
+// clause in this canonical left-deep, fully-parenthesized form (the shape emitted
+// by SHOW CREATE VIEW / mysqldump), e.g. sakila's film_list:
+//
+//	from ((((`category` left join `film_category` on(...)) left join `film` on(...))
+//	       join `film_actor` on(...)) join `actor` on(...))
+//
+// A leading run of '(' here must NOT be mistaken for a parenthesized sub-SELECT;
+// the deciding token is the first one past the parens (a query primary means a
+// derived table, a table reference means a join group).
+func TestParenthesizedJoinGroup(t *testing.T) {
+	for _, sql := range []string{
+		// single parenthesized table
+		"SELECT * FROM (t)",
+		"SELECT * FROM ((t))",
+		"SELECT * FROM (((t)))",
+		// 2-table parenthesized join group
+		"SELECT * FROM (a JOIN b ON a.id = b.id)",
+		"SELECT * FROM (`a` JOIN `b` ON(`a`.`id` = `b`.`id`))",
+		// join group whose factors carry aliases (the SHOW CREATE VIEW form)
+		"SELECT * FROM (`category` `a` JOIN `film_category` `b` ON(`a`.`category_id` = `b`.`category_id`))",
+		// nested left-deep groups (3, 4, 5 tables)
+		"SELECT * FROM ((a JOIN b ON a.id = b.id) JOIN c ON b.id = c.id)",
+		"SELECT * FROM (((a JOIN b ON a.id=b.id) JOIN c ON b.id=c.id) JOIN d ON c.id=d.id)",
+		"SELECT * FROM ((((`category` left join `film_category` on((`category`.`category_id` = `film_category`.`category_id`))) left join `film` on((`film_category`.`film_id` = `film`.`film_id`))) join `film_actor` on((`film`.`film_id` = `film_actor`.`film_id`))) join `actor` on((`film_actor`.`actor_id` = `actor`.`actor_id`)))",
+		// right-deep parenthesized group
+		"SELECT * FROM (a JOIN (b JOIN c ON b.id = c.id) ON a.id = b.id)",
+		// LEFT / INNER / CROSS / USING inside groups
+		"SELECT * FROM (a LEFT JOIN b ON a.id = b.id)",
+		"SELECT * FROM (a INNER JOIN b USING (id))",
+		"SELECT * FROM (a CROSS JOIN b)",
+		"SELECT * FROM ((a LEFT JOIN b ON a.id=b.id) JOIN c ON b.id=c.id)",
+		// full sakila film_list CREATE VIEW (the real-world repro)
+		"CREATE VIEW `film_list` AS select `film`.`film_id` AS `FID` from ((((`category` left join `film_category` on((`category`.`category_id` = `film_category`.`category_id`))) left join `film` on((`film_category`.`film_id` = `film`.`film_id`))) join `film_actor` on((`film`.`film_id` = `film_actor`.`film_id`))) join `actor` on((`film_actor`.`actor_id` = `actor`.`actor_id`))) group by `film`.`film_id`",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedJoinGroupRegression guards the derived-table side of the
+// disambiguation: a '(' run that ultimately opens a query primary must still be
+// parsed as a derived-table subquery (with its alias / column list), and plain /
+// comma / explicit joins must be unaffected.
+func TestParenthesizedJoinGroupRegression(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM t",
+		"SELECT * FROM a, b",
+		"SELECT * FROM a JOIN b ON a.id = b.id",
+		"SELECT * FROM a LEFT JOIN b ON a.id = b.id LEFT JOIN c ON b.id = c.id",
+		// derived tables
+		"SELECT * FROM (SELECT 1) x",
+		"SELECT * FROM ((SELECT 1)) x",
+		"SELECT * FROM (((SELECT 1))) x",
+		"SELECT * FROM (SELECT 1 AS c) AS t(x)",
+		"SELECT * FROM ((SELECT 1) UNION (SELECT 2)) u",
+		"SELECT * FROM (SELECT * FROM (SELECT 1) y) x",
+		// derived table mixed with a join group
+		"SELECT * FROM (a JOIN (SELECT 1) d ON a.id = d.x)",
+		"SELECT * FROM t JOIN (SELECT x FROM u) d ON t.c = d.x",
+		// LATERAL derived table (8.0)
+		"SELECT * FROM t, LATERAL (SELECT 1) d",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedJoinGroupStructure asserts the parenthesized join group folds
+// into the correct left-deep JoinClause tree (right join types, ON conditions
+// present, non-degenerate Loc spans) — not merely that it parses.
+func TestParenthesizedJoinGroupStructure(t *testing.T) {
+	sql := "SELECT * FROM ((((`category` left join `film_category` on(1)) left join `film` on(2)) join `film_actor` on(3)) join `actor` on(4))"
+	list := ParseAndCheck(t, sql)
+	sel, ok := list.Items[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected *SelectStmt, got %T", list.Items[0])
+	}
+	if len(sel.From) != 1 {
+		t.Fatalf("expected 1 folded FROM element, got %d", len(sel.From))
+	}
+
+	// Outer-to-inner spine of the left-deep tree.
+	wantSpine := []struct {
+		jt    ast.JoinType
+		right string
+	}{
+		{ast.JoinInner, "actor"},
+		{ast.JoinInner, "film_actor"},
+		{ast.JoinLeft, "film"},
+		{ast.JoinLeft, "film_category"},
+	}
+	cur := sel.From[0]
+	for i, w := range wantSpine {
+		jc, ok := cur.(*ast.JoinClause)
+		if !ok {
+			t.Fatalf("spine[%d]: expected *JoinClause, got %T", i, cur)
+		}
+		if jc.Type != w.jt {
+			t.Errorf("spine[%d]: join type = %v, want %v", i, jc.Type, w.jt)
+		}
+		if jc.Condition == nil {
+			t.Errorf("spine[%d]: missing ON/USING condition", i)
+		}
+		if jc.Loc.End <= jc.Loc.Start {
+			t.Errorf("spine[%d]: degenerate Loc span %d..%d", i, jc.Loc.Start, jc.Loc.End)
+		}
+		rt, ok := jc.Right.(*ast.TableRef)
+		if !ok {
+			t.Fatalf("spine[%d]: right expected *TableRef, got %T", i, jc.Right)
+		}
+		if rt.Name != w.right {
+			t.Errorf("spine[%d]: right table = %q, want %q", i, rt.Name, w.right)
+		}
+		cur = jc.Left
+	}
+	if leaf, ok := cur.(*ast.TableRef); !ok {
+		t.Fatalf("innermost left expected *TableRef, got %T", cur)
+	} else if leaf.Name != "category" {
+		t.Errorf("innermost left = %q, want %q", leaf.Name, "category")
+	}
+}
+
+// TestParenthesizedDerivedTableStillSubquery verifies derived tables are not
+// misrouted to the join-group path by the disambiguation.
+func TestParenthesizedDerivedTableStillSubquery(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT * FROM (SELECT 1) x",
+		"SELECT * FROM ((SELECT 1)) y",
+		"SELECT * FROM (((SELECT 1 UNION SELECT 2))) z",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			list := ParseAndCheck(t, sql)
+			sel := list.Items[0].(*ast.SelectStmt)
+			if len(sel.From) != 1 {
+				t.Fatalf("expected 1 FROM element, got %d", len(sel.From))
+			}
+			if _, ok := sel.From[0].(*ast.SubqueryExpr); !ok {
+				t.Errorf("expected *SubqueryExpr, got %T", sel.From[0])
+			}
+		})
+	}
+}

--- a/mysql/parser/select.go
+++ b/mysql/parser/select.go
@@ -412,6 +412,48 @@ func (p *Parser) isQueryExpressionStart() bool {
 	return isQueryPrimaryStartToken(next.Type) || next.Type == '('
 }
 
+// scanState captures the full lexical scan position so a speculative lookahead
+// can rewind without consuming input. The Lexer is a flat value (string + ints),
+// so a shallow copy snapshots its position; the buffered next token and the
+// current/previous tokens complete the parser's scan cursor.
+type scanState struct {
+	lexer   Lexer
+	cur     Token
+	prev    Token
+	nextBuf Token
+	hasNext bool
+}
+
+func (p *Parser) saveScan() scanState {
+	return scanState{lexer: *p.lexer, cur: p.cur, prev: p.prev, nextBuf: p.nextBuf, hasNext: p.hasNext}
+}
+
+func (p *Parser) restoreScan(s scanState) {
+	*p.lexer = s.lexer
+	p.cur = s.cur
+	p.prev = s.prev
+	p.nextBuf = s.nextBuf
+	p.hasNext = s.hasNext
+}
+
+// firstTokenPastParens returns the first token at or after the current position
+// that is not an opening parenthesis, without consuming input. It is the
+// disambiguator for a FROM-clause table factor that begins with '(': a run of
+// '(' may open either a (possibly nested) derived-table subquery
+// — `((SELECT ...))` — or a (possibly nested) parenthesized join group
+// — `((a JOIN b) JOIN c)`. MySQL's grammar distinguishes them by whether the
+// innermost head is a query primary (SELECT/WITH/TABLE/VALUES) or a table
+// reference; a fixed one-token lookahead on '(' cannot, so we scan past the
+// parens speculatively and rewind.
+func (p *Parser) firstTokenPastParens() Token {
+	saved := p.saveScan()
+	defer p.restoreScan(saved)
+	for p.cur.Type == '(' {
+		p.advance()
+	}
+	return p.cur
+}
+
 // parseSelectWithParens parses a parenthesized query expression (PostgreSQL's
 // select_with_parens): '(' select_no_parens ')'. It returns a WRAPPER node
 // whose ParenSource is the inner query; the wrapper's own ORDER BY / LIMIT hold
@@ -1127,9 +1169,15 @@ func (p *Parser) parseTableFactor() (nodes.TableExpr, error) {
 		startPos := p.pos()
 		p.advance()
 
-		// Subquery (derived table): (query_expression), including
-		// parenthesized set operations like ((SELECT ...) UNION (...)).
-		if p.isQueryExpressionStart() {
+		// Disambiguate the parenthesized table factor. A leading run of '(' may
+		// open either a derived-table subquery — `(SELECT ...)`, `((SELECT ...))`,
+		// `((SELECT ...) UNION (...))` — or a parenthesized join group using
+		// MySQL nested-join semantics — `(a JOIN b ON ...)`,
+		// `((a LEFT JOIN b ON ...) JOIN c ON ...)` (the canonical SHOW CREATE VIEW
+		// form for multi-table joins). The deciding token is the first one past
+		// the parens: a query primary (SELECT/WITH/TABLE/VALUES) means a subquery,
+		// anything else (a table reference) means a join group.
+		if isQueryPrimaryStartToken(p.firstTokenPastParens().Type) {
 			sel, err := p.parseSelectStmt()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Real-world-schema smoke (Sakila) found this: `MetadataToSDL` dumps a multi-table view's FROM clause in MySQL's canonical parenthesized left-deep JOIN form — e.g. `from ((((\`category\` left join \`film_category\` on(...)) left join \`film\` on(...)) join \`film_actor\` on(...)) join \`actor\` on(...))` — and the SDL FROM-clause parser rejected the leading `(` of a join group (only a parenthesized sub-SELECT was accepted) → `expected SELECT, TABLE, VALUES, or '('`. So **no multi-table-JOIN view could round-trip** through the declarative path (blocks Sakila, employees, and essentially every real app schema).

Fix (`mysql/parser/select.go`, +54): in the FROM-clause `table_reference` parser, disambiguate a leading `(` — a parenthesized sub-SELECT/derived-table stays the existing path; a parenthesized **join group** `( table_reference ... )` now recurses through the join parser and expects `)`. Matches MySQL's `'(' table_reference ')'` grammar.

Proven on live 5.7+8.0 (both gates): user-form-vs-stored canonical SDL diffs empty and CREATE OR REPLACE applies, for 3/4/5-table joins, LEFT/INNER mixes, GROUP BY over joins, view-on-multi-join-view, and the full sakila `film_list` shape; derived-table-in-FROM regression guards pass. Full parser/ast/catalog suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)