### PR TITLE
mysql: support adjacent string-literal concatenation in expressions

### DIFF
--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -2472,6 +2472,9 @@ func writeStringLit(sb *strings.Builder, n *StringLit) {
 	if n.Charset != "" {
 		fmt.Fprintf(sb, " :charset %s", n.Charset)
 	}
+	if n.Concatenated {
+		fmt.Fprintf(sb, " :first-segment %q", n.FirstSegment)
+	}
 	sb.WriteString("}")
 }
 

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -891,6 +891,14 @@ type StringLit struct {
 	Loc     Loc
 	Value   string
 	Charset string // optional charset introducer (_utf8, etc.)
+	// Concatenated marks a literal folded from ADJACENT quoted segments per
+	// MySQL's adjacent string-literal concatenation ('a' 'b' → "ab"). Value
+	// holds the folded result; FirstSegment holds the first segment's value,
+	// because MySQL derives the implicit output column name from the first
+	// segment only (SELECT 'a' 'b' → column named "a" with value "ab", and an
+	// empty first segment falls back to the positional Name_exp_N form).
+	Concatenated bool
+	FirstSegment string
 }
 
 func (l *StringLit) nodeTag()  {}

--- a/mysql/catalog/analyze_targetlist.go
+++ b/mysql/catalog/analyze_targetlist.go
@@ -56,7 +56,7 @@ func analyzeTargetEntry(c *Catalog, item nodes.ExprNode, q *Query, scope *analyz
 		te := &TargetEntryQ{
 			Expr:    analyzed,
 			ResNo:   *resNo,
-			ResName: deriveColumnName(item, analyzed),
+			ResName: deriveColumnName(item, analyzed, *resNo),
 		}
 		fillProvenance(te, q)
 		*resNo++
@@ -71,7 +71,7 @@ func analyzeTargetEntry(c *Catalog, item nodes.ExprNode, q *Query, scope *analyz
 		te := &TargetEntryQ{
 			Expr:    analyzed,
 			ResNo:   *resNo,
-			ResName: deriveColumnName(item, analyzed),
+			ResName: deriveColumnName(item, analyzed, *resNo),
 		}
 		fillProvenance(te, q)
 		*resNo++
@@ -150,8 +150,10 @@ func expandScopeEntry(e scopeEntry, q *Query, scope *analyzerScope, resNo *int) 
 	return result, nil
 }
 
-// deriveColumnName generates the output column name for an unaliased expression.
-func deriveColumnName(astNode nodes.ExprNode, _ AnalyzedExpr) string {
+// deriveColumnName generates the output column name for an unaliased
+// expression. position is the 1-based select-item position, used for MySQL's
+// positional Name_exp_N fallback when a string literal derives an empty name.
+func deriveColumnName(astNode nodes.ExprNode, _ AnalyzedExpr, position int) string {
 	switch n := astNode.(type) {
 	case *nodes.ColumnRef:
 		return n.Column
@@ -159,11 +161,17 @@ func deriveColumnName(astNode nodes.ExprNode, _ AnalyzedExpr) string {
 		return strconv.FormatInt(n.Value, 10)
 	case *nodes.StringLit:
 		// An adjacent-literal run ('a' 'b') is named after its FIRST segment,
-		// not the folded value (MySQL: SELECT 'a' 'b' → column "a").
+		// not the folded value; an empty name falls back to the positional
+		// Name_exp_N form (MySQL: SELECT 'a' 'b' → column "a", SELECT '' 'b' →
+		// Name_exp_1, SELECT '' → Name_exp_1).
+		name := n.Value
 		if n.Concatenated {
-			return n.FirstSegment
+			name = n.FirstSegment
 		}
-		return n.Value
+		if name == "" {
+			return fmt.Sprintf("Name_exp_%d", position)
+		}
+		return name
 	case *nodes.FloatLit:
 		return n.Value
 	case *nodes.BoolLit:
@@ -176,7 +184,7 @@ func deriveColumnName(astNode nodes.ExprNode, _ AnalyzedExpr) string {
 	case *nodes.FuncCallExpr:
 		return n.Name
 	case *nodes.ParenExpr:
-		return deriveColumnName(n.Expr, nil)
+		return deriveColumnName(n.Expr, nil, position)
 	default:
 		return "?"
 	}

--- a/mysql/catalog/analyze_targetlist.go
+++ b/mysql/catalog/analyze_targetlist.go
@@ -158,6 +158,11 @@ func deriveColumnName(astNode nodes.ExprNode, _ AnalyzedExpr) string {
 	case *nodes.IntLit:
 		return strconv.FormatInt(n.Value, 10)
 	case *nodes.StringLit:
+		// An adjacent-literal run ('a' 'b') is named after its FIRST segment,
+		// not the folded value (MySQL: SELECT 'a' 'b' → column "a").
+		if n.Concatenated {
+			return n.FirstSegment
+		}
 		return n.Value
 	case *nodes.FloatLit:
 		return n.Value

--- a/mysql/catalog/analyze_test.go
+++ b/mysql/catalog/analyze_test.go
@@ -2788,3 +2788,37 @@ func TestAnalyze_15_5_ViewFunctionTypeFlow(t *testing.T) {
 		t.Errorf("TargetList[2].ResName: want cnt, got %s", q.TargetList[2].ResName)
 	}
 }
+
+// TestAnalyze_AdjacentLiteralResName pins the implicit output column name for
+// adjacent string-literal runs: MySQL names the item after the FIRST segment
+// ('a' 'b' → "a"), and an empty derived name falls back to the positional
+// Name_exp_N form (SELECT ” 'b' → Name_exp_1, SELECT ” → Name_exp_1; second
+// position → Name_exp_2). Oracle: MySQL 8.0.32 + 5.7.25 SHOW CREATE VIEW.
+func TestAnalyze_AdjacentLiteralResName(t *testing.T) {
+	c := wtSetup(t)
+	cases := []struct {
+		sql   string
+		names []string
+	}{
+		{`SELECT 'a' 'b'`, []string{"a"}},
+		{`SELECT '' 'b'`, []string{"Name_exp_1"}},
+		{`SELECT ''`, []string{"Name_exp_1"}},
+		{`SELECT 1, '' 'b'`, []string{"1", "Name_exp_2"}},
+		{`SELECT 'a' '' 'b'`, []string{"a"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			sel := parseSelect(t, tc.sql)
+			q, err := c.AnalyzeSelectStmt(sel)
+			assertNoError(t, err)
+			if len(q.TargetList) != len(tc.names) {
+				t.Fatalf("TargetList: want %d entries, got %d", len(tc.names), len(q.TargetList))
+			}
+			for i, want := range tc.names {
+				if q.TargetList[i].ResName != want {
+					t.Errorf("TargetList[%d].ResName: want %q, got %q", i, want, q.TargetList[i].ResName)
+				}
+			}
+		})
+	}
+}

--- a/mysql/catalog/diff_oracle_test.go
+++ b/mysql/catalog/diff_oracle_test.go
@@ -191,6 +191,11 @@ func diffIdempotenceProbes() []diffProbe {
 		// adjacency inside LIST COLUMNS partition values: VALUES IN ('a' 'b') is stored
 		// folded as VALUES IN ('ab').
 		{"adjacent-literal-partition", "CREATE TABLE t (c VARCHAR(10) NOT NULL PRIMARY KEY) PARTITION BY LIST COLUMNS(c) (PARTITION p0 VALUES IN ('a' 'b'), PARTITION p1 VALUES IN ('z'))", "t", both()},
+		// charset-introduced string defaults, single and folded: the introducer is not
+		// part of the stored default (SHOW CREATE echoes DEFAULT 'xy' / DEFAULT 'z'), so
+		// the user form must diff EMPTY against the readback and never render
+		// DEFAULT '_utf8mb4'xy'' (invalid SQL, the codex-review P2 case).
+		{"adjacent-literal-default-introducer", "CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(20) CHARACTER SET utf8mb4 DEFAULT _utf8mb4'x' 'y', b VARCHAR(20) CHARACTER SET utf8mb4 DEFAULT _utf8mb4'z') DEFAULT CHARSET=utf8mb4", "t", both()},
 	}
 }
 

--- a/mysql/catalog/diff_oracle_test.go
+++ b/mysql/catalog/diff_oracle_test.go
@@ -184,6 +184,13 @@ func diffIdempotenceProbes() []diffProbe {
 		// user form and the readback both carry it → empty diff). Idempotence guard for the
 		// rowFormatChanged gate.
 		{"row-format-explicit", "CREATE TABLE t (id INT PRIMARY KEY) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8", "t", both()},
+		// adjacent string-literal concatenation in a bare column DEFAULT: the user form
+		// DEFAULT 'x' 'y' ('x' 'y' 'z', "x" 'y') is stored as the folded DEFAULT 'xy'
+		// ('xyz', 'xy') — the user form must diff EMPTY against that readback.
+		{"adjacent-literal-default", `CREATE TABLE t (id INT PRIMARY KEY, a VARCHAR(20) DEFAULT 'x' 'y', b VARCHAR(20) DEFAULT 'x' 'y' 'z', c VARCHAR(20) DEFAULT "x" 'y')`, "t", both()},
+		// adjacency inside LIST COLUMNS partition values: VALUES IN ('a' 'b') is stored
+		// folded as VALUES IN ('ab').
+		{"adjacent-literal-partition", "CREATE TABLE t (c VARCHAR(10) NOT NULL PRIMARY KEY) PARTITION BY LIST COLUMNS(c) (PARTITION p0 VALUES IN ('a' 'b'), PARTITION p1 VALUES IN ('z'))", "t", both()},
 	}
 }
 

--- a/mysql/catalog/diff_routine_test.go
+++ b/mysql/catalog/diff_routine_test.go
@@ -79,6 +79,11 @@ func routineIdempotenceProbes() []routineProbe {
 		{"proc-default-in-direction", "PROCEDURE", "p", "CREATE PROCEDURE p(x INT, y INT) BEGIN SET @v = x + y; END", both()},
 		{"proc-all-characteristics", "PROCEDURE", "p", "CREATE PROCEDURE p(IN a INT) DETERMINISTIC READS SQL DATA SQL SECURITY INVOKER COMMENT 'pc' BEGIN SET @v = a; END", both()},
 		{"proc-explicit-defaults", "PROCEDURE", "p", "CREATE PROCEDURE p(IN a INT) NOT DETERMINISTIC CONTAINS SQL SQL SECURITY DEFINER BEGIN SET @v = a; END", both()},
+		// Adjacent string-literal concatenation in the body ('...' '...' across a line
+		// break — the stock-8.0 sys.ps_trace_thread shape). Bodies are stored VERBATIM,
+		// so the engine readback still carries the adjacency and the reload re-parses
+		// it; before adjacency support that failed with "unexpected token".
+		{"proc-adjacent-literals", "PROCEDURE", "p", "CREATE PROCEDURE p()\nBEGIN\n    SELECT CONCAT('tmp disk tables: ', 3, '\\n'\n                  'select scan: ', 4, '\\n');\nEND", both()},
 	}
 }
 
@@ -174,6 +179,38 @@ func TestOracle_RoutineDiffIdempotence(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestOracle_SysProcedureAdjacentLiterals proves the real-world motivation for
+// adjacent string-literal support against the engine's OWN schema: the stock
+// sys.ps_trace_thread body (shipped in every 5.7/8.0 server) contains an
+// adjacent-literal run ('tmp disk tables: ...\n' followed by 'select scan: ...'
+// with no comma), so its SHOW CREATE readback must parse, load through LoadSDL,
+// and self-diff empty. Before adjacency support this failed with "unexpected
+// token" — hard-blocking the declarative path for any dump containing sys.
+func TestOracle_SysProcedureAdjacentLiterals(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(o.version)
+		t.Run(o.name, func(t *testing.T) {
+			rb, ok := o.showCreateRoutine(t, "sys", "PROCEDURE", "ps_trace_thread")
+			if !ok {
+				t.Skipf("[%s] sys.ps_trace_thread unavailable (stripped sys schema?)", o.name)
+			}
+			sdl := "CREATE DATABASE sysdump;\nUSE sysdump;\n" + rb + ";\n"
+			cat, err := LoadSDL(sdl)
+			if err != nil {
+				t.Fatalf("[%s] LoadSDL of stock sys.ps_trace_thread failed: %v", o.name, err)
+			}
+			if d := DiffWithNormalizer(cat, cat, n); !d.IsEmpty() {
+				t.Errorf("[%s] self-diff of stock sys.ps_trace_thread not empty: %s",
+					o.name, describeRoutineDiff(d))
+			}
+		})
 	}
 }
 

--- a/mysql/catalog/sdl_test.go
+++ b/mysql/catalog/sdl_test.go
@@ -771,3 +771,37 @@ END;
 		t.Errorf("self-diff of SDL with adjacent literals not empty")
 	}
 }
