### PR TITLE
fix(mysql): never panic on unterminated comments/strings in lexer

### DIFF
--- a/mysql/catalog/sdl_test.go
+++ b/mysql/catalog/sdl_test.go
@@ -168,6 +168,55 @@ func TestSDLValidation(t *testing.T) {
 	}
 }
 
+// TestSDLLoad_UnterminatedComment_NoPanic guards the declarative entry point
+// against malformed input. An unterminated /*! ... */ executable comment (no
+// closing */) once panicked the lexer with "slice bounds out of range"; a
+// malformed schema submitted to LoadSDL must return a clean error, never crash.
+func TestSDLLoad_UnterminatedComment_NoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		// The confirmed real-world repro (no closing */ on the version comment).
+		{"versioned_partition_comment", "CREATE TABLE `t` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB /*!50100 PARTITION BY HASH (`id`)"},
+		{"bare_exec_comment", "CREATE TABLE `t` (`id` int) /*! FOO"},
+		{"plain_block_comment", "CREATE TABLE `t` (`id` int) /* nope"},
+		{"unterminated_string", "CREATE TABLE `t` (`id` int) COMMENT='oops"},
+		{"unterminated_ident", "CREATE TABLE `t"},
+		// Trailing unterminated comment after a valid statement — the trailing
+		// segment must not be silently dropped by the splitter.
+		{"trailing_unterminated_comment", "CREATE TABLE `t` (`id` int); /*!50100"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("LoadSDL panicked on %q: %v", tc.sql, r)
+				}
+			}()
+			c, err := LoadSDL(tc.sql)
+			if err == nil {
+				t.Fatalf("expected a clean error for malformed input, got nil (catalog=%v)", c)
+			}
+		})
+	}
+}
+
+// TestSDLLoad_ValidVersionComment_Partition confirms the fix did not break the
+// valid, terminated version-comment form: a /*!50100 PARTITION BY ... */ clause
+// still loads and the table carries its partitioning.
+func TestSDLLoad_ValidVersionComment_Partition(t *testing.T) {
+	sql := "CREATE DATABASE app;\nUSE app;\nCREATE TABLE `t` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB /*!50100 PARTITION BY HASH (`id`) PARTITIONS 4 */;"
+	db := loadSDLForDB(t, sql, "app")
+	tbl := db.GetTable("t")
+	if tbl == nil {
+		t.Fatal("expected table t")
+	}
+	if tbl.Partitioning == nil {
+		t.Error("expected partitioning to survive the /*!50100 ... */ version comment, got none")
+	}
+}
+
 // TestSDLForwardForeignKey verifies a table with a forward FK reference (the
 // referenced table is declared *after* the referencing table) loads cleanly.
 // LoadSQL would fail here because foreign_key_checks defaults on and the parent

