### PR TITLE
mysql: order created views after the functions they reference

### DIFF
--- a/mysql/catalog/migration.go
+++ b/mysql/catalog/migration.go
@@ -113,16 +113,26 @@ type MigrationOp struct {
 // table/column subset the only ordering that matters is: a table's own CREATE/DROP versus
 // the column ALTERs on a surviving table. Breadth priorities are reserved so later nodes
 // slot in without renumbering.
+//
+// Routines are direction-split: their PhaseMain ops (CREATE/ALTER) run at
+// priorityRoutineCreate, BEFORE view creates, because CREATE VIEW eagerly validates the
+// functions its body calls (Error 1305 when missing — live-verified on 8.0.32 and 5.7.25)
+// while a routine body is lazily validated (a CREATE FUNCTION referencing a missing
+// function/view/table is accepted on both versions), so hoisting every routine above every
+// view is unconditionally safe and needs no per-edge dependency detection. Routine DROPs
+// stay at priorityRoutine, AFTER view drops (priorityView) in PhasePre, so a dropped
+// dependent view goes before the function it calls.
 const (
-	priorityTable      = 10
-	priorityColumn     = 20
-	priorityIndex      = 30
-	priorityConstraint = 40
-	priorityView       = 50
-	priorityRoutine    = 60
-	priorityTrigger    = 70
-	priorityEvent      = 80
-	priorityForeignKey = 99 // FK deferred to PhasePost (breadth)
+	priorityTable         = 10
+	priorityColumn        = 20
+	priorityIndex         = 30
+	priorityConstraint    = 40
+	priorityRoutineCreate = 45 // routine CREATE/ALTER (PhaseMain): before view creates
+	priorityView          = 50
+	priorityRoutine       = 60 // routine DROP (PhasePre): after view drops
+	priorityTrigger       = 70
+	priorityEvent         = 80
+	priorityForeignKey    = 99 // FK deferred to PhasePost (breadth)
 )
 
 // MigrationPlan holds an ordered list of DDL operations that transform one catalog state

--- a/mysql/catalog/migration.go
+++ b/mysql/catalog/migration.go
@@ -114,25 +114,25 @@ type MigrationOp struct {
 // the column ALTERs on a surviving table. Breadth priorities are reserved so later nodes
 // slot in without renumbering.
 //
-// Routines are direction-split: their PhaseMain ops (CREATE/ALTER) run at
-// priorityRoutineCreate, BEFORE view creates, because CREATE VIEW eagerly validates the
-// functions its body calls (Error 1305 when missing — live-verified on 8.0.32 and 5.7.25)
-// while a routine body is lazily validated (a CREATE FUNCTION referencing a missing
-// function/view/table is accepted on both versions), so hoisting every routine above every
-// view is unconditionally safe and needs no per-edge dependency detection. Routine DROPs
-// stay at priorityRoutine, AFTER view drops (priorityView) in PhasePre, so a dropped
-// dependent view goes before the function it calls.
+// Routines are direction-split (like priorityIndexDrop / priorityCheckDrop): their
+// PhaseMain ops (CREATE/ALTER) run at priorityRoutine, BEFORE view creates, because
+// CREATE VIEW eagerly validates the functions its body calls (Error 1305 when missing —
+// live-verified on 8.0.32 and 5.7.25) while a routine body is lazily validated (a CREATE
+// FUNCTION referencing a missing function/view/table is accepted on both versions), so
+// hoisting every routine above every view is unconditionally safe and needs no per-edge
+// dependency detection. Routine DROPs run at priorityRoutineDrop (migration_routine.go),
+// AFTER view drops (priorityView) in PhasePre, so a dropped dependent view goes before
+// the function it calls.
 const (
-	priorityTable         = 10
-	priorityColumn        = 20
-	priorityIndex         = 30
-	priorityConstraint    = 40
-	priorityRoutineCreate = 45 // routine CREATE/ALTER (PhaseMain): before view creates
-	priorityView          = 50
-	priorityRoutine       = 60 // routine DROP (PhasePre): after view drops
-	priorityTrigger       = 70
-	priorityEvent         = 80
-	priorityForeignKey    = 99 // FK deferred to PhasePost (breadth)
+	priorityTable      = 10
+	priorityColumn     = 20
+	priorityIndex      = 30
+	priorityConstraint = 40
+	priorityRoutine    = 45 // routine CREATE/ALTER (PhaseMain): before view creates
+	priorityView       = 50
+	priorityTrigger    = 70
+	priorityEvent      = 80
+	priorityForeignKey = 99 // FK deferred to PhasePost (breadth)
 )
 
 // MigrationPlan holds an ordered list of DDL operations that transform one catalog state

--- a/mysql/catalog/migration_ordering_oracle_test.go
+++ b/mysql/catalog/migration_ordering_oracle_test.go
@@ -79,6 +79,17 @@ func orderingProbes() []orderingProbe {
 				"CREATE VIEW v1 AS SELECT fn_base() AS n",
 				"CREATE VIEW v2 AS SELECT n FROM v1"),
 			[]string{"t"}, []string{"v1", "v2"}, []string{"fn_base"}, both()},
+		// The lazy-direction teeth: the function's body SELECTs from a view created in the SAME
+		// plan. The global hoist deliberately creates the function FIRST (before the view exists),
+		// so this apply succeeds only because routine bodies are lazily validated — the
+		// load-bearing safety claim behind hoisting routines above views. An engine that eagerly
+		// validated routine bodies would fail this probe.
+		{"create-function-selecting-view",
+			base("CREATE TABLE t (a INT)"),
+			base("CREATE TABLE t (a INT)",
+				"CREATE VIEW v_src AS SELECT a FROM t",
+				"CREATE FUNCTION fn_over_view() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM v_src)"),
+			[]string{"t"}, []string{"v_src"}, []string{"fn_over_view"}, both()},
 		// A body change forces the routine DROP+CREATE path; a NEW view calling the function lands
 		// in the same plan. Order must be DROP FUNCTION (PhasePre) → CREATE FUNCTION → CREATE VIEW.
 		{"modify-function-add-view",
@@ -177,16 +188,17 @@ func assertOrderingApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p or
 	if err != nil {
 		t.Fatalf("[%s] %s: reload of result failed: %v\n%s", o.name, p.id, err, resultSDL)
 	}
-	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+	resultDiff := DiffWithNormalizer(resultCat, toCat, n)
+	if !resultDiff.IsEmpty() {
 		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result SDL:\n%s\n  diff: %s",
-			o.name, p.id, plan.SQL(), resultSDL, describeOrderingDiff(d))
+			o.name, p.id, plan.SQL(), resultSDL, describeOrderingDiff(resultDiff))
 	}
 	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
 		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeOrderingDiff(d))
 	}
 
 	// CONVERGENCE: the follow-up plan from the applied result to `to` must be EMPTY.
-	followUp := GenerateMigrationWithNormalizer(resultCat, toCat, DiffWithNormalizer(resultCat, toCat, n), n)
+	followUp := GenerateMigrationWithNormalizer(resultCat, toCat, resultDiff, n)
 	if sql := followUp.SQL(); sql != "" {
 		t.Errorf("[%s] CONVERGENCE FAILED for %s: follow-up plan not empty:\n%s", o.name, p.id, sql)
 	}