+
+// TestSDLIntroducerDefaultRendersBareValue pins that a charset-introduced
+// string default — single (_utf8mb4'x') or folded (_utf8mb4'x' 'y') — is
+// stored and rendered by VALUE, the way MySQL stores it (SHOW CREATE TABLE
+// echoes DEFAULT 'x' / DEFAULT 'xy'; oracle 8.0.32 + 5.7.25). Deparsing the
+// introducer into the default rendered DEFAULT '_utf8mb4'x” — invalid SQL
+// the engine rejects with 1064 on apply.
+func TestSDLIntroducerDefaultRendersBareValue(t *testing.T) {
+	target, err := LoadSDL(`
+CREATE DATABASE d1;
+USE d1;
+CREATE TABLE t (
+    a varchar(10) CHARSET utf8mb4 DEFAULT _utf8mb4'x' 'y',
+    b varchar(10) CHARSET utf8mb4 DEFAULT _utf8mb4'x'
+);
+`)
+	if err != nil {
+		t.Fatalf("LoadSDL error: %v", err)
+	}
+	empty, err := LoadSDL("CREATE DATABASE d1;\n")
+	if err != nil {
+		t.Fatalf("LoadSDL(empty) error: %v", err)
+	}
+	sql := GenerateMigration(empty, target, Diff(empty, target)).SQL()
+	if !strings.Contains(sql, "DEFAULT 'xy'") || !strings.Contains(sql, "DEFAULT 'x'") {
+		t.Errorf("generated DDL must carry bare folded defaults, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "_utf8mb4") {
+		t.Errorf("generated DDL leaked the charset introducer into a default:\n%s", sql)
+	}
+	if d := Diff(target, target); !d.IsEmpty() {
+		t.Errorf("self-diff of introducer-default SDL not empty")
+	}
+}

--- a/mysql/catalog/sdl_test.go
+++ b/mysql/catalog/sdl_test.go
@@ -737,3 +737,37 @@ CREATE TABLE derived AS SELECT id FROM src;
 		t.Fatalf("expected CTAS rejection error mentioning SELECT, got: %v", err)
 	}
 }