--- a/mysql/parser/lexer.go
+++ b/mysql/parser/lexer.go
@@ -1696,6 +1696,78 @@ type Lexer struct {
 	prevToken    int // type of the previously emitted token
 	prevTokenEnd int // end position of the previously emitted token (for adjacency checks)
 	baseOffset   int // added to all token Loc values for absolute positioning
+
+	// errMsg/errPos record the first lexing error (unterminated comment, string,
+	// or quoted identifier). A malformed token that runs to EOF without its closing
+	// delimiter must never index past the buffer; instead the scan stops at EOF and
+	// records the error here, which the parser surfaces as a clean ParseError.
+	// errPos is stored in ORIGINAL-input coordinates (see spliceGaps).
+	errMsg string
+	errPos int
+	hasErr bool
+
+	// spliceGaps records byte ranges removed from l.input by executable-comment
+	// splices, so a position in the mutated buffer maps back to the original input.
+	// Splicing /*!NNNNN ... */ into just its inner content deletes two disjoint
+	// runs — the leading "/*!NNNNN" and the trailing "*/" — at two different mutated
+	// offsets. A position maps back by adding the sizes of every gap that begins at
+	// or before it (see originalPos): a position INSIDE the retained body is shifted
+	// only by the leading gap, one AFTER the body by both.
+	spliceGaps []spliceGap
+}
+
+// spliceGap is one run of bytes removed from l.input at mutated offset `at`.
+type spliceGap struct {
+	at      int // offset in the mutated buffer where the bytes were removed
+	removed int // number of bytes removed there
+}
+
+// originalPos maps a position in the current (spliced) l.input back to an offset
+// in the original input by adding every gap that starts at or before it.
+func (l *Lexer) originalPos(pos int) int {
+	orig := pos
+	for _, g := range l.spliceGaps {
+		if g.at <= pos {
+			orig += g.removed
+		}
+	}
+	return orig
+}
+
+// shiftGapsForSplice keeps existing spliceGaps in current-buffer coordinates when a
+// splice deletes two disjoint byte ranges from the CURRENT buffer: the leading run
+// [l.pos, vpos) and the trailing run [closeStart, closeStart+2) (vpos <= closeStart).
+// Both membership tests are evaluated against each gap's pre-splice offset and the
+// combined left-shift is applied once, so the two deletions don't interfere. Any gap
+// recorded by an earlier splice that lies to the right of a deleted range (e.g. an
+// outer comment's trailing "*/" when this is a nested comment inside its body) moves
+// left accordingly, preventing its at from drifting stale.
+func (l *Lexer) shiftGapsForSplice(leadStart, leadEnd, tailStart int) {
+	lead := leadEnd - leadStart
+	for i := range l.spliceGaps {
+		at := l.spliceGaps[i].at
+		shift := 0
+		if at >= leadEnd { // past the leading run [leadStart, leadEnd)
+			shift += lead
+		}
+		if at >= tailStart+2 { // past the trailing "*/" [tailStart, tailStart+2)
+			shift += 2
+		}
+		l.spliceGaps[i].at = at - shift
+	}
+}
+
+// setError records the first lexing error and ignores any later ones. Because the
+// lexer scans strictly left-to-right, the first error recorded is also the leftmost
+// (earliest) in the input. pos is a position in the current (possibly spliced)
+// l.input; it is translated back to original-input coordinates.
+func (l *Lexer) setError(msg string, pos int) {
+	if l.hasErr {
+		return
+	}
+	l.hasErr = true
+	l.errMsg = msg
+	l.errPos = l.originalPos(pos)
 }
 
 // NewLexer creates a new MySQL lexer for the given input.