--- a/mysql/catalog/migration_ordering_oracle_test.go
+++ b/mysql/catalog/migration_ordering_oracle_test.go
@@ -21,9 +21,9 @@ import (
 //     and 5.7.25) — so the pre-fix plan (view first) fails to apply. Routine bodies are lazily
 //     validated (a CREATE FUNCTION referencing a missing function/view/table is accepted on both
 //     versions), so hoisting every routine create above every view create is unconditionally safe:
-//     routine CREATE/ALTER runs at priorityRoutineCreate < priorityView (migration.go).
+//     routine CREATE/ALTER runs at priorityRoutine < priorityView (migration.go).
 //   - DROP direction (inverse): when a view and a function it calls are BOTH dropped, the view is
-//     dropped first (view DROP at priorityView < routine DROP at priorityRoutine in PhasePre).
+//     dropped first (view DROP at priorityView < routine DROP at priorityRoutineDrop in PhasePre).
 //     MySQL tolerates dropping a function a view still references (live-verified — the view merely
 //     goes invalid), so this is the safe semantic order rather than an apply-success requirement.
 //   - Transitive: function ← view ← view composes the routine-before-view priority with the view
@@ -49,10 +49,11 @@ type orderingProbe struct {
 }
 
 // orderingProbes enumerates the cross-object ordering FORMS: function+view created together (the
-// enterprise-SDL-smoke repro), both dropped together, the transitive function←view←view chain, and
-// a body-modified function (DROP+CREATE path) combined with a new dependent view. Functions
-// declare READS SQL DATA so they create on the 8.0 box (log_bin_trust_function_creators off →
-// error 1418 for a function with no binlog-safe characteristic).
+// enterprise-SDL-smoke repro), both dropped together, the transitive function←view←view chain, a
+// function created together with a view its body SELECTs from (the lazy-direction teeth), and a
+// body-modified function (DROP+CREATE path) combined with a new dependent view. Functions declare
+// READS SQL DATA so they create on the 8.0 box (log_bin_trust_function_creators off → error 1418
+// for a function with no binlog-safe characteristic).
 func orderingProbes() []orderingProbe {
 	base := func(ss ...string) []string { return ss }
 	return []orderingProbe{
@@ -64,7 +65,7 @@ func orderingProbes() []orderingProbe {
 				"CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users)",
 				"CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n"),
 			[]string{"users"}, []string{"ent_v_fn"}, []string{"ent_ucount"}, both()},
-		// Inverse: drop both. View drops first (PhasePre priorityView < priorityRoutine).
+		// Inverse: drop both. View drops first (PhasePre priorityView < priorityRoutineDrop).
 		{"drop-function-and-view",
 			base("CREATE TABLE users (id INT PRIMARY KEY)",
 				"CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users)",
@@ -243,9 +244,10 @@ func assertOrderingObjectsGone(t *testing.T, o *oracleConn, conn *sql.Conn, appl
 
 // dumpOrderingSchemaSDL reads back SHOW CREATE for the named tables, views, AND functions on conn
 // and assembles a reloadable SDL string under the logical database. Tables and views route through
-// dumpViewSchemaSDL (which re-homes the physical-db qualifier); function readbacks are appended
-// with the same qualifier rewrite (defensive — both engines store view-body function calls and the
-// function's own CREATE unqualified, live-verified).
+// dumpViewSchemaSDL, which re-homes the physical-db qualifier; function readbacks are appended
+// as-is — no rewrite is needed because SHOW CREATE FUNCTION returns an unqualified name and a
+// verbatim-stored body (the probes never db-qualify), live-verified on both versions, unlike
+// SHOW CREATE VIEW whose stored body IS db-qualified.
 func (o *oracleConn) dumpOrderingSchemaSDL(t *testing.T, conn *sql.Conn, physDB, logicalDB string, tables, views, functions []string) (string, bool) {
 	t.Helper()
 	sdl, ok := o.dumpViewSchemaSDL(t, conn, physDB, logicalDB, tables, views)
@@ -254,14 +256,12 @@ func (o *oracleConn) dumpOrderingSchemaSDL(t *testing.T, conn *sql.Conn, physDB,
 	}
 	var b strings.Builder
 	b.WriteString(sdl)
-	physPrefix := "`" + physDB + "`."
-	logicalPrefix := "`" + logicalDB + "`."
 	for _, fn := range functions {
 		rb, ok := o.showCreateRoutine(t, physDB, "FUNCTION", fn)
 		if !ok {
 			return "", false
 		}
-		b.WriteString(strings.ReplaceAll(rb, physPrefix, logicalPrefix))
+		b.WriteString(rb)
 		b.WriteString(";\n")
 	}
 	return b.String(), true

--- a/mysql/catalog/migration_ordering_oracle_test.go
+++ b/mysql/catalog/migration_ordering_oracle_test.go
@@ -1,0 +1,315 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle apply-correctness proof for CROSS-OBJECT operation ordering (correctness-protocol.md
+// gate 2), against the LIVE MySQL engines (5.7 :13307 ssl-disabled, 8.0 :13306). Per-object-kind
+// apply-correctness lives with each kind's own oracle file; THIS file proves the plan-level
+// ordering rules that span kinds — currently view ↔ stored-function:
+//
+//   - CREATE direction: a view whose body calls a stored function created in the SAME plan must be
+//     created AFTER the function. MySQL eagerly validates function references at CREATE VIEW time —
+//     Error 1305 "FUNCTION does not exist" when the function is missing (live-verified on 8.0.32
+//     and 5.7.25) — so the pre-fix plan (view first) fails to apply. Routine bodies are lazily
+//     validated (a CREATE FUNCTION referencing a missing function/view/table is accepted on both
+//     versions), so hoisting every routine create above every view create is unconditionally safe:
+//     routine CREATE/ALTER runs at priorityRoutineCreate < priorityView (migration.go).
+//   - DROP direction (inverse): when a view and a function it calls are BOTH dropped, the view is
+//     dropped first (view DROP at priorityView < routine DROP at priorityRoutine in PhasePre).
+//     MySQL tolerates dropping a function a view still references (live-verified — the view merely
+//     goes invalid), so this is the safe semantic order rather than an apply-success requirement.
+//   - Transitive: function ← view ← view composes the routine-before-view priority with the view
+//     node's own view-on-view depth ordering.
+//
+// Each probe builds from/to catalogs from the ENGINE'S OWN readbacks, generates the plan, applies
+// it statement-by-statement to a real from-state database (the pre-fix failure point), reads the
+// result back, and asserts (a) the result canonicalizes equal to `to` in both directions, and
+// (b) CONVERGENCE — re-diffing the applied result against `to` generates an EMPTY follow-up plan.
+// Scratch databases use the ordsdl_ prefix and are dropped after each probe.
+
+// orderingProbe is one cross-object apply-correctness case: transform a database from the `from`
+// schema to the `to` schema. tables/views/functions name the objects present in `to` (for readback
+// assembly); the `from` side's object names are extracted from its CREATE statements.
+type orderingProbe struct {
+	id        string
+	from      []string
+	to        []string
+	tables    []string
+	views     []string
+	functions []string
+	versions  []Version
+}
+
+// orderingProbes enumerates the cross-object ordering FORMS: function+view created together (the
+// enterprise-SDL-smoke repro), both dropped together, the transitive function←view←view chain, and
+// a body-modified function (DROP+CREATE path) combined with a new dependent view. Functions
+// declare READS SQL DATA so they create on the 8.0 box (log_bin_trust_function_creators off →
+// error 1418 for a function with no binlog-safe characteristic).
+func orderingProbes() []orderingProbe {
+	base := func(ss ...string) []string { return ss }
+	return []orderingProbe{
+		// The work-order repro: one release CREATEs a function AND a view calling it. Pre-fix the
+		// plan put the view first → Error 1305 on apply.
+		{"create-function-and-view",
+			base("CREATE TABLE users (id INT PRIMARY KEY)"),
+			base("CREATE TABLE users (id INT PRIMARY KEY)",
+				"CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users)",
+				"CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n"),
+			[]string{"users"}, []string{"ent_v_fn"}, []string{"ent_ucount"}, both()},
+		// Inverse: drop both. View drops first (PhasePre priorityView < priorityRoutine).
+		{"drop-function-and-view",
+			base("CREATE TABLE users (id INT PRIMARY KEY)",
+				"CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users)",
+				"CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n"),
+			base("CREATE TABLE users (id INT PRIMARY KEY)"),
+			[]string{"users"}, nil, nil, both()},
+		// Transitive: v2 → v1 → fn_base. The plan must order fn_base < v1 < v2.
+		{"create-function-view-view-chain",
+			base("CREATE TABLE t (a INT)"),
+			base("CREATE TABLE t (a INT)",
+				"CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM t)",
+				"CREATE VIEW v1 AS SELECT fn_base() AS n",
+				"CREATE VIEW v2 AS SELECT n FROM v1"),
+			[]string{"t"}, []string{"v1", "v2"}, []string{"fn_base"}, both()},
+		// A body change forces the routine DROP+CREATE path; a NEW view calling the function lands
+		// in the same plan. Order must be DROP FUNCTION (PhasePre) → CREATE FUNCTION → CREATE VIEW.
+		{"modify-function-add-view",
+			base("CREATE TABLE t (a INT)",
+				"CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM t)"),
+			base("CREATE TABLE t (a INT)",
+				"CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) + 1 FROM t)",
+				"CREATE VIEW v1 AS SELECT fn_base() AS n"),
+			[]string{"t"}, []string{"v1"}, []string{"fn_base"}, both()},
+	}
+}
+
+// TestOracle_CrossObjectOrderingApplyCorrectness proves gate 2 for every ordering probe on both
+// engines: the generated plan applies cleanly in emitted order and converges.
+func TestOracle_CrossObjectOrderingApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range orderingProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertOrderingApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// assertOrderingApplyCorrect is the per-probe gate-2 driver (mirrors assertViewApplyCorrect, plus
+// functions in the readback set and an explicit convergence check).
+func assertOrderingApplyCorrect(t *testing.T, o *oracleConn, n *Normalizer, p orderingProbe) {
+	t.Helper()
+	slug := strings.ReplaceAll(p.id, "-", "_")
+	ctx := context.Background()
+
+	// All three scratch databases share the ordsdl_ prefix and are dropped when the probe ends.
+	applyDB := "ordsdl_t"
+	toDB := "ordsdl_to_" + slug
+	fromDB := "ordsdl_from_" + slug
+	t.Cleanup(func() {
+		for _, db := range []string{applyDB, toDB, fromDB} {
+			_, _ = o.db.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+db)
+		}
+	})
+
+	// Build both catalogs from the engine's own readbacks, re-homed under the apply database so
+	// the generated DDL qualifies objects with it.
+	fromTables, fromViews, fromFunctions := orderingObjectNames(p.from)
+	toCat := loadOrderingSchemaFromEngine(t, o, toDB, applyDB, p.to, p.tables, p.views, p.functions)
+	if toCat == nil {
+		t.Skipf("[%s] could not obtain `to` readback for %s", o.name, p.id)
+	}
+	fromCat := loadOrderingSchemaFromEngine(t, o, fromDB, applyDB, p.from, fromTables, fromViews, fromFunctions)
+	if fromCat == nil {
+		t.Skipf("[%s] could not obtain `from` readback for %s", o.name, p.id)
+	}
+
+	diff := DiffWithNormalizer(fromCat, toCat, n)
+	plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+
+	// Build a real database in `from` state and apply the plan statement-by-statement, in emitted
+	// order, on one connection. A mis-ordered plan fails HERE (Error 1305 for the CREATE probes).
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	setup := append([]string{
+		"DROP DATABASE IF EXISTS " + applyDB,
+		fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", applyDB, serverCharsetFor(o.version)),
+		"USE " + applyDB,
+	}, p.from...)
+	for _, s := range setup {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Skipf("[%s] could not set up `from` state for %s: %q: %v", o.name, p.id, s, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+			t.Fatalf("[%s] APPLY FAILED for %s:\n  stmt: %s\n  err: %v\n  full plan:\n%s",
+				o.name, p.id, op.SQL, err, plan.SQL())
+		}
+	}
+
+	// Read the applied schema back and assert it canonicalizes equal to `to`, both directions.
+	resultSDL, ok := o.dumpOrderingSchemaSDL(t, conn, applyDB, applyDB, p.tables, p.views, p.functions)
+	if !ok {
+		t.Fatalf("[%s] %s: could not read back result", o.name, p.id)
+	}
+	resultCat, err := LoadSDLWithVersion(resultSDL, o.version)
+	if err != nil {
+		t.Fatalf("[%s] %s: reload of result failed: %v\n%s", o.name, p.id, err, resultSDL)
+	}
+	if d := DiffWithNormalizer(resultCat, toCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS FAILED for %s: result != to\n  plan:\n%s\n  result SDL:\n%s\n  diff: %s",
+			o.name, p.id, plan.SQL(), resultSDL, describeOrderingDiff(d))
+	}
+	if d := DiffWithNormalizer(toCat, resultCat, n); !d.IsEmpty() {
+		t.Errorf("[%s] APPLY-CORRECTNESS (reverse) FAILED for %s: %s", o.name, p.id, describeOrderingDiff(d))
+	}
+
+	// CONVERGENCE: the follow-up plan from the applied result to `to` must be EMPTY.
+	followUp := GenerateMigrationWithNormalizer(resultCat, toCat, DiffWithNormalizer(resultCat, toCat, n), n)
+	if sql := followUp.SQL(); sql != "" {
+		t.Errorf("[%s] CONVERGENCE FAILED for %s: follow-up plan not empty:\n%s", o.name, p.id, sql)
+	}
+
+	// DROP correctness: any view/function in `from` but not in `to` must not survive.
+	assertOrderingObjectsGone(t, o, conn, applyDB, p, fromViews, fromFunctions)
+}
+
+// assertOrderingObjectsGone asserts the views/functions dropped by the plan no longer exist.
+func assertOrderingObjectsGone(t *testing.T, o *oracleConn, conn *sql.Conn, applyDB string, p orderingProbe, fromViews, fromFunctions []string) {
+	t.Helper()
+	ctx := context.Background()
+	inTo := func(names []string, n string) bool {
+		for _, x := range names {
+			if strings.EqualFold(x, n) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, v := range fromViews {
+		if inTo(p.views, v) {
+			continue
+		}
+		var c1, c2, c3, c4 string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE VIEW %s.%s", applyDB, v))
+		if err := row.Scan(&c1, &c2, &c3, &c4); err == nil {
+			t.Errorf("[%s] %s: dropped view %s still exists", o.name, p.id, v)
+		}
+	}
+	for _, f := range fromFunctions {
+		if inTo(p.functions, f) {
+			continue
+		}
+		var c1, c2, c3, c4, c5, c6 sql.NullString
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE FUNCTION %s.%s", applyDB, f))
+		if err := row.Scan(&c1, &c2, &c3, &c4, &c5, &c6); err == nil {
+			t.Errorf("[%s] %s: dropped function %s still exists", o.name, p.id, f)
+		}
+	}
+}
+
+// dumpOrderingSchemaSDL reads back SHOW CREATE for the named tables, views, AND functions on conn
+// and assembles a reloadable SDL string under the logical database. Tables and views route through
+// dumpViewSchemaSDL (which re-homes the physical-db qualifier); function readbacks are appended
+// with the same qualifier rewrite (defensive — both engines store view-body function calls and the
+// function's own CREATE unqualified, live-verified).
+func (o *oracleConn) dumpOrderingSchemaSDL(t *testing.T, conn *sql.Conn, physDB, logicalDB string, tables, views, functions []string) (string, bool) {
+	t.Helper()
+	sdl, ok := o.dumpViewSchemaSDL(t, conn, physDB, logicalDB, tables, views)
+	if !ok {
+		return "", false
+	}
+	var b strings.Builder
+	b.WriteString(sdl)
+	physPrefix := "`" + physDB + "`."
+	logicalPrefix := "`" + logicalDB + "`."
+	for _, fn := range functions {
+		rb, ok := o.showCreateRoutine(t, physDB, "FUNCTION", fn)
+		if !ok {
+			return "", false
+		}
+		b.WriteString(strings.ReplaceAll(rb, physPrefix, logicalPrefix))
+		b.WriteString(";\n")
+	}
+	return b.String(), true
+}
+
+// loadOrderingSchemaFromEngine applies a schema to a throwaway physical db, reads back the named
+// tables + views + functions, and loads them into a catalog re-homed under the logical db
+// (version-aware). Returns nil on any apply/dump failure (the caller skips). An empty setup yields
+// an empty catalog.
+func loadOrderingSchemaFromEngine(t *testing.T, o *oracleConn, physDB, logicalDB string, setup, tables, views, functions []string) *Catalog {
+	t.Helper()
+	if len(setup) == 0 {
+		return New()
+	}
+	conn, ok := o.applyViewSchema(t, physDB, setup)
+	if !ok {
+		return nil
+	}
+	defer func() { _ = conn.Close() }()
+	sdl, ok := o.dumpOrderingSchemaSDL(t, conn, physDB, logicalDB, tables, views, functions)
+	if !ok {
+		return nil
+	}
+	cat, err := LoadSDLWithVersion(sdl, o.version)
+	if err != nil {
+		t.Fatalf("[%s] load ordering-schema-from-engine failed: %v\n%s", o.name, err, sdl)
+	}
+	return cat
+}
+
+// orderingObjectNames extracts the table, view, and function names declared by a list of CREATE
+// statements (the shapes the ordering probes use), so the `from` side needs no hand-maintained
+// name list.
+func orderingObjectNames(setup []string) (tables, views, functions []string) {
+	tables, views = schemaObjectNames(setup)
+	for _, s := range setup {
+		fields := strings.Fields(s)
+		if len(fields) >= 3 && strings.EqualFold(fields[0], "CREATE") && strings.EqualFold(fields[1], "FUNCTION") {
+			name := fields[2]
+			if i := strings.IndexByte(name, '('); i >= 0 {
+				name = name[:i]
+			}
+			functions = append(functions, strings.Trim(name, "`"))
+		}
+	}
+	return tables, views, functions
+}
+
+// describeOrderingDiff renders a compact description of a SchemaDiff's view/function/table changes
+// for failure output.
+func describeOrderingDiff(d *SchemaDiff) string {
+	var b strings.Builder
+	for _, fe := range d.Functions {
+		fmt.Fprintf(&b, "[function %s.%s %s]", fe.Database, fe.Name, fe.Action)
+	}
+	for _, ve := range d.Views {
+		fmt.Fprintf(&b, "[view %s.%s %s]", ve.Database, ve.Name, ve.Action)
+	}
+	for _, te := range d.Tables {
+		fmt.Fprintf(&b, "[table %s %s]", te.Name, te.Action)
+	}
+	return b.String()
+}

--- a/mysql/catalog/migration_routine.go
+++ b/mysql/catalog/migration_routine.go
@@ -12,7 +12,7 @@ import (
 // single generate hook covers both routine kinds: wired into GenerateMigrationWithNormalizer
 // (migration.go), it consumes BOTH SchemaDiff.Functions and SchemaDiff.Procedures and emits the
 // CREATE / DROP / ALTER ops (OpCreateFunction / OpDropFunction / OpCreateProcedure /
-// OpDropProcedure, priorityRoutine).
+// OpDropProcedure, priorityRoutineCreate for PhaseMain ops, priorityRoutine for drops).
 //
 // MySQL has NO `CREATE OR REPLACE` and NO `ALTER` for a routine's body/params/RETURNS. So a
 // change to any of those is a DROP followed by a CREATE. `ALTER FUNCTION/PROCEDURE` can change
@@ -24,11 +24,22 @@ import (
 //   - DiffModify, ALTER suffices    → ALTER (one statement, the changed characteristics).
 //   - DiffModify, ALTER insufficient → DROP + CREATE.
 //
-// Ordering (mirrors the index node's drop-before-add discipline): DROPs run in PhasePre, CREATEs
-// and ALTERs in PhaseMain, both at priorityRoutine. So a MODIFY's DROP (PhasePre) always precedes
-// its CREATE (PhaseMain) — the name is free for re-creation — and a routine dropped in one place
-// and created in another never reverses. sortMigrationOps re-imposes the global phase/priority/
-// name order.
+// Ordering (mirrors the index node's drop-before-add discipline): DROPs run in PhasePre at
+// priorityRoutine, CREATEs and ALTERs in PhaseMain at priorityRoutineCreate. So a MODIFY's DROP
+// (PhasePre) always precedes its CREATE (PhaseMain) — the name is free for re-creation — and a
+// routine dropped in one place and created in another never reverses. sortMigrationOps re-imposes
+// the global phase/priority/name order.
+//
+// The priorities are direction-split against VIEWS (live-verified on 8.0.32 and 5.7.25):
+//   - CREATE/ALTER at priorityRoutineCreate (< priorityView): CREATE VIEW eagerly validates the
+//     functions its body calls (Error 1305 when one is missing), while a routine body is lazily
+//     validated (CREATE FUNCTION referencing a missing function/view/table is accepted), so every
+//     routine created in a plan is hoisted above every view create — unconditionally safe, no
+//     dependency detection needed, and a function→view→view chain composes with the view node's
+//     own depth ordering.
+//   - DROP at priorityRoutine (> priorityView): a dropped dependent view goes before the function
+//     it calls. MySQL tolerates dropping a function a view still references (the view merely goes
+//     invalid), so this is the safe semantic order rather than an apply-success requirement.
 //
 // Rendering routes through the same form SHOW CREATE uses (showCreateRoutineBody), MINUS the
 // DEFINER clause: DEFINER is ignored in the diff (it is environment, not schema-as-code), so the
@@ -84,8 +95,8 @@ func routineOps(e *RoutineDiffEntry, n *Normalizer) []MigrationOp {
 	return nil
 }
 
-// createRoutineOp builds a CREATE FUNCTION/PROCEDURE op (PhaseMain). The SQL is the DEFINER-less
-// stored form (see the file doc).
+// createRoutineOp builds a CREATE FUNCTION/PROCEDURE op (PhaseMain, priorityRoutineCreate — before
+// view creates; see the file doc). The SQL is the DEFINER-less stored form.
 func createRoutineOp(e *RoutineDiffEntry, r *Routine, n *Normalizer) MigrationOp {
 	return MigrationOp{
 		Type:       createRoutineOpType(e.IsProcedure),
@@ -93,15 +104,16 @@ func createRoutineOp(e *RoutineDiffEntry, r *Routine, n *Normalizer) MigrationOp
 		ObjectName: e.Name,
 		SQL:        renderCreateRoutine(e.Database, r, n),
 		Phase:      PhaseMain,
-		Priority:   priorityRoutine,
+		Priority:   priorityRoutineCreate,
 		sortName:   routineSortName(e.Database, e.Name),
 	}
 }
 
-// dropRoutineOp builds a DROP FUNCTION/PROCEDURE op (PhasePre, so it precedes any re-CREATE in
-// the same plan). IF EXISTS is NOT used: the diff already established the routine is present in
-// `from`, and an unconditional DROP keeps the emitted DDL minimal and explicit (matching the
-// table node's DROP TABLE, which is likewise unconditional).
+// dropRoutineOp builds a DROP FUNCTION/PROCEDURE op (PhasePre at priorityRoutine, so it precedes
+// any re-CREATE in the same plan and follows view drops — a dropped dependent view goes first).
+// IF EXISTS is NOT used: the diff already established the routine is present in `from`, and an
+// unconditional DROP keeps the emitted DDL minimal and explicit (matching the table node's DROP
+// TABLE, which is likewise unconditional).
 func dropRoutineOp(e *RoutineDiffEntry, r *Routine) MigrationOp {
 	kw := "FUNCTION"
 	if e.IsProcedure {
@@ -122,7 +134,10 @@ func dropRoutineOp(e *RoutineDiffEntry, r *Routine) MigrationOp {
 // characteristic set (DATA ACCESS, SQL SECURITY, COMMENT) in their canonical default-folded
 // form. It re-states ALL three (not just the changed ones): re-applying a characteristic to its
 // existing value is a harmless no-op, and emitting the whole set keeps the op self-contained and
-// order-independent of what the synced side held. The op runs in PhaseMain at priorityRoutine.
+// order-independent of what the synced side held. The op runs in PhaseMain at
+// priorityRoutineCreate (grouped with routine CREATEs; an ALTER touches an existing routine, so
+// its position relative to views is immaterial — the shared priority just keeps routine PhaseMain
+// ops together).
 //
 // ALTER is chosen only when routineAlterSuffices(from, to) held — i.e. params, RETURNS, body, and
 // DETERMINISTIC are unchanged — so this never needs to touch a DROP+CREATE-only attribute.
@@ -143,7 +158,7 @@ func alterRoutineOp(e *RoutineDiffEntry, to *Routine) MigrationOp {
 		ObjectName: e.Name,
 		SQL:        b.String(),
 		Phase:      PhaseMain,
-		Priority:   priorityRoutine,
+		Priority:   priorityRoutineCreate,
 		sortName:   routineSortName(e.Database, e.Name),
 	}
 }

--- a/mysql/catalog/migration_routine.go
+++ b/mysql/catalog/migration_routine.go
@@ -12,7 +12,7 @@ import (
 // single generate hook covers both routine kinds: wired into GenerateMigrationWithNormalizer
 // (migration.go), it consumes BOTH SchemaDiff.Functions and SchemaDiff.Procedures and emits the
 // CREATE / DROP / ALTER ops (OpCreateFunction / OpDropFunction / OpCreateProcedure /
-// OpDropProcedure, priorityRoutineCreate for PhaseMain ops, priorityRoutine for drops).
+// OpDropProcedure, priorityRoutine for PhaseMain ops, priorityRoutineDrop for drops).
 //
 // MySQL has NO `CREATE OR REPLACE` and NO `ALTER` for a routine's body/params/RETURNS. So a
 // change to any of those is a DROP followed by a CREATE. `ALTER FUNCTION/PROCEDURE` can change
@@ -25,19 +25,19 @@ import (
 //   - DiffModify, ALTER insufficient → DROP + CREATE.
 //
 // Ordering (mirrors the index node's drop-before-add discipline): DROPs run in PhasePre at
-// priorityRoutine, CREATEs and ALTERs in PhaseMain at priorityRoutineCreate. So a MODIFY's DROP
+// priorityRoutineDrop, CREATEs and ALTERs in PhaseMain at priorityRoutine. So a MODIFY's DROP
 // (PhasePre) always precedes its CREATE (PhaseMain) — the name is free for re-creation — and a
 // routine dropped in one place and created in another never reverses. sortMigrationOps re-imposes
 // the global phase/priority/name order.
 //
 // The priorities are direction-split against VIEWS (live-verified on 8.0.32 and 5.7.25):
-//   - CREATE/ALTER at priorityRoutineCreate (< priorityView): CREATE VIEW eagerly validates the
+//   - CREATE/ALTER at priorityRoutine (< priorityView): CREATE VIEW eagerly validates the
 //     functions its body calls (Error 1305 when one is missing), while a routine body is lazily
 //     validated (CREATE FUNCTION referencing a missing function/view/table is accepted), so every
 //     routine created in a plan is hoisted above every view create — unconditionally safe, no
 //     dependency detection needed, and a function→view→view chain composes with the view node's
 //     own depth ordering.
-//   - DROP at priorityRoutine (> priorityView): a dropped dependent view goes before the function
+//   - DROP at priorityRoutineDrop (> priorityView): a dropped dependent view goes before the function
 //     it calls. MySQL tolerates dropping a function a view still references (the view merely goes
 //     invalid), so this is the safe semantic order rather than an apply-success requirement.
 //
@@ -95,7 +95,7 @@ func routineOps(e *RoutineDiffEntry, n *Normalizer) []MigrationOp {
 	return nil
 }
 
-// createRoutineOp builds a CREATE FUNCTION/PROCEDURE op (PhaseMain, priorityRoutineCreate — before
+// createRoutineOp builds a CREATE FUNCTION/PROCEDURE op (PhaseMain, priorityRoutine — before
 // view creates; see the file doc). The SQL is the DEFINER-less stored form.
 func createRoutineOp(e *RoutineDiffEntry, r *Routine, n *Normalizer) MigrationOp {
 	return MigrationOp{
@@ -104,12 +104,19 @@ func createRoutineOp(e *RoutineDiffEntry, r *Routine, n *Normalizer) MigrationOp
 		ObjectName: e.Name,
 		SQL:        renderCreateRoutine(e.Database, r, n),
 		Phase:      PhaseMain,
-		Priority:   priorityRoutineCreate,
+		Priority:   priorityRoutine,
 		sortName:   routineSortName(e.Database, e.Name),
 	}
 }
 
-// dropRoutineOp builds a DROP FUNCTION/PROCEDURE op (PhasePre at priorityRoutine, so it precedes
+// priorityRoutineDrop orders a routine DROP within PhasePre AFTER view drops (priorityView): when
+// a view and a function it calls are both dropped, the dependent view goes first. MySQL tolerates
+// the reverse (live-verified — the view merely goes invalid), so this is the safe semantic order
+// rather than an apply-success requirement. The PhaseMain side (CREATE/ALTER) uses priorityRoutine
+// (migration.go), which sorts routines BEFORE view creates; see the file doc for the evidence.
+const priorityRoutineDrop = priorityView + 10
+
+// dropRoutineOp builds a DROP FUNCTION/PROCEDURE op (PhasePre at priorityRoutineDrop, so it precedes
 // any re-CREATE in the same plan and follows view drops — a dropped dependent view goes first).
 // IF EXISTS is NOT used: the diff already established the routine is present in `from`, and an
 // unconditional DROP keeps the emitted DDL minimal and explicit (matching the table node's DROP
@@ -125,7 +132,7 @@ func dropRoutineOp(e *RoutineDiffEntry, r *Routine) MigrationOp {
 		ObjectName: e.Name,
 		SQL:        fmt.Sprintf("DROP %s %s", kw, routineIdent(e.Database, r.Name)),
 		Phase:      PhasePre,
-		Priority:   priorityRoutine,
+		Priority:   priorityRoutineDrop,
 		sortName:   routineSortName(e.Database, e.Name),
 	}
 }
@@ -135,7 +142,7 @@ func dropRoutineOp(e *RoutineDiffEntry, r *Routine) MigrationOp {
 // form. It re-states ALL three (not just the changed ones): re-applying a characteristic to its
 // existing value is a harmless no-op, and emitting the whole set keeps the op self-contained and
 // order-independent of what the synced side held. The op runs in PhaseMain at
-// priorityRoutineCreate (grouped with routine CREATEs; an ALTER touches an existing routine, so
+// priorityRoutine (grouped with routine CREATEs; an ALTER touches an existing routine, so
 // its position relative to views is immaterial — the shared priority just keeps routine PhaseMain
 // ops together).
 //
@@ -158,7 +165,7 @@ func alterRoutineOp(e *RoutineDiffEntry, to *Routine) MigrationOp {
 		ObjectName: e.Name,
 		SQL:        b.String(),
 		Phase:      PhaseMain,
-		Priority:   priorityRoutineCreate,
+		Priority:   priorityRoutine,
 		sortName:   routineSortName(e.Database, e.Name),
 	}
 }

--- a/mysql/catalog/migration_view.go
+++ b/mysql/catalog/migration_view.go
@@ -25,7 +25,7 @@ import (
 //
 // PHASE / ORDERING (apply-correctness, oracle-verified):
 //   - CREATE runs in PhaseMain at priorityView (=50), AFTER table creation (priorityTable=10),
-//     column ALTERs (priorityColumn=20), and routine CREATEs (priorityRoutineCreate=45). A view
+//     column ALTERs (priorityColumn=20), and routine CREATEs (priorityRoutine=45). A view
 //     over a freshly created/altered table therefore applies against the final table — creating a
 //     view whose referenced table does not yet exist fails (live-verified), and creating a view
 //     whose body calls a not-yet-created stored function fails with Error 1305 (live-verified on

--- a/mysql/catalog/migration_view.go
+++ b/mysql/catalog/migration_view.go
@@ -24,10 +24,13 @@ import (
 //   - DiffDrop → DROP VIEW IF EXISTS.
 //
 // PHASE / ORDERING (apply-correctness, oracle-verified):
-//   - CREATE runs in PhaseMain at priorityView (=50), AFTER table creation (priorityTable=10) and
-//     column ALTERs (priorityColumn=20). A view over a freshly created/altered table therefore
-//     applies against the final table — creating a view whose referenced table does not yet exist
-//     fails (live-verified), so this ordering is required.
+//   - CREATE runs in PhaseMain at priorityView (=50), AFTER table creation (priorityTable=10),
+//     column ALTERs (priorityColumn=20), and routine CREATEs (priorityRoutineCreate=45). A view
+//     over a freshly created/altered table therefore applies against the final table — creating a
+//     view whose referenced table does not yet exist fails (live-verified), and creating a view
+//     whose body calls a not-yet-created stored function fails with Error 1305 (live-verified on
+//     both versions; see migration_routine.go for the routine-side ordering rationale) — so this
+//     ordering is required.
 //   - view-on-view: a view that references another view being created in the SAME plan must be
 //     created AFTER it (the dependency must exist first — live-verified to fail otherwise). The
 //     ops all share priorityView, so the intra-priority tie-break (sortName, then stable original

--- a/mysql/catalog/migration_view_test.go
+++ b/mysql/catalog/migration_view_test.go
@@ -313,6 +313,118 @@ CREATE VIEW v1 AS SELECT a FROM t;`)
 	}
 }
 
+// opPositions returns the plan index of the first op matching each (type, name) request, -1 when
+// absent. Names are compared case-insensitively.
+func opPositions(plan *MigrationPlan, wants []struct {
+	typ  MigrationOpType
+	name string
+}) []int {
+	pos := make([]int, len(wants))
+	for i := range pos {
+		pos[i] = -1
+	}
+	for i, op := range plan.Ops {
+		for w, want := range wants {
+			if pos[w] < 0 && op.Type == want.typ && strings.EqualFold(op.ObjectName, want.name) {
+				pos[w] = i
+			}
+		}
+	}
+	return pos
+}
+
+// A view whose body calls a stored function created in the SAME plan must be created AFTER the
+// function: MySQL eagerly validates function references at CREATE VIEW time (Error 1305 "FUNCTION
+// does not exist", live-verified on 8.0.32 and 5.7.25), while a routine body is lazily validated
+// (a CREATE FUNCTION referencing a missing function/view/table is accepted, live-verified) — so
+// routine creates are hoisted before view creates unconditionally. Regression for the enterprise
+// SDL smoke failure (view-before-function plan → Error 1305 on apply).
+func TestGenerateView_ViewAfterFunction(t *testing.T) {
+	for _, version := range []Version{MySQL57, MySQL80} {
+		plan := viewPlanFor(t, version,
+			`CREATE TABLE users (id INT PRIMARY KEY);`,
+			`CREATE TABLE users (id INT PRIMARY KEY);
+CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users);
+CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n;`)
+		pos := opPositions(plan, []struct {
+			typ  MigrationOpType
+			name string
+		}{{OpCreateFunction, "ent_ucount"}, {OpCreateView, "ent_v_fn"}})
+		if pos[0] < 0 || pos[1] < 0 {
+			t.Fatalf("[v%d] missing ops: function=%d view=%d\n%s", version, pos[0], pos[1], plan.SQL())
+		}
+		if pos[0] > pos[1] {
+			t.Errorf("[v%d] CREATE FUNCTION must precede the CREATE VIEW that calls it:\n%s", version, plan.SQL())
+		}
+	}
+}
+
+// The inverse drop direction: when a view and the function it calls are BOTH dropped in one plan,
+// the view is dropped first (drop the dependent before its dependency). MySQL tolerates dropping a
+// function a view still references (live-verified — the view merely goes invalid), so this is the
+// safe semantic order rather than an apply-success requirement.
+func TestGenerateView_DropViewBeforeDropFunction(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE users (id INT PRIMARY KEY);
+CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users);
+CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n;`,
+		`CREATE TABLE users (id INT PRIMARY KEY);`)
+	pos := opPositions(plan, []struct {
+		typ  MigrationOpType
+		name string
+	}{{OpDropView, "ent_v_fn"}, {OpDropFunction, "ent_ucount"}})
+	if pos[0] < 0 || pos[1] < 0 {
+		t.Fatalf("missing ops: view=%d function=%d\n%s", pos[0], pos[1], plan.SQL())
+	}
+	if pos[0] > pos[1] {
+		t.Errorf("DROP VIEW must precede DROP FUNCTION of a function it calls:\n%s", plan.SQL())
+	}
+}
+
+// Transitive: function ← view ← view. Combining routine-before-view (priority) with view-on-view
+// depth ordering must yield fn < v1 < v2.
+func TestGenerateView_FunctionViewViewChainOrdering(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT);`,
+		`CREATE TABLE t (a INT);
+CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM t);
+CREATE VIEW v2 AS SELECT n FROM v1;
+CREATE VIEW v1 AS SELECT fn_base() AS n;`)
+	pos := opPositions(plan, []struct {
+		typ  MigrationOpType
+		name string
+	}{{OpCreateFunction, "fn_base"}, {OpCreateView, "v1"}, {OpCreateView, "v2"}})
+	if pos[0] < 0 || pos[1] < 0 || pos[2] < 0 {
+		t.Fatalf("missing ops: fn=%d v1=%d v2=%d\n%s", pos[0], pos[1], pos[2], plan.SQL())
+	}
+	if !(pos[0] < pos[1] && pos[1] < pos[2]) {
+		t.Errorf("chain order wrong (want fn < v1 < v2): fn=%d v1=%d v2=%d\n%s",
+			pos[0], pos[1], pos[2], plan.SQL())
+	}
+}
+
+// A body-modified function (DROP+CREATE path) with a NEW view calling it: the function's re-CREATE
+// (PhaseMain) must still precede the view's CREATE, and its DROP stays in PhasePre.
+func TestGenerateView_ViewAfterModifiedFunction(t *testing.T) {
+	plan := viewPlanFor(t, MySQL80,
+		`CREATE TABLE t (a INT);
+CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM t);`,
+		`CREATE TABLE t (a INT);
+CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) + 1 FROM t);
+CREATE VIEW v1 AS SELECT fn_base() AS n;`)
+	pos := opPositions(plan, []struct {
+		typ  MigrationOpType
+		name string
+	}{{OpDropFunction, "fn_base"}, {OpCreateFunction, "fn_base"}, {OpCreateView, "v1"}})
+	if pos[0] < 0 || pos[1] < 0 || pos[2] < 0 {
+		t.Fatalf("missing ops: drop=%d create=%d view=%d\n%s", pos[0], pos[1], pos[2], plan.SQL())
+	}
+	if !(pos[0] < pos[1] && pos[1] < pos[2]) {
+		t.Errorf("order wrong (want DROP FUNCTION < CREATE FUNCTION < CREATE VIEW): drop=%d create=%d view=%d\n%s",
+			pos[0], pos[1], pos[2], plan.SQL())
+	}
+}
+
 // All drops precede all creates: a view dropped and another created in one plan must not interleave
 // such that a create lands before the drops (PhasePre vs PhaseMain).
 func TestGenerateView_DropsBeforeCreates(t *testing.T) {

--- a/mysql/catalog/migration_view_test.go
+++ b/mysql/catalog/migration_view_test.go
@@ -313,12 +313,14 @@ CREATE VIEW v1 AS SELECT a FROM t;`)
 	}
 }
 
-// opPositions returns the plan index of the first op matching each (type, name) request, -1 when
-// absent. Names are compared case-insensitively.
-func opPositions(plan *MigrationPlan, wants []struct {
+// opWant identifies one plan op by type and (case-insensitive) object name for position asserts.
+type opWant struct {
 	typ  MigrationOpType
 	name string
-}) []int {
+}
+
+// opPositions returns the plan index of the first op matching each want, -1 when absent.
+func opPositions(plan *MigrationPlan, wants []opWant) []int {
 	pos := make([]int, len(wants))
 	for i := range pos {
 		pos[i] = -1
@@ -346,10 +348,7 @@ func TestGenerateView_ViewAfterFunction(t *testing.T) {
 			`CREATE TABLE users (id INT PRIMARY KEY);
 CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users);
 CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n;`)
-		pos := opPositions(plan, []struct {
-			typ  MigrationOpType
-			name string
-		}{{OpCreateFunction, "ent_ucount"}, {OpCreateView, "ent_v_fn"}})
+		pos := opPositions(plan, []opWant{{OpCreateFunction, "ent_ucount"}, {OpCreateView, "ent_v_fn"}})
 		if pos[0] < 0 || pos[1] < 0 {
 			t.Fatalf("[v%d] missing ops: function=%d view=%d\n%s", version, pos[0], pos[1], plan.SQL())
 		}
@@ -369,10 +368,7 @@ func TestGenerateView_DropViewBeforeDropFunction(t *testing.T) {
 CREATE FUNCTION ent_ucount() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM users);
 CREATE VIEW ent_v_fn AS SELECT ent_ucount() AS n;`,
 		`CREATE TABLE users (id INT PRIMARY KEY);`)
-	pos := opPositions(plan, []struct {
-		typ  MigrationOpType
-		name string
-	}{{OpDropView, "ent_v_fn"}, {OpDropFunction, "ent_ucount"}})
+	pos := opPositions(plan, []opWant{{OpDropView, "ent_v_fn"}, {OpDropFunction, "ent_ucount"}})
 	if pos[0] < 0 || pos[1] < 0 {
 		t.Fatalf("missing ops: view=%d function=%d\n%s", pos[0], pos[1], plan.SQL())
 	}
@@ -390,10 +386,7 @@ func TestGenerateView_FunctionViewViewChainOrdering(t *testing.T) {
 CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FROM t);
 CREATE VIEW v2 AS SELECT n FROM v1;
 CREATE VIEW v1 AS SELECT fn_base() AS n;`)
-	pos := opPositions(plan, []struct {
-		typ  MigrationOpType
-		name string
-	}{{OpCreateFunction, "fn_base"}, {OpCreateView, "v1"}, {OpCreateView, "v2"}})
+	pos := opPositions(plan, []opWant{{OpCreateFunction, "fn_base"}, {OpCreateView, "v1"}, {OpCreateView, "v2"}})
 	if pos[0] < 0 || pos[1] < 0 || pos[2] < 0 {
 		t.Fatalf("missing ops: fn=%d v1=%d v2=%d\n%s", pos[0], pos[1], pos[2], plan.SQL())
 	}
@@ -412,10 +405,7 @@ CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) FRO
 		`CREATE TABLE t (a INT);
 CREATE FUNCTION fn_base() RETURNS INT READS SQL DATA RETURN (SELECT COUNT(*) + 1 FROM t);
 CREATE VIEW v1 AS SELECT fn_base() AS n;`)
-	pos := opPositions(plan, []struct {
-		typ  MigrationOpType
-		name string
-	}{{OpDropFunction, "fn_base"}, {OpCreateFunction, "fn_base"}, {OpCreateView, "v1"}})
+	pos := opPositions(plan, []opWant{{OpDropFunction, "fn_base"}, {OpCreateFunction, "fn_base"}, {OpCreateView, "v1"}})
 	if pos[0] < 0 || pos[1] < 0 || pos[2] < 0 {
 		t.Fatalf("missing ops: drop=%d create=%d view=%d\n%s", pos[0], pos[1], pos[2], plan.SQL())
 	}

--- a/mysql/catalog/migration_view_test.go
+++ b/mysql/catalog/migration_view_test.go
@@ -397,7 +397,7 @@ CREATE VIEW v1 AS SELECT fn_base() AS n;`)
 	if pos[0] < 0 || pos[1] < 0 || pos[2] < 0 {
 		t.Fatalf("missing ops: fn=%d v1=%d v2=%d\n%s", pos[0], pos[1], pos[2], plan.SQL())
 	}
-	if !(pos[0] < pos[1] && pos[1] < pos[2]) {
+	if pos[0] >= pos[1] || pos[1] >= pos[2] {
 		t.Errorf("chain order wrong (want fn < v1 < v2): fn=%d v1=%d v2=%d\n%s",
 			pos[0], pos[1], pos[2], plan.SQL())
 	}
@@ -419,7 +419,7 @@ CREATE VIEW v1 AS SELECT fn_base() AS n;`)
 	if pos[0] < 0 || pos[1] < 0 || pos[2] < 0 {
 		t.Fatalf("missing ops: drop=%d create=%d view=%d\n%s", pos[0], pos[1], pos[2], plan.SQL())
 	}
-	if !(pos[0] < pos[1] && pos[1] < pos[2]) {
+	if pos[0] >= pos[1] || pos[1] >= pos[2] {
 		t.Errorf("order wrong (want DROP FUNCTION < CREATE FUNCTION < CREATE VIEW): drop=%d create=%d view=%d\n%s",
 			pos[0], pos[1], pos[2], plan.SQL())
 	}


### PR DESCRIPTION
## Problem

Found by the bytebase enterprise SDL smoke (live-apply oracle, both 8.0.32 and 5.7.25): when one declarative release CREATEs a function AND a view whose body calls that function, `GenerateMigration` emits `CREATE VIEW` **before** `CREATE FUNCTION`, and the apply fails with MySQL **Error 1305** (`FUNCTION ... does not exist`).

Repro (source = any base schema; target = source +):

```sql
CREATE FUNCTION `ent_ucount`() RETURNS int READS SQL DATA RETURN (SELECT COUNT(*) FROM `users`);
CREATE VIEW `ent_v_fn` AS SELECT `ent_ucount`() AS `n`;
```

Root cause: `sortMigrationOps` orders Phase → Priority → sortName, and `priorityView` (50) < `priorityRoutine` (60), so in PhaseMain every view create sorted before every routine create. View→routine dependencies were absent from operation ordering.

## Oracle evidence (live MySQL 8.0.32 :13306 and 5.7.25 :13307 — identical on both)

| Probe | Result |
|---|---|
| `CREATE VIEW` referencing a missing function | **Error 1305** — view creation eagerly validates function refs (the bug driver) |
| `CREATE FUNCTION` calling a missing function | accepted — routine bodies are lazily validated |
| `CREATE FUNCTION` selecting from a missing view/table | accepted — routines never eagerly depend on views |
| `DROP FUNCTION` while a view references it | allowed — the view merely goes invalid |
| View referencing an **existing** procedure (`SELECT p1()` / `AS CALL p1()`) | Error 1305 / syntax error — views cannot depend on procedures (out of scope confirmed) |
| Stored view body form | function calls stored **unqualified** on both versions |

Because routine bodies are lazily validated, hoisting **all** routine creates above **all** view creates is unconditionally safe (no cycle can exist), which makes per-edge name detection — and its builtin-name false-positive risk — unnecessary.

## Fix

Direction-split routine priority in the plan sort:

- **CREATE direction**: routine CREATE/ALTER ops (PhaseMain) move to new `priorityRoutineCreate` (45) < `priorityView` (50) — every function/procedure created in a plan now precedes every view create. Transitive `function ← view ← view` composes with the existing view-on-view depth ordering (`viewCreateOrder`).
- **DROP direction (inverse)**: routine DROPs keep `priorityRoutine` (60) in PhasePre, so view drops (50) keep preceding them — a dropped dependent view goes before the function it calls (semantic safety; MySQL tolerates the reverse, live-verified).
- The routine DROP+CREATE modify path is unaffected (DROP in PhasePre still precedes the re-CREATE in PhaseMain), and a body-modified function's re-CREATE now precedes any new dependent view.

## Coverage

Hermetic unit tests (`migration_view_test.go`), all red pre-fix except the drop-direction guard:
- `TestGenerateView_ViewAfterFunction` (the repro, on 5.7 and 8.0 normalizers)
- `TestGenerateView_DropViewBeforeDropFunction` (inverse direction regression guard)
- `TestGenerateView_FunctionViewViewChainOrdering` (transitive fn < v1 < v2)
- `TestGenerateView_ViewAfterModifiedFunction` (DROP+CREATE modify path + new dependent view)

Live-oracle apply-correctness (`migration_ordering_oracle_test.go`, new): 4 probes × 2 versions — `create-function-and-view` (the repro), `drop-function-and-view`, `create-function-view-view-chain`, `modify-function-add-view`. Each builds from/to catalogs from the engine's own readbacks, applies the generated plan statement-by-statement to a real from-state scratch DB (`ordsdl_` prefix, dropped after), asserts the result canonicalizes equal to `to` in both directions, asserts **convergence** (the follow-up plan is empty), and asserts dropped objects are gone. With the fix reverted, `create-function-and-view` fails with exactly Error 1305 — the test has teeth.

## Testing

- `go test ./mysql/...` fully green (including all live-oracle suites, both engines)
- `go test -short ./...` (the CI gate) green repo-wide
- `golangci-lint run ./mysql/...`: 0 issues in touched files (remaining findings pre-exist on main in untouched files)

No normalization rules were added or changed — this is pure operation ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