+
+// TestSDLAdjacentStringLiterals covers MySQL's adjacent string-literal
+// concatenation ('a' 'b' → 'ab') through the SDL loader. The stock MySQL 8.0
+// sys schema relies on it: ps_trace_thread's body concatenates '\n' with the
+// next segment across a line break, so a canonical dump of sys was unloadable
+// before adjacency support. Bodies are stored verbatim; the loaded catalog must
+// also self-diff empty so the adjacency never phantom-diffs.
+func TestSDLAdjacentStringLiterals(t *testing.T) {
+	sql := `
+CREATE DATABASE app;
+USE app;
+CREATE TABLE t (a varchar(40) DEFAULT 'x' 'y');
+CREATE PROCEDURE p()
+BEGIN
+    SELECT CONCAT('tmp disk tables: ', 3, '\n'
+                  'select scan: ', 4, '\n');
+END;
+`
+	db := loadSDLForDB(t, sql, "app")
+	if db.Procedures["p"] == nil {
+		t.Fatal("procedure p not loaded")
+	}
+	if !strings.Contains(db.Procedures["p"].Body, "'select scan: '") {
+		t.Errorf("procedure body not stored verbatim: %q", db.Procedures["p"].Body)
+	}
+
+	c, err := LoadSDL(sql)
+	if err != nil {
+		t.Fatalf("LoadSDL error: %v", err)
+	}
+	if d := Diff(c, c); !d.IsEmpty() {
+		t.Errorf("self-diff of SDL with adjacent literals not empty")
+	}
+}

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1022,6 +1022,21 @@ func columnDefaultValue(expr nodes.ExprNode) (string, ColumnDefaultKind) {
 			return ts, ColumnDefaultCurrentTimestamp
 		}
 		return nodeToSQL(e.Expr), ColumnDefaultExpression