@@ -1860,6 +1932,7 @@ func (l *Lexer) skipWhitespaceAndComments() {
 
 		// Block comment: /* ... */
 		if ch == '/' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '*' {
+			commentStart := l.pos
 			// MySQL conditional comments: /*!NNNNN ... */ or /*! ... */
 			// These should be parsed as SQL, not skipped.
 			if l.pos+2 < len(l.input) && l.input[l.pos+2] == '!' {
@@ -1870,13 +1943,16 @@ func (l *Lexer) skipWhitespaceAndComments() {
 				for vpos < len(l.input) && l.input[vpos] >= '0' && l.input[vpos] <= '9' {
 					vpos++
 				}
-				// Find the matching */
+				// Find the matching */. closeStart marks the '*' of the closing "*/"
+				// when found; it stays -1 if EOF is reached first.
 				end := vpos
+				closeStart := -1
 				depth := 1
 				for end < len(l.input) && depth > 0 {
 					if l.input[end] == '*' && end+1 < len(l.input) && l.input[end+1] == '/' {
 						depth--
 						if depth == 0 {
+							closeStart = end
 							break
 						}
 						end += 2
@@ -1887,16 +1963,37 @@ func (l *Lexer) skipWhitespaceAndComments() {
 						end++
 					}
 				}
+				if closeStart < 0 {
+					// Unterminated executable comment: no closing */ before EOF.
+					// Do NOT slice past the buffer (the historical `l.input[end+2:]`
+					// panicked here). Consume to EOF and record a clean lex error.
+					l.setError("unterminated comment", commentStart)
+					l.pos = len(l.input)
+					return
+				}
 				// Extract the inner content and splice it into the input,
-				// replacing the conditional comment with its content.
-				inner := l.input[vpos:end]
-				l.input = l.input[:l.pos] + inner + l.input[end+2:]
+				// replacing the conditional comment with its content. closeStart+2
+				// is in-bounds because closeStart points at '*' and closeStart+1 at '/'.
+				inner := l.input[vpos:closeStart]
+				// This splice deletes two disjoint byte ranges from the CURRENT
+				// buffer: the leading "/*!NNNNN" at [l.pos, vpos) and the trailing
+				// "*/" at [closeStart, closeStart+2). All spliceGaps.at values are kept
+				// in current-buffer coordinates, so first shift any earlier gaps that
+				// sit to the right of these ranges (nested-comment case), then record
+				// this splice's own two gaps. After the leading run is removed the
+				// trailing "*/" sits at l.pos+len(inner).
+				l.shiftGapsForSplice(l.pos, vpos, closeStart)
+				if leading := vpos - l.pos; leading > 0 {
+					l.spliceGaps = append(l.spliceGaps, spliceGap{at: l.pos, removed: leading})
+				}
+				l.spliceGaps = append(l.spliceGaps, spliceGap{at: l.pos + len(inner), removed: 2})
+				l.input = l.input[:l.pos] + inner + l.input[closeStart+2:]
 				// Don't advance l.pos — re-scan from the start of the inner content.
 				continue
 			}
 
 			l.pos += 2
-			// Regular block comment: skip everything.
+			// Regular block comment: skip everything up to the closing */.
 			depth := 1
 			for l.pos < len(l.input) && depth > 0 {
 				if l.input[l.pos] == '*' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '/' {
@@ -1908,6 +2005,11 @@ func (l *Lexer) skipWhitespaceAndComments() {
 				} else {
 					l.pos++
 				}
+			}
+			if depth > 0 {
+				// Unterminated block comment: reached EOF before the closing */.
+				l.setError("unterminated comment", commentStart)
+				return
 			}
 			continue
 		}
@@ -1937,6 +2039,11 @@ func (l *Lexer) scanVariable() Token {
 		name = l.input[nameStart:l.pos]
 		if l.pos < len(l.input) {
 			l.pos++ // skip closing backtick
+		} else {
+			// EOF reached before the closing backtick: unterminated `-quoted
+			// variable name. Record a clean error rather than accepting a
+			// half-open identifier (mirrors scanBacktickIdent).
+			l.setError("unterminated quoted identifier", start)
 		}
 	} else {
 		nameStart := l.pos
@@ -1958,6 +2065,7 @@ func (l *Lexer) scanBacktickIdent() Token {
 	start := l.pos
 	l.pos++ // skip opening backtick
 	var sb strings.Builder
+	closed := false
 	for l.pos < len(l.input) {
 		if l.input[l.pos] == '`' {
 			// Double backtick is an escape
@@ -1966,12 +2074,16 @@ func (l *Lexer) scanBacktickIdent() Token {
 				l.pos += 2
 			} else {
 				l.pos++ // skip closing backtick
+				closed = true
 				break
 			}
 		} else {
 			sb.WriteByte(l.input[l.pos])
 			l.pos++
 		}
+	}
+	if !closed {
+		l.setError("unterminated quoted identifier", start)
 	}
 	return Token{Type: tokIDENT, Str: sb.String(), Loc: start}
 }
@@ -1980,6 +2092,7 @@ func (l *Lexer) scanString(quote byte) Token {
 	start := l.pos
 	l.pos++ // skip opening quote
 	var sb strings.Builder
+	closed := false
 	for l.pos < len(l.input) {
 		ch := l.input[l.pos]
 		if ch == quote {
@@ -1989,6 +2102,7 @@ func (l *Lexer) scanString(quote byte) Token {
 				l.pos += 2
 			} else {
 				l.pos++ // skip closing quote
+				closed = true
 				break
 			}
 		} else if ch == '\\' {
@@ -2029,6 +2143,9 @@ func (l *Lexer) scanString(quote byte) Token {
 			sb.WriteByte(ch)
 			l.pos++
 		}
+	}
+	if !closed {
+		l.setError("unterminated string literal", start)
 	}
 	return Token{Type: tokSCONST, Str: sb.String(), Loc: start}
 }

--- a/mysql/parser/lexer_unterminated_test.go
+++ b/mysql/parser/lexer_unterminated_test.go
@@ -1,0 +1,223 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	nodes "github.com/bytebase/omni/mysql/ast"
+)
+
+// A lexer must never panic on malformed input; a truncated token that runs to
+// EOF without its closing delimiter must surface a clean parse error. These are
+// regression guards for the `slice bounds out of range` panic in
+// skipWhitespaceAndComments on an unterminated /*! ... */ executable comment
+// (and the adjacent unterminated-string / -identifier scan sites).
+
+// parseNoPanic parses sql, converting any panic into a test failure, and returns
+// the resulting error (nil on success).
+func parseNoPanic(t *testing.T, sql string) (err error) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Parse panicked on %q: %v", sql, r)
+		}
+	}()
+	_, err = Parse(sql)
+	return err
+}
+
+func TestLexer_UnterminatedComment_NoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		// The confirmed real-world repro: versioned executable comment, no closing */.
+		{"versioned_exec_comment", "CREATE TABLE `t` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB /*!50100 PARTITION BY HASH (`id`)"},
+		// Bare executable comment, no version, no closing */.
+		{"bare_exec_comment", "CREATE TABLE `t` (`id` int) /*! PARTITION BY HASH (`id`)"},
+		// Executable comment ending on a lone '*' at EOF (no trailing '/').
+		{"exec_comment_star_at_eof", "SELECT 1 /*!50100 abc*"},
+		// Plain (non-executable) block comment, no closing */.
+		{"plain_block_comment", "CREATE TABLE `t` (`id` int) /* unterminated"},
+		// Nested block comment where the inner one closes but the outer does not.
+		{"nested_block_comment", "SELECT 1 /* outer /* inner */"},
+		// Executable comment opened right at EOF.
+		{"exec_comment_only", "/*!50100"},
+		// Bare plain block comment as the whole input: Split must NOT drop it as an
+		// empty segment — the lexer has to surface the error (regression guard).
+		{"bare_block_comment_only", "/*"},
+		{"bare_block_comment_ws", "   /*   "},
+		// Trailing unterminated comment after a complete statement + delimiter: the
+		// trailing segment must not be silently dropped by Split.
+		{"trailing_after_stmt", "SELECT 1; /*"},
+		{"trailing_exec_after_stmt", "SELECT 1; /*!50100"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseNoPanic(t, tc.sql)
+			if err == nil {
+				t.Fatalf("expected a parse error for unterminated comment, got nil (sql: %q)", tc.sql)
+			}
+			if !strings.Contains(err.Error(), "unterminated comment") {
+				t.Errorf("error %q does not mention 'unterminated comment' (sql: %q)", err.Error(), tc.sql)
+			}
+		})
+	}
+}
+
+func TestLexer_UnterminatedString_NoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"single_quote", "SELECT 'abc"},
+		{"double_quote", "SELECT \"abc"},
+		// Trailing backslash at EOF: the escape has no following char and there is
+		// no closing quote — still unterminated, must not read past the buffer.
+		{"trailing_backslash", "SELECT 'abc\\"},
+		{"empty_open_quote", "SELECT '"},
+		{"string_in_ddl", "CREATE TABLE `t` (`id` int) COMMENT='oops"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseNoPanic(t, tc.sql)
+			if err == nil {
+				t.Fatalf("expected a parse error for unterminated string, got nil (sql: %q)", tc.sql)
+			}
+			if !strings.Contains(err.Error(), "unterminated string literal") {
+				t.Errorf("error %q does not mention 'unterminated string literal' (sql: %q)", err.Error(), tc.sql)
+			}
+		})
+	}
+}
+
+func TestLexer_UnterminatedBacktickIdent_NoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"select_ident", "SELECT `abc"},
+		{"empty_open_backtick", "SELECT `"},
+		// Doubled backtick escape immediately before EOF — still unterminated.
+		{"escaped_backtick_eof", "SELECT `a``"},
+		{"ddl_table_name", "CREATE TABLE `t"},
+		// Backtick-quoted user variable @`... scanned by scanVariable (a separate
+		// scan site from scanBacktickIdent) — must also report untermination.
+		{"backtick_user_variable", "SELECT @`abc"},
+		{"backtick_user_variable_empty", "SELECT @`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseNoPanic(t, tc.sql)
+			if err == nil {
+				t.Fatalf("expected a parse error for unterminated identifier, got nil (sql: %q)", tc.sql)
+			}
+			if !strings.Contains(err.Error(), "unterminated quoted identifier") {
+				t.Errorf("error %q does not mention 'unterminated quoted identifier' (sql: %q)", err.Error(), tc.sql)
+			}
+		})
+	}
+}
+
+// TestLexer_ValidCommentsAndDelimiters_StillParse is the regression counterpart:
+// the bound-checks must not break well-formed comments, strings, or identifiers.
+func TestLexer_ValidCommentsAndDelimiters_StillParse(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"plain_block_comment", "SELECT 1 /* a normal comment */ + 2"},
+		{"exec_comment", "SELECT 1 /*! + 2 */"},
+		{"versioned_exec_comment", "SELECT 1 /*!50100 + 2 */"},
+		{"versioned_partition", "CREATE TABLE `t` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB /*!50100 PARTITION BY HASH (`id`) */"},
+		{"nested_block_comment", "SELECT 1 /* outer /* inner */ still-outer */ + 2"},
+		{"line_comment", "SELECT 1 -- trailing\n+ 2"},
+		{"hash_comment", "SELECT 1 # trailing\n+ 2"},
+		{"single_quote_string", "SELECT 'hello world'"},
+		{"double_quote_string", "SELECT \"hello world\""},
+		{"escaped_string", "SELECT 'it''s fine'"},
+		{"backtick_ident", "SELECT `weird name`"},
+		{"escaped_backtick_ident", "SELECT `a``b`"},
+		{"backslash_escape_string", "SELECT 'line1\\nline2'"},
+		{"backtick_user_variable", "SELECT @`v`"},
+		// A valid, terminated executable comment followed by more SQL that also
+		// happens to be valid — exercises the splice path without any error.
+		{"exec_comment_then_string", "/*!  */ SELECT 'abc'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseNoPanic(t, tc.sql)
+			if err != nil {
+				t.Errorf("valid SQL failed to parse: %v (sql: %q)", err, tc.sql)
+			}
+		})
+	}
+}
+
+// TestLexer_ErrorPosition_AfterSplice guards that a lexer error carries the correct
+// position in ORIGINAL-input coordinates after an executable-comment splice shortens
+// the buffer. Two distinct cases must both be right: an error INSIDE the retained
+// comment body (shifted only by the leading "/*!NNNNN") and one AFTER the whole
+// comment (shifted by both the leading run and the trailing "*/"). The `want` in each
+// case is the byte offset of the opening single quote in the ORIGINAL string.
+func TestLexer_ErrorPosition_AfterSplice(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want int // expected ParseError.Position (0-based byte offset of the opening quote)
+	}{
+		// After the comment body.
+		{"after_body_bare", "/*!  */ SELECT 'abc", 15},
+		{"after_body_versioned", "/*!50100  */ SELECT 'x", 20},
+		{"after_body_double_splice", "/*!  */ /*!  */ SELECT 'x", 23},
+		// Inside the retained body of a terminated executable comment: the trailing
+		// */ is removed but sits AFTER the error, so it must not shift the position.
+		{"inside_body_bare", "/*! SELECT 'abc */", 11},
+		{"inside_body_versioned", "/*!50100 SELECT 'x */", 16},
+		{"inside_body_nested_comment", "/*! /* c */ SELECT 'x */", 19},
+		// Nested EXECUTABLE comment: the inner /*! ... */ splices inside the outer
+		// body, shortening the buffer to the left of the outer comment's trailing
+		// */. The outer trailing gap must be re-mapped or the position drifts 2 bytes
+		// too early (regression guard for the nested-splice coordinate-space bug).
+		{"nested_exec_then_string", "/*! /*! SELECT 1 */ */'x", 22},
+		{"nested_exec_then_string_ws", "/*! /*! SELECT 1 */ */ 'x", 23},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.sql)
+			if err == nil {
+				t.Fatalf("expected an unterminated-string error for %q", tc.sql)
+			}
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("expected *ParseError, got %T", err)
+			}
+			if pe.Position != tc.want {
+				t.Errorf("%q: error Position = %d, want %d (the opening quote in the original SQL)", tc.sql, pe.Position, tc.want)
+			}
+		})
+	}
+}
+
+// TestLexer_VersionedPartitionComment_ParsesPartition proves the executable-comment
+// splice still exposes the inner SQL for a valid /*!50100 ... */ partition clause —
+// i.e. the fix hardened the unterminated case without dropping the terminated one.
+// The PARTITION BY wrapped in /*!50100 ... */ must be parsed as real SQL, so the
+// resulting CREATE TABLE carries a partition clause.
+func TestLexer_VersionedPartitionComment_ParsesPartition(t *testing.T) {
+	withComment := "CREATE TABLE `t` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB /*!50100 PARTITION BY HASH (`id`) PARTITIONS 4 */"
+	got, err := Parse(withComment)
+	if err != nil {
+		t.Fatalf("versioned-comment partition failed to parse: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(got.Items))
+	}
+	ct, ok := got.Items[0].(*nodes.CreateTableStmt)
+	if !ok {
+		t.Fatalf("expected *CreateTableStmt, got %T", got.Items[0])
+	}
+	if ct.Partitions == nil {
+		t.Errorf("PARTITION BY inside /*!50100 ... */ was not parsed: CreateTableStmt.Partitions is nil")
+	}
+}

--- a/mysql/parser/parser.go
+++ b/mysql/parser/parser.go
@@ -69,10 +69,18 @@ func parseSingle(sql string, baseOffset int) (*nodes.List, error) {
 		}
 		stmt, err := p.parseStmt()
 		if err != nil {
+			// A lexing error (unterminated comment/string/identifier) is the more
+			// specific cause; report it in preference to the derived syntax error.
+			if lexErr := p.lexerError(); lexErr != nil {
+				return nil, p.enrichError(lexErr)
+			}
 			return nil, p.enrichError(err)
 		}
 		if stmt == nil {
 			// parseStmt returned nil without error — unconsumed tokens remain.
+			if lexErr := p.lexerError(); lexErr != nil {
+				return nil, p.enrichError(lexErr)
+			}
 			if p.cur.Type != tokEOF {
 				return nil, p.syntaxErrorAtCur()
 			}
@@ -81,10 +89,29 @@ func parseSingle(sql string, baseOffset int) (*nodes.List, error) {
 		stmts = append(stmts, stmt)
 	}
 
+	// A malformed token that ran to EOF without its closing delimiter is recorded
+	// on the lexer rather than panicking; surface it as a clean parse error even
+	// when the statements otherwise parsed successfully.
+	if lexErr := p.lexerError(); lexErr != nil {
+		return nil, p.enrichError(lexErr)
+	}
+
 	if len(stmts) == 0 {
 		return &nodes.List{}, nil
 	}
 	return &nodes.List{Items: stmts}, nil
+}
+
+// lexerError converts a recorded lexer error, if any, into a ParseError with an
+// absolute position. It returns nil when the lexer recorded no error.
+func (p *Parser) lexerError() *ParseError {
+	if !p.lexer.hasErr {
+		return nil
+	}
+	return &ParseError{
+		Message:  p.lexer.errMsg,
+		Position: p.lexer.errPos + p.lexer.baseOffset,
+	}
 }
 
 // advance consumes the current token and moves to the next one.
@@ -306,4 +333,3 @@ func extractLineStatic(input string, offset int) string {
 	}
 	return line
 }
