### PR TITLE
fix(mysql): parse aliased parenthesized JOIN groups in FROM clause (view round-trip, follow-up)

### DIFF
--- a/mysql/catalog/migration_view_oracle_test.go
+++ b/mysql/catalog/migration_view_oracle_test.go
@@ -132,6 +132,31 @@ func viewIdempotenceProbes() []viewSchemaProbe {
 			"CREATE VIEW base AS SELECT t.a AS a, u.y AS y, w.n AS n FROM t JOIN u ON t.c = u.x JOIN w ON u.y = w.m",
 			"CREATE VIEW v AS SELECT a, n FROM base WHERE a > 0",
 		}, []string{"t", "u", "w"}, []string{"base", "v"}, both()},
+		// Aliased parenthesized join group as the LEFT operand of a further top-level
+		// join, with a COMPOUND (AND) ON condition — the exact employees current_dept_emp
+		// shape. The engine stores the compound ON double-wrapped: `on(((a) and (b)))`, and
+		// the leading `((` there must be read as a parenthesized scalar expression, not a
+		// subquery. This is the residual gap #356's un-aliased/simple-ON guards did not
+		// cover; the join is also over a base VIEW (dept_emp_latest_date).
+		{"join-aliased-compound-on", []string{
+			"CREATE TABLE dept_emp (emp_no INT NOT NULL, dept_no CHAR(4) NOT NULL, from_date DATE NOT NULL, to_date DATE NOT NULL, PRIMARY KEY (emp_no, dept_no))",
+			"CREATE TABLE departments (dept_no CHAR(4) NOT NULL, dept_name VARCHAR(40) NOT NULL, PRIMARY KEY (dept_no))",
+			"CREATE VIEW dept_emp_latest_date AS SELECT emp_no, MAX(from_date) AS from_date, MAX(to_date) AS to_date FROM dept_emp GROUP BY emp_no",
+			"CREATE VIEW current_dept_emp AS SELECT l.emp_no, d.dept_no, l.from_date, l.to_date " +
+				"FROM dept_emp d " +
+				"JOIN dept_emp_latest_date l ON d.emp_no = l.emp_no AND d.from_date = l.from_date " +
+				"JOIN departments dp ON d.dept_no = dp.dept_no",
+		}, []string{"dept_emp", "departments"}, []string{"dept_emp_latest_date", "current_dept_emp"}, both()},
+		// Aliased 3-table LEFT/INNER mix with a compound ON on the parenthesized left
+		// operand (compound-ON on both the nested and the outer join).
+		{"join-aliased-left-inner-compound-on", []string{
+			"CREATE TABLE a (id INT, k INT, v INT)",
+			"CREATE TABLE b (id INT, k INT, w INT)",
+			"CREATE TABLE c (id INT, k INT, z INT)",
+			"CREATE VIEW v AS SELECT x.v, y.w, q.z FROM a x " +
+				"LEFT JOIN b y ON x.id = y.id AND x.k = y.k " +
+				"INNER JOIN c q ON y.id = q.id AND y.k = q.k",
+		}, []string{"a", "b", "c"}, []string{"v"}, both()},
 		// Derived table (subquery) in FROM — must still parse as a subquery, not a
 		// join group (regression guard for the disambiguation).
 		{"derived-table-from", []string{
@@ -415,6 +440,21 @@ func viewMigrationProbes() []viewMigrationProbe {
 					"JOIN actor ON film_actor.actor_id = actor.actor_id "+
 					"GROUP BY film.film_id"),
 			[]string{"category", "film_category", "film", "film_actor", "actor"}, []string{"v"}, both()},
+		// CREATE the employees current_dept_emp shape: an aliased parenthesized join
+		// group (compound AND ON) as the left operand of a further join, over a base
+		// view. Guards the `((expr))` scalar-vs-subquery disambiguation end-to-end.
+		{"create-employees-current-dept-emp",
+			base("CREATE TABLE dept_emp (emp_no INT NOT NULL, dept_no CHAR(4) NOT NULL, from_date DATE NOT NULL, to_date DATE NOT NULL, PRIMARY KEY (emp_no, dept_no))",
+				"CREATE TABLE departments (dept_no CHAR(4) NOT NULL, dept_name VARCHAR(40) NOT NULL, PRIMARY KEY (dept_no))",
+				"CREATE VIEW dept_emp_latest_date AS SELECT emp_no, MAX(from_date) AS from_date, MAX(to_date) AS to_date FROM dept_emp GROUP BY emp_no"),
+			base("CREATE TABLE dept_emp (emp_no INT NOT NULL, dept_no CHAR(4) NOT NULL, from_date DATE NOT NULL, to_date DATE NOT NULL, PRIMARY KEY (emp_no, dept_no))",
+				"CREATE TABLE departments (dept_no CHAR(4) NOT NULL, dept_name VARCHAR(40) NOT NULL, PRIMARY KEY (dept_no))",
+				"CREATE VIEW dept_emp_latest_date AS SELECT emp_no, MAX(from_date) AS from_date, MAX(to_date) AS to_date FROM dept_emp GROUP BY emp_no",
+				"CREATE VIEW current_dept_emp AS SELECT l.emp_no, d.dept_no, l.from_date, l.to_date "+
+					"FROM dept_emp d "+
+					"JOIN dept_emp_latest_date l ON d.emp_no = l.emp_no AND d.from_date = l.from_date "+
+					"JOIN departments dp ON d.dept_no = dp.dept_no"),
+			[]string{"dept_emp", "departments"}, []string{"dept_emp_latest_date", "current_dept_emp"}, both()},
 		// REPLACE a single-table body with a multi-table-join body.
 		{"replace-into-multi-join",
 			base("CREATE TABLE t (a INT, c INT)", "CREATE TABLE u (x INT, y INT)", "CREATE TABLE w (m INT, n INT)",

--- a/mysql/parser/parenthesized_join_test.go
+++ b/mysql/parser/parenthesized_join_test.go
@@ -49,6 +49,81 @@ func TestParenthesizedJoinGroup(t *testing.T) {
 	}
 }
 
+// TestParenthesizedJoinCompoundOn pins the residual case #356 did not cover: an
+// aliased parenthesized join group whose ON condition is COMPOUND (AND/OR), used
+// as the left operand of a further top-level join. MySQL's SHOW CREATE VIEW
+// double-wraps a compound ON — `on(((a = b) and (c = d)))` — and a redundant
+// single-condition wrap — `on(((a = b)))`. The leading `((` inside such an ON
+// must parse as a parenthesized scalar expression, NOT a subquery. This is the
+// exact shape of the employees `current_dept_emp` view.
+func TestParenthesizedJoinCompoundOn(t *testing.T) {
+	for _, sql := range []string{
+		// compound (AND) ON inside a parenthesized aliased join group
+		"SELECT * FROM (`a` `d` JOIN `b` `l` ON((`d`.`x` = `l`.`x`) AND (`d`.`y` = `l`.`y`)))",
+		// double-wrapped compound ON (the exact SHOW CREATE VIEW rendering)
+		"SELECT * FROM (`a` `d` JOIN `b` `l` ON(((`d`.`x` = `l`.`x`) AND (`d`.`y` = `l`.`y`))))",
+		// redundant-wrapped single-condition ON
+		"SELECT * FROM (`a` `d` JOIN `b` `l` ON(((`d`.`x` = `l`.`x`))))",
+		// aliased compound-ON paren group as LEFT operand of a further join (employees shape)
+		"SELECT * FROM (`a` `d` JOIN `b` `l` ON(((`d`.`x` = `l`.`x`) AND (`d`.`y` = `l`.`y`)))) JOIN `c` `dp` ON((`d`.`z` = `dp`.`z`))",
+		// the exact employees current_dept_emp FROM clause
+		"SELECT 1 FROM ((`dept_emp` `d` JOIN `dept_emp_latest_date` `l` ON(((`d`.`emp_no` = `l`.`emp_no`) AND (`d`.`from_date` = `l`.`from_date`)))) JOIN `departments` `dp` ON((`d`.`dept_no` = `dp`.`dept_no`)))",
+		// the full employees current_dept_emp CREATE VIEW (engine-emitted canonical form)
+		"CREATE ALGORITHM=UNDEFINED SQL SECURITY DEFINER VIEW `current_dept_emp` AS select `l`.`emp_no` AS `emp_no`,`d`.`dept_no` AS `dept_no`,`l`.`from_date` AS `from_date`,`l`.`to_date` AS `to_date` from ((`dept_emp` `d` join `dept_emp_latest_date` `l` on(((`d`.`emp_no` = `l`.`emp_no`) and (`d`.`from_date` = `l`.`from_date`)))) join `departments` `dp` on((`d`.`dept_no` = `dp`.`dept_no`)))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedScalarExprNotSubquery guards the disambiguation on the
+// expression side: a doubly (or more) parenthesized SCALAR expression `((expr))`
+// — anywhere an expression is parsed — must NOT be misread as a subquery. These
+// are the redundant-paren forms MySQL emits and that a fixed one-token '(('
+// lookahead wrongly classified as a query expression.
+func TestParenthesizedScalarExprNotSubquery(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT ((1))",
+		"SELECT (((1 + 2)))",
+		"SELECT ((a = b)) FROM t",
+		"SELECT * FROM t WHERE ((a = b) AND (c = d))",
+		"SELECT * FROM t WHERE (((a = b)))",
+		"SELECT * FROM t WHERE ((a > 1))",
+		"SELECT ((a)) + ((b)) FROM t",
+		"SELECT * FROM t WHERE a IN ((1), (2))",
+		"SELECT (SELECT ((1)))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
+// TestParenthesizedSubqueryStillSubquery guards the OTHER side of the same
+// disambiguation: a '(' run that ultimately opens a query primary must still be
+// read as a subquery in expression contexts (scalar subquery, IN, EXISTS,
+// quantified), including the doubly-parenthesized set-op forms.
+func TestParenthesizedSubqueryStillSubquery(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT (SELECT 1)",
+		"SELECT ((SELECT 1))",
+		"SELECT (((SELECT 1)))",
+		"SELECT * FROM t WHERE a IN (SELECT x FROM u)",
+		"SELECT * FROM t WHERE a IN ((SELECT x FROM u))",
+		"SELECT * FROM t WHERE EXISTS (SELECT 1)",
+		"SELECT * FROM t WHERE EXISTS ((SELECT 1))",
+		"SELECT * FROM t WHERE a = (SELECT MAX(x) FROM u)",
+		"SELECT * FROM t WHERE a > ALL (SELECT x FROM u)",
+		"SELECT * FROM t WHERE a > ALL ((SELECT x FROM u))",
+		"SELECT * FROM t WHERE a = ((SELECT 1) UNION (SELECT 2))",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			ParseAndCheck(t, sql)
+		})
+	}
+}
+
 // TestParenthesizedJoinGroupRegression guards the derived-table side of the
 // disambiguation: a '(' run that ultimately opens a query primary must still be
 // parsed as a derived-table subquery (with its alias / column list), and plain /

--- a/mysql/parser/select.go
+++ b/mysql/parser/select.go
@@ -408,8 +408,14 @@ func (p *Parser) isQueryExpressionStart() bool {
 	if p.cur.Type != '(' {
 		return false
 	}
-	next := p.peekNext()
-	return isQueryPrimaryStartToken(next.Type) || next.Type == '('
+	// A leading run of '(' may open either a parenthesized query expression
+	// — `((SELECT ...))`, `((SELECT 1) UNION (SELECT 2))` — or a parenthesized
+	// scalar expression — `((a = b))`, the redundant-paren form MySQL emits for
+	// a view's join ON condition (SHOW CREATE VIEW renders `on(((a) and (b)))`).
+	// A fixed one-token lookahead cannot tell them apart; scan past the run of
+	// '(' to the first non-'(' token — a query primary (SELECT/WITH/TABLE/VALUES)
+	// means a query expression, anything else means a scalar expression.
+	return isQueryPrimaryStartToken(p.firstTokenPastParens().Type)
 }
 
 // scanState captures the full lexical scan position so a speculative lookahead
@@ -438,13 +444,16 @@ func (p *Parser) restoreScan(s scanState) {
 
 // firstTokenPastParens returns the first token at or after the current position
 // that is not an opening parenthesis, without consuming input. It is the
-// disambiguator for a FROM-clause table factor that begins with '(': a run of
-// '(' may open either a (possibly nested) derived-table subquery
-// — `((SELECT ...))` — or a (possibly nested) parenthesized join group
-// — `((a JOIN b) JOIN c)`. MySQL's grammar distinguishes them by whether the
-// innermost head is a query primary (SELECT/WITH/TABLE/VALUES) or a table
-// reference; a fixed one-token lookahead on '(' cannot, so we scan past the
-// parens speculatively and rewind.
+// disambiguator for constructs that begin with a run of '(' whose meaning turns
+// on the innermost head:
+//   - a FROM-clause table factor — a (possibly nested) derived-table subquery
+//     `((SELECT ...))` vs. a parenthesized join group `((a JOIN b) JOIN c)`;
+//   - an expression '(' — a parenthesized query expression `((SELECT ...))` vs.
+//     a parenthesized scalar expression `((a = b))`.
+//
+// In each case MySQL's grammar distinguishes by whether the innermost head is a
+// query primary (SELECT/WITH/TABLE/VALUES) or not; a fixed one-token lookahead
+// on '(' cannot, so we scan past the parens speculatively and rewind.
 func (p *Parser) firstTokenPastParens() Token {
 	saved := p.saveScan()
 	defer p.restoreScan(saved)


### PR DESCRIPTION
Follow-up to #356, found by real-world smoke on the `employees` schema. #356 accepted un-aliased nested parenthesized joins (sakila `film_list`), but the `current_dept_emp` view's dumped FROM — `from (\`dept_emp\` \`d\` join \`dept_emp_latest_date\` \`l\` on(...)) join \`departments\` ...` — has **table aliases inside the parenthesized join** used as the left operand of a further top-level JOIN, which still failed `LoadSDL` with `expected SELECT, TABLE, VALUES, or '('`. Extends the FROM-clause parser to handle aliased parenthesized join groups. Oracle-proven both versions on the aliased shapes + the exact employees view; sakila/derived-table regression guards pass; full parser/ast/catalog suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)