+	case *nodes.StringLit:
+		// MySQL stores a bare string default by VALUE: a charset introducer is
+		// not part of the stored default — SHOW CREATE TABLE echoes
+		// DEFAULT _utf8mb4'x' as DEFAULT 'x' (oracle 8.0.32 + 5.7.25; same for
+		// the folded _utf8mb4'x' 'y' form). Deparsing the introducer into the
+		// stored value would render DEFAULT '_utf8mb4'x'' — invalid SQL that
+		// also phantom-diffs against the engine readback. Expression defaults
+		// (the ParenExpr case above) legitimately keep the introducer: the
+		// engine itself stores DEFAULT (_utf8mb4'xy').
+		if e.Charset != "" {
+			stripped := *e
+			stripped.Charset = ""
+			return nodeToSQL(&stripped), ColumnDefaultConstant
+		}
+		return nodeToSQL(expr), ColumnDefaultConstant
 	case *nodes.BoolLit:
 		if e.Value {
 			return "1", ColumnDefaultConstant

--- a/mysql/deparse/deparse.go
+++ b/mysql/deparse/deparse.go
@@ -532,10 +532,17 @@ func autoAlias(expr ast.ExprNode, exprStr string, position int) string {
 	case *ast.FloatLit:
 		return n.Value
 	case *ast.StringLit:
-		if n.Value == "" {
+		// An adjacent-literal run is named after its FIRST segment, not the
+		// folded value; an empty first segment falls back to Name_exp_N
+		// (oracle: SELECT '' 'b' → value 'b' named Name_exp_1).
+		name := n.Value
+		if n.Concatenated {
+			name = n.FirstSegment
+		}
+		if name == "" {
 			return fmt.Sprintf("Name_exp_%d", position)
 		}
-		return n.Value
+		return name
 	case *ast.NullLit:
 		return "NULL"
 	case *ast.BoolLit:

--- a/mysql/parser/adjacent_literal_test.go
+++ b/mysql/parser/adjacent_literal_test.go
@@ -203,6 +203,60 @@ func TestAdjacentStringLiteralAliasInterplay(t *testing.T) {
 	}
 }
 
+// TestCharsetIntroducerRecognition pins which _ident prefixes form a charset
+// introducer. MySQL's lexer only builds an introducer for real charset names,
+// case-insensitively; anything else is an ordinary identifier followed by a
+// separate string literal (oracle 8.0.32 + 5.7.25: SELECT _typo'abc' → 1054
+// unknown column '_typo', SELECT CONCAT(_typo'abc') → 1583 — never a folded
+// string and never a syntax error at the introducer position).
+func TestCharsetIntroducerRecognition(t *testing.T) {
+	t.Run("known charsets fold, case-insensitive", func(t *testing.T) {
+		for _, tc := range []struct {
+			sql         string
+			wantCharset string
+			wantValue   string
+		}{
+			{`SELECT _utf8mb4'a' 'b'`, "_utf8mb4", "ab"},
+			{`SELECT _UTF8MB4'a' 'b'`, "_UTF8MB4", "ab"},
+			{`SELECT _Utf8'a'`, "_Utf8", "a"},
+			{`SELECT _utf8mb3'a'`, "_utf8mb3", "a"},
+			{`SELECT _latin1'a'`, "_latin1", "a"},
+			{`SELECT _binary'a'`, "_binary", "a"},
+		} {
+			item := firstSelectItem(t, tc.sql)
+			lit, ok := item.(*ast.StringLit)
+			if !ok {
+				t.Fatalf("%s: expected *ast.StringLit, got %T", tc.sql, item)
+			}
+			if lit.Charset != tc.wantCharset || lit.Value != tc.wantValue {
+				t.Errorf("%s: got Charset %q Value %q, want %q %q",
+					tc.sql, lit.Charset, lit.Value, tc.wantCharset, tc.wantValue)
+			}
+		}
+	})
+	t.Run("unknown _ident is an identifier, not an introducer", func(t *testing.T) {
+		// SELECT _typo'abc' — MySQL parses column ref _typo with implicit
+		// string alias 'abc' (1054 at resolution). The parser must do the
+		// same, not fold a StringLit with a bogus charset.
+		item := firstSelectItem(t, `SELECT _typo'abc'`)
+		rt, ok := item.(*ast.ResTarget)
+		if !ok {
+			t.Fatalf("expected aliased column ref, got %T", item)
+		}
+		col, ok := rt.Val.(*ast.ColumnRef)
+		if !ok || col.Column != "_typo" || rt.Name != "abc" {
+			t.Fatalf("expected ColumnRef _typo aliased 'abc', got %#v alias %q", rt.Val, rt.Name)
+		}
+	})
+	t.Run("unknown _ident in function args rejects", func(t *testing.T) {
+		// MySQL: CONCAT(_typo'abc') → 1583 (alias not allowed to a native
+		// function). The parser rejects at the dangling string.
+		if _, err := Parse(`SELECT CONCAT(_typo'abc')`); err == nil {
+			t.Fatal("Parse succeeded; MySQL rejects CONCAT(_typo'abc')")
+		}
+	})
+}
+
 // TestAdjacentStringLiteralRejects pins the forms MySQL rejects (1064 on both
 // 8.0.32 and 5.7.25): a continuation segment cannot carry a charset introducer,
 // a string cannot continue a hex literal inside an expression argument, and the

--- a/mysql/parser/adjacent_literal_test.go
+++ b/mysql/parser/adjacent_literal_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/mysql/ast"
@@ -46,19 +45,20 @@ func TestAdjacentStringLiteralConcat(t *testing.T) {
 		sql          string
 		wantValue    string
 		wantCharset  string
+		wantConcat   bool
 		wantFirstSeg string // FirstSegment when the run concatenated; "" for aliasless single
 	}{
-		{name: "two literals", sql: `SELECT 'a' 'b'`, wantValue: "ab", wantFirstSeg: "a"},
-		{name: "three literals", sql: `SELECT 'a' 'b' 'c'`, wantValue: "abc", wantFirstSeg: "a"},
-		{name: "newline between", sql: "SELECT 'a'\n'b'", wantValue: "ab", wantFirstSeg: "a"},
-		{name: "block comment between", sql: `SELECT 'a' /* c */ 'b'`, wantValue: "ab", wantFirstSeg: "a"},
-		{name: "line comment between", sql: "SELECT 'a' -- c\n'b'", wantValue: "ab", wantFirstSeg: "a"},
-		{name: "double-quote mix", sql: `SELECT 'a' "b"`, wantValue: "ab", wantFirstSeg: "a"},
-		{name: "double-quote first", sql: `SELECT "a" 'b'`, wantValue: "ab", wantFirstSeg: "a"},
-		{name: "empty middle segment", sql: `SELECT 'a' '' 'b'`, wantValue: "ab", wantFirstSeg: "a"},
-		{name: "empty first segment", sql: `SELECT '' 'b'`, wantValue: "b", wantFirstSeg: ""},
-		{name: "escaped quote in segment", sql: `SELECT 'a''x' 'b'`, wantValue: "a'xb", wantFirstSeg: "a'x"},
-		{name: "introducer on first", sql: `SELECT _utf8mb4'a' 'b'`, wantValue: "ab", wantCharset: "_utf8mb4", wantFirstSeg: "a"},
+		{name: "two literals", sql: `SELECT 'a' 'b'`, wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "three literals", sql: `SELECT 'a' 'b' 'c'`, wantValue: "abc", wantConcat: true, wantFirstSeg: "a"},
+		{name: "newline between", sql: "SELECT 'a'\n'b'", wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "block comment between", sql: `SELECT 'a' /* c */ 'b'`, wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "line comment between", sql: "SELECT 'a' -- c\n'b'", wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "double-quote mix", sql: `SELECT 'a' "b"`, wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "double-quote first", sql: `SELECT "a" 'b'`, wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "empty middle segment", sql: `SELECT 'a' '' 'b'`, wantValue: "ab", wantConcat: true, wantFirstSeg: "a"},
+		{name: "empty first segment", sql: `SELECT '' 'b'`, wantValue: "b", wantConcat: true, wantFirstSeg: ""},
+		{name: "escaped quote in segment", sql: `SELECT 'a''x' 'b'`, wantValue: "a'xb", wantConcat: true, wantFirstSeg: "a'x"},
+		{name: "introducer on first", sql: `SELECT _utf8mb4'a' 'b'`, wantValue: "ab", wantCharset: "_utf8mb4", wantConcat: true, wantFirstSeg: "a"},
 		{name: "single literal unchanged", sql: `SELECT 'a'`, wantValue: "a"},
 		{name: "single introducer unchanged", sql: `SELECT _utf8mb4'a'`, wantValue: "a", wantCharset: "_utf8mb4"},
 	}
@@ -75,9 +75,8 @@ func TestAdjacentStringLiteralConcat(t *testing.T) {
 			if lit.Charset != tc.wantCharset {
 				t.Errorf("Charset = %q, want %q", lit.Charset, tc.wantCharset)
 			}
-			wantConcat := strings.Count(tc.sql, "'")+strings.Count(tc.sql, `"`) > 2
-			if lit.Concatenated != wantConcat {
-				t.Errorf("Concatenated = %v, want %v", lit.Concatenated, wantConcat)
+			if lit.Concatenated != tc.wantConcat {
+				t.Errorf("Concatenated = %v, want %v", lit.Concatenated, tc.wantConcat)
 			}
 			if lit.FirstSegment != tc.wantFirstSeg {
 				t.Errorf("FirstSegment = %q, want %q", lit.FirstSegment, tc.wantFirstSeg)
@@ -215,6 +214,7 @@ func TestAdjacentStringLiteralRejects(t *testing.T) {
 		`CREATE TABLE t (a int) COMMENT 'x' 'y'`,
 		`CREATE TABLE t (a int COMMENT 'x' 'y')`,
 		`CREATE TABLE t (e ENUM('a' 'b'))`,
+		`CREATE PROCEDURE p() COMMENT 'x' 'y' SELECT 1`,
 	}
 	for _, sql := range cases {
 		t.Run(sql, func(t *testing.T) {

--- a/mysql/parser/adjacent_literal_test.go
+++ b/mysql/parser/adjacent_literal_test.go
@@ -1,0 +1,258 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mysql/ast"
+)
+
+// MySQL concatenates adjacent quoted string literals into a single literal:
+// 'a' 'b' → 'ab' (manual 9.1.1: "Quoted strings placed next to each other are
+// concatenated to a single string"). The rule lives on text_literal only —
+// hex/bit/temporal literals never join a run, a charset introducer is valid on
+// the FIRST segment only, and the implicit output column name derives from the
+// first segment ('SELECT 'a' 'b'' → column "a", value "ab").
+//
+// Oracle evidence: MySQL 8.0.32 and 5.7.25 agree on every case below
+// (probed live; see PR body). The real-world motivation is the stock MySQL 8.0
+// sys schema: ps_trace_thread's body contains an adjacent-literal run, so a
+// canonical dump of sys was unparseable before this support.
+
+// firstSelectItem parses sql and returns the single select item, which may be a
+// bare expression or a *ast.ResTarget wrapper when an alias was attached.
+func firstSelectItem(t *testing.T, sql string) ast.ExprNode {
+	t.Helper()
+	list, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse(%q) error: %v", sql, err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("Parse(%q): expected 1 statement, got %d", sql, len(list.Items))
+	}
+	sel, ok := list.Items[0].(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("Parse(%q): expected *ast.SelectStmt, got %T", sql, list.Items[0])
+	}
+	if len(sel.TargetList) != 1 {
+		t.Fatalf("Parse(%q): expected 1 select item, got %d", sql, len(sel.TargetList))
+	}
+	return sel.TargetList[0]
+}
+
+func TestAdjacentStringLiteralConcat(t *testing.T) {
+	cases := []struct {
+		name         string
+		sql          string
+		wantValue    string
+		wantCharset  string
+		wantFirstSeg string // FirstSegment when the run concatenated; "" for aliasless single
+	}{
+		{name: "two literals", sql: `SELECT 'a' 'b'`, wantValue: "ab", wantFirstSeg: "a"},
+		{name: "three literals", sql: `SELECT 'a' 'b' 'c'`, wantValue: "abc", wantFirstSeg: "a"},
+		{name: "newline between", sql: "SELECT 'a'\n'b'", wantValue: "ab", wantFirstSeg: "a"},
+		{name: "block comment between", sql: `SELECT 'a' /* c */ 'b'`, wantValue: "ab", wantFirstSeg: "a"},
+		{name: "line comment between", sql: "SELECT 'a' -- c\n'b'", wantValue: "ab", wantFirstSeg: "a"},
+		{name: "double-quote mix", sql: `SELECT 'a' "b"`, wantValue: "ab", wantFirstSeg: "a"},
+		{name: "double-quote first", sql: `SELECT "a" 'b'`, wantValue: "ab", wantFirstSeg: "a"},
+		{name: "empty middle segment", sql: `SELECT 'a' '' 'b'`, wantValue: "ab", wantFirstSeg: "a"},
+		{name: "empty first segment", sql: `SELECT '' 'b'`, wantValue: "b", wantFirstSeg: ""},
+		{name: "escaped quote in segment", sql: `SELECT 'a''x' 'b'`, wantValue: "a'xb", wantFirstSeg: "a'x"},
+		{name: "introducer on first", sql: `SELECT _utf8mb4'a' 'b'`, wantValue: "ab", wantCharset: "_utf8mb4", wantFirstSeg: "a"},
+		{name: "single literal unchanged", sql: `SELECT 'a'`, wantValue: "a"},
+		{name: "single introducer unchanged", sql: `SELECT _utf8mb4'a'`, wantValue: "a", wantCharset: "_utf8mb4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := firstSelectItem(t, tc.sql)
+			lit, ok := item.(*ast.StringLit)
+			if !ok {
+				t.Fatalf("expected *ast.StringLit select item, got %T", item)
+			}
+			if lit.Value != tc.wantValue {
+				t.Errorf("Value = %q, want %q", lit.Value, tc.wantValue)
+			}
+			if lit.Charset != tc.wantCharset {
+				t.Errorf("Charset = %q, want %q", lit.Charset, tc.wantCharset)
+			}
+			wantConcat := strings.Count(tc.sql, "'")+strings.Count(tc.sql, `"`) > 2
+			if lit.Concatenated != wantConcat {
+				t.Errorf("Concatenated = %v, want %v", lit.Concatenated, wantConcat)
+			}
+			if lit.FirstSegment != tc.wantFirstSeg {
+				t.Errorf("FirstSegment = %q, want %q", lit.FirstSegment, tc.wantFirstSeg)
+			}
+		})
+	}
+}
+
+// TestAdjacentStringLiteralExprContexts proves the run folds inside every
+// expression position the oracle accepts it in: function args, comparisons,
+// IN lists, ORDER BY, and INSERT values.
+func TestAdjacentStringLiteralExprContexts(t *testing.T) {
+	cases := []string{
+		`SELECT CONCAT('a' 'b', 'c')`,
+		`SELECT 'a' 'b' = 'ab'`,
+		`SELECT * FROM t WHERE c = 'a' 'b'`,
+		`SELECT * FROM t WHERE c IN ('a' 'b', 'c')`,
+		`SELECT c FROM t ORDER BY 'a' 'b'`,
+		`INSERT INTO t VALUES ('a' 'b')`,
+		`SET @v = 'a' 'b'`,
+		`CREATE TABLE t (a varchar(10) DEFAULT 'x' 'y')`,
+		`CREATE TABLE t (a varchar(10) DEFAULT 'x' 'y' 'z' NOT NULL)`,
+		`CREATE TABLE t (a varchar(10) DEFAULT _utf8mb4'x' 'y')`,
+		`CREATE TABLE t (a varchar(20) DEFAULT ('x' 'y'))`,
+		`CREATE TABLE t (a int, g varchar(10) GENERATED ALWAYS AS ('x' 'y') STORED)`,
+		"CREATE TABLE tp (c varchar(10) NOT NULL) PARTITION BY LIST COLUMNS(c) (PARTITION p0 VALUES IN ('a' 'b'), PARTITION p1 VALUES IN ('z'))",
+		`CREATE VIEW v AS SELECT 'a' 'b' AS c`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err != nil {
+				t.Fatalf("Parse(%q) error: %v", sql, err)
+			}
+		})
+	}
+}
+
+// TestAdjacentStringLiteralDefaultValue pins the folded value on the column
+// default: MySQL stores DEFAULT 'x' 'y' as DEFAULT 'xy' (oracle: SHOW CREATE
+// TABLE on 8.0.32 and 5.7.25).
+func TestAdjacentStringLiteralDefaultValue(t *testing.T) {
+	list, err := Parse(`CREATE TABLE t (a varchar(10) DEFAULT 'x' 'y' 'z')`)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	ct, ok := list.Items[0].(*ast.CreateTableStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateTableStmt, got %T", list.Items[0])
+	}
+	lit, ok := ct.Columns[0].DefaultValue.(*ast.StringLit)
+	if !ok {
+		t.Fatalf("expected *ast.StringLit default, got %T", ct.Columns[0].DefaultValue)
+	}
+	if lit.Value != "xyz" {
+		t.Errorf("default Value = %q, want %q", lit.Value, "xyz")
+	}
+}
+
+// TestAdjacentStringLiteralAliasInterplay pins the boundary between adjacency
+// and MySQL's implicit string alias: a quoted string after a TEXT literal joins
+// the run (greedy, matching MySQL), while a quoted string after any other
+// literal stays an alias.
+func TestAdjacentStringLiteralAliasInterplay(t *testing.T) {
+	t.Run("run swallows would-be alias", func(t *testing.T) {
+		item := firstSelectItem(t, `SELECT 'a' 'b'`)
+		if _, ok := item.(*ast.ResTarget); ok {
+			t.Fatalf("SELECT 'a' 'b' parsed as aliased item; MySQL concatenates instead")
+		}
+	})
+	t.Run("explicit AS breaks the run", func(t *testing.T) {
+		item := firstSelectItem(t, `SELECT 'a' AS 'b'`)
+		rt, ok := item.(*ast.ResTarget)
+		if !ok {
+			t.Fatalf("expected *ast.ResTarget, got %T", item)
+		}
+		if rt.Name != "b" {
+			t.Errorf("alias = %q, want %q", rt.Name, "b")
+		}
+		if lit, ok := rt.Val.(*ast.StringLit); !ok || lit.Value != "a" {
+			t.Errorf("value = %#v, want StringLit 'a'", rt.Val)
+		}
+	})
+	t.Run("run then explicit AS alias", func(t *testing.T) {
+		item := firstSelectItem(t, `SELECT 'a' 'b' AS c`)
+		rt, ok := item.(*ast.ResTarget)
+		if !ok {
+			t.Fatalf("expected *ast.ResTarget, got %T", item)
+		}
+		if lit, ok := rt.Val.(*ast.StringLit); !ok || lit.Value != "ab" {
+			t.Errorf("value = %#v, want StringLit 'ab'", rt.Val)
+		}
+	})
+	t.Run("int literal keeps string alias", func(t *testing.T) {
+		item := firstSelectItem(t, `SELECT 1 'x'`)
+		rt, ok := item.(*ast.ResTarget)
+		if !ok || rt.Name != "x" {
+			t.Fatalf("SELECT 1 'x': expected alias 'x', got %#v", item)
+		}
+	})
+	// Hex, bit, and temporal literals never join a run: MySQL parses the
+	// trailing string as the item alias (oracle: SELECT x'41' 'b' yields value
+	// 'A' named 'b', and CONCAT(x'41' 'b') is not a concatenation).
+	for _, tc := range []struct {
+		sql  string
+		want string
+	}{
+		{`SELECT x'41' 'b'`, "b"},
+		{`SELECT b'01000001' 'c'`, "c"},
+		{`SELECT DATE '2024-01-01' 'd'`, "d"},
+	} {
+		t.Run(tc.sql, func(t *testing.T) {
+			item := firstSelectItem(t, tc.sql)
+			rt, ok := item.(*ast.ResTarget)
+			if !ok {
+				t.Fatalf("expected aliased item, got %T", item)
+			}
+			if rt.Name != tc.want {
+				t.Errorf("alias = %q, want %q", rt.Name, tc.want)
+			}
+			if _, isStr := rt.Val.(*ast.StringLit); isStr {
+				t.Errorf("value folded into a StringLit; hex/bit/temporal must not concatenate")
+			}
+		})
+	}
+}
+
+// TestAdjacentStringLiteralRejects pins the forms MySQL rejects (1064 on both
+// 8.0.32 and 5.7.25): a continuation segment cannot carry a charset introducer,
+// a string cannot continue a hex literal inside an expression argument, and the
+// TEXT_STRING_sys contexts (COMMENT, ENUM members) never concatenate.
+func TestAdjacentStringLiteralRejects(t *testing.T) {
+	cases := []string{
+		`SELECT 'a' _utf8mb4'b'`,
+		`SELECT CONCAT('a' x'41')`,
+		`CREATE TABLE t (a int) COMMENT 'x' 'y'`,
+		`CREATE TABLE t (a int COMMENT 'x' 'y')`,
+		`CREATE TABLE t (e ENUM('a' 'b'))`,
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := Parse(sql); err == nil {
+				t.Fatalf("Parse(%q) succeeded; MySQL rejects this form", sql)
+			}
+		})
+	}
+}
+
+// TestAdjacentStringLiteralSysProcedureRepro is the real-world shape: the stock
+// MySQL 8.0 sys schema's ps_trace_thread body concatenates '\n' with the next
+// segment across a line break. The body must parse and BodyText must round-trip
+// the source bytes verbatim (routine bodies are stored verbatim by MySQL).
+func TestAdjacentStringLiteralSysProcedureRepro(t *testing.T) {
+	body := "BEGIN\n    SELECT CONCAT('tmp disk tables: ', 3, '\\n'\n                  'select scan: ', 4, '\\n');\nEND"
+	sql := "CREATE PROCEDURE p()\n" + body
+	list, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	fn, ok := list.Items[0].(*ast.CreateFunctionStmt)
+	if !ok {
+		t.Fatalf("expected *ast.CreateFunctionStmt, got %T", list.Items[0])
+	}
+	if fn.BodyText != body {
+		t.Errorf("BodyText not verbatim:\n got: %q\nwant: %q", fn.BodyText, body)
+	}
+
+	// Control: the same body with a comma instead of adjacency parses too.
+	control := "CREATE PROCEDURE p()\nBEGIN\n    SELECT CONCAT('tmp disk tables: ', 3, '\\n',\n                  'select scan: ', 4, '\\n');\nEND"
+	if _, err := Parse(control); err != nil {
+		t.Fatalf("control Parse error: %v", err)
+	}
+
+	// Trigger bodies share the expression path.
+	trigger := "CREATE TRIGGER trg1 BEFORE INSERT ON t1 FOR EACH ROW\nBEGIN\n    SET NEW.a = CONCAT('x' 'y');\nEND"
+	if _, err := Parse(trigger); err != nil {
+		t.Fatalf("trigger Parse error: %v", err)
+	}
+}

--- a/mysql/parser/charset.go
+++ b/mysql/parser/charset.go
@@ -1,0 +1,34 @@
+package parser
+
+import "strings"
+
+// charsetIntroducerNames is the set of character set names MySQL accepts as a
+// string-literal charset introducer (_utf8mb4'...'). Taken from SHOW CHARACTER
+// SET on live MySQL 8.0.32 and 5.7.25 (union), plus the utf8/utf8mb3 aliases —
+// both engines accept _utf8 and _utf8mb3 even where SHOW lists only one of
+// them. Collation names (utf8mb4_0900_ai_ci, ...) are NOT introducers and are
+// deliberately absent. Matching is case-insensitive (_UTF8MB4 is valid).
+var charsetIntroducerNames = map[string]bool{
+	"armscii8": true, "ascii": true, "big5": true, "binary": true,
+	"cp1250": true, "cp1251": true, "cp1256": true, "cp1257": true,
+	"cp850": true, "cp852": true, "cp866": true, "cp932": true,
+	"dec8": true, "eucjpms": true, "euckr": true, "gb18030": true,
+	"gb2312": true, "gbk": true, "geostd8": true, "greek": true,
+	"hebrew": true, "hp8": true, "keybcs2": true, "koi8r": true,
+	"koi8u": true, "latin1": true, "latin2": true, "latin5": true,
+	"latin7": true, "macce": true, "macroman": true, "sjis": true,
+	"swe7": true, "tis620": true, "ucs2": true, "ujis": true,
+	"utf16": true, "utf16le": true, "utf32": true, "utf8": true,
+	"utf8mb3": true, "utf8mb4": true,
+}
+
+// isCharsetIntroducer reports whether ident is a charset introducer: an
+// underscore followed by a known MySQL character set name. MySQL's lexer only
+// forms an introducer token for real charset names — any other _ident before a
+// string literal is an ordinary identifier.
+func isCharsetIntroducer(ident string) bool {
+	if len(ident) < 2 || ident[0] != '_' {
+		return false
+	}
+	return charsetIntroducerNames[strings.ToLower(ident[1:])]
+}

--- a/mysql/parser/error_test.go
+++ b/mysql/parser/error_test.go
@@ -246,6 +246,56 @@ func TestLineCol(t *testing.T) {
 	}
 }
 