-

--- a/mysql/parser/split.go
+++ b/mysql/parser/split.go
@@ -34,6 +34,12 @@ func (s Segment) Empty() bool {
 			if i+2 < len(t) && t[i+2] == '!' {
 				return false
 			}
+			// An unterminated block comment (no closing */ before EOF) is malformed
+			// input, not empty whitespace: keep the segment so the lexer surfaces a
+			// clean "unterminated comment" error instead of Split silently dropping it.
+			if !blockCommentTerminated(t, i) {
+				return false
+			}
 			prev := i
 			i = skipBlockCommentMySQL(t, i)
 			if i == prev {
@@ -539,4 +545,24 @@ func skipBlockCommentMySQL(sql string, i int) int {
 		}
 	}
 	return i
+}
+
+// blockCommentTerminated reports whether the block comment starting at i (on "/*")
+// has a matching closing */ before EOF. Used by Segment.Empty to distinguish a
+// well-formed empty comment from malformed, unterminated input.
+func blockCommentTerminated(sql string, i int) bool {
+	i += 2 // skip /*
+	depth := 1
+	for i < len(sql) && depth > 0 {
+		if sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*' {
+			depth++
+			i += 2
+		} else if sql[i] == '*' && i+1 < len(sql) && sql[i+1] == '/' {
+			depth--
+			i += 2
+		} else {
+			i++
+		}
+	}
+	return depth == 0
 }


