### PR TITLE
ci: run container tests on pull requests

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -1,6 +1,8 @@
 name: Container Tests
 
 on:
+  pull_request:
+    branches: [main]
   schedule:
     # Run daily at 08:00 UTC (17:00 JST)
     - cron: '0 8 * * *'
@@ -56,6 +58,9 @@ jobs:
     # fresh mismatch doesn't auto-fail the nightly build; the
     # timestamped artefact under testdata/paren-fuzz-defer/ is the
     # triage signal.
+    # Skipped on pull_request: ci.yml already runs the N=1000 PR gate,
+    # and the wide-N run takes up to 55 minutes.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
## What

Add a `pull_request` trigger to container-tests.yml so the pg container tests and all 8 MySQL container shards run on every PR, not just the daily cron.

`paren-fuzz-nightly` is explicitly skipped on PRs (`if: github.event_name != 'pull_request'`) — ci.yml already runs the N=1000 PR gate, and the wide-N=10000 run takes up to 55 minutes.

## Why

Container oracle tests currently only run once a day, so a PR that breaks catalog behavior lands green and is only caught the next morning.

Measured from the 2026-07-01 daily run (verified in job logs that containers actually start and tests run):
- mysql shards: 40–53s per job end-to-end
- pg-container-tests: 35s
- current PR critical path: build-and-test at 165s

All container jobs run in parallel and finish well under build-and-test, so **PR wall-clock time is unchanged**. The repo is public, so Actions minutes are free.

## Testing

This PR itself exercises the new trigger — the pg + 8 mysql shard checks should appear below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)