+// TestParseErrorLineExact pins that Parse reports the error line/column against
+// the EXACT input it was handed — across leading comments, blank lines,
+// multi-statement input, compound bodies, and DELIMITER directives. Callers
+// that prepend a synthetic prologue (e.g. "CREATE DATABASE d;\nUSE d;\n")
+// before parsing must translate reported lines back themselves; the parser
+// does not drift.
+func TestParseErrorLineExact(t *testing.T) {
+	cases := []struct {
+		name     string
+		sql      string
+		wantLine int
+		wantCol  int
+	}{
+		{
+			name:     "error on line 6 of an 8-line compound input",
+			sql:      "-- a comment\n\nCREATE PROCEDURE p()\nBEGIN\n    SELECT CONCAT('a',\n                  ,, 'b');\nEND;\n-- trailing",
+			wantLine: 6,
+			wantCol:  19,
+		},
+		{
+			name:     "error after a DELIMITER directive",
+			sql:      "DELIMITER $$\nCREATE PROCEDURE p()\nBEGIN\n    SELECT CONCAT('a',\n                  ,, 'b');\nEND$$\nDELIMITER ;",
+			wantLine: 5,
+			wantCol:  19,
+		},
+		{
+			name:     "error in the second statement",
+			sql:      "SELECT 1;\nSELECT CONCAT('a',\n,, 'b');",
+			wantLine: 3,
+			wantCol:  1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.sql)
+			if err == nil {
+				t.Fatal("expected parse error, got nil")
+			}
+			pe, ok := err.(*ParseError)
+			if !ok {
+				t.Fatalf("expected *ParseError, got %T: %v", err, err)
+			}
+			if pe.Line != tc.wantLine || pe.Column != tc.wantCol {
+				t.Errorf("error at line %d col %d, want line %d col %d\nerror: %v",
+					pe.Line, pe.Column, tc.wantLine, tc.wantCol, err)
+			}
+		})
+	}
+}
+
 func TestParseError_Section_2_1_ArithmeticOperators(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -516,8 +516,12 @@ func (p *Parser) parsePrimaryExpr() (nodes.ExprNode, error) {
 			}, nil
 		}
 