### PR DESCRIPTION
## What

Harden the MySQL lexer against malformed input. `mysql/parser/lexer.go` `skipWhitespaceAndComments` **panicked** with `runtime error: slice bounds out of range` on an **unterminated executable comment** — a `/*! ...` or `/*!50100 ...` with no closing `*/`. A malformed schema submitted to the declarative path (`catalog.LoadSDL`) could crash the process. A lexer must never panic on malformed input; it must return a clean parse error.

## Root cause

In the `/*!` conditional-comment branch, after scanning for the closing `*/` the code spliced the inner content back into the buffer:

```go
inner := l.input[vpos:end]
l.input = l.input[:l.pos] + inner + l.input[end+2:]
```

When there is no closing `*/`, the scan loop exits with `end == len(l.input)`, so `l.input[end+2:]` slices past the buffer → panic (`slice bounds out of range [N+2:N]`).

Confirmed repro (no closing `*/`), fed to `catalog.LoadSDL`:

```sql
CREATE TABLE `t` (`id` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB /*!50100 PARTITION BY HASH (`id`)
```

→ `panic: runtime error: slice bounds out of range` at `skipWhitespaceAndComments`.

## Fix

- **Executable comment `/*! ... */`** — track `closeStart` (index of the closing `*/`). If EOF is reached first (`closeStart < 0`), record an `"unterminated comment"` lexer error, consume to EOF, and return — never slicing past the buffer. When the close is found, splice with `l.input[vpos:closeStart] + l.input[closeStart+2:]` (`closeStart+2` is provably in-bounds: `closeStart` points at `*`, `closeStart+1` at `/`).
- **Plain block comment `/* ... */`** — record `"unterminated comment"` if `depth > 0` at EOF.
- **Adjacent scan-site audit** (same bug class — a truncated token that assumes a closing delimiter):
  - `scanString` — `"unterminated string literal"` on EOF without the closing quote (covers `'...`, `"...`, and a trailing backslash at EOF).
  - `scanBacktickIdent` and the backtick branch of `scanVariable` (`@`\``…`) — `"unterminated quoted identifier"` on EOF without the closing backtick.
  - The remaining two-index slices in the lexer (`scanNumber`, `scanIdentOrKeyword`, the plain `scanVariable` name) are all `input[start:l.pos]` with `l.pos <= len(input)` — already bound-safe, verified, left unchanged.
- **Splitter** (`split.go`) — a bare/trailing unterminated block comment (`/*`, `SELECT 1; /*`) was being dropped by `Segment.Empty()` before the lexer ran. `Empty()` now keeps such a segment (via `blockCommentTerminated`) so the lexer surfaces the error instead of `Split` silently swallowing it.
- **Surfacing** — the lexer records the first error (`errMsg`/`errPos`/`hasErr` + `setError`); `parser.go`'s `parseSingle` converts it to a `*ParseError` via `lexerError()`, mirroring the existing parse-error path (line/column/related-text enrichment).
- **Error position after a splice** — the executable-comment splice shortens the buffer, so a naive error offset would point too early. `setError` maps positions back to original-input coordinates via recorded `spliceGaps` (the removed leading `/*!NNNNN` and trailing `*/` runs). Nested executable comments (`/*! /*! … */ */`) are handled correctly — `shiftGapsForSplice` keeps every earlier gap in current-buffer coordinates when an inner splice shortens the buffer to its left.

## Coverage / proof

Confirm-then-fix. Every unterminated form returns a **clean error, no panic**: `/*`, `/*!`, `/*!50100`, `'string`, `"string`, `` `ident ``, `@`\``ident`, bare/trailing `/*`. Valid forms still lex + parse unchanged: `/* c */`, `/*! ... */`, `/*!50100 PARTITION BY ... */`, nested `/* /* */ */`, empty `/*!*/`, strings/identifiers with escapes. Error positions are exact across after-body, inside-body, versioned, double-splice, and nested-executable-comment cases.

Tests (permanent regression guards; each wraps the call and fails on panic):
- `mysql/parser/lexer_unterminated_test.go` — no-panic + clean-error for every comment/string/identifier form; valid-form regressions; a position-accuracy table (after-body, inside-body, nested exec); a partitioned-table version-comment AST assertion.
- `mysql/catalog/sdl_test.go` — `LoadSDL` (the reported crash boundary) returns a clean error on malformed input (including a trailing unterminated comment after a valid statement) and still loads a valid `/*!50100 PARTITION BY ... */` table with its partitioning intact.

Gates (MySQL 5.7 :13307 ssl-disabled + 8.0 :13306):
- `go test ./mysql/parser/... ./mysql/catalog/... -count=1` — green on both versions (catalog suite exercises the oracle against 5.7 and 8.0).
- Partition idempotence/apply oracle tests (which round-trip `/*!50100 ... */` version-comments through the real engines) — green on both 5.7 and 8.0, proving valid version-comments are unaffected.
- `golangci-lint run --new-from-rev origin/main` — 0 new issues. `go vet` clean. `go build ./mysql/...` clean.

Reviewed by cross-family review (Claude + Codex) over multiple rounds; all blockers resolved.

## Test plan

```
go test ./mysql/parser/... ./mysql/catalog/... -count=1
golangci-lint run --new-from-rev origin/main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