-		// Charset introducer: _utf8mb4'hello', _latin1'world'
-		if p.cur.Type == tokIDENT && strings.HasPrefix(p.cur.Str, "_") && p.peekNext().Type == tokSCONST {
+		// Charset introducer: _utf8mb4'hello', _latin1'world'. Only a real
+		// charset name forms an introducer — MySQL lexes _typo'abc' as an
+		// identifier followed by a separate string literal (oracle 8.0.32 +
+		// 5.7.25: SELECT _typo'abc' → 1054 unknown column, not a syntax
+		// error), so an unknown name falls through to identifier parsing.
+		if p.cur.Type == tokIDENT && isCharsetIntroducer(p.cur.Str) && p.peekNext().Type == tokSCONST {
 			charsetTok := p.advance() // consume the charset identifier
 			strTok := p.advance()     // consume the string literal
 			lit := &nodes.StringLit{

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -337,6 +337,31 @@ func (p *Parser) parseUnaryExpr(op nodes.UnaryOp) (nodes.ExprNode, error) {
 	}, nil
 }
 
+// foldAdjacentStringLits folds MySQL's adjacent string-literal concatenation
+// into lit: quoted strings placed next to each other are a single literal whose
+// value is the concatenation of the segments ('a' 'b' → 'ab', manual 9.1.1).
+// The rule lives on text_literal only — continuation segments must be bare
+// quoted strings (never a charset introducer, hex/bit literal, or temporal
+// literal; MySQL 8.0.32 and 5.7.25 both reject or alias those forms), and the
+// character set of the run is that of the first segment. FirstSegment records
+// the first segment's value because the implicit output column name derives
+// from it, not from the folded value (SELECT 'a' 'b' → column "a", value "ab").
+func (p *Parser) foldAdjacentStringLits(lit *nodes.StringLit) {
+	if p.cur.Type != tokSCONST {
+		return
+	}
+	var sb strings.Builder
+	sb.WriteString(lit.Value)
+	lit.FirstSegment = lit.Value
+	lit.Concatenated = true
+	for p.cur.Type == tokSCONST {
+		next := p.advance()
+		sb.WriteString(next.Str)
+	}
+	lit.Value = sb.String()
+	lit.Loc.End = p.pos()
+}
+
 // parsePrimaryExpr parses atoms: literals, column refs, subqueries, func calls, parenthesized exprs.
 func (p *Parser) parsePrimaryExpr() (nodes.ExprNode, error) {
 	switch p.cur.Type {
@@ -354,7 +379,9 @@ func (p *Parser) parsePrimaryExpr() (nodes.ExprNode, error) {
 
 	case tokSCONST:
 		tok := p.advance()
-		return &nodes.StringLit{Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}, Value: tok.Str}, nil
+		lit := &nodes.StringLit{Loc: nodes.Loc{Start: tok.Loc, End: p.pos()}, Value: tok.Str}
+		p.foldAdjacentStringLits(lit)
+		return lit, nil
 
 	case tokXCONST:
 		tok := p.advance()
@@ -493,11 +520,13 @@ func (p *Parser) parsePrimaryExpr() (nodes.ExprNode, error) {
 		if p.cur.Type == tokIDENT && strings.HasPrefix(p.cur.Str, "_") && p.peekNext().Type == tokSCONST {
 			charsetTok := p.advance() // consume the charset identifier
 			strTok := p.advance()     // consume the string literal
-			return &nodes.StringLit{
+			lit := &nodes.StringLit{
 				Loc:     nodes.Loc{Start: charsetTok.Loc, End: strTok.Loc + len(strTok.Str) + 2},
 				Value:   strTok.Str,
 				Charset: charsetTok.Str,
-			}, nil
+			}
+			p.foldAdjacentStringLits(lit)
+			return lit, nil
 		}
 
 		// Identifier — could be column ref or function call


### PR DESCRIPTION
## Motivation (real-world)

MySQL concatenates adjacent quoted string literals — `SELECT 'a' 'b'` → `'ab'` (manual 9.1.1: "Quoted strings placed next to each other are concatenated to a single string"). The omni MySQL parser rejected the second literal with "unexpected token".

This hard-blocked the declarative path on the **stock sys schema**: `sys.ps_trace_thread` (ships in every 5.7/8.0 server) contains an adjacent run in its body — `'tmp disk tables: ', created_tmp_disk_tables, '\\n'` followed (across a line break on 8.0, inline on 5.7) by `'select scan: ', select_scan, ...` with no comma. Routine bodies are stored **verbatim**, so the engine's own `SHOW CREATE PROCEDURE` readback is unparseable, and `LoadSDL` fails on any canonical dump containing sys.

## Repro (fails on main)

```sql
CREATE PROCEDURE p()
BEGIN
    SELECT CONCAT('tmp disk tables: ', 3, '\n'
                  'select scan: ', 4, '\n');
END;
```

main: `unexpected token`. The control (comma after the first `'\n'`) parses fine. The actual stock `sys.ps_trace_thread` readback fails identically on main against both live engines (8.0.32: line 101 col 29; 5.7.25: line 5 col 2976 — exactly the adjacency point).

## What changed

- `mysql/parser/expr.go` — `parsePrimaryExpr` folds a run of adjacent `tokSCONST` tokens into one `StringLit` (`foldAdjacentStringLits`), for bare literals and charset-introducer literals. Continuation segments must be bare quoted strings — an introducer, hex/bit, or temporal literal never joins a run (per oracle).
- `mysql/ast/parsenodes.go` — `StringLit` gains `Concatenated` + `FirstSegment`: MySQL derives the implicit output column name from the FIRST segment, not the folded value.
- `mysql/catalog/analyze_targetlist.go` (`deriveColumnName`) and `mysql/deparse/deparse.go` (`autoAlias`) use `FirstSegment` for folded literals; an empty first segment falls back to `Name_exp_N` (matches oracle).
- `mysql/ast/outfuncs.go` — AST dump prints `:first-segment` when folded (single-literal dumps unchanged).

## Oracle evidence (live MySQL 8.0.32 and 5.7.25 — identical verdicts unless noted)

| Case | Oracle verdict (both versions) | Implemented |
|---|---|---|
| `'a' 'b'`, `'a' 'b' 'c'` | concat → `'ab'` / `'abc'` | fold |
| across newline / block / line comments | concat | fold (token stream) |
| `'a' "b"`, `"a" 'b'` | concat | fold |
| `'a' '' 'b'` | `'ab'` | fold |
| `_utf8mb4'a' 'b'` | concat; `CHARSET(_latin1'a' 'b')` = `latin1` — charset of FIRST segment governs | fold; charset kept from first |
| `'a' _utf8mb4'b'` | **1064** — continuation cannot carry an introducer | keep rejecting |
| `x'41' 'b'` | NOT concat — value `A`, `'b'` is the item alias; `CONCAT(x'41' 'b')` → error 1583 (legacy UDF-arg alias), not concat | hex path unchanged (alias) |
| `b'01000001' 'b'` | NOT concat (same alias behavior) | bit path unchanged |
| `DATE '2024-01-01' 'x'` | NOT concat (`'x'` = alias; `CONCAT(...)` form → 1583) | temporal path unchanged |
| `'a' x'41'` | **1064** | keep rejecting |
| bare `DEFAULT 'x' 'y'` (also 3-run, introducer) | stored `DEFAULT 'xy'` / `'xyz'` | fold via expression path |
| `DEFAULT ('x' 'y')` (8.0 expression default) | stored `(_latin1'xy')` (5.7: no expr defaults at all) | fold via expression path |
| generated column `AS ('x' 'y')` | stored `(_latin1'xy')` (8.0) / `('xy')` (5.7) | fold via expression path |
| partition `LIST COLUMNS ... VALUES IN ('a' 'b')` | stored `VALUES IN ('ab')` | fold via expression path |
| table/column `COMMENT 'x' 'y'` | **1064** (TEXT_STRING_sys — no adjacency) | keep rejecting |
| `ENUM('a' 'b')` | **1064** | keep rejecting |
| routine/trigger bodies with adjacency | accepted; body stored VERBATIM (readback keeps the adjacency) | parse via expression path; `BodyText` verbatim |
| implicit column name of `SELECT 'a' 'b'` | column `a`, value `ab` (view readback: ``select 'ab' AS `a` ``) | `FirstSegment` |
| `SELECT '' 'b'` | value `b` named `Name_exp_1` | empty `FirstSegment` → `Name_exp_N` |
| stock `sys.ps_trace_thread` readback | parses, `LoadSDL`s, self-diffs EMPTY | `TestOracle_SysProcedureAdjacentLiterals` |

## Parse-error line numbers (secondary, investigated)

The reported "+2 line drift" is **not** in the parser: `Parse`/`LoadSDL` report exact positions for the input they receive — pinned by the new `TestParseErrorLineExact` (error on line 6 of an 8-line file reports line 6; DELIMITER directives and multi-statement inputs are exact too). The drift reproduces only when a caller prepends a 2-line prologue (`CREATE DATABASE d;\nUSE d;\n`) to user SDL and then reads the reported line against the unwrapped file. Callers must translate positions back (or parse the user text unwrapped).

## Verification

- Full `go test ./mysql/...` including the live-oracle gates against MySQL 8.0.32 and 5.7.25: **PASS**.
- New oracle idempotence probes (both engines, both directions user↔stored): `proc-adjacent-literals` (verbatim-body readback reload), `adjacent-literal-default`, `adjacent-literal-partition`.
- New oracle regression: `TestOracle_SysProcedureAdjacentLiterals` — the engine's own stock sys procedure end-to-end.
- Hermetic regressions: `mysql/parser/adjacent_literal_test.go` (concat shapes, alias-vs-concat boundary, rejects, sys-shape body verbatim round-trip), `TestSDLAdjacentStringLiterals` (loader + self-diff), `TestParseErrorLineExact`.
- `go generate ./mysql/ast/...` — `walk_generated.go` unchanged.
- `golangci-lint run --new-from-rev origin/main ./mysql/...`: 0 issues (stable across runs). gofmt clean on touched files.
- Cross-family pre-PR review: Claude `/code-review` + Codex review — no surviving blockers.
